### PR TITLE
fix(dashboard): warmRetryDelayFor fallback recovers main typecheck

### DIFF
--- a/dashboard/src/namespace-truth-actions.ts
+++ b/dashboard/src/namespace-truth-actions.ts
@@ -26,7 +26,7 @@ export const WARM_RETRY_CAP_MS = 30_000
 export function warmRetryDelayFor(attempt: number): number {
   // attempt is 1-indexed by callers; clamp to the schedule, falling back
   // to the cap so a misuse never produces 0 / NaN / negative delay.
-  if (!Number.isFinite(attempt) || attempt < 1) return WARM_RETRY_DELAYS_MS[0]
+  if (!Number.isFinite(attempt) || attempt < 1) return WARM_RETRY_DELAYS_MS[0] ?? WARM_RETRY_CAP_MS
   const idx = Math.min(attempt - 1, WARM_RETRY_DELAYS_MS.length - 1)
   const delay = WARM_RETRY_DELAYS_MS[idx]
   return delay ?? WARM_RETRY_CAP_MS


### PR DESCRIPTION
## Summary

Main typecheck is failing after PR #16664. The `attempt < 1` guard arm
returns `WARM_RETRY_DELAYS_MS[0]` (a direct index access) which yields
`number | undefined` under `noUncheckedIndexedAccess`. The other return
arm already falls back to `WARM_RETRY_CAP_MS`; this PR applies the same
fallback so both arms are total.

## Root
Array literal access yields `T | undefined` under strict bounds checking.
`WARM_RETRY_DELAYS_MS` is in fact non-empty (5 elements) so runtime
behavior is unchanged — this is purely a type-soundness fix.

## Verification
- `pnpm typecheck` → pass (was failing on `origin/main`)
- `pnpm vitest run namespace-truth-actions` → pass (existing tests unaffected)

## Why this is separate
Discovered while preparing RFC-0135 PR-12 (keeperBand SSOT integration).
Keeping the hotfix as its own PR so PR-12 stays scoped to RFC-0135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>