### PR TITLE
refactor: split dashboard core entities

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -98,6 +98,7 @@
  server_dashboard_http_keeper_runtime_lens_swimlane
  server_dashboard_http_keeper_runtime_lens_summaries
  server_dashboard_http_keeper_runtime_lens_gaps
+ server_dashboard_http_core_entities
  dashboard_goal_loop
  dashboard_http_autoresearch
  dashboard_harness_health

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -1152,118 +1152,28 @@ let dashboard_mission_briefing_http_json ~state ~sw ~clock request =
       compute)
 ;;
 
-let dashboard_shell_status_json (config : Coord.config) : Yojson.Safe.t =
-  let room_state = Coord.read_state config in
-  let cluster = Env_config_core.cluster_name () in
-  let tempo = Tempo.get_tempo config in
-  let build = Build_identity.current () in
-  `Assoc
-    [ "cluster", `String cluster
-    ; "base_path", `String config.base_path
-    ; "coordination_root", `String config.base_path
-    ; "workspace_path", `String config.workspace_path
-    ; "workspace_differs", `Bool (config.workspace_path <> config.base_path)
-    ; "cluster", `String (Env_config_core.cluster_name ())
-    ; "project", `String room_state.project
-    ; "tempo_interval_s", `Float tempo.current_interval_s
-    ; "paused", `Bool room_state.paused
-    ; "version", `String build.release_version
-    ; "build", Build_identity.to_yojson build
-    ]
+let dashboard_shell_status_json =
+  Server_dashboard_http_core_entities.dashboard_shell_status_json
 ;;
 
-let dashboard_task_assignee (task : Masc_domain.task) =
-  match task.task_status with
-  | Claimed { assignee; _ }
-  | InProgress { assignee; _ }
-  | AwaitingVerification { assignee; _ }
-  | Done { assignee; _ } -> Some assignee
-  | Todo | Cancelled _ -> None
-;;
-
-let dashboard_task_json config (task : Masc_domain.task) =
-  let base_fields =
-    [ "id", `String task.id
-    ; "title", `String task.title
-    ; "description", `String task.description
-    ; "status", `String (Masc_domain.string_of_task_status task.task_status)
-    ; "priority", `Int task.priority
-    ; "assignee", Json_util.string_opt_to_json (dashboard_task_assignee task)
-    ; "created_at", `String task.created_at
-    ]
-  in
-  let projection_fields =
-    match
-      (fun _t ->
-         ignore config;
-         `Assoc [])
-        task
-    with
-    | `Assoc fields -> fields
-    | _ -> []
-  in
-  `Assoc (base_fields @ projection_fields)
-;;
-
-let dashboard_agent_json (agent : Masc_domain.agent) =
-  let profile = Dashboard_execution_helpers.get_agent_profile agent.name in
-  let meta = agent.meta in
-  `Assoc
-    [ "name", `String agent.name
-    ; "agent_type", `String agent.agent_type
-    ; ( "keeper_name"
-      , Json_util.string_opt_to_json (Option.bind meta (fun m -> m.keeper_name)) )
-    ; "keeper_id", Json_util.string_opt_to_json (Option.bind meta (fun m -> m.keeper_id))
-    ; "status", `String (Masc_domain.string_of_agent_status agent.status)
-    ; "current_task", Json_util.string_opt_to_json agent.current_task
-    ; "joined_at", `String agent.joined_at
-    ; "last_seen", `String agent.last_seen
-    ; "capabilities", `List (List.map (fun item -> `String item) agent.capabilities)
-    ; "emoji", `String profile.emoji
-    ; "koreanName", `String profile.korean_name
-    ; "model", `Null
-    ; "traits", `List (List.map (fun t -> `String t) profile.traits)
-    ; "interests", `List (List.map (fun i -> `String i) profile.interests)
-    ; "activityLevel", Json_util.float_opt_to_json profile.activity_level
-    ; "primaryValue", Json_util.string_opt_to_json profile.primary_value
-    ]
-;;
-
-let dashboard_message_json (message : Masc_domain.message) =
-  `Assoc
-    [ "from", `String message.from_agent
-    ; "type", `String message.msg_type
-    ; "content", `String message.content
-    ; "mention", Json_util.string_opt_to_json message.mention
-    ; "timestamp", `String message.timestamp
-    ; "trace_context", Json_util.string_opt_to_json message.trace_context
-    ; "expires_at", Json_util.float_opt_to_json message.expires_at
-    ; "relevance", `String message.relevance
-    ; "seq", `Int message.seq
-    ]
-;;
+let dashboard_task_json = Server_dashboard_http_core_entities.dashboard_task_json
+let dashboard_agent_json = Server_dashboard_http_core_entities.dashboard_agent_json
+let dashboard_message_json = Server_dashboard_http_core_entities.dashboard_message_json
 
 (* dashboard_current_room_id removed — namespace retired (#unify-namespace). *)
 
-let dashboard_tasks_safe config = Coord.get_tasks_safe config
-let dashboard_agents_safe config = Coord.get_active_agents config
+let dashboard_tasks_safe = Server_dashboard_http_core_entities.dashboard_tasks_safe
+let dashboard_agents_safe = Server_dashboard_http_core_entities.dashboard_agents_safe
 
 let dashboard_messages_safe config ~since_seq ~limit =
-  Coord.get_messages_raw config ~since_seq ~limit
+  Server_dashboard_http_core_entities.dashboard_messages_safe config ~since_seq ~limit
 ;;
 
-let is_keeper_agent (agent : Masc_domain.agent) =
-  String.equal (String.lowercase_ascii (String.trim agent.agent_type)) "keeper"
+let dashboard_general_agent_count =
+  Server_dashboard_http_core_entities.dashboard_general_agent_count
 ;;
 
-let dashboard_general_agent_count agents =
-  agents
-  |> List.fold_left
-       (fun count agent -> if is_keeper_agent agent then count else count + 1)
-       0
-;;
-
-let provider_capacity_json () : Yojson.Safe.t = `Assoc []
+let provider_capacity_json = Server_dashboard_http_core_entities.provider_capacity_json
 
 (* #10544: light mode is meant to skip the heavy belief/tension evaluation
    and the full board scan, so it should also have a smaller wall-clock

--- a/lib/server/server_dashboard_http_core_entities.ml
+++ b/lib/server/server_dashboard_http_core_entities.ml
@@ -1,0 +1,110 @@
+let dashboard_shell_status_json (config : Coord.config) : Yojson.Safe.t =
+  let room_state = Coord.read_state config in
+  let cluster = Env_config_core.cluster_name () in
+  let tempo = Tempo.get_tempo config in
+  let build = Build_identity.current () in
+  `Assoc
+    [ "cluster", `String cluster
+    ; "base_path", `String config.base_path
+    ; "coordination_root", `String config.base_path
+    ; "workspace_path", `String config.workspace_path
+    ; "workspace_differs", `Bool (config.workspace_path <> config.base_path)
+    ; "cluster", `String (Env_config_core.cluster_name ())
+    ; "project", `String room_state.project
+    ; "tempo_interval_s", `Float tempo.current_interval_s
+    ; "paused", `Bool room_state.paused
+    ; "version", `String build.release_version
+    ; "build", Build_identity.to_yojson build
+    ]
+;;
+
+let dashboard_task_assignee (task : Masc_domain.task) =
+  match task.task_status with
+  | Claimed { assignee; _ }
+  | InProgress { assignee; _ }
+  | AwaitingVerification { assignee; _ }
+  | Done { assignee; _ } -> Some assignee
+  | Todo | Cancelled _ -> None
+;;
+
+let dashboard_task_json config (task : Masc_domain.task) =
+  let base_fields =
+    [ "id", `String task.id
+    ; "title", `String task.title
+    ; "description", `String task.description
+    ; "status", `String (Masc_domain.string_of_task_status task.task_status)
+    ; "priority", `Int task.priority
+    ; "assignee", Json_util.string_opt_to_json (dashboard_task_assignee task)
+    ; "created_at", `String task.created_at
+    ]
+  in
+  let projection_fields =
+    match
+      (fun _t ->
+         ignore config;
+         `Assoc [])
+        task
+    with
+    | `Assoc fields -> fields
+    | _ -> []
+  in
+  `Assoc (base_fields @ projection_fields)
+;;
+
+let dashboard_agent_json (agent : Masc_domain.agent) =
+  let profile = Dashboard_execution_helpers.get_agent_profile agent.name in
+  let meta = agent.meta in
+  `Assoc
+    [ "name", `String agent.name
+    ; "agent_type", `String agent.agent_type
+    ; ( "keeper_name"
+      , Json_util.string_opt_to_json (Option.bind meta (fun m -> m.keeper_name)) )
+    ; "keeper_id", Json_util.string_opt_to_json (Option.bind meta (fun m -> m.keeper_id))
+    ; "status", `String (Masc_domain.string_of_agent_status agent.status)
+    ; "current_task", Json_util.string_opt_to_json agent.current_task
+    ; "joined_at", `String agent.joined_at
+    ; "last_seen", `String agent.last_seen
+    ; "capabilities", `List (List.map (fun item -> `String item) agent.capabilities)
+    ; "emoji", `String profile.emoji
+    ; "koreanName", `String profile.korean_name
+    ; "model", `Null
+    ; "traits", `List (List.map (fun t -> `String t) profile.traits)
+    ; "interests", `List (List.map (fun i -> `String i) profile.interests)
+    ; "activityLevel", Json_util.float_opt_to_json profile.activity_level
+    ; "primaryValue", Json_util.string_opt_to_json profile.primary_value
+    ]
+;;
+
+let dashboard_message_json (message : Masc_domain.message) =
+  `Assoc
+    [ "from", `String message.from_agent
+    ; "type", `String message.msg_type
+    ; "content", `String message.content
+    ; "mention", Json_util.string_opt_to_json message.mention
+    ; "timestamp", `String message.timestamp
+    ; "trace_context", Json_util.string_opt_to_json message.trace_context
+    ; "expires_at", Json_util.float_opt_to_json message.expires_at
+    ; "relevance", `String message.relevance
+    ; "seq", `Int message.seq
+    ]
+;;
+
+let dashboard_tasks_safe config = Coord.get_tasks_safe config
+let dashboard_agents_safe config = Coord.get_active_agents config
+
+let dashboard_messages_safe config ~since_seq ~limit =
+  Coord.get_messages_raw config ~since_seq ~limit
+;;
+
+let is_keeper_agent (agent : Masc_domain.agent) =
+  String.equal (String.lowercase_ascii (String.trim agent.agent_type)) "keeper"
+;;
+
+let dashboard_general_agent_count agents =
+  agents
+  |> List.fold_left
+       (fun count agent -> if is_keeper_agent agent then count else count + 1)
+       0
+;;
+
+let provider_capacity_json () : Yojson.Safe.t = `Assoc []

--- a/lib/server/server_dashboard_http_core_entities.mli
+++ b/lib/server/server_dashboard_http_core_entities.mli
@@ -1,0 +1,12 @@
+val dashboard_shell_status_json : Coord.config -> Yojson.Safe.t
+val dashboard_task_json : Coord.config -> Masc_domain.task -> Yojson.Safe.t
+val dashboard_agent_json : Masc_domain.agent -> Yojson.Safe.t
+val dashboard_message_json : Masc_domain.message -> Yojson.Safe.t
+val dashboard_tasks_safe : Coord.config -> Masc_domain.task list
+val dashboard_agents_safe : Coord.config -> Masc_domain.agent list
+
+val dashboard_messages_safe :
+  Coord.config -> since_seq:int -> limit:int -> Masc_domain.message list
+
+val dashboard_general_agent_count : Masc_domain.agent list -> int
+val provider_capacity_json : unit -> Yojson.Safe.t


### PR DESCRIPTION
## Summary
- split dashboard shell/entity JSON helpers from Server_dashboard_http_core into Server_dashboard_http_core_entities
- keep existing Server_dashboard_http_core public aliases intact for callers/tests
- reduce lib/server/server_dashboard_http_core.ml from 1979 to 1889 LOC

## Validation
- ocamlformat --check lib/server/server_dashboard_http_core.ml lib/server/server_dashboard_http_core_entities.ml lib/server/server_dashboard_http_core_entities.mli
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- bash scripts/lint/godfile-size-regression.sh
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_dashboard_http_core.exe
- ./_build/default/test/test_dashboard_http_core.exe test executor_pool 2
- ./_build/default/test/test_dashboard_http_core.exe test executor_pool 15
- ./_build/default/test/test_dashboard_http_core.exe test executor_pool 20

## Known existing failure
- Full ./_build/default/test/test_dashboard_http_core.exe fails on executor_pool 3: runtime base_path preserves raw input. Reproduced on current main with the same assertion: expected <tmp>/.masc, received <tmp>.