### PR TITLE
fix(shell): clarify public Bash front door

### DIFF
--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -195,8 +195,12 @@ let bash_public_schema =
     [ property
         "command"
         "string"
-        "The shell command to execute. Single command only. No chaining (&&, ||, ;), \
-         pipes (|), or redirects (>, >>). Example: 'scripts/dune-local.sh build', 'rg pattern lib/'."
+        "The single shell command to execute through the public Bash front door. Do \
+         not call keeper_* or masc_* tool names here; use visible task/board/PR tools \
+         directly. For file reads or search, use Read or Grep first. No chaining (&&, \
+         ||, ;), pipes (|), redirects (>, >>), command substitution, or background \
+         operators. Always set cwd for multi-repo git/gh commands. Example: \
+         'scripts/dune-local.sh build test/test_keeper_tool_alias.exe'."
     ; property
         "cwd"
         "string"

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -1215,12 +1215,13 @@ let make_tool_bundle
                let description =
                  match public with
                  | "Grep" ->
-                   "Search file contents with ripgrep. This is a public alias for \
-                    keeper_shell op=rg only; use Bash/keeper_bash for command execution."
+                   "Search file contents with ripgrep. Use this for code/file observation; \
+                    use Bash only for command execution."
                  | "Bash" ->
-                   "Execute one shell command through keeper_bash, including Legendary \
-                    Bash safety gates, write gating, background execution, and sandbox \
-                    routing."
+                   "Execute one shell command through the public Bash front door. Set cwd \
+                    for multi-repo git/gh commands; use Read/Grep for file observation and \
+                    visible task/board/PR tools instead of typing tool names as shell \
+                    commands."
                  | _ -> internal_def.description
                in
                let h =

--- a/test/test_keeper_tool_alias.ml
+++ b/test/test_keeper_tool_alias.ml
@@ -370,6 +370,25 @@ let yojson_field name j =
   | _ -> None
 ;;
 
+let yojson_string_field name j =
+  match yojson_field name j with
+  | Some (`String s) -> Some s
+  | _ -> None
+;;
+
+let string_contains ~sub text =
+  let text_len = String.length text in
+  let sub_len = String.length sub in
+  let rec loop idx =
+    if idx + sub_len > text_len
+    then false
+    else if String.sub text idx sub_len = sub
+    then true
+    else loop (idx + 1)
+  in
+  sub_len = 0 || loop 0
+;;
+
 let test_public_names_stable_order () =
   (* public_names returns all LLM-native surface names in stable order. *)
   let names = Alias.public_names () in
@@ -419,6 +438,27 @@ let test_bash_schema_uses_command_field () =
     | _ -> []
   in
   Alcotest.(check (list string)) "Bash requires 'command'" [ "command" ] required
+;;
+
+let test_bash_schema_guides_public_frontdoor () =
+  let schema = Option.get (Alias.public_input_schema "Bash") in
+  let props = Option.get (yojson_field "properties" schema) in
+  let command = Option.get (yojson_field "command" props) in
+  let description = Option.get (yojson_string_field "description" command) in
+  List.iter
+    (fun (label, needle) ->
+       Alcotest.(check bool)
+         label
+         true
+         (string_contains ~sub:needle description))
+    [ "Bash command schema names public front door", "public Bash front door"
+    ; "Bash command schema blocks keeper tool names", "Do not call keeper_*"
+    ; "Bash command schema blocks masc tool names", "masc_* tool names"
+    ; "Bash command schema routes file observation", "use Read or Grep first"
+    ; "Bash command schema routes workflow tools", "visible task/board/PR tools"
+    ; "Bash command schema asks for cwd", "Always set cwd"
+    ; "Bash command schema blocks command substitution", "command substitution"
+    ]
 ;;
 
 let test_read_schema_uses_file_path () =
@@ -823,6 +863,10 @@ let () =
             "Bash schema uses 'command' field"
             `Quick
             test_bash_schema_uses_command_field
+        ; Alcotest.test_case
+            "Bash schema guides public front door"
+            `Quick
+            test_bash_schema_guides_public_frontdoor
         ; Alcotest.test_case
             "Read schema uses 'file_path' field"
             `Quick

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -220,6 +220,56 @@ let with_env name value f =
     f
 ;;
 
+let test_public_alias_descriptions_are_frontdoor_safe () =
+  let meta = make_test_meta () in
+  let ctx_snapshot = make_test_ctx () in
+  let dir = Filename.temp_file "test_keeper_tools_descriptions_" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       let config = Coord.default_config dir in
+       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
+       let bash = find_tool "Bash" tools in
+       let grep = find_tool "Grep" tools in
+       check bool
+         "Bash description names public front door"
+         true
+         (string_contains ~sub:"public Bash front door" bash.schema.description);
+       check bool
+         "Bash description routes file observation"
+         true
+         (string_contains ~sub:"Read/Grep" bash.schema.description);
+       check bool
+         "Bash description routes workflow tools"
+         true
+         (string_contains ~sub:"visible task/board/PR tools" bash.schema.description);
+       check bool
+         "Bash description hides internal keeper_bash"
+         false
+         (string_contains ~sub:"keeper_bash" bash.schema.description);
+       check bool
+         "Bash description drops Legendary wording"
+         false
+         (string_contains ~sub:"Legendary" bash.schema.description);
+       check bool
+         "Grep description names observation lane"
+         true
+         (string_contains ~sub:"code/file observation" grep.schema.description);
+       check bool
+         "Grep description keeps execution in Bash"
+         true
+         (string_contains ~sub:"Bash only for command execution" grep.schema.description);
+       check bool
+         "Grep description hides internal keeper_shell"
+         false
+         (string_contains ~sub:"keeper_shell" grep.schema.description))
+;;
+
 let test_tool_side_effect_failures_are_observed () =
   let meta =
     make_test_meta ~name:"test-keeper-side-effects" ~allowed_paths:[ "repos" ] ()
@@ -1357,6 +1407,10 @@ let () =
     [ ( "make_tools"
       , [ test_case "returns nonempty" `Quick test_make_tools_returns_nonempty
         ; test_case "valid schemas" `Quick test_tools_have_valid_schemas
+        ; test_case
+            "public alias descriptions are front-door safe"
+            `Quick
+            test_public_alias_descriptions_are_frontdoor_safe
         ; test_case "count matches allowed" `Quick test_tool_count_matches_allowed
         ; test_case
             "error json becomes tool error"


### PR DESCRIPTION
## Summary
- describe Bash as the public single-command execution front door instead of an internal/Legendary Bash surface
- route file observation toward Read/Grep and task/board/PR workflows toward visible JSON tools
- add regression tests for Bash schema guidance and OAS public alias descriptions

## Verification
- scripts/dune-local.sh build test/test_keeper_tool_alias.exe test/test_keeper_tools_oas.exe
- ./_build/default/test/test_keeper_tool_alias.exe
- ./_build/default/test/test_keeper_tools_oas.exe
- git diff --check