### PR TITLE
feat(worker_execution_spec): report received JSON kind+excerpt in parse errors

### DIFF
--- a/lib/worker_execution_spec.ml
+++ b/lib/worker_execution_spec.ml
@@ -22,7 +22,11 @@ let required_trimmed_string field = function
   | `String value ->
       let trimmed = String.trim value in
       if trimmed = "" then Error (field ^ " must not be empty") else Ok trimmed
-  | _ -> Error (field ^ " must be a string")
+  | `Null -> Error (Printf.sprintf "%s is required (got null)" field)
+  | other ->
+      Error
+        (Printf.sprintf "%s must be a string, got %s: %s" field
+           (Json_util.kind_name other) (Json_util.excerpt other))
 
 let option_string json =
   match json with
@@ -125,4 +129,7 @@ let of_yojson (json : Yojson.Safe.t) =
        | Yojson.Json_error msg -> Error ("worker execution spec JSON error: " ^ msg)
        | Type_error (msg, _) -> Error ("worker execution spec type error: " ^ msg)
        | Failure msg -> Error msg)
-  | _ -> Error "worker execution spec must be a JSON object"
+  | other ->
+      Error
+        (Printf.sprintf "worker execution spec must be a JSON object, got %s: %s"
+           (Json_util.kind_name other) (Json_util.excerpt other))


### PR DESCRIPTION
## Why

`worker_execution_spec.ml`은 worker dispatch boundary의 핵심 deserializer — `masc_worker_up.run` caller가 spec JSON을 reject하면 원본 payload 디버깅 필요. 2 type-shape catch-all이 received kind 누락.

## What

| Line | Function | 변경 |
|------|----------|------|
| L25 | `required_trimmed_string` | `\`Null` (missing) 분리 + non-string `(received <kind>: <excerpt>)` |
| L128 | `of_yojson` outer | non-Assoc `(received <kind>: <excerpt>)` |

PR #16375 패턴 일관 적용 (`Json_util.kind_name + excerpt`). RFC-0133 vocab cluster (방금 머지 wave) sister PR.

## Iter series

FSM/TLA+ observability sweep `/loop 20m` cron `253cc0f6` **iter#38**:
- Phase 2 vocab cleanup audit 후 narrow received-kind 영역 복귀
- Sprint 도메인: type-shape mismatch 명시화
- Sweep: 2 CONFLICTING (#16555/#16352 sprint 외) / 37 open

## Workaround Rejection Bar

- [ ] telemetry-as-fix: 아님
- [ ] string classifier 추가: 아님 (variant match split)
- [ ] N-of-M: 아님 (file 2/2)
- [ ] catch-all 추가: 아님 (catch-all *세분화*)

## RFC Check

`bash ~/me/scripts/pr-rfc-check.sh` PASS (exit 0). worker_execution_spec — credential/identity/operator/sandbox/dashboard-credential/hooks/workflow* 무관.

## Verification

- ocamlformat PASS
- 1 file +9/-2
- Caller API 동일

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>