### PR TITLE
refactor: split keeper API runtime summaries

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -91,6 +91,7 @@
  dashboard_http_keeper_trust
  dashboard_http_keeper
  server_dashboard_http_keeper_api_checkpoints
+ server_dashboard_http_keeper_api_runtime_summaries
  server_dashboard_http_keeper_runtime_manifest_scan
  server_dashboard_http_keeper_runtime_lens_proof
  server_dashboard_http_keeper_runtime_lens_swimlane

--- a/lib/dune
+++ b/lib/dune
@@ -90,6 +90,7 @@
  dashboard_http_keeper_outcomes
  dashboard_http_keeper_trust
  dashboard_http_keeper
+ server_dashboard_http_keeper_api_checkpoints
  server_dashboard_http_keeper_runtime_manifest_scan
  server_dashboard_http_keeper_runtime_lens_proof
  server_dashboard_http_keeper_runtime_lens_swimlane

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -5,6 +5,7 @@
     /config, /boot, /shutdown endpoints. *)
 
 module Http = Http_server_eio
+module Checkpoints = Server_dashboard_http_keeper_api_checkpoints
 
 (* Keeper route constants + classifier moved to
    Server_dashboard_http_keeper_api_types (intra-library file split,
@@ -162,127 +163,9 @@ let handle_keeper_tools_post state req reqd =
    to Server_dashboard_http_keeper_api_types
    (intra-library file split, 2026-05-16). *)
 
-let stat_json_of_path (path : string) =
-  try
-    let stat = Unix.stat path in
-    `Assoc
-      [
-        ("size_bytes", `Int stat.st_size);
-        ("mtime", `Float stat.st_mtime);
-      ]
-  with
-  | Unix.Unix_error _ -> `Null
-
-let oas_checkpoint_summary_json
-    ~(source_kind : string)
-    ~(snapshot_id : string)
-    ~(path : string)
-    ~(is_current : bool)
-    ~(fallback_generation : int)
-    (checkpoint : Agent_sdk.Checkpoint.t) =
-  let generation =
-    Keeper_context_core.checkpoint_generation checkpoint
-      ~fallback:fallback_generation
-  in
-  let messages = checkpoint.messages in
-  let continuity_summary = continuity_summary_of_messages messages in
-  `Assoc
-    [
-      ("snapshot_id", `String snapshot_id);
-      ("source_kind", `String source_kind);
-      ("is_current", `Bool is_current);
-      ("path", `String path);
-      ("created_at", `Float checkpoint.created_at);
-      ("generation", `Int generation);
-      ("message_count", `Int (List.length messages));
-      ( "system_prompt_present",
-        `Bool
-          (match checkpoint.system_prompt with
-           | Some prompt -> String.trim prompt <> ""
-           | None -> false) );
-      ( "latest_preview",
-        match latest_preview_of_messages messages with
-        | Some preview -> `String preview
-        | None -> `Null );
-      ( "continuity_summary",
-        match continuity_summary with
-        | Some summary -> `String summary
-        | None -> `Null );
-      ("file_stat", stat_json_of_path path);
-    ]
-
-let keeper_checkpoint_inventory_json
-    (config : Coord.config)
-    (name : string) : [ `OK | `Not_found ] * Yojson.Safe.t =
-  match Keeper_types.read_meta_resolved config name with
-  | Error msg ->
-      (`Not_found, `Assoc [("error", `String msg)])
-  | Ok None ->
-      (`Not_found,
-       `Assoc [("error", `String (Printf.sprintf "keeper %S not found" name))])
-  | Ok (Some (_, meta)) ->
-      let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
-      let session_dir = Keeper_types.keeper_session_dir config trace_id in
-      let current_path =
-        Keeper_checkpoint_store.oas_checkpoint_path
-          ~session_dir ~session_id:trace_id
-      in
-      let current_json =
-        match
-          Keeper_checkpoint_store.load_oas ~session_dir ~session_id:trace_id
-        with
-        | Ok checkpoint ->
-            let current_history_snapshot_id =
-              Keeper_checkpoint_store.oas_history_snapshot_id_of_checkpoint checkpoint
-            in
-            oas_checkpoint_summary_json
-              ~source_kind:"oas_current"
-              ~snapshot_id:(Filename.basename current_path)
-              ~path:current_path
-              ~is_current:true
-              ~fallback_generation:meta.runtime.generation
-              checkpoint
-            |> fun json -> Some (json, current_history_snapshot_id)
-        | Error _ -> None
-      in
-      let history_json =
-        Keeper_checkpoint_store.list_oas_history_files ~session_dir
-        |> List.filter (fun snapshot_id ->
-             match current_json with
-             | Some (_json, current_history_snapshot_id) ->
-                 snapshot_id <> current_history_snapshot_id
-             | None -> true)
-        |> List.filter_map (fun snapshot_id ->
-             match
-               Keeper_checkpoint_store.load_oas_history_file
-                 ~session_dir ~snapshot_id
-             with
-             | Ok checkpoint ->
-                 Some
-                   (oas_checkpoint_summary_json
-                      ~source_kind:"oas_history"
-                      ~snapshot_id
-                      ~path:
-                        (Keeper_checkpoint_store.oas_history_path
-                           ~session_dir ~snapshot_id)
-                      ~is_current:false
-                      ~fallback_generation:meta.runtime.generation
-                      checkpoint)
-             | Error _ -> None)
-      in
-      ( `OK,
-        `Assoc
-          [
-            ("keeper", `String name);
-            ("trace_id", `String trace_id);
-            ("session_dir", `String session_dir);
-            ("current", match current_json with Some (json, _snapshot_id) -> json | None -> `Null);
-            ("history", `List history_json);
-            ( "legacy_shadow_count",
-              `Int
-                (List.length
-                   (Keeper_checkpoint_store.list_checkpoints ~session_dir)) );
-          ] )
+let stat_json_of_path = Checkpoints.stat_json_of_path
+let oas_checkpoint_summary_json = Checkpoints.oas_checkpoint_summary_json
+let keeper_checkpoint_inventory_json = Checkpoints.inventory_json
 
 (* Yojson member extractors + take_last list helper moved to
    Server_dashboard_http_keeper_api_types (intra-library file split,
@@ -291,14 +174,7 @@ let keeper_checkpoint_inventory_json
 (* unique_present_paths moved to Server_dashboard_http_keeper_api_types
    (intra-library file split, 2026-05-16). *)
 
-let linked_artifact_json ~kind path =
-  `Assoc
-    [
-      ("kind", `String kind);
-      ("path", `String path);
-      ("present", `Bool (Fs_compat.file_exists path));
-      ("file_stat", stat_json_of_path path);
-    ]
+let linked_artifact_json = Checkpoints.linked_artifact_json
 
 (* manifest_row_matches moved to Server_dashboard_http_keeper_api_types
    (intra-library file split, 2026-05-16). *)

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -6,6 +6,7 @@
 
 module Http = Http_server_eio
 module Checkpoints = Server_dashboard_http_keeper_api_checkpoints
+module Runtime_summaries = Server_dashboard_http_keeper_api_runtime_summaries
 
 (* Keeper route constants + classifier moved to
    Server_dashboard_http_keeper_api_types (intra-library file split,
@@ -202,13 +203,6 @@ let read_receipt_rows ~keeper_name ~trace_id ?turn_id paths =
            else acc)
          path
        |> List.rev)
-
-let unique_ints values =
-  values
-  |> List.sort_uniq Int.compare
-
-let json_int_list values =
-  `List (List.map (fun value -> `Int value) values)
 
 let json_int_opt = function
   | None -> `Null
@@ -618,92 +612,8 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
    Server_dashboard_http_keeper_api_types (intra-library file split,
    2026-05-16). *)
 
-let provider_attempts_summary_json scan =
-  let attempt_rows = queue_to_list scan.provider_attempt_rows in
-  let terminal = scan.provider_terminal_row in
-  let terminal_decision_string key =
-    Option.bind terminal (fun row ->
-      json_string_member_opt key row.Keeper_runtime_manifest.decision)
-  in
-  `Assoc
-    [
-      ("started_count", `Int scan.provider_started_count);
-      ("finished_count", `Int scan.provider_finished_count);
-      ( "terminal_status",
-        json_string_opt
-          (Option.map (fun row -> row.Keeper_runtime_manifest.status) terminal) );
-      ( "terminal_model_source",
-        json_string_opt (terminal_decision_string "model_source") );
-      ( "terminal_resolved_model_source",
-        json_string_opt (terminal_decision_string "resolved_model_source") );
-      ( "terminal_capability_source",
-        json_string_opt (terminal_decision_string "capability_source") );
-      ( "terminal_fallback_authority",
-        json_string_opt (terminal_decision_string "fallback_authority") );
-      ( "terminal_provider_source_cascade",
-        json_string_opt (terminal_decision_string "provider_source_cascade") );
-      ( "terminal_error",
-        json_string_opt (terminal_decision_string "error") );
-      ( "terminal_exception_kind",
-        json_string_opt (terminal_decision_string "exception_kind") );
-      ("attempts", `List (List.map provider_attempt_row_json attempt_rows));
-    ]
-
-let turn_identity_summary_json ?turn_id scan receipts =
-  let manifest_keeper_turn_ids =
-    scan.keeper_turn_ids
-    |> List.rev
-    |> unique_ints
-  in
-  let receipt_turn_counts =
-    receipts
-    |> List.filter_map (json_int_member_opt "turn_count")
-    |> unique_ints
-  in
-  `Assoc
-    [
-      ( "requested_keeper_turn_id",
-        match turn_id with Some value -> `Int value | None -> `Null );
-      ("manifest_keeper_turn_ids", json_int_list manifest_keeper_turn_ids);
-      ("receipt_turn_counts", json_int_list receipt_turn_counts);
-      ("max_oas_turn_count", json_int_opt scan.max_oas_turn_count);
-      ( "provider_lane_resolved_count",
-        `Int
-          (runtime_manifest_scan_event_count scan
-             Keeper_runtime_manifest.Provider_lane_resolved) );
-      ( "provider_attempt_started_count",
-        `Int
-          (runtime_manifest_scan_event_count scan
-             Keeper_runtime_manifest.Provider_attempt_started) );
-      ( "provider_attempt_finished_count",
-        `Int
-          (runtime_manifest_scan_event_count scan
-             Keeper_runtime_manifest.Provider_attempt_finished) );
-      ( "checkpoint_saved_count",
-        `Int
-          (runtime_manifest_scan_event_count scan
-             Keeper_runtime_manifest.Checkpoint_saved) );
-      ( "event_bus_correlated_count",
-        `Int
-          (runtime_manifest_scan_event_count scan
-             Keeper_runtime_manifest.Event_bus_correlated) );
-      ( "memory_injected_count",
-        `Int
-          (runtime_manifest_scan_event_count scan
-             Keeper_runtime_manifest.Memory_injected) );
-      ( "memory_flushed_count",
-        `Int
-          (runtime_manifest_scan_event_count scan
-             Keeper_runtime_manifest.Memory_flushed) );
-      ( "receipt_appended_count",
-        `Int
-          (runtime_manifest_scan_event_count scan
-             Keeper_runtime_manifest.Receipt_appended) );
-      ( "turn_finished_count",
-        `Int
-          (runtime_manifest_scan_event_count scan
-             Keeper_runtime_manifest.Turn_finished) );
-    ]
+let provider_attempts_summary_json = Runtime_summaries.provider_attempts_summary_json
+let turn_identity_summary_json = Runtime_summaries.turn_identity_summary_json
 
 let keeper_runtime_trace_json (config : Coord.config) (name : string)
     ?trace_id ?turn_id ?(limit = 200) ()

--- a/lib/server/server_dashboard_http_keeper_api_checkpoints.ml
+++ b/lib/server/server_dashboard_http_keeper_api_checkpoints.ml
@@ -1,0 +1,123 @@
+open Server_dashboard_http_keeper_api_types
+
+let stat_json_of_path (path : string) =
+  try
+    let stat = Unix.stat path in
+    `Assoc [ "size_bytes", `Int stat.st_size; "mtime", `Float stat.st_mtime ]
+  with
+  | Unix.Unix_error _ -> `Null
+;;
+
+let oas_checkpoint_summary_json
+      ~(source_kind : string)
+      ~(snapshot_id : string)
+      ~(path : string)
+      ~(is_current : bool)
+      ~(fallback_generation : int)
+      (checkpoint : Agent_sdk.Checkpoint.t)
+  =
+  let generation =
+    Keeper_context_core.checkpoint_generation checkpoint ~fallback:fallback_generation
+  in
+  let messages = checkpoint.messages in
+  let continuity_summary = continuity_summary_of_messages messages in
+  `Assoc
+    [ "snapshot_id", `String snapshot_id
+    ; "source_kind", `String source_kind
+    ; "is_current", `Bool is_current
+    ; "path", `String path
+    ; "created_at", `Float checkpoint.created_at
+    ; "generation", `Int generation
+    ; "message_count", `Int (List.length messages)
+    ; ( "system_prompt_present"
+      , `Bool
+          (match checkpoint.system_prompt with
+           | Some prompt -> String.trim prompt <> ""
+           | None -> false) )
+    ; ( "latest_preview"
+      , match latest_preview_of_messages messages with
+        | Some preview -> `String preview
+        | None -> `Null )
+    ; ( "continuity_summary"
+      , match continuity_summary with
+        | Some summary -> `String summary
+        | None -> `Null )
+    ; "file_stat", stat_json_of_path path
+    ]
+;;
+
+let inventory_json (config : Coord.config) (name : string)
+  : [ `OK | `Not_found ] * Yojson.Safe.t
+  =
+  match Keeper_types.read_meta_resolved config name with
+  | Error msg -> `Not_found, `Assoc [ "error", `String msg ]
+  | Ok None ->
+    ( `Not_found
+    , `Assoc [ "error", `String (Printf.sprintf "keeper %S not found" name) ] )
+  | Ok (Some (_, meta)) ->
+    let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+    let session_dir = Keeper_types.keeper_session_dir config trace_id in
+    let current_path =
+      Keeper_checkpoint_store.oas_checkpoint_path ~session_dir ~session_id:trace_id
+    in
+    let current_json =
+      match Keeper_checkpoint_store.load_oas ~session_dir ~session_id:trace_id with
+      | Ok checkpoint ->
+        let current_history_snapshot_id =
+          Keeper_checkpoint_store.oas_history_snapshot_id_of_checkpoint checkpoint
+        in
+        oas_checkpoint_summary_json
+          ~source_kind:"oas_current"
+          ~snapshot_id:(Filename.basename current_path)
+          ~path:current_path
+          ~is_current:true
+          ~fallback_generation:meta.runtime.generation
+          checkpoint
+        |> fun json -> Some (json, current_history_snapshot_id)
+      | Error _ -> None
+    in
+    let history_json =
+      Keeper_checkpoint_store.list_oas_history_files ~session_dir
+      |> List.filter (fun snapshot_id ->
+        match current_json with
+        | Some (_json, current_history_snapshot_id) ->
+          snapshot_id <> current_history_snapshot_id
+        | None -> true)
+      |> List.filter_map (fun snapshot_id ->
+        match
+          Keeper_checkpoint_store.load_oas_history_file ~session_dir ~snapshot_id
+        with
+        | Ok checkpoint ->
+          Some
+            (oas_checkpoint_summary_json
+               ~source_kind:"oas_history"
+               ~snapshot_id
+               ~path:(Keeper_checkpoint_store.oas_history_path ~session_dir ~snapshot_id)
+               ~is_current:false
+               ~fallback_generation:meta.runtime.generation
+               checkpoint)
+        | Error _ -> None)
+    in
+    ( `OK
+    , `Assoc
+        [ "keeper", `String name
+        ; "trace_id", `String trace_id
+        ; "session_dir", `String session_dir
+        ; ( "current"
+          , match current_json with
+            | Some (json, _snapshot_id) -> json
+            | None -> `Null )
+        ; "history", `List history_json
+        ; ( "legacy_shadow_count"
+          , `Int (List.length (Keeper_checkpoint_store.list_checkpoints ~session_dir)) )
+        ] )
+;;
+
+let linked_artifact_json ~kind path =
+  `Assoc
+    [ "kind", `String kind
+    ; "path", `String path
+    ; "present", `Bool (Fs_compat.file_exists path)
+    ; "file_stat", stat_json_of_path path
+    ]
+;;

--- a/lib/server/server_dashboard_http_keeper_api_checkpoints.mli
+++ b/lib/server/server_dashboard_http_keeper_api_checkpoints.mli
@@ -1,0 +1,16 @@
+(** Checkpoint inventory JSON helpers for keeper dashboard API. *)
+
+val stat_json_of_path : string -> Yojson.Safe.t
+
+val oas_checkpoint_summary_json :
+  source_kind:string ->
+  snapshot_id:string ->
+  path:string ->
+  is_current:bool ->
+  fallback_generation:int ->
+  Agent_sdk.Checkpoint.t ->
+  Yojson.Safe.t
+
+val inventory_json : Coord.config -> string -> [ `Not_found | `OK ] * Yojson.Safe.t
+
+val linked_artifact_json : kind:string -> string -> Yojson.Safe.t

--- a/lib/server/server_dashboard_http_keeper_api_runtime_summaries.ml
+++ b/lib/server/server_dashboard_http_keeper_api_runtime_summaries.ml
@@ -1,0 +1,95 @@
+module Scan = Server_dashboard_http_keeper_runtime_manifest_scan
+open Server_dashboard_http_keeper_api_types
+
+let unique_ints values = values |> List.sort_uniq Int.compare
+let json_int_list values = `List (List.map (fun value -> `Int value) values)
+
+let json_int_opt = function
+  | None -> `Null
+  | Some value -> `Int value
+;;
+
+let provider_attempts_summary_json scan =
+  let attempt_rows = Scan.queue_to_list scan.Scan.provider_attempt_rows in
+  let terminal = scan.Scan.provider_terminal_row in
+  let terminal_decision_string key =
+    Option.bind terminal (fun row -> json_string_member_opt key row.decision)
+  in
+  `Assoc
+    [ "started_count", `Int scan.provider_started_count
+    ; "finished_count", `Int scan.provider_finished_count
+    ; ( "terminal_status"
+      , json_string_opt
+          (Option.map (fun row -> row.Keeper_runtime_manifest.status) terminal) )
+    ; "terminal_model_source", json_string_opt (terminal_decision_string "model_source")
+    ; ( "terminal_resolved_model_source"
+      , json_string_opt (terminal_decision_string "resolved_model_source") )
+    ; ( "terminal_capability_source"
+      , json_string_opt (terminal_decision_string "capability_source") )
+    ; ( "terminal_fallback_authority"
+      , json_string_opt (terminal_decision_string "fallback_authority") )
+    ; ( "terminal_provider_source_cascade"
+      , json_string_opt (terminal_decision_string "provider_source_cascade") )
+    ; "terminal_error", json_string_opt (terminal_decision_string "error")
+    ; ( "terminal_exception_kind"
+      , json_string_opt (terminal_decision_string "exception_kind") )
+    ; "attempts", `List (List.map provider_attempt_row_json attempt_rows)
+    ]
+;;
+
+let turn_identity_summary_json ?turn_id scan receipts =
+  let manifest_keeper_turn_ids = scan.Scan.keeper_turn_ids |> List.rev |> unique_ints in
+  let receipt_turn_counts =
+    receipts |> List.filter_map (json_int_member_opt "turn_count") |> unique_ints
+  in
+  `Assoc
+    [ ( "requested_keeper_turn_id"
+      , match turn_id with
+        | Some value -> `Int value
+        | None -> `Null )
+    ; "manifest_keeper_turn_ids", json_int_list manifest_keeper_turn_ids
+    ; "receipt_turn_counts", json_int_list receipt_turn_counts
+    ; "max_oas_turn_count", json_int_opt scan.max_oas_turn_count
+    ; ( "provider_lane_resolved_count"
+      , `Int
+          (Scan.runtime_manifest_scan_event_count
+             scan
+             Keeper_runtime_manifest.Provider_lane_resolved) )
+    ; ( "provider_attempt_started_count"
+      , `Int
+          (Scan.runtime_manifest_scan_event_count
+             scan
+             Keeper_runtime_manifest.Provider_attempt_started) )
+    ; ( "provider_attempt_finished_count"
+      , `Int
+          (Scan.runtime_manifest_scan_event_count
+             scan
+             Keeper_runtime_manifest.Provider_attempt_finished) )
+    ; ( "checkpoint_saved_count"
+      , `Int
+          (Scan.runtime_manifest_scan_event_count
+             scan
+             Keeper_runtime_manifest.Checkpoint_saved) )
+    ; ( "event_bus_correlated_count"
+      , `Int
+          (Scan.runtime_manifest_scan_event_count
+             scan
+             Keeper_runtime_manifest.Event_bus_correlated) )
+    ; ( "memory_injected_count"
+      , `Int
+          (Scan.runtime_manifest_scan_event_count scan Keeper_runtime_manifest.Memory_injected)
+      )
+    ; ( "memory_flushed_count"
+      , `Int
+          (Scan.runtime_manifest_scan_event_count scan Keeper_runtime_manifest.Memory_flushed)
+      )
+    ; ( "receipt_appended_count"
+      , `Int
+          (Scan.runtime_manifest_scan_event_count scan Keeper_runtime_manifest.Receipt_appended)
+      )
+    ; ( "turn_finished_count"
+      , `Int
+          (Scan.runtime_manifest_scan_event_count scan Keeper_runtime_manifest.Turn_finished)
+      )
+    ]
+;;

--- a/lib/server/server_dashboard_http_keeper_api_runtime_summaries.mli
+++ b/lib/server/server_dashboard_http_keeper_api_runtime_summaries.mli
@@ -1,0 +1,11 @@
+(** Runtime-trace summary JSON helpers for keeper dashboard API. *)
+
+val provider_attempts_summary_json :
+  Server_dashboard_http_keeper_runtime_manifest_scan.runtime_manifest_scan ->
+  Yojson.Safe.t
+
+val turn_identity_summary_json :
+  ?turn_id:int ->
+  Server_dashboard_http_keeper_runtime_manifest_scan.runtime_manifest_scan ->
+  Yojson.Safe.t list ->
+  Yojson.Safe.t


### PR DESCRIPTION
## Summary
- stack on #16339 and split provider-attempt / turn-identity runtime summary JSON into Server_dashboard_http_keeper_api_runtime_summaries
- keep local wrappers in Server_dashboard_http_keeper_api for existing call sites
- reduce server_dashboard_http_keeper_api.ml from 2075 to 1985 LOC, removing it from the 2000+ bucket on this stack

## Verification
- ocamlformat --check lib/server/server_dashboard_http_keeper_api.ml lib/server/server_dashboard_http_keeper_api_checkpoints.ml lib/server/server_dashboard_http_keeper_api_checkpoints.mli lib/server/server_dashboard_http_keeper_api_runtime_summaries.ml lib/server/server_dashboard_http_keeper_api_runtime_summaries.mli
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- bash scripts/lint/godfile-size-regression.sh
- MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build lib/masc_mcp.cmxa: failed in unrelated current-base code at lib/prometheus.ml:262, unbound value metric_key