### PR TITLE
feat(board): report received JSON kind in board_attachment_meta parse errors

### DIFF
--- a/lib/board_attachment_meta.ml
+++ b/lib/board_attachment_meta.ml
@@ -90,35 +90,67 @@ let to_yojson (t : t) : Yojson.Safe.t =
     "created_at", `Float t.created_at;
   ]
 
+let json_kind_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "intlit"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+
 let opt_int_of_yojson = function
   | `Null -> Ok None
   | `Int i -> Ok (Some i)
-  | _ -> Error (Invalid_payload "expected null or int")
+  | other ->
+      Error
+        (Invalid_payload
+           (Printf.sprintf "expected null or int (received %s)"
+              (json_kind_name other)))
 
 let assoc_get key = function
   | `Assoc kvs -> (
       match List.assoc_opt key kvs with
       | Some v -> Ok v
       | None -> Error (Missing_field key))
-  | _ -> Error (Invalid_payload "expected JSON object")
+  | other ->
+      Error
+        (Invalid_payload
+           (Printf.sprintf "expected JSON object (received %s)"
+              (json_kind_name other)))
 
 let string_of_yojson key json =
   match assoc_get key json with
   | Ok (`String s) -> Ok s
-  | Ok _ -> Error (Invalid_payload (Printf.sprintf "%s: expected string" key))
+  | Ok other ->
+      Error
+        (Invalid_payload
+           (Printf.sprintf "%s: expected string (received %s)" key
+              (json_kind_name other)))
   | Error e -> Error e
 
 let int_of_yojson key json =
   match assoc_get key json with
   | Ok (`Int i) -> Ok i
-  | Ok _ -> Error (Invalid_payload (Printf.sprintf "%s: expected int" key))
+  | Ok other ->
+      Error
+        (Invalid_payload
+           (Printf.sprintf "%s: expected int (received %s)" key
+              (json_kind_name other)))
   | Error e -> Error e
 
 let float_of_yojson key json =
   match assoc_get key json with
   | Ok (`Float f) -> Ok f
   | Ok (`Int i) -> Ok (float_of_int i)
-  | Ok _ -> Error (Invalid_payload (Printf.sprintf "%s: expected float" key))
+  | Ok other ->
+      Error
+        (Invalid_payload
+           (Printf.sprintf "%s: expected float (received %s)" key
+              (json_kind_name other)))
   | Error e -> Error e
 
 let opt_int_field key json =


### PR DESCRIPTION
## Why

`board_attachment_meta.ml`의 5개 JSON 파서 사이트가 "expected X" 만 보고하고 실제로 받은 kind를 누락 → operator가 payload 디버깅 시 원본 JSON을 손으로 grep해야 함. FSM/TLA+ observability 스프린트 cohort closure.

## What

| Line | Function | 변경 |
|------|----------|------|
| L96 | `opt_int_of_yojson` | non-(Null\|Int) catch-all `(received <kind>)` 추가 |
| L103 | `assoc_get` | non-Assoc catch-all `(received <kind>)` 추가 |
| L108 | `string_of_yojson` | Ok-not-String 분기 `(received <kind>)` 추가 |
| L114 | `int_of_yojson` | Ok-not-Int 분기 `(received <kind>)` 추가 |
| L121 | `float_of_yojson` | Ok-not-(Float\|Int) 분기 `(received <kind>)` 추가 |

`json_kind_name : Yojson.Safe.t -> string` 11-line closed total function (10 variants, no catch-all). Errors stay wrapped in existing `Invalid_payload` typed variant — caller API 무변경.

## Cohort closure

`lib/board_attachment_meta.ml` 내 모든 type-shape mismatch 사이트 5/5 닫음. 같은 모듈 내 비-shape 검증(non-empty/range/bound) out of scope.

## Iter series

FSM/TLA+ observability sweep loop **iter#26 of /loop 20m cron `253cc0f6`**:
- 81 사이트 across 16 files
- 2 MERGED (#16330, #16358) + 22 Draft+MERGEABLE + 이 PR
- 16th inline `json_kind_name` copy (dedup deferred to PR #16375)

## Workaround Rejection Bar

- [ ] telemetry-as-fix: 아님 (typed error variant 그대로 사용)
- [ ] string classifier 추가: 아님 (variant match 확장)
- [ ] N-of-M: 아님 (file cohort 5/5)
- [ ] catch-all 추가: 아님 (closed match)
- [ ] cap/cooldown/dedup/repair: 아님
- [ ] test backdoor: 아님
- [ ] codemod 미수행 typo 반복: N/A

## RFC Check

`bash ~/me/scripts/pr-rfc-check.sh` PASS. board attachment metadata record + JSON codec — credential/identity/operator/sandbox/dashboard-credential/hooks/workflow* 무관.

## Verification

- `dune build lib/board_attachment_meta.ml` PASS
- `ocamlformat --check` PASS
- Caller API unchanged (Invalid_payload 변형 그대로)

## Iter#15.5 conflict sweep

`gh pr list --json mergeable` → 50 open / 0 CONFLICTING (11회째 PASS).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>