### PR TITLE
fix(server_auth): exhaustive http_status_of_auth_error mirroring Masc_error.code

### DIFF
--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -498,10 +498,36 @@ let ensure_same_origin_browser_request request :
                { agent = "browser";
                  action = "cross-origin HTTP mutation" })))
 
-let http_status_of_auth_error = function
-  | Masc_domain.Auth (Masc_domain.Auth_error.Unauthorized _ | Masc_domain.Auth_error.InvalidToken _ | Masc_domain.Auth_error.TokenExpired _) -> `Unauthorized
+(* Mirrors [Masc_error.code] (the typed SSOT in lib/types/masc_error.ml).
+   Previously the catch-all [_ -> `Internal_server_error] silently demoted
+   [RateLimitExceeded _] to 500 (should be 429), [Task/Agent (NotFound _)]
+   to 500 (should be 404), and the 400-class validation errors to 500.
+   Operators reading the access log could not distinguish rate limiting
+   from a real server fault. The match is now exhaustive; adding a new
+   [Masc_error.t] outer variant will trip Warning 8 here and force an
+   explicit HTTP-status decision. *)
+let http_status_of_auth_error : Masc_domain.masc_error -> Httpun.Status.t =
+  function
+  | Masc_domain.Auth
+      (Masc_domain.Auth_error.Unauthorized _
+      | Masc_domain.Auth_error.InvalidToken _
+      | Masc_domain.Auth_error.TokenExpired _) -> `Unauthorized
   | Masc_domain.Auth (Masc_domain.Auth_error.Forbidden _) -> `Forbidden
-  | _ -> `Internal_server_error
+  | Masc_domain.Task (Masc_domain.Task_error.NotFound _) -> `Not_found
+  | Masc_domain.Agent (Masc_domain.Agent_error.NotFound _) -> `Not_found
+  | Masc_domain.Task
+      (Masc_domain.Task_error.AlreadyClaimed _
+      | Masc_domain.Task_error.NotClaimed _
+      | Masc_domain.Task_error.InvalidState _
+      | Masc_domain.Task_error.InvalidId _) -> `Bad_request
+  | Masc_domain.Agent
+      (Masc_domain.Agent_error.NotJoined _
+      | Masc_domain.Agent_error.AlreadyJoined _
+      | Masc_domain.Agent_error.InvalidName _) -> `Bad_request
+  | Masc_domain.Portal _ -> `Bad_request
+  | Masc_domain.System _ -> `Bad_request
+  | Masc_domain.RateLimitExceeded _ -> `Too_many_requests
+  | Masc_domain.CacheError _ -> `Internal_server_error
 
 (** Server state - initialized at startup *)
 let server_state : Mcp_server.server_state option ref = ref None


### PR DESCRIPTION
## Summary

\`http_status_of_auth_error\` accepted the full \`Masc_domain.masc_error\` type but only enumerated Auth subvariants; everything else fell through \`_ -> \\\`Internal_server_error\`. This silently demoted real signals (rate limiting, not-found, validation) to 500. The match is now exhaustive and mirrors \`Masc_error.code\` — the typed SSOT in \`lib/types/masc_error.ml\`.

## Why

\`authorize_tool_request\` returns \`(unit, Masc_domain.masc_error) result\` where \`masc_error\` has 7 outer variants (\`Task\`, \`Agent\`, \`Auth\`, \`Portal\`, \`System\`, \`RateLimitExceeded\`, \`CacheError\`). The previous mapper handled only \`Auth\` subvariants explicitly; the catch-all collapsed everything else to 500:

| Variant | Before | After |
|---|---|---|
| \`Auth (Unauthorized | InvalidToken | TokenExpired)\` | 401 | 401 |
| \`Auth (Forbidden _)\` | 403 | 403 |
| \`Task (NotFound _)\` | **500** | **404** |
| \`Agent (NotFound _)\` | **500** | **404** |
| \`Task (AlreadyClaimed/NotClaimed/InvalidState/InvalidId)\` | **500** | **400** |
| \`Agent (NotJoined/AlreadyJoined/InvalidName)\` | **500** | **400** |
| \`Portal _\` | **500** | **400** |
| \`System _\` | **500** | **400** |
| \`RateLimitExceeded _\` | **500** | **429** |
| \`CacheError _\` | 500 | 500 |

User-facing impact: an operator inspecting the access log for rate-limited traffic previously saw it as generic 5xx server faults. \`Too_many_requests\` (429) and \`Not_found\` (404) now reach the client correctly, and structured monitoring on 5xx error rate no longer trips on validation errors.

## Change

- Enumerate every \`Masc_error.t\` outer variant, mirroring \`Masc_error.code\` exactly.
- Task/Agent inner subsets are listed explicitly so a *new* inner variant trips Warning 8 and forces an explicit HTTP-status decision.
- Portal/System collapse to single \`Portal _\` / \`System _\` arms to match \`Masc_error.code\`'s intentional bucket (every existing inner variant maps to 400 in code SSOT).
- Add explicit return type \`Httpun.Status.t\` so the mapping is type-locked, not inferred from branches.
- Explanatory comment cites the SSOT and the now-prevented anti-pattern.

## Scope

- 1 file (\`lib/server/server_auth.ml\`), 1 function, +29/-3 LoC.
- Body format (\`auth_error_json\`) unchanged.
- 5 call sites in 2 files (\`server_h2_gateway.ml\` × 3, \`server_auth.ml\` × 1, plus the helper definition) all unchanged.

## Verification

- \`dune build lib/server --root .\` → exit 0.
- Mirror correctness checked against \`Masc_error.code\` (lib/types/masc_error.ml:224-250) line-by-line.

## Follow-up (not in this PR)

The function is named \`http_status_of_auth_error\` but the input type is now revealed as \`masc_error\`. Renaming requires touching 5 call sites; left to a separate scope-clean PR.

## Iter#51 context

Found via FSM-sparse-match audit (Workaround Rejection Bar §FSM Sparse Match anti-pattern). The catch-all was the exact pattern the bar prohibits: a closed sum type with \`_ ->\` hiding cases that *deserve different handling*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>