### PR TITLE
fix: route raw gh pr bash to native tools

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -24,6 +24,83 @@ let elapsed_duration_ms ~start_time ~end_time =
 let string_contains_char s ch = String.exists (Char.equal ch) s
 let string_contains_substring s needle = String_util.contains_substring s needle
 
+type native_tool_hint = {
+  rule_id : string;
+  tool_suggestion : string;
+  rewrite : string;
+  hint : string;
+  alternatives : string list;
+}
+
+let gh_pr_native_tool_hint cmd =
+  let make ~rule_id ~tool_suggestion ~rewrite ~hint ~alternatives =
+    Some { rule_id; tool_suggestion; rewrite; hint; alternatives }
+  in
+  match cmd_gh_pr_native_subcommand cmd with
+  | Some Gh_pr_list ->
+    make
+      ~rule_id:"gh_pr_list_requires_keeper_pr_list"
+      ~tool_suggestion:"keeper_pr_list"
+      ~rewrite:"Use keeper_pr_list with the same repo/state/search intent."
+      ~hint:
+        "Do not call gh pr list through keeper_bash. Use keeper_pr_list so PR \
+         reads are routed through the native PR tool surface."
+      ~alternatives:
+        [ "keeper_pr_list repo=OWNER/REPO state=open"
+        ; "keeper_pr_list repo=OWNER/REPO search=term"
+        ]
+  | Some Gh_pr_status ->
+    make
+      ~rule_id:"gh_pr_status_requires_keeper_pr_status"
+      ~tool_suggestion:"keeper_pr_status"
+      ~rewrite:"Use keeper_pr_status for PR state, checks, draft state, and mergeability."
+      ~hint:
+        "Do not call gh pr view/status/checks through keeper_bash. Use \
+         keeper_pr_status so PR status reads are captured by the native PR \
+         receipt path."
+      ~alternatives:
+        [ "keeper_pr_status pr=NUMBER repo=OWNER/REPO"
+        ; "keeper_pr_status head=BRANCH repo=OWNER/REPO"
+        ]
+  | Some Gh_pr_diff ->
+    make
+      ~rule_id:"gh_pr_diff_requires_keeper_pr_review_read"
+      ~tool_suggestion:"keeper_pr_review_read"
+      ~rewrite:"Use keeper_pr_review_read for PR diff/review context reads."
+      ~hint:
+        "Do not call gh pr diff through keeper_bash. Use \
+         keeper_pr_review_read so review context is read through the PR review \
+         tool surface."
+      ~alternatives:
+        [ "keeper_pr_review_read pr=NUMBER repo=OWNER/REPO"
+        ; "keeper_pr_status pr=NUMBER repo=OWNER/REPO"
+        ]
+  | Some Gh_pr_review ->
+    make
+      ~rule_id:"gh_pr_review_requires_keeper_pr_review_comment"
+      ~tool_suggestion:"keeper_pr_review_comment"
+      ~rewrite:"Use keeper_pr_review_comment for PR review comments or review actions."
+      ~hint:
+        "Do not call gh pr review/comment through keeper_bash. Use \
+         keeper_pr_review_comment so review actions keep approval and audit \
+         receipts."
+      ~alternatives:
+        [ "keeper_pr_review_comment pr=NUMBER repo=OWNER/REPO body=..."
+        ; "keeper_pr_review_read pr=NUMBER repo=OWNER/REPO"
+        ]
+  | None -> None
+;;
+
+let native_tool_diagnosis hint =
+  { Exec_core.rule_id = hint.rule_id
+  ; explanation =
+      "Raw GitHub PR commands are blocked in keeper_bash; the native PR tool \
+       surface preserves routing, audit, and retry receipts."
+  ; rewrite = Some hint.rewrite
+  ; tool_suggestion = Some hint.tool_suggestion
+  }
+;;
+
 let has_malformed_dev_null_redirect_token scan_text =
   scan_text
   |> String.split_on_char ' '
@@ -957,6 +1034,25 @@ let handle_keeper_bash
          ; "cmd", `String cmd_for_log
          ])
   in
+  let native_pr_command_block hint =
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_shell_bash_failures
+      ~labels:[("keeper", meta.name); ("site", "gh_pr_native_tool")]
+      ();
+    Log.Keeper.warn
+      "keeper_bash gh pr command routed to native tool: keeper=%s rule=%s cmd=%s"
+      meta.name hint.rule_id cmd_for_log;
+    Yojson.Safe.to_string
+      (Exec_core.blocked_result_json
+         ~cmd
+         ~error:"command_blocked"
+         ~reason:"Raw GitHub PR commands must use the native PR tool surface."
+         ~hint:hint.hint
+         ~alternatives:hint.alternatives
+         ~diag:(Some (native_tool_diagnosis hint))
+         ~extra:[ "cmd", `String cmd_for_log; "execution_time_ms", `Int 0 ]
+         ())
+  in
   let direct_tool_command_block ~tool_policy_visible tool_name =
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_shell_bash_failures
@@ -1061,6 +1157,10 @@ let handle_keeper_bash
     | Some (tool_name, tool_policy_visible) ->
       direct_tool_command_block ~tool_policy_visible tool_name
     | None when cmd_contains_gh_pr_create cmd -> gh_pr_create_block ()
+    | None when Option.is_some (gh_pr_native_tool_hint cmd) ->
+      (match gh_pr_native_tool_hint cmd with
+       | Some hint -> native_pr_command_block hint
+       | None -> error_json "internal native PR command hint mismatch")
     | None when Task_probe.mentions_task_state_file cmd ->
       task_state_file_probe_block ()
     | None when Task_probe.looks_like_http_probe cmd ->
@@ -1536,12 +1636,19 @@ let handle_keeper_bash
       match validate validation_cmd with
       | Error reason ->
         let reason_str = Worker_dev_tools.block_reason_to_string reason in
+        let native_tool_hint =
+          match reason with
+          | Worker_dev_tools.Command_not_allowed name
+            when String_util.equals_ci name "gh" ->
+            gh_pr_native_tool_hint cmd
+          | _ -> None
+        in
         Prometheus.inc_counter
           Keeper_metrics.metric_keeper_shell_bash_failures
           ~labels:[("site", "generic_blocked")]
           ();
         Log.Keeper.warn "keeper_bash blocked: %s (cmd=%s)" reason_str cmd_for_log;
-        let hint =
+        let default_hint =
           match reason with
           | Worker_dev_tools.Command_not_allowed name
             when String_util.equals_ci name "gh" ->
@@ -1555,10 +1662,14 @@ let handle_keeper_bash
             "Avoid shell metacharacters. Use keeper_shell with a specific op (rg, find, ls) instead."
           | Command_not_allowed _ ->
             "Check the command for blocked patterns. Use keeper_shell for structured ops (rg, ls, find)."
-          | Empty_command ->
-            "Provide a non-empty command string."
+          | Empty_command -> "Provide a non-empty command string."
         in
-        let alternatives =
+        let hint =
+          match native_tool_hint with
+          | Some hint -> hint.hint
+          | None -> default_hint
+        in
+        let default_alternatives =
           match reason with
           | Worker_dev_tools.Command_not_allowed name
             when String_util.equals_ci name "gh" ->
@@ -1586,6 +1697,16 @@ let handle_keeper_bash
             ; "Example: keeper_bash cmd='ls -la lib/'."
             ]
         in
+        let alternatives =
+          match native_tool_hint with
+          | Some hint -> hint.alternatives
+          | None -> default_alternatives
+        in
+        let diag =
+          match native_tool_hint with
+          | Some hint -> Some (native_tool_diagnosis hint)
+          | None -> Keeper_shell_shared.diagnosis_of_block_reason reason
+        in
         Yojson.Safe.to_string
           (Exec_core.blocked_result_json
              ~cmd
@@ -1593,7 +1714,7 @@ let handle_keeper_bash
              ~reason:reason_str
              ~hint
              ~alternatives
-             ~diag:(Keeper_shell_shared.diagnosis_of_block_reason reason)
+             ~diag
              ~extra:[ "execution_time_ms", `Int 0 ]
              ~env_snapshot:env_snap
              ())

--- a/lib/keeper/keeper_shell_bash_words.ml
+++ b/lib/keeper/keeper_shell_bash_words.ml
@@ -167,6 +167,41 @@ let gh_pr_create_sequence = function
     && String.equal create.text "create"
   | _ -> false
 
+type gh_pr_native_subcommand =
+  | Gh_pr_list
+  | Gh_pr_status
+  | Gh_pr_diff
+  | Gh_pr_review
+
+let gh_pr_native_subcommand_sequence = function
+  | gh :: pr :: subcommand :: _
+    when String.equal (command_name gh.text) "gh"
+         && String.equal pr.text "pr" ->
+    (match subcommand.text with
+     | "list" -> Some Gh_pr_list
+     | "view" | "status" | "checks" -> Some Gh_pr_status
+     | "diff" -> Some Gh_pr_diff
+     | "review" | "comment" -> Some Gh_pr_review
+     | _ -> None)
+  | _ -> None
+
+let rec cmd_gh_pr_native_subcommand cmd =
+  let words = shell_words_with_boundaries cmd in
+  let rec loop = function
+    | word :: rest when word.starts_command ->
+      (match gh_pr_native_subcommand_sequence (strip_command_wrappers (word :: rest)) with
+       | Some _ as hit -> hit
+       | None -> loop rest)
+    | _ :: rest -> loop rest
+    | [] -> None
+  in
+  match loop words with
+  | Some _ as hit -> hit
+  | None ->
+    (match shell_c_payload words with
+     | Some payload -> cmd_gh_pr_native_subcommand payload
+     | None -> None)
+
 let rec cmd_contains_gh_pr_create cmd =
   let words = shell_words_with_boundaries cmd in
   let rec loop = function

--- a/lib/keeper/keeper_shell_bash_words.mli
+++ b/lib/keeper/keeper_shell_bash_words.mli
@@ -13,4 +13,12 @@ val strip_command_wrappers : shell_word list -> shell_word list
 val direct_tool_command_name :
   meta:Keeper_types.keeper_meta -> string -> (string * bool) option
 
+type gh_pr_native_subcommand =
+  | Gh_pr_list
+  | Gh_pr_status
+  | Gh_pr_diff
+  | Gh_pr_review
+
+val cmd_gh_pr_native_subcommand : string -> gh_pr_native_subcommand option
+
 val cmd_contains_gh_pr_create : string -> bool

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -12,6 +12,7 @@ module Keeper_exec_shell = Masc_mcp.Keeper_exec_shell
 module Keeper_registry = Masc_mcp.Keeper_registry
 module Keeper_sandbox = Masc_mcp.Keeper_sandbox
 module Keeper_shell_docker = Masc_mcp.Keeper_shell_docker
+module Keeper_shell_words = Masc_mcp.Keeper_shell_bash_words
 module Keeper_types = Masc_mcp.Keeper_types
 module Json = Yojson.Safe.Util
 
@@ -1827,6 +1828,52 @@ let test_bash_blocks_direct_masc_tool_command () =
     false
     (Json.member "tool_policy_visible" json |> Json.to_bool)
 
+let test_bash_blocks_gh_pr_list_with_native_pr_hint () =
+  with_eio_fs @@ fun () ->
+  Alcotest.(check bool)
+    "prose is not a native PR command"
+    true
+    (Option.is_none
+       (Keeper_shell_words.cmd_gh_pr_native_subcommand "echo gh pr list"));
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let meta = make_docker_meta "gh-pr-list-native-hint" in
+  let raw =
+    Keeper_exec_shell.handle_keeper_bash
+      ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None ~exec_cache:None
+      ~config ~meta
+      ~args:
+        (`Assoc
+           [ ( "cmd"
+             , `String
+                 "gh pr list --repo jeong-sik/masc-mcp --state open --limit 10"
+             )
+           ])
+      ()
+  in
+  let json = Yojson.Safe.from_string raw in
+  let diagnosis = Json.member "diagnosis" json in
+  Alcotest.(check (option string))
+    "error"
+    (Some "command_blocked")
+    (Json.member "error" json |> Json.to_string_option);
+  Alcotest.(check (option string))
+    "rule id"
+    (Some "gh_pr_list_requires_keeper_pr_list")
+    (Json.member "rule_id" diagnosis |> Json.to_string_option);
+  Alcotest.(check (option string))
+    "tool suggestion"
+    (Some "keeper_pr_list")
+    (Json.member "tool_suggestion" diagnosis |> Json.to_string_option);
+  Alcotest.(check bool)
+    "hint names native PR list tool"
+    true
+    (String_util.contains_substring
+       (Json.member "hint" json |> Json.to_string)
+       "keeper_pr_list")
+
 let test_shell_missing_op_field () =
   with_eio_fs @@ fun () ->
   let base_path, config = make_config () in
@@ -2011,6 +2058,8 @@ let () =
       Alcotest.test_case "missing cmd field" `Quick test_bash_missing_cmd_field;
       Alcotest.test_case "direct MASC tool command blocked" `Quick
         test_bash_blocks_direct_masc_tool_command;
+      Alcotest.test_case "raw gh pr list suggests keeper_pr_list" `Quick
+        test_bash_blocks_gh_pr_list_with_native_pr_hint;
       Alcotest.test_case "missing op field" `Quick test_shell_missing_op_field;
       Alcotest.test_case "unsupported op" `Quick test_shell_unsupported_op;
     ]);


### PR DESCRIPTION
## Summary
- route raw keeper_bash gh pr list/view/status/checks/diff/review/comment commands to native PR tool hints before Docker execution
- add shell-word based detection so prose like echo gh pr list is not treated as a PR command
- cover Docker keeper_bash gh pr list with a regression test

## Tests
- ocamlformat --check lib/keeper/keeper_shell_bash.ml lib/keeper/keeper_shell_bash_words.ml lib/keeper/keeper_shell_bash_words.mli test/test_keeper_bash_safety.ml
- git diff --check
- scripts/dune-local.sh build test/test_keeper_bash_safety.exe
- ./_build/default/test/test_keeper_bash_safety.exe