### PR TITLE
feat(keepers): add MASC 기본 소양 instructions to base.toml

### DIFF
--- a/config/keepers/base.toml
+++ b/config/keepers/base.toml
@@ -6,6 +6,18 @@ work_discovery_enabled = true
 github_identity = "anyang-keepers"
 git_identity_mode = "github_identity"
 
+instructions = """
+MASC 기본 소양 — 모든 keeper의 공통 행동 기반. persona instructions는 이 위에 stack.
+
+1. 코드 변경 라우팅: masc_code_read, masc_code_write, masc_code_edit, masc_code_git을 사용한다. raw Write/Edit 또는 Bash redirection/tee는 governance/path guard에 막힌다.
+2. Worktree 생성: masc_worktree_create에 task_id와 repo_name을 명시한다. 직접 git worktree add를 호출하지 않는다.
+3. PR 생성 흐름: 코드 작업 완료 후 keeper_pr_create draft=true로 PR을 연다. 이어서 keeper_task_submit_for_verification으로 검증을 요청한다. Ready 전환은 사용자/verifier 권한이다.
+4. Task 상태 조회: keeper_tasks_list 또는 masc_tasks를 사용한다. .task.json, task-*.json, .masc, backlog JSON을 find/grep/rg/ls로 찾지 않는다.
+5. Task lifecycle 변경: masc_transition으로 claim/start/done/cancel/release/approve/reject를 호출한다. expected_version으로 CAS 충돌을 회피한다.
+6. Bash 규칙: keeper_bash 호출 시 shell quote, glob, brace expansion을 쓰지 않는다. 경로 인자는 plain path. keeper_bash_command_shape_blocked 또는 workflow_rejection을 받으면 변형 재시도 대신 typed tool (keeper_tasks_list, masc_code_* 등)로 전환한다.
+7. 협업: 다중 keeper 환경에서는 masc_broadcast (전체 공지) 또는 masc_messages (1:1)로 소통한다. 특정 keeper 호출은 @mention. 진행 상태는 masc_heartbeat로 유지한다.
+"""
+
 [provider_health]
 ttfrc_degraded_ms = 5000.0
 ttfrc_unhealthy_ms = 15000.0


### PR DESCRIPTION
## 목적

`base.toml`을 상속하는 모든 keeper에 공통 *procedural literacy*를 주입한다. 권한(`also_allow`)이 있어도 절차 prompt가 없으면 LLM이 PR creation 같은 multi-step flow를 자발적으로 수행하지 않는 원인을 root-fix.

## 진단 (TOML survey 2026-05-19)

| Keeper | 위치 | `instructions` PR-flow | 결과 |
|---|---|---|---|
| executor / analyst | basepath | ✅ "keeper_pr_create draft=true → submit_for_verification" | PR 생성 성공률 높음 |
| sangsu / ramarama (basepath) | basepath | ❌ 페르소나만 정의 | 권한 있어도 PR 생성 거의 없음 |
| issue_king / masc-improver / sangsu / taskmaster / verifier (repo) | repo | base.toml 상속하지만 base에 instructions 없음 | 동일 문제 |

권한(`tool_access.also_allow`에 `masc_code_git` 포함)은 모든 keeper 동일. 차이는 *procedural prompt*.

## 변경

- `config/keepers/base.toml`에 `instructions` 필드 추가 (7항목, ~15줄):
  1. 코드 변경 라우팅 (masc_code_*)
  2. Worktree 생성 (masc_worktree_create)
  3. **PR 생성 흐름** (keeper_pr_create draft=true → keeper_task_submit_for_verification)
  4. Task 상태 조회 (keeper_tasks_list / masc_tasks)
  5. Task lifecycle (masc_transition + CAS)
  6. Bash 규칙 (quote/glob 금지, command_shape_blocked 시 typed tool 전환)
  7. 협업 (broadcast/messages, heartbeat)

## Scope

- 1 파일, +12줄.
- `base = "base.toml"` 참조하는 repo TOMLs가 상속.
- basepath의 self-contained TOMLs (`~/me/.masc/config/keepers/*.toml`)는 별도 PR로 동일 정책 적용 예정.

## Test plan

- [ ] 기존 keeper autoboot 후 PR creation 호출 빈도 변화 측정 (특히 sangsu/ramarama).
- [ ] verifier처럼 자체 instructions가 있는 keeper는 base.toml 상속 시 instructions가 *합쳐지는지 vs override되는지* 코드 확인 필요. 합쳐지지 않으면 verifier는 영향 없음 (의도된 동작).

## Risk

- persona-pure keeper (sangsu/ramarama)의 *charactor 톤*에 procedural instructions가 섞여 영화/홍상수 페르소나가 약해질 가능성. 영향 측정 후 stack 순서 조정 검토.

## Follow-up

- basepath TOML mirroring (RFC-0093 Phase B와 별개)
- Keeper instructions merging 동작 (override vs concat) 코드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)