### PR TITLE
fix(keeper): export livelock guard metrics

### DIFF
--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -227,6 +227,8 @@ val metric_keeper_turn_starts : string
 val metric_keeper_turn_reattempts : string
 val metric_keeper_turn_regressions : string
 val metric_keeper_turn_livelock_blocks : string
+val metric_keeper_turn_livelock_blocks_repeated : string
+val metric_keeper_turn_livelock_blocks_threshold_park : string
 val metric_keeper_turn_latency_bucket : string
 val metric_keeper_turn_latency_by_model_bucket : string
 val metric_keeper_provider_cooldown_skip : string


### PR DESCRIPTION
## Summary

- Export the repeated livelock block metric from `Keeper_metrics.mli`.
- Export the threshold-park livelock block metric from `Keeper_metrics.mli`.

## Root Cause

`keeper_metrics.ml` defined the new livelock guard metric names and `keeper_unified_turn.ml` referenced them, but the interface file only exposed the older aggregate `metric_keeper_turn_livelock_blocks` value. Current `main` therefore fails to rebuild `bin/main_eio.exe` from a stale executable.

Closes #16454.

## Validation

```bash
scripts/dune-local.sh build bin/main_eio.exe
```
