### PR TITLE
fix(dashboard): Korean labels for terminal_reason_code

### DIFF
--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -441,6 +441,60 @@ export function cascadeOutcomeLabel(value: string | null | undefined): string | 
   return CASCADE_OUTCOME_LABELS[value] ?? value
 }
 
+/** Korean labels for `execution.terminal_reason_code`. Backend emits this
+ *  across multiple paths:
+ *  - `Keeper_turn_terminal_code.to_wire` (lib/keeper/keeper_turn_terminal_code.ml:28-50)
+ *    emits 10 fixed wire values + parameterized `Provider_runtime_error`,
+ *    `Tool_required_unsatisfied`, `Sdk_error` (which inject the raw `code`
+ *    string straight onto the wire).
+ *  - `Keeper_agent_error.to_terminal_reason_code` (lib/keeper/keeper_agent_error.ml:134-143)
+ *    maps Agent SDK Retry variants to `api_error_*` codes
+ *    (`api_error_server:<http_status>` is parameterized).
+ *  - `Keeper_agent_run` emits `"completed"` on Cascade_runner.Completed.
+ *  - `keeper_execution_receipt.ml:492` recognises the
+ *    `completion_contract_violation:<detail>` prefix.
+ *  Kept separate from `STATE_DISPLAY_NAMES` because generic tokens like
+ *  `completed` / `healthy` are also emitted by other axes (same isolation
+ *  pattern as TOOL_CONTRACT_LABELS in #16374). Parameterized codes fall
+ *  through to a prefix match below before the raw fallback. */
+const TERMINAL_REASON_CODE_LABELS: Record<string, string> = {
+  // Keeper_turn_terminal_code.to_wire
+  healthy: '정상',
+  stale_turn_timeout: '오래된 턴 시간 초과',
+  stale_termination_storm: 'Stale 종료 폭주',
+  stale_fleet_batch: 'Fleet stale 배치',
+  oas_timeout_budget: 'OAS 타임아웃 예산',
+  heartbeat_failures: '하트비트 실패',
+  turn_failures: '턴 실패 반복',
+  ambiguous_partial_commit: '부분 commit 모호',
+  fiber_unresolved: 'Fiber 미해결',
+  exception: '런타임 예외',
+  // Keeper_agent_run completion
+  completed: '완료',
+  // Keeper_agent_error Retry → api_error_*
+  api_error_rate_limited: 'API rate-limit',
+  api_error_overloaded: 'API 과부하',
+  api_error_auth: 'API 인증 오류',
+  api_error_invalid_request: 'API 잘못된 요청',
+  api_error_not_found: 'API 자원 없음',
+  api_error_context_overflow: 'API 컨텍스트 초과',
+  api_error_network: 'API 네트워크 오류',
+  api_error_timeout: 'API 타임아웃',
+  // keeper_unified_turn.ml:210
+  registry_phase_missing: '레지스트리 phase 누락',
+}
+
+export function terminalReasonCodeLabel(value: string | null | undefined): string | null {
+  if (!value) return null
+  const exact = TERMINAL_REASON_CODE_LABELS[value]
+  if (exact) return exact
+  // Parameterized prefixes: `api_error_server:<status>`,
+  // `completion_contract_violation:<detail>`.
+  if (value.startsWith('api_error_server:')) return 'API 서버 오류'
+  if (value.startsWith('completion_contract_violation:')) return '완료 계약 위반'
+  return value
+}
+
 export type StateEntries = {
   phase: number
   turn: number

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -10,12 +10,9 @@ import { TimeAgo } from './common/time-ago'
 import { formatDuration } from './mission-utils'
 import type { Keeper } from '../types'
 import { StrongSecondary, RuntimeBadge } from './keeper-detail-primitives'
-<<<<<<< HEAD
 import { trustDispositionLabel as resolveTrustDispositionLabel } from './fsm-hub-types'
-||||||| parent of 782f34b080 (fix(dashboard): Korean labels for operator_disposition + operator_disposition_reason)
-=======
 import { operatorDispositionReasonLabel } from './fsm-hub-types'
->>>>>>> 782f34b080 (fix(dashboard): Korean labels for operator_disposition + operator_disposition_reason)
+import { terminalReasonCodeLabel } from './fsm-hub-types'
 import { keeperNeedsDiagnosticAttention, refreshAfterRuntimeAction } from './keeper-detail-helpers'
 import { pauseKeeper, resumeKeeper, wakeKeeper } from '../api/keeper'
 import { showToast } from './common/toast'
@@ -325,7 +322,7 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
           ? html`<span><strong class="text-[var(--color-fg-secondary)]">정지 원인</strong> · ${stopCause.code}${stopCause.summary ? html` · ${stopCause.summary}` : null}</span>`
           : null}
         ${latestTerminalCode && latestTerminalCode !== stopCause?.code
-          ? html`<span><strong class="text-[var(--color-fg-secondary)]">종료 코드</strong> · ${latestTerminalCode}${latestTerminalSummary ? html` · ${latestTerminalSummary}` : null}</span>`
+          ? html`<span title=${latestTerminalCode}><strong class="text-[var(--color-fg-secondary)]">종료 코드</strong> · ${terminalReasonCodeLabel(latestTerminalCode)}${latestTerminalSummary ? html` · ${latestTerminalSummary}` : null}</span>`
           : null}
         ${latestNextAction
           ? html`<span><strong class="text-[var(--color-fg-secondary)]">권장 조치</strong> · ${latestNextAction}</span>`


### PR DESCRIPTION
## 요약

Backend `terminal_reason_code` 가 4 paths 에서 20+ values 로 emit 되지만 dashboard `keeper-detail-alert-strip.ts:300` 가 raw 영문 표시 — \"종료 코드 · api_error_timeout\" 형태.

## 측정된 근거

| Source | Values |
|--------|--------|
| `Keeper_turn_terminal_code.to_wire` (lib/keeper/keeper_turn_terminal_code.ml:28-50) | 10 fixed + 3 parameterized (Provider_runtime_error/Tool_required_unsatisfied/Sdk_error) |
| `Keeper_agent_error.to_terminal_reason_code` (lib/keeper/keeper_agent_error.ml:134-143) | 8 `api_error_*` + 1 parameterized (`api_error_server:<status>`) |
| `Keeper_agent_run.ml:1167` | `completed` |
| `keeper_unified_turn.ml:210` | `registry_phase_missing` |

User-facing 표시 위치:
- `keeper-detail-alert-strip.ts:300` — \`종료 코드 · ${latestTerminalCode}\`

## 변경

1. `fsm-hub-types.ts` — `TERMINAL_REASON_CODE_LABELS` (20 fixed entries) + `terminalReasonCodeLabel` helper.
   - Prefix fallback: `api_error_server:*` → \"API 서버 오류\", `completion_contract_violation:*` → \"완료 계약 위반\".
   - Raw passthrough for unmapped (Provider_runtime_error / Sdk_error variable codes).
2. `keeper-detail-alert-strip.ts:300` — `terminalReasonCodeLabel` 통과; raw `title` 보존.

## 검증

\`\`\`
$ pnpm typecheck                                              → clean
$ pnpm vitest run src/components/fsm-hub-types src/components/keeper-detail-alert-strip → 24/24
\`\`\`

## Related

본 세션 17번째 PR. Label coverage 스레드: #16351, #16355, #16370, #16374, #16377, #16380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)