### PR TITLE
refactor: split mcp eio join state tests

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -802,6 +802,7 @@
   test_autoresearch_knowledge
   test_mcp_server_eio
   test_mcp_server_eio_call_tool
+  test_mcp_server_eio_join_state
   test_code_navigation_eio
   test_backend
   test_room_eio
@@ -1025,6 +1026,7 @@
   test_autoresearch_knowledge
   test_mcp_server_eio
   test_mcp_server_eio_call_tool
+  test_mcp_server_eio_join_state
   test_code_navigation_eio
   test_backend
   test_room_eio

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -202,101 +202,6 @@ let find_mcp_tool_log_exn ~phase ~tool_name ~request_id entries =
       Alcotest.failf "MCP tool log missing phase=%s tool=%s request_id=%s"
         phase tool_name request_id
 
-let test_resolve_join_state_skips_read_only_lookup () =
-  let called = ref false in
-  let joined =
-    Masc_mcp.Mcp_server_eio_execute.resolve_join_state
-      ~room_initialized:true
-      ~join_required:false
-      ~agent_name:"codex"
-      ~base_path:"/tmp/masc-test-resolve-join"
-      ~check_join:(fun _candidate ->
-        called := true;
-        true)
-  in
-  Alcotest.(check bool) "lookup skipped" false !called;
-  Alcotest.(check bool) "read-only defaults false" false joined
-
-let test_resolve_join_state_checks_join_required_tools () =
-  let called = ref false in
-  let joined =
-    Masc_mcp.Mcp_server_eio_execute.resolve_join_state
-      ~room_initialized:true
-      ~join_required:true
-      ~agent_name:"codex"
-      ~base_path:"/tmp/masc-test-resolve-join"
-      ~check_join:(fun _candidate ->
-        called := true;
-        true)
-  in
-  Alcotest.(check bool) "lookup performed" true !called;
-  Alcotest.(check bool) "join result preserved" true joined
-
-let test_resolve_join_state_skips_unknown_agent () =
-  let called = ref false in
-  let joined =
-    Masc_mcp.Mcp_server_eio_execute.resolve_join_state
-      ~room_initialized:true
-      ~join_required:true
-      ~agent_name:"unknown"
-      ~base_path:"/tmp/masc-test-resolve-join"
-      ~check_join:(fun _candidate ->
-        called := true;
-        true)
-  in
-  Alcotest.(check bool) "unknown agent skipped" false !called;
-  Alcotest.(check bool) "unknown agent treated unjoined" false joined
-
-(* #10699 Family A — rotation alias (e.g. [nick0cave-happy-shark])
-   falls through to the canonical agent form
-   [keeper-<keeper_name>-agent] that [ensure_keeper_room_presence]
-   joined under at boot. *)
-let test_resolve_join_state_alias_resolves_to_canonical () =
-  let candidates = ref [] in
-  let joined =
-    Masc_mcp.Mcp_server_eio_execute.resolve_join_state
-      ~room_initialized:true
-      ~join_required:true
-      ~agent_name:"codex-happy-shark"
-      ~base_path:"/tmp/masc-test-resolve-join"
-      ~check_join:(fun candidate ->
-        candidates := candidate :: !candidates;
-        candidate = "keeper-codex-agent")
-  in
-  Alcotest.(check bool) "join recovered via canonical" true joined;
-  let recorded = List.rev !candidates in
-  Alcotest.(check bool) "raw alias attempted first"
-    true
-    (List.length recorded >= 1 && List.hd recorded = "codex-happy-shark");
-  Alcotest.(check bool) "canonical agent form considered"
-    true
-    (List.exists (String.equal "keeper-codex-agent") recorded)
-
-(* #10699 Family A — non-keeper input never invents a canonical match. *)
-let test_resolve_join_state_unknown_alias_stays_false () =
-  let joined =
-    Masc_mcp.Mcp_server_eio_execute.resolve_join_state
-      ~room_initialized:true
-      ~join_required:true
-      ~agent_name:"a-b"  (* < 3 parts, not a generated nickname *)
-      ~base_path:"/tmp/masc-test-resolve-join"
-      ~check_join:(fun _candidate -> false)
-  in
-  Alcotest.(check bool) "non-keeper input stays unjoined" false joined
-
-let test_should_read_legacy_persisted_agent_name () =
-  let should_read =
-    Masc_mcp.Mcp_server_eio_caller_identity
-    .should_read_legacy_persisted_agent_name
-  in
-  Alcotest.(check bool) "ephemeral fallback reads legacy state" true
-    (should_read ~has_explicit_agent_name:false ~agent_name:"agent-12345678");
-  Alcotest.(check bool) "stable nickname skips legacy read" false
-    (should_read ~has_explicit_agent_name:false
-       ~agent_name:"codex-swift-fox");
-  Alcotest.(check bool) "explicit agent name skips legacy read" false
-    (should_read ~has_explicit_agent_name:true ~agent_name:"agent-12345678")
-
 let rec collect_tools ~clock ~sw ?profile ?cursor state acc =
   let response = tools_list_response ~clock ~sw ?profile ?cursor state in
   let tools = tools_from_response response in
@@ -3102,16 +3007,6 @@ let state_tests = [
   "type compatibility", `Quick, test_type_compatibility;
   "eio context delegation", `Quick, test_eio_context_delegation;
   "eio context scoped restore", `Quick, test_eio_context_with_test_env_restores;
-  "resolve_join_state skips read-only lookup", `Quick,
-    test_resolve_join_state_skips_read_only_lookup;
-  "resolve_join_state checks join-required tools", `Quick,
-    test_resolve_join_state_checks_join_required_tools;
-  "resolve_join_state skips unknown agent", `Quick,
-    test_resolve_join_state_skips_unknown_agent;
-  "resolve_join_state alias resolves to canonical", `Quick,
-    test_resolve_join_state_alias_resolves_to_canonical;
-  "resolve_join_state unknown alias stays false", `Quick,
-    test_resolve_join_state_unknown_alias_stays_false;
 ]
 
 let protocol_tests = [
@@ -3215,8 +3110,6 @@ let eio_tests = [
   (* TRPG tool tests removed — modules archived *)
   (* Governance status tool test removed *)
   (* execution_session_step direct call test removed — team session cleanup *)
-  "legacy persisted agent read only for ephemeral names", `Quick,
-    test_should_read_legacy_persisted_agent_name;
   "explicit agent_name not overridden", `Quick, test_execute_tool_explicit_agent_name_not_overridden;
   "explicit alias reuses joined nickname", `Quick, test_execute_tool_explicit_alias_reuses_joined_nickname;
   "generated agent_name uses token identity", `Quick,

--- a/test/test_mcp_server_eio_join_state.ml
+++ b/test/test_mcp_server_eio_join_state.ml
@@ -1,0 +1,121 @@
+let test_resolve_join_state_skips_read_only_lookup () =
+  let called = ref false in
+  let joined =
+    Masc_mcp.Mcp_server_eio_execute.resolve_join_state
+      ~room_initialized:true
+      ~join_required:false
+      ~agent_name:"codex"
+      ~base_path:"/tmp/masc-test-resolve-join"
+      ~check_join:(fun _candidate ->
+        called := true;
+        true)
+  in
+  Alcotest.(check bool) "lookup skipped" false !called;
+  Alcotest.(check bool) "read-only defaults false" false joined
+
+let test_resolve_join_state_checks_join_required_tools () =
+  let called = ref false in
+  let joined =
+    Masc_mcp.Mcp_server_eio_execute.resolve_join_state
+      ~room_initialized:true
+      ~join_required:true
+      ~agent_name:"codex"
+      ~base_path:"/tmp/masc-test-resolve-join"
+      ~check_join:(fun _candidate ->
+        called := true;
+        true)
+  in
+  Alcotest.(check bool) "lookup performed" true !called;
+  Alcotest.(check bool) "join result preserved" true joined
+
+let test_resolve_join_state_skips_unknown_agent () =
+  let called = ref false in
+  let joined =
+    Masc_mcp.Mcp_server_eio_execute.resolve_join_state
+      ~room_initialized:true
+      ~join_required:true
+      ~agent_name:"unknown"
+      ~base_path:"/tmp/masc-test-resolve-join"
+      ~check_join:(fun _candidate ->
+        called := true;
+        true)
+  in
+  Alcotest.(check bool) "unknown agent skipped" false !called;
+  Alcotest.(check bool) "unknown agent treated unjoined" false joined
+
+let test_resolve_join_state_alias_resolves_to_canonical () =
+  let candidates = ref [] in
+  let joined =
+    Masc_mcp.Mcp_server_eio_execute.resolve_join_state
+      ~room_initialized:true
+      ~join_required:true
+      ~agent_name:"codex-happy-shark"
+      ~base_path:"/tmp/masc-test-resolve-join"
+      ~check_join:(fun candidate ->
+        candidates := candidate :: !candidates;
+        candidate = "keeper-codex-agent")
+  in
+  Alcotest.(check bool) "join recovered via canonical" true joined;
+  let recorded = List.rev !candidates in
+  Alcotest.(check bool)
+    "raw alias attempted first"
+    true
+    (List.length recorded >= 1 && List.hd recorded = "codex-happy-shark");
+  Alcotest.(check bool)
+    "canonical agent form considered"
+    true
+    (List.exists (String.equal "keeper-codex-agent") recorded)
+
+let test_resolve_join_state_unknown_alias_stays_false () =
+  let joined =
+    Masc_mcp.Mcp_server_eio_execute.resolve_join_state
+      ~room_initialized:true
+      ~join_required:true
+      ~agent_name:"a-b"
+      ~base_path:"/tmp/masc-test-resolve-join"
+      ~check_join:(fun _candidate -> false)
+  in
+  Alcotest.(check bool) "non-keeper input stays unjoined" false joined
+
+let test_should_read_legacy_persisted_agent_name () =
+  let should_read =
+    Masc_mcp.Mcp_server_eio_caller_identity
+    .should_read_legacy_persisted_agent_name
+  in
+  Alcotest.(check bool)
+    "ephemeral fallback reads legacy state"
+    true
+    (should_read ~has_explicit_agent_name:false ~agent_name:"agent-12345678");
+  Alcotest.(check bool)
+    "stable nickname skips legacy read"
+    false
+    (should_read ~has_explicit_agent_name:false ~agent_name:"codex-swift-fox");
+  Alcotest.(check bool)
+    "explicit agent name skips legacy read"
+    false
+    (should_read ~has_explicit_agent_name:true ~agent_name:"agent-12345678")
+
+let () =
+  Alcotest.run
+    "Mcp_server_eio_join_state"
+    [ ( "join_state"
+      , [ ( "resolve_join_state skips read-only lookup"
+          , `Quick
+          , test_resolve_join_state_skips_read_only_lookup )
+        ; ( "resolve_join_state checks join-required tools"
+          , `Quick
+          , test_resolve_join_state_checks_join_required_tools )
+        ; ( "resolve_join_state skips unknown agent"
+          , `Quick
+          , test_resolve_join_state_skips_unknown_agent )
+        ; ( "resolve_join_state alias resolves to canonical"
+          , `Quick
+          , test_resolve_join_state_alias_resolves_to_canonical )
+        ; ( "resolve_join_state unknown alias stays false"
+          , `Quick
+          , test_resolve_join_state_unknown_alias_stays_false )
+        ; ( "legacy persisted agent read only for ephemeral names"
+          , `Quick
+          , test_should_read_legacy_persisted_agent_name )
+        ] )
+    ]


### PR DESCRIPTION
## Summary
- move MCP Eio join-state and legacy persisted-agent decision checks into test_mcp_server_eio_join_state.ml
- register the new test binary in the Eio test stanza
- keep test_mcp_server_eio focused on protocol/tool execution coverage

## Validation
- ocamlformat --check test/test_mcp_server_eio.ml test/test_mcp_server_eio_join_state.ml
- git diff --check
- bash scripts/lint/godfile-size-regression.sh
- scripts/ocaml-structure-ratchet.sh
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_mcp_server_eio_join_state.exe (blocked: scripts/dune-local.sh refused due live bare Dune processes outside wrapper; CI is the compile surface)