### PR TITLE
fix(build) + feat(keeper_schema): partial-match fix + voice_* schema declaration

### DIFF
--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -353,6 +353,22 @@ let keeper_schemas : tool_schema list = [
           ("type", `String "boolean");
           ("description", `String "If true, keeper can send proactive check-ins after idle periods. Defaults to false unless explicitly enabled.");
         ]);
+        ("policy_voice_enabled", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "Master switch for voice-bridge tool access. When false, the keeper cannot interact with the voice bridge regardless of the other voice_* fields. Defaults to keeper-profile setting.");
+        ]);
+        ("voice_enabled", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "Per-keeper runtime voice-bridge participation. Requires policy_voice_enabled=true to take effect. Defaults to keeper-profile setting.");
+        ]);
+        ("voice_channel", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional: voice-bridge channel handle the keeper joins when voice_enabled is true. Defaults to the keeper-profile channel.");
+        ]);
+        ("voice_agent_id", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional: voice-bridge agent identifier presented on the channel. Defaults to the keeper name.");
+        ]);
         ("proactive_idle_sec", `Assoc [
           ("type", `String "integer");
           ("description", `String "Idle seconds before proactive check-in is allowed (default: 900).");

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -109,6 +109,8 @@ let cascade_exhaustion_reason_code
   | Keeper_types.Candidates_filtered_after_cycles ->
     "cascade_exhausted_candidates_filtered"
   | Keeper_types.Max_turns_exceeded -> "cascade_exhausted_max_turns"
+  | Keeper_types.Structural_attempt_timeout _ ->
+    "cascade_exhausted_structural_attempt_timeout"
   | Keeper_types.Other_detail detail -> cascade_exhaustion_detail_code detail
 ;;
 


### PR DESCRIPTION
## Two-commit narrow PR

Both commits address typed-API drift surfaced during /loop Iter#48 scout sweep. They live together because the build-fix unblocks verification of the schema-declaration commit.

### Commit 1 — \`fix(keeper_unified_turn_types)\`: Structural_attempt_timeout exhaustive

\`cascade_exhaustion_reason_code\` in \`lib/keeper/keeper_unified_turn_types.ml\` matched 6 of 7 \`Keeper_types.cascade_exhaustion_reason\` variants. \`Structural_attempt_timeout\` (defined at \`lib/keeper/keeper_types.mli:167\`) was missing, and dune's \`-w +4\` flag promotes \`warning 8 partial-match\` to a build error. **Main was red** for any worktree built today.

\`\`\`ocaml
| Structural_attempt_timeout _ ->
  \"cascade_exhausted_structural_attempt_timeout\"
\`\`\`

This is the FSM-sparse-match anti-pattern documented in \`instructions/software-development.md §4\` — variant added without sweeping callers. The cure is exhaustive match, not a catch-all.

### Commit 2 — \`feat(keeper_schema)\`: declare voice_* fields in masc_keeper_up

The handler at \`lib/keeper/keeper_turn_up_args.ml:243-247\` reads four voice-bridge fields and persists them across the keeper subsystem (18 files reference these fields: \`keeper_meta_json_parse\`, \`keeper_types_profile\`, \`keeper_runtime\`, \`keeper_persona_authoring\`, \`keeper_exec_persona\`, etc.):

- \`policy_voice_enabled\` (boolean) — master switch for voice-bridge tool access
- \`voice_enabled\` (boolean) — per-keeper runtime participation
- \`voice_channel\` (string) — channel handle
- \`voice_agent_id\` (string) — agent identifier on the channel

**But none were declared in the JSON schema** (\`keeper_schema.ml masc_keeper_up\` entry, L289-422). LLM callers had no machine-readable way to discover this configuration surface — a HIDDEN API. The fields *work* if sent, but no caller sees them.

Add the four field declarations after \`proactive_enabled\` (adjacent boolean configuration). Descriptions match runtime semantics. **No behavioural change**; pure schema-advertisement fix.

### Why two commits in one PR

| | Standalone fix-build PR | Standalone schema PR | Combined |
|--|--|--|--|
| Reviewer burden | 2 PRs to track | 1 PR but stale because main was red | 1 PR |
| Verify schema build clean | impossible (main red) | impossible | yes |
| Bisect granularity | preserved | preserved | preserved (commits are separable) |

Combined keeps each commit reviewable in isolation while still unblocking verification.

### Verification

\`\`\`
dune build --root . @check       # clean (was failing before commit 1)
\`\`\`

The schema change does not alter any tool dispatch or input parser — handlers already read these fields. The change is purely in what the LLM sees when querying the tool catalog.

### Touch points

- \`lib/keeper/keeper_unified_turn_types.ml\`: +2 (one missing match arm)
- \`lib/keeper/keeper_schema.ml\`: +16 (four field declarations)

### Reference

Scout sweep, 2026-05-19 /loop Iter#48. Sibling findings (schema mismatch in \`masc_board_post post_kind\`, timeout 600× discrepancy in ollama probe, raw FS API in 8 sites) deferred to follow-up tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>