### PR TITLE
refactor(dashboard): extract `TOOL_SUCCESS_WARN_PCT = 90` magic number

### DIFF
--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -12,6 +12,13 @@ import {
 export const PRESSURE_HOT_RATIO = 0.75
 export const PRESSURE_WARN_RATIO = 0.5
 export const STALE_ACTIVITY_SEC = 900
+// Tool-success percentage below this threshold trips the fleet
+// `attention` band and contributes to the row urgency score. Used by
+// both `fleetBand` (binary attention decision) and `rowUrgencyScore`
+// (continuous score) — extracted as a named constant per
+// `software-development.md` §"Magic Number 금지" (the same `90` literal
+// appeared at two sites with the same semantic meaning).
+export const TOOL_SUCCESS_WARN_PCT = 90
 const TELEMETRY_ACTIVITY_FRESH_SEC = 300
 const TELEMETRY_SOURCE_STALE_SEC = 900
 const OAS_EVENT_LAG_WARN_SEC = 600
@@ -328,7 +335,7 @@ export function fleetBand(row: FleetRow): FleetBand {
     || row.terminal_reason_severity === 'warn'
     || row.context_ratio >= PRESSURE_WARN_RATIO
     || (row.last_activity_ago_s != null && row.last_activity_ago_s >= STALE_ACTIVITY_SEC)
-    || (row.tool_success_pct != null && row.tool_success_pct < 90)
+    || (row.tool_success_pct != null && row.tool_success_pct < TOOL_SUCCESS_WARN_PCT)
   ) {
     return 'attention'
   }
@@ -353,7 +360,7 @@ export function rowUrgencyScore(row: FleetRow): number {
   if (row.last_activity_ago_s != null && row.last_activity_ago_s >= STALE_ACTIVITY_SEC) {
     score += Math.min(row.last_activity_ago_s / STALE_ACTIVITY_SEC, 5)
   }
-  if (typeof row.tool_success_pct === 'number' && row.tool_success_pct < 90) {
+  if (typeof row.tool_success_pct === 'number' && row.tool_success_pct < TOOL_SUCCESS_WARN_PCT) {
     score += (100 - row.tool_success_pct) / 5
   }
   return score


### PR DESCRIPTION
## 요약

`dashboard/src/components/fleet-telemetry-utils.ts` 의 magic number `90` (tool-success percentage 임계) 2-site duplicate → named constant `TOOL_SUCCESS_WARN_PCT` 추출.

## 근거

`software-development.md` §"Magic Number 금지":
> "같은 리터럴이 2곳 이상 등장하면 반드시 named constant 로 교체한다."

해당 사이트:
- `fleetBand` (line 331) — binary attention 결정: `tool_success_pct < 90` → attention band
- `rowUrgencyScore` (line 356) — 연속 urgency score 기여: `tool_success_pct < 90` → score 추가

같은 의미 (tool-success 임계) 인데 다른 두 함수에 리터럴 복붙 → drift 위험.

## 변경

기존 fleet 임계 상수 옆에 추가:

```ts
export const PRESSURE_HOT_RATIO = 0.75
export const PRESSURE_WARN_RATIO = 0.5
export const STALE_ACTIVITY_SEC = 900
+ export const TOOL_SUCCESS_WARN_PCT = 90  // new
```

두 호출 site 가 named constant 사용:

```diff
-    || (row.tool_success_pct != null && row.tool_success_pct < 90)
+    || (row.tool_success_pct != null && row.tool_success_pct < TOOL_SUCCESS_WARN_PCT)
```

```diff
- if (typeof row.tool_success_pct === 'number' && row.tool_success_pct < 90) {
+ if (typeof row.tool_success_pct === 'number' && row.tool_success_pct < TOOL_SUCCESS_WARN_PCT) {
    score += (100 - row.tool_success_pct) / 5
  }
```

## 행동 변경 없음

두 site 모두 *동일한 값* (90) 을 *named constant 경유* 로 비교. 단순 dedup.

## 영향 범위

- export 만 추가 — 기존 caller 영향 없음
- typecheck clean
- `pnpm vitest run src/components/fleet-telemetry` 103/103 PASS
- 미래 test 또는 dashboard component 가 같은 임계를 참조할 때 `TOOL_SUCCESS_WARN_PCT` import 가능

## RFC 매칭

해당 subsystem 비포함. RFC 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)