### PR TITLE
refactor(keeper): RFC-0136 PR-1 extract Keeper_unified_turn_phase_gate

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -237,6 +237,7 @@
   keeper_unified_turn_success
   keeper_unified_turn_failure
   keeper_unified_turn_phase_plan
+  keeper_unified_turn_phase_gate
   keeper_unified_turn_livelock_block
   keeper_exec_context
   keeper_guards

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -126,133 +126,17 @@ let run_keeper_cycle
      Satisfies the FSM contract: active state observed → SupervisorRequestsStop
      (Phase_gating → Phase_gating, stop signal acknowledged) then HonorStopSignal
      (Phase_gating → Cancelled supervisor_stop). *)
-  let supervisor_stop_at_entry =
-    match Keeper_registry.get ~base_path:registry_base_path meta.name with
-    | Some entry -> Atomic.get entry.fiber_stop
-    | None -> false
-  in
-  if supervisor_stop_at_entry
-  then (
-    let turn_plan =
-      decide_turn_plan_at_phase_gate ~keeper_turn_id
-        ~supervisor_stop_at_entry:true None
-    in
-    append_phase_gate_decision turn_plan;
-    Log.Keeper.info
-      ~keeper_name:meta.name
-      ~turn_id:keeper_turn_id
-      "%s: supervisor stop signal observed at turn entry — honoring (phase_gating)"
-      meta.name;
-    (* FSM: SupervisorRequestsStop — stop signal raised while in active state *)
-    Keeper_turn_fsm.emit_transition
-      ~keeper_name:meta.name
-      ~turn_id:keeper_turn_id
-      ~prev:Keeper_turn_fsm.Phase_gating
-      Keeper_turn_fsm.Phase_gating;
-    record_pre_dispatch_terminal_observation
-      ~config
-      ~meta
-      ~generation
-      ~cascade_name:
-        (Keeper_execution_receipt.cascade_name_of_string (cascade_name_of_meta meta))
-      ~outcome:`Cancelled
-      ~terminal_reason_code:"supervisor_stop"
-      ~activity_kind:"keeper.turn_cancelled"
-      ~trajectory_outcome:(Trajectory.Gated "supervisor_stop")
-      ~keeper_turn_id
-      ();
-    (* FSM: HonorStopSignal — cooperative cancel at phase_gating *)
-    Keeper_turn_fsm.emit_transition
-      ~keeper_name:meta.name
-      ~turn_id:keeper_turn_id
-      ~prev:Keeper_turn_fsm.Phase_gating
-      (Keeper_turn_fsm.Cancelled Keeper_turn_fsm.Cancelled_supervisor_stop);
-    Ok meta)
-  else (
-    match Keeper_registry.get_phase ~base_path:registry_base_path meta.name with
-    | Some phase when not (Keeper_state_machine.can_execute_turn phase) ->
-      let turn_plan =
-        decide_turn_plan_at_phase_gate ~keeper_turn_id
-          ~supervisor_stop_at_entry:false (Some phase)
-      in
-      let phase_string = Keeper_state_machine.phase_to_string phase in
-      append_phase_gate_decision turn_plan;
-      Log.Keeper.info
-        ~keeper_name:meta.name
-        ~turn_id:keeper_turn_id
-        "%s: keeper cycle skipped in non-executable phase=%s"
-        meta.name
-        phase_string;
-      let terminal_reason_code = Printf.sprintf "non_executable_phase:%s" phase_string in
-      record_pre_dispatch_terminal_observation
-        ~config
-        ~meta
-        ~generation
-        ~cascade_name:
-          (Keeper_execution_receipt.cascade_name_of_string (cascade_name_of_meta meta))
-        ~outcome:`Skipped
-        ~terminal_reason_code
-        ~activity_kind:"keeper.turn_skipped"
-        ~trajectory_outcome:(Trajectory.Gated terminal_reason_code)
-        ~keeper_turn_id
-        ();
-      Keeper_turn_fsm.emit_transition
-        ~keeper_name:meta.name
-        ~turn_id:keeper_turn_id
-        ~prev:Keeper_turn_fsm.Phase_gating
-        Keeper_turn_fsm.Done;
-      Ok meta
-    | None ->
-      let turn_plan =
-        decide_turn_plan_at_phase_gate ~keeper_turn_id
-          ~supervisor_stop_at_entry:false None
-      in
-      let terminal_reason_code = "registry_phase_missing" in
-      let error_message =
-        Printf.sprintf
-          "%s: keeper registry phase lookup returned None before dispatch"
-          meta.name
-      in
-      append_phase_gate_decision turn_plan;
-      Log.Keeper.error
-        ~keeper_name:meta.name
-        ~turn_id:keeper_turn_id
-        "%s"
-        error_message;
-      record_pre_dispatch_terminal_observation
-        ~config
-        ~meta
-        ~generation
-        ~cascade_name:
-          (Keeper_execution_receipt.cascade_name_of_string (cascade_name_of_meta meta))
-        ~outcome:`Error
-        ~terminal_reason_code
-        ~activity_kind:"keeper.turn_blocked"
-        ~trajectory_outcome:(Trajectory.Failed terminal_reason_code)
-        ~error_kind:(Keeper_execution_receipt.error_kind_of_string terminal_reason_code)
-        ~error_message
-        ~keeper_turn_id
-        ();
-      Keeper_turn_fsm.emit_transition
-        ~keeper_name:meta.name
-        ~turn_id:keeper_turn_id
-        ~prev:Keeper_turn_fsm.Phase_gating
-        (Keeper_turn_fsm.Failed
-           (Keeper_turn_fsm.Failure_runtime_error terminal_reason_code));
-      Error (Agent_sdk.Error.Internal error_message)
-    | phase_opt ->
-      (* State-aware cascade routing (TLA+ KeeperCoreTriad.SelectCascade).
-         At this point [phase] is executable; blocked phases returned above. *)
-      let turn_plan =
-        decide_turn_plan_at_phase_gate ~keeper_turn_id
-          ~supervisor_stop_at_entry:false phase_opt
-      in
-      append_phase_gate_decision turn_plan;
-      Keeper_turn_fsm.emit_transition
-        ~keeper_name:meta.name
-        ~turn_id:keeper_turn_id
-        ~prev:Keeper_turn_fsm.Phase_gating
-        Keeper_turn_fsm.Cascade_routing;
+  (* RFC-0136 PR-1: phase gate stage extracted to
+     [Keeper_unified_turn_phase_gate].  The main turn body is wrapped
+     as a nested [main_path] function so the caller can match on a
+     typed [phase_gate_outcome] and dispatch each terminal outcome at
+     the top of the function body, rather than burying early-exits in
+     deeply nested match arms.
+
+     State-aware cascade routing (TLA+ KeeperCoreTriad.SelectCascade)
+     resumes inside [main_path]; at that point [phase_opt] is whatever
+     the registry returned for an executable phase. *)
+  let main_path phase_opt =
       (* RFC-0041 Phase B4: when a specific item was selected by the
          proactive router, override (cascade_name_of_meta meta) so downstream
          cascade resolution uses the item's group. *)
@@ -1937,7 +1821,21 @@ let run_keeper_cycle
                   (* Cycle 45: KeeperTaskAcquisition.tla TurnComplete post-action. *)
                   cycle_completed := true;
                   post_turn_complete_task ~cycle_completed;
-                  Ok updated_meta)))))
+                  Ok updated_meta))))
+  in
+  match
+    Keeper_unified_turn_phase_gate.decide_and_record
+      ~config
+      ~meta
+      ~generation
+      ~keeper_turn_id
+      ~append_phase_gate_decision
+      ~registry_base_path
+  with
+  | Keeper_unified_turn_phase_gate.Phase_gate_terminal_ok meta -> Ok meta
+  | Keeper_unified_turn_phase_gate.Phase_gate_terminal_error err -> Error err
+  | Keeper_unified_turn_phase_gate.Phase_gate_proceed phase_opt ->
+    main_path phase_opt
 ;;
 
 let run_unified_turn = run_keeper_cycle

--- a/lib/keeper/keeper_unified_turn_phase_gate.ml
+++ b/lib/keeper/keeper_unified_turn_phase_gate.ml
@@ -1,0 +1,162 @@
+(* Keeper_unified_turn_phase_gate — RFC-0136 PR-1.
+
+   Extracted from keeper_unified_turn.ml (L129-L255) during the
+   run_keeper_cycle stage decomposition. The gate owns the three
+   pre-dispatch early-exit paths plus the FSM transition into
+   Cascade_routing on the proceed path. *)
+
+open Keeper_types
+open Keeper_exec_context
+
+type phase_gate_outcome =
+  | Phase_gate_proceed of Keeper_state_machine.phase option
+  | Phase_gate_terminal_ok of keeper_meta
+  | Phase_gate_terminal_error of Agent_sdk.Error.sdk_error
+
+let decide_and_record
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+      ~(generation : int)
+      ~(keeper_turn_id : int)
+      ~(append_phase_gate_decision :
+         Keeper_unified_turn_phase_plan.turn_plan -> unit)
+      ~(registry_base_path : string)
+  =
+  let supervisor_stop_at_entry =
+    match Keeper_registry.get ~base_path:registry_base_path meta.name with
+    | Some entry -> Atomic.get entry.fiber_stop
+    | None -> false
+  in
+  if supervisor_stop_at_entry
+  then (
+    let turn_plan =
+      Keeper_unified_turn_phase_plan.decide_turn_plan_at_phase_gate
+        ~keeper_turn_id
+        ~supervisor_stop_at_entry:true None
+    in
+    append_phase_gate_decision turn_plan;
+    Log.Keeper.info
+      ~keeper_name:meta.name
+      ~turn_id:keeper_turn_id
+      "%s: supervisor stop signal observed at turn entry — honoring (phase_gating)"
+      meta.name;
+    (* FSM: SupervisorRequestsStop — stop signal raised while in active state *)
+    Keeper_turn_fsm.emit_transition
+      ~keeper_name:meta.name
+      ~turn_id:keeper_turn_id
+      ~prev:Keeper_turn_fsm.Phase_gating
+      Keeper_turn_fsm.Phase_gating;
+    Keeper_turn_helpers.record_pre_dispatch_terminal_observation
+      ~config
+      ~meta
+      ~generation
+      ~cascade_name:
+        (Keeper_execution_receipt.cascade_name_of_string
+           (cascade_name_of_meta meta))
+      ~outcome:`Cancelled
+      ~terminal_reason_code:"supervisor_stop"
+      ~activity_kind:"keeper.turn_cancelled"
+      ~trajectory_outcome:(Trajectory.Gated "supervisor_stop")
+      ~keeper_turn_id
+      ();
+    (* FSM: HonorStopSignal — cooperative cancel at phase_gating *)
+    Keeper_turn_fsm.emit_transition
+      ~keeper_name:meta.name
+      ~turn_id:keeper_turn_id
+      ~prev:Keeper_turn_fsm.Phase_gating
+      (Keeper_turn_fsm.Cancelled Keeper_turn_fsm.Cancelled_supervisor_stop);
+    Phase_gate_terminal_ok meta)
+  else (
+    match
+      Keeper_registry.get_phase ~base_path:registry_base_path meta.name
+    with
+    | Some phase when not (Keeper_state_machine.can_execute_turn phase) ->
+      let turn_plan =
+        Keeper_unified_turn_phase_plan.decide_turn_plan_at_phase_gate
+          ~keeper_turn_id
+          ~supervisor_stop_at_entry:false (Some phase)
+      in
+      let phase_string = Keeper_state_machine.phase_to_string phase in
+      append_phase_gate_decision turn_plan;
+      Log.Keeper.info
+        ~keeper_name:meta.name
+        ~turn_id:keeper_turn_id
+        "%s: keeper cycle skipped in non-executable phase=%s"
+        meta.name
+        phase_string;
+      let terminal_reason_code =
+        Printf.sprintf "non_executable_phase:%s" phase_string
+      in
+      Keeper_turn_helpers.record_pre_dispatch_terminal_observation
+        ~config
+        ~meta
+        ~generation
+        ~cascade_name:
+          (Keeper_execution_receipt.cascade_name_of_string
+             (cascade_name_of_meta meta))
+        ~outcome:`Skipped
+        ~terminal_reason_code
+        ~activity_kind:"keeper.turn_skipped"
+        ~trajectory_outcome:(Trajectory.Gated terminal_reason_code)
+        ~keeper_turn_id
+        ();
+      Keeper_turn_fsm.emit_transition
+        ~keeper_name:meta.name
+        ~turn_id:keeper_turn_id
+        ~prev:Keeper_turn_fsm.Phase_gating
+        Keeper_turn_fsm.Done;
+      Phase_gate_terminal_ok meta
+    | None ->
+      let turn_plan =
+        Keeper_unified_turn_phase_plan.decide_turn_plan_at_phase_gate
+          ~keeper_turn_id
+          ~supervisor_stop_at_entry:false None
+      in
+      let terminal_reason_code = "registry_phase_missing" in
+      let error_message =
+        Printf.sprintf
+          "%s: keeper registry phase lookup returned None before dispatch"
+          meta.name
+      in
+      append_phase_gate_decision turn_plan;
+      Log.Keeper.error
+        ~keeper_name:meta.name
+        ~turn_id:keeper_turn_id
+        "%s"
+        error_message;
+      Keeper_turn_helpers.record_pre_dispatch_terminal_observation
+        ~config
+        ~meta
+        ~generation
+        ~cascade_name:
+          (Keeper_execution_receipt.cascade_name_of_string
+             (cascade_name_of_meta meta))
+        ~outcome:`Error
+        ~terminal_reason_code
+        ~activity_kind:"keeper.turn_blocked"
+        ~trajectory_outcome:(Trajectory.Failed terminal_reason_code)
+        ~error_kind:
+          (Keeper_execution_receipt.error_kind_of_string terminal_reason_code)
+        ~error_message
+        ~keeper_turn_id
+        ();
+      Keeper_turn_fsm.emit_transition
+        ~keeper_name:meta.name
+        ~turn_id:keeper_turn_id
+        ~prev:Keeper_turn_fsm.Phase_gating
+        (Keeper_turn_fsm.Failed
+           (Keeper_turn_fsm.Failure_runtime_error terminal_reason_code));
+      Phase_gate_terminal_error (Agent_sdk.Error.Internal error_message)
+    | phase_opt ->
+      let turn_plan =
+        Keeper_unified_turn_phase_plan.decide_turn_plan_at_phase_gate
+          ~keeper_turn_id
+          ~supervisor_stop_at_entry:false phase_opt
+      in
+      append_phase_gate_decision turn_plan;
+      Keeper_turn_fsm.emit_transition
+        ~keeper_name:meta.name
+        ~turn_id:keeper_turn_id
+        ~prev:Keeper_turn_fsm.Phase_gating
+        Keeper_turn_fsm.Cascade_routing;
+      Phase_gate_proceed phase_opt)

--- a/lib/keeper/keeper_unified_turn_phase_gate.mli
+++ b/lib/keeper/keeper_unified_turn_phase_gate.mli
@@ -1,0 +1,54 @@
+(** Phase-gate stage extracted from [Keeper_unified_turn.run_keeper_cycle]
+    per RFC-0136 PR-1.
+
+    Decides whether a keeper turn proceeds to cascade routing or exits at
+    one of three terminal outcomes (supervisor stop, non-executable
+    registry phase, or registry phase missing). The gate owns all FSM
+    transitions, observability records, and manifest decisions tied to
+    the phase-gate boundary. *)
+
+type phase_gate_outcome =
+  | Phase_gate_proceed of Keeper_state_machine.phase option
+    (** Registry phase is executable (or unknown but recoverable); the
+        caller may proceed to cascade routing. The carried [phase_opt]
+        is the same value the gate observed in the registry, so the
+        caller's cascade routing dispatches on the gate's view. *)
+  | Phase_gate_terminal_ok of Keeper_types.keeper_meta
+    (** Cooperative early-exit: supervisor stop, or non-executable
+        phase. [run_keeper_cycle] returns [Ok meta] with [meta]
+        unchanged. *)
+  | Phase_gate_terminal_error of Agent_sdk.Error.sdk_error
+    (** Hard early-exit: registry phase missing. [run_keeper_cycle]
+        returns [Error err]. *)
+
+val decide_and_record
+  :  config:Coord.config
+  -> meta:Keeper_types.keeper_meta
+  -> generation:int
+  -> keeper_turn_id:int
+  -> append_phase_gate_decision:
+       (Keeper_unified_turn_phase_plan.turn_plan -> unit)
+  -> registry_base_path:string
+  -> phase_gate_outcome
+(** Run the phase gate logic, including all FSM transitions,
+    observability records, and runtime-manifest decisions.
+
+    On [Phase_gate_proceed], the gate has already transitioned the
+    keeper FSM from [Phase_gating] to [Cascade_routing] and appended
+    its decision via [append_phase_gate_decision]. The caller resumes
+    with main-path cascade resolution.
+
+    On either terminal outcome, the gate has recorded a
+    pre-dispatch terminal observation, emitted the appropriate FSM
+    transition, and the keeper turn is complete from the gate's
+    perspective.
+
+    @param config Coord configuration passed through to observability.
+    @param meta Current keeper metadata. Returned unchanged on
+      [Phase_gate_terminal_ok] outcomes.
+    @param generation Current generation counter.
+    @param keeper_turn_id Turn identifier assigned at function entry.
+    @param append_phase_gate_decision Callback closing over the
+      caller's [runtime_manifest_context]; called once per outcome.
+    @param registry_base_path Pre-resolved [config.base_path] reused
+      from the caller's setup. *)


### PR DESCRIPTION
## Summary

RFC-0136 PR-1: extract the phase-gate stage from `run_keeper_cycle` into a new sub-module `Keeper_unified_turn_phase_gate` with a typed `phase_gate_outcome` sum.

- `lib/keeper/keeper_unified_turn.ml`: 1943 → 1841 (**-102 LOC**)
- `lib/keeper/keeper_unified_turn_phase_gate.{ml,mli}`: +216 LOC
- `lib/dune` private modules list: +1 entry

## Why

`keeper_unified_turn.ml` is the 5th largest godfile (1943 LOC) and is explicitly named in `fundamental_roadmap.md` Phase 5. RFC-0136 (`docs/rfc/RFC-0136-keeper-unified-turn-decomposition.md`, see PR #16601) lays out the stage decomposition strategy. This PR is the first concrete extraction.

The phase-gate stage (L129-255 in `keeper_unified_turn.ml@origin/main`) bundled three implicit early-exit paths (supervisor stop, non-executable phase, registry phase missing) plus the FSM transition into `Cascade_routing` on the proceed path. Caller dispatched on these via deeply nested `if/match` arms, hiding the outcome shape from the type system — a textbook *parse-don't-validate* violation.

## Design

```ocaml
(* lib/keeper/keeper_unified_turn_phase_gate.mli *)

type phase_gate_outcome =
  | Phase_gate_proceed of Keeper_state_machine.phase option
  | Phase_gate_terminal_ok of Keeper_types.keeper_meta
  | Phase_gate_terminal_error of Agent_sdk.Error.sdk_error

val decide_and_record
  :  config:Coord.config
  -> meta:Keeper_types.keeper_meta
  -> generation:int
  -> keeper_turn_id:int
  -> append_phase_gate_decision:
       (Keeper_unified_turn_phase_plan.turn_plan -> unit)
  -> registry_base_path:string
  -> phase_gate_outcome
```

Caller now matches on the typed outcome at the top of `run_keeper_cycle`'s body:

```ocaml
match
  Keeper_unified_turn_phase_gate.decide_and_record
    ~config ~meta ~generation
    ~keeper_turn_id
    ~append_phase_gate_decision
    ~registry_base_path
with
| Keeper_unified_turn_phase_gate.Phase_gate_terminal_ok meta -> Ok meta
| Keeper_unified_turn_phase_gate.Phase_gate_terminal_error err -> Error err
| Keeper_unified_turn_phase_gate.Phase_gate_proceed phase_opt ->
  main_path phase_opt
```

The remaining 1657 LOC main body is wrapped as a nested `let main_path phase_opt = ... in` function — this keeps indentation stable for the unchanged body (zero whitespace diff inside `main_path`) while letting the caller dispatch from the function-body top.

## Behavior preservation

Phase gate logic moved verbatim:

- `Keeper_registry.get` + `Atomic.get ... .fiber_stop` supervisor_stop check.
- `Keeper_registry.get_phase` registry lookup.
- All three `Log.Keeper.{info,error}` messages identical.
- All four `Keeper_turn_fsm.emit_transition` calls in the same order.
- `record_pre_dispatch_terminal_observation` arguments unchanged.
- `decide_turn_plan_at_phase_gate` + `append_phase_gate_decision` call sequence identical.
- Outcome wire: `Ok meta` (supervisor_stop, non-executable) / `Error (Internal msg)` (registry missing) / `Phase_gate_proceed phase_opt` (executable) → caller produces same final `Ok meta` / `Error err`.

Closure dependencies (7) lifted to explicit named args; no escape of outer-scope mutable state (the `cycle_completed` ref stays in the caller — phase gate never touches it).

## Anti-pattern self-check (CLAUDE.md §워크어라운드 거부)

| # | Pattern | 상태 |
|---|---------|------|
| 1 | Telemetry-as-fix | N/A — pure restructure |
| 2 | String classifier | N/A — typed sum introduced (opposite direction) |
| 3 | N-of-M migration | Bounded — 1 of 4 stages closed by this PR |
| 4 | Catch-all `_ ->` added | N/A — `phase_gate_outcome` 3 variants exhaustive |
| 5 | Cap/cooldown/dedup/repair | N/A |
| 6 | Test backdoor | N/A |
| 7 | N-site mechanical fix | N/A — 1 file, 1 call site |

## Validation

- [x] `dune build --root . @check` clean.
- [x] `scripts/lint/godfile-size-regression.sh` clean (cap 3350).
- [x] `scripts/lint/no-ocaml-comment-terminator-trap.sh` clean.
- [x] `scripts/lint/no-yojson-3-dead-arms.sh` clean.
- [x] `scripts/lint/no-inline-json-kind-name.sh` clean.
- [ ] `dune build --root . @runtest` — *deferred to CI* (existing keeper turn integration tests cover the gate via `run_unified_turn` transitive path).

## RFC citation

`RFC-0136 PR-1`: see `docs/rfc/RFC-0136-keeper-unified-turn-decomposition.md` (PR #16601 — RFC body in flight).

## Related

- RFC-0136 PR-2 (deferred) — Cascade resolution stage.
- RFC-0051 — `keeper_turn_driver.run_named` closure decomp (parallel work, draft only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)