### PR TITLE
test: add Yojson type error reproduction for board posts

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -826,6 +826,7 @@
   test_tool_board_coverage
   test_anti_rationalization_fail_mode
   test_board_truncation_detection
+  test_yojson_type_error_board
   ; test_proof_criteria removed (team session cleanup)
   test_tool_registration_consistency
   ; test_tree_index removed (CP purge)

--- a/test/test_yojson_type_error_board.ml
+++ b/test/test_yojson_type_error_board.ml
@@ -1,0 +1,222 @@
+(** task-318: Reproduce Yojson Type_error with minimal test cases.
+
+    Exercises the JSON boundary in [Tool_board_format] that surfaces
+    [Yojson.Safe.Util.Type_error] when callers pass unexpected JSON shapes
+    for optional fields like `sources`, `meta`, etc.
+
+    The companion boundary wrapper [with_yojson_boundary] converts these
+    into structured error results — this test verifies the *raw* exceptions
+    so we pin down the exact trigger conditions. *)
+
+open Alcotest
+open Masc_mcp
+
+(* ---- Helpers ---- *)
+
+let () = Mirage_crypto_rng_unix.use_default ()
+
+(** Build a `Yojson.Safe.t` args association list. *)
+let args_of_list fields : Yojson.Safe.t =
+  `Assoc fields
+
+(** Extract string from Tool_result error, or raise. *)
+let error_string_of_result r =
+  match r with
+  | Tool_result.{ kind = `Error; text; _ } -> text
+  | _ -> failwith "expected error result"
+
+(* ---- Test: source_entries_arg with non-list "sources" ---- *)
+
+let test_source_entries_non_list_raises () =
+  (* "sources" is a string instead of a list — must raise Type_error *)
+  let args = args_of_list [ "sources", `String "https://example.com" ] in
+  let raises =
+    try
+      let _ : Yojson.Safe.t option list option =
+        Tool_board_format.source_entries_arg args
+      in
+      false
+    with Yojson.Safe.Util.Type_error _ -> true
+  in
+  check bool "non-list sources must raise Type_error" true raises
+
+let test_source_entries_null_raises () =
+  (* "sources" is null instead of a list *)
+  let args = args_of_list [ "sources", `Null ] in
+  let raises =
+    try
+      let _ = Tool_board_format.source_entries_arg args in
+      false
+    with Yojson.Safe.Util.Type_error _ -> true
+  in
+  check bool "null sources must raise Type_error" true raises
+
+let test_source_entries_int_raises () =
+  (* "sources" is an int instead of a list *)
+  let args = args_of_list [ "sources", `Int 42 ] in
+  let raises =
+    try
+      let _ = Tool_board_format.source_entries_arg args in
+      false
+    with Yojson.Safe.Util.Type_error _ -> true
+  in
+  check bool "int sources must raise Type_error" true raises
+
+(* ---- Test: source_entries_arg with valid list ---- *)
+
+let test_source_entries_valid_list () =
+  let args =
+    args_of_list
+      [ "sources"
+      , `List
+          [ `Assoc [ "url", `String "https://example.com"
+                   ; "quote", `String "example quote" ]
+          ; `Assoc [ "url", `String "https://other.com" ]
+          ]
+      ]
+  in
+  let result = Tool_board_format.source_entries_arg args in
+  check (option (list (testable Yojson.Safe.pretty_to_string (fun a b -> Yojson.Safe.equal a b))))
+    "valid sources list"
+    (Some
+       [ `Assoc [ "url", `String "https://example.com"
+                ; "quote", `String "example quote" ]
+       ; `Assoc [ "url", `String "https://other.com" ]
+       ])
+    result
+
+(* ---- Test: source_entries_arg with empty list ---- *)
+
+let test_source_entries_empty_list () =
+  let args = args_of_list [ "sources", `List [] ] in
+  let result = Tool_board_format.source_entries_arg args in
+  check (option (list (testable Yojson.Safe.pretty_to_string (fun a b -> Yojson.Safe.equal a b))))
+    "empty list returns None"
+    None
+    result
+
+(* ---- Test: source_entries_arg with missing key ---- *)
+
+let test_source_entries_missing_key () =
+  let args = args_of_list [ "content", `String "hello" ] in
+  let result = Tool_board_format.source_entries_arg args in
+  check (option (list (testable Yojson.Safe.pretty_to_string (fun a b -> Yojson.Safe.equal a b))))
+    "missing key returns None"
+    None
+    result
+
+(* ---- Test: source_entry with non-string url ---- *)
+
+let test_source_entry_non_string_url () =
+  (* url is an int — source_entry returns None, filter_map drops it *)
+  let args =
+    args_of_list
+      [ "sources"
+      , `List [ `Assoc [ "url", `Int 42 ] ]
+      ]
+  in
+  let result = Tool_board_format.source_entries_arg args in
+  check (option (list (testable Yojson.Safe.pretty_to_string (fun a b -> Yojson.Safe.equal a b))))
+    "non-string url entry is filtered out → None"
+    None
+    result
+
+(* ---- Test: merge_sources_into_meta with non-Assoc meta ---- *)
+
+let test_merge_sources_null_meta () =
+  let sources =
+    [ `Assoc [ "url", `String "https://example.com" ] ]
+  in
+  let result =
+    Tool_board_format.merge_sources_into_meta
+      (Some `Null)
+      sources
+  in
+  check (option (testable Yojson.Safe.pretty_to_string (fun a b -> Yojson.Safe.equal a b)))
+    "null meta gets replaced with Assoc containing sources"
+    (Some
+       (`Assoc
+          [ "sources", `List sources
+          ; "has_external_sources", `Bool true
+          ]))
+    result
+
+let test_merge_sources_int_meta () =
+  let sources =
+    [ `Assoc [ "url", `String "https://example.com" ] ]
+  in
+  let result =
+    Tool_board_format.merge_sources_into_meta
+      (Some (`Int 99))
+      sources
+  in
+  check (option (testable Yojson.Safe.pretty_to_string (fun a b -> Yojson.Safe.equal a b)))
+    "int meta gets replaced with Assoc containing sources"
+    (Some
+       (`Assoc
+          [ "sources", `List sources
+          ; "has_external_sources", `Bool true
+          ]))
+    result
+
+(* ---- Test: normalize_arg_payload on nested unexpected types ---- *)
+
+let test_normalize_arg_payload_string_meta () =
+  (* meta field is a plain string — normalize should not crash *)
+  let args = args_of_list [ "meta", `String "some meta" ] in
+  let raises =
+    try
+      let _ = Tool_board_format.normalize_arg_payload args in
+      false
+    with Yojson.Safe.Util.Type_error _ -> true
+  in
+  check bool "string meta must not raise Type_error" false raises
+
+let test_normalize_arg_payload_list_meta () =
+  (* meta field is a list — normalize should not crash *)
+  let args = args_of_list [ "meta", `List [ `String "a" ] ] in
+  let raises =
+    try
+      let _ = Tool_board_format.normalize_arg_payload args in
+      false
+    with Yojson.Safe.Util.Type_error _ -> true
+  in
+  check bool "list meta must not raise Type_error" false raises
+
+(* ---- Suite ---- *)
+
+let () =
+  run "yojson_type_error_board"
+    [
+      ( "source_entries_arg"
+      , [
+          test_case "non-list sources raises Type_error" `Quick
+            test_source_entries_non_list_raises;
+          test_case "null sources raises Type_error" `Quick
+            test_source_entries_null_raises;
+          test_case "int sources raises Type_error" `Quick
+            test_source_entries_int_raises;
+          test_case "valid sources list parsed" `Quick
+            test_source_entries_valid_list;
+          test_case "empty list returns None" `Quick
+            test_source_entries_empty_list;
+          test_case "missing key returns None" `Quick
+            test_source_entries_missing_key;
+          test_case "non-string url filtered out" `Quick
+            test_source_entry_non_string_url;
+        ] );
+      ( "merge_sources_into_meta"
+      , [
+          test_case "null meta replaced" `Quick
+            test_merge_sources_null_meta;
+          test_case "int meta replaced" `Quick
+            test_merge_sources_int_meta;
+        ] );
+      ( "normalize_arg_payload"
+      , [
+          test_case "string meta does not crash" `Quick
+            test_normalize_arg_payload_string_meta;
+          test_case "list meta does not crash" `Quick
+            test_normalize_arg_payload_list_meta;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
Adds 222-line reproduction test (`test/test_yojson_type_error_board.ml`) that pins down the JSON shape variants triggering `Yojson.Safe.Util.Type_error` in `Tool_board_format.source_entries_arg` and related board-post field parsers.

Salvaged from autonomous-agent branch `keeper-nick0cave-agent/task-318` (no PR). The companion boundary wrapper `with_yojson_boundary` is already in main; this test verifies the *raw* exceptions still surface so we know exactly which shapes the boundary needs to handle.

## Test pattern
Each case wraps the target call in `try … with Yojson.Safe.Util.Type_error _ -> true` and `check bool "..." true raises` — a deliberate raise-and-catch idiom (not `Alcotest.check_raises` because the test wants to assert the *specific* exception family rather than any exception). This is a *valid* Alcotest pattern.

## Verification
- `ocamlformat --check test/test_yojson_type_error_board.ml`: PASS
- `git diff --check`: PASS
- Cherry-picked cleanly onto main HEAD `2e3396d030` (post-#16289 merge).

## Origin
- Source: `origin/keeper-nick0cave-agent/task-318` (2026-05-19, no PR, 1 commit ahead novel work).
- Sister branch `task-285` already landed via #16336 (pretty-print debug logs).

RFC-WAIVED: pure test addition — `test/test_yojson_type_error_board.ml`. No production code touched. Not in RFC-mandatory keeper subsystems.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
