### PR TITLE
fix(ci): refresh spawn-bounded allowlist

### DIFF
--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -31,8 +31,9 @@ lib/process/process_eio.ml:493
 # manager itself. Bounded by session scope, not by per-call timeout.
 lib/server/lsp_process_manager.ml:178
 
-# lib/worker_dev_tools.ml:1816 — dev-tools worker spawn. Wrapped by
+# lib/worker_dev_tools.ml:1440 — dev-tools worker spawn. Wrapped by
 # Tool_resource_gate, Fd_accountant, Eio.Time.with_timeout_exn, and a fresh
 # Eio.Switch.run at the call boundary. Line renumbered from :1941 by
-# #16222 (split: worker dev tool paths).
-lib/worker_dev_tools.ml:1816
+# #16222 (split: worker dev tool paths), then from :1816 by
+# #16394 (cascade preflight disable follow-up).
+lib/worker_dev_tools.ml:1440


### PR DESCRIPTION
## Summary

Refresh scripts/lint-spawn-bounded.allowlist after current main moved the bounded worker_dev_tools spawn from lib/worker_dev_tools.ml:1816 to lib/worker_dev_tools.ml:1440.

## Root cause

Latest main kept the same bounded call site, but line movement made the line-number ratchet report one new entry and one stale entry. The call remains wrapped by Fd_accountant, Eio.Time.with_timeout_exn, and a fresh Eio.Switch.run.

## Validation

- bash scripts/lint-spawn-bounded.sh
- git diff --check

Refs #16405