### PR TITLE
fix(dashboard): align execution.outcome compares to TLA-prefix wire format

### DIFF
--- a/dashboard/src/components/fleet-fsm-matrix.test.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.test.ts
@@ -85,7 +85,7 @@ function execution(
   return {
     latest_receipt_present: true,
     recorded_at: '2026-04-25T07:30:00Z',
-    outcome: 'ok',
+    outcome: 'receipt_done',
     terminal_reason_code: 'completed',
     operator_disposition: 'pass',
     operator_disposition_reason: 'healthy',
@@ -204,7 +204,7 @@ describe('runtimeAttentionForSnapshot', () => {
     const snap = snapshot({
       is_live: false,
       execution: execution({
-        outcome: 'error',
+        outcome: 'receipt_failed',
         terminal_reason_code: 'api_error',
         operator_disposition: 'pause_human',
         operator_disposition_reason: 'tool_required_unsatisfied',
@@ -230,7 +230,7 @@ describe('runtimeAttentionForSnapshot', () => {
     const snap = snapshot({
       is_live: false,
       execution: execution({
-        outcome: 'ok',
+        outcome: 'receipt_done',
         terminal_reason_code: 'completed',
         operator_disposition: 'pass',
         operator_disposition_reason: 'healthy',
@@ -392,7 +392,7 @@ describe('runtimeAttentionForSnapshot', () => {
       name: 'blocked',
       is_live: false,
       execution: execution({
-        outcome: 'error',
+        outcome: 'receipt_failed',
         terminal_reason_code: 'api_error',
         operator_disposition: 'pause_human',
       }),
@@ -437,7 +437,7 @@ describe('runtimeAttentionForSnapshot', () => {
     const snap = snapshot({
       is_live: false,
       execution: execution({
-        outcome: 'error',
+        outcome: 'receipt_failed',
         terminal_reason_code: 'completion_contract_violation:require_tool_use',
         operator_disposition: 'pause_human',
         operator_disposition_reason: 'tool_required_unsatisfied',
@@ -468,7 +468,7 @@ describe('runtimeAttentionForSnapshot', () => {
     const snap = snapshot({
       is_live: true,
       execution: execution({
-        outcome: 'error',
+        outcome: 'receipt_failed',
         terminal_reason_code: 'api_error_timeout',
         operator_disposition: 'pause_human',
         operator_disposition_reason: 'tool_required_unsatisfied',
@@ -495,7 +495,7 @@ describe('fleetCellPresentation', () => {
       phase: 'Running',
       is_live: false,
       execution: execution({
-        outcome: 'error',
+        outcome: 'receipt_failed',
         terminal_reason_code: 'api_error',
         operator_disposition: 'pause_human',
         operator_disposition_reason: 'tool_required_unsatisfied',
@@ -546,7 +546,7 @@ describe('buildRuntimeAssistPrompt', () => {
       phase: 'Running',
       is_live: false,
       execution: execution({
-        outcome: 'error',
+        outcome: 'receipt_failed',
         terminal_reason_code: 'api_error',
         operator_disposition: 'pause_human',
         operator_disposition_reason: 'tool_required_unsatisfied',
@@ -758,7 +758,7 @@ describe('FleetFsmMatrix streaming fallback', () => {
           phase: 'Running',
           is_live: false,
           execution: execution({
-            outcome: 'error',
+            outcome: 'receipt_failed',
             terminal_reason_code: 'api_error',
             operator_disposition: 'pause_human',
           }),
@@ -782,7 +782,7 @@ describe('FleetFsmMatrix streaming fallback', () => {
           phase: 'Running',
           is_live: false,
           execution: execution({
-            outcome: 'error',
+            outcome: 'receipt_failed',
             terminal_reason_code: 'api_error',
             operator_disposition: 'pause_human',
             operator_disposition_reason: 'tool_required_unsatisfied',
@@ -828,7 +828,7 @@ describe('FleetFsmMatrix streaming fallback', () => {
           phase: 'Running',
           is_live: false,
           execution: execution({
-            outcome: 'error',
+            outcome: 'receipt_failed',
             terminal_reason_code: 'api_error',
             operator_disposition: 'pause_human',
             operator_disposition_reason: 'tool_required_unsatisfied',
@@ -887,7 +887,7 @@ describe('FleetFsmMatrix streaming fallback', () => {
           phase: 'Running',
           is_live: false,
           execution: execution({
-            outcome: 'error',
+            outcome: 'receipt_failed',
             terminal_reason_code: 'api_error',
             operator_disposition: 'unknown',
           }),

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -309,12 +309,17 @@ function executionEvidence(snapshot: KeeperCompositeSnapshot): string[] {
   return parts
 }
 
+// `execution.outcome` wire format is the TLA-prefix form
+// ('receipt_done' / 'receipt_skipped' / 'receipt_failed' /
+//  'receipt_cancelled') emitted by `outcome_kind_to_tla_receipt`
+// (lib/keeper/keeper_execution_receipt.ml:24-29). Prior short-form
+// compares ('error' / 'ok') were dead in production.
 function hasBlockingExecutionEvidence(snapshot: KeeperCompositeSnapshot): boolean {
   const execution = snapshot.execution
   if (!execution) return false
   if (hasPreviousTurnExecutionReceipt(snapshot)) return false
   if (execution.operator_disposition === 'pause_human') return true
-  if (execution.outcome === 'error') return true
+  if (execution.outcome === 'receipt_failed') return true
   if (execution.terminal_reason_code && execution.terminal_reason_code !== 'completed') return true
   if (execution.tool_contract_result === 'missing_required_tool_use') return true
   if (execution.tool_contract_result === 'unknown' && execution.error != null) return true
@@ -393,7 +398,8 @@ function hasHealthyExecutionEvidence(snapshot: KeeperCompositeSnapshot): boolean
   const execution = snapshot.execution
   if (!execution || hasBlockingExecutionEvidence(snapshot)) return false
   if (execution.latest_receipt_present !== true) return false
-  if (execution.outcome === 'ok') return true
+  // TLA-prefix wire format — see `hasBlockingExecutionEvidence` comment above.
+  if (execution.outcome === 'receipt_done' || execution.outcome === 'receipt_skipped') return true
   if (execution.terminal_reason_code === 'completed') return true
   if (execution.tool_contract_result?.startsWith('satisfied')) return true
   return false
@@ -437,8 +443,8 @@ function blockingCause(snapshot: KeeperCompositeSnapshot): string {
   if (execution.error?.kind) {
     parts.push(`error: ${execution.error.kind}`)
   }
-  if (execution.outcome === 'error' && parts.length === 0) {
-    parts.push('execution outcome: error')
+  if (execution.outcome === 'receipt_failed' && parts.length === 0) {
+    parts.push('execution outcome: receipt_failed')
   }
   return parts.length > 0 ? parts.join(' · ') : 'blocking execution evidence present'
 }

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -130,10 +130,15 @@ function formatMs(ms: number | null | undefined): string {
 
 function executionReceiptTone(execution: KeeperCompositeExecution | undefined): 'ok' | 'warn' | 'bad' | 'muted' {
   if (!execution?.latest_receipt_present) return 'muted'
+  // `execution.outcome` wire format is the TLA-prefix form emitted by
+  // `outcome_kind_to_tla_receipt`
+  // (lib/keeper/keeper_execution_receipt.ml:24-29). 'ok' / 'error' short
+  // forms never appear on this field — those compares were dead, so the
+  // receipt tone never reached 'ok' or 'bad' regardless of actual outcome.
   const outcome = execution.outcome?.toLowerCase()
   const terminal = execution.terminal_reason_code?.toLowerCase() ?? ''
-  if (outcome === 'ok' || terminal === 'completed') return 'ok'
-  if (terminal.includes('config') || terminal.includes('exhausted') || outcome === 'error') return 'bad'
+  if (outcome === 'receipt_done' || outcome === 'receipt_skipped' || terminal === 'completed') return 'ok'
+  if (terminal.includes('config') || terminal.includes('exhausted') || outcome === 'receipt_failed') return 'bad'
   return 'warn'
 }
 

--- a/dashboard/src/components/turn-fsm-detail-panel.test.ts
+++ b/dashboard/src/components/turn-fsm-detail-panel.test.ts
@@ -62,13 +62,19 @@ describe("turnFsmChipTone", () => {
   })
 })
 
+// `execution.outcome` wire format is the TLA-prefix form
+// (`receipt_done` | `receipt_skipped` | `receipt_failed` |
+//  `receipt_cancelled`) emitted by `outcome_kind_to_tla_receipt`
+// (lib/keeper/keeper_execution_receipt.ml:24-29). Short forms
+// ('done' / 'skipped' / 'failed' / 'error') never appear here in
+// production — prior fixtures asserting them was a mock↔mock loophole
+// that hid five dead branches.
 describe("terminalTone", () => {
   it.each([
-    ["done", "ok"],
-    ["skipped", "ok"],
-    ["cancelled", "warn"],
-    ["failed", "err"],
-    ["error", "err"],
+    ["receipt_done", "ok"],
+    ["receipt_skipped", "ok"],
+    ["receipt_cancelled", "warn"],
+    ["receipt_failed", "err"],
     ["unknown", "neutral"],
     ["", "neutral"],
     [null, "neutral"],

--- a/dashboard/src/components/turn-fsm-detail-panel.ts
+++ b/dashboard/src/components/turn-fsm-detail-panel.ts
@@ -29,15 +29,25 @@ export function turnFsmChipTone(tone: TurnChipTone): StatusChipTone {
   }
 }
 
+// `execution.outcome` wire format on the composite snapshot is the
+// TLA-prefix form emitted by `outcome_kind_to_tla_receipt`
+// (lib/keeper/keeper_execution_receipt.ml:24-29):
+//   `Ok        -> "receipt_done"
+//   `Skipped   -> "receipt_skipped"
+//   `Error     -> "receipt_failed"
+//   `Cancelled -> "receipt_cancelled"
+// The TLA ReceiptIsAuthoritative invariant fixes this canonical form
+// (keeper_execution_receipt.ml:54-58). The prior branches used short
+// forms the backend never emits on this field, so every receipt tone
+// fell through to 'neutral' regardless of actual outcome.
 export function terminalTone(outcome: string | null | undefined): 'neutral' | 'ok' | 'warn' | 'err' {
   switch (outcome) {
-    case 'done':
-    case 'skipped':
+    case 'receipt_done':
+    case 'receipt_skipped':
       return 'ok'
-    case 'cancelled':
+    case 'receipt_cancelled':
       return 'warn'
-    case 'failed':
-    case 'error':
+    case 'receipt_failed':
       return 'err'
     default:
       return 'neutral'


### PR DESCRIPTION
## 요약

`execution.outcome` on `KeeperCompositeSnapshot` 은 backend 가 TLA-prefix 형식 (`receipt_done | receipt_skipped | receipt_failed | receipt_cancelled`) 으로 emit 하지만 dashboard 3 파일이 short form (`done | skipped | cancelled | failed | error | ok`) 으로 비교 → 모든 분기 dead. 운영자가 receipt 색상/healthy/blocking 신호를 정상으로 받지 못함.

PR #16312 와 동일한 SSOT/FSM-misrepresentation 패턴, 다른 state 축 (execution outcome).

## 측정된 근거

- Backend: `lib/keeper/keeper_execution_receipt.ml:24-29 outcome_kind_to_tla_receipt`
  - `\`Ok -> \"receipt_done\"`, `\`Skipped -> \"receipt_skipped\"`, `\`Error -> \"receipt_failed\"`, `\`Cancelled -> \"receipt_cancelled\"`
- Emit 사이트: `keeper_execution_receipt.ml:703, 906` 모두 동일 TLA-prefix 사용.
- TLA spec: ReceiptIsAuthoritative invariant 가 prefix form 고정 (`keeper_execution_receipt.ml:54-58` 코멘트 + `KeeperTurnFSM.tla:336`).
- Composite emit 경로: `lib/server/server_dashboard_http.ml:1019` 가 receipt JSON 의 \"outcome\" 필드 pass-through.

## 변경 사이트 (3 파일, 9 dead 비교)

| 파일 | Site | Before | After |
|------|------|--------|-------|
| `turn-fsm-detail-panel.ts:32-44 terminalTone` | 5 switch arms | `'done'/'skipped'/'cancelled'/'failed'/'error'` | `'receipt_done'/'receipt_skipped'/'receipt_cancelled'/'receipt_failed'` |
| `fsm-hub.ts:135-136 executionReceiptTone` | 2 compares | `=== 'ok' / 'error'` | `=== 'receipt_done' \|\| 'receipt_skipped'` / `=== 'receipt_failed'` |
| `fleet-fsm-matrix.ts:304/383/427` | 3 sites | `=== 'error' / 'ok'` | `=== 'receipt_failed' / 'receipt_done' \|\| 'receipt_skipped'` |
| Tests | 12 fixture + 5 terminalTone | short form | TLA-prefix |

## 검증

\`\`\`
$ pnpm vitest run src/components/turn-fsm-detail-panel.test.ts src/components/fleet-fsm-matrix.test.ts
Tests  60 passed (60)
$ pnpm typecheck  → clean
\`\`\`

## 안티패턴 회피

- ❌ 새 normalizer/translator 추가 (RFC-0088 §Repair).
- ❌ short form 도 같이 받는 dual key (defensive double-coding).
- ✅ wire format 으로 정렬, test fixture 도 정렬해 mock↔mock loophole 봉합.

## Related

- #16312 (snapshot.phase casing), #16333 (FSM lane analysis sweep), #16343 (5th TLA invariant). 같은 defect class 의 다른 state 축.

🤖 Generated with [Claude Code](https://claude.com/claude-code)