### PR TITLE
docs(rfc): backfill implementation_prs for 34 RFCs (redo of #16750 squash-lost commit)

### DIFF
--- a/docs/rfc/RFC-0010-ocamlformat-config-reconciliation.md
+++ b/docs/rfc/RFC-0010-ocamlformat-config-reconciliation.md
@@ -3,12 +3,12 @@ rfc: "0010"
 title: "ocamlformat config reconciliation"
 status: Draft
 created: 2026-05-12
-updated: 2026-05-12
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0058"]
-implementation_prs: []
+implementation_prs: [14952]
 ---
 
 # RFC-0010 — ocamlformat config reconciliation

--- a/docs/rfc/RFC-0071-exhaustive-match-sweep-codemod.md
+++ b/docs/rfc/RFC-0071-exhaustive-match-sweep-codemod.md
@@ -3,12 +3,12 @@ rfc: "0071"
 title: "Exhaustive Match Sweep Codemod — Eliminate N-of-M `_ -> false/None` Anti-Pattern"
 status: Draft
 created: 2026-05-12
-updated: 2026-05-12
+updated: 2026-05-20
 author: yousleepwhen
 supersedes: []
 superseded_by: null
 related: ["0042", "0068"]
-implementation_prs: []
+implementation_prs: [14881,14923,14930,14936,14942,14945,14965,14969,14974,14984,14987,14990,14997,15003,15006,15012]
 ---
 
 # RFC-0071: Exhaustive Match Sweep Codemod — Eliminate N-of-M `_ -> false/None` Anti-Pattern

--- a/docs/rfc/RFC-0072-keeper-sub-fsm-transitions-typed.md
+++ b/docs/rfc/RFC-0072-keeper-sub-fsm-transitions-typed.md
@@ -3,12 +3,12 @@ rfc: "0072"
 title: "Type-encoded keeper sub-FSM transitions (cascade + turn_phase)"
 status: Draft
 created: 2026-05-12
-updated: 2026-05-12
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0002", "0039", "0042", "0046"]
-implementation_prs: []
+implementation_prs: [14880,14903,14908,14912,14918,14927,14938]
 ---
 
 # RFC-0072 — Type-encoded keeper sub-FSM transitions (cascade + turn_phase)

--- a/docs/rfc/RFC-0073-tool-readiness-probe.md
+++ b/docs/rfc/RFC-0073-tool-readiness-probe.md
@@ -3,12 +3,12 @@ rfc: "0073"
 title: "Tool Readiness Probe — Typed Precondition + Runtime Gap Disclosure"
 status: Draft
 created: 2026-05-14
-updated: 2026-05-14
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0005", "0019", "0057", "0062", "0074", "0075", "0076"]
-implementation_prs: []
+implementation_prs: [15064]
 ---
 
 # Tool Readiness Probe — Typed Precondition + Runtime Gap Disclosure

--- a/docs/rfc/RFC-0077-write-side-silent-failure-typed.md
+++ b/docs/rfc/RFC-0077-write-side-silent-failure-typed.md
@@ -3,12 +3,12 @@ rfc: "0077"
 title: "Write-side silent failure — typed propagation"
 status: Draft
 created: 2026-05-14
-updated: 2026-05-14
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0042", "0044", "0062", "0063", "0071"]
-implementation_prs: []
+implementation_prs: [15054]
 ---
 
 # RFC-0077 — Write-side silent failure: typed propagation

--- a/docs/rfc/RFC-0078-rfc-number-reservation-ledger.md
+++ b/docs/rfc/RFC-0078-rfc-number-reservation-ledger.md
@@ -3,12 +3,12 @@ rfc: "0078"
 title: "RFC Number Reservation Ledger + CI Collision Guard"
 status: Draft
 created: 2026-05-14
-updated: 2026-05-14
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0057", "0058"]
-implementation_prs: []
+implementation_prs: [15200]
 ---
 
 # RFC-0078: RFC Number Reservation Ledger + CI Collision Guard

--- a/docs/rfc/RFC-0079-log-row-typed-encoder.md
+++ b/docs/rfc/RFC-0079-log-row-typed-encoder.md
@@ -3,12 +3,12 @@ rfc: "0079"
 title: "Log row typed encoder + silent-drop removal"
 status: Draft
 created: 2026-05-14
-updated: 2026-05-14
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0042", "0044", "0058", "0078"]
-implementation_prs: []
+implementation_prs: [15211]
 ---
 
 # RFC-0079: Log row typed encoder + silent-drop removal

--- a/docs/rfc/RFC-0080-tool-registry-ssot.md
+++ b/docs/rfc/RFC-0080-tool-registry-ssot.md
@@ -3,12 +3,12 @@ rfc: "0080"
 title: "Tool registry SSOT — collapse 15-fold OR membership into typed Tool_name boundary"
 status: Draft
 created: 2026-05-14
-updated: 2026-05-14
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0070", "0072"]
-implementation_prs: []
+implementation_prs: [15207,15268,15271]
 ---
 
 # RFC-0080 — Tool registry SSOT

--- a/docs/rfc/RFC-0081-telemetry-envelope-and-pivot-timeline.md
+++ b/docs/rfc/RFC-0081-telemetry-envelope-and-pivot-timeline.md
@@ -3,12 +3,12 @@ rfc: "0081"
 title: "OAS Telemetry Envelope Context & Keeper/Goal Pivot Timeline"
 status: Draft
 created: 2026-05-14
-updated: 2026-05-14
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0046", "0049", "0063"]
-implementation_prs: []
+implementation_prs: [15137]
 ---
 
 # RFC-0081 — OAS Telemetry Envelope Context & Keeper/Goal Pivot Timeline

--- a/docs/rfc/RFC-0086-keeper-namespace-bulk-promotion.md
+++ b/docs/rfc/RFC-0086-keeper-namespace-bulk-promotion.md
@@ -3,12 +3,12 @@ rfc: "0086"
 title: "Keeper namespace bulk promotion to sub-library"
 status: Draft
 created: 2026-05-15
-updated: 2026-05-15
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0056", "0042", "0050"]
-implementation_prs: []
+implementation_prs: [15467,15474,15488,15493,15494,15522,15531]
 ---
 
 # RFC-0086 — Keeper namespace bulk promotion to sub-library

--- a/docs/rfc/RFC-0090-write-side-success-model-attribution.md
+++ b/docs/rfc/RFC-0090-write-side-success-model-attribution.md
@@ -3,12 +3,12 @@ rfc: "0090"
 title: "Write-side success-model attribution — finish N-of-M migration"
 status: Draft
 created: 2026-05-17
-updated: 2026-05-17
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0044", "0077", "0088"]
-implementation_prs: []
+implementation_prs: [15651]
 ---
 
 # RFC-0090 — Write-side success-model attribution: finish N-of-M migration

--- a/docs/rfc/RFC-0094-compact-cooldown-semantics-split.md
+++ b/docs/rfc/RFC-0094-compact-cooldown-semantics-split.md
@@ -3,12 +3,12 @@ rfc: "0094"
 title: "Compact cooldown semantics split — typed write anchor vs check anchor"
 status: Draft
 created: 2026-05-17
-updated: 2026-05-17
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0088"]
-implementation_prs: []
+implementation_prs: [15716]
 ---
 
 # RFC-0094: Compact cooldown semantics split

--- a/docs/rfc/RFC-0095-openai-compat-streaming-wire-up.md
+++ b/docs/rfc/RFC-0095-openai-compat-streaming-wire-up.md
@@ -3,12 +3,12 @@ rfc: "0095"
 title: "OpenAI-compat provider streaming wire-up"
 status: Draft
 created: 2026-05-17
-updated: 2026-05-17
+updated: 2026-05-20
 author: jeong-sik
 supersedes: []
 superseded_by: null
 related: ["0047", "0045", "0033", "0058"]
-implementation_prs: []
+implementation_prs: [15722,15725]
 ---
 
 # RFC-0095 — OpenAI-compat provider streaming wire-up

--- a/docs/rfc/RFC-0096-keeper-turn-contract-multi-turn-and-tier-group-spof.md
+++ b/docs/rfc/RFC-0096-keeper-turn-contract-multi-turn-and-tier-group-spof.md
@@ -3,12 +3,12 @@ rfc: "0096"
 title: "Keeper Turn Contract — multi-turn reasoning + tier-group SPOF root-fix"
 status: Draft
 created: 2026-05-17
-updated: 2026-05-17
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0084", "0085", "0086", "0087", "0089"]
-implementation_prs: []
+implementation_prs: [15688]
 ---
 
 # RFC-0096 — Keeper Turn Contract: multi-turn reasoning + tier-group SPOF

--- a/docs/rfc/RFC-0102-pre-turn-cascade-availability-gate.md
+++ b/docs/rfc/RFC-0102-pre-turn-cascade-availability-gate.md
@@ -3,12 +3,12 @@ rfc: "0102"
 title: "Pre-turn cascade availability gate — reuse, not new surface"
 status: Draft
 created: 2026-05-17
-updated: 2026-05-17
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0009", "0012", "0022", "0042", "0072", "0088"]
-implementation_prs: []
+implementation_prs: [15814]
 ---
 
 # RFC-0102 — Pre-turn cascade availability gate

--- a/docs/rfc/RFC-0106-cancel-safe-try-with-discipline.md
+++ b/docs/rfc/RFC-0106-cancel-safe-try-with-discipline.md
@@ -3,12 +3,12 @@ rfc: "0106"
 title: "Cancel-safe try-with discipline (Eio.Cancel.Cancelled propagation)"
 status: Draft
 created: 2026-05-17
-updated: 2026-05-17
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0072", "0097", "0101"]
-implementation_prs: []
+implementation_prs: [15894,15904,15917,15919,15920,15925]
 ---
 
 # RFC-0106 — Cancel-safe try-with discipline

--- a/docs/rfc/RFC-0110-tool-pair-atomicity-write-boundary.md
+++ b/docs/rfc/RFC-0110-tool-pair-atomicity-write-boundary.md
@@ -3,12 +3,12 @@ rfc: "0110"
 title: "Tool-pair atomicity at write boundary — sunset compaction repair fabrication"
 status: Draft
 created: 2026-05-17
-updated: 2026-05-17
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0042", "0077", "0088"]
-implementation_prs: []
+implementation_prs: [15924]
 ---
 
 # RFC-0110: Tool-pair atomicity at write boundary — sunset compaction repair fabrication

--- a/docs/rfc/RFC-0111-goal-mint-atomicity-uniqueness-invariant.md
+++ b/docs/rfc/RFC-0111-goal-mint-atomicity-uniqueness-invariant.md
@@ -3,12 +3,12 @@ rfc: "0111"
 title: "Goal mint atomicity — auto-goal uniqueness invariant at write boundary"
 status: Draft
 created: 2026-05-17
-updated: 2026-05-17
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0042", "0077", "0088", "0110"]
-implementation_prs: []
+implementation_prs: [15927]
 ---
 
 # RFC-0111: Goal mint atomicity — auto-goal uniqueness invariant at write boundary

--- a/docs/rfc/RFC-0112-typed-json-parse-boundary.md
+++ b/docs/rfc/RFC-0112-typed-json-parse-boundary.md
@@ -3,12 +3,12 @@ rfc: "0112"
 title: "Typed JSON parse boundary — eliminate silent-drop fallback across read sites"
 status: Draft
 created: 2026-05-17
-updated: 2026-05-17
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0042", "0077", "0088", "0098"]
-implementation_prs: []
+implementation_prs: [15933]
 ---
 
 # RFC-0112: Typed JSON parse boundary — eliminate silent-drop fallback across read sites

--- a/docs/rfc/RFC-0113-keeper-reaction-liveness-runtime.md
+++ b/docs/rfc/RFC-0113-keeper-reaction-liveness-runtime.md
@@ -3,12 +3,12 @@ rfc: "0113"
 title: "KeeperReactionLiveness L1–L5 runtime — phased OCaml mirror of TLA+ design ground"
 status: Draft
 created: 2026-05-17
-updated: 2026-05-17
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0002", "0003", "0020", "0042", "0072"]
-implementation_prs: []
+implementation_prs: [15937]
 ---
 
 # RFC-0113: KeeperReactionLiveness L1–L5 runtime — phased OCaml mirror of TLA+ design ground

--- a/docs/rfc/RFC-0114-ksm-precondition-enforcement.md
+++ b/docs/rfc/RFC-0114-ksm-precondition-enforcement.md
@@ -3,12 +3,12 @@ rfc: "0114"
 title: "KSM event precondition enforcement at apply_event boundary"
 status: Draft
 created: 2026-05-17
-updated: 2026-05-17
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0002", "0042", "0072", "0113"]
-implementation_prs: []
+implementation_prs: [15939]
 ---
 
 # RFC-0114: KSM event precondition enforcement at apply_event boundary

--- a/docs/rfc/RFC-0115-ktc-turn-phase-spec-runtime-parity.md
+++ b/docs/rfc/RFC-0115-ktc-turn-phase-spec-runtime-parity.md
@@ -3,12 +3,12 @@ rfc: "0115"
 title: "KTC turn_phase spec ← runtime parity — backfill spec for Turn_routing / Turn_exhausted"
 status: Draft
 created: 2026-05-17
-updated: 2026-05-17
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0002", "0042", "0072", "0113", "0114"]
-implementation_prs: []
+implementation_prs: [15944]
 ---
 
 # RFC-0115: KTC turn_phase spec ← runtime parity — backfill spec for Turn_routing / Turn_exhausted

--- a/docs/rfc/RFC-0116-kcr-fallback-cap-mechanism-parity.md
+++ b/docs/rfc/RFC-0116-kcr-fallback-cap-mechanism-parity.md
@@ -3,12 +3,12 @@ rfc: "0116"
 title: "KCR fallback cap mechanism parity — explicit counter at spec ↔ visited-list at runtime"
 status: Draft
 created: 2026-05-17
-updated: 2026-05-17
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0042", "0072", "0113", "0114", "0115"]
-implementation_prs: []
+implementation_prs: [15947]
 ---
 
 # RFC-0116: KCR fallback cap mechanism parity — explicit counter at spec ↔ visited-list at runtime

--- a/docs/rfc/RFC-0117-kcr-health-state-representation-parity.md
+++ b/docs/rfc/RFC-0117-kcr-health-state-representation-parity.md
@@ -3,12 +3,12 @@ rfc: "0117"
 title: "KCR item-health representation parity — typed Degraded variant + spec cooldown action + PerKeeperIsolation correction"
 status: Draft
 created: 2026-05-17
-updated: 2026-05-17
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0042", "0072", "0113", "0114", "0115", "0116"]
-implementation_prs: []
+implementation_prs: [15957]
 ---
 
 # RFC-0117: KCR item-health representation parity — typed Degraded variant + spec cooldown action + PerKeeperIsolation correction

--- a/docs/rfc/RFC-0118-kct-terminal-cascade-contract.md
+++ b/docs/rfc/RFC-0118-kct-terminal-cascade-contract.md
@@ -3,12 +3,12 @@ rfc: "0118"
 title: "KCT NoTerminalCascade S1 — typed Result at select_cascade boundary + Zombie mapping correction"
 status: Draft
 created: 2026-05-17
-updated: 2026-05-17
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0042", "0072", "0113", "0114", "0115", "0116", "0117"]
-implementation_prs: []
+implementation_prs: [15963]
 ---
 
 # RFC-0118: KCT NoTerminalCascade S1 — typed Result at select_cascade boundary + Zombie mapping correction

--- a/docs/rfc/RFC-0119-observer-spec-mapping-table-drift-lint.md
+++ b/docs/rfc/RFC-0119-observer-spec-mapping-table-drift-lint.md
@@ -3,12 +3,12 @@ rfc: "0119"
 title: "Observer spec mapping table drift lint — sentinel-marker validator for OCaml↔TLA+ collapse projections"
 status: Draft
 created: 2026-05-17
-updated: 2026-05-17
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0042", "0072", "0113", "0114", "0115", "0116", "0117", "0118"]
-implementation_prs: []
+implementation_prs: [15967]
 ---
 
 # RFC-0119: Observer spec mapping table drift lint — sentinel-marker validator for OCaml↔TLA+ collapse projections

--- a/docs/rfc/RFC-0122-keeper-disk-pressure.md
+++ b/docs/rfc/RFC-0122-keeper-disk-pressure.md
@@ -3,12 +3,12 @@ rfc: "0122"
 title: "Keeper disk pressure — process-local fleet failure mode beyond FD"
 status: Draft
 created: 2026-05-17
-updated: 2026-05-17
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0042", "0097", "0101", "0103"]
-implementation_prs: []
+implementation_prs: [15975]
 ---
 
 # RFC-0122: Keeper disk pressure — process-local fleet failure mode beyond FD

--- a/docs/rfc/RFC-0123-briefing-last-event-fabrication-write-boundary.md
+++ b/docs/rfc/RFC-0123-briefing-last-event-fabrication-write-boundary.md
@@ -3,12 +3,12 @@ rfc: "0123"
 title: "Briefing last_event fabrication — option-typed write boundary, sunset read-side sentinel"
 status: Draft
 created: 2026-05-17
-updated: 2026-05-17
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0042", "0077", "0088", "0110"]
-implementation_prs: []
+implementation_prs: [15976]
 ---
 
 # RFC-0123: Briefing last_event fabrication — option-typed write boundary, sunset read-side sentinel

--- a/docs/rfc/RFC-0125-bounded-subprocess-discipline.md
+++ b/docs/rfc/RFC-0125-bounded-subprocess-discipline.md
@@ -3,12 +3,12 @@ rfc: "0125"
 title: "Bounded subprocess discipline: per-call Switch scope + Fiber.first timeout race"
 status: Draft
 created: 2026-05-17
-updated: 2026-05-17
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0072", "0097", "0101", "0106"]
-implementation_prs: []
+implementation_prs: [15940,15973]
 ---
 
 # RFC-0125 — Bounded subprocess discipline

--- a/docs/rfc/RFC-0131-shell-command-gate-facade.md
+++ b/docs/rfc/RFC-0131-shell-command-gate-facade.md
@@ -8,7 +8,7 @@ author: vincent
 supersedes: []
 superseded_by: null
 related: ["0054", "0089", "0091", "0092", "0126"]
-implementation_prs: []
+implementation_prs: [16335,16340,16346,16433,16527,16532,16542]
 ---
 
 # RFC-0131 — Shell Command Gate facade

--- a/docs/rfc/RFC-0132-redaction-ssot.md
+++ b/docs/rfc/RFC-0132-redaction-ssot.md
@@ -3,12 +3,12 @@ rfc: "0132"
 title: "Redaction SSOT — `runtime` boundary-label private type"
 status: Draft
 created: 2026-05-19
-updated: 2026-05-19
+updated: 2026-05-20
 author: claude-cron-loop (vincent)
 supersedes: []
 superseded_by: null
 related: ["0085", "0088", "0089", "0126", "0131"]
-implementation_prs: []
+implementation_prs: [16531,16536,16537]
 ---
 
 # RFC-0132 — Redaction SSOT for `"runtime"` boundary label

--- a/docs/rfc/RFC-0133-keeper-phase-casing-ssot-consolidation.md
+++ b/docs/rfc/RFC-0133-keeper-phase-casing-ssot-consolidation.md
@@ -3,12 +3,12 @@ rfc: "0132"
 title: "Keeper Phase Casing SSOT Consolidation"
 status: Draft
 created: 2026-05-19
-updated: 2026-05-19
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0042", "0046", "0088"]
-implementation_prs: []
+implementation_prs: [16316]
 ---
 
 # RFC-0133 — Keeper Phase Casing SSOT Consolidation

--- a/docs/rfc/RFC-0137-host-fd-pressure-keeper-pause.md
+++ b/docs/rfc/RFC-0137-host-fd-pressure-keeper-pause.md
@@ -3,12 +3,12 @@ rfc: "0137"
 title: "Host FD pressure → Keeper pause (safety-net for Docker VM FD accumulation)"
 status: Draft
 created: 2026-05-19
-updated: 2026-05-19
+updated: 2026-05-20
 author: jeong-sik
 supersedes: []
 superseded_by: null
 related: ["0097", "0101"]
-implementation_prs: []
+implementation_prs: [16665]
 ---
 
 # RFC-0137 — Host FD pressure → Keeper pause

--- a/docs/rfc/RFC-0140-dashboard-wire-codec-layer.md
+++ b/docs/rfc/RFC-0140-dashboard-wire-codec-layer.md
@@ -3,12 +3,12 @@ rfc: "0140"
 title: "Dashboard Wire-Format Codec Layer"
 status: Draft
 created: 2026-05-19
-updated: 2026-05-19
+updated: 2026-05-20
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0135", "0139"]
-implementation_prs: []
+implementation_prs: [16700]
 ---
 
 # RFC-0140: Dashboard Wire-Format Codec Layer


### PR DESCRIPTION
## Summary

**Recovery of work silently dropped by PR #16750's squash-merge.**

PR #16750 had two commits:
- `a7b3357d2d` — 3 RFC backfill (0091/0093/0097)
- `1c71fd4708` — 34 RFC backfill (the big sweep)

The squash-merge commit `65d9b9fc98` shows `3 files changed, 6 insertions(+), 6 deletions(-)` — only the first commit was picked up. The second commit was pushed after the admin-merge window locked the squash target, so it was silently dropped. None of the 34 RFCs is on main today (verified `grep '^implementation_prs: \[\]$' docs/rfc/RFC-0080-tool-registry-ssot.md` returns the empty form).

This PR re-applies that same 34-RFC backfill against current main (`f1a873088b`).

## Restored data

| Largest batches | # PRs |
|----------------|-------|
| RFC-0071 exhaustive-match-sweep-codemod | 16 |
| RFC-0086 keeper-namespace-bulk-promotion | 7 |
| RFC-0072 keeper-sub-fsm-transitions-typed | 7 |
| RFC-0131 shell-command-gate-facade | 7 |
| RFC-0106 cancel-safe-try-with-discipline | 6 |
| RFC-0080 tool-registry-ssot | 3 |
| RFC-0125 bounded-subprocess-discipline | 2 |
| RFC-0095 openai-compat-streaming-wire-up | 2 |
| RFC-0132 redaction-ssot | 3 |
| RFC-0094 compact-cooldown-semantics-split | 1 |

Full list of 34 RFCs in the commit message.

## Lesson learned

When pushing additional commits to a stack-friendly Draft PR right around an admin-merge window, the second commit can be invisibly dropped. **Detection method**: after merge, run `git show <merge-sha> --stat` and compare file count against expected.

## Out of scope

- **RFC-0108 number collision**: deferred (needs renumber + cross-ref update + user approval).
- **RFC-0136 phase-split**: handled by separate Draft PR #16764.
- **Body-only RFCs (0141/0142/0143)**: `[]` is accurate, no impl PRs.

## Self-review

- [x] Each cited PR is merged.
- [x] Format consistency: bare ints, no quotes/`#`.
- [x] No status field touched.
- [x] `updated: 2026-05-20` on all 34 files.
- [x] Worktree-first.

## Scope guard

Docs-only. 34 files / 67 lines. No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>