### PR TITLE
fix(keeper): typed dedup for repeated on_tool_error hook ERROR logs

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -462,6 +462,18 @@
    ;; mirrors the keeper_livelock_state pattern so the standalone
    ;; alcotest builds in seconds without dragging the main library.
    masc_mcp.keeper_tool_retry_state
+   ;; LAMBDA-HOOK-ERROR (2026-05-19): typed dedupe state for the
+   ;; Keeper_hooks_oas on_tool_error hook ERROR log noise (8 events
+   ;; from 4 distinct (keeper, tool) triples in a 1000-line system_log
+   ;; sample — keeper:verifier × Bash, lifecycle-worker-fast-1 ×
+   ;; masc_worktree_create, lifecycle-reviewer-fast-1 ×
+   ;; keeper_pr_review_comment, analyst × masc_transition). Single
+   ;; emit site at lib/keeper/keeper_hooks_oas.ml:720. Sibling of
+   ;; keeper_tool_retry_state with a (keeper, tool, signature) key.
+   ;; Stdlib-only leaf; mirrors the keeper_tool_retry_state pattern so
+   ;; the standalone alcotest builds in seconds without dragging the
+   ;; main library.
+   masc_mcp.keeper_tool_hook_error_state
    ;; RFC-0086 Phase 2.B prereq — Tool_catalog_surfaces (lib/ root, 554+103 LoC)
    ;; extracted to lib/tool_catalog_surfaces/. deps: Agent_sdk + stdlib only.
    ;; Unblocks one of 6 cycle modules identified in plan §8.14 iter-2.

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -713,12 +713,49 @@ let make_hooks
 
     on_tool_error = Some (function
       | Agent_sdk.Hooks.OnToolError { tool_name; error } ->
+        (* Always increment the durable Prometheus signal: noise
+           dedupe is a log-surface concern only; the counter carries
+           the count for dashboards and alert rules. *)
         Prometheus.inc_counter
           Keeper_metrics.metric_keeper_lifecycle_callback_failures
           ~labels:[(label_keeper, (!meta_ref).name); (label_callback, callback_label_on_tool_error)]
           ();
-        Log.Keeper.error "keeper:%s tool_error: %s — %s"
-          (!meta_ref).name tool_name error;
+        (* λ-HOOK-ERROR (2026-05-19) — typed dedupe of repeated
+           [on_tool_error] hook ERROR lines. system_log 1000-line
+           sample (keeper:verifier × Bash × 2, lifecycle-worker-fast-1
+           × masc_worktree_create × 2, lifecycle-reviewer-fast-1 ×
+           keeper_pr_review_comment × 2, analyst × masc_transition ×
+           2) shows the same (keeper, tool, error) triple recurring
+           across time; only the first occurrence carries
+           operator-visible ERROR value. See
+           lib/keeper_tool_hook_error_state for rationale. *)
+        let keeper_name = (!meta_ref).name in
+        let error_signature = Keeper_tool_hook_error_state.normalize error in
+        (match
+           Keeper_tool_hook_error_state.record
+             ~keeper_name
+             ~tool_name
+             ~error_signature
+             ()
+         with
+         | `First ->
+           Log.Keeper.error "keeper:%s tool_error: %s — %s"
+             keeper_name tool_name error
+         | `Repeated n ->
+           Log.Keeper.debug
+             "keeper:%s tool_error repeated (total=%d, dedup): %s — %s"
+             keeper_name n tool_name error
+         | `Threshold_silence n ->
+           Log.Keeper.error
+             "keeper:%s tool_error threshold-silence after %d identical: %s — %s"
+             keeper_name n tool_name error;
+           Prometheus.inc_counter
+             Keeper_metrics.metric_keeper_lifecycle_callback_failures
+             ~labels:
+               [ (label_keeper, keeper_name)
+               ; (label_callback, "on_tool_error_threshold_silence")
+               ]
+             ());
         Agent_sdk.Hooks.Continue
       | _ -> Agent_sdk.Hooks.Continue);
 

--- a/lib/keeper_tool_hook_error_state/dune
+++ b/lib/keeper_tool_hook_error_state/dune
@@ -1,0 +1,39 @@
+; Keeper_tool_hook_error_state — typed dedupe state for the
+; Keeper_hooks_oas on_tool_error hook ERROR log noise.
+;
+; MASC/OAS Error-Warn Reduction Goal §P3 adjacency (tool error hook
+; noise): system_log 1000-line sample (2026-05-19) shows the single
+; emit site at lib/keeper/keeper_hooks_oas.ml:720 emitting
+;     "keeper:%s tool_error: %s — %s"
+; at ERROR level on every keeper-tool failure. The same
+; (keeper, tool, normalized error) triple recurs across time as the
+; same keeper hits the same tool error repeatedly, so a single keeper
+; failure family produces N ERROR lines.
+; Observed in the sample: keeper:verifier × Bash × 2,
+; keeper:lifecycle-worker-fast-1 × masc_worktree_create × 2,
+; keeper:lifecycle-reviewer-fast-1 × keeper_pr_review_comment × 2,
+; keeper:analyst × masc_transition × 2 — 4 distinct triples × 2 = 8
+; events in 1000 lines.
+;
+; Sibling of [Keeper_tool_retry_state] (lib/keeper_tool_retry_state/).
+; Same shape, deliberately separate: the retry module keys on
+; (tool, signature) for the per-cycle 1→2→3 retry ladder, while this
+; module keys on (keeper, tool, signature) for the cross-time
+; per-keeper hook firings. Composition would force the smaller key
+; shape on the hook site — wrong direction.
+;
+; Pure stdlib (Hashtbl + Mutex + String); no Eio link so the
+; standalone test executable builds in seconds without dragging the
+; main masc_mcp library.
+;
+; (include_subdirs no) opts out of the parent (include_subdirs
+; unqualified). (wrapped false) keeps the bare identifier
+; [Keeper_tool_hook_error_state] to match the existing lib/keeper/*
+; flat namespace at call sites.
+(include_subdirs no)
+
+(library
+ (name masc_mcp_keeper_tool_hook_error_state)
+ (public_name masc_mcp.keeper_tool_hook_error_state)
+ (wrapped false)
+ (libraries))

--- a/lib/keeper_tool_hook_error_state/keeper_tool_hook_error_state.ml
+++ b/lib/keeper_tool_hook_error_state/keeper_tool_hook_error_state.ml
@@ -1,0 +1,181 @@
+(* Typed dedupe state for the Keeper_hooks_oas on_tool_error ERROR log noise.
+
+   See the .mli for the rationale and the production system_log evidence
+   that motivates this noise-dedupe layer. The module is intentionally
+   stdlib-only (Hashtbl + Mutex + String) so it can be linked into both
+   the main library and a standalone Alcotest executable without dragging
+   Eio in.
+
+   Sibling of [Keeper_tool_retry_state] (lib/keeper_tool_retry_state/).
+   Same shape, different fingerprint dimension: the retry module keys on
+   [(tool, signature)] because the retry loop iterates within a single
+   keeper context, while this module keys on [(keeper, tool, signature)]
+   because the hook fires per-keeper and two different keepers seeing
+   the same tool error are legitimately distinct ERROR events.
+
+   Threading: the in-memory [Hashtbl.t] is guarded by a single [Mutex.t].
+   All public entry points take and release the lock in a critical
+   section that performs only [Hashtbl] manipulation and integer
+   arithmetic; no allocations of caller-visible records happen while the
+   lock is held, so contention is bounded.
+
+   Memory: there is no eviction policy. The set of distinct
+   (keeper_name, tool_name, error_signature) fingerprints is bounded by
+   (number of distinct keepers) × (number of distinct tools each
+   exercises) × (number of distinct normalized error families per
+   tool). At production scale (~tens of keepers, low tens of tools per
+   keeper, low tens of stable error families per tool) the cardinality
+   is at most low thousands — unbounded accumulation across process
+   lifetime is acceptable. *)
+
+type outcome =
+  [ `First
+  | `Repeated of int
+  | `Threshold_silence of int
+  ]
+
+(* Threshold tuned against the 2026-05-19 1000-line system_log sample
+   (4 distinct (keeper, tool) pairs × 2 repetitions each). With the
+   on_tool_error hook firing once per failure (no 1→3 retry ladder
+   bundled inside one event), threshold 5 means the operator sees the
+   first ERROR plus four DEBUG-demoted intermediates before the durable
+   Threshold_silence ERROR fires. *)
+let default_silence_threshold = 5
+
+(* Byte cap on the normalized signature. The first 80 bytes of a
+   typical OAS tool error carry the error-class prefix and a short
+   stable description (the high-signal portion). Variable payloads
+   (timestamps, paths, request IDs, PR numbers) that follow are
+   deliberately dropped from the fingerprint so the dedupe layer can
+   converge. *)
+let normalize_length_cap = 80
+
+(* ── normalize ────────────────────────────────────────────────────
+
+   Total, idempotent projection of an arbitrary error string to a
+   stable fingerprint suffix. Steps:
+
+   1. Walk the bytes; whitespace runs (ASCII space, tab, CR, LF) are
+      collapsed to a single space. Leading whitespace is dropped.
+   2. ASCII letters [A]–[Z] are lowercased; non-ASCII bytes pass
+      through untouched.
+   3. After the walk, trailing whitespace is trimmed and the result
+      is truncated to [normalize_length_cap] bytes.
+
+   Pure stdlib (Buffer + Bytes + Char). No regex. *)
+
+let is_ws c =
+  match c with
+  | ' ' | '\t' | '\r' | '\n' -> true
+  | _ -> false
+;;
+
+let lowercase_ascii c =
+  match c with
+  | 'A' .. 'Z' -> Char.chr (Char.code c + 32)
+  | _ -> c
+;;
+
+let normalize (raw : string) : string =
+  let n = String.length raw in
+  let buf = Buffer.create (min n normalize_length_cap) in
+  let prev_was_space = ref true (* drop leading whitespace *) in
+  let i = ref 0 in
+  while !i < n do
+    let c = String.unsafe_get raw !i in
+    if is_ws c
+    then (
+      if not !prev_was_space
+      then (
+        Buffer.add_char buf ' ';
+        prev_was_space := true))
+    else (
+      Buffer.add_char buf (lowercase_ascii c);
+      prev_was_space := false);
+    incr i
+  done;
+  let s = Buffer.contents buf in
+  let s =
+    (* trim trailing whitespace introduced by the walk above. The
+       collapse step preserves at most one trailing space when the
+       input ended on whitespace; strip it. *)
+    let len = String.length s in
+    if len > 0 && Char.equal (String.unsafe_get s (len - 1)) ' '
+    then String.sub s 0 (len - 1)
+    else s
+  in
+  if String.length s > normalize_length_cap
+  then String.sub s 0 normalize_length_cap
+  else s
+;;
+
+type entry =
+  { mutable count : int
+  ; mutable silenced_emitted : bool
+        (* True once a [`Threshold_silence] outcome has been returned
+           for this entry, so subsequent calls return [`Repeated]
+           rather than re-firing the silence outcome. *)
+  }
+
+let make_entry () = { count = 0; silenced_emitted = false }
+
+(* Fingerprint key. [keeper_name], [tool_name], and [error_signature]
+   are concatenated with a null separator. The separator avoids the
+   collision risk of straight concatenation when one component happens
+   to be a prefix of another component's neighbour (e.g. tool name
+   "ab" + signature "cd" vs tool name "a" + signature "bcd"). *)
+let key ~keeper_name ~tool_name ~error_signature =
+  String.concat "\x00" [ keeper_name; tool_name; error_signature ]
+;;
+
+let state : (string, entry) Hashtbl.t = Hashtbl.create 32
+let mutex = Mutex.create ()
+
+let with_lock f =
+  Mutex.lock mutex;
+  Fun.protect ~finally:(fun () -> Mutex.unlock mutex) f
+;;
+
+let record
+  ?(silence_threshold = default_silence_threshold)
+  ~(keeper_name : string)
+  ~(tool_name : string)
+  ~(error_signature : string)
+  ()
+  : outcome
+  =
+  let k = key ~keeper_name ~tool_name ~error_signature in
+  with_lock (fun () ->
+    match Hashtbl.find_opt state k with
+    | None ->
+      let e = make_entry () in
+      e.count <- 1;
+      Hashtbl.replace state k e;
+      `First
+    | Some e ->
+      e.count <- e.count + 1;
+      if e.count >= silence_threshold && not e.silenced_emitted
+      then (
+        e.silenced_emitted <- true;
+        `Threshold_silence e.count)
+      else `Repeated e.count)
+;;
+
+let reset_for_test () : unit = with_lock (fun () -> Hashtbl.clear state)
+
+let cardinality () : int =
+  with_lock (fun () -> Hashtbl.length state)
+;;
+
+let occurrence_count
+  ~(keeper_name : string)
+  ~(tool_name : string)
+  ~(error_signature : string)
+  : int
+  =
+  let k = key ~keeper_name ~tool_name ~error_signature in
+  with_lock (fun () ->
+    match Hashtbl.find_opt state k with
+    | None -> 0
+    | Some e -> e.count)
+;;

--- a/lib/keeper_tool_hook_error_state/keeper_tool_hook_error_state.mli
+++ b/lib/keeper_tool_hook_error_state/keeper_tool_hook_error_state.mli
@@ -1,0 +1,170 @@
+(** Typed dedupe state for the [on_tool_error] hook ERROR log noise
+    emitted by [Keeper_hooks_oas] at the single emit site
+    (lib/keeper/keeper_hooks_oas.ml:720).
+
+    Background
+    ──────────
+    [Keeper_hooks_oas] installs an [on_tool_error] hook that fires on
+    every keeper tool error returned to the supervisor. The hook body
+    emits
+
+        "keeper:%s tool_error: %s — %s"
+
+    at [Log.Error] level for the [(keeper_name, tool_name, error)]
+    tuple. The hook fires *per failure*, not per retry, so unlike the
+    retry-loop site this is not a 1→2→3 sliding count within a single
+    cycle — instead the same fingerprint recurs across time as the
+    same keeper hits the same tool error repeatedly.
+
+    System_log inspection (1000-line sample, 2026-05-19) shows the
+    pattern in production:
+    - keeper:verifier × Bash × 2
+    - keeper:lifecycle-worker-fast-1 × masc_worktree_create × 2
+    - keeper:lifecycle-reviewer-fast-1 × keeper_pr_review_comment × 2
+    - keeper:analyst × masc_transition × 2
+
+    That is 4 distinct (keeper, tool) pairs, each repeating twice with
+    identical error payloads inside the same 1000-line window. Only
+    the first occurrence carries operator-visible ERROR value;
+    subsequent occurrences confirm "still happening" but add no new
+    signal at ERROR level.
+
+    Relationship to [Keeper_tool_retry_state]
+    ─────────────────────────────────────────
+    Sibling module, deliberately separate. The retry-state module
+    keys on [(tool_name, error_signature)] because its caller is the
+    supervisor's retry loop where the *same* keeper retries the
+    *same* tool 1→2→3 times within one cycle. This module keys on
+    [(keeper_name, tool_name, error_signature)] because its caller is
+    the OAS hook chain installed per-keeper — two different keepers
+    hitting the "same" tool error from independent code paths are
+    legitimately distinct ERROR events and must not collapse. The
+    fingerprint shapes differ; the dedupe state lives in different
+    Hashtbls; reuse via composition would force the smaller key shape
+    on the hook site, which is the wrong direction.
+
+    Workaround posture
+    ──────────────────
+    [WORKAROUND-CARRYOVER]: this module is a noise-dedupe layer, not
+    a structural fix. The root fix lives either upstream (reduce the
+    rate of keeper-tool failures themselves) or in the hook chain
+    redesign (one summary line per keeper per failure family,
+    typed). Both are out of scope here. The [`Threshold_silence]
+    outcome gives the operator a one-line ERROR after
+    [default_silence_threshold] identical repetitions, plus a
+    Prometheus counter increment with site label
+    [on_tool_error_threshold_silence] preserved at the call site.
+
+    Closed sum type, no catch-all.
+
+    Threading
+    ─────────
+    Backed by an in-memory [Hashtbl.t] under a [Mutex]. Process
+    lifetime; not persisted. A server restart sees the first
+    occurrence per fingerprint emit at ERROR again, which is the
+    desired behaviour (operator-visible "this is still happening
+    after restart"). *)
+
+(** Outcome of a [record] call. The caller is the [on_tool_error]
+    hook body at lib/keeper/keeper_hooks_oas.ml:720; the outcome
+    dictates how that branch logs the event:
+
+    - [`First] — first time this [(keeper_name, tool_name,
+      error_signature)] triple has been recorded in this process
+      lifetime. Emit at ERROR (preserve existing operator-visible
+      signal).
+
+    - [`Repeated n] — the same triple has been recorded before; [n]
+      is the running occurrence count including this call (>=2) and
+      is strictly less than [silence_threshold]. Demote to DEBUG.
+
+    - [`Threshold_silence n] — the [silence_threshold]th identical
+      repetition has just been observed for this triple; [n] is the
+      running count at the moment the threshold tripped (>=
+      [silence_threshold]). Emit one durable ERROR
+      ("threshold-silence after N identical events") and bump the
+      Prometheus callback-failures counter with site label
+      [on_tool_error_threshold_silence]. Subsequent occurrences for
+      the same triple return [`Repeated] (no second
+      [`Threshold_silence] fires within the same process lifetime
+      until [reset_for_test] is called). *)
+type outcome =
+  [ `First
+  | `Repeated of int
+  | `Threshold_silence of int
+  ]
+
+(** Default silence threshold. Tuned against the 2026-05-19 1000-line
+    system_log sample (4 distinct (keeper, tool) pairs × 2
+    repetitions each). With the [on_tool_error] hook firing once per
+    failure (no 1→3 retry ladder bundled inside one event), threshold
+    5 means the operator sees the first ERROR plus four DEBUG-demoted
+    intermediates before the durable [`Threshold_silence] ERROR
+    fires. Tunable via [?silence_threshold] on [record]. *)
+val default_silence_threshold : int
+
+(** [normalize raw] projects [raw] to a stable fingerprint suffix.
+    The pipeline is intentionally minimal and lossy-by-design:
+
+    1. Trim leading and trailing whitespace.
+    2. Collapse runs of ASCII whitespace (space, tab, CR, LF) to a
+       single space character.
+    3. Lowercase ASCII letters ([A]–[Z] → [a]–[z]; non-ASCII bytes
+       pass through untouched).
+    4. Truncate to at most [normalize_length_cap] bytes.
+
+    The cap exists because keeper-tool error details routinely embed
+    variable payloads (timestamps, paths, request IDs, PR numbers)
+    that would otherwise prevent fingerprint convergence. The first
+    80 bytes of a typical OAS tool error carry the error-class
+    prefix and a short stable description, which is the high-signal
+    portion. The normalize function is total and idempotent
+    ([normalize (normalize x) = normalize x]). *)
+val normalize : string -> string
+
+(** Byte cap applied by [normalize]. Exposed for tests and for
+    callers that need to predict the post-normalize length. *)
+val normalize_length_cap : int
+
+(** [record ~keeper_name ~tool_name ~error_signature] registers a
+    hook tool_error event and returns the classification.
+
+    The fingerprint is [(keeper_name, tool_name, error_signature)].
+    The caller is responsible for passing an [error_signature] that
+    has already been [normalize]d (the call site does this once and
+    passes the result through). The triple is conservative on
+    purpose: two different keepers hitting the same tool error from
+    independent code paths are legitimately distinct ERROR events
+    and must not collapse.
+
+    The default silence threshold is [default_silence_threshold];
+    callers that need a different threshold (e.g. tests) can
+    override via [?silence_threshold]. *)
+val record
+  :  ?silence_threshold:int
+  -> keeper_name:string
+  -> tool_name:string
+  -> error_signature:string
+  -> unit
+  -> outcome
+
+(** Reset all internal state. Test-only entry point — do not call
+    from production code. Exposed so unit tests can enforce
+    isolation between cases. *)
+val reset_for_test : unit -> unit
+
+(** Current number of distinct [(keeper_name, tool_name,
+    error_signature)] entries. Diagnostic only; never used for
+    control flow. *)
+val cardinality : unit -> int
+
+(** [occurrence_count ~keeper_name ~tool_name ~error_signature]
+    returns the current running occurrence count for the given
+    fingerprint, or [0] when no state exists. Diagnostic /
+    introspection only; never used for control flow inside the
+    module. *)
+val occurrence_count
+  :  keeper_name:string
+  -> tool_name:string
+  -> error_signature:string
+  -> int


### PR DESCRIPTION
## 요약

`Keeper_hooks_oas`의 `on_tool_error` 훅(`lib/keeper/keeper_hooks_oas.ml:720`)이 keeper 도구 실패마다 ERROR 레벨로 다음과 같이 로깅합니다:

```
"keeper:%s tool_error: %s — %s"
```

훅은 *실패마다* 발화하므로 (단일 cycle 내 1→3 retry ladder가 아님), 같은 `(keeper, tool, error)` 3-tuple이 시간 격차를 두고 반복됩니다. 첫 발생만 운영자에게 의미 있고, 이후는 "여전히 발생 중"의 확증일 뿐 새로운 신호가 없습니다.

## 근거

system_log 1000줄 샘플(2026-05-19):

| 키퍼 | 도구 | 횟수 |
| --- | --- | --- |
| `verifier` | `Bash` | 2 |
| `lifecycle-worker-fast-1` | `masc_worktree_create` | 2 |
| `lifecycle-reviewer-fast-1` | `keeper_pr_review_comment` | 2 |
| `analyst` | `masc_transition` | 2 |

→ 4 distinct triples × 2 = 8 events / 1000줄. 모두 동일 페이로드.

## 설계

`ι(#16470)` `Keeper_tool_retry_state`와 **형제 모듈**이지만 새로 만든 이유:

| | `Keeper_tool_retry_state` (ι) | `Keeper_tool_hook_error_state` (λ, 본 PR) |
| --- | --- | --- |
| 호출 지점 | retry loop (`keeper_tools_oas.ml:733`) | hook chain (`keeper_hooks_oas.ml:720`) |
| 발화 분포 | 단일 cycle 1→2→3 (같은 키퍼) | 시간 격차 (다른/같은 키퍼) |
| 지문 | `(tool, signature)` | `(keeper, tool, signature)` |

두 키퍼가 *같은* `(tool, error)`를 독립 경로로 만나는 것은 *합법적으로 다른* ERROR 이벤트입니다. 2-tuple로 합치면 keeper 식별이 손실됩니다. 합성으로 재사용하면 더 좁은 키 형태가 hook 사이트에 강요되어 정보가 깎입니다. → 별도 모듈 + 별도 Hashtbl.

## 변경 사항

- **신규 sub-library** `lib/keeper_tool_hook_error_state/` (stdlib only: Hashtbl + Mutex + String + Buffer; Eio 의존 없음):
  - `keeper_tool_hook_error_state.mli` — closed sum type ``[ \`First | \`Repeated of int | \`Threshold_silence of int ]``, `record`/`normalize`/`reset_for_test`/`cardinality`/`occurrence_count` API.
  - `keeper_tool_hook_error_state.ml` — `(keeper, tool, signature)` 3-tuple Hashtbl key (null-separator concat), Mutex 보호, 프로세스 lifetime.
  - `dune` — `(library ... (wrapped false))`, public_name `masc_mcp.keeper_tool_hook_error_state`.
- **emit site 수정** `lib/keeper/keeper_hooks_oas.ml:720`:
  - Prometheus `metric_keeper_lifecycle_callback_failures` 카운터는 *모든* 이벤트에서 보존 (대시보드/알람의 항구 신호).
  - `record` 결과로 분기:
    - `` `First `` → ERROR (기존 메시지 그대로 유지)
    - `` `Repeated n `` → DEBUG (demote, `total=%d, dedup` 마커 포함)
    - `` `Threshold_silence n `` → ERROR(한 줄) + 추가 Prometheus `on_tool_error_threshold_silence` 라벨 카운터.
  - `_ ->` catch-all 없음. 닫힌 합 타입이 누락을 컴파일러로 차단.
- **`lib/dune` 라이브러리 의존성 등록** (`masc_mcp.keeper_tool_hook_error_state`) — `keeper_tool_retry_state` 바로 뒤에 위치, 코멘트 블록으로 근거 명시.

## 검증

`scripts/dune-local.sh` 호출하지 않음(글로벌 lock 회피, `memory/reference_masc_mcp_dune_local_lock_contention.md`). **Standalone Alcotest**로 직접 컴파일:

```bash
ocamlfind ocamlopt -package alcotest,threads.posix -thread -c \
  keeper_tool_hook_error_state.{mli,ml} test_keeper_tool_hook_error_state.ml
ocamlfind ocamlopt -package alcotest,threads.posix -thread -linkpkg \
  keeper_tool_hook_error_state.cmx test_keeper_tool_hook_error_state.cmx -o run_tests
./run_tests
```

**결과**: 18 tests run, 모두 OK, 0.001s. 그룹별:

- `normalize` (5): idempotent / trim+lowercase / whitespace collapse / length cap / non-ASCII passthrough
- `record` (4): First / Repeated 2 / Threshold_silence at boundary / fires only once per fingerprint
- `distinct_keys` (4): **distinct keepers independent** (헤드라인 invariant) / distinct tool names / distinct signatures / null-separator collision guard
- `reset_and_introspection` (3): reset clears / cardinality tracks 3-tuples / missing returns 0
- `production_scenario` (2): 2026-05-19 4-triples × 2 replay / 5 keepers × 1 (tool, sig) → 5 distinct `` `First ``

## Workaround posture

`WORKAROUND-CARRYOVER`: 본 PR은 로그 surface dedupe layer이지 구조적 근본 수정이 아닙니다.

- **근본 수정 후보 1**: keeper-tool 실패율 자체를 줄임 (client-side arg validation, container reuse RFC-0097 류).
- **근본 수정 후보 2**: hook chain 재설계 — keeper별 실패 family당 한 줄 typed summary로 emit.

둘 다 본 PR 범위 밖. 본 PR은 운영자가 지금 보는 ERROR noise를 즉시 줄이고, Prometheus 카운터는 그대로 유지하여 항구 신호를 보존합니다.

## RFC

본 변경은 credential/identity/auth, operator control plane, keeper sandbox, dashboard credential, Claude Code hooks, workflow 문서 어느 surface에도 닿지 않습니다. → `pr-rfc-check.sh` 범위 밖.

## Plan SSOT

`MASC/OAS Error-Warn Reduction Goal - 2026-05-18` §P3 인접 (tool error hook noise). `ι(#16470)`(`Keeper_tool_retry_state`)와 대칭 emit.

## Test plan

- [x] Standalone Alcotest 18 tests PASS (수치/그룹 위에 기재)
- [x] 단일 emit site `lib/keeper/keeper_hooks_oas.ml:720` 외 다른 site 미수정 (`rg "tool_error" lib/keeper/keeper_hooks_oas.ml` 1 hit)
- [x] Closed sum type, `_ ->` catch-all 없음
- [x] `Keeper_tool_retry_state` 의존성 추가하지 않음 (`grep -n "keeper_tool_retry_state" lib/keeper_tool_hook_error_state/` empty)
- [x] `dune build` / `scripts/dune-local.sh` 미실행
- [ ] human-approved-ready 라벨 부여 후 admin merge (사용자)

🤖 Generated with [Claude Code](https://claude.com/claude-code)