### PR TITLE
fix(dashboard): promote silent catch-all failures to console.warn (4 sites)

### DIFF
--- a/dashboard/src/api/actions.ts
+++ b/dashboard/src/api/actions.ts
@@ -66,7 +66,10 @@ export async function fetchActivityGraph(
     return parseActivityGraphResponse(raw)
   } catch (err) {
     if (err instanceof ActionsActivitySchemaDriftError) throw err
-    console.debug('[activity] graph fetch failed', err instanceof Error ? err.message : err)
+    // Mirrors sse-store.ts §256: activity graph fetch failures cause the
+    // dashboard to show empty / stale activity data. Promote to warn so the
+    // operator sees the failure at default DevTools level.
+    console.warn('[activity] graph fetch failed', err instanceof Error ? err.message : err)
     throw err
   }
 }
@@ -86,7 +89,10 @@ export async function fetchSwimlane(
     return parseSwimlaneResponse(raw)
   } catch (err) {
     if (err instanceof ActionsActivitySchemaDriftError) throw err
-    console.debug('[activity] swimlane fetch failed', err instanceof Error ? err.message : err)
+    // Mirrors sse-store.ts §256: swimlane fetch failures cause the dashboard
+    // to show empty / stale swimlane data. Promote to warn so the operator
+    // sees the failure at default DevTools level.
+    console.warn('[activity] swimlane fetch failed', err instanceof Error ? err.message : err)
     throw err
   }
 }

--- a/dashboard/src/components/keeper-detail-state.ts
+++ b/dashboard/src/components/keeper-detail-state.ts
@@ -16,7 +16,10 @@ registerKeeperTurnRefresh((keeperName: string) => {
       void loadTrajectory(keeperName)
     })
     .catch(err => {
-      console.debug('[keeper] trajectory refresh unavailable', err instanceof Error ? err.message : '')
+      // Mirrors sse-store.ts §256: when the trajectory module fails to load,
+      // the keeper detail timeline goes stale silently. Promote to warn so
+      // operators see it without changing DevTools filter level.
+      console.warn('[keeper] trajectory refresh unavailable', err instanceof Error ? err.message : '')
     })
 })
 

--- a/dashboard/src/composite-signals.ts
+++ b/dashboard/src/composite-signals.ts
@@ -28,6 +28,9 @@ export function hydrateFleetCompositeSnapshot(payload: unknown): void {
       fleetCompositeSnapshot.value = parseFleetCompositeSnapshot(payload)
     })
     .catch(err => {
-      console.debug('[Composite] fleet snapshot hydration failed', err instanceof Error ? err.message : '')
+      // Mirrors sse-store.ts §256 rationale: hydration failures leave the UI
+      // showing stale composite data — operator-actionable, so warn (visible
+      // in default DevTools level) rather than debug (hidden).
+      console.warn('[Composite] fleet snapshot hydration failed', err instanceof Error ? err.message : '')
     })
 }


### PR DESCRIPTION
## Summary

Extends PR #16720 (sse-store hydration warns) by promoting 4 more silent catch-all failures to `console.warn` in `dashboard/src/`.

| File | Line | Before | After |
|---|---|---|---|
| `dashboard/src/composite-signals.ts` | 31 | `console.debug('[Composite] fleet snapshot hydration failed', …)` | `console.warn(…)` |
| `dashboard/src/components/keeper-detail-state.ts` | 19 | `console.debug('[keeper] trajectory refresh unavailable', …)` | `console.warn(…)` |
| `dashboard/src/api/actions.ts` | 69 | `console.debug('[activity] graph fetch failed', …)` | `console.warn(…)` |
| `dashboard/src/api/actions.ts` | 89 | `console.debug('[activity] swimlane fetch failed', …)` | `console.warn(…)` |

## Why warn (not debug)

Same rationale as `sse-store.ts` lines 252-258 (transport-health P2 fix): DevTools default level hides `debug`. These failures all leave the rendered UI in a stale state (composite snapshot frozen, keeper trajectory not refreshing, activity/swimlane panels empty) — operators need to see them without flipping the DevTools level. Each promoted call gets a comment referencing the sse-store rationale.

## Out of scope

Other `console.debug` / silent-catch candidates seen but not changed in this PR:

- `dashboard/src/sse.ts:233,244,246` — connection lifecycle breadcrumbs (not failures).
- `dashboard/src/namespace-truth-actions.ts:50,82` — warm-up state-machine breadcrumbs (planned retries, not failures).
- `dashboard/src/api/keeper.ts:155` — SSE frame parse skip in a streaming hot loop; partial frames are expected during normal stream framing.
- `dashboard/src/keeper-stream.ts:22` — intentional abort notice.
- `dashboard/src/sse-store.ts:321,534` — already audited in #16720 and intentionally left as `debug` (best-effort optional modules; sufficient single-shot signals elsewhere).
- Bare `} catch {}` sites in `dashboard/src/transports/*`, `dashboard/src/dashboard-ws*.ts`, `dashboard/src/main.ts` — transport / privacy / quota fallbacks where silent fall-through is the documented behavior (separate audit, larger surface).
- `dashboard/src/components/credential-settings/` and `dashboard/src/components/keeper-repo-mapping/` — subsystems under RFC, require RFC waiver (not touched).

## Verification

- `pnpm tsc --noEmit`: **skipped** — `dashboard/node_modules` not provisioned in this worktree (mechanical change, no type or signature touched).
- 4 sites, +16/-4 LoC, no control-flow / return-value / type changes.
- All changes are level promotion + rationale comment only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>