### PR TITLE
fix(tool_types/dune): activate ppx_deriving_yojson preprocess (production-blocking)

### DIFF
--- a/lib/tool_types/dune
+++ b/lib/tool_types/dune
@@ -22,4 +22,5 @@
  (name masc_mcp_tool_types)
  (public_name masc_mcp.tool_types)
  (wrapped false)
- (libraries yojson masc_log masc_core eio time_compat))
+ (libraries yojson masc_log masc_core eio time_compat)
+ (preprocess (pps ppx_deriving_yojson)))


### PR DESCRIPTION
## Summary

`lib/tool_types/tool_result.ml` 가 `[@@deriving yojson]` 을 사용하지만 `lib/tool_types/dune` 에 preprocess 가 등록돼 있지 않아 ppx 가 돌지 않음.

결과: `tool_failure_class_to_yojson is required but not provided` — **모든 후속 PR 빌드 fail**.

## Why

- PR #16671 (\`feat(telemetry): Tool_called row carries typed failure_class option\`) 머지 시 \`lib/tool_types/dune\` 에 preprocess 추가 누락.
- mli 는 \`tool_failure_class_to_yojson\` / \`tool_failure_class_of_yojson\` 을 export 선언 → ml 에서 ppx 자동 생성 기대 → preprocess 없으니 silent 무시 → mli/ml mismatch.
- 같은 lib 안 다른 dune (\`lib/types/dune:10\`, \`lib/dashboard_api_types/dune:9\`, \`lib/coord/dune:83\`) 모두 preprocess pps 명시.

## Fix

\`\`\`diff
 (library
  (name masc_mcp_tool_types)
  (public_name masc_mcp.tool_types)
  (wrapped false)
- (libraries yojson masc_log masc_core eio time_compat))
+ (libraries yojson masc_log masc_core eio time_compat)
+ (preprocess (pps ppx_deriving_yojson)))
\`\`\`

## Validation

- [x] \`dune build --root . lib/tool_types/\` 통과 (no output).
- [ ] CI 빌드 + 다른 dependent 검증.

## Workaround Self-check

| # | Pattern | Status |
|---|---------|--------|
| 1 | Telemetry-as-fix | N/A — 진짜 fix (preprocess 활성화) |
| 2 | String classifier | N/A |
| 3 | N-of-M migration | N/A (1 lib, 1 file) |
| 4 | Catch-all | N/A |
| 5 | Cap/cooldown | N/A |
| 6 | Test backdoor | N/A |
| 7 | N-site fix | N/A |

## RFC waiver

\`RFC-WAIVED: production-blocking build break, dune preprocess hygiene-only — 코드 변경 0, 1 line dune 추가.\`

## Related

- PR #16671 (typed failure_class 도입, preprocess 누락 근원)
- 차단된 작업: RFC-0136 PR-4-a (\`hotfix/...\` → \`rfc/0136-pr-4a-retry-setup\` rebase 의존)

🤖 Generated with [Claude Code](https://claude.com/claude-code)