### PR TITLE
feat(keeper): report received JSON kind in persona authoring errors

### DIFF
--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -29,6 +29,19 @@ let assoc_without key fields =
 
 let assoc_set key value fields = (key, value) :: assoc_without key fields
 
+let json_kind_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "intlit"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+;;
+
 let assoc_get key = function
   | `Assoc fields -> List.assoc_opt key fields
   | _ -> None
@@ -558,7 +571,11 @@ let normalize_keeper_json ~handle keeper_json =
                  in
                  `Assoc (List.rev fields))
               cascade_name_result)))
-  | _ -> Error "profile.keeper must be an object"
+  | other ->
+    Error
+      (Printf.sprintf
+         "profile.keeper must be an object (received %s)"
+         (json_kind_name other))
 ;;
 
 let normalize_profile ~handle profile =
@@ -586,7 +603,11 @@ let normalize_profile ~handle profile =
            |> assoc_set "keeper" keeper
          in
          Ok (`Assoc (List.rev top_fields)))
-    | _ -> Error "profile must be a JSON object")
+    | other ->
+      Error
+        (Printf.sprintf
+           "profile must be a JSON object (received %s)"
+           (json_kind_name other)))
 ;;
 
 let ensure_personas_root root =


### PR DESCRIPTION
## Why

`lib/keeper/keeper_persona_authoring.ml`의 두 catch-all 사이트가 shape mismatch 시 *기대*만 알리고 *받은 것*은 누락 — operator가 profile.json 편집 중 에러를 만나면 무엇이 잘못됐는지 추측해야 함.

OAS log reduction goal과 같은 정신: error를 *구체적으로 actionable*하게.

## What

2 사이트 enrich, 같은 `(received <kind>)` 패턴:

| Site | Before | After |
|---|---|---|
| `normalize_keeper_json` L561 | `profile.keeper must be an object` | `profile.keeper must be an object (received array)` |
| `normalize_profile` L589 | `profile must be a JSON object` | `profile must be a JSON object (received string)` |

Module-level `json_kind_name` helper — closed total function over 10 `Yojson.Safe.t` variants (null/bool/int/intlit/float/string/object/array/tuple/variant). **No catch-all** — 새 variant 추가 시 컴파일러가 잡음.

## Iter#13 자매 site

PR #16447과 동일 패턴 (parser → received-kind enrich). Iter#13가 `keeper_runtime_manifest.ml`이었고 본 PR이 `keeper_persona_authoring.ml`. 둘 다 helper inline — PR #16375 (`Json_util.kind_name`/`excerpt`) 머지 후 단일 dedup PR로 통합 예정 (3 inline copy → 1 shared helper).

## Workaround Rejection Bar self-check

- [x] Counter-as-fix 아님 — 새 metric 0
- [x] String/substring classifier 아님 — closed sum type
- [x] N-of-M 아님 — 두 사이트 같은 PR
- [x] Cap/cooldown/dedup/repair 아님 — pure error string enrich
- [x] Test backdoor 아님

## RFC Check

PASS — credential/identity/operator/sandbox/dashboard-credential/.claude-hooks/workflow* 미접촉.

## Verification

- [x] `ocamlformat --check lib/keeper/keeper_persona_authoring.ml` PASS (auto-formatted)
- [x] `rg 'profile.keeper must be|profile must be a JSON' test/` = 0 match — 영향 받는 테스트 없음
- [ ] CI 모니터링

## Related

- Iter#13 PR #16447 — `keeper_runtime_manifest.ml` 6 사이트 자매
- Iter#6 PR #16375 — `Json_util.kind_name`/`excerpt` baseline (미머지)

🤖 /loop cron `253cc0f6` Iter#14

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>