### PR TITLE
fix(dashboard): surface KCB axis in keeper-state-diagram

### DIFF
--- a/dashboard/src/components/keeper-state-diagram.ts
+++ b/dashboard/src/components/keeper-state-diagram.ts
@@ -239,6 +239,7 @@ export function KeeperStateDiagramPanel({ keeperName, snapshot: externalSnapshot
         <${PhaseBadge}>KDP ${displayState(snapshot.decision.stage)}<//>
         <${PhaseBadge}>KCL ${displayState(snapshot.cascade.state)}<//>
         <${PhaseBadge}>KMC ${displayState(snapshot.compaction.stage)}<//>
+        <${PhaseBadge}>KCB ${displayState(snapshot.circuit_breaker?.state ?? 'clean')}<//>
         ${transitions.length > 0 ? html`
           <${PhaseBadge}>observed ${transitions.length} transitions<//>
         ` : null}
@@ -247,7 +248,7 @@ export function KeeperStateDiagramPanel({ keeperName, snapshot: externalSnapshot
       <div>
         <div class="mb-2 flex flex-wrap items-center justify-between gap-2">
           <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">
-            통합 라이프사이클 (KSM · KTC · KDP · KCL · KMC)
+            통합 라이프사이클 (KSM · KTC · KDP · KCL · KMC · KCB)
           </div>
           <${FilterChips}
             chips=${DIAGRAM_VIEW_CHIPS}


### PR DESCRIPTION
## 요약

`keeper-state-diagram.ts:237-241` overview row 가 6 axis composite snapshot 중 5개 (KSM/KTC/KDP/KCL/KMC) 만 badge 로 표시 — **KCB (circuit_breaker, LT-16-KCB Phase 3) 누락**. 운영자가 per-keeper state-diagram 에서 breaker state 를 catch 못 함.

#16343 (5th TLA invariant) 와 동일 결함 class: snapshot 의 axis 를 enumerate 해야 할 surface 가 한 axis 를 omit. 다른 surface (FsmHub fleet view) 는 정상 표시하지만 keeper-state-diagram per-keeper 에서 누락.

## 측정된 근거

- Backend emit: `lib/keeper/keeper_failure_circuit_breaker.ml:438 display_state_to_string` → `\"clean\" | \"warning\" | \"cooling\"`.
- Composite 통과: `lib/keeper/keeper_composite_observer.ml:639-644` 모든 snapshot 에 포함.
- Dashboard codebase precedent: `fsm-hub-types.ts:30 extractLaneValue` / `fleet-fsm-matrix.ts:256, 489` / `fsm-hub-derivations.ts:31` 모두 `?? 'clean'` fallback 으로 핸들. keeper-state-diagram 만 누락.

## 변경

- `keeper-state-diagram.ts:241+` — KCB badge 추가 (`?? 'clean'` fallback 으로 Phase 2 pinned backend 대응).
- 섹션 헤딩 \"통합 라이프사이클 (KSM · KTC · KDP · KCL · KMC)\" → \"... · KCB\" 6 axis enumeration.

## 검증

\`\`\`
$ pnpm typecheck                                              → clean
$ pnpm vitest run src/components/keeper-state-diagram        → 27/27
\`\`\`

## Related

본 세션 11번째 PR. FSM/TLA axis coverage 스레드:
- #16312 snapshot.phase casing
- #16327 FSM exhausted edges
- #16333 FSM lane analysis sweep
- #16343 5th TLA invariant
- #16348 execution.outcome TLA-prefix
- #16351 stay_silent_loop blocker
- #16355 attention_reason + next_human_action coverage
- #16316 RFC-0132 (broader closure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)