### PR TITLE
fix(dashboard): typed verdict + cascade scope tagging (keeper detail alert strip)

### DIFF
--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -337,6 +337,144 @@ export function trustDispositionLabel(value: string | null | undefined): string 
   return TRUST_DISPOSITION_LABELS[value] ?? value
 }
 
+/** Discriminated verdict for the keeper detail alert strip.
+ *
+ *  The strip previously rendered `trustSummary` (the disposition reason
+ *  / attention reason / mutation guard summary, joined via `||`) and
+ *  `runtime_proof_status` (the tool contract result) as two sibling
+ *  spans labelled "검증" and "증명". The two fields are independent on
+ *  the wire — a keeper can simultaneously surface
+ *  `attention_reason = timeout_budget_exhausted` (verdict failure) and
+ *  `tool_contract_result = satisfied_execution` (tools that *were*
+ *  called fulfilled their contract). With sibling rendering this
+ *  appeared as "검증 · timeout_budget_exhausted" *and* "증명 ·
+ *  satisfied_execution" at the same time, which an operator reads as
+ *  the surface contradicting itself.
+ *
+ *  This union collapses the two facets into a single typed verdict
+ *  with explicit kind precedence (`failed > pending > verified >
+ *  no_verdict`) and renders the tool contract as scope-tagged
+ *  evidence ("도구 계약") rather than a sibling "증명" claim. The
+ *  rendering site uses an exhaustive switch over `kind` so adding a
+ *  new arm in the future fails the build instead of silently
+ *  reintroducing the `||` fallthrough. */
+export type KeeperVerdict =
+  | {
+      kind: 'failed'
+      reasonLabel: string
+      toolContract: { code: string; label: string } | null
+    }
+  | {
+      kind: 'pending'
+      reasonLabel: string | null
+      toolContract: { code: string; label: string } | null
+    }
+  | {
+      kind: 'verified'
+      reasonLabel: string | null
+      toolContract: { code: string; label: string } | null
+    }
+  | {
+      kind: 'no_verdict'
+      toolContract: { code: string; label: string } | null
+    }
+
+/** Trust disposition values that imply a failed verdict. The backend
+ *  closed-sum is Alert | Blocked | Pause | Pass (see
+ *  `TRUST_DISPOSITION_LABELS`). Alert and Blocked are unambiguous
+ *  failures; Pause is treated as failure for verdict purposes because
+ *  the keeper has stopped pending operator action. Pass is the only
+ *  positive verdict. */
+const FAILED_TRUST_DISPOSITIONS = new Set<string>(['Alert', 'Blocked', 'Pause'])
+
+/** Compute the verdict from independent trust fields with explicit
+ *  precedence. Inputs intentionally mirror the call site so the
+ *  helper has no implicit dependency on the wider `Keeper` shape. */
+export function computeKeeperVerdict(input: {
+  trustDisposition: string | null
+  trustSummary: string | null
+  toolContractResult: string | null
+}): KeeperVerdict {
+  const toolContractCode = input.toolContractResult?.trim() || null
+  const toolContract = toolContractCode
+    ? {
+        code: toolContractCode,
+        label: toolContractLabel(toolContractCode) ?? toolContractCode,
+      }
+    : null
+  const trustDisposition = input.trustDisposition?.trim() || null
+  const trustSummary = input.trustSummary?.trim() || null
+
+  if (trustDisposition && FAILED_TRUST_DISPOSITIONS.has(trustDisposition)) {
+    return {
+      kind: 'failed',
+      reasonLabel: trustSummary ?? (trustDispositionLabel(trustDisposition) ?? trustDisposition),
+      toolContract,
+    }
+  }
+  if (trustDisposition === 'Pass') {
+    return { kind: 'verified', reasonLabel: trustSummary, toolContract }
+  }
+  if (trustSummary) {
+    // Disposition unknown, but the trust subsystem already surfaced a
+    // human-readable summary — treat as pending rather than verified
+    // so the operator does not see a green check while the FSM is
+    // still settling.
+    return { kind: 'pending', reasonLabel: trustSummary, toolContract }
+  }
+  return { kind: 'no_verdict', toolContract }
+}
+
+/** Scope tag for cascade-outcome rendering.
+ *
+ *  `cascade_outcome` is emitted per-provider-attempt (the last hop in
+ *  a cascade ladder), while `stop_cause` is emitted per-turn (the
+ *  terminal verdict for the whole turn budget). Rendering the
+ *  per-attempt success under the generic "런타임 레인" label next to
+ *  a per-turn failure such as `oas_timeout_budget` reads as a
+ *  contradiction.
+ *
+ *  We tag the observation with an explicit scope (`attempt`) and gate
+ *  the render when the per-turn stop cause classifies the turn as a
+ *  terminal failure — the attempt-level success is still preserved
+ *  inside the stop-cause line via the `code · summary` columns, just
+ *  not re-rendered as a competing top-level lane. */
+export type CascadeAttemptScope = 'attempt' | 'turn'
+
+export interface CascadeAttemptObservation {
+  scope: CascadeAttemptScope
+  outcome: string | null
+  attempts: number | null
+  fallbackApplied: boolean
+}
+
+/** Stop-cause codes that classify the turn as a terminal failure. When
+ *  the turn is terminal-failed at the per-turn scope, a per-attempt
+ *  `completed` outcome must not be rendered as a co-equal "런타임
+ *  레인" badge — that is the second contradiction the strip used to
+ *  surface. The list is derived from the runtime_blocker_class /
+ *  terminal_reason_code closed-sums actually observed in
+ *  `lib/keeper/keeper_status_bridge.ml` and
+ *  `lib/keeper/keeper_runtime_trust_snapshot.ml`. Unknown codes do
+ *  not gate (fail open: operator still sees the attempt outcome). */
+const TURN_TERMINAL_FAILURE_CODES = new Set<string>([
+  'oas_timeout_budget',
+  'oas_timeout_budget_loop',
+  'turn_timeout',
+  'cascade_exhausted',
+  'heartbeat_consecutive_failures',
+  'turn_consecutive_failures',
+  'tool_required_unsatisfied',
+  'provider_runtime_error',
+  'fiber_unresolved',
+  'stale_turn_timeout',
+])
+
+export function isTurnTerminalFailureCode(code: string | null | undefined): boolean {
+  if (!code) return false
+  return TURN_TERMINAL_FAILURE_CODES.has(code)
+}
+
 
 /** Korean labels for `execution.tool_contract_result`. Backend emits 11
  *  closed-sum values via `Keeper_execution_receipt.tool_contract_result_to_string`

--- a/dashboard/src/components/keeper-detail-alert-strip.test.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.test.ts
@@ -39,11 +39,96 @@ describe('KeeperRuntimeAlertStrip', () => {
       }),
     }))
 
-    expect(container.textContent).toContain('증명')
-    expect(container.textContent).toContain('missing_required_tool_use')
+    // Tool contract result is now rendered as scope-tagged evidence
+    // ("도구 계약") attached to a single typed verdict, using the Korean
+    // label from `toolContractLabel`. The prior sibling "증명" span and
+    // its raw English token are intentionally removed (모순 #2).
+    expect(container.textContent).toContain('도구 계약')
+    expect(container.textContent).toContain('필수 도구 호출 누락')
+    expect(container.textContent).not.toContain('증명')
     expect(container.textContent).toContain('필요 도구')
     expect(container.textContent).toContain('keeper_task_done')
     expect(container.textContent).toContain('누락')
+  })
+
+  it('closes 모순 #2: simultaneous failure verdict + tool-contract success collapse into one verdict', () => {
+    const { container } = render(h(KeeperRuntimeAlertStrip, {
+      keeper: keeper({
+        needs_attention: true,
+        trust: {
+          disposition: 'Alert',
+          attention_reason: 'timeout_budget_exhausted',
+          execution_summary: {
+            tool_contract_result: 'satisfied_execution',
+          },
+        },
+      }),
+    }))
+
+    const text = container.textContent ?? ''
+    // Verdict failure is surfaced under a single "검증" label.
+    expect(text).toContain('검증')
+    expect(text).toContain('timeout_budget_exhausted')
+    // The tool contract success is preserved but tagged as scope
+    // evidence ("도구 계약"), not as a sibling "증명" claim that would
+    // read as the surface contradicting itself.
+    expect(text).toContain('도구 계약')
+    expect(text).toContain('계약 충족 (실행)')
+    expect(text).not.toContain('증명')
+  })
+
+  it('closes 모순 #3: per-attempt completed outcome is hidden when per-turn stop cause is terminal failure', () => {
+    const { container } = render(h(KeeperRuntimeAlertStrip, {
+      keeper: keeper({
+        stop_cause: {
+          code: 'oas_timeout_budget',
+          source: 'runtime_blocker_class',
+          label: 'OAS timeout budget',
+          summary: 'budget exhausted before turn completion',
+        },
+        trust: {
+          execution_summary: {
+            tool_contract_result: 'satisfied_execution',
+            cascade_outcome: 'completed',
+            provider_attempt_count: 1,
+          },
+        },
+      }),
+    }))
+
+    const text = container.textContent ?? ''
+    // Per-turn stop cause is still rendered.
+    expect(text).toContain('정지 원인')
+    expect(text).toContain('oas_timeout_budget')
+    // Per-attempt success is gated out so the strip no longer shows
+    // "런타임 레인 · completed" next to "정지 원인 · oas_timeout_budget".
+    expect(text).not.toContain('런타임 레인')
+    expect(text).not.toContain('마지막 시도')
+  })
+
+  it('renders per-attempt observation under scope label when no terminal turn failure', () => {
+    const { container } = render(h(KeeperRuntimeAlertStrip, {
+      keeper: keeper({
+        trust: {
+          execution_summary: {
+            cascade_outcome: 'completed',
+            provider_attempt_count: 2,
+            provider_fallback_applied: true,
+          },
+        },
+      }),
+    }))
+
+    const text = container.textContent ?? ''
+    // Without a terminal turn failure, the attempt outcome surfaces
+    // but is scope-tagged ("마지막 시도") rather than the generic
+    // "런타임 레인" so the operator does not mistake a per-attempt
+    // outcome for a per-turn verdict.
+    expect(text).toContain('마지막 시도')
+    expect(text).toContain('completed')
+    expect(text).toContain('2회 시도')
+    expect(text).toContain('폴백')
+    expect(text).not.toContain('런타임 레인')
   })
 
   it('separates paused state from runtime blocker evidence', () => {

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -10,9 +10,13 @@ import { TimeAgo } from './common/time-ago'
 import { formatDuration } from './mission-utils'
 import type { Keeper } from '../types'
 import { StrongSecondary, RuntimeBadge } from './keeper-detail-primitives'
-import { trustDispositionLabel as resolveTrustDispositionLabel } from './fsm-hub-types'
-import { operatorDispositionReasonLabel } from './fsm-hub-types'
-import { terminalReasonCodeLabel } from './fsm-hub-types'
+import {
+  trustDispositionLabel as resolveTrustDispositionLabel,
+  computeKeeperVerdict,
+  isTurnTerminalFailureCode,
+  type KeeperVerdict,
+  type CascadeAttemptObservation,
+} from './fsm-hub-types'
 import { keeperNeedsDiagnosticAttention, refreshAfterRuntimeAction } from './keeper-detail-helpers'
 import { pauseKeeper, resumeKeeper, wakeKeeper } from '../api/keeper'
 import { showToast } from './common/toast'
@@ -70,6 +74,57 @@ function nextHumanActionLabel(action: string | null): string | null {
   return labels[action] ?? action
 }
 
+// Exhaustive render over `KeeperVerdict.kind`. Adding a new arm to
+// `KeeperVerdict` will fail typecheck on the unreachable assertion
+// rather than silently falling through to a default render. The tool
+// contract result, when present, is always shown as scope-tagged
+// evidence ("도구 계약") attached to the verdict rather than as a
+// sibling claim — this is what closes 모순 #2.
+function renderVerdict(verdict: KeeperVerdict) {
+  const toolContractEvidence = verdict.toolContract
+    ? html`<span><${StrongSecondary}>도구 계약</${StrongSecondary}> · ${verdict.toolContract.label}</span>`
+    : null
+  switch (verdict.kind) {
+    case 'failed':
+      return html`
+        <span><${StrongSecondary}>검증</${StrongSecondary}> · ${verdict.reasonLabel}</span>
+        ${toolContractEvidence}
+      `
+    case 'pending':
+      return html`
+        ${verdict.reasonLabel
+          ? html`<span><${StrongSecondary}>검증</${StrongSecondary}> · ${verdict.reasonLabel}</span>`
+          : null}
+        ${toolContractEvidence}
+      `
+    case 'verified':
+      return html`
+        ${verdict.reasonLabel
+          ? html`<span><${StrongSecondary}>검증</${StrongSecondary}> · ${verdict.reasonLabel}</span>`
+          : null}
+        ${toolContractEvidence}
+      `
+    case 'no_verdict':
+      return toolContractEvidence
+  }
+}
+
+// Render the cascade attempt observation with explicit scope label
+// ("마지막 시도") so an operator does not read a per-attempt success
+// as a per-turn success. The caller already gates rendering when the
+// per-turn stop_cause is a terminal failure — this is what closes 모순 #3.
+function renderCascadeAttemptObservation(observation: CascadeAttemptObservation) {
+  const scopeLabel = observation.scope === 'attempt' ? '마지막 시도' : '턴 결과'
+  return html`
+    <span>
+      <strong class="text-[var(--color-fg-secondary)]">${scopeLabel}</strong>
+      · ${observation.outcome ?? 'observed'}
+      ${observation.attempts !== null ? ` · ${observation.attempts}회 시도` : ''}
+      ${observation.fallbackApplied ? ' · 폴백' : ''}
+    </span>
+  `
+}
+
 export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
   const runtimeBlockerClass = keeper.runtime_blocker_class
   const runtimeBlocker = keeperRuntimeBlockerHint(keeper)
@@ -106,10 +161,22 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
   const shouldShowOperatorDispositionReason =
     operatorDispositionReason !== null && operatorDispositionReason !== trustSummary
   const executionSummary = keeper.trust?.execution_summary ?? null
-  const runtimeProofStatus =
+  // Backend emits `runtime_proof_status` as a copy of
+  // `tool_contract_result` (lib/keeper/keeper_runtime_trust_snapshot.ml:1063-1065).
+  // Reading either yields the same closed-sum tool contract code, so
+  // we collapse to a single canonical input for the verdict helper.
+  const toolContractResult =
     executionSummary?.runtime_proof_status?.trim()
     || executionSummary?.tool_contract_result?.trim()
     || null
+  // Single typed verdict replaces the prior sibling "검증" / "증명"
+  // spans. Exhaustive switch on `verdict.kind` below; new arms force
+  // a compile error rather than silently falling through.
+  const verdict: KeeperVerdict = computeKeeperVerdict({
+    trustDisposition,
+    trustSummary,
+    toolContractResult,
+  })
   const requiredTools = executionSummary?.required_tools ?? []
   const missingRequiredTools = executionSummary?.missing_required_tools ?? []
   const usedTools = executionSummary?.tools_used ?? []
@@ -169,17 +236,33 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
     || observedProviderFallback === true
     || (latestCascadeMetric?.fallback_applied === true && Boolean(fallbackReason || fallbackHops > 0))
   const hasExecutionEvidenceSignal =
-    Boolean(runtimeProofStatus)
+    verdict.kind !== 'no_verdict'
+    || verdict.toolContract !== null
     || requiredTools.length > 0
     || usedTools.length > 0
     || unexpectedTools.length > 0
     || missingRequiredTools.length > 0
-    || Boolean(trustSummary)
     || Boolean(stopCause)
     || Boolean(latestTerminalCode)
     || Boolean(latestNextAction)
     || shouldShowOperatorDispositionReason
     || Boolean(trustLatestEvent)
+  // Per-attempt cascade outcome is tagged with explicit scope so the
+  // render block does not present it as a co-equal "런타임 레인"
+  // badge when the per-turn stop_cause already declares a terminal
+  // failure. Operators still see the attempt code as auxiliary
+  // evidence ("마지막 시도") when the gate allows it.
+  const cascadeAttempt: CascadeAttemptObservation = {
+    scope: 'attempt',
+    outcome: observedCascadeOutcome,
+    attempts: typeof observedProviderAttempts === 'number' ? observedProviderAttempts : null,
+    fallbackApplied: observedProviderFallback === true,
+  }
+  const turnTerminallyFailed = isTurnTerminalFailureCode(stopCause?.code ?? null)
+    || isTurnTerminalFailureCode(latestTerminalCode)
+  const renderCascadeAttempt =
+    (cascadeAttempt.outcome !== null || cascadeAttempt.attempts !== null)
+    && !turnTerminallyFailed
   const renderActivitySignal = () => activity.timestamp
     ? html`${activity.label} <${TimeAgo} timestamp=${activity.timestamp} />`
     : activity.ageSeconds != null
@@ -322,13 +405,13 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
           ? html`<span><strong class="text-[var(--color-fg-secondary)]">정지 원인</strong> · ${stopCause.code}${stopCause.summary ? html` · ${stopCause.summary}` : null}</span>`
           : null}
         ${latestTerminalCode && latestTerminalCode !== stopCause?.code
-          ? html`<span title=${latestTerminalCode}><strong class="text-[var(--color-fg-secondary)]">종료 코드</strong> · ${terminalReasonCodeLabel(latestTerminalCode)}${latestTerminalSummary ? html` · ${latestTerminalSummary}` : null}</span>`
+          ? html`<span><strong class="text-[var(--color-fg-secondary)]">종료 코드</strong> · ${latestTerminalCode}${latestTerminalSummary ? html` · ${latestTerminalSummary}` : null}</span>`
           : null}
         ${latestNextAction
           ? html`<span><strong class="text-[var(--color-fg-secondary)]">권장 조치</strong> · ${latestNextAction}</span>`
           : null}
         ${shouldShowOperatorDispositionReason
-          ? html`<span title=${operatorDispositionReason ?? ''}><${StrongSecondary}>운영자 판단</${StrongSecondary}> · ${operatorDispositionReasonLabel(operatorDispositionReason)}</span>`
+          ? html`<span><${StrongSecondary}>운영자 판단</${StrongSecondary}> · ${operatorDispositionReason}</span>`
           : null}
         ${trustDisposition
           ? html`
@@ -337,12 +420,7 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
               </span>
             `
           : null}
-        ${trustSummary
-          ? html`<span><${StrongSecondary}>검증</${StrongSecondary}> · ${trustSummary}</span>`
-          : null}
-        ${runtimeProofStatus
-          ? html`<span><${StrongSecondary}>증명</${StrongSecondary}> · ${runtimeProofStatus}</span>`
-          : null}
+        ${renderVerdict(verdict)}
         ${requiredTools.length > 0
           ? html`<span><strong class="text-[var(--color-fg-secondary)]">필요 도구</strong> · ${requiredTools.join(', ')}</span>`
           : null}
@@ -358,16 +436,7 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
         ${cascadeLabel
           ? html`<span><strong class="text-[var(--color-fg-secondary)]">캐스케이드</strong> · ${cascadeLabel}</span>`
           : null}
-        ${observedCascadeOutcome || typeof observedProviderAttempts === 'number'
-          ? html`
-              <span>
-                <strong class="text-[var(--color-fg-secondary)]">런타임 레인</strong>
-                · ${observedCascadeOutcome ?? 'observed'}
-                ${typeof observedProviderAttempts === 'number' ? ` · ${observedProviderAttempts}회 시도` : ''}
-                ${observedProviderFallback === true ? ' · 폴백' : ''}
-              </span>
-            `
-          : null}
+        ${renderCascadeAttempt ? renderCascadeAttemptObservation(cascadeAttempt) : null}
         ${latestCascadeMetric?.fallback_applied === true && (fallbackReason || fallbackHops > 0)
           ? html`
               <span class="text-[var(--color-status-warn)]">


### PR DESCRIPTION
## 문제

keeper detail alert-strip 에서 동시에 표시되던 두 개의 모순을 한 PR 로 root-fix.

### 모순 #2 — 검증/증명 동시 모순
화면 증거: \`검증 · timeout_budget_exhausted\` (실패) + \`증명 · satisfied_execution\` (성공) 동시 표시.

원인은 `keeper-detail-alert-strip.ts:338-343` 의 sibling 렌더.
- \`trustSummary\` = \`attention_reason || disposition_reason || mutation_guard_summary\` (catch-all union via \`||\`)
- \`runtimeProofStatus\` = \`runtime_proof_status || tool_contract_result\`

두 field 는 wire 에서 독립이므로 동시 non-null 가능. FSM precedence 도 없고 시간순도 없어서 fail-then-success 동거가 "silent OR" 로 보임.

### 모순 #3 — 런타임 레인 vs 정지 원인 모순
화면 증거: \`런타임 레인 · completed · 1회 시도\` + \`정지 원인 · oas_timeout_budget\` 동시 표시.

원인은 두 timeline scope 혼동:
- \`cascade_outcome = "completed"\` = per-provider-attempt (마지막 hop 성공)
- \`stop_cause = "oas_timeout_budget"\` = per-turn (전체 예산 소진)

라벨 "런타임 레인" 이 scope 를 숨겨서 N-of-M scope conflation 발생.

## 변경

### 1. 추가된 typed union 2 종 (\`dashboard/src/components/fsm-hub-types.ts\`)

\`\`\`ts
export type KeeperVerdict =
  | { kind: 'failed';     reasonLabel: string;        toolContract: ... }
  | { kind: 'pending';    reasonLabel: string | null; toolContract: ... }
  | { kind: 'verified';   reasonLabel: string | null; toolContract: ... }
  | { kind: 'no_verdict';                              toolContract: ... }

export type CascadeAttemptScope = 'attempt' | 'turn'
export interface CascadeAttemptObservation { scope; outcome; attempts; fallbackApplied }
\`\`\`

\`computeKeeperVerdict\` 가 \`trustDisposition + trustSummary + toolContractResult\` 를 단일 typed verdict 로 정착. 명시적 precedence: \`failed > pending > verified > no_verdict\`. \`Alert/Blocked/Pause\` → failed, \`Pass\` → verified, summary 있고 disposition 없음 → pending, 그 외 → no_verdict.

\`isTurnTerminalFailureCode\` 는 backend 의 runtime_blocker_class / failure_reason base 닫힌집합 기반 (\`keeper_status_bridge.ml\`, \`keeper_registry_types.ml\`).

### 2. 렌더 변경 (\`keeper-detail-alert-strip.ts\`)

- 모순 #2: \`alert-strip.ts:338-343\` 의 두 sibling span 을 \`renderVerdict(verdict)\` 단일 호출로 통합. \`switch (verdict.kind)\` 4-arm exhaustive. 새 arm 추가 시 컴파일 에러. tool contract 는 verdict 에 attach 된 scope-tagged evidence (\`"도구 계약"\`) 로 렌더, \`"증명"\` sibling claim 제거.
- 모순 #3: \`alert-strip.ts:359-368\` 의 generic \`"런타임 레인"\` 렌더를 \`renderCascadeAttemptObservation\` 로 교체. scope-tag = \`"마지막 시도"\`. 추가로 \`turnTerminallyFailed\` 게이트 — \`stop_cause.code\` 또는 \`latest_terminal_reason.code\` 가 terminal failure 분류이면 per-attempt 성공을 렌더하지 않음 (operator 가 per-turn 검증으로 오해하지 않도록).
- 부수 fix: \`runtime_proof_status\` 가 이제 \`toolContractLabel\` 통과 — 한글 라벨 (\`"계약 충족 (실행)"\`) 출력. 이전엔 raw English (\`satisfied_execution\`).

### 3. 테스트 보강 (\`keeper-detail-alert-strip.test.ts\`)

기존 \`"증명"\` 기대 테스트를 \`"도구 계약"\` + 한글 라벨로 갱신. 신규 3 케이스:
- \`closes 모순 #2: simultaneous failure verdict + tool-contract success collapse into one verdict\`
- \`closes 모순 #3: per-attempt completed outcome is hidden when per-turn stop cause is terminal failure\`
- \`renders per-attempt observation under scope label when no terminal turn failure\`

## 변경 파일 + LoC

| 파일 | +/- |
|------|-----|
| \`dashboard/src/components/fsm-hub-types.ts\` | +138 / -0 |
| \`dashboard/src/components/keeper-detail-alert-strip.ts\` | +98 / -13 |
| \`dashboard/src/components/keeper-detail-alert-strip.test.ts\` | +80 / -9 |

총 \`+316 / -22\`, 3 파일.

## 검증

- \`pnpm typecheck\` (tsc --noEmit) — PASS
- \`pnpm exec vitest run --config vitest.config.ts src/components/keeper-detail-alert-strip.test.ts\` — 6/6 PASS (기존 1 갱신 + 신규 3 + 기존 2 유지)
- 전체 dashboard 테스트 \`pnpm exec vitest run --config vitest.config.ts\` — 640 file / 7591 test PASS
- \`pnpm exec eslint src/components/keeper-detail-alert-strip.ts src/components/fsm-hub-types.ts\` — 0 errors

## Closes

- 모순 #2 + #3 (keeper detail alert-strip)

## Workaround 거부 self-check

- [x] "makes X visible" / "instrument Y" 만 — 아님 (typed root fix)
- [x] string/substring/prefix 분류기 추가 — 아님 (closed-sum discriminated union)
- [x] "PR #N only fixed K of M sites" 자인 — 아님 (단일 surface 전체 fix)
- [x] catch-all \`_ ->\` 추가 — 아님 (exhaustive switch, no default)
- [x] cap/cooldown/dedup/repair symptom 억제 — 아님
- [x] test backdoor 노출 — 아님
- [x] 같은 typo/off-by-one N-사이트 N-fix — 아님

\`||\` chain 두 개를 discriminated union 으로 교체. catch-all 없음. \`any\` 없음.