### PR TITLE
fix(server_auth): widen http_status_of_auth_error mli signature (production-blocking)

### DIFF
--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -506,8 +506,7 @@ let ensure_same_origin_browser_request request :
    from a real server fault. The match is now exhaustive; adding a new
    [Masc_error.t] outer variant will trip Warning 8 here and force an
    explicit HTTP-status decision. *)
-let http_status_of_auth_error : Masc_domain.masc_error -> Httpun.Status.t =
-  function
+let http_status_of_auth_error = function
   | Masc_domain.Auth
       (Masc_domain.Auth_error.Unauthorized _
       | Masc_domain.Auth_error.InvalidToken _

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -182,8 +182,16 @@ val ensure_same_origin_browser_request :
 
 val http_status_of_auth_error :
   Masc_domain.masc_error ->
-  [> `Forbidden | `Internal_server_error | `Unauthorized ]
-(** HTTP status to return for a given auth-domain error. *)
+  [> `Bad_request
+   | `Forbidden
+   | `Internal_server_error
+   | `Not_found
+   | `Too_many_requests
+   | `Unauthorized
+   ]
+(** HTTP status to return for a given auth-domain error. Returned as an
+    open polymorphic-variant subset so callers can pass the result to
+    either [Httpun.Status.t]- or [H2.Status.t]-typed sinks. *)
 
 val server_state : Mcp_server.server_state option ref
 (** Process-wide server state handle used by auth helpers when no


### PR DESCRIPTION
## Summary

**main is un-buildable** since #16690.

\`\`\`
$ dune build @check
Error: The implementation lib/server/server_auth.pp.ml does not match
       the interface lib/server/server_auth.pp.mli:
         val http_status_of_auth_error : Masc_error.t -> Httpun.Status.t
       is not included in
         val http_status_of_auth_error :
           Masc_error.t -> [> \`Forbidden | \`Internal_server_error | \`Unauthorized]
\`\`\`

### 원인

#16690 (\`fix(server_auth): exhaustive http_status_of_auth_error mirroring Masc_error.code\`)이 .ml 구현을 \`Bad_request\` / \`Not_found\` / \`Too_many_requests\` 포함한 6 태그로 확장했지만 .mli 선언은 3 태그(\`Forbidden\` | \`Internal_server_error\` | \`Unauthorized\`)에 머무름. 동일한 incomplete-merge drift 패턴이 #16671→#16692로 한 번 발생한 직후 재발.

### 변경

1. **.mli** — 실제 .ml이 돌려주는 6 태그를 모두 포함하는 open polymorphic variant로 widening
   - 여전히 \`[> ...]\` (open) 이라서 \`Httpun.Status.t\` sink (HTTP/1.1)와 \`H2.Status.t\` sink (HTTP/2 — \`server_h2_gateway.ml\` / \`h2_respond_json\`) 양쪽으로 흐를 수 있음
2. **.ml** — 함수 binding에 붙어있던 explicit \`Httpun.Status.t\` 타입 annotation 제거. .mli가 open variant를 약속하므로 .ml도 같은 모양으로 inference

### 검증
\`\`\`
$ dune build --root . @check
$ echo \$?
0
\`\`\`

### 라벨
- \`WORKAROUND: production-blocking main build break\` — \`software-development.md\` §워크어라운드 거부 기준 §Override 조건
- \`RFC-WAIVED: hotfix for #16690 mli/ml type mismatch\`

본 PR + #16692 (이미 머지)가 모두 같은 incomplete-merge 패턴 fix. 향후 비슷한 case 방지를 위한 lint 후보 (PR signature delta vs .mli) — 별도 RFC 후보.

## Test plan
- [x] dune @check green
- [ ] CI 통과 후 사용자 admin merge

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>