### PR TITLE
refactor: split keeper supervisor self preservation

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -221,6 +221,7 @@
   keeper_supervisor_alive_but_stuck
   keeper_supervisor_liveness_recovery
   keeper_supervisor_restart_noop
+  keeper_supervisor_self_preservation
   ;; keeper_event_queue: promoted to lib/keeper_event_queue/ sub-library
   ;; (RFC-0056 Phase 1I) — listed in (libraries) below.
   keeper_relevance_check

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -12,7 +12,6 @@
 
 open Keeper_types
 open Keeper_execution
-module StringMap = Map.Make (String)
 module Startup_helpers = Keeper_supervisor_startup_helpers
 
 (* ── Pure helpers ────────────────────────────────────────── *)
@@ -972,36 +971,11 @@ let cleanup_dead_tombstone (ctx : _ context) (entry : Keeper_registry.registry_e
    persists, the keeper crashes again, lands back in the next
    sweep's [to_restart] with the same cohort, and the counter
    resumes. *)
-type sp_escape_state =
-  { mutable last_dominant_cohort : string
-  ; mutable consecutive_suppressions : int
-  }
-
-let sp_escape_state = { last_dominant_cohort = ""; consecutive_suppressions = 0 }
-
-(** Probe cadence.  10 sweeps × default 30s sweep interval = 5
-    minute probe — long enough that genuine systemic issues aren't
-    probed back into life every cycle, short enough that a transient
-    cohort clears within 1-2 probes once the root condition is fixed.
-    Code constant rather than env knob per
-    [feedback_no-hyperparameter-as-env-knob] — this is calibration,
-    not operator policy. *)
-let probe_after_n_suppressions = 10
-
-(** Bounded minority exception for partial stale recovery.
-
-    The live regression was 6/17 keepers: enough to trip the global
-    self-preservation ratio gate, but not a fleet-wide provider/cascade
-    storm.  Keep this below a majority so large-but-not-universal stale
-    cohorts still go through the circuit breaker/probe path. *)
-let partial_stale_recovery_max_ratio = 0.50
-
 (** Reset the escape-valve state.  Test-only; production code never
     needs to call this (state cycles through the [last_dominant_cohort]
     inequality branch naturally). *)
 let reset_self_preservation_escape_state_for_test () =
-  sp_escape_state.last_dominant_cohort <- "";
-  sp_escape_state.consecutive_suppressions <- 0
+  Keeper_supervisor_self_preservation.reset_for_test ()
 ;;
 
 
@@ -1013,166 +987,11 @@ let reset_self_preservation_escape_state_for_test () =
     #10887: emits a probe restart every [probe_after_n_suppressions]
     consecutive suppressions of the same cohort. *)
 let apply_self_preservation ~keepers_dir ~total_keepers to_restart =
-  let sp_ratio = Env_config.KeeperSupervisor.self_preservation_ratio in
-  let sp_min = Env_config.KeeperSupervisor.self_preservation_min_candidates in
-  let n_candidates = List.length to_restart in
-  let n_total = max 1 total_keepers in
-  let ratio = float_of_int n_candidates /. float_of_int n_total in
-  if ratio > sp_ratio && n_candidates >= sp_min
-  then (
-    (* Group by failure_reason ADT variant (not string prefix) *)
-    let insert_cohort acc (entry : Keeper_registry.registry_entry) _msg =
-      let key = cohort_key_of_reason entry.last_failure_reason in
-      let prev = StringMap.find_opt key acc |> Option.value ~default:[] in
-      StringMap.add key ((entry, _msg) :: prev) acc
-    in
-    let cohorts =
-      List.fold_left
-        (fun acc ((e, m) : _ * string) -> insert_cohort acc e m)
-        StringMap.empty
-        to_restart
-    in
-    let dominant_key, dominant_entries =
-      StringMap.fold
-        (fun k v (best_k, best_v) ->
-           if List.length v > List.length best_v then k, v else best_k, best_v)
-        cohorts
-        ("", [])
-    in
-    if List.length dominant_entries >= sp_min
-    then (
-      let dominant_count = List.length dominant_entries in
-      let dominant_ratio = float_of_int dominant_count /. float_of_int n_total in
-      if
-        String.equal dominant_key stale_turn_timeout_cohort_key
-        && dominant_ratio <= partial_stale_recovery_max_ratio
-      then (
-        reset_self_preservation_escape_state_for_test ();
-        Log.Keeper.warn
-          "self-preservation: allowing partial stale_turn_timeout recovery cohort \
-           through (dominant=%d/%d ratio_dominant=%.2f, overall_candidates=%d/%d \
-           ratio_overall=%.2f)"
-          dominant_count
-          n_total
-          dominant_ratio
-          n_candidates
-          n_total
-          ratio;
-        to_restart)
-      else (
-        (* #10887: track consecutive suppressions of the same dominant
-         cohort.  Different cohort -> counter resets to 1; same
-         cohort -> counter increments. *)
-        if String.equal sp_escape_state.last_dominant_cohort dominant_key
-        then
-          sp_escape_state.consecutive_suppressions
-          <- sp_escape_state.consecutive_suppressions + 1
-        else (
-          sp_escape_state.last_dominant_cohort <- dominant_key;
-          sp_escape_state.consecutive_suppressions <- 1);
-        let probe_due =
-          sp_escape_state.consecutive_suppressions >= probe_after_n_suppressions
-        in
-        let probe_entry =
-          if probe_due
-          then (
-            match dominant_entries with
-            | (e, _) :: _ -> Some e.Keeper_registry.name
-            | [] -> None)
-          else None
-        in
-        let suppressed_names =
-          List.filter_map
-            (fun ((e : Keeper_registry.registry_entry), _) ->
-               match probe_entry with
-               | Some probe_name when String.equal e.name probe_name -> None
-               | _ -> Some e.name)
-            dominant_entries
-        in
-        let suppressed_count = List.length suppressed_names in
-        (match probe_entry with
-         | Some probe_name ->
-           (* Probe valve fires — positive signal, fleet is attempting
-              auto-recovery.  WARN regardless of ratio. *)
-           Log.Keeper.warn
-             "self-preservation probe: allowing %s through after %d consecutive \
-              same-cohort suppressions (ratio=%.2f, cohort=%s)"
-             probe_name
-             sp_escape_state.consecutive_suppressions
-             ratio
-             dominant_key;
-           (* Reset the counter so the next probe is also
-              [probe_after_n_suppressions] sweeps away. *)
-           sp_escape_state.consecutive_suppressions <- 0
-         | None ->
-           (* #10945 + #10887: split universal (ratio>=0.99) vs partial
-              suppression.  Universal = entire fleet sharing one
-              cohort = auto-recovery is structurally OFF — log ERROR
-              with operator-actionable hint.  Partial = circuit
-              breaker working as designed = WARN.  Both lines carry
-              [streak=N] so dashboards can show how close the next
-              probe valve is. *)
-           if ratio >= 0.99
-           then (
-             Prometheus.inc_counter
-               Keeper_metrics.metric_keeper_self_preservation_universal
-               ~labels:[ "cohort", dominant_key ]
-               ();
-             Log.Keeper.error
-               "self-preservation: UNIVERSAL suppression %d/%d (ratio=%.2f, cohort=%s, \
-                streak=%d) — auto-recovery is OFF until operator clears the shared \
-                failure mode (e.g. cascade.toml hot-reload, token rotation, or kill the \
-                dominant cohort to let SP release).  Probe valve will allow one keeper \
-                through after %d consecutive suppressions.  See #10887 / #10765."
-               suppressed_count
-               n_total
-               ratio
-               dominant_key
-               sp_escape_state.consecutive_suppressions
-               probe_after_n_suppressions)
-           else
-             Log.Keeper.warn
-               "self-preservation: suppressing %d/%d restarts (ratio=%.2f, cohort=%s, \
-                streak=%d)"
-               suppressed_count
-               n_total
-               ratio
-               dominant_key
-               sp_escape_state.consecutive_suppressions);
-        publish_lifecycle
-          ~event:
-            (Keeper_lifecycle_events.Custom_event
-               { verb = Keeper_lifecycle_events.Self_preservation; phase = None })
-          "supervisor"
-          (Printf.sprintf
-             "%d/%d suppressed, cohort=%s%s"
-             suppressed_count
-             n_total
-             dominant_key
-             (match probe_entry with
-              | Some name -> Printf.sprintf ", probe=%s" name
-              | None -> ""))
-          ();
-        Keeper_crash_persistence.enqueue_sp_event
-          ~keepers_dir
-          ~ts:(Time_compat.now ())
-          ~suppressed_count
-          ~total:n_total
-          ~ratio
-          ~dominant_cohort:dominant_key;
-        List.filter
-          (fun ((e : Keeper_registry.registry_entry), _) ->
-             not (List.mem e.name suppressed_names))
-          to_restart))
-    else (
-      (* Dominant cohort below sp_min — no suppression this cycle,
-         so the streak no longer applies to this cohort. *)
-      reset_self_preservation_escape_state_for_test ();
-      to_restart))
-  else (
-    (* No suppression: streak resets. *)
-    reset_self_preservation_escape_state_for_test ();
-    to_restart)
+  Keeper_supervisor_self_preservation.apply
+    ~keepers_dir
+    ~publish_lifecycle
+    ~total_keepers
+    to_restart
 ;;
 
 

--- a/lib/keeper/keeper_supervisor_self_preservation.ml
+++ b/lib/keeper/keeper_supervisor_self_preservation.ml
@@ -1,0 +1,195 @@
+(** See [keeper_supervisor_self_preservation.mli] for the contract. *)
+
+module StringMap = Map.Make (String)
+
+type escape_state =
+  { mutable last_dominant_cohort : string
+  ; mutable consecutive_suppressions : int
+  }
+
+let escape_state = { last_dominant_cohort = ""; consecutive_suppressions = 0 }
+
+(* 10 sweeps times the default 30s sweep interval gives a 5 minute probe cadence:
+   long enough to avoid probing persistent systemic failures every cycle, short
+   enough for transient cohorts to clear once the root condition is fixed. *)
+let probe_after_n_suppressions = 10
+
+(* Keep this below a majority so large-but-not-universal stale cohorts still use
+   the circuit breaker/probe path. *)
+let partial_stale_recovery_max_ratio = 0.50
+
+let reset_for_test () =
+  escape_state.last_dominant_cohort <- "";
+  escape_state.consecutive_suppressions <- 0
+;;
+
+let group_by_failure_cohort to_restart =
+  let insert_cohort acc (entry : Keeper_registry.registry_entry) msg =
+    let key = Keeper_supervisor_types.cohort_key_of_reason entry.last_failure_reason in
+    let prev = StringMap.find_opt key acc |> Option.value ~default:[] in
+    StringMap.add key ((entry, msg) :: prev) acc
+  in
+  List.fold_left
+    (fun acc ((entry, msg) : _ * string) -> insert_cohort acc entry msg)
+    StringMap.empty
+    to_restart
+;;
+
+let dominant_cohort cohorts =
+  StringMap.fold
+    (fun k v (best_k, best_v) ->
+       if List.length v > List.length best_v then k, v else best_k, best_v)
+    cohorts
+    ("", [])
+;;
+
+let update_suppression_streak dominant_key =
+  if String.equal escape_state.last_dominant_cohort dominant_key
+  then
+    escape_state.consecutive_suppressions
+    <- escape_state.consecutive_suppressions + 1
+  else (
+    escape_state.last_dominant_cohort <- dominant_key;
+    escape_state.consecutive_suppressions <- 1)
+;;
+
+let publish_suppression
+      ~publish_lifecycle
+      ~suppressed_count
+      ~n_total
+      ~dominant_key
+      ~probe_entry
+  =
+  publish_lifecycle
+    ~event:
+      (Keeper_lifecycle_events.Custom_event
+         { verb = Keeper_lifecycle_events.Self_preservation; phase = None })
+    "supervisor"
+    (Printf.sprintf
+       "%d/%d suppressed, cohort=%s%s"
+       suppressed_count
+       n_total
+       dominant_key
+       (match probe_entry with
+        | Some name -> Printf.sprintf ", probe=%s" name
+        | None -> ""))
+    ()
+;;
+
+let log_suppression ~ratio ~n_total ~dominant_key ~suppressed_count =
+  if ratio >= 0.99
+  then (
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_self_preservation_universal
+      ~labels:[ "cohort", dominant_key ]
+      ();
+    Log.Keeper.error
+      "self-preservation: UNIVERSAL suppression %d/%d (ratio=%.2f, cohort=%s, \
+       streak=%d) -- auto-recovery is OFF until operator clears the shared failure \
+       mode. Probe valve will allow one keeper through after %d consecutive \
+       suppressions. See #10887 / #10765."
+      suppressed_count
+      n_total
+      ratio
+      dominant_key
+      escape_state.consecutive_suppressions
+      probe_after_n_suppressions)
+  else
+    Log.Keeper.warn
+      "self-preservation: suppressing %d/%d restarts (ratio=%.2f, cohort=%s, \
+       streak=%d)"
+      suppressed_count
+      n_total
+      ratio
+      dominant_key
+      escape_state.consecutive_suppressions
+;;
+
+let apply ~keepers_dir ~publish_lifecycle ~total_keepers to_restart =
+  let sp_ratio = Env_config.KeeperSupervisor.self_preservation_ratio in
+  let sp_min = Env_config.KeeperSupervisor.self_preservation_min_candidates in
+  let n_candidates = List.length to_restart in
+  let n_total = max 1 total_keepers in
+  let ratio = float_of_int n_candidates /. float_of_int n_total in
+  if ratio > sp_ratio && n_candidates >= sp_min
+  then (
+    let dominant_key, dominant_entries =
+      to_restart |> group_by_failure_cohort |> dominant_cohort
+    in
+    if List.length dominant_entries >= sp_min
+    then (
+      let dominant_count = List.length dominant_entries in
+      let dominant_ratio = float_of_int dominant_count /. float_of_int n_total in
+      if
+        String.equal dominant_key Keeper_supervisor_types.stale_turn_timeout_cohort_key
+        && dominant_ratio <= partial_stale_recovery_max_ratio
+      then (
+        reset_for_test ();
+        Log.Keeper.warn
+          "self-preservation: allowing partial stale_turn_timeout recovery cohort \
+           through (dominant=%d/%d ratio_dominant=%.2f, overall_candidates=%d/%d \
+           ratio_overall=%.2f)"
+          dominant_count
+          n_total
+          dominant_ratio
+          n_candidates
+          n_total
+          ratio;
+        to_restart)
+      else (
+        update_suppression_streak dominant_key;
+        let probe_due =
+          escape_state.consecutive_suppressions >= probe_after_n_suppressions
+        in
+        let probe_entry =
+          if probe_due
+          then (
+            match dominant_entries with
+            | (entry, _) :: _ -> Some entry.Keeper_registry.name
+            | [] -> None)
+          else None
+        in
+        let suppressed_names =
+          List.filter_map
+            (fun ((entry : Keeper_registry.registry_entry), _) ->
+               match probe_entry with
+               | Some probe_name when String.equal entry.name probe_name -> None
+               | _ -> Some entry.name)
+            dominant_entries
+        in
+        let suppressed_count = List.length suppressed_names in
+        (match probe_entry with
+         | Some probe_name ->
+           Log.Keeper.warn
+             "self-preservation probe: allowing %s through after %d consecutive \
+              same-cohort suppressions (ratio=%.2f, cohort=%s)"
+             probe_name
+             escape_state.consecutive_suppressions
+             ratio
+             dominant_key;
+           escape_state.consecutive_suppressions <- 0
+         | None -> log_suppression ~ratio ~n_total ~dominant_key ~suppressed_count);
+        publish_suppression
+          ~publish_lifecycle
+          ~suppressed_count
+          ~n_total
+          ~dominant_key
+          ~probe_entry;
+        Keeper_crash_persistence.enqueue_sp_event
+          ~keepers_dir
+          ~ts:(Time_compat.now ())
+          ~suppressed_count
+          ~total:n_total
+          ~ratio
+          ~dominant_cohort:dominant_key;
+        List.filter
+          (fun ((entry : Keeper_registry.registry_entry), _) ->
+             not (List.mem entry.name suppressed_names))
+          to_restart))
+    else (
+      reset_for_test ();
+      to_restart))
+  else (
+    reset_for_test ();
+    to_restart)
+;;

--- a/lib/keeper/keeper_supervisor_self_preservation.mli
+++ b/lib/keeper/keeper_supervisor_self_preservation.mli
@@ -1,0 +1,11 @@
+(** Self-preservation restart filter for keeper supervisor. *)
+
+val reset_for_test : unit -> unit
+
+val apply
+  :  keepers_dir:string
+  -> publish_lifecycle:
+       (event:Keeper_lifecycle_events.lifecycle_event -> string -> string -> unit -> unit)
+  -> total_keepers:int
+  -> (Keeper_registry.registry_entry * string) list
+  -> (Keeper_registry.registry_entry * string) list


### PR DESCRIPTION
## Summary

- split keeper supervisor self-preservation restart filtering into `Keeper_supervisor_self_preservation`
- keep the existing public `Keeper_supervisor.apply_self_preservation` and test reset hook as wrappers
- register the new private module in `lib/dune`

## Godfile delta

- `lib/keeper/keeper_supervisor.ml`: 2006 -> 1825 lines
- New module:
  - `lib/keeper/keeper_supervisor_self_preservation.ml`: 195 lines
  - `lib/keeper/keeper_supervisor_self_preservation.mli`: 11 lines

## Validation

- `ocamlformat --check lib/keeper/keeper_supervisor.ml lib/keeper/keeper_supervisor_self_preservation.ml lib/keeper/keeper_supervisor_self_preservation.mli`
- `git diff --check`
- `scripts/ocaml-structure-ratchet.sh`
- `bash scripts/lint/godfile-size-regression.sh`
- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_supervisor.exe test/test_heartbeat_integration.exe`
- `./_build/default/test/test_keeper_supervisor.exe` (77 tests)
- `./_build/default/test/test_heartbeat_integration.exe` (21 tests)
