### PR TITLE
refactor(json-util): dedup 11 inline json_kind_name copies (SSOT)

### DIFF
--- a/lib/board_attachment_meta.ml
+++ b/lib/board_attachment_meta.ml
@@ -90,16 +90,6 @@ let to_yojson (t : t) : Yojson.Safe.t =
     "created_at", `Float t.created_at;
   ]
 
-let json_kind_name : Yojson.Safe.t -> string = function
-  | `Null -> "null"
-  | `Bool _ -> "bool"
-  | `Int _ -> "int"
-  | `Intlit _ -> "intlit"
-  | `Float _ -> "float"
-  | `String _ -> "string"
-  | `Assoc _ -> "object"
-  | `List _ -> "array"
-
 let opt_int_of_yojson = function
   | `Null -> Ok None
   | `Int i -> Ok (Some i)
@@ -107,7 +97,7 @@ let opt_int_of_yojson = function
       Error
         (Invalid_payload
            (Printf.sprintf "expected null or int (received %s)"
-              (json_kind_name other)))
+              (Json_util.kind_name other)))
 
 let assoc_get key = function
   | `Assoc kvs -> (
@@ -118,7 +108,7 @@ let assoc_get key = function
       Error
         (Invalid_payload
            (Printf.sprintf "expected JSON object (received %s)"
-              (json_kind_name other)))
+              (Json_util.kind_name other)))
 
 let string_of_yojson key json =
   match assoc_get key json with
@@ -127,7 +117,7 @@ let string_of_yojson key json =
       Error
         (Invalid_payload
            (Printf.sprintf "%s: expected string (received %s)" key
-              (json_kind_name other)))
+              (Json_util.kind_name other)))
   | Error e -> Error e
 
 let int_of_yojson key json =
@@ -137,7 +127,7 @@ let int_of_yojson key json =
       Error
         (Invalid_payload
            (Printf.sprintf "%s: expected int (received %s)" key
-              (json_kind_name other)))
+              (Json_util.kind_name other)))
   | Error e -> Error e
 
 let float_of_yojson key json =
@@ -148,7 +138,7 @@ let float_of_yojson key json =
       Error
         (Invalid_payload
            (Printf.sprintf "%s: expected float (received %s)" key
-              (json_kind_name other)))
+              (Json_util.kind_name other)))
   | Error e -> Error e
 
 let opt_int_field key json =

--- a/lib/dashboard_tool_host_events.ml
+++ b/lib/dashboard_tool_host_events.ml
@@ -15,16 +15,6 @@ module Char = Stdlib.Char
 module Int = Stdlib.Int
 module Float = Stdlib.Float
 
-let json_kind_name : Yojson.Safe.t -> string = function
-  | `Null -> "null"
-  | `Bool _ -> "bool"
-  | `Int _ -> "int"
-  | `Intlit _ -> "intlit"
-  | `Float _ -> "float"
-  | `String _ -> "string"
-  | `Assoc _ -> "object"
-  | `List _ -> "array"
-
 type report = {
   agent_name : string;
   client_name : string;
@@ -110,7 +100,7 @@ let report_of_yojson ?fallback_agent (json : Yojson.Safe.t) :
   | other ->
       Error
         (Printf.sprintf "request body must be a JSON object (received %s)"
-           (json_kind_name other))
+           (Json_util.kind_name other))
 
 let details_json (report : report) =
   let envelope =

--- a/lib/failure_envelope.ml
+++ b/lib/failure_envelope.ml
@@ -22,16 +22,6 @@ type t = {
 
 let tool_host_log_module_name = "ToolHost"
 
-let json_kind_name : Yojson.Safe.t -> string = function
-  | `Null -> "null"
-  | `Bool _ -> "bool"
-  | `Int _ -> "int"
-  | `Intlit _ -> "intlit"
-  | `Float _ -> "float"
-  | `String _ -> "string"
-  | `Assoc _ -> "object"
-  | `List _ -> "array"
-
 let severity_to_string = function
   | Warn -> "warn"
   | Bad -> "bad"
@@ -152,7 +142,7 @@ let required_string json key =
       Error
         (Printf.sprintf
            "failure field %s must be a string (received %s)" key
-           (json_kind_name other))
+           (Json_util.kind_name other))
 
 let optional_string json key =
   let open Yojson.Safe.Util in
@@ -209,7 +199,7 @@ let of_yojson json =
   | other ->
       Error
         (Printf.sprintf "failure envelope must be a JSON object (received %s)"
-           (json_kind_name other))
+           (Json_util.kind_name other))
 
 let attach_to_details details envelope =
   match details with

--- a/lib/keeper/keeper_meta_tool_access.ml
+++ b/lib/keeper/keeper_meta_tool_access.ml
@@ -6,17 +6,6 @@
 
 open Keeper_types_profile
 
-let json_kind_name : Yojson.Safe.t -> string = function
-  | `Null -> "null"
-  | `Bool _ -> "bool"
-  | `Int _ -> "int"
-  | `Intlit _ -> "intlit"
-  | `Float _ -> "float"
-  | `String _ -> "string"
-  | `Assoc _ -> "object"
-  | `List _ -> "array"
-;;
-
 type tool_preset =
   | Minimal
   | Social
@@ -166,14 +155,14 @@ let string_list_field_result ?label ~field_name (json : Yojson.Safe.t) =
       | bad :: _ ->
         Error
           (Printf.sprintf "keeper %s[%d] must be a string (received %s)" label
-             index (json_kind_name bad))
+             index (Json_util.kind_name bad))
     in
     collect [] 0 items
   | `Null -> Error (Printf.sprintf "keeper %s must be an array of strings" label)
   | other ->
     Error
       (Printf.sprintf "keeper %s must be an array of strings (received %s)"
-         label (json_kind_name other))
+         label (Json_util.kind_name other))
 ;;
 
 let string_list_field_opt_result ?label ~field_name (json : Yojson.Safe.t) =

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -67,16 +67,6 @@ let json_non_null_member_present key (json : Yojson.Safe.t) =
       | Some _ -> true)
   | _ -> false
 
-let json_kind_name : Yojson.Safe.t -> string = function
-  | `Null -> "null"
-  | `Bool _ -> "bool"
-  | `Int _ -> "int"
-  | `Intlit _ -> "intlit"
-  | `Float _ -> "float"
-  | `String _ -> "string"
-  | `Assoc _ -> "object"
-  | `List _ -> "array"
-
 let parse_present_tool_name_list_opt args key =
   match json_assoc_member_opt key args with
   | None -> Ok None
@@ -87,14 +77,14 @@ let parse_present_tool_name_list_opt args key =
         | bad :: _ ->
             Error
               (Printf.sprintf "%s[%d] must be a string (received %s)" key
-                 index (json_kind_name bad))
+                 index (Json_util.kind_name bad))
       in
       collect [] 0 items
   | Some `Null -> Error (Printf.sprintf "%s must not be null" key)
   | Some other ->
       Error
         (Printf.sprintf "%s must be an array of strings (received %s)" key
-           (json_kind_name other))
+           (Json_util.kind_name other))
 
 let parse_present_string_list_opt args key =
   match json_assoc_member_opt key args with
@@ -106,14 +96,14 @@ let parse_present_string_list_opt args key =
         | bad :: _ ->
             Error
               (Printf.sprintf "%s[%d] must be a string (received %s)" key
-                 index (json_kind_name bad))
+                 index (Json_util.kind_name bad))
       in
       collect [] 0 items
   | Some `Null -> Error (Printf.sprintf "%s must not be null" key)
   | Some other ->
       Error
         (Printf.sprintf "%s must be an array of strings (received %s)" key
-           (json_kind_name other))
+           (Json_util.kind_name other))
 
 let parse_enum_string_opt args key of_string ~allowed_values =
   match json_assoc_member_opt key args with
@@ -129,7 +119,7 @@ let parse_enum_string_opt args key of_string ~allowed_values =
   | Some other ->
       Error
         (Printf.sprintf "%s must be a string (received %s)" key
-           (json_kind_name other))
+           (Json_util.kind_name other))
 
 let parse_cascade_name_opt args =
   match get_string_opt args "cascade_name" with
@@ -197,7 +187,7 @@ let parse_tool_access_input (args : Yojson.Safe.t) :
       | Some other ->
           Error
             (Printf.sprintf "tool_access must be an object (received %s)"
-               (json_kind_name other))
+               (Json_util.kind_name other))
       | None -> Ok None
     in
     match tool_access_opt with

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -356,16 +356,6 @@ type tools_list_params = {
 
 open Result.Syntax
 
-let json_kind_name : Yojson.Safe.t -> string = function
-  | `Null -> "null"
-  | `Bool _ -> "bool"
-  | `Int _ -> "int"
-  | `Intlit _ -> "intlit"
-  | `Float _ -> "float"
-  | `String _ -> "string"
-  | `Assoc _ -> "object"
-  | `List _ -> "array"
-
 let strict_assoc_params params =
   match params with
   | None -> Ok []
@@ -373,7 +363,7 @@ let strict_assoc_params params =
   | Some other ->
       Error
         (Printf.sprintf "Invalid params: expected object (received %s)"
-           (json_kind_name other))
+           (Json_util.kind_name other))
 
 let cursor_param payload =
   let open Yojson.Safe.Util in
@@ -388,7 +378,7 @@ let cursor_param payload =
   | other ->
       Error
         (Printf.sprintf "Invalid params: cursor must be a string (received %s)"
-           (json_kind_name other))
+           (Json_util.kind_name other))
 
 let bool_param payload key =
   let open Yojson.Safe.Util in
@@ -398,7 +388,7 @@ let bool_param payload key =
   | other ->
       Error
         (Printf.sprintf "Invalid params: %s must be a boolean (received %s)"
-           key (json_kind_name other))
+           key (Json_util.kind_name other))
 
 let decode_cursor_offset = function
   | None -> Ok 0
@@ -444,7 +434,7 @@ let cursor_only_params params =
   | Some other ->
       Error
         (Printf.sprintf "Invalid params: expected object (received %s)"
-           (json_kind_name other))
+           (Json_util.kind_name other))
 
 let validate_optional_meta payload =
   match Yojson.Safe.Util.member "_meta" payload with
@@ -453,7 +443,7 @@ let validate_optional_meta payload =
   | other ->
       Error
         (Printf.sprintf "Invalid params: _meta must be an object (received %s)"
-           (json_kind_name other))
+           (Json_util.kind_name other))
 
 let requested_tool_list_params params =
   let open Yojson.Safe.Util in
@@ -489,14 +479,14 @@ let requested_tool_list_params params =
                        (Printf.sprintf
                           "Invalid params: names must be an array of strings \
                            (received %s element)"
-                          (json_kind_name bad)))
+                          (Json_util.kind_name bad)))
                (Ok [])
           |> Result.map (fun names -> Some (List.rev names))
       | other ->
           Error
             (Printf.sprintf
                "Invalid params: names must be an array of strings (received %s)"
-               (json_kind_name other))
+               (Json_util.kind_name other))
     in
     let* cursor = cursor_param payload in
     let* include_hidden = bool_param payload "include_hidden" in
@@ -534,7 +524,7 @@ let parse_cursor_only_params params =
         Error
           (Printf.sprintf
              "Invalid params: cursor must be a string (received %s)"
-             (json_kind_name other))
+             (Json_util.kind_name other))
 
 let list_page_size () = Env_config.Tools.list_page_size ()
 

--- a/lib/sdk_tool_contract.ml
+++ b/lib/sdk_tool_contract.ml
@@ -291,16 +291,6 @@ let label_or_default label fallback =
   | Some value when String.trim value <> "" -> value
   | _ -> fallback
 
-let json_kind_name : Yojson.Safe.t -> string = function
-  | `Null -> "null"
-  | `Bool _ -> "bool"
-  | `Int _ -> "int"
-  | `Intlit _ -> "intlit"
-  | `Float _ -> "float"
-  | `String _ -> "string"
-  | `Assoc _ -> "object"
-  | `List _ -> "array"
-
 let rec validate_json_value ?label schema value =
   let label = label_or_default label "input" in
   match schema_type schema with
@@ -332,7 +322,7 @@ let rec validate_json_value ?label schema value =
       | other ->
           Error
             (Printf.sprintf "%s must be a JSON object (received %s)" label
-               (json_kind_name other)))
+               (Json_util.kind_name other)))
   | "array" -> (
       match value with
       | `List items ->
@@ -354,35 +344,35 @@ let rec validate_json_value ?label schema value =
       | other ->
           Error
             (Printf.sprintf "%s must be a JSON array (received %s)" label
-               (json_kind_name other)))
+               (Json_util.kind_name other)))
   | "string" -> (
       match value with
       | `String _ -> Ok ()
       | other ->
           Error
             (Printf.sprintf "%s must be a string (received %s)" label
-               (json_kind_name other)))
+               (Json_util.kind_name other)))
   | "integer" -> (
       match value with
       | `Int _ -> Ok ()
       | other ->
           Error
             (Printf.sprintf "%s must be an integer (received %s)" label
-               (json_kind_name other)))
+               (Json_util.kind_name other)))
   | "number" -> (
       match value with
       | `Int _ | `Float _ -> Ok ()
       | other ->
           Error
             (Printf.sprintf "%s must be a number (received %s)" label
-               (json_kind_name other)))
+               (Json_util.kind_name other)))
   | "boolean" -> (
       match value with
       | `Bool _ -> Ok ()
       | other ->
           Error
             (Printf.sprintf "%s must be a boolean (received %s)" label
-               (json_kind_name other)))
+               (Json_util.kind_name other)))
   | _ -> Ok ()
 
 let validate_input_json schema json =
@@ -456,7 +446,7 @@ let build_operation_arguments ~agent_name binding json =
       | other ->
           Error
             (Printf.sprintf "input must be a JSON object (received %s)"
-               (json_kind_name other)))
+               (Json_util.kind_name other)))
 
 let resolve_requested_tool_call ~agent_name ~requested_name ~arguments =
   match sdk_binding_by_name requested_name with

--- a/lib/tool_board_format.ml
+++ b/lib/tool_board_format.ml
@@ -19,17 +19,6 @@ module Float = Stdlib.Float
     truncated-markdown detector, and the Yojson-error boundary shared
     across the [Tool_board] submodules. Stage 10 split. *)
 
-let json_kind_name : Yojson.Safe.t -> string = function
-  | `Null -> "null"
-  | `Bool _ -> "bool"
-  | `Int _ -> "int"
-  | `Intlit _ -> "intlit"
-  | `Float _ -> "float"
-  | `String _ -> "string"
-  | `Assoc _ -> "object"
-  | `List _ -> "array"
-;;
-
 (** Strip [STATE]...[/STATE] blocks. Inlined to avoid the
     Keeper_prompt dependency cycle via Keeper_alerting. *)
 let strip_state_blocks_text (s : string) : string =
@@ -552,7 +541,7 @@ let provenance_arg args =
        Error
          (Printf.sprintf
             "provenance must be an object (received %s)"
-            (json_kind_name other))
+            (Json_util.kind_name other))
      | _ -> Ok (`Assoc []))
   | _ -> Ok (`Assoc [])
 ;;

--- a/lib/tool_task_args.ml
+++ b/lib/tool_task_args.ml
@@ -8,16 +8,6 @@
 
 open Yojson.Safe.Util
 
-let json_kind_name : Yojson.Safe.t -> string = function
-  | `Null -> "null"
-  | `Bool _ -> "bool"
-  | `Int _ -> "int"
-  | `Intlit _ -> "intlit"
-  | `Float _ -> "float"
-  | `String _ -> "string"
-  | `Assoc _ -> "object"
-  | `List _ -> "array"
-
 let parse_task_contract args =
   match args |> member "contract" with
   | `Null -> Ok None
@@ -31,7 +21,7 @@ let parse_task_contract args =
       Error
         (Printf.sprintf
            "contract must be an object when provided (received %s)"
-           (json_kind_name other))
+           (Json_util.kind_name other))
 
 let is_internal_marker key =
   String.length key > 0 && Char.equal key.[0] '_'
@@ -163,7 +153,7 @@ let parse_handoff_context ~(agent_name : string)
       Error
         (Printf.sprintf
            "handoff_context must be an object when provided (received %s)"
-           (json_kind_name other))
+           (Json_util.kind_name other))
 
 let transition_known_args =
   [

--- a/lib/types/task_stage.ml
+++ b/lib/types/task_stage.ml
@@ -29,22 +29,12 @@ let of_string = function
 
 let to_yojson t = `String (to_string t)
 
-let json_kind_name : Yojson.Safe.t -> string = function
-  | `Null -> "null"
-  | `Bool _ -> "bool"
-  | `Int _ -> "int"
-  | `Intlit _ -> "intlit"
-  | `Float _ -> "float"
-  | `String _ -> "string"
-  | `Assoc _ -> "object"
-  | `List _ -> "array"
-
 let of_yojson = function
   | `String s -> of_string s
   | other ->
       Error
         (Printf.sprintf "task stage must be a string (received %s)"
-           (json_kind_name other))
+           (Json_util.kind_name other))
 
 let all = [Decompose; Inspect; Implement; Verify; Review]
 

--- a/lib/worker_execution_backend.ml
+++ b/lib/worker_execution_backend.ml
@@ -15,16 +15,6 @@ let of_string value =
 let to_yojson backend =
   `String (to_string backend)
 
-let json_kind_name : Yojson.Safe.t -> string = function
-  | `Null -> "null"
-  | `Bool _ -> "bool"
-  | `Int _ -> "int"
-  | `Intlit _ -> "intlit"
-  | `Float _ -> "float"
-  | `String _ -> "string"
-  | `Assoc _ -> "object"
-  | `List _ -> "array"
-
 let of_yojson = function
   | `String value -> (
       match of_string value with
@@ -36,4 +26,4 @@ let of_yojson = function
       Error
         (Printf.sprintf
            "worker execution backend must be a string (received %s)"
-           (json_kind_name other))
+           (Json_util.kind_name other))


### PR DESCRIPTION
## Summary

Follow-up to #16546 (yojson 3.0 dead-arm cleanup, 본 세션 PR) and #16534
(`Json_util.kind_name` SSOT initial 6-site dedup).  Extends dedup to
**11 more inline `json_kind_name` copies** by routing to the SSOT
`Json_util.kind_name` (declared in `lib/core/json_util.ml:149`).

Net change: **-112 LoC** across 11 files (148 deletions, 36 additions).

## Why root-fix now

The received-kind enrich sprint (#16490 / #16493 / #16498 / #16503 /
#16508 / #16516 / #16522 / #16525 / #16530) introduced ~20 copies of
the identical 9-line `json_kind_name` helper across files.  #16534
extracted the SSOT and dedup'd 6 callsites in
`lib/types/` + `lib/keeper/`.  This PR closes the remaining 11
non-isolated sites — `lib/types/task_stage.ml`, 8 main-lib files, and
2 keeper files — so the SSOT covers every non-isolated copy.

Per CLAUDE.md AI Code Generation Anti-Patterns §1 ("Scattered
Hardcoded Defaults"), this is exactly the boilerplate the rule
targets: same 9-line literal block repeated across files without an
SSOT.  This PR collapses the surface to one helper.

## Files (11 dedup'd)

```
lib/types/task_stage.ml            (types sub-lib, already imports masc_core)
lib/keeper/keeper_meta_tool_access.ml
lib/keeper/keeper_turn_up_args.ml
lib/mcp_server_eio_tool_profile.ml
lib/tool_task_args.ml
lib/dashboard_tool_host_events.ml
lib/board_attachment_meta.ml
lib/tool_board_format.ml
lib/sdk_tool_contract.ml
lib/failure_envelope.ml
lib/worker_execution_backend.ml
```

## Files INTENTIONALLY left inline (4, sub-lib isolation)

```
lib/cdal_runtime/effect_evidence.ml   (cdal_runtime sub-lib)
lib/chronicle_event/chronicle_event.ml (chronicle_event sub-lib)
lib/multimodal/payload.ml             (multimodal sub-lib, yojson-only)
lib/autonomous/stimulus.ml            (autonomous sub-lib, yojson-only)
```

These sub-libraries' `dune` files declare yojson-only dependencies
(RFC-0056 leaf-isolation pattern).  Adding `masc_core` here would
break the isolation invariant; the 9-line cost per file is the
smaller trade-off — same reason #16534's commit message disclosed for
the original 2 files.

## Mechanism

```
perl -i -0777 -pe 's/let json_kind_name : Yojson\.Safe\.t -> string = function\n
  \| `Null -> "null"\n  ... (8 arms)\n(;;\n)?\n?//'
perl -i -pe 's/\bjson_kind_name\b/Json_util.kind_name/g'
```

Per-file: 9-line inline definition removed + every `json_kind_name`
callsite replaced with `Json_util.kind_name`.  No semantic change
(`Json_util.kind_name` is the same function the inline copies
re-implemented).

## Evidence

- `dune build --root . @check` — passes (full project type-check).
- `opam exec -- ocamlformat --check` on all 11 files — passes.
- `git diff --shortstat` — `11 files changed, 36 insertions(+),
  148 deletions(-)`.
- `rg "let json_kind_name : Yojson" lib/` — 4 hits remaining (all in
  isolated sub-libraries, as expected).

## Anti-pattern self-check (per CLAUDE.md workaround-rejection bar)

| # | Pattern | Status |
|---|---------|--------|
| 1 | Telemetry-as-fix | N/A — root fix |
| 2 | String classifier | ✅ removed 11 inline string-tag copies; SSOT remains |
| 3 | N-of-M migration | ⚠️ 4 sub-lib sites intentionally left; disclosed with rationale (RFC-0056 isolation) |
| 4 | Catch-all `_ ->` added | ✅ no new arms; SSOT remains exhaustive over 8 surviving `Yojson.Safe.t` tags |
| 5 | Cap/cooldown/dedup/repair | N/A |
| 6 | Test backdoor | N/A |
| 7 | N-site mechanical fix | ✅ this PR *closes* an N-site repetition pattern — opposite of the anti-pattern |

## RFC waiver

`RFC-WAIVED: SSOT dedup of inline copies, no design choice involved.
Touches lib/keeper/ (2 files) only to replace inline copies with
existing Json_util.kind_name call.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)