### PR TITLE
fix(dashboard): stagger full-health startup refresh

### DIFF
--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -154,6 +154,11 @@ let bg_revalidate_backoff_factor = 2.0
 
 exception Compute_timeout of string * bool
 
+let is_compute_timeout exn =
+  match exn with
+  | Compute_timeout _ -> true
+  | _ -> false
+
 let is_internal_race_cancel exn =
   match exn with
   | Eio.Cancel.Cancelled _ ->
@@ -376,7 +381,7 @@ let get_or_compute_eio ?wait_timeout_sec key ~ttl compute =
            value
        | Some (Error exn) ->
            let fallback_val = ref None in
-           if not (is_internal_race_cancel exn) then
+           if not (is_internal_race_cancel exn || is_compute_timeout exn) then
              Log.Dashboard.error "cache revalidation failed: %s" (Printexc.to_string exn);
            atomic_update table (fun map ->
              match SMap.find_opt key map with

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -804,8 +804,13 @@ let full_health_snapshot = ref None
 let full_health_refresh_in_flight = ref false
 let full_health_refresh_started_at = ref None
 let full_health_refresh_requested = ref false
-let full_health_refresh_interval_sec = 10.0
-let full_health_refresh_timeout_sec = 8.0
+let full_health_refresh_timeout_sec =
+  Float.max 8.0 Env_config_runtime.Dashboard.shell_timeout_sec
+;;
+
+let full_health_refresh_interval_sec =
+  Float.max 30.0 (full_health_refresh_timeout_sec +. 5.0)
+;;
 
 let with_full_health_snapshot_lock f =
   Stdlib.Mutex.lock full_health_snapshot_mu;
@@ -1068,6 +1073,9 @@ module For_testing = struct
 
   let refresh_full_health_snapshot_now ?(listener = "http/1.1") request =
     refresh_full_health_snapshot_sync ~listener request
+
+  let full_health_refresh_timing () =
+    (full_health_refresh_interval_sec, full_health_refresh_timeout_sec)
 end
 
 let full_health_requested request =

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -218,6 +218,9 @@ module For_testing : sig
   val refresh_full_health_snapshot_now :
     ?listener:string -> Httpun.Request.t -> unit
   (** Synchronously recomputes and stores the cached full-health snapshot. *)
+
+  val full_health_refresh_timing : unit -> float * float
+  (** Returns [(interval_sec, timeout_sec)] for the full-health refresh loop. *)
 end
 
 val keeper_fleet_runtime_resolution_fields : unit -> (string * Yojson.Safe.t) list

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1443,7 +1443,6 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
          (execution, transport_health) start immediately. *)
       Server_dashboard_http.start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock;
       Server_dashboard_http.start_transport_health_refresh_loop ~state ~sw ~clock;
-      Server_routes_http_runtime.start_full_health_snapshot_refresh_loop ~sw ~clock;
       Server_dashboard_http.start_mission_refresh_loop ~state ~sw ~clock;
       Server_dashboard_http.start_operator_snapshot_refresh_loop ~state ~sw ~clock;
       Server_dashboard_http.start_operator_digest_refresh_loop ~state ~sw ~clock;
@@ -1468,7 +1467,11 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
          | Eio.Cancel.Cancelled _ as e -> raise e
          | exn ->
              Log.Dashboard.warn "shell cache pre-warm failed: %s"
-             (Printexc.to_string exn)));
+             (Printexc.to_string exn));
+        (* Full-health scans are heavier than the probe path. Start them after
+           shell prewarm has either succeeded or exhausted its own budget so
+           cold-start diagnostics do not contend with the shell's first render. *)
+        Server_routes_http_runtime.start_full_health_snapshot_refresh_loop ~sw ~clock);
       start_lazy_startup state;
       (match catalog_validation_error with
        | Some detail -> Server_startup_state.mark_degraded ~error:detail

--- a/test/test_dashboard_cache.ml
+++ b/test/test_dashboard_cache.ml
@@ -29,6 +29,32 @@ let test_proactive_refresh_timeout_message_names_phase () =
      elapsed_s=33.2"
     msg
 
+let latest_log_seq () =
+  match Log.Ring.recent ~limit:1 () with
+  | [] -> -1
+  | entry :: _ -> entry.Log.Ring.seq
+
+let test_compute_timeout_not_logged_as_error ~clock () =
+  Dashboard_cache.invalidate_all ();
+  let before_seq = latest_log_seq () in
+  let result =
+    Dashboard_cache.get_or_compute_with_timeout "timeout-no-error" ~ttl:0.1
+      ~clock ~timeout_sec:0.01 (fun () ->
+        Eio.Time.sleep clock 0.1;
+        `String "never")
+  in
+  Alcotest.(check string) "timeout kind" "owner" (timeout_kind result);
+  let cache_revalidation_errors =
+    Log.Ring.recent ~since_seq:before_seq
+      ~min_level:(Log.level_to_int Log.Error)
+      ()
+    |> List.filter (fun entry ->
+      String_util.contains_substring entry.Log.Ring.message
+        "cache revalidation failed")
+  in
+  Alcotest.(check int) "compute timeout does not emit ERROR" 0
+    (List.length cache_revalidation_errors)
+
 (* -- 1. Nested get_or_compute must not deadlock ----------------------------- *)
 
 let test_nested_no_deadlock () =
@@ -586,6 +612,8 @@ let () =
         [
           test_case "proactive refresh timeout names phase" `Quick
             test_proactive_refresh_timeout_message_names_phase;
+          test_case "compute timeout is not logged as error" `Quick
+            (test_compute_timeout_not_logged_as_error ~clock);
           test_case "stale preserved on timeout" `Quick
             (fun () ->
                Eio.Switch.run @@ fun sw ->

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1361,6 +1361,15 @@ let test_health_response_full_query_uses_snapshot_cache () =
      | `Assoc _ -> true
      | _ -> false)
 
+let test_full_health_refresh_budget_tracks_shell_budget () =
+  let interval_sec, timeout_sec =
+    Server_routes_http_runtime.For_testing.full_health_refresh_timing ()
+  in
+  Alcotest.(check bool) "full health timeout covers shell full budget" true
+    (timeout_sec >= Env_config_runtime.Dashboard.shell_timeout_sec);
+  Alcotest.(check bool) "full health interval exceeds timeout" true
+    (interval_sec > timeout_sec)
+
 let test_health_response_survives_deleted_cwd () =
   with_temp_dir "health-deleted-cwd" (fun dir ->
       let deleted_cwd = Filename.concat dir "deleted-cwd" in
@@ -2916,6 +2925,8 @@ let () =
             test_health_response_default_is_light_probe;
           Alcotest.test_case "full health query uses snapshot cache" `Quick
             test_health_response_full_query_uses_snapshot_cache;
+          Alcotest.test_case "full health refresh budget tracks shell budget"
+            `Quick test_full_health_refresh_budget_tracks_shell_budget;
           Alcotest.test_case "health response survives deleted cwd" `Quick
             test_health_response_survives_deleted_cwd;
           Alcotest.test_case "readiness false before init" `Quick


### PR DESCRIPTION
## Summary

- stop treating expected Dashboard_cache Compute_timeout as cache revalidation ERROR noise
- delay the full-health snapshot refresh loop until shell prewarm has completed or exhausted its budget
- align full-health refresh timeout/interval with the shell full-render budget so startup diagnostics do not self-timeout under cold cache contention

## Verification

- MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_DUNE_ALLOW_LIVE_BUILD_LOCK=1 DUNE_LOCAL_JOBS=2 scripts/dune-local.sh build test/test_dashboard_cache.exe test/test_server_runtime_bootstrap.exe bin/main_eio.exe
- ./_build/default/test/test_dashboard_cache.exe test timeout 1-6 --show-errors
- ./_build/default/test/test_server_runtime_bootstrap.exe test bootstrap 39-40 --show-errors
- ocamlformat --check lib/dashboard/dashboard_cache.ml lib/server/server_routes_http_runtime.ml lib/server/server_routes_http_runtime.mli lib/server/server_runtime_bootstrap.ml test/test_dashboard_cache.ml test/test_server_runtime_bootstrap.ml

Note: full repo @fmt still reports pre-existing dune file formatting diffs unrelated to this PR.