### PR TITLE
feat(keeper_memory_recall): counter + WARN for swallowed read errors

### DIFF
--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -17,6 +17,13 @@ let read_file_tail_lines path ~max_bytes ~max_lines : string list =
   if max_lines <= 0 then []
   else if not (Fs_compat.file_exists path) then []
   else
+    (* The catch-all below preserves prior behavior (return [[]] on
+       IO failure), but read errors used to be indistinguishable from
+       "no recorded memory" — both paths returned the empty list.
+       Emit a counter + WARN so corrupt / missing memory bank files
+       become visible in operator dashboards. Label cardinality is
+       bounded by reusing [Keeper_memory_recall_exn_class] (a 4-value
+       closed sum); the full error string still goes to the log body. *)
     try
       let fd = Unix.openfile path [ Unix.O_RDONLY ] 0 in
       Fun.protect
@@ -71,8 +78,19 @@ let read_file_tail_lines path ~max_bytes ~max_lines : string list =
           else
             let drop = n - max_lines in
             List.filteri (fun i _ -> i >= drop) lines)
-    with Sys_error _ | Unix.Unix_error _ | End_of_file ->
-      []
+    with
+    | (Sys_error _ | Unix.Unix_error _ | End_of_file) as exn ->
+        let exn_label =
+          Keeper_memory_recall_exn_class.(to_label (classify exn))
+        in
+        Log.Keeper.warn
+          "read_file_tail_lines: dropping read of %s: %s"
+          path (Printexc.to_string exn);
+        Prometheus.inc_counter
+          Keeper_metrics.metric_keeper_memory_recall_read_errors
+          ~labels:[ ("exception_class", exn_label) ]
+          ();
+        []
 
 let read_keeper_memory_summary
     (config : Coord.config)

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -209,6 +209,7 @@ type t =
   | RecurringFailures
   | TurnCleanupFailures
   | MemoryBankLoadHistorySwallowedExceptions
+  | MemoryRecallReadErrors
   | CascadeHttpProbeJsonParseFailures
 
 (** String conversion
@@ -422,6 +423,8 @@ let to_string = function
   | TurnCleanupFailures -> "masc_keeper_turn_cleanup_failures_total"
   | MemoryBankLoadHistorySwallowedExceptions ->
       "masc_keeper_memory_bank_load_history_swallowed_exceptions_total"
+  | MemoryRecallReadErrors ->
+      "masc_keeper_memory_recall_read_errors_total"
   | CascadeHttpProbeJsonParseFailures ->
       "masc_cascade_http_probe_json_parse_failures_total"
 ;;
@@ -989,6 +992,10 @@ let metric_keeper_session_cleanup_failures = "masc_keeper_session_cleanup_failur
 
 let metric_keeper_memory_bank_load_history_swallowed_exceptions =
   to_string MemoryBankLoadHistorySwallowedExceptions
+;;
+
+let metric_keeper_memory_recall_read_errors =
+  to_string MemoryRecallReadErrors
 ;;
 
 let metric_cascade_http_probe_json_parse_failures =

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -201,6 +201,7 @@ type t =
   | RecurringFailures
   | TurnCleanupFailures
   | MemoryBankLoadHistorySwallowedExceptions
+  | MemoryRecallReadErrors
   | CascadeHttpProbeJsonParseFailures
 
 val to_string : t -> string
@@ -634,6 +635,17 @@ val metric_keeper_session_cleanup_failures : string
     line); the counter exists so JSONL corruption / fs faults stop
     masking as "no history". *)
 val metric_keeper_memory_bank_load_history_swallowed_exceptions : string
+
+(** Counter for IO / read failures swallowed by the silent
+    [try ... with Sys_error _ | Unix.Unix_error _ | End_of_file -> []]
+    catch-all in [Keeper_memory_recall.read_file_tail_lines]. Without this
+    counter a corrupt or missing memory bank file is indistinguishable
+    from a keeper with no recorded memory — the recall code returns
+    [[]] in both cases. The counter uses the same
+    [Keeper_memory_recall_exn_class] closed-sum [exception_class] label
+    as the load-history counter so cardinality is bounded. Behavior is
+    unchanged (read still returns [[]] on failure). *)
+val metric_keeper_memory_recall_read_errors : string
 
 (** Counter for probe responses dropped by the silent JSON parse catch-all
     in [Cascade_http_probe.try_probe]. Before this counter existed the


### PR DESCRIPTION
## 요약

- `read_file_tail_lines` 의 silent catch-all (`try ... with Sys_error _ | Unix.Unix_error _ | End_of_file -> []`) 이 *empty memory* 와 *IO read failure* 를 구분 불가능하게 만듦
- Prometheus counter `masc_keeper_memory_recall_read_errors_total` 추가, `exception_class` label 로 분류 (4-value closed sum 재사용)
- WARN log + counter 로 corrupt / missing memory bank 가시화 — 동작은 보존 (read 여전히 `[]` 반환)

## 패턴

PR #15781 의 `MemoryBankLoadHistorySwallowedExceptions` counter + Codex P1 follow-up 의 `Keeper_memory_recall_exn_class` 재사용 — 동일 SSOT closed-sum 으로 label cardinality 보장.

## 배경

`memory/masc-mcp-code-flowchart-audit-2026-05-20.html` §3 MEMORY HIGH — 6-subsystem flowchart audit (Turn/Life/Memory/Compact/Tool/Cascade) 의 정량 개선 대상 중 첫번째.

같은 audit 에서 발견된 다른 site 2개는 이미 해소됨:
- `keeper_memory_llm_summary.ml:182-205` chain exhausted counter + WARN 존재
- `keeper_memory_recall.ml:632-660` load_history_user_messages exception class label 존재 (PR #15781 + Codex P1)

이 PR 은 마지막 잔존 silent 경로를 같은 패턴으로 닫음.

## 변경

| 파일 | 변경 |
|---|---|
| `lib/keeper/keeper_metrics.mli` | `MemoryRecallReadErrors` variant + `metric_keeper_memory_recall_read_errors` val + 주석 |
| `lib/keeper/keeper_metrics.ml` | variant + `to_string` arm + binding |
| `lib/keeper/keeper_memory_recall.ml` | try-with arm 에 `Log.Keeper.warn` + `Prometheus.inc_counter` |

## 검증

- `dune build --root . @check` PASS (exit 0)
- 동작 보존: catch-all 여전히 `[]` 반환

## 측정 가능한 개선

- `read_error / read_total` ratio 가 Prometheus 에서 visible
- corrupt jsonl / fs fault / permission 변화가 더 이상 "no memory" 로 silent 통과 안 함

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>