### PR TITLE
feat(keeper): structured contract violation encoding in execution receipt

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -208,6 +208,80 @@ let tool_contract_result_of_contract_status
   | Satisfied_execution -> Contract_satisfied_execution
 ;;
 
+(* Structured contract-violation terminal_reason_code encoding.
+   The legacy wire format is:
+     completion_contract_violation:<contract_id>
+   The extended format adds called and satisfying tool lists:
+     completion_contract_violation:<contract_id>:called[t1,t2]:satisfying[t3,t4]
+   Both forms start with the same prefix so existing prefix-matching
+   consumers (dashboard, disposition logic) remain backward-compatible.
+   Empty tool lists are encoded as empty brackets: called[]:satisfying[]. *)
+
+let encode_tool_list = function
+  | [] -> "[]"
+  | tools -> "[" ^ String.concat "," tools ^ "]"
+;;
+
+let encode_contract_violation_reason
+    ~called_tools
+    ~satisfying_tools
+    (contract_id : string)
+  : string
+  =
+  Printf.sprintf
+    "completion_contract_violation:%s:called%s:satisfying%s"
+    contract_id
+    (encode_tool_list called_tools)
+    (encode_tool_list satisfying_tools)
+;;
+
+(* Decode the extended terminal_reason_code back into its components.
+   Returns [None] if the string is not a contract-violation code.
+   For the legacy format (no called/satisfying suffix), both lists are [ [] ]. *)
+let decode_tool_list str =
+  let len = String.length str in
+  if len < 2 then None
+  else if String.sub str 0 1 <> "[" || String.sub str (len - 1) 1 <> "]"
+  then None
+  else
+    let inner = String.sub str 1 (len - 2) in
+    if inner = "" then Some []
+    else Some (String.split_on_char ',' inner)
+;;
+
+let decode_contract_violation_reason (wire : string)
+  : (string * string list * string list) option
+  =
+  let prefix = "completion_contract_violation:" in
+  if not (String.starts_with ~prefix wire) then None
+  else
+    let rest = String.sub wire (String.length prefix) (String.length wire - String.length prefix) in
+    match String.split_on_char ':' rest with
+    | [] -> None
+    | [ contract_id ] ->
+      Some (contract_id, [], [])
+    | contract_id :: parts ->
+      let called = ref [] in
+      let satisfying = ref [] in
+      let consumed = ref 0 in
+      List.iter (fun part ->
+        if String.length part > 6 && String.sub part 0 6 = "called"
+        then (
+          match decode_tool_list (String.sub part 6 (String.length part - 6)) with
+          | Some tools -> called := tools; incr consumed
+          | None -> ())
+        else if String.length part > 10 && String.sub part 0 10 = "satisfying"
+        then (
+          match decode_tool_list (String.sub part 10 (String.length part - 10)) with
+          | Some tools -> satisfying := tools; incr consumed
+          | None -> ())
+        else ()
+      ) parts;
+      if !consumed > 0
+      then Some (contract_id, !called, !satisfying)
+      else Some (contract_id, [], [])
+;;
+
 type cascade_rotation_attempt =
   { from_cascade : cascade_name
   ; to_cascade : cascade_name
@@ -270,6 +344,36 @@ let stop_reason_to_string = function
     (match tool_name with
      | Some tool -> Printf.sprintf "mutation_boundary:%s:%d" tool turns_used
      | None -> Printf.sprintf "mutation_boundary:%d" turns_used)
+;;
+
+(* Build an extended terminal_reason_code from a receipt whose
+   terminal_reason_code is already set to the legacy
+   "completion_contract_violation:<id>" form. Uses the receipt's
+   canonical_tools + observed_tools + tools_used as called_tools
+   and tool_surface.required_tools as satisfying_tools.
+   Returns the original code unchanged if it is not a contract-violation
+   code or is already enriched. *)
+let enrich_contract_violation_reason (receipt : t) : string =
+  match decode_contract_violation_reason receipt.terminal_reason_code with
+  | None -> receipt.terminal_reason_code
+  | Some (_contract_id, _called, _satisfying) ->
+    if _called <> [] || _satisfying <> []
+    then receipt.terminal_reason_code
+    else
+      let canonical_names names =
+        names
+        |> List.map Keeper_tool_disclosure.canonical_tool_name
+        |> Keeper_types.dedupe_keep_order
+      in
+      let called =
+        canonical_names
+          (receipt.canonical_tools @ receipt.observed_tools @ receipt.tools_used)
+      in
+      let satisfying = canonical_names receipt.tool_surface.required_tools in
+      encode_contract_violation_reason
+        ~called_tools:called
+        ~satisfying_tools:satisfying
+        _contract_id
 ;;
 
 let sandbox_kind_of_meta (meta : Keeper_types.keeper_meta) : Keeper_types.sandbox_profile =
@@ -625,6 +729,7 @@ let operator_disposition (receipt : t)
 ;;
 
 let to_json (receipt : t) =
+  let terminal_reason_code = enrich_contract_violation_reason receipt in
   let disposition, disposition_reason = operator_disposition receipt in
   let operator_disposition = operator_disposition_kind_to_string disposition in
   let operator_disposition_reason =
@@ -701,7 +806,7 @@ let to_json (receipt : t) =
         | None -> `Null )
     ; "goal_ids", list_json receipt.goal_ids
     ; "outcome", `String (outcome_kind_to_tla_receipt receipt.outcome)
-    ; "terminal_reason_code", `String receipt.terminal_reason_code
+    ; "terminal_reason_code", `String terminal_reason_code
     ; "operator_disposition", `String operator_disposition
     ; "operator_disposition_reason", `String operator_disposition_reason
     ; "runtime_contract", runtime_contract
@@ -889,6 +994,7 @@ let should_emit_operator_broadcast receipt ~disposition ~reason =
 ;;
 
 let operator_broadcast_payload (receipt : t) ~disposition ~reason =
+  let terminal_reason_code = enrich_contract_violation_reason receipt in
   let disposition_s = operator_disposition_kind_to_string disposition in
   let reason_s = operator_disposition_reason_to_string reason in
   `Assoc
@@ -904,7 +1010,7 @@ let operator_broadcast_payload (receipt : t) ~disposition ~reason =
     ; "disposition", `String disposition_s
     ; "disposition_reason", `String reason_s
     ; "outcome", `String (outcome_kind_to_tla_receipt receipt.outcome)
-    ; "terminal_reason_code", `String receipt.terminal_reason_code
+    ; "terminal_reason_code", `String terminal_reason_code
     ; ( "current_task_id"
       , match receipt.current_task_id with
         | Some value -> `String value
@@ -920,6 +1026,15 @@ let operator_broadcast_payload (receipt : t) ~disposition ~reason =
         | Some value -> `String value
         | None -> `Null )
     ; "tools_used", list_json receipt.tools_used
+    ; ( "contract_violation_detail"
+      , match decode_contract_violation_reason terminal_reason_code with
+        | None -> `Null
+        | Some (contract_id, called, satisfying) ->
+          `Assoc
+            [ "contract_id", `String contract_id
+            ; "called_tools", list_json called
+            ; "satisfying_tools", list_json satisfying
+            ] )
     ; ( "tool_contract"
       , `Assoc
           [ ( "result"

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -159,6 +159,31 @@ val tool_contract_result_of_contract_status
   :  Keeper_contract_classifier.contract_status
   -> tool_contract_result
 
+(** {2 Structured contract-violation encoding} *)
+
+(** Encode a tool list into the wire bracket format.
+    [[] for empty, [t1,t2] for non-empty. *)
+val encode_tool_list : string list -> string
+
+(** Build an extended terminal_reason_code with called and satisfying
+    tool lists. Produces:
+    [completion_contract_violation:<contract_id>:called[...]:satisfying[...]]
+    The prefix [completion_contract_violation:] is preserved so existing
+    prefix-matching consumers remain backward-compatible. *)
+val encode_contract_violation_reason
+  :  called_tools:string list
+  -> satisfying_tools:string list
+  -> string
+  -> string
+
+(** Decode a terminal_reason_code back into its components.
+    Returns [Some (contract_id, called_tools, satisfying_tools)] for
+    both legacy and extended formats, [None] for non-violation codes.
+    Legacy format yields empty tool lists. *)
+val decode_contract_violation_reason
+  :  string
+  -> (string * string list * string list) option
+
 type cascade_rotation_attempt =
   { from_cascade : cascade_name
   ; to_cascade : cascade_name
@@ -216,6 +241,13 @@ type t =
 val stop_reason_to_string : Cascade_runner.stop_reason -> string
 val sandbox_kind_of_meta : Keeper_types.keeper_meta -> Keeper_types.sandbox_profile
 val to_json : t -> Yojson.Safe.t
+
+(** Enrich a receipt's terminal_reason_code from legacy to extended format.
+    Uses [canonical_tools + observed_tools + tools_used] as called and
+    [tool_surface.required_tools] as satisfying. Returns the original
+    code unchanged if it is not a contract-violation code or already
+    contains tool data. *)
+val enrich_contract_violation_reason : t -> string
 
 (** Operator-facing classification of a finished turn. Closed set.
 

--- a/test/test_keeper_terminal_reason.ml
+++ b/test/test_keeper_terminal_reason.ml
@@ -511,6 +511,124 @@ let test_legacy_gh_worktree_text () =
     (terminal_next_action terminal)
 ;;
 
+(* Contract violation encoding/decoding tests *)
+
+module KER = Masc_mcp.Keeper_execution_receipt
+
+let test_encode_tool_list () =
+  check string "empty" "[]" (KER.encode_tool_list []);
+  check string "single" "[keeper_board_list]" (KER.encode_tool_list [ "keeper_board_list" ]);
+  check
+    string
+    "multiple"
+    "[keeper_board_list,keeper_memory_search]"
+    (KER.encode_tool_list [ "keeper_board_list"; "keeper_memory_search" ])
+;;
+
+let test_encode_contract_violation_reason () =
+  check
+    string
+    "empty tools"
+    "completion_contract_violation:require_tool_use:called[]:satisfying[]"
+    (KER.encode_contract_violation_reason ~called_tools:[] ~satisfying_tools:[] "require_tool_use");
+  check
+    string
+    "with tools"
+    "completion_contract_violation:require_tool_use:called[keeper_board_list,keeper_memory_search]:satisfying[keeper_board_post,masc_broadcast]"
+    (KER.encode_contract_violation_reason
+       ~called_tools:[ "keeper_board_list"; "keeper_memory_search" ]
+       ~satisfying_tools:[ "keeper_board_post"; "masc_broadcast" ]
+       "require_tool_use")
+;;
+
+let test_decode_legacy_format () =
+  let result = KER.decode_contract_violation_reason "completion_contract_violation:require_tool_use" in
+  (match result with
+   | None -> Alcotest.fail "expected Some for legacy format"
+   | Some (contract_id, called, satisfying) ->
+     check string "contract_id" "require_tool_use" contract_id;
+     check (list string) "called empty" [] called;
+     check (list string) "satisfying empty" [] satisfying)
+;;
+
+let test_decode_extended_format () =
+  let wire =
+    "completion_contract_violation:require_tool_use:called[keeper_board_list,keeper_memory_search]:satisfying[keeper_board_post,masc_broadcast]"
+  in
+  let result = KER.decode_contract_violation_reason wire in
+  (match result with
+   | None -> Alcotest.fail "expected Some for extended format"
+   | Some (contract_id, called, satisfying) ->
+     check string "contract_id" "require_tool_use" contract_id;
+     check
+       (list string)
+       "called"
+       [ "keeper_board_list"; "keeper_memory_search" ]
+       called;
+     check
+       (list string)
+       "satisfying"
+       [ "keeper_board_post"; "masc_broadcast" ]
+       satisfying)
+;;
+
+let test_decode_extended_empty_tools () =
+  let wire = "completion_contract_violation:require_tool_use:called[]:satisfying[]" in
+  let result = KER.decode_contract_violation_reason wire in
+  (match result with
+   | None -> Alcotest.fail "expected Some for extended format with empty tools"
+   | Some (contract_id, called, satisfying) ->
+     check string "contract_id" "require_tool_use" contract_id;
+     check (list string) "called empty" [] called;
+     check (list string) "satisfying empty" [] satisfying)
+;;
+
+let test_decode_non_violation () =
+  let result = KER.decode_contract_violation_reason "api_error_rate_limited" in
+  check (option string) "non-violation -> None" None
+    (Option.map (fun (cid, _, _) -> cid) result);
+  let result2 = KER.decode_contract_violation_reason "" in
+  check (option string) "empty string -> None" None
+    (Option.map (fun (cid, _, _) -> cid) result2)
+;;
+
+let test_decode_roundtrip () =
+  let called = [ "tool_a"; "tool_b"; "tool_c" ] in
+  let satisfying = [ "tool_x" ] in
+  let encoded =
+    KER.encode_contract_violation_reason ~called_tools:called ~satisfying_tools:satisfying "my_contract"
+  in
+  let decoded = KER.decode_contract_violation_reason encoded in
+  (match decoded with
+   | None -> Alcotest.fail "roundtrip: expected Some"
+   | Some (cid, dec_called, dec_satisfying) ->
+     check string "contract_id" "my_contract" cid;
+     check (list string) "called" called dec_called;
+     check (list string) "satisfying" satisfying dec_satisfying)
+;;
+
+let test_prefix_backward_compat () =
+  (* Both legacy and extended forms must start with the prefix that
+     the dashboard disposition logic checks via String.starts_with *)
+  let legacy = "completion_contract_violation:require_tool_use" in
+  let extended =
+    KER.encode_contract_violation_reason
+      ~called_tools:[ "a" ]
+      ~satisfying_tools:[ "b" ]
+      "require_tool_use"
+  in
+  check
+    bool
+    "legacy starts with prefix"
+    true
+    (String.starts_with ~prefix:"completion_contract_violation:" legacy);
+  check
+    bool
+    "extended starts with prefix"
+    true
+    (String.starts_with ~prefix:"completion_contract_violation:" extended)
+;;
+
 let () =
   run
     "keeper_terminal_reason"
@@ -605,6 +723,22 @@ let () =
             `Quick
             test_structured_no_tool_capable_provider
         ; test_case "legacy gh missing worktree text" `Quick test_legacy_gh_worktree_text
+        ] )
+    ; ( "contract violation encoding"
+      , [ test_case "encode_tool_list" `Quick test_encode_tool_list
+        ; test_case
+            "encode_contract_violation_reason"
+            `Quick
+            test_encode_contract_violation_reason
+        ; test_case "decode legacy format" `Quick test_decode_legacy_format
+        ; test_case "decode extended format" `Quick test_decode_extended_format
+        ; test_case
+            "decode extended empty tools"
+            `Quick
+            test_decode_extended_empty_tools
+        ; test_case "decode non-violation" `Quick test_decode_non_violation
+        ; test_case "decode roundtrip" `Quick test_decode_roundtrip
+        ; test_case "prefix backward compat" `Quick test_prefix_backward_compat
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- Add typed encode/decode for contract violation reason codes with `called_tools` and `satisfying_tools`
- Wire format: `completion_contract_violation:require_tool_use:called[X,Y]:satisfying[A,B]`
- `decode_contract_violation_reason` parses back to `(string * string list * string list) option`
- `enrich_contract_violation_reason` upgrades legacy codes using receipt data
- 8 Alcotest tests covering encode/decode/roundtrip/backward-compat
- Fixed off-by-one bug: `"satisfying"` is 10 chars, code was using 11

## Context
Terminal reason codes were opaque strings. Dashboard and downstream consumers had to use fragile prefix matching. Structured encoding enables typed parsing without breaking legacy consumers.

## Test plan
- [x] `dune build --root .` passes
- [x] 44 tests pass (36 existing + 8 new) in `test_keeper_terminal_reason`
- [x] Roundtrip encode→decode verified
- [x] Legacy prefix backward compat verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)