### PR TITLE
feat(keeper): surface tool-result compaction reasons in stub + counter

### DIFF
--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -815,8 +815,34 @@ let sanitize_checkpoint_message
                 || kept_tool_result_chars + tool_chars
                    > default_max_checkpoint_tool_result_total_chars
              then
-               (* Over count or aggregate budget: stub the result *)
-               let stub_content = "[tool result cleared]" in
+               (* Over count or aggregate byte budget: stub the result.
+                  The two triggers are split into separate [reason]
+                  labels (and named in [stub_content]) so operators
+                  reading the Prometheus rate or inspecting a stubbed
+                  checkpoint know which cap to revisit, and so an
+                  LLM that later reads the checkpoint can tell that a
+                  payload was removed (and why) rather than silently
+                  reasoning over the placeholder. *)
+               let stub_reason =
+                 if kept_tool_results
+                    >= default_max_checkpoint_tool_results_per_message
+                 then "over_count"
+                 else "over_aggregate_bytes"
+               in
+               let stub_content =
+                 Printf.sprintf
+                   "[tool result cleared: reason=%s tool_use_id=%s \
+                    original_bytes=%d; removed by \
+                    Keeper_context_core.sanitize_checkpoint_message \
+                    to fit checkpoint budget]"
+                   stub_reason
+                   tool_use_id
+                   tool_chars
+               in
+               Prometheus.inc_counter
+                 Prometheus.metric_keeper_context_tool_result_compacted
+                 ~labels:[ "action", "stubbed"; "reason", stub_reason ]
+                 ();
                let stub =
                  Agent_sdk.Types.ToolResult
                    { tool_use_id;
@@ -834,7 +860,15 @@ let sanitize_checkpoint_message
                      dropped_chars = tool_chars } )
              else if tool_chars > default_max_checkpoint_tool_result_chars
              then
-               (* Individual result too large: truncate *)
+               (* Individual result too large: truncate.  The cap
+                  marker already advertises truncation in the content
+                  itself; the counter increment is what surfaces the
+                  rate to operators without log scraping. *)
+               Prometheus.inc_counter
+                 Prometheus.metric_keeper_context_tool_result_compacted
+                 ~labels:
+                   [ "action", "truncated"; "reason", "over_single_byte" ]
+                 ();
                let capped =
                  String.sub content 0
                    default_max_checkpoint_tool_result_chars

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -202,6 +202,19 @@ let metric_oas_bridge_unmigrated_payload_kind =
 let metric_cascade_attempt_empty_provider_label =
   "masc_cascade_attempt_empty_provider_label_total"
 ;;
+
+(* Per-tool-result compaction events emitted by
+   [Keeper_context_core.sanitize_checkpoint_message] when a tool
+   result exceeds the per-message count cap, the aggregate byte
+   budget, or its own single-result byte cap.  Labels are
+   closed-vocabulary so cardinality is bounded:
+     action  = stubbed | truncated
+     reason  = over_count | over_aggregate_bytes | over_single_byte
+   The [stubbed] action replaces the content entirely with a marker
+   string; [truncated] caps the content and appends a marker. *)
+let metric_keeper_context_tool_result_compacted =
+  "masc_keeper_context_tool_result_compacted_total"
+;;
 let metric_runtime_ollama_probe_generate_skips =
   "masc_runtime_ollama_probe_generate_skips_total"
 ;;

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -228,6 +228,27 @@ val metric_oas_bridge_unmigrated_payload_kind : string
     call site and pass a real provider through. *)
 val metric_cascade_attempt_empty_provider_label : string
 
+(** Counter: tool-result blocks compacted by
+    [Keeper_context_core.sanitize_checkpoint_message] because the
+    raw content would have exceeded a budget.  Labels are
+    closed-vocabulary (cardinality 6):
+
+    - [action] = [stubbed | truncated].
+      [stubbed] replaces the content with a marker string so the
+      block contributes essentially zero bytes; [truncated] keeps a
+      prefix and appends a cap marker.
+    - [reason] = [over_count | over_aggregate_bytes | over_single_byte].
+      [over_count] = per-message tool-result count cap reached.
+      [over_aggregate_bytes] = adding this result would exceed the
+      cumulative tool-result byte budget for the message.
+      [over_single_byte] = this single result exceeds the per-result
+      byte cap.
+
+    A persistent non-zero rate means operators are losing tool-result
+    payload at checkpoint time; the [reason] label tells them which
+    cap to revisit (per-result vs aggregate vs count). *)
+val metric_keeper_context_tool_result_compacted : string
+
 val metric_runtime_ollama_probe_generate_skips : string
 
 (** #9632: subprocess executions that exceeded their configured

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -1838,8 +1838,17 @@ let test_sanitize_checkpoint_message_caps_tool_result_aggregate_budget () =
              (contains_substring first KCC.checkpoint_text_cap_marker);
            check bool "second tool result truncated" true
              (contains_substring second KCC.checkpoint_text_cap_marker);
-           check string "aggregate overflow gets stubbed"
-             "[tool result cleared]" third
+           (* The stubbed payload carries the compaction reason and
+              the originating [tool_use_id] so an LLM reading the
+              checkpoint later (and an operator scanning the log)
+              knows the placeholder is intentional and which cap
+              tripped it. *)
+           check bool "aggregate overflow gets stubbed" true
+             (contains_substring third "[tool result cleared:");
+           check bool "stub names the over-aggregate-bytes reason" true
+             (contains_substring third "reason=over_aggregate_bytes");
+           check bool "stub preserves tool_use_id for traceability" true
+             (contains_substring third "tool_use_id=tool-agg-3")
        | _ -> fail "expected three ToolResult blocks after aggregate cap");
       check int "aggregate cap records truncated blocks" 2
         stats.truncated_blocks;


### PR DESCRIPTION
## 목표

`Keeper_context_core.sanitize_checkpoint_message`는 checkpoint 시점에 tool-result 블록을 세 가지 cap에서 compact한다 (per-msg count cap / aggregate byte budget / single-result byte cap). 기존 동작은 정상이지만 *왜·무엇이·얼마나 자주* compaction되는지가 stub 자체와 fleet metric 두 layer 모두에서 안 보였다.

| 누락된 정보 | 영향 |
|---|---|
| *Why* (over_count vs over_aggregate_bytes를 OR로 묶음) | operator가 어느 cap을 tune할지 모름 |
| *Which* (`tool_use_id`가 스코프엔 있는데 stub 메시지엔 누락) | 어떤 tool result가 사라졌는지 추적 불가 |
| *How often* (fleet-wide rate) | aggregate stats만 있고 Prometheus surface 0 |
| LLM 가시성 | `"[tool result cleared]"` 5단어 marker → LLM이 placeholder의 의미를 모르고 hallucinate 위험 |

본 PR은 compaction 동작 자체는 *건드리지 않고* 세 신호를 추가한다.

`★ 워크어라운드 거부 기준 self-check ─────────────────`
이 PR은 기존 compaction(의도된 budget enforcement)을 *제거하지 않고* 가시성을 추가. counter는 alert/fix가 아니라 *진단 정보*. cardinality는 closed-vocab labels로 6에 묶임. Iter#1 PR #16330과 같은 observability-addition 패턴. 통과.
`─────────────────────────────────────────────────`

## 변경 파일

| 파일 | 변경 |
|---|---|
| `lib/prometheus.{ml,mli}` | 새 counter `metric_keeper_context_tool_result_compacted` |
| `lib/keeper/keeper_context_core.ml` | 3 사이트에서 `Prometheus.inc_counter` + stub_content를 `Printf` 포맷으로 강화 (reason / tool_use_id / original_bytes). over_count vs over_aggregate_bytes를 separate label로 split |
| `test/test_keeper_lifecycle.ml` | `test_sanitize_checkpoint_message_caps_tool_result_aggregate_budget`가 새 stub contract 검증 (prefix + reason + tool_use_id) |

총: 4 files, +83 / -5.

## Operator / LLM 시야 (Before / After)

**Before** — checkpoint message에 tool_result가 aggregate cap 초과:
```
ToolResult { tool_use_id="tool-abc"; content="[tool result cleared]"; ... }
```
+ stats: `dropped_blocks=1, dropped_chars=190000`
- Prometheus: 0 metric
- LLM: marker가 무엇을 의미하는지 모름 → 빈 결과로 reasoning
- Operator: stats만 보고는 어느 cap이 트리거인지 모름

**After**:
```
ToolResult { tool_use_id="tool-abc";
             content="[tool result cleared: reason=over_aggregate_bytes \
                      tool_use_id=tool-abc original_bytes=190000; \
                      removed by Keeper_context_core.sanitize_checkpoint_message \
                      to fit checkpoint budget]"; ... }
```
+ `masc_keeper_context_tool_result_compacted_total{action="stubbed",reason="over_aggregate_bytes"}` += 1
- LLM: marker가 budget compaction임을 인지 + 원래 payload 크기 알 수 있음
- Operator: counter rate로 fleet-wide compaction 빈도 + reason label로 어느 cap 튜닝할지 즉시 식별

## Cardinality

| label | 값 | cardinality |
|---|---|---|
| `action` | `stubbed` \| `truncated` | 2 |
| `reason` | `over_count` \| `over_aggregate_bytes` \| `over_single_byte` | 3 |
| total combinations | | 6 (one combo currently unreachable — `truncated` × `over_count`는 발생 불가) |

closed vocab — 새 reason은 코드 변경 시 명시적 추가, 자유 string 입력 없음.

## 로컬 검증

- `ocamlformat --check` PASS (4/4)
- 기존 `test_sanitize_checkpoint_message_caps_tool_result_aggregate_budget`이 새 contract pin (위 3 assertions)
- `dune build @check` — origin/main이 #16289로 broken. Iter#1 #16330 / Iter#2 #16344 과 동일 blocker. ocamlformat + manual sibling-pattern 검증으로 진행
- `Provider_tool_support.capabilities` 5개 field가 dummy_caps에 정확히 매칭 (해당 PR 아님 - Iter#2 컨텍스트)

## 미검증

- [ ] Full `dune build @check` (#16289 머지 후 재검증)
- [ ] 다른 compaction site (예: `tool_result_text_of_block`이 `[tool:` prefix로 별도 projection) — 별도 PR 대상, sanitize path만 본 iter scope
- [ ] Dashboard surface (Iter#1 follow-on issue #16345 — SSE consumer 자체 미구현)

## RFC

`bash ~/me/scripts/pr-rfc-check.sh` PASS — keeper context core compaction은 boundary subsystem (credential/identity/operator/sandbox/dashboard credential) 아님. RFC waiver 불필요.

## 참고

같은 /loop의 Iter#1 PR #16330 (cascade observability), Iter#2 PR #16344 (cascade typed profile lookup)과 같은 observability-addition 시리즈.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>