### PR TITLE
fix(tool_agent_timeline): parse-fail of latency_ms/context_ratio yields null, not zero

### DIFF
--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -387,8 +387,8 @@ let turn_completed_events (config : Coord.config) ~agent_name ~limit :
          with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> None
        in
        let latency_ms =
-         try e.payload |> member "latency_ms" |> to_int
-         with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> 0
+         try Some (e.payload |> member "latency_ms" |> to_int)
+         with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> None
        in
        let model_used =
          try e.payload |> member "model_used" |> to_string
@@ -399,8 +399,8 @@ let turn_completed_events (config : Coord.config) ~agent_name ~limit :
          |> Option.value ~default:"unknown"
        in
        let context_ratio =
-         try e.payload |> member "context_ratio" |> to_float
-         with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> 0.0
+         try Some (e.payload |> member "context_ratio" |> to_float)
+         with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> None
        in
        let tools_used =
          try e.payload |> member "tools_used" |> to_list
@@ -450,10 +450,10 @@ let turn_completed_events (config : Coord.config) ~agent_name ~limit :
                  ("cache_creation_tokens", Json_util.int_opt_to_json cache_creation_tokens);
                  ("cache_read_tokens", Json_util.int_opt_to_json cache_read_tokens);
                  ("cost_usd", Json_util.float_opt_to_json cost_usd);
-                 ("latency_ms", `Int latency_ms);
+                 ("latency_ms", Json_util.int_opt_to_json latency_ms);
                  ("model_used", `String model_used);
                  ("work_kind", `String work_kind);
-                 ("context_ratio", `Float context_ratio);
+                 ("context_ratio", Json_util.float_opt_to_json context_ratio);
                  ("tools_used", `List (List.map (fun s -> `String s) tools_used));
                ] @ optional_fields);
          })


### PR DESCRIPTION
## Goal

\`Tool_agent_timeline.build_timeline\` decoded two boundary fields with a \`_ -> 0\` fall-through that masked unparseable payloads as semantically-valid zero values:

- \`latency_ms = 0\` reads as "instant" — physically impossible
- \`context_ratio = 0.0\` reads as "no context used" — misleads compaction triggers

Both are the **Workaround-Rejection-Bar #2 anti-pattern** (instructions/software-development.md §"Unknown → Permissive Default"): boundary input silently mapped to a permissive default that pollutes downstream analytics.

Discovered by parallel scout sweep during /loop Iter#43, verified and corrected in Iter#46.

## Why this is a *real fix*, not telemetry-as-fix

The sibling fields in the same record (\`cost_usd\`, \`input_tokens\`, \`output_tokens\`, \`cache_creation_tokens\`, \`cache_read_tokens\`) already use the \`Some _ / None\` + \`Json_util.{int,float}_opt_to_json\` pattern. \`latency_ms\` and \`context_ratio\` were *asymmetric* outliers. The change makes them consistent with the existing typed-option convention, surfacing parse failures as JSON \`null\` instead of zero.

## Diff shape

\`\`\`ocaml
(* before *)
let latency_ms =
  try e.payload |> member \"latency_ms\" |> to_int
  with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> 0
...
(\"latency_ms\", \`Int latency_ms);

(* after — symmetric with cost_usd at L385 *)
let latency_ms =
  try Some (e.payload |> member \"latency_ms\" |> to_int)
  with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> None
...
(\"latency_ms\", Json_util.int_opt_to_json latency_ms);
\`\`\`

Same shape applied to \`context_ratio\` (float).

## Frontend compatibility verified

| File | Pattern |
|------|---------|
| \`dashboard/src/keeper-message.ts:66\` | \`latencyMs: asNumber(payload.latency_ms) ?? null\` |
| \`dashboard/src/mission-normalizers-entities.ts:122\` | \`context_ratio: asNumber(raw.context_ratio) ?? null\` |
| \`dashboard/src/keeper-store-normalize.ts:287\` | \`if (ts == null \|\| contextRatio == null) return null\` |

Frontend already designs for the null branch on both fields. The change is consistent with all other nullable timeline fields.

## Scope — what is NOT in this PR

The **aggregation sites** at \`build_timeline\` lines 531-549 (\`total_input_tokens\` / \`total_output_tokens\` / \`total_cost_usd\` via \`List.fold_left + _ -> 0\`) are deliberately deferred to a separate PR. Changing the fold-with-None semantic widens the sum's interpretation (partial-sum vs. parse-failure-counter) and warrants its own task.

## Verification

\`\`\`
dune build --root . @check       # clean
\`\`\`

## Touch points

- 1 file, +6 / -6 LoC (3 hunks: latency_ms parse, context_ratio parse, record literal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>