### PR TITLE
fix(dashboard): deduplicate trustDispositionLabel into fsm-hub-types

### DIFF
--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -193,6 +193,28 @@ export function displayState(value: string): string {
   return STATE_DISPLAY_NAMES[value] ?? value
 }
 
+/** Korean labels for `trust.disposition`. Backend emits 4 closed-sum
+ *  values via `display_disposition_of_operator`
+ *  (lib/keeper/keeper_runtime_trust_snapshot.ml:687-697):
+ *  Alert / Blocked / Pause / Pass. Kept separate from
+ *  `STATE_DISPLAY_NAMES` to avoid collision on generic PascalCase
+ *  tokens that other axes also emit. Two prior inline copies of this
+ *  map (`keeper-detail-alert-strip.ts:201-205` and
+ *  `goals/goal-tree.ts:194-199`) were identical 4-entry literals —
+ *  consolidating here closes the duplicate-definition surface in the
+ *  same spirit as #16343 (5th invariant grid). */
+const TRUST_DISPOSITION_LABELS: Record<string, string> = {
+  Alert: '경보',
+  Blocked: '차단',
+  Pause: '정지',
+  Pass: '통과',
+}
+
+export function trustDispositionLabel(value: string | null | undefined): string | null {
+  if (!value) return null
+  return TRUST_DISPOSITION_LABELS[value] ?? value
+}
+
 export type StateEntries = {
   phase: number
   turn: number

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -16,6 +16,7 @@ import { ActionButton } from '../common/button'
 import { FilterChips } from '../common/filter-chips'
 import { StatusBadge } from '../common/status-badge'
 import { ringFocusClasses } from '../common/ring'
+import { trustDispositionLabel } from '../fsm-hub-types'
 import { TimeAgo } from '../common/time-ago'
 import { TaskCreateForm } from '../task-manage/task-create-form'
 import type {
@@ -191,12 +192,9 @@ function healthLabel(health: GoalTreeNode['health']): string {
   }
 }
 
-function trustDispositionLabel(disposition: string | null | undefined): string | null {
-  if (!disposition) return null
-  return ({ Alert: '경보', Blocked: '차단', Pause: '정지', Pass: '통과' } as Record<string, string>)[
-    disposition
-  ] ?? disposition
-}
+// `trustDispositionLabel` moved to `../fsm-hub-types` to deduplicate the
+// 4-entry inline label literal that also lived in
+// `keeper-detail-alert-strip.ts:201-205`. Same map, single SSOT.
 
 function compactTrustList(items: readonly string[] | null | undefined): string[] {
   return (items ?? []).map(item => item.trim()).filter(Boolean)

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -10,6 +10,7 @@ import { TimeAgo } from './common/time-ago'
 import { formatDuration } from './mission-utils'
 import type { Keeper } from '../types'
 import { StrongSecondary, RuntimeBadge } from './keeper-detail-primitives'
+import { trustDispositionLabel as resolveTrustDispositionLabel } from './fsm-hub-types'
 import { keeperNeedsDiagnosticAttention, refreshAfterRuntimeAction } from './keeper-detail-helpers'
 import { pauseKeeper, resumeKeeper, wakeKeeper } from '../api/keeper'
 import { showToast } from './common/toast'
@@ -198,11 +199,9 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
         : trustDisposition === 'Pass'
           ? 'bg-[var(--ok-10)] text-[var(--color-status-ok)]'
           : 'bg-[var(--color-bg-hover)] text-[var(--color-fg-secondary)]'
-  const trustDispositionLabel = trustDisposition
-    ? ({ Alert: '경보', Blocked: '차단', Pause: '정지', Pass: '통과' } as Record<string, string>)[
-        trustDisposition
-      ] ?? trustDisposition
-    : null
+  // Inline 4-entry copy moved to `./fsm-hub-types` so the same map
+  // doesn't drift between this surface and `goals/goal-tree.ts:194`.
+  const trustDispositionLabel = resolveTrustDispositionLabel(trustDisposition)
 
   return html`
     <div class="px-6 pt-4">


### PR DESCRIPTION
## 요약

`trustDispositionLabel` 의 4-entry Korean 라벨 맵이 두 파일에 동일하게 인라인 복사됨:
- `keeper-detail-alert-strip.ts:201-205` (IIFE)
- `goals/goal-tree.ts:194-199` (local function)

Backend (`display_disposition_of_operator`, lib/keeper/keeper_runtime_trust_snapshot.ml:687-697) 가 정확히 4 values (Alert/Blocked/Pause/Pass) emit — 두 inline map 이 byte-for-byte 동일 but 향후 drift 가능. #16343 (5th invariant grid duplicate) 와 같은 결함 class.

## 변경

1. `fsm-hub-types.ts` — `TRUST_DISPOSITION_LABELS` const + `trustDispositionLabel(value)` helper.
2. `keeper-detail-alert-strip.ts:201-205` — IIFE 삭제; helper import (shadowing 회피 위해 `as resolveTrustDispositionLabel`).
3. `goals/goal-tree.ts:194-199` — local function 삭제; helper import.

## 검증

\`\`\`
$ pnpm typecheck                                              → clean
$ pnpm vitest run src/components/fsm-hub-types src/components/keeper-detail-alert-strip src/components/goals/goal-tree → 24/24
\`\`\`

## Related

본 세션 18번째 PR. Duplicate-definition (DRY/SSOT) 결함 class — #16343 (5th invariant duplicate) 와 같은 패턴. 함께 #16351, #16355, #16370, #16374, #16377, #16380, #16382 (label coverage), RFC-0132 (#16316) broader closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)