### PR TITLE
fix(institution, voice, coord-playground-cache): surface 3 silent-failure read sites via warn

### DIFF
--- a/lib/coord/playground_repo_cache.ml
+++ b/lib/coord/playground_repo_cache.ml
@@ -86,7 +86,14 @@ let update
           match Yojson.Safe.Util.member "repos" json with
           | `List repos -> repos
           | _ -> []
-        with Sys_error _ | Yojson.Json_error _ -> []
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | (Sys_error _ | Yojson.Json_error _) as exn ->
+          Log.Misc.warn
+            "[playground_repo_cache] existing cache read failed at %s: %s"
+            cache_path
+            (Printexc.to_string exn);
+          []
       in
       let updated =
         entry

--- a/lib/institution_eio.ml
+++ b/lib/institution_eio.ml
@@ -741,7 +741,12 @@ let load_and_format_for_welcome ~fs:_ (config : config) : string =
       let inst = institution_of_json json in
       format_for_welcome inst
     with
-    | Sys_error _ | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> ""
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | (Sys_error _ | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _) as exn ->
+      Log.Institution.warn
+        "[load_and_format_for_welcome] institution read failed: %s"
+        (Printexc.to_string exn);
+      ""
     | exn ->
       Log.Misc.error "Unexpected institution load error: %s" (Printexc.to_string exn);
       "")

--- a/lib/voice/voice_session_manager.ml
+++ b/lib/voice/voice_session_manager.ml
@@ -135,7 +135,14 @@ let load_session t agent_id =
       let content = Fs_compat.load_file filepath in
       let json = Yojson.Safe.from_string content in
       Some (session_of_json json)
-    with Sys_error _ | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | (Sys_error _ | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _) as exn ->
+      Log.Misc.warn
+        "[voice_session_manager.load_session] read failed for agent=%s: %s"
+        agent_id
+        (Printexc.to_string exn);
+      None
   end else
     None
 


### PR DESCRIPTION
## Summary

Three remaining `Sys_error _ | Yojson.Json_error _ [| Yojson.Safe.Util.Type_error _] -> default` sites collapsed read failure into a silent default. Unified to the canonical `Cancelled-safe → warn → default` shape mirroring #16724 / #16725 / #16729.

| File | Line | Default | Adjusted to |
|---|---|---|---|
| lib/institution_eio.ml | 744 | `""` | warn + `""` |
| lib/voice/voice_session_manager.ml | 138 | `None` | warn + `None` |
| lib/coord/playground_repo_cache.ml | 89 | `[]` | warn + `[]` |

## Cancelled-safety

Every `exn` arm now leads with `Eio.Cancel.Cancelled _ as e -> raise e` per RFC-0106.

## Verification

- `dune build --root . @check` EXIT=0 from worktree.
- +22/-3 LoC, 3 files.
- 0 caller surface change.

## Iter#60 context (parallel dispatch)

Part of 3-agent parallel sweep: lib/ OCaml + dashboard TypeScript + FSM catch-all hunt. Continues 6-iter silent-failure series #16712 → #16720 → #16724 → #16725 → #16729 → #16733.

RFC-WAIVED: not in credential/operator/sandbox subsystem

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>