### PR TITLE
refactor: split keeper profile persona views

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -74,6 +74,7 @@
  keeper_persona_authoring_contract
  keeper_persona_authoring_slug
  keeper_types_profile_sandbox
+ keeper_types_profile_persona
  keeper_types_profile
  keeper_meta_tool_access
  keeper_meta_contract

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -213,89 +213,37 @@ and per_provider_timeout_state =
   | Per_provider_timeout_invalid
   | Per_provider_timeout_set
 
-type persona_summary = {
-  persona_name : string;
-  display_name : string;
-  role : string option;
-  trait : string option;
-  profile_path : string;
-  has_keeper_defaults : bool;
-}
+type persona_summary = Keeper_types_profile_persona.persona_summary =
+  { persona_name : string
+  ; display_name : string
+  ; role : string option
+  ; trait : string option
+  ; profile_path : string
+  ; has_keeper_defaults : bool
+  }
 
-let operator_todo_placeholder_marker = "OPERATOR_TODO"
+let operator_todo_placeholder_marker =
+  Keeper_types_profile_persona.operator_todo_placeholder_marker
+;;
 
-let string_has_operator_todo_placeholder value =
-  String_util.contains_substring value operator_todo_placeholder_marker
+let string_has_operator_todo_placeholder =
+  Keeper_types_profile_persona.string_has_operator_todo_placeholder
+;;
 
-let rec json_has_operator_todo_placeholder = function
-  | `String value -> string_has_operator_todo_placeholder value
-  | `Assoc fields ->
-      List.exists
-        (fun (key, value) ->
-          string_has_operator_todo_placeholder key
-          || json_has_operator_todo_placeholder value)
-        fields
-  | `List values -> List.exists json_has_operator_todo_placeholder values
-  | `Tuple values -> List.exists json_has_operator_todo_placeholder values
-  | `Variant (name, value) ->
-      string_has_operator_todo_placeholder name
-      ||
-      (match value with
-       | Some json -> json_has_operator_todo_placeholder json
-       | None -> false)
-  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `Floatlit _ -> false
+let json_has_operator_todo_placeholder =
+  Keeper_types_profile_persona.json_has_operator_todo_placeholder
+;;
 
-let json_operator_todo_placeholder_paths json =
-  let child_path path key =
-    if path = "$" then "$." ^ key else path ^ "." ^ key
-  in
-  let indexed_path path index =
-    Printf.sprintf "%s[%d]" path index
-  in
-  let rec loop path = function
-    | `String value ->
-        if string_has_operator_todo_placeholder value then [ path ] else []
-    | `Assoc fields ->
-        fields
-        |> List.map (fun (key, value) ->
-          let field_path = child_path path key in
-          let key_hits =
-            if string_has_operator_todo_placeholder key then [ field_path ] else []
-          in
-          key_hits @ loop field_path value)
-        |> List.concat
-    | `List values | `Tuple values ->
-        values
-        |> List.mapi (fun index value -> loop (indexed_path path index) value)
-        |> List.concat
-    | `Variant (name, value) ->
-        let variant_path = child_path path name in
-        let name_hits =
-          if string_has_operator_todo_placeholder name then [ variant_path ] else []
-        in
-        name_hits
-        @
-        (match value with
-         | Some json -> loop variant_path json
-         | None -> [])
-    | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `Floatlit _ -> []
-  in
-  loop "$" json
+let json_operator_todo_placeholder_paths =
+  Keeper_types_profile_persona.json_operator_todo_placeholder_paths
+;;
 
-let reject_placeholder_persona_profile ~label ~path json =
-  if json_has_operator_todo_placeholder json then (
-    Log.Keeper.warn
-      "%s: rejecting persona profile %s because it contains %s placeholder text"
-      label path operator_todo_placeholder_marker;
-    true)
-  else false
+let reject_placeholder_persona_profile =
+  Keeper_types_profile_persona.reject_placeholder_persona_profile
+;;
 
-let operator_todo_placeholder_fields fields =
-  fields
-  |> List.filter_map (fun (field, value) ->
-    match value with
-    | Some raw when string_has_operator_todo_placeholder raw -> Some field
-    | _ -> None)
+let operator_todo_placeholder_fields =
+  Keeper_types_profile_persona.operator_todo_placeholder_fields
 
 let persona_operator_todo_placeholder_fields
     (summary : persona_summary)
@@ -428,42 +376,8 @@ let normalize_per_provider_timeout_json_field ~(source : string)
   per_provider_timeout_of_json_field ~source ~field json |> snd
 ;;
 
-let personas_root_opt () =
-  try
-    Config_dir_resolver.log_warnings ~context:"KeeperTypesProfile" ();
-    Config_dir_resolver.personas_dir_opt ()
-  with
-  | Sys_error _ -> None
-  | exn ->
-      Prometheus.inc_counter
-        Keeper_metrics.metric_keeper_profile_load_failures
-        ~labels:[("site", Keeper_profile_load_failure_site.(to_label Personas_root))]
-        ();
-      Log.Keeper.warn "personas_root_opt unexpected: %s" (Printexc.to_string exn);
-      None
-
-let persona_profile_path_opt name =
-  let dirs =
-    try
-      Config_dir_resolver.log_warnings ~context:"KeeperTypesProfile" ();
-      Config_dir_resolver.personas_dirs ()
-    with
-    | Sys_error _ -> []
-    | exn ->
-        Prometheus.inc_counter
-          Keeper_metrics.metric_keeper_profile_load_failures
-          ~labels:[("site", Keeper_profile_load_failure_site.(to_label Personas_dirs_resolve))]
-          ();
-        Log.Keeper.warn "personas_dirs unexpected: %s" (Printexc.to_string exn);
-        []
-  in
-  (* Search the resolved persona roots only.
-     Config_dir_resolver.personas_dirs now returns a single source of truth:
-     explicit MASC_PERSONAS_DIR or resolved CONFIG_ROOT/personas. *)
-  dirs
-  |> List.find_map (fun root ->
-         let path = Filename.concat (Filename.concat root name) "profile.json" in
-         if Fs_compat.file_exists path then Some path else None)
+let personas_root_opt = Keeper_types_profile_persona.personas_root_opt
+let persona_profile_path_opt = Keeper_types_profile_persona.persona_profile_path_opt
 
 (* ================================================================ *)
 (* TOML -> keeper_profile_defaults conversion                        *)
@@ -1712,147 +1626,18 @@ let keeper_default_source_snapshot name : keeper_default_source_snapshot =
       in
       { source_kind; defaults }
 
-(** Load extended persona description from AGENT.md if present.
-    Truncated to [max_chars] to avoid bloating the system prompt. *)
-let persona_description_max_chars = 4000
+let persona_description_max_chars =
+  Keeper_types_profile_persona.persona_description_max_chars
+;;
 
-let load_persona_extended ?(max_chars = persona_description_max_chars) name : string option =
-  let dirs =
-    try Config_dir_resolver.personas_dirs ()
-    with
-    | Sys_error _ -> []
-    | exn ->
-        Prometheus.inc_counter
-          Keeper_metrics.metric_keeper_profile_load_failures
-          ~labels:[("site", Keeper_profile_load_failure_site.(to_label Load_persona_extended))]
-          ();
-        Log.Keeper.warn "load_persona_extended personas_dirs unexpected: %s"
-          (Printexc.to_string exn);
-        []
-  in
-  (* Later dirs (local) override earlier (repo) *)
-  dirs
-  |> List.rev
-  |> List.find_map (fun root ->
-      let path = Filename.concat (Filename.concat root name) "AGENT.md" in
-      if Fs_compat.file_exists path then
-        match Safe_ops.read_file_safe path with
-        | Error msg ->
-          Prometheus.inc_counter
-            Keeper_metrics.metric_keeper_profile_load_failures
-            ~labels:[("site", Keeper_profile_load_failure_site.(to_label Agent_md_read))]
-            ();
-          Log.Keeper.warn "[load_agent_md] failed to read %s: %s" path msg;
-          None
-        | Ok content ->
-          let trimmed = String.trim content in
-          if String.length trimmed = 0 then None
-          else if String.length trimmed <= max_chars then Some trimmed
-          else Some (String.sub trimmed 0 max_chars ^ "\n[truncated]")
-      else None)
+let load_persona_extended = Keeper_types_profile_persona.load_persona_extended
+let load_persona_summary = Keeper_types_profile_persona.load_persona_summary
 
-let load_persona_summary name : persona_summary option =
-  match persona_profile_path_opt name with
-  | None -> None
-  | Some path -> (
-      match Safe_ops.read_json_file_logged ~label:"load_persona_summary" path with
-      | None -> None
-      | Some json ->
-          if
-            reject_placeholder_persona_profile ~label:"load_persona_summary"
-              ~path json
-          then None
-          else
-          let display_name =
-            Safe_ops.json_string_opt "name" json |> Option.value ~default:name
-          in
-          let role = Safe_ops.json_string_opt "role" json in
-          let trait = Safe_ops.json_string_opt "trait" json in
-          let has_keeper_defaults =
-            match Yojson.Safe.Util.member "keeper" json with
-            | `Assoc _ -> true
-            | _ -> false
-          in
-          Some
-            {
-              persona_name = name;
-              display_name;
-              role;
-              trait;
-              profile_path = path;
-              has_keeper_defaults;
-            })
+let load_persona_summary_from_path =
+  Keeper_types_profile_persona.load_persona_summary_from_path
+;;
 
-let load_persona_summary_from_path name profile_path : persona_summary option =
-  match Safe_ops.read_json_file_logged ~label:"load_persona_summary_from_path" profile_path with
-  | None -> None
-  | Some json ->
-      if
-        reject_placeholder_persona_profile
-          ~label:"load_persona_summary_from_path" ~path:profile_path json
-      then None
-      else
-      let display_name =
-        Safe_ops.json_string_opt "name" json |> Option.value ~default:name
-      in
-      let role = Safe_ops.json_string_opt "role" json in
-      let trait = Safe_ops.json_string_opt "trait" json in
-      let has_keeper_defaults =
-        match Yojson.Safe.Util.member "keeper" json with
-        | `Assoc _ -> true
-        | _ -> false
-      in
-      Some
-        {
-          persona_name = name;
-          display_name;
-          role;
-          trait;
-          profile_path;
-          has_keeper_defaults;
-        }
-
-let list_persona_summaries () : persona_summary list =
-  let dirs =
-    try Config_dir_resolver.personas_dirs ()
-    with
-    | Sys_error _ -> []
-    | exn ->
-        Prometheus.inc_counter
-          Keeper_metrics.metric_keeper_profile_load_failures
-          ~labels:[("site", Keeper_profile_load_failure_site.(to_label List_persona_summaries))]
-          ();
-        Log.Keeper.warn "list_persona_summaries personas_dirs unexpected: %s"
-          (Printexc.to_string exn);
-        []
-  in
-  let entries_from_dir root =
-    try
-      root
-      |> Sys.readdir
-      |> Array.to_list
-      |> List.filter validate_name
-      |> List.filter_map (fun name ->
-             let profile_path =
-               Filename.concat (Filename.concat root name) "profile.json"
-             in
-             if Fs_compat.file_exists profile_path then Some (name, profile_path)
-             else None)
-    with Sys_error _ -> []
-  in
-  (* Collect all persona (name, path) from all dirs; later dirs override *)
-  let module SS = Set.Make (String) in
-  let raw = dirs |> List.concat_map entries_from_dir in
-  let all_entries =
-    List.fold_left (fun (acc, seen) (name, path) ->
-      if SS.mem name seen then (acc, seen)
-      else ((name, path) :: acc, SS.add name seen))
-      ([], SS.empty) raw
-    |> fun (acc, _) -> List.rev acc
-  in
-  all_entries
-  |> List.filter_map (fun (name, path) -> load_persona_summary_from_path name path)
-  |> List.sort (fun a b -> String.compare a.persona_name b.persona_name)
+let list_persona_summaries = Keeper_types_profile_persona.list_persona_summaries
 
 let keeper_dir (config : Coord.config) =
   let d = Filename.concat (Coord.masc_root_dir config) "keepers" in

--- a/lib/keeper/keeper_types_profile_persona.ml
+++ b/lib/keeper/keeper_types_profile_persona.ml
@@ -1,0 +1,248 @@
+include Keeper_config
+
+type persona_summary =
+  { persona_name : string
+  ; display_name : string
+  ; role : string option
+  ; trait : string option
+  ; profile_path : string
+  ; has_keeper_defaults : bool
+  }
+
+let operator_todo_placeholder_marker = "OPERATOR_TODO"
+
+let string_has_operator_todo_placeholder value =
+  String_util.contains_substring value operator_todo_placeholder_marker
+;;
+
+let rec json_has_operator_todo_placeholder = function
+  | `String value -> string_has_operator_todo_placeholder value
+  | `Assoc fields ->
+    List.exists
+      (fun (key, value) ->
+        string_has_operator_todo_placeholder key
+        || json_has_operator_todo_placeholder value)
+      fields
+  | `List values -> List.exists json_has_operator_todo_placeholder values
+  | `Tuple values -> List.exists json_has_operator_todo_placeholder values
+  | `Variant (name, value) ->
+    string_has_operator_todo_placeholder name
+    ||
+    (match value with
+     | Some json -> json_has_operator_todo_placeholder json
+     | None -> false)
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `Floatlit _ -> false
+;;
+
+let json_operator_todo_placeholder_paths json =
+  let child_path path key = if path = "$" then "$." ^ key else path ^ "." ^ key in
+  let indexed_path path index = Printf.sprintf "%s[%d]" path index in
+  let rec loop path = function
+    | `String value ->
+      if string_has_operator_todo_placeholder value then [ path ] else []
+    | `Assoc fields ->
+      fields
+      |> List.map (fun (key, value) ->
+        let field_path = child_path path key in
+        let key_hits =
+          if string_has_operator_todo_placeholder key then [ field_path ] else []
+        in
+        key_hits @ loop field_path value)
+      |> List.concat
+    | `List values | `Tuple values ->
+      values
+      |> List.mapi (fun index value -> loop (indexed_path path index) value)
+      |> List.concat
+    | `Variant (name, value) ->
+      let variant_path = child_path path name in
+      let name_hits =
+        if string_has_operator_todo_placeholder name then [ variant_path ] else []
+      in
+      name_hits
+      @
+      (match value with
+       | Some json -> loop variant_path json
+       | None -> [])
+    | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `Floatlit _ -> []
+  in
+  loop "$" json
+;;
+
+let reject_placeholder_persona_profile ~label ~path json =
+  if json_has_operator_todo_placeholder json
+  then (
+    Log.Keeper.warn
+      "%s: rejecting persona profile %s because it contains %s placeholder text"
+      label
+      path
+      operator_todo_placeholder_marker;
+    true)
+  else false
+;;
+
+let operator_todo_placeholder_fields fields =
+  fields
+  |> List.filter_map (fun (field, value) ->
+    match value with
+    | Some raw when string_has_operator_todo_placeholder raw -> Some field
+    | _ -> None)
+;;
+
+let personas_root_opt () =
+  try
+    Config_dir_resolver.log_warnings ~context:"KeeperTypesProfile" ();
+    Config_dir_resolver.personas_dir_opt ()
+  with
+  | Sys_error _ -> None
+  | exn ->
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_profile_load_failures
+      ~labels:[ "site", Keeper_profile_load_failure_site.(to_label Personas_root) ]
+      ();
+    Log.Keeper.warn "personas_root_opt unexpected: %s" (Printexc.to_string exn);
+    None
+;;
+
+let persona_profile_path_opt name =
+  let dirs =
+    try
+      Config_dir_resolver.log_warnings ~context:"KeeperTypesProfile" ();
+      Config_dir_resolver.personas_dirs ()
+    with
+    | Sys_error _ -> []
+    | exn ->
+      Prometheus.inc_counter
+        Keeper_metrics.metric_keeper_profile_load_failures
+        ~labels:[ "site", Keeper_profile_load_failure_site.(to_label Personas_dirs_resolve) ]
+        ();
+      Log.Keeper.warn "personas_dirs unexpected: %s" (Printexc.to_string exn);
+      []
+  in
+  (* Search the resolved persona roots only.
+     Config_dir_resolver.personas_dirs now returns a single source of truth:
+     explicit MASC_PERSONAS_DIR or resolved CONFIG_ROOT/personas. *)
+  dirs
+  |> List.find_map (fun root ->
+    let path = Filename.concat (Filename.concat root name) "profile.json" in
+    if Fs_compat.file_exists path then Some path else None)
+;;
+
+(** Load extended persona description from AGENT.md if present.
+    Truncated to [max_chars] to avoid bloating the system prompt. *)
+let persona_description_max_chars = 4000
+
+let load_persona_extended ?(max_chars = persona_description_max_chars) name
+  : string option =
+  let dirs =
+    try Config_dir_resolver.personas_dirs () with
+    | Sys_error _ -> []
+    | exn ->
+      Prometheus.inc_counter
+        Keeper_metrics.metric_keeper_profile_load_failures
+        ~labels:[ "site", Keeper_profile_load_failure_site.(to_label Load_persona_extended) ]
+        ();
+      Log.Keeper.warn
+        "load_persona_extended personas_dirs unexpected: %s"
+        (Printexc.to_string exn);
+      []
+  in
+  (* Later dirs (local) override earlier (repo) *)
+  dirs
+  |> List.rev
+  |> List.find_map (fun root ->
+    let path = Filename.concat (Filename.concat root name) "AGENT.md" in
+    if Fs_compat.file_exists path
+    then
+      match Safe_ops.read_file_safe path with
+      | Error msg ->
+        Prometheus.inc_counter
+          Keeper_metrics.metric_keeper_profile_load_failures
+          ~labels:[ "site", Keeper_profile_load_failure_site.(to_label Agent_md_read) ]
+          ();
+        Log.Keeper.warn "[load_agent_md] failed to read %s: %s" path msg;
+        None
+      | Ok content ->
+        let trimmed = String.trim content in
+        if String.length trimmed = 0
+        then None
+        else if String.length trimmed <= max_chars
+        then Some trimmed
+        else Some (String.sub trimmed 0 max_chars ^ "\n[truncated]")
+    else None)
+;;
+
+let persona_summary_of_profile_json name profile_path json =
+  if reject_placeholder_persona_profile ~label:"load_persona_summary" ~path:profile_path json
+  then None
+  else (
+    let display_name =
+      match Safe_ops.json_string_opt "name" json with
+      | Some value -> value
+      | None -> name
+    in
+    let role = Safe_ops.json_string_opt "role" json in
+    let trait = Safe_ops.json_string_opt "trait" json in
+    let has_keeper_defaults =
+      match Yojson.Safe.Util.member "keeper" json with
+      | `Assoc _ -> true
+      | _ -> false
+    in
+    Some { persona_name = name; display_name; role; trait; profile_path; has_keeper_defaults })
+;;
+
+let load_persona_summary name : persona_summary option =
+  match persona_profile_path_opt name with
+  | None -> None
+  | Some path ->
+    (match Safe_ops.read_json_file_logged ~label:"load_persona_summary" path with
+     | None -> None
+     | Some json -> persona_summary_of_profile_json name path json)
+;;
+
+let load_persona_summary_from_path name profile_path : persona_summary option =
+  match Safe_ops.read_json_file_logged ~label:"load_persona_summary_from_path" profile_path with
+  | None -> None
+  | Some json -> persona_summary_of_profile_json name profile_path json
+;;
+
+let list_persona_summaries () : persona_summary list =
+  let dirs =
+    try Config_dir_resolver.personas_dirs () with
+    | Sys_error _ -> []
+    | exn ->
+      Prometheus.inc_counter
+        Keeper_metrics.metric_keeper_profile_load_failures
+        ~labels:[ "site", Keeper_profile_load_failure_site.(to_label List_persona_summaries) ]
+        ();
+      Log.Keeper.warn
+        "list_persona_summaries personas_dirs unexpected: %s"
+        (Printexc.to_string exn);
+      []
+  in
+  let entries_from_dir root =
+    try
+      root
+      |> Sys.readdir
+      |> Array.to_list
+      |> List.filter validate_name
+      |> List.filter_map (fun name ->
+        let profile_path = Filename.concat (Filename.concat root name) "profile.json" in
+        if Fs_compat.file_exists profile_path then Some (name, profile_path) else None)
+    with
+    | Sys_error _ -> []
+  in
+  (* Collect all persona (name, path) from all dirs; later dirs override. *)
+  let module SS = Set.Make (String) in
+  let raw = dirs |> List.concat_map entries_from_dir in
+  let all_entries =
+    List.fold_left
+      (fun (acc, seen) (name, path) ->
+        if SS.mem name seen then acc, seen else (name, path) :: acc, SS.add name seen)
+      ([], SS.empty)
+      raw
+    |> fun (acc, _) -> List.rev acc
+  in
+  all_entries
+  |> List.filter_map (fun (name, path) -> load_persona_summary_from_path name path)
+  |> List.sort (fun a b -> String.compare a.persona_name b.persona_name)
+;;

--- a/lib/keeper/keeper_types_profile_persona.mli
+++ b/lib/keeper/keeper_types_profile_persona.mli
@@ -1,0 +1,23 @@
+type persona_summary =
+  { persona_name : string
+  ; display_name : string
+  ; role : string option
+  ; trait : string option
+  ; profile_path : string
+  ; has_keeper_defaults : bool
+  }
+
+val operator_todo_placeholder_marker : string
+val string_has_operator_todo_placeholder : string -> bool
+val json_has_operator_todo_placeholder : Yojson.Safe.t -> bool
+val json_operator_todo_placeholder_paths : Yojson.Safe.t -> string list
+val reject_placeholder_persona_profile :
+  label:string -> path:string -> Yojson.Safe.t -> bool
+val operator_todo_placeholder_fields : (string * string option) list -> string list
+val personas_root_opt : unit -> string option
+val persona_profile_path_opt : string -> string option
+val persona_description_max_chars : int
+val load_persona_extended : ?max_chars:int -> string -> string option
+val load_persona_summary : string -> persona_summary option
+val load_persona_summary_from_path : string -> string -> persona_summary option
+val list_persona_summaries : unit -> persona_summary list


### PR DESCRIPTION
## Summary
- split persona summary/path/placeholder helpers from Keeper_types_profile into Keeper_types_profile_persona
- keep Keeper_types_profile record type alias and public helper aliases intact for existing callers
- reduce lib/keeper/keeper_types_profile.ml from 1878 to 1663 LOC

## Validation
- ocamlformat --check lib/keeper/keeper_types_profile.ml lib/keeper/keeper_types_profile_persona.ml lib/keeper/keeper_types_profile_persona.mli
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- bash scripts/lint/godfile-size-regression.sh
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_toml.exe test/test_keeper_meta_listing.exe
- ./_build/default/test/test_keeper_toml.exe test discovery
- ./_build/default/test/test_keeper_meta_listing.exe test listing

## Notes
- Sys.readdir in Keeper_types_profile_persona.list_persona_summaries is the existing synchronous directory scan moved unchanged; this PR does not add a timeout-wrapped blocking path.