### PR TITLE
fix(dashboard): type OasKeeperLifecycleEvent.phase as KeeperPhase | null (audit F2)

### DIFF
--- a/dashboard/src/oas-runtime-store.test.ts
+++ b/dashboard/src/oas-runtime-store.test.ts
@@ -144,10 +144,12 @@ describe('oas-runtime-store', () => {
 
     expect(oasHealthSummary.value.totalEvents).toBe(1)
     expect(oasHealthSummary.value.agentEventsCount).toBe(1)
+    // Wire format is lowercase (backend `phase_to_string`); the factory
+    // normalizes to PascalCase `KeeperPhase` for frontend consistency.
     expect(oasAgentEvents.value[0]).toMatchObject({
       type: 'keeper_lifecycle',
       keeper_name: 'keeper-a',
-      phase: 'running',
+      phase: 'Running',
       event: 'started',
       detail: 'supervised',
     })

--- a/dashboard/src/oas-runtime-store.ts
+++ b/dashboard/src/oas-runtime-store.ts
@@ -1,5 +1,6 @@
 import { appendLiveOasEvent } from './components/session-trace/session-trace-live-store'
 import { isRecord, asNumber, asString } from './components/common/normalize'
+import { toKeeperPhase } from './keeper-store-normalize'
 import { fetchTelemetry, type TelemetryEntry } from './api/dashboard'
 import { OAS_TELEMETRY_REPLAY_LIMIT } from './config/constants'
 import {
@@ -273,7 +274,7 @@ function keeperLifecycleEvent(event: OasRuntimeEnvelope): OasKeeperLifecycleEven
     actor_kind: 'keeper',
     keeper_name: keeperName,
     event: asString(payload.event),
-    phase: asString(payload.phase),
+    phase: toKeeperPhase(asString(payload.phase)),
     detail: asString(payload.detail),
     event_type: runtimeEventType(event),
     correlation_id: asString(event.correlation_id),

--- a/dashboard/src/store.test.ts
+++ b/dashboard/src/store.test.ts
@@ -107,7 +107,7 @@ describe('oasHealthSummary', () => {
       agent_name: 'dreamer',
       timestamp: 1,
       event_key: 'lifecycle',
-      phase: 'running',
+      phase: 'Running',
       detail: 'started',
     } satisfies OasAgentEvent)
     expect(oasHealthSummary.value.agentEventsCount).toBe(2)

--- a/dashboard/src/types/oas.ts
+++ b/dashboard/src/types/oas.ts
@@ -2,6 +2,8 @@
 // Keep this slice as a discriminated union so each event kind has a stable
 // contract instead of one wide product type with many unrelated optionals.
 
+import type { KeeperPhase } from './core'
+
 interface OasAgentEventBase {
   agent_name: string
   event_type?: string
@@ -33,12 +35,21 @@ interface OasAgentActionExecutedEvent extends OasAgentEventBase {
   success?: boolean
 }
 
+// `phase` is the keeper FSM phase at emit time. Backend emits the
+// lowercase wire form via `Keeper_state_machine.phase_to_string`
+// (lib/cascade/cascade_events.ml:170–179); the factory in
+// `oas-runtime-store.ts` normalizes it to the canonical PascalCase
+// `KeeperPhase` so consumers don't carry around two casing forms.
+// `null` means either the lifecycle event genuinely had no phase
+// (e.g. a `Custom_event` with `phase = None`) or the wire value
+// didn't match any known variant — both cases collapse to the same
+// "no typed phase" state.
 export interface OasKeeperLifecycleEvent extends OasAgentEventBase {
   type: 'keeper_lifecycle'
   actor_kind: 'keeper'
   keeper_name?: string
   event?: string
-  phase?: string
+  phase?: KeeperPhase | null
   detail?: string
 }
 


### PR DESCRIPTION
## Summary

Dashboard SSOT audit (2026-05-19 P0) finding **F2** — \`OasKeeperLifecycleEvent.phase\` 가 \`string\` 으로 untyped. backend 가 *같은 KeeperPhase variant set* 를 emit 하지만 wire boundary 가 약화됨.

## Why

Backend wire path:

\`\`\`
publish_keeper_lifecycle (cascade_events.ml:170)
  → phase_json = \`String (Keeper_state_machine.phase_to_string phase)
\`\`\`

\`phase_to_string\` 의 13 entries (offline/running/.../zombie) 가 *frontend* \`KeeperPhase\` union 의 13 PascalCase variants 와 정확히 대응. 그러나 OAS event factory 에서 \`asString\` 만 호출 → frontend 가 raw lowercase string 을 들고 다니며 typed 우회.

## What Changed

- \`types/oas.ts\`: \`phase?: string\` → \`phase?: KeeperPhase | null\`
- \`oas-runtime-store.ts\` factory: \`phase: toKeeperPhase(asString(payload.phase))\` — single boundary conversion
- consumer (oas-runtime-store.ts:386, 396 / keeper-fsm-specs.ts) 는 PascalCase 받음 — frontend 일관성 유지
- 2 tests updated: input 은 wire format lowercase 유지, expected output 이 PascalCase

## Trade-off

- *시각 변경*: live-trace summary 가 \"... build · running · ...\" → \"... build · Running · ...\". 같은 의미, 다른 표기. frontend 다른 곳 모두 PascalCase 이므로 *오히려 정합*.
- 회귀 위험: 없음. typecheck + test 검증
- 향후 backend 가 새 phase variant 추가 시 frontend KeeperPhase + BACKEND_PHASE_MAP 동시 update 필요 — A1 (#16662) 의 coverage check 가 frontend 누락을 build-time fail

## Backend SSOT

- Variant 정의: \`lib/keeper/keeper_state_machine.ml:6–19\` (13 arms)
- Wire emit: \`lib/cascade/cascade_events.ml:170–179 publish_keeper_lifecycle\`

## Test plan

- [x] \`pnpm typecheck\` PASS
- [x] 18/18 tests PASS (oas-runtime-store + store)
- [ ] human review

## Related

- Audit A1 (#16662 — BACKEND_PHASE_MAP coverage check) — backend variant 추가 시 frontend KeeperPhase 강제 update 메커니즘 (본 PR 의 SSOT 가 그 가드 통해 enforce 됨)
- Dashboard SSOT/IA audit 2026-05-19 (F2)

RFC-WAIVED: typed sum hardening, no architectural change

🤖 Generated with [Claude Code](https://claude.com/claude-code)