### PR TITLE
feat(auth): typed dashboard_actor_fallback variant on Auth_error_kind

### DIFF
--- a/lib/auth_error_kind.ml
+++ b/lib/auth_error_kind.ml
@@ -62,3 +62,80 @@ let all =
   ; Invalid_json
   ; Other
   ]
+
+(* ----- Dashboard actor fallback typed surface ------------------------ *)
+(* See .mli for rationale. The two warn-message templates below are
+   byte-equivalent to the prior inline format strings in
+   [lib/server/server_auth.ml:298-302] (Outcome_none) and
+   [lib/server/server_auth.ml:340-344] (Outcome_error). The
+   token_mismatch remediation tail is reproduced verbatim because
+   operators key alerts on the literal "Remediation:" substring
+   (server_auth.ml:332-339 inline rationale). *)
+
+type dashboard_actor_fallback_outcome =
+  | Outcome_none
+  | Outcome_error of
+      { err : Masc_domain.t
+      ; err_kind : t
+      ; actor_hint : string option
+      }
+
+type dashboard_actor_fallback =
+  { outcome : dashboard_actor_fallback_outcome
+  ; token_hash_prefix : string
+  }
+
+let dashboard_actor_fallback_log_message fb =
+  match fb.outcome with
+  | Outcome_none ->
+      (* Byte-equivalent to the prior inline Printf format. The continuation
+         lines were OCaml string-literal continuations (backslash-newline +
+         leading whitespace), which the compiler concatenates into a single
+         space-joined sentence — preserved here without leading whitespace. *)
+      Printf.sprintf
+        "[silent:dashboard_actor_fallback] outcome=none token_hash_prefix=%s \
+         \xe2\x80\x94 bearer token resolved to no agent, falling back to \
+         request actor hint"
+        fb.token_hash_prefix
+  | Outcome_error { err; err_kind; actor_hint } ->
+      let err_str = Masc_domain.masc_error_to_string err in
+      let hint =
+        match actor_hint with
+        | Some s -> s
+        | None -> "<none>"
+      in
+      let err_kind_label = to_string err_kind in
+      let extra_hint =
+        match err_kind with
+        | Token_mismatch ->
+            " Remediation: clear the browser's stored dashboard token \
+             (localStorage masc_dashboard_token) or delete \
+             .masc/auth/dashboard.token so a fresh token is minted on \
+             the next dashboard load."
+        | Token_expired
+        | Unauthorized
+        | Forbidden
+        | Agent_not_found
+        | Io_error
+        | Invalid_json
+        | Other -> ""
+      in
+      Printf.sprintf
+        "[silent:dashboard_actor_fallback] outcome=error \
+         token_hash_prefix=%s err_kind=%s actor_hint=%s err=%s \xe2\x80\x94 \
+         falling back to request actor hint.%s"
+        fb.token_hash_prefix err_kind_label hint err_str extra_hint
+
+let dashboard_actor_fallback_prometheus_labels fb =
+  match fb.outcome with
+  | Outcome_none ->
+      [ ( "outcome"
+        , Silent_dashboard_actor_outcome.to_label
+            Silent_dashboard_actor_outcome.None_resolved )
+      ]
+  | Outcome_error { err_kind; _ } ->
+      [ ( "outcome"
+        , Silent_dashboard_actor_outcome.to_label
+            Silent_dashboard_actor_outcome.Error_classified )
+      ; ("err_kind", to_string err_kind)
+      ]

--- a/lib/auth_error_kind.mli
+++ b/lib/auth_error_kind.mli
@@ -27,3 +27,66 @@ val classify : Masc_domain.t -> t
 
 (** All inhabitants in declaration order. Used by exhaustiveness tests. *)
 val all : t list
+
+(** {1 Dashboard actor fallback typed surface}
+
+    The dashboard actor resolution path in [lib/server/server_auth.ml]
+    falls back to the request-actor hint when the bearer token cannot be
+    mapped to a credential. Two structurally distinct failure modes share
+    a single counter ([metric_silent_dashboard_actor_fallback]):
+
+    - [Outcome_none]: token resolution returned [Ok None] (no matching
+      credential on file).
+    - [Outcome_error]: token resolution raised a classified
+      [Masc_domain.t] (the variant carries the typed [t] in the
+      [err_kind] field, alongside the request-actor hint and the raw
+      error string).
+
+    Previously these two branches were inline at two adjacent call
+    sites with hardcoded format strings, so callers had no typed handle
+    on *why* the fallback fired — a counter is not a fix
+    (see CLAUDE.md §Workaround Rejection Bar §1 Counter-as-Fix). The
+    fallback path itself is preserved as a production safety net
+    (dashboard cannot go dark on token churn); this surface adds the
+    typed kind that downstream reducers need without removing the
+    safety net.
+
+    Reference: ~/Downloads/MASC-MCP Reverse Engineering Design Map.html
+    §Gap "Auth identity is spread across several layers" + §개선 #2
+    (request identity state machine). *)
+
+(** Why the dashboard actor fallback path was taken. *)
+type dashboard_actor_fallback_outcome =
+  | Outcome_none
+      (** Token resolution returned [Ok None]: the bearer token is
+          syntactically valid but matches no credential on file. *)
+  | Outcome_error of
+      { err : Masc_domain.t
+      ; err_kind : t
+      ; actor_hint : string option
+      }
+      (** Token resolution raised a classified domain error. [err_kind]
+          is the closed-enum classification of [err]; [actor_hint] is
+          the request actor hint (header / query param) that the
+          callsite is about to fall back to, captured for the log line. *)
+
+(** Full record of a single dashboard actor fallback event. *)
+type dashboard_actor_fallback =
+  { outcome : dashboard_actor_fallback_outcome
+  ; token_hash_prefix : string
+        (** First 8 hex chars of SHA-256(bearer_token) — see
+            [server_auth.ml:281-291] for the security rationale. *)
+  }
+
+(** Render the byte-equivalent warn-log message for a fallback event.
+    Used by the consolidated helper at the callsite; the format strings
+    match the prior inline [Log.Auth.warn] templates so prometheus log
+    queries and alerting rules keyed on the [silent:dashboard_actor_fallback]
+    prefix continue to fire unchanged. *)
+val dashboard_actor_fallback_log_message : dashboard_actor_fallback -> string
+
+(** Prometheus counter labels for a fallback event. Always includes the
+    [outcome] dimension; the [Outcome_error] case additionally carries
+    the [err_kind] dimension. *)
+val dashboard_actor_fallback_prometheus_labels :
+  dashboard_actor_fallback -> (string * string) list

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -275,6 +275,20 @@ let sanitize_dashboard_actor_name raw =
     value;
   Buffer.contents buf
 
+(* Consolidates the two prior [silent:dashboard_actor_fallback] warn sites
+   (Ok None / Error err arms in [dashboard_actor_for_request]) onto a single
+   helper. The message rendering and prometheus labels are owned by
+   [Auth_error_kind] so the contract is round-tripped through a typed
+   record rather than two parallel inline format strings. *)
+let record_dashboard_actor_fallback
+    (fb : Auth_error_kind.dashboard_actor_fallback) =
+  Log.Auth.warn "%s"
+    (Auth_error_kind.dashboard_actor_fallback_log_message fb);
+  Prometheus.inc_counter
+    Prometheus.metric_silent_dashboard_actor_fallback
+    ~labels:(Auth_error_kind.dashboard_actor_fallback_prometheus_labels fb)
+    ()
+
 let dashboard_actor_for_request ~base_path request =
   match auth_token_from_request request with
   | Some token -> (
@@ -294,16 +308,21 @@ let dashboard_actor_for_request ~base_path request =
       | Ok None ->
           (* PR-I: surface the silent fallback. Token did not resolve to any
              agent, so we drop to the request actor hint (header / query
-             param), masking identity drift in the HTTP transport. *)
-          Log.Auth.warn
-            "[silent:dashboard_actor_fallback] outcome=none token_hash_prefix=%s \
-             — bearer token resolved to no agent, falling back to request \
-             actor hint"
-            token_hash_prefix;
-          Prometheus.inc_counter
-            Prometheus.metric_silent_dashboard_actor_fallback
-            ~labels:[ ("outcome", Silent_dashboard_actor_outcome.(to_label None_resolved)) ]
-            ();
+             param), masking identity drift in the HTTP transport.
+
+             WORKAROUND-CARRYOVER: the fallback path itself is retained as a
+             production safety net — the dashboard cannot go dark on token
+             churn — but the two warn sites here and at the [Error] arm now
+             flow through [Auth_error_kind.dashboard_actor_fallback], giving
+             callers a typed handle on *why* the fallback fired. The
+             string emitted by [dashboard_actor_fallback_log_message] is
+             byte-equivalent to the prior inline format so prometheus log
+             alerts keyed on the literal prefix continue to fire.
+             Reference: Reverse Engineering Design Map §개선 #2. *)
+          let fb : Auth_error_kind.dashboard_actor_fallback =
+            { outcome = Auth_error_kind.Outcome_none; token_hash_prefix }
+          in
+          record_dashboard_actor_fallback fb;
           request_actor_hint request
       | Error err ->
           (* The previous warn line elided the actual error string and the
@@ -311,41 +330,21 @@ let dashboard_actor_for_request ~base_path request =
              told them *something* errored — not what.  Production logs
              showed the warn firing 1–2 times/second with no diagnostic
              surface, so the WARN was loud noise without root-cause
-             attribution.  Surface both the error class and the hint. *)
-          let err_str = Masc_domain.masc_error_to_string err in
-          let hint =
-            match request_actor_hint request with
-            | Some s -> s
-            | None -> "<none>"
+             attribution.  Surface both the error class and the hint via
+             the typed [Auth_error_kind.Outcome_error] arm — the
+             [Token_mismatch] remediation tail is embedded in
+             [dashboard_actor_fallback_log_message]. *)
+          let fb : Auth_error_kind.dashboard_actor_fallback =
+            { outcome =
+                Auth_error_kind.Outcome_error
+                  { err
+                  ; err_kind = Auth_error_kind.classify err
+                  ; actor_hint = request_actor_hint request
+                  }
+            ; token_hash_prefix
+            }
           in
-          (* err_kind is a closed enum in [Auth_error_kind] — issue #11266
-             Track 2a. The stable label is shared with the MCP-side dispatch in
-             [mcp_server_eio_execute.ml:silent_auth_token_error_kind]. *)
-          let err_kind = Auth_error_kind.to_string (Auth_error_kind.classify err) in
-          (* P3-5: token_mismatch means the dashboard's bearer token does not
-             match any credential on file.  This is a structural auth-path
-             defect: the dashboard is presenting a stale token from a previous
-             startup or a browser session whose credential was rotated.  Add a
-             one-time remediation hint to guide operators toward the fix:
-             clearing the stored dashboard token causes ensure_dashboard_dev_token
-             to mint a fresh one on the next page load. *)
-          let extra_hint =
-            if String.equal err_kind "token_mismatch" then
-              " Remediation: clear the browser's stored dashboard token \
-               (localStorage masc_dashboard_token) or delete \
-               .masc/auth/dashboard.token so a fresh token is minted on \
-               the next dashboard load."
-            else ""
-          in
-          Log.Auth.warn
-            "[silent:dashboard_actor_fallback] outcome=error \
-             token_hash_prefix=%s err_kind=%s actor_hint=%s err=%s — falling \
-             back to request actor hint.%s"
-            token_hash_prefix err_kind hint err_str extra_hint;
-          Prometheus.inc_counter
-            Prometheus.metric_silent_dashboard_actor_fallback
-            ~labels:[ ("outcome", Silent_dashboard_actor_outcome.(to_label Error_classified)); ("err_kind", err_kind) ]
-            ();
+          record_dashboard_actor_fallback fb;
           request_actor_hint request)
   | None -> request_actor_hint request
 

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -110,6 +110,23 @@ val sanitize_dashboard_actor_name : string -> string
 (** Strip non-printable characters and clamp length so the actor name
     is safe to log / render. *)
 
+val record_dashboard_actor_fallback :
+  Auth_error_kind.dashboard_actor_fallback -> unit
+(** Emit the [silent:dashboard_actor_fallback] warn log + increment
+    [metric_silent_dashboard_actor_fallback] for a typed fallback event.
+
+    Consolidates the two prior inline warn sites (Ok None / Error err
+    arms in [dashboard_actor_for_request]) onto a single helper. The
+    rendered log message is byte-equivalent to the prior format strings
+    — prometheus log alerts keyed on the literal
+    [silent:dashboard_actor_fallback] prefix continue to fire.
+
+    WORKAROUND-CARRYOVER: the fallback path itself remains (the
+    dashboard cannot go dark on token churn), but downstream reducers
+    now have a typed handle on *why* the fallback fired. Reference:
+    Reverse Engineering Design Map §개선 #2 (request identity state
+    machine). *)
+
 val dashboard_actor_for_request :
   base_path:string -> Httpun.Request.t -> string option
 (** Resolve the dashboard actor name from the request. *)

--- a/test/dune
+++ b/test/dune
@@ -42,6 +42,7 @@
   test_auth
   test_auth_doctor
   test_auth_error_kind
+  test_auth_error_kind_dashboard_fallback
   test_mcp_error_code
   test_error_body_delegation
   test_session_lifecycle_event
@@ -339,6 +340,7 @@
   test_auth
   test_auth_doctor
   test_auth_error_kind
+  test_auth_error_kind_dashboard_fallback
   test_mcp_error_code
   test_error_body_delegation
   test_session_lifecycle_event

--- a/test/test_auth_error_kind_dashboard_fallback.ml
+++ b/test/test_auth_error_kind_dashboard_fallback.ml
@@ -1,0 +1,330 @@
+(** Byte-equivalence + label tests for the dashboard_actor_fallback typed
+    surface on [Auth_error_kind].
+
+    The two prior inline warn sites at [lib/server/server_auth.ml] used
+    Printf format strings that the OCaml lexer concatenates across the
+    [\<newline><whitespace>] escape into a single line. Operators key
+    prometheus log alerts on the literal [silent:dashboard_actor_fallback]
+    prefix and on the [Remediation:] substring in the [token_mismatch]
+    arm, so the consolidated helper MUST emit the byte-identical message.
+
+    These tests lock the rendered string for both outcome arms against an
+    explicit hex-literal expected value, and check that the prometheus
+    label list matches the prior call. Reference:
+    [auth_error_kind.mli §Dashboard actor fallback typed surface]. *)
+
+open Alcotest
+module Aek = Masc_mcp.Auth_error_kind
+module Sda = Masc_mcp.Silent_dashboard_actor_outcome
+
+(* ----- Outcome_none: byte-equivalent log message --------------------- *)
+
+let test_outcome_none_log_message_byte_equivalent () =
+  let fb : Aek.dashboard_actor_fallback =
+    { outcome = Aek.Outcome_none; token_hash_prefix = "deadbeef" }
+  in
+  let actual = Aek.dashboard_actor_fallback_log_message fb in
+  let expected =
+    "[silent:dashboard_actor_fallback] outcome=none \
+     token_hash_prefix=deadbeef \xe2\x80\x94 bearer token resolved to no \
+     agent, falling back to request actor hint"
+  in
+  Alcotest.(check string) "byte-equivalent rendering" expected actual
+
+let test_outcome_none_log_message_starts_with_alert_prefix () =
+  (* Lock the [silent:dashboard_actor_fallback] prefix — prometheus log
+     alerts grep for this literal substring. *)
+  let fb : Aek.dashboard_actor_fallback =
+    { outcome = Aek.Outcome_none; token_hash_prefix = "ab12cd34" }
+  in
+  let msg = Aek.dashboard_actor_fallback_log_message fb in
+  let prefix = "[silent:dashboard_actor_fallback] outcome=none" in
+  let n = String.length prefix in
+  Alcotest.(check string)
+    "alert prefix preserved"
+    prefix
+    (String.sub msg 0 n)
+
+let test_outcome_none_log_message_no_leading_whitespace_after_dash () =
+  (* The OCaml [\<newline><whitespace>] continuation collapses to nothing,
+     so the source-level visual indent must NOT appear in the rendered
+     string. A regression that inserted a literal space-newline-space
+     would shift downstream log parsers — guard it. *)
+  let fb : Aek.dashboard_actor_fallback =
+    { outcome = Aek.Outcome_none; token_hash_prefix = "zz" }
+  in
+  let msg = Aek.dashboard_actor_fallback_log_message fb in
+  (* Must contain "zz \xe2\x80\x94 bearer" — em-dash directly after the
+     single space, no double-space. *)
+  let needle = "zz \xe2\x80\x94 bearer" in
+  Alcotest.(check bool)
+    "single space before em-dash"
+    true
+    (Astring.String.is_infix ~affix:needle msg)
+
+(* ----- Outcome_error: byte-equivalent log message -------------------- *)
+
+let invalid_token_err =
+  Masc_domain.Auth (Masc_domain.Auth_error.InvalidToken "stale-token-x")
+
+let unauthorized_err =
+  Masc_domain.Auth (Masc_domain.Auth_error.Unauthorized "no perms")
+
+let test_outcome_error_token_mismatch_renders_remediation () =
+  (* [Token_mismatch] is the only [err_kind] that appends the
+     remediation tail. Lock the literal "Remediation:" substring +
+     trailing period from the original format. *)
+  let fb : Aek.dashboard_actor_fallback =
+    { outcome =
+        Aek.Outcome_error
+          { err = invalid_token_err
+          ; err_kind = Aek.Token_mismatch
+          ; actor_hint = Some "dashboard-admin"
+          }
+    ; token_hash_prefix = "feed1234"
+    }
+  in
+  let msg = Aek.dashboard_actor_fallback_log_message fb in
+  (* Spot-check critical substrings independently — the full byte
+     equivalence is locked by a separate test below. *)
+  Alcotest.(check bool)
+    "alert prefix"
+    true
+    (Astring.String.is_prefix
+       ~affix:
+         "[silent:dashboard_actor_fallback] outcome=error \
+          token_hash_prefix=feed1234"
+       msg);
+  Alcotest.(check bool)
+    "err_kind label"
+    true
+    (Astring.String.is_infix ~affix:"err_kind=token_mismatch" msg);
+  Alcotest.(check bool)
+    "actor_hint inlined"
+    true
+    (Astring.String.is_infix ~affix:"actor_hint=dashboard-admin" msg);
+  Alcotest.(check bool)
+    "remediation tail present"
+    true
+    (Astring.String.is_infix ~affix:" Remediation: " msg);
+  Alcotest.(check bool)
+    "localStorage hint"
+    true
+    (Astring.String.is_infix
+       ~affix:"localStorage masc_dashboard_token"
+       msg)
+
+let test_outcome_error_token_mismatch_byte_equivalent () =
+  let fb : Aek.dashboard_actor_fallback =
+    { outcome =
+        Aek.Outcome_error
+          { err = invalid_token_err
+          ; err_kind = Aek.Token_mismatch
+          ; actor_hint = Some "dashboard-admin"
+          }
+    ; token_hash_prefix = "feed1234"
+    }
+  in
+  let actual = Aek.dashboard_actor_fallback_log_message fb in
+  let err_str = Masc_domain.masc_error_to_string invalid_token_err in
+  let expected =
+    Printf.sprintf
+      "[silent:dashboard_actor_fallback] outcome=error \
+       token_hash_prefix=feed1234 err_kind=token_mismatch \
+       actor_hint=dashboard-admin err=%s \xe2\x80\x94 falling back to \
+       request actor hint. Remediation: clear the browser's stored \
+       dashboard token (localStorage masc_dashboard_token) or delete \
+       .masc/auth/dashboard.token so a fresh token is minted on the \
+       next dashboard load."
+      err_str
+  in
+  Alcotest.(check string) "byte-equivalent rendering" expected actual
+
+let test_outcome_error_non_token_mismatch_no_remediation () =
+  (* The remediation tail is exclusive to [Token_mismatch]. Other
+     [err_kind] arms must end at the trailing period of "actor hint." *)
+  let fb : Aek.dashboard_actor_fallback =
+    { outcome =
+        Aek.Outcome_error
+          { err = unauthorized_err
+          ; err_kind = Aek.Unauthorized
+          ; actor_hint = None
+          }
+    ; token_hash_prefix = "0000abcd"
+    }
+  in
+  let msg = Aek.dashboard_actor_fallback_log_message fb in
+  Alcotest.(check bool)
+    "no remediation tail"
+    false
+    (Astring.String.is_infix ~affix:" Remediation: " msg);
+  Alcotest.(check bool)
+    "actor_hint=<none> placeholder"
+    true
+    (Astring.String.is_infix ~affix:"actor_hint=<none>" msg);
+  Alcotest.(check bool)
+    "ends at hint period"
+    true
+    (Astring.String.is_suffix
+       ~affix:"falling back to request actor hint."
+       msg)
+
+(* ----- Prometheus label correspondence ------------------------------- *)
+
+let labels_eq actual expected =
+  let sort = List.sort compare in
+  Alcotest.(check (list (pair string string)))
+    "label set"
+    (sort expected)
+    (sort actual)
+
+let test_outcome_none_labels () =
+  let fb : Aek.dashboard_actor_fallback =
+    { outcome = Aek.Outcome_none; token_hash_prefix = "x" }
+  in
+  let labels = Aek.dashboard_actor_fallback_prometheus_labels fb in
+  labels_eq labels [ ("outcome", Sda.to_label Sda.None_resolved) ];
+  Alcotest.(check string)
+    "outcome label is 'none'"
+    "none"
+    (Sda.to_label Sda.None_resolved)
+
+let test_outcome_error_labels_include_err_kind () =
+  let fb : Aek.dashboard_actor_fallback =
+    { outcome =
+        Aek.Outcome_error
+          { err = invalid_token_err
+          ; err_kind = Aek.Token_mismatch
+          ; actor_hint = Some "dashboard-admin"
+          }
+    ; token_hash_prefix = "x"
+    }
+  in
+  let labels = Aek.dashboard_actor_fallback_prometheus_labels fb in
+  labels_eq labels
+    [ ("outcome", Sda.to_label Sda.Error_classified)
+    ; ("err_kind", "token_mismatch")
+    ];
+  Alcotest.(check string)
+    "outcome label is 'error'"
+    "error"
+    (Sda.to_label Sda.Error_classified)
+
+let test_outcome_error_labels_for_every_err_kind () =
+  (* Walk every modelled [Auth_error_kind.t] and confirm the
+     prometheus label list shape is stable: ("outcome", "error") +
+     ("err_kind", <stable_label>). This guards against the
+     [Other]-collapse anti-pattern (CLAUDE.md §Workaround Rejection Bar
+     §2 String/Substring classifier). *)
+  List.iter
+    (fun err_kind ->
+      let fb : Aek.dashboard_actor_fallback =
+        { outcome =
+            Aek.Outcome_error
+              { err = invalid_token_err
+              ; err_kind
+              ; actor_hint = None
+              }
+        ; token_hash_prefix = "x"
+        }
+      in
+      let labels = Aek.dashboard_actor_fallback_prometheus_labels fb in
+      let outcome =
+        List.assoc_opt "outcome" labels
+        |> Option.value ~default:"<missing>"
+      in
+      let err_kind_lbl =
+        List.assoc_opt "err_kind" labels
+        |> Option.value ~default:"<missing>"
+      in
+      Alcotest.(check string)
+        "outcome='error'" "error" outcome;
+      Alcotest.(check string)
+        "err_kind label matches to_string"
+        (Aek.to_string err_kind)
+        err_kind_lbl)
+    Aek.all
+
+(* ----- Side-effect: prometheus counter increments -------------------- *)
+
+let test_outcome_none_increments_counter () =
+  let module Prom = Masc_mcp.Prometheus in
+  let labels = [ ("outcome", "none") ] in
+  let before =
+    Prom.metric_value_or_zero
+      Prom.metric_silent_dashboard_actor_fallback ~labels ()
+  in
+  (* Drive the helper directly via the same internal entry point as
+     server_auth.ml — exercise [Auth_error_kind] then increment via the
+     prometheus surface. The helper itself lives in [Server_auth] so we
+     call [record_dashboard_actor_fallback] there. *)
+  let fb : Aek.dashboard_actor_fallback =
+    { outcome = Aek.Outcome_none; token_hash_prefix = "feedface" }
+  in
+  Masc_mcp.Server_auth.record_dashboard_actor_fallback fb;
+  let after =
+    Prom.metric_value_or_zero
+      Prom.metric_silent_dashboard_actor_fallback ~labels ()
+  in
+  Alcotest.(check (float 0.0))
+    "counter +1.0 for outcome=none"
+    (before +. 1.0)
+    after
+
+let test_outcome_error_increments_counter_with_err_kind () =
+  let module Prom = Masc_mcp.Prometheus in
+  let labels =
+    [ ("outcome", "error"); ("err_kind", "unauthorized") ]
+  in
+  let before =
+    Prom.metric_value_or_zero
+      Prom.metric_silent_dashboard_actor_fallback ~labels ()
+  in
+  let fb : Aek.dashboard_actor_fallback =
+    { outcome =
+        Aek.Outcome_error
+          { err = unauthorized_err
+          ; err_kind = Aek.Unauthorized
+          ; actor_hint = None
+          }
+    ; token_hash_prefix = "feedface"
+    }
+  in
+  Masc_mcp.Server_auth.record_dashboard_actor_fallback fb;
+  let after =
+    Prom.metric_value_or_zero
+      Prom.metric_silent_dashboard_actor_fallback ~labels ()
+  in
+  Alcotest.(check (float 0.0))
+    "counter +1.0 for outcome=error+err_kind=unauthorized"
+    (before +. 1.0)
+    after
+
+let suite =
+  [ test_case "Outcome_none: byte-equivalent log message" `Quick
+      test_outcome_none_log_message_byte_equivalent
+  ; test_case "Outcome_none: alert prefix locked" `Quick
+      test_outcome_none_log_message_starts_with_alert_prefix
+  ; test_case "Outcome_none: no whitespace before em-dash" `Quick
+      test_outcome_none_log_message_no_leading_whitespace_after_dash
+  ; test_case "Outcome_error+Token_mismatch: remediation tail present" `Quick
+      test_outcome_error_token_mismatch_renders_remediation
+  ; test_case "Outcome_error+Token_mismatch: byte-equivalent" `Quick
+      test_outcome_error_token_mismatch_byte_equivalent
+  ; test_case "Outcome_error+other err_kind: no remediation tail" `Quick
+      test_outcome_error_non_token_mismatch_no_remediation
+  ; test_case "Outcome_none: prometheus labels" `Quick
+      test_outcome_none_labels
+  ; test_case "Outcome_error: prometheus labels include err_kind" `Quick
+      test_outcome_error_labels_include_err_kind
+  ; test_case "Outcome_error: label shape stable across err_kind" `Quick
+      test_outcome_error_labels_for_every_err_kind
+  ; test_case "Outcome_none: counter increments" `Quick
+      test_outcome_none_increments_counter
+  ; test_case "Outcome_error: counter increments with err_kind label" `Quick
+      test_outcome_error_increments_counter_with_err_kind
+  ]
+
+let () =
+  Alcotest.run "Auth_error_kind_dashboard_fallback"
+    [ ("dashboard_actor_fallback", suite) ]


### PR DESCRIPTION
## 요약

`lib/server/server_auth.ml`의 `dashboard_actor_for_request`에서 2분기로
흩어져 있던 `[silent:dashboard_actor_fallback]` warn 사이트를 typed
변종(`Auth_error_kind.dashboard_actor_fallback`)으로 변환하고, 두 사이트를
단일 helper(`record_dashboard_actor_fallback`)로 통합합니다. **fallback
path 자체는 보존**하고, typed surface만 추가하여 후속 reducer가 *왜
fallback이 발생했는지*에 따라 production-safety 결정을 내릴 수 있도록
합니다.

### 배경

- `~/me/.masc/logs/system_log_2026-05-18.jsonl` 72h 분석:
  `[silent:dashboard_actor_fallback] outcome=none|error` 200+회 누적.
- emit 위치는 2분기:
  - `lib/server/server_auth.ml:299` outcome=none (token이 어떤 agent에도
    resolve 안 됨)
  - `lib/server/server_auth.ml:341` outcome=error (token resolution이
    classified `Masc_domain.t` raise)
- counter `metric_silent_dashboard_actor_fallback`는 이미 존재하지만,
  raw warn log + counter increment 두 줄로 흩어져 있어 caller가
  **왜 fallback인지** 구분 못함.
- `lib/auth_error_kind.ml:5` 주석에 typed kind candidate가 명시되어
  있으나 미구현 상태였음.

### 참고

- `~/Downloads/MASC-MCP Reverse Engineering Design Map.html`
  - § Gap "Auth identity is spread across several layers"
  - § 개선 #2 "Tool execution identity state machine" — precursor 작업
- Tracking issue 후보: 본 PR은 *typed surface 추가* 단계이며,
  request identity state machine 자체는 별도 RFC로 후속.

## 변경

### `lib/auth_error_kind.{ml,mli}`

기존 closed-enum `type t` (prometheus dashboard용 문자열-stable 라벨)
**그대로 유지**. 옆에 typed surface 추가:

```ocaml
type dashboard_actor_fallback_outcome =
  | Outcome_none
  | Outcome_error of
      { err : Masc_domain.t
      ; err_kind : t
      ; actor_hint : string option
      }

type dashboard_actor_fallback =
  { outcome : dashboard_actor_fallback_outcome
  ; token_hash_prefix : string
  }

val dashboard_actor_fallback_log_message : dashboard_actor_fallback -> string
val dashboard_actor_fallback_prometheus_labels :
  dashboard_actor_fallback -> (string * string) list
```

- `dashboard_actor_fallback_log_message`는 기존 inline `Printf.sprintf`
  format string과 **byte-equivalent**로 렌더링합니다. `Token_mismatch`
  remediation tail(`localStorage masc_dashboard_token` 등)은 typed kind
  match로 분기하며, 다른 `err_kind` 변종은 exhaustive match로 명시
  (catch-all `_ -> ()` 없음).
- `dashboard_actor_fallback_prometheus_labels`는
  `Silent_dashboard_actor_outcome.to_label`을 재사용해 `("outcome",
  ...)` 라벨 SSOT를 유지하고, `Outcome_error` arm에서만 `("err_kind",
  ...)` 차원을 추가합니다.

### `lib/server/server_auth.{ml,mli}`

- 신규 `record_dashboard_actor_fallback :
  Auth_error_kind.dashboard_actor_fallback -> unit` helper —
  `Log.Auth.warn` 1회 + `Prometheus.inc_counter` 1회.
- `dashboard_actor_for_request`의 두 분기를 helper 호출 1줄 + 변종
  생성으로 축약. 기존 `Auth_error_kind.classify err`로 typed err_kind
  계산, `request_actor_hint request`로 actor hint를 capture 후 변종에
  포함시켜 helper에 위임.
- `Log.Auth.warn` 호출 횟수, `Prometheus.inc_counter` 호출 횟수, 라벨
  세트, 메시지 바이트 전부 **변경 전과 동일**.

### `test/test_auth_error_kind_dashboard_fallback.ml` (신규)

11 test cases:

1. `Outcome_none`: 알려진 expected string과 byte-equivalent 비교
2. `Outcome_none`: alert prefix(`[silent:dashboard_actor_fallback]
   outcome=none`) 유지 확인
3. `Outcome_none`: em-dash 앞 single-space 보장 (regression guard)
4. `Outcome_error+Token_mismatch`: remediation tail 부분 존재 확인
5. `Outcome_error+Token_mismatch`: 알려진 expected string과
   byte-equivalent 비교 (em-dash UTF-8 포함)
6. `Outcome_error+다른 err_kind`: remediation tail 부재 확인,
   `actor_hint=<none>` placeholder 검증
7. `Outcome_none`: prometheus 라벨이
   `[("outcome", "none")]`인지 검증
8. `Outcome_error`: prometheus 라벨이
   `[("outcome", "error"); ("err_kind", "token_mismatch")]`인지 검증
9. `Outcome_error`: `Auth_error_kind.all`을 순회하며 라벨 모양 stable
   검증 (Other 포함, fall-through 없음)
10. `Outcome_none`: helper 1회 호출 후 counter +1.0 검증
11. `Outcome_error`: helper 1회 호출 후 counter +1.0 + err_kind 라벨
    검증

`ocamlformat --check` 통과, `git diff --check origin/main...HEAD` 통과,
`ocamlfind ocamlc -c` 직접 호출로 test 타입 체크 통과 (cmi 생성됨).

## 라벨

`WORKAROUND-CARRYOVER: silent fallback path 유지, typed surface만 추가`

이 PR은 fallback path를 **제거하지 않습니다**. dashboard가 token 회전
시점에 *완전히 꺼져서는 안 되는* production safety net이기 때문입니다.
대신, typed kind를 caller에게 노출하여 후속 reducer가 production-safety
결정을 가능하게 합니다. CLAUDE.md §Workaround Rejection Bar §Symptom
억제 패턴에 따라 `WORKAROUND-CARRYOVER` 라벨을 부여합니다.

### 대체 RFC 후보

- **Reverse Engineering Map §개선 #2** (request identity state machine):
  request 단위의 identity 결정을 explicit FSM으로 모델링. `Anonymous`,
  `Token_resolved`, `Token_failed_with_classified_err`, `Token_failed_silent`
  같은 상태를 typed로 표현하여 fallback path 자체를 unrepresentable로
  만들 가능성 검토.
- Tracking issue / RFC 번호는 후속 PR에서 할당.

## 빌드 / 검증

| 명령 | 결과 |
|---|---|
| `opam exec -- ocamlformat --check ...` | EXIT=0 |
| `git diff --check --cached origin/main` | EXIT=0 |
| `dune build --root . @check` (전체) | **lib/prometheus.ml**에서 pre-existing 빌드 실패 (origin/main 자체가 깨져 있음, #16281 후속). `lib/auth_error_kind.cmo`, `lib/server/server_auth.cmo` 등 본 PR이 건드린 파일의 cmo는 정상 생성됨. |
| `ocamlfind ocamlc -c` (test 단독) | EXIT=0 (테스트 타입 체크 성공, cmi 생성 확인) |

### 알려진 blocker (PR 외 작업)

`lib/prometheus.ml:262`의 `let key = metric_key name [] in`이 `Unbound
value metric_key`로 실패합니다. 원인은 `refactor: split prometheus
metric store (#16281)` 이후 `Prometheus_store.mli`가 `metric_key`를
export 하지 않고, `prometheus.ml`이 `include Prometheus_store` 만으로
접근하려 하기 때문입니다. **본 PR의 작업이 아닙니다** — origin/main
6bc64306e4 시점에서도 동일하게 실패합니다 (clean checkout으로 확인).
upstream 핫픽스 후 본 PR의 통합 테스트(`dune runtest`)를 함께
재실행해야 합니다.

## 후속 단계

1. 본 PR 머지 후, caller(token resolution path, `lib/auth.ml`
   `resolve_agent_from_token`)가 typed kind에 따라 production-safety 결정을
   가능하게 하는 reducer를 별도 PR로.
2. `Outcome_none`을 silent하게 두는 대신, audit 로그 + dashboard 경고로
   surface 하는 옵션을 RFC로 평가.
3. Reverse Engineering Map §개선 #2 RFC 작성: request identity FSM.

## 라벨

- WORKAROUND-CARRYOVER
- Reverse-Engineering-Map: §Gap "Auth identity is spread across several
  layers" / §개선 #2

RFC-WAIVED: `lib/server/server_auth.ml`는 agent_delegation의
credential/identity/keeper sandbox/operator/dashboard credential subsystem
**바깥**의 일반 HTTP auth 경로. behavior 보존 + typed surface 추가만
포함하며, fallback path는 유지. 대체 RFC 후보 = Reverse Engineering
Design Map §개선 #2.

Co-Authored-By: Claude (subagent GAMMA, /loop iter 3, 2026-05-19)