### PR TITLE
fix: align code shell allowlist with dev shell

### DIFF
--- a/docs/KEEPER-SHELL-QUALITY-LEAKS.md
+++ b/docs/KEEPER-SHELL-QUALITY-LEAKS.md
@@ -1,7 +1,7 @@
 # Keeper Shell Quality Leaks
 
 Runtime baseline: `/Users/dancer/me/.masc/tool_calls`, 240h window ending
-`2026-05-19T08:48:40+0900`.
+`2026-05-19T09:47:28+0900`.
 
 Baseline command:
 
@@ -13,9 +13,9 @@ Baseline result:
 
 | Metric | Count |
 |---|---:|
-| Bash calls | 21,721 |
-| Failed or semantic-failed Bash calls | 8,835 |
-| Failure rate | 40.67% |
+| Bash calls | 21,917 |
+| Failed or semantic-failed Bash calls | 8,902 |
+| Failure rate | 40.62% |
 
 Release target: after the improvement PR is merged and keepers have generated a
 fresh 240h sample, the same script should report `failure_pct < 10.00`.
@@ -24,30 +24,30 @@ Adjacent tool-surface sample from the same 240h window:
 
 | Tool | Failed | OK | Failure rate |
 |---|---:|---:|---:|
-| `masc_code_shell` | 1,640 | 6,326 | 20.59% |
+| `masc_code_shell` | 1,643 | 6,340 | 20.58% |
 | `masc_code_edit` | 119 | 51 | 70.00% |
-| `keeper_shell` | 166 | 404 | 29.12% |
-| `keeper_bash` | 172 | 948 | 15.36% |
+| `keeper_shell` | 166 | 399 | 29.38% |
+| `keeper_bash` | 174 | 948 | 15.51% |
 | `keeper_pr_review_read` | 17 | 23 | 42.50% |
-| `keeper_pr_review_comment` | 50 | 47 | 51.55% |
-| public `Edit` | 38 | 15 | 71.70% |
-| public `Write` | 94 | 6 | 94.00% |
+| `keeper_pr_review_comment` | 58 | 50 | 53.70% |
+| public `Edit` | 41 | 15 | 73.21% |
+| public `Write` | 103 | 8 | 92.79% |
 
 ## Leak Map
 
 | Leak class | Baseline count | Code boundary | Current fix path |
 |---|---:|---|---|
-| `shape_block:pipe_or_redirect` | 2,580 | `lib/keeper/keeper_shell_bash.ml`, `scripts/analyze-keeper-bash-failures.sh` | Infer shape from the command, not from hint text. Keep unsafe pipelines blocked, but allow safe read-only `|| echo`, stderr-dev-null, and `read-only primary | head -N` fallbacks through deterministic validation of the primary command. |
-| Missing path or wrong cwd | 1,596 | `lib/worker_dev_tools.ml`, `lib/keeper/keeper_shell_docker.ml` | Preserve path validation, but make public `Bash` expose `cwd`, make retry hints use the public `Bash { command, cwd }` shape, and allow the safe `/dev/null` sentinel instead of treating `cat /dev/null` as an out-of-whitelist path. |
-| `shape_block:chaining` | 1,270 | `lib/keeper/keeper_shell_bash.ml` | Normalize safe read-only fallbacks. `cd repos/... && <read-only>` is treated like a cwd-scoped read instead of a hard shape failure. |
-| Non-zero command exits | 836 | `lib/exec_core.ml`, `lib/keeper_tool_call_log.ml` | Treat structured `ok=true` and `semantic_status=no_match` as semantic success even when the transport-level call was marked failed. |
+| `shape_block:pipe_or_redirect` | 2,606 | `lib/keeper/keeper_shell_bash.ml`, `scripts/analyze-keeper-bash-failures.sh` | Infer shape from the command, not from hint text. Keep unsafe pipelines blocked, but allow safe read-only `|| echo`, stderr-dev-null, and `read-only primary | head -N` fallbacks through deterministic validation of the primary command. |
+| Missing path or wrong cwd | 1,602 | `lib/worker_dev_tools.ml`, `lib/keeper/keeper_shell_docker.ml` | Preserve path validation, but make public `Bash` expose `cwd`, make retry hints use the public `Bash { command, cwd }` shape, and allow the safe `/dev/null` sentinel instead of treating `cat /dev/null` as an out-of-whitelist path. |
+| `shape_block:chaining` | 1,275 | `lib/keeper/keeper_shell_bash.ml` | Normalize safe read-only fallbacks. `cd repos/... && <read-only>` is treated like a cwd-scoped read instead of a hard shape failure. |
+| Non-zero command exits | 846 | `lib/exec_core.ml`, `lib/keeper_tool_call_log.ml` | Treat structured `ok=true` and `semantic_status=no_match` as semantic success even when the transport-level call was marked failed. |
 | Path syntax blocked | 540 | `lib/worker_dev_tools.ml`, `lib/keeper/keeper_path_check_error.ml`, `lib/keeper/keeper_tool_pr_review.ml` | Keep the safety gate; measure it distinctly instead of collapsing it into generic structured errors. PR review mutation tools now write review bodies to temp files and pass `--body-file` / `-F body=@file`, so body prose is no longer parsed as path-bearing shell syntax. |
-| `other` / unclassified failures | 450 | `lib/keeper_tool_call_log.ml`, `lib/dashboard/dashboard_http_tool_quality.ml` | Promote structured `semantic_status`, `shape_block`, and diagnosis fields into stable failure categories. |
+| `other` / unclassified failures | 459 | `lib/keeper_tool_call_log.ml`, `lib/dashboard/dashboard_http_tool_quality.ml` | Promote structured `semantic_status`, `shape_block`, and diagnosis fields into stable failure categories. |
 | `shape_block:unknown` | 352 | `scripts/analyze-keeper-bash-failures.sh` | Leave true parser-unknown shape blocks separate from command-inferable pipe/chaining failures. |
-| Multi-repo cwd required | 282 | `lib/keeper/keeper_shell_docker.ml`, `lib/keeper/keeper_tool_alias.ml` | Parse command tokens with the Bash parser and return a public `Bash` retry shape including `cwd`. |
+| Multi-repo cwd required | 286 | `lib/keeper/keeper_shell_docker.ml`, `lib/keeper/keeper_tool_alias.ml` | Parse command tokens with the Bash parser and return a public `Bash` retry shape including `cwd`. |
 | Timeout | 271 | `lib/exec_core.ml`, Docker shell runtime | Classify as `semantic_status:timeout` for the quality loop; command scoping remains the caller-side correction. |
 | Repeat/streak gates | 203 | OAS retry cache, keeper tool diversity gates | Measure separately as `repeat_or_streak_gate` so retries are not mistaken for new Bash defects. |
-| Wrong tool channel | 157 | `lib/keeper/keeper_shell_bash.ml`, `scripts/analyze-keeper-bash-failures.sh` | Preserve the pre-exec block, expose it as `wrong_tool_channel`, and classify public `gh`/MASC-tool attempts before generic allowlist failures. |
+| Wrong tool channel | 164 | `lib/keeper/keeper_shell_bash.ml`, `scripts/analyze-keeper-bash-failures.sh` | Preserve the pre-exec block, expose it as `wrong_tool_channel`, and classify public `gh`/MASC-tool attempts before generic allowlist failures. |
 | Command not allowed by validator | 110 | `lib/keeper/keeper_shell_bash.ml`, `lib/tool_code_write.ml` | Keep the explicit validator block, but measure it separately from path syntax, wrong-tool, and shell shape classes. |
 | Docker image missing | 108 | Docker sandbox runtime | Measure separately from command-shape failures; this is an infrastructure/runtime availability class. |
 | Command usage or regex errors | 59 | command-specific handlers | Keep as caller-command defects rather than path or sandbox defects. |
@@ -57,10 +57,11 @@ Adjacent tool-surface sample from the same 240h window:
 
 `masc_code_shell` had a separate allowlist from `keeper_bash`, so safe inspection
 commands could fail even when the same read shape was accepted elsewhere. The
-top observed class was `command_not_allowed`; safe inspection commands such as
-`sed -n ...` and `pwd` are now in the code-shell allowlist, and the tool schema
-now matches the validator: allowlisted pipelines are supported, but shell
-chaining remains blocked.
+top observed adjacent class was `command_not_allowed`; code shell now reuses the
+`Dev_exec_allowlist.dev` SSOT plus its tool-specific extras, so commands such as
+`sed -n ...`, `pwd`, `echo`, `python3`, `ruff`, and `pyright` no longer drift
+from keeper dev-shell policy. The tool schema now describes that SSOT and the
+validator still blocks chaining, command substitution, and unsafe redirects.
 
 `keeper_pr_review_comment` and `keeper_pr_review_reply` also shared the path
 syntax leak indirectly: the handlers inlined review prose into a shell command,
@@ -84,6 +85,7 @@ Focused tests:
 scripts/dune-local.sh build test/test_keeper_bash_safety.exe
 scripts/dune-local.sh build test/test_keeper_tool_call_log.exe
 scripts/dune-local.sh build test/test_keeper_pr_review.exe
+scripts/dune-local.sh build test/test_tool_code_write_coverage.exe
 ```
 
 Runtime remeasure:

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -34,6 +34,8 @@ type t =
   | TurnReattempts
   | TurnRegressions
   | TurnLivelockBlocks
+  | TurnLivelockBlocksRepeated
+  | TurnLivelockBlocksThresholdPark
   | TurnLatencyBucket
   | TurnLatencyByModelBucket
   | ProviderCooldownSkip
@@ -238,6 +240,9 @@ let to_string = function
   | TurnReattempts -> "masc_keeper_turn_reattempts_total"
   | TurnRegressions -> "masc_keeper_turn_regressions_total"
   | TurnLivelockBlocks -> "masc_keeper_turn_livelock_blocks_total"
+  | TurnLivelockBlocksRepeated -> "masc_keeper_turn_livelock_blocks_repeated_total"
+  | TurnLivelockBlocksThresholdPark ->
+    "masc_keeper_turn_livelock_blocks_threshold_park_total"
   | TurnLatencyBucket -> "masc_keeper_turn_latency_bucket_total"
   | TurnLatencyByModelBucket -> "masc_keeper_turn_latency_by_model_bucket_total"
   | ProviderCooldownSkip -> "masc_keeper_provider_cooldown_skip_total"

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -26,6 +26,8 @@ type t =
   | TurnReattempts
   | TurnRegressions
   | TurnLivelockBlocks
+  | TurnLivelockBlocksRepeated
+  | TurnLivelockBlocksThresholdPark
   | TurnLatencyBucket
   | TurnLatencyByModelBucket
   | ProviderCooldownSkip

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -47,13 +47,15 @@ let first_nonempty_line output =
   |> List.map String.trim
   |> List.find_opt (fun s -> not (String.equal s ""))
 
-(* Shell command allowlist *)
-let allowed_shell_commands = [
-  "dune-local.sh"; "make"; "npm"; "npx"; "node";
-  "git"; "ls"; "cat"; "head"; "tail"; "wc";
-  "rg"; "grep"; "find"; "sed"; "pwd"; "diff"; "patch"; "mkdir";
-  "opam"; "ocamlfind"; "tsc";
-]
+let add_unique acc item =
+  if List.exists (String.equal item) acc then acc else acc @ [ item ]
+
+(* Shell command allowlist.  Keep this aligned with keeper_bash/dev shell so
+   safe coding probes do not fail only because they entered through
+   masc_code_shell.  Tool-specific extras are kept here. *)
+let allowed_shell_commands =
+  List.fold_left add_unique Dev_exec_allowlist.dev
+    [ "diff"; "patch"; "mkdir"; "ocamlfind"; "tsc" ]
 
 let validate_code_shell_command (command : string) : (unit, string) Result.t =
   Worker_dev_tools.validate_command_coding_with_allowlist
@@ -936,9 +938,8 @@ Use when removing generated, obsolete, or conflicting files during code work.";
     name = "masc_code_shell";
     description = "Run an allowlisted command in an allowed coding sandbox \
 (.worktrees/ or .masc/playground/). \
-Allowed: scripts/dune-local.sh, make, npm, npx, node, git, ls, cat, head, tail, \
-wc, rg, grep, find, sed, pwd, diff, patch, mkdir, opam, ocamlfind, tsc. Use for building and \
-testing code in isolated worktrees. For unrestricted shell at project root, use keeper_bash. \
+Allowed: keeper dev-shell commands plus diff, patch, mkdir, ocamlfind, and tsc. \
+Use for building and testing code in isolated worktrees. For unrestricted shell at project root, use keeper_bash. \
 Returns exit_code and stdout (truncated at " ^ max_output_label ^ ").";
     input_schema = `Assoc [
       ("type", `String "object");

--- a/lib/tool_code_write.mli
+++ b/lib/tool_code_write.mli
@@ -127,11 +127,10 @@ val validate_code_shell_command :
   string -> (unit, string) Result.t
 (** [validate_code_shell_command command] delegates to
     {!Worker_dev_tools.validate_command_coding_with_allowlist}
-    with [~allow_pipes:true] and the pinned
-    [allowed_shell_commands] list (dune-local, make, npm/npx/node,
-    git, ls, cat, head, tail, wc, rg, grep, find, sed, pwd, diff, patch, mkdir,
-    opam, ocamlfind, tsc).  Drift in the allowlist changes the
-    keeper sandbox surface — pinned at the contract seam. *)
+    with [~allow_pipes:true] and the pinned [Dev_exec_allowlist.dev]
+    surface plus tool-specific commands ([diff], [patch], [mkdir],
+    [ocamlfind], [tsc]).  Drift in the allowlist changes the keeper
+    sandbox surface — pinned at the contract seam. *)
 
 (** {1 Git clone validation} *)
 

--- a/test/test_keeper_fs_edit_patch.ml
+++ b/test/test_keeper_fs_edit_patch.ml
@@ -7,6 +7,7 @@
 module Coord = Masc_mcp.Coord
 module Keeper_exec_fs = Masc_mcp.Keeper_exec_fs
 module Keeper_registry = Masc_mcp.Keeper_registry
+module Keeper_tool_alias = Masc_mcp.Keeper_tool_alias
 module Keeper_types = Masc_mcp.Keeper_types
 module Keeper_alerting_path = Masc_mcp.Keeper_alerting_path
 module Fs_compat = Fs_compat
@@ -78,6 +79,7 @@ let setup ?(sandbox = Keeper_types.Local) f =
       (Keeper_alerting_path.playground_path_of_keeper meta.name)
   in
   ensure_dir playground;
+  ignore (Keeper_registry.register ~base_path:base meta.name meta);
   f ~config ~meta ~playground
 
 let parse raw = Yojson.Safe.from_string raw
@@ -91,6 +93,19 @@ let parse_error raw =
 
 let parse_int raw field =
   parse raw |> Json.member field |> Json.to_int_option
+
+let public_fs_edit_call ~public ~config ~(meta : Keeper_types.keeper_meta) args =
+  let args = Keeper_tool_alias.translate_input ~public args in
+  Keeper_exec_fs.handle_keeper_fs_edit
+    ~turn_sandbox_factory:None
+    ~config
+    ~keeper_name:meta.name
+    ~args
+
+let seed_single_playground_repo playground =
+  let repo = Filename.concat playground "repos/masc-mcp" in
+  ensure_dir (Filename.concat repo ".git");
+  repo
 
 (* ── Tests ───────────────────────────────────────────────────────── *)
 
@@ -260,6 +275,47 @@ let test_overwrite_unchanged_by_patch_addition () =
   Alcotest.(check string) "overwrite wrote bytes"
     "fresh" (Fs_compat.load_file path)
 
+let test_public_edit_maps_top_relative_single_repo_path () =
+  setup @@ fun ~config ~meta ~playground ->
+  let repo = seed_single_playground_repo playground in
+  let path = Filename.concat repo "lib/src.ml" in
+  ensure_dir (Filename.dirname path);
+  Fs_compat.save_file path "let x = 1\n";
+  let raw =
+    public_fs_edit_call
+      ~public:"Edit"
+      ~config
+      ~meta
+      (`Assoc
+        [
+          ("file_path", `String "lib/src.ml");
+          ("old_string", `String "let x = 1");
+          ("new_string", `String "let x = 2");
+        ])
+  in
+  Alcotest.(check bool) "ok" true (parse_ok raw);
+  Alcotest.(check string) "file edited through single repo rewrite"
+    "let x = 2\n" (Fs_compat.load_file path)
+
+let test_public_write_maps_top_relative_single_repo_path () =
+  setup @@ fun ~config ~meta ~playground ->
+  let repo = seed_single_playground_repo playground in
+  let path = Filename.concat repo "lib/generated.ml" in
+  let raw =
+    public_fs_edit_call
+      ~public:"Write"
+      ~config
+      ~meta
+      (`Assoc
+        [
+          ("file_path", `String "lib/generated.ml");
+          ("content", `String "let generated = true\n");
+        ])
+  in
+  Alcotest.(check bool) "ok" true (parse_ok raw);
+  Alcotest.(check string) "file written through single repo rewrite"
+    "let generated = true\n" (Fs_compat.load_file path)
+
 let () =
   Alcotest.run "Keeper_fs_edit_patch"
     [
@@ -281,5 +337,9 @@ let () =
             test_patch_delete_via_empty_new_string;
           Alcotest.test_case "overwrite mode regression" `Quick
             test_overwrite_unchanged_by_patch_addition;
+          Alcotest.test_case "public Edit maps top-relative single repo path" `Quick
+            test_public_edit_maps_top_relative_single_repo_path;
+          Alcotest.test_case "public Write maps top-relative single repo path" `Quick
+            test_public_write_maps_top_relative_single_repo_path;
         ] );
     ]

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -435,6 +435,14 @@ let test_validate_code_shell_command_allows_sed_and_pwd () =
   check (result unit string) "pwd allowed" (Ok ())
     (Tool_code_write.validate_code_shell_command "pwd")
 
+let test_validate_code_shell_command_uses_dev_allowlist_ssot () =
+  check (result unit string) "echo probe allowed" (Ok ())
+    (Tool_code_write.validate_code_shell_command "echo Docker probe OK");
+  check (result unit string) "python3 dev probe allowed" (Ok ())
+    (Tool_code_write.validate_code_shell_command "python3 --version");
+  check (result unit string) "ruff dev probe allowed" (Ok ())
+    (Tool_code_write.validate_code_shell_command "ruff --version")
+
 let test_validate_code_shell_command_allows_quoted_regex_alternation () =
   check (result unit string) "quoted rg alternation allowed" (Ok ())
     (Tool_code_write.validate_code_shell_command
@@ -457,13 +465,13 @@ let test_validate_code_shell_command_allows_log_regression_shapes () =
        "find . -name \"cascade.toml\" -type f 2>/dev/null")
 
 let test_validate_code_shell_command_uses_code_shell_allowlist_hint () =
-  match Tool_code_write.validate_code_shell_command "python3 --version" with
+  match Tool_code_write.validate_code_shell_command "curl --version" with
   | Error reason ->
       check bool "uses caller-specific allowlist label" true
         (msg_contains ~needle:"Allowed commands for this tool" reason);
       check bool "names grep because code shell allows it" true
         (msg_contains ~needle:"grep" reason)
-  | Ok () -> fail "expected python3 to be rejected by masc_code_shell allowlist"
+  | Ok () -> fail "expected curl to be rejected by masc_code_shell allowlist"
 
 let test_validate_code_shell_command_rejects_semicolon () =
   match
@@ -1050,6 +1058,8 @@ let () =
         test_validate_code_shell_command_allows_grep;
       test_case "allows sed and pwd" `Quick
         test_validate_code_shell_command_allows_sed_and_pwd;
+      test_case "uses dev allowlist SSOT" `Quick
+        test_validate_code_shell_command_uses_dev_allowlist_ssot;
       test_case "allows quoted regex alternation" `Quick
         test_validate_code_shell_command_allows_quoted_regex_alternation;
       test_case "allows log-derived read command shapes" `Quick


### PR DESCRIPTION
## Summary
- align masc_code_shell allowlist with the keeper dev-shell SSOT plus code-shell extras
- keep the existing shape gates for chaining, command substitution, direct dune, and unsafe redirects
- add public Edit/Write regression coverage for top-relative single-repo paths through keeper_fs_edit
- export the new livelock repeat/threshold metric constants from Keeper_metrics so the latest main base compiles
- refresh the shell-quality leak doc with the latest 240h measurement and adjacent surface notes

## Verification
- opam exec -- ocamlformat --check lib/keeper/keeper_metrics.ml lib/keeper/keeper_metrics.mli lib/tool_code_write.ml lib/tool_code_write.mli test/test_tool_code_write_coverage.ml test/test_keeper_fs_edit_patch.ml
- git diff --check origin/main..HEAD
- env MASC_DUNE_THROTTLE=0 DUNE_LOCAL_JOBS=1 MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_tool_code_write_coverage.exe test/test_keeper_fs_edit_patch.exe
- ./_build/default/test/test_tool_code_write_coverage.exe (61 tests, run B6OJKCSK)
- ./_build/default/test/test_keeper_fs_edit_patch.exe (10 tests, run 4C80LHHK)