### PR TITLE
refactor(dashboard): RFC-0135 PR-13 paused predicate SSOT migration

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -57,6 +57,7 @@ import {
 // 2026-05-19 lifecycle-worker symptom (`현재 차단 · synthetic_stall` in
 // the list while detail showed `턴 진행 중 · executing live`).
 import { deriveKeeperOperationalState } from '../lib/keeper-operational-state'
+import { isKeeperPaused } from '../lib/keeper-predicates'
 import type { KeeperCompositeSnapshot } from '../api/schemas/keeper-composite'
 import { fleetCompositeSnapshot } from '../composite-signals'
 
@@ -188,9 +189,15 @@ function findKeeperRuntimeForAgent(
 
 type KeeperFilterMode = 'all' | 'agent-only' | 'keeper-only'
 
-function isRuntimeBackedKeeper(keeper: Pick<Keeper, 'paused' | 'registered' | 'keepalive_running'>): boolean {
+function isRuntimeBackedKeeper(keeper: Keeper): boolean {
   if (keeper.registered === false && keeper.keepalive_running === false) return false
-  if (keeper.paused === true && keeper.registered !== true && keeper.keepalive_running !== true) return false
+  // RFC-0135 PR-13: use canonical paused predicate. SSOT also covers
+  // `phase === 'Paused'` / `status === 'paused'` / `pipeline_stage ===
+  // 'paused'`. Effect: an FSM-paused but-not-flag-paused keeper that
+  // also lost registration + keepalive is now filtered out, matching
+  // the "no real backing runtime" intent the original `paused === true`
+  // check captured only partially.
+  if (isKeeperPaused(keeper) && keeper.registered !== true && keeper.keepalive_running !== true) return false
   return true
 }
 

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -6,6 +6,7 @@ import {
   keeperRuntimeBlockerLabel,
   keeperRuntimeBlockerHint,
 } from '../lib/keeper-runtime-display'
+import { isKeeperPaused } from '../lib/keeper-predicates'
 import { TimeAgo } from './common/time-ago'
 import { formatDuration } from './mission-utils'
 import type { Keeper } from '../types'
@@ -161,8 +162,13 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
   const socialFallbackActive = keeper.social_model_recognized === false
   const attentionReason = keeper.attention_reason?.trim() || null
   const nextHumanAction = keeper.next_human_action?.trim() || null
-  const pausedRuntimeBlocker = keeper.paused === true && runtimeBlockerClass != null
-  const attentionReasonText = attentionReasonLabel(attentionReason, keeper.paused === true)
+  // RFC-0135 PR-13: canonical paused predicate. SSOT also covers
+  // FSM phase=Paused / pipeline_stage=paused / status=paused, so the
+  // "paused + live blocker" composite flag and the attention-reason
+  // label now agree across the four paused axes (RFC §1.5 Cluster C3).
+  const isPaused = isKeeperPaused(keeper)
+  const pausedRuntimeBlocker = isPaused && runtimeBlockerClass != null
+  const attentionReasonText = attentionReasonLabel(attentionReason, isPaused)
   const nextHumanActionText = nextHumanActionLabel(nextHumanAction)
   const sandboxTarget = keeper.sandbox_target?.trim() || keeper.sandbox_profile?.trim() || null
   const persistedPolicyCount = keeper.approval_policy_effective?.persisted_rules


### PR DESCRIPTION
## Summary

Closes audit findings **B4 + A-MEDIUM paused cluster** — three Keeper-type callsites migrated from raw `keeper.paused === true` to canonical `isKeeperPaused` SSOT.

## Migrations (3 sites)

| Site | Before | After |
|------|--------|-------|
| `agent-roster.ts:193` (isRuntimeBackedKeeper) | `keeper.paused === true && registered !== true && keepalive_running !== true` | `isKeeperPaused(keeper) && registered !== true && keepalive_running !== true` |
| `keeper-detail-alert-strip.ts:164` (pausedRuntimeBlocker) | `keeper.paused === true && runtimeBlockerClass != null` | `isKeeperPaused(keeper) && runtimeBlockerClass != null` |
| `keeper-detail-alert-strip.ts:165` (attentionReasonText) | `attentionReasonLabel(reason, keeper.paused === true)` | `attentionReasonLabel(reason, isKeeperPaused(keeper))` |

## Behavior

Each call now covers all four paused axes (flag, phase=Paused, pipeline_stage=paused, status=paused). An FSM-paused but flag-not-paused keeper now correctly counts as paused — matches the SSOT semantic established by PR-1.

`isRuntimeBackedKeeper` signature widened from `Pick<...>` to `Keeper` so the SSOT predicate has full input.

## Scope cut

Audit Goal-5 also flagged 3 `normalizeStatus(keeper.status) !== 'offline'` sites in `components/board/composer-v2.ts`, `components/ops/keeper-utilities.ts`, `components/ops/quick-intervene.ts`. These accept `OperatorKeeperSnapshot` (subset shape — `status` only, no `phase`/`pipeline_stage`), **not** the full `Keeper`. Migration requires promoting `isKeeperOffline` to the wider snapshot domain — deferred to a separate RFC line. The audit's "5 sites" was an over-collection across two domains.

## Verification
- [x] `pnpm typecheck` → pass
- [x] `pnpm vitest run agent-roster keeper-detail-alert-strip keeper-predicates` → 62/62 pass
- [x] `bash scripts/lint/dashboard-ssot-keeper-state.sh` → exit 0
- [x] diff: 2 files, +17/-4

## RFC reference
RFC-0135 §1.5 Cluster C3 (paused predicate 4-way OR-chain).
Audit: `~/me/.tmp/masc-dashboard-ssot-audit-2026-05-19.html` Goal-5.

RFC-WAIVED: N/A — strengthens RFC-0135 SSOT.

---

Status: Draft — agent PR. Ready 전환은 사용자 라벨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>