### PR TITLE
feat(dashboard): RFC-0135 PR-14b deriveKeeperTurnPhase axis SSOT

### DIFF
--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -11,7 +11,7 @@ import { useEffect, useState } from 'preact/hooks'
 // represent *live-execution* attention (`execution_current && blocked`,
 // see `lib/server/server_dashboard_http.ml:1114`), which is orthogonal to
 // the blocker-class-vs-stale-execution axis and stays inline below.
-import { deriveKeeperAttention, deriveKeeperDisplayReason, deriveKeeperOperationalState } from '../lib/keeper-operational-state'
+import { deriveKeeperAttention, deriveKeeperDisplayReason, deriveKeeperOperationalState, deriveKeeperTurnPhase } from '../lib/keeper-operational-state'
 import { deriveFiberAlive } from '../lib/keeper-fiber-alive'
 import { formatPct1 } from '../lib/format-number'
 import { formatDuration } from '../lib/format-time'
@@ -186,13 +186,13 @@ export function deriveKeeperLiveTruth({
   runtimeResolution?: KeeperLiveTruthRuntimeInput | null
 }): KeeperLiveTruthSummary {
   const linkedState = linkedRuntimeState(keeper)
-  // Per-axis SSOT routing (RFC-0046 §4.3): the FSM hub below this panel is
-  // the canonical phase/turn surface, so this panel only needs `turnPhase`
-  // for the contextual "현재 턴" row detail. The old 3-way fallback
-  // `compositeSnapshot?.phase ?? keeper.phase ?? keeper.status` was the
-  // §AI코드생성 §2 Unknown-→-Permissive-Default anti-pattern that let stale
-  // flat-record fields silently feed status badges; removed here.
-  const turnPhase = compactToken(compositeSnapshot?.turn_phase ?? keeper.pipeline_stage)
+  // RFC-0135 PR-14b: turn-phase SSOT. The 2-way fallback
+  // `compositeSnapshot?.turn_phase ?? keeper.pipeline_stage` is owned
+  // by `deriveKeeperTurnPhase` so the composite-preferred precedence
+  // can be reused by other consumers (the prior 3-way fallback was
+  // removed by PR-5; this PR finishes the move by moving the 2-way
+  // fallback itself into SSOT).
+  const turnPhase = compactToken(deriveKeeperTurnPhase(keeper, compositeSnapshot ?? null))
   // Typed SSOT (lib/keeper-fiber-alive.ts) — preserves provenance instead of
   // collapsing four semantically distinct signals into one OR-chain.
   const fiberAlive = deriveFiberAlive({

--- a/dashboard/src/lib/keeper-operational-state.test.ts
+++ b/dashboard/src/lib/keeper-operational-state.test.ts
@@ -9,6 +9,7 @@ import {
   deriveKeeperAttention,
   deriveKeeperDisplayReason,
   deriveKeeperOperationalState,
+  deriveKeeperTurnPhase,
   toKsmPhase,
   type KeeperAttention,
   type KeeperKsmPhase,
@@ -514,5 +515,30 @@ describe('deriveKeeperDisplayReason — RFC-0135 PR-14c', () => {
   })
   it('returns null when no source has a non-empty value', () => {
     expect(deriveKeeperDisplayReason({} as Keeper, null)).toBeNull()
+  })
+})
+
+describe('deriveKeeperTurnPhase — RFC-0135 PR-14b', () => {
+  it('composite turn_phase wins over flat pipeline_stage', () => {
+    expect(
+      deriveKeeperTurnPhase(
+        { pipeline_stage: 'idle' } as Keeper,
+        { turn_phase: 'executing' } as unknown as KeeperCompositeSnapshot,
+      ),
+    ).toBe('executing')
+  })
+  it('falls back to pipeline_stage when composite null', () => {
+    expect(deriveKeeperTurnPhase({ pipeline_stage: 'compacting' } as Keeper, null)).toBe('compacting')
+  })
+  it('falls back to pipeline_stage when composite turn_phase empty string', () => {
+    expect(
+      deriveKeeperTurnPhase(
+        { pipeline_stage: 'handoff' } as Keeper,
+        { turn_phase: '' } as unknown as KeeperCompositeSnapshot,
+      ),
+    ).toBe('handoff')
+  })
+  it('returns null when both sources empty', () => {
+    expect(deriveKeeperTurnPhase({} as Keeper, null)).toBeNull()
   })
 })

--- a/dashboard/src/lib/keeper-operational-state.ts
+++ b/dashboard/src/lib/keeper-operational-state.ts
@@ -38,6 +38,7 @@
 import type {
   Keeper,
   KeeperRuntimeBlockerClass,
+  PipelineStage,
 } from '../types/core'
 import type {
   KeeperCompositeSnapshot,
@@ -297,4 +298,36 @@ export function deriveKeeperDisplayReason(
     ?? trim(keeper.attention_reason)
     ?? null
   )
+}
+
+// RFC-0135 PR-14b — turn-phase SSOT (Goal-2b typed-state expansion).
+//
+// `keeper-detail-runtime.ts:194-195` (and one earlier 3-way fallback
+// removed by PR-5) read turn phase via composite-or-flat fallback:
+//   `compositeSnapshot?.turn_phase ?? keeper.pipeline_stage`
+// The two sources have different semantics (composite is the *live*
+// KTC turn cycle from backend; pipeline_stage is the flat-record
+// snapshot of the prior turn) but downstream consumers treat them as
+// interchangeable strings. Centralizing the fallback policy here lets
+// future consumers (Goal-2c displaySummary, Goal-2d phase) reuse the
+// same precedence without re-reading raw composite fields.
+//
+// Precedence (composite preferred):
+//   1. composite.turn_phase if composite present
+//   2. keeper.pipeline_stage (flat record fallback)
+//   3. null (no signal available)
+
+/** Live turn phase, preferring composite SSE stream over flat record.
+ *  Returns `null` when no source has a value. Caller-side `??` against
+ *  a literal default (e.g. `'idle'`) is the supported fallback shape
+ *  — do not embed display defaults here. */
+export function deriveKeeperTurnPhase(
+  keeper: Pick<Keeper, 'pipeline_stage'>,
+  composite: KeeperCompositeSnapshot | null,
+): string | null {
+  const compositeTurn = composite?.turn_phase
+  if (typeof compositeTurn === 'string' && compositeTurn.length > 0) return compositeTurn
+  const flatStage: PipelineStage | undefined = keeper.pipeline_stage
+  if (typeof flatStage === 'string' && flatStage.length > 0) return flatStage
+  return null
 }


### PR DESCRIPTION
## Summary

Closes audit **Goal-2b** — `keeper-detail-runtime.ts:194-195` inlined the 2-way fallback `compositeSnapshot?.turn_phase ?? keeper.pipeline_stage`, mixing composite (live KTC turn cycle) with flat-record `pipeline_stage` (snapshot of prior turn) as if interchangeable.

## New helper

### `lib/keeper-operational-state.ts`
`deriveKeeperTurnPhase(keeper, composite)`:
- composite-preferred fallback with explicit empty-string handling
- returns `null` when no source has a non-empty value
- caller's `??` against a literal default is the supported shape (display defaults stay at callsite)

## Migration

```diff
- const turnPhase = compactToken(compositeSnapshot?.turn_phase ?? keeper.pipeline_stage)
+ const turnPhase = compactToken(deriveKeeperTurnPhase(keeper, compositeSnapshot ?? null))
```

The 3-way fallback was removed by PR-5; this PR finishes the move by relocating the 2-way fallback policy itself into SSOT. Future consumers (PR-14c/d) call this helper instead of reading raw composite fields.

## Verification
- [x] `pnpm typecheck` → pass
- [x] `pnpm vitest run keeper-operational-state keeper-detail-runtime` → 104/104 pass (+4 new)
- [x] `bash scripts/lint/dashboard-ssot-keeper-state.sh` → exit 0
- [x] diff: 3 files, +68/-8

## Plan
- PR-14a (#16687) — `attention` axis ✓
- **PR-14b (this) — `turnPhase` axis**
- PR-14c — `displaySummary` axis (next)
- PR-14d — `phase` axis

## RFC reference
RFC-0135 §2 typed-model expansion. Goal-2b of audit `~/me/.tmp/masc-dashboard-ssot-audit-2026-05-19.html`.

RFC-WAIVED: N/A.

---

Status: Draft — agent PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>