### PR TITLE
fix(dashboard): cover stay_silent_loop runtime blocker class

### DIFF
--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -213,6 +213,7 @@ const runtimeBlockerLabels = {
   supervisor_paused: 'Supervisor 일시정지',
   synthetic_stall: '합성 상태 정체',
   self_imposed_idle: '자체 대기',
+  stay_silent_loop: 'Stay-silent 루프',
   sdk_max_turns_exceeded: 'SDK 최대 턴 초과',
   sdk_token_budget_exceeded: 'SDK 토큰 예산 초과',
   sdk_cost_budget_exceeded: 'SDK 비용 예산 초과',
@@ -308,6 +309,11 @@ export function keeperRuntimeBlockerHint(keeper: Keeper | null | undefined): str
   }
   if (blockerClass === 'self_imposed_idle') {
     return 'Keeper가 관찰 또는 대기만 계획하고 있어 다음 실행 지시가 필요할 수 있습니다.'
+  }
+  if (blockerClass === 'stay_silent_loop') {
+    // keeper_unified_turn_stay_silent.ml: consecutive silent turns above
+    // threshold latched the blocker. Auto-clears on first non-silent turn.
+    return 'Keeper가 연속으로 빈 응답을 내고 있어 정지된 것 같습니다. 다음 실제 응답이 나오면 자동 해제됩니다.'
   }
   return null
 }

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -409,6 +409,11 @@ export const KEEPER_RUNTIME_BLOCKER_CLASSES = [
   'supervisor_paused',
   'synthetic_stall',
   'self_imposed_idle',
+  // Emitted by `lib/keeper/keeper_unified_turn_stay_silent.ml:76` when
+  // a keeper produces consecutive silent turns above the configured
+  // threshold. Serialized via
+  // `keeper_meta_contract.ml:147 blocker_class_to_string Stay_silent_loop`.
+  'stay_silent_loop',
   'sdk_max_turns_exceeded',
   'sdk_token_budget_exceeded',
   'sdk_cost_budget_exceeded',


### PR DESCRIPTION
## 요약

Backend 가 `runtime_blocker_class: \"stay_silent_loop\"` 를 emit 하지만 dashboard 타입 union 에 누락 — 운영자가 keeper 가 silent-loop 블록 상태일 때 Korean 라벨 또는 hint 메시지를 받지 못함. 32/33 coverage 가 33/33 으로 완결.

## 측정된 근거

| 위치 | 내용 |
|------|------|
| `lib/keeper/keeper_unified_turn_stay_silent.ml:76` | `Keeper_types.Stay_silent_loop` blocker 부여 |
| `lib/keeper/keeper_meta_contract.ml:147` | `Stay_silent_loop -> \"stay_silent_loop\"` wire format |
| `lib/keeper/keeper_status_bridge.ml:316, 347` | bridge 가 이 클래스 routing |
| `lib/keeper/keeper_unified_turn_stay_silent.ml:81-99 clear_if_recovered` | first non-silent turn 시 자동 해제 |
| `dashboard/src/types/core.ts:387-421 KEEPER_RUNTIME_BLOCKER_CLASSES` | **`stay_silent_loop` 누락** (32/33) |

## 영향

- `runtimeBlockerLabels[blockerClass]` → `undefined` → null label 표시.
- `keeperRuntimeBlockerHint(blockerClass)` switch arms 미일치 → null hint 표시.
- 운영자가 raw `stay_silent_loop` 영문 토큰만 보고 의미/회복 조건 파악 불가.

## 변경

1. `core.ts:411` — `KEEPER_RUNTIME_BLOCKER_CLASSES` 에 `stay_silent_loop` 추가 (backend emit site 인용 코멘트 포함).
2. `keeper-runtime-display.ts:216` — Korean 라벨 `'Stay-silent 루프'`.
3. `keeper-runtime-display.ts:313` — `keeperRuntimeBlockerHint` 새 arm: silent-streak 조건 + auto-recovery 동작 설명.

## 검증

\`\`\`
$ pnpm typecheck                                              → clean
  (\`satisfies Record<KeeperRuntimeBlockerClass, string>\` 가
   라벨 누락 시 컴파일 실패하는 sentinel — 통과.)
$ pnpm vitest run src/lib/keeper-runtime-display.test.ts
                  src/lib/runtime-blocker-class.test.ts        → 40/40
\`\`\`

## Related

본 세션 FSM/TLA-misrepresentation 스레드의 8번째 PR. #16312/#16327/#16333/#16343/#16348 (각각 다른 state 축의 동일 SSOT 패턴 봉합) + #16316 RFC-0132 (구조적 closure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)