### PR TITLE
Cooldown required-tool contract provider failures

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -32,6 +32,9 @@ let label_source = "source"
 let fallback_class_hard_quota = "hard_quota"
 let fallback_class_max_turns = "max_turns"
 let fallback_class_resumable_cli_session = "resumable_cli_session"
+let fallback_class_required_tool_contract_violation =
+  "required_tool_contract_violation"
+
 let provider_label_max_execution_time = "max_execution_time"
 
 
@@ -521,6 +524,14 @@ let sdk_error_is_terminal_provider_runtime_failure
   || message_looks_like_terminal_provider_runtime_failure
        (Agent_sdk.Error.to_string err)
 
+let sdk_error_is_required_tool_contract_violation
+    (err : Agent_sdk.Error.sdk_error) : bool =
+  match err with
+  | Agent_sdk.Error.Agent
+      (Agent_sdk.Error.CompletionContractViolation { contract; _ }) ->
+    contract = Agent_sdk.Completion_contract_id.Require_tool_use
+  | _ -> false
+
 let sdk_error_is_hard_quota (err : Agent_sdk.Error.sdk_error) : bool =
   match err with
   | Agent_sdk.Error.Provider (Llm_provider.Error.HardQuota _) -> true
@@ -902,4 +913,6 @@ let sdk_error_cascade_fallback_class (err : Agent_sdk.Error.sdk_error) :
   else if sdk_error_is_max_turns_exceeded err then Some fallback_class_max_turns
   else if sdk_error_is_resumable_cli_session err then
     Some fallback_class_resumable_cli_session
+  else if sdk_error_is_required_tool_contract_violation err then
+    Some fallback_class_required_tool_contract_violation
   else None

--- a/lib/cascade/cascade_attempt_fsm.mli
+++ b/lib/cascade/cascade_attempt_fsm.mli
@@ -75,6 +75,11 @@ val sdk_error_is_model_access_denied : Agent_sdk.Error.sdk_error -> bool
 (** [true] for deterministic model-access denials that should cool down the
     concrete provider/model pair without poisoning sibling models. *)
 
+val sdk_error_is_required_tool_contract_violation :
+  Agent_sdk.Error.sdk_error -> bool
+(** [true] when a provider/model violated the required-tool-use contract by
+    returning no usable tool call for a strict tool-choice turn. *)
+
 val sdk_error_is_hard_quota : Agent_sdk.Error.sdk_error -> bool
 (** [true] when the error represents a hard usage quota that will not
     recover within the cascade turn budget. *)

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -690,6 +690,13 @@ let run_named
         ~error_kind
         ~error_reason
         ()
+    else if sdk_error_is_required_tool_contract_violation sdk_err then
+      Cascade_health_tracker.record_terminal_failure
+        Cascade_health_tracker.global
+        ~provider_key:model_key
+        ~error_kind
+        ~error_reason
+        ()
     else if sdk_error_is_resumable_cli_session sdk_err
             || sdk_error_is_terminal_provider_runtime_failure sdk_err
     then

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -122,6 +122,9 @@ val sdk_error_is_terminal_provider_runtime_failure :
 
 val sdk_error_is_model_access_denied : Agent_sdk.Error.sdk_error -> bool
 
+val sdk_error_is_required_tool_contract_violation :
+  Agent_sdk.Error.sdk_error -> bool
+
 val sdk_error_is_hard_quota : Agent_sdk.Error.sdk_error -> bool
 
 val sdk_error_soft_rate_limited :

--- a/lib/keeper/keeper_turn_driver_provider_attempt.ml
+++ b/lib/keeper/keeper_turn_driver_provider_attempt.ml
@@ -163,6 +163,17 @@ let record_candidate_health_error candidate sdk_err =
         ~error_kind
         ~error_reason
         ()))
+  else if sdk_error_is_required_tool_contract_violation sdk_err
+  then (
+    let error_kind = health_error_kind "required_tool_contract_violation" in
+    health_keys
+    |> List.iter (fun provider_key ->
+      Cascade_health_tracker.record_terminal_failure
+        Cascade_health_tracker.global
+        ~provider_key
+        ~error_kind
+        ~error_reason
+        ()))
   else
     match sdk_error_soft_rate_limited sdk_err with
     | Some retry_after_s ->

--- a/test/test_cascade_attempt_fsm_response_pins.ml
+++ b/test/test_cascade_attempt_fsm_response_pins.ml
@@ -116,11 +116,60 @@ let test_case_insensitive () =
   check_bool "lower" true lower
 ;;
 
+let required_tool_contract_violation_error () =
+  Agent_sdk.Error.Agent
+    (CompletionContractViolation
+       { contract = Agent_sdk.Completion_contract_id.Require_tool_use
+       ; reason =
+           "required tool contract unsatisfied: tool_choice requested tool use, but \
+            the model returned no ToolUse block"
+       })
+;;
+
+let test_required_tool_contract_violation_is_typed () =
+  let err = required_tool_contract_violation_error () in
+  check_bool
+    "required tool contract predicate"
+    true
+    (Cascade_attempt_fsm.sdk_error_is_required_tool_contract_violation err);
+  Alcotest.(check (option string))
+    "fallback class"
+    (Some "required_tool_contract_violation")
+    (Cascade_attempt_fsm.sdk_error_cascade_fallback_class err)
+;;
+
+let test_required_tool_contract_violation_ignores_legacy_internal_text () =
+  let err =
+    Agent_sdk.Error.Internal
+      "Completion contract [require_tool_use] violated: required tool contract \
+       unsatisfied: tool_choice requested tool use, but the model returned no ToolUse \
+       block"
+  in
+  check_bool
+    "legacy internal text is not typed contract evidence"
+    false
+    (Cascade_attempt_fsm.sdk_error_is_required_tool_contract_violation err);
+  Alcotest.(check (option string))
+    "no fallback class"
+    None
+    (Cascade_attempt_fsm.sdk_error_cascade_fallback_class err)
+;;
+
 let () =
   Alcotest.run
     "cascade_attempt_fsm_response_pins"
     [ "hard_quota", [ Alcotest.test_case "pin fixtures" `Quick test_hard_quota_pins ]
     ; "max_turns", [ Alcotest.test_case "pin fixtures" `Quick test_max_turns_pins ]
     ; "case_insensitive", [ Alcotest.test_case "ci check" `Quick test_case_insensitive ]
+    ; ( "required_tool_contract"
+      , [ Alcotest.test_case
+            "typed contract maps to fallback class"
+            `Quick
+            test_required_tool_contract_violation_is_typed
+        ; Alcotest.test_case
+            "legacy internal text ignored"
+            `Quick
+            test_required_tool_contract_violation_ignores_legacy_internal_text
+        ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

- classify typed `CompletionContractViolation Require_tool_use` as `required_tool_contract_violation` in the cascade fallback classifier
- record required-tool contract failures as immediate terminal provider/model health failures instead of generic provider failures
- add pin coverage proving typed required-tool contract errors map to the stable fallback class while legacy internal text does not

## Why

Live keepers can hit `tool_choice requested tool use, but no ToolUse block` on strict required-tool turns. Before this change, that failure could rotate within the turn, but provider health only saw a generic provider error, so the same non-compliant provider/model could be selected again in later attempts instead of cooling down like other deterministic runtime failures.

## Validation

- `ocamlformat --check lib/cascade/cascade_attempt_fsm.ml lib/cascade/cascade_attempt_fsm.mli lib/keeper/keeper_turn_driver.mli lib/keeper/keeper_turn_driver_provider_attempt.ml lib/keeper/keeper_turn_driver.ml test/test_cascade_attempt_fsm_response_pins.ml`
- `git diff --check origin/main...HEAD`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_JOBS=1 scripts/dune-local.sh build test/test_cascade_attempt_fsm_response_pins.exe`
- `./_build/default/test/test_cascade_attempt_fsm_response_pins.exe --color=never`
