### PR TITLE
refactor(cascade_error_classify): drop sentinel Other_detail on decode failure

### DIFF
--- a/lib/cascade/cascade_error_classify.ml
+++ b/lib/cascade/cascade_error_classify.ml
@@ -434,20 +434,28 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
       | Some (`String "cascade_exhausted") -> (
           match string_opt_of_assoc "cascade_name" json with
           | Some cascade_name ->
-            let reason =
-              match List.assoc_opt "reason" (match json with `Assoc fields -> fields | _ -> []) with
+            (* If the reason payload does not round-trip through a typed
+               [cascade_exhaustion_reason] variant, the entire payload is
+               returned as [None] so the caller treats the SDK error as
+               opaque. Synthesizing a sentinel reason here would be
+               indistinguishable from a real cascade-reason value and
+               poison downstream typed pattern matches. *)
+            let reason_opt =
+              match List.assoc_opt "reason"
+                      (match json with `Assoc fields -> fields | _ -> []) with
               | Some json_val ->
-                  (match Keeper_types.cascade_exhaustion_reason_of_json json_val with
-                   | Some r -> r
-                   | None -> Other_detail "unknown_cascade_reason")
-              | None -> Other_detail "missing_reason_field"
+                  Keeper_types.cascade_exhaustion_reason_of_json json_val
+              | None -> None
             in
-            Some
-              (Cascade_exhausted
-                 {
-                   cascade_name = cascade_name_of_string cascade_name;
-                   reason;
-                 })
+            (match reason_opt with
+             | Some reason ->
+               Some
+                 (Cascade_exhausted
+                    {
+                      cascade_name = cascade_name_of_string cascade_name;
+                      reason;
+                    })
+             | None -> None)
           | None -> None)
       | Some (`String "resumable_cli_session") -> (
           match string_opt_of_assoc "cascade_name" json, string_opt_of_assoc "detail" json with

--- a/test/dune
+++ b/test/dune
@@ -120,6 +120,7 @@
   test_keeper_tool_selection_passive_streak
   test_keeper_health_probe
   test_oas_error_kind_counter
+  test_cascade_error_classify_decoder
   test_oas_empty_response_diagnostic
   test_board_author_identity_10297
   test_fsm_drift_counter
@@ -432,6 +433,7 @@
   test_keeper_tool_selection_passive_streak
   test_keeper_health_probe
   test_oas_error_kind_counter
+  test_cascade_error_classify_decoder
   test_oas_empty_response_diagnostic
   test_board_author_identity_10297
   test_fsm_drift_counter

--- a/test/test_cascade_error_classify_decoder.ml
+++ b/test/test_cascade_error_classify_decoder.ml
@@ -1,0 +1,187 @@
+(* test/test_cascade_error_classify_decoder.ml
+
+   Pins the typed-reason round-trip behavior of
+   [Cascade_error_classify.classify_masc_internal_error_of_string] so a
+   schema-drift payload (unknown reason tag or missing reason field)
+   returns [None] instead of synthesizing a sentinel
+   [Other_detail "unknown_cascade_reason"] / [Other_detail "missing_reason_field"]
+   that downstream consumers could not distinguish from a real
+   [Other_detail] cascade reason.
+
+   Closes the §R1 gap from the 2026-05-20 consolidated state report. *)
+
+module Classify = Masc_mcp.Cascade_error_classify
+module Keeper_types = Masc_mcp.Keeper_types
+
+let pp_internal_error fmt = function
+  | None -> Format.fprintf fmt "None"
+  | Some e ->
+    Format.fprintf fmt "Some(%s)" (Classify.kind_of_masc_internal_error e)
+
+let internal_error_testable =
+  Alcotest.testable pp_internal_error ( = )
+
+let wrap_masc_oas_error (payload : Yojson.Safe.t) : string =
+  "[masc_oas_error] " ^ Yojson.Safe.to_string payload
+
+(* --- positive round-trip cases --------------------------------------- *)
+
+let test_roundtrip_other_detail () =
+  (* [Other_detail msg] is a legitimate emitted variant for free-form
+     cascade reasons (e.g. "all providers tried").  It must still
+     decode losslessly even after the schema-drift hardening. *)
+  let payload =
+    `Assoc
+      [ ("kind", `String "cascade_exhausted")
+      ; ("cascade_name", `String "primary")
+      ; ( "reason"
+        , `Assoc
+            [ ("tag", `String "other_detail")
+            ; ("message", `String "all providers tried")
+            ] )
+      ]
+  in
+  let decoded =
+    Classify.classify_masc_internal_error_of_string (wrap_masc_oas_error payload)
+  in
+  match decoded with
+  | Some (Classify.Cascade_exhausted { cascade_name; reason }) ->
+    Alcotest.(check string)
+      "cascade name preserved"
+      "primary"
+      (Classify.cascade_name_to_string cascade_name);
+    (match reason with
+     | Keeper_types.Other_detail msg ->
+       Alcotest.(check string) "Other_detail payload preserved" "all providers tried" msg
+     | _ -> Alcotest.fail "expected Other_detail reason")
+  | _ -> Alcotest.fail "expected Cascade_exhausted"
+
+let test_roundtrip_structural_attempt_timeout () =
+  let payload =
+    `Assoc
+      [ ("kind", `String "cascade_exhausted")
+      ; ("cascade_name", `String "primary")
+      ; ( "reason"
+        , `Assoc
+            [ ("tag", `String "structural_attempt_timeout")
+            ; ("detail", `String "max_execution_time_s exceeded")
+            ] )
+      ]
+  in
+  let decoded =
+    Classify.classify_masc_internal_error_of_string (wrap_masc_oas_error payload)
+  in
+  match decoded with
+  | Some (Classify.Cascade_exhausted { reason; _ }) ->
+    (match reason with
+     | Keeper_types.Structural_attempt_timeout { detail } ->
+       Alcotest.(check string)
+         "Structural_attempt_timeout detail preserved"
+         "max_execution_time_s exceeded"
+         detail
+     | _ -> Alcotest.fail "expected Structural_attempt_timeout")
+  | _ -> Alcotest.fail "expected Cascade_exhausted"
+
+let test_roundtrip_bare_string_reason () =
+  (* Bare string reasons like "no_providers_available" decode through the
+     [`String _] arm of [cascade_exhaustion_reason_of_json]. *)
+  let payload =
+    `Assoc
+      [ ("kind", `String "cascade_exhausted")
+      ; ("cascade_name", `String "secondary")
+      ; ("reason", `String "no_providers_available")
+      ]
+  in
+  let decoded =
+    Classify.classify_masc_internal_error_of_string (wrap_masc_oas_error payload)
+  in
+  match decoded with
+  | Some (Classify.Cascade_exhausted { reason; _ }) ->
+    Alcotest.check
+      (Alcotest.testable
+         (fun fmt _ -> Format.fprintf fmt "reason")
+         ( = ))
+      "bare string reason decoded"
+      Keeper_types.No_providers_available
+      reason
+  | _ -> Alcotest.fail "expected Cascade_exhausted"
+
+(* --- schema-drift cases: must return None ---------------------------- *)
+
+let test_unknown_reason_tag_decodes_to_none () =
+  (* Emitter wrote a [tag] that the decoder does not know.  Previously
+     this synthesized [Other_detail "unknown_cascade_reason"].  After
+     the §R1 hardening the entire payload is opaque ([None]) so
+     downstream typed pattern matches cannot mistake a sentinel for a
+     real cascade reason. *)
+  let payload =
+    `Assoc
+      [ ("kind", `String "cascade_exhausted")
+      ; ("cascade_name", `String "primary")
+      ; ( "reason"
+        , `Assoc
+            [ ("tag", `String "future_reason_not_yet_known")
+            ; ("message", `String "drift")
+            ] )
+      ]
+  in
+  let decoded =
+    Classify.classify_masc_internal_error_of_string (wrap_masc_oas_error payload)
+  in
+  Alcotest.check internal_error_testable
+    "unknown reason tag → None (no sentinel synthesized)"
+    None decoded
+
+let test_missing_reason_field_decodes_to_none () =
+  let payload =
+    `Assoc
+      [ ("kind", `String "cascade_exhausted")
+      ; ("cascade_name", `String "primary")
+      ]
+  in
+  let decoded =
+    Classify.classify_masc_internal_error_of_string (wrap_masc_oas_error payload)
+  in
+  Alcotest.check internal_error_testable
+    "missing reason field → None (no sentinel synthesized)"
+    None decoded
+
+let test_malformed_reason_payload_decodes_to_none () =
+  (* "reason" is present but is an unexpected JSON shape (a bool). *)
+  let payload =
+    `Assoc
+      [ ("kind", `String "cascade_exhausted")
+      ; ("cascade_name", `String "primary")
+      ; ("reason", `Bool true)
+      ]
+  in
+  let decoded =
+    Classify.classify_masc_internal_error_of_string (wrap_masc_oas_error payload)
+  in
+  Alcotest.check internal_error_testable
+    "malformed reason payload → None (no sentinel synthesized)"
+    None decoded
+
+let () =
+  Alcotest.run "cascade_error_classify_decoder"
+    [ ( "round-trip"
+      , [ Alcotest.test_case "Other_detail" `Quick test_roundtrip_other_detail
+        ; Alcotest.test_case
+            "Structural_attempt_timeout" `Quick
+            test_roundtrip_structural_attempt_timeout
+        ; Alcotest.test_case
+            "bare string reason" `Quick test_roundtrip_bare_string_reason
+        ] )
+    ; ( "schema-drift → None"
+      , [ Alcotest.test_case
+            "unknown reason tag" `Quick test_unknown_reason_tag_decodes_to_none
+        ; Alcotest.test_case
+            "missing reason field"
+            `Quick
+            test_missing_reason_field_decodes_to_none
+        ; Alcotest.test_case
+            "malformed reason payload"
+            `Quick
+            test_malformed_reason_payload_decodes_to_none
+        ] )
+    ]


### PR DESCRIPTION
## Goal

`Cascade_error_classify.parse_masc_internal_error_json` 에서 `cascade_exhausted` 페이로드의 `reason` 필드 디코드가 실패할 때 합성하던 sentinel `Other_detail "unknown_cascade_reason"` / `"missing_reason_field"` 를 제거하고, 전체 페이로드를 `None` 으로 처리한다.

## Why

`Other_detail` 은 producer 가 free-form cascade 사유 (예: "all providers tried") 를 expose 할 때 쓰는 합법 variant 이다. 그러나 decoder 의 *parse-failure sentinel* 로 같은 variant 를 합성하면 downstream typed pattern match 가 schema-drift 와 real reason 을 구별할 수 없게 된다. Sentinel string 이 Prometheus label / operator surface 로 흘러가 잘못된 "cascade 사유" 통계를 만든다.

근본은 *parse-don't-validate*: round-trip 실패는 페이로드 전체를 opaque 처리한다. Caller (`classify_masc_internal_error` / `_of_string`) 는 이미 `None` 을 "구조화된 MASC 에러 아님" 으로 처리 중이므로 호출 측 행동은 변하지 않는다.

## What changes

- `lib/cascade/cascade_error_classify.ml` `parse_masc_internal_error_json` cascade_exhausted 분기
  - 이전: `match reason_of_json json with Some r -> r | None -> Other_detail "unknown_cascade_reason"` 를 합성
  - 이후: `reason_opt` 가 `None` 이면 전체 `Cascade_exhausted` 디코드를 `None` 으로 반환
- 새 catch-all `_ ->` arm 도입 없음
- 기존 `Other_detail` variant 자체는 그대로 (legitimate 사용처 — test 포함)

## Verification

Acceptance from ~/me/memory/masc-consolidated-state-and-roadmap-2026-05-20.html §6 R1:

```
$ rg "Other_detail" lib/cascade/cascade_error_classify.ml | wc -l
0
```

Tests (`test/test_cascade_error_classify_decoder.ml`, 6 cases):

1. round-trip Other_detail — legitimate variant 보존
2. round-trip Structural_attempt_timeout — typed variant 보존
3. round-trip bare-string reason — `String "no_providers_available"` decode
4. unknown reason tag → `None`
5. missing reason field → `None`
6. malformed reason payload (Bool) → `None`

전 6/6 PASS. 기존 `test_oas_error_kind_counter` 16/16 PASS (회귀 없음).

## Workaround Rejection Bar 적용

- §1 Counter-as-Fix: 아니다. sentinel 제거 (make-invisible-the-bug 가 아니라 stop-emitting-bug)
- §2 String/Substring 분류기 보강: 아니다. classifier 추가 없음, 합성 *제거*
- §3 N-of-M: 아니다. 단일 사이트
- §Cap/Cooldown/Dedup/Repair: 아니다

RFC-0088 (Counter-as-Fix, Active) 정신과 정합 — make-visible-without-fixing 패턴의 inverse.

## References

- Source plan: `~/me/memory/masc-consolidated-state-and-roadmap-2026-05-20.html` §6 R1, §7 Action 1
- Related: RFC-0088 Counter-as-Fix (Active)
- Co-Authored-By: Claude Opus 4.7