### PR TITLE
Classify OAS timeout phases

### DIFF
--- a/lib/keeper/keeper_failure_policy.ml
+++ b/lib/keeper/keeper_failure_policy.ml
@@ -47,6 +47,9 @@ let stream_idle_state_is_activity = function
 ;;
 
 type timeout_phase =
+  | Admission
+  | Queue
+  | First_token
   | Http_operation
   | Non_streaming_body
   | Stream_body
@@ -54,9 +57,14 @@ type timeout_phase =
   | Provider_step
   | Cli_stdout_idle
   | Caller_budget
+  | Wall_clock
+  | Capacity_backpressure
   | Unknown_timeout
 
 let timeout_phase_to_label = function
+  | Admission -> "admission"
+  | Queue -> "queue"
+  | First_token -> "first_token"
   | Http_operation -> "http_operation"
   | Non_streaming_body -> "non_streaming_body"
   | Stream_body -> "stream_body"
@@ -64,11 +72,21 @@ let timeout_phase_to_label = function
   | Provider_step -> "provider_step"
   | Cli_stdout_idle -> "cli_stdout_idle"
   | Caller_budget -> "caller_budget"
+  | Wall_clock -> "wall_clock"
+  | Capacity_backpressure -> "capacity_backpressure"
   | Unknown_timeout -> "unknown_timeout"
 ;;
 
 let timeout_phase_of_label label =
-  let label = String.trim label in
+  let normalize label =
+    label
+    |> String.trim
+    |> String.lowercase_ascii
+    |> String.map (function
+      | '-' | ' ' -> '_'
+      | ch -> ch)
+  in
+  let label = normalize label in
   let stream_idle_prefix = "stream_idle:" in
   if String.starts_with ~prefix:stream_idle_prefix label
   then
@@ -78,24 +96,41 @@ let timeout_phase_of_label label =
     |> Option.map (fun state -> Stream_idle state)
   else
     match label with
+    | "admission" | "admission_timeout" -> Some Admission
+    | "queue" | "provider_queue" | "admission_queue"
+    | "admission_queue_timeout" | "queued" ->
+      Some Queue
+    | "first_token" | "no_first_token" | "time_to_first_token" | "ttft" ->
+      Some First_token
     | "http_operation" -> Some Http_operation
     | "non_streaming_body" -> Some Non_streaming_body
     | "stream_body" -> Some Stream_body
+    | "stream_idle" -> Some (Stream_idle Streaming_unknown)
     | "provider_step" -> Some Provider_step
     | "cli_stdout_idle" -> Some Cli_stdout_idle
     | "caller_budget" -> Some Caller_budget
+    | "wall_clock" | "wall_clock_timeout" | "wall_exceeded" | "max_execution_time" ->
+      Some Wall_clock
+    | "capacity_backpressure" | "capacity_exhausted" | "slot_full"
+    | "client_capacity" | "client_capacity_full" ->
+      Some Capacity_backpressure
     | "unknown_timeout" -> Some Unknown_timeout
     | _ -> None
 ;;
 
 let timeout_phase_is_streaming_activity = function
   | Stream_idle state -> stream_idle_state_is_activity state
+  | Admission
+  | Queue
+  | First_token
   | Http_operation
   | Non_streaming_body
   | Stream_body
   | Provider_step
   | Cli_stdout_idle
   | Caller_budget
+  | Wall_clock
+  | Capacity_backpressure
   | Unknown_timeout -> false
 ;;
 
@@ -224,12 +259,14 @@ let liveness_is_lost = function
   | Recent_heartbeat | In_turn_progress | Unknown_liveness -> false
 ;;
 
-let oas_budget_loop_effect ~strikes ~liveness =
-  match strikes with
-  | Some n when n >= 3 && liveness_is_lost liveness ->
+let oas_budget_loop_effect ~phase ~strikes ~liveness =
+  match phase, strikes with
+  | _, Some n when n >= 3 && liveness_is_lost liveness ->
     Pause_keeper, Operator_breaker, Inspect_keeper_liveness, "oas_timeout_budget_liveness_lost"
-  | Some n when n >= 3 ->
+  | _, Some n when n >= 3 ->
     Pause_current_work, Provider_cooldown, Reroute_or_tune_provider, "oas_timeout_budget_loop"
+  | Some Capacity_backpressure, _ ->
+    Soft_fail_turn, Provider_cooldown, Reroute_or_tune_provider, "oas_timeout_budget"
   | _ -> Soft_fail_turn, Provider_cooldown, Inspect_timeout_budget, "oas_timeout_budget"
 ;;
 
@@ -259,6 +296,14 @@ let decide = function
         (if has_activity
          then "provider_stream_idle_active:" ^ stream_idle_state_to_label state
          else "provider_stream_idle:" ^ stream_idle_state_to_label state)
+  | Provider_timeout { phase = Some Capacity_backpressure; liveness = _ } ->
+    make_decision
+      ~failure_scope:Provider_scope
+      ~lifecycle_effect:Soft_fail_turn
+      ~circuit_effect:Provider_cooldown
+      ~operator_action:Reroute_or_tune_provider
+      ~keeper_death_allowed:false
+      ~reason:"provider_timeout:capacity_backpressure"
   | Provider_timeout { phase; liveness = _ } ->
     let reason =
       match phase with
@@ -274,7 +319,7 @@ let decide = function
       ~reason
   | Oas_timeout_budget { phase; strikes; liveness } ->
     let lifecycle_effect, circuit_effect, operator_action, reason =
-      oas_budget_loop_effect ~strikes ~liveness
+      oas_budget_loop_effect ~phase ~strikes ~liveness
     in
     let reason =
       match phase with

--- a/lib/keeper/keeper_failure_policy.mli
+++ b/lib/keeper/keeper_failure_policy.mli
@@ -22,6 +22,9 @@ val stream_idle_state_of_label : string -> stream_idle_state option
 val stream_idle_state_is_activity : stream_idle_state -> bool
 
 type timeout_phase =
+  | Admission
+  | Queue
+  | First_token
   | Http_operation
   | Non_streaming_body
   | Stream_body
@@ -29,6 +32,8 @@ type timeout_phase =
   | Provider_step
   | Cli_stdout_idle
   | Caller_budget
+  | Wall_clock
+  | Capacity_backpressure
   | Unknown_timeout
 
 val timeout_phase_to_label : timeout_phase -> string

--- a/test/test_keeper_failure_policy.ml
+++ b/test/test_keeper_failure_policy.ml
@@ -42,6 +42,26 @@ let test_stream_idle_awaiting_delta_is_not_activity () =
     (Policy.timeout_phase_is_streaming_activity phase)
 ;;
 
+let test_operational_timeout_phase_aliases () =
+  let cases =
+    [
+      "admission", Policy.Admission;
+      "admission_queue_timeout", Policy.Queue;
+      "no_first_token", Policy.First_token;
+      "stream_idle", Policy.Stream_idle Policy.Streaming_unknown;
+      "max_execution_time", Policy.Wall_clock;
+      "capacity_exhausted", Policy.Capacity_backpressure;
+      "slot-full", Policy.Capacity_backpressure;
+    ]
+  in
+  List.iter
+    (fun (label, expected) ->
+       match Policy.timeout_phase_of_label label with
+       | Some actual -> check bool label true (actual = expected)
+       | None -> fail (label ^ " did not parse"))
+    cases
+;;
+
 let test_provider_streaming_thinking_timeout_does_not_kill_keeper () =
   let decision =
     Policy.decide
@@ -60,6 +80,39 @@ let test_provider_streaming_thinking_timeout_does_not_kill_keeper () =
     "reason"
     "provider_stream_idle_active:streaming_thinking"
     decision.reason
+;;
+
+let test_provider_capacity_backpressure_reroutes_provider () =
+  let decision =
+    Policy.decide
+      (Policy.Provider_timeout
+         {
+           phase = Some Policy.Capacity_backpressure;
+           liveness = Policy.Recent_heartbeat;
+         })
+  in
+  check_scope "scope" "provider" decision.failure_scope;
+  check_lifecycle "lifecycle" "soft_fail_turn" decision.lifecycle_effect;
+  check_circuit "circuit" "provider_cooldown" decision.circuit_effect;
+  check_action "action" "reroute_or_tune_provider" decision.operator_action;
+  check string "reason" "provider_timeout:capacity_backpressure" decision.reason
+;;
+
+let test_oas_capacity_backpressure_reroutes_before_loop_threshold () =
+  let decision =
+    Policy.decide
+      (Policy.Oas_timeout_budget
+         {
+           phase = Some Policy.Capacity_backpressure;
+           strikes = Some 1;
+           liveness = Policy.Recent_heartbeat;
+         })
+  in
+  check_scope "scope" "turn" decision.failure_scope;
+  check_lifecycle "lifecycle" "soft_fail_turn" decision.lifecycle_effect;
+  check_circuit "circuit" "provider_cooldown" decision.circuit_effect;
+  check_action "action" "reroute_or_tune_provider" decision.operator_action;
+  check string "reason" "oas_timeout_budget:capacity_backpressure" decision.reason
 ;;
 
 let test_oas_budget_loop_with_live_keeper_pauses_work_not_keeper () =
@@ -143,11 +196,17 @@ let () =
             test_stream_idle_thinking_label_round_trips;
           test_case "awaiting first delta is not activity" `Quick
             test_stream_idle_awaiting_delta_is_not_activity;
+          test_case "operational timeout phase aliases parse" `Quick
+            test_operational_timeout_phase_aliases;
         ] );
       ( "decision_matrix",
         [
           test_case "provider streaming thinking timeout stays provider-scoped" `Quick
             test_provider_streaming_thinking_timeout_does_not_kill_keeper;
+          test_case "provider capacity backpressure reroutes provider" `Quick
+            test_provider_capacity_backpressure_reroutes_provider;
+          test_case "OAS capacity backpressure reroutes before loop threshold" `Quick
+            test_oas_capacity_backpressure_reroutes_before_loop_threshold;
           test_case "live OAS budget loop pauses work, not keeper" `Quick
             test_oas_budget_loop_with_live_keeper_pauses_work_not_keeper;
           test_case "lost-liveness OAS budget loop pauses keeper without death" `Quick

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -92,6 +92,29 @@ let test_strike_limit_routes_through_policy_without_keeper_death () =
       "oas_timeout_budget_loop:stream_idle:streaming_thinking"
       decision.reason
 
+let test_capacity_phase_routes_to_provider_tuning () =
+  let err = oas_timeout_budget_error ~phase:"slot_full" in
+  match KH.oas_timeout_budget_policy_decision ~strikes:1 err with
+  | None -> Alcotest.fail "expected OAS timeout budget policy decision"
+  | Some decision ->
+    Alcotest.(check bool) "keeper death denied" false decision.keeper_death_allowed;
+    Alcotest.(check string)
+      "lifecycle"
+      "soft_fail_turn"
+      (KFP.lifecycle_effect_to_label decision.lifecycle_effect);
+    Alcotest.(check string)
+      "circuit"
+      "provider_cooldown"
+      (KFP.circuit_effect_to_label decision.circuit_effect);
+    Alcotest.(check string)
+      "operator action"
+      "reroute_or_tune_provider"
+      (KFP.operator_action_to_label decision.operator_action);
+    Alcotest.(check string)
+      "reason preserves capacity phase"
+      "oas_timeout_budget:capacity_backpressure"
+      decision.reason
+
 let test_concurrent_bumps_do_not_lose_updates () =
   let keeper = "parallel-bumps" in
   with_reset keeper (fun () ->
@@ -125,6 +148,8 @@ let () =
           test_strike_limit_is_soft_backoff;
         Alcotest.test_case "strike limit uses policy, not keeper death" `Quick
           test_strike_limit_routes_through_policy_without_keeper_death;
+        Alcotest.test_case "capacity phase routes to provider tuning" `Quick
+          test_capacity_phase_routes_to_provider_tuning;
         Alcotest.test_case "concurrent bumps do not lose updates" `Quick
           test_concurrent_bumps_do_not_lose_updates;
       ] );


### PR DESCRIPTION
## Summary

- add canonical OAS timeout phases for admission, queue, first_token, wall_clock, and capacity_backpressure
- normalize operational aliases such as no_first_token, max_execution_time, capacity_exhausted, and slot_full into the shared timeout phase enum
- route capacity/backpressure timeout budget failures to provider reroute/tuning instead of generic timeout inspection

## Root Cause

MASC already carried an OAS timeout phase string, but the keeper failure policy only understood lower-level labels such as http_operation, stream_idle:*, and caller_budget. Capacity and queue pressure could therefore remain operationally indistinct from generic timeout budget exhaustion.

## Validation

- ocamlformat --check lib/keeper/keeper_failure_policy.mli lib/keeper/keeper_failure_policy.ml test/test_keeper_failure_policy.ml test/test_oas_timeout_budget_strike.ml
- git diff --check origin/main
- ocamlc -c lib/keeper/keeper_failure_policy.mli
- ocamlc -c lib/keeper/keeper_failure_policy.ml

Focused Dune build was attempted with scripts/dune-local.sh build test/test_keeper_failure_policy.exe, but the host hit system FD exhaustion: Too many open files in system / errno=23 while another bare dune @check and repo-wide bfs scans were active. CI should run the full repo check on a cleaner runner.
