### PR TITLE
fix(telemetry): tool-call dedup success match exhaustive

### DIFF
--- a/lib/telemetry_unified.ml
+++ b/lib/telemetry_unified.ml
@@ -529,7 +529,8 @@ let same_tool_call_signature left right =
   &&
   (match left.success, right.success with
    | Some a, Some b -> Bool.equal a b
-   | _ -> true)
+   | None, None -> true
+   | Some _, None | None, Some _ -> false)
   && abs_float (left.ts -. right.ts) <= 5.0
 
 let suppress_shadow_agent_tool_events entries =


### PR DESCRIPTION
## Goal
RFC-0088 §3 \"Log Dedup\" workaround signature 제거. `lib/telemetry_unified.ml:526` 의 `same_tool_call_signature`에서 `_ -> true` catch-all로 인해 *success 상태가 한 쪽만 알려진 호출 쌍*이 silent dedup으로 누락되던 사이트.

## Changes
- `same_tool_call_signature` success 비교를 4-arm exhaustive match로 변경
  - `Some a, Some b` -> `Bool.equal a b`
  - `None, None` -> `true`
  - `Some _, None | None, Some _` -> `false` (distinct, do not dedup)

## Why
- catch-all `_ -> true`는 호출 정보가 부족할 때 *임의로 동일 판정* → `suppress_shadow_agent_tool_events`가 다른 호출을 동일 호출로 보고 drop
- RFC-0088 시그니처 §3 (Log Dedup/Demote 워크어라운드) 직격탄
- exhaustive match는 새 success 상태 추가 시 컴파일러가 누락 감지

## Surface impact
- 호출자: `suppress_shadow_agent_tool_events` (lib/telemetry_unified.ml:909) 단일 — 같은 파일 내부, 검색 응답 시점 dedup 경로
- 동작 방향: 보수적 (false-positive dedup 줄임, 새 drop 도입 안 함)

## Local validation
- `dune build --root . @check` PASS
- 추가 unit test 없음 — OCaml exhaustive match가 compiler-level soundness 보증

## Risk
- 의도되지 않은 dedup 손실로 인해 search response가 약간 *더 많은* shadow event를 포함할 수 있음 (false-positive dedup 제거 결과)
- 실측 fleet 영향 별도 측정 안 됨

## Self-review (best-programmer)
- [x] type-system 우회 없음 (Obj.magic, `_` 변환 없음)
- [x] catch-all 도입 없음 — 제거
- [x] silent failure 신규 도입 없음
- [x] caller 격리 (1곳)
- [x] commit message가 \"WHY\" 명시 (RFC-0088 시그니처 인용)

## Related
- audit context: lib/ silent failure 코드 스멜 감사 (2026-05-20), Tier B2