### PR TITLE
fix: export repeated livelock metrics

### DIFF
--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -227,6 +227,8 @@ val metric_keeper_turn_starts : string
 val metric_keeper_turn_reattempts : string
 val metric_keeper_turn_regressions : string
 val metric_keeper_turn_livelock_blocks : string
+val metric_keeper_turn_livelock_blocks_repeated : string
+val metric_keeper_turn_livelock_blocks_threshold_park : string
 val metric_keeper_turn_latency_bucket : string
 val metric_keeper_turn_latency_by_model_bucket : string
 val metric_keeper_provider_cooldown_skip : string


### PR DESCRIPTION
## Summary
- export `metric_keeper_turn_livelock_blocks_repeated`
- export `metric_keeper_turn_livelock_blocks_threshold_park`
- unblock the current main compile failure where `keeper_unified_turn.ml` references livelock metrics already defined in `keeper_metrics.ml`

## Context
- The original ok-envelope blocker in `tool_keeper_persona_audit.ml` has already landed on `main` through #16456.
- This PR was rebased onto current `origin/main` and now carries only the remaining build fix: the missing `keeper_metrics.mli` exports.

## Verification
- `opam exec -- ocamlformat --check lib/keeper/keeper_metrics.mli`
- `git diff --check origin/main...HEAD`
- `bash scripts/lint/no-inline-ok-envelope.sh`
- `bash scripts/lint/no-inline-error-envelope.sh`

## Notes
- Rebased onto current `origin/main` head `c20b5a559c`.
- Focused Dune build `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_keeper_turn_livelock_10121.exe` was attempted after a wrapper `dune clean`, but remained blocked behind another repo-local `dune-local` lock owned by a different worktree and was stopped without killing the other job.
