### PR TITLE
fix(dashboard): route latest_next_action through nextHumanActionLabel

### DIFF
--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -323,7 +323,7 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
           ? html`<span><strong class="text-[var(--color-fg-secondary)]">종료 코드</strong> · ${latestTerminalCode}${latestTerminalSummary ? html` · ${latestTerminalSummary}` : null}</span>`
           : null}
         ${latestNextAction
-          ? html`<span><strong class="text-[var(--color-fg-secondary)]">권장 조치</strong> · ${latestNextAction}</span>`
+          ? html`<span title=${latestNextAction}><strong class="text-[var(--color-fg-secondary)]">권장 조치</strong> · ${nextHumanActionLabel(latestNextAction)}</span>`
           : null}
         ${shouldShowOperatorDispositionReason
           ? html`<span><${StrongSecondary}>운영자 판단</${StrongSecondary}> · ${operatorDispositionReason}</span>`


### PR DESCRIPTION
## 요약

`keeper-detail-alert-strip.ts:302` 의 \"권장 조치 · \${latestNextAction}\" 셀이 raw 영문 토큰 표시. \`keeper.trust.latest_next_action\` 가 \`next_human_action\` 와 같은 closed-sum vocabulary 인데도 헬퍼(`nextHumanActionLabel` line 33-44 — #16355 extended) 를 우회하고 raw로 표시.

## 측정된 근거

- Backend: lib/keeper/keeper_runtime_trust_snapshot.ml:1161-1163 가 latest terminal reason 의 \`next_action\` 필드를 \`latest_next_action\` 으로 emit.
- 같은 axis 다른 source: 기존 \`keeper.next_human_action\` flat 필드와 동일 vocabulary.
- Dashboard 표시: \`권장 조치 · \${rawEnglish}\` (sister cells \"운영자 판단\" / \"주의 사유\" 는 이미 Korean 표시).

## 변경

\`latestNextAction\` 을 \`nextHumanActionLabel\` 통과; raw 토큰 \`title\` 보존.

## 검증

\`\`\`
$ pnpm typecheck                                              → clean
$ pnpm vitest run src/components/keeper-detail-alert-strip   → 3/3
\`\`\`

## Related

본 세션 19번째 PR. Alert strip Korean facade thread: #16355 (attention_reason + next_human_action), #16377 (operator_disposition + reason), #16382 (terminal_reason_code), #16388 (trustDispositionLabel SSOT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)