### PR TITLE
fix(server-routes-sidecar): log silent file-read/JSON-parse failures in sidecar record readers

### DIFF
--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -196,13 +196,29 @@ let sidecar_attempt_path ~base_path id =
     (Printf.sprintf ".gate/runtime/%s/sidecar_lifecycle_attempt.json" id)
 ;;
 
+(* Silent [Sys_error _ | Yojson.Json_error _ -> None] previously
+   collapsed two distinct failure modes into "no record":
+   (1) file existed at [Sys.file_exists] check but read failed (TOCTOU
+       race, permission change, partial write mid-rename),
+   (2) file read OK but JSON was malformed.
+   Operators tracing why [/api/v1/sidecar/status] reports stale state
+   need to tell these apart from a genuinely absent record. Log-only —
+   [None] return preserved so caller contracts are unchanged. *)
 let read_desired_record ~base_path id =
   let path = sidecar_desired_path ~base_path id in
   if not (Sys.file_exists path)
   then None
   else (
     try read_file path |> Yojson.Safe.from_string |> desired_record_of_json with
-    | Sys_error _ | Yojson.Json_error _ -> None)
+    | Sys_error msg ->
+      Log.Server.warn
+        "[sidecar/desired] file_exists OK but read failed at %s: %s"
+        path
+        msg;
+      None
+    | Yojson.Json_error msg ->
+      Log.Server.warn "[sidecar/desired] malformed JSON at %s: %s" path msg;
+      None)
 ;;
 
 let read_attempt_record ~base_path id =
@@ -211,7 +227,15 @@ let read_attempt_record ~base_path id =
   then None
   else (
     try read_file path |> Yojson.Safe.from_string |> attempt_record_of_json with
-    | Sys_error _ | Yojson.Json_error _ -> None)
+    | Sys_error msg ->
+      Log.Server.warn
+        "[sidecar/attempt] file_exists OK but read failed at %s: %s"
+        path
+        msg;
+      None
+    | Yojson.Json_error msg ->
+      Log.Server.warn "[sidecar/attempt] malformed JSON at %s: %s" path msg;
+      None)
 ;;
 
 let isoish_now () =
@@ -522,8 +546,16 @@ let read_status_json ~base_path id =
     then (
       let body = read_file path in
       let parsed =
+        (* Mirror read_desired_record/read_attempt_record: surface
+           malformed JSON instead of silently collapsing to [`Null] in
+           the response payload. *)
         try Some (Yojson.Safe.from_string body) with
-        | Yojson.Json_error _ -> None
+        | Yojson.Json_error msg ->
+          Log.Server.warn
+            "[sidecar/status] malformed JSON at %s: %s"
+            path
+            msg;
+          None
       in
       `Assoc
         [ "ok", `Bool true


### PR DESCRIPTION
## Summary

Three sidecar record readers in `lib/server/server_routes_http_routes_sidecar.ml` collapsed `Sys_error _` and `Yojson.Json_error _` into `None` / ` `Null` without any log:

| Site | Function | Lines | Before | After |
|---|---|---|---|---|
| 1 | `read_desired_record` | 199-215 | `\| Sys_error _ \| Yojson.Json_error _ -> None` | distinguishes both branches with `Log.Server.warn` + path + message |
| 2 | `read_attempt_record` | 208-215 | same | same |
| 3 | sidecar `/status` reader | ~544-557 | `\| Yojson.Json_error _ -> None` (`Null` in response) | logs malformed JSON case |

## Why this matches the user's vision

Operators tracing why `/api/v1/sidecar/status` reports stale state cannot today tell apart:

1. **Genuinely absent record** — file_exists returned false. Expected.
2. **TOCTOU race / permission change / mid-write partial** — file_exists OK at line N, then `read_file` at line N+1 throws `Sys_error`. The atomic-write at line ~260 (`.tmp + rename`) makes this rare-but-real under load.
3. **Malformed JSON** — file read OK but body unparseable (schema drift, mid-write read before atomic rename, manual tampering).

Today all three look identical to a caller. PR makes (2) and (3) observable.

## Why log-only, not return type change

This is the same scope-discipline as #16712 (cascade_http_probe transport failures) and #16720 (dashboard SSE hydration warn):
- Caller surface preserved (`None` / ` `Null` unchanged) → no upstream contract drift
- `Log.Server.warn` is the standard sink the dashboard/operators already monitor
- A typed `Result.t` migration is the structural fix but requires the 5-6 caller sites to handle the error variant — out of scope for one iter

## Cancelled-safety

`Eio.Cancel.Cancelled` is not caught by either `Sys_error _` or `Yojson.Json_error _` patterns (it's an entirely different exception family), so cancellation propagation is unchanged. No `Cancel_safe.protect` wrapper needed at these sites.

## Verification

- `dune build --root . @check` EXIT=0 from worktree.
- +35/-3 LoC, single file modification.
- No changes to function signatures.
- 0 callers affected.

## Iter#56 context

Follow-up to Iter#54 (#16712) and Iter#55 (#16720) — same "silent failure → observable warn" pattern at a third site cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>