### PR TITLE
docs(rfc): backfill implementation_prs for 37 audit-miss RFCs

### DIFF
--- a/docs/rfc/RFC-0091-keeper-bash-typed-argv.md
+++ b/docs/rfc/RFC-0091-keeper-bash-typed-argv.md
@@ -3,12 +3,12 @@ rfc: "0091"
 title: "Keeper bash tool: cmd string → typed Argv schema (lexer/validator 박멸)"
 status: Draft
 created: 2026-05-17
-updated: 2026-05-17
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0042", "0084", "0089"]
-implementation_prs: []
+implementation_prs: [15720]
 ---
 
 # RFC-0091 — Keeper bash tool: cmd string → typed Argv schema

--- a/docs/rfc/RFC-0093-board-persistence-path-unification.md
+++ b/docs/rfc/RFC-0093-board-persistence-path-unification.md
@@ -3,12 +3,12 @@ rfc: "0093"
 title: "Board persistence — path unification (snapshot vs append)"
 status: Draft
 created: 2026-05-17
-updated: 2026-05-17
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0077", "0042", "0062"]
-implementation_prs: []
+implementation_prs: [15711]
 ---
 
 # RFC-0093 — Board persistence: path unification

--- a/docs/rfc/RFC-0097-keeper-sandbox-container-reuse.md
+++ b/docs/rfc/RFC-0097-keeper-sandbox-container-reuse.md
@@ -3,12 +3,12 @@ rfc: "0097"
 title: "Keeper sandbox container reuse (long-running sandbox per keeper)"
 status: In-progress
 created: 2026-05-17
-updated: 2026-05-17
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0042", "0107"]
-implementation_prs: ["#15991"]
+implementation_prs: [15991]
 ---
 
 # RFC-0097 — Keeper sandbox container reuse


### PR DESCRIPTION
## Summary

Two-commit follow-up to PR #16746 (RFC documentation sync). The first commit fixed three RFCs missed by #16746's grep audit; the second commit ran a full sweep and backfilled **34 additional Draft RFCs** whose `implementation_prs:` field was empty despite having merged work.

| Commit | Files | What |
|---|---|---|
| `a7b3357d2d` | 3 | RFC-0091/0093/0097 audit miss + format normalize (`[\"#15991\"]` → `[15991]`) |
| `1c71fd4708` | 34 | Full sweep — 91 unique PR refs backfilled across 34 RFCs |

**Total: 37 RFCs, 92 PR refs added.**

## Audit method (second commit)

```bash
for f in docs/rfc/RFC-*.md with `implementation_prs: []`:
  rfc = number(f)
  candidates = git log --all --oneline --grep=\"RFC-${rfc}\"
  impls = [pr_num(c) for c in candidates
           if commit_subject(c) contains \"RFC-${rfc}\"]
  if impls: backfill(rfc, sort(uniq(impls)))
```

The classifier requires the RFC number to appear in the **commit subject** (not just the body) — this filters out PRs that only cross-reference the RFC in their description.

## Largest batches

| RFC | # PRs | Topic |
|---|---|---|
| RFC-0071 | 16 | Exhaustive-match sweep codemod sprint |
| RFC-0108 *(atomic-jsonl-append, not the collision-twin)* | 9 | Atomic JSONL append |
| RFC-0086 | 7 | Keeper namespace bulk promotion |
| RFC-0072 | 7 | Keeper sub-FSM transitions typed |
| RFC-0131 | 7 | Shell Command Gate (ongoing) |
| RFC-0136 | 7 | Phase 4 retry loop |
| RFC-0106 | 6 | Cancel-safe try-with discipline |

## Scope guard

- **Docs-only.** Only `docs/rfc/RFC-*.md` frontmatter touched.
- **No status promotion.** All RFCs keep their current Draft / In-progress / Active value.
- **Format consistency.** Bare ints in `[]`, no quotes, no `#` prefix — matches the convention #16746 introduced.

## Deliberately out of scope

- **RFC number collisions**: RFC-0108 and RFC-0136 each have two files claiming the same number (e.g. `RFC-0108-atomic-jsonl-append.md` vs `RFC-0108-pr-worktree-operation-safety-gates.md`). My `ls RFC-NNNN-*.md | head -1` picks alphabetically first → second twin not backfilled. **Needs manual disambiguation in a separate sweep.**
- **Cross-reference-only PRs**: kept out of `implementation_prs:` to avoid inflating the field with related-but-not-implementation work.
- **Renumbered RFCs**: a few merged PRs cite the *original* RFC number before renumber (e.g. PR #15711 says \"RFC-0091\" but the body is now RFC-0093). Handled case-by-case in commit `a7b3357d2d`; the sweep didn't re-audit them.

## Verification

```bash
# After this PR, the sweep should return zero entries:
$ bash <<'X' | wc -l
for f in docs/rfc/RFC-*.md; do
  rfc=\$(basename \$f | grep -oE 'RFC-[0-9]+' | head -1 | sed 's/RFC-//')
  grep -q '^implementation_prs: \[\]\$' \"\$f\" || continue
  c=\$(git log --all --oneline --grep=\"RFC-\$rfc\" | grep -cE \"RFC-\$rfc([^0-9]|\\\$)\")
  [[ \"\$c\" -gt 0 ]] && echo \"\$rfc\"
done
X
```

Expected: zero output (modulo the two collision-twins flagged above).

## Self-review

- [x] Each cited PR is merged (`git log --all` only shows merged PRs in this repo).
- [x] Format consistency: bare ints in `[]`, no quotes, no `#` prefix.
- [x] No status field touched.
- [x] `updated: 2026-05-20` set on all 37 files.
- [x] Worktree-first, no main edits.

## Future work

- **Automation**: `scripts/rfc-impl-prs-sync.sh` + CI gate so the ledger stays in sync without manual sweeps. Separate RFC-scale design.
- **Collision resolution**: RFC-0108 / RFC-0136 number twins.

## RFC discovery check

Per `~/me/instructions/workflow-pr.md` §11: docs-only PR. Does not touch credential / identity / operator / sandbox runtime / dashboard credential / hooks. No `pr-rfc-check.sh` waiver needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>