### PR TITLE
fix(keeper): surface structured shell recovery plans

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -670,7 +670,105 @@ end
 
 let workflow_rejection_field = "failure_class", `String "workflow_rejection"
 
+let recovery_plan_extra ?rule_id ?(source_tool = "keeper_bash") plan =
+  let rule_fields =
+    match rule_id with
+    | None -> []
+    | Some id -> [ "recovery_rule_id", `String id ]
+  in
+  [
+    "recovery_plan", recovery_plan_to_json plan;
+    "required_next_tool", `String plan.next_tool;
+    "do_not_retry_tool", `String source_tool;
+    "do_not_retry_same_args", `Bool true;
+  ]
+  @ rule_fields
+
+let shell_rewrite_plan ?(confidence = "medium") ~next_tool ~next_args ~instruction ~reason
+    () =
+  { next_tool; next_args; instruction; reason; confidence }
+
+let keeper_shell_rewrite_args op fields = ("op", `String op) :: fields
+
+let command_block_recovery_plan ~cmd:_ reason hint =
+  match reason with
+  | Worker_dev_tools.Command_not_allowed name when String_util.equals_ci name "gh" ->
+    Some
+      (shell_rewrite_plan
+         ~confidence:"high"
+         ~next_tool:"keeper_shell"
+         ~next_args:
+           (keeper_shell_rewrite_args "gh" [ "cmd", `String "pr list --state open" ])
+         ~instruction:hint
+         ~reason:"gh_requires_structured_shell_op"
+         ())
+  | Worker_dev_tools.Command_not_allowed _ ->
+    Some
+      (shell_rewrite_plan
+         ~next_tool:"keeper_shell"
+         ~next_args:
+           (keeper_shell_rewrite_args
+              "rg"
+              [ "pattern", `String "SEARCH_TERM"; "path", `String "SCOPED_PATH" ])
+         ~instruction:hint
+         ~reason:"command_not_allowed_use_structured_op"
+         ())
+  | Chain_or_redirect | Pipes_not_allowed ->
+    Some
+      (shell_rewrite_plan
+         ~confidence:"high"
+         ~next_tool:"keeper_shell"
+         ~next_args:
+           (keeper_shell_rewrite_args
+              "rg"
+              [ "pattern", `String "SEARCH_TERM"; "path", `String "SCOPED_PATH" ])
+         ~instruction:hint
+         ~reason:"shell_shape_requires_structured_op"
+         ())
+  | Injection | Process_substitution ->
+    Some
+      (shell_rewrite_plan
+         ~next_tool:"keeper_shell"
+         ~next_args:
+           (keeper_shell_rewrite_args
+              "rg"
+              [ "pattern", `String "DISCOVERY_TERM"; "path", `String "SCOPED_PATH" ])
+         ~instruction:hint
+         ~reason:"shell_injection_requires_discovery_first"
+         ())
+  | Direct_dune_invocation ->
+    Some
+      (shell_rewrite_plan
+         ~confidence:"high"
+         ~next_tool:"keeper_bash"
+         ~next_args:[ "cmd", `String "scripts/dune-local.sh build <target>" ]
+         ~instruction:hint
+         ~reason:"dune_must_use_local_wrapper"
+         ())
+  | Unsafe_redirect ->
+    Some
+      (shell_rewrite_plan
+         ~next_tool:"keeper_fs_edit"
+         ~next_args:[ "path", `String "FILE_PATH"; "content", `String "CONTENT" ]
+         ~instruction:hint
+         ~reason:"redirect_requires_file_edit_tool"
+         ())
+  | Empty_command ->
+    Some
+      (shell_rewrite_plan
+         ~next_tool:"keeper_shell"
+         ~next_args:(keeper_shell_rewrite_args "ls" [ "path", `String "." ])
+         ~instruction:hint
+         ~reason:"empty_command_requires_explicit_op"
+         ())
+
 let bash_shape_block_result ~cmd ~cmd_for_log ~env_snapshot block =
+  let rule_id = "keeper_bash_" ^ bash_shape_block_tag block ^ "_blocked" in
+  let recovery_extra =
+    match bash_shape_block_recovery_plan ~cmd block with
+    | None -> []
+    | Some plan -> recovery_plan_extra ~rule_id plan
+  in
   Yojson.Safe.to_string
     (Exec_core.blocked_result_json
        ~cmd
@@ -681,8 +779,7 @@ let bash_shape_block_result ~cmd ~cmd_for_log ~env_snapshot block =
        ~diag:
          (Some
             {
-              Exec_core.rule_id =
-                "keeper_bash_" ^ bash_shape_block_tag block ^ "_blocked";
+              Exec_core.rule_id = rule_id;
               explanation = bash_shape_block_reason block;
               rewrite = Some (bash_shape_block_hint ~cmd block);
               tool_suggestion =
@@ -695,12 +792,13 @@ let bash_shape_block_result ~cmd ~cmd_for_log ~env_snapshot block =
                  | Chaining | Substitution -> None);
             })
        ~extra:
-         [
-           workflow_rejection_field;
-           "cmd", `String cmd_for_log;
-           "shape_block", `String (bash_shape_block_tag block);
-           "execution_time_ms", `Int 0;
-         ]
+         ([
+            workflow_rejection_field;
+            "cmd", `String cmd_for_log;
+            "shape_block", `String (bash_shape_block_tag block);
+            "execution_time_ms", `Int 0;
+          ]
+          @ recovery_extra)
        ~env_snapshot
        ())
 
@@ -1068,6 +1166,15 @@ let handle_keeper_bash
          ])
   in
   let native_pr_command_block hint =
+    let plan =
+      shell_rewrite_plan
+        ~confidence:"high"
+        ~next_tool:hint.tool_suggestion
+        ~next_args:[]
+        ~instruction:hint.hint
+        ~reason:hint.rule_id
+        ()
+    in
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_shell_bash_failures
       ~labels:[("keeper", meta.name); ("site", "gh_pr_native_tool")]
@@ -1083,7 +1190,9 @@ let handle_keeper_bash
          ~hint:hint.hint
          ~alternatives:hint.alternatives
          ~diag:(Some (native_tool_diagnosis hint))
-         ~extra:[ "cmd", `String cmd_for_log; "execution_time_ms", `Int 0 ]
+         ~extra:
+           ([ "cmd", `String cmd_for_log; "execution_time_ms", `Int 0 ]
+            @ recovery_plan_extra ~rule_id:hint.rule_id plan)
          ())
   in
   let direct_tool_command_block ~tool_policy_visible tool_name =
@@ -1127,6 +1236,15 @@ let handle_keeper_bash
     | exception Yojson.Json_error _ -> `String raw
   in
   let task_state_probe_blocked_json ~error ~reason =
+    let plan =
+      shell_rewrite_plan
+        ~confidence:"high"
+        ~next_tool:"keeper_tasks_list"
+        ~next_args:[ "include_done", `Bool false ]
+        ~instruction:Task_probe.hint
+        ~reason:"task_state_tool_ssot"
+        ()
+    in
     Exec_core.blocked_result_json
       ~cmd
       ~error
@@ -1143,7 +1261,9 @@ let handle_keeper_bash
            ; rewrite = Some Task_probe.hint
            ; tool_suggestion = Some "keeper_tasks_list"
            })
-      ~extra:[ "cmd", `String cmd_for_log; "execution_time_ms", `Int 0 ]
+      ~extra:
+        ([ "cmd", `String cmd_for_log; "execution_time_ms", `Int 0 ]
+         @ recovery_plan_extra ~rule_id:error plan)
       ()
   in
   let task_state_probe_autoroute ~original_error ~reason =
@@ -1740,6 +1860,17 @@ let handle_keeper_bash
           | Some hint -> Some (native_tool_diagnosis hint)
           | None -> Keeper_shell_shared.diagnosis_of_block_reason reason
         in
+        let recovery_extra =
+          match command_block_recovery_plan ~cmd reason hint with
+          | None -> []
+          | Some plan ->
+            let rule_id =
+              match diag with
+              | Some d -> Some d.Exec_core.rule_id
+              | None -> None
+            in
+            recovery_plan_extra ?rule_id plan
+        in
         Yojson.Safe.to_string
           (Exec_core.blocked_result_json
              ~cmd
@@ -1748,7 +1879,7 @@ let handle_keeper_bash
              ~hint
              ~alternatives
              ~diag
-             ~extra:[ "execution_time_ms", `Int 0 ]
+             ~extra:([ "execution_time_ms", `Int 0 ] @ recovery_extra)
              ~env_snapshot:env_snap
              ())
       | Ok () ->

--- a/lib/keeper/keeper_shell_bash_shape_messages.ml
+++ b/lib/keeper/keeper_shell_bash_shape_messages.ml
@@ -7,6 +7,14 @@ type bash_shape_block =
   | Substitution
   | Repo_wide_scan
 
+type recovery_plan = {
+  next_tool : string;
+  next_args : (string * Yojson.Safe.t) list;
+  instruction : string;
+  reason : string;
+  confidence : string;
+}
+
 let bash_shape_block_tag = function
   | Gh_pr_checks -> "gh_pr_checks"
   | Pipe_or_redirect -> "pipe_or_redirect"
@@ -138,3 +146,152 @@ let bash_shape_block_alternatives ~cmd = function
         "keeper_shell op=find path=lib pattern='*.ml'";
         "keeper_bash cmd='git log --oneline -20'";
       ]
+
+let recovery_plan_to_json plan =
+  `Assoc
+    [ "kind", `String "structured_tool_rewrite"
+    ; "next_tool", `String plan.next_tool
+    ; "next_args", `Assoc plan.next_args
+    ; "instruction", `String plan.instruction
+    ; "reason", `String plan.reason
+    ; "confidence", `String plan.confidence
+    ; "do_not_retry_same_args", `Bool true
+    ]
+
+let plan ?(confidence = "medium") ~next_tool ~next_args ~instruction ~reason () =
+  { next_tool; next_args; instruction; reason; confidence }
+
+let keeper_shell_args op fields =
+  ("op", `String op) :: fields
+
+let bash_shape_block_recovery_plan ~cmd = function
+  | _ when command_looks_like_task_state_discovery cmd ->
+    Some
+      (plan
+         ~confidence:"high"
+         ~next_tool:"keeper_tasks_list"
+         ~next_args:[ "include_done", `Bool false ]
+         ~instruction:task_state_shell_hint
+         ~reason:"task_state_tool_ssot"
+         ())
+  | Gh_pr_checks ->
+    Some
+      (plan
+         ~next_tool:"keeper_pr_status"
+         ~next_args:
+           [ "pr", `String "NUMBER_FROM_COMMAND"
+           ; "repo", `String "OWNER/REPO_FROM_COMMAND"
+           ]
+         ~instruction:(bash_shape_block_hint ~cmd Gh_pr_checks)
+         ~reason:"native_pr_status_tool_required"
+         ())
+  | Pipe_or_redirect when command_looks_like_search_pipeline cmd ->
+    Some
+      (plan
+         ~confidence:"high"
+         ~next_tool:"keeper_shell"
+         ~next_args:
+           (keeper_shell_args
+              "rg"
+              [ "pattern", `String "SEARCH_TERM"
+              ; "path", `String "SCOPED_PATH"
+              ; "glob", `String "*.ml"
+              ])
+         ~instruction:(bash_shape_block_hint ~cmd Pipe_or_redirect)
+         ~reason:"pipe_to_head_rewrite"
+         ())
+  | Pipe_or_redirect when
+      command_looks_like_find_pipeline cmd || lowercase_contains cmd "find " ->
+    Some
+      (plan
+         ~confidence:"high"
+         ~next_tool:"keeper_shell"
+         ~next_args:
+           (keeper_shell_args
+              "find"
+              [ "path", `String "SCOPED_PATH"
+              ; "pattern", `String "FILE_GLOB"
+              ; "limit", `Int 30
+              ])
+         ~instruction:(bash_shape_block_hint ~cmd Pipe_or_redirect)
+         ~reason:"find_head_rewrite"
+         ())
+  | Pipe_or_redirect ->
+    Some
+      (plan
+         ~next_tool:"keeper_shell"
+         ~next_args:
+           (keeper_shell_args
+              "head"
+              [ "path", `String "FILE_PATH"; "lines", `Int 80 ])
+         ~instruction:(bash_shape_block_hint ~cmd Pipe_or_redirect)
+         ~reason:"pipe_or_redirect_blocked"
+         ())
+  | Chaining when command_looks_like_cd_chained_search cmd ->
+    Some
+      (plan
+         ~confidence:"high"
+         ~next_tool:"keeper_shell"
+         ~next_args:
+           (keeper_shell_args
+              "rg"
+              [ "cwd", `String "REPO_OR_WORKTREE_CWD"
+              ; "pattern", `String "SEARCH_TERM"
+              ; "path", `String "SCOPED_PATH"
+              ])
+         ~instruction:(bash_shape_block_hint ~cmd Chaining)
+         ~reason:"cd_chained_search_rewrite"
+         ())
+  | Chaining ->
+    Some
+      (plan
+         ~next_tool:"keeper_shell"
+         ~next_args:
+           (keeper_shell_args
+              "rg"
+              [ "pattern", `String "SEARCH_TERM"; "path", `String "SCOPED_PATH" ])
+         ~instruction:(bash_shape_block_hint ~cmd Chaining)
+         ~reason:"command_chaining_blocked"
+         ())
+  | Substitution ->
+    Some
+      (plan
+         ~next_tool:"keeper_shell"
+         ~next_args:
+           (keeper_shell_args
+              "rg"
+              [ "pattern", `String "DISCOVERY_TERM"; "path", `String "SCOPED_PATH" ])
+         ~instruction:(bash_shape_block_hint ~cmd Substitution)
+         ~reason:"substitution_requires_discovery_first"
+         ())
+  | Repo_wide_scan ->
+    if command_looks_like_repo_wide_git_log_grep cmd then
+      Some
+        (plan
+           ~confidence:"high"
+           ~next_tool:"keeper_shell"
+           ~next_args:
+             (keeper_shell_args
+                "git_log"
+                [ "cwd", `String "REPO_OR_WORKTREE_CWD"
+                ; "count", `Int 5
+                ; "grep", `String "SEARCH_TERM"
+                ])
+           ~instruction:(bash_shape_block_hint ~cmd Repo_wide_scan)
+           ~reason:"repo_wide_git_history_scan_blocked"
+           ())
+    else
+      Some
+        (plan
+           ~confidence:"high"
+           ~next_tool:"keeper_shell"
+           ~next_args:
+             (keeper_shell_args
+                "rg"
+                [ "pattern", `String "SEARCH_TERM"
+                ; "path", `String "SCOPED_PATH"
+                ; "glob", `String "*.ml"
+                ])
+           ~instruction:(bash_shape_block_hint ~cmd Repo_wide_scan)
+           ~reason:"repo_wide_scan_blocked"
+           ())

--- a/lib/keeper/keeper_shell_bash_shape_messages.mli
+++ b/lib/keeper/keeper_shell_bash_shape_messages.mli
@@ -5,7 +5,17 @@ type bash_shape_block =
   | Substitution
   | Repo_wide_scan
 
+type recovery_plan = {
+  next_tool : string;
+  next_args : (string * Yojson.Safe.t) list;
+  instruction : string;
+  reason : string;
+  confidence : string;
+}
+
 val bash_shape_block_tag : bash_shape_block -> string
 val bash_shape_block_reason : bash_shape_block -> string
 val bash_shape_block_hint : cmd:string -> bash_shape_block -> string
 val bash_shape_block_alternatives : cmd:string -> bash_shape_block -> string list
+val recovery_plan_to_json : recovery_plan -> Yojson.Safe.t
+val bash_shape_block_recovery_plan : cmd:string -> bash_shape_block -> recovery_plan option

--- a/lib/keeper/keeper_tool_deterministic_error.ml
+++ b/lib/keeper/keeper_tool_deterministic_error.ml
@@ -1,7 +1,9 @@
 (** Keeper_tool_deterministic_error — see .mli for design notes. *)
 
 type deterministic_reason =
+  | Command_blocked
   | Command_shape_blocked
+  | Task_state_probe_blocked
   | Destructive_operation_blocked
   | Path_syntax_blocked
   | Path_outside_sandbox
@@ -12,7 +14,10 @@ type deterministic_reason =
   | Workflow_rejection_blocked
 
 let to_telemetry_key = function
+  | Command_blocked -> "deterministic_error_command_blocked"
   | Command_shape_blocked -> "deterministic_error_command_shape_blocked"
+  | Task_state_probe_blocked ->
+    "deterministic_error_task_state_probe_blocked"
   | Destructive_operation_blocked ->
     "deterministic_error_destructive_operation_blocked"
   | Path_syntax_blocked -> "deterministic_error_path_syntax_blocked"
@@ -26,8 +31,12 @@ let to_telemetry_key = function
 ;;
 
 let to_string = function
+  | Command_blocked ->
+    "keeper shell command blocked by policy; follow recovery_plan instead"
   | Command_shape_blocked ->
     "keeper_bash command-shape blocked (pipes/redirects/chaining/substitution/scan)"
+  | Task_state_probe_blocked ->
+    "raw shell task-state probe blocked; use keeper task/context tools"
   | Destructive_operation_blocked ->
     "destructive operation blocked (force push / rm -rf / push to main)"
   | Path_syntax_blocked -> "path argument failed syntax check before execution"
@@ -72,7 +81,10 @@ let error_or_detail_string key json =
    must be wired here explicitly; an unmapped value returns [None]
    so transient/runtime errors stay outside the short-circuit. *)
 let reason_of_error_code = function
+  | "command_blocked" -> Some Command_blocked
   | "keeper_bash_command_shape_blocked" -> Some Command_shape_blocked
+  | "task_state_file_probe_blocked" | "task_state_http_probe_blocked" ->
+    Some Task_state_probe_blocked
   | "destructive_operation_blocked" -> Some Destructive_operation_blocked
   | "policy_blocked" -> Some Policy_blocked
   | "policy_not_loaded" -> Some Policy_blocked

--- a/lib/keeper/keeper_tool_deterministic_error.mli
+++ b/lib/keeper/keeper_tool_deterministic_error.mli
@@ -23,9 +23,14 @@
     [to_string] (variant -> stable telemetry label). Exhaustive match
     is enforced by [-strict-sequence] in the [dune] config. *)
 type deterministic_reason =
+  | Command_blocked
+      (** keeper_bash/keeper_shell policy block with a structured
+          recovery_plan. *)
   | Command_shape_blocked
       (** keeper_bash policy block: pipes, redirects, chaining,
           substitution, repo-wide scans, gh pr checks. *)
+  | Task_state_probe_blocked
+      (** raw shell attempted to inspect task state files or guessed task APIs. *)
   | Destructive_operation_blocked
       (** force push / rm -rf / push to main detected. *)
   | Path_syntax_blocked

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -265,6 +265,34 @@ let workflow_rejection_recovery_fields ~tool_name ~count raw =
     @ if count >= 2 then [ "workflow_rejection_loop", `Bool true ] else []
 ;;
 
+let recovery_plan_json_opt json =
+  match json_assoc_field_opt "recovery_plan" json with
+  | Some (`Assoc _ as plan) -> Some plan
+  | _ ->
+    (match detail_json_opt json with
+     | Some detail ->
+       (match json_assoc_field_opt "recovery_plan" detail with
+        | Some (`Assoc _ as plan) -> Some plan
+        | _ -> None)
+     | None -> None)
+;;
+
+let deterministic_recovery_plan_fields raw =
+  try
+    let json = Yojson.Safe.from_string raw in
+    match recovery_plan_json_opt json with
+    | None -> []
+    | Some plan ->
+      let next_tool =
+        match json_assoc_string_opt "next_tool" plan with
+        | Some next_tool -> [ "required_next_tool", `String next_tool ]
+        | None -> []
+      in
+      ("recovery_plan", plan) :: next_tool
+  with
+  | Yojson.Json_error _ -> []
+;;
+
 (** Normalize a raw tool result string into a consistent JSON envelope.
 
     The LLM sees this output directly. Without normalization, tool results
@@ -648,6 +676,7 @@ let make_keeper_tool_handler
                   , `String
                       (Keeper_tool_deterministic_error.to_string reason) )
                 ]
+                @ deterministic_recovery_plan_fields raw_result
             in
             let recovery_fields =
               workflow_rejection_recovery_fields @ deterministic_recovery_fields

--- a/lib/keeper/keeper_tools_oas.mli
+++ b/lib/keeper/keeper_tools_oas.mli
@@ -67,6 +67,11 @@ val workflow_rejection_recovery_fields
   -> string
   -> (string * Yojson.Safe.t) list
 
+(** Promote a tool-specific [recovery_plan] out of a deterministic
+    failure payload so required-tool turns can route the next call
+    without scraping nested detail text. *)
+val deterministic_recovery_plan_fields : string -> (string * Yojson.Safe.t) list
+
 (** Build the structured, recoverable envelope used when a keeper tool
     raises mutex EDEADLK / "Resource deadlock avoided". *)
 val transient_mutex_contention_tool_error

--- a/test/test_keeper_bash_retry_deterministic_close.ml
+++ b/test/test_keeper_bash_retry_deterministic_close.ml
@@ -26,6 +26,16 @@ let check_classify ~name ~expected raw =
 
 (* ── Deterministic — error code path ──────────────────────────── *)
 
+let test_command_blocked () =
+  let raw =
+    {|{"ok":false,"error":"command_blocked","reason":"Shell injection syntax blocked"}|}
+  in
+  check_classify
+    ~name:"command_blocked"
+    ~expected:(Some D.Command_blocked)
+    raw
+;;
+
 let test_command_shape_blocked () =
   let raw =
     {|{"ok":false,"error":"keeper_bash_command_shape_blocked","reason":"pipes blocked"}|}
@@ -33,6 +43,16 @@ let test_command_shape_blocked () =
   check_classify
     ~name:"keeper_bash_command_shape_blocked"
     ~expected:(Some D.Command_shape_blocked)
+    raw
+;;
+
+let test_task_state_file_probe_blocked () =
+  let raw =
+    {|{"ok":false,"error":"task_state_file_probe_blocked","reason":"Do not inspect task files"}|}
+  in
+  check_classify
+    ~name:"task_state_file_probe_blocked"
+    ~expected:(Some D.Task_state_probe_blocked)
     raw
 ;;
 
@@ -190,7 +210,9 @@ let test_telemetry_key_format () =
 
 let test_to_string_non_empty_for_every_variant () =
   let variants =
-    [ D.Command_shape_blocked
+    [ D.Command_blocked
+    ; D.Command_shape_blocked
+    ; D.Task_state_probe_blocked
     ; D.Destructive_operation_blocked
     ; D.Path_syntax_blocked
     ; D.Path_outside_sandbox
@@ -215,10 +237,15 @@ let () =
   Alcotest.run
     "keeper_bash_retry_deterministic_close"
     [ ( "classify_error_code"
-      , [ Alcotest.test_case
+      , [ Alcotest.test_case "command_blocked" `Quick test_command_blocked
+        ; Alcotest.test_case
             "command_shape_blocked"
             `Quick
             test_command_shape_blocked
+        ; Alcotest.test_case
+            "task_state_file_probe_blocked"
+            `Quick
+            test_task_state_file_probe_blocked
         ; Alcotest.test_case
             "destructive_operation_blocked"
             `Quick

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -1497,7 +1497,8 @@ let test_bash_fake_docker_executes () =
   Alcotest.(check bool) "bash output includes fake docker stdout" true
     (response_mentions raw "output" "stdout:")
 
-let test_bash_allows_validator_safe_pipe_redirect_for_coding_preset () =
+let test_bash_blocks_validator_safe_pipe_redirect_with_recovery_plan () =
+  with_tool_policy_config @@ fun () ->
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
   with_fake_docker fake_docker_echo_script @@ fun () ->
   setup_with_preset ~sandbox:Keeper_types.Docker ~preset:Keeper_types.Coding
@@ -1515,13 +1516,23 @@ let test_bash_allows_validator_safe_pipe_redirect_for_coding_preset () =
           ])
       ()
   in
-  Alcotest.(check (option bool)) "safe pipeline executes" (Some true)
+  let json = Yojson.Safe.from_string raw in
+  let recovery_plan = Json.member "recovery_plan" json in
+  Alcotest.(check (option bool)) "safe pipeline is blocked" (Some false)
     (parse_bool_field raw "ok");
-  Alcotest.(check (option string)) "bash via=docker" (Some "docker")
-    (parse_string_field raw "via");
-  Alcotest.(check bool) "bash output includes fake docker stdout" true
-    (response_mentions raw "output" "stdout:");
-  Alcotest.(check bool) "docker was invoked" true
+  Alcotest.(check (option string))
+    "shape-block error"
+    (Some "keeper_bash_command_shape_blocked")
+    (parse_string_field raw "error");
+  Alcotest.(check string)
+    "required next tool"
+    "keeper_shell"
+    (Json.member "required_next_tool" json |> Json.to_string);
+  Alcotest.(check string)
+    "recovery op"
+    "head"
+    Yojson.Safe.Util.(recovery_plan |> member "next_args" |> member "op" |> to_string);
+  Alcotest.(check bool) "docker was not invoked" false
     (Sys.file_exists log_path)
 
 let test_bash_rg_no_match_remains_successful_in_docker_route () =
@@ -1612,11 +1623,59 @@ let test_bash_blocks_gh_pr_checks_before_docker () =
   Alcotest.(check (option bool)) "blocked before docker" (Some false)
     (parse_bool_field raw "ok");
   Alcotest.(check (option string))
+    "native PR shell block"
+    (Some "command_blocked")
+    (parse_string_field raw "error");
+  Alcotest.(check (option string))
+    "required next tool"
+    (Some "keeper_pr_status")
+    (parse_string_field raw "required_next_tool");
+  Alcotest.(check bool) "docker was not invoked" false
+    (Sys.file_exists log_path)
+
+let test_bash_search_pipeline_exposes_structured_recovery_plan () =
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "alpine:test" @@ fun () ->
+  with_fake_docker fake_docker_echo_script @@ fun () ->
+  setup_with_preset ~sandbox:Keeper_types.Docker ~preset:Keeper_types.Coding
+  @@ fun ~config ~meta ~playground ->
+  let log_path = Filename.concat config.Coord.base_path "docker.log" in
+  with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
+  let raw =
+    Keeper_exec_shell.handle_keeper_bash ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None ~exec_cache:None ~config ~meta
+      ~args:
+        (`Assoc
+          [
+            ("cmd", `String "rg TODO repos | head -20");
+            ("cwd", `String playground);
+          ])
+      ()
+  in
+  let json = Yojson.Safe.from_string raw in
+  let recovery_plan = Json.member "recovery_plan" json in
+  let next_args = Json.member "next_args" recovery_plan in
+  Alcotest.(check (option bool)) "blocked before docker" (Some false)
+    (parse_bool_field raw "ok");
+  Alcotest.(check (option string))
     "shape_block"
-    (Some "gh_pr_checks")
+    (Some "repo_wide_scan")
     (parse_string_field raw "shape_block");
-  Alcotest.(check bool) "hint points to PR status tool" true
-    (response_mentions raw "hint" "keeper_pr_status");
+  Alcotest.(check string)
+    "required_next_tool"
+    "keeper_shell"
+    (Json.member "required_next_tool" json |> Json.to_string);
+  Alcotest.(check string)
+    "recovery next tool"
+    "keeper_shell"
+    (Json.member "next_tool" recovery_plan |> Json.to_string);
+  Alcotest.(check string)
+    "recovery op"
+    "rg"
+    (Json.member "op" next_args |> Json.to_string);
+  Alcotest.(check bool)
+    "same args retry forbidden"
+    true
+    (Json.member "do_not_retry_same_args" recovery_plan |> Json.to_bool);
   Alcotest.(check bool) "docker was not invoked" false
     (Sys.file_exists log_path)
 
@@ -1790,8 +1849,8 @@ let () =
             "docker keeper bash executes through fake docker"
             `Quick test_bash_fake_docker_executes;
           Alcotest.test_case
-            "docker keeper bash allows validator-safe pipe redirects"
-            `Quick test_bash_allows_validator_safe_pipe_redirect_for_coding_preset;
+            "docker keeper bash pipe redirects expose structured recovery"
+            `Quick test_bash_blocks_validator_safe_pipe_redirect_with_recovery_plan;
           Alcotest.test_case
             "docker keeper bash rg no-match remains successful"
             `Quick test_bash_rg_no_match_remains_successful_in_docker_route;
@@ -1801,6 +1860,9 @@ let () =
           Alcotest.test_case
             "docker keeper bash blocks gh pr checks before docker"
             `Quick test_bash_blocks_gh_pr_checks_before_docker;
+          Alcotest.test_case
+            "docker keeper bash shape block exposes structured recovery plan"
+            `Quick test_bash_search_pipeline_exposes_structured_recovery_plan;
           Alcotest.test_case
             "docker keeper bash rewrites host paths before exec"
             `Quick test_bash_rewrites_host_path_command_for_docker;

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -1217,6 +1217,28 @@ let test_workflow_rejection_recovery_fields_mark_loop () =
   check int "workflow rejection count" 2 (json_int "count" recovery)
 ;;
 
+let test_deterministic_recovery_plan_fields_promote_next_tool () =
+  let raw =
+    {|{"ok":false,"error":"command_blocked","recovery_plan":{"kind":"structured_tool_rewrite","next_tool":"keeper_shell","next_args":{"op":"rg","path":"lib"},"instruction":"Use keeper_shell op=rg.","reason":"shell_shape_requires_structured_op","confidence":"high","do_not_retry_same_args":true}}|}
+  in
+  let fields = Keeper_tools_oas.deterministic_recovery_plan_fields raw in
+  let normalized =
+    Keeper_tools_oas.normalize_tool_result
+      ~workflow_rejection_recovery_fields:fields
+      ~success:false
+      raw
+  in
+  let json = parse normalized in
+  check string "required next tool" "keeper_shell" (json_string "required_next_tool" json);
+  let plan = Yojson.Safe.Util.member "recovery_plan" json in
+  check string "plan next tool" "keeper_shell" (json_string "next_tool" plan);
+  check
+    string
+    "plan op"
+    "rg"
+    Yojson.Safe.Util.(member "next_args" plan |> member "op" |> to_string)
+;;
+
 let test_workflow_rejection_same_args_short_circuits_after_first_failure () =
   let meta =
     make_test_meta
@@ -1546,6 +1568,10 @@ let () =
             "workflow rejection marks repeated loop"
             `Quick
             test_workflow_rejection_recovery_fields_mark_loop
+        ; test_case
+            "deterministic recovery plan promotes next tool"
+            `Quick
+            test_deterministic_recovery_plan_fields_promote_next_tool
         ; test_case
             "workflow rejection same args stops after first failure"
             `Quick


### PR DESCRIPTION
## Summary

- Add machine-readable `recovery_plan` payloads to raw shell rejections so keepers get `next_tool`, `next_args`, and `do_not_retry_same_args` instead of prose-only hints.
- Classify `command_blocked` and task-state shell probes as deterministic retry-skip failures.
- Promote deterministic `recovery_plan` fields through the OAS wrapper so the normalized tool result exposes `required_next_tool`.
- Align docker-route tests with the stricter raw-Bash pipe policy and verify structured keeper_shell rewrites.

## Verification

- `ocamlformat --check lib/keeper/keeper_shell_bash.ml lib/keeper/keeper_shell_bash_shape_messages.ml lib/keeper/keeper_shell_bash_shape_messages.mli lib/keeper/keeper_tool_deterministic_error.ml lib/keeper/keeper_tool_deterministic_error.mli lib/keeper/keeper_tools_oas.ml lib/keeper/keeper_tools_oas.mli test/test_keeper_bash_retry_deterministic_close.ml test/test_keeper_shell_docker_route.ml test/test_keeper_tools_oas.ml`
- `git diff --check origin/main...HEAD`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_JOBS=1 scripts/dune-local.sh build test/test_keeper_bash_retry_deterministic_close.exe test/test_keeper_shell_docker_route.exe test/test_keeper_tools_oas.exe`
- `./_build/default/test/test_keeper_bash_retry_deterministic_close.exe --color=never`
- `./_build/default/test/test_keeper_shell_docker_route.exe --color=never`
- `./_build/default/test/test_keeper_tools_oas.exe test normalize_tool_result 8 --color=never`

Note: after a final conflict-free rebase, a repeat wrapper build was interrupted while waiting behind another worktree's long-held Dune lock; the same targets had passed immediately before that rebase, and CI is the final full-suite gate.
