### PR TITLE
fix(dashboard): RFC-0135 §11.1 audit — add turn_livelock_blocked to typed blocker class union

### DIFF
--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -196,6 +196,7 @@ const runtimeBlockerLabels = {
   turn_timeout_after_queue_wait: '대기 후 턴 만료',
   oas_timeout_budget: 'OAS 응답 만료',
   turn_timeout: '턴 응답 만료',
+  turn_livelock_blocked: '턴 livelock 차단',
   completion_contract_violation: '완료 계약 위반',
   cascade_exhausted: '캐스케이드 소진',
   no_tool_capable_provider: '도구 실행 Provider 없음',

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -392,6 +392,11 @@ export const KEEPER_RUNTIME_BLOCKER_CLASSES = [
   'turn_timeout_after_queue_wait',
   'oas_timeout_budget',
   'turn_timeout',
+  // Emitted by `lib/keeper/keeper_meta_contract.ml:101` (Turn_livelock_blocked)
+  // serialized via `blocker_class_to_string` → `"turn_livelock_blocked"`.
+  // Korean label already exists at `fsm-hub-types.ts:572` — the union
+  // omission caused silent string-fallback narrowing on the wire.
+  'turn_livelock_blocked',
   'completion_contract_violation',
   'cascade_exhausted',
   'no_tool_capable_provider',


### PR DESCRIPTION
## Summary

RFC-0135 §11.1 *typed sum 의 variant arm 확정* audit 의 실증 결과: backend `keeper_meta_contract.ml:101` 의 \`Turn_livelock_blocked\` variant 가 wire 에 \`\"turn_livelock_blocked\"\` 로 emit 되지만 dashboard \`KEEPER_RUNTIME_BLOCKER_CLASSES\` 에서 누락되어 silent string-fallback narrowing 됨.

흥미로운 점: \`fsm-hub-types.ts:572\` 에는 한국어 라벨 (\`'턴 livelock 차단'\`) 이 이미 존재했으나, types/core 의 union 에 누락되어 \`satisfies Record<KeeperRuntimeBlockerClass, string>\` SSOT 가드 (keeper-runtime-display.ts:227) 가 *현재 시점에서는* 통과. union 추가로 가드가 재정렬됨.

## Why

- 사용자 RFC-0135 §11.1 open question 의 직접 audit 결과
- 본 세션 *놓친 구현 자평* 에서 발견된 유일한 confirmed drift
- 기존 SSOT 가드 (\`satisfies Record<...>\`) 와 정합 — 가드가 향후 drift 방지

## Trade-off

- 추가 변경 없음 (union 1 entry + label 1 entry, +6 lines)
- backend variants 와 1:1 매칭 부족 부분 (e.g., \`provider_runtime_error\`, \`heartbeat_failures\` 등은 dashboard 만 존재) 은 본 PR 범위 외 — 별도 audit 가 필요하나 *backend wire path 미확인* 이므로 yagni
- 회귀 위험: 없음. 신규 enum 값 추가 + label 매핑만

## Test plan

- [x] \`pnpm typecheck\` PASS (\`satisfies Record<KeeperRuntimeBlockerClass, string>\` 가드 통과)
- [x] \`vitest run src/lib/keeper-runtime-display\` 36/36 PASS
- [ ] human review for backend wire path confirmation

## Related

- RFC-0135 §11.1 (typed sum variant arm 확정)
- Backend SSOT: \`lib/keeper/keeper_meta_contract.ml:101\` (\`Turn_livelock_blocked\` variant)
- Existing label: \`dashboard/src/components/fsm-hub-types.ts:572\`

RFC-WAIVED: typed sum drift fix, no architectural change

🤖 Generated with [Claude Code](https://claude.com/claude-code)