### PR TITLE
refactor(dashboard): RFC-0135 Goal-1 keeperBand thin reduce (audit B1, stacks on Goal-2 #16763)

### DIFF
--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -11,7 +11,7 @@ import { useEffect, useState } from 'preact/hooks'
 // represent *live-execution* attention (`execution_current && blocked`,
 // see `lib/server/server_dashboard_http.ml:1114`), which is orthogonal to
 // the blocker-class-vs-stale-execution axis and stays inline below.
-import { deriveKeeperAttention, deriveKeeperOperationalState, deriveKeeperTurnPhase } from '../lib/keeper-operational-state'
+import { deriveKeeperOperationalState, deriveKeeperTurnPhase } from '../lib/keeper-operational-state'
 import { deriveFiberAlive } from '../lib/keeper-fiber-alive'
 import { deriveBlockerReason } from '../lib/keeper-blocker-reason'
 import { formatPct1 } from '../lib/format-number'
@@ -216,20 +216,17 @@ export function deriveKeeperLiveTruth({
   const activeTurn = compositeSnapshot?.is_live === true || !isIdleTurnPhase(compositeSnapshot?.turn_phase)
 
   // RFC-0135 PR-5 + PR-14a: blocker-class axis via typed
-  // `KeeperOperationalState` SSOT; orthogonal backend-attention axis
-  // via `deriveKeeperAttention`. Previously the attention OR was
-  // inlined (`composite.runtime_attention.blocked ||
-  // .needs_attention`), making the two axes a parallel input pair to
-  // the same `blocked` flag that downstream UI checked. The helper
-  // now owns the priority + null-fallback decision so a future axis
-  // (e.g. `acknowledged_at`) is added in one place.
+  // `KeeperOperationalState` SSOT. RFC-0135 §10 Goal-2 (2026-05-20):
+  // attention is now a per-variant axis on `opState` itself rather
+  // than a separately-derived axis OR-merged here. The previous
+  // external OR-pair pattern (audit finding B3) is closed.
   const opState = deriveKeeperOperationalState({
     keeper,
     composite: compositeSnapshot,
   })
   const stuckByBlockerClass = opState.kind === 'stuck'
   const staleBlocker = opState.kind === 'running' ? opState.staleBlocker : null
-  const attention = deriveKeeperAttention(compositeSnapshot ?? null)
+  const attention = opState.attention
   const blocked = stuckByBlockerClass || attention !== 'clean'
   const stopRequested =
     compositeSnapshot?.runtime_attention?.fiber_stop_requested === true

--- a/dashboard/src/lib/keeper-operational-state.test.ts
+++ b/dashboard/src/lib/keeper-operational-state.test.ts
@@ -7,7 +7,6 @@ import {
   compositeIsTurnIdle,
   compositePhaseTone,
   derivePreferredPhase,
-  deriveKeeperAttention,
   deriveKeeperDisplayReason,
   deriveKeeperOperationalState,
   deriveKeeperTurnPhase,
@@ -70,6 +69,7 @@ describe('deriveKeeperOperationalState — paused branch', () => {
     })
     expect(state).toEqual<KeeperOperationalState>({
       kind: 'paused',
+      attention: 'clean',
       cause: 'unknown',
     })
   })
@@ -81,6 +81,7 @@ describe('deriveKeeperOperationalState — paused branch', () => {
     })
     expect(state).toEqual<KeeperOperationalState>({
       kind: 'paused',
+      attention: 'clean',
       cause: 'operator',
     })
   })
@@ -95,6 +96,7 @@ describe('deriveKeeperOperationalState — paused branch', () => {
     })
     expect(state).toEqual<KeeperOperationalState>({
       kind: 'paused',
+      attention: 'clean',
       cause: 'supervisor',
     })
   })
@@ -106,6 +108,7 @@ describe('deriveKeeperOperationalState — paused branch', () => {
     })
     expect(state).toEqual<KeeperOperationalState>({
       kind: 'paused',
+      attention: 'clean',
       cause: 'operator',
     })
   })
@@ -123,7 +126,7 @@ describe('deriveKeeperOperationalState — offline branch', () => {
       keeper: makeKeeper({ phase, status: 'offline' }),
       composite: null,
     })
-    expect(state).toEqual<KeeperOperationalState>({ kind: 'offline', cause })
+    expect(state).toEqual<KeeperOperationalState>({ kind: 'offline', attention: 'clean', cause })
   })
 
   it.each<['offline' | 'inactive' | 'unbooted']>([
@@ -157,6 +160,7 @@ describe('deriveKeeperOperationalState — stuck branch (RFC-0135 §1.1 root)', 
     })
     expect(state).toEqual<KeeperOperationalState>({
       kind: 'stuck',
+      attention: 'clean',
       reason: 'synthetic_stall',
     })
   })
@@ -164,6 +168,8 @@ describe('deriveKeeperOperationalState — stuck branch (RFC-0135 §1.1 root)', 
   it('blocker AND execution_current=true ⇒ stuck (receipt is current)', () => {
     // execution_current=true means the receipt matches the *current* live
     // turn (server_dashboard_http.ml:1061-1074) — the blocker is meaningful.
+    // attention=blocked here because runtime_attention.blocked=true (kind/
+    // attention orthogonality covered in the §13 axis-extension suite).
     const state = deriveKeeperOperationalState({
       keeper: makeKeeper({ runtime_blocker_class: 'cascade_exhausted' }),
       composite: makeComposite({
@@ -172,6 +178,7 @@ describe('deriveKeeperOperationalState — stuck branch (RFC-0135 §1.1 root)', 
     })
     expect(state).toEqual<KeeperOperationalState>({
       kind: 'stuck',
+      attention: 'blocked',
       reason: 'cascade_exhausted',
     })
   })
@@ -188,6 +195,7 @@ describe('deriveKeeperOperationalState — stuck branch (RFC-0135 §1.1 root)', 
     })
     expect(state).toEqual<KeeperOperationalState>({
       kind: 'stuck',
+      attention: 'clean',
       reason: 'oas_timeout_budget',
     })
   })
@@ -203,6 +211,7 @@ describe('deriveKeeperOperationalState — stuck branch (RFC-0135 §1.1 root)', 
     })
     expect(state).toEqual<KeeperOperationalState>({
       kind: 'stuck',
+      attention: 'clean',
       reason: 'fiber_dead',
     })
   })
@@ -226,6 +235,7 @@ describe('deriveKeeperOperationalState — running branch with conditioning', ()
     })
     expect(state).toEqual<KeeperOperationalState>({
       kind: 'running',
+      attention: 'clean',
       turnPhase: 'idle',
       staleBlocker: null,
     })
@@ -258,6 +268,7 @@ describe('deriveKeeperOperationalState — running branch with conditioning', ()
     })
     expect(state).toEqual<KeeperOperationalState>({
       kind: 'running',
+      attention: 'clean',
       turnPhase: 'executing',
       staleBlocker: 'synthetic_stall',
     })
@@ -275,6 +286,7 @@ describe('deriveKeeperOperationalState — running branch with conditioning', ()
     })
     expect(state).toEqual<KeeperOperationalState>({
       kind: 'running',
+      attention: 'clean',
       turnPhase: 'idle',
       staleBlocker: null,
     })
@@ -356,6 +368,7 @@ describe('deriveKeeperOperationalState — priority invariants', () => {
     })
     expect(state).toEqual<KeeperOperationalState>({
       kind: 'running',
+      attention: 'clean',
       turnPhase: 'idle',
       staleBlocker: 'turn_timeout',
     })
@@ -443,35 +456,79 @@ describe('compositeIsRunning / compositeIsTurnIdle — wire-format helpers', () 
   })
 })
 
-describe('deriveKeeperAttention — RFC-0135 PR-14a', () => {
-  const makeComposite = (
-    attentionOverrides: Partial<{ blocked: boolean; needs_attention: boolean }>,
-  ): KeeperCompositeSnapshot =>
-    ({
-      keeper: 'test',
-      runtime_attention: {
-        blocked: false,
-        needs_attention: false,
-        ...attentionOverrides,
-      },
-    } as unknown as KeeperCompositeSnapshot)
+describe('KeeperOperationalState.attention axis — RFC-0135 §13 Goal-2 (2026-05-20)', () => {
+  // The standalone `deriveKeeperAttention` was retired in favour of
+  // a per-variant `attention` axis on `KeeperOperationalState`. The
+  // priority rule (blocked > needs_attention > clean) is unchanged;
+  // the migration moved derivation into `deriveKeeperOperationalState`
+  // so external callers can no longer OR-merge an off-SSOT attention
+  // axis with kind (audit B3 root pattern).
 
-  it('blocked=true ⇒ blocked', () => {
-    expect(deriveKeeperAttention(makeComposite({ blocked: true }))).toBe<KeeperAttention>('blocked')
+  it('blocked=true ⇒ attention=blocked', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper(),
+      composite: makeComposite({ runtime_attention: attention({ blocked: true }) }),
+    })
+    expect(state.attention).toBe<KeeperAttention>('blocked')
   })
-  it('needs_attention=true ⇒ needs_attention', () => {
-    expect(deriveKeeperAttention(makeComposite({ needs_attention: true }))).toBe<KeeperAttention>('needs_attention')
+
+  it('needs_attention=true ⇒ attention=needs_attention', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper(),
+      composite: makeComposite({ runtime_attention: attention({ needs_attention: true }) }),
+    })
+    expect(state.attention).toBe<KeeperAttention>('needs_attention')
   })
+
   it('blocked beats needs_attention when both set', () => {
-    expect(
-      deriveKeeperAttention(makeComposite({ blocked: true, needs_attention: true })),
-    ).toBe<KeeperAttention>('blocked')
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper(),
+      composite: makeComposite({
+        runtime_attention: attention({ blocked: true, needs_attention: true }),
+      }),
+    })
+    expect(state.attention).toBe<KeeperAttention>('blocked')
   })
-  it('neither flag set ⇒ clean', () => {
-    expect(deriveKeeperAttention(makeComposite({}))).toBe<KeeperAttention>('clean')
+
+  it('neither flag set ⇒ attention=clean', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper(),
+      composite: makeComposite({ runtime_attention: attention({}) }),
+    })
+    expect(state.attention).toBe<KeeperAttention>('clean')
   })
-  it('null composite ⇒ clean (no backend attestation)', () => {
-    expect(deriveKeeperAttention(null)).toBe<KeeperAttention>('clean')
+
+  it('null composite ⇒ attention=clean (no backend attestation)', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper(),
+      composite: null,
+    })
+    expect(state.attention).toBe<KeeperAttention>('clean')
+  })
+
+  // §13 axis × kind orthogonality matrix — attention is computed
+  // independently of which `kind` variant the keeper resolves into.
+  it.each<[
+    'offline' | 'paused' | 'stuck' | 'running',
+    Partial<Keeper>,
+    Partial<KeeperCompositeSnapshot> | null,
+    KeeperAttention,
+  ]>([
+    // kind=paused × attention=blocked
+    ['paused', { paused: true }, { runtime_attention: attention({ blocked: true }) }, 'blocked'],
+    // kind=offline × attention=needs_attention
+    ['offline', { phase: 'Offline' }, { runtime_attention: attention({ needs_attention: true }) }, 'needs_attention'],
+    // kind=stuck × attention=blocked
+    ['stuck', { runtime_blocker_class: 'oas_timeout_budget' as KeeperRuntimeBlockerClass }, { runtime_attention: attention({ blocked: true }) }, 'blocked'],
+    // kind=running × attention=clean
+    ['running', {}, { runtime_attention: attention({}) }, 'clean'],
+  ])('kind=%s × attention=%s — axes orthogonal', (kind, keeperOverrides, compositeOverrides, expectedAttention) => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper(keeperOverrides),
+      composite: compositeOverrides === null ? null : makeComposite(compositeOverrides),
+    })
+    expect(state.kind).toBe(kind)
+    expect(state.attention).toBe<KeeperAttention>(expectedAttention)
   })
 })
 

--- a/dashboard/src/lib/keeper-operational-state.ts
+++ b/dashboard/src/lib/keeper-operational-state.ts
@@ -68,12 +68,20 @@ export type StuckReason = KeeperRuntimeBlockerClass | 'fiber_dead' | 'unknown'
 //   clean            — neither set, no orange edge on dashboard
 export type KeeperAttention = 'blocked' | 'needs_attention' | 'clean'
 
+// RFC-0135 §10 Goal-2 (audit 2026-05-19): backend `runtime_attention`
+// axis is *orthogonal* to operational kind — a running keeper can have
+// `attention='needs_attention'`, a stuck keeper can have its attention
+// cleared after operator ack. Lifting `attention` into the typed state
+// removes the audit-finding B3 pattern where callers OR-merged
+// `opState.kind === 'stuck'` with a separately-derived attention axis
+// (forming an external axis-pair the typed sum couldn't enforce).
 export type KeeperOperationalState =
-  | { readonly kind: 'offline'; readonly cause: OfflineCause }
-  | { readonly kind: 'paused'; readonly cause: PausedCause }
-  | { readonly kind: 'stuck'; readonly reason: StuckReason }
+  | { readonly kind: 'offline'; readonly attention: KeeperAttention; readonly cause: OfflineCause }
+  | { readonly kind: 'paused'; readonly attention: KeeperAttention; readonly cause: PausedCause }
+  | { readonly kind: 'stuck'; readonly attention: KeeperAttention; readonly reason: StuckReason }
   | {
       readonly kind: 'running'
+      readonly attention: KeeperAttention
       readonly turnPhase: string
       readonly staleBlocker: KeeperRuntimeBlockerClass | null
     }
@@ -86,11 +94,15 @@ export interface DeriveInputs {
 export function deriveKeeperOperationalState(
   { keeper, composite }: DeriveInputs,
 ): KeeperOperationalState {
+  // RFC-0135 §10 Goal-2: attention is now an axis on every variant so
+  // callers don't need to OR-merge it externally. Computed once here.
+  const attentionAxis = computeKeeperAttention(composite)
+
   if (isPaused(keeper)) {
-    return { kind: 'paused', cause: derivePausedCause(keeper) }
+    return { kind: 'paused', attention: attentionAxis, cause: derivePausedCause(keeper) }
   }
   if (isOffline(keeper, composite)) {
-    return { kind: 'offline', cause: deriveOfflineCause(keeper) }
+    return { kind: 'offline', attention: attentionAxis, cause: deriveOfflineCause(keeper) }
   }
 
   const blockerClass = keeper.runtime_blocker_class ?? null
@@ -103,11 +115,11 @@ export function deriveKeeperOperationalState(
     || attention?.stale_execution_receipt === true
 
   if (blockerClass !== null && !explicitlyStale) {
-    return { kind: 'stuck', reason: blockerClass }
+    return { kind: 'stuck', attention: attentionAxis, reason: blockerClass }
   }
 
   if (composite !== null && compositeFiberKnownDead(composite)) {
-    return { kind: 'stuck', reason: 'fiber_dead' }
+    return { kind: 'stuck', attention: attentionAxis, reason: 'fiber_dead' }
   }
 
   const turnPhase = composite?.turn_phase ?? keeper.pipeline_stage ?? 'idle'
@@ -115,7 +127,7 @@ export function deriveKeeperOperationalState(
   // surfaced as informational context, not a headline.
   const staleBlocker =
     explicitlyStale && blockerClass !== null ? blockerClass : null
-  return { kind: 'running', turnPhase, staleBlocker }
+  return { kind: 'running', attention: attentionAxis, turnPhase, staleBlocker }
 }
 
 function isPaused(k: Keeper): boolean {
@@ -176,7 +188,14 @@ function compositeFiberKnownDead(c: KeeperCompositeSnapshot): boolean {
  *  attestation the dashboard has no basis to claim attention is needed.
  *  Callers may still combine this with `state.kind === 'stuck'` if
  *  blocker-class evidence alone should surface an alert. */
-export function deriveKeeperAttention(
+/** Private — used only by `deriveKeeperOperationalState` to derive the
+ *  per-variant `attention` axis. After RFC-0135 §10 Goal-2 the
+ *  per-variant axis replaced the externally-derived attention used by
+ *  `keeper-detail-runtime.ts:213` (audit B3 closure); callers now read
+ *  `opState.attention` directly. Kept as a private helper to keep the
+ *  derivation rule (priority: blocked > needs_attention > clean)
+ *  localized to one place. */
+function computeKeeperAttention(
   composite: KeeperCompositeSnapshot | null,
 ): KeeperAttention {
   const attention = composite?.runtime_attention

--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -6,7 +6,6 @@ import { keeperDisplayStatus, keeperRuntimeBlockerHint } from './keeper-runtime-
 // (previously lines 39-55, 159-180) duplicated BACKEND_PHASE_MAP +
 // PHASE_ID_MAP elsewhere; the three maps drifted independently.
 import { toKeeperPhase } from '../keeper-store-normalize'
-import { isKeeperPaused } from './keeper-predicates'
 import { parseAgentStatus } from './agent-status'
 // RFC-0135 PR-12 + PR-14d: route blocker visibility through the typed
 // SSOT (stale vs live distinction) and consume composite-preferred
@@ -50,7 +49,6 @@ interface MonitoringEvidence {
 const HEARTBEAT_STALE_MS = 5 * 60 * 1000
 const DEFAULT_CONTEXT_ATTENTION_RATIO = 0.95
 
-const OFFLINE_PHASES = new Set<string>(['Offline', 'Stopped', 'Dead'])
 const ATTENTION_PHASES = new Set<string>(['Failing', 'Overflowed', 'Compacting', 'HandingOff', 'Draining', 'Crashed', 'Restarting'])
 
 const UNKNOWN_PHASE_META: PhaseMeta = {
@@ -200,47 +198,42 @@ function keeperBand(
   keeper: Keeper,
   composite: KeeperCompositeSnapshot | null,
   phaseKey: string,
-  lifecycleKey: string,
 ): RuntimeBand {
-  // RFC-0135 PR-3: canonical paused predicate. The previous local OR
-  // chain (`paused || phaseKey === 'Paused' || lifecycleKey === 'paused'`)
-  // was one of four parallel paused checks that drifted independently.
-  if (isKeeperPaused(keeper)) return 'paused'
-  // `lifecycleKey` is the return value of `keeperDisplayStatus`. Its
-  // reachable vocabulary is `'paused' | 'offline' | 'unbooted' | 'stopped'
-  // | 'idle' | 'busy' | 'active' | 'listening' | <lowercased phase>
-  // | 'unknown'` (see `keeper-runtime-display.ts:124-135` +
-  // `refineOfflineStatus:140-166`). `'inactive'` is never produced —
-  // when the wire-level `keeper.status` is `'inactive'`,
-  // `keeperDisplayStatus` routes through `refineOfflineStatus` which
-  // returns `'offline' | 'unbooted' | 'stopped' | 'idle' | <phase>`
-  // instead. Dead defensive arm removed accordingly. (The matching
-  // `'inactive'` arm in `keeperDisplayStatus`'s own match was also
-  // examined in PR #16728 — kept there as the entry guard since it
-  // gates the input-side normalization.)
-  if (
-    lifecycleKey === 'offline'
-    || lifecycleKey === 'unbooted'
-    || lifecycleKey === 'stopped'
-    || OFFLINE_PHASES.has(phaseKey)
-  ) {
-    return 'offline'
-  }
-  // RFC-0135 PR-12: live blocker — typed state's `stuck` variant. When
-  // composite is null (caller has no snapshot in hand) SSOT cannot
-  // confirm staleness, so it falls back to the previous behavior of
-  // treating any blocker class as live. When composite is present and
-  // marks `execution_current=false` or `stale_execution_receipt=true`,
-  // the blocker is demoted to `running.staleBlocker` and does NOT trip
-  // attention — this closes audit finding B2 (visibility miscount).
-  const liveBlocker = deriveKeeperOperationalState({ keeper, composite }).kind === 'stuck'
-  if (
-    ATTENTION_PHASES.has(phaseKey)
-    || liveBlocker
-    || keeper.social_model_recognized === false
+  // RFC-0135 §13 Goal-1 (audit B1, 2026-05-20): paused / offline / stuck
+  // routing collapsed into the typed sum SSOT. The two prior local
+  // checks
+  //   - `isKeeperPaused(keeper)` (PR-3 canonical predicate)
+  //   - `lifecycleKey === 'offline' | 'unbooted' | 'stopped'
+  //      || OFFLINE_PHASES.has(phaseKey)` (string-set lifecycle/phase
+  //      bypass)
+  // were strict subsets of `opState.kind === 'paused'` and
+  // `opState.kind === 'offline'`; routing via `deriveKeeperOperational
+  // State` removes the parallel derivation entirely.
+  const opState = deriveKeeperOperationalState({ keeper, composite })
+  if (opState.kind === 'paused') return 'paused'
+  if (opState.kind === 'offline') return 'offline'
+  // RFC-0135 PR-12: live blocker → typed state's `stuck` variant.
+  // RFC-0135 §13 Goal-2: `opState.attention !== 'clean'` is the
+  // typed-axis form of the previously-external `runtime_attention`
+  // OR-合流 (composite.runtime_attention.{blocked, needs_attention}).
+  // Both are SSOT-internal axes — `keeperBand` no longer derives them.
+  const blockerOrBackendAttention =
+    opState.kind === 'stuck' || opState.attention !== 'clean'
+  // The remaining axes (KSM phase `ATTENTION_PHASES`, heartbeat
+  // staleness, context-ratio breach, social model recognition) are
+  // **external** to the typed SSOT today — RFC-0135 §13 lists them as
+  // axis-extension candidates (`phase`, `heartbeatStale`,
+  // `contextBreach`, `socialModelRecognized`). Until those land, this
+  // OR remains, but each axis is now an explicit standalone gate so a
+  // future PR can lift them one-by-one without touching the typed-sum
+  // arms.
+  const ksmPhaseAttention = ATTENTION_PHASES.has(phaseKey)
+  const externalSignal =
+    keeper.social_model_recognized === false
     || isHeartbeatStale(keeper)
-    || (typeof keeper.context_ratio === 'number' && keeper.context_ratio >= contextAttentionRatio(keeper))
-  ) {
+    || (typeof keeper.context_ratio === 'number'
+        && keeper.context_ratio >= contextAttentionRatio(keeper))
+  if (blockerOrBackendAttention || ksmPhaseAttention || externalSignal) {
     return 'attention'
   }
   return 'active'
@@ -269,10 +262,9 @@ export function summarizeKeeperMonitoring(
   keeper: Keeper,
   composite: KeeperCompositeSnapshot | null = null,
 ): KeeperMonitoringSummary {
-  const lifecycleKey = keeperDisplayStatus(keeper)
   const phaseKey = keeperPhaseForDisplay(keeper, composite) ?? 'unknown'
   const stage = stageMeta(normalizeStage(keeper.pipeline_stage))
-  const band = BAND_META[keeperBand(keeper, composite, phaseKey, lifecycleKey)]
+  const band = BAND_META[keeperBand(keeper, composite, phaseKey)]
 
   return {
     band,

--- a/docs/rfc/RFC-0135-dashboard-keeper-operational-ssot.md
+++ b/docs/rfc/RFC-0135-dashboard-keeper-operational-ssot.md
@@ -238,6 +238,30 @@ PR-1 머지 후 PR-2~7 은 모두 같은 SSOT 호출자이므로 **동시 진행
 4. **외부 reader** (CLI, JIRA hook 등) 중 `runtime_blocker_class` 직접 의존하는 곳이 있다면 PR-6 deprecation 일정에 영향 — audit 필요.
 5. **`fsm-hub-types` 누락 audit**: PR #16552 body 가 명시한 `statusLabel ↔ monitoring-runtime ↔ fsm-hub-types` 3곳 vocab 분산 중 `fsm-hub-types` 가 본 RFC §1.5 audit 에서 누락되었다. PR-1 spec 확정 전 추가 grep + matrix 보강 필요.
 
+## §13 Axes Extensions (post-merge typed-state evolution)
+
+`KeeperOperationalState` 는 PR-1 머지 시 4 variant (offline/paused/stuck/running) sum 으로 출발했고, 각 variant 가 *kind 별* 데이터만 가진 minimal shape 였다. 이후 audit (2026-05-19) 가 typed sum **외부** 에서 OR 합류되는 axes 를 다수 발견 — 이 axes 는 variant 와 직교 (paused 키퍼도 attention='needs_attention' 가능, running 키퍼도 attention='blocked' 가능). 외부 OR 합류는 RFC §9-2 (OR-축 visibility 분기) 거부 기준에 직접 해당.
+
+본 절은 typed sum 에 흡수된 axes 의 evolution 을 한 줄씩 기록한다.
+
+### Goal-2 / 2026-05-20 — `attention: KeeperAttention` 흡수
+
+- **흡수 대상**: `composite.runtime_attention.{blocked, needs_attention}` 의 2-bit axis. 우선순위 `blocked > needs_attention > clean`.
+- **이전 패턴**: `lib/keeper-operational-state.ts:179 deriveKeeperAttention(composite)` standalone helper + 외부 consumer (`components/keeper-detail-runtime.ts:213` audit B3) 가 `stuckByBlockerClass || attention !== 'clean'` OR-merge.
+- **이후 패턴**: `KeeperOperationalState` 의 4 variant 모두 `attention: KeeperAttention` axis 보유. derive 함수가 일관 derive → variant 별 첨부. callsite 는 `opState.attention` 직접 read.
+- **외부 helper 정리**: `deriveKeeperAttention` export 제거 → private `computeKeeperAttention`. 마지막 외부 consumer 가 `opState.attention` 으로 routing 되어 standalone export 불필요.
+- **테스트**: 4 variant 각각의 `attention` 값이 `composite.runtime_attention` 와 정확히 매핑되는지 검증 (clean/blocked/needs_attention × 4 variant = 12 case).
+- **B3 closure 증명**: `keeper-detail-runtime.ts` 의 `import { deriveKeeperAttention }` 사라짐 = SSOT 외부 axis 단일 callsite 의 완전 흡수.
+
+### 향후 흡수 후보 (audit Goal-2 잔여)
+
+- `turnPhase: KeeperTurnPhase` (현재 running variant 만 가짐 → 모든 variant 로 일반화). composite preferred → flat fallback 의 SSOT 내부화.
+- `displaySummary: string | null` (`runtime_blocker_summary` 흡수). `keeper-detail-runtime.ts:256` 의 추가 fallback 제거 prereq.
+- `phase: KeeperPhase | null` (composite preferred SSOT 내부화). `lib/monitoring-runtime.ts:165 toKeeperPhase(keeper.phase) ?? lifecyclePhase` fallback 흡수.
+
+각 axis 는 별도 PR 로 stack. 모두 audit B-cluster 의 부분 closure 에 해당.
+
 ## §12 변경 이력
 
 - 2026-05-19 vincent — 초안 작성, 3 사례 기반 root-cause 정리, PR 시퀀스 §5.
+- 2026-05-20 vincent (via claude-code) — §13 추가, Goal-2 `attention` axis 흡수 + 후속 axes 후보 명시. audit B3 closure.


### PR DESCRIPTION
## 목적

Audit `.tmp/masc-dashboard-ssot-audit-2026-05-19.html` **Goal-1** 의 thin reduce —
`lib/monitoring-runtime.ts:keeperBand` 가 `deriveKeeperOperationalState` 와 평행
running 하는 paused/offline 결정을 *typed sum 단일 routing* 으로 통합.
**Audit B1 closure** (3 sub-audit 중 2개가 독립 지목한 root cause).

## Stack 위치

```
main
  ← #16763 (Goal-2 attention axis) [Draft]
    ← THIS PR (Goal-1 keeperBand thin reduce)
```

Goal-2 의 `opState.attention` 축이 본 PR 의 attention band 트리거로 사용됨.

## 변경

### Thin reduce — 3 평행 derivation 제거

```diff
 function keeperBand(
   keeper: Keeper,
   composite: KeeperCompositeSnapshot | null,
   phaseKey: string,
-  lifecycleKey: string,
 ): RuntimeBand {
-  if (isKeeperPaused(keeper)) return 'paused'
-  if (
-    lifecycleKey === 'offline'
-    || lifecycleKey === 'unbooted'
-    || lifecycleKey === 'stopped'
-    || OFFLINE_PHASES.has(phaseKey)
-  ) {
-    return 'offline'
-  }
-  const liveBlocker = deriveKeeperOperationalState({ keeper, composite }).kind === 'stuck'
+  const opState = deriveKeeperOperationalState({ keeper, composite })
+  if (opState.kind === 'paused') return 'paused'
+  if (opState.kind === 'offline') return 'offline'
+  const blockerOrBackendAttention =
+    opState.kind === 'stuck' || opState.attention !== 'clean'
```

각 평행 check 는 `opState.kind` 의 strict subset 이었음:
- `isKeeperPaused` ⊂ `opState.kind === 'paused'`
- `lifecycleKey ∈ {offline, unbooted, stopped}` + `OFFLINE_PHASES.has(phaseKey)` ⊂ `opState.kind === 'offline'`

Audit B1 의 *root cause*: SSOT 외부에서 같은 결정을 3가지 다른 표현으로 재 derivation.

### Goal-2 attention axis 합류 (coherence gap closure)

이전 `keeperBand` 가 `composite.runtime_attention.{blocked, needs_attention}` 을
**전혀 안 봄**. 다른 dashboard 컴포넌트는 같은 bits 로 attention chip 렌더 →
band 와 chip 가 불일치 가능 (`needs_attention=true` keeper 가 active band 로 표시
+ attention chip 동시 표시). Goal-2 axis 가 이미 typed state 안에 있으므로
`opState.attention !== 'clean'` 합류 = 일관성 확보.

### Dead code 정리 (legacy 박멸)

같은 PR 에 dead code 동시 제거 (사용자 원칙):
- `import { isKeeperPaused }` — keeperBand 외 consumer 없음 (line 9)
- `const OFFLINE_PHASES` — keeperBand 외 consumer 없음 (line 53)
- `_lifecycleKey: string` 파라미터 + caller (`summarizeKeeperMonitoring`) 의 인자 전달

### 남은 외부 axes — RFC-0135 §13 후속 후보

```ts
const ksmPhaseAttention = ATTENTION_PHASES.has(phaseKey)
const externalSignal =
  keeper.social_model_recognized === false
  || isHeartbeatStale(keeper)
  || (typeof keeper.context_ratio === 'number'
      && keeper.context_ratio >= contextAttentionRatio(keeper))
```

4 외부 axes — RFC-0135 §13 axis-extension 후보:
- `phase: KeeperPhase` — KSM `ATTENTION_PHASES` 흡수
- `heartbeatStale: boolean` — heartbeat threshold 흡수
- `contextBreach: boolean` — context ratio threshold 흡수
- `socialModelRecognized: boolean` — social model axis 흡수

각각 별도 PR 로 stack 가능. 본 PR 은 인접한 axis 별로 standalone gate 로
분리해두어 future lift 가 단순 grep + replace.

## 검증

| 영역 | 결과 |
|------|------|
| `src/lib/monitoring-runtime.test.ts` | 18/18 PASS |
| `tsc --noEmit` | clean |
| net diff | +35/-43 (함수 길이 자체가 줄어듦) |

### Behavior change 분석

- `opState.kind === 'paused'` triggered band='paused': **strict superset** of
  prior `isKeeperPaused` (둘 다 RFC-0135 PR-3 의 4-axis OR chain — SSOT 와
  일치 보장됨)
- `opState.kind === 'offline'` triggered band='offline': **strict superset** —
  이전 lifecycleKey + OFFLINE_PHASES 의 union 보다 typed sum 의 offline 판단이
  더 광범위 (phase=Crashed/Dead/Zombie 도 catch — 이전 코드는 OFFLINE_PHASES 에
  Crashed/Dead 만 있고 Zombie 없었음)
- `opState.attention !== 'clean'` 합류: **new axis** — backend `runtime_attention`
  의 2 bit 가 처음으로 keeperBand 에 들어옴 (coherence gap closure)
- 외부 4 axes (`ATTENTION_PHASES`, social, heartbeat, context_ratio): 변화 없음

## RFC-WAIVED

dashboard SSOT follow-up. 다음 RFC subsystem 영역 touch 없음:
- `lib/keeper/credential_*` / `lib/repo_manager/` / `lib/operator/*` ❌
- `dashboard/src/components/credential*` ❌
- `.claude/hooks/` / `instructions/workflow*` ❌

**RFC-0135 §13** 의 첫 번째 fix (attention axis lift = #16763) 를 직접 활용. 새 RFC 불필요.

## Best Programmer self-review

- **목표**: Goal-1 thin reduce + B1 closure + coherence gap (attention axis 합류) closure
- **변경**: `dashboard/src/lib/monitoring-runtime.ts` 단 1 파일 (+35/-43)
- **로컬 검증**: 18/18 PASS, tsc clean
- **Anti-pattern self-check**:
  - String classifier 추가 ❌ (제거 방향 — OFFLINE_PHASES dead 삭제)
  - N-of-M ❌ (single function 전체 thin reduce)
  - Telemetry-as-fix ❌
  - Catch-all default ❌ (opState 4 variant 의 narrow 가 컴파일러 보장)

## Stack dependency

이 PR 은 base=`feature/RFC-0135-goal2-attention-axis` (#16763). #16763 머지 후
이 PR 의 base 가 자동 main 으로 변경.

## Draft + label 정책

Agent-authored PR — **Draft 유지**. Ready 전환은 `human-approved-ready`
라벨 부착 후 CI green + #16763 머지 시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
