### PR TITLE
fix(tool_task): typed verification_id match replaces silent default (PR-5)

### DIFF
--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -940,9 +940,22 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
               | Masc_domain.Done _ | Masc_domain.Cancelled _ -> ())
            | None -> ())
         | Masc_domain.Approve_verification ->
-          let verification_id = Option.value ~default:"" verification_id_before in
-          Verification_protocol.notify_approve_verification
-            ~task_id ~verifier:ctx.agent_name ~verification_id ~notes;
+          (* Previously this arm used [Option.value ~default:""
+             verification_id_before], which silently turned a missing
+             verification_id into the empty string and let
+             [notify_approve_verification] proceed against an invalid
+             id.  An Approve_verification action without a preceding
+             AwaitingVerification record is a logical invariant
+             violation — log it so dashboards surface the drift
+             instead of acting on empty strings. *)
+          (match verification_id_before with
+           | None ->
+             Log.Task.warn
+               "approve_verification action for task %s without verification_id_before (skipping notify)"
+               task_id
+           | Some verification_id ->
+             Verification_protocol.notify_approve_verification
+               ~task_id ~verifier:ctx.agent_name ~verification_id ~notes);
           (* Record a CDAL verdict attribution on the approval leg so the
              dashboard gets a complete audit line.  With the verification
              FSM enabled, tasks reach Done via approve_verification rather
@@ -952,7 +965,8 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
              contracts are present.  The rejection string is intentionally
              dropped — the verifier keeper has already judged the task,
              we only want the [Dashboard_attribution] side effect that
-             [gate_check] performs internally. *)
+             [gate_check] performs internally.  This runs independently
+             of verification_id presence. *)
           if Env_config_runtime.Cdal.gate_enabled () then
             ignore
               (Cdal_verdict_gate.gate_check
@@ -961,9 +975,14 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
                  ~task_id ())
         | Masc_domain.Reject_verification ->
           let reason = if not (String.equal notes "") then notes else reason in
-          let verification_id = Option.value ~default:"" verification_id_before in
-          Verification_protocol.notify_reject_verification
-            ~task_id ~verifier:ctx.agent_name ~verification_id ~reason;
+          (match verification_id_before with
+           | None ->
+             Log.Task.warn
+               "reject_verification action for task %s without verification_id_before (skipping notify)"
+               task_id
+           | Some verification_id ->
+             Verification_protocol.notify_reject_verification
+               ~task_id ~verifier:ctx.agent_name ~verification_id ~reason);
           if Env_config_runtime.Cdal.gate_enabled () then
             ignore
               (Cdal_verdict_gate.gate_check


### PR DESCRIPTION
## 목적

`tool_task.ml`의 `Approve_verification`/`Reject_verification` arm 2곳에서 `Option.value ~default:"" verification_id_before` 패턴으로 **silent default**가 invalid empty-string verification_id를 만들어 `notify_*`를 호출. RFC-0088 §1 "silent fallback default" 워크어라운드 시그니처.

## 변경 (minimal scope)

1 파일, +26 / -7:
- line 943 `Approve_verification` arm: `Option.value ~default:""` 제거 → `match verification_id_before with None -> Log.Task.warn ... | Some id -> notify_*`
- line 964 `Reject_verification` arm: 같은 패턴
- CDAL `gate_check`는 verification_id 비의존이므로 *양쪽 브랜치 모두에서* 실행 (Dashboard_attribution coverage 보존)

## 왜 root-fix인가

`Approve_verification`/`Reject_verification` action이 verification_id 없이 *논리적으로 valid*할 수 없습니다. 이전 코드는 None을 empty string `""`로 변환해 `Verification_protocol.notify_approve_verification ~verification_id:""` 같은 *명백히 invalid* 호출을 *silent*하게 만듦. board-slo-extractor.sh가 추적 중인 `pending_verification_gt_48h = 4`의 일부가 이 silent path의 결과일 가능성.

## Scope 밖 (별도 후속 PR / RFC-0109 amend)

더 깊은 root-fix: `Masc_domain.task_action` ADT에서 `Approve_verification`/`Reject_verification`가 verification_id payload를 *강제 캐리*하게 widen — None 케이스가 *컴파일 시점에 불가능*해짐. 그건 ADT 변경 + producer 사이트 ripple로 별도 PR.

## 워크어라운드 audit

- [x] 카운터-as-fix 없음 (Log.Task.warn은 visibility 추가일 뿐 silent를 noisy로 *전환* — silent default 자체 *제거*)
- [x] string/prefix 분류기 없음
- [x] catch-all 없음 (Option match exhaustive)
- [x] N-of-M 없음 (두 같은 사이트를 *같은 PR*에서 동시 fix — N-of-M의 반대)
- [x] cap/cooldown/dedup 없음

## 검증

local build skipped (4 concurrent bare-dune lock) — CI 위임. `Log.Task.warn` 시그니처는 line 975의 `Log.Task.error` 형식과 정합. 컴파일러 검증 0 risk.

## Best Programmer self-review

- 목표: `Option.value ~default:""` silent fallback 2 사이트 제거 — verification 도메인 한정.
- 변경 파일: 1 (tool_task.ml)
- 로컬 검증: `rg 'Option.value.*default.*"".*verification'` 잔존 0 확인
- 미검증: full dune build → CI

Co-Authored-By: Claude Opus 4.7