### PR TITLE
fix(jsonl): log atomic writer cleanup failures

### DIFF
--- a/lib/jsonl_atomic/dune
+++ b/lib/jsonl_atomic/dune
@@ -5,4 +5,4 @@
  (modules jsonl_atomic)
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags (:standard -w +4))
- (libraries eio eio.unix unix yojson))
+ (libraries eio eio.unix unix yojson masc_log))

--- a/lib/jsonl_atomic/jsonl_atomic.ml
+++ b/lib/jsonl_atomic/jsonl_atomic.ml
@@ -56,6 +56,9 @@ let get_or_create_mutex key =
         Hashtbl.add mutex_registry key m;
         m)
 
+let warn_io_failure ~op ~path exn =
+  Log.warn ~ctx:"jsonl_atomic" "%s failed for %s: %s" op path (Printexc.to_string exn)
+
 let open_writer ~sw ~fs ~path =
   (* Create parent directories *within the provided fs root* — using
      [Eio.Path.mkdirs] on the fs-scoped path matches how [open_out]
@@ -65,7 +68,9 @@ let open_writer ~sw ~fs ~path =
   let dir = Filename.dirname path in
   if dir <> "" && dir <> "." && dir <> "/" then begin
     let eio_dir = Eio.Path.(fs / dir) in
-    try Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 eio_dir with _ -> ()
+    try Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 eio_dir with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> warn_io_failure ~op:"mkdirs" ~path:dir exn
   end;
   let eio_path = Eio.Path.(fs / path) in
   let sink =
@@ -99,5 +104,7 @@ let close t =
     t.closed <- true;
     (* Eio.Resource.close releases the fd. Idempotent on the resource
        side too, but we guard with [t.closed] for cheap short-circuit. *)
-    try Eio.Resource.close t.sink with _ -> ()
+    try Eio.Resource.close t.sink with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> warn_io_failure ~op:"close" ~path:t.path exn
   end


### PR DESCRIPTION
## Summary
- replace silent mkdir/close exception swallowing in Jsonl_atomic with cancel-aware logging
- keep cancellation propagation intact and reduce production anti-fake scan violations from 16 to 14

## Verification
- ocamlformat --check lib/jsonl_atomic/jsonl_atomic.ml
- git diff --check
- bash scripts/ci/check-silent-failure-patterns.sh
- bash scripts/anti-fake-audit.sh --production-scan | rg 'jsonl_atomic|Production Scan Summary|violation'  # no jsonl_atomic hits; remaining repo debt is 14 violations

Focused Dune build attempted:
- scripts/dune-local.sh build lib/jsonl_atomic/jsonl_atomic.cmx test/test_jsonl_atomic.exe
- blocked by shared /tmp/me-dune-local.lock held by another repo-level @check build; CI should provide build proof.