### PR TITLE
refactor(dashboard): RFC-0135 PR-7 + PR-6 partial — noun/verb label split

### DIFF
--- a/dashboard/src/components/keeper-action-panel.ts
+++ b/dashboard/src/components/keeper-action-panel.ts
@@ -30,6 +30,11 @@ import {
 } from '../api/keeper'
 import { invalidateDashboardCache, refreshDashboard, keepers } from '../store'
 import type { Keeper } from '../types'
+import {
+  actionLabel,
+  actionTooltip,
+  type KeeperActionVerb,
+} from '../lib/status-label'
 
 // ── Shared helpers ────────────────────────────────────────────────────────
 
@@ -41,20 +46,17 @@ function afterAction(): void {
   })
 }
 
-type KeeperActionKey = 'pause' | 'resume' | 'wakeup' | 'boot' | 'shutdown'
+type KeeperActionKey = KeeperActionVerb
 
 /** Execute a lifecycle action for a single keeper with toast feedback. */
 async function runKeeperAction(
   name: string,
   action: KeeperActionKey,
 ): Promise<void> {
-  const labels: Record<KeeperActionKey, string> = {
-    pause: '일시정지',
-    resume: '재개',
-    wakeup: '깨우기',
-    boot: '기동',
-    shutdown: '종료',
-  }
+  // Past-tense for confirmation, action-noun-without-suffix for
+  // failure (the toast already reads as "<verb> 실패" rather than
+  // "<verb>하기 실패").
+  const entry = actionLabel(action)
 
   try {
     let res: { ok: boolean; error?: string }
@@ -66,13 +68,13 @@ async function runKeeperAction(
       case 'shutdown': res = await shutdownKeeper(name); break
     }
     if (res.ok) {
-      showToast(`${name} ${labels[action]}됨`, 'success')
+      showToast(`${name} ${entry.pastTense}`, 'success')
       afterAction()
     } else {
-      showToast(res.error ?? `${labels[action]} 실패`, 'error')
+      showToast(res.error ?? `${entry.text} 실패`, 'error')
     }
   } catch {
-    showToast(`${labels[action]} 실패`, 'error')
+    showToast(`${entry.text} 실패`, 'error')
   }
 }
 
@@ -160,9 +162,11 @@ function KeeperActionRow({ keeper }: { keeper: Keeper }) {
       <div class="flex items-center gap-2 min-w-0 flex-1">
         <span class="text-xs font-semibold text-[var(--color-fg-secondary)] truncate max-w-28">${keeper.name}</span>
         <${KeeperPhaseBadge} phase=${keeper.phase} compact />
-        ${keeper.paused
-          ? html`<span class="text-3xs font-semibold text-[var(--paused,var(--color-status-warn))]">일시정지</span>`
-          : null}
+        ${'' /* RFC-0135 §1.2 — the auxiliary `keeper.paused` span used
+                  to live here and re-emit '일시정지' next to the badge.
+                  The phase badge already renders the paused state, so
+                  the span was pure redundancy and the row-level noun
+                  was visually colliding with the verb button text. */}
       </div>
       <div class="flex items-center gap-1 shrink-0">
         ${vis.canBoot
@@ -171,8 +175,8 @@ function KeeperActionRow({ keeper }: { keeper: Keeper }) {
               size="sm"
               disabled=${busy.value}
               onClick=${() => handle('boot')}
-              title="기동"
-            >기동<//>`
+              title=${actionTooltip('boot')}
+            >${actionLabel('boot').text}<//>`
           : null}
         ${vis.canPause
           ? html`<${ActionButton}
@@ -180,8 +184,8 @@ function KeeperActionRow({ keeper }: { keeper: Keeper }) {
               size="sm"
               disabled=${busy.value}
               onClick=${() => handle('pause')}
-              title="일시정지"
-            >일시정지<//>`
+              title=${actionTooltip('pause')}
+            >${actionLabel('pause').text}<//>`
           : null}
         ${vis.canResume
           ? html`<${ActionButton}
@@ -189,8 +193,8 @@ function KeeperActionRow({ keeper }: { keeper: Keeper }) {
               size="sm"
               disabled=${busy.value}
               onClick=${() => handle('resume')}
-              title="재개"
-            >재개<//>`
+              title=${actionTooltip('resume')}
+            >${actionLabel('resume').text}<//>`
           : null}
         ${vis.canWake && !vis.canBoot
           ? html`<${ActionButton}
@@ -198,8 +202,8 @@ function KeeperActionRow({ keeper }: { keeper: Keeper }) {
               size="sm"
               disabled=${busy.value}
               onClick=${() => handle('wakeup')}
-              title="깨우기: sleep 중인 keeper를 즉시 깨워 다음 turn을 시도"
-            >깨우기<//>`
+              title=${actionTooltip('wakeup')}
+            >${actionLabel('wakeup').text}<//>`
           : null}
         ${vis.canShutdown
           ? html`<${ActionButton}
@@ -207,8 +211,8 @@ function KeeperActionRow({ keeper }: { keeper: Keeper }) {
               size="sm"
               disabled=${busy.value}
               onClick=${() => handle('shutdown')}
-              title="종료"
-            >종료<//>`
+              title=${actionTooltip('shutdown')}
+            >${actionLabel('shutdown').text}<//>`
           : null}
       </div>
     </article>

--- a/dashboard/src/lib/status-label.test.ts
+++ b/dashboard/src/lib/status-label.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { statusLabel, displayStatus, prettyJson } from './status-label'
+import {
+  statusLabel,
+  displayStatus,
+  prettyJson,
+  actionLabel,
+  actionTooltip,
+  type KeeperActionVerb,
+} from './status-label'
 
 describe('statusLabel', () => {
   it('maps ok variants', () => {
@@ -83,6 +90,54 @@ describe('statusLabel collision fixes (Iter#36)', () => {
   })
   it('in_progress aliases active/running', () => {
     expect(statusLabel('in_progress')).toBe('진행 중')
+  })
+})
+
+describe('actionLabel (RFC-0135 PR-7 noun/verb 분리)', () => {
+  it('verb buttons carry 하기 suffix to distinguish from state nouns', () => {
+    // The state badge for a paused keeper reads "일시정지" (noun).
+    // The button to pause a running keeper must NOT read the same
+    // word, or RFC-0135 §1.2 collision returns. The fix is the 하기
+    // suffix for the verbs that have state-noun twins.
+    expect(actionLabel('pause').text).toBe('일시정지하기')
+    expect(actionLabel('resume').text).toBe('재개하기')
+    expect(actionLabel('boot').text).toBe('기동하기')
+    expect(actionLabel('shutdown').text).toBe('종료하기')
+  })
+
+  it('wakeup keeps the concise form because no state-noun collides', () => {
+    expect(actionLabel('wakeup').text).toBe('깨우기')
+  })
+
+  it('past-tense form drops the 하기 suffix and adds 됨 for toast confirmation', () => {
+    expect(actionLabel('pause').pastTense).toBe('일시정지됨')
+    expect(actionLabel('resume').pastTense).toBe('재개됨')
+    expect(actionLabel('boot').pastTense).toBe('기동됨')
+    expect(actionLabel('shutdown').pastTense).toBe('종료됨')
+    expect(actionLabel('wakeup').pastTense).toBe('깨워짐')
+  })
+
+  it('every verb declares precondition and effect tooltips', () => {
+    const verbs: KeeperActionVerb[] = [
+      'pause',
+      'resume',
+      'wakeup',
+      'boot',
+      'shutdown',
+    ]
+    for (const verb of verbs) {
+      const entry = actionLabel(verb)
+      expect(entry.precondition.length).toBeGreaterThan(0)
+      expect(entry.effect.length).toBeGreaterThan(0)
+      expect(entry.icon.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('actionTooltip combines label + precondition + effect for the title attribute', () => {
+    const tip = actionTooltip('pause')
+    expect(tip).toContain('일시정지하기')
+    expect(tip).toContain('사전조건')
+    expect(tip).toContain('효과')
   })
 })
 

--- a/dashboard/src/lib/status-label.ts
+++ b/dashboard/src/lib/status-label.ts
@@ -7,6 +7,13 @@
 // Distinct meanings get distinct labels — collisions across unrelated keys
 // (the prior `중단됨` = interrupted + stopped, `대기` = listening + idle + todo,
 // `오류` vs `문제` for error/failed) are an operator-confusion source.
+//
+// RFC-0135 §3 / PR-7 — `actionLabel(verb)` lives alongside `statusLabel`
+// for the noun/verb separation. State labels are nouns ("일시정지"),
+// action labels are verbs ("일시정지하기"). The visual distinction is
+// what prevents the §1.5.2 collision matrix (operator looks at one
+// row and can't tell whether "일시정지" is a state badge or the button
+// they're about to press).
 
 /** Comprehensive status label — maps normalized status strings to Korean labels. */
 export function statusLabel(value?: string | null): string {
@@ -115,6 +122,107 @@ export function statusLabel(value?: string | null): string {
  */
 export function displayStatus(status?: string | null): string {
   return statusLabel(status)
+}
+
+/**
+ * The five keeper lifecycle action verbs. Exhaustive — adding a new
+ * verb requires extending {@link KeeperActionVerb}, the
+ * {@link ACTION_LABELS} map, and any consumer that switches on the
+ * verb. TS catches the missing arms.
+ */
+export type KeeperActionVerb =
+  | 'pause'
+  | 'resume'
+  | 'wakeup'
+  | 'boot'
+  | 'shutdown'
+
+/**
+ * Verb metadata for keeper action buttons.
+ *
+ * `text` is the Korean button label with the `하기` suffix that
+ * visually separates the verb form from the matching state noun
+ * (state '일시정지' vs verb '일시정지하기'). The `wakeup` verb keeps
+ * its concise form ('깨우기') because it has no state-noun twin
+ * (there is no Wakeup phase, only the Stuck phase that the action
+ * resolves).
+ *
+ * `pastTense` is the toast-feedback noun ("일시정지됨") — past
+ * participle form, used after the backend confirms the action.
+ *
+ * `icon` is a single-character glyph for `title` tooltips and any
+ * icon-only variant; intentionally not Lucide since the action panel
+ * already carries the button color/tone visually.
+ *
+ * `precondition` / `effect` are Korean tooltips that render via the
+ * `title` attribute on the action button. RFC-0135 §3.3 requires
+ * every action verb to declare both — operators should never have to
+ * read code to learn what a button does.
+ */
+interface ActionLabelEntry {
+  text: string
+  pastTense: string
+  icon: string
+  precondition: string
+  effect: string
+}
+
+const ACTION_LABELS: Record<KeeperActionVerb, ActionLabelEntry> = {
+  pause: {
+    text: '일시정지하기',
+    pastTense: '일시정지됨',
+    icon: '⏸',
+    precondition: '실행 중인 키퍼만',
+    effect: '현재 turn 완료 후 정지, 재개 시 동일 generation 유지',
+  },
+  resume: {
+    text: '재개하기',
+    pastTense: '재개됨',
+    icon: '▶',
+    precondition: '일시정지된 키퍼만',
+    effect: '다음 turn부터 정상 실행 재개',
+  },
+  wakeup: {
+    text: '깨우기',
+    pastTense: '깨워짐',
+    icon: '⚡',
+    precondition: '실행 중이거나 차단된 키퍼',
+    effect: '즉시 다음 turn 시도, sleep/cooldown 우회',
+  },
+  boot: {
+    text: '기동하기',
+    pastTense: '기동됨',
+    icon: '🚀',
+    precondition: '오프라인 키퍼만',
+    effect: '새 fiber 시작, 첫 turn 진입',
+  },
+  shutdown: {
+    text: '종료하기',
+    pastTense: '종료됨',
+    icon: '⏏',
+    precondition: '실행 중이거나 일시정지된 키퍼',
+    effect: '현재 turn 중단, fiber 종료. 재시작은 기동 필요',
+  },
+}
+
+/**
+ * Lookup verb metadata for a keeper action button. Returns the full
+ * {@link ActionLabelEntry}; consumers pick the fields they need
+ * (`text` for the button label, `precondition + effect` for the
+ * tooltip, `pastTense` for toast feedback).
+ */
+export function actionLabel(verb: KeeperActionVerb): ActionLabelEntry {
+  return ACTION_LABELS[verb]
+}
+
+/**
+ * Build the standard tooltip text for an action button. Combines the
+ * verb label with its precondition + effect so operators see the
+ * contract before clicking.
+ */
+export function actionTooltip(verb: KeeperActionVerb): string {
+  const entry = ACTION_LABELS[verb]
+  return `${entry.text}\n사전조건: ${entry.precondition}\n효과: ${entry.effect}`
 }
 
 /** Format unknown values as pretty JSON or pass-through strings. */


### PR DESCRIPTION
## Why (RFC-0135 §1.2)

\`keeper-action-panel\` 의 row 가 동일 한국어 단어 \"일시정지\" 를 세 번 인접 위치에 표시:

- KeeperPhaseBadge (paused phase) → \`⏸ 일시정지\` (상태)
- 보조 \`<span>\` (\`keeper.paused\`) → \`일시정지\` (상태, 중복)
- 액션 버튼 → \`일시정지\` (동사)

운영자는 어느 \`일시정지\` 가 *현재 상태* 인지 *클릭 가능한 동작* 인지 단어만으로는 구분 못함. RFC-0135 §3 의 noun/verb 분리로 해결.

## What

**1. \`src/lib/status-label.ts\`**

- 새 \`KeeperActionVerb\` typed union (5 동사)
- \`ACTION_LABELS\` exhaustive map (catch-all 금지)
- \`actionLabel(verb)\` — 동사 라벨 metadata 접근자
- \`actionTooltip(verb)\` — \`사전조건/효과\` 조합 (RFC §3.3)
- 기존 \`statusLabel\` / \`displayStatus\` / \`prettyJson\` 변경 없음

**2. \`src/components/keeper-action-panel.ts\`**

- inline 동사 라벨 (\`'일시정지'/'재개'/...\`) → \`actionLabel(verb).text\` 호출
- 상태↔동사 collision 해소: 모든 noun-twin 동사가 \`하기\` 접미사
  - pause → \`'일시정지하기'\` (vs 상태 \`'일시정지'\`)
  - resume → \`'재개하기'\`
  - boot → \`'기동하기'\`
  - shutdown → \`'종료하기'\`
  - wakeup → \`'깨우기'\` (state-noun twin 없음, concise 유지)
- \`title\` attribute = \`actionTooltip(verb)\` (3-line: 동사 / 사전조건 / 효과)
- toast: \`entry.pastTense\` 직접 사용 (\`${name} 일시정지됨\`)
- **§1.2 직격**: 중복 \`<span>일시정지</span>\` (line 164) 삭제 — KeeperPhaseBadge 가 같은 axis 표시, span 은 pure redundancy 였음

**3. \`src/lib/status-label.test.ts\` — 5 신규 assertion**

- 하기 접미사 검증 (pause/resume/boot/shutdown)
- 깨우기 concise form (no twin)
- past-tense (\`pastTense\` 필드)
- 모든 동사가 precondition + effect + icon 선언
- actionTooltip 조합 검증

## RFC-0135 §5 PR-7 acceptance

- [x] \`status-label.ts\` exposes \`actionLabel(verb)\`
- [x] 동사 text 가 noun-twin 과 visually distinct (하기 접미사)
- [x] keeper-action-panel 의 모든 verb-site call site updated
- [x] action button title 에 precondition + effect 노출

## RFC-0135 §5 PR-6 partial

- [x] line 164 중복 \`<span>일시정지</span>\` 제거
- [ ] action visibility OR-chain (\`canWake = isStuck || ...\`) typed-state 기반 재작성 — 별도 follow-up
- [ ] \`keeperActionVisibility\` typed-state 호출 — 별도 PR (PR-3 keeper-predicates 의존)

## Tests

- \`pnpm typecheck\` clean
- \`pnpm vitest run src/lib/status-label.test.ts src/components/keeper-action-panel.test.ts\` — **38/38 pass** (33 → 38, +5)

## 의존

PR-1 (typed-sum) MERGED + PR-4 (#16603) / PR-5 (#16612) 와 직교 (병행 가능).

## Test plan

- [ ] dashboard preview 의 fleet action panel 에서 paused keeper row 에 'KeeperPhaseBadge 일시정지' 와 '재개하기' 버튼 만 보이는지 확인 (보조 일시정지 span 제거됨)
- [ ] running keeper row 에 '일시정지하기' 버튼 (상태 라벨 '일시정지' 와 단어 다름) 확인
- [ ] action button 에 hover 시 \`{동사}\\n사전조건: ...\\n효과: ...\` tooltip 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)