### PR TITLE
fix(dashboard): governance alert_level / risk_level typed (audit F4)

### DIFF
--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -1,5 +1,6 @@
 import { currentDashboardActor, get, post, del, put, withRetries, defaultBoardVoter } from './core'
 import { isRecord, asNullableString, asString, asNumber, asInt, asStringList } from '../components/common/normalize'
+import { asKeeperApprovalRiskLevel } from '../lib/governance-risk-level'
 import { timeBoardRequest } from '../board-metrics'
 import type {
   BoardActorIdentity, BoardPost, BoardComment, BoardReactionSummary,
@@ -65,7 +66,7 @@ export function normalizeKeeperApprovalQueueItem(raw: unknown): KeeperApprovalQu
   const id = asString(raw.id, '').trim()
   const keeperName = asString(raw.keeper_name, '').trim()
   const toolName = asString(raw.tool_name, '').trim()
-  const riskLevel = asString(raw.risk_level, '').trim()
+  const riskLevel = asKeeperApprovalRiskLevel(raw.risk_level)
   if (!id || !keeperName || !toolName || !riskLevel) return null
   const runtimeContract = isRecord(raw.runtime_contract)
     ? {

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -35,6 +35,7 @@ import {
   type ProviderLogTailResponse,
 } from './schemas/provider-logs'
 import { asKeeperRuntimeBlockerClass } from '../lib/runtime-blocker-class'
+import { asKeeperApprovalRiskLevel } from '../lib/governance-risk-level'
 import type {
   KeeperConfig,
   KeeperFeatureStatus,
@@ -438,7 +439,7 @@ function normalizeKeeperApprovalRule(raw: unknown): KeeperApprovalRule | null {
     request_fingerprint: asNullableString(raw.request_fingerprint) ?? undefined,
     request_fingerprint_preview:
       asNullableString(raw.request_fingerprint_preview) ?? undefined,
-    max_risk: asNullableString(raw.max_risk) ?? undefined,
+    max_risk: asKeeperApprovalRiskLevel(raw.max_risk) ?? undefined,
     created_at: asNullableIsoTimestamp(raw.created_at_iso ?? raw.created_at),
     created_by: asNullableString(raw.created_by),
     last_matched_at:

--- a/dashboard/src/lib/governance-risk-level.ts
+++ b/dashboard/src/lib/governance-risk-level.ts
@@ -1,0 +1,34 @@
+// Typed parsers for governance risk-level wire strings.
+//
+// Backend SSOT:
+//   `lib/governance_pipeline_types.ml:1-18` —
+//     type risk_level = Low | Medium | High | Critical
+//   `risk_level_to_string` serializes to {low, medium, high, critical}.
+// Same vocabulary at `lib/keeper/keeper_approval_queue.ml:49-53, :814`.
+//
+// Companion to `lib/runtime-blocker-class.ts` and
+// `lib/keeper-runtime-state.ts` — same boundary-hardening pattern.
+
+import type { KeeperApprovalRiskLevel } from '../types/governance'
+
+const RISK_LEVEL_VALUES: ReadonlySet<string> = new Set([
+  'low',
+  'medium',
+  'high',
+  'critical',
+] satisfies readonly KeeperApprovalRiskLevel[])
+
+export function isKeeperApprovalRiskLevel(
+  value: string,
+): value is KeeperApprovalRiskLevel {
+  return RISK_LEVEL_VALUES.has(value)
+}
+
+export function asKeeperApprovalRiskLevel(
+  value: unknown,
+): KeeperApprovalRiskLevel | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim().toLowerCase()
+  if (trimmed === '') return null
+  return isKeeperApprovalRiskLevel(trimmed) ? trimmed : null
+}

--- a/dashboard/src/types/governance.ts
+++ b/dashboard/src/types/governance.ts
@@ -157,8 +157,14 @@ export interface GovernanceJudgeSummary {
   last_error?: string | null
 }
 
+// Wire emit: `lib/dashboard/dashboard_http_monitoring.ml:143–149,170,
+//   195–199,226` — alert_level is computed as exactly one of
+//   {"ok","warn","bad"}. The previous `| string` catch-all hid this
+//   closed vocabulary and let unmapped values flow through.
+export type GovernanceAlertLevel = 'ok' | 'warn' | 'bad'
+
 export interface BoardMonitoring {
-  alert_level?: 'ok' | 'warn' | 'bad' | string
+  alert_level?: GovernanceAlertLevel
   posts_total?: number
   new_posts_24h?: number
   unanswered_posts?: number
@@ -168,7 +174,7 @@ export interface BoardMonitoring {
 }
 
 export interface GovernanceMonitoring {
-  alert_level?: 'ok' | 'warn' | 'bad' | string
+  alert_level?: GovernanceAlertLevel
   note?: string
   cases_open?: number
   pending_ruling?: number
@@ -196,13 +202,20 @@ export interface PendingConfirmation {
   preview?: unknown
 }
 
+// Wire emit: `lib/governance_pipeline_types.ml:1–18` —
+//   `type risk_level = Low | Medium | High | Critical`,
+//   `risk_level_to_string` produces exactly these four lowercase strings.
+//   Same vocabulary at `lib/keeper/keeper_approval_queue.ml:49–53` and
+//   serialized at `:814`. Frontend was untyped `string`.
+export type KeeperApprovalRiskLevel = 'low' | 'medium' | 'high' | 'critical'
+
 export interface KeeperApprovalQueueItem {
   id: string
   keeper_name: string
   tool_name: string
   action_key?: string | null
   sandbox_target?: string | null
-  risk_level: string
+  risk_level: KeeperApprovalRiskLevel
   requested_at?: string | null
   waiting_s?: number
   turn_id?: number | null
@@ -236,7 +249,9 @@ export interface KeeperApprovalRule {
   backend?: string | null
   request_fingerprint?: string
   request_fingerprint_preview?: string
-  max_risk?: string
+  /** Same vocabulary as `KeeperApprovalRiskLevel` (backend
+   *  `risk_level_to_string` ∈ {low, medium, high, critical}). */
+  max_risk?: KeeperApprovalRiskLevel
   created_at?: string | null
   created_by?: string | null
   last_matched_at?: string | null


### PR DESCRIPTION
## Summary

Dashboard SSOT audit (2026-05-19 P1/P2) **F4** — governance interfaces 의 untyped/catch-all string unions 4 곳 closure.

## Backend SSOT

| Field | Backend variant | Wire vocabulary |
|---|---|---|
| \`alert_level\` | computed at \`dashboard_http_monitoring.ml:143-149,170,195-199,226\` | \`{\"ok\",\"warn\",\"bad\"}\` closed 3-arm |
| \`risk_level\` | \`governance_pipeline_types.ml:1-18\` \`type risk_level = Low \| Medium \| High \| Critical\` | \`{low, medium, high, critical}\` closed 4-arm |

같은 vocabulary 가 \`keeper_approval_queue.ml:49-53, :814\` 에서도 사용 — backend 측은 *완전한 closed enum*. 그러나 frontend 가 \`| string\` catch-all 또는 raw \`string\` 으로 약화.

## What Changed

1. \`types/governance.ts\`:
   - new export \`GovernanceAlertLevel = 'ok' | 'warn' | 'bad'\`
   - new export \`KeeperApprovalRiskLevel = 'low' | 'medium' | 'high' | 'critical'\`
   - 4 interface fields 모두 closed unions 로 narrow

2. \`lib/governance-risk-level.ts\` 신설: \`asKeeperApprovalRiskLevel\` typed parser (boundary narrowing, F1 의 \`lib/keeper-runtime-state.ts\` 패턴 복제)

3. \`api/board.ts:68\` + \`api/dashboard.ts:441\` — raw \`asString\` → typed parser

\`alert_level\` 의 display callers (string-equality 비교) 는 이미 implicit closed set 가정 — caller-side 변경 불필요.

## Trade-off

- 회귀 위험: 없음. backend wire 는 closed vocabulary
- 새 모듈: \`lib/governance-risk-level.ts\` (parser 만, 30 lines) — F1/F2 boundary pattern 일관
- caller=2 (board.ts, dashboard.ts) 가 둘 다 api/ 안 → typed boundary 강제

## Test plan

- [x] \`pnpm typecheck\` PASS
- [x] 395/395 api tests PASS
- [ ] human review

## Related

- F1 #16652 (✅ merged) — 같은 boundary hardening 패턴 (\`KeeperPauseState\`)
- F2 #16669 (✅ merged) — wire boundary typed narrowing (\`OasKeeperLifecycleEvent.phase\`)
- A1 #16662 (✅ merged) — compile-time coverage check (\`KeeperPhase\`)
- Dashboard SSOT/IA audit 2026-05-19 (F4)

RFC-WAIVED: typed sum closure, no architectural change

🤖 Generated with [Claude Code](https://claude.com/claude-code)