### PR TITLE
refactor(dashboard): RFC-0135 PR-4 — rosterStateNote composite-aware

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -49,6 +49,11 @@ import {
 import {
   keeperActivityDisplay,
 } from '../lib/keeper-runtime-display'
+import { fleetCompositeSnapshot } from '../composite-signals'
+import type { KeeperCompositeSnapshot } from '../api/schemas/keeper-composite'
+import {
+  deriveKeeperOperationalState,
+} from '../lib/keeper-operational-state'
 
 type StatusFilter = 'all' | RuntimeBand
 
@@ -84,35 +89,66 @@ function rosterContextMeta(
   return { pct, detail }
 }
 
+/**
+ * RFC-0135 PR-4 — roster-row state note now derives from the typed
+ * operational state instead of reading flat `runtime_blocker_*` fields
+ * directly. With composite snapshots in hand, a fresh execution
+ * receipt suppresses a stale blocker (the §1.1 lifecycle-worker case
+ * where the roster screamed "현재 차단 · synthetic_stall" while the
+ * detail view said "턴 진행 중 · executing live").
+ */
 function rosterStateNote(
-  keeper: {
-    runtime_blocker_summary?: string | null
-    runtime_blocker_class?: string | null
-    diagnostic?: { last_error?: string | null } | null
-  } | null | undefined,
+  keeper: Keeper | null | undefined,
+  composite: KeeperCompositeSnapshot | null,
   monitoringHint?: string | null,
 ): { label: string; text: string; kind?: string } | null {
-  const runtimeBlocker = keeper?.runtime_blocker_summary?.trim()
-  const blockerClass = keeper?.runtime_blocker_class?.trim() || undefined
-  if (runtimeBlocker) {
-    return { label: '현재 차단', text: runtimeBlocker, kind: blockerClass }
-  }
-  // Class without summary: surface the typed kind so operators still see *why*
-  // (e.g. "heartbeat_failures") instead of an unlabelled '현재 차단' badge.
-  if (blockerClass) {
-    return {
-      label: '현재 차단',
-      text: `차단 종류: ${blockerClass} (요약 메시지 없음)`,
-      kind: blockerClass,
+  if (!keeper) return null
+
+  const state = deriveKeeperOperationalState({ keeper, composite })
+
+  switch (state.kind) {
+    case 'stuck': {
+      const summary = keeper.runtime_blocker_summary?.trim()
+      if (summary) {
+        return { label: '현재 차단', text: summary, kind: state.reason }
+      }
+      return {
+        label: '현재 차단',
+        text: `차단 종류: ${state.reason} (요약 메시지 없음)`,
+        kind: state.reason,
+      }
+    }
+    case 'running': {
+      // Fresh execution receipt — even if `runtime_blocker_class` is
+      // still set on the flat record, it's stale and must not surface
+      // as a "blocked" note. Fall through to non-blocker notes.
+      break
+    }
+    case 'paused':
+    case 'offline': {
+      // Paused/offline state is already conveyed by the phase badge
+      // elsewhere on the card. No extra "state note" needed.
+      break
     }
   }
 
-  const diagnosticError = keeper?.diagnostic?.last_error?.trim()
+  const diagnosticError = keeper.diagnostic?.last_error?.trim()
   if (diagnosticError) return { label: '최근 오류', text: diagnosticError }
 
   const hint = monitoringHint?.trim()
   if (hint) return { label: '상태 메모', text: hint }
   return null
+}
+
+function compositeForKeeper(
+  keeperName: string | null | undefined,
+): KeeperCompositeSnapshot | null {
+  if (!keeperName) return null
+  const fleet = fleetCompositeSnapshot.value
+  if (!fleet) return null
+  return (
+    fleet.snapshots.find(snap => snap.keeper === keeperName) ?? null
+  )
 }
 
 function registerKeeperLookup<T extends Pick<Keeper, 'keeper_id' | 'name' | 'agent_name'>>(
@@ -661,7 +697,11 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
           const summaryText = workPreview
           const stateNote =
             keeperRuntime
-              ? rosterStateNote(keeperRuntime, band.key === 'active' ? null : keeperMonitoring?.hint ?? null)
+              ? rosterStateNote(
+                  keeperRuntime,
+                  compositeForKeeper(keeperRuntime.name ?? null),
+                  band.key === 'active' ? null : keeperMonitoring?.hint ?? null,
+                )
               : null
           const recentTools = uniqueToolNames(
             keeperRuntime?.recent_tool_names,


### PR DESCRIPTION
## Why (RFC-0135 §1.1)

`lifecycle-worker` keeper 한 명이 동시에:

- **목록 카드** (`agent-roster.ts:rosterStateNote`) → `현재 차단 · synthetic_stall`
- **상세 LIVE TRUTH** (`keeper-detail-runtime.ts:deriveKeeperLiveTruth`) → `턴 진행 중 · fiber alive · executing live`

같은 keeper, 같은 wire payload, 반대 결론. 목록은 `keeper.runtime_blocker_class` flat read 만, 상세는 `composite.runtime_attention.execution_current` 로 conditioning 후 stale blocker 무시.

## What

`rosterStateNote` 시그니처를 `(keeper, composite, hint)` 로 확장하고 typed-sum SSOT (`deriveKeeperOperationalState`, RFC-0135 PR-1) 호출로 변경. fresh execution receipt 가 있으면 stale `runtime_blocker_*` flat read 는 verdict 결정에 영향 없음.

- `rosterStateNote`: `deriveKeeperOperationalState({ keeper, composite })` switch on kind
  - `'stuck'` → 기존 `'현재 차단'` 노트 (summary text + typed `kind` 유지)
  - `'running'` → fresh receipt 이므로 stale blocker note 표시 안 함, diagnostic/hint fall-through
  - `'paused' | 'offline'` → phase badge 가 이미 표시, double-render 안 함
- 새 `compositeForKeeper(name)` 헬퍼: `fleetCompositeSnapshot.value.snapshots` 에서 registry name 으로 lookup
- 호출 사이트 (fleet card map): composite 인자 추가

## Behavioural delta

| 케이스 | Before | After |
|---|---|---|
| Fresh receipt + stale blocker class | `'현재 차단' / synthetic_stall` | (no note, fresh execution conveyed by 'running' kind) |
| 진짜 stuck (execution stale + blocker set) | `'현재 차단' / 차단 종류: synthetic_stall` | 동일 (state.kind === 'stuck' 분기) |
| Paused / offline | `'현재 차단'` 라벨 누락 가능 | phase badge 가 표시, blocker note 없음 (clean) |
| No composite (older backend / race) | flat-read fallback | `deriveKeeperOperationalState` 자체 fallback 처리 (PR-1 §) |

## RFC-0135 §5 PR-4 acceptance

- [x] `rosterStateNote` signature `(keeper, composite, monitoringHint)`
- [x] `deriveKeeperOperationalState` dispatch
- [x] `runtime_blocker_summary` 은 `'stuck'` arm 안에서만 read (verdict 결정엔 미사용)
- [x] §1.1 reproducer fresh-receipt + stale blocker → `'running'` → no `'현재 차단'` note

## Tests

- `pnpm typecheck` clean
- `pnpm vitest run src/components/agent-roster.test.ts src/lib/keeper-operational-state.test.ts` — **32/32 pass**
- `pnpm vitest run src/components/keeper-detail src/components/fsm-hub src/lib/keeper-` — 453/454 pass (1 pre-existing main fail, RuntimeLensSection `inj 1/1 · flush 1/0 · ep/proc 2/1`, 본 PR 영역 밖)

## 의존

PR-1 (typed-sum SSOT) — 머지됨 (`keeper-operational-state.ts` main 에 존재). 후속 RFC-0135 PR-3/5/6/7 와 직교 (병행 가능).

## Test plan

- [ ] dashboard preview 에서 keeper 의 fresh-receipt 상태일 때 roster card 의 `'현재 차단'` note 표시되지 않는지 확인
- [ ] 같은 keeper 의 detail view 의 LIVE TRUTH 가 `'turn 진행 중'` 표시하는지 확인 (양쪽 verdict 일치)
- [ ] 진짜 stuck keeper 의 roster card 가 여전히 `'현재 차단'` 표시하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)