### PR TITLE
feat(verification): JSON parsers name what they actually received

### DIFF
--- a/lib/coord/coord_verification_store.ml
+++ b/lib/coord/coord_verification_store.ml
@@ -57,8 +57,23 @@ let verdict_of_yojson = function
              | _ -> "no reason given"
            in
            Ok (`Partial (score, reason))
-       | _ -> Error "unknown or missing verdict")
-  | _ -> Error "verdict must be a JSON object"
+       | other ->
+           let got =
+             match other with
+             | Some j -> Printf.sprintf "got %s" (Json_util.excerpt j)
+             | None -> "field missing"
+           in
+           Error
+             (Printf.sprintf
+                "unknown or missing 'verdict' (expected one of: \
+                 pass | fail | partial; %s)"
+                got))
+  | other ->
+      Error
+        (Printf.sprintf
+           "verdict must be a JSON object, got %s: %s"
+           (Json_util.kind_name other)
+           (Json_util.excerpt other))
 
 let request_status_of_yojson = function
   | `Assoc fields ->
@@ -67,13 +82,38 @@ let request_status_of_yojson = function
        | Some (`String "assigned") ->
            (match List.assoc_opt "verifier" fields with
             | Some (`String agent) -> Ok (`Assigned agent)
-            | _ -> Error "assigned requires 'verifier' field")
+            | other ->
+                let got =
+                  match other with
+                  | Some j -> Printf.sprintf "got %s" (Json_util.excerpt j)
+                  | None -> "field missing"
+                in
+                Error
+                  (Printf.sprintf
+                     "assigned status requires 'verifier' string field \
+                      (%s)"
+                     got))
        | Some (`String "completed") ->
            (match verdict_of_yojson (`Assoc fields) with
             | Ok verdict -> Ok (`Completed verdict)
             | Error err -> Error err)
-       | _ -> Error "unknown request status")
-  | _ -> Error "request status must be a JSON object"
+       | other ->
+           let got =
+             match other with
+             | Some j -> Printf.sprintf "got %s" (Json_util.excerpt j)
+             | None -> "field missing"
+           in
+           Error
+             (Printf.sprintf
+                "unknown 'status' (expected one of: pending | assigned \
+                 | completed; %s)"
+                got))
+  | other ->
+      Error
+        (Printf.sprintf
+           "request status must be a JSON object, got %s: %s"
+           (Json_util.kind_name other)
+           (Json_util.excerpt other))
 
 let request_header_of_yojson = function
   | `Assoc fields ->
@@ -109,8 +149,24 @@ let request_header_of_yojson = function
              | None -> `Pending
            in
            Ok { id; task_id; worker; verifier; created_at; status }
-       | _ -> Error "verification request requires 'id', 'task_id', 'worker' fields")
-  | _ -> Error "verification request must be a JSON object"
+       | id_opt, task_opt, worker_opt ->
+           let missing =
+             List.filter_map
+               (fun (name, opt) -> if Option.is_none opt then Some name else None)
+               [ "id", id_opt; "task_id", task_opt; "worker", worker_opt ]
+           in
+           Error
+             (Printf.sprintf
+                "verification request missing required string field(s) \
+                 [%s] (object had keys: [%s])"
+                (String.concat ", " missing)
+                (String.concat ", " (List.map fst fields))))
+  | other ->
+      Error
+        (Printf.sprintf
+           "verification request must be a JSON object, got %s: %s"
+           (Json_util.kind_name other)
+           (Json_util.excerpt other))
 
 let load_request_header base_path req_id =
   let path = request_path base_path req_id in

--- a/lib/core/json_util.ml
+++ b/lib/core/json_util.ml
@@ -143,6 +143,29 @@ let bool_opt_to_json : bool option -> Yojson.Safe.t = function
   | Some b -> `Bool b
   | None -> `Null
 
+(** Short snake_case name for a top-level JSON shape, useful in
+    error messages that want to say *what was received* without
+    dumping the full payload. *)
+let kind_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "int"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+
+(** Bounded stringification for diagnostic / log use.  Prefix-truncates
+    to [max] characters (default 160) and appends ["..."] when the
+    serialised form is longer, so a misshapen 5MB request body cannot
+    flood the log line. *)
+let excerpt ?(max = 160) (json : Yojson.Safe.t) : string =
+  let s = Yojson.Safe.to_string json in
+  if String.length s > max then String.sub s 0 max ^ "..." else s
+
 (** List utilities *)
 
 let dedupe_keep_order xs =

--- a/lib/core/json_util.mli
+++ b/lib/core/json_util.mli
@@ -66,6 +66,29 @@ val string_opt_to_json : string option -> Yojson.Safe.t
 val float_opt_to_json : float option -> Yojson.Safe.t
 val bool_opt_to_json : bool option -> Yojson.Safe.t
 
+(** {1 Diagnostic helpers}
+
+    Small formatters intended for [Error _] payloads in JSON parsers
+    so a failing parse can name the JSON kind it received and echo a
+    bounded excerpt of the offending value.  The two helpers replace
+    the "expected X" / "must be a JSON object" pattern with messages
+    that also tell the operator *what* was received. *)
+
+val kind_name : Yojson.Safe.t -> string
+(** [kind_name json] returns a short snake_case name for the
+    top-level JSON shape: [null | bool | int | float | string |
+    object | array | tuple | variant].  Use in error messages
+    where the parser expected a specific shape and wants to name
+    what it actually got. *)
+
+val excerpt : ?max:int -> Yojson.Safe.t -> string
+(** [excerpt ?max json] serialises [json] via [Yojson.Safe.to_string]
+    and truncates to [max] characters (default 160), appending
+    ["..."] if truncation occurred.  Safe for use in error messages
+    and warn logs: bounded length avoids flooding the log when the
+    rejected JSON is large, while the prefix is usually enough for
+    an operator to locate the offending value. *)
+
 (** List utilities *)
 
 val dedupe_keep_order : 'a list -> 'a list

--- a/lib/verification.ml
+++ b/lib/verification.ml
@@ -90,8 +90,23 @@ let verdict_of_yojson = function
              | _ -> "no reason given"
            in
            Ok (Partial (score, reason))
-       | _ -> Error "unknown or missing verdict")
-  | _ -> Error "verdict must be a JSON object"
+       | other ->
+           let got =
+             match other with
+             | Some j -> Printf.sprintf "got %s" (Json_util.excerpt j)
+             | None -> "field missing"
+           in
+           Error
+             (Printf.sprintf
+                "unknown or missing 'verdict' (expected one of: \
+                 pass | fail | partial; %s)"
+                got))
+  | other ->
+      Error
+        (Printf.sprintf
+           "verdict must be a JSON object, got %s: %s"
+           (Json_util.kind_name other)
+           (Json_util.excerpt other))
 
 (** Verification request *)
 type verification_request = {
@@ -130,13 +145,38 @@ let request_status_of_yojson = function
        | Some (`String "assigned") ->
            (match List.assoc_opt "verifier" fields with
             | Some (`String a) -> Ok (Assigned a)
-            | _ -> Error "assigned requires 'verifier' field")
+            | other ->
+                let got =
+                  match other with
+                  | Some j -> Printf.sprintf "got %s" (Json_util.excerpt j)
+                  | None -> "field missing"
+                in
+                Error
+                  (Printf.sprintf
+                     "assigned status requires 'verifier' string field \
+                      (%s)"
+                     got))
        | Some (`String "completed") ->
            (match verdict_of_yojson (`Assoc fields) with
             | Ok v -> Ok (Completed v)
             | Error e -> Error e)
-       | _ -> Error "unknown request status")
-  | _ -> Error "request status must be a JSON object"
+       | other ->
+           let got =
+             match other with
+             | Some j -> Printf.sprintf "got %s" (Json_util.excerpt j)
+             | None -> "field missing"
+           in
+           Error
+             (Printf.sprintf
+                "unknown 'status' (expected one of: pending | assigned \
+                 | completed; %s)"
+                got))
+  | other ->
+      Error
+        (Printf.sprintf
+           "request status must be a JSON object, got %s: %s"
+           (Json_util.kind_name other)
+           (Json_util.excerpt other))
 
 let request_to_yojson req =
   `Assoc [
@@ -197,8 +237,24 @@ let request_of_yojson = function
              | None -> Pending
            in
            Ok { id; task_id; output; criteria; worker; verifier; created_at; status }
-       | _ -> Error "verification request requires 'id', 'task_id', 'worker' fields")
-  | _ -> Error "verification request must be a JSON object"
+       | id_opt, task_opt, worker_opt ->
+           let missing =
+             List.filter_map
+               (fun (name, opt) -> if Option.is_none opt then Some name else None)
+               [ "id", id_opt; "task_id", task_opt; "worker", worker_opt ]
+           in
+           Error
+             (Printf.sprintf
+                "verification request missing required string field(s) \
+                 [%s] (object had keys: [%s])"
+                (String.concat ", " missing)
+                (String.concat ", " (List.map fst fields))))
+  | other ->
+      Error
+        (Printf.sprintf
+           "verification request must be a JSON object, got %s: %s"
+           (Json_util.kind_name other)
+           (Json_util.excerpt other))
 
 (** ID generation — cryptographic random, 128-bit space.
 


### PR DESCRIPTION
## 목표

`Verification.{verdict,request_status,request}_of_yojson`와 `Coord_verification_store`의 동일 복제 7+7 사이트가 *expected-only* 메시지("verdict must be a JSON object", "verification request requires 'id', 'task_id', 'worker' fields" 등)를 emit. operator는 *expected*는 알지만 *received*는 모름. missing-field 케이스에서 가장 심함: parser가 어느 필드가 missing인지 *이미 알고 있지만* 메시지는 required 키만 나열.

`★ 워크어라운드 거부 기준 self-check ─────────────────`
이 PR은 silent-failure 시그니처를 *제거* (received value/kind를 inline). 새 catch-all/string 분류기/cap/cooldown/dedup 도입 없음. Behaviour 변화 0 — `Result.t Error` payload는 같은 call site로 흐름, 메시지만 풍부. 통과.
`─────────────────────────────────────────────────`

## 변경 파일

| 파일 | 변경 |
|---|---|
| `lib/core/json_util.{ml,mli}` | 새 helpers `kind_name : Yojson.Safe.t -> string`, `excerpt : ?max:int -> Yojson.Safe.t -> string` (Error payload용, bounded 160 chars 기본) |
| `lib/verification.ml` | 7 사이트: verdict/status/request parser. kind + bounded excerpt + missing field 명시 |
| `lib/coord/coord_verification_store.ml` | 동일 7 사이트 (parser 자체가 모듈 간 복제됨 — dedup은 별도 PR scope) |

총 4 files, +172 / -14. `lib/core/`에 추가한 helper는 cross-module SSOT — 미래 다른 JSON parser도 reuse 가능.

## Operator 시야 (Before / After)

**Before** (verification request에 typo `worker_id` instead of `worker`):
```
Error: verification request requires 'id', 'task_id', 'worker' fields
```
→ 무엇이 누락됐는지 모름.  실제로는 worker만 누락이지만 operator는 셋 다 확인 필요.

**After**:
```
Error: verification request missing required string field(s) [worker]
       (object had keys: [id, task_id, worker_id, output, criteria, created_at])
```
→ 누락 필드 + 받은 키 목록 즉시 식별. typo origin (`worker_id`) 바로 보임.

**Before** (verdict에 잘못된 enum value):
```
Error: unknown or missing verdict
```

**After**:
```
Error: unknown or missing 'verdict' (expected one of: pass | fail | partial;
       got "succeeded")
```

**Before** (top-level이 array):
```
Error: verdict must be a JSON object
```

**After**:
```
Error: verdict must be a JSON object, got array: [{"verdict":"pass"}]
```

## 로컬 검증

- `ocamlformat --check` PASS (4/4)
- `test/test_verification.ml`은 valid round-trip만 검증 — error string 정확 비교 0 → test 영향 0
- `dune build @check` — origin/main이 #16289로 broken (Iter#1~#5 PR과 동일 blocker)
- `Json_util.` qualified 사용은 lib/coord/, lib/ 둘 다 검증됨 (`Json_util.string_opt_to_json` callers 다수)

## 미검증

- [ ] Full `dune build @check` (#16289 머지 후 재검증)
- [ ] 두 모듈의 parser 자체 dedup — 같은 함수가 거의 1:1로 복제됨. 본 PR scope 외 (message UX 영역만). 별도 dedup PR 후보로 적합 (다른 /loop의 #16364 keeper_unified_metrics dedup 패턴과 동일)

## RFC

`bash ~/me/scripts/pr-rfc-check.sh` PASS — JSON parser 영역, boundary subsystem 아님. RFC waiver 불필요.

## 시리즈

같은 /loop의 Iter#1 PR #16330, Iter#2 #16344, Iter#3 #16352, Iter#4 #16358, Iter#5 #16367과 같은 *user-actionable diagnostic* 시리즈. 핵심 원칙: sentinel-only diagnostic → received-value를 명시.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>