### PR TITLE
fix(lint): replace inline ok-envelope in tool_keeper_persona_audit

### DIFF
--- a/lib/tool_keeper_persona_audit.ml
+++ b/lib/tool_keeper_persona_audit.ml
@@ -422,9 +422,8 @@ let handle ctx args : tool_result =
                  (Config_dir_resolver.personas_dirs ())) );
         ]
     in
-    let base_response =
+    let base_fields =
       [
-        ("status", `String "ok");
         ("tool", `String "masc_keeper_persona_audit");
         ("roots", roots);
         ("summary", summary audited_items);
@@ -432,11 +431,11 @@ let handle ctx args : tool_result =
         ("items", `List returned_items);
       ]
     in
-    let response_with_repair =
+    let response_fields =
       match repair_result with
       | Some r ->
           ("goal_repair", Keeper_goal_repair.repair_result_to_yojson r)
-          :: base_response
-      | None -> base_response
+          :: base_fields
+      | None -> base_fields
     in
-    (true, Yojson.Safe.pretty_to_string (`Assoc response_with_repair))
+    (true, ok_response response_fields)


### PR DESCRIPTION
## Summary
- `lib/tool_keeper_persona_audit.ml:427` had `("status", \`String "ok")` inline, triggering T27/T28/T29 lint on **every** open PR
- Replaced with `Tool_args.ok_response` SSOT helper (file already `open Tool_args`)
- Pre-existing violation on `origin/main`, not introduced by any open PR

## Why
All 20+ open PRs fail the `No inline ok-envelope literals (T27/T28/T29)` check because this single violation exists on main. Merging this unblocks all of them.

## Test plan
- [x] `bash scripts/lint/no-inline-ok-envelope.sh` → OK
- [x] `dune build --root .` → OK
- [ ] CI green on this PR

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>