### PR TITLE
Fix cascade capacity failover

### DIFF
--- a/dashboard/src/api/schemas/cascade.test.ts
+++ b/dashboard/src/api/schemas/cascade.test.ts
@@ -63,10 +63,36 @@ describe('cascade API schemas', () => {
       source_path: '/tmp/masc/cascade.toml',
       source_editable: true,
       source_text: '[profiles.keeper_unified]\n',
+      assist: {
+        parse_status: 'parsed',
+        providers: ['glm-coding'],
+        models: ['glm-auto'],
+        bindings: ['glm-coding.glm-auto'],
+        aliases: ['glm-coding.glm-auto.deep'],
+        tiers: ['primary'],
+        tier_groups: ['primary'],
+        routes: ['keeper_turn'],
+        feature_params: [
+          {
+            key: 'thinking-enabled',
+            scope: 'alias',
+            value_type: 'boolean',
+            example: 'thinking-enabled = true',
+          },
+          {
+            key: 'max-output',
+            scope: 'alias',
+            value_type: 'integer',
+            example: 'max-output = 8192',
+          },
+        ],
+        errors: [],
+      },
     })
 
     expect(parsed.source_editable).toBe(true)
     expect(parsed.source_text).toContain('keeper_unified')
+    expect(parsed.assist?.feature_params.map(param => param.key)).toContain('max-output')
   })
 
   it('parses valid cascade health payloads', () => {

--- a/dashboard/src/api/schemas/cascade.ts
+++ b/dashboard/src/api/schemas/cascade.ts
@@ -93,6 +93,26 @@ const CascadeRawConfigResponseSchema = object({
   source_path: string(),
   source_editable: boolean(),
   source_text: string(),
+  assist: optional(object({
+    parse_status: picklist(['parsed', 'unavailable']),
+    providers: array(string()),
+    models: array(string()),
+    bindings: array(string()),
+    aliases: array(string()),
+    tiers: array(string()),
+    tier_groups: array(string()),
+    routes: array(string()),
+    feature_params: array(object({
+      key: string(),
+      scope: string(),
+      value_type: string(),
+      example: string(),
+    })),
+    errors: array(object({
+      path: string(),
+      message: string(),
+    })),
+  })),
 })
 
 export type CascadeRawConfigResponse = InferOutput<typeof CascadeRawConfigResponseSchema>

--- a/dashboard/src/components/cascade-config-panel.test.ts
+++ b/dashboard/src/components/cascade-config-panel.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildCascadeBindingSnippet,
+  buildCascadeThinkingAliasSnippet,
+  buildCascadeTierSnippet,
+} from './cascade-config-panel'
+
+describe('cascade config authoring snippets', () => {
+  it('builds provider-model binding snippets with client capacity', () => {
+    expect(buildCascadeBindingSnippet('runpod', 'qwen-coder', 2)).toBe([
+      '[runpod.qwen-coder]',
+      'is-default = false',
+      'max-concurrent = 2',
+    ].join('\n'))
+  })
+
+  it('builds thinking alias snippets without provider-specific model logic', () => {
+    expect(buildCascadeThinkingAliasSnippet('ollama-cloud', 'qwen3', 8192)).toBe([
+      '[ollama-cloud.qwen3.thinking]',
+      'temperature = 0.2',
+      'thinking-enabled = true',
+      'thinking-budget = 8192',
+    ].join('\n'))
+  })
+
+  it('clamps tier max-concurrent snippets to at least one', () => {
+    expect(buildCascadeTierSnippet('primary', 'runpod.qwen-coder', 0)).toContain('max-concurrent = 1')
+  })
+})

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -64,6 +64,8 @@ interface CascadeData {
   slo: CascadeSloResponse | null
 }
 
+type CascadeRawConfigAssist = NonNullable<CascadeRawConfigResponse['assist']>
+
 async function loadCascadeData(resource: ManagedAsyncResource<CascadeData>) {
   await resource.load(async (signal) => {
     const gateKeepersPromise = fetchGateKeepers(signal)
@@ -193,6 +195,56 @@ function validateSourceConfigText(
   _sourceText: string,
 ): string | null {
   return null
+}
+
+function positiveIntOrDefault(value: string, fallback: number): number {
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function normalizeTomlBlock(source: string, snippet: string): string {
+  const base = source.trimEnd()
+  const block = snippet.trim()
+  if (block === '') return source
+  return `${base}${base === '' ? '' : '\n\n'}${block}\n`
+}
+
+export function buildCascadeBindingSnippet(
+  provider: string,
+  model: string,
+  maxConcurrent: number,
+): string {
+  return [
+    `[${provider}.${model}]`,
+    'is-default = false',
+    `max-concurrent = ${Math.max(1, maxConcurrent)}`,
+  ].join('\n')
+}
+
+export function buildCascadeThinkingAliasSnippet(
+  provider: string,
+  model: string,
+  budget: number,
+): string {
+  return [
+    `[${provider}.${model}.thinking]`,
+    'temperature = 0.2',
+    'thinking-enabled = true',
+    `thinking-budget = ${Math.max(1, budget)}`,
+  ].join('\n')
+}
+
+export function buildCascadeTierSnippet(
+  tier: string,
+  member: string,
+  maxConcurrent: number,
+): string {
+  return [
+    `[tier.${tier}]`,
+    `members = ["${member}"]`,
+    'strategy = "failover"',
+    `max-concurrent = ${Math.max(1, maxConcurrent)}`,
+  ].join('\n')
 }
 
 function validationTone(status: CascadeValidationStatus): 'ok' | 'warn' | 'bad' {
@@ -1050,6 +1102,178 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
+function SourceAssistInput({
+  id,
+  label,
+  value,
+  options,
+  onInput,
+}: {
+  id: string
+  label: string
+  value: string
+  options: readonly string[]
+  onInput: (value: string) => void
+}) {
+  return html`
+    <label class="flex min-w-0 flex-1 flex-col gap-1 text-2xs font-medium uppercase tracking-wide text-[var(--color-fg-muted)]">
+      ${label}
+      <input
+        class="w-full rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1.5 font-mono text-xs text-[var(--color-fg-primary)]"
+        list=${`${id}-list`}
+        value=${value}
+        onInput=${(event: Event) => onInput((event.target as HTMLInputElement).value)}
+      />
+      <datalist id=${`${id}-list`}>
+        ${options.map(option => html`<option value=${option} />`)}
+      </datalist>
+    </label>
+  `
+}
+
+function firstNonEmpty(values: readonly string[]): string {
+  return values.find(value => value.trim() !== '') ?? ''
+}
+
+function selectedBindingLabel(
+  provider: string,
+  model: string,
+  assist: CascadeRawConfigAssist,
+): string {
+  if (provider.trim() !== '' && model.trim() !== '') return `${provider.trim()}.${model.trim()}`
+  return firstNonEmpty(assist.bindings)
+}
+
+function CascadeSourceAssist({
+  assist,
+  provider,
+  model,
+  tier,
+  maxConcurrent,
+  thinkingBudget,
+  onProviderInput,
+  onModelInput,
+  onTierInput,
+  onMaxConcurrentInput,
+  onThinkingBudgetInput,
+  onInsert,
+}: {
+  assist: CascadeRawConfigAssist
+  provider: string
+  model: string
+  tier: string
+  maxConcurrent: string
+  thinkingBudget: string
+  onProviderInput: (value: string) => void
+  onModelInput: (value: string) => void
+  onTierInput: (value: string) => void
+  onMaxConcurrentInput: (value: string) => void
+  onThinkingBudgetInput: (value: string) => void
+  onInsert: (snippet: string) => void
+}) {
+  const parentBinding = selectedBindingLabel(provider, model, assist)
+  const hasProviderModel = provider.trim() !== '' && model.trim() !== ''
+  const hasMember = parentBinding.trim() !== ''
+  const tierName = tier.trim() || 'primary'
+  const maxConcurrentValue = positiveIntOrDefault(maxConcurrent, 2)
+  const thinkingBudgetValue = positiveIntOrDefault(thinkingBudget, 8192)
+  const parsed = assist.parse_status === 'parsed'
+
+  return html`
+    <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-subtle)] p-3">
+      <div class="mb-3 flex items-center gap-2">
+        <${StatusChip} tone=${parsed ? 'ok' : 'warn'} uppercase=${false}>${parsed ? 'parsed' : 'parse issue'}<//>
+        <span class="text-xs text-[var(--color-fg-muted)]">
+          ${assist.providers.length} providers · ${assist.models.length} models · ${assist.bindings.length} bindings
+        </span>
+      </div>
+      ${assist.errors.length > 0
+        ? html`
+          <div class="mb-3 rounded-[var(--r-1)] border border-[var(--color-status-warn)] px-2 py-1 text-xs text-[var(--color-fg-muted)]">
+            ${assist.errors[0]?.path}: ${assist.errors[0]?.message}
+          </div>
+        `
+        : null}
+      <div class="grid gap-2 md:grid-cols-3">
+        <${SourceAssistInput}
+          id="cascade-provider-assist"
+          label="Provider"
+          value=${provider}
+          options=${assist.providers}
+          onInput=${onProviderInput}
+        />
+        <${SourceAssistInput}
+          id="cascade-model-assist"
+          label="Model"
+          value=${model}
+          options=${assist.models}
+          onInput=${onModelInput}
+        />
+        <${SourceAssistInput}
+          id="cascade-tier-assist"
+          label="Tier"
+          value=${tier}
+          options=${assist.tiers.length > 0 ? assist.tiers : ['primary']}
+          onInput=${onTierInput}
+        />
+      </div>
+      <div class="mt-2 grid gap-2 md:grid-cols-2">
+        <label class="flex min-w-0 flex-col gap-1 text-2xs font-medium uppercase tracking-wide text-[var(--color-fg-muted)]">
+          max-concurrent
+          <input
+            class="w-full rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1.5 text-xs text-[var(--color-fg-primary)]"
+            type="number"
+            min="1"
+            value=${maxConcurrent}
+            onInput=${(event: Event) => onMaxConcurrentInput((event.target as HTMLInputElement).value)}
+          />
+        </label>
+        <label class="flex min-w-0 flex-col gap-1 text-2xs font-medium uppercase tracking-wide text-[var(--color-fg-muted)]">
+          thinking-budget
+          <input
+            class="w-full rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1.5 text-xs text-[var(--color-fg-primary)]"
+            type="number"
+            min="1"
+            value=${thinkingBudget}
+            onInput=${(event: Event) => onThinkingBudgetInput((event.target as HTMLInputElement).value)}
+          />
+        </label>
+      </div>
+      <div class="mt-3 flex flex-wrap gap-2">
+        <${Btn}
+          disabled=${!hasProviderModel}
+          onClick=${() => onInsert(buildCascadeBindingSnippet(provider.trim(), model.trim(), maxConcurrentValue))}
+        >
+          Insert binding
+        <//>
+        <${Btn}
+          disabled=${!hasProviderModel}
+          onClick=${() => onInsert(buildCascadeThinkingAliasSnippet(provider.trim(), model.trim(), thinkingBudgetValue))}
+        >
+          Insert thinking alias
+        <//>
+        <${Btn}
+          disabled=${!hasMember}
+          onClick=${() => onInsert(buildCascadeTierSnippet(tierName, parentBinding, maxConcurrentValue))}
+        >
+          Insert tier
+        <//>
+      </div>
+      ${assist.feature_params.length > 0
+        ? html`
+          <div class="mt-3 flex flex-wrap gap-1">
+            ${assist.feature_params.map(param => html`
+              <span title=${`${param.scope} · ${param.example}`}>
+                <${StatusChip} tone="neutral" uppercase=${false}>${param.key}<//>
+              </span>
+            `)}
+          </div>
+        `
+        : null}
+    </div>
+  `
+}
+
 function CascadeRawConfigEditor({
   raw,
   onRefresh,
@@ -1061,6 +1285,11 @@ function CascadeRawConfigEditor({
   const editorDirty = useSignal(false)
   const saving = useSignal(false)
   const saveMessage = useSignal<string | null>(null)
+  const assistProvider = useSignal(firstNonEmpty(raw?.assist?.providers ?? []))
+  const assistModel = useSignal(firstNonEmpty(raw?.assist?.models ?? []))
+  const assistTier = useSignal(firstNonEmpty(raw?.assist?.tiers ?? []) || 'primary')
+  const maxConcurrent = useSignal('2')
+  const thinkingBudget = useSignal('8192')
   const mode = rawConfigModeSummary(raw)
   const sourceEditable = raw !== null && raw.source_editable !== false
 
@@ -1068,6 +1297,20 @@ function CascadeRawConfigEditor({
     if (!raw || editorDirty.value) return
     editorText.value = raw.source_text
   }, [raw?.updated_at, raw?.source_path, raw?.source_text])
+
+  useEffect(() => {
+    const assist = raw?.assist
+    if (!assist) return
+    if (!assist.providers.includes(assistProvider.value)) {
+      assistProvider.value = firstNonEmpty(assist.providers)
+    }
+    if (!assist.models.includes(assistModel.value)) {
+      assistModel.value = firstNonEmpty(assist.models)
+    }
+    if (!assist.tiers.includes(assistTier.value)) {
+      assistTier.value = firstNonEmpty(assist.tiers) || 'primary'
+    }
+  }, [raw?.updated_at, raw?.source_path])
 
   const syntaxError = validateSourceConfigText(raw, editorText.value)
   const saveDisabled = saving.value
@@ -1079,6 +1322,12 @@ function CascadeRawConfigEditor({
     editorText.value = raw?.source_text ?? ''
     editorDirty.value = false
     saveMessage.value = 'Latest source snapshot restored in the editor.'
+  }
+
+  const insertSnippet = (snippet: string) => {
+    editorText.value = normalizeTomlBlock(editorText.value, snippet)
+    editorDirty.value = true
+    saveMessage.value = null
   }
 
   const handleSave = async (event: Event) => {
@@ -1121,6 +1370,24 @@ function CascadeRawConfigEditor({
         </p>
 
         <form class="flex flex-col gap-3" onSubmit=${handleSave}>
+          ${raw?.assist
+            ? html`
+              <${CascadeSourceAssist}
+                assist=${raw.assist}
+                provider=${assistProvider.value}
+                model=${assistModel.value}
+                tier=${assistTier.value}
+                maxConcurrent=${maxConcurrent.value}
+                thinkingBudget=${thinkingBudget.value}
+                onProviderInput=${(value: string) => { assistProvider.value = value }}
+                onModelInput=${(value: string) => { assistModel.value = value }}
+                onTierInput=${(value: string) => { assistTier.value = value }}
+                onMaxConcurrentInput=${(value: string) => { maxConcurrent.value = value }}
+                onThinkingBudgetInput=${(value: string) => { thinkingBudget.value = value }}
+                onInsert=${insertSnippet}
+              />
+            `
+            : null}
           <textarea
             aria-label="설정 편집기"
             class="h-96 w-full rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-2 font-mono text-xs text-[var(--color-fg-primary)]"

--- a/lib/cascade/cascade_declarative_adapter.ml
+++ b/lib/cascade/cascade_declarative_adapter.ml
@@ -363,9 +363,17 @@ let build_strategy (tier : cascade_tier) : Cascade_strategy.t =
 let build_tier_group_strategy (tg : cascade_tier_group)
     (tier_tiers : string list list) : Cascade_strategy.t =
   let kind = map_strategy_kind tg.strategy in
+  let cycle =
+    match kind with
+    | Cascade_strategy.Priority_tier ->
+      { Cascade_strategy.default_cycle_policy with
+        max_cycles = max 1 (List.length tier_tiers)
+      }
+    | Cascade_strategy.Failover -> Cascade_strategy.default_cycle_policy
+  in
   {
     Cascade_strategy.kind;
-    cycle = Cascade_strategy.default_cycle_policy;
+    cycle;
     tiers = tier_tiers;
   }
 

--- a/lib/cascade/cascade_runtime_candidate.ml
+++ b/lib/cascade/cascade_runtime_candidate.ml
@@ -393,6 +393,17 @@ let tool_filter_rejection_label
 let capacity_key candidate = candidate.capacity_key
 let capacity_keys candidates = List.map capacity_key candidates
 
+let declared_client_capacity candidate =
+  match candidate.provider_cfg.internal_model_rotation_count with
+  | Some n when n > 0 -> Some n
+  | _ -> None
+
+let register_declared_client_capacity candidate =
+  match declared_client_capacity candidate, String.trim candidate.capacity_key with
+  | Some max_concurrent, capacity_key when not (String.equal capacity_key "") ->
+      Cascade_client_capacity.register ~url:capacity_key ~max_concurrent
+  | _ -> ()
+
 let runtime_urls candidates =
   candidates
   |> List.filter_map (fun candidate ->

--- a/lib/cascade/cascade_runtime_candidate.mli
+++ b/lib/cascade/cascade_runtime_candidate.mli
@@ -101,6 +101,13 @@ val tool_filter_rejection_label :
 
 val capacity_key : t -> string
 val capacity_keys : t list -> string list
+val declared_client_capacity : t -> int option
+(** Client-side [max-concurrent] declared on the provider-model binding.
+    This is opaque to routing callers: [None] means the candidate did not
+    declare a MASC-owned client semaphore. *)
+
+val register_declared_client_capacity : t -> unit
+(** Register the candidate's declared client semaphore, when present. *)
 
 val runtime_urls : t list -> string list
 val local_runtime_urls : t list -> string list

--- a/lib/dashboard_cascade.mli
+++ b/lib/dashboard_cascade.mli
@@ -87,6 +87,24 @@ val invalid_assignments_for_public_profiles :
         "source_path": "/path/to/cascade.toml",
         "source_editable": true,
         "source_text": "comment = ...\n[providers.X]\n...",
+        "assist": {
+          "parse_status": "parsed" | "unavailable",
+          "providers": ["glm-coding", ...],
+          "models": ["glm-auto", ...],
+          "bindings": ["glm-coding.glm-auto", ...],
+          "aliases": ["glm-coding.glm-auto.deep", ...],
+          "tiers": ["primary", ...],
+          "tier_groups": ["primary", ...],
+          "routes": ["keeper_turn", ...],
+          "feature_params": [
+            { "key": "thinking-enabled",
+              "scope": "alias",
+              "value_type": "boolean",
+              "example": "thinking-enabled = true" },
+            ...
+          ],
+          "errors": []
+        },
         "raw_json": "{ ... }\n",
         "materialization_error": null | "..."
       }
@@ -97,6 +115,9 @@ val invalid_assignments_for_public_profiles :
     {!Cascade_toml_materializer.render_toml_to_json_string}. RFC-0058 §9
     Phase 9.3 retired the JSON-native authoring mode and the on-disk JSON
     sibling, so the [config_path] and [raw_json_editable] fields are gone.
+    [assist] is a dashboard authoring helper derived from the same TOML source:
+    it exposes only opaque provider/model/tier identifiers and supported
+    MASC-side feature parameter names, not provider-specific model semantics.
 
     @since 0.160.1 *)
 val raw_config_json : unit -> Yojson.Safe.t

--- a/lib/dashboard_cascade_config.ml
+++ b/lib/dashboard_cascade_config.ml
@@ -10,6 +10,161 @@
 
 open Dashboard_cascade_helpers
 
+let sorted_unique_strings values =
+  values
+  |> List.map String.trim
+  |> List.filter (fun value -> not (String.equal value ""))
+  |> List.sort_uniq String.compare
+;;
+
+let feature_param_json ~key ~scope ~value_type ~example =
+  `Assoc
+    [ "key", `String key
+    ; "scope", `String scope
+    ; "value_type", `String value_type
+    ; "example", `String example
+    ]
+;;
+
+let cascade_source_feature_params_json =
+  `List
+    [ feature_param_json
+        ~key:"is-default"
+        ~scope:"binding"
+        ~value_type:"boolean"
+        ~example:"is-default = false"
+    ; feature_param_json
+        ~key:"max-concurrent"
+        ~scope:"binding,tier"
+        ~value_type:"integer"
+        ~example:"max-concurrent = 2"
+    ; feature_param_json
+        ~key:"temperature"
+        ~scope:"alias"
+        ~value_type:"float"
+        ~example:"temperature = 0.2"
+    ; feature_param_json
+        ~key:"max-input"
+        ~scope:"alias"
+        ~value_type:"integer"
+        ~example:"max-input = 32768"
+    ; feature_param_json
+        ~key:"max-output"
+        ~scope:"alias"
+        ~value_type:"integer"
+        ~example:"max-output = 8192"
+    ; feature_param_json
+        ~key:"thinking-enabled"
+        ~scope:"alias"
+        ~value_type:"boolean"
+        ~example:"thinking-enabled = true"
+    ; feature_param_json
+        ~key:"thinking-budget"
+        ~scope:"alias"
+        ~value_type:"integer"
+        ~example:"thinking-budget = 8192"
+    ; feature_param_json
+        ~key:"keep-alive"
+        ~scope:"binding"
+        ~value_type:"string"
+        ~example:"keep-alive = \"30m\""
+    ; feature_param_json
+        ~key:"num-ctx"
+        ~scope:"binding"
+        ~value_type:"integer"
+        ~example:"num-ctx = 32768"
+    ; feature_param_json
+        ~key:"price-input"
+        ~scope:"binding"
+        ~value_type:"float"
+        ~example:"price-input = 0.15"
+    ; feature_param_json
+        ~key:"price-output"
+        ~scope:"binding"
+        ~value_type:"float"
+        ~example:"price-output = 0.60"
+    ; feature_param_json
+        ~key:"strategy"
+        ~scope:"tier,tier-group"
+        ~value_type:"string"
+        ~example:"strategy = \"priority_tier\""
+    ; feature_param_json
+        ~key:"max-cycles"
+        ~scope:"tier.cycle-policy"
+        ~value_type:"integer"
+        ~example:"max-cycles = 3"
+    ; feature_param_json
+        ~key:"sticky-ttl-ms"
+        ~scope:"tier"
+        ~value_type:"integer"
+        ~example:"sticky-ttl-ms = 30000"
+    ]
+;;
+
+let parse_error_to_json (error : Cascade_declarative_parser.parse_error) =
+  `Assoc [ "path", `String error.path; "message", `String error.message ]
+;;
+
+let source_assist_json source_text =
+  match Cascade_declarative_parser.parse_string source_text with
+  | Error errors ->
+    `Assoc
+      [ "parse_status", `String "unavailable"
+      ; "providers", `List []
+      ; "models", `List []
+      ; "bindings", `List []
+      ; "aliases", `List []
+      ; "tiers", `List []
+      ; "tier_groups", `List []
+      ; "routes", `List []
+      ; "feature_params", cascade_source_feature_params_json
+      ; "errors", `List (List.map parse_error_to_json errors)
+      ]
+  | Ok cfg ->
+    let bindings =
+      cfg.Cascade_declarative_types.bindings
+      |> List.map Cascade_declarative_types.binding_key
+    in
+    let aliases =
+      cfg.Cascade_declarative_types.aliases
+      |> List.map Cascade_declarative_types.alias_key
+    in
+    let string_list values = string_list_to_json (sorted_unique_strings values) in
+    `Assoc
+      [ "parse_status", `String "parsed"
+      ; ( "providers"
+        , string_list
+            (List.map
+               (fun (p : Cascade_declarative_types.cascade_provider) -> p.id)
+               cfg.providers)
+        )
+      ; ( "models"
+        , string_list
+            (List.map
+               (fun (m : Cascade_declarative_types.cascade_model_spec) -> m.id)
+               cfg.models)
+        )
+      ; "bindings", string_list bindings
+      ; "aliases", string_list aliases
+      ; ( "tiers"
+        , string_list
+            (List.map (fun (t : Cascade_declarative_types.cascade_tier) -> t.name) cfg.tiers)
+        )
+      ; ( "tier_groups"
+        , string_list
+            (List.map
+               (fun (tg : Cascade_declarative_types.cascade_tier_group) -> tg.name)
+               cfg.tier_groups)
+        )
+      ; ( "routes"
+        , string_list
+            (List.map (fun (r : Cascade_declarative_types.cascade_route) -> r.name) cfg.routes)
+        )
+      ; "feature_params", cascade_source_feature_params_json
+      ; "errors", `List []
+      ]
+;;
+
 (** Profiles to surface in the dashboard.
 
     When the validated runtime snapshot is unavailable (for example
@@ -290,6 +445,7 @@ let raw_config_json () =
     ; "source_path", `String source.source_path
     ; "source_editable", `Bool (Option.is_none !source_read_error)
     ; "source_text", `String source_text
+    ; "assist", source_assist_json source_text
     ; "raw_json", `String raw_json
     ; ( "materialization_error"
       , match materialization_error with

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -114,6 +114,14 @@ let provider_attempt_finished_decision record =
   `Assoc decision_fields
 ;;
 
+let client_capacity_full_decision ~capacity_key =
+  `Assoc
+    [ "blocker", `String "client_capacity_full"
+    ; "capacity_key", `String capacity_key
+    ; "provider_attempt_started", `Bool false
+    ]
+;;
+
 let success_selected_model_raw candidate =
   Some (Cascade_runtime_candidate.model_health_key candidate)
 
@@ -380,6 +388,65 @@ let run_named
       (List.length unhealthy_local_endpoints)
       (String.concat ", " unhealthy_local_endpoints);
   let candidates = local_prefiltered_candidates in
+  let optional_capacity_override ~knob resolve =
+    match resolve () with
+    | Ok value -> value
+    | Error detail ->
+      Log.Misc.warn
+        "cascade %s: failed to resolve %s capacity override: %s"
+        cascade_name
+        knob
+        detail;
+      None
+  in
+  let register_capacity_controls candidates =
+    List.iter
+      Cascade_runtime_candidate.register_declared_client_capacity
+      candidates;
+    let capacity_keys =
+      Cascade_runtime_candidate.capacity_keys candidates
+      |> List.map String.trim
+      |> List.filter (fun key -> not (String.equal key ""))
+      |> Json_util.dedupe_keep_order
+    in
+    let cli_max_concurrent =
+      optional_capacity_override ~knob:"cli_max_concurrent" (fun () ->
+        Cascade_catalog_runtime.resolve_cli_max_concurrent
+          ~sw
+          ~net
+          ~name:cascade_name
+          ())
+    in
+    (match cli_max_concurrent with
+     | Some max_concurrent ->
+       Cascade_client_capacity.auto_register_cli_with_override
+         ~capacity_keys
+         ~max_concurrent
+     | None ->
+       Cascade_client_capacity.auto_register_cli_for_candidates ~capacity_keys);
+    let http_probe_default_max_concurrent = 1 in
+    let http_probe_max_concurrent =
+      match
+        optional_capacity_override ~knob:"ollama_max_concurrent" (fun () ->
+          Cascade_catalog_runtime.resolve_ollama_max_concurrent
+            ~sw
+            ~net
+            ~name:cascade_name
+            ())
+      with
+      | Some max_concurrent -> max_concurrent
+      | None ->
+        (* DET-OK: absent or unresolved HTTP-probe capacity uses the stable
+           single-flight default at the runtime boundary; configured values are
+           still explicit [Some n] inputs from the cascade catalog. *)
+        http_probe_default_max_concurrent
+    in
+    List.iter
+      (Cascade_runtime_candidate.register_http_probe_capable
+         ~max_concurrent:http_probe_max_concurrent)
+      candidates
+  in
+  register_capacity_controls candidates;
   if health_cooldown_fail_open then
     Log.Misc.warn
       "cascade %s: all tool-capable candidates are in health/cooldown; \
@@ -766,6 +833,24 @@ let run_named
           ~error_reason
           ()
   in
+  let acquire_client_capacity_slot candidate =
+    let capacity_key =
+      Cascade_runtime_candidate.capacity_key candidate |> String.trim
+    in
+    if String.equal capacity_key ""
+       || not (Cascade_client_capacity.is_registered capacity_key)
+    then `No_client_capacity
+    else
+      match Cascade_client_capacity.try_acquire capacity_key with
+      | Some release -> `Acquired (capacity_key, release)
+      | None -> `Full capacity_key
+  in
+  let emit_capacity_blocked_manifest ~capacity_key =
+    emit_runtime_manifest
+      ~status:"blocked"
+      ~decision:(client_capacity_full_decision ~capacity_key)
+      Keeper_runtime_manifest.Pre_dispatch_blocked
+  in
   let rec try_cascade
       ?(on_success = fun ~provider_key:_ -> ())
       ?resume_checkpoint ?per_provider_timeout_s remaining last_err =
@@ -880,6 +965,46 @@ let run_named
              cascade_name runtime_candidate_label runtime_candidate_label msg
        | None -> ());
       let is_last = rest = [] in
+      match acquire_client_capacity_slot candidate with
+      | `Full capacity_key ->
+        emit_capacity_blocked_manifest ~capacity_key;
+        record_cascade_attempt candidate ~outcome:(`Failure "slot_full") ();
+        Cascade_legacy_runner.record_fallback_event capture
+          ~from_model:runtime_candidate_label
+          ~to_model:runtime_candidate_label
+          ~reason:"client_capacity_full";
+        Log.Misc.info
+          "[cascade-fallback] cascade %s: %s skipped because client capacity \
+           key %s is full, trying next"
+          cascade_name
+          runtime_candidate_label
+          capacity_key;
+        let slot_last_err =
+          match
+            Cascade_fsm.decide
+              ~accept_on_exhaustion:false
+              ~is_last
+              Cascade_fsm.Slot_full
+          with
+          | Cascade_fsm.Try_next { last_err = Some err }
+          | Cascade_fsm.Exhausted { last_err = Some err } ->
+            Some err
+          | Cascade_fsm.Try_next { last_err = None }
+          | Cascade_fsm.Exhausted { last_err = None } ->
+            last_err
+          | Cascade_fsm.Accept _
+          | Cascade_fsm.Accept_on_exhaustion _ ->
+            last_err
+        in
+        try_cascade ~on_success ?resume_checkpoint ?per_provider_timeout_s
+          rest slot_last_err
+      | (`No_client_capacity | `Acquired _) as capacity_slot ->
+      let capacity_release =
+        match capacity_slot with
+        | `Acquired (_capacity_key, release) -> Some release
+        | `No_client_capacity -> None
+        | `Full _ -> None
+      in
       Log.Misc.debug "cascade %s: trying %s (is_last=%b)" cascade_name runtime_candidate_label is_last;
       let pp_timeout =
         Cascade_runtime_candidate.effective_attempt_timeout_s
@@ -894,10 +1019,6 @@ let run_named
         ; started_per_provider_timeout_s = pp_timeout
         }
       in
-      emit_runtime_manifest
-        ~status:"started"
-        ~decision:(provider_attempt_started_decision started_record)
-        Keeper_runtime_manifest.Provider_attempt_started;
       let provider_attempt_finished_emitted = ref false in
       let emit_provider_attempt_finished_once
             ~status
@@ -936,6 +1057,13 @@ let run_named
       in
       let (result, checkpoint_after, liveness_success_sample, attempt_latency_ms) =
         Eio.Switch.run (fun provider_attempt_sw ->
+          Option.iter
+            (fun release -> Eio.Switch.on_release provider_attempt_sw release)
+            capacity_release;
+          emit_runtime_manifest
+            ~status:"started"
+            ~decision:(provider_attempt_started_decision started_record)
+            Keeper_runtime_manifest.Provider_attempt_started;
           Eio.Switch.on_release provider_attempt_sw (fun () ->
             if not !provider_attempt_finished_emitted then
               let attempt_latency_ms =
@@ -1336,7 +1464,7 @@ let run_named
   let adapter = Cascade_runtime_candidate.strategy_adapter in
   let signal_ctx : Cascade_strategy.signal_ctx = {
     health = Cascade_health_tracker.global;
-    capacity = (fun _ -> None);
+    capacity = Cascade_capacity_probe.capacity;
     now = Unix.gettimeofday ();
     rand_int = Random.int;
     keeper_name;

--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -31,8 +31,8 @@ lib/process/process_eio.ml:493
 # manager itself. Bounded by session scope, not by per-call timeout.
 lib/server/lsp_process_manager.ml:178
 
-# lib/worker_dev_tools.ml:1816 — dev-tools worker spawn. Wrapped by
+# lib/worker_dev_tools.ml:1440 — dev-tools worker spawn. Wrapped by
 # Tool_resource_gate, Fd_accountant, Eio.Time.with_timeout_exn, and a fresh
-# Eio.Switch.run at the call boundary. Line renumbered from :1941 by
-# #16222 (split: worker dev tool paths).
-lib/worker_dev_tools.ml:1816
+# Eio.Switch.run at the call boundary. Line renumbered by worker-dev-tools
+# split/refactor waves.
+lib/worker_dev_tools.ml:1440

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-17T13:32:54Z (HEAD: 621ef006aa)
+Generated: 2026-05-18T18:32:53Z (HEAD: 0496c3c4dd)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 

--- a/test/test_cascade_declarative_hotpath.ml
+++ b/test/test_cascade_declarative_hotpath.ml
@@ -329,6 +329,12 @@ let test_strategy_preserved () =
     (Cascade_strategy.kind_to_string
        primary.Hotpath.strategy.Cascade_strategy.kind)
 
+let test_tier_group_priority_cycles_cover_all_tiers () =
+  let snapshot = get_snapshot valid_toml in
+  let primary = find_profile snapshot "tier-group.primary" in
+  check int "priority tier max_cycles spans tier count"
+    2 primary.Hotpath.strategy.Cascade_strategy.cycle.max_cycles
+
 let test_probes_field_absent () =
   (* Mirror type has no probes field — this test verifies the type shape *)
   let snapshot = get_snapshot valid_toml in
@@ -746,6 +752,10 @@ let () =
           `Quick
           test_tier_group_inference_max_tokens_uses_model_capability;
         test_case "strategy preserved" `Quick test_strategy_preserved;
+        test_case
+          "tier-group priority cycles cover all tiers"
+          `Quick
+          test_tier_group_priority_cycles_cover_all_tiers;
         test_case "probes field absent" `Quick test_probes_field_absent;
         test_case "ollama_max_concurrent" `Quick test_ollama_max_concurrent;
       ];

--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -258,6 +258,27 @@ let test_client_capacity_release_idempotent () =
       check int "active = 0 not -1" 0 info.process_active
     | None -> fail "capacity disappeared"
 
+let test_declared_client_capacity_registers_generic_endpoint () =
+  C.unregister_all ();
+  let cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.OpenAI_compat
+      ~model_id:"runpod-qwen"
+      ~base_url:"https://runpod.example/v1"
+      ~internal_model_rotation_count:2
+      ()
+  in
+  let candidate = Masc_mcp.Cascade_runtime_candidate.of_provider_config cfg in
+  check (option int) "declared capacity"
+    (Some 2)
+    (Masc_mcp.Cascade_runtime_candidate.declared_client_capacity candidate);
+  Masc_mcp.Cascade_runtime_candidate.register_declared_client_capacity candidate;
+  match C.capacity "https://runpod.example/v1" with
+  | None -> fail "declared endpoint capacity was not registered"
+  | Some info ->
+    check int "generic endpoint total" 2 info.total;
+    check int "generic endpoint available" 2 info.process_available
+
 let test_client_capacity_unregistered_url () =
   C.unregister_all ();
   check (option int) "capacity = None for unregistered URL"
@@ -852,6 +873,8 @@ let () =
         test_client_capacity_acquire_release;
       test_case "release is idempotent" `Quick
         test_client_capacity_release_idempotent;
+      test_case "declared generic endpoint capacity registers" `Quick
+        test_declared_client_capacity_registers_generic_endpoint;
       test_case "unregistered URL returns None" `Quick
         test_client_capacity_unregistered_url;
       test_case "max_concurrent <= 0 clamped to 1" `Quick

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -140,10 +140,10 @@ let openai_usage =
       ("total_tokens", `Int 13);
     ]
 
-let openai_tool_call_response ~tool_name ~arguments =
+let openai_probe_response =
   `Assoc
     [
-      ("id", `String "chatcmpl-tool");
+      ("id", `String "chatcmpl-probe");
       ("object", `String "chat.completion");
       ("model", `String "mock-runtime-manifest");
       ( "choices",
@@ -154,47 +154,8 @@ let openai_tool_call_response ~tool_name ~arguments =
                 ("index", `Int 0);
                 ( "message",
                   `Assoc
-                    [
-                      ("role", `String "assistant");
-                      ("content", `Null);
-                      ( "tool_calls",
-                        `List
-                          [
-                            `Assoc
-                              [
-                                ("id", `String "call_keeper_tool_search");
-                                ("type", `String "function");
-                                ( "function",
-                                  `Assoc
-                                    [
-                                      ("name", `String tool_name);
-                                      ("arguments", `String arguments);
-                                    ] );
-                              ];
-                          ] );
-                    ] );
-                ("finish_reason", `String "tool_calls");
-              ];
-          ] );
-      ("usage", openai_usage);
-    ]
-  |> Yojson.Safe.to_string
-
-let openai_text_response text =
-  `Assoc
-    [
-      ("id", `String "chatcmpl-final");
-      ("object", `String "chat.completion");
-      ("model", `String "mock-runtime-manifest");
-      ( "choices",
-        `List
-          [
-            `Assoc
-              [
-                ("index", `Int 0);
-                ( "message",
-                  `Assoc
-                    [ ("role", `String "assistant"); ("content", `String text) ] );
+                    [ ("role", `String "assistant"); ("content", `String "probe ok") ]
+                );
                 ("finish_reason", `String "stop");
               ];
           ] );
@@ -202,14 +163,118 @@ let openai_text_response text =
     ]
   |> Yojson.Safe.to_string
 
+let openai_sse chunks =
+  let data_lines =
+    chunks
+    |> List.map (fun json -> "data: " ^ Yojson.Safe.to_string json ^ "\n\n")
+  in
+  String.concat "" (data_lines @ [ "data: [DONE]\n\n" ])
+
+let openai_tool_call_response ~tool_name ~arguments =
+  openai_sse
+    [
+      `Assoc
+        [
+          ("id", `String "chatcmpl-tool");
+          ("object", `String "chat.completion.chunk");
+          ("model", `String "mock-runtime-manifest");
+          ( "choices",
+            `List
+              [
+                `Assoc
+                  [
+                    ("index", `Int 0);
+                    ( "delta",
+                      `Assoc
+                        [
+                          ( "tool_calls",
+                            `List
+                              [
+                                `Assoc
+                                  [
+                                    ("index", `Int 0);
+                                    ("id", `String "call_keeper_tool");
+                                    ("type", `String "function");
+                                    ( "function",
+                                      `Assoc
+                                        [
+                                          ("name", `String tool_name);
+                                          ("arguments", `String arguments);
+                                        ] );
+                                  ];
+                              ] );
+                        ] );
+                    ("finish_reason", `Null);
+                  ];
+              ] );
+        ];
+      `Assoc
+        [
+          ("id", `String "chatcmpl-tool");
+          ("object", `String "chat.completion.chunk");
+          ("model", `String "mock-runtime-manifest");
+          ( "choices",
+            `List
+              [
+                `Assoc
+                  [ ("index", `Int 0); ("delta", `Assoc []); ("finish_reason", `String "tool_calls") ];
+              ] );
+          ("usage", openai_usage);
+        ];
+    ]
+
+let openai_text_response text =
+  openai_sse
+    [
+      `Assoc
+        [
+          ("id", `String "chatcmpl-final");
+          ("object", `String "chat.completion.chunk");
+          ("model", `String "mock-runtime-manifest");
+          ( "choices",
+            `List
+              [
+                `Assoc
+                  [
+                    ("index", `Int 0);
+                    ("delta", `Assoc [ ("content", `String text) ]);
+                    ("finish_reason", `Null);
+                  ];
+              ] );
+        ];
+      `Assoc
+        [
+          ("id", `String "chatcmpl-final");
+          ("object", `String "chat.completion.chunk");
+          ("model", `String "mock-runtime-manifest");
+          ( "choices",
+            `List
+              [
+                `Assoc
+                  [ ("index", `Int 0); ("delta", `Assoc []); ("finish_reason", `String "stop") ];
+              ] );
+          ("usage", openai_usage);
+        ];
+    ]
+
 let start_multi_mock ~sw ~net ~port responses =
   let idx = Atomic.make 0 in
   let handler _conn _req body =
-    let _ = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
+    let request_body = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
     let n = List.length responses in
-    let i = Atomic.fetch_and_add idx 1 in
-    let response = List.nth responses (i mod n) in
-    let headers = Cohttp.Header.init_with "content-type" "application/json" in
+    let is_probe = String.trim request_body = "" in
+    let response =
+      if is_probe
+      then openai_probe_response
+      else (
+        let i = Atomic.fetch_and_add idx 1 in
+        List.nth responses (i mod n))
+    in
+    let headers =
+      Cohttp.Header.init_with
+        "content-type"
+        (if is_probe then "application/json" else "text/event-stream")
+    in
     Cohttp_eio.Server.respond_string ~headers ~status:`OK ~body:response ()
   in
   let socket =
@@ -224,10 +289,21 @@ let start_multi_mock ~sw ~net ~port responses =
 let start_delayed_mock ~sw ~net ~clock ~port ~delay_s response =
   let calls = Atomic.make 0 in
   let handler _conn _req body =
-    ignore (Atomic.fetch_and_add calls 1);
-    let _ = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
-    Eio.Time.sleep clock delay_s;
-    let headers = Cohttp.Header.init_with "content-type" "application/json" in
+    let request_body = Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) in
+    let is_probe = String.trim request_body = "" in
+    let response =
+      if is_probe
+      then openai_probe_response
+      else (
+        ignore (Atomic.fetch_and_add calls 1);
+        Eio.Time.sleep clock delay_s;
+        response)
+    in
+    let headers =
+      Cohttp.Header.init_with
+        "content-type"
+        (if is_probe then "application/json" else "text/event-stream")
+    in
     Cohttp_eio.Server.respond_string ~headers ~status:`OK ~body:response ()
   in
   let socket =
@@ -237,7 +313,9 @@ let start_delayed_mock ~sw ~net ~clock ~port ~delay_s response =
   let server = Cohttp_eio.Server.make ~callback:handler () in
   Eio.Fiber.fork_daemon ~sw (fun () ->
     Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
-  Printf.sprintf "http://127.0.0.1:%d" port, fun () -> Atomic.get calls
+  (* Avoid the loopback timeout floor so this fixture exercises the explicit
+     per-provider timeout path. *)
+  Printf.sprintf "http://0.0.0.0:%d" port, fun () -> Atomic.get calls
 
 let rec find_repo_root dir =
   if Sys.file_exists (Filename.concat dir "dune-project") then
@@ -686,7 +764,7 @@ let test_pre_dispatch_terminal_observation_emits_manifest_rows () =
         (json_int_member "turn_count" receipt_json);
       Alcotest.(check (option string))
         "receipt outcome"
-        (Some "skipped")
+        (Some "receipt_skipped")
         (json_string_member_opt "outcome" receipt_json);
       Alcotest.(check (option string))
         "receipt terminal reason"
@@ -1504,9 +1582,9 @@ let test_successful_provider_turn_links_runtime_artifacts () =
       let base_url, request_count =
         start_multi_mock ~sw ~net ~port
           [
-            openai_tool_call_response ~tool_name:"keeper_tool_search"
+            openai_tool_call_response ~tool_name:"keeper_board_post"
               ~arguments:
-                {|{"query":"context","max_results":1}|};
+                {|{"content":"runtime manifest fixture progress","hearth":"test"}|};
             openai_text_response "context checked; runtime artifacts should persist.";
           ]
       in
@@ -1552,7 +1630,7 @@ let test_successful_provider_turn_links_runtime_artifacts () =
               ~base_dir:session_base_dir
               ~max_context:16_000
               ~build_turn_prompt
-              ~user_message:"Call keeper_tool_search once, then answer."
+              ~user_message:"Call keeper_board_post once, then answer."
               ~cascade_name:
                 (Masc_mcp.Keeper_cascade_profile.runtime_name_of_string
                    cascade_name)
@@ -1573,9 +1651,9 @@ let test_successful_provider_turn_links_runtime_artifacts () =
           in
           Alcotest.(check int) "provider calls" 2 (request_count ());
           Alcotest.(check bool)
-            "keeper_tool_search used"
+            "keeper_board_post used"
             true
-            (List.mem "keeper_tool_search" result.tools_used);
+            (List.mem "keeper_board_post" result.tools_used);
           let latest_tool =
             Masc_mcp.Keeper_tool_call_log.read_latest
               ~keeper_name:meta.name ()
@@ -1583,7 +1661,7 @@ let test_successful_provider_turn_links_runtime_artifacts () =
           let latest_tool = require_some "latest tool-call log" latest_tool in
           Alcotest.(check string)
             "latest tool name"
-            "keeper_tool_search"
+            "keeper_board_post"
             Yojson.Safe.Util.(latest_tool |> member "tool" |> to_string);
           Alcotest.(check int)
             "tool-call log uses keeper turn id"
@@ -2150,6 +2228,10 @@ let test_wired_manifest_sites () =
           "Keeper_cascade_engine.guard_keeper_hot_path";
           "cascade_engine;";
           "Keeper_cascade_engine.manifest_fields";
+          "client_capacity_full_decision";
+          "client_capacity_full";
+          "provider_attempt_started";
+          "Keeper_runtime_manifest.Pre_dispatch_blocked";
           "Keeper_runtime_manifest.Provider_attempt_started";
           "Keeper_runtime_manifest.Provider_attempt_finished";
         ] );
@@ -2174,7 +2256,7 @@ let test_wired_manifest_sites () =
         ]
       );
       ( "lib/server/server_dashboard_http_keeper_api.ml",
-        [ "keeper_runtime_trace_json"; "/runtime-trace" ] );
+        [ "keeper_runtime_trace_json"; "keeper_suffix_runtime_trace" ] );
       ( "bin/masc_trace.ml",
         [
           "runtime-manifests";


### PR DESCRIPTION
## Summary
- register cascade TOML max-concurrent declarations as MASC client capacity semaphores before provider attempts
- skip full capacity keys with Slot_full fallback, capacity history, and pre-dispatch manifest visibility
- make priority_tier tier-groups cycle across every configured tier instead of stopping after the first cycle
- add dashboard raw cascade assist metadata, datalist authoring helpers, TOML snippets, and opaque feature parameter hints
- expose Prometheus store snapshots through the public store API so the current build compiles cleanly

## Validation
- git diff --check
- ocamlformat --check touched OCaml files
- scripts/dune-local.sh build lib/masc_mcp.cmxa test/test_cascade_strategy.exe test/test_cascade_declarative_hotpath.exe
- ./_build/default/test/test_cascade_strategy.exe (42 tests)
- ./_build/default/test/test_cascade_declarative_hotpath.exe (23 tests)
- pnpm exec tsc --noEmit --pretty false
- pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/api/schemas/cascade.test.ts src/components/cascade-config-panel.test.ts src/api/dashboard-cascade.test.ts (13 tests)

## Notes
- OAS was inspected but not changed: provider-specific thinking/reasoning serialization is already owned there.
- The dashboard assist exposes opaque ids and MASC-side parameter keys only; it does not infer provider/model identity semantics.