### PR TITLE
fix(dashboard): typed semantic for fsm hub memory counters (no ratio implication)

### DIFF
--- a/dashboard/src/components/counter-format.test.ts
+++ b/dashboard/src/components/counter-format.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import {
+  formatRatioPair,
+  formatIndependentCounters,
+} from './counter-format'
+
+describe('counter-format', () => {
+  describe('formatRatioPair', () => {
+    it('renders numerator/denominator with a slash', () => {
+      expect(formatRatioPair({ numerator: 3, denominator: 7 })).toBe('3/7')
+    })
+
+    it('renders 0/0 unchanged for empty ratio', () => {
+      expect(formatRatioPair({ numerator: 0, denominator: 0 })).toBe('0/0')
+    })
+
+    it('renders equal values as N/N', () => {
+      expect(formatRatioPair({ numerator: 5, denominator: 5 })).toBe('5/5')
+    })
+  })
+
+  describe('formatIndependentCounters', () => {
+    it('uses label N · label M form (no slash)', () => {
+      const out = formatIndependentCounters({
+        leftLabel: 'inj',
+        leftValue: 909,
+        rightLabel: 'flush',
+        rightValue: 722,
+      })
+      expect(out).toBe('inj 909 · flush 722')
+    })
+
+    it('does not produce ratio-implying slash even when left > right', () => {
+      // Regression: live keepers showed "mem 909/722" (126%). The new format
+      // must never render as "N/M" for independent counters.
+      const out = formatIndependentCounters({
+        leftLabel: 'inj',
+        leftValue: 909,
+        rightLabel: 'flush',
+        rightValue: 722,
+      })
+      expect(out).not.toMatch(/\d+\/\d+/)
+    })
+
+    it('handles zero values explicitly', () => {
+      expect(
+        formatIndependentCounters({
+          leftLabel: 'ok',
+          leftValue: 0,
+          rightLabel: 'error',
+          rightValue: 0,
+        }),
+      ).toBe('ok 0 · error 0')
+    })
+  })
+})

--- a/dashboard/src/components/counter-format.ts
+++ b/dashboard/src/components/counter-format.ts
@@ -1,0 +1,52 @@
+// Counter display helpers that separate two semantically distinct shapes:
+//
+//   1. RatioPair  — invariant: numerator ≤ denominator. Safe to render as
+//                   "N/M" because that visually implies a "of-quota" ratio.
+//                   Examples: manifest_returned_rows / manifest_total_rows,
+//                   context_compacted_count / context_compact_started_count,
+//                   provider_attempt_finished_count / provider_attempt_started_count.
+//
+//   2. IndependentCounters — two monotonic lifetime counters with NO ordering
+//                   invariant between them. Rendering as "N/M" implicates a
+//                   ratio (e.g. "909/722" reads as 126% used-of-quota) which
+//                   is wrong. We render these with explicit labels and a
+//                   non-slash separator to remove the ratio implication.
+//                   Examples: memory_injected_count vs memory_flushed_count
+//                   (injected events and flushed events are independent
+//                   lifetime tallies), memory_flush_success_count vs
+//                   memory_flush_error_count.
+//
+// The split exists because we observed live keepers showing "mem 909/722"
+// (126%) — telemetry-as-fix anti-pattern where two independent counters were
+// jammed into a ratio-shaped UI without typed disambiguation.
+
+export type RatioPair = {
+  readonly numerator: number
+  readonly denominator: number
+}
+
+export type IndependentCounters = {
+  readonly leftLabel: string
+  readonly leftValue: number
+  readonly rightLabel: string
+  readonly rightValue: number
+}
+
+/**
+ * Render a ratio pair as "N/M". Caller asserts numerator ≤ denominator
+ * as a domain invariant; this helper does not enforce it at runtime
+ * because the values originate from backend cumulative counters where a
+ * transient over-count is itself a signal worth seeing.
+ */
+export function formatRatioPair(pair: RatioPair): string {
+  return `${pair.numerator}/${pair.denominator}`
+}
+
+/**
+ * Render two independent counters with labels and a non-slash separator
+ * (mid dot). Use this whenever the two counts do NOT have a numerator ≤
+ * denominator relationship.
+ */
+export function formatIndependentCounters(counters: IndependentCounters): string {
+  return `${counters.leftLabel} ${counters.leftValue} · ${counters.rightLabel} ${counters.rightValue}`
+}

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -38,6 +38,7 @@ import { OperationalMeaningPanel, HeroPhase, TurnPipelineStrip, CompositeGraphPa
 import { DwellHistogramPanel, SwimlaneTimeline, TopTransitionsPanel, TransitionTrail } from './fsm-hub-timeline-panels'
 import { MeasurementCard, InvariantsPanel } from './fsm-hub-health-panels'
 import { ringFocusClasses } from './common/ring'
+import { formatIndependentCounters, formatRatioPair } from './counter-format'
 
 // ── Backward-compatible re-exports ─────────────────────
 // External consumers (agents-unified.ts, fsm-hub.test.ts)
@@ -262,20 +263,39 @@ function runtimeTraceTitle(trace: KeeperRuntimeTraceResponse): string {
     `trace_id: ${trace.trace_id || '(unknown)'}`,
     trace.stale_reason ? `stale_reason: ${trace.stale_reason}` : '',
     trace.manifest_path ? `manifest: ${trace.manifest_path}` : '',
-    `manifest rows: ${trace.manifest_returned_rows}/${trace.manifest_total_rows}`,
+    // manifest_returned_rows ≤ manifest_total_rows is a true invariant pair.
+    `manifest rows: ${formatRatioPair({ numerator: trace.manifest_returned_rows, denominator: trace.manifest_total_rows })}`,
     `receipt rows: ${trace.receipt_returned_rows}`,
 	    turn.manifest_keeper_turn_ids.length > 0 ? `keeper_turn_ids: ${turn.manifest_keeper_turn_ids.join(', ')}` : '',
 	    turn.receipt_turn_counts.length > 0 ? `receipt_turn_counts: ${turn.receipt_turn_counts.join(', ')}` : '',
-	    `provider attempts: ${turn.provider_attempt_started_count}/${turn.provider_attempt_finished_count}`,
+	    // provider_attempt_finished ≤ provider_attempt_started is a true invariant pair
+	    // (a finish is always preceded by a start). Started is the denominator.
+	    `provider attempts: ${formatRatioPair({ numerator: turn.provider_attempt_finished_count, denominator: turn.provider_attempt_started_count })}`,
 	    provider.terminal_status ? `provider terminal: ${provider.terminal_status}` : '',
 	    provider.terminal_exception_kind ? `provider exception: ${provider.terminal_exception_kind}` : '',
 	    provider.terminal_error ? `provider error: ${shortText(provider.terminal_error, 220)}` : '',
 	    eventBus.correlation_ids.length > 0 ? `correlation_ids: ${eventBus.correlation_ids.join(', ')}` : '',
     eventBus.run_ids.length > 0 ? `run_ids: ${eventBus.run_ids.join(', ')}` : '',
-    `context compaction: ${eventBus.context_compacted_count}/${eventBus.context_compact_started_count}`,
+    // context_compacted ≤ context_compact_started is a true invariant pair.
+    `context compaction: ${formatRatioPair({ numerator: eventBus.context_compacted_count, denominator: eventBus.context_compact_started_count })}`,
     formatRuntimeTraceUnknown(eventBus.last_compaction),
-    `memory injected/flushed: ${memory.memory_injected_count}/${memory.memory_flushed_count}`,
-    `memory flush ok/error: ${memory.memory_flush_success_count}/${memory.memory_flush_error_count}`,
+    // memory_injected_count and memory_flushed_count are independent monotonic
+    // lifetime counters — no invariant relation between them. Avoid slash UI
+    // (e.g. "909/722" would read as 126% ratio).
+    `memory: ${formatIndependentCounters({
+      leftLabel: 'injected',
+      leftValue: memory.memory_injected_count,
+      rightLabel: 'flushed',
+      rightValue: memory.memory_flushed_count,
+    })}`,
+    // memory_flush_success_count and memory_flush_error_count are independent
+    // outcome tallies (one or the other increments per flush), not a ratio.
+    `memory flush: ${formatIndependentCounters({
+      leftLabel: 'ok',
+      leftValue: memory.memory_flush_success_count,
+      rightLabel: 'error',
+      rightValue: memory.memory_flush_error_count,
+    })}`,
   ].filter(Boolean).join('\n')
 }
 
@@ -300,10 +320,10 @@ function RuntimeEvidenceSummary({
 	      ${runtimeProviderAttemptLabel(trace)}
 	    </span>
 	    <span class=${`${commonClass} border-[var(--info-border)] text-[var(--info-fg)]`} title=${title}>
-      evt ${eventBus.event_bus_correlated_count} · ctx ${eventBus.context_compacted_count}/${eventBus.context_compact_started_count}
+      evt ${eventBus.event_bus_correlated_count} · ctx ${formatRatioPair({ numerator: eventBus.context_compacted_count, denominator: eventBus.context_compact_started_count })}
     </span>
     <span class=${`${commonClass} border-[var(--color-border-default)] text-[var(--color-fg-muted)]`} title=${title}>
-      mem ${memory.memory_injected_count}/${memory.memory_flushed_count}
+      mem ${formatIndependentCounters({ leftLabel: 'inj', leftValue: memory.memory_injected_count, rightLabel: 'flush', rightValue: memory.memory_flushed_count })}
     </span>
   `
 }


### PR DESCRIPTION
## 요약

FSM hub footer 의 `mem 909/722` (126%) 처럼 독립 lifetime counter 두 개를 `X/Y` slash-format 으로 표시해 ratio 처럼 보이던 모순을 typed semantic 분리로 root-fix.

- `memory_injected_count` 와 `memory_flushed_count` 는 독립 monotonic counter — `injected ≤ flushed` 같은 invariant 없음. 정상 동작 중에도 `injected > flushed` 가능.
- 기존 `mem ${injected}/${flushed}` 는 "used / quota" ratio 를 강하게 implicate.
- **Telemetry-as-fix 안티패턴**: counter 두 개를 typed semantic 없이 같은 ratio UI 에 박은 결과.

## 변경

### `dashboard/src/components/counter-format.ts` (new, +52)
두 헬퍼로 의미 분리:
- `formatRatioPair({ numerator, denominator })` → `"N/M"`. caller 가 `numerator ≤ denominator` invariant 를 도메인 차원에서 보장하는 경우에만 사용 (예: `manifest_returned_rows / manifest_total_rows`).
- `formatIndependentCounters({ leftLabel, leftValue, rightLabel, rightValue })` → `"label N · label M"`. ratio implication 제거.

JSDoc 으로 두 함수의 사용 조건 명시. 형식적 타입 강제(brand type 등)는 어렵지만 helper 이름 + 주석 + 호출부 의도가 코드 리뷰 시점에서 잡힘.

### `dashboard/src/components/fsm-hub.ts` (~34 LoC delta)
`RuntimeEvidenceSummary` footer chip + `runtimeTraceTitle` 모두 라우팅:

**Independent counters** (slash 제거):
- `memory injected/flushed: 909/722` → `memory: injected 909 · flushed 722`
- `memory flush ok/error: X/Y` → `memory flush: ok X · error Y`
- footer chip `mem 909/722` → `mem inj 909 · flush 722`

**True invariant pairs** (slash 유지, helper 경유):
- `manifest rows: returned/total`
- `provider attempts: finished/started` (finished ≤ started, 인자 순서 정정)
- `context compaction: compacted/started`
- footer chip `ctx X/Y`

### `dashboard/src/components/counter-format.test.ts` (new, +56)
6 케이스: `formatRatioPair` 3개, `formatIndependentCounters` 3개. 회귀 케이스로 `inj=909, flush=722` 입력이 `/` 를 절대 포함하지 않음을 명시 (`not.toMatch(/\d+\/\d+/)`).

## Before / After

**Before** (live keeper screenshot evidence):
```
mem 909/722        ← 126% 처럼 보임
```

**After**:
```
mem inj 909 · flush 722
```

Title tooltip 도 동일:
```
memory: injected 909 · flushed 722
memory flush: ok 12 · error 0
```

## 검증

- `pnpm typecheck` PASS (no `any`, no new lint).
- `pnpm vitest run src/components/counter-format.test.ts` → 6/6 PASS.
- `pnpm vitest run src/components/fsm-hub` → 9 files, 255/255 PASS.

## 사이드 사이트 (out of scope)

같은 `mem ${injected}/${flushed}` 패턴이 `dashboard/src/components/journey-panel.ts:238` 에도 존재. 본 PR scope (FSM hub footer 모순 #5) 와 별개라 미포함. 동일 helper 로 후속 PR 에서 정리 가능.

`dashboard/src/components/keeper-detail-runtime.ts:932-934` 의 `inj ${present}/${injected}` (present ≤ injected 는 진짜 invariant pair) 와 `flush ${success}/${error}` (독립) 는 mixed — 별도 검토 필요. 본 PR 미포함.

## CONFLICT 체크

PR #16553 은 `fsm-hub.ts` line 347+ (reducer/view projection) 영역만 건드림. 본 PR 은 line 263-323 영역 (`runtimeTraceTitle`, `RuntimeEvidenceSummary`) 만 수정 → **conflict 없음** (`git diff origin/main --stat` 기준 fsm-hub.ts 단일 파일).

Closes: 모순 #5 (keeper detail FSM hub mem 909/722 ratio implication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)