### PR TITLE
refactor(keeper_heartbeat_loop): extract stimulus intake into sibling module

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -372,185 +372,26 @@ let record_semaphore_wait_observation =
   Observations.record_semaphore_wait_observation
 ;;
 
-let record_recovery_stimulus_turn_started
-      ~(ctx : _ context)
-      ~keeper_name
-      (stimulus : Keeper_event_queue.stimulus)
-  =
-  try
-    Keeper_reaction_ledger.record_event_queue_reaction
-      ~base_path:ctx.config.base_path
-      ~keeper_name
-      ~reaction_kind:Keeper_reaction_ledger.Turn_started
-      stimulus
-  with
-  | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn ->
-    Log.Keeper.error
-      "turn entry: failed to persist recovery stimulus reaction post_id=%s \
-       (keeper=%s): %s"
-      stimulus.post_id
-      keeper_name
-      (Printexc.to_string exn)
+(* Event-Layer stimulus intake extracted to [Keeper_heartbeat_stimulus_intake]
+   (godfile decomp). Type + entry point are re-exported as transparent
+   aliases so callers (incl. .mli consumers) stay byte-identical. *)
+module Stimulus_intake = Keeper_heartbeat_stimulus_intake
+
+let stimulus_urgency_to_string = Stimulus_intake.stimulus_urgency_to_string
+let stimulus_class_to_string = Stimulus_intake.stimulus_class_to_string
+let pending_board_event_of_stimulus = Stimulus_intake.pending_board_event_of_stimulus
+let record_recovery_stimulus_turn_started =
+  Stimulus_intake.record_recovery_stimulus_turn_started
 ;;
 
-type heartbeat_event_intake = {
+type heartbeat_event_intake = Stimulus_intake.heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
   consumed_stimulus_count : int;
 }
 
-let stimulus_urgency_to_string = function
-  | Keeper_event_queue.Immediate -> "immediate"
-  | Keeper_event_queue.Normal -> "normal"
-  | Keeper_event_queue.Low -> "low"
-;;
-
-let stimulus_class_to_string = function
-  | Keeper_event_queue.Board_signal -> "board_signal"
-  | Bootstrap -> "bootstrap"
-  | Alive_but_stuck_recovery -> "alive_but_stuck_recovery"
-  | Stay_silent_recovery -> "stay_silent_recovery"
-  | Unsupported _ -> "unsupported"
-;;
-
-let pending_board_event_of_stimulus ~meta_after_triage stim =
-  Keeper_world_observation.pending_board_event_of_stimulus
-    ~continuity_summary:meta_after_triage.continuity_summary
-    ~meta:meta_after_triage
-    stim
-;;
-
-let consume_single_heartbeat_stimulus
-      ~(ctx : _ context)
-      ~meta_after_triage
-      (stim : Keeper_event_queue.stimulus)
-  =
-  let stimulus_class = Keeper_event_queue.classify stim in
-  let class_str = stimulus_class_to_string stimulus_class in
-  Prometheus.inc_counter
-    Keeper_metrics.metric_keeper_stimulus_consumed
-    ~labels:[ "keeper", meta_after_triage.name; "class", class_str ]
-    ();
-  Log.Keeper.info
-    "turn entry: consumed stimulus stimulus_id=%s urgency=%s class=%s \
-     payload_len=%d (keeper=%s)"
-    stim.post_id
-    (stimulus_urgency_to_string stim.urgency)
-    class_str
-    (String.length stim.payload)
-    meta_after_triage.name;
-  match stimulus_class with
-  | Board_signal -> pending_board_event_of_stimulus ~meta_after_triage stim |> Option.to_list
-  | Bootstrap ->
-    Log.Keeper.info
-      "turn entry: bootstrap stimulus consumed (keeper=%s)"
-      meta_after_triage.name;
-    []
-  | Alive_but_stuck_recovery ->
-    Log.Keeper.info
-      "turn entry: alive-but-stuck recovery stimulus consumed post_id=%s \
-       (keeper=%s)"
-      stim.post_id
-      meta_after_triage.name;
-    record_recovery_stimulus_turn_started
-      ~ctx
-      ~keeper_name:meta_after_triage.name
-      stim;
-    []
-  | Stay_silent_recovery ->
-    Log.Keeper.info
-      "turn entry: stay-silent recovery stimulus consumed post_id=%s \
-       (keeper=%s)"
-      stim.post_id
-      meta_after_triage.name;
-    record_recovery_stimulus_turn_started
-      ~ctx
-      ~keeper_name:meta_after_triage.name
-      stim;
-    []
-  | Unsupported prefix ->
-    Prometheus.inc_counter
-      Keeper_metrics.metric_keeper_unsupported_stimulus
-      ~labels:[ "keeper", meta_after_triage.name ]
-      ();
-    Log.Keeper.warn
-      "turn entry: unsupported stimulus consumed prefix=%S post_id=%s \
-       (keeper=%s) — wake→no_signal gap #12684"
-      prefix
-      stim.post_id
-      meta_after_triage.name;
-    []
-;;
-
-let consume_board_stimulus_batch ~meta_after_triage batch =
-  let batch_len = List.length batch in
-  if batch_len > 1 then
-    Log.Keeper.info
-      "debounce: coalesced %d board signals (keeper=%s)"
-      batch_len
-      meta_after_triage.name;
-  List.filter_map
-    (fun (stim : Keeper_event_queue.stimulus) ->
-       Prometheus.inc_counter
-         Keeper_metrics.metric_keeper_stimulus_consumed
-         ~labels:[ "keeper", meta_after_triage.name; "class", "board_signal" ]
-         ();
-       Log.Keeper.info
-         "turn entry: consumed stimulus stimulus_id=%s urgency=%s class=board_signal \
-          payload_len=%d (keeper=%s)"
-         stim.post_id
-         (stimulus_urgency_to_string stim.urgency)
-         (String.length stim.payload)
-         meta_after_triage.name;
-       pending_board_event_of_stimulus ~meta_after_triage stim)
-    batch
-;;
-
-let heartbeat_event_intake ~ctx ~meta_after_triage ~pending_board_events =
-  (* RFC-0020 §3 Rule 4 — drain at most one Event Layer stimulus
-     per turn. Board signals are coalesced by a debounce window before
-     falling back to a single non-board queue dequeue. *)
-  let window = Keeper_config.keeper_board_debounce_window_sec () in
-  let board_batch =
-    Keeper_registry_event_queue.drain_board
-      ~window_sec:window
-      ~base_path:ctx.config.base_path
-      meta_after_triage.name
-  in
-  let queued_observations, consumed_stimulus_count =
-    match board_batch with
-    | [] ->
-      (match
-         Keeper_registry_event_queue.dequeue
-           ~base_path:ctx.config.base_path
-           meta_after_triage.name
-       with
-       | None -> [], 0
-       | Some stim -> consume_single_heartbeat_stimulus ~ctx ~meta_after_triage stim, 1)
-    | batch -> consume_board_stimulus_batch ~meta_after_triage batch, List.length batch
-  in
-  let pending_board_events =
-    List.fold_left
-      (fun acc (event : Keeper_world_observation.pending_board_event) ->
-         if
-           List.exists
-             (fun existing ->
-                String.equal
-                  existing.Keeper_world_observation.post_id
-                  event.Keeper_world_observation.post_id)
-             acc
-         then acc
-         else (
-           Log.Keeper.info
-             "turn entry: promoted queued board stimulus post_id=%s keeper=%s"
-             event.Keeper_world_observation.post_id
-             meta_after_triage.name;
-           event :: acc))
-      pending_board_events
-      (List.rev queued_observations)
-  in
-  { pending_board_events; consumed_stimulus_count }
-;;
+let consume_single_heartbeat_stimulus = Stimulus_intake.consume_single_heartbeat_stimulus
+let consume_board_stimulus_batch = Stimulus_intake.consume_board_stimulus_batch
+let heartbeat_event_intake = Stimulus_intake.heartbeat_event_intake
 
 type cascade_backpressure_decision = Observations.cascade_backpressure_decision =
   | Cascade_admitted

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -1,0 +1,195 @@
+(** Event-Layer stimulus intake for the keeper heartbeat loop.
+
+    Extracted from [keeper_heartbeat_loop.ml] (lines 375-553) as part of
+    the godfile decomp campaign. Owns:
+
+    - the [heartbeat_event_intake] record returned to the heartbeat loop;
+    - per-class string labels used in Prometheus and log lines;
+    - per-stimulus consumption ([consume_single_heartbeat_stimulus]) +
+      board-batch consumption ([consume_board_stimulus_batch]);
+    - the top-level RFC-0020 §3 Rule 4 draining function
+      ([heartbeat_event_intake]) that prefers a debounced board batch and
+      falls back to a single non-board queue dequeue. *)
+
+open Keeper_types
+open Keeper_execution
+
+let stimulus_urgency_to_string = function
+  | Keeper_event_queue.Immediate -> "immediate"
+  | Keeper_event_queue.Normal -> "normal"
+  | Keeper_event_queue.Low -> "low"
+;;
+
+let stimulus_class_to_string = function
+  | Keeper_event_queue.Board_signal -> "board_signal"
+  | Bootstrap -> "bootstrap"
+  | Alive_but_stuck_recovery -> "alive_but_stuck_recovery"
+  | Stay_silent_recovery -> "stay_silent_recovery"
+  | Unsupported _ -> "unsupported"
+;;
+
+let pending_board_event_of_stimulus ~meta_after_triage stim =
+  Keeper_world_observation.pending_board_event_of_stimulus
+    ~continuity_summary:meta_after_triage.continuity_summary
+    ~meta:meta_after_triage
+    stim
+;;
+
+let record_recovery_stimulus_turn_started
+      ~(ctx : _ context)
+      ~keeper_name
+      (stimulus : Keeper_event_queue.stimulus)
+  =
+  try
+    Keeper_reaction_ledger.record_event_queue_reaction
+      ~base_path:ctx.config.base_path
+      ~keeper_name
+      ~reaction_kind:Keeper_reaction_ledger.Turn_started
+      stimulus
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Log.Keeper.error
+      "turn entry: failed to persist recovery stimulus reaction post_id=%s \
+       (keeper=%s): %s"
+      stimulus.post_id
+      keeper_name
+      (Printexc.to_string exn)
+;;
+
+type heartbeat_event_intake = {
+  pending_board_events : Keeper_world_observation.pending_board_event list;
+  consumed_stimulus_count : int;
+}
+
+let consume_single_heartbeat_stimulus
+      ~(ctx : _ context)
+      ~meta_after_triage
+      (stim : Keeper_event_queue.stimulus)
+  =
+  let stimulus_class = Keeper_event_queue.classify stim in
+  let class_str = stimulus_class_to_string stimulus_class in
+  Prometheus.inc_counter
+    Keeper_metrics.metric_keeper_stimulus_consumed
+    ~labels:[ "keeper", meta_after_triage.name; "class", class_str ]
+    ();
+  Log.Keeper.info
+    "turn entry: consumed stimulus stimulus_id=%s urgency=%s class=%s \
+     payload_len=%d (keeper=%s)"
+    stim.post_id
+    (stimulus_urgency_to_string stim.urgency)
+    class_str
+    (String.length stim.payload)
+    meta_after_triage.name;
+  match stimulus_class with
+  | Board_signal -> pending_board_event_of_stimulus ~meta_after_triage stim |> Option.to_list
+  | Bootstrap ->
+    Log.Keeper.info
+      "turn entry: bootstrap stimulus consumed (keeper=%s)"
+      meta_after_triage.name;
+    []
+  | Alive_but_stuck_recovery ->
+    Log.Keeper.info
+      "turn entry: alive-but-stuck recovery stimulus consumed post_id=%s \
+       (keeper=%s)"
+      stim.post_id
+      meta_after_triage.name;
+    record_recovery_stimulus_turn_started
+      ~ctx
+      ~keeper_name:meta_after_triage.name
+      stim;
+    []
+  | Stay_silent_recovery ->
+    Log.Keeper.info
+      "turn entry: stay-silent recovery stimulus consumed post_id=%s \
+       (keeper=%s)"
+      stim.post_id
+      meta_after_triage.name;
+    record_recovery_stimulus_turn_started
+      ~ctx
+      ~keeper_name:meta_after_triage.name
+      stim;
+    []
+  | Unsupported prefix ->
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_unsupported_stimulus
+      ~labels:[ "keeper", meta_after_triage.name ]
+      ();
+    Log.Keeper.warn
+      "turn entry: unsupported stimulus consumed prefix=%S post_id=%s \
+       (keeper=%s) — wake→no_signal gap #12684"
+      prefix
+      stim.post_id
+      meta_after_triage.name;
+    []
+;;
+
+let consume_board_stimulus_batch ~meta_after_triage batch =
+  let batch_len = List.length batch in
+  if batch_len > 1 then
+    Log.Keeper.info
+      "debounce: coalesced %d board signals (keeper=%s)"
+      batch_len
+      meta_after_triage.name;
+  List.filter_map
+    (fun (stim : Keeper_event_queue.stimulus) ->
+       Prometheus.inc_counter
+         Keeper_metrics.metric_keeper_stimulus_consumed
+         ~labels:[ "keeper", meta_after_triage.name; "class", "board_signal" ]
+         ();
+       Log.Keeper.info
+         "turn entry: consumed stimulus stimulus_id=%s urgency=%s class=board_signal \
+          payload_len=%d (keeper=%s)"
+         stim.post_id
+         (stimulus_urgency_to_string stim.urgency)
+         (String.length stim.payload)
+         meta_after_triage.name;
+       pending_board_event_of_stimulus ~meta_after_triage stim)
+    batch
+;;
+
+let heartbeat_event_intake ~ctx ~meta_after_triage ~pending_board_events =
+  (* RFC-0020 §3 Rule 4 — drain at most one Event Layer stimulus
+     per turn. Board signals are coalesced by a debounce window before
+     falling back to a single non-board queue dequeue. *)
+  let window = Keeper_config.keeper_board_debounce_window_sec () in
+  let board_batch =
+    Keeper_registry_event_queue.drain_board
+      ~window_sec:window
+      ~base_path:ctx.config.base_path
+      meta_after_triage.name
+  in
+  let queued_observations, consumed_stimulus_count =
+    match board_batch with
+    | [] ->
+      (match
+         Keeper_registry_event_queue.dequeue
+           ~base_path:ctx.config.base_path
+           meta_after_triage.name
+       with
+       | None -> [], 0
+       | Some stim -> consume_single_heartbeat_stimulus ~ctx ~meta_after_triage stim, 1)
+    | batch -> consume_board_stimulus_batch ~meta_after_triage batch, List.length batch
+  in
+  let pending_board_events =
+    List.fold_left
+      (fun acc (event : Keeper_world_observation.pending_board_event) ->
+         if
+           List.exists
+             (fun existing ->
+                String.equal
+                  existing.Keeper_world_observation.post_id
+                  event.Keeper_world_observation.post_id)
+             acc
+         then acc
+         else (
+           Log.Keeper.info
+             "turn entry: promoted queued board stimulus post_id=%s keeper=%s"
+             event.Keeper_world_observation.post_id
+             meta_after_triage.name;
+           event :: acc))
+      pending_board_events
+      (List.rev queued_observations)
+  in
+  { pending_board_events; consumed_stimulus_count }
+;;

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.mli
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.mli
@@ -1,0 +1,69 @@
+(** Event-Layer stimulus intake for the keeper heartbeat loop.
+
+    Drains at most one Event Layer stimulus per turn following
+    RFC-0020 §3 Rule 4. Board signals are coalesced by a debounce
+    window before falling back to a single non-board queue dequeue. *)
+
+open Keeper_types
+open Keeper_execution
+
+(** [stimulus_urgency_to_string u] returns the Prometheus / log label
+    for [u] ([immediate] / [normal] / [low]). *)
+val stimulus_urgency_to_string : Keeper_event_queue.urgency -> string
+
+(** [stimulus_class_to_string c] returns the Prometheus / log label for
+    a stimulus class. *)
+val stimulus_class_to_string : Keeper_event_queue.stimulus_class -> string
+
+(** [pending_board_event_of_stimulus ~meta_after_triage stim] wraps a
+    stimulus into a pending board event, threading the keeper meta's
+    continuity summary. *)
+val pending_board_event_of_stimulus
+  :  meta_after_triage:keeper_meta
+  -> Keeper_event_queue.stimulus
+  -> Keeper_world_observation.pending_board_event option
+
+(** [record_recovery_stimulus_turn_started ~ctx ~keeper_name stim] writes
+    a [Turn_started] reaction to the keeper reaction ledger for [stim].
+    Logs and swallows errors except [Eio.Cancel.Cancelled]. *)
+val record_recovery_stimulus_turn_started
+  :  ctx:_ context
+  -> keeper_name:string
+  -> Keeper_event_queue.stimulus
+  -> unit
+
+(** Result of one heartbeat intake — accumulated pending board events
+    after dedup and the number of stimuli consumed from the queue. *)
+type heartbeat_event_intake = {
+  pending_board_events : Keeper_world_observation.pending_board_event list;
+  consumed_stimulus_count : int;
+}
+
+(** [consume_single_heartbeat_stimulus ~ctx ~meta_after_triage stim]
+    increments Prometheus, logs the consumption, and returns a list of
+    pending board events derived from [stim] (empty for non-board
+    classes). [Alive_but_stuck_recovery] and [Stay_silent_recovery]
+    also write a reaction-ledger entry. *)
+val consume_single_heartbeat_stimulus
+  :  ctx:_ context
+  -> meta_after_triage:keeper_meta
+  -> Keeper_event_queue.stimulus
+  -> Keeper_world_observation.pending_board_event list
+
+(** [consume_board_stimulus_batch ~meta_after_triage batch] increments
+    Prometheus per stimulus, logs debounce coalescing, and returns the
+    pending board events derived from [batch]. *)
+val consume_board_stimulus_batch
+  :  meta_after_triage:keeper_meta
+  -> Keeper_event_queue.stimulus list
+  -> Keeper_world_observation.pending_board_event list
+
+(** [heartbeat_event_intake ~ctx ~meta_after_triage ~pending_board_events]
+    drains the Event-Layer queue (per RFC-0020 §3 Rule 4) and merges
+    newly-consumed board events with the [pending_board_events] already
+    accumulated by the caller, deduplicating by [post_id]. *)
+val heartbeat_event_intake
+  :  ctx:'a context
+  -> meta_after_triage:keeper_meta
+  -> pending_board_events:Keeper_world_observation.pending_board_event list
+  -> heartbeat_event_intake

--- a/lib/server/server_dashboard_shell_snapshot.ml
+++ b/lib/server/server_dashboard_shell_snapshot.ml
@@ -73,7 +73,7 @@ let select_telemetry_summary_json
         Server_timing.measure
           timing_obj
           Server_timing.Telemetry_summary_aggregate
-          (fun () -> Telemetry_unified.summary_json ~base_path ~masc_root ()))
+          (fun () -> Telemetry_unified.summary_json ~base_path ~masc_root ())))
 ;;
 
 let select_project_snapshot_json ~state ~sw ~clock ?timing req


### PR DESCRIPTION
## 요약

\`keeper_heartbeat_loop.ml\` (godfile, 1892 LoC) 에서 RFC-0020 §3 Rule 4
\"Event-Layer stimulus intake\" 클러스터 (lines 375-553) 를 sibling
모듈로 추출. 본 PR 머지 후 1892 → 1733 (−159, −8.4%).

## 추출된 함수

- \`stimulus_urgency_to_string\` / \`stimulus_class_to_string\` —
  Prometheus / log 레이블
- \`pending_board_event_of_stimulus\` — stimulus → pending board event
- \`record_recovery_stimulus_turn_started\` — Eio.Cancel-safe ledger write
- \`consume_single_heartbeat_stimulus\` — per-stimulus Prometheus + 클래스별 분기
- \`consume_board_stimulus_batch\` — debounce coalescing 후 board batch
- \`heartbeat_event_intake\` — RFC-0020 §3 Rule 4 main entrypoint

## 패턴

이전 PR (#16726, #16758) 의 *transparent alias re-export* 패턴:

1. 새 모듈 \`Keeper_heartbeat_stimulus_intake\` 가 \`Keeper_types\` +
   \`Keeper_execution\` 만 의존. 클러스터 내부 호출은 새 모듈 내에서
   모두 resolve (\`consume_single_heartbeat_stimulus\` →
   \`record_recovery_stimulus_turn_started\`). back-edge 없음.
2. \`keeper_heartbeat_loop.ml\` 상단에
   \`module Stimulus_intake = Keeper_heartbeat_stimulus_intake\` +
   7 함수 alias.
3. record 타입 \`heartbeat_event_intake\` 는 transparent type alias 로
   재노출 — 기존 필드 접근 + .mli 가 byte-identical.

## 검증

\`\`\`
$ dune build --root . @check     # exit 0
$ _build/default/test/test_heartbeat_smart.exe         # 13/13 PASS
$ _build/default/test/test_heartbeat_integration.exe   # 21/21 PASS
\`\`\`

7 함수 중 \`heartbeat_event_intake\` 만 외부 caller (\`.mli\`) — transparent
alias 로 호환 유지. 나머지 6 함수 0 external caller.

## 의존성

PR #16754 (server_dashboard_shell_snapshot.ml syntax fix) commit
\`a157ad2563\` 위에 stack. \`dune build @check\` 통과 필수.

## LoC

| 파일 | LoC |
|------|-----|
| keeper_heartbeat_loop.ml | 1892 → 1733 (−159) |
| keeper_heartbeat_stimulus_intake.ml (new) | 195 |
| keeper_heartbeat_stimulus_intake.mli (new) | 69 |
| 본 PR diff | +278 / −173 |

## RFC

RFC-WAIVED: pure mechanical extraction of internal helpers within
\`lib/keeper/\` (not in credential / identity / operator_control / sandbox /
hooks / workflow subsystem). 동작 변경 없음 (transparent alias).