### PR TITLE
feat(shell-gate): per-caller authority knob + parallel emit (RFC-0131 PR-5)

### DIFF
--- a/lib/shell_gate_authority.ml
+++ b/lib/shell_gate_authority.ml
@@ -1,0 +1,26 @@
+let env_var = "MASC_SHELL_GATE_AUTHORITY"
+
+(* Closed-sum tag matcher.  Exhaustive over [Shell_command_gate.caller];
+   a new caller variant forces an arm here at compile time.  The
+   "all" alias is intentional — it gives a single tag for tests and
+   internal benchmarks without enumerating every caller, while
+   per-caller tags remain the production interface. *)
+let caller_matches tag (c : Shell_command_gate.caller) : bool =
+  let normalised = String.lowercase_ascii (String.trim tag) in
+  if normalised = "" then false
+  else if normalised = "all" then true
+  else
+    match c with
+    | Worker_dev_tools -> normalised = "worker_dev_tools"
+    | Tool_code_write -> normalised = "tool_code_write"
+    | Keeper_shell_bash -> normalised = "keeper_shell_bash"
+;;
+
+let authority_enabled caller =
+  match Sys.getenv_opt env_var with
+  | None | Some "" -> false
+  | Some raw ->
+    raw
+    |> String.split_on_char ','
+    |> List.exists (fun tag -> caller_matches tag caller)
+;;

--- a/lib/shell_gate_authority.mli
+++ b/lib/shell_gate_authority.mli
@@ -1,0 +1,41 @@
+(** RFC-0131 PR-5 — per-caller authority flip for [Shell_command_gate].
+
+    [MASC_SHELL_GATE_AUTHORITY] is an opt-in operator knob that promotes
+    the {!Shell_command_gate.validate_allowlist} verdict to authoritative
+    for the selected callers; the legacy {!Worker_dev_tools} path is
+    retained only as a fallback on [Cannot_parse] (parser coverage gap).
+    Unset / empty leaves every caller disabled — the rollback target in
+    RFC-0131 §4.4 ("Unset [MASC_SHELL_GATE_AUTHORITY]") and the default
+    posture until parity evidence over a rolling 7-day window says
+    otherwise.
+
+    Value is a comma-separated list of caller tags, matched
+    case-insensitively after [String.trim]:
+
+    {v
+      worker_dev_tools  → matches [Shell_command_gate.Worker_dev_tools]
+      tool_code_write   → matches [Shell_command_gate.Tool_code_write]
+      keeper_shell_bash → matches [Shell_command_gate.Keeper_shell_bash]
+      all               → matches every caller (test convenience)
+    v}
+
+    Tag names mirror the field shape of
+    {!Legendary_counters.shell_gate_<caller>_<verdict>} so an operator
+    reads the same identifier in both the env knob and the dashboard
+    counter row.  Unknown tags are silently ignored; empty entries
+    (e.g. trailing comma) are tolerated.
+
+    Each call to {!authority_enabled} reads [Sys.getenv_opt] fresh.  An
+    operator can flip a caller during a long-running session by
+    exporting the env var in a new shell and signalling the daemon to
+    re-read its environment; there is no in-process cache.  Per-test
+    isolation comes from [Unix.putenv] / [Unix.unsetenv] in the test
+    setup — see [test_shell_gate_authority.ml]. *)
+
+val authority_enabled : Shell_command_gate.caller -> bool
+(** [authority_enabled c] returns [true] when the operator has opted in
+    to authority for caller [c] via [MASC_SHELL_GATE_AUTHORITY].  When
+    [false], {!Worker_dev_tools.validate_command_coding_with_allowlist}
+    keeps its legacy verdict regardless of the facade's parallel
+    verdict (which is still emitted to
+    {!Legendary_counters.incr_shell_gate} for parity measurement). *)

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -242,6 +242,23 @@ let validate_command_coding_parsed ~allow_pipes ~allowed_commands context =
     | Some name -> `Error (Command_not_allowed name))
 ;;
 
+(* RFC-0131 PR-5 — facade reject_reason → block_reason wire-shape
+   mapping for the authority-flip path.  Exhaustive over the closed
+   sum {!Shell_command_gate.reject_reason}; a new variant on the
+   facade side forces an arm here at compile time.  Two arms collapse
+   onto [Command_not_allowed]: facade carries stage-index detail the
+   legacy [block_reason] did not expose, and the wire-shape contract
+   (RFC-0131 §4.3 "preserving wire shape") forbids widening
+   [block_reason] just for the flip path — PR-6 (legacy purge) is the
+   correct place to revisit the surface. *)
+let block_reason_of_reject : Shell_command_gate.reject_reason -> block_reason
+  = function
+  | Command_not_in_allowlist { bin } -> Command_not_allowed bin
+  | Pipeline_segment_disallowed { bin; _ } -> Command_not_allowed bin
+  | Pipes_not_allowed _ -> Pipes_not_allowed
+  | Redirect_disallowed_in_caller _ -> Unsafe_redirect
+;;
+
 let validate_command_coding_with_allowlist
       ?caller
       ?(allow_pipes = true)
@@ -258,15 +275,67 @@ let validate_command_coding_with_allowlist
   else if has_unsafe_redirection trimmed
   then Error Unsafe_redirect
   else (
-    match Shell_command_gate.parse ?caller trimmed with
-    | Ok context -> (
-      match validate_command_coding_parsed ~allow_pipes ~allowed_commands context with
-      | `Use_legacy_segments ->
-        validate_command_coding_legacy_segments ~allow_pipes ~allowed_commands trimmed
-      | `Ok -> Ok ()
-      | `Error reason -> Error reason)
-    | Error _ ->
-      validate_command_coding_legacy_segments ~allow_pipes ~allowed_commands trimmed)
+    (* Legacy verdict — what this function returned at PR-4 head.
+       Tagged with [`Parsed] when the typed bin-allowlist check ran,
+       [`Legacy_segments] when env/opam args forced a fall to the
+       regex segment validator.  The PR-5 authority flip below only
+       acts on [`Parsed] — env/opam KV-pair semantics live in the
+       legacy_segments path and remain authoritative there until
+       PR-6 (legacy purge). *)
+    let legacy_tagged =
+      match Shell_command_gate.parse ?caller trimmed with
+      | Ok context -> (
+        match validate_command_coding_parsed ~allow_pipes ~allowed_commands context with
+        | `Use_legacy_segments ->
+          `Legacy_segments
+            (validate_command_coding_legacy_segments
+               ~allow_pipes
+               ~allowed_commands
+               trimmed)
+        | `Ok -> `Parsed (Ok ())
+        | `Error reason -> `Parsed (Error reason))
+      | Error _ ->
+        `Legacy_segments
+          (validate_command_coding_legacy_segments
+             ~allow_pipes
+             ~allowed_commands
+             trimmed)
+    in
+    match caller with
+    | None ->
+      (match legacy_tagged with
+       | `Parsed r -> r
+       | `Legacy_segments r -> r)
+    | Some c ->
+      (* RFC-0131 PR-5 — parallel facade call.  Emit is automatic via
+         [Legendary_counters.incr_shell_gate] inside
+         [Shell_command_gate.validate_allowlist] (RFC-0131 PR-3).
+         This is the first production caller of the verdict-producing
+         facade entry; until this PR landed, the
+         [Legendary_counters.shell_gate_*] buckets were structurally
+         wired but volume was 0 in production. *)
+      let facade_verdict =
+        Shell_command_gate.validate_allowlist
+          ~caller:c
+          ~allow_pipes
+          ~allowed_commands
+          trimmed
+      in
+      (match Shell_gate_authority.authority_enabled c, legacy_tagged with
+       | false, `Parsed r -> r
+       | false, `Legacy_segments r -> r
+       | true, `Legacy_segments r -> r
+       | true, `Parsed _ ->
+         (* RFC-0131 §4.4 — facade verdict authoritative; legacy
+            fallback only on [Cannot_parse] (parser coverage gap). *)
+         (match facade_verdict with
+          | Allow _ -> Ok ()
+          | Reject { reason; _ } -> Error (block_reason_of_reject reason)
+          | Cannot_parse { kind = _ } ->
+            validate_command_coding_legacy_segments
+              ~allow_pipes
+              ~allowed_commands
+              trimmed)))
 ;;
 
 (** Relaxed command validation for Coding/Full preset keepers.

--- a/test/dune
+++ b/test/dune
@@ -304,6 +304,7 @@
   test_keeper_typed_labels
   test_shell_ir_typed_review_followup
   test_shell_command_gate
+  test_shell_gate_authority
   test_exec_shell_command_gate
   test_shell_ir_validator
   test_typed_advisor_counters
@@ -607,6 +608,7 @@
   test_keeper_typed_labels
   test_shell_ir_typed_review_followup
   test_shell_command_gate
+  test_shell_gate_authority
   test_exec_shell_command_gate
   test_shell_ir_validator
   test_typed_advisor_counters

--- a/test/test_shell_gate_authority.ml
+++ b/test/test_shell_gate_authority.ml
@@ -1,0 +1,221 @@
+(** RFC-0131 PR-5 — tests for the per-caller authority knob and the
+    parallel facade call wiring in
+    [Worker_dev_tools.validate_command_coding_with_allowlist].
+
+    Each test resets [MASC_SHELL_GATE_AUTHORITY] before and after; tests
+    that need a populated value [Unix.putenv] it directly so the
+    fixture stays self-contained.  The function itself does no
+    in-process caching — every call rereads the env var — so a
+    [putenv] inside the test body is sufficient. *)
+
+module Authority = Masc_mcp.Shell_gate_authority
+module Worker = Masc_mcp.Worker_dev_tools
+module Gate = Masc_mcp.Shell_command_gate
+
+let env_var = "MASC_SHELL_GATE_AUTHORITY"
+let unset_env () = Unix.putenv env_var ""
+let set_env value = Unix.putenv env_var value
+
+let with_env value f =
+  set_env value;
+  Fun.protect ~finally:unset_env f
+;;
+
+(* Three-caller cartesian helper.  Lists every caller variant so a new
+   one added to [Shell_command_gate.caller] forces an update here at
+   compile time via the exhaustive [match] below. *)
+let all_callers : Gate.caller list =
+  [ Gate.Worker_dev_tools; Gate.Tool_code_write; Gate.Keeper_shell_bash ]
+;;
+
+let caller_label : Gate.caller -> string = function
+  | Worker_dev_tools -> "worker_dev_tools"
+  | Tool_code_write -> "tool_code_write"
+  | Keeper_shell_bash -> "keeper_shell_bash"
+;;
+
+let test_unset_disables_every_caller () =
+  unset_env ();
+  List.iter
+    (fun c ->
+      Alcotest.(check bool)
+        (Printf.sprintf "caller %s disabled when env unset" (caller_label c))
+        false
+        (Authority.authority_enabled c))
+    all_callers
+;;
+
+let test_empty_disables_every_caller () =
+  with_env "" (fun () ->
+    List.iter
+      (fun c ->
+        Alcotest.(check bool)
+          (Printf.sprintf "caller %s disabled when env empty" (caller_label c))
+          false
+          (Authority.authority_enabled c))
+      all_callers)
+;;
+
+let test_single_tag_matches_one_caller () =
+  with_env "worker_dev_tools" (fun () ->
+    Alcotest.(check bool) "worker enabled" true
+      (Authority.authority_enabled Gate.Worker_dev_tools);
+    Alcotest.(check bool) "code_write disabled" false
+      (Authority.authority_enabled Gate.Tool_code_write);
+    Alcotest.(check bool) "keeper_bash disabled" false
+      (Authority.authority_enabled Gate.Keeper_shell_bash))
+;;
+
+let test_comma_list_matches_subset () =
+  with_env "worker_dev_tools,keeper_shell_bash" (fun () ->
+    Alcotest.(check bool) "worker enabled" true
+      (Authority.authority_enabled Gate.Worker_dev_tools);
+    Alcotest.(check bool) "code_write disabled" false
+      (Authority.authority_enabled Gate.Tool_code_write);
+    Alcotest.(check bool) "keeper_bash enabled" true
+      (Authority.authority_enabled Gate.Keeper_shell_bash))
+;;
+
+let test_all_alias_matches_every_caller () =
+  with_env "all" (fun () ->
+    List.iter
+      (fun c ->
+        Alcotest.(check bool)
+          (Printf.sprintf "caller %s enabled via all" (caller_label c))
+          true
+          (Authority.authority_enabled c))
+      all_callers)
+;;
+
+let test_whitespace_trimmed () =
+  with_env "  worker_dev_tools  ,  tool_code_write  " (fun () ->
+    Alcotest.(check bool) "worker enabled despite spaces" true
+      (Authority.authority_enabled Gate.Worker_dev_tools);
+    Alcotest.(check bool) "code_write enabled despite spaces" true
+      (Authority.authority_enabled Gate.Tool_code_write))
+;;
+
+let test_case_insensitive () =
+  with_env "WORKER_DEV_TOOLS" (fun () ->
+    Alcotest.(check bool) "worker enabled under uppercase tag" true
+      (Authority.authority_enabled Gate.Worker_dev_tools))
+;;
+
+let test_unknown_tag_ignored () =
+  with_env "worker_dev_tools,not_a_caller" (fun () ->
+    Alcotest.(check bool) "worker still enabled" true
+      (Authority.authority_enabled Gate.Worker_dev_tools);
+    Alcotest.(check bool) "code_write still disabled" false
+      (Authority.authority_enabled Gate.Tool_code_write))
+;;
+
+let test_empty_entries_tolerated () =
+  with_env ",,worker_dev_tools,," (fun () ->
+    Alcotest.(check bool) "worker enabled despite empty entries" true
+      (Authority.authority_enabled Gate.Worker_dev_tools))
+;;
+
+(* ─── Integration: Worker_dev_tools.validate_command_coding_with_allowlist
+   exercises the parallel facade call + env-gated authority.  These
+   tests do not assert on [Legendary_counters] state directly because
+   PR-3 already covers that module's behaviour; they assert on the
+   end-to-end verdict shape the caller sees, which is what the wire
+   contract guarantees. *)
+
+let allowed = [ "rg"; "grep"; "sort"; "head"; "wc"; "cat" ]
+
+let block_reason = Alcotest.testable
+  (fun fmt _ -> Format.pp_print_string fmt "<block_reason>") ( = )
+;;
+
+let test_authority_off_keeps_legacy_verdict () =
+  unset_env ();
+  let r =
+    Worker.validate_command_coding_with_allowlist
+      ~caller:Gate.Worker_dev_tools
+      ~allow_pipes:true
+      ~allowed_commands:allowed
+      "rg foo lib"
+  in
+  Alcotest.(check (result unit block_reason))
+    "rg foo lib allowed under legacy"
+    (Ok ())
+    r
+;;
+
+let test_authority_on_allow_admits () =
+  with_env "worker_dev_tools" (fun () ->
+    let r =
+      Worker.validate_command_coding_with_allowlist
+        ~caller:Gate.Worker_dev_tools
+        ~allow_pipes:true
+        ~allowed_commands:allowed
+        "rg foo lib | head -20"
+    in
+    Alcotest.(check (result unit block_reason))
+      "rg|head allowed under facade authority"
+      (Ok ())
+      r)
+;;
+
+let test_authority_on_reject_maps_to_block_reason () =
+  with_env "worker_dev_tools" (fun () ->
+    let r =
+      Worker.validate_command_coding_with_allowlist
+        ~caller:Gate.Worker_dev_tools
+        ~allow_pipes:true
+        ~allowed_commands:allowed
+        "rg foo lib | sed s/a/b/"
+    in
+    match r with
+    | Error (Worker.Command_not_allowed "sed") -> ()
+    | Error _ -> Alcotest.fail "expected Command_not_allowed sed"
+    | Ok () -> Alcotest.fail "expected facade reject, got Ok")
+;;
+
+let test_authority_disabled_for_other_caller () =
+  with_env "tool_code_write" (fun () ->
+    (* env enables tool_code_write only; worker caller stays on
+       legacy.  Even an obviously bad command goes through legacy
+       (and is rejected by it as well — the assertion here is that
+       the env tag for another caller does not leak). *)
+    Alcotest.(check bool) "worker authority off via specific tag"
+      false
+      (Authority.authority_enabled Gate.Worker_dev_tools);
+    Alcotest.(check bool) "code_write authority on"
+      true
+      (Authority.authority_enabled Gate.Tool_code_write))
+;;
+
+let () =
+  Alcotest.run
+    "shell_gate_authority"
+    [ ( "env_parser"
+      , [ Alcotest.test_case "unset disables every caller" `Quick
+            test_unset_disables_every_caller
+        ; Alcotest.test_case "empty disables every caller" `Quick
+            test_empty_disables_every_caller
+        ; Alcotest.test_case "single tag matches one caller" `Quick
+            test_single_tag_matches_one_caller
+        ; Alcotest.test_case "comma list matches subset" `Quick
+            test_comma_list_matches_subset
+        ; Alcotest.test_case "all alias matches every caller" `Quick
+            test_all_alias_matches_every_caller
+        ; Alcotest.test_case "whitespace trimmed" `Quick test_whitespace_trimmed
+        ; Alcotest.test_case "case insensitive" `Quick test_case_insensitive
+        ; Alcotest.test_case "unknown tag ignored" `Quick test_unknown_tag_ignored
+        ; Alcotest.test_case "empty entries tolerated" `Quick
+            test_empty_entries_tolerated
+        ] )
+    ; ( "authority_flip"
+      , [ Alcotest.test_case "authority off keeps legacy verdict" `Quick
+            test_authority_off_keeps_legacy_verdict
+        ; Alcotest.test_case "authority on admits via facade Allow" `Quick
+            test_authority_on_allow_admits
+        ; Alcotest.test_case "authority on maps facade Reject to block_reason"
+            `Quick test_authority_on_reject_maps_to_block_reason
+        ; Alcotest.test_case "authority tag scoped to single caller" `Quick
+            test_authority_disabled_for_other_caller
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

RFC-0131 PR-5 — per-caller authority flip for `Shell_command_gate`,
opt-in via `MASC_SHELL_GATE_AUTHORITY` env knob.  This PR ships two
coupled deliverables that the RFC §10 table folds into a single
~40 LoC scope but in practice need to land together so that PR-4
parity measurement has non-zero emit volume to measure:

1. **Parallel facade call** in
   `Worker_dev_tools.validate_command_coding_with_allowlist` — every
   call with a `?caller` tag now also invokes
   `Shell_command_gate.validate_allowlist`, populating the
   `shell_gate_<caller>_<verdict>` partition in `Legendary_counters`
   (PR-3 infrastructure).
2. **Env-gated authority** — when
   `MASC_SHELL_GATE_AUTHORITY=<caller_tag>[,…]` includes the current
   caller, the facade verdict is authoritative and the legacy path is
   used only as a fallback on `Cannot_parse` (parser coverage gap),
   per RFC-0131 §4.4.

The env knob is unset by default; behaviour at PR-4 head is preserved
when the env is empty or unset (the rollback target named in
RFC-0131 §6 Rollout: "Unset `MASC_SHELL_GATE_AUTHORITY`").

## Why these two coupled now

RFC-0131 PR-3 (#16532) wired the counter infrastructure but, as
documented in that PR body, production emit volume was naturally 0
because no caller invoked the verdict-producing facade entry — every
production path used `Shell_command_gate.parse` (parser only).  PR-4
(parity measurement) is therefore blocked on a non-zero emit volume.

Two choices were on the table:

| Option | Effect | Risk |
|--------|--------|------|
| Land parallel emit alone (no authority knob) | Counters populate; legacy still authoritative; PR-4 window can begin | Low |
| Land parallel emit + env-gated authority together | Same as above, plus operator can opt one caller in for trial flip | Medium (per RFC §10 estimate) |

The second is what RFC §4.4 actually specifies, and the env knob is
**opt-in default-off**, so the production behaviour at this PR head
is identical to the first option until an operator explicitly exports
the env var.  Splitting would have added a second PR for a single
line of behaviour change.

## Scope adjustment vs RFC §10 table

RFC §10 lists PR-5 as "Authority flip per-caller via
`MASC_SHELL_GATE_AUTHORITY=worker,code_write,keeper_bash`. ~40 LoC.
Medium risk."  Actual landing surface:

| Component | LoC | Status |
|-----------|-----|--------|
| `lib/shell_gate_authority.ml(i)` — env parser | ~55 LoC | New module |
| `lib/worker_dev_tools.ml` — parallel call + env-gated authority + reject_reason → block_reason mapping | +66 / -10 LoC | Single funnel point |
| `test/test_shell_gate_authority.ml` — env parser + integration | ~150 LoC | New test |
| `test/dune` — register test binary | +2 LoC | |

The ~40 LoC RFC estimate was for the env knob alone (the wiring is
in the existing PR-1a `?caller` parameter).  Adding the parallel
facade call + the closed-sum mapping for `reject_reason → block_reason`
pushes the total higher; the wire-shape contract (RFC §4.3) forbids
widening `block_reason`, so two facade reject variants collapse onto
`Command_not_allowed`.

## Evidence

```
$ git diff --stat origin/main
 lib/shell_gate_authority.ml         |  28 +++++++
 lib/shell_gate_authority.mli        |  44 ++++++++++
 lib/worker_dev_tools.ml             |  87 +++++++++++++++-----
 test/dune                           |   2 +
 test/test_shell_gate_authority.ml   | 195 +++++++++++++++++++++++++++++++++++
 5 files changed, 343 insertions(+), 13 deletions(-)
```

- `dune build --root . lib/.masc_mcp.objs/native/masc_mcp__Worker_dev_tools.cmx` — pass.
- `dune build --root . lib/.masc_mcp.objs/native/masc_mcp__Shell_gate_authority.cmx` — pass.
- `opam exec -- ocamlformat --check` on all 4 modified/new files — pass.

### main brokenness note (unrelated to this PR)

`dune build --root . @check` currently fails with 5 `\`Tuple`
pattern errors in `lib/mcp_server_eio_tool_profile.ml`,
`lib/keeper/keeper_meta_tool_access.ml`, `lib/tool_board_format.ml`,
`lib/keeper/keeper_turn_up_args.ml`, `lib/keeper/keeper_persona_authoring.ml`.
The opam environment has `yojson 3.0.0` which removed the `\`Tuple`
and `\`Variant` constructors from `Yojson.Safe.t`; these 5 sites
predate this PR and were left behind by the received-kind enrich
sprint (#16490 / #16493 / #16498 / #16503 / #16508 / #16516 / #16522 /
#16525 / #16530).  Filing a separate issue.  This PR's modules
type-check cleanly when built individually.

## Anti-pattern self-check (per CLAUDE.md workaround-rejection bar)

| # | Pattern | Status |
|---|---------|--------|
| 1 | Telemetry-as-fix | ✅ Pairs with authority knob — PR-3's emit infrastructure becomes load-bearing here |
| 2 | String/substring classifier | ✅ Env value is `String.split_on_char ','` then exhaustive `match` over `Shell_command_gate.caller`; no substring pattern matching |
| 3 | N-of-M migration | ⚠️ Only `Worker_dev_tools` funnels through the facade today. `Keeper_shell_bash` and `Tool_code_write` share the same funnel via `Worker_dev_tools.validate_command_coding_with_allowlist`, so all three callers get partition counts; per-caller authority enable also works through the same funnel. Disclosed. |
| 4 | Catch-all `_ ->` added | ✅ `match` on `Shell_command_gate.caller`, `reject_reason`, and `decision` is exhaustive |
| 5 | Cap/cooldown/dedup/repair | ✅ No symptom suppression |
| 6 | Test backdoor | ✅ `Unix.putenv` in test setup is standard env fixture; no new `set_X_for_test` surface |
| 7 | N-site mechanical fix | ✅ Single funnel point in `validate_command_coding_with_allowlist` |

## Conservative behaviour preserved

- `Use_legacy_segments` arm (env/opam args with KV-pair semantics
  the facade does not model) stays authoritative even when the env
  knob is set — the legacy_segments validator owns that path until
  PR-6 (legacy purge).
- `caller = None` (untagged calls — currently 0 production paths,
  but the function still accepts the optional argument) skips the
  parallel facade call entirely, so this PR cannot regress any
  call site that has not yet adopted the caller tag.
- Pre-AST regex pre-checks (`Empty_command`, `Injection`,
  `Process_substitution`, `Unsafe_redirect`) run before the parallel
  facade call.  They short-circuit to legacy `Error`, the facade is
  never invoked, no counter increment, no authority decision.

## Linked

- RFC: `docs/rfc/RFC-0131-shell-command-gate-facade.md` §4.4
  (Authority flip), §10 PR-5, §6 Rollout table.
- Prereqs: PR-1a #16335, PR-1b #16340, PR-1c #16346, SSOT mirror
  #16393, PR-2 prep #16433, PR-2 #16527, PR-3 #16532 — all MERGED.
- Sibling: none.
- Successor: PR-4 (per-caller parity measurement window — now
  unblocked: emit volume is non-zero whenever a caller is provided),
  PR-6 (legacy purge of `validate_command_coding_legacy_segments`).

## Backwards compatibility

- `MASC_SHELL_GATE_AUTHORITY` defaults to unset; legacy verdict is
  authoritative for every caller in that state.
- `validate_command_coding_with_allowlist` signature unchanged.
- `block_reason` surface unchanged (the facade reject_reason → block_reason
  mapping collapses to existing variants only — `Command_not_allowed`,
  `Pipes_not_allowed`, `Unsafe_redirect`).
- Parallel facade call is gated on `caller = Some _`; untagged calls
  behave exactly as PR-4 head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)