### PR TITLE
[RFC-0139 PR-1d] agentBand routes via parseAgentStatus

### DIFF
--- a/dashboard/src/lib/agent-status.test.ts
+++ b/dashboard/src/lib/agent-status.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AGENT_STATUS_VALUES,
+  isAgentActive,
+  isAgentOffline,
+  isAgentPresent,
+  parseAgentStatus,
+  type AgentStatus,
+} from './agent-status'
+
+describe('AGENT_STATUS_VALUES', () => {
+  it('matches the Agent.status literal union (6 tokens)', () => {
+    expect(AGENT_STATUS_VALUES).toEqual([
+      'active',
+      'busy',
+      'listening',
+      'idle',
+      'inactive',
+      'offline',
+    ])
+  })
+})
+
+describe('parseAgentStatus', () => {
+  it('accepts each known token', () => {
+    for (const token of AGENT_STATUS_VALUES) {
+      expect(parseAgentStatus(token)).toBe(token)
+    }
+  })
+
+  it('is case-insensitive', () => {
+    expect(parseAgentStatus('ACTIVE')).toBe('active')
+    expect(parseAgentStatus('Busy')).toBe('busy')
+    expect(parseAgentStatus('OFFLINE')).toBe('offline')
+  })
+
+  it('returns null for unknown tokens', () => {
+    expect(parseAgentStatus('retired')).toBeNull()
+    expect(parseAgentStatus('unbooted')).toBeNull()
+    expect(parseAgentStatus('stopped')).toBeNull()
+    expect(parseAgentStatus('running')).toBeNull()
+  })
+
+  it('returns null for null / undefined / empty', () => {
+    expect(parseAgentStatus(null)).toBeNull()
+    expect(parseAgentStatus(undefined)).toBeNull()
+    expect(parseAgentStatus('')).toBeNull()
+  })
+})
+
+describe('isAgentOffline', () => {
+  it('returns true for offline / inactive only', () => {
+    expect(isAgentOffline({ status: 'offline' })).toBe(true)
+    expect(isAgentOffline({ status: 'inactive' })).toBe(true)
+  })
+
+  it('returns false for presence states', () => {
+    expect(isAgentOffline({ status: 'active' })).toBe(false)
+    expect(isAgentOffline({ status: 'busy' })).toBe(false)
+    expect(isAgentOffline({ status: 'listening' })).toBe(false)
+    expect(isAgentOffline({ status: 'idle' })).toBe(false)
+  })
+
+  it('rejects keeper-domain tokens (unbooted / stopped)', () => {
+    expect(isAgentOffline({ status: 'unbooted' as unknown as AgentStatus })).toBe(false)
+    expect(isAgentOffline({ status: 'stopped' as unknown as AgentStatus })).toBe(false)
+  })
+
+  it('returns false for missing status', () => {
+    expect(isAgentOffline({ status: undefined })).toBe(false)
+  })
+})
+
+describe('isAgentActive', () => {
+  it('returns true for active / busy', () => {
+    expect(isAgentActive({ status: 'active' })).toBe(true)
+    expect(isAgentActive({ status: 'busy' })).toBe(true)
+  })
+
+  it('returns false for listening / idle (present but not active)', () => {
+    expect(isAgentActive({ status: 'listening' })).toBe(false)
+    expect(isAgentActive({ status: 'idle' })).toBe(false)
+  })
+
+  it('returns false for offline / inactive', () => {
+    expect(isAgentActive({ status: 'offline' })).toBe(false)
+    expect(isAgentActive({ status: 'inactive' })).toBe(false)
+  })
+
+  it('returns false for missing / unknown', () => {
+    expect(isAgentActive({ status: undefined })).toBe(false)
+    expect(isAgentActive({ status: 'retired' as unknown as AgentStatus })).toBe(false)
+  })
+})
+
+describe('isAgentPresent', () => {
+  it('returns true for the 4 presence states', () => {
+    expect(isAgentPresent({ status: 'active' })).toBe(true)
+    expect(isAgentPresent({ status: 'busy' })).toBe(true)
+    expect(isAgentPresent({ status: 'listening' })).toBe(true)
+    expect(isAgentPresent({ status: 'idle' })).toBe(true)
+  })
+
+  it('returns false for offline / inactive', () => {
+    expect(isAgentPresent({ status: 'offline' })).toBe(false)
+    expect(isAgentPresent({ status: 'inactive' })).toBe(false)
+  })
+
+  it('returns false for unknown tokens', () => {
+    expect(isAgentPresent({ status: 'retired' as unknown as AgentStatus })).toBe(false)
+    expect(isAgentPresent({ status: undefined })).toBe(false)
+  })
+})
+
+describe('boundary cases (cross-domain isolation)', () => {
+  it('keeper-only tokens are not classified as agent presence', () => {
+    expect(parseAgentStatus('unbooted')).toBeNull()
+    expect(parseAgentStatus('stopped')).toBeNull()
+    expect(isAgentPresent({ status: 'unbooted' as unknown as AgentStatus })).toBe(false)
+    expect(isAgentOffline({ status: 'unbooted' as unknown as AgentStatus })).toBe(false)
+  })
+})

--- a/dashboard/src/lib/agent-status.ts
+++ b/dashboard/src/lib/agent-status.ts
@@ -1,0 +1,68 @@
+// RFC-0139 Phase 1 PR-1a — Agent status vocabulary SSOT.
+//
+// Typed closed sum + total parser + domain-specific predicates for
+// dashboard agent presence. Keeps the keeper-status SSOT (lib/keeper-
+// predicates.ts, RFC-0135) and the agent-status SSOT as parallel typed
+// vocabularies; conversion between them happens at component boundaries
+// only.
+//
+// No callsite migration in this PR — module + tests only. Migration to
+// the predicates lands in RFC-0139 PR-1b/PR-1c.
+
+import type { Agent } from '../types/core'
+
+/** Closed sum of agent presence states. Mirrors the literal union on
+ *  `Agent.status` in `dashboard/src/types/core.ts`. */
+export type AgentStatus =
+  | 'active'
+  | 'busy'
+  | 'listening'
+  | 'idle'
+  | 'inactive'
+  | 'offline'
+
+export const AGENT_STATUS_VALUES = [
+  'active',
+  'busy',
+  'listening',
+  'idle',
+  'inactive',
+  'offline',
+] as const satisfies ReadonlyArray<AgentStatus>
+
+const AGENT_STATUS_SET: ReadonlySet<string> = new Set(AGENT_STATUS_VALUES)
+
+/** Total parser: raw string → typed AgentStatus, or null when the input
+ *  is unknown / missing. Use at boundaries (wire decode, JSON parse). */
+export function parseAgentStatus(raw: string | undefined | null): AgentStatus | null {
+  if (raw == null) return null
+  const lower = raw.toLowerCase()
+  return AGENT_STATUS_SET.has(lower) ? (lower as AgentStatus) : null
+}
+
+/** True when the agent is not present (the backend has dropped the
+ *  connection or the registry marked the slot dormant). Mirrors the
+ *  cross-domain `isOfflineStatus` predicate scoped to *agent* tokens
+ *  only — keeper-specific tokens like 'unbooted' / 'stopped' are
+ *  rejected. */
+export function isAgentOffline(agent: Pick<Agent, 'status'>): boolean {
+  const parsed = parseAgentStatus(agent.status ?? null)
+  return parsed === 'offline' || parsed === 'inactive'
+}
+
+/** True when the agent is actively driving work (taking turns, or
+ *  consuming a tool). Distinct from "present" — listening / idle
+ *  agents are present but not active. */
+export function isAgentActive(agent: Pick<Agent, 'status'>): boolean {
+  const parsed = parseAgentStatus(agent.status ?? null)
+  return parsed === 'active' || parsed === 'busy'
+}
+
+/** True when the agent is reachable in any presence state (active,
+ *  working, or just listening / idle). The negation of `isAgentOffline`
+ *  for known tokens; unknown tokens return false. */
+export function isAgentPresent(agent: Pick<Agent, 'status'>): boolean {
+  const parsed = parseAgentStatus(agent.status ?? null)
+  if (parsed == null) return false
+  return parsed !== 'offline' && parsed !== 'inactive'
+}

--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -7,6 +7,7 @@ import { keeperDisplayStatus, keeperRuntimeBlockerHint } from './keeper-runtime-
 // PHASE_ID_MAP elsewhere; the three maps drifted independently.
 import { toKeeperPhase } from '../keeper-store-normalize'
 import { isKeeperPaused } from './keeper-predicates'
+import { parseAgentStatus } from './agent-status'
 // RFC-0135 PR-12 + PR-14d: route blocker visibility through the typed
 // SSOT (stale vs live distinction) and consume composite-preferred
 // phase via `derivePreferredPhase`. Previously
@@ -290,11 +291,19 @@ export function summarizeMonitoringEvidence(summary: KeeperMonitoringSummary): M
 }
 
 function agentBand(status: string | undefined | null): RuntimeBand {
-  const normalized = (status ?? '').trim().toLowerCase()
-  if (!normalized) return 'attention'
-  if (normalized === 'inactive' || normalized === 'offline' || normalized === 'dead' || normalized === 'left') {
-    return 'offline'
-  }
+  if (status == null || status.trim() === '') return 'attention'
+  const parsed = parseAgentStatus(status)
+  if (parsed === 'inactive' || parsed === 'offline') return 'offline'
+  if (parsed != null) return 'active'
+  // Wire-format tokens outside the declared AgentStatus union. The
+  // OCaml backend agent_status sum (lib/types/types_core.ml:42) emits
+  // only Active|Busy|Listening|Inactive; 'dead' and 'left' here are
+  // legacy defensive arms from before the typed union was defined
+  // (predates RFC-0139). Kept as documented compat until a wire-format
+  // audit confirms zero emission, then collapse into the parsed-null
+  // branch below.
+  const lower = status.trim().toLowerCase()
+  if (lower === 'dead' || lower === 'left') return 'offline'
   return 'active'
 }
 


### PR DESCRIPTION
## Summary

RFC-0139 §6 Phase 1 PR-1d — migrate `lib/monitoring-runtime.ts:agentBand` off the 4-OR raw-string classifier onto `parseAgentStatus` + typed comparison.

- Known tokens (`inactive`, `offline`) → `'offline'`
- Known tokens (`active`, `busy`, `listening`, `idle`) → `'active'`
- Unknown tokens (`'dead'`, `'left'`) → defensive `'offline'` (documented)

## Why

`agentBand` had 4 string literals in a single OR chain. The backend OCaml `agent_status` sum (`lib/types/types_core.ml:42`) only emits `Active | Busy | Listening | Inactive` — `'dead' | 'left'` are legacy defensive arms predating the typed union.

This PR adds typed routing for the 4 backend-emitted tokens while keeping the defensive arms as a documented wire-extras compat layer.

## Lint gate deferred

The RFC-0139 lint guard (banning new `agent.status === '<literal>'` direct comparisons) is deferred until PR-1b (#16708) and PR-1c (#16711) merge — the gate would fail on first run otherwise because `live-store.ts` and `ide-presence-strip.ts` still contain the literals.

## Verification

- `pnpm typecheck` clean
- `pnpm test` monitoring-runtime → 18/18 pass

## Stack

- Base: `feature/RFC-0139-pr1a-agent-status` (PR #16707)
- Independent of PR-1b (#16708) and PR-1c (#16711) — all share same base.

## Out-of-scope follow-ups (separate RFC candidate)

- Narrow frontend `Agent.status` to match backend (drop `'idle'`, `'offline'` from the type)
- Audit `'dead' | 'left'` wire emission; if zero, collapse the defensive arms

## Test plan

- [x] typecheck
- [x] vitest monitoring-runtime
- [ ] (next PR after merges) lint gate addition

RFC-WAIVED: typed-sum predicate migration in dashboard, no credential / keeper / operator / sandbox surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)