### PR TITLE
fix(dashboard): counter-format helper 잔존 사이트 정리 (모순 #5 재발 방지)

### DIFF
--- a/dashboard/src/components/journey-panel.ts
+++ b/dashboard/src/components/journey-panel.ts
@@ -21,6 +21,7 @@ import { EmptyState, ErrorState, LoadingState } from './common/feedback-state'
 import { Select } from './common/select'
 import { StatusChip, keeperStateTone } from './common/status-chip'
 import { TimeAgo } from './common/time-ago'
+import { formatIndependentCounters } from './counter-format'
 import {
   buildJourneyWaterfall,
   selectDefaultJourneyKeeper,
@@ -235,7 +236,12 @@ function RuntimeEvidenceStrip({
         ctx ${evidence.contextCompactedCount}/${evidence.contextCompactStartedCount}
       </span>
       <span class="rounded-[var(--r-1)] border border-[var(--color-border-default)] px-1.5 py-0.5 font-mono text-[var(--color-fg-muted)]">
-        mem ${evidence.memoryInjectedCount}/${evidence.memoryFlushedCount}
+        mem ${formatIndependentCounters({
+          leftLabel: 'inj',
+          leftValue: evidence.memoryInjectedCount,
+          rightLabel: 'flush',
+          rightValue: evidence.memoryFlushedCount,
+        })}
       </span>
     </div>
   `

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -14,6 +14,7 @@ import { TimeAgo } from './common/time-ago'
 import { SectionHeader } from './common/section-header'
 import { StatusChip, type StatusChipTone } from './common/status-chip'
 import { toolCategory } from './tool-call-shared'
+import { formatIndependentCounters, formatRatioPair } from './counter-format'
 import type { Keeper } from '../types'
 import type {
   KeeperCompositeSnapshot,
@@ -948,10 +949,32 @@ function runtimeTraceEventIds(trace: KeeperRuntimeTraceResponse): string {
 
 function runtimeTraceMemoryEvidence(trace: KeeperRuntimeTraceResponse): string {
   const memory = trace.memory
+  // inj present/injected is a true ratio pair: scan increments
+  // memory_injected_count unconditionally and memory_injected_present_count
+  // only when content is present, so present ≤ injected always holds.
+  // (see server_dashboard_http_keeper_runtime_manifest_scan.ml:152-154)
+  //
+  // flush success/error are independent monotonic counters; rendering as
+  // "N/M" would falsely imply a ratio. Use formatIndependentCounters.
+  //
+  // ep/proc episodes_flushed/procedures_flushed are also independent.
   return [
-    `inj ${memory.memory_injected_present_count}/${memory.memory_injected_count}`,
-    `flush ${memory.memory_flush_success_count}/${memory.memory_flush_error_count}`,
-    `ep/proc ${memory.episodes_flushed}/${memory.procedures_flushed}`,
+    `inj ${formatRatioPair({
+      numerator: memory.memory_injected_present_count,
+      denominator: memory.memory_injected_count,
+    })}`,
+    `flush ${formatIndependentCounters({
+      leftLabel: 'success',
+      leftValue: memory.memory_flush_success_count,
+      rightLabel: 'error',
+      rightValue: memory.memory_flush_error_count,
+    })}`,
+    `ep/proc ${formatIndependentCounters({
+      leftLabel: 'ep',
+      leftValue: memory.episodes_flushed,
+      rightLabel: 'proc',
+      rightValue: memory.procedures_flushed,
+    })}`,
   ].join(' · ')
 }
 
@@ -1066,15 +1089,15 @@ export function RuntimeLensSection({
         />
         <${SignalRow} label="proof tools" value=${formatLensList(proof.tools)} />
         <${SignalRow} label="network proof" value=${formatLensList(proof.network_modes)} />
-        <${SignalRow} label="context compaction" value=${`${context.context_compacted_count}/${context.context_compact_started_count}`} />
-        <${SignalRow} label="memory flush" value=${`${memory.memory_flush_success_count}/${memory.memory_flush_error_count}`} />
+        <${SignalRow} label="context compaction" value=${formatRatioPair({ numerator: context.context_compacted_count, denominator: context.context_compact_started_count })} />
+        <${SignalRow} label="memory flush" value=${formatIndependentCounters({ leftLabel: 'success', leftValue: memory.memory_flush_success_count, rightLabel: 'error', rightValue: memory.memory_flush_error_count })} />
         <${SignalRow} label="trace id" value=${compactToken(trace.trace_id)} />
         <${SignalRow}
           label="manifest file"
           value=${trace.manifest_path_present ? 'present' : 'missing'}
           title=${trace.manifest_path}
         />
-        <${SignalRow} label="manifest rows" value=${`${trace.manifest_returned_rows}/${trace.manifest_total_rows}`} />
+        <${SignalRow} label="manifest rows" value=${formatRatioPair({ numerator: trace.manifest_returned_rows, denominator: trace.manifest_total_rows })} />
         <${SignalRow} label="receipt rows" value=${trace.receipt_returned_rows} />
         <${SignalRow} label="manifest raw rows" value=${trace.manifest_rows.length} />
         <${SignalRow} label="receipt raw rows" value=${trace.receipts.length} />


### PR DESCRIPTION
Follow-up: 모순 #5 재발 방지 (#16557 out-of-scope 사이트 정리)

## 배경

PR #16557 가 `dashboard/src/components/counter-format.ts` 에 `formatRatioPair` / `formatIndependentCounters` 두 typed helper 를 도입했고, `fsm-hub.ts` 한 곳에만 적용되었습니다. 같은 슬래시 카운터 패턴이 `journey-panel.ts`, `keeper-detail-runtime.ts` 에 잔존하여 화면 모순 #5 (`mem 909/722` 가 126% 비율로 잘못 읽히는 telemetry-as-fix) 가 재발 가능한 상태였습니다.

## 변경

### journey-panel.ts:238 — Independent counters

| 위치 | 변경 |
|------|------|
| `mem ${memoryInjectedCount}/${memoryFlushedCount}` | `formatIndependentCounters({ leftLabel: 'inj', ... rightLabel: 'flush', ... })` |

`memory_injected_count` 와 `memory_flushed_count` 는 독립 lifetime 카운터입니다 (`counter-format.ts:14` 헤더 주석에 명시).

### keeper-detail-runtime.ts:952-954 — `runtimeTraceMemoryEvidence`

| Site | 분류 | 근거 | 적용 helper |
|------|------|------|-------------|
| `inj present/injected` | **RatioPair** | `server_dashboard_http_keeper_runtime_manifest_scan.ml:152-154` 에서 scan 이 `memory_injected_count` 무조건 +1, `memory_injected_present_count` 는 content 존재 시에만 +1. 즉 `present ≤ injected` invariant 성립. | `formatRatioPair` |
| `flush success/error` | IndependentCounters | success/error 사이 ordering invariant 없음. | `formatIndependentCounters` |
| `ep/proc episodes/procedures` | IndependentCounters | 두 도메인 독립 monotonic counter. | `formatIndependentCounters` |

### keeper-detail-runtime.ts:1069-1100 — Runtime Lens SignalRow 3 곳

| Site | 분류 | 근거 | 적용 helper |
|------|------|------|-------------|
| `context compaction: compacted/compactStarted` | RatioPair | `compacted ≤ compactStarted`. `fsm-hub.ts:281` 동일 precedent. | `formatRatioPair` |
| `memory flush: success/error` | IndependentCounters | 위와 동일. | `formatIndependentCounters` |
| `manifest rows: returned/total` | RatioPair | 페이지네이션 부분집합, `fsm-hub.ts:268` precedent. | `formatRatioPair` |

## Before / After (사용자 가시 변화)

```
Before:
  mem 909/722                                   # 126% 처럼 읽힘
  inj 12/40 · flush 3/2 · ep/proc 8/4           # flush, ep/proc 는 ratio 아님

After:
  mem inj 909 · flush 722                       # 독립 표시 명시
  inj 12/40 · flush success 3 · error 2 · ep/proc ep 8 · proc 4
```

`inj 12/40`, `context compaction 7/9`, `manifest rows 100/250` 는 ratio 의미가 유지되므로 슬래시 형태를 보존합니다.

## Invariant 검증 결과

| Pair | Invariant | 확인 위치 |
|------|-----------|----------|
| `memory_injected_present_count ≤ memory_injected_count` | ✅ | `lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml:152-154` |
| `context_compacted_count ≤ context_compact_started_count` | ✅ | fsm-hub.ts 기존 precedent (line 281) |
| `manifest_returned_rows ≤ manifest_total_rows` | ✅ | fsm-hub.ts 기존 precedent (line 268) |
| `provider_attempt_finished_count ≤ provider_attempt_started_count` | ⚠️ | journey-panel.ts:232 에 `started/finished` 순서로 잔존, 별도 PR (본 PR scope 밖) |

## TypeScript 검증

```
$ pnpm typecheck
> tsc --noEmit
(no errors)

$ pnpm vitest run src/components/counter-format.test.ts
Test Files  1 passed (1)
Tests       6 passed (6)
```

## Out of scope (별도 PR 후보)

- **journey-panel.ts:232** `attempts ${started}/${finished}` — `fsm-hub.ts:274` 와 인자 순서 불일치. fsm-hub 는 `finished/started` (numerator ≤ denominator 유지) 인데 journey-panel 은 반대. 단순 수정 아닌 표시 일관성 검토 필요.
- **claude-in-chrome / runtime lens 다른 슬래시 패턴** — 본 PR 은 mem 도메인 + Runtime Lens 동일 함수 내 인접 사이트만 처리.

## 안전성

- catch-all 없음
- magic number 없음
- TypeScript `any` 없음
- helper 호출만 추가, 새 타입/로직 도입 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)