### PR TITLE
Classify cascade capacity backpressure

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -173,6 +173,14 @@ let is_required_tool_contract_violation (err : Agent_sdk.Error.sdk_error) : bool
   | Agent_sdk.Error.A2a _
   | Agent_sdk.Error.Internal _ -> false
 
+let message_looks_like_capacity_backpressure detail =
+  let lower = String.lowercase_ascii detail in
+  string_contains_substring ~needle:"slot full" lower
+  || string_contains_substring ~needle:"client capacity" lower
+  || string_contains_substring ~needle:"capacity_exhausted" lower
+  || string_contains_substring ~needle:"capacity exhausted" lower
+  || string_contains_substring ~needle:"local_resource_exhaustion" lower
+
 let is_auto_recoverable_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error) : bool =
   match Keeper_turn_driver.classify_masc_internal_error err with
   | Some
@@ -188,6 +196,7 @@ let is_auto_recoverable_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error
          { reason = Keeper_types.Other_detail detail; _ }) ->
       Keeper_turn_driver.message_looks_like_cli_wrapped_hard_quota detail
       || Keeper_turn_driver.message_looks_like_cli_wrapped_max_turns detail
+      || message_looks_like_capacity_backpressure detail
   | Some (Keeper_turn_driver.Cascade_exhausted _) ->
       false
   | Some (Keeper_turn_driver.No_tool_capable_provider _)
@@ -239,6 +248,7 @@ type degraded_retry_reason =
   | Cascade_candidates_filtered
   | Required_tool_contract_violation
   | Cascade_exhausted
+  | Capacity_exhausted
   | Rate_limit
   | Server_error
   | Auth_error
@@ -253,6 +263,7 @@ let degraded_retry_reason_to_string = function
   | Cascade_candidates_filtered -> "cascade_candidates_filtered"
   | Required_tool_contract_violation -> "required_tool_contract_violation"
   | Cascade_exhausted -> "cascade_exhausted"
+  | Capacity_exhausted -> "capacity_exhausted"
   | Rate_limit -> "rate_limit"
   | Server_error -> "server_error"
   | Auth_error -> "auth_error"
@@ -337,6 +348,11 @@ let degraded_retry_after_recoverable_error
            { reason = Keeper_types.Other_detail detail; _ })
       when Keeper_turn_driver.message_looks_like_cli_wrapped_hard_quota detail ->
         local_recovery_retry Hard_quota
+    | Some
+        (Keeper_turn_driver.Cascade_exhausted
+           { reason = Keeper_types.Other_detail detail; _ })
+      when message_looks_like_capacity_backpressure detail ->
+        local_recovery_retry Capacity_exhausted
     | Some (Keeper_turn_driver.Cascade_exhausted _)
     | Some (Keeper_turn_driver.No_tool_capable_provider _)
     | Some (Keeper_turn_driver.Accept_rejected _)
@@ -376,6 +392,11 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
            { reason = Keeper_types.Other_detail detail; _ })
       when Keeper_turn_driver.message_looks_like_cli_wrapped_hard_quota detail ->
         Some Hard_quota
+    | Some
+        (Keeper_turn_driver.Cascade_exhausted
+           { reason = Keeper_types.Other_detail detail; _ })
+      when message_looks_like_capacity_backpressure detail ->
+        Some Capacity_exhausted
     | Some (Keeper_turn_driver.Cascade_exhausted _) ->
         (* Generic cascade exhaustion: all candidates failed without a more
            specific reason. Treat as recoverable so declarative
@@ -417,9 +438,10 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
          | Agent_sdk.Error.Api (Llm_provider.Retry.AuthError _) ->
              Some Auth_error
          | Agent_sdk.Error.Provider
-             (Llm_provider.Error.RateLimit _
-             | Llm_provider.Error.CapacityExhausted _) ->
+             (Llm_provider.Error.RateLimit _) ->
              Some Rate_limit
+         | Agent_sdk.Error.Provider (Llm_provider.Error.CapacityExhausted _) ->
+             Some Capacity_exhausted
          | Agent_sdk.Error.Provider (Llm_provider.Error.HardQuota _) ->
              Some Hard_quota
          | Agent_sdk.Error.Provider (Llm_provider.Error.ServerError { code; transient; _ })

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -73,6 +73,7 @@ type degraded_retry_reason =
   | Cascade_candidates_filtered
   | Required_tool_contract_violation
   | Cascade_exhausted
+  | Capacity_exhausted
   | Rate_limit
   | Server_error
   | Auth_error

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -53,6 +53,41 @@ let test_other_detail_generic_recoverable () =
   | None ->
     fail "Generic Cascade_exhausted with Other_detail should be recoverable"
 
+let test_slot_full_other_detail_is_capacity_backpressure () =
+  let err =
+    make_cascade_exhausted
+      (KT.Other_detail "slot full, cascading to next provider")
+  in
+  check bool "slot full is auto-recoverable" true
+    (KEC.is_auto_recoverable_turn_error err);
+  check bool "slot full remains cascade_exhausted" true
+    (KEC.is_cascade_exhausted_error err);
+  match KEC.recoverable_cascade_failure_reason err with
+  | Some reason ->
+    check string "slot full -> capacity_exhausted" "capacity_exhausted"
+      (KEC.degraded_retry_reason_to_string reason)
+  | None ->
+    fail "slot full should be capacity-backpressure recoverable"
+
+let test_provider_capacity_exhausted_is_capacity_backpressure () =
+  let err =
+    Agent_sdk.Error.Provider
+      (Llm_provider.Error.CapacityExhausted
+         {
+           scope = Llm_provider.Error.CapacityProvider;
+           affected = [ "runtime" ];
+           retry_after = None;
+           detail = "capacity exhausted";
+         })
+  in
+  match KEC.recoverable_cascade_failure_reason err with
+  | Some reason ->
+    check string "Provider CapacityExhausted -> capacity_exhausted"
+      "capacity_exhausted"
+      (KEC.degraded_retry_reason_to_string reason)
+  | None ->
+    fail "Provider CapacityExhausted should be recoverable as capacity"
+
 let test_all_providers_failed_recoverable () =
   let err = make_cascade_exhausted KT.All_providers_failed in
   match KEC.recoverable_cascade_failure_reason err with
@@ -385,6 +420,10 @@ let () =
             test_auto_recoverable_cascade_exhausted_is_still_cascade_exhausted;
           test_case "Other_detail (non-quota) is recoverable" `Quick
             test_other_detail_generic_recoverable;
+          test_case "slot full Other_detail is capacity backpressure" `Quick
+            test_slot_full_other_detail_is_capacity_backpressure;
+          test_case "provider CapacityExhausted is capacity backpressure" `Quick
+            test_provider_capacity_exhausted_is_capacity_backpressure;
           test_case "All_providers_failed is recoverable" `Quick
             test_all_providers_failed_recoverable;
           test_case "No_providers_available is recoverable" `Quick


### PR DESCRIPTION
## Summary

Classifies provider/cascade capacity backpressure separately from generic cascade exhaustion and soft rate limits.

Live keeper logs showed `cascade_exhausted` with `Other_detail` such as `slot full, cascading to next provider`. That is not the same operational bucket as a generic provider failure or a soft 429. It means the cascade/provider route is capacity saturated and should be visible as its own retry reason.

## Changes

- Adds a capacity/backpressure detector for `slot full`, `client capacity`, `capacity_exhausted`, `capacity exhausted`, and `local_resource_exhaustion`.
- Adds `Capacity_exhausted` as a degraded retry reason with wire label `capacity_exhausted`.
- Maps provider `Llm_provider.Error.CapacityExhausted` to `capacity_exhausted` instead of `rate_limit`.
- Adds regression coverage for both wrapped `Cascade_exhausted Other_detail` and structured provider capacity errors.

## Validation

- `env DUNE_CACHE=disabled MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build --cache=disabled test/test_keeper_error_classify_recoverable.exe`
- `./_build/default/test/test_keeper_error_classify_recoverable.exe`
  - 24 tests passed, including the new `slot full` and provider `CapacityExhausted` cases.

Note: the first focused build attempt hit local Dune shared-cache contention (`rmdir(...dune_*_artifacts): Directory not empty`). Re-running with Dune cache disabled passed.
