### PR TITLE
feat(cascade): typed profile-lookup errors instead of silent-false collapse

### DIFF
--- a/lib/cascade/cascade_capability_profile.ml
+++ b/lib/cascade/cascade_capability_profile.ml
@@ -148,15 +148,42 @@ let declared_profile_names () =
 let satisfies req has =
   match req with Optional -> true | Required -> has
 
-let provider_satisfies_named_profile name (caps : Provider_tool_support.capabilities) =
+type named_profile_lookup_error =
+  | Unknown_named_profile of
+      { name : string; builtin : string list; declared : string list }
+
+let named_profile_lookup_error_to_string = function
+  | Unknown_named_profile { name; builtin; declared } ->
+      let render = function
+        | [] -> "(none)"
+        | xs -> String.concat ", " xs
+      in
+      Printf.sprintf
+        "unknown profile %S (known built-in: %s; declared: %s)"
+        name
+        (render builtin)
+        (render declared)
+
+let provider_satisfies_named_profile
+    ~name
+    (caps : Provider_tool_support.capabilities) =
   match resolve_required_capabilities name with
-  | None -> false
+  | None ->
+      Error
+        (Unknown_named_profile
+           { name
+           ; builtin = Cascade_capability_schema.all_profile_names
+           ; declared = declared_profile_names ()
+           })
   | Some req ->
-      satisfies req.inline_tools caps.supports_inline_tools
-      && satisfies req.inline_tool_choice caps.supports_inline_tool_choice
-      && satisfies req.runtime_mcp_tools caps.supports_runtime_mcp_tools
-      && satisfies req.runtime_tool_events caps.supports_runtime_tool_events
-      && satisfies req.runtime_mcp_http_headers caps.supports_runtime_mcp_http_headers
+      Ok
+        (satisfies req.inline_tools caps.supports_inline_tools
+        && satisfies req.inline_tool_choice caps.supports_inline_tool_choice
+        && satisfies req.runtime_mcp_tools caps.supports_runtime_mcp_tools
+        && satisfies req.runtime_tool_events caps.supports_runtime_tool_events
+        && satisfies
+             req.runtime_mcp_http_headers
+             caps.supports_runtime_mcp_http_headers)
 
 let safe_lane_cascade_name = "__safe_lane"
 

--- a/lib/cascade/cascade_capability_profile.mli
+++ b/lib/cascade/cascade_capability_profile.mli
@@ -78,11 +78,35 @@ val resolve_provider_filter : string -> string option
     declared in the TOML profile, or [None] if the profile is
     built-in or has no filter. *)
 
+(** Why a {!provider_satisfies_named_profile} call could not produce a
+    [bool] answer.  An unknown profile name is a config error (the
+    operator typo'd a profile name in [cascade.toml] or a downstream
+    pin removed a profile) — silently returning [false] would emit a
+    misleading lint warning like "all models fail profile X" when the
+    real issue is "profile X is unknown".  The [builtin] / [declared]
+    fields list the two known pools separately so the diagnostic can
+    say which side the name should have come from. *)
+type named_profile_lookup_error =
+  | Unknown_named_profile of
+      { name : string; builtin : string list; declared : string list }
+
+(** Format a {!named_profile_lookup_error} as a user-facing string for
+    drop-in use in lint warnings and config error messages. *)
+val named_profile_lookup_error_to_string :
+  named_profile_lookup_error -> string
+
 val provider_satisfies_named_profile :
-  string -> Provider_tool_support.capabilities -> bool
-(** String-based satisfaction check.  Resolves the profile name
-    (built-in or declared), then checks capabilities.  Returns
-    [false] for unknown profile names. *)
+  name:string ->
+  Provider_tool_support.capabilities ->
+  (bool, named_profile_lookup_error) result
+(** [provider_satisfies_named_profile ~name caps] is [Ok true] iff
+    [caps] satisfies every [Required] capability of profile [name],
+    and [Ok false] when at least one [Required] capability is missing.
+    Returns an [Error] when [name] is neither a built-in profile name
+    ({!Cascade_capability_schema.all_profile_names}) nor a TOML-declared
+    profile ({!declared_profile_names}); callers must not collapse the
+    [Error] to [false] because the two cases imply different operator
+    actions (fix profile name vs upgrade provider capabilities). *)
 
 val required_capabilities_of_string_list :
   string list -> required_capabilities

--- a/lib/cascade/cascade_capability_schema.ml
+++ b/lib/cascade/cascade_capability_schema.ml
@@ -86,10 +86,41 @@ let all_profile_names =
 let is_known_profile name =
   List.exists (fun (n, _) -> String.equal n name) builtin_profiles
 
-let is_subset_profile src_name dst_name =
-  match resolve_profile src_name, resolve_profile dst_name with
-  | Some src, Some dst ->
-      List.for_all
-        (fun cap -> List.mem cap dst.required_capabilities)
-        src.required_capabilities
-  | _, _ -> false
+type profile_lookup_error =
+  | Unknown_source_profile of { name : string; known : string list }
+  | Unknown_destination_profile of { name : string; known : string list }
+  | Unknown_both_profiles of { src : string; dst : string; known : string list }
+
+let profile_lookup_error_to_string = function
+  | Unknown_source_profile { name; known } ->
+      Printf.sprintf
+        "unknown source profile %S (known: %s)"
+        name
+        (String.concat ", " known)
+  | Unknown_destination_profile { name; known } ->
+      Printf.sprintf
+        "unknown destination profile %S (known: %s)"
+        name
+        (String.concat ", " known)
+  | Unknown_both_profiles { src; dst; known } ->
+      Printf.sprintf
+        "unknown source profile %S and unknown destination profile %S \
+         (known: %s)"
+        src
+        dst
+        (String.concat ", " known)
+
+let is_subset_profile ~src ~dst =
+  match resolve_profile src, resolve_profile dst with
+  | Some s, Some d ->
+      Ok
+        (List.for_all
+           (fun cap -> List.mem cap d.required_capabilities)
+           s.required_capabilities)
+  | None, None ->
+      Error (Unknown_both_profiles { src; dst; known = all_profile_names })
+  | None, Some _ ->
+      Error (Unknown_source_profile { name = src; known = all_profile_names })
+  | Some _, None ->
+      Error
+        (Unknown_destination_profile { name = dst; known = all_profile_names })

--- a/lib/cascade/cascade_capability_schema.mli
+++ b/lib/cascade/cascade_capability_schema.mli
@@ -46,7 +46,28 @@ val all_profile_names : string list
 val is_known_profile : string -> bool
 (** [is_known_profile name] checks whether [name] matches a builtin. *)
 
-val is_subset_profile : string -> string -> bool
-(** [is_subset_profile src dst] is [true] iff every capability required
-    by [src] is also required by [dst].  Returns [false] if either
-    profile name is unknown. *)
+(** Why a {!is_subset_profile} call could not produce a [bool] answer.
+    Returned as the [Error] branch instead of being silently collapsed
+    to [false] so callers (config validators, RFC-0058 wiring,
+    diagnostics) can surface an actionable message that names the
+    offending profile and lists the known pool. *)
+type profile_lookup_error =
+  | Unknown_source_profile of { name : string; known : string list }
+  | Unknown_destination_profile of { name : string; known : string list }
+  | Unknown_both_profiles of { src : string; dst : string; known : string list }
+
+(** Format a {!profile_lookup_error} as a user-facing string.  The known
+    pool is rendered comma-separated so the message can be dropped into
+    a lint warning, log line, or config error verbatim. *)
+val profile_lookup_error_to_string : profile_lookup_error -> string
+
+val is_subset_profile :
+  src:string -> dst:string -> (bool, profile_lookup_error) result
+(** [is_subset_profile ~src ~dst] is [Ok true] iff every capability
+    required by profile [src] is also required by profile [dst], and
+    [Ok false] if at least one capability in [src] is not required by
+    [dst].  If either profile name is unknown, returns an [Error] that
+    names which side(s) failed lookup and lists the known builtin
+    profile names; callers must not silently collapse this to [false]
+    because an unknown profile is a config error (not a real subset
+    miss) and operators need to see which profile name was wrong. *)

--- a/lib/cascade/cascade_tier.ml
+++ b/lib/cascade/cascade_tier.ml
@@ -10,8 +10,8 @@
 
 open Cascade_capability_profile
 
-let is_subset_profile src_name dst_name =
-  Cascade_capability_schema.is_subset_profile src_name dst_name
+let is_subset_profile ~src ~dst =
+  Cascade_capability_schema.is_subset_profile ~src ~dst
 
 (* Support for TOML-declared profiles (RFC-0058 Phase 1). *)
 let requirement_leq a b =
@@ -27,10 +27,25 @@ let is_subset_caps (s : required_capabilities) (d : required_capabilities) =
   && requirement_leq s.runtime_tool_events d.runtime_tool_events
   && requirement_leq s.runtime_mcp_http_headers d.runtime_mcp_http_headers
 
-let is_subset_named_profile src_name dst_name =
+let is_subset_named_profile ~src ~dst =
+  let known_pool =
+    Cascade_capability_schema.all_profile_names
+    @ Cascade_capability_profile.declared_profile_names ()
+  in
   match
-    ( resolve_required_capabilities src_name,
-      resolve_required_capabilities dst_name )
+    ( resolve_required_capabilities src,
+      resolve_required_capabilities dst )
   with
-  | Some s, Some d -> is_subset_caps s d
-  | _ -> false
+  | Some s, Some d -> Ok (is_subset_caps s d)
+  | None, None ->
+      Error
+        (Cascade_capability_schema.Unknown_both_profiles
+           { src; dst; known = known_pool })
+  | None, Some _ ->
+      Error
+        (Cascade_capability_schema.Unknown_source_profile
+           { name = src; known = known_pool })
+  | Some _, None ->
+      Error
+        (Cascade_capability_schema.Unknown_destination_profile
+           { name = dst; known = known_pool })

--- a/lib/cascade/cascade_tier.mli
+++ b/lib/cascade/cascade_tier.mli
@@ -1,6 +1,15 @@
 (** Capability-tier monotonicity checks for cascade fallback chains. *)
 
-val is_subset_profile : string -> string -> bool
+val is_subset_profile :
+  src:string ->
+  dst:string ->
+  (bool, Cascade_capability_schema.profile_lookup_error) result
+(** [is_subset_profile ~src ~dst] re-exports
+    {!Cascade_capability_schema.is_subset_profile} for callers that
+    only want to depend on [Cascade_tier].  See that function's
+    docstring for the [Error] semantics — an unknown profile name
+    must not be silently collapsed to [false] (it is a config error,
+    not a subset miss). *)
 
 val requirement_leq :
   Cascade_capability_profile.requirement ->
@@ -12,4 +21,13 @@ val is_subset_caps :
   Cascade_capability_profile.required_capabilities ->
   bool
 
-val is_subset_named_profile : string -> string -> bool
+val is_subset_named_profile :
+  src:string ->
+  dst:string ->
+  (bool, Cascade_capability_schema.profile_lookup_error) result
+(** [is_subset_named_profile ~src ~dst] performs the same kind of
+    subset check as {!is_subset_profile} but resolves through
+    {!Cascade_capability_profile.resolve_required_capabilities},
+    which sees both built-in and TOML-declared profiles (RFC-0058
+    Phase 1).  The [Error] branch's [known] field therefore lists
+    the union of builtin + declared names at call time. *)

--- a/lib/cascade_catalog_validator.ml
+++ b/lib/cascade_catalog_validator.ml
@@ -314,35 +314,78 @@ let capability_mismatch_issues ~profile ~required_profile model_specs =
   match capability_lint_severity () with
   | None -> []
   | Some severity ->
-      let mismatches =
-        model_specs
-        |> Cascade_config.expand_auto_models
-        |> List.filter_map (fun spec ->
-               match Cascade_config.parse_model_string_result spec with
-               | Ok cfg ->
-                   let caps = Provider_tool_support.capabilities_of_config cfg in
-                   if Cascade_capability_profile.provider_satisfies_named_profile
-                        required_profile caps
-                   then None
-                   else Some spec
-               | Error _ -> None)
+      (* An unknown [required_profile] is spec-independent (every model
+         would report the same Error), so check it once up front and emit
+         a single accurate diagnostic naming the profile and the known
+         pool, instead of looping over every spec and printing the
+         misleading "N model(s) do not satisfy profile X" message that
+         the previous silent-false collapse produced. *)
+      let dummy_caps : Provider_tool_support.capabilities =
+        { supports_inline_tools = true
+        ; supports_inline_tool_choice = true
+        ; supports_runtime_mcp_tools = true
+        ; supports_runtime_tool_events = true
+        ; supports_runtime_mcp_http_headers = true
+        }
       in
-      if mismatches = [] then []
-      else
-        [
-          {
-            profile = Some profile;
-            severity;
-            message =
-              Printf.sprintf
-                "Cascade preset %s declares required_capability_profile=%S \
-                 but %d model(s) do not satisfy it: %s"
-                profile
-                required_profile
-                (List.length mismatches)
-                (String.concat ", " mismatches);
-          };
-        ]
+      (match
+         Cascade_capability_profile.provider_satisfies_named_profile
+           ~name:required_profile
+           dummy_caps
+       with
+       | Error err ->
+           [ { profile = Some profile
+             ; severity
+             ; message =
+                 Printf.sprintf
+                   "Cascade preset %s declares required_capability_profile=%S \
+                    but the profile name is %s.  Fix the preset's \
+                    [required_capability_profile] or add the profile to \
+                    [profiles] in cascade.toml."
+                   profile
+                   required_profile
+                   (Cascade_capability_profile
+                    .named_profile_lookup_error_to_string err)
+             } ]
+       | Ok _ ->
+           let mismatches =
+             model_specs
+             |> Cascade_config.expand_auto_models
+             |> List.filter_map (fun spec ->
+                    match Cascade_config.parse_model_string_result spec with
+                    | Ok cfg ->
+                        let caps =
+                          Provider_tool_support.capabilities_of_config cfg
+                        in
+                        (match
+                           Cascade_capability_profile
+                           .provider_satisfies_named_profile
+                             ~name:required_profile
+                             caps
+                         with
+                         | Ok true -> None
+                         | Ok false -> Some spec
+                         | Error _ ->
+                             (* Impossible: the up-front check already
+                                returned Ok for this profile name. *)
+                             None)
+                    | Error _ -> None)
+           in
+           if mismatches = []
+           then []
+           else
+             [ { profile = Some profile
+               ; severity
+               ; message =
+                   Printf.sprintf
+                     "Cascade preset %s declares \
+                      required_capability_profile=%S but %d model(s) do not \
+                      satisfy it: %s"
+                     profile
+                     required_profile
+                     (List.length mismatches)
+                     (String.concat ", " mismatches)
+               } ])
 
 let snapshot_profile_for ~config_path ~profile =
   match Cascade_catalog_runtime.inspect_active () with


### PR DESCRIPTION
## 목표

`Cascade_capability_schema.is_subset_profile` / `Cascade_tier.is_subset_named_profile` / `Cascade_capability_profile.provider_satisfies_named_profile` 세 함수는 unknown profile name을 silently `false`로 collapse한다. 두 가지 의미가 한 boolean에 압축되어 있어 operator는 잘못된 진단을 받는다:

| 진짜 시나리오 | Operator action |
|---|---|
| Real subset miss / capability shortfall | provider 업그레이드 또는 profile 완화 |
| Unknown profile name (typo / pin 제거) | profile name 정정 또는 cascade.toml에 등록 |

`cascade_catalog_validator.capability_mismatch_issues`가 이 silent collapse의 직접 피해 사이트: `required_capability_profile`이 unknown이면 모든 model spec가 mismatch로 보고되고 "N model(s) do not satisfy profile X" 메시지로 operator를 *provider 추적*으로 오도한다. 진짜 문제는 "profile X is unknown".

`★ 워크어라운드 거부 기준 self-check ─────────────────`
이 PR은 silent-failure를 *제거*한다. 새 catch-all/string 분류기/cap/cooldown/dedup 도입 없음. 신규 typed sum type + Result.t는 caller에게 illegal state unrepresentable을 강제 (Parse, Don't Validate). 통과.
`─────────────────────────────────────────────────`

## 변경 파일

| 파일 | 변경 |
|---|---|
| `lib/cascade/cascade_capability_schema.{ml,mli}` | 새 `profile_lookup_error` (3개 variant) + `*_to_string` formatter. `is_subset_profile : src:string -> dst:string -> (bool, profile_lookup_error) result` |
| `lib/cascade/cascade_capability_profile.{ml,mli}` | 새 `named_profile_lookup_error` (`Unknown_named_profile`이 builtin + declared pools를 분리해 carry) + formatter. `provider_satisfies_named_profile : name:string -> capabilities -> (bool, named_profile_lookup_error) result` |
| `lib/cascade/cascade_tier.{ml,mli}` | 두 wrap 함수를 typed result로 재export. `is_subset_named_profile`은 builtin + declared 둘 다 known pool에 통합 |
| `lib/cascade_catalog_validator.ml` | `capability_mismatch_issues`를 typed result에 적응. unknown profile은 spec-independent라 1회 upfront check → 단일 정확한 diagnostic 발행 (loop spam 제거) |

총: 7 files, +238 / -59.

## Operator 시야 (Before / After)

cascade.toml에서 typo: `required_capability_profile = "tool_stict"` (correct: `tool_strict`)

**Before**:
```
[WARN] catalog_validator: Cascade preset main declares
required_capability_profile="tool_stict" but 12 model(s) do not satisfy it:
gpt-4o, gpt-4o-mini, claude-3-5-sonnet, ...
```
→ Operator는 *provider 12개를 하나씩 점검* (오답)

**After**:
```
[WARN] catalog_validator: Cascade preset main declares
required_capability_profile="tool_stict" but the profile name is
unknown profile "tool_stict" (known built-in: tool_strict, inline_tools,
lite, local_inline, local; declared: foo, bar).  Fix the preset's
[required_capability_profile] or add the profile to [profiles] in
cascade.toml.
```
→ Operator는 typo 즉시 발견 + 옆 known list로 자체 교정 가능 (정답)

## Caller 영향

| 함수 | 외부 caller 수 | 본 PR 변경 |
|---|---|---|
| `Cascade_capability_schema.is_subset_profile` | 1 (`Cascade_tier`) | wrap에서 typed forward |
| `Cascade_tier.is_subset_profile` | 0 (RFC-0058 doc만 mention) | typed signature 미리 보강 |
| `Cascade_tier.is_subset_named_profile` | 0 (dead-ish) | typed signature 미리 보강 |
| `Cascade_capability_profile.provider_satisfies_named_profile` | 1 (`cascade_catalog_validator.ml:324`) | upfront check + per-spec typed handle |

caller 0인 dead-ish API는 RFC-0058 wiring 시 미래 caller가 typed Result를 컴파일러로 강제 handle하게 됨 — silent failure 패턴 재발 차단.

## 로컬 검증

- `ocamlformat --check` PASS (7/7 files)
- `dune build @check` — origin/main이 #16289로 깨져 있어 우리 worktree에서도 동일 fail (Iter#1 PR #16330과 같은 상황). 우리 변경 자체는:
  - 신규 type 정의는 record + closed variant (well-typed by construction)
  - mli/ml 시그니처 매뉴얼 1:1 검증
  - caller 전수 grep 후 호출 syntax 모두 named-arg / Result handle로 업데이트
  - `Provider_tool_support.capabilities` 5개 field가 dummy_caps에 정확히 매칭 (`lib/provider_tool_support.ml:1-7` 대조)

## 미검증

- [ ] Full `dune build @check` (#16289 머지 후 재검증)
- [ ] cascade_catalog_validator unit test가 unknown-profile 분기를 cover하는지 — 본 PR scope에서 보류, 후속 test PR로 분리

## RFC

`bash ~/me/scripts/pr-rfc-check.sh` PASS — cascade capability resolution은 credential/identity/operator/sandbox/dashboard credential boundary 아님. RFC waiver 불필요.

## 후속 후보

- `dashboard_bonsai/src/sse.ml`은 16줄 spike stub (Iter#2에서 발견). Dashboard SSE wiring 자체가 미구현 — Iter#1 PR #16330의 `migration_target` payload가 활용될 path가 아직 없음. 별도 issue로 trace 권장 (multi-iter work이라 본 PR scope 외).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>