### PR TITLE
refactor(tool_agent_timeline): replace try-blanket JSON parsing with Safe_ops in turn_completed_events

### DIFF
--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -362,53 +362,27 @@ let turn_completed_events (config : Coord.config) ~agent_name ~limit :
   |> List.filter_map (fun (e : Activity_graph.event) ->
        let ts = Float.of_int e.ts_ms /. 1000.0 in
        let open Yojson.Safe.Util in
-       let keeper_name =
-         try e.payload |> member "keeper_name" |> to_string
-         with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> "unknown"
-       in
-       let input_tokens =
-         try Some (e.payload |> member "input_tokens" |> to_int)
-         with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> None
-       in
-       let output_tokens =
-         try Some (e.payload |> member "output_tokens" |> to_int)
-         with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> None
-       in
+       (* Pure-shape JSON access via Safe_ops: no exception swallow, no
+          performative [Cancelled] re-raise. Behavior parity with the prior
+          [try ... |> to_X with _ -> default] pattern on missing/wrong-typed
+          fields; widens acceptance to string-coerced numerics per the
+          codebase convention documented in Safe_ops.json_*_opt. *)
+       let keeper_name = Safe_ops.json_string ~default:"unknown" "keeper_name" e.payload in
+       let input_tokens = Safe_ops.json_int_opt "input_tokens" e.payload in
+       let output_tokens = Safe_ops.json_int_opt "output_tokens" e.payload in
        let cache_creation_tokens =
-         try Some (e.payload |> member "cache_creation_tokens" |> to_int)
-         with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> None
+         Safe_ops.json_int_opt "cache_creation_tokens" e.payload
        in
-       let cache_read_tokens =
-         try Some (e.payload |> member "cache_read_tokens" |> to_int)
-         with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> None
-       in
-       let cost_usd =
-         try Some (e.payload |> member "cost_usd" |> to_float)
-         with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> None
-       in
-       let latency_ms =
-         try Some (e.payload |> member "latency_ms" |> to_int)
-         with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> None
-       in
-       let model_used =
-         try e.payload |> member "model_used" |> to_string
-         with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> "unknown"
-       in
+       let cache_read_tokens = Safe_ops.json_int_opt "cache_read_tokens" e.payload in
+       let cost_usd = Safe_ops.json_float_opt "cost_usd" e.payload in
+       let latency_ms = Safe_ops.json_int_opt "latency_ms" e.payload in
+       let model_used = Safe_ops.json_string ~default:"unknown" "model_used" e.payload in
        let work_kind =
          Keeper_unified_metrics.work_kind_of_json e.payload
          |> Option.value ~default:"unknown"
        in
-       let context_ratio =
-         try Some (e.payload |> member "context_ratio" |> to_float)
-         with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> None
-       in
-       let tools_used =
-         try e.payload |> member "tools_used" |> to_list
-             |> List.filter_map (fun j ->
-                  try Some (to_string j)
-                  with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> None)
-         with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> []
-       in
+       let context_ratio = Safe_ops.json_float_opt "context_ratio" e.payload in
+       let tools_used = Safe_ops.json_string_list "tools_used" e.payload in
        let optional_fields =
          let reasoning =
            try match e.payload |> member "reasoning_tokens" with


### PR DESCRIPTION
## Summary

Replace 10 identical \`try e.payload |> member X |> to_Y with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> default\` blocks in \`turn_completed_events\` with \`Safe_ops.*\` typed accessors. Net -25 LoC, no behavior change on happy path.

## Why

Two issues with the prior pattern:

1. **Workaround Rejection Bar §2 (Unknown → Permissive Default)** — blanket \`with ... | _ -> None\` on a closed JSON value type. The performative \`Eio.Cancel.Cancelled _ as ex -> raise ex\` re-raise is itself an admission that the catch-all is too wide.
2. **Local inconsistency** — line 283 of the same file already uses \`Safe_ops.json_string ~default:\"unknown\"\` for an analogous payload read. The remaining 10 sites used the older try-blanket idiom.

## Change

| Before | After |
|---|---|
| \`try e.payload |> member \"keeper_name\" |> to_string with ... | _ -> \"unknown\"\` | \`Safe_ops.json_string ~default:\"unknown\" \"keeper_name\" e.payload\` |
| \`try Some (e.payload |> member \"input_tokens\" |> to_int) with ... | _ -> None\` | \`Safe_ops.json_int_opt \"input_tokens\" e.payload\` |
| (same for output_tokens, cache_*_tokens, latency_ms, cost_usd, context_ratio, tools_used) | (json_int_opt / json_float_opt / json_string_list) |

\`Safe_ops\` accessors use pure pattern matching on the JSON variant — no exception path, no \`Cancelled\` swallow risk. They additionally accept stringified numerics per the codebase convention for small-LLM-produced payloads (documented in \`lib/core/safe_ops.ml\`).

## Out of Scope

The \`optional_fields\` block (\`reasoning_tokens\` / \`tokens_per_second\` / \`prompt_per_second\` / \`hw_decode_tokens_per_second\`) preserves the *raw* JSON type variant for re-embedding into an assoc-list. Those sites do not collapse through the Option pipeline and stay on the explicit-match shape.

## Scope

- 1 file (\`lib/tool_agent_timeline.ml\`), 1 hunk inside one function.
- +15 / -41 LoC (net -26).
- No happy-path behavior change. On wrong-typed values that were string-coerced (\`\"30\"\` → \`Int 30\`), behavior widens from \`None\`/\`default\` to the coerced value — aligned with rest of the codebase.

## ⚠️ CI Note

Main is currently broken with \`Error: Unbound value Tool_result.pp_tool_failure_class\` (separate ppx_show derivation gap introduced in \`telemetry_eio.ml\` line 65 where \`[@@deriving yojson, show]\` references a \`Tool_result.tool_failure_class option\` field, but \`Tool_result\`'s own deriving directive only emits \`yojson\`).

This refactor is isolated from that issue. CI will fail until the upstream \`pp_tool_failure_class\` issue is fixed (either add \`, show\` to \`Tool_result\`'s deriving directive + dune preprocessor, or drop \`, show\` from \`telemetry_eio.ml\`'s event type). The design decision belongs to the telemetry_eio / tool_types owner.

## Iter#52 context

Found via the same FSM-sparse-match / unknown→permissive audit as Iter#48 / Iter#51. Iter#48 already partially cleaned this function (PR #16647) for a different cluster; this PR continues the cleanup for the remaining payload-read sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>