### PR TITLE
feat(dashboard): inline reasons in goals-timeline "unknown" sentinels

### DIFF
--- a/lib/dashboard/dashboard_goals_types_timeline.ml
+++ b/lib/dashboard/dashboard_goals_types_timeline.ml
@@ -163,9 +163,20 @@ let goal_event_timeline_json event =
   let title, summary, severity =
     match event_type with
     | "goal_phase" ->
+        (* Each [Option.value ~default:"unknown"] in this match used to
+           render in the dashboard timeline as a verbatim value
+           (e.g. "phase=unknown by ...", "principal voted unknown",
+           "status=unknown", "decision=unknown") that the operator
+           reads when investigating a stuck goal.  "unknown" collides
+           with any legitimate value named "unknown" in the producer
+           event stream, so the operator cannot tell "the payload
+           field was missing" apart from "the producer sent the
+           string 'unknown'".  Bracketed sentinels are not emitted by
+           any producer, so a non-zero appearance is an unambiguous
+           producer-side fix signal. *)
         let phase =
           payload_field "phase" |> to_string_option
-          |> Option.value ~default:"unknown"
+          |> Option.value ~default:"<missing payload.phase>"
         in
         let actor =
           payload_field "actor" |> json_member_or_null "id" |> to_string_option
@@ -197,7 +208,7 @@ let goal_event_timeline_json event =
         let vote = payload_field "vote" in
         let decision =
           vote |> json_member_or_null "decision" |> to_string_option
-          |> Option.value ~default:"unknown"
+          |> Option.value ~default:"<missing payload.vote.decision>"
         in
         let principal =
           vote |> json_member_or_null "principal" |> json_member_or_null "id"
@@ -210,7 +221,7 @@ let goal_event_timeline_json event =
     | "goal_verification_resolved" ->
         let status =
           payload_field "status" |> to_string_option
-          |> Option.value ~default:"unknown"
+          |> Option.value ~default:"<missing payload.status>"
         in
         ( "Goal Verification Resolved",
           Printf.sprintf "status=%s" status,
@@ -228,7 +239,7 @@ let goal_event_timeline_json event =
     | "goal_approval_resolved" ->
         let decision =
           payload_field "decision" |> to_string_option
-          |> Option.value ~default:"unknown"
+          |> Option.value ~default:"<missing payload.decision>"
         in
         ( "Goal Approval Resolved",
           Printf.sprintf "decision=%s" decision,
@@ -312,7 +323,8 @@ let build_goal_timeline node linked_keepers approvals goal_events =
                    | None -> None
                    | Some ended_at ->
                        let outcome =
-                         receipt_outcome receipt |> Option.value ~default:"unknown"
+                         receipt_outcome receipt
+                         |> Option.value ~default:"<missing receipt.outcome>"
                        in
                        let severity =
                          if receipt_has_error receipt then "bad"


### PR DESCRIPTION
## 목표

`dashboard_goals_types_timeline.ml`의 goal-event match arms는 dashboard timeline에 사용자가 직접 읽는 5개 string을 emit. 모두 `Option.value ~default:"unknown"` — *producer가 진짜 "unknown" 값 emit* vs *payload field missing* 두 다른 case가 동일 라벨로 collapse. operator는 어느 case인지 모름.

| 사이트 | 표시 (Before) |
|---|---|
| L168 phase | `phase=unknown by ...` |
| L200 vote decision | `principal voted unknown` |
| L213 status | `status=unknown` |
| L231 approval decision | `decision=unknown` |
| L315 receipt outcome | bucket `outcome=unknown` |

`★ 워크어라운드 거부 기준 self-check ─────────────────`
silent collision *제거*. 새 catch-all/string 분류기/cap/cooldown/dedup 도입 없음. behavior 변화 0 (severity match arm `_ -> ...` default가 새 sentinel string도 처리). 통과.
`─────────────────────────────────────────────────`

## 변경 파일

| 파일 | 변경 |
|---|---|
| `lib/dashboard/dashboard_goals_types_timeline.ml` | 5 사이트 → `<missing payload.X>` / `<missing receipt.outcome>` bracketed sentinel |

총 1 file, +17 / -5.

## Dashboard 사용자 시야

**Before** (goal phase event에 payload.phase missing):
```
Goal Phase   phase=unknown by user-42       ← producer 버그? real "unknown" phase?
```

**After**:
```
Goal Phase   phase=<missing payload.phase> by user-42    ← producer-side 명확
```

bracketed sentinel은 producer가 emit하지 않으므로 (`<...>` wrapping은 producer JSON schema 외) real value와 충돌 없음. dashboard에 나타나면 즉시 producer fix 신호.

## 로컬 검증

- `ocamlformat --check` PASS (1/1)
- **`dune build @check` PASS**
- severity match arm (`_ -> "ok"` / `_ -> "warn"`) 모두 새 sentinel string에도 default arm으로 매칭 — behavior 변화 0

## RFC

`bash ~/me/scripts/pr-rfc-check.sh` PASS — dashboard goals timeline은 boundary subsystem 아님.

## 시리즈

같은 /loop의 Iter#7 PR #16383 (runtime-mismatch), Iter#9 PR #16404 (tool_quality bucket keys)와 같은 *dashboard user-facing diagnostic* 패턴.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>