### PR TITLE
refactor(keeper_state_machine): apply_event current_phase exhaustive arms (anti-pattern #4 follow-up)

### DIFF
--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -1210,12 +1210,26 @@ let check_event_precondition (c : conditions) (ev : event)
 (* ── apply_event ───────────────────────────────────────── *)
 
 let apply_event ~current_phase ~conditions ~event ~now =
-  (* Terminal states reject all events *)
+  (* Terminal states reject all events. Non-terminal phases enumerated
+     explicitly per software-development.md §"FSM Sparse Match" — if a
+     new phase variant is added, this match surfaces warning 8 instead
+     of silently routing the new phase to the non-terminal branch
+     (which is wrong if the new phase is itself intended terminal).
+     Mirrors the [can_transition] exhaustive refactor in #16747. *)
   match current_phase with
   | Stopped | Dead | Zombie ->
     Error
       (Terminal_state { current = current_phase; attempted_event = event_to_string event })
-  | _ ->
+  | Offline
+  | Running
+  | Failing
+  | Overflowed
+  | Compacting
+  | HandingOff
+  | Draining
+  | Paused
+  | Crashed
+  | Restarting ->
     (match check_event_precondition conditions event with
      | Error _ as e -> e
      | Ok () ->


### PR DESCRIPTION
## Summary

Companion to **#16747** (`can_transition` exhaustive deny-lists). The `apply_event` function at `lib/keeper/keeper_state_machine.ml:1212` used the **same sparse-match shape** on `current_phase`:

```ocaml
match current_phase with
| Stopped | Dead | Zombie -> Error (Terminal_state ...)
| _ -> <non-terminal branch>
```

If a future phase variant is intended *terminal*, the wildcard silently routes it to the *non-terminal* branch — compile-time invisible regression. Per `software-development.md` §"FSM Sparse Match".

## Fix

Enumerate the 10 non-terminal phases explicitly:

```ocaml
match current_phase with
| Stopped | Dead | Zombie -> Error (Terminal_state ...)
| Offline | Running | Failing | Overflowed | Compacting | HandingOff
| Draining | Paused | Crashed | Restarting -> <non-terminal branch>
```

Behavior preserved (non-terminal branch body unchanged); compile-time safety added.

## Compile-time canary verified

Transiently added `Migrating` variant to `phase`. `dune build @check` surfaced warning 8 at the new arm:

```
File "...keeper_state_machine.ml", line 1218:
Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
Here is an example of a case that is not matched: Migrating
```

Defense in depth: 7+ other match blocks in the same file also surface warning 8 on the new variant.

## Verification

- `dune build --root . @check` EXIT=0.
- `dune runtest --root . test/test_keeper_state_machine.ml`: **130/130 PASS**.
- +14/-1 LoC, single function.

## Iter#63 context

Continues anti-pattern-#4 sweep from #16747. The remaining `_` in `keeper_state_machine.ml` (lines 51 `phase_of_string`, 1157 `check_event_precondition`) are *not* anti-pattern instances:
- Line 51 wildcards on `string` input (correct).
- Line 1157 wildcards on `event` variant where the comment explicitly notes "Other events have no TLA+ state preconditions" — intentional design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>