### PR TITLE
fix: align provenance json kind helper with yojson safe

### DIFF
--- a/lib/multimodal/provenance_stub.ml
+++ b/lib/multimodal/provenance_stub.ml
@@ -2,7 +2,7 @@
 
 (* Inline kind_name helper — multimodal sub-lib lists (libraries shared_types
    unix yojson) and intentionally excludes masc_core (Json_util's home) for
-   RFC-0056 dependency-leaf isolation. The 12-line cost of an inline copy is
+   RFC-0056 dependency-leaf isolation. The 10-line cost of an inline copy is
    the smaller trade-off vs widening the sub-lib's dependency surface. Iter#32
    PR #16534 set this same pattern for chronicle_event + autonomous/stimulus. *)
 let kind_name : Yojson.Safe.t -> string = function
@@ -14,8 +14,6 @@ let kind_name : Yojson.Safe.t -> string = function
   | `String _ -> "string"
   | `Assoc _ -> "object"
   | `List _ -> "array"
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 
 type t = {
   origin_artifact_ids : Shared_types.Artifact_id.t list;

--- a/scripts/lint/no-runtime-literal-outside-boundary-redaction.sh
+++ b/scripts/lint/no-runtime-literal-outside-boundary-redaction.sh
@@ -11,8 +11,8 @@
 # labels, or internal observability and are out of RFC-0132 scope.
 #
 # Exemption: add `RFC-0132-EXEMPT: <reason>` on the same line or the
-# preceding line. The 4 known-exempt sites listed below are pre-approved
-# (schema field, classification list, debug format string).
+# preceding line. The 2 known-exempt sites listed below are pre-approved
+# (classification list, debug format string).
 #
 # Adding to scope: extend SCAN_FILES when a new subsystem's boundary
 # emit-site is routed through Boundary_redaction. Each addition must
@@ -70,16 +70,11 @@ SCAN_FILES=(
 )
 
 # Pre-approved exemptions from PR-2 audit. Each entry is `path:line:reason`.
-# These four sites carry a `"runtime"` literal that is NOT a redaction
-# target (schema field name, classification list, debug format string).
+# These two sites carry a `"runtime"` literal that is NOT a redaction
+# target (classification list, debug format string).
 # Drift (line move) makes the entry stale and must be cleaned in the
 # same PR. The runtime check accepts any of the listed lines.
 PREAPPROVED=(
-  # Doc comment continuation line — comment body explaining the schema
-  # field below. Closing `*)` lives on this line.
-  "lib/cascade/cascade_event_bridge.ml:247"
-  # JSON schema field name — wire-format key, not a label.
-  "lib/cascade/cascade_event_bridge.ml:249"
   # Classification list — enumeration of category names, not a label.
   "lib/keeper/keeper_exec_status.ml:220"
   # Debug format string inside Printf.sprintf — internal observability


### PR DESCRIPTION
Summary:
- remove Yojson.Safe-incompatible Tuple and Variant cases from provenance_stub kind_name
- keep the multimodal sub-library dependency-local helper without widening dependencies

Validation:
- ocamlformat --check lib/multimodal/provenance_stub.ml
- git diff --check
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/multimodal/test_provenance_stub.exe
- ./_build/default/test/multimodal/test_provenance_stub.exe