### PR TITLE
fix(dashboard): align PipelineStage type and STAGES list with RFC-0046 SSOT

### DIFF
--- a/dashboard/src/components/agent-monitor/runtime-strip.test.ts
+++ b/dashboard/src/components/agent-monitor/runtime-strip.test.ts
@@ -45,7 +45,7 @@ describe('AgentRuntimeStrip', () => {
 
   it('renders pipeline stage badge', () => {
     mockFindKeeper.mockReturnValue({
-      pipeline_stage: 'thinking',
+      pipeline_stage: 'compacting',
       context_ratio: null,
       generation: null,
     })
@@ -53,7 +53,8 @@ describe('AgentRuntimeStrip', () => {
     mockKeeperActivityDisplay.mockReturnValue({ ageSeconds: null, label: '' })
     const container = document.createElement('div')
     render(h(AgentRuntimeStrip, { name: 'Alpha' }), container)
-    expect(container.textContent).toContain('thinking')
+    // STAGES short label for `compacting` is `compact`.
+    expect(container.textContent).toContain('compact')
   })
 
   it('renders context ratio bar when present', () => {

--- a/dashboard/src/components/keeper-pipeline-stage.test.ts
+++ b/dashboard/src/components/keeper-pipeline-stage.test.ts
@@ -6,11 +6,11 @@ import { PipelineStageBadge } from './keeper-pipeline-stage'
 describe('PipelineStageBadge', () => {
   it('renders label for known stage', () => {
     const container = document.createElement('div')
-    render(h(PipelineStageBadge, { stage: 'thinking' }), container)
-    expect(container.textContent).toContain('think')
+    render(h(PipelineStageBadge, { stage: 'compacting' }), container)
+    expect(container.textContent).toContain('compact')
     const badge = container.querySelector('.pipeline-stage-badge')
     expect(badge).not.toBeNull()
-    expect(badge!.classList.contains('stage-thinking')).toBe(true)
+    expect(badge!.classList.contains('stage-compacting')).toBe(true)
   })
 
   it('renders unknown for null stage', () => {

--- a/dashboard/src/components/keeper-pipeline-stage.ts
+++ b/dashboard/src/components/keeper-pipeline-stage.ts
@@ -5,13 +5,26 @@
 import { html } from 'htm/preact'
 import type { PipelineStage } from '../types'
 
+// 10 values emitted by `Keeper_exec_status.pipeline_stage_of_phase`
+// (lib/keeper/keeper_exec_status.ml:537) post-RFC-0046 (#14707). The
+// legacy 6-entry list had `thinking` / `tool_use` /
+// `scheduled_autonomous` which the backend never emits as a
+// pipeline_stage value (they live in trajectory content_type / turn
+// channel respectively), and was missing `failing` / `overflowed` /
+// `draining` / `paused` / `crashed` / `restarting` / `offline` — so
+// 7 real backend values fell through to the raw-string fallback at
+// line 33. Labels are short forms suitable for the roster badge.
 const STAGES: { key: PipelineStage; label: string }[] = [
   { key: 'idle', label: 'idle' },
-  { key: 'thinking', label: 'think' },
-  { key: 'tool_use', label: 'tool' },
   { key: 'compacting', label: 'compact' },
   { key: 'handoff', label: 'handoff' },
-  { key: 'scheduled_autonomous', label: 'auto' },
+  { key: 'offline', label: 'offline' },
+  { key: 'failing', label: 'fail' },
+  { key: 'overflowed', label: 'overflow' },
+  { key: 'draining', label: 'drain' },
+  { key: 'paused', label: 'pause' },
+  { key: 'crashed', label: 'crash' },
+  { key: 'restarting', label: 'restart' },
 ]
 
 /**

--- a/dashboard/src/components/keeper-reactivity-monitor.test.ts
+++ b/dashboard/src/components/keeper-reactivity-monitor.test.ts
@@ -288,7 +288,7 @@ describe('isKeeperPaused', () => {
   })
 
   it('returns false when paused is false and phase is Running', () => {
-    expect(isKeeperPaused(keeper({ paused: false, phase: 'Running', pipeline_stage: 'thinking' }))).toBe(false)
+    expect(isKeeperPaused(keeper({ paused: false, phase: 'Running', pipeline_stage: 'idle' }))).toBe(false)
   })
 
   it('returns false when paused is undefined (unset)', () => {

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -684,15 +684,22 @@ export interface KeeperStatusDetail {
   loadedAt: string
 }
 
+// Backend SSOT: `Keeper_exec_status.pipeline_stage_of_phase`
+// (lib/keeper/keeper_exec_status.ml:537) deterministic mapping from
+// the 13-state KeeperPhase, post-RFC-0046 (#14707). Emits 10 distinct
+// values; `unknown` is a dashboard-side sentinel for missing data
+// (`asString(row.pipeline_stage) ?? 'unknown'`). Removed legacy
+// `thinking` / `tool_use` (= trajectory content_type, never
+// pipeline_stage) and `scheduled_autonomous` (= turn channel, never
+// pipeline_stage). Added `overflowed` which the backend emits but
+// the type previously rejected.
 export type PipelineStage =
   | 'idle'
-  | 'thinking'
-  | 'tool_use'
   | 'compacting'
   | 'handoff'
-  | 'scheduled_autonomous'
   | 'offline'
   | 'failing'
+  | 'overflowed'
   | 'draining'
   | 'paused'
   | 'crashed'


### PR DESCRIPTION
## 증상

dashboard `PipelineStage` union type과 \`STAGES\` array가 RFC-0046 (#14707) 이후 backend SSOT와 drift 상태.

| 위치 | Drift 종류 |
|---|---|
| \`types/core.ts:687\` | False members 3개 (\`thinking\`, \`tool_use\`, \`scheduled_autonomous\`) + missing \`overflowed\` |
| \`components/keeper-pipeline-stage.ts:8\` STAGES | 3 dead entries + 7 missing entries |
| 3개 테스트 | mock↔mock self-validation으로 \`pipeline_stage: 'thinking'\` fixture |

## SSOT 비교

Backend \`Keeper_exec_status.pipeline_stage_of_phase\` (lib/keeper/keeper_exec_status.ml:537) 10 emit:

| KeeperPhase | pipeline_stage |
|---|---|
| Offline / Stopped / Dead / Zombie | \`offline\` |
| Running | \`idle\` |
| Failing | \`failing\` |
| Overflowed | \`overflowed\` |
| Compacting | \`compacting\` |
| HandingOff | \`handoff\` |
| Draining | \`draining\` |
| Paused | \`paused\` |
| Crashed | \`crashed\` |
| Restarting | \`restarting\` |

False members 출처:
- \`thinking\` / \`tool_use\`: trajectory content_type (\`lib/trajectory/trajectory.ml:185\`) 또는 cascade event kind (\`cascade_event_bridge.ml:138\`). pipeline_stage 값이 아님.
- \`scheduled_autonomous\`: turn channel (\`dashboard_http_keeper_detail.ml:146\`). pipeline_stage 값이 아님.

\`as PipelineStage\` cast (keeper-store-normalize.ts:531, live-store.ts:178)가 type narrow를 silence하여 backend가 emit하는 "overflowed"를 runtime에서 받지만 \`STAGES.find\`가 매칭 못 해 raw 값 그대로 표시되던 상태.

## Fix

1. \`PipelineStage\` type: 3 false members 제거, \`overflowed\` 추가. \`unknown\`은 frontend sentinel로 유지.
2. \`STAGES\` array: backend 10 emit value 모두 매핑, short label 부여 (\`failing → fail\`, \`overflowed → overflow\`, etc.).
3. 3개 test fixture: \`'thinking'\` → \`'idle'\` 또는 \`'compacting'\` (legitimate value)로 갱신.

## 검증

- \`pnpm typecheck\` exit=0 (silent cast 제거 후 type narrow 통과)
- 40/40 affected tests pass (keeper-pipeline-stage, keeper-reactivity-monitor, runtime-strip)
- production producer가 dead value를 set하는 site 0건 (\`rg "pipeline_stage[: =]+ ['\"](thinking|tool_use|scheduled_autonomous)['\"]" dashboard/src/\` excluding test fixtures)

## 알려진 main 상태

main HEAD에 \`keeper_unified_turn.ml:513\` livelock metric unbound regression이 잔존 (#16420 후속). 본 PR과 무관 — dashboard side만 수정.

## RFC-WAIVED

RFC-0046 (#14707)이 이미 backend SSOT를 정립. 본 PR은 dashboard mirror 정렬만. credential/identity/operator/sandbox 영역에 해당하지 않음.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>