### PR TITLE
refactor: split keeper heartbeat liveness pulse

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -208,6 +208,7 @@
   keeper_turn_lifecycle
   keeper_msg_async
   keeper_event_bus
+  keeper_heartbeat_liveness_pulse
   keeper_supervisor_alive_but_stuck
   keeper_supervisor_liveness_recovery
   keeper_supervisor_restart_noop

--- a/lib/keeper/keeper_heartbeat_liveness_pulse.ml
+++ b/lib/keeper/keeper_heartbeat_liveness_pulse.ml
@@ -1,0 +1,113 @@
+open Keeper_types
+
+let in_turn_liveness_pulse_interval_sec () =
+  max 5.0 (min 30.0 (float_of_int (Keeper_heartbeat_snapshot.keepalive_interval_sec ())))
+;;
+
+let with_in_turn_liveness_pulse_for_test ~sw:_sw ~clock ~interval_sec ~tick f =
+  let interval_sec = max 0.001 interval_sec in
+  Eio.Switch.run (fun pulse_sw ->
+    let pulse_stop = Atomic.make false in
+    let pulse_cancel = ref None in
+    let stop_pulse () =
+      Atomic.set pulse_stop true;
+      match !pulse_cancel with
+      | None -> ()
+      | Some cc ->
+        (try Eio.Cancel.cancel cc (Failure "in_turn_liveness_pulse_stop") with
+         | Eio.Cancel.Cancelled _ -> ()
+         | Invalid_argument _ -> ())
+    in
+    Eio.Switch.on_release pulse_sw stop_pulse;
+    Eio.Fiber.fork ~sw:pulse_sw (fun () ->
+      try
+        Eio.Cancel.sub (fun cc ->
+          pulse_cancel := Some cc;
+          let rec loop () =
+            if not (Atomic.get pulse_stop)
+            then (
+              Eio.Time.sleep clock interval_sec;
+              if not (Atomic.get pulse_stop)
+              then
+                (try tick () with
+                 | Eio.Cancel.Cancelled _ as e -> raise e
+                 | exn ->
+                   Log.Keeper.warn
+                     "in-turn liveness pulse failed: %s"
+                     (Printexc.to_string exn);
+                   Prometheus.inc_counter
+                     Keeper_metrics.metric_keeper_heartbeat_failures
+                     ~labels:[ "keeper", "liveness_pulse"; "phase", "pulse_tick" ]
+                     ());
+              loop ())
+          in
+          loop ())
+      with
+      | Eio.Cancel.Cancelled _ -> ());
+    match f () with
+    | result ->
+      stop_pulse ();
+      result
+    | exception exn ->
+      let backtrace = Printexc.get_raw_backtrace () in
+      stop_pulse ();
+      Printexc.raise_with_backtrace exn backtrace)
+;;
+
+let emit_in_turn_liveness_pulse ~(ctx : _ context) ~(meta : keeper_meta) =
+  match Keeper_registry.get ~base_path:ctx.config.base_path meta.name with
+  | Some entry when Option.is_some entry.current_turn_observation ->
+    (try
+       let _heartbeat = Coord.heartbeat ctx.config ~agent_name:meta.agent_name in
+       ()
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+       Log.Keeper.warn
+         "in-turn heartbeat failed for %s: %s"
+         meta.name
+         (Printexc.to_string exn);
+       Prometheus.inc_counter
+         Keeper_metrics.metric_keeper_heartbeat_failures
+         ~labels:[ "keeper", meta.name; "phase", "in_turn_heartbeat" ]
+         ());
+    let now_ts = Time_compat.now () in
+    (try
+       let json =
+         `Assoc
+           [ "type", `String "keeper_heartbeat"
+           ; "name", `String meta.name
+           ; "generation", `Int meta.runtime.generation
+           ; "ts_unix", `Float now_ts
+           ; "phase", `String "turn_running"
+           ; "in_turn", `Bool true
+           ]
+       in
+       Sse.broadcast json;
+       Sse.broadcast_presence json
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+       Prometheus.inc_counter
+         Keeper_metrics.metric_keeper_sse_broadcast_failures
+         ~labels:[ "keeper", meta.name ]
+         ();
+       Log.Keeper.error
+         "in-turn heartbeat SSE broadcast failed: %s"
+         (Printexc.to_string exn))
+  | _ -> ()
+;;
+
+let with_in_turn_liveness_pulse
+      ~(ctx : _ context)
+      ~(meta : keeper_meta)
+      ~(stop : bool Atomic.t)
+      f
+  =
+  with_in_turn_liveness_pulse_for_test
+    ~sw:ctx.sw
+    ~clock:ctx.clock
+    ~interval_sec:(in_turn_liveness_pulse_interval_sec ())
+    ~tick:(fun () -> if not (Atomic.get stop) then emit_in_turn_liveness_pulse ~ctx ~meta)
+    f
+;;

--- a/lib/keeper/keeper_heartbeat_liveness_pulse.mli
+++ b/lib/keeper/keeper_heartbeat_liveness_pulse.mli
@@ -1,0 +1,20 @@
+open Keeper_types
+
+val in_turn_liveness_pulse_interval_sec : unit -> float
+
+val with_in_turn_liveness_pulse_for_test :
+  sw:Eio.Switch.t ->
+  clock:'a Eio.Time.clock ->
+  interval_sec:float ->
+  tick:(unit -> unit) ->
+  (unit -> 'b) ->
+  'b
+
+val emit_in_turn_liveness_pulse :
+  ctx:'a context -> meta:keeper_meta -> unit
+
+val with_in_turn_liveness_pulse :
+  ctx:'a context ->
+  meta:keeper_meta ->
+  stop:bool Atomic.t ->
+  (unit -> 'b) -> 'b

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -10,6 +10,8 @@ open Keeper_memory
 open Keeper_execution
 open Keeper_keepalive_signal
 
+module Liveness_pulse = Keeper_heartbeat_liveness_pulse
+
 let effective_keepalive_meta
       ~base_path
       ~(fallback : keeper_meta)
@@ -247,117 +249,16 @@ let collect_keepalive_board_events
     pending_board_events, meta_current)
 ;;
 
-let in_turn_liveness_pulse_interval_sec () =
-  max 5.0 (min 30.0 (float_of_int (Keeper_heartbeat_snapshot.keepalive_interval_sec ())))
+let in_turn_liveness_pulse_interval_sec =
+  Liveness_pulse.in_turn_liveness_pulse_interval_sec
 ;;
 
-let with_in_turn_liveness_pulse_for_test ~sw:_sw ~clock ~interval_sec ~tick f =
-  let interval_sec = max 0.001 interval_sec in
-  Eio.Switch.run (fun pulse_sw ->
-    let pulse_stop = Atomic.make false in
-    let pulse_cancel = ref None in
-    let stop_pulse () =
-      Atomic.set pulse_stop true;
-      match !pulse_cancel with
-      | None -> ()
-      | Some cc ->
-        (try Eio.Cancel.cancel cc (Failure "in_turn_liveness_pulse_stop") with
-         | Eio.Cancel.Cancelled _ -> ()
-         | Invalid_argument _ -> ())
-    in
-    Eio.Switch.on_release pulse_sw stop_pulse;
-    Eio.Fiber.fork ~sw:pulse_sw (fun () ->
-      try
-        Eio.Cancel.sub (fun cc ->
-          pulse_cancel := Some cc;
-          let rec loop () =
-            if not (Atomic.get pulse_stop)
-            then (
-              Eio.Time.sleep clock interval_sec;
-              if not (Atomic.get pulse_stop)
-              then
-                (try tick () with
-                 | Eio.Cancel.Cancelled _ as e -> raise e
-                 | exn ->
-                   Log.Keeper.warn
-                     "in-turn liveness pulse failed: %s"
-                     (Printexc.to_string exn);
-                   Prometheus.inc_counter
-                     Keeper_metrics.metric_keeper_heartbeat_failures
-                     ~labels:[ "keeper", "liveness_pulse"; "phase", "pulse_tick" ]
-                     ());
-              loop ())
-          in
-          loop ())
-      with
-      | Eio.Cancel.Cancelled _ -> ());
-    match f () with
-    | result ->
-      stop_pulse ();
-      result
-    | exception exn ->
-      let backtrace = Printexc.get_raw_backtrace () in
-      stop_pulse ();
-      Printexc.raise_with_backtrace exn backtrace)
+let with_in_turn_liveness_pulse_for_test =
+  Liveness_pulse.with_in_turn_liveness_pulse_for_test
 ;;
 
-let emit_in_turn_liveness_pulse ~(ctx : _ context) ~(meta : keeper_meta) =
-  match Keeper_registry.get ~base_path:ctx.config.base_path meta.name with
-  | Some entry when Option.is_some entry.current_turn_observation ->
-    (try
-       let _heartbeat = Coord.heartbeat ctx.config ~agent_name:meta.agent_name in
-       ()
-     with
-     | Eio.Cancel.Cancelled _ as e -> raise e
-     | exn ->
-       Log.Keeper.warn
-         "in-turn heartbeat failed for %s: %s"
-         meta.name
-         (Printexc.to_string exn);
-       Prometheus.inc_counter
-         Keeper_metrics.metric_keeper_heartbeat_failures
-         ~labels:[ "keeper", meta.name; "phase", "in_turn_heartbeat" ]
-         ());
-    let now_ts = Time_compat.now () in
-    (try
-       let json =
-         `Assoc
-           [ "type", `String "keeper_heartbeat"
-           ; "name", `String meta.name
-           ; "generation", `Int meta.runtime.generation
-           ; "ts_unix", `Float now_ts
-           ; "phase", `String "turn_running"
-           ; "in_turn", `Bool true
-           ]
-       in
-       Sse.broadcast json;
-       Sse.broadcast_presence json
-     with
-     | Eio.Cancel.Cancelled _ as e -> raise e
-     | exn ->
-       Prometheus.inc_counter
-         Keeper_metrics.metric_keeper_sse_broadcast_failures
-         ~labels:[ "keeper", meta.name ]
-         ();
-       Log.Keeper.error
-         "in-turn heartbeat SSE broadcast failed: %s"
-         (Printexc.to_string exn))
-  | _ -> ()
-;;
-
-let with_in_turn_liveness_pulse
-      ~(ctx : _ context)
-      ~(meta : keeper_meta)
-      ~(stop : bool Atomic.t)
-      f
-  =
-  with_in_turn_liveness_pulse_for_test
-    ~sw:ctx.sw
-    ~clock:ctx.clock
-    ~interval_sec:(in_turn_liveness_pulse_interval_sec ())
-    ~tick:(fun () -> if not (Atomic.get stop) then emit_in_turn_liveness_pulse ~ctx ~meta)
-    f
-;;
+let emit_in_turn_liveness_pulse = Liveness_pulse.emit_in_turn_liveness_pulse
+let with_in_turn_liveness_pulse = Liveness_pulse.with_in_turn_liveness_pulse
 
 type semaphore_wait_observation_kind =
   | Semaphore_wait_pending


### PR DESCRIPTION
## Summary
- split in-turn heartbeat liveness pulse helpers into Keeper_heartbeat_liveness_pulse
- keep Keeper_heartbeat_loop public functions as aliases for compatibility
- reduce keeper_heartbeat_loop.ml from 2039 to 1940 LOC

## Validation
- ocamlformat --check lib/keeper/keeper_heartbeat_loop.ml lib/keeper/keeper_heartbeat_liveness_pulse.ml lib/keeper/keeper_heartbeat_liveness_pulse.mli
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- bash scripts/lint/godfile-size-regression.sh
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build lib/masc_mcp.cmxa (blocked by current base: lib/prometheus.ml:262 Unbound value metric_key)