### PR TITLE
feat(sdk-tool): received-kind in input-schema validator (7 sites)

### DIFF
--- a/lib/sdk_tool_contract.ml
+++ b/lib/sdk_tool_contract.ml
@@ -291,6 +291,18 @@ let label_or_default label fallback =
   | Some value when String.trim value <> "" -> value
   | _ -> fallback
 
+let json_kind_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "intlit"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+
 let rec validate_json_value ?label schema value =
   let label = label_or_default label "input" in
   match schema_type schema with
@@ -319,7 +331,10 @@ let rec validate_json_value ?label schema value =
                         | Error _ as error -> error))
               in
               validate_props properties)
-      | _ -> Error (Printf.sprintf "%s must be a JSON object" label))
+      | other ->
+          Error
+            (Printf.sprintf "%s must be a JSON object (received %s)" label
+               (json_kind_name other)))
   | "array" -> (
       match value with
       | `List items ->
@@ -338,23 +353,38 @@ let rec validate_json_value ?label schema value =
                       | Error _ as error -> error)
                 in
                 validate_items items)
-      | _ -> Error (Printf.sprintf "%s must be a JSON array" label))
+      | other ->
+          Error
+            (Printf.sprintf "%s must be a JSON array (received %s)" label
+               (json_kind_name other)))
   | "string" -> (
       match value with
       | `String _ -> Ok ()
-      | _ -> Error (Printf.sprintf "%s must be a string" label))
+      | other ->
+          Error
+            (Printf.sprintf "%s must be a string (received %s)" label
+               (json_kind_name other)))
   | "integer" -> (
       match value with
       | `Int _ -> Ok ()
-      | _ -> Error (Printf.sprintf "%s must be an integer" label))
+      | other ->
+          Error
+            (Printf.sprintf "%s must be an integer (received %s)" label
+               (json_kind_name other)))
   | "number" -> (
       match value with
       | `Int _ | `Float _ -> Ok ()
-      | _ -> Error (Printf.sprintf "%s must be a number" label))
+      | other ->
+          Error
+            (Printf.sprintf "%s must be a number (received %s)" label
+               (json_kind_name other)))
   | "boolean" -> (
       match value with
       | `Bool _ -> Ok ()
-      | _ -> Error (Printf.sprintf "%s must be a boolean" label))
+      | other ->
+          Error
+            (Printf.sprintf "%s must be a boolean (received %s)" label
+               (json_kind_name other)))
   | _ -> Ok ()
 
 let validate_input_json schema json =
@@ -425,7 +455,10 @@ let build_operation_arguments ~agent_name binding json =
                     | None -> build acc rest))
           in
           build [] binding.arg_bindings
-      | _ -> Error "input must be a JSON object")
+      | other ->
+          Error
+            (Printf.sprintf "input must be a JSON object (received %s)"
+               (json_kind_name other)))
 
 let resolve_requested_tool_call ~agent_name ~requested_name ~arguments =
   match sdk_binding_by_name requested_name with


### PR DESCRIPTION
## Why

`lib/sdk_tool_contract.ml`의 JSON-Schema validator 7 사이트가 expected-only 안티패턴. tool invocation 실패 시 operator는 validation이 어디서 어떤 값에 걸렸는지 추측해야 함.

## What

7 사이트 cohort closure, 모두 label-aware `(received <kind>)`:

| Line | Schema type |
|---|---|
| 334 | object (non-object value) |
| 353 | array (non-array value) |
| 357 | string (non-string value) |
| 361 | integer (non-int value) |
| 365 | number (non-int|float value) |
| 369 | boolean (non-bool value) |
| 458 | input top-level (non-object outer) |

이전 `items[3] must be a string` → 이제 `items[3] must be a string (received int)`. label-prefix는 nested schema path를 보존하므로 어디서 fail인지 즉시 식별.

File-private `json_kind_name` — 10 `Yojson.Safe.t` variants closed total function.

## Cohort boundary

L340 `%s must be a non-empty JSON array` 는 *semantic minItems constraint* (positive count check), type-shape mismatch가 아니므로 cohort 외.

## Iter#13~#21 series

9-PR series = **51 사이트 across 9 files**, 같은 inline `json_kind_name` form.

## Workaround Rejection Bar

- [x] Counter-as-fix 아님
- [x] String/substring classifier 아님 — closed sum type
- [x] N-of-M 아님 — 7/7 type-shape cohort
- [x] Cap/cooldown/dedup/repair 아님
- [x] Test backdoor 아님

## RFC Check

PASS — sdk_tool_contract = tool-binding + input-schema validator. credential boundary 아님.

## Verification

- [x] `ocamlformat --check` PASS (auto)
- [x] test grep 결과 sdk_tool_contract 무관
- [ ] CI 모니터링

## Iter#15.5 sweep

30 PR sweep PASS (6회째).

🤖 /loop cron \`253cc0f6\` Iter#21

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>