### PR TITLE
fix(keeper): bound async keeper message timeout

### DIFF
--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -294,9 +294,15 @@ let gc_stale () =
     |> List.iter (fun id -> Hashtbl.remove pending id))
 ;;
 
-let set_status request_id status =
+let is_terminal_status = function
+  | Done _ | Lost _ -> true
+  | Queued | Running -> false
+;;
+
+let set_status ?(preserve_terminal = false) request_id status =
   with_lock (fun () ->
     match Hashtbl.find_opt pending request_id with
+    | Some entry when preserve_terminal && is_terminal_status entry.status -> ()
     | Some entry ->
       let completed_at =
         match status with
@@ -309,8 +315,8 @@ let set_status request_id status =
     | None -> ())
 ;;
 
-let set_status_protected request_id status =
-  Eio.Cancel.protect (fun () -> set_status request_id status)
+let set_status_protected ?preserve_terminal request_id status =
+  Eio.Cancel.protect (fun () -> set_status ?preserve_terminal request_id status)
 ;;
 
 let cancelled_lost_status exn =
@@ -322,9 +328,29 @@ let cancelled_lost_status exn =
     }
 ;;
 
+let timeout_done_status ~request_id ~keeper_name ~timeout_sec =
+  Done
+    { ok = false
+    ; body =
+        Yojson.Safe.to_string
+          (`Assoc
+              [ "error", `String "keeper_msg_timeout"
+              ; "message", `String "keeper_msg request exceeded timeout_sec"
+              ; "request_id", `String request_id
+              ; "keeper_name", `String keeper_name
+              ; "timeout_sec", `Float timeout_sec
+              ])
+    }
+;;
+
+type worker_result =
+  | Worker_done of tool_result
+  | Worker_timeout of { timeout_sec : float }
+
 (** Submit a keeper_msg turn for async execution.
     Forks a background fiber on [sw], returns the request_id immediately. *)
-let submit ~sw ~base_path ~(f : unit -> tool_result) ~keeper_name : string =
+let submit ?clock ?timeout_sec ~sw ~base_path ~(f : unit -> tool_result)
+    ~keeper_name () : string =
   gc_stale ();
   ignore (gc_stale_disk ~base_path);
   let request_id = generate_request_id ~keeper_name in
@@ -341,11 +367,20 @@ let submit ~sw ~base_path ~(f : unit -> tool_result) ~keeper_name : string =
     Hashtbl.replace pending request_id entry;
     persist_entry entry);
   Eio.Fiber.fork_daemon ~sw (fun () ->
-    set_status_protected request_id Running;
+    set_status_protected ~preserve_terminal:true request_id Running;
     let result =
       try
-        let ok, body = f () in
-        Done { ok; body }
+        let worker_result =
+          match clock, timeout_sec with
+          | Some clock, Some timeout_sec ->
+            (try Worker_done (Eio.Time.with_timeout_exn clock timeout_sec f) with
+             | Eio.Time.Timeout -> Worker_timeout { timeout_sec })
+          | None, _ | _, None -> Worker_done (f ())
+        in
+        (match worker_result with
+         | Worker_done (ok, body) -> Done { ok; body }
+         | Worker_timeout { timeout_sec } ->
+           timeout_done_status ~request_id ~keeper_name ~timeout_sec)
       with
       | Eio.Cancel.Cancelled _ as e -> cancelled_lost_status e
       | exn ->
@@ -354,7 +389,7 @@ let submit ~sw ~base_path ~(f : unit -> tool_result) ~keeper_name : string =
           ; body = Printf.sprintf "keeper_msg failed: %s" (Printexc.to_string exn)
           }
     in
-    set_status_protected request_id result;
+    set_status_protected ~preserve_terminal:true request_id result;
     `Stop_daemon);
   request_id
 ;;

--- a/lib/keeper/keeper_msg_async.mli
+++ b/lib/keeper/keeper_msg_async.mli
@@ -29,16 +29,21 @@ type entry =
 
 (** {1 Submit and poll} *)
 
-(** [submit ~sw ~f ~keeper_name] forks a background daemon fiber on
+(** [submit ?clock ?timeout_sec ~sw ~f ~keeper_name] forks a background daemon fiber on
     [sw] that runs [f] and stores the result. Returns the fresh
-    [request_id] synchronously. Cancellation of [sw] interrupts the
-    worker and records a terminal [Lost] state before stopping, so
-    pollers do not observe an indefinite [Running] request. *)
+    [request_id] synchronously. When both [clock] and [timeout_sec] are
+    provided, the worker records a terminal timeout error if [f] does not
+    return before the deadline. Cancellation of [sw] interrupts the worker
+    and records a terminal [Lost] state before stopping, so pollers do not
+    observe an indefinite [Running] request. *)
 val submit
-  :  sw:Eio.Switch.t
+  :  ?clock:_ Eio.Time.clock
+  -> ?timeout_sec:float
+  -> sw:Eio.Switch.t
   -> base_path:string
   -> f:(unit -> Keeper_types.tool_result)
   -> keeper_name:string
+  -> unit
   -> string
 
 (** [poll ?base_path request_id] returns the current entry, or [None] when the

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -577,7 +577,7 @@ let keeper_schemas : tool_schema list = [
         ]);
         ("timeout_sec", `Assoc [
           ("type", `String "number");
-          ("description", `String "Optional: overall cascade timeout (sec) for this keeper message call");
+          ("description", `String "Optional: overall timeout (sec) for this async keeper message request and its cascade turn");
         ]);
         ("required_tools", `Assoc [
           ("type", `String "array");

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -25,6 +25,11 @@ val preflight_keeper_msg :
 (** Run synchronous validation for [handle_keeper_msg] before an async wrapper
     accepts the turn for later execution. *)
 
+val keeper_msg_timeout_override : Yojson.Safe.t -> (float option, string) result
+(** Parse the optional [timeout_sec] override used by [masc_keeper_msg]. The
+    value bounds the OAS turn and, for async dispatch, the request result
+    lifecycle exposed via [masc_keeper_msg_result]. *)
+
 val handle_keeper_msg :
   ?on_text_delta:(string -> unit) ->
   _ Keeper_types.context -> Yojson.Safe.t -> tool_result

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -492,7 +492,12 @@ let handle_keeper_msg ctx args : tool_result =
       (match Turn.preflight_keeper_msg ctx resolved_args with
       | Error err -> (false, err)
       | Ok () ->
-      let request_id = Keeper_msg_async.submit ~sw:ctx.sw
+      let timeout_sec =
+        match Turn.keeper_msg_timeout_override resolved_args with
+        | Ok value -> value
+        | Error _ -> None
+      in
+      let request_id = Keeper_msg_async.submit ?timeout_sec ~clock:ctx.clock ~sw:ctx.sw
         ~base_path:ctx.config.base_path
         ~keeper_name:name
         ~f:(fun () ->
@@ -502,6 +507,7 @@ let handle_keeper_msg ctx args : tool_result =
             invalidate_status_cache name
           end;
           (ok, body))
+        ()
       in
       let json = `Assoc [
         ("request_id", `String request_id);

--- a/test/test_keeper_mutex_coverage.ml
+++ b/test/test_keeper_mutex_coverage.ml
@@ -14,6 +14,19 @@ let wait_for_done request_id =
   loop 200
 ;;
 
+let wait_for_done_with_clock clock request_id =
+  let rec loop remaining =
+    match Keeper_msg_async.poll request_id with
+    | Some ({ status = Done _; _ } as entry) -> entry
+    | _ when remaining <= 0 ->
+      failwith (Printf.sprintf "request %s did not complete" request_id)
+    | _ ->
+      Eio.Time.sleep clock 0.01;
+      loop (remaining - 1)
+  in
+  loop 100
+;;
+
 let wait_for_running request_id =
   let rec loop remaining =
     match Keeper_msg_async.poll request_id with
@@ -94,9 +107,14 @@ let test_keeper_msg_async_roundtrip () =
   @@ fun sw ->
   let base_path = temp_dir "keeper-msg-async-roundtrip-" in
   let request_id =
-    Keeper_msg_async.submit ~sw ~base_path ~keeper_name:"alpha" ~f:(fun () ->
-      Eio.Fiber.yield ();
-      true, Yojson.Safe.to_string (`Assoc [ "kind", `String "done" ]))
+    Keeper_msg_async.submit
+      ~sw
+      ~base_path
+      ~keeper_name:"alpha"
+      ~f:(fun () ->
+        Eio.Fiber.yield ();
+        true, Yojson.Safe.to_string (`Assoc [ "kind", `String "done" ]))
+      ()
   in
   let entry = wait_for_done request_id in
   Alcotest.(check bool)
@@ -118,9 +136,14 @@ let test_keeper_msg_async_recovers_done_from_disk () =
   @@ fun sw ->
   let base_path = temp_dir "keeper-msg-async-done-" in
   let request_id =
-    Keeper_msg_async.submit ~sw ~base_path ~keeper_name:"beta" ~f:(fun () ->
-      Eio.Fiber.yield ();
-      true, Yojson.Safe.to_string (`Assoc [ "kind", `String "done" ]))
+    Keeper_msg_async.submit
+      ~sw
+      ~base_path
+      ~keeper_name:"beta"
+      ~f:(fun () ->
+        Eio.Fiber.yield ();
+        true, Yojson.Safe.to_string (`Assoc [ "kind", `String "done" ]))
+      ()
   in
   let entry = wait_for_done request_id in
   Alcotest.(check bool)
@@ -148,9 +171,14 @@ let test_keeper_msg_async_marks_recovered_inflight_lost () =
   let base_path = temp_dir "keeper-msg-async-lost-" in
   let promise, _resolver = Eio.Promise.create () in
   let request_id =
-    Keeper_msg_async.submit ~sw ~base_path ~keeper_name:"gamma" ~f:(fun () ->
-      Eio.Promise.await promise;
-      true, "{}")
+    Keeper_msg_async.submit
+      ~sw
+      ~base_path
+      ~keeper_name:"gamma"
+      ~f:(fun () ->
+        Eio.Promise.await promise;
+        true, "{}")
+      ()
   in
   ignore (wait_for_running request_id : Keeper_msg_async.entry);
   Keeper_msg_async.For_testing.forget request_id;
@@ -180,10 +208,14 @@ let test_keeper_msg_async_marks_cancelled_worker_lost () =
     @@ fun sw ->
     let never, _resolver = Eio.Promise.create () in
     let request_id =
-      Keeper_msg_async.submit ~sw ~base_path:(temp_dir "keeper-msg-async-cancel-")
-        ~keeper_name:"cancelled" ~f:(fun () ->
+      Keeper_msg_async.submit
+        ~sw
+        ~base_path:(temp_dir "keeper-msg-async-cancel-")
+        ~keeper_name:"cancelled"
+        ~f:(fun () ->
           Eio.Promise.await never;
           true, "{}")
+        ()
     in
     ignore (wait_for_running request_id : Keeper_msg_async.entry);
     request_id
@@ -200,6 +232,65 @@ let test_keeper_msg_async_marks_cancelled_worker_lost () =
       (Keeper_msg_async.status_to_string entry.Keeper_msg_async.status)
 ;;
 
+let test_keeper_msg_async_timeout_is_terminal_error () =
+  with_eio_env
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let clock = Eio.Stdenv.clock env in
+  let base_path = temp_dir "keeper-msg-async-timeout-" in
+  let release_late, notify_release_late = Eio.Promise.create () in
+  let request_id =
+    Keeper_msg_async.submit
+      ~clock
+      ~timeout_sec:0.02
+      ~sw
+      ~base_path
+      ~keeper_name:"timeout"
+      ~f:(fun () ->
+        Eio.Promise.await release_late;
+        true, Yojson.Safe.to_string (`Assoc [ "kind", `String "late" ]))
+      ()
+  in
+  let entry = wait_for_done_with_clock clock request_id in
+  let timeout_body =
+    match entry.Keeper_msg_async.status with
+    | Done { ok = false; body } ->
+      Alcotest.(check bool)
+        "timeout completion timestamp"
+        true
+        (Option.is_some entry.completed_at);
+      body
+    | Done { ok = true; body } ->
+      Alcotest.failf "expected timeout error, got ok body=%s" body
+    | status ->
+      Alcotest.failf
+        "expected timeout error, got %s"
+        (Keeper_msg_async.status_to_string status)
+  in
+  (match Yojson.Safe.from_string timeout_body with
+   | `Assoc fields ->
+     Alcotest.(check (option string))
+       "timeout error code"
+       (Some "keeper_msg_timeout")
+       (Option.bind
+          (List.assoc_opt "error" fields)
+          (function
+          | `String value -> Some value
+          | _ -> None))
+   | _ -> Alcotest.fail "expected timeout body JSON object");
+  Eio.Promise.resolve notify_release_late ();
+  Eio.Time.sleep clock 0.05;
+  match Keeper_msg_async.poll request_id with
+  | Some { Keeper_msg_async.status = Done { ok = false; body }; _ } ->
+    Alcotest.(check string) "late worker result cannot overwrite timeout" timeout_body body
+  | Some entry ->
+    Alcotest.failf
+      "expected timeout to remain terminal, got %s"
+      (Keeper_msg_async.status_to_string entry.Keeper_msg_async.status)
+  | None -> Alcotest.fail "expected timeout request to remain pollable"
+;;
+
 let test_keeper_msg_async_gc_removes_stale_terminal_disk_record () =
   with_eio_env
   @@ fun _env ->
@@ -207,9 +298,14 @@ let test_keeper_msg_async_gc_removes_stale_terminal_disk_record () =
   @@ fun sw ->
   let base_path = temp_dir "keeper-msg-async-gc-" in
   let request_id =
-    Keeper_msg_async.submit ~sw ~base_path ~keeper_name:"delta" ~f:(fun () ->
-      Eio.Fiber.yield ();
-      true, "{}")
+    Keeper_msg_async.submit
+      ~sw
+      ~base_path
+      ~keeper_name:"delta"
+      ~f:(fun () ->
+        Eio.Fiber.yield ();
+        true, "{}")
+      ()
   in
   let entry = wait_for_done request_id in
   let path =
@@ -335,6 +431,10 @@ let () =
             "cancelled worker is terminal lost"
             `Quick
             test_keeper_msg_async_marks_cancelled_worker_lost
+        ; test_case
+            "timeout is terminal error"
+            `Quick
+            test_keeper_msg_async_timeout_is_terminal_error
         ; test_case
             "gc removes stale terminal disk record"
             `Quick


### PR DESCRIPTION
## Summary

- Bound `masc_keeper_msg` async request execution with the caller-provided `timeout_sec`, using the server Eio clock.
- Return a terminal `keeper_msg_timeout` error through `masc_keeper_msg_result` instead of leaving requests indefinitely `running`.
- Added a focused async regression test that verifies timeout terminal state and late-result preservation.

## Product impact

Operators and keepers can now rely on `timeout_sec` as the visible request lifecycle deadline for async keeper messages. A stalled required-tool keeper turn no longer waits until server restart to become `lost`.

## Evidence

- `scripts/dune-local.sh build test/test_keeper_mutex_coverage.exe`
- `_build/default/test/test_keeper_mutex_coverage.exe`

## Review evidence

- `git diff --check`
- Focused test result: `keeper_mutex_coverage` passed 10 tests, including `timeout is terminal error`.

## Linked issue

- Fixes #16496
