### PR TITLE
fix(dashboard): use base_path SSOT helper to preserve raw input

### DIFF
--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -501,7 +501,18 @@ let runtime_resolution_json (config : Coord.config) =
   let workspace_commit = git_rev_parse_short config.workspace_path in
   let resolved_base_commit = git_rev_parse_short config.base_path in
   let base_path_input =
-    (Host_config.from_env ()).base_path_raw |> Option.value ~default:config.workspace_path
+    (* SSOT: Env_config_core.base_path_source_opt prefers
+       MASC_BASE_PATH_INPUT over MASC_BASE_PATH, preserving an
+       operator's raw "<base>/.masc" input.
+       Host_config.base_path_raw only reads MASC_BASE_PATH and strips
+       a preserved ".masc" suffix when both env vars are set.
+       RFC-0085 PR-9 keeps the raw helper private, so use
+       base_path_source_opt's value component.
+       Test: "runtime base_path preserves raw input"
+       (test/test_dashboard_http_core.ml:260). *)
+    Env_config_core.base_path_source_opt ()
+    |> Option.map snd
+    |> Option.value ~default:config.workspace_path
   in
   let prompt_markdown_dir =
     Prompt_registry.get_markdown_dir () |> Option.value ~default:""


### PR DESCRIPTION
## Summary

Fix the pre-existing test failure `runtime base_path preserves raw input` (test/test_dashboard_http_core.ml:260) by routing `server_dashboard_http_runtime_info.ml` through the correct env_config SSOT helper.

## Root Cause

`server_dashboard_http_runtime_info.ml:503-505` previously read:

```ocaml
let base_path_input =
  (Host_config.from_env ()).base_path_raw |> Option.value ~default:config.workspace_path
in
```

`Host_config.base_path_raw` only consults `MASC_BASE_PATH` (see `lib/host_config/host_config.ml:97`). When the operator (or test) sets `MASC_BASE_PATH_INPUT=<base>/.masc` alongside `MASC_BASE_PATH=<base>`, the `.masc` suffix is silently stripped on the way through.

`Env_config_core.base_path_source_opt` (public via mli line 137) returns `(env_key, value)` honouring the documented precedence: `MASC_BASE_PATH_INPUT` first, then `MASC_BASE_PATH`. RFC-0085 PR-9 keeps the underlying `base_path_raw_opt` private; this fix uses the public `base_path_source_opt` and extracts the value component via `|> Option.map snd`.

The test (added in PR #15956) was correct; the production caller was the gap.

## Change

```ocaml
let base_path_input =
  Env_config_core.base_path_source_opt ()
  |> Option.map snd
  |> Option.value ~default:config.workspace_path
in
```

Single-site change. Other callers of `Host_config.from_env ().base_path_raw` (server_dashboard_http_core.ml, server_runtime_bootstrap.ml, server_routes_http_runtime.ml, config_doctor.ml — flagged by the audit) likely have the same SSOT drift but are out of scope here; a follow-up sweep PR should address them.

## Verification

```bash
opam exec -- dune build --root . test/test_dashboard_http_core.exe
./_build/default/test/test_dashboard_http_core.exe test executor_pool
# 28 tests run, 0 failures (was 27/28 — "runtime base_path preserves raw input" failing on main).
```

## Workaround Rejection Bar Self-Check

- [x] §1 텔레메트리-as-fix: real fix, not instrumentation.
- [x] §2 string 분류기: none.
- [x] §3 N-of-M: this PR fixes the single site asserted by the failing test. The audit identified 4+ other callers with the same SSOT drift; explicitly scoped out so reviewers can track them as a separate sweep PR (do not accrue silently).
- [x] catch-all `_ ->`: none.
- [x] cap/cooldown: none.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
