### PR TITLE
feat(rfc-0070): Cluster A Step 1a — Sandbox_error.Image_not_found at docker_read producer

### DIFF
--- a/lib/keeper/keeper_docker_read.ml
+++ b/lib/keeper/keeper_docker_read.ml
@@ -136,10 +136,12 @@ let run_command_in_container_with_status ?turn_sandbox_factory
     | None ->
       match Keeper_sandbox_runtime.ensure_keeper_sandbox_image_present ~image ~timeout_sec with
       | Error err ->
+        let typed = Sandbox_error.Image_not_found { image } in
         Error
           (Printf.sprintf
-             "docker_%s_failed: sandbox_image_missing: %s"
+             "docker_%s_failed: %s: %s"
              head_program
+             (Sandbox_error.to_string typed)
              err)
       | Ok () ->
       match Keeper_sandbox_runtime.ensure_keeper_sandbox_runtime ~timeout_sec with


### PR DESCRIPTION
## RFC-0070 Phase 4.1 — Cluster A 본격 구현 시작

Phase B Cluster A의 첫 step. RFC-0070 §2 G2 (Sandbox producer migration) 시작.

## 변경 (1 file, +3/-1)

`lib/keeper/keeper_docker_read.ml:137-145`: image-missing error를 typed `Sandbox_error.Image_not_found { image }`로 구성, `Sandbox_error.to_string`으로 string 변환 후 기존 \`(_, string) result\` signature로 반환.

## Step 1a vs Step 1b 분리

이 PR은 **Step 1a (typed value adoption)** — signature 유지. Step 1b (signature `(_, Sandbox_error.t) result` 변경 + caller migration)는 별도 PR.

### Plan correction

Plan doc(\`memory/rfc-phase-b-pr-cluster-plan-20260519.md\`)은 Step 1을 \"~30 lines, 기존 caller가 Result.Error 분기 처리\"로 추정. 실제 surface scan 결과:

**Caller**: \`lib/keeper/keeper_shell_ops.ml:239-244\`

\`\`\`ocaml
| Error msg
  when attempts_left > 0
       && String_util.contains_substring_ci msg
            \"interrupted system call\" ->
    loop (attempts_left - 1)
| Error msg -> Error (docker_read_error ~target msg)
\`\`\`

Substring match \`\"interrupted system call\"\`은 RFC-0088 §2 *string classifier* anti-pattern. 깔끔한 signature migration은 EINTR retry path도 함께 typed로 표현해야 한다.

### Step 1b 옵션 (RFC-0070 update 후 결정)

(a) \`Sandbox_error.t\`에 \`Eintr_during_exec\` variant 추가  
    → EINTR는 Exec_gate 내부 발생, Sandbox 도메인이 아니라 type purpose 확장됨.

(b) 함수 분할 — pure-sandbox stage \`Sandbox_error.t\` + exec stage \`Exec_error.t\` 별도 type.

둘 다 RFC-0070 §2 G2 scope 확장이라 Step 1b 진행 전 RFC-0070 v2.6 업데이트 권장.

## Anti-pattern 인식

이 변경은 \"typed-then-to_string\" decorative pattern (RFC-0088 §1 신호 약함). Step 1b가 같은 sprint에 머지되지 않으면 *dead-type adoption*이 됨. 본 PR은 *Cluster A의 첫 step*로 기록되며 Step 1b 미진행 시 revert 또는 RFC-WAIVED 라벨 필요.

## Build 검증

- \`dune build lib/keeper/\` 통과 (keeper 서브트리 깨끗).
- 다른 모듈 (server_auth.ml:509 polymorphic variant exhaustiveness) 에러는 main의 PR #16690 잔여, 본 변경과 무관.

## Cluster A 잔여 step (plan 기준)

| Step | 파일 | 예상 LoC | 비고 |
|---|---|---|---|
| 1b | keeper_docker_read.ml + caller | 30+ | RFC-0070 v2.6 후 |
| 2 | keeper_sandbox_runtime.ml 4 dispatch | ~80 | |
| 3 | keeper_turn_sandbox_runtime.ml:151 | ~25 | |
| 4 | Tool_result.classify_from_dispatch_failure 제거 | net -54 | RFC-0088 §2 직격 |
| 5 | process_eio.ml:518/593 Exec_timeout | ~20 | |

## SLO 영향 (예상)

- \`docker_false_positive_24h\` (baseline 3/day): Cluster A 전체 완료 후 0 target.
- \`cascade_audit_failure_pct\` (baseline 37.4%): sandbox 분류 비중만큼 감소.

본 PR(Step 1a)만으로는 SLO 변화 없음 (decorative). Step 2-5 누적 후 측정.

## 다음 액션

1. RFC-0070 v2.6 업데이트 (Step 1b 옵션 a/b 결정)
2. Step 1b PR (signature + caller migration)
3. Step 2 시작

🤖 Generated with [Claude Code](https://claude.com/claude-code)