### PR TITLE
fix: remove impossible Yojson.Safe tuple branches

### DIFF
--- a/lib/autonomous/stimulus.ml
+++ b/lib/autonomous/stimulus.ml
@@ -89,8 +89,6 @@ let json_kind_name : Yojson.Safe.t -> string = function
   | `String _ -> "string"
   | `Assoc _ -> "object"
   | `List _ -> "array"
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 
 (* Defensive parsing: no exceptions escape — every malformed input
    maps to [Error msg] with a localised reason. The salience and id

--- a/lib/board_attachment_meta.ml
+++ b/lib/board_attachment_meta.ml
@@ -99,8 +99,6 @@ let json_kind_name : Yojson.Safe.t -> string = function
   | `String _ -> "string"
   | `Assoc _ -> "object"
   | `List _ -> "array"
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 
 let opt_int_of_yojson = function
   | `Null -> Ok None

--- a/lib/cdal_runtime/effect_evidence.ml
+++ b/lib/cdal_runtime/effect_evidence.ml
@@ -184,8 +184,6 @@ let json_kind_name : Yojson.Safe.t -> string = function
   | `String _ -> "string"
   | `Assoc _ -> "object"
   | `List _ -> "array"
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 ;;
 
 let assoc_field name fields =

--- a/lib/chronicle_event/chronicle_event.ml
+++ b/lib/chronicle_event/chronicle_event.ml
@@ -283,8 +283,6 @@ let json_kind_name : Yojson.Safe.t -> string = function
   | `String _ -> "string"
   | `Assoc _ -> "object"
   | `List _ -> "array"
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 
 let expect_assoc ~where = function
   | `Assoc fields -> Ok fields

--- a/lib/core/json_util.ml
+++ b/lib/core/json_util.ml
@@ -155,8 +155,6 @@ let kind_name : Yojson.Safe.t -> string = function
   | `String _ -> "string"
   | `Assoc _ -> "object"
   | `List _ -> "array"
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 
 (** Bounded stringification for diagnostic / log use.  Prefix-truncates
     to [max] characters (default 160) and appends ["..."] when the

--- a/lib/dashboard_tool_host_events.ml
+++ b/lib/dashboard_tool_host_events.ml
@@ -24,8 +24,6 @@ let json_kind_name : Yojson.Safe.t -> string = function
   | `String _ -> "string"
   | `Assoc _ -> "object"
   | `List _ -> "array"
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 
 type report = {
   agent_name : string;

--- a/lib/failure_envelope.ml
+++ b/lib/failure_envelope.ml
@@ -31,8 +31,6 @@ let json_kind_name : Yojson.Safe.t -> string = function
   | `String _ -> "string"
   | `Assoc _ -> "object"
   | `List _ -> "array"
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 
 let severity_to_string = function
   | Warn -> "warn"

--- a/lib/keeper/keeper_id.ml
+++ b/lib/keeper/keeper_id.ml
@@ -7,8 +7,6 @@ let json_kind_name : Yojson.Safe.t -> string = function
   | `String _ -> "string"
   | `Assoc _ -> "object"
   | `List _ -> "array"
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 
 module Keeper_name = struct
   type t = string

--- a/lib/keeper/keeper_meta_tool_access.ml
+++ b/lib/keeper/keeper_meta_tool_access.ml
@@ -15,8 +15,6 @@ let json_kind_name : Yojson.Safe.t -> string = function
   | `String _ -> "string"
   | `Assoc _ -> "object"
   | `List _ -> "array"
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 ;;
 
 type tool_preset =

--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -38,8 +38,6 @@ let json_kind_name : Yojson.Safe.t -> string = function
   | `String _ -> "string"
   | `Assoc _ -> "object"
   | `List _ -> "array"
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 ;;
 
 let assoc_get key = function

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -258,8 +258,6 @@ let json_kind_name : Yojson.Safe.t -> string = function
   | `String _ -> "string"
   | `Assoc _ -> "object"
   | `List _ -> "array"
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 
 let field key fields =
   match List.assoc_opt key fields with

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -76,8 +76,6 @@ let json_kind_name : Yojson.Safe.t -> string = function
   | `String _ -> "string"
   | `Assoc _ -> "object"
   | `List _ -> "array"
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 
 let parse_present_tool_name_list_opt args key =
   match json_assoc_member_opt key args with

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -365,8 +365,6 @@ let json_kind_name : Yojson.Safe.t -> string = function
   | `String _ -> "string"
   | `Assoc _ -> "object"
   | `List _ -> "array"
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 
 let strict_assoc_params params =
   match params with

--- a/lib/multimodal/payload.ml
+++ b/lib/multimodal/payload.ml
@@ -22,8 +22,6 @@ let json_kind_name : Yojson.Safe.t -> string = function
   | `String _ -> "string"
   | `Assoc _ -> "object"
   | `List _ -> "array"
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 
 let of_json = function
   | `Assoc kv -> (

--- a/lib/sdk_tool_contract.ml
+++ b/lib/sdk_tool_contract.ml
@@ -300,8 +300,6 @@ let json_kind_name : Yojson.Safe.t -> string = function
   | `String _ -> "string"
   | `Assoc _ -> "object"
   | `List _ -> "array"
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 
 let rec validate_json_value ?label schema value =
   let label = label_or_default label "input" in

--- a/lib/tool_board_format.ml
+++ b/lib/tool_board_format.ml
@@ -28,8 +28,6 @@ let json_kind_name : Yojson.Safe.t -> string = function
   | `String _ -> "string"
   | `Assoc _ -> "object"
   | `List _ -> "array"
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 ;;
 
 (** Strip [STATE]...[/STATE] blocks. Inlined to avoid the

--- a/lib/tool_task_args.ml
+++ b/lib/tool_task_args.ml
@@ -17,8 +17,6 @@ let json_kind_name : Yojson.Safe.t -> string = function
   | `String _ -> "string"
   | `Assoc _ -> "object"
   | `List _ -> "array"
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 
 let parse_task_contract args =
   match args |> member "contract" with

--- a/lib/tui_decode.ml
+++ b/lib/tui_decode.ml
@@ -72,8 +72,6 @@ let json_kind_name : Yojson.Safe.t -> string = function
   | `String _ -> "string"
   | `Assoc _ -> "object"
   | `List _ -> "array"
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 
 let member key json = Yojson.Safe.Util.member key json
 

--- a/lib/types/ids.ml
+++ b/lib/types/ids.ml
@@ -9,8 +9,6 @@ let json_kind_name : Yojson.Safe.t -> string = function
   | `String _ -> "string"
   | `Assoc _ -> "object"
   | `List _ -> "array"
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 
 (** Agent identifier - prevents mixing with task_id, file_path, etc. *)
 module Agent_id : sig

--- a/lib/types/task_stage.ml
+++ b/lib/types/task_stage.ml
@@ -38,8 +38,6 @@ let json_kind_name : Yojson.Safe.t -> string = function
   | `String _ -> "string"
   | `Assoc _ -> "object"
   | `List _ -> "array"
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 
 let of_yojson = function
   | `String s -> of_string s

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -12,8 +12,6 @@ let json_kind_name : Yojson.Safe.t -> string = function
   | `String _ -> "string"
   | `Assoc _ -> "object"
   | `List _ -> "array"
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 
 (* ============================================ *)
 (* Timestamp utilities                          *)
@@ -162,8 +160,6 @@ let short_json_repr = function
   | `Assoc _ -> "<object>"
   | `List _ -> "<array>"
   | `Intlit s -> s
-  | `Tuple _ -> "<tuple>"
-  | `Variant _ -> "<variant>"
 
 let agent_of_yojson json =
   match agent_of_yojson_generated json with

--- a/lib/worker_execution_backend.ml
+++ b/lib/worker_execution_backend.ml
@@ -24,8 +24,6 @@ let json_kind_name : Yojson.Safe.t -> string = function
   | `String _ -> "string"
   | `Assoc _ -> "object"
   | `List _ -> "array"
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 
 let of_yojson = function
   | `String value -> (

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -108,7 +108,7 @@ let rec check_json_strings_valid_utf8 label = function
              (Printf.sprintf "%s[%d]" label idx)
              value)
         values
-  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `Tuple _ | `Variant _ -> ()
+  | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ -> ()
 
 let test_timeout_quality_is_error () =
   let quality =


### PR DESCRIPTION
## Summary
- remove impossible `Tuple/`Variant branches from helpers typed as `Yojson.Safe.t`
- cover the same received-kind helper pattern added across latest main
- keep the MCP call-tool UTF-8 test aligned with `Yojson.Safe.t` constructors

## Why
Latest main failed `scripts/dune-local.sh build bin/main_eio.exe` because recent JSON-kind helpers matched constructors that are not part of `Yojson.Safe.t`.

## Verification
- `git diff --check`
- `rg -n '`Tuple _ -> "tuple"|`Variant _ -> "variant"|`Tuple _ -> "<tuple>"|`Variant _ -> "<variant>"' lib test` returned no matches
- `scripts/dune-local.sh build bin/main_eio.exe test/test_mcp_server_eio_call_tool.exe`
- `./_build/default/test/test_mcp_server_eio_call_tool.exe`