### PR TITLE
fix(tool_keeper): return typed unsupported envelope from masc_keeper_repair stub

### DIFF
--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -723,9 +723,43 @@ let handle_keeper_repair ctx args : tool_result =
                           ("source_text", `String source_text) :: fields
                       | None -> fields
                     in
+                    (* Execution path is not yet implemented; the tool
+                       advertises its schema and validates inputs for a
+                       future migration. Return a typed [unsupported]
+                       envelope so callers can distinguish "tool exists
+                       but is dormant" from a generic error, and so the
+                       operator sees that every validated argument was
+                       accepted (preventing "did I send the args wrong?"
+                       debugging loops). Backward-compatible: the legacy
+                       ["error"] string field is preserved. *)
                     let ok, body =
-                      ignore (ctx.sw, ctx.clock, ctx.config, fields);
-                      (false, {|{"error":"keeper repair handler not implemented"}|})
+                      ignore (ctx.sw, ctx.clock, ctx.config);
+                      let body_json =
+                        `Assoc
+                          [ ( "error"
+                            , `String
+                                "masc_keeper_repair execution path is \
+                                 not yet implemented; the tool \
+                                 advertises its schema for future \
+                                 migration but currently returns this \
+                                 typed unsupported response." )
+                          ; ("unsupported", `Bool true)
+                          ; ("tool", `String "masc_keeper_repair")
+                          ; ("validated_fields", `Assoc fields)
+                          ; ( "operator_guidance"
+                            , `String
+                                "All input arguments were validated \
+                                 successfully (keeper identity, \
+                                 playground working_dir, validator \
+                                 profile, max_attempts, optional \
+                                 target_file / source_text). If this \
+                                 tool is critical for your workflow, \
+                                 please file a tracking issue \
+                                 requesting implementation rather than \
+                                 retrying." )
+                          ]
+                      in
+                      (false, Yojson.Safe.to_string body_json)
                     in
                     invalidate_status_cache meta.name;
                     ( ok,


### PR DESCRIPTION
## Goal

\`handle_keeper_repair\` at \`lib/tool_keeper.ml:649\` validates every input argument carefully (keeper identity, playground working_dir, target_file existence, validator profile, max_attempts bounds, optional source_text), and is advertised as a typed first-class tool in \`tool_catalog_surfaces\`, \`tool_name.ml Repair\` constructor, \`keeper_schema.ml\`, \`tool_permission_map.ml\`, and the MCP dispatch chain. But the execution path at L726-729 was:

\`\`\`ocaml
let ok, body =
  ignore (ctx.sw, ctx.clock, ctx.config, fields);
  (false, {|{\"error\":\"keeper repair handler not implemented\"}|})
in
\`\`\`

— an opaque \"go away\" string with no indication that the caller's arguments were even accepted. A user who passes valid args runs the entire validation chain and then sees \`error: keeper repair handler not implemented\` and naturally retries with different arg shapes, getting the same response. Frustration UX.

Discovered by parallel scout sweep during /loop Iter#43; verified and corrected in Iter#47.

## Change

Replace the bare error string with a structured envelope:

\`\`\`ocaml
let body_json =
  \`Assoc
    [ (\"error\", \`String
         \"masc_keeper_repair execution path is not yet implemented; \
          the tool advertises its schema for future migration but \
          currently returns this typed unsupported response.\")
    ; (\"unsupported\", \`Bool true)
    ; (\"tool\", \`String \"masc_keeper_repair\")
    ; (\"validated_fields\", \`Assoc fields)
    ; (\"operator_guidance\", \`String \"All input arguments were \
       validated successfully (keeper identity, playground \
       working_dir, validator profile, max_attempts, optional \
       target_file / source_text). If this tool is critical for \
       your workflow, please file a tracking issue requesting \
       implementation rather than retrying.\")
    ]
in
(false, Yojson.Safe.to_string body_json)
\`\`\`

## Why this is not a workaround (Workaround Rejection Bar §1 check)

The Bar #1 \"telemetry-as-fix\" pattern adds visibility without fixing the silent failure. Here:

1. The bug is *not* silent failure — the response is already \`ok=false\`. The bug is *uninformative* failure.
2. The change converts opacity into operator-actionable detail. Every validated arg is echoed back so the operator can confirm the validation pipeline succeeded.
3. The legacy \`\"error\"\` string field is preserved (wording change is internal-only; the *key* and *false* ok pair are unchanged) so any existing pattern-matching caller still works.
4. The new \`\"unsupported\": true\` flag lets a frontend distinguish \"tool exists but dormant\" from a transient runtime error — a *typed* signal, not a string classifier.

## Why not option 1 or option 2

| Option | Scope | Why not |
|--------|-------|---------|
| 1. Implement the repair loop | wide — referenced sibling \`tool_repair_loop\` module does not exist in \`lib/\` | RFC scope; not bundleable in /loop iter |
| 2. Remove from dispatch | 8 files: \`tool_name.ml\` typed \`Repair\` constructor + roundtrip, \`keeper_schema.ml\` schema, \`tool_catalog_surfaces\` catalog, \`tool_permission_map\` entry, \`mcp_server_eio_tool_profile\` mapping, \`test_tools_coverage\` schema test, \`test_operator_control_keeper\` dispatch test, dispatch arm itself | risks losing the future-migration affordance the rest of the machinery preserves |
| **3. Typed unsupported response** | **1 file, 1 hunk, +36/-2 LoC** | **this PR** |

## Verification

\`\`\`
dune build --root . @check       # clean
_build/default/test/test_tools_coverage.exe   # 54/54 pass
\`\`\`

The dispatch path and input validators are untouched. The behavioural difference is purely in the response body shape (string error → structured envelope with the same \`ok=false\` outcome).

## Follow-up

If/when this tool's execution path is implemented, the structured envelope provides a forward-compatible JSON shape — implementer just replaces the body with the real result and drops the \`unsupported\`/\`operator_guidance\` keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>