### PR TITLE
feat(types): received-kind in tempo_mode / A2A / portal state errors

### DIFF
--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -3,6 +3,18 @@
 (* Newtypes are in ids.ml *)
 include Ids
 
+let json_kind_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "intlit"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+
 (* ============================================ *)
 (* Timestamp utilities                          *)
 (* ============================================ *)
@@ -712,7 +724,10 @@ let tempo_mode_to_yojson mode = `String (tempo_mode_to_string mode)
 
 let tempo_mode_of_yojson = function
   | `String s -> tempo_mode_of_string s
-  | _ -> Error "Expected string for tempo_mode"
+  | other ->
+    Error
+      (Printf.sprintf "Expected string for tempo_mode (received %s)"
+         (json_kind_name other))
 
 (** Tempo configuration *)
 type tempo_config = {
@@ -822,7 +837,10 @@ let a2a_task_status_to_yojson s = `String (a2a_task_status_to_string s)
 
 let a2a_task_status_of_yojson = function
   | `String s -> a2a_task_status_of_string s
-  | _ -> Error "Expected string for A2A task status"
+  | other ->
+    Error
+      (Printf.sprintf "Expected string for A2A task status (received %s)"
+         (json_kind_name other))
 
 (** Portal status - enforced at compile time *)
 type portal_state =
@@ -843,7 +861,10 @@ let portal_state_to_yojson s = `String (portal_state_to_string s)
 
 let portal_state_of_yojson = function
   | `String s -> portal_state_of_string s
-  | _ -> Error "Expected string for portal state"
+  | other ->
+    Error
+      (Printf.sprintf "Expected string for portal state (received %s)"
+         (json_kind_name other))
 
 (** A2A Task - Google A2A Protocol task object *)
 type a2a_task = {


### PR DESCRIPTION
## Why

`lib/types/types_core.ml`의 3 enum-style `of_yojson` 사이트가 같은 catch-all 안티패턴으로 received-kind 누락. systemic sweep (`rg '_ -> Error "Expected'`) 으로 발견된 cohort.

## What

3 사이트 enrich, 모두 같은 `(received <kind>)` 패턴:

| Line | Enum | Before | After |
|---|---|---|---|
| 715 | `tempo_mode_of_yojson` | `Expected string for tempo_mode` | `... (received <kind>)` |
| 825 | `a2a_task_status_of_yojson` | `Expected string for A2A task status` | `... (received <kind>)` |
| 846 | `portal_state_of_yojson` | `Expected string for portal state` | `... (received <kind>)` |

File-private `json_kind_name` — closed total function over 10 `Yojson.Safe.t` variants. `include Ids` 라인 직후에 배치 (#16460의 ids.ml helper와 자연스러운 후속).

## Cohort closure

3/3 enum 같은 PR — N-of-M 잔존 0. Iter#15 ids.ml (6 IDs) cohort 패턴 재현.

## Iter#13~#17 series

- Iter#13 PR #16447 — `keeper_runtime_manifest` 6 사이트
- Iter#14 PR #16453 — `keeper_persona_authoring` 2 사이트
- Iter#15 PR #16460 — `lib/types/ids.ml` 6 newtype-ID
- Iter#16 PR #16467 — `keeper_id.ml` 2 사이트
- **Iter#17 (this)** — `types_core.ml` 3 enums

5-PR series = **19 사이트 across 5 files**, 같은 inline form. PR #16375 + #16460 머지 후 single dedup PR로 통합.

## Workaround Rejection Bar self-check

- [x] Counter-as-fix 아님
- [x] String/substring classifier 아님 — closed sum type
- [x] N-of-M 아님 — 3/3 cohort closure
- [x] Cap/cooldown/dedup/repair 아님
- [x] Test backdoor 아님

## RFC Check

PASS — types_core.ml은 domain model. credential storage 아님.

## Verification

- [x] `ocamlformat --check lib/types/types_core.ml` PASS (auto)
- [x] `rg 'Expected string for (tempo_mode|A2A task status|portal state)' test/` = 0 match
- [ ] CI 모니터링

## Iter#15.5 sweep

본 iter 시작 시 30 PR sweep PASS (CONFLICTING 0).

🤖 /loop cron \`253cc0f6\` Iter#17

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>