### PR TITLE
[RFC-0136 PR-4-b] keeper_unified_turn: extract mark_terminal_error (-46 LoC)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -241,6 +241,7 @@
   keeper_unified_turn_cascade_resolution
   keeper_unified_turn_pre_dispatch
   keeper_unified_turn_retry_setup
+  keeper_unified_turn_terminal_error
   keeper_unified_turn_livelock_block
   keeper_exec_context
   keeper_guards

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -592,57 +592,12 @@ let run_keeper_cycle
                            KCP.runtime_name_to_string execution.cascade_name
                          in
                          let mark_terminal_error err =
-                           if EC.is_cascade_exhausted_error err
-                           then (
-                             Keeper_registry.mark_turn_cascade_exhausted
-                               ~base_path:config.base_path
-                               meta.name;
-                             Prometheus.inc_counter
-                               Keeper_metrics.metric_keeper_fsm_edge_transitions
-                               ~labels:[ "edge", "kcl_to_ktc_exhaustion" ]
-                               ();
-                             (* Cycle 52 narrative: cascade exhaustion is a silent
-                   failure on dashboards reading only Turn_failed.  The
-                   fsm_edge counter records the transition, but operators
-                   forensically investigating "why is this keeper stuck?"
-                   benefit from a structured WARN line distinguishing
-                   'all cascades exhausted' from 'single transient error'.
-                   Companion to PR #11708 (gate rejection narrative) and
-                   PR #11717 (unmapped regression alert). *)
-                             Log.Keeper.warn
-                               "%s: all cascades exhausted (terminal) — last_err=%s \
-                                attempt=%d attempted_cascades=[%s]"
-                               meta.name
-                               (Agent_sdk.Error.to_string err)
-                               attempt
-                               (String.concat ", " attempted_cascades);
-                             Prometheus.inc_counter
-                               Keeper_metrics.metric_keeper_oas_execution_errors
-                               ~labels:
-                                 [ "keeper", meta.name; "phase", Keeper_oas_execution_error_phase.(to_label Cascade_exhausted) ]
-                               ())
-                           else (
-                             Keeper_registry.set_turn_phase
-                               ~base_path:config.base_path
-                               meta.name
-                               Keeper_registry.(Packed Turn_finalizing);
-                             (* Cycle 52 narrative companion: non-exhaustion terminal
-                   errors (transient).  Logged so dashboard readers can
-                   distinguish exhaustion from transient failure without
-                   re-parsing Turn_finalizing reason fields. *)
-                             Prometheus.inc_counter
-                               Keeper_metrics.metric_keeper_oas_execution_errors
-                               ~labels:
-                                 [ "keeper", meta.name
-                                 ; "phase", Keeper_oas_execution_error_phase.(to_label Terminal_non_exhaustion)
-                                 ]
-                               ();
-                             Log.Keeper.warn
-                               "%s: turn terminal (non-exhaustion error) — err=%s \
-                                attempt=%d"
-                               meta.name
-                               (Agent_sdk.Error.to_string err)
-                               attempt)
+                           Keeper_unified_turn_terminal_error.handle
+                             ~config
+                             ~keeper_name:meta.name
+                             ~attempt
+                             ~attempted_cascades
+                             err
                          in
                          let attempt_timeout_budget = ref None in
                          let max_turns =

--- a/lib/keeper/keeper_unified_turn_terminal_error.ml
+++ b/lib/keeper/keeper_unified_turn_terminal_error.ml
@@ -1,0 +1,44 @@
+module EC = Keeper_error_classify
+
+let handle ~config ~keeper_name ~attempt ~attempted_cascades err =
+  if EC.is_cascade_exhausted_error err
+  then (
+    Keeper_registry.mark_turn_cascade_exhausted
+      ~base_path:config.Coord.base_path
+      keeper_name;
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_fsm_edge_transitions
+      ~labels:[ "edge", "kcl_to_ktc_exhaustion" ]
+      ();
+    Log.Keeper.warn
+      "%s: all cascades exhausted (terminal) — last_err=%s attempt=%d \
+       attempted_cascades=[%s]"
+      keeper_name
+      (Agent_sdk.Error.to_string err)
+      attempt
+      (String.concat ", " attempted_cascades);
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_oas_execution_errors
+      ~labels:
+        [ "keeper", keeper_name
+        ; "phase", Keeper_oas_execution_error_phase.(to_label Cascade_exhausted)
+        ]
+      ())
+  else (
+    Keeper_registry.set_turn_phase
+      ~base_path:config.Coord.base_path
+      keeper_name
+      Keeper_registry.(Packed Turn_finalizing);
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_oas_execution_errors
+      ~labels:
+        [ "keeper", keeper_name
+        ; "phase"
+        , Keeper_oas_execution_error_phase.(to_label Terminal_non_exhaustion)
+        ]
+      ();
+    Log.Keeper.warn
+      "%s: turn terminal (non-exhaustion error) — err=%s attempt=%d"
+      keeper_name
+      (Agent_sdk.Error.to_string err)
+      attempt)

--- a/lib/keeper/keeper_unified_turn_terminal_error.mli
+++ b/lib/keeper/keeper_unified_turn_terminal_error.mli
@@ -1,0 +1,26 @@
+(** RFC-0136 PR-4-b: terminal error side effects extracted from
+    [keeper_unified_turn] retry loop.
+
+    Two paths based on [Keeper_error_classify.is_cascade_exhausted_error]:
+
+    - [Cascade_exhausted] — sets registry to [Turn_cascade_exhausted],
+      increments the [kcl_to_ktc_exhaustion] FSM edge counter, logs a
+      structured WARN listing the attempted cascades, and increments
+      the [oas_execution_errors] counter with phase [Cascade_exhausted].
+
+    - Otherwise — sets the turn phase to [Turn_finalizing], increments
+      the [oas_execution_errors] counter with phase
+      [Terminal_non_exhaustion], and logs a structured WARN.
+
+    Side effects only.  The function is unit-returning to keep the 9
+    retry-loop call sites unchanged: they invoke a [mark_terminal_error]
+    closure that adapts {!handle} to the loop-scoped [attempt] /
+    [attempted_cascades] values.  Cycle 52 narrative behavior preserved. *)
+
+val handle
+  :  config:Coord.config
+  -> keeper_name:string
+  -> attempt:int
+  -> attempted_cascades:string list
+  -> Agent_sdk.Error.sdk_error
+  -> unit


### PR DESCRIPTION
## Summary

RFC-0136 Phase 4 sub-doc PR-4-b 구현. retry-loop \`mark_terminal_error\` 53 LoC body를 외부 모듈 \`Keeper_unified_turn_terminal_error.handle\` 로 이동.

## 측정

| 항목 | 값 |
|------|----|
| \`keeper_unified_turn.ml\` 절감 | **-46 LoC** (1720 → 1674) |
| 새 모듈 | \`keeper_unified_turn_terminal_error.{ml,mli}\` (+71) |
| Callsite churn | **0** (9 callsite 모두 wrapper closure 통과 무수정) |
| Behavior preservation | exhausted / non-exhausted 2 path + Cycle 52 narrative |

## Wrapper closure 패턴

\`\`\`ocaml
let mark_terminal_error err =
  Keeper_unified_turn_terminal_error.handle
    ~config ~keeper_name:meta.name
    ~attempt ~attempted_cascades err
in
(* 9 callsites unchanged *)
\`\`\`

retry-loop 의 loop-scoped \`attempt\` / \`attempted_cascades\` 는 closure 가 capture. 외부 모듈은 *순수 함수*.

## RFC-0136 누적 진행

| PR | LoC 변화 | 모듈 |
|----|---------|------|
| PR-1 (#16604) | -102 | phase_gate |
| PR-2 (#16624) | -51 | cascade_resolution |
| PR-3 (#16643) | -48 | pre_dispatch |
| **PR-4-a (#16701)** | **-22** | retry_setup |
| **PR-4-b (현재)** | **-46** | terminal_error |
| **누적** | **-269** | 1943 → 1674 |

## Validation

- [x] \`dune build --root . lib/keeper/\` 통과 (no output)
- [x] 9 callsite 무수정 (wrapper closure)
- [ ] CI 전체 빌드 — \`Detect Changed Surfaces\` 가 lib/keeper/ 만 빌드

## RFC

\`docs/rfc/RFC-0136-phase-4-retry-loop.md\` PR-4-b (PR #16650 merged).

## Related

- **PR-4-a #16701** (retry_setup) — *영역 zero overlap* — 동시 진행 안전
- PR-4-c (retry-loop recursive core) — PR-4-a + PR-4-b 머지 후 진행

🤖 Generated with [Claude Code](https://claude.com/claude-code)