### PR TITLE
fix(tool_types): activate ppx_deriving.show + add failure_class to Telemetry_eio consumers (production-blocking)

### DIFF
--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -473,6 +473,7 @@ let track_tool_called ?fs config ~tool_name ~success ~duration_ms ?agent_id
          error_message;
          exit_code;
          stderr_excerpt;
+         failure_class = None;
        });
   if not success then
     match error_kind with

--- a/lib/telemetry_eio.mli
+++ b/lib/telemetry_eio.mli
@@ -59,6 +59,7 @@ type event =
       error_message : string option; [@default None]
       exit_code : int option; [@default None]
       stderr_excerpt : string option; [@default None]
+      failure_class : Tool_result.tool_failure_class option; [@default None]
     }
   | Tool_assigned of {
       agent_id : string;

--- a/lib/tool_types/dune
+++ b/lib/tool_types/dune
@@ -23,4 +23,4 @@
  (public_name masc_mcp.tool_types)
  (wrapped false)
  (libraries yojson masc_log masc_core eio time_compat)
- (preprocess (pps ppx_deriving_yojson)))
+ (preprocess (pps ppx_deriving_yojson ppx_deriving.show)))

--- a/lib/tool_types/tool_result.ml
+++ b/lib/tool_types/tool_result.ml
@@ -22,7 +22,7 @@ type tool_failure_class =
   | Policy_rejection (** Auth/permission/boundary — permanent *)
   | Runtime_failure (** Internal error/bug — non-retryable *)
   | Workflow_rejection (** Business rule violation — non-retryable *)
-[@@deriving yojson]
+[@@deriving yojson, show]
 
 let tool_failure_class_to_string = function
   | Transient_error -> "transient_error"

--- a/lib/tool_types/tool_result.mli
+++ b/lib/tool_types/tool_result.mli
@@ -22,6 +22,9 @@ val tool_failure_class_to_yojson : tool_failure_class -> Yojson.Safe.t
 val tool_failure_class_of_yojson :
   Yojson.Safe.t -> (tool_failure_class, string) result
 
+val pp_tool_failure_class : Format.formatter -> tool_failure_class -> unit
+val show_tool_failure_class : tool_failure_class -> string
+
 val tool_failure_class_to_string : tool_failure_class -> string
 
 (** [Transient_error] is the only retryable class. *)

--- a/test/test_observability_provider_contracts.ml
+++ b/test/test_observability_provider_contracts.ml
@@ -275,6 +275,7 @@ let test_event_serialization_roundtrip () =
           error_message = None;
           exit_code = None;
           stderr_excerpt = None;
+          failure_class = None;
         };
       T.Error_occurred { code = "E001"; message = "test"; context = "test" } ]
   in

--- a/test/test_telemetry_eio_coverage.ml
+++ b/test/test_telemetry_eio_coverage.ml
@@ -118,6 +118,7 @@ let test_event_tool_called () =
     error_message = Some "timed out after 30s";
     exit_code = None;
     stderr_excerpt = None;
+    failure_class = None;
   } in
   match e with
   | Telemetry_eio.Tool_called r ->

--- a/test/test_telemetry_eio_pbt.ml
+++ b/test/test_telemetry_eio_pbt.ml
@@ -90,6 +90,7 @@ let gen_event : Telemetry_eio.event QCheck.Gen.t =
              error_message;
              exit_code;
              stderr_excerpt;
+             failure_class = None;
            })
   | _ ->
       let* agent_id = string_small in
@@ -144,6 +145,7 @@ let saturated_tool_called : Telemetry_eio.event_record =
           error_message = Some "boom";
           exit_code = Some 1;
           stderr_excerpt = Some "...";
+          failure_class = None;
         };
   }
 


### PR DESCRIPTION
## Summary

**main is currently un-buildable**. PR-6 (#16671) + hotfix #16684 left the build in an inconsistent state.

\`\`\`
$ dune build @check
Error: Unbound value Tool_result.pp_tool_failure_class
\`\`\`

### 원인 분석

- **#16671** (Tool_called row carries typed failure_class): `Telemetry_eio`의 \`Tool_called\` 레코드에 \`failure_class: Tool_result.tool_failure_class option\` 필드 + \`[@@deriving yojson, show]\` 추가
- **#16684** (hotfix): \`lib/tool_types/dune\`에 \`ppx_deriving_yojson\` preprocessor만 추가 → \`ppx_deriving.show\`는 누락 → \`pp_tool_failure_class\` 미생성 → 부모 라이브러리의 \`[@@deriving show]\`가 \`Tool_result.pp_tool_failure_class\`를 못 찾고 빌드 실패

### 변경

1. \`lib/tool_types/dune\` — \`(preprocess (pps ppx_deriving_yojson ppx_deriving.show))\`
2. \`lib/tool_types/tool_result.ml\` — \`[@@deriving yojson, show]\`
3. \`lib/tool_types/tool_result.mli\` — \`val pp_tool_failure_class\` / \`val show_tool_failure_class\` 선언
4. \`lib/telemetry_eio.mli\` — \`Tool_called\` 레코드에 \`failure_class\` 필드 선언 (PR-6에서 .ml만 업데이트, .mli 누락)
5. \`lib/telemetry_eio.ml\` — 잔존 construction site에 \`failure_class = None\` 추가
6. test files (3개) — record literal에 \`failure_class = None\` 추가

### 검증

\`\`\`
$ dune build --root . @check
$ echo \$?
0
\`\`\`

### 라벨
- \`WORKAROUND: production-blocking main build break\` — \`software-development.md\` §워크어라운드 거부 기준 §Override 조건 (production이 *지금* 깨지고 있음)
- 대체 RFC 불필요 (incomplete merge 흡수)
- \`RFC-WAIVED: hotfix for #16671 + #16684 incomplete merge cascade\`

## Test plan
- [x] dune @check green
- [ ] CI 전체 통과 후 사용자 admin merge

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>