### PR TITLE
fix: separate keeper tool presence from progress gates

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -705,7 +705,7 @@ let run_turn
                        }
                      ~required_tool_satisfaction:(fun call ->
                        Keeper_tool_disclosure
-                       .required_tool_satisfaction_for_required_names
+                       .required_tool_satisfaction_for_turn
                          ~required_tool_names:acc.tool_surface.required_tool_names
                          call)
                      ~max_turns

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -518,6 +518,16 @@ let required_tool_satisfaction_for_required_names
   else required_tool_satisfaction call
 ;;
 
+let required_tool_satisfaction_for_turn
+      ~(required_tool_names : string list)
+      (call : Agent_sdk.Completion_contract.tool_call)
+  : (unit, string) result
+  =
+  match required_tool_names with
+  | [] -> Ok ()
+  | _ -> required_tool_satisfaction_for_required_names ~required_tool_names call
+;;
+
 let classify_tool_progress name =
   if is_keeper_observation_alias name
   then Passive_status

--- a/lib/keeper/keeper_tool_disclosure.mli
+++ b/lib/keeper/keeper_tool_disclosure.mli
@@ -183,6 +183,18 @@ val required_tool_satisfaction_for_required_names
   -> Agent_sdk.Completion_contract.tool_call
   -> (unit, string) result
 
+(** OAS-level satisfaction callback for keeper turns.
+
+    Generic required-tool gates use OAS to enforce tool presence only; MASC
+    classifies passive-only / no-execution-progress calls after the run, where
+    it can emit a precise receipt without converting the turn into a provider
+    contract error that can durable-pause the keeper. Explicit
+    [required_tool_names] still require the named tool. *)
+val required_tool_satisfaction_for_turn
+  :  required_tool_names:string list
+  -> Agent_sdk.Completion_contract.tool_call
+  -> (unit, string) result
+
 (** Project a tool name to its [tool_progress_class]. *)
 val classify_tool_progress : string -> tool_progress_class
 

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -9859,6 +9859,38 @@ let test_explicit_required_tool_satisfaction_accepts_named_passive_tool () =
        (`Assoc []))
 ;;
 
+let test_turn_required_tool_satisfaction_keeps_generic_presence_separate () =
+  check
+    bool
+    "generic required-action predicate still rejects passive board read"
+    false
+    (satisfies_required_tool "keeper_board_get" (`Assoc []));
+  check
+    bool
+    "turn-level generic gate accepts passive tool presence for post-run classification"
+    true
+    (Result.is_ok
+       (KTD.required_tool_satisfaction_for_turn
+          ~required_tool_names:[]
+          (required_tool_call "keeper_board_get" (`Assoc []))));
+  check
+    bool
+    "explicit required action still rejects unrelated passive tool"
+    false
+    (Result.is_ok
+       (KTD.required_tool_satisfaction_for_turn
+          ~required_tool_names:[ "keeper_bash" ]
+          (required_tool_call "keeper_board_get" (`Assoc []))));
+  check
+    bool
+    "explicit named passive tool remains allowed"
+    true
+    (Result.is_ok
+       (KTD.required_tool_satisfaction_for_turn
+          ~required_tool_names:[ "keeper_board_get" ]
+          (required_tool_call "keeper_board_get" (`Assoc []))))
+;;
+
 let test_tool_usage_delta_uses_registry_counts () =
   let before = [ "keeper_board_post", 1; "keeper_fs_read", 0; "keeper_voice_agent", 2 ] in
   let after = [ "keeper_board_post", 1; "keeper_fs_read", 1; "keeper_voice_agent", 4 ] in
@@ -12805,6 +12837,10 @@ let () =
             "explicit required tool predicate accepts named passive tool"
             `Quick
             test_explicit_required_tool_satisfaction_accepts_named_passive_tool
+        ; test_case
+            "turn required tool predicate separates presence from progress"
+            `Quick
+            test_turn_required_tool_satisfaction_keeps_generic_presence_separate
         ; test_case
             "tool usage delta uses registry counts"
             `Quick


### PR DESCRIPTION
## Summary

- Separate OAS-level generic tool presence satisfaction from MASC keeper execution-progress classification.
- Keep explicit `required_tool_names` exact: named required tools still reject unrelated passive calls.
- Add regression coverage for passive board reads under the generic gate versus explicit required tools.

## Product impact

Keeps passive keeper tools like `keeper_board_get`, `keeper_board_list`, and `masc_tasks` from being converted into provider contract failures before MASC can classify the turn as passive/no-progress. This prevents generic `require_tool_use` turns from accumulating durable completion-contract pauses while preserving the stricter execution-progress checks inside MASC.

## Evidence

- `scripts/dune-local.sh build bin/main_eio.exe test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_unified.exe test metrics_observation 60-63`
- `./_build/default/test/test_keeper_unified.exe test transient_network_error 34-35`
- `./_build/default/test/test_keeper_unified.exe test phase_gate 32-38`
- `git diff --check`

## Review evidence

Full `test/test_keeper_unified.exe` was also run before this commit and the newly added `metrics_observation 63` passed. The full run still includes existing unrelated failures in `unified_prompt 30` and OAS timeout-budget cases, so this PR relies on the focused keeper contract/gate checks above plus CI for the broader suite.

## Linked issue

None.
