### PR TITLE
docs(rfc-0136): retrofit Active status + Phase 4 actual deltas + PR-4-d/e deferral

### DIFF
--- a/docs/rfc/RFC-0136-keeper-unified-turn-decomposition.md
+++ b/docs/rfc/RFC-0136-keeper-unified-turn-decomposition.md
@@ -1,14 +1,14 @@
 ---
 rfc: "0136"
 title: "Keeper Unified Turn — Stage Decomposition of run_keeper_cycle"
-status: Draft
+status: Active
 created: 2026-05-19
 updated: 2026-05-19
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0051", "0056", "0085"]
-implementation_prs: []
+implementation_prs: [16604, 16624, 16643, 16701, 16709, 16751]
 ---
 
 # RFC-0136 — Keeper Unified Turn Decomposition
@@ -278,3 +278,50 @@ PR-3 (retry loop body) 가 *전체 LOC delta 의 60%+ 차지* — 별도 RFC sub
 - `lib/keeper/keeper_unified_turn.mli` — 319 LOC, 30+ surface.
 - `scripts/lint/godfile-size-regression.sh` — cap 3350 LOC, decomposition mandate L22-26.
 - `~/me/planning/claude-plans/joyful-tumbling-dragon.md` — fundamental_roadmap.md Phase 5 godfile target (6 files including keeper_unified_turn).
+
+---
+
+## 8. Progress (2026-05-19)
+
+### 8.1 Merged sub-PRs
+
+| PR | # | LoC Δ | Pattern |
+|----|----|-------|---------|
+| RFC body | #16601 | docs | Initial Draft |
+| **PR-1** Phase Gate | #16604 | -130 | Typed outcome (Parse, don't validate) |
+| **PR-2** Cascade Resolution | #16624 | -50 | Sibling sub-module |
+| **PR-3** Pre-dispatch | #16643 | -33 | Sibling sub-module |
+| Phase 4 sub-doc | #16650 | docs | 5-PR plan |
+| **PR-4-a** Retry Setup | #16701 | -55 | Record destructuring (16 deps) |
+| **PR-4-b** Terminal Error | #16709 | -25 | Side-effects wrapper closure (9 callsites) |
+| **PR-4-c** Dispatch Watchdog | #16751 | -33 | Typed wrapper (row-polymorphic) |
+| **Cumulative** | | **-326** | (-15.5% of base 1943) |
+
+### 8.2 Current state
+
+- `lib/keeper/keeper_unified_turn.ml` = 1641 LOC (post-PR-4-c).
+- `run_keeper_cycle` body (L22-L1640) = 1618 LOC — still single mega-function.
+- Sibling sub-modules total: 1858 LOC across 13 files (`keeper_unified_turn_{phase_gate, cascade_resolution, pre_dispatch, retry_setup, terminal_error, attempt_watchdog, livelock_block, phase_plan, event_bus, failure, stay_silent, success, types}`).
+
+### 8.3 PR-4-d / PR-4-e 보류 결정
+
+Phase 4 sub-doc (#16650) 의 PR-4-c/d/e 추정값 `-400/-300/-180` 은 *PR-4-a/b 머지 *전* base 가정*. PR-4-c 실측 boundary 측정 (2026-05-19) 후 다음 어려움 발견:
+
+| 후보 | 측정 결과 | 결정 |
+|------|----------|------|
+| `attempt_result` 통째 추출 (L613-L687, 75 LoC) | 외부 deps 20+ (record 도입해도 폭증) | 보류 |
+| `do_run` 통째 추출 (L456-L578, 122 LoC) | closure deps 16+ + `run_turn` 47-arg signature | 보류 |
+| `dispatch_with_watchdog` (L490-L577, 88 LoC subset) | typed wrapper 4-5 args, generic | **PR-4-c MERGED** |
+| `match attempt_result with` dispatch (L688-L1191, 503 LoC) | recursive `retry_loop` self-reference + 큰 분기 매트릭스 | 보류 |
+
+retry_loop body (L582-L1191, 610 LoC) 의 *internal cohesion* — *state machine self-reference + closure captures* — 가 추가 분할 비용을 *typed-wrapper 추출이 가능한 작은 영역* 으로 제한. PR-4-d/e 는 *별도 측정 RFC sub-doc* 또는 *deferred* 로 둔다.
+
+### 8.4 Implemented criteria 진척
+
+| Criterion | Target | Current | Status |
+|-----------|--------|---------|--------|
+| `run_keeper_cycle` LOC | < 700 (orchestrator only) | 1618 | 미달 |
+| `keeper_unified_turn.ml` total LOC | (implicit cap) | 1641 | 진척 -15.5% |
+| 모든 sub-PR (PR-1/2/3/4) 머지 | required | PR-1~PR-4-c 머지, PR-4-d/e 보류 | 부분 충족 |
+
+본 RFC status `Active` 유지.  *Implemented* 전환은 (a) PR-4-d/e 측정 RFC sub-doc + 재시작, 또는 (b) 별도 후속 RFC 에서 `run_keeper_cycle` mega-function 분해를 다른 접근으로 닫은 후 가능.

--- a/docs/rfc/RFC-0136-phase-4-retry-loop.md
+++ b/docs/rfc/RFC-0136-phase-4-retry-loop.md
@@ -1,7 +1,7 @@
 ---
 rfc: "0136"
 title: "Keeper Unified Turn — Phase 4: Retry Loop Body Decomposition"
-status: Draft
+status: Active
 created: 2026-05-19
 updated: 2026-05-19
 author: vincent
@@ -9,7 +9,7 @@ supersedes: []
 superseded_by: null
 related: ["0051", "0056", "0085"]
 extends: "0136"
-implementation_prs: []
+implementation_prs: [16701, 16709, 16751]
 ---
 
 # RFC-0136 Phase 4 — Retry Loop Body Decomposition
@@ -147,6 +147,8 @@ caller (retry_loop) 가 *exhausted vs single-error* 구분을 *typed* 로 dispat
 
 ## 3. 누적 효과
 
+### 3.1 원안 추정 (작성 시점, 부정확)
+
 | Sub-PR | 시작 → 끝 | delta |
 |--------|----------|-------|
 | PR-4-a | 1742 → 1575 | -167 |
@@ -155,9 +157,36 @@ caller (retry_loop) 가 *exhausted vs single-error* 구분을 *typed* 로 dispat
 | PR-4-d | ~1100 → ~800 | -300 |
 | PR-4-e | ~800 → ~620 | -180 |
 
-**예상 최종 `keeper_unified_turn.ml`**: ~620 LOC. 1943 → ~620 = **-1320 LOC (-68%)**. Phase 5 godfile target 6개 중 keeper_unified_turn 사실상 *closure*.
+**원안 예상 최종**: ~620 LOC. 1943 → ~620 = **-1320 LOC (-68%)**.
 
-본 예상은 *추정* — boundary 측정이 정확하지 않음 + nested helper 의 *실제 outer scope 영향*은 *각 sub-PR impl 시점*에 *재측정*.
+### 3.2 실측 결과 (2026-05-19)
+
+| Sub-PR | # | 시작 → 끝 | delta | 원안 대비 |
+|--------|---|----------|-------|----------|
+| PR-4-a Retry Setup | #16701 | 1742 → 1687 | **-55** | 33% (167 의 1/3) |
+| PR-4-b Terminal Error | #16709 | 1687 → 1675 | **-25** | 47% (53 의 1/2) |
+| PR-4-c Dispatch Watchdog | #16751 | 1675 → 1641 | **-33** | **8% (400 의 1/12)** |
+| **누적 실측** | | 1742 → 1641 | **-101** | 22% (167+53+400 의 1/5) |
+
+**실측 최종 (PR-4-c 머지 후)**: 1641 LOC. PR-1/2/3 기여 -201 LoC 포함 시 1943 → 1641 = **-302 LoC (-15.5%)**.
+
+### 3.3 원안 오차 정량
+
+PR-4-c 추정 -400 LoC 가 가장 큰 오차 (실측 -33, 12배 over-estimate). 원인:
+
+- 원안은 `retry_loop` *전체 body* (~1100 LOC) 의 *recursive core* 추출 가정.
+- 실측 PR-4-c 는 *dispatch_with_watchdog* (88 LoC subset) 만 추출 — `try ... Eio.Time.with_timeout_exn ... with Cancelled/Timeout` 부분.
+- `attempt_result` (75 LoC) + `do_run` 통째 (122 LoC) 추출은 *closure capture 16-20+ deps 폭증*으로 *typed boundary 어려움* 확인.
+- `match attempt_result with` dispatch (L688-L1191, 503 LoC) 는 *retry_loop self-reference + 큰 분기 매트릭스* 로 외부 추출 비용 큼.
+
+### 3.4 PR-4-d / PR-4-e 보류 결정
+
+다음 두 가지 path 중 하나로 진행:
+
+- (a) 별도 측정 RFC sub-doc 작성 + retry_loop body 의 *typed-wrapper-가능 영역* 만 fine-grained 분할.
+- (b) `run_keeper_cycle` mega-function 분해를 *다른 접근* (context record 도입, monomorphization, state-machine refactor) 으로 *별도 후속 RFC* 에서.
+
+본 sub-doc 의 PR-4-c/d/e 원안 추정값은 *historical reference* 로 보존하되 *retry_loop body internal cohesion*에 의해 *원안 그대로 적용 불가* 가 확정.
 
 ---
 


### PR DESCRIPTION
## 요약

RFC-0136 + Phase 4 sub-doc 의 *실측 LoC* 반영 + PR-4-d/e 보류 결정 기록. PR-1~PR-4-c 6개 sub-PR 머지 완료 후 closeout 문서 업데이트.

## 변경

| 파일 | 변경 |
|------|------|
| `docs/rfc/RFC-0136-keeper-unified-turn-decomposition.md` | frontmatter status `Draft → Active`, implementation_prs +6, Section 8 (Progress) 신규 |
| `docs/rfc/RFC-0136-phase-4-retry-loop.md` | frontmatter status `Draft → Active`, implementation_prs +3, Section 3 split (원안 + 실측 + 오차 + 보류) |

## 실측 vs 원안 (Phase 4)

| Sub-PR | 원안 | 실측 |
|--------|------|------|
| PR-4-a | -167 | -55 (33%) |
| PR-4-b | -53 | -25 (47%) |
| PR-4-c | -400 | **-33 (8%)** |
| PR-4-d | -300 | 보류 |
| PR-4-e | -180 | 보류 |

PR-4-c 가 가장 큰 over-estimate (12배). 원인은 `retry_loop` body 의 *internal cohesion* — `attempt_result` (75 LoC, 20+ deps) / `do_run` (122 LoC, 16+ deps) 통째 추출이 *typed boundary 폭증*. `dispatch_with_watchdog` (88 LoC subset, 5 deps) 만 추출 가능.

## RFC-0136 누적 상태

- `keeper_unified_turn.ml`: 1943 → **1641 LoC (-302, -15.5%)**
- `run_keeper_cycle` body: 1618 LoC (Implemented criteria <700 미달)
- status: `Active` 유지

## PR-4-d/e 진행 path

다음 둘 중 하나:

(a) 별도 측정 RFC sub-doc + retry_loop body 의 typed-wrapper 가능 영역 fine-grained 분할
(b) `run_keeper_cycle` mega-function 분해를 *다른 접근* (context record, monomorphization, state-machine refactor) 으로 별도 후속 RFC

원안 추정값은 *historical reference* 보존.

## Anti-pattern 가드

- ✅ workaround 없음 (docs only, accuracy retrofit)
- ✅ telemetry-as-fix 없음
- ✅ string classifier 없음
- ✅ N-of-M 미적용 (실측 인벤토리 명시)

## RFC

`docs/rfc/RFC-0136-keeper-unified-turn-decomposition.md`
`docs/rfc/RFC-0136-phase-4-retry-loop.md`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
