### PR TITLE
perf(dashboard): /telemetry endpoint 1s TTL Dashboard_cache (Phase 2 Action 5)

### DIFF
--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -1246,14 +1246,37 @@ let rec add_routes ~sw ~clock router =
              ]
          in
          let timing = Server_timing.create () in
-         let result =
-           Server_timing.measure timing Telemetry_query (fun () ->
-             Telemetry_unified.read_unified_result ~base_path ~masc_root ~sources
-               ?keeper_name ?session_id ?operation_id ?worker_run_id
-               ?since_ts ?until_ts ~n ())
+         (* Phase 2 Action 5 — 1s TTL cache.  Telemetry callers (dashboard
+            polling, autonomous reload checks) frequently re-issue the same
+            (keeper, session_id, source, n) query within tight loops.  A 1s
+            TTL is short enough to keep "near-live" semantics while
+            deduplicating storms.  All query parameters participate in the
+            cache key so two different windows never collide. *)
+         let sources_key =
+           sources
+           |> List.map Telemetry_unified.source_to_string
+           |> List.sort String.compare
+           |> String.concat ","
          in
-         let generated_at = Masc_domain.now_iso () in
-         let json =
+         let opt_str = function None -> "" | Some s -> s in
+         let opt_ts = function None -> "" | Some f -> Printf.sprintf "%.3f" f in
+         let cache_key =
+           Printf.sprintf
+             "telemetry:%s:%s:src=%s:n=%d:k=%s:s=%s:o=%s:w=%s:since=%s:until=%s"
+             base_path masc_root sources_key n
+             (opt_str keeper_name) (opt_str session_id)
+             (opt_str operation_id) (opt_str worker_run_id)
+             (opt_ts since_ts) (opt_ts until_ts)
+         in
+         let dashboard_telemetry_cache_ttl_sec = 1.0 in
+         let compute () =
+           let result =
+             Server_timing.measure timing Telemetry_query (fun () ->
+               Telemetry_unified.read_unified_result ~base_path ~masc_root
+                 ~sources ?keeper_name ?session_id ?operation_id
+                 ?worker_run_id ?since_ts ?until_ts ~n ())
+           in
+           let generated_at = Masc_domain.now_iso () in
            Server_timing.measure timing Json_serialize (fun () ->
              `Assoc [
                ("generated_at", `String generated_at);
@@ -1269,6 +1292,11 @@ let rec add_routes ~sw ~clock router =
                ("truncated", `Bool result.truncated);
                ("entries", `List result.entries);
              ])
+         in
+         let json =
+           Server_timing.measure timing Cache_lookup (fun () ->
+             Dashboard_cache.get_or_compute cache_key
+               ~ttl:dashboard_telemetry_cache_ttl_sec compute)
          in
          Http.Response.json ~compress:true ~request:req
            ~extra_headers:(Server_timing.extra_header timing)


### PR DESCRIPTION
## Summary

`GET /api/v1/dashboard/telemetry` 는 보고서 §3 #4 — `Telemetry_unified.read_unified_result` 가 base_path 안 telemetry jsonl 파일들을 traverse하는 fs I/O 무거운 hot path. 동일 쿼리(`keeper=X&session_id=Y&n=100`)가 dashboard polling + autonomous reload 두 곳에서 short window 안 중복 호출되는 패턴을 보고서 §3 #4 측정값에서 확인.

본 PR은 **Phase 2 Action 5** — query-key 기반 1s TTL `Dashboard_cache` 추가. 1s TTL = telemetry의 "near-live" 의미를 지키면서 burst 중복 호출 dedup.

#16645 (Server-Timing) + #16654 (cache-stats)는 main에 머지됨. 본 PR은 그 measurement infra 위에서 데이터-driven 진행.

분석 보고서: `memory/masc-mcp-dashboard-slow-endpoints-report-2026-05-19.html` (jeong-sik/me#1144).

## Changes

### `lib/server/server_routes_http_routes_dashboard.ml` — /telemetry 핸들러
- `cache_key` 빌더: `base_path:masc_root:src=…:n=…:k=…:s=…:o=…:w=…:since=…:until=…`
  - `sources` 는 alphabetical sort 후 concat — list ordering이 cache key에 영향 미치지 않음
  - 모든 query parameter 포함 — 다른 window 가 같은 slot 차지하지 않음 (silent data leak 방지)
- `compute ()` 클로저: 기존 read_unified_result + JSON assoc 그대로
- `Server_timing.measure ... Cache_lookup` 으로 wrap → hit/miss latency가 Server-Timing 헤더에 노출
- `dashboard_telemetry_cache_ttl_sec = 1.0` named constant (sw-dev §Magic Number 금지)

## Trade-offs

| | 채택 | 거부 | 이유 |
|---|---|---|---|
| TTL | **1s** | 5s, 30s | telemetry는 fresh 중요. polling cadence(~3s) 안 burst는 dedup, 다음 polling cycle 결과는 fresh |
| Cache 범위 | **전체 JSON** | result만 (JSON 매번 fresh) | Dashboard_cache는 `Yojson.Safe.t` 만 캐시. result 타입 직접 캐시 안 됨. 1s 안에서 `generated_at` 차이는 무시 가능 |
| Cache key 구성 | **명시적 모든 query param** | (base_path, masc_root) only | 다른 query parameter들이 silent collision (다른 keeper 결과 leak) 위험 |
| Sources ordering | **alphabetical sort 후 concat** | list 그대로 | OCaml 변수 순서가 list 인덱스에 영향. 안전망 |

## Workaround Rejection Bar Self-Check

- [x] §1 텔레메트리-as-fix: **위반 아님**. 실제 fs I/O 감축.
- [x] §2 string 분류기: 없음.
- [x] §3 N-of-M: 없음.
- [x] cap/cooldown: 없음 (TTL은 cap 아님 — stale-while-revalidate 호환)
- [x] test backdoor: 없음.

## Verification

```bash
opam exec -- dune build --root . @check

# Manual smoke (서버 기동 후)
TARGET=http://localhost:8935/api/v1/dashboard/telemetry?n=100
curl -s -D - $TARGET 2>&1 | grep -i Server-Timing  # cold: cache_lookup;dur=850ms+
curl -s -D - $TARGET 2>&1 | grep -i Server-Timing  # warm: cache_lookup;dur~0.1ms

# Cache key separation
diff <(curl -s $TARGET) <(curl -s "$TARGET&keeper=foo")  # must differ
```

## Limitations

- **Test 부재**: /telemetry endpoint는 telemetry jsonl scaffolding 필요해서 단위 테스트 작성 비용이 크다. Smoke test 명령을 PR body에 명시했고 (위), Dashboard_cache 자체는 다른 PR에서 충분히 커버. follow-up RFC에서 telemetry E2E 회복 시 채워질 영역.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
