### PR TITLE
fix(keeper): align mark_dead prometheus to_phase casing with phase_to_string SSOT

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -485,9 +485,22 @@ let () =
 ;;
 
 let mark_dead ~base_path name ~at =
+  (* Same metric is also incremented at line ~1907 via
+     `phase_to_string tr.new_phase`, which emits lowercase wire format
+     (`dead`, `running`, `handing_off`, ...). The historical hardcoded
+     `"Dead"` here split the time series in two — `to_phase="Dead"`
+     from this site vs `to_phase="dead"` from the transition path —
+     so any Prometheus consumer aggregating on `to_phase` undercounted
+     deaths. Route through `phase_to_string` so both emit sites share
+     the SSOT casing. `from_phase` stays as the literal sentinel
+     `"direct"` to flag transition-bypass writes. *)
   Prometheus.inc_counter
     Keeper_metrics.metric_keeper_lifecycle_transitions
-    ~labels:[ "keeper", name; "from_phase", "direct"; "to_phase", "Dead" ]
+    ~labels:
+      [ "keeper", name
+      ; "from_phase", "direct"
+      ; "to_phase", Keeper_state_machine.phase_to_string Dead
+      ]
     ();
   Log.Keeper.error "registry: marking keeper dead name=%s at=%.0f" name at;
   update_entry ~base_path name (fun entry ->


### PR DESCRIPTION
## 증상

같은 Prometheus metric `masc_keeper_lifecycle_transitions_total`이 *두 가지 casing*으로 emit:

| Emit site | `to_phase` value | Source |
|---|---|---|
| `keeper_registry.ml:490` (`mark_dead`) | `"Dead"` (PascalCase) | hardcoded literal |
| `keeper_registry.ml:1907` (transition path) | `"dead"` (lowercase) | `phase_to_string tr.new_phase` |

Prometheus가 두 값을 별개 time series로 처리 → `to_phase`로 aggregate하는 consumer가 keeper death를 *분리 집계*. 사용자가 보는 dashboard에서 keeper lifecycle 통계 일관성이 깨진 상태.

## 원인

`mark_dead`는 transition 우회 (직접 mark) 경로라 `tr.new_phase`가 없어 emit 시점에 string을 직접 작성. PascalCase string literal이 *backend의 또 다른 PascalCase emit 함수* (`phase_to_mermaid_id`, line 1349-1361)와 우연히 형태가 같아 검토에서 놓침. wire format SSOT는 `phase_to_string` (line 21-35) lowercase.

## Fix

`Keeper_state_machine.phase_to_string Dead`로 라우팅하여 두 emit site가 같은 SSOT 함수를 사용하도록 변경. `from_phase`는 `"direct"` 리터럴 유지 (transition-bypass sentinel로 의미 있음). 1-line behavior change.

## 검증

- `dune build --root . lib/keeper` exit=0 (keeper sublib isolated 빌드 성공)
- 외부 consumer 검색 (`rg 'masc_keeper_lifecycle_transitions' --glob '!*.ml' --glob '!*.mli'`) → 결과 0건, alerting rule / Grafana panel에서 기존 `to_phase="Dead"` 쿼리 의존성 없음. production risk 낮음.

## 알려진 main 빌드 상태

`lib/keeper/keeper_unified_turn.ml:513` `Keeper_metrics.metric_keeper_turn_livelock_blocks_repeated` unbound — main HEAD (8f9c6934e5)의 #16420 후속 latent regression. **본 PR과 무관**. 본 PR의 변경 파일 `keeper_registry.ml`은 isolated build 정상.

## Anti-pattern category

`~/me/instructions/software-development.md` §AI 코드 생성 안티패턴 #1 (Scattered Hardcoded Defaults) + Magic Number 금지 (같은 의미의 리터럴이 2곳 이상 등장하면 named SSOT로 교체). root-fix, N-of-M 아님.

## RFC-WAIVED

단순 magic-string SSOT routing, 의미 변경 없음. credential/identity/operator/sandbox/dashboard credential/hooks/workflow 영역 어디에도 해당하지 않음.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>