### PR TITLE
fix(ci): refresh spawn-bounded allowlist for worker_dev_tools.ml

### DIFF
--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -31,7 +31,7 @@ lib/process/process_eio.ml:493
 # manager itself. Bounded by session scope, not by per-call timeout.
 lib/server/lsp_process_manager.ml:178
 
-# lib/worker_dev_tools.ml:1941 — dev-tools worker spawn. Wrapped by
+# lib/worker_dev_tools.ml:1816 — dev-tools worker spawn. Wrapped by
 # Tool_resource_gate, Fd_accountant, Eio.Time.with_timeout_exn, and a fresh
 # Eio.Switch.run at the call boundary.
-lib/worker_dev_tools.ml:1941
+lib/worker_dev_tools.ml:1816


### PR DESCRIPTION
## Summary

`lib/worker_dev_tools.ml` shrank after recent godfile splits. The `Eio.Process.spawn` site at line 1941 moved to line 1816, so the **Spawn-bounded ratchet** now reports both stale and new entries on every PR's CI.

One-line allowlist refresh (no code change). Unblocks every open PR currently failing this check.

## Product impact

The spawn site is semantically unchanged: still wrapped by `Fd_accountant.with_slot ~kind:Sandbox_exec` → `Eio.Time.with_timeout_exn clock timeout` → `Eio.Switch.run`, which satisfies bound condition (b) per `scripts/lint-spawn-bounded.sh`. Only the line number drifted because the file shrunk during recent splits.

The failing PRs include at least:
- #16323 (RFC-0131 facade RFC)
- #16335 (PR-1a caller tag)
- #16340 (PR-1b nested-pipeline reject)
- #16346 (PR-1c redirect policy)
- #16330 (FSM/TLA+ sweep cascade_event_bridge — separate /loop)

## Evidence

```
$ gh run view 26048113627 --log-failed | tail -10
lint-spawn-bounded: NEW spawn site(s) without allowlist entry:
  lib/worker_dev_tools.ml:1816
lint-spawn-bounded: STALE allowlist entry/entries (no longer matches a spawn line):
  lib/worker_dev_tools.ml:1941
```

```
$ git diff scripts/lint-spawn-bounded.allowlist
-# lib/worker_dev_tools.ml:1941 — dev-tools worker spawn. Wrapped by
+# lib/worker_dev_tools.ml:1816 — dev-tools worker spawn. Wrapped by
-lib/worker_dev_tools.ml:1941
+lib/worker_dev_tools.ml:1816
```

## Review evidence

```
$ bash scripts/lint-spawn-bounded.sh
lint-spawn-bounded: PASS (5 spawn site(s), all in allowlist)
```

Spawn site context (showing the bounded primitive wrap):

```ocaml
Fd_accountant.with_slot ~kind:Sandbox_exec (fun () ->
  Eio.Time.with_timeout_exn clock timeout (fun () ->
    Eio.Switch.run
    @@ fun sw ->
    let stdout_r, stdout_w = Eio.Process.pipe ~sw proc_mgr in
    let proc =
      Eio.Process.spawn      (* line 1816 — bounded by all three wraps above *)
        ~sw proc_mgr ~stdout:stdout_w
        [ "sh"; "-c"; wrapped_command ^ " 2>&1" ]
    in ...
```

## Linked issue

Recurring pattern: per CLAUDE.md feedback `feedback_workdir_grep_must_cross_check_origin_main`, allowlists tied to file:line should be refreshed during godfile splits. Consider adding a CI step that updates the allowlist atomically during refactor PRs in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)