### PR TITLE
refactor(keeper_supervisor): extract crash pause policy into sibling module

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -984,198 +984,28 @@ let apply_self_preservation ~keepers_dir ~total_keepers to_restart =
     a CAS race.  The keeper would re-resume on a server restart in that
     edge case, but that is strictly less bad than the pre-Phase-2 baseline
     (continuous restart loop). *)
-type crash_pause_resume_policy =
+(* Crash-driven pause policy extracted to [Keeper_supervisor_pause_policy]
+   (godfile decomp). The publisher [publish_phase_lifecycle] is local to
+   this module and is injected explicitly on each call. *)
+module Pause_policy = Keeper_supervisor_pause_policy
+
+type crash_pause_resume_policy = Pause_policy.crash_pause_resume_policy =
   | Manual_resume_required
   | Auto_resume_with_backoff
 
-let handle_crash_auto_pause
-      (ctx : _ context)
-      (entry : Keeper_registry.registry_entry)
-      ~reason_tag
-      ~metric_name
-      ~lifecycle_detail
-      ~log_message
-      ~blocker_class
-      ~resume_policy
-  =
-  (match read_meta ctx.config entry.name with
-   | Ok (Some meta) ->
-     let initial_sec = Env_config.KeeperSupervisor.auto_resume_initial_sec in
-     let max_sec = Env_config.KeeperSupervisor.auto_resume_max_sec in
-     let auto_resume_after_sec =
-       match resume_policy with
-       | Manual_resume_required -> None
-       | Auto_resume_with_backoff ->
-         next_auto_resume_after_sec ~initial_sec ~max_sec meta.auto_resume_after_sec
-     in
-     let blocker_text =
-       let existing =
-         match meta.runtime.last_blocker with
-         | Some info -> String.trim info.detail
-         | None -> ""
-       in
-       if existing <> ""
-       then existing
-       else (
-         match blocker_class with
-         | Some cls -> blocker_class_to_string cls
-         | None -> reason_tag)
-     in
-     let blocker_info_opt =
-       match blocker_class with
-       | Some klass -> Some (blocker_info_of_class ~detail:blocker_text klass)
-       | None ->
-         (* No typed class available — preserve pre-existing typed
-              info if any, otherwise drop the slot.  We refuse to
-              silently fabricate a klass from [reason_tag]. *)
-         meta.runtime.last_blocker
-     in
-     (* Task-138 §"Max no-task-progress 30min = release claimed":
-          when the supervisor pauses a keeper because the same blocker
-          class is looping (stale_storm or oas_timeout_budget_loop),
-          the keeper is no longer making progress on its claimed task.
-          Releasing [current_task_id] here lets a peer pick the task
-          up while this keeper sits in [paused=true] back-off.
-
-          Without this release the diagnostic state is "executor.json:
-          current_task_id=task-147, paused=true, last_blocker.klass=
-          oas_timeout_budget" — task is stuck forever because (a) this
-          keeper cannot run while paused and (b) other keepers see the
-          claim and skip.  The released task ID is not separately audited
-          here; [last_blocker] in [runtime] already carries the pause
-          reason, and Prometheus [keeper_paused_total] is incremented
-          below.  Discovered 2026-05-05 fleet-stuck. *)
-     (match
-        write_meta_with_merge
-          ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
-          ctx.config
-          { meta with
-            paused = true
-          ; auto_resume_after_sec
-          ; updated_at = now_iso ()
-          ; current_task_id = None
-          ; runtime = { meta.runtime with last_blocker = blocker_info_opt }
-          }
-      with
-      | Ok () -> ()
-      | Error err ->
-        Prometheus.inc_counter
-          Keeper_metrics.metric_keeper_write_meta_failures
-          ~labels:[ "keeper", entry.name; "phase", "blocker_pause" ]
-          ();
-        Log.Keeper.warn
-          "%s: %s pause meta write failed (in-memory failure_reason still gates restart, \
-           but persisted state will not survive server restart): %s"
-          entry.name
-          reason_tag
-          err)
-   | Ok None ->
-     Log.Keeper.warn
-       "%s: %s pause: meta missing, cannot persist paused=true"
-       entry.name
-       reason_tag;
-     Prometheus.inc_counter
-       Keeper_metrics.metric_keeper_write_meta_failures
-       ~labels:[ "keeper", entry.name; "phase", "pause_meta_missing" ]
-       ()
-   | Error err ->
-     Log.Keeper.warn "%s: %s pause read_meta failed: %s" entry.name reason_tag err;
-     Prometheus.inc_counter
-       Keeper_metrics.metric_keeper_write_meta_failures
-       ~labels:[ "keeper", entry.name; "phase", "pause_read_meta" ]
-       ());
-  Prometheus.inc_counter metric_name ~labels:[ "keeper", entry.name ] ();
-  publish_phase_lifecycle
-    ~phase:Keeper_state_machine.Paused
-    entry.name
-    lifecycle_detail
-    ();
-  Log.Keeper.error "%s: %s" entry.name log_message
+let handle_crash_auto_pause ctx entry =
+  Pause_policy.handle_crash_auto_pause ~publish_phase_lifecycle ctx entry
 ;;
 
-let handle_stale_storm_pause
-      (ctx : _ context)
-      (entry : Keeper_registry.registry_entry)
-      ~count
-  =
-  handle_crash_auto_pause
-    ctx
-    entry
-    ~reason_tag:"stale_storm"
-    ~metric_name:Keeper_metrics.metric_keeper_stale_storm_paused
-    ~lifecycle_detail:(Printf.sprintf "stale_termination_storm count=%d" count)
-    ~blocker_class:(Some Turn_timeout)
-    ~resume_policy:Manual_resume_required
-    ~log_message:
-      (Printf.sprintf
-         "STALE STORM AUTO-PAUSED (count=%d in 6h window). Auto-resume is disabled \
-          until the root cause clears; operator must resume manually via masc_keeper_up \
-          or API after investigating the underlying cascade/tool/runtime loop. See \
-          issue #10765."
-         count)
+let handle_stale_storm_pause ctx entry =
+  Pause_policy.handle_stale_storm_pause ~publish_phase_lifecycle ctx entry
 ;;
 
-let handle_oas_timeout_budget_pause
-      (ctx : _ context)
-      (entry : Keeper_registry.registry_entry)
-      ~count
-  =
-  handle_crash_auto_pause
-    ctx
-    entry
-    ~reason_tag:"oas_timeout_budget_loop"
-    ~metric_name:Keeper_metrics.metric_keeper_oas_timeout_budget_loop_paused
-    ~lifecycle_detail:(Printf.sprintf "oas_timeout_budget_loop count=%d" count)
-    ~blocker_class:(Some Oas_timeout_budget)
-    ~resume_policy:Auto_resume_with_backoff
-    ~log_message:
-      (Printf.sprintf
-         "OAS TIMEOUT BUDGET LOOP AUTO-PAUSED (count=%d). Supervisor will attempt \
-          self-healing auto-resume with exponential back-off (see \
-          MASC_KEEPER_AUTO_RESUME_INITIAL_SEC). Operator may also tune or reroute the \
-          cascade/model before resuming manually; restarting into the same slow-provider \
-          budget loop is avoided by the back-off delay."
-         count)
+let handle_oas_timeout_budget_pause ctx entry =
+  Pause_policy.handle_oas_timeout_budget_pause ~publish_phase_lifecycle ctx entry
 ;;
 
-let failure_reason_policy_decision
-      (reason : Keeper_registry.failure_reason option)
-  : Keeper_failure_policy.decision option
-  =
-  match reason with
-  | Some (Keeper_registry.Oas_timeout_budget_loop { count }) ->
-    Some
-      (Keeper_failure_policy.decide
-         (Keeper_failure_policy.Oas_timeout_budget
-            { phase = None
-            ; strikes = Some count
-            ; liveness = Keeper_failure_policy.Watchdog_stale
-            }))
-  | Some (Keeper_registry.Stale_termination_storm { count }) ->
-    Some
-      (Keeper_failure_policy.decide
-         (Keeper_failure_policy.Stale_termination_storm { count }))
-  | Some (Keeper_registry.Stale_turn_timeout _) ->
-    Some
-      (Keeper_failure_policy.decide
-         (Keeper_failure_policy.Stale_turn { progress_seen = false }))
-  | Some (Keeper_registry.Tool_required_unsatisfied _) ->
-    Some
-      (Keeper_failure_policy.decide
-         Keeper_failure_policy.Required_tool_contract_violation)
-  | Some (Keeper_registry.Ambiguous_partial_commit _) ->
-    Some (Keeper_failure_policy.decide Keeper_failure_policy.Ambiguous_partial_commit)
-  | Some
-      ( Keeper_registry.Heartbeat_consecutive_failures _
-      | Keeper_registry.Turn_consecutive_failures _
-      | Keeper_registry.Stale_fleet_batch _
-      | Keeper_registry.Provider_runtime_error _
-      | Keeper_registry.Fiber_unresolved
-      | Keeper_registry.Exception _ )
-  | None ->
-    None
-;;
-
+let failure_reason_policy_decision = Pause_policy.failure_reason_policy_decision
 let failure_reason_policy_decision_for_test = failure_reason_policy_decision
 
 let sweep_and_recover (ctx : _ context) =

--- a/lib/keeper/keeper_supervisor_pause_policy.ml
+++ b/lib/keeper/keeper_supervisor_pause_policy.ml
@@ -1,0 +1,219 @@
+(** Crash-driven pause policy for the keeper supervisor.
+
+    Extracted from [keeper_supervisor.ml] (lines 987-1180) as part of the
+    godfile decomp campaign. Owns:
+
+    - the [crash_pause_resume_policy] knob ([Manual_resume_required] vs
+      [Auto_resume_with_backoff]);
+    - the unified entrypoint [handle_crash_auto_pause] used by both
+      stale-termination-storm and OAS-timeout-budget-loop pause paths;
+    - thin per-cause wrappers [handle_stale_storm_pause] and
+      [handle_oas_timeout_budget_pause];
+    - the read-side classifier [failure_reason_policy_decision] that
+      maps a persisted [Keeper_registry.failure_reason] back to a
+      [Keeper_failure_policy.decision].
+
+    The phase-event publisher [publish_phase_lifecycle] is injected
+    explicitly so this module does not need to know about the
+    [Keeper_lifecycle_events] / [Cascade_events] surface. *)
+
+open Keeper_types
+open Keeper_execution
+open Keeper_supervisor_types
+
+type crash_pause_resume_policy =
+  | Manual_resume_required
+  | Auto_resume_with_backoff
+
+let handle_crash_auto_pause
+      ~publish_phase_lifecycle
+      (ctx : _ context)
+      (entry : Keeper_registry.registry_entry)
+      ~reason_tag
+      ~metric_name
+      ~lifecycle_detail
+      ~log_message
+      ~blocker_class
+      ~resume_policy
+  =
+  (match read_meta ctx.config entry.name with
+   | Ok (Some meta) ->
+     let initial_sec = Env_config.KeeperSupervisor.auto_resume_initial_sec in
+     let max_sec = Env_config.KeeperSupervisor.auto_resume_max_sec in
+     let auto_resume_after_sec =
+       match resume_policy with
+       | Manual_resume_required -> None
+       | Auto_resume_with_backoff ->
+         next_auto_resume_after_sec ~initial_sec ~max_sec meta.auto_resume_after_sec
+     in
+     let blocker_text =
+       let existing =
+         match meta.runtime.last_blocker with
+         | Some info -> String.trim info.detail
+         | None -> ""
+       in
+       if existing <> ""
+       then existing
+       else (
+         match blocker_class with
+         | Some cls -> blocker_class_to_string cls
+         | None -> reason_tag)
+     in
+     let blocker_info_opt =
+       match blocker_class with
+       | Some klass -> Some (blocker_info_of_class ~detail:blocker_text klass)
+       | None ->
+         (* No typed class available — preserve pre-existing typed
+              info if any, otherwise drop the slot.  We refuse to
+              silently fabricate a klass from [reason_tag]. *)
+         meta.runtime.last_blocker
+     in
+     (* Task-138 §"Max no-task-progress 30min = release claimed":
+          when the supervisor pauses a keeper because the same blocker
+          class is looping (stale_storm or oas_timeout_budget_loop),
+          the keeper is no longer making progress on its claimed task.
+          Releasing [current_task_id] here lets a peer pick the task
+          up while this keeper sits in [paused=true] back-off.
+
+          Without this release the diagnostic state is "executor.json:
+          current_task_id=task-147, paused=true, last_blocker.klass=
+          oas_timeout_budget" — task is stuck forever because (a) this
+          keeper cannot run while paused and (b) other keepers see the
+          claim and skip.  The released task ID is not separately audited
+          here; [last_blocker] in [runtime] already carries the pause
+          reason, and Prometheus [keeper_paused_total] is incremented
+          below.  Discovered 2026-05-05 fleet-stuck. *)
+     (match
+        write_meta_with_merge
+          ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+          ctx.config
+          { meta with
+            paused = true
+          ; auto_resume_after_sec
+          ; updated_at = now_iso ()
+          ; current_task_id = None
+          ; runtime = { meta.runtime with last_blocker = blocker_info_opt }
+          }
+      with
+      | Ok () -> ()
+      | Error err ->
+        Prometheus.inc_counter
+          Keeper_metrics.metric_keeper_write_meta_failures
+          ~labels:[ "keeper", entry.name; "phase", "blocker_pause" ]
+          ();
+        Log.Keeper.warn
+          "%s: %s pause meta write failed (in-memory failure_reason still gates restart, \
+           but persisted state will not survive server restart): %s"
+          entry.name
+          reason_tag
+          err)
+   | Ok None ->
+     Log.Keeper.warn
+       "%s: %s pause: meta missing, cannot persist paused=true"
+       entry.name
+       reason_tag;
+     Prometheus.inc_counter
+       Keeper_metrics.metric_keeper_write_meta_failures
+       ~labels:[ "keeper", entry.name; "phase", "pause_meta_missing" ]
+       ()
+   | Error err ->
+     Log.Keeper.warn "%s: %s pause read_meta failed: %s" entry.name reason_tag err;
+     Prometheus.inc_counter
+       Keeper_metrics.metric_keeper_write_meta_failures
+       ~labels:[ "keeper", entry.name; "phase", "pause_read_meta" ]
+       ());
+  Prometheus.inc_counter metric_name ~labels:[ "keeper", entry.name ] ();
+  publish_phase_lifecycle
+    ~phase:Keeper_state_machine.Paused
+    entry.name
+    lifecycle_detail
+    ();
+  Log.Keeper.error "%s: %s" entry.name log_message
+;;
+
+let handle_stale_storm_pause
+      ~publish_phase_lifecycle
+      (ctx : _ context)
+      (entry : Keeper_registry.registry_entry)
+      ~count
+  =
+  handle_crash_auto_pause
+    ~publish_phase_lifecycle
+    ctx
+    entry
+    ~reason_tag:"stale_storm"
+    ~metric_name:Keeper_metrics.metric_keeper_stale_storm_paused
+    ~lifecycle_detail:(Printf.sprintf "stale_termination_storm count=%d" count)
+    ~blocker_class:(Some Turn_timeout)
+    ~resume_policy:Manual_resume_required
+    ~log_message:
+      (Printf.sprintf
+         "STALE STORM AUTO-PAUSED (count=%d in 6h window). Auto-resume is disabled \
+          until the root cause clears; operator must resume manually via masc_keeper_up \
+          or API after investigating the underlying cascade/tool/runtime loop. See \
+          issue #10765."
+         count)
+;;
+
+let handle_oas_timeout_budget_pause
+      ~publish_phase_lifecycle
+      (ctx : _ context)
+      (entry : Keeper_registry.registry_entry)
+      ~count
+  =
+  handle_crash_auto_pause
+    ~publish_phase_lifecycle
+    ctx
+    entry
+    ~reason_tag:"oas_timeout_budget_loop"
+    ~metric_name:Keeper_metrics.metric_keeper_oas_timeout_budget_loop_paused
+    ~lifecycle_detail:(Printf.sprintf "oas_timeout_budget_loop count=%d" count)
+    ~blocker_class:(Some Oas_timeout_budget)
+    ~resume_policy:Auto_resume_with_backoff
+    ~log_message:
+      (Printf.sprintf
+         "OAS TIMEOUT BUDGET LOOP AUTO-PAUSED (count=%d). Supervisor will attempt \
+          self-healing auto-resume with exponential back-off (see \
+          MASC_KEEPER_AUTO_RESUME_INITIAL_SEC). Operator may also tune or reroute the \
+          cascade/model before resuming manually; restarting into the same slow-provider \
+          budget loop is avoided by the back-off delay."
+         count)
+;;
+
+let failure_reason_policy_decision
+      (reason : Keeper_registry.failure_reason option)
+  : Keeper_failure_policy.decision option
+  =
+  match reason with
+  | Some (Keeper_registry.Oas_timeout_budget_loop { count }) ->
+    Some
+      (Keeper_failure_policy.decide
+         (Keeper_failure_policy.Oas_timeout_budget
+            { phase = None
+            ; strikes = Some count
+            ; liveness = Keeper_failure_policy.Watchdog_stale
+            }))
+  | Some (Keeper_registry.Stale_termination_storm { count }) ->
+    Some
+      (Keeper_failure_policy.decide
+         (Keeper_failure_policy.Stale_termination_storm { count }))
+  | Some (Keeper_registry.Stale_turn_timeout _) ->
+    Some
+      (Keeper_failure_policy.decide
+         (Keeper_failure_policy.Stale_turn { progress_seen = false }))
+  | Some (Keeper_registry.Tool_required_unsatisfied _) ->
+    Some
+      (Keeper_failure_policy.decide
+         Keeper_failure_policy.Required_tool_contract_violation)
+  | Some (Keeper_registry.Ambiguous_partial_commit _) ->
+    Some (Keeper_failure_policy.decide Keeper_failure_policy.Ambiguous_partial_commit)
+  | Some
+      ( Keeper_registry.Heartbeat_consecutive_failures _
+      | Keeper_registry.Turn_consecutive_failures _
+      | Keeper_registry.Stale_fleet_batch _
+      | Keeper_registry.Provider_runtime_error _
+      | Keeper_registry.Fiber_unresolved
+      | Keeper_registry.Exception _ )
+  | None ->
+    None
+;;

--- a/lib/keeper/keeper_supervisor_pause_policy.mli
+++ b/lib/keeper/keeper_supervisor_pause_policy.mli
@@ -1,0 +1,79 @@
+(** Crash-driven pause policy for the keeper supervisor.
+
+    Provides the unified [handle_crash_auto_pause] entrypoint that
+    persists [paused=true] + back-off + typed blocker info + releases
+    [current_task_id], plus per-cause wrappers and the read-side
+    [failure_reason_policy_decision] classifier.
+
+    The phase-event publisher is injected (via [~publish_phase_lifecycle])
+    so this module stays free of [Keeper_lifecycle_events] /
+    [Cascade_events] dependencies. *)
+
+open Keeper_types
+open Keeper_execution
+
+(** Resume policy: whether the supervisor can auto-resume the keeper
+    after a back-off delay, or whether an operator must intervene. *)
+type crash_pause_resume_policy =
+  | Manual_resume_required
+  | Auto_resume_with_backoff
+
+(** [handle_crash_auto_pause ~publish_phase_lifecycle ctx entry
+      ~reason_tag ~metric_name ~lifecycle_detail ~log_message
+      ~blocker_class ~resume_policy] persists [paused=true] on disk,
+    sets [auto_resume_after_sec] per [resume_policy], releases
+    [current_task_id] so a peer can pick the task up, increments
+    [metric_name], publishes a [Paused] phase event via the injected
+    publisher, and emits [log_message] at ERROR.
+
+    On disk write failure: increments [keeper_write_meta_failures]
+    with the appropriate phase label and falls back to logging — the
+    in-memory failure-reason still gates restart, but the persisted
+    pause will not survive a server restart. *)
+val handle_crash_auto_pause
+  :  publish_phase_lifecycle:
+       (phase:Keeper_state_machine.phase -> string -> string -> unit -> unit)
+  -> _ context
+  -> Keeper_registry.registry_entry
+  -> reason_tag:string
+  -> metric_name:string
+  -> lifecycle_detail:string
+  -> log_message:string
+  -> blocker_class:Keeper_meta_contract.blocker_class option
+  -> resume_policy:crash_pause_resume_policy
+  -> unit
+
+(** [handle_stale_storm_pause ~publish_phase_lifecycle ctx entry ~count]
+    pauses [entry] because the same keeper terminated [count] times in
+    a 6h sliding window with [stale_termination]. Manual resume
+    required (operator must investigate the cascade/tool/runtime loop
+    that caused the storm). *)
+val handle_stale_storm_pause
+  :  publish_phase_lifecycle:
+       (phase:Keeper_state_machine.phase -> string -> string -> unit -> unit)
+  -> _ context
+  -> Keeper_registry.registry_entry
+  -> count:int
+  -> unit
+
+(** [handle_oas_timeout_budget_pause ~publish_phase_lifecycle ctx entry
+      ~count] pauses [entry] because the OAS provider call timed out
+    [count] times in a budget window. Auto-resume with exponential
+    back-off (see [MASC_KEEPER_AUTO_RESUME_INITIAL_SEC]). *)
+val handle_oas_timeout_budget_pause
+  :  publish_phase_lifecycle:
+       (phase:Keeper_state_machine.phase -> string -> string -> unit -> unit)
+  -> _ context
+  -> Keeper_registry.registry_entry
+  -> count:int
+  -> unit
+
+(** [failure_reason_policy_decision reason] maps a persisted
+    [Keeper_registry.failure_reason] back to a
+    [Keeper_failure_policy.decision]. Returns [None] for non-policy
+    reasons (heartbeat / turn consecutive failures, fleet batch,
+    provider runtime error, fiber unresolved, exception) and [None]
+    when [reason] itself is [None]. *)
+val failure_reason_policy_decision
+  :  Keeper_registry.failure_reason option
+  -> Keeper_failure_policy.decision option


### PR DESCRIPTION
## 요약

\`keeper_supervisor.ml\` (godfile, 1802 LoC) 의 crash-driven pause
policy 클러스터 (lines 987-1180) 를 sibling 모듈로 추출. 본 PR 머지 후
1802 → 1632 (−170, −9.4%).

## 추출된 함수

- \`type crash_pause_resume_policy\` (Manual / Auto)
- \`handle_crash_auto_pause\` — 통합 entrypoint
  - paused=true 영속화
  - exponential back-off (Auto)
  - typed blocker info (preserve existing, refuse silent fabrication)
  - Task-138 \`current_task_id := None\` (fleet-stuck 2026-05-05)
- \`handle_stale_storm_pause\` / \`handle_oas_timeout_budget_pause\` —
  per-cause wrapper
- \`failure_reason_policy_decision\` (+ \`_for_test\`) — persisted
  \`failure_reason\` → \`Keeper_failure_policy.decision\` mapper

## 패턴

이전 PR (#16726, #16758, #16770) 과 달리 *publisher 인자 주입* 사용:

- 로컬 helper \`publish_phase_lifecycle\` 가 cluster 안에서만 호출되는데,
  같은 helper 가 keeper_supervisor.ml 의 다른 6+ 함수 (\`launch_supervised_fiber\`,
  \`supervise_keepalive\`, \`reconcile_keepalive_keepers\` 등) 에서도 사용.
- helper 자체를 새 모듈로 이동하면 두 모듈 cross-reference 가 필요해
  cycle 위험.
- 대신 \`Pause_policy.handle_*\` 에 \`~publish_phase_lifecycle\` 인자를
  추가하고 keeper_supervisor.ml 의 wrapper 가 로컬 helper 를 주입.

\`crash_pause_resume_policy\` 타입은 transparent alias 로 재노출:
\`\`\`ocaml
type crash_pause_resume_policy = Pause_policy.crash_pause_resume_policy =
  | Manual_resume_required
  | Auto_resume_with_backoff
\`\`\`

## 검증

\`\`\`
$ dune build --root . @check                              # exit 0
$ _build/default/test/test_keeper_supervisor.exe          # 77/77 PASS
$ _build/default/test/test_keeper_auto_pause_*.exe        # 6/6 PASS
$ _build/default/test/test_keeper_pause_broadcast.exe     # 27/27 PASS
\`\`\`

총 110 tests PASS.

## 의존성

PR #16754 (server_dashboard_shell_snapshot.ml syntax fix) commit
\`a157ad2563\` 위에 stack. \`dune build @check\` 통과 필수.

## LoC

| 파일 | LoC |
|------|-----|
| keeper_supervisor.ml | 1802 → 1632 (−170) |
| keeper_supervisor_pause_policy.ml (new) | 219 |
| keeper_supervisor_pause_policy.mli (new) | 79 |
| 본 PR diff | +311 / −183 |

## RFC

RFC-WAIVED: pure mechanical extraction of internal helpers within
\`lib/keeper/\`. The supervisor pause policy is not in the RFC-gated
subsystem list (credential / identity / operator_control / sandbox /
hooks / workflow). Public surface preserved via transparent type alias
+ per-function aliases.