### PR TITLE
feat(keeper): report received JSON kind in Keeper_id parse errors

### DIFF
--- a/lib/keeper/keeper_id.ml
+++ b/lib/keeper/keeper_id.ml
@@ -1,3 +1,15 @@
+let json_kind_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "intlit"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+
 module Keeper_name = struct
   type t = string
   let is_valid s =
@@ -83,7 +95,10 @@ module Uid = struct
         (match of_string s with
          | Ok t -> Ok t
          | Error e -> Error e)
-    | _ -> Error "Expected string for Keeper_id.Uid"
+    | other ->
+        Error
+          (Printf.sprintf "Expected string for Keeper_id.Uid (received %s)"
+             (json_kind_name other))
 end
 
 (** Polymorphic variants for use in keeper_meta without depending on a
@@ -96,4 +111,4 @@ let uid_of_yojson : [ `String of string | `Null ] -> (Uid.t, string) result =
       (match Uid.of_string s with
        | Ok t -> Ok t
        | Error e -> Error e)
-  | `Null -> Error "Expected string for Keeper_id.Uid"
+  | `Null -> Error "Expected non-null string for Keeper_id.Uid (received null)"


### PR DESCRIPTION
## Why

`lib/keeper/keeper_id.ml`의 두 사이트가 expected-only 에러로 received-kind 누락. malformed snapshot 디버깅 시 operator는 무엇이 들어왔는지 추측해야 함 — Iter#13/14/15와 같은 cohort 마무리.

## What

| Line | Site | Before | After |
|---|---|---|---|
| 86 | `Uid.of_json` catch-all | `Expected string for Keeper_id.Uid` | `... (received <kind>)` |
| 99 | `uid_of_yojson` ``Null arm | `Expected string for Keeper_id.Uid` | `Expected non-null string for Keeper_id.Uid (received null)` |

File-private `json_kind_name` — closed total function over 10 `Yojson.Safe.t` variants. L99는 closed poly variant `[ \`String | \`Null ]`이라 ``Null만 reachable — runtime helper 대신 *type-guaranteed fixed wording*이 더 명확.

## Iter#13~#16 cohort 마무리

- Iter#13 PR #16447 — `keeper_runtime_manifest` 6 사이트
- Iter#14 PR #16453 — `keeper_persona_authoring` 2 사이트
- Iter#15 PR #16460 — `lib/types/ids.ml` 6 newtype-ID (Agent/Task/Thread/Turn/Keeper/Credential)
- **Iter#16 PR (this)** — `keeper_id.ml` 2 사이트 ← cohort 마지막

총 16 사이트 across 4 files. 모두 같은 inline `json_kind_name` form. PR #16375 머지 후 single dedup PR로 통합 예정.

## Workaround Rejection Bar self-check

- [x] Counter-as-fix 아님
- [x] String/substring classifier 아님 — closed sum type
- [x] N-of-M 아님 — 2/2 사이트 같은 PR
- [x] Cap/cooldown/dedup/repair 아님
- [x] Test backdoor 아님

## RFC Check

PASS — `lib/keeper/keeper_id.ml`은 newtype id wrapping. credential storage logic 아님.

## Verification

- [x] `ocamlformat --check lib/keeper/keeper_id.ml` PASS (auto)
- [x] `rg 'Expected string for Keeper_id.Uid' test/` = 0 match
- [ ] CI 모니터링

## Note (Iter#15.5 sweep)

본 iter 시작 시 conflict sweep 수행 — 30 open PR 모두 MERGEABLE (CONFLICTING 0). 새 표준 절차 적용 시작.

🤖 /loop cron \`253cc0f6\` Iter#16

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>