### PR TITLE
feat(scripts): audit-catchall.sh — classify 3417 catch-all arms by RHS

### DIFF
--- a/scripts/audit-catchall.sh
+++ b/scripts/audit-catchall.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Classify `| _ -> ...` catch-all arms across the OCaml tree.
+#
+# Motivation: the 2026-05-19 code-smell audit
+# (memory/masc-mcp-code-smell-report-2026-05-19.html, Hotspot #5)
+# counted 3,417 catch-all arms. The raw count mixes legitimate
+# variant catch-alls (e.g. `| _ -> acc` in a fold) with the
+# §AI 안티패턴 §4 (FSM Sparse Match) and §AI 안티패턴 §2
+# (Unknown -> Permissive Default) cases.
+#
+# This script bucketises every arm by the right-hand-side shape so
+# reviewers can ratchet-down the suspicious buckets without touching
+# the legitimate ones.
+#
+# Categories (priority order — first match wins):
+#   error-path           raise / failwith / Error _ / Exit / Invalid_argument
+#   unknown-sentinel     identifier ending in _unknown / HL_unknown / SL_unknown
+#                        / `Unknown _` / string "unknown"
+#   permissive-empty     None / [] / () / "" / 0 / 0.0 / false
+#                        — §AI §2 candidates
+#   literal-positive     true / Some _ literal — assertion-style fallback
+#   fallback-identifier  bare identifier (acc / default / result / state)
+#                        — fold or identity continuation (usually legit)
+#   other                everything else — needs manual audit
+#
+# Output modes:
+#   default          per-category totals (stdout)
+#   --by-file        top files with per-category counts
+#   --uncategorised  dump every `other` arm with file:line:body
+#   --file <PATH>    dump a single file's arms grouped by category
+#
+# Treat the report as informational. The script always exits 0
+# unless `--strict` is given: in that case the `other` bucket must
+# be zero (lockstep classification — CI ratchet candidate).
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "ripgrep (rg) is required" >&2
+  exit 2
+fi
+
+MODE="totals"
+TARGET="lib/"
+STRICT=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --by-file)       MODE="by-file"; shift ;;
+    --uncategorised) MODE="uncategorised"; shift ;;
+    --file)          MODE="single"; TARGET="$2"; shift 2 ;;
+    --strict)        STRICT=1; shift ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *)
+      echo "unknown arg: $1" >&2
+      exit 2 ;;
+  esac
+done
+
+# Collect raw matches as file:line:body. The leading whitespace and
+# the literal `| _ -> ` prefix are stripped to leave the RHS body.
+# `--with-filename` is required because rg omits the path when given
+# a single file as the search target.
+collect_arms() {
+  rg -nP --with-filename '^\s*\| _ -> ' "$1" 2>/dev/null \
+    | sed -E 's/^([^:]+:[0-9]+:)[[:space:]]*\| _ -> /\1/'
+}
+
+# Echo the category for one RHS body. Stdin = body.
+classify_body() {
+  awk '
+    {
+      body = $0
+      # Strip trailing close-parens, semicolons, comments
+      gsub(/\)+[[:space:]]*$/, "", body)
+      gsub(/;;[[:space:]]*$/, "", body)
+      gsub(/\(\*.*\*\)/, "", body)
+      sub(/^[[:space:]]+/, "", body)
+      sub(/[[:space:]]+$/, "", body)
+
+      # error-path
+      if (body ~ /^(raise[[:space:]]|failwith[[:space:]]|Error[[:space:]]|Invalid_argument|assert false|exit[[:space:]])/) {
+        print "error-path"; next
+      }
+      # unknown-sentinel
+      if (body ~ /(^|[^a-zA-Z_])(Unknown[[:space:]]|HL_unknown|SL_unknown|[A-Za-z_]+_unknown\b)/ \
+          || tolower(body) ~ /"unknown"/ \
+          || tolower(body) ~ /"_other_"/ \
+          || tolower(body) ~ /"other"/) {
+        print "unknown-sentinel"; next
+      }
+      # permissive-empty
+      if (body == "None"      \
+          || body == "[]"     \
+          || body == "()"     \
+          || body == "\"\""   \
+          || body == "0"      \
+          || body == "0.0"    \
+          || body == "false"  \
+          || body == "0L"     \
+          || body == "0l") {
+        print "permissive-empty"; next
+      }
+      # literal-positive
+      if (body == "true" || body ~ /^Some [A-Za-z0-9_"]+$/) {
+        print "literal-positive"; next
+      }
+      # fallback-identifier (bare lowercase ident, no parens / no leading ctor)
+      if (body ~ /^[a-z_][a-zA-Z0-9_]*$/) {
+        print "fallback-identifier"; next
+      }
+      print "other"
+    }
+  '
+}
+
+case "$MODE" in
+  totals)
+    collect_arms "$TARGET" \
+      | awk -F: '{ for (i=3; i<=NF; i++) printf "%s%s", $i, (i==NF? "\n":":") }' \
+      | classify_body \
+      | sort | uniq -c | sort -rn
+    ;;
+
+  by-file)
+    tmp="$(mktemp)"
+    collect_arms "$TARGET" > "$tmp"
+    cut -d: -f1 "$tmp" | sort | uniq -c | sort -rn | head -20 \
+      | while read -r count file; do
+          per=$(awk -F: -v f="$file" '$1==f { for (i=3;i<=NF;i++) printf "%s%s", $i, (i==NF? "\n":":") }' "$tmp" \
+                  | classify_body | sort | uniq -c | sort -rn | tr '\n' ' ')
+          printf '%5d  %-60s  %s\n' "$count" "$file" "$per"
+        done
+    rm -f "$tmp"
+    ;;
+
+  uncategorised)
+    collect_arms "$TARGET" \
+      | while IFS= read -r line; do
+          body="${line#*:*:}"
+          cat=$(printf '%s\n' "$body" | classify_body)
+          [[ "$cat" == "other" ]] && printf '%s\n' "$line"
+        done
+    ;;
+
+  single)
+    collect_arms "$TARGET" \
+      | while IFS= read -r line; do
+          body="${line#*:*:}"
+          cat=$(printf '%s\n' "$body" | classify_body)
+          printf '%-20s %s\n' "$cat" "$line"
+        done | sort
+    ;;
+esac
+
+if [[ "$STRICT" -eq 1 ]]; then
+  others=$(collect_arms "$TARGET" \
+    | awk -F: '{ for (i=3; i<=NF; i++) printf "%s%s", $i, (i==NF? "\n":":") }' \
+    | classify_body | grep -c '^other$' || true)
+  if [[ "$others" -gt 0 ]]; then
+    echo "STRICT FAIL: $others arms uncategorised" >&2
+    exit 1
+  fi
+fi


### PR DESCRIPTION
## 요약

`scripts/audit-catchall.sh` 신설. 보고서 §5 Action 4 구현. `| _ -> RHS` 3,417 사이트를 RHS 형태별로 6 카테고리로 분류해 §AI 안티패턴 §4 (FSM Sparse Match) / §AI 안티패턴 §2 (Unknown → Permissive Default) 후보를 정당한 variant catch-all로부터 분리한다.

## 동기

`memory/masc-mcp-code-smell-report-2026-05-19.html` Hotspot #5는 3,417 catch-all 사이트를 보고했지만 정당/안티 분리 없이는 ratchet/sweep으로 이어지지 않는다. grep 통계 위에 RHS 분류를 얹어 evidence-driven 후속 PR을 가능하게 만든다.

## 카테고리 (priority order — first match wins)

| 카테고리 | RHS 형태 | 평가 |
|----------|----------|------|
| `error-path` | `raise` / `failwith` / `Error _` / `assert false` / `exit` / `Invalid_argument` | 정당 |
| `unknown-sentinel` | `Unknown _` / `_unknown` ident / `"unknown"` / `"_other_"` / `"other"` 문자열 | §AI §2 강한 의심 — 단, variant `Unknown`은 정당이 흔하므로 수동 triage |
| `permissive-empty` | `None` / `[]` / `()` / `""` / `0` / `0.0` / `false` / `0L` / `0l` | §AI §2 주요 후보 |
| `literal-positive` | `true` / `Some <literal>` | assertion fallback — review |
| `fallback-identifier` | bare lowercase ident (`acc` / `default` / `result` / `state`) | fold/identity continuation, 보통 정당 |
| `other` | 그 외 | 수동 audit |

## First-light 측정 (lib/, 2026-05-19)

```
2001 permissive-empty
 867 other
 270 fallback-identifier
 209 error-path
  47 literal-positive
  24 unknown-sentinel
```

Top hot files (by-file):

```
 44  test_bash_parser.ml            44 error-path                                     # 전부 정당 (test)
 35  cascade_error_classify.ml      34 permissive-empty + 1 other                    # §AI §2 강한 후보
 27  server_dashboard_http.ml       17 permissive-empty + 8 other + 1 literal-positive + 1 error-path
 26  telemetry_unified.ml           21 permissive-empty + 3 literal-positive + 1 other + 1 fallback-identifier
 23  keeper_runtime_trust_timeline  13 permissive-empty + 8 other + 2 fallback-identifier
 23  dashboard_http_tool_quality    13 permissive-empty + 10 other
 22  dashboard_http_keeper          14 permissive-empty + 7 other + 1 fallback-identifier
 20  tool_task.ml                   13 permissive-empty + 3 other + 2 fallback-identifier + 1 literal-positive + 1 error-path
 20  model_inference_metrics_parser 17 permissive-empty + 3 error-path
 20  keeper_meta_contract.ml        16 permissive-empty + 4 other
 20  test_approval_policy.ml        20 error-path                                     # 전부 정당
```

## 모드

```
audit-catchall.sh                    # totals
audit-catchall.sh --by-file          # top 20 files w/ category breakdown
audit-catchall.sh --uncategorised    # dump all `other` arms (file:line:body)
audit-catchall.sh --file PATH        # single file, each arm with its category
audit-catchall.sh --strict           # exit 1 if `other` > 0 (lockstep ratchet)
```

## 변경 / 보존

- **추가**: `scripts/audit-catchall.sh` 169 LoC, 단독 bash + ripgrep + awk + sed
- **기존 동작**: 변경 없음 (이 PR은 도구만 추가, default exit 0 informational)
- **CI 부담**: 0 (별도 wire-in 없음)

## 후속 (이 PR 범위 외)

§5 Action 5와 결합:
1. `cascade_error_classify.ml`의 34 permissive-empty를 typed Result 또는 closed sum type으로 변환
2. `telemetry_unified.ml`의 21을 telemetry envelope 강제 evaluation으로 변환
3. `keeper_meta_contract.ml`의 16을 exhaustive variant match로 닫기
4. 후속 PR에서 `--strict` mode를 `Detect Changed Surfaces` workflow에 advisory로 연결 (still exit 0)

## 알려진 한계

- BSD awk vs GNU awk regex 차이는 회피했지만 일부 multiline match expression의 right-hand side는 `awk`로 inline 추출이 어렵다. 분류기는 single-line RHS를 가정. 보고서 3,417 totals와 본 카운트 ±1 차이 발생.
- variant `Unknown _`은 정당한 catch-all (closed sum type 외 fallback). 본 분류기는 `unknown-sentinel` 버킷에 묶은 뒤 수동 triage 권장.

RFC-WAIVED: read-only audit tool, exit 0 by default.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
