### PR TITLE
fix(multimodal): remove yojson 3.0 dead arms in provenance_stub

### DIFF
--- a/lib/multimodal/provenance_stub.ml
+++ b/lib/multimodal/provenance_stub.ml
@@ -14,8 +14,6 @@ let kind_name : Yojson.Safe.t -> string = function
   | `String _ -> "string"
   | `Assoc _ -> "object"
   | `List _ -> "array"
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 
 type t = {
   origin_artifact_ids : Shared_types.Artifact_id.t list;


### PR DESCRIPTION
## Summary

main build broken: `lib/multimodal/provenance_stub.ml:17` had `` `Tuple _ ``
and `` `Variant _ `` arms in its inline `kind_name` helper.  Yojson 3.0
(pinned in `masc_mcp.opam.locked`) removed those constructors from
`Yojson.Safe.t`; the file fails `dune build @check` until the dead arms
go.

## Root cause

This file was added by #16574 (provenance_stub split) before #16546
(yojson dead-arm cleanup, 22 files) caught the pattern repo-wide.
The boilerplate copy survived because:

1. #16574 was authored against an older yojson version (or copied from
   a pre-cleanup sibling).
2. The local function name is `kind_name` (not `json_kind_name`), so
   the prevention lint added in #16578 (which greps for the explicit
   `let json_kind_name : Yojson.Safe.t -> string` definition) did not
   catch it.

## Evidence

```
$ dune build --root . @check  # pre-fix
File "lib/multimodal/provenance_stub.ml", line 17, characters 4-12:
17 |   | `Tuple _ -> "tuple"
         ^^^^^^^^
Error: This pattern matches values of type [? `Tuple of 'a ]
       but a pattern was expected which matches values of type Yojson.Safe.t

$ dune build --root . @check  # post-fix
(passes silently)
```

## Follow-up

Tighten the lint added by #16578 to one of:

- Match the *signature* (`Yojson.Safe.t -> string = function`) rather
  than the exact name `json_kind_name`, OR
- Add a separate yojson-3.0 dead-arm lint blocking `` `Tuple _ `` and
  `` `Variant _ `` arms in any match against `Yojson.Safe.t`.

The signature-match variant has lower false-positive risk and catches
the same anti-pattern under any helper name.

## RFC waiver

`RFC-WAIVED: mechanical compile fix, no design choice.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)