### PR TITLE
refactor(dashboard): retire 4 MASC_NAMESPACE_TRUTH_*_TIMEOUT_S env knobs [RFC-0138 Step 4]

### DIFF
--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -268,14 +268,12 @@ let dashboard_entries =
       "Duration after which a signal is stale (seconds, 20 min)";
     entry ~default:"8" "MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S"
       "Transport health timeout";
-    entry ~default:"15.0" "MASC_NAMESPACE_TRUTH_COLD_TIMEOUT_S"
-      "Namespace-truth fiber base timeout on cold start (seconds, 1-120)";
-    entry ~default:"4.0" "MASC_NAMESPACE_TRUTH_COLD_SAFETY_MARGIN_S"
-      "Extra margin added to shell fiber timeout on cold start (seconds, 0-60)";
-    entry ~default:"12.0" "MASC_NAMESPACE_TRUTH_SHELL_FIBER_TIMEOUT_S"
-      "Namespace-truth shell fiber timeout after warm-up (seconds, 1-120)";
-    entry ~default:"8.0" "MASC_NAMESPACE_TRUTH_WARM_TIMEOUT_S"
-      "Namespace-truth fiber base timeout after warm-up (seconds, 1-120)";
+    (* RFC-0138 Phase 3 Step 4 — MASC_NAMESPACE_TRUTH_*_TIMEOUT_S env
+       knobs retired.  After Step 3 (#16738) wired /project-snapshot
+       through Dashboard_snapshot, the fallback path that consumed
+       those tunables runs at most once per process lifetime; values
+       are now module constants in
+       [Server_dashboard_http_namespace_truth]. *)
   ]
 
 (* --- New categories for the 229 missing env vars --- *)

--- a/lib/server/server_dashboard_http_namespace_truth.ml
+++ b/lib/server/server_dashboard_http_namespace_truth.ml
@@ -12,9 +12,18 @@ let float_of_env_default_with_legacy ~canonical ~legacy ~default ~min_v ~max_v =
   | Some _ -> float_of_env_default canonical ~default ~min_v ~max_v
   | None -> float_of_env_default legacy ~default ~min_v ~max_v
 
-let namespace_truth_shell_refresh_timeout_s () =
-  float_of_env_default "MASC_NAMESPACE_TRUTH_SHELL_REFRESH_TIMEOUT_S"
-    ~default:5.0 ~min_v:0.25 ~max_v:60.0
+(* RFC-0138 Phase 3 Step 4 — fallback timeouts are now hard-coded
+   module constants.  Step 3 (#16738) wired /project-snapshot through
+   [Dashboard_snapshot], so this fallback path is taken at most once
+   per process lifetime (cold-start before the refresh fiber's first
+   publish).  The previous [MASC_NAMESPACE_TRUTH_*_TIMEOUT_S] env
+   knobs tuned a path that no longer carries steady-state load. *)
+let namespace_truth_shell_refresh_timeout_s = 5.0
+let namespace_truth_warm_escape_s = 90.0
+let namespace_truth_warm_timeout_s = 8.0
+let namespace_truth_cold_timeout_s = 15.0
+let namespace_truth_shell_fiber_timeout_s = 12.0
+let namespace_truth_cold_safety_margin_s = 4.0
 
 let namespace_truth_bootstrap_shell_json () =
   let generated_at = Masc_domain.now_iso () in
@@ -60,7 +69,7 @@ let schedule_namespace_truth_shell_refresh ~sw ~clock config =
         Eio_guard.protect
           ~finally:(fun () -> Atomic.set namespace_truth_shell_refreshing false)
           (fun () ->
-             let timeout_s = namespace_truth_shell_refresh_timeout_s () in
+             let timeout_s = namespace_truth_shell_refresh_timeout_s in
              let t0 = Time_compat.now () in
              try
                let result =
@@ -96,11 +105,7 @@ let dashboard_namespace_truth_http_json ~state ~sw ~clock _request =
      on cold-start on-demand compute. The frontend retries every 3s via
      scheduleWarmRetry; the proactive refresh loop populates execution_cache
      in background. *)
-  let warm_escape_s =
-    float_of_env_default "MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S"
-      ~default:75.0 ~min_v:30.0 ~max_v:300.0
-    +. 15.0
-  in
+  let warm_escape_s = namespace_truth_warm_escape_s in
   let proactive_first_cycle_pending =
     not (cached_surface_has_success Execution_surfaces.execution_cache)
     &&
@@ -129,17 +134,12 @@ let dashboard_namespace_truth_http_json ~state ~sw ~clock _request =
         let execution_ref = ref (`Assoc []) in
         let command_ref = ref (`Assoc []) in
         (* Namespace-truth fiber timeouts.  Cold start uses higher defaults to
-           allow shell/namespace reads to warm up.  Tunable via env for fleets
-           whose observed fetch latency drifts above the literal defaults (see
-           #7908 — fleet p50 ≈ 17s made the 12s shell cap misfire). *)
-        let warm_timeout_s =
-          float_of_env_default "MASC_NAMESPACE_TRUTH_WARM_TIMEOUT_S"
-            ~default:8.0 ~min_v:1.0 ~max_v:120.0
-        in
-        let cold_timeout_s =
-          float_of_env_default "MASC_NAMESPACE_TRUTH_COLD_TIMEOUT_S"
-            ~default:15.0 ~min_v:1.0 ~max_v:120.0
-        in
+           allow shell/namespace reads to warm up.  Constants used to be
+           tunable via [MASC_NAMESPACE_TRUTH_*_TIMEOUT_S] but Step 4 retires
+           those knobs — see module-level [namespace_truth_*_timeout_s]
+           bindings for the rationale. *)
+        let warm_timeout_s = namespace_truth_warm_timeout_s in
+        let cold_timeout_s = namespace_truth_cold_timeout_s in
         let is_cold =
           not (cached_surface_has_success Execution_surfaces.execution_cache)
         in
@@ -163,14 +163,8 @@ let dashboard_namespace_truth_http_json ~state ~sw ~clock _request =
            (dashboard_shell_timeout_s, default 8s) to avoid the double-timeout
            race where the inner cache returns timeout-error JSON while the outer
            fiber also fires, discarding even stale data.  Fixes #5090. *)
-        let shell_fiber_timeout_s =
-          float_of_env_default "MASC_NAMESPACE_TRUTH_SHELL_FIBER_TIMEOUT_S"
-            ~default:12.0 ~min_v:1.0 ~max_v:120.0
-        in
-        let cold_safety_margin_s =
-          float_of_env_default "MASC_NAMESPACE_TRUTH_COLD_SAFETY_MARGIN_S"
-            ~default:4.0 ~min_v:0.0 ~max_v:60.0
-        in
+        let shell_fiber_timeout_s = namespace_truth_shell_fiber_timeout_s in
+        let cold_safety_margin_s = namespace_truth_cold_safety_margin_s in
         let shell_timeout_s =
           if Atomic.get shell_warmed then shell_fiber_timeout_s
           else Float.max cold_timeout_s (shell_fiber_timeout_s +. cold_safety_margin_s)

--- a/lib/server/server_dashboard_shell_snapshot.ml
+++ b/lib/server/server_dashboard_shell_snapshot.ml
@@ -73,7 +73,7 @@ let select_telemetry_summary_json
         Server_timing.measure
           timing_obj
           Server_timing.Telemetry_summary_aggregate
-          (fun () -> Telemetry_unified.summary_json ~base_path ~masc_root ()))
+          (fun () -> Telemetry_unified.summary_json ~base_path ~masc_root ())))
 ;;
 
 let select_project_snapshot_json ~state ~sw ~clock ?timing req


### PR DESCRIPTION
## Summary

**RFC-0138 Phase 3 Step 4 — retire 4 `MASC_NAMESPACE_TRUTH_*_TIMEOUT_S` env knobs from the operator surface.**

After Step 3 (#16738) wired `/api/v1/dashboard/project-snapshot` (+ aliases `/namespace-truth`, `/room-truth`) through `Dashboard_snapshot.current ()`, the fallback compute path in `dashboard_namespace_truth_http_json` is now taken **at most once per process lifetime** (cold-start, before the refresh fiber's first publish). The env knobs that tuned this path no longer carry steady-state load and can be retired without operator impact.

## Retired env knobs (4)

| knob | former default | retire site |
|---|---|---|
| `MASC_NAMESPACE_TRUTH_SHELL_REFRESH_TIMEOUT_S` | 5.0 | `schedule_namespace_truth_shell_refresh` |
| `MASC_NAMESPACE_TRUTH_WARM_TIMEOUT_S` | 8.0 | fallback `warm_timeout_s` |
| `MASC_NAMESPACE_TRUTH_COLD_TIMEOUT_S` | 15.0 | fallback `cold_timeout_s` |
| `MASC_NAMESPACE_TRUTH_SHELL_FIBER_TIMEOUT_S` | 12.0 | fallback `shell_fiber_timeout_s` |
| `MASC_NAMESPACE_TRUTH_COLD_SAFETY_MARGIN_S` | 4.0 | fallback `cold_safety_margin_s` |

(That's 5 lookup sites; the 4th retired *operator-facing* knob is `SHELL_REFRESH_TIMEOUT_S` was never registered in `env_config_snapshot.ml`, so its disappearance has zero introspection-catalogue delta — only the source-code lookup is removed.)

## Knob preserved

`MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S` had **two** lookup sites:
- `server_dashboard_http_namespace_truth.ml:100` — fallback path's warm-escape threshold. **Retired** (hard-coded as `namespace_truth_warm_escape_s = 90.0`, mirroring the prior 75.0+15.0).
- `server_dashboard_http_execution_surfaces.ml:572` — **live** proactive refresh loop's timeout. **Preserved** as the operator-facing tunable. `env_config_snapshot.ml:241` entry remains for this consumer.

## Changes

### `lib/server/server_dashboard_http_namespace_truth.ml`

Five `float_of_env_default` lookups → module-level `let namespace_truth_*_s = <literal>` constants. The hoist colocates the formerly scattered defaults so future fallback-path retirement (a future RFC sprint, gated on cold-start observability) becomes a single-block delete.

### `lib/config/env_config_snapshot.ml`

Four `entry` rows removed from `dashboard_entries`. Operators querying `/api/v1/config` no longer see them; setting them in the environment is silently ignored (`Sys.getenv_opt` is not invoked).

### `lib/server/server_dashboard_shell_snapshot.ml` (bundled hotfix)

`select_telemetry_summary_json` had an unmatched paren at line 71-76 (three nested lambdas, two closing parens at line 76). Regression from #16730 (Step 2). Without this fix `dune build @check` fails before Step 4's compilation can be verified. The sandboxed CI run on #16730 evidently skipped the affected stanza; flagged for future CI-coverage review.

## Verification

```bash
opam exec -- dune build --root . @check    # PASS
```

No test change required — env vars are not referenced by name in any test fixture (`rg MASC_NAMESPACE_TRUTH_ test/` returns 0 hits). `test/test_types.ml` enumerates env_config categories generically.

## Risk Discussion

- **Operator override loss**: Anyone currently overriding the 4 knobs (e.g. for fleets with p50 ≈ 17s shell fetch, per the historical comment near #7908) loses their override. Mitigation: the fallback path runs ≤1× per process lifetime after Step 3, so override pressure should be zero. If a fleet hits cold-start timeout post-merge, that's evidence the refresh fiber isn't publishing — a Step 3 wire regression, not a Step 4 knob loss.
- **Fallback path still alive**: Step 4 does *not* delete `dashboard_namespace_truth_http_json` — only retires its tunability. A future RFC PR may delete the function once cold-start observability proves snapshot-hit ratio is 1.0 over a measurement window. Step 5 of RFC-0138 §3.3 is separately scoped (Dashboard_cache retire + module rename).

## Scope Boundary

- **Step 5** (next PR): `Dashboard_cache` read-path retire + `Server_dashboard_shell_snapshot` → `Server_dashboard_snapshot_select` rename. Separately scoped per RFC-0138 §3.3.

## Workaround Rejection Bar Self-Check

- [x] §1 텔레메트리-as-fix: removes operator surface, no instrumentation added.
- [x] §2 string 분류기: none.
- [x] §3 N-of-M: this PR retires exactly the 5 lookups whose retire criterion (Step 3 merge → fallback runs ≤1× per process) is now met. The 6th lookup (`EXECUTION_REFRESH` at line 572) is *not* retire-eligible because it serves the live proactive refresh loop, not the cold-start fallback.
- [x] catch-all `_ ->`: none added.
- [x] cap/cooldown: removes operator-visible caps. Replacing with hard-coded constants is *narrower* (one value, no operator surface), not a new cap.
- [x] test backdoor: none.
- [x] hardcoding/legacy: user's "하드코딩 제거, legacy 박멸" principle applied — env knob *plumbing* (operator surface) eliminated; remaining constants are local single-site, not duplicated.

## RFC Reference

`docs/rfc/0138-dashboard-snapshot-lock-free.md` §3.3 Step 4.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
