### PR TITLE
fix(masc_http_client): surface evict-fiber exception silently swallowed

### DIFF
--- a/lib/masc_http_client/pool.ml
+++ b/lib/masc_http_client/pool.ml
@@ -90,6 +90,7 @@ type idle_entry = {
 type stats_counters = {
   mutable reuse_count_total  : int;
   mutable evict_count_total  : int;
+  mutable evict_failure_count_total : int;
   mutable create_count_total : int;
   mutable inflight           : int;
 }
@@ -97,6 +98,7 @@ type stats_counters = {
 let new_counters () =
   { reuse_count_total = 0;
     evict_count_total = 0;
+    evict_failure_count_total = 0;
     create_count_total = 0;
     inflight = 0; }
 
@@ -156,7 +158,16 @@ let start_eviction_fiber t =
         Eio.Time.sleep clock (t.config.idle_ttl_seconds /. 2.0);
         let now = Eio.Time.now clock in
         (try evict_expired_entries t now
-         with _ -> ());
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+             t.counters.evict_failure_count_total
+               <- t.counters.evict_failure_count_total + 1;
+             Printf.eprintf
+               "[masc_http_client.pool] eviction fiber caught \
+                exception (count=%d): %s\n%!"
+               t.counters.evict_failure_count_total
+               (Printexc.to_string exn));
         loop ()
       end
     in
@@ -528,6 +539,7 @@ type stats = {
   total_inflight : int;
   reuse_count_total : int;
   evict_count_total : int;
+  evict_failure_count_total : int;
   create_count_total : int;
 }
 
@@ -545,6 +557,7 @@ let stats t : stats =
       total_inflight = t.counters.inflight;
       reuse_count_total = t.counters.reuse_count_total;
       evict_count_total = t.counters.evict_count_total;
+      evict_failure_count_total = t.counters.evict_failure_count_total;
       create_count_total = t.counters.create_count_total; })
 
 (* ── Test-only ─────────────────────────────────────────────────── *)

--- a/lib/masc_http_client/pool.mli
+++ b/lib/masc_http_client/pool.mli
@@ -169,6 +169,11 @@ type stats = {
   total_inflight : int;
   reuse_count_total : int;
   evict_count_total : int;
+  (** Increments when the periodic eviction fiber catches an
+      exception while sweeping idle entries. Operator-visible signal
+      that the pool's TTL cleanup is silently failing. Surfaced as
+      [masc_pool_evict_failure_total] in Prometheus. *)
+  evict_failure_count_total : int;
   create_count_total : int;
 }
 

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -120,6 +120,7 @@ let metric_pool_idle_total = Pool_metrics.metric_idle_total
 let metric_pool_inflight_total = Pool_metrics.metric_inflight_total
 let metric_pool_reuse_total = Pool_metrics.metric_reuse_total
 let metric_pool_evict_total = Pool_metrics.metric_evict_total
+let metric_pool_evict_failure_total = Pool_metrics.metric_evict_failure_total
 let metric_pool_create_total = Pool_metrics.metric_create_total
 
 include Prometheus_policy_metric_names
@@ -374,6 +375,8 @@ let update_pool_metrics_gauges () =
     set_gauge metric_pool_idle_total (float_of_int stats.total_idle);
     set_gauge metric_pool_reuse_total (float_of_int stats.reuse_count_total);
     set_gauge metric_pool_evict_total (float_of_int stats.evict_count_total);
+    set_gauge metric_pool_evict_failure_total
+      (float_of_int stats.evict_failure_count_total);
     set_gauge metric_pool_create_total (float_of_int stats.create_count_total)
 ;;
 

--- a/lib/prometheus_builtin_metric_names.ml
+++ b/lib/prometheus_builtin_metric_names.ml
@@ -95,6 +95,7 @@ let metric_pool_idle_total = Pool_metrics.metric_idle_total
 let metric_pool_inflight_total = Pool_metrics.metric_inflight_total
 let metric_pool_reuse_total = Pool_metrics.metric_reuse_total
 let metric_pool_evict_total = Pool_metrics.metric_evict_total
+let metric_pool_evict_failure_total = Pool_metrics.metric_evict_failure_total
 let metric_pool_create_total = Pool_metrics.metric_create_total
 
 include Prometheus_policy_metric_names

--- a/lib/prometheus_builtin_metric_names.mli
+++ b/lib/prometheus_builtin_metric_names.mli
@@ -82,6 +82,7 @@ val metric_pool_idle_total : string
 val metric_pool_inflight_total : string
 val metric_pool_reuse_total : string
 val metric_pool_evict_total : string
+val metric_pool_evict_failure_total : string
 val metric_pool_create_total : string
 
 include module type of Prometheus_policy_metric_names

--- a/lib/prometheus_builtin_metrics_part4.ml
+++ b/lib/prometheus_builtin_metrics_part4.ml
@@ -53,6 +53,13 @@ let register
     "Cumulative count of pooled connections evicted by idle-TTL or LRU cap."
     `Counter;
   add
+    metric_pool_evict_failure_total
+    "Cumulative count of exceptions caught by the eviction fiber while \
+     sweeping idle entries. Previously swallowed by [with _ -> ()]; \
+     a non-zero value indicates the periodic TTL cleanup is silently \
+     failing and the pool may leak idle connections."
+    `Counter;
+  add
     metric_pool_create_total
     "Cumulative count of fresh piaf [Client.t] connections created on pool miss."
     `Counter;

--- a/lib/server/pool_metrics.ml
+++ b/lib/server/pool_metrics.ml
@@ -10,6 +10,7 @@ let metric_idle_total = "masc_pool_idle_total"
 let metric_inflight_total = "masc_pool_inflight_total"
 let metric_reuse_total = "masc_pool_reuse_total"
 let metric_evict_total = "masc_pool_evict_total"
+let metric_evict_failure_total = "masc_pool_evict_failure_total"
 let metric_create_total = "masc_pool_create_total"
 
 let current_snapshot () =

--- a/lib/server/pool_metrics.mli
+++ b/lib/server/pool_metrics.mli
@@ -11,6 +11,7 @@
     - [masc_pool_inflight_total] (gauge)
     - [masc_pool_reuse_total] (counter)
     - [masc_pool_evict_total] (counter)
+    - [masc_pool_evict_failure_total] (counter)
     - [masc_pool_create_total] (counter)
 
     The cumulative counters use [Pool.stats.*_total] snapshot values
@@ -32,6 +33,13 @@ val metric_reuse_total : string
 
 val metric_evict_total : string
 (** [masc_pool_evict_total] — counter, single time series. *)
+
+val metric_evict_failure_total : string
+(** [masc_pool_evict_failure_total] — counter, single time series.
+    Increments when the periodic eviction fiber catches an exception
+    while sweeping idle entries. Operator-visible signal that the
+    pool's TTL cleanup is silently failing (previously swallowed by
+    [with _ -> ()]). *)
 
 val metric_create_total : string
 (** [masc_pool_create_total] — counter, single time series. *)

--- a/test/test_pool.ml
+++ b/test/test_pool.ml
@@ -125,6 +125,7 @@ let test_stats_zero_state_shape () =
     total_inflight = 0;
     reuse_count_total = 0;
     evict_count_total = 0;
+    evict_failure_count_total = 0;
     create_count_total = 0;
   } in
   Alcotest.(check int) "zero total_idle" 0 zero.total_idle;


### PR DESCRIPTION
## Goal

The connection pool's periodic eviction fiber (`lib/masc_http_client/pool.ml:158`) caught all exceptions with `with _ -> ()` and looped on. If `evict_expired_entries` ever raised, the pool would silently stop reclaiming idle connections — an operator-invisible failure mode that can manifest as a slow leak of socket FDs.

User vision (`/loop` task): *"Error 가 나는 케이스에 대해 사용자가 정말 구체적으로 알도록 개선하라."* This PR closes one such silent-failure path.

## Change

Carve out a typed `Eio.Cancel.Cancelled` re-raise and replace the silent catch with:

- Increment of new `evict_failure_count_total` counter
- stderr line tagged `[masc_http_client.pool]` with the exception text
- Exposed via Prometheus as `masc_pool_evict_failure_total` (Counter)

```ocaml
(try evict_expired_entries t now
 with
 | Eio.Cancel.Cancelled _ as e -> raise e
 | exn ->
     t.counters.evict_failure_count_total
       <- t.counters.evict_failure_count_total + 1;
     Printf.eprintf
       \"[masc_http_client.pool] eviction fiber caught \
        exception (count=%d): %s\n%!\"
       t.counters.evict_failure_count_total
       (Printexc.to_string exn));
```

## Surface additions

| File | Change |
|------|--------|
| `lib/masc_http_client/pool.ml` | counter field + new_counters init + L158 fix + stats output |
| `lib/masc_http_client/pool.mli` | `evict_failure_count_total : int` in `stats` (doc'd) |
| `lib/server/pool_metrics.ml` + `.mli` | `metric_evict_failure_total` constant |
| `lib/prometheus.ml` | alias + `set_gauge` in `update_pool_metrics_gauges` |
| `lib/prometheus_builtin_metric_names.ml` + `.mli` | re-alias |
| `lib/prometheus_builtin_metrics_part4.ml` | registry `add` with description |
| `test/test_pool.ml` | zero-state literal updated |

## Why this site, not the other 4

`pool.ml` has 5 silent paths total. The eviction fiber is the only one inside a **live maintenance loop** — others are teardown tail or clock-gone fallback where silent absorption is correct:

| Site | Pattern | Verdict |
|------|---------|--------|
| L147 evict-iter shutdown | best-effort, normal eviction | keep |
| **L158 evict_expired_entries** | **maintenance fiber, looped silent fail** | **fix (this PR)** |
| L193 switch release shutdown | teardown tail | keep |
| L233-234 `Eio.Time.now` fallback | clock-gone teardown race (commented) | keep |
| L251/256 park-fail shutdown | cleanup tail | keep |

The eviction fiber is the only `with _ -> ()` sitting in a live maintenance loop where silent failure compounds across cycles.

## Cancel semantics

Cancellation is preserved by an explicit `Eio.Cancel.Cancelled _ as e -> raise e` re-raise before the counter/log path. This matches the convention in `Telemetry_observe.observe_or_fail` and `Keeper_tool_retry_state`.

## Workaround posture

This is **not** a workaround. The change converts an operator-invisible failure into an operator-visible one with a typed Prometheus counter. It does not suppress, dedupe, or string-classify — it surfaces.

If `masc_pool_evict_failure_total` ever increments non-zero in production, that is a real bug elsewhere (likely in `with_mu` lock acquisition or the `Host_map.map` body) and should be investigated; the counter is the signal, not the silencer.

## Verification

```
dune build --root . @check       # passes
dune build --root . test/test_pool.exe
_build/default/test/test_pool.exe  # 19/19 tests pass
```

Including the `stats type shape — zero state` test which validates the new field is initialized to 0.

## Touch points

- 9 files, +41 / -1 LoC
- No caller-side breakage (Pool.stats consumers are pool.ml and prometheus.ml only; both updated)
- No new dependency on the masc_http_client sub-lib (Printf.eprintf keeps it free of masc_log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>