### PR TITLE
[RFC-0137] Host FD pressure → Keeper pause (safety-net for Docker VM FD accumulation)

### DIFF
--- a/docs/rfc/RFC-0137-host-fd-pressure-keeper-pause.md
+++ b/docs/rfc/RFC-0137-host-fd-pressure-keeper-pause.md
@@ -1,0 +1,261 @@
+---
+rfc: "0137"
+title: "Host FD pressure → Keeper pause (safety-net for Docker VM FD accumulation)"
+status: Draft
+created: 2026-05-19
+updated: 2026-05-19
+author: jeong-sik
+supersedes: []
+superseded_by: null
+related: ["0097", "0101"]
+implementation_prs: []
+---
+
+# RFC-0137 — Host FD pressure → Keeper pause
+
+Status: Draft
+Author: jeong-sik (vincent)
+Date: 2026-05-19
+Related: RFC-0097 (keeper sandbox container reuse — root fix in progress),
+RFC-0101 (FD slot accountant — process-internal pressure).
+
+## 1. Problem
+
+On 2026-05-19 the macOS host suffered a kernel panic at 10:28:27 KST
+(`initproc exited`, `panic-full-2026-05-19-102827.0002.panic`). The
+proximate cause was *system-wide* FD table exhaustion driven by the
+single process
+`com.apple.Virtualization.VirtualMachine.xpc` (Apple Virtualization
+framework — Docker Desktop's VM backend). Same-day reproduction at
+22:02:26 KST captured a natural CRIT event
+(`fd=75%`, 368K / 491K `kern.maxfiles`) before user mitigation.
+
+### 1.1 Measurement evidence (same-day)
+
+| timestamp | system fd | pct | VM XPC fd | drift |
+|---|---|---|---|---|
+| 21:41 | 114,547 | 23% | 103,293 (pid 68615) | — |
+| 21:44 | 118,645 | 24% | 107,598 | +23 fd/sec |
+| 22:02 | ~368K | **75%** | (estimated 350K+) | **+51%p / 18min** |
+| 22:04 | — | — | — | `bash mkdir` returns ENFILE |
+| 22:05 (after user `killall -9 com.apple.Virtualization.VirtualMachine`) | 129,641 | 26% | XPC GONE | −239K recovered |
+
+Single XPC process owned **>90%** of the system FD table immediately
+before the CRIT. FD type breakdown at 21:41:
+`97,549 REG + 10,030 DIR + 13 misc`. Path sample (from earlier 7905-fd
+keeper task-318 audit) confirmed >99% live under
+`/Users/dancer/me/.worktrees/keeper-*/` — i.e. keeper-per-task worktree
+mounts shared into the Docker VM that the VM's filehandle cache never
+evicts under bookkeeping pressure.
+
+### 1.2 Why the existing layers do not catch this
+
+| layer | observes | acts | gap |
+|---|---|---|---|
+| `Keeper_fd_pressure` (RFC-0101) | process `nofile` + a probe of `kern.num_files` at error sites | trips a per-process circuit breaker | **probe is reactive at error sites only**; nothing polls the host budget while quiet, so a 1-hour drift to 75% triggers nothing until a syscall fails |
+| `Fd_accountant` (5-kind FD slot semaphore) | per-kind FD slots inside the masc-mcp process | rejects new spawns once the masc-mcp process budget is exhausted | observes *masc-mcp*, not the *host*. Apple VM XPC owns the FDs, not masc-mcp |
+| `Docker_spawn_throttle` (RFC-0097 adjacent, PR #15727) | concurrent docker spawns | per-kind semaphore | reduces *spawn rate*; does not reduce *cumulative* mount accumulation |
+| `sysmon-fd-oom-disk.sh` (out-of-process, `.tmp/`) | `kern.num_files / kern.maxfiles` every 60s | macOS notification + terminal bell | observer-only — masc-mcp keeper loop is not informed, so keepers keep adding work |
+
+The 2026-05-19 incident proves this gap empirically: sysmon emitted a
+WARN at 15:35 and a CRIT at 22:02; the keeper fleet kept scheduling
+turns the entire interval.
+
+### 1.3 Why this is *not* a counter-as-fix (RFC-0088)
+
+A naive read of this RFC could classify it as "make data loss visible"
+(RFC-0088 §counter-as-fix). It is not:
+
+- The drift is **not** a counter we plan to emit and walk away from.
+  The pressure signal triggers an **action** (keeper pause) before the
+  failure manifests.
+- The root fix (Apple VM cache lifecycle, Docker bind mount lifecycle,
+  keeper worktree-per-task) is **out-of-process** for masc-mcp.
+  RFC-0097 is the in-process root fix (container reuse). This RFC is
+  the safety net while RFC-0097 lands and reaches steady state.
+- The action (pause) is **degraded operation**, not a workaround that
+  hides failures.
+
+PR body for any implementation PR will carry the explicit deprecation
+target: *"Sunset when RFC-0097 reaches steady state and 24h cumulative
+VM XPC FD does not exceed 30K under fleet load."*
+
+## 2. Design
+
+Single-direction signal flow:
+
+```
+sysmon (.tmp/sysmon-fd-oom-disk.sh, already deployed)
+   │ emits  /tmp/masc-host-pressure.state  (atomic write)
+   │   {"level": "WARN"|"CRIT", "kinds": "...", "summary": "...", "ts": "...", "pid": ...}
+   ▼
+masc-mcp server polling loop (NEW)
+   │ reads /tmp/masc-host-pressure.state every 1s
+   │ on level change: invokes
+   ▼
+Keeper_fd_pressure.engage_external ~reason ~level  (NEW)
+   │ trips the existing cooldown atomic with longer expiry
+   ▼
+existing keeper scheduling
+   │ already consults Keeper_fd_pressure.active in pre-spawn / pre-turn gates
+   ▼
+keepers pause for cooldown_sec (WARN: 600s, CRIT: 1800s)
+```
+
+### 2.1 Signal contract
+
+`/tmp/masc-host-pressure.state` is **already produced** by
+`sysmon-fd-oom-disk.sh` (atomic temp-then-rename). Schema is JSON one-line:
+
+```json
+{"level":"OK|WARN|CRIT","kinds":"fd_total|fd_proc|vm_pressure|swap|disk","summary":"...","ts":"2026-05-19T22:02:26+0900","pid":66754}
+```
+
+`OK` is represented by **file absence**, not an `OK` line — this is the
+existing sysmon behaviour. The polling loop treats missing-file as
+`OK`.
+
+### 2.2 API surface
+
+`lib/keeper_fd_pressure.mli` adds:
+
+```ocaml
+type external_level = External_warn | External_crit
+
+val engage_external :
+  reason:string ->
+  level:external_level ->
+  ts:float ->
+  unit
+(** Trip the FD-pressure cooldown from an out-of-process source
+    (host kernel pressure detected by sysmon). [reason] is for
+    telemetry; [level] sets cooldown duration (WARN: 600s, CRIT:
+    1800s); [ts] is the source event timestamp.
+
+    Concurrency: monotonic CAS on [cooldown_until]; concurrent
+    invocations with stale [ts] are no-ops. *)
+```
+
+No existing call sites need to change — they already consult
+`Keeper_fd_pressure.active`.
+
+### 2.3 Polling loop
+
+New file: `lib/server/host_fd_pressure_poller.ml`.
+
+- Eio fiber, started from `Server_bootstrap_loops.start`.
+- Cadence: 1s. Cost: 1 `stat(2)` call per second.
+- On file present + parse success + new `(level, ts)`: invokes
+  `engage_external`.
+- On file absent (or stale ts > 120s): no-op. Cooldown expires on its own.
+- Telemetry: emits `host_fd_pressure_engage{level=warn|crit}` counter,
+  logs the engage event with `reason` truncated to 200 chars.
+- Failures (file partial write, malformed JSON): single WARN log per
+  hour, no crash.
+
+### 2.4 Cooldown durations
+
+| level | cooldown | rationale |
+|---|---|---|
+| WARN (≥30%) | 600s (10min) | give keepers room to drain in-flight turns; resume if pressure clears |
+| CRIT (≥75%) | 1800s (30min) | panic is imminent; sysmon's own macOS notification advises user restart in parallel |
+
+Durations are env-overrideable: `MASC_HOST_PRESSURE_COOLDOWN_WARN_SEC`,
+`MASC_HOST_PRESSURE_COOLDOWN_CRIT_SEC`.
+
+## 3. Implementation plan
+
+| PR | scope | LoC est | depends on |
+|---|---|---|---|
+| PR-1 | `keeper_fd_pressure.{ml,mli}` add `engage_external` + tests | ~60 | none |
+| PR-2 | `host_fd_pressure_poller.{ml,mli}` new module + wiring in `server_bootstrap_loops.ml` + tests | ~120 | PR-1 |
+| PR-3 (optional) | Prometheus metric `host_fd_pressure_*` registration | ~30 | PR-2 |
+
+Each PR is Draft, follows `workflow-pr.md` (RFC-WAIVED line not needed;
+this RFC itself is the citation).
+
+## 4. Verification
+
+### 4.1 Unit
+
+- `engage_external ~level:CRIT` with `ts` newer than current cooldown:
+  `active () = true`, `remaining_sec () ≈ 1800`.
+- `engage_external ~level:WARN` with `ts` older than current cooldown:
+  no-op.
+- Two concurrent fibers calling `engage_external` with same `level` —
+  one CAS wins, projection consistent.
+
+### 4.2 Integration (host required)
+
+Manual harness in `test/host_fd_pressure_integration_test.ml`:
+
+1. Write `{"level":"WARN",...}` to `/tmp/masc-host-pressure.state`.
+2. Assert: within 2s, `Keeper_fd_pressure.active ()` returns `true`.
+3. `rm` the file.
+4. Assert: after cooldown expiry, `active ()` returns `false`.
+
+### 4.3 Field validation
+
+Re-run the 2026-05-19 incident scenario:
+
+1. Pre: 16 keepers active, drift ~13 FD/sec.
+2. Wait for sysmon CRIT (≥75%).
+3. Expected: within 1-2s of CRIT event, all keeper proactive cycles
+   pause. Existing in-flight turns drain. New spawn requests rejected
+   with `host_fd_pressure_engaged` reason.
+4. User manual Docker restart resolves underlying issue; sysmon state
+   file goes absent; cooldown expires; keepers resume.
+
+Success criterion: **no `initproc exited` panic in the 24h following
+PR-2 deploy under the same workload that produced 2026-05-19 02:28 KST
+panic and 22:02 KST natural CRIT**.
+
+## 5. Rollback
+
+Single env flag `MASC_HOST_FD_PRESSURE_POLLER_DISABLED=1` short-circuits
+the poller at fiber start. `engage_external` becomes unreachable; no
+behaviour change beyond pre-PR-2 state.
+
+## 6. Migration
+
+Zero migration. The signal source (`sysmon-fd-oom-disk.sh`) is already
+running in `.tmp/` on the affected host. Other hosts without sysmon
+deployed: poller harmlessly observes file absent; no-op every 1s.
+
+## 7. Open questions
+
+1. **Should WARN-level engage cancel a running turn?** Current design:
+   no — only blocks new turns. CRIT optionally cancels (deferred to PR-2
+   review; default no until field data).
+2. **Should the poller log keeper-by-keeper engagement?** No — a single
+   broadcast log per state transition is enough. Per-keeper pause is
+   implicit via `Keeper_fd_pressure.active` check.
+3. **Other host pressure kinds (`vm_pressure`, `swap`, `disk`)?** Out of
+   scope for RFC-0137. FD is the panic-proximate cause. Future RFC may
+   generalize.
+
+## 8. Related work
+
+- **RFC-0097** (sandbox container reuse): the in-process root fix.
+  When RFC-0097 reaches steady state (24h cumulative VM XPC FD ≤ 30K),
+  RFC-0137 sunsets to a low-cardinality monitor — the poller stays as
+  defense-in-depth but should rarely fire.
+- **RFC-0101** (FD slot accountant): process-internal pressure. RFC-0137
+  is its host-external analog. Same cooldown atomic, different signal.
+- **RFC-0088** (counter-as-fix umbrella): RFC-0137 is *not* a workaround
+  in that taxonomy because it triggers a behaviour change (pause), not
+  a counter. PR body must reaffirm the sunset target.
+
+## 9. Sunset criteria
+
+This RFC sunsets when **all three** hold for a continuous 7-day window:
+
+1. RFC-0097 implementation steady state (no `keeper_sandbox_container_*`
+   error/restart counters over 7 days).
+2. Sysmon `host_fd_pressure_engage_warn_total` counter stays at 0 over
+   the same window.
+3. macOS kernel panic count = 0 attributable to FD exhaustion.
+
+When satisfied: sunset PR removes the poller and `engage_external`,
+keeping the `engage_external` interface stub guarded by `assert false`
+for one release cycle before deletion.

--- a/lib/keeper_fd_pressure.ml
+++ b/lib/keeper_fd_pressure.ml
@@ -198,6 +198,60 @@ let degraded_trust_json ?now () =
     ]
 ;;
 
+(* RFC-0137: host-external FD pressure → cooldown trip.
+
+   [Keeper_fd_pressure.note] is reactive — it fires only when an internal
+   call site hits EMFILE/ENFILE. That misses the slow-burn case where the
+   *host* kernel FD table accumulates against [kern.maxfiles] from an
+   adjacent process (Apple Virtualization VM XPC under Docker Desktop)
+   while masc-mcp's own [nofile] budget stays comfortable.
+
+   The out-of-process [sysmon-fd-oom-disk.sh] daemon emits a JSON state
+   file at [/tmp/masc-host-pressure.state] on WARN/CRIT thresholds; the
+   [Host_fd_pressure_poller] (PR-2) reads it on a 1s cadence and invokes
+   [engage_external].
+
+   Monotonic guarantee: stale [ts] produces a smaller [until_ts] than
+   the current [cooldown_until], so [cas_monotonic_max] rejects it — no
+   separate last_external_ts atomic needed. *)
+type external_level =
+  | External_warn
+  | External_crit
+
+let string_of_external_level = function
+  | External_warn -> "warn"
+  | External_crit -> "crit"
+;;
+
+let external_cooldown_sec_of level =
+  let default_sec, env_var =
+    match level with
+    | External_warn -> 600.0, "MASC_HOST_PRESSURE_COOLDOWN_WARN_SEC"
+    | External_crit -> 1800.0, "MASC_HOST_PRESSURE_COOLDOWN_CRIT_SEC"
+  in
+  Env_config_core.get_float ~default:default_sec env_var
+  |> Float.max 5.0
+  |> Float.min 3600.0
+;;
+
+let engage_external ~reason ~level ~ts () =
+  let cooldown = external_cooldown_sec_of level in
+  let until_ts = ts +. cooldown in
+  let advanced = cas_monotonic_max ~atom:cooldown_until until_ts in
+  if advanced
+  then begin
+    let now = Time_compat.now () in
+    let last = Atomic.get last_log_at in
+    if now -. last >= 10.0 && Atomic.compare_and_set last_log_at last now
+    then
+      Log.Keeper.error
+        "fd_pressure: external engage level=%s cooldown=%.0fs reason=%s"
+        (string_of_external_level level)
+        cooldown
+        reason
+  end
+;;
+
 let reset_for_tests () =
   Atomic.set cooldown_until 0.0;
   Atomic.set last_log_at 0.0;

--- a/lib/server/host_fd_pressure_poller.ml
+++ b/lib/server/host_fd_pressure_poller.ml
@@ -1,0 +1,189 @@
+(* Host_fd_pressure_poller — see .mli for contract.
+
+   RFC-0137 PR-2. Sunsets when RFC-0097 (sandbox container reuse)
+   reaches steady state. See RFC-0137 §9.
+
+   Design choices worth noting:
+   - The poller does NOT dedup by (level, ts). The downstream
+     [Keeper_fd_pressure.engage_external] uses [cas_monotonic_max]
+     on [cooldown_until]; a stale [ts] yields a smaller [until_ts]
+     and is rejected by the CAS. So even if this poller reads the
+     same line twice, behaviour is correct.
+   - Parse failures and missing files are no-ops, not warnings —
+     during normal operation the file is *absent* most of the time. *)
+
+let state_file_path () =
+  match Sys.getenv_opt "MASC_HOST_FD_PRESSURE_STATE_FILE" with
+  | Some s when s <> "" -> s
+  | _ -> "/tmp/masc-host-pressure.state"
+;;
+
+let poll_interval_sec () =
+  Env_config_core.get_float
+    ~default:1.0
+    "MASC_HOST_FD_PRESSURE_POLL_INTERVAL_SEC"
+  |> Float.max 0.5
+  |> Float.min 60.0
+;;
+
+(* iso8601 -> unix epoch seconds. sysmon emits e.g.
+   "2026-05-19T22:02:26+0900". We strip the trailing tz offset and
+   accept the local time as-is — for our purposes the absolute value
+   matters only relative to other [ts] values from the same source. *)
+let parse_iso8601_opt s =
+  match String.split_on_char 'T' s with
+  | [ date; rest ] ->
+    let time_part =
+      (* split off "+0900" or "-0500" or "Z" *)
+      let cut_at_tz s =
+        let len = String.length s in
+        let rec find i =
+          if i >= len
+          then s
+          else
+            match s.[i] with
+            | '+' | '-' | 'Z' -> String.sub s 0 i
+            | _ -> find (i + 1)
+        in
+        find 0
+      in
+      cut_at_tz rest
+    in
+    (try
+       Scanf.sscanf
+         (date ^ " " ^ time_part)
+         "%d-%d-%d %d:%d:%d"
+         (fun y mo d h mi s ->
+           let tm =
+             { Unix.tm_year = y - 1900
+             ; tm_mon = mo - 1
+             ; tm_mday = d
+             ; tm_hour = h
+             ; tm_min = mi
+             ; tm_sec = s
+             ; tm_wday = 0
+             ; tm_yday = 0
+             ; tm_isdst = false
+             }
+           in
+           let epoch, _ = Unix.mktime tm in
+           Some epoch)
+     with
+     | _ -> None)
+  | _ -> None
+;;
+
+type parsed =
+  { level : Keeper_fd_pressure.external_level
+  ; ts : float
+  ; reason : string
+  }
+
+let parse_state_line line =
+  match Yojson.Safe.from_string line with
+  | json ->
+    let open Yojson.Safe.Util in
+    (try
+       let level_str = json |> member "level" |> to_string in
+       let level =
+         match String.uppercase_ascii level_str with
+         | "WARN" -> Some Keeper_fd_pressure.External_warn
+         | "CRIT" -> Some Keeper_fd_pressure.External_crit
+         | _ -> None
+       in
+       let ts_str =
+         match json |> member "ts" with
+         | `String s -> s
+         | _ -> ""
+       in
+       let kinds =
+         match json |> member "kinds" with
+         | `String s -> s
+         | _ -> "?"
+       in
+       let summary =
+         match json |> member "summary" with
+         | `String s -> s
+         | _ -> ""
+       in
+       match level, parse_iso8601_opt ts_str with
+       | Some level, Some ts ->
+         let reason =
+           let r = Printf.sprintf "sysmon kinds=%s %s" kinds summary in
+           if String.length r > 200 then String.sub r 0 200 else r
+         in
+         Some { level; ts; reason }
+       | _ -> None
+     with
+     | _ -> None)
+  | exception _ -> None
+;;
+
+let read_state_file_opt path =
+  try
+    let ic = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+        match input_line ic with
+        | line -> Some line
+        | exception End_of_file -> None)
+  with
+  | Sys_error _ -> None
+;;
+
+let last_warn_log_at = Atomic.make 0.0
+
+(* 1 hour throttle for poller WARN logs: parse failures should not flood.
+   Takes a thunk so the message-building work is skipped when throttled. *)
+let log_throttled_warn (mk_msg : unit -> string) =
+  let now = Time_compat.now () in
+  let last = Atomic.get last_warn_log_at in
+  if now -. last >= 3600.0 && Atomic.compare_and_set last_warn_log_at last now
+  then Log.Server.warn "%s" (mk_msg ())
+;;
+
+let one_tick path =
+  match read_state_file_opt path with
+  | None -> ()
+  | Some line ->
+    (match parse_state_line line with
+     | Some p ->
+       Keeper_fd_pressure.engage_external
+         ~reason:p.reason
+         ~level:p.level
+         ~ts:p.ts
+         ()
+     | None ->
+       log_throttled_warn (fun () ->
+         let truncated =
+           if String.length line > 80 then String.sub line 0 80 else line
+         in
+         Printf.sprintf
+           "host_fd_pressure_poller: malformed state line (truncated): %s"
+           truncated))
+;;
+
+let start ~sw ~clock =
+  Eio.Fiber.fork ~sw (fun () ->
+    let path = state_file_path () in
+    let interval = poll_interval_sec () in
+    Log.Server.info
+      "host_fd_pressure_poller: started path=%s interval=%.1fs"
+      path
+      interval;
+    let rec loop () =
+      Eio.Time.sleep clock interval;
+      (try one_tick path with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+         log_throttled_warn (fun () ->
+           Printf.sprintf
+             "host_fd_pressure_poller: tick crashed: %s"
+             (Printexc.to_string exn)));
+      loop ()
+    in
+    try loop () with
+    | Eio.Cancel.Cancelled _ ->
+      Log.Server.info "host_fd_pressure_poller: cancelled, exiting cleanly")
+;;

--- a/lib/server/host_fd_pressure_poller.mli
+++ b/lib/server/host_fd_pressure_poller.mli
@@ -1,0 +1,32 @@
+(** Host_fd_pressure_poller — bridges out-of-process host FD pressure
+    signal into [Keeper_fd_pressure.engage_external]. (RFC-0137 PR-2)
+
+    The companion [sysmon-fd-oom-disk.sh] daemon atomically writes
+    [/tmp/masc-host-pressure.state] (JSON one-line) on WARN/CRIT
+    thresholds against [kern.maxfiles]; file absence means OK.
+
+    This module starts a single Eio fiber that stats the state file
+    every 1s. On parse success + advancing [ts] it invokes
+    [Keeper_fd_pressure.engage_external] with the matching level.
+
+    Concurrency: idempotent. [Keeper_fd_pressure.engage_external] is
+    monotonic on its own [cooldown_until] CAS, so stale or duplicate
+    reads are absorbed there — no separate dedup atomic is needed.
+
+    Failure modes: malformed JSON, partial writes, missing file,
+    stat(2) errors — all no-ops. Single throttled WARN log per hour. *)
+
+val start : sw:Eio.Switch.t -> clock:_ Eio.Time.clock -> unit
+(** [start ~sw ~clock] forks the poller fiber under [sw]. Wired from
+    [Server_bootstrap_loops.start_background_maintenance]. Cancelled
+    when [sw] terminates. *)
+
+val state_file_path : unit -> string
+(** [state_file_path ()] returns the configured pressure state path.
+    Default [/tmp/masc-host-pressure.state]; env-overrideable via
+    [MASC_HOST_FD_PRESSURE_STATE_FILE]. Exposed for testing. *)
+
+val poll_interval_sec : unit -> float
+(** [poll_interval_sec ()] returns the poll cadence. Default 1.0s;
+    env-overrideable via [MASC_HOST_FD_PRESSURE_POLL_INTERVAL_SEC],
+    bounded [0.5, 60.0]. *)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -980,6 +980,18 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn -> Log.Server.error "metrics_flush fiber crashed: %s" (Printexc.to_string exn));
   Shutdown.register ~name:"metrics_flush" ~priority:30 Metrics_store_eio.flush_pending;
+  (* RFC-0137 PR-2: host FD pressure poller. Watches sysmon's pressure state
+     file at /tmp/masc-host-pressure.state every 1s; bridges WARN/CRIT into
+     [Keeper_fd_pressure.engage_external] so the keeper scheduling gates pause
+     before kern.maxfiles exhaustion can panic the kernel. Disable via
+     [MASC_HOST_FD_PRESSURE_POLLER_DISABLED=1]. Sunsets when RFC-0097
+     (sandbox container reuse) reaches steady state — see RFC-0137 §9. *)
+  let poller_disabled =
+    match Sys.getenv_opt "MASC_HOST_FD_PRESSURE_POLLER_DISABLED" with
+    | Some ("1" | "true" | "TRUE") -> true
+    | _ -> false
+  in
+  if not poller_disabled then Host_fd_pressure_poller.start ~sw ~clock;
   (* Deterministic output budget enforcement: truncate oversized tool outputs
      with structured metadata before metrics/OTEL hooks see them. *)
   Tool_output_validation.install ();

--- a/test/test_keeper_fd_pressure_fleet.ml
+++ b/test/test_keeper_fd_pressure_fleet.ml
@@ -192,6 +192,59 @@ let test_nofile_probe_is_native_not_shell () =
     | Some limit -> Alcotest.failf "expected positive native nofile limit, got %d" limit
     | None -> Alcotest.fail "expected native nofile probe to resolve on Unix")
 
+(* RFC-0137 — external engage from host FD pressure (PR-1). *)
+
+let test_engage_external_crit_advances_cooldown () =
+  FD.reset_for_tests ();
+  Alcotest.(check bool) "inactive before engage" false (FD.active ());
+  let ts = Time_compat.now () in
+  FD.engage_external ~reason:"sysmon fd=75%" ~level:FD.External_crit ~ts ();
+  Alcotest.(check bool) "active after CRIT engage" true (FD.active ());
+  let remaining = FD.remaining_sec () in
+  (* default CRIT cooldown = 1800s; allow slack for slow CI scheduling. *)
+  Alcotest.(check bool)
+    (Printf.sprintf "remaining %.0fs ≈ 1800 (within [1700, 1801])" remaining)
+    true
+    (remaining >= 1700.0 && remaining <= 1801.0);
+  FD.reset_for_tests ()
+
+let test_engage_external_stale_ts_is_noop () =
+  FD.reset_for_tests ();
+  let now = Time_compat.now () in
+  FD.engage_external ~reason:"current WARN" ~level:FD.External_warn ~ts:now ();
+  let after_first = FD.remaining_sec () in
+  (* Engage with a [ts] 120s in the past — produces a smaller [until_ts]
+     than the existing cooldown, so [cas_monotonic_max] must reject it.
+     No separate last_external_ts atomic exists by design — the monotonic
+     CAS on [cooldown_until] is the only ordering primitive. *)
+  FD.engage_external
+    ~reason:"stale WARN — should be no-op"
+    ~level:FD.External_warn
+    ~ts:(now -. 120.0)
+    ();
+  let after_stale = FD.remaining_sec () in
+  Alcotest.(check bool)
+    (Printf.sprintf
+       "stale ts did not shorten cooldown (before=%.0f after=%.0f)"
+       after_first
+       after_stale)
+    true
+    (after_stale >= after_first -. 1.0);
+  FD.reset_for_tests ()
+
+let test_engage_external_crit_extends_warn () =
+  FD.reset_for_tests ();
+  let ts = Time_compat.now () in
+  FD.engage_external ~reason:"WARN first" ~level:FD.External_warn ~ts ();
+  let after_warn = FD.remaining_sec () in
+  FD.engage_external ~reason:"CRIT escalates" ~level:FD.External_crit ~ts ();
+  let after_crit = FD.remaining_sec () in
+  Alcotest.(check bool)
+    (Printf.sprintf "CRIT %.0fs extends WARN %.0fs" after_crit after_warn)
+    true
+    (after_crit > after_warn);
+  FD.reset_for_tests ()
+
 let () =
   Alcotest.run
     "keeper_fd_pressure_fleet"
@@ -216,5 +269,13 @@ let () =
             test_nofile_cache_single_flight_resolves_once
         ; Alcotest.test_case "nofile probe is native" `Quick
             test_nofile_probe_is_native_not_shell
+        ] )
+    ; ( "external-engage"
+      , [ Alcotest.test_case "CRIT advances cooldown to ~1800s" `Quick
+            test_engage_external_crit_advances_cooldown
+        ; Alcotest.test_case "stale ts is no-op (monotonic rejection)" `Quick
+            test_engage_external_stale_ts_is_noop
+        ; Alcotest.test_case "CRIT extends WARN cooldown" `Quick
+            test_engage_external_crit_extends_warn
         ] )
     ]


### PR DESCRIPTION
## 목표

`Keeper_fd_pressure` cooldown 회로를 **host 외부 신호**(`sysmon-fd-oom-disk.sh`)에서도 trip 가능하게 한다. 오늘 (2026-05-19) 발생한 두 사건의 안전망:

1. **10:28 KST**: macOS kernel panic `initproc exited` — Apple Virtualization VM XPC가 system FD 표를 단독으로 90%+ 점유
2. **22:02 KST**: 자연 CRIT 재현 — `fd=75%` 도달, 18분 동안 24%→75% drift, `bash mkdir` ENFILE 발생

기존 4 layer (Keeper_fd_pressure error-site probe / Fd_accountant per-process / Docker_spawn_throttle / sysmon notification)는 모두 이 누적을 못 잡았다. 안전망이 빠져있다.

## 변경 파일

| 파일 | LoC | 역할 |
|---|---|---|
| `docs/rfc/RFC-0137-host-fd-pressure-keeper-pause.md` | +261 | RFC body (9 섹션, motivation/design/verification/sunset) |
| `lib/keeper_fd_pressure.ml` | +54 | PR-1 — `engage_external ~reason ~level ~ts ()` 추가 |
| `test/test_keeper_fd_pressure_fleet.ml` | +61 | PR-1 — 3 unit test (external-engage section) |
| `lib/server/host_fd_pressure_poller.{ml,mli}` | +221 | PR-2 — Eio fiber, `/tmp/masc-host-pressure.state` 1s polling |
| `lib/server/server_bootstrap_loops.ml` | +12 | PR-2 — fiber wiring + env disable flag |

**Total: 609 insertions, 0 deletions** (2 commits — `bbe563a609` PR-1 + `b8dcd92eda` PR-2)

## 로컬 검증

```
dune build --root . @check  → exit 0
dune exec --root . test/test_keeper_fd_pressure_fleet.exe  → 11/11 PASS (0.007s)
  - external-engage 0: CRIT advances cooldown to ~1800s
  - external-engage 1: stale ts is no-op (monotonic CAS rejection)
  - external-engage 2: CRIT extends WARN cooldown
```

## 디자인 핵심

```
sysmon (.tmp/sysmon-fd-oom-disk.sh, 이미 deploy됨)
   │ atomic write /tmp/masc-host-pressure.state (JSON 한 줄)
   ▼
Host_fd_pressure_poller (NEW, Eio fiber, 1s cadence)
   │ stat + parse + dispatch
   ▼
Keeper_fd_pressure.engage_external ~reason ~level ~ts  (NEW)
   │ cas_monotonic_max on cooldown_until (RFC-0101에서 검증된 primitive 재사용)
   ▼
기존 keeper 스케줄링 게이트가 Keeper_fd_pressure.active를 이미 consult → 자동 pause
```

**stale ts rejection은 cas_monotonic_max로 자동** — 별도 atomic 불필요. 작은 `until_ts`는 CAS가 거부.

**Cooldown**: WARN 600s, CRIT 1800s. env-overrideable (`MASC_HOST_PRESSURE_COOLDOWN_WARN_SEC`, `_CRIT_SEC`), [5, 3600] bounded.

## RFC-0088 (counter-as-fix umbrella) 자기방어

이 RFC는 워크어라운드가 **아니다**:
- 신호 발견 시 **행동 변경** (keeper pause) — counter 아니라 action
- 폐기 trigger 명시 (RFC-0137 §9): RFC-0097 steady state 도달 시 자동 sunset
- masc-mcp 외부 root (Apple VM cache lifecycle + Docker bind mount lifecycle)에 대한 in-process 안전망

## Step A 실측 — RFC-0097 미작동 확정

오늘 측정 (Docker 재시작 후 42분):
- baseline 22:10 fds=2,778
- 22:53 fds=55,545
- drift **20.5 fds/sec** (panic 시점 43/sec의 절반)
- RFC-0097 PR #15728 머지됐어도 새 keeper task spawn마다 새 mount 추가 — RFC-0137 안전망 필수성 확인

## 남은 미검증

- **Field validation (RFC-0137 §4.3)**: 같은 워크로드에서 24h 동안 panic 0건 — production merge 후에만 검증 가능
- **Integration test (§4.2)**: sysmon JSON state file 작성 → `Keeper_fd_pressure.active ()` 2초 안에 true 전환. 수동 시나리오 (이 PR scope 아님)
- **Prometheus metric (PR-3)**: `host_fd_pressure_engage_total{level=...}` counter 등록 — 별도 follow-up PR로 분리

## 폐기 기준 (RFC-0137 §9)

연속 7일 동안 모두 만족 시 RFC-0137 sunset:
1. RFC-0097 implementation steady state (sandbox container error/restart counter 0)
2. `host_fd_pressure_engage_warn_total` counter 0
3. FD exhaustion 기인 kernel panic 0건

## CI 모니터링 계획

Draft 상태 유지. CI 결과 + CodeRabbit 리뷰 코멘트 + 사용자 검토 후 Ready 전환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)