### PR TITLE
fix(keeper): preserve direct message verification signals

### DIFF
--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -104,28 +104,12 @@ let update_direct_turn_meta (meta : keeper_meta) ~(latency_ms : int)
     ~total_cost_usd:updated_meta.runtime.usage.total_cost_usd;
   updated_meta
 
-let direct_turn_observation (meta : keeper_meta) :
+let direct_turn_observation ~(config : Coord.config) (meta : keeper_meta) :
     Keeper_world_observation.world_observation =
-  {
-    pending_mentions = [];
-    pending_board_events = [];
-    pending_scope_messages = [];
-    message_cursor_updates = [];
-    idle_seconds = 0;
-    active_goals = meta.active_goal_ids;
-    continuity_summary = meta.continuity_summary;
-    worktree_change_summary = None;
-    context_ratio = 0.0;
-    economic_pressure = Agent_economy.Normal;
-    unclaimed_task_count = 0;
-    claimable_task_count = 0;
-    failed_task_count = 0;
-    pending_verification_count = 0;
-    backlog_updated_since_last_scheduled_autonomous = false;
-    active_agent_count = 0;
-    last_turn_budget = None;
-    work_discovery_due = false;
-  }
+  Keeper_world_observation.observe_direct_keeper_msg
+    ~allowed_tool_names:None
+    ~config
+    ~meta
 
 let resolve_turn_cascade_name (meta : keeper_meta) =
   let raw_name = String.trim (Keeper_types.cascade_name_of_meta meta) in
@@ -498,6 +482,12 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
             in
             Progress.Tracker.step turn_tracker
               ~message:(Printf.sprintf "Executing Agent.run for %s" name) ();
+            let world_observation = direct_turn_observation ~config:ctx.config meta in
+            let turn_affordances =
+              Keeper_unified_metrics.observed_affordances_of_observation
+                ~meta
+                world_observation
+            in
             let run_result, latency_ms =
               Keeper_exec_context.timed (fun () ->
                   Keeper_agent_run.run_turn
@@ -507,7 +497,8 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                     ~user_message:message
                     ~cascade_name:
                       (Keeper_cascade_profile.Runtime_name turn_cascade_name)
-                    ~world_observation:(direct_turn_observation meta)
+                    ~world_observation
+                    ~turn_affordances
                     ~required_tool_names
                     ?oas_timeout_s:keeper_msg_oas_timeout_s
                     ?provider_filter:(Env_config_keeper.KeeperCascade.provider_allowlist ())
@@ -613,7 +604,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                  Keeper_unified_metrics.append_metrics_snapshot
                    ~config:ctx.config
                    ~meta:updated_meta
-                   ~observation:(direct_turn_observation updated_meta)
+                   ~observation:(direct_turn_observation ~config:ctx.config updated_meta)
                    ~result
                    ~latency_ms
                    ~turn_cost:(turn_cost_for_result ~meta:updated_meta result)

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -1139,6 +1139,45 @@ let observe
   }
 ;;
 
+let observe_direct_keeper_msg
+      ~allowed_tool_names
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+  : world_observation
+  =
+  let ( unclaimed_task_count
+      , claimable_task_count
+      , failed_task_count
+      , pending_verification_count
+      , backlog_updated_since_last_scheduled_autonomous )
+    =
+    read_backlog_counts ~allowed_tool_names ~config ~meta
+  in
+  { pending_mentions = []
+  ; pending_board_events = []
+  ; pending_scope_messages = []
+  ; message_cursor_updates = []
+  ; idle_seconds = compute_idle_seconds ~meta
+  ; active_goals = meta.active_goal_ids
+  ; continuity_summary = read_continuity_summary ~config ~meta
+  ; worktree_change_summary =
+      Worktree_live_context.capture_change_block
+        ~base_path:config.base_path
+        ~actor_key:meta.name
+  ; context_ratio = read_context_ratio ~config ~meta
+  ; economic_pressure =
+      Agent_economy.economic_pressure ~base_path:config.base_path ~agent_name:meta.name
+  ; unclaimed_task_count
+  ; claimable_task_count
+  ; failed_task_count
+  ; pending_verification_count
+  ; backlog_updated_since_last_scheduled_autonomous
+  ; active_agent_count = count_active_agents ~config
+  ; last_turn_budget = None
+  ; work_discovery_due = false
+  }
+;;
+
 let durable_signal_present
       ~allowed_tool_names
       ~pending_board_events

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -229,6 +229,20 @@ val observe :
   meta:Keeper_types.keeper_meta ->
   world_observation
 
+(** Build the observation used by direct [masc_keeper_msg] turns.
+
+    This intentionally reads durable room/task state, including pending
+    verification counts, while suppressing transient board/message events and
+    cursor updates. Direct operator messages should not advance autonomous
+    cursors, inherit unrelated room chatter, or synthesize scheduled
+    work-discovery timer signals, but they must still see the durable work
+    signals that drive tool-use contracts. *)
+val observe_direct_keeper_msg :
+  allowed_tool_names:string list option ->
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  world_observation
+
 (** Non-mutating probe for the smart-heartbeat gate.
 
     Returns [true] when durable room state already contains work that should

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -11928,6 +11928,83 @@ let test_direct_keeper_msg_timeout_overrides_meta_per_provider_timeout () =
     (KAR.per_provider_timeout_for_turn ~meta ~timeout_s:900.0 ())
 ;;
 
+let test_direct_keeper_msg_observation_keeps_durable_verification_signal () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       set_test_base_path base_dir;
+       let config = Masc_mcp.Coord.default_config base_dir in
+       ignore (Masc_mcp.Coord.init config ~agent_name:(Some "observer"));
+       let submitted_at = "2026-05-19T00:00:00Z" in
+       let task : Types.task =
+         { id = "task-direct-verification"
+         ; title = "Direct verifier work"
+         ; description = "awaiting verification"
+         ; task_status =
+             Types.AwaitingVerification
+               { assignee = "worker"
+               ; submitted_at
+               ; verification_id = "verify-direct-1"
+               ; deadline = None
+               }
+         ; priority = 3
+         ; files = []
+         ; created_at = submitted_at
+         ; created_by = Some "worker"
+         ; worktree = None
+         ; goal_id = None
+         ; stage = None
+         ; contract = None
+         ; handoff_context = None
+         ; cycle_count = 0
+         ; do_not_reclaim_reason = None
+         }
+       in
+       let backlog : Types.backlog =
+         { tasks = [ task ]; last_updated = submitted_at; version = 1 }
+       in
+       Masc_mcp.Coord.write_backlog config backlog;
+       let meta =
+         { minimal_meta with
+           name = "verifier"
+         ; mention_targets = [ "verifier" ]
+         ; work_discovery_enabled = Some false
+         }
+       in
+       let obs =
+         WO.observe_direct_keeper_msg
+           ~allowed_tool_names:None
+           ~config
+           ~meta
+       in
+       check int "pending verification is read from backlog" 1
+         obs.pending_verification_count;
+       check int "direct msg suppresses room mentions" 0 (List.length obs.pending_mentions);
+       check int "direct msg suppresses board events" 0
+         (List.length obs.pending_board_events);
+       check int "direct msg suppresses scope messages" 0
+         (List.length obs.pending_scope_messages);
+       check int "direct msg does not emit cursor updates" 0
+         (List.length obs.message_cursor_updates);
+       let affordances = UM.observed_affordances_of_observation ~meta obs in
+       check
+         bool
+         "direct msg exposes task_verify affordance"
+         true
+         (List.mem "task_verify" affordances);
+       check
+         bool
+         "direct msg task_verify can require an active tool"
+         true
+         (KAR.should_require_tools_for_initial_turn
+            ~max_turns:2
+            ~turn_affordances:affordances))
+;;
+
 let test_internal_keeper_loop_timeout_honors_meta_per_provider_timeout () =
   let meta =
     { (make_meta "internal-timeout-cap") with per_provider_timeout_s = Some 120.0 }
@@ -13605,6 +13682,10 @@ let () =
             "direct keeper msg timeout overrides stale per-provider timeout"
             `Quick
             test_direct_keeper_msg_timeout_overrides_meta_per_provider_timeout
+        ; test_case
+            "direct keeper msg observes durable verification signal"
+            `Quick
+            test_direct_keeper_msg_observation_keeps_durable_verification_signal
         ; test_case
             "internal keeper loop honors profile per-provider timeout"
             `Quick


### PR DESCRIPTION
Fixes #16423.

Summary:
- Replaces the zeroed direct keeper-message observation with a direct-message observation that reads durable backlog counts.
- Passes derived turn_affordances into run_turn so pending verification exposes task_verify.
- Keeps direct message observation non-mutating for room/board cursors and scheduled work-discovery timer state.

Verification:
- ocamlformat --check lib/keeper/keeper_world_observation.mli lib/keeper/keeper_world_observation.ml lib/keeper/keeper_turn.ml test/test_keeper_unified.ml
- git diff --check
- scripts/dune-local.sh build test/test_keeper_unified.exe
- ./_build/default/test/test_keeper_unified.exe test tool_classification 9 --quick-tests --compact
- scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD

Notes:
- PR is intentionally draft per workspace policy.
