### PR TITLE
Prevent repeated workflow rejection tool calls

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -652,22 +652,23 @@ let make_keeper_tool_handler
             let recovery_fields =
               workflow_rejection_recovery_fields @ deterministic_recovery_fields
             in
-            (* Deterministic policy/shape blocks: jump the per-(tool,args)
-               failure counter to [max_consecutive_failures] on the first
-               occurrence so the next invocation with the same args lands
-               in the [prior_fails >= max_consecutive_failures] block branch
-               at the top of the handler instead of repeating the same
-               error log at 2/3 and 3/3. The current call still emits
-               once (with the [retry_skipped*] recovery fields above) so
-               the LLM receives a single, self-correcting response. *)
+            (* Deterministic policy/shape blocks, including typed workflow
+               rejections: jump the per-(tool,args) failure counter to
+               [max_consecutive_failures] on the first occurrence so the next
+               invocation with the same args lands in the
+               [prior_fails >= max_consecutive_failures] block branch at the
+               top of the handler instead of executing the same rejected tool
+               again. The current call still emits once (with the
+               [retry_skipped*] / workflow recovery fields above) so the LLM
+               receives a single, self-correcting response. *)
             let count =
               match deterministic_reason, is_workflow_rejection with
-              | _, true -> 0
               | Some _, _ ->
                 failure_count_jump_to
                   failure_counts
                   key
                   ~target:max_consecutive_failures
+              | None, true -> 0
               | None, false -> failure_count_record_failure failure_counts key
             in
             Keeper_registry.record_tool_use

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -1217,6 +1217,61 @@ let test_workflow_rejection_recovery_fields_mark_loop () =
   check int "workflow rejection count" 2 (json_int "count" recovery)
 ;;
 
+let test_workflow_rejection_same_args_short_circuits_after_first_failure () =
+  let meta =
+    make_test_meta
+      ~name:"test-keeper-workflow-no-repeat"
+      ~allowed_paths:[ "*" ]
+      ()
+  in
+  let ctx_snapshot = make_test_ctx () in
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "test_keeper_tools_workflow_%d" (Random.int 100000))
+  in
+  (try Unix.mkdir dir 0o755 with
+   | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       let config = Coord.default_config dir in
+       let tools = make_registered_tools ~config ~meta ~ctx_snapshot () in
+       let bash = find_tool "Bash" tools in
+       let args = `Assoc [ "command", `String "keeper_tasks_list" ] in
+       (match Tool.execute bash args with
+        | Error { Agent_sdk.Types.message; _ } ->
+          let json = parse message in
+          check bool "first failure is not guardrail" false (is_guardrail_message message);
+          check
+            string
+            "failure class"
+            "workflow_rejection"
+            (json_string "failure_class" json);
+          check
+            bool
+            "self correction required"
+            true
+            (json_bool "self_correction_required" json);
+          check
+            string
+            "retry skipped reason"
+            "deterministic_error_workflow_rejection_blocked"
+            (json_string "retry_skipped_reason" json)
+        | Ok _ -> fail "direct tool command through Bash should be a workflow rejection");
+       match Tool.execute bash args with
+       | Error { Agent_sdk.Types.message; _ } ->
+         check
+           bool
+           "same deterministic workflow rejection is blocked"
+           true
+           (is_guardrail_message message)
+       | Ok _ -> fail "same workflow rejection should be blocked before execution")
+;;
+
 let test_normalize_failure_plain_text () =
   let raw = "tool keeper_bash failed (3/5): Unix_error(ENOENT)" in
   let normalized = Keeper_tools_oas.normalize_tool_result ~success:false raw in
@@ -1491,6 +1546,10 @@ let () =
             "workflow rejection marks repeated loop"
             `Quick
             test_workflow_rejection_recovery_fields_mark_loop
+        ; test_case
+            "workflow rejection same args stops after first failure"
+            `Quick
+            test_workflow_rejection_same_args_short_circuits_after_first_failure
         ; test_case
             "failure plain text wraps as error"
             `Quick


### PR DESCRIPTION
## Summary

- Treat typed workflow_rejection tool failures as deterministic for the per-tool same-args retry guard.
- Preserve the first self-correcting response, then block the next identical tool call before it executes.
- Add a regression that drives the public Bash alias through a workflow rejection and verifies the second identical call is stopped by the guardrail.

## Root Cause

The handler already classified failure_class=workflow_rejection as deterministic, but the failure counter matched the workflow_rejection branch first and reset the same-args count to zero. That allowed the keeper to retry the same rejected action on later turns instead of using the self-correction fields.

## Validation

- ocamlformat --check lib/keeper/keeper_tools_oas.ml test/test_keeper_tools_oas.ml
- git diff --check
- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_JOBS=1 scripts/dune-local.sh build test/test_keeper_tools_oas.exe
- ./_build/default/test/test_keeper_tools_oas.exe test normalize_tool_result 8 --color=never
- ./_build/default/test/test_keeper_tools_oas.exe test make_tools 6 --color=never

## Local Note

Running the full test_keeper_tools_oas.exe locally still exposes an existing order-dependent failure in make_tools 6 when it runs after earlier cases. The changed regression passes, and the existing make_tools 6 case passes when run alone.
