### PR TITLE
fix(dashboard): RFC-0135 PR-12 keeperBand SSOT integration (CRITICAL)

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -396,6 +396,7 @@ function buildAgentRoster(
 function countAgentsByStatus(
   agentList: Agent[],
   keeperList: Keeper[],
+  compositeByKeeperKey: ReadonlyMap<string, KeeperCompositeSnapshot> | null = null,
 ): Record<StatusFilter, number> {
   const keeperLookup = buildKeeperRuntimeLookup(keeperList)
   const counts: Record<StatusFilter, number> = {
@@ -408,7 +409,16 @@ function countAgentsByStatus(
 
   for (const agent of agentList) {
     const keeperRuntime = findKeeperRuntimeForAgent(agent, keeperLookup)
-    const band = runtimeBandMetaForAgent(agent, keeperRuntime).key
+    // RFC-0135 PR-12: pass composite to band derivation so stale
+    // blockers are demoted via SSOT instead of inflating attention.
+    const composite =
+      keeperRuntime && compositeByKeeperKey
+        ? compositeByKeeperKey.get(keeperRuntime.name)
+          ?? (typeof keeperRuntime.keeper_id === 'string'
+            ? compositeByKeeperKey.get(keeperRuntime.keeper_id) ?? null
+            : null)
+        : null
+    const band = runtimeBandMetaForAgent(agent, keeperRuntime, composite).key
     counts[band] += 1
   }
 
@@ -502,17 +512,25 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   )
   const bandByAgent = useMemo(
     () => new Map(
-      scopedAgents.map(agent => [
-        agent.name,
-        runtimeBandMetaForAgent(
-          agent,
+      scopedAgents.map(agent => {
+        const keeperRuntime =
           keeperRuntimeLookup.get(agent.name)
             ?? findKeeperRuntimeForAgent(agent, keeperRuntimeLookup)
-            ?? findKeeperRuntime(agent.name, runtimeKeeperList),
-        ),
-      ] as const),
+            ?? findKeeperRuntime(agent.name, runtimeKeeperList)
+        // RFC-0135 PR-12: thread composite snapshot through band
+        // derivation so stale-blocker demotion in the typed SSOT
+        // applies to the badge color too.
+        const composite =
+          keeperRuntime
+            ? compositeByKeeperKey.get(keeperRuntime.name)
+              ?? (typeof keeperRuntime.keeper_id === 'string'
+                ? compositeByKeeperKey.get(keeperRuntime.keeper_id) ?? null
+                : null)
+            : null
+        return [agent.name, runtimeBandMetaForAgent(agent, keeperRuntime, composite)] as const
+      }),
     ),
-    [scopedAgents, keeperRuntimeLookup, runtimeKeeperList],
+    [scopedAgents, keeperRuntimeLookup, runtimeKeeperList, compositeByKeeperKey],
   )
   const normalizedSearch = search.trim().toLowerCase()
   const searchTermsByAgent = useMemo(
@@ -567,7 +585,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
       return a.name.localeCompare(b.name)
     })
 
-  const counts = countAgentsByStatus(scopedAgents, runtimeKeeperList)
+  const counts = countAgentsByStatus(scopedAgents, runtimeKeeperList, compositeByKeeperKey)
   const showExecutionFallbackState = shouldShowExecutionFallbackState({
     executionLoaded: executionLoaded.value,
     executionLoading: executionLoading.value,
@@ -685,7 +703,17 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             ?? findKeeperRuntimeForAgent(agent, keeperRuntimeLookup)
             ?? findKeeperRuntime(agent.name, runtimeKeeperList)
           const band = bandByAgent.get(agent.name) ?? runtimeBandMeta('attention')
-          const keeperMonitoring = keeperRuntime ? summarizeKeeperMonitoring(keeperRuntime) : null
+          // RFC-0135 PR-12: detail panel summary shares the same composite
+          // pickup as bandByAgent so the visible state and the band tone
+          // can never disagree on stale-vs-live blocker classification.
+          const compositeForMonitoring: KeeperCompositeSnapshot | null =
+            keeperRuntime
+              ? compositeByKeeperKey.get(keeperRuntime.name)
+                ?? (typeof keeperRuntime.keeper_id === 'string'
+                  ? compositeByKeeperKey.get(keeperRuntime.keeper_id) ?? null
+                  : null)
+              : null
+          const keeperMonitoring = keeperRuntime ? summarizeKeeperMonitoring(keeperRuntime, compositeForMonitoring) : null
           const monitoringEvidence = keeperMonitoring ? summarizeMonitoringEvidence(keeperMonitoring) : null
           const fsmPhase = keeperRuntime ? keeperPhaseForDisplay(keeperRuntime) : null
           const isKeeper = keeperRuntime != null

--- a/dashboard/src/lib/monitoring-runtime.test.ts
+++ b/dashboard/src/lib/monitoring-runtime.test.ts
@@ -137,4 +137,63 @@ describe('summarizeKeeperMonitoring', () => {
     expect(summary.band.key).toBe('attention')
     expect(summary.hint).toBe('turn timed out after queue wait')
   })
+
+  // RFC-0135 PR-12 — stale-vs-live blocker via composite SSOT.
+  describe('composite stale-blocker conditioning', () => {
+    const keeper = {
+      name: 'keeper-stale',
+      status: 'idle',
+      phase: 'Running',
+      last_heartbeat: new Date().toISOString(),
+      runtime_blocker_class: 'turn_timeout',
+      runtime_blocker_summary: 'turn timed out after queue wait',
+    } as Keeper
+
+    it('without composite ⇒ blocker treated as live (attention)', () => {
+      const summary = summarizeKeeperMonitoring(keeper)
+      expect(summary.band.key).toBe('attention')
+    })
+
+    it('composite says execution_current=false ⇒ blocker demoted, band=active', () => {
+      const compositeStaleByExecutionCurrent = {
+        keeper: 'keeper-stale',
+        runtime_attention: {
+          execution_current: false,
+          stale_execution_receipt: false,
+          blocked: false,
+          needs_attention: false,
+        },
+      } as unknown as Parameters<typeof summarizeKeeperMonitoring>[1] extends infer C ? C : never
+      const summary = summarizeKeeperMonitoring(keeper, compositeStaleByExecutionCurrent)
+      expect(summary.band.key).toBe('active')
+    })
+
+    it('composite says stale_execution_receipt=true ⇒ blocker demoted, band=active', () => {
+      const compositeStaleByReceipt = {
+        keeper: 'keeper-stale',
+        runtime_attention: {
+          execution_current: true,
+          stale_execution_receipt: true,
+          blocked: false,
+          needs_attention: false,
+        },
+      } as unknown as Parameters<typeof summarizeKeeperMonitoring>[1] extends infer C ? C : never
+      const summary = summarizeKeeperMonitoring(keeper, compositeStaleByReceipt)
+      expect(summary.band.key).toBe('active')
+    })
+
+    it('composite with live execution ⇒ blocker stays attention', () => {
+      const compositeLive = {
+        keeper: 'keeper-stale',
+        runtime_attention: {
+          execution_current: true,
+          stale_execution_receipt: false,
+          blocked: false,
+          needs_attention: false,
+        },
+      } as unknown as Parameters<typeof summarizeKeeperMonitoring>[1] extends infer C ? C : never
+      const summary = summarizeKeeperMonitoring(keeper, compositeLive)
+      expect(summary.band.key).toBe('attention')
+    })
+  })
 })

--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -1,4 +1,5 @@
 import type { Agent, Keeper, PipelineStage } from '../types'
+import type { KeeperCompositeSnapshot } from '../api/schemas/keeper-composite'
 import { keeperDisplayStatus, keeperRuntimeBlockerHint } from './keeper-runtime-display'
 // RFC-0135 PR-2: phase casing SSOT — single source `toKeeperPhase` in
 // keeper-store-normalize. Local CANONICAL_PHASE_KEYS + normalizePhase
@@ -6,6 +7,12 @@ import { keeperDisplayStatus, keeperRuntimeBlockerHint } from './keeper-runtime-
 // PHASE_ID_MAP elsewhere; the three maps drifted independently.
 import { toKeeperPhase } from '../keeper-store-normalize'
 import { isKeeperPaused } from './keeper-predicates'
+// RFC-0135 PR-12: route blocker visibility through the typed SSOT so
+// stale vs live blocker distinction (composite.execution_current /
+// stale_execution_receipt) is honored. Previously the inline
+// `Boolean(keeper.runtime_blocker_class)` flipped attention on stale
+// receipts that the typed state demoted to `running.staleBlocker`.
+import { deriveKeeperOperationalState } from './keeper-operational-state'
 
 export type RuntimeBand = 'active' | 'attention' | 'paused' | 'offline'
 
@@ -179,7 +186,12 @@ function contextAttentionRatio(keeper: Keeper): number {
     : DEFAULT_CONTEXT_ATTENTION_RATIO
 }
 
-function keeperBand(keeper: Keeper, phaseKey: string, lifecycleKey: string): RuntimeBand {
+function keeperBand(
+  keeper: Keeper,
+  composite: KeeperCompositeSnapshot | null,
+  phaseKey: string,
+  lifecycleKey: string,
+): RuntimeBand {
   // RFC-0135 PR-3: canonical paused predicate. The previous local OR
   // chain (`paused || phaseKey === 'Paused' || lifecycleKey === 'paused'`)
   // was one of four parallel paused checks that drifted independently.
@@ -193,9 +205,17 @@ function keeperBand(keeper: Keeper, phaseKey: string, lifecycleKey: string): Run
   ) {
     return 'offline'
   }
+  // RFC-0135 PR-12: live blocker — typed state's `stuck` variant. When
+  // composite is null (caller has no snapshot in hand) SSOT cannot
+  // confirm staleness, so it falls back to the previous behavior of
+  // treating any blocker class as live. When composite is present and
+  // marks `execution_current=false` or `stale_execution_receipt=true`,
+  // the blocker is demoted to `running.staleBlocker` and does NOT trip
+  // attention — this closes audit finding B2 (visibility miscount).
+  const liveBlocker = deriveKeeperOperationalState({ keeper, composite }).kind === 'stuck'
   if (
     ATTENTION_PHASES.has(phaseKey)
-    || Boolean(keeper.runtime_blocker_class)
+    || liveBlocker
     || keeper.social_model_recognized === false
     || isHeartbeatStale(keeper)
     || (typeof keeper.context_ratio === 'number' && keeper.context_ratio >= contextAttentionRatio(keeper))
@@ -224,11 +244,14 @@ function keeperHint(keeper: Keeper, band: RuntimeBand, stage: StageMeta): string
   return stage.description
 }
 
-export function summarizeKeeperMonitoring(keeper: Keeper): KeeperMonitoringSummary {
+export function summarizeKeeperMonitoring(
+  keeper: Keeper,
+  composite: KeeperCompositeSnapshot | null = null,
+): KeeperMonitoringSummary {
   const lifecycleKey = keeperDisplayStatus(keeper)
   const phaseKey = keeperPhaseForDisplay(keeper) ?? 'unknown'
   const stage = stageMeta(normalizeStage(keeper.pipeline_stage))
-  const band = BAND_META[keeperBand(keeper, phaseKey, lifecycleKey)]
+  const band = BAND_META[keeperBand(keeper, composite, phaseKey, lifecycleKey)]
 
   return {
     band,
@@ -266,13 +289,21 @@ function agentBand(status: string | undefined | null): RuntimeBand {
   return 'active'
 }
 
-function runtimeBandForAgent(agent: Agent, keeper?: Keeper | null): RuntimeBand {
-  if (keeper) return summarizeKeeperMonitoring(keeper).band.key
+function runtimeBandForAgent(
+  agent: Agent,
+  keeper?: Keeper | null,
+  composite?: KeeperCompositeSnapshot | null,
+): RuntimeBand {
+  if (keeper) return summarizeKeeperMonitoring(keeper, composite ?? null).band.key
   return agentBand(agent.status)
 }
 
-export function runtimeBandMetaForAgent(agent: Agent, keeper?: Keeper | null): RuntimeBandMeta {
-  return BAND_META[runtimeBandForAgent(agent, keeper)]
+export function runtimeBandMetaForAgent(
+  agent: Agent,
+  keeper?: Keeper | null,
+  composite?: KeeperCompositeSnapshot | null,
+): RuntimeBandMeta {
+  return BAND_META[runtimeBandForAgent(agent, keeper, composite)]
 }
 
 export function runtimeBandMeta(band: RuntimeBand): RuntimeBandMeta {

--- a/dashboard/src/namespace-truth-actions.ts
+++ b/dashboard/src/namespace-truth-actions.ts
@@ -26,7 +26,7 @@ export const WARM_RETRY_CAP_MS = 30_000
 export function warmRetryDelayFor(attempt: number): number {
   // attempt is 1-indexed by callers; clamp to the schedule, falling back
   // to the cap so a misuse never produces 0 / NaN / negative delay.
-  if (!Number.isFinite(attempt) || attempt < 1) return WARM_RETRY_DELAYS_MS[0]
+  if (!Number.isFinite(attempt) || attempt < 1) return WARM_RETRY_DELAYS_MS[0] ?? WARM_RETRY_CAP_MS
   const idx = Math.min(attempt - 1, WARM_RETRY_DELAYS_MS.length - 1)
   const delay = WARM_RETRY_DELAYS_MS[idx]
   return delay ?? WARM_RETRY_CAP_MS


### PR DESCRIPTION
## Summary

Closes audit findings **B1 + B2 (CRITICAL)** — the single largest SSOT
violation surface. 3 of 3 audit sub-agents independently flagged
`monitoring-runtime.ts keeperBand` as *parallel* derivation of
`KeeperOperationalState`.

## Root

`keeperBand` flipped a roster band to **attention** whenever
`Boolean(keeper.runtime_blocker_class)` was true, ignoring composite
`execution_current` / `stale_execution_receipt` signals that the typed
SSOT (PR-1) uses to demote stale blockers to `running.staleBlocker`.

Symptom: roster orange badge while detail panel shows "running (stale
receipt)" — same conflict the user reported on 2026-05-19 §1.1.

## Changes

| File | Change |
|------|--------|
| `lib/monitoring-runtime.ts` | `summarizeKeeperMonitoring` + `runtimeBandForAgent` + `runtimeBandMetaForAgent` accept optional `composite`. `keeperBand` routes blocker visibility via `deriveKeeperOperationalState(...).kind === 'stuck'`. |
| `components/agent-roster.ts` | 3 callsites updated to thread `composite` from existing `compositeByKeeperKey` map (count function, `bandByAgent` useMemo, per-row monitoring). |
| `namespace-truth-actions.ts` | One-line typecheck fix (same as hotfix #16678, included so this PR's typecheck passes ahead of hotfix merge). |

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| `runtime_blocker_class=turn_timeout`, no composite | attention | attention (fallback, identical) |
| Live blocker + composite `execution_current=true` | attention | attention |
| Stale receipt + composite `execution_current=false` | **attention (WRONG)** | **active (FIXED)** |
| Stale receipt + composite `stale_execution_receipt=true` | **attention (WRONG)** | **active (FIXED)** |

## Verification
- [x] `pnpm typecheck` → pass
- [x] `pnpm vitest run monitoring-runtime keeper-operational-state agent-roster keeper-action-panel` → **68/68 pass** (+4 new stale-blocker fixtures)
- [x] `bash scripts/lint/dashboard-ssot-keeper-state.sh` → exit 0
- [x] diff: 4 files, +138/-20

## RFC reference
RFC-0135 §1.5 Cluster C5 (composite fallback) + §4 conditioning matrix.
Audit report: `~/me/.tmp/masc-dashboard-ssot-audit-2026-05-19.html` Goal-1.

RFC-WAIVED: N/A — strengthens RFC-0135 SSOT.

## Stack
- Independent of PR #16663 (PR-10), PR #16672 (PR-11).
- Includes hotfix duplicate of #16678 (auto-resolves on rebase after either merges).

---

Status: Draft — agent PR. Ready 전환은 사용자 라벨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>