### PR TITLE
feat(dashboard): Server-Timing header for 5 slow endpoints (Phase 1 Action 1)

### DIFF
--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -1530,11 +1530,39 @@ let shell_projection_trace_log cache_key =
     , snapshot.snapshot_elapsed_ms )
 ;;
 
-let dashboard_shell_payload_json ?(light = false) (config : Coord.config) : Yojson.Safe.t =
+(* Closed mapping from internal projection labels to Server_timing phases.
+   Total over the label set actually emitted by [dashboard_shell_payload_json];
+   any label outside that set is recorded as [Custom label] so an unintended
+   typo surfaces in the response header rather than vanishing silently. *)
+let shell_projection_label_to_phase : string -> Server_timing.phase = function
+  | "status" -> Projection_status
+  | "agents" -> Projection_agents
+  | "tasks" -> Projection_tasks
+  | "keepers" -> Projection_keepers
+  | "configured_keepers" -> Projection_configured_keepers
+  | "meta_cognition" -> Projection_meta_cognition
+  | "config_resolution" -> Projection_config_resolution
+  | "runtime_resolution" -> Projection_runtime_resolution
+  | other -> Custom other
+;;
+
+let dashboard_shell_payload_json
+      ?timing
+      ?(light = false)
+      (config : Coord.config)
+  : Yojson.Safe.t
+  =
   let cluster = Env_config_core.cluster_name () in
   let cache_key = dashboard_shell_cache_key ~light config in
   let trace = shell_projection_trace_start ~cache_key ~light in
   let started_at = Unix.gettimeofday () in
+  let record_timing label elapsed_ms =
+    match timing with
+    | None -> ()
+    | Some t ->
+      Server_timing.record_ms t (shell_projection_label_to_phase label)
+        (float_of_int elapsed_ms)
+  in
   let measure_ms label f =
     shell_projection_trace_start_projection trace label;
     let t0 = Unix.gettimeofday () in
@@ -1542,6 +1570,7 @@ let dashboard_shell_payload_json ?(light = false) (config : Coord.config) : Yojs
     | value ->
       let elapsed_ms = int_of_float ((Unix.gettimeofday () -. t0) *. 1000.0) in
       shell_projection_trace_finish_projection trace label elapsed_ms;
+      record_timing label elapsed_ms;
       value, elapsed_ms
     | exception (Eio.Cancel.Cancelled _ as exn) ->
       (* Keep the active projection marker for timeout fallback diagnostics. *)
@@ -1549,6 +1578,7 @@ let dashboard_shell_payload_json ?(light = false) (config : Coord.config) : Yojs
     | exception exn ->
       let elapsed_ms = int_of_float ((Unix.gettimeofday () -. t0) *. 1000.0) in
       shell_projection_trace_finish_projection trace label elapsed_ms;
+      record_timing label elapsed_ms;
       raise exn
   in
   let measure_json_projection label f =
@@ -1800,14 +1830,19 @@ let dashboard_shell_auth_json ~(request : Httpun.Request.t) (config : Coord.conf
     ]
 ;;
 
-let dashboard_shell_http_json ?clock ?request ?(light = false) (config : Coord.config)
+let dashboard_shell_http_json
+      ?clock
+      ?request
+      ?timing
+      ?(light = false)
+      (config : Coord.config)
   : Yojson.Safe.t
   =
   let cache_key = dashboard_shell_cache_key ~light config in
   let compute () =
     (* Shell endpoint is read-only; use config directly without isolation
        since state is not available in this context. *)
-    dashboard_shell_payload_json ~light config
+    dashboard_shell_payload_json ?timing ~light config
   in
   let clock_opt =
     match clock with
@@ -1858,20 +1893,25 @@ let dashboard_shell_http_json ?clock ?request ?(light = false) (config : Coord.c
     && (Atomic.get shell_warming || startup_shell_bootstrap_pending)
     && not (Atomic.get shell_warmed)
   in
+  let cache_load () =
+    match clock_opt with
+    | Some clock ->
+      Dashboard_cache.get_or_compute_with_timeout
+        cache_key
+        ~ttl:15.0
+        ~clock
+        ~timeout_sec:(dashboard_shell_timeout_for ~light)
+        compute
+    | None -> Dashboard_cache.get_or_compute cache_key ~ttl:15.0 compute
+  in
   let payload =
     if startup_prewarm_pending
     then fallback_payload ()
     else (
       let computed =
-        match clock_opt with
-        | Some clock ->
-          Dashboard_cache.get_or_compute_with_timeout
-            cache_key
-            ~ttl:15.0
-            ~clock
-            ~timeout_sec:(dashboard_shell_timeout_for ~light)
-            compute
-        | None -> Dashboard_cache.get_or_compute cache_key ~ttl:15.0 compute
+        match timing with
+        | None -> cache_load ()
+        | Some t -> Server_timing.measure t Cache_lookup cache_load
       in
       if is_dashboard_cache_timeout_json computed
       then timeout_fallback_payload (dashboard_shell_timeout_for ~light)

--- a/lib/server/server_dashboard_http_core.mli
+++ b/lib/server/server_dashboard_http_core.mli
@@ -146,6 +146,7 @@ val provider_capacity_json : unit -> Yojson.Safe.t
 val dashboard_shell_http_json :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   ?request:Httpun.Request.t ->
+  ?timing:Server_timing.t ->
   ?light:bool ->
   Coord.config ->
   Yojson.Safe.t
@@ -156,6 +157,7 @@ val dashboard_shell_cache_key :
   string
 
 val dashboard_shell_payload_json :
+  ?timing:Server_timing.t ->
   ?light:bool ->
   Coord.config -> Yojson.Safe.t
 

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -687,19 +687,37 @@ let runtime_resolution_json (config : Coord.config) =
       @ Server_routes_http_runtime.keeper_fleet_runtime_resolution_fields () )
 ;;
 
-let dashboard_tools_http_json ?actor (config : Coord.config) : Yojson.Safe.t =
+let dashboard_tools_http_json ?actor ?timing (config : Coord.config) : Yojson.Safe.t =
   let ctx : Tool_misc.context =
     { config; agent_name = Option.value ~default:"dashboard" actor }
   in
+  let run phase f =
+    match timing with
+    | None -> f ()
+    | Some t -> Server_timing.measure t phase f
+  in
+  let config_resolution =
+    run Projection_config_resolution (fun () ->
+      Config_dir_resolver.(resolve () |> to_json))
+  in
+  let runtime_resolution =
+    run Projection_runtime_resolution (fun () -> runtime_resolution_json config)
+  in
+  let inventory =
+    run Tools_compute (fun () ->
+      Tool_misc.tool_inventory_json ctx ~include_hidden:true ~include_deprecated:true)
+  in
+  let usage =
+    run Tools_compute (fun () ->
+      Tool_unified.summary_report ()
+      |> Tool_usage_log.attach_source_metadata ~masc_root:(Coord.masc_root_dir config))
+  in
   `Assoc
     [ "generated_at", `String (Masc_domain.now_iso ())
-    ; ("config_resolution", Config_dir_resolver.(resolve () |> to_json))
-    ; "runtime_resolution", runtime_resolution_json config
-    ; ( "tool_inventory"
-      , Tool_misc.tool_inventory_json ctx ~include_hidden:true ~include_deprecated:true )
-    ; ( "tool_usage"
-      , Tool_unified.summary_report ()
-        |> Tool_usage_log.attach_source_metadata ~masc_root:(Coord.masc_root_dir config) )
+    ; "config_resolution", config_resolution
+    ; "runtime_resolution", runtime_resolution
+    ; "tool_inventory", inventory
+    ; "tool_usage", usage
     ]
 ;;
 

--- a/lib/server/server_dashboard_http_runtime_info.mli
+++ b/lib/server/server_dashboard_http_runtime_info.mli
@@ -66,10 +66,16 @@ val dashboard_perf_http_json : Coord.config -> Yojson.Safe.t
     skew, etc). *)
 
 val dashboard_tools_http_json :
-  ?actor:string -> Coord.config -> Yojson.Safe.t
+  ?actor:string ->
+  ?timing:Server_timing.t ->
+  Coord.config ->
+  Yojson.Safe.t
 (** Renders the dashboard tools projection.  [?actor]
     selects the per-agent tool catalogue when present;
-    otherwise the full registry surface is returned. *)
+    otherwise the full registry surface is returned.  When [?timing] is
+    provided, internal phases (config_resolution, runtime_resolution,
+    tools_compute) are accumulated into the [Server_timing.t] for surfacing
+    via the [Server-Timing] response header. *)
 
 (** {1 Runtime-probe test seams} *)
 

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -465,11 +465,14 @@ let rec add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/dashboard/shell" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let light = Server_utils.bool_query_param req "light" ~default:false in
+         let timing = Server_timing.create () in
          let json =
-           dashboard_shell_http_json ?clock:state.Mcp_server.clock ~request:req ~light
-             state.Mcp_server.room_config
+           dashboard_shell_http_json ?clock:state.Mcp_server.clock ~request:req
+             ~timing ~light state.Mcp_server.room_config
          in
-         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+         Http.Response.json ~compress:true ~request:req
+           ~extra_headers:(Server_timing.extra_header timing)
+           (Yojson.Safe.to_string json) reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/nudges" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -675,18 +678,36 @@ let rec add_routes ~sw ~clock router =
          ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/project-snapshot" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let json = dashboard_namespace_truth_http_json ~state ~sw ~clock req in
-         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+         let timing = Server_timing.create () in
+         let json =
+           Server_timing.measure timing Project_snapshot_runtime (fun () ->
+             dashboard_namespace_truth_http_json ~state ~sw ~clock req)
+         in
+         Http.Response.json ~compress:true ~request:req
+           ~extra_headers:(Server_timing.extra_header timing)
+           (Yojson.Safe.to_string json) reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/namespace-truth" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let json = dashboard_namespace_truth_http_json ~state ~sw ~clock req in
-         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+         let timing = Server_timing.create () in
+         let json =
+           Server_timing.measure timing Project_snapshot_runtime (fun () ->
+             dashboard_namespace_truth_http_json ~state ~sw ~clock req)
+         in
+         Http.Response.json ~compress:true ~request:req
+           ~extra_headers:(Server_timing.extra_header timing)
+           (Yojson.Safe.to_string json) reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/room-truth" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let json = dashboard_namespace_truth_http_json ~state ~sw ~clock req in
-         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+         let timing = Server_timing.create () in
+         let json =
+           Server_timing.measure timing Project_snapshot_runtime (fun () ->
+             dashboard_namespace_truth_http_json ~state ~sw ~clock req)
+         in
+         Http.Response.json ~compress:true ~request:req
+           ~extra_headers:(Server_timing.extra_header timing)
+           (Yojson.Safe.to_string json) reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/execution" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -944,14 +965,18 @@ let rec add_routes ~sw ~clock router =
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/tools" (fun request reqd ->
        with_public_read (fun state req reqd ->
+           let timing = Server_timing.create () in
            let json =
              dashboard_tools_http_json
-             ?actor:
-               (dashboard_actor_for_request
-                  ~base_path:state.Mcp_server.room_config.base_path request)
-             state.Mcp_server.room_config
+               ~timing
+               ?actor:
+                 (dashboard_actor_for_request
+                    ~base_path:state.Mcp_server.room_config.base_path request)
+               state.Mcp_server.room_config
            in
-         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+         Http.Response.json ~compress:true ~request:req
+           ~extra_headers:(Server_timing.extra_header timing)
+           (Yojson.Safe.to_string json) reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/mission/briefing" (fun request reqd ->
        with_public_read (fun state req reqd ->
@@ -1209,27 +1234,33 @@ let rec add_routes ~sw ~clock router =
                    until_ts );
              ]
          in
+         let timing = Server_timing.create () in
          let result =
-           Telemetry_unified.read_unified_result ~base_path ~masc_root ~sources
-             ?keeper_name ?session_id ?operation_id ?worker_run_id
-             ?since_ts ?until_ts ~n ()
+           Server_timing.measure timing Telemetry_query (fun () ->
+             Telemetry_unified.read_unified_result ~base_path ~masc_root ~sources
+               ?keeper_name ?session_id ?operation_id ?worker_run_id
+               ?since_ts ?until_ts ~n ())
          in
          let generated_at = Masc_domain.now_iso () in
-         let json = `Assoc [
-           ("generated_at", `String generated_at);
-           ("generated_at_iso", `String generated_at);
-           ("dashboard_surface", `String "/api/v1/dashboard/telemetry");
-           ("source", `String "telemetry_unified");
-           ( "retention",
-             Telemetry_unified.replay_retention_json ~base_path ~masc_root
-               ~sources );
-           ("query", query_json);
-           ("count", `Int (List.length result.entries));
-           ("total_matching_entries", `Int result.total_matching_entries);
-           ("truncated", `Bool result.truncated);
-           ("entries", `List result.entries);
-         ] in
+         let json =
+           Server_timing.measure timing Json_serialize (fun () ->
+             `Assoc [
+               ("generated_at", `String generated_at);
+               ("generated_at_iso", `String generated_at);
+               ("dashboard_surface", `String "/api/v1/dashboard/telemetry");
+               ("source", `String "telemetry_unified");
+               ( "retention",
+                 Telemetry_unified.replay_retention_json ~base_path ~masc_root
+                   ~sources );
+               ("query", query_json);
+               ("count", `Int (List.length result.entries));
+               ("total_matching_entries", `Int result.total_matching_entries);
+               ("truncated", `Bool result.truncated);
+               ("entries", `List result.entries);
+             ])
+         in
          Http.Response.json ~compress:true ~request:req
+           ~extra_headers:(Server_timing.extra_header timing)
            (Yojson.Safe.to_string json) reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/telemetry/summary" (fun request reqd ->
@@ -1238,11 +1269,15 @@ let rec add_routes ~sw ~clock router =
          let base_path = config.base_path in
          let masc_root = Coord.masc_root_dir config in
          let cache_key = telemetry_summary_cache_key ~base_path ~masc_root in
+         let timing = Server_timing.create () in
          let json =
-           Dashboard_cache.get_or_compute cache_key ~ttl:30.0 (fun () ->
-               Telemetry_unified.summary_json ~base_path ~masc_root ())
+           Server_timing.measure timing Cache_lookup (fun () ->
+             Dashboard_cache.get_or_compute cache_key ~ttl:30.0 (fun () ->
+               Server_timing.measure timing Telemetry_summary_aggregate (fun () ->
+                 Telemetry_unified.summary_json ~base_path ~masc_root ())))
          in
          Http.Response.json ~compress:true ~request:req
+           ~extra_headers:(Server_timing.extra_header timing)
            (Yojson.Safe.to_string json) reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/oas/telemetry/recent" (fun request reqd ->

--- a/lib/server/server_timing.ml
+++ b/lib/server/server_timing.ml
@@ -1,0 +1,117 @@
+(** See [server_timing.mli] for the public contract. *)
+
+type phase =
+  | Cache_lookup
+  | Cache_compute
+  | Projection_status
+  | Projection_agents
+  | Projection_tasks
+  | Projection_keepers
+  | Projection_configured_keepers
+  | Projection_meta_cognition
+  | Projection_config_resolution
+  | Projection_runtime_resolution
+  | Project_snapshot_shell_refresh
+  | Project_snapshot_runtime
+  | Tools_compute
+  | Telemetry_query
+  | Telemetry_filter
+  | Telemetry_summary_per_keeper
+  | Telemetry_summary_aggregate
+  | Json_serialize
+  | Custom of string
+
+(* RFC 8673 §3.2.1 token grammar: ALPHA / DIGIT / "-" / "_" / "." *)
+let is_token_char = function
+  | '0' .. '9' | 'A' .. 'Z' | 'a' .. 'z' | '-' | '_' | '.' -> true
+  | _ -> false
+;;
+
+let sanitize_token s =
+  if String.length s = 0
+  then "anon"
+  else String.map (fun c -> if is_token_char c then c else '_') s
+;;
+
+let phase_token = function
+  | Cache_lookup -> "cache_lookup"
+  | Cache_compute -> "cache_compute"
+  | Projection_status -> "projection_status"
+  | Projection_agents -> "projection_agents"
+  | Projection_tasks -> "projection_tasks"
+  | Projection_keepers -> "projection_keepers"
+  | Projection_configured_keepers -> "projection_configured_keepers"
+  | Projection_meta_cognition -> "projection_meta_cognition"
+  | Projection_config_resolution -> "projection_config_resolution"
+  | Projection_runtime_resolution -> "projection_runtime_resolution"
+  | Project_snapshot_shell_refresh -> "project_snapshot_shell_refresh"
+  | Project_snapshot_runtime -> "project_snapshot_runtime"
+  | Tools_compute -> "tools_compute"
+  | Telemetry_query -> "telemetry_query"
+  | Telemetry_filter -> "telemetry_filter"
+  | Telemetry_summary_per_keeper -> "telemetry_summary_per_keeper"
+  | Telemetry_summary_aggregate -> "telemetry_summary_aggregate"
+  | Json_serialize -> "json_serialize"
+  | Custom raw -> sanitize_token raw
+;;
+
+(* Entries are kept in insertion order so DevTools renders the bars in
+   the order the handler actually executed phases. *)
+type entry = { token : string; mutable ms : float }
+type t = { mutable entries : entry list }
+
+let create () = { entries = [] }
+
+let find_or_add t token =
+  let rec loop = function
+    | [] ->
+      let e = { token; ms = 0.0 } in
+      t.entries <- t.entries @ [ e ];
+      e
+    | e :: _ when String.equal e.token token -> e
+    | _ :: rest -> loop rest
+  in
+  loop t.entries
+;;
+
+let record_ms t phase ms =
+  let e = find_or_add t (phase_token phase) in
+  e.ms <- e.ms +. ms
+;;
+
+let measure t phase f =
+  let started = Unix.gettimeofday () in
+  let finish () =
+    let elapsed_ms = (Unix.gettimeofday () -. started) *. 1000.0 in
+    record_ms t phase elapsed_ms
+  in
+  match f () with
+  | result ->
+    finish ();
+    result
+  | exception exn ->
+    finish ();
+    raise exn
+;;
+
+(* Round to one decimal place via integer arithmetic so the wire format
+   does not depend on locale or Printf rounding modes. *)
+let format_ms ms =
+  let tenths = int_of_float ((ms *. 10.0) +. 0.5) in
+  Printf.sprintf "%d.%d" (tenths / 10) (tenths mod 10)
+;;
+
+let to_header_value t =
+  match t.entries with
+  | [] -> ""
+  | _ ->
+    t.entries
+    |> List.map (fun e -> Printf.sprintf "%s;dur=%s" e.token (format_ms e.ms))
+    |> String.concat ", "
+;;
+
+let extra_header t =
+  match to_header_value t with
+  | "" -> []
+  | v -> [ "Server-Timing", v ]
+;;

--- a/lib/server/server_timing.mli
+++ b/lib/server/server_timing.mli
@@ -1,0 +1,71 @@
+(** RFC 8673 Server-Timing header builder for dashboard endpoints.
+
+    Each request handler creates a fresh [t], wraps measured phases with
+    {!measure}, and threads the resulting [(string * string) list] from
+    {!extra_header} into the existing [~extra_headers] argument of
+    [Http_server_eio.Response.json].  Browser DevTools (Network tab ->
+    Timing -> Server Timing) renders the bars directly; curl shows them
+    via [-D -].
+
+    The aim is *attribution* — turning "the request took 30s" into
+    "cache=12ms compute=850ms json=2ms" without a separate APM stack.
+
+    Phase names are a closed variant so a new phase requires a compile-
+    time edit of {!phase_token}; magic strings would let typos through
+    and DevTools silently drops malformed entries. *)
+
+(** Concrete phases used across dashboard endpoints.
+
+    Add a constructor here (and update {!phase_token}) when a new
+    measurement site is introduced.  Use {!Custom} sparingly for one-
+    off ad-hoc measurements (e.g. exploratory profiling) — its body is
+    sanitised to token characters per RFC 8673 §3.2.1, so invalid input
+    is dropped to ['_']. *)
+type phase =
+  | Cache_lookup
+  | Cache_compute
+  | Projection_status
+  | Projection_agents
+  | Projection_tasks
+  | Projection_keepers
+  | Projection_configured_keepers
+  | Projection_meta_cognition
+  | Projection_config_resolution
+  | Projection_runtime_resolution
+  | Project_snapshot_shell_refresh
+  | Project_snapshot_runtime
+  | Tools_compute
+  | Telemetry_query
+  | Telemetry_filter
+  | Telemetry_summary_per_keeper
+  | Telemetry_summary_aggregate
+  | Json_serialize
+  | Custom of string
+
+val phase_token : phase -> string
+(** Lowercase RFC 8673 token-safe identifier.  Total. *)
+
+type t
+(** Mutable accumulator.  Single-fiber by design — see top-level note.
+    Callers should not share a [t] across fibers. *)
+
+val create : unit -> t
+
+val measure : t -> phase -> (unit -> 'a) -> 'a
+(** [measure t phase f] runs [f ()], accumulates the elapsed
+    wall-clock duration under [phase], and returns [f]'s result.  If
+    [f] raises, the elapsed time is still recorded and the exception
+    re-raised (so failure paths are still attributed). *)
+
+val record_ms : t -> phase -> float -> unit
+(** Manually record [ms] under [phase].  Use when a measurement is
+    produced by a callback or pre-existing instrumentation that
+    already returned an elapsed value. *)
+
+val to_header_value : t -> string
+(** RFC 8673 [Server-Timing] field value, comma-separated.  Returns
+    [""] if no phases were recorded. *)
+
+val extra_header : t -> (string * string) list
+(** [\[("Server-Timing", v)\]] when non-empty, otherwise [\[\]].
+    Use directly with [Http.Response.json ~extra_headers]. *)

--- a/test/dune
+++ b/test/dune
@@ -716,6 +716,7 @@
   test_server_runtime_bootstrap
   test_server_runtime_bootstrap_codex_config
   test_server_base_path_diagnostics
+  test_server_timing
   test_server_startup_takeover
   test_keeper_meta_listing
   test_keeper_meta_cas_retry
@@ -942,6 +943,7 @@
   test_server_runtime_bootstrap
   test_server_runtime_bootstrap_codex_config
   test_server_base_path_diagnostics
+  test_server_timing
   test_server_startup_takeover
   test_keeper_meta_listing
   test_keeper_meta_cas_retry

--- a/test/test_server_timing.ml
+++ b/test/test_server_timing.ml
@@ -1,0 +1,152 @@
+open Masc_mcp
+
+let test_empty_header () =
+  let t = Server_timing.create () in
+  Alcotest.(check string) "empty header value" "" (Server_timing.to_header_value t);
+  Alcotest.(check (list (pair string string)))
+    "extra_header empty" [] (Server_timing.extra_header t)
+;;
+
+let test_single_phase_format () =
+  let t = Server_timing.create () in
+  Server_timing.record_ms t Server_timing.Cache_lookup 12.34;
+  let header = Server_timing.to_header_value t in
+  (* Single decimal, RFC 8673 token grammar: ALPHA / DIGIT / "-" / "_" / "."  *)
+  Alcotest.(check string) "single entry rounded" "cache_lookup;dur=12.3" header
+;;
+
+let test_multiple_phases_insertion_order () =
+  let t = Server_timing.create () in
+  Server_timing.record_ms t Server_timing.Cache_lookup 5.0;
+  Server_timing.record_ms t Server_timing.Projection_status 100.0;
+  Server_timing.record_ms t Server_timing.Json_serialize 2.5;
+  let header = Server_timing.to_header_value t in
+  Alcotest.(check string) "insertion order preserved"
+    "cache_lookup;dur=5.0, projection_status;dur=100.0, json_serialize;dur=2.5"
+    header
+;;
+
+let test_repeated_phase_accumulates () =
+  let t = Server_timing.create () in
+  Server_timing.record_ms t Server_timing.Projection_agents 10.0;
+  Server_timing.record_ms t Server_timing.Projection_agents 7.5;
+  let header = Server_timing.to_header_value t in
+  Alcotest.(check string) "same phase accumulates"
+    "projection_agents;dur=17.5" header
+;;
+
+let test_measure_records_elapsed () =
+  let t = Server_timing.create () in
+  let _result =
+    Server_timing.measure t Server_timing.Tools_compute (fun () ->
+      Unix.sleepf 0.005;
+      42)
+  in
+  let header = Server_timing.to_header_value t in
+  (* The entry exists with the right token; we cannot assert exact ms because
+     sleep is approximate, but it must be at least 1ms. *)
+  let prefix = "tools_compute;dur=" in
+  Alcotest.(check bool) "entry present"
+    true (String.length header > String.length prefix
+          && String.sub header 0 (String.length prefix) = prefix)
+;;
+
+let test_measure_records_on_exception () =
+  let t = Server_timing.create () in
+  let caught =
+    try
+      let _ =
+        Server_timing.measure t Server_timing.Json_serialize (fun () ->
+          failwith "boom")
+      in
+      false
+    with Failure _ -> true
+  in
+  Alcotest.(check bool) "exception re-raised" true caught;
+  let header = Server_timing.to_header_value t in
+  Alcotest.(check bool) "elapsed still recorded on failure path"
+    true (String.length header > 0)
+;;
+
+let test_phase_token_total_and_lowercase () =
+  let all_phases : Server_timing.phase list = [
+    Cache_lookup; Cache_compute;
+    Projection_status; Projection_agents; Projection_tasks;
+    Projection_keepers; Projection_configured_keepers; Projection_meta_cognition;
+    Projection_config_resolution; Projection_runtime_resolution;
+    Project_snapshot_shell_refresh; Project_snapshot_runtime;
+    Tools_compute;
+    Telemetry_query; Telemetry_filter;
+    Telemetry_summary_per_keeper; Telemetry_summary_aggregate;
+    Json_serialize;
+  ] in
+  List.iter (fun p ->
+    let tok = Server_timing.phase_token p in
+    Alcotest.(check bool)
+      (Printf.sprintf "token nonempty: %s" tok)
+      true (String.length tok > 0);
+    String.iter (fun c ->
+      let ok =
+        (c >= '0' && c <= '9') ||
+        (c >= 'a' && c <= 'z') ||
+        c = '-' || c = '_' || c = '.'
+      in
+      Alcotest.(check bool)
+        (Printf.sprintf "RFC8673 token char in %s: %c" tok c)
+        true ok
+    ) tok
+  ) all_phases
+;;
+
+let test_custom_phase_sanitized () =
+  let raw = "weird name with space/and@punct" in
+  let tok = Server_timing.phase_token (Custom raw) in
+  String.iter (fun c ->
+    let ok =
+      (c >= '0' && c <= '9') ||
+      (c >= 'A' && c <= 'Z') ||
+      (c >= 'a' && c <= 'z') ||
+      c = '-' || c = '_' || c = '.'
+    in
+    Alcotest.(check bool)
+      (Printf.sprintf "Custom sanitised char: %c" c) true ok
+  ) tok;
+  let empty_tok = Server_timing.phase_token (Custom "") in
+  Alcotest.(check bool)
+    "empty Custom yields non-empty token"
+    true (String.length empty_tok > 0)
+;;
+
+let test_extra_header_wrap () =
+  let t = Server_timing.create () in
+  Server_timing.record_ms t Server_timing.Cache_compute 1.0;
+  match Server_timing.extra_header t with
+  | [ (name, value) ] ->
+    Alcotest.(check string) "header name" "Server-Timing" name;
+    Alcotest.(check bool) "value non-empty"
+      true (String.length value > 0)
+  | _ -> Alcotest.fail "expected exactly one extra header"
+;;
+
+let () =
+  Alcotest.run "Server_timing"
+    [
+      ( "empty",
+        [ Alcotest.test_case "empty header" `Quick test_empty_header ] );
+      ( "format",
+        [ Alcotest.test_case "single phase" `Quick test_single_phase_format;
+          Alcotest.test_case "insertion order" `Quick test_multiple_phases_insertion_order;
+          Alcotest.test_case "phase accumulates" `Quick test_repeated_phase_accumulates;
+        ] );
+      ( "measure",
+        [ Alcotest.test_case "records elapsed" `Quick test_measure_records_elapsed;
+          Alcotest.test_case "records on exception" `Quick test_measure_records_on_exception;
+        ] );
+      ( "tokens",
+        [ Alcotest.test_case "phase_token total + RFC8673" `Quick test_phase_token_total_and_lowercase;
+          Alcotest.test_case "Custom sanitised" `Quick test_custom_phase_sanitized;
+        ] );
+      ( "wrap",
+        [ Alcotest.test_case "extra_header" `Quick test_extra_header_wrap ] );
+    ]
+;;


### PR DESCRIPTION
## Summary

Dashboard 5개 endpoint(`/shell`, `/tools`, `/project-snapshot`, `/telemetry`, `/telemetry/summary`)에서 30초+ pending이 관찰되었으나, 어디서 시간이 가는지 측정할 인프라가 없었음. 본 PR은 **Phase 1 Action 1 (Server-Timing 헤더)** 만 다룬다 — 측정 없이 cap/cooldown 추가는 sw-dev §워크어라운드 거부 기준 §1 (텔레메트리-as-fix) 위반이라, *근본 개선의 prerequisite로 측정을 먼저* 마련한다.

분석 보고서: `memory/masc-mcp-dashboard-slow-endpoints-report-2026-05-19.html` (jeong-sik/me#1144).

## Changes

### 신규 `Server_timing` 모듈 (`lib/server/server_timing.{ml,mli}`)
- RFC 8673 §3.1 token grammar 준수 헤더 직렬화기
- Phase는 **closed variant** (string magic 금지) — 새 phase 추가 시 컴파일 타임 강제. `Custom` constructor는 ad-hoc 사용한정 + token char sanitisation
- `measure : t -> phase -> (unit -> 'a) -> 'a`: 예외 발생해도 elapsed 누적 후 re-raise (실패 path도 attribution)
- `extra_header : t -> (string * string) list`: 비어있으면 [] 반환 → `Http.Response.json ~extra_headers` 와 그대로 호환

### 5 endpoint wire
| Endpoint | 측정 phase |
|---|---|
| `GET /api/v1/dashboard/shell` | `cache_lookup` + 8 projection phase (status / agents / tasks / keepers / configured_keepers / meta_cognition / config_resolution / runtime_resolution) |
| `GET /api/v1/dashboard/tools` | `projection_config_resolution`, `projection_runtime_resolution`, `tools_compute` ×2 (inventory + usage) |
| `GET /api/v1/dashboard/project-snapshot` (+ `/namespace-truth`, `/room-truth`) | `project_snapshot_runtime` (wrapper, 내부 fiber phase 분리는 후속 PR) |
| `GET /api/v1/dashboard/telemetry` | `telemetry_query` + `json_serialize` |
| `GET /api/v1/dashboard/telemetry/summary` | `cache_lookup` (wrap) + `telemetry_summary_aggregate` (miss path) |

### 단위 테스트 (`test/test_server_timing.ml`)
- 빈 header → `""` 보장 (Browser DevTools가 빈 헤더 무시)
- 단일 phase format: `cache_lookup;dur=12.3` (소수점 1자리, 정수 산술 round)
- Insertion order 보존 (DevTools render 순서 일치)
- 동일 phase 누적
- `measure` 예외 경로에서도 elapsed 기록
- 모든 closed variant constructor의 `phase_token` RFC 8673 token char만 사용
- `Custom` constructor sanitisation

## Trade-offs

| | 채택 | 거부 | 이유 |
|---|---|---|---|
| **Time API** | `Unix.gettimeofday` | `Mtime_clock.now_ns` (monotonic) | codebase 일관성. NTP 점프 영향 ms 단위에서는 무시 가능. dep 추가 회피 |
| **Phase typing** | closed variant + `Custom` escape | string label | magic string drift 방지. `Custom`은 token sanitisation 강제로 silent failure 차단 |
| **Concurrency model** | per-fiber mutable accumulator | `Atomic.t` lock-free | request 한 fiber 안 sequential. mli에 single-fiber 의무 명시. 불필요한 비용 회피 |
| **Backward compat** | `?timing` 옵션 인자 (전 함수) | 강제 인자 | 기존 호출자 변경 없음 |
| **project-snapshot wire 깊이** | wrapper 1 phase | 내부 4 fiber phase 분리 | 본 PR scope를 instrumentation으로 한정. 내부 phase는 측정값이 알려준 후 후속 PR |

## Workaround Rejection Bar Self-Check

본 PR이 sw-dev §워크어라운드 거부 기준 시그니처 3종 + 체크리스트 7항목 위반인지 점검:

- [x] §1 텔레메트리-as-fix: **위반 아님**. 본 PR은 *측정 인프라*이지 *failure-as-counter*가 아니다. `Server-Timing` 헤더는 latency attribution이고, latency 자체를 줄이는 후속 PR (Phase 2-3)의 prerequisite. 보고서 본문에 이 PR이 후속 *근본 fix*를 가능하게 한다고 명시.
- [x] §2 string 분류기: **위반 아님**. phase는 closed variant. `Custom` constructor는 sanitisation으로 token grammar 강제, 새 string prefix를 받지 않음.
- [x] §3 N-of-M: **위반 아님**. 5 endpoint 모두 wire (`shell`, `tools`, `project-snapshot`+2 alias, `telemetry`, `telemetry/summary`). 모든 production endpoint 일괄 적용.
- [x] catch-all `_ ->` 추가: 없음.
- [x] cap/cooldown/dedup: 없음.
- [x] test backdoor: 없음.
- [x] N개 사이트 N번 fix: 없음 (codemod-스타일 일괄 wire).

## Verification

```bash
# 1) typecheck
opam exec -- dune build --root . @check

# 2) unit tests
opam exec -- dune build --root . test/test_server_timing.exe
./_build/default/test/test_server_timing.exe

# 3) Manual smoke (서버 기동 후)
curl -D - http://localhost:8935/api/v1/dashboard/shell?light=true 2>&1 | grep -i Server-Timing
# → Server-Timing: cache_lookup;dur=12.3, projection_status;dur=85.0, ...
```

## Next steps (out of scope)

후속 PR (분리):
- **Action 2**: `Dashboard_cache` stats endpoint (hit ratio / in-flight)
- **Action 3**: `Prometheus.histogram` per-endpoint p50/p95/p99
- **Action 4**: `/tools` endpoint 30s TTL `Dashboard_cache` 추가 (현재 cache 없음)
- **Action 8 (Phase 3)**: `Dashboard_snapshot` 모듈 — `Atomic.t` 기반 lock-free snapshot, 14+ timeout env 변수 sunset

본 PR이 머지되면 production fleet 1주 측정 후 Action 4-8 우선순위 데이터로 검증한다.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
