### PR TITLE
feat(dashboard): inline reasons in tool_quality "unknown" bucket keys

### DIFF
--- a/lib/dashboard/dashboard_http_tool_quality.ml
+++ b/lib/dashboard/dashboard_http_tool_quality.ml
@@ -86,8 +86,17 @@ let classify_failure_output (output : string) : string =
       let fallback_category () =
         match Safe_ops.json_string_opt "error" j |> Option.map String.trim with
         | Some "command_blocked_readonly" ->
+          (* The block payload normally carries a [category] string
+             naming which readonly policy rule fired (e.g. "write",
+             "exec", "network").  Dashboard groups on the full key
+             [command_blocked_readonly:<category>], so a bare "unknown"
+             tells the operator the rule fired but hides which policy
+             class.  Use a structured marker so the operator can grep
+             the source events and find the producer that omitted the
+             field. *)
           let category =
-            Safe_ops.json_string_opt "category" j |> Option.value ~default:"unknown"
+            Safe_ops.json_string_opt "category" j
+            |> Option.value ~default:"<missing category field>"
           in
           Printf.sprintf "command_blocked_readonly:%s" category
         | Some error when error <> "" -> normalize_failure_text error
@@ -122,14 +131,18 @@ let cascade_bucket_key record =
      | Some value when String.trim value <> "" -> value
      | _ -> "runtime")
 
+(* Split the two failure modes that previously collapsed to the
+   bare "unknown" bucket so a non-zero count on either tells the
+   operator a distinct producer fix: missing/non-bool field vs
+   non-object record envelope. *)
 let thinking_mode_of_record record =
   match record with
   | `Assoc fields ->
     (match List.assoc_opt "thinking_enabled" fields with
      | Some (`Bool true) -> "enabled"
      | Some (`Bool false) -> "disabled"
-     | _ -> "unknown")
-  | _ -> "unknown"
+     | _ -> "<missing thinking_enabled field>")
+  | _ -> "<non-object record envelope>"
 
 let bool_field_opt record field =
   match record with
@@ -168,8 +181,8 @@ let hour_key_of_record record =
      | Some (`Int i) -> hour_of_unix (Float.of_int i)
      | Some (`String s) when String.length s >= 13 -> String.sub s 0 13
      | Some (`String s) -> s
-     | _ -> "unknown")
-  | _ -> "unknown"
+     | _ -> "<missing or non-numeric ts field>")
+  | _ -> "<non-object record envelope>"
 
 let update_rate_table table key ok =
   let key = if String.trim key = "" then "unknown" else key in
@@ -285,13 +298,20 @@ let aggregate ?(n = 5000) ?window_hours () : Yojson.Safe.t =
   let failure_cats : (string, int ref) Hashtbl.t = Hashtbl.create 32 in
   List.iter (fun record ->
     incr total;
+    (* [tool] and [keeper] become bucket keys in the dashboard
+       histogram.  A bare "unknown" bucket appears in the same column
+       as a legitimate tool named "unknown", so the operator cannot
+       tell "the tool field was missing from N records" apart from
+       "tool 'unknown' was invoked N times".  Use structured markers
+       so a non-zero bucket on either is a producer-side fix
+       signal. *)
     let tool =
       Safe_ops.json_string_opt "tool" record
-      |> Option.value ~default:"unknown"
+      |> Option.value ~default:"<missing tool field>"
     in
     let keeper =
       Safe_ops.json_string_opt "keeper" record
-      |> Option.value ~default:"unknown"
+      |> Option.value ~default:"<missing keeper field>"
     in
     let ok = tool_success_of_record record in
     let semantic_outcome = semantic_outcome_of_record record ~ok in


### PR DESCRIPTION
## 목표

`dashboard_http_tool_quality.ml`이 dashboard에 표시하는 5 사이트가 *missing-field* / *wrong-shape* 두 다른 문제를 동일 `"unknown"` 라벨로 collapse. operator가 dashboard에서 `tool="unknown"` row를 보면 *legitimate tool 'unknown'이 호출됐는지*, *tool field가 producer에서 누락됐는지* 구분 불가.

| 사이트 | 문제 |
|---|---|
| L79 `command_blocked_readonly:unknown` | 정책 class 누락 vs 실제 unknown 정책 구분 불가 |
| L268 `tool=unknown` (bucket) | tool field 누락 vs 'unknown' 이름 tool 호출 conflate |
| L272 `keeper=unknown` (bucket) | 동일 패턴 |
| L118/119 `thinking_mode=unknown` | field missing on Assoc vs record가 Assoc 아님 두 다른 case collapse |
| L158/159 `hour_key=unknown` | ts field missing vs record가 Assoc 아님 |

`★ 워크어라운드 거부 기준 self-check ─────────────────`
silent collision을 *제거*. 새 catch-all/string 분류기/cap/cooldown/dedup 도입 없음. dashboard schema 변경 0. behavior 변화 0. 통과.
`─────────────────────────────────────────────────`

## 변경 파일

| 파일 | 변경 |
|---|---|
| `lib/dashboard/dashboard_http_tool_quality.ml` | 5 사이트 → 각 missing-field/wrong-shape 별 distinct sentinel. bracketed (`<missing X>`) 형태라 real free-form value와 충돌 없음 |

총 1 file, +27 / -7.

## Dashboard 사용자 시야 (Before / After)

**Before** — `tool=unknown` bucket이 dashboard에 카운트 100:
```
tool                  count
─────────────────     ─────
unknown               100      ← producer 누락? 실제 unknown tool? 알 수 없음
grep_search             45
read_file               30
```

**After**:
```
tool                          count
─────────────────────────     ─────
<missing tool field>          100   ← producer-side 명확, fix는 emitter 측
grep_search                    45
read_file                      30
```

## L43 보류 사유

`classify_process_status`의 `kind` default "unknown" (L43)은 *control-flow match*에 묶임 — 단순 라벨 변경이 아니라 classifier 재설계 필요. 본 PR scope 외, 별도 후속 후보.

## 로컬 검증

- `ocamlformat --check` PASS (1/1)
- **`dune build @check` PASS**
- `<bracketed>` sentinel은 producer가 emit 안 함 (producers never emit angle-bracket-wrapped values), 충돌 없음

## RFC

`bash ~/me/scripts/pr-rfc-check.sh` PASS — dashboard tool_quality는 boundary subsystem 아님. RFC waiver 불필요.

## 시리즈

같은 /loop의 Iter#7 PR #16383 (dashboard runtime-mismatch sentinel inline reason)과 같은 *dashboard user-facing diagnostic* 패턴. /loop 전체로는 Iter#1-#8의 "sentinel-only → received-value 명시" 시리즈 연속.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>