### PR TITLE
feat(dashboard): RFC-0135 PR-1 keeper-operational-state typed SSOT

### DIFF
--- a/dashboard/src/lib/keeper-operational-state.test.ts
+++ b/dashboard/src/lib/keeper-operational-state.test.ts
@@ -1,0 +1,339 @@
+import { describe, expect, it } from 'vitest'
+import type { Keeper, KeeperRuntimeBlockerClass } from '../types/core'
+import { KEEPER_RUNTIME_BLOCKER_CLASSES } from '../types/core'
+import type { KeeperCompositeSnapshot } from '../api/schemas/keeper-composite'
+import {
+  deriveKeeperOperationalState,
+  type KeeperOperationalState,
+} from './keeper-operational-state'
+
+function makeKeeper(overrides: Partial<Keeper> = {}): Keeper {
+  return {
+    name: 'test-keeper',
+    status: 'active',
+    ...overrides,
+  } as Keeper
+}
+
+function makeComposite(
+  overrides: Partial<KeeperCompositeSnapshot> = {},
+): KeeperCompositeSnapshot {
+  return {
+    correlation_id: 'corr',
+    run_id: 'run',
+    ts: 0,
+    phase: 'Stable',
+    turn_phase: 'idle',
+    decision: { stage: 'idle' },
+    cascade: { state: 'idle' },
+    compaction: { stage: 'idle' },
+    measurement: {} as KeeperCompositeSnapshot['measurement'],
+    invariants: {} as KeeperCompositeSnapshot['invariants'],
+    fsm_guard_violations: 0,
+    is_live: false,
+    last_outcome: null,
+    recommended_actions: [],
+    ...overrides,
+  } as KeeperCompositeSnapshot
+}
+
+function attention(
+  overrides: Partial<NonNullable<KeeperCompositeSnapshot['runtime_attention']>> = {},
+): NonNullable<KeeperCompositeSnapshot['runtime_attention']> {
+  return {
+    state: 'active',
+    needs_attention: false,
+    blocked: false,
+    reason: null,
+    raw_phase: null,
+    is_live: true,
+    source: 'test',
+    ...overrides,
+  }
+}
+
+describe('deriveKeeperOperationalState — paused branch', () => {
+  it('paused when keeper.paused === true', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({ paused: true }),
+      composite: null,
+    })
+    expect(state).toEqual<KeeperOperationalState>({
+      kind: 'paused',
+      cause: 'unknown',
+    })
+  })
+
+  it('paused operator cause when phase === Paused', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({ phase: 'Paused' }),
+      composite: null,
+    })
+    expect(state).toEqual<KeeperOperationalState>({
+      kind: 'paused',
+      cause: 'operator',
+    })
+  })
+
+  it('paused supervisor cause when blocker is supervisor_paused', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({
+        paused: true,
+        runtime_blocker_class: 'supervisor_paused',
+      }),
+      composite: null,
+    })
+    expect(state).toEqual<KeeperOperationalState>({
+      kind: 'paused',
+      cause: 'supervisor',
+    })
+  })
+
+  it('paused operator cause when pause_state === paused', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({ pause_state: 'paused' }),
+      composite: null,
+    })
+    expect(state).toEqual<KeeperOperationalState>({
+      kind: 'paused',
+      cause: 'operator',
+    })
+  })
+})
+
+describe('deriveKeeperOperationalState — offline branch', () => {
+  it.each<[Keeper['phase'], 'crashed' | 'dead' | 'shutdown' | 'unbooted']>([
+    ['Crashed', 'crashed'],
+    ['Dead', 'dead'],
+    ['Zombie', 'dead'],
+    ['Stopped', 'shutdown'],
+    ['Offline', 'unbooted'],
+  ])('phase=%s → cause=%s', (phase, cause) => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({ phase, status: 'offline' }),
+      composite: null,
+    })
+    expect(state).toEqual<KeeperOperationalState>({ kind: 'offline', cause })
+  })
+
+  it.each<['offline' | 'inactive' | 'unbooted']>([
+    ['offline'],
+    ['inactive'],
+    ['unbooted'],
+  ])('status=%s without phase → offline', (status) => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({ status }),
+      composite: null,
+    })
+    expect(state.kind).toBe('offline')
+  })
+
+  it('composite phase Stopped overrides keeper.phase', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({ phase: 'Running', status: 'active' }),
+      composite: makeComposite({ phase: 'Stopped' }),
+    })
+    expect(state.kind).toBe('offline')
+  })
+})
+
+describe('deriveKeeperOperationalState — stuck branch (RFC-0135 §1.1 root)', () => {
+  it('blocker without composite ⇒ stuck reason=blocker_class', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({
+        runtime_blocker_class: 'synthetic_stall',
+      }),
+      composite: null,
+    })
+    expect(state).toEqual<KeeperOperationalState>({
+      kind: 'stuck',
+      reason: 'synthetic_stall',
+    })
+  })
+
+  it('blocker AND execution_current=false ⇒ stuck (RFC §1.1)', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({ runtime_blocker_class: 'cascade_exhausted' }),
+      composite: makeComposite({
+        runtime_attention: attention({ execution_current: false, blocked: true }),
+      }),
+    })
+    expect(state).toEqual<KeeperOperationalState>({
+      kind: 'stuck',
+      reason: 'cascade_exhausted',
+    })
+  })
+
+  it('fiber_alive=false ⇒ stuck reason=fiber_dead even without blocker', () => {
+    const composite = makeComposite()
+    ;(composite as unknown as { phase_diagnosis: unknown }).phase_diagnosis = {
+      conditions: { fiber_alive: false },
+    }
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper(),
+      composite,
+    })
+    expect(state).toEqual<KeeperOperationalState>({
+      kind: 'stuck',
+      reason: 'fiber_dead',
+    })
+  })
+
+  it('every KEEPER_RUNTIME_BLOCKER_CLASSES value is a valid StuckReason', () => {
+    for (const cls of KEEPER_RUNTIME_BLOCKER_CLASSES) {
+      const state = deriveKeeperOperationalState({
+        keeper: makeKeeper({ runtime_blocker_class: cls as KeeperRuntimeBlockerClass }),
+        composite: null,
+      })
+      expect(state.kind === 'stuck' && state.reason === cls).toBe(true)
+    }
+  })
+})
+
+describe('deriveKeeperOperationalState — running branch with conditioning', () => {
+  it('plain running, no composite, no blocker', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({ phase: 'Running', status: 'active' }),
+      composite: null,
+    })
+    expect(state).toEqual<KeeperOperationalState>({
+      kind: 'running',
+      turnPhase: 'idle',
+      staleBlocker: null,
+    })
+  })
+
+  it('RFC §1.1 EXACT scenario: blocker set BUT execution_current=true → running, blocker is stale', () => {
+    // This is the lifecycle-worker case the user reported on 2026-05-19:
+    // list card showed "현재 차단 · synthetic_stall" while detail showed
+    // "턴 진행 중 · executing live". The SSOT verdict must be running.
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({
+        phase: 'Running',
+        status: 'active',
+        runtime_blocker_class: 'synthetic_stall',
+      }),
+      composite: makeComposite({
+        phase: 'Stable',
+        turn_phase: 'executing',
+        is_live: true,
+        runtime_attention: attention({
+          state: 'active',
+          execution_current: true,
+          blocked: false,
+        }),
+      }),
+    })
+    expect(state).toEqual<KeeperOperationalState>({
+      kind: 'running',
+      turnPhase: 'executing',
+      staleBlocker: 'synthetic_stall',
+    })
+  })
+
+  it('stale_execution_receipt=true with no blocker still surfaces as running (staleBlocker null)', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({ phase: 'Running', status: 'active' }),
+      composite: makeComposite({
+        runtime_attention: attention({
+          execution_current: true,
+          stale_execution_receipt: true,
+        }),
+      }),
+    })
+    expect(state).toEqual<KeeperOperationalState>({
+      kind: 'running',
+      turnPhase: 'idle',
+      staleBlocker: null,
+    })
+  })
+
+  it('turn_phase from composite takes precedence over keeper.pipeline_stage', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({
+        phase: 'Running',
+        status: 'active',
+        pipeline_stage: 'idle',
+      }),
+      composite: makeComposite({ turn_phase: 'compacting' }),
+    })
+    expect(state.kind === 'running' && state.turnPhase === 'compacting').toBe(true)
+  })
+})
+
+describe('deriveKeeperOperationalState — priority invariants', () => {
+  it('paused beats offline (paused supersedes status=offline)', () => {
+    // A paused keeper with offline status must still derive paused, not
+    // offline — paused is the more actionable operator signal.
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({ paused: true, status: 'offline' }),
+      composite: null,
+    })
+    expect(state.kind).toBe('paused')
+  })
+
+  it('paused beats stuck (paused supersedes blocker_class)', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({
+        paused: true,
+        runtime_blocker_class: 'synthetic_stall',
+      }),
+      composite: null,
+    })
+    expect(state.kind).toBe('paused')
+  })
+
+  it('offline beats stuck (offline supersedes blocker_class)', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({
+        phase: 'Crashed',
+        runtime_blocker_class: 'cascade_exhausted',
+      }),
+      composite: null,
+    })
+    expect(state.kind).toBe('offline')
+  })
+
+  it('stuck beats running (when execution not fresh)', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({
+        phase: 'Running',
+        runtime_blocker_class: 'turn_timeout',
+      }),
+      composite: makeComposite({
+        runtime_attention: attention({ execution_current: false }),
+      }),
+    })
+    expect(state.kind).toBe('stuck')
+  })
+})
+
+describe('deriveKeeperOperationalState — exhaustive kind union', () => {
+  it('every returned state has a discriminant kind ∈ {offline, paused, stuck, running}', () => {
+    const samples: Array<DeriveInputsLite> = [
+      { keeper: makeKeeper(), composite: null },
+      { keeper: makeKeeper({ paused: true }), composite: null },
+      { keeper: makeKeeper({ phase: 'Crashed' }), composite: null },
+      {
+        keeper: makeKeeper({ runtime_blocker_class: 'exception' }),
+        composite: null,
+      },
+      {
+        keeper: makeKeeper(),
+        composite: makeComposite({
+          runtime_attention: attention({ execution_current: true }),
+        }),
+      },
+    ]
+    const validKinds = new Set(['offline', 'paused', 'stuck', 'running'])
+    for (const input of samples) {
+      const result = deriveKeeperOperationalState(input)
+      expect(validKinds.has(result.kind)).toBe(true)
+    }
+  })
+})
+
+interface DeriveInputsLite {
+  keeper: Keeper
+  composite: KeeperCompositeSnapshot | null
+}

--- a/dashboard/src/lib/keeper-operational-state.ts
+++ b/dashboard/src/lib/keeper-operational-state.ts
@@ -1,0 +1,128 @@
+// RFC-0135 §2 — Typed SSOT for keeper operational state.
+//
+// Every dashboard surface (roster card, detail runtime panel, alert strip,
+// action panel, lifecycle timeline) derives its display verdict from this
+// single function. Three pre-RFC sites that disagreed on the same keeper:
+//   - agent-roster.ts:rosterStateNote        (flat runtime_blocker_class read)
+//   - keeper-detail-runtime.ts:deriveKeeperLiveTruth
+//                                            (composite-aware conditioning)
+//   - keeper-action-panel.ts:keeperActionVisibility
+//                                            (status/phase/paused OR-chain)
+// will all call `deriveKeeperOperationalState` instead (PR-3 ~ PR-6).
+//
+// Discriminant invariants (RFC-0135 §2 conditioning matrix):
+//   paused      ⇐ keeper.paused | phase==='Paused' | pause_state==='paused'
+//   offline     ⇐ phase ∈ Offline/Stopped/Dead/Crashed/Zombie  OR
+//                 status ∈ offline/inactive/unbooted
+//   stuck       ⇐ runtime_blocker_class set AND execution_current !== true
+//                 OR composite reports fiber_alive === false
+//   running     ⇐ otherwise (turn_phase carried; lingering stale blocker is
+//                 recorded but does NOT drive the headline)
+//
+// catch-all `default:` is forbidden — see RFC-0135 §9 (PR-9 CI guard).
+
+import type {
+  Keeper,
+  KeeperRuntimeBlockerClass,
+} from '../types/core'
+import type {
+  KeeperCompositeSnapshot,
+} from '../api/schemas/keeper-composite'
+
+export type OfflineCause = 'unbooted' | 'shutdown' | 'crashed' | 'dead' | 'unknown'
+export type PausedCause = 'operator' | 'supervisor' | 'auto_recover' | 'unknown'
+export type StuckReason = KeeperRuntimeBlockerClass | 'fiber_dead' | 'unknown'
+
+export type KeeperOperationalState =
+  | { readonly kind: 'offline'; readonly cause: OfflineCause }
+  | { readonly kind: 'paused'; readonly cause: PausedCause }
+  | { readonly kind: 'stuck'; readonly reason: StuckReason }
+  | {
+      readonly kind: 'running'
+      readonly turnPhase: string
+      readonly staleBlocker: KeeperRuntimeBlockerClass | null
+    }
+
+export interface DeriveInputs {
+  readonly keeper: Keeper
+  readonly composite: KeeperCompositeSnapshot | null
+}
+
+export function deriveKeeperOperationalState(
+  { keeper, composite }: DeriveInputs,
+): KeeperOperationalState {
+  if (isPaused(keeper)) {
+    return { kind: 'paused', cause: derivePausedCause(keeper) }
+  }
+  if (isOffline(keeper, composite)) {
+    return { kind: 'offline', cause: deriveOfflineCause(keeper) }
+  }
+
+  const blockerClass = keeper.runtime_blocker_class ?? null
+  const attention = composite?.runtime_attention ?? null
+  const executionFresh = attention?.execution_current === true
+  const staleReceipt = attention?.stale_execution_receipt === true
+
+  if (blockerClass !== null && !executionFresh) {
+    return { kind: 'stuck', reason: blockerClass }
+  }
+
+  if (composite !== null && compositeFiberKnownDead(composite)) {
+    return { kind: 'stuck', reason: 'fiber_dead' }
+  }
+
+  const turnPhase = composite?.turn_phase ?? keeper.pipeline_stage ?? 'idle'
+  const staleBlocker =
+    executionFresh && (blockerClass !== null || staleReceipt)
+      ? blockerClass
+      : null
+  return { kind: 'running', turnPhase, staleBlocker }
+}
+
+function isPaused(k: Keeper): boolean {
+  if (k.paused === true) return true
+  if (k.phase === 'Paused') return true
+  if (k.pause_state === 'paused') return true
+  return false
+}
+
+function derivePausedCause(k: Keeper): PausedCause {
+  if (k.runtime_blocker_class === 'supervisor_paused') return 'supervisor'
+  if (k.pause_state === 'paused') return 'operator'
+  if (k.phase === 'Paused') return 'operator'
+  return 'unknown'
+}
+
+function isOffline(k: Keeper, c: KeeperCompositeSnapshot | null): boolean {
+  if (c !== null && (c.phase === 'Stopped' || c.phase === 'Dead')) return true
+  if (
+    k.phase === 'Offline'
+    || k.phase === 'Stopped'
+    || k.phase === 'Dead'
+    || k.phase === 'Crashed'
+    || k.phase === 'Zombie'
+  ) return true
+  const normalizedStatus = (k.status ?? '').toLowerCase()
+  return (
+    normalizedStatus === 'offline'
+    || normalizedStatus === 'inactive'
+    || normalizedStatus === 'unbooted'
+  )
+}
+
+function deriveOfflineCause(k: Keeper): OfflineCause {
+  if (k.phase === 'Crashed') return 'crashed'
+  if (k.phase === 'Dead' || k.phase === 'Zombie') return 'dead'
+  if (k.phase === 'Stopped') return 'shutdown'
+  const normalizedStatus = (k.status ?? '').toLowerCase()
+  if (normalizedStatus === 'unbooted') return 'unbooted'
+  if (normalizedStatus === 'offline' || normalizedStatus === 'inactive') return 'unbooted'
+  return 'unknown'
+}
+
+function compositeFiberKnownDead(c: KeeperCompositeSnapshot): boolean {
+  const diag = c.phase_diagnosis
+  if (diag == null) return false
+  const fiberAlive = diag.conditions.fiber_alive
+  return fiberAlive === false
+}


### PR DESCRIPTION
## Why

[RFC-0135 §2](docs/rfc/RFC-0135-dashboard-keeper-operational-ssot.md) typed sum SSOT 모듈 신설. RFC-0135 PR 시퀀스의 *기반* — PR-3~PR-6 이 모두 같은 함수를 호출.

사용자 보고 (2026-05-19): `lifecycle-worker` 가 목록에서는 `현재 차단 · synthetic_stall`, 상세에서는 `턴 진행 중 · executing live` 로 *정반대* 결론. 원인: 두 화면이 같은 wire payload 에 다른 ad-hoc normalize 적용.

## What

**`dashboard/src/lib/keeper-operational-state.ts`** 신설:

\`\`\`ts
type KeeperOperationalState =
  | { kind: 'offline'; cause: OfflineCause }
  | { kind: 'paused'; cause: PausedCause }
  | { kind: 'stuck'; reason: StuckReason }
  | {
      kind: 'running'
      turnPhase: string
      staleBlocker: KeeperRuntimeBlockerClass | null  // execution fresh 시 prior block 기록 (headline driving 안 함)
    }

deriveKeeperOperationalState({ keeper, composite }): KeeperOperationalState
\`\`\`

핵심 conditioning (RFC-0135 §2 매트릭스):
- \`runtime_blocker_class\` set AND \`composite.runtime_attention.execution_current === true\` → **running** (blocker = stale signal, `staleBlocker` 필드 보존)
- \`runtime_blocker_class\` set AND execution not fresh → **stuck**
- \`composite.phase_diagnosis.conditions.fiber_alive === false\` → **stuck** reason=\`fiber_dead\`
- 우선순위: **paused > offline > stuck > running**

## Test matrix (26/26 PASS)

- paused branch — 4 사례 (paused=true / phase=Paused / pause_state=paused / supervisor_paused blocker)
- offline branch — 5 phase × 3 status × composite override
- **stuck branch** — RFC §1.1 사례 직접 fixture + \`KEEPER_RUNTIME_BLOCKER_CLASSES\` 26 variants × 1 assertion
- **running 우선순위 invariant** — RFC §1.1 EXACT reproduction (blocker_class=synthetic_stall + execution_current=true → kind=running, staleBlocker=synthetic_stall)
- priority invariant 4 사례 (paused>offline, paused>stuck, offline>stuck, stuck>running)
- exhaustive kind union — 모든 fixture 가 4 kind 중 하나로만 매핑

## Verification

- \`pnpm typecheck\` — PASS (0 errors)
- \`pnpm exec vitest run src/lib/keeper-operational-state.test.ts\` — 26/26 PASS
- \`pnpm lint\` — exit 0, 0 errors (기존 src/lib/ 파일과 동일한 warning 패턴 1건)

## Workaround Rejection Bar

- [x] telemetry-as-fix 아님 — 새 derivation 함수, display divergence 제거
- [x] string classifier 추가 아님 — \`KEEPER_RUNTIME_BLOCKER_CLASSES\` 기존 closed sum 재사용
- [x] N-of-M 아님 — 본 PR 은 *기반 모듈*, 후속 PR 이 모든 호출처 마이그레이션
- [x] catch-all \`default:\` 아님 — 명시적 금지 (모듈 헤더 코멘트)
- [x] cap/cooldown/dedup 아님

## RFC Check

\`bash ~/me/scripts/pr-rfc-check.sh\` — dashboard SSOT 영역, RFC-0135 PR #16573 reference. `dashboard/src/lib/`는 credential/identity/operator-control/sandbox/dashboard-credential/hooks/workflow* 무관.

## Next (RFC-0135 §5)

| PR | 내용 |
|---|---|
| PR-2 | Phase casing 3-맵 → \`toKeeperPhase()\` 단일 호출 |
| PR-3 | \`keeper-predicates.ts\` (paused/offline/blocker/wakeup) SSOT |
| **PR-4** | \`agent-roster.ts:rosterStateNote\` typed state 호출 (§1.1 직접 fix) |
| **PR-5** | \`keeper-detail-runtime.ts:deriveKeeperLiveTruth\` typed state 호출 |
| **PR-6** | \`keeper-action-panel.ts\` typed state + 중복 \`<span>일시정지</span>\` 제거 |
| PR-7 | \`stateLabel\` / \`actionLabel\` 분리 (\`하기\` 접미사) |
| PR-8 | Backend \`effective_blocker\` post-conditioned (OCaml, 독립 stack) |
| PR-9 | CI guard |

PR-1 머지 후 PR-2~7 동시 진행 가능.

## Status

**Draft** — agent PR. Ready 전환은 사용자 라벨 부착 (\`human-approved-ready\`).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>