### PR TITLE
feat(keeper-shell): pass ~caller:Keeper_shell_bash to validation (RFC-0131 PR-2)

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -257,6 +257,7 @@ let safe_read_primary_rewrite primary_cmd =
     else (
       match
         Worker_dev_tools.validate_command_coding_with_allowlist
+          ~caller:Shell_command_gate.Keeper_shell_bash
           ~allow_pipes:false
           ~allowed_commands:Worker_dev_tools.dev_allowed_commands
           primary_cmd
@@ -527,7 +528,11 @@ let safe_read_fallback_of_command ~write_enabled:_ ~stderr_dev_null_stripped cmd
 
 let shape_block_allowed_by_active_validator ~write_enabled cmd = function
   | Pipe_or_redirect when write_enabled ->
-    (match Worker_dev_tools.validate_command_coding cmd with
+    (match
+       Worker_dev_tools.validate_command_coding
+         ~caller:Shell_command_gate.Keeper_shell_bash
+         cmd
+     with
      | Ok () -> true
      | Error _ -> false)
   | Gh_pr_checks | Chaining | Substitution | Repo_wide_scan | Pipe_or_redirect ->
@@ -698,6 +703,7 @@ let single_repo_cwd_for_top_relative_read
   else
     match
       Worker_dev_tools.validate_command_coding_with_allowlist
+        ~caller:Shell_command_gate.Keeper_shell_bash
         ~allow_pipes:false
         ~allowed_commands:Worker_dev_tools.dev_allowed_commands
         cmd
@@ -1513,12 +1519,19 @@ let handle_keeper_bash
         ();
       (* Local execution path: full validation applies *)
       let validate =
-        if write_enabled then Worker_dev_tools.validate_command_coding
-        else if Option.is_some safe_read_fallback then
+        if write_enabled
+        then
+          Worker_dev_tools.validate_command_coding
+            ~caller:Shell_command_gate.Keeper_shell_bash
+        else if Option.is_some safe_read_fallback
+        then
           Worker_dev_tools.validate_command_coding_with_allowlist
+            ~caller:Shell_command_gate.Keeper_shell_bash
             ~allow_pipes:false
             ~allowed_commands:Worker_dev_tools.dev_allowed_commands
-        else Worker_dev_tools.validate_command
+        else
+          Worker_dev_tools.validate_command
+            ~caller:Shell_command_gate.Keeper_shell_bash
       in
       match validate validation_cmd with
       | Error reason ->


### PR DESCRIPTION
## Summary

RFC-0131 PR-2 — wire `keeper_shell_bash.ml` to forward `~caller:Shell_command_gate.Keeper_shell_bash` through `Worker_dev_tools.validate_command*`.

PR-1a (#16335, MERGED), PR-1b (#16340, MERGED), SSOT mirror (#16393, MERGED), and PR-2 prep (#16433, MERGED) introduced and propagated the `?caller` API surface. This PR is the keeper-side wiring that tags every `keeper_shell_bash` validation call so the upcoming telemetry counter exposure (RFC-0131 PR-3, Plan Phase 4 measurement window) can emit per-caller partition rows.

## Product impact

- Behavior unchanged today (`caller` is captured but does not affect verdict).
- When PR-3 lands, `keeper_shell_bash` becomes distinguishable from `tool_code_write` and ad-hoc `worker_dev_tools` callers in the per-caller verdict counter.

## Changes — 6 call sites in `lib/keeper/keeper_shell_bash.ml`

| Line (pre-edit) | API | Form |
|-----------------|-----|------|
| 259 | `validate_command_coding_with_allowlist` | named args |
| 530 | `validate_command_coding` | positional |
| 700 | `validate_command_coding_with_allowlist` | named args |
| 1516 | `validate_command_coding` (partial app) | let-bound |
| 1518 | `validate_command_coding_with_allowlist` (partial app) | let-bound |
| 1521 | `validate_command` (partial app) | let-bound |

### Why 6 sites (Plan doc R2 estimated 5)

The `let validate = ...` partial application at lines 1516–1521 requires uniform `string -> (unit, block_reason) result` shape across all three branches. PR-2 prep (#16433) added `?caller` to `validate_command` for call-site parity — so omitting `~caller:` on the `validate_command` arm would leave `?caller:caller -> string -> result` and break partial-app unification. The 6th site is mechanical, not scope creep.

## Evidence

```
$ git diff --stat
 lib/keeper/keeper_shell_bash.ml | 21 +++++++++++++++++----
 1 file changed, 17 insertions(+), 4 deletions(-)
```

- `dune build --root . lib/.masc_mcp.objs/native/masc_mcp__Keeper_shell_bash.cmx` — passed (exit 0).
- `opam exec -- ocamlformat --check lib/keeper/keeper_shell_bash.ml` — pass.

## Linked

- RFC: `docs/rfc/RFC-0131-shell-command-gate-facade.md` §10 — Shell Command Gate facade.
- Prereqs: #16335 (PR-1a, MERGED), #16340 (PR-1b, MERGED), #16393 (SSOT mirror, MERGED), #16433 (PR-2 prep, MERGED).
- Sibling: #16346 (PR-1c, redirect_allowed) — independently mergeable.
- Plan: Shell IR Promotion Goal R2 — Iteration 18 = keeper_shell_bash direct wiring.

## Backwards compatibility

- `?caller` is an optional named arg with `None` default; no behavioral change for non-keeper callers.
- `keeper_shell_bash` is the only caller in this PR; no external surface affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
