### PR TITLE
fix(dashboard/sse-store): promote hydration failure logs from console.debug to console.warn

### DIFF
--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -220,7 +220,10 @@ function handleNamespaceTruthSnapshot(payload: unknown): void {
       normalized.root.status ?? null,
     )
   } catch (err) {
-    console.debug('[SSE] project-snapshot hydration failed, will fallback to HTTP', err instanceof Error ? err.message : '')
+    // Mirrors the transport-health P2 fix below: hydration failures are
+    // operator-actionable (UI shows stale data + falls back to HTTP), not
+    // background-debug, so they get console.warn instead of console.debug.
+    console.warn('[SSE] project-snapshot hydration failed, will fallback to HTTP', err instanceof Error ? err.message : '')
   }
 }
 
@@ -229,7 +232,7 @@ function handleExecutionSnapshot(payload: unknown): void {
   try {
     hydrateExecutionSnapshot(payload as DashboardExecutionResponse)
   } catch (err) {
-    console.debug('[SSE] execution snapshot hydration failed, will fallback to HTTP', err instanceof Error ? err.message : '')
+    console.warn('[SSE] execution snapshot hydration failed, will fallback to HTTP', err instanceof Error ? err.message : '')
   }
 }
 
@@ -237,7 +240,7 @@ function handleOperatorSnapshot(payload: unknown): void {
   try {
     operatorSnapshot.value = normalizeOperatorSnapshot(payload)
   } catch (err) {
-    console.debug('[SSE] operator snapshot hydration failed', err instanceof Error ? err.message : '')
+    console.warn('[SSE] operator snapshot hydration failed', err instanceof Error ? err.message : '')
   }
 }
 
@@ -245,7 +248,7 @@ function handleOperatorDigest(payload: unknown): void {
   try {
     operatorRoomDigest.value = normalizeOperatorDigest(payload)
   } catch (err) {
-    console.debug('[SSE] operator digest hydration failed', err instanceof Error ? err.message : '')
+    console.warn('[SSE] operator digest hydration failed', err instanceof Error ? err.message : '')
   }
 }
 


### PR DESCRIPTION
## Summary

Promote 4 SSE hydration-failure logs from \`console.debug\` to \`console.warn\` so operators see them at the default DevTools log level. Mirrors the rationale of the **transport-health P2 fix** already in this file (lines 252-258).

## Why

When an SSE handler can't normalize the incoming payload, the UI silently swallows the error and falls back to HTTP. Operators investigating "why is X stale?" or "why didn't the SSE wire format update?" need that signal. With \`console.debug\` the signal is filtered out unless the user has already raised their log level — which they wouldn't unless they already suspected a problem. Catch-22.

The same file already documents this exact issue for one handler — \`handleTransportHealth\` was upgraded in a P2 fix (sse-store.ts lines 252-258):

> previously the dynamic import retried on every SSE transport-health event with only \`console.debug\` on failure (hidden from default DevTools view). [...] Promote the failure log to \`console.warn\` so operators see it when investigating "transport health widget is missing/stale."

This PR applies the same upgrade to the 4 remaining hydration handlers that the P2 fix left behind.

## Change

| Handler | Before | After |
|---------|--------|-------|
| \`handleNamespaceTruthSnapshot\` | \`console.debug\` | \`console.warn\` |
| \`handleExecutionSnapshot\` | \`console.debug\` | \`console.warn\` |
| \`handleOperatorSnapshot\` | \`console.debug\` | \`console.warn\` |
| \`handleOperatorDigest\` | \`console.debug\` | \`console.warn\` |

Added a 3-line explanatory comment at the first call site cross-referencing the P2 fix block below, so future readers see the design rationale.

## Scope

- 1 file (\`dashboard/src/sse-store.ts\`), +7/-4 LoC.
- No behavior change beyond log-level visibility — same message string, same arguments, same error-suppression semantics, same fallback-to-HTTP path.
- \`rg\` confirms no test asserts on \`console.debug\` being called for these handlers, so test green is preserved.

## Iter#55 context

Iter sprint focused on \`Error 가 나는 케이스에 대해 사용자가 정말 구체적으로 알도록 개선하라\` — this is the dashboard-side analog of the cascade probe observability fix (PR #16712). Both surface a previously-silent failure mode at the boundary where downstream code falls back to a slower path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>