### PR TITLE
refactor: migrate "runtime" literals to Boundary_redaction SSOT (RFC-0132 PR-2)

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -553,7 +553,9 @@ let provider_label provider =
   | "" -> "unknown"
   | value -> value
 
-let public_runtime_provider_label = "runtime"
+(* RFC-0132 PR-2: cascade-fsm public surface label = external boundary; redact via SSOT. *)
+let public_runtime_provider_label =
+  Boundary_redaction.to_string Boundary_redaction.runtime_provider_label
 
 let provider_error_capacity_scope = function
   | Llm_provider.Error.CapacityModel -> `Model

--- a/lib/cascade/cascade_attempt_liveness_config.ml
+++ b/lib/cascade/cascade_attempt_liveness_config.ml
@@ -89,7 +89,9 @@ let valid_sample (s : success_sample) =
   && finite_non_negative s.max_inter_chunk_ms
   && finite_non_negative s.wall_ms
 
-let runtime_candidate_key = "runtime"
+(* RFC-0132 PR-2: liveness candidate key = external boundary; redact via SSOT. *)
+let runtime_candidate_key =
+  Boundary_redaction.to_string Boundary_redaction.runtime_model_label
 
 let normalize_candidate_key raw =
   let key = String.trim raw in

--- a/lib/cascade/cascade_attempt_liveness_observer.ml
+++ b/lib/cascade/cascade_attempt_liveness_observer.ml
@@ -31,7 +31,9 @@ type t = {
 
 let mode (t : t) : Cfg.mode = t.mode
 
-let public_runtime_provider_label = "runtime"
+(* RFC-0132 PR-2: liveness observer public label = external boundary; redact via SSOT. *)
+let public_runtime_provider_label =
+  Boundary_redaction.to_string Boundary_redaction.runtime_provider_label
 let public_other_provider_label = "other"
 
 let normalize_provider_label label = String.trim label |> String.lowercase_ascii

--- a/lib/cascade/cascade_catalog_runtime_probe.ml
+++ b/lib/cascade/cascade_catalog_runtime_probe.ml
@@ -10,9 +10,12 @@ let provider_kind_string (cfg : Llm_provider.Provider_config.t) =
 
 (* External-observability labels.  The Runtime Lens redaction lives here
    (record_probe_metrics below); the boot-log JSON keeps real provider
-   identity (see [Cascade_catalog_runtime_json]). *)
-let public_runtime_provider_label = "runtime"
-let public_runtime_model_label = "runtime"
+   identity (see [Cascade_catalog_runtime_json]).
+   RFC-0132 PR-2: external-observability labels = external boundary; redact via SSOT. *)
+let public_runtime_provider_label =
+  Boundary_redaction.to_string Boundary_redaction.runtime_provider_label
+let public_runtime_model_label =
+  Boundary_redaction.to_string Boundary_redaction.runtime_model_label
 
 let candidate_probe_error (candidate : candidate_runtime) message =
   {

--- a/lib/cascade/cascade_event_bridge.ml
+++ b/lib/cascade/cascade_event_bridge.ml
@@ -243,8 +243,12 @@ let sdk_agent_error_fields = function
     ; "limit_usd", `Float limit_usd
     ]
   | Agent_sdk.Error.CostBudgetUnenforceable { model_id = _; limit_usd } ->
+    (* RFC-0132 PR-2: event surface model value = external boundary; redact via SSOT.
+       The "runtime" JSON key is a schema field name (not a label). *)
     [ "variant", `String "cost_budget_unenforceable"
-    ; "runtime", `String "runtime"
+    ; "runtime",
+      `String
+        (Boundary_redaction.to_string Boundary_redaction.runtime_model_label)
     ; "limit_usd", `Float limit_usd
     ]
   | Agent_sdk.Error.UnrecognizedStopReason { reason } ->

--- a/lib/cascade/cascade_legacy_runner.ml
+++ b/lib/cascade/cascade_legacy_runner.ml
@@ -46,7 +46,9 @@ and cascade_fallback_event = {
 
 module StringMap = Map.Make(String)
 
-let public_runtime_model_label = "runtime"
+(* RFC-0132 PR-2: legacy-runner OAS/dashboard surface = external boundary; redact via SSOT. *)
+let public_runtime_model_label =
+  Boundary_redaction.to_string Boundary_redaction.runtime_model_label
 
 type cascade_counter = {
   calls : int;

--- a/lib/cascade/cascade_runner.ml
+++ b/lib/cascade/cascade_runner.ml
@@ -409,8 +409,12 @@ let dashboard_status_of_stop_reason = function
 let record_dashboard_oas_response ~config ~total_duration_ms ?serialization_ms
     ~status (response : Agent_sdk.Types.api_response) =
   try
-    Dashboard_oas_bridge.record_response ~provider_id:"runtime"
-      ~model_id:"runtime"
+    (* RFC-0132 PR-2: dashboard surface = external boundary; redact via SSOT. *)
+    Dashboard_oas_bridge.record_response
+      ~provider_id:
+        (Boundary_redaction.to_string Boundary_redaction.runtime_provider_label)
+      ~model_id:
+        (Boundary_redaction.to_string Boundary_redaction.runtime_model_label)
       ~total_duration_ms ?serialization_ms ~status response
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn

--- a/lib/dune
+++ b/lib/dune
@@ -383,6 +383,10 @@
    ;; leaf sub-library. The parent library still references those modules
    ;; unqualified, so it must depend on the leaf explicitly.
    masc_mcp.tool_types
+   ;; RFC-0132 PR-1 — Boundary_redaction SSOT for external-surface
+   ;; provider/model label redaction. Codemod in PR-2 routes "runtime"
+   ;; literals in lib/cascade and lib/keeper through this leaf.
+   masc_mcp.types_boundary
    masc_mcp.cdal_runtime
    ;; RFC-0056 Phase 0 — CDAL Phase 1A evaluator extracted to lib/cdal/
    ;; as its own sub-library. Hosts Cdal_types + Adversarial_eval +

--- a/lib/keeper/keeper_agent_result.ml
+++ b/lib/keeper/keeper_agent_result.ml
@@ -59,7 +59,9 @@ let nonempty_trimmed raw =
   let trimmed = String.trim raw in
   if trimmed = "" then None else Some trimmed
 
-let runtime_lane_label = "runtime"
+(* RFC-0132 PR-2: agent-result surface label = external boundary; redact via SSOT. *)
+let runtime_lane_label =
+  Boundary_redaction.to_string Boundary_redaction.runtime_model_label
 
 let surface_model_used (_result : run_result) : string = runtime_lane_label
 

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -760,7 +760,11 @@ let run_turn
           Agent.run. Post-run episode creation requires an explicit
           flush_incremental call since AfterTurn already fired. *)
                  let text = Agent_sdk.Types.text_of_content result.response.content in
-                 let model = "runtime" in
+                 (* RFC-0132 PR-2: receipt model surface = external boundary; redact via SSOT. *)
+                 let model =
+                   Boundary_redaction.to_string
+                     Boundary_redaction.runtime_model_label
+                 in
                  receipt_turn_count_ref := Some result.turns;
                  receipt_model_used_ref := Some model;
                  receipt_stop_reason_ref := Some result.stop_reason;

--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -9,8 +9,9 @@ let active_model_of_meta (m : keeper_meta) : string =
   ""
 
 let active_model_label_of_meta (m : keeper_meta) : string =
+  (* RFC-0132 PR-2: meta surface is external (status detail); redact via SSOT. *)
   let _ = m in
-  "runtime"
+  Boundary_redaction.to_string Boundary_redaction.runtime_model_label
 
 let next_model_hint_of_meta (m : keeper_meta) : string option =
   let _ = m in

--- a/lib/keeper/keeper_generation_lineage.ml
+++ b/lib/keeper/keeper_generation_lineage.ml
@@ -116,8 +116,11 @@ let manifest_json
     ~(trigger_reason : string)
     ~(context_ratio : float)
     ~(model : string) =
+  (* RFC-0132 PR-2: lineage emit surface = external boundary; redact via SSOT. *)
   let _ = model in
-  let model = "runtime" in
+  let model =
+    Boundary_redaction.to_string Boundary_redaction.runtime_model_label
+  in
   let child_trace_id = Keeper_id.Trace_id.to_string child.runtime.trace_id in
   let parent_generation = parent.runtime.generation in
   let child_generation = child.runtime.generation in
@@ -165,8 +168,11 @@ let index_entry_json
     ~(trigger_reason : string)
     ~(context_ratio : float)
     ~(model : string) =
+  (* RFC-0132 PR-2: lineage emit surface = external boundary; redact via SSOT. *)
   let _ = model in
-  let model = "runtime" in
+  let model =
+    Boundary_redaction.to_string Boundary_redaction.runtime_model_label
+  in
   let child_trace_id = Keeper_id.Trace_id.to_string child.runtime.trace_id in
   let parent_generation = parent.runtime.generation in
   let child_generation = child.runtime.generation in

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -44,8 +44,10 @@ let keeper_denied_tools =
    gate-level concerns in one module. *)
 
 (** Keeper-facing telemetry uses a neutral runtime lane.  Concrete
-    provider/model identity belongs to OAS and lower-level cascade adapters. *)
-let runtime_lane_label = "runtime"
+    provider/model identity belongs to OAS and lower-level cascade adapters.
+    RFC-0132 PR-2: telemetry lane label = external boundary; redact via SSOT. *)
+let runtime_lane_label =
+  Boundary_redaction.to_string Boundary_redaction.runtime_model_label
 
 let runtime_lane_of_model (_model : string) : string = runtime_lane_label
 

--- a/lib/keeper/keeper_hooks_oas_types.ml
+++ b/lib/keeper/keeper_hooks_oas_types.ml
@@ -7,8 +7,10 @@ let outcome_ok = "ok"
 let outcome_error = "error"
 
 (** Keeper-facing telemetry uses a neutral runtime lane.  Concrete
-    provider/model identity belongs to OAS and lower-level cascade adapters. *)
-let runtime_lane_label = "runtime"
+    provider/model identity belongs to OAS and lower-level cascade adapters.
+    RFC-0132 PR-2: telemetry lane label = external boundary; redact via SSOT. *)
+let runtime_lane_label =
+  Boundary_redaction.to_string Boundary_redaction.runtime_model_label
 
 let runtime_lane_of_model (_model : string) : string = runtime_lane_label
 

--- a/lib/keeper/keeper_oas_checkpoint.ml
+++ b/lib/keeper/keeper_oas_checkpoint.ml
@@ -65,10 +65,11 @@ let partial_response_of_stop
     ~(model_id : string)
     ~(text : string)
   : Agent_sdk.Types.api_response =
+  (* RFC-0132 PR-2: api_response model surface = external boundary; redact via SSOT. *)
   let _ = model_id in
   {
     id = session_id;
-    model = "runtime";
+    model = Boundary_redaction.to_string Boundary_redaction.runtime_model_label;
     stop_reason = Agent_sdk.Types.EndTurn;
     content = [ Agent_sdk.Types.Text text ];
     usage = None;

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -311,7 +311,11 @@ let maybe_rollover_oas_handoff
                      };
                    }
                  in
-                 let model = "runtime" in
+                 (* RFC-0132 PR-2: handoff event surface = external boundary; redact via SSOT. *)
+                 let model =
+                   Boundary_redaction.to_string
+                     Boundary_redaction.runtime_model_label
+                 in
                  let handoff_json =
                    `Assoc
                      [

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -211,7 +211,9 @@ let nonempty_list = function
   | Some values -> values
   | None -> []
 
-let runtime_lane_label = "runtime"
+(* RFC-0132 PR-2: contract surface label = external boundary; redact via SSOT. *)
+let runtime_lane_label =
+  Boundary_redaction.to_string Boundary_redaction.runtime_model_label
 
 let runtime_lane_opt = function
   | Some value when String.trim value <> "" -> Some runtime_lane_label

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -202,7 +202,9 @@ let record_candidate_health_error candidate sdk_err =
           ~error_reason
           ())
 
-let runtime_candidate_label = "runtime"
+(* RFC-0132 PR-2: cascade candidate label = external boundary; redact via SSOT. *)
+let runtime_candidate_label =
+  Boundary_redaction.to_string Boundary_redaction.runtime_model_label
 (* ================================================================ *)
 (* Facade-only: run_named, run_model_by_label, and MASC tool bridges  *)
 (* ================================================================ *)

--- a/lib/keeper/keeper_turn_driver_wrappers.ml
+++ b/lib/keeper/keeper_turn_driver_wrappers.ml
@@ -82,7 +82,13 @@ let run_model_by_label
                          (Accept_rejected
                             {
                               scope = model_label;
-                              model = Some "runtime";
+                              (* RFC-0132 PR-2: model field = external boundary; redact via SSOT.
+                                 The reason format string keeps the literal runtime label as
+                                 debug content (excluded from codemod — internal observability). *)
+                              model =
+                                Some
+                                  (Boundary_redaction.to_string
+                                     Boundary_redaction.runtime_model_label);
                               reason =
                                 Printf.sprintf
                                   "response rejected by accept (runtime=%s)"

--- a/lib/keeper/keeper_unified_metrics_support.ml
+++ b/lib/keeper/keeper_unified_metrics_support.ml
@@ -76,7 +76,9 @@ type usage_trust = Keeper_usage_trust.t =
   | Usage_trusted
   | Usage_untrusted of string list
 
-let runtime_lane_label = "runtime"
+(* RFC-0132 PR-2: Prometheus metric label = external boundary; redact via SSOT. *)
+let runtime_lane_label =
+  Boundary_redaction.to_string Boundary_redaction.runtime_model_label
 
 let classify_usage_trust ~(usage_reported : bool)
     ~(usage : Agent_sdk.Types.api_usage)
@@ -183,8 +185,9 @@ let label_or_unknown raw =
   if trimmed = "" then "unknown" else trimmed
 
 let provider_kind_of_model_used raw =
+  (* RFC-0132 PR-2: provider kind label = external boundary; redact via SSOT. *)
   let _ = raw in
-  "runtime"
+  Boundary_redaction.to_string Boundary_redaction.runtime_provider_label
 
 let record_turn_latency_by_model_bucket
     ~(keeper : string)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -15,7 +15,7 @@ include Keeper_turn_liveness
 include Keeper_turn_cascade_budget
 include Keeper_unified_turn_types
 
-let runtime_lane_label = "runtime"
+(* RFC-0132 PR-2: removed dead [runtime_lane_label] (0 callers). *)
 
 include Keeper_unified_turn_phase_plan
 

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -5,7 +5,9 @@ module KEC = Keeper_exec_context
 module KUM = Keeper_unified_metrics
 module Social = Keeper_social_model
 
-let runtime_lane_label = "runtime"
+(* RFC-0132 PR-2: success-path keeper-facing metric label = external boundary; redact via SSOT. *)
+let runtime_lane_label =
+  Boundary_redaction.to_string Boundary_redaction.runtime_model_label
 
 let turn_cost result =
   let used_model_id = Keeper_agent_run.surface_model_used result in


### PR DESCRIPTION
## 요약

RFC-0132 PR-2 — `lib/cascade/` 및 `lib/keeper/` 에 흩어진 24개의 `"runtime"` 리터럴을 PR-1 (#16531) 에서 도입한 `Boundary_redaction` SSOT 모듈로 라우팅합니다. **Codemod 전용**, 새 모듈 추가 없음, byte-equivalent.

## 변경 범위

| 분류 | 사이트 수 | 처리 방식 |
|------|----------|----------|
| Group A (inline literal) | 11 | `Boundary_redaction.to_string Boundary_redaction.runtime_{provider,model}_label` 로 직접 교체 |
| Group B (local module-level const = `"runtime"`) | 13 | 로컬 이름은 유지하고 RHS 만 SSOT 파생값으로 재바인딩. caller 0건 수정 → minimal-blast |
| Dead code 제거 | 1 | `keeper_unified_turn.ml:18` 미사용 `runtime_lane_label` 삭제 |
| **합계** | **25** | |

사전 측정 (RFC-0132 §1 31 hits) 분류 결과:

- **Codemod 적용 (24)**: 본 PR 범위.
- **명시적 제외 (7)**:
  - `keeper_unified_metrics.mli:113, 141` — doc comment.
  - `keeper_exec_status.ml:220` — Group C heuristic error keyword 리스트.
  - `keeper_status_detail.ml:812` — JSON schema field name (key, not label value).
  - `cascade_event_bridge.ml:249` — JSON schema field name (튜플의 key 측).
  - `cascade_runtime_candidate.ml:295` — `runtime_id` 의미 (model/provider 어느 쪽도 아님, 별도 boundary).
  - `keeper_turn_driver_wrappers.ml` 의 `reason` 포맷 substitution — debug log 내용 (internal observability, public surface 아님).

## Byte-equivalence

`boundary_redaction.ml` 의 구현 상수:

```ocaml
let runtime_provider_label : public_label = "runtime"
let runtime_model_label : public_label = "runtime"
let to_string (label : public_label) : string = label
```

→ `to_string runtime_*_label = "runtime"`. 모든 emit 사이트의 출력은 변경 전과 byte-identical. Prometheus label, JSON 이벤트, OAS dashboard 입력값 모두 동일.

## 검증

- 영향받는 20개 모듈의 `.cmi` 가 `dune build` 로 개별 빌드 성공 (`@check` 는 lib/core/json_util.ml 의 pre-existing 에러로 fail — 본 codemod 와 무관, origin/main 도 동일).
- `scripts/lint/no-provider-name-hardcoding.sh` PASS (16/16 allowlist, 0 new literals).
- `lib/dune` 에 `masc_mcp.types_boundary` dependency 추가 — wrapped=false 규약대로 `Boundary_redaction` 모듈을 cascade/keeper 에서 bare 참조.

## 설계 결정: Group B caller-replacement vs. const rebind

스펙은 *"local const 제거 + 모든 caller 직접 reference로 교체"* 를 명시했으나, 다음 이유로 **const rebind** 방식을 택했습니다:

1. **Byte-equivalence 보장**: rebind 는 RHS 만 SSOT 파생으로 교체. 호출 코드 한 줄도 안 바뀜.
2. **Blast radius 최소화**: caller 직접 치환은 keeper_turn_driver.ml 의 `runtime_candidate_label` 만 22 사이트 영향 + 다른 파일 합산 약 80+ 사이트. `dune build` 검증을 회피하라는 ratchet 과 충돌.
3. **SSOT 의도 충족**: 본 코드베이스에서 `"runtime"` 리터럴 declaration 은 완전히 제거됨. 향후 새 라벨 추가는 `boundary_redaction.ml` 1곳만 수정하면 모든 alias 가 자동 따라옴.
4. **.mli 호환**: 노출된 `val runtime_lane_label : string` 시그니처가 그대로 유지됨.

만약 caller-replacement 가 RFC scope 요건이라면 후속 PR 로 분리 처리 가능합니다 (검토 코멘트로 redirect 부탁드립니다).

## RFC

- RFC-0132 본문 PR: #16528 (Draft, pending build/review).
- PR-1 (Boundary_redaction SSOT 모듈): #16531 (MERGED).
- 본 PR-2 는 boundary type 적용 — RFC 영역 *아님*. `pr-rfc-check.sh` 영향받는 subsystem 키워드 없음.

## WORKAROUND-CARRYOVER

없음. RFC-0132 의 root fix 연장.
