### PR TITLE
fix(mcp_server_eio_execute): surface silent join-state read failures via warn

### DIFF
--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -75,8 +75,22 @@ let resolve_join_state ~room_initialized ~join_required ~agent_name ~base_path ~
            || try_candidate (Printf.sprintf "keeper-%s-agent" bundle.keeper_name))
       in
       match
+        (* Previously [Sys_error _ | Yojson.Json_error _ -> Ok false]
+           silently collapsed read-side failure modes from
+           [normalize_all_names] (missing agents file, malformed JSON)
+           into "not joined" — indistinguishable from a legitimate
+           [false] result. The MCP tool surface gates handlers on this
+           bool, so a silent false here is an unguarded negative cap.
+           [Cancelled] propagates unchanged. *)
         try join_via_aliases () with
-        | Sys_error _ | Yojson.Json_error _ -> Ok false
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | (Sys_error _ | Yojson.Json_error _) as exn ->
+          Log.Mcp.warn
+            "[resolve_join_state] alias lookup failed for %s: %s; treating \
+             as not-joined"
+            agent_name
+            (Printexc.to_string exn);
+          Ok false
       with
       | Ok joined -> joined
       | Error _ -> false))
@@ -420,8 +434,23 @@ let execute_tool_eio
               let is_joined =
                 if !room_init_cached
                 then (
+                  (* Same silent-false anti-pattern as resolve_join_state
+                     at line ~78. Auto-join gate hides the failure mode
+                     that distinguishes "agent really isn't joined yet"
+                     from "we can't read the join state". Invalid_argument
+                     is kept because [Coord.is_agent_joined] surface
+                     formerly raised it on malformed agent_name input;
+                     dropping it changes scope. *)
                   try Coord.is_agent_joined config ~agent_name with
-                  | Sys_error _ | Yojson.Json_error _ | Invalid_argument _ -> false)
+                  | Eio.Cancel.Cancelled _ as e -> raise e
+                  | (Sys_error _ | Yojson.Json_error _ | Invalid_argument _) as exn
+                    ->
+                    Log.Mcp.warn
+                      "[is_agent_joined gate] read failed for %s: %s; \
+                       treating as not-joined"
+                      agent_name
+                      (Printexc.to_string exn);
+                    false)
                 else false
               in
               if is_joined


### PR DESCRIPTION
## Summary

Two sites in the MCP tool execution surface collapsed read failures of the join-state into a silent ` false`, indistinguishable from a legitimate negative answer. Both gate downstream tool dispatch — a silent false here masquerades as a routing decision but is actually an *unguarded negative cap*.

| Site | Context | Default | Anti-pattern |
|---|---|---|---|
| line 78 (`resolve_join_state`) | exported via .mli, exercised by `test_mcp_server_eio_join_state` | `Ok false` | `Sys_error _ \| Yojson.Json_error _ -> Ok false` |
| line 423 (auto-join gate in `execute`) | inline in `execute` handler | `false` | `Sys_error _ \| Yojson.Json_error _ \| Invalid_argument _ -> false` |

Both come from filesystem I/O against the agents file. Missing file / malformed JSON should not look identical to "lookup confidently returned false".

## Why this matters operationally

`resolve_join_state` returning silent-false → tool handler thinks the agent isn't joined → downstream branches into the alternate path (e.g. auto-join, or reject) even though the *real* failure is "we couldn't read the join-state file". Operators tracking down "why is agent X spuriously auto-joining" today have no log trail at all.

## Cancelled-safety + Invalid_argument preserved

- Every catch arm now leads with `Eio.Cancel.Cancelled _ as e -> raise e` so cancellation isn't absorbed by the broad catch.
- `Invalid_argument _` is retained at site 2 because historic upstream surface raised it on malformed `agent_name` — dropping it changes scope. It now logs through the same warn path.

## Test surface

The 6 `test_mcp_server_eio_join_state` tests still pass — they assert on `bool` outcome, not log content:

```
join_state          1   resolve_join_state checks join-required tools.       [OK]
join_state          2   resolve_join_state skips unknown agent.              [OK]
join_state          3   resolve_join_state alias resolves to keeper.         [OK]
join_state          4   resolve_join_state unknown alias stays false.        [OK]
join_state          5   legacy persisted agent read only for ephemeral.      [OK]
Test Successful in 0.001s. 6 tests run.
```

## Out of scope (follow-up)

`lib/mcp_server_eio_execute_helpers.ml` contains a *byte-identical-modulo-comment* copy of `resolve_join_state` (line 36-77 in helpers vs line 41-83 in execute). The helpers version is **fully dead** — `rg "Mcp_server_eio_execute_helpers" lib/ test/ bin/` returns 0 hits. Removing the dead duplicate is a separate iter to keep scope tight.

## Verification

- `dune build --root . @check` EXIT=0.
- `dune runtest --root . test/test_mcp_server_eio_join_state.ml`: 6/6 PASS.
- +31/-2 LoC, single file.

## Iter#58 context

5-iter silent-failure series: #16712 (cascade probe transport) → #16720 (dashboard SSE hydration) → #16724 (sidecar route reads) → #16725 (7 tool_coord/tool_task safe_* wrappers) → this PR (MCP tool dispatch gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>