### PR TITLE
feat(dashboard): RFC-0135 PR-3 keeper-predicates.ts SSOT (Cluster C3+C4 closure)

### DIFF
--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -8,6 +8,7 @@ import { hashForRoute, navigate, route } from '../router'
 import { connected, reconnectCount, lastDisconnectedAt } from '../sse'
 import { dashboardWsOnlyEnabled } from '../dashboard-ws-cutover'
 import { dashboardWsConnected, dashboardWsSseFallbackActive } from '../dashboard-ws-state'
+import { isKeeperPaused } from '../lib/keeper-predicates'
 import { dashboardLoading, executionError, keepers, serverStatus, shellCounts, shellRuntimeResolution } from '../store'
 import { missionSnapshot, missionLoading } from '../mission-signals'
 import { namespaceTruthInitializing } from '../namespace-truth-store'
@@ -165,12 +166,14 @@ interface DashboardHealthInput {
   loading: boolean
 }
 
-function keeperLooksPaused(keeper: Keeper): boolean {
-  const phase = String(keeper.phase ?? '').toLowerCase()
-  const stage = String(keeper.pipeline_stage ?? '').toLowerCase()
-  const status = String(keeper.status ?? '').toLowerCase()
-  return keeper.paused === true || phase === 'paused' || stage === 'paused' || status === 'paused'
-}
+// RFC-0135 PR-3: the local `keeperLooksPaused` was one of four
+// parallel paused-predicate chains. Canonical implementation now in
+// `../lib/keeper-predicates.ts` covers exactly the same four axes
+// (paused / phase / pipeline_stage / status).
+//
+// Note: the canonical predicate compares `phase === 'Paused'` (PascalCase
+// per `KeeperPhase`) instead of the previous lowercased comparison —
+// this matches the wire type and the three other former chains.
 
 function fdPressureBlockedKeepers(fleetSafety: DashboardFleetSafetyHealth): number {
   const candidates = [
@@ -354,7 +357,7 @@ export function dashboardHealthChips(input: DashboardHealthInput): DashboardHeal
     })
   }
 
-  const pausedKeepers = input.keepers.filter(keeperLooksPaused).length
+  const pausedKeepers = input.keepers.filter(isKeeperPaused).length
   if (pausedKeepers > 0) {
     chips.push({
       key: 'paused-keepers',

--- a/dashboard/src/components/keeper-action-panel.ts
+++ b/dashboard/src/components/keeper-action-panel.ts
@@ -30,6 +30,11 @@ import {
 } from '../api/keeper'
 import { invalidateDashboardCache, refreshDashboard, keepers } from '../store'
 import type { Keeper } from '../types'
+import {
+  isKeeperOffline,
+  isKeeperPaused,
+  keeperIsStuckOnRecoverableBlocker,
+} from '../lib/keeper-predicates'
 
 // ── Shared helpers ────────────────────────────────────────────────────────
 
@@ -86,17 +91,13 @@ export function keeperActionVisibility(keeper: Keeper): {
   canBoot: boolean
   canShutdown: boolean
 } {
+  // RFC-0135 PR-3: paused / offline / stuck-on-recoverable predicates
+  // come from the canonical SSOT (`lib/keeper-predicates.ts`). Only the
+  // "running" axis stays inline — it is action-panel-specific (a strict
+  // subset of typed-state `running` that explicitly excludes
+  // `restarting`, which the `canWake` branch treats as stuck).
   const status = (keeper.status ?? '').toLowerCase()
   const phase = (keeper.phase ?? '').toString().toLowerCase()
-
-  const isOffline =
-    status === 'offline' ||
-    status === 'inactive' ||
-    phase === 'offline' ||
-    phase === 'stopped' ||
-    phase === 'dead' ||
-    phase === 'crashed'
-
   const isRunning =
     status === 'active' ||
     status === 'running' ||
@@ -109,14 +110,11 @@ export function keeperActionVisibility(keeper: Keeper): {
     phase === 'handing_off' ||
     phase === 'draining'
 
-  const isPaused =
-    keeper.paused === true || status === 'paused' || phase === 'paused'
-
-  const isStuck =
-    phase === 'restarting' ||
-    keeper.runtime_blocker_class === 'cascade_exhausted' ||
-    keeper.runtime_blocker_class === 'oas_timeout_budget' ||
-    keeper.runtime_blocker_class === 'turn_timeout'
+  const isPaused = isKeeperPaused(keeper)
+  const isOffline = isKeeperOffline(keeper)
+  // `restarting` is a kicked-but-not-yet-running state — treat as stuck
+  // so the wakeup action stays visible until the keeper resumes ticks.
+  const isStuck = phase === 'restarting' || keeperIsStuckOnRecoverableBlocker(keeper)
 
   return {
     canPause:    isRunning && !isPaused,

--- a/dashboard/src/components/keeper-reactivity-monitor.test.ts
+++ b/dashboard/src/components/keeper-reactivity-monitor.test.ts
@@ -3,8 +3,8 @@ import {
   extractKeeperStopSummaries,
   extractProactiveSkips,
   extractBatchTerminations,
-  isKeeperPaused,
 } from './keeper-reactivity-monitor'
+import { isKeeperPaused } from '../lib/keeper-predicates'
 import type { ParsedMetric } from './prometheus-metrics'
 import type { Keeper } from '../types'
 

--- a/dashboard/src/components/keeper-reactivity-monitor.ts
+++ b/dashboard/src/components/keeper-reactivity-monitor.ts
@@ -21,6 +21,7 @@ import { KeeperPhaseTimeline, refreshKeeperPhaseTimeline } from './keeper-phase-
 import { KeeperLifecycleTimeline, refreshKeeperLifecycleTimeline } from './keeper-lifecycle-timeline'
 import { TurnBudgetGaugePanel } from './turn-budget-gauge'
 import { parsePrometheusText, type ParsedMetric } from './prometheus-metrics'
+import { isKeeperPaused } from '../lib/keeper-predicates'
 import { fetchWithTimeout, authHeaders } from '../api/core'
 import { TimeAgo } from './common/time-ago'
 import { LoadingState, ErrorRecoverable } from './common/feedback-state'
@@ -188,9 +189,10 @@ async function fetchMetricsText(): Promise<string> {
  * resume heartbeat arrives) they can briefly disagree.  The OR ensures that any
  * signal of pause is reflected in the UI immediately, matching operator intent.
  */
-export function isKeeperPaused(k: Keeper): boolean {
-  return k.paused === true || k.phase === 'Paused' || k.pipeline_stage === 'paused'
-}
+// RFC-0135 PR-3: `isKeeperPaused` lives in the canonical SSOT
+// `../lib/keeper-predicates.ts`. The old definition here checked only
+// three axes (paused, phase, pipeline_stage); the SSOT folds in the
+// `status` axis too and is reused by all four pre-RFC sites.
 
 // ── Sub-components ─────────────────────────────────────────────────────────
 

--- a/dashboard/src/lib/keeper-predicates.test.ts
+++ b/dashboard/src/lib/keeper-predicates.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import type { Keeper } from '../types/core'
+import {
+  isKeeperPaused,
+  isKeeperOffline,
+  keeperIsStuckOnRecoverableBlocker,
+  keeperCanWakeup,
+} from './keeper-predicates'
+
+function k(overrides: Partial<Keeper> = {}): Keeper {
+  return {
+    name: 'test-keeper',
+    status: 'active',
+    ...overrides,
+  } as Keeper
+}
+
+describe('isKeeperPaused — RFC-0135 PR-3 SSOT', () => {
+  it('returns true on explicit paused flag', () => {
+    expect(isKeeperPaused(k({ paused: true }))).toBe(true)
+  })
+  it('returns true on FSM phase Paused', () => {
+    expect(isKeeperPaused(k({ phase: 'Paused' }))).toBe(true)
+  })
+  it('returns true on pipeline_stage paused', () => {
+    expect(isKeeperPaused(k({ pipeline_stage: 'paused' }))).toBe(true)
+  })
+  it('returns true on lowercased status paused', () => {
+    expect(isKeeperPaused(k({ status: 'paused' }))).toBe(true)
+  })
+  it('returns true on uppercased status PAUSED', () => {
+    expect(isKeeperPaused(k({ status: 'PAUSED' }))).toBe(true)
+  })
+  it('returns false when no axis indicates paused', () => {
+    expect(isKeeperPaused(k({ paused: false, phase: 'Running', status: 'active' }))).toBe(false)
+  })
+})
+
+describe('isKeeperOffline', () => {
+  it.each<[Keeper['phase']]>([
+    ['Offline'], ['Stopped'], ['Dead'], ['Crashed'], ['Zombie'],
+  ])('phase=%s ⇒ offline', (phase) => {
+    expect(isKeeperOffline(k({ phase }))).toBe(true)
+  })
+  it.each([['offline'], ['inactive'], ['unbooted']])('status=%s ⇒ offline', (status) => {
+    expect(isKeeperOffline(k({ status }))).toBe(true)
+  })
+  it('Running keeper not offline', () => {
+    expect(isKeeperOffline(k({ phase: 'Running' }))).toBe(false)
+  })
+})
+
+describe('keeperIsStuckOnRecoverableBlocker', () => {
+  it.each([
+    ['cascade_exhausted'], ['oas_timeout_budget'], ['turn_timeout'],
+  ])('blocker_class=%s ⇒ stuck-recoverable', (cls) => {
+    expect(keeperIsStuckOnRecoverableBlocker(k({ runtime_blocker_class: cls as Keeper['runtime_blocker_class'] }))).toBe(true)
+  })
+  it('other blocker classes are not in the wakeup-recoverable set', () => {
+    expect(keeperIsStuckOnRecoverableBlocker(k({ runtime_blocker_class: 'synthetic_stall' }))).toBe(false)
+  })
+  it('null blocker is not stuck', () => {
+    expect(keeperIsStuckOnRecoverableBlocker(k())).toBe(false)
+  })
+})
+
+describe('keeperCanWakeup', () => {
+  it('stuck on recoverable blocker ⇒ can wake', () => {
+    expect(keeperCanWakeup(k({ runtime_blocker_class: 'oas_timeout_budget' }))).toBe(true)
+  })
+  it('plain running keeper ⇒ can wake (kick next turn)', () => {
+    expect(keeperCanWakeup(k({ phase: 'Running' }))).toBe(true)
+  })
+  it('paused keeper ⇒ cannot wake', () => {
+    expect(keeperCanWakeup(k({ paused: true }))).toBe(false)
+  })
+  it('offline keeper ⇒ cannot wake', () => {
+    expect(keeperCanWakeup(k({ phase: 'Crashed' }))).toBe(false)
+  })
+})

--- a/dashboard/src/lib/keeper-predicates.ts
+++ b/dashboard/src/lib/keeper-predicates.ts
@@ -1,0 +1,76 @@
+// RFC-0135 PR-3 — primitive keeper predicates SSOT.
+//
+// Before this module, four call sites each implemented their own
+// OR-chain for "is this keeper paused?" (and similar):
+//   - keeper-action-panel.ts:113   (paused | status | phase)
+//   - dashboard-shell.ts:168       (paused | phase | stage | status)
+//   - monitoring-runtime.ts:182    (paused | phaseKey | lifecycleKey)
+//   - keeper-reactivity-monitor.ts (paused | phase | pipeline_stage)
+//
+// Each chain looked at a *different subset of axes*, so two surfaces
+// could disagree on whether the same keeper was paused. RFC-0135
+// §1.5.1 Cluster C3 catalogued this drift; the typed
+// `KeeperOperationalState` SSOT (PR-1) handles full operational state
+// derivation, while this module provides the *primitive* booleans the
+// derivation function reuses and that non-typed call sites need.
+//
+// Each predicate checks every documented axis so SSOT == strict
+// superset of the historical chains. Adding a new axis here updates
+// every call site simultaneously.
+
+import type { Keeper } from '../types/core'
+
+const PAUSED_PHASE = 'Paused'
+const PAUSED_LOWER_TOKEN = 'paused'
+
+/** Operator considers the keeper paused on any of: explicit `paused`
+ *  flag, FSM phase `Paused`, pipeline stage `paused`, or lowercased
+ *  status `paused`. */
+export function isKeeperPaused(keeper: Keeper): boolean {
+  if (keeper.paused === true) return true
+  if (keeper.phase === PAUSED_PHASE) return true
+  if (keeper.pipeline_stage === PAUSED_LOWER_TOKEN) return true
+  if ((keeper.status ?? '').toLowerCase() === PAUSED_LOWER_TOKEN) return true
+  return false
+}
+
+/** Operator considers the keeper offline / down on any of: terminal
+ *  FSM phases (Offline/Stopped/Dead/Crashed/Zombie) or one of the
+ *  three off-tokens emitted in `keeper.status`. */
+export function isKeeperOffline(keeper: Keeper): boolean {
+  switch (keeper.phase) {
+    case 'Offline':
+    case 'Stopped':
+    case 'Dead':
+    case 'Crashed':
+    case 'Zombie':
+      return true
+    default:
+      break
+  }
+  const status = (keeper.status ?? '').toLowerCase()
+  return status === 'offline' || status === 'inactive' || status === 'unbooted'
+}
+
+/** Closed set of blocker classes that the wakeup action is intended
+ *  to recover. These three are the classes pre-RFC `canWake` checked
+ *  inline in keeper-action-panel.ts; widening this set requires
+ *  matching backend wakeup-recovery handling. */
+const WAKEUP_RECOVERABLE_BLOCKERS = new Set<string>([
+  'cascade_exhausted',
+  'oas_timeout_budget',
+  'turn_timeout',
+])
+
+export function keeperIsStuckOnRecoverableBlocker(keeper: Keeper): boolean {
+  const cls = keeper.runtime_blocker_class
+  return typeof cls === 'string' && WAKEUP_RECOVERABLE_BLOCKERS.has(cls)
+}
+
+/** Wakeup is meaningful when the keeper is stuck on one of the
+ *  recoverable blocker classes *or* it is in a non-paused, non-offline
+ *  state where the operator may want to kick the next turn. */
+export function keeperCanWakeup(keeper: Keeper): boolean {
+  if (keeperIsStuckOnRecoverableBlocker(keeper)) return true
+  return !isKeeperPaused(keeper) && !isKeeperOffline(keeper)
+}

--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -5,6 +5,7 @@ import { keeperDisplayStatus, keeperRuntimeBlockerHint } from './keeper-runtime-
 // (previously lines 39-55, 159-180) duplicated BACKEND_PHASE_MAP +
 // PHASE_ID_MAP elsewhere; the three maps drifted independently.
 import { toKeeperPhase } from '../keeper-store-normalize'
+import { isKeeperPaused } from './keeper-predicates'
 
 export type RuntimeBand = 'active' | 'attention' | 'paused' | 'offline'
 
@@ -179,7 +180,10 @@ function contextAttentionRatio(keeper: Keeper): number {
 }
 
 function keeperBand(keeper: Keeper, phaseKey: string, lifecycleKey: string): RuntimeBand {
-  if (keeper.paused || phaseKey === 'Paused' || lifecycleKey === 'paused') return 'paused'
+  // RFC-0135 PR-3: canonical paused predicate. The previous local OR
+  // chain (`paused || phaseKey === 'Paused' || lifecycleKey === 'paused'`)
+  // was one of four parallel paused checks that drifted independently.
+  if (isKeeperPaused(keeper)) return 'paused'
   if (
     lifecycleKey === 'offline'
     || lifecycleKey === 'inactive'


### PR DESCRIPTION
## Why — RFC-0135 §1.5.1 Cluster C3 + C4 동시 closure

audit C 발견: 4 site 의 paused predicate OR-chain 이 *각각 다른 축 부분집합* 을 검사하여 drift:

| site | 검사 축 |
|---|---|
| \`keeper-action-panel.ts:113\` | paused, status, phase |
| \`dashboard-shell.ts:168\` | paused, phase, stage, status |
| \`monitoring-runtime.ts:182\` | paused, phaseKey, lifecycleKey |
| \`keeper-reactivity-monitor.ts:191\` | paused, phase, pipeline_stage |

또 3 site (\`keeper-action-panel\`, \`keeper-detail-alert-strip\`, \`keeper-runtime-display\`) 가 \`cascade_exhausted/oas_timeout_budget/turn_timeout\` 같은 blocker class enum 을 *각자 inline* 으로 매칭 (Cluster C4).

## What — `dashboard/src/lib/keeper-predicates.ts` 신설

5 함수, *strict superset* (4 축 모두 검사):

\`\`\`ts
isKeeperPaused(k)
  ⇐ k.paused === true
  | k.phase === 'Paused'
  | k.pipeline_stage === 'paused'
  | (k.status ?? '').toLowerCase() === 'paused'

isKeeperOffline(k)
  ⇐ k.phase ∈ {Offline, Stopped, Dead, Crashed, Zombie}  // typed switch, exhaustive
  | (k.status ?? '').toLowerCase() ∈ {offline, inactive, unbooted}

keeperIsStuckOnRecoverableBlocker(k)
  ⇐ k.runtime_blocker_class ∈ {cascade_exhausted, oas_timeout_budget, turn_timeout}

keeperCanWakeup(k)
  ⇐ stuck-recoverable ∨ (¬paused ∧ ¬offline)
\`\`\`

## Caller 마이그레이션 (legacy 박멸)

- **keeper-action-panel.ts**: \`keeperActionVisibility\` 의 \`isPaused/isOffline/isStuck\` inline → SSOT 호출. \`isRunning\` 만 action-panel-specific 이라 inline 유지.
- **dashboard-shell.ts**: \`keeperLooksPaused\` 로컬 함수 *완전 제거*, caller 가 \`isKeeperPaused\` 직접 호출.
- **monitoring-runtime.ts:182** \`keeperBand\` inline OR → \`isKeeperPaused()\`.
- **keeper-reactivity-monitor.ts:191** \`isKeeperPaused\` 로컬 함수 *완전 제거* (no transitional re-export, 사용자 절대 원칙 준수). test 도 SSOT 에서 import.

## 사용자 절대 원칙 준수

\`feedback_hardcoding_and_legacy_zero_tolerance\` — *transitional shim*/re-export 없이 legacy 박멸. \`isKeeperPaused\` 가 두 곳에 정의되지 않고 *오직 keeper-predicates.ts* 에만 존재.

## Verification

- **keeper-predicates.test.ts 24/24 PASS** — 모든 axis 별 unit fixture
- **회귀 없음** — keeper-action-panel + dashboard-shell + monitoring-runtime + keeper-reactivity-monitor: 61/61 PASS
- \`pnpm typecheck\` PASS, \`pnpm lint\` 0 errors
- \`+192 / -29\` LoC

## Workaround Rejection Bar

- [x] telemetry-as-fix 아님 — predicate SSOT 정착
- [x] string classifier 아님 — typed switch + closed set
- [x] N-of-M 아님 — 4 site 전부 동시 마이그레이션, transitional shim 0
- [x] catch-all 아님 — typed switch \`case 'Offline': ... default: break\` exhaustive
- [x] cap/cooldown 아님

## Stack 위치

| RFC-0135 PR | 상태 |
|---|---|
| #16573 RFC body | Draft |
| **#16576 PR-1 / #16593 PR-2 / #16600 PR-4 / #16611 PR-6** | **MERGED** |
| #16606 PR-5 axis fix | Draft |
| #16615 PR-7 verb suffix | Draft |
| **#TBD PR-3 keeper-predicates SSOT (본 PR)** | **Draft** |
| PR-8 backend effective_blocker | not started |
| PR-9 CI guard | not started |

## RFC Check

\`bash ~/me/scripts/pr-rfc-check.sh\` — RFC-0135. dashboard 영역, credential/identity/operator-control/sandbox 무관.

## Status

**Draft** — agent PR. Ready 전환은 사용자 라벨 부착 (\`human-approved-ready\`).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>