### PR TITLE
feat(dashboard): RFC-0135 PR-14d derivePreferredPhase SSOT

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -722,7 +722,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
               : null
           const keeperMonitoring = keeperRuntime ? summarizeKeeperMonitoring(keeperRuntime, compositeForMonitoring) : null
           const monitoringEvidence = keeperMonitoring ? summarizeMonitoringEvidence(keeperMonitoring) : null
-          const fsmPhase = keeperRuntime ? keeperPhaseForDisplay(keeperRuntime) : null
+          const fsmPhase = keeperRuntime ? keeperPhaseForDisplay(keeperRuntime, compositeForMonitoring) : null
           const isKeeper = keeperRuntime != null
           const goalSummary = keeperRuntime?.short_goal ?? keeperRuntime?.goal ?? agent.current_task ?? null
           const currentWork =

--- a/dashboard/src/lib/keeper-operational-state.test.ts
+++ b/dashboard/src/lib/keeper-operational-state.test.ts
@@ -6,6 +6,7 @@ import {
   compositeIsRunning,
   compositeIsTurnIdle,
   compositePhaseTone,
+  derivePreferredPhase,
   deriveKeeperAttention,
   deriveKeeperDisplayReason,
   deriveKeeperOperationalState,
@@ -540,5 +541,32 @@ describe('deriveKeeperTurnPhase — RFC-0135 PR-14b', () => {
   })
   it('returns null when both sources empty', () => {
     expect(deriveKeeperTurnPhase({} as Keeper, null)).toBeNull()
+  })
+})
+
+describe('derivePreferredPhase — RFC-0135 PR-14d', () => {
+  it('composite wire phase wins over flat keeper.phase', () => {
+    expect(
+      derivePreferredPhase(
+        { phase: 'Running' } as Keeper,
+        { phase: 'compacting' } as unknown as KeeperCompositeSnapshot,
+      ),
+    ).toBe('Compacting')
+  })
+  it('falls back to keeper.phase when composite empty', () => {
+    expect(
+      derivePreferredPhase({ phase: 'HandingOff' } as Keeper, null),
+    ).toBe('HandingOff')
+  })
+  it('falls back to keeper.phase when composite has unknown wire value', () => {
+    expect(
+      derivePreferredPhase(
+        { phase: 'Running' } as Keeper,
+        { phase: 'inventing_new_state' } as unknown as KeeperCompositeSnapshot,
+      ),
+    ).toBe('Running')
+  })
+  it('returns null when neither source has a known phase', () => {
+    expect(derivePreferredPhase({} as Keeper, null)).toBeNull()
   })
 })

--- a/dashboard/src/lib/keeper-operational-state.ts
+++ b/dashboard/src/lib/keeper-operational-state.ts
@@ -37,9 +37,11 @@
 
 import type {
   Keeper,
+  KeeperPhase,
   KeeperRuntimeBlockerClass,
   PipelineStage,
 } from '../types/core'
+import { toKeeperPhase } from '../keeper-store-normalize'
 import type {
   KeeperCompositeSnapshot,
 } from '../api/schemas/keeper-composite'
@@ -330,4 +332,30 @@ export function deriveKeeperTurnPhase(
   const flatStage: PipelineStage | undefined = keeper.pipeline_stage
   if (typeof flatStage === 'string' && flatStage.length > 0) return flatStage
   return null
+}
+
+// RFC-0135 PR-14d — composite-preferred phase SSOT (Goal-2d).
+//
+// Two phase sources exist on the wire:
+//   - `composite.phase` (lowercase, live KSM wire format)
+//   - `keeper.phase` (PascalCase, flat-record snapshot)
+// `monitoring-runtime.ts:keeperPhaseForDisplay` previously consumed
+// only `keeper.phase`, leaving composite-fresh phase signals unused
+// when a composite snapshot was available. This helper centralizes
+// the precedence so `monitoring-runtime` and `agent-roster` see the
+// same phase for the same keeper.
+
+/** Composite-preferred `KeeperPhase`. Returns the typed PascalCase
+ *  value from composite if present and narrow-able, else from the
+ *  flat record, else `null`. */
+export function derivePreferredPhase(
+  keeper: Pick<Keeper, 'phase'>,
+  composite: KeeperCompositeSnapshot | null,
+): KeeperPhase | null {
+  const compositePhase = composite?.phase
+  if (typeof compositePhase === 'string' && compositePhase.length > 0) {
+    const narrowed = toKeeperPhase(compositePhase)
+    if (narrowed !== null) return narrowed
+  }
+  return toKeeperPhase(keeper.phase)
 }

--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -7,12 +7,12 @@ import { keeperDisplayStatus, keeperRuntimeBlockerHint } from './keeper-runtime-
 // PHASE_ID_MAP elsewhere; the three maps drifted independently.
 import { toKeeperPhase } from '../keeper-store-normalize'
 import { isKeeperPaused } from './keeper-predicates'
-// RFC-0135 PR-12: route blocker visibility through the typed SSOT so
-// stale vs live blocker distinction (composite.execution_current /
-// stale_execution_receipt) is honored. Previously the inline
-// `Boolean(keeper.runtime_blocker_class)` flipped attention on stale
-// receipts that the typed state demoted to `running.staleBlocker`.
-import { deriveKeeperOperationalState } from './keeper-operational-state'
+// RFC-0135 PR-12 + PR-14d: route blocker visibility through the typed
+// SSOT (stale vs live distinction) and consume composite-preferred
+// phase via `derivePreferredPhase`. Previously
+// `keeperPhaseForDisplay` consumed only `keeper.phase`, ignoring
+// live phase emitted by composite SSE.
+import { derivePreferredPhase, deriveKeeperOperationalState } from './keeper-operational-state'
 
 export type RuntimeBand = 'active' | 'attention' | 'paused' | 'offline'
 
@@ -158,7 +158,10 @@ function normalizeStage(stage: PipelineStage | string | null | undefined): strin
   return stage ? String(stage) : 'offline'
 }
 
-export function keeperPhaseForDisplay(keeper: Keeper): string | null {
+export function keeperPhaseForDisplay(
+  keeper: Keeper,
+  composite: KeeperCompositeSnapshot | null = null,
+): string | null {
   const lifecycleKey = keeperDisplayStatus(keeper)
   const lifecyclePhase = toKeeperPhase(lifecycleKey)
   if (
@@ -169,7 +172,13 @@ export function keeperPhaseForDisplay(keeper: Keeper): string | null {
   ) {
     return lifecyclePhase
   }
-  return toKeeperPhase(keeper.phase) ?? lifecyclePhase
+  // RFC-0135 PR-14d: composite-preferred phase before flat-record
+  // `keeper.phase`. The terminal-phase guard above intentionally
+  // ignores composite — once `keeperDisplayStatus` says paused/stopped/
+  // offline/dead, that's the authoritative answer (live composite
+  // phase from a previous SSE frame cannot override an operator-
+  // pinned terminal state).
+  return derivePreferredPhase(keeper, composite) ?? lifecyclePhase
 }
 
 function isHeartbeatStale(keeper: Keeper): boolean {
@@ -249,7 +258,7 @@ export function summarizeKeeperMonitoring(
   composite: KeeperCompositeSnapshot | null = null,
 ): KeeperMonitoringSummary {
   const lifecycleKey = keeperDisplayStatus(keeper)
-  const phaseKey = keeperPhaseForDisplay(keeper) ?? 'unknown'
+  const phaseKey = keeperPhaseForDisplay(keeper, composite) ?? 'unknown'
   const stage = stageMeta(normalizeStage(keeper.pipeline_stage))
   const band = BAND_META[keeperBand(keeper, composite, phaseKey, lifecycleKey)]
 


### PR DESCRIPTION
## Summary

Closes audit **Goal-2d** (final of Goal-2 4-sub-PR series) — `keeperPhaseForDisplay` consumed only `keeper.phase` flat-record snapshot, ignoring live composite SSE phase.

## New helper

### `lib/keeper-operational-state.ts`
`derivePreferredPhase(keeper, composite)`:
- composite-preferred PascalCase `KeeperPhase`
- lowercase wire-format composite phase narrowed via `toKeeperPhase`
- unknown wire values fall back to `keeper.phase`
- returns `null` when neither source has a known phase

## Migration

### `lib/monitoring-runtime.ts`
- `keeperPhaseForDisplay(keeper, composite?)` signature widened
- Terminal-phase guard (Paused/Stopped/Offline/Dead) **intentionally** consults only `keeperDisplayStatus(keeper)` — once it says terminal, no composite phase from a previous SSE frame should override
- Non-terminal branch routes through `derivePreferredPhase`
- `summarizeKeeperMonitoring` passes its existing `composite` arg

### `components/agent-roster.ts:725`
Uses existing `compositeForMonitoring` lookup from PR-12.

## Verification
- [x] `pnpm typecheck` → pass
- [x] `pnpm vitest run keeper-operational-state monitoring-runtime agent-roster` → 103/103 pass (+4 new)
- [x] `bash scripts/lint/dashboard-ssot-keeper-state.sh` → exit 0
- [x] diff: 4 files, +76/-10

## Plan complete (Goal-2 4-sub-PR series)
- PR-14a `attention` ✓
- PR-14b `turnPhase` ✓ (#16689)
- PR-14c `displaySummary` ✓ (#16691)
- **PR-14d (this) — `phase`**

## RFC reference
RFC-0135 §2 typed-model expansion.

RFC-WAIVED: N/A.

---

Status: Draft — agent PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>