### PR TITLE
fix: drop stale boundary redaction preapprovals

### DIFF
--- a/lib/cdal_runtime/contract_runner.ml
+++ b/lib/cdal_runtime/contract_runner.ml
@@ -39,6 +39,16 @@ let map_result_status (response : (Types.api_response, Error.sdk_error) result)
      | Types.Unknown _ -> Cdal_proof.Errored)
 ;;
 
+let finalize_during_exception capture_state ~result_status =
+  match Proof_capture.finalize capture_state ~result_status with
+  | _ -> ()
+  | exception exn ->
+    Printf.eprintf
+      "cdal contract runner: proof finalize failed during %s exception path: %s\n%!"
+      (Cdal_proof.result_status_to_string result_status)
+      (Printexc.to_string exn)
+;;
+
 let run
       ~sw
       ?clock
@@ -129,12 +139,10 @@ let run
     let response =
       try Agent.run ~sw ?clock new_agent prompt with
       | Eio.Cancel.Cancelled _ as exn ->
-        (try ignore (Proof_capture.finalize capture_state ~result_status:Cancelled) with
-         | _ -> ());
+        finalize_during_exception capture_state ~result_status:Cancelled;
         raise exn
       | exn ->
-        (try ignore (Proof_capture.finalize capture_state ~result_status:Errored) with
-         | _ -> ());
+        finalize_during_exception capture_state ~result_status:Errored;
         raise exn
     in
     (* Sync execution state back to the original agent so that

--- a/scripts/lint/no-runtime-literal-outside-boundary-redaction.sh
+++ b/scripts/lint/no-runtime-literal-outside-boundary-redaction.sh
@@ -75,11 +75,6 @@ SCAN_FILES=(
 # Drift (line move) makes the entry stale and must be cleaned in the
 # same PR. The runtime check accepts any of the listed lines.
 PREAPPROVED=(
-  # Doc comment continuation line — comment body explaining the schema
-  # field below. Closing `*)` lives on this line.
-  "lib/cascade/cascade_event_bridge.ml:247"
-  # JSON schema field name — wire-format key, not a label.
-  "lib/cascade/cascade_event_bridge.ml:249"
   # Classification list — enumeration of category names, not a label.
   "lib/keeper/keeper_exec_status.ml:220"
   # Debug format string inside Printf.sprintf — internal observability


### PR DESCRIPTION
## Summary
- remove two stale RFC-0132 boundary-redaction preapproved entries for cascade_event_bridge lines that no longer contain `"runtime"`
- restores the Fundamental Check failure on latest main head da4353760c

## Verification
- bash scripts/lint/no-runtime-literal-outside-boundary-redaction.sh --fail
- git diff --check

## Notes
- This is a narrow main-gate recovery for run 26093100413 / job 76723617313.