### PR TITLE
refactor(dashboard): RFC-0135 PR-11 phaseTone + running predicate SSOT extraction

### DIFF
--- a/dashboard/src/components/keeper-action-panel.ts
+++ b/dashboard/src/components/keeper-action-panel.ts
@@ -33,6 +33,7 @@ import type { Keeper } from '../types'
 import {
   isKeeperOffline,
   isKeeperPaused,
+  isKeeperRunningExcludingRestarting,
   keeperIsStuckOnRecoverableBlocker,
 } from '../lib/keeper-predicates'
 
@@ -91,30 +92,17 @@ export function keeperActionVisibility(keeper: Keeper): {
   canBoot: boolean
   canShutdown: boolean
 } {
-  // RFC-0135 PR-3: paused / offline / stuck-on-recoverable predicates
-  // come from the canonical SSOT (`lib/keeper-predicates.ts`). Only the
-  // "running" axis stays inline — it is action-panel-specific (a strict
-  // subset of typed-state `running` that explicitly excludes
-  // `restarting`, which the `canWake` branch treats as stuck).
-  const status = (keeper.status ?? '').toLowerCase()
-  const phase = (keeper.phase ?? '').toString().toLowerCase()
-  const isRunning =
-    status === 'active' ||
-    status === 'running' ||
-    status === 'idle' ||
-    status === 'busy' ||
-    phase === 'running' ||
-    phase === 'failing' ||
-    phase === 'overflowed' ||
-    phase === 'compacting' ||
-    phase === 'handing_off' ||
-    phase === 'draining'
-
+  // RFC-0135 PR-11: every visibility axis routes through SSOT predicates
+  // in `lib/keeper-predicates.ts`. The previous 10-literal inline OR
+  // chain for `isRunning` (with self-doc admitting the duplication) was
+  // promoted to `isKeeperRunningExcludingRestarting` so a new lifecycle
+  // phase added to the running cluster updates every consumer at once.
   const isPaused = isKeeperPaused(keeper)
   const isOffline = isKeeperOffline(keeper)
+  const isRunning = isKeeperRunningExcludingRestarting(keeper)
   // `restarting` is a kicked-but-not-yet-running state — treat as stuck
   // so the wakeup action stays visible until the keeper resumes ticks.
-  const isStuck = phase === 'restarting' || keeperIsStuckOnRecoverableBlocker(keeper)
+  const isStuck = keeper.phase === 'Restarting' || keeperIsStuckOnRecoverableBlocker(keeper)
 
   return {
     canPause:    isRunning && !isPaused,

--- a/dashboard/src/components/keeper-fsm-specs.ts
+++ b/dashboard/src/components/keeper-fsm-specs.ts
@@ -2,6 +2,7 @@
 // Each returns an FsmGraphSpec consumed by CytoscapeFsm.
 
 import type { FsmGraphSpec, FsmNode, FsmEdge } from './common/cytoscape-fsm'
+import { compositePhaseTone, toKsmPhase } from '../lib/keeper-operational-state'
 
 
 // ================================================================
@@ -136,21 +137,14 @@ function clusterNodes(
 }
 
 export function buildCompositeFsmSpec(params: CompositeFsmParams): FsmGraphSpec {
-  const ksmTone: 'active' | 'warn' | 'err' =
-    (params.phase === 'failing'
-      || params.phase === 'stopped'
-      || params.phase === 'crashed'
-      || params.phase === 'dead'
-      || params.phase === 'zombie')
-      ? 'err'
-      : (params.phase === 'overflowed'
-        || params.phase === 'compacting'
-        || params.phase === 'handing_off'
-        || params.phase === 'draining'
-        || params.phase === 'paused'
-        || params.phase === 'restarting')
-        ? 'warn'
-        : 'active'
+  // RFC-0135 PR-11: phase tone derivation moved to SSOT
+  // (`compositePhaseTone` in `lib/keeper-operational-state.ts`). Same 6
+  // warn-phase literals were copy-pasted between this builder and
+  // `fsm-hub-invariant-analysis.ts` (N-of-M anti-pattern). Unknown wire
+  // values fall back to 'active' to match the previous fall-through
+  // semantics of the inline OR chain.
+  const ksmPhase = toKsmPhase(params.phase)
+  const ksmTone: 'active' | 'warn' | 'err' = ksmPhase === null ? 'active' : compositePhaseTone(ksmPhase)
   const nodes: FsmNode[] = [
     ...clusterNodes('KSM', 'KSM · keeper lifecycle', KSM_STATES, params.phase, ksmTone),
     ...clusterNodes('KTC', 'KTC · turn cycle', KTC_STATES, params.turnPhase, 'active'),

--- a/dashboard/src/lib/keeper-operational-state.test.ts
+++ b/dashboard/src/lib/keeper-operational-state.test.ts
@@ -3,7 +3,12 @@ import type { Keeper, KeeperRuntimeBlockerClass } from '../types/core'
 import { KEEPER_RUNTIME_BLOCKER_CLASSES } from '../types/core'
 import type { KeeperCompositeSnapshot } from '../api/schemas/keeper-composite'
 import {
+  compositeIsRunning,
+  compositeIsTurnIdle,
+  compositePhaseTone,
   deriveKeeperOperationalState,
+  toKsmPhase,
+  type KeeperKsmPhase,
   type KeeperOperationalState,
 } from './keeper-operational-state'
 
@@ -381,3 +386,54 @@ interface DeriveInputsLite {
   keeper: Keeper
   composite: KeeperCompositeSnapshot | null
 }
+
+describe('toKsmPhase — RFC-0135 PR-11 wire-boundary narrow', () => {
+  it.each<KeeperKsmPhase>([
+    'offline', 'running', 'failing', 'overflowed', 'compacting',
+    'handing_off', 'draining', 'paused', 'stopped', 'crashed',
+    'restarting', 'dead', 'zombie',
+  ])('accepts canonical KSM phase %s', (phase) => {
+    expect(toKsmPhase(phase)).toBe(phase)
+  })
+  it('returns null on unknown string', () => {
+    expect(toKsmPhase('plotting_revenge')).toBeNull()
+  })
+  it('returns null on null/undefined', () => {
+    expect(toKsmPhase(null)).toBeNull()
+    expect(toKsmPhase(undefined)).toBeNull()
+  })
+  it('returns null on empty string', () => {
+    expect(toKsmPhase('')).toBeNull()
+  })
+})
+
+describe('compositePhaseTone — RFC-0135 PR-11 exhaustive switch', () => {
+  it.each<KeeperKsmPhase>(['offline', 'running'])('phase %s ⇒ active', (phase) => {
+    expect(compositePhaseTone(phase)).toBe('active')
+  })
+  it.each<KeeperKsmPhase>([
+    'overflowed', 'compacting', 'handing_off', 'draining', 'paused', 'restarting',
+  ])('phase %s ⇒ warn', (phase) => {
+    expect(compositePhaseTone(phase)).toBe('warn')
+  })
+  it.each<KeeperKsmPhase>([
+    'failing', 'stopped', 'crashed', 'dead', 'zombie',
+  ])('phase %s ⇒ err', (phase) => {
+    expect(compositePhaseTone(phase)).toBe('err')
+  })
+})
+
+describe('compositeIsRunning / compositeIsTurnIdle — wire-format helpers', () => {
+  it('phase=running ⇒ true', () => {
+    expect(compositeIsRunning({ phase: 'running' })).toBe(true)
+  })
+  it('phase=paused ⇒ false', () => {
+    expect(compositeIsRunning({ phase: 'paused' })).toBe(false)
+  })
+  it('turn_phase=idle ⇒ true', () => {
+    expect(compositeIsTurnIdle({ turn_phase: 'idle' })).toBe(true)
+  })
+  it('turn_phase=executing ⇒ false', () => {
+    expect(compositeIsTurnIdle({ turn_phase: 'executing' })).toBe(false)
+  })
+})

--- a/dashboard/src/lib/keeper-operational-state.ts
+++ b/dashboard/src/lib/keeper-operational-state.ts
@@ -144,3 +144,91 @@ function compositeFiberKnownDead(c: KeeperCompositeSnapshot): boolean {
   const fiberAlive = diag.conditions.fiber_alive
   return fiberAlive === false
 }
+
+// RFC-0135 PR-11 — Composite KSM phase SSOT helpers.
+//
+// `KeeperCompositeSnapshot.phase` is wire-format lowercase emitted by
+// backend `lib/server/server_dashboard_http.ml` and typed as bare
+// `string` in `api/schemas/keeper-composite.ts`. Three call sites had
+// re-implemented phase grouping inline:
+//   - keeper-fsm-specs.ts:140-150   (ksmTone — 11-literal 2-tier OR)
+//   - fsm-hub-invariant-analysis.ts:74-186  (8 literal compares)
+//   - fleet-fsm-matrix.ts:262,486,497  (running/idle compares)
+// Same 6 warn-phase literals were copy-pasted between fsm-specs and
+// invariant-analysis (N-of-M anti-pattern; software-development.md
+// §AI 코드 생성 안티패턴 #2).
+//
+// `KeeperKsmPhase` is the closed sum of states emitted by the backend
+// KeeperStateMachine TLA spec (KSM_STATES in keeper-fsm-specs.ts).
+// `compositePhaseTone` is total and exhaustive — adding a new variant
+// here requires touching every consumer at compile time.
+
+export type KeeperKsmPhase =
+  | 'offline'
+  | 'running'
+  | 'failing'
+  | 'overflowed'
+  | 'compacting'
+  | 'handing_off'
+  | 'draining'
+  | 'paused'
+  | 'stopped'
+  | 'crashed'
+  | 'restarting'
+  | 'dead'
+  | 'zombie'
+
+const KSM_PHASE_VALUES: ReadonlySet<string> = new Set<KeeperKsmPhase>([
+  'offline', 'running', 'failing', 'overflowed', 'compacting',
+  'handing_off', 'draining', 'paused', 'stopped', 'crashed',
+  'restarting', 'dead', 'zombie',
+])
+
+/** Narrow `string` to `KeeperKsmPhase` if it is a known value, else
+ *  return `null`. Use at the schema/wire boundary; downstream code
+ *  should consume the typed sum directly. */
+export function toKsmPhase(raw: string | null | undefined): KeeperKsmPhase | null {
+  if (raw == null) return null
+  return KSM_PHASE_VALUES.has(raw) ? (raw as KeeperKsmPhase) : null
+}
+
+/** Three-valued tone classification used by FSM-graph node rendering
+ *  and invariant cards: terminal/error phases → 'err', long-running
+ *  rare-state phases → 'warn', live forward-progress phases → 'active'.
+ *
+ *  Exhaustive over `KeeperKsmPhase`. If TypeScript reports a missing
+ *  case after adding a new variant, route it to the appropriate tone —
+ *  do not add a `default:` (RFC-0135 §9-4 forbids catch-all). */
+export function compositePhaseTone(phase: KeeperKsmPhase): 'active' | 'warn' | 'err' {
+  switch (phase) {
+    case 'offline':
+    case 'running':
+      return 'active'
+    case 'overflowed':
+    case 'compacting':
+    case 'handing_off':
+    case 'draining':
+    case 'paused':
+    case 'restarting':
+      return 'warn'
+    case 'failing':
+    case 'stopped':
+    case 'crashed':
+    case 'dead':
+    case 'zombie':
+      return 'err'
+  }
+}
+
+/** Composite snapshot is in the "running" KSM bucket. Mirrors the
+ *  semantic of `state.kind === 'running'` for typed-keeper SSOT but
+ *  operates on the lowercase wire format from composite snapshots. */
+export function compositeIsRunning(snapshot: { phase: string }): boolean {
+  return snapshot.phase === 'running'
+}
+
+/** Composite snapshot is in the "idle" KTC turn-phase bucket.
+ *  Lowercase wire format. */
+export function compositeIsTurnIdle(snapshot: { turn_phase: string }): boolean {
+  return snapshot.turn_phase === 'idle'
+}

--- a/dashboard/src/lib/keeper-predicates.test.ts
+++ b/dashboard/src/lib/keeper-predicates.test.ts
@@ -3,6 +3,7 @@ import type { Keeper } from '../types/core'
 import {
   isKeeperPaused,
   isKeeperOffline,
+  isKeeperRunningExcludingRestarting,
   keeperIsStuckOnRecoverableBlocker,
   keeperCanWakeup,
 } from './keeper-predicates'
@@ -76,5 +77,26 @@ describe('keeperCanWakeup', () => {
   })
   it('offline keeper ⇒ cannot wake', () => {
     expect(keeperCanWakeup(k({ phase: 'Crashed' }))).toBe(false)
+  })
+})
+
+describe('isKeeperRunningExcludingRestarting — RFC-0135 PR-11', () => {
+  it.each([
+    ['active'], ['running'], ['idle'], ['busy'],
+  ])('status=%s ⇒ running', (status) => {
+    expect(isKeeperRunningExcludingRestarting(k({ status }))).toBe(true)
+  })
+  it.each([
+    ['Running'], ['Failing'], ['Overflowed'], ['Compacting'], ['HandingOff'], ['Draining'],
+  ])('phase=%s ⇒ running', (phase) => {
+    expect(isKeeperRunningExcludingRestarting(k({ status: 'unknown', phase: phase as Keeper['phase'] }))).toBe(true)
+  })
+  it('Restarting phase ⇒ NOT running (action panel treats as stuck)', () => {
+    expect(isKeeperRunningExcludingRestarting(k({ status: 'unknown', phase: 'Restarting' }))).toBe(false)
+  })
+  it.each([
+    ['Offline'], ['Stopped'], ['Crashed'], ['Dead'], ['Zombie'], ['Paused'],
+  ])('phase=%s ⇒ NOT running', (phase) => {
+    expect(isKeeperRunningExcludingRestarting(k({ status: 'unknown', phase: phase as Keeper['phase'] }))).toBe(false)
   })
 })

--- a/dashboard/src/lib/keeper-predicates.ts
+++ b/dashboard/src/lib/keeper-predicates.ts
@@ -74,3 +74,46 @@ export function keeperCanWakeup(keeper: Keeper): boolean {
   if (keeperIsStuckOnRecoverableBlocker(keeper)) return true
   return !isKeeperPaused(keeper) && !isKeeperOffline(keeper)
 }
+
+// RFC-0135 PR-11 — running predicate excluding `Restarting`.
+//
+// The action panel's `canPause`/`canWake` gates treat `Restarting` as
+// "stuck" (kicked but not yet running), not "running". This subset of
+// the SSOT running variant is action-panel-specific but had been
+// inlined as a 10-literal OR chain at keeper-action-panel.ts:99-117
+// with a self-doc comment admitting the duplication. The full literal
+// set lives here so a new lifecycle phase added to the running cluster
+// is reflected in every consumer at once.
+const RUNNING_STATUS_TOKENS = new Set<string>([
+  'active',
+  'running',
+  'idle',
+  'busy',
+])
+
+const RUNNING_PHASES_EXCLUDING_RESTARTING: ReadonlySet<string> = new Set<string>([
+  'Running',
+  'Failing',
+  'Overflowed',
+  'Compacting',
+  'HandingOff',
+  'Draining',
+])
+
+/** Keeper is "running" for action-panel purposes — turn-producing,
+ *  alive, but explicitly *not* `Restarting`. The action panel routes
+ *  `Restarting` to the wakeup branch (kicked-but-not-ticking) rather
+ *  than the pause branch, so a single SSOT predicate must distinguish.
+ *
+ *  Strict subset of `deriveKeeperOperationalState(...).kind === 'running'`
+ *  — it excludes the `Restarting` phase the typed state currently maps
+ *  to `running`. When `KeeperOperationalState` gains a dedicated
+ *  `restarting` variant (RFC-0135 follow-up Goal-2), this predicate
+ *  collapses to that check. */
+export function isKeeperRunningExcludingRestarting(keeper: Keeper): boolean {
+  const status = (keeper.status ?? '').toLowerCase()
+  if (RUNNING_STATUS_TOKENS.has(status)) return true
+  const phase = keeper.phase
+  if (typeof phase === 'string' && RUNNING_PHASES_EXCLUDING_RESTARTING.has(phase)) return true
+  return false
+}


### PR DESCRIPTION
## Summary

Closes 2026-05-19 audit findings **A3 (CRITICAL)** + **A4 (HIGH)**:
- A3: `keeper-fsm-specs.ts:140-150` 11-literal 2-tier OR for `ksmTone` (same 6 warn-phase literals copy-pasted to `fsm-hub-invariant-analysis.ts` — N-of-M anti-pattern)
- A4: `keeper-action-panel.ts:99-117` 10-literal `isRunning` with self-doc *admitting* the duplication

## New SSOT helpers

### `lib/keeper-operational-state.ts`
- `KeeperKsmPhase` — closed sum (13 lowercase KSM wire variants)
- `toKsmPhase(raw)` — narrow `string` → `KeeperKsmPhase | null` (wire boundary)
- `compositePhaseTone(phase): 'active'|'warn'|'err'` — exhaustive switch (no catch-all, RFC §9-4)
- `compositeIsRunning(snapshot)` + `compositeIsTurnIdle(snapshot)` — wire-format helpers

### `lib/keeper-predicates.ts`
- `isKeeperRunningExcludingRestarting(keeper)` — strict subset of `state.kind === 'running'` excluding `Restarting` (action-panel-specific semantic: kicked-but-not-ticking → wakeup branch)

## Migrations

| Site | Before | After |
|------|--------|-------|
| `keeper-fsm-specs.ts:140-150` | 11-literal 2-tier OR | `compositePhaseTone(toKsmPhase(params.phase) ?? ...)` |
| `keeper-action-panel.ts:99-117` | 10-literal `isRunning` + `phase === 'restarting'` | `isKeeperRunningExcludingRestarting(keeper)` + `keeper.phase === 'Restarting'` (typed PascalCase) |

## Scope cut (deferred)

A5 helper-ready (`compositeIsRunning`/`compositePhaseTone` exposed) but call-site migration in `fsm-hub-invariant-analysis.ts` + `fleet-fsm-matrix.ts` deferred — those 11 sites are *individual invariant analyses* (each literal is a semantic check, not a grouping). Helper available; rewrite is its own PR.

## Verification
- [x] `pnpm typecheck` → pass
- [x] `pnpm vitest run keeper-operational-state keeper-predicates keeper-action-panel` → **109/109 pass** (+50 new tests)
- [x] `bash scripts/lint/dashboard-ssot-keeper-state.sh` → exit 0 (clean)
- [x] diff: 6 files, +226/-35

## RFC reference
RFC-0135-dashboard-keeper-operational-ssot.md §1.5 (C5) + §2 (typed model) + §9-4 (no catch-all).
Audit report: `~/me/.tmp/masc-dashboard-ssot-audit-2026-05-19.html` Goal-3.

RFC-WAIVED: N/A — strengthens existing RFC-0135 SSOT.

---

Status: Draft — agent PR. Ready 전환은 사용자 라벨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>