### PR TITLE
feat(coord): name missing field(s) in lock_info_of_json error

### DIFF
--- a/lib/coord/coord_eio.ml
+++ b/lib/coord/coord_eio.ml
@@ -479,15 +479,35 @@ let lock_info_of_json json =
       | `String s -> Some s
       | _ -> None
     in
-    match
-      (parse_string (member "resource" json),
-       parse_string (member "owner" json),
-       parse_float (member "acquired_at" json),
-       parse_float (member "expires_at" json))
-    with
+    let resource_opt = parse_string (member "resource" json) in
+    let owner_opt = parse_string (member "owner" json) in
+    let acquired_at_opt = parse_float (member "acquired_at" json) in
+    let expires_at_opt = parse_float (member "expires_at" json) in
+    match resource_opt, owner_opt, acquired_at_opt, expires_at_opt with
     | Some resource, Some owner, Some acquired_at, Some expires_at ->
         Ok { resource; owner; acquired_at; expires_at }
-    | _ -> Error "Invalid lock metadata"
+    | _ ->
+        (* Previously collapsed to the bare "Invalid lock metadata".
+           Operators reading a recover/repair log line cannot tell
+           which of the four fields the lock JSON was missing; that
+           detail is what the producer-side fix needs.  Enumerate
+           which field(s) failed to parse so the message carries the
+           same information the parser already has in scope. *)
+        let missing =
+          List.filter_map (fun (name, opt) ->
+            if Option.is_none opt then Some name else None)
+            [ ("resource (string)", Option.map (fun _ -> ()) resource_opt);
+              ("owner (string)", Option.map (fun _ -> ()) owner_opt);
+              ("acquired_at (number)",
+               Option.map (fun _ -> ()) acquired_at_opt);
+              ("expires_at (number)",
+               Option.map (fun _ -> ()) expires_at_opt);
+            ]
+        in
+        Error
+          (Printf.sprintf
+             "Invalid lock metadata: missing or wrong-type field(s) [%s]"
+             (String.concat ", " missing))
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | e -> Error (Printexc.to_string e)


### PR DESCRIPTION
## 목표

`Coord_eio.lock_info_of_json`은 4-field lock metadata JSON (`resource`, `owner`, `acquired_at`, `expires_at`)을 parse. 어느 field라도 missing/wrong-type이면 모든 case가 `"Invalid lock metadata"` 한 줄로 collapse — operator는 recover/repair log에서 *어느 field*가 문제인지 모름. parser는 *이미 per-field option*을 scope에 갖고 있음.

`★ 워크어라운드 거부 기준 self-check ─────────────────`
silent collapse 제거 + 컴파일러가 이미 갖고 있는 정보를 inline. 새 catch-all/string 분류기 도입 없음. behaviour 변화 0 (signature/Ok 동일, Error payload만 풍부). 통과.
`─────────────────────────────────────────────────`

## 변경 파일

| 파일 | 변경 |
|---|---|
| `lib/coord/coord_eio.ml` | `lock_info_of_json` catch-all → 4 field별 named option 캡처 + missing list 명시 |

1 file, +27/-7. Iter#6 verification parser PR #16375과 같은 패턴. Helper inline 유지 (PR #16375 stacking 회피, 독립 머지 가능).

## Operator 시야 (Before / After)

**Before** — repair log에 lock JSON에 `expires_at` missing:
```
[ERROR] coord_eio: Invalid lock metadata
```
→ 어느 field가 문제? 4 후보 모두 점검 필요.

**After**:
```
[ERROR] coord_eio: Invalid lock metadata: missing or wrong-type field(s) [expires_at (number)]
```
→ 즉시 producer-side 식별.

## 로컬 검증

- `ocamlformat --check` PASS (1/1)
- 기존 test (`test_types_utils_coverage.ml`): Ok roundtrip + Ok int-as-float coercion만 assert. error string 영향 없음.

## RFC

`bash ~/me/scripts/pr-rfc-check.sh` PASS — coord 영역, boundary subsystem 아님.

## 시리즈

같은 /loop의 Iter#6 PR #16375 (verification JSON parsers), Iter#7-#11 dashboard sentinel 시리즈와 같은 *sentinel-only → named-field* 패턴.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>