### PR TITLE
docs(rfc-0137): add Step A baseline + RFC-0097 deployment drift evidence (§1.1 follow-up)

### DIFF
--- a/docs/rfc/RFC-0137-host-fd-pressure-keeper-pause.md
+++ b/docs/rfc/RFC-0137-host-fd-pressure-keeper-pause.md
@@ -39,6 +39,8 @@ framework — Docker Desktop's VM backend). Same-day reproduction at
 | 22:02 | ~368K | **75%** | (estimated 350K+) | **+51%p / 18min** |
 | 22:04 | — | — | — | `bash mkdir` returns ENFILE |
 | 22:05 (after user `killall -9 com.apple.Virtualization.VirtualMachine`) | 129,641 | 26% | XPC GONE | −239K recovered |
+| 22:10 (post Docker reboot baseline) | 75,875 | 15% | new XPC pid 37573, 2,778 fds | clean baseline |
+| 22:53 (43 min after baseline, under normal 16-keeper load) | 65,842 | 13% | XPC pid 89896, **55,545 fds** | **+20.5 fds/sec sustained** even with RFC-0097 (PR #15728) deployed |
 
 Single XPC process owned **>90%** of the system FD table immediately
 before the CRIT. FD type breakdown at 21:41:


### PR DESCRIPTION
## 목표

RFC-0137 §1.1 표에 **PR #16665 머지 직전** 측정한 두 row 추가.

PR #16665는 이미 main 머지 완료 (`0d8b46e7e7`). 머지 직전 수집한 후속 evidence가 별도 commit에 있었으나 post-merge timing으로 main 진입 못 함 — supersedes로 별도 PR.

## 변경

| 파일 | 변경 |
|---|---|
| `docs/rfc/RFC-0137-host-fd-pressure-keeper-pause.md` | §1.1 표 2 row 추가 (22:10 baseline + 22:53 RFC-0097 deployment drift) |

## evidence 핵심

- **22:10**: Docker 재시작 직후 clean baseline (2,778 fds on new XPC pid 37573)
- **22:53**: 43분 후, 16-keeper 정상 부하 (55,545 fds on XPC pid 89896)
- **drift rate: +20.5 fds/sec sustained** — RFC-0097 (sandbox container reuse PR #15728) 머지된 상태에서도 누적 진행

## 왜 중요한가

RFC-0137 §9 sunset criteria가 "RFC-0097 steady state"를 trigger 조건으로 명시. 이 evidence는 그 조건이 **아직 만족 안 됐다**는 측정값 — RFC-0137 가치의 empirical baseline.

## 로컬 검증

docs-only change, 코드 변경 0. `dune build` 무관.

## Supersedes

- PR #16665 (이미 머지됨)
- branch `rfc/0137-host-fd-pressure`의 post-merge commit `1066a87cc7`를 cherry-pick

🤖 Generated with [Claude Code](https://claude.com/claude-code)