### PR TITLE
fix(metrics): export livelock repeat counters

### DIFF
--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -227,6 +227,8 @@ val metric_keeper_turn_starts : string
 val metric_keeper_turn_reattempts : string
 val metric_keeper_turn_regressions : string
 val metric_keeper_turn_livelock_blocks : string
+val metric_keeper_turn_livelock_blocks_repeated : string
+val metric_keeper_turn_livelock_blocks_threshold_park : string
 val metric_keeper_turn_latency_bucket : string
 val metric_keeper_turn_latency_by_model_bucket : string
 val metric_keeper_provider_cooldown_skip : string


### PR DESCRIPTION
## Summary
- export existing livelock repeat and threshold-park metric constants from keeper_metrics.mli
- restore compilation for keeper_unified_turn callers on current main

## Verification
- scripts/dune-local.sh build test/test_keeper_tool_alias.exe
- ./_build/default/test/test_keeper_tool_alias.exe
- git diff --check