### PR TITLE
feat(worker_tool_input): received-kind+excerpt across 6 catch-alls (DRY)

### DIFF
--- a/lib/worker_tool_input.ml
+++ b/lib/worker_tool_input.ml
@@ -3,14 +3,21 @@
 let json_to_string json =
   Yojson.Safe.pretty_to_string json
 
+let outer_kind_error other =
+  Printf.sprintf "input must be a JSON object, got %s: %s"
+    (Json_util.kind_name other) (Json_util.excerpt other)
+
 let extract_string key json =
   match json with
   | `Assoc pairs ->
     (match List.assoc_opt key pairs with
      | Some (`String s) -> Ok s
-     | Some _ -> Error (Printf.sprintf "%s must be a string" key)
+     | Some other ->
+       Error
+         (Printf.sprintf "%s must be a string, got %s: %s" key
+            (Json_util.kind_name other) (Json_util.excerpt other))
      | None -> Error (Printf.sprintf "missing required field: %s" key))
-  | _ -> Error "input must be a JSON object"
+  | other -> Error (outer_kind_error other)
 
 let extract_optional_string key json =
   match json with
@@ -18,8 +25,11 @@ let extract_optional_string key json =
     (match List.assoc_opt key pairs with
      | Some (`String s) -> Ok (Some s)
      | Some `Null | None -> Ok None
-     | Some _ -> Error (Printf.sprintf "%s must be a string" key))
-  | _ -> Error "input must be a JSON object"
+     | Some other ->
+       Error
+         (Printf.sprintf "%s must be a string, got %s: %s" key
+            (Json_util.kind_name other) (Json_util.excerpt other)))
+  | other -> Error (outer_kind_error other)
 
 let extract_tasks_array json =
   match json with
@@ -40,9 +50,12 @@ let extract_tasks_array json =
              | Error e -> Error e)
        in
        collect [] items
-     | Some _ -> Error "tasks must be a JSON array"
+     | Some other ->
+       Error
+         (Printf.sprintf "tasks must be a JSON array, got %s: %s"
+            (Json_util.kind_name other) (Json_util.excerpt other))
      | None -> Error "missing required field: tasks")
-  | _ -> Error "input must be a JSON object"
+  | other -> Error (outer_kind_error other)
 
 let extract_float key json =
   match json with


### PR DESCRIPTION
## Why

`worker_tool_input.ml` = Agent SDK tool input **shared parser**. LLM keeper들이 tool args를 wrong-type으로 보내는 mistake가 빈번 — error message에 received kind/excerpt가 있으면 self-correct 가능.

3 extractor에 동일 `"input must be a JSON object"` 외부 catch-all *반복* + 각자 wrong-type field catch-all. 6 catch-alls total.

## What

| Site | 변경 |
|------|------|
| L11 `extract_string` Some-not-String | `(got <kind>: <excerpt>)` |
| L13 outer non-Assoc | `outer_kind_error` helper |
| L21 `extract_optional_string` Some-not-String | `(got <kind>: <excerpt>)` |
| L22 outer non-Assoc | helper |
| L43 `extract_tasks_array` Some-not-List | `(got <kind>: <excerpt>)` |
| L45 outer non-Assoc | helper |

**DRY**: 3 외부 catch-all이 같은 "input must be a JSON object" → `outer_kind_error` helper로 SSOT.

## Iter series

FSM/TLA+ observability sweep `/loop 20m` cron `253cc0f6` **iter#41**:
- main 새 머지: **PR #16576 RFC-0135 PR-1 keeper-operational-state typed SSOT** (Phase 2 vocab RFC 실제 진행). Iter#36~#37 vocab cleanup이 RFC 단위로 promote.
- PR #16585 main 머지 = #16574 follow-up (yojson 3.0 dead arms removal)
- Sweep 25회째: 1/33 CONFLICTING

## Workaround Rejection Bar

- [ ] telemetry-as-fix: 아님
- [ ] string classifier 추가: 아님 (variant match 세분화 + DRY)
- [ ] N-of-M: 아님 (file 6/6)
- [ ] catch-all 추가: 아님

## RFC Check

`bash ~/me/scripts/pr-rfc-check.sh` PASS (exit 0).

## Verification

- ocamlformat PASS
- 1 file, +19 / -6
- Caller API 동일

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>