### PR TITLE
chore(lint-spawn-bounded): bump worker_dev_tools.ml allowlist line 1941 → 1816

### DIFF
--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -31,7 +31,7 @@ lib/process/process_eio.ml:493
 # manager itself. Bounded by session scope, not by per-call timeout.
 lib/server/lsp_process_manager.ml:178
 
-# lib/worker_dev_tools.ml:1941 — dev-tools worker spawn. Wrapped by
+# lib/worker_dev_tools.ml:1816 — dev-tools worker spawn. Wrapped by
 # Tool_resource_gate, Fd_accountant, Eio.Time.with_timeout_exn, and a fresh
 # Eio.Switch.run at the call boundary.
-lib/worker_dev_tools.ml:1941
+lib/worker_dev_tools.ml:1816


### PR DESCRIPTION
## Summary
Unblocks every in-flight PR's `Spawn-bounded ratchet` check.

The dev-tools worker spawn at `lib/worker_dev_tools.ml` moved from line 1941 → 1816 after the 2026-05-18 godfile decomposition trimmed the file (~125 lines removed). The previous allowlist entry pointed at a now-empty line (reported as STALE) while the new spawn site was reported as NEW without a justification.

The spawn itself is unchanged — still wrapped at the call boundary by `Eio.Time.with_timeout_exn` + a fresh `Eio.Switch.run` + `Fd_accountant.with_slot ~kind:Sandbox_exec`. So it continues to satisfy allowlist criterion #2 ("Wrapped at the call layer in `Eio.Time.with_timeout_exn` + fresh `Eio.Switch.run`, with the wall-clock budget sourced from a typed configuration").

## Changes
- `scripts/lint-spawn-bounded.allowlist`: comment + entry bumped from `:1941` to `:1816` (2-line diff).

## Verification
- `bash scripts/lint-spawn-bounded.sh` locally: `PASS (5 spawn site(s), all in allowlist)`

## Affected PRs (currently failing `Spawn-bounded ratchet` due to this drift)
#16289, #16292, #16293, #16294, #16295, #16296, #16301, #16302, #16304, #16306, #16307

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
