### PR TITLE
feat(cascade): surface empty provider_label substitutions

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -548,9 +548,31 @@ let sdk_error_is_hard_quota (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.A2a _
   | Agent_sdk.Error.Internal _ -> false
 
+(* [provider_label] sanitises an upstream-supplied provider string
+   into a metric/log label value.  Empty / whitespace-only input
+   is replaced with the literal "unknown" so Prometheus labels stay
+   well-formed.  The replacement is fail-open by design (we never
+   want metric emission to itself raise), but the empty case is
+   almost always a bug at the call site — the caller forgot to
+   thread a real provider through.  WARN + counter make the
+   substitution visible so the root call site can be traced and
+   fixed; the helper itself does not change behaviour. *)
 let provider_label provider =
   match String.trim provider with
-  | "" -> "unknown"
+  | "" ->
+      Prometheus.inc_counter
+        Prometheus.metric_cascade_attempt_empty_provider_label
+        ();
+      let bt =
+        Printexc.raw_backtrace_to_string (Printexc.get_callstack 6)
+      in
+      Log.Misc.warn
+        "[cascade_attempt:empty_provider_label] provider_label received \
+         empty/blank input; substituting \"unknown\".  Fix the call \
+         site that passed an empty provider through \
+         Cascade_attempt_fsm.provider_label. Callstack (top 6):\n%s"
+        bt;
+      "unknown"
   | value -> value
 
 let public_runtime_provider_label = "runtime"

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -193,6 +193,15 @@ let metric_oas_bridge_unmigrated_payload_kind =
   "masc_oas_bridge_unmigrated_payload_kind_total"
 ;;
 
+(* [Cascade_attempt_fsm.provider_label] receives an empty/blank string
+   and falls back to the literal "unknown" so metric labels do not
+   carry an empty value.  A non-zero rate here means an upstream
+   call site is emitting metrics without a real provider name —
+   the helper paints over the symptom; the counter surfaces it so
+   the source can be found and fixed. *)
+let metric_cascade_attempt_empty_provider_label =
+  "masc_cascade_attempt_empty_provider_label_total"
+;;
 let metric_runtime_ollama_probe_generate_skips =
   "masc_runtime_ollama_probe_generate_skips_total"
 ;;

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -213,6 +213,21 @@ val metric_oas_bus_capacity : string
     ["oas_event_bridge: kind-only fallback ..."]. *)
 val metric_oas_bridge_unmigrated_payload_kind : string
 
+(** Counter: occurrences where
+    [Cascade_attempt_fsm.provider_label] received an empty or
+    whitespace-only string and substituted the literal ["unknown"]
+    label.  No labels (the empty-input case is the only signal —
+    cardinality 1).
+
+    A non-zero rate means an upstream metric/log emitter is passing
+    an empty provider through {!Cascade_attempt_fsm.provider_label}.
+    The helper paints over the symptom for metric-label safety; this
+    counter and the paired WARN line are the operator's signal that
+    the source needs a real provider value.  Fix: trace the
+    paired ["[cascade_attempt:empty_provider_label]"] WARN to the
+    call site and pass a real provider through. *)
+val metric_cascade_attempt_empty_provider_label : string
+
 val metric_runtime_ollama_probe_generate_skips : string
 
 (** #9632: subprocess executions that exceeded their configured


### PR DESCRIPTION
## 목표

`Cascade_attempt_fsm.provider_label`은 5개 metric/label emitter가 사용하는 small helper. 입력 string이 empty/whitespace-only면 silently `"unknown"`으로 치환 — metric label safety는 OK지만 *어떤 caller가 empty를 넘기는지* 추적 불가. 사용자 dashboard에서 `provider="unknown"` row가 보여도 thread를 잡을 단서 0.

Helper 자체는 fail-open이 정당 (metric emission이 raise하면 안 됨). 다만 substitution event가 *발생한 사실*과 *어디서*는 observability 영역.

`★ 워크어라운드 거부 기준 self-check ─────────────────`
이 PR은 silent substitution을 *유지하면서* 가시성을 추가 (Iter#1 PR #16330 패턴). counter+WARN은 fix가 아니라 *진단* — root caller를 trace 후 진짜 fix는 별도 PR. helper의 fail-open은 *의도된 design* (metric emission ≠ business logic). dedup/cap/cooldown 도입 없음. 통과.
`─────────────────────────────────────────────────`

## 변경 파일

| 파일 | 변경 |
|---|---|
| `lib/prometheus.{ml,mli}` | 새 counter `metric_cascade_attempt_empty_provider_label` (no labels, cardinality 1) |
| `lib/cascade/cascade_attempt_fsm.ml` | `provider_label` empty 분기: `Prometheus.inc_counter` + `Log.Misc.warn` with `Printexc.get_callstack 6`. fail-open 동작 유지 |

총 3 files, +49 / −1.

## Operator 시야 (Before / After)

**Before** — dashboard에 `cascade_attempt{provider="unknown"} 14.5/s`:
→ "unknown"이 어디서 왔는지 단서 0. caller 후보 5개를 일일이 trace 필요.

**After**:
```
[WARN] [cascade_attempt:empty_provider_label] provider_label received empty/blank input;
substituting "unknown".  Fix the call site that passed an empty provider through
Cascade_attempt_fsm.provider_label. Callstack (top 6):
Raised by primitive operation at Cascade_attempt_fsm.provider_label in file ".../cascade_attempt_fsm.ml", line 562
Called from Cascade_attempt_fsm.record_attempt_outcome in file "...", line 696
Called from Cascade_runner.emit_attempt_outcome in file ".../cascade_runner.ml", line 318
...
```
+ Prometheus: `masc_cascade_attempt_empty_provider_label_total` increments
→ 6-frame backtrace로 정확한 caller chain 식별 + scrape rate로 fleet-wide 빈도 확인 즉시 가능.

## Cardinality

- `metric_cascade_attempt_empty_provider_label`: **no labels** (cardinality 1) — empty-input case는 single signal이라 추가 dimension 불필요. callsite은 backtrace로 식별 (Prometheus metric에 inline callsite 넣으면 cardinality 폭증).

## 로컬 검증

- `ocamlformat --check` PASS (3/3)
- `dune build @check` — origin/main이 #16289로 broken (Iter#1~#4 PR과 동일 blocker)
- Caller 영향: 5 callsite 모두 lib-private (`.mli` 없음, `Cascade_attempt_fsm.provider_label` 외부 caller 0 — `rg -n 'Cascade_attempt_fsm\.provider_label' lib bin test`로 확인). 시그니처 변화 없음 (`string -> string`).
- `Log.Misc.warn` / `Printexc.get_callstack` 모두 표준 OCaml + masc-mcp 패턴 (cascade_event_bridge.ml 등에서 동일 사용)

## 미검증

- [ ] Full `dune build @check` (#16289 머지 후 재검증)
- [ ] 실제 production에서 `masc_cascade_attempt_empty_provider_label_total > 0`인지 — production trace로 결정 (단, 본 PR scope는 측정 layer만)
- [ ] Spam 위험: empty가 매 cycle마다 발생하면 log spam. 그러나 의도된 동작 (root caller fix시 자동 0). dedup/cap을 추가하면 워크어라운드 시그니처라 거부.

## RFC

`bash ~/me/scripts/pr-rfc-check.sh` PASS — cascade observability는 credential/identity/operator/sandbox/dashboard credential boundary 아님. RFC waiver 불필요.

## 시리즈

같은 /loop의 Iter#1 PR #16330, Iter#2 PR #16344, Iter#3 PR #16352, Iter#4 PR #16358와 같은 observability-clarity 시리즈. 다음 fire에서 keeper_state_machine "silent corruption" 영역 audit 예정.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>