### PR TITLE
refactor: split mcp eio tool dispatch tests

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -805,6 +805,7 @@
   test_mcp_server_eio
   test_mcp_server_eio_call_tool
   test_mcp_server_eio_join_state
+  test_mcp_server_eio_tool_dispatch
   test_code_navigation_eio
   test_backend
   test_room_eio
@@ -1029,6 +1030,7 @@
   test_mcp_server_eio
   test_mcp_server_eio_call_tool
   test_mcp_server_eio_join_state
+  test_mcp_server_eio_tool_dispatch
   test_code_navigation_eio
   test_backend
   test_room_eio

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -9,7 +9,6 @@ module Types = Masc_domain
 module Mcp_eio = Masc_mcp.Mcp_server_eio
 module Mcp = Masc_mcp.Mcp_server
 module Config = Masc_mcp.Config
-module Tool_dispatch = Masc_mcp.Tool_dispatch
 module Tool_result = Tool_result
 module Keeper_types = Masc_mcp.Keeper_types
 module Keeper_registry = Masc_mcp.Keeper_registry
@@ -34,14 +33,6 @@ let cleanup_dir dir =
       Unix.unlink path
   in
   try rm dir with _ -> ()
-
-let create_admin_token base_path =
-  match
-    Masc_mcp.Auth.create_token base_path ~agent_name:"stable-admin"
-      ~role:Masc_domain.Admin
-  with
-  | Ok (token, _cred) -> token
-  | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e)
 
 let contains_substring s needle =
   let s_len = String.length s in
@@ -106,13 +97,6 @@ let make_keeper_meta ?agent_name ?tool_access name =
   match Masc_test_deps.meta_of_json_fixture json with
   | Ok meta -> meta
   | Error err -> Alcotest.fail ("make_keeper_meta failed: " ^ err)
-
-let extract_json_from_text text =
-  try
-    let idx = String.index text '{' in
-    Yojson.Safe.from_string (String.sub text idx (String.length text - idx))
-  with Not_found ->
-    Alcotest.failf "expected JSON payload in text: %s" text
 
 let tools_list_response ~clock ~sw ?profile ?cursor state =
   let params =
@@ -2887,119 +2871,6 @@ let test_handle_request_resources_subscribe_roundtrip () =
    | _ -> Alcotest.fail "unsubscribe response not an object");
   cleanup_dir base_path
 
-let test_execute_tool_help_tool () =
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  Mcp_eio.set_net (Eio.Stdenv.net env);
-  Mcp_eio.set_clock (Eio.Stdenv.clock env);
-  let clock = Eio.Stdenv.clock env in
-  Eio.Switch.run @@ fun sw ->
-  let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  let raw_token = create_admin_token base_path in
-  let result =
-    Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
-      ~name:"masc_tool_help"
-      ~arguments:(`Assoc [ ("tool_name", `String "masc_status") ])
-  in
-  Alcotest.(check bool) "tool help call succeeds" true result.Tool_result.success;
-  let json = extract_json_from_text (Tool_result.message result) in
-  Alcotest.(check string) "help tool echoes name" "masc_status"
-    Yojson.Safe.Util.(json |> member "name" |> to_string);
-  cleanup_dir base_path
-
-let test_execute_tool_tag_dispatch_respects_pre_hooks () =
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  Mcp_eio.set_net (Eio.Stdenv.net env);
-  Mcp_eio.set_clock (Eio.Stdenv.clock env);
-  let clock = Eio.Stdenv.clock env in
-  Eio.Switch.run @@ fun sw ->
-  let base_path = temp_dir () in
-  Fun.protect
-    ~finally:(fun () ->
-      Tool_dispatch.clear_hooks ();
-      cleanup_dir base_path)
-    (fun () ->
-      Tool_dispatch.clear_hooks ();
-      Tool_dispatch.register_pre_hook
-        (fun ~name ~args:_ ->
-          if String.equal name "masc_tool_help" then
-            Tool_dispatch.Reject
-              {
-                Tool_result.success = false;
-                data = `String "blocked-by-pre-hook";
-                legacy_message = "blocked-by-pre-hook";
-                tool_name = name;
-                duration_ms = 0.0;
-                failure_class = None;
-              }
-          else Tool_dispatch.Pass);
-      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-      let raw_token = create_admin_token base_path in
-      let _room_path = Masc_mcp.Coord.masc_dir state.room_config in
-      let hook_result =
-        Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
-          ~name:"masc_tool_help"
-          ~arguments:(`Assoc [ ("tool_name", `String "masc_status") ])
-      in
-      Alcotest.(check bool) "pre-hook blocks tagged dispatch" false
-        hook_result.Tool_result.success;
-      Alcotest.(check string) "blocked message returned" "blocked-by-pre-hook"
-        (Tool_result.message hook_result))
-
-let test_execute_tool_autoresearch_uses_resolved_session_agent () =
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  Mcp_eio.set_net (Eio.Stdenv.net env);
-  Mcp_eio.set_clock (Eio.Stdenv.clock env);
-  let clock = Eio.Stdenv.clock env in
-  Eio.Switch.run @@ fun sw ->
-  let base_path = temp_dir () in
-  let workdir_path = Filename.concat base_path "not-a-git-repo" in
-  Unix.mkdir workdir_path 0o755;
-  Fun.protect
-    ~finally:(fun () ->
-      Tool_dispatch.clear_hooks ();
-      cleanup_dir base_path)
-    (fun () ->
-      Tool_dispatch.clear_hooks ();
-      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-      let sid = "mcp-autoresearch-session-agent" in
-      let init_result =
-        Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
-          ~name:"masc_init" ~arguments:(`Assoc [])
-      in
-      (* masc_init pruned from registry — dispatch fails. Initialise
-         the room state directly so downstream masc_join succeeds. *)
-      Alcotest.(check bool) "init returns failure (tool pruned)" false init_result.Tool_result.success;
-      let _ = Masc_mcp.Coord.init state.room_config ~agent_name:None in
-      let join_result =
-        Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
-          ~name:"masc_join"
-          ~arguments:(`Assoc [ ("agent_name", `String "codex") ])
-      in
-      Alcotest.(check bool) "join success" true join_result.Tool_result.success;
-      let start_result =
-        Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
-          ~name:"masc_autoresearch_start"
-          ~arguments:
-            (`Assoc
-              [
-                ("goal", `String "permission regression");
-                ("metric_fn", `String "echo");
-                ("target_file", `String "target.txt");
-                ("workdir", `String workdir_path);
-                ("model_model", `String "test:dummy");
-                ("max_cycles", `Int 1);
-              ])
-      in
-      Alcotest.(check bool) "start fails" false start_result.Tool_result.success;
-      (* Without the legacy Tool_permissions pre-hook, the call reaches
-         workdir validation which rejects non-git directories. *)
-      Alcotest.(check bool) "fails at workdir validation" true
-        (contains_substring (Tool_result.message start_result) "workdir is not inside a git repository"))
-
 (* ===== Test Suites ===== *)
 
 let state_tests = [
@@ -3055,11 +2926,6 @@ let eio_tests = [
     test_handle_request_dashboard_ping_reports_unknown_ws_session;
   "handle resources/subscribe roundtrip", `Quick,
     test_handle_request_resources_subscribe_roundtrip;
-  "execute masc_tool_help", `Quick, test_execute_tool_help_tool;
-  "execute tag dispatch respects pre-hooks", `Quick,
-    test_execute_tool_tag_dispatch_respects_pre_hooks;
-  "execute autoresearch uses resolved session agent", `Quick,
-    test_execute_tool_autoresearch_uses_resolved_session_agent;
   "handle tools/list filters requested names", `Quick,
     test_handle_request_tools_list_rejects_nonstandard_names_filter;
   "handle initialize managed profile", `Quick,

--- a/test/test_mcp_server_eio_tool_dispatch.ml
+++ b/test/test_mcp_server_eio_tool_dispatch.ml
@@ -1,0 +1,176 @@
+module Mcp_eio = Masc_mcp.Mcp_server_eio
+module Tool_dispatch = Masc_mcp.Tool_dispatch
+module Tool_result = Tool_result
+
+let () = Mirage_crypto_rng_unix.use_default ()
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_mcp_eio_tool_dispatch_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.is_directory path then begin
+      Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+      Unix.rmdir path
+    end else
+      Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+let create_admin_token base_path =
+  match
+    Masc_mcp.Auth.create_token base_path ~agent_name:"stable-admin"
+      ~role:Masc_domain.Admin
+  with
+  | Ok (token, _cred) -> token
+  | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e)
+
+let contains_substring s needle =
+  let s_len = String.length s in
+  let n_len = String.length needle in
+  let rec loop i =
+    if i + n_len > s_len then false
+    else if String.sub s i n_len = needle then true
+    else loop (i + 1)
+  in
+  if n_len = 0 then true else loop 0
+
+let extract_json_from_text text =
+  try
+    let idx = String.index text '{' in
+    Yojson.Safe.from_string (String.sub text idx (String.length text - idx))
+  with Not_found ->
+    Alcotest.failf "expected JSON payload in text: %s" text
+
+let test_execute_tool_help_tool () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let raw_token = create_admin_token base_path in
+  let result =
+    Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
+      ~name:"masc_tool_help"
+      ~arguments:(`Assoc [ ("tool_name", `String "masc_status") ])
+  in
+  Alcotest.(check bool) "tool help call succeeds" true result.Tool_result.success;
+  let json = extract_json_from_text (Tool_result.message result) in
+  Alcotest.(check string) "help tool echoes name" "masc_status"
+    Yojson.Safe.Util.(json |> member "name" |> to_string);
+  cleanup_dir base_path
+
+let test_execute_tool_tag_dispatch_respects_pre_hooks () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Tool_dispatch.clear_hooks ();
+      cleanup_dir base_path)
+    (fun () ->
+      Tool_dispatch.clear_hooks ();
+      Tool_dispatch.register_pre_hook
+        (fun ~name ~args:_ ->
+          if String.equal name "masc_tool_help" then
+            Tool_dispatch.Reject
+              {
+                Tool_result.success = false;
+                data = `String "blocked-by-pre-hook";
+                legacy_message = "blocked-by-pre-hook";
+                tool_name = name;
+                duration_ms = 0.0;
+                failure_class = None;
+              }
+          else Tool_dispatch.Pass);
+      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      let raw_token = create_admin_token base_path in
+      let _room_path = Masc_mcp.Coord.masc_dir state.room_config in
+      let hook_result =
+        Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
+          ~name:"masc_tool_help"
+          ~arguments:(`Assoc [ ("tool_name", `String "masc_status") ])
+      in
+      Alcotest.(check bool) "pre-hook blocks tagged dispatch" false
+        hook_result.Tool_result.success;
+      Alcotest.(check string) "blocked message returned" "blocked-by-pre-hook"
+        (Tool_result.message hook_result))
+
+let test_execute_tool_autoresearch_uses_resolved_session_agent () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Mcp_eio.set_net (Eio.Stdenv.net env);
+  Mcp_eio.set_clock (Eio.Stdenv.clock env);
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  let workdir_path = Filename.concat base_path "not-a-git-repo" in
+  Unix.mkdir workdir_path 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      Tool_dispatch.clear_hooks ();
+      cleanup_dir base_path)
+    (fun () ->
+      Tool_dispatch.clear_hooks ();
+      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      let sid = "mcp-autoresearch-session-agent" in
+      let init_result =
+        Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
+          ~name:"masc_init" ~arguments:(`Assoc [])
+      in
+      (* masc_init pruned from registry - dispatch fails. Initialise
+         the room state directly so downstream masc_join succeeds. *)
+      Alcotest.(check bool) "init returns failure (tool pruned)" false
+        init_result.Tool_result.success;
+      let _ = Masc_mcp.Coord.init state.room_config ~agent_name:None in
+      let join_result =
+        Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
+          ~name:"masc_join"
+          ~arguments:(`Assoc [ ("agent_name", `String "codex") ])
+      in
+      Alcotest.(check bool) "join success" true join_result.Tool_result.success;
+      let start_result =
+        Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
+          ~name:"masc_autoresearch_start"
+          ~arguments:
+            (`Assoc
+              [
+                ("goal", `String "permission regression");
+                ("metric_fn", `String "echo");
+                ("target_file", `String "target.txt");
+                ("workdir", `String workdir_path);
+                ("model_model", `String "test:dummy");
+                ("max_cycles", `Int 1);
+              ])
+      in
+      Alcotest.(check bool) "start fails" false start_result.Tool_result.success;
+      (* Without the legacy Tool_permissions pre-hook, the call reaches
+         workdir validation which rejects non-git directories. *)
+      Alcotest.(check bool) "fails at workdir validation" true
+        (contains_substring (Tool_result.message start_result)
+           "workdir is not inside a git repository"))
+
+let () =
+  Alcotest.run "Mcp_server_eio_tool_dispatch"
+    [
+      ( "tool_dispatch",
+        [
+          "execute masc_tool_help", `Quick, test_execute_tool_help_tool;
+          ( "execute tag dispatch respects pre-hooks",
+            `Quick,
+            test_execute_tool_tag_dispatch_respects_pre_hooks );
+          ( "execute autoresearch uses resolved session agent",
+            `Quick,
+            test_execute_tool_autoresearch_uses_resolved_session_agent );
+        ] );
+    ]


### PR DESCRIPTION
Summary:
- split MCP Eio tool-dispatch cases into test_mcp_server_eio_tool_dispatch.ml
- remove the moved helper surface from test_mcp_server_eio.ml
- register the new test binary in test/dune

Validation:
- ocamlformat --check test/test_mcp_server_eio.ml test/test_mcp_server_eio_tool_dispatch.ml test/dune
- git diff --check
- bash scripts/lint/godfile-size-regression.sh
- scripts/ocaml-structure-ratchet.sh
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_mcp_server_eio_tool_dispatch.exe (blocked locally: scripts/dune-local.sh exit 75 because unrelated bare Dune processes are already holding the machine-wide Dune slot)