### PR TITLE
fix(keeper_shell_docker, process_eio): raise docker_run floor to 20s + stage-split timeout telemetry

### DIFF
--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -557,18 +557,23 @@ let () = Atomic.set Coord_hooks.cache_desync_cleared_fn record_cache_desync_clea
    the small set of commands MASC actually invokes (~10-20 series). *)
 let process_timeout_metric = Prometheus.metric_process_timeout
 
-let record_process_timeout ~program ~timeout_sec =
+let record_process_timeout ~program ~timeout_sec ~stage =
   (* Bucket the raw float to keep Prometheus cardinality bounded — a
      [Printf.sprintf "%.0f"] of caller-supplied seconds would mint a
      new series per distinct value.  Five closed buckets preserve the
      operator question "is 15s/60s the right budget?" while
      guaranteeing the label set never grows beyond
-     [Timeout_bucket]'s variant arity. *)
+     [Timeout_bucket]'s variant arity.
+
+     [stage] is a closed 3-variant label (slot_wait | spawn | command)
+     so the total cardinality stays bounded by
+     [program × bucket × stage] (~10-20 × 5 × 3 ≈ 300 series). *)
   Prometheus.inc_counter
     process_timeout_metric
     ~labels:
       [ "program", program
       ; ("timeout_bucket", Timeout_bucket.(to_label (of_seconds timeout_sec)))
+      ; ("stage", Process_eio.timeout_stage_to_string stage)
       ]
     ()
 ;;

--- a/lib/coord.mli
+++ b/lib/coord.mli
@@ -74,11 +74,16 @@ val record_fsm_drift_with_agent :
 val process_timeout_metric : string
 (** Canonical Prometheus metric for [Process_eio] timeouts
     ([masc_process_timeout_total]).  Labels: [program] (argv0
-    basename, e.g. ["git"], ["gh"]), [timeout_sec] (configured budget,
-    e.g. ["15"], ["60"]).  Exposed so tests and Grafana rules can pin
-    the name. *)
+    basename, e.g. ["git"], ["gh"]), [timeout_bucket] (configured budget
+    bucket, e.g. ["ge_15s_lt_60s"]), [stage] (closed 3-variant from
+    {!Process_eio.timeout_stage}: [slot_wait] | [spawn] | [command]).
+    Exposed so tests and Grafana rules can pin the name. *)
 
-val record_process_timeout : program:string -> timeout_sec:float -> unit
+val record_process_timeout :
+  program:string ->
+  timeout_sec:float ->
+  stage:Process_eio.timeout_stage ->
+  unit
 (** Increment {!process_timeout_metric}.  Wired to
     {!Process_eio.process_timeout_observer_fn} at module load so every
     [Eio.Time.Timeout] in [run_argv] / [run_argv_with_stdin] /

--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -28,9 +28,12 @@ val gh_min_timeout_sec : float
     tests can lock the floor against drift back to sub-network-latency
     values. See #8688. *)
 
-val keeper_bash_min_timeout_sec : float
-(** Minimum timeout_sec floor applied to keeper_bash. Exposed so regression
-    tests can lock the floor against drift back to sub-I/O-latency values. *)
+val keeper_bash_native_min_timeout_sec : float
+(** Minimum timeout_sec floor applied to keeper_bash on the *native*
+    (non-Docker) executor path. Exposed so regression tests can lock the
+    floor against drift back to sub-I/O-latency values.  The Docker
+    dispatch path re-clamps independently to
+    {!Keeper_shell_docker.docker_run_min_timeout_sec}. *)
 
 val rewrite_turn_runtime_paths_to_host :
   config:Coord.config ->

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -980,7 +980,7 @@ let handle_keeper_bash
   in
   let timeout_sec =
     Keeper_shell_shared.clamp_shell_timeout
-      ~min_sec:Keeper_shell_shared.keeper_bash_min_timeout_sec
+      ~min_sec:Keeper_shell_shared.keeper_bash_native_min_timeout_sec
       ~default:Keeper_shell_shared.io_timeout_sec
       args
   in

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -926,10 +926,28 @@ type docker_shell_result =
   ; network_label : string
   }
 
-(* docker run --rm includes image layer pull + container creation cold start.
-   A 1s floor is insufficient even for trivial commands. This minimum applies
-   only to the run path, not to docker exec against a warm container. *)
-let docker_run_min_timeout_sec = 5.0
+(* docker run --rm wall-clock covers slot_wait + spawn + container
+   cold start + actual cmd + drain. A 5s floor was insufficient under
+   typical conditions — trivial commands such as [git -C ... status]
+   were timing out at 5s because the cold-start path alone (image pull
+   + container creation + shell init) can take 10-60s on a cold host.
+
+   #8688 raised the gh-cli floor to [gh_min_timeout_sec = 15s] for the
+   same class of failure (sub-network-latency timeouts cascading into
+   401 retries); the docker path was left at 5s — an N-of-M between
+   sibling timeout floors. This restores parity (15s gh + 5s headroom
+   for container creation) and exposes an env override so operators
+   can tune for slow-pull fleets without rebuilding.
+
+   This minimum applies only to the [docker run] path, not to
+   [docker exec] against a warm container. *)
+let docker_run_min_timeout_sec =
+  let default = 20.0 in
+  let raw =
+    try float_of_string (Sys.getenv "MASC_KEEPER_DOCKER_RUN_MIN_TIMEOUT_SEC")
+    with Not_found | Failure _ -> default
+  in
+  Float.max 1.0 raw
 
 let docker_cleanup_rm_timeout_sec () =
   Env_config_sandbox.Shell_timeout.timeout_sec

--- a/lib/keeper/keeper_shell_docker.mli
+++ b/lib/keeper/keeper_shell_docker.mli
@@ -132,7 +132,13 @@ type docker_shell_result =
   ; network_label : string
   }
 
-(** Cold-start floor (seconds) for [docker run --rm]. *)
+(** Cold-start floor (seconds) for [docker run --rm].  The wall-clock
+    budget covers slot_wait + spawn + container cold start + actual
+    cmd + drain; the default ([20.0]) matches the [gh] CLI floor
+    ([gh_min_timeout_sec = 15s], #8688) plus 5s headroom for image
+    pull and container creation.  Operators can override via
+    [MASC_KEEPER_DOCKER_RUN_MIN_TIMEOUT_SEC] (read once at module
+    load, floor 1s). *)
 val docker_run_min_timeout_sec : float
 
 (** Run [cmd] inside the keeper Docker sandbox; clamps

--- a/lib/keeper/keeper_shell_shared.ml
+++ b/lib/keeper/keeper_shell_shared.ml
@@ -72,7 +72,16 @@ let user_timeout_max_sec = env_float "MASC_KEEPER_USER_TIMEOUT_MAX_SEC" 180.0
    timeout_sec=5 (#8688). 15s keeps keepers from requesting a
    sub-network-latency timeout without masking genuine hangs. *)
 let gh_min_timeout_sec = 15.0
-let keeper_bash_min_timeout_sec = 5.0
+
+(* Floor applied to caller-supplied [timeout_sec] for keeper_bash when
+   the command runs through the *native* (non-Docker) executor.  The
+   Docker dispatch path re-clamps inside
+   [Keeper_shell_docker.run_docker_shell_command_with_status_internal]
+   to [docker_run_min_timeout_sec] because container cold start adds
+   10-60s on top of the actual command — see runtime log issue #5
+   (2026-05-20).  Keeping a separate native floor avoids penalising
+   the host-side fast path for the Docker path's overhead. *)
+let keeper_bash_native_min_timeout_sec = 5.0
 
 (* Public shell metadata timeout used by git-status helpers. The playground
    repo-cache writer keeps its own copy in the lower-level coord module so

--- a/lib/keeper/keeper_shell_shared.mli
+++ b/lib/keeper/keeper_shell_shared.mli
@@ -72,10 +72,18 @@ val gh_min_timeout_sec : float
     cannot lower; sub-network-latency timeouts cause cascading 401
     retries (#8688). *)
 
-val keeper_bash_min_timeout_sec : float
-(** Floor for keeper_bash [timeout_sec] (5s).  Custom Bash commands often
-    touch disk, Docker, or git metadata; lower caller-supplied values produce
-    noisy partial-output timeout failures rather than useful latency bounds. *)
+val keeper_bash_native_min_timeout_sec : float
+(** Floor for keeper_bash [timeout_sec] when the command runs through the
+    *native* (non-Docker) executor (5s).  Custom Bash commands often touch
+    disk or git metadata; lower caller-supplied values produce noisy
+    partial-output timeout failures rather than useful latency bounds.
+
+    The Docker dispatch path re-clamps to
+    {!Keeper_shell_docker.docker_run_min_timeout_sec} inside
+    [run_docker_shell_command_with_status_internal] because container
+    cold start adds 10-60s on top of the actual command (runtime log
+    issue #5, 2026-05-20).  Keeping a separate native floor avoids
+    penalising the host-side fast path for the Docker path's overhead. *)
 
 val git_meta_timeout_sec : float
 (** Ceiling for lightweight git metadata commands (rev-parse,

--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -23,6 +23,29 @@ type runtime = {
     after [init] has published the runtime on the main domain. *)
 let runtime_state : runtime option Atomic.t = Atomic.make None
 
+(** Stage at which an [Eio.Time.with_timeout_exn] budget was exhausted.
+
+    [Slot_wait] is reserved for callers that wrap [run_argv*] with their
+    own slot/semaphore wait and want to attribute a timeout to slot
+    contention rather than to the subprocess itself; the [Process_eio]
+    layer never emits it directly because [with_timeout_exn] starts the
+    clock after slot acquisition.
+
+    [Spawn] fires if the timeout trips before
+    [Eio.Process.spawn] / [Unix.create_process_env] returns — i.e. the
+    process creation syscall itself stalled (docker daemon backpressure,
+    container cold start during [docker run]).
+
+    [Command] fires once the child has been created and we are draining
+    pipes or awaiting exit — this is the “normal” timeout case where the
+    subprocess itself is slow. *)
+type timeout_stage = Slot_wait | Spawn | Command
+
+let timeout_stage_to_string = function
+  | Slot_wait -> "slot_wait"
+  | Spawn -> "spawn"
+  | Command -> "command"
+
 (** Observability hook: invoked when an Eio process call hits its
     [timeout_sec] budget.  Default no-op so the lower [masc_process]
     layer carries no [Prometheus] dependency.  Wired from [lib/coord.ml]
@@ -30,19 +53,21 @@ let runtime_state : runtime option Atomic.t = Atomic.make None
 
     Cardinality: callers should pass [program = Filename.basename argv0]
     (~10-20 distinct programs fleet-wide); [timeout_sec] is the per-call
-    budget (a few discrete values: 15.0, 60.0, ...). *)
+    budget (a few discrete values: 15.0, 60.0, ...); [stage] has
+    3 closed-variant labels (slot_wait | spawn | command) — total label
+    cardinality is bounded by [program × bucket × stage]. *)
 let process_timeout_observer_fn :
-    (program:string -> timeout_sec:float -> unit) Atomic.t =
-  Atomic.make (fun ~program:_ ~timeout_sec:_ -> ())
+    (program:string -> timeout_sec:float -> stage:timeout_stage -> unit) Atomic.t =
+  Atomic.make (fun ~program:_ ~timeout_sec:_ ~stage:_ -> ())
 
 let argv_program = function
   | [] -> "<empty>"
   | prog :: _ -> Filename.basename prog
 
-let observe_process_timeout argv ~timeout_sec =
+let observe_process_timeout argv ~timeout_sec ~stage =
   try
     (Atomic.get process_timeout_observer_fn)
-      ~program:(argv_program argv) ~timeout_sec
+      ~program:(argv_program argv) ~timeout_sec ~stage
   with exn ->
     Log.Misc.warn "[Process_eio] timeout observer failed: %s"
       (Printexc.to_string exn)
@@ -396,7 +421,11 @@ let with_unix_capture ?env ?cwd ?stdin_content ?(capture_stderr = false)
               else stderr
             in
             if !timed_out then
-              observe_process_timeout argv ~timeout_sec;
+              (* Unix fallback starts the timeout clock after
+                 [create_process_env] returns (see line above where
+                 [deadline] is computed), so any timeout here is always
+                 attributable to the running child. *)
+              observe_process_timeout argv ~timeout_sec ~stage:Command;
             cleanup ();
             on_success status stdout stderr)
      with
@@ -460,7 +489,7 @@ let run_unix_argv_with_stdin_and_status_split_fallback
 
     The fix mirrors [Eio.Process.parse_out]: create pipes, close write ends
     after spawn, read to EOF in parallel fibers, then await the exit status. *)
-let spawn_and_drain_stdout ~sw pm ~cwd ?env ?stdin_source argv stdout_buf =
+let spawn_and_drain_stdout ?phase_ref ~sw pm ~cwd ?env ?stdin_source argv stdout_buf =
   let stdout_r, stdout_w = Eio.Process.pipe ~sw pm in
   let proc =
     Eio.Process.spawn ~sw pm ~cwd ?env
@@ -468,6 +497,10 @@ let spawn_and_drain_stdout ~sw pm ~cwd ?env ?stdin_source argv stdout_buf =
       ~stdout:stdout_w
       argv
   in
+  (* spawn returned — any further timeout is attributable to the
+     child, not to process creation.  Callers thread [phase_ref] so the
+     timeout branches can label the metric accordingly. *)
+  Option.iter (fun r -> r := Command) phase_ref;
   Eio.Flow.close stdout_w;
   (* Drain to EOF before await — pipe close is switch-managed on cancel. *)
   (try
@@ -485,7 +518,7 @@ let spawn_and_drain_stdout ~sw pm ~cwd ?env ?stdin_source argv stdout_buf =
     separate buffers and returns the process exit status.
     Drain happens in parallel via [Fiber.both]; [await] is called after
     both pipes reach EOF, so buffers are guaranteed complete. *)
-let spawn_and_drain_both ~sw pm ~cwd ?env ?stdin_source argv stdout_buf
+let spawn_and_drain_both ?phase_ref ~sw pm ~cwd ?env ?stdin_source argv stdout_buf
     stderr_buf =
   let stdout_r, stdout_w = Eio.Process.pipe ~sw pm in
   let stderr_r, stderr_w = Eio.Process.pipe ~sw pm in
@@ -496,6 +529,7 @@ let spawn_and_drain_both ~sw pm ~cwd ?env ?stdin_source argv stdout_buf
       ~stderr:stderr_w
       argv
   in
+  Option.iter (fun r -> r := Command) phase_ref;
   Eio.Flow.close stdout_w;
   Eio.Flow.close stderr_w;
   (try
@@ -527,16 +561,17 @@ let run_argv ?(timeout_sec = default_timeout_sec) ?env (argv : string list) : st
         | Ok pm, Ok clk, Ok cwd ->
             let buf = Buffer.create default_buffer_size in
             let label = String.concat " " (List.map Filename.quote argv) in
+            let phase_ref = ref Spawn in
             try
               Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
                   Eio.Switch.run (fun sw ->
-                      let status = spawn_and_drain_stdout ~sw pm ~cwd ?env argv buf in
+                      let status = spawn_and_drain_stdout ~phase_ref ~sw pm ~cwd ?env argv buf in
                       output_for_status ~status ~stdout:(Buffer.contents buf) ~stderr:""))
             with
             | Eio.Time.Timeout ->
-                Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
-                  timeout_sec label;
-                observe_process_timeout argv ~timeout_sec;
+                Log.Misc.warn "[Process_eio] Timeout after %.0fs (%s): %s"
+                  timeout_sec (timeout_stage_to_string !phase_ref) label;
+                observe_process_timeout argv ~timeout_sec ~stage:!phase_ref;
                 process_error_output ~label
                   ~reason:(Printf.sprintf "timeout after %.0fs" timeout_sec) ()
             | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -564,18 +599,19 @@ let run_argv_with_stdin ?(timeout_sec = default_timeout_sec) ?env ~(stdin_conten
             let buf = Buffer.create default_buffer_size in
             let label = String.concat " " (List.map Filename.quote argv) in
             let stdin_source = Eio.Flow.string_source stdin_content in
+            let phase_ref = ref Spawn in
             try
               Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
                   Eio.Switch.run (fun sw ->
                       let status =
-                        spawn_and_drain_stdout ~sw pm ~cwd ?env ~stdin_source argv buf
+                        spawn_and_drain_stdout ~phase_ref ~sw pm ~cwd ?env ~stdin_source argv buf
                       in
                       output_for_status ~status ~stdout:(Buffer.contents buf) ~stderr:""))
             with
             | Eio.Time.Timeout ->
-                Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
-                  timeout_sec label;
-                observe_process_timeout argv ~timeout_sec;
+                Log.Misc.warn "[Process_eio] Timeout after %.0fs (%s): %s"
+                  timeout_sec (timeout_stage_to_string !phase_ref) label;
+                observe_process_timeout argv ~timeout_sec ~stage:!phase_ref;
                 process_error_output ~label
                   ~reason:(Printf.sprintf "timeout after %.0fs" timeout_sec) ()
             | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -616,11 +652,12 @@ let run_argv_with_stdin_and_status_split
             let stderr_buf = Buffer.create default_buffer_size in
             let label = String.concat " " (List.map Filename.quote argv) in
             let stdin_source = Eio.Flow.string_source stdin_content in
+            let phase_ref = ref Spawn in
             try
               Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
                   let unix_status =
                     Eio.Switch.run (fun sw ->
-                        spawn_and_drain_both ~sw pm ~cwd:effective_cwd ?env
+                        spawn_and_drain_both ~phase_ref ~sw pm ~cwd:effective_cwd ?env
                           ~stdin_source argv stdout_buf stderr_buf)
                   in
                   ( unix_status,
@@ -628,9 +665,9 @@ let run_argv_with_stdin_and_status_split
                     Buffer.contents stderr_buf ))
             with
             | Eio.Time.Timeout ->
-                Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
-                  timeout_sec label;
-                observe_process_timeout argv ~timeout_sec;
+                Log.Misc.warn "[Process_eio] Timeout after %.0fs (%s): %s"
+                  timeout_sec (timeout_stage_to_string !phase_ref) label;
+                observe_process_timeout argv ~timeout_sec ~stage:!phase_ref;
                 let timeout_status = Unix.WEXITED 124 in
                 let stdout = Buffer.contents stdout_buf in
                 let stderr = Buffer.contents stderr_buf in
@@ -689,11 +726,12 @@ let run_argv_with_status_split ?(timeout_sec = default_timeout_sec) ?env ?cwd
             let stdout_buf = Buffer.create default_buffer_size in
             let stderr_buf = Buffer.create 256 in
             let label = String.concat " " (List.map Filename.quote argv) in
+            let phase_ref = ref Spawn in
             try
               Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
                   let unix_status =
                     Eio.Switch.run (fun sw ->
-                        spawn_and_drain_both ~sw pm ~cwd:effective_cwd ?env
+                        spawn_and_drain_both ~phase_ref ~sw pm ~cwd:effective_cwd ?env
                           argv stdout_buf stderr_buf)
                   in
                   ( unix_status,
@@ -701,9 +739,9 @@ let run_argv_with_status_split ?(timeout_sec = default_timeout_sec) ?env ?cwd
                     Buffer.contents stderr_buf ))
             with
             | Eio.Time.Timeout ->
-                Log.Misc.warn "[Process_eio] Timeout after %.0fs: %s"
-                  timeout_sec label;
-                observe_process_timeout argv ~timeout_sec;
+                Log.Misc.warn "[Process_eio] Timeout after %.0fs (%s): %s"
+                  timeout_sec (timeout_stage_to_string !phase_ref) label;
+                observe_process_timeout argv ~timeout_sec ~stage:!phase_ref;
                 let timeout_status = Unix.WEXITED 124 in
                 let stdout = Buffer.contents stdout_buf in
                 let stderr = Buffer.contents stderr_buf in

--- a/lib/process/process_eio.mli
+++ b/lib/process/process_eio.mli
@@ -25,13 +25,35 @@ val should_retry_unix_fallback : exn -> bool
 
 (** {1 Observability hook (#9632)} *)
 
+(** Stage at which a [run_argv*] timeout budget was exhausted.
+
+    - [Slot_wait] — reserved for callers that wrap [run_argv*] with their
+      own slot/semaphore (e.g. [Docker_spawn_throttle.with_slot]) and want
+      to attribute a timeout to slot contention.  Not emitted by
+      [Process_eio] directly because [Eio.Time.with_timeout_exn] starts
+      the clock after slot acquisition.
+    - [Spawn] — timeout fired before [Eio.Process.spawn] returned, i.e.
+      process creation itself stalled (docker daemon backpressure, container
+      cold start during [docker run]).
+    - [Command] — timeout fired after the child was created and while
+      draining pipes or awaiting exit; the normal “command was slow” case.
+
+    Closed sum so [lib/coord.ml] can label
+    [masc_process_timeout_total] without per-call string allocation. *)
+type timeout_stage = Slot_wait | Spawn | Command
+
+val timeout_stage_to_string : timeout_stage -> string
+(** [timeout_stage_to_string Slot_wait = "slot_wait"], etc.  Exposed so
+    log lines and Prometheus labels share one vocabulary. *)
+
 val process_timeout_observer_fn :
-  (program:string -> timeout_sec:float -> unit) Atomic.t
+  (program:string -> timeout_sec:float -> stage:timeout_stage -> unit) Atomic.t
 (** Hook fired from every [run_argv*] timeout branch.  Default no-op so
     [masc_process] carries no [Prometheus] dependency.  [lib/coord.ml]
     wires it at module load to emit [masc_process_timeout_total].
     [program] is [Filename.basename argv0] (~10-20 distinct programs
-    fleet-wide). *)
+    fleet-wide); [stage] is a closed 3-variant label so the metric’s
+    total cardinality stays bounded by [program × bucket × stage]. *)
 
 val argv_program : string list -> string
 (** [argv_program argv] returns [Filename.basename argv0] (or

--- a/lib/prometheus_builtin_metrics_part4.ml
+++ b/lib/prometheus_builtin_metrics_part4.ml
@@ -177,8 +177,11 @@ let register
   add
     metric_process_timeout
     "Total subprocess executions that exceeded their configured timeout. Labeled by \
-     program and timeout_bucket (Timeout_bucket.to_label: lt_1s | ge_1s_lt_15s | \
-     ge_15s_lt_60s | ge_60s_lt_300s | ge_300s)."
+     program, timeout_bucket (Timeout_bucket.to_label: lt_1s | ge_1s_lt_15s | \
+     ge_15s_lt_60s | ge_60s_lt_300s | ge_300s), and stage \
+     (Process_eio.timeout_stage: slot_wait | spawn | command — distinguishes \
+     timeouts spent waiting for an external slot, in process creation, or in the \
+     running child)."
     `Counter;
   add
     metric_bg_task_sidecar_failures

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -331,10 +331,10 @@ let test_keeper_bash_elapsed_duration_preserves_positive_sub_ms () =
 let test_keeper_bash_timeout_floor_is_not_sub_io_latency () =
   let args = `Assoc [ "timeout_sec", `Float 1.0 ] in
   Alcotest.(check (float 0.001))
-    "keeper_bash timeout floor"
-    Keeper_exec_shell.keeper_bash_min_timeout_sec
+    "keeper_bash native timeout floor"
+    Keeper_exec_shell.keeper_bash_native_min_timeout_sec
     (Masc_mcp.Keeper_shell_shared.clamp_shell_timeout
-       ~min_sec:Keeper_exec_shell.keeper_bash_min_timeout_sec
+       ~min_sec:Keeper_exec_shell.keeper_bash_native_min_timeout_sec
        ~default:Masc_mcp.Keeper_shell_shared.io_timeout_sec
        args)
 

--- a/test/test_process_eio_coverage.ml
+++ b/test/test_process_eio_coverage.ml
@@ -98,8 +98,8 @@ let with_timeout_observer f =
   let previous = Atomic.get Process_eio.process_timeout_observer_fn in
   let seen = ref [] in
   Atomic.set Process_eio.process_timeout_observer_fn
-    (fun ~program ~timeout_sec ->
-       seen := (program, timeout_sec) :: !seen);
+    (fun ~program ~timeout_sec ~stage ->
+       seen := (program, timeout_sec, Process_eio.timeout_stage_to_string stage) :: !seen);
   Fun.protect
     ~finally:(fun () ->
       Atomic.set Process_eio.process_timeout_observer_fn previous)
@@ -113,10 +113,12 @@ let test_run_argv_with_status_fallback_observes_timeout () =
       in
       let code = match status with Unix.WEXITED c -> c | _ -> -1 in
       check int "fallback timeout exit code" 124 code;
+      (* Unix fallback runs after [create_process_env] returns, so the
+         stage is always [command]. *)
       check
-        (list (pair string (float 0.0001)))
+        (list (triple string (float 0.0001) string))
         "fallback timeout observer payload"
-        [ ("sleep", 0.02) ]
+        [ ("sleep", 0.02, "command") ]
         (List.rev !seen))
 
 let test_init_exposes_complete_runtime () =

--- a/test/test_process_timeout_counter.ml
+++ b/test/test_process_timeout_counter.ml
@@ -18,12 +18,13 @@
    directly for counter mechanics, and [Process_eio.argv_program]
    for the cardinality-bounding helper. *)
 
-let counter_for ~program ~timeout_sec =
+let counter_for ?(stage = Process_eio.Command) ~program ~timeout_sec () =
   Masc_mcp.Prometheus.metric_value_or_zero
     Masc_mcp.Coord.process_timeout_metric
     ~labels:
       [ "program", program
       ; ("timeout_bucket", Masc_mcp.Timeout_bucket.(to_label (of_seconds timeout_sec)))
+      ; ("stage", Process_eio.timeout_stage_to_string stage)
       ]
     ()
 ;;
@@ -72,17 +73,18 @@ let test_argv_program_empty () =
 let test_record_increments () =
   let program = "test_program_9632" in
   let timeout_sec = 15.0 in
-  let before = counter_for ~program ~timeout_sec in
-  Masc_mcp.Coord.record_process_timeout ~program ~timeout_sec;
+  let stage = Process_eio.Command in
+  let before = counter_for ~program ~timeout_sec ~stage () in
+  Masc_mcp.Coord.record_process_timeout ~program ~timeout_sec ~stage;
   Alcotest.(check (float 0.0001))
     "+1 on call"
     (before +. 1.0)
-    (counter_for ~program ~timeout_sec);
-  Masc_mcp.Coord.record_process_timeout ~program ~timeout_sec;
+    (counter_for ~program ~timeout_sec ~stage ());
+  Masc_mcp.Coord.record_process_timeout ~program ~timeout_sec ~stage;
   Alcotest.(check (float 0.0001))
     "+1 again"
     (before +. 2.0)
-    (counter_for ~program ~timeout_sec)
+    (counter_for ~program ~timeout_sec ~stage ())
 ;;
 
 let test_program_isolation () =
@@ -90,28 +92,65 @@ let test_program_isolation () =
   let timeout_sec = 60.0 in
   let prog_a = "isolation_a_9632" in
   let prog_b = "isolation_b_9632" in
-  let before_a = counter_for ~program:prog_a ~timeout_sec in
-  Masc_mcp.Coord.record_process_timeout ~program:prog_b ~timeout_sec;
+  let stage = Process_eio.Command in
+  let before_a = counter_for ~program:prog_a ~timeout_sec ~stage () in
+  Masc_mcp.Coord.record_process_timeout ~program:prog_b ~timeout_sec ~stage;
   Alcotest.(check (float 0.0001))
     "program A unchanged"
     before_a
-    (counter_for ~program:prog_a ~timeout_sec)
+    (counter_for ~program:prog_a ~timeout_sec ~stage ())
 ;;
 
 let test_timeout_sec_isolation () =
   (* Same program with two budgets must split into separate series. *)
   let program = "budget_split_9632" in
-  let before_15 = counter_for ~program ~timeout_sec:15.0 in
-  let before_60 = counter_for ~program ~timeout_sec:60.0 in
-  Masc_mcp.Coord.record_process_timeout ~program ~timeout_sec:15.0;
+  let stage = Process_eio.Command in
+  let before_15 = counter_for ~program ~timeout_sec:15.0 ~stage () in
+  let before_60 = counter_for ~program ~timeout_sec:60.0 ~stage () in
+  Masc_mcp.Coord.record_process_timeout ~program ~timeout_sec:15.0 ~stage;
   Alcotest.(check (float 0.0001))
     "15s budget +1"
     (before_15 +. 1.0)
-    (counter_for ~program ~timeout_sec:15.0);
+    (counter_for ~program ~timeout_sec:15.0 ~stage ());
   Alcotest.(check (float 0.0001))
     "60s budget unchanged"
     before_60
-    (counter_for ~program ~timeout_sec:60.0)
+    (counter_for ~program ~timeout_sec:60.0 ~stage ())
+;;
+
+let test_stage_isolation () =
+  (* Same program + budget with different stages must split. *)
+  let program = "stage_split_9632" in
+  let timeout_sec = 15.0 in
+  let before_cmd =
+    counter_for ~program ~timeout_sec ~stage:Process_eio.Command ()
+  in
+  let before_spawn =
+    counter_for ~program ~timeout_sec ~stage:Process_eio.Spawn ()
+  in
+  Masc_mcp.Coord.record_process_timeout
+    ~program
+    ~timeout_sec
+    ~stage:Process_eio.Spawn;
+  Alcotest.(check (float 0.0001))
+    "spawn stage +1"
+    (before_spawn +. 1.0)
+    (counter_for ~program ~timeout_sec ~stage:Process_eio.Spawn ());
+  Alcotest.(check (float 0.0001))
+    "command stage unchanged"
+    before_cmd
+    (counter_for ~program ~timeout_sec ~stage:Process_eio.Command ())
+;;
+
+let test_stage_label_vocabulary () =
+  (* Pin the wire-format label strings so a future rename surfaces here
+     and not as a silent dashboard regression. *)
+  Alcotest.(check string) "slot_wait label" "slot_wait"
+    (Process_eio.timeout_stage_to_string Process_eio.Slot_wait);
+  Alcotest.(check string) "spawn label" "spawn"
+    (Process_eio.timeout_stage_to_string Process_eio.Spawn);
+  Alcotest.(check string) "command label" "command"
+    (Process_eio.timeout_stage_to_string Process_eio.Command)
 ;;
 
 (* Pin the boundary semantics + label vocabulary so a future refactor
@@ -160,6 +199,13 @@ let () =
     ; ( "isolation"
       , [ Alcotest.test_case "programs isolated" `Quick test_program_isolation
         ; Alcotest.test_case "timeout_sec isolated" `Quick test_timeout_sec_isolation
+        ; Alcotest.test_case "stages isolated" `Quick test_stage_isolation
+        ] )
+    ; ( "stage_labels"
+      , [ Alcotest.test_case
+            "stage label vocabulary stable"
+            `Quick
+            test_stage_label_vocabulary
         ] )
     ; ( "bucket_matrix"
       , [ Alcotest.test_case


### PR DESCRIPTION
## 배경

runtime 로그 감사(2026-05-20) 의 이슈 #5:

```
[Process_eio] Timeout after 5s — docker run … bash -lc 'git -C … status'
```

매우 자주 발생. `lib/keeper/keeper_shell_docker.ml:932` 의 `docker_run_min_timeout_sec = 5.0` 이 image pull + container cold start + 실제 cmd 를 모두 5s 안에 소화하지 못해 `git status` 같은 trivial 명령까지 타임아웃.

`lib/keeper/keeper_shell_shared.ml:74` 의 `gh_min_timeout_sec = 15.0` 은 같은 종류의 cascading 401 retry 문제로 #8688 에서 1s → 15s 로 올렸음. docker 쪽은 그대로 5s 로 방치되어 N-of-M 상태.

## 변경 요약

| 파일 | 변경 |
|------|------|
| `lib/keeper/keeper_shell_docker.ml` | `docker_run_min_timeout_sec` 5.0 → 20.0, env `MASC_KEEPER_DOCKER_RUN_MIN_TIMEOUT_SEC` 추가 |
| `lib/keeper/keeper_shell_docker.mli` | doc 갱신 (20s 의 의미 + env override) |
| `lib/keeper/keeper_shell_shared.{ml,mli}` | `keeper_bash_min_timeout_sec` → `keeper_bash_native_min_timeout_sec` rename (의미 명시) |
| `lib/keeper/keeper_exec_shell.mli` | facade re-export 갱신 |
| `lib/keeper/keeper_shell_bash.ml` | caller 갱신 (line 1134) |
| `lib/process/process_eio.{ml,mli}` | `type timeout_stage = Slot_wait \| Spawn \| Command` 추가, `observe_process_timeout ~stage` signature 변경, 5개 fire 사이트 phase_ref 로 stage 식별 |
| `lib/coord.{ml,mli}` | `record_process_timeout ~stage` 추가, Prometheus label `stage` 추가 |
| `lib/prometheus_builtin_metrics_part4.ml` | metric description 갱신 |
| `test/test_process_timeout_counter.ml` | stage label vocabulary + isolation 테스트 추가 |
| `test/test_process_eio_coverage.ml` | observer signature 변경 반영 (Unix fallback 은 항상 Command) |
| `test/test_keeper_bash_safety.ml` | rename caller |

총: 14 files, +234 / −69.

## Caller sweep 결과

- `rg 'keeper_bash_min_timeout_sec' lib test bin` → **0** (rename 완료)
- `rg 'observe_process_timeout' lib test` → 5 fire 사이트 모두 `~stage:` 인자 전달
- `rg 'process_timeout_observer_fn' lib test` → 정의 1 + 사용 5 모두 신 signature 호환
- `rg 'record_process_timeout' lib test` → 5 사이트 모두 `~stage` 갱신

## Stage 매핑 (각 fire 사이트의 stage 추론 근거)

| 위치 | stage 결정 방식 |
|------|---------------|
| `with_unix_capture` (line 424) | Unix fallback 은 `create_process_env` 이후에 timeout deadline 시작 → 항상 `Command` |
| `run_argv` (line 573) | `phase_ref = ref Spawn`, `spawn_and_drain_stdout` 이 `Eio.Process.spawn` 직후 `Command` 로 갱신 |
| `run_argv_with_stdin` (line 612) | 동일 |
| `run_argv_with_stdin_and_status_split` (line 667) | 동일 (`spawn_and_drain_both`) |
| `run_argv_with_status_split` (line 740) | 동일 (`spawn_and_drain_both`) |

`Slot_wait` 는 `Docker_spawn_throttle.with_slot` 이 `Eio.Time.with_timeout_exn` *바깥* 에서 블로킹하므로 `Process_eio` 에서는 emit 되지 않음 — 타입에는 포함시켜서 외부 caller 가 슬롯 대기 timeout 을 별도로 emit 할 미래 후크를 열어둠 (RFC-level slot 예산 도입 시 사용).

## Telemetry cardinality

`masc_process_timeout_total{program, timeout_bucket, stage}`:
- `program` ~10-20 (argv0 basename, fleet 고정)
- `timeout_bucket` 5 (`Timeout_bucket.to_label`)
- `stage` 3 (`slot_wait | spawn | command`)
- 총 series 상한 ≈ **300**, Prometheus 안전 범위.

## Self-review (best-programmer 기준)

- 목표: 5s floor 증상 제거 + timeout 책임 소재(spawn vs cmd) 식별 가능 telemetry.
- 변경 파일: 14 (lib 11 + test 3).
- 로컬 검증: 사용자 위임. `rg` 기반 caller sweep 으로 unresolved symbol 없음 확인.
- 미검증 항목: `dune build @check` / `dune runtest` (사용자 환경에서 실행). worktree sandbox 가 `MASC_CONFIG_DIR` unset 시 fail 하는 known issue (#15504) 때문에 worktree 내 직접 빌드 우회.

## Workaround 거부 기준 (§3)

본 PR 은 §3 N-of-M 패치 해소형:

- `gh_min_timeout_sec = 15` (#8688) ↔ `docker_run_min_timeout_sec = 5` 의 불균형을 한 PR 에서 해소.
- `keeper_bash_min_timeout_sec` 라는 단일 이름이 native + docker 두 경로의 floor 를 *암시적으로* 공유하던 것을 `keeper_bash_native_min_timeout_sec` rename 으로 *도메인 명시*. Docker 경로는 dispatch 안에서 `docker_run_min_timeout_sec` 으로 명시 re-clamp.
- `observe_process_timeout` 의 stage 분기로 "5s 타임아웃이 docker 슬롯 contention 인지 cmd 자체인지" 라는 운영자 질문이 *string 으로 추론* 단계에서 *typed 라벨* 로 격상.

본 PR 은 **floor + telemetry** 만 다룸. `Slot_starvation` typed variant + `with_slot_timed ~budget_sec` 도입 (signature 변경 + 11 caller 영향) 은 별도 PR 로 분리 (scope 밖).

## Reference

- 로그 이슈 #5: masc-mcp runtime log audit 2026-05-20
- 선행 fix: #8688 (gh CLI floor 1s → 15s)
- 후속 후보: Slot_starvation typed error variant + with_slot budget

RFC-WAIVED: 작은 floor 조정 + telemetry label 추가. credential / identity / sandbox containment / dashboard credential 영역 미접촉, hooks/workflow 문서 미접촉.