### PR TITLE
refactor(dashboard): Phase 4 — [SYNTHETIC] surface scope tag + tooltip

### DIFF
--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -20,6 +20,35 @@ import {
 import { keeperNeedsDiagnosticAttention, refreshAfterRuntimeAction } from './keeper-detail-helpers'
 import { pauseKeeper, resumeKeeper, wakeKeeper } from '../api/keeper'
 import { showToast } from './common/toast'
+import {
+  SYNTHETIC_SCOPE_LABEL,
+  SYNTHETIC_TOOLTIP,
+  stripSyntheticMarker,
+} from '../lib/synthetic-marker'
+
+/**
+ * Render a text field that *might* carry the backend `[SYNTHETIC]`
+ * prefix. Synthesized values render with a side chip + tooltip so
+ * operators don't mistake a backend fallback for ground-truth model
+ * output. Phase 4 surface fix for the §1.6 asymmetry: memory search
+ * already rejected synthetic rows, but the dashboard rendered them
+ * verbatim until now.
+ */
+function SyntheticAwareText({ text }: { text: string }) {
+  const { stripped, synthesized } = stripSyntheticMarker(text)
+  if (!synthesized) return html`<span>${stripped}</span>`
+  return html`
+    <span class="inline-flex flex-wrap items-baseline gap-1.5">
+      <span
+        class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--warn-30)] bg-[var(--warn-10)] px-1.5 py-px text-[10px] font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-status-warn)]"
+        title=${SYNTHETIC_TOOLTIP}
+      >
+        ${SYNTHETIC_SCOPE_LABEL}
+      </span>
+      <span>${stripped}</span>
+    </span>
+  `
+}
 
 // Backend `attention_reason` is set across three emit sites (verified by
 // `rg '"attention_reason".*\`String "' lib/`):
@@ -402,16 +431,16 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
           ? html`<span><strong class="text-[var(--color-fg-secondary)]">다음 액션</strong> · ${nextHumanActionText}</span>`
           : null}
         ${stopCause
-          ? html`<span><strong class="text-[var(--color-fg-secondary)]">정지 원인</strong> · ${stopCause.code}${stopCause.summary ? html` · ${stopCause.summary}` : null}</span>`
+          ? html`<span><strong class="text-[var(--color-fg-secondary)]">정지 원인</strong> · ${stopCause.code}${stopCause.summary ? html` · <${SyntheticAwareText} text=${stopCause.summary} />` : null}</span>`
           : null}
         ${latestTerminalCode && latestTerminalCode !== stopCause?.code
-          ? html`<span><strong class="text-[var(--color-fg-secondary)]">종료 코드</strong> · ${latestTerminalCode}${latestTerminalSummary ? html` · ${latestTerminalSummary}` : null}</span>`
+          ? html`<span><strong class="text-[var(--color-fg-secondary)]">종료 코드</strong> · ${latestTerminalCode}${latestTerminalSummary ? html` · <${SyntheticAwareText} text=${latestTerminalSummary} />` : null}</span>`
           : null}
         ${latestNextAction
           ? html`<span title=${latestNextAction}><strong class="text-[var(--color-fg-secondary)]">권장 조치</strong> · ${nextHumanActionLabel(latestNextAction)}</span>`
           : null}
-        ${shouldShowOperatorDispositionReason
-          ? html`<span><${StrongSecondary}>운영자 판단</${StrongSecondary}> · ${operatorDispositionReason}</span>`
+        ${shouldShowOperatorDispositionReason && operatorDispositionReason
+          ? html`<span><${StrongSecondary}>운영자 판단</${StrongSecondary}> · <${SyntheticAwareText} text=${operatorDispositionReason} /></span>`
           : null}
         ${trustDisposition
           ? html`

--- a/dashboard/src/lib/synthetic-marker.test.ts
+++ b/dashboard/src/lib/synthetic-marker.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import {
+  SYNTHETIC_PREFIX,
+  SYNTHETIC_SCOPE_LABEL,
+  SYNTHETIC_TOOLTIP,
+  hasSyntheticMarker,
+  stripSyntheticMarker,
+} from './synthetic-marker'
+
+describe('stripSyntheticMarker', () => {
+  it('detects the [SYNTHETIC] prefix and strips it', () => {
+    const result = stripSyntheticMarker('[SYNTHETIC] Last output: tool: keeper_task_done')
+    expect(result.synthesized).toBe(true)
+    expect(result.stripped).toBe('Last output: tool: keeper_task_done')
+  })
+
+  it('handles leading whitespace around the prefix', () => {
+    const result = stripSyntheticMarker('   [SYNTHETIC]   Decisions: pause')
+    expect(result.synthesized).toBe(true)
+    expect(result.stripped).toBe('Decisions: pause')
+  })
+
+  it('returns synthesized=false for plain text', () => {
+    const result = stripSyntheticMarker('Last output: model native')
+    expect(result.synthesized).toBe(false)
+    expect(result.stripped).toBe('Last output: model native')
+  })
+
+  it('treats mid-string [SYNTHETIC] mentions as plain text', () => {
+    // Could be a quoted message from another keeper — only the
+    // prefix form is the wire contract.
+    const result = stripSyntheticMarker('keeper@bob said: "[SYNTHETIC] is rare"')
+    expect(result.synthesized).toBe(false)
+    expect(result.stripped).toBe('keeper@bob said: "[SYNTHETIC] is rare"')
+  })
+
+  it('handles null / undefined / empty input', () => {
+    expect(stripSyntheticMarker(null)).toEqual({ stripped: '', synthesized: false })
+    expect(stripSyntheticMarker(undefined)).toEqual({ stripped: '', synthesized: false })
+    expect(stripSyntheticMarker('')).toEqual({ stripped: '', synthesized: false })
+    expect(stripSyntheticMarker('   ')).toEqual({ stripped: '', synthesized: false })
+  })
+
+  it('preserves trailing/internal whitespace in the stripped body', () => {
+    const result = stripSyntheticMarker('[SYNTHETIC] line1\nline2')
+    expect(result.synthesized).toBe(true)
+    expect(result.stripped).toBe('line1\nline2')
+  })
+})
+
+describe('hasSyntheticMarker', () => {
+  it('returns true only when the prefix is present', () => {
+    expect(hasSyntheticMarker('[SYNTHETIC] x')).toBe(true)
+    expect(hasSyntheticMarker('x [SYNTHETIC]')).toBe(false)
+    expect(hasSyntheticMarker(null)).toBe(false)
+  })
+})
+
+describe('exported constants', () => {
+  it('SYNTHETIC_PREFIX matches the backend literal', () => {
+    expect(SYNTHETIC_PREFIX).toBe('[SYNTHETIC]')
+  })
+
+  it('operator-facing strings are non-empty', () => {
+    expect(SYNTHETIC_SCOPE_LABEL.length).toBeGreaterThan(0)
+    expect(SYNTHETIC_TOOLTIP.length).toBeGreaterThan(0)
+    expect(SYNTHETIC_TOOLTIP).toContain('TTL')
+  })
+})

--- a/dashboard/src/lib/synthetic-marker.ts
+++ b/dashboard/src/lib/synthetic-marker.ts
@@ -1,0 +1,82 @@
+// Frontend utility for backend `[SYNTHETIC]` marker handling.
+//
+// The MASC backend synthesizes a deterministic STATE block when a
+// model finishes a turn without emitting one (so generation
+// continuity is preserved — see
+// `lib/keeper/keeper_memory_policy.ml:synthesize_state_from_run_result`
+// and the SSOT in `lib/keeper/keeper_synthetic_marker.mli`). The
+// synthesized payload is tagged `[SYNTHETIC] ...` so any consumer
+// can tell apart model-native output from a backend fallback.
+//
+// Backend memory search rejects `[SYNTHETIC]` rows via
+// `is_meaningful_memory_text` (verified at
+// `test/test_keeper_memory.ml:1381`), but the dashboard surface used
+// to render the marker raw — operators saw decisions / blocker
+// summaries / disposition text prefixed with `[SYNTHETIC]` and had
+// to either know what it meant or chase it through the codebase.
+//
+// This module is the dashboard-side equivalent of the backend SSOT:
+// a single detector + a single user-facing label + a tooltip that
+// explains the contract.
+
+export const SYNTHETIC_PREFIX = '[SYNTHETIC]'
+
+/**
+ * Operator-facing scope label for the synthetic-marker chip. Kept
+ * separate from the literal `[SYNTHETIC]` token so a future i18n or
+ * naming change has a single edit point.
+ */
+export const SYNTHETIC_SCOPE_LABEL = '합성 fallback'
+
+/**
+ * Tooltip text rendered alongside the synthetic chip. The wording is
+ * deliberately blunt about *what this is not* — "마지막 turn 의 실제
+ * 모델 출력이 아닙니다" — so operators don't treat the synthesized
+ * text as ground truth.
+ */
+export const SYNTHETIC_TOOLTIP =
+  '모델이 STATE 블록을 누락한 turn 에서 backend 가 자동 생성한 fallback 입니다. '
+  + '가장 최근 turn 의 실제 모델 출력이 아닐 수 있으며, 다음 non-synthetic generation '
+  + '까지 그대로 유지됩니다 (TTL 없음). 의사결정 근거로 사용 전 별도 확인 필요.'
+
+interface ScopedText {
+  /** Text with the `[SYNTHETIC]` prefix stripped. Always trimmed. */
+  stripped: string
+  /** Whether the original text carried the synthetic marker. */
+  synthesized: boolean
+}
+
+/**
+ * Detect and strip the `[SYNTHETIC]` prefix from a text field.
+ * Returns the cleaned text plus a boolean for the marker presence.
+ *
+ * The marker is matched case-sensitively (backend always emits the
+ * exact literal `[SYNTHETIC]`) and only as a *prefix* after trim —
+ * inline mid-string occurrences are treated as plain text because
+ * they could legitimately be quoted content from another keeper.
+ */
+export function stripSyntheticMarker(
+  text: string | null | undefined,
+): ScopedText {
+  const raw = text ?? ''
+  const trimmed = raw.trim()
+  if (!trimmed) return { stripped: '', synthesized: false }
+  if (trimmed.startsWith(SYNTHETIC_PREFIX)) {
+    return {
+      stripped: trimmed.slice(SYNTHETIC_PREFIX.length).trim(),
+      synthesized: true,
+    }
+  }
+  return { stripped: trimmed, synthesized: false }
+}
+
+/**
+ * Detect-only variant — returns just the boolean. Use this when the
+ * caller wants to render the original text but with a side chip,
+ * rather than the stripped form.
+ */
+export function hasSyntheticMarker(
+  text: string | null | undefined,
+): boolean {
+  return stripSyntheticMarker(text).synthesized
+}


### PR DESCRIPTION
## Why (Phase 4 / RFC-0135 §1.6 asymmetry)

사용자 캡처 화면 (2026-05-19 sangsu keeper detail) 의 alert strip 에 \`Decisions: [SYNTHETIC] Last output: tool: keeper_task_done ...\` 텍스트가 verbatim 표시됨. backend 의 \`synthesize_state_from_run_result\` 가 모델 STATE 블록 누락 시 emit 하는 fallback 마커가 *backend-synthesized* 인 사실은 dashboard 가 알리지 않음 — 운영자는 ground-truth 모델 출력으로 오인 가능.

비대칭: backend memory search 는 \`[SYNTHETIC]\` rows 를 \`is_meaningful_memory_text\` (\`test_keeper_memory.ml:1381\`) 가 reject 하는데, dashboard 는 그대로 노출. 검색 인덱스보다 *운영자가 더 적은 컨텍스트* 를 가지는 상황.

## What

**1. \`src/lib/synthetic-marker.ts\` 신규 유틸 모듈** (frontend SSOT)

- \`SYNTHETIC_PREFIX\` 백엔드 SSOT (\`keeper_synthetic_marker.mli\`) 와 정확히 일치
- \`SYNTHETIC_SCOPE_LABEL\` / \`SYNTHETIC_TOOLTIP\` operator-facing 문구 단일 edit point
- \`stripSyntheticMarker(text)\` returns \`{ stripped, synthesized }\` — prefix-only detection (case-sensitive, after trim — 중간 mention 은 quoted content 가능성 있어 plain text 취급)
- \`hasSyntheticMarker(text)\` detect-only

**2. \`keeper-detail-alert-strip.ts\` — \`SyntheticAwareText\` 컴포넌트 + 3 spans 적용**

- \`정지 원인 · stop_cause.summary\`
- \`종료 코드 · latestTerminalSummary\`
- \`운영자 판단 · operator_disposition_reason\`

각 span 이 stripped text + warn-toned '합성 fallback' chip 동시 렌더. chip 의 tooltip:

> 모델이 STATE 블록을 누락한 turn 에서 backend 가 자동 생성한 fallback 입니다. 가장 최근 turn 의 실제 모델 출력이 아닐 수 있으며, 다음 non-synthetic generation 까지 그대로 유지됩니다 (TTL 없음). 의사결정 근거로 사용 전 별도 확인 필요.

**3. 9 unit tests**: prefix 검출, leading whitespace, mid-string non-detection, null/undefined/empty handling, 상수 무결성.

## Tests

- \`pnpm typecheck\` clean
- \`pnpm vitest run src/lib/synthetic-marker.test.ts src/components/keeper-detail-alert-strip.test.ts\` — **15/15 pass** (9 new + 기존 6)

## Out of scope (RFC-0135 PR-8 별도 stack)

- Backend \`synthesized_at_ts\` 필드 추가
- Frontend age 표시 (\`'9시간 전 합성'\`)
- TTL 자체 — 현재 \`keeper_memory_bank\` 에 다음 non-synthetic generation 까지 persist. tooltip 이 그 사실을 명시.

## Plan reference

\`memory/project_dashboard_keeper_detail_ssot_reconciliation_2026_05_19.md\` Phase 4.

## Test plan

- [ ] preview 에서 합성 fallback 를 emit 한 keeper 의 alert-strip 에 'SCOPE LABEL · 합성 fallback' chip 표시 확인
- [ ] chip 에 hover 시 tooltip 표시 확인
- [ ] non-synthetic decision summary 는 chip 없이 plain 표시 확인 (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)