### PR TITLE
feat(keeper): name FSM violations + split classifier-gap from initial transition

### DIFF
--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -272,18 +272,36 @@ let guard_transition ?ctx ~keeper_name ~turn_id ~from_state ~to_state () =
   match assert_transition_allowed ?ctx ~from_state ~to_state () with
   | Ok _ -> ()
   | Error violation ->
-      (* Log first: [wrap_unit] catches [Assert_failure] only to bump the
-         Prometheus counter, then re-raises. Anything sequenced after
-         [wrap_unit] would never run, so the diagnostic warn has to
-         precede it for operators to see *which* transition violated. *)
+      (* Log first: [wrap_unit] catches the raised exception only to
+         bump the Prometheus counter, then re-raises. Anything
+         sequenced after [wrap_unit] would never run, so the
+         diagnostic warn has to precede it for operators to see
+         *which* transition violated. *)
       Log.Keeper.warn ~keeper_name ~turn_id
         "[fsm:transition:violation] %s -> %s (%s)"
         violation.from_state violation.to_state violation.reason;
       let stage = violation.from_state ^ "->" ^ violation.to_state in
+      (* [Invalid_argument] (not [assert false]) carries an explicit
+         message into the re-raise backtrace.  Operators reading a
+         crash dump or test failure see the violating transition +
+         reason without having to cross-reference the WARN line by
+         keeper/turn id.  See [keeper_fsm_guard_runtime.mli] for the
+         "any escaping exception is the spec-violation channel"
+         contract that lets this be a plain exception rather than
+         the typed [Keeper_registry.Cascade_transition_violation]
+         (naming the typed exception here would form a module
+         dependency cycle). *)
+      let detail =
+        Printf.sprintf
+          "fsm:transition:violation keeper=%s turn=%s from=%s to=%s \
+           reason=%s"
+          keeper_name turn_id violation.from_state violation.to_state
+          violation.reason
+      in
       Keeper_fsm_guard_runtime.wrap_unit
         ~action:"KeeperTurnFSM.Next"
         ~stage
-        (fun () -> assert false)
+        (fun () -> invalid_arg detail)
 
 (* Per-keeper last-transition wallclock, used to record the dwell time
    spent in [prev] state when a transition fires. Single-domain Eio
@@ -328,10 +346,30 @@ let emit_transition ?ctx ~keeper_name ~turn_id ?prev state =
        guard_transition ?ctx ~keeper_name ~turn_id ~from_state ~to_state:state ()
    | None -> ());
   let state_label = turn_state_label state in
+  (* [action_label] used to be a single "unknown" sentinel for two
+     distinct cases:
+       1. [prev = None] — the first emit for a turn; there is no
+          [from_state] to classify against, so "initial" is the
+          accurate label.
+       2. [prev = Some _] with [classified = None] — the transition
+          is *allowed* (otherwise [guard_transition] would have
+          raised above) but {!classify_transition} has no arm for the
+          (from, to) pair, so the audit trail loses the action.
+          This is a *classifier gap* the operator can fix by adding
+          an arm; surface it as a separate label + WARN so it is
+          discoverable from the same log line as the transition. *)
   let action_label =
-    match classified with
-    | Some action -> transition_action_label action
-    | None -> "unknown"
+    match classified, prev with
+    | Some action, _ -> transition_action_label action
+    | None, None -> "initial"
+    | None, Some _ ->
+        Log.Keeper.warn ~keeper_name ~turn_id
+          "[fsm:transition:unclassified] %s -> %s — classify_transition \
+           has no arm for this (from, to) pair; add one in \
+           lib/keeper/keeper_turn_fsm.ml::classify_transition so the \
+           audit trail captures the action"
+          prev_label state_label;
+        "unclassified"
   in
   let stop_label =
     match ctx with


### PR DESCRIPTION
## 목표

`Keeper_turn_fsm`의 두 *operator-actionable* 케이스가 messageless / opaque로 collapsed:

1. **`guard_transition` violation: `assert false`** — Re-raised `Assert_failure ("...", line, col)`에 컨텍스트 0. WARN 로그는 있지만 crash dump / test failure 자체에는 violation 정보가 없어서 keeper+turn id로 cross-reference 필요.
2. **`emit_transition` action_label: `"unknown"`** — 두 다른 케이스를 한 sentinel로 압축:
   - `prev = None` (첫 emit, no transition to classify): 정상적인 케이스
   - `prev = Some _` + `classify_transition`이 해당 (from, to) pair에 arm 없음: *classifier gap* (operator가 fix 가능)
   둘이 합쳐져서 gap이 *invisible*.

`★ 워크어라운드 거부 기준 self-check ─────────────────`
이 PR은 silent-failure를 *제거*하고 두 distinct case를 split. 새 catch-all/string 분류기/cap/cooldown/dedup 도입 없음. 새 라벨("initial", "unclassified")은 closed-vocab 확장(코드 변경 필요). 통과.
`─────────────────────────────────────────────────`

## 변경 파일

| 파일 | 변경 |
|---|---|
| `lib/keeper/keeper_turn_fsm.ml` | (a) `assert false` → `invalid_arg detail` with keeper/turn/from/to/reason. wrap_unit이 여전히 catch+counter+re-raise — 동작 동일, 메시지만 추가. (b) `action_label`을 `Some _` / `None,None` / `None,Some _` 3-way split. 마지막 케이스에 WARN log + 정확한 file:function migration target. |

1 file, +46 / −8. `.mli` 변경 없음 (signature preserved).

## Operator 시야 (Before / After)

**Before** (violation crash dump):
```
Fatal error: exception Assert_failure("lib/keeper/keeper_turn_fsm.ml", 286, 17)
```
→ 어떤 transition이 어떤 keeper에서 깨졌는지 backtrace에 없음. WARN 로그를 같은 시각으로 cross-reference 필요.

**After**:
```
Fatal error: exception Invalid_argument(
  "fsm:transition:violation keeper=nicholas turn=t-42 from=Phase_gating \
   to=Stop_signal_seen reason=stop_signal received in non-final state")
```
→ 단일 예외 메시지에 모든 컨텍스트.

**Before** (classifier gap — operator는 발생 자체를 모름):
```
[fsm:transition] Idle -> Running action=unknown
```
→ "unknown"이 첫 emit 때문인지 classifier gap 때문인지 모름.

**After**:
```
[fsm:transition:unclassified] Idle -> Running — classify_transition has no arm \
for this (from, to) pair; add one in \
lib/keeper/keeper_turn_fsm.ml::classify_transition so the audit trail captures \
the action
[fsm:transition] Idle -> Running action=unclassified
```
→ Operator는 (a) 어디서 case 추가해야 하는지 즉시 식별 + (b) Prometheus `action="unclassified"` 라벨로 fleet-wide gap 빈도 measurable.

## Vocabulary

| label 값 | 의미 | 추가 시점 |
|---|---|---|
| `<transition_action_label>` (기존) | classifier가 dispatch한 정상 action | 기존 |
| `initial` | 첫 emit (prev=None), 분류할 from_state 없음 | 본 PR |
| `unclassified` | 정상 transition이지만 classifier에 arm 누락 | 본 PR |

closed vocab (코드 변경 시만 추가) — Prometheus `action` label cardinality bounded.

## 로컬 검증

- `ocamlformat --check` PASS (1/1)
- `dune build @check` — origin/main이 #16289로 broken (Iter#1~#3 PR과 동일 blocker). 우리 변경:
  - `assert false`/`Invalid_argument`/`Failure` 모두 `wrap_unit`이 잡는 exception이므로 동작 동일 (`keeper_fsm_guard_runtime.mli` 명시)
  - mli 변경 없음 → 외부 caller 영향 0
  - 기존 test grep: turn FSM `action="unknown"` 직접 expect하는 test 없음 (`test_keeper_transition_audit.ml:366`은 specific action `"StreamComplete"` 사용)

## 미검증

- [ ] Full `dune build @check` (#16289 머지 후 재검증)
- [ ] classifier gap 발생 시 `unclassified` 라벨이 *실제로* nonzero인지 prod에서 관찰 — 본 PR은 측정 layer만 추가, 실제 gap 존재 여부는 production trace로 결정

## RFC

`bash ~/me/scripts/pr-rfc-check.sh` PASS — keeper turn FSM은 credential/identity/operator/sandbox/dashboard credential boundary 아님. RFC waiver 불필요.

## 참고

같은 /loop의 Iter#1 PR #16330, Iter#2 PR #16344, Iter#3 PR #16352와 같은 observability-clarity 시리즈. 다음 fire에서 keeper_alerting RFC-0001 Phase 3 audit 예정.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>