### PR TITLE
feat(tool_task): report received JSON kind in args parse errors

### DIFF
--- a/lib/tool_task_args.ml
+++ b/lib/tool_task_args.ml
@@ -8,6 +8,18 @@
 
 open Yojson.Safe.Util
 
+let json_kind_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "intlit"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+
 let parse_task_contract args =
   match args |> member "contract" with
   | `Null -> Ok None
@@ -17,7 +29,11 @@ let parse_task_contract args =
       | Error error ->
           Error
             (Printf.sprintf "Invalid contract payload: %s" error))
-  | _ -> Error "contract must be an object when provided"
+  | other ->
+      Error
+        (Printf.sprintf
+           "contract must be an object when provided (received %s)"
+           (json_kind_name other))
 
 let is_internal_marker key =
   String.length key > 0 && Char.equal key.[0] '_'
@@ -145,7 +161,11 @@ let parse_handoff_context ~(agent_name : string)
                    updated_at = Some (Masc_domain.now_iso ());
                    updated_by = Some agent_name;
                  }))
-  | _ -> Error "handoff_context must be an object when provided"
+  | other ->
+      Error
+        (Printf.sprintf
+           "handoff_context must be an object when provided (received %s)"
+           (json_kind_name other))
 
 let transition_known_args =
   [


### PR DESCRIPTION
## Why

`tool_task_args.ml`의 2개 type-shape catch-all이 받은 kind를 누락. 이 모듈은 **masc_transition tool의 사용자-노출 argument validator** — LLM keeper들이 자주 `contract` / `handoff_context`를 string으로 보내는 mistake를 함. error message가 received kind를 명시하면 operator + keeper 모두 self-correct 가능.

## What

| Line | Function | 변경 |
|------|----------|------|
| L20 | `parse_task_contract` | non-(Null\|Assoc) catch-all `(received <kind>)` |
| L148 | handoff_context parser | non-(Null\|Assoc) catch-all `(received <kind>)` |

Inline `json_kind_name : Yojson.Safe.t -> string` 11-line closed total function (10 variants, catch-all 0). 18th inline copy.

## Cohort closure

`lib/tool_task_args.ml` 내 모든 type-shape mismatch 사이트 2/2 닫음. 같은 모듈 내 semantic 검증 (`summary is required`, `non-empty trimmed`)은 out of cohort.

## Iter series

FSM/TLA+ observability sweep `/loop 20m` cron `253cc0f6` **iter#28**:
- 86 사이트 across 18 files
- 2 MERGED (#16330, #16358) + 25 Draft+MERGEABLE
- 18th inline copy (PR #16375 dedup 머지 대기)
- Sweep 13회째 PASS (60 open / 0 CONFLICTING)

## Workaround Rejection Bar

- [ ] telemetry-as-fix: 아님 (typed Error 위 string detail)
- [ ] string classifier 추가: 아님 (variant match 확장)
- [ ] N-of-M: 아님 (file cohort 2/2)
- [ ] catch-all 추가: 아님 (closed match)
- [ ] cap/cooldown/dedup/repair: 아님
- [ ] test backdoor: 아님

## RFC Check

`bash ~/me/scripts/pr-rfc-check.sh` PASS (exit 0). tool_task_args — credential/identity/operator/sandbox/dashboard-credential/hooks/workflow* 무관.

## Verification

- ocamlformat --check PASS
- Caller API unchanged (still `(_, string) result`)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>