### PR TITLE
feat(types_boundary): introduce Boundary_redaction SSOT module (RFC-0132 PR-1)

### DIFF
--- a/lib/types_boundary/boundary_redaction.ml
+++ b/lib/types_boundary/boundary_redaction.ml
@@ -1,0 +1,8 @@
+(* Boundary redaction SSOT — see boundary_redaction.mli for contract. *)
+
+type public_label = string
+
+let runtime_provider_label : public_label = "runtime"
+let runtime_model_label : public_label = "runtime"
+
+let to_string (label : public_label) : string = label

--- a/lib/types_boundary/boundary_redaction.mli
+++ b/lib/types_boundary/boundary_redaction.mli
@@ -1,0 +1,21 @@
+(** Boundary redaction SSOT.
+
+    External-surface emit sites (dashboard telemetry, OAS boundary,
+    operator log) must redact provider/model identity to a small set
+    of [public_label] values. The [private string] type prevents
+    callers from constructing arbitrary labels — the only labels are
+    the constructors exposed below.
+
+    Internal observability paths (real provider tracking, internal
+    metrics) MUST NOT use this module — they should emit the real
+    string. RFC-0132 §3 enumerates the boundary classification.
+
+    Adding a new public label requires both: a new constructor here,
+    and a row in RFC-0132 §3 explaining the surface that emits it. *)
+
+type public_label = private string
+
+val runtime_provider_label : public_label
+val runtime_model_label : public_label
+
+val to_string : public_label -> string

--- a/lib/types_boundary/dune
+++ b/lib/types_boundary/dune
@@ -1,0 +1,7 @@
+(include_subdirs no)
+(library
+ (name masc_types_boundary)
+ (public_name masc_mcp.types_boundary)
+ (wrapped false)
+ (modules boundary_redaction)
+ (flags (:standard -w +4)))


### PR DESCRIPTION
## 요약

RFC-0132 §2 *Proposed solution* 의 모듈 코드만 도입합니다. `lib/types_boundary/boundary_redaction.{ml,mli}` SSOT 모듈을 추가하여 외부 surface (dashboard telemetry, OAS boundary emit, operator log) 에서 사용할 redacted provider/model identity 라벨을 한 곳에 모읍니다.

본 PR 은 **모듈 코드만** 다룹니다 — 23 사이트 caller 마이그레이션은 후속 **PR-2 codemod** 에서 처리합니다.

Cross-ref: RFC-0132 PR #16528.

## 변경

`lib/types_boundary/` 신규 sublib:

- `boundary_redaction.mli` (21 LoC)
  - `type public_label = private string` — 외부 caller 가 임의 문자열로 라벨을 만들 수 없음 (compile-time invariant)
  - `runtime_provider_label : public_label`
  - `runtime_model_label : public_label`
  - `val to_string : public_label -> string` (read-only coercion)
- `boundary_redaction.ml` (8 LoC)
  - 두 라벨 모두 현 시점 `"runtime"` 으로 redact
- `dune` (7 LoC)
  - sublib `masc_mcp.types_boundary`, `(wrapped false)`, `-w +4`

## `private string` 강제 메커니즘

`.mli` 가 `type public_label = private string` 선언:

| 방향 | 허용? | 근거 |
|---|---|---|
| `public_label -> string` | 허용 (via `to_string`) | external observer 가 redacted 결과를 string 으로 읽음 |
| `string -> public_label` | **차단** | private type abstraction |
| 외부에서 `let x : public_label = "foo"` | **compile error** | abstraction violation |

→ 새 public label 추가 = `.mli` 에 constructor + RFC-0132 §3 row 추가 두 가지 모두 필수.

## 경계 분리 (RFC-0132 §3 SSOT)

- **외부 surface (dashboard telemetry, OAS boundary, operator log)** → 본 모듈 사용 *강제*
- **내부 observability (real provider tracking, internal metrics)** → 본 모듈 *사용 금지*, real string 그대로

## 검증 (standalone alcotest, no dune build)

5/5 PASS:

```
Testing `Boundary_redaction'.
  [OK]  labels  0   runtime_provider_label -> "runtime".
  [OK]  labels  1   runtime_model_label -> "runtime".
  [OK]  labels  2   constants byte-equivalent.
  [OK]  labels  3   to_string idempotent.
  [OK]  labels  4   label is nonempty.
Test Successful in 0.001s. 5 tests run.
```

**Negative compile test (private type 강제 확인)** — `let _bad : Boundary_redaction.public_label = "foo"` 는 compile FAIL:

```
File "test_boundary_redaction_negative.ml", line 14, characters 45-50:
14 | let _bad : Boundary_redaction.public_label = "foo"
                                                  ^^^^^
Error: This constant has type string but an expression was expected of type
         Boundary_redaction.public_label
```

`scripts/dune-local.sh` 미실행 (사용자 정책: standalone alcotest 만, masc-mcp dune-local global lock 회피).

## WORKAROUND-CARRYOVER 없음

본 PR 은 root fix module 도입. SSOT abstraction 으로 hardcoding 산포 (`software-development.md` §AI 코드 생성 안티패턴 #1) 를 닫는 변경입니다.

## RFC 영역 아님

이 PR 은 credential/identity/auth/operator/sandbox 변경이 아니라 **새 boundary type 모듈 추가** 입니다 (RFC-0132 본문은 PR #16528 에 있음). `pr-rfc-check.sh` PASS 예상.

## 후속

- PR-2: 23 사이트 caller 마이그레이션 codemod
- PR-3+: RFC-0132 §5 enforcement (lint / boundary test) — 후속 RFC sweep 에서

Co-Authored-By: Claude <noreply@anthropic.com>
