### PR TITLE
feat(dashboard): /cache-stats endpoint + extended stats (Phase 1 Action 2)

### DIFF
--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -192,11 +192,19 @@ let wait_poll_interval_sec = 0.25
     instrumentation — never branches on these counters. *)
 let cache_metric_label = [("cache", "dashboard")]
 
+(* Local hit/miss counters in addition to Prometheus, because Prometheus has
+   no read-back API in this codebase and we want to surface live ratios via
+   [stats ()] without forcing operators to scrape /metrics. *)
+let cache_hits_total = Atomic.make 0
+let cache_misses_total = Atomic.make 0
+
 let inc_cache_hit () =
+  Atomic.incr cache_hits_total;
   Prometheus.inc_counter Prometheus.metric_cache_hits_total
     ~labels:cache_metric_label ()
 
 let inc_cache_miss () =
+  Atomic.incr cache_misses_total;
   Prometheus.inc_counter Prometheus.metric_cache_misses_total
     ~labels:cache_metric_label ()
 
@@ -553,6 +561,28 @@ let invalidate_all () =
   Atomic.set table SMap.empty;
   clear_timeout_circuit_all ()
 
+(* Slot kind string used in [stats ()] entry list and tests.  Kept as a
+   total function rather than a string buried in [stats ()] so callers can
+   pattern-match it (e.g. dashboard UI filters by kind). *)
+type slot_kind = Fresh | Stale | Expired | Computing_slot
+
+let slot_kind_to_string = function
+  | Fresh -> "fresh"
+  | Stale -> "stale"
+  | Expired -> "expired"
+  | Computing_slot -> "computing"
+;;
+
+let slot_kind ~now_ts = function
+  | Ready e ->
+    if now_ts <= e.expires_at then Fresh
+    else if now_ts <= e.stale_until then Stale
+    else Expired
+  | Computing _ -> Computing_slot
+;;
+
+let max_entries_in_stats = 50
+
 let stats () =
   let map = Atomic.get table in
   let now_ts = Time_compat.now () in
@@ -560,17 +590,68 @@ let stats () =
   let ready_stale = ref 0 in
   let ready_expired = ref 0 in
   let computing = ref 0 in
-  SMap.iter (fun _ v ->
-    match v with
-    | Ready e ->
-        if now_ts <= e.expires_at then
-          incr ready_fresh
-        else if now_ts <= e.stale_until then
-          incr ready_stale
-        else
-          incr ready_expired
-    | Computing _ -> incr computing
+  let entries_acc = ref [] in
+  SMap.iter (fun k v ->
+    let kind = slot_kind ~now_ts v in
+    (match kind with
+     | Fresh -> incr ready_fresh
+     | Stale -> incr ready_stale
+     | Expired -> incr ready_expired
+     | Computing_slot -> incr computing);
+    let entry_json =
+      match v with
+      | Ready e ->
+        `Assoc [
+          ("key", `String k);
+          ("kind", `String (slot_kind_to_string kind));
+          ("ttl_remaining_ms", `Int (int_of_float ((e.expires_at -. now_ts) *. 1000.0)));
+          ("stale_remaining_ms",
+           `Int (int_of_float ((e.stale_until -. now_ts) *. 1000.0)));
+        ]
+      | Computing { started_at; stale; _ } ->
+        `Assoc [
+          ("key", `String k);
+          ("kind", `String "computing");
+          ("computing_for_ms", `Int (int_of_float ((now_ts -. started_at) *. 1000.0)));
+          ("has_stale_fallback", `Bool (Option.is_some stale));
+        ]
+    in
+    entries_acc := entry_json :: !entries_acc
   ) map;
+  (* Truncate per-entry list to bound payload size — operators looking for
+     specific keys can read [/metrics] for the full prometheus surface. *)
+  let entries_list =
+    let all = List.rev !entries_acc in
+    if List.length all <= max_entries_in_stats
+    then all
+    else (
+      (* Keep the [max_entries_in_stats] entries closest to expiry (most
+         actionable) — sort by ttl_remaining_ms ascending and take first N. *)
+      let key_of = function
+        | `Assoc fields ->
+          (match List.assoc_opt "ttl_remaining_ms" fields with
+           | Some (`Int n) -> n
+           | _ ->
+             (match List.assoc_opt "computing_for_ms" fields with
+              | Some (`Int n) -> -n  (* computing slots first *)
+              | _ -> max_int))
+        | _ -> max_int
+      in
+      List.sort (fun a b -> compare (key_of a) (key_of b)) all
+      |> List.filteri (fun i _ -> i < max_entries_in_stats))
+  in
+  let hits = Atomic.get cache_hits_total in
+  let misses = Atomic.get cache_misses_total in
+  let total = hits + misses in
+  let hit_ratio =
+    if total = 0 then 0.0 else float_of_int hits /. float_of_int total
+  in
+  let timeout_circuit_map = Atomic.get timeout_circuit_table in
+  let circuit_open_count =
+    SMap.fold (fun _ c acc ->
+      if c.opened_until > now_ts then acc + 1 else acc
+    ) timeout_circuit_map 0
+  in
   `Assoc [
     ("entries", `Int (SMap.cardinal map));
     ("fresh", `Int !ready_fresh);
@@ -580,4 +661,11 @@ let stats () =
     ("ready_stale", `Int !ready_stale);
     ("computing", `Int !computing);
     ("max_entries", `Int max_entries);
+    ("hits_total", `Int hits);
+    ("misses_total", `Int misses);
+    ("hit_ratio", `Float hit_ratio);
+    ("timeout_circuit_open", `Int circuit_open_count);
+    ("timeout_circuit_tracked", `Int (SMap.cardinal timeout_circuit_map));
+    ("entries_truncated_to", `Int max_entries_in_stats);
+    ("entry_details", `List entries_list);
   ]

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -543,6 +543,17 @@ let rec add_routes ~sw ~clock router =
            (Yojson.Safe.to_string json) reqd
        in
        with_tool_auth ~tool_name:"masc_runtime_ollama_probe" handle request reqd)
+  (* Phase 1 Action 2 — live Dashboard_cache state surface.  Renders
+     hit_ratio, in-flight compute count, per-entry ttl_remaining, and
+     timeout-circuit-open counts so operators can correlate slow endpoints
+     (Server-Timing header) with cache contention without scraping
+     /metrics.  Read-only; no env tuning side-effect. *)
+  |> Http.Router.get "/api/v1/dashboard/cache-stats" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let json = Dashboard_cache.stats () in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/logs" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let limit =

--- a/test/test_dashboard_cache.ml
+++ b/test/test_dashboard_cache.ml
@@ -201,6 +201,57 @@ let test_stats () =
   let fresh = Yojson.Safe.Util.(member "ready_fresh" stats |> to_int) in
   Alcotest.(check int) "2 fresh entries" 2 fresh
 
+(* Phase 1 Action 2 — verify the extended stats surface that the
+   /api/v1/dashboard/cache-stats endpoint exposes.  This protects:
+   - per-entry ttl_remaining_ms and kind strings (UI filters on them)
+   - hit_ratio computation when there are both hits and misses
+   - bounded entry_details payload (no unbounded growth) *)
+let test_stats_detail_surface () =
+  Dashboard_cache.invalidate_all ();
+  (* Two misses (cold compute), then two hits on same keys. *)
+  ignore (Dashboard_cache.get_or_compute "d1" ~ttl:10.0 (fun () -> `Int 1));
+  ignore (Dashboard_cache.get_or_compute "d2" ~ttl:10.0 (fun () -> `Int 2));
+  ignore (Dashboard_cache.get_or_compute "d1" ~ttl:10.0 (fun () -> `Int 99));
+  ignore (Dashboard_cache.get_or_compute "d2" ~ttl:10.0 (fun () -> `Int 99));
+  let stats = Dashboard_cache.stats () in
+  let open Yojson.Safe.Util in
+  let hits = member "hits_total" stats |> to_int in
+  let misses = member "misses_total" stats |> to_int in
+  Alcotest.(check bool) "hits >= 2" true (hits >= 2);
+  Alcotest.(check bool) "misses >= 2" true (misses >= 2);
+  let ratio = member "hit_ratio" stats |> to_number in
+  Alcotest.(check bool) "ratio in [0,1]" true (ratio >= 0.0 && ratio <= 1.0);
+  Alcotest.(check int) "entries_truncated_to surfaced"
+    50 (member "entries_truncated_to" stats |> to_int);
+  (* entry_details must be a JSON list and each element a JSON object. *)
+  let details = member "entry_details" stats |> to_list in
+  Alcotest.(check bool) "details non-empty" true (List.length details >= 2);
+  List.iter (fun e ->
+    let key = member "key" e |> to_string in
+    let kind = member "kind" e |> to_string in
+    Alcotest.(check bool)
+      (Printf.sprintf "kind is fresh|stale|expired|computing for key=%s" key)
+      true (List.mem kind ["fresh"; "stale"; "expired"; "computing"])
+  ) details
+;;
+
+let test_stats_handles_empty_table () =
+  (* [invalidate_all] only clears the entry table; hit/miss counters are
+     cumulative monotonic (Prometheus convention). So after other tests in
+     the same harness, hit_ratio is non-zero — we assert it is still in
+     [0,1] and that the entries surface itself is empty.  This is the
+     invariant operators actually care about (no NaN, no negative). *)
+  Dashboard_cache.invalidate_all ();
+  let stats = Dashboard_cache.stats () in
+  let open Yojson.Safe.Util in
+  Alcotest.(check int) "no entries" 0 (member "entries" stats |> to_int);
+  Alcotest.(check bool) "empty details"
+    true (member "entry_details" stats |> to_list = []);
+  let ratio = member "hit_ratio" stats |> to_number in
+  Alcotest.(check bool) "ratio in [0,1] (no NaN, no negative)"
+    true (ratio >= 0.0 && ratio <= 1.0)
+;;
+
 (* -- 6. Stampede: N fibers, same key -> compute runs once ------------------- *)
 
 let test_stampede () =
@@ -517,6 +568,8 @@ let () =
           test_case "invalidate" `Quick test_invalidate;
           test_case "invalidate_prefix" `Quick test_invalidate_prefix;
           test_case "stats" `Quick test_stats;
+          test_case "stats detail surface" `Quick test_stats_detail_surface;
+          test_case "stats empty table" `Quick test_stats_handles_empty_table;
           test_case "exception recovery" `Quick test_exception_recovery;
           test_case "invalidate_all wakes waiters" `Quick
             test_invalidate_all_wakes_waiters;


### PR DESCRIPTION
## Summary

Dashboard 5개 endpoint이 30s pending인 이유 후보 중 하나가 `Dashboard_cache` lock contention + 다발 in-flight compute. 그러나 운영자는 그 상태를 보려면 `/metrics` 스크래이프 후 prometheus query 작성을 해야 했다. 본 PR은 **Phase 1 Action 2 — Dashboard_cache 통계 endpoint**. 운영자가 `curl /api/v1/dashboard/cache-stats` 한 번이면 hit ratio + in-flight 수 + per-entry TTL을 본다.

본 PR은 #16645 (Phase 1 Action 1, Server-Timing 헤더)의 자매 PR. 두 PR 머지 후에는 endpoint 차원 attribution (Server-Timing) + 캐시 차원 attribution (cache-stats) 두 layer가 모두 마련된다 → Phase 2-3 (lock-free snapshot, cap sunset) 결정을 데이터로 한다.

분석 보고서: `memory/masc-mcp-dashboard-slow-endpoints-report-2026-05-19.html` (jeong-sik/me#1144).

## Changes

### `lib/dashboard/dashboard_cache.ml` — stats 확장
- `cache_hits_total`, `cache_misses_total` Atomic.int 추가 (Prometheus는 read-back API가 없어 stats 노출에 직접 사용 불가)
- `slot_kind` typed 변환 함수 (Fresh / Stale / Expired / Computing_slot) — 매직 string 회피, dashboard UI 필터 키 stable
- `stats ()` 확장:
  - `hits_total`, `misses_total`, `hit_ratio` (총 traffic = 0 시 0.0, division-by-zero 없음)
  - `entry_details` 최대 50개 (ttl_remaining_ms 오름차순, computing slot 먼저 — 가장 actionable)
  - `timeout_circuit_open` / `timeout_circuit_tracked` 카운트
  - 기존 `fresh`/`stale`/`expired`/`computing`/`max_entries` 유지 — backward compat

### `lib/server/server_routes_http_routes_dashboard.ml` — 신규 endpoint
- `GET /api/v1/dashboard/cache-stats` — read-only, public_read auth (다른 dashboard endpoint와 동일)
- 본문은 `Dashboard_cache.stats ()` 한 줄

### `test/test_dashboard_cache.ml` — 추가 테스트 2개
- `test_stats_detail_surface`: hit/miss 누적 후 ratio ∈ [0,1] + entry_details kind 토큰 검증 + 길이 ≥ 미스 횟수
- `test_stats_handles_empty_table`: 빈 테이블에서 division-by-zero 없음, entry_details = []

## Trade-offs

| 채택 | 거부 | 이유 |
|---|---|---|
| 자체 `Atomic.int` hit/miss | Prometheus 카운터만 사용 | codebase에 Prometheus read-back API 없음. /metrics 스크래이프 안 한 운영자도 즉시 hit ratio 확인 가능 |
| `slot_kind` typed 변환 | string match 분기 | 새 slot kind 추가 시 컴파일 타임 강제 (sw-dev §AI 안티패턴 §4 FSM sparse match 회피) |
| Top 50 entry detail | 전체 entry 노출 | payload size 무한 증가 회피. detail 50개 + 전체 카운트로 sampling 충분 |
| Public read auth | tool_auth | 읽기 전용 통계. 토큰 노출 안 함. 운영자 cURL 즉시성 우선 |

## Workaround Rejection Bar Self-Check

- [x] §1 텔레메트리-as-fix: **위반 아님**. 본 PR은 *측정 가시화*이지 *failure counter*가 아니다. hit ratio 자체가 fix가 아니라 후속 fix의 prerequisite. cap/cooldown sunset 결정의 데이터.
- [x] §2 string 분류기: **위반 아님**. `slot_kind` typed variant 도입으로 string match를 *줄임*.
- [x] §3 N-of-M: **위반 아님**. cache-stats 하나의 endpoint 단일 책임.
- [x] cap/cooldown/dedup: 없음.
- [x] test backdoor: 없음.

## Verification

```bash
# typecheck
opam exec -- dune build --root . @check

# unit tests
opam exec -- dune build --root . test/test_dashboard_cache.exe
./_build/default/test/test_dashboard_cache.exe

# Manual smoke (서버 기동 후)
curl -s http://localhost:8935/api/v1/dashboard/cache-stats | jq '{
  hit_ratio, hits_total, misses_total, computing, timeout_circuit_open
}'
```

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
