### PR TITLE
Run full health snapshot refresh in Eio loop

### DIFF
--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -803,6 +803,8 @@ let full_health_snapshot_mu = Stdlib.Mutex.create ()
 let full_health_snapshot = ref None
 let full_health_refresh_in_flight = ref false
 let full_health_refresh_started_at = ref None
+let full_health_refresh_requested = ref false
+let full_health_refresh_interval_sec = 10.0
 let full_health_refresh_timeout_sec = 5.0
 
 let with_full_health_snapshot_lock f =
@@ -909,6 +911,7 @@ let compute_full_health_snapshot ?(listener = "http/1.1") request =
       error = None;
     }
   with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
       let finished_at = Unix.gettimeofday () in
       let error = Printexc.to_string exn in
@@ -923,16 +926,41 @@ let store_full_health_snapshot snapshot =
   with_full_health_snapshot_lock (fun () ->
       full_health_snapshot := Some snapshot;
       full_health_refresh_in_flight := false;
-      full_health_refresh_started_at := None)
+      full_health_refresh_started_at := None;
+      full_health_refresh_requested := false)
+
+let mark_full_health_snapshot_error exn =
+  let now = Unix.gettimeofday () in
+  let error = Printexc.to_string exn in
+  with_full_health_snapshot_lock (fun () ->
+      full_health_snapshot :=
+        Some
+          {
+            fields = full_health_placeholder_fields ~error ~status:"error" ();
+            computed_at = now;
+            duration_ms = 0;
+            error = Some error;
+          };
+      full_health_refresh_in_flight := false;
+      full_health_refresh_started_at := None;
+      full_health_refresh_requested := false)
+
+let compute_full_health_snapshot_for_refresh ?(listener = "http/1.1") request =
+  with_full_health_snapshot_lock (fun () ->
+      full_health_refresh_in_flight := true;
+      full_health_refresh_started_at := Some (Unix.gettimeofday ());
+      full_health_refresh_requested := false);
+  compute_full_health_snapshot ~listener request
 
 let refresh_full_health_snapshot_sync ?(listener = "http/1.1") request =
-  store_full_health_snapshot (compute_full_health_snapshot ~listener request)
+  compute_full_health_snapshot_for_refresh ~listener request
+  |> store_full_health_snapshot
 
 let snapshot_is_stale ~now snapshot =
   now -. snapshot.computed_at > full_health_snapshot_ttl_sec
 
 let full_health_snapshot_metadata ~now ~refresh_in_flight ~refresh_started_at
-    snapshot =
+    ~refresh_requested snapshot =
   let component_timed_out =
     match (refresh_in_flight, refresh_started_at) with
     | true, Some started_at ->
@@ -963,6 +991,7 @@ let full_health_snapshot_metadata ~now ~refresh_in_flight ~refresh_started_at
       ("duration_ms", duration_ms);
       ("ttl_ms", `Int (int_of_float (full_health_snapshot_ttl_sec *. 1000.)));
       ("refresh_in_flight", `Bool refresh_in_flight);
+      ("refresh_requested", `Bool refresh_requested);
       ( "refresh_started_at_unix",
         match refresh_started_at with
         | Some started_at -> `Float started_at
@@ -973,46 +1002,19 @@ let full_health_snapshot_metadata ~now ~refresh_in_flight ~refresh_started_at
       ("error", error);
     ]
 
-let schedule_full_health_snapshot_refresh ?(listener = "http/1.1") request =
-  let should_start =
-    with_full_health_snapshot_lock (fun () ->
-        if !full_health_refresh_in_flight then false
-        else (
-          full_health_refresh_in_flight := true;
-          full_health_refresh_started_at := Some (Unix.gettimeofday ());
-          true))
-  in
-  if should_start then
-    try
-      ignore
-        (Thread.create
-           (fun () -> refresh_full_health_snapshot_sync ~listener request)
-           ())
-    with
-    | exn ->
-        let error = Printexc.to_string exn in
-        let now = Unix.gettimeofday () in
-        with_full_health_snapshot_lock (fun () ->
-            full_health_snapshot :=
-              Some
-                {
-                  fields = full_health_placeholder_fields ~error ~status:"error" ();
-                  computed_at = now;
-                  duration_ms = 0;
-                  error = Some error;
-                };
-            full_health_refresh_in_flight := false;
-            full_health_refresh_started_at := None)
+let mark_full_health_refresh_requested () =
+  with_full_health_snapshot_lock (fun () -> full_health_refresh_requested := true)
 
 let full_health_snapshot_state () =
   with_full_health_snapshot_lock (fun () ->
       ( !full_health_snapshot,
         !full_health_refresh_in_flight,
-        !full_health_refresh_started_at ))
+        !full_health_refresh_started_at,
+        !full_health_refresh_requested ))
 
 let make_cached_full_health_json ?(listener = "http/1.1") request =
   let now = Unix.gettimeofday () in
-  let snapshot, refresh_in_flight, _refresh_started_at =
+  let snapshot, _refresh_in_flight, _refresh_started_at, _refresh_requested =
     full_health_snapshot_state ()
   in
   let needs_refresh =
@@ -1020,9 +1022,8 @@ let make_cached_full_health_json ?(listener = "http/1.1") request =
     | None -> true
     | Some snapshot -> snapshot_is_stale ~now snapshot
   in
-  if needs_refresh && not refresh_in_flight then
-    schedule_full_health_snapshot_refresh ~listener request;
-  let snapshot, refresh_in_flight, refresh_started_at =
+  if needs_refresh then mark_full_health_refresh_requested ();
+  let snapshot, refresh_in_flight, refresh_started_at, refresh_requested =
     full_health_snapshot_state ()
   in
   let fields =
@@ -1036,15 +1037,34 @@ let make_cached_full_health_json ?(listener = "http/1.1") request =
      @ [
          ( "full_health_snapshot",
            full_health_snapshot_metadata ~now ~refresh_in_flight
-             ~refresh_started_at snapshot );
+             ~refresh_started_at ~refresh_requested snapshot );
        ])
+
+let start_full_health_snapshot_refresh_loop ~sw ~clock =
+  let request = Httpun.Request.create `GET "/health?full=1" in
+  Proactive_refresh.start
+    ~sw
+    ~clock
+    ~config:
+      {
+        (Proactive_refresh.default_config
+           ~label:"full_health_snapshot"
+           ~interval_s:full_health_refresh_interval_sec)
+        with
+        timeout_s = full_health_refresh_timeout_sec;
+        on_error = Some mark_full_health_snapshot_error;
+        warm_delay_s = 0.5;
+      }
+    ~compute:(fun () -> compute_full_health_snapshot_for_refresh request)
+    ~on_result:store_full_health_snapshot
 
 module For_testing = struct
   let reset_full_health_snapshot () =
     with_full_health_snapshot_lock (fun () ->
         full_health_snapshot := None;
         full_health_refresh_in_flight := false;
-        full_health_refresh_started_at := None)
+        full_health_refresh_started_at := None;
+        full_health_refresh_requested := false)
 
   let refresh_full_health_snapshot_now ?(listener = "http/1.1") request =
     refresh_full_health_snapshot_sync ~listener request

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -198,9 +198,18 @@ val make_health_response_json :
 (** [make_health_response_json ?listener request] is the public [/health]
     renderer.  It returns {!make_health_probe_json} by default.  When the
     request query contains [full=1] / [full=true], it returns the latest cached
-    full-health snapshot plus cheap request-local fields and starts a
-    background refresh when the snapshot is missing or stale.  The HTTP handler
-    must not synchronously run durable keeper scans. *)
+    full-health snapshot plus cheap request-local fields and marks the snapshot
+    for refresh when it is missing or stale.  The HTTP handler must not
+    synchronously run durable keeper scans; the Eio refresh loop started by
+    {!start_full_health_snapshot_refresh_loop} performs those scans. *)
+
+val start_full_health_snapshot_refresh_loop :
+  sw:Eio.Switch.t ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  unit
+(** Starts the Eio background refresh loop for cached [/health?full=1]
+    diagnostics.  The loop keeps heavy durable scans out of the HTTP request
+    path and stores stale/error metadata when refreshes fail or time out. *)
 
 module For_testing : sig
   val reset_full_health_snapshot : unit -> unit

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1443,6 +1443,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
          (execution, transport_health) start immediately. *)
       Server_dashboard_http.start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock;
       Server_dashboard_http.start_transport_health_refresh_loop ~state ~sw ~clock;
+      Server_routes_http_runtime.start_full_health_snapshot_refresh_loop ~sw ~clock;
       Server_dashboard_http.start_mission_refresh_loop ~state ~sw ~clock;
       Server_dashboard_http.start_operator_snapshot_refresh_loop ~state ~sw ~clock;
       Server_dashboard_http.start_operator_digest_refresh_loop ~state ~sw ~clock;


### PR DESCRIPTION
## Summary

- move full-health snapshot refresh out of the ad-hoc `Thread.create` path and into the existing Eio `Proactive_refresh` loop
- keep `/health?full=1` request handling cheap: it returns the latest cached snapshot and only marks stale/missing snapshots as refresh-requested
- start the full-health snapshot refresh loop during runtime bootstrap alongside the other dashboard/transport refresh loops

## Root Cause

#16614 fixed the synchronous `/health?full=1` request path, but its first implementation used a raw system thread for background refresh. That is unsafe for this code path because the full health builder touches Eio-backed transport state; in the focused test it poisoned an Eio mutex after the background refresh attempted to compute the snapshot outside the Eio runtime.

## Validation

- `ocamlformat --check lib/server/server_routes_http_runtime.ml lib/server/server_routes_http_runtime.mli lib/server/server_runtime_bootstrap.ml test/test_server_runtime_bootstrap.ml`
- `git diff --check`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_server_runtime_bootstrap.exe`
- `./_build/default/test/test_server_runtime_bootstrap.exe test --color=never -q bootstrap 38,39`
