### PR TITLE
feat(dashboard): RFC-0135 PR-4 roster typed-state conditioning (§1.1 fix)

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -2,8 +2,9 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { AgentRoster, countRuntimeKinds } from './agent-roster'
+import { AgentRoster, countRuntimeKinds, rosterStateNote } from './agent-roster'
 import type { Agent, Keeper } from '../types'
+import type { KeeperCompositeSnapshot } from '../api/schemas/keeper-composite'
 import {
   agents,
   keepers,
@@ -30,6 +31,171 @@ async function flushUi(): Promise<void> {
     await Promise.resolve()
   })
 }
+
+describe('rosterStateNote — RFC-0135 §1.1 typed-state conditioning', () => {
+  function k(overrides: Partial<Keeper> = {}): Keeper {
+    return {
+      name: 'lifecycle-worker',
+      status: 'active',
+      ...overrides,
+    } as Keeper
+  }
+
+  function compositeWith(
+    runtimeAttention: NonNullable<KeeperCompositeSnapshot['runtime_attention']>,
+    extras: Partial<KeeperCompositeSnapshot> = {},
+  ): KeeperCompositeSnapshot {
+    return {
+      correlation_id: 'c',
+      run_id: 'r',
+      ts: 0,
+      phase: 'Stable',
+      turn_phase: 'idle',
+      decision: { stage: 'idle' },
+      cascade: { state: 'idle' },
+      compaction: { stage: 'idle' },
+      measurement: {} as KeeperCompositeSnapshot['measurement'],
+      invariants: {} as KeeperCompositeSnapshot['invariants'],
+      fsm_guard_violations: 0,
+      is_live: false,
+      last_outcome: null,
+      recommended_actions: [],
+      runtime_attention: runtimeAttention,
+      ...extras,
+    } as KeeperCompositeSnapshot
+  }
+
+  function attention(
+    partial: Partial<NonNullable<KeeperCompositeSnapshot['runtime_attention']>> = {},
+  ): NonNullable<KeeperCompositeSnapshot['runtime_attention']> {
+    return {
+      state: 'active',
+      needs_attention: false,
+      blocked: false,
+      reason: null,
+      raw_phase: null,
+      is_live: true,
+      source: 'test',
+      ...partial,
+    }
+  }
+
+  it('returns "현재 차단" when blocker is set and no composite is available', () => {
+    const note = rosterStateNote(
+      k({ runtime_blocker_class: 'synthetic_stall', runtime_blocker_summary: '실제 막힘' }),
+      null,
+      null,
+    )
+    expect(note).toEqual({
+      label: '현재 차단',
+      text: '실제 막힘',
+      kind: 'synthetic_stall',
+    })
+  })
+
+  it('RFC §1.1 EXACT — blocker_class=synthetic_stall + execution_current=true must NOT surface as 현재 차단', () => {
+    // The exact 2026-05-19 lifecycle-worker scenario the user reported:
+    // list card said "현재 차단 · synthetic_stall" while the detail panel
+    // showed "턴 진행 중 · executing live". The fix routes the roster
+    // through the same typed conditioning the detail panel uses, so the
+    // blocker_class is recognized as stale and demoted to "이전 차단".
+    const note = rosterStateNote(
+      k({
+        phase: 'Running',
+        runtime_blocker_class: 'synthetic_stall',
+        runtime_blocker_summary: '잔여 marker',
+      }),
+      compositeWith(attention({ execution_current: true, blocked: false }), {
+        turn_phase: 'executing',
+        is_live: true,
+      }),
+      null,
+    )
+    expect(note).toEqual({
+      label: '이전 차단',
+      text: '이전 턴 차단 (synthetic_stall) — 현재는 실행 중',
+      kind: 'synthetic_stall',
+    })
+  })
+
+  it('genuine stuck — blocker_class set + execution_current=false → 현재 차단', () => {
+    const note = rosterStateNote(
+      k({
+        phase: 'Running',
+        runtime_blocker_class: 'cascade_exhausted',
+        runtime_blocker_summary: 'cascade list 소진',
+      }),
+      compositeWith(attention({ execution_current: false, blocked: true })),
+      null,
+    )
+    expect(note).toEqual({
+      label: '현재 차단',
+      text: 'cascade list 소진',
+      kind: 'cascade_exhausted',
+    })
+  })
+
+  it('class without summary surfaces typed reason in fallback message', () => {
+    const note = rosterStateNote(
+      k({ runtime_blocker_class: 'heartbeat_failures' }),
+      null,
+      null,
+    )
+    expect(note).toEqual({
+      label: '현재 차단',
+      text: '차단 종류: heartbeat_failures (요약 메시지 없음)',
+      kind: 'heartbeat_failures',
+    })
+  })
+
+  it('falls through to diagnostic error when no blocker and no stale blocker', () => {
+    const note = rosterStateNote(
+      k({
+        phase: 'Running',
+        diagnostic: {
+          last_error: 'tool call failed',
+          health_state: 'degraded',
+          next_action_path: 'recover',
+          last_reply_status: 'error',
+        },
+      }),
+      compositeWith(attention({ execution_current: true })),
+      null,
+    )
+    expect(note).toEqual({ label: '최근 오류', text: 'tool call failed' })
+  })
+
+  it('falls through to monitoring hint when nothing else applies', () => {
+    const note = rosterStateNote(
+      k({ phase: 'Running' }),
+      null,
+      '관찰 메모',
+    )
+    expect(note).toEqual({ label: '상태 메모', text: '관찰 메모' })
+  })
+
+  it('paused keeper produces no state note (signaled by badge elsewhere)', () => {
+    const note = rosterStateNote(
+      k({ paused: true, runtime_blocker_class: 'supervisor_paused' }),
+      null,
+      null,
+    )
+    expect(note).toBeNull()
+  })
+
+  it('offline keeper produces no state note', () => {
+    const note = rosterStateNote(
+      k({ phase: 'Crashed', status: 'offline' }),
+      null,
+      null,
+    )
+    expect(note).toBeNull()
+  })
+
+  it('null keeper returns null', () => {
+    expect(rosterStateNote(null, null, null)).toBeNull()
+  })
+})
 
 describe('countRuntimeKinds', () => {
   it('excludes configured-only paused keepers from live runtime counts', () => {

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -49,6 +49,16 @@ import {
 import {
   keeperActivityDisplay,
 } from '../lib/keeper-runtime-display'
+// RFC-0135 PR-4: roster card derives its blocker note through the typed
+// KeeperOperationalState SSOT so the headline (`현재 차단` vs `이전 차단`
+// vs `실행중`) matches the detail panel for the same keeper. Previously
+// `rosterStateNote` read `keeper.runtime_blocker_*` flat and never saw
+// `composite.runtime_attention.execution_current`, producing the
+// 2026-05-19 lifecycle-worker symptom (`현재 차단 · synthetic_stall` in
+// the list while detail showed `턴 진행 중 · executing live`).
+import { deriveKeeperOperationalState } from '../lib/keeper-operational-state'
+import type { KeeperCompositeSnapshot } from '../api/schemas/keeper-composite'
+import { fleetCompositeSnapshot } from '../composite-signals'
 
 type StatusFilter = 'all' | RuntimeBand
 
@@ -84,30 +94,50 @@ function rosterContextMeta(
   return { pct, detail }
 }
 
-function rosterStateNote(
-  keeper: {
-    runtime_blocker_summary?: string | null
-    runtime_blocker_class?: string | null
-    diagnostic?: { last_error?: string | null } | null
-  } | null | undefined,
+/**
+ * RFC-0135 §1.1 root fix. Decide the roster card state note from the
+ * typed `KeeperOperationalState` SSOT — the same function the detail
+ * panel calls — so the two surfaces cannot diverge.
+ *
+ * Display rules per typed state:
+ *  - stuck             → `현재 차단`  (text: backend summary or typed reason)
+ *  - running + staleBlocker → `이전 차단` (informational; not a headline)
+ *  - running           → fallback to diagnostic error / monitoring hint
+ *  - paused / offline  → null — these states are signaled by the row's
+ *                         phase badge and dedicated chips elsewhere; the
+ *                         state-note slot stays available for extra
+ *                         operational context only.
+ */
+export function rosterStateNote(
+  keeper: Keeper | null | undefined,
+  composite: KeeperCompositeSnapshot | null,
   monitoringHint?: string | null,
 ): { label: string; text: string; kind?: string } | null {
-  const runtimeBlocker = keeper?.runtime_blocker_summary?.trim()
-  const blockerClass = keeper?.runtime_blocker_class?.trim() || undefined
-  if (runtimeBlocker) {
-    return { label: '현재 차단', text: runtimeBlocker, kind: blockerClass }
-  }
-  // Class without summary: surface the typed kind so operators still see *why*
-  // (e.g. "heartbeat_failures") instead of an unlabelled '현재 차단' badge.
-  if (blockerClass) {
+  if (!keeper) return null
+
+  const state = deriveKeeperOperationalState({ keeper, composite })
+
+  if (state.kind === 'stuck') {
+    const summary = keeper.runtime_blocker_summary?.trim()
+    if (summary) {
+      return { label: '현재 차단', text: summary, kind: state.reason }
+    }
     return {
       label: '현재 차단',
-      text: `차단 종류: ${blockerClass} (요약 메시지 없음)`,
-      kind: blockerClass,
+      text: `차단 종류: ${state.reason} (요약 메시지 없음)`,
+      kind: state.reason,
     }
   }
 
-  const diagnosticError = keeper?.diagnostic?.last_error?.trim()
+  if (state.kind === 'running' && state.staleBlocker !== null) {
+    return {
+      label: '이전 차단',
+      text: `이전 턴 차단 (${state.staleBlocker}) — 현재는 실행 중`,
+      kind: state.staleBlocker,
+    }
+  }
+
+  const diagnosticError = keeper.diagnostic?.last_error?.trim()
   if (diagnosticError) return { label: '최근 오류', text: diagnosticError }
 
   const hint = monitoringHint?.trim()
@@ -425,6 +455,26 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     [runtimeKeeperList],
   )
 
+  // RFC-0135 PR-4: index the fleet-wide composite snapshot stream by
+  // keeper identity so each roster row can read the same conditioning
+  // signals (`runtime_attention.execution_current` etc.) the detail
+  // panel already uses. `.value` access here auto-subscribes the
+  // component to SSE-driven updates from `hydrateFleetCompositeSnapshot`.
+  const fleetSnapshot = fleetCompositeSnapshot.value
+  const compositeByKeeperKey = useMemo(() => {
+    const map = new Map<string, KeeperCompositeSnapshot>()
+    if (!fleetSnapshot) return map
+    for (const snap of fleetSnapshot.snapshots) {
+      const identityKeys = [snap.keeper, snap.correlation_id]
+      for (const candidate of identityKeys) {
+        if (typeof candidate === 'string' && candidate !== '' && !map.has(candidate)) {
+          map.set(candidate, snap)
+        }
+      }
+    }
+    return map
+  }, [fleetSnapshot])
+
   // Derive runtime kind counts from memoized roster (avoids duplicate buildAgentRoster call)
   const liveRuntimeCounts = useMemo(() => {
     const keeperCount = scopeAgentsByKeeperFilter(rosterAgents, runtimeKeeperList, 'keeper-only', keeperRuntimeLookup).length
@@ -659,9 +709,20 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             ?? trimText(goalSummary, 140)
             ?? '최근 활동 요약 없음'
           const summaryText = workPreview
+          const compositeForKeeper: KeeperCompositeSnapshot | null = keeperRuntime
+            ? compositeByKeeperKey.get(keeperRuntime.name)
+              ?? (keeperRuntime.keeper_id != null
+                ? compositeByKeeperKey.get(keeperRuntime.keeper_id)
+                : undefined)
+              ?? null
+            : null
           const stateNote =
             keeperRuntime
-              ? rosterStateNote(keeperRuntime, band.key === 'active' ? null : keeperMonitoring?.hint ?? null)
+              ? rosterStateNote(
+                  keeperRuntime,
+                  compositeForKeeper,
+                  band.key === 'active' ? null : keeperMonitoring?.hint ?? null,
+                )
               : null
           const recentTools = uniqueToolNames(
             keeperRuntime?.recent_tool_names,


### PR DESCRIPTION
## Why

**RFC-0135 §1.1 직접 fix** — 2026-05-19 사용자 보고:

> "lifecycle-worker 목록에서는 '현재 차단/synthetic_stall', 상세에서는 '턴 진행 중/executing live' — 이 불일치를 어케함?"

audit C derivation 함수 #1 의 근본 원인: \`rosterStateNote\` 시그니처가 **\`composite\` 인자 자체를 안 받음** → \`composite.runtime_attention.execution_current\` 로 stale blocker 를 demote 하는 conditioning 이 *물리적으로 불가능*했던 구조적 결함. detail panel 의 \`deriveKeeperLiveTruth\` 는 이미 같은 conditioning 으로 정렬됨.

## What

\`rosterStateNote\` 가 RFC-0135 PR-1 (#16576 MERGED) 의 typed SSOT 호출:

\`\`\`ts
// Before
function rosterStateNote(keeper, monitoringHint) {
  if (keeper?.runtime_blocker_summary) return { label: '현재 차단', ... }  // flat read, blind to composite
  ...
}

// After
export function rosterStateNote(keeper, composite, monitoringHint) {
  const state = deriveKeeperOperationalState({ keeper, composite })
  if (state.kind === 'stuck')                   return { label: '현재 차단', ... }
  if (state.kind === 'running' && staleBlocker) return { label: '이전 차단', ... }
  // diagnostic / monitoring hint fallback
}
\`\`\`

분기 매트릭스:

| state | display label |
|---|---|
| \`stuck\` | \`현재 차단\` (summary 또는 typed reason) |
| \`running + staleBlocker\` | \`이전 차단\` (informational, 헤드라인 demoted) |
| \`running\` (clean) | 기존 diagnostic / monitoring hint fallback |
| \`paused\` / \`offline\` | \`null\` — phase badge + 전용 chip 이 표시, slot 은 *추가 context* 전용 |

## Caller 변경

\`AgentRoster\` 본문에 \`fleetCompositeSnapshot.value\` → \`compositeByKeeperKey\` Map 신설. \`name\` / \`keeper_id\` / \`correlation_id\` 셋 다 키로 등록. preact/signals 자동 subscription 이 SSE 갱신에 자동 반응 (별도 useEffect 없음).

\`\`\`tsx
const fleetSnapshot = fleetCompositeSnapshot.value
const compositeByKeeperKey = useMemo(() => {
  const map = new Map<string, KeeperCompositeSnapshot>()
  if (!fleetSnapshot) return map
  for (const snap of fleetSnapshot.snapshots) {
    for (const candidate of [snap.keeper, snap.correlation_id]) {
      if (typeof candidate === 'string' && candidate !== '' && !map.has(candidate)) {
        map.set(candidate, snap)
      }
    }
  }
  return map
}, [fleetSnapshot])
\`\`\`

## Tests (8 신규 fixture)

\`agent-roster.test.ts\` 에 \`rosterStateNote — RFC-0135 §1.1 typed-state conditioning\` describe:

| 시나리오 | 기대 |
|---|---|
| **RFC §1.1 EXACT** | \`blocker=synthetic_stall + execution_current=true\` → \`이전 차단\` (헤드라인 demoted) |
| genuine stuck | \`blocker=cascade_exhausted + execution_current=false\` → \`현재 차단\` |
| class without summary | typed reason fallback message |
| no composite + blocker | \`현재 차단\` (composite 없으면 conditioning 불가 → stuck 분기) |
| diagnostic fallback | 차단 없을 때 diagnostic.last_error 노출 |
| monitoring hint fallback | 차단/diagnostic 없을 때 monitoring hint |
| paused → null | slot 보존 invariant |
| offline → null | slot 보존 invariant |

## Workaround Rejection Bar

- [x] telemetry-as-fix 아님 — 시그니처 *구조적 결함* fix
- [x] string classifier 추가 아님 — typed SSOT 호출
- [x] N-of-M 아님 — \`rosterStateNote\` 전체 시그니처 변경 + 모든 caller 동시 업데이트 (caller 1개)
- [x] catch-all 추가 아님 — \`switch\` 없이 명시적 \`if\` 분기, 각 state.kind 별로 따로
- [x] cap/cooldown 아님

\`feedback_dual_path_normalize_vs_raw_wire_format\` 패턴 close.

## Verification

- \`pnpm typecheck\` PASS
- \`agent-roster.test.ts\` 15/15 PASS (8 신규 + 7 기존)
- \`pnpm lint\` 0 errors (1 unrelated pre-existing warning)
- \`+246 / -19\` LoC

## Stack 위치

| RFC-0135 PR | 상태 |
|---|---|
| #16573 RFC body | Draft |
| **#16576 PR-1 typed sum module** | **MERGED ✓** |
| **#16593 PR-2 phase casing SSOT** | **MERGED ✓** |
| **#TBD PR-4 roster typed conditioning (본 PR)** | **Draft** |
| PR-3 keeper-predicates.ts | not started |
| PR-5 deriveKeeperLiveTruth typed state | not started |
| PR-6 keeper-action-panel 중복 span 제거 | not started |
| PR-7 stateLabel/actionLabel 분리 | not started |
| PR-8 backend effective_blocker | not started |
| PR-9 CI guard | not started |

## RFC Check

\`bash ~/me/scripts/pr-rfc-check.sh\` — RFC-0135 PR #16573 reference. dashboard 영역, credential/identity/operator-control/sandbox 무관.

## Status

**Draft** — agent PR. Ready 전환은 사용자 라벨 부착 (\`human-approved-ready\`).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>