### PR TITLE
refactor(keeper_registry): extract read-only lookup API (godfile decomp)

### DIFF
--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -115,7 +115,7 @@ let missing_file_error_json
 let find_registry_meta ~(keeper_name : string) ~(source_layer : string)
   : Keeper_types.keeper_meta option
   =
-  match Keeper_registry.find_by_name keeper_name with
+  match Keeper_registry_lookup.find_by_name keeper_name with
   | None ->
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_path_resolver_identity_mismatch

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -41,10 +41,10 @@ let get_bus () = Keeper_event_bus.get ()
 (* ── gRPC directive processing ── *)
 
 let with_keeper_entry_by_identity ~identity ~on_missing f =
-  match Keeper_registry.find_by_agent_name identity with
+  match Keeper_registry_lookup.find_by_agent_name identity with
   | Some entry -> f entry
   | None ->
-    (match Keeper_registry.find_by_name identity with
+    (match Keeper_registry_lookup.find_by_name identity with
      | Some entry -> f entry
      | None -> on_missing ())
 ;;
@@ -189,7 +189,7 @@ let process_directive ~agent_name directive =
        guard fires.  In both cases a wakeup should start from a fresh counter
        instead of immediately re-blocking the same turn. *)
     let entry_paused =
-      match Keeper_registry.find_by_agent_name agent_name with
+      match Keeper_registry_lookup.find_by_agent_name agent_name with
       | Some e -> e.meta.paused
       | None ->
         (match Keeper_exec_shared.find_registry_meta
@@ -243,7 +243,7 @@ let reconcile_current_task_id_for_heartbeat ~config ~agent_name =
 ;;
 
 let registry_current_task_id agent_name =
-  match Keeper_registry.find_by_agent_name agent_name with
+  match Keeper_registry_lookup.find_by_agent_name agent_name with
   | Some e -> e.meta.current_task_id
   | None -> None
 ;;

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1486,61 +1486,9 @@ let tool_usage_of ~base_path name =
     |> List.sort (fun (_, a) (_, b) -> Int.compare b.count a.count)
 ;;
 
-(** Look up a keeper by name across all base_paths (O(n) scan). *)
-let find_by_name name =
-  StringMap.fold
-    (fun _k v acc ->
-       match acc with
-       | Some _ -> acc
-       | None -> if String.equal v.name name then Some v else None)
-    (Atomic.get registry)
-    None
-;;
-
-let find_by_agent_name agent_name =
-  StringMap.fold
-    (fun _k v acc ->
-       match acc with
-       | Some _ -> acc
-       | None -> if String.equal v.meta.agent_name agent_name then Some v else None)
-    (Atomic.get registry)
-    None
-;;
-
-let find_by_id (uid : Keeper_id.Uid.t) =
-  StringMap.fold
-    (fun _k v acc ->
-       match acc with
-       | Some _ -> acc
-       | None ->
-         (match v.meta.keeper_id with
-          | Some id when Keeper_id.Uid.equal id uid -> Some v
-          | _ -> None))
-    (Atomic.get registry)
-    None
-;;
-
-let tool_usage_of_by_name name =
-  match find_by_name name with
-  | None -> []
-  | Some entry ->
-    StringMap.fold (fun n e acc -> (n, e) :: acc) entry.tool_usage []
-    |> List.sort (fun (_, a) (_, b) -> Int.compare b.count a.count)
-;;
-
-(* -- Config resolution --------------------------------------------- *)
-
-let resolve_config (config : Coord_utils_backend_setup.config) keeper_name
-  : Coord_utils_backend_setup.config
-  =
-  if keeper_name = ""
-  then config
-  else (
-    (* Keeper config resolution is scoped to the caller's current base_path.
-       Do not retarget requests across other base_path registries. *)
-    match get ~base_path:config.base_path keeper_name with
-    | Some _ | None -> config)
-;;
+(* Lookup API (find_by_name / find_by_agent_name / find_by_id /
+   tool_usage_of_by_name / resolve_config) moved to
+   Keeper_registry_lookup. *)
 
 (* -- Tool usage persistence ---------------------------------------- *)
 

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -376,25 +376,9 @@ val record_tool_use :
 val tool_usage_of : base_path:string -> string ->
   (string * Keeper_types.tool_call_entry) list
 
-(** Look up a keeper by name across all base_paths (O(n) scan). *)
-val find_by_name : string -> registry_entry option
-
-(** Look up a keeper by agent_name across all base_paths (O(n) scan). *)
-val find_by_agent_name : string -> registry_entry option
-
-(** Look up a keeper by stable UID across all base_paths (O(n) scan). *)
-val find_by_id : Keeper_id.Uid.t -> registry_entry option
-
-(** Get tool usage by keeper name (scans all base_paths). *)
-val tool_usage_of_by_name : string ->
-  (string * Keeper_types.tool_call_entry) list
-
-(** Resolve config for a keeper tool dispatch.
-    Tries scoped lookup first (O(1) map lookup), then falls back to
-    cross-base_path scan (O(n)) when not found in the caller's scope.
-    Returns config with the keeper's actual base_path, or the original
-    config unchanged if the keeper is not in the registry. *)
-val resolve_config : Coord_utils_backend_setup.config -> string -> Coord_utils_backend_setup.config
+(* Lookup API moved to Keeper_registry_lookup:
+   find_by_name / find_by_agent_name / find_by_id /
+   tool_usage_of_by_name / resolve_config. *)
 
 (** Flush in-memory tool usage stats to disk for persistence across restarts. *)
 val flush_tool_usage : base_path:string -> string -> unit

--- a/lib/keeper/keeper_registry_lookup.ml
+++ b/lib/keeper/keeper_registry_lookup.ml
@@ -1,0 +1,51 @@
+(** Read-only lookups over Keeper_registry.
+
+    Extracted from keeper_registry.ml (1490-1546) as part of the
+    godfile decomp campaign. These are O(n) scans across all
+    registered keepers; they do not need access to the internal
+    Atomic state primitive and instead consume [Keeper_registry.all]
+    snapshots. Moving them out of the registry's mutator-rich core
+    isolates the read API from the CAS retry loops. *)
+
+open Keeper_registry_types
+
+let find_by_name name =
+  Keeper_registry.all ()
+  |> List.find_opt (fun (v : registry_entry) -> String.equal v.name name)
+;;
+
+let find_by_agent_name agent_name =
+  Keeper_registry.all ()
+  |> List.find_opt (fun (v : registry_entry) ->
+       String.equal v.meta.Keeper_types.agent_name agent_name)
+;;
+
+let find_by_id (uid : Keeper_id.Uid.t) =
+  Keeper_registry.all ()
+  |> List.find_opt (fun (v : registry_entry) ->
+       match v.meta.Keeper_types.keeper_id with
+       | Some id -> Keeper_id.Uid.equal id uid
+       | None -> false)
+;;
+
+let tool_usage_of_by_name name =
+  match find_by_name name with
+  | None -> []
+  | Some entry ->
+    StringMap.fold (fun n e acc -> (n, e) :: acc) entry.tool_usage []
+    |> List.sort (fun (_, (a : Keeper_types.tool_call_entry))
+                      (_, (b : Keeper_types.tool_call_entry)) ->
+         Int.compare b.count a.count)
+;;
+
+let resolve_config (config : Coord_utils_backend_setup.config) keeper_name
+  : Coord_utils_backend_setup.config
+  =
+  if keeper_name = ""
+  then config
+  else
+    (* Keeper config resolution is scoped to the caller's current base_path.
+       Do not retarget requests across other base_path registries. *)
+    match Keeper_registry.get ~base_path:config.base_path keeper_name with
+    | Some _ | None -> config
+;;

--- a/lib/keeper/keeper_registry_lookup.mli
+++ b/lib/keeper/keeper_registry_lookup.mli
@@ -1,0 +1,26 @@
+(** Read-only lookups over Keeper_registry. SSOT for cross-base_path
+    scans used by HTTP routing, MCP tool dispatch, and keeper liveness
+    checks. *)
+
+open Keeper_registry_types
+
+(** Look up a keeper by name across all base_paths (O(n) scan). *)
+val find_by_name : string -> registry_entry option
+
+(** Look up a keeper by agent_name across all base_paths (O(n) scan). *)
+val find_by_agent_name : string -> registry_entry option
+
+(** Look up a keeper by stable UID across all base_paths (O(n) scan). *)
+val find_by_id : Keeper_id.Uid.t -> registry_entry option
+
+(** Get tool usage by keeper name (scans all base_paths), sorted by
+    call count descending. *)
+val tool_usage_of_by_name : string ->
+  (string * Keeper_types.tool_call_entry) list
+
+(** Resolve config for a keeper tool dispatch.
+    Currently a no-op pass-through — the legacy fallback that
+    retargeted across base_path registries has been removed; this
+    function preserves the public API surface for callers. *)
+val resolve_config :
+  Coord_utils_backend_setup.config -> string -> Coord_utils_backend_setup.config

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -29,7 +29,7 @@ type tool_bundle =
     These public functions preserve the existing API surface. *)
 
 let tool_usage_for_keeper keeper_name : (string * tool_call_entry) list =
-  Keeper_registry.tool_usage_of_by_name keeper_name
+  Keeper_registry_lookup.tool_usage_of_by_name keeper_name
 ;;
 
 let tool_usage_json keeper_name : Yojson.Safe.t =

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -759,7 +759,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
      missing identity falls through to External_mcp.  Issue #8915. *)
   let keeper_entry =
     if String.length agent_name = 0 then None
-    else Keeper_registry.find_by_agent_name agent_name
+    else Keeper_registry_lookup.find_by_agent_name agent_name
   in
   let source : Tool_registry.call_source =
     match keeper_entry with

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -750,7 +750,7 @@ let execute_tool_eio
                   reason
             in
             let internal_keeper_meta_of_agent () =
-              match Keeper_registry.find_by_agent_name agent_name with
+              match Keeper_registry_lookup.find_by_agent_name agent_name with
               | Some (entry : Keeper_registry.registry_entry)
                 when String.equal entry.base_path config.base_path -> Ok entry.meta
               | Some _ | None ->

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1008,7 +1008,7 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
   else
     let config = state.Mcp_server.room_config in
     let resolve_keeper_agent_name () =
-      match Keeper_registry.find_by_name name with
+      match Keeper_registry_lookup.find_by_name name with
       | Some entry -> Some entry.meta.agent_name
       | None -> (
           match Keeper_types.read_meta config name with
@@ -1314,7 +1314,7 @@ let handle_keeper_directive_post state _agent_name req reqd body_str =
            | _ ->
                Log.Server.warn "Unknown keeper directive: %s" action_str);
           let resolved_agent_name =
-            match Keeper_registry.find_by_name name with
+            match Keeper_registry_lookup.find_by_name name with
             | Some entry -> entry.meta.agent_name
             | None -> (
                 match meta_opt with

--- a/lib/server/server_utils.ml
+++ b/lib/server/server_utils.ml
@@ -58,11 +58,11 @@ let board_actor_keeper_identity raw =
   let raw = String.trim raw in
   if raw = "" then None
   else
-    match Keeper_registry.find_by_agent_name raw with
+    match Keeper_registry_lookup.find_by_agent_name raw with
     | Some entry ->
         Some (entry.name, Some entry.meta.agent_name, "keeper_registry_agent_name")
     | None -> (
-        match Keeper_registry.find_by_name raw with
+        match Keeper_registry_lookup.find_by_name raw with
         | Some entry ->
             Some (entry.name, Some entry.meta.agent_name, "keeper_registry_name")
         | None -> (

--- a/lib/server/server_utils.mli
+++ b/lib/server/server_utils.mli
@@ -101,8 +101,8 @@ val board_fetch_limit :
     lookup tiers, all operator-visible through the [source] field:
 
     1. [keeper_registry_agent_name] —
-       {!Keeper_registry.find_by_agent_name}
-    2. [keeper_registry_name] — {!Keeper_registry.find_by_name}
+       {!Keeper_registry_lookup.find_by_agent_name}
+    2. [keeper_registry_name] — {!Keeper_registry_lookup.find_by_name}
     3. [keeper_alias_contract] —
        {!Keeper_identity.canonical_keeper_name_from_agent_name}
 

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -1604,11 +1604,11 @@ let test_find_by_agent_name () =
   R.clear ();
   let _entry = R.register ~base_path:bp "fn1" (make_meta "fn1") in
   let _entry2 = R.register ~base_path:bp "fn2" (make_meta "fn2") in
-  (match R.find_by_agent_name "agent-fn2" with
+  (match Masc_mcp.Keeper_registry_lookup.find_by_agent_name "agent-fn2" with
    | Some e -> check string "found by agent_name" "fn2" e.name
    | None -> fail "expected fn2 via agent_name");
   check bool "not found returns None" true
-    (Option.is_none (R.find_by_agent_name "agent-nonexistent"))
+    (Option.is_none (Masc_mcp.Keeper_registry_lookup.find_by_agent_name "agent-nonexistent"))
 
 (* ── resolve_config tests ────────────────────────────────── *)
 
@@ -1636,7 +1636,7 @@ let test_resolve_config_scoped_hit () =
   R.clear ();
   let _entry = R.register ~base_path:bp "rc1" (make_meta "rc1") in
   let config = make_test_config bp in
-  let resolved = R.resolve_config config "rc1" in
+  let resolved = Masc_mcp.Keeper_registry_lookup.resolve_config config "rc1" in
   check string "scoped hit keeps base_path" bp resolved.base_path
 
 let test_resolve_config_cross_base_path () =
@@ -1644,19 +1644,19 @@ let test_resolve_config_cross_base_path () =
   let bp2 = "/tmp/other" in
   let _entry = R.register ~base_path:bp2 "rc2" (make_meta "rc2") in
   let config = make_test_config bp in
-  let resolved = R.resolve_config config "rc2" in
+  let resolved = Masc_mcp.Keeper_registry_lookup.resolve_config config "rc2" in
   check string "cross-base_path keeps original scope" bp resolved.base_path
 
 let test_resolve_config_not_found () =
   R.clear ();
   let config = make_test_config bp in
-  let resolved = R.resolve_config config "nonexistent" in
+  let resolved = Masc_mcp.Keeper_registry_lookup.resolve_config config "nonexistent" in
   check string "unknown keeper keeps original" bp resolved.base_path
 
 let test_resolve_config_empty_name () =
   R.clear ();
   let config = make_test_config bp in
-  let resolved = R.resolve_config config "" in
+  let resolved = Masc_mcp.Keeper_registry_lookup.resolve_config config "" in
   check string "empty name keeps original" bp resolved.base_path
 
 (* ── Directive processing tests ─────────────────────────── *)


### PR DESCRIPTION
## Summary

keeper_registry godfile decomp — read-only lookup API isolation.

원본 보고서 `memory/masc-mcp-action6-7-8-report-2026-05-19.md` §Action 7에서 식별한 cleanly extractable 영역의 첫 PR.

### 변경 요약

- 신규 모듈 `lib/keeper/keeper_registry_lookup.ml` + `.mli` (51 + 26 LoC)
- 5 함수 이동: `find_by_name` / `find_by_agent_name` / `find_by_id` / `tool_usage_of_by_name` / `resolve_config`
- 구현 변경: `Atomic.get registry` 직접 접근 → `Keeper_registry.all ()` snapshot 소비 (동일 데이터 소스, isolation 확보)
- 8 caller + 1 test alias 갱신

### LoC 효과

| | Before | After | Δ |
|--|--------|-------|---|
| `lib/keeper/keeper_registry.ml` | 2129 | 2077 | -52 |
| `lib/keeper/keeper_registry.mli` | 499 | 483 | -16 |
| 신규 `keeper_registry_lookup.ml` | — | 51 | +51 |
| 신규 `keeper_registry_lookup.mli` | — | 26 | +26 |

keeper_registry.ml은 여전히 godfile threshold(1000+) 위. 본 PR은 read-only SSOT 분리만 목표.

### 검증
- `dune build --root . @check` exit 0
- `test/test_keeper_registry.exe` 109 tests PASS

### Scope guard
- credential / identity / operator-control / sandbox / dashboard credential / hooks / workflow 영역 무관
- `RFC-WAIVED: read-only API extraction, godfile decomp follow-up to RFC-0136 stack`

## Test plan
- [x] dune @check green
- [x] keeper_registry alcotest suite (109 tests) PASS
- [ ] CI 통과 후 사용자 라벨 dispatch

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>