### PR TITLE
fix(dashboard): typed deriveFiberAlive replaces 4-fallback OR-chain (audit A2)

### DIFF
--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -12,6 +12,7 @@ import { useEffect, useState } from 'preact/hooks'
 // see `lib/server/server_dashboard_http.ml:1114`), which is orthogonal to
 // the blocker-class-vs-stale-execution axis and stays inline below.
 import { deriveKeeperOperationalState } from '../lib/keeper-operational-state'
+import { deriveFiberAlive } from '../lib/keeper-fiber-alive'
 import { formatPct1 } from '../lib/format-number'
 import { formatDuration } from '../lib/format-time'
 import { ActionButton } from './common/button'
@@ -192,11 +193,13 @@ export function deriveKeeperLiveTruth({
   // §AI코드생성 §2 Unknown-→-Permissive-Default anti-pattern that let stale
   // flat-record fields silently feed status badges; removed here.
   const turnPhase = compactToken(compositeSnapshot?.turn_phase ?? keeper.pipeline_stage)
-  const fiberAlive =
-    compositeSnapshot?.phase_diagnosis?.conditions.fiber_alive
-    ?? keeper.keepalive_running
-    ?? keeper.presence_keepalive
-    ?? (linkedState !== 'offline')
+  // Typed SSOT (lib/keeper-fiber-alive.ts) — preserves provenance instead of
+  // collapsing four semantically distinct signals into one OR-chain.
+  const fiberAlive = deriveFiberAlive({
+    keeper,
+    composite: compositeSnapshot,
+    linkedState,
+  }).alive
   const activeTurn = compositeSnapshot?.is_live === true || !isIdleTurnPhase(compositeSnapshot?.turn_phase)
 
   // RFC-0135 PR-5: route the blocker-class axis through the typed SSOT,

--- a/dashboard/src/lib/keeper-fiber-alive.test.ts
+++ b/dashboard/src/lib/keeper-fiber-alive.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { deriveFiberAlive } from './keeper-fiber-alive'
+import type { KeeperCompositeSnapshot } from '../api/schemas/keeper-composite'
+
+const baseComposite = (
+  fiberAlive: boolean | undefined,
+): KeeperCompositeSnapshot | null => {
+  if (fiberAlive === undefined) return null
+  return {
+    phase_diagnosis: {
+      conditions: { fiber_alive: fiberAlive },
+    },
+  } as unknown as KeeperCompositeSnapshot
+}
+
+describe('deriveFiberAlive', () => {
+  it('prefers composite phase_diagnosis when the boolean is present', () => {
+    const r = deriveFiberAlive({
+      keeper: { keepalive_running: false, presence_keepalive: false },
+      composite: baseComposite(true),
+      linkedState: 'offline',
+    })
+    expect(r).toEqual({ alive: true, source: 'composite_phase_diagnosis' })
+  })
+
+  it('reads composite false even when keepalive signals would say true', () => {
+    const r = deriveFiberAlive({
+      keeper: { keepalive_running: true, presence_keepalive: true },
+      composite: baseComposite(false),
+      linkedState: 'idle',
+    })
+    expect(r).toEqual({ alive: false, source: 'composite_phase_diagnosis' })
+  })
+
+  it('falls through to keepalive_running when composite is null', () => {
+    const r = deriveFiberAlive({
+      keeper: { keepalive_running: true, presence_keepalive: false },
+      composite: null,
+      linkedState: 'offline',
+    })
+    expect(r).toEqual({ alive: true, source: 'keepalive_running' })
+  })
+
+  it('falls through to presence_keepalive when keepalive_running is undefined', () => {
+    const r = deriveFiberAlive({
+      keeper: { keepalive_running: undefined, presence_keepalive: true },
+      composite: null,
+      linkedState: 'offline',
+    })
+    expect(r).toEqual({ alive: true, source: 'presence_keepalive' })
+  })
+
+  it('falls through to link-state inference when all per-keeper signals are absent', () => {
+    const r1 = deriveFiberAlive({
+      keeper: { keepalive_running: undefined, presence_keepalive: undefined },
+      composite: null,
+      linkedState: 'offline',
+    })
+    expect(r1).toEqual({ alive: false, source: 'link_state_inference' })
+
+    const r2 = deriveFiberAlive({
+      keeper: { keepalive_running: undefined, presence_keepalive: undefined },
+      composite: null,
+      linkedState: 'running',
+    })
+    expect(r2).toEqual({ alive: true, source: 'link_state_inference' })
+  })
+
+  it('treats explicit false from a higher-priority source as authoritative', () => {
+    // Regression guard: a careless OR-chain (`?? a ?? b`) skips only
+    // null/undefined — booleans must stick. The typed function preserves
+    // that: an explicit `false` at keepalive_running is the authority,
+    // not a signal-absence that should fall through.
+    const r = deriveFiberAlive({
+      keeper: { keepalive_running: false, presence_keepalive: true },
+      composite: null,
+      linkedState: 'running',
+    })
+    expect(r).toEqual({ alive: false, source: 'keepalive_running' })
+  })
+})

--- a/dashboard/src/lib/keeper-fiber-alive.ts
+++ b/dashboard/src/lib/keeper-fiber-alive.ts
@@ -1,0 +1,61 @@
+// Typed fiber-alive decision for a keeper.
+//
+// Background: `keeper-detail-runtime.ts` derived `fiberAlive` from a
+// 4-fallback chain that mixed four *semantically distinct* signals:
+//
+//   composite?.phase_diagnosis?.conditions.fiber_alive
+//   ?? keeper.keepalive_running
+//   ?? keeper.presence_keepalive
+//   ?? (linkedState !== 'offline')
+//
+// Each signal answers a slightly different question:
+//   1. composite truth         — "what did the observer record?"
+//   2. keepalive_running       — "is the keepalive thread alive?"
+//   3. presence_keepalive      — "did the presence ping arrive?"
+//   4. link-state inference    — "do we even believe the keeper exists?"
+//
+// Collapsing them into one OR-chain loses provenance: when the dashboard
+// shows "fiber alive" or "fiber dead", an operator cannot trace which
+// source produced the verdict. This module returns the verdict *and*
+// its source so downstream UI / debug surfaces can disambiguate.
+
+import type { Keeper } from '../types'
+import type { KeeperCompositeSnapshot } from '../api/schemas/keeper-composite'
+
+export type FiberAliveSource =
+  | 'composite_phase_diagnosis'
+  | 'keepalive_running'
+  | 'presence_keepalive'
+  | 'link_state_inference'
+
+export interface FiberAliveDecision {
+  readonly alive: boolean
+  readonly source: FiberAliveSource
+}
+
+interface FiberAliveInput {
+  readonly keeper: Pick<Keeper, 'keepalive_running' | 'presence_keepalive'>
+  readonly composite: KeeperCompositeSnapshot | null
+  /** Result of `linkedRuntimeState(keeper)` — a string state ('offline'
+   *  or other). Pass through as-is; this module only checks the
+   *  offline sentinel to inform the lowest-priority fallback. */
+  readonly linkedState: string
+}
+
+export function deriveFiberAlive({
+  keeper,
+  composite,
+  linkedState,
+}: FiberAliveInput): FiberAliveDecision {
+  const fromComposite = composite?.phase_diagnosis?.conditions.fiber_alive
+  if (typeof fromComposite === 'boolean') {
+    return { alive: fromComposite, source: 'composite_phase_diagnosis' }
+  }
+  if (typeof keeper.keepalive_running === 'boolean') {
+    return { alive: keeper.keepalive_running, source: 'keepalive_running' }
+  }
+  if (typeof keeper.presence_keepalive === 'boolean') {
+    return { alive: keeper.presence_keepalive, source: 'presence_keepalive' }
+  }
+  return { alive: linkedState !== 'offline', source: 'link_state_inference' }
+}


### PR DESCRIPTION
## Summary

Dashboard SSOT audit (2026-05-19 P1) **A2** — CRIT severity. \`keeper-detail-runtime.ts:195–199\` 의 4-fallback OR-chain 을 typed function \`deriveFiberAlive\` 로 추출.

## Why

기존 코드는 *semantically distinct* 4 signal 을 OR 로 collapse:

\`\`\`ts
const fiberAlive =
  composite?.phase_diagnosis?.conditions.fiber_alive
  ?? keeper.keepalive_running
  ?? keeper.presence_keepalive
  ?? (linkedState !== 'offline')
\`\`\`

각 signal 의 의미가 다름:

| 우선순위 | Signal | 질문 |
|---|---|---|
| 1 | \`composite.phase_diagnosis.conditions.fiber_alive\` | "observer 가 기록한 진실" |
| 2 | \`keeper.keepalive_running\` | "keepalive 스레드가 살아있나?" |
| 3 | \`keeper.presence_keepalive\` | "presence ping 이 도착했나?" |
| 4 | \`linkedState !== 'offline'\` | "keeper 가 존재한다고 믿는가?" |

문제:
1. **Provenance loss**: dashboard 가 "fiber alive" 또는 "fiber dead" 표시 시 operator 가 *어느 source* 에서 그 verdict 가 왔는지 trace 불가
2. **OR-chain 의 misleading 동작**: \`??\` 가 nullish 만 short-circuit — 그러나 boolean \`false\` 가 *명시 verdict* 인 source 에서는 *위 source 의 \`false\` 가 down-source 의 \`true\` 로 덮이는* 일이 없어야 함. 의도가 코드에서 안 드러남

## What Changed

신규 모듈 \`lib/keeper-fiber-alive.ts\`:

\`\`\`ts
export interface FiberAliveDecision {
  readonly alive: boolean
  readonly source: FiberAliveSource  // 4 variants
}

export function deriveFiberAlive(input): FiberAliveDecision
\`\`\`

- 동작 동일 (priority order + boolean output 보존)
- \`source\` field 명시 → debug surface / telemetry 에서 사용 가능 (현재 caller 는 \`.alive\` 만 사용)
- 6 unit tests (4 sources + composite-false override + boolean-false 회귀 guard)

## Test plan

- [x] \`pnpm typecheck\` PASS
- [x] 6/6 new fiber-alive tests PASS
- [x] 119/119 related tests PASS
- [ ] human review

## Related

- RFC-0135 §11 (typed sum SSOT)
- A1 #16662, F1 #16652, F2 #16669 — 같은 audit cycle의 typed boundary 패턴
- Dashboard SSOT/IA audit 2026-05-19 (A2)

RFC-WAIVED: typed extraction, semantic-preserving

🤖 Generated with [Claude Code](https://claude.com/claude-code)