### PR TITLE
refactor(dashboard): isKeeperOffline SSOT for 3 ops filters + §9-6 lint (audit B5)

### DIFF
--- a/dashboard/src/components/board/composer-v2.ts
+++ b/dashboard/src/components/board/composer-v2.ts
@@ -16,6 +16,7 @@ import {
   stateBlockKeys,
   STATE_BLOCK_TEMPLATE,
 } from '../ops/ops-state'
+import { isKeeperOffline } from '../../lib/keeper-predicates'
 
 export type ComposerV2Mode = 'broadcast' | 'dm' | 'state-block'
 
@@ -61,10 +62,6 @@ const MENTION_LISTBOX_ID = 'composer-v2-mention-listbox'
 function normalizeRoomId(roomId: string | null | undefined): string {
   const normalized = roomId?.trim().replace(/^#+/, '')
   return normalized || 'default'
-}
-
-function normalizeStatus(value: unknown): string {
-  return typeof value === 'string' ? value.trim().toLowerCase() : ''
 }
 
 function keeperNameFromTarget(value: string): string | null {
@@ -163,8 +160,13 @@ export function ComposerV2({ roomId }: { roomId?: string | null }) {
   const room = normalizeRoomId(roomId)
   const snapshot = operatorSnapshot.value
   const busy = submitting || operatorActionBusy.value
+  // RFC-0135 audit B5 (2026-05-19): the previous local
+  // normalizeStatus-against-the-offline-literal filter matched only
+  // the literal offline token and silently let inactive / unbooted
+  // keepers through as "online". The SSOT isKeeperOffline catches
+  // all three off-tokens.
   const onlineKeepers = (snapshot?.keepers ?? [])
-    .filter(keeper => normalizeStatus(keeper.status) !== 'offline')
+    .filter(keeper => !isKeeperOffline(keeper))
     .map(keeper => ({ name: keeper.name, status: keeper.status }))
   const onlineKeeperNames = onlineKeepers.map(keeper => keeper.name).join('\0')
   const selectedKeeper = keeperNameFromTarget(keeperTarget)

--- a/dashboard/src/components/ops/helpers.ts
+++ b/dashboard/src/components/ops/helpers.ts
@@ -33,10 +33,6 @@ export {
 
 export { prettyJson, displayStatus }
 
-export function normalizeStatus(value: unknown): string {
-  return typeof value === 'string' ? value.trim().toLowerCase() : ''
-}
-
 function canonicalizeActionType(value?: string | null): string | null {
   if (!value) return null
   const normalized = value.trim()

--- a/dashboard/src/components/ops/keeper-utilities.ts
+++ b/dashboard/src/components/ops/keeper-utilities.ts
@@ -5,7 +5,8 @@ import { CARD_STANDARD } from '../common/card'
 import { Select } from '../common/select'
 import { operatorActionBusy, operatorSnapshot } from '../../operator-store'
 import type { OperatorActionDescriptor } from '../../types'
-import { actionTypeLabel, executeAction, normalizeStatus } from './helpers'
+import { actionTypeLabel, executeAction } from './helpers'
+import { isKeeperOffline } from '../../lib/keeper-predicates'
 
 const ADAPTED_KEEPER_ACTIONS = new Set([
   'keeper_probe',
@@ -55,8 +56,11 @@ export function KeeperUtilitiesPanel() {
   const actions = (snapshot?.available_actions ?? []).filter(visibleKeeperAction)
   if (actions.length === 0) return null
 
+  // RFC-0135 audit B5 (2026-05-19): SSOT-routed presence filter (see
+  // composer-v2.ts for the same migration). The previous status-only
+  // literal-offline check undercounted inactive / unbooted keepers.
   const onlineKeepers = (snapshot?.keepers ?? [])
-    .filter(keeper => normalizeStatus(keeper.status) !== 'offline')
+    .filter(keeper => !isKeeperOffline(keeper))
   const selectedName = onlineKeepers.some(keeper => keeper.name === selectedKeeper.value)
     ? selectedKeeper.value
     : (onlineKeepers[0]?.name ?? '')

--- a/dashboard/src/components/ops/quick-intervene.ts
+++ b/dashboard/src/components/ops/quick-intervene.ts
@@ -23,7 +23,8 @@ import {
   STATE_BLOCK_TEMPLATE,
   type QuickComposerMode,
 } from './ops-state'
-import { executeAction, normalizeStatus } from './helpers'
+import { executeAction } from './helpers'
+import { isKeeperOffline } from '../../lib/keeper-predicates'
 
 interface ComposerTarget {
   action_type: 'broadcast' | 'keeper_message'
@@ -162,7 +163,9 @@ export function QuickIntervene() {
   const busy = operatorActionBusy.value
   const currentRoute = route.value
 
-  const onlineKeepers = keepers.filter(k => normalizeStatus(k.status) !== 'offline')
+  // RFC-0135 audit B5 (2026-05-19): SSOT-routed presence filter — see
+  // composer-v2.ts/keeper-utilities.ts for the parallel migrations.
+  const onlineKeepers = keepers.filter(k => !isKeeperOffline(k))
   const onlineKeeperNames = onlineKeepers.map(keeper => keeper.name).join('\0')
   const mode = quickComposerMode.value
   const stateKeys = mode === 'state' ? stateBlockKeys(quickMessage.value) : []

--- a/dashboard/src/lib/keeper-predicates.ts
+++ b/dashboard/src/lib/keeper-predicates.ts
@@ -56,10 +56,27 @@ export function isKeeperCrashed(keeper: Keeper): boolean {
   return typeof phase === 'string' && CRASHED_PHASES.has(phase)
 }
 
+/** Structural subset of `Keeper` accepted by `isKeeperOffline`.
+ *  The predicate only reads `phase` and `status`, so callers that
+ *  receive narrower snapshot shapes (e.g. `OperatorKeeperSnapshot`,
+ *  which has no `phase` field) can pass them in directly. When
+ *  `phase` is absent the switch falls through to the status-token
+ *  check — the more conservative answer than only matching the
+ *  literal `'offline'` token.
+ *
+ *  Audit finding B5 (2026-05-19): two callsites used a local
+ *  `normalizeStatus(keeper.status) !== 'offline'` which only catches
+ *  one of the three off-tokens (`offline | inactive | unbooted`).
+ *  Routing them through this predicate closes the undercount. */
+export interface KeeperOfflineInput {
+  phase?: Keeper['phase']
+  status?: string
+}
+
 /** Operator considers the keeper offline / down on any of: terminal
  *  FSM phases (Offline/Stopped/Dead/Crashed/Zombie) or one of the
  *  three off-tokens emitted in `keeper.status`. */
-export function isKeeperOffline(keeper: Keeper): boolean {
+export function isKeeperOffline(keeper: KeeperOfflineInput): boolean {
   switch (keeper.phase) {
     case 'Offline':
     case 'Stopped':

--- a/scripts/lint/dashboard-ssot-keeper-state.sh
+++ b/scripts/lint/dashboard-ssot-keeper-state.sh
@@ -23,6 +23,10 @@
 #   §9-5  Same Korean word emitted as both a state noun (badge/chip) and
 #         an action verb (button label) in the same file — append `하기`
 #         to the verb form per PR-7.
+#   §9-6  Status-only offline classifier (audit B5, 2026-05-19) — local
+#         `keeper.status !== 'offline'` filters undercount presence.
+#         Must route through `isKeeperOffline` SSOT (catches the full
+#         off-token set: `offline | inactive | unbooted`).
 #
 # Allowlist: scripts/lint/dashboard-ssot-keeper-state.allowlist
 #   path:line — line-anchored debt entry
@@ -180,6 +184,29 @@ for kw in "${collision_keywords[@]}"; do
     done <<< "$bad_button"
   fi
 done
+
+# §9-6 — Status-only offline classifier (audit B5, 2026-05-19).
+# Detect `<anything>(keeper.status) !== 'offline'` or `(.status) === 'offline'`
+# style guards. The SSOT `isKeeperOffline(keeper)` catches all three
+# off-tokens (`offline | inactive | unbooted`) — local helpers that
+# only literal-match `'offline'` undercount presence (PR-B migrated
+# the three sites originally affected: composer-v2, keeper-utilities,
+# quick-intervene).
+#
+# Exempt: lib/keeper-predicates.ts (canonical reader).
+status_offline_classifier=$(
+  rg -n \
+    --type ts \
+    -g '!dashboard/src/lib/keeper-predicates.ts' \
+    -g '!dashboard/src/lib/keeper-predicates.test.ts' \
+    '\([a-zA-Z_]+\.status\s*\)?\s*!==\s*[\x27"]offline[\x27"]' \
+    dashboard/src 2>/dev/null || true
+)
+if [[ -n "$status_offline_classifier" ]]; then
+  while IFS= read -r line; do
+    [[ -n "$line" ]] && violations+=("§9-6 status-only offline classifier:$line")
+  done <<< "$status_offline_classifier"
+fi
 
 # Allowlist filter.
 allowlist_lines=$(grep -vE '^\s*(#|$)' "$ALLOWLIST_FILE" || true)


### PR DESCRIPTION
## 목적

2026-05-19 MASC Dashboard SSOT audit
(`.tmp/masc-dashboard-ssot-audit-2026-05-19.html`) finding **B5** 닫기
+ **audit 누락 3rd site 동시 처리** (N-of-M 안티패턴 거부).

## 발견된 사이트

audit 보고서 명시:
- `dashboard/src/components/board/composer-v2.ts:167`
- `dashboard/src/components/ops/keeper-utilities.ts:59`

**audit 누락 사이트 (sweep 으로 발견)**:
- `dashboard/src/components/ops/quick-intervene.ts:165`

3 사이트 모두 정확히 같은 패턴 — split PR 금지
(software-development.md workaround-rejection §3).

## 변경

### 핵심 마이그레이션

각 사이트의 `normalizeStatus(keeper.status) !== 'offline'` 을
`!isKeeperOffline(keeper)` 로 교체. 의도:

- 기존 코드: 리터럴 `'offline'` 토큰만 match — `'inactive'` / `'unbooted'`
  status 의 keeper 가 *online* 으로 잘못 표시
- 새 코드: SSOT `isKeeperOffline` 가 3 off-token 모두 catch + terminal
  FSM phase 도 catch

### Signature narrow (`isKeeperOffline`)

`Keeper` → `KeeperOfflineInput {phase?: Keeper['phase']; status?: string}`
로 structural 좁힘. `OperatorKeeperSnapshot` 가 `phase` 필드 없는 narrow
타입이라 그대로 호출 가능. `Keeper` 입력 동작은 변화 없음
(필드 모두 존재), snapshot 입력은 phase switch fall-through → status-token
check 만 — 이전 리터럴 매치 대비 strictly more conservative.

### Dead code 제거

`isKeeperOffline` 마이그레이션 후 `normalizeStatus` consumer 0:
- `dashboard/src/components/ops/helpers.ts` 의 export 제거
- `dashboard/src/components/board/composer-v2.ts` 의 inline 정의 제거

(사용자 절대 원칙 — 하드코딩/legacy 박멸, root-fix 와 같은 PR 에서 dead code 동시 정리)

### Lint §9-6 추가

`scripts/lint/dashboard-ssot-keeper-state.sh` 에 새 가드 — 재발 방지.

```
§9-6 — Status-only offline classifier (audit B5, 2026-05-19)
       <expr>.status !== 'offline' 패턴 발견 시 violation
       Exempt: dashboard/src/lib/keeper-predicates.ts (canonical reader)
```

가드 적용 후 lint 결과: `clean (0 allowlisted violations)`.

## 검증

```
$ npx vitest run --config vitest.config.ts src/lib/keeper-predicates.test.ts
Test Files  1 passed (1)
Tests       41 passed (41)

$ npx tsc --noEmit
(clean)

$ bash scripts/lint/dashboard-ssot-keeper-state.sh
RFC-0135 §9 SSOT guard: clean (0 allowlisted violation(s))
```

`isKeeperOffline` 의 시그니처 narrow 가 기존 callsite 전체 회귀 없는지
typecheck 로 확인 — 41 test PASS + tsc clean.

## RFC-WAIVED

dashboard SSOT follow-up, 새 RFC subsystem 영역 touch 없음:
- `lib/keeper/credential_*` / `lib/repo_manager/` / `lib/operator/*` ❌
- `dashboard/src/components/credential*` ❌
- `.claude/hooks/` / `instructions/workflow*` ❌

RFC-WAIVED: 변경 영역 = dashboard general (3 ops components + 1
predicate lib + 1 lint script). RFC-0135 의 follow-up 이지만 새 RFC
필요한 wiring/타입/스키마 변경 없음 (signature narrow 는 structural
backward-compatible).

## Best Programmer self-review

- **목표**: audit B5 closure + N-of-M anti-pattern 회피 (3 사이트 동시)
- **변경 파일**:
  - `dashboard/src/lib/keeper-predicates.ts` — signature narrow (+19/-1)
  - `dashboard/src/components/board/composer-v2.ts` — migrate + remove inline normalizeStatus
  - `dashboard/src/components/ops/keeper-utilities.ts` — migrate
  - `dashboard/src/components/ops/quick-intervene.ts` — migrate (audit-missed)
  - `dashboard/src/components/ops/helpers.ts` — remove dead normalizeStatus export
  - `scripts/lint/dashboard-ssot-keeper-state.sh` — §9-6 추가
- **로컬 검증**: vitest 41/41 PASS, tsc clean, lint guard clean
- **Anti-pattern self-check**:
  - String classifier 추가 ❌ (제거 방향)
  - N-of-M ❌ (audit 미명시 3rd site 동시 처리)
  - Telemetry-as-fix ❌
  - Lint as fix (workaround) ❌ — lint 은 회귀 방지 *추가*, 본 fix 는 code 변경

## Draft + label 정책

Agent-authored PR — **Draft 유지**. Ready 전환은
`human-approved-ready` 라벨 부착 후 CI green 시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
