### PR TITLE
fix(cdal): surface incomplete proof store health

### DIFF
--- a/lib/cdal_runtime/contract_runner.ml
+++ b/lib/cdal_runtime/contract_runner.ml
@@ -126,7 +126,17 @@ let run
     let context = Agent.context agent in
     let net = Agent.net agent in
     let new_agent = Agent.create ~net ~config ~tools ~context ~options:new_opts () in
-    let response = Agent.run ~sw ?clock new_agent prompt in
+    let response =
+      try Agent.run ~sw ?clock new_agent prompt with
+      | Eio.Cancel.Cancelled _ as exn ->
+        (try ignore (Proof_capture.finalize capture_state ~result_status:Cancelled) with
+         | _ -> ());
+        raise exn
+      | exn ->
+        (try ignore (Proof_capture.finalize capture_state ~result_status:Errored) with
+         | _ -> ());
+        raise exn
+    in
     (* Sync execution state back to the original agent so that
        downstream checkpoint capture sees the post-run messages,
        turn_count, and usage — not the pre-run empty state. *)

--- a/lib/cdal_runtime_health.ml
+++ b/lib/cdal_runtime_health.ml
@@ -43,6 +43,68 @@ let age_seconds ~now = function
   | Some ts -> Some (max 0.0 (now -. ts))
 ;;
 
+let file_exists path =
+  try Sys.file_exists path with
+  | Sys_error _ -> false
+;;
+
+let stat_mtime path =
+  try Some (Unix.stat path).Unix.st_mtime with
+  | Unix.Unix_error _ | Sys_error _ -> None
+;;
+
+let max_float_opt a b =
+  match a, b with
+  | None, None -> None
+  | Some value, None | None, Some value -> Some value
+  | Some left, Some right -> Some (max left right)
+;;
+
+let max_child_mtime ?(limit = 32) dir =
+  if not (is_dir dir)
+  then None
+  else (
+    let entries =
+      try Sys.readdir dir with
+      | Sys_error _ -> [||]
+    in
+    let latest = ref None in
+    let scan_len = min limit (Array.length entries) in
+    for i = 0 to scan_len - 1 do
+      latest := max_float_opt !latest (stat_mtime (Filename.concat dir entries.(i)))
+    done;
+    !latest)
+;;
+
+let proof_run_dir config ~run_id = Filename.concat (Proof_store.proofs_dir config) run_id
+let proof_traces_dir config ~run_id = Filename.concat (proof_run_dir config ~run_id) "tool_traces"
+let proof_evidence_dir config ~run_id = Filename.concat (proof_run_dir config ~run_id) "evidence"
+let proof_contract_path config ~run_id = Filename.concat (proof_run_dir config ~run_id) "contract.json"
+
+let run_latest_mtime config ~run_id =
+  let run_dir = proof_run_dir config ~run_id in
+  let traces_dir = proof_traces_dir config ~run_id in
+  let evidence_dir = proof_evidence_dir config ~run_id in
+  [ stat_mtime run_dir
+  ; stat_mtime (Proof_store.manifest_path config ~run_id)
+  ; stat_mtime (proof_contract_path config ~run_id)
+  ; stat_mtime traces_dir
+  ; max_child_mtime traces_dir
+  ; stat_mtime evidence_dir
+  ; max_child_mtime evidence_dir
+  ]
+  |> List.fold_left max_float_opt None
+;;
+
+let take n xs =
+  let rec loop remaining acc = function
+    | _ when remaining <= 0 -> List.rev acc
+    | [] -> List.rev acc
+    | x :: rest -> loop (remaining - 1) (x :: acc) rest
+  in
+  loop n [] xs
+;;
+
 let proof_root_default () = Proof_store.default_config.root
 
 let proof_root_candidates configured_root =
@@ -59,12 +121,116 @@ let proof_root_candidates configured_root =
   |> List.sort_uniq String.compare
 ;;
 
-let proof_store_root_json ~now ~stale_age_seconds root =
-  let proofs_dir = Proof_store.proofs_dir { root } in
+let proof_completeness_json
+      ~now
+      ?(scan_limit = 200)
+      ?(stale_incomplete_grace_seconds = 300.0)
+      config
+  =
+  let proofs_dir = Proof_store.proofs_dir config in
+  if not (is_dir proofs_dir)
+  then
+    `Assoc
+      [ "scan_limit", `Int scan_limit
+      ; "run_dirs_scanned", `Int 0
+      ; "completed_run_dirs", `Int 0
+      ; "incomplete_run_dirs", `Int 0
+      ; "stale_incomplete_run_dirs", `Int 0
+      ; "missing_manifest_run_dirs", `Int 0
+      ; "missing_contract_run_dirs", `Int 0
+      ; "stale_incomplete_grace_seconds", `Float stale_incomplete_grace_seconds
+      ; "sample_stale_incomplete_run_ids", `List []
+      ]
+  else (
+    let run_ids =
+      try Sys.readdir proofs_dir |> Array.to_list with
+      | Sys_error _ -> []
+    in
+    let run_infos =
+      run_ids
+      |> List.filter (fun run_id -> is_dir (proof_run_dir config ~run_id))
+      |> List.filter_map (fun run_id ->
+        match run_latest_mtime config ~run_id with
+        | None -> None
+        | Some mtime -> Some (run_id, mtime))
+      |> List.sort (fun (_a_id, a_mtime) (_b_id, b_mtime) ->
+        Float.compare b_mtime a_mtime)
+      |> take scan_limit
+    in
+    let completed = ref 0 in
+    let incomplete = ref 0 in
+    let stale_incomplete = ref 0 in
+    let missing_manifest = ref 0 in
+    let missing_contract = ref 0 in
+    let stale_samples = ref [] in
+    List.iter
+      (fun (run_id, mtime) ->
+         let has_manifest = file_exists (Proof_store.manifest_path config ~run_id) in
+         let has_contract = file_exists (proof_contract_path config ~run_id) in
+         if has_manifest && has_contract
+         then incr completed
+         else (
+           incr incomplete;
+           if not has_manifest then incr missing_manifest;
+           if not has_contract then incr missing_contract;
+           let run_age_seconds = max 0.0 (now -. mtime) in
+           if run_age_seconds > stale_incomplete_grace_seconds
+           then (
+             incr stale_incomplete;
+             if List.length !stale_samples < 5 then stale_samples := run_id :: !stale_samples)))
+      run_infos;
+    `Assoc
+      [ "scan_limit", `Int scan_limit
+      ; "run_dirs_scanned", `Int (List.length run_infos)
+      ; "completed_run_dirs", `Int !completed
+      ; "incomplete_run_dirs", `Int !incomplete
+      ; "stale_incomplete_run_dirs", `Int !stale_incomplete
+      ; "missing_manifest_run_dirs", `Int !missing_manifest
+      ; "missing_contract_run_dirs", `Int !missing_contract
+      ; "stale_incomplete_grace_seconds", `Float stale_incomplete_grace_seconds
+      ; ( "sample_stale_incomplete_run_ids"
+        , `List (List.rev_map (fun run_id -> `String run_id) !stale_samples) )
+      ])
+;;
+
+let json_int_field key = function
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`Int value) -> Some value
+     | _ -> None)
+  | _ -> None
+;;
+
+let has_stale_incomplete_runs completeness =
+  match json_int_field "stale_incomplete_run_dirs" completeness with
+  | Some count -> count > 0
+  | None -> false
+;;
+
+let proof_store_root_json
+      ~now
+      ~stale_age_seconds
+      ?proof_scan_limit
+      ?stale_incomplete_run_seconds
+      root
+  =
+  let config : Proof_store.config = { root } in
+  let proofs_dir = Proof_store.proofs_dir config in
   let latest_mtime = stat_mtime_if_dir proofs_dir in
   let age_seconds = age_seconds ~now latest_mtime in
   let exists = is_dir proofs_dir in
-  let status = status_of_latest ~stale_age_seconds ~exists ~age_seconds in
+  let completeness =
+    proof_completeness_json
+      ~now
+      ?scan_limit:proof_scan_limit
+      ?stale_incomplete_grace_seconds:stale_incomplete_run_seconds
+      config
+  in
+  let status =
+    if has_stale_incomplete_runs completeness
+    then "stale_incomplete_runs"
+    else status_of_latest ~stale_age_seconds ~exists ~age_seconds
+  in
   `Assoc
     [ "root", `String root
     ; "proofs_dir", `String proofs_dir
@@ -73,6 +239,7 @@ let proof_store_root_json ~now ~stale_age_seconds root =
     ; "latest_activity_unix", float_opt_to_json latest_mtime
     ; "age_seconds", float_opt_to_json age_seconds
     ; "status", `String status
+    ; "completeness", completeness
     ]
 ;;
 
@@ -99,14 +266,19 @@ let task_scope_json ?base_dir ?(recent_limit = Env_config_runtime.Cdal.verdict_l
       then "missing_ledger"
       else if task_id_rows = 0
       then "missing_task_scope"
+      else if task_id_rows < recent_rows
+      then "partial_task_scope"
       else "present"
     in
+    let missing_task_scope_rows = recent_rows - task_id_rows in
     `Assoc
       [ "status", `String status
       ; "recent_limit", `Int recent_limit
       ; "recent_rows", `Int recent_rows
       ; "task_id_rows", `Int task_id_rows
-      ; "missing_task_scope", `Bool (recent_rows > 0 && task_id_rows = 0)
+      ; "missing_task_scope_rows", `Int missing_task_scope_rows
+      ; "missing_task_scope", `Bool (recent_rows > 0 && missing_task_scope_rows > 0)
+      ; "partial_task_scope", `Bool (task_id_rows > 0 && missing_task_scope_rows > 0)
       ]
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -115,7 +287,9 @@ let task_scope_json ?base_dir ?(recent_limit = Env_config_runtime.Cdal.verdict_l
       [ "recent_limit", `Int recent_limit
       ; "recent_rows", `Int 0
       ; "task_id_rows", `Int 0
+      ; "missing_task_scope_rows", `Int 0
       ; "missing_task_scope", `Bool false
+      ; "partial_task_scope", `Bool false
       ; "error", `String (Printexc.to_string exn)
       ]
 ;;
@@ -146,13 +320,16 @@ let json_string_field key = function
   | _ -> None
 ;;
 
-let writer_status ~ledger_status ~task_scope_status =
-  match ledger_status, task_scope_status with
-  | "missing", _ -> "missing"
-  | "dormant", _ -> "dormant"
-  | _, "missing_task_scope" -> "missing_task_scope"
-  | "active", "present" -> "active"
-  | _, "error" -> "error"
+let writer_status ~ledger_status ~task_scope_status ~proof_store_status =
+  match ledger_status, task_scope_status, proof_store_status with
+  | "missing", _, _ -> "missing"
+  | "dormant", _, _ -> "dormant"
+  | _, _, "missing" -> "proof_store_missing"
+  | _, _, "stale_incomplete_runs" -> "proof_store_incomplete"
+  | _, "missing_task_scope", _ -> "missing_task_scope"
+  | _, "partial_task_scope", _ -> "partial_task_scope"
+  | "active", "present", ("active" | "dormant") -> "active"
+  | _, "error", _ -> "error"
   | _ -> "unknown"
 ;;
 
@@ -178,22 +355,36 @@ let proof_path_drift configured_json alternate_json =
 
 let snapshot_json ?base_dir ?proof_root ?(now = Time_compat.now ())
     ?(stale_age_seconds = Cdal_verdict_gate.stale_age_seconds_default)
-    ?recent_limit () =
+    ?recent_limit ?proof_scan_limit ?stale_incomplete_run_seconds () =
   let ledger = ledger_json ?base_dir ~now ~stale_age_seconds () in
   let task_scope = task_scope_json ?base_dir ?recent_limit () in
   let configured_root = Option.value proof_root ~default:(proof_root_default ()) in
-  let configured_proof = proof_store_root_json ~now ~stale_age_seconds configured_root in
+  let configured_proof =
+    proof_store_root_json
+      ~now
+      ~stale_age_seconds
+      ?proof_scan_limit
+      ?stale_incomplete_run_seconds
+      configured_root
+  in
   let alternate_proofs =
     `List
       (List.map
-         (proof_store_root_json ~now ~stale_age_seconds)
+         (proof_store_root_json
+            ~now
+            ~stale_age_seconds
+            ?proof_scan_limit
+            ?stale_incomplete_run_seconds)
          (proof_root_candidates configured_root))
   in
   let ledger_status = Option.value ~default:"unknown" (json_string_field "status" ledger) in
   let task_scope_status =
     Option.value ~default:"unknown" (json_string_field "status" task_scope)
   in
-  let writer_status = writer_status ~ledger_status ~task_scope_status in
+  let proof_store_status =
+    Option.value ~default:"unknown" (json_string_field "status" configured_proof)
+  in
+  let writer_status = writer_status ~ledger_status ~task_scope_status ~proof_store_status in
   `Assoc
     [ "writer_status", `String writer_status
     ; "operator_action_required", `Bool (not (String.equal writer_status "active"))

--- a/lib/cdal_runtime_health.mli
+++ b/lib/cdal_runtime_health.mli
@@ -1,7 +1,8 @@
 (** CDAL runtime health projection.
 
     Surfaces whether the proof/verdict writer appears active, dormant,
-    missing, or still writing verdicts without task scope. *)
+    missing, writing verdicts without task scope, or leaving stale incomplete
+    proof bundles behind. *)
 
 val snapshot_json :
   ?base_dir:string ->
@@ -9,5 +10,7 @@ val snapshot_json :
   ?now:float ->
   ?stale_age_seconds:float ->
   ?recent_limit:int ->
+  ?proof_scan_limit:int ->
+  ?stale_incomplete_run_seconds:float ->
   unit ->
   Yojson.Safe.t

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -227,6 +227,8 @@ val metric_keeper_turn_starts : string
 val metric_keeper_turn_reattempts : string
 val metric_keeper_turn_regressions : string
 val metric_keeper_turn_livelock_blocks : string
+val metric_keeper_turn_livelock_blocks_repeated : string
+val metric_keeper_turn_livelock_blocks_threshold_park : string
 val metric_keeper_turn_latency_bucket : string
 val metric_keeper_turn_latency_by_model_bucket : string
 val metric_keeper_provider_cooldown_skip : string

--- a/lib/prometheus_builtin_metrics_part1.ml
+++ b/lib/prometheus_builtin_metrics_part1.ml
@@ -180,6 +180,16 @@ let register
     "Total keeper turn dispatches blocked by the stuck-turn livelock guard (labels: \
      keeper, reason=attempts_exhausted|stuck_age_exceeded)"
     `Counter;
+  add
+    Keeper_metrics.metric_keeper_turn_livelock_blocks_repeated
+    "Total repeated keeper turn livelock blocks demoted to DEBUG (labels: keeper, \
+     gate_kind)"
+    `Counter;
+  add
+    Keeper_metrics.metric_keeper_turn_livelock_blocks_threshold_park
+    "Total keeper turn livelock block streams that crossed the threshold-park boundary \
+     (labels: keeper, gate_kind)"
+    `Counter;
   (* #9943: per-keeper turn latency bucket distribution.  Each
      completed turn increments exactly one bucket.  Bucket vocabulary
      [under_60s | 60-300s | 300-600s | 600-1200s | over_1200s]. *)

--- a/test/test_cdal_runtime_health_15748.ml
+++ b/test/test_cdal_runtime_health_15748.ml
@@ -63,11 +63,40 @@ let write_ledger_row ~base_dir ?mtime row =
   path
 ;;
 
+let write_file path content =
+  let oc = open_out_gen [ Open_wronly; Open_creat; Open_text; Open_trunc ] 0o644 path in
+  output_string oc content;
+  close_out oc
+;;
+
 let make_proof_root ?mtime root =
   let proofs_dir = Filename.concat root "proofs" in
   mkdir_p proofs_dir;
   Option.iter (fun ts -> Unix.utimes proofs_dir ts ts) mtime;
   proofs_dir
+;;
+
+let make_proof_run ?mtime ?(manifest = false) ?(contract = false) root run_id =
+  let proofs_dir = make_proof_root root in
+  let run_dir = Filename.concat proofs_dir run_id in
+  let traces_dir = Filename.concat run_dir "tool_traces" in
+  let evidence_dir = Filename.concat run_dir "evidence" in
+  mkdir_p traces_dir;
+  mkdir_p evidence_dir;
+  if manifest then write_file (Filename.concat run_dir "manifest.json") "{}\n";
+  if contract then write_file (Filename.concat run_dir "contract.json") "{}\n";
+  Option.iter
+    (fun ts ->
+       List.iter
+         (fun path -> if Sys.file_exists path then Unix.utimes path ts ts)
+         [ run_dir
+         ; traces_dir
+         ; evidence_dir
+         ; Filename.concat run_dir "manifest.json"
+         ; Filename.concat run_dir "contract.json"
+         ];
+       Unix.utimes proofs_dir ts ts)
+    mtime
 ;;
 
 let member_string key json =
@@ -81,6 +110,13 @@ let member_string key json =
 ;;
 
 let nested key json = Yojson.Safe.Util.member key json
+
+let member_int key json =
+  match Yojson.Safe.Util.member key json with
+  | `Int value -> value
+  | other ->
+    Alcotest.failf "expected int field %s, got %s" key (Yojson.Safe.to_string other)
+;;
 
 let list_field key json =
   match Yojson.Safe.Util.member key json with
@@ -138,6 +174,40 @@ let test_missing_task_scope_status () =
     (member_string "status" (nested "task_scope" json))
 ;;
 
+let test_partial_task_scope_status () =
+  with_temp_dir @@ fun dir ->
+  let base_dir = Filename.concat dir "cdal_verdicts" in
+  let proof_root = Filename.concat dir ".oas" in
+  ignore
+    (write_ledger_row
+       ~base_dir
+       (`Assoc [ "_task_id", `String "task-15748"; "run_id", `String "run-task" ]));
+  ignore (write_ledger_row ~base_dir (`Assoc [ "run_id", `String "run-no-task" ]));
+  ignore (make_proof_root proof_root);
+  let json =
+    H.snapshot_json
+      ~base_dir
+      ~proof_root
+      ~now:(Time_compat.now ())
+      ~stale_age_seconds:60.0
+      ~recent_limit:20
+      ()
+  in
+  Alcotest.(check string)
+    "writer_status"
+    "partial_task_scope"
+    (member_string "writer_status" json);
+  let task_scope = nested "task_scope" json in
+  Alcotest.(check string)
+    "task scope status"
+    "partial_task_scope"
+    (member_string "status" task_scope);
+  Alcotest.(check int)
+    "missing task rows"
+    1
+    (member_int "missing_task_scope_rows" task_scope)
+;;
+
 let test_active_writer_status () =
   with_temp_dir @@ fun dir ->
   let base_dir = Filename.concat dir "cdal_verdicts" in
@@ -161,6 +231,83 @@ let test_active_writer_status () =
     "task scope status"
     "present"
     (member_string "status" (nested "task_scope" json))
+;;
+
+let test_stale_incomplete_proof_store_status () =
+  with_temp_dir @@ fun dir ->
+  let base_dir = Filename.concat dir "cdal_verdicts" in
+  let proof_root = Filename.concat dir ".oas" in
+  let now = Time_compat.now () in
+  ignore
+    (write_ledger_row
+       ~base_dir
+       ~mtime:now
+       (`Assoc [ "_task_id", `String "task-15748"; "run_id", `String "run-task" ]));
+  make_proof_run
+    ~mtime:(now -. 100.0)
+    ~manifest:true
+    ~contract:true
+    proof_root
+    "cdal-complete";
+  make_proof_run ~mtime:(now -. 1000.0) proof_root "cdal-stale-incomplete";
+  let json =
+    H.snapshot_json
+      ~base_dir
+      ~proof_root
+      ~now
+      ~stale_age_seconds:600.0
+      ~recent_limit:20
+      ~proof_scan_limit:20
+      ~stale_incomplete_run_seconds:300.0
+      ()
+  in
+  Alcotest.(check string)
+    "writer_status"
+    "proof_store_incomplete"
+    (member_string "writer_status" json);
+  let proof_store = nested "proof_store" json in
+  Alcotest.(check string)
+    "proof store status"
+    "stale_incomplete_runs"
+    (member_string "status" proof_store);
+  Alcotest.(check int)
+    "stale incomplete run count"
+    1
+    (member_int "stale_incomplete_run_dirs" (nested "completeness" proof_store))
+;;
+
+let test_recent_incomplete_proof_store_is_in_flight () =
+  with_temp_dir @@ fun dir ->
+  let base_dir = Filename.concat dir "cdal_verdicts" in
+  let proof_root = Filename.concat dir ".oas" in
+  let now = Time_compat.now () in
+  ignore
+    (write_ledger_row
+       ~base_dir
+       ~mtime:now
+       (`Assoc [ "_task_id", `String "task-15748"; "run_id", `String "run-task" ]));
+  make_proof_run ~mtime:(now -. 10.0) proof_root "cdal-recent-incomplete";
+  let json =
+    H.snapshot_json
+      ~base_dir
+      ~proof_root
+      ~now
+      ~stale_age_seconds:600.0
+      ~recent_limit:20
+      ~proof_scan_limit:20
+      ~stale_incomplete_run_seconds:300.0
+      ()
+  in
+  Alcotest.(check string) "writer_status" "active" (member_string "writer_status" json);
+  let proof_store = nested "proof_store" json in
+  Alcotest.(check string)
+    "proof store status"
+    "active"
+    (member_string "status" proof_store);
+  Alcotest.(check int)
+    "stale incomplete run count"
+    0
+    (member_int "stale_incomplete_run_dirs" (nested "completeness" proof_store))
 ;;
 
 let test_dormant_writer_status () =
@@ -250,7 +397,16 @@ let () =
     [ ( "writer_status"
       , [ Alcotest.test_case "missing" `Quick test_missing_writer_status
         ; Alcotest.test_case "missing task scope" `Quick test_missing_task_scope_status
+        ; Alcotest.test_case "partial task scope" `Quick test_partial_task_scope_status
         ; Alcotest.test_case "active" `Quick test_active_writer_status
+        ; Alcotest.test_case
+            "stale incomplete proof store"
+            `Quick
+            test_stale_incomplete_proof_store_status
+        ; Alcotest.test_case
+            "recent incomplete proof store is in flight"
+            `Quick
+            test_recent_incomplete_proof_store_is_in_flight
         ; Alcotest.test_case "dormant" `Quick test_dormant_writer_status
         ; Alcotest.test_case
             "alternate proof stores ignore home .oas"


### PR DESCRIPTION
## Summary
- report stale incomplete CDAL proof bundles in /health instead of treating proof-store mtime as active
- distinguish partial task-scoped verdict coverage from fully present task scope
- finalize CDAL proof bundles as errored/cancelled if Agent.run raises before normal finalize
- export/register the new livelock escalation metrics currently referenced on main so bin/main_eio builds

## Verification
- ocamlformat --check lib/cdal_runtime_health.ml lib/cdal_runtime_health.mli lib/cdal_runtime/contract_runner.ml test/test_cdal_runtime_health_15748.ml lib/keeper/keeper_metrics.mli lib/prometheus_builtin_metrics_part1.ml
- env MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 MASC_SKIP_DEPS_CHECK=1 MASC_SKIP_OCAML_VERSION_CHECK=1 scripts/dune-local.sh build ./test/test_cdal_runtime_health_15748.exe ./bin/main_eio.exe
- ./_build/default/test/test_cdal_runtime_health_15748.exe