### PR TITLE
refactor: split keeper api trace helpers

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -92,6 +92,7 @@
  dashboard_http_keeper_outcomes
  dashboard_http_keeper_trust
  dashboard_http_keeper
+ server_dashboard_http_keeper_api_trace
  server_dashboard_http_keeper_api_checkpoints
  server_dashboard_http_keeper_runtime_manifest_scan
  server_dashboard_http_keeper_runtime_lens_proof

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -6,6 +6,7 @@
 
 module Http = Http_server_eio
 module Checkpoints = Server_dashboard_http_keeper_api_checkpoints
+module Trace = Server_dashboard_http_keeper_api_trace
 
 (* Keeper route constants + classifier moved to
    Server_dashboard_http_keeper_api_types (intra-library file split,
@@ -16,59 +17,15 @@ let dedupe_tool_names names =
   Json_util.dedupe_keep_order
     (names |> List.map String.trim |> List.filter (fun name -> name <> ""))
 
-let trajectory_line_ts = function
-  | Trajectory.Tool_call entry -> entry.ts
-  | Trajectory.Thinking entry -> entry.ts
-
-let dedupe_thinking_lines (lines : Trajectory.trajectory_line list)
-    : Trajectory.trajectory_line list =
-  let seen = Hashtbl.create 32 in
-  List.filter
-    (function
-      | Trajectory.Tool_call _ -> true
-      | Trajectory.Thinking entry ->
-          let key =
-            Printf.sprintf "%.6f\x1f%b\x1f%s"
-              entry.ts entry.redacted entry.content
-          in
-          if Hashtbl.mem seen key then false
-          else (
-            Hashtbl.add seen key ();
-            true))
-    lines
+let trajectory_line_ts = Trace.line_ts
+let dedupe_thinking_lines = Trace.dedupe_thinking_lines
 
 (* internal_history_json_to_trajectory_line moved to
    Server_dashboard_http_keeper_api_types (intra-library file split,
    2026-05-16). *)
 
-let read_internal_history_lines ~(config : Coord.config) ~(trace_id : string)
-    : Trajectory.trajectory_line list =
-  let path = Keeper_types.keeper_internal_history_path config trace_id in
-  (* Streaming filter — avoid materialising the full JSONL list when
-     only a subset of lines decode to [trajectory_line]. Output is built
-     in reverse and reversed once, matching List.filter_map ordering. *)
-  Fs_compat.fold_jsonl_lines
-    ~init:[]
-    ~f:(fun acc ~line_no:_ json ->
-      match internal_history_json_to_trajectory_line json with
-      | Some line -> line :: acc
-      | None -> acc)
-    path
-  |> List.rev
-
-let merge_keeper_trace_lines ~(config : Coord.config) ~(trace_id : string)
-    (trajectory_lines : Trajectory.trajectory_line list)
-    : Trajectory.trajectory_line list =
-  let internal_lines = read_internal_history_lines ~config ~trace_id in
-  dedupe_thinking_lines (trajectory_lines @ internal_lines)
-  |> List.sort (fun left right ->
-         let cmp = Float.compare (trajectory_line_ts left) (trajectory_line_ts right) in
-         if cmp <> 0 then cmp
-         else
-           match left, right with
-           | Trajectory.Thinking _, Trajectory.Tool_call _ -> -1
-           | Trajectory.Tool_call _, Trajectory.Thinking _ -> 1
-           | _ -> 0)
+let read_internal_history_lines = Trace.read_internal_history_lines
+let merge_keeper_trace_lines = Trace.merge_keeper_trace_lines
 
 let keeper_tools_response_json (meta : Keeper_types.keeper_meta) =
   let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in

--- a/lib/server/server_dashboard_http_keeper_api_trace.ml
+++ b/lib/server/server_dashboard_http_keeper_api_trace.ml
@@ -1,0 +1,66 @@
+(** Runtime trace trajectory helpers for keeper dashboard API. *)
+
+let line_ts = function
+  | Trajectory.Tool_call entry -> entry.ts
+  | Trajectory.Thinking entry -> entry.ts
+;;
+
+let dedupe_thinking_lines (lines : Trajectory.trajectory_line list)
+  : Trajectory.trajectory_line list
+  =
+  let seen = Hashtbl.create 32 in
+  List.filter
+    (function
+      | Trajectory.Tool_call _ -> true
+      | Trajectory.Thinking entry ->
+        let key =
+          Printf.sprintf
+            "%.6f\x1f%b\x1f%s"
+            entry.ts
+            entry.redacted
+            entry.content
+        in
+        if Hashtbl.mem seen key
+        then false
+        else (
+          Hashtbl.add seen key ();
+          true))
+    lines
+;;
+
+let read_internal_history_lines ~(config : Coord.config) ~(trace_id : string)
+  : Trajectory.trajectory_line list
+  =
+  let path = Keeper_types.keeper_internal_history_path config trace_id in
+  (* Streaming filter: avoid materialising the full JSONL list when only a
+     subset of lines decode to [trajectory_line]. *)
+  Fs_compat.fold_jsonl_lines
+    ~init:[]
+    ~f:(fun acc ~line_no:_ json ->
+       match
+         Server_dashboard_http_keeper_api_types
+         .internal_history_json_to_trajectory_line
+           json
+       with
+       | Some line -> line :: acc
+       | None -> acc)
+    path
+  |> List.rev
+;;
+
+let merge_keeper_trace_lines ~(config : Coord.config) ~(trace_id : string)
+      (trajectory_lines : Trajectory.trajectory_line list)
+  : Trajectory.trajectory_line list
+  =
+  let internal_lines = read_internal_history_lines ~config ~trace_id in
+  dedupe_thinking_lines (trajectory_lines @ internal_lines)
+  |> List.sort (fun left right ->
+    let cmp = Float.compare (line_ts left) (line_ts right) in
+    if cmp <> 0
+    then cmp
+    else
+      match left, right with
+      | Trajectory.Thinking _, Trajectory.Tool_call _ -> -1
+      | Trajectory.Tool_call _, Trajectory.Thinking _ -> 1
+      | _ -> 0)
+;;

--- a/lib/server/server_dashboard_http_keeper_api_trace.mli
+++ b/lib/server/server_dashboard_http_keeper_api_trace.mli
@@ -1,0 +1,18 @@
+(** Runtime trace trajectory helpers for keeper dashboard API. *)
+
+val line_ts : Trajectory.trajectory_line -> float
+
+val dedupe_thinking_lines
+  :  Trajectory.trajectory_line list
+  -> Trajectory.trajectory_line list
+
+val read_internal_history_lines
+  :  config:Coord.config
+  -> trace_id:string
+  -> Trajectory.trajectory_line list
+
+val merge_keeper_trace_lines
+  :  config:Coord.config
+  -> trace_id:string
+  -> Trajectory.trajectory_line list
+  -> Trajectory.trajectory_line list


### PR DESCRIPTION
## Summary

- split keeper dashboard runtime trace trajectory helpers into `Server_dashboard_http_keeper_api_trace`
- preserve existing `Server_dashboard_http_keeper_api` public helper names as wrappers
- register the new private module in `lib/dune`

## Godfile delta

- `lib/server/server_dashboard_http_keeper_api.ml`: 2075 -> 2032 lines
- New module:
  - `lib/server/server_dashboard_http_keeper_api_trace.ml`: 66 lines
  - `lib/server/server_dashboard_http_keeper_api_trace.mli`: 18 lines

## Validation

- `ocamlformat --check lib/server/server_dashboard_http_keeper_api.ml lib/server/server_dashboard_http_keeper_api_trace.ml lib/server/server_dashboard_http_keeper_api_trace.mli`
- `git diff --check`
- `scripts/ocaml-structure-ratchet.sh`
- `bash scripts/lint/godfile-size-regression.sh`
- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_dashboard_keeper_routes.exe`
- `./_build/default/test/test_dashboard_keeper_routes.exe test dashboard_keeper_routes 22` (targeted trace merge case)

## Note

- Full `./_build/default/test/test_dashboard_keeper_routes.exe` currently fails in existing cascade assignment fixture case 8 with `cascade profile missing from config: tier-group.primary`. The targeted trace merge case 22 passed and is the behavior touched by this split.
