### PR TITLE
fix(dashboard): RFC-0135 PR-5 invert execution_current axis + detail panel typed-state

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -93,22 +93,32 @@ describe('rosterStateNote — RFC-0135 §1.1 typed-state conditioning', () => {
     })
   })
 
-  it('RFC §1.1 EXACT — blocker_class=synthetic_stall + execution_current=true must NOT surface as 현재 차단', () => {
-    // The exact 2026-05-19 lifecycle-worker scenario the user reported:
-    // list card said "현재 차단 · synthetic_stall" while the detail panel
-    // showed "턴 진행 중 · executing live". The fix routes the roster
-    // through the same typed conditioning the detail panel uses, so the
-    // blocker_class is recognized as stale and demoted to "이전 차단".
+  it('RFC §1.1 EXACT — blocker set BUT receipt is stale (execution_current=false) → 이전 차단', () => {
+    // The exact 2026-05-19 lifecycle-worker scenario. Backend emits
+    // execution_current=false (`server_dashboard_http.ml:1061-1074`)
+    // when the latest receipt is from a prior turn while a newer live
+    // turn is in progress (`receipt_at < live_started_at`). The blocker
+    // class belongs to the prior turn — demoted to "이전 차단" so the
+    // headline matches what the detail panel shows ("턴 진행 중 ·
+    // executing live").
+    //
+    // PR-4 originally encoded this scenario with `execution_current=true`,
+    // which inverted the semantics; PR-5 fixes the typed SSOT axis and
+    // realigns this fixture with backend reality.
     const note = rosterStateNote(
       k({
         phase: 'Running',
         runtime_blocker_class: 'synthetic_stall',
         runtime_blocker_summary: '잔여 marker',
       }),
-      compositeWith(attention({ execution_current: true, blocked: false }), {
-        turn_phase: 'executing',
-        is_live: true,
-      }),
+      compositeWith(
+        attention({
+          execution_current: false,
+          stale_execution_receipt: true,
+          blocked: false,
+        }),
+        { turn_phase: 'executing', is_live: true },
+      ),
       null,
     )
     expect(note).toEqual({
@@ -118,14 +128,14 @@ describe('rosterStateNote — RFC-0135 §1.1 typed-state conditioning', () => {
     })
   })
 
-  it('genuine stuck — blocker_class set + execution_current=false → 현재 차단', () => {
+  it('genuine stuck — blocker set AND receipt is current (execution_current=true) → 현재 차단', () => {
     const note = rosterStateNote(
       k({
         phase: 'Running',
         runtime_blocker_class: 'cascade_exhausted',
         runtime_blocker_summary: 'cascade list 소진',
       }),
-      compositeWith(attention({ execution_current: false, blocked: true })),
+      compositeWith(attention({ execution_current: true, blocked: true })),
       null,
     )
     expect(note).toEqual({

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -4,6 +4,14 @@
 
 import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
+// RFC-0135 PR-5: detail panel and roster card derive blocker conditioning
+// through the same typed `KeeperOperationalState` SSOT (PR-1 #16576), so
+// `현재 차단 / 이전 차단` decisions cannot diverge between the two
+// surfaces. The `runtime_attention.blocked / needs_attention` signals
+// represent *live-execution* attention (`execution_current && blocked`,
+// see `lib/server/server_dashboard_http.ml:1114`), which is orthogonal to
+// the blocker-class-vs-stale-execution axis and stays inline below.
+import { deriveKeeperOperationalState } from '../lib/keeper-operational-state'
 import { formatPct1 } from '../lib/format-number'
 import { formatDuration } from '../lib/format-time'
 import { ActionButton } from './common/button'
@@ -190,13 +198,22 @@ export function deriveKeeperLiveTruth({
     ?? keeper.presence_keepalive
     ?? (linkedState !== 'offline')
   const activeTurn = compositeSnapshot?.is_live === true || !isIdleTurnPhase(compositeSnapshot?.turn_phase)
-  const previousExecutionReceipt =
-    compositeSnapshot?.runtime_attention?.stale_execution_receipt === true
-    || compositeSnapshot?.runtime_attention?.execution_current === false
-  const blocked =
+
+  // RFC-0135 PR-5: route the blocker-class axis through the typed SSOT,
+  // matching the roster card (`agent-roster.ts:rosterStateNote`). The
+  // attention-level axis (live-execution blocked / needs_attention) is
+  // separate — backend sets it as `execution_current && blocked`, which
+  // typed state does not cover, so it stays inline.
+  const opState = deriveKeeperOperationalState({
+    keeper,
+    composite: compositeSnapshot,
+  })
+  const stuckByBlockerClass = opState.kind === 'stuck'
+  const staleBlocker = opState.kind === 'running' ? opState.staleBlocker : null
+  const attentionBlocked =
     compositeSnapshot?.runtime_attention?.blocked === true
     || compositeSnapshot?.runtime_attention?.needs_attention === true
-    || (!previousExecutionReceipt && Boolean(keeper.runtime_blocker_class))
+  const blocked = stuckByBlockerClass || attentionBlocked
   const stopRequested =
     compositeSnapshot?.runtime_attention?.fiber_stop_requested === true
     || compositeSnapshot?.phase_diagnosis?.conditions.stop_requested === true
@@ -293,8 +310,21 @@ export function deriveKeeperLiveTruth({
       },
       {
         label: '차단',
-        value: blocked ? compactToken(compositeSnapshot?.runtime_attention?.state, 'blocked') : 'none',
-        detail: `${runtimeReason} · ${toolContract}`,
+        // RFC-0135 PR-5: typed reason takes precedence so the row text
+        // matches the roster card ("synthetic_stall" vs bare "blocked").
+        // When the receipt is from a prior turn (`staleBlocker` set),
+        // the row stays at 'none' (current execution is not blocked)
+        // and the prior-turn class is shown in the detail line below.
+        // This preserves the pre-RFC "차단 = none means clean now"
+        // operator mental model.
+        value: stuckByBlockerClass
+          ? opState.reason
+          : attentionBlocked
+            ? compactToken(compositeSnapshot?.runtime_attention?.state, 'blocked')
+            : 'none',
+        detail: staleBlocker !== null
+          ? `${runtimeReason} · ${toolContract} · 이전 차단: ${staleBlocker}`
+          : `${runtimeReason} · ${toolContract}`,
         tone: blocked ? 'warn' : 'ok',
       },
     ],

--- a/dashboard/src/lib/keeper-operational-state.test.ts
+++ b/dashboard/src/lib/keeper-operational-state.test.ts
@@ -151,16 +151,34 @@ describe('deriveKeeperOperationalState — stuck branch (RFC-0135 §1.1 root)', 
     })
   })
 
-  it('blocker AND execution_current=false ⇒ stuck (RFC §1.1)', () => {
+  it('blocker AND execution_current=true ⇒ stuck (receipt is current)', () => {
+    // execution_current=true means the receipt matches the *current* live
+    // turn (server_dashboard_http.ml:1061-1074) — the blocker is meaningful.
     const state = deriveKeeperOperationalState({
       keeper: makeKeeper({ runtime_blocker_class: 'cascade_exhausted' }),
       composite: makeComposite({
-        runtime_attention: attention({ execution_current: false, blocked: true }),
+        runtime_attention: attention({ execution_current: true, blocked: true }),
       }),
     })
     expect(state).toEqual<KeeperOperationalState>({
       kind: 'stuck',
       reason: 'cascade_exhausted',
+    })
+  })
+
+  it('blocker without explicit stale marker ⇒ stuck (fail-closed default)', () => {
+    // attention present but execution_current undefined → no explicit
+    // stale marker → blocker stays meaningful (fail-closed). Mirrors the
+    // older-backend case where runtime_attention may omit the field.
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({ runtime_blocker_class: 'oas_timeout_budget' }),
+      composite: makeComposite({
+        runtime_attention: attention({ execution_current: undefined }),
+      }),
+    })
+    expect(state).toEqual<KeeperOperationalState>({
+      kind: 'stuck',
+      reason: 'oas_timeout_budget',
     })
   })
 
@@ -203,10 +221,13 @@ describe('deriveKeeperOperationalState — running branch with conditioning', ()
     })
   })
 
-  it('RFC §1.1 EXACT scenario: blocker set BUT execution_current=true → running, blocker is stale', () => {
+  it('RFC §1.1 EXACT scenario: blocker set BUT execution_current=false → running, blocker is stale', () => {
     // This is the lifecycle-worker case the user reported on 2026-05-19:
     // list card showed "현재 차단 · synthetic_stall" while detail showed
-    // "턴 진행 중 · executing live". The SSOT verdict must be running.
+    // "턴 진행 중 · executing live". The detail panel's pre-RFC logic
+    // demoted the blocker when execution_current=false (receipt is from
+    // a prior turn). The typed SSOT mirrors that, producing
+    // `running { staleBlocker: synthetic_stall }`.
     const state = deriveKeeperOperationalState({
       keeper: makeKeeper({
         phase: 'Running',
@@ -219,7 +240,8 @@ describe('deriveKeeperOperationalState — running branch with conditioning', ()
         is_live: true,
         runtime_attention: attention({
           state: 'active',
-          execution_current: true,
+          execution_current: false,
+          stale_execution_receipt: true,
           blocked: false,
         }),
       }),
@@ -294,17 +316,39 @@ describe('deriveKeeperOperationalState — priority invariants', () => {
     expect(state.kind).toBe('offline')
   })
 
-  it('stuck beats running (when execution not fresh)', () => {
+  it('stuck beats running (when receipt is current — execution_current=true)', () => {
+    // Mirror of the pre-RFC detail-panel logic: the blocker drives the
+    // headline iff the receipt is from the current live turn.
     const state = deriveKeeperOperationalState({
       keeper: makeKeeper({
         phase: 'Running',
         runtime_blocker_class: 'turn_timeout',
       }),
       composite: makeComposite({
-        runtime_attention: attention({ execution_current: false }),
+        runtime_attention: attention({ execution_current: true }),
       }),
     })
     expect(state.kind).toBe('stuck')
+  })
+
+  it('running with staleBlocker beats stuck (when receipt is from prior turn)', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({
+        phase: 'Running',
+        runtime_blocker_class: 'turn_timeout',
+      }),
+      composite: makeComposite({
+        runtime_attention: attention({
+          execution_current: false,
+          stale_execution_receipt: true,
+        }),
+      }),
+    })
+    expect(state).toEqual<KeeperOperationalState>({
+      kind: 'running',
+      turnPhase: 'idle',
+      staleBlocker: 'turn_timeout',
+    })
   })
 })
 

--- a/dashboard/src/lib/keeper-operational-state.ts
+++ b/dashboard/src/lib/keeper-operational-state.ts
@@ -10,14 +10,28 @@
 //                                            (status/phase/paused OR-chain)
 // will all call `deriveKeeperOperationalState` instead (PR-3 ~ PR-6).
 //
-// Discriminant invariants (RFC-0135 §2 conditioning matrix):
-//   paused      ⇐ keeper.paused | phase==='Paused' | pause_state==='paused'
-//   offline     ⇐ phase ∈ Offline/Stopped/Dead/Crashed/Zombie  OR
-//                 status ∈ offline/inactive/unbooted
-//   stuck       ⇐ runtime_blocker_class set AND execution_current !== true
-//                 OR composite reports fiber_alive === false
-//   running     ⇐ otherwise (turn_phase carried; lingering stale blocker is
-//                 recorded but does NOT drive the headline)
+// Discriminant invariants (RFC-0135 §2 conditioning matrix). The
+// `execution_current` semantics are anchored at
+// `lib/server/server_dashboard_http.ml:1061-1074`:
+//
+//   `execution_current = true`  — receipt either (a) does not exist, or
+//      (b) is not from a stale live turn (`receipt_at >= live_started_at`).
+//      The receipt's blocker, if any, reflects the *current* live turn.
+//   `execution_current = false` — receipt is from a *previous* live turn
+//      (`receipt_at < live_started_at` with a newer turn now live). The
+//      blocker class describes that prior turn and is stale.
+//   `stale_execution_receipt = receipt_present && !execution_current` is
+//      the same axis seen from the receipt side; either signal counts as
+//      an explicitly-stale marker.
+//
+//   paused   ⇐ keeper.paused | phase==='Paused' | pause_state==='paused'
+//   offline  ⇐ phase ∈ Offline/Stopped/Dead/Crashed/Zombie  OR
+//              status ∈ offline/inactive/unbooted
+//   stuck    ⇐ (runtime_blocker_class set AND NOT explicitlyStale)
+//              OR composite reports fiber_alive === false
+//   running  ⇐ otherwise. When the blocker_class is set but the receipt
+//              is explicitly stale, the blocker is recorded as
+//              `staleBlocker` for display but does NOT drive the headline.
 //
 // catch-all `default:` is forbidden — see RFC-0135 §9 (PR-9 CI guard).
 
@@ -60,10 +74,14 @@ export function deriveKeeperOperationalState(
 
   const blockerClass = keeper.runtime_blocker_class ?? null
   const attention = composite?.runtime_attention ?? null
-  const executionFresh = attention?.execution_current === true
-  const staleReceipt = attention?.stale_execution_receipt === true
+  // An explicit stale marker is required to demote a blocker. The absence
+  // of `runtime_attention` (older backend, missing composite) leaves the
+  // blocker meaningful — fail-closed default.
+  const explicitlyStale =
+    attention?.execution_current === false
+    || attention?.stale_execution_receipt === true
 
-  if (blockerClass !== null && !executionFresh) {
+  if (blockerClass !== null && !explicitlyStale) {
     return { kind: 'stuck', reason: blockerClass }
   }
 
@@ -72,10 +90,10 @@ export function deriveKeeperOperationalState(
   }
 
   const turnPhase = composite?.turn_phase ?? keeper.pipeline_stage ?? 'idle'
+  // A blocker that *was* recorded but is now explicitly stale gets
+  // surfaced as informational context, not a headline.
   const staleBlocker =
-    executionFresh && (blockerClass !== null || staleReceipt)
-      ? blockerClass
-      : null
+    explicitlyStale && blockerClass !== null ? blockerClass : null
   return { kind: 'running', turnPhase, staleBlocker }
 }
 


### PR DESCRIPTION
## Why — 2개 버그 동시 fix

PR-1 (#16576 MERGED) 와 PR-4 (#16600 MERGED) 모두 \`execution_current\` 축의 의미를 *정반대로* 인코딩했음. detail panel 통합 작업 중 \`keeper-detail-runtime.test.ts:RuntimeLensSection > keeps previous receipt blockers out of the current live-turn summary\` 가 fail 하면서 발견.

## Backend 의미 (`lib/server/server_dashboard_http.ml:1061-1074`)

\`\`\`ocaml
let composite_execution_current_for_runtime_state ~snapshot ~execution =
  if not (receipt_present) then true
  else if not is_live then true
  else match (live_turn_started_at, receipt_at) with
       | Some live_started, Some receipt_at -> receipt_at >= live_started
       | _ -> false
\`\`\`

| \`execution_current\` | 의미 | blocker_class 해석 |
|---|---|---|
| \`true\` | receipt 가 *현재* live turn 매칭 | **meaningful** → stuck |
| \`false\` | receipt 가 *이전* turn (newer turn now live) | **stale** → demote |

## Bug 1 — PR-1 derive 함수 inverted

**Before** (\`keeper-operational-state.ts:63-67\`):
\`\`\`ts
const executionFresh = attention?.execution_current === true
if (blockerClass !== null && !executionFresh) {
  return { kind: 'stuck', reason: blockerClass }
}
\`\`\`

이 코드는 *\`execution_current=true\` (current receipt) → NOT stuck* 라고 해석. 정반대.

**After**:
\`\`\`ts
const explicitlyStale =
  attention?.execution_current === false
  || attention?.stale_execution_receipt === true

if (blockerClass !== null && !explicitlyStale) {
  return { kind: 'stuck', reason: blockerClass }
}
// staleBlocker recorded only when explicit stale signal present
\`\`\`

Fail-closed default — \`execution_current=undefined\` (older backend) 면 blocker meaningful (stuck), 새 fixture 가 cover.

## Bug 2 — PR-4 fixture EXACT scenario input inverted

\`agent-roster.test.ts:RFC §1.1 EXACT — blocker_class=synthetic_stall + execution_current=true must NOT surface as 현재 차단\` 가 \`execution_current=true\` 를 *stale* 시나리오로 의도. 위 backend 의미에 따라 *완전 반대*.

Fixture realignment: \`execution_current=false + stale_execution_receipt=true\` 로 swap. RFC §1.1 의 사용자 보고 사례 (lifecycle-worker 목록=차단, 상세=턴 진행 중) 와 *일치* — backend 가 그 시나리오에서 \`execution_current=false\` 를 emit (live turn started but receipt is prior).

## Detail panel 통합

\`keeper-detail-runtime.ts:deriveKeeperLiveTruth\`:
- \`stuckByBlockerClass = opState.kind === 'stuck'\` — typed SSOT 분기
- \`attentionBlocked = runtime_attention.blocked || needs_attention\` — **별개 축**으로 inline 유지. backend 가 \`execution_current && composite_execution_blocked\` 로 set 하므로 blocker-class-vs-stale-receipt 축과 orthogonal.
- \`blocked = stuckByBlockerClass || attentionBlocked\` — pre-RFC '조치 필요' 헤드라인 동작 동등.
- '차단' row value 는 \`stuck-by-blocker → typed reason\` / \`attentionBlocked → state string\` / \`none\` 순. \`staleBlocker\` 정보는 *detail 텍스트*에만 \`이전 차단: <class>\` 형태로 노출 — "value=none means clean now" mental model 보존.

## 변경 파일

| 파일 | 변경 |
|---|---|
| \`keeper-operational-state.ts\` | derive 함수 conditioning matrix invert + 주석 backend reference |
| \`keeper-operational-state.test.ts\` | RFC §1.1 EXACT input swap, "stuck beats running" split into current-vs-stale, fail-closed default 추가 |
| \`agent-roster.test.ts\` | EXACT / genuine-stuck fixture inputs swap |
| \`keeper-detail-runtime.ts\` | typed state 호출 + '차단' row 통합 |

## Verification

- \`pnpm typecheck\` PASS
- 3 영향 파일 82/82 PASS (PR-4 후 main 에 있었던 \`keeper-detail-runtime.test.ts:RuntimeLensSection > keeps previous receipt blockers out of the current live-turn summary\` fail 이 본 PR 로 *fixed*)
- \`pnpm lint\` 0 errors

## Workaround Rejection Bar

- [x] telemetry-as-fix 아님 — *바른 의미*로 re-axis
- [x] string classifier 아님 — typed sum 일관성 강화
- [x] N-of-M 아님 — PR-1/PR-4 둘 다 *같은 PR* 에서 fix
- [x] catch-all 추가 아님 — explicit \`!explicitlyStale\` 분기
- [x] cap/cooldown 아님

\`feedback_dual_path_normalize_vs_raw_wire_format\` + \`feedback_workdir_grep_must_cross_check_origin_main\` 패턴 확인 — 본 PR 도중 main fail 이 origin pre-existing 인지 cross-check 후 PR-5 가 *그 fail 도 fix* 함을 검증.

## 사용자 절대 원칙 준수

\`feedback_hardcoding_and_legacy_zero_tolerance\` — *transitional shim* 없음. PR-1 의 잘못된 의미를 *제거*하고 root fix (backend 의미 anchor 인용).

## Stack 위치

| RFC-0135 PR | 상태 |
|---|---|
| #16573 RFC body | Draft |
| **#16576 PR-1 typed sum module** | **MERGED** (의미 inverted, PR-5 가 fix) |
| **#16593 PR-2 phase casing SSOT** | **MERGED** |
| **#16600 PR-4 roster typed conditioning** | **MERGED** (fixture inverted, PR-5 가 fix) |
| **#TBD PR-5 axis fix + detail panel (본 PR)** | **Draft** |
| PR-3 keeper-predicates.ts | not started |
| PR-6 keeper-action-panel 중복 span 제거 | not started |
| PR-7 stateLabel/actionLabel 분리 | not started |
| PR-8 backend effective_blocker | not started |
| PR-9 CI guard | not started |

## RFC Check

\`bash ~/me/scripts/pr-rfc-check.sh\` — RFC-0135 reference. dashboard 영역, credential/identity/operator-control/sandbox 무관.

## Status

**Draft** — agent PR. Ready 전환은 사용자 라벨 부착 (\`human-approved-ready\`).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>