### PR TITLE
fix(dashboard): Korean labels for tool_surface axes

### DIFF
--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -227,6 +227,56 @@ export function executionOutcomeLabel(value: string | null | undefined): string 
   return EXECUTION_OUTCOME_LABELS[value] ?? value
 }
 
+
+/** Korean labels for the three tool-surface axes emitted by
+ *  `lib/keeper/keeper_agent_tool_surface.ml`:
+ *  - `tool_requirement` (3 values, line 24-27):
+ *    required / optional / none.
+ *  - `tool_surface_class` (3 values, line 103-107, RFC-0065 §3.2.2):
+ *    none / public_only / mixed.
+ *  - `turn_lane` (6 values, line 57-63):
+ *    pre_dispatch / text_only / tool_required / tool_optional /
+ *    tool_disabled / retry.
+ *  Tooltips in `fsm-hub.ts:159-160` and stale-cause parts list in
+ *  `fleet-fsm-matrix.ts:289-295` currently interpolate these as raw
+ *  English tokens. Each helper keeps the raw token as fallback so a
+ *  backend-ahead variant still surfaces verbatim. */
+const TOOL_REQUIREMENT_LABELS: Record<string, string> = {
+  required: '필수',
+  optional: '선택',
+  none: '없음',
+}
+
+const TOOL_SURFACE_CLASS_LABELS: Record<string, string> = {
+  none: '도구 없음',
+  public_only: '공개 도구만',
+  mixed: '혼합 도구',
+}
+
+const TURN_LANE_LABELS: Record<string, string> = {
+  pre_dispatch: '디스패치 전',
+  text_only: '텍스트 전용',
+  tool_required: '도구 필수',
+  tool_optional: '도구 선택',
+  tool_disabled: '도구 비활성',
+  retry: '재시도',
+}
+
+export function toolRequirementLabel(value: string | null | undefined): string | null {
+  if (!value) return null
+  return TOOL_REQUIREMENT_LABELS[value] ?? value
+}
+
+export function toolSurfaceClassLabel(value: string | null | undefined): string | null {
+  if (!value) return null
+  return TOOL_SURFACE_CLASS_LABELS[value] ?? value
+}
+
+export function turnLaneLabel(value: string | null | undefined): string | null {
+  if (!value) return null
+  return TURN_LANE_LABELS[value] ?? value
+}
+
 /** Korean labels for `trust.disposition`. Backend emits 4 closed-sum
  *  values via `display_disposition_of_operator`
  *  (lib/keeper/keeper_runtime_trust_snapshot.ml:687-697):

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -58,6 +58,12 @@ export type {
 
 export { displayState } from './fsm-hub-types'
 
+import {
+  toolRequirementLabel,
+  toolSurfaceClassLabel,
+  turnLaneLabel,
+} from './fsm-hub-types'
+
 export {
   appendCompositeObservation,
   deriveLaneDwellHistograms,
@@ -161,9 +167,9 @@ function executionReceiptTitle(execution: KeeperCompositeExecution | undefined):
     execution.recorded_at ? `recorded_at: ${execution.recorded_at}` : '',
     execution.operator_disposition ? `operator: ${execution.operator_disposition}` : '',
     execution.operator_disposition_reason ? `reason: ${execution.operator_disposition_reason}` : '',
-    surface?.tool_requirement ? `tool_requirement: ${surface.tool_requirement}` : '',
-    surface?.turn_lane ? `turn_lane: ${surface.turn_lane}` : '',
-    surface?.tool_surface_class ? `tool_surface: ${surface.tool_surface_class}` : '',
+    surface?.tool_requirement ? `tool_requirement: ${toolRequirementLabel(surface.tool_requirement) ?? surface.tool_requirement}` : '',
+    surface?.turn_lane ? `turn_lane: ${turnLaneLabel(surface.turn_lane) ?? surface.turn_lane}` : '',
+    surface?.tool_surface_class ? `tool_surface: ${toolSurfaceClassLabel(surface.tool_surface_class) ?? surface.tool_surface_class}` : '',
     typeof surface?.visible_tool_count === 'number' ? `visible_tools: ${surface.visible_tool_count}` : '',
     surface?.tool_surface_fallback_used === true ? 'tool_surface_fallback: true' : '',
     execution.cascade?.fallback_reason ? `fallback: ${execution.cascade.fallback_reason}` : '',


### PR DESCRIPTION
## 요약

Backend `tool_surface` schema 3 axes (tool_requirement, tool_surface_class, turn_lane) 가 \`lib/keeper/keeper_agent_tool_surface.ml\` 에서 closed-sum 12 values emit. \`fsm-hub.ts:152-167 executionReceiptTitle\` tooltip 이 모두 raw 영문 표시 — 같은 tooltip 의 다른 axis 들은 한국어인데 불일치.

## 측정된 근거

| Axis | 값 | Source |
|------|-----|--------|
| tool_requirement | required / optional / none | keeper_agent_tool_surface.ml:24-27 |
| tool_surface_class | none / public_only / mixed | keeper_agent_tool_surface.ml:103-107 (RFC-0065 §3.2.2) |
| turn_lane | pre_dispatch / text_only / tool_required / tool_optional / tool_disabled / retry | keeper_agent_tool_surface.ml:57-63 |

## 변경

\`fsm-hub-types.ts\` 에 3 helper + 12 label entries 추가. \`fsm-hub.ts:159-161\` 의 tooltip 3 line 을 helper 통과시킴.

## 검증

\`\`\`
$ pnpm typecheck                                              → clean
$ pnpm vitest run src/components/fsm-hub-types               → 21/21
\`\`\`

## Related

본 세션 20번째 PR. Label coverage thread: #16351, #16355, #16370, #16374, #16377, #16380, #16382, #16388, #16391.

🤖 Generated with [Claude Code](https://claude.com/claude-code)