### PR TITLE
fix(dashboard): BACKEND_PHASE_MAP compile-time coverage check (audit A1)

### DIFF
--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -28,11 +28,17 @@ function normalizeCascadeRef(raw: unknown): CascadeRef | null {
   return { group, item }
 }
 
-/** Maps lowercase backend phase strings to PascalCase KeeperPhase values.
- *  Backend (keeper_state_machine.ml) emits lowercase: "offline", "running", "handing_off", etc.
- *  Frontend KeeperPhase type uses PascalCase: "Offline", "Running", "HandingOff", etc.
+/** Maps lowercase backend phase strings (`keeper_state_machine.ml:phase_to_string`)
+ *  to PascalCase `KeeperPhase` values. The two unions must stay 1:1 — this is
+ *  enforced at compile time by `_BACKEND_PHASE_COVERAGE_CHECK` below.
+ *
+ *  SSOT contract:
+ *    backend variant added → lowercase entry added AND KeeperPhase union extended.
+ *    KeeperPhase union extended → coverage check fails if lowercase entry missing.
+ *  Drift in either direction surfaces as a typecheck failure, not a silent
+ *  string-as-truth fallback.
  */
-const BACKEND_PHASE_MAP: Record<string, KeeperPhase> = {
+const BACKEND_PHASE_LOWERCASE_MAP = {
   offline: 'Offline',
   running: 'Running',
   failing: 'Failing',
@@ -46,7 +52,12 @@ const BACKEND_PHASE_MAP: Record<string, KeeperPhase> = {
   restarting: 'Restarting',
   dead: 'Dead',
   zombie: 'Zombie',
-  // Also accept PascalCase for forward-compat / test fixtures
+} as const satisfies Record<string, KeeperPhase>
+
+/** Forward-compat PascalCase passthrough — accepts already-typed values from
+ *  test fixtures or future backend emit paths. Constrained to `KeeperPhase`
+ *  keys so a typo would fail typecheck. */
+const BACKEND_PHASE_PASCAL_PASSTHROUGH = {
   Offline: 'Offline',
   Running: 'Running',
   Failing: 'Failing',
@@ -60,13 +71,33 @@ const BACKEND_PHASE_MAP: Record<string, KeeperPhase> = {
   Restarting: 'Restarting',
   Dead: 'Dead',
   Zombie: 'Zombie',
-}
+} as const satisfies Record<KeeperPhase, KeeperPhase>
+
+// Compile-time coverage check: every KeeperPhase variant must appear as a
+// *value* in the lowercase map. If KeeperPhase adds a new arm but the
+// lowercase entry is forgotten, this line fails to typecheck.
+//
+//   type _Missing = Exclude<KeeperPhase, typeof MAP[keyof typeof MAP]>
+//
+// resolves to `never` only when the map is exhaustive over KeeperPhase.
+type _LowercaseMapValueUnion = typeof BACKEND_PHASE_LOWERCASE_MAP[keyof typeof BACKEND_PHASE_LOWERCASE_MAP]
+type _MissingLowercaseCoverage = Exclude<KeeperPhase, _LowercaseMapValueUnion>
+// If the lowercase map drifts away from `KeeperPhase`, `_MissingLowercaseCoverage`
+// resolves to the un-mapped variant string and the `true` literal fails to assign.
+const _BACKEND_PHASE_COVERAGE_CHECK: [_MissingLowercaseCoverage] extends [never] ? true : _MissingLowercaseCoverage = true
+void _BACKEND_PHASE_COVERAGE_CHECK
 
 export function toKeeperPhase(raw: string | null | undefined): KeeperPhase | null {
   if (!raw) return null
   const trimmed = raw.trim()
   if (!trimmed) return null
-  return BACKEND_PHASE_MAP[trimmed] ?? null
+  if (trimmed in BACKEND_PHASE_LOWERCASE_MAP) {
+    return BACKEND_PHASE_LOWERCASE_MAP[trimmed as keyof typeof BACKEND_PHASE_LOWERCASE_MAP]
+  }
+  if (trimmed in BACKEND_PHASE_PASCAL_PASSTHROUGH) {
+    return BACKEND_PHASE_PASCAL_PASSTHROUGH[trimmed as keyof typeof BACKEND_PHASE_PASCAL_PASSTHROUGH]
+  }
+  return null
 }
 
 function normalizeKeeperAgentStatus(value: unknown): Keeper['status'] {


### PR DESCRIPTION
## Summary

Dashboard SSOT audit (2026-05-19 P0) finding **A1** — refined. 원래 audit 는 "Phase normalization 3-site 분산" 으로 진단했으나 cross-check 결과:

- \`monitoring-runtime.ts:154–166 keeperPhaseForDisplay()\` 는 *이미* \`toKeeperPhase()\` 사용 (PR-2 #16593 결과)
- \`keeper-detail-runtime.ts:194 turn_phase\` 는 *별도 도메인* (turn phase ≠ keeper phase)
- 진짜 SSOT 위반은 **\`BACKEND_PHASE_MAP\` 의 type 가드 부재** — backend variant 가 1 개 추가되면 frontend 가 silent miss

## Why

기존 \`BACKEND_PHASE_MAP: Record<string, KeeperPhase>\` 는 *value 만* 제약. \`KeeperPhase\` 에 새 variant 가 추가되어도 lowercase map entry 가 누락되면 typecheck PASS, runtime 에서 silent \`null\` fallback. RFC-0135 §11.1 "typed sum 의 variant arm 확정" 의 *build-time* enforcement.

## How

1. Map 분할:
   - \`BACKEND_PHASE_LOWERCASE_MAP\` — \`satisfies Record<string, KeeperPhase>\` (실제 backend emit path)
   - \`BACKEND_PHASE_PASCAL_PASSTHROUGH\` — \`satisfies Record<KeeperPhase, KeeperPhase>\` (forward-compat, 키 가 KeeperPhase 로 제약되어 typo 시 fail)

2. Compile-time coverage check:
   \`\`\`ts
   type _Missing = Exclude<KeeperPhase, _LowercaseMapValueUnion>
   const _CHECK: [_Missing] extends [never] ? true : _Missing = true
   \`\`\`
   \`KeeperPhase\` 가 새 variant 추가하면 \`_Missing\` 이 그 variant 의 string literal 로 resolve → \`true\` assignment fail → 빌드 깨짐 (오류 메세지에 누락된 variant 이름 명시).

3. \`toKeeperPhase()\` 는 \`in\` 으로 두 narrow map membership 확인.

## Backend ↔ Frontend SSOT

- Backend: \`lib/keeper/keeper_state_machine.ml:6–19\` — 13 variants
- Frontend: \`types/core.ts:870–884\` \`KeeperPhase\` — 13 variants
- 현재 1:1 ✓ — 본 PR 가 이 1:1 invariant 를 build-time guarantee 로 승격

## Trade-off

- 코드량 +31 line (가드 + 두 map 분리)
- runtime 동작 동일 (lookup 경로 약간 다름; 결과 동일)
- 회귀 위험: 없음. 가드 통과 = 현재 vocabulary 정합

## Test plan

- [x] \`pnpm typecheck\` PASS (coverage check 통과 = 현재 vocabulary 1:1)
- [x] 38/38 keeper-store-normalize tests PASS
- [ ] human review

## Out of scope (Audit refinement)

- \`keeper-state-diagram.ts:290, 292\` 의 raw fallback (\`?? transition.prev_phase\`) — typed SSOT 우회 가능. 별도 follow-up PR 권장 (sentinel + console.warn 또는 dev-only assertion)
- \`keeper-detail-runtime.ts:194 turn_phase\` 도메인 → 별도 audit (turn phase typed union 정의 필요)

## Related

- RFC-0135 §11.1 (typed sum variant arm 확정)
- PR-2 (#16593) — phase casing SSOT 통합 (caller cascade)
- Dashboard SSOT/IA audit 2026-05-19 (A1)

RFC-WAIVED: typed-guard hardening, no architectural change

🤖 Generated with [Claude Code](https://claude.com/claude-code)