### PR TITLE
refactor(keeper_registry): extract per-keeper event-queue access (godfile decomp)

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -512,7 +512,7 @@ let heartbeat_event_intake ~ctx ~meta_after_triage ~pending_board_events =
      falling back to a single non-board queue dequeue. *)
   let window = Keeper_config.keeper_board_debounce_window_sec () in
   let board_batch =
-    Keeper_registry.drain_board_events
+    Keeper_registry_event_queue.drain_board
       ~window_sec:window
       ~base_path:ctx.config.base_path
       meta_after_triage.name
@@ -521,7 +521,7 @@ let heartbeat_event_intake ~ctx ~meta_after_triage ~pending_board_events =
     match board_batch with
     | [] ->
       (match
-         Keeper_registry.dequeue_event
+         Keeper_registry_event_queue.dequeue
            ~base_path:ctx.config.base_path
            meta_after_triage.name
        with
@@ -1398,7 +1398,7 @@ let run_smart_heartbeat_gate
   let pending_signal_present =
     lazy
       (let queue =
-         Keeper_registry.event_queue_snapshot
+         Keeper_registry_event_queue.snapshot
            ~base_path:config.base_path
            meta_current.name
        in

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -121,7 +121,7 @@ let interruptible_sleep ~clock ~stop ~wakeup duration : sleep_outcome =
     when a @mention targets a running keeper.
 
     When [?stimulus] is provided, the stimulus is appended to the keeper's
-    Event Layer queue ([Keeper_registry.enqueue_event]) before the wakeup
+    Event Layer queue ([Keeper_registry_event_queue.enqueue]) before the wakeup
     flag flips. This is RFC-0020 Rule 1 (enqueue is independent of policy)
     + the data-channel half of the layer split — [fiber_wakeup] remains the
     hint signal, the queue is the authoritative payload. *)
@@ -132,7 +132,7 @@ let wakeup_keeper ?base_path ?stimulus name =
     then begin
       Option.iter
         (fun s ->
-          Keeper_registry.enqueue_event ~base_path:entry.base_path name s)
+          Keeper_registry_event_queue.enqueue ~base_path:entry.base_path name s)
         stimulus;
       Keeper_registry.wakeup ~base_path:entry.base_path name
     end)

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -40,7 +40,7 @@ val interruptible_sleep :
 (** Wake up a specific keeper immediately.
 
     When [?stimulus] is given, the stimulus is appended to the keeper's
-    Event Layer queue ([Keeper_registry.enqueue_event]) before the wakeup
+    Event Layer queue ([Keeper_registry_event_queue.enqueue]) before the wakeup
     flag flips. Callers that have a real payload (board post, mention,
     operator directive) should pass it; callers that only need to break
     the keeper out of [interruptible_sleep] may omit it and the call

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1905,50 +1905,5 @@ let get_conditions ~base_path name =
   | None -> None
 ;;
 
-let enqueue_event ~base_path name stimulus =
-  match get ~base_path name with
-  | None ->
-    Log.Keeper.warn
-      "registry: enqueue_event name=%s base_path=%s: keeper not registered"
-      name
-      base_path
-  | Some entry ->
-    let rec loop () =
-      let cur = Atomic.get entry.event_queue in
-      let next = Keeper_event_queue.enqueue cur stimulus in
-      if not (Atomic.compare_and_set entry.event_queue cur next) then loop ()
-    in
-    loop ()
-;;
-
-let event_queue_snapshot ~base_path name =
-  match get ~base_path name with
-  | None -> Keeper_event_queue.empty
-  | Some entry -> Atomic.get entry.event_queue
-;;
-
-let dequeue_event ~base_path name =
-  match get ~base_path name with
-  | None -> None
-  | Some entry ->
-    let rec loop () =
-      let cur = Atomic.get entry.event_queue in
-      match Keeper_event_queue.dequeue cur with
-      | None -> None
-      | Some (stim, rest) ->
-        if Atomic.compare_and_set entry.event_queue cur rest then Some stim else loop ()
-    in
-    loop ()
-;;
-
-let drain_board_events ?window_sec ~base_path name =
-  match get ~base_path name with
-  | None -> []
-  | Some entry ->
-    let rec loop () =
-      let cur = Atomic.get entry.event_queue in
-      let board, rest = Keeper_event_queue.drain_board_window ?window_sec cur in
-      if Atomic.compare_and_set entry.event_queue cur rest then board else loop ()
-    in
-    loop ()
-;;
+(* Event-queue access (enqueue_event / event_queue_snapshot / dequeue_event /
+   drain_board_events) moved to Keeper_registry_event_queue. *)

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -449,41 +449,5 @@ val get_phase : base_path:string -> string -> Keeper_state_machine.phase option
 (** Get the observable conditions of a keeper. *)
 val get_conditions : base_path:string -> string -> Keeper_state_machine.conditions option
 
-(** Append a stimulus to the keeper's Event Layer queue.
-
-    Always succeeds when the keeper is registered. Lock-free CAS
-    loop on [entry.event_queue]; concurrent [enqueue_event] callers
-    do not block. Stimuli arrive in the order observed by the CAS
-    winner, which the Policy Layer respects via [Keeper_event_queue.dequeue].
-
-    Logs a warning when [name] is not in the registry — calling sites
-    should not depend on enqueue success for missing keepers. *)
-val enqueue_event :
-  base_path:string -> string -> Keeper_event_queue.stimulus -> unit
-
-(** Snapshot the keeper's Event Layer queue. Returns [Keeper_event_queue.empty]
-    when the keeper is missing. Read-only — does not consume stimuli. *)
-val event_queue_snapshot :
-  base_path:string -> string -> Keeper_event_queue.t
-
-(** Consume at most one stimulus from the keeper's Event Layer queue.
-
-    Returns [Some stim] when the queue had work (and the stimulus is
-    removed from the queue), [None] when the queue is empty or the
-    keeper is not registered. Lock-free CAS retry on
-    [entry.event_queue]; concurrent callers do not block.
-
-    The Policy Layer (turn entry) calls this once per [Emit] tick to
-    drain one stimulus per turn. See RFC-0020 §3 (Rule 4: per-turn
-    dequeue) and KeeperEventQueue.tla Conservation invariant
-    ([dequeued_total <= enqueued_total]). *)
-val dequeue_event :
-  base_path:string -> string -> Keeper_event_queue.stimulus option
-
-val drain_board_events :
-  ?window_sec:float ->
-  base_path:string -> string -> Keeper_event_queue.stimulus list
-(** Drain all board-signal stimuli within [window_sec] from the keeper's
-    event queue using a CAS loop.  Returns the coalesced board signals
-    (urgency-sorted) and updates the queue atomically.  Returns []
-    when the keeper is not found or the queue has no board signals. *)
+(* Event-queue access (enqueue_event / event_queue_snapshot / dequeue_event /
+   drain_board_events) moved to Keeper_registry_event_queue. *)

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -1,0 +1,56 @@
+(** Per-keeper event-queue access.
+
+    Extracted from keeper_registry.ml (lines 1854-1900) as part of the
+    godfile decomp campaign. Each [registry_entry] carries its own
+    [event_queue : Keeper_event_queue.t Atomic.t] — these wrappers do
+    CAS on that per-entry atomic after locating the entry via the
+    central registry's public [get]. No coupling to the central
+    Atomic state primitive. *)
+
+let enqueue ~base_path name stimulus =
+  match Keeper_registry.get ~base_path name with
+  | None ->
+    Log.Keeper.warn
+      "registry: enqueue_event name=%s base_path=%s: keeper not registered"
+      name
+      base_path
+  | Some entry ->
+    let rec loop () =
+      let cur = Atomic.get entry.event_queue in
+      let next = Keeper_event_queue.enqueue cur stimulus in
+      if not (Atomic.compare_and_set entry.event_queue cur next) then loop ()
+    in
+    loop ()
+;;
+
+let snapshot ~base_path name =
+  match Keeper_registry.get ~base_path name with
+  | None -> Keeper_event_queue.empty
+  | Some entry -> Atomic.get entry.event_queue
+;;
+
+let dequeue ~base_path name =
+  match Keeper_registry.get ~base_path name with
+  | None -> None
+  | Some entry ->
+    let rec loop () =
+      let cur = Atomic.get entry.event_queue in
+      match Keeper_event_queue.dequeue cur with
+      | None -> None
+      | Some (stim, rest) ->
+        if Atomic.compare_and_set entry.event_queue cur rest then Some stim else loop ()
+    in
+    loop ()
+;;
+
+let drain_board ?window_sec ~base_path name =
+  match Keeper_registry.get ~base_path name with
+  | None -> []
+  | Some entry ->
+    let rec loop () =
+      let cur = Atomic.get entry.event_queue in
+      let board, rest = Keeper_event_queue.drain_board_window ?window_sec cur in
+      if Atomic.compare_and_set entry.event_queue cur rest then board else loop ()
+    in
+    loop ()
+;;

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -1,0 +1,24 @@
+(** Per-keeper event-queue access.
+
+    SSOT for enqueueing / draining the per-keeper stimulus queue.
+    Internal CAS retry on the entry-owned
+    [event_queue : Keeper_event_queue.t Atomic.t] field; no central
+    registry Atomic touched. *)
+
+(** Enqueue a stimulus on the keeper's event queue.
+    Logs a warning when the keeper is not registered. *)
+val enqueue : base_path:string -> string -> Keeper_event_queue.stimulus -> unit
+
+(** Read-only snapshot of the keeper's queue. Returns
+    [Keeper_event_queue.empty] when the keeper is unregistered. *)
+val snapshot : base_path:string -> string -> Keeper_event_queue.t
+
+(** Remove and return the head stimulus, or [None] when the queue is
+    empty or the keeper is unregistered. *)
+val dequeue : base_path:string -> string -> Keeper_event_queue.stimulus option
+
+(** Drain stimuli intended for board reactivity. [window_sec] caps the
+    age of stimuli returned to the caller. *)
+val drain_board :
+  ?window_sec:float -> base_path:string -> string
+  -> Keeper_event_queue.stimulus list

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -108,7 +108,7 @@ let launch_supervised_fiber
       ; payload = "Keeper bootstrap signal"
       }
     in
-    Keeper_registry.enqueue_event ~base_path meta.name bootstrap_signal;
+    Keeper_registry_event_queue.enqueue ~base_path meta.name bootstrap_signal;
     (* RFC-0059 PR-7-pilot originally routed the whole keepalive body through
        a Domain_pool worker.  Live recovery proved that unsafe: the body is
        an Eio fiber loop that uses the server switch, clock, turn timeouts, and

--- a/lib/keeper/keeper_supervisor_alive_but_stuck.ml
+++ b/lib/keeper/keeper_supervisor_alive_but_stuck.ml
@@ -64,7 +64,7 @@ let queue_recovery ~base_path ~now ~elapsed ~threshold
   then "skipped_not_running"
   else (
     let stimulus = recovery_stimulus ~now ~elapsed ~threshold entry in
-    Keeper_registry.enqueue_event ~base_path entry.name stimulus;
+    Keeper_registry_event_queue.enqueue ~base_path entry.name stimulus;
     Keeper_registry.wakeup ~base_path entry.name;
     "queued")
 ;;

--- a/lib/keeper/keeper_unified_turn_stay_silent.ml
+++ b/lib/keeper/keeper_unified_turn_stay_silent.ml
@@ -43,7 +43,7 @@ let mark_loop_detected ~(config : Coord.config) meta ~streak ~threshold =
       ~streak
       ~threshold
   in
-  Keeper_registry.enqueue_event
+  Keeper_registry_event_queue.enqueue
     ~base_path:config.base_path
     meta.Keeper_types.name
     stimulus;

--- a/lib/keeper_event_queue/keeper_event_queue.mli
+++ b/lib/keeper_event_queue/keeper_event_queue.mli
@@ -7,10 +7,10 @@
     bookkeeping concerns that never delay an [enqueue].
 
     This module is data only. The enqueue side is wired:
-    [keeper_keepalive_signal.ml] calls [Keeper_registry.enqueue_event]
+    [keeper_keepalive_signal.ml] calls [Keeper_registry_event_queue.enqueue]
     before the wakeup flag flips (RFC-0020 Rule 1). On the dequeue side,
     [keeper_heartbeat_loop.ml] drains the board-signal batch within the
-    debounce window via [Keeper_registry.drain_board_events] (a CAS loop
+    debounce window via [Keeper_registry_event_queue.drain_board] (a CAS loop
     over [drain_board_window]) and falls back to a single non-board
     [dequeue_event] when that batch is empty — either path pins the
     [Conservation] invariant. [run_smart_heartbeat_gate] then snapshots

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -120,7 +120,7 @@ include module type of Prometheus_cascade_metric_names
 (** RFC-0020 Rule 2 evidence — incremented every time
     [run_smart_heartbeat_gate] overrides a [Skip_busy] / [Skip_idle]
     decision because the Event Layer queue
-    ([Keeper_registry.event_queue_snapshot]) was non-empty. A zero
+    ([Keeper_registry_event_queue.snapshot]) was non-empty. A zero
     rate against ongoing keeper activity means either the queue
     write path (PR-C1 [wakeup_keeper ?stimulus]) is not firing or
     the smart heartbeat is already returning [Emit] on its own —

--- a/lib/prometheus_builtin_metric_names.mli
+++ b/lib/prometheus_builtin_metric_names.mli
@@ -121,7 +121,7 @@ include module type of Prometheus_cascade_metric_names
 (** RFC-0020 Rule 2 evidence — incremented every time
     [run_smart_heartbeat_gate] overrides a [Skip_busy] / [Skip_idle]
     decision because the Event Layer queue
-    ([Keeper_registry.event_queue_snapshot]) was non-empty. A zero
+    ([Keeper_registry_event_queue.snapshot]) was non-empty. A zero
     rate against ongoing keeper activity means either the queue
     write path (PR-C1 [wakeup_keeper ?stimulus]) is not firing or
     the smart heartbeat is already returning [Emit] on its own —

--- a/lib/prometheus_builtin_metrics_part2.ml
+++ b/lib/prometheus_builtin_metrics_part2.ml
@@ -364,7 +364,7 @@ let register
     Keeper_metrics.metric_keeper_event_queue_override
     "RFC-0020 Rule 2 — total times run_smart_heartbeat_gate forced Keeper_heartbeat_smart.Emit. \
      The [reason] label disambiguates the two override paths: [event_queue] = the Event \
-     Layer queue (Keeper_registry.event_queue_snapshot) held an unprocessed stimulus; \
+     Layer queue (Keeper_registry_event_queue.snapshot) held an unprocessed stimulus; \
      [durable_state] = the queue was empty but a durable world-observation signal \
      (#13078) called for a cycle resume before the stale-watchdog deadline. Pairs with \
      masc_keeper_skip_idle_wake_resumed: skip-idle-resumed measures the fiber_wakeup \

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -1108,29 +1108,29 @@ let test_dequeue_event_consumes_fifo () =
     make_stimulus ~urgency:Keeper_event_queue.Immediate "post-2"
       "second"
   in
-  R.enqueue_event ~base_path:bp keeper_name s1;
-  R.enqueue_event ~base_path:bp keeper_name s2;
+  Masc_mcp.Keeper_registry_event_queue.enqueue ~base_path:bp keeper_name s1;
+  Masc_mcp.Keeper_registry_event_queue.enqueue ~base_path:bp keeper_name s2;
   check int "queued before dequeue" 2
     (Keeper_event_queue.length
-       (R.event_queue_snapshot ~base_path:bp keeper_name));
-  (match R.dequeue_event ~base_path:bp keeper_name with
+       (Masc_mcp.Keeper_registry_event_queue.snapshot ~base_path:bp keeper_name));
+  (match Masc_mcp.Keeper_registry_event_queue.dequeue ~base_path:bp keeper_name with
    | Some stim ->
        check string "first post id" "post-1" stim.post_id;
        check string "first payload" "first" stim.payload
    | None -> fail "expected first stimulus");
   check int "one queued after first dequeue" 1
     (Keeper_event_queue.length
-       (R.event_queue_snapshot ~base_path:bp keeper_name));
-  (match R.dequeue_event ~base_path:bp keeper_name with
+       (Masc_mcp.Keeper_registry_event_queue.snapshot ~base_path:bp keeper_name));
+  (match Masc_mcp.Keeper_registry_event_queue.dequeue ~base_path:bp keeper_name with
    | Some stim ->
        check string "second post id" "post-2" stim.post_id;
        check string "second payload" "second" stim.payload
    | None -> fail "expected second stimulus");
   check bool "empty after drain" true
     (Keeper_event_queue.is_empty
-       (R.event_queue_snapshot ~base_path:bp keeper_name));
+       (Masc_mcp.Keeper_registry_event_queue.snapshot ~base_path:bp keeper_name));
   check bool "dequeue empty returns None" true
-    (Option.is_none (R.dequeue_event ~base_path:bp keeper_name))
+    (Option.is_none (Masc_mcp.Keeper_registry_event_queue.dequeue ~base_path:bp keeper_name))
 
 let test_dequeue_event_respects_base_path_and_missing_keeper () =
   R.clear ();
@@ -1138,12 +1138,12 @@ let test_dequeue_event_respects_base_path_and_missing_keeper () =
   let other_bp = "/tmp/test-dequeue-scope-other" in
   ignore (R.register ~base_path:bp name (make_meta name));
   ignore (R.register ~base_path:other_bp name (make_meta name));
-  R.enqueue_event ~base_path:bp name (make_stimulus "scoped" "payload");
+  Masc_mcp.Keeper_registry_event_queue.enqueue ~base_path:bp name (make_stimulus "scoped" "payload");
   check bool "missing keeper returns None" true
-    (Option.is_none (R.dequeue_event ~base_path:bp "missing-dequeue"));
+    (Option.is_none (Masc_mcp.Keeper_registry_event_queue.dequeue ~base_path:bp "missing-dequeue"));
   check bool "other base path stays empty" true
-    (Option.is_none (R.dequeue_event ~base_path:other_bp name));
-  match R.dequeue_event ~base_path:bp name with
+    (Option.is_none (Masc_mcp.Keeper_registry_event_queue.dequeue ~base_path:other_bp name));
+  match Masc_mcp.Keeper_registry_event_queue.dequeue ~base_path:bp name with
   | Some stim -> check string "scoped payload" "payload" stim.payload
   | None -> fail "expected scoped stimulus"
 
@@ -1157,27 +1157,27 @@ let test_wakeup_hint_separate_from_event_payload () =
   let later_payload = make_stimulus "later-post" "later-payload" in
   check bool "initial wakeup false" false (Atomic.get entry.fiber_wakeup);
   check int "initial queue empty" 0
-    (R.event_queue_snapshot ~base_path:bp name |> Keeper_event_queue.length);
+    (Masc_mcp.Keeper_registry_event_queue.snapshot ~base_path:bp name |> Keeper_event_queue.length);
   R.wakeup ~base_path:bp name;
   check bool "wakeup sets hint flag" true (Atomic.get entry.fiber_wakeup);
   check int "wakeup does not synthesize payload" 0
-    (R.event_queue_snapshot ~base_path:bp name |> Keeper_event_queue.length);
+    (Masc_mcp.Keeper_registry_event_queue.snapshot ~base_path:bp name |> Keeper_event_queue.length);
   check bool "wakeup-only dequeue has no payload" true
-    (Option.is_none (R.dequeue_event ~base_path:bp name));
-  R.enqueue_event ~base_path:bp name queued_payload;
+    (Option.is_none (Masc_mcp.Keeper_registry_event_queue.dequeue ~base_path:bp name));
+  Masc_mcp.Keeper_registry_event_queue.enqueue ~base_path:bp name queued_payload;
   check bool "enqueue does not clear wakeup hint" true (Atomic.get entry.fiber_wakeup);
   Atomic.set entry.fiber_wakeup false;
   check int "queued payload survives wakeup reset" 1
-    (R.event_queue_snapshot ~base_path:bp name |> Keeper_event_queue.length);
-  (match R.dequeue_event ~base_path:bp name with
+    (Masc_mcp.Keeper_registry_event_queue.snapshot ~base_path:bp name |> Keeper_event_queue.length);
+  (match Masc_mcp.Keeper_registry_event_queue.dequeue ~base_path:bp name with
    | Some stim ->
        check string "queued post preserved" "queued-post" stim.post_id;
        check string "queued payload preserved" "queued-payload" stim.payload
    | None -> fail "expected queued payload");
   check bool "dequeue does not set wakeup hint" false (Atomic.get entry.fiber_wakeup);
-  R.enqueue_event ~base_path:bp name later_payload;
+  Masc_mcp.Keeper_registry_event_queue.enqueue ~base_path:bp name later_payload;
   check bool "enqueue alone does not wake keeper" false (Atomic.get entry.fiber_wakeup);
-  (match R.dequeue_event ~base_path:bp name with
+  (match Masc_mcp.Keeper_registry_event_queue.dequeue ~base_path:bp name with
    | Some stim -> check string "later payload preserved" "later-payload" stim.payload
    | None -> fail "expected later payload")
 
@@ -1901,12 +1901,12 @@ let test_board_signal_wakeup_only_wakes_opted_in_scope_keeper () =
         KK.wakeup_relevant_keeper_for_board_signal ~config signal;
         check bool "opted-in keeper woken" true (Atomic.get entry_a.fiber_wakeup);
         check int "opted-in keeper queued board stimulus" 1
-          (R.event_queue_snapshot ~base_path:base_dir "opted-in"
+          (Masc_mcp.Keeper_registry_event_queue.snapshot ~base_path:base_dir "opted-in"
            |> Keeper_event_queue.length);
         check bool "defaulted keeper stays asleep" false
           (Atomic.get entry_b.fiber_wakeup);
         check int "defaulted keeper has no stimulus" 0
-          (R.event_queue_snapshot ~base_path:base_dir "defaulted"
+          (Masc_mcp.Keeper_registry_event_queue.snapshot ~base_path:base_dir "defaulted"
            |> Keeper_event_queue.length)))
 
 let test_board_signal_wakeup_keeps_thread_reply_after_self_comment () =
@@ -1970,12 +1970,12 @@ let test_board_signal_wakeup_keeps_thread_reply_after_self_comment () =
         check bool "participant keeper woken" true
           (Atomic.get entry_a.fiber_wakeup);
         check int "participant keeper queued board stimulus" 1
-          (R.event_queue_snapshot ~base_path:base_dir "participant"
+          (Masc_mcp.Keeper_registry_event_queue.snapshot ~base_path:base_dir "participant"
            |> Keeper_event_queue.length);
         check bool "bystander keeper stays asleep" false
           (Atomic.get entry_b.fiber_wakeup);
         check int "bystander keeper has no stimulus" 0
-          (R.event_queue_snapshot ~base_path:base_dir "bystander"
+          (Masc_mcp.Keeper_registry_event_queue.snapshot ~base_path:base_dir "bystander"
            |> Keeper_event_queue.length)))
 
 let test_effective_keepalive_meta_prefers_registry_when_disk_unchanged () =

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -2123,7 +2123,7 @@ let () =
                 check bool "alive-but-stuck threshold exported" true
                   (threshold_seconds > 0.0);
                 let queue =
-                  Reg.event_queue_snapshot ~base_path:config.base_path name
+                  Masc_mcp.Keeper_registry_event_queue.snapshot ~base_path:config.base_path name
                 in
                 check int "one recovery stimulus queued" 1
                   (Keeper_event_queue.length queue);
@@ -2202,7 +2202,7 @@ let () =
                 Sup.alive_but_stuck_scan ctx;
                 Sup.alive_but_stuck_scan ctx;
                 let queue =
-                  Reg.event_queue_snapshot ~base_path:config.base_path name
+                  Masc_mcp.Keeper_registry_event_queue.snapshot ~base_path:config.base_path name
                 in
                 check int
                   "dedup window holds queue length to 1 across 3 sweeps"
@@ -2212,7 +2212,7 @@ let () =
                 Sup.alive_but_stuck_reset_for_test ();
                 Sup.alive_but_stuck_scan ctx;
                 let queue2 =
-                  Reg.event_queue_snapshot ~base_path:config.base_path name
+                  Masc_mcp.Keeper_registry_event_queue.snapshot ~base_path:config.base_path name
                 in
                 check int
                   "after dedup reset, the next scan re-queues (now 2 total)"


### PR DESCRIPTION
## Summary

Stacked atop #16702. Fourth keeper_registry godfile decomp PR after #16657 (lookup), #16677 (tool_usage_persistence), #16705 (cascade_attempt).

### 변경 요약

4 event-queue accessor functions (lines 1944-1990) → 새 sibling module \`keeper_registry_event_queue.ml\`:

| 원본 | 새 위치 |
|------|---------|
| \`enqueue_event\` | \`Keeper_registry_event_queue.enqueue\` |
| \`event_queue_snapshot\` | \`Keeper_registry_event_queue.snapshot\` |
| \`dequeue_event\` | \`Keeper_registry_event_queue.dequeue\` |
| \`drain_board_events\` | \`Keeper_registry_event_queue.drain_board\` |

Wrappers는 public \`Keeper_registry.get\`으로 entry를 찾은 뒤, entry-owned \`event_queue : Keeper_event_queue.t Atomic.t\`에 CAS retry. **central registry Atomic을 건드리지 않으므로 cycle-free**.

### LoC 효과

| | Before | After | Δ |
|--|--------|-------|---|
| \`lib/keeper/keeper_registry.ml\` | 2034 | 1945 | −89 |
| \`lib/keeper/keeper_registry.mli\` | 487 | 456 | −31 |
| 신규 \`keeper_registry_event_queue.ml\` | — | 55 | +55 |
| 신규 \`keeper_registry_event_queue.mli\` | — | 24 | +24 |

**Combined stack (#16657 + #16677 + #16705 + this PR): 2129 → 1945 LoC (−184, 8.6% 감소)**.

### 12 caller 파일 갱신
- \`lib/keeper/keeper_heartbeat_loop.ml\` (3)
- \`lib/keeper/keeper_keepalive_signal.ml\` (2)
- \`lib/keeper/keeper_keepalive_signal.mli\` (1)
- \`lib/keeper/keeper_supervisor.ml\` (1)
- \`lib/keeper/keeper_supervisor_alive_but_stuck.ml\` (1)
- \`lib/keeper/keeper_unified_turn_stay_silent.ml\` (1)
- \`lib/keeper_event_queue/keeper_event_queue.mli\` (2)
- \`lib/prometheus*\` (3)
- \`test/test_keeper_registry.ml\` + \`test/test_keeper_supervisor.ml\` aliases rewired

### 검증
- \`dune build --root . @check\` exit 0
- \`test/test_keeper_registry.exe\` 109 tests PASS

### Scope guard
- credential / identity / operator-control / sandbox / dashboard credential / hooks / workflow 영역 무관
- \`RFC-WAIVED: cluster extraction, godfile decomp follow-up to RFC-0136 stack\`

## Test plan
- [x] dune @check green
- [x] keeper_registry alcotest (109) PASS
- [ ] base PR #16702 머지 후 base → main 또는 stack squash 머지
- [ ] 사용자 라벨 dispatch

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>