### PR TITLE
refactor: split heartbeat loop observations

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -217,6 +217,7 @@
   keeper_turn_lifecycle
   keeper_msg_async
   keeper_event_bus
+  keeper_heartbeat_loop_observations
   keeper_supervisor_startup_helpers
   keeper_supervisor_alive_but_stuck
   keeper_supervisor_liveness_recovery

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -9,6 +9,7 @@ open Keeper_types
 open Keeper_memory
 open Keeper_execution
 open Keeper_keepalive_signal
+module Observations = Keeper_heartbeat_loop_observations
 
 let effective_keepalive_meta
       ~base_path
@@ -359,39 +360,16 @@ let with_in_turn_liveness_pulse
     f
 ;;
 
-type semaphore_wait_observation_kind =
+type semaphore_wait_observation_kind = Observations.semaphore_wait_observation_kind =
   | Semaphore_wait_pending
   | Semaphore_wait_timeout
 
-let semaphore_wait_observation_reasons ?phase_label ~kind ~channel () =
-  let kind_reason =
-    match kind with
-    | Semaphore_wait_pending -> "semaphore_wait_pending"
-    | Semaphore_wait_timeout -> "semaphore_wait_timeout"
-  in
-  let wait_reason =
-    match phase_label with
-    | Some phase -> "phase_" ^ phase
-    | None -> "peers_holding_slot"
-  in
-  [ kind_reason
-  ; wait_reason
-  ; "channel_" ^ Keeper_world_observation.channel_to_string channel
-  ]
+let semaphore_wait_observation_reasons =
+  Observations.semaphore_wait_observation_reasons
 ;;
 
-let record_semaphore_wait_observation
-      ?phase_label
-      ~base_path
-      ~keeper_name
-      ~channel
-      ~kind
-      ()
-  =
-  Keeper_registry.record_skip_reasons
-    ~base_path
-    keeper_name
-    ~reasons:(semaphore_wait_observation_reasons ?phase_label ~kind ~channel ())
+let record_semaphore_wait_observation =
+  Observations.record_semaphore_wait_observation
 ;;
 
 let record_recovery_stimulus_turn_started
@@ -574,64 +552,19 @@ let heartbeat_event_intake ~ctx ~meta_after_triage ~pending_board_events =
   { pending_board_events; consumed_stimulus_count }
 ;;
 
-type cascade_backpressure_decision =
+type cascade_backpressure_decision = Observations.cascade_backpressure_decision =
   | Cascade_admitted
   | Cascade_backpressured of {
       cascade_name : string;
       reason : string;
     }
 
-let skip_reason_component raw =
-  let normalized = String.lowercase_ascii (String.trim raw) in
-  let mapped =
-    String.map
-      (function
-        | ('a' .. 'z' | '0' .. '9' | '_') as c -> c
-        | '-' -> '_'
-        | _ -> '_')
-      normalized
-  in
-  if String.equal mapped "" then "unknown" else mapped
+let cascade_backpressure_observation_reasons =
+  Observations.cascade_backpressure_observation_reasons
 ;;
 
-let cascade_backpressure_observation_reasons ~reason =
-  let category =
-    if String.starts_with ~prefix:"cascade_resilience_" reason then
-      "cascade_resilience"
-    else "cascade_unhealthy"
-  in
-  [ "cascade_backpressure"
-  ; category
-  ; "reason_" ^ skip_reason_component reason
-  ]
-;;
-
-let cascade_resilience_backpressure_reason
-      (resilience : Keeper_exec_preflight.cascade_resilience)
-  =
-  Option.map
-    (fun blocker -> "cascade_resilience_" ^ blocker)
-    resilience.blocker
-;;
-
-let cascade_backpressure_decision
-      ~cascade_resilience
-      ~should_run_turn
-      ~cascade_name
-      ~cascade_status
-  =
-  let resilience_reason =
-    match cascade_resilience with
-    | None -> None
-    | Some resilience -> cascade_resilience_backpressure_reason resilience
-  in
-  match should_run_turn, cascade_status, resilience_reason with
-  | true, Keeper_health_probe.Unhealthy reason, _ ->
-    Cascade_backpressured { cascade_name; reason }
-  | true, _, Some reason -> Cascade_backpressured { cascade_name; reason }
-  | false, _, _
-  | true, Keeper_health_probe.Unknown, None
-  | true, Keeper_health_probe.Healthy, None -> Cascade_admitted
+let cascade_backpressure_decision =
+  Observations.cascade_backpressure_decision
 ;;
 
 type keepalive_scheduling_decision = {
@@ -691,118 +624,38 @@ let decide_keepalive_scheduling
   }
 ;;
 
-let record_cascade_backpressure_observation ~base_path ~keeper_name ~reason =
-  Keeper_registry.record_skip_reasons
-    ~base_path
-    keeper_name
-    ~reasons:(cascade_backpressure_observation_reasons ~reason);
-  Keeper_registry.touch_last_turn_ts ~base_path keeper_name
+let record_cascade_backpressure_observation =
+  Observations.record_cascade_backpressure_observation
 ;;
 
 let oas_timeout_budget_observation_reasons =
-  [ "provider_runtime_error"; "oas_timeout_budget"; "keeper_turn_retry_backoff" ]
+  Observations.oas_timeout_budget_observation_reasons
 ;;
 
-let record_oas_timeout_budget_observation ~base_path ~keeper_name =
-  Keeper_registry.record_skip_reasons
-    ~base_path
-    keeper_name
-    ~reasons:oas_timeout_budget_observation_reasons;
-  Keeper_registry.touch_last_turn_ts ~base_path keeper_name
+let record_oas_timeout_budget_observation =
+  Observations.record_oas_timeout_budget_observation
 ;;
 
-let clear_oas_timeout_budget_failure_reason ~base_path ~keeper_name =
-  match Keeper_registry.get ~base_path keeper_name with
-  | Some
-      { Keeper_registry.last_failure_reason =
-          Some (Keeper_registry.Oas_timeout_budget_loop _)
-      ; _
-      } -> Keeper_registry.set_failure_reason ~base_path keeper_name None
-  | _ -> ()
+let clear_oas_timeout_budget_failure_reason =
+  Observations.clear_oas_timeout_budget_failure_reason
 ;;
 
-let prior_oas_timeout_budget_strikes ~base_path ~keeper_name =
-  match Keeper_registry.get ~base_path keeper_name with
-  | Some
-      { Keeper_registry.last_failure_reason =
-          Some (Keeper_registry.Oas_timeout_budget_loop { count })
-      ; _
-      } -> count
-  | _ -> 0
+let prior_oas_timeout_budget_strikes =
+  Observations.prior_oas_timeout_budget_strikes
 ;;
 
-let is_oas_timeout_budget_error (err : Agent_sdk.Error.sdk_error) =
-  (* Enumerate every [masc_internal_error] variant + [None] so the
-     compiler flags any new constructor here. Mirrors the fix in
-     [degraded_retry_bypasses_slot_phase_guard] (PR #14716) and
-     [cascade_permanently_dead] (PR #14762); this site was missed in
-     both sweeps — the same predicate shape exists in three places
-     and only this one still had a catch-all. *)
-  match Keeper_turn_driver.classify_masc_internal_error err with
-  | Some (Keeper_turn_driver.Oas_timeout_budget _) -> true
-  | Some
-      ( Keeper_turn_driver.Cascade_exhausted _
-      | Keeper_turn_driver.Resumable_cli_session _
-      | Keeper_turn_driver.No_tool_capable_provider _
-      | Keeper_turn_driver.Accept_rejected _
-      | Keeper_turn_driver.Admission_queue_timeout _
-      | Keeper_turn_driver.Admission_queue_rejected _
-      | Keeper_turn_driver.Turn_timeout _
-      | Keeper_turn_driver.Max_tokens_ceiling_violation _
-      | Keeper_turn_driver.Ambiguous_post_commit _ )
-  | None ->
-    false
+let is_oas_timeout_budget_error = Observations.is_oas_timeout_budget_error
+
+let timeout_phase_of_oas_timeout_budget_phase =
+  Observations.timeout_phase_of_oas_timeout_budget_phase
 ;;
 
-let timeout_phase_of_oas_timeout_budget_phase phase =
-  let phase = String.trim phase in
-  if String.equal phase ""
-  then None
-  else (
-    match Keeper_failure_policy.timeout_phase_of_label phase with
-    | Some phase -> Some phase
-    | None -> Some Keeper_failure_policy.Unknown_timeout)
+let oas_timeout_budget_policy_decision =
+  Observations.oas_timeout_budget_policy_decision
 ;;
 
-let oas_timeout_budget_policy_decision
-      ~(strikes : int)
-      (err : Agent_sdk.Error.sdk_error)
-  : Keeper_failure_policy.decision option
-  =
-  match Keeper_turn_driver.classify_masc_internal_error err with
-  | Some (Keeper_turn_driver.Oas_timeout_budget { phase; _ }) ->
-    Some
-      (Keeper_failure_policy.decide
-         (Keeper_failure_policy.Oas_timeout_budget
-            { phase = timeout_phase_of_oas_timeout_budget_phase phase
-            ; strikes = Some strikes
-            ; liveness = Keeper_failure_policy.Recent_heartbeat
-            }))
-  | Some
-      ( Keeper_turn_driver.Cascade_exhausted _
-      | Keeper_turn_driver.Resumable_cli_session _
-      | Keeper_turn_driver.No_tool_capable_provider _
-      | Keeper_turn_driver.Accept_rejected _
-      | Keeper_turn_driver.Admission_queue_timeout _
-      | Keeper_turn_driver.Admission_queue_rejected _
-      | Keeper_turn_driver.Turn_timeout _
-      | Keeper_turn_driver.Max_tokens_ceiling_violation _
-      | Keeper_turn_driver.Ambiguous_post_commit _ )
-  | None ->
-    None
-;;
-
-let oas_timeout_budget_metric_outcome
-      (decision : Keeper_failure_policy.decision)
-  =
-  match decision.lifecycle_effect with
-  | Keeper_failure_policy.Keep_running
-  | Keeper_failure_policy.Soft_fail_turn -> "warn"
-  | Keeper_failure_policy.Pause_current_work -> "soft_backoff"
-  | Keeper_failure_policy.Force_release_turn -> "force_release"
-  | Keeper_failure_policy.Pause_keeper -> "pause"
-  | Keeper_failure_policy.Restart_keeper ->
-    if Keeper_failure_policy.should_kill_keeper decision then "promote" else "restart"
+let oas_timeout_budget_metric_outcome =
+  Observations.oas_timeout_budget_metric_outcome
 ;;
 
 let persist_message_cursor_updates ~config (meta : keeper_meta) updates =

--- a/lib/keeper/keeper_heartbeat_loop_observations.ml
+++ b/lib/keeper/keeper_heartbeat_loop_observations.ml
@@ -1,0 +1,210 @@
+(** Observation reason helpers for the keeper heartbeat loop. *)
+
+type semaphore_wait_observation_kind =
+  | Semaphore_wait_pending
+  | Semaphore_wait_timeout
+
+let semaphore_wait_observation_reasons ?phase_label ~kind ~channel () =
+  let kind_reason =
+    match kind with
+    | Semaphore_wait_pending -> "semaphore_wait_pending"
+    | Semaphore_wait_timeout -> "semaphore_wait_timeout"
+  in
+  let wait_reason =
+    match phase_label with
+    | Some phase -> "phase_" ^ phase
+    | None -> "peers_holding_slot"
+  in
+  [ kind_reason
+  ; wait_reason
+  ; "channel_" ^ Keeper_world_observation.channel_to_string channel
+  ]
+;;
+
+let record_semaphore_wait_observation
+      ?phase_label
+      ~base_path
+      ~keeper_name
+      ~channel
+      ~kind
+      ()
+  =
+  Keeper_registry.record_skip_reasons
+    ~base_path
+    keeper_name
+    ~reasons:(semaphore_wait_observation_reasons ?phase_label ~kind ~channel ())
+;;
+
+type cascade_backpressure_decision =
+  | Cascade_admitted
+  | Cascade_backpressured of {
+      cascade_name : string;
+      reason : string;
+    }
+
+let skip_reason_component raw =
+  let normalized = String.lowercase_ascii (String.trim raw) in
+  let mapped =
+    String.map
+      (function
+        | ('a' .. 'z' | '0' .. '9' | '_') as c -> c
+        | '-' -> '_'
+        | _ -> '_')
+      normalized
+  in
+  if String.equal mapped "" then "unknown" else mapped
+;;
+
+let cascade_backpressure_observation_reasons ~reason =
+  let category =
+    if String.starts_with ~prefix:"cascade_resilience_" reason
+    then "cascade_resilience"
+    else "cascade_unhealthy"
+  in
+  [ "cascade_backpressure"
+  ; category
+  ; "reason_" ^ skip_reason_component reason
+  ]
+;;
+
+let cascade_resilience_backpressure_reason
+      (resilience : Keeper_exec_preflight.cascade_resilience)
+  =
+  Option.map
+    (fun blocker -> "cascade_resilience_" ^ blocker)
+    resilience.blocker
+;;
+
+let cascade_backpressure_decision
+      ~cascade_resilience
+      ~should_run_turn
+      ~cascade_name
+      ~cascade_status
+  =
+  let resilience_reason =
+    match cascade_resilience with
+    | None -> None
+    | Some resilience -> cascade_resilience_backpressure_reason resilience
+  in
+  match should_run_turn, cascade_status, resilience_reason with
+  | true, Keeper_health_probe.Unhealthy reason, _ ->
+    Cascade_backpressured { cascade_name; reason }
+  | true, _, Some reason -> Cascade_backpressured { cascade_name; reason }
+  | false, _, _
+  | true, Keeper_health_probe.Unknown, None
+  | true, Keeper_health_probe.Healthy, None -> Cascade_admitted
+;;
+
+let record_cascade_backpressure_observation ~base_path ~keeper_name ~reason =
+  Keeper_registry.record_skip_reasons
+    ~base_path
+    keeper_name
+    ~reasons:(cascade_backpressure_observation_reasons ~reason);
+  Keeper_registry.touch_last_turn_ts ~base_path keeper_name
+;;
+
+let oas_timeout_budget_observation_reasons =
+  [ "provider_runtime_error"; "oas_timeout_budget"; "keeper_turn_retry_backoff" ]
+;;
+
+let record_oas_timeout_budget_observation ~base_path ~keeper_name =
+  Keeper_registry.record_skip_reasons
+    ~base_path
+    keeper_name
+    ~reasons:oas_timeout_budget_observation_reasons;
+  Keeper_registry.touch_last_turn_ts ~base_path keeper_name
+;;
+
+let clear_oas_timeout_budget_failure_reason ~base_path ~keeper_name =
+  match Keeper_registry.get ~base_path keeper_name with
+  | Some
+      { Keeper_registry.last_failure_reason =
+          Some (Keeper_registry.Oas_timeout_budget_loop _)
+      ; _
+      } -> Keeper_registry.set_failure_reason ~base_path keeper_name None
+  | _ -> ()
+;;
+
+let prior_oas_timeout_budget_strikes ~base_path ~keeper_name =
+  match Keeper_registry.get ~base_path keeper_name with
+  | Some
+      { Keeper_registry.last_failure_reason =
+          Some (Keeper_registry.Oas_timeout_budget_loop { count })
+      ; _
+      } -> count
+  | _ -> 0
+;;
+
+let is_oas_timeout_budget_error (err : Agent_sdk.Error.sdk_error) =
+  (* Enumerate every [masc_internal_error] variant + [None] so the
+     compiler flags any new constructor here. Mirrors the fix in
+     [degraded_retry_bypasses_slot_phase_guard] (PR #14716) and
+     [cascade_permanently_dead] (PR #14762); this site was missed in
+     both sweeps — the same predicate shape exists in three places
+     and only this one still had a catch-all. *)
+  match Keeper_turn_driver.classify_masc_internal_error err with
+  | Some (Keeper_turn_driver.Oas_timeout_budget _) -> true
+  | Some
+      ( Keeper_turn_driver.Cascade_exhausted _
+      | Keeper_turn_driver.Resumable_cli_session _
+      | Keeper_turn_driver.No_tool_capable_provider _
+      | Keeper_turn_driver.Accept_rejected _
+      | Keeper_turn_driver.Admission_queue_timeout _
+      | Keeper_turn_driver.Admission_queue_rejected _
+      | Keeper_turn_driver.Turn_timeout _
+      | Keeper_turn_driver.Max_tokens_ceiling_violation _
+      | Keeper_turn_driver.Ambiguous_post_commit _ )
+  | None ->
+    false
+;;
+
+let timeout_phase_of_oas_timeout_budget_phase phase =
+  let phase = String.trim phase in
+  if String.equal phase ""
+  then None
+  else (
+    match Keeper_failure_policy.timeout_phase_of_label phase with
+    | Some phase -> Some phase
+    | None -> Some Keeper_failure_policy.Unknown_timeout)
+;;
+
+let oas_timeout_budget_policy_decision
+      ~(strikes : int)
+      (err : Agent_sdk.Error.sdk_error)
+  : Keeper_failure_policy.decision option
+  =
+  match Keeper_turn_driver.classify_masc_internal_error err with
+  | Some (Keeper_turn_driver.Oas_timeout_budget { phase; _ }) ->
+    Some
+      (Keeper_failure_policy.decide
+         (Keeper_failure_policy.Oas_timeout_budget
+            { phase = timeout_phase_of_oas_timeout_budget_phase phase
+            ; strikes = Some strikes
+            ; liveness = Keeper_failure_policy.Recent_heartbeat
+            }))
+  | Some
+      ( Keeper_turn_driver.Cascade_exhausted _
+      | Keeper_turn_driver.Resumable_cli_session _
+      | Keeper_turn_driver.No_tool_capable_provider _
+      | Keeper_turn_driver.Accept_rejected _
+      | Keeper_turn_driver.Admission_queue_timeout _
+      | Keeper_turn_driver.Admission_queue_rejected _
+      | Keeper_turn_driver.Turn_timeout _
+      | Keeper_turn_driver.Max_tokens_ceiling_violation _
+      | Keeper_turn_driver.Ambiguous_post_commit _ )
+  | None ->
+    None
+;;
+
+let oas_timeout_budget_metric_outcome
+      (decision : Keeper_failure_policy.decision)
+  =
+  match decision.lifecycle_effect with
+  | Keeper_failure_policy.Keep_running
+  | Keeper_failure_policy.Soft_fail_turn -> "warn"
+  | Keeper_failure_policy.Pause_current_work -> "soft_backoff"
+  | Keeper_failure_policy.Force_release_turn -> "force_release"
+  | Keeper_failure_policy.Pause_keeper -> "pause"
+  | Keeper_failure_policy.Restart_keeper ->
+    if Keeper_failure_policy.should_kill_keeper decision then "promote" else "restart"
+;;

--- a/lib/keeper/keeper_heartbeat_loop_observations.mli
+++ b/lib/keeper/keeper_heartbeat_loop_observations.mli
@@ -1,0 +1,70 @@
+(** Observation reason helpers for the keeper heartbeat loop. *)
+
+type semaphore_wait_observation_kind =
+  | Semaphore_wait_pending
+  | Semaphore_wait_timeout
+
+val semaphore_wait_observation_reasons
+  :  ?phase_label:string
+  -> kind:semaphore_wait_observation_kind
+  -> channel:Keeper_world_observation.keeper_cycle_channel
+  -> unit
+  -> string list
+
+val record_semaphore_wait_observation
+  :  ?phase_label:string
+  -> base_path:string
+  -> keeper_name:string
+  -> channel:Keeper_world_observation.keeper_cycle_channel
+  -> kind:semaphore_wait_observation_kind
+  -> unit
+  -> unit
+
+type cascade_backpressure_decision =
+  | Cascade_admitted
+  | Cascade_backpressured of {
+      cascade_name : string;
+      reason : string;
+    }
+
+val cascade_backpressure_observation_reasons : reason:string -> string list
+
+val cascade_backpressure_decision
+  :  cascade_resilience:Keeper_exec_preflight.cascade_resilience option
+  -> should_run_turn:bool
+  -> cascade_name:string
+  -> cascade_status:Keeper_health_probe.health_status
+  -> cascade_backpressure_decision
+
+val record_cascade_backpressure_observation
+  :  base_path:string
+  -> keeper_name:string
+  -> reason:string
+  -> unit
+
+val oas_timeout_budget_observation_reasons : string list
+
+val record_oas_timeout_budget_observation
+  :  base_path:string
+  -> keeper_name:string
+  -> unit
+
+val clear_oas_timeout_budget_failure_reason
+  :  base_path:string
+  -> keeper_name:string
+  -> unit
+
+val prior_oas_timeout_budget_strikes
+  :  base_path:string
+  -> keeper_name:string
+  -> int
+
+val is_oas_timeout_budget_error : Agent_sdk.Error.sdk_error -> bool
+val timeout_phase_of_oas_timeout_budget_phase : string -> Keeper_failure_policy.timeout_phase option
+
+val oas_timeout_budget_policy_decision
+  :  strikes:int
+  -> Agent_sdk.Error.sdk_error
+  -> Keeper_failure_policy.decision option
+
+val oas_timeout_budget_metric_outcome : Keeper_failure_policy.decision -> string


### PR DESCRIPTION
## Summary

- split heartbeat-loop observation helpers into `Keeper_heartbeat_loop_observations`
- preserve the existing `Keeper_heartbeat_loop` public aliases for semaphore wait, cascade backpressure, and OAS timeout budget helpers
- register the new private module in `lib/dune`

## Godfile delta

- `lib/keeper/keeper_heartbeat_loop.ml`: 2039 -> 1892 lines
- New module:
  - `lib/keeper/keeper_heartbeat_loop_observations.ml`: 210 lines
  - `lib/keeper/keeper_heartbeat_loop_observations.mli`: 70 lines

## Validation

- `ocamlformat --check lib/keeper/keeper_heartbeat_loop.ml lib/keeper/keeper_heartbeat_loop_observations.ml lib/keeper/keeper_heartbeat_loop_observations.mli`
- `git diff --check`
- `scripts/ocaml-structure-ratchet.sh`
- `bash scripts/lint/godfile-size-regression.sh`
- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_semaphore_wait_counter.exe test/test_oas_timeout_budget_strike.exe`
- `./_build/default/test/test_keeper_semaphore_wait_counter.exe` (15 tests)
- `./_build/default/test/test_oas_timeout_budget_strike.exe` (7 tests)
