### PR TITLE
feat(ci): silent-failure ratchet — gate net additions of 3 SF shapes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -967,6 +967,9 @@ jobs:
       - name: Run OAS boundary ratchet
         run: scripts/oas-boundary-ratchet.sh
 
+      - name: Run silent-failure ratchet
+        run: scripts/silent-failure-ratchet.sh
+
   keeper-cwd-leak-gate:
     name: Keeper Cwd Leak Gate
     runs-on: ubuntu-latest

--- a/scripts/silent-failure-baseline.json
+++ b/scripts/silent-failure-baseline.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "Silent-failure ratchet baseline. Regenerate with scripts/silent-failure-ratchet.sh --regenerate.",
+  "_metrics": "See scripts/silent-failure-ratchet.sh METRICS / DESCRIPTIVE_METRICS arrays.",
+  "_audit": "lib/ silent failure code-smell audit 2026-05-20",
+  "error_to_ok_silence": 13,
+  "error_result_silence": 194,
+  "exception_catchall_swallow": 7,
+  "variant_catchall_default": 2140
+}

--- a/scripts/silent-failure-ratchet.sh
+++ b/scripts/silent-failure-ratchet.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# Silent failure ratchet gate.
+#
+# Tracks four metrics that count textual silent-failure shapes in
+# OCaml sources under lib/. The baseline is committed to
+#   scripts/silent-failure-baseline.json
+# and the gate fails when any strict metric *increases* against it.
+#
+# Complementary to scripts/ci/check-silent-failure-patterns.sh
+# (binary anti-pattern detector, issue #9517). This ratchet is the
+# *trend gate* — it permits the existing population but rejects net
+# additions, so any new silent failure surfaces in PR review.
+#
+# Strict metrics (gated):
+#   - error_to_ok_silence: `| Error _ -> Ok …` — promotes failure to
+#     success silently. RFC-0088 §3 most-dangerous shape.
+#   - error_result_silence: any `| Error _ -> (Ok|None|[]|true|false|())`.
+#     Superset including the strict one.
+#   - exception_catchall_swallow: `try … with _ -> …`. Absorbs every
+#     exception including Eio.Cancel.Cancelled (KeeperOASAdvanced.tla
+#     CancelledAbsorbed model).
+#
+# Descriptive metric (printed only):
+#   - variant_catchall_default: line-leading `| _ -> (None|[]|""|false
+#     |true|()|Ok)`. Too broad to gate as strict (legitimate uses in
+#     parser fallbacks dominate) but the trend is informative.
+#
+# Policy: ratchet only — current must be <= committed baseline. PRs
+# that intentionally add a tracked shape (e.g. a refactor that
+# justifies one site) must --regenerate AND document the rationale in
+# the PR body, citing the new site. Silent baseline rebound after
+# admin override is the anti-pattern (memory:
+# feedback_ratchet-naturalization-after-admin-merge).
+#
+# Usage:
+#   scripts/silent-failure-ratchet.sh             # check; exit 0 ok / 2 drift up / 1 error
+#   scripts/silent-failure-ratchet.sh --regenerate # rewrite baseline from current counts
+#   scripts/silent-failure-ratchet.sh --print     # print current counts, no compare
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BASELINE_FILE="${REPO_ROOT}/scripts/silent-failure-baseline.json"
+
+for tool in rg python3 awk; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "[silent-failure-ratchet] required tool missing: $tool" >&2
+    exit 1
+  }
+done
+
+# Scope: lib/ OCaml sources, excluding the cdal sub-library
+# (RFC-0056 isolation — boundary policed elsewhere) and any test
+# directories nested under lib/.
+RG_SCOPE=(
+  --type ocaml
+  --glob 'lib/**/*.ml'
+  --glob '!lib/cdal/**'
+  --glob '!lib/**/test/**'
+)
+
+count_error_to_ok_silence() {
+  ( set +o pipefail
+    cd "$REPO_ROOT"
+    rg -c '\|\s*Error\s+_\s*->\s*Ok' "${RG_SCOPE[@]}" 2>/dev/null \
+      | awk -F: '{s+=$NF} END {print s+0}'
+  )
+}
+
+count_error_result_silence() {
+  ( set +o pipefail
+    cd "$REPO_ROOT"
+    rg -c '\|\s*Error\s+_\s*->\s*(Ok|None|\[\]|true|false|\(\))' "${RG_SCOPE[@]}" 2>/dev/null \
+      | awk -F: '{s+=$NF} END {print s+0}'
+  )
+}
+
+count_exception_catchall_swallow() {
+  ( set +o pipefail
+    cd "$REPO_ROOT"
+    rg -c '\btry\b[^|]*\bwith\s+_\s*->' "${RG_SCOPE[@]}" 2>/dev/null \
+      | awk -F: '{s+=$NF} END {print s+0}'
+  )
+}
+
+count_variant_catchall_default() {
+  ( set +o pipefail
+    cd "$REPO_ROOT"
+    rg -c '^\s*\|\s*_\s*->\s*(None|\[\]|""|false|true|\(\)|Ok)' "${RG_SCOPE[@]}" 2>/dev/null \
+      | awk -F: '{s+=$NF} END {print s+0}'
+  )
+}
+
+# Strict metrics — name|hint. The hint MUST NOT contain `|`; the
+# parser splits on the LAST `|`, so a literal pipe in the hint would
+# truncate the metric name. Describe variant shapes in prose instead.
+METRICS=(
+  "error_to_ok_silence|Error arm collapsed into Ok promotes failure to success silently. Propagate the error or wrap in a typed envelope."
+  "error_result_silence|Error arm collapsed into a constant default Ok/None/empty-list/true/false/unit. Propagate the error or extract via a guarded helper."
+  "exception_catchall_swallow|try with underscore catches every exception including Eio.Cancel.Cancelled. Match concrete exception constructors instead."
+)
+
+DESCRIPTIVE_METRICS=(
+  "variant_catchall_default|Line-leading wildcard arm returning a default constant. Trend only — too broad to gate."
+)
+
+current_value() {
+  case "$1" in
+    error_to_ok_silence)         count_error_to_ok_silence ;;
+    error_result_silence)        count_error_result_silence ;;
+    exception_catchall_swallow)  count_exception_catchall_swallow ;;
+    variant_catchall_default)    count_variant_catchall_default ;;
+    *) echo "unknown metric: $1" >&2; exit 1 ;;
+  esac
+}
+
+baseline_value() {
+  local name="$1"
+  if [[ -f "$BASELINE_FILE" ]]; then
+    python3 -c "
+import json
+with open('$BASELINE_FILE') as f:
+    data = json.load(f)
+print(data.get('$name', 0))
+"
+  else
+    echo 0
+  fi
+}
+
+print_counts() {
+  printf "%-32s %9s  %9s\n" "metric" "current" "baseline"
+  echo "----------------------------------------------------------------"
+  echo "[strict — ratchet enforced]"
+  for spec in "${METRICS[@]}"; do
+    local name="${spec%%|*}"
+    local current baseline
+    current=$(current_value "$name")
+    baseline=$(baseline_value "$name")
+    printf "%-32s %9d  %9d\n" "$name" "$current" "$baseline"
+  done
+  echo
+  echo "[descriptive — recorded only]"
+  for spec in "${DESCRIPTIVE_METRICS[@]}"; do
+    local name="${spec%%|*}"
+    local current baseline
+    current=$(current_value "$name")
+    baseline=$(baseline_value "$name")
+    printf "%-32s %9d  %9d\n" "$name" "$current" "$baseline"
+  done
+}
+
+regenerate() {
+  local v_eto v_err v_exc v_var
+  v_eto=$(count_error_to_ok_silence)
+  v_err=$(count_error_result_silence)
+  v_exc=$(count_exception_catchall_swallow)
+  v_var=$(count_variant_catchall_default)
+  python3 - "$BASELINE_FILE" "$v_eto" "$v_err" "$v_exc" "$v_var" <<'PYEOF'
+import json, sys
+path, eto, err, exc, var = sys.argv[1], *map(int, sys.argv[2:])
+data = {
+    "_comment": "Silent-failure ratchet baseline. Regenerate with scripts/silent-failure-ratchet.sh --regenerate.",
+    "_metrics": "See scripts/silent-failure-ratchet.sh METRICS / DESCRIPTIVE_METRICS arrays.",
+    "_audit": "lib/ silent failure code-smell audit 2026-05-20",
+    "error_to_ok_silence":        eto,
+    "error_result_silence":       err,
+    "exception_catchall_swallow": exc,
+    "variant_catchall_default":   var,
+}
+with open(path, "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+print(f"[regenerate] wrote {path}")
+PYEOF
+}
+
+check() {
+  local drift=0
+  for spec in "${METRICS[@]}"; do
+    local name="${spec%%|*}"
+    local hint="${spec##*|}"
+    local current baseline
+    current=$(current_value "$name")
+    baseline=$(baseline_value "$name")
+    if (( current > baseline )); then
+      echo "[silent-failure-ratchet] DRIFT UP: $name current=$current baseline=$baseline" >&2
+      echo "  hint: $hint" >&2
+      drift=1
+    fi
+  done
+  return $drift
+}
+
+case "${1:-}" in
+  --print)
+    print_counts
+    ;;
+  --regenerate)
+    regenerate
+    ;;
+  "")
+    print_counts
+    if check; then
+      echo
+      echo "[silent-failure-ratchet] OK"
+      exit 0
+    else
+      echo
+      echo "[silent-failure-ratchet] FAIL — current exceeds baseline" >&2
+      echo "  if the increase is intentional, run --regenerate AND" >&2
+      echo "  document the new site(s) in the PR body." >&2
+      exit 2
+    fi
+    ;;
+  *)
+    echo "usage: $0 [--print | --regenerate]" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Goal
오늘 audit에서 가시화된 silent failure population을 *현재 수준에서 고정* + *증가 차단*. PR #16731 (Tier B2) / PR #16739 (Tier A1) 직접 fix와 paired — 머지된 fix는 baseline 감소, 신규 silent failure 도입은 ratchet drift fail.

## Why ratchet over binary gate
- 기존 `scripts/ci/check-silent-failure-patterns.sh` (Issue #9517)는 binary detector. 5 패턴만 cover.
- 본 audit에서 발견된 198 site는 *전부 fix하기 전*에 새 silent failure 도입을 막을 메커니즘 필요.
- RFC-0126 lint stack ratchet 패턴 재사용: baseline JSON + drift check. AI 에이전트가 워크어라운드를 누적 학습하는 spiral을 baseline cap으로 차단.

## Surface
| 파일 | 역할 |
|---|---|
| `scripts/silent-failure-ratchet.sh` | 4 metric count, baseline 비교, --print / --regenerate / default check |
| `scripts/silent-failure-baseline.json` | 3 strict + 1 descriptive 현재 count |
| `.github/workflows/ci.yml` (+3 LoC) | `structure-ratchet` job에 step 추가 (lib_deps / build 변경 시 발동) |

## Strict metrics (gated)
| Metric | Baseline | RFC-0088 시그니처 |
|---|---|---|
| `error_to_ok_silence` | **13** | §3 most dangerous: 실패를 성공으로 promote |
| `error_result_silence` | **194** | §3 일반화: Error를 default constant로 collapse |
| `exception_catchall_swallow` | **7** | §3 + KeeperOASAdvanced.tla `CancelledAbsorbed`: try/with _ → cancellation 흡수 |

## Descriptive (trend only)
| Metric | Baseline |
|---|---|
| `variant_catchall_default` | 2140 |

## Scope discipline
- `lib/**/*.ml`
- exclude `lib/cdal/**` (RFC-0056 isolated sub-library)
- exclude `lib/**/test/**`

기존 `*-ratchet.sh` siblings (`oas-boundary`, `stringly-boundary`, `ocaml-structure`)와 동일 패턴.

## Drift detection 검증
- 합성 site `let foo = match Ok x with Ok v -> v | Error _ -> Ok 0` 를 `lib/test_silent_drift.ml`에 추가
- `error_to_ok_silence` 13→14, `error_result_silence` 194→195
- ratchet `--check` exit=2, DRIFT UP 메시지 2개 출력
- 파일 제거 → exit=0 복귀

## Behavior on existing PRs
- PR #16731 (Tier B2, telemetry dedup): 행복 경로 동작 변경 없음 — `_ -> true` 가 `_ -> false` 등 새 catch-all로 바뀌지 않고 exhaustive variant로 대체. variant_catchall_default 1 감소 가능 (descriptive).
- PR #16739 (Tier A1, cascade parser): 8 site 제거 → error_result_silence -8, error_to_ok_silence 부분 -0 (cascade parser는 `Error _ -> Ok` 형식 없음, `Error _ -> None/[]` 형식). 머지 시 ratchet baseline regenerate 권장.

## Self-review (best-programmer)
- [x] 기존 `*-ratchet.sh` 패턴 일관성 (script + JSON + ci.yml step)
- [x] 메트릭 단순 — strict/descriptive 분리 명시
- [x] hint 안에 `|` literal 회피 (parser 자르기 방지)
- [x] cdal/test 제외 scope = sibling ratchet 동일
- [x] commit message가 WHY 명시 (RFC-0088 + #9517 보완 + RFC-0126 패턴)
- [x] silent failure 신규 도입 없음 (자체 script)

## Risk
- Baseline은 *snapshot* (origin/main `a0538bb117`). PR #16731/#16739 머지 후 *너무 빠르게* baseline regenerate 안 하면 PR drift up false-positive 가능 — regenerate는 fix PR과 묶어서.
- 새 site가 의도적일 경우 `--regenerate` 후 PR body에 사이트 명시 의무 (commit message에 policy 명시).

## Related
- audit context: lib/ silent failure 코드 스멜 감사 (2026-05-20)
- stack: PR #16731 / #16739 와 disjoint, 독립 머지 가능
- 후속: RFC drafts (keeper_cascade_profile / credential_store / cascade_error_classify)