### PR TITLE
refactor(keeper_registry): extract SSE broadcast helpers (godfile decomp)

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -607,49 +607,10 @@ let set_last_correlation_id ~base_path name cid =
   update_entry ~base_path name (fun e -> { e with last_event_bus_correlation = Some cid })
 ;;
 
-let broadcast_composite_changed ~name ~ts_unix =
-  try
-    let json =
-      `Assoc
-        [ "type", `String "keeper_composite_changed"
-        ; "name", `String name
-        ; "ts_unix", `Float ts_unix
-        ]
-    in
-    Sse.broadcast json;
-    Sse.broadcast_presence json
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn ->
-    (* P2 silent-failure fix: previously this discarded the exception
-         silently, hiding the case where the SSE broadcast pipe is dead
-         (subscriber cleanup race, transport tear-down).  Operators
-         investigating "dashboard stopped updating" had no signal that
-         the broadcast itself was failing.  PR-C (#11075) added a
-         counter on the SSE side, but only for per-client failures
-         inside broadcast_impl — exceptions thrown out of
-         Sse.broadcast itself bypass that counter.  Logging here
-         makes the exception visible at the call site. *)
-    Prometheus.inc_counter
-      Keeper_metrics.metric_keeper_lifecycle_dispatch_rejections
-      ~labels:[ "keeper", name; "event", "broadcast_composite_failed" ]
-      ();
-    Log.Keeper.warn
-      "registry: broadcast_composite_changed name=%s failed: %s"
-      name
-      (Printexc.to_string exn)
-;;
-
-let record_phase_broadcast_failure ~name exn =
-  Prometheus.inc_counter
-    Keeper_metrics.metric_keeper_sse_broadcast_failures
-    ~labels:[ "keeper", name; "site", "phase_changed" ]
-    ();
-  Log.Keeper.warn
-    "registry: keeper_phase_changed broadcast failed name=%s err=%s"
-    name
-    (Printexc.to_string exn)
-;;
+(* SSE broadcast helpers (broadcast_composite_changed /
+   record_phase_broadcast_failure) moved to Keeper_registry_broadcast. *)
+let broadcast_composite_changed = Keeper_registry_broadcast.composite_changed
+let record_phase_broadcast_failure = Keeper_registry_broadcast.record_phase_failure
 
 let update_current_turn e f =
   let current_turn_observation =

--- a/lib/keeper/keeper_registry_broadcast.ml
+++ b/lib/keeper/keeper_registry_broadcast.ml
@@ -1,0 +1,50 @@
+(** SSE broadcast helpers for keeper lifecycle events.
+
+    Extracted from keeper_registry.ml (lines 610-652) as part of the
+    godfile decomp campaign. Two pure side-effect wrappers around
+    [Sse.broadcast] / [Sse.broadcast_presence] with Prometheus counter
+    + log on failure. No registry state touched. *)
+
+let composite_changed ~name ~ts_unix =
+  try
+    let json =
+      `Assoc
+        [ "type", `String "keeper_composite_changed"
+        ; "name", `String name
+        ; "ts_unix", `Float ts_unix
+        ]
+    in
+    Sse.broadcast json;
+    Sse.broadcast_presence json
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    (* P2 silent-failure fix: previously this discarded the exception
+         silently, hiding the case where the SSE broadcast pipe is dead
+         (subscriber cleanup race, transport tear-down).  Operators
+         investigating "dashboard stopped updating" had no signal that
+         the broadcast itself was failing.  PR-C (#11075) added a
+         counter on the SSE side, but only for per-client failures
+         inside broadcast_impl — exceptions thrown out of
+         Sse.broadcast itself bypass that counter.  Logging here
+         makes the exception visible at the call site. *)
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_lifecycle_dispatch_rejections
+      ~labels:[ "keeper", name; "event", "broadcast_composite_failed" ]
+      ();
+    Log.Keeper.warn
+      "registry: broadcast_composite_changed name=%s failed: %s"
+      name
+      (Printexc.to_string exn)
+;;
+
+let record_phase_failure ~name exn =
+  Prometheus.inc_counter
+    Keeper_metrics.metric_keeper_sse_broadcast_failures
+    ~labels:[ "keeper", name; "site", "phase_changed" ]
+    ();
+  Log.Keeper.warn
+    "registry: keeper_phase_changed broadcast failed name=%s err=%s"
+    name
+    (Printexc.to_string exn)
+;;

--- a/lib/keeper/keeper_registry_broadcast.mli
+++ b/lib/keeper/keeper_registry_broadcast.mli
@@ -1,0 +1,18 @@
+(** SSE broadcast helpers for keeper lifecycle events.
+
+    Pure side-effect wrappers — no registry state read or written. *)
+
+(** Broadcast a [keeper_composite_changed] SSE event on both the main
+    broadcast channel and the presence stream.
+
+    Exceptions from [Sse.broadcast] are caught, counted on the
+    [keeper_lifecycle_dispatch_rejections] Prometheus counter (with
+    the [broadcast_composite_failed] event label), and logged at WARN.
+    [Eio.Cancel.Cancelled] propagates so cancellation semantics are
+    preserved. *)
+val composite_changed : name:string -> ts_unix:float -> unit
+
+(** Account for a [keeper_phase_changed] SSE broadcast failure: bump the
+    [keeper_sse_broadcast_failures] Prometheus counter (site label
+    [phase_changed]) and log the exception at WARN. *)
+val record_phase_failure : name:string -> exn -> unit


### PR DESCRIPTION
## Summary

Stacked atop #16702. Fifth keeper_registry godfile decomp PR.

### 변경 요약

2 SSE broadcast helpers (lines 610-652) → 새 sibling module \`keeper_registry_broadcast.ml\`:

| 원본 | 새 위치 | Alias |
|------|---------|-------|
| \`broadcast_composite_changed\` | \`Keeper_registry_broadcast.composite_changed\` | \`let broadcast_composite_changed = ...\` |
| \`record_phase_broadcast_failure\` | \`Keeper_registry_broadcast.record_phase_failure\` | \`let record_phase_broadcast_failure = ...\` |

15 internal callsite는 alias 덕분에 변경 불필요 — 추후 PR에서 직접 호출로 마이그레이션 가능.

### 동작 보존
- 동일 SSE broadcast 시퀀스 (\`Sse.broadcast\` + \`Sse.broadcast_presence\`)
- 동일 Prometheus 카운터 (\`metric_keeper_lifecycle_dispatch_rejections\`, \`metric_keeper_sse_broadcast_failures\`)
- 동일 \`Eio.Cancel.Cancelled\` rethrow
- 동일 WARN 로그 메시지

### LoC 효과

| | Before | After | Δ |
|--|--------|-------|---|
| \`lib/keeper/keeper_registry.ml\` | 1985 | 1951 | −34 |
| 신규 \`keeper_registry_broadcast.ml\` | — | 50 | +50 |
| 신규 \`keeper_registry_broadcast.mli\` | — | 18 | +18 |

### 검증
- \`dune build --root . @check\` exit 0
- \`test/test_keeper_registry.exe\` 109 tests PASS

### Scope guard
- credential / identity / operator-control / sandbox / dashboard credential / hooks / workflow 영역 무관
- \`RFC-WAIVED: side-effect helper extraction, godfile decomp follow-up to RFC-0136 stack\`

## Test plan
- [x] dune @check green
- [x] keeper_registry alcotest (109) PASS
- [ ] base PR #16702 머지 후 base → main
- [ ] 사용자 라벨 dispatch

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>