### PR TITLE
feat(cascade): observe unmigrated OAS variant SSE fallback

### DIFF
--- a/lib/cascade/cascade_event_bridge.ml
+++ b/lib/cascade/cascade_event_bridge.ml
@@ -744,8 +744,17 @@ let wrap_event
     (#10490, #10574, #10584).  Without the catch-all, every new
     upstream variant breaks main with [-warn-error +8] until the
     consumer is migrated; with it, the relay degrades to a
-    kind-labelled placeholder + a warn log signal until an explicit
-    arm is added.
+    kind-labelled placeholder while emitting three operator signals:
+
+    - WARN log [oas_event_bridge: SSE-degraded ...] including the
+      offending [kind], correlation ids, timestamp, and the explicit
+      file:function where the migration arm should be added.
+    - Counter [masc_oas_bridge_unmigrated_payload_kind_total{kind}]
+      ({!Prometheus.metric_oas_bridge_unmigrated_payload_kind}) so the
+      degradation rate is visible to Prometheus without log scraping.
+    - SSE payload [note] + [migration_target] fields so dashboard code
+      can render the partial-data row distinctly and link the operator
+      back to the file that needs editing.
 
     Suppressing warning 11 ([@warning "-11"]) is therefore the entire
     point of this function's shape — do not remove it without also
@@ -980,23 +989,37 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
          see *something happened* (with stable [event_type] for
          filtering) instead of having the whole stream fail to parse.
 
-         [note] flags the partial-data shape so dashboards can render
-         it as a placeholder rather than treating it as a complete
-         payload.  The warn log gives operators a per-process signal
-         that an OAS variant has shipped without a masc-mcp consumer
-         migration; downstream PRs should then move the variant out
-         of this catch-all into an explicit arm. *)
+         [note] + [migration_target] flag the partial-data shape so
+         dashboards can render it as a placeholder rather than treating
+         it as a complete payload, and tell the operator *where* to add
+         the explicit arm.  The warn log gives operators a per-process
+         signal that an OAS variant has shipped without a masc-mcp
+         consumer migration; the
+         [masc_oas_bridge_unmigrated_payload_kind_total{kind}] counter
+         gives them the per-process *rate*, surfaced on the Prometheus
+         scrape so dashboards can alert without log scraping. *)
     let kind = Agent_sdk.Event_bus.payload_kind other in
+    Prometheus.inc_counter
+      Prometheus.metric_oas_bridge_unmigrated_payload_kind
+      ~labels:[ "kind", kind ]
+      ();
     Log.Misc.warn
-      "oas_event_bridge: kind-only fallback for unmigrated payload variant kind=%s \
-       correlation_id=%s run_id=%s"
+      "oas_event_bridge: SSE-degraded to kind-only payload for unmigrated OAS \
+       variant kind=%s correlation_id=%s run_id=%s ts=%f fix: add explicit arm in \
+       lib/cascade/cascade_event_bridge.ml::native_event_to_json for this kind"
       kind
       correlation_id
-      run_id;
+      run_id
+      ts;
     let payload =
       `Assoc
         [ "kind", `String kind
-        ; "note", `String "kind-only fallback; consumer not yet migrated"
+        ; ( "note"
+          , `String
+              "kind-only fallback; explicit arm not yet wired in \
+               cascade_event_bridge.native_event_to_json" )
+        ; ( "migration_target"
+          , `String "lib/cascade/cascade_event_bridge.ml::native_event_to_json" )
         ]
     in
     Some (wrap ~event_type:kind ~payload ())

--- a/lib/cascade/cascade_health_tracker.ml
+++ b/lib/cascade/cascade_health_tracker.ml
@@ -668,7 +668,15 @@ let take_first_n n lst =
 
 (** Composite health score: success_rate * speed_score * cost_score.
     - speed_score: p95 latency based. None = 1.0 (no penalty without data).
-    - cost_score: placeholder 1.0 (cost tracking not yet wired). *)
+    - cost_score: banded thresholds from {!cost_score_of_avg} over the
+      average cost ring populated by {!record_event} when [cost_usd]
+      is provided. None = 1.0 (no penalty until samples accumulate).
+
+    The function is total in the score arguments — callers receive the
+    multiplied score regardless of whether samples exist. Read together
+    with {!build_info_locked} which feeds [avg_cost_locked] through
+    [cost_score_of_avg]; the dashboard's per-provider cost banding is
+    therefore wired end-to-end (no longer a stub). *)
 let compute_health_score ~success_rate ~p95_latency_ms_opt ~cost_score_opt =
   let speed_score =
     match p95_latency_ms_opt with

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -183,6 +183,16 @@ let metric_oas_bus_publish_block_seconds = "masc_oas_bus_publish_block_seconds_t
 let metric_oas_bus_publish = "masc_oas_bus_publish_total"
 let metric_oas_bus_capacity = "masc_oas_bus_capacity"
 
+(* Catch-all entries in [Cascade_event_bridge.native_event_to_json]
+   for OAS payload variants that have not yet received an explicit
+   arm in this consumer.  A non-zero rate per [kind] label means an
+   upstream OAS pin bump shipped a new payload variant before the
+   masc-mcp consumer was migrated; SSE subscribers receive only a
+   kind-only placeholder payload until the explicit arm is added. *)
+let metric_oas_bridge_unmigrated_payload_kind =
+  "masc_oas_bridge_unmigrated_payload_kind_total"
+;;
+
 let metric_runtime_ollama_probe_generate_skips =
   "masc_runtime_ollama_probe_generate_skips_total"
 ;;

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -191,6 +191,28 @@ val metric_oas_bus_capacity : string
     Published once per bus at [Masc_event_bus_policy.create_bus] so
     operators can interpret [metric_oas_bus_subscriber_stream_depth]
     as a fraction of capacity. *)
+
+(** Counter: OAS [Agent_sdk.Event_bus.payload] variants that the
+    cascade event bridge did not have an explicit arm for and
+    degraded to a kind-only SSE payload via the catch-all in
+    [Cascade_event_bridge.native_event_to_json].  Labels: [kind]
+    carries [Agent_sdk.Event_bus.payload_kind other] (snake_case,
+    one-to-one with the upstream OAS payload constructor name —
+    cardinality is bounded by the OAS variant set and grows only
+    on upstream pin bumps).
+
+    A non-zero rate means an OAS pin bump shipped a new payload
+    variant before the masc-mcp consumer was migrated.  The catch-all
+    is deliberate (see [Cascade_event_bridge.native_event_to_json])
+    but degrades SSE subscribers to a kind-only payload, so this
+    counter is the per-process signal that an explicit arm needs
+    to be added.  Fix: extend the explicit match in
+    [lib/cascade/cascade_event_bridge.ml] for the offending [kind].
+
+    Pairs with the per-occurrence WARN log
+    ["oas_event_bridge: kind-only fallback ..."]. *)
+val metric_oas_bridge_unmigrated_payload_kind : string
+
 val metric_runtime_ollama_probe_generate_skips : string
 
 (** #9632: subprocess executions that exceeded their configured


### PR DESCRIPTION
## 목표

`Cascade_event_bridge.native_event_to_json`의 catch-all은 의도된 워크어라운드(OAS pin bump가 새 payload variant를 ship할 때 main이 `-warn-error +8`로 깨지는 P0 클래스 — #10490, #10574, #10584 — 방어)이지만, 진입 시 신호가 **WARN log 한 줄**뿐이라 fleet-wide rate 가시성이 없고, log 자체도 *어디서 무엇을 고쳐야 하는지* 정보가 없다. 이번 PR은 catch-all 자체는 건드리지 않고 *진입 시점의 가시성*만 추가한다.

`★ 워크어라운드 거부 기준 self-check ─────────────────`
본 변경은 워크어라운드를 *제거하지 않고* 워크어라운드의 *가시성을 추가*한다. "telemetry-as-fix" 시그니처와 반대 방향 — degradation은 이미 코드에 존재하고 본 PR은 그것을 *명확하게* 만든다. 새 catch-all/silent default/cap/cooldown/dedup/string 분류기를 도입하지 않는다.
`─────────────────────────────────────────────────`

## 변경 파일

| 파일 | 변경 |
|---|---|
| `lib/prometheus.ml` / `lib/prometheus.mli` | 새 counter `masc_oas_bridge_unmigrated_payload_kind_total{kind}` |
| `lib/cascade/cascade_event_bridge.ml` | catch-all에서 (a) `Prometheus.inc_counter`, (b) WARN에 `ts` + 정확한 migration target 파일·함수 추가, (c) SSE payload에 `note` + `migration_target` 필드 추가. 함수 docstring을 세 신호(WARN/Counter/Payload)로 갱신 |
| `lib/cascade/cascade_health_tracker.ml` | `compute_health_score` doc drift 정정 (cost_score는 `cost_score_of_avg` 5-tier 밴딩으로 wired되어 있는데 주석은 "placeholder 1.0 (cost tracking not yet wired)"이라 stub처럼 오해 유발) |

총: 4 files, +76 / -13.

## Operator 시야 (Before / After)

**Before** — OAS pin bump가 새 variant ship → 첫 발생 시:
```
[WARN] oas_event_bridge: kind-only fallback for unmigrated payload variant kind=foo_event correlation_id=... run_id=...
```
- Prometheus scrape에 흔적 0
- 로그 메시지에 "어디서 고쳐야 하는지" 정보 0
- Dashboard에서 partial-data row를 구분할 방법 0

**After**:
```
[WARN] oas_event_bridge: SSE-degraded to kind-only payload for unmigrated OAS variant kind=foo_event correlation_id=... run_id=... ts=1750000000.0 fix: add explicit arm in lib/cascade/cascade_event_bridge.ml::native_event_to_json for this kind
```
- `masc_oas_bridge_unmigrated_payload_kind_total{kind="foo_event"}` 증가 (Prometheus scrape로 fleet-wide rate)
- SSE payload `{"kind":"foo_event","note":"...","migration_target":"lib/cascade/cascade_event_bridge.ml::native_event_to_json"}` — dashboard가 row를 placeholder로 렌더 + 링크 가능

## 로컬 검증

- `ocamlformat --check` PASS (4/4 files)
- `dune build @check` — origin/main이 **이미 깨져있어** worktree에서도 동일 fail. 원인은 본 PR과 무관: `lib/prometheus_store.mli`가 `metric_key`를 expose하지 않아 `Prometheus.init`의 line 272 `metric_key name []`이 unbound. CI `Detect Changed Surfaces` gate 뒤 `Build and Test`가 SKIPPED되는 패턴(2026-05-12 #14924, MEMORY 참조) 영향으로 main이 깨진 채 머지 누적된 상태. **별도 follow-up issue로 main `@check` 복구가 필요** (Issue #16289). 본 PR의 변경 자체는 syntax 정합성(ocamlformat) 및 sibling `metric_oas_bus_*` 패턴 호환(inc_counter signature 동일) 확인.
- 우리 catch-all 진입 단위 테스트는 OAS variant set이 closed라 unknown kind를 명시적으로 모킹하기 어려워 본 PR scope에서 제외. 추후 OAS variant pin이 bumped될 때 자연 발생.

## 미검증

- [ ] Full `dune build @check` (main 복구 후 재검증 필요)
- [ ] 대시보드 코드(`dashboard_bonsai/`)에서 `migration_target` 필드 렌더 — 본 PR은 metric/log/payload만 추가. 대시보드 UI 변경은 별도 PR (follow-up).
- [ ] Grafana 알람 룰 (`masc_oas_bridge_unmigrated_payload_kind_total` rate > 0 → 5분 burn) — operator runbook 영역, infra repo

## RFC

`bash ~/me/scripts/pr-rfc-check.sh` PASS — cascade observability는 credential/identity/operator/sandbox/dashboard credential boundary subsystem 아님. RFC waiver 불필요.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>