### PR TITLE
feat(keeper): received-kind in keeper_up arg parser errors (6 sites)

### DIFF
--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -67,6 +67,18 @@ let json_non_null_member_present key (json : Yojson.Safe.t) =
       | Some _ -> true)
   | _ -> false
 
+let json_kind_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "intlit"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+
 let parse_present_tool_name_list_opt args key =
   match json_assoc_member_opt key args with
   | None -> Ok None
@@ -74,12 +86,17 @@ let parse_present_tool_name_list_opt args key =
       let rec collect acc index = function
         | [] -> Ok (Some (normalize_tool_name_list (List.rev acc)))
         | `String value :: rest -> collect (value :: acc) (index + 1) rest
-        | _ :: _ ->
-            Error (Printf.sprintf "%s[%d] must be a string" key index)
+        | bad :: _ ->
+            Error
+              (Printf.sprintf "%s[%d] must be a string (received %s)" key
+                 index (json_kind_name bad))
       in
       collect [] 0 items
   | Some `Null -> Error (Printf.sprintf "%s must not be null" key)
-  | Some _ -> Error (Printf.sprintf "%s must be an array of strings" key)
+  | Some other ->
+      Error
+        (Printf.sprintf "%s must be an array of strings (received %s)" key
+           (json_kind_name other))
 
 let parse_present_string_list_opt args key =
   match json_assoc_member_opt key args with
@@ -88,12 +105,17 @@ let parse_present_string_list_opt args key =
       let rec collect acc index = function
         | [] -> Ok (Some (normalize_name_list (List.rev acc)))
         | `String value :: rest -> collect (value :: acc) (index + 1) rest
-        | _ :: _ ->
-            Error (Printf.sprintf "%s[%d] must be a string" key index)
+        | bad :: _ ->
+            Error
+              (Printf.sprintf "%s[%d] must be a string (received %s)" key
+                 index (json_kind_name bad))
       in
       collect [] 0 items
   | Some `Null -> Error (Printf.sprintf "%s must not be null" key)
-  | Some _ -> Error (Printf.sprintf "%s must be an array of strings" key)
+  | Some other ->
+      Error
+        (Printf.sprintf "%s must be an array of strings (received %s)" key
+           (json_kind_name other))
 
 let parse_enum_string_opt args key of_string ~allowed_values =
   match json_assoc_member_opt key args with
@@ -106,7 +128,10 @@ let parse_enum_string_opt args key of_string ~allowed_values =
             (Printf.sprintf "invalid %s '%s' (allowed: %s)"
                key raw allowed_values))
   | Some `Null -> Error (Printf.sprintf "%s must not be null" key)
-  | Some _ -> Error (Printf.sprintf "%s must be a string" key)
+  | Some other ->
+      Error
+        (Printf.sprintf "%s must be a string (received %s)" key
+           (json_kind_name other))
 
 let parse_cascade_name_opt args =
   match get_string_opt args "cascade_name" with
@@ -171,7 +196,10 @@ let parse_tool_access_input (args : Yojson.Safe.t) :
               | Ok access -> Ok (Some access)
               | Error msg -> Error msg))
       | Some `Null -> Ok None
-      | Some _ -> Error "tool_access must be an object"
+      | Some other ->
+          Error
+            (Printf.sprintf "tool_access must be an object (received %s)"
+               (json_kind_name other))
       | None -> Ok None
     in
     match tool_access_opt with


### PR DESCRIPTION
## Why

`lib/keeper/keeper_turn_up_args.ml`의 6 JSON-shape mismatch 사이트가 expected-only 안티패턴. keeper_up 호출 디버깅 시 operator는 받은 type 추측해야 함.

## What

6 사이트 cohort closure:

| Line | Site |
|---|---|
| 78 | `parse_present_tool_name_list_opt` element non-string (chronicle_event `bad :: _` 패턴) |
| 82 | `parse_present_tool_name_list_opt` outer non-list-non-null |
| 92 | `parse_present_string_list_opt` element non-string |
| 96 | `parse_present_string_list_opt` outer non-list-non-null |
| 109 | `parse_enum_string_opt` Some-not-String |
| 174 | tool_access outer non-object |

File-private `json_kind_name` — 10 `Yojson.Safe.t` variants closed total function.

## Cohort boundary

`Some \`Null -> Error "must not be null"` arms (L81/L95/L108)는 *non-null 의무 제약*. parser가 optional처럼 보여도 null을 reject하는 의도 — semantic constraint, cohort 외. cascade_name non-empty (L118)도 동일 patterns.

## Iter#13~#24 series

12-PR series = **72 사이트 across 12 files**, 같은 inline `json_kind_name` form.

## Workaround Rejection Bar

- [x] Counter-as-fix 아님
- [x] String/substring classifier 아님 — closed sum type
- [x] N-of-M 아님 — 6/6 cohort closure
- [x] Cap/cooldown/dedup/repair 아님
- [x] Test backdoor 아님

## RFC Check

PASS — keeper_up arg parser. credential boundary 아님.

## Verification

- [x] `ocamlformat --check` PASS (auto)
- [x] test grep 0
- [ ] CI 모니터링

## Iter#15.5 sweep

30 PR sweep PASS (9회째).

🤖 /loop cron \`253cc0f6\` Iter#24

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>