### PR TITLE
refactor(keeper_meta_contract): exhaustive blocker_class_continue_gate

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -201,8 +201,30 @@ let cascade_exhaustion_summary = function
 ;;
 
 let blocker_class_continue_gate = function
-  | Ambiguous_post_commit_timeout | Ambiguous_post_commit_failure -> true
-  | _ -> false
+  | Ambiguous_post_commit_timeout
+  | Ambiguous_post_commit_failure -> true
+  | Cascade_exhausted _
+  | Autonomous_slot_wait_timeout
+  | Admission_queue_wait_timeout
+  | Turn_timeout_after_queue_wait
+  | Oas_timeout_budget
+  | Turn_timeout
+  | Turn_livelock_blocked
+  | Completion_contract_violation
+  | No_tool_capable_provider
+  | Stay_silent_loop
+  | Fiber_unresolved
+  | Stale_turn_timeout
+  | Stale_fleet_batch
+  | Sdk_max_turns_exceeded
+  | Sdk_token_budget_exceeded
+  | Sdk_cost_budget_exceeded
+  | Sdk_unrecognized_stop_reason
+  | Sdk_idle_detected
+  | Sdk_tool_retry_exhausted
+  | Sdk_guardrail_violation
+  | Sdk_tripwire_violation
+  | Sdk_exit_condition_met -> false
 ;;
 
 let cascade_exhaustion_reason_to_json = function


### PR DESCRIPTION
## 요약

`keeper_meta_contract.ml:203-206`의 `blocker_class_continue_gate`를 exhaustive match로 변환. `| _ -> false` catch-all을 24 constructor 전부 명시로 교체. §AI 안티패턴 §4 (FSM Sparse Match) 해소.

## 동기

`memory/masc-mcp-action5-evidence-2026-05-19.md` (PR jeong-sik/me#1145) sweep 결과 4 hot file을 검증한 결과, 대부분의 `permissive-empty` 사이트는 JSON parser boundary fallback이었다. 비-경계 §AI §4 사이트는 **이 한 곳**.

`blocker_class`는 24 constructor의 closed sum type. 새 constructor 추가 시 `| _ -> false` catch-all은 silently `continue=false`로 흘려보냄 — 새 blocker가 continue 가능해야 하는지 명시적 결정을 강제하지 못함.

## 변경

```ocaml
(* before *)
let blocker_class_continue_gate = function
  | Ambiguous_post_commit_timeout | Ambiguous_post_commit_failure -> true
  | _ -> false

(* after *)
let blocker_class_continue_gate = function
  | Ambiguous_post_commit_timeout
  | Ambiguous_post_commit_failure -> true
  | Cascade_exhausted _
  | Autonomous_slot_wait_timeout
  ... (22 ctors enumerated)
  | Sdk_exit_condition_met -> false
```

## 보존

- **동작 동일**: 두 `true` 사이트 (Ambiguous_post_commit_*) 보존, 나머지 22 ctor → `false` 그대로
- **외부 surface**: `.mli` 변경 없음, caller signature 동일
- **새 ctor 추가 시**: 컴파일 에러로 이 site를 강제로 다시 보게 됨

## 측정

- 보고서 §AI §4 가이드라인 핵심: "FSM 전이 매트릭스는 `_ -> false` catch-all을 사용하지 않고 모든 쌍을 명시. OCaml의 exhaustive match를 활용해 새 variant 추가 시 컴파일 타임에 누락 감지."
- 본 변경은 이 정책의 single-line application.

RFC-WAIVED: exhaustive match conversion, runtime semantics identical.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
