### PR TITLE
feat(autonomous): received-kind in Stimulus.of_json (5 sites cohort)

### DIFF
--- a/lib/autonomous/stimulus.ml
+++ b/lib/autonomous/stimulus.ml
@@ -80,6 +80,18 @@ let to_json t : Yojson.Safe.t =
       ("timestamp", `Float t.timestamp);
     ]
 
+let json_kind_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "intlit"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+
 (* Defensive parsing: no exceptions escape — every malformed input
    maps to [Error msg] with a localised reason. The salience and id
    validations re-use the construction-time invariants. *)
@@ -96,13 +108,20 @@ let of_json (j : Yojson.Safe.t) : (t, string) result =
       let* id =
         match id_j with
         | `String s -> Ok s
-        | _ -> Error "Stimulus.of_json: id must be a string"
+        | other ->
+            Error
+              (Printf.sprintf "Stimulus.of_json: id must be a string (received %s)"
+                 (json_kind_name other))
       in
       let* source_j = lookup "source" in
       let* source_str =
         match source_j with
         | `String s -> Ok s
-        | _ -> Error "Stimulus.of_json: source must be a string"
+        | other ->
+            Error
+              (Printf.sprintf
+                 "Stimulus.of_json: source must be a string (received %s)"
+                 (json_kind_name other))
       in
       let* source =
         match source_of_string source_str with
@@ -118,17 +137,29 @@ let of_json (j : Yojson.Safe.t) : (t, string) result =
         match salience_j with
         | `Float f -> Ok f
         | `Int i -> Ok (float_of_int i)
-        | _ -> Error "Stimulus.of_json: salience must be a number"
+        | other ->
+            Error
+              (Printf.sprintf
+                 "Stimulus.of_json: salience must be a number (received %s)"
+                 (json_kind_name other))
       in
       let* timestamp_j = lookup "timestamp" in
       let* timestamp =
         match timestamp_j with
         | `Float f -> Ok f
         | `Int i -> Ok (float_of_int i)
-        | _ -> Error "Stimulus.of_json: timestamp must be a number"
+        | other ->
+            Error
+              (Printf.sprintf
+                 "Stimulus.of_json: timestamp must be a number (received %s)"
+                 (json_kind_name other))
       in
       (* Re-run construction-time invariants so [of_json |> to_json]
          and [make ...] enforce the same range. *)
       (try Ok (make ~id ~source ~payload ~salience ~timestamp)
        with Invalid_argument msg -> Error msg)
-  | _ -> Error "Stimulus.of_json: expected JSON object"
+  | other ->
+      Error
+        (Printf.sprintf
+           "Stimulus.of_json: expected JSON object (received %s)"
+           (json_kind_name other))


### PR DESCRIPTION
## Why

`lib/autonomous/stimulus.ml`의 `of_json` 함수 5 사이트가 expected-only 안티패턴. autonomous keeper stimulus replay 디버깅 시 operator는 어느 type을 받았는지 모름.

## What

5 of_json 사이트 cohort closure, 모두 `(received <kind>)`:

| Line | Field | Filter |
|---|---|---|
| 99 | `id` | String only |
| 105 | `source` | String only |
| 121 | `salience` | Float \| Int |
| 128 | `timestamp` | Float \| Int |
| 134 | top-level | Assoc only |

File-private `json_kind_name` — closed total function over 10 `Yojson.Safe.t` variants. of_json 직전 배치.

## Iter#13~#19 series

- Iter#13~#16 — keeper_runtime_manifest/persona_authoring/ids/keeper_id (16 사이트)
- Iter#17 — types_core 3 enums
- Iter#18 — chronicle_event 10 사이트 (with shape-aware range_of_yojson)
- **Iter#19 (this)** — stimulus 5 사이트

7-PR series = **34 사이트 across 7 files**, 같은 inline `json_kind_name` form. PR #16375 머지 후 single dedup PR.

## Workaround Rejection Bar

- [x] Counter-as-fix 아님
- [x] String/substring classifier 아님 — closed sum type
- [x] N-of-M 아님 — 5/5 cohort closure
- [x] Cap/cooldown/dedup/repair 아님
- [x] Test backdoor 아님

## RFC Check

PASS — autonomous/stimulus는 stimulus record + codec, credential boundary 아님.

## Verification

- [x] `ocamlformat --check` PASS (auto)
- [x] `rg 'Stimulus.of_json:' test/` = 0 match
- [ ] CI 모니터링

## Iter#15.5 sweep

30 PR sweep PASS (4회째).

🤖 /loop cron \`253cc0f6\` Iter#19

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>