### PR TITLE
feat(shell_command_gate): reject nested pipelines (RFC-0131 PR-1b)

### DIFF
--- a/lib/shell_command_gate.ml
+++ b/lib/shell_command_gate.ml
@@ -7,6 +7,7 @@ type cannot_parse_kind =
   | Parse_error
   | Parse_aborted of Masc_exec.Parsed.reason_aborted
   | Too_complex of Masc_exec.Parsed.reason_too_complex
+  | Unsupported_nested_pipeline of { stage_index : int }
 
 type shape =
   | Simple
@@ -32,9 +33,27 @@ type decision =
     }
   | Cannot_parse of { kind : cannot_parse_kind }
 
-let rec simples_of_ir = function
-  | Masc_exec.Shell_ir.Simple simple -> [ simple ]
-  | Masc_exec.Shell_ir.Pipeline stages -> List.concat_map simples_of_ir stages
+(* Walk a Shell_ir.t and return a flat [simple list] if there are no
+   nested pipelines, or [Error stage_index] (0-based) for the first
+   nested stage encountered.
+
+   The current bash_subset grammar never produces nested pipelines
+   (see lib/exec/parser/bash.ml's [to_shell_ir] which maps a list of
+   stages directly to [Pipeline (List.map Simple ...)]); but the
+   [Shell_ir.t] type allows nesting structurally, so this walker
+   is the explicit fail-closed boundary.  RFC-0131 PR-1b replaces
+   the prior [List.concat_map] flattener that silently collapsed
+   any future nested pipeline into a flat stage list. *)
+let safe_simples_of_ir : Masc_exec.Shell_ir.t -> (Masc_exec.Shell_ir.simple list, int) result
+  = function
+  | Masc_exec.Shell_ir.Simple simple -> Ok [ simple ]
+  | Masc_exec.Shell_ir.Pipeline stages ->
+    let rec loop idx acc = function
+      | [] -> Ok (List.rev acc)
+      | Masc_exec.Shell_ir.Simple s :: rest -> loop (idx + 1) (s :: acc) rest
+      | Masc_exec.Shell_ir.Pipeline _ :: _ -> Error idx
+    in
+    loop 0 [] stages
 ;;
 
 let shape_of_count = function
@@ -42,12 +61,15 @@ let shape_of_count = function
   | stages -> Pipeline { stages }
 ;;
 
-let parsed_context_of_ast ast =
-  let simples = simples_of_ir ast in
-  let stage_bins =
-    simples |> List.map (fun simple -> Masc_exec.Bin.to_string simple.Masc_exec.Shell_ir.bin)
-  in
-  { ast; shape = shape_of_count (List.length stage_bins); stage_bins }
+let parsed_context_of_shell_ir ast : (parsed_context, cannot_parse_kind) result =
+  match safe_simples_of_ir ast with
+  | Error stage_index -> Error (Unsupported_nested_pipeline { stage_index })
+  | Ok simples ->
+    let stage_bins =
+      simples
+      |> List.map (fun simple -> Masc_exec.Bin.to_string simple.Masc_exec.Shell_ir.bin)
+    in
+    Ok { ast; shape = shape_of_count (List.length stage_bins); stage_bins }
 ;;
 
 let parse ?caller:_ cmd =
@@ -56,7 +78,7 @@ let parse ?caller:_ cmd =
      ignored-argument pattern is intentional: PR-1a establishes the
      API surface; PR-3 wires the counters. *)
   match Masc_exec_bash_parser.Bash.parse_string cmd with
-  | Masc_exec.Parsed.Parsed ast -> Ok (parsed_context_of_ast ast)
+  | Masc_exec.Parsed.Parsed ast -> parsed_context_of_shell_ir ast
   | Masc_exec.Parsed.Parse_error _ -> Error Parse_error
   | Masc_exec.Parsed.Parse_aborted r -> Error (Parse_aborted r)
   | Masc_exec.Parsed.Too_complex r -> Error (Too_complex r)
@@ -127,6 +149,7 @@ let cannot_parse_kind_tag = function
   | Parse_aborted `Timeout_50ms -> "timeout"
   | Parse_aborted `Depth_limit -> "depth_limit"
   | Parse_aborted `Token_limit_50k -> "token_limit"
+  | Unsupported_nested_pipeline _ -> "unsupported_nested_pipeline"
   | Too_complex `Heredoc -> "heredoc"
   | Too_complex `Here_string -> "here_string"
   | Too_complex `Cmd_subst -> "cmd_subst"

--- a/lib/shell_command_gate.mli
+++ b/lib/shell_command_gate.mli
@@ -21,6 +21,15 @@ type cannot_parse_kind =
   | Parse_error
   | Parse_aborted of Masc_exec.Parsed.reason_aborted
   | Too_complex of Masc_exec.Parsed.reason_too_complex
+  | Unsupported_nested_pipeline of { stage_index : int }
+      (** A [Shell_ir.Pipeline] stage was itself a [Shell_ir.Pipeline].
+          [stage_index] is the 0-based position of the offending stage.
+          The current bash_subset grammar never produces this shape, so
+          this arm is unreachable via {!parse}; it can surface from the
+          typed-IR entry {!parsed_context_of_shell_ir} when a caller
+          constructs a {!Masc_exec.Shell_ir.t} manually.  RFC-0131
+          PR-1b: replaces the prior silent flattening for fail-closed
+          policy. *)
 
 type shape =
   | Simple
@@ -50,6 +59,15 @@ val parse : ?caller:caller -> string -> (parsed_context, cannot_parse_kind) resu
 (** Parse a raw command into a reusable Shell_ir context.  [?caller] is
     captured for the upcoming telemetry partition (RFC-0131 PR-3) and
     does not affect the parse result. *)
+
+val parsed_context_of_shell_ir
+  :  Masc_exec.Shell_ir.t
+  -> (parsed_context, cannot_parse_kind) result
+(** Promote an already-parsed {!Masc_exec.Shell_ir.t} (e.g. lowered
+    from a typed argv per RFC-0091) into the same context returned by
+    {!parse}.  Nested pipelines surface as
+    {!Unsupported_nested_pipeline} rather than being silently
+    flattened — RFC-0131 PR-1b §4.5 (typed argv compatibility). *)
 
 val validate_allowlist
   :  ?caller:caller

--- a/test/test_shell_command_gate.ml
+++ b/test/test_shell_command_gate.ml
@@ -119,6 +119,74 @@ let test_parse_with_caller_matches_without () =
     Alcotest.failf "without=Error %s but with_caller=Ok" (Gate.cannot_parse_kind_tag wk)
 ;;
 
+(* RFC-0131 PR-1b — fail-closed boundary for nested pipelines.
+
+   The current bash_subset grammar (see lib/exec/parser/bash.ml's
+   [to_shell_ir]) only emits non-nested pipelines, so [Gate.parse] can
+   never reach the new arm via a string input.  The tests below
+   exercise the {!Gate.parsed_context_of_shell_ir} typed-IR entry,
+   which mirrors the eventual RFC-0091 typed-argv lowering path. *)
+
+let mk_simple_bin name : Masc_exec.Shell_ir.simple =
+  match Masc_exec.Bin.of_string name with
+  | Error (`Unknown raw) ->
+    Alcotest.failf "Bin.of_string rejected %S as %S" name raw
+  | Ok bin ->
+    { Masc_exec.Shell_ir.bin
+    ; args = []
+    ; env = []
+    ; cwd = None
+    ; redirects = []
+    ; sandbox = Masc_exec.Sandbox_target.host ()
+    }
+;;
+
+let test_typed_input_flat_pipeline_round_trips () =
+  let ast =
+    Masc_exec.Shell_ir.Pipeline
+      [ Masc_exec.Shell_ir.Simple (mk_simple_bin "rg")
+      ; Masc_exec.Shell_ir.Simple (mk_simple_bin "head")
+      ]
+  in
+  match Gate.parsed_context_of_shell_ir ast with
+  | Ok context ->
+    Alcotest.(check int) "stage count" 2 (Gate.stage_count context);
+    check_stage_bins "stage bins" [ "rg"; "head" ] context
+  | Error kind ->
+    Alcotest.failf
+      "expected Ok for flat pipeline, got Error %s"
+      (Gate.cannot_parse_kind_tag kind)
+;;
+
+let test_typed_input_nested_pipeline_rejected () =
+  let inner =
+    Masc_exec.Shell_ir.Pipeline
+      [ Masc_exec.Shell_ir.Simple (mk_simple_bin "sort")
+      ; Masc_exec.Shell_ir.Simple (mk_simple_bin "head")
+      ]
+  in
+  let outer = Masc_exec.Shell_ir.Pipeline
+    [ Masc_exec.Shell_ir.Simple (mk_simple_bin "rg"); inner ]
+  in
+  match Gate.parsed_context_of_shell_ir outer with
+  | Error (Gate.Unsupported_nested_pipeline { stage_index = 1 }) -> ()
+  | Error other ->
+    Alcotest.failf
+      "expected Unsupported_nested_pipeline at index 1, got %s"
+      (Gate.cannot_parse_kind_tag other)
+  | Ok context ->
+    Alcotest.failf
+      "expected Error, got Ok with stage_bins=[%s]"
+      (String.concat "; " context.Gate.stage_bins)
+;;
+
+let test_unsupported_nested_pipeline_tag () =
+  Alcotest.(check string)
+    "tag"
+    "unsupported_nested_pipeline"
+    (Gate.cannot_parse_kind_tag (Gate.Unsupported_nested_pipeline { stage_index = 0 }))
+;;
+
 let () =
   Alcotest.run
     "shell_command_gate"
@@ -145,6 +213,20 @@ let () =
             "parse with caller matches without"
             `Quick
             test_parse_with_caller_matches_without
+        ] )
+    ; ( "typed_input"
+      , [ Alcotest.test_case
+            "flat pipeline round trips"
+            `Quick
+            test_typed_input_flat_pipeline_round_trips
+        ; Alcotest.test_case
+            "nested pipeline rejected with stage index"
+            `Quick
+            test_typed_input_nested_pipeline_rejected
+        ; Alcotest.test_case
+            "unsupported_nested_pipeline tag"
+            `Quick
+            test_unsupported_nested_pipeline_tag
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

RFC-0131 §10 PR-1b closes a silent-failure boundary in `Shell_command_gate`. The prior `simples_of_ir` used `List.concat_map` to walk `Shell_ir.Pipeline _` recursively — any nested pipeline structurally allowed by the type would collapse silently into the flat stage list.

Three changes:

1. **New `cannot_parse_kind` arm**: `Unsupported_nested_pipeline of { stage_index : int }`. 0-based offending stage index, fail-closed.
2. **Replaces `simples_of_ir`** with `safe_simples_of_ir` — a fail-closed walker returning `Error stage_index` for the first nested stage.
3. **New typed entry point** `parsed_context_of_shell_ir : Shell_ir.t -> (parsed_context, cannot_parse_kind) result` for typed-argv lowering per RFC-0131 §4.5 / RFC-0091.

Parallel to PR-1a (#16335), independently mergeable.

## Product impact

The current `bash_subset.mly` grammar (see `lib/exec/parser/bash.ml`'s `to_shell_ir`) never produces nested pipelines, so this is not a live-bug fix today. Three reasons it's worth landing:

1. **Fail-closed boundary**: per CLAUDE.md `software-development.md §AI 코드 생성 안티패턴 — FSM Sparse Match`, structural type-rejection is preferred over silent flattening. Adding the explicit arm forces every future caller to handle nested explicitly.
2. **Typed input path**: `parsed_context_of_shell_ir` is the entry point RFC-0091's typed argv lowering will use. RFC-0091 already plans `Pipeline.stages` as a structured input — without this rejection, a typed-input caller could submit nested IR and the gate would silently flatten it (Doc #3 G2.2 violation).
3. **Grammar evolution**: if `bash_subset.mly` ever grows to support nested pipelines (e.g. `(a | b) | c`), the existing flat-collapse would suppress the policy distinction. With this arm, grammar expansion forces a deliberate decision.

## Evidence

```
$ git diff --stat
 lib/shell_command_gate.ml       | 43 +++++++++++++++-----
 lib/shell_command_gate.mli      | 18 ++++++++
 test/test_shell_command_gate.ml | 82 ++++++++++++++++++++++++++++++++++++++
 3 files changed, 133 insertions(+), 10 deletions(-)
```

3 new test cases under `typed_input`:

- `test_typed_input_flat_pipeline_round_trips`: regression check that `parsed_context_of_shell_ir` matches `parse`'s shape for a 2-stage pipeline.
- `test_typed_input_nested_pipeline_rejected`: typed Pipeline with an inner Pipeline at stage_index=1 → `Error Unsupported_nested_pipeline { stage_index = 1 }`.
- `test_unsupported_nested_pipeline_tag`: tag round trip.

## Review evidence

- `dune build --root . lib/.masc_mcp.objs/native/masc_mcp__Shell_command_gate.cmx` — passed (facade typechecks against the new .mli).
- `opam exec -- ocamlformat --check lib/shell_command_gate.ml lib/shell_command_gate.mli test/test_shell_command_gate.ml` — passed.
- Full `test_shell_command_gate.exe` build blocked by pre-existing `lib/prometheus.ml:262 Unbound value metric_key` regression on `origin/main` (tracked separately in PR #16289). CI will run the test once that fix lands.

## Backwards compatibility

- The string entry (`parse`, `validate_allowlist`) reaches the new arm only if `bash_subset.mly` ever grows to emit nested pipelines. Today the grammar's `to_shell_ir` always emits non-nested `Pipeline (List.map Simple ...)`, so all existing string-input tests return the same verdict.
- Existing 2 callers (`lib/tool_code_write.ml`, `lib/worker_dev_tools.ml`) match `parse` results with `Ok ctx | Error _` wildcards. The new arm is absorbed silently when (if) it ever fires.
- Neither caller consumes `parsed_context_of_shell_ir` (typed entry); it lands as a new API surface used by RFC-0091's planned wiring (a separate PR).

## Linked issue

RFC: `docs/rfc/RFC-0131-shell-command-gate-facade.md` §10 PR-1b.
Parent RFC PR: #16323.
Parallel sibling: #16335 (PR-1a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)