### PR TITLE
refactor(keeper_registry): extract event-dispatch validators (godfile decomp)

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1502,24 +1502,7 @@ let set_tool_usage_entry ~base_path ~name ~tool_name (e : tool_call_entry) =
 
 (* ── RFC-0002 Event Dispatch ───────────────────────────── *)
 
-let validate_paired_lifecycle_origin origin event =
-  if origin_allows_paired_lifecycle_event origin event
-  then Ok ()
-  else
-    Error
-      (Keeper_state_machine.Precondition_violation
-         { event = Keeper_state_machine.event_to_string event
-         ; reason =
-             Printf.sprintf
-               "paired lifecycle event requires origin=post_turn_lifecycle%s; got %s"
-               (match event with
-                | Keeper_state_machine.Compaction_started
-                | Keeper_state_machine.Compaction_completed _
-                | Keeper_state_machine.Compaction_failed _ -> " or origin=operator_compact"
-                | _ -> "")
-               (lifecycle_event_origin_to_string origin)
-         })
-;;
+let validate_paired_lifecycle_origin = Keeper_registry_event_validators.paired_lifecycle_origin
 
 (* Entry-action dispatch observability helpers
    (execute_entry_action_observability / followup_event_of_entry_action /
@@ -1535,54 +1518,7 @@ let record_followup_dispatch_rejection =
   Keeper_registry_entry_action_dispatch.record_dispatch_rejection
 ;;
 
-(* RFC-0072 Phase 6: the 3×3 compaction matrix dispatched as an exhaustive
-   match — the 3 valid pairs (incl. idempotent self-loops) return [()], the
-   3 forbidden pairs raise the typed [Compaction_transition_violation]
-   (replacing the prior bare [assert], whose [Assert_failure] carried no
-   labels).  Still wrapped in [Keeper_fsm_guard_runtime.wrap_unit] so
-   [metric_fsm_guard_violation] (action=compaction_transition, stage=guard)
-   fires on a forbidden pair; the match stays exhaustive so adding a
-   [compaction_stage] variant triggers Warning 8 here.  No
-   [Compaction_transition] GADT / [resolve_*] helper: with 3 states and a
-   single consumer the resolver indirection would be premature. *)
-let validate_compaction_transition ~from ~to_ =
-  Keeper_fsm_guard_runtime.wrap_unit
-    ~action:"compaction_transition"
-    ~stage:"guard"
-    (fun () ->
-       match from, to_ with
-       (* Idempotent self-loops + valid cross-state transitions (6). *)
-       | Packed Compaction_accumulating, Packed Compaction_accumulating
-       | Packed Compaction_accumulating, Packed Compaction_compacting
-       (* via set_compaction_stage *)
-       | Packed Compaction_compacting, Packed Compaction_accumulating
-       (* via set_compaction_stage: retry after a failed compaction *)
-       | Packed Compaction_compacting, Packed Compaction_compacting
-       | Packed Compaction_compacting, Packed Compaction_done
-       (* via set_compaction_stage *)
-       | Packed Compaction_done, Packed Compaction_done -> ()
-       (* Forbidden transitions (3). *)
-       | Packed Compaction_accumulating, Packed Compaction_done ->
-         raise_compaction_transition_violation
-           ~where:"validate_compaction_transition"
-           ~from
-           ~to_
-           ~violation:Accumulating_to_done
-       | Packed Compaction_done, Packed Compaction_accumulating ->
-         (* terminal; a fresh compaction is a reset, not a transition *)
-         raise_compaction_transition_violation
-           ~where:"validate_compaction_transition"
-           ~from
-           ~to_
-           ~violation:Done_to_accumulating
-       | Packed Compaction_done, Packed Compaction_compacting ->
-         (* terminal *)
-         raise_compaction_transition_violation
-           ~where:"validate_compaction_transition"
-           ~from
-           ~to_
-           ~violation:Done_to_compacting)
-;;
+let validate_compaction_transition = Keeper_registry_event_validators.compaction_transition
 
 let compaction_stage_after_event entry event =
   let old_stage = entry.compaction_stage in

--- a/lib/keeper/keeper_registry_event_validators.ml
+++ b/lib/keeper/keeper_registry_event_validators.ml
@@ -1,0 +1,80 @@
+(** Event-dispatch transition validators.
+
+    Extracted from keeper_registry.ml as part of the godfile decomp
+    campaign. Two side-effect wrappers shared by RFC-0002 Event
+    Dispatch and RFC-0072 Phase 6 (compaction matrix). Pure on top of
+    [Keeper_registry_types] resolvers / state machine helpers — no
+    registry state read or written.
+
+    Companion to [Keeper_registry_fsm_validators] (cascade /
+    turn_phase) which carries the GADT-resolver wrappers. *)
+
+open Keeper_registry_types
+
+let paired_lifecycle_origin origin event =
+  if origin_allows_paired_lifecycle_event origin event
+  then Ok ()
+  else
+    Error
+      (Keeper_state_machine.Precondition_violation
+         { event = Keeper_state_machine.event_to_string event
+         ; reason =
+             Printf.sprintf
+               "paired lifecycle event requires origin=post_turn_lifecycle%s; got %s"
+               (match event with
+                | Keeper_state_machine.Compaction_started
+                | Keeper_state_machine.Compaction_completed _
+                | Keeper_state_machine.Compaction_failed _ -> " or origin=operator_compact"
+                | _ -> "")
+               (lifecycle_event_origin_to_string origin)
+         })
+;;
+
+(* RFC-0072 Phase 6: the 3×3 compaction matrix dispatched as an exhaustive
+   match — the 3 valid pairs (incl. idempotent self-loops) return [()], the
+   3 forbidden pairs raise the typed [Compaction_transition_violation]
+   (replacing the prior bare [assert], whose [Assert_failure] carried no
+   labels).  Still wrapped in [Keeper_fsm_guard_runtime.wrap_unit] so
+   [metric_fsm_guard_violation] (action=compaction_transition, stage=guard)
+   fires on a forbidden pair; the match stays exhaustive so adding a
+   [compaction_stage] variant triggers Warning 8 here.  No
+   [Compaction_transition] GADT / [resolve_*] helper: with 3 states and a
+   single consumer the resolver indirection would be premature. *)
+let compaction_transition ~from ~to_ =
+  Keeper_fsm_guard_runtime.wrap_unit
+    ~action:"compaction_transition"
+    ~stage:"guard"
+    (fun () ->
+       match from, to_ with
+       (* Idempotent self-loops + valid cross-state transitions (6). *)
+       | Packed Compaction_accumulating, Packed Compaction_accumulating
+       | Packed Compaction_accumulating, Packed Compaction_compacting
+       (* via set_compaction_stage *)
+       | Packed Compaction_compacting, Packed Compaction_accumulating
+       (* via set_compaction_stage: retry after a failed compaction *)
+       | Packed Compaction_compacting, Packed Compaction_compacting
+       | Packed Compaction_compacting, Packed Compaction_done
+       (* via set_compaction_stage *)
+       | Packed Compaction_done, Packed Compaction_done -> ()
+       (* Forbidden transitions (3). *)
+       | Packed Compaction_accumulating, Packed Compaction_done ->
+         raise_compaction_transition_violation
+           ~where:"validate_compaction_transition"
+           ~from
+           ~to_
+           ~violation:Accumulating_to_done
+       | Packed Compaction_done, Packed Compaction_accumulating ->
+         (* terminal; a fresh compaction is a reset, not a transition *)
+         raise_compaction_transition_violation
+           ~where:"validate_compaction_transition"
+           ~from
+           ~to_
+           ~violation:Done_to_accumulating
+       | Packed Compaction_done, Packed Compaction_compacting ->
+         (* terminal *)
+         raise_compaction_transition_violation
+           ~where:"validate_compaction_transition"
+           ~from
+           ~to_
+           ~violation:Done_to_compacting)
+;;

--- a/lib/keeper/keeper_registry_event_validators.mli
+++ b/lib/keeper/keeper_registry_event_validators.mli
@@ -1,0 +1,22 @@
+(** Event-dispatch transition validators (RFC-0002 + RFC-0072 Phase 6).
+
+    Companion to [Keeper_registry_fsm_validators]; all pure side-effect
+    wrappers, no registry state touched. *)
+
+open Keeper_registry_types
+
+(** Validate that the paired lifecycle event's origin is allowed.
+    Returns [Ok ()] when the origin authorizes the half-event,
+    [Error (Precondition_violation _)] otherwise — message preserves
+    the legacy text shape for log/metrics consumers. *)
+val paired_lifecycle_origin :
+  lifecycle_event_origin -> Keeper_state_machine.event
+  -> (unit, Keeper_state_machine.transition_error) result
+
+(** Validate a compaction_stage transition. Idempotent self-loops are
+    accepted; the 3 spec-forbidden pairs raise
+    [Compaction_transition_violation] with the typed
+    [compaction_transition_spec_violation] payload. Counter:
+    [metric_fsm_guard_violation] (action=compaction_transition, stage=guard). *)
+val compaction_transition :
+  from:packed_compaction_stage -> to_:packed_compaction_stage -> unit


### PR DESCRIPTION
## Summary

Stacked atop #16702. Seventh keeper_registry godfile decomp PR. Companion to #16715 (cascade / turn_phase validators).

### 변경 요약

2 event-dispatch validators → 새 sibling module \`keeper_registry_event_validators.ml\`:

| 원본 | 새 위치 | Alias |
|------|---------|-------|
| \`validate_paired_lifecycle_origin\` | \`Keeper_registry_event_validators.paired_lifecycle_origin\` | \`let validate_paired_lifecycle_origin = ...\` |
| \`validate_compaction_transition\` | \`Keeper_registry_event_validators.compaction_transition\` | \`let validate_compaction_transition = ...\` |

내부 1 callsite (\`compaction_stage_after_event\`) + test \`open Masc_mcp.Keeper_registry\` 모두 alias로 0 변경.

### 동작 보존
- \`paired_lifecycle_origin\`: 동일 \`Precondition_violation\` 메시지 shape (legacy text 보존)
- \`compaction_transition\`: 동일 \`Keeper_fsm_guard_runtime.wrap_unit\` instrumentation + 동일 exhaustive 3×3 match + 동일 typed exception
- \`metric_fsm_guard_violation\` 동일 label 패턴

### LoC 효과

| | Before | After | Δ |
|--|--------|-------|---|
| \`lib/keeper/keeper_registry.ml\` | 1985 | 1926 | −59 |
| 신규 \`keeper_registry_event_validators.ml\` | — | 80 | +80 |
| 신규 \`keeper_registry_event_validators.mli\` | — | 22 | +22 |

### 검증
- \`dune build --root . @check\` exit 0
- \`test/test_keeper_sub_fsm_guards.exe\` 12 tests PASS

### Scope guard
- credential / identity / operator-control / sandbox / dashboard credential / hooks / workflow 영역 무관
- \`RFC-WAIVED: side-effect helper extraction, godfile decomp follow-up to RFC-0136 stack\`

## Test plan
- [x] dune @check green
- [x] keeper_sub_fsm_guards (12) PASS
- [ ] base PR #16702 머지 후 base → main
- [ ] 사용자 라벨 dispatch

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>