### PR TITLE
feat(cascade_http_probe): log HTTP transport failures instead of silent None

### DIFF
--- a/lib/cascade/cascade_http_probe.ml
+++ b/lib/cascade/cascade_http_probe.ml
@@ -158,7 +158,24 @@ let try_probe ~sw ~net:_ ?clock ?timeout_s ?now url =
       ~headers:[ "accept", "application/json" ]
       ()
   with
-  | Error _ -> None
+  | Error message ->
+    (* Distinguish HTTP-side failure modes (timeout / connection refused /
+       DNS / TLS) at the probe boundary. Previously [Error _ -> None]
+       collapsed every transport failure into "endpoint down", and the
+       0.5s [probe_timeout_default_s] hit was indistinguishable from an
+       actual unreachable host. Operators tuning the timeout ceiling or
+       restarting the box need this signal.
+
+       Log-only for now — the existing
+       [metric_cascade_http_probe_json_parse_failures] counter is
+       semantically scoped to body-parse failures, so mixing transport
+       errors there would dirty its label cardinality. A dedicated
+       [cascade_http_probe_transport_failures] metric is a follow-up
+       once the structural fix lands. *)
+    Log.Cascade.warn
+      "[cascade-http-probe] probe transport failure at %s: %s"
+      endpoint message;
+    None
   | Ok (status, body) when status = 200 ->
     (* Iter 29 (V07 follow-up): make malformed JSON probe responses
        visible. Previously the [exception _ -> None] catch-all returned


### PR DESCRIPTION
## Summary

\`try_probe\` at \`lib/cascade/cascade_http_probe.ml:160-161\` returned \`None\` on every \`Masc_http_client.get_sync\` \`Error\` without log or counter, collapsing four distinct failure modes into a single "endpoint down" signal. This PR adds a \`Log.Cascade.warn\` so operators can tell them apart.

## Why

The probe's body-parse arm (Iter 29 V07 follow-up) already separates "endpoint up but malformed JSON" from "endpoint down" via warn + Prometheus counter. The **transport-side** equivalent was missing — when \`get_sync\` returned \`Error _\` (timeout / connection refused / DNS failure / TLS handshake), the arm swallowed the message and returned \`None\`.

Operators tuning \`probe_timeout_default_s\` (0.5s) need to tell:
- "raise the ceiling" (timeout hit on a slow-loading model) vs
- "restart the box" (connection refused / unreachable host) vs
- "fix DNS / TLS"

apart. Without this signal, all four collapse to one symptom in the dashboard.

## Change

\`\`\`ocaml
  with
- | Error _ -> None
+ | Error message ->
+   (* ... explanatory comment ... *)
+   Log.Cascade.warn
+     "[cascade-http-probe] probe transport failure at %s: %s"
+     endpoint message;
+   None
  | Ok (status, body) when status = 200 -> ...
\`\`\`

- \`Masc_http_client.get_sync\` returns \`((int * string), string) result\` where the \`Error\` string carries the underlying reason. We log it verbatim.
- Behavior preserved — still returns \`None\` so the cascade caller sees the same "no capacity update" outcome.

## Why log-only (no Prometheus counter)

The existing \`metric_cascade_http_probe_json_parse_failures\` counter is semantically scoped to *body-parse* failures. Mixing transport errors there would dirty its label cardinality and break dashboards that filter on \`error_kind="yojson_parse_error"\`. A dedicated \`cascade_http_probe_transport_failures\` metric is a follow-up; the structural fix (no more silent swallow) lands first.

## Investigation note (Task #30)

While investigating the "probe 0.5s vs OAS provider 300s — 600× timeout gap" finding, I confirmed the gap is **intentional asymmetry** between health probe (cheap GET /api/ps) and inference workload (potentially long model invocation). The comment at line 132-137 already documents this and provides a \`?timeout_s\` override. **Not a bug.** The actionable finding from that audit was the silent-swallow at line 160-161 — fixed here. **Task #30 closeable** as "decide-first investigation → no probe-side timeout change; this observability PR is the resolution".

## Scope

- 1 file, 1 hunk, +18/-1 LoC.
- Build verified locally by temporarily cherry-picking PR #16703 hotfix; the change is mechanical (warn before None) and exercises only \`Log.Cascade\` and the already-bound \`message\` string.

## Iter#54 context

Main is currently broken — see PR #16703 (my self-regression hotfix from #16690 merge). Once #16703 lands, this PR's CI runs cleanly on green main. Until then, CI will inherit the broken baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>