### PR TITLE
refactor: split operator context snapshot

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -1,114 +1,24 @@
 module U = Yojson.Safe.Util
+module Context_snapshot = Operator_control_snapshot_context
 include Operator_pending_confirm
 include Operator_digest
 
-let resolved_context_budget_of_meta (meta : Keeper_types.keeper_meta) : int option =
-  let _ = meta in
-  None
-;;
+let resolved_context_budget_of_meta = Context_snapshot.resolved_context_budget_of_meta
+let compute_context_ratio = Context_snapshot.compute_context_ratio
 
-let compute_context_ratio (meta : Keeper_types.keeper_meta) : float option =
-  let input_tokens = meta.runtime.usage.last_input_tokens in
-  if input_tokens = 0
-  then None
-  else (
-    match resolved_context_budget_of_meta meta with
-    | Some max_ctx -> Some (float_of_int input_tokens /. float_of_int max_ctx)
-    | None -> None)
-;;
-
-type keeper_context_snapshot =
+type keeper_context_snapshot = Context_snapshot.keeper_context_snapshot =
   { context_ratio : float option
   ; context_tokens : int option
   ; context_max : int option
   ; context_source : string option
   }
 
-let keeper_context_snapshot_is_empty (snapshot : keeper_context_snapshot) =
-  snapshot.context_ratio = None
-  && snapshot.context_tokens = None
-  && snapshot.context_max = None
-  && snapshot.context_source = None
-;;
-
-let keeper_context_snapshot_from_metrics_json (json : Yojson.Safe.t) =
-  let snapshot =
-    { context_ratio = Safe_ops.json_float_opt "context_ratio" json
-    ; context_tokens = Safe_ops.json_int_opt "context_tokens" json
-    ; context_max = Safe_ops.json_int_opt "context_max" json
-    ; context_source =
-        (match Safe_ops.json_string_opt "snapshot_source" json with
-         | Some source when String.trim source <> "" -> Some source
-         | _ ->
-           (match Safe_ops.json_string_opt "channel" json with
-            | Some channel when String.trim channel <> "" ->
-              Some ("metrics_" ^ String.trim channel)
-            | _ -> Some "metrics_log"))
-    }
-  in
-  if keeper_context_snapshot_is_empty snapshot then None else Some snapshot
-;;
-
-let latest_keeper_context_snapshot_from_files config keeper_name =
-  let metrics_lines =
-    let store = Keeper_types.keeper_metrics_store config keeper_name in
-    let dated = Dated_jsonl.read_recent_lines store 32 in
-    if dated <> []
-    then dated
-    else (
-      let path = Keeper_types.keeper_metrics_path config keeper_name in
-      Keeper_memory.read_file_tail_lines path ~max_bytes:32000 ~max_lines:32)
-  in
-  let snapshots =
-    List.rev metrics_lines
-    |> List.filter_map (fun line ->
-      try
-        let json = Yojson.Safe.from_string line in
-        keeper_context_snapshot_from_metrics_json json
-      with
-      | Yojson.Json_error _ -> None)
-  in
-  match
-    List.find_opt
-      (fun snapshot -> snapshot.context_source = Some "keeper_context_status")
-      snapshots
-  with
-  | Some snapshot -> Some snapshot
-  | None ->
-    (match snapshots with
-     | snapshot :: _ -> Some snapshot
-     | [] -> None)
-;;
-
-let fallback_keeper_context_snapshot (meta : Keeper_types.keeper_meta) =
-  { context_ratio = compute_context_ratio meta
-  ; context_tokens =
-      (match meta.runtime.usage.last_input_tokens with
-       | n when n > 0 -> Some n
-       | _ -> None)
-  ; context_max = resolved_context_budget_of_meta meta
-  ; context_source =
-      (match
-         meta.runtime.usage.last_input_tokens, resolved_context_budget_of_meta meta
-       with
-       | n, Some _ when n > 0 -> Some "usage_last_input_tokens"
-       | _ -> None)
-  }
-;;
-
-let keeper_context_snapshot_of_meta config (meta : Keeper_types.keeper_meta) =
-  match latest_keeper_context_snapshot_from_files config meta.name with
-  | Some snapshot -> snapshot
-  | None -> fallback_keeper_context_snapshot meta
-;;
-
-let keeper_context_snapshot_fields (snapshot : keeper_context_snapshot) =
-  [ "context_ratio", option_to_json (fun value -> `Float value) snapshot.context_ratio
-  ; "context_tokens", option_to_json (fun value -> `Int value) snapshot.context_tokens
-  ; "context_max", option_to_json (fun value -> `Int value) snapshot.context_max
-  ; "context_source", string_option_to_json snapshot.context_source
-  ]
-;;
+let keeper_context_snapshot_is_empty = Context_snapshot.keeper_context_snapshot_is_empty
+let keeper_context_snapshot_from_metrics_json = Context_snapshot.keeper_context_snapshot_from_metrics_json
+let latest_keeper_context_snapshot_from_files = Context_snapshot.latest_keeper_context_snapshot_from_files
+let fallback_keeper_context_snapshot = Context_snapshot.fallback_keeper_context_snapshot
+let keeper_context_snapshot_of_meta = Context_snapshot.keeper_context_snapshot_of_meta
+let keeper_context_snapshot_fields = Context_snapshot.keeper_context_snapshot_fields
 
 let non_empty_trimmed_string_opt value =
   let trimmed = String.trim value in

--- a/lib/operator/operator_control_snapshot_context.ml
+++ b/lib/operator/operator_control_snapshot_context.ml
@@ -1,0 +1,110 @@
+let resolved_context_budget_of_meta (meta : Keeper_types.keeper_meta) : int option =
+  let _ = meta in
+  None
+;;
+
+let compute_context_ratio (meta : Keeper_types.keeper_meta) : float option =
+  let input_tokens = meta.runtime.usage.last_input_tokens in
+  if input_tokens = 0
+  then None
+  else (
+    match resolved_context_budget_of_meta meta with
+    | Some max_ctx -> Some (float_of_int input_tokens /. float_of_int max_ctx)
+    | None -> None)
+;;
+
+type keeper_context_snapshot =
+  { context_ratio : float option
+  ; context_tokens : int option
+  ; context_max : int option
+  ; context_source : string option
+  }
+
+let keeper_context_snapshot_is_empty (snapshot : keeper_context_snapshot) =
+  snapshot.context_ratio = None
+  && snapshot.context_tokens = None
+  && snapshot.context_max = None
+  && snapshot.context_source = None
+;;
+
+let keeper_context_snapshot_from_metrics_json (json : Yojson.Safe.t) =
+  let snapshot =
+    { context_ratio = Safe_ops.json_float_opt "context_ratio" json
+    ; context_tokens = Safe_ops.json_int_opt "context_tokens" json
+    ; context_max = Safe_ops.json_int_opt "context_max" json
+    ; context_source =
+        (match Safe_ops.json_string_opt "snapshot_source" json with
+         | Some source when String.trim source <> "" -> Some source
+         | _ ->
+           (match Safe_ops.json_string_opt "channel" json with
+            | Some channel when String.trim channel <> "" ->
+              Some ("metrics_" ^ String.trim channel)
+            | _ -> Some "metrics_log"))
+    }
+  in
+  if keeper_context_snapshot_is_empty snapshot then None else Some snapshot
+;;
+
+let latest_keeper_context_snapshot_from_files config keeper_name =
+  let metrics_lines =
+    let store = Keeper_types.keeper_metrics_store config keeper_name in
+    let dated = Dated_jsonl.read_recent_lines store 32 in
+    if dated <> []
+    then dated
+    else (
+      let path = Keeper_types.keeper_metrics_path config keeper_name in
+      Keeper_memory.read_file_tail_lines path ~max_bytes:32000 ~max_lines:32)
+  in
+  let snapshots =
+    List.rev metrics_lines
+    |> List.filter_map (fun line ->
+      try
+        let json = Yojson.Safe.from_string line in
+        keeper_context_snapshot_from_metrics_json json
+      with
+      | Yojson.Json_error _ -> None)
+  in
+  match
+    List.find_opt
+      (fun snapshot -> snapshot.context_source = Some "keeper_context_status")
+      snapshots
+  with
+  | Some snapshot -> Some snapshot
+  | None ->
+    (match snapshots with
+     | snapshot :: _ -> Some snapshot
+     | [] -> None)
+;;
+
+let fallback_keeper_context_snapshot (meta : Keeper_types.keeper_meta) =
+  { context_ratio = compute_context_ratio meta
+  ; context_tokens =
+      (match meta.runtime.usage.last_input_tokens with
+       | n when n > 0 -> Some n
+       | _ -> None)
+  ; context_max = resolved_context_budget_of_meta meta
+  ; context_source =
+      (match
+         meta.runtime.usage.last_input_tokens, resolved_context_budget_of_meta meta
+       with
+       | n, Some _ when n > 0 -> Some "usage_last_input_tokens"
+       | _ -> None)
+  }
+;;
+
+let keeper_context_snapshot_of_meta config (meta : Keeper_types.keeper_meta) =
+  match latest_keeper_context_snapshot_from_files config meta.name with
+  | Some snapshot -> snapshot
+  | None -> fallback_keeper_context_snapshot meta
+;;
+
+let keeper_context_snapshot_fields (snapshot : keeper_context_snapshot) =
+  [ ( "context_ratio"
+    , Operator_pending_confirm.option_to_json (fun value -> `Float value) snapshot.context_ratio )
+  ; ( "context_tokens"
+    , Operator_pending_confirm.option_to_json (fun value -> `Int value) snapshot.context_tokens )
+  ; ( "context_max"
+    , Operator_pending_confirm.option_to_json (fun value -> `Int value) snapshot.context_max )
+  ; "context_source", Operator_pending_confirm.string_option_to_json snapshot.context_source
+  ]
+;;

--- a/lib/operator/operator_control_snapshot_context.mli
+++ b/lib/operator/operator_control_snapshot_context.mli
@@ -1,0 +1,15 @@
+type keeper_context_snapshot =
+  { context_ratio : float option
+  ; context_tokens : int option
+  ; context_max : int option
+  ; context_source : string option
+  }
+
+val resolved_context_budget_of_meta : Keeper_types.keeper_meta -> int option
+val compute_context_ratio : Keeper_types.keeper_meta -> float option
+val keeper_context_snapshot_is_empty : keeper_context_snapshot -> bool
+val keeper_context_snapshot_from_metrics_json : Yojson.Safe.t -> keeper_context_snapshot option
+val latest_keeper_context_snapshot_from_files : Coord.config -> string -> keeper_context_snapshot option
+val fallback_keeper_context_snapshot : Keeper_types.keeper_meta -> keeper_context_snapshot
+val keeper_context_snapshot_of_meta : Coord.config -> Keeper_types.keeper_meta -> keeper_context_snapshot
+val keeper_context_snapshot_fields : keeper_context_snapshot -> (string * Yojson.Safe.t) list


### PR DESCRIPTION
## Summary
- extract operator keeper-context snapshot parsing/fallback/field helpers into Operator_control_snapshot_context
- preserve Operator_control_snapshot public aliases, including compute_context_ratio
- reduce lib/operator/operator_control_snapshot.ml from 1768 to 1678 LOC

## Validation
- ocamlformat --check lib/operator/operator_control_snapshot.ml lib/operator/operator_control_snapshot_context.ml lib/operator/operator_control_snapshot_context.mli
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- bash scripts/lint/godfile-size-regression.sh
- env MASC_SKIP_PIN_CHECK=1 MASC_INCLUDE_OPERATOR_CONTROL=true scripts/dune-local.sh build test/test_operator_control.exe *(blocked by current base: lib/prometheus.ml:262 unbound value metric_key)*