### PR TITLE
fix(server_auth): hotfix mli signature after #16690 widened http_status_of_auth_error

### DIFF
--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -506,8 +506,11 @@ let ensure_same_origin_browser_request request :
    from a real server fault. The match is now exhaustive; adding a new
    [Masc_error.t] outer variant will trip Warning 8 here and force an
    explicit HTTP-status decision. *)
-let http_status_of_auth_error : Masc_domain.masc_error -> Httpun.Status.t =
-  function
+(* Return type is intentionally left as the inferred open polymorphic
+   variant so the value is assignable to both [Httpun.Status.t] and
+   [H2.Status.t] at call sites (server_h2_gateway consumes the latter).
+   The mli pins the open lower bound. *)
+let http_status_of_auth_error = function
   | Masc_domain.Auth
       (Masc_domain.Auth_error.Unauthorized _
       | Masc_domain.Auth_error.InvalidToken _

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -182,8 +182,20 @@ val ensure_same_origin_browser_request :
 
 val http_status_of_auth_error :
   Masc_domain.masc_error ->
-  [> `Forbidden | `Internal_server_error | `Unauthorized ]
-(** HTTP status to return for a given auth-domain error. *)
+  [> `Bad_request
+  | `Forbidden
+  | `Internal_server_error
+  | `Not_found
+  | `Too_many_requests
+  | `Unauthorized ]
+(** HTTP status to return for a given masc_error.
+
+    The return type is an open polymorphic variant so the result is
+    assignable to both [Httpun.Status.t] and [H2.Status.t] (callers in
+    [server_h2_gateway] consume it as the latter). Variants widened
+    in PR #16690 (exhaustive mapping mirroring [Masc_error.code]);
+    the mli was not updated in that PR, leaving main with an
+    interface/implementation type mismatch — this is the hotfix. *)
 
 val server_state : Mcp_server.server_state option ref
 (** Process-wide server state handle used by auth helpers when no


### PR DESCRIPTION
## ⚠️ Production-blocking hotfix (NOT Draft — Ready)

PR #16690 (merged) widened \`http_status_of_auth_error\`'s impl to return the exhaustive HTTP status enum but did **not** update \`server_auth.mli\`. The mli check fails on every fresh checkout of main:

\`\`\`
Error: The implementation lib/server/server_auth.pp.ml
       does not match the interface lib/server/server_auth.pp.mli:
       Values do not match:
         val http_status_of_auth_error : Masc_error.t -> Httpun.Status.t
       is not included in
         val http_status_of_auth_error :
           Masc_error.t -> [> \`Forbidden | \`Internal_server_error | \`Unauthorized ]
\`\`\`

Every PR in flight inherits the broken main and fails CI. Please admin-merge / Ready-merge.

## Root

I introduced this in #16690 — added type annotation \`Httpun.Status.t\` on the impl + added new return tags (\`Bad_request, \`Not_found, \`Too_many_requests) without widening the mli. **My regression, my fix.**

## Fix

1. **mli** — widen the polyvariant lower bound to the 6 actually returned tags: \`Bad_request\`, \`Forbidden\`, \`Internal_server_error\`, \`Not_found\`, \`Too_many_requests\`, \`Unauthorized\`. Kept as **open** polyvariant (\`[> ...]\`) because callers in \`server_h2_gateway\` consume the result as \`H2.Status.t\` (not \`Httpun.Status.t\`) — the open form keeps the value assignable to both library Status types via row polymorphism.
2. **ml** — remove the explicit \`Httpun.Status.t\` annotation I added in #16690. That annotation closed the row and broke \`H2.Status.t\` call sites. Leave the return type inferred.

This is the row-polymorphism design the original mli used; the correct widening is "more variants in the same open shape", not "switch to a concrete \`Httpun.Status.t\`".

## Verification

- \`dune build --root .\` → exit 0 ✅ (main is green again with this patch applied).
- No call-site changes needed; row polymorphism handles both Status libs.
- Diff: +19/-4 LoC across 2 files.

## Iter#53 context

3rd main-broken incident in this cron session, and the **first one that was actually my fault**. Caught immediately after #16697 merge revealed it via fresh worktree build. Following the iter49/52 pattern: scope-discipline + immediate fix-forward + explicit incident trail in the commit body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>