### PR TITLE
fix(dashboard): Korean labels for execution.outcome / latest_execution_outcome

### DIFF
--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -193,6 +193,29 @@ export function displayState(value: string): string {
   return STATE_DISPLAY_NAMES[value] ?? value
 }
 
+/** Korean labels for `execution.outcome` / `keeper.latest_execution_outcome`.
+ *  Backend emits the TLA-prefix form via
+ *  `Keeper_execution_receipt.outcome_kind_to_tla_receipt`
+ *  (lib/keeper/keeper_execution_receipt.ml:24-29):
+ *  receipt_done / receipt_skipped / receipt_failed / receipt_cancelled.
+ *  The TLA spec ReceiptIsAuthoritative invariant
+ *  (keeper_execution_receipt.ml:54-58) fixes this canonical form.
+ *  Kept separate from `STATE_DISPLAY_NAMES` so generic short tokens
+ *  do not collide; the prefix makes collisions unlikely but the
+ *  per-axis helper pattern (#16374, #16377, #16380, #16382, #16388,
+ *  #16396) is the established discipline. */
+const EXECUTION_OUTCOME_LABELS: Record<string, string> = {
+  receipt_done: '완료',
+  receipt_skipped: '건너뜀',
+  receipt_failed: '실패',
+  receipt_cancelled: '취소됨',
+}
+
+export function executionOutcomeLabel(value: string | null | undefined): string | null {
+  if (!value) return null
+  return EXECUTION_OUTCOME_LABELS[value] ?? value
+}
+
 /** Korean labels for `trust.disposition`. Backend emits 4 closed-sum
  *  values via `display_disposition_of_operator`
  *  (lib/keeper/keeper_runtime_trust_snapshot.ml:687-697):

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -15,6 +15,7 @@ import { EmptyState, ErrorState, LoadingState } from '../common/feedback-state'
 import { ActionButton } from '../common/button'
 import { FilterChips } from '../common/filter-chips'
 import { StatusBadge } from '../common/status-badge'
+import { executionOutcomeLabel } from '../fsm-hub-types'
 import { ringFocusClasses } from '../common/ring'
 import { trustDispositionLabel } from '../fsm-hub-types'
 import { TimeAgo } from '../common/time-ago'
@@ -945,8 +946,8 @@ function KeeperCard({ keeper }: { keeper: GoalDetailKeeper }) {
             </span>
           ` : null}
           ${keeper.latest_execution_outcome ? html`
-            <span class="rounded-[var(--r-1)] border border-card-border/60 bg-[var(--color-bg-elevated)] px-2 py-0.5 text-3xs font-semibold text-text-body">
-              ${keeper.latest_execution_outcome}
+            <span class="rounded-[var(--r-1)] border border-card-border/60 bg-[var(--color-bg-elevated)] px-2 py-0.5 text-3xs font-semibold text-text-body" title=${keeper.latest_execution_outcome}>
+              ${executionOutcomeLabel(keeper.latest_execution_outcome)}
             </span>
           ` : null}
         </div>


### PR DESCRIPTION
## 요약

`goal-tree.ts:949` 가 \`keeper.latest_execution_outcome\` (TLA-prefix \`receipt_*\`) 을 raw 영문 토큰 표시. 같은 chip 주변의 다른 axes (status / trust disposition / goal phase) 는 모두 Korean 라벨 인데 불일치.

#16348 (TLA-prefix branching) 의 *display label* 측면 보완 — branching wire-format 정렬 + display Korean label.

## 측정된 근거

Backend (`Keeper_execution_receipt.outcome_kind_to_tla_receipt`, lib/keeper/keeper_execution_receipt.ml:24-29):
- receipt_done / receipt_skipped / receipt_failed / receipt_cancelled

TLA spec ReceiptIsAuthoritative invariant (lib/keeper/keeper_execution_receipt.ml:54-58).

## 변경

\`fsm-hub-types.ts\` + helper \`executionOutcomeLabel\` (4 entries). \`goal-tree.ts:949\` 의 chip 을 helper 통과; raw \`title\` 보존.

## 검증

\`\`\`
$ pnpm typecheck                                              → clean
$ pnpm vitest run src/components/fsm-hub-types src/components/goals/goal-tree → 21/21
\`\`\`

## Related

본 세션 21번째 PR. #16348 (TLA-prefix branching) 의 display label 보완. 누적 label coverage: KSM/KTC/KDP/KCL/KMC/KCB + 14 다른 axes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)