### PR TITLE
refactor: split keeper idle cooldown tests

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -185,6 +185,7 @@
   test_tool_exposure
   test_autonomy_liberation
   test_keeper_unified
+  test_keeper_unified_idle_cooldown
   test_decision_pipeline
   test_decision_pipeline_observer
   test_keeper_composite_observer
@@ -484,6 +485,7 @@
   test_tool_exposure
   test_autonomy_liberation
   test_keeper_unified
+  test_keeper_unified_idle_cooldown
   test_decision_pipeline
   test_decision_pipeline_observer
   test_keeper_composite_observer

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1405,101 +1405,6 @@ let test_keepalive_scheduling_seam_gates_requested_run_on_stop () =
     decision.admission_reasons
 ;;
 
-let test_effective_cooldown_no_decay_within_base () =
-  (* Within the base cooldown period, no decay should apply. *)
-  let result =
-    WO.effective_scheduled_autonomous_cooldown ~base_cooldown:1800 ~since_last:900 ()
-  in
-  check int "no decay within base" 1800 result
-;;
-
-let test_effective_cooldown_at_boundary () =
-  (* Exactly at the base cooldown, no decay yet. *)
-  let result =
-    WO.effective_scheduled_autonomous_cooldown ~base_cooldown:1800 ~since_last:1800 ()
-  in
-  check int "no decay at boundary" 1800 result
-;;
-
-let test_effective_cooldown_first_decay () =
-  (* One full extra period: cooldown halved. *)
-  let result =
-    WO.effective_scheduled_autonomous_cooldown ~base_cooldown:1800 ~since_last:3600 ()
-  in
-  check int "first decay halves cooldown" 900 result
-;;
-
-let test_effective_cooldown_second_decay () =
-  (* Two extra periods: cooldown quartered. *)
-  let result =
-    WO.effective_scheduled_autonomous_cooldown ~base_cooldown:1800 ~since_last:5400 ()
-  in
-  check int "second decay quarters cooldown" 450 result
-;;
-
-let test_effective_cooldown_floor () =
-  (* Four+ extra periods: cooldown at floor (300s default). *)
-  let result =
-    WO.effective_scheduled_autonomous_cooldown ~base_cooldown:1800 ~since_last:10800 ()
-  in
-  check int "decay floors at min_cooldown" 300 result
-;;
-
-let test_effective_cooldown_max_int () =
-  (* max_int (first scheduled autonomous cycle ever): should hit floor immediately. *)
-  let result =
-    WO.effective_scheduled_autonomous_cooldown ~base_cooldown:1800 ~since_last:max_int ()
-  in
-  check int "max_int hits floor" 300 result
-;;
-
-let test_noop_backoff_doubles_cooldown () =
-  let result =
-    WO.effective_scheduled_autonomous_cooldown
-      ~base_cooldown:1800
-      ~since_last:900
-      ~consecutive_noop_count:1
-      ()
-  in
-  (* 1 noop → 2x multiplier → effective base = 3600, since_last < 3600 *)
-  check int "1 noop doubles effective base" 3600 result
-;;
-
-let test_noop_backoff_quadruples_cooldown () =
-  let result =
-    WO.effective_scheduled_autonomous_cooldown
-      ~base_cooldown:1800
-      ~since_last:900
-      ~consecutive_noop_count:2
-      ()
-  in
-  (* 2 noops → 4x multiplier → effective base = 7200 *)
-  check int "2 noops quadruples effective base" 7200 result
-;;
-
-let test_noop_backoff_caps_at_8x () =
-  let result =
-    WO.effective_scheduled_autonomous_cooldown
-      ~base_cooldown:1800
-      ~since_last:900
-      ~consecutive_noop_count:5
-      ()
-  in
-  (* 5 noops → capped at 3 → 8x multiplier → effective base = 14400 *)
-  check int "noop backoff caps at 8x" 14400 result
-;;
-
-let test_noop_backoff_zero_noops_unchanged () =
-  let result =
-    WO.effective_scheduled_autonomous_cooldown
-      ~base_cooldown:1800
-      ~since_last:900
-      ~consecutive_noop_count:0
-      ()
-  in
-  check int "0 noops = no backoff" 1800 result
-;;
-
 let test_idle_decay_triggers_turn () =
   (* After extended idle, decay should make cooldown_elapsed true
      even when since_last_proactive < base cooldown_sec, provided the
@@ -12418,28 +12323,6 @@ let () =
             "keepalive scheduling seam gates requested run on stop"
             `Quick
             test_keepalive_scheduling_seam_gates_requested_run_on_stop
-        ; test_case
-            "idle decay: no decay within base"
-            `Quick
-            test_effective_cooldown_no_decay_within_base
-        ; test_case "idle decay: at boundary" `Quick test_effective_cooldown_at_boundary
-        ; test_case "idle decay: first decay" `Quick test_effective_cooldown_first_decay
-        ; test_case "idle decay: second decay" `Quick test_effective_cooldown_second_decay
-        ; test_case "idle decay: floor" `Quick test_effective_cooldown_floor
-        ; test_case "idle decay: max_int" `Quick test_effective_cooldown_max_int
-        ; test_case
-            "noop backoff: doubles cooldown"
-            `Quick
-            test_noop_backoff_doubles_cooldown
-        ; test_case
-            "noop backoff: quadruples cooldown"
-            `Quick
-            test_noop_backoff_quadruples_cooldown
-        ; test_case "noop backoff: caps at 8x" `Quick test_noop_backoff_caps_at_8x
-        ; test_case
-            "noop backoff: zero noops unchanged"
-            `Quick
-            test_noop_backoff_zero_noops_unchanged
         ; test_case "idle decay: triggers turn" `Quick test_idle_decay_triggers_turn
         ; test_case
             "scheduled decision uses backlog acceleration"

--- a/test/test_keeper_unified_idle_cooldown.ml
+++ b/test/test_keeper_unified_idle_cooldown.ml
@@ -1,0 +1,119 @@
+open Alcotest
+
+module WO = Masc_mcp.Keeper_world_observation
+
+let test_effective_cooldown_no_decay_within_base () =
+  let result =
+    WO.effective_scheduled_autonomous_cooldown ~base_cooldown:1800 ~since_last:900 ()
+  in
+  check int "no decay within base" 1800 result
+;;
+
+let test_effective_cooldown_at_boundary () =
+  let result =
+    WO.effective_scheduled_autonomous_cooldown ~base_cooldown:1800 ~since_last:1800 ()
+  in
+  check int "no decay at boundary" 1800 result
+;;
+
+let test_effective_cooldown_first_decay () =
+  let result =
+    WO.effective_scheduled_autonomous_cooldown ~base_cooldown:1800 ~since_last:3600 ()
+  in
+  check int "first decay halves cooldown" 900 result
+;;
+
+let test_effective_cooldown_second_decay () =
+  let result =
+    WO.effective_scheduled_autonomous_cooldown ~base_cooldown:1800 ~since_last:5400 ()
+  in
+  check int "second decay quarters cooldown" 450 result
+;;
+
+let test_effective_cooldown_floor () =
+  let result =
+    WO.effective_scheduled_autonomous_cooldown ~base_cooldown:1800 ~since_last:10800 ()
+  in
+  check int "decay floors at min_cooldown" 300 result
+;;
+
+let test_effective_cooldown_max_int () =
+  let result =
+    WO.effective_scheduled_autonomous_cooldown ~base_cooldown:1800 ~since_last:max_int ()
+  in
+  check int "max_int hits floor" 300 result
+;;
+
+let test_noop_backoff_doubles_cooldown () =
+  let result =
+    WO.effective_scheduled_autonomous_cooldown
+      ~base_cooldown:1800
+      ~since_last:900
+      ~consecutive_noop_count:1
+      ()
+  in
+  check int "1 noop doubles effective base" 3600 result
+;;
+
+let test_noop_backoff_quadruples_cooldown () =
+  let result =
+    WO.effective_scheduled_autonomous_cooldown
+      ~base_cooldown:1800
+      ~since_last:900
+      ~consecutive_noop_count:2
+      ()
+  in
+  check int "2 noops quadruples effective base" 7200 result
+;;
+
+let test_noop_backoff_caps_at_8x () =
+  let result =
+    WO.effective_scheduled_autonomous_cooldown
+      ~base_cooldown:1800
+      ~since_last:900
+      ~consecutive_noop_count:5
+      ()
+  in
+  check int "noop backoff caps at 8x" 14400 result
+;;
+
+let test_noop_backoff_zero_noops_unchanged () =
+  let result =
+    WO.effective_scheduled_autonomous_cooldown
+      ~base_cooldown:1800
+      ~since_last:900
+      ~consecutive_noop_count:0
+      ()
+  in
+  check int "0 noops = no backoff" 1800 result
+;;
+
+let () =
+  run
+    "keeper unified idle cooldown"
+    [ ( "idle_decay"
+      , [ test_case
+            "idle decay: no decay within base"
+            `Quick
+            test_effective_cooldown_no_decay_within_base
+        ; test_case "idle decay: at boundary" `Quick test_effective_cooldown_at_boundary
+        ; test_case "idle decay: first decay" `Quick test_effective_cooldown_first_decay
+        ; test_case "idle decay: second decay" `Quick test_effective_cooldown_second_decay
+        ; test_case "idle decay: floor" `Quick test_effective_cooldown_floor
+        ; test_case "idle decay: max_int" `Quick test_effective_cooldown_max_int
+        ; test_case
+            "noop backoff: doubles cooldown"
+            `Quick
+            test_noop_backoff_doubles_cooldown
+        ; test_case
+            "noop backoff: quadruples cooldown"
+            `Quick
+            test_noop_backoff_quadruples_cooldown
+        ; test_case "noop backoff: caps at 8x" `Quick test_noop_backoff_caps_at_8x
+        ; test_case
+            "noop backoff: zero noops unchanged"
+            `Quick
+            test_noop_backoff_zero_noops_unchanged
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- move pure idle cooldown and noop backoff checks out of test_keeper_unified.ml
- register test_keeper_unified_idle_cooldown as its own standard test binary
- leave the stateful idle-decay scheduling test in test_keeper_unified.ml

## Validation
- ocamlformat --check test/test_keeper_unified.ml test/test_keeper_unified_idle_cooldown.ml
- git diff --check
- bash scripts/lint/godfile-size-regression.sh
- scripts/ocaml-structure-ratchet.sh
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_unified_idle_cooldown.exe (blocked: scripts/dune-local.sh refused due live bare Dune processes outside wrapper; CI is the compile surface)