### PR TITLE
feat(lint): enforce Boundary_redaction SSOT (RFC-0132 PR-3)

### DIFF
--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -68,6 +68,16 @@ jobs:
       - name: Run lint
         run: bash scripts/lint/no-provider-name-hardcoding.sh --fail
 
+  no-runtime-literal-outside-boundary-redaction:
+    name: Boundary redaction SSOT enforcement (RFC-0132 PR-3)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install ripgrep
+        run: sudo apt-get install -y -qq ripgrep
+      - name: Run lint
+        run: bash scripts/lint/no-runtime-literal-outside-boundary-redaction.sh --fail
+
   no-fabricated-telemetry:
     name: Math.random in components
     runs-on: ubuntu-latest

--- a/scripts/lint/no-runtime-literal-outside-boundary-redaction.sh
+++ b/scripts/lint/no-runtime-literal-outside-boundary-redaction.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# RFC-0132 PR-3: Boundary_redaction SSOT enforcement.
+#
+# After RFC-0132 PR-2 (#16536) routed 24 "runtime" public-surface labels
+# through Boundary_redaction in cascade/ and keeper/ subsystems, this lint
+# blocks regression: any *new* inline "runtime" literal in those files
+# must go through the SSOT module.
+#
+# Scope: the 21 OCaml files PR-2 touched. NOT a repo-wide grep — many
+# "runtime" strings elsewhere are JSON schema keys, feature-flag category
+# labels, or internal observability and are out of RFC-0132 scope.
+#
+# Exemption: add `RFC-0132-EXEMPT: <reason>` on the same line or the
+# preceding line. The 4 known-exempt sites listed below are pre-approved
+# (schema field, classification list, debug format string).
+#
+# Adding to scope: extend SCAN_FILES when a new subsystem's boundary
+# emit-site is routed through Boundary_redaction. Each addition must
+# cite the codemod PR in RFC-0132.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+MODE="--fail"
+case "${1:---fail}" in
+  --fail|"") MODE="--fail" ;;
+  --print)   MODE="--print" ;;
+  -h|--help)
+    sed -n '2,22p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+  *)
+    echo "Usage: $0 [--fail|--print]" >&2
+    exit 2
+    ;;
+esac
+
+for tool in rg awk sed; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "[no-runtime-literal-outside-boundary-redaction] required tool missing: $tool" >&2
+    exit 2
+  }
+done
+
+# Files routed through Boundary_redaction SSOT by RFC-0132 PR-2 (#16536).
+SCAN_FILES=(
+  "lib/cascade/cascade_attempt_fsm.ml"
+  "lib/cascade/cascade_attempt_liveness_config.ml"
+  "lib/cascade/cascade_attempt_liveness_observer.ml"
+  "lib/cascade/cascade_catalog_runtime_probe.ml"
+  "lib/cascade/cascade_event_bridge.ml"
+  "lib/cascade/cascade_legacy_runner.ml"
+  "lib/cascade/cascade_runner.ml"
+  "lib/keeper/keeper_agent_result.ml"
+  "lib/keeper/keeper_agent_run.ml"
+  "lib/keeper/keeper_exec_status.ml"
+  "lib/keeper/keeper_generation_lineage.ml"
+  "lib/keeper/keeper_hooks_oas.ml"
+  "lib/keeper/keeper_hooks_oas_types.ml"
+  "lib/keeper/keeper_oas_checkpoint.ml"
+  "lib/keeper/keeper_rollover.ml"
+  "lib/keeper/keeper_runtime_contract.ml"
+  "lib/keeper/keeper_turn_driver.ml"
+  "lib/keeper/keeper_turn_driver_wrappers.ml"
+  "lib/keeper/keeper_unified_metrics_support.ml"
+  "lib/keeper/keeper_unified_turn.ml"
+  "lib/keeper/keeper_unified_turn_success.ml"
+)
+
+# Pre-approved exemptions from PR-2 audit. Each entry is `path:line:reason`.
+# These four sites carry a `"runtime"` literal that is NOT a redaction
+# target (schema field name, classification list, debug format string).
+# Drift (line move) makes the entry stale and must be cleaned in the
+# same PR. The runtime check accepts any of the listed lines.
+PREAPPROVED=(
+  # Doc comment continuation line — comment body explaining the schema
+  # field below. Closing `*)` lives on this line.
+  "lib/cascade/cascade_event_bridge.ml:247"
+  # JSON schema field name — wire-format key, not a label.
+  "lib/cascade/cascade_event_bridge.ml:249"
+  # Classification list — enumeration of category names, not a label.
+  "lib/keeper/keeper_exec_status.ml:220"
+  # Debug format string inside Printf.sprintf — internal observability
+  # (real provider identity, not boundary redaction). The model field
+  # above it is already routed via Boundary_redaction.
+  "lib/keeper/keeper_turn_driver_wrappers.ml:95"
+)
+
+violations_tmp="$(mktemp -t rfc0132-pr3.violations.XXXXXX)"
+stale_tmp="$(mktemp -t rfc0132-pr3.stale.XXXXXX)"
+trap 'rm -f "$violations_tmp" "$stale_tmp"' EXIT
+
+is_preapproved() {
+  local key="$1"
+  local entry
+  for entry in "${PREAPPROVED[@]}"; do
+    [[ "$key" == "$entry" ]] && return 0
+  done
+  return 1
+}
+
+scan_file() {
+  local file="$1"
+  [[ -f "$file" ]] || return 0
+
+  # rg with line numbers + content. Each match emits a `path:line:content` row.
+  while IFS= read -r row; do
+    [[ -z "$row" ]] && continue
+    local path line content
+    path="${row%%:*}"
+    local rest="${row#*:}"
+    line="${rest%%:*}"
+    content="${rest#*:}"
+
+    # Skip doc comments (heuristic: leading `(*` after trim).
+    local trimmed="${content#"${content%%[![:space:]]*}"}"
+    [[ "$trimmed" == "(*"* ]] && continue
+
+    # Same-line pragma exemption.
+    if [[ "$content" == *"RFC-0132-EXEMPT"* ]]; then
+      continue
+    fi
+
+    # Preceding-line pragma exemption.
+    local prev_line
+    prev_line=$((line - 1))
+    if [[ "$prev_line" -ge 1 ]]; then
+      local prev_content
+      prev_content="$(sed -n "${prev_line}p" "$path" 2>/dev/null || true)"
+      if [[ "$prev_content" == *"RFC-0132-EXEMPT"* ]]; then
+        continue
+      fi
+    fi
+
+    local key="${path}:${line}"
+    if is_preapproved "$key"; then
+      continue
+    fi
+
+    printf '%s:%s:%s\n' "$path" "$line" "$content" >>"$violations_tmp"
+  done < <(rg --with-filename --no-heading --line-number --color=never --fixed-strings '"runtime"' "$file" 2>/dev/null || true)
+}
+
+for f in "${SCAN_FILES[@]}"; do
+  scan_file "$f"
+done
+
+# Detect stale preapproved entries: line no longer carries `"runtime"`.
+for entry in "${PREAPPROVED[@]}"; do
+  path="${entry%%:*}"
+  line="${entry#*:}"
+  [[ -f "$path" ]] || { echo "$entry (file missing)" >>"$stale_tmp"; continue; }
+  current="$(sed -n "${line}p" "$path" 2>/dev/null || true)"
+  if [[ "$current" != *'"runtime"'* ]]; then
+    echo "$entry" >>"$stale_tmp"
+  fi
+done
+
+violations_count=0
+stale_count=0
+[[ -s "$violations_tmp" ]] && violations_count="$(wc -l <"$violations_tmp" | tr -d ' ')"
+[[ -s "$stale_tmp" ]] && stale_count="$(wc -l <"$stale_tmp" | tr -d ' ')"
+
+printf "%-44s %8s\n" "metric" "count"
+echo "--------------------------------------------------------"
+printf "%-44s %8s\n" "rfc0132_pr3_scan_files" "${#SCAN_FILES[@]}"
+printf "%-44s %8s\n" "rfc0132_pr3_preapproved_entries" "${#PREAPPROVED[@]}"
+printf "%-44s %8s\n" "rfc0132_pr3_violations" "$violations_count"
+printf "%-44s %8s\n" "rfc0132_pr3_stale_preapproved" "$stale_count"
+
+if [[ "$MODE" = "--print" ]]; then
+  if [[ -s "$violations_tmp" ]]; then
+    echo
+    echo "[no-runtime-literal-outside-boundary-redaction] violations:"
+    sed 's/^/  - /' "$violations_tmp"
+  fi
+  exit 0
+fi
+
+exit_code=0
+
+if [[ -s "$violations_tmp" ]]; then
+  echo >&2
+  echo "ERROR: inline \"runtime\" literal found outside Boundary_redaction:" >&2
+  sed 's/^/  /' "$violations_tmp" >&2
+  echo >&2
+  echo "RFC-0132 requires that \"runtime\" public-surface labels go through" >&2
+  echo "the Boundary_redaction SSOT module. Replace with:" >&2
+  echo "  Boundary_redaction.runtime_provider_label |> Boundary_redaction.to_string" >&2
+  echo "  Boundary_redaction.runtime_model_label    |> Boundary_redaction.to_string" >&2
+  echo >&2
+  echo "If this is an internal observability path (real provider/model" >&2
+  echo "identity, not boundary redaction), add an explicit ignore comment" >&2
+  echo "on the same line or the line directly above:" >&2
+  echo "  (* RFC-0132-EXEMPT: internal observability *)" >&2
+  exit_code=1
+fi
+
+if [[ -s "$stale_tmp" ]]; then
+  echo >&2
+  echo "ERROR: stale RFC-0132 preapproved entries (line no longer carries \"runtime\"):" >&2
+  sed 's/^/  - /' "$stale_tmp" >&2
+  echo "Remove the entry from PREAPPROVED in $(basename "${BASH_SOURCE[0]}") in the same PR." >&2
+  exit_code=1
+fi
+
+if [[ "$exit_code" -eq 0 ]]; then
+  echo
+  echo "[no-runtime-literal-outside-boundary-redaction] OK"
+fi
+
+exit "$exit_code"


### PR DESCRIPTION
## 요약 (RFC-0132 PR-3)

RFC-0132 §3에서 명시한 **future drift 차단** lint rule입니다. PR-2 (#16536)에서 24개 `\"runtime\"` literal을 `Boundary_redaction` SSOT 모듈로 codemod했고, 이 PR은 그 결과를 회귀 방지로 게이팅합니다.

## 동작

- **scope**: PR-2가 건드린 21개 OCaml 파일 (`lib/cascade/`, `lib/keeper/`) 안에서 새로 추가되는 `\"runtime\"` literal을 차단합니다.
- **non-scope**: 의도적으로 repo 전체 grep을 하지 *않습니다*. JSON schema 키, feature-flag category, env config category, 내부 observability 등에서 사용되는 `\"runtime\"`은 RFC-0132 §3에서 명시적으로 boundary가 아니라고 분류된 영역입니다. 광범위 lint는 false positive 폭증과 exempt pragma 남용을 유발합니다 (워크어라운드 거부 기준 §1 — string 분류기 보강).
- **exempt 메커니즘**: 두 가지를 제공합니다.
  1. 같은 줄 또는 바로 위 줄에 `(* RFC-0132-EXEMPT: <이유> *)` pragma
  2. 스크립트 안 `PREAPPROVED` 배열의 `path:line` 엔트리 (debt ledger — 라인 이동/삭제 시 자동으로 stale 감지하여 fail)
- **현재 preapproved**: 4건 — schema 필드 키 1, classification list 1, 디버그 format string 1, doc comment continuation line 1. 모두 PR-2 audit에서 boundary가 아닌 것으로 확인된 사이트입니다.

## CI 통합

- `.github/workflows/fundamental-check.yml` 에 `Boundary redaction SSOT enforcement (RFC-0132 PR-3)` job 신규 추가.
- 기존 lint job (특히 `no-provider-name-hardcoding`) 와 비교: 기능 중복 아님. 기존 스크립트는 `lib/provider_runtime_projection.ml` + `lib/cascade/cascade_runtime.ml` 2개 파일에 한정된 provider/model identity 감시이고, 본 스크립트는 RFC-0132 boundary redaction이라는 별개 축의 SSOT 게이트입니다.

## Standalone Test 결과

`/tmp/test_redaction_ssot_lint.sh` — 5/5 PASS:

```
PASS  baseline (no new literal) (exit=0)
PASS  FAIL: new \"runtime\" literal injected (exit=1)
PASS  PASS: same-line RFC-0132-EXEMPT pragma (exit=0)
PASS  PASS: preceding-line RFC-0132-EXEMPT pragma (exit=0)
PASS  PASS: doc comment \"runtime\" (heuristic skip) (exit=0)
---
PASS=5  FAIL=0
```

Baseline lint 출력:
```
rfc0132_pr3_scan_files                             21
rfc0132_pr3_preapproved_entries                     4
rfc0132_pr3_violations                              0
rfc0132_pr3_stale_preapproved                       0
[no-runtime-literal-outside-boundary-redaction] OK
```

## Exempt Pragma 사용법

새로운 boundary가 아닌 사이트 (내부 observability, 실제 provider/model identity 추적 등)에서 `\"runtime\"` literal이 필요한 경우:

```ocaml
(* RFC-0132-EXEMPT: internal observability — real provider identity tracking *)
let _real = \"runtime\"

let _inline = \"runtime\"  (* RFC-0132-EXEMPT: schema field name *)
```

광범위 허용을 피하기 위해 — pragma는 한 줄짜리 영역 (preceding line 또는 same line) 에만 적용됩니다. 블록 전체 disable은 없습니다.

## Workaround-carryover

없음. RFC-0132 PR-1/PR-2의 SSOT 구축이 완료된 상태에서 future drift만 차단하는 **root fix** completion입니다.

## 확인 사항

- 영향: lint script + CI workflow 추가만. `lib/` 디렉토리 OCaml 코드 변경 0건.
- `dune build` / `dune-local.sh` 실행 안 함 (lint-only PR).
- `bash scripts/lint/yaml-syntax.sh` PASS — 27 workflow file(s) parsed OK.
- `shellcheck` PASS (warning/error 없음).
- `pr-rfc-check.sh` PASS — lint/CI 파일은 subsystem 감시 영역 아님.

## Test plan

- [x] standalone 5-case test 통과
- [x] baseline lint exit 0 with 4 preapproved entries
- [x] shellcheck clean
- [x] yaml-syntax PASS
- [ ] CI `Boundary redaction SSOT enforcement (RFC-0132 PR-3)` job green (PR open 후 확인)

Refs: #16528 (RFC-0132), #16536 (PR-2 codemod).

Co-Authored-By: Claude <noreply@anthropic.com>