### PR TITLE
refactor: split keeper profile oas env parsing

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -74,6 +74,7 @@
  keeper_persona_authoring_contract
  keeper_persona_authoring_slug
  keeper_types_profile_sandbox
+ keeper_types_profile_oas_env
  keeper_types_profile
  keeper_meta_tool_access
  keeper_meta_contract

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -469,116 +469,17 @@ let persona_profile_path_opt name =
 (* TOML -> keeper_profile_defaults conversion                        *)
 (* ================================================================ *)
 
-(** Scan a flat TOML doc for keys under [[keeper.oas_env]].  Only provider
-    OAS prefixes and [MASC_KEEPER_OAS_*] are accepted.  The legacy
-    [MASC_KEEPER_UNIFIED_MAX_TOKENS] key remains accepted as a narrow migration
-    alias for the canonical [MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS].  Any other
-    entries are dropped.  This guards against
-    arbitrary process env injection via keeper TOML.  Values are coerced
-    to strings via [string_of_toml_value_for_env] (bool → "1"/"0"), so
-    integers and booleans in TOML map to the string shapes the OAS
-    transport build_args already understand. *)
-let string_of_toml_value_for_env = function
-  | Keeper_toml_loader.Toml_string s -> Some s
-  | Keeper_toml_loader.Toml_int i -> Some (string_of_int i)
-  | Keeper_toml_loader.Toml_float f -> Some (string_of_float f)
-  | Keeper_toml_loader.Toml_bool true -> Some "1"
-  | Keeper_toml_loader.Toml_bool false -> Some "0"
-  | Keeper_toml_loader.Toml_string_array _ -> None
+module Oas_env = Keeper_types_profile_oas_env
 
-let oas_env_key_prefix = "keeper.oas_env."
-
-let oas_env_allowed_prefixes =
-  [ "OAS_CLAUDE_"; "OAS_CODEX_"; "OAS_GEMINI_"; "MASC_KEEPER_OAS_" ]
-
-let keeper_unified_max_tokens_oas_env_key =
-  "MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS"
-
-let legacy_keeper_unified_max_tokens_oas_env_key =
-  "MASC_KEEPER_UNIFIED_MAX_TOKENS"
-
-let oas_env_allowed_exact_keys =
-  [ legacy_keeper_unified_max_tokens_oas_env_key ]
-
-let oas_env_key_is_allowed suffix =
-  List.mem suffix oas_env_allowed_exact_keys
-  || List.exists
-       (fun p ->
-         String.length suffix > String.length p
-         && String.sub suffix 0 (String.length p) = p)
-       oas_env_allowed_prefixes
-
-(* Observability for the env-key allowlist drop branch.  Previously
-   any [keeper.oas_env.<X>] entry whose suffix did not match
-   [OAS_(CLAUDE|CODEX|GEMINI)_] or [MASC_KEEPER_OAS_*] was filtered out with
-   no signal — operators could not tell whether a typo'd key
-   (e.g. [OAS_CLUADE_API_KEY]) had been silently ignored.
-   Closes the silent-drop gap noted in
-   .tmp/memory-compacting-analysis.html (oas_env allowlist drop). *)
-let () =
-  Prometheus.register_counter
-    ~name:Keeper_metrics.metric_keeper_oas_env_key_rejections
-    ~help:
-      "Total keeper.oas_env.<X> entries rejected by the allowlist \
-       in [extract_oas_env_from_doc].  Each rejected key produces \
-       a warn line; non-zero counts at startup mean the TOML \
-       contains keys the runtime silently ignored."
-    ()
-;;
-
-let extract_oas_env_from_doc (doc : Keeper_toml_loader.toml_doc)
-    : (string * string) list =
-  let prefix_len = String.length oas_env_key_prefix in
-  List.filter_map
-    (fun (k, v) ->
-      if String.length k > prefix_len
-         && String.starts_with k ~prefix:oas_env_key_prefix
-      then
-        let suffix = String.sub k prefix_len (String.length k - prefix_len) in
-        if oas_env_key_is_allowed suffix then
-          Option.map (fun sv -> (suffix, sv)) (string_of_toml_value_for_env v)
-        else begin
-          Prometheus.inc_counter
-            Keeper_metrics.metric_keeper_oas_env_key_rejections
-            ();
-          Log.Keeper.warn
-            "keeper.oas_env: dropping key=%S — suffix %S not in \
-             allowlist (OAS_CLAUDE_* | OAS_CODEX_* | OAS_GEMINI_* | \
-             MASC_KEEPER_OAS_<suffix>); fix the TOML or expand the allowlist"
-            k suffix;
-          ignore v;
-          None
-        end
-      else None)
-    doc
-
-let unified_max_tokens_override_of_oas_env ?keeper_name pairs =
-  let key, raw_opt =
-    match List.assoc_opt keeper_unified_max_tokens_oas_env_key pairs with
-    | Some raw -> keeper_unified_max_tokens_oas_env_key, Some raw
-    | None ->
-      ( legacy_keeper_unified_max_tokens_oas_env_key,
-        List.assoc_opt legacy_keeper_unified_max_tokens_oas_env_key pairs )
-  in
-  match raw_opt with
-  | None -> None
-  | Some raw ->
-    let trimmed = String.trim raw in
-    (match int_of_string_opt trimmed with
-     | Some value ->
-       let min_v = 256 in
-       let max_v = 262_144 in
-       Some (max min_v (min max_v value))
-     | None ->
-       let keeper =
-         match keeper_name with
-         | Some name -> name
-         | None -> "(unknown)"
-       in
-       Log.Keeper.warn
-         "keeper.oas_env: ignoring invalid %s=%S for keeper=%s; expected integer"
-         key raw keeper;
-       None)
+let string_of_toml_value_for_env = Oas_env.string_of_toml_value_for_env
+let oas_env_key_prefix = Oas_env.oas_env_key_prefix
+let oas_env_allowed_prefixes = Oas_env.oas_env_allowed_prefixes
+let keeper_unified_max_tokens_oas_env_key = Oas_env.keeper_unified_max_tokens_oas_env_key
+let legacy_keeper_unified_max_tokens_oas_env_key = Oas_env.legacy_keeper_unified_max_tokens_oas_env_key
+let oas_env_allowed_exact_keys = Oas_env.oas_env_allowed_exact_keys
+let oas_env_key_is_allowed = Oas_env.oas_env_key_is_allowed
+let extract_oas_env_from_doc = Oas_env.extract_oas_env_from_doc
+let unified_max_tokens_override_of_oas_env = Oas_env.unified_max_tokens_override_of_oas_env
 
 let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
     : (keeper_profile_defaults, string) result =

--- a/lib/keeper/keeper_types_profile_oas_env.ml
+++ b/lib/keeper/keeper_types_profile_oas_env.ml
@@ -1,0 +1,112 @@
+(** keeper.oas_env TOML allowlist extraction and override parsing. *)
+
+(** Scan a flat TOML doc for keys under [[keeper.oas_env]].  Only provider
+    OAS prefixes and [MASC_KEEPER_OAS_*] are accepted.  The legacy
+    [MASC_KEEPER_UNIFIED_MAX_TOKENS] key remains accepted as a narrow migration
+    alias for the canonical [MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS].  Any other
+    entries are dropped.  This guards against
+    arbitrary process env injection via keeper TOML.  Values are coerced
+    to strings via [string_of_toml_value_for_env] (bool → "1"/"0"), so
+    integers and booleans in TOML map to the string shapes the OAS
+    transport build_args already understand. *)
+let string_of_toml_value_for_env = function
+  | Keeper_toml_loader.Toml_string s -> Some s
+  | Keeper_toml_loader.Toml_int i -> Some (string_of_int i)
+  | Keeper_toml_loader.Toml_float f -> Some (string_of_float f)
+  | Keeper_toml_loader.Toml_bool true -> Some "1"
+  | Keeper_toml_loader.Toml_bool false -> Some "0"
+  | Keeper_toml_loader.Toml_string_array _ -> None
+
+let oas_env_key_prefix = "keeper.oas_env."
+
+let oas_env_allowed_prefixes =
+  [ "OAS_CLAUDE_"; "OAS_CODEX_"; "OAS_GEMINI_"; "MASC_KEEPER_OAS_" ]
+
+let keeper_unified_max_tokens_oas_env_key =
+  "MASC_KEEPER_OAS_UNIFIED_MAX_TOKENS"
+
+let legacy_keeper_unified_max_tokens_oas_env_key =
+  "MASC_KEEPER_UNIFIED_MAX_TOKENS"
+
+let oas_env_allowed_exact_keys =
+  [ legacy_keeper_unified_max_tokens_oas_env_key ]
+
+let oas_env_key_is_allowed suffix =
+  List.mem suffix oas_env_allowed_exact_keys
+  || List.exists
+       (fun p ->
+         String.length suffix > String.length p
+         && String.sub suffix 0 (String.length p) = p)
+       oas_env_allowed_prefixes
+
+(* Observability for the env-key allowlist drop branch.  Previously
+   any [keeper.oas_env.<X>] entry whose suffix did not match
+   [OAS_(CLAUDE|CODEX|GEMINI)_] or [MASC_KEEPER_OAS_*] was filtered out with
+   no signal — operators could not tell whether a typo'd key
+   (e.g. [OAS_CLUADE_API_KEY]) had been silently ignored.
+   Closes the silent-drop gap noted in
+   .tmp/memory-compacting-analysis.html (oas_env allowlist drop). *)
+let () =
+  Prometheus.register_counter
+    ~name:Keeper_metrics.metric_keeper_oas_env_key_rejections
+    ~help:
+      "Total keeper.oas_env.<X> entries rejected by the allowlist \
+       in [extract_oas_env_from_doc].  Each rejected key produces \
+       a warn line; non-zero counts at startup mean the TOML \
+       contains keys the runtime silently ignored."
+    ()
+;;
+
+let extract_oas_env_from_doc (doc : Keeper_toml_loader.toml_doc)
+    : (string * string) list =
+  let prefix_len = String.length oas_env_key_prefix in
+  List.filter_map
+    (fun (k, v) ->
+      if String.length k > prefix_len
+         && String.starts_with k ~prefix:oas_env_key_prefix
+      then
+        let suffix = String.sub k prefix_len (String.length k - prefix_len) in
+        if oas_env_key_is_allowed suffix then
+          Option.map (fun sv -> (suffix, sv)) (string_of_toml_value_for_env v)
+        else begin
+          Prometheus.inc_counter
+            Keeper_metrics.metric_keeper_oas_env_key_rejections
+            ();
+          Log.Keeper.warn
+            "keeper.oas_env: dropping key=%S — suffix %S not in \
+             allowlist (OAS_CLAUDE_* | OAS_CODEX_* | OAS_GEMINI_* | \
+             MASC_KEEPER_OAS_<suffix>); fix the TOML or expand the allowlist"
+            k suffix;
+          ignore v;
+          None
+        end
+      else None)
+    doc
+
+let unified_max_tokens_override_of_oas_env ?keeper_name pairs =
+  let key, raw_opt =
+    match List.assoc_opt keeper_unified_max_tokens_oas_env_key pairs with
+    | Some raw -> keeper_unified_max_tokens_oas_env_key, Some raw
+    | None ->
+      ( legacy_keeper_unified_max_tokens_oas_env_key,
+        List.assoc_opt legacy_keeper_unified_max_tokens_oas_env_key pairs )
+  in
+  match raw_opt with
+  | None -> None
+  | Some raw ->
+    let trimmed = String.trim raw in
+    (match int_of_string_opt trimmed with
+     | Some value ->
+       let min_v = 256 in
+       let max_v = 262_144 in
+       Some (max min_v (min max_v value))
+     | None ->
+       let keeper =
+         match keeper_name with
+         | Some name -> name
+         | None -> "(unknown)"
+       in
+       Log.Keeper.warn
+         "keeper.oas_env: ignoring invalid %s=%S for keeper=%s; expected integer"
+         key raw keeper;
+       None)

--- a/lib/keeper/keeper_types_profile_oas_env.mli
+++ b/lib/keeper/keeper_types_profile_oas_env.mli
@@ -1,0 +1,9 @@
+val string_of_toml_value_for_env : Keeper_toml_loader.toml_value -> string option
+val oas_env_key_prefix : string
+val oas_env_allowed_prefixes : string list
+val keeper_unified_max_tokens_oas_env_key : string
+val legacy_keeper_unified_max_tokens_oas_env_key : string
+val oas_env_allowed_exact_keys : string list
+val oas_env_key_is_allowed : string -> bool
+val extract_oas_env_from_doc : Keeper_toml_loader.toml_doc -> (string * string) list
+val unified_max_tokens_override_of_oas_env : ?keeper_name:string -> (string * string) list -> int option


### PR DESCRIPTION
## Summary
- Extract keeper.oas_env TOML allowlist parsing and unified-token override parsing into Keeper_types_profile_oas_env.
- Keep existing Keeper_types_profile constants/functions as forwarding bindings for compatibility.
- Reduce lib/keeper/keeper_types_profile.ml from 1890-ish current main size to 1779 lines.

## Validation
- ocamlformat --check lib/keeper/keeper_types_profile.ml lib/keeper/keeper_types_profile_oas_env.ml lib/keeper/keeper_types_profile_oas_env.mli
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- bash scripts/lint/godfile-size-regression.sh
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_toml.exe (blocked before build: live bare dune process outside scripts/dune-local.sh: PID 1702 dune build --root .)