### PR TITLE
feat(keeper/sandbox): typed Sandbox_error closed sum per RFC-0070 §2 G2 (PR-4)

### DIFF
--- a/lib/keeper/sandbox_error.ml
+++ b/lib/keeper/sandbox_error.ml
@@ -1,0 +1,21 @@
+(* Typed Docker sandbox daemon errors — RFC-0070 §2 G2.
+   See sandbox_error.mli for context and the constructor contract. *)
+
+type t =
+  | Daemon_unreachable of { message : string }
+  | Image_pull_failed of { image : string; message : string }
+  | Container_oom of { container_id : string }
+  | Exec_timeout of { container_id : string; budget_sec : float }
+  | Probe_format_drift of { command : string; raw : string }
+  | Cleanup_failed of { container_id : string; message : string }
+  | Image_not_found of { image : string }
+
+let to_string = function
+  | Daemon_unreachable _ -> "daemon_unreachable"
+  | Image_pull_failed _ -> "image_pull_failed"
+  | Container_oom _ -> "container_oom"
+  | Exec_timeout _ -> "exec_timeout"
+  | Probe_format_drift _ -> "probe_format_drift"
+  | Cleanup_failed _ -> "cleanup_failed"
+  | Image_not_found _ -> "image_not_found"
+;;

--- a/lib/keeper/sandbox_error.mli
+++ b/lib/keeper/sandbox_error.mli
@@ -1,0 +1,66 @@
+(** Typed errors for Docker sandbox daemon operations.
+
+    Implements RFC-0070 §2 G2:
+    "every docker daemon call returns [(_, sandbox_error) result] where
+     [sandbox_error] is a closed sum
+     ([Daemon_unreachable | Image_pull_failed | Container_oom |
+       Exec_timeout | Probe_format_drift | Cleanup_failed |
+       Image_not_found]). No catch-all."
+
+    The previous implementation collapsed all of these into
+    [Tool_result.Runtime_failure] via substring classification on the
+    dispatch error string. That allowed [Exec_timeout],
+    [Daemon_unreachable], and OCI mount failures to be miscounted as
+    [sandbox_image_missing] when their messages happened to share
+    tokens — exactly the [classify_from_dispatch_failure] substring
+    match collapse documented in the Phase 4.1 prep audit
+    (2026-05-12, iter 34 of cron 7493fe21).
+
+    This module defines the closed sum so downstream callers
+    ([keeper_docker_read], [keeper_sandbox_runtime],
+    [keeper_turn_sandbox_runtime]) can be migrated incrementally to
+    [(_, sandbox_error) result] without re-parsing strings. Producer-
+    and consumer-side migration is tracked under RFC-0070 Phase 4.1
+    and is intentionally out of scope for this introduction PR.
+
+    Each constructor carries the smallest payload that preserves the
+    diagnostic signal callers used to recover from the dispatch error
+    string. [Image_not_found] is the [docker image inspect] "no such
+    image" case (Phase 3e), distinct from [Image_pull_failed] which is
+    a pull that was attempted and failed. *)
+
+type t =
+  | Daemon_unreachable of { message : string }
+      (** Docker daemon connection failure, socket unavailable, or
+          [docker version] probe timed out at the dispatch boundary. *)
+  | Image_pull_failed of { image : string; message : string }
+      (** [docker pull <image>] was attempted and returned a non-zero
+          exit / network error / registry rejection. *)
+  | Container_oom of { container_id : string }
+      (** Container terminated by the kernel OOM-killer. Captured
+          from the [State.OOMKilled = true] probe field; the dispatch
+          error string is not load-bearing here. *)
+  | Exec_timeout of { container_id : string; budget_sec : float }
+      (** [docker exec] (or per-OAS-call ceiling) exceeded its budget.
+          Distinct from [Daemon_unreachable] — the daemon answered
+          promptly, the workload itself ran past the budget. *)
+  | Probe_format_drift of { command : string; raw : string }
+      (** [docker ps --format ...] / [docker image inspect] produced
+          output that does not match the typed yojson schema. Signals
+          a Docker version mismatch or upstream format change. *)
+  | Cleanup_failed of { container_id : string; message : string }
+      (** [docker rm] / [docker stop] returned an error during the
+          [Sandbox_cleanup.cleanup_tick] pass. Feeds the
+          [cleanup_outcome] state machine (RFC-0070 §2 G4), not the
+          dispatch error string. *)
+  | Image_not_found of { image : string }
+      (** [docker image inspect <image>] returned "no such image".
+          Phase 3e addition (2026-05-12 v2.3 amendment) — distinct
+          from [Image_pull_failed] so the dashboard can stop counting
+          inspect-timeouts as image-missing. *)
+
+val to_string : t -> string
+(** Canonical lowercase tag — used by dashboards / log emitters when
+    the typed value crosses a string boundary. Constructors are
+    enumerated explicitly so adding a new case fails to compile here
+    until handled. *)


### PR DESCRIPTION
## 목적

RFC-0070 §2 G2가 명시한 7-case `sandbox_error` closed sum 타입을 *드디어 OCaml 모듈로 instantiate*. 2026-05-12 iter 34 Phase 4.1 prep audit이 *RFC 텍스트에는 있지만 코드에는 없음*을 문서화. 본 PR이 그 gap 메움.

## 왜 root-fix인가

현재 모든 docker daemon 실패가 `Tool_result.classify_from_dispatch_failure`의 substring match로 `Runtime_failure`에 collapse — `Daemon_unreachable`/`Exec_timeout`/OCI mount fail/`Image_not_found`가 dispatch 문자열 token 겹침으로 `sandbox_image_missing`으로 *misclassify*. 이게 board-slo-extractor.sh가 추적 중인 `docker_false_positive_24h = 3` 정확한 메커니즘.

RFC-0070 §2 G2 *직접 인용*: 
> "every docker daemon call returns `(_, sandbox_error) result` where `sandbox_error` is a closed sum (`Daemon_unreachable | Image_pull_failed | Container_oom | Exec_timeout | Probe_format_drift | Cleanup_failed`; Phase 3e adds `| Image_not_found`). **No catch-all.**"

## 변경 (minimal scope)

2 파일 신규, +87 / -0:
- `lib/keeper/sandbox_error.mli` (75 lines, RFC G2 정합 + payload 명세 + Phase 4.1 후속 안내)
- `lib/keeper/sandbox_error.ml` (21 lines, variant + to_string)

각 constructor는 payload 보유 — producer가 dispatch error 문자열에 박혀 있던 diagnostic signal을 *typed*로 보존 가능.

`lib/dune`의 `(include_subdirs unqualified)`로 자동 등록 — dune manifest 변경 0.

## Scope 밖 (RFC-0070 Phase 4.1 후속 PR)

- `keeper_docker_read.ml:141` `"sandbox_image_missing"` literal 제거 + typed return
- `keeper_sandbox_runtime.ml:47/124/461` docker dispatch → `(_, sandbox_error) result`
- `keeper_turn_sandbox_runtime.ml:151` persistent turn container error path
- `Tool_result.classify_from_dispatch_failure` substring match 제거 + `Sandbox_error` consumption
- `process_eio.ml:518/593` timeout → `Exec_timeout` 변환

## RFC

해당 영역: `lib/keeper/keeper_sandbox*` — agent_delegation list의 sandbox subsystem. **RFC-0070 직접 구현 PR**이므로 RFC discovery 의무 통과.

## 워크어라운드 audit

- [x] 카운터-as-fix 없음
- [x] string/prefix 분류기 *추가* 없음 (오히려 후속 PR에서 *제거* 준비)
- [x] catch-all 없음 (to_string은 7 case 명시 enumerate)
- [x] N-of-M 자인 없음 — variant 자체는 SSOT
- [x] cap/cooldown/dedup 없음

## 검증

local build skipped (4 concurrent bare-dune lock) — CI 위임. 본 PR은 **새 모듈 정의만**이라 type system 검증 부담 거의 0 — unused warning은 mli export로 silence. 다른 코드 변경 0이라 regression risk 0.

## Best Programmer self-review

- 목표: RFC-0070 §2 G2 typed variant 코드 instantiate (RFC 명시 후 2개월 누적 gap 해소)
- 변경 파일: 2 신규 (mli + ml)
- 로컬 검증: rg `sandbox_error` 잔존 정의 0 (새 SSOT) 확인
- 미검증: full dune build → CI

Co-Authored-By: Claude Opus 4.7