### PR TITLE
refactor: split keeper context tool-pair repair

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -165,6 +165,7 @@
   keeper_current_task_reconcile keeper_checkpoint_store
   keeper_text_processing
   keeper_summarizer
+  keeper_context_core_message_json
   keeper_context_core
   keeper_compact_policy
   keeper_compact_audit

--- a/lib/dune
+++ b/lib/dune
@@ -166,6 +166,7 @@
   keeper_text_processing
   keeper_summarizer
   keeper_context_core_message_json
+  keeper_context_core_tool_pair_repair
   keeper_context_core
   keeper_compact_policy
   keeper_compact_audit

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -11,6 +11,7 @@ open Printf
 open Keeper_types
 
 module StringSet = Set.Make (String)
+module Message_json = Keeper_context_core_message_json
 
 (* ================================================================ *)
 (* Constants                                                         *)
@@ -200,183 +201,17 @@ let generate_checkpoint_id () =
   let ts = int_of_float (Time_compat.now () *. 1000.0) in
   sprintf "ckpt-%d" ts
 
-let role_to_string (r : Agent_sdk.Types.role) = match r with
-  | System -> "system" | User -> "user"
-  | Assistant -> "assistant" | Tool -> "tool"
-
-(* Issue #8623: returns [Some] only for the 4 wire-format names.
-   Callers must handle [None] explicitly — the previous Variant
-   shape silently routed unknowns to [User], which misattributes
-   checkpoint messages: a "system" / "assistant" / "tool" decoded as
-   "user" causes the LLM to treat tool output as user instructions,
-   echo prior assistant replies as user input, or downgrade system
-   prompt privileges. Same anti-pattern class as #8605/#8615. *)
-let role_of_string_opt = function
-  | "system" -> Some Agent_sdk.Types.System
-  | "user" -> Some Agent_sdk.Types.User
-  | "assistant" -> Some Agent_sdk.Types.Assistant
-  | "tool" -> Some Agent_sdk.Types.Tool
-  | _ -> None
-
-(* Backwards-compatible wrapper. [Tool] is the safest fallback for an
-   unrecognised role: tool messages are interpretive context, not
-   instructions, so misclassifying System/Assistant/User as Tool hides
-   the message rather than letting the LLM act on it. The warn log
-   preserves operator visibility. *)
-let role_of_string s =
-  match role_of_string_opt s with
-  | Some role -> role
-  | None ->
-    Log.Misc.warn
-      "keeper_context_core: unknown role %S, defaulting to Tool (#8623)" s;
-    Agent_sdk.Types.Tool
-
-let content_blocks_to_json
-    (blocks : Agent_sdk.Types.content_block list) : Yojson.Safe.t =
-  `List (List.map Agent_sdk.Api.content_block_to_json blocks)
-
-let content_blocks_of_json
-    (json : Yojson.Safe.t) : Agent_sdk.Types.content_block list option =
-  let open Yojson.Safe.Util in
-  let parse_block_list = function
-    | `List blocks ->
-        let parsed =
-          List.filter_map Agent_sdk.Api.content_block_of_json blocks
-        in
-        if List.length parsed = List.length blocks then Some parsed else None
-    | _ -> None
-  in
-  match parse_block_list (json |> member "content_blocks") with
-  | Some _ as blocks -> blocks
-  | None ->
-      (* Some OAS/OpenAI-style checkpoints use a structured [content] array
-         instead of MASC's [content_blocks] field. Treat that as the same
-         block source rather than forcing the legacy flat-string path. *)
-      parse_block_list (json |> member "content")
-
-let legacy_content_text_of_json (json : Yojson.Safe.t) : string =
-  let open Yojson.Safe.Util in
-  match json |> member "content" with
-  | `String value -> Inference_utils.sanitize_text_utf8 value
-  | `Null -> ""
-  | `List blocks ->
-      let parsed =
-        List.filter_map Agent_sdk.Api.content_block_of_json blocks
-      in
-      let msg : Agent_sdk.Types.message =
-        {
-          Agent_sdk.Types.role = Agent_sdk.Types.User;
-          content = parsed;
-          name = None;
-          tool_call_id = None;
-          metadata = [];
-        }
-      in
-      Inference_utils.sanitize_text_utf8 (text_of_message msg)
-  | _ -> ""
-
-let string_field_opt key value =
-  match value with
-  | Some text -> [ (key, `String text) ]
-  | None -> []
-
-let metadata_of_json (json : Yojson.Safe.t) : (string * Yojson.Safe.t) list =
-  match Yojson.Safe.Util.member "metadata" json with
-  | `Assoc fields -> fields
-  | _ -> []
-
-let message_to_json (m : Agent_sdk.Types.message) : Yojson.Safe.t =
-  let m = Inference_utils.sanitize_message_utf8 m in
-  let tool_call_id =
-    match m.tool_call_id with
-    | Some _ as explicit -> explicit
-    | None ->
-        (match m.role with
-         | Agent_sdk.Types.Tool ->
-             List.find_map
-               (function
-                 | Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
-                 (* Other content_block variants do not carry a tool_use_id. *)
-                 | Agent_sdk.Types.Text _
-                 | Agent_sdk.Types.Thinking _
-                 | Agent_sdk.Types.RedactedThinking _
-                 | Agent_sdk.Types.ToolUse _
-                 | Agent_sdk.Types.Image _
-                 | Agent_sdk.Types.Document _
-                 | Agent_sdk.Types.Audio _ -> None)
-               m.content
-         (* Non-Tool roles never own a tool_call_id. *)
-         | Agent_sdk.Types.System
-         | Agent_sdk.Types.User
-         | Agent_sdk.Types.Assistant -> None)
-  in
-  (* SSOT: structured [content_blocks] only. The previous flat [content]
-     field was a duplicate of [text_of_message m] used by legacy
-     checkpoint readers; new readers reconstruct text from
-     [content_blocks] via [text_of_history_jsonl_line] (see below).
-     Old checkpoints written with both fields still load fine because
-     [message_of_json] keeps the legacy [content] fallback. *)
-  let base = [
-    ("role", `String (role_to_string m.role));
-    ("content_blocks", content_blocks_to_json m.content);
-  ] in
-  `Assoc
-    (base
-     @ string_field_opt "name" m.name
-     @ string_field_opt "tool_call_id" tool_call_id
-     @ if m.metadata = [] then [] else [ ("metadata", `Assoc m.metadata) ])
-
-let message_of_json (json : Yojson.Safe.t) : Agent_sdk.Types.message =
-  let open Yojson.Safe.Util in
-  let role = json |> member "role" |> to_string |> role_of_string in
-  let text = legacy_content_text_of_json json in
-  let content =
-    match content_blocks_of_json json with
-    | Some blocks ->
-        if blocks <> [] then blocks else
-        (* Legacy checkpoints stored only flattened text + role. For Tool
-           messages that means the original assistant ToolUse block is gone,
-           so rebuilding a structured ToolResult here creates an invalid
-           orphaned pair on the next Anthropic request. Fall back to plain
-           text so old checkpoints remain readable without breaking turns. *)
-        [ Agent_sdk.Types.Text text ]
-    | None ->
-        [ Agent_sdk.Types.Text text ]
-  in
-  Inference_utils.sanitize_message_utf8
-    {
-      Agent_sdk.Types.role;
-      content;
-      name =
-        (json |> member "name" |> to_string_option
-         |> Option.map Inference_utils.sanitize_text_utf8);
-      tool_call_id =
-        (json |> member "tool_call_id" |> to_string_option
-         |> Option.map Inference_utils.sanitize_text_utf8);
-      metadata = [];
-    }
-
-(** Extract human-readable text from a single history.jsonl line that was
-    produced by [message_to_json].  Reads structured [content_blocks]
-    first (current SSOT), falls back to the legacy flat [content] field
-    for lines written before that field was retired.  Returns [""] when
-    neither shape is parseable. *)
-let text_of_history_jsonl_json (json : Yojson.Safe.t) : string =
-  let open Yojson.Safe.Util in
-  match content_blocks_of_json json with
-  | Some blocks when blocks <> [] ->
-      let msg : Agent_sdk.Types.message =
-        {
-          Agent_sdk.Types.role = Agent_sdk.Types.User;
-          content = blocks;
-          name = None;
-          tool_call_id = None;
-          metadata = [];
-        }
-      in
-      Inference_utils.sanitize_text_utf8 (text_of_message msg)
-  | _ ->
-      legacy_content_text_of_json json
+let role_to_string = Message_json.role_to_string
+let role_of_string_opt = Message_json.role_of_string_opt
+let role_of_string = Message_json.role_of_string
+let content_blocks_to_json = Message_json.content_blocks_to_json
+let content_blocks_of_json = Message_json.content_blocks_of_json
+let legacy_content_text_of_json = Message_json.legacy_content_text_of_json
+let string_field_opt = Message_json.string_field_opt
+let metadata_of_json = Message_json.metadata_of_json
+let message_to_json = Message_json.message_to_json
+let message_of_json = Message_json.message_of_json
+let text_of_history_jsonl_json = Message_json.text_of_history_jsonl_json
 
 let tool_use_ids_of_message (msg : Agent_sdk.Types.message) : string list =
   List.filter_map

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -12,6 +12,7 @@ open Keeper_types
 
 module StringSet = Set.Make (String)
 module Message_json = Keeper_context_core_message_json
+module Tool_pair_repair = Keeper_context_core_tool_pair_repair
 
 (* ================================================================ *)
 (* Constants                                                         *)
@@ -37,7 +38,8 @@ let checkpoint_text_cap_marker = "\n[capped]"
     (e.g. 280 blocks × 7K chars = 1.95M chars) passes through the
     sanitizer untouched, causing context window overflow on next load.
     Values aligned with Claude Code: 200K aggregate, per-result 8K. *)
-let default_max_checkpoint_tool_result_chars = 8_000
+let default_max_checkpoint_tool_result_chars =
+  Tool_pair_repair.default_max_checkpoint_tool_result_chars
 let default_max_checkpoint_tool_results_per_message = 20
 let default_max_checkpoint_tool_result_total_chars = 200_000
 
@@ -213,289 +215,39 @@ let message_to_json = Message_json.message_to_json
 let message_of_json = Message_json.message_of_json
 let text_of_history_jsonl_json = Message_json.text_of_history_jsonl_json
 
-let tool_use_ids_of_message (msg : Agent_sdk.Types.message) : string list =
-  List.filter_map
-    (function
-      | Agent_sdk.Types.ToolUse { id; _ } -> Some id
-      (* Only [ToolUse] carries a tool-use id; other blocks contribute none. *)
-      | Agent_sdk.Types.Text _
-      | Agent_sdk.Types.Thinking _
-      | Agent_sdk.Types.RedactedThinking _
-      | Agent_sdk.Types.ToolResult _
-      | Agent_sdk.Types.Image _
-      | Agent_sdk.Types.Document _
-      | Agent_sdk.Types.Audio _ -> None)
-    msg.content
+let tool_use_ids_of_message = Tool_pair_repair.tool_use_ids_of_message
+let tool_result_ids_of_message = Tool_pair_repair.tool_result_ids_of_message
+let has_tool_result_block = Tool_pair_repair.has_tool_result_block
+let trim_messages_preserving_pairs = Tool_pair_repair.trim_messages_preserving_pairs
+let tool_result_text_of_block = Tool_pair_repair.tool_result_text_of_block
+let tool_use_text_of_block = Tool_pair_repair.tool_use_text_of_block
 
-let tool_result_ids_of_message (msg : Agent_sdk.Types.message) : string list =
-  List.filter_map
-    (function
-      | Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
-      (* Only [ToolResult] carries a tool_use_id reference; others contribute none. *)
-      | Agent_sdk.Types.Text _
-      | Agent_sdk.Types.Thinking _
-      | Agent_sdk.Types.RedactedThinking _
-      | Agent_sdk.Types.ToolUse _
-      | Agent_sdk.Types.Image _
-      | Agent_sdk.Types.Document _
-      | Agent_sdk.Types.Audio _ -> None)
-    msg.content
-
-let has_tool_result_block (msg : Agent_sdk.Types.message) : bool =
-  List.exists
-    (function
-      | Agent_sdk.Types.ToolResult _ -> true
-      (* Only [ToolResult] qualifies; other blocks are not tool-result evidence. *)
-      | Agent_sdk.Types.Text _
-      | Agent_sdk.Types.Thinking _
-      | Agent_sdk.Types.RedactedThinking _
-      | Agent_sdk.Types.ToolUse _
-      | Agent_sdk.Types.Image _
-      | Agent_sdk.Types.Document _
-      | Agent_sdk.Types.Audio _ -> false)
-    msg.content
-
-(** Trim messages to at most [max_count] while preserving ToolUse/ToolResult
-    pairing.  Drops from the front.  If the drop point lands on a
-    ToolResult whose ToolUse would be the last dropped message, advance
-    the drop by 1 so the orphan ToolResult is also removed (pair stays
-    together on the dropped side).  This may yield fewer than [max_count]
-    messages but never creates orphans.
-
-    Root cause of recurring "unexpected tool_use_id" errors: the previous
-    implementation used [List.filteri (fun i _ -> i >= drop)] which splits
-    on message index, breaking mid-pair boundaries. *)
-let trim_messages_preserving_pairs
-    (messages : Agent_sdk.Types.message list) ~(max_count : int)
-    : Agent_sdk.Types.message list =
-  let n = List.length messages in
-  if n <= max_count then messages
-  else
-    let drop = n - max_count in
-    (* If the first kept message would be an orphan ToolResult,
-       drop it too so the pair stays together on the removed side. *)
-    let effective_drop =
-      match List.nth_opt messages drop with
-      | Some msg when has_tool_result_block msg ->
-        (* Advance drop to skip the orphan ToolResult *)
-        drop + 1
-      | _ -> drop
-    in
-    List.filteri (fun i _ -> i >= effective_drop) messages
-
-let tool_result_text_of_block
-    ~(tool_use_id : string)
-    ~(content : string)
-    ~(json : Yojson.Safe.t option) : string =
-  let content = Inference_utils.sanitize_text_utf8 (String.trim content) in
-  if content <> "" then content
-  else
-    match json with
-    | Some value ->
-        (* Stringify json only when it fits the per-result cap. Larger
-           payloads collapse to a stub so a single orphan-repair pass
-           cannot inflate one Text block to multi-MB and trigger the same
-           escape-depth blow-up that motivated the artifact-store work
-           (see [tool_blob_store] and the tool-output-washing series). *)
-        let serialized = Yojson.Safe.to_string value in
-        let len = String.length serialized in
-        if len <= default_max_checkpoint_tool_result_chars then serialized
-        else
-          Printf.sprintf "[tool:json id:%s bytes:%d elided]" tool_use_id len
-    | None -> Printf.sprintf "[tool result %s]" tool_use_id
-
-let tool_use_text_of_block
-    ~(tool_use_id : string)
-    ~(tool_name : string)
-    ~(input : Yojson.Safe.t) : string =
-  let tool_name = Inference_utils.sanitize_text_utf8 (String.trim tool_name) in
-  let tool_use_id = Inference_utils.sanitize_text_utf8 (String.trim tool_use_id) in
-  let tool_name =
-    if tool_name = "" then "unknown_tool" else tool_name
-  in
-  let input_json = Yojson.Safe.to_string input |> Inference_utils.sanitize_text_utf8 in
-  Printf.sprintf "[tool use %s %s input=%s]" tool_name tool_use_id input_json
-
-type tool_pair_repair_stats =
+type tool_pair_repair_stats = Tool_pair_repair.tool_pair_repair_stats =
   { downgraded_tool_uses : int
   ; downgraded_tool_results : int
   }
 
-let empty_tool_pair_repair_stats =
-  { downgraded_tool_uses = 0; downgraded_tool_results = 0 }
+let empty_tool_pair_repair_stats = Tool_pair_repair.empty_tool_pair_repair_stats
+let add_tool_pair_repair_stats = Tool_pair_repair.add_tool_pair_repair_stats
+let tool_pair_repair_stats_changed = Tool_pair_repair.tool_pair_repair_stats_changed
+let pair_repair_metadata_key = Tool_pair_repair.pair_repair_metadata_key
 
-let add_tool_pair_repair_stats left right =
-  { downgraded_tool_uses =
-      left.downgraded_tool_uses + right.downgraded_tool_uses
-  ; downgraded_tool_results =
-      left.downgraded_tool_results + right.downgraded_tool_results
-  }
+let repair_dangling_tool_use_messages_with_stats =
+  Tool_pair_repair.repair_dangling_tool_use_messages_with_stats
 
-let tool_pair_repair_stats_changed stats =
-  stats.downgraded_tool_uses > 0 || stats.downgraded_tool_results > 0
+let repair_dangling_tool_use_messages =
+  Tool_pair_repair.repair_dangling_tool_use_messages
 
-let pair_repair_metadata_key = "masc.tool_pair_repair"
+let repair_orphan_tool_result_messages_with_stats =
+  Tool_pair_repair.repair_orphan_tool_result_messages_with_stats
 
-let pair_repair_metadata_keys =
-  [ "was_fabricated"; "fabrication_source"; pair_repair_metadata_key ]
+let repair_orphan_tool_result_messages =
+  Tool_pair_repair.repair_orphan_tool_result_messages
 
-let with_pair_repair_metadata ~kind ~count (msg : Agent_sdk.Types.message) =
-  let metadata =
-    List.filter
-      (fun (key, _) -> not (List.mem key pair_repair_metadata_keys))
-      msg.metadata
-  in
-  { msg with
-    metadata =
-      [ "was_fabricated", `Bool true
-      ; "fabrication_source", `String "tool_pair_repair"
-      ; ( pair_repair_metadata_key
-        , `Assoc
-            [ "version", `Int 1
-            ; "kind", `String kind
-            ; "count", `Int count
-            ] )
-      ]
-      @ metadata
-  }
+let repair_broken_tool_call_pairs_with_stats =
+  Tool_pair_repair.repair_broken_tool_call_pairs_with_stats
 
-let repair_dangling_tool_use_messages_with_stats
-    (messages : Agent_sdk.Types.message list)
-    : Agent_sdk.Types.message list * tool_pair_repair_stats =
-  let repair_with_next
-      (current : Agent_sdk.Types.message)
-      (next_opt : Agent_sdk.Types.message option) =
-    let next_tool_result_ids =
-      match next_opt with
-      | Some next -> tool_result_ids_of_message next
-      | None -> []
-    in
-    let has_dangling =
-      List.exists
-        (function
-          | Agent_sdk.Types.ToolUse { id; _ } ->
-              not (List.mem id next_tool_result_ids)
-          (* Only [ToolUse] blocks can be dangling without a paired ToolResult. *)
-          | Agent_sdk.Types.Text _
-          | Agent_sdk.Types.Thinking _
-          | Agent_sdk.Types.RedactedThinking _
-          | Agent_sdk.Types.ToolResult _
-          | Agent_sdk.Types.Image _
-          | Agent_sdk.Types.Document _
-          | Agent_sdk.Types.Audio _ -> false)
-        current.content
-    in
-    if not has_dangling then (current, empty_tool_pair_repair_stats)
-    else
-      let downgraded_tool_uses = ref 0 in
-      let content =
-        List.map
-          (function
-            | Agent_sdk.Types.ToolUse { id; name; input }
-              when not (List.mem id next_tool_result_ids) ->
-                incr downgraded_tool_uses;
-                Agent_sdk.Types.Text
-                  (tool_use_text_of_block
-                     ~tool_use_id:id ~tool_name:name ~input)
-            | other -> other)
-          current.content
-      in
-      ( { current with content }
-        |> with_pair_repair_metadata
-             ~kind:"downgraded_tool_use"
-             ~count:!downgraded_tool_uses
-      , { empty_tool_pair_repair_stats with
-          downgraded_tool_uses = !downgraded_tool_uses
-        } )
-  in
-  let rec loop acc_stats acc = function
-    | [] -> List.rev acc, acc_stats
-    | [ current ] ->
-        let repaired, repair_stats = repair_with_next current None in
-        List.rev (repaired :: acc), add_tool_pair_repair_stats acc_stats repair_stats
-    | current :: ((next :: _) as rest) ->
-        let repaired, repair_stats = repair_with_next current (Some next) in
-        loop (add_tool_pair_repair_stats acc_stats repair_stats) (repaired :: acc) rest
-  in
-  loop empty_tool_pair_repair_stats [] messages
-
-let repair_dangling_tool_use_messages messages =
-  fst (repair_dangling_tool_use_messages_with_stats messages)
-
-let repair_orphan_tool_result_messages_with_stats
-    (messages : Agent_sdk.Types.message list)
-    : Agent_sdk.Types.message list * tool_pair_repair_stats =
-  let rec loop acc_stats prev acc = function
-    | [] -> List.rev acc, acc_stats
-    | msg :: rest ->
-        let repaired, stats =
-          if not (has_tool_result_block msg) then
-            (msg, empty_tool_pair_repair_stats)
-          else
-            let prev_tool_use_ids =
-              match prev with
-              | Some previous -> tool_use_ids_of_message previous
-              | None -> []
-            in
-            (* Anthropic validates ToolResult blocks against ToolUse blocks
-               in the immediately previous message. If checkpoint capping
-               drops that predecessor, the resumed history becomes invalid.
-               Downgrade only the orphaned structured result blocks to
-               plain text so the semantic output survives without replaying
-               provider-specific tool metadata. *)
-            let has_orphan =
-              List.exists
-                (function
-                  | Agent_sdk.Types.ToolResult { tool_use_id; _ } ->
-                      not (List.mem tool_use_id prev_tool_use_ids)
-                  (* Only [ToolResult] can be orphaned w.r.t. prior ToolUse ids. *)
-                  | Agent_sdk.Types.Text _
-                  | Agent_sdk.Types.Thinking _
-                  | Agent_sdk.Types.RedactedThinking _
-                  | Agent_sdk.Types.ToolUse _
-                  | Agent_sdk.Types.Image _
-                  | Agent_sdk.Types.Document _
-                  | Agent_sdk.Types.Audio _ -> false)
-                msg.content
-            in
-            if not has_orphan then (msg, empty_tool_pair_repair_stats)
-            else
-              let downgraded_tool_results = ref 0 in
-              let content =
-                List.map
-                  (function
-                    | Agent_sdk.Types.ToolResult { tool_use_id; content; json; _ } ->
-                        incr downgraded_tool_results;
-                        Agent_sdk.Types.Text
-                          (tool_result_text_of_block ~tool_use_id ~content ~json)
-                    | other -> other)
-                  msg.content
-              in
-              ( { msg with content }
-                |> with_pair_repair_metadata
-                     ~kind:"downgraded_tool_result"
-                     ~count:!downgraded_tool_results
-              , { empty_tool_pair_repair_stats with
-                  downgraded_tool_results = !downgraded_tool_results
-                } )
-        in
-        loop (add_tool_pair_repair_stats acc_stats stats) (Some repaired) (repaired :: acc) rest
-  in
-  loop empty_tool_pair_repair_stats None [] messages
-
-let repair_orphan_tool_result_messages messages =
-  fst (repair_orphan_tool_result_messages_with_stats messages)
-
-let repair_broken_tool_call_pairs_with_stats
-    (messages : Agent_sdk.Types.message list)
-    : Agent_sdk.Types.message list * tool_pair_repair_stats =
-  let messages, dangling_stats = repair_dangling_tool_use_messages_with_stats messages in
-  let messages, orphan_stats = repair_orphan_tool_result_messages_with_stats messages in
-  messages, add_tool_pair_repair_stats dangling_stats orphan_stats
-
-let repair_broken_tool_call_pairs
-    (messages : Agent_sdk.Types.message list) : Agent_sdk.Types.message list =
-  fst (repair_broken_tool_call_pairs_with_stats messages)
+let repair_broken_tool_call_pairs = Tool_pair_repair.repair_broken_tool_call_pairs
 
 let serialize_context (ctx : working_context) : string =
   let json = `Assoc [

--- a/lib/keeper/keeper_context_core_message_json.ml
+++ b/lib/keeper/keeper_context_core_message_json.ml
@@ -1,0 +1,177 @@
+let role_to_string (r : Agent_sdk.Types.role) =
+  match r with
+  | System -> "system"
+  | User -> "user"
+  | Assistant -> "assistant"
+  | Tool -> "tool"
+
+(* Issue #8623: returns [Some] only for the 4 wire-format names.
+   Callers must handle [None] explicitly — the previous Variant
+   shape silently routed unknowns to [User], which misattributes
+   checkpoint messages: a "system" / "assistant" / "tool" decoded as
+   "user" causes the LLM to treat tool output as user instructions,
+   echo prior assistant replies as user input, or downgrade system
+   prompt privileges. Same anti-pattern class as #8605/#8615. *)
+let role_of_string_opt = function
+  | "system" -> Some Agent_sdk.Types.System
+  | "user" -> Some Agent_sdk.Types.User
+  | "assistant" -> Some Agent_sdk.Types.Assistant
+  | "tool" -> Some Agent_sdk.Types.Tool
+  | _ -> None
+
+(* Backwards-compatible wrapper. [Tool] is the safest fallback for an
+   unrecognised role: tool messages are interpretive context, not
+   instructions, so misclassifying System/Assistant/User as Tool hides
+   the message rather than letting the LLM act on it. The warn log
+   preserves operator visibility. *)
+let role_of_string s =
+  match role_of_string_opt s with
+  | Some role -> role
+  | None ->
+      Log.Misc.warn
+        "keeper_context_core: unknown role %S, defaulting to Tool (#8623)" s;
+      Agent_sdk.Types.Tool
+
+let content_blocks_to_json
+    (blocks : Agent_sdk.Types.content_block list) : Yojson.Safe.t =
+  `List (List.map Agent_sdk.Api.content_block_to_json blocks)
+
+let content_blocks_of_json
+    (json : Yojson.Safe.t) : Agent_sdk.Types.content_block list option =
+  let open Yojson.Safe.Util in
+  let parse_block_list = function
+    | `List blocks ->
+        let parsed = List.filter_map Agent_sdk.Api.content_block_of_json blocks in
+        if List.length parsed = List.length blocks then Some parsed else None
+    | _ -> None
+  in
+  match parse_block_list (json |> member "content_blocks") with
+  | Some _ as blocks -> blocks
+  | None ->
+      (* Some OAS/OpenAI-style checkpoints use a structured [content] array
+         instead of MASC's [content_blocks] field. Treat that as the same
+         block source rather than forcing the legacy flat-string path. *)
+      parse_block_list (json |> member "content")
+
+let legacy_content_text_of_json (json : Yojson.Safe.t) : string =
+  let open Yojson.Safe.Util in
+  match json |> member "content" with
+  | `String value -> Inference_utils.sanitize_text_utf8 value
+  | `Null -> ""
+  | `List blocks ->
+      let parsed = List.filter_map Agent_sdk.Api.content_block_of_json blocks in
+      let msg : Agent_sdk.Types.message =
+        {
+          Agent_sdk.Types.role = Agent_sdk.Types.User;
+          content = parsed;
+          name = None;
+          tool_call_id = None;
+          metadata = [];
+        }
+      in
+      Inference_utils.sanitize_text_utf8 (Agent_sdk.Types.text_of_message msg)
+  | _ -> ""
+
+let string_field_opt key value =
+  match value with
+  | Some text -> [ (key, `String text) ]
+  | None -> []
+
+let metadata_of_json (json : Yojson.Safe.t) : (string * Yojson.Safe.t) list =
+  match Yojson.Safe.Util.member "metadata" json with
+  | `Assoc fields -> fields
+  | _ -> []
+
+let message_to_json (m : Agent_sdk.Types.message) : Yojson.Safe.t =
+  let m = Inference_utils.sanitize_message_utf8 m in
+  let tool_call_id =
+    match m.tool_call_id with
+    | Some _ as explicit -> explicit
+    | None -> (
+        match m.role with
+        | Agent_sdk.Types.Tool ->
+            List.find_map
+              (function
+                | Agent_sdk.Types.ToolResult { tool_use_id; _ } ->
+                    Some tool_use_id
+                (* Other content_block variants do not carry a tool_use_id. *)
+                | Agent_sdk.Types.Text _
+                | Agent_sdk.Types.Thinking _
+                | Agent_sdk.Types.RedactedThinking _
+                | Agent_sdk.Types.ToolUse _
+                | Agent_sdk.Types.Image _
+                | Agent_sdk.Types.Document _
+                | Agent_sdk.Types.Audio _ -> None)
+              m.content
+        (* Non-Tool roles never own a tool_call_id. *)
+        | Agent_sdk.Types.System
+        | Agent_sdk.Types.User
+        | Agent_sdk.Types.Assistant -> None)
+  in
+  (* SSOT: structured [content_blocks] only. The previous flat [content]
+     field was a duplicate of [text_of_message m] used by legacy
+     checkpoint readers; new readers reconstruct text from
+     [content_blocks] via [text_of_history_jsonl_line] (see below).
+     Old checkpoints written with both fields still load fine because
+     [message_of_json] keeps the legacy [content] fallback. *)
+  let base =
+    [
+      ("role", `String (role_to_string m.role));
+      ("content_blocks", content_blocks_to_json m.content);
+    ]
+  in
+  `Assoc
+    (base
+     @ string_field_opt "name" m.name
+     @ string_field_opt "tool_call_id" tool_call_id
+     @ if m.metadata = [] then [] else [ ("metadata", `Assoc m.metadata) ])
+
+let message_of_json (json : Yojson.Safe.t) : Agent_sdk.Types.message =
+  let open Yojson.Safe.Util in
+  let role = json |> member "role" |> to_string |> role_of_string in
+  let text = legacy_content_text_of_json json in
+  let content =
+    match content_blocks_of_json json with
+    | Some blocks ->
+        if blocks <> [] then blocks
+        else
+          (* Legacy checkpoints stored only flattened text + role. For Tool
+             messages that means the original assistant ToolUse block is gone,
+             so rebuilding a structured ToolResult here creates an invalid
+             orphaned pair on the next Anthropic request. Fall back to plain
+             text so old checkpoints remain readable without breaking turns. *)
+          [ Agent_sdk.Types.Text text ]
+    | None -> [ Agent_sdk.Types.Text text ]
+  in
+  Inference_utils.sanitize_message_utf8
+    {
+      Agent_sdk.Types.role;
+      content;
+      name =
+        (json |> member "name" |> to_string_option
+         |> Option.map Inference_utils.sanitize_text_utf8);
+      tool_call_id =
+        (json |> member "tool_call_id" |> to_string_option
+         |> Option.map Inference_utils.sanitize_text_utf8);
+      metadata = [];
+    }
+
+(** Extract human-readable text from a single history.jsonl line that was
+    produced by [message_to_json].  Reads structured [content_blocks]
+    first (current SSOT), falls back to the legacy flat [content] field
+    for lines written before that field was retired.  Returns [""] when
+    neither shape is parseable. *)
+let text_of_history_jsonl_json (json : Yojson.Safe.t) : string =
+  match content_blocks_of_json json with
+  | Some blocks when blocks <> [] ->
+      let msg : Agent_sdk.Types.message =
+        {
+          Agent_sdk.Types.role = Agent_sdk.Types.User;
+          content = blocks;
+          name = None;
+          tool_call_id = None;
+          metadata = [];
+        }
+      in
+      Inference_utils.sanitize_text_utf8 (Agent_sdk.Types.text_of_message msg)
+  | _ -> legacy_content_text_of_json json

--- a/lib/keeper/keeper_context_core_message_json.mli
+++ b/lib/keeper/keeper_context_core_message_json.mli
@@ -1,0 +1,16 @@
+val role_to_string : Agent_sdk.Types.role -> string
+val role_of_string_opt : string -> Agent_sdk.Types.role option
+val role_of_string : string -> Agent_sdk.Types.role
+
+val content_blocks_to_json :
+  Agent_sdk.Types.content_block list -> Yojson.Safe.t
+
+val content_blocks_of_json :
+  Yojson.Safe.t -> Agent_sdk.Types.content_block list option
+
+val legacy_content_text_of_json : Yojson.Safe.t -> string
+val string_field_opt : string -> string option -> (string * Yojson.Safe.t) list
+val metadata_of_json : Yojson.Safe.t -> (string * Yojson.Safe.t) list
+val message_to_json : Agent_sdk.Types.message -> Yojson.Safe.t
+val message_of_json : Yojson.Safe.t -> Agent_sdk.Types.message
+val text_of_history_jsonl_json : Yojson.Safe.t -> string

--- a/lib/keeper/keeper_context_core_tool_pair_repair.ml
+++ b/lib/keeper/keeper_context_core_tool_pair_repair.ml
@@ -1,0 +1,293 @@
+let default_max_checkpoint_tool_result_chars = 8_000
+
+let tool_use_ids_of_message (msg : Agent_sdk.Types.message) : string list =
+  List.filter_map
+    (function
+      | Agent_sdk.Types.ToolUse { id; _ } -> Some id
+      (* Only [ToolUse] carries a tool-use id; other blocks contribute none. *)
+      | Agent_sdk.Types.Text _
+      | Agent_sdk.Types.Thinking _
+      | Agent_sdk.Types.RedactedThinking _
+      | Agent_sdk.Types.ToolResult _
+      | Agent_sdk.Types.Image _
+      | Agent_sdk.Types.Document _
+      | Agent_sdk.Types.Audio _ -> None)
+    msg.content
+
+let tool_result_ids_of_message (msg : Agent_sdk.Types.message) : string list =
+  List.filter_map
+    (function
+      | Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
+      (* Only [ToolResult] carries a tool_use_id reference; others contribute none. *)
+      | Agent_sdk.Types.Text _
+      | Agent_sdk.Types.Thinking _
+      | Agent_sdk.Types.RedactedThinking _
+      | Agent_sdk.Types.ToolUse _
+      | Agent_sdk.Types.Image _
+      | Agent_sdk.Types.Document _
+      | Agent_sdk.Types.Audio _ -> None)
+    msg.content
+
+let has_tool_result_block (msg : Agent_sdk.Types.message) : bool =
+  List.exists
+    (function
+      | Agent_sdk.Types.ToolResult _ -> true
+      (* Only [ToolResult] qualifies; other blocks are not tool-result evidence. *)
+      | Agent_sdk.Types.Text _
+      | Agent_sdk.Types.Thinking _
+      | Agent_sdk.Types.RedactedThinking _
+      | Agent_sdk.Types.ToolUse _
+      | Agent_sdk.Types.Image _
+      | Agent_sdk.Types.Document _
+      | Agent_sdk.Types.Audio _ -> false)
+    msg.content
+
+(** Trim messages to at most [max_count] while preserving ToolUse/ToolResult
+    pairing.  Drops from the front.  If the drop point lands on a
+    ToolResult whose ToolUse would be the last dropped message, advance
+    the drop by 1 so the orphan ToolResult is also removed (pair stays
+    together on the dropped side).  This may yield fewer than [max_count]
+    messages but never creates orphans.
+
+    Root cause of recurring "unexpected tool_use_id" errors: the previous
+    implementation used [List.filteri (fun i _ -> i >= drop)] which splits
+    on message index, breaking mid-pair boundaries. *)
+let trim_messages_preserving_pairs
+    (messages : Agent_sdk.Types.message list) ~(max_count : int)
+    : Agent_sdk.Types.message list =
+  let n = List.length messages in
+  if n <= max_count then messages
+  else
+    let drop = n - max_count in
+    (* If the first kept message would be an orphan ToolResult,
+       drop it too so the pair stays together on the removed side. *)
+    let effective_drop =
+      match List.nth_opt messages drop with
+      | Some msg when has_tool_result_block msg ->
+          (* Advance drop to skip the orphan ToolResult *)
+          drop + 1
+      | _ -> drop
+    in
+    List.filteri (fun i _ -> i >= effective_drop) messages
+
+let tool_result_text_of_block
+    ~(tool_use_id : string)
+    ~(content : string)
+    ~(json : Yojson.Safe.t option) : string =
+  let content = Inference_utils.sanitize_text_utf8 (String.trim content) in
+  if content <> "" then content
+  else
+    match json with
+    | Some value ->
+        (* Stringify json only when it fits the per-result cap. Larger
+           payloads collapse to a stub so a single orphan-repair pass
+           cannot inflate one Text block to multi-MB and trigger the same
+           escape-depth blow-up that motivated the artifact-store work
+           (see [tool_blob_store] and the tool-output-washing series). *)
+        let serialized = Yojson.Safe.to_string value in
+        let len = String.length serialized in
+        if len <= default_max_checkpoint_tool_result_chars then serialized
+        else Printf.sprintf "[tool:json id:%s bytes:%d elided]" tool_use_id len
+    | None -> Printf.sprintf "[tool result %s]" tool_use_id
+
+let tool_use_text_of_block
+    ~(tool_use_id : string)
+    ~(tool_name : string)
+    ~(input : Yojson.Safe.t) : string =
+  let tool_name = Inference_utils.sanitize_text_utf8 (String.trim tool_name) in
+  let tool_use_id =
+    Inference_utils.sanitize_text_utf8 (String.trim tool_use_id)
+  in
+  let tool_name = if tool_name = "" then "unknown_tool" else tool_name in
+  let input_json =
+    Yojson.Safe.to_string input |> Inference_utils.sanitize_text_utf8
+  in
+  Printf.sprintf "[tool use %s %s input=%s]" tool_name tool_use_id input_json
+
+type tool_pair_repair_stats =
+  { downgraded_tool_uses : int
+  ; downgraded_tool_results : int
+  }
+
+let empty_tool_pair_repair_stats =
+  { downgraded_tool_uses = 0; downgraded_tool_results = 0 }
+
+let add_tool_pair_repair_stats left right =
+  { downgraded_tool_uses =
+      left.downgraded_tool_uses + right.downgraded_tool_uses
+  ; downgraded_tool_results =
+      left.downgraded_tool_results + right.downgraded_tool_results
+  }
+
+let tool_pair_repair_stats_changed stats =
+  stats.downgraded_tool_uses > 0 || stats.downgraded_tool_results > 0
+
+let pair_repair_metadata_key = "masc.tool_pair_repair"
+
+let pair_repair_metadata_keys =
+  [ "was_fabricated"; "fabrication_source"; pair_repair_metadata_key ]
+
+let with_pair_repair_metadata ~kind ~count (msg : Agent_sdk.Types.message) =
+  let metadata =
+    List.filter
+      (fun (key, _) -> not (List.mem key pair_repair_metadata_keys))
+      msg.metadata
+  in
+  { msg with
+    metadata =
+      [ "was_fabricated", `Bool true
+      ; "fabrication_source", `String "tool_pair_repair"
+      ; ( pair_repair_metadata_key
+        , `Assoc
+            [ "version", `Int 1
+            ; "kind", `String kind
+            ; "count", `Int count
+            ] )
+      ]
+      @ metadata
+  }
+
+let repair_dangling_tool_use_messages_with_stats
+    (messages : Agent_sdk.Types.message list)
+    : Agent_sdk.Types.message list * tool_pair_repair_stats =
+  let repair_with_next
+      (current : Agent_sdk.Types.message)
+      (next_opt : Agent_sdk.Types.message option) =
+    let next_tool_result_ids =
+      match next_opt with
+      | Some next -> tool_result_ids_of_message next
+      | None -> []
+    in
+    let has_dangling =
+      List.exists
+        (function
+          | Agent_sdk.Types.ToolUse { id; _ } ->
+              not (List.mem id next_tool_result_ids)
+          (* Only [ToolUse] blocks can be dangling without a paired ToolResult. *)
+          | Agent_sdk.Types.Text _
+          | Agent_sdk.Types.Thinking _
+          | Agent_sdk.Types.RedactedThinking _
+          | Agent_sdk.Types.ToolResult _
+          | Agent_sdk.Types.Image _
+          | Agent_sdk.Types.Document _
+          | Agent_sdk.Types.Audio _ -> false)
+        current.content
+    in
+    if not has_dangling then (current, empty_tool_pair_repair_stats)
+    else
+      let downgraded_tool_uses = ref 0 in
+      let content =
+        List.map
+          (function
+            | Agent_sdk.Types.ToolUse { id; name; input }
+              when not (List.mem id next_tool_result_ids) ->
+                incr downgraded_tool_uses;
+                Agent_sdk.Types.Text
+                  (tool_use_text_of_block
+                     ~tool_use_id:id ~tool_name:name ~input)
+            | other -> other)
+          current.content
+      in
+      ( { current with content }
+        |> with_pair_repair_metadata
+             ~kind:"downgraded_tool_use"
+             ~count:!downgraded_tool_uses
+      , { empty_tool_pair_repair_stats with
+          downgraded_tool_uses = !downgraded_tool_uses
+        } )
+  in
+  let rec loop acc_stats acc = function
+    | [] -> List.rev acc, acc_stats
+    | [ current ] ->
+        let repaired, repair_stats = repair_with_next current None in
+        ( List.rev (repaired :: acc)
+        , add_tool_pair_repair_stats acc_stats repair_stats )
+    | current :: ((next :: _) as rest) ->
+        let repaired, repair_stats = repair_with_next current (Some next) in
+        loop
+          (add_tool_pair_repair_stats acc_stats repair_stats)
+          (repaired :: acc) rest
+  in
+  loop empty_tool_pair_repair_stats [] messages
+
+let repair_dangling_tool_use_messages messages =
+  fst (repair_dangling_tool_use_messages_with_stats messages)
+
+let repair_orphan_tool_result_messages_with_stats
+    (messages : Agent_sdk.Types.message list)
+    : Agent_sdk.Types.message list * tool_pair_repair_stats =
+  let rec loop acc_stats prev acc = function
+    | [] -> List.rev acc, acc_stats
+    | msg :: rest ->
+        let repaired, stats =
+          if not (has_tool_result_block msg) then
+            (msg, empty_tool_pair_repair_stats)
+          else
+            let prev_tool_use_ids =
+              match prev with
+              | Some previous -> tool_use_ids_of_message previous
+              | None -> []
+            in
+            (* Anthropic validates ToolResult blocks against ToolUse blocks
+               in the immediately previous message. If checkpoint capping
+               drops that predecessor, the resumed history becomes invalid.
+               Downgrade only the orphaned structured result blocks to
+               plain text so the semantic output survives without replaying
+               provider-specific tool metadata. *)
+            let has_orphan =
+              List.exists
+                (function
+                  | Agent_sdk.Types.ToolResult { tool_use_id; _ } ->
+                      not (List.mem tool_use_id prev_tool_use_ids)
+                  (* Only [ToolResult] can be orphaned w.r.t. prior ToolUse ids. *)
+                  | Agent_sdk.Types.Text _
+                  | Agent_sdk.Types.Thinking _
+                  | Agent_sdk.Types.RedactedThinking _
+                  | Agent_sdk.Types.ToolUse _
+                  | Agent_sdk.Types.Image _
+                  | Agent_sdk.Types.Document _
+                  | Agent_sdk.Types.Audio _ -> false)
+                msg.content
+            in
+            if not has_orphan then (msg, empty_tool_pair_repair_stats)
+            else
+              let downgraded_tool_results = ref 0 in
+              let content =
+                List.map
+                  (function
+                    | Agent_sdk.Types.ToolResult { tool_use_id; content; json; _ } ->
+                        incr downgraded_tool_results;
+                        Agent_sdk.Types.Text
+                          (tool_result_text_of_block ~tool_use_id ~content ~json)
+                    | other -> other)
+                  msg.content
+              in
+              ( { msg with content }
+                |> with_pair_repair_metadata
+                     ~kind:"downgraded_tool_result"
+                     ~count:!downgraded_tool_results
+              , { empty_tool_pair_repair_stats with
+                  downgraded_tool_results = !downgraded_tool_results
+                } )
+        in
+        loop
+          (add_tool_pair_repair_stats acc_stats stats)
+          (Some repaired) (repaired :: acc) rest
+  in
+  loop empty_tool_pair_repair_stats None [] messages
+
+let repair_orphan_tool_result_messages messages =
+  fst (repair_orphan_tool_result_messages_with_stats messages)
+
+let repair_broken_tool_call_pairs_with_stats
+    (messages : Agent_sdk.Types.message list)
+    : Agent_sdk.Types.message list * tool_pair_repair_stats =
+  let messages, dangling_stats =
+    repair_dangling_tool_use_messages_with_stats messages
+  in
+  let messages, orphan_stats = repair_orphan_tool_result_messages_with_stats messages in
+  messages, add_tool_pair_repair_stats dangling_stats orphan_stats
+
+let repair_broken_tool_call_pairs
+    (messages : Agent_sdk.Types.message list) : Agent_sdk.Types.message list =
+  fst (repair_broken_tool_call_pairs_with_stats messages)

--- a/lib/keeper/keeper_context_core_tool_pair_repair.mli
+++ b/lib/keeper/keeper_context_core_tool_pair_repair.mli
@@ -1,0 +1,32 @@
+val default_max_checkpoint_tool_result_chars : int
+val tool_use_ids_of_message : Agent_sdk.Types.message -> string list
+val tool_result_ids_of_message : Agent_sdk.Types.message -> string list
+val has_tool_result_block : Agent_sdk.Types.message -> bool
+
+val trim_messages_preserving_pairs :
+  Agent_sdk.Types.message list -> max_count:int -> Agent_sdk.Types.message list
+
+val tool_result_text_of_block :
+  tool_use_id:string -> content:string -> json:Yojson.Safe.t option -> string
+
+val tool_use_text_of_block :
+  tool_use_id:string -> tool_name:string -> input:Yojson.Safe.t -> string
+
+type tool_pair_repair_stats =
+  { downgraded_tool_uses : int
+  ; downgraded_tool_results : int
+  }
+
+val empty_tool_pair_repair_stats : tool_pair_repair_stats
+val add_tool_pair_repair_stats : tool_pair_repair_stats -> tool_pair_repair_stats -> tool_pair_repair_stats
+val tool_pair_repair_stats_changed : tool_pair_repair_stats -> bool
+val pair_repair_metadata_key : string
+val repair_dangling_tool_use_messages_with_stats :
+  Agent_sdk.Types.message list -> Agent_sdk.Types.message list * tool_pair_repair_stats
+val repair_dangling_tool_use_messages : Agent_sdk.Types.message list -> Agent_sdk.Types.message list
+val repair_orphan_tool_result_messages_with_stats :
+  Agent_sdk.Types.message list -> Agent_sdk.Types.message list * tool_pair_repair_stats
+val repair_orphan_tool_result_messages : Agent_sdk.Types.message list -> Agent_sdk.Types.message list
+val repair_broken_tool_call_pairs_with_stats :
+  Agent_sdk.Types.message list -> Agent_sdk.Types.message list * tool_pair_repair_stats
+val repair_broken_tool_call_pairs : Agent_sdk.Types.message list -> Agent_sdk.Types.message list


### PR DESCRIPTION
## Summary
- stack on #16381 and extract tool-use/tool-result pair repair into Keeper_context_core_tool_pair_repair
- keep Keeper_context_core public repair API and constants as forwarding bindings
- reduce stacked lib/keeper/keeper_context_core.ml from 1643 to 1395 LOC

## Validation
- ocamlformat --check lib/keeper/keeper_context_core.ml lib/keeper/keeper_context_core_tool_pair_repair.ml lib/keeper/keeper_context_core_tool_pair_repair.mli
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- bash scripts/lint/godfile-size-regression.sh
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_context_core_dedup.exe *(blocked before build by machine-wide bare Dune guard: live `dune build --root .` pid 46174 outside scripts/dune-local.sh)*