### PR TITLE
refactor(rfc-0136): PR-4-c extract dispatch_with_watchdog from do_run

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -241,6 +241,7 @@
   keeper_unified_turn_pre_dispatch
   keeper_unified_turn_retry_setup
   keeper_unified_turn_terminal_error
+  keeper_unified_turn_attempt_watchdog
   keeper_unified_turn_livelock_block
   keeper_exec_context
   keeper_guards

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -487,94 +487,60 @@ let run_keeper_cycle
                                 ~turn_id:keeper_turn_id
                                 ~prev:Keeper_turn_fsm.Awaiting_provider
                                 Keeper_turn_fsm.Streaming;
-                              try
-                                Eio.Time.with_timeout_exn
-                                  clock
-                                  attempt_watchdog_s
-                                  (fun () ->
-                                     Keeper_agent_run.run_turn
-                                       ~config
-                                       ~meta:run_meta
-                                       ~base_dir
-                                       ~max_context:execution.max_context
-                                       ~build_turn_prompt
-                                       ~user_message
-                                       ~cascade_name:execution.cascade_name
-                                       ~world_observation:observation
-                                       ~turn_affordances
-                                       ?provider_filter:
-                                         (Env_config_keeper.KeeperCascade
-                                          .provider_allowlist
-                                            ())
-                                       ~generation:run_generation
-                                       ~max_turns
-                                       ~max_idle_turns
-                                       ~history_user_source:"world_state_prompt"
-                                       ~history_assistant_source:"internal_assistant"
-                                       ~degraded_retry_applied:
-                                         (Option.is_some !degraded_retry_info)
-                                       ?degraded_retry_cascade:
-                                         (Option.map
-                                            (fun (retry : EC.degraded_retry) ->
-                                               retry.next_cascade)
-                                            !degraded_retry_info)
-                                       ?fallback_reason:
-                                         (Option.map
-                                            (fun (retry : EC.degraded_retry) ->
-                                               retry.fallback_reason)
-                                            !degraded_retry_info)
-                                       ~cascade_rotation_attempts:
-                                         (List.rev !cascade_rotation_attempts)
-                                       ~temperature:execution.temperature
-                                       ~max_tokens:execution.max_tokens
-                                       ~oas_timeout_s
-                                       ~oas_timeout_is_explicit:false
-                                       ?max_cost_usd
-                                       ~trajectory_acc
-                                       ~is_retry
-                                       ?shared_context
-                                       ?event_bus:(Keeper_event_bus.get ())
-                                       ())
-                              with
-                              | Eio.Cancel.Cancelled _ as e ->
-                                (* Cycle 1b-iv: external cancellation that escapes the
-                     in-band receipt builder in [Keeper_agent_run.run_turn].
-                     The 14 inner Cancel handlers all re-raise; without an
-                     outer catch the receipt for this turn is silently
-                     dropped (FSM emits Streaming then nothing — the turn
-                     just disappears from the operator's timeline).
-
-                     Emit a minimal cancelled receipt + matching FSM
-                     Cancelled transition before re-raising.  When
-                     [fiber_stop] is confirmed set in the registry the
-                     cancellation came from the supervisor cooperative-stop
-                     path: emit SupervisorRequestsStop (Streaming →
-                     Streaming) to record the signal-raised window, then
-                     HonorStopSignal (Streaming → Cancelled supervisor_stop).
-                     For other Eio cancellations (switch teardown, timeout)
-                     [fiber_stop] is false and we skip straight to
-                     HonorStopSignal with the same conservative cancel
-                     reason. *)
-                                record_streaming_cancelled_observation
-                                  ~config
-                                  ~run_meta
-                                  ~run_generation
-                                  ~cascade_name:execution.cascade_name
-                                  ~keeper_turn_id
-                                  ();
-                                raise e
-                              | Eio.Time.Timeout ->
-                                Error
-                                  (Agent_sdk.Error.Api
-                                     (Timeout
-                                        { message =
-                                            Printf.sprintf
-                                              "Turn wall-clock budget exhausted during \
-                                               cascade attempt (budget=%.1fs, \
-                                               watchdog=%.1fs)"
-                                              oas_timeout_s
-                                              attempt_watchdog_s
-                                        })))
+                              Keeper_unified_turn_attempt_watchdog.dispatch
+                                ~clock
+                                ~attempt_watchdog_s
+                                ~oas_timeout_s
+                                ~on_cancelled:(fun () ->
+                                  record_streaming_cancelled_observation
+                                    ~config
+                                    ~run_meta
+                                    ~run_generation
+                                    ~cascade_name:execution.cascade_name
+                                    ~keeper_turn_id
+                                    ())
+                                ~run:(fun () ->
+                                  Keeper_agent_run.run_turn
+                                    ~config
+                                    ~meta:run_meta
+                                    ~base_dir
+                                    ~max_context:execution.max_context
+                                    ~build_turn_prompt
+                                    ~user_message
+                                    ~cascade_name:execution.cascade_name
+                                    ~world_observation:observation
+                                    ~turn_affordances
+                                    ?provider_filter:
+                                      (Env_config_keeper.KeeperCascade.provider_allowlist ())
+                                    ~generation:run_generation
+                                    ~max_turns
+                                    ~max_idle_turns
+                                    ~history_user_source:"world_state_prompt"
+                                    ~history_assistant_source:"internal_assistant"
+                                    ~degraded_retry_applied:
+                                      (Option.is_some !degraded_retry_info)
+                                    ?degraded_retry_cascade:
+                                      (Option.map
+                                         (fun (retry : EC.degraded_retry) ->
+                                            retry.next_cascade)
+                                         !degraded_retry_info)
+                                    ?fallback_reason:
+                                      (Option.map
+                                         (fun (retry : EC.degraded_retry) ->
+                                            retry.fallback_reason)
+                                         !degraded_retry_info)
+                                    ~cascade_rotation_attempts:
+                                      (List.rev !cascade_rotation_attempts)
+                                    ~temperature:execution.temperature
+                                    ~max_tokens:execution.max_tokens
+                                    ~oas_timeout_s
+                                    ~oas_timeout_is_explicit:false
+                                    ?max_cost_usd
+                                    ~trajectory_acc
+                                    ~is_retry
+                                    ?shared_context
+                                    ?event_bus:(Keeper_event_bus.get ())
+                                    ()))
                        in
                        let fail_open_rotation_cascades =
                          active_fail_open_rotation_cascades ()

--- a/lib/keeper/keeper_unified_turn_attempt_watchdog.ml
+++ b/lib/keeper/keeper_unified_turn_attempt_watchdog.ml
@@ -1,0 +1,23 @@
+let dispatch
+      ~clock
+      ~attempt_watchdog_s
+      ~oas_timeout_s
+      ~on_cancelled
+      ~run
+  =
+  try Eio.Time.with_timeout_exn clock attempt_watchdog_s run with
+  | Eio.Cancel.Cancelled _ as e ->
+    on_cancelled ();
+    raise e
+  | Eio.Time.Timeout ->
+    Error
+      (Agent_sdk.Error.Api
+         (Timeout
+            { message =
+                Printf.sprintf
+                  "Turn wall-clock budget exhausted during cascade attempt \
+                   (budget=%.1fs, watchdog=%.1fs)"
+                  oas_timeout_s
+                  attempt_watchdog_s
+            }))
+;;

--- a/lib/keeper/keeper_unified_turn_attempt_watchdog.mli
+++ b/lib/keeper/keeper_unified_turn_attempt_watchdog.mli
@@ -1,0 +1,28 @@
+(** RFC-0136 PR-4-c: wrap [Eio.Time.with_timeout_exn] + the
+    [Eio.Cancel.Cancelled] / [Eio.Time.Timeout] handling for a single
+    keeper turn cascade attempt.  Extracted from
+    [keeper_unified_turn.ml] do_run closure (L490-L577).
+
+    Three outcomes:
+
+    - normal completion: pass-through of [run]'s [result]
+    - [Eio.Cancel.Cancelled]: invoke [on_cancelled] for the terminal
+      receipt + FSM transition, then re-raise so the outer cleanup
+      handler observes the cancellation
+    - [Eio.Time.Timeout]: return [Error (Api (Timeout {message}))]
+      with the budget / watchdog values inlined for operator
+      diagnostics
+
+    The Cancelled re-raise path is the outer catch for cancellations
+    that escape the in-band receipt builder in
+    [Keeper_agent_run.run_turn]: the 14 inner Cancel handlers all
+    re-raise, so without [on_cancelled] the FSM emits Streaming and
+    then nothing — the turn silently disappears from the operator's
+    timeline.  Cycle 1b-iv. *)
+val dispatch
+  :  clock:_ Eio.Time.clock
+  -> attempt_watchdog_s:float
+  -> oas_timeout_s:float
+  -> on_cancelled:(unit -> unit)
+  -> run:(unit -> ('a, Agent_sdk.Error.sdk_error) result)
+  -> ('a, Agent_sdk.Error.sdk_error) result


### PR DESCRIPTION
## 요약

RFC-0136 Phase 4 PR-4-c — `do_run` closure 안의 `Eio.Time.with_timeout_exn` 블록 + Cancelled/Timeout 핸들링을 sibling typed wrapper 모듈로 추출.

## 변경

| 파일 | 변경 | LoC |
|------|------|-----|
| `lib/keeper/keeper_unified_turn.ml` | try-with 블록 -> wrapper 호출 | **-33** |
| `lib/keeper/keeper_unified_turn_attempt_watchdog.ml` | typed dispatch | +23 |
| `lib/keeper/keeper_unified_turn_attempt_watchdog.mli` | signature + Cycle 1b-iv 코멘트 | +28 |
| `lib/dune` | private_modules 등록 | +1 |

## RFC-0136 누적

| Phase | LoC Δ |
|-------|-------|
| PR-1 (Phase Gate, #16604) | -130 |
| PR-2 (Cascade Resolution) | -50 |
| PR-3 (Pre-dispatch) | -33 |
| PR-4-a (Retry Setup, #16701) | -55 |
| PR-4-b (Terminal Error, #16709) | -25 |
| **PR-4-c (이 PR)** | **-33** |
| 누적 | -326 |
| **base 1943 -> 1642 (-15.5%)** | |

## 보존 invariant

- **Cycle 1b-iv outer cancellation receipt**: `on_cancelled` callback 으로 `record_streaming_cancelled_observation` 호출 보존. FSM `Streaming -> ???` silent gap 안 생김.
- **Wall-clock timeout 메시지**: `Printf.sprintf` 의 budget/watchdog 값 그대로 inline (operator diagnostics 보존).
- **`Eio.Cancel.Cancelled` re-raise**: catch + on_cancelled invoke + raise — outer cleanup handler 가 그대로 catch.
- **typed boundary**: `('a, Agent_sdk.Error.sdk_error) result` row-polymorphic, clock kind 도 row-polymorphic.

## 검증

- ✅ Edit 후 syntax paren 매칭 manual 확인 (with_keeper_turn_span callback close paren).
- ⚠️ `dune build --root .` worktree timeout (dune-local lock contention 패턴, 메모리 reference). CI 가 ground truth.
- ✅ 코드 의도 보존 — 호출 시 동일 callback chain + 동일 typed error 반환.

## RFC

`docs/rfc/RFC-0136-keeper-unified-turn-decomposition.md`

## Stacked-after

- PR-4-a #16701 (Retry Setup) — MERGED
- PR-4-b #16709 (Terminal Error) — MERGED

## Anti-pattern 가드

- ✅ workaround 없음 (typed boundary, generic wrapper, side-effect-free dispatch)
- ✅ callsite 변경 0 churn 외 (1 callsite 직접 교체, behavior 동일)
- ✅ test backdoor 없음
- ✅ string classifier 없음

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
