### PR TITLE
fix(ci): stabilize release evidence and Dune cache retry

### DIFF
--- a/scripts/release-evidence.sh
+++ b/scripts/release-evidence.sh
@@ -61,6 +61,8 @@ namespace_headers="$out_dir/namespace-truth.headers"
 namespace_body="$out_dir/namespace-truth.body"
 namespace_json="$out_dir/namespace-truth.json"
 dev_token_json="$out_dir/dashboard-dev-token.json"
+install_version_stdout="$out_dir/install-version.stdout"
+install_version_stderr="$out_dir/install-version.stderr"
 
 cleanup() {
   if [[ -n "${SERVER_PID:-}" ]]; then
@@ -205,14 +207,35 @@ copy_install_smoke() {
   cp config/tool_policy.toml "$base_path/.masc/config/tool_policy.toml"
 }
 
+capture_installed_version() {
+  : >"$install_version_stdout"
+  : >"$install_version_stderr"
+  if ! MASC_BASE_PATH="$base_path" \
+    "$installed_bin" --version >"$install_version_stdout" 2>"$install_version_stderr"; then
+    echo "release-evidence: installed binary --version failed" >&2
+    cat "$install_version_stderr" >&2 || true
+    exit 1
+  fi
+
+  local version
+  version="$(tail -n1 "$install_version_stdout")"
+  if [[ -z "$version" ]]; then
+    echo "release-evidence: installed binary --version produced no output" >&2
+    cat "$install_version_stderr" >&2 || true
+    exit 1
+  fi
+  printf '%s\n' "$version"
+}
+
 PORT="${SMOKE_PORT:-$(pick_free_port)}"
 BASE_URL="http://127.0.0.1:${PORT}"
 MCP_URL="${BASE_URL}/mcp"
 
 copy_install_smoke
-installed_version="$("$installed_bin" --version 2>/dev/null | tail -n1)"
+installed_version="$(capture_installed_version)"
 
 env \
+  MASC_BASE_PATH="$base_path" \
   MASC_ADMIN_TOKEN= \
   MASC_INTERNAL_MCP_TOKEN= \
   MASC_MCP_TOKEN= \
@@ -382,6 +405,8 @@ md = f"""# Release Evidence Bundle
 
 ## Raw Captures
 
+- `install-version.stdout`
+- `install-version.stderr`
 - `health.json`
 - `initialize.headers`
 - `initialize.json`

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -89,6 +89,13 @@ is_stale_dune_artifact_log() {
         "$log_file"
 }
 
+is_dune_cache_temp_log() {
+    local log_file="$1"
+    grep -Eiq \
+        'rmdir\(.*[.]cache/dune/db/temp/.*\): Directory not empty|[.]cache/dune/db/temp/.*Directory not empty' \
+        "$log_file"
+}
+
 run_dune_local() {
     local wrapper="$SCRIPT_DIR/scripts/dune-local.sh"
     if [ ! -x "$wrapper" ]; then
@@ -116,6 +123,20 @@ dune_build_with_stale_retry() {
         return 0
     else
         first_status=$?
+    fi
+
+    if is_dune_cache_temp_log "$log_file"; then
+        cat "$log_file" >&2
+        echo "[startup] Dune cache temp cleanup failed while building $label; retrying once with DUNE_CACHE=disabled." >&2
+        if DUNE_CACHE=disabled run_dune_local build "$target" >"$log_file" 2>&1; then
+            cat "$log_file" >&2
+            rm -f "$log_file"
+            return 0
+        fi
+        cat "$log_file" >&2
+        echo "[startup] Retry build failed after disabling Dune cache; preserved Dune output above." >&2
+        rm -f "$log_file"
+        return 1
     fi
 
     if ! is_stale_dune_artifact_log "$log_file"; then

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -669,6 +669,12 @@ let test_release_truth_contracts () =
   check bool "release workflow ships evidence with artifacts" true
     (file_contains_pattern ".github/workflows/release.yml"
        "path: dist/*");
+  check bool "release evidence install smoke uses isolated base path" true
+    (file_contains_pattern "scripts/release-evidence.sh"
+       "MASC_BASE_PATH=\"$base_path\"");
+  check bool "release evidence install smoke fails loudly" true
+    (file_contains_pattern "scripts/release-evidence.sh"
+       "release-evidence: installed binary --version failed");
   check bool "make install deps skips with-doc" true
     (file_contains_pattern "mk/build.mk"
        "opam install . --deps-only --with-test -y");

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -200,13 +200,63 @@ esac
 |}
        (quote state_file) (quote clean_marker))
 
+let write_fake_dune_cache_temp_then_success ~path ~state_file ~clean_marker =
+  write_executable path
+    (Printf.sprintf
+       {|
+#!/bin/sh
+set -eu
+state=%s
+clean_marker=%s
+cmd="${1:-}"
+case "$cmd" in
+  build)
+    count=0
+    if [ -f "$state" ]; then
+      count="$(cat "$state")"
+    fi
+    if [ "$count" = "0" ]; then
+      echo 1 > "$state"
+      echo "Error:" >&2
+      echo "rmdir(/Users/test/.cache/dune/db/temp/dune_6eb519_artifacts): Directory not empty" >&2
+      exit 1
+    fi
+    if [ "${DUNE_CACHE:-}" != "disabled" ]; then
+      echo "expected DUNE_CACHE=disabled on cache-temp retry, got ${DUNE_CACHE:-<unset>}" >&2
+      exit 3
+    fi
+    mkdir -p _build/default/bin
+    cat > _build/default/bin/main_eio.exe <<'EXE'
+#!/bin/sh
+set -eu
+{
+  printf 'FAKE_EXE_MARKER=eio-after-cache-temp-retry\n'
+  printf 'PWD=%%s\n' "$(pwd)"
+  printf 'ARGS=%%s\n' "$*"
+} >"${FAKE_CAPTURE_FILE:?}"
+exit 0
+EXE
+    chmod +x _build/default/bin/main_eio.exe
+    echo "fake dune build recovered with cache disabled" >&2
+    ;;
+  clean)
+    echo clean > "$clean_marker"
+    ;;
+  *)
+    echo "unexpected dune command: $*" >&2
+    exit 2
+    ;;
+esac
+|}
+       (quote state_file) (quote clean_marker))
+
 let write_fake_dune_local ~path ~log_file =
   write_executable path
     (Printf.sprintf
        {|
 #!/bin/sh
 set -eu
-printf 'dune-local %%s DUNE_JOBS=%%s DUNE_LOCAL_JOBS=%%s\n' "$*" "${DUNE_JOBS:-}" "${DUNE_LOCAL_JOBS:-}" >> %s
+printf 'dune-local %%s DUNE_JOBS=%%s DUNE_LOCAL_JOBS=%%s DUNE_CACHE=%%s\n' "$*" "${DUNE_JOBS:-}" "${DUNE_LOCAL_JOBS:-}" "${DUNE_CACHE:-}" >> %s
 exec dune "$@"
 |}
        (quote log_file))
@@ -810,6 +860,65 @@ let test_stale_dune_artifacts_are_cleaned_and_retried () =
           check bool "retry output preserved" true
             (contains_substring stderr "fake dune build recovered")))
 
+let test_dune_cache_temp_error_retries_with_cache_disabled () =
+  with_temp_dir "start-masc-script-cache-temp-dune" (fun dir ->
+      with_temp_dir "start-masc-cache-temp-fake-bin" (fun fake_bin ->
+          let script = Filename.concat dir "start-masc-mcp.sh" in
+          let scripts_dir = Filename.concat dir "scripts" in
+          let dune_state = Filename.concat dir "dune-build-count.txt" in
+          let clean_marker = Filename.concat dir "dune-clean-ran.txt" in
+          let dune_local_log = Filename.concat dir "dune-local-calls.txt" in
+          let capture = Filename.concat dir "captured-cache-temp-dune.txt" in
+          copy_script (script_path ()) script;
+          ignore (make_config_root dir);
+          mkdir_p scripts_dir;
+          mkdir_p fake_bin;
+          write_executable (Filename.concat fake_bin "opam")
+            "#!/bin/sh\nexit 0\n";
+          write_fake_dune_cache_temp_then_success
+            ~path:(Filename.concat fake_bin "dune")
+            ~state_file:dune_state ~clean_marker;
+          write_fake_dune_local
+            ~path:(Filename.concat scripts_dir "dune-local.sh")
+            ~log_file:dune_local_log;
+          let code, stdout, stderr =
+            run_shell ~cwd:dir
+              ~env:
+                [
+                  ("FAKE_CAPTURE_FILE", capture);
+                  ("MASC_BASE_PATH", dir);
+                  ("MASC_DUNE_JOBS", "2");
+                  ("PATH", fake_bin ^ ":" ^ Sys.getenv "PATH");
+                ]
+              (Printf.sprintf "%s --http --port 9972 --base-path %s"
+                 (quote script) (quote dir))
+          in
+          if code <> 0 then
+            failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s"
+              code stdout stderr;
+          let captured = read_file capture in
+          check bool "server started from cache-disabled retry executable" true
+            (contains_substring captured
+               "FAKE_EXE_MARKER=eio-after-cache-temp-retry");
+          check bool "dune clean was not used for cache temp retry" false
+            (Sys.file_exists clean_marker);
+          let dune_local_calls = read_file dune_local_log in
+          check bool "initial startup build used cache default" true
+            (contains_substring dune_local_calls
+               "dune-local build bin/main_eio.exe DUNE_JOBS=2 DUNE_LOCAL_JOBS=2 DUNE_CACHE=");
+          check bool "retry disabled Dune cache" true
+            (contains_substring dune_local_calls
+               "dune-local build bin/main_eio.exe DUNE_JOBS=2 DUNE_LOCAL_JOBS=2 DUNE_CACHE=disabled");
+          check bool "original cache temp error preserved" true
+            (contains_substring stderr
+               "rmdir(/Users/test/.cache/dune/db/temp/dune_6eb519_artifacts): Directory not empty");
+          check bool "cache retry is explained" true
+            (contains_substring stderr
+               "Dune cache temp cleanup failed while building main_eio.exe");
+          check bool "cache retry output preserved" true
+            (contains_substring stderr
+               "fake dune build recovered with cache disabled")))
+
 let test_stale_executable_requires_build_lock () =
   with_temp_dir "start-masc-script-build-lock" (fun dir ->
       with_temp_dir "start-masc-build-lock-fake-bin" (fun fake_bin ->
@@ -1045,6 +1154,8 @@ let () =
             test_grpc_direct_banner_is_preserved_in_stderr;
           test_case "stale Dune artifacts are cleaned and retried" `Quick
             test_stale_dune_artifacts_are_cleaned_and_retried;
+          test_case "Dune cache temp errors retry with cache disabled" `Quick
+            test_dune_cache_temp_error_retries_with_cache_disabled;
           test_case "stale executable requires build lock" `Quick
             test_stale_executable_requires_build_lock;
           test_case "stdio skips dashboard build and HTTP preflight" `Quick


### PR DESCRIPTION
## Summary

- retry `start-masc-mcp.sh` once with `DUNE_CACHE=disabled` when Dune cache temp cleanup fails with `Directory not empty`
- make `scripts/release-evidence.sh` run install-smoke and server boot against the isolated `MASC_BASE_PATH`
- preserve install-smoke stdout/stderr in the release evidence bundle so CI does not fail silently

## Root Cause

Main runtime restart failed locally on:

```text
rmdir(.../.cache/dune/db/temp/...): Directory not empty
```

Main CI was not failing at compile/test. `Build`, quick suite, operator/SSE/transport/contract, Lint, Health, Dashboard, Meta Guards, and TLA passed. The hard blocker was `Generate main release evidence bundle`, which reproduced locally when `MASC_BASE_PATH` was unset. The script had created an isolated base path, but did not export it for `--version` or server boot.

## Verification

- `bash -n start-masc-mcp.sh`
- `bash -n scripts/release-evidence.sh`
- `opam exec -- ocamlformat --check test/test_start_masc_mcp_script.ml test/test_ci_hardening_source.ml`
- `git diff --check`
- `env -u MASC_BASE_PATH -u MASC_CONFIG_DIR -u MASC_MCP_TOKEN -u MASC_ADMIN_TOKEN -u MASC_INTERNAL_MCP_TOKEN BOOT_WAIT_SEC=20 scripts/release-evidence.sh /Users/dancer/me/workspace/yousleepwhen/masc-mcp/_build/default/bin/main_eio.exe /private/tmp/main-release-evidence-no-base-fixed.md`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_ci_hardening_source.exe test/test_start_masc_mcp_script.exe`
- `./_build/default/test/test_start_masc_mcp_script.exe`
- `./_build/default/test/test_ci_hardening_source.exe test source_guard 5`

## Notes

Full `./_build/default/test/test_ci_hardening_source.exe` still fails on existing unrelated source-guard drift. The touched `release truth contracts` case passes when run directly.
