### PR TITLE
fix(dashboard): wire-format FSM lane analysis (color + stall + meaning)

### DIFF
--- a/dashboard/src/components/fsm-hub-lane-analysis.test.ts
+++ b/dashboard/src/components/fsm-hub-lane-analysis.test.ts
@@ -5,35 +5,38 @@ import { isObservedStall } from './fsm-hub-lane-analysis'
 // isObservedStall
 // ================================================================
 
+// Wire format is lowercase + snake_case (phase_to_string in
+// keeper_state_machine.ml:21-35). Prior fixtures asserted PascalCase
+// that never reached the function in production — mock↔mock loophole.
 describe('isObservedStall', () => {
   // --- phase lane ---
 
-  it('detects Failing stall at 90s', () => {
-    expect(isObservedStall('phase', 'Failing', 90)).toBe(true)
+  it('detects failing stall at 90s', () => {
+    expect(isObservedStall('phase', 'failing', 90)).toBe(true)
   })
 
-  it('does not detect Failing stall below 90s', () => {
-    expect(isObservedStall('phase', 'Failing', 89)).toBe(false)
+  it('does not detect failing stall below 90s', () => {
+    expect(isObservedStall('phase', 'failing', 89)).toBe(false)
   })
 
-  it('detects Overflowed stall at 60s', () => {
-    expect(isObservedStall('phase', 'Overflowed', 60)).toBe(true)
+  it('detects overflowed stall at 60s', () => {
+    expect(isObservedStall('phase', 'overflowed', 60)).toBe(true)
   })
 
-  it('detects Compacting stall at 90s', () => {
-    expect(isObservedStall('phase', 'Compacting', 90)).toBe(true)
+  it('detects compacting stall at 90s', () => {
+    expect(isObservedStall('phase', 'compacting', 90)).toBe(true)
   })
 
-  it('detects HandingOff stall at 60s', () => {
-    expect(isObservedStall('phase', 'HandingOff', 60)).toBe(true)
+  it('detects handing_off stall at 60s', () => {
+    expect(isObservedStall('phase', 'handing_off', 60)).toBe(true)
   })
 
-  it('detects Draining stall at 60s', () => {
-    expect(isObservedStall('phase', 'Draining', 60)).toBe(true)
+  it('detects draining stall at 60s', () => {
+    expect(isObservedStall('phase', 'draining', 60)).toBe(true)
   })
 
-  it('does not detect Running stall', () => {
-    expect(isObservedStall('phase', 'Running', 120)).toBe(false)
+  it('does not detect running stall', () => {
+    expect(isObservedStall('phase', 'running', 120)).toBe(false)
   })
 
   // --- turn lane ---

--- a/dashboard/src/components/fsm-hub-lane-analysis.ts
+++ b/dashboard/src/components/fsm-hub-lane-analysis.ts
@@ -17,10 +17,13 @@ export function isObservedStall(
   observedForSec: number,
 ): boolean {
   if (key === 'phase') {
-    if (value === 'Failing') return observedForSec >= 90
-    if (value === 'Overflowed') return observedForSec >= 60
-    if (value === 'Compacting') return observedForSec >= 90
-    if (value === 'HandingOff' || value === 'Draining') return observedForSec >= 60
+    // Wire format from `phase_to_string` (lib/keeper/keeper_state_machine.ml:21-35)
+    // is lowercase + snake_case. Prior PascalCase compares never matched —
+    // KSM stalled detection silently disabled for every non-terminal phase.
+    if (value === 'failing') return observedForSec >= 90
+    if (value === 'overflowed') return observedForSec >= 60
+    if (value === 'compacting') return observedForSec >= 90
+    if (value === 'handing_off' || value === 'draining') return observedForSec >= 60
     return false
   }
   if (key === 'turn') {
@@ -50,23 +53,26 @@ function laneMeaning(
   const base: { tone: InsightTone; meaning: string } = (() => {
     switch (key) {
     case 'phase':
+      // Wire format from `phase_to_string` (lib/keeper/keeper_state_machine.ml:21-35)
+      // is lowercase + snake_case. PascalCase cases ('Stable' was the
+      // 7-phase composite projection per KeeperCompositeLifecycle.tla:143,
+      // never emitted by the backend; remove rather than carry the dead
+      // arm).
       switch (value) {
-        case 'Running':
+        case 'running':
           return snapshot.is_live
             ? { tone: 'info', meaning: 'parent lifecycle 정상 — live turn 진행 중' }
             : { tone: 'ok', meaning: 'live turn 없음 — 다음 observation cycle 대기' }
-        case 'Failing':
+        case 'failing':
           return { tone: 'error', meaning: 'parent lifecycle degraded — healthy turn 재개 전 해소 필요' }
-        case 'Overflowed':
+        case 'overflowed':
           return { tone: 'warn', meaning: 'context overflow latched — healthy turn 재개 전 해소 필요' }
-        case 'Compacting':
+        case 'compacting':
           return { tone: 'warn', meaning: 'post-turn compaction 이 lifecycle 점유 중' }
-        case 'HandingOff':
+        case 'handing_off':
           return { tone: 'warn', meaning: 'handoff 가 keeper 를 stop 방향으로 drain 중' }
-        case 'Draining':
+        case 'draining':
           return { tone: 'warn', meaning: 'keeper 가 in-flight work 를 drain 중 (stop 전)' }
-        case 'Stable':
-          return { tone: 'info', meaning: '현재 예상되는 lifecycle activity 없음' }
         default:
           return { tone: 'info', meaning: 'lifecycle state 관측됨' }
       }

--- a/dashboard/src/components/fsm-hub-timeline-panels.test.ts
+++ b/dashboard/src/components/fsm-hub-timeline-panels.test.ts
@@ -8,33 +8,34 @@ import {
 
 // ── swimlaneSegmentColor ──────────────────────────────────────
 
+// Wire format: backend (keeper_state_machine.ml:21-35 + keeper_composite_observer.ml:141-201)
+// emits all lane values lowercase + snake_case. Prior fixtures asserted
+// PascalCase ('Failing', 'Overflowed', 'Stable', 'HandingOff') that the
+// backend never emits — mock↔mock loophole that hid the dead branches.
 describe('swimlaneSegmentColor', () => {
   it('returns alarm color for alarm values', () => {
-    expect(swimlaneSegmentColor('Failing')).toBe('bg-[var(--bad-50)]')
+    expect(swimlaneSegmentColor('failing')).toBe('bg-[var(--bad-50)]')
     expect(swimlaneSegmentColor('gate_rejected')).toBe('bg-[var(--bad-50)]')
     expect(swimlaneSegmentColor('exhausted')).toBe('bg-[var(--bad-50)]')
-    // Overflowed is in ALARM_VALUES, so it returns alarm color (line 55 matches first)
-    expect(swimlaneSegmentColor('Overflowed')).toBe('bg-[var(--bad-50)]')
   })
 
   it('returns idle color for idle-like values', () => {
     expect(swimlaneSegmentColor('idle')).toBe('bg-[var(--color-bg-panel-alt)]')
     expect(swimlaneSegmentColor('undecided')).toBe('bg-[var(--color-bg-panel-alt)]')
     expect(swimlaneSegmentColor('accumulating')).toBe('bg-[var(--color-bg-panel-alt)]')
-    expect(swimlaneSegmentColor('Stable')).toBe('bg-[var(--color-bg-panel-alt)]')
   })
 
-  it('returns warn color for Compacting', () => {
-    expect(swimlaneSegmentColor('Compacting')).toBe('bg-[var(--amber-bright-45)]')
+  it('returns warn color for overflowed and compacting', () => {
+    expect(swimlaneSegmentColor('overflowed')).toBe('bg-[var(--amber-bright-45)]')
     expect(swimlaneSegmentColor('compacting')).toBe('bg-[var(--amber-bright-45)]')
   })
 
-  it('returns handoff color for HandingOff', () => {
-    expect(swimlaneSegmentColor('HandingOff')).toBe('bg-[var(--purple-50)]')
+  it('returns handoff color for handing_off', () => {
+    expect(swimlaneSegmentColor('handing_off')).toBe('bg-[var(--purple-50)]')
   })
 
-  it('returns default active color for unknown values', () => {
-    expect(swimlaneSegmentColor('Running')).toBe('bg-[var(--indigo-45)]')
+  it('returns default active color for unknown / active values', () => {
+    expect(swimlaneSegmentColor('running')).toBe('bg-[var(--indigo-45)]')
     expect(swimlaneSegmentColor('thinking')).toBe('bg-[var(--indigo-45)]')
   })
 })

--- a/dashboard/src/components/fsm-hub-timeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-timeline-panels.ts
@@ -49,16 +49,24 @@ const SWIMLANE_LANES: Array<{
   { key: 'compaction', label: '컨텍스트 압축', short: 'KMC' },
 ]
 
+// Wire format is lowercase + snake_case for every lane:
+//   - KSM phase: `phase_to_string` in lib/keeper/keeper_state_machine.ml:21-35
+//     emits 'running' | 'failing' | 'handing_off' etc.
+//   - KTC/KDP/KCL/KMC: keeper_composite_observer.ml:141-201 lowercase.
+//   - KCB display state: keeper_failure_circuit_breaker.ml:438 emits
+//     'clean' | 'warning' | 'cooling'.
+// Prior PascalCase entries ('Failing', 'Overflowed', 'Stable', 'HandingOff')
+// never matched backend emit; swimlane segments for those phases fell
+// through to the default indigo color, losing the alarm/warn/handoff
+// visual signals.
 const IDLE_LIKE_VALUES = new Set([
   'idle',
   'undecided',
   'accumulating',
-  'Stable',
 ])
 
 const ALARM_VALUES = new Set([
-  'Failing',
-  'Overflowed',
+  'failing',
   'gate_rejected',
   'exhausted',
 ])
@@ -66,9 +74,8 @@ const ALARM_VALUES = new Set([
 export function swimlaneSegmentColor(value: string): string {
   if (ALARM_VALUES.has(value)) return 'bg-[var(--bad-50)]'
   if (IDLE_LIKE_VALUES.has(value)) return 'bg-[var(--color-bg-panel-alt)]'
-  if (value === 'Overflowed') return 'bg-[var(--amber-bright-45)]'
-  if (value === 'Compacting' || value === 'compacting') return 'bg-[var(--amber-bright-45)]'
-  if (value === 'HandingOff') return 'bg-[var(--purple-50)]'
+  if (value === 'overflowed' || value === 'compacting') return 'bg-[var(--amber-bright-45)]'
+  if (value === 'handing_off') return 'bg-[var(--purple-50)]'
   return 'bg-[var(--indigo-45)]'
 }
 


### PR DESCRIPTION
## 요약

`fsm-hub-timeline-panels.ts` 의 swimlane 색상 함수 `swimlaneSegmentColor` 가 PascalCase 키로 alarm/idle Set 을 정의 (`'Failing'`, `'Overflowed'`, `'Stable'`, `'HandingOff'`). Backend wire format 은 lowercase + snake_case 만 emit 하므로 — PR #16312 가 다른 파일에서 봉합한 것과 동일한 결함 — 매칭이 항상 false, **failing / overflowed / handing_off phase 의 swimlane segment 가 default indigo 색으로 fallthrough** 되어 alarm / warn / handoff 시각 신호를 잃음.

## 측정된 근거

- Backend KSM emit: `lib/keeper/keeper_state_machine.ml:21-35` `phase_to_string` → lowercase 13-state.
- 다른 4 축 (KTC/KDP/KCL/KMC): `lib/keeper/keeper_composite_observer.ml:141-201` lowercase.
- KCB display state: `keeper_failure_circuit_breaker.ml:438` lowercase 3-state.
- `'Stable'` 은 TLA spec (`KeeperCompositeLifecycle.tla:143`) 7-phase projection 으로 선언되지만 OCaml emit 0건.

## 변경

| 위치 | Before | After |
|------|--------|-------|
| `IDLE_LIKE_VALUES` | `{idle, undecided, accumulating, Stable}` | `{idle, undecided, accumulating}` (Stable 삭제 — emit 안 됨) |
| `ALARM_VALUES` | `{Failing, Overflowed, gate_rejected, exhausted}` | `{failing, gate_rejected, exhausted}` (Overflowed → amber 분기로 이동) |
| `swimlaneSegmentColor` body | 4개 PascalCase 비교 + 1 defensive double-match | 3개 lowercase 비교, dead branch 제거 |
| 테스트 fixture | PascalCase 입력 5개 (mock↔mock 패턴) | 모두 wire format lowercase |

## 검증

\`\`\`
$ pnpm vitest run src/components/fsm-hub-timeline-panels.test.ts
Tests  20 passed (20)
$ pnpm typecheck  → clean
\`\`\`

## 안티패턴 회피

- ❌ case-insensitive comparator helper (workaround #2).
- ❌ defensive `'Compacting' || 'compacting'` 이중 키 유지 (workaround #4 Repair 잔존).
- ✅ wire format 으로 코드 정렬. 테스트 fixture 도 정렬해 mock↔mock loophole 봉합.

## Related

- #16312 (이전 sweep — fsm-hub-invariant-analysis / fsm-hub-pipeline-panels / fleet-fsm-matrix 의 동일 패턴 봉합).
- #16316 RFC-0132 (casing SSOT consolidation — 구조적 closure, 4 normalizer + dual map purge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)