### PR TITLE
fix(cascade): route Provider.CapacityExhausted to immediate cooldown

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -832,6 +832,23 @@ let emit_sdk_provider_error_metric ~cascade_name ~provider err =
    here and clamped/defaulted at the tracker boundary so the caller's
    semantics ("the 429 still happened, so cool down at least the
    default") are maintained centrally. *)
+(* [Provider.CapacityExhausted] is a typed signal that the provider rejected
+   the request for capacity reasons (slot full, model overloaded, region
+   throttled). One event is enough evidence to deprioritize the provider
+   for the rest of the cycle — the same logic that justifies
+   [sdk_error_soft_rate_limited]'s immediate-cooldown handling (see
+   [Cascade_health_tracker.soft_rate_limit_cooldown_sec] doc: "a single
+   429 should already deprioritize the provider"). Threshold-counting via
+   [record_failure] would burn 2 additional cascade attempts on a
+   provider that has just declared it cannot serve. *)
+let sdk_error_capacity_exhausted_retry_after_s (err : Agent_sdk.Error.sdk_error)
+  : float option option =
+  match err with
+  | Agent_sdk.Error.Provider
+      (Llm_provider.Error.CapacityExhausted { retry_after; _ }) ->
+    Some retry_after
+  | _ -> None
+
 let sdk_error_soft_rate_limited (err : Agent_sdk.Error.sdk_error)
   : float option option =
   match err with

--- a/lib/cascade/cascade_attempt_fsm.mli
+++ b/lib/cascade/cascade_attempt_fsm.mli
@@ -123,6 +123,17 @@ val sdk_error_soft_rate_limited :
     [retry_after].  [Some None] when [retry_after] is absent.
     [None] for non-429 or hard-quota-429 errors. *)
 
+val sdk_error_capacity_exhausted_retry_after_s :
+  Agent_sdk.Error.sdk_error -> float option option
+(** [Some (Some retry_after)] for a [Provider.CapacityExhausted] error
+    carrying a parsed [retry_after].  [Some None] when [retry_after] is
+    absent.  [None] for all other errors.  Mirrors
+    {!sdk_error_soft_rate_limited} so [Cascade_health_tracker.record_soft_rate_limited]
+    can be reused for the immediate-cooldown semantics — one capacity
+    rejection is enough to deprioritize the provider, threshold-counting
+    via [record_failure] would burn additional cascade attempts on the
+    same exhausted provider. *)
+
 val sdk_error_is_max_turns_exceeded : Agent_sdk.Error.sdk_error -> bool
 
 val sdk_error_cascade_fallback_class :

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -707,7 +707,19 @@ let run_named
         ~error_reason
         ()
     else
-      match sdk_error_soft_rate_limited sdk_err with
+      (* Capacity_exhausted shares the immediate-cooldown semantics of a
+         soft rate limit: one event is sufficient evidence that the
+         provider cannot serve, so we reuse [record_soft_rate_limited]
+         rather than counting toward the 3-failure threshold of
+         [record_failure]. The retry_after hint, when present, drives
+         cooldown duration (clamped by
+         [Cascade_health_tracker.soft_rate_limit_max_clamp_sec]). *)
+      let immediate_cooldown_retry_after =
+        match sdk_error_capacity_exhausted_retry_after_s sdk_err with
+        | Some retry_after -> Some retry_after
+        | None -> sdk_error_soft_rate_limited sdk_err
+      in
+      match immediate_cooldown_retry_after with
       | Some retry_after_s ->
         Cascade_health_tracker.record_soft_rate_limited
           Cascade_health_tracker.global

--- a/test/dune
+++ b/test/dune
@@ -121,6 +121,7 @@
   test_keeper_health_probe
   test_oas_error_kind_counter
   test_cascade_error_classify_decoder
+  test_cascade_capacity_exhausted_cooldown
   test_oas_empty_response_diagnostic
   test_board_author_identity_10297
   test_fsm_drift_counter
@@ -434,6 +435,7 @@
   test_keeper_health_probe
   test_oas_error_kind_counter
   test_cascade_error_classify_decoder
+  test_cascade_capacity_exhausted_cooldown
   test_oas_empty_response_diagnostic
   test_board_author_identity_10297
   test_fsm_drift_counter

--- a/test/test_cascade_capacity_exhausted_cooldown.ml
+++ b/test/test_cascade_capacity_exhausted_cooldown.ml
@@ -1,0 +1,95 @@
+(** Pins the typed extraction of [Provider.CapacityExhausted] retry_after
+    from an [Agent_sdk.Error.sdk_error] via
+    [Cascade_attempt_fsm.sdk_error_capacity_exhausted_retry_after_s].
+
+    Without this helper, [Capacity_exhausted] events fall through to
+    [record_failure] (threshold-based) instead of [record_soft_rate_limited]
+    (immediate). One slot-full event is sufficient evidence to deprioritize
+    a provider — the same reasoning [Cascade_health_tracker.soft_rate_limit_cooldown_sec]
+    documents for a 429.
+
+    Closes §6 R2 (admission pre-check wiring) from the 2026-05-20
+    consolidated state report. *)
+
+module FSM = Masc_mcp.Cascade_attempt_fsm
+module ErrSdk = Agent_sdk.Error
+
+let pp_extract fmt = function
+  | None -> Format.fprintf fmt "None"
+  | Some None -> Format.fprintf fmt "Some(None)"
+  | Some (Some f) -> Format.fprintf fmt "Some(Some(%g))" f
+
+let extract_testable =
+  Alcotest.testable pp_extract ( = )
+
+let mk_capacity_exhausted ?retry_after ?(scope = Llm_provider.Error.CapacityProvider)
+    ?(affected = []) ?(detail = "slot full") () : ErrSdk.sdk_error =
+  ErrSdk.Provider
+    (Llm_provider.Error.CapacityExhausted
+       { scope; affected; retry_after; detail })
+
+let test_capacity_with_retry_after_extracted () =
+  let err = mk_capacity_exhausted ~retry_after:7.5 () in
+  Alcotest.check extract_testable
+    "CapacityExhausted with retry_after=7.5 → Some(Some 7.5)"
+    (Some (Some 7.5))
+    (FSM.sdk_error_capacity_exhausted_retry_after_s err)
+
+let test_capacity_without_retry_after_extracted () =
+  let err = mk_capacity_exhausted () in
+  Alcotest.check extract_testable
+    "CapacityExhausted without retry_after → Some(None)"
+    (Some None)
+    (FSM.sdk_error_capacity_exhausted_retry_after_s err)
+
+let test_non_capacity_error_returns_none () =
+  let err =
+    ErrSdk.Provider
+      (Llm_provider.Error.RateLimit
+         { provider = "test"; retry_after = Some 3.0; detail = "" })
+  in
+  Alcotest.check extract_testable
+    "RateLimit is not CapacityExhausted → None"
+    None
+    (FSM.sdk_error_capacity_exhausted_retry_after_s err)
+
+let test_hard_quota_returns_none () =
+  let err =
+    ErrSdk.Provider
+      (Llm_provider.Error.HardQuota
+         { provider = "test"; retry_after = Some 600.0; detail = "" })
+  in
+  Alcotest.check extract_testable
+    "HardQuota is not CapacityExhausted → None"
+    None
+    (FSM.sdk_error_capacity_exhausted_retry_after_s err)
+
+let test_soft_rate_limited_helper_does_not_match_capacity () =
+  (* Without the new helper, callers reaching only sdk_error_soft_rate_limited
+     would miss CapacityExhausted entirely — that's the bug this PR fixes.
+     This regression-pin keeps the two helpers semantically distinct. *)
+  let err = mk_capacity_exhausted ~retry_after:7.5 () in
+  Alcotest.check extract_testable
+    "soft_rate_limited helper does NOT swallow CapacityExhausted"
+    None
+    (FSM.sdk_error_soft_rate_limited err)
+
+let () =
+  Alcotest.run "cascade_capacity_exhausted_cooldown"
+    [ ( "typed extraction"
+      , [ Alcotest.test_case
+            "CapacityExhausted with retry_after" `Quick
+            test_capacity_with_retry_after_extracted
+        ; Alcotest.test_case
+            "CapacityExhausted without retry_after" `Quick
+            test_capacity_without_retry_after_extracted
+        ; Alcotest.test_case
+            "non-capacity error → None" `Quick test_non_capacity_error_returns_none
+        ; Alcotest.test_case
+            "HardQuota is distinct" `Quick test_hard_quota_returns_none
+        ; Alcotest.test_case
+            "soft_rate_limited does not subsume CapacityExhausted"
+            `Quick
+            test_soft_rate_limited_helper_does_not_match_capacity
+        ] )
+    ]


### PR DESCRIPTION
## Goal

`Provider.CapacityExhausted` 이벤트가 `record_failure` (threshold-based, 3 회) 가 아닌 `record_soft_rate_limited` (immediate cooldown) 로 라우팅되도록 한다.

## Why

`Cascade_health_tracker` 의 admission pre-check 자체는 이미 wired 상태였다 (`cascade_strategy.ml:107`, `cascade_config_selection.ml:171`, `cascade_pool.ml:41,50` 모두 `is_in_cooldown` consult). 진짜 gap 은 *recording 측*: `Capacity_exhausted` SDK 에러가 `keeper_turn_driver.record_candidate_error` 의 `else` 분기로 떨어져 `record_failure` 의 cooldown_threshold (=3) 를 카운트만 했다. 따라서 슬롯-풀 1회로는 즉시 deprioritize 되지 않고 2 attempt 가 더 burn 됐다.

`Cascade_health_tracker.soft_rate_limit_cooldown_sec` 문서가 명시한 바와 같이 — "a single 429 should already deprioritize the provider for the remainder of the current cascade cycle — the cooldown_threshold count-to-three semantics are wrong for transient rate limits." 같은 논리가 CapacityExhausted 에도 그대로 적용된다.

## What changes

- **`lib/cascade/cascade_attempt_fsm.{ml,mli}`** — `sdk_error_capacity_exhausted_retry_after_s : Agent_sdk.Error.sdk_error -> float option option` 추가. `sdk_error_soft_rate_limited` 와 동일한 시그니처/시맨틱.
- **`lib/keeper/keeper_turn_driver.ml:709-725`** — `record_candidate_error` 의 final `else` 분기를 capacity-exhausted 우선, soft-rate-limited 차선, threshold-failure 마지막 순서로 재구성. `record_soft_rate_limited` 의 `Cascade_health_tracker.soft_rate_limit_max_clamp_sec` 클램프가 그대로 적용된다.
- **새 catch-all `_ ->` 도입 없음**.

## Verification

```
$ dune build --root . @check
exit=0
$ dune exec --root . test/test_cascade_capacity_exhausted_cooldown.exe
5/5 PASS
$ dune exec --root . test/test_cascade_health_tracker.exe
59/59 PASS (regression OK)
```

New tests (`test/test_cascade_capacity_exhausted_cooldown.ml`):

1. `CapacityExhausted with retry_after=7.5` → `Some (Some 7.5)`
2. `CapacityExhausted without retry_after` → `Some None`
3. `RateLimit` → `None` (distinct)
4. `HardQuota` → `None` (distinct — keeps hard_quota_cooldown_sec=3600 path intact)
5. Regression pin: `sdk_error_soft_rate_limited` does NOT swallow CapacityExhausted

## Workaround Rejection Bar 검토

- §1 Counter-as-Fix: 아니다. 새 카운터 없음, recording 라우팅 수정
- §2 String/Substring 분류기 보강: 아니다. typed variant extractor 추가
- §3 N-of-M: 아니다. 1 caller (`record_candidate_error`)
- §Cap/Cooldown: 형식상 cooldown 인용 — 단 이건 *기존* cooldown infrastructure 의 typed wiring 이지 새 cap 도입이 아님. retry_after 가 있으면 그것을, 없으면 `soft_rate_limit_cooldown_sec` (10s 기본) 적용. clamp 도 기존 SSOT 사용.
- §Retry-as-fix: 아니다. retry 추가 없음, 이미 일어나던 retry 가 더 빨리 다른 provider 로 넘어가게 함

## Trade-off

후속 follow-up 후보 (이 PR 범위 밖):
- `Capacity_exhausted` 가 빈번하면 *해당 provider 의 model* 만 (전체 provider 가 아니라) cooldown 처리할지 여부 — `affected` 필드와 `scope` 필드를 활용 가능. scope 별 cooldown 은 별도 RFC.

## References

- Source plan: `~/me/memory/masc-consolidated-state-and-roadmap-2026-05-20.html` §6 R2, §7 Action 2
- Sibling PR: #16732 (cascade_error_classify Other_detail removal) — same trajectory
- Cooldown semantics SSOT: `lib/cascade/cascade_health_tracker.mli:45-63`