### PR TITLE
fix(prometheus): expose metric_key / metrics / with_lock via .mli

### DIFF
--- a/lib/prometheus_store.mli
+++ b/lib/prometheus_store.mli
@@ -19,6 +19,27 @@ type metric =
   ; labels : label list
   }
 
+(** Encode [(name, labels)] into the table key used by {!metrics}. Same
+    function as [Prometheus_key.metric_key]; re-exported here so
+    [Prometheus] can call the bare name after [include Prometheus_store].
+    Without this declaration the [.ml] re-export at line 5 is dropped by
+    the signature, and [prometheus.ml]'s [init] helper fails to compile
+    with [Unbound value metric_key] (CI: Lint Build with warnings as
+    errors). *)
+val metric_key : string -> label list -> string
+
+(** The shared metric table. Exposed so [Prometheus.init] can register
+    built-in metrics via [Hashtbl.add metrics key {...}]; downstream
+    consumers should prefer [register_counter] / [register_gauge] /
+    [register_histogram] over reaching into the table directly. *)
+val metrics : (string, metric) Hashtbl.t
+
+(** Acquire the store mutex around [f] with a deadlock-backtrace guard.
+    Exposed so [Prometheus.snapshot] (and any other compound operation
+    in the facade) can serialize multi-step access to {!metrics} the
+    same way [register_*] / [observe_histogram] do internally. *)
+val with_lock : (unit -> 'a) -> 'a
+
 val register_counter : name:string -> help:string -> ?labels:label list -> unit -> unit
 val register_gauge : name:string -> help:string -> ?labels:label list -> unit -> unit
 val register_histogram : name:string -> help:string -> ?labels:label list -> unit -> unit


### PR DESCRIPTION
## 요약

Prometheus godfile split (#16193/#16196/#16199/#16277/#16278/#16280/#16281) 후 `lib/prometheus.ml` 가 `lib/prometheus_store.ml` 의 `metric_key` / `metrics` / `with_lock` 를 직접 사용하지만 `lib/prometheus_store.mli` 에 declarations 가 없어서 `include Prometheus_store` 가 이들을 가져오지 못함. CI `Lint Build with warnings as errors` 가 `Error: Unbound value metric_key` 로 실패.

**모든 열린 PR이 동일 fail** (#16312, #16327 외 다수 확인) — main-branch baseline breakage, 개별 PR 코드가 도입한 것 아님.

## 측정된 근거

\`\`\`
$ rg -n '^let metric_key|^let metrics|^let with_lock' lib/prometheus_store.ml
5:let metric_key = Prometheus_key.metric_key
23:let metrics : (string, metric) Hashtbl.t = Hashtbl.create 64
30:let with_lock f =

$ rg -n 'val metric_key|val metrics|val with_lock' lib/prometheus_store.mli
# (empty before this PR)

$ rg -n '^\s*(metric_key|with_lock)\b|^\s*metrics\b' lib/prometheus.ml
262:    let key = metric_key name [] in
372:    with_lock (fun () ->
382:        metrics

$ dune build lib/.masc_mcp.objs/byte/masc_mcp__Prometheus.cmo
File \"lib/prometheus.ml\", line 262, characters 14-24:
Error: Unbound value metric_key
\`\`\`

## 변경

`lib/prometheus_store.mli` 에 3 declaration 추가:

- `val metric_key : string -> label list -> string` — pure encoder, safe public.
- `val metrics : (string, metric) Hashtbl.t` — 공유 테이블 노출 + 새 consumer 가 `register_*` API 우선 사용하도록 doc note.
- `val with_lock : (unit -> 'a) -> 'a` — facade 의 compound op 가 store mutex 잡을 수 있게.

## 검증

\`\`\`
$ dune build lib/.masc_mcp.objs/byte/masc_mcp__Prometheus.cmo  → clean
$ dune build @check                                              → clean
\`\`\`

## Unblocks

`Lint  fail` job 가 `prometheus.ml` 컴파일 실패로 떨어지던 모든 PR. #16324 (spawn-bounded allowlist drift after #16222 split) 와 동일 fleet-wide unblocker 패턴 — godfile decomposition 후 caller-side surface 가 .mli 에 노출 안 되어 누적된 baseline 결함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)