### PR TITLE
refactor: split keeper unified context budget tests

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -186,6 +186,7 @@
   test_tool_exposure
   test_autonomy_liberation
   test_keeper_unified
+  test_keeper_unified_context_budget
   test_keeper_unified_context_overflow
   test_keeper_unified_turn_pipeline_records
   test_keeper_unified_idle_cooldown
@@ -493,6 +494,7 @@
   test_tool_exposure
   test_autonomy_liberation
   test_keeper_unified
+  test_keeper_unified_context_budget
   test_keeper_unified_context_overflow
   test_keeper_unified_turn_pipeline_records
   test_keeper_unified_idle_cooldown

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -8560,80 +8560,6 @@ let test_degraded_retry_budget_gate_allows_retry_with_tiny_remaining () =
   | UT.No_degraded_retry -> fail "expected degraded retry"
 ;;
 
-let test_pure_local_labels_detection () =
-  check
-    bool
-    "ollama-only cascade is pure local"
-    true
-    (OMR.labels_are_pure_local [ "ollama:qwen3.5:35b-a3b-nvfp4" ]);
-  check
-    bool
-    "mixed cascade is not pure local"
-    false
-    (OMR.labels_are_pure_local [ "glm:glm-5.1"; "ollama:qwen3.5:35b-a3b-nvfp4" ])
-;;
-
-let test_clamp_context_for_pure_local_labels () =
-  let local_floor = Env_config.ContextCompact.small_local_floor in
-  check
-    int
-    "pure local max_context gets capped"
-    local_floor
-    (OMR.clamp_context_for_pure_local_labels
-       ~labels:[ "ollama:qwen3.5:35b-a3b-nvfp4" ]
-       ~max_context:262_144);
-  check
-    int
-    "mixed cascade keeps raw context"
-    262_144
-    (OMR.clamp_context_for_pure_local_labels
-       ~labels:[ "glm:glm-5.1"; "ollama:qwen3.5:35b-a3b-nvfp4" ]
-       ~max_context:262_144)
-;;
-
-let test_resolved_max_context_for_turn_uses_primary_budget () =
-  let labels = [ "glm:glm-5.1"; "ollama:qwen3.5:35b-a3b-nvfp4" ] in
-  let expected = OMR.resolve_primary_max_context labels in
-  check
-    int
-    "turn budget follows primary available model"
-    expected
-    (UT.resolved_max_context_for_turn ~meta:minimal_meta labels)
-;;
-
-let test_max_context_resolution_separates_override_and_effective_budget () =
-  let labels = [ "unknown:model" ] in
-  let resolution =
-    KEC.resolve_max_context_resolution ~requested_override:(Some 1_000_000) labels
-  in
-  check
-    int
-    "primary budget uses fallback context window"
-    Masc_mcp.Cascade_runtime.fallback_context_window
-    resolution.primary_budget;
-  check int "turn budget preserves requested override" 1_000_000 resolution.turn_budget;
-  check
-    int
-    "effective budget caps to primary budget"
-    resolution.primary_budget
-    resolution.effective_budget
-;;
-
-let test_resolved_max_context_for_turn_uses_effective_budget () =
-  let labels = [ "unknown:model" ] in
-  let meta = { minimal_meta with max_context_override = Some 1_000_000 } in
-  let resolution =
-    KEC.resolve_max_context_resolution
-      ~requested_override:meta.max_context_override
-      labels
-  in
-  check
-    int
-    "turn dispatch budget is capped to effective budget"
-    resolution.effective_budget
-    (UT.resolved_max_context_for_turn ~meta labels)
-;;
-
 let test_side_effect_reclassification_ignores_keeper_read_only_tools () =
   let original =
     Agent_sdk.Error.Api (Timeout { message = "Execution cancelled after 300.0s" })
@@ -12883,23 +12809,6 @@ let () =
             "degraded retry gate allows retry with tiny remaining (#12675)"
             `Quick
             test_degraded_retry_budget_gate_allows_retry_with_tiny_remaining
-        ; test_case "pure local label detection" `Quick test_pure_local_labels_detection
-        ; test_case
-            "pure local context clamp"
-            `Quick
-            test_clamp_context_for_pure_local_labels
-        ; test_case
-            "turn context budget uses primary model"
-            `Quick
-            test_resolved_max_context_for_turn_uses_primary_budget
-        ; test_case
-            "max_context resolution separates override and effective budget"
-            `Quick
-            test_max_context_resolution_separates_override_and_effective_budget
-        ; test_case
-            "resolved max_context dispatch uses effective budget"
-            `Quick
-            test_resolved_max_context_for_turn_uses_effective_budget
         ; test_case
             "read-only keeper tools do not become ambiguous partial"
             `Quick

--- a/test/test_keeper_unified_context_budget.ml
+++ b/test/test_keeper_unified_context_budget.ml
@@ -1,0 +1,119 @@
+open Alcotest
+
+module KEC = Masc_mcp.Keeper_exec_context
+module OMR = Masc_mcp.Cascade_runtime
+module UT = Masc_mcp.Keeper_unified_turn
+
+let make_meta name : Masc_mcp.Keeper_types.keeper_meta =
+  let json =
+    `Assoc
+      [
+        ("name", `String name);
+        ("trace_id", `String ("test-trace-" ^ name));
+        ("goal", `String "test goal");
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok m -> m
+  | Error e -> failwith ("meta_of_json failed: " ^ e)
+
+let minimal_meta : Masc_mcp.Keeper_types.keeper_meta = make_meta "test-keeper"
+
+let test_pure_local_labels_detection () =
+  check
+    bool
+    "ollama-only cascade is pure local"
+    true
+    (OMR.labels_are_pure_local [ "ollama:qwen3.5:35b-a3b-nvfp4" ]);
+  check
+    bool
+    "mixed cascade is not pure local"
+    false
+    (OMR.labels_are_pure_local [ "glm:glm-5.1"; "ollama:qwen3.5:35b-a3b-nvfp4" ])
+;;
+
+let test_clamp_context_for_pure_local_labels () =
+  let local_floor = Env_config.ContextCompact.small_local_floor in
+  check
+    int
+    "pure local max_context gets capped"
+    local_floor
+    (OMR.clamp_context_for_pure_local_labels
+       ~labels:[ "ollama:qwen3.5:35b-a3b-nvfp4" ]
+       ~max_context:262_144);
+  check
+    int
+    "mixed cascade keeps raw context"
+    262_144
+    (OMR.clamp_context_for_pure_local_labels
+       ~labels:[ "glm:glm-5.1"; "ollama:qwen3.5:35b-a3b-nvfp4" ]
+       ~max_context:262_144)
+;;
+
+let test_resolved_max_context_for_turn_uses_primary_budget () =
+  let labels = [ "glm:glm-5.1"; "ollama:qwen3.5:35b-a3b-nvfp4" ] in
+  let expected = OMR.resolve_primary_max_context labels in
+  check
+    int
+    "turn budget follows primary available model"
+    expected
+    (UT.resolved_max_context_for_turn ~meta:minimal_meta labels)
+;;
+
+let test_max_context_resolution_separates_override_and_effective_budget () =
+  let labels = [ "unknown:model" ] in
+  let resolution =
+    KEC.resolve_max_context_resolution ~requested_override:(Some 1_000_000) labels
+  in
+  check
+    int
+    "primary budget uses fallback context window"
+    Masc_mcp.Cascade_runtime.fallback_context_window
+    resolution.primary_budget;
+  check int "turn budget preserves requested override" 1_000_000 resolution.turn_budget;
+  check
+    int
+    "effective budget caps to primary budget"
+    resolution.primary_budget
+    resolution.effective_budget
+;;
+
+let test_resolved_max_context_for_turn_uses_effective_budget () =
+  let labels = [ "unknown:model" ] in
+  let meta = { minimal_meta with max_context_override = Some 1_000_000 } in
+  let resolution =
+    KEC.resolve_max_context_resolution
+      ~requested_override:meta.max_context_override
+      labels
+  in
+  check
+    int
+    "turn dispatch budget is capped to effective budget"
+    resolution.effective_budget
+    (UT.resolved_max_context_for_turn ~meta labels)
+;;
+
+let () =
+  run
+    "keeper_unified_context_budget"
+    [ ( "context_budget"
+      , [ test_case "pure local label detection" `Quick test_pure_local_labels_detection
+        ; test_case
+            "pure local context clamp"
+            `Quick
+            test_clamp_context_for_pure_local_labels
+        ; test_case
+            "turn context budget uses primary model"
+            `Quick
+            test_resolved_max_context_for_turn_uses_primary_budget
+        ; test_case
+            "max_context resolution separates override and effective budget"
+            `Quick
+            test_max_context_resolution_separates_override_and_effective_budget
+        ; test_case
+            "resolved max_context dispatch uses effective budget"
+            `Quick
+            test_resolved_max_context_for_turn_uses_effective_budget
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- move pure-local/context-budget keeper_unified tests into test_keeper_unified_context_budget
- register the new focused test binary in test/dune
- reduce test/test_keeper_unified.ml from 13,185 to 13,094 lines after #16653

## Validation
- ocamlformat --check test/test_keeper_unified.ml test/test_keeper_unified_context_budget.ml test/dune
- git diff --check
- bash scripts/lint/godfile-size-regression.sh
- scripts/ocaml-structure-ratchet.sh
- env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_unified_context_budget.exe: blocked by unrelated bare Dune guard (exit 75); external `dune build` processes were already bypassing the wrapper lock