### PR TITLE
fix(board): judgment_arg silently drops List Yojson types (#16300)

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -250,19 +250,13 @@ let metric_mention_dedup_decisions_total = "masc_mention_dedup_decisions_total"
 (** {1 Built-in Metrics} *)
 
 let init () =
-  (* Module-level init runs before Eio context exists.
-     Single-threaded at load time — bypass mutex. *)
+  (* Module-level init runs before Eio context exists; the store lock is a
+     Stdlib.Mutex and is safe to use here. *)
   let add name help metric_kind =
-    let metric_type =
-      match metric_kind with
-      | `Counter -> Counter
-      | `Gauge -> Gauge
-      | `Histogram -> Histogram
-    in
-    let key = metric_key name [] in
-    if not (Hashtbl.mem metrics key)
-    then
-      Hashtbl.add metrics key { name; help; metric_type; value = 0.0; labels = [] }
+    match metric_kind with
+    | `Counter -> register_counter ~name ~help ()
+    | `Gauge -> register_gauge ~name ~help ()
+    | `Histogram -> register_histogram ~name ~help ()
   in
   Prometheus_builtin_metrics.register
     ~add
@@ -369,18 +363,14 @@ let to_prometheus_text () =
      are still updating [metrics].  [m.value] is mutable so we copy it
      here rather than holding the lock for the full render. *)
   let snapshot =
-    with_lock (fun () ->
-      Hashtbl.fold
-        (fun _ (m : metric) acc ->
-           Prometheus_text.metric
-             ~name:m.name
-             ~help:m.help
-             ~metric_type:(text_metric_type m.metric_type)
-             ~value:m.value
-             ~labels:m.labels
-           :: acc)
-        metrics
-        [])
+    snapshot_metrics ()
+    |> List.map (fun (m : metric) ->
+      Prometheus_text.metric
+        ~name:m.name
+        ~help:m.help
+        ~metric_type:(text_metric_type m.metric_type)
+        ~value:m.value
+        ~labels:m.labels)
   in
   Prometheus_text.render snapshot
 ;;

--- a/lib/prometheus_store.ml
+++ b/lib/prometheus_store.ml
@@ -118,6 +118,11 @@ let metric_total name =
       0.0)
 ;;
 
+let snapshot_metrics () =
+  with_lock (fun () ->
+    Hashtbl.fold (fun _ (m : metric) acc -> { m with value = m.value } :: acc) metrics [])
+;;
+
 let observe_histogram name ?(labels = []) value =
   let key = metric_key name labels in
   let count_key = metric_key (name ^ "_count") labels in

--- a/lib/prometheus_store.mli
+++ b/lib/prometheus_store.mli
@@ -30,6 +30,7 @@ val observe_histogram : string -> ?labels:label list -> float -> unit
 val get_metric_value : string -> ?labels:label list -> unit -> float option
 val metric_value_or_zero : string -> ?labels:label list -> unit -> float
 val metric_total : string -> float
+val snapshot_metrics : unit -> metric list
 
 (** The most recent EDEADLK backtrace captured by the store lock. [None]
     until the first re-entrant lock failure. *)

--- a/lib/tool_board_format.ml
+++ b/lib/tool_board_format.ml
@@ -403,7 +403,8 @@ let judgment_arg args =
     | `String value when String.equal (String.trim value) "" -> None
     | `String _ as value -> Some value
     | `Assoc _ as value -> Some value
-    | _ -> None
+    | `List _ as value -> Some value
+    | `Bool _ | `Int _ | `Intlit _ | `Float _ -> None
   in
   match value_of "judgment" with
   | Some _ as value -> value

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -625,6 +625,68 @@ let test_post_create_judgment_roundtrip () =
   Alcotest.(check string) "judgment summary kept in meta" summary
     Yojson.Safe.Util.(json |> member "meta" |> member "judgment" |> member "summary" |> to_string)
 
+(** Judgment as JSON List (e.g. [{summary: "...", confidence: 0.9}])
+    was silently dropped before the fix. Issue #16300. *)
+let test_post_create_judgment_list_roundtrip () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let ok, body =
+    dispatch "masc_board_post"
+      (make_args
+         [
+           ("content", `String "List-judged board post");
+           ("author", `String "tester");
+           ( "judgment",
+             `List [ `Assoc [ ("summary", `String "list-judged"); ("score", `Float 0.85) ] ] );
+         ])
+  in
+  Alcotest.(check bool) "create ok" true ok;
+  let json = parse_create_response_json body in
+  let judgment_json = Yojson.Safe.Util.(json |> member "meta" |> member "judgment") in
+  (* The List judgment must be preserved, not silently dropped. *)
+  Alcotest.(check bool) "list judgment is a non-null value" true
+    (judgment_json <> `Null);
+  let summary = Yojson.Safe.Util.(judgment_json |> index 0 |> member "summary" |> to_string) in
+  Alcotest.(check string) "list judgment summary preserved" "list-judged" summary
+
+(** Scalar JSON types (Bool, Int, Float, Intlit) for judgment must not
+    silently produce a valid post with judgment absent. They are
+    rejected or ignored — but the post itself succeeds (judgment is
+    optional). Issue #16300. *)
+let test_post_create_judgment_scalar_types_ignored () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let scalars =
+    [
+      ("Bool", `Bool true);
+      ("Int", `Int 42);
+      ("Float", `Float 3.14);
+      ("Intlit", `Intlit "999999999999999999999999");
+    ]
+  in
+  List.iter
+    (fun (label, scalar_value) ->
+       cleanup ();
+       let ok, body =
+         dispatch "masc_board_post"
+           (make_args
+              [
+                ("content", `String ("scalar-judgment-" ^ label));
+                ("author", `String "tester");
+                ("judgment", scalar_value);
+              ])
+       in
+       Alcotest.(check bool) (label ^ ": create ok") true ok;
+       let json = parse_create_response_json body in
+       let judgment_json =
+         try Yojson.Safe.Util.(json |> member "meta" |> member "judgment")
+         with _ -> `Null
+       in
+       Alcotest.(check bool) (label ^ ": scalar judgment ignored (null)") true
+         (judgment_json = `Null))
+    scalars
+
 let test_post_create_sources_footer_and_meta () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1570,6 +1632,10 @@ let () =
             test_post_create_structured_payload;
           Alcotest.test_case "create judgment roundtrip" `Quick
             test_post_create_judgment_roundtrip;
+          Alcotest.test_case "create judgment list roundtrip (#16300)" `Quick
+            test_post_create_judgment_list_roundtrip;
+          Alcotest.test_case "create judgment scalar types ignored (#16300)" `Quick
+            test_post_create_judgment_scalar_types_ignored;
           Alcotest.test_case "create sources footer and meta" `Quick
             test_post_create_sources_footer_and_meta;
           Alcotest.test_case "keeper board post preserves meta reason" `Quick


### PR DESCRIPTION
## Summary
- `judgment_arg` in `tool_board_format.ml` used `_ -> None` catch-all that silently dropped non-String/non-Assoc Yojson values, losing classification metadata when keepers send judgment as JSON List
- Replace catch-all with exhaustive match over all 8 Yojson.Safe.t variants (`Bool`, `Int`, `Intlit`, `Float` → None; `List` → preserved)
- Cherry-picks prometheus build fix from sibling branch to unblock CI (main broken at `6bc64306e4`)

## Test plan
- [x] `test_post_create_judgment_list_roundtrip` — List judgment preserved through post creation into meta
- [x] `test_post_create_judgment_scalar_types_ignored` — Bool/Int/Float/Intlit return None (no data corruption)
- [x] 76/77 existing tests pass (1 pre-existing `tools count` regression unrelated to this change)

Closes #16300

🤖 Generated with [Claude Code](https://claude.com/claude-code)