### PR TITLE
fix(dashboard): keeper detail 활동 시간 3중 표시 단일 SSOT 통합

### DIFF
--- a/dashboard/src/components/keeper-detail-activity-summary.ts
+++ b/dashboard/src/components/keeper-detail-activity-summary.ts
@@ -1,10 +1,18 @@
 import { html } from 'htm/preact'
 import { TimeAgo } from './common/time-ago'
+import { formatDuration } from '../lib/format-time'
+import { keeperActivityDisplay } from '../lib/keeper-runtime-display'
 import type { Keeper } from '../types'
 
+// SSOT: 활동 시간 표시는 raw `keeper.last_heartbeat`를 직접 읽지 않고
+// `keeperActivityDisplay()`로 통일한다. 헤드라인/사이드바/헤더가
+// 같은 helper를 소비해 다른 timestamp field가 동시에 렌더링되는
+// "26초 전 / 18시간 전 / 27일 전" 3중 표시 모순을 봉인한다.
 export function KeeperActivitySummary({ keeper }: { keeper: Keeper }) {
+  const activity = keeperActivityDisplay(keeper, keeper.agent?.last_seen)
+  const hasActivitySignal = activity.source !== 'none' && activity.source !== 'created'
   const hasActivity =
-    keeper.last_heartbeat ||
+    hasActivitySignal ||
     keeper.last_speech_act ||
     keeper.recent_output_preview ||
     keeper.memory_recent_note ||
@@ -14,9 +22,14 @@ export function KeeperActivitySummary({ keeper }: { keeper: Keeper }) {
 
   return html`
     <div class="flex flex-wrap items-start gap-3 px-1">
-      ${keeper.last_heartbeat
+      ${hasActivitySignal
         ? html`<span class="inline-flex items-center gap-1.5 text-2xs text-[var(--color-fg-muted)] px-2.5 py-1 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]">
-            하트비트 <${TimeAgo} timestamp=${keeper.last_heartbeat} />
+            ${activity.label}
+            ${activity.timestamp
+              ? html`<${TimeAgo} timestamp=${activity.timestamp} />`
+              : activity.ageSeconds != null
+                ? html`${formatDuration(activity.ageSeconds)} 전`
+                : null}
           </span>`
         : null}
       ${keeper.last_speech_act

--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -197,7 +197,8 @@ export function KeeperDetailHeaderInfo({
         ${keeper.koreanName || keeper.created_at ? html`
           <div class="flex flex-wrap items-center gap-2 text-xs text-[var(--color-fg-muted)]">
             ${keeper.koreanName ? html`<span>${keeper.koreanName}</span>` : null}
-            ${keeper.created_at ? html`<span class="font-mono tabular-nums opacity-60"><${TimeAgo} timestamp=${keeper.created_at} /></span>` : null}
+            ${'' /* 활동 시각은 사이드바의 keeperActivityDisplay()가 SSOT. 여기서는 keeper 생성 시각만 표시하며 라벨로 의미를 분리한다. */}
+            ${keeper.created_at ? html`<span class="font-mono tabular-nums opacity-60">생성 <${TimeAgo} timestamp=${keeper.created_at} /></span>` : null}
           </div>
         ` : null}
       </div>

--- a/dashboard/src/lib/keeper-runtime-display.test.ts
+++ b/dashboard/src/lib/keeper-runtime-display.test.ts
@@ -319,4 +319,31 @@ describe('keeperActivityDisplay', () => {
       ageSeconds: 75,
     })
   })
+
+  // SSOT regression guard: keeper detail에서 헤드라인(last_heartbeat raw),
+  // 사이드바(activityDisplay), 헤더(created_at raw)가 서로 다른 필드를 읽어
+  // "26초 전 / 18시간 전 / 27일 전"이 동시에 렌더링되던 문제.
+  // 동일 keeper 입력에 대해 helper가 단일 source/timestamp/ageSeconds를
+  // 반환해야 모든 surface가 동일 값을 표시할 수 있다.
+  it('picks a single freshest source when heartbeat, turn, and created_at all coexist', () => {
+    const result = keeperActivityDisplay({
+      // 26초 전 — freshest, 우승해야 함
+      last_heartbeat: '2026-04-24T17:59:34Z',
+      // 18시간 전
+      last_turn_ago_s: 18 * 3600,
+      // 27일 전 — 활동 후보가 있을 때는 절대 선택되면 안 됨
+      created_at: '2026-03-28T18:00:00Z',
+    })
+    expect(result.source).toBe('heartbeat')
+    expect(result.timestamp).toBe('2026-04-24T17:59:34Z')
+    expect(result.ageSeconds).toBe(26)
+  })
+
+  it('falls back to created_at only when every activity candidate is absent', () => {
+    const result = keeperActivityDisplay({
+      created_at: '2026-03-28T18:00:00Z',
+    })
+    expect(result.source).toBe('created')
+    expect(result.label).toBe('생성')
+  })
 })


### PR DESCRIPTION
## 문제

키퍼 상세 화면에서 활동 시간이 서로 다른 timestamp field를 직접 참조해 한 화면 안에 3개 값이 동시에 표시되는 모순:

- **헤드라인 chip**: \`keeper.last_heartbeat\` raw → "26초 전"
- **사이드바 카드**: \`keeperActivityDisplay()\` 결과 → "18시간 전"
- **헤더 옆 라벨**: \`keeper.created_at\` raw → "27일 전"

세 surface 가 동일 keeper 의 활동 시간을 표현한다고 시각적으로 약속하지만, 실제로는 각각 다른 field 를 우회해 읽어 동시 렌더링됐다.

## Root cause

**N-of-M abstraction failure + SSOT absent**. \`keeperActivityDisplay()\` helper 가 존재해 freshest-wins picker 로 단일 진실을 만들어 주는데, sidebar 만 helper 를 소비하고 activity-summary 와 header 는 raw field 를 bypass 했다. 새 surface 가 추가될 때마다 우회가 누적되는 안티패턴.

## 변경

\`keeperActivityDisplay()\` 를 단일 SSOT 로 강제. raw timestamp 우회 제거.

| Surface | Before | After |
|---|---|---|
| 헤드라인 (\`KeeperActivitySummary\`) | \`keeper.last_heartbeat\` raw + 고정 라벨 "하트비트" | \`keeperActivityDisplay()\` source/label/timestamp/ageSeconds 소비 |
| 사이드바 (\`KeeperDetailOverviewSidebar\`) | 이미 \`keeperActivityDisplay()\` 사용 | 변경 없음 |
| 헤더 (\`KeeperDetailHeaderInfo\`) | \`keeper.created_at\` 단독 \`<TimeAgo>\` | "생성 N 전" 명시 라벨로 의미 분리 (창설 시각 ≠ 활동 시각) |

### \`KeeperActivityDisplay\` 타입

타입은 기존 그대로. discriminator \`source: 'autonomous_action'|'heartbeat'|'last_activity'|'last_turn'|'agent_seen'|'created'|'none'\` 가 이미 존재했고 exhaustive 상태였음 (RFC 추가 가공 불필요). consumer 가 raw field 를 우회하지 않도록 *소비 경로*만 정렬한 fix.

### 통합된 surface 3개

1. **헤드라인** (\`dashboard/src/components/keeper-detail-activity-summary.ts\`) — raw \`keeper.last_heartbeat\` 우회 제거. helper 의 \`source\`가 \`'none'\`/\`'created'\`일 때만 chip 자체를 hide (활동 신호 없음을 정직하게 표현).
2. **사이드바** (\`dashboard/src/components/keeper-detail-shell.ts:282\` \`KeeperDetailOverviewSidebar\`) — 이미 helper 사용. 변경 없음.
3. **헤더** (\`dashboard/src/components/keeper-detail-shell.ts:200\`) — \`created_at\`을 "생성" 라벨로 표기해 활동 시각이 아님을 명시. 활동 시각 SSOT 는 사이드바라는 사실을 inline 주석으로 박아 두었음.

## 변경 파일 (+45 / -4)

| File | LoC |
|---|---|
| \`dashboard/src/components/keeper-detail-activity-summary.ts\` | +16 / -3 |
| \`dashboard/src/components/keeper-detail-shell.ts\` | +2 / -1 |
| \`dashboard/src/lib/keeper-runtime-display.test.ts\` | +27 / -0 |

## 검증

- \`pnpm run typecheck\` → ✅ no error
- \`vitest run src/lib/keeper-runtime-display.test.ts\` → ✅ 36 passed (기존 34 + 신규 2)
- \`eslint\` (변경 파일) → ✅ 0 error
- TypeScript no \`any\`, catch-all 추가 없음

### 신규 unit test

3 candidate (heartbeat 26s + last_turn 18h + created 27일) 동시 입력 시 freshest 인 \`heartbeat\` 가 선택되고 ageSeconds=26 임을 잠금. created_at fallback 은 모든 활동 후보 부재 시에만 동작함을 검증.

## 비-목표 (이번 PR 범위 외)

- 다른 surface (agent-roster, agent-profile, runtime-strip, fleet-telemetry-utils) 는 이미 \`keeperActivityDisplay()\` 를 사용 중이라 변경 불필요. 향후 raw field 우회 재발 방지는 RFC 후보 (helper 외 \`last_heartbeat\` direct read lint rule 가능).

## RFC 체크

변경 영역(\`dashboard/src/components\`, \`dashboard/src/lib\`)이 \`pr-rfc-check.sh\` 가드 범위(credential/keeper sandbox/operator control plane/.claude/hooks) 밖이므로 RFC waiver 불필요.

## Closes

- 모순 #1 (keeper detail 시간 3중 표시: "26초 전 / 18시간 전 / 27일 전")

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>