### PR TITLE
fix(dashboard): cover KCB display states in STATE_DISPLAY_NAMES

### DIFF
--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -160,6 +160,17 @@ export const STATE_DISPLAY_NAMES: Record<string, string> = {
   compacting: '압축 중',
   // KMC
   accumulating: '수집 중',
+  // KCB (LT-16-KCB Phase 3) — circuit breaker display states emitted by
+  // `Keeper_failure_circuit_breaker.display_state_to_string`
+  // (lib/keeper/keeper_failure_circuit_breaker.ml:438):
+  // clean | warning | cooling. The lane is consumed via
+  // `extractLaneValue` (line 30) and the per-keeper KCB badge added in
+  // #16365. Without these entries the Korean facade falls through to
+  // raw English so operators see `KCB clean` while every other axis
+  // renders Korean.
+  clean: '정상',
+  warning: '경고',
+  cooling: '냉각 중',
   // KSM
   running: '가동 중',
   failing: '오류 발생',


### PR DESCRIPTION
## 요약

`STATE_DISPLAY_NAMES` (fsm-hub-types.ts:143) 가 5 axes (KSM/KTC/KDP/KCL/KMC) 한국어 라벨 완비, **KCB (circuit_breaker, LT-16-KCB Phase 3) 누락**. PR #16365 가 keeper-state-diagram 에 KCB badge 추가했지만 라벨 맵에 entry 없어서 \`KCB clean\` (영문 raw) 표시 — 다른 badge 가 한국어인 것과 불일치.

## 측정된 근거

- Backend KCB emit: `lib/keeper/keeper_failure_circuit_breaker.ml:438 display_state_to_string` → `clean | warning | cooling` (3 values).
- 라벨 맵 STATE_DISPLAY_NAMES: 위 3 키 모두 누락 → `displayState` 가 `STATE_DISPLAY_NAMES[value] ?? value` 로 raw English fallback.
- 영향 surface: 본 세션 #16365 badge + 기타 KCB 표시 위치.

## 변경

`STATE_DISPLAY_NAMES` 에 3 entry 추가 + header comment 가 backend emit site + 도입 PR 인용 — 다음 contributor 가 새 KCB state 추가 시 sync gate.

- `clean: '정상'`
- `warning: '경고'`
- `cooling: '냉각 중'`

## 검증

\`\`\`
$ pnpm typecheck                                              → clean
$ pnpm vitest run src/components/fsm-hub-types                → 21/21
\`\`\`

## Related

본 세션 13번째 PR. Axis coverage 스레드: #16343 (5th invariant), #16351 (stay_silent_loop blocker), #16355 (attention_reason + next_human_action), #16365 (KCB badge). 이 PR 은 #16365 의 *Korean facade* 측면 보완 — badge 가 한국어로 렌더되도록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)