### PR TITLE
refactor(tool_agent_timeline): replace try-blanket JSON parsing with Safe_ops in token/cost aggregation (closes Task #28)

### DIFF
--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -502,26 +502,38 @@ let build_timeline (config : Coord.config) ~agent_name ~since_hours ~limit
     List.filter (fun e -> String.equal e.event_type "turn_completed") events
   in
   let turns_completed = List.length turn_events in
+  (* Aggregation fold-semantic decision (Task #28):
+     Silent-zero on missing/malformed field is intentional and acceptable
+     because (a) per-event detail is rendered separately in the
+     ["events"] array below, so operators can drill down to find the
+     event with the malformed payload, (b) under-reporting is honest —
+     a sum of "what we could parse" beats inventing values, (c) using
+     [Safe_ops.json_int_opt] / [json_float_opt] removes the implicit
+     try/catch that previously could absorb non-Cancelled exceptions
+     (Yojson.Safe.Util.Type_error etc.) without distinguishing them
+     from a legitimately missing field. The new shape uses pure
+     pattern-matching accessors and no try/catch on the hot path. *)
   let total_input_tokens =
-    List.fold_left (fun acc e ->
-      let open Yojson.Safe.Util in
-      acc + (try e.detail |> member "input_tokens" |> to_int
-             with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> 0))
-      0 turn_events
+    List.fold_left
+      (fun acc e ->
+        acc + Option.value (Safe_ops.json_int_opt "input_tokens" e.detail) ~default:0)
+      0
+      turn_events
   in
   let total_output_tokens =
-    List.fold_left (fun acc e ->
-      let open Yojson.Safe.Util in
-      acc + (try e.detail |> member "output_tokens" |> to_int
-             with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> 0))
-      0 turn_events
+    List.fold_left
+      (fun acc e ->
+        acc + Option.value (Safe_ops.json_int_opt "output_tokens" e.detail) ~default:0)
+      0
+      turn_events
   in
   let total_cost_usd =
-    List.fold_left (fun acc e ->
-      let open Yojson.Safe.Util in
-      acc +. (try e.detail |> member "cost_usd" |> to_float
-              with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> 0.0))
-      0.0 turn_events
+    List.fold_left
+      (fun acc e ->
+        acc
+        +. Option.value (Safe_ops.json_float_opt "cost_usd" e.detail) ~default:0.0)
+      0.0
+      turn_events
   in
   (* Active duration: time between first and last event *)
   let active_duration_minutes =


### PR DESCRIPTION
## Summary

Three `List.fold_left` aggregations for `total_input_tokens`, `total_output_tokens`, and `total_cost_usd` (lib/tool_agent_timeline.ml:505-525) each used:

```ocaml
acc + (try e.detail |> member "input_tokens" |> to_int
       with Eio.Cancel.Cancelled _ as ex -> raise ex | _ -> 0)
```

The `_ -> 0` silent fallback absorbed `Yojson.Safe.Util.Type_error` (numeric parse failure on string-typed field) alongside legitimately missing fields, *indistinguishable*.

## Fix

Migrate to `Safe_ops.json_int_opt` / `json_float_opt` + `Option.value ~default:0`:

```ocaml
acc + Option.value (Safe_ops.json_int_opt "input_tokens" e.detail) ~default:0
```

- Pure pattern-matching accessors — no implicit exception path.
- No try/catch on the hot path — `Cancelled` propagates naturally.
- Same numeric default (`0` / `0.0`) preserved.

## Task #28 decision (decide-first)

**Keep silent-zero semantic** (no per-field `parse_failures` counter, no error propagation to caller).

Rationale:

| Consideration | Verdict |
|---|---|
| Per-event detail visibility | Rendered separately in `["events"]` array of same response — operators can drill down to find the malformed event |
| Total accuracy semantics | Under-reporting via silent-zero is honest — "sum of what we could parse" > inventing values |
| `parse_failures` counter | Scope creep — would need UI consumer too; per-event view already surfaces gaps |
| Caller surface change | None — dashboard consumers continue to receive `total_*: <int>` / `total_cost_usd: <float>` shape |

## Verification

- `dune build --root . @check` EXIT=0.
- No tests touch these aggregation fields directly (`rg total_input_tokens test/` returns empty); the surrounding `build_summary` path is exercised by integration tests via the `/api/v1/agents/<id>/timeline` HTTP route.
- +27/-15 LoC, single function in single file.

## Pattern continuity

Aligns with PR #16697 (turn_completed_events sweep, same file) which made the same migration on adjacent JSON parse sites. The codebase Safe_ops convention is now uniformly applied across `lib/tool_agent_timeline.ml`'s JSON access sites.

## Iter#64 context

Closes Task #28 (decide-first deferred since iter#48). The decide-first portion took ~30 min of audit across 6 iters to confirm silent-zero was the right semantic — recorded in commit body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>