### PR TITLE
feat(dashboard): surface runtime_blocker_class + widen text row for keeper cards

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -87,12 +87,25 @@ function rosterContextMeta(
 function rosterStateNote(
   keeper: {
     runtime_blocker_summary?: string | null
+    runtime_blocker_class?: string | null
     diagnostic?: { last_error?: string | null } | null
   } | null | undefined,
   monitoringHint?: string | null,
-): { label: string; text: string } | null {
+): { label: string; text: string; kind?: string } | null {
   const runtimeBlocker = keeper?.runtime_blocker_summary?.trim()
-  if (runtimeBlocker) return { label: '현재 차단', text: runtimeBlocker }
+  const blockerClass = keeper?.runtime_blocker_class?.trim() || undefined
+  if (runtimeBlocker) {
+    return { label: '현재 차단', text: runtimeBlocker, kind: blockerClass }
+  }
+  // Class without summary: surface the typed kind so operators still see *why*
+  // (e.g. "heartbeat_failures") instead of an unlabelled '현재 차단' badge.
+  if (blockerClass) {
+    return {
+      label: '현재 차단',
+      text: `차단 종류: ${blockerClass} (요약 메시지 없음)`,
+      kind: blockerClass,
+    }
+  }
 
   const diagnosticError = keeper?.diagnostic?.last_error?.trim()
   if (diagnosticError) return { label: '최근 오류', text: diagnosticError }
@@ -720,16 +733,23 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
               <p class="m-0 text-sm leading-paragraph text-[var(--color-fg-primary)] break-words line-clamp-2" title=${summaryText}>${summaryText}</p>
 
               ${stateNote ? html`
-                <div class="flex flex-wrap items-center gap-2 text-2xs text-[var(--color-fg-muted)]">
-                  <span class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-0.5 text-3xs font-semibold text-[var(--color-status-warn)]">
-                    ${stateNote.label}
-                  </span>
-                  ${lastActivityAt
-                    ? html`<span class="text-3xs text-[var(--color-fg-muted)]">최근 신호 · ${lastActivityLabel} <${TimeAgo} timestamp=${lastActivityAt} /></span>`
-                    : lastActivityAge != null
-                      ? html`<span class="text-3xs text-[var(--color-fg-muted)]">최근 신호 · ${lastActivityLabel} ${formatDuration(lastActivityAge)} 전</span>`
-                    : null}
-                  <span class="min-w-0 flex-1 text-xs leading-relaxed text-[var(--color-fg-primary)] break-words line-clamp-2" title=${stateNote.text}>
+                <div class="flex flex-col gap-1 text-2xs text-[var(--color-fg-muted)]">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <span class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-0.5 text-3xs font-semibold text-[var(--color-status-warn)]">
+                      ${stateNote.label}
+                    </span>
+                    ${stateNote.kind
+                      ? html`<span class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--color-border-divider)] bg-[var(--color-bg-page)] px-2 py-0.5 text-3xs font-mono text-[var(--color-fg-primary)]" title="runtime_blocker_class">
+                          ${stateNote.kind}
+                        </span>`
+                      : null}
+                    ${lastActivityAt
+                      ? html`<span class="text-3xs text-[var(--color-fg-muted)]">최근 신호 · ${lastActivityLabel} <${TimeAgo} timestamp=${lastActivityAt} /></span>`
+                      : lastActivityAge != null
+                        ? html`<span class="text-3xs text-[var(--color-fg-muted)]">최근 신호 · ${lastActivityLabel} ${formatDuration(lastActivityAge)} 전</span>`
+                        : null}
+                  </div>
+                  <span class="block text-xs leading-relaxed text-[var(--color-fg-primary)] break-words line-clamp-3" title=${stateNote.text}>
                     ${stateNote.text}
                   </span>
                 </div>


### PR DESCRIPTION
## Why

**User-reported issue (Agent Observatory screenshot)**:
> "현재 차단" 이 뭔 말인지 왜 계속 차단인지 ㅋㅋ

매 keeper card에 노란 `현재 차단` 뱃지만 보이고 *왜* 차단됐는지 안 보임. 두 가지 origin:

1. **Layout truncation**: `stateNote.text` (= `runtime_blocker_summary`)가 `flex-wrap` row 3번째 column 안에 `line-clamp-2`로 들어가 매우 좁은 폭에서 *완전히 가려짐*. Backend는 풍부한 actionable string 생성 ("Heartbeat failed 3 consecutive cycle(s); supervisor recovery is required.") — UI에서 보이지 않을 뿐.

2. **Class-without-summary silent skip**: `runtime_blocker_class` field가 set인데 `runtime_blocker_summary`가 empty/null이면 `rosterStateNote`가 silent하게 *next branch*로 폴백 → 결과적으로 `현재 차단` 라벨이 보이지만 정보 0.

## What

### 1. `rosterStateNote` enrich (lines 87-117)

```diff
-): { label: string; text: string } | null {
+): { label: string; text: string; kind?: string } | null {
   const runtimeBlocker = keeper?.runtime_blocker_summary?.trim()
+  const blockerClass = keeper?.runtime_blocker_class?.trim() || undefined
   if (runtimeBlocker) {
-    return { label: '현재 차단', text: runtimeBlocker }
+    return { label: '현재 차단', text: runtimeBlocker, kind: blockerClass }
+  }
+  if (blockerClass) {
+    return {
+      label: '현재 차단',
+      text: `차단 종류: ${blockerClass} (요약 메시지 없음)`,
+      kind: blockerClass,
+    }
   }
```

### 2. Card renderer two-row layout

- **Row 1 (chips)**: `[현재 차단]` label + **monospace `kind` badge** (e.g. `heartbeat_failures`) + activity timestamp
- **Row 2 (full-width text)**: summary message with `line-clamp-3` (이전 line-clamp-2에서 확장), `block` display로 column 압박 없이 fully visible

## Effect (UI)

| Before | After |
|--------|-------|
| `[현재 차단] 최근 신호 · 하트비트 2분 전 (text 거의 안 보임)` | `[현재 차단] [heartbeat_failures] 최근 신호 · 2분 전` |
| ↑ — | `Heartbeat failed 3 consecutive cycle(s); supervisor recovery is required.` |

## Iter series

FSM/TLA+ observability sweep `/loop 20m` cron `253cc0f6` **iter#35**:
- 사용자가 스크린샷으로 직접 보고한 dashboard clarity issue → sprint goal "대시보드도 같이 개선" 직격
- Backend `keeper_status_bridge.runtime_blocker_surface_of_*` 가 이미 풍부한 actionable summary 생성 — UI 시각화만 부족했음
- Sweep 20회째: 1 CONFLICTING (#16403, 비-sprint)

## Workaround Rejection Bar

- [ ] telemetry-as-fix: 아님 (UI surface 변경, backend는 그대로)
- [ ] string classifier 추가: 아님 (이미 typed `runtime_blocker_class` 활용)
- [ ] N-of-M: 아님 (`agent-roster.ts` 단일 surface)
- [ ] catch-all 추가: 아님

## RFC Check

`bash ~/me/scripts/pr-rfc-check.sh` PASS (exit 0). `dashboard/src/components/agent-roster.ts` — `credential-settings` / `keeper-repo-mapping` 무관.

## Verification

- TypeScript syntax: optional field 추가 + JSX layout (compile 확인 worktree에 node_modules 없음 — main branch에 머지 후 CI 빌드 검증).
- Backend producer 변경 0 (UI consumer 측 개선만).
- 다른 caller 영향 0 (`rosterStateNote`는 본 파일 내부 함수, return type 확장 — 기존 caller가 `kind?`를 ignore 가능).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>