### PR TITLE
refactor: split oas worker idle detail tests

### DIFF
--- a/test/stanzas/test_oas_worker.inc
+++ b/test/stanzas/test_oas_worker.inc
@@ -4,7 +4,11 @@
 
 (test
  (name test_oas_worker)
- (modules test_oas_worker test_oas_worker_provider_labels test_oas_worker_sdk_error)
+ (modules
+  test_oas_worker
+  test_oas_worker_idle_detail
+  test_oas_worker_provider_labels
+  test_oas_worker_sdk_error)
  (ocamlopt_flags (:standard -w -32))
  (action
   (setenv MASC_BASE_PATH /tmp/test-oas-worker

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -5806,77 +5806,6 @@ let test_restart_continuity_load_oas_non_empty () =
 ;;
 
 (* ================================================================ *)
-(* enrich_idle_detail — unit tests (OAS #5020 regression)          *)
-(* ================================================================ *)
-
-(** Build a minimal assistant message that contains a single ToolUse. *)
-let make_assistant_tool_use_msg name : Agent_sdk.Types.message =
-  { Agent_sdk.Types.role = Agent_sdk.Types.Assistant
-  ; content = [ Agent_sdk.Types.ToolUse { id = "call-1"; name; input = `Assoc [] } ]
-  ; name = None
-  ; tool_call_id = None
-  ; metadata = []
-  }
-;;
-
-(** Idle error with a preceding tool-use: should append "(tool: <name>)". *)
-let test_enrich_idle_detail_with_tool () =
-  let detail = "Idle detected after 3 identical turns" in
-  let messages = [ make_assistant_tool_use_msg "my_tool" ] in
-  let result = Cascade_runner.enrich_idle_detail detail messages in
-  Alcotest.(check bool)
-    "contains original prefix"
-    true
-    (String.starts_with ~prefix:detail result);
-  Alcotest.(check bool)
-    "appends tool name"
-    true
-    (contains_substring ~needle:"(tool: my_tool)" result)
-;;
-
-(** Idle error with no tool use in messages: detail should be unchanged. *)
-let test_enrich_idle_detail_no_tool () =
-  let detail = "Idle detected after 3 identical turns" in
-  let messages : Agent_sdk.Types.message list =
-    [ { Agent_sdk.Types.role = Agent_sdk.Types.User
-      ; content = [ Agent_sdk.Types.Text "hello" ]
-      ; name = None
-      ; tool_call_id = None
-      ; metadata = []
-      }
-    ]
-  in
-  let result = Cascade_runner.enrich_idle_detail detail messages in
-  Alcotest.(check string) "unchanged when no tool" detail result
-;;
-
-(** Idle error with empty message list: detail should be unchanged. *)
-let test_enrich_idle_detail_empty_messages () =
-  let detail = "Idle detected: no progress" in
-  let result = Cascade_runner.enrich_idle_detail detail [] in
-  Alcotest.(check string) "unchanged with empty messages" detail result
-;;
-
-(** Non-idle error: detail must not be modified at all. *)
-let test_enrich_idle_detail_non_idle_error () =
-  let detail = "Rate limit exceeded" in
-  let messages = [ make_assistant_tool_use_msg "some_tool" ] in
-  let result = Cascade_runner.enrich_idle_detail detail messages in
-  Alcotest.(check string) "non-idle error unchanged" detail result
-;;
-
-(** Last tool in message list wins when multiple assistant messages are present. *)
-let test_enrich_idle_detail_picks_last_tool () =
-  let detail = "Idle detected after 3 identical turns" in
-  let messages =
-    [ make_assistant_tool_use_msg "first_tool"; make_assistant_tool_use_msg "last_tool" ]
-  in
-  let expected = detail ^ " (tool: last_tool)" in
-  let result = Cascade_runner.enrich_idle_detail detail messages in
-  Alcotest.(check string) "exact string with last tool" expected result
-;;
-
-(* ================================================================ *)
 (* P0: Circuit-breaker fallback at run_named boundary               *)
 (* ================================================================ *)
 
@@ -6576,27 +6505,7 @@ let () =
             test_restart_continuity_load_oas_non_empty
         ] )
     ; ( "idle_detail_enrichment"
-      , [ Alcotest.test_case
-            "idle error with tool appends tool name"
-            `Quick
-            test_enrich_idle_detail_with_tool
-        ; Alcotest.test_case
-            "idle error with no tool is unchanged"
-            `Quick
-            test_enrich_idle_detail_no_tool
-        ; Alcotest.test_case
-            "idle error with empty messages is unchanged"
-            `Quick
-            test_enrich_idle_detail_empty_messages
-        ; Alcotest.test_case
-            "non-idle error is never modified"
-            `Quick
-            test_enrich_idle_detail_non_idle_error
-        ; Alcotest.test_case
-            "last tool name wins over earlier ones"
-            `Quick
-            test_enrich_idle_detail_picks_last_tool
-        ] )
+      , Test_oas_worker_idle_detail.cases )
     ; ( "circuit_breaker_cascade_fallback"
       , [ Alcotest.test_case
             "P0: open provider is skipped and fallback succeeds at run_named boundary"

--- a/test/test_oas_worker_idle_detail.ml
+++ b/test/test_oas_worker_idle_detail.ml
@@ -1,0 +1,98 @@
+(** Idle detail enrichment tests for [test_oas_worker]. *)
+
+open Masc_mcp
+
+let contains_substring ~needle haystack =
+  let n = String.length needle in
+  let h = String.length haystack in
+  let rec loop i =
+    i + n <= h
+    && (String.sub haystack i n = needle || loop (i + 1))
+  in
+  n = 0 || loop 0
+;;
+
+let make_assistant_tool_use_msg name : Agent_sdk.Types.message =
+  { Agent_sdk.Types.role = Agent_sdk.Types.Assistant
+  ; content = [ Agent_sdk.Types.ToolUse { id = "call-1"; name; input = `Assoc [] } ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+;;
+
+let test_enrich_idle_detail_with_tool () =
+  let detail = "Idle detected after 3 identical turns" in
+  let messages = [ make_assistant_tool_use_msg "my_tool" ] in
+  let result = Cascade_runner.enrich_idle_detail detail messages in
+  Alcotest.(check bool)
+    "contains original prefix"
+    true
+    (String.starts_with ~prefix:detail result);
+  Alcotest.(check bool)
+    "appends tool name"
+    true
+    (contains_substring ~needle:"(tool: my_tool)" result)
+;;
+
+let test_enrich_idle_detail_no_tool () =
+  let detail = "Idle detected after 3 identical turns" in
+  let messages : Agent_sdk.Types.message list =
+    [ { Agent_sdk.Types.role = Agent_sdk.Types.User
+      ; content = [ Agent_sdk.Types.Text "hello" ]
+      ; name = None
+      ; tool_call_id = None
+      ; metadata = []
+      }
+    ]
+  in
+  let result = Cascade_runner.enrich_idle_detail detail messages in
+  Alcotest.(check string) "unchanged when no tool" detail result
+;;
+
+let test_enrich_idle_detail_empty_messages () =
+  let detail = "Idle detected: no progress" in
+  let result = Cascade_runner.enrich_idle_detail detail [] in
+  Alcotest.(check string) "unchanged with empty messages" detail result
+;;
+
+let test_enrich_idle_detail_non_idle_error () =
+  let detail = "Rate limit exceeded" in
+  let messages = [ make_assistant_tool_use_msg "some_tool" ] in
+  let result = Cascade_runner.enrich_idle_detail detail messages in
+  Alcotest.(check string) "non-idle error unchanged" detail result
+;;
+
+let test_enrich_idle_detail_picks_last_tool () =
+  let detail = "Idle detected after 3 identical turns" in
+  let messages =
+    [ make_assistant_tool_use_msg "first_tool"; make_assistant_tool_use_msg "last_tool" ]
+  in
+  let expected = detail ^ " (tool: last_tool)" in
+  let result = Cascade_runner.enrich_idle_detail detail messages in
+  Alcotest.(check string) "exact string with last tool" expected result
+;;
+
+let cases =
+  [ Alcotest.test_case
+      "idle error with tool appends tool name"
+      `Quick
+      test_enrich_idle_detail_with_tool
+  ; Alcotest.test_case
+      "idle error with no tool is unchanged"
+      `Quick
+      test_enrich_idle_detail_no_tool
+  ; Alcotest.test_case
+      "idle error with empty messages is unchanged"
+      `Quick
+      test_enrich_idle_detail_empty_messages
+  ; Alcotest.test_case
+      "non-idle error is never modified"
+      `Quick
+      test_enrich_idle_detail_non_idle_error
+  ; Alcotest.test_case
+      "last tool name wins over earlier ones"
+      `Quick
+      test_enrich_idle_detail_picks_last_tool
+  ]
+;;


### PR DESCRIPTION
## Summary
- move idle detail enrichment tests into test_oas_worker_idle_detail.ml
- keep the existing idle_detail_enrichment Alcotest group wired through the new module
- register the new module in the test_oas_worker stanza

## Validation
- ocamlformat --check test/test_oas_worker.ml test/test_oas_worker_idle_detail.ml test/test_oas_worker_provider_labels.ml test/test_oas_worker_sdk_error.ml
- git diff --check
- bash scripts/lint/godfile-size-regression.sh
- scripts/ocaml-structure-ratchet.sh
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_oas_worker.exe (blocked: scripts/dune-local.sh refused due live bare Dune processes outside wrapper; CI is the compile surface)