### PR TITLE
feat(provenance_stub): split missing vs wrong-type + received kind

### DIFF
--- a/lib/multimodal/provenance_stub.ml
+++ b/lib/multimodal/provenance_stub.ml
@@ -1,5 +1,22 @@
 (* Provenance_stub — Cycle 24 / Tier B8. *)
 
+(* Inline kind_name helper — multimodal sub-lib lists (libraries shared_types
+   unix yojson) and intentionally excludes masc_core (Json_util's home) for
+   RFC-0056 dependency-leaf isolation. The 12-line cost of an inline copy is
+   the smaller trade-off vs widening the sub-lib's dependency surface. Iter#32
+   PR #16534 set this same pattern for chronicle_event + autonomous/stimulus. *)
+let kind_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "intlit"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+  | `Tuple _ -> "tuple"
+  | `Variant _ -> "variant"
+
 type t = {
   origin_artifact_ids : Shared_types.Artifact_id.t list;
   created_by : string;
@@ -33,18 +50,32 @@ let of_json = function
                 | _, Error e -> Error e)
               xs (Ok [])
         | None -> Ok []
-        | _ -> Error "origin_artifact_ids must be a JSON list"
+        | Some other ->
+            Error
+              (Printf.sprintf
+                 "origin_artifact_ids must be a JSON list (got %s)"
+                 (kind_name other))
       in
       let created_by_result =
         match List.assoc_opt "created_by" kv with
         | Some (`String s) -> Ok s
-        | _ -> Error "created_by must be a JSON string"
+        | None -> Error "created_by is required"
+        | Some other ->
+            Error
+              (Printf.sprintf
+                 "created_by must be a JSON string (got %s)"
+                 (kind_name other))
       in
       let created_at_result =
         match List.assoc_opt "created_at" kv with
         | Some (`Float f) -> Ok f
         | Some (`Int i) -> Ok (float_of_int i)
-        | _ -> Error "created_at must be a JSON number"
+        | None -> Error "created_at is required"
+        | Some other ->
+            Error
+              (Printf.sprintf
+                 "created_at must be a JSON number (got %s)"
+                 (kind_name other))
       in
       (match origin_result, created_by_result, created_at_result with
        | Ok ids, Ok name, Ok ts ->
@@ -55,4 +86,7 @@ let of_json = function
                created_at = ts;
              }
        | Error e, _, _ | _, Error e, _ | _, _, Error e -> Error e)
-  | _ -> Error "provenance_stub must be a JSON object"
+  | other ->
+      Error
+        (Printf.sprintf "provenance_stub must be a JSON object (got %s)"
+           (kind_name other))


### PR DESCRIPTION
## Why

multimodal/provenance_stub.ml의 `of_json`이 4 type-shape catch-all에서 missing↔wrong-type collapse + received kind 누락:

| Issue | Before |
|-------|--------|
| `origin_artifact_ids` Some non-list | "must be a JSON list" (kind 누락) |
| `created_by` missing + wrong-type | 같은 메시지 |
| `created_at` missing + wrong-type | 같은 메시지 |
| outer non-Assoc | "must be a JSON object" |

PR #16525 (Iter#30 multimodal/payload) **sister cluster** — 같은 sub-lib, 같은 split 패턴.

## What

| Line | 변경 |
|------|------|
| L36 | `origin_artifact_ids`: `Some other` → `(got <kind>)` (None=absent OK 유지) |
| L41 | `created_by`: `None` → "is required" / `Some other` → wrong-type kind |
| L47 | `created_at`: `None` → "is required" / `Some other` → wrong-type kind |
| L58 | outer: `(got <kind>)` |

Inline `kind_name` helper 추가 (12-line closed total, 10 Yojson.Safe.t variants).

## RFC-0056 isolation 존중

`lib/multimodal/dune` deps = `(libraries shared_types unix yojson)` — masc_core 의도적 배제. `Json_util.kind_name` (masc_core 안)이 reachable 안 됨.

PR #16572 (방금 머지)가 main lib의 11 inline copy를 `Json_util.kind_name`으로 dedup했지만, **sub-lib outlier (chronicle_event, autonomous/stimulus, multimodal/payload, 본 PR)는 by design**. 추후 kind_name을 zero-dep helper sub-library 또는 yojson contrib로 옮기면 일관 dedup 가능.

## Iter series

FSM/TLA+ observability sweep `/loop 20m` cron `253cc0f6` **iter#40**:
- 사용자 요청 "반복중 개선": 잔존 received-kind sites cluster sweep
- Iter#30 #16525 (multimodal/payload) sister
- Sweep 24회째 (사용자 머지 wave 후 main 거대 진화)

## Workaround Rejection Bar

- [ ] telemetry-as-fix: 아님
- [ ] string classifier 추가: 아님 (variant match 세분화)
- [ ] N-of-M: 아님 (file 4/4)
- [ ] catch-all 추가: 아님 (split)

## RFC Check

`bash ~/me/scripts/pr-rfc-check.sh` PASS (exit 0).

## Verification

- ocamlformat PASS
- 1 file, +38 / -4

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>