### PR TITLE
feat(voice_config): report received JSON kind+excerpt in 6 parse errors

### DIFF
--- a/lib/voice/voice_config.ml
+++ b/lib/voice/voice_config.ml
@@ -161,12 +161,18 @@ let require_string ~ctx ~field json =
 let require_object ~ctx ~field json =
   match Yojson.Safe.Util.member field json with
   | `Assoc _ as obj -> Ok obj
-  | _ -> Error (Printf.sprintf "%s.%s must be object" ctx field)
+  | other ->
+      Error
+        (Printf.sprintf "%s.%s must be object, got %s: %s" ctx field
+           (Json_util.kind_name other) (Json_util.excerpt other))
 
 let require_list ~ctx ~field json =
   match Yojson.Safe.Util.member field json with
   | `List items -> Ok items
-  | _ -> Error (Printf.sprintf "%s.%s must be array" ctx field)
+  | other ->
+      Error
+        (Printf.sprintf "%s.%s must be array, got %s: %s" ctx field
+           (Json_util.kind_name other) (Json_util.excerpt other))
 
 let endpoint_kind_of_string = function
   | "openai_compat" -> Ok Openai_compat
@@ -252,7 +258,10 @@ let parse_agent_voices json =
       in
       loop [] pairs
   | `Null -> Ok []
-  | _ -> Error "tts.agent_voices must be an object"
+  | other ->
+      Error
+        (Printf.sprintf "tts.agent_voices must be an object, got %s: %s"
+           (Json_util.kind_name other) (Json_util.excerpt other))
 
 let parse_voice_tuning ~ctx json =
   match json with
@@ -268,7 +277,10 @@ let parse_voice_tuning ~ctx json =
         }
   | `Null ->
       Ok { stability = 0.5; similarity_boost = 0.75; style = 0.0 }
-  | _ -> Error (Printf.sprintf "%s must be an object" ctx)
+  | other ->
+      Error
+        (Printf.sprintf "%s must be an object, got %s: %s" ctx
+           (Json_util.kind_name other) (Json_util.excerpt other))
 
 let parse_agent_voice_settings json =
   match Yojson.Safe.Util.member "agent_voice_settings" json with
@@ -282,7 +294,10 @@ let parse_agent_voice_settings json =
       in
       loop [] pairs
   | `Null -> Ok []
-  | _ -> Error "tts.agent_voice_settings must be an object"
+  | other ->
+      Error
+        (Printf.sprintf "tts.agent_voice_settings must be an object, got %s: %s"
+           (Json_util.kind_name other) (Json_util.excerpt other))
 
 let parse_tts json =
   let open Result in
@@ -343,7 +358,10 @@ let parse_local_playback json =
       in
       Ok { enabled; agents }
   | `Null -> Ok { enabled = false; agents = [] }
-  | _ -> Error "root.local_playback must be an object"
+  | other ->
+      Error
+        (Printf.sprintf "root.local_playback must be an object, got %s: %s"
+           (Json_util.kind_name other) (Json_util.excerpt other))
 
 let parse_json json =
   let open Result in


### PR DESCRIPTION
## Why

`voice_config.ml`은 TTS/STT/voice-MCP 런타임 설정 SSOT. 6개 type-shape catch-all이 received kind/excerpt 누락 → operator가 잘못된 config 디버깅 시 raw JSON 직접 grep.

**PR #16375 패턴 일관 적용** (`Json_util.kind_name + Json_util.excerpt`) — sprint Iter#13~#30의 단순 `(received <kind>)` 보다 superior.

## What

| Line | Function | 변경 |
|------|----------|------|
| L164 | `require_object` | wrong-type field `(got <kind>: <excerpt>)` |
| L169 | `require_list` | 동일 |
| L255 | `parse_agent_voices` | non-(Assoc\|Null) 동일 |
| L271 | `parse_voice_tuning` | 동일 |
| L285 | `parse_agent_voice_settings` | 동일 |
| L346 | `parse_local_playback` | 동일 |

## Cohort closure

`lib/voice/voice_config.ml` 내 모든 type-shape mismatch 사이트 6/6. `endpoint.kind` enum mismatch (L171) + non-empty string semantic (L251)은 *semantic constraint*, out of cohort.

## Iter series

FSM/TLA+ observability sweep `/loop 20m` cron `253cc0f6` **iter#34**:
- Silent-failure 도메인에서 진짜 root-fix narrow site 고갈 (대부분 variant disambiguation/documented silent) → received-kind 도메인 복귀
- PR #16375 패턴 일관 채택 (sprint 패턴 통일)
- Sweep 19회째: 1 CONFLICTING (#16403 godfile, 비-sprint)
- 신규 main: #16538 (Iter#33 silent fix), #16539 (RFC-0134 counter-as-fix root fix — sprint와 같은 도메인)

## Workaround Rejection Bar

- [ ] telemetry-as-fix: 아님
- [ ] string classifier 추가: 아님 (variant match 확장)
- [ ] N-of-M: 아님 (file cohort 6/6)
- [ ] catch-all 추가: 아님 (closed match)
- [ ] cap/cooldown/dedup/repair: 아님

## RFC Check

`bash ~/me/scripts/pr-rfc-check.sh` PASS (exit 0).

## Verification

- ocamlformat --check PASS
- Test string equality 비의존
- 1 file, +24 / -6

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>