### PR TITLE
feat(failure_envelope): split missing vs wrong-type field errors

### DIFF
--- a/lib/failure_envelope.ml
+++ b/lib/failure_envelope.ml
@@ -22,6 +22,18 @@ type t = {
 
 let tool_host_log_module_name = "ToolHost"
 
+let json_kind_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "intlit"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+
 let severity_to_string = function
   | Warn -> "warn"
   | Bad -> "bad"
@@ -137,7 +149,12 @@ let required_string json key =
   let open Yojson.Safe.Util in
   match json |> member key with
   | `String value -> Ok value
-  | _ -> Error ("missing required failure field: " ^ key)
+  | `Null -> Error (Printf.sprintf "missing required failure field: %s" key)
+  | other ->
+      Error
+        (Printf.sprintf
+           "failure field %s must be a string (received %s)" key
+           (json_kind_name other))
 
 let optional_string json key =
   let open Yojson.Safe.Util in
@@ -191,7 +208,10 @@ let of_yojson json =
                                             Yojson.Safe.Util.member
                                               "evidence_ref" json;
                                         }))))))))
-  | _ -> Error "failure envelope must be a JSON object"
+  | other ->
+      Error
+        (Printf.sprintf "failure envelope must be a JSON object (received %s)"
+           (json_kind_name other))
 
 let attach_to_details details envelope =
   match details with


### PR DESCRIPTION
## Why

`failure_envelope.ml`은 operator의 **FSM-across-surfaces failure visibility의 SSOT** (keeper/coord/cascade/tool_host). 파싱 실패 시 두 distinct cause를 같은 메시지로 collapse:
- **Missing field** (`producer가 X를 안 보냄`) vs **wrong-type field** (`producer가 X를 잘못된 타입으로 보냄`) — 둘 다 `missing required failure field: X`
- Outer `must be a JSON object` — received kind 누락

이건 FSM-critical: failure_envelope이 broken이면 operator는 *왜* failure가 났는지조차 모름 (meta-level visibility loss).

## What

| Line | Function | 변경 |
|------|----------|------|
| L136 | `required_string` | `\`Null` arm = missing / `other` arm = "failure field X must be a string (received <kind>)" 분리 |
| L194 | `of_yojson` outer catch-all | `(received <kind>)` 추가 |

Inline `json_kind_name` 11-line closed total function (10 variants).

## Behavior change (intentional improvement)

- Old: missing + wrong-type collapsed into `"missing required failure field: X"`
- New: missing → 동일 / wrong-type → `"failure field X must be a string (received int)"`
- 영향 받는 테스트 0 (`rg "missing required failure" test/` empty).
- Caller API 동일 (`(_, string) result`).

## Cohort closure

`lib/failure_envelope.ml` 내 모든 type-shape mismatch 사이트 2/2 닫음. `optional_string` (L142)의 silent `_ -> None`는 **워크어라운드 시그니처 #2** (silent default) — out of cohort, RFC 후보.

## Iter series

FSM/TLA+ observability sweep `/loop 20m` cron `253cc0f6` **iter#29**:
- 88 사이트 across 19 files
- 2 MERGED (#16330, #16358) + 26 Draft+MERGEABLE
- 19th inline copy (PR #16375 dedup 미해소)
- Sweep 14회째 PASS (60 open / 0 CONFLICTING)

## Workaround Rejection Bar

- [ ] telemetry-as-fix: 아님
- [ ] string classifier 추가: 아님 (variant match split)
- [ ] N-of-M: 아님 (file cohort 2/2)
- [ ] catch-all 추가: 아님 (catch-all 분기로 *세분화*)
- [ ] cap/cooldown/dedup/repair: 아님

## RFC Check

`bash ~/me/scripts/pr-rfc-check.sh` PASS (exit 0). failure_envelope은 cross-surface but credential/identity/operator-control/sandbox/dashboard-credential/hooks/workflow* 무관.

## Verification

- ocamlformat --check PASS
- Test suite는 string equality 비의존

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>