### PR TITLE
fix(dashboard): Korean labels for cascade_outcome

### DIFF
--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -421,6 +421,26 @@ export function operatorDispositionReasonLabel(
   return OPERATOR_DISPOSITION_REASON_LABELS[value] ?? value
 }
 
+/** Korean labels for `execution.cascade.outcome` /
+ *  `keeper.cascade_outcome`. Backend emits 4 closed-sum values via
+ *  `Keeper_execution_receipt.cascade_outcome_to_string`
+ *  (lib/keeper/keeper_execution_receipt.ml:144-149). Kept separate
+ *  from `STATE_DISPLAY_NAMES` because `completed` and
+ *  `not_observed` are generic tokens other axes may emit (same
+ *  isolation pattern as TOOL_CONTRACT_LABELS in #16374 and
+ *  OPERATOR_DISPOSITION_LABELS in #16377). */
+const CASCADE_OUTCOME_LABELS: Record<string, string> = {
+  passed_to_next_model: '다음 모델로 진행',
+  completed: '완료',
+  not_observed: '관측되지 않음',
+  not_dispatched: '디스패치 안 됨',
+}
+
+export function cascadeOutcomeLabel(value: string | null | undefined): string | null {
+  if (!value) return null
+  return CASCADE_OUTCOME_LABELS[value] ?? value
+}
+
 export type StateEntries = {
   phase: number
   turn: number

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -15,12 +15,9 @@ import { EmptyState, ErrorState, LoadingState } from '../common/feedback-state'
 import { ActionButton } from '../common/button'
 import { FilterChips } from '../common/filter-chips'
 import { StatusBadge } from '../common/status-badge'
-<<<<<<< HEAD
 import { executionOutcomeLabel } from '../fsm-hub-types'
-||||||| parent of 4cc3b7dc43 (fix(dashboard): Korean labels for operator_disposition + operator_disposition_reason)
-=======
 import { operatorDispositionReasonLabel } from '../fsm-hub-types'
->>>>>>> 4cc3b7dc43 (fix(dashboard): Korean labels for operator_disposition + operator_disposition_reason)
+import { cascadeOutcomeLabel } from '../fsm-hub-types'
 import { ringFocusClasses } from '../common/ring'
 import { trustDispositionLabel } from '../fsm-hub-types'
 import { TimeAgo } from '../common/time-ago'
@@ -965,7 +962,7 @@ function KeeperCard({ keeper }: { keeper: GoalDetailKeeper }) {
         <div>캐스케이드</div>
         <div class="text-right text-text-body">${keeper.cascade_name ?? executionCascadeOutcome ?? '-'}</div>
         <div>결과</div>
-        <div class="text-right text-text-body">${keeper.cascade_outcome ?? executionCascadeOutcome ?? '-'}</div>
+        <div class="text-right text-text-body" title=${keeper.cascade_outcome ?? executionCascadeOutcome ?? ''}>${cascadeOutcomeLabel(keeper.cascade_outcome ?? executionCascadeOutcome) ?? '-'}</div>
       </div>
       ${shouldShowTrustSummary ? html`
         <div class="mt-3 rounded-[var(--r-1)] border border-card-border/50 bg-[var(--color-bg-surface)] p-3">


### PR DESCRIPTION
## 요약

Backend `cascade_outcome` 가 4 closed-sum values 로 emit 되지만 dashboard `goals/goal-tree.ts:964` 가 raw 영문 토큰 표시 — 운영자가 \"결과 · passed_to_next_model\" 형태로 봄.

## 측정된 근거

| Field | Backend emit | 값 |
|-------|--------------|-----|
| `cascade_outcome` | `Keeper_execution_receipt.cascade_outcome_to_string` (lib/keeper/keeper_execution_receipt.ml:144-149) | passed_to_next_model / completed / not_observed / not_dispatched |

## 변경

1. `fsm-hub-types.ts` — `CASCADE_OUTCOME_LABELS` (4 entries) + `cascadeOutcomeLabel` helper. STATE_DISPLAY_NAMES 와 분리 (#16374/#16377 패턴).
2. `goals/goal-tree.ts:964` — `cascadeOutcomeLabel` 통과; raw 토큰 `title` 보존.

## 검증

\`\`\`
$ pnpm typecheck                                              → clean
$ pnpm vitest run src/components/fsm-hub-types src/components/goals/goal-tree → 21/21
\`\`\`

## Related

본 세션 16번째 PR. Label coverage 스레드 누적: #16351, #16355, #16370, #16374, #16377.

🤖 Generated with [Claude Code](https://claude.com/claude-code)