### PR TITLE
fix(lint): refresh spawn-bounded allowlist line ref (1442 → 1281)

### DIFF
--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -31,8 +31,8 @@ lib/process/process_eio.ml:493
 # manager itself. Bounded by session scope, not by per-call timeout.
 lib/server/lsp_process_manager.ml:178
 
-# lib/worker_dev_tools.ml:1442 — dev-tools worker spawn. Wrapped by
+# lib/worker_dev_tools.ml:1281 — dev-tools worker spawn. Wrapped by
 # Tool_resource_gate, Fd_accountant, Eio.Time.with_timeout_exn, and a fresh
 # Eio.Switch.run at the call boundary. Line renumbered by worker-dev-tools
 # split/refactor waves.
-lib/worker_dev_tools.ml:1442
+lib/worker_dev_tools.ml:1281


### PR DESCRIPTION
## 목적

`Spawn-bounded ratchet` lint 가 모든 PR 에 대해 `STALE allowlist entry` 로 FAIL —
`lib/worker_dev_tools.ml:1442` 가 split/refactor 로 옮겨가 실제 spawn 은 line 1281.

## 변경

`scripts/lint-spawn-bounded.allowlist` 의 line ref + 주석 1442 → 1281.

## 영향

- 5종 모순 sprint 의 3 PR (#16551 / #16553 / #16555 / #16557) 모두 동일 stale 로 차단 — 본 PR 머지 후 rebase 로 unblock.
- worker_dev_tools.ml:1281 의 spawn 은 fresh `Eio.Switch.run` (line 1275) 안에서 wrap — RFC-0109 SSOT 정책 (b) 충족.

## 검증

- `sed -n '1275,1290p' lib/worker_dev_tools.ml` 로 spawn site + Eio.Switch.run wrap 확인.
- 변경 1 파일, +2 / -2.

RFC-WAIVED: lint 메타 워크플로 (workflow* 영역 아님)