### PR TITLE
refactor(dashboard): RFC-0135 PR-5 — deriveKeeperLiveTruth typed-sum SSOT

### DIFF
--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -25,6 +25,10 @@ import { serverStatus, shellRuntimeResolution } from '../store'
 import { operatorSnapshot } from '../operator-store'
 import type { KeeperDetailEvidenceState } from './keeper-detail-hooks'
 import {
+  deriveKeeperOperationalState,
+  type KeeperOperationalState,
+} from '../lib/keeper-operational-state'
+import {
   allowlistEmptyState,
   auditMetadataState,
   linkedRuntimeState,
@@ -165,6 +169,49 @@ function terminalEventLabel(trace: KeeperRuntimeTraceResponse | null): {
   }
 }
 
+// ── Typed-state → headline / tone helpers (RFC-0135 PR-5) ───────────
+//
+// Two pure projections from `KeeperOperationalState` to the headline
+// text + tone the panel renders. Kept here (rather than inside
+// keeper-operational-state) because the *exact* Korean wording and
+// the warnings-present / runtime-trace-present overrides are
+// LIVE-TRUTH-specific cosmetics. The kind branching, however, is
+// exhaustive — TS catches new arms before they ship.
+
+function headlineForState(
+  state: KeeperOperationalState,
+  context: { fiberAlive: boolean; runtimeTracePresent: boolean },
+): string {
+  switch (state.kind) {
+    case 'offline':
+      return context.runtimeTracePresent ? '실행 미확인' : '증거 부족'
+    case 'paused':
+      return '일시정지'
+    case 'stuck':
+      return '조치 필요'
+    case 'running':
+      if (state.staleBlocker !== null) return '턴 진행 중'
+      return context.fiberAlive ? '턴 진행 중' : '대기 중'
+  }
+}
+
+function toneForState(
+  state: KeeperOperationalState,
+  context: { warningsPresent: boolean; runtimeTracePresent: boolean },
+): StatusChipTone {
+  if (context.warningsPresent) return 'warn'
+  switch (state.kind) {
+    case 'offline':
+      return context.runtimeTracePresent ? 'warn' : 'neutral'
+    case 'paused':
+      return 'warn'
+    case 'stuck':
+      return 'warn'
+    case 'running':
+      return 'ok'
+  }
+}
+
 export function deriveKeeperLiveTruth({
   keeper,
   compositeSnapshot,
@@ -177,55 +224,36 @@ export function deriveKeeperLiveTruth({
   runtimeResolution?: KeeperLiveTruthRuntimeInput | null
 }): KeeperLiveTruthSummary {
   const linkedState = linkedRuntimeState(keeper)
-  // Per-axis SSOT routing (RFC-0046 §4.3): the FSM hub below this panel is
-  // the canonical phase/turn surface, so this panel only needs `turnPhase`
-  // for the contextual "현재 턴" row detail. The old 3-way fallback
-  // `compositeSnapshot?.phase ?? keeper.phase ?? keeper.status` was the
-  // §AI코드생성 §2 Unknown-→-Permissive-Default anti-pattern that let stale
-  // flat-record fields silently feed status badges; removed here.
+  // RFC-0135 PR-5 — headline / tone / blocked are driven by the typed
+  // operational state SSOT in `lib/keeper-operational-state.ts`. The
+  // previous inline conditioning (3-OR blocked, multi-arm headline,
+  // matching tone ladder) lived in this function only; now both the
+  // roster (RFC-0135 PR-4 / `rosterStateNote`) and this LIVE TRUTH
+  // panel share the same derivation, which closes the §1.1
+  // list-vs-detail divergence at the source.
+  const state = deriveKeeperOperationalState({ keeper, composite: compositeSnapshot })
   const turnPhase = compactToken(compositeSnapshot?.turn_phase ?? keeper.pipeline_stage)
+  // `fiberAlive` and `activeTurn` are still useful as *row-level
+  // detail* (런타임 row + 현재 턴 row) even though they no longer
+  // drive the headline.
   const fiberAlive =
     compositeSnapshot?.phase_diagnosis?.conditions.fiber_alive
     ?? keeper.keepalive_running
     ?? keeper.presence_keepalive
     ?? (linkedState !== 'offline')
   const activeTurn = compositeSnapshot?.is_live === true || !isIdleTurnPhase(compositeSnapshot?.turn_phase)
-  const previousExecutionReceipt =
-    compositeSnapshot?.runtime_attention?.stale_execution_receipt === true
-    || compositeSnapshot?.runtime_attention?.execution_current === false
-  const blocked =
-    compositeSnapshot?.runtime_attention?.blocked === true
-    || compositeSnapshot?.runtime_attention?.needs_attention === true
-    || (!previousExecutionReceipt && Boolean(keeper.runtime_blocker_class))
   const stopRequested =
     compositeSnapshot?.runtime_attention?.fiber_stop_requested === true
     || compositeSnapshot?.phase_diagnosis?.conditions.stop_requested === true
   const traceEvidence = terminalEventLabel(runtimeTrace)
   const warnings = runtimeWarningList(runtimeResolution)
-  const headline =
-    stopRequested
-      ? '종료 신호'
-      : blocked
-        ? '조치 필요'
-        : fiberAlive && activeTurn
-          ? '턴 진행 중'
-          : fiberAlive
-            ? '대기 중'
-            : runtimeTrace
-              ? '실행 미확인'
-              : '증거 부족'
-  const tone: StatusChipTone =
-    stopRequested
-      ? 'bad'
-      : blocked || warnings.length > 0
-        ? 'warn'
-        : fiberAlive && activeTurn
-          ? 'ok'
-          : fiberAlive
-            ? 'neutral'
-            : runtimeTrace
-              ? 'warn'
-              : 'neutral'
+  const blocked = state.kind === 'stuck'
+  const headline = stopRequested
+    ? '종료 신호'
+    : headlineForState(state, { fiberAlive, runtimeTracePresent: runtimeTrace !== null })
+  const tone: StatusChipTone = stopRequested
+    ? 'bad'
+    : toneForState(state, { warningsPresent: warnings.length > 0, runtimeTracePresent: runtimeTrace !== null })
 
   const idleLabel =
     typeof compositeSnapshot?.idle_seconds === 'number'

--- a/dashboard/src/lib/keeper-operational-state.test.ts
+++ b/dashboard/src/lib/keeper-operational-state.test.ts
@@ -231,6 +231,40 @@ describe('deriveKeeperOperationalState — running branch with conditioning', ()
     })
   })
 
+  it('is_live=true with execution_current=false still treats blocker as stale (running, RFC §1.1 sibling)', () => {
+    // Backend may briefly emit `execution_current=false` early in a
+    // fresh turn — before the first receipt for it has landed — while
+    // still flagging the live turn via `is_live=true`. The flat
+    // `runtime_blocker_class` from the prior turn must not surface as
+    // an active blocker in this window. Matches the
+    // `deriveKeeperLiveTruth` fixture 2 expectation
+    // (`previousExecutionReceipt` short-circuit) that this typed-sum
+    // is taking over.
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({
+        phase: 'Running',
+        status: 'active',
+        runtime_blocker_class: 'cascade_exhausted',
+        runtime_blocker_summary: 'previous turn exhausted cascade',
+      }),
+      composite: makeComposite({
+        is_live: true,
+        turn_phase: 'executing',
+        runtime_attention: attention({
+          state: 'ok',
+          execution_current: false,
+          stale_execution_receipt: true,
+          blocked: false,
+        }),
+      }),
+    })
+    expect(state).toEqual<KeeperOperationalState>({
+      kind: 'running',
+      turnPhase: 'executing',
+      staleBlocker: 'cascade_exhausted',
+    })
+  })
+
   it('stale_execution_receipt=true with no blocker still surfaces as running (staleBlocker null)', () => {
     const state = deriveKeeperOperationalState({
       keeper: makeKeeper({ phase: 'Running', status: 'active' }),

--- a/dashboard/src/lib/keeper-operational-state.ts
+++ b/dashboard/src/lib/keeper-operational-state.ts
@@ -60,11 +60,33 @@ export function deriveKeeperOperationalState(
 
   const blockerClass = keeper.runtime_blocker_class ?? null
   const attention = composite?.runtime_attention ?? null
-  const executionFresh = attention?.execution_current === true
+  // `execution_current === true` is the strongest fresh-turn signal,
+  // but backend may leave it unset (or briefly `false`) while a fresh
+  // turn is in flight and the first receipt for it hasn't landed.
+  // `is_live === true` confirms a live turn is in progress; either
+  // signal is enough to treat a flat `runtime_blocker_class` as a
+  // stale prior-turn leftover rather than an active blocker (matches
+  // the `previousExecutionReceipt` interpretation in the legacy
+  // `deriveKeeperLiveTruth` path that this module is taking over).
+  const executionFresh =
+    attention?.execution_current === true || composite?.is_live === true
   const staleReceipt = attention?.stale_execution_receipt === true
 
   if (blockerClass !== null && !executionFresh) {
     return { kind: 'stuck', reason: blockerClass }
+  }
+
+  // Backend explicitly flagged the keeper as needing attention. Trust
+  // this over the flat blocker-class read — backend has already done
+  // the stale-receipt conditioning for us. When no typed
+  // `runtime_blocker_class` is present (or it's an old keeper that
+  // lost the class but kept the attention flag), fall back to the
+  // `'unknown'` StuckReason variant.
+  if (
+    attention?.blocked === true
+    || attention?.needs_attention === true
+  ) {
+    return { kind: 'stuck', reason: blockerClass ?? 'unknown' }
   }
 
   if (composite !== null && compositeFiberKnownDead(composite)) {


### PR DESCRIPTION
## Why (RFC-0135 §1.1 close-out)

직전 PR-4 (#16603) 가 roster 가 typed-sum 호출하도록 만들었지만, detail 의 LIVE TRUTH 패널은 여전히 inline 3-OR \`blocked\` + 6-arm \`headline\` 로 동일 답을 *따로* 계산했음. 같은 keeper, 같은 wire frame 에서 두 surface 가 다른 답 내놓는 §1.1 사례의 *남은 절반* 닫음.

## What

**1. \`keeper-operational-state.ts\` typed-sum 보강 2 곳**

- \`executionFresh\` 에 \`composite.is_live === true\` OR 추가. backend 가 fresh turn 첫 receipt 도착 전 \`execution_current=false\` 잠시 emit 하는 윈도우에서 flat blocker_class 를 stale 로 봄. (기존 inline \`previousExecutionReceipt\` 로직과 정렬)
- \`runtime_attention.blocked === true\` (또는 \`needs_attention === true\`) 가 \`'stuck'\` 분기. typed blocker class 없으면 \`'unknown'\` fallback. backend conditioning 신뢰.

**2. \`deriveKeeperLiveTruth\` typed-sum 호출**

- 기존 inline conditioning 22 줄 (\`previousExecutionReceipt\` / \`blocked\` 3-OR / 6-arm \`headline\` / 6-arm \`tone\`) 제거
- 단일 \`state = deriveKeeperOperationalState({ keeper, composite })\` 호출
- 2 개 pure projection: \`headlineForState(state, ctx)\` / \`toneForState(state, ctx)\` — TS exhaustive match (catch-all 금지)
- \`fiberAlive\` / \`activeTurn\` 는 row-level detail 로 유지 (헤드라인 결정엔 미사용)

**3. 신규 typed-sum 테스트**

- \`is_live=true with execution_current=false still treats blocker as stale (running, RFC §1.1 sibling)\` — fixture 2 shape (live turn + stale receipt + stale blocker) 가 \`'running' staleBlocker=cascade_exhausted\` 로 정확히 분류되는지 검증

## RFC-0135 §5 PR-5 acceptance

- [x] \`deriveKeeperLiveTruth\` calls \`deriveKeeperOperationalState\`
- [x] Inline conditioning (line 188-194) 제거
- [x] §1.1 reproducer (fresh-receipt + stale blocker class) → roster + detail 동일 verdict

## Tests

- \`pnpm typecheck\` clean
- \`pnpm vitest run src/components/keeper-detail-runtime.test.ts src/lib/keeper-operational-state.test.ts\` — **66/66 pass**
- \`pnpm vitest run src/components/keeper-detail src/components/fsm-hub src/components/agent-roster\` — **389/389 pass**
- \`pnpm vitest run\` (전체) — 7630/7634 pass (4 pre-existing fails: \`useFileSuggestions\`, \`IdeActivityPanel\`, \`CytoscapeFsm\`, auth/window — 모두 본 PR 영역 밖)
- \`pnpm lint\` clean (1 pre-existing warning 무관 파일)

## 의존

PR-1 (typed-sum) MERGED + PR-4 (#16603) 와 stack. PR-4 머지 후 본 PR rebase.

## Test plan

- [ ] dashboard preview 에서 RFC §1.1 reproducer (fresh turn 시작 직후 stale blocker_class) 의 keeper 가 detail LIVE TRUTH 에 \`'턴 진행 중'\` 표시되는지 확인
- [ ] 같은 keeper 의 roster card 도 \`'현재 차단'\` note 표시하지 않는지 확인 (PR-4 와 동일 verdict)
- [ ] 진짜 stuck keeper 가 \`'조치 필요'\` 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)