### PR TITLE
chore(keeper_exec_board): pretty-print debug log JSON for readability

### DIFF
--- a/lib/keeper/keeper_exec_board.ml
+++ b/lib/keeper/keeper_exec_board.ml
@@ -284,7 +284,7 @@ let handle_keeper_board_tool
       "%s called by %s, raw args: %s"
       keeper_source
       author
-      (Yojson.Safe.to_string args);
+      (Yojson.Safe.pretty_to_string args);
     (match
        quantitative_claim_rejection_reason
          ~content:(post_content_arg args)
@@ -307,7 +307,7 @@ let handle_keeper_board_tool
            ~source:keeper_source
            (assoc_override_string "author" author args)
        in
-       Log.Keeper.debug "board_args: %s" (Yojson.Safe.to_string board_args);
+       Log.Keeper.debug "board_args: %s" (Yojson.Safe.pretty_to_string board_args);
        let result =
          Tool_board.handle_tool
            (Tool_name.Masc.to_string Tool_name.Masc.Board_post)


### PR DESCRIPTION
## Summary
Switch two `Log.Keeper.debug` call sites in `keeper_exec_board.ml` from `Yojson.Safe.to_string` to `Yojson.Safe.pretty_to_string` so multi-field board-tool argument JSON is readable when grepping through keeper debug logs.

Salvaged from autonomous-agent branch `keeper-nick0cave-agent/task-285` (no PR, 178 commits behind main). The 2 target lines are still in place on current main, so the cherry-pick applied cleanly.

## Changes
- `lib/keeper/keeper_exec_board.ml:287` — `raw args:` debug log
- `lib/keeper/keeper_exec_board.ml:310` — `board_args:` debug log

Total: 1 file, +2 / -2.

## Behavior delta
- Before: `{"agent":"foo","content":"...","quantitative_evidence":[...]}` on one line.
- After: pretty-printed across multiple lines, indented.
- Performance: `pretty_to_string` is slower (line-breaking + indentation), but only fires when `Log.Keeper.debug` is enabled — debug logs are already off in production.

## Verification
- `ocamlformat --check lib/keeper/keeper_exec_board.ml`: PASS
- `git diff --check`: PASS
- Pure call-site swap; no logic, no signature change.

RFC-WAIVED: `lib/keeper/keeper_exec_board.ml` is not in the RFC-mandatory keeper subsystems. Debug-log formatting change only.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
