### PR TITLE
feat(multimodal): split missing vs wrong-type in payload.of_json errors

### DIFF
--- a/lib/multimodal/payload.ml
+++ b/lib/multimodal/payload.ml
@@ -13,6 +13,18 @@ let to_json = function
   | Streaming n ->
       `Assoc [ ("kind", `String "streaming"); ("bytes", `Int n) ]
 
+let json_kind_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "intlit"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+
 let of_json = function
   | `Assoc kv -> (
       match List.assoc_opt "kind" kv with
@@ -20,12 +32,30 @@ let of_json = function
       | Some (`String "blob_ref") -> (
           match List.assoc_opt "ref" kv with
           | Some (`String s) -> Ok (Blob_ref s)
-          | _ -> Error "blob_ref payload missing 'ref' string field")
+          | None -> Error "blob_ref payload missing 'ref' field"
+          | Some other ->
+              Error
+                (Printf.sprintf
+                   "blob_ref payload 'ref' field must be a string (received %s)"
+                   (json_kind_name other)))
       | Some (`String "streaming") -> (
           match List.assoc_opt "bytes" kv with
           | Some (`Int n) -> Ok (Streaming n)
-          | _ -> Error "streaming payload missing 'bytes' int field")
+          | None -> Error "streaming payload missing 'bytes' field"
+          | Some other ->
+              Error
+                (Printf.sprintf
+                   "streaming payload 'bytes' field must be an int (received %s)"
+                   (json_kind_name other)))
       | Some (`String other) ->
           Error (Printf.sprintf "unknown payload kind: %s" other)
-      | _ -> Error "payload missing 'kind' string field")
-  | _ -> Error "payload must be a JSON object"
+      | None -> Error "payload missing 'kind' field"
+      | Some other ->
+          Error
+            (Printf.sprintf
+               "payload 'kind' field must be a string (received %s)"
+               (json_kind_name other)))
+  | other ->
+      Error
+        (Printf.sprintf "payload must be a JSON object (received %s)"
+           (json_kind_name other))


### PR DESCRIPTION
## Why

`multimodal/payload.ml`의 `of_json` 4-arm 파서가 두 distinct producer mistake를 같은 메시지로 collapse:

| 문제 | Before | After |
|------|--------|-------|
| Missing `ref` field | `"blob_ref payload missing 'ref' string field"` | `"missing 'ref' field"` (명시) |
| `ref` field가 int | (위와 동일 메시지) | `"'ref' field must be a string (received int)"` |
| Outer non-object | `"payload must be a JSON object"` | `"... (received <kind>)"` |

multimodal payload는 OAS SSE multimodal 전송 SSOT — LLM이 자주 ref를 int/null로 보내거나 bytes를 string으로 보내는 mistake. self-correctable hint 추가.

## What

| Line | Arm | 변경 |
|------|-----|------|
| L21 | blob_ref `ref` | None vs Some-non-string 분리 |
| L25 | streaming `bytes` | None vs Some-non-int 분리 |
| L30 | `kind` field | None vs Some-non-string 분리 |
| L31 | outer | `(received <kind>)` |

Inline `json_kind_name` 11-line closed total. 20th inline copy.

## Behavior change (intentional improvement)

- Old error strings collapse missing↔wrong-type.
- New strings distinguish them cleanly.
- Test 영향 0 (`rg "blob_ref payload missing" test/` empty).
- Caller API 동일 (`(_, string) result`).

## Cohort closure

`lib/multimodal/payload.ml` 4/4 type-shape 사이트 닫음.

## Iter series

FSM/TLA+ observability sweep `/loop 20m` cron `253cc0f6` **iter#30**:
- 92 사이트 across 20 files
- 2 MERGED (#16330, #16358) + 27 Draft+MERGEABLE
- 20th inline copy (PR #16375 dedup ROI 강화)
- Sweep 15회째 PASS (80 open / 0 CONFLICTING)

## Workaround Rejection Bar

- [ ] telemetry-as-fix: 아님
- [ ] string classifier 추가: 아님 (variant match 세분화)
- [ ] N-of-M: 아님 (cohort 4/4)
- [ ] catch-all 추가: 아님 (catch-all *세분화*)
- [ ] cap/cooldown/dedup/repair: 아님

## RFC Check

`bash ~/me/scripts/pr-rfc-check.sh` PASS (exit 0). multimodal/payload — credential/identity/operator/sandbox/dashboard-credential/hooks/workflow* 무관.

## Verification

- ocamlformat --check PASS
- Caller API unchanged (`(t, string) result`)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>