### PR TITLE
[RFC-0139 PR-1c] ide-presence-strip uses parseAgentStatus

### DIFF
--- a/dashboard/src/components/ide/ide-presence-strip.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.ts
@@ -12,6 +12,7 @@ import {
 import { cursorOverlaySignal, type KeeperCursor } from './keeper-cursor-overlay'
 import { focusIdeContextAnchor, type IdeContextFocus } from './ide-state'
 import { routeLinksForContext } from './ide-context-lens'
+import { parseAgentStatus } from '../../lib/agent-status'
 
 export interface ApiAgent {
   readonly name: string
@@ -54,9 +55,8 @@ const CONTEXT_BADGE_STYLE = {
 }
 
 function mapAgentStatus(status: string): KeeperPresenceEntry['status'] {
-  if (status === 'active' || status === 'busy') return 'active'
-  if (status === 'listening') return 'idle'
-  return 'idle'
+  const parsed = parseAgentStatus(status)
+  return parsed === 'active' || parsed === 'busy' ? 'active' : 'idle'
 }
 
 /**

--- a/dashboard/src/lib/agent-status.test.ts
+++ b/dashboard/src/lib/agent-status.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AGENT_STATUS_VALUES,
+  isAgentActive,
+  isAgentOffline,
+  isAgentPresent,
+  parseAgentStatus,
+  type AgentStatus,
+} from './agent-status'
+
+describe('AGENT_STATUS_VALUES', () => {
+  it('matches the Agent.status literal union (6 tokens)', () => {
+    expect(AGENT_STATUS_VALUES).toEqual([
+      'active',
+      'busy',
+      'listening',
+      'idle',
+      'inactive',
+      'offline',
+    ])
+  })
+})
+
+describe('parseAgentStatus', () => {
+  it('accepts each known token', () => {
+    for (const token of AGENT_STATUS_VALUES) {
+      expect(parseAgentStatus(token)).toBe(token)
+    }
+  })
+
+  it('is case-insensitive', () => {
+    expect(parseAgentStatus('ACTIVE')).toBe('active')
+    expect(parseAgentStatus('Busy')).toBe('busy')
+    expect(parseAgentStatus('OFFLINE')).toBe('offline')
+  })
+
+  it('returns null for unknown tokens', () => {
+    expect(parseAgentStatus('retired')).toBeNull()
+    expect(parseAgentStatus('unbooted')).toBeNull()
+    expect(parseAgentStatus('stopped')).toBeNull()
+    expect(parseAgentStatus('running')).toBeNull()
+  })
+
+  it('returns null for null / undefined / empty', () => {
+    expect(parseAgentStatus(null)).toBeNull()
+    expect(parseAgentStatus(undefined)).toBeNull()
+    expect(parseAgentStatus('')).toBeNull()
+  })
+})
+
+describe('isAgentOffline', () => {
+  it('returns true for offline / inactive only', () => {
+    expect(isAgentOffline({ status: 'offline' })).toBe(true)
+    expect(isAgentOffline({ status: 'inactive' })).toBe(true)
+  })
+
+  it('returns false for presence states', () => {
+    expect(isAgentOffline({ status: 'active' })).toBe(false)
+    expect(isAgentOffline({ status: 'busy' })).toBe(false)
+    expect(isAgentOffline({ status: 'listening' })).toBe(false)
+    expect(isAgentOffline({ status: 'idle' })).toBe(false)
+  })
+
+  it('rejects keeper-domain tokens (unbooted / stopped)', () => {
+    expect(isAgentOffline({ status: 'unbooted' as unknown as AgentStatus })).toBe(false)
+    expect(isAgentOffline({ status: 'stopped' as unknown as AgentStatus })).toBe(false)
+  })
+
+  it('returns false for missing status', () => {
+    expect(isAgentOffline({ status: undefined })).toBe(false)
+  })
+})
+
+describe('isAgentActive', () => {
+  it('returns true for active / busy', () => {
+    expect(isAgentActive({ status: 'active' })).toBe(true)
+    expect(isAgentActive({ status: 'busy' })).toBe(true)
+  })
+
+  it('returns false for listening / idle (present but not active)', () => {
+    expect(isAgentActive({ status: 'listening' })).toBe(false)
+    expect(isAgentActive({ status: 'idle' })).toBe(false)
+  })
+
+  it('returns false for offline / inactive', () => {
+    expect(isAgentActive({ status: 'offline' })).toBe(false)
+    expect(isAgentActive({ status: 'inactive' })).toBe(false)
+  })
+
+  it('returns false for missing / unknown', () => {
+    expect(isAgentActive({ status: undefined })).toBe(false)
+    expect(isAgentActive({ status: 'retired' as unknown as AgentStatus })).toBe(false)
+  })
+})
+
+describe('isAgentPresent', () => {
+  it('returns true for the 4 presence states', () => {
+    expect(isAgentPresent({ status: 'active' })).toBe(true)
+    expect(isAgentPresent({ status: 'busy' })).toBe(true)
+    expect(isAgentPresent({ status: 'listening' })).toBe(true)
+    expect(isAgentPresent({ status: 'idle' })).toBe(true)
+  })
+
+  it('returns false for offline / inactive', () => {
+    expect(isAgentPresent({ status: 'offline' })).toBe(false)
+    expect(isAgentPresent({ status: 'inactive' })).toBe(false)
+  })
+
+  it('returns false for unknown tokens', () => {
+    expect(isAgentPresent({ status: 'retired' as unknown as AgentStatus })).toBe(false)
+    expect(isAgentPresent({ status: undefined })).toBe(false)
+  })
+})
+
+describe('boundary cases (cross-domain isolation)', () => {
+  it('keeper-only tokens are not classified as agent presence', () => {
+    expect(parseAgentStatus('unbooted')).toBeNull()
+    expect(parseAgentStatus('stopped')).toBeNull()
+    expect(isAgentPresent({ status: 'unbooted' as unknown as AgentStatus })).toBe(false)
+    expect(isAgentOffline({ status: 'unbooted' as unknown as AgentStatus })).toBe(false)
+  })
+})

--- a/dashboard/src/lib/agent-status.ts
+++ b/dashboard/src/lib/agent-status.ts
@@ -1,0 +1,68 @@
+// RFC-0139 Phase 1 PR-1a — Agent status vocabulary SSOT.
+//
+// Typed closed sum + total parser + domain-specific predicates for
+// dashboard agent presence. Keeps the keeper-status SSOT (lib/keeper-
+// predicates.ts, RFC-0135) and the agent-status SSOT as parallel typed
+// vocabularies; conversion between them happens at component boundaries
+// only.
+//
+// No callsite migration in this PR — module + tests only. Migration to
+// the predicates lands in RFC-0139 PR-1b/PR-1c.
+
+import type { Agent } from '../types/core'
+
+/** Closed sum of agent presence states. Mirrors the literal union on
+ *  `Agent.status` in `dashboard/src/types/core.ts`. */
+export type AgentStatus =
+  | 'active'
+  | 'busy'
+  | 'listening'
+  | 'idle'
+  | 'inactive'
+  | 'offline'
+
+export const AGENT_STATUS_VALUES = [
+  'active',
+  'busy',
+  'listening',
+  'idle',
+  'inactive',
+  'offline',
+] as const satisfies ReadonlyArray<AgentStatus>
+
+const AGENT_STATUS_SET: ReadonlySet<string> = new Set(AGENT_STATUS_VALUES)
+
+/** Total parser: raw string → typed AgentStatus, or null when the input
+ *  is unknown / missing. Use at boundaries (wire decode, JSON parse). */
+export function parseAgentStatus(raw: string | undefined | null): AgentStatus | null {
+  if (raw == null) return null
+  const lower = raw.toLowerCase()
+  return AGENT_STATUS_SET.has(lower) ? (lower as AgentStatus) : null
+}
+
+/** True when the agent is not present (the backend has dropped the
+ *  connection or the registry marked the slot dormant). Mirrors the
+ *  cross-domain `isOfflineStatus` predicate scoped to *agent* tokens
+ *  only — keeper-specific tokens like 'unbooted' / 'stopped' are
+ *  rejected. */
+export function isAgentOffline(agent: Pick<Agent, 'status'>): boolean {
+  const parsed = parseAgentStatus(agent.status ?? null)
+  return parsed === 'offline' || parsed === 'inactive'
+}
+
+/** True when the agent is actively driving work (taking turns, or
+ *  consuming a tool). Distinct from "present" — listening / idle
+ *  agents are present but not active. */
+export function isAgentActive(agent: Pick<Agent, 'status'>): boolean {
+  const parsed = parseAgentStatus(agent.status ?? null)
+  return parsed === 'active' || parsed === 'busy'
+}
+
+/** True when the agent is reachable in any presence state (active,
+ *  working, or just listening / idle). The negation of `isAgentOffline`
+ *  for known tokens; unknown tokens return false. */
+export function isAgentPresent(agent: Pick<Agent, 'status'>): boolean {
+  const parsed = parseAgentStatus(agent.status ?? null)
+  if (parsed == null) return false
+  return parsed !== 'offline' && parsed !== 'inactive'
+}


### PR DESCRIPTION
## Summary

RFC-0139 §6 Phase 1 PR-1c — migrate `mapAgentStatus` in `ide-presence-strip.ts` (1 callsite) onto `parseAgentStatus` from PR-1a.

3 raw `status === '<literal>'` comparisons → 1 `parseAgentStatus` + typed comparison.

## Why

Wire-boundary pattern: when input is raw `string` (API ingest), prefer `parseAgentStatus(raw)` over `isAgent*` predicates (the predicates take `Pick<Agent, 'status'>`).

## Scope correction (RFC §1)

- `activity-graph-view.ts` `n.status === 'offline' || 'retired'` is a multi-domain node-status check. `'retired'` not in `AgentStatus`. Excluded — separate `NodeStatus` RFC if needed.
- `keeper-presence-store.ts:113 entry.status === 'active'` is the 3-token `KeeperPresenceEntry.status` typed sum (already typed). No migration needed.

## Deferred to PR-1d

`monitoring-runtime.ts:agentBand` accepts wire-format slang `'dead' | 'left'` outside the declared `AgentStatus` union. PR-1d will widen the union or add a documented wire-extras branch, then migrate.

## Verification

- `pnpm typecheck` clean
- `pnpm test` ide-presence-strip → 21/21 pass
- `pnpm lint` clean

## Stack

- Base: `feature/RFC-0139-pr1a-agent-status` (PR #16707)
- Independent of PR-1b (#16708) — both target same base.

## Test plan

- [x] typecheck
- [x] vitest ide-presence-strip
- [x] lint
- [ ] (deferred PR-1d) `agentBand` migration + Agent.status wire-extras decision
- [ ] (deferred PR-1d) lint gate banning new `agent.status === '<literal>'`

RFC-WAIVED: typed-sum predicate migration in dashboard, no credential / keeper / operator / sandbox surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)