### PR TITLE
fix(dashboard): drop `| string` catch-all on KeeperPauseState / KeeperRuntimeBlockerState (audit F1)

### DIFF
--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -14,6 +14,10 @@ import { isRecord, asString, asNumber, asBoolean, asStringArray, toIsoTimestamp 
 import { isOfflineStatus } from './lib/status-utils'
 import { keeperDisplayStatus } from './lib/keeper-runtime-display'
 import { asKeeperRuntimeBlockerClass } from './lib/runtime-blocker-class'
+import {
+  asKeeperPauseState,
+  asKeeperRuntimeBlockerState,
+} from './lib/keeper-runtime-state'
 import { normalizeStopCause } from './lib/stop-cause'
 import { contextThresholds } from './config/context-thresholds'
 import { normalizeKeeperDiagnostic } from './keeper-state'
@@ -560,8 +564,8 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
           typeof row.proactive_enabled === 'boolean' ? row.proactive_enabled : undefined,
         proactive_idle_sec: asNumber(row.proactive_idle_sec),
         proactive_cooldown_sec: asNumber(row.proactive_cooldown_sec),
-        pause_state: asString(row.pause_state) ?? null,
-        runtime_blocker_state: asString(row.runtime_blocker_state) ?? null,
+        pause_state: asKeeperPauseState(row.pause_state),
+        runtime_blocker_state: asKeeperRuntimeBlockerState(row.runtime_blocker_state),
         runtime_blocker_class: runtimeBlockerClass,
         runtime_blocker_summary: runtimeBlockerSummary,
         runtime_blocker_continue_gate:

--- a/dashboard/src/lib/keeper-runtime-state.ts
+++ b/dashboard/src/lib/keeper-runtime-state.ts
@@ -1,0 +1,55 @@
+// Typed parsers for keeper wire-format state strings.
+//
+// Companion to `lib/runtime-blocker-class.ts` — same boundary
+// hardening pattern (string → closed-union narrowing at the wire
+// boundary, `null` for anything else).
+//
+// Why a parser at all? Backend (`lib/keeper/keeper_status_bridge.ml:720–725`)
+// emits `pause_state` ∈ {"active","paused"} and `runtime_blocker_state` ∈
+// {"clear","blocked","continue_gate"} — both *closed* vocabularies.
+// Previously `KeeperPauseState` carried a `| string` catch-all that
+// hid this fact and let unmapped values flow silently through type
+// narrowing (workaround-rejection-bar §5).
+//
+// This module is the SSOT for the *wire → typed* transition.
+
+import type { KeeperPauseState, KeeperRuntimeBlockerState } from '../types'
+
+const PAUSE_STATE_VALUES: ReadonlySet<string> = new Set([
+  'active',
+  'paused',
+] satisfies readonly KeeperPauseState[])
+
+const RUNTIME_BLOCKER_STATE_VALUES: ReadonlySet<string> = new Set([
+  'clear',
+  'blocked',
+  'continue_gate',
+] satisfies readonly KeeperRuntimeBlockerState[])
+
+export function isKeeperPauseState(value: string): value is KeeperPauseState {
+  return PAUSE_STATE_VALUES.has(value)
+}
+
+export function asKeeperPauseState(
+  value: unknown,
+): KeeperPauseState | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  if (trimmed === '') return null
+  return isKeeperPauseState(trimmed) ? trimmed : null
+}
+
+export function isKeeperRuntimeBlockerState(
+  value: string,
+): value is KeeperRuntimeBlockerState {
+  return RUNTIME_BLOCKER_STATE_VALUES.has(value)
+}
+
+export function asKeeperRuntimeBlockerState(
+  value: unknown,
+): KeeperRuntimeBlockerState | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  if (trimmed === '') return null
+  return isKeeperRuntimeBlockerState(trimmed) ? trimmed : null
+}

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -431,8 +431,16 @@ export const KEEPER_RUNTIME_BLOCKER_CLASSES = [
 ] as const
 
 export type KeeperRuntimeBlockerClass = (typeof KEEPER_RUNTIME_BLOCKER_CLASSES)[number]
-export type KeeperPauseState = 'active' | 'paused' | string
-export type KeeperRuntimeBlockerState = 'clear' | 'blocked' | 'continue_gate' | string
+// Wire emit: `lib/keeper/keeper_status_bridge.ml:720` —
+//   `pause_state = if meta.paused then "paused" else "active"`.
+// Closed 2-arm; the previous `| string` catch-all hid the fact that
+// the wire vocabulary is exhaustive and let unmapped values flow
+// silently through narrowing.
+export type KeeperPauseState = 'active' | 'paused'
+
+// Wire emit: `lib/keeper/keeper_status_bridge.ml:721–724` — derived
+// from `runtime_blocker_surface_opt` + `continue_gate`. Closed 3-arm.
+export type KeeperRuntimeBlockerState = 'clear' | 'blocked' | 'continue_gate'
 
 export type StopCauseSource =
   | 'runtime_blocker_class'


### PR DESCRIPTION
## Summary

Dashboard SSOT audit (2026-05-19 P0) finding **F1** — \`KeeperPauseState\` 와 \`KeeperRuntimeBlockerState\` 의 \`| string\` catch-all 제거.

## Why

Backend (\`lib/keeper/keeper_status_bridge.ml:720–725\`) 가 두 필드를 *closed vocabulary* 로 emit:

- \`pause_state ∈ {\"active\",\"paused\"}\`
- \`runtime_blocker_state ∈ {\"clear\",\"blocked\",\"continue_gate\"}\`

이전 typed union 의 \`| string\` catch-all 은 이 사실을 *숨기고* unmapped wire 값을 silent narrowing 통과시킴. workaround-rejection-bar §5 (catch-all 추가는 제거가 아닌 추가 → 워크어라운드 시그니처).

## Trade-off

- **위험 없음**: backend emit 값이 *반드시* 위 closed set 안에 있음 (verified)
- **새 모듈** \`lib/keeper-runtime-state.ts\`: 기존 \`lib/runtime-blocker-class.ts\` 의 typed parser 패턴 복제 — caller=1 (keeper-store-normalize) 이지만 wire boundary SSOT 컨벤션 따름
- 새 wire 값 추가 시 backend OCaml 변경 + frontend union 확장이 *동시에 필요* — 컴파일러가 enforce

## What Changed

- \`types/core.ts:434–435\`: closed unions + emit-site 주석
- \`lib/keeper-runtime-state.ts\` 신설: \`asKeeperPauseState\`, \`asKeeperRuntimeBlockerState\` typed parsers
- \`keeper-store-normalize.ts:563–564\`: raw \`asString\` → typed parser 호출

## Test plan

- [x] \`pnpm typecheck\` PASS
- [x] 72/72 tests PASS (keeper-store-normalize + keeper-operational-state + runtime-blocker-class)
- [ ] human review

## Related

- Dashboard SSOT/IA audit 2026-05-19 (F1)
- Similar pattern: \`lib/runtime-blocker-class.ts\` (\`asKeeperRuntimeBlockerClass\`)
- RFC reference: workaround-rejection-bar §5 (catch-all default 거부 기준)

RFC-WAIVED: typed sum hardening only, no architectural change

🤖 Generated with [Claude Code](https://claude.com/claude-code)