### PR TITLE
fix(dashboard): replace axis-confused `keeper.status` crash check with typed `keeper.phase` (audit U1)

### DIFF
--- a/dashboard/src/components/status-tray.ts
+++ b/dashboard/src/components/status-tray.ts
@@ -169,8 +169,18 @@ function countKeeperAttention(keeperInput: readonly Keeper[]): number {
   return keeperInput.filter(keeper => {
     if (keeper.needs_attention) return true
     if (hasExecutionAttentionEvidence(keeper)) return true
-    const status = (keeper.status ?? '').toLowerCase()
-    return status.includes('crash') || status === 'dead' || status === 'zombie'
+    // Terminal/crashed lifecycle states. The previous version inspected
+    // `keeper.status` for `'crash' | 'dead' | 'zombie'`, but the
+    // backend `Keeper.status` emit (`patched_keeper_status` in
+    // `lib/server/server_dashboard_http_execution_surfaces.ml:424-432`)
+    // only ever produces `'offline' | 'busy' | 'active' | 'listening' | 'idle'`.
+    // None of those crashed-state tokens are emitted into the status
+    // slot — they belong to `Keeper.phase` (typed `KeeperPhase` union
+    // in `core.ts:879-892`), normalised by `toKeeperPhase` at the wire
+    // boundary. Comparing typed phase tokens here means crashed keepers
+    // actually get counted as attention rather than silently slipping
+    // past an axis-confused string match.
+    return keeper.phase === 'Crashed' || keeper.phase === 'Dead' || keeper.phase === 'Zombie'
   }).length
 }
 

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -142,9 +142,22 @@ function refineOfflineStatus(keeper: Keeper | null | undefined): string {
 
   // Heartbeat alive but agent offline — keepalive fiber is running.
   // Show actual phase instead of misleading "offline".
+  //
+  // `keeper.phase` carries the typed `KeeperPhase` PascalCase token
+  // (`dashboard/src/types/core.ts:879-892`), normalised by
+  // `toKeeperPhase` at the wire boundary. Lowercasing it here is for
+  // the display layer (`keeperDisplayStatus` callers expect lowercase
+  // status labels like `'idle' / 'unbooted' / 'stopped'`).
+  //
+  // Only `'offline'` is filtered — that is the `'Offline'.toLowerCase()`
+  // case we are refining away. The prior version also filtered
+  // `'inactive'`, but `KeeperPhase` does not contain that variant
+  // (audit: `keeper_state_machine.ml:21-34` `phase_to_string` emits
+  // only the 13 PascalCase phases, none of which lowercase to
+  // `'inactive'`), so the guard was dead defensive.
   if (keeper.last_heartbeat && isHeartbeatAlive(keeper.last_heartbeat)) {
     const phase = keeper.phase?.trim().toLowerCase()
-    if (phase && phase !== 'offline' && phase !== 'inactive') return phase
+    if (phase && phase !== 'offline') return phase
     return 'idle'
   }
 


### PR DESCRIPTION
## 요약

`status-tray.ts:countKeeperAttention` + `keeper-runtime-display.ts:refineOfflineStatus` 두 사이트의 *axis-confused* 또는 *dead defensive* 분기 정리.

## 변경 1 — `countKeeperAttention` typed `keeper.phase` compare

`keeper.status` 자리에 emit 된 적 없는 `'crash'`/`'dead'`/`'zombie'` 토큰을 찾고 있었음. backend `patched_keeper_status` 가 *그 자리에* 5개만 emit (`'offline' | 'busy' | 'active' | 'listening' | 'idle'`). 크래시 상태는 *다른 axis* (`Keeper.phase`, typed `KeeperPhase`) 에서 보냄. 결과 — 크래시된 keeper 가 *attention 카운트에서 silently 빠짐*.

`keeper.phase === 'Crashed' | 'Dead' | 'Zombie'` typed compare 로 교체 → **silent bug fix**.

| 자리 | SSOT | 합법 vocab |
|---|---|---|
| `keeper.status` | `lib/server/server_dashboard_http_execution_surfaces.ml:424-432` `patched_keeper_status` | `offline / busy / active / listening / idle` (5개) |
| `keeper.phase` | `lib/keeper/keeper_state_machine.ml:21-34` `phase_to_string` (lowercase) | 13개 — 합법 `crashed / dead / zombie` 포함 |
| frontend `KeeperPhase` typed enum | `dashboard/src/types/core.ts:879-892` | 13개 (PascalCase) — `'Crashed' \| 'Dead' \| 'Zombie'` 포함 |
| boundary normalizer | `dashboard/src/keeper-store-normalize.ts:94` `toKeeperPhase` | lowercase → PascalCase (13/13 tests PASS) |

### 행동 변경 (silent bug fix)

이전:
- `keeper.phase === 'Crashed'` 인 keeper 가 `needs_attention=false` 이고 `hasExecutionAttentionEvidence=false` 일 때 → status 의 lowercase 가 `'crash'` 등을 *포함할 수 없으므로* (backend emit 없음) → **attention 카운트에서 silently 제외**.

이후:
- 같은 조건 → `keeper.phase === 'Crashed'` 직접 검출 → **attention 카운트 포함** (정확한 의도).

## 변경 2 — `refineOfflineStatus` `'inactive'` dead arm 제거

`refineOfflineStatus` 가 `keeper.phase?.trim().toLowerCase()` 후 `phase !== 'offline' && phase !== 'inactive'` 검사. `KeeperPhase` 합법 vocab 13개 중 lowercase 가 `'inactive'` 되는 변형 *없음* → 이 가드는 production 에서 firing 한 적 없음 (pure dead defensive).

`'offline'` 분기 유지 — `'Offline'.toLowerCase()` 의 합법 case.

추가 주석으로 *왜 lowercase 변환이 의도된 동작* (display layer 가 lowercase 라벨 기대) 인지 명시.

## 영향 범위

- `status-tray.ts` 호출자 1: status-tray 의 attention 카운터/배지
- `keeper-runtime-display.ts` 호출자: `keeperDisplayStatus` → `mission-agent-cards`, `keeper-store-normalize` 등
- typecheck clean
- `status-tray.test.ts` 9/9 PASS
- `keeper-runtime-display.test.ts` 36/36 PASS

## audit 추적

`dashboard/.tmp/dashboard-ssot-ia-audit-2026-05-19.html` U1 (noun/verb 충돌) 의 추가 2-site. PR #16723 (`isIdleTurnPhase`, `agentBand`) + PR #16727 (`agentBand` unknown→attention) 의 후속.

## RFC 매칭

해당 subsystem 비포함. RFC 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)