### PR TITLE
refactor: split keeper agent run manifest helpers

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -175,6 +175,7 @@
   keeper_turn_telemetry
   keeper_agent_prompt_metrics
   keeper_agent_tool_surface
+  keeper_agent_run_contract_helpers
   keeper_agent_result
   keeper_agent_error
   keeper_agent_memory_episode

--- a/lib/dune
+++ b/lib/dune
@@ -201,6 +201,7 @@
   keeper_exec_context
   keeper_guards
   keeper_agent_run_turn_helpers
+  keeper_agent_run_manifest_helpers
   keeper_turn_setup
   keeper_turn_up_args
   keeper_turn_up_create

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -500,52 +500,21 @@ let run_turn
             }
             : Cascade_runner.cli_transport_overrides)
        in
-       (* Phase 0: wake-time payload telemetry (Option C baseline).
-       Entire block is dead code when MASC_PAYLOAD_TELEMETRY is unset.
-       Compute logic lives in [Keeper_wake_telemetry] for unit tests;
-       exceptions from the telemetry path never abort the LLM call. *)
-       let () =
-         if Env_config_keeper.KeeperTelemetry.payload_telemetry_enabled ()
-         then (
-           try
-             let sizes =
-               Keeper_wake_telemetry.compute_sizes
-                 ~system_prompt:turn_system_prompt
-                 ~tools
-                 ~history_messages
-                 ~user_message
-             in
-             let model_id =
-               match Keeper_model_labels.configured_model_labels_of_meta meta with
-               | m :: _ -> m
-               | [] -> "auto"
-             in
-             let _event : Dashboard_harness_health.wake_payload_event =
-               Dashboard_harness_health.record_wake_payload
-                 ~keeper_name:meta.name
-                 ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-                 ~turn_index:start_turn_count
-                 ~model_id
-                 ~context_window:max_context
-                 ~approx_body_bytes:sizes.approx_body_bytes
-                 ~system_prompt_bytes:sizes.system_prompt_bytes
-                 ~tool_defs_bytes:sizes.tool_defs_bytes
-                 ~messages_bytes:sizes.messages_bytes
-                 ~message_count:sizes.message_count
-                 ~role_counts:sizes.role_counts
-                 ~tool_count:sizes.tool_count
-                 ~has_compact_happened:pre_dispatch_compacted
-             in
-             ()
-           with
-           | Eio.Cancel.Cancelled _ as e -> raise e
-           | exn ->
-             Log.Harness.warn
-               "[wake_payload] telemetry failed keeper=%s: %s"
-               meta.name
-               (Printexc.to_string exn))
-       in
-       let turn_result =
+	       (* Phase 0: wake-time payload telemetry (Option C baseline).
+	       Entire block is dead code when MASC_PAYLOAD_TELEMETRY is unset.
+	       Compute logic lives in [Keeper_wake_telemetry] for unit tests;
+	       exceptions from the telemetry path never abort the LLM call. *)
+	       Turn_helpers.record_wake_payload_if_enabled
+	         ~meta
+	         ~trace_id
+	         ~start_turn_count
+	         ~max_context
+	         ~pre_dispatch_compacted
+	         ~turn_system_prompt
+	         ~tools
+	         ~history_messages
+	         ~user_message;
+	       let turn_result =
          match pre_dispatch_checkpoint_error with
          | Some err -> Error err
          | None ->

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -9,6 +9,7 @@ include Keeper_agent_tool_surface
 include Keeper_agent_result
 include Keeper_agent_error
 include Keeper_agent_checkpoint_hygiene
+module Contract_helpers = Keeper_agent_run_contract_helpers
 module Turn_helpers = Keeper_agent_run_turn_helpers
 
 (* Post-turn telemetry logging — extracted to Keeper_turn_telemetry (#5732) *)
@@ -20,54 +21,13 @@ let sse_event_progress_kind = Turn_helpers.sse_event_progress_kind
 let registry_progress_on_event = Turn_helpers.registry_progress_on_event
 let select_cdal_proof = Turn_helpers.select_cdal_proof
 
-let cdal_task_id_for_verdict ~(current_task_id : string option)
-    ~(tool_calls : tool_call_detail list) =
-  match current_task_id with
-  | Some task_id -> Some task_id
-  | None ->
-    List.find_map
-      (fun (detail : tool_call_detail) ->
-         match detail.task_id with
-         | Some task_id when String.trim task_id <> "" -> Some task_id
-         | _ -> None)
-      tool_calls
+let cdal_task_id_for_verdict = Contract_helpers.cdal_task_id_for_verdict
+let progress_keeper_tool_names_for_contract =
+  Contract_helpers.progress_keeper_tool_names_for_contract
 ;;
 
-let keeper_tool_names_for_outcome
-      ~(allowed_tool_names : string list)
-      ~(tool_calls : tool_call_detail list)
-      ~(outcome : string)
-  : string list
-  =
-  let observed_tool_names =
-    tool_calls
-    |> List.rev
-    |> List.filter_map (fun (detail : tool_call_detail) ->
-      if String.equal detail.outcome outcome then Some detail.tool_name else None)
-  in
-  Keeper_tool_disclosure.final_keeper_tool_names
-    ~reported_tool_names:[]
-    ~observed_tool_names
-    ~allowed_tool_names
-;;
-
-let progress_keeper_tool_names_for_contract
-      ~(allowed_tool_names : string list)
-      ~(actual_keeper_tool_names : string list)
-      ~(tool_calls : tool_call_detail list)
-  : string list
-  =
-  match tool_calls with
-  | [] -> actual_keeper_tool_names
-  | _ :: _ -> keeper_tool_names_for_outcome ~allowed_tool_names ~tool_calls ~outcome:"ok"
-;;
-
-let no_progress_success_tool_names_for_contract
-      ~(allowed_tool_names : string list)
-      ~(tool_calls : tool_call_detail list)
-  : string list
-  =
-  keeper_tool_names_for_outcome ~allowed_tool_names ~tool_calls ~outcome:"ok_no_progress"
+let no_progress_success_tool_names_for_contract =
+  Contract_helpers.no_progress_success_tool_names_for_contract
 ;;
 
 module For_testing = struct

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -10,6 +10,7 @@ include Keeper_agent_result
 include Keeper_agent_error
 include Keeper_agent_checkpoint_hygiene
 module Contract_helpers = Keeper_agent_run_contract_helpers
+module Manifest_helpers = Keeper_agent_run_manifest_helpers
 module Turn_helpers = Keeper_agent_run_turn_helpers
 
 (* Post-turn telemetry logging — extracted to Keeper_turn_telemetry (#5732) *)
@@ -227,38 +228,13 @@ let run_turn
       ~generation
       ~cascade_name:cascade_name_string
   in
-  let digest_text = Turn_helpers.digest_text in
-  let digest_message_texts_as_joined =
-    Turn_helpers.digest_message_texts_as_joined
-  in
-  append_manifest ~site:"checkpoint_loaded"
+  Manifest_helpers.append_checkpoint_start_events
+    ~append_manifest
     ~keeper_turn_id:manifest_keeper_turn_id
     ~checkpoint_path
-    ~decision:
-      (`Assoc
-        [
-          ("loaded_checkpoint_present", `Bool ctx.loaded_checkpoint_present);
-          ("pre_dispatch_compacted", `Bool pre_dispatch_compacted);
-          ( "pre_dispatch_checkpoint_error",
-            match pre_dispatch_checkpoint_error with
-            | None -> `Null
-            | Some err -> `String (Agent_sdk.Error.to_string err) );
-        ])
-    Keeper_runtime_manifest.Checkpoint_loaded;
-  append_manifest ~site:"context_compacted"
-    ~keeper_turn_id:manifest_keeper_turn_id
-    ~status:(if pre_dispatch_compacted then "compacted" else "skipped")
-    ~decision:
-      (`Assoc
-        [
-          ("pre_dispatch_compacted", `Bool pre_dispatch_compacted);
-          ( "pre_dispatch_checkpoint_error",
-            match pre_dispatch_checkpoint_error with
-            | None -> `Null
-            | Some err -> `String (Agent_sdk.Error.to_string err) );
-          ("checkpoint_path", `String checkpoint_path);
-        ])
-    Keeper_runtime_manifest.Context_compacted;
+    ~loaded_checkpoint_present:ctx.loaded_checkpoint_present
+    ~pre_dispatch_compacted
+    ~pre_dispatch_checkpoint_error;
   (* Steps 5-6: turn prompt, memory/temporal context, prompt metrics,
      user message append, token estimation — Keeper_run_prompt. *)
   let prompt_ctx =
@@ -280,23 +256,17 @@ let run_turn
   let history_messages = prompt_ctx.Keeper_run_prompt.history_messages in
   let estimated_input_tokens = prompt_ctx.Keeper_run_prompt.estimated_input_tokens in
   let ctx_work = prompt_ctx.Keeper_run_prompt.ctx_work in
-  let history_messages_digest = digest_message_texts_as_joined history_messages in
-  append_manifest ~site:"context_injected"
+  Manifest_helpers.append_context_injected
+    ~append_manifest
     ~keeper_turn_id:manifest_keeper_turn_id
-    ~decision:
-      (`Assoc
-        [
-          ("base_system_prompt_digest", `String (digest_text base_system_prompt));
-          ("turn_system_prompt_digest", `String (digest_text turn_system_prompt));
-          ("dynamic_context_digest", `String (digest_text dynamic_context));
-          ("memory_context_digest", `String (digest_text memory_context));
-          ("temporal_context_digest", `String (digest_text temporal_context));
-          ("user_message_digest", `String (digest_text user_message));
-          ("history_message_count", `Int (List.length history_messages));
-          ("history_messages_digest", `String history_messages_digest);
-          ("estimated_input_tokens", `Int estimated_input_tokens);
-        ])
-    Keeper_runtime_manifest.Context_injected;
+    ~base_system_prompt
+    ~turn_system_prompt
+    ~dynamic_context
+    ~memory_context
+    ~temporal_context
+    ~user_message
+    ~history_messages
+    ~estimated_input_tokens;
   let actionable_signal =
     match world_observation with
     | None -> false
@@ -357,42 +327,10 @@ let run_turn
     let reducer = s.Keeper_run_tools.reducer in
     let memory = s.Keeper_run_tools.memory in
     let acc = s.Keeper_run_tools.acc in
-    append_manifest ~site:"tool_surface_selected"
+    Manifest_helpers.append_tool_surface_selected
+      ~append_manifest
       ~keeper_turn_id:manifest_keeper_turn_id
-      ~decision:
-        (`Assoc
-          [
-            ("turn_lane", `String (turn_lane_to_string acc.tool_surface.turn_lane));
-            ( "tool_surface_class",
-              `String
-                (tool_surface_class_to_string
-                   acc.tool_surface.tool_surface_class) );
-            ( "tool_requirement",
-              `String
-                (tool_requirement_to_string acc.tool_surface.tool_requirement)
-            );
-            ("visible_tool_count", `Int acc.tool_surface.visible_tool_count);
-            ("tool_gate_enabled", `Bool acc.tool_surface.tool_gate_enabled);
-            ( "tool_surface_fallback_used",
-              `Bool acc.tool_surface.tool_surface_fallback_used );
-            ( "required_tool_names",
-              `List
-                (List.map
-                   (fun name -> `String name)
-                   acc.tool_surface.required_tool_names) );
-            ( "required_tool_candidate_names",
-              `List
-                (List.map
-                   (fun name -> `String name)
-                   acc.tool_surface.required_tool_candidate_names) );
-            ( "missing_required_tool_names",
-              `List
-                (List.map
-                   (fun name -> `String name)
-                   acc.tool_surface.missing_required_tool_names) );
-            ("config_root", `String acc.tool_surface.config_root);
-          ])
-      Keeper_runtime_manifest.Tool_surface_selected;
+      acc.tool_surface;
     let agent_ref : Agent_sdk.Agent.t option ref = ref None in
     let proof_ref : Masc_mcp_cdal_runtime.Cdal_proof.t option ref = ref None in
     let initial_tool_surface = s.Keeper_run_tools.initial_tool_surface in

--- a/lib/keeper/keeper_agent_run_contract_helpers.ml
+++ b/lib/keeper/keeper_agent_run_contract_helpers.ml
@@ -1,0 +1,50 @@
+let cdal_task_id_for_verdict ~(current_task_id : string option)
+      ~(tool_calls : Keeper_agent_result.tool_call_detail list)
+  =
+  match current_task_id with
+  | Some task_id -> Some task_id
+  | None ->
+    List.find_map
+      (fun (detail : Keeper_agent_result.tool_call_detail) ->
+         match detail.task_id with
+         | Some task_id when String.trim task_id <> "" -> Some task_id
+         | _ -> None)
+      tool_calls
+;;
+
+let keeper_tool_names_for_outcome
+      ~(allowed_tool_names : string list)
+      ~(tool_calls : Keeper_agent_result.tool_call_detail list)
+      ~(outcome : string)
+  : string list
+  =
+  let observed_tool_names =
+    tool_calls
+    |> List.rev
+    |> List.filter_map (fun (detail : Keeper_agent_result.tool_call_detail) ->
+      if String.equal detail.outcome outcome then Some detail.tool_name else None)
+  in
+  Keeper_tool_disclosure.final_keeper_tool_names
+    ~reported_tool_names:[]
+    ~observed_tool_names
+    ~allowed_tool_names
+;;
+
+let progress_keeper_tool_names_for_contract
+      ~(allowed_tool_names : string list)
+      ~(actual_keeper_tool_names : string list)
+      ~(tool_calls : Keeper_agent_result.tool_call_detail list)
+  : string list
+  =
+  match tool_calls with
+  | [] -> actual_keeper_tool_names
+  | _ :: _ -> keeper_tool_names_for_outcome ~allowed_tool_names ~tool_calls ~outcome:"ok"
+;;
+
+let no_progress_success_tool_names_for_contract
+      ~(allowed_tool_names : string list)
+      ~(tool_calls : Keeper_agent_result.tool_call_detail list)
+  : string list
+  =
+  keeper_tool_names_for_outcome ~allowed_tool_names ~tool_calls ~outcome:"ok_no_progress"
+;;

--- a/lib/keeper/keeper_agent_run_contract_helpers.mli
+++ b/lib/keeper/keeper_agent_run_contract_helpers.mli
@@ -1,0 +1,17 @@
+(** Pure contract helpers for {!Keeper_agent_run}. *)
+
+val cdal_task_id_for_verdict :
+  current_task_id:string option ->
+  tool_calls:Keeper_agent_result.tool_call_detail list ->
+  string option
+
+val progress_keeper_tool_names_for_contract :
+  allowed_tool_names:string list ->
+  actual_keeper_tool_names:string list ->
+  tool_calls:Keeper_agent_result.tool_call_detail list ->
+  string list
+
+val no_progress_success_tool_names_for_contract :
+  allowed_tool_names:string list ->
+  tool_calls:Keeper_agent_result.tool_call_detail list ->
+  string list

--- a/lib/keeper/keeper_agent_run_manifest_helpers.ml
+++ b/lib/keeper/keeper_agent_run_manifest_helpers.ml
@@ -1,0 +1,117 @@
+type append_manifest =
+  ?status:string ->
+  ?decision:Yojson.Safe.t ->
+  ?keeper_turn_id:int ->
+  ?oas_turn_count:int ->
+  ?checkpoint_path:string ->
+  ?receipt_path:string ->
+  site:string ->
+  Keeper_runtime_manifest.event_kind ->
+  unit
+
+let checkpoint_error_json = function
+  | None -> `Null
+  | Some err -> `String (Agent_sdk.Error.to_string err)
+;;
+
+let append_checkpoint_start_events
+      ~append_manifest
+      ~keeper_turn_id
+      ~checkpoint_path
+      ~loaded_checkpoint_present
+      ~pre_dispatch_compacted
+      ~pre_dispatch_checkpoint_error
+  =
+  append_manifest
+    ~site:"checkpoint_loaded"
+    ~keeper_turn_id
+    ~checkpoint_path
+    ~decision:
+      (`Assoc
+        [ "loaded_checkpoint_present", `Bool loaded_checkpoint_present
+        ; "pre_dispatch_compacted", `Bool pre_dispatch_compacted
+        ; "pre_dispatch_checkpoint_error", checkpoint_error_json pre_dispatch_checkpoint_error
+        ])
+    Keeper_runtime_manifest.Checkpoint_loaded;
+  append_manifest
+    ~site:"context_compacted"
+    ~keeper_turn_id
+    ~status:(if pre_dispatch_compacted then "compacted" else "skipped")
+    ~decision:
+      (`Assoc
+        [ "pre_dispatch_compacted", `Bool pre_dispatch_compacted
+        ; "pre_dispatch_checkpoint_error", checkpoint_error_json pre_dispatch_checkpoint_error
+        ; "checkpoint_path", `String checkpoint_path
+        ])
+    Keeper_runtime_manifest.Context_compacted
+;;
+
+let append_context_injected
+      ~append_manifest
+      ~keeper_turn_id
+      ~base_system_prompt
+      ~turn_system_prompt
+      ~dynamic_context
+      ~memory_context
+      ~temporal_context
+      ~user_message
+      ~history_messages
+      ~estimated_input_tokens
+  =
+  let digest_text = Keeper_agent_run_turn_helpers.digest_text in
+  let history_messages_digest =
+    Keeper_agent_run_turn_helpers.digest_message_texts_as_joined history_messages
+  in
+  append_manifest
+    ~site:"context_injected"
+    ~keeper_turn_id
+    ~decision:
+      (`Assoc
+        [ "base_system_prompt_digest", `String (digest_text base_system_prompt)
+        ; "turn_system_prompt_digest", `String (digest_text turn_system_prompt)
+        ; "dynamic_context_digest", `String (digest_text dynamic_context)
+        ; "memory_context_digest", `String (digest_text memory_context)
+        ; "temporal_context_digest", `String (digest_text temporal_context)
+        ; "user_message_digest", `String (digest_text user_message)
+        ; "history_message_count", `Int (List.length history_messages)
+        ; "history_messages_digest", `String history_messages_digest
+        ; "estimated_input_tokens", `Int estimated_input_tokens
+        ])
+    Keeper_runtime_manifest.Context_injected
+;;
+
+let string_list_json names = `List (List.map (fun name -> `String name) names)
+
+let append_tool_surface_selected
+      ~append_manifest
+      ~keeper_turn_id
+      (tool_surface : Keeper_agent_tool_surface.tool_surface_metrics)
+  =
+  append_manifest
+    ~site:"tool_surface_selected"
+    ~keeper_turn_id
+    ~decision:
+      (`Assoc
+        [ ( "turn_lane"
+          , `String (Keeper_agent_tool_surface.turn_lane_to_string tool_surface.turn_lane)
+          )
+        ; ( "tool_surface_class"
+          , `String
+              (Keeper_agent_tool_surface.tool_surface_class_to_string
+                 tool_surface.tool_surface_class) )
+        ; ( "tool_requirement"
+          , `String
+              (Keeper_agent_tool_surface.tool_requirement_to_string
+                 tool_surface.tool_requirement) )
+        ; "visible_tool_count", `Int tool_surface.visible_tool_count
+        ; "tool_gate_enabled", `Bool tool_surface.tool_gate_enabled
+        ; "tool_surface_fallback_used", `Bool tool_surface.tool_surface_fallback_used
+        ; "required_tool_names", string_list_json tool_surface.required_tool_names
+        ; ( "required_tool_candidate_names"
+          , string_list_json tool_surface.required_tool_candidate_names )
+        ; ( "missing_required_tool_names"
+          , string_list_json tool_surface.missing_required_tool_names )
+        ; "config_root", `String tool_surface.config_root
+        ])
+    Keeper_runtime_manifest.Tool_surface_selected
+;;

--- a/lib/keeper/keeper_agent_run_manifest_helpers.mli
+++ b/lib/keeper/keeper_agent_run_manifest_helpers.mli
@@ -1,0 +1,40 @@
+(** Runtime-manifest append helpers for {!Keeper_agent_run}. *)
+
+type append_manifest =
+  ?status:string ->
+  ?decision:Yojson.Safe.t ->
+  ?keeper_turn_id:int ->
+  ?oas_turn_count:int ->
+  ?checkpoint_path:string ->
+  ?receipt_path:string ->
+  site:string ->
+  Keeper_runtime_manifest.event_kind ->
+  unit
+
+val append_checkpoint_start_events :
+  append_manifest:append_manifest ->
+  keeper_turn_id:int ->
+  checkpoint_path:string ->
+  loaded_checkpoint_present:bool ->
+  pre_dispatch_compacted:bool ->
+  pre_dispatch_checkpoint_error:Agent_sdk.Error.sdk_error option ->
+  unit
+
+val append_context_injected :
+  append_manifest:append_manifest ->
+  keeper_turn_id:int ->
+  base_system_prompt:string ->
+  turn_system_prompt:string ->
+  dynamic_context:string ->
+  memory_context:string ->
+  temporal_context:string ->
+  user_message:string ->
+  history_messages:Agent_sdk.Types.message list ->
+  estimated_input_tokens:int ->
+  unit
+
+val append_tool_surface_selected :
+  append_manifest:append_manifest ->
+  keeper_turn_id:int ->
+  Keeper_agent_tool_surface.tool_surface_metrics ->
+  unit

--- a/lib/keeper/keeper_agent_run_turn_helpers.ml
+++ b/lib/keeper/keeper_agent_run_turn_helpers.ml
@@ -227,3 +227,44 @@ let turn_progress_callbacks ~config ~keeper_name ~downstream =
   in
   let on_event = Some (registry_progress_on_event ~record_turn_progress downstream) in
   (record_turn_progress, yield_on_tool, on_yield, on_resume, on_event)
+
+let record_wake_payload_if_enabled ~meta ~trace_id ~start_turn_count ~max_context
+    ~pre_dispatch_compacted ~turn_system_prompt ~tools ~history_messages ~user_message =
+  if Env_config_keeper.KeeperTelemetry.payload_telemetry_enabled () then
+    try
+      let sizes =
+        Keeper_wake_telemetry.compute_sizes
+          ~system_prompt:turn_system_prompt
+          ~tools
+          ~history_messages
+          ~user_message
+      in
+      let model_id =
+        match Keeper_model_labels.configured_model_labels_of_meta meta with
+        | m :: _ -> m
+        | [] -> "auto"
+      in
+      let _event : Dashboard_harness_health.wake_payload_event =
+        Dashboard_harness_health.record_wake_payload
+          ~keeper_name:meta.name
+          ~trace_id
+          ~turn_index:start_turn_count
+          ~model_id
+          ~context_window:max_context
+          ~approx_body_bytes:sizes.approx_body_bytes
+          ~system_prompt_bytes:sizes.system_prompt_bytes
+          ~tool_defs_bytes:sizes.tool_defs_bytes
+          ~messages_bytes:sizes.messages_bytes
+          ~message_count:sizes.message_count
+          ~role_counts:sizes.role_counts
+          ~tool_count:sizes.tool_count
+          ~has_compact_happened:pre_dispatch_compacted
+      in
+      ()
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+        Log.Harness.warn
+          "[wake_payload] telemetry failed keeper=%s: %s"
+          meta.name
+          (Printexc.to_string exn)

--- a/lib/keeper/keeper_agent_run_turn_helpers.mli
+++ b/lib/keeper/keeper_agent_run_turn_helpers.mli
@@ -81,3 +81,15 @@ val turn_progress_callbacks :
   * (unit -> unit) option
   * (unit -> unit) option
   * (Agent_sdk.Types.sse_event -> unit) option
+
+val record_wake_payload_if_enabled :
+  meta:Keeper_types.keeper_meta ->
+  trace_id:string ->
+  start_turn_count:int ->
+  max_context:int ->
+  pre_dispatch_compacted:bool ->
+  turn_system_prompt:string ->
+  tools:Agent_sdk.Tool.t list ->
+  history_messages:Agent_sdk.Types.message list ->
+  user_message:string ->
+  unit


### PR DESCRIPTION
## Summary
- stack on #16347 and split Keeper_agent_run runtime-manifest append payload helpers into Keeper_agent_run_manifest_helpers
- preserve run_turn behavior while moving checkpoint/context/tool-surface manifest JSON construction out of the godfile
- reduce keeper_agent_run.ml from 2040 to 1978 LOC, removing it from the 2000+ bucket on this stack

## Verification
- ocamlformat --check lib/keeper/keeper_agent_run.ml lib/keeper/keeper_agent_run_manifest_helpers.ml lib/keeper/keeper_agent_run_manifest_helpers.mli lib/keeper/keeper_agent_run_contract_helpers.ml lib/keeper/keeper_agent_run_contract_helpers.mli
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- bash scripts/lint/godfile-size-regression.sh
- MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build lib/masc_mcp.cmxa: not run to completion; wrapper waited on /tmp/me-dune-local.lock held by another session (verify-16311-on-16289-20260519 scripts/dune-local.sh build test/test_tool_worktree_coverage.exe), then I stopped my waiting lockf