### PR TITLE
feat(dashboard): RFC-0135 PR-14a KeeperAttention axis SSOT

### DIFF
--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -11,7 +11,7 @@ import { useEffect, useState } from 'preact/hooks'
 // represent *live-execution* attention (`execution_current && blocked`,
 // see `lib/server/server_dashboard_http.ml:1114`), which is orthogonal to
 // the blocker-class-vs-stale-execution axis and stays inline below.
-import { deriveKeeperOperationalState } from '../lib/keeper-operational-state'
+import { deriveKeeperAttention, deriveKeeperOperationalState } from '../lib/keeper-operational-state'
 import { formatPct1 } from '../lib/format-number'
 import { formatDuration } from '../lib/format-time'
 import { ActionButton } from './common/button'
@@ -199,21 +199,22 @@ export function deriveKeeperLiveTruth({
     ?? (linkedState !== 'offline')
   const activeTurn = compositeSnapshot?.is_live === true || !isIdleTurnPhase(compositeSnapshot?.turn_phase)
 
-  // RFC-0135 PR-5: route the blocker-class axis through the typed SSOT,
-  // matching the roster card (`agent-roster.ts:rosterStateNote`). The
-  // attention-level axis (live-execution blocked / needs_attention) is
-  // separate — backend sets it as `execution_current && blocked`, which
-  // typed state does not cover, so it stays inline.
+  // RFC-0135 PR-5 + PR-14a: blocker-class axis via typed
+  // `KeeperOperationalState` SSOT; orthogonal backend-attention axis
+  // via `deriveKeeperAttention`. Previously the attention OR was
+  // inlined (`composite.runtime_attention.blocked ||
+  // .needs_attention`), making the two axes a parallel input pair to
+  // the same `blocked` flag that downstream UI checked. The helper
+  // now owns the priority + null-fallback decision so a future axis
+  // (e.g. `acknowledged_at`) is added in one place.
   const opState = deriveKeeperOperationalState({
     keeper,
     composite: compositeSnapshot,
   })
   const stuckByBlockerClass = opState.kind === 'stuck'
   const staleBlocker = opState.kind === 'running' ? opState.staleBlocker : null
-  const attentionBlocked =
-    compositeSnapshot?.runtime_attention?.blocked === true
-    || compositeSnapshot?.runtime_attention?.needs_attention === true
-  const blocked = stuckByBlockerClass || attentionBlocked
+  const attention = deriveKeeperAttention(compositeSnapshot ?? null)
+  const blocked = stuckByBlockerClass || attention !== 'clean'
   const stopRequested =
     compositeSnapshot?.runtime_attention?.fiber_stop_requested === true
     || compositeSnapshot?.phase_diagnosis?.conditions.stop_requested === true
@@ -319,7 +320,7 @@ export function deriveKeeperLiveTruth({
         // operator mental model.
         value: stuckByBlockerClass
           ? opState.reason
-          : attentionBlocked
+          : attention !== 'clean'
             ? compactToken(compositeSnapshot?.runtime_attention?.state, 'blocked')
             : 'none',
         detail: staleBlocker !== null

--- a/dashboard/src/lib/keeper-operational-state.test.ts
+++ b/dashboard/src/lib/keeper-operational-state.test.ts
@@ -6,8 +6,10 @@ import {
   compositeIsRunning,
   compositeIsTurnIdle,
   compositePhaseTone,
+  deriveKeeperAttention,
   deriveKeeperOperationalState,
   toKsmPhase,
+  type KeeperAttention,
   type KeeperKsmPhase,
   type KeeperOperationalState,
 } from './keeper-operational-state'
@@ -435,5 +437,37 @@ describe('compositeIsRunning / compositeIsTurnIdle — wire-format helpers', () 
   })
   it('turn_phase=executing ⇒ false', () => {
     expect(compositeIsTurnIdle({ turn_phase: 'executing' })).toBe(false)
+  })
+})
+
+describe('deriveKeeperAttention — RFC-0135 PR-14a', () => {
+  const makeComposite = (
+    attentionOverrides: Partial<{ blocked: boolean; needs_attention: boolean }>,
+  ): KeeperCompositeSnapshot =>
+    ({
+      keeper: 'test',
+      runtime_attention: {
+        blocked: false,
+        needs_attention: false,
+        ...attentionOverrides,
+      },
+    } as unknown as KeeperCompositeSnapshot)
+
+  it('blocked=true ⇒ blocked', () => {
+    expect(deriveKeeperAttention(makeComposite({ blocked: true }))).toBe<KeeperAttention>('blocked')
+  })
+  it('needs_attention=true ⇒ needs_attention', () => {
+    expect(deriveKeeperAttention(makeComposite({ needs_attention: true }))).toBe<KeeperAttention>('needs_attention')
+  })
+  it('blocked beats needs_attention when both set', () => {
+    expect(
+      deriveKeeperAttention(makeComposite({ blocked: true, needs_attention: true })),
+    ).toBe<KeeperAttention>('blocked')
+  })
+  it('neither flag set ⇒ clean', () => {
+    expect(deriveKeeperAttention(makeComposite({}))).toBe<KeeperAttention>('clean')
+  })
+  it('null composite ⇒ clean (no backend attestation)', () => {
+    expect(deriveKeeperAttention(null)).toBe<KeeperAttention>('clean')
   })
 })

--- a/dashboard/src/lib/keeper-operational-state.ts
+++ b/dashboard/src/lib/keeper-operational-state.ts
@@ -47,6 +47,24 @@ export type OfflineCause = 'unbooted' | 'shutdown' | 'crashed' | 'dead' | 'unkno
 export type PausedCause = 'operator' | 'supervisor' | 'auto_recover' | 'unknown'
 export type StuckReason = KeeperRuntimeBlockerClass | 'fiber_dead' | 'unknown'
 
+// RFC-0135 PR-14a — attention axis SSOT (Goal-2 typed-state expansion).
+//
+// `runtime_attention.{blocked,needs_attention}` was previously OR'd
+// against `state.kind === 'stuck'` inline at
+// `components/keeper-detail-runtime.ts:213-216`, leaving the typed
+// state and the attention axis as parallel inputs to the same
+// `blocked` decision. The two axes are *orthogonal* — a running keeper
+// can have `attention: 'needs_attention'` set by backend without any
+// blocker class, and a stuck keeper can have its attention cleared
+// after operator acknowledgement. Encoding attention as a sum next to
+// `KeeperOperationalState` keeps both signals explicit.
+//
+// Closed sum (no catch-all per RFC-0135 §9-4):
+//   blocked          — backend says live execution is held
+//   needs_attention  — backend flagged operator action required
+//   clean            — neither set, no orange edge on dashboard
+export type KeeperAttention = 'blocked' | 'needs_attention' | 'clean'
+
 export type KeeperOperationalState =
   | { readonly kind: 'offline'; readonly cause: OfflineCause }
   | { readonly kind: 'paused'; readonly cause: PausedCause }
@@ -143,6 +161,25 @@ function compositeFiberKnownDead(c: KeeperCompositeSnapshot): boolean {
   if (diag == null) return false
   const fiberAlive = diag.conditions.fiber_alive
   return fiberAlive === false
+}
+
+/** RFC-0135 PR-14a — orthogonal attention axis.
+ *
+ *  Maps `composite.runtime_attention.{blocked, needs_attention}` to a
+ *  closed sum. Priority: `blocked` over `needs_attention` (backend can
+ *  set both, in which case the operator-blocking case is louder).
+ *
+ *  When composite is null, returns `'clean'` — without backend
+ *  attestation the dashboard has no basis to claim attention is needed.
+ *  Callers may still combine this with `state.kind === 'stuck'` if
+ *  blocker-class evidence alone should surface an alert. */
+export function deriveKeeperAttention(
+  composite: KeeperCompositeSnapshot | null,
+): KeeperAttention {
+  const attention = composite?.runtime_attention
+  if (attention?.blocked === true) return 'blocked'
+  if (attention?.needs_attention === true) return 'needs_attention'
+  return 'clean'
 }
 
 // RFC-0135 PR-11 — Composite KSM phase SSOT helpers.


### PR DESCRIPTION
## Summary

Closes audit finding **B3 (HIGH)** — `keeper-detail-runtime.ts:213-216` inlined `composite.runtime_attention.{blocked, needs_attention}` as a parallel axis OR'd against `state.kind === 'stuck'`.

## New helper

### `lib/keeper-operational-state.ts`
- `KeeperAttention` closed sum: `'blocked' | 'needs_attention' | 'clean'`
- `deriveKeeperAttention(composite)`: maps `composite.runtime_attention` to the typed sum. Priority `blocked > needs_attention`. Null composite → `'clean'`.

## Migration

`keeper-detail-runtime.ts:213-216`:
```diff
- const attentionBlocked =
-   compositeSnapshot?.runtime_attention?.blocked === true
-   || compositeSnapshot?.runtime_attention?.needs_attention === true
- const blocked = stuckByBlockerClass || attentionBlocked
+ const attention = deriveKeeperAttention(compositeSnapshot ?? null)
+ const blocked = stuckByBlockerClass || attention !== 'clean'
```

Downstream '차단' row consumer (line 323) updated to read `attention !== 'clean'`.

## Why orthogonal axis (not variant field)

`KeeperOperationalState` kinds describe *what the keeper is doing*; attention is *what backend asks operator to look at*. They can co-occur in any combo (e.g. `running + needs_attention` is the typical "near context budget" case). Separate axis avoids 4×3 variant explosion.

## Verification
- [x] `pnpm typecheck` → pass
- [x] `pnpm vitest run keeper-operational-state keeper-detail-runtime` → **105/105 pass** (+5 new)
- [x] `bash scripts/lint/dashboard-ssot-keeper-state.sh` → exit 0
- [x] diff: 3 files, +83/-11

## Plan
Goal-2 of audit splits into 4 sub-PRs (one axis each) to keep review surface small:
- **PR-14a (this) — `attention`** axis
- PR-14b — `turnPhase` axis (closes `keeper-detail-runtime.ts:194` 2-way fallback)
- PR-14c — `displaySummary` axis (closes `keeper-detail-runtime.ts:256` fallback)
- PR-14d — `phase` axis (closes `monitoring-runtime.ts:165` composite-preferred logic)

## RFC reference
RFC-0135 §2 typed-model expansion + §9-4. Goal-2a of `~/me/.tmp/masc-dashboard-ssot-audit-2026-05-19.html`.

RFC-WAIVED: N/A — strengthens RFC-0135 SSOT.

---

Status: Draft — agent PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>