### PR TITLE
refactor(shell): dedupe lowercase_contains via task_state SSOT (PR-3)

### DIFF
--- a/lib/keeper/keeper_shell_bash_task_probe.ml
+++ b/lib/keeper/keeper_shell_bash_task_probe.ml
@@ -1,23 +1,13 @@
-(** Task-state probing detection for keeper_bash command-shape guidance. *)
+(** Task-state probing detection for keeper_bash command-shape guidance.
+
+    [lowercase_contains] is sourced from [Keeper_shell_bash_task_state] so
+    the substring matcher has a single definition in the shell-policy
+    surface (the local copy was a byte-identical duplicate of the same
+    algorithm, matching RFC-0088 §1 N-of-M classifier pattern). *)
 
 open Keeper_shell_bash_words
 
-let lowercase_contains haystack needle =
-  let haystack = String.lowercase_ascii haystack in
-  let needle = String.lowercase_ascii needle in
-  let h_len = String.length haystack in
-  let n_len = String.length needle in
-  let rec loop i =
-    if n_len = 0
-    then true
-    else if i + n_len > h_len
-    then false
-    else if String.sub haystack i n_len = needle
-    then true
-    else loop (i + 1)
-  in
-  loop 0
-;;
+let lowercase_contains = Keeper_shell_bash_task_state.lowercase_contains
 
 let task_state_file_probe_command_names =
   [ "cat"; "head"; "tail"; "ls"; "find"; "rg"; "grep"; "test"; "[" ]


### PR DESCRIPTION
## 목적

`Keeper_shell_bash_task_probe.lowercase_contains`가 sibling 모듈 `Keeper_shell_bash_task_state.lowercase_contains`와 **byte-identical 17-line 중복** — RFC-0088 §1 N-of-M classifier 패턴.

## 변경

1 파일, +7 / -17:
- 지역 17-line `let lowercase_contains haystack needle = ...` 제거
- `let lowercase_contains = Keeper_shell_bash_task_state.lowercase_contains` binding 추가
- 14 callsite 그대로 (이름 충돌 없음, 같은 signature)

## 워크어라운드 audit

- [x] 카운터-as-fix 없음
- [x] substring/prefix 분류기 *추가* 없음 (오히려 2 정의 → 1 정의로 축소)
- [x] catch-all 추가 없음
- [x] N-of-M 자인 *제거* (본 PR이 정확히 N-of-M 해소)

## Scope 밖 (별도 후속 PR)

- `Exec_core.lowercase_contains:588`는 *3번째 사본*. 통합하려면 `String_util` 도입 또는 의존성 방향 결정 필요. 별도 RFC-0092 Phase B 작업.
- `keeper_shell_bash_task_probe.ml:50`의 `_ :: rest -> loop rest` catch-all은 *non-starts_command word skip*이라는 의미적으로 옳은 trivial passthrough — root-fix 대상 아님.
- `next_action : validator_stage option` typed receipt 도입은 RFC-0092 Phase B 본격 작업.

## 검증

local build skipped (machine-wide dune lock by 4 parallel worktrees) — CI 위임. type-system 보장: binding이 단순 re-export이므로 caller signature 불변, 새 컴파일 에러 0 예상.

## Best Programmer self-review

- 목표: shell-policy 표면의 `lowercase_contains` 중복 정의 1개 제거 (SSOT).
- 변경 파일: 1 (keeper_shell_bash_task_probe.ml)
- 로컬 검증: rg로 정의 잔존 0 확인
- 미검증: full dune build → CI

Co-Authored-By: Claude Opus 4.7