### PR TITLE
feat: bundle received-kind enrich for 3 narrow JSON parsers

### DIFF
--- a/lib/keeper/keeper_meta_tool_access.ml
+++ b/lib/keeper/keeper_meta_tool_access.ml
@@ -6,6 +6,19 @@
 
 open Keeper_types_profile
 
+let json_kind_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "intlit"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+;;
+
 type tool_preset =
   | Minimal
   | Social
@@ -152,11 +165,17 @@ let string_list_field_result ?label ~field_name (json : Yojson.Safe.t) =
     let rec collect acc index = function
       | [] -> Ok (List.rev acc)
       | `String value :: rest -> collect (value :: acc) (index + 1) rest
-      | _ :: _ -> Error (Printf.sprintf "keeper %s[%d] must be a string" label index)
+      | bad :: _ ->
+        Error
+          (Printf.sprintf "keeper %s[%d] must be a string (received %s)" label
+             index (json_kind_name bad))
     in
     collect [] 0 items
   | `Null -> Error (Printf.sprintf "keeper %s must be an array of strings" label)
-  | _ -> Error (Printf.sprintf "keeper %s must be an array of strings" label)
+  | other ->
+    Error
+      (Printf.sprintf "keeper %s must be an array of strings (received %s)"
+         label (json_kind_name other))
 ;;
 
 let string_list_field_opt_result ?label ~field_name (json : Yojson.Safe.t) =

--- a/lib/types/task_stage.ml
+++ b/lib/types/task_stage.ml
@@ -29,9 +29,24 @@ let of_string = function
 
 let to_yojson t = `String (to_string t)
 
+let json_kind_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "intlit"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+
 let of_yojson = function
   | `String s -> of_string s
-  | _ -> Error "task stage must be a string"
+  | other ->
+      Error
+        (Printf.sprintf "task stage must be a string (received %s)"
+           (json_kind_name other))
 
 let all = [Decompose; Inspect; Implement; Verify; Review]
 

--- a/lib/worker_execution_backend.ml
+++ b/lib/worker_execution_backend.ml
@@ -15,6 +15,18 @@ let of_string value =
 let to_yojson backend =
   `String (to_string backend)
 
+let json_kind_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "intlit"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+
 let of_yojson = function
   | `String value -> (
       match of_string value with
@@ -22,4 +34,8 @@ let of_yojson = function
       | None ->
           Error
             (Printf.sprintf "unknown worker execution backend: %s" value))
-  | _ -> Error "worker execution backend must be a string"
+  | other ->
+      Error
+        (Printf.sprintf
+           "worker execution backend must be a string (received %s)"
+           (json_kind_name other))


### PR DESCRIPTION
## Why

3 narrow 1-site files share 같은 expected-only 안티패턴 — bundle PR로 cohort closure 효율 유지.

## What

| File | Site | Note |
|---|---|---|
| `lib/types/task_stage.ml` L34 | `of_yojson` top-level | enum string parser |
| `lib/worker_execution_backend.ml` L25 | `of_yojson` top-level | enum string parser |
| `lib/keeper/keeper_meta_tool_access.ml` L155 | `string_list_field_result` element | `bad :: _` 패턴 |
| `lib/keeper/keeper_meta_tool_access.ml` L159 | `string_list_field_result` outer | non-list catch-all |

각 파일에 file-private `json_kind_name` (10 variant closed total function). 4 type-shape 사이트.

## Cohort boundary

`lib/keeper/keeper_meta_tool_access.ml` L158 (이전) ``Null arm은 *non-null 의무 제약* — required-list field, keeper_turn_up_args (Iter#24)와 평행. semantic constraint로 유지.

## Iter#13~#25 series

13-PR series = **76 사이트 across 15 files**, 같은 inline `json_kind_name` form (PR #16375 머지 후 dedup target).

## Workaround Rejection Bar

- [x] Counter-as-fix 아님
- [x] String/substring classifier 아님 — closed sum type
- [x] N-of-M 아님 — bundle PR로 narrow 자매 site 일괄
- [x] Cap/cooldown/dedup/repair 아님
- [x] Test backdoor 아님

## RFC Check

PASS — 3 모듈 모두 pure type/codec (task stage enum, worker execution backend enum, keeper tool-access JSON helpers). credential boundary 아님.

## Verification

- [x] `ocamlformat --check` PASS (auto)
- [x] test grep 0
- [ ] CI 모니터링

## Iter#15.5 sweep

30 PR sweep PASS (10회째). 🎉 첫 10회 누적.

🤖 /loop cron \`253cc0f6\` Iter#25

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>