### PR TITLE
refactor: split runtime trust timeline helpers

### DIFF
--- a/lib/cascade/cascade_event_bridge.ml
+++ b/lib/cascade/cascade_event_bridge.ml
@@ -17,121 +17,12 @@
     @modified 2.255.0 — accept OAS native events (#5620)
     @modified 2.260.0 — emit envelope correlation_id/run_id (oas#845) *)
 
+open Cascade_event_bridge_inference
+
 (** Drain interval: how often we poll the Event_bus subscription.
     Lower default keeps the dashboard close to real-time, while staying
     runtime-tunable for quieter deployments. *)
 let drain_interval_s () = Env_config.Oas_sse.drain_interval_sec
-
-let json_string_opt = function
-  | Some value when String.trim value <> "" -> `String value
-  | _ -> `Null
-;;
-
-let payload_string_opt key = function
-  | `Assoc fields ->
-    (match List.assoc_opt key fields with
-     | Some (`String value) when String.trim value <> "" -> Some value
-     | _ -> None)
-  | _ -> None
-;;
-
-let payload_int_opt key = function
-  | `Assoc fields ->
-    (match List.assoc_opt key fields with
-     | Some (`Int value) -> Some value
-     | Some (`Intlit value) -> int_of_string_opt value
-     | _ -> None)
-  | _ -> None
-;;
-
-let inference_model_bucket ~provider ~model =
-  let has needle =
-    String_util.contains_substring_ci provider needle
-    || String_util.contains_substring_ci model needle
-  in
-  if has "kimi"
-  then "kimi"
-  else if has "claude" || has "anthropic"
-  then "anthropic"
-  else if has "openai" || has "gpt" || has "codex"
-  then "openai"
-  else if has "gemini" || has "google"
-  then "gemini"
-  else if has "glm" || has "zai"
-  then "glm"
-  else if has "qwen"
-  then "qwen"
-  else if has "llama"
-  then "llama"
-  else "other"
-;;
-
-let inference_provider_bucket ~provider ~model =
-  let provider = String.trim provider in
-  if provider = ""
-  then inference_model_bucket ~provider ~model
-  else inference_model_bucket ~provider ~model:""
-;;
-
-let positive_finite value =
-  value > 0.0
-  &&
-  match classify_float value with
-  | FP_nan | FP_infinite -> false
-  | FP_normal | FP_subnormal | FP_zero -> true
-;;
-
-let tok_per_sec_from_ms ~tokens ~ms =
-  match tokens, ms with
-  | Some tokens, Some ms when tokens > 0 && positive_finite ms ->
-    Some (float_of_int tokens /. (ms /. 1000.0))
-  | _ -> None
-;;
-
-let observe_inference_rate metric ~model_bucket = function
-  | Some rate when positive_finite rate ->
-    Prometheus.observe_histogram metric ~labels:[ "model_bucket", model_bucket ] rate
-  | _ -> ()
-;;
-
-let observe_inference_telemetry
-      ~provider
-      ~model
-      ~prompt_tokens
-      ~completion_tokens
-      ~prompt_ms
-      ~decode_ms
-      ~decode_tok_s
-  =
-  let model_bucket = inference_model_bucket ~provider ~model in
-  (* Token counts are NOT emitted here.  The authoritative per-request
-     token counter is [on_token_usage] → [Llm_metric_bridge.emit_token_usage]
-     with precise {provider, model} labels.  This function retains only
-     the latency/rate metrics (prompt_tok/s, decode_tok/s) that are
-     unique to the [InferenceTelemetry] event payload. *)
-  observe_inference_rate
-    Prometheus.metric_oas_inference_prompt_tok_per_sec
-    ~model_bucket
-    (tok_per_sec_from_ms ~tokens:prompt_tokens ~ms:prompt_ms);
-  let decode_tok_s =
-    match decode_tok_s with
-    | Some rate when positive_finite rate -> Some rate
-    | _ -> tok_per_sec_from_ms ~tokens:completion_tokens ~ms:decode_ms
-  in
-  observe_inference_rate
-    Prometheus.metric_oas_inference_decode_tok_per_sec
-    ~model_bucket
-    decode_tok_s
-;;
-
-let observe_inference_cost ~provider ~model_bucket = function
-  | Some cost when positive_finite cost ->
-    Prometheus.observe_histogram
-      Prometheus.metric_oas_inference_cost_usd
-      ~labels:[ "provider", provider; "model_bucket", model_bucket ]
-      cost
-  | _ -> ()
-;;
 
 let stop_reason_to_wire = function
   | Agent_sdk.Types.EndTurn -> "end_turn"

--- a/lib/cascade/cascade_event_bridge_inference.ml
+++ b/lib/cascade/cascade_event_bridge_inference.ml
@@ -1,0 +1,110 @@
+let json_string_opt = function
+  | Some value when String.trim value <> "" -> `String value
+  | _ -> `Null
+;;
+
+let payload_string_opt key = function
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`String value) when String.trim value <> "" -> Some value
+     | _ -> None)
+  | _ -> None
+;;
+
+let payload_int_opt key = function
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`Int value) -> Some value
+     | Some (`Intlit value) -> int_of_string_opt value
+     | _ -> None)
+  | _ -> None
+;;
+
+let inference_model_bucket ~provider ~model =
+  let has needle =
+    String_util.contains_substring_ci provider needle
+    || String_util.contains_substring_ci model needle
+  in
+  if has "kimi"
+  then "kimi"
+  else if has "claude" || has "anthropic"
+  then "anthropic"
+  else if has "openai" || has "gpt" || has "codex"
+  then "openai"
+  else if has "gemini" || has "google"
+  then "gemini"
+  else if has "glm" || has "zai"
+  then "glm"
+  else if has "qwen"
+  then "qwen"
+  else if has "llama"
+  then "llama"
+  else "other"
+;;
+
+let inference_provider_bucket ~provider ~model =
+  let provider = String.trim provider in
+  if provider = ""
+  then inference_model_bucket ~provider ~model
+  else inference_model_bucket ~provider ~model:""
+;;
+
+let positive_finite value =
+  value > 0.0
+  &&
+  match classify_float value with
+  | FP_nan | FP_infinite -> false
+  | FP_normal | FP_subnormal | FP_zero -> true
+;;
+
+let tok_per_sec_from_ms ~tokens ~ms =
+  match tokens, ms with
+  | Some tokens, Some ms when tokens > 0 && positive_finite ms ->
+    Some (float_of_int tokens /. (ms /. 1000.0))
+  | _ -> None
+;;
+
+let observe_inference_rate metric ~model_bucket = function
+  | Some rate when positive_finite rate ->
+    Prometheus.observe_histogram metric ~labels:[ "model_bucket", model_bucket ] rate
+  | _ -> ()
+;;
+
+let observe_inference_telemetry
+      ~provider
+      ~model
+      ~prompt_tokens
+      ~completion_tokens
+      ~prompt_ms
+      ~decode_ms
+      ~decode_tok_s
+  =
+  let model_bucket = inference_model_bucket ~provider ~model in
+  (* Token counts are NOT emitted here.  The authoritative per-request
+     token counter is [on_token_usage] -> [Llm_metric_bridge.emit_token_usage]
+     with precise {provider, model} labels.  This function retains only
+     the latency/rate metrics (prompt_tok/s, decode_tok/s) that are
+     unique to the [InferenceTelemetry] event payload. *)
+  observe_inference_rate
+    Prometheus.metric_oas_inference_prompt_tok_per_sec
+    ~model_bucket
+    (tok_per_sec_from_ms ~tokens:prompt_tokens ~ms:prompt_ms);
+  let decode_tok_s =
+    match decode_tok_s with
+    | Some rate when positive_finite rate -> Some rate
+    | _ -> tok_per_sec_from_ms ~tokens:completion_tokens ~ms:decode_ms
+  in
+  observe_inference_rate
+    Prometheus.metric_oas_inference_decode_tok_per_sec
+    ~model_bucket
+    decode_tok_s
+;;
+
+let observe_inference_cost ~provider ~model_bucket = function
+  | Some cost when positive_finite cost ->
+    Prometheus.observe_histogram
+      Prometheus.metric_oas_inference_cost_usd
+      ~labels:[ "provider", provider; "model_bucket", model_bucket ]
+      cost
+  | _ -> ()
+;;

--- a/lib/cascade/cascade_event_bridge_inference.mli
+++ b/lib/cascade/cascade_event_bridge_inference.mli
@@ -1,0 +1,22 @@
+val json_string_opt : string option -> Yojson.Safe.t
+
+val payload_string_opt : string -> Yojson.Safe.t -> string option
+
+val payload_int_opt : string -> Yojson.Safe.t -> int option
+
+val inference_model_bucket : provider:string -> model:string -> string
+
+val inference_provider_bucket : provider:string -> model:string -> string
+
+val observe_inference_telemetry :
+  provider:string ->
+  model:string ->
+  prompt_tokens:int option ->
+  completion_tokens:int option ->
+  prompt_ms:float option ->
+  decode_ms:float option ->
+  decode_tok_s:float option ->
+  unit
+
+val observe_inference_cost :
+  provider:string -> model_bucket:string -> float option -> unit

--- a/lib/dune
+++ b/lib/dune
@@ -249,6 +249,7 @@
   keeper_memory_llm_summary
   keeper_memory_recall
   keeper_status_bridge
+  keeper_runtime_trust_timeline
   keeper_hooks_oas_gate_attempt
   keeper_hooks_oas_output_json
   keeper_hooks_oas_response_metrics

--- a/lib/dune
+++ b/lib/dune
@@ -197,6 +197,7 @@
   provider_runtime_projection
   voice_bridge_transport
   cascade_wire_overlay
+  cascade_event_bridge_inference
   cascade_http_probe_url
   cascade_agent_context
   cascade_health_tracker_config
@@ -422,7 +423,8 @@
    masc_mcp.dashboard_eval_feed
    ;; RFC-0004 Phase A0.1 PR-1 — Typed SSE event lib (lib/sse_event/).
    ;; atdgen-generated payload types + hand-rolled envelope wrap that
-   ;; mirrors cascade_event_bridge.wrap_event/json_string_opt
+   ;; mirrors cascade_event_bridge.wrap_event and
+   ;; cascade_event_bridge_inference.json_string_opt
    ;; semantics.  PR-2 onwards: cascade_event_bridge arms call into
    ;; Sse_event.<event>_constructor instead of inline `Assoc.
    masc_mcp.sse_event

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -1,115 +1,6 @@
 open Keeper_types
+open Keeper_runtime_trust_timeline
 
-let json_member key = function
-  | `Assoc _ as json -> Yojson.Safe.Util.member key json
-  | _ -> `Null
-
-let json_int_opt_member key json =
-  match json_member key json with
-  | `Int n -> Some n
-  | `Intlit raw -> int_of_string_opt raw
-  | _ -> None
-
-let json_float_opt_member key json =
-  match json_member key json with
-  | `Float value -> Some value
-  | `Int value -> Some (float_of_int value)
-  | `Intlit raw -> float_of_string_opt raw
-  | _ -> None
-
-let json_string_opt_member key json =
-  match json_member key json with
-  | `String value when String.trim value <> "" -> Some value
-  | _ -> None
-
-let json_string_opt_value = function
-  | `String value when String.trim value <> "" -> Some value
-  | _ -> None
-
-let json_bool_opt_member key json =
-  match json_member key json with
-  | `Bool value -> Some value
-  | _ -> None
-
-let json_list_member key json =
-  match json_member key json with
-  | `List items -> items
-  | _ -> []
-
-let json_string_list_member key json =
-  json_list_member key json
-  |> List.filter_map (function
-       | `String value when String.trim value <> "" -> Some value
-       | _ -> None)
-
-let string_list_json values =
-  `List (List.map (fun value -> `String value) values)
-
-let assoc_bool_default key ~default fields =
-  match List.assoc_opt key fields with
-  | Some (`Bool value) -> value
-  | _ -> default
-
-let assoc_string_opt key fields =
-  match List.assoc_opt key fields with
-  | Some (`String value) when String.trim value <> "" -> Some value
-  | _ -> None
-
-let assoc_json_opt key fields =
-  match List.assoc_opt key fields with
-  | Some `Null | None -> None
-  | Some value -> Some value
-
-let iso_of_unix_seconds ts =
-  Masc_domain.iso8601_of_unix_seconds ts
-
-let take limit values =
-  values |> List.filteri (fun idx _ -> idx < limit)
-
-let goal_ids_of_json json =
-  match json_string_list_member "goal_ids" json with
-  | [] -> (
-      match json_string_opt_member "goal_id" json with
-      | Some goal_id -> [ goal_id ]
-      | None -> [])
-  | goal_ids -> goal_ids
-
-let keeper_turn_id_of_json json =
-  match json_int_opt_member "keeper_turn_id" json with
-  | Some _ as value -> value
-  | None -> (
-      match json_int_opt_member "turn_id" json with
-      | Some _ as value -> value
-      | None -> json_int_opt_member "turn" json)
-
-let timeline_event_json ?trace_id ?keeper_turn_id ?task_id ?(goal_ids = [])
-    ?next_human_action ?observed_at_unix ?(observation_only = false)
-    ~ts_unix ~kind ~title ~summary ~severity () =
-  let observed_at_unix = Option.value ~default:ts_unix observed_at_unix in
-  `Assoc
-    [
-      ("kind", `String kind);
-      ("ts", `String (iso_of_unix_seconds ts_unix));
-      ("ts_unix", `Float ts_unix);
-      ("observed_at", `String (iso_of_unix_seconds observed_at_unix));
-      ("observed_at_unix", `Float observed_at_unix);
-      ("observation_only", `Bool observation_only);
-      ("trace_id", Json_util.string_opt_to_json trace_id);
-      ("keeper_turn_id", Json_util.int_opt_to_json keeper_turn_id);
-      ("task_id", Json_util.string_opt_to_json task_id);
-      ("goal_ids", `List (List.map (fun goal_id -> `String goal_id) goal_ids));
-      ("title", `String title);
-      ("summary", `String summary);
-      ("severity", `String severity);
-      ("next_human_action", Json_util.string_opt_to_json next_human_action);
-    ]
-
-let severity_of_decision = function
-  | "run" -> "ok"
-  | "skip" -> "warn"
-  | _ -> "warn"
-
-let severity_of_tool_call success = if success then "ok" else "bad"
 
 (* RFC-0047 PR-4: deserialization-boundary normalize for legacy persisted
    wires. Pre-PR-4, [Keeper_turn_terminal.normalize_code] silently remapped
@@ -269,210 +160,6 @@ let latest_terminal_reason_opt ~meta ~runtime_blocker_fields ~latest_decision
       then terminal_reason_from_runtime_blocker_fields runtime_blocker_fields
       else Option.bind latest_receipt terminal_reason_from_receipt
 
-let severity_of_approval_event event decision =
-  match event with
-  | "pending" -> "warn"
-  | "expired" | "approval_timeout" | "cancelled" -> "bad"
-  | "resolved" -> (
-      match decision with
-      | Some raw when String_util.contains_substring_ci raw "reject" -> "bad"
-      | _ -> "ok")
-  | "auto_approved_rule_match" | "auto_approved_always" | "rule_created" -> "ok"
-  | _ -> "warn"
-
-let severity_of_transition_type event_type =
-  if String_util.contains_substring_ci event_type "failed"
-     || String_util.contains_substring_ci event_type "exhausted"
-  then "bad"
-  else if
-    String_util.contains_substring_ci event_type "pause"
-    || String_util.contains_substring_ci event_type "stop"
-    || String_util.contains_substring_ci event_type "handoff"
-    || String_util.contains_substring_ci event_type "compaction"
-  then "warn"
-  else "ok"
-
-let tool_call_timeline_event json =
-  match json_float_opt_member "ts" json, json_string_opt_member "tool" json with
-  | Some ts_unix, Some tool_name ->
-      let success =
-        json_bool_opt_member "success" json |> Option.value ~default:true
-      in
-      let duration_ms = json_float_opt_member "duration_ms" json in
-      let summary =
-        match duration_ms with
-        | Some ms ->
-            Printf.sprintf "%s %s in %.0fms"
-              tool_name
-              (if success then "succeeded" else "failed")
-              ms
-        | None ->
-            Printf.sprintf "%s %s"
-              tool_name
-              (if success then "succeeded" else "failed")
-      in
-      Some
-        (timeline_event_json
-           ?trace_id:(json_string_opt_member "trace_id" json)
-           ?keeper_turn_id:(keeper_turn_id_of_json json)
-           ?task_id:(json_string_opt_member "task_id" json)
-           ~goal_ids:(goal_ids_of_json json)
-           ~ts_unix ~kind:"tool_call"
-           ~title:(Printf.sprintf "Tool · %s" tool_name)
-           ~summary ~severity:(severity_of_tool_call success) ())
-  | _ -> None
-
-let is_worktree_tool tool_name =
-  String.equal tool_name "masc_worktree_create"
-
-let live_pending_approval_timeline_event json =
-  match json_float_opt_member "requested_at" json with
-  | None -> None
-  | Some ts_unix ->
-      let tool_name =
-        json_string_opt_member "tool_name" json |> Option.value ~default:"tool"
-      in
-      let approval_id =
-        json_string_opt_member "id" json |> Option.value ~default:"unknown"
-      in
-      let task_id = json_string_opt_member "task_id" json in
-      let blocker_class =
-        if is_worktree_tool tool_name then "blocked_before_worktree"
-        else "approval_pending"
-      in
-      let summary =
-        Printf.sprintf
-          "approval_required · id=%s · blocker=%s · waiting for operator"
-          approval_id blocker_class
-      in
-      Some
-        (timeline_event_json
-           ?task_id
-           ~ts_unix ~kind:"approval_pending_live"
-           ~title:(Printf.sprintf "Approval Pending · %s" tool_name)
-           ~summary
-           ~severity:"warn"
-           ~observation_only:true
-           ~next_human_action:"resolve_approval"
-           ())
-
-let approval_event_timeline_event json =
-  match json_float_opt_member "ts" json, json_string_opt_member "event" json with
-  | Some ts_unix, Some event ->
-      let tool_name =
-        json_string_opt_member "tool" json |> Option.value ~default:"tool"
-      in
-      let keeper_name = json_string_opt_member "keeper" json in
-      let approval_summary text =
-        match keeper_name with
-        | Some keeper when String.trim keeper <> "" ->
-            Printf.sprintf "%s · keeper=%s" text keeper
-        | _ -> text
-      in
-      let decision = json_string_opt_member "decision" json in
-      let kind, title, summary, next_human_action =
-        match event with
-        | "pending" ->
-            ( "approval_requested",
-              Printf.sprintf "Approval · %s" tool_name,
-              approval_summary
-                "approval requested and waiting for operator decision",
-              Some "resolve_approval" )
-        | "resolved" ->
-            let decision_label =
-              Option.value ~default:"resolved" decision
-            in
-            ( "approval_resolved",
-              Printf.sprintf "Approval · %s" tool_name,
-              approval_summary (Printf.sprintf "approval %s" decision_label),
-              None )
-        | "expired" ->
-            let blocker_note =
-              if is_worktree_tool tool_name then
-                " · blocked_before_worktree"
-              else ""
-            in
-            let next_action =
-              if is_worktree_tool tool_name then "retry_worktree_approval"
-              else "retry_or_rerun"
-            in
-            let decision_label =
-              match decision with
-              | Some value -> value
-              | None -> "approval expired"
-            in
-            ( "approval_expired",
-              Printf.sprintf "Approval · %s" tool_name,
-              approval_summary (decision_label ^ blocker_note),
-              Some next_action )
-        | "approval_timeout" | "cancelled" ->
-            let summary =
-              match decision with
-              | Some value -> value
-              | None -> "approval await cancelled"
-            in
-            ( "approval_expired",
-              Printf.sprintf "Approval · %s" tool_name,
-              approval_summary summary,
-              Some "retry_or_rerun" )
-        | "auto_approved_rule_match" ->
-            let matched_by =
-              json |> json_member "rule_match"
-              |> json_string_opt_member "matched_by"
-              |> Option.value ~default:"always_rule"
-            in
-            ( "approval_rule_match",
-              Printf.sprintf "Approval Rule · %s" tool_name,
-              approval_summary (Printf.sprintf "auto-approved by %s" matched_by),
-              None )
-        | "auto_approved_always" ->
-            ( "approval_always_flag",
-              Printf.sprintf "Approval Always · %s" tool_name,
-              approval_summary "auto-approved by keeper always_approve flag",
-              None )
-        | "rule_created" ->
-            ( "approval_rule_created",
-              Printf.sprintf "Approval Rule · %s" tool_name,
-              approval_summary "persistent approval rule recorded",
-              None )
-        | other ->
-            ( "approval_event",
-              Printf.sprintf "Approval · %s" tool_name,
-              approval_summary other,
-              None )
-      in
-      Some
-        (timeline_event_json
-           ?keeper_turn_id:(keeper_turn_id_of_json json)
-           ?task_id:(json_string_opt_member "task_id" json)
-           ~goal_ids:(goal_ids_of_json json)
-           ?next_human_action
-           ~ts_unix ~kind ~title ~summary
-           ~severity:(severity_of_approval_event event decision) ())
-  | _ -> None
-
-let decision_timeline_event json =
-  match json_float_opt_member "wall_clock" json with
-  | None -> None
-  | Some ts_unix ->
-      let turn_verdict =
-        json_string_opt_member "turn_verdict" json
-        |> Option.value ~default:"unknown"
-      in
-      let reasons =
-        json_string_list_member "turn_reasons" json
-      in
-      let summary =
-        match reasons with
-        | [] -> Printf.sprintf "turn verdict=%s" turn_verdict
-        | _ -> String.concat "; " reasons
-      in
-      Some
-        (timeline_event_json ~ts_unix ~kind:"decision"
-           ~title:"Turn Decision"
-           ~summary
-           ~severity:(severity_of_decision turn_verdict) ())
-
 let terminal_reason_timeline_event ~latest_decision ~latest_receipt =
   let source_json, ts_unix_opt, reason_opt =
     match latest_decision with
@@ -522,158 +209,6 @@ let terminal_reason_timeline_event ~latest_decision ~latest_receipt =
            ~severity:(Keeper_turn_terminal.severity_to_string reason.severity)
            ())
   | _ -> None
-
-let transition_timeline_event json =
-  match json_float_opt_member "wall_clock_at_decision" json with
-  | None -> None
-  | Some ts_unix ->
-      let operator_signal =
-        match json |> json_member "operator_signal" with
-        | `Assoc fields -> Some fields
-        | _ -> None
-      in
-      let signal_string key =
-        Option.bind operator_signal (assoc_string_opt key)
-      in
-      let signal_bool key =
-        Option.map
-          (fun fields -> assoc_bool_default key ~default:false fields)
-          operator_signal
-      in
-      let prev_phase =
-        json |> json_member "prev_phase"
-        |> json_string_opt_value
-      in
-      let new_phase =
-        json |> json_member "new_phase"
-        |> json_string_opt_value
-      in
-      let selected_event =
-        json |> json_member "selected_event"
-      in
-      let event_type =
-        (match json_string_opt_member "event_type" json with
-         | Some _ as value -> value
-         | None -> json_string_opt_member "type" selected_event)
-        |> Option.value ~default:"transition"
-      in
-      let prev_phase = Option.value ~default:"unknown" prev_phase in
-      let new_phase = Option.value ~default:"unknown" new_phase in
-      let signal_summary = signal_string "summary" in
-      let next_human_action =
-        match signal_bool "requires_operator_decision" with
-        | Some true -> signal_string "next_human_action"
-        | _ -> None
-      in
-      let summary =
-        match signal_summary with
-        | Some signal when String.trim signal <> "" ->
-            Printf.sprintf "%s -> %s via %s · %s"
-              prev_phase new_phase event_type signal
-        | _ ->
-            Printf.sprintf "%s -> %s via %s"
-              prev_phase new_phase event_type
-      in
-      let severity =
-        signal_string "severity"
-        |> Option.value ~default:(severity_of_transition_type event_type)
-      in
-      Some
-        (timeline_event_json ?next_human_action ~ts_unix ~kind:"transition"
-           ~title:(Printf.sprintf "Transition · %s" event_type)
-           ~summary ~severity ())
-
-let receipt_timeline_event receipt =
-  match json_string_opt_member "ended_at" receipt with
-  | None -> None
-  | Some ended_at ->
-      let ts_unix =
-        Masc_domain.parse_iso8601 ~default_time:0.0 ended_at
-      in
-      if ts_unix <= 0.0 then None
-      else
-        let outcome =
-          json_string_opt_member "outcome" receipt
-          |> Option.value ~default:"unknown"
-        in
-        let tool_contract_result =
-          json_string_opt_member "tool_contract_result" receipt
-          |> Option.value ~default:"unknown"
-        in
-        let cascade_outcome =
-          receipt |> json_member "cascade"
-          |> json_string_opt_member "outcome"
-          |> Option.value ~default:"not_observed"
-        in
-        let error_kind =
-          match json_member "error" receipt with
-          | `Assoc _ as error -> json_string_opt_member "kind" error
-          | _ -> None
-        in
-        let severity =
-          match error_kind with
-          | Some _ -> "bad"
-          | None ->
-              if String.equal tool_contract_result "violated" then "bad"
-              else if
-                String.equal cascade_outcome "passed_to_next_model"
-                || (receipt |> json_member "cascade"
-                    |> json_bool_opt_member "fallback_applied"
-                    |> Option.value ~default:false)
-              then "warn"
-              else "ok"
-        in
-        Some
-          (timeline_event_json
-             ?trace_id:(json_string_opt_member "trace_id" receipt)
-             ?keeper_turn_id:(json_int_opt_member "turn_count" receipt)
-             ?task_id:(json_string_opt_member "current_task_id" receipt)
-             ~goal_ids:(goal_ids_of_json receipt)
-             ~ts_unix ~kind:"execution_receipt"
-             ~title:"Execution Receipt"
-             ~summary:
-               (Printf.sprintf "%s · tool_contract=%s · cascade=%s"
-                  outcome tool_contract_result cascade_outcome)
-             ~severity ())
-
-let blocker_timeline_event ?task_id ?(goal_ids = []) ?trace_id
-    ?observed_at_unix ~ts_unix ~runtime_blocker_fields
-    ~next_human_action ?(observation_only = true) () =
-  let blocker_class = assoc_string_opt "runtime_blocker_class" runtime_blocker_fields in
-  let blocker_summary =
-    assoc_string_opt "runtime_blocker_summary" runtime_blocker_fields
-  in
-  match blocker_class, blocker_summary with
-  | None, None -> None
-  | Some blocker_class, Some summary
-    when String.trim summary <> "" ->
-      Some
-        (timeline_event_json ?trace_id ?task_id ~goal_ids ?next_human_action
-           ?observed_at_unix ~observation_only
-           ~ts_unix ~kind:"runtime_blocker"
-           ~title:"Runtime Blocker"
-           ~summary
-           ~severity:
-             (match blocker_class with
-              | "cascade_exhausted" | "completion_contract_violation" -> "bad"
-              | _ -> "warn")
-           ())
-  | None, Some summary
-    when String.trim summary <> "" ->
-      Some
-        (timeline_event_json ?trace_id ?task_id ~goal_ids ?next_human_action
-           ?observed_at_unix ~observation_only
-           ~ts_unix ~kind:"runtime_blocker"
-           ~title:"Runtime Blocker"
-           ~summary ~severity:"warn" ())
-  | Some blocker_class, None ->
-      Some
-        (timeline_event_json ?trace_id ?task_id ~goal_ids ?next_human_action
-           ?observed_at_unix ~observation_only
-           ~ts_unix ~kind:"runtime_blocker"
-           ~title:"Runtime Blocker"
-           ~summary:blocker_class ~severity:"warn" ())
-  | Some _, Some _ | None, Some _ -> None
 
 let disposition_of_snapshot ~pending_approval_count ~runtime_blocker_fields =
   let continue_gate =
@@ -830,22 +365,6 @@ let latest_decision_json ~(config : Coord.config) ~(keeper_name : string) :
                  ~detail:"decision log row is not a JSON object";
                None)
 
-let latest_tool_call_json ~(keeper_name : string) =
-  Keeper_tool_call_log.read_latest ~keeper_name ()
-
-let pending_approval_json ~(keeper_name : string) =
-  match Keeper_approval_queue.list_pending_dashboard_json () with
-  | `List entries ->
-      entries
-      |> List.filter (fun json ->
-             String.equal keeper_name
-               (Safe_ops.json_string ~default:"" "keeper_name" json))
-      |> List.sort (fun left right ->
-             Float.compare
-               (Safe_ops.json_float ~default:0.0 "requested_at" right)
-               (Safe_ops.json_float ~default:0.0 "requested_at" left))
-      |> fun entries -> `List entries
-  | _ -> `List []
 
 let latest_turn_id ~(registry_entry : Keeper_registry.registry_entry option)
     ~(latest_decision : Yojson.Safe.t option)
@@ -868,39 +387,14 @@ let latest_turn_id ~(registry_entry : Keeper_registry.registry_entry option)
 let latest_receipt_json ~(config : Coord.config) ~(keeper_name : string) =
   Keeper_execution_receipt.latest_json config keeper_name
 
-let sort_timeline_events events =
-  List.sort
-    (fun left right ->
+let selected_model_of_latest_decision latest_decision =
+  Option.bind latest_decision (fun decision ->
       match
-        Bool.compare
-          (json_bool_opt_member "observation_only" left
-           |> Option.value ~default:false)
-          (json_bool_opt_member "observation_only" right
-           |> Option.value ~default:false)
+        decision |> json_member "telemetry"
+        |> json_string_opt_member "selected_model"
       with
-      | 0 ->
-          Float.compare
-            (json_float_opt_member "ts_unix" right |> Option.value ~default:0.0)
-            (json_float_opt_member "ts_unix" left |> Option.value ~default:0.0)
-      | cmp -> cmp)
-    events
-
-let latest_causal_from_timeline = function
-  | `List items -> (
-      match
-        List.find_opt
-          (fun json ->
-             not
-               (json_bool_opt_member "observation_only" json
-                |> Option.value ~default:false))
-          items
-      with
-      | Some event -> event
-      | None -> (
-          match items with
-          | event :: _ -> event
-          | [] -> `Null))
-  | _ -> `Null
+      | Some _ as value -> value
+      | None -> json_string_opt_member "selected_model" decision)
 
 let pending_first_json pending_approvals =
   match pending_approvals with
@@ -1337,6 +831,7 @@ let snapshot_json ~(config : Coord.config) ~(meta : keeper_meta) =
   let latest_next_action =
     Option.bind latest_terminal_reason (fun reason -> reason.next_action)
   in
+  let selected_model = selected_model_of_latest_decision latest_decision in
   let attention_fields =
     Keeper_status_bridge.attention_fields_json config meta
   in
@@ -1401,8 +896,8 @@ let snapshot_json ~(config : Coord.config) ~(meta : keeper_meta) =
       ("current_task_id", Json_util.string_opt_to_json (Keeper_runtime_contract.current_task_id_opt meta));
       ("goal_id", Json_util.string_opt_to_json (Keeper_runtime_contract.primary_goal_id_opt meta));
       ("goal_ids", `List (List.map (fun goal_id -> `String goal_id) meta.active_goal_ids));
-      ("active_model", `Null);
-      ("selected_model", `Null);
+      ("active_model", Json_util.string_opt_to_json selected_model);
+      ("selected_model", Json_util.string_opt_to_json selected_model);
       ("runtime_contract", runtime_contract);
       ("runtime_blockers", `Assoc runtime_blocker_fields);
       ("disposition", `String disposition);

--- a/lib/keeper/keeper_runtime_trust_timeline.ml
+++ b/lib/keeper/keeper_runtime_trust_timeline.ml
@@ -1,0 +1,519 @@
+let json_member key = function
+  | `Assoc _ as json -> Yojson.Safe.Util.member key json
+  | _ -> `Null
+
+let json_int_opt_member key json =
+  match json_member key json with
+  | `Int n -> Some n
+  | `Intlit raw -> int_of_string_opt raw
+  | _ -> None
+
+let json_float_opt_member key json =
+  match json_member key json with
+  | `Float value -> Some value
+  | `Int value -> Some (float_of_int value)
+  | `Intlit raw -> float_of_string_opt raw
+  | _ -> None
+
+let json_string_opt_member key json =
+  match json_member key json with
+  | `String value when String.trim value <> "" -> Some value
+  | _ -> None
+
+let json_string_opt_value = function
+  | `String value when String.trim value <> "" -> Some value
+  | _ -> None
+
+let json_bool_opt_member key json =
+  match json_member key json with
+  | `Bool value -> Some value
+  | _ -> None
+
+let json_list_member key json =
+  match json_member key json with
+  | `List items -> items
+  | _ -> []
+
+let json_string_list_member key json =
+  json_list_member key json
+  |> List.filter_map (function
+       | `String value when String.trim value <> "" -> Some value
+       | _ -> None)
+
+let string_list_json values =
+  `List (List.map (fun value -> `String value) values)
+
+let assoc_bool_default key ~default fields =
+  match List.assoc_opt key fields with
+  | Some (`Bool value) -> value
+  | _ -> default
+
+let assoc_string_opt key fields =
+  match List.assoc_opt key fields with
+  | Some (`String value) when String.trim value <> "" -> Some value
+  | _ -> None
+
+let assoc_json_opt key fields =
+  match List.assoc_opt key fields with
+  | Some `Null | None -> None
+  | Some value -> Some value
+
+let iso_of_unix_seconds ts =
+  Masc_domain.iso8601_of_unix_seconds ts
+
+let take limit values =
+  values |> List.filteri (fun idx _ -> idx < limit)
+
+let goal_ids_of_json json =
+  match json_string_list_member "goal_ids" json with
+  | [] -> (
+      match json_string_opt_member "goal_id" json with
+      | Some goal_id -> [ goal_id ]
+      | None -> [])
+  | goal_ids -> goal_ids
+
+let keeper_turn_id_of_json json =
+  match json_int_opt_member "keeper_turn_id" json with
+  | Some _ as value -> value
+  | None -> (
+      match json_int_opt_member "turn_id" json with
+      | Some _ as value -> value
+      | None -> json_int_opt_member "turn" json)
+
+let timeline_event_json ?trace_id ?keeper_turn_id ?task_id ?(goal_ids = [])
+    ?next_human_action ?observed_at_unix ?(observation_only = false)
+    ~ts_unix ~kind ~title ~summary ~severity () =
+  let observed_at_unix = Option.value ~default:ts_unix observed_at_unix in
+  `Assoc
+    [
+      ("kind", `String kind);
+      ("ts", `String (iso_of_unix_seconds ts_unix));
+      ("ts_unix", `Float ts_unix);
+      ("observed_at", `String (iso_of_unix_seconds observed_at_unix));
+      ("observed_at_unix", `Float observed_at_unix);
+      ("observation_only", `Bool observation_only);
+      ("trace_id", Json_util.string_opt_to_json trace_id);
+      ("keeper_turn_id", Json_util.int_opt_to_json keeper_turn_id);
+      ("task_id", Json_util.string_opt_to_json task_id);
+      ("goal_ids", `List (List.map (fun goal_id -> `String goal_id) goal_ids));
+      ("title", `String title);
+      ("summary", `String summary);
+      ("severity", `String severity);
+      ("next_human_action", Json_util.string_opt_to_json next_human_action);
+    ]
+
+let severity_of_decision = function
+  | "run" -> "ok"
+  | "skip" -> "warn"
+  | _ -> "warn"
+
+let severity_of_tool_call success = if success then "ok" else "bad"
+
+let severity_of_approval_event event decision =
+  match event with
+  | "pending" -> "warn"
+  | "expired" | "approval_timeout" | "cancelled" -> "bad"
+  | "resolved" -> (
+      match decision with
+      | Some raw when String_util.contains_substring_ci raw "reject" -> "bad"
+      | _ -> "ok")
+  | "auto_approved_rule_match" | "auto_approved_always" | "rule_created" -> "ok"
+  | _ -> "warn"
+
+let severity_of_transition_type event_type =
+  if String_util.contains_substring_ci event_type "failed"
+     || String_util.contains_substring_ci event_type "exhausted"
+  then "bad"
+  else if
+    String_util.contains_substring_ci event_type "pause"
+    || String_util.contains_substring_ci event_type "stop"
+    || String_util.contains_substring_ci event_type "handoff"
+    || String_util.contains_substring_ci event_type "compaction"
+  then "warn"
+  else "ok"
+
+let tool_call_timeline_event json =
+  match json_float_opt_member "ts" json, json_string_opt_member "tool" json with
+  | Some ts_unix, Some tool_name ->
+      let success =
+        json_bool_opt_member "success" json |> Option.value ~default:true
+      in
+      let duration_ms = json_float_opt_member "duration_ms" json in
+      let summary =
+        match duration_ms with
+        | Some ms ->
+            Printf.sprintf "%s %s in %.0fms"
+              tool_name
+              (if success then "succeeded" else "failed")
+              ms
+        | None ->
+            Printf.sprintf "%s %s"
+              tool_name
+              (if success then "succeeded" else "failed")
+      in
+      Some
+        (timeline_event_json
+           ?trace_id:(json_string_opt_member "trace_id" json)
+           ?keeper_turn_id:(keeper_turn_id_of_json json)
+           ?task_id:(json_string_opt_member "task_id" json)
+           ~goal_ids:(goal_ids_of_json json)
+           ~ts_unix ~kind:"tool_call"
+           ~title:(Printf.sprintf "Tool · %s" tool_name)
+           ~summary ~severity:(severity_of_tool_call success) ())
+  | _ -> None
+
+let is_worktree_tool tool_name =
+  String.equal tool_name "masc_worktree_create"
+
+let live_pending_approval_timeline_event json =
+  match json_float_opt_member "requested_at" json with
+  | None -> None
+  | Some ts_unix ->
+      let tool_name =
+        json_string_opt_member "tool_name" json |> Option.value ~default:"tool"
+      in
+      let approval_id =
+        json_string_opt_member "id" json |> Option.value ~default:"unknown"
+      in
+      let task_id = json_string_opt_member "task_id" json in
+      let blocker_class =
+        if is_worktree_tool tool_name then "blocked_before_worktree"
+        else "approval_pending"
+      in
+      let summary =
+        Printf.sprintf
+          "approval_required · id=%s · blocker=%s · waiting for operator"
+          approval_id blocker_class
+      in
+      Some
+        (timeline_event_json
+           ?task_id
+           ~ts_unix ~kind:"approval_pending_live"
+           ~title:(Printf.sprintf "Approval Pending · %s" tool_name)
+           ~summary
+           ~severity:"warn"
+           ~observation_only:true
+           ~next_human_action:"resolve_approval"
+           ())
+
+let approval_event_timeline_event json =
+  match json_float_opt_member "ts" json, json_string_opt_member "event" json with
+  | Some ts_unix, Some event ->
+      let tool_name =
+        json_string_opt_member "tool" json |> Option.value ~default:"tool"
+      in
+      let keeper_name = json_string_opt_member "keeper" json in
+      let approval_summary text =
+        match keeper_name with
+        | Some keeper when String.trim keeper <> "" ->
+            Printf.sprintf "%s · keeper=%s" text keeper
+        | _ -> text
+      in
+      let decision = json_string_opt_member "decision" json in
+      let kind, title, summary, next_human_action =
+        match event with
+        | "pending" ->
+            ( "approval_requested",
+              Printf.sprintf "Approval · %s" tool_name,
+              approval_summary
+                "approval requested and waiting for operator decision",
+              Some "resolve_approval" )
+        | "resolved" ->
+            let decision_label =
+              Option.value ~default:"resolved" decision
+            in
+            ( "approval_resolved",
+              Printf.sprintf "Approval · %s" tool_name,
+              approval_summary (Printf.sprintf "approval %s" decision_label),
+              None )
+        | "expired" ->
+            let blocker_note =
+              if is_worktree_tool tool_name then
+                " · blocked_before_worktree"
+              else ""
+            in
+            let next_action =
+              if is_worktree_tool tool_name then "retry_worktree_approval"
+              else "retry_or_rerun"
+            in
+            let decision_label =
+              match decision with
+              | Some value -> value
+              | None -> "approval expired"
+            in
+            ( "approval_expired",
+              Printf.sprintf "Approval · %s" tool_name,
+              approval_summary (decision_label ^ blocker_note),
+              Some next_action )
+        | "approval_timeout" | "cancelled" ->
+            let summary =
+              match decision with
+              | Some value -> value
+              | None -> "approval await cancelled"
+            in
+            ( "approval_expired",
+              Printf.sprintf "Approval · %s" tool_name,
+              approval_summary summary,
+              Some "retry_or_rerun" )
+        | "auto_approved_rule_match" ->
+            let matched_by =
+              json |> json_member "rule_match"
+              |> json_string_opt_member "matched_by"
+              |> Option.value ~default:"always_rule"
+            in
+            ( "approval_rule_match",
+              Printf.sprintf "Approval Rule · %s" tool_name,
+              approval_summary (Printf.sprintf "auto-approved by %s" matched_by),
+              None )
+        | "auto_approved_always" ->
+            ( "approval_always_flag",
+              Printf.sprintf "Approval Always · %s" tool_name,
+              approval_summary "auto-approved by keeper always_approve flag",
+              None )
+        | "rule_created" ->
+            ( "approval_rule_created",
+              Printf.sprintf "Approval Rule · %s" tool_name,
+              approval_summary "persistent approval rule recorded",
+              None )
+        | other ->
+            ( "approval_event",
+              Printf.sprintf "Approval · %s" tool_name,
+              approval_summary other,
+              None )
+      in
+      Some
+        (timeline_event_json
+           ?keeper_turn_id:(keeper_turn_id_of_json json)
+           ?task_id:(json_string_opt_member "task_id" json)
+           ~goal_ids:(goal_ids_of_json json)
+           ?next_human_action
+           ~ts_unix ~kind ~title ~summary
+           ~severity:(severity_of_approval_event event decision) ())
+  | _ -> None
+
+let decision_timeline_event json =
+  match json_float_opt_member "wall_clock" json with
+  | None -> None
+  | Some ts_unix ->
+      let turn_verdict =
+        json_string_opt_member "turn_verdict" json
+        |> Option.value ~default:"unknown"
+      in
+      let reasons =
+        json_string_list_member "turn_reasons" json
+      in
+      let summary =
+        match reasons with
+        | [] -> Printf.sprintf "turn verdict=%s" turn_verdict
+        | _ -> String.concat "; " reasons
+      in
+      Some
+        (timeline_event_json ~ts_unix ~kind:"decision"
+           ~title:"Turn Decision"
+           ~summary
+           ~severity:(severity_of_decision turn_verdict) ())
+
+
+let transition_timeline_event json =
+  match json_float_opt_member "wall_clock_at_decision" json with
+  | None -> None
+  | Some ts_unix ->
+      let operator_signal =
+        match json |> json_member "operator_signal" with
+        | `Assoc fields -> Some fields
+        | _ -> None
+      in
+      let signal_string key =
+        Option.bind operator_signal (assoc_string_opt key)
+      in
+      let signal_bool key =
+        Option.map
+          (fun fields -> assoc_bool_default key ~default:false fields)
+          operator_signal
+      in
+      let prev_phase =
+        json |> json_member "prev_phase"
+        |> json_string_opt_value
+      in
+      let new_phase =
+        json |> json_member "new_phase"
+        |> json_string_opt_value
+      in
+      let selected_event =
+        json |> json_member "selected_event"
+      in
+      let event_type =
+        (match json_string_opt_member "event_type" json with
+         | Some _ as value -> value
+         | None -> json_string_opt_member "type" selected_event)
+        |> Option.value ~default:"transition"
+      in
+      let prev_phase = Option.value ~default:"unknown" prev_phase in
+      let new_phase = Option.value ~default:"unknown" new_phase in
+      let signal_summary = signal_string "summary" in
+      let next_human_action =
+        match signal_bool "requires_operator_decision" with
+        | Some true -> signal_string "next_human_action"
+        | _ -> None
+      in
+      let summary =
+        match signal_summary with
+        | Some signal when String.trim signal <> "" ->
+            Printf.sprintf "%s -> %s via %s · %s"
+              prev_phase new_phase event_type signal
+        | _ ->
+            Printf.sprintf "%s -> %s via %s"
+              prev_phase new_phase event_type
+      in
+      let severity =
+        signal_string "severity"
+        |> Option.value ~default:(severity_of_transition_type event_type)
+      in
+      Some
+        (timeline_event_json ?next_human_action ~ts_unix ~kind:"transition"
+           ~title:(Printf.sprintf "Transition · %s" event_type)
+           ~summary ~severity ())
+
+let receipt_timeline_event receipt =
+  match json_string_opt_member "ended_at" receipt with
+  | None -> None
+  | Some ended_at ->
+      let ts_unix =
+        Masc_domain.parse_iso8601 ~default_time:0.0 ended_at
+      in
+      if ts_unix <= 0.0 then None
+      else
+        let outcome =
+          json_string_opt_member "outcome" receipt
+          |> Option.value ~default:"unknown"
+        in
+        let tool_contract_result =
+          json_string_opt_member "tool_contract_result" receipt
+          |> Option.value ~default:"unknown"
+        in
+        let cascade_outcome =
+          receipt |> json_member "cascade"
+          |> json_string_opt_member "outcome"
+          |> Option.value ~default:"not_observed"
+        in
+        let error_kind =
+          match json_member "error" receipt with
+          | `Assoc _ as error -> json_string_opt_member "kind" error
+          | _ -> None
+        in
+        let severity =
+          match error_kind with
+          | Some _ -> "bad"
+          | None ->
+              if String.equal tool_contract_result "violated" then "bad"
+              else if
+                String.equal cascade_outcome "passed_to_next_model"
+                || (receipt |> json_member "cascade"
+                    |> json_bool_opt_member "fallback_applied"
+                    |> Option.value ~default:false)
+              then "warn"
+              else "ok"
+        in
+        Some
+          (timeline_event_json
+             ?trace_id:(json_string_opt_member "trace_id" receipt)
+             ?keeper_turn_id:(json_int_opt_member "turn_count" receipt)
+             ?task_id:(json_string_opt_member "current_task_id" receipt)
+             ~goal_ids:(goal_ids_of_json receipt)
+             ~ts_unix ~kind:"execution_receipt"
+             ~title:"Execution Receipt"
+             ~summary:
+               (Printf.sprintf "%s · tool_contract=%s · cascade=%s"
+                  outcome tool_contract_result cascade_outcome)
+             ~severity ())
+
+let blocker_timeline_event ?task_id ?(goal_ids = []) ?trace_id
+    ?observed_at_unix ~ts_unix ~runtime_blocker_fields
+    ~next_human_action ?(observation_only = true) () =
+  let blocker_class = assoc_string_opt "runtime_blocker_class" runtime_blocker_fields in
+  let blocker_summary =
+    assoc_string_opt "runtime_blocker_summary" runtime_blocker_fields
+  in
+  match blocker_class, blocker_summary with
+  | None, None -> None
+  | Some blocker_class, Some summary
+    when String.trim summary <> "" ->
+      Some
+        (timeline_event_json ?trace_id ?task_id ~goal_ids ?next_human_action
+           ?observed_at_unix ~observation_only
+           ~ts_unix ~kind:"runtime_blocker"
+           ~title:"Runtime Blocker"
+           ~summary
+           ~severity:
+             (match blocker_class with
+              | "cascade_exhausted" | "completion_contract_violation" -> "bad"
+              | _ -> "warn")
+           ())
+  | None, Some summary
+    when String.trim summary <> "" ->
+      Some
+        (timeline_event_json ?trace_id ?task_id ~goal_ids ?next_human_action
+           ?observed_at_unix ~observation_only
+           ~ts_unix ~kind:"runtime_blocker"
+           ~title:"Runtime Blocker"
+           ~summary ~severity:"warn" ())
+  | Some blocker_class, None ->
+      Some
+        (timeline_event_json ?trace_id ?task_id ~goal_ids ?next_human_action
+           ?observed_at_unix ~observation_only
+           ~ts_unix ~kind:"runtime_blocker"
+           ~title:"Runtime Blocker"
+           ~summary:blocker_class ~severity:"warn" ())
+  | Some _, Some _ | None, Some _ -> None
+
+
+let latest_tool_call_json ~(keeper_name : string) =
+  Keeper_tool_call_log.read_latest ~keeper_name ()
+
+let pending_approval_json ~(keeper_name : string) =
+  match Keeper_approval_queue.list_pending_dashboard_json () with
+  | `List entries ->
+      entries
+      |> List.filter (fun json ->
+             String.equal keeper_name
+               (Safe_ops.json_string ~default:"" "keeper_name" json))
+      |> List.sort (fun left right ->
+             Float.compare
+               (Safe_ops.json_float ~default:0.0 "requested_at" right)
+               (Safe_ops.json_float ~default:0.0 "requested_at" left))
+      |> fun entries -> `List entries
+  | _ -> `List []
+
+let sort_timeline_events events =
+  List.sort
+    (fun left right ->
+      match
+        Bool.compare
+          (json_bool_opt_member "observation_only" left
+           |> Option.value ~default:false)
+          (json_bool_opt_member "observation_only" right
+           |> Option.value ~default:false)
+      with
+      | 0 ->
+          Float.compare
+            (json_float_opt_member "ts_unix" right |> Option.value ~default:0.0)
+            (json_float_opt_member "ts_unix" left |> Option.value ~default:0.0)
+      | cmp -> cmp)
+    events
+
+let latest_causal_from_timeline = function
+  | `List items -> (
+      match
+        List.find_opt
+          (fun json ->
+             not
+               (json_bool_opt_member "observation_only" json
+                |> Option.value ~default:false))
+          items
+      with
+      | Some event -> event
+      | None -> (
+          match items with
+          | event :: _ -> event
+          | [] -> `Null))
+  | _ -> `Null

--- a/lib/keeper/keeper_runtime_trust_timeline.mli
+++ b/lib/keeper/keeper_runtime_trust_timeline.mli
@@ -1,0 +1,81 @@
+val json_member : string -> Yojson.Safe.t -> Yojson.Safe.t
+
+val json_int_opt_member : string -> Yojson.Safe.t -> int option
+
+val json_float_opt_member : string -> Yojson.Safe.t -> float option
+
+val json_string_opt_member : string -> Yojson.Safe.t -> string option
+
+val json_string_opt_value : Yojson.Safe.t -> string option
+
+val json_bool_opt_member : string -> Yojson.Safe.t -> bool option
+
+val json_string_list_member : string -> Yojson.Safe.t -> string list
+
+val string_list_json : string list -> Yojson.Safe.t
+
+val assoc_bool_default :
+  string -> default:bool -> (string * Yojson.Safe.t) list -> bool
+
+val assoc_string_opt : string -> (string * Yojson.Safe.t) list -> string option
+
+val assoc_json_opt : string -> (string * Yojson.Safe.t) list -> Yojson.Safe.t option
+
+val iso_of_unix_seconds : float -> string
+
+val take : int -> 'a list -> 'a list
+
+val goal_ids_of_json : Yojson.Safe.t -> string list
+
+val keeper_turn_id_of_json : Yojson.Safe.t -> int option
+
+val timeline_event_json :
+  ?trace_id:string ->
+  ?keeper_turn_id:int ->
+  ?task_id:string ->
+  ?goal_ids:string list ->
+  ?next_human_action:string ->
+  ?observed_at_unix:float ->
+  ?observation_only:bool ->
+  ts_unix:float ->
+  kind:string ->
+  title:string ->
+  summary:string ->
+  severity:string ->
+  unit ->
+  Yojson.Safe.t
+
+val tool_call_timeline_event : Yojson.Safe.t -> Yojson.Safe.t option
+
+val is_worktree_tool : string -> bool
+
+val live_pending_approval_timeline_event :
+  Yojson.Safe.t -> Yojson.Safe.t option
+
+val approval_event_timeline_event : Yojson.Safe.t -> Yojson.Safe.t option
+
+val decision_timeline_event : Yojson.Safe.t -> Yojson.Safe.t option
+
+val transition_timeline_event : Yojson.Safe.t -> Yojson.Safe.t option
+
+val receipt_timeline_event : Yojson.Safe.t -> Yojson.Safe.t option
+
+val blocker_timeline_event :
+  ?task_id:string ->
+  ?goal_ids:string list ->
+  ?trace_id:string ->
+  ?observed_at_unix:float ->
+  ts_unix:float ->
+  runtime_blocker_fields:(string * Yojson.Safe.t) list ->
+  next_human_action:string option ->
+  ?observation_only:bool ->
+  unit ->
+  Yojson.Safe.t option
+
+val latest_tool_call_json : keeper_name:string -> Yojson.Safe.t option
+
+val pending_approval_json : keeper_name:string -> Yojson.Safe.t
+
+val sort_timeline_events : Yojson.Safe.t list -> Yojson.Safe.t list
+
+val latest_causal_from_timeline : Yojson.Safe.t -> Yojson.Safe.t

--- a/lib/sse_event/sse_event.ml
+++ b/lib/sse_event/sse_event.ml
@@ -27,7 +27,7 @@ type envelope_meta =
   ; tool_name : string option
   }
 
-(** Replicates [cascade_event_bridge.json_string_opt]:
+(** Replicates [cascade_event_bridge_inference.json_string_opt]:
 
     - [Some "non-empty"] → [`String value]
     - [Some "" \| Some "<whitespace>"] → [`Null]


### PR DESCRIPTION
## Summary
- split runtime trust timeline/event JSON helpers into Keeper_runtime_trust_timeline
- keep Keeper_runtime_trust_snapshot public API unchanged while reducing it below 1k LOC
- preserve selected_model from latest decision telemetry so existing runtime trust snapshot coverage passes

## Stack
- Base PR: #16545 fixes Safe JSON kind-name branches that currently break focused builds on latest main.

## Validation
- ocamlformat --check lib/keeper/keeper_runtime_trust_snapshot.ml lib/keeper/keeper_runtime_trust_timeline.ml lib/keeper/keeper_runtime_trust_timeline.mli lib/dune
- git diff --check
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_runtime_trust_snapshot.exe test/test_dashboard_execution.exe
- ./_build/default/test/test_keeper_runtime_trust_snapshot.exe
- ./_build/default/test/test_dashboard_execution.exe
- MASC_INCLUDE_OPERATOR_CONTROL=true ./_build/default/test/test_operator_control.exe test operator 59
- scripts/ocaml-structure-ratchet.sh
- bash scripts/lint/godfile-size-regression.sh
- scripts/ci/check-determinism-contract.sh