### PR TITLE
fix(tool_result+telemetry_eio): complete PR #16671 surfaces (build break)

### DIFF
--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -473,6 +473,12 @@ let track_tool_called ?fs config ~tool_name ~success ~duration_ms ?agent_id
          error_message;
          exit_code;
          stderr_excerpt;
+         (* PR #16671 (#16671) added typed [failure_class] to Tool_called
+            but did not backfill this caller. The default is [None] —
+            this site is the legacy untyped path, so no failure-class
+            classification is available at the call site. Future
+            classification belongs at the dispatcher level, not here. *)
+         failure_class = None;
        });
   if not success then
     match error_kind with

--- a/lib/telemetry_eio.mli
+++ b/lib/telemetry_eio.mli
@@ -59,6 +59,10 @@ type event =
       error_message : string option; [@default None]
       exit_code : int option; [@default None]
       stderr_excerpt : string option; [@default None]
+      failure_class : Tool_result.tool_failure_class option; [@default None]
+          (** PR #16671 typed failure classification — added to .ml but
+              the .mli declaration was not updated, breaking the
+              interface match. *)
     }
   | Tool_assigned of {
       agent_id : string;

--- a/lib/tool_types/tool_result.ml
+++ b/lib/tool_types/tool_result.ml
@@ -22,7 +22,6 @@ type tool_failure_class =
   | Policy_rejection (** Auth/permission/boundary — permanent *)
   | Runtime_failure (** Internal error/bug — non-retryable *)
   | Workflow_rejection (** Business rule violation — non-retryable *)
-[@@deriving yojson]
 
 let tool_failure_class_to_string = function
   | Transient_error -> "transient_error"
@@ -37,6 +36,35 @@ let tool_failure_class_of_string = function
   | "runtime_failure" -> Some Runtime_failure
   | "workflow_rejection" -> Some Workflow_rejection
   | _ -> None
+;;
+
+(* PR #16671 added [@@deriving yojson] (and was relied on for an
+   implicit show-derived [pp_*] by downstream PPX users), but
+   lib/tool_types/dune has no `(preprocess (pps ...))` stanza, so
+   neither *_to_yojson / *_of_yojson nor pp_* were ever synthesized.
+   The .mli advertised the yojson pair and downstream code called
+   pp_tool_failure_class, breaking the build with:
+     "value is required but not provided"
+     "Unbound value Tool_result.pp_tool_failure_class"
+   Manual wrappers via *_to_string keep the sub-library PPX-free
+   (matching the rest of leaf tool_types) and recover the surface. *)
+let pp_tool_failure_class ppf c =
+  Format.fprintf ppf "%s" (tool_failure_class_to_string c)
+;;
+
+let tool_failure_class_to_yojson (c : tool_failure_class) : Yojson.Safe.t =
+  `String (tool_failure_class_to_string c)
+;;
+
+let tool_failure_class_of_yojson (json : Yojson.Safe.t)
+  : (tool_failure_class, string) result
+  =
+  match json with
+  | `String s ->
+    (match tool_failure_class_of_string s with
+     | Some c -> Ok c
+     | None -> Error ("tool_failure_class_of_yojson: unknown value " ^ s))
+  | _ -> Error "tool_failure_class_of_yojson: expected JSON string"
 ;;
 
 let is_retryable = function

--- a/lib/tool_types/tool_result.mli
+++ b/lib/tool_types/tool_result.mli
@@ -22,6 +22,12 @@ val tool_failure_class_to_yojson : tool_failure_class -> Yojson.Safe.t
 val tool_failure_class_of_yojson :
   Yojson.Safe.t -> (tool_failure_class, string) result
 
+val pp_tool_failure_class : Format.formatter -> tool_failure_class -> unit
+(** Pretty-printer mirroring the [@@deriving show] convention so
+    callers using [Tool_result.pp_tool_failure_class] (PPX-expanded
+    elsewhere, or hand-written debug) keep compiling. Falls through
+    to [tool_failure_class_to_string]. *)
+
 val tool_failure_class_to_string : tool_failure_class -> string
 
 (** [Transient_error] is the only retryable class. *)

--- a/test/test_observability_provider_contracts.ml
+++ b/test/test_observability_provider_contracts.ml
@@ -275,6 +275,7 @@ let test_event_serialization_roundtrip () =
           error_message = None;
           exit_code = None;
           stderr_excerpt = None;
+          failure_class = None;
         };
       T.Error_occurred { code = "E001"; message = "test"; context = "test" } ]
   in

--- a/test/test_telemetry_eio_coverage.ml
+++ b/test/test_telemetry_eio_coverage.ml
@@ -118,6 +118,7 @@ let test_event_tool_called () =
     error_message = Some "timed out after 30s";
     exit_code = None;
     stderr_excerpt = None;
+    failure_class = None;
   } in
   match e with
   | Telemetry_eio.Tool_called r ->

--- a/test/test_telemetry_eio_pbt.ml
+++ b/test/test_telemetry_eio_pbt.ml
@@ -90,6 +90,7 @@ let gen_event : Telemetry_eio.event QCheck.Gen.t =
              error_message;
              exit_code;
              stderr_excerpt;
+             failure_class = None;
            })
   | _ ->
       let* agent_id = string_small in
@@ -144,6 +145,7 @@ let saturated_tool_called : Telemetry_eio.event_record =
           error_message = Some "boom";
           exit_code = Some 1;
           stderr_excerpt = Some "...";
+          failure_class = None;
         };
   }
 


### PR DESCRIPTION
## 목표

PR #16671 (`feat(telemetry): Tool_called row carries typed failure_class option`)이 incomplete 상태로 main 머지되어 build가 빨간 상태. 모든 mismatch 채워 build 복구.

오늘 (2026-05-19) main 트리에서 빌드 시도하면 다음 에러 발생:

```
Error: The value tool_failure_class_to_yojson is required but not provided
Error: Unbound value Tool_result.pp_tool_failure_class
Error: Some record fields are undefined: failure_class  (×4 sites)
```

## 변경 파일

| 파일 | 변경 | 용도 |
|---|---|---|
| `lib/tool_types/tool_result.ml` | +30 / -1 | `[@@deriving yojson]` 제거 + 수동 `pp_tool_failure_class`, `_to_yojson`, `_of_yojson` 추가 |
| `lib/tool_types/tool_result.mli` | +6 | `pp_tool_failure_class` declaration 추가 |
| `lib/telemetry_eio.mli` | +4 | Tool_called variant에 `failure_class` field 선언 추가 (mli sync) |
| `lib/telemetry_eio.ml` | +6 | record literal에 `failure_class = None` backfill (1 production caller) |
| `test/test_observability_provider_contracts.ml` | +1 | Tool_called test literal backfill |
| `test/test_telemetry_eio_pbt.ml` | +2 | Tool_called test literal backfill (2 사이트) |
| `test/test_telemetry_eio_coverage.ml` | +1 | Tool_called test literal backfill |

**Total: 49 insertions, 1 deletion**

## Root cause

PR #16671 (commit `9d4d4f3033`)이 두 가지 변경을 했지만 둘 다 wiring 빠짐:

1. **`Tool_result.tool_failure_class`에 `[@@deriving yojson]` 추가** — `lib/tool_types/dune`에 `(preprocess (pps ...))` stanza 없음. PPX 작동 안 함. `.mli`는 yojson 함수 advertise하는데 `.ml`에 함수 없음.

2. **`Telemetry_eio.Tool_called` variant에 `failure_class` field 추가** — `.ml`만 변경, `.mli` declaration 미반영. 4 record literal caller (production 1 + test 3) 모두 새 field 미지정.

## Fix 선택지 비교

| 접근 | 장점 | 단점 | 채택 |
|---|---|---|---|
| `lib/tool_types/dune`에 `(preprocess (pps ppx_deriving_yojson))` 추가 | 한 줄 | opam dep 추가, sub-lib 정책 변경 | ❌ |
| 수동 `_to_yojson` / `_of_yojson` / `pp_*` | 명시적, dep 0 | 코드 ~30 LoC | ✅ |

masc-mcp의 leaf sub-library (`tool_types`)는 일반적으로 PPX 안 씀. 수동 wrapper가 정합.

## 로컬 검증

```
dune build --root . @check  →  exit 0
```

## 남은 미검증

- **`engine_id_to_yojson` / 다른 yojson 함수**: 이 PR scope는 build 복구만. PR #16671의 의도(typed failure_class를 yojson으로 직렬화)는 작동 — 수동 wrapper로 동일 surface 유지
- **CI**: Draft 상태 유지, CI 결과 + 사용자 검토 후 Ready

## 영향

PR #16671 머지 시점부터 main의 모든 빌드가 빨간 상태였음. 이 PR 머지하면 즉시 복구.

🤖 Generated with [Claude Code](https://claude.com/claude-code)