### PR TITLE
refactor(keeper_registry_types): make origin_allows_paired_lifecycle_event exhaustive on origin

### DIFF
--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -1120,15 +1120,28 @@ let is_paired_lifecycle_event = function
 ;;
 
 let origin_allows_paired_lifecycle_event origin event =
-  match origin, event with
-  | Post_turn_lifecycle, event when is_paired_lifecycle_event event -> true
-  | ( Operator_compact
-    , ( Keeper_state_machine.Compaction_started
-      | Keeper_state_machine.Compaction_completed _
-      | Keeper_state_machine.Compaction_failed _ ) ) -> true
-  | Generic_dispatch, event when is_paired_lifecycle_event event -> false
-  | Operator_compact, event when is_paired_lifecycle_event event -> false
-  | _, _ -> true
+  (* This guard only constrains paired lifecycle events (compaction +
+     handoff half-events). For any other event the gate is outside its
+     domain and returns true unconditionally — the caller's question
+     does not apply. *)
+  if not (is_paired_lifecycle_event event) then true
+  else
+    (* Outer match is exhaustive on [lifecycle_event_origin] so adding a
+       new origin variant forces an explicit arm here instead of silently
+       inheriting the previous [_, _ -> true] default-allow catch-all,
+       which was the FSM-sparse-match anti-pattern called out in
+       instructions/software-development.md §4. *)
+    match origin with
+    | Post_turn_lifecycle -> true
+    | Generic_dispatch -> false
+    | Operator_compact ->
+      (* Operator_compact authorizes only compaction half-events;
+         handoff half-events flow through other origins. *)
+      (match event with
+       | Keeper_state_machine.Compaction_started
+       | Keeper_state_machine.Compaction_completed _
+       | Keeper_state_machine.Compaction_failed _ -> true
+       | _ -> false)
 ;;
 
 let pending_measurement_after_event now entry event =


### PR DESCRIPTION
## Goal

Eliminate the \`_, _ -> true\` catch-all in \`lib/keeper/keeper_registry_types.ml:1131\`. This is the FSM-sparse-match anti-pattern documented in \`instructions/software-development.md §4\`: a new \`lifecycle_event_origin\` variant added to the type would silently inherit \`default-allow\` semantics without any compile error.

Discovered by parallel scout sweep during /loop Iter#43, verified and corrected in Iter#45.

## Before

\`\`\`ocaml
let origin_allows_paired_lifecycle_event origin event =
  match origin, event with
  | Post_turn_lifecycle, event when is_paired_lifecycle_event event -> true
  | (Operator_compact, (Compaction_started | Compaction_completed _ | Compaction_failed _)) -> true
  | Generic_dispatch, event when is_paired_lifecycle_event event -> false
  | Operator_compact, event when is_paired_lifecycle_event event -> false
  | _, _ -> true
\`\`\`

## After

\`\`\`ocaml
let origin_allows_paired_lifecycle_event origin event =
  if not (is_paired_lifecycle_event event) then true
  else
    match origin with
    | Post_turn_lifecycle -> true
    | Generic_dispatch -> false
    | Operator_compact ->
      (match event with
       | Keeper_state_machine.Compaction_started
       | Keeper_state_machine.Compaction_completed _
       | Keeper_state_machine.Compaction_failed _ -> true
       | _ -> false)
\`\`\`

## Behavior preserved

| Origin              | event             | Result |
|---------------------|-------------------|--------|
| Post_turn_lifecycle | any paired event   | true   |
| Generic_dispatch    | any paired event   | false  |
| Operator_compact    | Compaction_*       | true   |
| Operator_compact    | Handoff_*          | false  |
| (any)               | non-paired event   | true   |

Five rows × confirmed against the original match arms by hand. The pure refactor's value is *future safety*: adding a new origin variant to the type now yields a compile error here, instead of silently falling into the previous \`_, _ -> true\` default-allow branch.

## Verification

\`\`\`
dune build --root . @check       # clean
\`\`\`

No existing tests cover this function directly; caller \`lib/keeper/keeper_registry.ml\` is exercised by integration tests for paired lifecycle dispatch. Unit-test extraction is a separate task (deliberately not bundled to keep this PR a pure refactor).

## Touch points

- 1 file, +22 / -9 LoC (mostly the rationale comment + explicit arms)

## Sibling cousin (separate PR scope)

The scout report also flagged \`keeper_heartbeat_loop.ml:1342\` \`cycle_continues_after_wake\` (1 explicit arm + fallback). Same anti-pattern shape but different domain; should ship as a follow-up so each PR remains reviewable in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>