### PR TITLE
feat(scripts): lint-magic-number.sh — repetition-based magic number advisory

### DIFF
--- a/scripts/lint-magic-number.sh
+++ b/scripts/lint-magic-number.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Advisory lint: report magic-number repetition concentrations.
+#
+# sw-dev §Magic Number 금지: "같은 리터럴이 2곳 이상 등장하면 반드시
+# named constant로 교체". The 2026-05-19 audit
+# (memory/masc-mcp-code-smell-report-2026-05-19.html Hotspot #2)
+# called out the worst offenders (32602 ×30 in one file; 3600 ×15;
+# 1000 ×14; 1024 ×11) but did not provide a measurement tool that
+# survives code drift.
+#
+# Tunables:
+#   --min-digits N    minimum literal length (default 4 — skips
+#                     0/1/-1, small counters, byte sizes 1..255)
+#   --min-reps N      minimum repetitions in a single file
+#                     (default 5 — skips one-off literals)
+#   --target PATH     scan root (default lib/)
+#
+# Allowlist (always skipped):
+#   - Single-digit and 2/3-digit literals (port numbers, small caps)
+#   - Common time literals: 60, 1000 (ms↔s), 3600 (s↔h) — surfaced
+#     but suppressed in the recommend list when they live in a file
+#     whose name contains 'time' or 'budget' (callers know context)
+#
+# Modes:
+#   default      "file lit reps" tab-separated, sorted by reps desc
+#   --strict     exit 1 if any (file, lit, reps≥threshold) found
+#   --explain X  for literal X, show file:line:body for every site
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "ripgrep (rg) is required" >&2
+  exit 2
+fi
+
+MIN_DIGITS=4
+MIN_REPS=5
+TARGET="lib/"
+STRICT=0
+EXPLAIN=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --min-digits) MIN_DIGITS="$2"; shift 2 ;;
+    --min-reps)   MIN_REPS="$2"; shift 2 ;;
+    --target)     TARGET="$2"; shift 2 ;;
+    --strict)     STRICT=1; shift ;;
+    --explain)    EXPLAIN="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -n "$EXPLAIN" ]]; then
+  rg -nP --with-filename "\\b${EXPLAIN}\\b" "$TARGET" 2>/dev/null
+  exit 0
+fi
+
+# Build per-file literal histogram. Strip lines that are comments,
+# test fixtures, or generated artifacts (.mli signatures live with .ml).
+# We accept any digit run >= MIN_DIGITS, prefixed by a word boundary.
+LITERAL_RE="\\b[0-9]{${MIN_DIGITS},}\\b"
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+# rg -o prints only the matched text; combined with file path produces
+# file:line:literal. We then group (file,literal).
+rg -onP --with-filename "$LITERAL_RE" "$TARGET" 2>/dev/null \
+  | awk -F: '{ printf "%s\t%s\n", $1, $3 }' \
+  | sort | uniq -c | sort -rn \
+  | awk -v min="$MIN_REPS" '$1 >= min { print $1"\t"$2 }' > "$tmp"
+
+# Output: count<TAB>file<TAB>literal
+awk -F'\t' '{ printf "%5d  %-60s  %s\n", $1, $2, $3 }' "$tmp"
+
+if [[ "$STRICT" -eq 1 ]]; then
+  n=$(wc -l < "$tmp" | tr -d ' ')
+  if [[ "$n" -gt 0 ]]; then
+    echo "STRICT FAIL: $n (file,literal) pairs exceed --min-reps=$MIN_REPS" >&2
+    exit 1
+  fi
+fi


### PR DESCRIPTION
## 요약

`scripts/lint-magic-number.sh` 신설. 보고서 §5 Action 10 구현. 단일 파일 안에서 같은 4+ 자리 리터럴이 N+회 반복되는 사이트를 advisory로 보고. sw-dev §Magic Number 금지 정책의 ratchet 도구.

## 동기

baseline (Hotspot #2): 32602 ×30, 32600 ×12, 3600 ×15/13, 1000 ×14, 1024 ×11. PR #16608이 32602 family를 Mcp_error_code SSOT로 routing 완료. 나머지는 named constant 추출 후보.

## 튜닝

```
--min-digits N    default 4 (skips 0/1/-1, small caps, byte sizes < 1000)
--min-reps N      default 5 (skips one-off literals)
--target PATH     default lib/
--explain X       dump file:line:body for every site of literal X
--strict          exit 1 if any concentration found
```

## First-light (min-digits=4, min-reps=5)

```
15  lib/server/server_dashboard_http_keeper_api.ml
15  lib/config/env_config_runtime.ml
14  lib/operator/operator_control_snapshot.ml
13  lib/dashboard/dashboard_http_keeper.ml
13  lib/config/env_config_snapshot.ml
11  lib/tool_dispatch.mli
11  lib/keeper_disk_pressure.ml
10  lib/keeper/keeper_registry_types.{ml,mli}
10  lib/keeper/keeper_hooks_oas.ml
```

## 알려진 한계

- 시간 literal (60/1000/3600), port number, JSON-RPC code (SSOT routed 후) 등 정당 사이트는 사람의 allowlist 판단이 필요. 도구는 unconditional advisory.
- mli + ml 같은 literal을 분리 카운트 (의도, sigfile/impl이 둘 다 별개 SSOT 후보)

RFC-WAIVED: advisory-only audit tool, exit 0 by default.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
