### PR TITLE
feat(mcp-server): received-kind in tool-profile params errors (8 sites)

### DIFF
--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -356,11 +356,26 @@ type tools_list_params = {
 
 open Result.Syntax
 
+let json_kind_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "intlit"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+
 let strict_assoc_params params =
   match params with
   | None -> Ok []
   | Some (`Assoc fields) -> Ok fields
-  | Some _ -> Error "Invalid params: expected object"
+  | Some other ->
+      Error
+        (Printf.sprintf "Invalid params: expected object (received %s)"
+           (json_kind_name other))
 
 let cursor_param payload =
   let open Yojson.Safe.Util in
@@ -372,14 +387,20 @@ let cursor_param payload =
         Error "Invalid params: cursor must not be empty"
       else
         Ok (Some trimmed)
-  | _ -> Error "Invalid params: cursor must be a string"
+  | other ->
+      Error
+        (Printf.sprintf "Invalid params: cursor must be a string (received %s)"
+           (json_kind_name other))
 
 let bool_param payload key =
   let open Yojson.Safe.Util in
   match payload |> member key with
   | `Null -> Ok false
   | `Bool value -> Ok value
-  | _ -> Error (Printf.sprintf "Invalid params: %s must be a boolean" key)
+  | other ->
+      Error
+        (Printf.sprintf "Invalid params: %s must be a boolean (received %s)"
+           key (json_kind_name other))
 
 let decode_cursor_offset = function
   | None -> Ok 0
@@ -422,13 +443,19 @@ let cursor_only_params params =
   match params with
   | None -> Ok None
   | Some (`Assoc _ as payload) -> cursor_param payload
-  | Some _ -> Error "Invalid params: expected object"
+  | Some other ->
+      Error
+        (Printf.sprintf "Invalid params: expected object (received %s)"
+           (json_kind_name other))
 
 let validate_optional_meta payload =
   match Yojson.Safe.Util.member "_meta" payload with
   | `Null
   | `Assoc _ -> Ok ()
-  | _ -> Error "Invalid params: _meta must be an object"
+  | other ->
+      Error
+        (Printf.sprintf "Invalid params: _meta must be an object (received %s)"
+           (json_kind_name other))
 
 let requested_tool_list_params params =
   let open Yojson.Safe.Util in
@@ -459,11 +486,19 @@ let requested_tool_list_params params =
                  match (acc, item) with
                  | Error _ as err, _ -> err
                  | Ok names, `String value -> Ok (value :: names)
-                 | Ok _, _ ->
-                     Error "Invalid params: names must be an array of strings")
+                 | Ok _, bad ->
+                     Error
+                       (Printf.sprintf
+                          "Invalid params: names must be an array of strings \
+                           (received %s element)"
+                          (json_kind_name bad)))
                (Ok [])
           |> Result.map (fun names -> Some (List.rev names))
-      | _ -> Error "Invalid params: names must be an array of strings"
+      | other ->
+          Error
+            (Printf.sprintf
+               "Invalid params: names must be an array of strings (received %s)"
+               (json_kind_name other))
     in
     let* cursor = cursor_param payload in
     let* include_hidden = bool_param payload "include_hidden" in
@@ -497,7 +532,11 @@ let parse_cursor_only_params params =
     match payload |> member "cursor" with
     | `Null -> Ok { cursor = None }
     | `String cursor -> Ok { cursor = Some cursor }
-    | _ -> Error "Invalid params: cursor must be a string"
+    | other ->
+        Error
+          (Printf.sprintf
+             "Invalid params: cursor must be a string (received %s)"
+             (json_kind_name other))
 
 let list_page_size () = Env_config.Tools.list_page_size ()
 


### PR DESCRIPTION
## Why

`lib/mcp_server_eio_tool_profile.ml`의 8 JSON-shape mismatch 사이트가 expected-only 안티패턴. MCP 클라이언트가 tools/list 또는 tools/call 호출 시 params validation 실패하면 무엇이 잘못됐는지 추측해야 함.

## What

8 사이트 cohort closure, 모두 `(received <kind>)`:

| Line | Site | Notes |
|---|---|---|
| 363 | `strict_assoc_params` Some-but-not-Assoc | top-level shape |
| 375 | `cursor_param` non-String non-Null | optional cursor |
| 382 | `bool_param` non-Bool non-Null | key-parameterized |
| 425 | `cursor_only_params` Some-but-not-Assoc | sibling of L363 |
| 431 | `validate_optional_meta` non-Null non-Assoc | _meta hint |
| 463 | `names` array element non-String | `bad :: _` element-offset pattern |
| 466 | `names` outer non-List non-Null | container shape |
| 500 | tools/call `cursor` non-String non-Null | sibling of L375 |

File-private `json_kind_name` — 10 `Yojson.Safe.t` variants closed total function.

## Cohort boundary

Semantic constraints (non-empty/range/base64-format) cohort 외:
- L372 `cursor must not be empty` (non-empty)
- L389 `cursor must be a non-negative integer string` (parse + range)
- L528 `cursor is invalid` (base64/format decode)

## Iter#13~#22 series

10-PR series = **59 사이트 across 10 files**, 같은 inline `json_kind_name` form.

## Workaround Rejection Bar

- [x] Counter-as-fix 아님
- [x] String/substring classifier 아님 — closed sum type
- [x] N-of-M 아님 — 8/8 type-shape cohort closure
- [x] Cap/cooldown/dedup/repair 아님
- [x] Test backdoor 아님

## RFC Check

PASS — MCP protocol params 파싱, credential boundary 아님.

## Verification

- [x] `ocamlformat --check` PASS (auto)
- [x] test grep 0 영향
- [ ] CI 모니터링

## Iter#15.5 sweep

30 PR sweep PASS (7회째).

🤖 /loop cron \`253cc0f6\` Iter#22

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>