### PR TITLE
audit(dashboard): backend keeper_meta_contract blocker_class coverage check (#16638 follow-up)

### DIFF
--- a/dashboard/src/lib/runtime-blocker-class.ts
+++ b/dashboard/src/lib/runtime-blocker-class.ts
@@ -18,3 +18,65 @@ export function asKeeperRuntimeBlockerClass(
   if (trimmed === '') return null
   return isKeeperRuntimeBlockerClass(trimmed) ? trimmed : null
 }
+
+// ─────────────────────────────────────────────────────────────────────
+// Backend ↔ frontend variant coverage check
+//
+// Source of truth: `lib/keeper/keeper_meta_contract.ml:91 type blocker_class`
+//   + `blocker_class_to_string` (`lib/keeper/keeper_meta_contract.ml:137–164`).
+//
+// Backend emits exactly these 24 lowercase wire strings (verified by
+// `Keeper_synthetic_marker` audit, 2026-05-19). The list below is the
+// *frozen* mirror — keep it 1:1 with `keeper_meta_contract.ml`.
+//
+// Status bridge (`lib/keeper/keeper_status_bridge.ml`) emits two
+// additional dashboard-only synthetic classes (`synthetic_stall`,
+// `self_imposed_idle`) and the runtime trust pipeline emits
+// dashboard-conditioned ones (`provider_runtime_error`,
+// `tool_required_unsatisfied`, `stale_termination_storm`,
+// `heartbeat_failures`, `turn_failures`, `exception`,
+// `awaiting_operator`, `awaiting_sandbox_egress`, `supervisor_paused`).
+// These are NOT in `keeper_meta_contract` and so do not appear in this
+// coverage list; they are validated separately by
+// `KEEPER_RUNTIME_BLOCKER_CLASSES` membership.
+//
+// Drift discipline:
+//   - new backend `keeper_meta_contract` variant → add a lowercase
+//     entry here AND to `types/core.ts:KEEPER_RUNTIME_BLOCKER_CLASSES`
+//   - if the lowercase entry is added here but not in the frontend
+//     union, `_BackendCoverageDelta` resolves to that string literal
+//     and the `true` constant below fails to assign — typecheck stops
+//     the drift at build time.
+
+const BACKEND_KEEPER_META_BLOCKER_CLASSES = [
+  'cascade_exhausted',
+  'ambiguous_post_commit_timeout',
+  'ambiguous_post_commit_failure',
+  'autonomous_slot_wait_timeout',
+  'admission_queue_wait_timeout',
+  'turn_timeout_after_queue_wait',
+  'oas_timeout_budget',
+  'turn_timeout',
+  'turn_livelock_blocked',
+  'completion_contract_violation',
+  'no_tool_capable_provider',
+  'stay_silent_loop',
+  'fiber_unresolved',
+  'stale_turn_timeout',
+  'stale_fleet_batch',
+  'sdk_max_turns_exceeded',
+  'sdk_token_budget_exceeded',
+  'sdk_cost_budget_exceeded',
+  'sdk_unrecognized_stop_reason',
+  'sdk_idle_detected',
+  'sdk_tool_retry_exhausted',
+  'sdk_guardrail_violation',
+  'sdk_tripwire_violation',
+  'sdk_exit_condition_met',
+] as const
+
+type BackendKeeperMetaBlockerClass = typeof BACKEND_KEEPER_META_BLOCKER_CLASSES[number]
+type _BackendCoverageDelta = Exclude<BackendKeeperMetaBlockerClass, KeeperRuntimeBlockerClass>
+const _BACKEND_KEEPER_META_COVERAGE_CHECK:
+  [_BackendCoverageDelta] extends [never] ? true : _BackendCoverageDelta = true
+void _BACKEND_KEEPER_META_COVERAGE_CHECK


### PR DESCRIPTION
## Summary

Dashboard SSOT audit (2026-05-19 P0) — #16638 (\`turn_livelock_blocked\`) 의 후속. **24-arm 1:1 audit 완료** + build-time guard 추가.

## Audit 결과

Backend \`lib/keeper/keeper_meta_contract.ml:91 type blocker_class\` 의 24 arms 모두 frontend \`KEEPER_RUNTIME_BLOCKER_CLASSES\` 에 *1:1 매칭* 확인:

| # | Backend variant | Wire string | Frontend |
|---|---|---|---|
| 1 | \`Cascade_exhausted\` | \`cascade_exhausted\` | ✓ |
| 2 | \`Ambiguous_post_commit_timeout\` | \`ambiguous_post_commit_timeout\` | ✓ |
| 3 | \`Ambiguous_post_commit_failure\` | \`ambiguous_post_commit_failure\` | ✓ |
| 4 | \`Autonomous_slot_wait_timeout\` | \`autonomous_slot_wait_timeout\` | ✓ |
| 5 | \`Admission_queue_wait_timeout\` | \`admission_queue_wait_timeout\` | ✓ |
| 6 | \`Turn_timeout_after_queue_wait\` | \`turn_timeout_after_queue_wait\` | ✓ |
| 7 | \`Oas_timeout_budget\` | \`oas_timeout_budget\` | ✓ |
| 8 | \`Turn_timeout\` | \`turn_timeout\` | ✓ |
| 9 | \`Turn_livelock_blocked\` | \`turn_livelock_blocked\` | ✓ (added #16638) |
| 10 | \`Completion_contract_violation\` | \`completion_contract_violation\` | ✓ |
| 11 | \`No_tool_capable_provider\` | \`no_tool_capable_provider\` | ✓ |
| 12 | \`Stay_silent_loop\` | \`stay_silent_loop\` | ✓ |
| 13 | \`Fiber_unresolved\` | \`fiber_unresolved\` | ✓ |
| 14 | \`Stale_turn_timeout\` | \`stale_turn_timeout\` | ✓ |
| 15 | \`Stale_fleet_batch\` | \`stale_fleet_batch\` | ✓ |
| 16-24 | \`Sdk_*\` (9 arms) | \`sdk_*\` | ✓ all |

**결과**: 24/24 backend → frontend 1:1 ✓. 본 PR 이전 audit 시점에 누락 0건.

## Build-time guard

A1 (#16662) 와 동일 패턴:

\`\`\`ts
const BACKEND_KEEPER_META_BLOCKER_CLASSES = [
  'cascade_exhausted', ... // 24 entries mirroring keeper_meta_contract.ml
] as const

type _BackendCoverageDelta = Exclude<BackendMirrorUnion, KeeperRuntimeBlockerClass>
const _CHECK: [_BackendCoverageDelta] extends [never] ? true : _BackendCoverageDelta = true
\`\`\`

새 backend variant 추가 시:
1. 본 mirror 에 lowercase entry 추가 + \`KEEPER_RUNTIME_BLOCKER_CLASSES\` 추가 → typecheck PASS
2. mirror 만 추가, frontend 누락 → \`_Missing\` 이 누락 variant 의 string literal → \`true\` assignment fail → 빌드 깨짐 (오류 메세지에 누락 variant 이름)

## Frontend-only entries (의도된 제외)

11 entries (\`synthetic_stall\`, \`self_imposed_idle\`, \`provider_runtime_error\`, \`tool_required_unsatisfied\`, \`stale_termination_storm\`, \`heartbeat_failures\`, \`turn_failures\`, \`exception\`, \`awaiting_operator\`, \`awaiting_sandbox_egress\`, \`supervisor_paused\`) 는 \`keeper_meta_contract\` 외부 emit (status_bridge / runtime-trust pipeline). mirror 에서 의도적 제외. 본 가드는 \`keeper_meta_contract\` 24 arms 만 1:1 enforce.

## Test plan

- [x] 6/6 \`runtime-blocker-class\` tests PASS
- [x] guard logic 검증: 현재 union 정합 시 \`_BackendCoverageDelta = never\` → assignment PASS
- [ ] human review

## Pre-existing baseline

\`pnpm typecheck\` 전체 실행 시 \`src/namespace-truth-actions.ts:29\` 에 *unrelated* error 존재 — 본 PR 변경 *제거* 후에도 동일 reproduce. main-side baseline issue 로 본 PR scope 외. 별도 follow-up 필요.

## Related

- #16638 (turn_livelock_blocked add) — 본 PR 의 시초
- A1 #16662 (BACKEND_PHASE_MAP coverage check) — 동일 build-time enforcement 패턴
- F1 #16652 (✅ merged), F2 #16669 (Draft) — 같은 audit cycle
- Dashboard SSOT/IA audit 2026-05-19

RFC-WAIVED: audit + type-guard only

🤖 Generated with [Claude Code](https://claude.com/claude-code)