### PR TITLE
refactor: split cascade event inference helpers

### DIFF
--- a/lib/cascade/cascade_event_bridge.ml
+++ b/lib/cascade/cascade_event_bridge.ml
@@ -17,121 +17,12 @@
     @modified 2.255.0 — accept OAS native events (#5620)
     @modified 2.260.0 — emit envelope correlation_id/run_id (oas#845) *)
 
+open Cascade_event_bridge_inference
+
 (** Drain interval: how often we poll the Event_bus subscription.
     Lower default keeps the dashboard close to real-time, while staying
     runtime-tunable for quieter deployments. *)
 let drain_interval_s () = Env_config.Oas_sse.drain_interval_sec
-
-let json_string_opt = function
-  | Some value when String.trim value <> "" -> `String value
-  | _ -> `Null
-;;
-
-let payload_string_opt key = function
-  | `Assoc fields ->
-    (match List.assoc_opt key fields with
-     | Some (`String value) when String.trim value <> "" -> Some value
-     | _ -> None)
-  | _ -> None
-;;
-
-let payload_int_opt key = function
-  | `Assoc fields ->
-    (match List.assoc_opt key fields with
-     | Some (`Int value) -> Some value
-     | Some (`Intlit value) -> int_of_string_opt value
-     | _ -> None)
-  | _ -> None
-;;
-
-let inference_model_bucket ~provider ~model =
-  let has needle =
-    String_util.contains_substring_ci provider needle
-    || String_util.contains_substring_ci model needle
-  in
-  if has "kimi"
-  then "kimi"
-  else if has "claude" || has "anthropic"
-  then "anthropic"
-  else if has "openai" || has "gpt" || has "codex"
-  then "openai"
-  else if has "gemini" || has "google"
-  then "gemini"
-  else if has "glm" || has "zai"
-  then "glm"
-  else if has "qwen"
-  then "qwen"
-  else if has "llama"
-  then "llama"
-  else "other"
-;;
-
-let inference_provider_bucket ~provider ~model =
-  let provider = String.trim provider in
-  if provider = ""
-  then inference_model_bucket ~provider ~model
-  else inference_model_bucket ~provider ~model:""
-;;
-
-let positive_finite value =
-  value > 0.0
-  &&
-  match classify_float value with
-  | FP_nan | FP_infinite -> false
-  | FP_normal | FP_subnormal | FP_zero -> true
-;;
-
-let tok_per_sec_from_ms ~tokens ~ms =
-  match tokens, ms with
-  | Some tokens, Some ms when tokens > 0 && positive_finite ms ->
-    Some (float_of_int tokens /. (ms /. 1000.0))
-  | _ -> None
-;;
-
-let observe_inference_rate metric ~model_bucket = function
-  | Some rate when positive_finite rate ->
-    Prometheus.observe_histogram metric ~labels:[ "model_bucket", model_bucket ] rate
-  | _ -> ()
-;;
-
-let observe_inference_telemetry
-      ~provider
-      ~model
-      ~prompt_tokens
-      ~completion_tokens
-      ~prompt_ms
-      ~decode_ms
-      ~decode_tok_s
-  =
-  let model_bucket = inference_model_bucket ~provider ~model in
-  (* Token counts are NOT emitted here.  The authoritative per-request
-     token counter is [on_token_usage] → [Llm_metric_bridge.emit_token_usage]
-     with precise {provider, model} labels.  This function retains only
-     the latency/rate metrics (prompt_tok/s, decode_tok/s) that are
-     unique to the [InferenceTelemetry] event payload. *)
-  observe_inference_rate
-    Prometheus.metric_oas_inference_prompt_tok_per_sec
-    ~model_bucket
-    (tok_per_sec_from_ms ~tokens:prompt_tokens ~ms:prompt_ms);
-  let decode_tok_s =
-    match decode_tok_s with
-    | Some rate when positive_finite rate -> Some rate
-    | _ -> tok_per_sec_from_ms ~tokens:completion_tokens ~ms:decode_ms
-  in
-  observe_inference_rate
-    Prometheus.metric_oas_inference_decode_tok_per_sec
-    ~model_bucket
-    decode_tok_s
-;;
-
-let observe_inference_cost ~provider ~model_bucket = function
-  | Some cost when positive_finite cost ->
-    Prometheus.observe_histogram
-      Prometheus.metric_oas_inference_cost_usd
-      ~labels:[ "provider", provider; "model_bucket", model_bucket ]
-      cost
-  | _ -> ()
-;;
 
 let stop_reason_to_wire = function
   | Agent_sdk.Types.EndTurn -> "end_turn"

--- a/lib/cascade/cascade_event_bridge_inference.ml
+++ b/lib/cascade/cascade_event_bridge_inference.ml
@@ -1,0 +1,110 @@
+let json_string_opt = function
+  | Some value when String.trim value <> "" -> `String value
+  | _ -> `Null
+;;
+
+let payload_string_opt key = function
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`String value) when String.trim value <> "" -> Some value
+     | _ -> None)
+  | _ -> None
+;;
+
+let payload_int_opt key = function
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`Int value) -> Some value
+     | Some (`Intlit value) -> int_of_string_opt value
+     | _ -> None)
+  | _ -> None
+;;
+
+let inference_model_bucket ~provider ~model =
+  let has needle =
+    String_util.contains_substring_ci provider needle
+    || String_util.contains_substring_ci model needle
+  in
+  if has "kimi"
+  then "kimi"
+  else if has "claude" || has "anthropic"
+  then "anthropic"
+  else if has "openai" || has "gpt" || has "codex"
+  then "openai"
+  else if has "gemini" || has "google"
+  then "gemini"
+  else if has "glm" || has "zai"
+  then "glm"
+  else if has "qwen"
+  then "qwen"
+  else if has "llama"
+  then "llama"
+  else "other"
+;;
+
+let inference_provider_bucket ~provider ~model =
+  let provider = String.trim provider in
+  if provider = ""
+  then inference_model_bucket ~provider ~model
+  else inference_model_bucket ~provider ~model:""
+;;
+
+let positive_finite value =
+  value > 0.0
+  &&
+  match classify_float value with
+  | FP_nan | FP_infinite -> false
+  | FP_normal | FP_subnormal | FP_zero -> true
+;;
+
+let tok_per_sec_from_ms ~tokens ~ms =
+  match tokens, ms with
+  | Some tokens, Some ms when tokens > 0 && positive_finite ms ->
+    Some (float_of_int tokens /. (ms /. 1000.0))
+  | _ -> None
+;;
+
+let observe_inference_rate metric ~model_bucket = function
+  | Some rate when positive_finite rate ->
+    Prometheus.observe_histogram metric ~labels:[ "model_bucket", model_bucket ] rate
+  | _ -> ()
+;;
+
+let observe_inference_telemetry
+      ~provider
+      ~model
+      ~prompt_tokens
+      ~completion_tokens
+      ~prompt_ms
+      ~decode_ms
+      ~decode_tok_s
+  =
+  let model_bucket = inference_model_bucket ~provider ~model in
+  (* Token counts are NOT emitted here.  The authoritative per-request
+     token counter is [on_token_usage] -> [Llm_metric_bridge.emit_token_usage]
+     with precise {provider, model} labels.  This function retains only
+     the latency/rate metrics (prompt_tok/s, decode_tok/s) that are
+     unique to the [InferenceTelemetry] event payload. *)
+  observe_inference_rate
+    Prometheus.metric_oas_inference_prompt_tok_per_sec
+    ~model_bucket
+    (tok_per_sec_from_ms ~tokens:prompt_tokens ~ms:prompt_ms);
+  let decode_tok_s =
+    match decode_tok_s with
+    | Some rate when positive_finite rate -> Some rate
+    | _ -> tok_per_sec_from_ms ~tokens:completion_tokens ~ms:decode_ms
+  in
+  observe_inference_rate
+    Prometheus.metric_oas_inference_decode_tok_per_sec
+    ~model_bucket
+    decode_tok_s
+;;
+
+let observe_inference_cost ~provider ~model_bucket = function
+  | Some cost when positive_finite cost ->
+    Prometheus.observe_histogram
+      Prometheus.metric_oas_inference_cost_usd
+      ~labels:[ "provider", provider; "model_bucket", model_bucket ]
+      cost
+  | _ -> ()
+;;

--- a/lib/cascade/cascade_event_bridge_inference.mli
+++ b/lib/cascade/cascade_event_bridge_inference.mli
@@ -1,0 +1,22 @@
+val json_string_opt : string option -> Yojson.Safe.t
+
+val payload_string_opt : string -> Yojson.Safe.t -> string option
+
+val payload_int_opt : string -> Yojson.Safe.t -> int option
+
+val inference_model_bucket : provider:string -> model:string -> string
+
+val inference_provider_bucket : provider:string -> model:string -> string
+
+val observe_inference_telemetry :
+  provider:string ->
+  model:string ->
+  prompt_tokens:int option ->
+  completion_tokens:int option ->
+  prompt_ms:float option ->
+  decode_ms:float option ->
+  decode_tok_s:float option ->
+  unit
+
+val observe_inference_cost :
+  provider:string -> model_bucket:string -> float option -> unit

--- a/lib/dune
+++ b/lib/dune
@@ -197,6 +197,7 @@
   provider_runtime_projection
   voice_bridge_transport
   cascade_wire_overlay
+  cascade_event_bridge_inference
   cascade_http_probe_url
   cascade_agent_context
   cascade_health_tracker_config
@@ -422,7 +423,8 @@
    masc_mcp.dashboard_eval_feed
    ;; RFC-0004 Phase A0.1 PR-1 — Typed SSE event lib (lib/sse_event/).
    ;; atdgen-generated payload types + hand-rolled envelope wrap that
-   ;; mirrors cascade_event_bridge.wrap_event/json_string_opt
+   ;; mirrors cascade_event_bridge.wrap_event and
+   ;; cascade_event_bridge_inference.json_string_opt
    ;; semantics.  PR-2 onwards: cascade_event_bridge arms call into
    ;; Sse_event.<event>_constructor instead of inline `Assoc.
    masc_mcp.sse_event

--- a/lib/sse_event/sse_event.ml
+++ b/lib/sse_event/sse_event.ml
@@ -27,7 +27,7 @@ type envelope_meta =
   ; tool_name : string option
   }
 
-(** Replicates [cascade_event_bridge.json_string_opt]:
+(** Replicates [cascade_event_bridge_inference.json_string_opt]:
 
     - [Some "non-empty"] → [`String value]
     - [Some "" \| Some "<whitespace>"] → [`Null]


### PR DESCRIPTION
## Summary
- split cascade event bridge payload/inference helper functions into Cascade_event_bridge_inference
- keep native_event_to_json and public bridge API unchanged
- update comments that reference the moved json_string_opt helper

## Stack
- Base PR: #16540 runtime trust timeline split
- Underlying build-fix PR: #16545 Safe JSON kind-name fix

## Validation
- ocamlformat --check lib/cascade/cascade_event_bridge.ml lib/cascade/cascade_event_bridge_inference.ml lib/cascade/cascade_event_bridge_inference.mli lib/sse_event/sse_event.ml lib/dune
- git diff --check
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_oas_integration.exe test/sse_event/test_sse_event.exe
- ./_build/default/test/sse_event/test_sse_event.exe
- ./_build/default/test/test_oas_integration.exe test oas_events 9-24
- scripts/ocaml-structure-ratchet.sh
- bash scripts/lint/godfile-size-regression.sh
- scripts/ci/check-determinism-contract.sh