### PR TITLE
chore(lint): renumber worker_dev_tools spawn allowlist after #16222 split

### DIFF
--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -33,5 +33,6 @@ lib/server/lsp_process_manager.ml:178
 
 # lib/worker_dev_tools.ml:1816 — dev-tools worker spawn. Wrapped by
 # Tool_resource_gate, Fd_accountant, Eio.Time.with_timeout_exn, and a fresh
-# Eio.Switch.run at the call boundary.
+# Eio.Switch.run at the call boundary. Line renumbered from :1941 by
+# #16222 (split: worker dev tool paths).
 lib/worker_dev_tools.ml:1816


### PR DESCRIPTION
## 요약

`scripts/lint-spawn-bounded.sh` ratchet 가 **모든 열린 PR** 에서 동일하게 실패하고 있습니다 (#16312, #16292, #16293, #16294, #16295, #16296 외 다수):

\`\`\`
NEW spawn site(s) without allowlist entry:
  lib/worker_dev_tools.ml:1816
STALE allowlist entry/entries (no longer matches a spawn line):
  lib/worker_dev_tools.ml:1941
\`\`\`

#16222 (refactor: split worker dev tool paths) 가 `lib/worker_dev_tools.ml` 을 분할하면서 dev-tools worker spawn 이 line 1941 → 1816 으로 이동했지만 allowlist 가 업데이트되지 않아 ratchet 이 모든 후속 PR 을 blocking 중입니다.

## 변경

같은 spawn site, 같은 wrap 패턴 (`Eio.Switch.run @@ fun sw -> ... Eio.Process.spawn ~sw ...`) — 줄 번호만 갱신 + 코멘트에 #16222 split 추적.

## 검증

로컬 lint 통과:

\`\`\`
$ bash scripts/lint-spawn-bounded.sh
lint-spawn-bounded: PASS (5 spawn site(s), all in allowlist)
\`\`\`

Spawn 자체는 변경 없음 (1816 위치의 코드는 1941 이전과 byte-for-byte 동일한 wrap 패턴). 본 PR 은 ratchet 메타데이터만 갱신.

## Unblocks

| PR | 영향 |
|----|------|
| #16312 (dashboard snapshot.phase casing) | 다른 12 check PASS, 이 1 check 만 FAIL |
| #16292/#16293/#16294/#16295/#16296 (godfile 분할 후속) | 동일 fail |
| 기타 open PR (12+ 영향) | 동일 fail |

🤖 Generated with [Claude Code](https://claude.com/claude-code)