### PR TITLE
fix(keeper): format turn_id as %d instead of %s in FSM violation detail

### DIFF
--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -293,7 +293,7 @@ let guard_transition ?ctx ~keeper_name ~turn_id ~from_state ~to_state () =
          dependency cycle). *)
       let detail =
         Printf.sprintf
-          "fsm:transition:violation keeper=%s turn=%s from=%s to=%s \
+          "fsm:transition:violation keeper=%s turn=%d from=%s to=%s \
            reason=%s"
           keeper_name turn_id violation.from_state violation.to_state
           violation.reason


### PR DESCRIPTION
## 요약

`lib/keeper/keeper_turn_fsm.ml:298` 에서 `Printf.sprintf` 의 `turn=%s` format placeholder가 `turn_id : int` (per `keeper_turn_fsm.mli:165`) 와 type mismatch. PR #16358 머지가 도입한 회귀로 main의 `dune build @check` 가 *모든 열린 PR* 에서 fail.

α-corpus agent의 build 시도가 이 회귀를 식별.

## 변경

```diff
-           "fsm:transition:violation keeper=%s turn=%s from=%s to=%s \
+           "fsm:transition:violation keeper=%s turn=%d from=%s to=%s \
```

1 file, +1/-1.

## 검증

- `opam exec -- ocamlformat --check lib/keeper/keeper_turn_fsm.ml` clean
- `git diff --check origin/main..HEAD` clean
- type signature: `turn_id : int` 명시적으로 `%d` 가 정합

## 영향

- main `dune build @check` 회복
- 우리 3 open PR (#16389 δ, #16390 α-corpus, #16394 ζ) + 외부 다수 PR의 base CI 회복

RFC-WAIVED: single-line type error fix, no logic change.

Co-Authored-By: Claude (subagent HOTFIX-fsm, /loop iter 14, 2026-05-19)
