### PR TITLE
refactor: split keeper run tool search helpers

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -178,6 +178,7 @@
   keeper_agent_result
   keeper_agent_error
   keeper_agent_memory_episode
+  keeper_run_tools_search
   provider_runtime_projection
   voice_bridge_transport
   cascade_wire_overlay

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -9,6 +9,8 @@ open Keeper_agent_result
 open Keeper_agent_error
 open Keeper_agent_prompt_metrics
 
+module Tool_search = Keeper_run_tools_search
+
 (** Mutable accumulator for OAS hook callbacks.
 
     OAS hooks (before_turn, on_tool_executed) cannot return values, so
@@ -98,75 +100,14 @@ let task_id_scope_of_tool_input ~tool_name input =
   else None
 ;;
 
-type tool_search_hit_partition =
+type tool_search_hit_partition = Tool_search.tool_search_hit_partition =
   { visible_core_hits : (string * float) list
   ; discoverable_hits : (string * float) list
   ; filtered_by_policy : int
   }
 
-let partition_tool_search_hits ~core ~core_always ~allowed ~retrieved ~max_results =
-  (* PR #14574 review #1/#7: only expose a public alias (e.g. "Bash") when
-     its routed internal handler (e.g. [keeper_bash]) is actually in the
-     incoming [allowed] set for this preset. Adding all [public_names ()]
-     unconditionally let [keeper_tool_search] return aliases even when
-     their backing tool was not permitted for the turn, which would invite
-     the model to attempt unregistered tool calls. *)
-  let allowed_internal_set =
-    let tbl = Hashtbl.create (List.length allowed) in
-    List.iter (fun n -> Hashtbl.replace tbl n ()) allowed;
-    tbl
-  in
-  let aliases_with_allowed_route =
-    Keeper_tool_alias.public_names ()
-    |> List.filter (fun pub ->
-      match Keeper_tool_alias.route pub with
-      | Some r -> Hashtbl.mem allowed_internal_set r.internal_name
-      | None -> false)
-  in
-  let allowed = allowed @ aliases_with_allowed_route in
-  let allowed_set =
-    let tbl = Hashtbl.create (List.length allowed) in
-    List.iter (fun n -> Hashtbl.replace tbl n ()) allowed;
-    List.iter (fun n -> Hashtbl.replace tbl n ()) core_always;
-    tbl
-  in
-  let allowed_retrieved =
-    retrieved |> List.filter (fun (name, _) -> Hashtbl.mem allowed_set name)
-  in
-  let is_core name = List.mem name core || List.mem name core_always in
-  let visible_core_hits =
-    allowed_retrieved |> List.filter (fun (name, _) -> is_core name)
-  in
-  let discoverable_hits =
-    allowed_retrieved
-    |> List.filter (fun (name, _) -> not (is_core name))
-    |> List.filteri (fun i _ -> i < max_results)
-  in
-  { visible_core_hits
-  ; discoverable_hits
-  ; filtered_by_policy = List.length retrieved - List.length allowed_retrieved
-  }
-;;
-
-let truncate_tool_surface_names ~max_tools ~essential_names all_allowed =
-  if List.length all_allowed <= max_tools
-  then all_allowed
-  else (
-    let essential_names = Keeper_types.dedupe_keep_order essential_names in
-    let essential =
-      all_allowed
-      |> List.filter (fun name -> List.mem name essential_names)
-      |> Keeper_types.dedupe_keep_order
-    in
-    let non_essential =
-      List.filter (fun name -> not (List.mem name essential_names)) all_allowed
-    in
-    let budget = max 0 (max_tools - List.length essential) in
-    essential
-    @ (non_essential
-       |> List.filteri (fun i _ -> i < budget)
-       |> Keeper_types.dedupe_keep_order))
-;;
+let partition_tool_search_hits = Tool_search.partition_tool_search_hits
+let truncate_tool_surface_names = Tool_search.truncate_tool_surface_names
 
 (** Agent setup produced by Step 7.
 

--- a/lib/keeper/keeper_run_tools_search.ml
+++ b/lib/keeper/keeper_run_tools_search.ml
@@ -1,0 +1,69 @@
+type tool_search_hit_partition =
+  { visible_core_hits : (string * float) list
+  ; discoverable_hits : (string * float) list
+  ; filtered_by_policy : int
+  }
+
+let partition_tool_search_hits ~core ~core_always ~allowed ~retrieved ~max_results =
+  (* PR #14574 review #1/#7: only expose a public alias (e.g. "Bash") when
+     its routed internal handler (e.g. [keeper_bash]) is actually in the
+     incoming [allowed] set for this preset. Adding all [public_names ()]
+     unconditionally let [keeper_tool_search] return aliases even when
+     their backing tool was not permitted for the turn, which would invite
+     the model to attempt unregistered tool calls. *)
+  let allowed_internal_set =
+    let tbl = Hashtbl.create (List.length allowed) in
+    List.iter (fun n -> Hashtbl.replace tbl n ()) allowed;
+    tbl
+  in
+  let aliases_with_allowed_route =
+    Keeper_tool_alias.public_names ()
+    |> List.filter (fun pub ->
+      match Keeper_tool_alias.route pub with
+      | Some r -> Hashtbl.mem allowed_internal_set r.internal_name
+      | None -> false)
+  in
+  let allowed = allowed @ aliases_with_allowed_route in
+  let allowed_set =
+    let tbl = Hashtbl.create (List.length allowed) in
+    List.iter (fun n -> Hashtbl.replace tbl n ()) allowed;
+    List.iter (fun n -> Hashtbl.replace tbl n ()) core_always;
+    tbl
+  in
+  let allowed_retrieved =
+    retrieved |> List.filter (fun (name, _) -> Hashtbl.mem allowed_set name)
+  in
+  let is_core name = List.mem name core || List.mem name core_always in
+  let visible_core_hits =
+    allowed_retrieved |> List.filter (fun (name, _) -> is_core name)
+  in
+  let discoverable_hits =
+    allowed_retrieved
+    |> List.filter (fun (name, _) -> not (is_core name))
+    |> List.filteri (fun i _ -> i < max_results)
+  in
+  { visible_core_hits
+  ; discoverable_hits
+  ; filtered_by_policy = List.length retrieved - List.length allowed_retrieved
+  }
+;;
+
+let truncate_tool_surface_names ~max_tools ~essential_names all_allowed =
+  if List.length all_allowed <= max_tools
+  then all_allowed
+  else (
+    let essential_names = Keeper_types.dedupe_keep_order essential_names in
+    let essential =
+      all_allowed
+      |> List.filter (fun name -> List.mem name essential_names)
+      |> Keeper_types.dedupe_keep_order
+    in
+    let non_essential =
+      List.filter (fun name -> not (List.mem name essential_names)) all_allowed
+    in
+    let budget = max 0 (max_tools - List.length essential) in
+    essential
+    @ (non_essential
+       |> List.filteri (fun i _ -> i < budget)
+       |> Keeper_types.dedupe_keep_order))
+;;

--- a/lib/keeper/keeper_run_tools_search.mli
+++ b/lib/keeper/keeper_run_tools_search.mli
@@ -1,0 +1,19 @@
+type tool_search_hit_partition =
+  { visible_core_hits : (string * float) list
+  ; discoverable_hits : (string * float) list
+  ; filtered_by_policy : int
+  }
+
+val partition_tool_search_hits
+  :  core:string list
+  -> core_always:string list
+  -> allowed:string list
+  -> retrieved:(string * float) list
+  -> max_results:int
+  -> tool_search_hit_partition
+
+val truncate_tool_surface_names
+  :  max_tools:int
+  -> essential_names:string list
+  -> string list
+  -> string list


### PR DESCRIPTION
## Summary
- split keeper_run_tools tool-search partition/truncation helpers into Keeper_run_tools_search
- keep Keeper_run_tools.tool_search_hit_partition as a record re-export and preserve existing function names
- reduce keeper_run_tools.ml from 1983 to 1924 LOC

## Validation
- ocamlformat --check lib/keeper/keeper_run_tools.ml lib/keeper/keeper_run_tools_search.ml lib/keeper/keeper_run_tools_search.mli
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- bash scripts/lint/godfile-size-regression.sh
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_topk_llm.exe (not completed: shared /tmp/me-dune-local.lock held by codex/godfile-zero-56-dashboard-cascade; killed this worktree's waiting lockf only)