### PR TITLE
fix(dashboard): wire bootstrap + H/2 gateway to snapshot selector [RFC-0138 Step 3 follow-up]

### DIFF
--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -1470,7 +1470,14 @@ let dashboard_bootstrap_http_json
   in
   let namespace_truth =
     slice "namespace_truth" (fun () ->
-      dashboard_namespace_truth_http_json ~state ~sw ~clock request)
+      (* RFC-0138 Phase 3 Step 3 follow-up — route through the snapshot
+         selector instead of calling the compute path directly so the
+         lock-free read takes effect for /api/v1/dashboard/bootstrap as
+         well as /project-snapshot.  Without this wire, the
+         "fallback runs ≤1× per process" claim in #16738 is false for
+         bootstrap-driven loads. *)
+      Server_dashboard_shell_snapshot.select_project_snapshot_json
+        ~state ~sw ~clock request)
   in
   let goals =
     slice "goals" (fun () ->

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -703,7 +703,13 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
       | `GET, "/api/v1/dashboard/room-truth" ->
           with_h2_public_read h2_reqd (fun state ->
             let json =
-              dashboard_namespace_truth_http_json ~state ~sw ~clock httpun_request
+              (* RFC-0138 Phase 3 Step 3 follow-up — route H/2 gateway
+                 through the snapshot selector for parity with the H/1
+                 router (see server_routes_http_routes_dashboard.ml).
+                 Without this, H/2 clients bypass Dashboard_snapshot
+                 entirely and the cold-start fallback claim is false. *)
+              Server_dashboard_shell_snapshot.select_project_snapshot_json
+                ~state ~sw ~clock httpun_request
             in
             h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)
 


### PR DESCRIPTION
## Summary

**RFC-0138 Phase 3 Step 3 follow-up — close two missed wire points.**

PR #16738 (Step 3) routed `/api/v1/dashboard/project-snapshot` through `Server_dashboard_shell_snapshot.select_project_snapshot_json` for the H/1 router. A sub-agent audit on 2026-05-20 found two parallel call sites that **still bypass** `Dashboard_snapshot` and go straight to the synchronous compute path:

| call site | route | symptom |
|---|---|---|
| `lib/server/server_dashboard_http.ml:1473` | `/api/v1/dashboard/bootstrap` composite | every bootstrap fetch hits `dashboard_namespace_truth_http_json` |
| `lib/server/server_h2_gateway.ml:706` | H/2 gateway for `/project-snapshot`, `/namespace-truth`, `/room-truth` | every H/2 client bypasses snapshot |

The retire criterion in #16738 ("fallback runs at most once per process lifetime") was therefore **false** as merged — true only for the H/1 router-mediated requests. The Step 4 PR (#16752) retire of `MASC_NAMESPACE_TRUTH_*_TIMEOUT_S` env knobs was based on this claim; technically it remains safe because the hardcoded constants match the prior defaults, but the operational reality differs from the documented claim.

This PR closes both gaps so the three entry points share the same snapshot read.

## Changes

### `lib/server/server_dashboard_http.ml:1471-1480`

```ocaml
let namespace_truth =
  slice "namespace_truth" (fun () ->
    Server_dashboard_shell_snapshot.select_project_snapshot_json
      ~state ~sw ~clock request)
in
```

Replaces direct `dashboard_namespace_truth_http_json ~state ~sw ~clock request` call with the snapshot-first selector.

### `lib/server/server_h2_gateway.ml:701-712`

Same selector substitution for the H/2 handler covering `/project-snapshot`, `/namespace-truth`, `/room-truth` GETs.

## Verification

```bash
opam exec -- dune build --root . @check    # PASS
```

No new tests — the change is a refactoring of three call sites onto an already-tested selector (Step 3's `select_project_snapshot_json` carries its own alcotest case from #16738).

## Risk Discussion

- **No behavior change when snapshot is unpublished** (cold start). Selector falls through to `dashboard_namespace_truth_http_json` so cold semantics are identical.
- **Behavior change once snapshot publishes**: previously these two sites paid full compute cost on every request; after this fix they return cached snapshot in O(1). Strictly an improvement.
- **Module name**: this PR uses `Server_dashboard_shell_snapshot` (the current name on main). After PR #16761 (Step 5) merges and renames it to `Server_dashboard_snapshot_select`, this PR will need a 2-symbol rename rebase. Trivial.

## Related

- #16738 (Step 3 wire — original)
- #16752 (Step 4 env retire — merged with the now-fixed claim premise)
- #16761 (Step 5 rename — superseding module name pending)

## Workaround Rejection Bar Self-Check

- [x] §1 텔레메트리-as-fix: this is a wire fix, not instrumentation.
- [x] §2 string 분류기: none.
- [x] §3 N-of-M: explicitly closes the N-of-M gap identified in #16738 (router wired, bootstrap+H/2 missed). This is the missing-half PR — exactly the pattern N-of-M would caution against accruing.
- [x] catch-all `_ ->`: none added.
- [x] cap/cooldown: none.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
