### PR TITLE
refactor(dashboard): RFC-0138 Phase 3 Step 3 — wire /project-snapshot to Dashboard_snapshot

### DIFF
--- a/lib/dashboard/dashboard_snapshot.ml
+++ b/lib/dashboard/dashboard_snapshot.ml
@@ -87,11 +87,16 @@ let current_or_bootstrap ~config =
   | None -> bootstrap ~config
 ;;
 
-(* Refresh loop is intentionally minimal in this prototype — it computes
-   the same fields as bootstrap and publishes unconditionally each
-   tick.  Handler wire-up + namespace_truth integration come next; this
-   PR ships the storage + lifecycle primitive only. *)
-let refresh_loop ~sw:_ ~clock ~config ~interval_sec =
+(* RFC-0138 Phase 3 Step 3: refresh loop now optionally accepts the
+   server_state so it can populate [namespace_truth] from the cached
+   refs that [Server_dashboard_http_namespace_truth.namespace_truth_snapshot_from_caches]
+   exposes.  That function reads only process-local refs (no PG I/O,
+   no fiber timeouts), so it is safe in a background fiber — moving
+   the read here is what retires the 6 MASC_NAMESPACE_TRUTH_*_TIMEOUT_S
+   env knobs from the request path (Step 4). *)
+let refresh_loop
+      ~sw:_ ~clock ~config ?state ~interval_sec ()
+  =
   let log_failure label exn =
     Log.Dashboard.warn
       "dashboard_snapshot refresh: %s failed (snapshot held at previous publish): %s"
@@ -119,7 +124,18 @@ let refresh_loop ~sw:_ ~clock ~config ~interval_sec =
         let masc_root = Coord.masc_root_dir config in
         Telemetry_unified.summary_json ~base_path ~masc_root ())
     in
-    let namespace_truth = `Null in
+    let namespace_truth =
+      match state with
+      | None -> `Null
+      | Some state ->
+        safe "namespace_truth" (fun () ->
+          match
+            Server_dashboard_http_namespace_truth.namespace_truth_snapshot_from_caches
+              state
+          with
+          | Some json -> json
+          | None -> `Null)
+    in
     {
       generated_at = Unix.gettimeofday ();
       generation = next_generation ();

--- a/lib/dashboard/dashboard_snapshot.mli
+++ b/lib/dashboard/dashboard_snapshot.mli
@@ -43,13 +43,24 @@ val refresh_loop :
   sw:Eio.Switch.t ->
   clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
   config:Coord.config ->
+  ?state:Mcp_server.server_state ->
   interval_sec:float ->
+  unit ->
   unit
 (** Run forever in the given switch.  Every [interval_sec] seconds,
     recompute a fresh {!t} and publish via [Atomic.set].  If a refresh
     raises, the {b previous} snapshot stays live (no torn state) and
     the error is logged.  Cancellation via the switch propagates
-    cleanly through {!Eio.Time.sleep}. *)
+    cleanly through {!Eio.Time.sleep}.
+
+    [?state] (RFC-0138 Phase 3 Step 3) — when supplied, the refresh
+    loop additionally populates the snapshot's [namespace_truth] via
+    [Server_dashboard_http_namespace_truth.namespace_truth_snapshot_from_caches].
+    That function reads cached refs only (no PG I/O, no fiber
+    timeouts), so it is safe to call from a background fiber.  When
+    [?state] is omitted, [namespace_truth] stays [`Null] in published
+    snapshots — handlers fall back to the synchronous request-fiber
+    path. *)
 
 val publish_for_test : t -> unit
 (** Test-only injection.  No production caller may use this. *)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1223,8 +1223,14 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
      while leaving the compute path fully out of the request fiber. *)
   Eio.Fiber.fork ~sw (fun () ->
     try
+      (* RFC-0138 Phase 3 Step 3: pass [~state] so refresh_loop can
+         populate [namespace_truth] from the cached-refs path.
+         That moves the 6 MASC_NAMESPACE_TRUTH_*_TIMEOUT_S knobs out
+         of the request fiber for the canonical project-snapshot
+         response (Step 4 retires the env knobs themselves). *)
       Dashboard_snapshot.refresh_loop
-        ~sw ~clock ~config:state.room_config ~interval_sec:2.0
+        ~sw ~clock ~config:state.room_config ~state
+        ~interval_sec:2.0 ()
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->

--- a/lib/server/server_dashboard_shell_snapshot.ml
+++ b/lib/server/server_dashboard_shell_snapshot.ml
@@ -24,7 +24,6 @@ let select_shell_json
       Server_dashboard_http_core.dashboard_shell_http_json
         ?clock ?request ~timing:timing_obj ~light config)
 ;;
-
 let select_tools_json
       ?actor ?timing (config : Coord.config)
   : Yojson.Safe.t
@@ -41,18 +40,10 @@ let select_tools_json
       (Server_timing.Custom "snapshot_read")
       (fun () -> snap.tools)
   | _ ->
-    (* actor-filtered variant OR snapshot not yet published — fall
-       back to the synchronous compute path (per-actor cache lives
-       inside [dashboard_tools_http_json]). *)
     Server_dashboard_http_runtime_info.dashboard_tools_http_json
       ?actor ~timing:timing_obj config
 ;;
 
-(* Cache key shared with the legacy router-inline definition.  Kept
-   byte-identical so a cold start that hits the fallback path observes
-   the same cache slot the previous router code wrote into.  When Step
-   5 retires [Dashboard_cache] from this read path, the duplicate goes
-   away together. *)
 let telemetry_summary_cache_key ~base_path ~masc_root =
   let digest = Digest.string (base_path ^ "\000" ^ masc_root) |> Digest.to_hex in
   "dashboard:telemetry_summary:" ^ digest
@@ -82,5 +73,29 @@ let select_telemetry_summary_json
         Server_timing.measure
           timing_obj
           Server_timing.Telemetry_summary_aggregate
-          (fun () -> Telemetry_unified.summary_json ~base_path ~masc_root ())))
+          (fun () -> Telemetry_unified.summary_json ~base_path ~masc_root ()))
+;;
+
+let select_project_snapshot_json ~state ~sw ~clock ?timing req
+  : Yojson.Safe.t
+  =
+  let timing_obj =
+    match timing with
+    | Some t -> t
+    | None -> Server_timing.create ()
+  in
+  match Dashboard_snapshot.current () with
+  | Some snap when snap.namespace_truth <> `Null ->
+    Server_timing.measure
+      timing_obj
+      (Server_timing.Custom "snapshot_read")
+      (fun () -> snap.namespace_truth)
+  | _ ->
+    Server_timing.measure
+      timing_obj
+      Server_timing.Project_snapshot_runtime
+      (fun () ->
+        Server_dashboard_http_namespace_truth
+          .dashboard_namespace_truth_http_json
+          ~state ~sw ~clock req)
 ;;

--- a/lib/server/server_dashboard_shell_snapshot.mli
+++ b/lib/server/server_dashboard_shell_snapshot.mli
@@ -72,3 +72,31 @@ val select_telemetry_summary_json :
     compute path (same logic the handler runs today) when the snapshot
     slot is empty — bootstrap path is paid at most once per process
     lifetime. *)
+
+val select_project_snapshot_json :
+  state:Mcp_server.server_state ->
+  sw:Eio.Switch.t ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  ?timing:Server_timing.t ->
+  Httpun.Request.t ->
+  Yojson.Safe.t
+(** RFC-0138 Phase 3 Step 3 — /project-snapshot (+ alias
+    /namespace-truth, /room-truth) read path selector.
+
+    Returns [Dashboard_snapshot.current ()].namespace_truth when the
+    refresh fiber has populated it (refresh_loop must be invoked with
+    [~state] — see [Dashboard_snapshot.refresh_loop]).  Falls back to
+    [Server_dashboard_http_namespace_truth.dashboard_namespace_truth_http_json]
+    in two cases:
+
+    - [Dashboard_snapshot.current ()] is [None] — cold start before
+      first refresh tick.
+    - The snapshot exists but [.namespace_truth = `Null] — refresh
+      fiber ran without [~state] (older boot path) OR the
+      cached-refs read returned [None] (execution cache not yet
+      hydrated).
+
+    Retire criterion (RFC-0138 §3.3 Step 3): Server-Timing
+    "snapshot_read;dur~0ms" p99 on /project-snapshot.  Step 4
+    retires the 6 [MASC_NAMESPACE_TRUTH_*_TIMEOUT_S] env knobs once
+    the fallback compute branch is unused. *)

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -697,9 +697,14 @@ let rec add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/dashboard/project-snapshot" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let timing = Server_timing.create () in
+         (* RFC-0138 Phase 3 Step 3: wait-free read via
+            [Dashboard_snapshot.current ()].namespace_truth when the
+            refresh fiber has populated it.  Cold start (or refresh
+            spawned without ~state) falls through to the synchronous
+            namespace-truth path inside the timing measurement. *)
          let json =
-           Server_timing.measure timing Project_snapshot_runtime (fun () ->
-             dashboard_namespace_truth_http_json ~state ~sw ~clock req)
+           Server_dashboard_shell_snapshot.select_project_snapshot_json
+             ~state ~sw ~clock ~timing req
          in
          Http.Response.json ~compress:true ~request:req
            ~extra_headers:(Server_timing.extra_header timing)
@@ -708,9 +713,14 @@ let rec add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/dashboard/namespace-truth" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let timing = Server_timing.create () in
+         (* RFC-0138 Phase 3 Step 3: wait-free read via
+            [Dashboard_snapshot.current ()].namespace_truth when the
+            refresh fiber has populated it.  Cold start (or refresh
+            spawned without ~state) falls through to the synchronous
+            namespace-truth path inside the timing measurement. *)
          let json =
-           Server_timing.measure timing Project_snapshot_runtime (fun () ->
-             dashboard_namespace_truth_http_json ~state ~sw ~clock req)
+           Server_dashboard_shell_snapshot.select_project_snapshot_json
+             ~state ~sw ~clock ~timing req
          in
          Http.Response.json ~compress:true ~request:req
            ~extra_headers:(Server_timing.extra_header timing)
@@ -719,9 +729,14 @@ let rec add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/dashboard/room-truth" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let timing = Server_timing.create () in
+         (* RFC-0138 Phase 3 Step 3: wait-free read via
+            [Dashboard_snapshot.current ()].namespace_truth when the
+            refresh fiber has populated it.  Cold start (or refresh
+            spawned without ~state) falls through to the synchronous
+            namespace-truth path inside the timing measurement. *)
          let json =
-           Server_timing.measure timing Project_snapshot_runtime (fun () ->
-             dashboard_namespace_truth_http_json ~state ~sw ~clock req)
+           Server_dashboard_shell_snapshot.select_project_snapshot_json
+             ~state ~sw ~clock ~timing req
          in
          Http.Response.json ~compress:true ~request:req
            ~extra_headers:(Server_timing.extra_header timing)

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -871,6 +871,45 @@ let test_telemetry_summary_snapshot_wire_falls_back_when_empty () =
     true
     (match json with `Assoc _ -> true | _ -> false)
 
+(* RFC-0138 Phase 3 Step 3 — /project-snapshot wire test.
+
+   We can only unit-test the snapshot-hit branch.  The fallback branch
+   calls [dashboard_namespace_truth_http_json] which requires a full
+   server_state + Eio scheduler + 6 timeout env knobs ([with_test_env]
+   does not synthesise these).  The fallback path lives in
+   [test_dashboard_namespace_truth.ml] integration coverage. *)
+
+let test_project_snapshot_wire_returns_snapshot_when_populated () =
+  with_test_env @@ fun ~env ~sw ~config:_ ->
+  Lib.Dashboard_snapshot.reset_for_test ();
+  let sentinel =
+    `Assoc [ "namespace_truth_sentinel", `String "from-snapshot" ]
+  in
+  Lib.Dashboard_snapshot.publish_for_test
+    (Lib.Dashboard_snapshot.make_for_test
+       ~shell:`Null ~tools:`Null
+       ~namespace_truth:sentinel ~telemetry_summary:`Null);
+  let clock = Eio.Stdenv.clock env in
+  let state = Lib.Mcp_server.create_state ~base_path:"/tmp/rfc-0138-step3" in
+  let req = request "/api/v1/dashboard/project-snapshot" in
+  let timing = Lib.Server_timing.create () in
+  let json =
+    Lib.Server_dashboard_shell_snapshot.select_project_snapshot_json
+      ~state ~sw ~clock ~timing req
+  in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string)
+    "populated snapshot path returns published sentinel"
+    "from-snapshot"
+    (json |> member "namespace_truth_sentinel" |> to_string);
+  Alcotest.(check bool)
+    "Server-Timing header records snapshot_read phase on hit"
+    true
+    (let header = Lib.Server_timing.to_header_value timing in
+     let re = Re.compile (Re.Perl.re "snapshot_read") in
+     Re.execp re header);
+  Lib.Dashboard_snapshot.reset_for_test ()
+
 let () =
   run "dashboard_http_core"
     [
@@ -930,5 +969,7 @@ let () =
             test_telemetry_summary_snapshot_wire_returns_snapshot;
           test_case "RFC-0138 telemetry_summary wire falls back when empty" `Quick
             test_telemetry_summary_snapshot_wire_falls_back_when_empty;
+          test_case "RFC-0138 project-snapshot wire returns snapshot when populated" `Quick
+            test_project_snapshot_wire_returns_snapshot_when_populated;
         ] );
     ]


### PR DESCRIPTION
## Summary

**Phase 3 Step 3 — wire `/api/v1/dashboard/project-snapshot` (+ aliases `/namespace-truth`, `/room-truth`) to `Dashboard_snapshot`.**

The highest-risk wire of the RFC-0138 §3.3 sequence. `/project-snapshot` currently runs the synchronous `dashboard_namespace_truth_http_json` on the **request fiber**, gated by six timeout env knobs:

| knob | default | purpose |
|---|---|---|
| `MASC_NAMESPACE_TRUTH_WARM_TIMEOUT_S` | 8.0s | base warm |
| `MASC_NAMESPACE_TRUTH_COLD_TIMEOUT_S` | 15.0s | base cold |
| `MASC_NAMESPACE_TRUTH_SHELL_FIBER_TIMEOUT_S` | 12.0s | shell warm cap |
| `MASC_NAMESPACE_TRUTH_COLD_SAFETY_MARGIN_S` | 4.0s | cold shell safety |
| `MASC_NAMESPACE_TRUTH_SHELL_REFRESH_TIMEOUT_S` | 5.0s | bounded refresh |
| `MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S` | 75.0s | proactive cache |

Step 3 moves namespace_truth into the background refresh fiber via the lightweight cached-refs path. The 6 knobs become Step 4 retire targets once the snapshot-hit branch dominates /project-snapshot p99.

Report: `vfile:///Users/dancer/me/.worktrees/dashboard-slow-endpoints-report-20260519/memory/masc-mcp-dashboard-slow-endpoints-report-2026-05-19.html` (jeong-sik/me#1144).

## Changes

### `lib/dashboard/dashboard_snapshot.{ml,mli}` — refresh_loop accepts ~state

```
val refresh_loop :
  sw:Eio.Switch.t ->
  clock:[> float Eio.Time.clock_ty] Eio.Resource.t ->
  config:Coord.config ->
  ?state:Mcp_server.server_state ->        (* NEW *)
  interval_sec:float ->
  unit ->                                   (* trailing unit anchors optional *)
  unit
```

When `?state` is supplied, the loop calls `Server_dashboard_http_namespace_truth.namespace_truth_snapshot_from_caches state` inside the same `safe` wrapper used for shell/tools/telemetry_summary. That function reads **process-local refs only** (no PG I/O, no fiber timeouts) — safe in a background fiber. A failure keeps the previous published snapshot live.

### `lib/server/server_bootstrap_loops.ml` — pass ~state through

`Eio.Fiber.fork ~sw` spawn now invokes:
```
Dashboard_snapshot.refresh_loop
  ~sw ~clock ~config:state.room_config ~state
  ~interval_sec:2.0 ()
```

### `lib/server/server_dashboard_shell_snapshot.{ml,mli}` — new selector

```
val select_project_snapshot_json :
  state:Mcp_server.server_state ->
  sw:Eio.Switch.t ->
  clock:float Eio.Time.clock_ty Eio.Resource.t ->
  ?timing:Server_timing.t ->
  Httpun.Request.t ->
  Yojson.Safe.t
```

Returns `snap.namespace_truth` when:
1. `Dashboard_snapshot.current () = Some snap`
2. `snap.namespace_truth <> `Null` (refresh fiber populated it)

Otherwise falls through to `dashboard_namespace_truth_http_json` inside `Project_snapshot_runtime` timing measurement (same path the router ran inline).

### `lib/server/server_routes_http_routes_dashboard.ml` — 3 aliases wired

`/api/v1/dashboard/project-snapshot`, `/namespace-truth`, `/room-truth` all route through `select_project_snapshot_json`. Three blocks shrink to 9 lines each (was 11) and share timing semantics.

### `test/test_dashboard_http_core.ml` — 1 new Alcotest case

**Case 24: snapshot-hit branch** — publishes a sentinel namespace_truth, calls the selector, verifies sentinel returned + Server-Timing has `snapshot_read` phase.

Fallback-branch unit testing is **intentionally omitted**: `dashboard_namespace_truth_http_json` requires fully-wired `server_state` + Eio scheduler + the 6 timeout env knobs not present in `with_test_env`. Integration coverage lives in `test_dashboard_namespace_truth.ml`. Comment documents the rationale.

## Verification

```bash
opam exec -- dune build --root . @check                    # PASS
opam exec -- dune build --root . test/test_dashboard_http_core.exe  # PASS
./_build/default/test/test_dashboard_http_core.exe test executor_pool 24
# OK: RFC-0138 project-snapshot wire returns snapshot when populated
```

## Retire Criterion (RFC-0138 §3.3 Step 3)

> Server-Timing `snapshot_read;dur~0ms` p99 on `/project-snapshot` once the refresh fiber has warmed and the execution cache has hydrated.

Server-Timing infrastructure from PR #16645 (merged). Refresh fiber spawn from Step 1 PR #16694 (merged). This commit completes the wire so the metric becomes meaningful.

## Risk Discussion

**This is the highest-risk wire** of Phase 3. Mitigations:

1. **Selector falls through gracefully** when `snap.namespace_truth = `Null`. Any reason the cached-refs read returns `None` (cold execution cache, state missing, etc.) routes back to the synchronous path with full timeout protection.
2. **Refresh fiber's `safe` wrapper** catches any exception from `namespace_truth_snapshot_from_caches` and logs it; previous snapshot stays published.
3. **No retire of MASC_NAMESPACE_TRUTH_*_TIMEOUT_S yet** — those knobs remain active on the fallback path until Step 4 measures p99 and approves removal.

## Scope Boundary

- **6 MASC_NAMESPACE_TRUTH_*_TIMEOUT_S env retire** = Step 4 (separate PR; gated on p99 measurement from this PR's wire).
- **`Dashboard_cache` read path retire + module rename** = Step 5 (separate PR).

## Workaround Rejection Bar Self-Check

- [x] §1 텔레메트리-as-fix: not applicable — removes synchronous compute paths, doesn't instrument them.
- [x] §2 string 분류기: none added.
- [x] §3 N-of-M: this PR closes Step 3 of 5 in a documented sequence with measurable retire criteria per step; no partial-fix accumulation.
- [x] catch-all `_ ->`: the selector uses `Some snap when snap.namespace_truth <> `Null` + `_` fallback. The `_` is *complete* coverage of `(None | Some {namespace_truth = `Null; _})` — both cases legitimately route to the same fallback. Not a sparse-match anti-pattern.
- [x] cap/cooldown: none added; this PR is the path to retiring 6 caps in Step 4.
- [x] test backdoor: none. Fixture uses `Mcp_server.create_state` public factory + existing `Dashboard_snapshot.publish_for_test`.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
