### PR TITLE
fix(dashboard): surface TLA phase_derivation_agreement drift in PhaseConditionsPanel

### DIFF
--- a/dashboard/src/components/phase-conditions-panel.ts
+++ b/dashboard/src/components/phase-conditions-panel.ts
@@ -74,6 +74,19 @@ export function PhaseConditionsPanel({ diagnosis }: { diagnosis: PhaseDiagnosis 
       ? 'warn'
       : 'neutral'
 
+  // TLA invariant `phase_derivation_agreement` (KeeperCompositeLifecycle.tla;
+  // see lib/keeper/keeper_composite_observer.ml:599-602 phase_diagnosis_to_json):
+  // stored KSM phase must agree with `derive_phase(conditions)` for the
+  // recorded condition vector. When the two strings disagree on this
+  // panel the spec invariant is *currently violated* — surface that
+  // visually with warn/bad tones instead of leaving both chips in
+  // neutral/info (the prior layout required the operator to spot the
+  // disagreement by string comparison).
+  const driftDetected =
+    diagnosis.currentPhase !== null
+    && diagnosis.derivedPhase !== null
+    && diagnosis.currentPhase !== diagnosis.derivedPhase
+
   return html`
     <section
       class="grid gap-3"
@@ -91,10 +104,13 @@ export function PhaseConditionsPanel({ diagnosis }: { diagnosis: PhaseDiagnosis 
         </div>
         <div class="flex flex-wrap items-center gap-1.5 text-3xs">
           ${diagnosis.currentPhase ? html`
-            <${StatusChip} tone="neutral" uppercase=${false} class="font-mono">current ${diagnosis.currentPhase}</${StatusChip}>
+            <${StatusChip} tone=${driftDetected ? 'warn' : 'neutral'} uppercase=${false} class="font-mono">current ${diagnosis.currentPhase}</${StatusChip}>
           ` : null}
           ${diagnosis.derivedPhase ? html`
-            <${StatusChip} tone="info" uppercase=${false} class="font-mono">derived ${diagnosis.derivedPhase}</${StatusChip}>
+            <${StatusChip} tone=${driftDetected ? 'warn' : 'info'} uppercase=${false} class="font-mono">derived ${diagnosis.derivedPhase}</${StatusChip}>
+          ` : null}
+          ${driftDetected ? html`
+            <${StatusChip} tone="bad" uppercase=${false} title="phase_derivation_agreement (TLA): stored phase != derive_phase(conditions)">drift</${StatusChip}>
           ` : null}
           <${StatusChip} tone=${executableTone} uppercase=${false}>
             turn ${diagnosis.canExecuteTurn === null ? 'unknown' : diagnosis.canExecuteTurn ? 'executable' : 'blocked'}


### PR DESCRIPTION
## 요약

`PhaseConditionsPanel` 는 `current_phase` (backend 저장값) 과 `derived_phase` (조건 벡터 priority 재계산 결과) 를 chip 으로 나란히 표시. TLA invariant `phase_derivation_agreement` (KeeperCompositeLifecycle.tla; lib/keeper/keeper_composite_observer.ml:599-602 emit) 가 두 값의 agreement 를 요구. 그러나 **panel 은 일치/불일치 관계없이 neutral/info 톤만 사용** — 운영자가 drift 를 string compare 로만 catch 가능.

#16343 (5th TLA invariant row 추가) 의 *visual signal* 측면 보완: invariant grid 가 ok/violated 알림을 표시하더라도, *왜* drifted 인지 보려고 operator 가 여는 diagnosis panel 자체가 시각적으로 평이.

## 변경

- `driftDetected = currentPhase !== null && derivedPhase !== null && currentPhase !== derivedPhase` 계산.
- drift 시 `current` chip 톤 neutral → warn, `derived` chip 톤 info → warn.
- 추가 explicit `drift` chip (bad tone) + tooltip 가 TLA invariant 이름 인용 → 운영자가 origin 추적 가능.

## 측정된 근거

- TLA spec: `specs/keeper-state-machine/KeeperCompositeLifecycle.tla` `phase_derivation_agreement` invariant.
- Backend emit: `lib/keeper/keeper_composite_observer.ml:599-602 phase_diagnosis_to_json` 가 `current_phase` + `derived_phase` 동시 emit.
- 기존 사용자 표면: `PhaseConditionsPanel` 라인 92-101 가 두 값 모두 neutral/info 표시.

## 검증

\`\`\`
$ pnpm typecheck                                              → clean
$ pnpm vitest run src/components/phase-conditions             → 4/4
\`\`\`

## Related

본 세션 12번째 PR. FSM/TLA visibility 스레드: #16312, #16327, #16333, #16343 (5th invariant), #16348, #16351, #16355, #16365 (KCB axis). RFC-0132 (#16316) 가 broader structural closure. 본 PR 은 "spec-level invariant 가 visual-level signal 과 일치해야" 의 정확한 사례.

🤖 Generated with [Claude Code](https://claude.com/claude-code)