### PR TITLE
fix(dashboard): split statusLabel collisions + unify displayStatus

### DIFF
--- a/dashboard/src/lib/status-label.test.ts
+++ b/dashboard/src/lib/status-label.test.ts
@@ -45,11 +45,14 @@ describe('statusLabel', () => {
 })
 
 describe('displayStatus', () => {
-  it('maps core statuses', () => {
+  // displayStatus now delegates to statusLabel — same key, same label.
+  // The prior `failed → '문제'` divergence is intentionally removed; both
+  // call sites get `'오류'` so operators see one consistent surface.
+  it('maps core statuses (delegates to statusLabel)', () => {
     expect(displayStatus('active')).toBe('진행 중')
     expect(displayStatus('paused')).toBe('일시정지')
     expect(displayStatus('done')).toBe('완료')
-    expect(displayStatus('failed')).toBe('문제')
+    expect(displayStatus('failed')).toBe('오류') // was '문제' — unified
     expect(displayStatus('stopped')).toBe('중단됨')
     expect(displayStatus('offline')).toBe('오프라인')
     expect(displayStatus('idle')).toBe('대기')
@@ -63,6 +66,23 @@ describe('displayStatus', () => {
   it('is case-insensitive', () => {
     expect(displayStatus('ACTIVE')).toBe('진행 중')
     expect(displayStatus('Paused')).toBe('일시정지')
+  })
+})
+
+describe('statusLabel collision fixes (Iter#36)', () => {
+  // Before this PR three pairs of distinct English keys collapsed onto the
+  // same Korean label, making the dashboard label ambiguous.
+  it('listening / idle / todo no longer all map to 대기', () => {
+    expect(statusLabel('listening')).toBe('수신 대기')
+    expect(statusLabel('idle')).toBe('대기')
+    expect(statusLabel('todo')).toBe('예정')
+  })
+  it('interrupted (run aborted mid-flight) is distinct from stopped (clean termination)', () => {
+    expect(statusLabel('interrupted')).toBe('인터럽트됨')
+    expect(statusLabel('stopped')).toBe('중단됨')
+  })
+  it('in_progress aliases active/running', () => {
+    expect(statusLabel('in_progress')).toBe('진행 중')
   })
 })
 

--- a/dashboard/src/lib/status-label.ts
+++ b/dashboard/src/lib/status-label.ts
@@ -1,6 +1,12 @@
 // Unified status display utilities.
 // Consolidates statusLabel, displayStatus, prettyJson from
 // mission-utils, agents, agent-roster, status-badge, helpers, ops/helpers.
+//
+// SSOT principle: one English-key → one Korean label. Sister keys that share
+// a meaning (e.g. `done`/`completed`/`ended`) collapse to the same label.
+// Distinct meanings get distinct labels — collisions across unrelated keys
+// (the prior `중단됨` = interrupted + stopped, `대기` = listening + idle + todo,
+// `오류` vs `문제` for error/failed) are an operator-confusion source.
 
 /** Comprehensive status label — maps normalized status strings to Korean labels. */
 export function statusLabel(value?: string | null): string {
@@ -12,6 +18,7 @@ export function statusLabel(value?: string | null): string {
       return '안정'
     case 'active':
     case 'running':
+    case 'in_progress':
       return '진행 중'
     case 'working':
     case 'busy':
@@ -19,14 +26,20 @@ export function statusLabel(value?: string | null): string {
     case 'watching':
       return '관찰 중'
     case 'listening':
-      return '대기'
+      return '수신 대기'
     case 'pending':
       return '대기 중'
+    case 'todo':
+      return '예정'
+    case 'idle':
+      return '대기'
     case 'paused':
       return '일시정지'
     case 'blocked':
       return '차단됨'
     case 'interrupted':
+      return '인터럽트됨'
+    case 'stopped':
       return '중단됨'
     case 'warn':
     case 'watch':
@@ -42,10 +55,6 @@ export function statusLabel(value?: string | null): string {
       return '오프라인'
     case 'unbooted':
       return '미기동'
-    case 'stopped':
-      return '중단됨'
-    case 'idle':
-      return '대기'
     case 'quiet':
       return '조용함'
     case 'loading':
@@ -83,12 +92,8 @@ export function statusLabel(value?: string | null): string {
       return '핸드오프'
     case 'claimed':
       return '점유됨'
-    case 'in_progress':
-      return '진행 중'
     case 'awaiting_verification':
       return '검증 대기'
-    case 'todo':
-      return '대기'
     case 'preview':
       return '미리보기'
     case 'captured':
@@ -101,20 +106,15 @@ export function statusLabel(value?: string | null): string {
   }
 }
 
-/** Short display status — fewer cases, used in operator contexts. */
+/**
+ * Short display status — thin alias for {@link statusLabel} kept for
+ * backwards-compat with existing call sites. Previously this duplicated the
+ * dispatch table with `error → '문제'` while statusLabel returned `'오류'`,
+ * a silent divergence operators could only spot by reading both code paths.
+ * Delegating removes that divergence: same key, same label, everywhere.
+ */
 export function displayStatus(status?: string | null): string {
-  const normalized = (status ?? '').trim().toLowerCase()
-  if (!normalized) return '확인 필요'
-  if (normalized === 'active' || normalized === 'running') return '진행 중'
-  if (normalized === 'paused') return '일시정지'
-  if (normalized === 'done' || normalized === 'ended' || normalized === 'completed') return '완료'
-  if (normalized === 'failed' || normalized === 'error') return '문제'
-  if (normalized === 'stopped') return '중단됨'
-  if (normalized === 'unbooted') return '미기동'
-  if (normalized === 'offline') return '오프라인'
-  if (normalized === 'idle') return '대기'
-  if (normalized === 'unknown') return '확인 필요'
-  return status?.trim() || '확인 필요'
+  return statusLabel(status)
 }
 
 /** Format unknown values as pretty JSON or pass-through strings. */


### PR DESCRIPTION
## Why

사용자 보고 (Agent Observatory screenshot 후속):
> "라벨, 상태, 표시, 음 이거 너무 과하게 안되도록 이곳저곳 덕지덕지"

`dashboard/src/lib/status-label.ts`의 두 SSOT 함수가 *operator-confusion source*:

**1. `statusLabel` 내부 collision** — distinct 영문 키가 같은 한국어 라벨 collapse:

| Before | After |
|--------|-------|
| `interrupted` → `'중단됨'` | `'인터럽트됨'` (run aborted mid-flight) |
| `stopped` → `'중단됨'` ⚠️ | `'중단됨'` (clean termination) |
| `listening` → `'대기'` | `'수신 대기'` |
| `idle` → `'대기'` ⚠️ | `'대기'` |
| `todo` → `'대기'` ⚠️ | `'예정'` |

**2. `displayStatus` ↔ `statusLabel` divergence**:
- `statusLabel("failed")` = `'오류'` / `displayStatus("failed")` = `'문제'` ⚠️
- 같은 입력에 다른 출력 — silent vocabulary split

## What

| 변경 | 효과 |
|------|------|
| `statusLabel` collision 3쌍 분리 | 5 distinct state 가 visible |
| `displayStatus` → `statusLabel`의 thin alias | 1 영문 키 = 1 한국어 라벨, everywhere |
| `in_progress` → `'진행 중'` (active/running cluster 합류) | 누락 보강 |
| Tests 갱신 | 새 binding 커버 + Iter#36 collision describe block |

`displayStatus`는 *backwards-compat*로 함수 유지 (caller 변경 0). 다음 PR에서 caller 마이그레이션 후 alias 제거 검토.

## Behavior change (intentional)

- `displayStatus("failed")`: `'문제'` → `'오류'` (statusLabel과 동일화)
- `statusLabel("interrupted")`: `'중단됨'` → `'인터럽트됨'`
- `statusLabel("listening")`: `'대기'` → `'수신 대기'`
- `statusLabel("todo")`: `'대기'` → `'예정'`

다른 caller 영향 확인:
- `harness-health-sections`, `fleet-fsm-matrix`, `common/agent-presence`, `monitoring-runtime` 등에서 `'대기'`는 *idle* 의미로 사용 — 영향 없음.
- `interrupted`/`listening`/`todo` 키로 statusLabel을 호출하는 caller — *명시적 의미* 갖는 라벨이 더 정확.

## Out of scope (followup RFC 후보)

본 PR은 *SSOT 안 collision*만 정리. 더 wide cleanup 후보:

1. **`'정지'` 124회 occurrences** — statusLabel SSOT 외 별도 inline 라벨링. 별 audit/RFC 필요.
2. **컴포넌트별 inline 라벨** — `agent-roster.ts:95` "현재 차단" 등 (`rosterStateNote`), `keeper-action-panel.ts` 자체 라벨, `keeper-reactivity-monitor.ts` 등 — Vocabulary RFC로 통합.
3. **`statusLabel` ↔ `monitoring-runtime` ↔ `fsm-hub-types` SSOT 분산** — 3곳 모두 별도 라벨 매핑 보유. 같은 vocab RFC.

이 followup은 RFC-0135 *Keeper/Agent Status Vocabulary SSOT* (가칭) 후보.

## Iter series

FSM/TLA+ observability sweep `/loop 20m` cron `253cc0f6` **iter#36**:
- 사용자 명시 "덕지덕지 정리" Phase 2 첫 PR
- Iter#13~#35 series에 9 vocab cluster PR 사용자 머지 완료 (RFC-0133 SSOT + 8 dashboard fix) 직후 후속
- 본 PR은 *narrow collision fix* — *vocab 전체 RFC*는 별 후속

## Workaround Rejection Bar

- [ ] telemetry-as-fix: 아님 (display divergence **제거**)
- [ ] string classifier 추가: 아님 (오히려 *collision 분리*)
- [ ] N-of-M: 아님 (file cohort 완전, 다른 SSOT는 RFC 후보로 logged)
- [ ] catch-all 추가: 아님

## RFC Check

`bash ~/me/scripts/pr-rfc-check.sh` PASS (exit 0). `dashboard/src/lib/status-label.ts` — credential/identity/operator-control/sandbox/dashboard-credential/hooks/workflow* 무관.

## Verification

- ocamlformat N/A (TypeScript)
- 새 test cases 추가 (Iter#36 collision describe block)
- 2 files, +44 / -24

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>