### PR TITLE
refactor: dedup 11 contains_substring bodies to String_util SSOT

### DIFF
--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -164,8 +164,7 @@ let status_stale_visible = "stale_visible"
 let status_offline = "offline"
 let status_backoff = "backoff"
 
-let contains_substring haystack needle =
-  String_util.contains_substring haystack needle
+let contains_substring haystack needle = String_util.contains_substring haystack needle
 
 let degraded_reason_of_error message =
   let lower = String.lowercase_ascii message in

--- a/lib/dashboard/dashboard_keeper_git_pr_proof.ml
+++ b/lib/dashboard/dashboard_keeper_git_pr_proof.ml
@@ -22,27 +22,7 @@ let stage_specs =
   ]
 ;;
 
-let contains_substring text needle =
-  let text_len = String.length text in
-  let needle_len = String.length needle in
-  if needle_len = 0
-  then true
-  else if needle_len > text_len
-  then false
-  else (
-    let rec matches_at i j =
-      j = needle_len
-      || (String.get text (i + j) = String.get needle j
-          && matches_at i (j + 1))
-    in
-    let rec loop i =
-      if i + needle_len > text_len
-      then false
-      else if matches_at i 0 then true
-      else loop (i + 1)
-    in
-    loop 0)
-;;
+let contains_substring text needle = String_util.contains_substring text needle
 
 let lower text = String.lowercase_ascii text
 

--- a/lib/dashboard_tla_specs.ml
+++ b/lib/dashboard_tla_specs.ml
@@ -174,20 +174,7 @@ let normalize_int s =
   |> Stdlib.int_of_string_opt
 ;;
 
-let contains_substring needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  if needle_len = 0
-  then true
-  else if needle_len > haystack_len
-  then false
-  else (
-    let rec loop i =
-      i + needle_len <= haystack_len
-      && (String.equal (Stdlib.String.sub haystack i needle_len) needle || loop (i + 1))
-    in
-    loop 0)
-;;
+let contains_substring needle haystack = String_util.contains_substring haystack needle
 
 let split_lines text = String.split_on_char '\n' text |> List.map String.trim
 

--- a/lib/exec/path_scope.ml
+++ b/lib/exec/path_scope.ml
@@ -21,17 +21,7 @@ let sandbox_prefixes =
     "/private/tmp/masc_";
   ]
 
-let contains_substring s sub =
-  let sub_len = String.length sub in
-  let s_len = String.length s in
-  if sub_len > s_len then false
-  else
-    let rec scan i =
-      if i + sub_len > s_len then false
-      else if String.sub s i sub_len = sub then true
-      else scan (i + 1)
-    in
-    scan 0
+let contains_substring s sub = String_util.contains_substring s sub
 
 let starts_with_any prefixes s =
   List.exists (fun p -> String.starts_with ~prefix:p s) prefixes

--- a/lib/keeper/keeper_exec_board.ml
+++ b/lib/keeper/keeper_exec_board.ml
@@ -94,17 +94,7 @@ let re_matches_compiled re text =
   | Not_found -> false
 ;;
 
-let contains_substring haystack needle =
-  let len_haystack = String.length haystack in
-  let len_needle = String.length needle in
-  len_needle = 0
-  ||
-  let rec loop idx =
-    idx + len_needle <= len_haystack
-    && (String.sub haystack idx len_needle = needle || loop (idx + 1))
-  in
-  loop 0
-;;
+let contains_substring haystack needle = String_util.contains_substring haystack needle
 
 let content_has_inline_quantitative_evidence content =
   let lower = String.lowercase_ascii content in

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -46,15 +46,7 @@ let search_char c =
 
 let normalize_search_text text = String.lowercase_ascii (String.map search_char text)
 
-let contains_substring text needle =
-  let text_len = String.length text in
-  let needle_len = String.length needle in
-  let rec loop idx =
-    idx + needle_len <= text_len
-    && (String.sub text idx needle_len = needle || loop (idx + 1))
-  in
-  needle_len = 0 || loop 0
-;;
+let contains_substring text needle = String_util.contains_substring text needle
 
 let search_terms query =
   normalize_search_text query

--- a/lib/keeper/keeper_routine_allowlist.ml
+++ b/lib/keeper/keeper_routine_allowlist.ml
@@ -197,20 +197,7 @@ let first_nonempty_string_field keys = function
       keys
   | _ -> None
 
-let contains_substring haystack needle =
-  let haystack_len = String.length haystack in
-  let needle_len = String.length needle in
-  if needle_len = 0
-  then true
-  else if needle_len > haystack_len
-  then false
-  else (
-    let last = haystack_len - needle_len in
-    let rec loop i =
-      i <= last
-      && (String.equal (String.sub haystack i needle_len) needle || loop (i + 1))
-    in
-    loop 0)
+let contains_substring haystack needle = String_util.contains_substring haystack needle
 
 let path_has_git_dir path =
   String.equal (Filename.basename path) ".git" || contains_substring path "/.git/"

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -203,16 +203,7 @@ let apply_default opt current = match opt with Some v -> v | None -> current
 (** Same as [apply_default] but both TOML and meta are option-typed. *)
 let apply_default_opt opt current = match opt with Some _ -> opt | None -> current
 
-let contains_substring haystack needle =
-  let haystack_len = String.length haystack in
-  let needle_len = String.length needle in
-  let rec loop idx =
-    if needle_len = 0 then true
-    else if idx + needle_len > haystack_len then false
-    else if String.sub haystack idx needle_len = needle then true
-    else loop (idx + 1)
-  in
-  loop 0
+let contains_substring haystack needle = String_util.contains_substring haystack needle
 
 let invalid_profile_defaults_error ~keeper_name detail =
   if contains_substring detail "cascade_name" then

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -253,8 +253,7 @@ let runtime_contract_json_from_fields ~keeper_name ?agent_name ?trace_id
       ("cascade_profile", string_opt_json cascade_profile);
     ]
 
-let contains_substring haystack needle =
-  String_util.contains_substring haystack needle
+let contains_substring haystack needle = String_util.contains_substring haystack needle
 
 let json_string_field name = function
   | `Assoc _ as json -> Json_util.get_string_nonempty json name

--- a/lib/keeper/keeper_tool_github_pr.ml
+++ b/lib/keeper/keeper_tool_github_pr.ml
@@ -185,16 +185,7 @@ let status_ok = function
   | Unix.WEXITED 0 -> true
   | _ -> false
 
-let contains_substring haystack needle =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  let rec loop idx =
-    if needle_len = 0 then true
-    else if idx + needle_len > haystack_len then false
-    else if String.sub haystack idx needle_len = needle then true
-    else loop (idx + 1)
-  in
-  loop 0
+let contains_substring haystack needle = String_util.contains_substring haystack needle
 
 let pr_create_failure_may_have_created_pr output =
   let output = String.lowercase_ascii output in

--- a/lib/observability_redact.ml
+++ b/lib/observability_redact.ml
@@ -13,17 +13,7 @@ let default_max_len = 200
 let denied_tool_infixes =
   ["_auth"; "_encryption"; "_credential"; "_secret"]
 
-let contains_substring ~sub s =
-  let sub_len = String.length sub in
-  let s_len = String.length s in
-  if sub_len > s_len then false
-  else
-    let rec loop i =
-      if i > s_len - sub_len then false
-      else if String.sub s i sub_len = sub then true
-      else loop (i + 1)
-    in
-    loop 0
+let contains_substring ~sub s = String_util.contains_substring s sub
 
 let sensitive_key_markers =
   [ "token"; "secret"; "password"; "passwd"; "api_key"; "apikey"; "key" ]


### PR DESCRIPTION
## 요약

`contains_substring`의 자체 정의 본문 11개를 SSOT (`Masc_mcp.String_util.contains_substring`)로 라우팅. 본문이 11~22 줄짜리 byte-wise substring search로 흩어져 있었고, 모두 SSOT와 동일한 empty-needle→true 의미. 각 사이트 1-line wrapper로 축약.

## 동기 (Audit)

`memory/masc-mcp-code-smell-report-2026-05-19.html` Hotspot #1: 28 정의 사이트 중 12 SSOT routing + 14 자체 정의 + 2 본체. §AI 안티패턴 §1 (Scattered Hardcoded Defaults).

실측 후 자체 정의 14 중:
- **dedup 가능 11**: SSOT와 같은 알고리즘 + 같은 empty-needle 의미
- **의도적 분기 2**: `cascade_catalog_validator`, `server_routes_http_common` — empty needle → false (주석 명시). 이미 1줄 `String.length needle > 0 && String_util.contains_substring ...` guard로 SSOT 위에 얹혀 있어 그대로 보존
- **본체 2**: `core/string_util.ml` SSOT, `exec/string_util.ml` (sub-lib boundary 의도적 stub) — 손대지 않음

## 변경

각 자체 정의 본문을 1줄 wrapper로 교체. caller 호출 시그니처는 그대로 유지 (caller 측면 변경 0):

| 모듈 | 시그니처 | wrapping |
|------|---------|----------|
| `observability_redact` | `~sub s` | `String_util.contains_substring s sub` |
| `dashboard_tla_specs` | `needle haystack` (reversed positional) | `String_util.contains_substring haystack needle` |
| `dashboard_governance_judge` | `haystack needle` (이미 2-line alias) | 1-line으로 합침 |
| `dashboard_keeper_git_pr_proof` | `text needle` | `String_util.contains_substring text needle` |
| `exec/path_scope` | `s sub` | `String_util.contains_substring s sub` |
| `keeper_routine_allowlist` | `haystack needle` | direct |
| `keeper_runtime_contract` | `haystack needle` (이미 2-line alias) | 1-line으로 합침 |
| `keeper_tool_github_pr` | `haystack needle` | direct |
| `keeper_runtime` | `haystack needle` | direct |
| `keeper_exec_tools` | `text needle` | `String_util.contains_substring text needle` |
| `keeper_exec_board` | `haystack needle` | direct |

## 보존

- **caller signature**: 각 모듈은 자기 도메인 용어(`text`/`s`/`haystack`/`needle`/`sub`/labeled)로 호출 — caller 호출부 변경 0
- **empty-needle 의미**: 모든 11개는 SSOT와 동일하게 empty→true. 의도적으로 false 의미인 2개는 별도 guard 보존
- **wire/observable 변경 없음**

## 측정

```
$ git diff --stat
 11 files changed, 11 insertions(+), 115 deletions(-)

$ rg "^let contains_substring" lib/ | wc -l
28   # 사이트 수 동일 (1-line으로 압축, 본문만 SSOT routing)
```

## 보고서 자체에 대한 보정

보고서는 14 자체 정의에서 2개 이미 alias 사이트를 중복 카운트했다. 실제 dedup 대상은 11. 보고서는 후속 PR로 보정.

RFC-WAIVED: body-only dedup; same algorithm, same empty-needle contract, no caller signature change.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
