### PR TITLE
fix(dashboard): RFC-0135 PR-6 action panel — drop duplicate '일시정지' + verb tooltips

### DIFF
--- a/dashboard/src/components/keeper-action-panel.ts
+++ b/dashboard/src/components/keeper-action-panel.ts
@@ -160,9 +160,16 @@ function KeeperActionRow({ keeper }: { keeper: Keeper }) {
       <div class="flex items-center gap-2 min-w-0 flex-1">
         <span class="text-xs font-semibold text-[var(--color-fg-secondary)] truncate max-w-28">${keeper.name}</span>
         <${KeeperPhaseBadge} phase=${keeper.phase} compact />
-        ${keeper.paused
-          ? html`<span class="text-3xs font-semibold text-[var(--paused,var(--color-status-warn))]">일시정지</span>`
-          : null}
+        <!--
+          RFC-0135 §1.2: the previous auxiliary "일시정지" <span> at this
+          position duplicated KeeperPhaseBadge's "⏸ 일시정지" output and
+          colocated the *state noun* "일시정지" with the *verb button*
+          "일시정지" later in the row — the user reported this as
+          confusing on 2026-05-19. The badge already renders the state;
+          this slot is intentionally empty so the action buttons own the
+          verb meaning. PR-7 will further disambiguate by appending "하기"
+          to verb-button labels.
+        -->
       </div>
       <div class="flex items-center gap-1 shrink-0">
         ${vis.canBoot
@@ -171,7 +178,7 @@ function KeeperActionRow({ keeper }: { keeper: Keeper }) {
               size="sm"
               disabled=${busy.value}
               onClick=${() => handle('boot')}
-              title="기동"
+              title="기동: offline keeper 를 다시 시작합니다 (offline → running)"
             >기동<//>`
           : null}
         ${vis.canPause
@@ -180,7 +187,7 @@ function KeeperActionRow({ keeper }: { keeper: Keeper }) {
               size="sm"
               disabled=${busy.value}
               onClick=${() => handle('pause')}
-              title="일시정지"
+              title="일시정지: 실행 중인 keeper 를 일시 멈춥니다 (running → paused, 현재 turn 은 정상 종료)"
             >일시정지<//>`
           : null}
         ${vis.canResume
@@ -189,7 +196,7 @@ function KeeperActionRow({ keeper }: { keeper: Keeper }) {
               size="sm"
               disabled=${busy.value}
               onClick=${() => handle('resume')}
-              title="재개"
+              title="재개: 일시정지된 keeper 를 다시 실행합니다 (paused → running)"
             >재개<//>`
           : null}
         ${vis.canWake && !vis.canBoot
@@ -198,7 +205,7 @@ function KeeperActionRow({ keeper }: { keeper: Keeper }) {
               size="sm"
               disabled=${busy.value}
               onClick=${() => handle('wakeup')}
-              title="깨우기: sleep 중인 keeper를 즉시 깨워 다음 turn을 시도"
+              title="깨우기: idle 또는 stuck 상태에서 다음 turn 을 즉시 시도합니다. 실행 중이어도 노출되는 이유는 cascade/oas/turn timeout 같은 stuck signal 이 backend 보다 먼저 frontend 에 보이는 케이스를 다루기 위함입니다."
             >깨우기<//>`
           : null}
         ${vis.canShutdown
@@ -207,7 +214,7 @@ function KeeperActionRow({ keeper }: { keeper: Keeper }) {
               size="sm"
               disabled=${busy.value}
               onClick=${() => handle('shutdown')}
-              title="종료"
+              title="종료: keeper 를 완전 종료합니다 (running/paused → offline, fiber + 리소스 정리)"
             >종료<//>`
           : null}
       </div>


### PR DESCRIPTION
## Why — RFC-0135 §1.2 + §1.3 직접 fix

2026-05-19 사용자 보고 Command/Actions 화면 사례:

> "echo ⏸ 일시정지 [일시정지] [기동] [재개] [종료] — 의미 모름"

같은 row 에 한국어 어근 \"일시정지\" 가 **두 번** 표시되던 *시각적 모순*:

| 위치 | 출처 | 의미 |
|---|---|---|
| 1. \`KeeperPhaseBadge\` (compact) | line 162 | state: \"⏸ 일시정지\" (phase=Paused) |
| 2. 보조 \`<span>\` | line 163-165 | state: \"일시정지\" (paused=true) ← **중복** |
| 3. action button | line 178-185 | verb: \"일시정지\" (pause action) |

#1 과 #3 은 의미가 다르지만 KeeperPhaseBadge 가 이미 #1 을 표시하므로 **#2 는 순수 중복**. 본 PR 이 #2 를 제거. #1/#3 의 *noun vs verb* 분리는 PR-7 (\`stateLabel\`/\`actionLabel\` SSOT) 에서 verb button 라벨에 \"하기\" 접미사 추가로 완성.

또 5 action verb 의 *사전조건/효과* 가 tooltip 에 없어서 운영자가 의미 추측해야 했음 (특히 \`canWake = isStuck || (isRunning && !isPaused)\` 로 *정상 running 상태에서도* 깨우기 버튼이 보임). 모든 tooltip 에 사전조건/효과 명시.

## What

1. line 163-165 보조 \`<span>일시정지</span>\` **제거** + 의도 명시 주석
2. 5 verb tooltip 보강 (한국어, 사전조건/효과):

| verb | tooltip |
|---|---|
| 기동 | \"offline keeper 를 다시 시작합니다 (offline → running)\" |
| 일시정지 | \"실행 중인 keeper 를 일시 멈춥니다 (running → paused, 현재 turn 은 정상 종료)\" |
| 재개 | \"일시정지된 keeper 를 다시 실행합니다 (paused → running)\" |
| 깨우기 | \"idle 또는 stuck 상태에서 다음 turn 을 즉시 시도합니다. 실행 중이어도 노출되는 이유는 cascade/oas/turn timeout 같은 stuck signal 이 backend 보다 먼저 frontend 에 보이는 케이스를 다루기 위함입니다.\" |
| 종료 | \"keeper 를 완전 종료합니다 (running/paused → offline, fiber + 리소스 정리)\" |

## Verification

- \`pnpm typecheck\` PASS
- \`keeper-action-panel.test.ts\` 7/7 PASS
- \`pnpm lint\` 0 errors
- \`+15 / -8\` LoC (narrow scope)

## Workaround Rejection Bar

- [x] telemetry-as-fix 아님
- [x] string classifier 아님
- [x] N-of-M 아님
- [x] catch-all 아님
- [x] cap/cooldown 아님

## Stack 위치

| RFC-0135 PR | 상태 |
|---|---|
| #16573 RFC body | Draft |
| #16576 PR-1 / #16593 PR-2 / #16600 PR-4 | MERGED |
| #16606 PR-5 axis fix | Draft |
| **#TBD PR-6 action panel cleanup (본 PR)** | **Draft** |
| PR-3 keeper-predicates.ts | not started |
| PR-7 stateLabel/actionLabel 분리 | not started |
| PR-8 backend effective_blocker | not started |
| PR-9 CI guard | not started |

## Status

**Draft** — agent PR. Ready 전환은 사용자 라벨 부착 (\`human-approved-ready\`).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>