### PR TITLE
perf(dashboard): /tools endpoint 30s TTL Dashboard_cache (Phase 2 Action 4)

### DIFF
--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -687,6 +687,16 @@ let runtime_resolution_json (config : Coord.config) =
       @ Server_routes_http_runtime.keeper_fleet_runtime_resolution_fields () )
 ;;
 
+(* 30-second TTL chosen to match the dashboard frontend's natural refresh
+   cadence (~3s polling × 10 = a fresh value at least every minute under
+   sustained load).  Tool inventory + usage stats rarely change inside a
+   30s window — the per-actor cache key isolates permission changes from
+   leaking across actors. *)
+let dashboard_tools_cache_ttl_sec = 30.0
+
+let dashboard_tools_cache_key ~base_path ~actor =
+  Printf.sprintf "tools:%s:%s" base_path actor
+
 let dashboard_tools_http_json ?actor ?timing (config : Coord.config) : Yojson.Safe.t =
   let ctx : Tool_misc.context =
     { config; agent_name = Option.value ~default:"dashboard" actor }
@@ -696,29 +706,44 @@ let dashboard_tools_http_json ?actor ?timing (config : Coord.config) : Yojson.Sa
     | None -> f ()
     | Some t -> Server_timing.measure t phase f
   in
-  let config_resolution =
-    run Projection_config_resolution (fun () ->
-      Config_dir_resolver.(resolve () |> to_json))
+  let actor_for_key = Option.value ~default:"dashboard" actor in
+  let cache_key =
+    dashboard_tools_cache_key ~base_path:config.base_path ~actor:actor_for_key
   in
-  let runtime_resolution =
-    run Projection_runtime_resolution (fun () -> runtime_resolution_json config)
+  let compute () =
+    let config_resolution =
+      run Projection_config_resolution (fun () ->
+        Config_dir_resolver.(resolve () |> to_json))
+    in
+    let runtime_resolution =
+      run Projection_runtime_resolution (fun () -> runtime_resolution_json config)
+    in
+    let inventory =
+      run Tools_compute (fun () ->
+        Tool_misc.tool_inventory_json ctx ~include_hidden:true ~include_deprecated:true)
+    in
+    let usage =
+      run Tools_compute (fun () ->
+        Tool_unified.summary_report ()
+        |> Tool_usage_log.attach_source_metadata
+             ~masc_root:(Coord.masc_root_dir config))
+    in
+    `Assoc
+      [ "generated_at", `String (Masc_domain.now_iso ())
+      ; "config_resolution", config_resolution
+      ; "runtime_resolution", runtime_resolution
+      ; "tool_inventory", inventory
+      ; "tool_usage", usage
+      ]
   in
-  let inventory =
-    run Tools_compute (fun () ->
-      Tool_misc.tool_inventory_json ctx ~include_hidden:true ~include_deprecated:true)
-  in
-  let usage =
-    run Tools_compute (fun () ->
-      Tool_unified.summary_report ()
-      |> Tool_usage_log.attach_source_metadata ~masc_root:(Coord.masc_root_dir config))
-  in
-  `Assoc
-    [ "generated_at", `String (Masc_domain.now_iso ())
-    ; "config_resolution", config_resolution
-    ; "runtime_resolution", runtime_resolution
-    ; "tool_inventory", inventory
-    ; "tool_usage", usage
-    ]
+  match timing with
+  | None ->
+    Dashboard_cache.get_or_compute cache_key ~ttl:dashboard_tools_cache_ttl_sec
+      compute
+  | Some t ->
+    Server_timing.measure t Cache_lookup (fun () ->
+      Dashboard_cache.get_or_compute cache_key
+        ~ttl:dashboard_tools_cache_ttl_sec compute)
 ;;
 
 let dashboard_perf_http_json = Server_dashboard_http_perf.dashboard_perf_http_json

--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -429,6 +429,76 @@ let test_dashboard_tools_usage_marks_store_path_collision () =
       check int "tool usage path collision has synthetic gap" 1
         (usage |> member "coverage_gap_count" |> to_int))
 
+(* Phase 2 Action 4 — confirm the 30s Dashboard_cache wrapping holds.
+   Two back-to-back calls with the same actor must return byte-identical
+   payload (same [generated_at] timestamp); a different actor must
+   compute a fresh payload (different cache key).  We do not assert
+   exact compute count because the underlying Tool_unified.summary_report
+   has no observable counter — same-payload is the cleanest invariant.
+
+   This protects against a regression where the cache key drops the
+   actor, which would leak permission-scoped tool inventories across
+   agents. *)
+let test_dashboard_tools_cache_returns_same_payload_for_same_actor () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      with_stubbed_git_probe @@ fun () ->
+      with_dashboard_eio @@ fun () ->
+      let config = Coord_utils.default_config dir in
+      seed_git_probe_cache config;
+      ignore (Lib.Coord.init config ~agent_name:(Some "dashboard"));
+      Lib.Tool_usage_log.init ~base_path:dir ();
+      Lib.Dashboard_cache.invalidate_all ();
+      let first =
+        Lib.Server_dashboard_http.dashboard_tools_http_json ~actor:"dashboard"
+          config
+      in
+      let second =
+        Lib.Server_dashboard_http.dashboard_tools_http_json ~actor:"dashboard"
+          config
+      in
+      let open Yojson.Safe.Util in
+      let ts a = a |> member "generated_at" |> to_string in
+      check string "same actor returns cached payload (same generated_at)"
+        (ts first) (ts second))
+;;
+
+let test_dashboard_tools_cache_separates_actors () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      with_stubbed_git_probe @@ fun () ->
+      with_dashboard_eio @@ fun () ->
+      let config = Coord_utils.default_config dir in
+      seed_git_probe_cache config;
+      ignore (Lib.Coord.init config ~agent_name:(Some "dashboard"));
+      Lib.Tool_usage_log.init ~base_path:dir ();
+      Lib.Dashboard_cache.invalidate_all ();
+      let _ =
+        Lib.Server_dashboard_http.dashboard_tools_http_json ~actor:"dashboard"
+          config
+      in
+      (* Distinct actor must compute a *separate* cache entry — verify
+         via the entries count growing in Dashboard_cache stats. *)
+      let entries_before =
+        Lib.Dashboard_cache.stats ()
+        |> Yojson.Safe.Util.(fun j -> member "entries" j |> to_int)
+      in
+      let _ =
+        Lib.Server_dashboard_http.dashboard_tools_http_json
+          ~actor:"other-agent" config
+      in
+      let entries_after =
+        Lib.Dashboard_cache.stats ()
+        |> Yojson.Safe.Util.(fun j -> member "entries" j |> to_int)
+      in
+      check bool "distinct actor adds a separate cache entry"
+        true (entries_after > entries_before))
+;;
+
 let () =
   run "dashboard_tools"
     [
@@ -441,5 +511,11 @@ let () =
              test_tool_usage_store_failure_records_coverage_gap;
            test_case "tool usage marks store path collision" `Quick
              test_dashboard_tools_usage_marks_store_path_collision;
+         ]);
+      ("cache", [
+           test_case "same actor returns cached payload" `Quick
+             test_dashboard_tools_cache_returns_same_payload_for_same_actor;
+           test_case "distinct actors get separate cache entries" `Quick
+             test_dashboard_tools_cache_separates_actors;
          ]);
     ]


### PR DESCRIPTION
## Summary

`GET /api/v1/dashboard/tools` 는 보고서 §3 #2의 핵심 — **현재 cache 없음** + 매 요청마다 5-stage sequential I/O (`config_resolution`, `runtime_resolution`, `tool_inventory_json`, `summary_report`, `attach_source_metadata`). 보고서 Action 4: 30s TTL `Dashboard_cache` 추가.

본 PR은 **Phase 2 Action 4**. #16645 (Server-Timing) 머지로 phase 측정이 가능해진 *후* 들어가는 가장 작은 변경 + 가장 큰 효과.

분석 보고서: `memory/masc-mcp-dashboard-slow-endpoints-report-2026-05-19.html` (jeong-sik/me#1144).

## Changes

### `lib/server/server_dashboard_http_runtime_info.ml`
- `dashboard_tools_cache_ttl_sec = 30.0` 명명 상수 (sw-dev §Magic Number 금지)
- `dashboard_tools_cache_key ~base_path ~actor`: actor별 cache key 분리 (permission scope leak 방지)
- `dashboard_tools_http_json` 본문을 `compute ()` 클로저로 감쌈
- `Dashboard_cache.get_or_compute cache_key ~ttl:30.0 compute` wrapping
- `timing` 있으면 `Cache_lookup` phase로 측정 (Server-Timing 헤더 정합)

### `test/test_dashboard_tools.ml`
- `test_dashboard_tools_cache_returns_same_payload_for_same_actor`: 동일 actor 두 번 호출 시 `generated_at` 동일 (cache hit 입증)
- `test_dashboard_tools_cache_separates_actors`: actor 다르면 `Dashboard_cache.stats ().entries` 증가 (cache key 분리 입증, permission leak regression 가드)

## Why 30s TTL (Trade-off)

| | 채택 | 거부 | 이유 |
|---|---|---|---|
| TTL | 30s | 5s (적극적 refresh) | Dashboard frontend 평균 3s polling × 10 → 1분 이내 fresh 보장. Tool inventory가 30s 내 변경 거의 없음 |
| Cache key 분리 단위 | per-actor | per-base_path only | actor별 permission이 달라 같은 key 공유 시 silent leak. Permission 검증은 route level에서 수행하지만 *cache hit 시* 검증 skip되어 hidden surface |
| Cache backend | `Dashboard_cache.get_or_compute` | 새 cache 모듈 | 동일 stampede protection / stale-while-revalidate / circuit breaker 재사용. 일관성 |
| 측정 wire | `Cache_lookup` phase | wrapping 없음 | Server-Timing 헤더에서 cache hit ratio 추론 가능 (cache_lookup 단독 ~0ms = hit / 수백 ms = miss) |

## Workaround Rejection Bar Self-Check

- [x] §1 텔레메트리-as-fix: **위반 아님**. 본 PR은 *실제 latency 감축*. counter 추가가 아니다.
- [x] §2 string 분류기: 없음.
- [x] §3 N-of-M: 없음. /tools 단일 endpoint.
- [x] cap/cooldown: **TTL은 cap이 아니다** — 단순 caching with stampede protection. cap = "30s 안 들어왔으면 강제 차단"의 의미라면 위반이지만 우리는 stale-while-revalidate.
- [x] test backdoor: 없음.

## Verification

```bash
# Typecheck
opam exec -- dune build --root . @check

# Tests
opam exec -- dune build --root . test/test_dashboard_tools.exe
./_build/default/test/test_dashboard_tools.exe

# Manual smoke (서버 기동 후)
curl -s -D - http://localhost:8935/api/v1/dashboard/tools 2>&1 | grep -i Server-Timing
# Cold:  Server-Timing: cache_lookup;dur=850.0
# Warm:  Server-Timing: cache_lookup;dur=0.1
```

## Next steps (out of scope)

- Action 5: `/telemetry` query-key 기반 1s TTL cache
- Action 6: Frontend exponential backoff (3s → 30s cap)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
