### PR TITLE
feat(keeper_compact_policy): counter for negative-savings compaction cycles

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -309,6 +309,22 @@ let compact_if_needed_typed
     let new_ratio = context_ratio compacted_ctx in
     let new_msg_count = message_count compacted_ctx in
     let new_tok_count = token_count compacted_ctx in
+    (* [max 0 (pre - post)] silently floors the negative-delta case to
+       zero. Surface that case as a counter so operators can detect
+       divergence between the pre/post token (or message) measurement
+       sources — without this signal, [saved_tokens=0] is ambiguous
+       between "no savings" and "post-recount exceeded pre-estimate".
+       The kind label is a closed 2-value vocabulary. *)
+    if tok_count < new_tok_count then
+      Prometheus.inc_counter
+        Keeper_metrics.metric_keeper_compaction_negative_savings
+        ~labels:[ ("keeper", meta.name); ("kind", "tokens") ]
+        ();
+    if msg_count < new_msg_count then
+      Prometheus.inc_counter
+        Keeper_metrics.metric_keeper_compaction_negative_savings
+        ~labels:[ ("keeper", meta.name); ("kind", "messages") ]
+        ();
     let saved_tokens = max 0 (tok_count - new_tok_count) in
     let saved_messages = max 0 (msg_count - new_msg_count) in
     Prometheus.inc_counter

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -210,6 +210,7 @@ type t =
   | TurnCleanupFailures
   | MemoryBankLoadHistorySwallowedExceptions
   | MemoryRecallReadErrors
+  | CompactionNegativeSavings
   | CascadeHttpProbeJsonParseFailures
 
 (** String conversion
@@ -425,6 +426,8 @@ let to_string = function
       "masc_keeper_memory_bank_load_history_swallowed_exceptions_total"
   | MemoryRecallReadErrors ->
       "masc_keeper_memory_recall_read_errors_total"
+  | CompactionNegativeSavings ->
+      "masc_keeper_compaction_negative_savings_total"
   | CascadeHttpProbeJsonParseFailures ->
       "masc_cascade_http_probe_json_parse_failures_total"
 ;;
@@ -998,6 +1001,9 @@ let metric_keeper_memory_recall_read_errors =
   to_string MemoryRecallReadErrors
 ;;
 
+let metric_keeper_compaction_negative_savings =
+  to_string CompactionNegativeSavings
+;;
 let metric_cascade_http_probe_json_parse_failures =
   to_string CascadeHttpProbeJsonParseFailures
 ;;

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -202,6 +202,7 @@ type t =
   | TurnCleanupFailures
   | MemoryBankLoadHistorySwallowedExceptions
   | MemoryRecallReadErrors
+  | CompactionNegativeSavings
   | CascadeHttpProbeJsonParseFailures
 
 val to_string : t -> string
@@ -646,6 +647,20 @@ val metric_keeper_memory_bank_load_history_swallowed_exceptions : string
     as the load-history counter so cardinality is bounded. Behavior is
     unchanged (read still returns [[]] on failure). *)
 val metric_keeper_memory_recall_read_errors : string
+
+(** Counter for compactions where the post-compact recount exceeds the
+    pre-compact estimate, in which case [max 0 (pre - post)] silently
+    floors [saved_tokens] / [saved_messages] to zero. This used to mask
+    a divergence between the two count sources (the token / message
+    counter applied before and after compaction) — operators saw
+    [saved_tokens=0] without any signal that the post-count had grown.
+    The [kind] label is a closed 2-value vocabulary ([tokens] |
+    [messages]); the counter is incremented by one per affected
+    compaction, not by the negative delta, so a single divergent cycle
+    is visible without an unbounded magnitude term. Behavior is
+    unchanged (the floored value still propagates to the existing
+    [saved_tokens] / [saved_messages] gauges and the JSONL audit row). *)
+val metric_keeper_compaction_negative_savings : string
 
 (** Counter for probe responses dropped by the silent JSON parse catch-all
     in [Cascade_http_probe.try_probe]. Before this counter existed the


### PR DESCRIPTION
## 요약

- `keeper_compact_policy.ml:312` 의 `let saved_tokens = max 0 (tok_count - new_tok_count)` 는 post-recount 가 pre-estimate 보다 클 때 silent 0 floor
- `saved_messages` 도 동일 패턴
- Prometheus counter `masc_keeper_compaction_negative_savings_total` 추가, `kind` label 2-value closed (`tokens` | `messages`)
- 동작 보존 — 기존 saved_tokens / saved_messages gauge 값은 그대로 floor 적용된 0 으로 propagate

## 배경

`memory/masc-mcp-code-flowchart-audit-2026-05-20.html` §4 COMPACT HIGH (B5) — 6-subsystem flowchart audit (Turn/Life/Memory/Compact/Tool/Cascade) 의 정량 개선 대상.

`saved_tokens=0` 은 두 가지 의미가 압축되어 있었음:
- (a) 정상: 압축 결과 절감 토큰이 없음
- (b) 비정상: post-compact token count 측정이 pre-estimate 보다 큼 (측정 source divergence)

(b) 가 발생하면 operator 가 알 수 없었음. counter 로 case 를 분리.

## 패턴

PR #15781 (`MemoryBankLoadHistorySwallowedExceptions`), PR #16771 (`MemoryRecallReadErrors`) 와 동일 패턴 — silent floor / silent default 자리에 counter + closed label sum 부착, 동작 보존.

## 변경

| 파일 | 변경 |
|---|---|
| `lib/keeper/keeper_metrics.mli` | `CompactionNegativeSavings` variant + val + 주석 |
| `lib/keeper/keeper_metrics.ml` | variant + `to_string` arm + binding |
| `lib/keeper/keeper_compact_policy.ml` | `max 0` floor 직전 negative 분기에 counter incr |

## 검증

- `dune build --root . @check` PASS (exit 0)
- 38 insertions / 0 deletions, behavior preserving

## 측정 가능한 개선

- `compaction_negative_savings / compactions` ratio 가 Prometheus 에서 visible
- token / message 측정 source divergence 가 명시적으로 detect 가능

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>