### PR TITLE
refactor(dashboard): RFC-0046 §4.3 partial closure — drop LiveTruth FSM row + headlineDetail dual-render

### DIFF
--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -758,8 +758,11 @@ describe('RuntimeLensSection', () => {
     expect(summary.rows.find(row => row.label === '런타임')?.value).toBe('fiber alive')
     expect(summary.rows.find(row => row.label === '현재 턴')?.value).toBe('no live turn')
     expect(summary.rows.find(row => row.label === '최신 증거')?.value).toBe('turn #7 finished')
-    expect(summary.rows.find(row => row.label === 'FSM')?.value).toBe('KSM running / KTC idle')
     expect(summary.rows.find(row => row.label === '차단')?.detail).toContain('needs_execution_progress')
+    // RFC-0046 §4.3 partial closure: the FSM lane is now rendered exclusively
+    // by FsmHub mode='detail' under this panel. Asserting the absence here
+    // prevents regressing back to dual-rendering of KSM/KTC.
+    expect(summary.rows.find(row => row.label === 'FSM')).toBeUndefined()
   })
 
   it('keeps previous receipt blockers out of the current live-turn summary', () => {

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -94,7 +94,6 @@ export interface KeeperLiveTruthRow {
 
 export interface KeeperLiveTruthSummary {
   headline: string
-  headlineDetail: string
   tone: StatusChipTone
   rows: KeeperLiveTruthRow[]
   runtimeWarnings: string[]
@@ -178,7 +177,12 @@ export function deriveKeeperLiveTruth({
   runtimeResolution?: KeeperLiveTruthRuntimeInput | null
 }): KeeperLiveTruthSummary {
   const linkedState = linkedRuntimeState(keeper)
-  const phase = compactToken(compositeSnapshot?.phase ?? keeper.phase ?? keeper.status)
+  // Per-axis SSOT routing (RFC-0046 §4.3): the FSM hub below this panel is
+  // the canonical phase/turn surface, so this panel only needs `turnPhase`
+  // for the contextual "현재 턴" row detail. The old 3-way fallback
+  // `compositeSnapshot?.phase ?? keeper.phase ?? keeper.status` was the
+  // §AI코드생성 §2 Unknown-→-Permissive-Default anti-pattern that let stale
+  // flat-record fields silently feed status badges; removed here.
   const turnPhase = compactToken(compositeSnapshot?.turn_phase ?? keeper.pipeline_stage)
   const fiberAlive =
     compositeSnapshot?.phase_diagnosis?.conditions.fiber_alive
@@ -238,10 +242,9 @@ export function deriveKeeperLiveTruth({
       'no blocker reason',
     )
   const toolContract = compactToken(compositeSnapshot?.execution?.tool_contract_result ?? null, 'tool contract unknown')
-  const guardCount = compositeSnapshot?.fsm_guard_violations ?? 0
-  const invariantFailed = compositeSnapshot
-    ? Object.values(compositeSnapshot.invariants).some(value => value === false)
-    : false
+  // guardCount / invariantFailed have moved to FsmHub mode='detail' — they
+  // are rendered on the dedicated FSM lane strip directly under this panel
+  // and no longer need to be projected as a row here.
   const runtimeCommit =
     shortCommit(runtimeResolution?.server_repo_git_commit)
     ?? shortCommit(runtimeResolution?.build?.commit)
@@ -255,14 +258,16 @@ export function deriveKeeperLiveTruth({
     ? runtimeResolution.server_repo_path.path.split('/').slice(-2).join('/')
     : null
 
+  // RFC-0046 §4.3 partial closure (2026-05-19): the FSM row used to duplicate
+  // FsmHub mode='detail' (KSM/KTC/KDP/KCL/KMC/breaker lanes rendered directly
+  // below this panel). Dropping it here makes FsmHub the sole on-screen
+  // consumer of the composite invariant/guard axes. The remaining rows cover
+  // axes FsmHub does not (roster/linked runtime, idle-since label, terminal
+  // trace event, runtime_attention reason).
+  const fiberLabel = fiberAlive ? 'fiber alive' : 'fiber not proven'
+  const liveTurnLabel = activeTurn ? `${turnPhase} live` : 'no live turn'
   return {
     headline,
-    headlineDetail: [
-      `phase ${phase}`,
-      `turn ${turnPhase}`,
-      fiberAlive ? 'fiber alive' : 'fiber not proven',
-      activeTurn ? 'live turn' : 'no live turn',
-    ].join(' · '),
     tone,
     runtimeWarnings: warnings,
     runtimeBuildLabel,
@@ -270,13 +275,13 @@ export function deriveKeeperLiveTruth({
     rows: [
       {
         label: '런타임',
-        value: fiberAlive ? 'fiber alive' : 'fiber not proven',
+        value: fiberLabel,
         detail: `roster ${keeper.status} · linked ${linkedState}`,
         tone: fiberAlive ? 'ok' : 'warn',
       },
       {
         label: '현재 턴',
-        value: activeTurn ? `${turnPhase} live` : 'no live turn',
+        value: liveTurnLabel,
         detail: `${compositeSnapshot ? (compositeSnapshot.is_live === true ? 'is_live=true' : 'is_live=false') : 'is_live=unknown'} · ${turnPhase} · ${idleLabel}`,
         tone: activeTurn ? 'ok' : 'neutral',
       },
@@ -285,12 +290,6 @@ export function deriveKeeperLiveTruth({
         value: traceEvidence.value,
         detail: traceEvidence.detail,
         tone: traceEvidence.tone,
-      },
-      {
-        label: 'FSM',
-        value: `KSM ${phase} / KTC ${turnPhase}`,
-        detail: `${guardCount} guard violations · ${invariantFailed ? 'invariant fail' : 'invariants ok'}`,
-        tone: guardCount > 0 || invariantFailed ? 'bad' : 'ok',
       },
       {
         label: '차단',
@@ -369,7 +368,10 @@ export function KeeperLiveTruthPanel({
     runtimeTrace,
     runtimeResolution,
   })
-  const headlineParts = summary.headlineDetail.split(' · ').filter(Boolean)
+  // RFC-0046 §4.3 partial closure: the four inline detail badges that used
+  // to live next to the headline (`phase X · turn Y · fiber ... · live ...`)
+  // were a string-concat-then-split-back projection of the same fields the
+  // row grid below already shows. Dropped — single representation per axis.
   const firstWarning = summary.runtimeWarnings[0] ?? null
   const extraWarningCount = Math.max(0, summary.runtimeWarnings.length - 1)
 
@@ -383,11 +385,6 @@ export function KeeperLiveTruthPanel({
           <div class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Live truth</div>
           <div class="mt-1 flex flex-wrap items-center gap-2">
             <${StatusChip} tone=${summary.tone} uppercase=${false}>${summary.headline}<//>
-            ${headlineParts.map(part => html`
-              <span class="inline-flex max-w-full rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-3xs font-mono text-[var(--color-fg-secondary)]">
-                ${part}
-              </span>
-            `)}
           </div>
         </div>
         <div class="flex min-w-0 flex-wrap justify-start gap-2 sm:justify-end">


### PR DESCRIPTION
## Why

사용자가 캡처한 2026-05-19 keeper detail (`lifecycle-reviewer-fast-2`, stopped + 9h idle) 화면이 같은 사실을 **상위 panel 5개에 ~100 inline spans/badges** 로 동시 표시하고 있었습니다. 그 중 LiveTruthPanel 영역만 봐도:

1. headline 옆 4 inline badge: `phase X · turn Y · fiber not proven · no live turn`
2. 그 아래 5 row card 중 `FSM ok · KSM offline / KTC offline`
3. 그 아래 FsmHub mode='detail' 의 6-axis lane strip

세 번째가 RFC-0046 (Draft 2026-05-08) 가 SSOT 로 지정한 canonical surface 입니다. 1번과 2번 FSM row 는 그 SSOT 의 dual-render 입니다. 이 PR 은 그 dual-render 만 surgical 하게 제거합니다.

## What

`-27 / +27` (`dashboard/src/components/keeper-detail-runtime.ts` + 동일 파일 test):

1. `KeeperLiveTruthSummary.headlineDetail` 필드 제거 + split-back 렌더 제거
2. `rows.FSM` row 제거 (FsmHub mode='detail' 에 동일 axis 노출됨)
3. `compositeSnapshot?.phase ?? keeper.phase ?? keeper.status` 3-way fallback 제거 (`§AI코드생성 §2 Unknown→Permissive Default` anti-pattern)
4. `fiberAlive ? 'fiber alive' : 'fiber not proven'` stringify 가 같은 함수 안에서 2회 — 단일 `fiberLabel` const 로 dedup

drop 된 axis 는 모두 FsmHub mode='detail' lane strip + Phase State Machine collapsible 에 그대로 살아 있습니다.

## RFC-0046 acceptance criteria 진행

- [ ] composite snapshot consumers: 7 → **6** (LiveTruth FSM row 제거됨. KeeperStateDiagramPanel + KeeperMemoryTierPanel + FsmHub detail 잔존 — Phase 2 follow-up)
- [x] LiveTruth derive 가 `keeper.phase` 직접 read 안 함 (3-way fallback 제거됨)

전체 acceptance criteria 닫힘은 follow-up PR (typed verdict union, KeeperLiveTruthPanel 의 추가 row 와 alert strip 통합).

## Anti-pattern coverage (manifest §Workaround Rejection Bar)

- §AI코드생성 §1 하드코딩 산포: fiber 라벨 2회 stringify — dedup ✓
- §AI코드생성 §2 Unknown→Permissive Default: 3-way ?? fallback — 제거 ✓
- §Workaround Rejection Bar §3 N-of-M: RFC-0046 §4.3 의 "Removed surfaces" 가 N+1 변질된 사실 인정 + 부분 closure

## Tests

- `pnpm typecheck` clean
- `pnpm vitest run src/components/keeper-detail` — 119/120 pass. 1 fail (`inj 1/1 · flush 1/0 · ep/proc 2/1`, RuntimeLensSection)은 **이 PR 영역 밖, main 에서도 동일하게 실패** (stash verify 됨)
- `pnpm vitest run src/components/fsm-hub` — 255/255 pass
- 새 assertion: `summary.rows.find(row => row.label === 'FSM')).toBeUndefined()` — 재발 방지

## 동반 audit + multi-phase plan

`yousleepwhen/me` PR (별도): `memory/project_dashboard_keeper_detail_ssot_reconciliation_2026_05_19.md`. 본 PR 은 그 plan 의 Quick Win + Phase 1 일부 (RFC-0046 §4.3 partial closure).

## Test plan

- [ ] dashboard preview 에서 keeper detail 열어 LIVE TRUTH 영역에 `phase X · turn Y · fiber not proven · no live turn` 4 badge 사라졌는지 확인
- [ ] 그 아래 row grid 에 'FSM' row 사라졌는지 확인
- [ ] FsmHub mode='detail' lane strip 이 같은 axis 정보 그대로 표시하는지 확인 (정보 손실 0 확인)
- [ ] offline / running / paused keeper 각각 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)