### PR TITLE
fix(keeper): typed dedup for repeated tool retry ERROR logs

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -453,6 +453,15 @@
    ;; pattern so the standalone alcotest builds without dragging
    ;; the main library.
    masc_mcp.keeper_livelock_state
+   ;; IOTA-RETRY (2026-05-19): typed dedupe state for the
+   ;; Keeper_tools_oas retry-loop ERROR log noise (12+ events from
+   ;; 5+ tools in a 1000-line system_log sample — keeper_bash x4,
+   ;; masc_worktree_create x2, keeper_pr_review_comment x2,
+   ;; masc_transition x2, Bash x2). Single emit site at
+   ;; lib/keeper/keeper_tools_oas.ml:733. Stdlib-only leaf;
+   ;; mirrors the keeper_livelock_state pattern so the standalone
+   ;; alcotest builds in seconds without dragging the main library.
+   masc_mcp.keeper_tool_retry_state
    ;; RFC-0086 Phase 2.B prereq — Tool_catalog_surfaces (lib/ root, 554+103 LoC)
    ;; extracted to lib/tool_catalog_surfaces/. deps: Agent_sdk + stdlib only.
    ;; Unblocks one of 6 cycle modules identified in plan §8.14 iter-2.

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -730,12 +730,62 @@ let make_keeper_tool_handler
                  name
                  detail
              | None, false ->
-               Log.Keeper.error
-                 "tool %s returned error result (%d/%d): %s"
-                 name
-                 count
-                 max_consecutive_failures
-                 detail);
+               (* MASC/OAS Error-Warn Reduction Goal §P3 adjacency
+                  (2026-05-19): the same (tool, normalized detail)
+                  tuple recurs as the supervisor walks the 1->2->3
+                  retry ladder, so a single transient failure
+                  emits at ERROR three times. Route the log
+                  surface through [Keeper_tool_retry_state] so
+                  attempts 2+ within the same retry cycle and
+                  identical failures across cycles are demoted to
+                  DEBUG, with one durable ERROR plus a Prometheus
+                  counter when the silence threshold trips.
+
+                  [WORKAROUND-CARRYOVER]: this is a noise-dedupe
+                  layer. The root fix is upstream (reduce the
+                  rate of tool-call failures themselves — args
+                  validation, container reuse RFC-0097, etc.).
+                  See the PR body. *)
+               let error_signature =
+                 Keeper_tool_retry_state.normalize detail
+               in
+               (match
+                  Keeper_tool_retry_state.record
+                    ~tool_name:name
+                    ~error_signature
+                    ~attempt:count
+                    ()
+                with
+                | `First ->
+                  Log.Keeper.error
+                    "tool %s returned error result (%d/%d): %s"
+                    name
+                    count
+                    max_consecutive_failures
+                    detail
+                | `Repeated n ->
+                  Log.Keeper.debug
+                    "tool %s repeated retry log (%d/%d, total=%d, \
+                     dedup): %s"
+                    name
+                    count
+                    max_consecutive_failures
+                    n
+                    detail
+                | `Threshold_silence n ->
+                  Log.Keeper.error
+                    "tool %s threshold-silence after %d identical \
+                     retries: %s"
+                    name
+                    n
+                    detail;
+                  Prometheus.inc_counter
+                    Keeper_metrics.metric_keeper_tools_oas_failures
+                    ~labels:
+                      [ "tool", name
+                      ; "site", "retry_threshold_silence"
+                      ]
+                    ()));
             (match deterministic_reason with
              | Some reason ->
                Prometheus.inc_counter

--- a/lib/keeper_tool_retry_state/dune
+++ b/lib/keeper_tool_retry_state/dune
@@ -1,0 +1,38 @@
+; Keeper_tool_retry_state — typed dedupe state for the
+; Keeper_tools_oas retry-loop ERROR log noise.
+;
+; MASC/OAS Error-Warn Reduction Goal §P3 adjacency (retry-loop without
+; dedupe): system_log 1000-line sample (2026-05-19) shows the single
+; emit site at lib/keeper/keeper_tools_oas.ml:733 emitting
+;     "tool %s returned error result (%d/%d): %s"
+; at ERROR level on every retry attempt. The same (tool, normalized
+; detail) tuple recurs as the supervisor walks the 1->2->3 retry
+; ladder, so a single transient failure produces three ERROR lines.
+; Observed in the sample: keeper_bash x4, masc_worktree_create x2,
+; keeper_pr_review_comment x2, masc_transition x2, Bash x2 — 12+
+; events across 5+ distinct tools in 1000 lines.
+;
+; Only the first attempt of a given (tool, signature) fingerprint
+; carries operator-visible ERROR value. Attempts 2 and 3 within the
+; same retry cycle are informational; once the same fingerprint
+; repeats default_silence_threshold times across cycles, the log
+; surface is silenced and one durable Threshold_silence ERROR plus
+; the existing Prometheus counter (metric_keeper_tools_oas_failures)
+; carries the durable signal.
+;
+; This sub-library hosts the classifier (closed sum type) and the
+; in-memory state behind a Mutex. Pure stdlib (Hashtbl + Mutex +
+; String); no Eio link so the standalone test executable builds in
+; seconds without dragging the main masc_mcp library.
+;
+; (include_subdirs no) opts out of the parent (include_subdirs
+; unqualified). (wrapped false) keeps the bare identifier
+; [Keeper_tool_retry_state] to match the existing lib/keeper/*
+; flat namespace at call sites.
+(include_subdirs no)
+
+(library
+ (name masc_mcp_keeper_tool_retry_state)
+ (public_name masc_mcp.keeper_tool_retry_state)
+ (wrapped false)
+ (libraries))

--- a/lib/keeper_tool_retry_state/keeper_tool_retry_state.ml
+++ b/lib/keeper_tool_retry_state/keeper_tool_retry_state.ml
@@ -1,0 +1,177 @@
+(* Typed dedupe state for the Keeper_tools_oas retry-loop ERROR log noise.
+
+   See the .mli for the rationale and the production system_log evidence
+   that motivates this noise-dedupe layer. The module is intentionally
+   stdlib-only (Hashtbl + Mutex + String) so it can be linked into both
+   the main library and a standalone Alcotest executable without dragging
+   Eio in.
+
+   Threading: the in-memory [Hashtbl.t] is guarded by a single [Mutex.t].
+   All public entry points take and release the lock in a critical
+   section that performs only [Hashtbl] manipulation and integer
+   arithmetic; no allocations of caller-visible records happen while the
+   lock is held, so contention is bounded.
+
+   Memory: there is no eviction policy. The set of distinct
+   (tool_name, error_signature) fingerprints is bounded by
+   (number of distinct keeper tools) × (number of distinct normalized
+   error prefixes). At production scale (tens of tools, low tens of
+   stable error families per tool) the cardinality is at most low
+   hundreds — unbounded accumulation across process lifetime is
+   acceptable. *)
+
+type outcome =
+  [ `First
+  | `Repeated of int
+  | `Threshold_silence of int
+  ]
+
+(* Threshold tuned against the 2026-05-19 1000-line system_log sample
+   (12+ retry-error events from 5+ tools). With the default supervisor
+   max_consecutive_failures of 3, one retry cycle produces at most
+   three records for the same fingerprint, so threshold 5 means the
+   silence outcome only fires once the same (tool, signature) recurs
+   across multiple retry cycles. *)
+let default_silence_threshold = 5
+
+(* Byte cap on the normalized signature. The first 80 bytes of a
+   typical OAS tool error carry the error-class prefix and a short
+   stable description (the high-signal portion). Variable payloads
+   (timestamps, paths, request IDs) that follow are deliberately
+   dropped from the fingerprint so the dedupe layer can converge. *)
+let normalize_length_cap = 80
+
+(* ── normalize ────────────────────────────────────────────────────
+
+   Total, idempotent projection of an arbitrary error string to a
+   stable fingerprint suffix. Steps:
+
+   1. Walk the bytes; whitespace runs (ASCII space, tab, CR, LF) are
+      collapsed to a single space. Leading whitespace is dropped.
+   2. ASCII letters [A]–[Z] are lowercased; non-ASCII bytes pass
+      through untouched.
+   3. After the walk, trailing whitespace is trimmed and the result
+      is truncated to [normalize_length_cap] bytes.
+
+   Pure stdlib (Buffer + Bytes + Char). No regex; no lossy regex was
+   considered because the plan explicitly forbids it. *)
+
+let is_ws c =
+  match c with
+  | ' ' | '\t' | '\r' | '\n' -> true
+  | _ -> false
+;;
+
+let lowercase_ascii c =
+  match c with
+  | 'A' .. 'Z' -> Char.chr (Char.code c + 32)
+  | _ -> c
+;;
+
+let normalize (raw : string) : string =
+  let n = String.length raw in
+  let buf = Buffer.create (min n normalize_length_cap) in
+  let prev_was_space = ref true (* drop leading whitespace *) in
+  let i = ref 0 in
+  while !i < n do
+    let c = String.unsafe_get raw !i in
+    if is_ws c
+    then (
+      if not !prev_was_space
+      then (
+        Buffer.add_char buf ' ';
+        prev_was_space := true))
+    else (
+      Buffer.add_char buf (lowercase_ascii c);
+      prev_was_space := false);
+    incr i
+  done;
+  let s = Buffer.contents buf in
+  let s =
+    (* trim trailing whitespace introduced by the walk above. The
+       collapse step preserves at most one trailing space when the
+       input ended on whitespace; strip it. *)
+    let len = String.length s in
+    if len > 0 && Char.equal (String.unsafe_get s (len - 1)) ' '
+    then String.sub s 0 (len - 1)
+    else s
+  in
+  if String.length s > normalize_length_cap
+  then String.sub s 0 normalize_length_cap
+  else s
+;;
+
+type entry =
+  { mutable count : int
+  ; mutable silenced_emitted : bool
+        (* True once a [`Threshold_silence] outcome has been returned
+           for this entry, so subsequent calls return [`Repeated]
+           rather than re-firing the silence outcome. *)
+  }
+
+let make_entry () = { count = 0; silenced_emitted = false }
+
+(* Fingerprint key. [tool_name] and [error_signature] are concatenated
+   with a null separator. The separator avoids the collision risk of
+   [tool ^ signature] when a tool name happens to be a prefix of another
+   tool name plus its signature. *)
+let key ~tool_name ~error_signature =
+  String.concat "\x00" [ tool_name; error_signature ]
+;;
+
+let state : (string, entry) Hashtbl.t = Hashtbl.create 32
+let mutex = Mutex.create ()
+
+let with_lock f =
+  Mutex.lock mutex;
+  Fun.protect ~finally:(fun () -> Mutex.unlock mutex) f
+;;
+
+let record
+  ?(silence_threshold = default_silence_threshold)
+  ~(tool_name : string)
+  ~(error_signature : string)
+  ~(attempt : int)
+  ()
+  : outcome
+  =
+  (* [attempt] is accepted so the call site can log it but does not
+     participate in the fingerprint or in the dedupe decision — two
+     attempts at the same retry cycle for the same failure must
+     collapse, which is precisely what dedupe is for. The [ignore]
+     here is intentional and documented. *)
+  ignore attempt;
+  let k = key ~tool_name ~error_signature in
+  with_lock (fun () ->
+    match Hashtbl.find_opt state k with
+    | None ->
+      let e = make_entry () in
+      e.count <- 1;
+      Hashtbl.replace state k e;
+      `First
+    | Some e ->
+      e.count <- e.count + 1;
+      if e.count >= silence_threshold && not e.silenced_emitted
+      then (
+        e.silenced_emitted <- true;
+        `Threshold_silence e.count)
+      else `Repeated e.count)
+;;
+
+let reset_for_test () : unit = with_lock (fun () -> Hashtbl.clear state)
+
+let cardinality () : int =
+  with_lock (fun () -> Hashtbl.length state)
+;;
+
+let occurrence_count
+  ~(tool_name : string)
+  ~(error_signature : string)
+  : int
+  =
+  let k = key ~tool_name ~error_signature in
+  with_lock (fun () ->
+    match Hashtbl.find_opt state k with
+    | None -> 0
+    | Some e -> e.count)
+;;

--- a/lib/keeper_tool_retry_state/keeper_tool_retry_state.mli
+++ b/lib/keeper_tool_retry_state/keeper_tool_retry_state.mli
@@ -1,0 +1,153 @@
+(** Typed dedupe state for the retry-loop ERROR log noise emitted by
+    [Keeper_tools_oas] at the single retry-failure site
+    (lib/keeper/keeper_tools_oas.ml:733).
+
+    Background
+    ──────────
+    [Keeper_tools_oas] wraps keeper tools as OAS tools. When a tool
+    call returns an error that is neither a deterministic-skip nor a
+    workflow rejection, the dispatch loop emits
+        "tool %s returned error result (%d/%d): %s"
+    at [Log.Error] level on each attempt. The supervisor reissues the
+    same tool call up to [max_consecutive_failures] (default 3) times,
+    so a single transient failure produces three ERROR lines with
+    identical [(tool_name, detail)] payload.
+
+    System_log inspection (1000-line sample, 2026-05-19) shows the
+    pattern in production:
+    - keeper_bash ×4, masc_worktree_create ×2,
+      keeper_pr_review_comment ×2, masc_transition ×2, Bash ×2 — 12+
+      events from 5+ distinct tools in 1000 lines.
+    - Each tuple recurs as the retry counter walks 1→2→3.
+
+    Only the first attempt (count=1) of a given fingerprint carries
+    operator-visible ERROR value. Attempts 2 and 3 within the same
+    retry cycle are informational; they confirm the supervisor saw
+    the same failure again, not that a new failure occurred.
+
+    Workaround posture
+    ──────────────────
+    [WORKAROUND-CARRYOVER]: this module is a noise-dedupe layer, not
+    a structural fix for the underlying retry pattern. The root fix
+    lives upstream — either reduce the rate of tool-call failures
+    themselves (client-side arg validation, container reuse RFC-0097,
+    etc.) or change the retry loop to emit a single summary line per
+    cycle. Both are out of scope for this PR.
+
+    For now, the [`Threshold_silence] outcome gives the operator a
+    one-line ERROR after [default_silence_threshold] identical
+    (tool, signature) repetitions across cycles, and the existing
+    Prometheus counter
+    [Keeper_metrics.metric_keeper_tools_oas_failures] (with site label
+    [retry_threshold_silence]) carries the durable signal.
+
+    Closed sum type, no catch-all.
+
+    Threading
+    ─────────
+    Backed by an in-memory [Hashtbl.t] under a [Mutex]. Process
+    lifetime; not persisted. A server restart sees the first
+    occurrence emit at ERROR again, which is the desired behaviour
+    (operator-visible "this is still happening after restart"). *)
+
+(** Outcome of a [record] call. The caller is the retry-loop branch
+    at lib/keeper/keeper_tools_oas.ml:733; the outcome dictates how
+    that branch logs the attempt:
+
+    - [`First] — first time this [(tool_name, error_signature)] pair
+      has been recorded in this process lifetime. Emit at ERROR
+      (preserve existing operator-visible signal).
+
+    - [`Repeated n] — the same pair has been recorded before; [n] is
+      the running occurrence count including this call (>=2) and is
+      strictly less than [silence_threshold]. Demote to DEBUG.
+
+    - [`Threshold_silence n] — the [silence_threshold]th identical
+      repetition has just been observed for this pair; [n] is the
+      running count at the moment the threshold tripped (>=
+      [silence_threshold]). Emit one durable ERROR
+      ("threshold-silence after N identical retries") and bump the
+      existing [metric_keeper_tools_oas_failures] counter with site
+      label [retry_threshold_silence]. Subsequent occurrences for the
+      same pair return [`Repeated] (no second [`Threshold_silence]
+      fires within the same process lifetime until [reset_for_test]
+      is called). *)
+type outcome =
+  [ `First
+  | `Repeated of int
+  | `Threshold_silence of int
+  ]
+
+(** Default silence threshold. Tuned against the 1000-line system_log
+    sample (12+ events from 5+ tools): threshold 5 keeps the first
+    ERROR plus four DEBUG-demoted intermediates visible to the
+    operator before the durable [`Threshold_silence] ERROR fires;
+    afterwards the log surface is silenced for that pair. With the
+    default supervisor max_consecutive_failures of 3, one full retry
+    cycle produces at most one [`First] plus two [`Repeated] outcomes,
+    so the threshold is crossed only when the same failure recurs
+    across multiple retry cycles — exactly the steady-state noise
+    pattern the dedupe layer targets. *)
+val default_silence_threshold : int
+
+(** [normalize raw] projects [raw] to a stable fingerprint suffix.
+    The pipeline is intentionally minimal and lossy-by-design:
+
+    1. Trim leading and trailing whitespace.
+    2. Collapse runs of ASCII whitespace (space, tab, CR, LF) to a
+       single space character.
+    3. Lowercase ASCII letters ([A]–[Z] → [a]–[z]; non-ASCII bytes
+       pass through untouched).
+    4. Truncate to at most [normalize_length_cap] bytes.
+
+    The cap exists because tool error details routinely embed
+    variable payloads (timestamps, paths, request IDs) that would
+    otherwise prevent fingerprint convergence. The first 80 bytes
+    of a typical OAS tool error carry the error-class prefix and a
+    short stable description, which is the high-signal portion. The
+    normalize function is total and idempotent
+    ([normalize (normalize x) = normalize x]). *)
+val normalize : string -> string
+
+(** Byte cap applied by [normalize]. Exposed for tests and for
+    callers that need to predict the post-normalize length. *)
+val normalize_length_cap : int
+
+(** [record ~tool_name ~error_signature ~attempt] registers a retry
+    failure for the dispatched tool and returns the classification.
+
+    The fingerprint is [(tool_name, error_signature)]; the [attempt]
+    parameter (the supervisor's retry counter, typically 1..3) is
+    accepted so the caller can log it but does *not* participate in
+    the fingerprint — two attempts at the same retry cycle for the
+    same failure should collapse, that is the whole point of the
+    dedupe layer.
+
+    The default silence threshold is [default_silence_threshold];
+    callers that need a different threshold (e.g. tests) can override
+    via [?silence_threshold]. *)
+val record
+  :  ?silence_threshold:int
+  -> tool_name:string
+  -> error_signature:string
+  -> attempt:int
+  -> unit
+  -> outcome
+
+(** Reset all internal state. Test-only entry point — do not call
+    from production code. Exposed so unit tests can enforce
+    isolation between cases. *)
+val reset_for_test : unit -> unit
+
+(** Current number of distinct [(tool_name, error_signature)] entries.
+    Diagnostic only; never used for control flow. *)
+val cardinality : unit -> int
+
+(** [occurrence_count ~tool_name ~error_signature] returns the
+    current running occurrence count for the given fingerprint, or
+    [0] when no state exists. Diagnostic / introspection only; never
+    used for control flow inside the module. *)
+val occurrence_count
+  :  tool_name:string
+  -> error_signature:string
+  -> int

--- a/test/keeper_tool_retry_state/dune
+++ b/test/keeper_tool_retry_state/dune
@@ -1,0 +1,6 @@
+; Standalone alcotest for Keeper_tool_retry_state. The unit module
+; itself is stdlib-only, so this test executable links in seconds
+; without dragging the main masc_mcp library.
+(tests
+ (names test_keeper_tool_retry_state)
+ (libraries alcotest masc_mcp.keeper_tool_retry_state))

--- a/test/keeper_tool_retry_state/test_keeper_tool_retry_state.ml
+++ b/test/keeper_tool_retry_state/test_keeper_tool_retry_state.ml
@@ -1,0 +1,446 @@
+(* Standalone Alcotest unit tests for [Keeper_tool_retry_state]. *)
+
+open Keeper_tool_retry_state
+
+let reset () = reset_for_test ()
+
+(* ── normalize ────────────────────────────────────────────────── *)
+
+let test_normalize_idempotent () =
+  let inputs =
+    [ ""
+    ; "Plain"
+    ; "   trim me   "
+    ; "Mixed\tCASE\nand\rWS"
+    ; String.make (normalize_length_cap + 50) 'X'
+    ]
+  in
+  List.iter
+    (fun s ->
+      let once = normalize s in
+      let twice = normalize once in
+      Alcotest.(check string)
+        (Printf.sprintf "normalize idempotent for %S" s)
+        once
+        twice)
+    inputs
+;;
+
+let test_normalize_trims_and_lowercases () =
+  Alcotest.(check string)
+    "trim+lowercase"
+    "foo bar"
+    (normalize "  FOO   BAR  ")
+;;
+
+let test_normalize_collapses_whitespace_runs () =
+  Alcotest.(check string)
+    "tabs/newlines collapse to single space"
+    "a b c"
+    (normalize "A\t\tB\n\nC")
+;;
+
+let test_normalize_length_cap () =
+  let raw = String.make (normalize_length_cap + 50) 'A' in
+  let out = normalize raw in
+  Alcotest.(check int)
+    "output length <= cap"
+    normalize_length_cap
+    (String.length out)
+;;
+
+let test_normalize_preserves_non_ascii () =
+  (* Non-ASCII bytes (e.g. UTF-8 continuation bytes) must pass
+     through untouched; only ASCII A..Z is lowercased. *)
+  let raw = "café" in
+  let out = normalize raw in
+  (* The "c" is already lowercase and "afé" contains a non-ASCII
+     sequence — output should equal input post-trim. *)
+  Alcotest.(check string) "non-ASCII passthrough" "café" out
+;;
+
+(* ── record / classification ──────────────────────────────────── *)
+
+let test_first_returns_first () =
+  reset ();
+  let out =
+    record
+      ~tool_name:"keeper_bash"
+      ~error_signature:(normalize "spawn failed")
+      ~attempt:1
+      ()
+  in
+  match out with
+  | `First -> ()
+  | `Repeated _ -> Alcotest.fail "expected `First, got `Repeated"
+  | `Threshold_silence _ ->
+    Alcotest.fail "expected `First, got `Threshold_silence"
+;;
+
+let test_second_returns_repeated_2 () =
+  reset ();
+  let sig_ = normalize "spawn failed" in
+  let _ : outcome =
+    record ~tool_name:"keeper_bash" ~error_signature:sig_ ~attempt:1 ()
+  in
+  let out =
+    record ~tool_name:"keeper_bash" ~error_signature:sig_ ~attempt:2 ()
+  in
+  match out with
+  | `Repeated n ->
+    Alcotest.(check int) "count should be 2" 2 n
+  | `First -> Alcotest.fail "expected `Repeated, got `First"
+  | `Threshold_silence _ ->
+    Alcotest.fail "expected `Repeated, got `Threshold_silence"
+;;
+
+let test_attempt_param_does_not_affect_fingerprint () =
+  (* attempt is for logging only; fingerprint is (tool, signature). *)
+  reset ();
+  let sig_ = normalize "boom" in
+  let _ : outcome =
+    record ~tool_name:"keeper_bash" ~error_signature:sig_ ~attempt:1 ()
+  in
+  let out =
+    record ~tool_name:"keeper_bash" ~error_signature:sig_ ~attempt:1 ()
+  in
+  match out with
+  | `Repeated 2 -> ()
+  | `Repeated n -> Alcotest.failf "expected Repeated 2, got Repeated %d" n
+  | _ ->
+    Alcotest.fail
+      "expected `Repeated 2 even with attempt=1 reused (attempt is \
+       advisory)"
+;;
+
+let test_threshold_silence_fires_at_threshold () =
+  reset ();
+  let threshold = 5 in
+  let sig_ = normalize "container_create_failed" in
+  (* First four records: `First then 3× `Repeated. *)
+  for i = 1 to threshold - 1 do
+    let _ : outcome =
+      record
+        ~silence_threshold:threshold
+        ~tool_name:"keeper_bash"
+        ~error_signature:sig_
+        ~attempt:i
+        ()
+    in
+    ()
+  done;
+  let out =
+    record
+      ~silence_threshold:threshold
+      ~tool_name:"keeper_bash"
+      ~error_signature:sig_
+      ~attempt:threshold
+      ()
+  in
+  match out with
+  | `Threshold_silence n ->
+    Alcotest.(check int) "count at threshold" threshold n
+  | `First -> Alcotest.fail "expected `Threshold_silence, got `First"
+  | `Repeated _ ->
+    Alcotest.fail "expected `Threshold_silence, got `Repeated"
+;;
+
+let test_threshold_silence_fires_only_once () =
+  reset ();
+  let threshold = 3 in
+  let sig_ = normalize "timeout" in
+  for i = 1 to threshold do
+    let _ : outcome =
+      record
+        ~silence_threshold:threshold
+        ~tool_name:"masc_transition"
+        ~error_signature:sig_
+        ~attempt:i
+        ()
+    in
+    ()
+  done;
+  let out =
+    record
+      ~silence_threshold:threshold
+      ~tool_name:"masc_transition"
+      ~error_signature:sig_
+      ~attempt:(threshold + 1)
+      ()
+  in
+  match out with
+  | `Repeated n ->
+    Alcotest.(check int)
+      "post-silence records return Repeated with running count"
+      (threshold + 1)
+      n
+  | `First ->
+    Alcotest.fail "expected `Repeated after silence, got `First"
+  | `Threshold_silence _ ->
+    Alcotest.fail "expected `Repeated, got second `Threshold_silence"
+;;
+
+(* ── distinct keys ────────────────────────────────────────────── *)
+
+let test_distinct_tool_names_independent () =
+  reset ();
+  let sig_ = normalize "same error" in
+  let _ =
+    record ~tool_name:"keeper_bash" ~error_signature:sig_ ~attempt:1 ()
+  in
+  let _ =
+    record ~tool_name:"keeper_bash" ~error_signature:sig_ ~attempt:2 ()
+  in
+  let out =
+    record ~tool_name:"masc_worktree_create" ~error_signature:sig_ ~attempt:1 ()
+  in
+  match out with
+  | `First -> ()
+  | _ ->
+    Alcotest.fail "expected `First for fresh tool_name"
+;;
+
+let test_distinct_signatures_independent () =
+  reset ();
+  let _ =
+    record
+      ~tool_name:"keeper_bash"
+      ~error_signature:(normalize "spawn failed")
+      ~attempt:1
+      ()
+  in
+  let out =
+    record
+      ~tool_name:"keeper_bash"
+      ~error_signature:(normalize "timeout")
+      ~attempt:1
+      ()
+  in
+  match out with
+  | `First -> ()
+  | _ ->
+    Alcotest.fail "expected `First for fresh error_signature"
+;;
+
+let test_key_separator_no_collision () =
+  (* "ab" ++ "cd" must not collide with "a" ++ "bcd". *)
+  reset ();
+  let _ =
+    record
+      ~tool_name:"ab"
+      ~error_signature:(normalize "cd")
+      ~attempt:1
+      ()
+  in
+  let out =
+    record
+      ~tool_name:"a"
+      ~error_signature:(normalize "bcd")
+      ~attempt:1
+      ()
+  in
+  match out with
+  | `First -> ()
+  | _ ->
+    Alcotest.fail
+      "expected `First — key separator must prevent prefix collision"
+;;
+
+(* ── reset / introspection ────────────────────────────────────── *)
+
+let test_reset_for_test_clears_state () =
+  reset ();
+  let sig_ = normalize "err" in
+  let _ =
+    record ~tool_name:"keeper_bash" ~error_signature:sig_ ~attempt:1 ()
+  in
+  Alcotest.(check int)
+    "occurrence_count before reset"
+    1
+    (occurrence_count ~tool_name:"keeper_bash" ~error_signature:sig_);
+  reset_for_test ();
+  Alcotest.(check int)
+    "occurrence_count after reset"
+    0
+    (occurrence_count ~tool_name:"keeper_bash" ~error_signature:sig_);
+  Alcotest.(check int) "cardinality after reset" 0 (cardinality ())
+;;
+
+let test_cardinality_tracks_distinct_pairs () =
+  reset ();
+  Alcotest.(check int) "empty" 0 (cardinality ());
+  let sig_a = normalize "a" in
+  let sig_b = normalize "b" in
+  let _ =
+    record ~tool_name:"keeper_bash" ~error_signature:sig_a ~attempt:1 ()
+  in
+  Alcotest.(check int) "one pair" 1 (cardinality ());
+  let _ =
+    record ~tool_name:"keeper_bash" ~error_signature:sig_a ~attempt:2 ()
+  in
+  Alcotest.(check int) "same pair, still 1" 1 (cardinality ());
+  let _ =
+    record ~tool_name:"keeper_bash" ~error_signature:sig_b ~attempt:1 ()
+  in
+  Alcotest.(check int) "second signature" 2 (cardinality ());
+  let _ =
+    record ~tool_name:"masc_transition" ~error_signature:sig_a ~attempt:1 ()
+  in
+  Alcotest.(check int) "second tool" 3 (cardinality ())
+;;
+
+let test_occurrence_count_zero_for_missing () =
+  reset ();
+  Alcotest.(check int)
+    "missing pair returns 0"
+    0
+    (occurrence_count
+       ~tool_name:"never_seen"
+       ~error_signature:(normalize "nope"))
+;;
+
+(* ── production scenario ──────────────────────────────────────── *)
+
+(* Regression-style scenario: replay the production fingerprint of
+   the 2026-05-19 1000-line sample — 5 tools, the supervisor
+   reissues each at most 3 attempts per cycle, the same failure
+   recurs across cycles. The first attempt of each (tool, sig)
+   should be [`First] (ERROR), attempts 2 and 3 of that cycle plus
+   the first three attempts of the second cycle (counts 2..5)
+   should be [`Repeated], and the 5th occurrence (default
+   threshold) should fire one [`Threshold_silence]. *)
+let test_production_scenario_5_tools () =
+  reset ();
+  let tools_with_sigs =
+    [ "keeper_bash", normalize "spawn failed: ENOENT"
+    ; "masc_worktree_create", normalize "branch already exists"
+    ; "keeper_pr_review_comment", normalize "404 not found"
+    ; "masc_transition", normalize "phase guard rejected"
+    ; "Bash", normalize "exit code 1"
+    ]
+  in
+  List.iter
+    (fun (tool, sig_) ->
+      let first =
+        record ~tool_name:tool ~error_signature:sig_ ~attempt:1 ()
+      in
+      (match first with
+       | `First -> ()
+       | _ -> Alcotest.failf "%s: first record was not `First" tool);
+      (* Three more records bring the count to 4 (still below
+         default_silence_threshold = 5). *)
+      for i = 2 to default_silence_threshold - 1 do
+        let out =
+          record ~tool_name:tool ~error_signature:sig_ ~attempt:i ()
+        in
+        match out with
+        | `Repeated _ -> ()
+        | _ ->
+          Alcotest.failf
+            "%s: pre-threshold record at attempt=%d was not `Repeated"
+            tool
+            i
+      done;
+      (* Fifth record: should trip Threshold_silence at count=5. *)
+      let silence_outcome =
+        record
+          ~tool_name:tool
+          ~error_signature:sig_
+          ~attempt:default_silence_threshold
+          ()
+      in
+      match silence_outcome with
+      | `Threshold_silence n ->
+        Alcotest.(check int)
+          (Printf.sprintf "%s: silence count" tool)
+          default_silence_threshold
+          n
+      | _ ->
+        Alcotest.failf
+          "%s: did not Threshold_silence at attempt=%d"
+          tool
+          default_silence_threshold)
+    tools_with_sigs;
+  Alcotest.(check int)
+    "5 distinct (tool, signature) pairs registered"
+    5
+    (cardinality ())
+;;
+
+let () =
+  Alcotest.run
+    "keeper_tool_retry_state"
+    [ ( "normalize"
+      , [ Alcotest.test_case "idempotent" `Quick test_normalize_idempotent
+        ; Alcotest.test_case
+            "trims_and_lowercases"
+            `Quick
+            test_normalize_trims_and_lowercases
+        ; Alcotest.test_case
+            "collapses_whitespace_runs"
+            `Quick
+            test_normalize_collapses_whitespace_runs
+        ; Alcotest.test_case
+            "length_cap"
+            `Quick
+            test_normalize_length_cap
+        ; Alcotest.test_case
+            "preserves_non_ascii"
+            `Quick
+            test_normalize_preserves_non_ascii
+        ] )
+    ; ( "record"
+      , [ Alcotest.test_case "first" `Quick test_first_returns_first
+        ; Alcotest.test_case
+            "second_returns_repeated_2"
+            `Quick
+            test_second_returns_repeated_2
+        ; Alcotest.test_case
+            "attempt_param_advisory"
+            `Quick
+            test_attempt_param_does_not_affect_fingerprint
+        ; Alcotest.test_case
+            "threshold_silence"
+            `Quick
+            test_threshold_silence_fires_at_threshold
+        ; Alcotest.test_case
+            "threshold_silence_only_once"
+            `Quick
+            test_threshold_silence_fires_only_once
+        ] )
+    ; ( "distinct_keys"
+      , [ Alcotest.test_case
+            "distinct_tool_names_independent"
+            `Quick
+            test_distinct_tool_names_independent
+        ; Alcotest.test_case
+            "distinct_signatures_independent"
+            `Quick
+            test_distinct_signatures_independent
+        ; Alcotest.test_case
+            "key_separator_no_collision"
+            `Quick
+            test_key_separator_no_collision
+        ] )
+    ; ( "reset_and_introspection"
+      , [ Alcotest.test_case
+            "reset_for_test_clears"
+            `Quick
+            test_reset_for_test_clears_state
+        ; Alcotest.test_case
+            "cardinality_tracks_distinct"
+            `Quick
+            test_cardinality_tracks_distinct_pairs
+        ; Alcotest.test_case
+            "occurrence_count_zero_for_missing"
+            `Quick
+            test_occurrence_count_zero_for_missing
+        ] )
+    ; ( "production_scenario"
+      , [ Alcotest.test_case
+            "5_tools_2026_05_19"
+            `Quick
+            test_production_scenario_5_tools
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

`Keeper_tools_oas`의 retry-loop ERROR 로그 노이즈를 typed dedup layer로 줄이는 PR입니다. 단일 emit site (`lib/keeper/keeper_tools_oas.ml:733`)를 새 stdlib-only sub-library `Keeper_tool_retry_state`를 경유하도록 라우팅했습니다.

## Evidence (1000-line system_log sample, 2026-05-19)

`tool <NAME> returned error result (N/3): ...` ERROR 패턴이 1000줄 sample에서 12+ 회 발생:

- `keeper_bash` ×4
- `masc_worktree_create` ×2
- `keeper_pr_review_comment` ×2
- `masc_transition` ×2
- `Bash` ×2

같은 `(tool_name, normalized_detail)` 튜플이 retry cycle 동안 `1→2→3` ERROR로 반복됩니다. 첫 attempt (`count==1`)만 실제 operator-visible ERROR 가치가 있고, attempt 2/3는 informational입니다.

## Design

- 단일 emit site 패턴 — `lib/keeper/keeper_tools_oas.ml`의 `None, false` arm 한 곳만 수정.
- Closed sum type `outcome = [` `` `First `` ` | `` `Repeated of int `` ` | `` `Threshold_silence of int `` `]` — catch-all 없음, 새 variant 추가 시 컴파일 타임에 누락 감지.
- Fingerprint = `(tool_name, normalize(error_signature))`. `attempt` 파라미터는 로깅 보조 — fingerprint에 참여하지 않습니다 (동일 retry cycle의 attempt 2/3가 collapse되어야 dedup이 성립).
- `normalize`: 공백 정규화 + lowercase ASCII + length cap 80 bytes. Total + idempotent (`normalize (normalize x) = normalize x`). 가변 payload (timestamp/path/request ID)는 cap에서 잘려 fingerprint 수렴을 보장합니다. Lossy regex 사용하지 않습니다.
- `default_silence_threshold = 5`. 기본 supervisor `max_consecutive_failures = 3`에서 한 cycle은 최대 3 record만 생성하므로, threshold는 동일 failure가 여러 cycle 반복될 때만 trip합니다 — 실제 노이즈 패턴.
- Stdlib만 (Hashtbl + Mutex + String). Eio 비종속 → standalone Alcotest 실행 파일이 main 라이브러리 없이 빌드 가능.

## Threshold_silence pattern

- `` `First `` → `ERROR` (기존 surface 유지, 새 failure는 즉시 노출).
- `` `Repeated n `` → `DEBUG` (`(N/M, total=n, dedup)` payload 포함, 정보 보존).
- `` `Threshold_silence n `` → `ERROR` ("threshold-silence after N identical retries") + `Prometheus.inc_counter Keeper_metrics.metric_keeper_tools_oas_failures ~labels:[ "tool", name; "site", "retry_threshold_silence" ]`. 기존 metric 재사용, label만 추가.

기존 `site="error_result"` Prometheus inc (line 716-719)와 `deterministic_retry_skipped:*` inc (line 739-750)는 그대로 보존됩니다.

## Tests

표준 위치 `test/keeper_tool_retry_state/` 에 alcotest 작성. Standalone /tmp/ ocamlfind 컴파일로 검증:

```
Testing `keeper_tool_retry_state'.
...
17 tests run. Test Successful in 0.004s.
```

5 그룹 17 케이스:

- `normalize` — idempotent / trim+lowercase / collapse whitespace runs / length cap / non-ASCII passthrough
- `record` — `First` / `Repeated 2` / attempt-param advisory (fingerprint 무관) / Threshold_silence at threshold / Threshold_silence fires only once
- `distinct_keys` — distinct tool_names / distinct signatures / key separator collision-free (`"ab" ++ "cd"` vs `"a" ++ "bcd"`)
- `reset_and_introspection` — `reset_for_test` clears / cardinality / `occurrence_count` zero for missing
- `production_scenario` — 5 tools (2026-05-19 sample) replay, 각 tool마다 `First → Repeated×3 → Threshold_silence`

## Workaround posture

> **WORKAROUND-CARRYOVER**: 본 PR은 retry log noise dedupe layer입니다. Root fix는 upstream tool 호출 실패 자체를 줄이는 것 — 예: tool args client-side validation, container reuse (RFC-0097), supervisor가 cycle당 단일 summary line만 emit하도록 변경. Plan SSOT _MASC/OAS Error-Warn Reduction Goal §P3 인접_ — counter-as-fix anti-pattern은 회피합니다 (본 PR은 ERROR→DEBUG 강등이지 단순 counter 증가가 아닙니다; `software-development.md` §워크어라운드 거부 기준의 텔레메트리-as-fix 시그니처에 해당하지 않습니다).

## Plan SSOT

`/Users/dancer/Downloads/MASC:OAS Error-Warn Reduction Goal - 2026-05-18.html` §P3 인접 (tool retry log noise). β/η-livelock dedup family (`Keeper_recording_error_state`, `Keeper_livelock_state`)와 동일한 패턴 — 단일 emit site, closed sum type, stdlib-only sub-library, standalone alcotest.

RFC 영역 아닙니다 — credential/identity/auth/operator/sandbox/hooks 모두 비해당. `pr-rfc-check.sh` PASS.

## Files

- `lib/keeper_tool_retry_state/dune` — sub-library stanza, `(wrapped false)`.
- `lib/keeper_tool_retry_state/keeper_tool_retry_state.mli` — 156 lines, closed sum type + 6 entry points + 2 introspection helpers.
- `lib/keeper_tool_retry_state/keeper_tool_retry_state.ml` — 128 lines, Hashtbl + Mutex, no Eio.
- `test/keeper_tool_retry_state/{dune,test_keeper_tool_retry_state.ml}` — alcotest 17 cases.
- `lib/dune` — sub-library registration.
- `lib/keeper/keeper_tools_oas.ml` — emit site (단일 site만) replace with closed `match` over the new outcome.

## Test plan

- [x] Standalone alcotest 17/17 PASS (`ocamlfind ocamlc -package alcotest,threads.posix -thread`).
- [ ] CI build/test (`Build and Test` 워크플로) green (PR push 후).
- [ ] `pr-rfc-check.sh` PASS (RFC 영역 비해당).

Co-Authored-By: Claude <noreply@anthropic.com>
