### PR TITLE
feat(dashboard): inline reasons in runtime-mismatch "unknown" sentinels

### DIFF
--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -530,15 +530,40 @@ let runtime_resolution_json (config : Coord.config) =
   let add_source_mismatch_warning acc =
     if source_mismatch
     then (
-      let runtime = Option.value ~default:"unknown" runtime_commit in
+      (* When [runtime_commit] is [None] the warning previously
+         rendered as "Runtime build commit (unknown) differs from ...".
+         The *reason* the binary commit is unknown was emitted as a
+         separate [add_binary_commit_unknown_warning] further down,
+         forcing the dashboard reader to cross-reference two warnings
+         to understand a single mismatch.  Inline the reason in the
+         sentinel itself so the warning is self-contained. *)
+      let runtime =
+        match runtime_commit with
+        | Some commit -> commit
+        | None ->
+            "<unknown — Build_identity.binary_commit not populated by build \
+             pipeline>"
+      in
       let source_label, source_commit =
         match server_repo_commit with
         | Some commit -> "server repo HEAD", commit
-        | None -> "workspace HEAD", Option.value ~default:"unknown" workspace_commit
+        | None ->
+            (* [workspace_commit] is [git_rev_parse_short config.workspace_path].
+               [None] means [git rev-parse] failed at that path; naming the
+               path gives the operator the worktree to check. *)
+            let commit =
+              match workspace_commit with
+              | Some c -> c
+              | None ->
+                  Printf.sprintf
+                    "<unknown — git rev-parse failed at workspace_path=%s>"
+                    config.workspace_path
+            in
+            "workspace HEAD", commit
       in
       Printf.sprintf
-        "Runtime build commit (%s) differs from %s (%s). Rebuild/restart from the \
-         intended server worktree."
+        "Runtime build commit (%s) differs from %s (%s). Rebuild/restart from \
+         the intended server worktree."
         runtime
         source_label
         source_commit
@@ -556,13 +581,25 @@ let runtime_resolution_json (config : Coord.config) =
   let add_server_workspace_mismatch_warning acc =
     if server_workspace_mismatch
     then (
+      (* [server_workspace_mismatch] is only true when [server_repo_path] is
+         [Some _] (see the [Option.bind] guard above), so the [None] branch is
+         dead at runtime — but [Option.value ~default:"unknown server repo"]
+         silently buried that invariant.  Use the structured form instead:
+         the dead branch documents *why* it cannot fire. *)
       let server_repo =
-        server_repo_path |> Option.value ~default:"unknown server repo"
+        match server_repo_path with
+        | Some repo -> repo
+        | None ->
+            (* Unreachable: [server_workspace_mismatch] requires
+               [Option.bind server_repo_path normalized_path_opt = Some _],
+               which in turn requires [server_repo_path = Some _]. *)
+            "<unreachable — server_workspace_mismatch implies server_repo_path \
+             = Some _>"
       in
       Printf.sprintf
-        "Server binary checkout (%s) differs from dashboard workspace/base path (%s / \
-         %s). This can be intentional; verify the running worktree when dashboard \
-         data looks stale."
+        "Server binary checkout (%s) differs from dashboard workspace/base \
+         path (%s / %s). This can be intentional; verify the running worktree \
+         when dashboard data looks stale."
         server_repo
         config.workspace_path
         config.base_path


### PR DESCRIPTION
## 목표

`server_dashboard_http_runtime_info.runtime_resolution_json`이 dashboard에 verbatim 노출하는 세 warning이 *세 사이트 모두* missing source를 bare `"unknown"`/`"unknown server repo"`로 collapse. 같은 함수가 *이미 reason을 알고* 있는데도 dashboard 사용자는 cross-reference 강제됨.

| # | 사이트 | 원인 (이미 in scope) | 누락된 정보 |
|---|---|---|---|
| 1 | L533 `Runtime build commit (unknown)` | `runtime_commit = None` → build_identity가 미생산 | 별도 warning (L548-554)에 분리되어 cross-ref 필요 |
| 2 | L537 `workspace HEAD (unknown)` | `git rev-parse` 실패 at workspace_path | path 자체 누락 |
| 3 | L560 `(unknown server repo)` | invariant상 unreachable (server_workspace_mismatch 가드) | 죽은 분기인지 모름 |

`★ 워크어라운드 거부 기준 self-check ─────────────────`
이 PR은 silent-failure를 *제거* (sentinel에 reason 명시). 새 catch-all/string 분류기/cap/cooldown/dedup 도입 없음. behaviour 변화 0. unreachable 분기는 *삭제하지 않고* 왜 unreachable인지 명시 (다음 reader가 잘못 제거하는 것 방지). 통과.
`─────────────────────────────────────────────────`

## 변경 파일

| 파일 | 변경 |
|---|---|
| `lib/server/server_dashboard_http_runtime_info.ml` | 3 사이트 `Option.value ~default:"unknown"` → 각 reason 포함한 self-contained sentinel |

총 1 file, +45 / -8.

## Dashboard 사용자 시야 (Before / After)

**Before** (case 1+2 동시 발생):
```
Runtime build commit (unknown) differs from workspace HEAD (unknown).
Rebuild/restart from the intended server worktree.
```
→ 어느 path가 unknown인지, *왜* binary commit이 없는지 단서 0.

**After**:
```
Runtime build commit (<unknown — Build_identity.binary_commit not populated by
build pipeline>) differs from workspace HEAD (<unknown — git rev-parse failed at
workspace_path=/Users/dancer/me/workspace/yousleepwhen/masc-mcp>). Rebuild/restart
from the intended server worktree.
```
→ Operator는 (a) build pipeline 점검 (b) workspace path 점검 두 액션을 즉시 식별.

**Before** (case 3 — 죽은 분기):
```ocaml
let server_repo = server_repo_path |> Option.value ~default:"unknown server repo" in
```
→ 다음 reader가 "이 sentinel은 dead code"임을 모르고 fallback 제거하면 None match 시 crash.

**After**:
```ocaml
let server_repo =
  match server_repo_path with
  | Some repo -> repo
  | None ->
      "<unreachable — server_workspace_mismatch implies server_repo_path = Some _>"
in
```
→ invariant이 코드에 명시 + 다음 reader가 단순 제거 못함.

## 로컬 검증

- `ocamlformat --check` PASS (1/1)
- **`dune build @check` PASS** — 본 PR이 main #16289 fix (`2e3396d030`) 머지 후 첫 빌드 검증 통과한 iter (Iter#1~#6 PR도 main rebase로 동일하게 unblock 가능).
- `Option.value ~default` → `match ... with` rewrite는 기존 sibling 패턴 다수 (`add_source_mismatch_warning`의 commit handling과 동일 shape).

## RFC

`bash ~/me/scripts/pr-rfc-check.sh` PASS — dashboard runtime info는 boundary subsystem 아님. RFC waiver 불필요.

## 시리즈

같은 /loop의 Iter#1 PR #16330, Iter#2 #16344, Iter#3 #16352, Iter#4 #16358, Iter#5 #16367, Iter#6 #16375과 같은 *user-actionable diagnostic* 시리즈. 본 iter는 사용자 요청의 "대시보드도 같이 개선" 축에 정확히 부합 (dashboard가 직접 표시하는 warning).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>