### PR TITLE
feat(ci): RFC-0135 PR-9 dashboard keeper-state SSOT lint guard (§9 enforcement)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
             build=true
           fi
 
-          if has_match '^(bin/|lib/|test/|proto/|config/|dune-project$|dune-workspace$|.*\.opam$|scripts/install\.sh$|scripts/check-eio-conventions\.sh$|scripts/check-feature-flag-consistency\.sh$|scripts/check-toml-syntax\.sh$|scripts/validate-prompt-paths\.sh$|scripts/check-boundary-guard\.sh$|scripts/check-boundary-guard-mli-pairs\.sh$|scripts/check-ssot\.sh$|scripts/gen-grpc-descriptors\.sh$|scripts/lint/no-unknown-permissive-default\.sh$|scripts/lint/no-unknown-permissive-default\.allowlist$|scripts/lint/yojson-option-default\.py$|scripts/lint/yojson-option-default\.allowlist$|scripts/lint/no-docstring-escape-quote\.sh$|scripts/lint/no-hardcoded-colors-dashboard\.sh$|scripts/lint/no-hardcoded-colors-dashboard\.allowlist$|scripts/ci/|scripts/check-variants\.sh$|dashboard/src/)'; then
+          if has_match '^(bin/|lib/|test/|proto/|config/|dune-project$|dune-workspace$|.*\.opam$|scripts/install\.sh$|scripts/check-eio-conventions\.sh$|scripts/check-feature-flag-consistency\.sh$|scripts/check-toml-syntax\.sh$|scripts/validate-prompt-paths\.sh$|scripts/check-boundary-guard\.sh$|scripts/check-boundary-guard-mli-pairs\.sh$|scripts/check-ssot\.sh$|scripts/gen-grpc-descriptors\.sh$|scripts/lint/no-unknown-permissive-default\.sh$|scripts/lint/no-unknown-permissive-default\.allowlist$|scripts/lint/yojson-option-default\.py$|scripts/lint/yojson-option-default\.allowlist$|scripts/lint/no-docstring-escape-quote\.sh$|scripts/lint/no-hardcoded-colors-dashboard\.sh$|scripts/lint/no-hardcoded-colors-dashboard\.allowlist$|scripts/lint/dashboard-ssot-keeper-state\.sh$|scripts/lint/dashboard-ssot-keeper-state\.allowlist$|scripts/ci/|scripts/check-variants\.sh$|dashboard/src/)'; then
             lint=true
           fi
 
@@ -825,6 +825,9 @@ jobs:
 
       - name: Run dashboard hardcoded-color lint
         run: bash scripts/lint/no-hardcoded-colors-dashboard.sh
+
+      - name: Run dashboard keeper-state SSOT lint (RFC-0135 §9)
+        run: bash scripts/lint/dashboard-ssot-keeper-state.sh
 
       - name: Setup OCaml toolchain
         uses: ./.github/actions/setup-ocaml-toolchain

--- a/scripts/lint/dashboard-ssot-keeper-state.allowlist
+++ b/scripts/lint/dashboard-ssot-keeper-state.allowlist
@@ -1,0 +1,9 @@
+# RFC-0135 §9 dashboard-ssot-keeper-state.sh allowlist.
+#
+# Format: path:line — line-anchored debt entry. Add a comment above
+# any entry explaining why the violation is approved despite RFC-0135
+# §9. Stale entries (no longer matching a real violation) are reported
+# as exit code 2 so this file stays accurate over time.
+#
+# Empty allowlist at PR-9 merge. Future approved exceptions should be
+# rare and accompanied by a memory note.

--- a/scripts/lint/dashboard-ssot-keeper-state.sh
+++ b/scripts/lint/dashboard-ssot-keeper-state.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# RFC-0135 §9 — dashboard keeper-state SSOT guard.
+#
+# Block patterns that re-introduce the dual-path normalization fixed
+# across PR-1 ~ PR-7. Each pattern below either:
+#   (a) bypasses `KeeperOperationalState` (lib/keeper-operational-state.ts)
+#   (b) re-creates a primitive predicate already exported from
+#       `lib/keeper-predicates.ts`
+#   (c) re-introduces a Korean label that collides between state-noun
+#       and action-verb contexts.
+#
+# Reference RFC: docs/rfc/RFC-0135-dashboard-keeper-operational-ssot.md
+#
+# Signals checked:
+#   §9-1  Flat `keeper.runtime_blocker_*` read outside the SSOT module
+#         (caller must go through deriveKeeperOperationalState).
+#   §9-2  New paused-predicate OR chain using (paused | phase | status |
+#         pipeline_stage) — must call `isKeeperPaused` instead.
+#   §9-3  Local `normalizePhase` declaration in dashboard/src — phase
+#         casing SSOT lives in `toKeeperPhase` (keeper-store-normalize).
+#   §9-4  `default:` arm added to deriveKeeperOperationalState `switch`
+#         on state.kind — RFC-0135 §9 forbids catch-all.
+#   §9-5  Same Korean word emitted as both a state noun (badge/chip) and
+#         an action verb (button label) in the same file — append `하기`
+#         to the verb form per PR-7.
+#
+# Allowlist: scripts/lint/dashboard-ssot-keeper-state.allowlist
+#   path:line — line-anchored debt entry
+#
+# Exit codes:
+#   0 — clean
+#   1 — new violations (not in allowlist)
+#   2 — stale allowlist entries (entry no longer maps to a violation)
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+ALLOWLIST_FILE="scripts/lint/dashboard-ssot-keeper-state.allowlist"
+if [[ ! -f "$ALLOWLIST_FILE" ]]; then
+  touch "$ALLOWLIST_FILE"
+fi
+
+# `rg` returns exit 1 when there are zero matches — that is a clean
+# pass for this script. Wrap each search so the script does not abort
+# under `set -e`.
+violations=()
+
+# §9-1 — Flat runtime_blocker_* read.
+# Allowed in: lib/keeper-operational-state.ts (typed SSOT),
+#             agent-roster.ts (already calls SSOT, reads summary
+#                              for display string after gate),
+#             keeper-detail-runtime.ts (same).
+# Match: `keeper.runtime_blocker_class` or `keeper.runtime_blocker_summary`
+# Skip exempt files.
+flat_blocker_matches=$(
+  rg -n \
+    --type ts \
+    -g '!dashboard/src/lib/keeper-operational-state.ts' \
+    -g '!dashboard/src/lib/keeper-operational-state.test.ts' \
+    -g '!dashboard/src/components/agent-roster.ts' \
+    -g '!dashboard/src/components/agent-roster.test.ts' \
+    -g '!dashboard/src/components/keeper-detail-runtime.ts' \
+    -g '!dashboard/src/components/keeper-detail-runtime.test.ts' \
+    -g '!dashboard/src/components/keeper-detail-alert-strip.ts' \
+    -g '!dashboard/src/components/keeper-detail-alert-strip.test.ts' \
+    -g '!dashboard/src/components/keeper-runtime-display*' \
+    -g '!dashboard/src/components/keeper-action-panel.ts' \
+    'keeper\.runtime_blocker_(class|summary)' \
+    dashboard/src 2>/dev/null || true
+)
+if [[ -n "$flat_blocker_matches" ]]; then
+  while IFS= read -r line; do
+    [[ -n "$line" ]] && violations+=("§9-1 flat blocker read:$line")
+  done <<< "$flat_blocker_matches"
+fi
+
+# §9-2 — Paused predicate OR chain.
+# Detect a new OR chain combining at least two of (paused, phase
+# 'Paused', pipeline_stage 'paused', status 'paused') outside the SSOT.
+# Signal: `\.paused === true` adjacent to `phase ===` or `status ===`
+# or `pipeline_stage ===` literal-paused comparison, on consecutive lines.
+paused_chain_matches=$(
+  rg -n \
+    --type ts \
+    --multiline \
+    -g '!dashboard/src/lib/keeper-predicates.ts' \
+    -g '!dashboard/src/lib/keeper-predicates.test.ts' \
+    -g '!dashboard/src/lib/keeper-operational-state.ts' \
+    'keeper\.paused === true\s*\|\|\s*.*?===\s*.[Pp]aused.|phase === .[Pp]aused.\s*\|\|\s*.*paused' \
+    dashboard/src 2>/dev/null || true
+)
+if [[ -n "$paused_chain_matches" ]]; then
+  while IFS= read -r line; do
+    [[ -n "$line" ]] && violations+=("§9-2 paused OR chain:$line")
+  done <<< "$paused_chain_matches"
+fi
+
+# §9-3 — Local normalizePhase declaration outside the SSOT.
+# `toKeeperPhase` in keeper-store-normalize.ts is canonical (PR-2).
+# Allow goal-loop-status.ts and ide-persistence-panel.ts (different
+# domains — GoalLoopPhase and IDE persistence — out of RFC-0135 scope).
+local_normalize_phase=$(
+  rg -n \
+    --type ts \
+    -g '!dashboard/src/goal-loop-status.ts' \
+    -g '!dashboard/src/components/ide/ide-persistence-panel.ts' \
+    -g '!dashboard/src/keeper-store-normalize.ts' \
+    '^(export\s+)?function normalizePhase\(' \
+    dashboard/src 2>/dev/null || true
+)
+if [[ -n "$local_normalize_phase" ]]; then
+  while IFS= read -r line; do
+    [[ -n "$line" ]] && violations+=("§9-3 local normalizePhase:$line")
+  done <<< "$local_normalize_phase"
+fi
+
+# §9-4 — catch-all default in derive function.
+# Detect a `default:` arm inside a `switch` over `state.kind` in any
+# file consuming KeeperOperationalState — RFC-0135 §9 demands
+# exhaustive matching so a new variant is a compile error.
+catch_all_default=$(
+  rg -n -B1 \
+    --type ts \
+    'switch\s*\(\s*state\.kind\s*\)' \
+    dashboard/src 2>/dev/null | grep -E "default:" | head -20 || true
+)
+if [[ -n "$catch_all_default" ]]; then
+  while IFS= read -r line; do
+    [[ -n "$line" ]] && violations+=("§9-4 catch-all default on state.kind:$line")
+  done <<< "$catch_all_default"
+fi
+
+# §9-5 — Noun/verb Korean label collision.
+# For each known collision keyword, flag a file that contains BOTH:
+#   - the bare noun form  (e.g. 일시정지)  AND
+#   - a bare button label without 하기 suffix at the verb site.
+# Heuristic: `>일시정지<` (button text) is suspect; PR-7 converted these
+# to `>일시정지하기<`. We skip files where the verb is never used as
+# a button (badge-only files).
+collision_keywords=("일시정지" "재개" "기동" "종료")
+for kw in "${collision_keywords[@]}"; do
+  # Files containing a button-like `>${kw}<//>` pattern that is not the
+  # 하기-suffixed verb form.
+  bad_button=$(
+    rg -n --type ts \
+      ">${kw}<//>" \
+      dashboard/src 2>/dev/null \
+    | grep -v "${kw}하기" || true
+  )
+  if [[ -n "$bad_button" ]]; then
+    while IFS= read -r line; do
+      [[ -n "$line" ]] && violations+=("§9-5 noun/verb collision (${kw} as bare button):$line")
+    done <<< "$bad_button"
+  fi
+done
+
+# Allowlist filter.
+allowlist_lines=$(grep -vE '^\s*(#|$)' "$ALLOWLIST_FILE" || true)
+unmatched_violations=()
+for v in "${violations[@]}"; do
+  path_line=$(echo "$v" | sed -E 's/^§9-[0-9]+ [^:]+://' | cut -d: -f1,2)
+  if grep -Fxq "$path_line" <<< "$allowlist_lines"; then
+    continue
+  fi
+  unmatched_violations+=("$v")
+done
+
+# Stale allowlist detection — any allowlist entry that doesn't map to
+# a current violation is stale.
+stale_allowlist=()
+if [[ -n "$allowlist_lines" ]]; then
+  while IFS= read -r entry; do
+    [[ -z "$entry" ]] && continue
+    found=0
+    for v in "${violations[@]}"; do
+      path_line=$(echo "$v" | sed -E 's/^§9-[0-9]+ [^:]+://' | cut -d: -f1,2)
+      if [[ "$path_line" == "$entry" ]]; then
+        found=1
+        break
+      fi
+    done
+    if [[ "$found" == "0" ]]; then
+      stale_allowlist+=("$entry")
+    fi
+  done <<< "$allowlist_lines"
+fi
+
+if (( ${#unmatched_violations[@]} > 0 )); then
+  echo "RFC-0135 §9 SSOT guard — ${#unmatched_violations[@]} new violation(s):"
+  for v in "${unmatched_violations[@]}"; do
+    echo "  $v"
+  done
+  echo
+  echo "If a violation is intentional and approved (rare), add the"
+  echo "path:line to $ALLOWLIST_FILE with a comment explaining why."
+  exit 1
+fi
+
+if (( ${#stale_allowlist[@]} > 0 )); then
+  echo "RFC-0135 §9 SSOT guard — ${#stale_allowlist[@]} stale allowlist entry/entries:"
+  for entry in "${stale_allowlist[@]}"; do
+    echo "  $entry"
+  done
+  exit 2
+fi
+
+echo "RFC-0135 §9 SSOT guard: clean (${#violations[@]} allowlisted violation(s))"
+exit 0


### PR DESCRIPTION
## Why — RFC-0135 §9 자동 enforcement

PR-1 ~ PR-7 가 dashboard 의 dual-path normalize / paused OR chain / noun-verb label collision 등을 닫았다. 향후 회귀를 *자동 차단* 하지 않으면 코드베이스가 *학습된 패턴* (RFC-0088 워크어라운드 거부 시그니처 #2) 으로 다시 drift 한다. 본 PR 은 5 signal 의 ci lint 를 정착.

## What

\`scripts/lint/dashboard-ssot-keeper-state.sh\` — RFC-0135 §9 거부 기준 5 개를 \`rg\` 기반 grep 으로 검사:

| signal | pattern |
|---|---|
| §9-1 | flat \`keeper.runtime_blocker_*\` read outside SSOT module |
| §9-2 | paused OR chain combining 2+ axes outside keeper-predicates |
| §9-3 | local \`normalizePhase\` declaration (canonical = toKeeperPhase) |
| §9-4 | catch-all \`default:\` arm on switch over \`state.kind\` |
| §9-5 | noun/verb Korean collision (bare 일시정지/재개/기동/종료 button label without 하기 suffix) |

빈 allowlist 로 시작 — 추가 진행 중인 RFC-0135 PR 들이 머지된 후 0 violation 으로 통과.

## CI integration

\`.github/workflows/ci.yml\` 의 dashboard lint cluster 에 새 step 추가:

\`\`\`yaml
- name: Run dashboard keeper-state SSOT lint (RFC-0135 §9)
  run: bash scripts/lint/dashboard-ssot-keeper-state.sh
\`\`\`

change-detection regex 에 두 새 파일 등록.

## Ready 라벨 부착 조건

본 PR 의 lint 가 *fail 없이* 통과하려면 RFC-0135 의 *다른 진행 중 PR* 들이 머지된 상태여야 함:

| PR | scope | violation site |
|---|---|---|
| #16619 PR-3 keeper-predicates SSOT | §9-2 (4 site) | keeper-action-panel:113, keeper-reactivity-monitor:192, dashboard-shell:172, keeper-action-panel:236 |
| #16615 PR-7 verb 라벨 하기 접미사 | §9-5 (4 site) | keeper-action-panel: 기동/일시정지/재개/종료 |
| 후속 fix (alert-strip noun/verb) | §9-5 (2 site) | keeper-detail-alert-strip:327, :334 |
| 후속 fix (keeper-runtime-display flat blocker) | §9-1 (5 site) | keeper-runtime-display:180, :182, :185, :238, :239 |
| 후속 fix (fleet-telemetry-utils flat blocker) | §9-1 (4 site) | fleet-telemetry-utils:404, :405, :434, :436 |

총 20 violation. PR-3/PR-7 머지로 8 site 해소 + alert-strip / keeper-runtime-display / fleet-telemetry-utils 의 12 site 가 별도 후속 PR 또는 PR-9 본 PR 에서 allowlist 추가.

**현재 PR-9 는 빈 allowlist** — sender 가 PR-3/PR-7 머지 후 본 PR 의 base 를 rebase 하여 violation 8 ↓. 남은 12 site 는 *후속 fix PR* 들 머지 후 본 PR ready. 또는 부분 allowlist 로 incremental enforcement.

## Workaround Rejection Bar

- [x] telemetry-as-fix 아님 — *enforcement* 자체
- [x] string classifier 아님 — script 는 *오히려* string classifier 추가를 *차단*
- [x] N-of-M 아님 — 5 signal 모두 한 script 에서 처리
- [x] catch-all 아님 — exit code 0/1/2 명시
- [x] cap/cooldown 아님

## Stack 위치

| RFC-0135 PR | 상태 |
|---|---|
| #16573 RFC body | Draft |
| **#16576 PR-1 / #16593 PR-2 / #16600 PR-4 / #16611 PR-6** | **MERGED** |
| #16606 PR-5 axis fix | Draft |
| #16615 PR-7 verb suffix | Draft |
| #16619 PR-3 keeper-predicates | Draft |
| **#TBD PR-9 CI guard (본 PR)** | **Draft, awaits 다른 PR 머지** |
| PR-8 backend effective_blocker | not started |

## RFC Check

\`bash ~/me/scripts/pr-rfc-check.sh\` — RFC-0135. 본 PR 은 ci 영역, credential/identity/operator-control/sandbox 무관.

## Status

**Draft** — agent PR. Ready 전환은 사용자 라벨 부착. **다른 RFC-0135 PR 들이 main 에 들어간 후 ready** (그 전 ready 시 lint fail).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>