### PR TITLE
refactor: split keeper agent wake telemetry

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -500,52 +500,21 @@ let run_turn
             }
             : Cascade_runner.cli_transport_overrides)
        in
-       (* Phase 0: wake-time payload telemetry (Option C baseline).
-       Entire block is dead code when MASC_PAYLOAD_TELEMETRY is unset.
-       Compute logic lives in [Keeper_wake_telemetry] for unit tests;
-       exceptions from the telemetry path never abort the LLM call. *)
-       let () =
-         if Env_config_keeper.KeeperTelemetry.payload_telemetry_enabled ()
-         then (
-           try
-             let sizes =
-               Keeper_wake_telemetry.compute_sizes
-                 ~system_prompt:turn_system_prompt
-                 ~tools
-                 ~history_messages
-                 ~user_message
-             in
-             let model_id =
-               match Keeper_model_labels.configured_model_labels_of_meta meta with
-               | m :: _ -> m
-               | [] -> "auto"
-             in
-             let _event : Dashboard_harness_health.wake_payload_event =
-               Dashboard_harness_health.record_wake_payload
-                 ~keeper_name:meta.name
-                 ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-                 ~turn_index:start_turn_count
-                 ~model_id
-                 ~context_window:max_context
-                 ~approx_body_bytes:sizes.approx_body_bytes
-                 ~system_prompt_bytes:sizes.system_prompt_bytes
-                 ~tool_defs_bytes:sizes.tool_defs_bytes
-                 ~messages_bytes:sizes.messages_bytes
-                 ~message_count:sizes.message_count
-                 ~role_counts:sizes.role_counts
-                 ~tool_count:sizes.tool_count
-                 ~has_compact_happened:pre_dispatch_compacted
-             in
-             ()
-           with
-           | Eio.Cancel.Cancelled _ as e -> raise e
-           | exn ->
-             Log.Harness.warn
-               "[wake_payload] telemetry failed keeper=%s: %s"
-               meta.name
-               (Printexc.to_string exn))
-       in
-       let turn_result =
+	       (* Phase 0: wake-time payload telemetry (Option C baseline).
+	       Entire block is dead code when MASC_PAYLOAD_TELEMETRY is unset.
+	       Compute logic lives in [Keeper_wake_telemetry] for unit tests;
+	       exceptions from the telemetry path never abort the LLM call. *)
+	       Turn_helpers.record_wake_payload_if_enabled
+	         ~meta
+	         ~trace_id
+	         ~start_turn_count
+	         ~max_context
+	         ~pre_dispatch_compacted
+	         ~turn_system_prompt
+	         ~tools
+	         ~history_messages
+	         ~user_message;
+	       let turn_result =
          match pre_dispatch_checkpoint_error with
          | Some err -> Error err
          | None ->

--- a/lib/keeper/keeper_agent_run_turn_helpers.ml
+++ b/lib/keeper/keeper_agent_run_turn_helpers.ml
@@ -227,3 +227,44 @@ let turn_progress_callbacks ~config ~keeper_name ~downstream =
   in
   let on_event = Some (registry_progress_on_event ~record_turn_progress downstream) in
   (record_turn_progress, yield_on_tool, on_yield, on_resume, on_event)
+
+let record_wake_payload_if_enabled ~meta ~trace_id ~start_turn_count ~max_context
+    ~pre_dispatch_compacted ~turn_system_prompt ~tools ~history_messages ~user_message =
+  if Env_config_keeper.KeeperTelemetry.payload_telemetry_enabled () then
+    try
+      let sizes =
+        Keeper_wake_telemetry.compute_sizes
+          ~system_prompt:turn_system_prompt
+          ~tools
+          ~history_messages
+          ~user_message
+      in
+      let model_id =
+        match Keeper_model_labels.configured_model_labels_of_meta meta with
+        | m :: _ -> m
+        | [] -> "auto"
+      in
+      let _event : Dashboard_harness_health.wake_payload_event =
+        Dashboard_harness_health.record_wake_payload
+          ~keeper_name:meta.name
+          ~trace_id
+          ~turn_index:start_turn_count
+          ~model_id
+          ~context_window:max_context
+          ~approx_body_bytes:sizes.approx_body_bytes
+          ~system_prompt_bytes:sizes.system_prompt_bytes
+          ~tool_defs_bytes:sizes.tool_defs_bytes
+          ~messages_bytes:sizes.messages_bytes
+          ~message_count:sizes.message_count
+          ~role_counts:sizes.role_counts
+          ~tool_count:sizes.tool_count
+          ~has_compact_happened:pre_dispatch_compacted
+      in
+      ()
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+        Log.Harness.warn
+          "[wake_payload] telemetry failed keeper=%s: %s"
+          meta.name
+          (Printexc.to_string exn)

--- a/lib/keeper/keeper_agent_run_turn_helpers.mli
+++ b/lib/keeper/keeper_agent_run_turn_helpers.mli
@@ -81,3 +81,15 @@ val turn_progress_callbacks :
   * (unit -> unit) option
   * (unit -> unit) option
   * (Agent_sdk.Types.sse_event -> unit) option
+
+val record_wake_payload_if_enabled :
+  meta:Keeper_types.keeper_meta ->
+  trace_id:string ->
+  start_turn_count:int ->
+  max_context:int ->
+  pre_dispatch_compacted:bool ->
+  turn_system_prompt:string ->
+  tools:Agent_sdk.Tool.t list ->
+  history_messages:Agent_sdk.Types.message list ->
+  user_message:string ->
+  unit


### PR DESCRIPTION
## Summary
- Move wake payload telemetry recording from keeper_agent_run into keeper_agent_run_turn_helpers.
- Keep telemetry behavior unchanged: disabled unless MASC_PAYLOAD_TELEMETRY is enabled and non-cancel exceptions are warning-only.
- Reduce keeper_agent_run.ml from 1978 to 1947 lines in this stack.

## Validation
- ocamlformat --check lib/keeper/keeper_agent_run.ml lib/keeper/keeper_agent_run_turn_helpers.ml lib/keeper/keeper_agent_run_turn_helpers.mli
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- bash scripts/lint/godfile-size-regression.sh

## Validation gap
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_wake_telemetry.exe test/test_keeper_agent_run_sandbox_source.exe currently stops in the parent stack at lib/prometheus.ml:262 with Unbound value metric_key. The changed files are keeper_agent_run* only; main already has the newer register_* implementation in lib/prometheus.ml.