### PR TITLE
feat(types): report received JSON kind in newtype-ID parse errors

### DIFF
--- a/lib/types/ids.ml
+++ b/lib/types/ids.ml
@@ -1,5 +1,17 @@
 (** MASC MCP Types - Newtypes (Prevent string mixups) *)
 
+let json_kind_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "intlit"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+
 (** Agent identifier - prevents mixing with task_id, file_path, etc. *)
 module Agent_id : sig
   type t
@@ -22,7 +34,10 @@ end = struct
   let to_yojson t = `String t
   let of_yojson = function
     | `String s -> Ok s
-    | _ -> Error "Expected string for Agent_id"
+    | other ->
+        Error
+          (Printf.sprintf "Expected string for Agent_id (received %s)"
+             (json_kind_name other))
 end
 
 (** Task identifier - prevents mixing with agent_id, etc. *)
@@ -52,7 +67,10 @@ end = struct
   let to_yojson t = `String t
   let of_yojson = function
     | `String s -> Ok s
-    | _ -> Error "Expected string for Task_id"
+    | other ->
+        Error
+          (Printf.sprintf "Expected string for Task_id (received %s)"
+             (json_kind_name other))
 end
 
 (** Thread identifier - conversation thread ID *)
@@ -82,7 +100,10 @@ end = struct
   let to_yojson t = `String t
   let of_yojson = function
     | `String s -> Ok s
-    | _ -> Error "Expected string for Thread_id"
+    | other ->
+        Error
+          (Printf.sprintf "Expected string for Thread_id (received %s)"
+             (json_kind_name other))
 end
 
 (** Turn identifier - individual turn within a thread *)
@@ -106,7 +127,10 @@ end = struct
   let to_yojson t = `String t
   let of_yojson = function
     | `String s -> Ok s
-    | _ -> Error "Expected string for Turn_id"
+    | other ->
+        Error
+          (Printf.sprintf "Expected string for Turn_id (received %s)"
+             (json_kind_name other))
 end
 
 (** Keeper identifier - deterministic UUIDv5 from namespace + name + path *)
@@ -143,7 +167,10 @@ end = struct
   let to_yojson t = `String t
   let of_yojson = function
     | `String s -> Ok s
-    | _ -> Error "Expected string for Keeper_id"
+    | other ->
+        Error
+          (Printf.sprintf "Expected string for Keeper_id (received %s)"
+             (json_kind_name other))
   module Keeper_name = struct
     type t = string
     let is_valid s =
@@ -200,7 +227,10 @@ end = struct
   let to_yojson t = `String t
   let of_yojson = function
     | `String s -> Ok s
-    | _ -> Error "Expected string for Credential_id"
+    | other ->
+        Error
+          (Printf.sprintf "Expected string for Credential_id (received %s)"
+             (json_kind_name other))
 end
 
 (** Relay GraphQL-style global ID: base64("type:uuid") *)


### PR DESCRIPTION
## Why

`lib/types/ids.ml`의 6 newtype-ID 모듈 (Agent_id, Task_id, Thread_id, Turn_id, Keeper_id, Credential_id)이 동일 catch-all 패턴으로 received-kind 정보를 드롭. malformed snapshot/replay 디버깅 시 operator는 무엇이 들어왔는지 추측해야 함.

## What

6 사이트 enrich:

| Line | ID | Before | After |
|---|---|---|---|
| 25→37 | Agent_id | `Expected string for Agent_id` | `... (received <kind>)` |
| 55→67 | Task_id | `Expected string for Task_id` | `... (received <kind>)` |
| 85→97 | Thread_id | `Expected string for Thread_id` | `... (received <kind>)` |
| 109→121 | Turn_id | `Expected string for Turn_id` | `... (received <kind>)` |
| 146→158 | Keeper_id | `Expected string for Keeper_id` | `... (received <kind>)` |
| 203→215 | Credential_id | `Expected string for Credential_id` | `... (received <kind>)` |

File-private `json_kind_name` — closed total function over 10 `Yojson.Safe.t` variants (no catch-all). Helper는 file top-level (sealed module signature 안에서 호출 가능).

## Cohort closure

6 ID 전부 같은 PR에서 root-fix — **N-of-M 잔존 없음**. AI 코드 생성 안티패턴 #1 (하드코딩 산포)의 closure example.

## Iter#13/#14 자매

PR #16447 (`keeper_runtime_manifest`) + PR #16453 (`keeper_persona_authoring`)과 동일 inline `json_kind_name` form. PR #16375 (`Json_util.kind_name`) 머지 후 4 inline copy → 1 shared helper로 dedup 예정.

## Workaround Rejection Bar self-check

- [x] Counter-as-fix 아님 — 새 metric 0
- [x] String/substring classifier 아님 — closed sum type
- [x] N-of-M 아님 — 6/6 사이트 같은 PR (cohort closure)
- [x] Cap/cooldown/dedup/repair 아님 — pure error string enrich
- [x] Test backdoor 아님

## RFC Check

PASS — `lib/types/ids.ml`은 newtype 래퍼 (string-mixup 방지). credential storage logic이 아니므로 RFC subsystem 목록 (credential_*, repo_manager, operator_control*, keeper_sandbox*, dashboard credential, hooks, workflow*) 미접촉.

## Verification

- [x] `ocamlformat --check lib/types/ids.ml` PASS (auto-formatted)
- [x] `rg 'Expected string for (Agent|Task|Thread|Turn|Keeper|Credential)' test/` = 0 match
- [ ] CI 모니터링

## Related

- Iter#13 PR #16447 — `keeper_runtime_manifest` 6 사이트
- Iter#14 PR #16453 — `keeper_persona_authoring` 2 사이트
- Iter#6 PR #16375 — `Json_util.kind_name`/`excerpt` baseline (미머지)

🤖 /loop cron \`253cc0f6\` Iter#15

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>