### PR TITLE
fix(dashboard): close missing paren in select_telemetry_summary_json

### DIFF
--- a/lib/server/server_dashboard_shell_snapshot.ml
+++ b/lib/server/server_dashboard_shell_snapshot.ml
@@ -73,7 +73,7 @@ let select_telemetry_summary_json
         Server_timing.measure
           timing_obj
           Server_timing.Telemetry_summary_aggregate
-          (fun () -> Telemetry_unified.summary_json ~base_path ~masc_root ()))
+          (fun () -> Telemetry_unified.summary_json ~base_path ~masc_root ())))
 ;;
 
 let select_project_snapshot_json ~state ~sw ~clock ?timing req


### PR DESCRIPTION
## 요약

PR #16738 (RFC-0138 Phase 3 Step 3) 가 3-level nested call
(\`Server_timing.measure\` → \`Dashboard_cache.get_or_compute\` →
\`Server_timing.measure\`) 을 작성하면서 닫는 괄호 1개를 누락해서
\`(fun () ->\` 가 line 71 에서 unmatched 상태로 남았습니다.

## 증상

origin/main 에서:

\`\`\`
$ dune build --root . @check
File \"lib/server/server_dashboard_shell_snapshot.ml\", line 77, characters 0-2:
77 | ;;
     ^^
Error: Syntax error: ) expected
File \"lib/server/server_dashboard_shell_snapshot.ml\", line 71, characters 64-65:
71 |     Server_timing.measure timing_obj Server_timing.Cache_lookup (fun () ->
                                                                     ^
  This ( might be unmatched
\`\`\`

빌드 전체 차단 (production-blocking).

## 수정

\`(fun () -> Telemetry_unified.summary_json ~base_path ~masc_root ()))\` →
\`(fun () -> Telemetry_unified.summary_json ~base_path ~masc_root ())))\`

3 close → 4 close. 동작 변경 없음.

## 검증

\`\`\`
$ dune build --root . @check
$ echo \$?
0
\`\`\`

RFC-WAIVED: surgical syntax fix (1 char), not in any RFC subsystem
(dashboard query helper, no credential/identity/operator/keeper boundary).