### PR TITLE
fix(coord): surface status parse errors instead of silent Pending fallback

### DIFF
--- a/lib/coord/coord_verification_store.ml
+++ b/lib/coord/coord_verification_store.ml
@@ -140,15 +140,20 @@ let request_header_of_yojson = function
              | Some f -> f
              | None -> Time_compat.now ()
            in
-           let status =
+           let status_result =
              match List.assoc_opt "status" fields with
-             | Some json -> (
-                 match request_status_of_yojson json with
-                 | Ok s -> s
-                 | Error _ -> `Pending)
-             | None -> `Pending
+             | None -> Ok `Pending
+             | Some json -> request_status_of_yojson json
            in
-           Ok { id; task_id; worker; verifier; created_at; status }
+           (match status_result with
+            | Ok status ->
+                Ok { id; task_id; worker; verifier; created_at; status }
+            | Error err ->
+                Error
+                  (Printf.sprintf
+                     "verification request '%s' has invalid 'status' field: \
+                      %s"
+                     id err))
        | id_opt, task_opt, worker_opt ->
            let missing =
              List.filter_map


### PR DESCRIPTION
## Why

`request_header_of_yojson:148`이 status field 파싱 실패 시 silent하게 `Pending`으로 fallback. 이건 verifier의 critical visibility loss:
- Producer가 `Completed`를 잘못 보냈는데 silently `Pending`로 다운그레이드 → verifier가 "아직 처리 안 함"으로 인식
- Producer에게 zero 피드백 → wire format mismatch가 production에 silent landed

**Workaround Rejection Bar 시그니처 #2 (unknown→permissive default)** — Iter#27 review에서 식별, 별 PR로 분리 (project memory `fsm-tla observability loop 2026-05-19`).

## What

```diff
-           let status =
-             match List.assoc_opt "status" fields with
-             | Some json -> (
-                 match request_status_of_yojson json with
-                 | Ok s -> s
-                 | Error _ -> `Pending)
-             | None -> `Pending
-           in
-           Ok { id; task_id; worker; verifier; created_at; status }
+           let status_result =
+             match List.assoc_opt "status" fields with
+             | None -> Ok `Pending
+             | Some json -> request_status_of_yojson json
+           in
+           (match status_result with
+            | Ok status ->
+                Ok { id; task_id; worker; verifier; created_at; status }
+            | Error err ->
+                Error (Printf.sprintf
+                  "verification request '%s' has invalid 'status' field: %s"
+                  id err))
```

**Key**: missing status (`None`) → `Pending`은 유지 (legacy compat). 파싱 실패 (`Error _`)만 propagate.

## Caller verification (no per-request crash risk)

- `load_request_header` (L171): 이미 Result.Error 정상 처리 → 1 corrupt file만 affected
- `list_request_headers`: 이미 `report_persistence_read_drop`로 per-file drop 가능 → entire list 안 깨짐

즉 silent fallback 제거가 *entire verifier 마비* 위험을 만들지 않음 — caller가 이미 partial-fail safe.

## Behavior change (intentional improvement)

| 시나리오 | Old | New |
|---------|-----|-----|
| Status field 없음 | `Pending` | `Pending` (동일) |
| Status field corrupt (parse fail) | `Pending` silent | Error propagated with id + inner |

## Iter series

FSM/TLA+ observability sweep `/loop 20m` cron `253cc0f6` **iter#33**:
- Silent-failure 도메인 첫 PR (received-kind sweep에서 silent-failure로 전환)
- Iter#27 deferred 작업 closure
- Sweep 17회째 후 #16513 close (superseded by #16375 main work). 10 CONFLICTING 중 1개 정리.

## Workaround Rejection Bar

- [ ] telemetry-as-fix: 아님 (silent fallback **제거** + Error propagate)
- [ ] string classifier 추가: 아님
- [ ] N-of-M: 아님 (file 내 단일 silent fallback)
- [ ] catch-all 추가: 아님 (catch-all *제거*)
- [ ] cap/cooldown/dedup/repair: 아님

## RFC Check

`bash ~/me/scripts/pr-rfc-check.sh` PASS (exit 0). coord/coord_verification_store — credential/identity/operator/sandbox/dashboard-credential/hooks/workflow* 무관.

## Verification

- ocamlformat --check PASS
- 테스트는 string equality 비의존 (`rg "invalid 'status' field" test/` empty)
- 1 file, +12 / -7

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>