### PR TITLE
test(dashboard): align runtime lens memory evidence expectation

### DIFF
--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -729,7 +729,7 @@ describe('RuntimeLensSection', () => {
     expect(screen.getByText('event ids')).toBeInTheDocument()
     expect(screen.getByText('corr corr-1 · run run-1')).toBeInTheDocument()
     expect(screen.getByText('memory evidence')).toBeInTheDocument()
-    expect(screen.getByText('inj 1/1 · flush 1/0 · ep/proc 2/1')).toBeInTheDocument()
+    expect(screen.getByText('inj 1/1 · flush success 1 · error 0 · ep/proc ep 2 · proc 1')).toBeInTheDocument()
     expect(screen.getAllByText('keeper_task_done').length).toBeGreaterThan(0)
     expect(screen.getByText('Provider')).toBeInTheDocument()
     expect(screen.getByText('Tool Runtime')).toBeInTheDocument()


### PR DESCRIPTION
## Why

Latest main Dashboard CI failed in `src/components/keeper-detail-runtime.test.ts` because the runtime lens test still expected the old ratio-shaped memory evidence text:

`inj 1/1 · flush 1/0 · ep/proc 2/1`

The component now intentionally renders independent counters with explicit labels via `formatIndependentCounters`, so the live UI text is:

`inj 1/1 · flush success 1 · error 0 · ep/proc ep 2 · proc 1`

This PR updates the stale assertion to match the current counter-format SSOT.

## Tests

- `pnpm install --offline --frozen-lockfile`
- `pnpm exec vitest run src/components/keeper-detail-runtime.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1` - 39 passed
- `pnpm run typecheck`
- `pnpm lint` - passed with one pre-existing warning in `src/components/common/virtual-list.ts`
- `pnpm test` - 643 files / 7636 tests passed, then Solid suite 16 files / 175 tests passed
- `git diff --check`
