### PR TITLE
fix(dashboard): collapse `agentBand` dead arms + unknown→`'attention'`

### DIFF
--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -295,16 +295,29 @@ function agentBand(status: string | undefined | null): RuntimeBand {
   const parsed = parseAgentStatus(status)
   if (parsed === 'inactive' || parsed === 'offline') return 'offline'
   if (parsed != null) return 'active'
-  // Wire-format tokens outside the declared AgentStatus union. The
-  // OCaml backend agent_status sum (lib/types/types_core.ml:42) emits
-  // only Active|Busy|Listening|Inactive; 'dead' and 'left' here are
-  // legacy defensive arms from before the typed union was defined
-  // (predates RFC-0139). Kept as documented compat until a wire-format
-  // audit confirms zero emission, then collapse into the parsed-null
-  // branch below.
-  const lower = status.trim().toLowerCase()
-  if (lower === 'dead' || lower === 'left') return 'offline'
-  return 'active'
+  // Wire-format tokens outside the declared AgentStatus union
+  // (`parseAgentStatus` returned null). The OCaml backend
+  // `agent_status` sum (lib/types/types_core.ml:42) emits only
+  // Active|Busy|Listening|Inactive, plus `dashboard_mission_agents.ml:206-207`
+  // adds `"offline" | "unknown"` via typed-union bypass.
+  //
+  // Wire-format audit 2026-05-20: `rg -n '"dead"|"left"' lib/` returned
+  // zero hits in the `agent.status` slot — `"dead"` belongs to
+  // `Fiber_dead`/`KH_dead`/`subsystem_health`, `"left"` belongs to
+  // `Span_left` (different axis vocabularies). Defensive arms for
+  // those tokens dropped.
+  //
+  // Unknown token surfaces as `'attention'` (not the prior `'active'`
+  // default). `"unknown"` is an emitted backend default
+  // (`dashboard_mission_agents.ml:207` `| None -> "unknown"`,
+  // `dashboard_execution_builders.ml:209` `~default:"unknown"`), so the
+  // previous `'active'` fallback silently absorbed operator-relevant
+  // ambiguity into a "running" badge. `'attention'` ("주의 필요 — 응답
+  // 지연, 오류, 복구, 승계 등으로 상태 확인이 필요합니다") preserves
+  // that signal. Software-development.md §"Unknown → Permissive
+  // Default" anti-pattern: unknown input must surface as a distinct
+  // state, not collapse into the happy-path default.
+  return 'attention'
 }
 
 function runtimeBandForAgent(


### PR DESCRIPTION
## 요약

`dashboard/src/lib/monitoring-runtime.ts:agentBand` 두 가지 정리:

1. **Dead defensive arm 제거** — `lower === 'dead' || lower === 'left'` → 'offline' 분기. 두 토큰 모두 backend `agent.status` 자리에 emit 0 (다른 axis 의 합법 vocab).
2. **Unknown → Permissive Default 정정** — `return 'active'` → `return 'attention'`. backend `"unknown"` emit 이 *실제* 사례.

## 배경

PR #16723 squash-merge 시점에 두번째 commit (agentBand cleanup) 이 *원격 도착 전* admin-merge cron 이 첫 commit (`isIdleTurnPhase`) 만 가져감 → orphan commit 발생 (memory: `feedback_post_merge_push_check_required.md` 패턴). 이번 PR 이 main 기반 새 worktree 에서 두 변경 통합.

## 변경 1 — Dead defensive arm

| 토큰 | 다른 axis 의 합법 위치 |
|---|---|
| `"dead"` | `lib/keeper/keeper_exec_status.ml:23,33` (Fiber_dead/KH_dead), `lib/subsystem_health.ml` (`alive \| dead`) |
| `"left"` | `lib/activity_graph/activity_graph_types.ml:75` (Span_left) |

audit: `rg -n '"dead"\|"left"' lib/` → agent.status slot 0 hit.

## 변경 2 — Unknown → `'attention'`

### 근거 (backend emit 사례)

`"unknown"` 토큰을 *실제로* emit 하는 backend:

- `lib/dashboard/dashboard_mission_agents.ml:207` — `| None -> "unknown"` (session 정보 없을 때)
- `lib/dashboard/dashboard_execution_builders.ml:209` — `string_field ~default:"unknown" "status" keeper`
- `lib/cdal_runtime_health.ml:380,382,385` — 여러 `Option.value ~default:"unknown"`

### 행동 변경

| status 입력 | before | after |
|---|---|---|
| `"active"`/`"busy"`/`"listening"`/`"idle"` | 'active' | 'active' (변경 없음) |
| `"inactive"`/`"offline"` | 'offline' | 'offline' (변경 없음) |
| `null`/empty/`undefined` | 'attention' | 'attention' (변경 없음) |
| `"unknown"` 또는 미정의 토큰 | **'active'** (silent absorb) | **'attention'** (operator-visible) |

`'attention'` BAND_META: "주의 필요 — 응답 지연, 오류, 복구, 승계 등으로 상태 확인이 필요합니다".

### 정합

`software-development.md` §"AI 코드 생성 안티패턴 #2 Unknown → Permissive Default":
> "Unknown 입력은 Error/None/Unknown 변형으로 처리. option 을 Some default 로 압축하지 않는다."

이 PR 이전엔 unknown wire token → 'active' (Some Permissive default). 변경 후 → 'attention' (운영자 시그널 보존). RFC-0139 `parseAgentStatus` (typed null-on-unknown) 의 의도가 final fallback 에서도 유지됨.

## 영향 범위

- 호출자 1: `dashboard/src/components/agent-roster.ts:428,537` → `runtimeBandMetaForAgent(agent, ...).key`
- agent-roster 의 wire 에 `"unknown"` 흐름 시: 이전 = '가동중' 카드 (false positive), 이후 = '주의 필요' 카드 (정확)
- typecheck clean, `monitoring-runtime.test.ts` 18/18 PASS, `agent-roster.test.ts` 15/15 PASS

## RFC 매칭

해당 subsystem 비포함. RFC 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)