### PR TITLE
feat(rfc-0092): Cluster C Step 1 — introduce validator_stage typed enum

### DIFF
--- a/lib/exec_core.ml
+++ b/lib/exec_core.ml
@@ -34,6 +34,25 @@ type retryability =
   | Self_correct
   | Operator_required
 
+(* RFC-0092 Phase B Step 1: typed validator hand-off marker.
+   Replaces string-based "next_action" suggestion in blocked_result_json
+   extras with a closed sum.  Consumers (Cluster C Step 5,
+   keeper_shell_bash.ml block path) will populate this; readers
+   pattern-match exhaustively so new validator stages become a
+   compile-time addition. *)
+type validator_stage =
+  | Probe_task_state
+  | Probe_http
+  | Probe_search
+  | Allowed
+
+let validator_stage_to_string = function
+  | Probe_task_state -> "probe_task_state"
+  | Probe_http -> "probe_http"
+  | Probe_search -> "probe_search"
+  | Allowed -> "allowed"
+;;
+
 type artifact_policy =
   | Inline_only
   | Persist_if_large


### PR DESCRIPTION
## RFC-0092 Phase B Cluster C — 본격 구현 시작

Phase B Cluster C의 첫 step. RFC-0092 typed Shell_ir + validator receipt 시작 — typed marker 도입.

## 변경 (1 file, +20/-0)

\`lib/exec_core.ml:32-55\`: \`validator_stage\` closed sum + helper 도입.

\`\`\`ocaml
type validator_stage =
  | Probe_task_state
  | Probe_http
  | Probe_search
  | Allowed
\`\`\`

## 왜 cluster를 활성화하는가

현재 \`blocked_result_json\` (line 1003)이 \`extras\` 라는 *임의 assoc list*로 추가 필드 전달. Shell-bash block path에서 \`next_action\`을 free string (\"probe_task_state\", \"probe_http\" 등)으로 set. 이는 RFC-0088 §2 *substring 분류기* 신호 — keeper 코드에서 string match로 분기.

본 Step 1은 closed sum을 도입 (wiring 없음). Step 5에서 \`keeper_shell_bash.ml:1160\` block emit site가 typed value 채움. Downstream reader는 exhaustive pattern match로 새 stage 추가 시 컴파일 시점 break.

## Anti-pattern 명시 (RFC-0088 §1)

Step 5 머지 전까지 type *dead* — \`validator_stage_to_string\` helper만 호출 가능하나 caller 0. *introduce-before-consume* 패턴. consumer step이 같은 RFC sprint에 따라오면 허용. Step 5 stall 시 revert 또는 feature flag 권장.

## What this does NOT do

- \`?next_action: validator_stage option\` 인자 \`blocked_result_json\`에 추가 — **Step 1b**로 분리 (consumer와 함께 머지)
- Shell_ir AST 도입 — Step 2-4 별도 PR

## Build 검증

- \`dune build lib/exec_core.ml\` 에러 없음.
- 다른 모듈 (server_auth.ml:509) 에러는 main의 PR #16690 잔여.

## Cluster C 잔여 step (plan 기준)

| Step | 설명 | 예상 LoC |
|---|---|---|
| 1b | \`?next_action\` 추가 (with Step 5) | ~10 |
| 2 | \`Shell_ir.t\` AST 신규 모듈 | ~80 |
| 3 | \`keeper_shell_bash_words\` → Shell_ir 파서 | ~50 |
| 4 | \`keeper_shell_bash_task_probe\` substring → AST match | ~120 |
| 5 | \`keeper_shell_bash.ml:1160\` validator_stage emit | ~30 |

## SLO 영향

본 PR(Step 1)만으로는 SLO 변화 없음. Step 4 (AST match) 후 \`keeper_bash_command_shape_blocked\` (baseline ~893/day) 감소 기대. \`bash_failure_pct\` (baseline 26.14%) → 23% 이하 target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)