### PR TITLE
feat(coord): report received JSON kind in verification store parse errors

### DIFF
--- a/lib/coord/coord_verification_store.ml
+++ b/lib/coord/coord_verification_store.ml
@@ -17,6 +17,18 @@ type request_header = {
   status : request_status;
 }
 
+let json_kind_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "intlit"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+
 let project_root_of_base_path base_path =
   if Filename.basename base_path = Common.masc_dirname then
     Filename.dirname base_path
@@ -58,7 +70,10 @@ let verdict_of_yojson = function
            in
            Ok (`Partial (score, reason))
        | _ -> Error "unknown or missing verdict")
-  | _ -> Error "verdict must be a JSON object"
+  | other ->
+      Error
+        (Printf.sprintf "verdict must be a JSON object (received %s)"
+           (json_kind_name other))
 
 let request_status_of_yojson = function
   | `Assoc fields ->
@@ -73,7 +88,10 @@ let request_status_of_yojson = function
             | Ok verdict -> Ok (`Completed verdict)
             | Error err -> Error err)
        | _ -> Error "unknown request status")
-  | _ -> Error "request status must be a JSON object"
+  | other ->
+      Error
+        (Printf.sprintf "request status must be a JSON object (received %s)"
+           (json_kind_name other))
 
 let request_header_of_yojson = function
   | `Assoc fields ->
@@ -110,7 +128,10 @@ let request_header_of_yojson = function
            in
            Ok { id; task_id; worker; verifier; created_at; status }
        | _ -> Error "verification request requires 'id', 'task_id', 'worker' fields")
-  | _ -> Error "verification request must be a JSON object"
+  | other ->
+      Error
+        (Printf.sprintf "verification request must be a JSON object (received %s)"
+           (json_kind_name other))
 
 let load_request_header base_path req_id =
   let path = request_path base_path req_id in


### PR DESCRIPTION
## Why

`coord_verification_store.ml`의 3개 JSON 파서 사이트가 "must be a JSON object"만 보고하고 실제 받은 kind를 누락. coord verification은 worker↔verifier 협조 critical path — operator가 잘못된 payload (e.g. 빈 `"pending"` string instead of object envelope) 디버깅 시 raw JSON 직접 봐야 함.

## What

| Line | Function | 변경 |
|------|----------|------|
| L61 | `verdict_of_yojson` | non-Assoc catch-all `(received <kind>)` |
| L76 | `request_status_of_yojson` | non-Assoc catch-all `(received <kind>)` |
| L113 | `request_header_of_yojson` | non-Assoc catch-all `(received <kind>)` |

Inline `json_kind_name : Yojson.Safe.t -> string` 11-line closed total function (10 variants, catch-all 0). 17th inline copy.

## Cohort closure

`lib/coord/coord_verification_store.ml` 내 모든 type-shape mismatch 사이트 3/3 닫음.

**Out of cohort (semantic, separate)**:
- L60 `"unknown or missing verdict"` (enum/missing field)
- L70 `"assigned requires 'verifier' field"` (missing field semantic)
- L75 `"unknown request status"` (enum string mismatch)
- L107 `| Error _ -> \`Pending` ⚠️ silent failure (status parse error 시 silent Pending fallback) — **워크어라운드 시그니처 #1 (unknown→permissive default)** 후보, 추후 RFC 검토

## Iter series

FSM/TLA+ observability sweep `/loop 20m` cron `253cc0f6` **iter#27**:
- 84 사이트 across 17 files
- 2 MERGED (#16330, #16358) + 24 Draft+MERGEABLE
- 17th inline `json_kind_name` (dedup PR #16375 머지 대기)

## Workaround Rejection Bar

- [ ] telemetry-as-fix: 아님 (typed Error 위에 string detail)
- [ ] string classifier 추가: 아님 (variant match 확장)
- [ ] N-of-M: 아님 (file cohort 3/3 closed)
- [ ] catch-all 추가: 아님 (closed match)
- [ ] cap/cooldown/dedup/repair: 아님
- [ ] test backdoor: 아님

## RFC Check

`bash ~/me/scripts/pr-rfc-check.sh` PASS (exit 0). coord/coord_verification_store — credential/identity/operator/sandbox/dashboard-credential/hooks/workflow* 무관.

## Verification

- ocamlformat --check PASS
- Caller API unchanged (`(_, string) result`)

## Iter#15.5 conflict sweep

`gh pr list --json mergeable` → 50 open / 0 CONFLICTING (12회째 PASS).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>