### PR TITLE
feat(board): per-author comment rate limiting

### DIFF
--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -51,6 +51,44 @@ let create_store () =
   }
 ;;
 
+(** {1 Comment Rate Limiting}
+
+    Per-author sliding window tracker.  Module-level Hashtbl avoids
+    changing the store type; all access is inside the existing
+    [with_lock store] in [add_comment_with_status]. *)
+
+let comment_timestamps : (string, float list ref) Hashtbl.t = Hashtbl.create 32
+
+let check_comment_rate_limit ~author ~now =
+  let limit = Limits.comment_rate_limit in
+  if limit <= 0 then None
+  else
+    let window = Float.of_int Limits.comment_rate_window_sec in
+    match Hashtbl.find_opt comment_timestamps author with
+    | None -> None
+    | Some ts_ref ->
+      let recent = List.filter (fun t -> now -. t < window) !ts_ref in
+      ts_ref := recent;
+      if List.length recent >= limit
+      then
+        let oldest = List.hd (List.sort Stdlib.compare recent) in
+        let retry_after = window -. (now -. oldest) +. 1.0 in
+        Some retry_after
+      else None
+
+let record_comment_timestamp ~author ~now =
+  let ts_ref =
+    match Hashtbl.find_opt comment_timestamps author with
+    | Some r -> r
+    | None ->
+      let r = ref [] in
+      Hashtbl.replace comment_timestamps author r;
+      r
+  in
+  ts_ref := now :: !ts_ref
+
+let reset_comment_rate_tracker () = Hashtbl.clear comment_timestamps
+
 (** Remove [value] from the string list stored at [key] in [tbl].
     Removes the key entirely when the list becomes empty. *)
 let remove_from_list_index tbl key value =
@@ -201,6 +239,16 @@ let sweep store =
                   Stdlib.incr cap_evicted)
                to_evict))
         author_posts);
+    (* Prune stale rate-limit entries *)
+    let window = Stdlib.Float.of_int Limits.comment_rate_window_sec in
+    let stale_authors = ref [] in
+    Hashtbl.iter
+      (fun author ts_ref ->
+         let recent = List.filter (fun t -> now -. t < window) !ts_ref in
+         if List.length recent = 0 then stale_authors := author :: !stale_authors
+         else ts_ref := recent)
+      comment_timestamps;
+    List.iter (Hashtbl.remove comment_timestamps) !stale_authors;
     (* Invalidate caches if anything was swept *)
     if !removed_posts > 0 || !cap_evicted > 0 then invalidate_post_caches store;
     if !removed_comments > 0 then invalidate_comment_caches store;
@@ -1116,6 +1164,10 @@ let add_comment_with_status
                             })
                      else (
                     let now = Time_compat.now () in
+                    match check_comment_rate_limit ~author:author_str ~now with
+                    | Some retry_after ->
+                      Error (Rate_limited { retry_after })
+                    | None ->
                     let ttl =
                       match post.post_kind with
                       | Automation_post | System_post ->
@@ -1155,6 +1207,7 @@ let add_comment_with_status
                       store.posts
                       post_key
                       { post with reply_count = post.reply_count + 1; updated_at = now };
+                    record_comment_timestamp ~author:author_str ~now;
                     invalidate_post_caches store;
                     invalidate_comment_caches store;
                     Ok (`Fresh comment)))))

--- a/lib/board_core.mli
+++ b/lib/board_core.mli
@@ -70,6 +70,19 @@ val flush_interval_sec : float
     [flusher_inbox] capped at 1000 messages. *)
 val create_store : unit -> store
 
+(** Reset the per-author comment rate-limit tracker.  Test-only. *)
+val reset_comment_rate_tracker : unit -> unit
+
+(** Check whether [author] is currently rate-limited at time [now].
+    Returns [Some retry_after] if the author has reached the limit,
+    [None] otherwise. *)
+val check_comment_rate_limit : author:string -> now:float -> float option
+
+(** Record a comment timestamp for [author] at time [now].
+    Used internally by [add_comment_with_status]; exposed for test
+    manipulation of the sliding window. *)
+val record_comment_timestamp : author:string -> now:float -> unit
+
 (** {1 Locking + cache invalidation} *)
 
 (** [with_lock store f] runs [f ()] under

--- a/lib/board_types/board_types.ml
+++ b/lib/board_types/board_types.ml
@@ -240,6 +240,8 @@ module Limits = struct
   let sweeper_batch_size = env_int "MASC_BOARD_SWEEPER_BATCH_SIZE" 100
   let author_post_cap = env_int "MASC_BOARD_AUTHOR_POST_CAP" 100
   let max_sub_boards = env_int "MASC_BOARD_MAX_SUB_BOARDS" 256
+  let comment_rate_limit = env_int "MASC_BOARD_COMMENT_RATE_LIMIT" 30
+  let comment_rate_window_sec = env_int "MASC_BOARD_COMMENT_RATE_WINDOW_SEC" 300
 end
 
 (** {1 Vote Direction} *)

--- a/lib/board_types/board_types.mli
+++ b/lib/board_types/board_types.mli
@@ -181,6 +181,10 @@ module Limits : sig
   val author_post_cap : int
   val max_sub_boards : int
   (** Maximum number of sub-boards. Default 256. *)
+  val comment_rate_limit : int
+  (** Max comments per author within [comment_rate_window_sec]. 0 = disabled. Default 30. *)
+  val comment_rate_window_sec : int
+  (** Sliding window duration in seconds. Default 300 (5 min). *)
 end
 
 (** {1 Vote Direction} *)

--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -696,6 +696,7 @@ let global () = Eio.Lazy.force !global_lazy
 (** Reset global store for test isolation. Next [global ()] call creates fresh store.
     Safe: only called from test setup before concurrent fibers exist. *)
 let reset_global_for_test () =
+  reset_comment_rate_tracker ();
   global_lazy := Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
     let store = create_store () in
     load_persisted_posts store;

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -1527,6 +1527,153 @@ let test_curation_health_score_schema_bounds () =
   check_bounds "keeper curation submit"
     (find_tool "keeper_board_curation_submit" Tool_shard.shard_board.tools)
 
+(** {1 Comment Rate Limiting Tests} *)
+
+(** Helper: create a post and return its id. *)
+let rate_test_post_id store =
+  match Board.create_post store
+    ~author:"tester" ~content:"rate limit test post"
+    ~post_kind:Human_post () with
+  | Ok p -> Board.Post_id.to_string p.id
+  | Error e -> Alcotest.failf "post create failed: %s" (Board.show_board_error e)
+
+(** Helper: add a comment via the core API and return Ok/Error. *)
+let rate_add_comment store post_id idx =
+  Board.add_comment_with_status store
+    ~post_id ~author:"tester"
+    ~content:(Printf.sprintf "comment #%d" idx) ()
+
+let test_rate_under_limit_succeeds () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let store = Board.create_store () in
+  let post_id = rate_test_post_id store in
+  for i = 1 to 28 do
+    match rate_add_comment store post_id i with
+    | Ok (_c, `Fresh) -> ()
+    | Ok (_c, `Dedup) -> Alcotest.failf "comment %d unexpectedly deduped" i
+    | Error e -> Alcotest.failf "comment %d rejected: %s" i (Board.show_board_error e)
+  done
+
+let test_rate_at_limit_rejects () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let store = Board.create_store () in
+  let post_id = rate_test_post_id store in
+  for i = 1 to 30 do
+    ignore (rate_add_comment store post_id i : (_, _) result)
+  done;
+  (match rate_add_comment store post_id 31 with
+   | Error (Board.Rate_limited _) -> ()
+   | Ok _ -> Alcotest.fail "31st comment should have been rate-limited"
+   | Error e -> Alcotest.failf "unexpected error: %s" (Board.show_board_error e))
+
+let test_rate_different_authors_independent () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let store = Board.create_store () in
+  let post_id = rate_test_post_id store in
+  for i = 1 to 30 do
+    ignore (Board.add_comment_with_status store
+      ~post_id ~author:"author-a" ~content:(Printf.sprintf "fill-%d" i) () : (_, _) result)
+  done;
+  (match Board.add_comment_with_status store
+    ~post_id ~author:"author-b" ~content:"b-comment" () with
+   | Ok _ -> ()
+   | Error e -> Alcotest.failf "author-b rejected: %s" (Board.show_board_error e))
+
+let test_rate_retry_after_positive () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let store = Board.create_store () in
+  let post_id = rate_test_post_id store in
+  for i = 1 to 30 do
+    ignore (rate_add_comment store post_id i)
+  done;
+  (match rate_add_comment store post_id 31 with
+   | Error (Board.Rate_limited { retry_after }) ->
+     Alcotest.(check bool) "retry_after > 0" true (retry_after > 0.0)
+   | _ -> Alcotest.fail "expected Rate_limited error")
+
+let test_rate_dedup_does_not_consume_quota () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let store = Board.create_store () in
+  let post_id = rate_test_post_id store in
+  for _i = 1 to 30 do
+    ignore (Board.add_comment_with_status store
+      ~post_id ~author:"tester" ~content:"identical" () : (_, _) result)
+  done;
+  (match Board.add_comment_with_status store
+    ~post_id ~author:"tester" ~content:"different" () with
+   | Ok _ -> ()
+   | Error e -> Alcotest.failf "dedup-consumed quota: %s" (Board.show_board_error e))
+
+let test_rate_window_expiry_allows_more () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  let store = Board.create_store () in
+  let post_id = rate_test_post_id store in
+  let old = Unix.gettimeofday () -. 600.0 in
+  for i = 1 to 30 do
+    Board_core.record_comment_timestamp ~author:"tester" ~now:(old +. float_of_int i)
+  done;
+  (match rate_add_comment store post_id 1 with
+   | Ok _ -> ()
+   | Error e -> Alcotest.failf "window expiry rejected: %s" (Board.show_board_error e))
+
+let test_rate_disabled_when_limit_zero () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  ignore (Board.create_store ());
+  (match Board_core.check_comment_rate_limit ~author:"unknown-agent" ~now:(Unix.gettimeofday ()) with
+   | None -> ()
+   | Some _ -> Alcotest.fail "unknown author should not be rate-limited")
+
+let test_rate_dispatch_error_message () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  cleanup ();
+  (* Use dispatch (Board.global) for everything so post exists in the right store *)
+  let (_ok, create_msg) = dispatch "masc_board_post" (make_args [
+    ("title", `String "rate-test"); ("content", `String "hello");
+    ("author", `String "tester")
+  ]) in
+  let json = parse_create_response_json create_msg in
+  let post_id = Yojson.Safe.Util.(json |> member "id" |> to_string) in
+  for i = 1 to 30 do
+    ignore (dispatch "masc_board_comment" (make_args [
+      ("post_id", `String post_id);
+      ("content", `String (Printf.sprintf "comment-%d" i));
+      ("author", `String "tester")
+    ]) : bool * string)
+  done;
+  let (ok, msg) = dispatch "masc_board_comment" (make_args [
+    ("post_id", `String post_id);
+    ("content", `String "overflow");
+    ("author", `String "tester")
+  ]) in
+  Alcotest.(check bool) "rate limited via dispatch" false ok;
+  Alcotest.(check bool) "error mentions rate/limit/retry" true
+    (let lower = String.lowercase_ascii msg in
+     let contains sub =
+       let sub_len = String.length sub in
+       let msg_len = String.length lower in
+       let rec loop i =
+         i + sub_len <= msg_len &&
+         (String.sub lower i sub_len = sub || loop (i + 1))
+       in
+       loop 0
+     in
+     contains "rate" || contains "limit" || contains "retry")
+
 (** {1 Test Runner} *)
 
 let () =
@@ -1857,5 +2004,19 @@ let () =
             let (_ok2, body2) = dispatch "masc_board_list" args in
             Alcotest.(check bool) "cache invalidated after vote" true
               (body1 <> body2));
+        ] );
+      ( "comment_rate_limit",
+        [
+          Alcotest.test_case "under limit succeeds" `Quick test_rate_under_limit_succeeds;
+          Alcotest.test_case "at limit rejects" `Quick test_rate_at_limit_rejects;
+          Alcotest.test_case "different authors independent" `Quick
+            test_rate_different_authors_independent;
+          Alcotest.test_case "retry_after positive" `Quick test_rate_retry_after_positive;
+          Alcotest.test_case "dedup does not consume quota" `Quick
+            test_rate_dedup_does_not_consume_quota;
+          Alcotest.test_case "window expiry allows more" `Quick
+            test_rate_window_expiry_allows_more;
+          Alcotest.test_case "disabled when limit zero" `Quick test_rate_disabled_when_limit_zero;
+          Alcotest.test_case "dispatch error message" `Quick test_rate_dispatch_error_message;
         ] );
     ]


### PR DESCRIPTION
## Summary
- Per-author sliding-window rate limiting for board comments (closes #16298)
- Module-level Hashtbl tracks `(author, float list ref)` timestamps
- `MASC_BOARD_COMMENT_RATE_LIMIT` (default 30) comments per `MASC_BOARD_COMMENT_RATE_WINDOW_SEC` (default 300s)
- Returns `Rate_limited { retry_after }` when exceeded
- Sweeper prunes stale entries; `reset_comment_rate_tracker` in test cleanup

## Changes
- `lib/board_types/board_types.ml` — 2 new Limits constants
- `lib/board_core.ml` — tracker, check, record, sweeper integration
- `lib/board_core.mli` — expose reset + check + record for testing
- `lib/board_votes.ml` — call reset in `reset_global_for_test`
- `test/test_tool_board_coverage.ml` — 8 Alcotest cases

## Test plan
- [x] 8/8 `comment_rate_limit` Alcotest tests pass
- [x] `dune build` clean (no warnings)
- [ ] `dune runtest` full suite (1 pre-existing failure in `schemas/tools count` unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)