### PR TITLE
feat(tool_board_schemas): declare post_kind in masc_board_post input schema

### DIFF
--- a/lib/tool_board_schemas.ml
+++ b/lib/tool_board_schemas.ml
@@ -92,6 +92,19 @@ let tool_post_create : Masc_domain.tool_schema =
                     ; ( "description"
                       , `String "public|unlisted|internal|direct (default: internal)" )
                     ] )
+              ; ( "post_kind"
+                , `Assoc
+                    [ "type", `String "string"
+                    ; ( "description"
+                      , `String
+                          "Optional post classification: 'direct' (alias 'human') = \
+                           caller is a human user; 'automation' = caller is an agent or \
+                           automated source. 'system' is reserved for internal surfaces \
+                           (keeper, operator) and will be rejected if sent by an \
+                           external caller. When omitted, inferred from author: \
+                           empty/anonymous → automation; registered agent → automation; \
+                           otherwise human." )
+                    ] )
               ; ( "ttl_hours"
                 , `Assoc
                     [ "type", `String "integer"


### PR DESCRIPTION
## Goal

The masc_board_post handler at \`lib/tool_board_post.ml:103\` reads a \`post_kind\` field and routes it through \`Tool_board_handlers.resolve_board_post_kind\`. The field is **missing from the JSON schema** at \`lib/tool_board_schemas.ml\`, leaving LLM callers with no documented way to discover this classification surface — a HIDDEN API, same shape as the voice_* fields fixed in PR #16676 (Iter#48).

## Change

Add the field after \`visibility\` (post classification fields together). Description carries the accepted values inline, matching the file's existing convention (visibility uses the same description-only pattern without JSON Schema \`enum\`).

\`\`\`ocaml
; ( \"post_kind\"
  , \`Assoc
      [ \"type\", \`String \"string\"
      ; ( \"description\"
        , \`String
            \"Optional post classification: 'direct' (alias 'human') = \\
             caller is a human user; 'automation' = caller is an agent or \\
             automated source. 'system' is reserved for internal surfaces \\
             (keeper, operator) and will be rejected if sent by an \\
             external caller. When omitted, inferred from author: \\
             empty/anonymous → automation; registered agent → automation; \\
             otherwise human.\" )
      ] )
\`\`\`

Accepted values verified against \`lib/board_core_classify.ml:61-66\` (\`post_kind_of_string\`) and \`lib/tool_board_handlers.ml:50-71\` (\`resolve_board_post_kind\`, which rejects \`System_post\`).

## No behavioural change

The handler already reads this field. The change is purely in what the LLM sees when querying the tool catalog.

## ⚠️ CI will fail on this PR for a reason unrelated to this change

When this PR was built locally, \`dune build @check\` failed at \`lib/tool_types/tool_result.{ml,mli}\`:

\`\`\`
Error: The implementation lib/tool_types/tool_result.ml
       does not match the interface lib/tool_types/tool_result.mli:
       The value tool_failure_class_to_yojson is required but not provided
       ...
Error: Unbound value Tool_result.pp_tool_failure_class
\`\`\`

Root cause: the typed \`tool_failure_class\` introduced by PR #16671 has \`[@@deriving yojson]\` in the .ml but the .mli declares a \`Result\`-returning signature, and \`pp_tool_failure_class\` is referenced somewhere without being derived. This is a **design decision that belongs to the owner of the failure_class work**, not this PR.

This schema PR is intentionally not bundling a fix-build (unlike Iter#48 PR #16676, where the build break was a trivial 1-line missing match arm). The ppx-derived signature design is wider scope and likely has an in-flight follow-up PR.

**Recommend**: do not merge this until main is green again. The change itself is verified by inspection of the file diff — single field declaration, matches existing convention.

## Touch points

- 1 file, +13 / -0 LoC

## Reference

Scout sweep during /loop Iter#48, attempted in Iter#49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>