### PR TITLE
feat(chronicle): received-kind in chronicle_event parse errors (10 sites)

### DIFF
--- a/lib/chronicle_event/chronicle_event.ml
+++ b/lib/chronicle_event/chronicle_event.ml
@@ -274,41 +274,71 @@ let to_yojson
 
 let ( let* ) = Result.bind
 
+let json_kind_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "intlit"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+
 let expect_assoc ~where = function
   | `Assoc fields -> Ok fields
-  | _ -> Error (Printf.sprintf "%s: expected JSON object" where)
+  | other ->
+    Error
+      (Printf.sprintf "%s: expected JSON object (received %s)" where
+         (json_kind_name other))
 
 let find_field fields name = List.assoc_opt name fields
 
 let require_string fields name =
   match find_field fields name with
   | Some (`String s) -> Ok s
-  | Some _ -> Error (Printf.sprintf "field '%s' must be a string" name)
+  | Some other ->
+    Error
+      (Printf.sprintf "field '%s' must be a string (received %s)" name
+         (json_kind_name other))
   | None -> Error (Printf.sprintf "missing required string field '%s'" name)
 
 let require_int fields name =
   match find_field fields name with
   | Some (`Int n) -> Ok n
-  | Some _ -> Error (Printf.sprintf "field '%s' must be an integer" name)
+  | Some other ->
+    Error
+      (Printf.sprintf "field '%s' must be an integer (received %s)" name
+         (json_kind_name other))
   | None -> Error (Printf.sprintf "missing required int field '%s'" name)
 
 let optional_string fields name =
   match find_field fields name with
   | None | Some `Null -> Ok None
   | Some (`String s) -> Ok (Some s)
-  | Some _ -> Error (Printf.sprintf "field '%s' must be a string when present" name)
+  | Some other ->
+    Error
+      (Printf.sprintf "field '%s' must be a string when present (received %s)"
+         name (json_kind_name other))
 
 let optional_int fields name =
   match find_field fields name with
   | None | Some `Null -> Ok None
   | Some (`Int n) -> Ok (Some n)
-  | Some _ -> Error (Printf.sprintf "field '%s' must be an integer when present" name)
+  | Some other ->
+    Error
+      (Printf.sprintf "field '%s' must be an integer when present (received %s)"
+         name (json_kind_name other))
 
 let optional_bool fields name =
   match find_field fields name with
   | None | Some `Null -> Ok None
   | Some (`Bool b) -> Ok (Some b)
-  | Some _ -> Error (Printf.sprintf "field '%s' must be a bool when present" name)
+  | Some other ->
+    Error
+      (Printf.sprintf "field '%s' must be a bool when present (received %s)"
+         name (json_kind_name other))
 
 let string_list fields name =
   match find_field fields name with
@@ -317,11 +347,17 @@ let string_list fields name =
     let rec loop acc = function
       | [] -> Ok (List.rev acc)
       | `String s :: rest -> loop (s :: acc) rest
-      | _ ->
-        Error (Printf.sprintf "field '%s' must be a list of strings" name)
+      | bad :: _ ->
+        Error
+          (Printf.sprintf
+             "field '%s' must be a list of strings (received %s element)" name
+             (json_kind_name bad))
     in
     loop [] xs
-  | Some _ -> Error (Printf.sprintf "field '%s' must be a list" name)
+  | Some other ->
+    Error
+      (Printf.sprintf "field '%s' must be a list (received %s)" name
+         (json_kind_name other))
 
 let actor_of_yojson json =
   let* fields = expect_assoc ~where:"actor" json in
@@ -334,7 +370,20 @@ let actor_of_yojson json =
 let range_of_yojson json =
   match json with
   | `List [ `Int a; `Int b ] -> Ok (a, b)
-  | _ -> Error "range must be a JSON array of two integers"
+  | `List xs ->
+    let element_kinds =
+      String.concat ", " (List.map json_kind_name xs)
+    in
+    Error
+      (Printf.sprintf
+         "range must be a JSON array of two integers (received array of \
+          length %d: [%s])"
+         (List.length xs) element_kinds)
+  | other ->
+    Error
+      (Printf.sprintf
+         "range must be a JSON array of two integers (received %s)"
+         (json_kind_name other))
 
 let target_of_yojson json =
   let* fields = expect_assoc ~where:"target" json in
@@ -393,7 +442,10 @@ let intent_of_yojson json =
     match find_field fields "confidence" with
     | Some (`Float f) -> Ok f
     | Some (`Int n) -> Ok (float_of_int n)
-    | Some _ -> Error "intent.confidence must be a number"
+    | Some other ->
+      Error
+        (Printf.sprintf "intent.confidence must be a number (received %s)"
+           (json_kind_name other))
     | None -> Error "intent.confidence is required"
   in
   Ok { stated_goal; inferred_intent; confidence }


### PR DESCRIPTION
## Why

`lib/chronicle_event/chronicle_event.ml`의 10 JSON-shape mismatch 사이트가 expected-only 안티패턴. 큰 cohort — single file의 가장 큰 sweep까지.

## What

| Line | Site | Helper applied |
|---|---|---|
| 279 | `expect_assoc` catch-all | `(received <kind>)` |
| 286 | `require_string` Some-mismatch | `(received <kind>)` |
| 292 | `require_int` Some-mismatch | `(received <kind>)` |
| 299 | `optional_string` Some-mismatch | `(received <kind>)` |
| 305 | `optional_int` Some-mismatch | `(received <kind>)` |
| 311 | `optional_bool` Some-mismatch | `(received <kind>)` |
| 321 | `string_list` element mismatch | `(received <kind> element)` ← first offending |
| 324 | `string_list` outer | `(received <kind>)` |
| 337 | `range_of_yojson` | shape-aware: array case → length + per-element kinds; non-array → kind |
| 396 | `intent.confidence` Some-arm | `(received <kind>)` |

File-private `json_kind_name` — closed total function over 10 `Yojson.Safe.t` variants (no catch-all).

## Cohort boundary

본 PR이 다루지 않는 사이트 (L491-511)는 *post-parse semantic validation*:
- length=0, timestamp<=0, non-empty fields, finite-float 범위 [0.0, 1.0]
- JSON shape mismatch가 아님 → cohort 밖. 자연스러운 경계.

## range_of_yojson 특별 처리

`[Int; Int]` 정확한 shape 요구. 단순 `(received <kind>)`이 list 안의 *내용* 미스매치 (e.g. `[1, "two"]`)는 못 잡아냄. shape-aware error 형식:
- `[\`Int 1; \`String "two"]` → `received array of length 2: [int, string]`
- `[\`Int 1; \`Int 2; \`Int 3]` → `received array of length 3: [int, int, int]`
- `\`Assoc []` → `received object`

## string_list 안에서

이전엔 `_ -> Error "must be a list of strings"`로 *어디서 ill-formed* 인지 무시. 이제 `bad :: _` pattern으로 첫 offending element kind 보고.

## Iter#13~#18 series

- Iter#13~#16 — keeper_runtime_manifest/persona_authoring/ids/keeper_id (16 사이트)
- Iter#17 — types_core 3 enums
- **Iter#18 (this)** — chronicle_event 10 사이트

6-PR series = **29 사이트 across 6 files**, 같은 inline `json_kind_name` form. PR #16375 머지 후 single dedup PR.

## Workaround Rejection Bar

- [x] Counter-as-fix 아님
- [x] String/substring classifier 아님 — closed sum type
- [x] N-of-M 아님 — 10/10 JSON-shape 사이트 cohort closure, semantic check는 별개
- [x] Cap/cooldown/dedup/repair 아님
- [x] Test backdoor 아님

## RFC Check

PASS — chronicle_event는 event-log domain model.

## Verification

- [x] `ocamlformat --check` PASS (auto)
- [x] `rg "field '%s' must be|intent.confidence must be|range must be" test/` = 0 match
- [ ] CI 모니터링

## Iter#15.5 sweep

30 PR sweep PASS (CONFLICTING 0).

🤖 /loop cron \`253cc0f6\` Iter#18

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>