### PR TITLE
feat(meta_cognition_parse): received-kind+excerpt in 3 belief/tension/desire parsers

### DIFF
--- a/lib/meta_cognition_parse.ml
+++ b/lib/meta_cognition_parse.ml
@@ -65,7 +65,10 @@ let parse_belief_summary = function
   | `Null -> Ok { id = None; claim = None; status = None; confidence = None;
                   support_agent_count = None; challenge_agent_count = None;
                   evidence_refs = []; challenge_refs = [] }
-  | _ -> Error "dominant_belief must be an object"
+  | other ->
+      Error
+        (Printf.sprintf "dominant_belief must be an object, got %s: %s"
+           (Json_util.kind_name other) (Json_util.excerpt other))
 
 let parse_tension_summary = function
   | `Assoc _ as json ->
@@ -95,7 +98,10 @@ let parse_tension_summary = function
           needs_operator = false;
           evidence_refs = [];
         }
-  | _ -> Error "top_tension must be an object"
+  | other ->
+      Error
+        (Printf.sprintf "top_tension must be an object, got %s: %s"
+           (Json_util.kind_name other) (Json_util.excerpt other))
 
 let parse_desire_summary = function
   | `Assoc _ as json ->
@@ -120,7 +126,10 @@ let parse_desire_summary = function
           strength = None;
           evidence_refs = [];
         }
-  | _ -> Error "top_desire must be an object"
+  | other ->
+      Error
+        (Printf.sprintf "top_desire must be an object, got %s: %s"
+           (Json_util.kind_name other) (Json_util.excerpt other))
 
 let parse_optional_summary parse value =
   match value with


### PR DESCRIPTION
## Why

`meta_cognition_parse.ml`은 LLM meta-cognition wire format (belief / tension / desire summary) deserializer. 3 type-shape catch-all이 received kind 누락 → LLM producer가 wrong-type 보냈을 때 self-correct hint 없음.

## What

| Line | Function | 변경 |
|------|----------|------|
| L68  | `parse_belief_summary` | non-(Null\|Assoc) `(received <kind>: <excerpt>)` |
| L98  | `parse_tension_summary` | 동일 |
| L123 | `parse_desire_summary` | 동일 |

PR #16375 패턴 (`Json_util.kind_name + excerpt`). Iter#37~#38 sprint sister.

## Iter series

FSM/TLA+ observability sweep `/loop 20m` cron `253cc0f6` **iter#39**:
- 사용자 머지 wave 후 main 거대 진화 (29/37 CONFLICTING — 대부분 sprint 외 dashboard refactor)
- 본 PR은 narrow received-kind sprint 도메인 잔존 site
- Sweep 23회째: 본 PR 등록 후 30 open

## Workaround Rejection Bar

- [ ] telemetry-as-fix: 아님
- [ ] string classifier 추가: 아님 (variant match 세분화)
- [ ] N-of-M: 아님 (file cohort 3/3)
- [ ] catch-all 추가: 아님

## RFC Check

`bash ~/me/scripts/pr-rfc-check.sh` PASS (exit 0).

## Verification

- ocamlformat PASS
- 1 file, +12 / -3
- Caller API 동일

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>