### PR TITLE
feat(keeper): report received JSON kind in manifest parser errors

### DIFF
--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -249,6 +249,18 @@ let to_json manifest =
       ("links", links_to_json manifest.links);
     ]
 
+let json_kind_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "intlit"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+
 let field key fields =
   match List.assoc_opt key fields with
   | Some value -> Ok value
@@ -257,26 +269,38 @@ let field key fields =
 let required_string key fields =
   match field key fields with
   | Ok (`String value) -> Ok value
-  | Ok _ -> Error (Printf.sprintf "field %S must be a string" key)
+  | Ok other ->
+      Error
+        (Printf.sprintf "field %S must be a string (received %s)" key
+           (json_kind_name other))
   | Error _ as err -> err
 
 let required_int key fields =
   match field key fields with
   | Ok (`Int value) -> Ok value
-  | Ok _ -> Error (Printf.sprintf "field %S must be an int" key)
+  | Ok other ->
+      Error
+        (Printf.sprintf "field %S must be an int (received %s)" key
+           (json_kind_name other))
   | Error _ as err -> err
 
 let optional_string key fields =
   match List.assoc_opt key fields with
   | None | Some `Null -> Ok None
   | Some (`String value) -> Ok (Some value)
-  | Some _ -> Error (Printf.sprintf "field %S must be a string or null" key)
+  | Some other ->
+      Error
+        (Printf.sprintf "field %S must be a string or null (received %s)" key
+           (json_kind_name other))
 
 let optional_int key fields =
   match List.assoc_opt key fields with
   | None | Some `Null -> Ok None
   | Some (`Int value) -> Ok (Some value)
-  | Some _ -> Error (Printf.sprintf "field %S must be an int or null" key)
+  | Some other ->
+      Error
+        (Printf.sprintf "field %S must be an int or null (received %s)" key
+           (json_kind_name other))
 
 let links_of_json = function
   | `Assoc fields -> (
@@ -290,7 +314,10 @@ let links_of_json = function
               | Error _ as err -> err
               | Ok tool_call_log_path ->
                   Ok { receipt_path; checkpoint_path; tool_call_log_path })))
-  | _ -> Error "field \"links\" must be an object"
+  | other ->
+      Error
+        (Printf.sprintf "field \"links\" must be an object (received %s)"
+           (json_kind_name other))
 
 let reject_retired_manifest_fields fields =
   match List.find_opt (fun (key, _) -> redacts_provider_model_key key) fields with
@@ -357,7 +384,10 @@ let of_json = function
                 decision;
                 links;
               })
-  | _ -> Error "manifest row must be a JSON object"
+  | other ->
+      Error
+        (Printf.sprintf "manifest row must be a JSON object (received %s)"
+           (json_kind_name other))
 
 let dated_jsonl_today_path base_dir =
   let open Unix in


### PR DESCRIPTION
## Why

`lib/keeper/keeper_runtime_manifest.ml`의 parser는 type mismatch 시 *기대한 type*만 알려주고 *실제로 받은 type*은 드롭. operator가 잘못된 manifest를 만나면 무엇이 들어왔는지 모름.

OAS log reduction goal과 같은 정신: error를 *구체적으로 actionable*하게 만들기.

## What

6 사이트 enrich, 모두 `(received <kind>)` 추가:

| Line | Before | After |
|---|---|---|
| `required_string` Ok-mismatch | `field "X" must be a string` | `field "X" must be a string (received int)` |
| `required_int` Ok-mismatch | `field "X" must be an int` | `field "X" must be an int (received string)` |
| `optional_string` Some-mismatch | `field "X" must be a string or null` | `field "X" must be a string or null (received bool)` |
| `optional_int` Some-mismatch | `field "X" must be an int or null` | `field "X" must be an int or null (received array)` |
| `links_of_json` catch-all | `field "links" must be an object` | `field "links" must be an object (received array)` |
| `of_json` catch-all | `manifest row must be a JSON object` | `manifest row must be a JSON object (received array)` |

Inline `json_kind_name` helper — closed total function over 10 `Yojson.Safe.t` variants (null/bool/int/intlit/float/string/object/array/tuple/variant). **No catch-all** — exhaustive match는 새 variant 추가 시 컴파일러가 잡음.

## Workaround Rejection Bar self-check

- [x] Counter-as-fix 아님 — 새 metric 0
- [x] String/substring classifier 아님 — closed sum type
- [x] N-of-M 아님 — 모든 6 사이트 같은 PR
- [x] Cap/cooldown/dedup/repair 아님 — pure error string enrich
- [x] test backdoor 아님

## Stacking 회피

PR #16375 (`Json_util.kind_name`/`excerpt`) 미머지 상태 — 그 helper에 의존하면 stack 위험. 본 PR은 inline 11-line helper로 *독립 머지 가능*. #16375 머지 후 별도 dedup PR이 가능 (`Json_util.kind_name`으로 inline 제거).

## RFC Check

PASS — credential/identity/operator/sandbox/dashboard-credential/.claude-hooks/workflow* 미접촉.

## Verification

- [x] `ocamlformat --check lib/keeper/keeper_runtime_manifest.ml` PASS
- [x] 기존 parse 테스트 검사 = `Error msg` opaque match (test/test_keeper_runtime_manifest.ml: L402/462/487/509/527/532/550/565/586/647/672/1535/1555/2117/2149/2551 모두 wording 무관)
- [ ] CI 모니터링

## Related

- Iter#6 PR #16375 — Json_util.kind_name/excerpt 도입 (parser dedup baseline)
- Iter#12 PR #16444 — coord_eio.lock_info_of_json missing-field enrich (자매)

🤖 /loop cron `253cc0f6` Iter#13

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>