### PR TITLE
fix(dashboard): show all 5 TLA invariants in keeper-state-diagram

### DIFF
--- a/dashboard/src/components/keeper-state-diagram.ts
+++ b/dashboard/src/components/keeper-state-diagram.ts
@@ -17,7 +17,8 @@ import { MermaidGraph } from './common/mermaid-graph'
 import { FilterChips } from './common/filter-chips'
 import { buildCompositeFsmSpec } from './keeper-fsm-specs'
 import { TurnFsmDetailPanel } from './turn-fsm-detail-panel'
-import { displayState } from './fsm-hub-types'
+import { displayState, INVARIANT_LABELS } from './fsm-hub-types'
+import type { KeeperCompositeInvariants } from '../api/schemas/keeper-composite'
 import {
   normalizePhaseDiagnosis,
   PhaseConditionsPanel,
@@ -67,12 +68,13 @@ const PHASE_ID_MAP: Record<string, string> = {
   zombie: 'Zombie',
 }
 
-const INVARIANT_LABELS: Array<[keyof KeeperCompositeSnapshot['invariants'], string]> = [
-  ['phase_turn_alignment', '단계 ⇔ 턴'],
-  ['no_cascade_before_measurement', 'Cascade 순서'],
-  ['compaction_atomicity', '압축 원자성'],
-  ['event_priority_monotone', '이벤트 우선순위'],
-]
+// INVARIANT_LABELS is the SSOT in `fsm-hub-types.ts:124` — same five TLA
+// joint observer invariants emitted by `keeper_composite_observer.ml`. A
+// prior local copy in this file enumerated only four (dropped
+// `phase_derivation_agreement`), so the operator panel below silently
+// hid one of the five invariant rows — they would never see KSM phase
+// derivation drift (stored phase vs `derive_phase(conditions)` result,
+// the strictest TLA agreement check).
 
 type DiagramView = 'cytoscape' | 'mermaid'
 
@@ -295,7 +297,7 @@ export function KeeperStateDiagramPanel({ keeperName, snapshot: externalSnapshot
       ` : null}
 
       <div class="grid gap-2 md:grid-cols-2">
-        ${INVARIANT_LABELS.map(([key, label]) => {
+        ${(Object.entries(INVARIANT_LABELS) as Array<[keyof KeeperCompositeInvariants, string]>).map(([key, label]) => {
           const ok = snapshot.invariants[key]
           return html`
             <div class=${`rounded-[var(--r-1)] border px-3 py-2 text-2xs leading-normal ${badgeTone(ok)}`}>


### PR DESCRIPTION
## 요약

`keeper-state-diagram.ts:70-75` 가 local `INVARIANT_LABELS` array 에 **4개 TLA invariant** 만 listing — 5번째 `phase_derivation_agreement` (KSM 저장 phase ↔ `derive_phase(conditions)` 결과 일치 — TLA 가장 strict 한 agreement 체크) 가 드롭됨. 운영자가 keeper-state-diagram 패널 에서 phase derivation drift 를 시각적으로 catch 못 함.

`fsm-hub-types.ts:124` 는 이미 5개 모두 가진 SSOT Record 를 export. local copy 가 그 SSOT 와 drift.

## 측정된 근거

- Backend: `lib/keeper/keeper_composite_observer.ml:599-602` `phase_diagnosis` 가 `current_phase` + `derived_phase` 를 emit. invariant `phase_derivation_agreement` 가 두 값의 일치를 검증.
- TLA spec: `specs/keeper-state-machine/KeeperCompositeLifecycle.tla` 가 5개 joint observer invariants 모두 명시.
- SSOT: `dashboard/src/components/fsm-hub-types.ts:124-130` 5개 invariants Record.
- Duplicate: `dashboard/src/components/keeper-state-diagram.ts:70-75` local array (deleted in this PR) — 4개만, `phase_derivation_agreement` 누락.
- Consumer site: `keeper-state-diagram.ts:297-307` 의 invariant grid 가 local array iterate → 5번째 row silently invisible.

## 변경

1. `keeper-state-diagram.ts` 의 local 4-item `INVARIANT_LABELS` array 삭제.
2. `fsm-hub-types.ts` SSOT `INVARIANT_LABELS` import.
3. Consumer iterate: `INVARIANT_LABELS.map([key, label]) → Object.entries(INVARIANT_LABELS).map(...)` (typed key cast).

## 검증

\`\`\`
$ pnpm typecheck                                                 → clean
$ pnpm vitest run src/components/fsm-hub-types.test.ts          → 21/21
  (line 148 'INVARIANT_LABELS has all 5 invariants' 이 SSOT 측 sentinel)
\`\`\`

## 안티패턴 회피

- ❌ Local array 에 누락된 entry 만 추가 (drift 표면 유지).
- ✅ Duplicate 자체 제거. SSOT 한 곳만 진실. 사용자 절대 원칙 (legacy 박멸).

## Related

- #16312 (snapshot.phase casing fix), #16316 RFC-0132 (broader SSOT consolidation), #16327 (FSM exhausted edges drift guard), #16333 (FSM lane analysis sweep).
- 사용자 명시 영역: \"FSM, TLA+ 정보를 오인하거나 혼동을 주고 있는데\" — invariant row 가 보이지 않으면 운영자가 KSM phase derivation drift 를 알 수 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)