### PR TITLE
refactor(cascade_decl): collapse 8 silent-failure dead arms

### DIFF
--- a/lib/cascade_decl/cascade_declarative_parser.ml
+++ b/lib/cascade_decl/cascade_declarative_parser.ml
@@ -18,6 +18,28 @@ type parse_error =
 let error path message = [ { path; message } ]
 let add_errors acc more = acc @ more
 
+(* Partition a list of per-entry parse results into a single
+   collected result. Either every entry parsed (return [Ok all]),
+   or at least one entry failed (return [Error] with every error
+   concatenated). Removes the historical two-pass pattern where the
+   success branch carried a dead [Error _ -> None] arm guarded by a
+   prior [if errs <> []]: with this helper the dead arm cannot be
+   written, so a future caller cannot accidentally re-introduce a
+   silent drop. *)
+let partition_results
+  (results : ('a, parse_error list) result list)
+  : ('a list, parse_error list) result
+  =
+  let oks, errs =
+    List.partition_map
+      (function
+        | Ok x -> Either.Left x
+        | Error e -> Either.Right e)
+      results
+  in
+  if errs <> [] then Error (List.concat errs) else Ok oks
+;;
+
 (* --- Protocol string -> cascade_api_format --- *)
 
 let api_format_of_protocol (s : string) : (cascade_api_format, string) result =
@@ -328,23 +350,8 @@ let parse_providers (toml : Otoml.t) : (cascade_provider list, parse_error list)
   | None -> Ok []
   | Some providers_tbl ->
     let entries = Otoml.get_table providers_tbl in
-    let results = List.map (fun (id, tbl) -> parse_provider id tbl) entries in
-    let errs =
-      List.filter_map
-        (function
-          | Error e -> Some e
-          | Ok _ -> None)
-        results
-    in
-    if errs <> []
-    then Error (List.concat errs)
-    else
-      Ok
-        (List.filter_map
-           (function
-             | Ok p -> Some p
-             | Error _ -> None)
-           results)
+    partition_results
+      (List.map (fun (id, tbl) -> parse_provider id tbl) entries)
 ;;
 
 (* --- Layer 2: Models --- *)
@@ -495,23 +502,8 @@ let parse_models (toml : Otoml.t) : (cascade_model_spec list, parse_error list) 
   | None -> Ok []
   | Some models_tbl ->
     let entries = Otoml.get_table models_tbl in
-    let results = List.map (fun (id, tbl) -> parse_model id tbl) entries in
-    let errs =
-      List.filter_map
-        (function
-          | Error e -> Some e
-          | Ok _ -> None)
-        results
-    in
-    if errs <> []
-    then Error (List.concat errs)
-    else
-      Ok
-        (List.filter_map
-           (function
-             | Ok m -> Some m
-             | Error _ -> None)
-           results)
+    partition_results
+      (List.map (fun (id, tbl) -> parse_model id tbl) entries)
 ;;
 
 (* --- Reserved namespace detection --- *)
@@ -753,23 +745,8 @@ let parse_tiers (toml : Otoml.t) : (cascade_tier list, parse_error list) result 
   | None -> Ok []
   | Some tier_tbl ->
     let entries = Otoml.get_table tier_tbl in
-    let results = List.map (fun (name, tbl) -> parse_tier name tbl) entries in
-    let errs =
-      List.filter_map
-        (function
-          | Error e -> Some e
-          | Ok _ -> None)
-        results
-    in
-    if errs <> []
-    then Error (List.concat errs)
-    else
-      Ok
-        (List.filter_map
-           (function
-             | Ok t -> Some t
-             | Error _ -> None)
-           results)
+    partition_results
+      (List.map (fun (name, tbl) -> parse_tier name tbl) entries)
 ;;
 
 (* --- Layer 5b: Tier Groups --- *)
@@ -803,23 +780,8 @@ let parse_tier_groups (toml : Otoml.t)
   | None -> Ok []
   | Some tg_tbl ->
     let entries = Otoml.get_table tg_tbl in
-    let results = List.map (fun (name, tbl) -> parse_tier_group name tbl) entries in
-    let errs =
-      List.filter_map
-        (function
-          | Error e -> Some e
-          | Ok _ -> None)
-        results
-    in
-    if errs <> []
-    then Error (List.concat errs)
-    else
-      Ok
-        (List.filter_map
-           (function
-             | Ok g -> Some g
-             | Error _ -> None)
-           results)
+    partition_results
+      (List.map (fun (name, tbl) -> parse_tier_group name tbl) entries)
 ;;
 
 (* --- Layer 5c: Routes --- *)
@@ -861,9 +823,25 @@ let parse_system_targets (toml : Otoml.t) : cascade_route list =
 
 (* --- Top-level parse --- *)
 
+(* Extract the [Ok] payload from a parse result that the caller has
+   just proven via the [!all_errors = []] guard. The [Error _] branch
+   is statically unreachable; reaching it indicates a refactor has
+   desynchronized [collect ...] from the extraction site. Crash with
+   [invalid_arg] rather than silently substituting an empty list,
+   which would mask a corrupt cascade.toml. *)
+let extract_after_all_errors_guard ~label = function
+  | Ok x -> x
+  | Error _ ->
+    invalid_arg
+      (Printf.sprintf
+         "cascade_declarative_parser.parse_toml: %s — guarded \
+          extraction reached Error branch; collect/extract desync"
+         label)
+;;
+
 let parse_toml (toml : Otoml.t) : (cascade_config, parse_error list) result =
   let all_errors = ref [] in
-  let collect name = function
+  let collect = function
     | Ok _ -> ()
     | Error errs -> all_errors := !all_errors @ errs
   in
@@ -871,10 +849,10 @@ let parse_toml (toml : Otoml.t) : (cascade_config, parse_error list) result =
   let models_result = parse_models toml in
   let tiers_result = parse_tiers toml in
   let tier_groups_result = parse_tier_groups toml in
-  collect "providers" providers_result;
-  collect "models" models_result;
-  collect "tiers" tiers_result;
-  collect "tier_groups" tier_groups_result;
+  collect providers_result;
+  collect models_result;
+  collect tiers_result;
+  collect tier_groups_result;
   let bindings, aliases = parse_bindings_and_aliases toml in
   let routes = parse_routes toml in
   let system_targets = parse_system_targets toml in
@@ -882,24 +860,12 @@ let parse_toml (toml : Otoml.t) : (cascade_config, parse_error list) result =
   then Error !all_errors
   else (
     let providers =
-      match providers_result with
-      | Ok p -> p
-      | Error _ -> []
+      extract_after_all_errors_guard ~label:"providers" providers_result
     in
-    let models =
-      match models_result with
-      | Ok m -> m
-      | Error _ -> []
-    in
-    let tiers =
-      match tiers_result with
-      | Ok t -> t
-      | Error _ -> []
-    in
+    let models = extract_after_all_errors_guard ~label:"models" models_result in
+    let tiers = extract_after_all_errors_guard ~label:"tiers" tiers_result in
     let tier_groups =
-      match tier_groups_result with
-      | Ok g -> g
-      | Error _ -> []
+      extract_after_all_errors_guard ~label:"tier_groups" tier_groups_result
     in
     Ok
       { providers; models; bindings; aliases; tiers; tier_groups; routes; system_targets })


### PR DESCRIPTION
## Goal
RFC-0088 §3 dead-arm + silent failure 시그니처 8개 site 제거. `lib/cascade_decl/cascade_declarative_parser.ml` 전체.

## Surface (8 site)
| 영역 | 함수 | line (pre-fix) | 패턴 |
|---|---|---|---|
| inner | parse_providers | 343-347 | `Ok p -> Some p \| Error _ -> None` (guarded dead arm) |
| inner | parse_models | 510-515 | 동상 |
| inner | parse_tiers | 760-764 | 동상 |
| inner | parse_tier_groups | 794-798 | 동상 |
| outer | parse_toml providers | 846-850 | `Ok p -> p \| Error _ -> []` after !all_errors guard |
| outer | parse_toml models | 851-855 | 동상 |
| outer | parse_toml tiers | 856-860 | 동상 |
| outer | parse_toml tier_groups | 861-865 | 동상 |

## Approach
1. **Inner 4 site**: `partition_results` helper로 `List.partition_map` 한 번에 분리. 두 phase pattern (`errs ≠ []`-check 후 별도 추출) 제거. Dead arm은 *구조적으로 작성 불가능*해짐.

2. **Outer 4 site**: `extract_after_all_errors_guard ~label` helper로 dead arm을 *loud invariant violation*으로 변환. 가드 desync 시 `invalid_arg` raise → silent corrupt `cascade_config` 대신 즉시 crash.

3. 부수: inner `collect` helper의 unused `name` 인자 제거.

## Why
- Otoml 가드 패턴이 컴파일러에게 *dead* 임을 알리지 못함 → 향후 가드 누락 시 silent failure 부활
- MEMORY `project_cascade_tier_group_misroute_2026_05_17` 같은 cascade.toml-driven 사고 재발 표면이었음 (corrupt tier-group 가 empty list로 silence)
- 두 helper로 8 site 모두 close — N-of-M 누락 없음

## Local validation
- `dune build --root . @check` PASS
- `dune exec test/test_cascade_declarative_parser.exe` 63/63 PASS
- `dune exec test/test_cascade_declarative_validator.exe` 29/29 PASS
- `dune exec test/test_cascade_declarative_hotpath.exe` 23/23 PASS
- `dune exec test/test_cascade_declarative_adapter.exe` 21/21 PASS
- `dune exec test/test_cascade_config_validity.exe` 6/6 PASS

Total: 142/142 tests pass.

## Net
- +55 / -89 = **-34 LoC**

## Self-review (best-programmer)
- [x] dead arm 제거 (8 site)
- [x] catch-all 신규 도입 없음
- [x] silent failure 신규 도입 없음
- [x] type-system 우회 없음
- [x] 행복 경로 동작 변경 없음 (test suite 142 PASS)
- [x] invariant 위반 시 loud crash 도입 (silent corruption ≪ noisy crash)
- [x] commit message가 WHY 명시 (RFC-0088 시그니처 + 과거 misroute 사고 인용)

## Related
- audit context: lib/ silent failure 코드 스멜 감사 (2026-05-20), Tier A1
- stack: PR #16731 (Tier B2)와 disjoint, 독립 머지 가능