### PR TITLE
refactor(keeper_registry): extract FSM transition validators (godfile decomp)

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -763,51 +763,11 @@ let mark_turn_measurement ~base_path name =
    a thin compatibility shim.  Adding a new [cascade_state] variant only
    requires updating [resolve_cascade_transition]; this function reflects
    the change automatically. *)
-let validate_cascade_transition ~from ~to_ =
-  (* Wrapped in [Keeper_fsm_guard_runtime.wrap_unit] for symmetry with
-     [validate_turn_phase_transition] and the setters
-     ([set_turn_cascade_state] / [set_turn_phase]): a forbidden pair
-     reached via this validator bumps [metric_fsm_guard_violation]
-     (action=cascade_transition, stage=guard) before re-raising the typed
-     [Cascade_transition_violation] with its backtrace intact. Without
-     this wrap, a direct call to this validator on a forbidden pair was
-     uninstrumented (RFC-0072 Phase 5 left it as a thin shim). *)
-  Keeper_fsm_guard_runtime.wrap_unit
-    ~action:"cascade_transition"
-    ~stage:"guard"
-    (fun () ->
-       match resolve_cascade_transition ~from ~target:to_ with
-       | Resolved_idempotent | Resolved_transition _ -> ()
-       | Resolved_violation violation ->
-         raise_cascade_transition_violation
-           ~where:"validate_cascade_transition"
-           ~from
-           ~to_
-           ~violation)
-;;
-
-(* RFC-0072 Phase 4b + Phase 5: collapse the 49-pair turn_phase matrix onto
-   [resolve_turn_phase_transition] (PR #14912) and raise the typed
-   [Turn_phase_transition_violation] (Phase 5) on the 19 forbidden pairs.
-   Wrapped in [Keeper_fsm_guard_runtime.wrap_unit] so the existing metric /
-   observability instrumentation ([metric_fsm_guard_violation], etc.) keeps
-   firing on forbidden pairs.  The typed
-   [turn_phase_transition_spec_violation] payload travels on the exception;
-   a [Printexc] printer reproduces the prior message text for log output. *)
-let validate_turn_phase_transition ~from ~to_ =
-  Keeper_fsm_guard_runtime.wrap_unit
-    ~action:"turn_phase_transition"
-    ~stage:"guard"
-    (fun () ->
-       match resolve_turn_phase_transition ~from ~target:to_ with
-       | Resolved_turn_idempotent | Resolved_turn_transition _ -> ()
-       | Resolved_turn_violation violation ->
-         raise_turn_phase_transition_violation
-           ~where:"validate_turn_phase_transition"
-           ~from
-           ~to_
-           ~violation)
-;;
+(* FSM transition validators (validate_cascade_transition /
+   validate_turn_phase_transition) moved to
+   Keeper_registry_fsm_validators. *)
+let validate_cascade_transition = Keeper_registry_fsm_validators.cascade_transition
+let validate_turn_phase_transition = Keeper_registry_fsm_validators.turn_phase_transition
 
 let set_turn_decision_stage ~base_path name (decision_stage : decision_stage_active) =
   (* Spec invariant: the 3 [<active>_to_undecided] transitions are forbidden

--- a/lib/keeper/keeper_registry_fsm_validators.ml
+++ b/lib/keeper/keeper_registry_fsm_validators.ml
@@ -1,0 +1,59 @@
+(** Runtime sub-FSM transition validators.
+
+    Extracted from keeper_registry.ml (lines 727-771) as part of the
+    godfile decomp campaign. Each validator wraps a pure transition
+    resolver from [Keeper_registry_types] in
+    [Keeper_fsm_guard_runtime.wrap_unit] so a forbidden pair bumps
+    [metric_fsm_guard_violation] (action/stage labels) before the
+    typed transition-violation exception is raised.
+
+    Pure side-effect calls on top of pure resolvers — no registry
+    state read or written. *)
+
+open Keeper_registry_types
+
+let cascade_transition ~from ~to_ =
+  (* Wrapped in [Keeper_fsm_guard_runtime.wrap_unit] for symmetry with
+     [turn_phase_transition] and the setters
+     ([set_turn_cascade_state] / [set_turn_phase]): a forbidden pair
+     reached via this validator bumps [metric_fsm_guard_violation]
+     (action=cascade_transition, stage=guard) before re-raising the typed
+     [Cascade_transition_violation] with its backtrace intact. Without
+     this wrap, a direct call to this validator on a forbidden pair was
+     uninstrumented (RFC-0072 Phase 5 left it as a thin shim). *)
+  Keeper_fsm_guard_runtime.wrap_unit
+    ~action:"cascade_transition"
+    ~stage:"guard"
+    (fun () ->
+       match resolve_cascade_transition ~from ~target:to_ with
+       | Resolved_idempotent | Resolved_transition _ -> ()
+       | Resolved_violation violation ->
+         raise_cascade_transition_violation
+           ~where:"validate_cascade_transition"
+           ~from
+           ~to_
+           ~violation)
+;;
+
+(* RFC-0072 Phase 4b + Phase 5: collapse the 49-pair turn_phase matrix onto
+   [resolve_turn_phase_transition] (PR #14912) and raise the typed
+   [Turn_phase_transition_violation] (Phase 5) on the 19 forbidden pairs.
+   Wrapped in [Keeper_fsm_guard_runtime.wrap_unit] so the existing metric /
+   observability instrumentation ([metric_fsm_guard_violation], etc.) keeps
+   firing on forbidden pairs.  The typed
+   [turn_phase_transition_spec_violation] payload travels on the exception;
+   a [Printexc] printer reproduces the prior message text for log output. *)
+let turn_phase_transition ~from ~to_ =
+  Keeper_fsm_guard_runtime.wrap_unit
+    ~action:"turn_phase_transition"
+    ~stage:"guard"
+    (fun () ->
+       match resolve_turn_phase_transition ~from ~target:to_ with
+       | Resolved_turn_idempotent | Resolved_turn_transition _ -> ()
+       | Resolved_turn_violation violation ->
+         raise_turn_phase_transition_violation
+           ~where:"validate_turn_phase_transition"
+           ~from
+           ~to_
+           ~violation)
+;;

--- a/lib/keeper/keeper_registry_fsm_validators.mli
+++ b/lib/keeper/keeper_registry_fsm_validators.mli
@@ -1,0 +1,23 @@
+(** Runtime sub-FSM transition validators.
+
+    Pure side-effect wrappers around [Keeper_registry_types] resolvers
+    that bump [metric_fsm_guard_violation] before raising the typed
+    transition-violation exception on a forbidden pair. *)
+
+open Keeper_registry_types
+
+(** Validate a cascade_state cross-state transition.
+    Idempotent self-loops are accepted; the 7 spec-forbidden pairs raise
+    [Cascade_transition_violation] with the typed
+    [cascade_transition_spec_violation] payload. Counter:
+    [metric_fsm_guard_violation] (action=cascade_transition, stage=guard). *)
+val cascade_transition :
+  from:packed_cascade_state -> to_:packed_cascade_state -> unit
+
+(** Validate a turn_phase cross-state transition.
+    Idempotent self-loops are accepted; the 19 spec-forbidden pairs raise
+    [Turn_phase_transition_violation] with the typed
+    [turn_phase_transition_spec_violation] payload. Counter:
+    [metric_fsm_guard_violation] (action=turn_phase_transition, stage=guard). *)
+val turn_phase_transition :
+  from:packed_turn_phase -> to_:packed_turn_phase -> unit


### PR DESCRIPTION
## Summary

Stacked atop #16702. Sixth keeper_registry godfile decomp PR.

### 변경 요약

2 FSM transition validators (lines 727-771) → 새 sibling module \`keeper_registry_fsm_validators.ml\`:

| 원본 | 새 위치 | Alias |
|------|---------|-------|
| \`validate_cascade_transition\` | \`Keeper_registry_fsm_validators.cascade_transition\` | \`let validate_cascade_transition = ...\` |
| \`validate_turn_phase_transition\` | \`Keeper_registry_fsm_validators.turn_phase_transition\` | \`let validate_turn_phase_transition = ...\` |

callsite는 alias 덕분에 변경 불필요 — \`test/test_keeper_sub_fsm_guards.ml\`의 \`open Masc_mcp.Keeper_registry\`도 그대로 동작.

### .mli 주석 honoring

기존 keeper_registry.mli 19-30행 주석:
> \`validate_turn_phase_transition\` and \`validate_cascade_transition\` stay in Keeper_registry because their implementations depend on Keeper_fsm_guard_runtime, not a pure type-level dependency.

이 주석은 *Keeper_registry_types(pure)로 이동하지 말라*는 의미. 새 sibling module도 \`Keeper_fsm_guard_runtime\` 의존이므로 honor됨.

### 동작 보존
- 동일 wrap_unit instrumentation (action / stage labels)
- 동일 typed exception (Cascade_transition_violation / Turn_phase_transition_violation)
- 동일 metric_fsm_guard_violation counter

### LoC 효과

| | Before | After | Δ |
|--|--------|-------|---|
| \`lib/keeper/keeper_registry.ml\` | 1985 | 1950 | −35 |
| 신규 \`keeper_registry_fsm_validators.ml\` | — | 59 | +59 |
| 신규 \`keeper_registry_fsm_validators.mli\` | — | 23 | +23 |

### 검증
- \`dune build --root . @check\` exit 0
- \`test/test_keeper_registry.exe\` 109 tests PASS
- \`test/test_keeper_sub_fsm_guards.exe\` 12 tests PASS

### Scope guard
- credential / identity / operator-control / sandbox / dashboard credential / hooks / workflow 영역 무관
- \`RFC-WAIVED: side-effect helper extraction, godfile decomp follow-up to RFC-0136 stack\`

## Test plan
- [x] dune @check green
- [x] keeper_registry (109) + keeper_sub_fsm_guards (12) alcotest PASS
- [ ] base PR #16702 머지 후 base → main
- [ ] 사용자 라벨 dispatch

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>