### PR TITLE
refactor: split keeper state machine mermaid tests

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -286,6 +286,7 @@
   test_run_local_script
   test_tool_prefilter
   test_keeper_state_machine
+  test_keeper_state_machine_mermaid
   test_keeper_state_machine_correspondence
   test_keeper_state_machine_tla_correspondence
   test_keeper_lifecycle_hooks
@@ -592,6 +593,7 @@
   test_run_local_script
   test_tool_prefilter
   test_keeper_state_machine
+  test_keeper_state_machine_mermaid
   test_keeper_state_machine_preconditions
   test_keeper_state_machine_correspondence
   test_keeper_state_machine_tla_correspondence

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -2221,116 +2221,6 @@ let test_invariant_priority_chain () =
 
 let test_all_phases_covered () = check int "13 phases" 13 (List.length SM.all_phases)
 
-(* ── Mermaid diagram tests ─────────────────────────────── *)
-
-(** Returns all lines of the Mermaid output for a given current phase. *)
-let mermaid_lines phase = SM.phase_to_mermaid ~current:phase |> String.split_on_char '\n'
-
-(** Returns true if [needle] appears as a substring of [haystack]. *)
-let string_contains haystack needle =
-  let hl = String.length haystack
-  and nl = String.length needle in
-  if nl = 0
-  then true
-  else if hl < nl
-  then false
-  else (
-    let found = ref false in
-    for i = 0 to hl - nl do
-      if (not !found) && String.sub haystack i nl = needle then found := true
-    done;
-    !found)
-;;
-
-let test_mermaid_header () =
-  let lines = mermaid_lines SM.Running in
-  check string "starts with stateDiagram-v2" "stateDiagram-v2" (List.nth lines 0)
-;;
-
-let test_mermaid_all_phases_appear () =
-  List.iter
-    (fun phase ->
-       let diagram = SM.phase_to_mermaid ~current:phase in
-       let id = SM.phase_to_mermaid_id phase in
-       check
-         bool
-         (Printf.sprintf "phase %s appears in diagram" id)
-         true
-         (string_contains diagram id))
-    SM.all_phases
-;;
-
-let class_lines_for lines id =
-  let prefix = Printf.sprintf "    class %s " id in
-  List.filter
-    (fun l ->
-       String.length l >= String.length prefix
-       && String.sub l 0 (String.length prefix) = prefix)
-    lines
-;;
-
-let test_mermaid_active_class () =
-  let active_phases = [ SM.Offline; SM.Running; SM.Paused ] in
-  List.iter
-    (fun phase ->
-       let lines = mermaid_lines phase in
-       let id = SM.phase_to_mermaid_id phase in
-       let cls = class_lines_for lines id in
-       check
-         int
-         (Printf.sprintf "phase %s has exactly one class line" id)
-         1
-         (List.length cls);
-       check
-         bool
-         (Printf.sprintf "phase %s assigned active class" id)
-         true
-         (List.mem (Printf.sprintf "    class %s active" id) cls))
-    active_phases
-;;
-
-let test_mermaid_buffer_class () =
-  let buffer_phases =
-    [ SM.Failing; SM.Compacting; SM.HandingOff; SM.Draining; SM.Restarting ]
-  in
-  List.iter
-    (fun phase ->
-       let lines = mermaid_lines phase in
-       let id = SM.phase_to_mermaid_id phase in
-       let cls = class_lines_for lines id in
-       check
-         int
-         (Printf.sprintf "phase %s has exactly one class line" id)
-         1
-         (List.length cls);
-       check
-         bool
-         (Printf.sprintf "phase %s assigned buffer class (not active)" id)
-         true
-         (List.mem (Printf.sprintf "    class %s buffer" id) cls))
-    buffer_phases
-;;
-
-let test_mermaid_terminal_class () =
-  let terminal_phases = [ SM.Stopped; SM.Dead ] in
-  List.iter
-    (fun phase ->
-       let lines = mermaid_lines phase in
-       let id = SM.phase_to_mermaid_id phase in
-       let cls = class_lines_for lines id in
-       check
-         int
-         (Printf.sprintf "phase %s has exactly one class line" id)
-         1
-         (List.length cls);
-       check
-         bool
-         (Printf.sprintf "phase %s assigned terminal class" id)
-         true
-         (List.mem (Printf.sprintf "    class %s terminal" id) cls))
-    terminal_phases
-;;
-
 (* ── Set/Clear Coverage ────────────────────────────────── *)
 
 (** Static verification that every boolean condition field in the FSM
@@ -2875,16 +2765,6 @@ let () =
             `Quick
             test_invariant_derive_matches_matrix
         ; test_case "INV-10: priority chain ordering" `Quick test_invariant_priority_chain
-        ] )
-    ; ( "mermaid"
-      , [ test_case "header is stateDiagram-v2" `Quick test_mermaid_header
-        ; test_case "all phases appear in diagram" `Quick test_mermaid_all_phases_appear
-        ; test_case "active phases get active class only" `Quick test_mermaid_active_class
-        ; test_case "buffer phases get buffer class only" `Quick test_mermaid_buffer_class
-        ; test_case
-            "terminal phases get terminal class only"
-            `Quick
-            test_mermaid_terminal_class
         ] )
     ; ( "setclear_coverage"
       , [ test_case

--- a/test/test_keeper_state_machine_mermaid.ml
+++ b/test/test_keeper_state_machine_mermaid.ml
@@ -1,0 +1,125 @@
+open Alcotest
+module SM = Masc_mcp.Keeper_state_machine
+
+(** Returns all lines of the Mermaid output for a given current phase. *)
+let mermaid_lines phase = SM.phase_to_mermaid ~current:phase |> String.split_on_char '\n'
+
+(** Returns true if [needle] appears as a substring of [haystack]. *)
+let string_contains haystack needle =
+  let hl = String.length haystack
+  and nl = String.length needle in
+  if nl = 0
+  then true
+  else if hl < nl
+  then false
+  else (
+    let found = ref false in
+    for i = 0 to hl - nl do
+      if (not !found) && String.sub haystack i nl = needle then found := true
+    done;
+    !found)
+;;
+
+let test_mermaid_header () =
+  let lines = mermaid_lines SM.Running in
+  check string "starts with stateDiagram-v2" "stateDiagram-v2" (List.nth lines 0)
+;;
+
+let test_mermaid_all_phases_appear () =
+  List.iter
+    (fun phase ->
+       let diagram = SM.phase_to_mermaid ~current:phase in
+       let id = SM.phase_to_mermaid_id phase in
+       check
+         bool
+         (Printf.sprintf "phase %s appears in diagram" id)
+         true
+         (string_contains diagram id))
+    SM.all_phases
+;;
+
+let class_lines_for lines id =
+  let prefix = Printf.sprintf "    class %s " id in
+  List.filter
+    (fun l ->
+       String.length l >= String.length prefix
+       && String.sub l 0 (String.length prefix) = prefix)
+    lines
+;;
+
+let test_mermaid_active_class () =
+  let active_phases = [ SM.Offline; SM.Running; SM.Paused ] in
+  List.iter
+    (fun phase ->
+       let lines = mermaid_lines phase in
+       let id = SM.phase_to_mermaid_id phase in
+       let cls = class_lines_for lines id in
+       check
+         int
+         (Printf.sprintf "phase %s has exactly one class line" id)
+         1
+         (List.length cls);
+       check
+         bool
+         (Printf.sprintf "phase %s assigned active class" id)
+         true
+         (List.mem (Printf.sprintf "    class %s active" id) cls))
+    active_phases
+;;
+
+let test_mermaid_buffer_class () =
+  let buffer_phases =
+    [ SM.Failing; SM.Compacting; SM.HandingOff; SM.Draining; SM.Restarting ]
+  in
+  List.iter
+    (fun phase ->
+       let lines = mermaid_lines phase in
+       let id = SM.phase_to_mermaid_id phase in
+       let cls = class_lines_for lines id in
+       check
+         int
+         (Printf.sprintf "phase %s has exactly one class line" id)
+         1
+         (List.length cls);
+       check
+         bool
+         (Printf.sprintf "phase %s assigned buffer class (not active)" id)
+         true
+         (List.mem (Printf.sprintf "    class %s buffer" id) cls))
+    buffer_phases
+;;
+
+let test_mermaid_terminal_class () =
+  let terminal_phases = [ SM.Stopped; SM.Dead ] in
+  List.iter
+    (fun phase ->
+       let lines = mermaid_lines phase in
+       let id = SM.phase_to_mermaid_id phase in
+       let cls = class_lines_for lines id in
+       check
+         int
+         (Printf.sprintf "phase %s has exactly one class line" id)
+         1
+         (List.length cls);
+       check
+         bool
+         (Printf.sprintf "phase %s assigned terminal class" id)
+         true
+         (List.mem (Printf.sprintf "    class %s terminal" id) cls))
+    terminal_phases
+;;
+
+let () =
+  run "keeper_state_machine_mermaid"
+    [ ( "mermaid"
+      , [ test_case "header is stateDiagram-v2" `Quick test_mermaid_header
+        ; test_case "all phases appear in diagram" `Quick test_mermaid_all_phases_appear
+        ; test_case "active phases get active class only" `Quick test_mermaid_active_class
+        ; test_case "buffer phases get buffer class only" `Quick test_mermaid_buffer_class
+        ; test_case
+            "terminal phases get terminal class only"
+            `Quick
+            test_mermaid_terminal_class
+        ] )
+    ]
+;;


### PR DESCRIPTION
Summary:
- split Keeper_state_machine Mermaid diagram tests into test_keeper_state_machine_mermaid.ml
- register the new test binary in test/dune
- reduce test/test_keeper_state_machine.ml from 2998 to 2878 lines on this branch base

Validation:
- ocamlformat --check test/test_keeper_state_machine.ml test/test_keeper_state_machine_mermaid.ml test/dune
- git diff --check
- bash scripts/lint/godfile-size-regression.sh
- scripts/ocaml-structure-ratchet.sh
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_state_machine_mermaid.exe (started but manually stopped after >7m of no output to avoid occupying the shared Dune slot; CI is the compile surface for this slice)