### PR TITLE
refactor(keeper): RFC-0136 PR-3 extract Keeper_unified_turn_pre_dispatch

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -239,6 +239,7 @@
   keeper_unified_turn_phase_plan
   keeper_unified_turn_phase_gate
   keeper_unified_turn_cascade_resolution
+  keeper_unified_turn_pre_dispatch
   keeper_unified_turn_livelock_block
   keeper_exec_context
   keeper_guards

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -163,71 +163,20 @@ let run_keeper_cycle
       (match None with
        | Some meta_after_skip -> Ok meta_after_skip
        | None ->
+         (* RFC-0136 PR-3: pre-dispatch validation extracted to
+            [Keeper_unified_turn_pre_dispatch].  profile_defaults stays
+            in scope so the retry-loop block below can also call the
+            extracted builder with the same defaults. *)
          let profile_defaults =
            Keeper_types_profile.load_keeper_profile_defaults meta.name
          in
-         let keeper_unified_max_tokens_fallback () =
-           match
-             Keeper_types_profile.unified_max_tokens_override_of_oas_env
-               ~keeper_name:meta.name
-               profile_defaults.oas_env
-           with
-           | Some value -> value
-           | None -> Keeper_config.keeper_unified_max_tokens ()
-         in
-         let build_cascade_execution ~(cascade_name : KCP.runtime_name)
-           : (cascade_execution, Agent_sdk.Error.sdk_error) result
-           =
-           let cascade_name_string = KCP.runtime_name_to_string cascade_name in
-           let meta_for_cascade = set_cascade_name cascade_name_string meta in
-           let model_labels =
-             Keeper_coordination.effective_model_labels_for_turn meta_for_cascade
-           in
-           match ensure_api_keys_for_labels model_labels with
-           | Error e -> Error (Agent_sdk.Error.Internal e)
-           | Ok () ->
-             (match ensure_local_discovery_ready model_labels with
-              | Error e -> Error (Agent_sdk.Error.Internal e)
-              | Ok () ->
-                let max_context_resolution =
-                  Keeper_exec_context.resolve_max_context_resolution
-                    ~requested_override:meta.max_context_override
-                    model_labels
-                in
-                let max_context = resolved_max_context_for_turn ~meta model_labels in
-                let temperature =
-                  Cascade_inference.resolve_temperature
-                    ~cascade_name
-                    ~fallback:Keeper_config.keeper_unified_temperature
-                in
-                let raw_max_tokens =
-                  Cascade_inference.resolve_max_tokens
-                    ~cascade_name
-                    ~fallback:keeper_unified_max_tokens_fallback
-                in
-                let max_output_ceiling =
-                  Cascade_runtime.max_output_tokens_ceiling_of_cascade_name
-                    cascade_name
-                in
-                (match
-                   Cascade_inference.validate_max_tokens_within_ceiling
-                     ~cascade_name
-                     ~provider_ceiling:max_output_ceiling
-                     raw_max_tokens
-                 with
-                 | Error err ->
-                   Error (Cascade_error_classify.sdk_error_of_masc_internal_error err)
-                 | Ok max_tokens ->
-                   Ok
-                     { cascade_name
-                     ; max_context_resolution
-                     ; max_context
-                     ; temperature
-                     ; max_tokens
-                     }))
-         in
          let effective_cascade_runtime_name = KCP.Runtime_name effective_cascade_name in
-         (match build_cascade_execution ~cascade_name:effective_cascade_runtime_name with
+         (match
+            Keeper_unified_turn_pre_dispatch.build_cascade_execution
+              ~meta
+              ~profile_defaults
+              ~cascade_name:effective_cascade_runtime_name
+          with
           | Error err ->
             let terminal_reason_code =
               Printf.sprintf
@@ -999,7 +948,10 @@ let run_keeper_cycle
                              with
                              | Degraded_retry_allowed degraded_retry ->
                                (match
-                                  build_cascade_execution
+                                  Keeper_unified_turn_pre_dispatch
+                                  .build_cascade_execution
+                                    ~meta
+                                    ~profile_defaults
                                     ~cascade_name:
                                       (KCP.Runtime_name degraded_retry.next_cascade)
                                 with

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.ml
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.ml
@@ -1,0 +1,89 @@
+(* Keeper_unified_turn_pre_dispatch — RFC-0136 PR-3.
+
+   Extracted from keeper_unified_turn.ml (L166-228) during the
+   run_keeper_cycle stage decomposition. Owns the cascade-execution
+   builder + unified-max-tokens fallback. *)
+
+open Keeper_types
+open Keeper_exec_context
+
+module KCP = Keeper_cascade_profile
+
+let resolve_unified_max_tokens_fallback
+      ~(meta_name : string)
+      ~(profile_defaults : Keeper_types_profile.keeper_profile_defaults)
+      ()
+  =
+  match
+    Keeper_types_profile.unified_max_tokens_override_of_oas_env
+      ~keeper_name:meta_name
+      profile_defaults.oas_env
+  with
+  | Some value -> value
+  | None -> Keeper_config.keeper_unified_max_tokens ()
+
+let build_cascade_execution
+      ~(meta : keeper_meta)
+      ~(profile_defaults : Keeper_types_profile.keeper_profile_defaults)
+      ~(cascade_name : KCP.runtime_name)
+  : ( Keeper_turn_cascade_budget.cascade_execution
+    , Agent_sdk.Error.sdk_error )
+    result
+  =
+  let cascade_name_string = KCP.runtime_name_to_string cascade_name in
+  let meta_for_cascade = set_cascade_name cascade_name_string meta in
+  let model_labels =
+    Keeper_coordination.effective_model_labels_for_turn meta_for_cascade
+  in
+  match ensure_api_keys_for_labels model_labels with
+  | Error e -> Error (Agent_sdk.Error.Internal e)
+  | Ok () ->
+    (match
+       Keeper_turn_helpers.ensure_local_discovery_ready model_labels
+     with
+     | Error e -> Error (Agent_sdk.Error.Internal e)
+     | Ok () ->
+       let max_context_resolution =
+         Keeper_exec_context.resolve_max_context_resolution
+           ~requested_override:meta.max_context_override
+           model_labels
+       in
+       let max_context =
+         Keeper_turn_cascade_budget.resolved_max_context_for_turn
+           ~meta
+           model_labels
+       in
+       let temperature =
+         Cascade_inference.resolve_temperature
+           ~cascade_name
+           ~fallback:Keeper_config.keeper_unified_temperature
+       in
+       let raw_max_tokens =
+         Cascade_inference.resolve_max_tokens
+           ~cascade_name
+           ~fallback:
+             (resolve_unified_max_tokens_fallback
+                ~meta_name:meta.name
+                ~profile_defaults)
+       in
+       let max_output_ceiling =
+         Cascade_runtime.max_output_tokens_ceiling_of_cascade_name
+           cascade_name
+       in
+       (match
+          Cascade_inference.validate_max_tokens_within_ceiling
+            ~cascade_name
+            ~provider_ceiling:max_output_ceiling
+            raw_max_tokens
+        with
+        | Error err ->
+          Error
+            (Cascade_error_classify.sdk_error_of_masc_internal_error err)
+        | Ok max_tokens ->
+          Ok
+            { Keeper_turn_cascade_budget.cascade_name
+            ; max_context_resolution
+            ; max_context
+            ; temperature
+            ; max_tokens
+            }))

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.mli
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.mli
@@ -1,0 +1,32 @@
+(** Pre-dispatch validation stage extracted from
+    [Keeper_unified_turn.run_keeper_cycle] per RFC-0136 PR-3.
+
+    Owns the cascade-execution builder: cascade-name → keeper-meta
+    projection, model-label resolution, API-key + local-discovery
+    readiness checks, context budget resolution, temperature/max-tokens
+    inference, and ceiling validation. Returns a
+    [Keeper_turn_cascade_budget.cascade_execution] record on success,
+    or a typed [Agent_sdk.Error.sdk_error] on the first failed check.
+
+    The unified-max-tokens fallback is internal to this module — its
+    behavior depends only on [meta_name] + [profile_defaults], so the
+    caller does not need to thread a callback through. *)
+
+val build_cascade_execution
+  :  meta:Keeper_types.keeper_meta
+  -> profile_defaults:Keeper_types_profile.keeper_profile_defaults
+  -> cascade_name:Keeper_cascade_profile.runtime_name
+  -> ( Keeper_turn_cascade_budget.cascade_execution
+     , Agent_sdk.Error.sdk_error )
+     result
+(** Build a [cascade_execution] for the given cascade name under
+    [meta]'s context.
+
+    Failure modes (returned as [Error]):
+    - [ensure_api_keys_for_labels] missing required keys.
+    - [ensure_local_discovery_ready] local-runtime discovery fail.
+    - [validate_max_tokens_within_ceiling] raw_max_tokens exceeds the
+      provider's [Cascade_runtime.max_output_tokens_ceiling].
+
+    The function is total over its three failure modes plus the [Ok]
+    case; no exceptions cross the boundary. *)


### PR DESCRIPTION
## Summary

RFC-0136 PR-3: extract the cascade-execution builder (`build_cascade_execution`) and the unified-max-tokens fallback helper from `run_keeper_cycle` into `Keeper_unified_turn_pre_dispatch`.

- `lib/keeper/keeper_unified_turn.ml`: 1790 → **1742 (-48 LOC)**.
- New `keeper_unified_turn_pre_dispatch.{ml,mli}`: +121 LOC.
- Cumulative since PR-1 baseline 1943: **-201 LOC (10.3%)**.

## Why

`run_keeper_cycle` has two callers of the same `build_cascade_execution` closure:
1. L230 in the setup path (first cascade attempt).
2. L951 deep inside the retry loop (`Degraded_retry_allowed` branch).

The closure captured `meta` + `profile_defaults` + an inner `keeper_unified_max_tokens_fallback` helper. Lifting the function out as a top-level module with explicit named args makes every dependency visible at the call sites and lets the retry-loop site re-use the same `profile_defaults` value from the setup path's scope.

## Design

```ocaml
val build_cascade_execution
  :  meta:Keeper_types.keeper_meta
  -> profile_defaults:Keeper_types_profile.keeper_profile_defaults
  -> cascade_name:Keeper_cascade_profile.runtime_name
  -> ( Keeper_turn_cascade_budget.cascade_execution
     , Agent_sdk.Error.sdk_error )
     result
```

`resolve_unified_max_tokens_fallback` stays internal — its inputs are `meta_name` + `profile_defaults` which the builder already has. The `cascade_execution` record type lives in `Keeper_turn_cascade_budget` (already-extracted sub-module from RFC-0085 keeper-namespace promotion); this PR uses qualified `Keeper_turn_cascade_budget.cascade_execution` rather than re-exporting.

## Caller swap

```ocaml
(* First call site (L230, setup path) *)
let profile_defaults =
  Keeper_types_profile.load_keeper_profile_defaults meta.name
in
let effective_cascade_runtime_name = KCP.Runtime_name effective_cascade_name in
(match
   Keeper_unified_turn_pre_dispatch.build_cascade_execution
     ~meta
     ~profile_defaults
     ~cascade_name:effective_cascade_runtime_name
 with
 | ...

(* Second call site (L951, retry loop) — same module, same profile_defaults *)
(match
   Keeper_unified_turn_pre_dispatch.build_cascade_execution
     ~meta
     ~profile_defaults
     ~cascade_name:
       (KCP.Runtime_name degraded_retry.next_cascade)
 with
 | ...
```

`profile_defaults` stays in the caller's scope so both call sites use the same value — no double-load, no drift.

## Behavior preservation

Verbatim moves:
- `KCP.runtime_name_to_string` + `set_cascade_name` projection.
- `Keeper_coordination.effective_model_labels_for_turn`.
- `ensure_api_keys_for_labels` (from `Keeper_types_support` via `Keeper_types` re-export) + `Keeper_turn_helpers.ensure_local_discovery_ready`.
- `Keeper_exec_context.resolve_max_context_resolution`.
- `Keeper_turn_cascade_budget.resolved_max_context_for_turn`.
- `Cascade_inference.{resolve_temperature, resolve_max_tokens, validate_max_tokens_within_ceiling}`.
- `Cascade_runtime.max_output_tokens_ceiling_of_cascade_name`.
- `Cascade_error_classify.sdk_error_of_masc_internal_error`.
- 3-failure mode shape (api_keys / local_discovery / max_tokens_ceiling) returned as typed `Agent_sdk.Error.sdk_error`.

## Anti-pattern self-check (CLAUDE.md §워크어라운드 거부)

| # | Pattern | Status |
|---|---------|--------|
| 1 | Telemetry-as-fix | N/A |
| 2 | String classifier | N/A |
| 3 | N-of-M migration | Bounded — 3 of 4 stages now closed |
| 4 | Catch-all `_ ->` added | N/A |
| 5 | Cap/cooldown/dedup/repair | N/A |
| 6 | Test backdoor | N/A |
| 7 | N-site mechanical fix | N/A — 1 file, 2 call sites of the same boundary |

## Validation

- [x] `dune build --root . @check` clean.
- [x] `scripts/lint/godfile-size-regression.sh` clean (cap 3350, new file 89 < 600).
- [x] `scripts/lint/no-ocaml-comment-terminator-trap.sh` clean.
- [x] `scripts/lint/no-yojson-3-dead-arms.sh` clean.
- [x] `scripts/lint/no-inline-json-kind-name.sh` clean.
- [ ] `@runtest` — CI delegated.

## RFC citation

`RFC-0136 PR-3`: see `docs/rfc/RFC-0136-keeper-unified-turn-decomposition.md` §4.2 (PR-3 row, deferred sub-doc planned for retry-loop body).

## Related

- RFC-0136 PR-1 (#16604 merged) — Phase Gate.
- RFC-0136 PR-2 (#16624 merged) — Cascade Resolution.
- RFC-0136 PR-4+ (deferred) — retry loop body (~800-1200 LOC, may require separate sub-doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)