### PR TITLE
feat(dashboard): RFC-0135 PR-14c deriveKeeperDisplayReason SSOT

### DIFF
--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -11,7 +11,7 @@ import { useEffect, useState } from 'preact/hooks'
 // represent *live-execution* attention (`execution_current && blocked`,
 // see `lib/server/server_dashboard_http.ml:1114`), which is orthogonal to
 // the blocker-class-vs-stale-execution axis and stays inline below.
-import { deriveKeeperAttention, deriveKeeperOperationalState } from '../lib/keeper-operational-state'
+import { deriveKeeperAttention, deriveKeeperDisplayReason, deriveKeeperOperationalState } from '../lib/keeper-operational-state'
 import { deriveFiberAlive } from '../lib/keeper-fiber-alive'
 import { formatPct1 } from '../lib/format-number'
 import { formatDuration } from '../lib/format-time'
@@ -254,14 +254,16 @@ export function deriveKeeperLiveTruth({
       : typeof keeper.last_turn_ago_s === 'number'
         ? `${formatDuration(keeper.last_turn_ago_s)} since turn`
         : 'idle age unknown'
-  const runtimeReason =
-    compactToken(
-      compositeSnapshot?.runtime_attention?.reason
-      ?? keeper.runtime_blocker_summary
-      ?? keeper.attention_reason
-      ?? null,
-      'no blocker reason',
-    )
+  // RFC-0135 PR-14c: display reason via composite-preferred SSOT.
+  // Inline 3-way fallback moved to `deriveKeeperDisplayReason` so
+  // future surfaces share the same precedence (live → flat summary →
+  // operator-pinned). Empty/whitespace strings are filtered by the
+  // helper, so the 'no blocker reason' fallback fires only when no
+  // source has a meaningful value.
+  const runtimeReason = compactToken(
+    deriveKeeperDisplayReason(keeper, compositeSnapshot ?? null),
+    'no blocker reason',
+  )
   const toolContract = compactToken(compositeSnapshot?.execution?.tool_contract_result ?? null, 'tool contract unknown')
   // guardCount / invariantFailed have moved to FsmHub mode='detail' — they
   // are rendered on the dedicated FSM lane strip directly under this panel

--- a/dashboard/src/lib/keeper-operational-state.test.ts
+++ b/dashboard/src/lib/keeper-operational-state.test.ts
@@ -7,6 +7,7 @@ import {
   compositeIsTurnIdle,
   compositePhaseTone,
   deriveKeeperAttention,
+  deriveKeeperDisplayReason,
   deriveKeeperOperationalState,
   toKsmPhase,
   type KeeperAttention,
@@ -469,5 +470,49 @@ describe('deriveKeeperAttention — RFC-0135 PR-14a', () => {
   })
   it('null composite ⇒ clean (no backend attestation)', () => {
     expect(deriveKeeperAttention(null)).toBe<KeeperAttention>('clean')
+  })
+})
+
+describe('deriveKeeperDisplayReason — RFC-0135 PR-14c', () => {
+  const composite = (reason: string | undefined): KeeperCompositeSnapshot =>
+    ({
+      keeper: 'test',
+      runtime_attention: reason !== undefined ? { reason } : {},
+    } as unknown as KeeperCompositeSnapshot)
+
+  it('composite reason wins over flat summary', () => {
+    expect(
+      deriveKeeperDisplayReason(
+        { runtime_blocker_summary: 'flat summary', attention_reason: 'pinned' } as Keeper,
+        composite('live reason'),
+      ),
+    ).toBe('live reason')
+  })
+  it('falls back to runtime_blocker_summary when composite empty', () => {
+    expect(
+      deriveKeeperDisplayReason(
+        { runtime_blocker_summary: 'flat summary', attention_reason: 'pinned' } as Keeper,
+        composite(undefined),
+      ),
+    ).toBe('flat summary')
+  })
+  it('falls back to attention_reason when summary missing', () => {
+    expect(
+      deriveKeeperDisplayReason(
+        { attention_reason: 'pinned' } as Keeper,
+        null,
+      ),
+    ).toBe('pinned')
+  })
+  it('filters whitespace-only reason', () => {
+    expect(
+      deriveKeeperDisplayReason(
+        { runtime_blocker_summary: 'real value' } as Keeper,
+        composite('   '),
+      ),
+    ).toBe('real value')
+  })
+  it('returns null when no source has a non-empty value', () => {
+    expect(deriveKeeperDisplayReason({} as Keeper, null)).toBeNull()
   })
 })

--- a/dashboard/src/lib/keeper-operational-state.ts
+++ b/dashboard/src/lib/keeper-operational-state.ts
@@ -269,3 +269,32 @@ export function compositeIsRunning(snapshot: { phase: string }): boolean {
 export function compositeIsTurnIdle(snapshot: { turn_phase: string }): boolean {
   return snapshot.turn_phase === 'idle'
 }
+
+// RFC-0135 PR-14c — display reason SSOT (Goal-2c typed-state expansion).
+//
+// `keeper-detail-runtime.ts:257-264` inlined a 3-way fallback for the
+// "runtime reason" detail line:
+//   composite.runtime_attention.reason
+//   ?? keeper.runtime_blocker_summary
+//   ?? keeper.attention_reason
+//   ?? null
+// The same precedence is needed by the alert strip and the agent
+// roster, and inlining the chain at each callsite makes it easy for
+// a future field to be added in one place but missed in another.
+
+/** Live display reason string for the current attention/blocker state,
+ *  with composite-preferred precedence. Returns `null` when no source
+ *  has a non-empty trimmed value — caller supplies the display fallback. */
+export function deriveKeeperDisplayReason(
+  keeper: Pick<Keeper, 'runtime_blocker_summary' | 'attention_reason'>,
+  composite: KeeperCompositeSnapshot | null,
+): string | null {
+  const trim = (raw: unknown): string | null =>
+    typeof raw === 'string' && raw.trim().length > 0 ? raw : null
+  return (
+    trim(composite?.runtime_attention?.reason)
+    ?? trim(keeper.runtime_blocker_summary)
+    ?? trim(keeper.attention_reason)
+    ?? null
+  )
+}


### PR DESCRIPTION
## Summary

Closes audit **Goal-2c** — `keeper-detail-runtime.ts:257-264` inlined a 3-way fallback for the runtime-reason display string. Centralizes precedence (composite preferred → flat summary → operator-pinned).

## New helper

### `lib/keeper-operational-state.ts`
`deriveKeeperDisplayReason(keeper, composite)`:
- composite-preferred 3-way fallback
- explicit whitespace filtering (empty live backend strings cascade to flat record correctly)
- returns `null` when no source has a non-empty value; caller supplies display fallback

## Migration

```diff
- const runtimeReason = compactToken(
-   compositeSnapshot?.runtime_attention?.reason
-   ?? keeper.runtime_blocker_summary
-   ?? keeper.attention_reason
-   ?? null,
-   'no blocker reason',
- )
+ const runtimeReason = compactToken(
+   deriveKeeperDisplayReason(keeper, compositeSnapshot ?? null),
+   'no blocker reason',
+ )
```

Behavior improvement: whitespace-only `runtime_attention.reason` values (which the previous nullish-coalesce passed through unchanged) are now filtered so empty live values cascade to the next source.

## Verification
- [x] `pnpm typecheck` → pass
- [x] `pnpm vitest run keeper-operational-state keeper-detail-runtime` → 110/110 pass (+5 new)
- [x] `bash scripts/lint/dashboard-ssot-keeper-state.sh` → exit 0
- [x] diff: 3 files, +85/-9

## Plan
- PR-14a `attention` ✓
- PR-14b `turnPhase` ✓ (#16689)
- **PR-14c (this) — `displaySummary`**
- PR-14d — `phase` axis (next)

## RFC reference
RFC-0135 §2 typed-model expansion. Goal-2c of `~/me/.tmp/masc-dashboard-ssot-audit-2026-05-19.html`.

RFC-WAIVED: N/A.

---

Status: Draft — agent PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>