### PR TITLE
ci(lint): block inline json_kind_name (use Json_util.kind_name)

### DIFF
--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -110,6 +110,14 @@ jobs:
       - name: Run lint
         run: bash scripts/lint/no-inline-error-envelope.sh
 
+  no-inline-json-kind-name:
+    name: No inline json_kind_name (use Json_util.kind_name)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run lint
+        run: bash scripts/lint/no-inline-json-kind-name.sh
+
   godfile-size-regression:
     name: Godfile size
     runs-on: ubuntu-latest

--- a/scripts/lint/no-inline-json-kind-name.sh
+++ b/scripts/lint/no-inline-json-kind-name.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# no-inline-json-kind-name.sh — Block inline `let json_kind_name :
+# Yojson.Safe.t -> string = function` definitions in lib/. Use
+# Json_util.kind_name (declared in lib/core/json_util.ml) instead.
+#
+# Rationale: PR #16534 (initial 6-site dedup) + #16546 (yojson 3.0
+# dead-arm cleanup, 22 sites) + #16572 (final 11-site dedup)
+# consolidated ~20 copies of the identical 9-line Yojson.Safe.t kind
+# classifier into a single SSOT.  Without a lint guard, the next
+# received-kind enrich sprint will reintroduce the boilerplate — AI
+# agents learn from codebase statistics, and the SSOT cost (one
+# `Json_util.kind_name` call) is small enough that the inline copy
+# is "convenient" for an agent producing isolated files.
+#
+# Allowlisted files fall into two categories:
+#   1. SSOT definition itself (lib/core/json_util.ml).
+#   2. Sub-libraries whose `dune` declares yojson-only dependencies
+#      (RFC-0056 leaf-isolation pattern).  Adding `masc_core` here
+#      would break the isolation invariant; the 9-line cost per
+#      file is the smaller trade-off.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+ALLOWLIST=(
+  # SSOT definition — the canonical helper itself.
+  "lib/core/json_util.ml"
+
+  # RFC-0056 yojson-only sub-libraries (leaf isolation).  Adding
+  # masc_core to these libs would break the dependency-graph
+  # invariant that the chronicle/event/autonomous/cdal sub-libs
+  # remain consumable by lightweight downstream tooling without
+  # pulling the whole masc_core surface.
+  "lib/chronicle_event/chronicle_event.ml"
+  "lib/autonomous/stimulus.ml"
+  "lib/cdal_runtime/effect_evidence.ml"
+  "lib/multimodal/payload.ml"
+)
+
+matches_file=$(mktemp)
+errors_file=$(mktemp)
+trap 'rm -f "$matches_file" "$errors_file"' EXIT
+
+count=0
+scan_status=0
+
+if command -v rg >/dev/null 2>&1; then
+  rg --line-number --no-heading --type ocaml \
+    'let json_kind_name : Yojson\.Safe\.t -> string = function' \
+    lib/ >"$matches_file" 2>"$errors_file" || scan_status=$?
+  if [[ $scan_status -gt 1 ]]; then
+    echo "ERROR: ripgrep failed while scanning inline json_kind_name definitions" >&2
+    cat "$errors_file" >&2
+    exit "$scan_status"
+  fi
+else
+  grep -RInE --include='*.ml' \
+    'let json_kind_name : Yojson\.Safe\.t -> string = function' \
+    lib/ >"$matches_file" 2>"$errors_file" || scan_status=$?
+  if [[ $scan_status -gt 1 ]]; then
+    echo "ERROR: grep failed while scanning inline json_kind_name definitions" >&2
+    cat "$errors_file" >&2
+    exit "$scan_status"
+  fi
+fi
+
+while IFS= read -r match; do
+  [[ -z "$match" ]] && continue
+  file=${match%%:*}
+
+  skip=0
+  for allowed in "${ALLOWLIST[@]}"; do
+    if [[ "$file" == "$allowed" ]]; then
+      skip=1
+      break
+    fi
+  done
+  [[ $skip -eq 1 ]] && continue
+
+  echo "ERROR: inline json_kind_name definition (use Json_util.kind_name): $match"
+  count=$((count + 1))
+done < "$matches_file"
+
+if [[ $count -gt 0 ]]; then
+  echo ""
+  echo "Found $count inline json_kind_name definition(s) outside the allowlist."
+  echo ""
+  echo "Migration guide:"
+  echo "  1. Delete the 9-line inline definition."
+  echo "  2. Replace each callsite: json_kind_name X  ->  Json_util.kind_name X"
+  echo "  3. If the file's library lacks masc_core, either:"
+  echo "     - Add masc_core to its dune (lib/<sub>/dune) if isolation allows; or"
+  echo "     - Add the file to the ALLOWLIST in this script with a one-line"
+  echo "       rationale comment explaining the isolation constraint."
+  echo ""
+  echo "Background: PR #16534 + #16546 + #16572 closed the boilerplate"
+  echo "pattern across the non-isolated surface; this lint prevents"
+  echo "regression from future PRs."
+  exit 1
+fi
+
+echo "OK: no inline json_kind_name definitions found outside allowlist"
+exit 0


### PR DESCRIPTION
## Summary

Closes the boilerplate-regression door opened by the received-kind
enrich sprint (#16490..#16530).  Three PRs landed the dedup:

1. **#16534** — initial 6-site dedup (`lib/types/` + `lib/keeper/`).
2. **#16546** — yojson 3.0 dead-arm cleanup (22 sites × 2 lines).
3. **#16572** — final 11-site dedup; only 4 RFC-0056 yojson-only
   sub-libraries (`chronicle_event`, `autonomous/stimulus`,
   `cdal_runtime/effect_evidence`, `multimodal/payload`) retain
   the inline copy on isolation grounds.

This PR adds the **CI lint** that prevents the next received-kind
enrich sprint from re-introducing the inline boilerplate.  Without
this guard, AI agents (Claude / Codex / Gemini) producing new
JSON-parsing files copy the 9-line inline definition from sibling
files — the codebase-statistics signal makes it look "convenient",
exactly the AI Code Generation Anti-Pattern #1 ("Scattered Hardcoded
Defaults") that the dedup PRs closed.

Net change: **+109 LoC** (lint script + CI workflow entry, both
trivial).  Zero `.ml` edits — the lint passes clean on `origin/main`.

## Anti-pattern self-check (per CLAUDE.md workaround-rejection bar)

| # | Pattern | Status |
|---|---------|--------|
| 1 | Telemetry-as-fix | ✅ this *prevents* the symptom from reappearing; root-fix complement to dedup |
| 2 | String classifier | ✅ lint pattern matches the *literal definition*, not the runtime use; no classifier branch |
| 3 | N-of-M migration | ✅ all non-isolated sites are already migrated by the dedup PRs; lint locks in the closed state |
| 4 | Catch-all `_ ->` added | N/A — lint script, not OCaml |
| 5 | Cap/cooldown/dedup/repair | N/A |
| 6 | Test backdoor | N/A |
| 7 | N-site mechanical fix | ✅ this is the *prevention* lint, paired with the (already-merged) N-site closure |

## Mechanics

The lint script grep's for the exact definition pattern:

```
let json_kind_name : Yojson\.Safe\.t -> string = function
```

…against `lib/**/*.ml`, with an explicit allowlist of:

- `lib/core/json_util.ml` — the SSOT itself.
- 4 RFC-0056 yojson-only sub-libraries — adding `masc_core` would
  break the leaf-isolation invariant.

A new file that adds the inline definition outside the allowlist
fails CI with a migration-guide message pointing to
`Json_util.kind_name`.

## Evidence

```
$ bash scripts/lint/no-inline-json-kind-name.sh
OK: no inline json_kind_name definitions found outside allowlist
```

The lint passes on `origin/main` HEAD; no PR-side edits required.
Future PRs adding inline definitions will fail with:

```
ERROR: inline json_kind_name definition (use Json_util.kind_name): lib/<file>.ml:<line>:...
Migration guide:
  1. Delete the 9-line inline definition.
  2. Replace each callsite: json_kind_name X  ->  Json_util.kind_name X
  3. If the file's library lacks masc_core, either:
     - Add masc_core to its dune (lib/<sub>/dune) if isolation allows; or
     - Add the file to the ALLOWLIST in this script with a one-line
       rationale comment explaining the isolation constraint.
```

## CI integration

Added `no-inline-json-kind-name` job to
`.github/workflows/fundamental-check.yml`, immediately after the
sibling `no-inline-error-envelope` job.  Same `checkout@v4` →
`bash <script>` shape as every other lint guard in the file.

## RFC waiver

`RFC-WAIVED: Prevention-lint for boilerplate already removed by
#16534 + #16546 + #16572.  No design choice; locks in the SSOT
posture established by the dedup PRs.`

## Why this is the *root* fix, not the dedup PRs

The dedup PRs (#16534/#16546/#16572) closed the *historical* copies.
Without this lint, the next enrich sprint adds **new** copies, and
~6 months from now an audit finds 8 inline copies again — the dedup
PRs' value erodes monotonically.

The lint *converts a recurring janitorial task into a one-time
boundary*.  This is what CLAUDE.md §"AI 페어 프로그래밍 검증 규칙"
item 2 prescribes: "2번째 fix → 근본 수정 강제 — 같은 영역/원인의
fix가 2회 발생하면 call site 패치를 멈추고, 하네스/인프라/lint 레벨
에서 근본 수정을 먼저 한다."  The json_kind_name pattern had three
fixes (#16534/#16546/#16572) before this lint; this PR is the
overdue infrastructure step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)