### PR TITLE
refactor(keeper_registry): extract entry-action dispatch observability (godfile decomp)

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -1521,54 +1521,18 @@ let validate_paired_lifecycle_origin origin event =
          })
 ;;
 
-let execute_entry_action_observability
-      ~(name : string)
-      ~(phase : Keeper_state_machine.phase)
-      ~(ts_unix : float)
-      (action : Keeper_state_machine.entry_action)
-  : unit
-  =
-  match action with
-  | Keeper_state_machine.Publish_lifecycle { event_name; detail } ->
-    Log.Keeper.info
-      "registry: lifecycle name=%s phase=%s event=%s detail=%s"
-      name
-      (Keeper_state_machine.phase_to_string phase)
-      event_name
-      detail;
-    let (_ignore_ts : float) = ts_unix in
-    ()
-  | Start_compaction
-  | Start_handoff
-  | Start_drain
-  | Schedule_restart _
-  | Mark_dead_tombstone
-  | Mark_zombie_tombstone
-  | Cleanup_and_unregister
-  | Trigger_immediate_cleanup
-  | Cancel_pending_oas -> ()
+(* Entry-action dispatch observability helpers
+   (execute_entry_action_observability / followup_event_of_entry_action /
+   record_followup_dispatch_rejection) moved to
+   Keeper_registry_entry_action_dispatch. *)
+let execute_entry_action_observability =
+  Keeper_registry_entry_action_dispatch.execute_observability
 ;;
-
-let followup_event_of_entry_action
-      ~(phase : Keeper_state_machine.phase)
-      (action : Keeper_state_machine.entry_action)
-  : Keeper_state_machine.event option
-  =
-  match phase, action with
-  | Keeper_state_machine.Overflowed, Start_compaction ->
-    Prometheus.inc_counter
-      Keeper_metrics.metric_keeper_fsm_edge_transitions
-      ~labels:[ "edge", "ksm_to_kmc_compact_trigger" ]
-      ();
-    Some Keeper_state_machine.Auto_compact_triggered
-  | _ -> None
+let followup_event_of_entry_action =
+  Keeper_registry_entry_action_dispatch.followup_event_of_action
 ;;
-
-let record_followup_dispatch_rejection event =
-  Prometheus.inc_counter
-    Keeper_metrics.metric_keeper_lifecycle_dispatch_rejections
-    ~labels:[ "event", Keeper_state_machine.event_to_string event ]
-    ()
+let record_followup_dispatch_rejection =
+  Keeper_registry_entry_action_dispatch.record_dispatch_rejection
 ;;
 
 (* RFC-0072 Phase 6: the 3×3 compaction matrix dispatched as an exhaustive

--- a/lib/keeper/keeper_registry_entry_action_dispatch.ml
+++ b/lib/keeper/keeper_registry_entry_action_dispatch.ml
@@ -1,0 +1,58 @@
+(** Entry-action dispatch observability helpers (RFC-0002).
+
+    Extracted from keeper_registry.ml (lines 1507-1555) as part of the
+    godfile decomp campaign. Three pure side-effect helpers — log line
+    on a [Publish_lifecycle] entry action, Prometheus-instrumented
+    lookup of a follow-up event for [Overflowed/Start_compaction], and
+    a counter bump on rejected follow-up dispatch. No registry state
+    read or written. *)
+
+let execute_observability
+      ~(name : string)
+      ~(phase : Keeper_state_machine.phase)
+      ~(ts_unix : float)
+      (action : Keeper_state_machine.entry_action)
+  : unit
+  =
+  match action with
+  | Keeper_state_machine.Publish_lifecycle { event_name; detail } ->
+    Log.Keeper.info
+      "registry: lifecycle name=%s phase=%s event=%s detail=%s"
+      name
+      (Keeper_state_machine.phase_to_string phase)
+      event_name
+      detail;
+    let (_ignore_ts : float) = ts_unix in
+    ()
+  | Start_compaction
+  | Start_handoff
+  | Start_drain
+  | Schedule_restart _
+  | Mark_dead_tombstone
+  | Mark_zombie_tombstone
+  | Cleanup_and_unregister
+  | Trigger_immediate_cleanup
+  | Cancel_pending_oas -> ()
+;;
+
+let followup_event_of_action
+      ~(phase : Keeper_state_machine.phase)
+      (action : Keeper_state_machine.entry_action)
+  : Keeper_state_machine.event option
+  =
+  match phase, action with
+  | Keeper_state_machine.Overflowed, Start_compaction ->
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_fsm_edge_transitions
+      ~labels:[ "edge", "ksm_to_kmc_compact_trigger" ]
+      ();
+    Some Keeper_state_machine.Auto_compact_triggered
+  | _ -> None
+;;
+
+let record_dispatch_rejection event =
+  Prometheus.inc_counter
+    Keeper_metrics.metric_keeper_lifecycle_dispatch_rejections
+    ~labels:[ "event", Keeper_state_machine.event_to_string event ]
+    ()
+;;

--- a/lib/keeper/keeper_registry_entry_action_dispatch.mli
+++ b/lib/keeper/keeper_registry_entry_action_dispatch.mli
@@ -1,0 +1,24 @@
+(** Entry-action dispatch observability helpers (RFC-0002).
+
+    Pure side-effect wrappers (log + Prometheus) — no registry state
+    read or written. *)
+
+(** Emit the lifecycle log line for a [Publish_lifecycle] entry action;
+    no-op for all other entry-action variants. *)
+val execute_observability :
+  name:string ->
+  phase:Keeper_state_machine.phase ->
+  ts_unix:float ->
+  Keeper_state_machine.entry_action -> unit
+
+(** Map a [(phase, action)] pair to the follow-up event the dispatcher
+    should fire (currently only [Overflowed/Start_compaction] →
+    [Auto_compact_triggered], with a [metric_keeper_fsm_edge_transitions]
+    counter bump). [None] for all other pairs. *)
+val followup_event_of_action :
+  phase:Keeper_state_machine.phase ->
+  Keeper_state_machine.entry_action -> Keeper_state_machine.event option
+
+(** Bump [metric_keeper_lifecycle_dispatch_rejections] when a follow-up
+    event is rejected by the state machine. *)
+val record_dispatch_rejection : Keeper_state_machine.event -> unit


### PR DESCRIPTION
## Summary

Eighth keeper_registry godfile decomp PR. Companion to #16715 / #16717 (FSM transition validators). Base = main (#16702 dependency removed — main is now buildable after #16694 restructured the server_auth boundary).

### 변경 요약

3 RFC-0002 Event Dispatch observability helpers → 새 sibling module \`keeper_registry_entry_action_dispatch.ml\`:

| 원본 | 새 위치 | Alias |
|------|---------|-------|
| \`execute_entry_action_observability\` | \`Keeper_registry_entry_action_dispatch.execute_observability\` | \`let execute_entry_action_observability = ...\` |
| \`followup_event_of_entry_action\` | \`Keeper_registry_entry_action_dispatch.followup_event_of_action\` | \`let followup_event_of_entry_action = ...\` |
| \`record_followup_dispatch_rejection\` | \`Keeper_registry_entry_action_dispatch.record_dispatch_rejection\` | \`let record_followup_dispatch_rejection = ...\` |

5 internal callsite in \`dispatch_event_with_audit\` → alias 덕분에 0 변경.

### 동작 보존
- \`execute_observability\`: 동일 \`Log.Keeper.info\` (lifecycle 이벤트), 동일 entry-action variant 분기
- \`followup_event_of_action\`: 동일 \`metric_keeper_fsm_edge_transitions\` 카운터 (edge=ksm_to_kmc_compact_trigger), 동일 \`Auto_compact_triggered\` return
- \`record_dispatch_rejection\`: 동일 \`metric_keeper_lifecycle_dispatch_rejections\` 카운터

### 분리 근거
이들은 RFC-0002 Event Dispatch의 *observability seam* — FSM 전이 검증 (\`Keeper_fsm_guard_runtime.wrap_unit\` 사용, #16715 / #16717)과 책임 영역 다름. 두 모듈로 분리해서 RFC 매핑이 더 명확해짐.

### LoC 효과

| | Before | After | Δ |
|--|--------|-------|---|
| \`lib/keeper/keeper_registry.ml\` (60 lines changed: 12 +, 48 −) | — | — | **−36 net** |
| 신규 \`keeper_registry_entry_action_dispatch.ml\` | — | 58 | +58 |
| 신규 \`keeper_registry_entry_action_dispatch.mli\` | — | 24 | +24 |

### 검증
- \`dune build --root . @check\` exit 0
- \`test/test_keeper_registry.exe\` 109 tests PASS

### Scope guard
- credential / identity / operator-control / sandbox / dashboard credential / hooks / workflow 영역 무관
- \`RFC-WAIVED: observability helper extraction, godfile decomp follow-up to RFC-0136 stack\`

## Test plan
- [x] dune @check green
- [x] keeper_registry alcotest (109) PASS
- [ ] 사용자 라벨 dispatch

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>