### PR TITLE
feat(telemetry): shell_command_gate caller × verdict counter (RFC-0131 PR-3)

### DIFF
--- a/lib/legendary_counters.ml
+++ b/lib/legendary_counters.ml
@@ -38,6 +38,21 @@ let typed_advisor_allow = Atomic.make 0
 let typed_advisor_reject = Atomic.make 0
 let typed_advisor_cannot_parse = Atomic.make 0
 
+(* RFC-0131 PR-3 — caller × verdict partition for the
+   [Shell_command_gate] facade.  3 callers × 3 verdicts = 9 atomic
+   counters.  Names follow [shell_gate_<caller>_<verdict>]; the
+   typed-dispatch in [incr_shell_gate] is exhaustive over both sums
+   so a new caller or verdict variant is a compile error. *)
+let shell_gate_worker_dev_tools_allow = Atomic.make 0
+let shell_gate_worker_dev_tools_reject = Atomic.make 0
+let shell_gate_worker_dev_tools_cannot_parse = Atomic.make 0
+let shell_gate_tool_code_write_allow = Atomic.make 0
+let shell_gate_tool_code_write_reject = Atomic.make 0
+let shell_gate_tool_code_write_cannot_parse = Atomic.make 0
+let shell_gate_keeper_shell_bash_allow = Atomic.make 0
+let shell_gate_keeper_shell_bash_reject = Atomic.make 0
+let shell_gate_keeper_shell_bash_cannot_parse = Atomic.make 0
+
 let incr a = ignore (Atomic.fetch_and_add a 1)
 
 let incr_gate_diff (diff : Gate_diff_types.gate_diff) =
@@ -101,6 +116,34 @@ let incr_typed_advisor (a : Shell_ir_validator.advisory) =
   | Shell_ir_validator.Reject _ -> incr typed_advisor_reject
   | Shell_ir_validator.Cannot_parse _ -> incr typed_advisor_cannot_parse
 
+(* RFC-0131 PR-3 — typed dispatch for caller × verdict partition.
+   Exhaustive over [shell_gate_caller × shell_gate_verdict_kind]; a
+   new variant in either sum forces an update here at compile time. *)
+type shell_gate_caller =
+  | Worker_dev_tools
+  | Tool_code_write
+  | Keeper_shell_bash
+
+type shell_gate_verdict_kind =
+  | Allow
+  | Reject
+  | Cannot_parse
+
+let incr_shell_gate ~caller ~verdict =
+  let counter =
+    match caller, verdict with
+    | Worker_dev_tools, Allow -> shell_gate_worker_dev_tools_allow
+    | Worker_dev_tools, Reject -> shell_gate_worker_dev_tools_reject
+    | Worker_dev_tools, Cannot_parse -> shell_gate_worker_dev_tools_cannot_parse
+    | Tool_code_write, Allow -> shell_gate_tool_code_write_allow
+    | Tool_code_write, Reject -> shell_gate_tool_code_write_reject
+    | Tool_code_write, Cannot_parse -> shell_gate_tool_code_write_cannot_parse
+    | Keeper_shell_bash, Allow -> shell_gate_keeper_shell_bash_allow
+    | Keeper_shell_bash, Reject -> shell_gate_keeper_shell_bash_reject
+    | Keeper_shell_bash, Cannot_parse -> shell_gate_keeper_shell_bash_cannot_parse
+  in
+  incr counter
+
 let reset () =
   Atomic.set gate_diff_total 0;
   Atomic.set gate_diff_agree 0;
@@ -132,7 +175,16 @@ let reset () =
   Atomic.set gh_exit_unknown 0;
   Atomic.set typed_advisor_allow 0;
   Atomic.set typed_advisor_reject 0;
-  Atomic.set typed_advisor_cannot_parse 0
+  Atomic.set typed_advisor_cannot_parse 0;
+  Atomic.set shell_gate_worker_dev_tools_allow 0;
+  Atomic.set shell_gate_worker_dev_tools_reject 0;
+  Atomic.set shell_gate_worker_dev_tools_cannot_parse 0;
+  Atomic.set shell_gate_tool_code_write_allow 0;
+  Atomic.set shell_gate_tool_code_write_reject 0;
+  Atomic.set shell_gate_tool_code_write_cannot_parse 0;
+  Atomic.set shell_gate_keeper_shell_bash_allow 0;
+  Atomic.set shell_gate_keeper_shell_bash_reject 0;
+  Atomic.set shell_gate_keeper_shell_bash_cannot_parse 0
 
 type snapshot = {
   gate_diff_total : int;
@@ -168,6 +220,16 @@ type snapshot = {
   typed_advisor_allow : int;
   typed_advisor_reject : int;
   typed_advisor_cannot_parse : int;
+  (* RFC-0131 PR-3 — Shell_command_gate caller × verdict partition. *)
+  shell_gate_worker_dev_tools_allow : int;
+  shell_gate_worker_dev_tools_reject : int;
+  shell_gate_worker_dev_tools_cannot_parse : int;
+  shell_gate_tool_code_write_allow : int;
+  shell_gate_tool_code_write_reject : int;
+  shell_gate_tool_code_write_cannot_parse : int;
+  shell_gate_keeper_shell_bash_allow : int;
+  shell_gate_keeper_shell_bash_reject : int;
+  shell_gate_keeper_shell_bash_cannot_parse : int;
 }
 
 let snapshot () =
@@ -206,6 +268,24 @@ let snapshot () =
     typed_advisor_allow = Atomic.get typed_advisor_allow;
     typed_advisor_reject = Atomic.get typed_advisor_reject;
     typed_advisor_cannot_parse = Atomic.get typed_advisor_cannot_parse;
+    shell_gate_worker_dev_tools_allow =
+      Atomic.get shell_gate_worker_dev_tools_allow;
+    shell_gate_worker_dev_tools_reject =
+      Atomic.get shell_gate_worker_dev_tools_reject;
+    shell_gate_worker_dev_tools_cannot_parse =
+      Atomic.get shell_gate_worker_dev_tools_cannot_parse;
+    shell_gate_tool_code_write_allow =
+      Atomic.get shell_gate_tool_code_write_allow;
+    shell_gate_tool_code_write_reject =
+      Atomic.get shell_gate_tool_code_write_reject;
+    shell_gate_tool_code_write_cannot_parse =
+      Atomic.get shell_gate_tool_code_write_cannot_parse;
+    shell_gate_keeper_shell_bash_allow =
+      Atomic.get shell_gate_keeper_shell_bash_allow;
+    shell_gate_keeper_shell_bash_reject =
+      Atomic.get shell_gate_keeper_shell_bash_reject;
+    shell_gate_keeper_shell_bash_cannot_parse =
+      Atomic.get shell_gate_keeper_shell_bash_cannot_parse;
   }
 
 let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
@@ -244,6 +324,24 @@ let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
     ("typed_advisor_allow", `Int s.typed_advisor_allow);
     ("typed_advisor_reject", `Int s.typed_advisor_reject);
     ("typed_advisor_cannot_parse", `Int s.typed_advisor_cannot_parse);
+    ("shell_gate_worker_dev_tools_allow",
+     `Int s.shell_gate_worker_dev_tools_allow);
+    ("shell_gate_worker_dev_tools_reject",
+     `Int s.shell_gate_worker_dev_tools_reject);
+    ("shell_gate_worker_dev_tools_cannot_parse",
+     `Int s.shell_gate_worker_dev_tools_cannot_parse);
+    ("shell_gate_tool_code_write_allow",
+     `Int s.shell_gate_tool_code_write_allow);
+    ("shell_gate_tool_code_write_reject",
+     `Int s.shell_gate_tool_code_write_reject);
+    ("shell_gate_tool_code_write_cannot_parse",
+     `Int s.shell_gate_tool_code_write_cannot_parse);
+    ("shell_gate_keeper_shell_bash_allow",
+     `Int s.shell_gate_keeper_shell_bash_allow);
+    ("shell_gate_keeper_shell_bash_reject",
+     `Int s.shell_gate_keeper_shell_bash_reject);
+    ("shell_gate_keeper_shell_bash_cannot_parse",
+     `Int s.shell_gate_keeper_shell_bash_cannot_parse);
   ]
 
 let safe_ratio ~num ~den =

--- a/lib/legendary_counters.mli
+++ b/lib/legendary_counters.mli
@@ -69,6 +69,46 @@ val incr_typed_advisor : Shell_ir_validator.advisory -> unit
     [Gate_diff_types.typed_advisor_log_enabled ()] is true so an
     operator running with the flag off pays zero cost. *)
 
+(** RFC-0131 PR-3 — caller × verdict telemetry partition for the
+    Shell_command_gate facade.
+
+    Mirrors the [caller] tag defined in {!Shell_command_gate.caller}
+    on both the legacy and SSOT facades.  Increment from each
+    facade's verdict-producing public entry point ({!Shell_command_gate.gate},
+    {!Shell_command_gate.lower_typed_pipeline}, and
+    {!Shell_command_gate.validate_allowlist} on legacy) so a future
+    authority flip (RFC-0131 PR-5) automatically populates the
+    per-caller partition without further wiring.
+
+    Until PR-5 lands the production parse path goes through
+    [Worker_dev_tools.validate_command_coding_with_allowlist] which
+    consumes only [Shell_command_gate.parse] (a parser, not a
+    verdict producer), so emit volume is naturally 0 in production.
+    Tests covering the verdict surface exercise this counter
+    directly. *)
+type shell_gate_caller =
+  | Worker_dev_tools
+  | Tool_code_write
+  | Keeper_shell_bash
+
+type shell_gate_verdict_kind =
+  | Allow
+  | Reject
+  | Cannot_parse
+
+val incr_shell_gate
+  :  caller:shell_gate_caller
+  -> verdict:shell_gate_verdict_kind
+  -> unit
+(** Record one shell_command_gate verdict under the given
+    [caller × verdict] bucket.  Exhaustive over both sums; adding a
+    new caller or verdict variant forces an update here at compile
+    time.
+
+    [caller] is required because partition-less rows are useless for
+    the PR-5 authority-flip decision; legacy callers without a
+    caller tag simply do not increment. *)
+
 val reset : unit -> unit
 (** Zero every counter.  Used by tests; operators should not rely on
     this surface. *)
@@ -117,6 +157,19 @@ type snapshot = {
   typed_advisor_allow : int;
   typed_advisor_reject : int;
   typed_advisor_cannot_parse : int;
+  (* RFC-0131 PR-3 — caller × verdict partition for the
+     [Shell_command_gate] facade.  3 callers × 3 verdicts = 9
+     buckets.  Field order matches [shell_gate_caller × shell_gate_verdict_kind]
+     row-major.  See {!incr_shell_gate} for the increment surface. *)
+  shell_gate_worker_dev_tools_allow : int;
+  shell_gate_worker_dev_tools_reject : int;
+  shell_gate_worker_dev_tools_cannot_parse : int;
+  shell_gate_tool_code_write_allow : int;
+  shell_gate_tool_code_write_reject : int;
+  shell_gate_tool_code_write_cannot_parse : int;
+  shell_gate_keeper_shell_bash_allow : int;
+  shell_gate_keeper_shell_bash_reject : int;
+  shell_gate_keeper_shell_bash_cannot_parse : int;
 }
 
 val snapshot : unit -> snapshot

--- a/lib/shell_command_gate.ml
+++ b/lib/shell_command_gate.ml
@@ -191,6 +191,23 @@ let validate_parsed_context
     | None -> Allow context)
 ;;
 
+(* RFC-0131 PR-3 — variant bridge between the facade [caller] sum and
+   the [Legendary_counters] partition sum.  Same shape on purpose;
+   the legacy facade and Legendary_counters live in the same library
+   (no cycle), so the bridge is mechanical and forces an update at
+   compile time when either side grows a variant. *)
+let legendary_caller_of = function
+  | Worker_dev_tools -> Legendary_counters.Worker_dev_tools
+  | Tool_code_write -> Legendary_counters.Tool_code_write
+  | Keeper_shell_bash -> Legendary_counters.Keeper_shell_bash
+;;
+
+let legendary_verdict_kind_of = function
+  | Allow _ -> Legendary_counters.Allow
+  | Reject _ -> Legendary_counters.Reject
+  | Cannot_parse _ -> Legendary_counters.Cannot_parse
+;;
+
 let validate_allowlist
       ?caller
       ?(allow_pipes = true)
@@ -198,9 +215,19 @@ let validate_allowlist
       ~allowed_commands
       cmd
   =
-  match parse ?caller cmd with
-  | Error kind -> Cannot_parse { kind }
-  | Ok context -> validate_parsed_context ~allow_pipes ~redirect_allowed ~allowed_commands context
+  let verdict =
+    match parse ?caller cmd with
+    | Error kind -> Cannot_parse { kind }
+    | Ok context ->
+      validate_parsed_context ~allow_pipes ~redirect_allowed ~allowed_commands context
+  in
+  (match caller with
+   | Some c ->
+     Legendary_counters.incr_shell_gate
+       ~caller:(legendary_caller_of c)
+       ~verdict:(legendary_verdict_kind_of verdict)
+   | None -> ());
+  verdict
 ;;
 
 let caller_tag = function


### PR DESCRIPTION
## Summary

RFC-0131 PR-3 — caller × verdict telemetry partition for the
`Shell_command_gate` facade.  Introduces 9 atomic counters
(3 callers × 3 verdicts) in `Legendary_counters` and wires the
legacy facade `validate_allowlist` to emit on every verdict.

The existing `GET /api/v1/legendary_bash/shadow_counters` endpoint
already surfaces every `Legendary_counters.snapshot` field via
`snapshot_to_json_with_ratios`, so the dashboard read is automatic —
no HTTP handler change needed.

## Why telemetry now, before authority flip (RFC §11.1)

RFC-0131 §11 calls out "telemetry-as-fix" as anti-pattern #1.  PR-3
avoids it as follows:

1. PR-3 introduces the counter API surface.  Until PR-5 flips
   authority per-caller, emit volume in production is naturally 0
   because the production parse path is
   `Worker_dev_tools.validate_command_coding_with_allowlist` →
   `Shell_command_gate.parse` (parser only, no verdict producer).
2. PR-5 then flips a caller from worker self-validation to
   `Shell_command_gate.validate_allowlist`, at which point this
   counter begins populating partition rows automatically.
3. The pair `PR-3 + PR-5` together is the deliverable (visibility
   plus authority).  PR-3 alone is *infrastructure*, not a fix —
   matching §4.3's "Phase 4.3 (caller adoption) emits telemetry
   *and* prepares the authority flip in 4.4."

## Scope adjustment vs RFC §10 table

RFC §10 table lists PR-3 as `Legendary_counters.incr_shell_gate +
dashboard read` (~120 LoC).  Actual landing surface:

| Component | Status |
|-----------|--------|
| `Legendary_counters.incr_shell_gate` typed dispatch | ✅ landed |
| 9-bucket atomic counters + snapshot + JSON | ✅ landed |
| `dashboard read` via `snapshot_to_json_with_ratios` | ✅ automatic (existing endpoint) |
| Legacy facade `validate_allowlist` emit | ✅ landed |
| **SSOT facade (`lib/exec/command_gate/`) emit** | **⏳ follow-up PR** |

The SSOT sub-library `masc_exec_command_gate` cannot import
`Legendary_counters` because the dependency direction is
`masc_mcp` → `masc_exec_command_gate`; the reverse would close a
cycle.  Three follow-up options:

- **a.** Extract `Legendary_counters` (or just the
  `shell_gate_caller/verdict_kind` sums + a hook) into a leaf
  sublib that both `masc_mcp` and `masc_exec_command_gate` can
  depend on.
- **b.** Inject a callback via the SSOT facade
  (`Shell_command_gate.set_telemetry_hook`) initialised from
  `masc_mcp` at startup.
- **c.** Defer SSOT emit until PR-5 (authority flip) since SSOT
  has 0 production callers today and PR-4 parity measurement only
  needs legacy-side rows.

Recommendation in PR body: option (a) as the cleanest long-term
shape (no global mutable state, no hook indirection); leave the
decision to RFC author / reviewer.

## Evidence

```
$ git diff --stat
 lib/legendary_counters.ml  | 100 ++++++++++++++++++++++++++++++++++++++++++++-
 lib/legendary_counters.mli |  53 ++++++++++++++++++++++++
 lib/shell_command_gate.ml  |  33 +++++++++++++--
 3 files changed, 182 insertions(+), 4 deletions(-)
```

- `dune build --root . @check` — passed (full project type-check).
- `opam exec -- ocamlformat --check lib/legendary_counters.ml lib/legendary_counters.mli lib/shell_command_gate.ml` — pass.
- 9-bucket exhaustive typed dispatch in `incr_shell_gate` — new
  caller or verdict variant forces compile error here.

## Anti-pattern self-check (per CLAUDE.md workaround-rejection bar)

| # | Pattern | Status |
|---|---------|--------|
| 1 | Telemetry-as-fix | ✅ avoided — pair with PR-5 (see §11.1 above) |
| 2 | String/substring classifier | ✅ closed sums (`shell_gate_caller`, `shell_gate_verdict_kind`) |
| 3 | N-of-M migration | ⚠️ SSOT facade left for follow-up — disclosed in scope table |
| 4 | Catch-all `_ ->` added | ✅ exhaustive match in `incr_shell_gate`, `legendary_caller_of`, `legendary_verdict_kind_of` |
| 5 | Cap/cooldown/dedup/repair | ✅ no symptom suppression |
| 6 | Test backdoor | ✅ `reset` was already public for tests, no new backdoor |
| 7 | N-site mechanical fix | ✅ single emit point per facade |

## Linked

- RFC: `docs/rfc/RFC-0131-shell-command-gate-facade.md` §10 PR-3,
  §11.1 (anti-patterns), §4.3 (Phase 4.3 caller adoption).
- Prereqs: PR-1a #16335, PR-1b #16340, SSOT mirror #16393,
  PR-2 prep #16433, PR-2 #16527, PR-1c #16346 — all MERGED.
- Sibling: none.
- Successor: PR-4 (per-caller parity measurement window, observation
  only) + PR-5 (authority flip).

## Backwards compatibility

- New counters default to 0; no change to existing snapshot field
  semantics.
- `snapshot_to_json` shape gains 9 keys; consumers tolerating
  unknown keys (standard JSON consumer behavior) unaffected.
- `validate_allowlist` verdict semantics unchanged — emit happens
  after verdict is computed and before return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
