### PR TITLE
[RFC-0139 PR-1b] live-store migrates to typed agent-status

### DIFF
--- a/dashboard/src/lib/agent-status.test.ts
+++ b/dashboard/src/lib/agent-status.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AGENT_STATUS_VALUES,
+  isAgentActive,
+  isAgentOffline,
+  isAgentPresent,
+  parseAgentStatus,
+  type AgentStatus,
+} from './agent-status'
+
+describe('AGENT_STATUS_VALUES', () => {
+  it('matches the Agent.status literal union (6 tokens)', () => {
+    expect(AGENT_STATUS_VALUES).toEqual([
+      'active',
+      'busy',
+      'listening',
+      'idle',
+      'inactive',
+      'offline',
+    ])
+  })
+})
+
+describe('parseAgentStatus', () => {
+  it('accepts each known token', () => {
+    for (const token of AGENT_STATUS_VALUES) {
+      expect(parseAgentStatus(token)).toBe(token)
+    }
+  })
+
+  it('is case-insensitive', () => {
+    expect(parseAgentStatus('ACTIVE')).toBe('active')
+    expect(parseAgentStatus('Busy')).toBe('busy')
+    expect(parseAgentStatus('OFFLINE')).toBe('offline')
+  })
+
+  it('returns null for unknown tokens', () => {
+    expect(parseAgentStatus('retired')).toBeNull()
+    expect(parseAgentStatus('unbooted')).toBeNull()
+    expect(parseAgentStatus('stopped')).toBeNull()
+    expect(parseAgentStatus('running')).toBeNull()
+  })
+
+  it('returns null for null / undefined / empty', () => {
+    expect(parseAgentStatus(null)).toBeNull()
+    expect(parseAgentStatus(undefined)).toBeNull()
+    expect(parseAgentStatus('')).toBeNull()
+  })
+})
+
+describe('isAgentOffline', () => {
+  it('returns true for offline / inactive only', () => {
+    expect(isAgentOffline({ status: 'offline' })).toBe(true)
+    expect(isAgentOffline({ status: 'inactive' })).toBe(true)
+  })
+
+  it('returns false for presence states', () => {
+    expect(isAgentOffline({ status: 'active' })).toBe(false)
+    expect(isAgentOffline({ status: 'busy' })).toBe(false)
+    expect(isAgentOffline({ status: 'listening' })).toBe(false)
+    expect(isAgentOffline({ status: 'idle' })).toBe(false)
+  })
+
+  it('rejects keeper-domain tokens (unbooted / stopped)', () => {
+    expect(isAgentOffline({ status: 'unbooted' as unknown as AgentStatus })).toBe(false)
+    expect(isAgentOffline({ status: 'stopped' as unknown as AgentStatus })).toBe(false)
+  })
+
+  it('returns false for missing status', () => {
+    expect(isAgentOffline({ status: undefined })).toBe(false)
+  })
+})
+
+describe('isAgentActive', () => {
+  it('returns true for active / busy', () => {
+    expect(isAgentActive({ status: 'active' })).toBe(true)
+    expect(isAgentActive({ status: 'busy' })).toBe(true)
+  })
+
+  it('returns false for listening / idle (present but not active)', () => {
+    expect(isAgentActive({ status: 'listening' })).toBe(false)
+    expect(isAgentActive({ status: 'idle' })).toBe(false)
+  })
+
+  it('returns false for offline / inactive', () => {
+    expect(isAgentActive({ status: 'offline' })).toBe(false)
+    expect(isAgentActive({ status: 'inactive' })).toBe(false)
+  })
+
+  it('returns false for missing / unknown', () => {
+    expect(isAgentActive({ status: undefined })).toBe(false)
+    expect(isAgentActive({ status: 'retired' as unknown as AgentStatus })).toBe(false)
+  })
+})
+
+describe('isAgentPresent', () => {
+  it('returns true for the 4 presence states', () => {
+    expect(isAgentPresent({ status: 'active' })).toBe(true)
+    expect(isAgentPresent({ status: 'busy' })).toBe(true)
+    expect(isAgentPresent({ status: 'listening' })).toBe(true)
+    expect(isAgentPresent({ status: 'idle' })).toBe(true)
+  })
+
+  it('returns false for offline / inactive', () => {
+    expect(isAgentPresent({ status: 'offline' })).toBe(false)
+    expect(isAgentPresent({ status: 'inactive' })).toBe(false)
+  })
+
+  it('returns false for unknown tokens', () => {
+    expect(isAgentPresent({ status: 'retired' as unknown as AgentStatus })).toBe(false)
+    expect(isAgentPresent({ status: undefined })).toBe(false)
+  })
+})
+
+describe('boundary cases (cross-domain isolation)', () => {
+  it('keeper-only tokens are not classified as agent presence', () => {
+    expect(parseAgentStatus('unbooted')).toBeNull()
+    expect(parseAgentStatus('stopped')).toBeNull()
+    expect(isAgentPresent({ status: 'unbooted' as unknown as AgentStatus })).toBe(false)
+    expect(isAgentOffline({ status: 'unbooted' as unknown as AgentStatus })).toBe(false)
+  })
+})

--- a/dashboard/src/lib/agent-status.ts
+++ b/dashboard/src/lib/agent-status.ts
@@ -1,0 +1,68 @@
+// RFC-0139 Phase 1 PR-1a — Agent status vocabulary SSOT.
+//
+// Typed closed sum + total parser + domain-specific predicates for
+// dashboard agent presence. Keeps the keeper-status SSOT (lib/keeper-
+// predicates.ts, RFC-0135) and the agent-status SSOT as parallel typed
+// vocabularies; conversion between them happens at component boundaries
+// only.
+//
+// No callsite migration in this PR — module + tests only. Migration to
+// the predicates lands in RFC-0139 PR-1b/PR-1c.
+
+import type { Agent } from '../types/core'
+
+/** Closed sum of agent presence states. Mirrors the literal union on
+ *  `Agent.status` in `dashboard/src/types/core.ts`. */
+export type AgentStatus =
+  | 'active'
+  | 'busy'
+  | 'listening'
+  | 'idle'
+  | 'inactive'
+  | 'offline'
+
+export const AGENT_STATUS_VALUES = [
+  'active',
+  'busy',
+  'listening',
+  'idle',
+  'inactive',
+  'offline',
+] as const satisfies ReadonlyArray<AgentStatus>
+
+const AGENT_STATUS_SET: ReadonlySet<string> = new Set(AGENT_STATUS_VALUES)
+
+/** Total parser: raw string → typed AgentStatus, or null when the input
+ *  is unknown / missing. Use at boundaries (wire decode, JSON parse). */
+export function parseAgentStatus(raw: string | undefined | null): AgentStatus | null {
+  if (raw == null) return null
+  const lower = raw.toLowerCase()
+  return AGENT_STATUS_SET.has(lower) ? (lower as AgentStatus) : null
+}
+
+/** True when the agent is not present (the backend has dropped the
+ *  connection or the registry marked the slot dormant). Mirrors the
+ *  cross-domain `isOfflineStatus` predicate scoped to *agent* tokens
+ *  only — keeper-specific tokens like 'unbooted' / 'stopped' are
+ *  rejected. */
+export function isAgentOffline(agent: Pick<Agent, 'status'>): boolean {
+  const parsed = parseAgentStatus(agent.status ?? null)
+  return parsed === 'offline' || parsed === 'inactive'
+}
+
+/** True when the agent is actively driving work (taking turns, or
+ *  consuming a tool). Distinct from "present" — listening / idle
+ *  agents are present but not active. */
+export function isAgentActive(agent: Pick<Agent, 'status'>): boolean {
+  const parsed = parseAgentStatus(agent.status ?? null)
+  return parsed === 'active' || parsed === 'busy'
+}
+
+/** True when the agent is reachable in any presence state (active,
+ *  working, or just listening / idle). The negation of `isAgentOffline`
+ *  for known tokens; unknown tokens return false. */
+export function isAgentPresent(agent: Pick<Agent, 'status'>): boolean {
+  const parsed = parseAgentStatus(agent.status ?? null)
+  if (parsed == null) return false
+  return parsed !== 'offline' && parsed !== 'inactive'
+}

--- a/dashboard/src/live-store.ts
+++ b/dashboard/src/live-store.ts
@@ -1,7 +1,7 @@
 // Live Monitor tab — derived signals and filter state
 
 import { signal, computed, type ReadonlySignal } from '@preact/signals'
-import { isOfflineStatus } from './lib/status-utils'
+import { isAgentActive, isAgentOffline, isAgentPresent } from './lib/agent-status'
 import type { JournalEntry } from './types'
 import type { PipelineStage } from './types/core'
 import type { AuditEntry } from './api/dashboard'
@@ -73,7 +73,7 @@ export const agentPulses: ReadonlySignal<AgentPulse[]> = computed(() => {
     const motion = motionMap.get(key) ?? null
 
     let state: PulseState = 'idle'
-    if (agent.status === 'active' || agent.status === 'busy') {
+    if (isAgentActive(agent)) {
       const lastAt = motion?.lastActivityAt
       if (lastAt) {
         const elapsed = now - new Date(lastAt).getTime()
@@ -81,7 +81,7 @@ export const agentPulses: ReadonlySignal<AgentPulse[]> = computed(() => {
       } else {
         state = 'working'
       }
-    } else if (isOfflineStatus(agent.status)) {
+    } else if (isAgentOffline(agent)) {
       state = 'stale'
     }
 
@@ -113,12 +113,7 @@ export const focusAgents: ReadonlySignal<FocusAgent[]> = computed(() => {
   const motionMap = agentMotionMap.value
 
   return agents.value
-    .filter(a =>
-      a.status === 'active'
-      || a.status === 'busy'
-      || a.status === 'listening'
-      || a.status === 'idle',
-    )
+    .filter(a => isAgentPresent(a))
     .map(agent => {
       const key = agent.name.trim().toLowerCase()
       const motion = motionMap.get(key)


### PR DESCRIPTION
## Summary

RFC-0139 §6 Phase 1 PR-1b — migrate `live-store.ts` (3 callsites) off raw `agent.status === '<literal>'` comparisons onto PR-1a's typed predicates.

- L76 `'active' || 'busy'` → `isAgentActive(agent)`
- L84 `isOfflineStatus(agent.status)` → `isAgentOffline(agent)` (agent-domain scoped, no `'unbooted' / 'stopped'` cross-leak)
- L117-120 4-OR presence chain → `isAgentPresent(a)`

## Why

RFC-0135 sister SSOT pattern: callsite churn after the typed-sum module lands. Same review structure as PR-14a/b/c/d for keeper.

## Scope correction (RFC body §1 inaccuracy)

`keeper-presence-store.ts:113` was listed in RFC §1 but is actually `KeeperPresenceEntry.status` (own 3-token typed sum). Different vocab — excluded. PR-1c covers the IDE presence sites that are *actually* agent-status.

## Verification

- `pnpm typecheck` clean
- `pnpm test` (agent-status + live-store) → 45/45 pass
- `pnpm lint` clean (preexisting virtual-list.ts warning unrelated)

## Stack

- Base: `feature/RFC-0139-pr1a-agent-status` (PR #16707)
- Auto-rebases to `main` once PR-1a merges (GitHub UI shows base-update prompt)

## Test plan

- [x] typecheck
- [x] vitest live-store + agent-status
- [x] lint
- [ ] (deferred to PR-1d) `isOfflineStatus` keeper consumer migration + removal

RFC-WAIVED: typed-sum predicate migration in dashboard, no credential / keeper / operator / sandbox surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)