### PR TITLE
refactor(keeper_registry): extract cascade-attempt cluster (godfile decomp)

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -619,7 +619,7 @@ let record_keeper_crashed
   if resolve_registry_done entry (`Crashed reason)
   then (
     let outcome =
-      Keeper_registry.enrich_fiber_unresolved_outcome
+      Keeper_registry_cascade_attempt.enrich_fiber_unresolved_outcome
         ~base_path
         ~keeper_name
         reason

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -370,100 +370,10 @@ let update_meta ~base_path name meta =
   update_entry ~base_path name (fun e -> { e with meta })
 ;;
 
-let cascade_attempt_merge ~(latest : keeper_meta) ~(caller : keeper_meta) =
-  { latest with
-    meta_version = latest.meta_version
-  ; runtime =
-      { latest.runtime with
-        last_cascade_attempt = caller.runtime.last_cascade_attempt
-      }
-  }
-;;
-
-let meta_for_cascade_attempt ~base_path ~keeper_name =
-  let config = Coord.default_config base_path in
-  match read_meta config keeper_name with
-  | Ok (Some meta) -> Some (config, meta)
-  | Ok None | Error _ ->
-    (match get ~base_path keeper_name with
-     | Some entry -> Some (config, entry.meta)
-     | None -> None)
-;;
-
-let record_cascade_attempt ~base_path ~keeper_name attempt =
-  try
-    let keeper_name = String.trim keeper_name in
-    if String.equal keeper_name ""
-    then ()
-    else
-      match meta_for_cascade_attempt ~base_path ~keeper_name with
-      | None -> ()
-      | Some (config, meta) ->
-        let caller =
-          { meta with
-            runtime = { meta.runtime with last_cascade_attempt = Some attempt }
-          }
-        in
-        ignore
-          (write_meta_with_merge
-             ~merge:cascade_attempt_merge
-             config
-             caller
-            : (unit, string) result)
-  with
-  | _ -> ()
-;;
-
-let cascade_attempt_suffix (attempt : cascade_attempt_record) =
-  let http =
-    match attempt.http_status with
-    | Some status -> string_of_int status
-    | None -> "none"
-  in
-  Printf.sprintf " provider=%s http=%s" attempt.provider_id http
-;;
-
-let last_cascade_attempt ~base_path ~keeper_name =
-  let keeper_name = String.trim keeper_name in
-  if String.equal keeper_name ""
-  then None
-  else
-    try
-      match meta_for_cascade_attempt ~base_path ~keeper_name with
-      | Some (_config, meta) -> meta.runtime.last_cascade_attempt
-      | None -> None
-    with
-    | _ -> None
-;;
-
-(* Stale provenance threshold: cascade attempts older than this are not
-   attached to a fresh [fiber_unresolved] outcome (P1 review finding).
-   Long enough to span a normal keeper turn cascade chain; short enough
-   that a quiescent slot from a prior turn does not taint a new crash. *)
-let cascade_attempt_freshness_threshold_sec = 120.0
-
-let enrich_fiber_unresolved_outcome ~base_path ~keeper_name outcome =
-  let fiber_unresolved = failure_reason_to_string Fiber_unresolved in
-  if not (String.equal outcome fiber_unresolved)
-  then outcome
-  else
-    match last_cascade_attempt ~base_path ~keeper_name with
-    | None -> outcome
-    | Some attempt ->
-      (* P2 finding: only failure attempts explain a fiber_unresolved
-         outcome. A persisted success would otherwise inherit
-         [provider=... http=none] into a later failure label. *)
-      (match attempt.outcome with
-       | `Success -> outcome
-       | `Failure _ ->
-         (* P1 finding: gate enrichment on attempt freshness so a stale
-            slot from an earlier turn cannot taint a new crash. NDT-OK:
-            wall-clock comparison against persisted attempt timestamp. *)
-         let age = Unix.gettimeofday () -. attempt.timestamp in
-         if age > cascade_attempt_freshness_threshold_sec
-         then outcome
-         else outcome ^ cascade_attempt_suffix attempt)
-;;
+(* Cascade-attempt cluster (cascade_attempt_merge / meta_for_cascade_attempt /
+   record_cascade_attempt / cascade_attempt_suffix / last_cascade_attempt /
+   cascade_attempt_freshness_threshold_sec / enrich_fiber_unresolved_outcome)
+   moved to Keeper_registry_cascade_attempt. *)
 
 let sync_meta_if_registered ~base_path name meta =
   let key = registry_key ~base_path name in

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -78,16 +78,8 @@ val all : ?base_path:string -> unit -> registry_entry list
 (** Update the meta for a registered keeper. No-op if not found. *)
 val update_meta : base_path:string -> string -> keeper_meta -> unit
 
-(** Persist the last cascade provider attempt in keeper runtime meta.
-    Best-effort: missing keepers or meta write failures are ignored. *)
-val record_cascade_attempt :
-  base_path:string -> keeper_name:string -> cascade_attempt_record -> unit
-
-(** Add [provider=<id> http=<status>] to [fiber_unresolved] outcomes when
-    keeper runtime meta has a recorded cascade attempt. Other outcomes are
-    returned unchanged. *)
-val enrich_fiber_unresolved_outcome :
-  base_path:string -> keeper_name:string -> string -> string
+(* Cascade-attempt persistence + enrichment moved to
+   Keeper_registry_cascade_attempt (record / enrich_fiber_unresolved_outcome). *)
 
 (** Record a restart. Increments restart_count and updates last_restart_ts. *)
 val record_restart : base_path:string -> string -> unit

--- a/lib/keeper/keeper_registry_cascade_attempt.ml
+++ b/lib/keeper/keeper_registry_cascade_attempt.ml
@@ -1,0 +1,111 @@
+(** Cascade-attempt persistence + fiber_unresolved enrichment.
+
+    Extracted from keeper_registry.ml (lines 373-466) as part of the
+    godfile decomp campaign. The 7 functions here form a self-contained
+    cluster: read keeper runtime meta, update only the [last_cascade_attempt]
+    slot via a focused [write_meta_with_merge] callback, and use the
+    persisted attempt to enrich [fiber_unresolved] outcome labels with
+    [provider=… http=…] suffixes (gated on freshness so stale slots
+    from prior turns can't taint a new crash).
+
+    Dependencies kept on Keeper_registry: only [get] (read-only lookup
+    of in-memory entry for fallback when meta file read fails). No
+    direct Atomic CAS path is required. *)
+
+open Keeper_types
+open Keeper_registry_types
+
+let cascade_attempt_merge ~(latest : keeper_meta) ~(caller : keeper_meta) =
+  { latest with
+    meta_version = latest.meta_version
+  ; runtime =
+      { latest.runtime with
+        last_cascade_attempt = caller.runtime.last_cascade_attempt
+      }
+  }
+;;
+
+let meta_for_cascade_attempt ~base_path ~keeper_name =
+  let config = Coord.default_config base_path in
+  match read_meta config keeper_name with
+  | Ok (Some meta) -> Some (config, meta)
+  | Ok None | Error _ ->
+    (match Keeper_registry.get ~base_path keeper_name with
+     | Some entry -> Some (config, entry.meta)
+     | None -> None)
+;;
+
+let record ~base_path ~keeper_name attempt =
+  try
+    let keeper_name = String.trim keeper_name in
+    if String.equal keeper_name ""
+    then ()
+    else
+      match meta_for_cascade_attempt ~base_path ~keeper_name with
+      | None -> ()
+      | Some (config, meta) ->
+        let caller =
+          { meta with
+            runtime = { meta.runtime with last_cascade_attempt = Some attempt }
+          }
+        in
+        ignore
+          (write_meta_with_merge
+             ~merge:cascade_attempt_merge
+             config
+             caller
+            : (unit, string) result)
+  with
+  | _ -> ()
+;;
+
+let suffix (attempt : cascade_attempt_record) =
+  let http =
+    match attempt.http_status with
+    | Some status -> string_of_int status
+    | None -> "none"
+  in
+  Printf.sprintf " provider=%s http=%s" attempt.provider_id http
+;;
+
+let last ~base_path ~keeper_name =
+  let keeper_name = String.trim keeper_name in
+  if String.equal keeper_name ""
+  then None
+  else
+    try
+      match meta_for_cascade_attempt ~base_path ~keeper_name with
+      | Some (_config, meta) -> meta.runtime.last_cascade_attempt
+      | None -> None
+    with
+    | _ -> None
+;;
+
+(* Stale provenance threshold: cascade attempts older than this are not
+   attached to a fresh [fiber_unresolved] outcome (P1 review finding).
+   Long enough to span a normal keeper turn cascade chain; short enough
+   that a quiescent slot from a prior turn does not taint a new crash. *)
+let freshness_threshold_sec = 120.0
+
+let enrich_fiber_unresolved_outcome ~base_path ~keeper_name outcome =
+  let fiber_unresolved = failure_reason_to_string Fiber_unresolved in
+  if not (String.equal outcome fiber_unresolved)
+  then outcome
+  else
+    match last ~base_path ~keeper_name with
+    | None -> outcome
+    | Some attempt ->
+      (* P2 finding: only failure attempts explain a fiber_unresolved
+         outcome. A persisted success would otherwise inherit
+         [provider=... http=none] into a later failure label. *)
+      (match attempt.outcome with
+       | `Success -> outcome
+       | `Failure _ ->
+         (* P1 finding: gate enrichment on attempt freshness so a stale
+            slot from an earlier turn cannot taint a new crash. NDT-OK:
+            wall-clock comparison against persisted attempt timestamp. *)
+         let age = Unix.gettimeofday () -. attempt.timestamp in
+         if age > freshness_threshold_sec
+         then outcome
+         else outcome ^ suffix attempt)
+;;

--- a/lib/keeper/keeper_registry_cascade_attempt.mli
+++ b/lib/keeper/keeper_registry_cascade_attempt.mli
@@ -1,0 +1,20 @@
+(** Cascade-attempt persistence + fiber_unresolved enrichment.
+
+    SSOT for the cascade-attempt slot of keeper runtime meta. The only
+    write-path is [record], which updates [meta.runtime.last_cascade_attempt]
+    through a focused [Keeper_types.write_meta_with_merge] callback;
+    [enrich_fiber_unresolved_outcome] is the dashboard / supervisor
+    read-path that attaches a [provider=… http=…] suffix when a fresh
+    failure attempt is on file. *)
+
+(** Persist the last cascade provider attempt in keeper runtime meta.
+    Best-effort: missing keepers or meta write failures are ignored. *)
+val record :
+  base_path:string -> keeper_name:string
+  -> Keeper_types.cascade_attempt_record -> unit
+
+(** Add [provider=<id> http=<status>] to [fiber_unresolved] outcomes when
+    keeper runtime meta has a recorded cascade attempt within
+    [freshness_threshold_sec]. Other outcomes are returned unchanged. *)
+val enrich_fiber_unresolved_outcome :
+  base_path:string -> keeper_name:string -> string -> string

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -235,7 +235,7 @@ let launch_supervised_fiber
                  | None -> "stale_turn_timeout"
 	               in
 	               let outcome =
-	                 Keeper_registry.enrich_fiber_unresolved_outcome
+	                 Keeper_registry_cascade_attempt.enrich_fiber_unresolved_outcome
 	                   ~base_path
 	                   ~keeper_name:meta.name
 	                   reason
@@ -321,7 +321,7 @@ let launch_supervised_fiber
 	             in
 	             let reason = Keeper_registry.failure_reason_to_string fr in
 	             let outcome =
-	               Keeper_registry.enrich_fiber_unresolved_outcome
+	               Keeper_registry_cascade_attempt.enrich_fiber_unresolved_outcome
 	                 ~base_path
 	                 ~keeper_name:meta.name
 	                 reason
@@ -403,7 +403,7 @@ let launch_supervised_fiber
 	                    Keeper_registry.Fiber_unresolved
 	                in
 	                let outcome =
-	                  Keeper_registry.enrich_fiber_unresolved_outcome
+	                  Keeper_registry_cascade_attempt.enrich_fiber_unresolved_outcome
 	                    ~base_path
 	                    ~keeper_name:meta.name
 	                    reason
@@ -1404,7 +1404,7 @@ let sweep_and_recover (ctx : _ context) =
 	    if Keeper_registry.try_resolve_done entry (`Crashed msg)
 	    then (
 	      let outcome =
-	        Keeper_registry.enrich_fiber_unresolved_outcome
+	        Keeper_registry_cascade_attempt.enrich_fiber_unresolved_outcome
 	          ~base_path
 	          ~keeper_name:entry.name
 	          msg

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -609,7 +609,7 @@ let run_named
                       (* NDT-OK: external provider observation timestamp only. *)
                   }
                 in
-                Keeper_registry.record_cascade_attempt ~base_path ~keeper_name record
+                Keeper_registry_cascade_attempt.record ~base_path ~keeper_name record
           in
           let http_status_of_provider_error = function
             | Some (Provider_error.ServerError { code; _ }) -> Some code

--- a/test/test_cascade_attempt_provenance.ml
+++ b/test/test_cascade_attempt_provenance.ml
@@ -59,7 +59,7 @@ let test_record_cascade_attempt_round_trips_from_meta () =
         ; timestamp = 1_768_600_000.25
         }
       in
-      Registry.record_cascade_attempt
+      Masc_mcp.Keeper_registry_cascade_attempt.record
         ~base_path:config.base_path
         ~keeper_name
         expected;


### PR DESCRIPTION
## Summary

Stacked atop #16702 (server_auth mli hotfix — production main build break). Third keeper_registry godfile decomp PR after #16657 (lookup, MERGED) and #16677 (tool_usage_persistence, MERGED).

### 변경 요약

7-function cascade-attempt cluster (lines 373-466) → 새 sibling module \`keeper_registry_cascade_attempt.ml\`:

| 원본 | 새 위치 | 노출 |
|------|---------|------|
| \`cascade_attempt_merge\` | \`Keeper_registry_cascade_attempt\` | internal |
| \`meta_for_cascade_attempt\` | 동 | internal |
| \`record_cascade_attempt\` | \`Keeper_registry_cascade_attempt.record\` | public |
| \`cascade_attempt_suffix\` | \`Keeper_registry_cascade_attempt.suffix\` | internal |
| \`last_cascade_attempt\` | \`Keeper_registry_cascade_attempt.last\` | internal |
| \`cascade_attempt_freshness_threshold_sec\` | \`Keeper_registry_cascade_attempt.freshness_threshold_sec\` | internal |
| \`enrich_fiber_unresolved_outcome\` | \`Keeper_registry_cascade_attempt.enrich_fiber_unresolved_outcome\` | public (name kept) |

Cluster은 cycle-free: \`Coord\` + \`Keeper_types.read_meta\` / \`write_meta_with_merge\` 사용, in-memory entry fallback은 이미 public인 \`Keeper_registry.get\` 통해. Atomic CAS path 불필요.

### LoC 효과

| | Before | After | Δ |
|--|--------|-------|---|
| \`lib/keeper/keeper_registry.ml\` | 1990 | 1900 | −90 |
| \`lib/keeper/keeper_registry.mli\` | 489 | 484 | −5 |
| 신규 \`keeper_registry_cascade_attempt.ml\` | — | 110 | +110 |
| 신규 \`keeper_registry_cascade_attempt.mli\` | — | 20 | +20 |

**Combined stack (#16657 + #16677 + this PR): 2129 → 1900 (−229 LoC, 10.8% 감소)**.

### 동작 보존
- 동일 freshness threshold (120s)
- 동일 write_meta_with_merge merge fn (last_cascade_attempt slot 만)
- 동일 enrichment logic (Failure outcomes, freshness gate)

### 검증
- \`dune build --root . @check\` exit 0
- \`test/test_keeper_registry.exe\` 109 tests PASS
- \`test/test_cascade_attempt_provenance.exe\` 1 test PASS

### 4 caller files
- \`lib/keeper/keeper_turn_driver.ml\` (1)
- \`lib/keeper/keeper_supervisor.ml\` (4)
- \`lib/keeper/keeper_keepalive.ml\` (1)
- \`test/test_cascade_attempt_provenance.ml\` (Registry alias rewired)

### Scope guard
- credential / identity / operator-control / sandbox / dashboard credential / hooks / workflow 영역 무관
- \`RFC-WAIVED: cluster extraction, godfile decomp follow-up to RFC-0136 stack\`

## Test plan
- [x] dune @check green
- [x] keeper_registry alcotest (109) + cascade_attempt_provenance (1) PASS
- [ ] base PR #16702 머지 후 base를 main으로 변경 (또는 stack squash 머지)
- [ ] 사용자 라벨 dispatch

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>