### PR TITLE
fix(dashboard): RFC-0135 PR-7b alert-strip verb 라벨 하기 접미사 + tooltip

### DIFF
--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -324,14 +324,16 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
               class="!py-0.5 !bg-[var(--color-bg-hover)] !text-[var(--color-fg-secondary)] inline-flex items-center"
               disabled=${directiveLoading.value}
               onClick=${() => handleDirective('resume')}
-            >재개<//>`
+              title="재개: 일시정지된 keeper 를 다시 실행합니다 (paused → running)"
+            >재개하기<//>`
           : html`<${ActionButton}
               variant="ghost"
               size="sm"
               class="!py-0.5 !bg-[var(--color-bg-hover)] !text-[var(--color-fg-secondary)] inline-flex items-center"
               disabled=${directiveLoading.value}
               onClick=${() => handleDirective('pause')}
-            >일시정지<//>
+              title="일시정지: 실행 중인 keeper 를 일시 멈춥니다 (running → paused, 현재 turn 은 정상 종료)"
+            >일시정지하기<//>
             ${(hbStale || runtimeBlockerClass === 'oas_timeout_budget' || runtimeBlockerClass === 'cascade_exhausted' || runtimeBlockerClass === 'turn_timeout')
               ? html`<${ActionButton}
                   variant="warn"


### PR DESCRIPTION
## Why

PR-7 (#16615) 가 \`keeper-action-panel\` 의 verb 라벨에 \`하기\` 접미사를 추가했지만 \`keeper-detail-alert-strip.ts:327, :334\` 의 두 verb button (\`재개\`, \`일시정지\`) 은 *동일 패턴* 인데 누락. PR-9 lint §9-5 가 정확히 이 2 site 를 catch.

## What

| 위치 | before | after |
|---|---|---|
| line 327 (resume button) | \`>재개<//>\` | \`>재개하기<//>\` + tooltip |
| line 334 (pause button) | \`>일시정지<//>\` | \`>일시정지하기<//>\` + tooltip |
| line 343 (wakeup button) | \`>깨우기<//>\` | 그대로 (이미 동사형) |

추가로 두 button 에 PR-6 style 의 사전조건/효과 tooltip 부착.

## Verification

- \`pnpm typecheck\` PASS
- \`keeper-detail-alert-strip.test.ts\` 6/6 PASS
- \`+4 / -2\` LoC

## Stack

| RFC-0135 PR | 상태 |
|---|---|
| RFC body + PR-1/2/4/6 | **MERGED** |
| PR-3 / PR-5 / PR-7 / PR-9 | Draft |
| **PR-7b alert-strip (본 PR)** | **Draft** |

## RFC Check

\`bash ~/me/scripts/pr-rfc-check.sh\` — RFC-0135 reference.

## Status

**Draft** — agent PR. Ready 전환은 사용자 라벨 부착.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>