### PR TITLE
refactor(cascade): typed Structural_attempt_timeout — remove N-of-M substring classifier (PR-2)

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -86,6 +86,7 @@ type cascade_exhaustion_reason =
   | All_providers_failed
   | Candidates_filtered_after_cycles
   | Max_turns_exceeded
+  | Structural_attempt_timeout of { detail : string }
   | Other_detail of string
 
 type blocker_class =
@@ -197,6 +198,8 @@ let cascade_exhaustion_summary = function
   | Candidates_filtered_after_cycles -> "Cascade exhausted after provider failures."
   | Max_turns_exceeded ->
     "Cascade exhausted after a provider hit its per-call turn budget."
+  | Structural_attempt_timeout _ ->
+    "Cascade exhausted after the per-OAS-call ceiling (max_execution_time_s) fired."
   | Other_detail _ -> "Cascade exhausted after provider failures."
 ;;
 
@@ -233,6 +236,8 @@ let cascade_exhaustion_reason_to_json = function
   | All_providers_failed -> `String "all_providers_failed"
   | Candidates_filtered_after_cycles -> `String "candidates_filtered_after_cycles"
   | Max_turns_exceeded -> `String "max_turns_exceeded"
+  | Structural_attempt_timeout { detail } ->
+    `Assoc [ "tag", `String "structural_attempt_timeout"; "detail", `String detail ]
   | Other_detail msg -> `Assoc [ "tag", `String "other_detail"; "message", `String msg ]
 ;;
 
@@ -244,12 +249,29 @@ let cascade_exhaustion_reason_of_json = function
   | `String "max_turns_exceeded" -> Some Max_turns_exceeded
   | `Assoc fields ->
     (match List.assoc_opt "tag" fields with
+     | Some (`String "structural_attempt_timeout") ->
+       (match List.assoc_opt "detail" fields with
+        | Some (`String detail) -> Some (Structural_attempt_timeout { detail })
+        | _ -> None)
      | Some (`String "other_detail") ->
        (match List.assoc_opt "message" fields with
         | Some (`String msg) -> Some (Other_detail msg)
         | _ -> None)
      | _ -> None)
   | _ -> None
+;;
+
+let cascade_exhaustion_reason_from_message msg =
+  (* SSOT: the only place that decides whether a free-form cascade-exhaustion
+     message names a structural per-OAS-call ceiling.  Producers call this
+     instead of writing [Other_detail msg] directly so downstream consumers
+     can pattern-match the typed [Structural_attempt_timeout] case.
+     Substring is unavoidable here (the upstream message is a raw SDK
+     string), but it is contained to a single function — replacing the
+     prior N-of-M classifier with one source of truth. *)
+  if String_util.contains_substring_ci msg "max_execution_time_s"
+  then Structural_attempt_timeout { detail = msg }
+  else Other_detail msg
 ;;
 
 (* ── Unified blocker_info: typed klass + free-form detail ───────

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -138,6 +138,13 @@ type cascade_exhaustion_reason =
   | All_providers_failed
   | Candidates_filtered_after_cycles
   | Max_turns_exceeded
+  | Structural_attempt_timeout of { detail : string }
+      (** Agent SDK [with_optional_timeout] wrapper fired its per-OAS-call
+          ceiling ([max_execution_time_s]). Distinct from transport-level
+          provider timeouts. [detail] preserves the upstream message for
+          diagnostics. Replaces substring-tagged [Other_detail] payloads
+          that downstream consumers had to re-parse with
+          [contains_substring_ci ... "max_execution_time_s"]. *)
   | Other_detail of string
 
 type blocker_class =
@@ -188,6 +195,18 @@ val cascade_exhaustion_reason_to_json :
 
 val cascade_exhaustion_reason_of_json :
   Yojson.Safe.t -> cascade_exhaustion_reason option
+
+val cascade_exhaustion_reason_from_message :
+  string -> cascade_exhaustion_reason
+(** SSOT for the {b only} substring-based classification of cascade
+    exhaustion messages. Returns
+    [Structural_attempt_timeout { detail = msg }] when [msg] contains
+    "max_execution_time_s" (case-insensitive), otherwise
+    [Other_detail msg]. Producers that previously wrote
+    [Other_detail (Cascade_fsm.to_user_message err)] should call this
+    so downstream consumers can [match] typed cases instead of
+    re-parsing the string. Removes the N-of-M substring classifier
+    pattern (RFC-0088 §1) that previously lived in three call sites. *)
 
 val blocker_class_of_serialized_string :
   string -> blocker_class option

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -216,10 +216,19 @@ let degraded_retry_slot_phase_available ~(time_spent_in_turn_s : float) : bool =
 
 let cascade_reason_is_structural_attempt_timeout
     (reason : Keeper_types.cascade_exhaustion_reason) : bool =
+  (* Typed match — no substring re-parsing. Producers route structural
+     OAS-ceiling messages into [Structural_attempt_timeout] via
+     [cascade_exhaustion_reason_from_message] (SSOT). Enumerate every
+     constructor so a new reason variant fails to compile here rather
+     than silently falling through to [false]. *)
   match reason with
-  | Keeper_types.Other_detail detail ->
-      String_util.contains_substring_ci detail "max_execution_time_s"
-  | _ -> false
+  | Keeper_types.Structural_attempt_timeout _ -> true
+  | Keeper_types.Connection_refused
+  | Keeper_types.No_providers_available
+  | Keeper_types.All_providers_failed
+  | Keeper_types.Candidates_filtered_after_cycles
+  | Keeper_types.Max_turns_exceeded
+  | Keeper_types.Other_detail _ -> false
 
 let degraded_retry_bypasses_slot_phase_guard
     (err : Agent_sdk.Error.sdk_error) : bool =

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -748,36 +748,42 @@ let run_named
             else if message_looks_like_cli_wrapped_max_turns message then
               Keeper_types.Max_turns_exceeded
             else
-              Keeper_types.Other_detail (Cascade_fsm.to_user_message last_err)
+              Keeper_types.cascade_exhaustion_reason_from_message
+                (Cascade_fsm.to_user_message last_err)
         | Some (Llm_provider.Http_client.TimeoutError { message; _ }) ->
             if message_looks_like_cli_wrapped_max_turns message then
               Keeper_types.Max_turns_exceeded
             else
-              Keeper_types.Other_detail (Cascade_fsm.to_user_message last_err)
+              Keeper_types.cascade_exhaustion_reason_from_message
+                (Cascade_fsm.to_user_message last_err)
         | Some (Llm_provider.Http_client.HttpError { body; _ }) ->
             if message_looks_like_cli_wrapped_max_turns body then
               Keeper_types.Max_turns_exceeded
             else
-              Keeper_types.Other_detail (Cascade_fsm.to_user_message last_err)
+              Keeper_types.cascade_exhaustion_reason_from_message
+                (Cascade_fsm.to_user_message last_err)
         | Some (Llm_provider.Http_client.AcceptRejected { reason = r }) ->
             if message_looks_like_cli_wrapped_max_turns r then
               Keeper_types.Max_turns_exceeded
             else
-              Keeper_types.Other_detail (Cascade_fsm.to_user_message last_err)
+              Keeper_types.cascade_exhaustion_reason_from_message
+                (Cascade_fsm.to_user_message last_err)
         | Some (Llm_provider.Http_client.CliTransportRequired _) ->
-            Keeper_types.Other_detail (Cascade_fsm.to_user_message last_err)
+            Keeper_types.cascade_exhaustion_reason_from_message
+                (Cascade_fsm.to_user_message last_err)
         | Some (Llm_provider.Http_client.ProviderTerminal
             { kind = Llm_provider.Http_client.Max_turns _; _ }) ->
             Keeper_types.Max_turns_exceeded
         | Some (Llm_provider.Http_client.ProviderTerminal
             { kind = Llm_provider.Http_client.Other _; _ }) ->
-            Keeper_types.Other_detail (Cascade_fsm.to_user_message last_err)
+            Keeper_types.cascade_exhaustion_reason_from_message
+                (Cascade_fsm.to_user_message last_err)
         | Some (Llm_provider.Http_client.ProviderFailure _ as err) ->
             let message = Cascade_fsm.to_user_message (Some err) in
             if message_looks_like_cli_wrapped_max_turns message then
               Keeper_types.Max_turns_exceeded
             else
-              Keeper_types.Other_detail message
+              Keeper_types.cascade_exhaustion_reason_from_message message
         | None -> Keeper_types.No_providers_available
       in
       let observation =

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -164,6 +164,7 @@ type cascade_exhaustion_reason = Keeper_meta_contract.cascade_exhaustion_reason 
   | All_providers_failed
   | Candidates_filtered_after_cycles
   | Max_turns_exceeded
+  | Structural_attempt_timeout of { detail : string }
   | Other_detail of string
 
 type blocker_class = Keeper_meta_contract.blocker_class =
@@ -197,6 +198,13 @@ val cascade_exhaustion_summary : cascade_exhaustion_reason -> string
 val blocker_class_continue_gate : blocker_class -> bool
 val cascade_exhaustion_reason_to_json : cascade_exhaustion_reason -> Yojson.Safe.t
 val cascade_exhaustion_reason_of_json : Yojson.Safe.t -> cascade_exhaustion_reason option
+
+val cascade_exhaustion_reason_from_message :
+  string -> cascade_exhaustion_reason
+(** SSOT helper for tagging free-form cascade-exhaustion messages with
+    [Structural_attempt_timeout] when the upstream SDK fired its
+    per-OAS-call ceiling ([max_execution_time_s]). See
+    [Keeper_meta_contract.cascade_exhaustion_reason_from_message]. *)
 
 (** Authoritative blocker representation: typed [klass] + free-form
     [detail].  Replaces the historic [last_blocker: string] +


### PR DESCRIPTION
## 목적

Agent-SDK의 per-OAS-call ceiling (`max_execution_time_s`) 시그널이 `cascade_exhaustion_reason.Other_detail msg`의 *free-form string*에만 인코딩되어 있어, 3 consumer가 `contains_substring_ci ... "max_execution_time_s"`로 다시 파싱하는 **RFC-0088 §1 N-of-M substring classifier 워크어라운드 패턴**을 제거.

## 변경 (root-fix)

1. `keeper_meta_contract.{mli,ml}`: typed case `Structural_attempt_timeout of { detail : string }` 추가, `Other_detail`은 *genuinely unclassified* 메시지 fallback으로 보존.
2. `keeper_meta_contract.{mli,ml}`: SSOT helper `cascade_exhaustion_reason_from_message : string -> cascade_exhaustion_reason` 신설 — substring 매칭이 **단일 위치**에만 존재.
3. `keeper_types.mli`: 신규 case + helper signature 재노출 (Keeper_types facade는 `include Keeper_meta_contract`로 자동 노출되므로 .ml 변경 불필요).
4. `keeper_turn_cascade_budget.ml`: `cascade_reason_is_structural_attempt_timeout`을 substring 매치에서 **exhaustive typed match**로 교체 — 새 reason variant가 추가되면 컴파일러가 즉시 catch.
5. `keeper_turn_driver.ml`: 7 producer 사이트를 `Keeper_types.Other_detail (Cascade_fsm.to_user_message ...)` → `Keeper_types.cascade_exhaustion_reason_from_message (...)`로 마이그레이션.

## 변경 통계

5 파일, +74 / -10. `Other_detail` constructor 자체는 유지 (다른 도메인 fallback 용).

## 워크어라운드 자체 audit (사용자 워크플로 §1)

- [x] 카운터-as-fix 없음
- [x] string/prefix 분류기 *추가* 없음 (오히려 3 사이트 → 1 사이트로 *축소*)
- [x] catch-all `_ -> ...` *추가* 없음 (consumer는 exhaustive로 강화)
- [x] N-of-M 자인 없음 — 본 PR이 정확히 *N-of-M 해소*
- [x] cap/cooldown/dedup 없음
- [x] test backdoor 없음

## Scope 밖 (별도 후속 PR)

- `cascade_attempt_fsm.ml:743/745` `timeout_source_label`의 raw `Agent_sdk.Error.sdk_error` substring 매치 — *다른 도메인* (SDK error 직접 분석). 두 도메인이 공유할 substring helper 추출은 별도 RFC 후보.
- 더 깊은 root-fix: SDK error 시점에 typed 분기하여 `typed→string→typed` round-trip 제거. 9 producer site ripple로 별도 PR 권장.

## RFC

해당 subsystem (`lib/keeper/keeper_*`, `lib/cascade/`)은 agent_delegation list (credential/identity/repo/operator/sandbox/hooks/workflow)에 *해당하지 않음*. 그러나 정합 RFC 인용: RFC-0127 (cascade fast-fail provenance), RFC-0129 (HTTP idle timeout streaming progress). 새 RFC 신설 불필요.

## 검증

**Local build skipped**: 4 concurrent bare-dune processes (PIDs 60639/50955/58049/50083) hold the machine-wide Dune lock from other worktrees. `scripts/dune-local.sh`의 안전 가드가 우회를 거부 — 사용자 워크플로 §10 정상 경로에 따라 CI에 검증 위임.

**Self-evident type-system check**: variant 추가 + producer signature 단일화 → 새 case 누락은 컴파일러가 즉시 catch. 5 파일 grep 결과 `Other_detail.*Cascade_fsm.to_user_message` 잔존 0건 확인.

## 후속

- PR-3: `keeper_shell_bash_task_probe.ml:50` catch-all + lowercase_contains loop, blocked_result_json typed next_action
- PR-4: RFC-0070 §2 G2 `sandbox_error` 7-case variant 구현 (Phase 4.1 prereq)
- PR-5: tool_task.ml:695 exhaustive enforce + coord_task.ml 3 WORKAROUND 해소
- PR-6: Tool_called row에 failure_class 추가 + telemetry_unified suppress_shadow dedup 제거 + RFC-0093 Phase B
- separate cross-domain helper for SDK timeout substring (cascade_attempt_fsm.timeout_source_label)

## Best Programmer self-review

- 목표: RFC-0088 §1 N-of-M substring classifier 패턴 제거 — `cascade_exhaustion_reason` 도메인 한정.
- 변경 파일: 5 (meta_contract.mli/.ml, types.mli, turn_cascade_budget.ml, turn_driver.ml)
- 로컬 검증: grep으로 old pattern 잔존 0, type system은 컴파일러 강제 (CI 위임)
- 미검증: dune build (machine-wide lock 점유) → CI checks 결과 대기

Co-Authored-By: Claude Opus 4.7