### PR TITLE
refactor: split keeper registry cascade attempts

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -163,6 +163,7 @@
   keeper_fs
   keeper_identity
   keeper_current_task_reconcile keeper_checkpoint_store
+  keeper_registry_entry_builder
   keeper_registry_orphan_drops
   keeper_text_processing
   keeper_summarizer

--- a/lib/dune
+++ b/lib/dune
@@ -163,6 +163,7 @@
   keeper_fs
   keeper_identity
   keeper_current_task_reconcile keeper_checkpoint_store
+  keeper_registry_orphan_drops
   keeper_text_processing
   keeper_summarizer
   keeper_context_core

--- a/lib/dune
+++ b/lib/dune
@@ -163,6 +163,7 @@
   keeper_fs
   keeper_identity
   keeper_current_task_reconcile keeper_checkpoint_store
+  keeper_registry_cascade_attempts
   keeper_registry_entry_builder
   keeper_registry_orphan_drops
   keeper_text_processing

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -26,6 +26,7 @@ include Keeper_registry_types
 
 let registry : registry_entry StringMap.t Atomic.t = Atomic.make StringMap.empty
 let running_count_atomic = Atomic.make 0
+module Orphan_drops = Keeper_registry_orphan_drops
 
 (** CAS loop for clamped decrement.  [Atomic.fetch_and_add _ (-1)] can
     leave the counter negative if increment/decrement paths interleave,
@@ -62,76 +63,6 @@ let put_entry key entry =
   loop ()
 ;;
 
-(* P0-2 (2026-05-07): orphan turn-loop observability.
-
-   Background — [update_entry] returns silently when the key is absent
-   (the keeper was deregistered while a caller still held its name).
-   At fleet scale the WARN line is invisible: a single orphan keeper
-   emits 30+ drops per turn (each tool-dispatch + each phase setter).
-   See verifier-loop incident 2026-05-07.
-
-   Surgical observability fix:
-   - Track per-(name) drop count in a [(int * float) StringMap.t Atomic]
-     (count, first_drop_at) so we can detect "many drops in a short
-     window" without a wall-clock heuristic at every caller.
-   - Bump [metric_keeper_registry_update_dropped] every drop.
-   - Edge-trigger: when count crosses [orphan_drop_threshold] inside
-     [orphan_drop_window_sec], emit one WARN and bump
-     [metric_keeper_registry_orphan_threshold_breached] exactly once
-     per breach window.  Individual drops stay DEBUG; the metric is the
-     durable signal and the threshold log is the operator attention point.
-   - Reset state on the successful Some-entry path (orphan resolved)
-     and after the window expires.
-
-   Behavior is otherwise unchanged: the dropped update is still
-   silently absorbed (29 caller signatures preserved). Fiber
-   cancellation on orphan detection is intentionally out of scope —
-   that requires unregister-time fiber cancel and is RFC-level. *)
-let orphan_drop_threshold = 5
-let orphan_drop_window_sec = 60.0
-let orphan_drop_state : (int * float) StringMap.t Atomic.t = Atomic.make StringMap.empty
-
-(* Returns [(count, breached_now)]. [breached_now] is [true] exactly
-   on the transition from below-threshold to at-threshold within an
-   active window. *)
-let record_orphan_drop ~base_path name =
-  let key = registry_key ~base_path name in
-  let now = Time_compat.now () in
-  let rec loop () =
-    let current = Atomic.get orphan_drop_state in
-    let count, first_at, breached_now =
-      match StringMap.find_opt key current with
-      | Some (prev_count, prev_first_at)
-        when now -. prev_first_at <= orphan_drop_window_sec ->
-        let new_count = prev_count + 1 in
-        let breached =
-          prev_count < orphan_drop_threshold && new_count >= orphan_drop_threshold
-        in
-        new_count, prev_first_at, breached
-      | _ ->
-        (* Fresh window (no prior state, or prior window expired). *)
-        1, now, false
-    in
-    let updated = StringMap.add key (count, first_at) current in
-    if Atomic.compare_and_set orphan_drop_state current updated
-    then count, breached_now
-    else loop ()
-  in
-  loop ()
-;;
-
-let clear_orphan_drop ~base_path name =
-  let key = registry_key ~base_path name in
-  let rec loop () =
-    let current = Atomic.get orphan_drop_state in
-    if StringMap.mem key current
-    then (
-      let updated = StringMap.remove key current in
-      if not (Atomic.compare_and_set orphan_drop_state current updated) then loop ())
-  in
-  loop ()
-;;
-
 (** Apply [f entry] and write back.  No-op if key absent.
 
     The find + apply + write is serialised via CAS so that concurrent
@@ -143,7 +74,7 @@ let update_entry ~base_path name f =
     let current = Atomic.get registry in
     match StringMap.find_opt key current with
     | None ->
-      let count, breached = record_orphan_drop ~base_path name in
+      let count, breached = Orphan_drops.record ~base_path name in
       Prometheus.inc_counter
         Keeper_metrics.metric_keeper_registry_update_dropped
         ~labels:[ "name", name ]
@@ -161,7 +92,7 @@ let update_entry ~base_path name f =
           name
           base_path
           count
-          orphan_drop_window_sec)
+          Orphan_drops.window_sec)
       else
         Log.Keeper.debug
           "registry: update_entry name=%s base_path=%s: entry not found, update dropped \
@@ -173,7 +104,7 @@ let update_entry ~base_path name f =
       let updated = StringMap.add key (f entry) current in
       if not (Atomic.compare_and_set registry current updated)
       then loop ()
-      else clear_orphan_drop ~base_path name
+      else Orphan_drops.clear ~base_path name
   in
   loop ()
 ;;
@@ -188,7 +119,7 @@ let update_entry_if_registered ~base_path name f =
       let updated = StringMap.add key (f entry) current in
       if Atomic.compare_and_set registry current updated
       then (
-        clear_orphan_drop ~base_path name;
+        Orphan_drops.clear ~base_path name;
         true)
       else loop ()
   in

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -26,6 +26,7 @@ include Keeper_registry_types
 
 let registry : registry_entry StringMap.t Atomic.t = Atomic.make StringMap.empty
 let running_count_atomic = Atomic.make 0
+module Cascade_attempts = Keeper_registry_cascade_attempts
 module Entry_builder = Keeper_registry_entry_builder
 module Orphan_drops = Keeper_registry_orphan_drops
 
@@ -300,99 +301,16 @@ let update_meta ~base_path name meta =
   update_entry ~base_path name (fun e -> { e with meta })
 ;;
 
-let cascade_attempt_merge ~(latest : keeper_meta) ~(caller : keeper_meta) =
-  { latest with
-    meta_version = latest.meta_version
-  ; runtime =
-      { latest.runtime with
-        last_cascade_attempt = caller.runtime.last_cascade_attempt
-      }
-  }
-;;
-
-let meta_for_cascade_attempt ~base_path ~keeper_name =
-  let config = Coord.default_config base_path in
-  match read_meta config keeper_name with
-  | Ok (Some meta) -> Some (config, meta)
-  | Ok None | Error _ ->
-    (match get ~base_path keeper_name with
-     | Some entry -> Some (config, entry.meta)
-     | None -> None)
-;;
-
 let record_cascade_attempt ~base_path ~keeper_name attempt =
-  try
-    let keeper_name = String.trim keeper_name in
-    if String.equal keeper_name ""
-    then ()
-    else
-      match meta_for_cascade_attempt ~base_path ~keeper_name with
-      | None -> ()
-      | Some (config, meta) ->
-        let caller =
-          { meta with
-            runtime = { meta.runtime with last_cascade_attempt = Some attempt }
-          }
-        in
-        ignore
-          (write_meta_with_merge
-             ~merge:cascade_attempt_merge
-             config
-             caller
-            : (unit, string) result)
-  with
-  | _ -> ()
+  Cascade_attempts.record ~get_entry:get ~base_path ~keeper_name attempt
 ;;
-
-let cascade_attempt_suffix (attempt : cascade_attempt_record) =
-  let http =
-    match attempt.http_status with
-    | Some status -> string_of_int status
-    | None -> "none"
-  in
-  Printf.sprintf " provider=%s http=%s" attempt.provider_id http
-;;
-
-let last_cascade_attempt ~base_path ~keeper_name =
-  let keeper_name = String.trim keeper_name in
-  if String.equal keeper_name ""
-  then None
-  else
-    try
-      match meta_for_cascade_attempt ~base_path ~keeper_name with
-      | Some (_config, meta) -> meta.runtime.last_cascade_attempt
-      | None -> None
-    with
-    | _ -> None
-;;
-
-(* Stale provenance threshold: cascade attempts older than this are not
-   attached to a fresh [fiber_unresolved] outcome (P1 review finding).
-   Long enough to span a normal keeper turn cascade chain; short enough
-   that a quiescent slot from a prior turn does not taint a new crash. *)
-let cascade_attempt_freshness_threshold_sec = 120.0
 
 let enrich_fiber_unresolved_outcome ~base_path ~keeper_name outcome =
-  let fiber_unresolved = failure_reason_to_string Fiber_unresolved in
-  if not (String.equal outcome fiber_unresolved)
-  then outcome
-  else
-    match last_cascade_attempt ~base_path ~keeper_name with
-    | None -> outcome
-    | Some attempt ->
-      (* P2 finding: only failure attempts explain a fiber_unresolved
-         outcome. A persisted success would otherwise inherit
-         [provider=... http=none] into a later failure label. *)
-      (match attempt.outcome with
-       | `Success -> outcome
-       | `Failure _ ->
-         (* P1 finding: gate enrichment on attempt freshness so a stale
-            slot from an earlier turn cannot taint a new crash. NDT-OK:
-            wall-clock comparison against persisted attempt timestamp. *)
-         let age = Unix.gettimeofday () -. attempt.timestamp in
-         if age > cascade_attempt_freshness_threshold_sec
-         then outcome
-         else outcome ^ cascade_attempt_suffix attempt)
+  Cascade_attempts.enrich_fiber_unresolved_outcome
+    ~get_entry:get
+    ~base_path
+    ~keeper_name
+    outcome
 ;;
 
 let sync_meta_if_registered ~base_path name meta =

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -26,6 +26,7 @@ include Keeper_registry_types
 
 let registry : registry_entry StringMap.t Atomic.t = Atomic.make StringMap.empty
 let running_count_atomic = Atomic.make 0
+module Entry_builder = Keeper_registry_entry_builder
 module Orphan_drops = Keeper_registry_orphan_drops
 
 (** CAS loop for clamped decrement.  [Atomic.fetch_and_add _ (-1)] can
@@ -140,7 +141,6 @@ let register_with_state
     name
     base_path
     (Keeper_state_machine.phase_to_string phase);
-  let done_p, done_r = Eio.Promise.create () in
   let key = registry_key ~base_path name in
   (match StringMap.find_opt key (Atomic.get registry) with
    | Some entry when entry.phase = Running ->
@@ -151,42 +151,7 @@ let register_with_state
      Log.Keeper.warn "registry: overwriting running keeper during register name=%s" name;
      decr_running_count_clamped ()
    | _ -> ());
-  let entry =
-    { base_path
-    ; name
-    ; meta
-    ; phase
-    ; conditions
-    ; fiber_stop = Atomic.make false
-    ; fiber_wakeup = Atomic.make false
-    ; event_queue = Atomic.make Keeper_event_queue.empty
-    ; started_at = Time_compat.now ()
-    ; grpc_close = Atomic.make None
-    ; done_p
-    ; done_r
-    ; restart_count = 0
-    ; last_restart_ts = 0.0
-    ; dead_since_ts = None
-    ; crash_log = []
-    ; last_error = None
-    ; last_failure_reason = None
-    ; turn_consecutive_failures = 0
-    ; last_agent_count = 0
-    ; board_wakeups = StringMap.empty
-    ; board_cursor_ts = 0.0
-    ; board_cursor_post_id = None
-    ; tool_usage = StringMap.empty
-    ; transition_seq = 0
-    ; waiting_for_inference = Atomic.make false
-    ; last_auto_rules = None
-    ; last_event_bus_correlation = None
-    ; pending_turn_measurement = None
-    ; current_turn_observation = None
-    ; last_completed_turn = None
-    ; last_skip_observation = None
-    ; compaction_stage = Packed Compaction_accumulating
-    }
-  in
+  let entry = Entry_builder.create ~base_path name meta ~phase ~conditions in
   put_entry key entry;
   if phase = Running then Atomic.incr running_count_atomic;
   Log.Keeper.debug
@@ -246,43 +211,7 @@ let register_restarting ~base_path name meta
   (* Build fresh entry once — its per-fiber atomics (fiber_stop,
      event_queue, etc.) are independent of registry contents, so a
      CAS retry can re-use the same record without re-allocating. *)
-  let done_p, done_r = Eio.Promise.create () in
-  let new_entry =
-    { base_path
-    ; name
-    ; meta
-    ; phase
-    ; conditions
-    ; fiber_stop = Atomic.make false
-    ; fiber_wakeup = Atomic.make false
-    ; event_queue = Atomic.make Keeper_event_queue.empty
-    ; started_at = Time_compat.now ()
-    ; grpc_close = Atomic.make None
-    ; done_p
-    ; done_r
-    ; restart_count = 0
-    ; last_restart_ts = 0.0
-    ; dead_since_ts = None
-    ; crash_log = []
-    ; last_error = None
-    ; last_failure_reason = None
-    ; turn_consecutive_failures = 0
-    ; last_agent_count = 0
-    ; board_wakeups = StringMap.empty
-    ; board_cursor_ts = 0.0
-    ; board_cursor_post_id = None
-    ; tool_usage = StringMap.empty
-    ; transition_seq = 0
-    ; waiting_for_inference = Atomic.make false
-    ; last_auto_rules = None
-    ; last_event_bus_correlation = None
-    ; pending_turn_measurement = None
-    ; current_turn_observation = None
-    ; last_completed_turn = None
-    ; last_skip_observation = None
-    ; compaction_stage = Packed Compaction_accumulating
-    }
-  in
+  let new_entry = Entry_builder.create ~base_path name meta ~phase ~conditions in
   (* Guard + write in a single CAS loop so a concurrent budget-exhaust
      update between our read and write cannot be overwritten back to
      [restart_budget_remaining = true].  Without this loop, two threads

--- a/lib/keeper/keeper_registry_cascade_attempts.ml
+++ b/lib/keeper/keeper_registry_cascade_attempts.ml
@@ -1,0 +1,93 @@
+open Keeper_types
+open Keeper_registry_types
+
+type get_entry = base_path:string -> string -> registry_entry option
+
+let merge_attempt ~(latest : keeper_meta) ~(caller : keeper_meta) =
+  { latest with
+    meta_version = latest.meta_version
+  ; runtime =
+      { latest.runtime with
+        last_cascade_attempt = caller.runtime.last_cascade_attempt
+      }
+  }
+;;
+
+let meta_for_attempt ~get_entry ~base_path ~keeper_name =
+  let config = Coord.default_config base_path in
+  match read_meta config keeper_name with
+  | Ok (Some meta) -> Some (config, meta)
+  | Ok None | Error _ ->
+    (match get_entry ~base_path keeper_name with
+     | Some entry -> Some (config, entry.meta)
+     | None -> None)
+;;
+
+let record ~get_entry ~base_path ~keeper_name attempt =
+  try
+    let keeper_name = String.trim keeper_name in
+    if String.equal keeper_name ""
+    then ()
+    else
+      match meta_for_attempt ~get_entry ~base_path ~keeper_name with
+      | None -> ()
+      | Some (config, meta) ->
+        let caller =
+          { meta with
+            runtime = { meta.runtime with last_cascade_attempt = Some attempt }
+          }
+        in
+        ignore
+          (write_meta_with_merge ~merge:merge_attempt config caller : (unit, string) result)
+  with
+  | _ -> ()
+;;
+
+let attempt_suffix (attempt : cascade_attempt_record) =
+  let http =
+    match attempt.http_status with
+    | Some status -> string_of_int status
+    | None -> "none"
+  in
+  Printf.sprintf " provider=%s http=%s" attempt.provider_id http
+;;
+
+let last_attempt ~get_entry ~base_path ~keeper_name =
+  let keeper_name = String.trim keeper_name in
+  if String.equal keeper_name ""
+  then None
+  else
+    try
+      match meta_for_attempt ~get_entry ~base_path ~keeper_name with
+      | Some (_config, meta) -> meta.runtime.last_cascade_attempt
+      | None -> None
+    with
+    | _ -> None
+;;
+
+(* Stale provenance threshold: cascade attempts older than this are not
+   attached to a fresh [fiber_unresolved] outcome (P1 review finding).
+   Long enough to span a normal keeper turn cascade chain; short enough
+   that a quiescent slot from a prior turn does not taint a new crash. *)
+let freshness_threshold_sec = 120.0
+
+let enrich_fiber_unresolved_outcome ~get_entry ~base_path ~keeper_name outcome =
+  let fiber_unresolved = failure_reason_to_string Fiber_unresolved in
+  if not (String.equal outcome fiber_unresolved)
+  then outcome
+  else
+    match last_attempt ~get_entry ~base_path ~keeper_name with
+    | None -> outcome
+    | Some attempt ->
+      (* P2 finding: only failure attempts explain a fiber_unresolved
+         outcome. A persisted success would otherwise inherit
+         [provider=... http=none] into a later failure label. *)
+      (match attempt.outcome with
+       | `Success -> outcome
+       | `Failure _ ->
+         (* P1 finding: gate enrichment on attempt freshness so a stale
+            slot from an earlier turn cannot taint a new crash. NDT-OK:
+            wall-clock comparison against persisted attempt timestamp. *)
+         let age = Unix.gettimeofday () -. attempt.timestamp in
+         if age > freshness_threshold_sec then outcome else outcome ^ attempt_suffix attempt)
+;;

--- a/lib/keeper/keeper_registry_cascade_attempts.mli
+++ b/lib/keeper/keeper_registry_cascade_attempts.mli
@@ -1,0 +1,17 @@
+(** Cascade-attempt persistence helpers for {!Keeper_registry}. *)
+
+type get_entry =
+  base_path:string -> string -> Keeper_registry_types.registry_entry option
+
+val record :
+  get_entry:get_entry ->
+  base_path:string ->
+  keeper_name:string ->
+  Keeper_types.cascade_attempt_record ->
+  unit
+(** Persist the last cascade provider attempt in keeper runtime meta.
+    Best-effort: missing keepers or meta write failures are ignored. *)
+
+val enrich_fiber_unresolved_outcome :
+  get_entry:get_entry -> base_path:string -> keeper_name:string -> string -> string
+(** Add [provider=<id> http=<status>] to fresh [fiber_unresolved] outcomes. *)

--- a/lib/keeper/keeper_registry_entry_builder.ml
+++ b/lib/keeper/keeper_registry_entry_builder.ml
@@ -1,0 +1,40 @@
+open Keeper_types
+open Keeper_registry_types
+
+let create ~base_path name meta ~phase ~conditions =
+  let done_p, done_r = Eio.Promise.create () in
+  { base_path
+  ; name
+  ; meta
+  ; phase
+  ; conditions
+  ; fiber_stop = Atomic.make false
+  ; fiber_wakeup = Atomic.make false
+  ; event_queue = Atomic.make Keeper_event_queue.empty
+  ; started_at = Time_compat.now ()
+  ; grpc_close = Atomic.make None
+  ; done_p
+  ; done_r
+  ; restart_count = 0
+  ; last_restart_ts = 0.0
+  ; dead_since_ts = None
+  ; crash_log = []
+  ; last_error = None
+  ; last_failure_reason = None
+  ; turn_consecutive_failures = 0
+  ; last_agent_count = 0
+  ; board_wakeups = StringMap.empty
+  ; board_cursor_ts = 0.0
+  ; board_cursor_post_id = None
+  ; tool_usage = StringMap.empty
+  ; transition_seq = 0
+  ; waiting_for_inference = Atomic.make false
+  ; last_auto_rules = None
+  ; last_event_bus_correlation = None
+  ; pending_turn_measurement = None
+  ; current_turn_observation = None
+  ; last_completed_turn = None
+  ; last_skip_observation = None
+  ; compaction_stage = Packed Compaction_accumulating
+  }
+;;

--- a/lib/keeper/keeper_registry_entry_builder.mli
+++ b/lib/keeper/keeper_registry_entry_builder.mli
@@ -1,0 +1,11 @@
+(** Registry entry construction shared by registration paths. *)
+
+val create :
+  base_path:string ->
+  string ->
+  Keeper_types.keeper_meta ->
+  phase:Keeper_state_machine.phase ->
+  conditions:Keeper_state_machine.conditions ->
+  Keeper_registry_types.registry_entry
+(** Allocate a fresh registry entry with per-fiber atomics/promises and
+    default counters. *)

--- a/lib/keeper/keeper_registry_orphan_drops.ml
+++ b/lib/keeper/keeper_registry_orphan_drops.ml
@@ -1,0 +1,38 @@
+open Keeper_registry_types
+
+let threshold = 5
+let window_sec = 60.0
+let state : (int * float) StringMap.t Atomic.t = Atomic.make StringMap.empty
+
+let record ~base_path name =
+  let key = registry_key ~base_path name in
+  let now = Time_compat.now () in
+  let rec loop () =
+    let current = Atomic.get state in
+    let count, first_at, breached_now =
+      match StringMap.find_opt key current with
+      | Some (prev_count, prev_first_at) when now -. prev_first_at <= window_sec ->
+        let new_count = prev_count + 1 in
+        let breached = prev_count < threshold && new_count >= threshold in
+        new_count, prev_first_at, breached
+      | _ ->
+        (* Fresh window: no prior state, or the prior window expired. *)
+        1, now, false
+    in
+    let updated = StringMap.add key (count, first_at) current in
+    if Atomic.compare_and_set state current updated then count, breached_now else loop ()
+  in
+  loop ()
+;;
+
+let clear ~base_path name =
+  let key = registry_key ~base_path name in
+  let rec loop () =
+    let current = Atomic.get state in
+    if StringMap.mem key current
+    then (
+      let updated = StringMap.remove key current in
+      if not (Atomic.compare_and_set state current updated) then loop ())
+  in
+  loop ()
+;;

--- a/lib/keeper/keeper_registry_orphan_drops.mli
+++ b/lib/keeper/keeper_registry_orphan_drops.mli
@@ -1,0 +1,20 @@
+(** Orphan update-drop window accounting for {!Keeper_registry}.
+
+    This module owns the small mutable CAS state used to decide when repeated
+    updates against a missing keeper should escalate from DEBUG-only drops to
+    the single threshold WARN/metric edge. *)
+
+val threshold : int
+(** Number of drops inside {!window_sec} that trips the edge. *)
+
+val window_sec : float
+(** Drop-count window in seconds. *)
+
+val record : base_path:string -> string -> int * bool
+(** Record one orphan drop for [(base_path, name)].
+
+    Returns [(count, breached_now)]. [breached_now] is [true] exactly on the
+    transition from below-threshold to at-threshold within an active window. *)
+
+val clear : base_path:string -> string -> unit
+(** Clear drop state for [(base_path, name)] after the keeper is found again. *)


### PR DESCRIPTION
## Summary
- stack on #16329 and split cascade-attempt persistence/enrichment into Keeper_registry_cascade_attempts
- keep Keeper_registry public wrappers for record_cascade_attempt and enrich_fiber_unresolved_outcome
- reduce keeper_registry.ml from 2067 to 1985 LOC, removing it from the 2000+ bucket on this stack

## Verification
- ocamlformat --check lib/keeper/keeper_registry.ml lib/keeper/keeper_registry_cascade_attempts.ml lib/keeper/keeper_registry_cascade_attempts.mli lib/keeper/keeper_registry_entry_builder.ml lib/keeper/keeper_registry_entry_builder.mli lib/keeper/keeper_registry_orphan_drops.ml lib/keeper/keeper_registry_orphan_drops.mli
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- bash scripts/lint/godfile-size-regression.sh
- MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build lib/masc_mcp.cmxa: refused before starting because a bare dune build was already running outside scripts/dune-local.sh