### PR TITLE
refactor(keeper-prompts): inline OCaml prose를 config/prompts markdown으로 외부화

### DIFF
--- a/config/prompts/keeper.immediate_task_move.md
+++ b/config/prompts/keeper.immediate_task_move.md
@@ -1,0 +1,8 @@
+---
+description: keeper user-prompt Immediate Task Move section (emitted when claimable backlog is visible and keeper holds no task)
+category: keeper
+---
+- Call keeper_task_claim with {} to claim the next eligible unclaimed task.
+- For the routine claim flow, call keeper_task_claim directly; use keeper_tasks_list to inspect backlog state, diagnose missing work, or verify task lifecycle. Never substitute Bash probes (ls/cat/find against .masc/, backlog.json, or repo-local task files) for keeper_tasks_list — keeper_shell blocks those with `task_state_file_probe_blocked`.
+- Prefer keeper_task_claim before keeper_board_list or keeper_shell when you have no claimed task.
+- If you need keeper_shell op=gh, claim first so gh can derive repo context from your active task worktree/current_task_id.

--- a/config/prompts/keeper.turn_intent.board_activity_guidance.md
+++ b/config/prompts/keeper.turn_intent.board_activity_guidance.md
@@ -1,0 +1,5 @@
+---
+description: keeper turn-intent board activity guidance bullet (board_get + comment pairing)
+category: keeper
+---
+- See board activity? Use the listed post_id. If the preview is enough, comment directly with keeper_board_comment. If you need the full post, call keeper_board_get and keeper_board_comment in the same response; keeper_board_get alone is passive and fails actionable turns.

--- a/config/prompts/keeper.turn_intent.board_curation_guidance.md
+++ b/config/prompts/keeper.turn_intent.board_curation_guidance.md
@@ -1,0 +1,5 @@
+---
+description: keeper turn-intent board curation guidance bullet
+category: keeper
+---
+- See enough board activity to summarize or route? Call keeper_board_curation_submit with a concise snapshot.

--- a/config/prompts/keeper.turn_intent.board_post_guidance.md
+++ b/config/prompts/keeper.turn_intent.board_post_guidance.md
@@ -1,0 +1,5 @@
+---
+description: keeper turn-intent board post guidance bullet
+category: keeper
+---
+- Have a finding or update? Call keeper_board_post.

--- a/config/prompts/keeper.turn_intent.broadcast_guidance.md
+++ b/config/prompts/keeper.turn_intent.broadcast_guidance.md
@@ -1,0 +1,5 @@
+---
+description: keeper turn-intent broadcast guidance bullet
+category: keeper
+---
+- Need to share broadly? Call keeper_broadcast.

--- a/config/prompts/keeper.turn_intent.claim_guidance_a.md
+++ b/config/prompts/keeper.turn_intent.claim_guidance_a.md
@@ -1,0 +1,5 @@
+---
+description: keeper turn-intent claim guidance bullet A (emitted when claimable backlog is visible)
+category: keeper
+---
+- See unclaimed work and you do not already hold a task? Call keeper_task_claim with {}. It auto-claims the next eligible task; you do not need a task_id argument. keeper_tasks_list remains the canonical way to inspect backlog state — use it any time you need to diagnose what work exists, not just when the claim returns empty.

--- a/config/prompts/keeper.turn_intent.claim_guidance_b.md
+++ b/config/prompts/keeper.turn_intent.claim_guidance_b.md
@@ -1,0 +1,5 @@
+---
+description: keeper turn-intent claim guidance bullet B (gh repo context via task worktree)
+category: keeper
+---
+- Need GitHub or PR inspection via keeper_shell op=gh? Claim first. gh repo context is derived from your active task worktree/current_task_id.

--- a/lib/keeper/keeper_prompt_names.ml
+++ b/lib/keeper/keeper_prompt_names.ml
@@ -19,3 +19,19 @@ let tool_workflow_gh_minimal = "keeper.tool_workflow_gh_minimal"
 let tool_unknown_guard = "keeper.tool_unknown_guard"
 let recovery_block = "keeper.recovery_block"
 let turn_intent = "keeper.turn_intent"
+
+(** Turn-intent substitution prose files. Each holds a single bullet (or
+    short block) that the OCaml side injects into [turn_intent] when the
+    corresponding toggle is active. Externalized from
+    [keeper_unified_prompt.ml] per the in-file policy stating that prose
+    edits belong alongside the other keeper prompt markdown files. *)
+let turn_intent_claim_guidance_a = "keeper.turn_intent.claim_guidance_a"
+let turn_intent_claim_guidance_b = "keeper.turn_intent.claim_guidance_b"
+let turn_intent_board_activity_guidance = "keeper.turn_intent.board_activity_guidance"
+let turn_intent_board_post_guidance = "keeper.turn_intent.board_post_guidance"
+let turn_intent_board_curation_guidance = "keeper.turn_intent.board_curation_guidance"
+let turn_intent_broadcast_guidance = "keeper.turn_intent.broadcast_guidance"
+
+(** User-prompt "Immediate Task Move" section body, emitted when a
+    claimable backlog is visible and the keeper holds no task. *)
+let immediate_task_move = "keeper.immediate_task_move"

--- a/lib/keeper/keeper_prompt_names.mli
+++ b/lib/keeper/keeper_prompt_names.mli
@@ -19,3 +19,14 @@ val tool_workflow_gh_minimal : string
 val tool_unknown_guard : string
 val recovery_block : string
 val turn_intent : string
+
+(** Turn-intent substitution prose template keys. *)
+val turn_intent_claim_guidance_a : string
+val turn_intent_claim_guidance_b : string
+val turn_intent_board_activity_guidance : string
+val turn_intent_board_post_guidance : string
+val turn_intent_board_curation_guidance : string
+val turn_intent_broadcast_guidance : string
+
+(** User-prompt "Immediate Task Move" section template key. *)
+val immediate_task_move : string

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -203,6 +203,84 @@ let resolve_turn_intent_block substitutions =
         observe_turn_intent_render_failure msg;
         raw)
 
+(** In-binary fallback prose for the externalized turn-intent and user-prompt
+    bullet files under [config/prompts/]. Used only when the registry returns
+    an empty body (missing file, frontmatter-only file, or markdown_dir not
+    set in tests). The in-binary copy is kept byte-for-byte equal to the
+    canonical markdown body (post-trim, single trailing newline injected by
+    [load_externalized_bullet]) so that a degraded prompt config still emits
+    the same guidance text. Edits should land in both places to keep them
+    aligned with the keeper.* markdown files. *)
+let fallback_externalized_bullet key =
+  if String.equal key Keeper_prompt_names.turn_intent_claim_guidance_a then
+    Some
+      "- See unclaimed work and you do not already hold a task? Call \
+       keeper_task_claim with {}. It auto-claims the next eligible task; \
+       you do not need a task_id argument. keeper_tasks_list remains the \
+       canonical way to inspect backlog state — use it any time you need to \
+       diagnose what work exists, not just when the claim returns empty."
+  else if String.equal key Keeper_prompt_names.turn_intent_claim_guidance_b then
+    Some
+      "- Need GitHub or PR inspection via keeper_shell op=gh? Claim first. \
+       gh repo context is derived from your active task worktree/current_task_id."
+  else if String.equal key Keeper_prompt_names.turn_intent_board_activity_guidance then
+    Some
+      "- See board activity? Use the listed post_id. If the preview is \
+       enough, comment directly with keeper_board_comment. If you need the \
+       full post, call keeper_board_get and keeper_board_comment in the same \
+       response; keeper_board_get alone is passive and fails actionable turns."
+  else if String.equal key Keeper_prompt_names.turn_intent_board_post_guidance then
+    Some "- Have a finding or update? Call keeper_board_post."
+  else if String.equal key Keeper_prompt_names.turn_intent_board_curation_guidance then
+    Some
+      "- See enough board activity to summarize or route? Call \
+       keeper_board_curation_submit with a concise snapshot."
+  else if String.equal key Keeper_prompt_names.turn_intent_broadcast_guidance then
+    Some "- Need to share broadly? Call keeper_broadcast."
+  else if String.equal key Keeper_prompt_names.immediate_task_move then
+    Some
+      "- Call keeper_task_claim with {} to claim the next eligible \
+       unclaimed task.\n\
+       - For the routine claim flow, call keeper_task_claim directly; use \
+       keeper_tasks_list to inspect backlog state, diagnose missing work, \
+       or verify task lifecycle. Never substitute Bash probes (ls/cat/find \
+       against .masc/, backlog.json, or repo-local task files) for \
+       keeper_tasks_list — keeper_shell blocks those with \
+       `task_state_file_probe_blocked`.\n\
+       - Prefer keeper_task_claim before keeper_board_list or keeper_shell \
+       when you have no claimed task.\n\
+       - If you need keeper_shell op=gh, claim first so gh can derive repo \
+       context from your active task worktree/current_task_id."
+  else None
+
+(** Load a turn-intent or user-prompt bullet from [config/prompts/].
+    Returns the body with a single trailing newline so multiple bullets
+    concatenate cleanly. Returns [""] when the key is toggled off; the
+    toggle is supplied by the caller. *)
+let load_externalized_bullet ~enabled key =
+  if not enabled then ""
+  else
+    let trimmed =
+      String.trim (Prompt_registry.get_prompt key)
+    in
+    if String.equal trimmed "" then
+      match fallback_externalized_bullet key with
+      | Some prose ->
+          Prometheus.inc_counter
+            Keeper_metrics.metric_keeper_prompt_failures
+            ~labels:[("prompt", key)]
+            ();
+          Log.Keeper.warn
+            "externalized prompt '%s' resolved empty; using in-binary fallback"
+            key;
+          prose ^ "\n"
+      | None ->
+          Log.Keeper.warn
+            "externalized prompt '%s' resolved empty and no fallback registered"
+            key;
+          ""
+    else trimmed ^ "\n"
+
 let autonomous_trigger_lines
     ~(decision : Keeper_world_observation.keeper_cycle_decision)
     ~(observation : Keeper_world_observation.world_observation) : string list =
@@ -300,47 +378,42 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
     && not meta.paused
     && Option.is_none meta.current_task_id
   in
+  (* Turn intent body and each conditional guidance bullet live as markdown
+     under config/prompts/. The OCaml side only computes the boolean toggle
+     for each bullet and loads the prose via Prompt_registry; the prose
+     itself (and any future edits) stay in the markdown files alongside the
+     other keeper prompts. See lib/keeper/keeper_prompt_names.ml for the
+     key set and fallback_externalized_bullet above for in-binary fallbacks. *)
   let board_activity_guidance =
-    if tool_allowed "keeper_board_get" && tool_allowed "keeper_board_comment" then
-      "- See board activity? Use the listed post_id. If the preview is enough, comment directly with keeper_board_comment. If you need the full post, call keeper_board_get and keeper_board_comment in the same response; keeper_board_get alone is passive and fails actionable turns.\n"
-    else
-      ""
+    load_externalized_bullet
+      ~enabled:(tool_allowed "keeper_board_get"
+                && tool_allowed "keeper_board_comment")
+      Keeper_prompt_names.turn_intent_board_activity_guidance
   in
   let board_post_guidance =
-    if tool_allowed "keeper_board_post" then
-      "- Have a finding or update? Call keeper_board_post.\n"
-    else
-      ""
+    load_externalized_bullet
+      ~enabled:(tool_allowed "keeper_board_post")
+      Keeper_prompt_names.turn_intent_board_post_guidance
   in
   let board_curation_guidance =
-    if tool_allowed "keeper_board_curation_submit" then
-      "- See enough board activity to summarize or route? Call keeper_board_curation_submit with a concise snapshot.\n"
-    else
-      ""
+    load_externalized_bullet
+      ~enabled:(tool_allowed "keeper_board_curation_submit")
+      Keeper_prompt_names.turn_intent_board_curation_guidance
   in
   let broadcast_guidance =
-    if tool_allowed "keeper_broadcast" then
-      "- Need to share broadly? Call keeper_broadcast.\n"
-    else
-      ""
+    load_externalized_bullet
+      ~enabled:(tool_allowed "keeper_broadcast")
+      Keeper_prompt_names.turn_intent_broadcast_guidance
   in
-  (* Turn intent body lives at config/prompts/keeper.turn_intent.md.
-     The OCaml side only assembles the conditional guidance bullets and feeds
-     them in as template variables; the prose itself (and any future edits)
-     stay in the markdown file alongside the other keeper prompts. *)
   let claim_guidance_a =
-    if show_claim_guidance then
-      "- See unclaimed work and you do not already hold a task? Call keeper_task_claim with {}. \
-       It auto-claims the next eligible task; you do not need a task_id argument. \
-       keeper_tasks_list remains the canonical way to inspect backlog state — \
-       use it any time you need to diagnose what work exists, not just when the claim returns empty.\n"
-    else ""
+    load_externalized_bullet
+      ~enabled:show_claim_guidance
+      Keeper_prompt_names.turn_intent_claim_guidance_a
   in
   let claim_guidance_b =
-    if show_claim_guidance then
-      "- Need GitHub or PR inspection via keeper_shell op=gh? Claim first. \
-       gh repo context is derived from your active task worktree/current_task_id.\n"
-    else ""
+    load_externalized_bullet
+      ~enabled:show_claim_guidance
+      Keeper_prompt_names.turn_intent_claim_guidance_b
   in
   let turn_intent_substitutions =
     [
@@ -466,21 +539,18 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
     Buffer.add_string ubuf
       (format_scope_messages observation.pending_scope_messages);
     Buffer.add_string ubuf "\n\n");
-  (* 8. Immediate task move — reactive operational guidance *)
+  (* 8. Immediate task move — reactive operational guidance.
+     Body lives at config/prompts/keeper.immediate_task_move.md. The OCaml
+     side only owns the section header and the trailing blank line; the
+     bullet prose stays in the markdown file alongside the other keeper
+     prompts (see fallback_externalized_bullet for the in-binary mirror). *)
   if show_claim_guidance then (
     Buffer.add_string ubuf "### Immediate Task Move\n";
     Buffer.add_string ubuf
-      "- Call keeper_task_claim with {} to claim the next eligible unclaimed task.\n";
-    Buffer.add_string ubuf
-      "- For the routine claim flow, call keeper_task_claim directly; \
-       use keeper_tasks_list to inspect backlog state, diagnose missing work, \
-       or verify task lifecycle. Never substitute Bash probes (ls/cat/find against \
-       .masc/, backlog.json, or repo-local task files) for keeper_tasks_list — \
-       keeper_shell blocks those with `task_state_file_probe_blocked`.\n";
-    Buffer.add_string ubuf
-      "- Prefer keeper_task_claim before keeper_board_list or keeper_shell when you have no claimed task.\n";
-    Buffer.add_string ubuf
-      "- If you need keeper_shell op=gh, claim first so gh can derive repo context from your active task worktree/current_task_id.\n\n");
+      (load_externalized_bullet
+         ~enabled:true
+         Keeper_prompt_names.immediate_task_move);
+    Buffer.add_char ubuf '\n');
   (* 9. Board activity — reactive trigger *)
   if observation.pending_board_events <> [] then (
     Buffer.add_string ubuf

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -3053,9 +3053,15 @@ let test_prompt_includes_claim_first_guidance () =
     (contains_substring user "### Immediate Task Move");
   check
     bool
-    "user prompt explains no task_id needed"
+    "user prompt keeps keeper_tasks_list as canonical backlog inspection"
     true
-    (contains_substring user "Do not wait for keeper_tasks_list");
+    (contains_substring user
+       "use keeper_tasks_list to inspect backlog state");
+  check
+    bool
+    "user prompt blocks Bash probes against task state files"
+    true
+    (contains_substring user "task_state_file_probe_blocked");
   check
     bool
     "user prompt prefers claim before browsing"


### PR DESCRIPTION
## 목적

`lib/keeper/keeper_unified_prompt.ml:327-330` 코멘트가 명시한 자체 정책을 같은 파일이 위반:

> Turn intent body lives at config/prompts/keeper.turn_intent.md. The OCaml side only assembles the conditional guidance bullets and feeds them in as template variables; **the prose itself (and any future edits) stay in the markdown file** alongside the other keeper prompts.

inline OCaml string literal prose 7 블록 (`claim_guidance_a/b`, `board_activity_guidance`, `board_post_guidance`, `board_curation_guidance`, `broadcast_guidance`, Immediate Task Move 섹션 4 bullet) 을 `config/prompts/` markdown 으로 이동.

Follows: PR #16571 (keeper_tasks_list 정렬, 외부화 prereq), enforces: `keeper_unified_prompt.ml:327-330` 자체 정책

## 변경 요약

### 새 markdown 파일 (7)

- `config/prompts/keeper.turn_intent.claim_guidance_a.md`
- `config/prompts/keeper.turn_intent.claim_guidance_b.md`
- `config/prompts/keeper.turn_intent.board_activity_guidance.md`
- `config/prompts/keeper.turn_intent.board_post_guidance.md`
- `config/prompts/keeper.turn_intent.board_curation_guidance.md`
- `config/prompts/keeper.turn_intent.broadcast_guidance.md`
- `config/prompts/keeper.immediate_task_move.md`

각 파일은 frontmatter (description/category) + 단일 bullet (또는 Immediate Task Move 4 bullet) 본문.

### OCaml 변경

- `lib/keeper/keeper_prompt_names.ml/.mli`: 7 개 새 prompt key 상수 추가
- `lib/keeper/keeper_unified_prompt.ml`:
  - `load_externalized_bullet ~enabled key` 헬퍼 도입 — toggle off 면 `""`, on 이면 `String.trim (Prompt_registry.get_prompt key) ^ "\n"`
  - `fallback_externalized_bullet key` 추가 — markdown 미발견 시 in-binary fallback (keeper_tool_guidance.ml 패턴 일치)
  - inline `let board_*_guidance = if ... then "..." else ""` 6 개 → `load_externalized_bullet` 호출
  - `Buffer.add_string ubuf "- ..."` 4 줄 (Immediate Task Move) → `load_externalized_bullet` 1 회 호출
- `test/test_keeper_unified.ml`: PR #16571 의 새 phrase 반영 (`use keeper_tasks_list to inspect backlog state`, `task_state_file_probe_blocked`)

### LoC

- OCaml inline prose 제거: −38 LoC
- markdown 추가: +30 LoC (frontmatter 포함)
- OCaml fallback + 헬퍼: +73 LoC (`load_externalized_bullet` + `fallback_externalized_bullet`)
- Test: ±10 LoC

### Template variable mapping

`keeper.turn_intent.md` 의 `{{board_activity_guidance}}` 등 substitution 메커니즘은 **변경 없음**. OCaml side 에서 `("board_activity_guidance", board_activity_guidance)` association 그대로 유지. prose 의 출처만 OCaml literal → markdown file.

## Scope 보존

본 PR 은 **외부화 only**. behavior 변경 없음.

- `load_externalized_bullet` 가 정상 경로에서 `String.trim` 후 `^ "\n"` 부착 → 기존 `"- bullet.\n"` 와 bytewise 동일
- Immediate Task Move 마지막 `\n\n` 도 보존 (markdown body trim 후 `\n` + OCaml 측 `\n`)
- 단 한 가지 prose 변경: PR #16571 의 keeper_tasks_list 가이드 (claim_guidance_a + immediate_task_move 4번째 bullet) — 외부화 prereq 로 명시됨

## 검증

```
dune build --root . lib/keeper      # PASS
dune build --root . test/test_keeper_unified.exe  # PASS
./_build/default/test/test_keeper_unified.exe test unified_prompt
  # 40 tests, 1 failure (test 30) — 사전 존재 fail
  # `lib/tool_shard_types.ml` 경로 hardcode, 실제 string 은 PR #16239 split 으로
  # `lib/tool_shard_types_schemas_shell.ml` 로 이동. 본 PR 무관.
./_build/default/test/test_keeper_unified.exe test unified_prompt 25  # PASS (claim first guidance)
./_build/default/test/test_keeper_unified.exe test unified_prompt 2   # PASS (turn intent fallback)
bash ~/me/scripts/pr-rfc-check.sh  # PASS (no RFC-gated subsystem touched)
```

## Self-review (best-programmer/AGENT.md)

- **목표**: 자체 정책 enforcement + prose 외부화
- **변경 파일**: 11 (markdown ×7, OCaml ×3, test ×1)
- **검증 완료**: 빌드, unified_prompt 39/40 tests (1 사전 fail 무관), pr-rfc-check
- **미검증**: 전체 keeper test_suite (광범위), dashboard / e2e

## RFC

해당 subsystem 없음 (credential/identity/operator/sandbox/dashboard credential/.claude hooks/instructions/workflow 모두 미변경). `bash ~/me/scripts/pr-rfc-check.sh` 결과 exit=0.