### PR TITLE
fix(keeper-prompts): align keeper_tasks_list guidance with shell guard

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -331,7 +331,9 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
   let claim_guidance_a =
     if show_claim_guidance then
       "- See unclaimed work and you do not already hold a task? Call keeper_task_claim with {}. \
-       It auto-claims the next eligible task; you do not need task_id or keeper_tasks_list first.\n"
+       It auto-claims the next eligible task; you do not need a task_id argument. \
+       keeper_tasks_list remains the canonical way to inspect backlog state — \
+       use it any time you need to diagnose what work exists, not just when the claim returns empty.\n"
     else ""
   in
   let claim_guidance_b =
@@ -470,7 +472,11 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
     Buffer.add_string ubuf
       "- Call keeper_task_claim with {} to claim the next eligible unclaimed task.\n";
     Buffer.add_string ubuf
-      "- Do not wait for keeper_tasks_list unless the claim call says no eligible task.\n";
+      "- For the routine claim flow, call keeper_task_claim directly; \
+       use keeper_tasks_list to inspect backlog state, diagnose missing work, \
+       or verify task lifecycle. Never substitute Bash probes (ls/cat/find against \
+       .masc/, backlog.json, or repo-local task files) for keeper_tasks_list — \
+       keeper_shell blocks those with `task_state_file_probe_blocked`.\n";
     Buffer.add_string ubuf
       "- Prefer keeper_task_claim before keeper_board_list or keeper_shell when you have no claimed task.\n";
     Buffer.add_string ubuf


### PR DESCRIPTION
## 진단

화면/로그에서 keeper qa-king 이 \`Bash ls .masc/tasks/\` 를 시도 → keeper_shell guard 가 \`task_state_file_probe_blocked\` 로 차단 → 같은 명령으로 retry → loop. 사용자 보고 (2026-05-19 19:45).

근본 원인: 3 source 가 keeper_tasks_list 에 대해 *상호 모순* 지시.

1. **inline OCaml prose** (\`keeper_unified_prompt.ml:333-334 + 473\`) — LLM 에 "keeper_tasks_list 쓰지 마라" 명시
2. **external markdown** (\`keeper.capabilities.md:148\`) — "View tasks: keeper_tasks_list" — 쓰라
3. **shell guard** (\`keeper_shell_bash.ml:1132\`) — \`tool_suggestion: keeper_tasks_list\` — 쓰라

LLM 은 시스템 프롬프트 직접 inline 인 (1) 을 우선 적용 → Bash 추측 → 가드 차단 → retry.

## 변경

\`lib/keeper/keeper_unified_prompt.ml\` 의 두 inline string:

- **claim_guidance_a**: keeper_tasks_list 부정 제거, "backlog state 진단/검증 시 canonical" 명시
- **Immediate Task Move** bullet: "Do not wait" 문장을 "routine claim 은 직접, 진단/검증/lifecycle 은 keeper_tasks_list, Bash probe 금지" 로 정렬 + 가드 ID 명시

## 잔존 (별도 PR)

\`keeper_unified_prompt.ml\` 의 line 327-330 코멘트는 *"prose 는 markdown file 에 stay"* 명시. 그런데 같은 함수 내 (line 331-342, 469-477) 가 *inline OCaml string literal prose*. 외부화 정책 위반은 본 PR scope 밖 — 별도 sprint 권장.

## 영향

- keeper LLM 이 keeper_tasks_list 를 사용해야 한다는 지시를 *명확히* 받음
- Bash \`ls .masc/tasks/\` retry loop 종료
- 1 file, +8 / -2

Closes: keeper_tasks_list retry loop (2026-05-19 사용자 보고)

RFC-WAIVED: prompt prose 정렬 (RFC 보호 subsystem 영역 아님)