### PR TITLE
refactor(keeper_registry): extract tool-usage disk persistence (godfile decomp)

### DIFF
--- a/lib/keeper/keeper_heartbeat_snapshot.ml
+++ b/lib/keeper/keeper_heartbeat_snapshot.ml
@@ -477,7 +477,7 @@ let write_heartbeat_snapshot
          ~message_count:message_count_v
      | None -> ());
     (try
-       Keeper_registry.flush_tool_usage ~base_path:ctx.config.base_path meta_current.name
+       Keeper_registry_tool_usage_persistence.flush ~base_path:ctx.config.base_path meta_current.name
      with
      | Eio.Cancel.Cancelled _ as e -> raise e
      | exn ->

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -683,7 +683,7 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
         Keeper_registry.register_offline ~base_path:ctx.config.base_path m.name m
       in
       (* Restore persisted tool usage stats from previous session *)
-      Keeper_registry.restore_tool_usage ~base_path:ctx.config.base_path m.name;
+      Keeper_registry_tool_usage_persistence.restore ~base_path:ctx.config.base_path m.name;
       let stop = reg.fiber_stop in
       let wakeup = reg.fiber_wakeup in
       (* Start optional gRPC heartbeat fiber *)

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1488,103 +1488,16 @@ let tool_usage_of ~base_path name =
 
 (* Lookup API (find_by_name / find_by_agent_name / find_by_id /
    tool_usage_of_by_name / resolve_config) moved to
-   Keeper_registry_lookup. *)
+   Keeper_registry_lookup.
 
-(* -- Tool usage persistence ---------------------------------------- *)
+   Tool usage persistence (tool_usage_path / flush_tool_usage /
+   restore_tool_usage) moved to Keeper_registry_tool_usage_persistence;
+   the CAS-bound write path is exposed below as
+   [set_tool_usage_entry]. *)
 
-let tool_usage_path ~base_path name =
-  let dir =
-    Filename.concat (Common.masc_dir_from_base_path ~base_path) "keepers/tool_usage"
-  in
-  Filename.concat dir (name ^ ".json")
-;;
-
-let flush_tool_usage ~base_path name =
-  match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
-  | None -> ()
-  | Some entry ->
-    let items =
-      StringMap.fold
-        (fun tool_name (e : tool_call_entry) acc ->
-           `Assoc
-             [ "tool", `String tool_name
-             ; "count", `Int e.count
-             ; "successes", `Int e.successes
-             ; "failures", `Int e.failures
-             ; "last_used_at", `Float e.last_used_at
-             ]
-           :: acc)
-        entry.tool_usage
-        []
-    in
-    let json =
-      `Assoc
-        [ "keeper", `String name
-        ; "flushed_at", `Float (Time_compat.now ())
-        ; "tools", `List items
-        ]
-    in
-    let path = tool_usage_path ~base_path name in
-    (try
-       Fs_compat.mkdir_p (Filename.dirname path);
-       Fs_compat.save_file path (Yojson.Safe.to_string json ^ "\n")
-     with
-     | Eio.Cancel.Cancelled _ as e -> raise e
-     | exn ->
-       Prometheus.inc_counter
-         Keeper_metrics.metric_keeper_tool_usage_flush_failures
-         ~labels:[ "keeper", name ]
-         ();
-       Log.Keeper.error "flush_tool_usage %s: %s" name (Printexc.to_string exn))
-;;
-
-let restore_tool_usage ~base_path name =
-  let path = tool_usage_path ~base_path name in
-  if not (Fs_compat.file_exists path)
-  then ()
-  else (
-    match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
-    | None -> ()
-    | Some _entry ->
-      (try
-         let content = Fs_compat.load_file path in
-         let json = Yojson.Safe.from_string content in
-         let tools =
-           match json with
-           | `Assoc fields ->
-             (match List.assoc_opt "tools" fields with
-              | Some (`List items) -> items
-              | _ -> [])
-           | _ -> []
-         in
-         List.iter
-           (fun item ->
-              match
-                ( Safe_ops.json_string_opt "tool" item
-                , Safe_ops.json_int_opt "count" item
-                , Safe_ops.json_int_opt "successes" item
-                , Safe_ops.json_int_opt "failures" item
-                , Safe_ops.json_float_opt "last_used_at" item )
-              with
-              | ( Some tool_name
-                , Some count
-                , Some successes
-                , Some failures
-                , Some last_used_at )
-                when tool_name <> "" ->
-                let e = { count; successes; failures; last_used_at } in
-                update_entry ~base_path name (fun ent ->
-                  { ent with tool_usage = StringMap.add tool_name e ent.tool_usage })
-              | _ -> ())
-           tools
-       with
-       | Eio.Cancel.Cancelled _ as e -> raise e
-       | exn ->
-         Prometheus.inc_counter
-           Keeper_metrics.metric_keeper_checkpoint_failures
-           ~labels:[ "keeper", name; "site", "restore_tool_usage" ]
-           ();
-         Log.Keeper.warn "restore_tool_usage %s: %s" name (Printexc.to_string exn)))
+let set_tool_usage_entry ~base_path ~name ~tool_name (e : tool_call_entry) =
+  update_entry ~base_path name (fun ent ->
+    { ent with tool_usage = StringMap.add tool_name e ent.tool_usage })
 ;;
 
 (* ── RFC-0002 Event Dispatch ───────────────────────────── *)

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -380,11 +380,17 @@ val tool_usage_of : base_path:string -> string ->
    find_by_name / find_by_agent_name / find_by_id /
    tool_usage_of_by_name / resolve_config. *)
 
-(** Flush in-memory tool usage stats to disk for persistence across restarts. *)
-val flush_tool_usage : base_path:string -> string -> unit
+(* Tool usage persistence (flush_tool_usage / restore_tool_usage /
+   tool_usage_path) moved to Keeper_registry_tool_usage_persistence.
+   The CAS-bound write path is exposed below for that module's use. *)
 
-(** Restore tool usage stats from disk after keeper re-registration. *)
-val restore_tool_usage : base_path:string -> string -> unit
+(** Replace (or insert) a single per-tool usage entry on a registered keeper.
+    Goes through the registry's CAS retry loop. Used by
+    [Keeper_registry_tool_usage_persistence.restore] to replay persisted
+    counters on re-registration. *)
+val set_tool_usage_entry :
+  base_path:string -> name:string -> tool_name:string
+  -> Keeper_types.tool_call_entry -> unit
 
 (** {1 RFC-0002 Event Dispatch} *)
 

--- a/lib/keeper/keeper_registry_tool_usage_persistence.ml
+++ b/lib/keeper/keeper_registry_tool_usage_persistence.ml
@@ -1,0 +1,107 @@
+(** Disk persistence for per-keeper tool-usage counters.
+
+    Extracted from keeper_registry.ml (1495-1588) as part of the
+    godfile decomp campaign. The file I/O (path + JSON serialization +
+    JSON parsing) is fully separable from the Atomic state primitive
+    — reads go through [Keeper_registry.get], writes go through
+    [Keeper_registry.set_tool_usage_entry] (a thin facade over the
+    same CAS retry [update_entry] used by [record_tool_use]). *)
+
+open Keeper_registry_types
+
+let tool_usage_path ~base_path name =
+  let dir =
+    Filename.concat (Common.masc_dir_from_base_path ~base_path) "keepers/tool_usage"
+  in
+  Filename.concat dir (name ^ ".json")
+;;
+
+let flush ~base_path name =
+  match Keeper_registry.get ~base_path name with
+  | None -> ()
+  | Some entry ->
+    let items =
+      StringMap.fold
+        (fun tool_name (e : Keeper_types.tool_call_entry) acc ->
+           `Assoc
+             [ "tool", `String tool_name
+             ; "count", `Int e.count
+             ; "successes", `Int e.successes
+             ; "failures", `Int e.failures
+             ; "last_used_at", `Float e.last_used_at
+             ]
+           :: acc)
+        entry.tool_usage
+        []
+    in
+    let json =
+      `Assoc
+        [ "keeper", `String name
+        ; "flushed_at", `Float (Time_compat.now ())
+        ; "tools", `List items
+        ]
+    in
+    let path = tool_usage_path ~base_path name in
+    (try
+       Fs_compat.mkdir_p (Filename.dirname path);
+       Fs_compat.save_file path (Yojson.Safe.to_string json ^ "\n")
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+       Prometheus.inc_counter
+         Keeper_metrics.metric_keeper_tool_usage_flush_failures
+         ~labels:[ "keeper", name ]
+         ();
+       Log.Keeper.error "flush_tool_usage %s: %s" name (Printexc.to_string exn))
+;;
+
+let restore ~base_path name =
+  let path = tool_usage_path ~base_path name in
+  if not (Fs_compat.file_exists path)
+  then ()
+  else (
+    match Keeper_registry.get ~base_path name with
+    | None -> ()
+    | Some _entry ->
+      (try
+         let content = Fs_compat.load_file path in
+         let json = Yojson.Safe.from_string content in
+         let tools =
+           match json with
+           | `Assoc fields ->
+             (match List.assoc_opt "tools" fields with
+              | Some (`List items) -> items
+              | _ -> [])
+           | _ -> []
+         in
+         List.iter
+           (fun item ->
+              match
+                ( Safe_ops.json_string_opt "tool" item
+                , Safe_ops.json_int_opt "count" item
+                , Safe_ops.json_int_opt "successes" item
+                , Safe_ops.json_int_opt "failures" item
+                , Safe_ops.json_float_opt "last_used_at" item )
+              with
+              | ( Some tool_name
+                , Some count
+                , Some successes
+                , Some failures
+                , Some last_used_at )
+                when tool_name <> "" ->
+                let e : Keeper_types.tool_call_entry =
+                  { count; successes; failures; last_used_at }
+                in
+                Keeper_registry.set_tool_usage_entry
+                  ~base_path ~name ~tool_name e
+              | _ -> ())
+           tools
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+         Prometheus.inc_counter
+           Keeper_metrics.metric_keeper_checkpoint_failures
+           ~labels:[ "keeper", name; "site", "restore_tool_usage" ]
+           ();
+         Log.Keeper.warn "restore_tool_usage %s: %s" name (Printexc.to_string exn)))
+;;

--- a/lib/keeper/keeper_registry_tool_usage_persistence.mli
+++ b/lib/keeper/keeper_registry_tool_usage_persistence.mli
@@ -1,0 +1,14 @@
+(** Disk persistence for per-keeper tool-usage counters. *)
+
+(** Filesystem path under [<masc>/keepers/tool_usage/<name>.json]. *)
+val tool_usage_path : base_path:string -> string -> string
+
+(** Flush in-memory tool usage stats to disk for persistence across restarts.
+    Reads the keeper entry via [Keeper_registry.get]; writes JSON atomically.
+    Increments [metric_keeper_tool_usage_flush_failures] on I/O failure. *)
+val flush : base_path:string -> string -> unit
+
+(** Restore tool usage stats from disk after keeper re-registration.
+    Reads JSON from [tool_usage_path]; replays each entry via
+    [Keeper_registry.set_tool_usage_entry]. *)
+val restore : base_path:string -> string -> unit

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -770,7 +770,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
    | Some entry ->
        Keeper_registry.record_tool_use
          ~base_path:entry.base_path entry.name ~tool_name:name ~success;
-       Keeper_registry.flush_tool_usage ~base_path:entry.base_path entry.name
+       Keeper_registry_tool_usage_persistence.flush ~base_path:entry.base_path entry.name
    | None -> ());
 
   (* #10358: classify failure mode at the dispatch boundary so


### PR DESCRIPTION
## Summary

Follow-up to #16657 (lookup extraction, already MERGED).
keeper_registry godfile decomp — disk persistence isolation.

### 변경 요약

- 신규 모듈 `lib/keeper/keeper_registry_tool_usage_persistence.ml` + `.mli` (107 + 14 LoC)
- 3 함수 이동: `tool_usage_path` / `flush_tool_usage` (→ `flush`) / `restore_tool_usage` (→ `restore`)
- keeper_registry에 작은 public API 추가: `set_tool_usage_entry` (CAS-bound write 경로 노출)
- 3 caller 갱신: `keeper_keepalive`, `keeper_heartbeat_snapshot`, `mcp_server_eio_call_tool`

### LoC 효과

| | Before | After | Δ |
|--|--------|-------|---|
| `lib/keeper/keeper_registry.ml` | 2077 | 1990 | -87 |
| `lib/keeper/keeper_registry.mli` | 483 | 489 | +6 |
| 신규 persistence.ml | — | 107 | +107 |
| 신규 persistence.mli | — | 14 | +14 |

**Combined with #16657: 2129 → 1990 LoC (-139 LoC, 6.5% 감소).**

### 동작 보존
- 동일 JSON 직렬화 shape
- 동일 Prometheus 카운터 (`metric_keeper_tool_usage_flush_failures`, `metric_keeper_checkpoint_failures`)
- 동일 `Eio.Cancel.Cancelled` rethrow on cancellation

### 검증
- `dune build --root . @check` exit 0
- `test/test_keeper_registry.exe` 109 tests PASS

### Scope guard
- credential / identity / operator-control / sandbox / dashboard credential / hooks / workflow 영역 무관
- `RFC-WAIVED: I/O extraction, godfile decomp follow-up to RFC-0136 stack`

## Test plan
- [x] dune @check green
- [x] keeper_registry alcotest suite (109 tests) PASS
- [ ] CI 통과 후 사용자 라벨 dispatch

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>