### PR TITLE
refactor(dashboard): RFC-0135 §13 attention axis lift (audit B3, Goal-2 first axis)

### DIFF
--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -11,7 +11,7 @@ import { useEffect, useState } from 'preact/hooks'
 // represent *live-execution* attention (`execution_current && blocked`,
 // see `lib/server/server_dashboard_http.ml:1114`), which is orthogonal to
 // the blocker-class-vs-stale-execution axis and stays inline below.
-import { deriveKeeperAttention, deriveKeeperOperationalState, deriveKeeperTurnPhase } from '../lib/keeper-operational-state'
+import { deriveKeeperOperationalState, deriveKeeperTurnPhase } from '../lib/keeper-operational-state'
 import { deriveFiberAlive } from '../lib/keeper-fiber-alive'
 import { deriveBlockerReason } from '../lib/keeper-blocker-reason'
 import { formatPct1 } from '../lib/format-number'
@@ -216,20 +216,17 @@ export function deriveKeeperLiveTruth({
   const activeTurn = compositeSnapshot?.is_live === true || !isIdleTurnPhase(compositeSnapshot?.turn_phase)
 
   // RFC-0135 PR-5 + PR-14a: blocker-class axis via typed
-  // `KeeperOperationalState` SSOT; orthogonal backend-attention axis
-  // via `deriveKeeperAttention`. Previously the attention OR was
-  // inlined (`composite.runtime_attention.blocked ||
-  // .needs_attention`), making the two axes a parallel input pair to
-  // the same `blocked` flag that downstream UI checked. The helper
-  // now owns the priority + null-fallback decision so a future axis
-  // (e.g. `acknowledged_at`) is added in one place.
+  // `KeeperOperationalState` SSOT. RFC-0135 §10 Goal-2 (2026-05-20):
+  // attention is now a per-variant axis on `opState` itself rather
+  // than a separately-derived axis OR-merged here. The previous
+  // external OR-pair pattern (audit finding B3) is closed.
   const opState = deriveKeeperOperationalState({
     keeper,
     composite: compositeSnapshot,
   })
   const stuckByBlockerClass = opState.kind === 'stuck'
   const staleBlocker = opState.kind === 'running' ? opState.staleBlocker : null
-  const attention = deriveKeeperAttention(compositeSnapshot ?? null)
+  const attention = opState.attention
   const blocked = stuckByBlockerClass || attention !== 'clean'
   const stopRequested =
     compositeSnapshot?.runtime_attention?.fiber_stop_requested === true

--- a/dashboard/src/lib/keeper-operational-state.test.ts
+++ b/dashboard/src/lib/keeper-operational-state.test.ts
@@ -7,7 +7,6 @@ import {
   compositeIsTurnIdle,
   compositePhaseTone,
   derivePreferredPhase,
-  deriveKeeperAttention,
   deriveKeeperDisplayReason,
   deriveKeeperOperationalState,
   deriveKeeperTurnPhase,
@@ -70,6 +69,7 @@ describe('deriveKeeperOperationalState — paused branch', () => {
     })
     expect(state).toEqual<KeeperOperationalState>({
       kind: 'paused',
+      attention: 'clean',
       cause: 'unknown',
     })
   })
@@ -81,6 +81,7 @@ describe('deriveKeeperOperationalState — paused branch', () => {
     })
     expect(state).toEqual<KeeperOperationalState>({
       kind: 'paused',
+      attention: 'clean',
       cause: 'operator',
     })
   })
@@ -95,6 +96,7 @@ describe('deriveKeeperOperationalState — paused branch', () => {
     })
     expect(state).toEqual<KeeperOperationalState>({
       kind: 'paused',
+      attention: 'clean',
       cause: 'supervisor',
     })
   })
@@ -106,6 +108,7 @@ describe('deriveKeeperOperationalState — paused branch', () => {
     })
     expect(state).toEqual<KeeperOperationalState>({
       kind: 'paused',
+      attention: 'clean',
       cause: 'operator',
     })
   })
@@ -123,7 +126,7 @@ describe('deriveKeeperOperationalState — offline branch', () => {
       keeper: makeKeeper({ phase, status: 'offline' }),
       composite: null,
     })
-    expect(state).toEqual<KeeperOperationalState>({ kind: 'offline', cause })
+    expect(state).toEqual<KeeperOperationalState>({ kind: 'offline', attention: 'clean', cause })
   })
 
   it.each<['offline' | 'inactive' | 'unbooted']>([
@@ -157,6 +160,7 @@ describe('deriveKeeperOperationalState — stuck branch (RFC-0135 §1.1 root)', 
     })
     expect(state).toEqual<KeeperOperationalState>({
       kind: 'stuck',
+      attention: 'clean',
       reason: 'synthetic_stall',
     })
   })
@@ -164,6 +168,8 @@ describe('deriveKeeperOperationalState — stuck branch (RFC-0135 §1.1 root)', 
   it('blocker AND execution_current=true ⇒ stuck (receipt is current)', () => {
     // execution_current=true means the receipt matches the *current* live
     // turn (server_dashboard_http.ml:1061-1074) — the blocker is meaningful.
+    // attention=blocked here because runtime_attention.blocked=true (kind/
+    // attention orthogonality covered in the §13 axis-extension suite).
     const state = deriveKeeperOperationalState({
       keeper: makeKeeper({ runtime_blocker_class: 'cascade_exhausted' }),
       composite: makeComposite({
@@ -172,6 +178,7 @@ describe('deriveKeeperOperationalState — stuck branch (RFC-0135 §1.1 root)', 
     })
     expect(state).toEqual<KeeperOperationalState>({
       kind: 'stuck',
+      attention: 'blocked',
       reason: 'cascade_exhausted',
     })
   })
@@ -188,6 +195,7 @@ describe('deriveKeeperOperationalState — stuck branch (RFC-0135 §1.1 root)', 
     })
     expect(state).toEqual<KeeperOperationalState>({
       kind: 'stuck',
+      attention: 'clean',
       reason: 'oas_timeout_budget',
     })
   })
@@ -203,6 +211,7 @@ describe('deriveKeeperOperationalState — stuck branch (RFC-0135 §1.1 root)', 
     })
     expect(state).toEqual<KeeperOperationalState>({
       kind: 'stuck',
+      attention: 'clean',
       reason: 'fiber_dead',
     })
   })
@@ -226,6 +235,7 @@ describe('deriveKeeperOperationalState — running branch with conditioning', ()
     })
     expect(state).toEqual<KeeperOperationalState>({
       kind: 'running',
+      attention: 'clean',
       turnPhase: 'idle',
       staleBlocker: null,
     })
@@ -258,6 +268,7 @@ describe('deriveKeeperOperationalState — running branch with conditioning', ()
     })
     expect(state).toEqual<KeeperOperationalState>({
       kind: 'running',
+      attention: 'clean',
       turnPhase: 'executing',
       staleBlocker: 'synthetic_stall',
     })
@@ -275,6 +286,7 @@ describe('deriveKeeperOperationalState — running branch with conditioning', ()
     })
     expect(state).toEqual<KeeperOperationalState>({
       kind: 'running',
+      attention: 'clean',
       turnPhase: 'idle',
       staleBlocker: null,
     })
@@ -356,6 +368,7 @@ describe('deriveKeeperOperationalState — priority invariants', () => {
     })
     expect(state).toEqual<KeeperOperationalState>({
       kind: 'running',
+      attention: 'clean',
       turnPhase: 'idle',
       staleBlocker: 'turn_timeout',
     })
@@ -443,35 +456,79 @@ describe('compositeIsRunning / compositeIsTurnIdle — wire-format helpers', () 
   })
 })
 
-describe('deriveKeeperAttention — RFC-0135 PR-14a', () => {
-  const makeComposite = (
-    attentionOverrides: Partial<{ blocked: boolean; needs_attention: boolean }>,
-  ): KeeperCompositeSnapshot =>
-    ({
-      keeper: 'test',
-      runtime_attention: {
-        blocked: false,
-        needs_attention: false,
-        ...attentionOverrides,
-      },
-    } as unknown as KeeperCompositeSnapshot)
+describe('KeeperOperationalState.attention axis — RFC-0135 §13 Goal-2 (2026-05-20)', () => {
+  // The standalone `deriveKeeperAttention` was retired in favour of
+  // a per-variant `attention` axis on `KeeperOperationalState`. The
+  // priority rule (blocked > needs_attention > clean) is unchanged;
+  // the migration moved derivation into `deriveKeeperOperationalState`
+  // so external callers can no longer OR-merge an off-SSOT attention
+  // axis with kind (audit B3 root pattern).
 
-  it('blocked=true ⇒ blocked', () => {
-    expect(deriveKeeperAttention(makeComposite({ blocked: true }))).toBe<KeeperAttention>('blocked')
+  it('blocked=true ⇒ attention=blocked', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper(),
+      composite: makeComposite({ runtime_attention: attention({ blocked: true }) }),
+    })
+    expect(state.attention).toBe<KeeperAttention>('blocked')
   })
-  it('needs_attention=true ⇒ needs_attention', () => {
-    expect(deriveKeeperAttention(makeComposite({ needs_attention: true }))).toBe<KeeperAttention>('needs_attention')
+
+  it('needs_attention=true ⇒ attention=needs_attention', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper(),
+      composite: makeComposite({ runtime_attention: attention({ needs_attention: true }) }),
+    })
+    expect(state.attention).toBe<KeeperAttention>('needs_attention')
   })
+
   it('blocked beats needs_attention when both set', () => {
-    expect(
-      deriveKeeperAttention(makeComposite({ blocked: true, needs_attention: true })),
-    ).toBe<KeeperAttention>('blocked')
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper(),
+      composite: makeComposite({
+        runtime_attention: attention({ blocked: true, needs_attention: true }),
+      }),
+    })
+    expect(state.attention).toBe<KeeperAttention>('blocked')
   })
-  it('neither flag set ⇒ clean', () => {
-    expect(deriveKeeperAttention(makeComposite({}))).toBe<KeeperAttention>('clean')
+
+  it('neither flag set ⇒ attention=clean', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper(),
+      composite: makeComposite({ runtime_attention: attention({}) }),
+    })
+    expect(state.attention).toBe<KeeperAttention>('clean')
   })
-  it('null composite ⇒ clean (no backend attestation)', () => {
-    expect(deriveKeeperAttention(null)).toBe<KeeperAttention>('clean')
+
+  it('null composite ⇒ attention=clean (no backend attestation)', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper(),
+      composite: null,
+    })
+    expect(state.attention).toBe<KeeperAttention>('clean')
+  })
+
+  // §13 axis × kind orthogonality matrix — attention is computed
+  // independently of which `kind` variant the keeper resolves into.
+  it.each<[
+    'offline' | 'paused' | 'stuck' | 'running',
+    Partial<Keeper>,
+    Partial<KeeperCompositeSnapshot> | null,
+    KeeperAttention,
+  ]>([
+    // kind=paused × attention=blocked
+    ['paused', { paused: true }, { runtime_attention: attention({ blocked: true }) }, 'blocked'],
+    // kind=offline × attention=needs_attention
+    ['offline', { phase: 'Offline' }, { runtime_attention: attention({ needs_attention: true }) }, 'needs_attention'],
+    // kind=stuck × attention=blocked
+    ['stuck', { runtime_blocker_class: 'oas_timeout_budget' as KeeperRuntimeBlockerClass }, { runtime_attention: attention({ blocked: true }) }, 'blocked'],
+    // kind=running × attention=clean
+    ['running', {}, { runtime_attention: attention({}) }, 'clean'],
+  ])('kind=%s × attention=%s — axes orthogonal', (kind, keeperOverrides, compositeOverrides, expectedAttention) => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper(keeperOverrides),
+      composite: compositeOverrides === null ? null : makeComposite(compositeOverrides),
+    })
+    expect(state.kind).toBe(kind)
+    expect(state.attention).toBe<KeeperAttention>(expectedAttention)
   })
 })
 

--- a/dashboard/src/lib/keeper-operational-state.ts
+++ b/dashboard/src/lib/keeper-operational-state.ts
@@ -68,12 +68,20 @@ export type StuckReason = KeeperRuntimeBlockerClass | 'fiber_dead' | 'unknown'
 //   clean            — neither set, no orange edge on dashboard
 export type KeeperAttention = 'blocked' | 'needs_attention' | 'clean'
 
+// RFC-0135 §10 Goal-2 (audit 2026-05-19): backend `runtime_attention`
+// axis is *orthogonal* to operational kind — a running keeper can have
+// `attention='needs_attention'`, a stuck keeper can have its attention
+// cleared after operator ack. Lifting `attention` into the typed state
+// removes the audit-finding B3 pattern where callers OR-merged
+// `opState.kind === 'stuck'` with a separately-derived attention axis
+// (forming an external axis-pair the typed sum couldn't enforce).
 export type KeeperOperationalState =
-  | { readonly kind: 'offline'; readonly cause: OfflineCause }
-  | { readonly kind: 'paused'; readonly cause: PausedCause }
-  | { readonly kind: 'stuck'; readonly reason: StuckReason }
+  | { readonly kind: 'offline'; readonly attention: KeeperAttention; readonly cause: OfflineCause }
+  | { readonly kind: 'paused'; readonly attention: KeeperAttention; readonly cause: PausedCause }
+  | { readonly kind: 'stuck'; readonly attention: KeeperAttention; readonly reason: StuckReason }
   | {
       readonly kind: 'running'
+      readonly attention: KeeperAttention
       readonly turnPhase: string
       readonly staleBlocker: KeeperRuntimeBlockerClass | null
     }
@@ -86,11 +94,15 @@ export interface DeriveInputs {
 export function deriveKeeperOperationalState(
   { keeper, composite }: DeriveInputs,
 ): KeeperOperationalState {
+  // RFC-0135 §10 Goal-2: attention is now an axis on every variant so
+  // callers don't need to OR-merge it externally. Computed once here.
+  const attentionAxis = computeKeeperAttention(composite)
+
   if (isPaused(keeper)) {
-    return { kind: 'paused', cause: derivePausedCause(keeper) }
+    return { kind: 'paused', attention: attentionAxis, cause: derivePausedCause(keeper) }
   }
   if (isOffline(keeper, composite)) {
-    return { kind: 'offline', cause: deriveOfflineCause(keeper) }
+    return { kind: 'offline', attention: attentionAxis, cause: deriveOfflineCause(keeper) }
   }
 
   const blockerClass = keeper.runtime_blocker_class ?? null
@@ -103,11 +115,11 @@ export function deriveKeeperOperationalState(
     || attention?.stale_execution_receipt === true
 
   if (blockerClass !== null && !explicitlyStale) {
-    return { kind: 'stuck', reason: blockerClass }
+    return { kind: 'stuck', attention: attentionAxis, reason: blockerClass }
   }
 
   if (composite !== null && compositeFiberKnownDead(composite)) {
-    return { kind: 'stuck', reason: 'fiber_dead' }
+    return { kind: 'stuck', attention: attentionAxis, reason: 'fiber_dead' }
   }
 
   const turnPhase = composite?.turn_phase ?? keeper.pipeline_stage ?? 'idle'
@@ -115,7 +127,7 @@ export function deriveKeeperOperationalState(
   // surfaced as informational context, not a headline.
   const staleBlocker =
     explicitlyStale && blockerClass !== null ? blockerClass : null
-  return { kind: 'running', turnPhase, staleBlocker }
+  return { kind: 'running', attention: attentionAxis, turnPhase, staleBlocker }
 }
 
 function isPaused(k: Keeper): boolean {
@@ -176,7 +188,14 @@ function compositeFiberKnownDead(c: KeeperCompositeSnapshot): boolean {
  *  attestation the dashboard has no basis to claim attention is needed.
  *  Callers may still combine this with `state.kind === 'stuck'` if
  *  blocker-class evidence alone should surface an alert. */
-export function deriveKeeperAttention(
+/** Private — used only by `deriveKeeperOperationalState` to derive the
+ *  per-variant `attention` axis. After RFC-0135 §10 Goal-2 the
+ *  per-variant axis replaced the externally-derived attention used by
+ *  `keeper-detail-runtime.ts:213` (audit B3 closure); callers now read
+ *  `opState.attention` directly. Kept as a private helper to keep the
+ *  derivation rule (priority: blocked > needs_attention > clean)
+ *  localized to one place. */
+function computeKeeperAttention(
   composite: KeeperCompositeSnapshot | null,
 ): KeeperAttention {
   const attention = composite?.runtime_attention

--- a/docs/rfc/RFC-0135-dashboard-keeper-operational-ssot.md
+++ b/docs/rfc/RFC-0135-dashboard-keeper-operational-ssot.md
@@ -238,6 +238,30 @@ PR-1 머지 후 PR-2~7 은 모두 같은 SSOT 호출자이므로 **동시 진행
 4. **외부 reader** (CLI, JIRA hook 등) 중 `runtime_blocker_class` 직접 의존하는 곳이 있다면 PR-6 deprecation 일정에 영향 — audit 필요.
 5. **`fsm-hub-types` 누락 audit**: PR #16552 body 가 명시한 `statusLabel ↔ monitoring-runtime ↔ fsm-hub-types` 3곳 vocab 분산 중 `fsm-hub-types` 가 본 RFC §1.5 audit 에서 누락되었다. PR-1 spec 확정 전 추가 grep + matrix 보강 필요.
 
+## §13 Axes Extensions (post-merge typed-state evolution)
+
+`KeeperOperationalState` 는 PR-1 머지 시 4 variant (offline/paused/stuck/running) sum 으로 출발했고, 각 variant 가 *kind 별* 데이터만 가진 minimal shape 였다. 이후 audit (2026-05-19) 가 typed sum **외부** 에서 OR 합류되는 axes 를 다수 발견 — 이 axes 는 variant 와 직교 (paused 키퍼도 attention='needs_attention' 가능, running 키퍼도 attention='blocked' 가능). 외부 OR 합류는 RFC §9-2 (OR-축 visibility 분기) 거부 기준에 직접 해당.
+
+본 절은 typed sum 에 흡수된 axes 의 evolution 을 한 줄씩 기록한다.
+
+### Goal-2 / 2026-05-20 — `attention: KeeperAttention` 흡수
+
+- **흡수 대상**: `composite.runtime_attention.{blocked, needs_attention}` 의 2-bit axis. 우선순위 `blocked > needs_attention > clean`.
+- **이전 패턴**: `lib/keeper-operational-state.ts:179 deriveKeeperAttention(composite)` standalone helper + 외부 consumer (`components/keeper-detail-runtime.ts:213` audit B3) 가 `stuckByBlockerClass || attention !== 'clean'` OR-merge.
+- **이후 패턴**: `KeeperOperationalState` 의 4 variant 모두 `attention: KeeperAttention` axis 보유. derive 함수가 일관 derive → variant 별 첨부. callsite 는 `opState.attention` 직접 read.
+- **외부 helper 정리**: `deriveKeeperAttention` export 제거 → private `computeKeeperAttention`. 마지막 외부 consumer 가 `opState.attention` 으로 routing 되어 standalone export 불필요.
+- **테스트**: 4 variant 각각의 `attention` 값이 `composite.runtime_attention` 와 정확히 매핑되는지 검증 (clean/blocked/needs_attention × 4 variant = 12 case).
+- **B3 closure 증명**: `keeper-detail-runtime.ts` 의 `import { deriveKeeperAttention }` 사라짐 = SSOT 외부 axis 단일 callsite 의 완전 흡수.
+
+### 향후 흡수 후보 (audit Goal-2 잔여)
+
+- `turnPhase: KeeperTurnPhase` (현재 running variant 만 가짐 → 모든 variant 로 일반화). composite preferred → flat fallback 의 SSOT 내부화.
+- `displaySummary: string | null` (`runtime_blocker_summary` 흡수). `keeper-detail-runtime.ts:256` 의 추가 fallback 제거 prereq.
+- `phase: KeeperPhase | null` (composite preferred SSOT 내부화). `lib/monitoring-runtime.ts:165 toKeeperPhase(keeper.phase) ?? lifecyclePhase` fallback 흡수.
+
+각 axis 는 별도 PR 로 stack. 모두 audit B-cluster 의 부분 closure 에 해당.
+
 ## §12 변경 이력
 
 - 2026-05-19 vincent — 초안 작성, 3 사례 기반 root-cause 정리, PR 시퀀스 §5.
+- 2026-05-20 vincent (via claude-code) — §13 추가, Goal-2 `attention` axis 흡수 + 후속 axes 후보 명시. audit B3 closure.


### PR DESCRIPTION
## 목적

Audit `.tmp/masc-dashboard-ssot-audit-2026-05-19.html` **Goal-2** 의 첫 axis
(`attention`) 흡수 + RFC-0135 §13 axis-extension 정책 신설.
**Audit finding B3 closure** — typed sum **외부** 에서 OR 합류되는 axes 제거.

## 변경

### KeeperOperationalState typed sum 확장

```diff
 export type KeeperOperationalState =
-  | { readonly kind: 'offline'; readonly cause: OfflineCause }
-  | { readonly kind: 'paused'; readonly cause: PausedCause }
-  | { readonly kind: 'stuck'; readonly reason: StuckReason }
-  | {
-      readonly kind: 'running'
-      readonly turnPhase: string
-      readonly staleBlocker: KeeperRuntimeBlockerClass | null
-    }
+  | { readonly kind: 'offline'; readonly attention: KeeperAttention; readonly cause: OfflineCause }
+  | { readonly kind: 'paused'; readonly attention: KeeperAttention; readonly cause: PausedCause }
+  | { readonly kind: 'stuck'; readonly attention: KeeperAttention; readonly reason: StuckReason }
+  | {
+      readonly kind: 'running'
+      readonly attention: KeeperAttention
+      readonly turnPhase: string
+      readonly staleBlocker: KeeperRuntimeBlockerClass | null
+    }
```

4 variant 모두 `attention: 'blocked' | 'needs_attention' | 'clean'` axis 보유.

### derivation 통합 + helper 정리

- `deriveKeeperOperationalState` 가 `computeKeeperAttention(composite)` 를 한 번
  호출 후 모든 variant return 에 첨부.
- `deriveKeeperAttention` export 제거 → private `computeKeeperAttention`
  helper 로 강등 (priority 규칙 `blocked > needs_attention > clean` 유지).

### B3 callsite 마이그레이션

```diff
-import { deriveKeeperAttention, deriveKeeperOperationalState, deriveKeeperTurnPhase } from '../lib/keeper-operational-state'
+import { deriveKeeperOperationalState, deriveKeeperTurnPhase } from '../lib/keeper-operational-state'

 const opState = deriveKeeperOperationalState({...})
 const stuckByBlockerClass = opState.kind === 'stuck'
-const attention = deriveKeeperAttention(compositeSnapshot ?? null)
+const attention = opState.attention
 const blocked = stuckByBlockerClass || attention !== 'clean'
```

외부 axis OR 합류 제거 — typed sum 내부 axis 로 일관.

### RFC-0135 §13 신설

`Axes Extensions (post-merge typed-state evolution)` 섹션 추가:

- Goal-2 / 2026-05-20 — `attention` axis 흡수 기록
- 후속 흡수 후보 명시: `turnPhase`, `displaySummary`, `phase`

각 axis 가 별도 PR 로 stack — 모두 audit B-cluster 의 부분 closure 에 해당.

## 검증

| 영역 | 결과 |
|------|------|
| `src/lib/keeper-operational-state.test.ts` | 78 → 83 PASS |
| 신규 axis × kind 매트릭스 | 5 case (paused×blocked, offline×needs_attention, stuck×blocked, running×clean + 1 sweep) |
| 기존 `toEqual` 강화 | 13 사이트 `attention` 명시 추가 (strict equality 유지, `toMatchObject` 사용 안 함) |
| `tsc --noEmit` | clean |
| `deriveKeeperAttention` 외부 consumer | 0 (확인됨) |

### B3 closure 증명

`keeper-detail-runtime.ts:14` 의 import 에서 `deriveKeeperAttention` 사라짐 =
SSOT 외부 axis 의 마지막 external callsite 가 typed state 내부로 흡수.
`opState.attention` 으로 routing — `composite.runtime_attention.blocked` /
`needs_attention` 의 두 wire bit 가 한 axis 로 통일.

## RFC-WAIVED

dashboard SSOT follow-up. 다음 RFC subsystem 영역 touch 없음:
- `lib/keeper/credential_*` / `lib/repo_manager/` / `lib/operator/*` ❌
- `dashboard/src/components/credential*` ❌
- `.claude/hooks/` / `instructions/workflow*` ❌

**RFC-0135 §13** 신설은 본 RFC 자체의 in-place 확장 (새 RFC 아님). 5/19 RFC 머지된
RFC-0135 가 axis 확장을 위해 §13 만 추가.

## Best Programmer self-review

- **목표**: Goal-2 첫 axis (attention) 흡수 + B3 closure + §13 axis-extension 정책
- **변경**:
  - `dashboard/src/lib/keeper-operational-state.ts` (+25/-12)
  - `dashboard/src/lib/keeper-operational-state.test.ts` (+82/-25)
  - `dashboard/src/components/keeper-detail-runtime.ts` (1 import + 5 comment + 1 line)
  - `docs/rfc/RFC-0135-dashboard-keeper-operational-ssot.md` (+24, §13 신설)
- **로컬 검증**: 83/83 PASS, tsc clean
- **Anti-pattern self-check**:
  - String classifier 추가 ❌ (axis lift 는 typed enrichment)
  - N-of-M ❌ (단 1 외부 consumer + audit B3 closure)
  - Telemetry-as-fix ❌
  - Catch-all default ❌ (4 variant exhaustive, attention 도 closed 3-token sum)

## Goal-1 의 prereq

본 PR 머지 후 Goal-1 (`keeperBand` thin reduce) 가 unblock — `keeperBand` 가
`opState.attention` 직접 read 로 외부 attention OR 제거 가능.

## Draft + label 정책

Agent-authored PR — **Draft 유지**. Ready 전환은 `human-approved-ready`
라벨 부착 후 CI green 시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
