### PR TITLE
fix(dashboard): drop dead `lifecycleKey === 'inactive'` arm in keeperBand (audit U1)

### DIFF
--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -206,9 +206,20 @@ function keeperBand(
   // chain (`paused || phaseKey === 'Paused' || lifecycleKey === 'paused'`)
   // was one of four parallel paused checks that drifted independently.
   if (isKeeperPaused(keeper)) return 'paused'
+  // `lifecycleKey` is the return value of `keeperDisplayStatus`. Its
+  // reachable vocabulary is `'paused' | 'offline' | 'unbooted' | 'stopped'
+  // | 'idle' | 'busy' | 'active' | 'listening' | <lowercased phase>
+  // | 'unknown'` (see `keeper-runtime-display.ts:124-135` +
+  // `refineOfflineStatus:140-166`). `'inactive'` is never produced —
+  // when the wire-level `keeper.status` is `'inactive'`,
+  // `keeperDisplayStatus` routes through `refineOfflineStatus` which
+  // returns `'offline' | 'unbooted' | 'stopped' | 'idle' | <phase>`
+  // instead. Dead defensive arm removed accordingly. (The matching
+  // `'inactive'` arm in `keeperDisplayStatus`'s own match was also
+  // examined in PR #16728 — kept there as the entry guard since it
+  // gates the input-side normalization.)
   if (
     lifecycleKey === 'offline'
-    || lifecycleKey === 'inactive'
     || lifecycleKey === 'unbooted'
     || lifecycleKey === 'stopped'
     || OFFLINE_PHASES.has(phaseKey)


### PR DESCRIPTION
## 요약

`dashboard/src/lib/monitoring-runtime.ts:keeperBand` 의 `lifecycleKey === 'inactive'` 분기 제거 (dead defensive). `keeperDisplayStatus` 의 *output vocabulary* 에 `'inactive'` 가 없음.

## 근거 (lifecycleKey output vocabulary 측정)

`lifecycleKey = keeperDisplayStatus(keeper)` 의 반환은 다음 합집합:

| source | 반환 vocabulary |
|---|---|
| `keeper?.paused` 분기 | `'paused'` |
| `refineOfflineStatus` 분기 (input `'offline' \| 'inactive'`) | `'offline' \| 'unbooted' \| 'stopped' \| 'idle' \| <lowercase phase>` |
| keeper.status 직접 passthrough | `'offline' \| 'busy' \| 'active' \| 'listening' \| 'idle'` (backend `patched_keeper_status` 5-vocab) |
| empty / nullish fallback | `'unknown'` |

→ **`'inactive'` 는 결코 output 으로 나오지 않음**. `keeperDisplayStatus` 가 wire-level `'inactive'` 를 받으면 `refineOfflineStatus` 로 routing 해서 다른 값 (`'offline' / 'unbooted' / 'stopped' / 'idle' / <phase>`) 으로 변환.

`KeeperLifecycleState` typed union (`types/core.ts:532-540`) 에도 `'inactive'` 없음.

## 변경

`keeperBand` 의 4-가드 OR-chain → 3-가드:

```diff
 if (
   lifecycleKey === 'offline'
-  || lifecycleKey === 'inactive'
   || lifecycleKey === 'unbooted'
   || lifecycleKey === 'stopped'
   || OFFLINE_PHASES.has(phaseKey)
 ) {
   return 'offline'
 }
```

## 의도적으로 *유지* 한 것

`keeperDisplayStatus` 자체의 *input* boundary 에 있는 `'inactive'` 가드 (`keeper-runtime-display.ts:130`) 는 그대로 둠. 이건 wire-level normalize *입구* 이고, 이 PR 은 *그 normalizer 의 output 뒤에서* 다시 같은 토큰을 검사하던 redundant 가드만 제거.

## 영향 범위

- `keeperBand` 호출자: `summarizeKeeperMonitoring` (monitoring-runtime.ts), `agent-roster.ts` 등
- 행동 변경 없음 — dead arm 이라 production 에서 fire 한 적 없음
- typecheck clean
- `pnpm vitest run src/lib/monitoring-runtime` 18/18 PASS

## audit 추적

`dashboard/.tmp/dashboard-ssot-ia-audit-2026-05-19.html` U1 (noun/verb 충돌) 의 추가 1-site. PR sprint:

- #16723 (`isIdleTurnPhase`) MERGED
- #16727 (`agentBand` cleanup + Unknown→attention) Draft
- #16728 (`countKeeperAttention` typed phase + `refineOfflineStatus` inactive arm) Draft
- 이 PR (`keeperBand` lifecycle inactive arm) Draft

본 sprint 의 5번째 dead-arm cleanup.

## RFC 매칭

해당 subsystem 비포함. RFC 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)