### PR TITLE
fix(dashboard): RFC-0135 PR-7 action verb 라벨에 '하기' 접미사 (state noun vs verb 분리)

### DIFF
--- a/dashboard/src/components/keeper-action-panel.ts
+++ b/dashboard/src/components/keeper-action-panel.ts
@@ -179,7 +179,7 @@ function KeeperActionRow({ keeper }: { keeper: Keeper }) {
               disabled=${busy.value}
               onClick=${() => handle('boot')}
               title="기동: offline keeper 를 다시 시작합니다 (offline → running)"
-            >기동<//>`
+            >기동하기<//>`
           : null}
         ${vis.canPause
           ? html`<${ActionButton}
@@ -188,7 +188,7 @@ function KeeperActionRow({ keeper }: { keeper: Keeper }) {
               disabled=${busy.value}
               onClick=${() => handle('pause')}
               title="일시정지: 실행 중인 keeper 를 일시 멈춥니다 (running → paused, 현재 turn 은 정상 종료)"
-            >일시정지<//>`
+            >일시정지하기<//>`
           : null}
         ${vis.canResume
           ? html`<${ActionButton}
@@ -197,7 +197,7 @@ function KeeperActionRow({ keeper }: { keeper: Keeper }) {
               disabled=${busy.value}
               onClick=${() => handle('resume')}
               title="재개: 일시정지된 keeper 를 다시 실행합니다 (paused → running)"
-            >재개<//>`
+            >재개하기<//>`
           : null}
         ${vis.canWake && !vis.canBoot
           ? html`<${ActionButton}
@@ -215,7 +215,7 @@ function KeeperActionRow({ keeper }: { keeper: Keeper }) {
               disabled=${busy.value}
               onClick=${() => handle('shutdown')}
               title="종료: keeper 를 완전 종료합니다 (running/paused → offline, fiber + 리소스 정리)"
-            >종료<//>`
+            >종료하기<//>`
           : null}
       </div>
     </article>


### PR DESCRIPTION
## Why — RFC-0135 §3 완성

PR-6 (#16611, MERGED) 가 보조 \`<span>일시정지</span>\` 중복을 제거했지만 같은 한국어 어근이 phase badge (\"⏸ 일시정지\", **state**) 와 action button (\"일시정지\", **verb**) 양쪽에 그대로 등장. 운영자가 같은 단어가 *어떤 의미* 로 쓰였는지 위치/색/아이콘만으로 구별해야 했음.

## What

5 action verb 라벨에 한국어 동사형 어미 \"하기\" 추가:

| verb | before | after |
|---|---|---|
| boot | 기동 | **기동하기** |
| pause | 일시정지 | **일시정지하기** |
| resume | 재개 | **재개하기** |
| shutdown | 종료 | **종료하기** |
| wakeup | 깨우기 | 그대로 (이미 동사형) |

이제 동일 row 에서 \"⏸ 일시정지\" (badge, state) 와 \"일시정지하기\" (button, verb) 가 **서로 다른 한국어 어형** 으로 분리됨.

PR-6 의 tooltip 보강과 본 PR 의 \"하기\" 접미사가 함께 §1.2 (label collision) + §1.3 (verb 의미 미설명) 사용자 보고를 *완전 해소*.

## Scope

\`status-label.ts\` SSOT 함수 분리 (\`stateLabel\` vs \`actionLabel\`) 는 후속 PR 후보. 본 PR 은 \`keeper-action-panel.ts\` 의 inline 라벨만 변경하여 **narrow scope** 유지 (+4/-4 LoC).

## Verification

- \`pnpm typecheck\` PASS
- \`keeper-action-panel.test.ts\` 7/7 PASS
- \`pnpm lint\` 0 errors

## Workaround Rejection Bar

- [x] telemetry-as-fix 아님 — 라벨 시각 분리
- [x] string classifier 아님 — 동사형 어미 정착
- [x] N-of-M 아님 — 4 verb (boot/pause/resume/shutdown) 전부 동시 변경 (\"깨우기\" 는 이미 동사형)
- [x] catch-all 아님
- [x] cap/cooldown 아님

## Stack 위치

| RFC-0135 PR | 상태 |
|---|---|
| #16573 RFC body | Draft |
| #16576 PR-1 / #16593 PR-2 / #16600 PR-4 / **#16611 PR-6** | **MERGED** |
| #16606 PR-5 axis fix | Draft |
| **#TBD PR-7 verb suffix (본 PR, base=origin/main)** | **Draft** |
| PR-3 keeper-predicates.ts | not started |
| PR-8 backend effective_blocker | not started |
| PR-9 CI guard | not started |

## Status

**Draft** — agent PR. Ready 전환은 사용자 라벨 부착 (\`human-approved-ready\`).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>