### PR TITLE
feat(tui): received-kind in tui_decode parse errors (10 sites cohort)

### DIFF
--- a/lib/tui_decode.ml
+++ b/lib/tui_decode.ml
@@ -63,13 +63,28 @@ type log_entry = {
 
 let ( let* ) = Result.bind
 
+let json_kind_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "intlit"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+
 let member key json = Yojson.Safe.Util.member key json
 
 let optional_string json key =
   match member key json with
   | `Null -> Ok None
   | `String s -> Ok (Some s)
-  | _ -> Error (Printf.sprintf "field '%s' must be a string" key)
+  | other ->
+      Error
+        (Printf.sprintf "field '%s' must be a string (received %s)" key
+           (json_kind_name other))
 
 let optional_int json key =
   match member key json with
@@ -80,20 +95,29 @@ let optional_int json key =
       | Some n -> Ok (Some n)
       | None ->
           Error (Printf.sprintf "field '%s' has non-integer intlit %S" key s))
-  | _ -> Error (Printf.sprintf "field '%s' must be an int" key)
+  | other ->
+      Error
+        (Printf.sprintf "field '%s' must be an int (received %s)" key
+           (json_kind_name other))
 
 let optional_float json key =
   match member key json with
   | `Null -> Ok None
   | `Float f -> Ok (Some f)
   | `Int n -> Ok (Some (Float.of_int n))
-  | _ -> Error (Printf.sprintf "field '%s' must be a float" key)
+  | other ->
+      Error
+        (Printf.sprintf "field '%s' must be a float (received %s)" key
+           (json_kind_name other))
 
 let optional_bool json key =
   match member key json with
   | `Null -> Ok None
   | `Bool b -> Ok (Some b)
-  | _ -> Error (Printf.sprintf "field '%s' must be a bool" key)
+  | other ->
+      Error
+        (Printf.sprintf "field '%s' must be a bool (received %s)" key
+           (json_kind_name other))
 
 let require_string_field json key = require_string json key
 let require_int_field json key = require_int json key
@@ -107,9 +131,11 @@ let require_string_list json key =
         (fun idx item ->
           match item with
           | `String value -> Ok value
-          | _ ->
+          | bad ->
               Error
-                (Printf.sprintf "field '%s[%d]' must be a string" key idx))
+                (Printf.sprintf
+                   "field '%s[%d]' must be a string (received %s)" key idx
+                   (json_kind_name bad)))
         items
       |> List.fold_left
            (fun acc item ->
@@ -119,7 +145,10 @@ let require_string_list json key =
            (Ok [])
       |> Result.map List.rev
   | `Null -> Error (Printf.sprintf "missing required field '%s'" key)
-  | _ -> Error (Printf.sprintf "field '%s' must be an array" key)
+  | other ->
+      Error
+        (Printf.sprintf "field '%s' must be an array (received %s)" key
+           (json_kind_name other))
 
 let string_of_intlike_float_field key f =
   if not (Float.is_finite f) then
@@ -134,8 +163,18 @@ let decode_status json =
   | `String s -> Ok s
   | `List (`String s :: _) -> Ok s
   | `List [] -> Error "field 'status' list must not be empty"
+  | `List (bad :: _) ->
+      Error
+        (Printf.sprintf
+           "field 'status' list head must be a string (received %s)"
+           (json_kind_name bad))
   | `Null -> Error "missing required field 'status'"
-  | _ -> Error "field 'status' must be a string or non-empty string array"
+  | other ->
+      Error
+        (Printf.sprintf
+           "field 'status' must be a string or non-empty string array \
+            (received %s)"
+           (json_kind_name other))
 
 let decode_agent json =
   let* name = require_string_field json "name" in
@@ -173,7 +212,11 @@ let decode_keeper ~filename json =
     match member "models" json with
     | `Null -> Ok []
     | `List _ -> require_string_list json "models"
-    | _ -> Error "field 'models' must be a list of strings"
+    | other ->
+        Error
+          (Printf.sprintf
+             "field 'models' must be a list of strings (received %s)"
+             (json_kind_name other))
   in
   let* k_proactive_enabled = require_bool_field json "proactive_enabled" in
   let* k_initiative_enabled = optional_bool json "initiative_enabled" in
@@ -186,7 +229,12 @@ let decode_keeper ~filename json =
     | `Float f -> string_of_intlike_float_field "last_turn_ts" f
     | `Int n -> Ok (string_of_int n)
     | `Null -> Ok ""
-    | _ -> Error "field 'last_turn_ts' must be a string, number, or null"
+    | other ->
+        Error
+          (Printf.sprintf
+             "field 'last_turn_ts' must be a string, number, or null \
+              (received %s)"
+             (json_kind_name other))
   in
   let* k_compaction_count = require_int_field json "compaction_count" in
   let* k_compaction_ratio_gate = require_float_field json "compaction_ratio_gate" in
@@ -260,7 +308,11 @@ let parse_log_entry line =
     match member "tools_used" json with
     | `Null -> Ok []
     | `List _ -> require_string_list json "tools_used"
-    | _ -> Error "field 'tools_used' must be an array"
+    | other ->
+        Error
+          (Printf.sprintf
+             "field 'tools_used' must be an array (received %s)"
+             (json_kind_name other))
   in
   let* le_tools_used = le_tools_used in
   let* le_compacted = optional_bool json "compacted" in


### PR DESCRIPTION
## Why

`lib/tui_decode.ml`의 10 type-shape mismatch 사이트가 expected-only 안티패턴. dashboard 페이로드 디버깅 시 operator가 받은 type을 모름.

## What

10 사이트 cohort closure:

| Line | Site | Refinement |
|---|---|---|
| 72 | `optional_string` | `(received <kind>)` |
| 83 | `optional_int` | `(received <kind>)` |
| 90 | `optional_float` | `(received <kind>)` |
| 96 | `optional_bool` | `(received <kind>)` |
| 112 | `require_string_list` element | `bad :: _` pattern + idx + kind ← chronicle_event 패턴 재사용 |
| 122 | `require_string_list` outer | `(received <kind>)` |
| 138 | `decode_status` | bespoke 5-arm; `\`List (bad :: _)` 별도 분리 |
| 176 | `models` field | `(received <kind>)` |
| 189 | `last_turn_ts` | `(received <kind>)` |
| 263 | `tools_used` | `(received <kind>)` |

File-private `json_kind_name` — 10 `Yojson.Safe.t` variants closed total function.

## decode_status 특별 분할

이전 `_ -> "must be a string or non-empty string array"`는 *list head가 non-string인 경우*도 같은 일반화된 메시지로 처리 → 디버깅 시 list이긴 한지조차 모름.

이제:
- `\`List (bad :: _)` → `list head must be a string (received <kind>)` — list이긴 한데 head가 잘못된 경우 명확
- catch-all → `must be a string or non-empty string array (received <kind>)` — list조차 아닌 경우

## Cohort boundary

L165 `status list must not be empty`는 *semantic non-empty constraint*, type-shape mismatch가 아니므로 cohort 외. 자연스러운 경계.

## Iter#13~#20 series

- Iter#13~#19 (앞선 7 PR) — 34 사이트 across 7 files
- **Iter#20 (this)** — `tui_decode.ml` 10 사이트

8-PR series = **44 사이트 across 8 files**, 같은 inline `json_kind_name` form. PR #16375 머지 후 single dedup PR.

## Workaround Rejection Bar

- [x] Counter-as-fix 아님
- [x] String/substring classifier 아님 — closed sum type
- [x] N-of-M 아님 — 10/10 type-shape cohort closure
- [x] Cap/cooldown/dedup/repair 아님
- [x] Test backdoor 아님

## RFC Check

PASS — TUI dashboard payload decoder, credential boundary 아님.

## Verification

- [x] `ocamlformat --check` PASS (auto)
- [x] `rg "field '%s' must be" test/ | rg tui_decode` = 0
- [ ] CI 모니터링

## Iter#15.5 sweep

30 PR sweep PASS (5회째).

🤖 /loop cron \`253cc0f6\` Iter#20

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>