### PR TITLE
fix(cascade): escalate repeated preflight unhealthy skips to typed disable

### DIFF
--- a/lib/cascade/cascade_preflight_state.ml
+++ b/lib/cascade/cascade_preflight_state.ml
@@ -1,0 +1,169 @@
+(** Implementation: see [Cascade_preflight_state.mli] for surface docs.
+
+    Closed sum types only — no catch-all branches in this file. *)
+
+type reason =
+  | Health_check_failed_repeatedly
+  | Permanent_unhealthy
+  | Transient_unhealthy
+  | Rate_limited_long_window
+
+type fingerprint = {
+  tier_group : string;
+  provider : string;
+  reason : reason;
+}
+
+type record_outcome =
+  [ `First
+  | `Repeated of int
+  | `Threshold_disable of int
+  | `Already_disabled
+  ]
+
+let default_threshold = 5
+
+(* Stable kebab-case slug for log interpolation and metric labels. *)
+let reason_slug = function
+  | Health_check_failed_repeatedly -> "health-check-failed-repeatedly"
+  | Permanent_unhealthy -> "permanent-unhealthy"
+  | Transient_unhealthy -> "transient-unhealthy"
+  | Rate_limited_long_window -> "rate-limited-long-window"
+;;
+
+(* Owned metric names. Following the cascade_metrics.ml RFC-0043 pattern
+   (module owns its constants; [Prometheus.ml]'s register_all() may mirror
+   for /metrics endpoint registration later). *)
+let metric_preflight_unhealthy_skip =
+  "masc_cascade_preflight_unhealthy_skip_total"
+;;
+
+let metric_provider_disabled = "masc_cascade_provider_disabled_total"
+let metric_provider_re_enabled = "masc_cascade_provider_re_enabled_total"
+
+(* ── State ──────────────────────────────────────────────────────── *)
+
+(* [Hashtbl] keyed by an opaque triple to avoid string interpolation
+   collisions when tier_group or provider contain separators. *)
+module Key = struct
+  type t = fingerprint
+
+  let equal (a : t) (b : t) =
+    String.equal a.tier_group b.tier_group
+    && String.equal a.provider b.provider
+    && a.reason = b.reason
+  ;;
+
+  let hash (k : t) =
+    Hashtbl.hash (k.tier_group, k.provider, reason_slug k.reason)
+  ;;
+end
+
+module FpTbl = Hashtbl.Make (Key)
+
+(* Per-provider disabled set membership — separate from fingerprint
+   counts so [is_disabled] is O(1) without scanning all fingerprints. *)
+module StrTbl = Hashtbl.Make (struct
+  type t = string
+
+  let equal = String.equal
+  let hash = Hashtbl.seeded_hash 0
+end)
+
+type t = {
+  counts : int FpTbl.t;
+  disabled : unit StrTbl.t;
+  mu : Stdlib.Mutex.t;
+      (* Stdlib.Mutex selected per feedback_ocaml5-mutex-selection.md:
+         cross-fiber, single-domain, no Eio effect dependency. The
+         critical section is small (table lookup + counter bump). *)
+  threshold : int;
+}
+
+let create ?(threshold = default_threshold) () =
+  {
+    counts = FpTbl.create 16;
+    disabled = StrTbl.create 8;
+    mu = Stdlib.Mutex.create ();
+    threshold;
+  }
+;;
+
+let global = create ()
+
+let with_lock t f =
+  Stdlib.Mutex.lock t.mu;
+  Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock t.mu) (fun () -> f ())
+;;
+
+(* ── Public API ─────────────────────────────────────────────────── *)
+
+let record t ~tier_group ~provider ~reason : record_outcome =
+  let fp = { tier_group; provider; reason } in
+  with_lock t (fun () ->
+    (* Always tick the per-call counter so dashboards see absolute
+       skip volume (independent of disable transitions). *)
+    Prometheus.inc_counter metric_preflight_unhealthy_skip
+      ~labels:
+        [ ("cascade", tier_group)
+        ; ("provider", provider)
+        ; ("reason", reason_slug reason)
+        ]
+      ();
+    if StrTbl.mem t.disabled provider
+    then `Already_disabled
+    else (
+      let prev = FpTbl.find_opt t.counts fp |> Option.value ~default:0 in
+      let next = prev + 1 in
+      FpTbl.replace t.counts fp next;
+      if next = 1
+      then `First
+      else if next >= t.threshold
+      then (
+        StrTbl.replace t.disabled provider ();
+        Prometheus.inc_counter metric_provider_disabled
+          ~labels:
+            [ ("cascade", tier_group)
+            ; ("provider", provider)
+            ; ("reason", reason_slug reason)
+            ]
+          ();
+        `Threshold_disable next)
+      else `Repeated next))
+;;
+
+let is_disabled t ~provider =
+  with_lock t (fun () -> StrTbl.mem t.disabled provider)
+;;
+
+let reset_on_health_recovery t ~provider =
+  with_lock t (fun () ->
+    let was_disabled = StrTbl.mem t.disabled provider in
+    StrTbl.remove t.disabled provider;
+    (* Drop all fingerprints for this provider, regardless of reason. *)
+    let stale_keys =
+      FpTbl.fold
+        (fun fp _count acc ->
+          if String.equal fp.provider provider then fp :: acc else acc)
+        t.counts
+        []
+    in
+    List.iter (fun fp -> FpTbl.remove t.counts fp) stale_keys;
+    if was_disabled
+    then
+      Prometheus.inc_counter metric_provider_re_enabled
+        ~labels:[ ("provider", provider) ]
+        ();
+    was_disabled)
+;;
+
+let disabled_providers t =
+  with_lock t (fun () ->
+    StrTbl.fold (fun provider () acc -> provider :: acc) t.disabled [])
+;;
+
+let reset_for_test t =
+  with_lock t (fun () ->
+    FpTbl.reset t.counts;
+    StrTbl.reset t.disabled)
+;;

--- a/lib/cascade/cascade_preflight_state.mli
+++ b/lib/cascade/cascade_preflight_state.mli
@@ -1,0 +1,113 @@
+(** Cascade preflight unhealthy-skip escalation state.
+
+    Tracks repeated [preflight skipped N unhealthy ...] events per
+    (tier_group, provider, reason) fingerprint. After [threshold_disable]
+    consecutive skips of the same fingerprint, the provider is registered
+    in an in-memory disabled list and a single ERROR-class escalation is
+    emitted (instead of a WARN per skip).
+
+    A successful health recovery (caller invokes
+    [reset_on_health_recovery]) clears all fingerprints for that provider
+    and removes it from the disabled list, emitting one INFO transition.
+
+    {1 Design notes}
+
+    - Routing semantics are preserved: the disabled list is advisory.
+      Callers may still attempt the provider; this module only changes
+      the {e log-level cadence}, not routing.
+    - State is in-memory only (per-process). Survives across cascade
+      attempts in one keeper-server lifetime; rebuilt at restart.
+    - Closed sum types only, no catch-all match.
+
+    {1 References}
+
+    - MASC/OAS Error-Warn Reduction Goal — 2026-05-18 §P3 (provider
+      cascade exhaustion).
+    - System log slice 2026-05-18, last 30min:
+      [strict_tool_candidates: preflight skipped 1 unhealthy] x35,
+      [glm-coding-with-spark: preflight skipped 1 unhealthy] x12. *)
+
+(** Reason for a single preflight unhealthy-skip event. Closed sum,
+    extend by adding a constructor (compiler enforces exhaustive
+    match downstream). *)
+type reason =
+  | Health_check_failed_repeatedly
+      (** Local-endpoint /health probe failed on the immediately
+          preceding cycle; same provider URL keeps failing. *)
+  | Permanent_unhealthy
+      (** Endpoint advertises a non-recoverable status (e.g. 410,
+          model-not-found, configuration error). *)
+  | Transient_unhealthy
+      (** Endpoint failed but the failure class is expected to
+          self-heal (e.g. cold-start, brief network blip). *)
+  | Rate_limited_long_window
+      (** Endpoint is healthy but currently rate-limited; the limit
+          window is long enough to count as a preflight skip. *)
+
+(** Fingerprint of a single skip event. *)
+type fingerprint = {
+  tier_group : string;  (** Cascade name (e.g. ["strict_tool_candidates"]). *)
+  provider : string;  (** Provider key or endpoint URL. *)
+  reason : reason;
+}
+
+(** Outcome of [record]: [`First] means this is a brand-new
+    fingerprint (or just-reset); [`Repeated n] means [n]th occurrence
+    (1-based after the first, so n>=2) but threshold not yet reached;
+    [`Threshold_disable n] means the fingerprint crossed
+    [threshold_disable] (n is the consecutive count, n=threshold) — the
+    caller should emit a single ERROR escalation and add the provider
+    to the disabled list. Subsequent matching records return
+    [`Already_disabled] until [reset_on_health_recovery] is called. *)
+type record_outcome =
+  [ `First
+  | `Repeated of int
+  | `Threshold_disable of int
+  | `Already_disabled
+  ]
+
+(** Default consecutive-skip threshold. Crossing this triggers
+    [`Threshold_disable]. *)
+val default_threshold : int
+
+(** Opaque tracker handle. The module exposes a process-singleton
+    [global], but creating local instances is supported for tests. *)
+type t
+
+(** Create a fresh tracker. Tests should call this for isolation
+    instead of using [global]. [threshold] defaults to
+    [default_threshold]. *)
+val create : ?threshold:int -> unit -> t
+
+(** Process-singleton tracker used by production code paths. *)
+val global : t
+
+(** Record one preflight unhealthy-skip event. Returns the outcome,
+    which the caller uses to decide log level and disable-list
+    registration. Increments
+    [masc_cascade_preflight_unhealthy_skip_total] (always) and
+    [masc_cascade_provider_disabled_total] (on the [`Threshold_disable]
+    transition). *)
+val record :
+  t -> tier_group:string -> provider:string -> reason:reason -> record_outcome
+
+(** True iff the provider is currently in the disabled list (i.e. some
+    fingerprint crossed threshold and recovery has not happened yet). *)
+val is_disabled : t -> provider:string -> bool
+
+(** Clear all fingerprints for the given provider and remove it from
+    the disabled list. Returns [true] iff the provider was previously
+    disabled (callers use this to emit a single INFO line on
+    transition). *)
+val reset_on_health_recovery : t -> provider:string -> bool
+
+(** Snapshot of currently disabled providers. Order is unspecified;
+    callers should sort for stable output. *)
+val disabled_providers : t -> string list
+
+(** Render a [reason] as a stable, kebab-case slug for log
+    interpolation and metric labels. *)
+val reason_slug : reason -> string
+
+(** Reset the entire tracker to its initial state. Test-only helper. *)
+val reset_for_test : t -> unit

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -372,13 +372,81 @@ let run_named
   let local_prefiltered_candidate_count =
     List.length local_prefiltered_candidates
   in
-  if unhealthy_local_endpoints <> [] then
-    Log.Misc.warn
-      "cascade %s: preflight skipped %d unhealthy local endpoint(s) before \
-       provider dispatch: [%s]"
-      cascade_name
-      (List.length unhealthy_local_endpoints)
-      (String.concat ", " unhealthy_local_endpoints);
+  (* RFC: MASC/OAS Error-Warn Reduction Goal — 2026-05-18 §P3.
+     For each unhealthy endpoint, record the preflight-skip event in
+     [Cascade_preflight_state.global]. After N consecutive skips of
+     the same (cascade, endpoint, reason) fingerprint we escalate to
+     ERROR once and register the endpoint in the in-process disabled
+     list — subsequent identical skips return [`Already_disabled] and
+     are dropped to DEBUG, so the log volume drops from ~35-50/30min
+     to a small fixed number of transitions.
+     Routing semantics are preserved: the disabled list is advisory
+     for log-level cadence; the existing
+     [filter_unhealthy_local_runtime_urls] already removed these
+     endpoints from [candidates]. *)
+  List.iter
+    (fun endpoint ->
+      let outcome =
+        Cascade_preflight_state.record
+          Cascade_preflight_state.global
+          ~tier_group:cascade_name
+          ~provider:endpoint
+          ~reason:Cascade_preflight_state.Health_check_failed_repeatedly
+      in
+      match outcome with
+      | `First ->
+        Log.Misc.warn
+          "cascade %s: preflight skipped 1 unhealthy local endpoint(s) before \
+           provider dispatch: [%s] (reason=%s, first occurrence)"
+          cascade_name
+          endpoint
+          (Cascade_preflight_state.reason_slug
+             Cascade_preflight_state.Health_check_failed_repeatedly)
+      | `Repeated n ->
+        Log.Misc.warn
+          "cascade %s: preflight skipped 1 unhealthy local endpoint(s) before \
+           provider dispatch: [%s] (reason=%s, consecutive=%d)"
+          cascade_name
+          endpoint
+          (Cascade_preflight_state.reason_slug
+             Cascade_preflight_state.Health_check_failed_repeatedly)
+          n
+      | `Threshold_disable n ->
+        Log.Misc.error
+          "cascade %s: provider [%s] disabled after %d consecutive preflight \
+           unhealthy skips (reason=%s); subsequent skips silenced via \
+           disabled-list. Recovery requires successful health probe."
+          cascade_name
+          endpoint
+          n
+          (Cascade_preflight_state.reason_slug
+             Cascade_preflight_state.Health_check_failed_repeatedly)
+      | `Already_disabled ->
+        (* Drop noise: this endpoint is in the disabled list and has
+           already emitted its ERROR escalation. *)
+        Log.Misc.debug
+          "cascade %s: preflight skipped already-disabled endpoint [%s]"
+          cascade_name endpoint)
+    unhealthy_local_endpoints;
+  (* Recovery: for any endpoint that probed healthy this cycle, clear
+     fingerprints + emit one INFO if it had been disabled. *)
+  List.iter
+    (fun (url, healthy) ->
+      if healthy
+         && Cascade_preflight_state.is_disabled
+              Cascade_preflight_state.global ~provider:url
+      then
+        let recovered =
+          Cascade_preflight_state.reset_on_health_recovery
+            Cascade_preflight_state.global ~provider:url
+        in
+        if recovered
+        then
+          Log.Misc.info
+            "cascade %s: provider [%s] re-enabled after successful health \
+             probe; removed from disabled-list."
+            cascade_name url)
+    local_endpoint_health;
   let candidates = local_prefiltered_candidates in
   if health_cooldown_fail_open then
     Log.Misc.warn

--- a/test/cascade_preflight_state/prometheus.ml
+++ b/test/cascade_preflight_state/prometheus.ml
@@ -1,0 +1,18 @@
+(** Stub Prometheus module used only by the standalone test build.
+
+    The real [Prometheus] module pulls in [prometheus_store], [eio], and
+    a large dependency closure. For unit tests of
+    [Cascade_preflight_state] we only need [inc_counter] to be callable
+    without raising — the test asserts on [record_outcome], not on
+    counter values.
+
+    This stub mirrors the API surface used by
+    [cascade_preflight_state.ml] (single function, named-arg form). *)
+
+type label = string * string
+
+let inc_counter (_metric : string) ?(labels : label list = []) ?(delta : float = 1.0) () =
+  ignore labels;
+  ignore delta;
+  ()
+;;

--- a/test/cascade_preflight_state/test_cascade_preflight_state.ml
+++ b/test/cascade_preflight_state/test_cascade_preflight_state.ml
@@ -1,0 +1,314 @@
+(** Standalone Alcotest suite for [Cascade_preflight_state].
+
+    Built outside of [dune] to avoid contention on the workspace-wide
+    [dune] / [opam] locks (see CLAUDE.md token-miser §5 — dune build is
+    blocked while a 5+ process queue holds the locks). Compile with:
+
+    {[
+    ocamlfind ocamlc -package alcotest -linkpkg \
+      prometheus.ml ../../lib/cascade/cascade_preflight_state.mli \
+      ../../lib/cascade/cascade_preflight_state.ml \
+      test_cascade_preflight_state.ml -o run_test
+    ./run_test
+    ]}
+
+    Covered properties:
+
+    - First record returns [`First]; subsequent records of same
+      fingerprint advance the count.
+    - Same (tier_group, provider, reason) reaching [threshold]
+      returns [`Threshold_disable n] exactly once. Subsequent same
+      records return [`Already_disabled].
+    - Different reasons for the same provider count independently
+      until any one reaches threshold (provider is disabled at
+      provider-level, not fingerprint-level).
+    - [reset_on_health_recovery] clears fingerprints and removes
+      provider from disabled list; returns [true] iff it was
+      previously disabled.
+    - [reason_slug] stable for log/metric interpolation. *)
+
+module S = Cascade_preflight_state
+
+let outcome_pp fmt = function
+  | `First -> Format.fprintf fmt "First"
+  | `Repeated n -> Format.fprintf fmt "Repeated %d" n
+  | `Threshold_disable n -> Format.fprintf fmt "Threshold_disable %d" n
+  | `Already_disabled -> Format.fprintf fmt "Already_disabled"
+;;
+
+let outcome_eq (a : S.record_outcome) (b : S.record_outcome) =
+  match a, b with
+  | `First, `First -> true
+  | `Repeated x, `Repeated y -> x = y
+  | `Threshold_disable x, `Threshold_disable y -> x = y
+  | `Already_disabled, `Already_disabled -> true
+  | (`First | `Repeated _ | `Threshold_disable _ | `Already_disabled), _ -> false
+;;
+
+let outcome = Alcotest.testable outcome_pp outcome_eq
+
+(* ── First / Repeated / Threshold ────────────────────────────── *)
+
+let test_first_call_returns_first () =
+  let t = S.create ~threshold:5 () in
+  let o =
+    S.record t ~tier_group:"strict_tool_candidates" ~provider:"http://a"
+      ~reason:S.Health_check_failed_repeatedly
+  in
+  Alcotest.(check outcome) "first" `First o
+;;
+
+let test_second_call_returns_repeated_2 () =
+  let t = S.create ~threshold:5 () in
+  let _ =
+    S.record t ~tier_group:"strict_tool_candidates" ~provider:"http://a"
+      ~reason:S.Health_check_failed_repeatedly
+  in
+  let o =
+    S.record t ~tier_group:"strict_tool_candidates" ~provider:"http://a"
+      ~reason:S.Health_check_failed_repeatedly
+  in
+  Alcotest.(check outcome) "second is repeated=2" (`Repeated 2) o
+;;
+
+let test_threshold_disable_at_exact_count () =
+  let t = S.create ~threshold:5 () in
+  let group = "strict_tool_candidates" in
+  let prov = "http://a" in
+  let reason = S.Health_check_failed_repeatedly in
+  let r1 = S.record t ~tier_group:group ~provider:prov ~reason in
+  let r2 = S.record t ~tier_group:group ~provider:prov ~reason in
+  let r3 = S.record t ~tier_group:group ~provider:prov ~reason in
+  let r4 = S.record t ~tier_group:group ~provider:prov ~reason in
+  let r5 = S.record t ~tier_group:group ~provider:prov ~reason in
+  Alcotest.(check outcome) "1=First" `First r1;
+  Alcotest.(check outcome) "2=Repeated 2" (`Repeated 2) r2;
+  Alcotest.(check outcome) "3=Repeated 3" (`Repeated 3) r3;
+  Alcotest.(check outcome) "4=Repeated 4" (`Repeated 4) r4;
+  Alcotest.(check outcome) "5=Threshold_disable 5" (`Threshold_disable 5) r5
+;;
+
+let test_after_threshold_returns_already_disabled () =
+  let t = S.create ~threshold:3 () in
+  let group = "g" in
+  let prov = "http://a" in
+  let reason = S.Health_check_failed_repeatedly in
+  let _ = S.record t ~tier_group:group ~provider:prov ~reason in
+  let _ = S.record t ~tier_group:group ~provider:prov ~reason in
+  let _ = S.record t ~tier_group:group ~provider:prov ~reason in
+  let r4 = S.record t ~tier_group:group ~provider:prov ~reason in
+  let r5 = S.record t ~tier_group:group ~provider:prov ~reason in
+  Alcotest.(check outcome) "after threshold = Already_disabled" `Already_disabled r4;
+  Alcotest.(check outcome) "still already-disabled" `Already_disabled r5
+;;
+
+(* ── Reason isolation (provider-level disable) ───────────────── *)
+
+let test_different_reasons_count_independently () =
+  let t = S.create ~threshold:5 () in
+  let group = "g" in
+  let prov = "http://a" in
+  let r1 =
+    S.record t ~tier_group:group ~provider:prov ~reason:S.Health_check_failed_repeatedly
+  in
+  let r2 =
+    S.record t ~tier_group:group ~provider:prov ~reason:S.Permanent_unhealthy
+  in
+  let r3 =
+    S.record t ~tier_group:group ~provider:prov ~reason:S.Transient_unhealthy
+  in
+  let r4 =
+    S.record t ~tier_group:group ~provider:prov ~reason:S.Rate_limited_long_window
+  in
+  Alcotest.(check outcome) "reason1 First" `First r1;
+  Alcotest.(check outcome) "reason2 First (different fingerprint)" `First r2;
+  Alcotest.(check outcome) "reason3 First" `First r3;
+  Alcotest.(check outcome) "reason4 First" `First r4
+;;
+
+let test_provider_disabled_by_any_reason_blocks_other_reasons () =
+  (* Once a provider is disabled (via threshold on reason A), records
+     for the same provider under reason B also return Already_disabled
+     — disable is provider-level not fingerprint-level. *)
+  let t = S.create ~threshold:3 () in
+  let group = "g" in
+  let prov = "http://a" in
+  let _ =
+    S.record t ~tier_group:group ~provider:prov ~reason:S.Health_check_failed_repeatedly
+  in
+  let _ =
+    S.record t ~tier_group:group ~provider:prov ~reason:S.Health_check_failed_repeatedly
+  in
+  let r =
+    S.record t ~tier_group:group ~provider:prov ~reason:S.Health_check_failed_repeatedly
+  in
+  Alcotest.(check outcome) "threshold reached on reason A" (`Threshold_disable 3) r;
+  let cross =
+    S.record t ~tier_group:group ~provider:prov ~reason:S.Permanent_unhealthy
+  in
+  Alcotest.(check outcome) "reason B blocked too" `Already_disabled cross
+;;
+
+(* ── is_disabled membership ──────────────────────────────────── *)
+
+let test_is_disabled_membership () =
+  let t = S.create ~threshold:2 () in
+  Alcotest.(check bool) "not disabled initially" false
+    (S.is_disabled t ~provider:"http://a");
+  let _ =
+    S.record t ~tier_group:"g" ~provider:"http://a"
+      ~reason:S.Health_check_failed_repeatedly
+  in
+  Alcotest.(check bool) "not disabled after 1" false
+    (S.is_disabled t ~provider:"http://a");
+  let _ =
+    S.record t ~tier_group:"g" ~provider:"http://a"
+      ~reason:S.Health_check_failed_repeatedly
+  in
+  Alcotest.(check bool) "disabled after threshold" true
+    (S.is_disabled t ~provider:"http://a");
+  Alcotest.(check bool) "other provider unaffected" false
+    (S.is_disabled t ~provider:"http://b")
+;;
+
+(* ── reset_on_health_recovery ────────────────────────────────── *)
+
+let test_reset_on_health_recovery_clears_disabled () =
+  let t = S.create ~threshold:2 () in
+  let _ =
+    S.record t ~tier_group:"g" ~provider:"http://a"
+      ~reason:S.Health_check_failed_repeatedly
+  in
+  let _ =
+    S.record t ~tier_group:"g" ~provider:"http://a"
+      ~reason:S.Health_check_failed_repeatedly
+  in
+  Alcotest.(check bool) "disabled" true (S.is_disabled t ~provider:"http://a");
+  let was_disabled = S.reset_on_health_recovery t ~provider:"http://a" in
+  Alcotest.(check bool) "reset returns previously-disabled=true" true was_disabled;
+  Alcotest.(check bool) "no longer disabled" false
+    (S.is_disabled t ~provider:"http://a")
+;;
+
+let test_reset_after_clear_restarts_count () =
+  (* After reset, fingerprints are gone — the next record should be
+     First again, not Already_disabled or some leftover count. *)
+  let t = S.create ~threshold:2 () in
+  let _ =
+    S.record t ~tier_group:"g" ~provider:"http://a"
+      ~reason:S.Health_check_failed_repeatedly
+  in
+  let _ =
+    S.record t ~tier_group:"g" ~provider:"http://a"
+      ~reason:S.Health_check_failed_repeatedly
+  in
+  let _ = S.reset_on_health_recovery t ~provider:"http://a" in
+  let r =
+    S.record t ~tier_group:"g" ~provider:"http://a"
+      ~reason:S.Health_check_failed_repeatedly
+  in
+  Alcotest.(check outcome) "post-reset is First again" `First r
+;;
+
+let test_reset_when_not_disabled_returns_false () =
+  let t = S.create () in
+  let was_disabled = S.reset_on_health_recovery t ~provider:"http://nope" in
+  Alcotest.(check bool) "reset when never-disabled = false" false was_disabled
+;;
+
+(* ── disabled_providers snapshot ─────────────────────────────── *)
+
+let test_disabled_providers_snapshot () =
+  let t = S.create ~threshold:2 () in
+  let _ =
+    S.record t ~tier_group:"g" ~provider:"http://a"
+      ~reason:S.Health_check_failed_repeatedly
+  in
+  let _ =
+    S.record t ~tier_group:"g" ~provider:"http://a"
+      ~reason:S.Health_check_failed_repeatedly
+  in
+  let _ =
+    S.record t ~tier_group:"g" ~provider:"http://b"
+      ~reason:S.Permanent_unhealthy
+  in
+  let _ =
+    S.record t ~tier_group:"g" ~provider:"http://b"
+      ~reason:S.Permanent_unhealthy
+  in
+  let snap = List.sort String.compare (S.disabled_providers t) in
+  Alcotest.(check (list string)) "both providers disabled" [ "http://a"; "http://b" ] snap
+;;
+
+(* ── reason_slug stability ───────────────────────────────────── *)
+
+let test_reason_slug_stable () =
+  Alcotest.(check string)
+    "Health_check_failed_repeatedly"
+    "health-check-failed-repeatedly"
+    (S.reason_slug S.Health_check_failed_repeatedly);
+  Alcotest.(check string)
+    "Permanent_unhealthy"
+    "permanent-unhealthy"
+    (S.reason_slug S.Permanent_unhealthy);
+  Alcotest.(check string)
+    "Transient_unhealthy"
+    "transient-unhealthy"
+    (S.reason_slug S.Transient_unhealthy);
+  Alcotest.(check string)
+    "Rate_limited_long_window"
+    "rate-limited-long-window"
+    (S.reason_slug S.Rate_limited_long_window)
+;;
+
+(* ── default_threshold sanity ────────────────────────────────── *)
+
+let test_default_threshold_is_5 () =
+  Alcotest.(check int) "default threshold matches spec (5)" 5 S.default_threshold
+;;
+
+let () =
+  Alcotest.run "cascade_preflight_state"
+    [ ( "first / repeated / threshold"
+      , [ Alcotest.test_case "first call returns First" `Quick
+            test_first_call_returns_first
+        ; Alcotest.test_case "second call returns Repeated 2" `Quick
+            test_second_call_returns_repeated_2
+        ; Alcotest.test_case "exact count triggers Threshold_disable" `Quick
+            test_threshold_disable_at_exact_count
+        ; Alcotest.test_case "post-threshold returns Already_disabled" `Quick
+            test_after_threshold_returns_already_disabled
+        ] )
+    ; ( "reason isolation"
+      , [ Alcotest.test_case "different reasons count independently" `Quick
+            test_different_reasons_count_independently
+        ; Alcotest.test_case "provider-level disable blocks other reasons too"
+            `Quick
+            test_provider_disabled_by_any_reason_blocks_other_reasons
+        ] )
+    ; ( "is_disabled membership"
+      , [ Alcotest.test_case "membership tracks threshold" `Quick
+            test_is_disabled_membership
+        ] )
+    ; ( "reset_on_health_recovery"
+      , [ Alcotest.test_case "clears disabled and reports prior state" `Quick
+            test_reset_on_health_recovery_clears_disabled
+        ; Alcotest.test_case "post-reset restarts count" `Quick
+            test_reset_after_clear_restarts_count
+        ; Alcotest.test_case "reset on never-disabled returns false" `Quick
+            test_reset_when_not_disabled_returns_false
+        ] )
+    ; ( "snapshot"
+      , [ Alcotest.test_case "disabled_providers returns set" `Quick
+            test_disabled_providers_snapshot
+        ] )
+    ; ( "reason slug"
+      , [ Alcotest.test_case "stable kebab-case mapping" `Quick
+            test_reason_slug_stable
+        ] )
+    ; ( "constants"
+      , [ Alcotest.test_case "default threshold = 5" `Quick
+            test_default_threshold_is_5
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 컨텍스트

`MASC/OAS Error-Warn Reduction Goal — 2026-05-18` §P3 (provider cascade exhaustion) 후속 작업.

system_log 2026-05-18 last 30min 슬라이스에서 동일한 WARN 패턴이 누적 47+회 관측됨:

- `cascade tier-group.strict_tool_candidates: preflight skipped 1 unhealthy local endpoint(s)` × 35
- `cascade glm-coding-with-spark: preflight skipped 1 unhealthy local endpoint(s)` × 12

`lib/keeper/keeper_turn_driver.ml:375-381`이 unhealthy provider를 silently skip하면서 **매 cycle마다** WARN을 emit. counter도 없고, threshold도 없고, recovery 알림도 없음. typed escalation 분류 없이 string-only 메시지.

근본 패턴은 ε2 (`Keeper_reconcile_state`)와 동일 — `same fingerprint 반복 emit → telemetry-as-fix 누적`. 단 이건 *cascade preflight side*.

## 변경 요약

### 신규 모듈 `lib/cascade/cascade_preflight_state.{ml,mli}`

- `type reason` — 닫힌 sum, 4 variant:
  - `Health_check_failed_repeatedly`
  - `Permanent_unhealthy`
  - `Transient_unhealthy`
  - `Rate_limited_long_window`
- `type record_outcome = [ \`First | \`Repeated of int | \`Threshold_disable of int | \`Already_disabled ]`
- in-memory `Hashtbl.Make` (fingerprint + provider disabled set) + `Stdlib.Mutex` (feedback_ocaml5-mutex-selection.md 패턴; cross-fiber, single-domain)
- `default_threshold = 5` 회 연속 같은 fingerprint → `Threshold_disable` (정확히 1회 발화) → provider를 disabled list에 등록
- 이후 같은 provider record는 `Already_disabled` 반환 → 호출자가 DEBUG로 강등
- `reset_on_health_recovery`: provider가 healthy로 복귀하면 fingerprint 전체 clear + disabled list 제거 + INFO 1회
- 신규 metric 3종 (모듈이 SSOT 소유, RFC-0043 패턴):
  - `masc_cascade_preflight_unhealthy_skip_total` (skip 1회당 tick, labels: cascade/provider/reason)
  - `masc_cascade_provider_disabled_total` (threshold-disable 전이 시 tick)
  - `masc_cascade_provider_re_enabled_total` (health recovery 시 tick)

### `lib/keeper/keeper_turn_driver.ml` patch (line 375-381)

- 기존 `Log.Misc.warn "cascade %s: preflight skipped %d unhealthy local endpoint(s) ..."` (매 cycle) 제거
- 각 unhealthy endpoint에 대해 `Cascade_preflight_state.record` 호출 후 `record_outcome`별로 분기:
  - `First | Repeated n` → 기존 WARN 보존 (각각 first-occurrence / consecutive=n 표시)
  - `Threshold_disable n` → `Log.Misc.error` 1회 + disabled list 등록 + Prometheus tick
  - `Already_disabled` → `Log.Misc.debug`만 (operator 노이즈 silenced)
- 같은 cycle에서 `local_endpoint_health`가 healthy로 보고하는 provider 중 disabled list에 있던 항목은 `reset_on_health_recovery` → INFO 1회

### Closed sum, catch-all 금지

- record_outcome `match` 모두 exhaustive (4-arm). `_ ->` 없음.
- record patch 분기도 4-arm exhaustive.
- reason variant 추가 시 컴파일러가 모든 match site에서 누락 감지.

## 검증

`dune build` lock contention 회피를 위해 standalone Alcotest 패턴 사용 (사용자 제약).

```bash
cd test/cascade_preflight_state
cp ../../lib/cascade/cascade_preflight_state.{mli,ml} .
ocamlfind ocamlc -package alcotest -linkpkg \
  prometheus.ml cascade_preflight_state.mli cascade_preflight_state.ml \
  test_cascade_preflight_state.ml -o run_test
./run_test
```

```
Testing `cascade_preflight_state'.
  [OK] first / repeated / threshold     0   first call returns First
  [OK] first / repeated / threshold     1   second call returns Repeated 2
  [OK] first / repeated / threshold     2   exact count triggers Threshold_disable
  [OK] first / repeated / threshold     3   post-threshold returns Already_disabled
  [OK] reason isolation                 0   different reasons count independently
  [OK] reason isolation                 1   provider-level disable blocks other reasons too
  [OK] is_disabled membership           0   membership tracks threshold
  [OK] reset_on_health_recovery         0   clears disabled and reports prior state
  [OK] reset_on_health_recovery         1   post-reset restarts count
  [OK] reset_on_health_recovery         2   reset on never-disabled returns false
  [OK] snapshot                         0   disabled_providers returns set
  [OK] reason slug                      0   stable kebab-case mapping
  [OK] constants                        0   default threshold = 5
Test Successful in 0.007s. 13 tests run.
```

13/13 PASS. ocamlformat clean (touched files 5개). `git diff --check` clean.

## 효과 예측 (24h)

| 항목 | Before | After (예측) |
|------|-------|------|
| `preflight skipped 1 unhealthy` WARN | ~35/30min × 12개 provider | First 1회 + Repeated 4회 = **5 WARN / provider / disable window** |
| ERROR escalation | 0 (silent) | provider별 1회 (threshold 도달 시) |
| DEBUG (silenced) | 0 | `Already_disabled` 도달 후 모든 cycle (operator dashboard에서 invisible) |
| 35회 → 약 5 + 1 = **6 visible log / provider / window** (~83% 감소) | | |

P3 목표 (provider cascade exhaustion 발생 시 typed escalation + provider 영구 disable 마커) 충족.

## RFC 발견 체크

`lib/cascade/cascade_preflight_state.{ml,mli}` 신규 (credential/identity/sandbox 영역 아님). cascade routing 의미 보존 (disabled list는 log-level cadence advisory). MASC/OAS Error-Warn Reduction Goal §P3 SSOT 인용.

RFC-WAIVED: lib/cascade/cascade_preflight_state 신규 + cascade routing 보존, MASC/OAS Error-Warn Reduction Goal §P3 SSOT 인용

## 보존된 워크어라운드 한계 (정직)

WORKAROUND-CARRYOVER: provider 영구 disable은 *routing 보호 측면이 아니라 log-level cadence*만 변경합니다. 근본 fix는 provider health probe 자체 개선 (RFC 후보: probe interval 적응형 / circuit breaker / 명시적 health endpoint 표준화). 본 PR은 cascade routing이 이미 `filter_unhealthy_local_runtime_urls`로 endpoint를 제외하는 상황에서 *operator-visible cadence*만 정리합니다. 신규 disabled list는 process-local + advisory + no-routing-side-effect.

## 비겹침

α/β/γ/ε2/δ/α-corpus 영역 (lib/exec/, keeper_tools_oas.ml, auth_error_kind.ml, server_auth.ml, keeper_reconcile_state.ml, keeper_runtime.ml, keeper_recording_error_state.ml, keeper_registry.ml, test/fixtures/shell_gate/) 손대지 않음.

Co-Authored-By: Claude (subagent ZETA, /loop iter 13, 2026-05-19)