### PR TITLE
feat(cdal): received-kind in effect_evidence parse errors (7 sites)

### DIFF
--- a/lib/cdal_runtime/effect_evidence.ml
+++ b/lib/cdal_runtime/effect_evidence.ml
@@ -175,6 +175,19 @@ let to_json t =
     ]
 ;;
 
+let json_kind_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "intlit"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+;;
+
 let assoc_field name fields =
   match List.assoc_opt name fields with
   | Some v -> Ok v
@@ -184,14 +197,20 @@ let assoc_field name fields =
 let int_field name fields =
   match assoc_field name fields with
   | Ok (`Int v) -> Ok v
-  | Ok _ -> Error (Printf.sprintf "field %s must be an int" name)
+  | Ok other ->
+    Error
+      (Printf.sprintf "field %s must be an int (received %s)" name
+         (json_kind_name other))
   | Error _ as err -> err
 ;;
 
 let string_field name fields =
   match assoc_field name fields with
   | Ok (`String v) -> Ok v
-  | Ok _ -> Error (Printf.sprintf "field %s must be a string" name)
+  | Ok other ->
+    Error
+      (Printf.sprintf "field %s must be a string (received %s)" name
+         (json_kind_name other))
   | Error _ as err -> err
 ;;
 
@@ -199,7 +218,10 @@ let float_field name fields =
   match assoc_field name fields with
   | Ok (`Float v) -> Ok v
   | Ok (`Int v) -> Ok (float_of_int v)
-  | Ok _ -> Error (Printf.sprintf "field %s must be a number" name)
+  | Ok other ->
+    Error
+      (Printf.sprintf "field %s must be a number (received %s)" name
+         (json_kind_name other))
   | Error _ as err -> err
 ;;
 
@@ -207,7 +229,10 @@ let option_string_field name fields =
   match List.assoc_opt name fields with
   | None | Some `Null -> Ok None
   | Some (`String v) -> Ok (Some v)
-  | Some _ -> Error (Printf.sprintf "field %s must be a string or null" name)
+  | Some other ->
+    Error
+      (Printf.sprintf "field %s must be a string or null (received %s)" name
+         (json_kind_name other))
 ;;
 
 let option_float_field name fields =
@@ -215,14 +240,20 @@ let option_float_field name fields =
   | None | Some `Null -> Ok None
   | Some (`Float v) -> Ok (Some v)
   | Some (`Int v) -> Ok (Some (float_of_int v))
-  | Some _ -> Error (Printf.sprintf "field %s must be a number or null" name)
+  | Some other ->
+    Error
+      (Printf.sprintf "field %s must be a number or null (received %s)" name
+         (json_kind_name other))
 ;;
 
 let option_int_field name fields =
   match List.assoc_opt name fields with
   | None | Some `Null -> Ok None
   | Some (`Int v) -> Ok (Some v)
-  | Some _ -> Error (Printf.sprintf "field %s must be an int or null" name)
+  | Some other ->
+    Error
+      (Printf.sprintf "field %s must be an int or null (received %s)" name
+         (json_kind_name other))
 ;;
 
 open Result_syntax
@@ -276,5 +307,8 @@ let of_json = function
       ; turn
       ; execution_mode
       }
-  | _ -> Error "effect evidence must be a JSON object"
+  | other ->
+    Error
+      (Printf.sprintf "effect evidence must be a JSON object (received %s)"
+         (json_kind_name other))
 ;;


### PR DESCRIPTION
## Why

`lib/cdal_runtime/effect_evidence.ml`의 7 JSON-shape mismatch 사이트가 expected-only 안티패턴. CDAL effect evidence row replay/inspection 시 operator는 받은 type 추측해야 함.

## What

7 사이트 cohort closure (단순 패턴, 모두 `(received <kind>)`):

| Line | Helper |
|---|---|
| 187 | `int_field` Ok-mismatch |
| 194 | `string_field` Ok-mismatch |
| 202 | `float_field` Ok-mismatch (Float\|Int filter) |
| 210 | `option_string_field` Some-mismatch |
| 218 | `option_float_field` Some-mismatch |
| 225 | `option_int_field` Some-mismatch |
| 279 | `of_json` top-level catch-all |

File-private `json_kind_name` — 10 `Yojson.Safe.t` variants closed total function.

## Iter#13~#23 series

11-PR series = **66 사이트 across 11 files**, 같은 inline `json_kind_name` form.

본 PR이 #16447 (`keeper_runtime_manifest.ml`)와 *구조적 거울*: 같은 6-helper-primitive + 1-top-level 패턴. 두 모듈이 *독립 생성*되었으나 동일 안티패턴 — codebase 전반의 systemic copy-paste 증거.

## Workaround Rejection Bar

- [x] Counter-as-fix 아님
- [x] String/substring classifier 아님 — closed sum type
- [x] N-of-M 아님 — 7/7 cohort closure
- [x] Cap/cooldown/dedup/repair 아님
- [x] Test backdoor 아님

## RFC Check

PASS — CDAL effect evidence record + codec. credential boundary 아님.

## Verification

- [x] `ocamlformat --check` PASS (auto)
- [x] test grep 0
- [ ] CI 모니터링

## Iter#15.5 sweep

30 PR sweep PASS (8회째).

🤖 /loop cron \`253cc0f6\` Iter#23

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>