### PR TITLE
refactor(dashboard): drop ROUTE FOCUS card + sidebar QuickFact grid (Phase 5 layout SSOT)

### DIFF
--- a/dashboard/src/components/keeper-detail-body.ts
+++ b/dashboard/src/components/keeper-detail-body.ts
@@ -51,7 +51,6 @@ import { FsmHub } from './fsm-hub'
 import { currentDashboardActor } from '../api'
 import type { Keeper } from '../types'
 import type { KeeperCompositeSnapshot, KeeperRuntimeTraceResponse } from '../api/keeper'
-import type { keeperActivityDisplay } from '../lib/keeper-runtime-display'
 import { KeeperRuntimeAlertStrip } from './keeper-detail-alert-strip'
 import { KeeperCommsPanel, PlaygroundReposPanel } from './keeper-detail-comms'
 import { KeeperClearContextDialog } from './keeper-detail-lifecycle'
@@ -59,11 +58,6 @@ import type { KeeperDetailEvidenceState } from './keeper-detail-hooks'
 
 export interface KeeperDetailBodyProps {
   keeper: Keeper
-  effectiveStatus: string
-  contextRatioPct: string
-  effectiveModelLabel: string
-  effectiveModel: string
-  activityDisplay: ReturnType<typeof keeperActivityDisplay>
   compositeSnapshot: KeeperCompositeSnapshot | null
   runtimeTrace: KeeperRuntimeTraceResponse | null
   compositeEvidence: KeeperDetailEvidenceState<KeeperCompositeSnapshot>
@@ -84,11 +78,6 @@ export interface KeeperDetailBodyProps {
 
 export function KeeperDetailBody({
   keeper,
-  effectiveStatus,
-  contextRatioPct,
-  effectiveModelLabel,
-  effectiveModel,
-  activityDisplay,
   compositeSnapshot,
   runtimeTrace,
   compositeEvidence,
@@ -108,13 +97,7 @@ export function KeeperDetailBody({
 }: KeeperDetailBodyProps) {
   return html`
     <div class="grid gap-5 xl:grid-cols-[280px_minmax(0,1fr)]">
-      <${KeeperDetailOverviewSidebar}
-        effectiveStatus=${effectiveStatus}
-        contextRatioPct=${contextRatioPct}
-        effectiveModelLabel=${effectiveModelLabel}
-        effectiveModel=${effectiveModel}
-        activity=${activityDisplay}
-      />
+      <${KeeperDetailOverviewSidebar} />
 
       <div class="order-1 xl:order-2 flex flex-col gap-5">
         <${KeeperRuntimeAlertStrip} keeper=${keeper} />

--- a/dashboard/src/components/keeper-detail-page.ts
+++ b/dashboard/src/components/keeper-detail-page.ts
@@ -1,15 +1,12 @@
 import { html } from 'htm/preact'
 import { useState, useRef, useEffect } from 'preact/hooks'
-import { replaceRoute, route } from '../router'
+import { route } from '../router'
 import { keepers } from '../store'
 import { selectKeeper } from '../keeper-runtime'
 import { loadKeeperConfig } from './keeper-config-panel'
 import { findKeeper } from '../lib/keeper-utils'
 import { resolveKeeperForDetail } from '../lib/keeper-detail-resolution'
-import {
-  keeperDisplayStatus,
-  keeperActivityDisplay,
-} from '../lib/keeper-runtime-display'
+import { keeperDisplayStatus } from '../lib/keeper-runtime-display'
 import { clearKeeper, fetchKeeperTransitions } from '../api/keeper'
 import { purgeAgent } from '../api/actions'
 import { showToast } from './common/toast'
@@ -44,54 +41,13 @@ const CLOSE_BUTTON_FOCUS_CLASS = ringFocusClasses({
   offsetSurface: 'page',
 })
 
-function clearKeeperRouteFocus(): void {
-  const params: Record<string, string> = { ...route.value.params, section: 'agents' }
-  delete params.agent
-  delete params.keeper
-  replaceRoute('monitoring', params)
-}
-
-function KeeperRouteFocusPanel({
-  keeperName,
-  status,
-  agentName,
-}: {
-  keeperName: string
-  status: string
-  agentName?: string | null
-}) {
-  return html`
-    <section
-      class="rounded-[var(--r-1)] border border-[var(--color-brass-border)] bg-[var(--color-brass-soft)] px-3 py-2"
-      data-testid="keeper-route-focus"
-      aria-label="Keeper route focus"
-    >
-      <div class="flex flex-wrap items-start justify-between gap-3">
-        <div class="min-w-0">
-          <div class="font-mono text-3xs font-semibold uppercase tracking-[var(--track-section)] text-[var(--color-accent-fg)]">
-            ROUTE FOCUS
-          </div>
-          <div class="mt-1 flex min-w-0 flex-wrap items-center gap-2 text-xs text-[var(--color-fg-secondary)]">
-            <span class="rounded-[var(--r-0)] border border-[var(--color-brass-border)] bg-[var(--color-bg-page)] px-2 py-1 font-mono text-3xs text-[var(--color-accent-fg)]">
-              KEEPER ${keeperName}
-            </span>
-            <span class="font-mono text-3xs text-[var(--color-fg-muted)]">status ${status}</span>
-            ${agentName ? html`
-              <span class="font-mono text-3xs text-[var(--color-fg-muted)]">agent ${agentName}</span>
-            ` : null}
-          </div>
-        </div>
-        <button
-          type="button"
-          class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-1 font-mono text-3xs text-[var(--color-fg-muted)] transition-colors hover:border-[var(--color-border-strong)] hover:text-[var(--color-fg-primary)]"
-          onClick=${clearKeeperRouteFocus}
-        >
-          CLEAR
-        </button>
-      </div>
-    </section>
-  `
-}
+// Removed `KeeperRouteFocusPanel` (2026-05-19): the panel duplicated the
+// sticky page header (`KeeperDetailHeaderInfo`) — same keeper name and
+// status — and the CLEAR navigation it offered is covered by the existing
+// header close button. `agent_name` was the only unique field; it is
+// surfaced in the 정체성 / 세대 section. Plan reference:
+// ~/me/memory/project_dashboard_keeper_detail_ssot_reconciliation_2026_05_19.md
+// Phase 5 (layout retune).
 
 export function KeeperDetailPage() {
   const keeperName =
@@ -174,13 +130,12 @@ export function KeeperDetailPage() {
     setClearPending(false)
   }, [keeper.name])
 
-  const contextRatioPct =
-    typeof keeper.context_ratio === 'number' && Number.isFinite(keeper.context_ratio)
-      ? `${Math.round(keeper.context_ratio * 100)}%`
-      : '정보 없음'
-  const effectiveModelLabel = '런타임'
-  const effectiveModel = 'runtime'
-  const activityDisplay = keeperActivityDisplay(keeper, keeper.agent?.last_seen)
+  // Removed 4 props formerly fed into KeeperDetailOverviewSidebar QuickFacts
+  // (2026-05-19): `상태` duplicated the page header status chip,
+  // `컨텍스트` duplicated KpiGrid (rendered inside 운영 상태 개요), and
+  // `런타임 / runtime` was the literal hardcoded placeholder string with no
+  // real data behind it. `최근 활동` duplicated the page header subtitle.
+  // Plan reference: ~/me/memory/.../ssot-reconciliation/Phase 5.
 
   const submitClearContext = () => {
     void (async () => {
@@ -271,19 +226,8 @@ export function KeeperDetailPage() {
         </div>
       </div>
 
-      <${KeeperRouteFocusPanel}
-        keeperName=${keeper.name}
-        status=${effectiveStatus}
-        agentName=${keeper.agent_name ?? keeper.agent?.name ?? null}
-      />
-
       <${KeeperDetailBody}
         keeper=${keeper}
-        effectiveStatus=${effectiveStatus}
-        contextRatioPct=${contextRatioPct}
-        effectiveModelLabel=${effectiveModelLabel}
-        effectiveModel=${effectiveModel}
-        activityDisplay=${activityDisplay}
         compositeSnapshot=${compositeSnapshot}
         runtimeTrace=${runtimeTrace}
         compositeEvidence=${compositeEvidence}

--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -7,11 +7,7 @@ import { showToast } from './common/toast'
 import type { Keeper } from '../types'
 import { refreshDashboard, keepers } from '../store'
 import { KeeperPhaseAndStage } from './keeper-phase-indicator'
-import { formatDuration } from '../lib/format-time'
-import {
-  keeperDisplayModel,
-  type KeeperActivityDisplay,
-} from '../lib/keeper-runtime-display'
+import { keeperDisplayModel } from '../lib/keeper-runtime-display'
 
 function SectionLabel({ children }: { children: unknown }) {
   return html`<div class="text-3xs font-semibold uppercase tracking-[var(--track-label)] text-[var(--color-fg-muted)]">${children}</div>`
@@ -255,70 +251,30 @@ function scrollToKeeperDetailSection(sectionId: KeeperDetailSectionId): void {
   document.getElementById(sectionId)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
 }
 
-function KeeperDetailQuickFact({
-  label,
-  children,
-}: {
-  label: string
-  children: ComponentChildren
-}) {
-  return html`
-    <div class="rounded-[var(--r-5)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] px-3.5 py-3">
-      <${SectionLabel}>${label}</${SectionLabel}>
-      <div class="mt-1 text-sm font-medium leading-snug text-[var(--color-fg-primary)]">${children}</div>
-    </div>
-  `
-}
-
-function KeeperActivityValue({ activity }: { activity: KeeperActivityDisplay }) {
-  if (activity.timestamp) {
-    return html`${activity.label} <${TimeAgo} timestamp=${activity.timestamp} />`
-  }
-  if (activity.ageSeconds != null) {
-    return html`${activity.label} ${formatDuration(activity.ageSeconds)} 전`
-  }
-  return html`정보 없음`
-}
-
-export function KeeperDetailOverviewSidebar({
-  effectiveStatus,
-  contextRatioPct,
-  effectiveModelLabel,
-  effectiveModel,
-  activity,
-}: {
-  effectiveStatus: string
-  contextRatioPct: string
-  effectiveModelLabel: string
-  effectiveModel: string
-  activity: KeeperActivityDisplay
-}) {
+// `KeeperDetailOverviewSidebar` previously rendered a 4-cell QuickFact
+// grid (상태 / 컨텍스트 / 런타임 / 최근 활동) above the navigation. Each
+// cell duplicated information shown elsewhere on the page (page header
+// status chip, KpiGrid context ratio, hardcoded placeholder
+// '런타임 runtime', page header activity subtitle). The grid was removed
+// 2026-05-19 as part of the SSOT reconciliation plan (Phase 5). What
+// remains is the sticky scroll navigation — the only piece that was
+// providing unique value.
+export function KeeperDetailOverviewSidebar() {
   return html`
     <aside class="order-2 xl:order-1 xl:sticky xl:top-[104px] xl:self-start" aria-label="키퍼 프로필 요약">
-      <div class="flex flex-col gap-4 rounded-[var(--r-6)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4 shadow-[var(--shadow-panel)]">
-        <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
-          <${KeeperDetailQuickFact} label="상태">${effectiveStatus}<//>
-          <${KeeperDetailQuickFact} label="컨텍스트">${contextRatioPct}<//>
-          <${KeeperDetailQuickFact} label=${effectiveModelLabel}>${effectiveModel}<//>
-          <${KeeperDetailQuickFact} label="최근 활동">
-            <${KeeperActivityValue} activity=${activity} />
-          <//>
-        </div>
-
-        <div class="rounded-[var(--r-5)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] p-3.5">
-          <${SectionLabel}>빠른 이동</${SectionLabel}>
-          <div class="mt-3 flex flex-col gap-2">
-            ${KEEPER_DETAIL_SECTIONS.map((section) => html`
-              <button
-                type="button"
-                class="rounded-[var(--r-5)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2 text-left transition-colors hover:bg-[var(--color-bg-hover)]"
-                onClick=${() => scrollToKeeperDetailSection(section.id)}
-              >
-                <div class="text-sm font-medium text-[var(--color-fg-primary)]">${section.label}</div>
-                <div class="mt-1 text-2xs leading-relaxed text-[var(--color-fg-muted)]">${section.summary}</div>
-              </button>
-            `)}
-          </div>
+      <div class="rounded-[var(--r-5)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] p-3.5 shadow-[var(--shadow-panel)]">
+        <${SectionLabel}>빠른 이동</${SectionLabel}>
+        <div class="mt-3 flex flex-col gap-2">
+          ${KEEPER_DETAIL_SECTIONS.map((section) => html`
+            <button
+              type="button"
+              class="rounded-[var(--r-5)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2 text-left transition-colors hover:bg-[var(--color-bg-hover)]"
+              onClick=${() => scrollToKeeperDetailSection(section.id)}
+            >
+              <div class="text-sm font-medium text-[var(--color-fg-primary)]">${section.label}</div>
+              <div class="mt-1 text-2xs leading-relaxed text-[var(--color-fg-muted)]">${section.summary}</div>
+            </button>
+          `)}
         </div>
       </div>
     </aside>

--- a/dashboard/src/components/keeper-detail.test.ts
+++ b/dashboard/src/components/keeper-detail.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
+import { cleanup, render, screen } from '@testing-library/preact'
 import { html } from 'htm/preact'
 
 import type { Keeper } from '../types'
@@ -317,38 +317,13 @@ describe('KeeperDetailPage', () => {
     expect(mocks.selectKeeper).toHaveBeenCalledWith('analyst')
   })
 
-  it('surfaces and clears keeper route focus without dropping the keepers view', () => {
-    const analyst = {
-      name: 'analyst',
-      status: 'active',
-      phase: 'Running',
-      pipeline_stage: 'idle',
-      agent_name: 'keeper-analyst-agent',
-      runtime_class: 'keeper',
-      agent: {
-        exists: true,
-        name: 'keeper-analyst-agent',
-        agent_type: 'agent',
-        status: 'active',
-      },
-    } as unknown as Keeper
-    keepers.value = [analyst]
-
-    render(html`<${KeeperDetailPage} />`)
-
-    const focus = screen.getByTestId('keeper-route-focus')
-    expect(focus.textContent).toContain('ROUTE FOCUS')
-    expect(focus.textContent).toContain('KEEPER analyst')
-    expect(focus.textContent).toContain('agent keeper-analyst-agent')
-    expect(document.querySelector('[data-route-focused-keeper="analyst"]')).toBeTruthy()
-
-    fireEvent.click(screen.getByRole('button', { name: 'CLEAR' }))
-
-    expect(mocks.replaceRoute).toHaveBeenCalledWith('monitoring', {
-      section: 'agents',
-      view: 'keepers',
-    })
-  })
+  // Removed test 'surfaces and clears keeper route focus...' (2026-05-19):
+  // KeeperRouteFocusPanel was deleted as part of the Phase 5 layout SSOT
+  // reconciliation. Page header (KeeperDetailHeaderInfo) renders the same
+  // keeper name + status, and the existing close button covers the CLEAR
+  // navigation. `data-route-focused-keeper` attribute moved to the outer
+  // page container in keeper-detail-page.ts and remains testable from
+  // there if needed.
 })
 
 function makeSummary(overrides: Partial<KeeperCheckpointSummary> = {}): KeeperCheckpointSummary {


### PR DESCRIPTION
## Why

사용자가 2026-05-19 캡처에서 직접 의문 표한 두 영역:

1. **ROUTE FOCUS card** — page 상단의 brass-border card. \`KEEPER lifecycle-reviewer-fast-2 / status stopped / agent keeper-lifecycle-reviewer-fast-2-agent / CLEAR\`. page header (\`KeeperDetailHeaderInfo\`) 가 이미 keeper 이름 + status 표시. agent name 은 정체성/세대 섹션에 노출됨. CLEAR 버튼은 header 의 close (✕) 와 동일 navigation.

2. **Left aside 의 4-QuickFact grid** (\`상태 busy / 컨텍스트 정보없음 / 런타임 runtime / 최근활동 하트비트 2분 전\`):
   - \`상태\` ⇄ page header status chip 중복
   - \`컨텍스트\` ⇄ KpiGrid context_ratio 중복
   - \`런타임 runtime\` — **하드코딩 placeholder** (\`keeper-detail-page.ts\` 의 \`effectiveModelLabel = '런타임'\` / \`effectiveModel = 'runtime'\` literal). 실제 데이터 없었음. §AI코드생성 §1 안티패턴
   - \`최근활동\` ⇄ page header subtitle 중복

## What (-189 / +47 LoC, 4 파일)

- \`keeper-detail-page.ts\`: \`KeeperRouteFocusPanel\` 함수 + \`clearKeeperRouteFocus\` helper + mount + 4 placeholder prop 계산 제거
- \`keeper-detail-body.ts\`: 4 prop 시그니처 정리, sidebar mount 단순화
- \`keeper-detail-shell.ts\`: \`KeeperDetailOverviewSidebar\` prop-less navigation-only 컴포넌트로. QuickFact grid + helper 2개 (\`KeeperDetailQuickFact\`, \`KeeperActivityValue\`) + unused imports 제거
- \`keeper-detail.test.ts\`: route-focus 검증 test 1개 제거 (panel 자체가 사라짐)

**보존된 것**: 빠른 이동 sticky scroll-nav (유일한 unique value). page header / KpiGrid / 운영 상태 개요 모든 surface 그대로.

## Anti-pattern coverage (manifest)

- §AI코드생성 §1 하드코딩 산포: \`'런타임'\` / \`'runtime'\` literal placeholder 제거 ✓
- §Workaround Rejection Bar §3 N-of-M: agent name / status / activity / context_ratio 4 axis 가 N개 panel 에서 따로 표시되던 패턴 닫음 ✓

## Tests

- \`pnpm typecheck\` clean
- \`pnpm vitest run src/components/keeper-detail\` 118/119 pass. 1 fail (\`RuntimeLensSection 'inj 1/1 · flush 1/0 · ep/proc 2/1'\`) **main 에서도 동일하게 실패**, 이 PR 영역 밖
- \`pnpm lint\` clean (1 pre-existing warning in unrelated file)

## Plan reference

\`memory/project_dashboard_keeper_detail_ssot_reconciliation_2026_05_19.md\` Phase 5 (layout retune). 직전 PR #16579 (RFC-0046 §4.3 partial closure) 와 같은 plan 의 다음 단계.

## Test plan

- [ ] keeper detail page 에서 brass ROUTE FOCUS card 사라졌는지 확인
- [ ] 좌측 280px aside 의 4 mini card 사라졌는지 확인
- [ ] \`빠른 이동\` jump-link nav 그대로 작동하는지 확인
- [ ] page header 의 keeper 이름 + status + 생성시간 표시 정상인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)