### PR TITLE
feat(dashboard): inline reasons in mission/health/sessions "unknown" sentinels

### DIFF
--- a/lib/dashboard/dashboard_execution_sessions.ml
+++ b/lib/dashboard/dashboard_execution_sessions.ml
@@ -32,7 +32,8 @@ let session_status_string session_json =
       | Some value -> value
       | None ->
           trim_to_option (string_field "status" session_json)
-          |> Option.value ~default:"unknown")
+          |> Option.value
+               ~default:"<missing status field in summary / meta / session>")
 
 let session_recent_events session_json =
   list_field "recent_events" session_json

--- a/lib/dashboard/dashboard_goals_types_health.ml
+++ b/lib/dashboard/dashboard_goals_types_health.ml
@@ -158,9 +158,23 @@ let goal_fsm_to_json ~effective_policy (goal : Goal_store.goal)
     ]
 
 let display_disposition_of_receipt_json receipt =
+  (* Previously this defaulted to the literal "unknown", which then hit
+     the [| "unknown" -> "Alert"/"unmapped_cascade_state"] arm below.
+     That conflated two distinct producer-side failure modes:
+     (1) missing [operator_disposition] field — the receipt was emitted
+         without the disposition at all (producer bug);
+     (2) [operator_disposition = "unknown"] — the producer explicitly
+         declared the state unmapped at the cascade layer.
+
+     Using a bracketed sentinel as the default lets the match below
+     fall through to the [_ -> "Alert"/"unmapped_operator_disposition"]
+     catch-all, which is the more accurate classification for case (1).
+     Both cases still surface as "Alert" severity (no operator-visible
+     regression in alerting), but the reason label now distinguishes
+     them so the operator can chase the right producer fix. *)
   let operator_disposition =
     receipt |> member "operator_disposition" |> to_string_option
-    |> Option.value ~default:"unknown"
+    |> Option.value ~default:"<missing operator_disposition field>"
   in
   let operator_disposition_reason =
     receipt |> member "operator_disposition_reason" |> to_string_option

--- a/lib/dashboard/dashboard_mission.ml
+++ b/lib/dashboard/dashboard_mission.ml
@@ -71,7 +71,10 @@ let session_status_string session_json =
   | None -> (
       match trim_to_option (string_field "status" meta) with
       | Some value -> value
-      | None -> trim_to_option (string_field "status" session_json) |> Option.value ~default:"unknown")
+      | None ->
+          trim_to_option (string_field "status" session_json)
+          |> Option.value
+               ~default:"<missing status field in summary / meta / session>")
 
 let session_recent_events session_json =
   list_field "recent_events" session_json
@@ -126,7 +129,7 @@ let creator_looks_system created_by =
 let session_origin_kind session_meta =
   let created_by =
     trim_to_option (string_field "created_by" session_meta)
-    |> Option.value ~default:"unknown"
+    |> Option.value ~default:"<missing created_by field>"
   in
   trim_to_option (string_field "origin_kind" session_meta)
   |> Option.value


### PR DESCRIPTION
## 목표

Iter#7/#9/#10 dashboard sentinel-clarity 시리즈의 잔여 3 모듈 4 사이트. 모두 `Option.value ~default:"unknown"`로 missing-field와 legitimate producer value를 collapse.

| 사이트 | 표시 |
|---|---|
| `dashboard_mission.session_status_string` L74 | session row `status=unknown` |
| `dashboard_mission.session_origin_kind` L129 | session origin `created_by=unknown` |
| `dashboard_goals_types_health.display_disposition_of_receipt_json` L163 | receipt "Alert/unmapped_cascade_state" |
| `dashboard_execution_sessions.session_status_string` L35 | session row `status=unknown` |

`★ 워크어라운드 거부 기준 self-check ─────────────────`
silent collision 제거. 새 catch-all/string 분류기 도입 없음. 통과.
`─────────────────────────────────────────────────`

## 변경 파일

| 파일 | 변경 |
|---|---|
| `lib/dashboard/dashboard_mission.ml` | 2 사이트 → `<missing status field ...>` / `<missing created_by field>` |
| `lib/dashboard/dashboard_goals_types_health.ml` | 1 사이트 → `<missing operator_disposition field>` (behavior shift, 아래) |
| `lib/dashboard/dashboard_execution_sessions.ml` | 1 사이트 → 동일 status pattern |

총 3 files, +22 / -4.

## ⚠️ Behavior shift: `display_disposition_of_receipt_json`

`operator_disposition` match는 specific arm `"unknown" -> "Alert"/"unmapped_cascade_state"` + catch-all `_ -> "Alert"/"unmapped_operator_disposition"`. 이전엔 missing field가 `"unknown"`으로 collapse → *unmapped_cascade_state* arm. 새 bracketed default는 catch-all로 떨어져 *unmapped_operator_disposition* arm.

| Case | Before | After |
|---|---|---|
| Producer가 진짜 `"unknown"` emit | Alert/unmapped_cascade_state | Alert/unmapped_cascade_state (변화 0) |
| `operator_disposition` field 자체 missing | Alert/unmapped_cascade_state (오분류) | Alert/unmapped_operator_disposition (정확) |

Severity는 둘 다 "Alert" 유지 → 알람 동작 변화 0. 단지 reason label로 올바른 producer-side fix 진단 가능.

## 로컬 검증

- `ocamlformat --check` PASS (3/3)
- `dune build @check` — main에 **별도 regression** (`Keeper_metrics.metric_keeper_turn_livelock_blocks_repeated` unbound, PR #16420 follow-up 미해결). 우리 변경과 무관, 4 single-line default swap + signature 동일 + Iter#7/#9/#10 sibling pattern 동일.

## 미검증

- [ ] Full `@check` (main #16420 follow-up fix 후 재verify)

## RFC

`bash ~/me/scripts/pr-rfc-check.sh` PASS — dashboard 영역, boundary subsystem 아님.

## 시리즈

같은 /loop의 dashboard sentinel-clarity 시리즈 마무리: Iter#7 #16383 (runtime-mismatch), Iter#9 #16404 (tool_quality), Iter#10 #16418 (goals timeline), **Iter#11 본 PR (mission/health/sessions)**.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>