### PR TITLE
fix(keeper): auto-route task-state bash probes

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -1088,51 +1088,79 @@ let handle_keeper_bash
          ; "retryable", `Bool true
          ])
   in
+  let json_of_raw raw =
+    match Yojson.Safe.from_string raw with
+    | json -> json
+    | exception Yojson.Json_error _ -> `String raw
+  in
+  let task_state_probe_blocked_json ~error ~reason =
+    Exec_core.blocked_result_json
+      ~cmd
+      ~error
+      ~reason
+      ~hint:Task_probe.hint
+      ~alternatives:Task_probe.alternatives
+      ~retryability:Exec_core.Self_correct
+      ~diag:
+        (Some
+           { Exec_core.rule_id = error
+           ; explanation =
+               "Keepers must use task-state tools instead of probing task \
+                state through shell."
+           ; rewrite = Some Task_probe.hint
+           ; tool_suggestion = Some "keeper_tasks_list"
+           })
+      ~extra:[ "cmd", `String cmd_for_log; "execution_time_ms", `Int 0 ]
+      ()
+  in
+  let task_state_probe_autoroute ~original_error ~reason =
+    try
+      let task_result =
+        Keeper_exec_task.handle_keeper_task_tool
+          ~config
+          ~meta
+          ~name:"keeper_tasks_list"
+          ~args:(`Assoc [ "include_done", `Bool false; "limit", `Int 50 ])
+      in
+      Yojson.Safe.to_string
+        (`Assoc
+           [ "ok", `Bool true
+           ; "auto_routed", `Bool true
+           ; "auto_routed_from_tool", `String "keeper_bash"
+           ; "auto_routed_to_tool", `String "keeper_tasks_list"
+           ; "original_error", `String original_error
+           ; "cmd", `String cmd_for_log
+           ; "reason", `String reason
+           ; "instruction",
+             `String
+               "This Bash task-state probe was executed through \
+                keeper_tasks_list instead. Continue with keeper task tools; do \
+                not retry Bash, guessed task files, or localhost task APIs."
+           ; "result", json_of_raw task_result
+           ])
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
+      Log.Keeper.warn
+        "keeper_bash task-state autoroute failed: keeper=%s error=%s cmd=%s"
+        meta.name
+        (Printexc.to_string exn)
+        cmd_for_log;
+      Yojson.Safe.to_string (task_state_probe_blocked_json ~error:original_error ~reason)
+  in
   let task_state_http_probe_block () =
-    Yojson.Safe.to_string
-      (Exec_core.blocked_result_json
-         ~cmd
-         ~error:"task_state_http_probe_blocked"
-         ~reason:
-           "Task state is not exposed through guessed localhost HTTP APIs from \
-            keeper_bash."
-         ~hint:Task_probe.hint
-         ~alternatives:Task_probe.alternatives
-         ~retryability:Exec_core.Self_correct
-         ~diag:
-           (Some
-              { Exec_core.rule_id = "task_state_http_probe_blocked"
-              ; explanation =
-                  "Keepers must use task-state tools instead of probing \
-                   localhost task APIs from shell."
-              ; rewrite = Some Task_probe.hint
-              ; tool_suggestion = Some "keeper_tasks_list"
-              })
-         ~extra:[ "cmd", `String cmd_for_log; "execution_time_ms", `Int 0 ]
-         ())
+    task_state_probe_autoroute
+      ~original_error:"task_state_http_probe_blocked"
+      ~reason:
+        "Task state is not exposed through guessed localhost HTTP APIs from \
+         keeper_bash."
   in
   let task_state_file_probe_block () =
-    Yojson.Safe.to_string
-      (Exec_core.blocked_result_json
-         ~cmd
-         ~error:"task_state_file_probe_blocked"
-         ~reason:
-           "Task state is owned by the MASC task tools, not by guessed \
-            backlog/current-task files in keeper sandboxes."
-         ~hint:Task_probe.hint
-         ~alternatives:Task_probe.alternatives
-         ~retryability:Exec_core.Self_correct
-         ~diag:
-           (Some
-              { Exec_core.rule_id = "task_state_file_probe_blocked"
-              ; explanation =
-                  "Keepers must use task-state tools instead of cat/find/rg \
-                   against .masc backlog files or worktree .task.json files."
-              ; rewrite = Some Task_probe.hint
-              ; tool_suggestion = Some "keeper_tasks_list"
-              })
-         ~extra:[ "cmd", `String cmd_for_log; "execution_time_ms", `Int 0 ]
-         ())
+    task_state_probe_autoroute
+      ~original_error:"task_state_file_probe_blocked"
+      ~reason:
+        "Task state is owned by the MASC task tools, not by guessed \
+         backlog/current-task files in keeper sandboxes."
   in
   if cmd = "" && has_typed_bash_input_key args
   then

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -785,6 +785,9 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
            (if !timeout_hit then "timeout" else "tool_failure"))
     else None
   in
+  let telemetry_failure_class =
+    if success then None else Tool_result.failure_class result
+  in
   (* Track tool call in telemetry (controlled by MASC_TELEMETRY_ENABLED) *)
   let telemetry_enabled = Env_config_core.telemetry_enabled () in
   if telemetry_enabled then
@@ -796,6 +799,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
                 ?session_id:telemetry_session_id
                 ?operation_id:telemetry_operation_id
                 ?worker_run_id:telemetry_worker_run_id
+                ?failure_class:telemetry_failure_class
                 ?error_kind:telemetry_error_kind
                 ?error_message:error_detail
                 ()

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -612,7 +612,7 @@ let respond_auth_error request reqd err =
     ("content-length", string_of_int (String.length body))
     :: cors_headers origin
   ) in
-  let response = Httpun.Response.create ~headers status in
+  let response = Httpun.Response.create ~headers (status :> Httpun.Status.t) in
   Httpun.Reqd.respond_with_string reqd response body
 
 (** Respond with 429 Too Many Requests when the per-agent rate limit is

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -81,7 +81,11 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
     in
     let h2_respond_auth_error h2_reqd err =
       let status = http_status_of_auth_error err in
-      h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
+      h2_respond_json
+        h2_reqd
+        (auth_error_json err)
+        ~status:(status :> H2.Status.t)
+        ~extra_headers:cors
     in
     let h2_respond_agent_rate_limited h2_reqd ~rl_key =
       h2_respond_json h2_reqd
@@ -235,7 +239,11 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
               with
               | Error err ->
                   let status = http_status_of_auth_error err in
-                  h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
+                  h2_respond_json
+                    h2_reqd
+                    (auth_error_json err)
+                    ~status:(status :> H2.Status.t)
+                    ~extra_headers:cors
               | Ok () ->
                   h2_read_body h2_reqd (fun body_str ->
                     match Server_webrtc_transport.handle_offer_request body_str with
@@ -260,7 +268,11 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
               with
               | Error err ->
                   let status = http_status_of_auth_error err in
-                  h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
+                  h2_respond_json
+                    h2_reqd
+                    (auth_error_json err)
+                    ~status:(status :> H2.Status.t)
+                    ~extra_headers:cors
               | Ok () ->
                   h2_read_body h2_reqd (fun body_str ->
                     match Server_webrtc_transport.handle_answer_request body_str with

--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -448,8 +448,9 @@ let nonempty_error_kind_opt value =
   | None -> None
 
 let track_tool_called ?fs config ~tool_name ~success ~duration_ms ?agent_id
-    ?source ?session_id ?operation_id ?worker_run_id ?error_kind
+    ?source ?session_id ?operation_id ?worker_run_id ?failure_class ?error_kind
     ?error_message ?exit_code ?stderr_excerpt () =
+  let failure_class = if success then None else failure_class in
   let error_kind =
     if success then None else nonempty_error_kind_opt error_kind
   in
@@ -473,7 +474,7 @@ let track_tool_called ?fs config ~tool_name ~success ~duration_ms ?agent_id
          error_message;
          exit_code;
          stderr_excerpt;
-         failure_class = None;
+         failure_class;
        });
   if not success then
     match error_kind with

--- a/lib/telemetry_eio.mli
+++ b/lib/telemetry_eio.mli
@@ -195,6 +195,7 @@ val track_tool_called :
   ?session_id:string ->
   ?operation_id:string ->
   ?worker_run_id:string ->
+  ?failure_class:Tool_result.tool_failure_class ->
   ?error_kind:error_kind ->
   ?error_message:string ->
   ?exit_code:int ->

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -78,7 +78,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | CascadeExhaustion.tla | CascadeExhaustion | manual | 2 | 1 | clean={inv:TypeOK, inv:ExhaustionSafetyLastOk} buggy={inv:TypeOK, inv:ExhaustionDiagnosticConsistency} | 20f49d7b2536 |
 | CascadeLiveness.tla | CascadeLiveness | manual | 3 | 1 | clean={inv:TypeOK, inv:SlotCapacity, inv:SlotNonNeg, inv:NoPhantomSlots, inv:AdmittedOK} buggy={inv:TypeOK, inv:NoPhantomSlots} liveness={inv:TypeOK, inv:SlotCapacity, inv:SlotNonNeg, inv:NoPhantomSlots, inv:AdmittedOK} | 47df51e8fce8 |
 | CooperativeDrainYield.tla | CooperativeDrainYield | manual | 2 | 1 | clean={inv:TypeOK, inv:NoStarvation} buggy={inv:TypeOK, inv:NoStarvation} | d3828a38e496 |
-| DashboardCacheStampede.tla | DashboardCacheStampede | manual | 2 | 1 | clean={inv:TypeOK, inv:NoZombieSlot} buggy={inv:TypeOK, inv:NoZombieSlot} | ab492d475875 |
+| DashboardCacheStampede.tla | DashboardCacheStampede | manual | 2 | 1 | clean={inv:TypeOK, inv:NoZombieSlot} buggy={inv:TypeOK, inv:NoZombieSlot} | 40fa7c5ba4cd |
 | DiscoveryCacheTTL.tla | DiscoveryCacheTTL | manual | 2 | 1 | clean={inv:TypeOK, inv:ConsistentRead} buggy={inv:TypeOK, inv:ConsistentRead} | 67b6a98c6628 |
 | DispatchCoverage.tla | DispatchCoverage | manual | 2 | 1 | clean={inv:TypeOK, inv:DataFsmConsistent, inv:PhaseConsistent, inv:NeverStuckFailing} buggy={inv:TypeOK, inv:DataFsmConsistent, inv:PhaseConsistent, inv:NeverStuckFailing} | 27f7463c8e91 |
 | DispatchHookChain.tla | DispatchHookChain | manual | 2 | 1 | clean={inv:ShortCircuitSkipsHandler, inv:PostHooksAfterHandler, inv:HandlerRequiresNoReject} buggy={inv:ShortCircuitSkipsHandler} | be2fa471842f |

--- a/specs/bug-models/DashboardCacheStampede.tla
+++ b/specs/bug-models/DashboardCacheStampede.tla
@@ -10,11 +10,11 @@
 \*
 \* Actual code (verified 2026-04-20):
 \*   lib/dashboard/dashboard_cache.ml:60   let maybe_evict map
-\*   lib/dashboard/dashboard_cache.ml:219  let get_or_compute_eio
-\*   lib/dashboard/dashboard_cache.ml:326  | Eio.Cancel.Cancelled _ -> ...
+\*   lib/dashboard/dashboard_cache.ml:227  let get_or_compute_eio
+\*   lib/dashboard/dashboard_cache.ml:328  | Eio.Cancel.Cancelled _ -> ...
 \*
 \* (Path drift: lib/dashboard_cache.ml -> lib/dashboard/dashboard_cache.ml.
-\*  Line drift: 265 -> 216 -> 161/262 -> 219/326. Recorded for cross-reference.)
+\*  Line drift: 265 -> 216 -> 161/262 -> 219/326 -> 227/328. Recorded for cross-reference.)
 
 EXTENDS Naturals
 

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -1281,6 +1281,7 @@ let test_keeper_bash_task_state_file_probe_uses_task_tools () =
   Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
   Keeper_registry.clear ();
   let meta = make_readonly_meta "task-file-probe" in
+  let _ = Coord.init config ~agent_name:(Some meta.name) in
   let playground = Filename.concat base_path (playground_path_of meta.name) in
   ensure_dir playground;
   let raw =
@@ -1298,16 +1299,22 @@ let test_keeper_bash_task_state_file_probe_uses_task_tools () =
       ()
   in
   let json = Yojson.Safe.from_string raw in
-  Alcotest.(check (option string)) "task file probe is blocked"
-    (Some "task_state_file_probe_blocked") (parse_error_field raw);
-  Alcotest.(check string) "suggested tool"
+  Alcotest.(check bool) "task file probe succeeds via autoroute" true
+    (json |> Json.member "ok" |> Json.to_bool);
+  Alcotest.(check bool) "task file probe is autorouted" true
+    (json |> Json.member "auto_routed" |> Json.to_bool);
+  Alcotest.(check string) "autorouted to tasks list"
     "keeper_tasks_list"
-    (json |> Json.member "diagnosis" |> Json.member "tool_suggestion" |> Json.to_string);
-  (match parse_hint raw with
-   | Some hint ->
-     Alcotest.(check bool) "hint points to keeper_tasks_list" true
-	       (String_util.contains_substring hint "keeper_tasks_list")
-	   | None -> Alcotest.fail ("expected hint, got: " ^ raw))
+    (json |> Json.member "auto_routed_to_tool" |> Json.to_string);
+  Alcotest.(check string) "original error preserved"
+    "task_state_file_probe_blocked"
+    (json |> Json.member "original_error" |> Json.to_string);
+  Alcotest.(check bool) "instruction points to keeper_tasks_list" true
+    (String_util.contains_substring
+       (json |> Json.member "instruction" |> Json.to_string)
+       "keeper_tasks_list");
+  Alcotest.(check (option string)) "not returned as bash error" None
+    (parse_error_field raw)
 
 let test_keeper_bash_unrelated_task_json_is_not_task_state_probe () =
   with_eio_fs @@ fun () ->
@@ -1407,6 +1414,7 @@ let test_keeper_bash_task_state_http_probe_uses_task_tools () =
   Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
   Keeper_registry.clear ();
   let meta = make_write_enabled_meta "task-http-probe" in
+  let _ = Coord.init config ~agent_name:(Some meta.name) in
   let playground = Filename.concat base_path (playground_path_of meta.name) in
   ensure_dir playground;
   let raw =
@@ -1425,16 +1433,22 @@ let test_keeper_bash_task_state_http_probe_uses_task_tools () =
       ()
   in
   let json = Yojson.Safe.from_string raw in
-  Alcotest.(check (option string)) "localhost task probe is blocked"
-    (Some "task_state_http_probe_blocked") (parse_error_field raw);
-  Alcotest.(check string) "suggested tool"
+  Alcotest.(check bool) "localhost task probe succeeds via autoroute" true
+    (json |> Json.member "ok" |> Json.to_bool);
+  Alcotest.(check bool) "localhost task probe is autorouted" true
+    (json |> Json.member "auto_routed" |> Json.to_bool);
+  Alcotest.(check string) "autorouted to tasks list"
     "keeper_tasks_list"
-    (json |> Json.member "diagnosis" |> Json.member "tool_suggestion" |> Json.to_string);
-  (match parse_hint raw with
-   | Some hint ->
-     Alcotest.(check bool) "hint points to keeper_tasks_list" true
-       (String_util.contains_substring hint "keeper_tasks_list")
-   | None -> Alcotest.fail ("expected hint, got: " ^ raw))
+    (json |> Json.member "auto_routed_to_tool" |> Json.to_string);
+  Alcotest.(check string) "original error preserved"
+    "task_state_http_probe_blocked"
+    (json |> Json.member "original_error" |> Json.to_string);
+  Alcotest.(check bool) "instruction points to keeper_tasks_list" true
+    (String_util.contains_substring
+       (json |> Json.member "instruction" |> Json.to_string)
+       "keeper_tasks_list");
+  Alcotest.(check (option string)) "not returned as bash error" None
+    (parse_error_field raw)
 
 let test_keeper_bash_echo_task_api_url_is_not_http_probe () =
   with_eio_fs @@ fun () ->


### PR DESCRIPTION
## Summary
- auto-route keeper_bash task-state file/localhost probes to keeper_tasks_list instead of returning a retryable Bash workflow rejection
- preserve auto-route markers and original error names for diagnostics
- pass typed tool failure_class through telemetry and align auth status typing exposed by current main

## Verification
- MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_DUNE_ALLOW_LIVE_BUILD_LOCK=1 DUNE_LOCAL_JOBS=2 scripts/dune-local.sh build test/test_keeper_bash_safety.exe
- ./_build/default/test/test_keeper_bash_safety.exe test readonly_hints 9,13 --show-errors
