### PR TITLE
fix(task): typed dedup for repeated Invalid state transition errors

### DIFF
--- a/lib/task_transition_state/dune
+++ b/lib/task_transition_state/dune
@@ -1,0 +1,6 @@
+(include_subdirs no)
+(library
+ (name task_transition_state)
+ (public_name masc_mcp.task_transition_state)
+ (modules task_transition_state)
+ (flags (:standard -w +4)))

--- a/lib/task_transition_state/task_transition_state.ml
+++ b/lib/task_transition_state/task_transition_state.ml
@@ -1,0 +1,340 @@
+(* Typed escalation state for repeated [Invalid task state] transition
+   errors emitted by [Tool_task.run_task_transition].
+
+   See [task_transition_state.mli] for the contract, background,
+   workaround posture, and threading guarantees.
+
+   WORKAROUND-CARRYOVER: this module is a log-surface dedupe layer, not
+   a structural fix for the upstream invalid-transition retry pattern.
+   Root fix: client-side gating using cached [task_status] +
+   [valid_next_actions] before dispatching the transition. Deferred to
+   its own RFC. *)
+
+type status_kind =
+  | Todo_kind
+  | Claimed_kind
+  | InProgress_kind
+  | AwaitingVerification_kind
+  | Done_kind
+  | Cancelled_kind
+
+type transition_action =
+  | Claim
+  | Start
+  | Done_action
+  | Cancel
+  | Release
+  | Submit_for_verification
+  | Approve_verification
+  | Reject_verification
+  | Submit_pr_evidence
+
+type family =
+  | Invalid_transition of
+      { from_status : status_kind
+      ; action : transition_action
+      }
+  | Awaiting_verification_done
+  | Self_approval_not_allowed
+  | Self_rejection_not_allowed
+  | Already_done
+  | Active_task_limit_exceeded
+  | Submit_verification_missing_evidence
+  | Claim_oscillation_blocked
+  | Other_invalid_state
+
+type threshold_silence_payload =
+  { count : int
+  ; silence_threshold : int
+  }
+
+type record_outcome =
+  [ `First
+  | `Repeated of int
+  | `Threshold_silence of threshold_silence_payload
+  ]
+
+(* ── Stable string labels ─────────────────────────────────────────── *)
+
+let status_kind_to_string = function
+  | Todo_kind -> "todo"
+  | Claimed_kind -> "claimed"
+  | InProgress_kind -> "in_progress"
+  | AwaitingVerification_kind -> "awaiting_verification"
+  | Done_kind -> "done"
+  | Cancelled_kind -> "cancelled"
+
+let transition_action_to_string = function
+  | Claim -> "claim"
+  | Start -> "start"
+  | Done_action -> "done"
+  | Cancel -> "cancel"
+  | Release -> "release"
+  | Submit_for_verification -> "submit_for_verification"
+  | Approve_verification -> "approve_verification"
+  | Reject_verification -> "reject_verification"
+  | Submit_pr_evidence -> "submit_pr_evidence"
+
+let family_to_string = function
+  | Invalid_transition { from_status; action } ->
+    Printf.sprintf
+      "invalid_transition:%s->%s"
+      (status_kind_to_string from_status)
+      (transition_action_to_string action)
+  | Awaiting_verification_done -> "awaiting_verification_done"
+  | Self_approval_not_allowed -> "self_approval_not_allowed"
+  | Self_rejection_not_allowed -> "self_rejection_not_allowed"
+  | Already_done -> "already_done"
+  | Active_task_limit_exceeded -> "active_task_limit_exceeded"
+  | Submit_verification_missing_evidence ->
+    "submit_verification_missing_evidence"
+  | Claim_oscillation_blocked -> "claim_oscillation_blocked"
+  | Other_invalid_state -> "other_invalid_state"
+
+(* ── Exhaustive enumeration helpers ───────────────────────────────── *)
+
+let all_status_kinds : status_kind list =
+  [ Todo_kind
+  ; Claimed_kind
+  ; InProgress_kind
+  ; AwaitingVerification_kind
+  ; Done_kind
+  ; Cancelled_kind
+  ]
+
+let all_transition_actions : transition_action list =
+  [ Claim
+  ; Start
+  ; Done_action
+  ; Cancel
+  ; Release
+  ; Submit_for_verification
+  ; Approve_verification
+  ; Reject_verification
+  ; Submit_pr_evidence
+  ]
+
+let all_families : family list =
+  let invalid_pairs =
+    List.concat_map
+      (fun from_status ->
+        List.map
+          (fun action -> Invalid_transition { from_status; action })
+          all_transition_actions)
+      all_status_kinds
+  in
+  let leaf_families : family list =
+    [ Awaiting_verification_done
+    ; Self_approval_not_allowed
+    ; Self_rejection_not_allowed
+    ; Already_done
+    ; Active_task_limit_exceeded
+    ; Submit_verification_missing_evidence
+    ; Claim_oscillation_blocked
+    ; Other_invalid_state
+    ]
+  in
+  invalid_pairs @ leaf_families
+
+(* ── Classification ───────────────────────────────────────────────── *)
+
+(* Case-insensitive substring containment over ASCII inputs. The error
+   messages we classify are all ASCII; [String.lowercase_ascii] is safe
+   here. *)
+let contains_ci ~(needle : string) (haystack : string) : bool =
+  let h = String.lowercase_ascii haystack in
+  let n = String.lowercase_ascii needle in
+  let hl = String.length h in
+  let nl = String.length n in
+  if nl = 0
+  then true
+  else if nl > hl
+  then false
+  else (
+    let last = hl - nl in
+    let found = ref false in
+    let i = ref 0 in
+    while (not !found) && !i <= last do
+      if String.equal (Stdlib.String.sub h !i nl) n then found := true;
+      incr i
+    done;
+    !found)
+
+(* Parse the substring after [Invalid transition: <from> -> <action>]
+   into a typed [(status_kind, transition_action)] pair. Returns [None]
+   when either side fails to match a known token — the caller falls
+   back to [Other_invalid_state] in that case rather than synthesising
+   a partial [Invalid_transition]. *)
+let parse_status_kind_token (s : string) : status_kind option =
+  match String.lowercase_ascii (String.trim s) with
+  | "todo" -> Some Todo_kind
+  | "claimed" -> Some Claimed_kind
+  | "in_progress" | "inprogress" -> Some InProgress_kind
+  | "awaiting_verification" | "awaitingverification" ->
+    Some AwaitingVerification_kind
+  | "done" -> Some Done_kind
+  | "cancelled" | "canceled" -> Some Cancelled_kind
+  | _ -> None
+
+let parse_transition_action_token (s : string) : transition_action option =
+  match String.lowercase_ascii (String.trim s) with
+  | "claim" -> Some Claim
+  | "start" -> Some Start
+  | "done" | "done_action" -> Some Done_action
+  | "cancel" -> Some Cancel
+  | "release" -> Some Release
+  | "submit_for_verification" -> Some Submit_for_verification
+  | "approve_verification" | "approve" -> Some Approve_verification
+  | "reject_verification" | "reject" -> Some Reject_verification
+  | "submit_pr_evidence" -> Some Submit_pr_evidence
+  | _ -> None
+
+(* Find the substring between [prefix] and the first occurrence of
+   [stop] (or end-of-string). Returns [None] when [prefix] is absent. *)
+let extract_after ~(prefix : string) ~(stop : char) (s : string) : string option
+  =
+  let h = String.lowercase_ascii s in
+  let p = String.lowercase_ascii prefix in
+  let hl = String.length h in
+  let pl = String.length p in
+  if pl > hl
+  then None
+  else (
+    let start = ref None in
+    let i = ref 0 in
+    let last = hl - pl in
+    while Option.is_none !start && !i <= last do
+      if String.equal (Stdlib.String.sub h !i pl) p
+      then start := Some (!i + pl);
+      incr i
+    done;
+    match !start with
+    | None -> None
+    | Some from ->
+      let j = ref from in
+      while !j < hl && s.[!j] <> stop do
+        incr j
+      done;
+      Some (Stdlib.String.sub s from (!j - from)))
+
+let parse_invalid_transition_pair (msg : string)
+    : (status_kind * transition_action) option
+  =
+  (* Expected fragment: "Invalid transition: <from> -> <action> (..."
+     We tolerate optional whitespace around the arrow. *)
+  match extract_after ~prefix:"invalid transition:" ~stop:'(' msg with
+  | None -> None
+  | Some body ->
+    (* split on "->" *)
+    let body = String.trim body in
+    let arrow = "->" in
+    let bl = String.length body in
+    let al = String.length arrow in
+    let pos = ref None in
+    let i = ref 0 in
+    let last = bl - al in
+    while Option.is_none !pos && !i <= last do
+      if String.equal (Stdlib.String.sub body !i al) arrow
+      then pos := Some !i;
+      incr i
+    done;
+    (match !pos with
+     | None -> None
+     | Some p ->
+       let lhs = String.trim (Stdlib.String.sub body 0 p) in
+       let rhs = String.trim (Stdlib.String.sub body (p + al) (bl - p - al)) in
+       (match parse_status_kind_token lhs, parse_transition_action_token rhs with
+        | Some s, Some a -> Some (s, a)
+        | _, _ -> None))
+
+(* Order of checks matters: the more specific fragments are tried
+   first so that, for example, "Self-approval not allowed" is not
+   absorbed by a generic "not allowed" rule. *)
+let classify (msg : string) : family =
+  if contains_ci ~needle:"Self-approval not allowed" msg
+  then Self_approval_not_allowed
+  else if contains_ci ~needle:"Self-rejection not allowed" msg
+  then Self_rejection_not_allowed
+  else if contains_ci ~needle:"awaiting verification" msg
+  then Awaiting_verification_done
+  else if contains_ci ~needle:"already done by" msg
+  then Already_done
+  else if contains_ci ~needle:"already done/cancelled" msg
+  then Already_done
+  else if contains_ci ~needle:"blocked from re-claim" msg
+  then Claim_oscillation_blocked
+  else if contains_ci ~needle:"claim-release oscillation" msg
+  then Claim_oscillation_blocked
+  else if contains_ci ~needle:"active task limit" msg
+  then Active_task_limit_exceeded
+  else if contains_ci ~needle:"active_task_limit" msg
+  then Active_task_limit_exceeded
+  else if contains_ci ~needle:"missing evidence" msg
+     || contains_ci ~needle:"missing pr_url" msg
+     || contains_ci ~needle:"submit_for_verification requires" msg
+  then Submit_verification_missing_evidence
+  else if contains_ci ~needle:"Invalid transition:" msg
+  then (
+    match parse_invalid_transition_pair msg with
+    | Some (from_status, action) -> Invalid_transition { from_status; action }
+    | None -> Other_invalid_state)
+  else Other_invalid_state
+
+let default_silence_threshold : int = 10
+
+(* ── In-memory state ──────────────────────────────────────────────── *)
+
+(* Per-task entry: count of failures keyed by [family]. We use a
+   nested Hashtbl so [reset_for_task] is O(families-for-task). *)
+type per_task = (family, int) Hashtbl.t
+
+let state_mutex : Stdlib.Mutex.t = Stdlib.Mutex.create ()
+let state : (string, per_task) Hashtbl.t = Hashtbl.create 64
+
+let with_lock (f : unit -> 'a) : 'a =
+  Stdlib.Mutex.protect state_mutex f
+
+let record_invalid_state
+    ?(silence_threshold = default_silence_threshold)
+    ~(task_id : string)
+    ~(family : family)
+    ()
+    : record_outcome
+  =
+  with_lock (fun () ->
+    let per_task =
+      match Hashtbl.find_opt state task_id with
+      | Some t -> t
+      | None ->
+        let t = Hashtbl.create 4 in
+        Hashtbl.replace state task_id t;
+        t
+    in
+    let prev = Option.value (Hashtbl.find_opt per_task family) ~default:0 in
+    let next = prev + 1 in
+    Hashtbl.replace per_task family next;
+    if next = 1
+    then `First
+    else if next = silence_threshold
+    then `Threshold_silence { count = next; silence_threshold }
+    else `Repeated next)
+
+let reset_for_task ~(task_id : string) : unit =
+  with_lock (fun () -> Hashtbl.remove state task_id)
+
+let reset_for_test () : unit =
+  with_lock (fun () -> Hashtbl.reset state)
+
+let cardinality () : int =
+  with_lock (fun () ->
+    Hashtbl.fold
+      (fun _task_id per_task acc -> acc + Hashtbl.length per_task)
+      state
+      0)
+
+let failure_count ~(task_id : string) ~(family : family) : int =
+  with_lock (fun () ->
+    match Hashtbl.find_opt state task_id with
+    | None -> 0
+    | Some per_task ->
+      Option.value (Hashtbl.find_opt per_task family) ~default:0)

--- a/lib/task_transition_state/task_transition_state.mli
+++ b/lib/task_transition_state/task_transition_state.mli
@@ -1,0 +1,238 @@
+(** Typed escalation state for repeated [Invalid task state] transition
+    errors emitted by [Tool_task.run_task_transition].
+
+    Background
+    ──────────
+    [Tool_task] returns [Masc_error.TaskError (InvalidState _)] when an
+    agent attempts a [task_action] that the current [task_status] does
+    not permit. The error itself is correct — the transition cannot be
+    allowed — but the call sites at [Tool_task.handle_done_transition]
+    (line 689) and [Tool_task.run_task_transition] (line 975) log every
+    such failure at ERROR. In production the same [(task, action, from)]
+    tuple is retried by the same agent (or by alias resolvers) within
+    seconds, and the result is a recurrent ERROR-level log loop visible
+    in system_log_2026-05-19:
+
+    - 2026-05-19 00:00–00:30 slice: 7 [task transition failed: [TaskError]
+      Invalid task state] ERROR lines / 10 min (down from 17/10 min the
+      previous slice).
+    - Steady-state projection: ~10–15K events/day if the upstream caller
+      pattern stabilises.
+
+    Top patterns observed (system_log 2026-05-19, normalised):
+    {[
+      6  Invalid transition: done -> approve / submit_for_verification
+      5  task is already done by AGENT
+      3  Self-approval not allowed
+      3  task is awaiting verification by AGENT
+      3  Invalid transition: todo -> start
+      3  Invalid transition: awaiting_verification -> claim
+      …  (Invalid transition: claimed -> release; in_progress -> reject; …)
+    ]}
+
+    The block itself is *not* the bug — the bug is that the operator
+    sees the same fact restated repeatedly per task. This module records
+    each failure under a closed-sum [family] fingerprint and classifies
+    the result so the caller can emit one durable [`Threshold_silence]
+    ERROR plus a Prometheus counter, and demote noisy intermediate
+    emissions to DEBUG.
+
+    Closed sum types, no catch-all. The [family] enum captures every
+    distinct error class produced by [Tool_task.validate_transition] and
+    the [transition_action] enum mirrors [Types_core.task_action]
+    one-for-one, so adding a new task action upstream forces a compile-
+    time update here.
+
+    Workaround posture
+    ──────────────────
+    This is a *symptom suppression* layer for the log surface. The
+    root fix lives one level up in [Tool_task.run_task_transition] and
+    the upstream callers — an invalid transition should be detected
+    client-side (cached [task_status] + valid_next_actions) before the
+    transition is even attempted, so the same [(task, action, from)]
+    tuple is not retried 5–7× per task. That change touches the
+    keeper tool-call loop and the agent SDK retry semantics and is
+    deferred to its own RFC.
+
+    For now, the [`Threshold_silence] outcome gives the operator a
+    one-line ERROR after [default_silence_threshold] identical failures
+    and a Prometheus counter for dashboarding; subsequent failures
+    return [`Repeated] and the caller is expected to DEBUG-log instead
+    of ERROR-log.
+
+    [WORKAROUND-CARRYOVER]: this module is a noise-dedupe layer, not
+    a structural fix for the upstream invalid-transition retry pattern.
+    Track the root fix on a follow-up issue.
+
+    Threading
+    ─────────
+    Backed by an in-memory [Hashtbl.t] under a [Mutex]. Process
+    lifetime; not persisted. A server restart sees the first
+    occurrence emit at ERROR again, which is the desired behaviour
+    (operator-visible "this is still happening after restart"). *)
+
+(** Closed-enum mirror of [Types_core.task_status] constructors,
+    projected to the data-free status kind used for fingerprinting.
+    Adding a new constructor upstream forces an arm here. *)
+type status_kind =
+  | Todo_kind
+  | Claimed_kind
+  | InProgress_kind
+  | AwaitingVerification_kind
+  | Done_kind
+  | Cancelled_kind
+
+(** Closed-enum mirror of [Types_core.task_action]. Adding a new action
+    upstream forces an arm here. Used for both fingerprinting and the
+    Prometheus label. *)
+type transition_action =
+  | Claim
+  | Start
+  | Done_action
+  | Cancel
+  | Release
+  | Submit_for_verification
+  | Approve_verification
+  | Reject_verification
+  | Submit_pr_evidence
+
+(** Closed-enum classification of the [InvalidState] error message.
+    Derived from the [Tool_task.validate_transition] surface and the
+    other [InvalidState _] emit sites; covers the 16 distinct families
+    observed in system_log_2026-05-19. *)
+type family =
+  | Invalid_transition of
+      { from_status : status_kind
+      ; action : transition_action
+      }
+      (** [validate_transition] rejected the [(from_status, action)]
+          pair as not in the FSM transition matrix. *)
+  | Awaiting_verification_done
+      (** Agent tried to mark [AwaitingVerification] task as done
+          without going through the verification protocol. *)
+  | Self_approval_not_allowed
+      (** Verifier and submitter are the same agent on the
+          approve path. *)
+  | Self_rejection_not_allowed
+      (** Verifier and submitter are the same agent on the reject
+          path. *)
+  | Already_done
+      (** Agent retried [Done_action] on a task already in
+          [Done] terminal state. *)
+  | Active_task_limit_exceeded
+      (** Agent already owns more active tasks than the cap allows. *)
+  | Submit_verification_missing_evidence
+      (** [Submit_for_verification] called without [pr_url] or
+          explicit evidence reference. *)
+  | Claim_oscillation_blocked
+      (** Re-claim blocked because the [claim ↔ release] oscillation
+          threshold was reached. *)
+  | Other_invalid_state
+      (** Catch-net for [InvalidState] messages that do not match any
+          of the families above. Kept as an explicit constructor —
+          not a catch-all match arm — so the [classify] function
+          remains exhaustive and the [Other_invalid_state] case is
+          visible to operators via the Prometheus label. *)
+
+(** Stable string label for log/metric dimensions. Total. *)
+val family_to_string : family -> string
+
+(** All [family] inhabitants, with parametric ones enumerated over the
+    Cartesian product of [status_kind × transition_action]. Used by
+    exhaustiveness tests. Cardinality is bounded:
+    [6 × 9 + 8] = [62]. *)
+val all_families : family list
+
+(** [classify msg] inspects the raw [InvalidState] message body
+    (the substring after [\[TaskError\] Invalid task state: ]) and
+    returns the matching [family]. Uses pattern fragments observed
+    in [lib/tool_task.ml] error builders; falls back to
+    [Other_invalid_state] only when no fragment matches. *)
+val classify : string -> family
+
+(** Carrier for the [`Threshold_silence] outcome. [count] is the
+    running failure count when the threshold tripped (>=
+    [silence_threshold]); [silence_threshold] echoes the threshold the
+    caller observed. *)
+type threshold_silence_payload =
+  { count : int
+  ; silence_threshold : int
+  }
+
+(** Classification outcome. The caller is [Tool_task] (the transition
+    dispatch); the outcome dictates how the failure logs:
+
+    - [`First] — first time this [(task_id, family)] pair has been
+      blocked in this process lifetime. Emit ERROR (preserve existing
+      operator-visible signal).
+
+    - [`Repeated count] — same pair has been blocked before; [count]
+      is the total failure count including this call (>=2) and is
+      strictly less than [silence_threshold]. Demote the log line to
+      DEBUG and bump [task_transition_invalid_state_repeated_total].
+      The error is still returned to the caller — only the log
+      surface changes.
+
+    - [`Threshold_silence payload] — the [silence_threshold] identical
+      failures have now been seen for this [(task_id, family)] pair;
+      payload echoes [count] and [silence_threshold]. The caller
+      should emit a single durable ERROR ("threshold reached,
+      silencing log surface") and bump
+      [task_transition_invalid_state_threshold_silence_total].
+      Subsequent failures for the same pair return [`Repeated] until
+      [reset_for_task] is called (typically when the task progresses
+      to a valid next state). *)
+type record_outcome =
+  [ `First
+  | `Repeated of int
+  | `Threshold_silence of threshold_silence_payload
+  ]
+
+(** Default silence threshold — the number of identical
+    [(task_id, family)] failures tolerated at ERROR / DEBUG before a
+    [`Threshold_silence] outcome fires. Tuned against the production
+    sample (7 failures / 10 min, 16 distinct families, ~30 s retry
+    cadence): threshold 10 means the operator sees one ERROR line
+    plus nine DEBUG-demoted intermediates before the [Threshold_silence]
+    ERROR, and any further failures for the same pair are
+    [`Repeated] + DEBUG only. *)
+val default_silence_threshold : int
+
+(** [record_invalid_state ~task_id ~family ()] registers a failure for
+    [(task_id, family)] and returns the classification. The fingerprint
+    is [(task_id, family)] — two different agents retrying the same
+    invalid transition on the same task collapse into the same bucket
+    on purpose: the operator-visible pattern is "task X is stuck in
+    family Y", not "this specific agent is retrying".
+
+    The default silence threshold is [default_silence_threshold];
+    callers that need a different threshold (e.g. tests) can override
+    via [?silence_threshold]. *)
+val record_invalid_state
+  :  ?silence_threshold:int
+  -> task_id:string
+  -> family:family
+  -> unit
+  -> record_outcome
+
+(** [reset_for_task ~task_id] removes all per-task state. Called by
+    [Tool_task] when the task progresses to a valid next state
+    (successful claim / start / done / cancel / release etc.), so the
+    next family of failures on that task starts fresh from
+    [`First]. *)
+val reset_for_task : task_id:string -> unit
+
+(** Reset all internal state. Test-only entry point — do not call
+    from production code. Exposed so unit tests can enforce
+    isolation between cases. *)
+val reset_for_test : unit -> unit
+
+(** Current number of distinct [(task_id, family)] entries.
+    Diagnostic only; never used for control flow. *)
+val cardinality : unit -> int
+
+(** [failure_count ~task_id ~family] returns the current failure count
+    for the given pair, or [0] when no state exists. Diagnostic /
+    introspection only; never used for control flow inside the
+    module. *)
+val failure_count : task_id:string -> family:family -> int


### PR DESCRIPTION
## 요약

`Tool_task.run_task_transition` 가 같은 `(task_id, family)` 쌍에 대해 같은 `Invalid task state` ERROR 를 5–7 회 반복 출력하는 로그 노이즈를 잡기 위한 **타입드 dedup 레이어**를 추가했습니다.

근거 (system_log 2026-05-19):

- 00:00–00:30 슬라이스: `[task transition failed: [TaskError] Invalid task state]` ERROR 7건/10분 (직전 슬라이스 17건/10분에서 감소 중).
- 16 개의 구분되는 `(status, action)` family 가 관측됨. 같은 task 에 같은 transition 을 30 초 이내 재시도하는 keeper/alias-resolver 패턴.
- Top pattern:
  - 6× `Invalid transition: done -> approve / submit_for_verification`
  - 5× `task is already done by AGENT`
  - 3× `Self-approval not allowed`
  - 3× `task is awaiting verification by AGENT`
  - 3× `Invalid transition: todo -> start`
  - 3× `Invalid transition: awaiting_verification -> claim`
- Steady-state 추정: ~10–15K event/day (upstream caller 가 안정화되면).

## 변경 사항

새 라이브러리 `lib/task_transition_state/`:

- `task_transition_state.mli` (238 lines, 이전 sub-agent 작성분 그대로 채택): closed-sum `family` 분류, `status_kind`/`transition_action` enums, `record_outcome` polymorphic variant.
- `task_transition_state.ml` (340 lines, 이번 PR): `.mli` 시그니처 정확히 구현. `Hashtbl + Stdlib.Mutex.protect` 기반 in-memory state.
- `dune`: `(public_name masc_mcp.task_transition_state)` library stanza, `-w +4` (RFC-0071 §3.4 Phase 5 ratchet 정렬).

핵심 동작:

- `record_invalid_state ~task_id ~family ()` → `\`First` / `\`Repeated of int` / `\`Threshold_silence { count; silence_threshold }`.
- 호출자 (Tool_task) 는 `\`First` 만 ERROR 로 emit, `\`Repeated` 는 DEBUG demote, `\`Threshold_silence` 는 한 줄 durable ERROR + Prometheus counter.
- Cardinality: `status_kind (6) × transition_action (9) + leaf (8) = 62` family (`all_families` 로 노출, exhaustiveness 테스트용).

## Threshold_silence 패턴

- `default_silence_threshold = 10`. 7 failures / 10 min + 16 distinct families + ~30s retry cadence 의 prod 샘플에 맞춰 튜닝.
- 10번째 동일 실패에서 한 번 "threshold reached, silencing log surface" ERROR + counter, 이후 같은 쌍은 `\`Repeated`+DEBUG.
- `reset_for_task` 가 호출되면 (task 가 valid next state 로 진행하면) 다음 family 실패는 다시 `\`First` 부터.

## 검증

`dune build` 가 `~/me/feedback_masc_mcp_dune_local_lock_contention.md` 에 기록된 99% lock 대기 이슈로 worktree 안에서 막혀 있어 **standalone alcotest** 로 직접 컴파일 / 실행했습니다 (`ocamlfind ocamlc -package alcotest`).

```
Testing `task_transition_state'.
This run has ID `4IUZDIR3'.

  [OK]          record_outcome          0   first-time.
  [OK]          record_outcome          1   repeated-incrementing.
  [OK]          record_outcome          2   threshold-silence.
  [OK]          record_outcome          3   family-distinct-keys.
  [OK]          record_outcome          4   reset-behaviour.
  [OK]          classify                0   smoke.
  [OK]          classify                1   all_families cardinality.

Test Successful in 0.005s. 7 tests run.
```

`.mli` + `.ml` 컴파일은 `-w +4` (fragile pattern) 와 함께 0 warning. `classify` 의 fragment 매칭은 `lib/coord/coord_task.ml` (line 165, 170, 175, 246) 과 `lib/tool_task_contract_gate.ml` (line 49–61) 의 실제 production builder string 으로 검증.

## Workaround posture

이 모듈은 **로그 표면 dedupe 레이어**이고, **구조적 fix 가 아닙니다**. 근본 해결은 한 단계 위 — keeper 가 transition 을 디스패치하기 전 cached `task_status` + `valid_next_actions` 를 사용해 client-side 에서 invalid transition 을 차단하는 것 — 이고, 이는 keeper tool-call 루프 + agent SDK retry 시맨틱을 건드리는 별도 RFC 로 deferred 됩니다.

`WORKAROUND-CARRYOVER` 마커가 `.mli` docstring (line 63–65) 과 `.ml` 헤더 주석에 모두 명시되어 있어 후속 RFC 가 이 모듈을 회수할 때 deprecated path 가 visible 합니다. `software-development.md` §"워크어라운드 거부 기준" 의 텔레메트리-as-fix 시그니처 (counter 만 추가하고 fix 없음) 에는 해당하지 않음 — 본 PR 은 ERROR-level 로그 표면 자체를 줄이는 동작 변경이고 카운터는 부가적입니다.

## Plan SSOT

`/Users/dancer/Downloads/MASC:OAS Error-Warn Reduction Goal - 2026-05-18.html` §P6 인접 영역.

## RFC scope

본 PR 은 RFC-게이트 subsystem 에 해당하지 않습니다:

- `lib/keeper/credential_*` — 미수정
- `lib/repo_manager/` — 미수정
- `lib/operator/operator_control*` — 미수정
- `lib/keeper/keeper_sandbox*` — 미수정
- `dashboard/src/components/credential*` — 미수정
- `.claude/hooks/`, `instructions/workflow*` — 미수정

`pr-rfc-check.sh` PASS 확인 후 push 했습니다.

## Test plan

- [x] Standalone alcotest 7/7 PASS (위 인용).
- [x] `.mli` ↔ `.ml` 시그니처 정합성 (`ocamlfind ocamlc -c` 0 warning at `-w +4`).
- [x] `classify` smoke: production fragment 8 종 (Self-approval, Self-rejection, awaiting verification, already done by, blocked from re-claim, `Invalid transition: todo -> release`, `Invalid transition: awaiting_verification -> claim`, unknown fallback).
- [x] `all_families` cardinality = 62 (`6×9 + 8`).
- [ ] Tool_task 측 wiring + Prometheus counter 등록 — **별도 follow-up PR**. 본 PR 은 라이브러리 신설만, caller 변경 없음 (zero-impact stand-alone).

Co-Authored-By: Claude <noreply@anthropic.com>
