### PR TITLE
refactor(keeper_registry): extract record_error dedup logic (godfile decomp)

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -630,7 +630,7 @@ let record_keeper_crashed
       keeper_name
       (Keeper_state_machine.Fiber_terminated { outcome; provider_id = None; http_status = None });
     Keeper_registry.record_crash ~base_path keeper_name (Time_compat.now ()) reason;
-    Keeper_registry.record_error ~base_path keeper_name reason;
+    Keeper_registry_error_recording.record ~base_path keeper_name reason;
     publish_keeper_phase_lifecycle
       ~phase:Keeper_state_machine.Crashed
       ~keeper_name

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -453,57 +453,17 @@ let record_restart ~base_path name =
     { e with restart_count = e.restart_count + 1; last_restart_ts = Time_compat.now () })
 ;;
 
-let record_error ~base_path ?details name err =
-  let details =
-    match details with
-    | Some _ as details -> details
-    | None ->
-      Keeper_sandbox_runtime.docker_mount_failure_details
-        ~base_path_hash:(Keeper_sandbox_runtime.base_path_hash base_path)
-        ~keeper_name:name
-        ~output:err
-        ()
-  in
-  (* MASC/OAS Error-Warn Reduction Goal §P6: same (keeper, error) was
-     emitting at ERROR up to 96× in 30-min slices on production
-     (system_log_2026-05-16 sample, 299 events/day; verifier
-     sandbox_docker ~48%). First occurrence keeps ERROR — operators
-     must still see *new* failure modes. Repeated occurrences demote
-     to DEBUG and bump a Prometheus counter so the dashboard still
-     reflects the retry rate without paging operators.
-
-     WORKAROUND-CARRYOVER: this is symptom suppression. The root fix
-     is the underlying error source (verifier sandbox docker exec,
-     path-syntax guard, stale-turn timeouts). Tracked as separate PRs
-     keyed on the [Keeper_recording_error_state.error_kind] buckets. *)
-  let kind, outcome =
-    Keeper_recording_error_state.classify_outcome ~keeper:name ~error:err
-  in
-  let kind_label = Keeper_recording_error_state.error_kind_to_string kind in
-  (match outcome with
-   | `First ->
-     (match details with
-      | Some details ->
-        Log.Keeper.emit
-          Log.Error
-          ~details
-          (Printf.sprintf "registry: recording error name=%s error=%s" name err)
-      | None ->
-        Log.Keeper.error "registry: recording error name=%s error=%s" name err)
-   | `Repeated count ->
-     Prometheus.inc_counter
-       Keeper_metrics.metric_keeper_recording_error_dedup
-       ~labels:[ "keeper", name; "error_kind", kind_label ]
-       ();
-     Log.Keeper.debug
-       "registry: recording error name=%s error=%s (repeated×%d, kind=%s, demoted)"
-       name
-       err
-       count
-       kind_label);
-  Keeper_fd_pressure.note_if_fd_exhaustion ~site:"keeper_registry.record_error" err;
+(* CAS write helper for the [last_error] slot, exposed for
+   Keeper_registry_error_recording.record (which holds the Log + Prometheus
+   dedup logic). *)
+let set_last_error_entry ~base_path ~name err =
   update_entry ~base_path name (fun e -> { e with last_error = Some err })
 ;;
+
+(* record_error (MASC/OAS Error-Warn Reduction Goal §P6 dedup logic) moved to
+   Keeper_registry_error_recording. No alias here — it would create a cycle
+   via [Keeper_registry.set_last_error_entry], so callers call the new
+   module directly. *)
 
 let clear_error ~base_path name =
   update_entry ~base_path name (fun e -> { e with last_error = None })

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -84,13 +84,12 @@ val update_meta : base_path:string -> string -> keeper_meta -> unit
 (** Record a restart. Increments restart_count and updates last_restart_ts. *)
 val record_restart : base_path:string -> string -> unit
 
-(** Record an error message. *)
-val record_error :
-  base_path:string ->
-  ?details:Yojson.Safe.t ->
-  string ->
-  string ->
-  unit
+(* [record_error] moved to [Keeper_registry_error_recording.record]. *)
+
+(** CAS-write the [last_error] slot for keeper [name]. Exposed for
+    [Keeper_registry_error_recording.record] which holds the dedup
+    logic. *)
+val set_last_error_entry : base_path:string -> name:string -> string -> unit
 
 (** Clear the last recorded error for a keeper. *)
 val clear_error : base_path:string -> string -> unit

--- a/lib/keeper/keeper_registry_error_recording.ml
+++ b/lib/keeper/keeper_registry_error_recording.ml
@@ -1,0 +1,60 @@
+(** Keeper error recording (Log + Prometheus dedup + last_error persistence).
+
+    Extracted from keeper_registry.ml (lines 456-506) as part of the
+    godfile decomp campaign. The MASC/OAS Error-Warn Reduction Goal §P6
+    deduplication logic + first/repeated emit policy lives here; the
+    final CAS write to [last_error] goes through
+    [Keeper_registry.set_last_error_entry] so this module does not need
+    to know about the central Atomic. *)
+
+let record ~base_path ?details name err =
+  let details =
+    match details with
+    | Some _ as details -> details
+    | None ->
+      Keeper_sandbox_runtime.docker_mount_failure_details
+        ~base_path_hash:(Keeper_sandbox_runtime.base_path_hash base_path)
+        ~keeper_name:name
+        ~output:err
+        ()
+  in
+  (* MASC/OAS Error-Warn Reduction Goal §P6: same (keeper, error) was
+     emitting at ERROR up to 96× in 30-min slices on production
+     (system_log_2026-05-16 sample, 299 events/day; verifier
+     sandbox_docker ~48%). First occurrence keeps ERROR — operators
+     must still see *new* failure modes. Repeated occurrences demote
+     to DEBUG and bump a Prometheus counter so the dashboard still
+     reflects the retry rate without paging operators.
+
+     WORKAROUND-CARRYOVER: this is symptom suppression. The root fix
+     is the underlying error source (verifier sandbox docker exec,
+     path-syntax guard, stale-turn timeouts). Tracked as separate PRs
+     keyed on the [Keeper_recording_error_state.error_kind] buckets. *)
+  let kind, outcome =
+    Keeper_recording_error_state.classify_outcome ~keeper:name ~error:err
+  in
+  let kind_label = Keeper_recording_error_state.error_kind_to_string kind in
+  (match outcome with
+   | `First ->
+     (match details with
+      | Some details ->
+        Log.Keeper.emit
+          Log.Error
+          ~details
+          (Printf.sprintf "registry: recording error name=%s error=%s" name err)
+      | None ->
+        Log.Keeper.error "registry: recording error name=%s error=%s" name err)
+   | `Repeated count ->
+     Prometheus.inc_counter
+       Keeper_metrics.metric_keeper_recording_error_dedup
+       ~labels:[ "keeper", name; "error_kind", kind_label ]
+       ();
+     Log.Keeper.debug
+       "registry: recording error name=%s error=%s (repeated×%d, kind=%s, demoted)"
+       name
+       err
+       count
+       kind_label);
+  Keeper_fd_pressure.note_if_fd_exhaustion ~site:"keeper_registry.record_error" err;
+  Keeper_registry.set_last_error_entry ~base_path ~name err
+;;

--- a/lib/keeper/keeper_registry_error_recording.mli
+++ b/lib/keeper/keeper_registry_error_recording.mli
@@ -1,0 +1,12 @@
+(** Keeper error recording: log + Prometheus dedup + last_error persistence. *)
+
+(** Record [err] on keeper [name].
+    - First occurrence emits at ERROR (with [?details] sandbox context).
+    - Repeated occurrences demote to DEBUG and bump
+      [metric_keeper_recording_error_dedup] (label [error_kind]).
+    - Also runs [Keeper_fd_pressure.note_if_fd_exhaustion] so an
+      [EMFILE/ENFILE] burst still surfaces on the fd-pressure track.
+    - Finally writes [last_error = Some err] through
+      [Keeper_registry.set_last_error_entry] (CAS retry). *)
+val record :
+  base_path:string -> ?details:Yojson.Safe.t -> string -> string -> unit

--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -248,7 +248,7 @@ let start_managed_container
                       Printf.sprintf "docker_managed_container_start_failed: %s"
                         (Worker_dev_tools.truncate_for_log out)
                     in
-                    Keeper_registry.record_error
+                    Keeper_registry_error_recording.record
                       ~base_path:config.base_path meta.name message;
                     Error message))
     | Error err -> Error err

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -116,7 +116,7 @@ let record_docker_exec_failure
       ~output
       ()
   in
-  Keeper_registry.record_error ?details ~base_path:config.base_path meta.name message
+  Keeper_registry_error_recording.record ?details ~base_path:config.base_path meta.name message
 ;;
 
 let path_exists path =
@@ -1029,7 +1029,7 @@ let run_docker_shell_command_with_status_internal
     | _ -> Env_config_keeper.KeeperSandbox.docker_image ()
   in
   let sandbox_error ?details message =
-    Keeper_registry.record_error ?details ~base_path:config.base_path meta.name message;
+    Keeper_registry_error_recording.record ?details ~base_path:config.base_path meta.name message;
     Error message
   in
   if String.trim image = ""
@@ -1393,7 +1393,7 @@ let run_docker_with_git_bash
     | _ -> Env_config_keeper.KeeperSandbox.docker_image ()
   in
   let sandbox_error_json message =
-    Keeper_registry.record_error ~base_path:config.base_path meta.name message;
+    Keeper_registry_error_recording.record ~base_path:config.base_path meta.name message;
     error_json message
   in
   if String.trim image = ""
@@ -1489,7 +1489,7 @@ let run_docker_hardened_bash
     | _ -> Env_config_keeper.KeeperSandbox.docker_image ()
   in
   let sandbox_error_json message =
-    Keeper_registry.record_error ~base_path:config.base_path meta.name message;
+    Keeper_registry_error_recording.record ~base_path:config.base_path meta.name message;
     error_json message
   in
   if String.trim image = ""

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -355,7 +355,7 @@ let launch_supervised_fiber
                ~ts
                ~reason
                ~restart_count:rc;
-             Keeper_registry.record_error ~base_path meta.name reason;
+             Keeper_registry_error_recording.record ~base_path meta.name reason;
              if resolve_done (`Crashed reason)
              then
                publish_phase_lifecycle
@@ -465,7 +465,7 @@ let launch_supervised_fiber
                   ~ts
                   ~reason
                   ~restart_count:rc;
-                Keeper_registry.record_error ~base_path meta.name reason;
+                Keeper_registry_error_recording.record ~base_path meta.name reason;
 	                Keeper_registry.dispatch_event_unit
 	                  ~base_path
 	                  meta.name
@@ -1416,7 +1416,7 @@ let sweep_and_recover (ctx : _ context) =
 	           (Keeper_state_machine.Fiber_terminated { outcome; provider_id = None; http_status = None }));
       let ts = Time_compat.now () in
       Keeper_registry.record_crash ~base_path entry.name ts msg;
-      Keeper_registry.record_error ~base_path entry.name msg;
+      Keeper_registry_error_recording.record ~base_path entry.name msg;
       match Keeper_registry.get ~base_path entry.name with
       | Some updated -> queue_crashed_entry updated msg
       | None -> ())

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -74,7 +74,7 @@ let report_keeper_cycle_side_effect_issue
   : unit
   =
   let message = Printf.sprintf "keeper cycle %s failed: %s" side_effect detail in
-  Keeper_registry.record_error ~base_path:config.base_path keeper_name message;
+  Keeper_registry_error_recording.record ~base_path:config.base_path keeper_name message;
   Prometheus.inc_counter
     Keeper_metrics.metric_keeper_dispatch_event_failures
     ~labels:[ "keeper", keeper_name; "site", side_effect_metric_label side_effect ]

--- a/test/test_dashboard.ml
+++ b/test/test_dashboard.ml
@@ -295,7 +295,7 @@ let test_keepers_section_with_error_truncated () =
   let long_err =
     "this is a long error message that should exceed the default display length of 35 chars and therefore be truncated with an ellipsis"
   in
-  Lib.Keeper_registry.record_error ~base_path:dir "echo" long_err;
+  Lib.Keeper_registry_error_recording.record ~base_path:dir "echo" long_err;
   let now = Unix.gettimeofday () in
   let section = Lib.Dashboard.keepers_section now in
   let line = List.hd section.content in

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -80,7 +80,7 @@ let test_crash_heartbeat_failure () =
   ignore (R.dispatch_event ~base_path:bp "hb-crash"
     (KSM.Fiber_terminated { outcome = "heartbeat_failure"; provider_id = None; http_status = None }));
   R.record_crash ~base_path:bp "hb-crash" 1000.0 reason_str;
-  R.record_error ~base_path:bp "hb-crash" reason_str;
+  Masc_mcp.Keeper_registry_error_recording.record ~base_path:bp "hb-crash" reason_str;
   Eio.Promise.resolve reg.done_r (`Crashed reason_str);
   (* Assert: registry state *)
   (match R.get ~base_path:bp "hb-crash" with
@@ -112,7 +112,7 @@ let test_crash_generic_exception () =
   ignore (R.dispatch_event ~base_path:bp "exn-crash"
     (KSM.Fiber_terminated { outcome = "exception"; provider_id = None; http_status = None }));
   R.record_crash ~base_path:bp "exn-crash" 1001.0 reason_str;
-  R.record_error ~base_path:bp "exn-crash" reason_str;
+  Masc_mcp.Keeper_registry_error_recording.record ~base_path:bp "exn-crash" reason_str;
   Eio.Promise.resolve reg.done_r (`Crashed reason_str);
   match R.get ~base_path:bp "exn-crash" with
   | None -> fail "expected exn-crash"
@@ -133,7 +133,7 @@ let test_crash_fiber_unresolved () =
   let reason_str = R.failure_reason_to_string fr in
   R.set_failure_reason ~base_path:bp "unresolved" (Some fr);
   R.record_crash ~base_path:bp "unresolved" 1002.0 reason_str;
-  R.record_error ~base_path:bp "unresolved" reason_str;
+  Masc_mcp.Keeper_registry_error_recording.record ~base_path:bp "unresolved" reason_str;
   ignore (R.dispatch_event ~base_path:bp "unresolved"
     (KSM.Fiber_terminated { outcome = "unresolved"; provider_id = None; http_status = None }));
   Eio.Promise.resolve reg.done_r (`Crashed reason_str);
@@ -387,7 +387,7 @@ let test_crash_turn_failures () =
   ignore (R.dispatch_event ~base_path:bp "turn-crash"
     (KSM.Fiber_terminated { outcome = "turn failure"; provider_id = None; http_status = None }));
   R.record_crash ~base_path:bp "turn-crash" 2000.0 reason_str;
-  R.record_error ~base_path:bp "turn-crash" reason_str;
+  Masc_mcp.Keeper_registry_error_recording.record ~base_path:bp "turn-crash" reason_str;
   Eio.Promise.resolve reg.done_r (`Crashed reason_str);
   match R.get ~base_path:bp "turn-crash" with
   | None -> fail "expected turn-crash"

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -1054,7 +1054,7 @@ let test_record_error () =
   let _entry = R.register ~base_path:bp "k6" (make_meta "k6") in
   check bool "no error initially" true
     (Option.is_none (Option.bind (R.get ~base_path:bp "k6") (fun e -> e.last_error)));
-  R.record_error ~base_path:bp "k6" "something broke";
+  Masc_mcp.Keeper_registry_error_recording.record ~base_path:bp "k6" "something broke";
   match R.get ~base_path:bp "k6" with
   | None -> fail "expected k6"
   | Some e ->
@@ -1063,7 +1063,7 @@ let test_record_error () =
 let test_clear_error () =
   R.clear ();
   let _entry = R.register ~base_path:bp "k6-clear" (make_meta "k6-clear") in
-  R.record_error ~base_path:bp "k6-clear" "stale error";
+  Masc_mcp.Keeper_registry_error_recording.record ~base_path:bp "k6-clear" "stale error";
   R.clear_error ~base_path:bp "k6-clear";
   match R.get ~base_path:bp "k6-clear" with
   | None -> fail "expected k6-clear"
@@ -1080,7 +1080,7 @@ let test_noop_on_missing () =
   R.update_meta ~base_path:bp "ghost" (make_meta "ghost");
   ignore (R.dispatch_event ~base_path:bp "ghost" KSM.Operator_pause);
   R.record_restart ~base_path:bp "ghost";
-  R.record_error ~base_path:bp "ghost" "err";
+  Masc_mcp.Keeper_registry_error_recording.record ~base_path:bp "ghost" "err";
   R.clear_error ~base_path:bp "ghost";
   R.record_crash ~base_path:bp "ghost" 0.0 "crash";
   R.set_grpc_close ~base_path:bp "ghost" None;


### PR DESCRIPTION
## Summary

Ninth keeper_registry godfile decomp PR. Extracts the largest single function from keeper_registry — \`record_error\` (50 LoC, MASC/OAS Error-Warn Reduction Goal §P6 dedup logic).

### 변경 요약

\`record_error\` → \`Keeper_registry_error_recording.record\`:

- First/Repeated outcome classification (\`Keeper_recording_error_state.classify_outcome\`)
- ERROR emit (first) / DEBUG demote (repeated) + Prometheus dedup counter
- \`Keeper_fd_pressure.note_if_fd_exhaustion\` hook
- Final \`last_error\` CAS write via new public helper

### Cycle 회피

\`Keeper_registry_error_recording\`이 \`Keeper_registry\`로 다시 (last_error CAS) 호출해야 하므로 alias re-export 패턴 사용 시 cycle 발생. 대신:

1. **\`Keeper_registry.set_last_error_entry\`** 작은 public API 1개 추가 (CAS-bound write 경로 노출)
2. \`Keeper_registry_error_recording.record\` 호출자 직접 마이그레이션 (12 사이트)
3. \`Keeper_registry.record_error\` 정의 제거 (alias 만들면 cycle)

### 12 caller 갱신

- \`lib/keeper/keeper_turn_helpers.ml\`
- \`lib/keeper/keeper_supervisor.ml\` (3 사이트)
- \`lib/keeper/keeper_sandbox_control.ml\`
- \`lib/keeper/keeper_shell_docker.ml\` (4 사이트)
- \`lib/keeper/keeper_keepalive.ml\`
- \`test/test_dashboard.ml\` (Lib alias 보존)
- \`test/test_heartbeat_integration.ml\` (R alias → Masc_mcp.Keeper_registry_error_recording)
- \`test/test_keeper_registry.ml\` (R alias → 동)

### 동작 보존
- 동일 First/Repeated 분기 + 동일 emit level
- 동일 Prometheus 카운터 (\`metric_keeper_recording_error_dedup\` label=keeper, error_kind)
- 동일 fd-pressure note
- 동일 final last_error 슬롯 CAS write

### LoC 효과

| | Before | After | Δ |
|--|--------|-------|---|
| \`lib/keeper/keeper_registry.ml\` | 1676 | 1636 | **−40 net** (50 LoC moved, +10 LoC set_last_error_entry helper) |
| 신규 \`keeper_registry_error_recording.ml\` | — | 60 | +60 |
| 신규 \`keeper_registry_error_recording.mli\` | — | 12 | +12 |

### 검증
- \`dune build --root . @check\` exit 0
- \`test/test_keeper_registry.exe\` 109 tests PASS

### Scope guard
- credential / identity / operator-control / sandbox / dashboard credential / hooks / workflow 영역 무관
- \`RFC-WAIVED: error-recording helper extraction, godfile decomp follow-up to RFC-0136 stack\`

## Test plan
- [x] dune @check green
- [x] keeper_registry alcotest (109) PASS
- [ ] 사용자 라벨 dispatch

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>