### PR TITLE
fix(dashboard): align fsm-hub-types paused label with canonical '일시정지'

### DIFF
--- a/dashboard/src/components/fsm-hub-types.test.ts
+++ b/dashboard/src/components/fsm-hub-types.test.ts
@@ -88,8 +88,8 @@ describe('displayState', () => {
     expect(displayState('idle')).toBe('대기')
     expect(displayState('executing')).toBe('실행 중')
     expect(displayState('Crashed')).toBe('비정상 종료')
-    expect(displayState('Paused')).toBe('일시 중지')
-    expect(displayState('paused')).toBe('일시 중지')
+    expect(displayState('Paused')).toBe('일시정지')
+    expect(displayState('paused')).toBe('일시정지')
     expect(displayState('crashed')).toBe('비정상 종료')
   })
 

--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -178,7 +178,7 @@ export const STATE_DISPLAY_NAMES: Record<string, string> = {
   handing_off: '인수인계',
   draining: '종료 준비',
   offline: '오프라인',
-  paused: '일시 중지',
+  paused: '일시정지',
   stopped: '정지',
   crashed: '비정상 종료',
   restarting: '재시작 중',
@@ -191,7 +191,7 @@ export const STATE_DISPLAY_NAMES: Record<string, string> = {
   Failing: '오류 발생',
   Crashed: '비정상 종료',
   Offline: '오프라인',
-  Paused: '일시 중지',
+  Paused: '일시정지',
   Stopped: '정지',
   Draining: '종료 준비',
   Restarting: '재시작 중',
@@ -328,7 +328,7 @@ export function turnLaneLabel(value: string | null | undefined): string | null {
 const TRUST_DISPOSITION_LABELS: Record<string, string> = {
   Alert: '경보',
   Blocked: '차단',
-  Pause: '정지',
+  Pause: '일시정지',
   Pass: '통과',
 }
 


### PR DESCRIPTION
## Why

사용자 보고 (Agent Observatory follow-up):
> "라벨, 상태, 표시, 음 이거 너무 과하게 안되도록 이곳저곳 덕지덕지"

Iter#36 PR #16552 후 vocab audit: **`fsm-hub-types.ts`만 외톨이** — 같은 *paused* concept이 3 라벨로 나뉨.

## Evidence (15+ canonical vs 3 outlier)

| Source | Korean Label |
|--------|--------------|
| `status-label.ts:paused` | **`'일시정지'`** ✓ |
| `monitoring-runtime.ts` (3 entries) | **`'일시정지'`** ✓ |
| `keeper-phase-indicator.ts:Paused` | **`'일시정지'`** ✓ |
| `keeper-action-panel.ts:pause` | **`'일시정지'`** ✓ |
| `keeper-detail-alert-strip.ts:paused` | **`'일시정지'`** ✓ |
| `goal-helpers.ts:paused` | **`'일시정지'`** ✓ |
| `repo-sidebar.ts:paused` | **`'일시정지'`** ✓ |
| `fsm-hub-types.STATE_DISPLAY_NAMES.paused/Paused` | `'일시 중지'` ⚠️ outlier |
| `fsm-hub-types.TRUST_DISPOSITION_LABELS.Pause` | `'정지'` ⚠️ outlier (wrong concept!) |

`TRUST_DISPOSITION_LABELS.Pause`가 `'정지'` 매핑된 것은 *semantic bug*: backend `display_disposition_of_operator`의 `Pause`는 *operator-paused state*인데, `'정지'`는 *stopped/clean-termination* 의미.

## What

3 entries 통일:
```diff
- paused: '일시 중지',
+ paused: '일시정지',
- Paused: '일시 중지',
+ Paused: '일시정지',
- Pause: '정지',  // TRUST_DISPOSITION_LABELS
+ Pause: '일시정지',
```

`stopped`/`Stopped` 라벨 `'정지'`은 **유지** — distinct concept (clean termination), Iter#36 `interrupted ↔ stopped` 분리와 일관.

## Behavior change (intentional)

- Operator가 keeper를 일시정지하면 trust disposition badge가 `'정지'` → `'일시정지'`로 표시. `STATE_DISPLAY_NAMES`의 `Paused` 상태와 동일 vocab.

## Iter series

FSM/TLA+ observability sweep `/loop 20m` cron `253cc0f6` **iter#37**:
- Iter#36 collision fix (#16552) 후 vocab audit
- Phase 2 후속 — *3-way SSOT 분산 narrow alignment*
- 사용자가 8 PR Phase 1 + #16552 일괄 머지 직후
- Sweep: 0 CONFLICTING / 48 open

## Workaround Rejection Bar

- [ ] telemetry-as-fix: 아님
- [ ] string classifier 추가: 아님 (라벨 *통일*)
- [ ] N-of-M: 아님 (file cohort 3/3 outlier 전부 fix)
- [ ] catch-all 추가: 아님

## RFC Check

`bash ~/me/scripts/pr-rfc-check.sh` PASS (exit 0).

## Verification

- 2 files, +5/-5
- Test 갱신 (`fsm-hub-types.test.ts`)
- 같은 file 내 `stopped: '정지'` keep — distinct state

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>