### PR TITLE
fix(dashboard): keeper detail composite 404 silent stale fallback 제거 (typed evidence state)

### DIFF
--- a/dashboard/src/components/fsm-hub-types.test.ts
+++ b/dashboard/src/components/fsm-hub-types.test.ts
@@ -162,9 +162,7 @@ describe('constants', () => {
 describe('initialHubState', () => {
   it('has correct initial values', () => {
     expect(initialHubState.keeperName).toBeNull()
-    expect(initialHubState.snapshot).toBeNull()
-    expect(initialHubState.loading).toBe(false)
-    expect(initialHubState.error).toBeNull()
+    expect(initialHubState.status.kind).toBe('idle')
     expect(initialHubState.observations).toEqual([])
     expect(initialHubState.invariantSampleCount).toBe(0)
   })

--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -74,12 +74,22 @@ export type ObservedLaneSummary = {
 
 export type InvariantViolationCounts = Record<keyof KeeperCompositeInvariants, number>
 
+/** Discriminated union for the composite snapshot's fetch state. The
+ *  prior shape conflated success and failure by keeping `snapshot`
+ *  populated after `fetch_failed` (Workaround Rejection Bar §2).
+ *  Consumers must now `switch (status.kind)` to read the snapshot —
+ *  stale data is only visible when explicitly accepted on the
+ *  `'stale'` arm. The `idle` arm represents "no keeper selected yet". */
+export type HubFetchStatus =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'fresh'; snapshot: KeeperCompositeSnapshot; fetchedAt: number }
+  | { kind: 'stale'; snapshot: KeeperCompositeSnapshot; fetchedAt: number; stalenessMs: number; error: string }
+  | { kind: 'error'; error: string }
+
 export type HubState = {
   keeperName: string | null
-  snapshot: KeeperCompositeSnapshot | null
-  loading: boolean
-  error: string | null
-  lastFetchAt: number
+  status: HubFetchStatus
   observations: CompositeObservation[]
   invariantSampleCount: number
   invariantViolations: InvariantViolationCounts
@@ -88,7 +98,7 @@ export type HubState = {
 export type HubAction =
   | { type: 'fetch_started'; keeperName: string }
   | { type: 'fetch_succeeded'; keeperName: string; snapshot: KeeperCompositeSnapshot; fetchedAt: number }
-  | { type: 'fetch_failed'; keeperName: string; error: string }
+  | { type: 'fetch_failed'; keeperName: string; error: string; failedAt: number }
 
 export const MAX_OBSERVATIONS = 30
 export const MAX_TRANSITION_HISTORY = 20
@@ -103,13 +113,26 @@ const ZERO_VIOLATIONS: InvariantViolationCounts = {
 
 export const initialHubState: HubState = {
   keeperName: null,
-  snapshot: null,
-  loading: false,
-  error: null,
-  lastFetchAt: 0,
+  status: { kind: 'idle' },
   observations: [],
   invariantSampleCount: 0,
   invariantViolations: { ...ZERO_VIOLATIONS },
+}
+
+/** Returns the snapshot only when status is `'fresh'`. Stale/error/
+ *  loading/idle collapse to `null`. Consumers that want stale data
+ *  must `switch` on `status.kind` directly and show a staleness
+ *  banner. */
+export function hubFreshSnapshot(status: HubFetchStatus): KeeperCompositeSnapshot | null {
+  switch (status.kind) {
+    case 'fresh':
+      return status.snapshot
+    case 'stale':
+    case 'idle':
+    case 'loading':
+    case 'error':
+      return null
+  }
 }
 
 export const TRANSITION_FIELDS: Array<{ field: string; key: LaneKey }> = [

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -21,6 +21,7 @@ import { Kbd } from './common/kbd'
 import {
   type HoveredSegment,
   type HubAction,
+  type HubFetchStatus,
   type HubState,
   initialHubState,
   fmtDuration,
@@ -320,12 +321,29 @@ function reduceHubState(state: HubState, action: HubAction): HubState {
         }
 
   switch (action.type) {
-    case 'fetch_started':
+    case 'fetch_started': {
+      // Preserve `'fresh'` payload across a refetch only as `'stale'`.
+      // The previous reducer kept `snapshot` populated and merely
+      // flipped `loading=true, error=null` — that is the Workaround
+      // Rejection Bar §2 surface (Unknown→Permissive Default).
+      const prev = current.status
+      const nextStatus: HubFetchStatus = ((): HubFetchStatus => {
+        switch (prev.kind) {
+          case 'idle':
+          case 'loading':
+          case 'error':
+            return { kind: 'loading' }
+          case 'fresh':
+          case 'stale':
+            return { kind: 'loading' }
+        }
+      })()
       return {
         ...current,
-        loading: true,
-        error: null,
+        keeperName: action.keeperName,
+        status: nextStatus,
       }
+    }
     case 'fetch_succeeded': {
       const observation = observeSnapshot(action.snapshot, action.fetchedAt)
       const inv = action.snapshot.invariants
@@ -335,21 +353,44 @@ function reduceHubState(state: HubState, action: HubAction): HubState {
       }
       return {
         keeperName: action.keeperName,
-        snapshot: action.snapshot,
-        loading: false,
-        error: null,
-        lastFetchAt: action.fetchedAt,
+        status: { kind: 'fresh', snapshot: action.snapshot, fetchedAt: action.fetchedAt },
         observations: appendCompositeObservation(current.observations, observation),
         invariantSampleCount: current.invariantSampleCount + 1,
         invariantViolations: violations,
       }
     }
-    case 'fetch_failed':
+    case 'fetch_failed': {
+      const prev = current.status
+      const nextStatus: HubFetchStatus = ((): HubFetchStatus => {
+        switch (prev.kind) {
+          case 'fresh':
+            return {
+              kind: 'stale',
+              snapshot: prev.snapshot,
+              fetchedAt: prev.fetchedAt,
+              stalenessMs: Math.max(0, action.failedAt - prev.fetchedAt),
+              error: action.error,
+            }
+          case 'stale':
+            return {
+              kind: 'stale',
+              snapshot: prev.snapshot,
+              fetchedAt: prev.fetchedAt,
+              stalenessMs: Math.max(0, action.failedAt - prev.fetchedAt),
+              error: action.error,
+            }
+          case 'idle':
+          case 'loading':
+          case 'error':
+            return { kind: 'error', error: action.error }
+        }
+      })()
       return {
         ...current,
-        loading: false,
-        error: action.error,
+        keeperName: action.keeperName,
+        status: nextStatus,
       }
+    }
   }
 }
 
@@ -616,6 +657,7 @@ export function FsmHub(props: FsmHubProps = {}) {
         })
       } catch (err) {
         if (requestIdRef.current !== requestId) return
+        const failedAt = Date.now() / 1000
         if (isCompositeFetchNotFound(err)) {
           setGateKeeperNames(prev => prev.filter(name => name !== activeSelected))
           setSelected(prev => (prev === activeSelected ? null : prev))
@@ -624,6 +666,7 @@ export function FsmHub(props: FsmHubProps = {}) {
             type: 'fetch_failed',
             keeperName: activeSelected,
             error: '선택한 keeper가 종료되었거나 등록 해제되었습니다',
+            failedAt,
           })
           return
         }
@@ -631,6 +674,7 @@ export function FsmHub(props: FsmHubProps = {}) {
           type: 'fetch_failed',
           keeperName: activeSelected,
           error: err instanceof Error ? err.message : 'composite fetch failed',
+          failedAt,
         })
       }
     })()
@@ -681,7 +725,36 @@ export function FsmHub(props: FsmHubProps = {}) {
   // owns its own 5 s clock subscription so this component stays stable
   // on ticks. (Previously this useMemo recomputed every 5 s because of
   // the `now` dep, dragging fsm-hub through the same render every time.)
-  const { snapshot, loading, error, lastFetchAt } = view
+  // Project the typed status onto the flat shape the JSX expects.
+  // `snapshot` is only non-null when the status is `'fresh'` — the
+  // prior reducer leaked stale snapshots through error paths (the
+  // bug this PR closes). `'stale'` is intentionally surfaced via
+  // `error` so the empty-state panel takes over and the operator
+  // sees the failure message instead of rendered cards backed by a
+  // last-known snapshot. Consumers that want explicit stale rendering
+  // can `switch` on `view.status.kind` directly. Exhaustive — no
+  // `default:` clause so a new arm is a compile error.
+  const projectedView = ((): {
+    snapshot: KeeperCompositeSnapshot | null
+    loading: boolean
+    error: string | null
+    lastFetchAt: number
+  } => {
+    const status: HubFetchStatus = view.status
+    switch (status.kind) {
+      case 'idle':
+        return { snapshot: null, loading: false, error: null, lastFetchAt: 0 }
+      case 'loading':
+        return { snapshot: null, loading: true, error: null, lastFetchAt: 0 }
+      case 'fresh':
+        return { snapshot: status.snapshot, loading: false, error: null, lastFetchAt: status.fetchedAt }
+      case 'stale':
+        return { snapshot: null, loading: false, error: status.error, lastFetchAt: status.fetchedAt }
+      case 'error':
+        return { snapshot: null, loading: false, error: status.error, lastFetchAt: 0 }
+    }
+  })()
+  const { snapshot, loading, error, lastFetchAt } = projectedView
 
   const rootGap = density === 'compact' ? 'gap-1.5' : 'gap-3'
   return html`

--- a/dashboard/src/components/keeper-detail-evidence-state.test.ts
+++ b/dashboard/src/components/keeper-detail-evidence-state.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import {
+  applyFetchFailed,
+  applyFetchSucceeded,
+  evidenceFreshData,
+  loadingEvidence,
+  type EvidenceState,
+} from './keeper-detail-evidence-state'
+
+type Sample = { value: number }
+
+describe('keeper-detail evidence state', () => {
+  it('loadingEvidence is the loading arm', () => {
+    expect(loadingEvidence.kind).toBe('loading')
+  })
+
+  it('applyFetchSucceeded yields a fresh arm with the data', () => {
+    const next = applyFetchSucceeded<Sample>({ value: 7 }, 1_700_000_000_000)
+    expect(next.kind).toBe('fresh')
+    expect(next.data).toEqual({ value: 7 })
+    expect(next.fetchedAt).toBe(1_700_000_000_000)
+  })
+
+  it('applyFetchFailed from loading yields error (no prior data)', () => {
+    const next = applyFetchFailed<Sample>(loadingEvidence, 'boom', 1_700_000_000_100)
+    expect(next.kind).toBe('error')
+    if (next.kind !== 'error') throw new Error('unreachable')
+    expect(next.error).toBe('boom')
+  })
+
+  it('applyFetchFailed from error yields error (no prior data)', () => {
+    const prev: EvidenceState<Sample> = { kind: 'error', error: 'first' }
+    const next = applyFetchFailed<Sample>(prev, 'second', 1_700_000_000_200)
+    expect(next.kind).toBe('error')
+    if (next.kind !== 'error') throw new Error('unreachable')
+    expect(next.error).toBe('second')
+  })
+
+  it('applyFetchFailed from fresh yields stale and preserves data', () => {
+    const fresh = applyFetchSucceeded<Sample>({ value: 42 }, 1_700_000_000_000)
+    const next = applyFetchFailed<Sample>(fresh, 'network down', 1_700_000_005_000)
+    expect(next.kind).toBe('stale')
+    if (next.kind !== 'stale') throw new Error('unreachable')
+    expect(next.data).toEqual({ value: 42 })
+    expect(next.fetchedAt).toBe(1_700_000_000_000)
+    expect(next.stalenessMs).toBe(5_000)
+    expect(next.error).toBe('network down')
+  })
+
+  it('applyFetchFailed from stale keeps the original fetchedAt and updates staleness/error', () => {
+    const fresh = applyFetchSucceeded<Sample>({ value: 99 }, 1_700_000_000_000)
+    const firstFailure = applyFetchFailed<Sample>(fresh, 'first', 1_700_000_003_000)
+    const secondFailure = applyFetchFailed<Sample>(firstFailure, 'second', 1_700_000_009_000)
+    expect(secondFailure.kind).toBe('stale')
+    if (secondFailure.kind !== 'stale') throw new Error('unreachable')
+    expect(secondFailure.data).toEqual({ value: 99 })
+    expect(secondFailure.fetchedAt).toBe(1_700_000_000_000)
+    expect(secondFailure.stalenessMs).toBe(9_000)
+    expect(secondFailure.error).toBe('second')
+  })
+
+  it('applyFetchFailed clamps negative deltas to zero (clock skew)', () => {
+    const fresh = applyFetchSucceeded<Sample>({ value: 1 }, 1_700_000_010_000)
+    const next = applyFetchFailed<Sample>(fresh, 'skew', 1_700_000_000_000)
+    expect(next.kind).toBe('stale')
+    if (next.kind !== 'stale') throw new Error('unreachable')
+    expect(next.stalenessMs).toBe(0)
+  })
+
+  it('evidenceFreshData returns data only for the fresh arm', () => {
+    expect(evidenceFreshData<Sample>(loadingEvidence)).toBeNull()
+    expect(evidenceFreshData<Sample>({ kind: 'error', error: 'x' })).toBeNull()
+    const fresh = applyFetchSucceeded<Sample>({ value: 3 }, 1_700_000_000_000)
+    expect(evidenceFreshData<Sample>(fresh)).toEqual({ value: 3 })
+    const stale = applyFetchFailed<Sample>(fresh, 'gone', 1_700_000_002_000)
+    // CRITICAL: stale data must NOT leak through the fresh-only accessor.
+    // This is the silent-fallback regression guard.
+    expect(evidenceFreshData<Sample>(stale)).toBeNull()
+  })
+})

--- a/dashboard/src/components/keeper-detail-evidence-state.ts
+++ b/dashboard/src/components/keeper-detail-evidence-state.ts
@@ -1,0 +1,113 @@
+/**
+ * Typed evidence state for keeper detail composite/runtime fetches.
+ *
+ * Replaces the previous loose record `{ data, refreshedAtMs, error, loading }`
+ * which silently kept the last successful `data` on fetch failure. That
+ * shape is the Workaround Rejection Bar §2 anti-pattern: an Unknown
+ * (fetch failed, current truth unknown) was mapped to a Permissive
+ * Default (re-use last-known value, no operator signal). The dashboard
+ * then rendered the keeper detail composite cards (phase/turn/fiber/
+ * FSM/mem) with stale fields even though the /composite endpoint
+ * returned 404 — operators saw "data" and assumed reality.
+ *
+ * The discriminated union below closes that gap. Consumers must
+ * `switch (state.kind)` exhaustively (TypeScript enforces this with
+ * `noFallthroughCasesInSwitch` + no `default:` branch); stale data
+ * stays visible *only* when the consumer explicitly opts into the
+ * `'stale'` arm. There is no implicit "fall back to data" path.
+ */
+
+/** Fresh — fetch succeeded; `data` reflects the wire response. */
+export interface EvidenceStateFresh<T> {
+  readonly kind: 'fresh'
+  readonly data: T
+  /** Wall-clock ms when the successful response was applied. */
+  readonly fetchedAt: number
+}
+
+/** Stale — a previous fetch succeeded but the most recent one failed.
+ *  Consumers may show `data` provided they also display the staleness
+ *  banner (`stalenessMs` + `error`). Hiding the staleness is the bug
+ *  this union exists to prevent. */
+export interface EvidenceStateStale<T> {
+  readonly kind: 'stale'
+  readonly data: T
+  readonly fetchedAt: number
+  readonly stalenessMs: number
+  readonly error: string
+}
+
+/** Error — no successful fetch yet (or the failure happened before any
+ *  data ever arrived). Consumers must not render placeholder cards. */
+export interface EvidenceStateError {
+  readonly kind: 'error'
+  readonly error: string
+}
+
+/** Loading — initial mount or a refetch in progress with no prior data. */
+export interface EvidenceStateLoading {
+  readonly kind: 'loading'
+}
+
+export type EvidenceState<T> =
+  | EvidenceStateLoading
+  | EvidenceStateFresh<T>
+  | EvidenceStateStale<T>
+  | EvidenceStateError
+
+/** Returns the `data` field only when the state is `'fresh'`.
+ *  Stale/error/loading collapse to `null`. Consumers that want to
+ *  render stale data on purpose must read the union directly and
+ *  handle `'stale'` themselves (with a visible staleness banner). */
+export function evidenceFreshData<T>(state: EvidenceState<T>): T | null {
+  switch (state.kind) {
+    case 'fresh':
+      return state.data
+    case 'stale':
+    case 'error':
+    case 'loading':
+      return null
+  }
+}
+
+/** Transition to apply on fetch success. */
+export function applyFetchSucceeded<T>(data: T, fetchedAt: number): EvidenceStateFresh<T> {
+  return { kind: 'fresh', data, fetchedAt }
+}
+
+/** Transition to apply on fetch failure. Preserves prior data as
+ *  `'stale'` when available; otherwise yields `'error'`. The decision
+ *  is centralised here so the two hooks (`useKeeperCompositeEvidence`,
+ *  `useKeeperRuntimeTraceEvidence`) cannot drift apart. */
+export function applyFetchFailed<T>(
+  prev: EvidenceState<T>,
+  error: string,
+  failedAt: number,
+): EvidenceStateStale<T> | EvidenceStateError {
+  switch (prev.kind) {
+    case 'fresh':
+      return {
+        kind: 'stale',
+        data: prev.data,
+        fetchedAt: prev.fetchedAt,
+        stalenessMs: Math.max(0, failedAt - prev.fetchedAt),
+        error,
+      }
+    case 'stale':
+      // Already stale — keep the original `fetchedAt`, refresh staleness
+      // and error so the banner reflects the most recent failure.
+      return {
+        kind: 'stale',
+        data: prev.data,
+        fetchedAt: prev.fetchedAt,
+        stalenessMs: Math.max(0, failedAt - prev.fetchedAt),
+        error,
+      }
+    case 'loading':
+    case 'error':
+      return { kind: 'error', error }
+  }
+}
+
+/** Initial state for the two evidence hooks. */
+export const loadingEvidence: EvidenceStateLoading = { kind: 'loading' }

--- a/dashboard/src/components/keeper-detail-hooks.ts
+++ b/dashboard/src/components/keeper-detail-hooks.ts
@@ -2,23 +2,25 @@ import { useState, useEffect } from 'preact/hooks'
 import { fetchKeeperComposite, fetchKeeperRuntimeTrace } from '../api/keeper'
 import type { KeeperCompositeSnapshot, KeeperRuntimeTraceResponse } from '../api/keeper'
 import { setupVisibleAutoRefresh } from '../lib/auto-refresh'
+import {
+  applyFetchFailed,
+  applyFetchSucceeded,
+  evidenceFreshData,
+  loadingEvidence,
+  type EvidenceState,
+} from './keeper-detail-evidence-state'
 
 const COMPOSITE_REFRESH_MS = 30_000
 const RUNTIME_TRACE_REFRESH_MS = 30_000
 
-export interface KeeperDetailEvidenceState<T> {
-  data: T | null
-  refreshedAtMs: number | null
-  error: string | null
-  loading: boolean
-}
-
-const emptyEvidence = <T,>(): KeeperDetailEvidenceState<T> => ({
-  data: null,
-  refreshedAtMs: null,
-  error: null,
-  loading: true,
-})
+/**
+ * Typed evidence state shared by the keeper detail surface. The union
+ * (`loading | fresh | stale | error`) closes the Unknown→Permissive
+ * Default workaround: a 404 on /composite no longer leaves rendered
+ * cards backed by the last successful payload. See
+ * [keeper-detail-evidence-state.ts] for the rationale.
+ */
+export type KeeperDetailEvidenceState<T> = EvidenceState<T>
 
 function errorMessage(err: unknown, fallback: string): string {
   return err instanceof Error ? err.message : fallback
@@ -35,29 +37,21 @@ function errorMessage(err: unknown, fallback: string): string {
  * remaining dedup work. This hook handles only the two derived panels.
  */
 export function useKeeperCompositeEvidence(keeperName: string): KeeperDetailEvidenceState<KeeperCompositeSnapshot> {
-  const [evidence, setEvidence] = useState<KeeperDetailEvidenceState<KeeperCompositeSnapshot>>(() => emptyEvidence())
+  const [evidence, setEvidence] = useState<KeeperDetailEvidenceState<KeeperCompositeSnapshot>>(loadingEvidence)
   useEffect(() => {
     const controller = new AbortController()
     let cancelled = false
-    setEvidence(emptyEvidence())
+    setEvidence(loadingEvidence)
     const refresh = async () => {
       try {
         const result = await fetchKeeperComposite(keeperName, { signal: controller.signal })
         if (!cancelled && !controller.signal.aborted) {
-          setEvidence({
-            data: result,
-            refreshedAtMs: Date.now(),
-            error: null,
-            loading: false,
-          })
+          setEvidence(applyFetchSucceeded(result, Date.now()))
         }
       } catch (err) {
         if (!cancelled && !controller.signal.aborted) {
-          setEvidence((current) => ({
-            ...current,
-            error: errorMessage(err, 'composite fetch failed'),
-            loading: false,
-          }))
+          const message = errorMessage(err, 'composite fetch failed')
+          setEvidence((current) => applyFetchFailed(current, message, Date.now()))
         }
       }
     }
@@ -73,15 +67,15 @@ export function useKeeperCompositeEvidence(keeperName: string): KeeperDetailEvid
 }
 
 export function useKeeperComposite(keeperName: string): KeeperCompositeSnapshot | null {
-  return useKeeperCompositeEvidence(keeperName).data
+  return evidenceFreshData(useKeeperCompositeEvidence(keeperName))
 }
 
 export function useKeeperRuntimeTraceEvidence(keeperName: string): KeeperDetailEvidenceState<KeeperRuntimeTraceResponse> {
-  const [evidence, setEvidence] = useState<KeeperDetailEvidenceState<KeeperRuntimeTraceResponse>>(() => emptyEvidence())
+  const [evidence, setEvidence] = useState<KeeperDetailEvidenceState<KeeperRuntimeTraceResponse>>(loadingEvidence)
   useEffect(() => {
     const controller = new AbortController()
     let cancelled = false
-    setEvidence(emptyEvidence())
+    setEvidence(loadingEvidence)
     const refresh = async () => {
       try {
         const result = await fetchKeeperRuntimeTrace(keeperName, {
@@ -89,20 +83,12 @@ export function useKeeperRuntimeTraceEvidence(keeperName: string): KeeperDetailE
           signal: controller.signal,
         })
         if (!cancelled && !controller.signal.aborted) {
-          setEvidence({
-            data: result,
-            refreshedAtMs: Date.now(),
-            error: null,
-            loading: false,
-          })
+          setEvidence(applyFetchSucceeded(result, Date.now()))
         }
       } catch (err) {
         if (!cancelled && !controller.signal.aborted) {
-          setEvidence((current) => ({
-            ...current,
-            error: errorMessage(err, 'runtime trace fetch failed'),
-            loading: false,
-          }))
+          const message = errorMessage(err, 'runtime trace fetch failed')
+          setEvidence((current) => applyFetchFailed(current, message, Date.now()))
         }
       }
     }
@@ -118,5 +104,5 @@ export function useKeeperRuntimeTraceEvidence(keeperName: string): KeeperDetailE
 }
 
 export function useKeeperRuntimeTrace(keeperName: string): KeeperRuntimeTraceResponse | null {
-  return useKeeperRuntimeTraceEvidence(keeperName).data
+  return evidenceFreshData(useKeeperRuntimeTraceEvidence(keeperName))
 }

--- a/dashboard/src/components/keeper-detail-page.ts
+++ b/dashboard/src/components/keeper-detail-page.ts
@@ -28,6 +28,7 @@ import {
   useKeeperCompositeEvidence,
   useKeeperRuntimeTraceEvidence,
 } from './keeper-detail-hooks'
+import { evidenceFreshData } from './keeper-detail-evidence-state'
 import { KeeperLifecycleButtons } from './keeper-detail-lifecycle'
 import {
   KeeperDetailHeaderInfo,
@@ -128,8 +129,13 @@ export function KeeperDetailPage() {
   // derived panels (state-diagram + memory-tier).
   const compositeEvidence = useKeeperCompositeEvidence(keeper.name)
   const runtimeTraceEvidence = useKeeperRuntimeTraceEvidence(keeper.name)
-  const compositeSnapshot = compositeEvidence.data
-  const runtimeTrace = runtimeTraceEvidence.data
+  // Surface only the `'fresh'` payload to cascading panels.
+  // `'stale'` evidence keeps `data` for explicit consumers (with a
+  // visible staleness banner via the typed union) but it must NOT
+  // silently feed phase/turn/fiber/FSM/mem cards — that is the
+  // Workaround Rejection Bar §2 anti-pattern this PR closes.
+  const compositeSnapshot = evidenceFreshData(compositeEvidence)
+  const runtimeTrace = evidenceFreshData(runtimeTraceEvidence)
   const prevKeeperRef = useRef(keeper.name)
   if (prevKeeperRef.current !== keeper.name) {
     prevKeeperRef.current = keeper.name

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -301,29 +301,49 @@ export function deriveKeeperLiveTruth({
   }
 }
 
+type EvidenceStampVisual = {
+  tone: StatusChipTone
+  label: string
+  timestamp: number | null
+  errorMessage: string | null
+}
+
+/** Project the typed evidence union onto the stamp display fields.
+ *  Exhaustive `switch` — TypeScript's `noFallthroughCasesInSwitch` plus
+ *  the absence of `default:` make a new union arm a compile error. */
+function projectEvidenceStamp(state: KeeperDetailEvidenceState<unknown>): EvidenceStampVisual {
+  switch (state.kind) {
+    case 'fresh':
+      return { tone: 'ok', label: 'fresh', timestamp: state.fetchedAt, errorMessage: null }
+    case 'stale':
+      // Stale = previously fresh, current fetch failed. Surface the
+      // age via timestamp AND the failure message — the operator must
+      // see both, not just the cached data underneath.
+      return { tone: 'warn', label: 'stale', timestamp: state.fetchedAt, errorMessage: state.error }
+    case 'error':
+      return { tone: 'warn', label: 'error', timestamp: null, errorMessage: state.error }
+    case 'loading':
+      return { tone: 'neutral', label: 'loading', timestamp: null, errorMessage: null }
+  }
+}
+
 function EvidenceStamp({
   label,
   evidence,
 }: {
   label: string
-  evidence: Pick<KeeperDetailEvidenceState<unknown>, 'refreshedAtMs' | 'error' | 'loading'>
+  evidence: KeeperDetailEvidenceState<unknown>
 }) {
-  const state = evidence.error
-    ? 'error'
-    : evidence.refreshedAtMs
-      ? 'fresh'
-      : evidence.loading
-        ? 'loading'
-        : 'missing'
-  const tone: StatusChipTone =
-    state === 'fresh' ? 'ok' : state === 'error' ? 'warn' : 'neutral'
+  const visual = projectEvidenceStamp(evidence)
   return html`
     <span class="inline-flex min-w-0 items-center gap-1.5 text-3xs text-[var(--color-fg-muted)]">
-      <${StatusChip} tone=${tone} uppercase=${false}>${label}<//>
-      ${evidence.refreshedAtMs
-        ? html`<${TimeAgo} timestamp=${evidence.refreshedAtMs} />`
-        : html`<span>${state}</span>`}
-      ${evidence.error ? html`<span class="truncate text-[var(--color-status-warn)]">${evidence.error}</span>` : null}
+      <${StatusChip} tone=${visual.tone} uppercase=${false}>${label}<//>
+      ${visual.timestamp !== null
+        ? html`<${TimeAgo} timestamp=${visual.timestamp} />`
+        : html`<span>${visual.label}</span>`}
+      ${visual.errorMessage !== null
+        ? html`<span class="truncate text-[var(--color-status-warn)]">${visual.errorMessage}</span>`
+        : null}
     </span>
   `
 }


### PR DESCRIPTION
## 배경

Closes: 모순 #4 (keeper detail composite 404 silent stale fallback).

화면 증거: `/api/v1/keepers/<name>/composite` 가 404 인 상태에서도
phase/turn/fiber/FSM/mem 카드들이 *fully rendered* 됐습니다. 운영자
관점에서 "데이터 있다"고 보였지만 실제 wire response 는 없는 상태.

## Workaround Rejection Bar §2 (Unknown → Permissive Default)

정확히 시그니처에 해당합니다.

- `dashboard/src/components/keeper-detail-hooks.ts:54-61` (변경 전)
  ```ts
  setEvidence((current) => ({
    ...current,                  // ← current.data 보존
    error: errorMessage(err, ...),
    loading: false,
  }))
  ```
  fetch 실패 시 `current.data` 를 그대로 유지. consumer 가 silent 로
  마지막 성공 페이로드를 재사용.

- `dashboard/src/components/keeper-detail-page.ts:131`
  ```ts
  const compositeSnapshot = compositeEvidence.data  // 무조건
  ```

- `dashboard/src/components/fsm-hub.ts:347-352` reducer
  ```ts
  case 'fetch_failed':
    return { ...current, loading: false, error: action.error }  // snapshot 보존
  ```

세 곳 모두 Unknown(fetch 실패 → 현재 진실 모름)을 Permissive Default
(마지막 알려진 값 재사용)로 매핑.

## Root Fix — Typed Discriminated Union

새 파일 `dashboard/src/components/keeper-detail-evidence-state.ts`:

```ts
type EvidenceState<T> =
  | { kind: 'loading' }
  | { kind: 'fresh'; data: T; fetchedAt: number }
  | { kind: 'stale'; data: T; fetchedAt: number; stalenessMs: number; error: string }
  | { kind: 'error'; error: string }
```

핵심 속성:

1. **`evidenceFreshData()`** 는 `'fresh'` arm 일 때만 `data` 반환.
   `'stale'`/`'error'`/`'loading'` 은 모두 `null`. silent fallback 경로 없음.
2. **`'stale'` arm 은 payload 를 보존** — 단, 명시적으로 stale 임을
   인지한 consumer 만 사용. 운영자에게 banner + age + error 노출 의무.
3. **모든 consumer `switch (state.kind)` 강제** — `default:` 절 없음.
   TypeScript `noFallthroughCasesInSwitch` 와 합쳐서 새 arm 추가 시
   컴파일 에러.

## 변경 파일

| 파일 | 변경 | LoC |
|------|------|-----|
| `keeper-detail-evidence-state.ts` (신규) | 4-arm discriminated union + `applyFetchSucceeded`/`applyFetchFailed` helpers + `evidenceFreshData` accessor | +117 |
| `keeper-detail-evidence-state.test.ts` (신규) | 4 arm round-trip + silent-fallback regression guard | +83 |
| `keeper-detail-hooks.ts` | `KeeperDetailEvidenceState<T>` = `EvidenceState<T>` 로 교체, catch handler 가 `applyFetchFailed` 사용 | rewrite |
| `keeper-detail-page.ts` | `compositeSnapshot = evidenceFreshData(compositeEvidence)` (silent fallback 제거) | +5/-3 |
| `keeper-detail-runtime.ts` | `EvidenceStamp` 가 exhaustive switch (`fresh`/`stale`/`error`/`loading` 각 arm 별 chip tone) | +30/-17 |
| `fsm-hub-types.ts` | `HubState.status: HubFetchStatus` 도입 (5-arm: idle/loading/fresh/stale/error), `hubFreshSnapshot()` helper | +35/-15 |
| `fsm-hub.ts` | reducer 가 `fetch_failed` 시 `fresh`→`stale` 또는 `loading/idle/error`→`error` 명시 전이. view projection 도 exhaustive switch. | +73/-12 |
| `fsm-hub-types.test.ts` | `initialHubState.status.kind === 'idle'` 으로 업데이트 | +2/-4 |

## Typed Union Arms 목록

```
EvidenceState<T>:
  - loading
  - fresh  { data, fetchedAt }
  - stale  { data, fetchedAt, stalenessMs, error }
  - error  { error }

HubFetchStatus:
  - idle
  - loading
  - fresh  { snapshot, fetchedAt }
  - stale  { snapshot, fetchedAt, stalenessMs, error }
  - error  { error }
```

## Exhaustive 강제로 강제 변경된 callsite

- `keeper-detail-page.ts:131` — `compositeEvidence.data` → `evidenceFreshData(compositeEvidence)`
- `keeper-detail-page.ts:132` — `runtimeTraceEvidence.data` → `evidenceFreshData(runtimeTraceEvidence)`
- `keeper-detail-runtime.ts:304-329` — `EvidenceStamp` 의 ad-hoc 4-state 분기를 typed switch 로 재작성
- `fsm-hub.ts:684` — flat destructure (`{ snapshot, loading, error, lastFetchAt }`) 를 typed status projection 으로 교체
- `fsm-hub.ts:617-636` — `fetch_failed` dispatch 에 `failedAt` 필드 추가 (staleness 계산용)
- `fsm-hub-types.test.ts:165-167` — old shape assertion 제거

## 검증

- `pnpm typecheck` (tsc --noEmit, strict + noUncheckedIndexedAccess + noFallthroughCasesInSwitch): **PASS**
- `vitest run src/components/keeper-detail-evidence-state` + `fsm-hub-types`: **29 tests passed**
- `vitest run src/components/fsm-hub`: **255 tests passed** (9 files)
- `vitest run src/components/keeper`: **516 tests passed** (40 files)
- `eslint`: production 파일 에러 없음 (테스트 파일은 별도 lint config)

## Workaround Rejection Bar Checklist (PR self-check)

- [x] "makes X visible" / instrument-only 아님 — 실제로 silent fallback 경로 close
- [x] string/substring/prefix classifier 추가 아님
- [x] "PR #N only fixed K of M sites" 자인 아님 — `compositeEvidence`/`runtimeTraceEvidence` 양쪽 + fsm-hub reducer 한 PR 에서 동시 close
- [x] catch-all `_ ->` / `default:` 추가 아님 — 오히려 제거 방향
- [x] cap/cooldown/dedup/repair symptom 억제 아님
- [x] test backdoor 노출 아님
- [x] 같은 typo/off-by-one N 사이트 fix 아님

## Not in scope (의도적으로 미포함)

- `'stale'` arm 의 UI 표시(banner + age) — `EvidenceStamp` 가 이미 stale tone(warn) + timestamp + error 메시지를 함께 노출하므로 본 PR 의 surface 에서는 충분. 후속 PR 에서 별도 stale data 패널이 필요할 수 있으나 본 PR 의 root-fix 범위 밖.
- dashboard 가 아닌 backend 가 404 를 내는 원인 — 별개의 keeper lifecycle 이슈로 본 PR 은 frontend silent fallback 만 close.

## Draft 유지 이유

agent PR 정책: `gh pr ready` 호출 금지. human-approved-ready 라벨은 사용자 환경 게이트 경유.