### PR TITLE
refactor: split keeper world observation inputs

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -22,6 +22,7 @@
  keeper_continuity_summary_source
  keeper_world_observation_board_signal
  keeper_world_observation_continuity
+ keeper_world_observation_inputs
  keeper_world_observation_message_scope
  keeper_profile_load_failure_site
  keeper_turn_cleanup_failure_site

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -7,7 +7,6 @@
 
 open Keeper_types
 open Keeper_memory
-open Keeper_exec_context
 
 type pending_board_event =
   { post_id : string
@@ -141,139 +140,17 @@ type board_signal_match =
   }
 
 module Message_scope = Keeper_world_observation_message_scope
+module Inputs = Keeper_world_observation_inputs
 
 let scope_message_feed_enabled = Message_scope.scope_message_feed_enabled
 let self_identity_tokens = Message_scope.self_identity_tokens
 let is_self_author = Message_scope.is_self_author
 let collect_message_scope = Message_scope.collect_message_scope
 let apply_message_cursor_updates = Message_scope.apply_message_cursor_updates
-
-let backlog_updated_since_last_scheduled_autonomous
-      ~(meta : keeper_meta)
-      ~(backlog : Masc_domain.backlog)
-  : bool
-  =
-  let last_ts = meta.runtime.proactive_rt.last_ts in
-  if last_ts <= 0.0
-  then backlog.tasks <> []
-  else (
-    match Coord_resilience.Time.parse_iso8601_opt backlog.last_updated with
-    | Some updated_at -> updated_at > last_ts
-    | None -> false)
-;;
-
-let claim_goal_scope_filter
-      ?agent_tool_names
-      ~(config : Coord.config)
-      ~(meta : keeper_meta)
-      ()
-  =
-  let scope =
-    Keeper_runtime_contract.resolve_observation_claim_goal_scope
-      ?agent_tool_names
-      ~config
-      ~meta
-      ()
-  in
-  scope.task_filter
-;;
-
-(** Read room backlog counts. *)
-let read_backlog_counts ~allowed_tool_names ~(config : Coord.config) ~(meta : keeper_meta)
-  : int * int * int * int * bool
-  =
-  try
-    let backlog = Coord.read_backlog config in
-    let unclaimed_tasks =
-      List.filter
-        (fun (t : Masc_domain.task) -> t.task_status = Masc_domain.Todo)
-        backlog.tasks
-    in
-    let unclaimed = List.length unclaimed_tasks in
-    let claim_scope_filter =
-      claim_goal_scope_filter ?agent_tool_names:allowed_tool_names ~config ~meta ()
-    in
-    (* Build the allowed-set once and reuse across all candidates in
-       the [unclaimed_tasks] filter below — see PR #14826 for the
-       O(R+A) rationale. *)
-    let required_tools_allowed =
-      Coord_task_schedule.make_required_tools_predicate
-        ?agent_tool_names:allowed_tool_names
-        ()
-    in
-    let claimable =
-      List.length
-        (List.filter
-           (fun task ->
-              Coord_task_schedule.task_is_claim_pool_candidate task
-              && claim_scope_filter task
-              && required_tools_allowed (Coord_task_schedule.task_required_tools task))
-           unclaimed_tasks)
-    in
-    let failed =
-      (* "Failed" here means still-auditable active work. Terminal Cancelled
-         tasks are historical evidence, not a reason to wake every keeper. *)
-      Coord.audit_orphan_tasks config
-      |> List.map fst
-      |> List.filter claim_scope_filter
-      |> List.length
-    in
-    let pending_verification =
-      List.length
-        (List.filter
-           (fun (t : Masc_domain.task) ->
-              match t.task_status with
-              | Masc_domain.AwaitingVerification _ -> true
-              | Masc_domain.Todo
-              | Masc_domain.Claimed _
-              | Masc_domain.InProgress _
-              | Masc_domain.Done _
-              | Masc_domain.Cancelled _ -> false)
-           backlog.tasks)
-    in
-    let backlog_updated_since_last_scheduled_autonomous =
-      backlog_updated_since_last_scheduled_autonomous ~meta ~backlog
-    in
-    ( unclaimed
-    , claimable
-    , failed
-    , pending_verification
-    , backlog_updated_since_last_scheduled_autonomous )
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | ex ->
-    Prometheus.inc_counter
-      Keeper_metrics.metric_keeper_observation_query_failures
-      ~labels:
-        [ ("operation", Keeper_observation_query_operation.(to_label Read_backlog_counts)) ]
-      ();
-    Log.Keeper.warn "read_backlog_counts failed: %s" (Printexc.to_string ex);
-    0, 0, 0, 0, false
-;;
-
-(** Count active agents in room. *)
-let count_active_agents ~(config : Coord.config) : int =
-  try List.length (Coord.get_agents_raw config) with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | ex ->
-    Prometheus.inc_counter
-      Keeper_metrics.metric_keeper_observation_query_failures
-      ~labels:
-        [ ("operation", Keeper_observation_query_operation.(to_label Count_active_agents)) ]
-      ();
-    Log.Keeper.warn "count_active_agents failed: %s" (Printexc.to_string ex);
-    0
-;;
-
-(** Compute idle seconds from keeper timestamps. *)
-let compute_idle_seconds ~(meta : keeper_meta) : int =
-  let now_ts = Time_compat.now () in
-  let created_ts =
-    Coord_resilience.Time.parse_iso8601_opt meta.created_at |> Option.value ~default:0.0
-  in
-  let activity_ts = List.fold_left max created_ts [ meta.runtime.proactive_rt.last_ts ] in
-  if activity_ts <= 0.0 then 0 else int_of_float (max 0.0 (now_ts -. activity_ts))
-;;
+let read_backlog_counts = Inputs.read_backlog_counts
+let count_active_agents = Inputs.count_active_agents
+let compute_idle_seconds = Inputs.compute_idle_seconds
+let read_context_ratio = Inputs.read_context_ratio
 
 let board_post_id_string (post : Board.post) = Board.Post_id.to_string post.id
 
@@ -338,34 +215,6 @@ let board_signal_match
     if matched_targets <> []
     then { explicit_mention = true; matched_targets; score = 100 }
     else { explicit_mention = false; matched_targets = []; score = 0 })
-;;
-
-(** Read context ratio from checkpoint if available. *)
-let read_context_ratio ~(config : Coord.config) ~(meta : keeper_meta) : float =
-  try
-    let cascade_models = Keeper_model_labels.configured_model_labels_of_meta meta in
-    let primary_max_context =
-      let resolution =
-        Keeper_exec_context.resolve_max_context_resolution
-          ~requested_override:meta.max_context_override
-          cascade_models
-      in
-      resolution.effective_budget
-    in
-    let base_dir = session_base_dir config in
-    let _session, ctx_opt =
-      load_context_from_checkpoint
-        ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
-        ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-        ~primary_model_max_tokens:primary_max_context
-        ~base_dir
-    in
-    match ctx_opt with
-    | Some c -> Keeper_exec_context.context_ratio c
-    | None -> 0.0
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | _ -> 0.0
 ;;
 
 module Continuity = Keeper_world_observation_continuity

--- a/lib/keeper/keeper_world_observation_inputs.ml
+++ b/lib/keeper/keeper_world_observation_inputs.ml
@@ -1,0 +1,155 @@
+(** See [keeper_world_observation_inputs.mli] for the contract. *)
+
+open Keeper_types
+open Keeper_exec_context
+
+let backlog_updated_since_last_scheduled_autonomous
+      ~(meta : keeper_meta)
+      ~(backlog : Masc_domain.backlog)
+  : bool
+  =
+  let last_ts = meta.runtime.proactive_rt.last_ts in
+  if last_ts <= 0.0
+  then backlog.tasks <> []
+  else (
+    match Coord_resilience.Time.parse_iso8601_opt backlog.last_updated with
+    | Some updated_at -> updated_at > last_ts
+    | None -> false)
+;;
+
+let claim_goal_scope_filter ?agent_tool_names ~(config : Coord.config)
+    ~(meta : keeper_meta) () =
+  let scope =
+    Keeper_runtime_contract.resolve_observation_claim_goal_scope
+      ?agent_tool_names
+      ~config
+      ~meta
+      ()
+  in
+  scope.task_filter
+;;
+
+(** Read room backlog counts. *)
+let read_backlog_counts ~allowed_tool_names ~(config : Coord.config) ~(meta : keeper_meta)
+  : int * int * int * int * bool
+  =
+  try
+    let backlog = Coord.read_backlog config in
+    let unclaimed_tasks =
+      List.filter
+        (fun (t : Masc_domain.task) -> t.task_status = Masc_domain.Todo)
+        backlog.tasks
+    in
+    let unclaimed = List.length unclaimed_tasks in
+    let claim_scope_filter =
+      claim_goal_scope_filter ?agent_tool_names:allowed_tool_names ~config ~meta ()
+    in
+    (* Build the allowed-set once and reuse across all candidates in
+       the [unclaimed_tasks] filter below -- see PR #14826 for the
+       O(R+A) rationale. *)
+    let required_tools_allowed =
+      Coord_task_schedule.make_required_tools_predicate
+        ?agent_tool_names:allowed_tool_names
+        ()
+    in
+    let claimable =
+      List.length
+        (List.filter
+           (fun task ->
+              Coord_task_schedule.task_is_claim_pool_candidate task
+              && claim_scope_filter task
+              && required_tools_allowed (Coord_task_schedule.task_required_tools task))
+           unclaimed_tasks)
+    in
+    let failed =
+      (* "Failed" here means still-auditable active work. Terminal Cancelled
+         tasks are historical evidence, not a reason to wake every keeper. *)
+      Coord.audit_orphan_tasks config
+      |> List.map fst
+      |> List.filter claim_scope_filter
+      |> List.length
+    in
+    let pending_verification =
+      List.length
+        (List.filter
+           (fun (t : Masc_domain.task) ->
+              match t.task_status with
+              | Masc_domain.AwaitingVerification _ -> true
+              | Masc_domain.Todo
+              | Masc_domain.Claimed _
+              | Masc_domain.InProgress _
+              | Masc_domain.Done _
+              | Masc_domain.Cancelled _ -> false)
+           backlog.tasks)
+    in
+    let backlog_updated_since_last_scheduled_autonomous =
+      backlog_updated_since_last_scheduled_autonomous ~meta ~backlog
+    in
+    ( unclaimed
+    , claimable
+    , failed
+    , pending_verification
+    , backlog_updated_since_last_scheduled_autonomous )
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | ex ->
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_observation_query_failures
+      ~labels:
+        [ ("operation", Keeper_observation_query_operation.(to_label Read_backlog_counts)) ]
+      ();
+    Log.Keeper.warn "read_backlog_counts failed: %s" (Printexc.to_string ex);
+    0, 0, 0, 0, false
+;;
+
+(** Count active agents in room. *)
+let count_active_agents ~(config : Coord.config) : int =
+  try List.length (Coord.get_agents_raw config) with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | ex ->
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_observation_query_failures
+      ~labels:
+        [ ("operation", Keeper_observation_query_operation.(to_label Count_active_agents)) ]
+      ();
+    Log.Keeper.warn "count_active_agents failed: %s" (Printexc.to_string ex);
+    0
+;;
+
+(** Compute idle seconds from keeper timestamps. *)
+let compute_idle_seconds ~(meta : keeper_meta) : int =
+  let now_ts = Time_compat.now () in
+  let created_ts =
+    Coord_resilience.Time.parse_iso8601_opt meta.created_at |> Option.value ~default:0.0
+  in
+  let activity_ts = List.fold_left max created_ts [ meta.runtime.proactive_rt.last_ts ] in
+  if activity_ts <= 0.0 then 0 else int_of_float (max 0.0 (now_ts -. activity_ts))
+;;
+
+(** Read context ratio from checkpoint if available. *)
+let read_context_ratio ~(config : Coord.config) ~(meta : keeper_meta) : float =
+  try
+    let cascade_models = Keeper_model_labels.configured_model_labels_of_meta meta in
+    let primary_max_context =
+      let resolution =
+        Keeper_exec_context.resolve_max_context_resolution
+          ~requested_override:meta.max_context_override
+          cascade_models
+      in
+      resolution.effective_budget
+    in
+    let base_dir = session_base_dir config in
+    let _session, ctx_opt =
+      load_context_from_checkpoint
+        ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
+        ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+        ~primary_model_max_tokens:primary_max_context
+        ~base_dir
+    in
+    match ctx_opt with
+    | Some c -> Keeper_exec_context.context_ratio c
+    | None -> 0.0
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | _ -> 0.0
+;;

--- a/lib/keeper/keeper_world_observation_inputs.mli
+++ b/lib/keeper/keeper_world_observation_inputs.mli
@@ -1,0 +1,18 @@
+(** Input query helpers for keeper world observation. *)
+
+open Keeper_types
+
+val backlog_updated_since_last_scheduled_autonomous
+  :  meta:keeper_meta
+  -> backlog:Masc_domain.backlog
+  -> bool
+
+val read_backlog_counts
+  :  allowed_tool_names:string list option
+  -> config:Coord.config
+  -> meta:keeper_meta
+  -> int * int * int * int * bool
+
+val count_active_agents : config:Coord.config -> int
+val compute_idle_seconds : meta:keeper_meta -> int
+val read_context_ratio : config:Coord.config -> meta:keeper_meta -> float


### PR DESCRIPTION
## Summary
- Extract keeper world backlog/input/context query helpers into keeper_world_observation_inputs.
- Keep keeper_world_observation callsites stable via module forwarding.
- Reduce keeper_world_observation.ml from 1287 to 1136 lines in this stack.

## Validation
- ocamlformat --check lib/keeper/keeper_world_observation.ml lib/keeper/keeper_world_observation_inputs.ml lib/keeper/keeper_world_observation_inputs.mli
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- bash scripts/lint/godfile-size-regression.sh
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_unified.exe test/test_keeper_memory.exe