### PR TITLE
[RFC-0136 PR-4-a] keeper_unified_turn: extract retry_setup record (-22 LoC)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -240,6 +240,7 @@
   keeper_unified_turn_phase_gate
   keeper_unified_turn_cascade_resolution
   keeper_unified_turn_pre_dispatch
+  keeper_unified_turn_retry_setup
   keeper_unified_turn_livelock_block
   keeper_exec_context
   keeper_guards

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -433,47 +433,25 @@ let run_keeper_cycle
                      match Eio_context.get_clock () with
                      | Error msg -> Error (Agent_sdk.Error.Internal msg)
                      | Ok clock ->
-                       let timeout_sec = Keeper_runtime_resolved.turn_timeout_sec () in
                        start_background_turn_event_bus_drain ~clock;
-                       let turn_started_at = Eio.Time.now clock in
-                       let turn_deadline = turn_started_at +. timeout_sec in
-                       let remaining_turn_budget_s () =
-                         Float.max 0.0 (turn_deadline -. Eio.Time.now clock)
-                       in
-                       let retry_phase_started_at = ref None in
-                       let elapsed_ms seconds =
-                         int_of_float (Float.max 0.0 seconds *. 1000.0)
-                       in
-                       let current_turn_phase_elapsed_ms () =
-                         let now = Eio.Time.now clock in
-                         match !retry_phase_started_at with
-                         | None -> elapsed_ms (now -. turn_started_at), Some 0
-                         | Some retry_started_at ->
-                           ( elapsed_ms (retry_started_at -. turn_started_at)
-                           , Some (elapsed_ms (now -. retry_started_at)) )
-                       in
-                       let keeper_profile =
-                         Keeper_types_profile.load_keeper_profile_defaults meta.name
-                       in
-                       let max_idle_turns, max_turns =
-                         match channel with
-                         | Keeper_world_observation.Reactive ->
-                           ( Keeper_runtime_resolved.reactive_max_idle_turns ()
-                           , Keeper_types_profile.effective_max_turns_per_call
-                               keeper_profile )
-                         | Keeper_world_observation.Scheduled_autonomous ->
-                           ( Keeper_runtime_resolved.autonomous_max_idle_turns ()
-                           , Keeper_types_profile
-                             .effective_max_turns_per_call_scheduled_autonomous
-                               keeper_profile )
-                       in
-                       let initial_tool_requirement =
-                         if
-                           Keeper_agent_run.should_require_tools_for_initial_turn
-                             ~max_turns
-                             ~turn_affordances
-                         then Keeper_agent_tool_surface.Required
-                         else Keeper_agent_tool_surface.Optional
+                       let { Keeper_unified_turn_retry_setup.timeout_sec
+                           ; turn_started_at
+                           ; turn_deadline
+                           ; remaining_turn_budget_s
+                           ; retry_phase_started_at
+                           ; elapsed_ms
+                           ; current_turn_phase_elapsed_ms
+                           ; keeper_profile
+                           ; max_idle_turns
+                           ; max_turns
+                           ; initial_tool_requirement
+                           }
+                         =
+                         Keeper_unified_turn_retry_setup.build
+                           ~now:(fun () -> Eio.Time.now clock)
+                           ~keeper_name:meta.name
+                           ~channel
+                           ~turn_affordances
                        in
                        let do_run
                              ~(execution : cascade_execution)

--- a/lib/keeper/keeper_unified_turn_retry_setup.ml
+++ b/lib/keeper/keeper_unified_turn_retry_setup.ml
@@ -1,0 +1,57 @@
+type retry_setup =
+  { timeout_sec : float
+  ; turn_started_at : float
+  ; turn_deadline : float
+  ; remaining_turn_budget_s : unit -> float
+  ; retry_phase_started_at : float option ref
+  ; elapsed_ms : float -> int
+  ; current_turn_phase_elapsed_ms : unit -> int * int option
+  ; keeper_profile : Keeper_types_profile.keeper_profile_defaults
+  ; max_idle_turns : int
+  ; max_turns : int
+  ; initial_tool_requirement : Keeper_agent_tool_surface.tool_requirement
+  }
+
+let build ~now ~keeper_name ~channel ~turn_affordances =
+  let timeout_sec = Keeper_runtime_resolved.turn_timeout_sec () in
+  let turn_started_at = now () in
+  let turn_deadline = turn_started_at +. timeout_sec in
+  let remaining_turn_budget_s () = Float.max 0.0 (turn_deadline -. now ()) in
+  let retry_phase_started_at = ref None in
+  let elapsed_ms seconds = int_of_float (Float.max 0.0 seconds *. 1000.0) in
+  let current_turn_phase_elapsed_ms () =
+    let now_s = now () in
+    match !retry_phase_started_at with
+    | None -> elapsed_ms (now_s -. turn_started_at), Some 0
+    | Some retry_started_at ->
+      ( elapsed_ms (retry_started_at -. turn_started_at)
+      , Some (elapsed_ms (now_s -. retry_started_at)) )
+  in
+  let keeper_profile = Keeper_types_profile.load_keeper_profile_defaults keeper_name in
+  let max_idle_turns, max_turns =
+    match channel with
+    | Keeper_world_observation.Reactive ->
+      ( Keeper_runtime_resolved.reactive_max_idle_turns ()
+      , Keeper_types_profile.effective_max_turns_per_call keeper_profile )
+    | Keeper_world_observation.Scheduled_autonomous ->
+      ( Keeper_runtime_resolved.autonomous_max_idle_turns ()
+      , Keeper_types_profile.effective_max_turns_per_call_scheduled_autonomous
+          keeper_profile )
+  in
+  let initial_tool_requirement =
+    if Keeper_agent_run.should_require_tools_for_initial_turn ~max_turns ~turn_affordances
+    then Keeper_agent_tool_surface.Required
+    else Keeper_agent_tool_surface.Optional
+  in
+  { timeout_sec
+  ; turn_started_at
+  ; turn_deadline
+  ; remaining_turn_budget_s
+  ; retry_phase_started_at
+  ; elapsed_ms
+  ; current_turn_phase_elapsed_ms
+  ; keeper_profile
+  ; max_idle_turns
+  ; max_turns
+  ; initial_tool_requirement
+  }

--- a/lib/keeper/keeper_unified_turn_retry_setup.mli
+++ b/lib/keeper/keeper_unified_turn_retry_setup.mli
@@ -1,0 +1,35 @@
+(** RFC-0136 PR-4-a: outer setup record for [keeper_unified_turn] retry loop.
+
+    Groups the 11 wall-clock / budget / profile / tool-requirement bindings
+    that the retry loop and [do_run] closure both observe.  Extraction is
+    behavior-preserving: a single [build] call replaces the inline setup
+    block, and callers destructure the record to keep existing names. *)
+
+type retry_setup =
+  { timeout_sec : float
+  ; turn_started_at : float
+  ; turn_deadline : float
+  ; remaining_turn_budget_s : unit -> float
+  ; retry_phase_started_at : float option ref
+  ; elapsed_ms : float -> int
+  ; current_turn_phase_elapsed_ms : unit -> int * int option
+  ; keeper_profile : Keeper_types_profile.keeper_profile_defaults
+  ; max_idle_turns : int
+  ; max_turns : int
+  ; initial_tool_requirement : Keeper_agent_tool_surface.tool_requirement
+  }
+
+(** [build ~now ~keeper_name ~channel ~turn_affordances] computes the wall
+    clock, max-turn, and tool-requirement values that bound a turn attempt.
+
+    [now ()] returns the monotonic clock time (in seconds) supplied by the
+    Eio clock at the dispatch site.  The retry loop reads it repeatedly via
+    [remaining_turn_budget_s] and [current_turn_phase_elapsed_ms].
+
+    [channel] selects between reactive and scheduled-autonomous turn caps. *)
+val build
+  :  now:(unit -> float)
+  -> keeper_name:string
+  -> channel:Keeper_world_observation.keeper_cycle_channel
+  -> turn_affordances:string list
+  -> retry_setup


### PR DESCRIPTION
## Summary

RFC-0136 Phase 4 sub-doc PR-4-a 구현. \`keeper_unified_turn.ml\` retry-loop outer setup 11 변수를 typed record \`Keeper_unified_turn_retry_setup.retry_setup\` 으로 추출.

## 측정

| 항목 | 값 |
|------|----|
| \`keeper_unified_turn.ml\` LoC | 1742 → 1720 (**-22**) |
| 새 모듈 | \`keeper_unified_turn_retry_setup.{ml,mli}\` (+92) |
| Callsite churn | **0** (destructuring 패턴) |
| 11 변수 사용처 | 무수정 |

## 왜 destructuring 패턴

11 변수 사용처 *34 곳*. 일일이 \`setup.field\` 로 바꾸면 churn 크다. \`let { Keeper_unified_turn_retry_setup.field; ... } = build ... in <body>\` 로 unpack 하면 body 안 names 그대로.

## 왜 do_run 은 안 옮겼나

retry-loop 안 \`do_run\` (123 LoC) 는 **16+ outer-scope deps** 가 있어 외부 모듈 이동 시 labeled args 폭증. PR-4-c (retry-loop recursive core) 의 일부로 분리.

→ sub-doc \`docs/rfc/RFC-0136-phase-4-retry-loop.md\` 의 \`-167 LoC\` 추정은 *do_run 포함 가정*이었음. impl 측정은 \`-22 LoC\` 로 정정. sub-doc closeout 시 retrofit 필요.

## Anti-pattern self-check

| # | Pattern | Status |
|---|---------|--------|
| 1 | Telemetry-as-fix | N/A — restructure |
| 2 | String classifier | N/A |
| 3 | N-of-M migration | **Boundary** — PR-4-a..e 자체가 N-of-M. sub-doc §2.5 closeout 명시 |
| 4 | Catch-all | N/A |
| 5 | Cap/cooldown | N/A |
| 6 | Test backdoor | N/A |
| 7 | N-site fix | N/A |

## RFC

\`docs/rfc/RFC-0136-keeper-unified-turn-decomposition.md\` + Phase 4 sub-doc PR-4-a 구현 (PR #16650 merged).

## Validation

- [x] \`dune build --root . lib/keeper/\` 통과 (no output)
- [ ] CI 전체 빌드 — \`lib/server/server_auth.{ml,mli}\` http_status mismatch broken main 으로 fail 가능 (PR #16690 이후, 본 PR 무관)

## Related

- PR-1 #16604, PR-2 #16624, PR-3 #16643 — MERGED
- Phase 4 sub-doc PR #16650 — MERGED
- 후속: PR-4-b (mark_terminal_error typed outcome) 병렬 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)