### PR TITLE
fix(dashboard): RFC-0135 PR-10 Korean verb 라벨 secondary surface sweep

### DIFF
--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -1045,7 +1045,7 @@ function ClientCapacityHistoryTable({
           <th scope="col" class="text-left py-1 w-20">시간</th>
           <th scope="col" class="text-left py-1">종류</th>
           <th scope="col" class="text-left py-1">키</th>
-          <th scope="col" class="text-right py-1">활성</th>
+          <th scope="col" class="text-right py-1">활성 수</th>
         </tr>
       </thead>
       <tbody>
@@ -1075,7 +1075,7 @@ function ClientCapacityTable({ capacity }: { capacity: CascadeClientCapacityResp
           <th scope="col" class="text-left py-1 w-4"></th>
           <th scope="col" class="text-left py-1">종류</th>
           <th scope="col" class="text-left py-1">키</th>
-          <th scope="col" class="text-right py-1">활성</th>
+          <th scope="col" class="text-right py-1">활성 수</th>
           <th scope="col" class="text-right py-1">가용</th>
           <th scope="col" class="text-right py-1">전체</th>
         </tr>

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -727,8 +727,9 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
       ` : html`
         <button type="button"
           class="${btnBase} bg-[var(--purple)] text-[var(--color-bg-0)]"
+          title="편집: 프롬프트 편집 모드로 진입합니다"
           onClick=${enterEditMode}
-        >편집</button>
+        >편집하기</button>
       `}
       ${saveError.value ? html`<span class="text-xs text-[var(--color-status-err)]" role="alert">${saveError.value}</span>` : null}
     </div>
@@ -1108,8 +1109,9 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
           >${runtimeSaving.value ? '저장 중...' : '런타임 설정 저장'}</button>
           <button type="button"
             class="${btnBase} bg-[var(--color-bg-hover)] text-[var(--color-fg-secondary)]"
+            title="초기화: 변경한 런타임 설정 draft 를 서버 값으로 되돌립니다"
             onClick=${resetRuntimeDraft}
-          >초기화</button>
+          >초기화하기</button>
           <span class="text-3xs text-accent-fg">변경된 설정이 있습니다</span>
         </div>
       ` : null}

--- a/dashboard/src/components/keeper-detail-lifecycle.ts
+++ b/dashboard/src/components/keeper-detail-lifecycle.ts
@@ -17,6 +17,7 @@ export function KeeperLifecycleButtons({ keeper, effectiveStatus }: { keeper: Ke
   if (isOffline) return html`
     <button type="button"
       class="py-1 px-3 rounded-[var(--r-1)] text-2xs font-semibold cursor-pointer border border-[var(--ok-border)] bg-[var(--ok-soft)] text-[var(--color-status-ok)] hover:bg-[var(--ok-soft)] transition-colors"
+      title="기동: offline keeper 를 다시 시작합니다 (offline → running)"
       onClick=${() => {
         void (async () => {
           try {
@@ -32,11 +33,12 @@ export function KeeperLifecycleButtons({ keeper, effectiveStatus }: { keeper: Ke
           }
         })()
       }}
-    >기동</button>`
+    >기동하기</button>`
 
   if (isRunning) return html`
     <button type="button"
       class="py-1 px-3 rounded-[var(--r-1)] text-2xs font-semibold cursor-pointer border border-[var(--bad-30)] bg-[var(--bad-10)] text-[var(--rose-light)] hover:bg-[var(--bad-soft)] transition-colors"
+      title="종료: keeper 를 완전 종료합니다 (running/paused → offline, fiber + 리소스 정리)"
       onClick=${() => {
         void (async () => {
           const confirmed = await requestConfirm({
@@ -59,7 +61,7 @@ export function KeeperLifecycleButtons({ keeper, effectiveStatus }: { keeper: Ke
           }
         })()
       }}
-    >종료</button>`
+    >종료하기</button>`
 
   return null
 }

--- a/dashboard/src/components/tool-executor/tool-executor.ts
+++ b/dashboard/src/components/tool-executor/tool-executor.ts
@@ -16,7 +16,7 @@ function ConfirmDialog({ toolName, onConfirm, onCancel }: { toolName: string; on
     <div class="rounded-[var(--r-1)] border border-[var(--err-border)] bg-[var(--bad-10)] p-3">
       <p class="text-xs text-[var(--bad-light)] mb-2"><strong>${toolName}</strong> 은 파괴적(destructive) 도구입니다. 실행하시겠습니까?</p>
       <div class="flex gap-2">
-        <${ActionButton} variant="danger" size="sm" onClick=${onConfirm}>실행<//>
+        <${ActionButton} variant="danger" size="sm" onClick=${onConfirm} title="실행: 파괴적 도구를 그대로 실행합니다">실행하기<//>
         <${ActionButton} variant="ghost" size="sm" onClick=${onCancel}>취소<//>
       </div>
     </div>
@@ -55,9 +55,9 @@ function ToolDetail() {
         ? html`<${ConfirmDialog} toolName=${tool.name} onConfirm=${handleConfirmedExecute} onCancel=${() => { showConfirm.value = false }} />`
         : html`
           <div class="flex gap-2">
-            <${ActionButton} variant=${isDestructive ? 'danger' : 'primary'} size="md" disabled=${executing.value || !toolAccess.allowed} onClick=${handleExecute}>
-              ${executing.value ? '실행 중...' : '실행'}<//>
-            <${ActionButton} variant="ghost" size="md" onClick=${() => { clearSelection(); showConfirm.value = false }}>초기화<//>
+            <${ActionButton} variant=${isDestructive ? 'danger' : 'primary'} size="md" disabled=${executing.value || !toolAccess.allowed} onClick=${handleExecute} title="실행: 입력값으로 도구를 호출합니다">
+              ${executing.value ? '실행 중...' : '실행하기'}<//>
+            <${ActionButton} variant="ghost" size="md" onClick=${() => { clearSelection(); showConfirm.value = false }} title="초기화: 선택과 입력값을 비웁니다">초기화하기<//>
           </div>`}
       ${lastResult.value ? html`<${ToolResultDisplay} key=${lastResult.value.timestamp} ...${lastResult.value} />` : null}
     </div>

--- a/scripts/lint/dashboard-ssot-keeper-state.sh
+++ b/scripts/lint/dashboard-ssot-keeper-state.sh
@@ -155,19 +155,22 @@ if [[ -n "$catch_all_default" ]]; then
 fi
 
 # §9-5 — Noun/verb Korean label collision.
-# For each known collision keyword, flag a file that contains BOTH:
-#   - the bare noun form  (e.g. 일시정지)  AND
-#   - a bare button label without 하기 suffix at the verb site.
-# Heuristic: `>일시정지<` (button text) is suspect; PR-7 converted these
-# to `>일시정지하기<`. We skip files where the verb is never used as
-# a button (badge-only files).
-collision_keywords=("일시정지" "재개" "기동" "종료")
+# For each known collision keyword, flag a file that contains a button
+# label without 하기 suffix at the verb site. Two button-shape patterns
+# are checked because the codebase uses both:
+#   - htm/preact `<${ActionButton}>...<//>` (template close)
+#   - native `<button ...>...</button>` (explicit close)
+# PR-7 converted action-panel/alert-strip to `${kw}하기`. PR-10 extends
+# the sweep to keeper-detail-lifecycle, keeper-config-panel, tool-executor.
+# The list of keywords grows when noun/verb usage diverges in practice;
+# `편집`, `실행`, `초기화` were added after the 2026-05-19 audit.
+collision_keywords=("일시정지" "재개" "기동" "종료" "편집" "실행" "초기화")
 for kw in "${collision_keywords[@]}"; do
-  # Files containing a button-like `>${kw}<//>` pattern that is not the
-  # 하기-suffixed verb form.
+  # Files containing a button-like pattern that is not the 하기-suffixed
+  # verb form. Captures both `<//>` and `</button>` close shapes.
   bad_button=$(
     rg -n --type ts \
-      ">${kw}<//>" \
+      ">${kw}<(//|/button)>" \
       dashboard/src 2>/dev/null \
     | grep -v "${kw}하기" || true
   )


### PR DESCRIPTION
## Summary

2026-05-19 dashboard SSOT audit (3 parallel sub-agents) found 5 secondary
button surfaces that **PR-7 missed** because the lint pattern only matched
`>${kw}<//>` (htm/preact close shape). Native `<button>${kw}</button>`
close in `keeper-detail-lifecycle.ts`, `keeper-config-panel.ts`, and
`tool-executor.ts` remained unflagged.

This PR fixes those 5 sites + 2 ambiguous `<th>활성</th>` headers, and
**widens the lint** so the gap closes structurally.

## Changes
- `keeper-detail-lifecycle.ts`: 기동→기동하기, 종료→종료하기 (+ title tooltip)
- `keeper-config-panel.ts`: 편집→편집하기, 초기화→초기화하기 (+ title)
- `tool-executor.ts`: 실행→실행하기 (2 sites: confirm dialog + main button); 초기화→초기화하기
- `cascade-config-panel.ts`: `<th>활성</th>` → `<th>활성 수</th>`
  (cell is `e.active_after` integer count, not boolean — *활성 수* is more
  accurate than the audit's *활성 여부*; cite: cascade-config-panel.ts:1059)
- `scripts/lint/dashboard-ssot-keeper-state.sh` §9-5:
  - pattern widened to `>(${kw})<(//|/button)>` (both close shapes)
  - keyword list extended: 편집, 실행, 초기화

## Audit Findings closed
- C1 CRITICAL — `keeper-detail-lifecycle.ts:35` `>기동</button>`
- C2 CRITICAL — `keeper-detail-lifecycle.ts:62` `>종료</button>`
- C3 HIGH — `keeper-config-panel.ts:731` `>편집</button>`
- C4 HIGH — `tool-executor.ts:19` `>실행<//>`
- C5 HIGH — `tool-executor.ts:60` + `keeper-config-panel.ts:1112` `>초기화<*>`

## Verification
- [x] `bash scripts/lint/dashboard-ssot-keeper-state.sh` → exit 0 (clean)
- [x] `pnpm typecheck` → pass
- [x] `pnpm vitest run keeper-detail-alert-strip keeper-action-panel keeper-operational-state keeper-predicates` → 65/65 pass
- [x] diff: 5 files, +27/-20

## RFC reference
RFC-0135-dashboard-keeper-operational-ssot.md §1.2/§1.3 (noun/verb collision) + §9-5 (lint signal).

RFC-WAIVED: N/A — this PR strengthens an existing RFC-0135 lint gate without
touching new RFC subsystems.

## Audit report
`/Users/dancer/me/.tmp/masc-dashboard-ssot-audit-2026-05-19.html` (Goal-4 of 6).

---

Status: Draft — agent PR. Ready 전환은 사용자 라벨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>