### PR TITLE
feat: bundle received-kind enrich for dashboard + board narrow parsers

### DIFF
--- a/lib/dashboard_tool_host_events.ml
+++ b/lib/dashboard_tool_host_events.ml
@@ -15,6 +15,18 @@ module Char = Stdlib.Char
 module Int = Stdlib.Int
 module Float = Stdlib.Float
 
+let json_kind_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "intlit"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+
 type report = {
   agent_name : string;
   client_name : string;
@@ -97,7 +109,10 @@ let report_of_yojson ?fallback_agent (json : Yojson.Safe.t) :
               timeout_ms = parse_timeout_ms json;
             }
       | Error msg, _ | _, Error msg -> Error msg)
-  | _ -> Error "request body must be a JSON object"
+  | other ->
+      Error
+        (Printf.sprintf "request body must be a JSON object (received %s)"
+           (json_kind_name other))
 
 let details_json (report : report) =
   let envelope =

--- a/lib/tool_board_format.ml
+++ b/lib/tool_board_format.ml
@@ -19,6 +19,19 @@ module Float = Stdlib.Float
     truncated-markdown detector, and the Yojson-error boundary shared
     across the [Tool_board] submodules. Stage 10 split. *)
 
+let json_kind_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "intlit"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+;;
+
 (** Strip [STATE]...[/STATE] blocks. Inlined to avoid the
     Keeper_prompt dependency cycle via Keeper_alerting. *)
 let strip_state_blocks_text (s : string) : string =
@@ -536,7 +549,11 @@ let provenance_arg args =
   | `Assoc fields ->
     (match assoc_field fields "provenance" with
      | Some (`Assoc _ as json) -> Ok json
-     | Some _ -> Error "provenance must be an object"
+     | Some other ->
+       Error
+         (Printf.sprintf
+            "provenance must be an object (received %s)"
+            (json_kind_name other))
      | _ -> Ok (`Assoc []))
   | _ -> Ok (`Assoc [])
 ;;


### PR DESCRIPTION
## Why

두 narrow 1-site 파서 bundle PR — Iter#25 bundle 패턴 적용 (per-file PR 노이즈 회피, 같은 surface 클러스터):

- `dashboard_tool_host_events.ml`: dashboard SSE consumer가 잘못된 request body 보낼 때 silent kind 누락
- `tool_board_format.ml`: board tool `provenance` arg가 wrong-type일 때 silent kind 누락

## What

| File | Line | 변경 |
|------|------|------|
| `dashboard_tool_host_events.ml` | L100 | request body non-Assoc catch-all `(received <kind>)` |
| `tool_board_format.ml` | L539 | provenance `Some _` (non-Assoc) `(received <kind>)` |

각 파일 inline `json_kind_name` 11-line closed total (21st/22nd copy). `tool_board_format`은 jstrick `;;` / fields-indented style 유지.

## Cohort closure

`dashboard_tool_host_events.ml`: 1/1 type-shape 사이트.
`tool_board_format.ml`: 1/1 (file 내 다른 `_ -> Ok ...` arms는 의도된 silent default fallback for optional `args` — out of cohort).

## Iter series

FSM/TLA+ observability sweep `/loop 20m` cron `253cc0f6` **iter#31**:
- 94 사이트 across 22 files
- 2 MERGED (#16330, #16358) + 28 Draft+MERGEABLE
- 21st/22nd inline copy (PR #16375 dedup ROI 강함: 22 × 11 = 242 LoC)
- Sweep 16회째: 1 CONFLICTING (#16526, 타인 작업)

## Workaround Rejection Bar

- [ ] telemetry-as-fix: 아님
- [ ] string classifier 추가: 아님 (variant match 확장)
- [ ] N-of-M: 아님 (각 파일 cohort 1/1)
- [ ] catch-all 추가: 아님 (closed match)
- [ ] cap/cooldown/dedup/repair: 아님

## RFC Check

`bash ~/me/scripts/pr-rfc-check.sh` PASS (exit 0). dashboard/board surface — credential/identity/operator-control/sandbox/dashboard-credential/hooks/workflow* 무관.

## Verification

- ocamlformat --check PASS
- Caller API unchanged

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>