### PR TITLE
fix(cascade): re-raise Eio.Cancel.Cancelled in liveness-observer tick fiber

### DIFF
--- a/lib/cascade/cascade_attempt_liveness_observer.ml
+++ b/lib/cascade/cascade_attempt_liveness_observer.ml
@@ -353,7 +353,16 @@ let start_tick_fiber (t : t) ~(sw : Eio.Switch.t)
             end
           in
           try loop () with
-          | Eio.Cancel.Cancelled _ -> ()
+          (* Cooperative cancel: re-raise so the parent switch sees the
+             signal propagate out of this fiber. Previously [-> ()] which
+             absorbed the cancel and broke Eio back-propagation conventions
+             (every other live-loop fiber in lib/keeper/keeper_keepalive.ml,
+             lib/keeper/keeper_heartbeat_loop.ml does the explicit re-raise). *)
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          (* Liveness_kill is the loop's own terminator: the body raises it
+             via [react_to_output] when the budget is exceeded and we want
+             the fiber to exit cleanly without surfacing the exception to
+             the parent. Intentional absorption. *)
           | Liveness_kill _ -> ()
           | exn ->
               Log.Misc.warn


### PR DESCRIPTION
## Goal

`lib/cascade/cascade_attempt_liveness_observer.ml:355` absorbed `Eio.Cancel.Cancelled` with `-> ()`. This breaks the cooperative cancel back-propagation convention used by every other live-loop fiber in `lib/keeper/`.

Discovered by parallel scout sweep during /loop Iter#43; verified and corrected in Iter#44.

## Before

\`\`\`ocaml
try loop () with
| Eio.Cancel.Cancelled _ -> ()        (* silent — broke convention *)
| Liveness_kill _ -> ()
| exn -> Log.Misc.warn \"...crashed: %s\" ...
\`\`\`

## After

\`\`\`ocaml
try loop () with
(* Cooperative cancel: re-raise so the parent switch sees the
   signal propagate out of this fiber. *)
| Eio.Cancel.Cancelled _ as e -> raise e
(* Liveness_kill is the loop's own terminator: the body raises it
   via [react_to_output] when the budget is exceeded and we want
   the fiber to exit cleanly without surfacing the exception to
   the parent. Intentional absorption. *)
| Liveness_kill _ -> ()
| exn -> Log.Misc.warn \"...crashed: %s\" ...
\`\`\`

## Why one variant is re-raised and the other is absorbed

| Exception | Source | Treatment | Reason |
|-----------|--------|-----------|--------|
| `Eio.Cancel.Cancelled` | Eio runtime (parent switch cancel) | **re-raise** | Cooperative cancel convention — parent must see propagation |
| `Liveness_kill` | Loop body's own `react_to_output` (L350) when budget exceeded | absorb | This is the loop's own terminator; surfacing to parent would treat budget violation as fiber crash |
| Other `exn` | Bug | log + absorb (existing) | Keep the fiber from taking down the parent switch on programmer error |

The pattern matches `lib/keeper/keeper_keepalive.ml:379-419` and `lib/keeper/keeper_heartbeat_loop.ml:1683-1900` which both re-raise `Cancelled` explicitly.

## Verification

\`\`\`
dune build @check                                   # clean
dune build test/test_cascade_attempt_liveness_observer.exe
_build/default/test/test_cascade_attempt_liveness_observer.exe   # 15/15 pass
\`\`\`

Two existing tests are direct invariants on cancel semantics:
- `lifetime 0 \"tick fiber dies with switch\"` — confirms the fiber still dies when its parent switch is cancelled (now via propagation rather than absorption)
- `enforce 0 \"Outcome -> Switch.fail Liveness_kill\"` — confirms Liveness_kill still routes via the switch fail path (not through the re-raised cancel)

Both pass.

## Touch points

- 1 file, +10 / -1 LoC (mostly the rationale comments)

## Severity context

Severity downgraded from scout's HIGH to MEDIUM after verification: parent switches are typically cancelled simultaneously, so the lost propagation rarely matters in practice. However, idiomatic Eio behavior requires the re-raise, and the cost of correctness here is one line + clarifying comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>