### PR TITLE
refactor(dashboard): replace `as KeeperPhase` casts with `toKeeperPhase` typed parse

### DIFF
--- a/dashboard/src/components/keeper-phase-indicator.ts
+++ b/dashboard/src/components/keeper-phase-indicator.ts
@@ -14,6 +14,7 @@
 
 import { html } from 'htm/preact'
 import type { KeeperPhase } from '../types'
+import { toKeeperPhase } from '../keeper-store-normalize'
 import { formatDuration } from '../lib/format-time'
 
 interface PhaseStyle {
@@ -65,7 +66,17 @@ const BUFFER_PHASES = new Set<string>(['Failing', 'Overflowed', 'Compacting', 'H
 
 function getPhaseStyle(phase: KeeperPhase | string | null | undefined): PhaseStyle {
   if (!phase) return PHASE_STYLES.Offline
-  return PHASE_STYLES[phase as KeeperPhase] ?? PHASE_STYLES.Offline
+  // Use the SSOT boundary parser (`toKeeperPhase`) instead of the raw
+  // `as KeeperPhase` assertion. `toKeeperPhase` accepts both PascalCase
+  // (canonical `Keeper.phase`) and lowercase backend tokens (the same
+  // shape `phase_to_string` emits in
+  // `lib/keeper/keeper_state_machine.ml:21-34`) and returns `null` on
+  // unknown input. This matches `software-development.md` §"Parse,
+  // don't validate": arbitrary strings should be narrowed through a
+  // total parser, not coerced through an unchecked cast that silently
+  // accesses an undefined record key.
+  const typed = toKeeperPhase(phase)
+  return typed != null ? PHASE_STYLES[typed] : PHASE_STYLES.Offline
 }
 
 /** Phase badge — color-coded pill showing the keeper lifecycle phase. */

--- a/dashboard/src/components/world-visualizer.ts
+++ b/dashboard/src/components/world-visualizer.ts
@@ -7,7 +7,7 @@ import { useRef, useState, useCallback } from 'preact/hooks'
 import { keepers, messages, tasks } from '../store'
 import { kSlot, kSigil } from './keeper-badge'
 import { getPhaseStyle } from './keeper-phase-indicator'
-import type { Keeper, KeeperPhase } from '../types'
+import type { Keeper } from '../types'
 
 // ── CSS custom property resolver for Canvas 2D ────────────────────
 // Canvas doesn't understand CSS var() — we resolve at paint time via
@@ -267,7 +267,11 @@ export function WorldVisualizer() {
     for (const k of fleet) {
       const p = positions[idx]!
       const color = keeperColor(k)
-      const phaseStyle = getPhaseStyle(k.phase as KeeperPhase | null)
+      // `k.phase` is already typed as `KeeperPhase | null | undefined`
+      // on the Keeper interface (`types/core.ts:898`). The previous
+      // `as KeeperPhase | null` assertion was a no-op cast; `getPhaseStyle`
+      // accepts `KeeperPhase | string | null | undefined` natively.
+      const phaseStyle = getPhaseStyle(k.phase)
 
       ctx.beginPath()
       ctx.arc(p.x, p.y, KEEPER_RADIUS + 2, 0, 2 * Math.PI)


### PR DESCRIPTION
## 요약

`dashboard/src/components/keeper-phase-indicator.ts:getPhaseStyle` 와 `dashboard/src/components/world-visualizer.ts:270` 의 `as KeeperPhase` unchecked cast 제거. SSOT boundary parser `toKeeperPhase` 사용.

## 근거

`software-development.md` §"Parse, don't validate":
> "타입 시스템을 무시하는 건 타입 시스템을 안 쓰는것과 똑같음. 이런 실수보다 적극적으로 타입을 지키며 개발하자."

두 site 모두 `phase as KeeperPhase` cast 로 runtime 안전성 검증 없이 typed enum 으로 *강제* 변환.

## 변경

### `keeper-phase-indicator.ts:getPhaseStyle`

```diff
+import { toKeeperPhase } from '../keeper-store-normalize'
+
 function getPhaseStyle(phase: KeeperPhase | string | null | undefined): PhaseStyle {
   if (!phase) return PHASE_STYLES.Offline
-  return PHASE_STYLES[phase as KeeperPhase] ?? PHASE_STYLES.Offline
+  const typed = toKeeperPhase(phase)
+  return typed != null ? PHASE_STYLES[typed] : PHASE_STYLES.Offline
 }
```

`toKeeperPhase` 의 입력 처리:
- PascalCase (`'Offline'`, `'Running'`, ...) — pass-through
- lowercase (`'offline'`, `'running'`, ...) — backend `phase_to_string` (lib/keeper/keeper_state_machine.ml:21-34) emit 형태, PascalCase 로 정규화
- unknown — `null` 반환

기능 향상 — 이전엔 lowercase 입력이 silently `Offline` fallback 됐지만 (PHASE_STYLES key 가 PascalCase 만이라), 이제 정확한 PascalCase 매핑 후 lookup.

### `world-visualizer.ts:270`

```diff
-import type { Keeper, KeeperPhase } from '../types'
+import type { Keeper } from '../types'
...
-      const phaseStyle = getPhaseStyle(k.phase as KeeperPhase | null)
+      const phaseStyle = getPhaseStyle(k.phase)
```

`k.phase` 는 *이미* `KeeperPhase | null | undefined` typed (types/core.ts:898). `getPhaseStyle` 도 같은 type 받음. cast 가 *no-op redundant*. 같이 unused `KeeperPhase` import 정리.

## 영향 범위

- typecheck clean
- `pnpm vitest run src/components/keeper-phase-indicator` 13/13 PASS
- `pnpm vitest run src/components/world-visualizer` 9/9 PASS
- runtime 행동 동일 (입력 lowercase 였을 경우 *개선*: PascalCase lookup → 정확한 style)

## 묶음 가능 cleanup (sprint 흐름)

본 sprint 진행 중:
- PR #16723 ✅ MERGED — `isIdleTurnPhase`
- PR #16727 🟡 Draft — `agentBand` dead arm + Unknown→attention
- PR #16728 🟡 Draft — `countKeeperAttention` typed phase + `refineOfflineStatus`
- PR #16734 🟡 Draft — `keeperBand` output-side dead arm
- PR #16743 🟡 Draft — `TOOL_SUCCESS_WARN_PCT` magic number
- 이 PR — `as KeeperPhase` cast 제거 (parse-don't-validate)

## RFC 매칭

해당 subsystem 비포함. RFC 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)