### PR TITLE
refactor: split keeper context checkpoint sanitize

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -167,6 +167,7 @@
   keeper_summarizer
   keeper_context_core_message_json
   keeper_context_core_tool_pair_repair
+  keeper_context_core_history_migration
   keeper_context_core
   keeper_compact_policy
   keeper_compact_audit

--- a/lib/dune
+++ b/lib/dune
@@ -165,6 +165,7 @@
   keeper_current_task_reconcile keeper_checkpoint_store
   keeper_text_processing
   keeper_summarizer
+  keeper_context_core_message_json
   keeper_context_core
   keeper_compact_policy
   keeper_compact_audit

--- a/lib/dune
+++ b/lib/dune
@@ -166,6 +166,7 @@
   keeper_text_processing
   keeper_summarizer
   keeper_context_core_message_json
+  keeper_context_core_tool_pair_repair
   keeper_context_core
   keeper_compact_policy
   keeper_compact_audit

--- a/lib/dune
+++ b/lib/dune
@@ -168,6 +168,7 @@
   keeper_context_core_message_json
   keeper_context_core_tool_pair_repair
   keeper_context_core_history_migration
+  keeper_context_core_checkpoint_sanitize
   keeper_context_core
   keeper_compact_policy
   keeper_compact_audit

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -11,6 +11,7 @@ open Printf
 open Keeper_types
 
 module StringSet = Set.Make (String)
+module Message_json = Keeper_context_core_message_json
 
 (* ================================================================ *)
 (* Constants                                                         *)
@@ -200,183 +201,17 @@ let generate_checkpoint_id () =
   let ts = int_of_float (Time_compat.now () *. 1000.0) in
   sprintf "ckpt-%d" ts
 
-let role_to_string (r : Agent_sdk.Types.role) = match r with
-  | System -> "system" | User -> "user"
-  | Assistant -> "assistant" | Tool -> "tool"
-
-(* Issue #8623: returns [Some] only for the 4 wire-format names.
-   Callers must handle [None] explicitly — the previous Variant
-   shape silently routed unknowns to [User], which misattributes
-   checkpoint messages: a "system" / "assistant" / "tool" decoded as
-   "user" causes the LLM to treat tool output as user instructions,
-   echo prior assistant replies as user input, or downgrade system
-   prompt privileges. Same anti-pattern class as #8605/#8615. *)
-let role_of_string_opt = function
-  | "system" -> Some Agent_sdk.Types.System
-  | "user" -> Some Agent_sdk.Types.User
-  | "assistant" -> Some Agent_sdk.Types.Assistant
-  | "tool" -> Some Agent_sdk.Types.Tool
-  | _ -> None
-
-(* Backwards-compatible wrapper. [Tool] is the safest fallback for an
-   unrecognised role: tool messages are interpretive context, not
-   instructions, so misclassifying System/Assistant/User as Tool hides
-   the message rather than letting the LLM act on it. The warn log
-   preserves operator visibility. *)
-let role_of_string s =
-  match role_of_string_opt s with
-  | Some role -> role
-  | None ->
-    Log.Misc.warn
-      "keeper_context_core: unknown role %S, defaulting to Tool (#8623)" s;
-    Agent_sdk.Types.Tool
-
-let content_blocks_to_json
-    (blocks : Agent_sdk.Types.content_block list) : Yojson.Safe.t =
-  `List (List.map Agent_sdk.Api.content_block_to_json blocks)
-
-let content_blocks_of_json
-    (json : Yojson.Safe.t) : Agent_sdk.Types.content_block list option =
-  let open Yojson.Safe.Util in
-  let parse_block_list = function
-    | `List blocks ->
-        let parsed =
-          List.filter_map Agent_sdk.Api.content_block_of_json blocks
-        in
-        if List.length parsed = List.length blocks then Some parsed else None
-    | _ -> None
-  in
-  match parse_block_list (json |> member "content_blocks") with
-  | Some _ as blocks -> blocks
-  | None ->
-      (* Some OAS/OpenAI-style checkpoints use a structured [content] array
-         instead of MASC's [content_blocks] field. Treat that as the same
-         block source rather than forcing the legacy flat-string path. *)
-      parse_block_list (json |> member "content")
-
-let legacy_content_text_of_json (json : Yojson.Safe.t) : string =
-  let open Yojson.Safe.Util in
-  match json |> member "content" with
-  | `String value -> Inference_utils.sanitize_text_utf8 value
-  | `Null -> ""
-  | `List blocks ->
-      let parsed =
-        List.filter_map Agent_sdk.Api.content_block_of_json blocks
-      in
-      let msg : Agent_sdk.Types.message =
-        {
-          Agent_sdk.Types.role = Agent_sdk.Types.User;
-          content = parsed;
-          name = None;
-          tool_call_id = None;
-          metadata = [];
-        }
-      in
-      Inference_utils.sanitize_text_utf8 (text_of_message msg)
-  | _ -> ""
-
-let string_field_opt key value =
-  match value with
-  | Some text -> [ (key, `String text) ]
-  | None -> []
-
-let metadata_of_json (json : Yojson.Safe.t) : (string * Yojson.Safe.t) list =
-  match Yojson.Safe.Util.member "metadata" json with
-  | `Assoc fields -> fields
-  | _ -> []
-
-let message_to_json (m : Agent_sdk.Types.message) : Yojson.Safe.t =
-  let m = Inference_utils.sanitize_message_utf8 m in
-  let tool_call_id =
-    match m.tool_call_id with
-    | Some _ as explicit -> explicit
-    | None ->
-        (match m.role with
-         | Agent_sdk.Types.Tool ->
-             List.find_map
-               (function
-                 | Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
-                 (* Other content_block variants do not carry a tool_use_id. *)
-                 | Agent_sdk.Types.Text _
-                 | Agent_sdk.Types.Thinking _
-                 | Agent_sdk.Types.RedactedThinking _
-                 | Agent_sdk.Types.ToolUse _
-                 | Agent_sdk.Types.Image _
-                 | Agent_sdk.Types.Document _
-                 | Agent_sdk.Types.Audio _ -> None)
-               m.content
-         (* Non-Tool roles never own a tool_call_id. *)
-         | Agent_sdk.Types.System
-         | Agent_sdk.Types.User
-         | Agent_sdk.Types.Assistant -> None)
-  in
-  (* SSOT: structured [content_blocks] only. The previous flat [content]
-     field was a duplicate of [text_of_message m] used by legacy
-     checkpoint readers; new readers reconstruct text from
-     [content_blocks] via [text_of_history_jsonl_line] (see below).
-     Old checkpoints written with both fields still load fine because
-     [message_of_json] keeps the legacy [content] fallback. *)
-  let base = [
-    ("role", `String (role_to_string m.role));
-    ("content_blocks", content_blocks_to_json m.content);
-  ] in
-  `Assoc
-    (base
-     @ string_field_opt "name" m.name
-     @ string_field_opt "tool_call_id" tool_call_id
-     @ if m.metadata = [] then [] else [ ("metadata", `Assoc m.metadata) ])
-
-let message_of_json (json : Yojson.Safe.t) : Agent_sdk.Types.message =
-  let open Yojson.Safe.Util in
-  let role = json |> member "role" |> to_string |> role_of_string in
-  let text = legacy_content_text_of_json json in
-  let content =
-    match content_blocks_of_json json with
-    | Some blocks ->
-        if blocks <> [] then blocks else
-        (* Legacy checkpoints stored only flattened text + role. For Tool
-           messages that means the original assistant ToolUse block is gone,
-           so rebuilding a structured ToolResult here creates an invalid
-           orphaned pair on the next Anthropic request. Fall back to plain
-           text so old checkpoints remain readable without breaking turns. *)
-        [ Agent_sdk.Types.Text text ]
-    | None ->
-        [ Agent_sdk.Types.Text text ]
-  in
-  Inference_utils.sanitize_message_utf8
-    {
-      Agent_sdk.Types.role;
-      content;
-      name =
-        (json |> member "name" |> to_string_option
-         |> Option.map Inference_utils.sanitize_text_utf8);
-      tool_call_id =
-        (json |> member "tool_call_id" |> to_string_option
-         |> Option.map Inference_utils.sanitize_text_utf8);
-      metadata = [];
-    }
-
-(** Extract human-readable text from a single history.jsonl line that was
-    produced by [message_to_json].  Reads structured [content_blocks]
-    first (current SSOT), falls back to the legacy flat [content] field
-    for lines written before that field was retired.  Returns [""] when
-    neither shape is parseable. *)
-let text_of_history_jsonl_json (json : Yojson.Safe.t) : string =
-  let open Yojson.Safe.Util in
-  match content_blocks_of_json json with
-  | Some blocks when blocks <> [] ->
-      let msg : Agent_sdk.Types.message =
-        {
-          Agent_sdk.Types.role = Agent_sdk.Types.User;
-          content = blocks;
-          name = None;
-          tool_call_id = None;
-          metadata = [];
-        }
-      in
-      Inference_utils.sanitize_text_utf8 (text_of_message msg)
-  | _ ->
-      legacy_content_text_of_json json
+let role_to_string = Message_json.role_to_string
+let role_of_string_opt = Message_json.role_of_string_opt
+let role_of_string = Message_json.role_of_string
+let content_blocks_to_json = Message_json.content_blocks_to_json
+let content_blocks_of_json = Message_json.content_blocks_of_json
+let legacy_content_text_of_json = Message_json.legacy_content_text_of_json
+let string_field_opt = Message_json.string_field_opt
+let metadata_of_json = Message_json.metadata_of_json
+let message_to_json = Message_json.message_to_json
+let message_of_json = Message_json.message_of_json
+let text_of_history_jsonl_json = Message_json.text_of_history_jsonl_json
 
 let tool_use_ids_of_message (msg : Agent_sdk.Types.message) : string list =
   List.filter_map

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -14,6 +14,7 @@ module StringSet = Set.Make (String)
 module Message_json = Keeper_context_core_message_json
 module Tool_pair_repair = Keeper_context_core_tool_pair_repair
 module History_migration = Keeper_context_core_history_migration
+module Checkpoint_sanitize = Keeper_context_core_checkpoint_sanitize
 
 (* ================================================================ *)
 (* Constants                                                         *)
@@ -29,10 +30,13 @@ let default_max_checkpoint_messages = 120
 (** Hard caps for checkpoint payload hygiene.
     Message-count capping alone is insufficient when a single message
     accumulates hundreds of text blocks or multi-MB synthetic context. *)
-let default_max_checkpoint_text_blocks_per_message = 32
-let default_max_checkpoint_text_chars_per_message = 16 * 1024
-let default_max_checkpoint_content_chars_total = 512 * 1024
-let checkpoint_text_cap_marker = "\n[capped]"
+let default_max_checkpoint_text_blocks_per_message =
+  Checkpoint_sanitize.default_max_checkpoint_text_blocks_per_message
+let default_max_checkpoint_text_chars_per_message =
+  Checkpoint_sanitize.default_max_checkpoint_text_chars_per_message
+let default_max_checkpoint_content_chars_total =
+  Checkpoint_sanitize.default_max_checkpoint_content_chars_total
+let checkpoint_text_cap_marker = Checkpoint_sanitize.checkpoint_text_cap_marker
 
 (** ToolResult block caps — analogous to text block caps above.
     Without these, a single message with hundreds of ToolResult blocks
@@ -40,9 +44,11 @@ let checkpoint_text_cap_marker = "\n[capped]"
     sanitizer untouched, causing context window overflow on next load.
     Values aligned with Claude Code: 200K aggregate, per-result 8K. *)
 let default_max_checkpoint_tool_result_chars =
-  Tool_pair_repair.default_max_checkpoint_tool_result_chars
-let default_max_checkpoint_tool_results_per_message = 20
-let default_max_checkpoint_tool_result_total_chars = 200_000
+  Checkpoint_sanitize.default_max_checkpoint_tool_result_chars
+let default_max_checkpoint_tool_results_per_message =
+  Checkpoint_sanitize.default_max_checkpoint_tool_results_per_message
+let default_max_checkpoint_tool_result_total_chars =
+  Checkpoint_sanitize.default_max_checkpoint_tool_result_total_chars
 
 (* ================================================================ *)
 (* Working Context Types (re-exported from Keeper_types)             *)
@@ -354,446 +360,51 @@ let log_keeper_exn ~label exn =
 
 let checkpoint_generation_key = "keeper_generation"
 
-type checkpoint_sanitize_stats = {
-  dropped_messages : int;
-  dropped_blocks : int;
-  dropped_chars : int;
-  truncated_blocks : int;
-  truncated_chars : int;
-}
+type checkpoint_sanitize_stats = Checkpoint_sanitize.checkpoint_sanitize_stats =
+  { dropped_messages : int
+  ; dropped_blocks : int
+  ; dropped_chars : int
+  ; truncated_blocks : int
+  ; truncated_chars : int
+  }
 
 let empty_checkpoint_sanitize_stats =
-  {
-    dropped_messages = 0;
-    dropped_blocks = 0;
-    dropped_chars = 0;
-    truncated_blocks = 0;
-    truncated_chars = 0;
-  }
+  Checkpoint_sanitize.empty_checkpoint_sanitize_stats
 
-let checkpoint_sanitize_changed (stats : checkpoint_sanitize_stats) : bool =
-  stats.dropped_messages > 0
-  || stats.dropped_blocks > 0
-  || stats.dropped_chars > 0
-  || stats.truncated_blocks > 0
-  || stats.truncated_chars > 0
+let checkpoint_sanitize_changed =
+  Checkpoint_sanitize.checkpoint_sanitize_changed
 
-let add_checkpoint_sanitize_stats
-    (a : checkpoint_sanitize_stats)
-    (b : checkpoint_sanitize_stats) : checkpoint_sanitize_stats =
-  {
-    dropped_messages = a.dropped_messages + b.dropped_messages;
-    dropped_blocks = a.dropped_blocks + b.dropped_blocks;
-    dropped_chars = a.dropped_chars + b.dropped_chars;
-    truncated_blocks = a.truncated_blocks + b.truncated_blocks;
-    truncated_chars = a.truncated_chars + b.truncated_chars;
-  }
+let add_checkpoint_sanitize_stats =
+  Checkpoint_sanitize.add_checkpoint_sanitize_stats
 
-let truncate_checkpoint_text ~max_chars (text : string) : string * int =
-  let len = String.length text in
-  if len <= max_chars then (text, 0)
-  else if max_chars <= 0 then ("", len)
-  else
-    let marker_len = String.length checkpoint_text_cap_marker in
-    if max_chars <= marker_len then
-      (String.sub checkpoint_text_cap_marker 0 max_chars, len)
-    else
-      let kept = max_chars - marker_len in
-      ( String.sub text 0 kept ^ checkpoint_text_cap_marker,
-        len - kept )
+let truncate_checkpoint_text = Checkpoint_sanitize.truncate_checkpoint_text
+let find_substring_from = Checkpoint_sanitize.find_substring_from
+let strip_world_state_segments = Checkpoint_sanitize.strip_world_state_segments
 
-let find_substring_from
-    ~(haystack : string)
-    ~(needle : string)
-    ~(start : int) : int option =
-  let hay_len = String.length haystack in
-  let needle_len = String.length needle in
-  if needle_len = 0 || start < 0 || start >= hay_len || needle_len > hay_len
-  then None
-  else
-    let rec loop idx =
-      if idx + needle_len > hay_len then None
-      else if String.sub haystack idx needle_len = needle then Some idx
-      else loop (idx + 1)
-    in
-    loop start
+let is_ephemeral_system_context_text =
+  Checkpoint_sanitize.is_ephemeral_system_context_text
 
-let strip_world_state_segments (text : string) : string =
-  let needle = "## Current World State" in
-  let rec loop current =
-    match find_substring_from ~haystack:current ~needle ~start:0 with
-    | None -> String.trim current
-    | Some idx ->
-        let seg_start =
-          match String.rindex_from_opt current idx '\n' with
-          | Some newline_idx -> newline_idx + 1
-          | None -> 0
-        in
-        let current_len = String.length current in
-        let seg_end =
-          let rec scan i =
-            if i >= current_len - 1 then current_len
-            else if current.[i] = '\n' && current.[i + 1] = '[' then i + 1
-            else scan (i + 1)
-          in
-          scan idx
-        in
-        let before = String.sub current 0 seg_start in
-        let after = String.sub current seg_end (current_len - seg_end) in
-        let combined =
-          if before = "" then after
-          else if after = "" then before
-          else before ^ "\n" ^ after
-        in
-        loop combined
-  in
-  loop text
+let sanitize_checkpoint_text_block =
+  Checkpoint_sanitize.sanitize_checkpoint_text_block
 
-let is_ephemeral_system_context_text (text : string) : bool =
-  let trimmed = String.trim text in
-  String.starts_with ~prefix:"[system context]" trimmed
+let sanitize_checkpoint_message = Checkpoint_sanitize.sanitize_checkpoint_message
 
-let sanitize_checkpoint_text_block (text : string)
-  : string option * checkpoint_sanitize_stats =
-  if is_ephemeral_system_context_text text then
-    ( None,
-      {
-        empty_checkpoint_sanitize_stats with
-        dropped_blocks = 1;
-        dropped_chars = String.length text;
-      } )
-  else if has_world_state_signature text then
-    let stripped = strip_world_state_segments text in
-    if stripped = "" then
-      ( None,
-        {
-          empty_checkpoint_sanitize_stats with
-          dropped_blocks = 1;
-          dropped_chars = String.length text;
-        } )
-    else if String.equal stripped text then
-      (Some text, empty_checkpoint_sanitize_stats)
-    else
-      ( Some stripped,
-        {
-          empty_checkpoint_sanitize_stats with
-          truncated_blocks = 1;
-          truncated_chars = String.length text - String.length stripped;
-        } )
-  else (Some text, empty_checkpoint_sanitize_stats)
+let checkpoint_content_chars_of_block =
+  Checkpoint_sanitize.checkpoint_content_chars_of_block
 
-let sanitize_checkpoint_message
-    (msg : Agent_sdk.Types.message)
-  : Agent_sdk.Types.message option * checkpoint_sanitize_stats =
-  let kept_rev, _, _, _, _, stats =
-    List.fold_left
-      (fun (kept_rev, kept_text_blocks, kept_text_chars,
-            kept_tool_results, kept_tool_result_chars, stats) block ->
-         match block with
-         | Agent_sdk.Types.Text text ->
-             let sanitized_text, text_stats =
-               sanitize_checkpoint_text_block text
-             in
-             (match sanitized_text with
-              | None ->
-                  ( kept_rev,
-                    kept_text_blocks,
-                    kept_text_chars,
-                    kept_tool_results, kept_tool_result_chars,
-                    add_checkpoint_sanitize_stats stats text_stats )
-              | Some text ->
-                  if kept_text_blocks
-                     >= default_max_checkpoint_text_blocks_per_message
-                  then
-                    ( kept_rev,
-                      kept_text_blocks,
-                      kept_text_chars,
-                      kept_tool_results, kept_tool_result_chars,
-                      add_checkpoint_sanitize_stats
-                        (add_checkpoint_sanitize_stats stats text_stats)
-                        {
-                          empty_checkpoint_sanitize_stats with
-                          dropped_blocks = 1;
-                          dropped_chars = String.length text;
-                        } )
-                  else
-                    let remaining =
-                      default_max_checkpoint_text_chars_per_message
-                      - kept_text_chars
-                    in
-                    if remaining <= 0 then
-                      ( kept_rev,
-                        kept_text_blocks,
-                        kept_text_chars,
-                        kept_tool_results, kept_tool_result_chars,
-                        add_checkpoint_sanitize_stats
-                          (add_checkpoint_sanitize_stats stats text_stats)
-                          {
-                            empty_checkpoint_sanitize_stats with
-                            dropped_blocks = 1;
-                            dropped_chars = String.length text;
-                          } )
-                    else
-                      let capped_text, truncated_chars =
-                        truncate_checkpoint_text ~max_chars:remaining text
-                      in
-                      let block_stats =
-                        if truncated_chars > 0 then
-                          {
-                            empty_checkpoint_sanitize_stats with
-                            truncated_blocks = 1;
-                            truncated_chars;
-                          }
-                        else empty_checkpoint_sanitize_stats
-                      in
-                      ( Agent_sdk.Types.Text capped_text :: kept_rev,
-                        kept_text_blocks + 1,
-                        kept_text_chars + String.length capped_text,
-                        kept_tool_results, kept_tool_result_chars,
-                        add_checkpoint_sanitize_stats
-                          (add_checkpoint_sanitize_stats stats text_stats)
-                          block_stats ))
-         | Agent_sdk.Types.Thinking { content; _ } ->
-             ( kept_rev,
-               kept_text_blocks,
-               kept_text_chars,
-               kept_tool_results, kept_tool_result_chars,
-               add_checkpoint_sanitize_stats stats
-                 {
-                   empty_checkpoint_sanitize_stats with
-                   dropped_blocks = 1;
-                   dropped_chars = String.length content;
-                 } )
-         | Agent_sdk.Types.RedactedThinking text ->
-             ( kept_rev,
-               kept_text_blocks,
-               kept_text_chars,
-               kept_tool_results, kept_tool_result_chars,
-               add_checkpoint_sanitize_stats stats
-                 {
-                   empty_checkpoint_sanitize_stats with
-                   dropped_blocks = 1;
-                   dropped_chars = String.length text;
-                 } )
-         | Agent_sdk.Types.ToolResult { tool_use_id; content; is_error; _ } ->
-             let tool_chars = String.length content in
-             if kept_tool_results
-                >= default_max_checkpoint_tool_results_per_message
-                || kept_tool_result_chars + tool_chars
-                   > default_max_checkpoint_tool_result_total_chars
-             then
-               (* Over count or aggregate budget: stub the result *)
-               let stub_content = "[tool result cleared]" in
-               let stub =
-                 Agent_sdk.Types.ToolResult
-                   { tool_use_id;
-                     content = stub_content;
-                     is_error;
-                     json = None }
-               in
-               ( stub :: kept_rev,
-                 kept_text_blocks, kept_text_chars,
-                 kept_tool_results + 1,
-                 kept_tool_result_chars + String.length stub_content,
-                 add_checkpoint_sanitize_stats stats
-                   { empty_checkpoint_sanitize_stats with
-                     dropped_blocks = 1;
-                     dropped_chars = tool_chars } )
-             else if tool_chars > default_max_checkpoint_tool_result_chars
-             then
-               (* Individual result too large: truncate *)
-               let capped =
-                 String.sub content 0
-                   default_max_checkpoint_tool_result_chars
-                 ^ checkpoint_text_cap_marker
-               in
-               let block =
-                 Agent_sdk.Types.ToolResult
-                   { tool_use_id; content = capped; is_error; json = None }
-               in
-               ( block :: kept_rev,
-                 kept_text_blocks, kept_text_chars,
-                 kept_tool_results + 1,
-                 kept_tool_result_chars
-                 + default_max_checkpoint_tool_result_chars,
-                 add_checkpoint_sanitize_stats stats
-                   { empty_checkpoint_sanitize_stats with
-                     truncated_blocks = 1;
-                     truncated_chars =
-                       tool_chars
-                       - default_max_checkpoint_tool_result_chars } )
-             else
-               (* Within budget: keep as-is *)
-               ( block :: kept_rev,
-                 kept_text_blocks, kept_text_chars,
-                 kept_tool_results + 1,
-                 kept_tool_result_chars + tool_chars,
-                 stats )
-         | _ ->
-             ( block :: kept_rev,
-               kept_text_blocks, kept_text_chars,
-               kept_tool_results, kept_tool_result_chars,
-               stats ))
-      ([], 0, 0, 0, 0, empty_checkpoint_sanitize_stats)
-      msg.content
-  in
-  let kept = List.rev kept_rev in
-  if kept = [] then
-    ( None,
-      add_checkpoint_sanitize_stats stats
-        { empty_checkpoint_sanitize_stats with dropped_messages = 1 } )
-  else (Some { msg with content = kept }, stats)
+let checkpoint_content_chars_of_message =
+  Checkpoint_sanitize.checkpoint_content_chars_of_message
 
-let checkpoint_content_chars_of_block = function
-  | Agent_sdk.Types.Text text -> String.length text
-  | Agent_sdk.Types.Thinking { content; _ } -> String.length content
-  | Agent_sdk.Types.RedactedThinking text -> String.length text
-  | Agent_sdk.Types.ToolResult { content; _ } -> String.length content
-  | _ -> 0
+let cap_checkpoint_message_to_remaining_content =
+  Checkpoint_sanitize.cap_checkpoint_message_to_remaining_content
 
-let checkpoint_content_chars_of_message (msg : Agent_sdk.Types.message) : int =
-  List.fold_left
-    (fun total block -> total + checkpoint_content_chars_of_block block)
-    0
-    msg.content
+let cap_checkpoint_messages_total_content =
+  Checkpoint_sanitize.cap_checkpoint_messages_total_content
 
-let cap_checkpoint_message_to_remaining_content
-    ~(remaining : int)
-    (msg : Agent_sdk.Types.message)
-  : Agent_sdk.Types.message option * int * checkpoint_sanitize_stats =
-  let message_chars = checkpoint_content_chars_of_message msg in
-  if message_chars = 0 then (Some msg, 0, empty_checkpoint_sanitize_stats)
-  else if remaining <= 0 then
-    ( None,
-      0,
-      {
-        empty_checkpoint_sanitize_stats with
-        dropped_messages = 1;
-        dropped_chars = message_chars;
-      } )
-  else if message_chars <= remaining then
-    (Some msg, message_chars, empty_checkpoint_sanitize_stats)
-  else
-    let remaining_ref = ref remaining in
-    let used_ref = ref 0 in
-    let kept_rev, stats =
-      List.fold_left
-        (fun (kept_rev, stats) block ->
-           let cap_content rebuild content =
-             let len = String.length content in
-             if len = 0 then
-               (rebuild content :: kept_rev, stats)
-             else if !remaining_ref <= 0 then
-               ( kept_rev,
-                 add_checkpoint_sanitize_stats stats
-                   {
-                     empty_checkpoint_sanitize_stats with
-                     dropped_blocks = 1;
-                     dropped_chars = len;
-                   } )
-             else if len <= !remaining_ref then (
-               remaining_ref := !remaining_ref - len;
-               used_ref := !used_ref + len;
-               (rebuild content :: kept_rev, stats))
-             else
-               let capped, truncated_chars =
-                 truncate_checkpoint_text ~max_chars:!remaining_ref content
-               in
-               let capped_len = String.length capped in
-               remaining_ref := 0;
-               used_ref := !used_ref + capped_len;
-               ( rebuild capped :: kept_rev,
-                 add_checkpoint_sanitize_stats stats
-                   {
-                     empty_checkpoint_sanitize_stats with
-                     truncated_blocks = 1;
-                     truncated_chars;
-                   } )
-           in
-           match block with
-           | Agent_sdk.Types.Text text ->
-               cap_content (fun text -> Agent_sdk.Types.Text text) text
-           | Agent_sdk.Types.ToolResult { tool_use_id; content; is_error; _ } ->
-               cap_content
-                 (fun content ->
-                   Agent_sdk.Types.ToolResult
-                     { tool_use_id; content; is_error; json = None })
-                 content
-           | Agent_sdk.Types.Thinking { content; _ } ->
-               cap_content (fun text -> Agent_sdk.Types.Text text) content
-           | Agent_sdk.Types.RedactedThinking text ->
-               cap_content (fun text -> Agent_sdk.Types.Text text) text
-           | _ -> (block :: kept_rev, stats))
-        ([], empty_checkpoint_sanitize_stats)
-        msg.content
-    in
-    let kept = List.rev kept_rev in
-    if kept = [] then
-      ( None,
-        !used_ref,
-        add_checkpoint_sanitize_stats stats
-          { empty_checkpoint_sanitize_stats with dropped_messages = 1 } )
-    else (Some { msg with content = kept }, !used_ref, stats)
+let sanitize_checkpoint_messages =
+  Checkpoint_sanitize.sanitize_checkpoint_messages
 
-let cap_checkpoint_messages_total_content
-    (messages : Agent_sdk.Types.message list)
-  : Agent_sdk.Types.message list * checkpoint_sanitize_stats =
-  let rec loop kept remaining stats = function
-    | [] -> (kept, stats)
-    | msg :: older ->
-        let sanitized, used, msg_stats =
-          cap_checkpoint_message_to_remaining_content ~remaining msg
-        in
-        let kept =
-          match sanitized with
-          | Some msg -> msg :: kept
-          | None -> kept
-        in
-        let remaining = max 0 (remaining - used) in
-        loop
-          kept
-          remaining
-          (add_checkpoint_sanitize_stats stats msg_stats)
-          older
-  in
-  loop
-    []
-    default_max_checkpoint_content_chars_total
-    empty_checkpoint_sanitize_stats
-    (List.rev messages)
-
-let sanitize_checkpoint_messages
-    (messages : Agent_sdk.Types.message list)
-  : Agent_sdk.Types.message list * checkpoint_sanitize_stats =
-  let messages, stats =
-    List.fold_right
-      (fun msg (acc, stats) ->
-         let sanitized_opt, msg_stats = sanitize_checkpoint_message msg in
-         let acc =
-           match sanitized_opt with
-           | Some sanitized -> sanitized :: acc
-           | None -> acc
-         in
-         let stats =
-           add_checkpoint_sanitize_stats stats msg_stats
-         in
-         (acc, stats))
-      messages
-      ([], empty_checkpoint_sanitize_stats)
-  in
-  let messages, total_stats = cap_checkpoint_messages_total_content messages in
-  (messages, add_checkpoint_sanitize_stats stats total_stats)
-
-let sanitize_oas_checkpoint
-    ?(repair_orphans = true)
-    (cp : Agent_sdk.Checkpoint.t)
-  : Agent_sdk.Checkpoint.t * checkpoint_sanitize_stats =
-  let messages, stats = sanitize_checkpoint_messages cp.messages in
-  let messages =
-    if repair_orphans then repair_broken_tool_call_pairs messages
-    else messages
-  in
-  ({ cp with messages }, stats)
+let sanitize_oas_checkpoint = Checkpoint_sanitize.sanitize_oas_checkpoint
 
 let capped_checkpoint_messages_of_context
       ~(max_checkpoint_messages : int)

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -13,6 +13,7 @@ open Keeper_types
 module StringSet = Set.Make (String)
 module Message_json = Keeper_context_core_message_json
 module Tool_pair_repair = Keeper_context_core_tool_pair_repair
+module History_migration = Keeper_context_core_history_migration
 
 (* ================================================================ *)
 (* Constants                                                         *)
@@ -304,216 +305,20 @@ let create_session ~session_id ~base_dir =
   ensure_dir session_dir;
   { session_id; session_dir; checkpoints = [] }
 
-type history_migration_stats = {
-  moved_lines : int;
-  dropped_lines : int;
-  kept_lines : int;
-  malformed_lines : int;
-}
+type history_migration_stats = History_migration.history_migration_stats =
+  { moved_lines : int
+  ; dropped_lines : int
+  ; kept_lines : int
+  ; malformed_lines : int
+  }
 
 let empty_history_migration_stats =
-  { moved_lines = 0; dropped_lines = 0; kept_lines = 0; malformed_lines = 0 }
+  History_migration.empty_history_migration_stats
 
-let split_jsonl_lines (content : string) : string list =
-  content
-  |> String.split_on_char '\n'
-  |> List.filter (fun line -> String.trim line <> "")
-
-let normalize_system_context_prefix (text : string) : string =
-  let trimmed = String.trim text in
-  let prefix = "[system context]" in
-  if String.starts_with ~prefix trimmed then
-    let prefix_len = String.length prefix in
-    let rest_len = String.length trimmed - prefix_len in
-    if rest_len <= 0 then ""
-    else String.trim (String.sub trimmed prefix_len rest_len)
-  else trimmed
-
-let has_world_state_signature (text : string) : bool =
-  let trimmed = normalize_system_context_prefix text in
-  String_util.contains_substring_ci trimmed "## Current World State"
-  &&
-  (String_util.contains_substring_ci trimmed "### Namespace State"
-   || String_util.contains_substring_ci trimmed "### Available Tools"
-   || String_util.contains_substring_ci trimmed "### Continuity")
-
-type history_line_action =
-  | Keep_main
-  | Move_internal
-  | Drop_line
-
-let classify_history_entry ~(source : string) ~(content : string) :
-    history_line_action =
-  (* World-state headings can appear in user-authored long-term memory.
-     Only explicit prompt/internal sources control history routing. *)
-  ignore content;
-  if Keeper_types.is_prompt_history_source source then Drop_line
-  else if Keeper_types.is_internal_history_source source then
-    Move_internal
-  else Keep_main
-
-let classify_history_jsonl_line (line : string) : history_line_action option =
-  try
-    let json = Yojson.Safe.from_string line in
-    let source =
-      Yojson.Safe.Util.(json |> member "source" |> to_string_option)
-      |> Option.value ~default:""
-      |> String.trim
-    in
-    let content = String.trim (text_of_history_jsonl_json json) in
-    Some (classify_history_entry ~source ~content)
-  with
-  | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None
-
-let render_jsonl_lines (lines : string list) : string =
-  match lines with
-  | [] -> ""
-  | _ -> String.concat "\n" lines ^ "\n"
-
-let dedupe_preserve_order (lines : string list) : string list =
-  let rec go seen acc = function
-    | [] -> List.rev acc
-    | line :: rest ->
-      if StringSet.mem line seen
-      then go seen acc rest
-      else go (StringSet.add line seen) (line :: acc) rest
-  in
-  go StringSet.empty [] lines
-
-let migrate_session_history_logs
-    ~(session_dir : string) : history_migration_stats =
-  let main_path = Filename.concat session_dir "history.jsonl" in
-  let internal_path = Filename.concat session_dir "history.internal.jsonl" in
-  if not (Fs_compat.file_exists main_path) && not (Fs_compat.file_exists internal_path) then
-    empty_history_migration_stats
-  else
-    let main_lines =
-      if Fs_compat.file_exists main_path then
-        split_jsonl_lines (Fs_compat.load_file main_path)
-      else []
-    in
-    let existing_internal =
-      if Fs_compat.file_exists internal_path then
-        split_jsonl_lines (Fs_compat.load_file internal_path)
-      else []
-    in
-    let kept_rev, moved_rev, dropped_main, malformed_main =
-      List.fold_left
-        (fun (kept_rev, moved_rev, dropped_lines, malformed_lines) line ->
-           match classify_history_jsonl_line line with
-           | Some Keep_main ->
-               (line :: kept_rev, moved_rev, dropped_lines, malformed_lines)
-           | Some Move_internal ->
-               (kept_rev, line :: moved_rev, dropped_lines, malformed_lines)
-           | Some Drop_line ->
-               (kept_rev, moved_rev, dropped_lines + 1, malformed_lines)
-           | None ->
-               (line :: kept_rev, moved_rev, dropped_lines, malformed_lines + 1))
-        ([], [], 0, 0)
-        main_lines
-    in
-    let kept_lines = List.rev kept_rev in
-    let moved_lines = List.rev moved_rev in
-    let internal_kept_rev, dropped_internal, malformed_internal =
-      List.fold_left
-        (fun (kept_rev, dropped_lines, malformed_lines) line ->
-           match classify_history_jsonl_line line with
-           | Some Drop_line -> (kept_rev, dropped_lines + 1, malformed_lines)
-           | Some _ -> (line :: kept_rev, dropped_lines, malformed_lines)
-           | None -> (line :: kept_rev, dropped_lines, malformed_lines + 1))
-        ([], 0, 0)
-        existing_internal
-    in
-    let sanitized_internal = List.rev internal_kept_rev in
-    let total_dropped = dropped_main + dropped_internal in
-    let malformed_lines = malformed_main + malformed_internal in
-    if moved_lines = [] && total_dropped = 0 then
-      {
-        moved_lines = 0;
-        dropped_lines = 0;
-        kept_lines = List.length kept_lines;
-        malformed_lines;
-      }
-    else
-      let merged_internal =
-        dedupe_preserve_order (sanitized_internal @ moved_lines)
-      in
-      (match Fs_compat.save_file_atomic main_path (render_jsonl_lines kept_lines) with
-       | Ok () -> ()
-       | Error detail ->
-           Prometheus.inc_counter
-             Keeper_metrics.metric_keeper_checkpoint_failures
-             ~labels:[("operation", Keeper_checkpoint_failure_operation.(to_label Migrate_main_history))]
-             ();
-           Log.Keeper.error "migrate_session_history_logs: save main history failed for %s: %s"
-             main_path detail);
-      (match
-         Fs_compat.save_file_atomic internal_path
-           (render_jsonl_lines merged_internal)
-       with
-       | Ok () -> ()
-       | Error detail ->
-           Prometheus.inc_counter
-             Keeper_metrics.metric_keeper_checkpoint_failures
-             ~labels:[("operation", Keeper_checkpoint_failure_operation.(to_label Migrate_internal_history))]
-             ();
-           Log.Keeper.error "migrate_session_history_logs: save internal history failed for %s: %s"
-             internal_path detail);
-      {
-        moved_lines = List.length moved_lines;
-        dropped_lines = total_dropped;
-        kept_lines = List.length kept_lines;
-        malformed_lines;
-      }
-
-let history_path_for_source
-    ~(session_dir : string)
-    ~(source : string option) : string =
-  match source with
-  | Some source when Keeper_types.is_internal_history_source source ->
-      Filename.concat session_dir "history.internal.jsonl"
-  | _ ->
-      Filename.concat session_dir "history.jsonl"
-
-let persist_message ?source session msg =
-  let msg = Inference_utils.sanitize_message_utf8 msg in
-  let source_text =
-    source |> Option.value ~default:"" |> String.trim
-  in
-  let content_text =
-    msg.content
-    |> List.filter_map (function
-         | Agent_sdk.Types.Text text -> Some text
-         (* Non-Text blocks contribute no inline text to the legacy field. *)
-         | Agent_sdk.Types.Thinking _
-         | Agent_sdk.Types.RedactedThinking _
-         | Agent_sdk.Types.ToolUse _
-         | Agent_sdk.Types.ToolResult _
-         | Agent_sdk.Types.Image _
-         | Agent_sdk.Types.Document _
-         | Agent_sdk.Types.Audio _ -> None)
-    |> String.concat "\n"
-  in
-  if classify_history_entry ~source:source_text ~content:content_text = Drop_line then
-    ()
-  else
-    let path = history_path_for_source ~session_dir:session.session_dir ~source in
-    let now_ts = Time_compat.now () in
-    let payload =
-      match message_to_json msg with
-      | `Assoc fields ->
-        let fields =
-          match source with
-          | Some source when String.trim source <> "" ->
-              ("source", `String source) :: fields
-          | _ -> fields
-        in
-        `Assoc
-          (("timestamp", `Float now_ts) :: ("ts_unix", `Float now_ts) :: fields)
-      | j -> j
-    in
-    let line = Yojson.Safe.to_string payload ^ "\n" in
-    Fs_compat.append_file path line
+let has_world_state_signature = History_migration.has_world_state_signature
+let migrate_session_history_logs = History_migration.migrate_session_history_logs
+let history_path_for_source = History_migration.history_path_for_source
+let persist_message = History_migration.persist_message
 
 (* ================================================================ *)
 (* End of inlined Keeper_working_context operations                  *)

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -12,6 +12,7 @@ open Keeper_types
 
 module StringSet = Set.Make (String)
 module Message_json = Keeper_context_core_message_json
+module Tool_pair_repair = Keeper_context_core_tool_pair_repair
 
 (* ================================================================ *)
 (* Constants                                                         *)
@@ -37,7 +38,8 @@ let checkpoint_text_cap_marker = "\n[capped]"
     (e.g. 280 blocks × 7K chars = 1.95M chars) passes through the
     sanitizer untouched, causing context window overflow on next load.
     Values aligned with Claude Code: 200K aggregate, per-result 8K. *)
-let default_max_checkpoint_tool_result_chars = 8_000
+let default_max_checkpoint_tool_result_chars =
+  Tool_pair_repair.default_max_checkpoint_tool_result_chars
 let default_max_checkpoint_tool_results_per_message = 20
 let default_max_checkpoint_tool_result_total_chars = 200_000
 
@@ -213,289 +215,39 @@ let message_to_json = Message_json.message_to_json
 let message_of_json = Message_json.message_of_json
 let text_of_history_jsonl_json = Message_json.text_of_history_jsonl_json
 
-let tool_use_ids_of_message (msg : Agent_sdk.Types.message) : string list =
-  List.filter_map
-    (function
-      | Agent_sdk.Types.ToolUse { id; _ } -> Some id
-      (* Only [ToolUse] carries a tool-use id; other blocks contribute none. *)
-      | Agent_sdk.Types.Text _
-      | Agent_sdk.Types.Thinking _
-      | Agent_sdk.Types.RedactedThinking _
-      | Agent_sdk.Types.ToolResult _
-      | Agent_sdk.Types.Image _
-      | Agent_sdk.Types.Document _
-      | Agent_sdk.Types.Audio _ -> None)
-    msg.content
+let tool_use_ids_of_message = Tool_pair_repair.tool_use_ids_of_message
+let tool_result_ids_of_message = Tool_pair_repair.tool_result_ids_of_message
+let has_tool_result_block = Tool_pair_repair.has_tool_result_block
+let trim_messages_preserving_pairs = Tool_pair_repair.trim_messages_preserving_pairs
+let tool_result_text_of_block = Tool_pair_repair.tool_result_text_of_block
+let tool_use_text_of_block = Tool_pair_repair.tool_use_text_of_block
 
-let tool_result_ids_of_message (msg : Agent_sdk.Types.message) : string list =
-  List.filter_map
-    (function
-      | Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
-      (* Only [ToolResult] carries a tool_use_id reference; others contribute none. *)
-      | Agent_sdk.Types.Text _
-      | Agent_sdk.Types.Thinking _
-      | Agent_sdk.Types.RedactedThinking _
-      | Agent_sdk.Types.ToolUse _
-      | Agent_sdk.Types.Image _
-      | Agent_sdk.Types.Document _
-      | Agent_sdk.Types.Audio _ -> None)
-    msg.content
-
-let has_tool_result_block (msg : Agent_sdk.Types.message) : bool =
-  List.exists
-    (function
-      | Agent_sdk.Types.ToolResult _ -> true
-      (* Only [ToolResult] qualifies; other blocks are not tool-result evidence. *)
-      | Agent_sdk.Types.Text _
-      | Agent_sdk.Types.Thinking _
-      | Agent_sdk.Types.RedactedThinking _
-      | Agent_sdk.Types.ToolUse _
-      | Agent_sdk.Types.Image _
-      | Agent_sdk.Types.Document _
-      | Agent_sdk.Types.Audio _ -> false)
-    msg.content
-
-(** Trim messages to at most [max_count] while preserving ToolUse/ToolResult
-    pairing.  Drops from the front.  If the drop point lands on a
-    ToolResult whose ToolUse would be the last dropped message, advance
-    the drop by 1 so the orphan ToolResult is also removed (pair stays
-    together on the dropped side).  This may yield fewer than [max_count]
-    messages but never creates orphans.
-
-    Root cause of recurring "unexpected tool_use_id" errors: the previous
-    implementation used [List.filteri (fun i _ -> i >= drop)] which splits
-    on message index, breaking mid-pair boundaries. *)
-let trim_messages_preserving_pairs
-    (messages : Agent_sdk.Types.message list) ~(max_count : int)
-    : Agent_sdk.Types.message list =
-  let n = List.length messages in
-  if n <= max_count then messages
-  else
-    let drop = n - max_count in
-    (* If the first kept message would be an orphan ToolResult,
-       drop it too so the pair stays together on the removed side. *)
-    let effective_drop =
-      match List.nth_opt messages drop with
-      | Some msg when has_tool_result_block msg ->
-        (* Advance drop to skip the orphan ToolResult *)
-        drop + 1
-      | _ -> drop
-    in
-    List.filteri (fun i _ -> i >= effective_drop) messages
-
-let tool_result_text_of_block
-    ~(tool_use_id : string)
-    ~(content : string)
-    ~(json : Yojson.Safe.t option) : string =
-  let content = Inference_utils.sanitize_text_utf8 (String.trim content) in
-  if content <> "" then content
-  else
-    match json with
-    | Some value ->
-        (* Stringify json only when it fits the per-result cap. Larger
-           payloads collapse to a stub so a single orphan-repair pass
-           cannot inflate one Text block to multi-MB and trigger the same
-           escape-depth blow-up that motivated the artifact-store work
-           (see [tool_blob_store] and the tool-output-washing series). *)
-        let serialized = Yojson.Safe.to_string value in
-        let len = String.length serialized in
-        if len <= default_max_checkpoint_tool_result_chars then serialized
-        else
-          Printf.sprintf "[tool:json id:%s bytes:%d elided]" tool_use_id len
-    | None -> Printf.sprintf "[tool result %s]" tool_use_id
-
-let tool_use_text_of_block
-    ~(tool_use_id : string)
-    ~(tool_name : string)
-    ~(input : Yojson.Safe.t) : string =
-  let tool_name = Inference_utils.sanitize_text_utf8 (String.trim tool_name) in
-  let tool_use_id = Inference_utils.sanitize_text_utf8 (String.trim tool_use_id) in
-  let tool_name =
-    if tool_name = "" then "unknown_tool" else tool_name
-  in
-  let input_json = Yojson.Safe.to_string input |> Inference_utils.sanitize_text_utf8 in
-  Printf.sprintf "[tool use %s %s input=%s]" tool_name tool_use_id input_json
-
-type tool_pair_repair_stats =
+type tool_pair_repair_stats = Tool_pair_repair.tool_pair_repair_stats =
   { downgraded_tool_uses : int
   ; downgraded_tool_results : int
   }
 
-let empty_tool_pair_repair_stats =
-  { downgraded_tool_uses = 0; downgraded_tool_results = 0 }
+let empty_tool_pair_repair_stats = Tool_pair_repair.empty_tool_pair_repair_stats
+let add_tool_pair_repair_stats = Tool_pair_repair.add_tool_pair_repair_stats
+let tool_pair_repair_stats_changed = Tool_pair_repair.tool_pair_repair_stats_changed
+let pair_repair_metadata_key = Tool_pair_repair.pair_repair_metadata_key
 
-let add_tool_pair_repair_stats left right =
-  { downgraded_tool_uses =
-      left.downgraded_tool_uses + right.downgraded_tool_uses
-  ; downgraded_tool_results =
-      left.downgraded_tool_results + right.downgraded_tool_results
-  }
+let repair_dangling_tool_use_messages_with_stats =
+  Tool_pair_repair.repair_dangling_tool_use_messages_with_stats
 
-let tool_pair_repair_stats_changed stats =
-  stats.downgraded_tool_uses > 0 || stats.downgraded_tool_results > 0
+let repair_dangling_tool_use_messages =
+  Tool_pair_repair.repair_dangling_tool_use_messages
 
-let pair_repair_metadata_key = "masc.tool_pair_repair"
+let repair_orphan_tool_result_messages_with_stats =
+  Tool_pair_repair.repair_orphan_tool_result_messages_with_stats
 
-let pair_repair_metadata_keys =
-  [ "was_fabricated"; "fabrication_source"; pair_repair_metadata_key ]
+let repair_orphan_tool_result_messages =
+  Tool_pair_repair.repair_orphan_tool_result_messages
 
-let with_pair_repair_metadata ~kind ~count (msg : Agent_sdk.Types.message) =
-  let metadata =
-    List.filter
-      (fun (key, _) -> not (List.mem key pair_repair_metadata_keys))
-      msg.metadata
-  in
-  { msg with
-    metadata =
-      [ "was_fabricated", `Bool true
-      ; "fabrication_source", `String "tool_pair_repair"
-      ; ( pair_repair_metadata_key
-        , `Assoc
-            [ "version", `Int 1
-            ; "kind", `String kind
-            ; "count", `Int count
-            ] )
-      ]
-      @ metadata
-  }
+let repair_broken_tool_call_pairs_with_stats =
+  Tool_pair_repair.repair_broken_tool_call_pairs_with_stats
 
-let repair_dangling_tool_use_messages_with_stats
-    (messages : Agent_sdk.Types.message list)
-    : Agent_sdk.Types.message list * tool_pair_repair_stats =
-  let repair_with_next
-      (current : Agent_sdk.Types.message)
-      (next_opt : Agent_sdk.Types.message option) =
-    let next_tool_result_ids =
-      match next_opt with
-      | Some next -> tool_result_ids_of_message next
-      | None -> []
-    in
-    let has_dangling =
-      List.exists
-        (function
-          | Agent_sdk.Types.ToolUse { id; _ } ->
-              not (List.mem id next_tool_result_ids)
-          (* Only [ToolUse] blocks can be dangling without a paired ToolResult. *)
-          | Agent_sdk.Types.Text _
-          | Agent_sdk.Types.Thinking _
-          | Agent_sdk.Types.RedactedThinking _
-          | Agent_sdk.Types.ToolResult _
-          | Agent_sdk.Types.Image _
-          | Agent_sdk.Types.Document _
-          | Agent_sdk.Types.Audio _ -> false)
-        current.content
-    in
-    if not has_dangling then (current, empty_tool_pair_repair_stats)
-    else
-      let downgraded_tool_uses = ref 0 in
-      let content =
-        List.map
-          (function
-            | Agent_sdk.Types.ToolUse { id; name; input }
-              when not (List.mem id next_tool_result_ids) ->
-                incr downgraded_tool_uses;
-                Agent_sdk.Types.Text
-                  (tool_use_text_of_block
-                     ~tool_use_id:id ~tool_name:name ~input)
-            | other -> other)
-          current.content
-      in
-      ( { current with content }
-        |> with_pair_repair_metadata
-             ~kind:"downgraded_tool_use"
-             ~count:!downgraded_tool_uses
-      , { empty_tool_pair_repair_stats with
-          downgraded_tool_uses = !downgraded_tool_uses
-        } )
-  in
-  let rec loop acc_stats acc = function
-    | [] -> List.rev acc, acc_stats
-    | [ current ] ->
-        let repaired, repair_stats = repair_with_next current None in
-        List.rev (repaired :: acc), add_tool_pair_repair_stats acc_stats repair_stats
-    | current :: ((next :: _) as rest) ->
-        let repaired, repair_stats = repair_with_next current (Some next) in
-        loop (add_tool_pair_repair_stats acc_stats repair_stats) (repaired :: acc) rest
-  in
-  loop empty_tool_pair_repair_stats [] messages
-
-let repair_dangling_tool_use_messages messages =
-  fst (repair_dangling_tool_use_messages_with_stats messages)
-
-let repair_orphan_tool_result_messages_with_stats
-    (messages : Agent_sdk.Types.message list)
-    : Agent_sdk.Types.message list * tool_pair_repair_stats =
-  let rec loop acc_stats prev acc = function
-    | [] -> List.rev acc, acc_stats
-    | msg :: rest ->
-        let repaired, stats =
-          if not (has_tool_result_block msg) then
-            (msg, empty_tool_pair_repair_stats)
-          else
-            let prev_tool_use_ids =
-              match prev with
-              | Some previous -> tool_use_ids_of_message previous
-              | None -> []
-            in
-            (* Anthropic validates ToolResult blocks against ToolUse blocks
-               in the immediately previous message. If checkpoint capping
-               drops that predecessor, the resumed history becomes invalid.
-               Downgrade only the orphaned structured result blocks to
-               plain text so the semantic output survives without replaying
-               provider-specific tool metadata. *)
-            let has_orphan =
-              List.exists
-                (function
-                  | Agent_sdk.Types.ToolResult { tool_use_id; _ } ->
-                      not (List.mem tool_use_id prev_tool_use_ids)
-                  (* Only [ToolResult] can be orphaned w.r.t. prior ToolUse ids. *)
-                  | Agent_sdk.Types.Text _
-                  | Agent_sdk.Types.Thinking _
-                  | Agent_sdk.Types.RedactedThinking _
-                  | Agent_sdk.Types.ToolUse _
-                  | Agent_sdk.Types.Image _
-                  | Agent_sdk.Types.Document _
-                  | Agent_sdk.Types.Audio _ -> false)
-                msg.content
-            in
-            if not has_orphan then (msg, empty_tool_pair_repair_stats)
-            else
-              let downgraded_tool_results = ref 0 in
-              let content =
-                List.map
-                  (function
-                    | Agent_sdk.Types.ToolResult { tool_use_id; content; json; _ } ->
-                        incr downgraded_tool_results;
-                        Agent_sdk.Types.Text
-                          (tool_result_text_of_block ~tool_use_id ~content ~json)
-                    | other -> other)
-                  msg.content
-              in
-              ( { msg with content }
-                |> with_pair_repair_metadata
-                     ~kind:"downgraded_tool_result"
-                     ~count:!downgraded_tool_results
-              , { empty_tool_pair_repair_stats with
-                  downgraded_tool_results = !downgraded_tool_results
-                } )
-        in
-        loop (add_tool_pair_repair_stats acc_stats stats) (Some repaired) (repaired :: acc) rest
-  in
-  loop empty_tool_pair_repair_stats None [] messages
-
-let repair_orphan_tool_result_messages messages =
-  fst (repair_orphan_tool_result_messages_with_stats messages)
-
-let repair_broken_tool_call_pairs_with_stats
-    (messages : Agent_sdk.Types.message list)
-    : Agent_sdk.Types.message list * tool_pair_repair_stats =
-  let messages, dangling_stats = repair_dangling_tool_use_messages_with_stats messages in
-  let messages, orphan_stats = repair_orphan_tool_result_messages_with_stats messages in
-  messages, add_tool_pair_repair_stats dangling_stats orphan_stats
-
-let repair_broken_tool_call_pairs
-    (messages : Agent_sdk.Types.message list) : Agent_sdk.Types.message list =
-  fst (repair_broken_tool_call_pairs_with_stats messages)
+let repair_broken_tool_call_pairs = Tool_pair_repair.repair_broken_tool_call_pairs
 
 let serialize_context (ctx : working_context) : string =
   let json = `Assoc [

--- a/lib/keeper/keeper_context_core_checkpoint_sanitize.ml
+++ b/lib/keeper/keeper_context_core_checkpoint_sanitize.ml
@@ -1,0 +1,453 @@
+module History_migration = Keeper_context_core_history_migration
+module Tool_pair_repair = Keeper_context_core_tool_pair_repair
+
+let default_max_checkpoint_text_blocks_per_message = 32
+let default_max_checkpoint_text_chars_per_message = 16 * 1024
+let default_max_checkpoint_content_chars_total = 512 * 1024
+let checkpoint_text_cap_marker = "\n[capped]"
+let default_max_checkpoint_tool_result_chars =
+  Tool_pair_repair.default_max_checkpoint_tool_result_chars
+let default_max_checkpoint_tool_results_per_message = 20
+let default_max_checkpoint_tool_result_total_chars = 200_000
+
+type checkpoint_sanitize_stats = {
+  dropped_messages : int;
+  dropped_blocks : int;
+  dropped_chars : int;
+  truncated_blocks : int;
+  truncated_chars : int;
+}
+
+let empty_checkpoint_sanitize_stats =
+  {
+    dropped_messages = 0;
+    dropped_blocks = 0;
+    dropped_chars = 0;
+    truncated_blocks = 0;
+    truncated_chars = 0;
+  }
+
+let checkpoint_sanitize_changed (stats : checkpoint_sanitize_stats) : bool =
+  stats.dropped_messages > 0
+  || stats.dropped_blocks > 0
+  || stats.dropped_chars > 0
+  || stats.truncated_blocks > 0
+  || stats.truncated_chars > 0
+
+let add_checkpoint_sanitize_stats
+    (a : checkpoint_sanitize_stats)
+    (b : checkpoint_sanitize_stats) : checkpoint_sanitize_stats =
+  {
+    dropped_messages = a.dropped_messages + b.dropped_messages;
+    dropped_blocks = a.dropped_blocks + b.dropped_blocks;
+    dropped_chars = a.dropped_chars + b.dropped_chars;
+    truncated_blocks = a.truncated_blocks + b.truncated_blocks;
+    truncated_chars = a.truncated_chars + b.truncated_chars;
+  }
+
+let truncate_checkpoint_text ~max_chars (text : string) : string * int =
+  let len = String.length text in
+  if len <= max_chars then (text, 0)
+  else if max_chars <= 0 then ("", len)
+  else
+    let marker_len = String.length checkpoint_text_cap_marker in
+    if max_chars <= marker_len then
+      (String.sub checkpoint_text_cap_marker 0 max_chars, len)
+    else
+      let kept = max_chars - marker_len in
+      (String.sub text 0 kept ^ checkpoint_text_cap_marker, len - kept)
+
+let find_substring_from
+    ~(haystack : string)
+    ~(needle : string)
+    ~(start : int) : int option =
+  let hay_len = String.length haystack in
+  let needle_len = String.length needle in
+  if needle_len = 0 || start < 0 || start >= hay_len || needle_len > hay_len
+  then None
+  else
+    let rec loop idx =
+      if idx + needle_len > hay_len then None
+      else if String.sub haystack idx needle_len = needle then Some idx
+      else loop (idx + 1)
+    in
+    loop start
+
+let strip_world_state_segments (text : string) : string =
+  let needle = "## Current World State" in
+  let rec loop current =
+    match find_substring_from ~haystack:current ~needle ~start:0 with
+    | None -> String.trim current
+    | Some idx ->
+        let seg_start =
+          match String.rindex_from_opt current idx '\n' with
+          | Some newline_idx -> newline_idx + 1
+          | None -> 0
+        in
+        let current_len = String.length current in
+        let seg_end =
+          let rec scan i =
+            if i >= current_len - 1 then current_len
+            else if current.[i] = '\n' && current.[i + 1] = '[' then i + 1
+            else scan (i + 1)
+          in
+          scan idx
+        in
+        let before = String.sub current 0 seg_start in
+        let after = String.sub current seg_end (current_len - seg_end) in
+        let combined =
+          if before = "" then after
+          else if after = "" then before
+          else before ^ "\n" ^ after
+        in
+        loop combined
+  in
+  loop text
+
+let is_ephemeral_system_context_text (text : string) : bool =
+  let trimmed = String.trim text in
+  String.starts_with ~prefix:"[system context]" trimmed
+
+let sanitize_checkpoint_text_block (text : string)
+  : string option * checkpoint_sanitize_stats =
+  if is_ephemeral_system_context_text text then
+    ( None,
+      {
+        empty_checkpoint_sanitize_stats with
+        dropped_blocks = 1;
+        dropped_chars = String.length text;
+      } )
+  else if History_migration.has_world_state_signature text then
+    let stripped = strip_world_state_segments text in
+    if stripped = "" then
+      ( None,
+        {
+          empty_checkpoint_sanitize_stats with
+          dropped_blocks = 1;
+          dropped_chars = String.length text;
+        } )
+    else if String.equal stripped text then
+      (Some text, empty_checkpoint_sanitize_stats)
+    else
+      ( Some stripped,
+        {
+          empty_checkpoint_sanitize_stats with
+          truncated_blocks = 1;
+          truncated_chars = String.length text - String.length stripped;
+        } )
+  else (Some text, empty_checkpoint_sanitize_stats)
+
+let sanitize_checkpoint_message
+    (msg : Agent_sdk.Types.message)
+  : Agent_sdk.Types.message option * checkpoint_sanitize_stats =
+  let kept_rev, _, _, _, _, stats =
+    List.fold_left
+      (fun ( kept_rev
+           , kept_text_blocks
+           , kept_text_chars
+           , kept_tool_results
+           , kept_tool_result_chars
+           , stats ) block ->
+        match block with
+        | Agent_sdk.Types.Text text ->
+            let sanitized_text, text_stats = sanitize_checkpoint_text_block text in
+            (match sanitized_text with
+             | None ->
+                 ( kept_rev,
+                   kept_text_blocks,
+                   kept_text_chars,
+                   kept_tool_results,
+                   kept_tool_result_chars,
+                   add_checkpoint_sanitize_stats stats text_stats )
+             | Some text ->
+                 if kept_text_blocks >= default_max_checkpoint_text_blocks_per_message
+                 then
+                   ( kept_rev,
+                     kept_text_blocks,
+                     kept_text_chars,
+                     kept_tool_results,
+                     kept_tool_result_chars,
+                     add_checkpoint_sanitize_stats
+                       (add_checkpoint_sanitize_stats stats text_stats)
+                       {
+                         empty_checkpoint_sanitize_stats with
+                         dropped_blocks = 1;
+                         dropped_chars = String.length text;
+                       } )
+                 else
+                   let remaining =
+                     default_max_checkpoint_text_chars_per_message
+                     - kept_text_chars
+                   in
+                   if remaining <= 0 then
+                     ( kept_rev,
+                       kept_text_blocks,
+                       kept_text_chars,
+                       kept_tool_results,
+                       kept_tool_result_chars,
+                       add_checkpoint_sanitize_stats
+                         (add_checkpoint_sanitize_stats stats text_stats)
+                         {
+                           empty_checkpoint_sanitize_stats with
+                           dropped_blocks = 1;
+                           dropped_chars = String.length text;
+                         } )
+                   else
+                     let capped_text, truncated_chars =
+                       truncate_checkpoint_text ~max_chars:remaining text
+                     in
+                     let block_stats =
+                       if truncated_chars > 0 then
+                         {
+                           empty_checkpoint_sanitize_stats with
+                           truncated_blocks = 1;
+                           truncated_chars;
+                         }
+                       else empty_checkpoint_sanitize_stats
+                     in
+                     ( Agent_sdk.Types.Text capped_text :: kept_rev,
+                       kept_text_blocks + 1,
+                       kept_text_chars + String.length capped_text,
+                       kept_tool_results,
+                       kept_tool_result_chars,
+                       add_checkpoint_sanitize_stats
+                         (add_checkpoint_sanitize_stats stats text_stats)
+                         block_stats ))
+        | Agent_sdk.Types.Thinking { content; _ } ->
+            ( kept_rev,
+              kept_text_blocks,
+              kept_text_chars,
+              kept_tool_results,
+              kept_tool_result_chars,
+              add_checkpoint_sanitize_stats stats
+                {
+                  empty_checkpoint_sanitize_stats with
+                  dropped_blocks = 1;
+                  dropped_chars = String.length content;
+                } )
+        | Agent_sdk.Types.RedactedThinking text ->
+            ( kept_rev,
+              kept_text_blocks,
+              kept_text_chars,
+              kept_tool_results,
+              kept_tool_result_chars,
+              add_checkpoint_sanitize_stats stats
+                {
+                  empty_checkpoint_sanitize_stats with
+                  dropped_blocks = 1;
+                  dropped_chars = String.length text;
+                } )
+        | Agent_sdk.Types.ToolResult { tool_use_id; content; is_error; _ } ->
+            let tool_chars = String.length content in
+            if
+              kept_tool_results >= default_max_checkpoint_tool_results_per_message
+              || kept_tool_result_chars + tool_chars
+                 > default_max_checkpoint_tool_result_total_chars
+            then
+              let stub_content = "[tool result cleared]" in
+              let stub =
+                Agent_sdk.Types.ToolResult
+                  { tool_use_id; content = stub_content; is_error; json = None }
+              in
+              ( stub :: kept_rev,
+                kept_text_blocks,
+                kept_text_chars,
+                kept_tool_results + 1,
+                kept_tool_result_chars + String.length stub_content,
+                add_checkpoint_sanitize_stats stats
+                  {
+                    empty_checkpoint_sanitize_stats with
+                    dropped_blocks = 1;
+                    dropped_chars = tool_chars;
+                  } )
+            else if tool_chars > default_max_checkpoint_tool_result_chars then
+              let capped =
+                String.sub content 0 default_max_checkpoint_tool_result_chars
+                ^ checkpoint_text_cap_marker
+              in
+              let block =
+                Agent_sdk.Types.ToolResult
+                  { tool_use_id; content = capped; is_error; json = None }
+              in
+              ( block :: kept_rev,
+                kept_text_blocks,
+                kept_text_chars,
+                kept_tool_results + 1,
+                kept_tool_result_chars + default_max_checkpoint_tool_result_chars,
+                add_checkpoint_sanitize_stats stats
+                  {
+                    empty_checkpoint_sanitize_stats with
+                    truncated_blocks = 1;
+                    truncated_chars =
+                      tool_chars - default_max_checkpoint_tool_result_chars;
+                  } )
+            else
+              ( block :: kept_rev,
+                kept_text_blocks,
+                kept_text_chars,
+                kept_tool_results + 1,
+                kept_tool_result_chars + tool_chars,
+                stats )
+        | _ ->
+            ( block :: kept_rev,
+              kept_text_blocks,
+              kept_text_chars,
+              kept_tool_results,
+              kept_tool_result_chars,
+              stats ))
+      ([], 0, 0, 0, 0, empty_checkpoint_sanitize_stats)
+      msg.content
+  in
+  let kept = List.rev kept_rev in
+  if kept = [] then
+    ( None,
+      add_checkpoint_sanitize_stats stats
+        { empty_checkpoint_sanitize_stats with dropped_messages = 1 } )
+  else (Some { msg with content = kept }, stats)
+
+let checkpoint_content_chars_of_block = function
+  | Agent_sdk.Types.Text text -> String.length text
+  | Agent_sdk.Types.Thinking { content; _ } -> String.length content
+  | Agent_sdk.Types.RedactedThinking text -> String.length text
+  | Agent_sdk.Types.ToolResult { content; _ } -> String.length content
+  | _ -> 0
+
+let checkpoint_content_chars_of_message (msg : Agent_sdk.Types.message) : int =
+  List.fold_left
+    (fun total block -> total + checkpoint_content_chars_of_block block)
+    0 msg.content
+
+let cap_checkpoint_message_to_remaining_content
+    ~(remaining : int)
+    (msg : Agent_sdk.Types.message)
+  : Agent_sdk.Types.message option * int * checkpoint_sanitize_stats =
+  let message_chars = checkpoint_content_chars_of_message msg in
+  if message_chars = 0 then (Some msg, 0, empty_checkpoint_sanitize_stats)
+  else if remaining <= 0 then
+    ( None,
+      0,
+      {
+        empty_checkpoint_sanitize_stats with
+        dropped_messages = 1;
+        dropped_chars = message_chars;
+      } )
+  else if message_chars <= remaining then
+    (Some msg, message_chars, empty_checkpoint_sanitize_stats)
+  else
+    let remaining_ref = ref remaining in
+    let used_ref = ref 0 in
+    let kept_rev, stats =
+      List.fold_left
+        (fun (kept_rev, stats) block ->
+          let cap_content rebuild content =
+            let len = String.length content in
+            if len = 0 then (rebuild content :: kept_rev, stats)
+            else if !remaining_ref <= 0 then
+              ( kept_rev,
+                add_checkpoint_sanitize_stats stats
+                  {
+                    empty_checkpoint_sanitize_stats with
+                    dropped_blocks = 1;
+                    dropped_chars = len;
+                  } )
+            else if len <= !remaining_ref then (
+              remaining_ref := !remaining_ref - len;
+              used_ref := !used_ref + len;
+              (rebuild content :: kept_rev, stats))
+            else
+              let capped, truncated_chars =
+                truncate_checkpoint_text ~max_chars:!remaining_ref content
+              in
+              let capped_len = String.length capped in
+              remaining_ref := 0;
+              used_ref := !used_ref + capped_len;
+              ( rebuild capped :: kept_rev,
+                add_checkpoint_sanitize_stats stats
+                  {
+                    empty_checkpoint_sanitize_stats with
+                    truncated_blocks = 1;
+                    truncated_chars;
+                  } )
+          in
+          match block with
+          | Agent_sdk.Types.Text text ->
+              cap_content (fun text -> Agent_sdk.Types.Text text) text
+          | Agent_sdk.Types.ToolResult { tool_use_id; content; is_error; _ } ->
+              cap_content
+                (fun content ->
+                  Agent_sdk.Types.ToolResult
+                    { tool_use_id; content; is_error; json = None })
+                content
+          | Agent_sdk.Types.Thinking { content; _ } ->
+              cap_content (fun text -> Agent_sdk.Types.Text text) content
+          | Agent_sdk.Types.RedactedThinking text ->
+              cap_content (fun text -> Agent_sdk.Types.Text text) text
+          | _ -> (block :: kept_rev, stats))
+        ([], empty_checkpoint_sanitize_stats)
+        msg.content
+    in
+    let kept = List.rev kept_rev in
+    if kept = [] then
+      ( None,
+        !used_ref,
+        add_checkpoint_sanitize_stats stats
+          { empty_checkpoint_sanitize_stats with dropped_messages = 1 } )
+    else (Some { msg with content = kept }, !used_ref, stats)
+
+let cap_checkpoint_messages_total_content
+    (messages : Agent_sdk.Types.message list)
+  : Agent_sdk.Types.message list * checkpoint_sanitize_stats =
+  let rec loop kept remaining stats = function
+    | [] -> (kept, stats)
+    | msg :: older ->
+        let sanitized, used, msg_stats =
+          cap_checkpoint_message_to_remaining_content ~remaining msg
+        in
+        let kept =
+          match sanitized with
+          | Some msg -> msg :: kept
+          | None -> kept
+        in
+        let remaining = max 0 (remaining - used) in
+        loop
+          kept
+          remaining
+          (add_checkpoint_sanitize_stats stats msg_stats)
+          older
+  in
+  loop
+    []
+    default_max_checkpoint_content_chars_total
+    empty_checkpoint_sanitize_stats
+    (List.rev messages)
+
+let sanitize_checkpoint_messages
+    (messages : Agent_sdk.Types.message list)
+  : Agent_sdk.Types.message list * checkpoint_sanitize_stats =
+  let messages, stats =
+    List.fold_right
+      (fun msg (acc, stats) ->
+        let sanitized_opt, msg_stats = sanitize_checkpoint_message msg in
+        let acc =
+          match sanitized_opt with
+          | Some sanitized -> sanitized :: acc
+          | None -> acc
+        in
+        let stats = add_checkpoint_sanitize_stats stats msg_stats in
+        (acc, stats))
+      messages
+      ([], empty_checkpoint_sanitize_stats)
+  in
+  let messages, total_stats = cap_checkpoint_messages_total_content messages in
+  (messages, add_checkpoint_sanitize_stats stats total_stats)
+
+let sanitize_oas_checkpoint
+    ?(repair_orphans = true)
+    (cp : Agent_sdk.Checkpoint.t)
+  : Agent_sdk.Checkpoint.t * checkpoint_sanitize_stats =
+  let messages, stats = sanitize_checkpoint_messages cp.messages in
+  let messages =
+    if repair_orphans then Tool_pair_repair.repair_broken_tool_call_pairs messages
+    else messages
+  in
+  ({ cp with messages }, stats)

--- a/lib/keeper/keeper_context_core_checkpoint_sanitize.mli
+++ b/lib/keeper/keeper_context_core_checkpoint_sanitize.mli
@@ -1,0 +1,39 @@
+val default_max_checkpoint_text_blocks_per_message : int
+val default_max_checkpoint_text_chars_per_message : int
+val default_max_checkpoint_content_chars_total : int
+val checkpoint_text_cap_marker : string
+val default_max_checkpoint_tool_result_chars : int
+val default_max_checkpoint_tool_results_per_message : int
+val default_max_checkpoint_tool_result_total_chars : int
+
+type checkpoint_sanitize_stats = {
+  dropped_messages : int;
+  dropped_blocks : int;
+  dropped_chars : int;
+  truncated_blocks : int;
+  truncated_chars : int;
+}
+
+val empty_checkpoint_sanitize_stats : checkpoint_sanitize_stats
+val checkpoint_sanitize_changed : checkpoint_sanitize_stats -> bool
+val add_checkpoint_sanitize_stats : checkpoint_sanitize_stats -> checkpoint_sanitize_stats -> checkpoint_sanitize_stats
+val truncate_checkpoint_text : max_chars:int -> string -> string * int
+val find_substring_from : haystack:string -> needle:string -> start:int -> int option
+val strip_world_state_segments : string -> string
+val is_ephemeral_system_context_text : string -> bool
+val sanitize_checkpoint_text_block : string -> string option * checkpoint_sanitize_stats
+val sanitize_checkpoint_message : Agent_sdk.Types.message -> Agent_sdk.Types.message option * checkpoint_sanitize_stats
+val checkpoint_content_chars_of_block : Agent_sdk.Types.content_block -> int
+val checkpoint_content_chars_of_message : Agent_sdk.Types.message -> int
+val cap_checkpoint_message_to_remaining_content :
+  remaining:int ->
+  Agent_sdk.Types.message ->
+  Agent_sdk.Types.message option * int * checkpoint_sanitize_stats
+val cap_checkpoint_messages_total_content :
+  Agent_sdk.Types.message list -> Agent_sdk.Types.message list * checkpoint_sanitize_stats
+val sanitize_checkpoint_messages :
+  Agent_sdk.Types.message list -> Agent_sdk.Types.message list * checkpoint_sanitize_stats
+val sanitize_oas_checkpoint :
+  ?repair_orphans:bool ->
+  Agent_sdk.Checkpoint.t ->
+  Agent_sdk.Checkpoint.t * checkpoint_sanitize_stats

--- a/lib/keeper/keeper_context_core_history_migration.ml
+++ b/lib/keeper/keeper_context_core_history_migration.ml
@@ -1,0 +1,222 @@
+module StringSet = Set.Make (String)
+module Message_json = Keeper_context_core_message_json
+
+type history_migration_stats = {
+  moved_lines : int;
+  dropped_lines : int;
+  kept_lines : int;
+  malformed_lines : int;
+}
+
+let empty_history_migration_stats =
+  { moved_lines = 0; dropped_lines = 0; kept_lines = 0; malformed_lines = 0 }
+
+let split_jsonl_lines (content : string) : string list =
+  content
+  |> String.split_on_char '\n'
+  |> List.filter (fun line -> String.trim line <> "")
+
+let normalize_system_context_prefix (text : string) : string =
+  let trimmed = String.trim text in
+  let prefix = "[system context]" in
+  if String.starts_with ~prefix trimmed then
+    let prefix_len = String.length prefix in
+    let rest_len = String.length trimmed - prefix_len in
+    if rest_len <= 0 then ""
+    else String.trim (String.sub trimmed prefix_len rest_len)
+  else trimmed
+
+let has_world_state_signature (text : string) : bool =
+  let trimmed = normalize_system_context_prefix text in
+  String_util.contains_substring_ci trimmed "## Current World State"
+  &&
+  (String_util.contains_substring_ci trimmed "### Namespace State"
+   || String_util.contains_substring_ci trimmed "### Available Tools"
+   || String_util.contains_substring_ci trimmed "### Continuity")
+
+type history_line_action =
+  | Keep_main
+  | Move_internal
+  | Drop_line
+
+let classify_history_entry ~(source : string) ~(content : string) :
+    history_line_action =
+  (* World-state headings can appear in user-authored long-term memory.
+     Only explicit prompt/internal sources control history routing. *)
+  ignore content;
+  if Keeper_types.is_prompt_history_source source then Drop_line
+  else if Keeper_types.is_internal_history_source source then Move_internal
+  else Keep_main
+
+let classify_history_jsonl_line (line : string) : history_line_action option =
+  try
+    let json = Yojson.Safe.from_string line in
+    let source =
+      Yojson.Safe.Util.(json |> member "source" |> to_string_option)
+      |> Option.value ~default:""
+      |> String.trim
+    in
+    let content = String.trim (Message_json.text_of_history_jsonl_json json) in
+    Some (classify_history_entry ~source ~content)
+  with
+  | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None
+
+let render_jsonl_lines (lines : string list) : string =
+  match lines with
+  | [] -> ""
+  | _ -> String.concat "\n" lines ^ "\n"
+
+let dedupe_preserve_order (lines : string list) : string list =
+  let rec go seen acc = function
+    | [] -> List.rev acc
+    | line :: rest ->
+        if StringSet.mem line seen then go seen acc rest
+        else go (StringSet.add line seen) (line :: acc) rest
+  in
+  go StringSet.empty [] lines
+
+let migrate_session_history_logs
+    ~(session_dir : string) : history_migration_stats =
+  let main_path = Filename.concat session_dir "history.jsonl" in
+  let internal_path = Filename.concat session_dir "history.internal.jsonl" in
+  if
+    (not (Fs_compat.file_exists main_path))
+    && not (Fs_compat.file_exists internal_path)
+  then empty_history_migration_stats
+  else
+    let main_lines =
+      if Fs_compat.file_exists main_path then
+        split_jsonl_lines (Fs_compat.load_file main_path)
+      else []
+    in
+    let existing_internal =
+      if Fs_compat.file_exists internal_path then
+        split_jsonl_lines (Fs_compat.load_file internal_path)
+      else []
+    in
+    let kept_rev, moved_rev, dropped_main, malformed_main =
+      List.fold_left
+        (fun (kept_rev, moved_rev, dropped_lines, malformed_lines) line ->
+          match classify_history_jsonl_line line with
+          | Some Keep_main ->
+              (line :: kept_rev, moved_rev, dropped_lines, malformed_lines)
+          | Some Move_internal ->
+              (kept_rev, line :: moved_rev, dropped_lines, malformed_lines)
+          | Some Drop_line ->
+              (kept_rev, moved_rev, dropped_lines + 1, malformed_lines)
+          | None ->
+              (line :: kept_rev, moved_rev, dropped_lines, malformed_lines + 1))
+        ([], [], 0, 0)
+        main_lines
+    in
+    let kept_lines = List.rev kept_rev in
+    let moved_lines = List.rev moved_rev in
+    let internal_kept_rev, dropped_internal, malformed_internal =
+      List.fold_left
+        (fun (kept_rev, dropped_lines, malformed_lines) line ->
+          match classify_history_jsonl_line line with
+          | Some Drop_line -> (kept_rev, dropped_lines + 1, malformed_lines)
+          | Some _ -> (line :: kept_rev, dropped_lines, malformed_lines)
+          | None -> (line :: kept_rev, dropped_lines, malformed_lines + 1))
+        ([], 0, 0)
+        existing_internal
+    in
+    let sanitized_internal = List.rev internal_kept_rev in
+    let total_dropped = dropped_main + dropped_internal in
+    let malformed_lines = malformed_main + malformed_internal in
+    if moved_lines = [] && total_dropped = 0 then
+      {
+        moved_lines = 0;
+        dropped_lines = 0;
+        kept_lines = List.length kept_lines;
+        malformed_lines;
+      }
+    else
+      let merged_internal =
+        dedupe_preserve_order (sanitized_internal @ moved_lines)
+      in
+      (match Fs_compat.save_file_atomic main_path (render_jsonl_lines kept_lines) with
+       | Ok () -> ()
+       | Error detail ->
+           Prometheus.inc_counter
+             Keeper_metrics.metric_keeper_checkpoint_failures
+             ~labels:
+               [
+                 ( "operation",
+                   Keeper_checkpoint_failure_operation.(
+                     to_label Migrate_main_history) );
+               ]
+             ();
+           Log.Keeper.error
+             "migrate_session_history_logs: save main history failed for %s: %s"
+             main_path detail);
+      (match
+         Fs_compat.save_file_atomic internal_path
+           (render_jsonl_lines merged_internal)
+       with
+       | Ok () -> ()
+       | Error detail ->
+           Prometheus.inc_counter
+             Keeper_metrics.metric_keeper_checkpoint_failures
+             ~labels:
+               [
+                 ( "operation",
+                   Keeper_checkpoint_failure_operation.(
+                     to_label Migrate_internal_history) );
+               ]
+             ();
+           Log.Keeper.error
+             "migrate_session_history_logs: save internal history failed for %s: %s"
+             internal_path detail);
+      {
+        moved_lines = List.length moved_lines;
+        dropped_lines = total_dropped;
+        kept_lines = List.length kept_lines;
+        malformed_lines;
+      }
+
+let history_path_for_source
+    ~(session_dir : string)
+    ~(source : string option) : string =
+  match source with
+  | Some source when Keeper_types.is_internal_history_source source ->
+      Filename.concat session_dir "history.internal.jsonl"
+  | _ -> Filename.concat session_dir "history.jsonl"
+
+let persist_message ?source (session : Keeper_types.session_context) msg =
+  let msg = Inference_utils.sanitize_message_utf8 msg in
+  let source_text = source |> Option.value ~default:"" |> String.trim in
+  let content_text =
+    msg.content
+    |> List.filter_map (function
+         | Agent_sdk.Types.Text text -> Some text
+         (* Non-Text blocks contribute no inline text to the legacy field. *)
+         | Agent_sdk.Types.Thinking _
+         | Agent_sdk.Types.RedactedThinking _
+         | Agent_sdk.Types.ToolUse _
+         | Agent_sdk.Types.ToolResult _
+         | Agent_sdk.Types.Image _
+         | Agent_sdk.Types.Document _
+         | Agent_sdk.Types.Audio _ -> None)
+    |> String.concat "\n"
+  in
+  if classify_history_entry ~source:source_text ~content:content_text = Drop_line
+  then ()
+  else
+    let path = history_path_for_source ~session_dir:session.session_dir ~source in
+    let now_ts = Time_compat.now () in
+    let payload =
+      match Message_json.message_to_json msg with
+      | `Assoc fields ->
+          let fields =
+            match source with
+            | Some source when String.trim source <> "" ->
+                ("source", `String source) :: fields
+            | _ -> fields
+          in
+          `Assoc
+            (("timestamp", `Float now_ts) :: ("ts_unix", `Float now_ts) :: fields)
+      | j -> j
+    in
+    let line = Yojson.Safe.to_string payload ^ "\n" in
+    Fs_compat.append_file path line

--- a/lib/keeper/keeper_context_core_history_migration.mli
+++ b/lib/keeper/keeper_context_core_history_migration.mli
@@ -1,0 +1,19 @@
+type history_migration_stats =
+  { moved_lines : int
+  ; dropped_lines : int
+  ; kept_lines : int
+  ; malformed_lines : int
+  }
+
+val empty_history_migration_stats : history_migration_stats
+val has_world_state_signature : string -> bool
+val migrate_session_history_logs : session_dir:string -> history_migration_stats
+
+val history_path_for_source :
+  session_dir:string -> source:string option -> string
+
+val persist_message :
+  ?source:string ->
+  Keeper_types.session_context ->
+  Agent_sdk.Types.message ->
+  unit

--- a/lib/keeper/keeper_context_core_message_json.ml
+++ b/lib/keeper/keeper_context_core_message_json.ml
@@ -1,0 +1,177 @@
+let role_to_string (r : Agent_sdk.Types.role) =
+  match r with
+  | System -> "system"
+  | User -> "user"
+  | Assistant -> "assistant"
+  | Tool -> "tool"
+
+(* Issue #8623: returns [Some] only for the 4 wire-format names.
+   Callers must handle [None] explicitly — the previous Variant
+   shape silently routed unknowns to [User], which misattributes
+   checkpoint messages: a "system" / "assistant" / "tool" decoded as
+   "user" causes the LLM to treat tool output as user instructions,
+   echo prior assistant replies as user input, or downgrade system
+   prompt privileges. Same anti-pattern class as #8605/#8615. *)
+let role_of_string_opt = function
+  | "system" -> Some Agent_sdk.Types.System
+  | "user" -> Some Agent_sdk.Types.User
+  | "assistant" -> Some Agent_sdk.Types.Assistant
+  | "tool" -> Some Agent_sdk.Types.Tool
+  | _ -> None
+
+(* Backwards-compatible wrapper. [Tool] is the safest fallback for an
+   unrecognised role: tool messages are interpretive context, not
+   instructions, so misclassifying System/Assistant/User as Tool hides
+   the message rather than letting the LLM act on it. The warn log
+   preserves operator visibility. *)
+let role_of_string s =
+  match role_of_string_opt s with
+  | Some role -> role
+  | None ->
+      Log.Misc.warn
+        "keeper_context_core: unknown role %S, defaulting to Tool (#8623)" s;
+      Agent_sdk.Types.Tool
+
+let content_blocks_to_json
+    (blocks : Agent_sdk.Types.content_block list) : Yojson.Safe.t =
+  `List (List.map Agent_sdk.Api.content_block_to_json blocks)
+
+let content_blocks_of_json
+    (json : Yojson.Safe.t) : Agent_sdk.Types.content_block list option =
+  let open Yojson.Safe.Util in
+  let parse_block_list = function
+    | `List blocks ->
+        let parsed = List.filter_map Agent_sdk.Api.content_block_of_json blocks in
+        if List.length parsed = List.length blocks then Some parsed else None
+    | _ -> None
+  in
+  match parse_block_list (json |> member "content_blocks") with
+  | Some _ as blocks -> blocks
+  | None ->
+      (* Some OAS/OpenAI-style checkpoints use a structured [content] array
+         instead of MASC's [content_blocks] field. Treat that as the same
+         block source rather than forcing the legacy flat-string path. *)
+      parse_block_list (json |> member "content")
+
+let legacy_content_text_of_json (json : Yojson.Safe.t) : string =
+  let open Yojson.Safe.Util in
+  match json |> member "content" with
+  | `String value -> Inference_utils.sanitize_text_utf8 value
+  | `Null -> ""
+  | `List blocks ->
+      let parsed = List.filter_map Agent_sdk.Api.content_block_of_json blocks in
+      let msg : Agent_sdk.Types.message =
+        {
+          Agent_sdk.Types.role = Agent_sdk.Types.User;
+          content = parsed;
+          name = None;
+          tool_call_id = None;
+          metadata = [];
+        }
+      in
+      Inference_utils.sanitize_text_utf8 (Agent_sdk.Types.text_of_message msg)
+  | _ -> ""
+
+let string_field_opt key value =
+  match value with
+  | Some text -> [ (key, `String text) ]
+  | None -> []
+
+let metadata_of_json (json : Yojson.Safe.t) : (string * Yojson.Safe.t) list =
+  match Yojson.Safe.Util.member "metadata" json with
+  | `Assoc fields -> fields
+  | _ -> []
+
+let message_to_json (m : Agent_sdk.Types.message) : Yojson.Safe.t =
+  let m = Inference_utils.sanitize_message_utf8 m in
+  let tool_call_id =
+    match m.tool_call_id with
+    | Some _ as explicit -> explicit
+    | None -> (
+        match m.role with
+        | Agent_sdk.Types.Tool ->
+            List.find_map
+              (function
+                | Agent_sdk.Types.ToolResult { tool_use_id; _ } ->
+                    Some tool_use_id
+                (* Other content_block variants do not carry a tool_use_id. *)
+                | Agent_sdk.Types.Text _
+                | Agent_sdk.Types.Thinking _
+                | Agent_sdk.Types.RedactedThinking _
+                | Agent_sdk.Types.ToolUse _
+                | Agent_sdk.Types.Image _
+                | Agent_sdk.Types.Document _
+                | Agent_sdk.Types.Audio _ -> None)
+              m.content
+        (* Non-Tool roles never own a tool_call_id. *)
+        | Agent_sdk.Types.System
+        | Agent_sdk.Types.User
+        | Agent_sdk.Types.Assistant -> None)
+  in
+  (* SSOT: structured [content_blocks] only. The previous flat [content]
+     field was a duplicate of [text_of_message m] used by legacy
+     checkpoint readers; new readers reconstruct text from
+     [content_blocks] via [text_of_history_jsonl_line] (see below).
+     Old checkpoints written with both fields still load fine because
+     [message_of_json] keeps the legacy [content] fallback. *)
+  let base =
+    [
+      ("role", `String (role_to_string m.role));
+      ("content_blocks", content_blocks_to_json m.content);
+    ]
+  in
+  `Assoc
+    (base
+     @ string_field_opt "name" m.name
+     @ string_field_opt "tool_call_id" tool_call_id
+     @ if m.metadata = [] then [] else [ ("metadata", `Assoc m.metadata) ])
+
+let message_of_json (json : Yojson.Safe.t) : Agent_sdk.Types.message =
+  let open Yojson.Safe.Util in
+  let role = json |> member "role" |> to_string |> role_of_string in
+  let text = legacy_content_text_of_json json in
+  let content =
+    match content_blocks_of_json json with
+    | Some blocks ->
+        if blocks <> [] then blocks
+        else
+          (* Legacy checkpoints stored only flattened text + role. For Tool
+             messages that means the original assistant ToolUse block is gone,
+             so rebuilding a structured ToolResult here creates an invalid
+             orphaned pair on the next Anthropic request. Fall back to plain
+             text so old checkpoints remain readable without breaking turns. *)
+          [ Agent_sdk.Types.Text text ]
+    | None -> [ Agent_sdk.Types.Text text ]
+  in
+  Inference_utils.sanitize_message_utf8
+    {
+      Agent_sdk.Types.role;
+      content;
+      name =
+        (json |> member "name" |> to_string_option
+         |> Option.map Inference_utils.sanitize_text_utf8);
+      tool_call_id =
+        (json |> member "tool_call_id" |> to_string_option
+         |> Option.map Inference_utils.sanitize_text_utf8);
+      metadata = [];
+    }
+
+(** Extract human-readable text from a single history.jsonl line that was
+    produced by [message_to_json].  Reads structured [content_blocks]
+    first (current SSOT), falls back to the legacy flat [content] field
+    for lines written before that field was retired.  Returns [""] when
+    neither shape is parseable. *)
+let text_of_history_jsonl_json (json : Yojson.Safe.t) : string =
+  match content_blocks_of_json json with
+  | Some blocks when blocks <> [] ->
+      let msg : Agent_sdk.Types.message =
+        {
+          Agent_sdk.Types.role = Agent_sdk.Types.User;
+          content = blocks;
+          name = None;
+          tool_call_id = None;
+          metadata = [];
+        }
+      in
+      Inference_utils.sanitize_text_utf8 (Agent_sdk.Types.text_of_message msg)
+  | _ -> legacy_content_text_of_json json

--- a/lib/keeper/keeper_context_core_message_json.mli
+++ b/lib/keeper/keeper_context_core_message_json.mli
@@ -1,0 +1,16 @@
+val role_to_string : Agent_sdk.Types.role -> string
+val role_of_string_opt : string -> Agent_sdk.Types.role option
+val role_of_string : string -> Agent_sdk.Types.role
+
+val content_blocks_to_json :
+  Agent_sdk.Types.content_block list -> Yojson.Safe.t
+
+val content_blocks_of_json :
+  Yojson.Safe.t -> Agent_sdk.Types.content_block list option
+
+val legacy_content_text_of_json : Yojson.Safe.t -> string
+val string_field_opt : string -> string option -> (string * Yojson.Safe.t) list
+val metadata_of_json : Yojson.Safe.t -> (string * Yojson.Safe.t) list
+val message_to_json : Agent_sdk.Types.message -> Yojson.Safe.t
+val message_of_json : Yojson.Safe.t -> Agent_sdk.Types.message
+val text_of_history_jsonl_json : Yojson.Safe.t -> string

--- a/lib/keeper/keeper_context_core_tool_pair_repair.ml
+++ b/lib/keeper/keeper_context_core_tool_pair_repair.ml
@@ -1,0 +1,293 @@
+let default_max_checkpoint_tool_result_chars = 8_000
+
+let tool_use_ids_of_message (msg : Agent_sdk.Types.message) : string list =
+  List.filter_map
+    (function
+      | Agent_sdk.Types.ToolUse { id; _ } -> Some id
+      (* Only [ToolUse] carries a tool-use id; other blocks contribute none. *)
+      | Agent_sdk.Types.Text _
+      | Agent_sdk.Types.Thinking _
+      | Agent_sdk.Types.RedactedThinking _
+      | Agent_sdk.Types.ToolResult _
+      | Agent_sdk.Types.Image _
+      | Agent_sdk.Types.Document _
+      | Agent_sdk.Types.Audio _ -> None)
+    msg.content
+
+let tool_result_ids_of_message (msg : Agent_sdk.Types.message) : string list =
+  List.filter_map
+    (function
+      | Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
+      (* Only [ToolResult] carries a tool_use_id reference; others contribute none. *)
+      | Agent_sdk.Types.Text _
+      | Agent_sdk.Types.Thinking _
+      | Agent_sdk.Types.RedactedThinking _
+      | Agent_sdk.Types.ToolUse _
+      | Agent_sdk.Types.Image _
+      | Agent_sdk.Types.Document _
+      | Agent_sdk.Types.Audio _ -> None)
+    msg.content
+
+let has_tool_result_block (msg : Agent_sdk.Types.message) : bool =
+  List.exists
+    (function
+      | Agent_sdk.Types.ToolResult _ -> true
+      (* Only [ToolResult] qualifies; other blocks are not tool-result evidence. *)
+      | Agent_sdk.Types.Text _
+      | Agent_sdk.Types.Thinking _
+      | Agent_sdk.Types.RedactedThinking _
+      | Agent_sdk.Types.ToolUse _
+      | Agent_sdk.Types.Image _
+      | Agent_sdk.Types.Document _
+      | Agent_sdk.Types.Audio _ -> false)
+    msg.content
+
+(** Trim messages to at most [max_count] while preserving ToolUse/ToolResult
+    pairing.  Drops from the front.  If the drop point lands on a
+    ToolResult whose ToolUse would be the last dropped message, advance
+    the drop by 1 so the orphan ToolResult is also removed (pair stays
+    together on the dropped side).  This may yield fewer than [max_count]
+    messages but never creates orphans.
+
+    Root cause of recurring "unexpected tool_use_id" errors: the previous
+    implementation used [List.filteri (fun i _ -> i >= drop)] which splits
+    on message index, breaking mid-pair boundaries. *)
+let trim_messages_preserving_pairs
+    (messages : Agent_sdk.Types.message list) ~(max_count : int)
+    : Agent_sdk.Types.message list =
+  let n = List.length messages in
+  if n <= max_count then messages
+  else
+    let drop = n - max_count in
+    (* If the first kept message would be an orphan ToolResult,
+       drop it too so the pair stays together on the removed side. *)
+    let effective_drop =
+      match List.nth_opt messages drop with
+      | Some msg when has_tool_result_block msg ->
+          (* Advance drop to skip the orphan ToolResult *)
+          drop + 1
+      | _ -> drop
+    in
+    List.filteri (fun i _ -> i >= effective_drop) messages
+
+let tool_result_text_of_block
+    ~(tool_use_id : string)
+    ~(content : string)
+    ~(json : Yojson.Safe.t option) : string =
+  let content = Inference_utils.sanitize_text_utf8 (String.trim content) in
+  if content <> "" then content
+  else
+    match json with
+    | Some value ->
+        (* Stringify json only when it fits the per-result cap. Larger
+           payloads collapse to a stub so a single orphan-repair pass
+           cannot inflate one Text block to multi-MB and trigger the same
+           escape-depth blow-up that motivated the artifact-store work
+           (see [tool_blob_store] and the tool-output-washing series). *)
+        let serialized = Yojson.Safe.to_string value in
+        let len = String.length serialized in
+        if len <= default_max_checkpoint_tool_result_chars then serialized
+        else Printf.sprintf "[tool:json id:%s bytes:%d elided]" tool_use_id len
+    | None -> Printf.sprintf "[tool result %s]" tool_use_id
+
+let tool_use_text_of_block
+    ~(tool_use_id : string)
+    ~(tool_name : string)
+    ~(input : Yojson.Safe.t) : string =
+  let tool_name = Inference_utils.sanitize_text_utf8 (String.trim tool_name) in
+  let tool_use_id =
+    Inference_utils.sanitize_text_utf8 (String.trim tool_use_id)
+  in
+  let tool_name = if tool_name = "" then "unknown_tool" else tool_name in
+  let input_json =
+    Yojson.Safe.to_string input |> Inference_utils.sanitize_text_utf8
+  in
+  Printf.sprintf "[tool use %s %s input=%s]" tool_name tool_use_id input_json
+
+type tool_pair_repair_stats =
+  { downgraded_tool_uses : int
+  ; downgraded_tool_results : int
+  }
+
+let empty_tool_pair_repair_stats =
+  { downgraded_tool_uses = 0; downgraded_tool_results = 0 }
+
+let add_tool_pair_repair_stats left right =
+  { downgraded_tool_uses =
+      left.downgraded_tool_uses + right.downgraded_tool_uses
+  ; downgraded_tool_results =
+      left.downgraded_tool_results + right.downgraded_tool_results
+  }
+
+let tool_pair_repair_stats_changed stats =
+  stats.downgraded_tool_uses > 0 || stats.downgraded_tool_results > 0
+
+let pair_repair_metadata_key = "masc.tool_pair_repair"
+
+let pair_repair_metadata_keys =
+  [ "was_fabricated"; "fabrication_source"; pair_repair_metadata_key ]
+
+let with_pair_repair_metadata ~kind ~count (msg : Agent_sdk.Types.message) =
+  let metadata =
+    List.filter
+      (fun (key, _) -> not (List.mem key pair_repair_metadata_keys))
+      msg.metadata
+  in
+  { msg with
+    metadata =
+      [ "was_fabricated", `Bool true
+      ; "fabrication_source", `String "tool_pair_repair"
+      ; ( pair_repair_metadata_key
+        , `Assoc
+            [ "version", `Int 1
+            ; "kind", `String kind
+            ; "count", `Int count
+            ] )
+      ]
+      @ metadata
+  }
+
+let repair_dangling_tool_use_messages_with_stats
+    (messages : Agent_sdk.Types.message list)
+    : Agent_sdk.Types.message list * tool_pair_repair_stats =
+  let repair_with_next
+      (current : Agent_sdk.Types.message)
+      (next_opt : Agent_sdk.Types.message option) =
+    let next_tool_result_ids =
+      match next_opt with
+      | Some next -> tool_result_ids_of_message next
+      | None -> []
+    in
+    let has_dangling =
+      List.exists
+        (function
+          | Agent_sdk.Types.ToolUse { id; _ } ->
+              not (List.mem id next_tool_result_ids)
+          (* Only [ToolUse] blocks can be dangling without a paired ToolResult. *)
+          | Agent_sdk.Types.Text _
+          | Agent_sdk.Types.Thinking _
+          | Agent_sdk.Types.RedactedThinking _
+          | Agent_sdk.Types.ToolResult _
+          | Agent_sdk.Types.Image _
+          | Agent_sdk.Types.Document _
+          | Agent_sdk.Types.Audio _ -> false)
+        current.content
+    in
+    if not has_dangling then (current, empty_tool_pair_repair_stats)
+    else
+      let downgraded_tool_uses = ref 0 in
+      let content =
+        List.map
+          (function
+            | Agent_sdk.Types.ToolUse { id; name; input }
+              when not (List.mem id next_tool_result_ids) ->
+                incr downgraded_tool_uses;
+                Agent_sdk.Types.Text
+                  (tool_use_text_of_block
+                     ~tool_use_id:id ~tool_name:name ~input)
+            | other -> other)
+          current.content
+      in
+      ( { current with content }
+        |> with_pair_repair_metadata
+             ~kind:"downgraded_tool_use"
+             ~count:!downgraded_tool_uses
+      , { empty_tool_pair_repair_stats with
+          downgraded_tool_uses = !downgraded_tool_uses
+        } )
+  in
+  let rec loop acc_stats acc = function
+    | [] -> List.rev acc, acc_stats
+    | [ current ] ->
+        let repaired, repair_stats = repair_with_next current None in
+        ( List.rev (repaired :: acc)
+        , add_tool_pair_repair_stats acc_stats repair_stats )
+    | current :: ((next :: _) as rest) ->
+        let repaired, repair_stats = repair_with_next current (Some next) in
+        loop
+          (add_tool_pair_repair_stats acc_stats repair_stats)
+          (repaired :: acc) rest
+  in
+  loop empty_tool_pair_repair_stats [] messages
+
+let repair_dangling_tool_use_messages messages =
+  fst (repair_dangling_tool_use_messages_with_stats messages)
+
+let repair_orphan_tool_result_messages_with_stats
+    (messages : Agent_sdk.Types.message list)
+    : Agent_sdk.Types.message list * tool_pair_repair_stats =
+  let rec loop acc_stats prev acc = function
+    | [] -> List.rev acc, acc_stats
+    | msg :: rest ->
+        let repaired, stats =
+          if not (has_tool_result_block msg) then
+            (msg, empty_tool_pair_repair_stats)
+          else
+            let prev_tool_use_ids =
+              match prev with
+              | Some previous -> tool_use_ids_of_message previous
+              | None -> []
+            in
+            (* Anthropic validates ToolResult blocks against ToolUse blocks
+               in the immediately previous message. If checkpoint capping
+               drops that predecessor, the resumed history becomes invalid.
+               Downgrade only the orphaned structured result blocks to
+               plain text so the semantic output survives without replaying
+               provider-specific tool metadata. *)
+            let has_orphan =
+              List.exists
+                (function
+                  | Agent_sdk.Types.ToolResult { tool_use_id; _ } ->
+                      not (List.mem tool_use_id prev_tool_use_ids)
+                  (* Only [ToolResult] can be orphaned w.r.t. prior ToolUse ids. *)
+                  | Agent_sdk.Types.Text _
+                  | Agent_sdk.Types.Thinking _
+                  | Agent_sdk.Types.RedactedThinking _
+                  | Agent_sdk.Types.ToolUse _
+                  | Agent_sdk.Types.Image _
+                  | Agent_sdk.Types.Document _
+                  | Agent_sdk.Types.Audio _ -> false)
+                msg.content
+            in
+            if not has_orphan then (msg, empty_tool_pair_repair_stats)
+            else
+              let downgraded_tool_results = ref 0 in
+              let content =
+                List.map
+                  (function
+                    | Agent_sdk.Types.ToolResult { tool_use_id; content; json; _ } ->
+                        incr downgraded_tool_results;
+                        Agent_sdk.Types.Text
+                          (tool_result_text_of_block ~tool_use_id ~content ~json)
+                    | other -> other)
+                  msg.content
+              in
+              ( { msg with content }
+                |> with_pair_repair_metadata
+                     ~kind:"downgraded_tool_result"
+                     ~count:!downgraded_tool_results
+              , { empty_tool_pair_repair_stats with
+                  downgraded_tool_results = !downgraded_tool_results
+                } )
+        in
+        loop
+          (add_tool_pair_repair_stats acc_stats stats)
+          (Some repaired) (repaired :: acc) rest
+  in
+  loop empty_tool_pair_repair_stats None [] messages
+
+let repair_orphan_tool_result_messages messages =
+  fst (repair_orphan_tool_result_messages_with_stats messages)
+
+let repair_broken_tool_call_pairs_with_stats
+    (messages : Agent_sdk.Types.message list)
+    : Agent_sdk.Types.message list * tool_pair_repair_stats =
+  let messages, dangling_stats =
+    repair_dangling_tool_use_messages_with_stats messages
+  in
+  let messages, orphan_stats = repair_orphan_tool_result_messages_with_stats messages in
+  messages, add_tool_pair_repair_stats dangling_stats orphan_stats
+
+let repair_broken_tool_call_pairs
+    (messages : Agent_sdk.Types.message list) : Agent_sdk.Types.message list =
+  fst (repair_broken_tool_call_pairs_with_stats messages)

--- a/lib/keeper/keeper_context_core_tool_pair_repair.mli
+++ b/lib/keeper/keeper_context_core_tool_pair_repair.mli
@@ -1,0 +1,32 @@
+val default_max_checkpoint_tool_result_chars : int
+val tool_use_ids_of_message : Agent_sdk.Types.message -> string list
+val tool_result_ids_of_message : Agent_sdk.Types.message -> string list
+val has_tool_result_block : Agent_sdk.Types.message -> bool
+
+val trim_messages_preserving_pairs :
+  Agent_sdk.Types.message list -> max_count:int -> Agent_sdk.Types.message list
+
+val tool_result_text_of_block :
+  tool_use_id:string -> content:string -> json:Yojson.Safe.t option -> string
+
+val tool_use_text_of_block :
+  tool_use_id:string -> tool_name:string -> input:Yojson.Safe.t -> string
+
+type tool_pair_repair_stats =
+  { downgraded_tool_uses : int
+  ; downgraded_tool_results : int
+  }
+
+val empty_tool_pair_repair_stats : tool_pair_repair_stats
+val add_tool_pair_repair_stats : tool_pair_repair_stats -> tool_pair_repair_stats -> tool_pair_repair_stats
+val tool_pair_repair_stats_changed : tool_pair_repair_stats -> bool
+val pair_repair_metadata_key : string
+val repair_dangling_tool_use_messages_with_stats :
+  Agent_sdk.Types.message list -> Agent_sdk.Types.message list * tool_pair_repair_stats
+val repair_dangling_tool_use_messages : Agent_sdk.Types.message list -> Agent_sdk.Types.message list
+val repair_orphan_tool_result_messages_with_stats :
+  Agent_sdk.Types.message list -> Agent_sdk.Types.message list * tool_pair_repair_stats
+val repair_orphan_tool_result_messages : Agent_sdk.Types.message list -> Agent_sdk.Types.message list
+val repair_broken_tool_call_pairs_with_stats :
+  Agent_sdk.Types.message list -> Agent_sdk.Types.message list * tool_pair_repair_stats
+val repair_broken_tool_call_pairs : Agent_sdk.Types.message list -> Agent_sdk.Types.message list


### PR DESCRIPTION
## Summary
- Stack on #16386.
- Extract checkpoint sanitizer/capping helpers into Keeper_context_core_checkpoint_sanitize.
- Keep Keeper_context_core public sanitizer constants and helper names as forwarding bindings.
- Reduce stacked lib/keeper/keeper_context_core.ml from 1200 to 811 lines.

## Validation
- ocamlformat --check lib/keeper/keeper_context_core.ml lib/keeper/keeper_context_core_checkpoint_sanitize.ml lib/keeper/keeper_context_core_checkpoint_sanitize.mli
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- bash scripts/lint/godfile-size-regression.sh
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_context_core_dedup.exe (blocked before build: live bare dune build PID 81199 outside scripts/dune-local.sh)