### PR TITLE
refactor(dashboard): RFC-0135 PR-2 phase casing 3-맵 SSOT 통합

### DIFF
--- a/dashboard/src/components/keeper-state-diagram.test.ts
+++ b/dashboard/src/components/keeper-state-diagram.test.ts
@@ -1,32 +1,13 @@
 // @vitest-environment happy-dom
 import { describe, expect, it, vi } from "vitest"
-import { normalizePhase, transitionType, signalTone, badgeTone } from "./keeper-state-diagram"
+import { transitionType, signalTone, badgeTone } from "./keeper-state-diagram"
 
-describe("normalizePhase", () => {
-  it.each([
-    ["Offline", "Offline"],
-    ["Running", "Running"],
-    ["Failing", "Failing"],
-    ["overflowed", "Overflowed"],
-    ["handing_off", "HandingOff"],
-    ["paused", "Paused"],
-    ["dead", "Dead"],
-  ])("maps %s to %s", (input, expected) => {
-    expect(normalizePhase(input)).toBe(expected)
-  })
-
-  it("returns unmapped phase as-is", () => {
-    expect(normalizePhase("custom_phase")).toBe("custom_phase")
-  })
-
-  it.each([
-    [null, null],
-    [undefined, null],
-    ["", null],
-  ])("returns null for %s", (input, expected) => {
-    expect(normalizePhase(input)).toBe(expected)
-  })
-})
+// RFC-0135 PR-2: the local `normalizePhase` export was removed; phase
+// normalization now flows through `toKeeperPhase` (keeper-store-normalize)
+// which is covered by `keeper-store-normalize.test.ts`. The two unmapped
+// cases this file previously asserted (passthrough of unknown phase, null
+// for falsy inputs) become the caller's fallback (`?? raw`) responsibility
+// at the two render sites (keeper-state-diagram.ts:290, 292).
 
 describe("transitionType", () => {
   it("extracts type from object", () => {

--- a/dashboard/src/components/keeper-state-diagram.ts
+++ b/dashboard/src/components/keeper-state-diagram.ts
@@ -23,6 +23,12 @@ import {
   normalizePhaseDiagnosis,
   PhaseConditionsPanel,
 } from './phase-conditions-panel'
+// RFC-0135 PR-2: phase casing SSOT — `toKeeperPhase` is the single
+// source. The local PHASE_ID_MAP (previously lines 42-69 of this file)
+// duplicated BACKEND_PHASE_MAP in keeper-store-normalize and drifted
+// independently; that map and the local `normalizePhase` export are
+// removed in favor of the canonical helper.
+import { toKeeperPhase } from '../keeper-store-normalize'
 
 interface KeeperStateDiagramProps {
   keeperName: string
@@ -39,35 +45,6 @@ function PhaseBadge({ accent, children }: { accent?: boolean; children: unknown 
   return html`<span class="${cls}">${children}</span>`
 }
 
-const PHASE_ID_MAP: Record<string, string> = {
-  Offline: 'Offline',
-  Running: 'Running',
-  Failing: 'Failing',
-  Overflowed: 'Overflowed',
-  Compacting: 'Compacting',
-  HandingOff: 'HandingOff',
-  Draining: 'Draining',
-  Paused: 'Paused',
-  Stopped: 'Stopped',
-  Crashed: 'Crashed',
-  Restarting: 'Restarting',
-  Dead: 'Dead',
-  Zombie: 'Zombie',
-  offline: 'Offline',
-  running: 'Running',
-  failing: 'Failing',
-  overflowed: 'Overflowed',
-  compacting: 'Compacting',
-  handing_off: 'HandingOff',
-  paused: 'Paused',
-  draining: 'Draining',
-  stopped: 'Stopped',
-  crashed: 'Crashed',
-  restarting: 'Restarting',
-  dead: 'Dead',
-  zombie: 'Zombie',
-}
-
 // INVARIANT_LABELS is the SSOT in `fsm-hub-types.ts:124` — same five TLA
 // joint observer invariants emitted by `keeper_composite_observer.ml`. A
 // prior local copy in this file enumerated only four (dropped
@@ -82,11 +59,6 @@ const DIAGRAM_VIEW_CHIPS: Array<{ key: DiagramView; label: string; title: string
   { key: 'cytoscape', label: 'Cytoscape', title: 'Composite lifecycle graph' },
   { key: 'mermaid', label: 'Mermaid', title: 'Backend-generated phase diagram' },
 ]
-
-export function normalizePhase(phase: string | null | undefined): string | null {
-  if (!phase) return null
-  return PHASE_ID_MAP[phase] ?? phase
-}
 
 export function transitionType(selectedEvent: unknown): string {
   if (selectedEvent && typeof selectedEvent === 'object' && 'type' in selectedEvent) {
@@ -315,9 +287,9 @@ export function KeeperStateDiagramPanel({ keeperName, snapshot: externalSnapshot
           ${transitions.map(transition => html`
             <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2 text-2xs leading-normal text-[var(--color-fg-primary)]">
               <div class="flex flex-wrap items-center gap-2">
-                <span class="font-mono text-[var(--color-fg-secondary)]">${normalizePhase(transition.prev_phase) ?? transition.prev_phase}</span>
+                <span class="font-mono text-[var(--color-fg-secondary)]">${toKeeperPhase(transition.prev_phase) ?? transition.prev_phase}</span>
                 <span class="text-[var(--color-fg-disabled)]">→</span>
-                <span class="font-mono text-[var(--color-accent-fg)]">${normalizePhase(transition.new_phase) ?? transition.new_phase}</span>
+                <span class="font-mono text-[var(--color-accent-fg)]">${toKeeperPhase(transition.new_phase) ?? transition.new_phase}</span>
                 <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5 text-3xs text-[var(--color-fg-muted)]">
                   ${transition.event_type ?? transitionType(transition.selected_event)}
                 </span>

--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -1,5 +1,10 @@
-import type { Agent, Keeper, KeeperPhase, PipelineStage } from '../types'
+import type { Agent, Keeper, PipelineStage } from '../types'
 import { keeperDisplayStatus, keeperRuntimeBlockerHint } from './keeper-runtime-display'
+// RFC-0135 PR-2: phase casing SSOT — single source `toKeeperPhase` in
+// keeper-store-normalize. Local CANONICAL_PHASE_KEYS + normalizePhase
+// (previously lines 39-55, 159-180) duplicated BACKEND_PHASE_MAP +
+// PHASE_ID_MAP elsewhere; the three maps drifted independently.
+import { toKeeperPhase } from '../keeper-store-normalize'
 
 export type RuntimeBand = 'active' | 'attention' | 'paused' | 'offline'
 
@@ -35,21 +40,6 @@ interface MonitoringEvidence {
 
 const HEARTBEAT_STALE_MS = 5 * 60 * 1000
 const DEFAULT_CONTEXT_ATTENTION_RATIO = 0.95
-
-const CANONICAL_PHASE_KEYS = new Set([
-  'Offline',
-  'Running',
-  'Failing',
-  'Overflowed',
-  'Compacting',
-  'HandingOff',
-  'Draining',
-  'Paused',
-  'Stopped',
-  'Crashed',
-  'Restarting',
-  'Dead',
-])
 
 const OFFLINE_PHASES = new Set<string>(['Offline', 'Stopped', 'Dead'])
 const ATTENTION_PHASES = new Set<string>(['Failing', 'Overflowed', 'Compacting', 'HandingOff', 'Draining', 'Crashed', 'Restarting'])
@@ -156,36 +146,13 @@ function stageMeta(key: string | null | undefined): StageMeta {
   return meta ?? OFFLINE_STAGE_META
 }
 
-function normalizePhase(phase: KeeperPhase | string | null | undefined): string | null {
-  if (!phase) return null
-  if (CANONICAL_PHASE_KEYS.has(phase)) return phase
-  const normalized = String(phase).trim().toLowerCase()
-  if (!normalized) return null
-  const lookup: Record<string, string> = {
-    offline: 'Offline',
-    running: 'Running',
-    failing: 'Failing',
-    overflowed: 'Overflowed',
-    compacting: 'Compacting',
-    handing_off: 'HandingOff',
-    handingoff: 'HandingOff',
-    draining: 'Draining',
-    paused: 'Paused',
-    stopped: 'Stopped',
-    crashed: 'Crashed',
-    restarting: 'Restarting',
-    dead: 'Dead',
-  }
-  return lookup[normalized] ?? null
-}
-
 function normalizeStage(stage: PipelineStage | string | null | undefined): string {
   return stage ? String(stage) : 'offline'
 }
 
 export function keeperPhaseForDisplay(keeper: Keeper): string | null {
   const lifecycleKey = keeperDisplayStatus(keeper)
-  const lifecyclePhase = normalizePhase(lifecycleKey)
+  const lifecyclePhase = toKeeperPhase(lifecycleKey)
   if (
     lifecyclePhase === 'Paused'
     || lifecyclePhase === 'Stopped'
@@ -194,7 +161,7 @@ export function keeperPhaseForDisplay(keeper: Keeper): string | null {
   ) {
     return lifecyclePhase
   }
-  return normalizePhase(keeper.phase) ?? lifecyclePhase
+  return toKeeperPhase(keeper.phase) ?? lifecyclePhase
 }
 
 function isHeartbeatStale(keeper: Keeper): boolean {


### PR DESCRIPTION
## Why

RFC-0135 §1.5.1 Cluster C1 fix.

같은 의미의 phase casing map 3 개가 cross-reference 없이 산재 (audit 인용):
- `keeper-store-normalize.ts:35-69` `BACKEND_PHASE_MAP` (canonical)
- `keeper-state-diagram.ts:42-69` `PHASE_ID_MAP` (중복)
- `monitoring-runtime.ts:39-52` `CANONICAL_PHASE_KEYS` + `:159-180` local `normalizePhase` (중복)

3 맵 각자 다른 lowercase fallback rule (\`handing_off\`/\`handingoff\`/\`paused\`/etc) 보유 → drift 위험. \`feedback_dual_path_normalize_vs_raw_wire_format\` (2026-05-19) 와 동형.

## What

\`toKeeperPhase()\` (keeper-store-normalize.ts SSOT) 를 단일 호출처로 정착.

| 파일 | 제거 |
|---|---|
| \`keeper-state-diagram.ts\` | \`PHASE_ID_MAP\` (28 entries) + exported \`normalizePhase\` 함수 |
| \`monitoring-runtime.ts\` | \`CANONICAL_PHASE_KEYS\` Set + module-local \`normalizePhase\` (13 lowercase entries) + unused \`KeeperPhase\` import |
| \`keeper-state-diagram.test.ts\` | \`normalizePhase\` describe block (3 it.each + 1 + 1) |

caller (2+2 사이트) 가 \`toKeeperPhase()\` 직접 호출. 기존 \`?? raw\` / \`?? lifecyclePhase\` fallback 유지로 *동작 동등*.

## Caller 동작 동등성

- \`keeper-state-diagram.ts:290/292\` — \`?? transition.prev_phase\` fallback 이 unknown 입력을 raw 로 흘려보냄. toKeeperPhase 의 stricter \`unknown → null\` 변환 후에도 동일 출력.
- \`monitoring-runtime.ts:188/197\` (\`keeperPhaseForDisplay\`) — \`?? lifecyclePhase\` chain 도 null 을 같은 방향으로 fallback.

## Workaround Rejection Bar

- [x] telemetry-as-fix 아님 — 중복 *제거*
- [x] string classifier 추가 아님 — 기존 SSOT 재사용, 추가 lookup 없음
- [x] N-of-M 아님 — 3 맵 *전부* 한 PR 에서 통합 (cluster C1 closure)
- [x] catch-all 추가 아님 — \`?? raw\` fallback 은 caller 별 명시적 결정으로 유지
- [x] cap/cooldown 아님

사용자 절대 원칙 (\`feedback_hardcoding_and_legacy_zero_tolerance\`) — *transitional shim* 없이 legacy 박멸 (\`normalizePhase\` thin wrapper 같은 deprecation alias 두지 않음).

## RFC Check

\`bash ~/me/scripts/pr-rfc-check.sh\` — RFC-0135 PR #16573 reference. dashboard 영역, credential/identity/operator-control/sandbox 무관.

## Verification

- \`pnpm typecheck\` — PASS
- 영향 받은 3 test 파일 (monitoring-runtime + keeper-state-diagram + keeper-store-normalize) — 68/68 PASS
- \`pnpm lint\` — exit 0
- main pre-existing fail 인지 cross-check: \`keeper-detail-runtime.test.ts:RuntimeLensSection\` 는 rebased main fresh 상태에서도 fail → origin/main 의 #16579 (RFC-0046 §4.3 partial closure) 머지 후 stale 회귀. 본 PR 무관.
- \`+23 / -103\` LoC (legacy 박멸 가중치)

## Diff stat

\`\`\`
dashboard/src/components/keeper-state-diagram.test.ts | -36 lines
dashboard/src/components/keeper-state-diagram.ts      | -33 lines (PHASE_ID_MAP -28 + normalizePhase -4 + comment +1)
dashboard/src/lib/monitoring-runtime.ts               | -34 lines (CANONICAL_PHASE_KEYS -14 + normalizePhase -22 + KeeperPhase import -1 + comment +5)
\`\`\`

## Stack 위치

| RFC-0135 PR | 상태 |
|---|---|
| #16573 RFC body | Draft |
| **#16576 PR-1 typed sum module** | **MERGED** |
| **#TBD PR-2 phase casing SSOT (본 PR)** | **Draft** |
| PR-3 keeper-predicates.ts | not started |
| PR-4 rosterStateNote composite 인자 | not started |
| PR-5 deriveKeeperLiveTruth typed state | not started |
| PR-6 keeper-action-panel 중복 span 제거 | not started |
| PR-7 stateLabel/actionLabel 분리 | not started |
| PR-8 backend effective_blocker | not started |
| PR-9 CI guard | not started |

본 PR 은 PR-1 의존 *없음* — caller 가 typed sum 호출 안 함. origin/main base 독립 stack.

## Status

**Draft** — agent PR. Ready 전환은 사용자 라벨 부착 (\`human-approved-ready\`).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>