### PR TITLE
refactor(tool_code): Tool_code_read_core SSOT with typed directory error

### DIFF
--- a/bin/gen_tool_descriptors.ml
+++ b/bin/gen_tool_descriptors.ml
@@ -72,8 +72,9 @@ let masc_config_spec : tool_spec =
 let masc_code_read_spec : tool_spec =
   { name = "masc_code_read"
   ; description =
-      "Read a file with offset/limit pagination for large files. Use when inspecting \
-       source code during task execution without loading the entire file into context."
+      "Read a single file with offset/limit pagination. Returns typed error_kind on \
+       failure (path_is_directory, file_not_found, binary_file, file_too_large, \
+       io_error). For directories use masc_code_search or shell 'ls -la'."
   ; parameters =
       [ { p_name = "path"
         ; p_type = T_string { enum = None; default = None }

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -726,7 +726,7 @@ let tool_search_alias_entries =
   ; "keeper_voice_session_start", "음성 세션 시작"
   ; "keeper_voice_session_end", "음성 세션 종료"
   ; "masc_code_search", "코드 검색 소스코드 찾기 심볼"
-  ; "masc_code_read", "코드 읽기 파일 소스코드"
+  ; "masc_code_read", "코드 읽기 단일 파일 (디렉토리 아님)"
   ; "masc_code_edit", "코드 편집 수정 파일 변경"
   ; "masc_code_write", "코드 작성 파일 생성 쓰기"
   ; "masc_code_symbols", "코드 심볼 함수 클래스 정의"

--- a/lib/keeper/keeper_exec_masc.ml
+++ b/lib/keeper/keeper_exec_masc.ml
@@ -76,6 +76,8 @@ let keeper_masc_path_blocked
       candidates)
 ;;
 
+(* Pipeline lives in [Tool_code_read_core] (SSOT shared with the
+   agent-side handler [Tool_code.handle_code_read]). *)
 let handle_keeper_masc_code_read
       ~(config : Coord.config)
       ~(meta : keeper_meta)
@@ -90,46 +92,16 @@ let handle_keeper_masc_code_read
     match resolve_keeper_read_path ~config ~meta ~raw_path:path with
     | Error e -> error_json e
     | Ok target ->
-      if not (Sys.file_exists target)
-      then error_json (Printf.sprintf "File not found: %s" path)
-      else if Tool_code.is_binary_file target
-      then error_json "Binary file detected"
-      else (
-        let file_size = (Unix.stat target).Unix.st_size in
-        if file_size > Tool_code.max_file_size
-        then
-          error_json
-            (Printf.sprintf
-               "File too large: %d bytes (max: %d)"
-               file_size
-               Tool_code.max_file_size)
-        else (
-          try
-            let content = Fs_compat.load_file target in
-            let lines = String.split_on_char '\n' content in
-            let total_lines = List.length lines in
-            let safe_offset = max 0 (min offset total_lines) in
-            let safe_limit = min limit (total_lines - safe_offset) in
-            let selected_lines = ref [] in
-            for i = safe_offset to safe_offset + safe_limit - 1 do
-              match List.nth_opt lines i with
-              | Some line -> selected_lines := line :: !selected_lines
-              | None -> ()
-            done;
-            let result_lines = List.rev !selected_lines in
-            Yojson.Safe.to_string
-              (`Assoc
-                  [ "path", `String path
-                  ; "offset", `Int safe_offset
-                  ; "limit", `Int safe_limit
-                  ; "total_lines", `Int total_lines
-                  ; "lines", `List (List.map (fun line -> `String line) result_lines)
-                  ])
-          with
-          | Eio.Cancel.Cancelled _ as e -> raise e
-          | exn ->
-            error_json
-              (Printf.sprintf "Failed to read file: %s" (Printexc.to_string exn)))))
+      (match
+         Tool_code_read_core.read_with_pagination
+           ~display_path:path ~validated_path:target ~offset ~limit
+       with
+       | Ok ok ->
+         Yojson.Safe.to_string
+           (Tool_code_read_core.ok_to_json ~display_path:path ok)
+       | Error err ->
+         Yojson.Safe.to_string
+           (Tool_code_read_core.read_error_to_json err)))
 ;;
 
 let handle_keeper_masc_tool

--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -36,25 +36,13 @@ type context = {
 }
 
 
-(* Security: Binary file extensions *)
-let binary_extensions = [
-  ".so"; ".a"; ".lib"; ".dll"; ".dylib";
-  ".wasm"; ".o"; ".obj";
-  ".jpg"; ".jpeg"; ".png"; ".gif"; ".bmp"; ".ico"; ".webp";
-  ".mp3"; ".mp4"; ".avi"; ".mov"; ".wav"; ".flac";
-  ".zip"; ".tar"; ".gz"; ".bz2"; ".xz"; ".7z";
-  ".pdf"; ".doc"; ".docx"; ".xls"; ".xlsx"; ".ppt"; ".pptx";
-]
-
-(* Security: Check if file is binary by extension *)
-let is_binary_file path =
-  List.exists (fun ext ->
-    String.length path >= String.length ext &&
-    String.equal (String.sub path (String.length path - String.length ext) (String.length ext)) ext
-  ) binary_extensions
-
-(* Security: Check file size limit (500KB) *)
-let max_file_size = 500 * 1024
+(* Security: Binary file extension check + size cap.
+   The SSOT moved into [Tool_code_read_core] so the read pipeline can
+   be composed without depending on [Tool_code]. The values here are
+   thin re-exports kept for wire compatibility (public [tool_code.mli]
+   exposes them). *)
+let is_binary_file = Tool_code_read_core.is_binary_file
+let max_file_size = Tool_code_read_core.max_file_size
 
 (* Security: Normalize path by resolving . and .. segments.
    Returns a clean absolute path with no traversal components. *)
@@ -531,7 +519,9 @@ let handle_code_symbols ~tool_name ~start_time ctx args =
         end
   end
 
-(* Handler: masc_code_read - Read file with offset/limit *)
+(* Handler: masc_code_read - Read file with offset/limit.
+   Pipeline lives in [Tool_code_read_core] (SSOT shared with the
+   keeper-side handler [Keeper_exec_masc.handle_keeper_masc_code_read]). *)
 let handle_code_read ~tool_name ~start_time ctx args =
   let path = get_string args "path" "" in
   let offset = get_int args "offset" 0 in
@@ -539,52 +529,24 @@ let handle_code_read ~tool_name ~start_time ctx args =
 
   if String.equal path "" then
     Tool_result.error ~tool_name ~start_time "Path required: 'path' parameter"
-  else begin
+  else
     match validate_read_path ~agent_name:ctx.agent_name ctx.config path with
-    | Error e -> Tool_result.error ~tool_name ~start_time (Masc_domain.masc_error_to_string e)
+    | Error e ->
+        Tool_result.error ~tool_name ~start_time
+          (Masc_domain.masc_error_to_string e)
     | Ok validated_path ->
-        if not (Sys.file_exists validated_path) then
-          Tool_result.error ~tool_name ~start_time (Printf.sprintf "File not found: %s" path)
-        else if is_binary_file validated_path then
-          Tool_result.error ~tool_name ~start_time "Binary file detected"
-        else begin
-          let file_size = (Unix.stat validated_path).Unix.st_size in
-          if file_size > max_file_size then
-            Tool_result.error ~tool_name ~start_time (Printf.sprintf "File too large: %d bytes (max: %d)" file_size max_file_size)
-          else begin
-            try
-              let content = In_channel.with_open_text validated_path In_channel.input_all in
-              let lines = String.split_on_char '\n' content in
-              let total_lines = List.length lines in
-
-              (* Validate offset *)
-              let safe_offset = max 0 (min offset total_lines) in
-
-              (* Calculate end line *)
-              let safe_limit = min limit (total_lines - safe_offset) in
-
-              (* Extract lines *)
-              let selected_lines = ref [] in
-              for i = safe_offset to safe_offset + safe_limit - 1 do
-                match List.nth_opt lines i with
-                | Some line -> selected_lines := line :: !selected_lines
-                | None -> ()
-              done;
-
-              let result_lines = List.rev !selected_lines in
-              let response = `Assoc [
-                ("path", `String path);
-                ("offset", `Int safe_offset);
-                ("limit", `Int safe_limit);
-                ("total_lines", `Int total_lines);
-                ("lines", `List (List.map (fun s -> `String s) result_lines));
-              ] in
-              Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
-            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-              Tool_result.error ~tool_name ~start_time (Printf.sprintf "Failed to read file: %s" (Stdlib.Printexc.to_string exn))
-          end
-        end
-  end
+      (match
+         Tool_code_read_core.read_with_pagination
+           ~display_path:path ~validated_path ~offset ~limit
+       with
+       | Ok ok ->
+           Tool_result.ok ~tool_name ~start_time
+             (Yojson.Safe.to_string
+                (Tool_code_read_core.ok_to_json ~display_path:path ok))
+       | Error err ->
+           Tool_result.error ~tool_name ~start_time
+             (Yojson.Safe.to_string
+                (Tool_code_read_core.read_error_to_json err)))
 
 (* Dispatch function - returns None if tool not handled *)
 let dispatch ctx ~name ~args : Tool_result.t option =
@@ -659,9 +621,9 @@ Pair with masc_code_read to then read specific line ranges of interest.";
   (* masc_code_read *)
   {
     name = "masc_code_read";
-    description = "Read a file with offset/limit pagination for token-efficient access to specific sections. \
-Use when you know the line range you need, especially for large files. \
-After masc_code_symbols identifies the relevant line numbers.";
+    description = "Read a single file with offset/limit pagination. \
+Returns typed error_kind on failure (path_is_directory, file_not_found, binary_file, file_too_large, io_error). \
+For directories use masc_code_search or shell 'ls -la'.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/lib/tool_code_read_core.ml
+++ b/lib/tool_code_read_core.ml
@@ -1,0 +1,169 @@
+(** Tool_code_read_core — SSOT pipeline for [masc_code_read].
+
+    See [tool_code_read_core.mli] for the rationale.
+
+    The binary-extension list and the max-file-size constant live here
+    (and are re-exported by [Tool_code] for wire compatibility) so
+    this module has no upward dependency on [Tool_code] and can be
+    composed freely. *)
+
+(* SSOT binary-extension block list — drift = silent regression in
+   the binary block. [Tool_code.is_binary_file] now delegates here. *)
+let binary_extensions =
+  [ ".so"; ".a"; ".lib"; ".dll"; ".dylib"
+  ; ".wasm"; ".o"; ".obj"
+  ; ".jpg"; ".jpeg"; ".png"; ".gif"; ".bmp"; ".ico"; ".webp"
+  ; ".mp3"; ".mp4"; ".avi"; ".mov"; ".wav"; ".flac"
+  ; ".zip"; ".tar"; ".gz"; ".bz2"; ".xz"; ".7z"
+  ; ".pdf"; ".doc"; ".docx"; ".xls"; ".xlsx"; ".ppt"; ".pptx"
+  ]
+
+let is_binary_file path =
+  List.exists
+    (fun ext ->
+      let plen = String.length path in
+      let elen = String.length ext in
+      plen >= elen
+      && String.equal (String.sub path (plen - elen) elen) ext)
+    binary_extensions
+
+let max_file_size = 500 * 1024
+
+type read_error =
+  | Path_is_directory of { path : string }
+  | File_not_found of { path : string }
+  | Binary_file of { path : string }
+  | Too_large of { path : string; size : int; max : int }
+  | Io_error of { path : string; detail : string }
+  | Internal_error of { path : string; detail : string }
+
+type ok =
+  { display_path : string
+  ; total_lines : int
+  ; safe_offset : int
+  ; safe_limit : int
+  ; lines : string list
+  }
+
+let slice_lines ~lines ~total_lines ~offset ~limit =
+  let safe_offset = max 0 (min offset total_lines) in
+  let safe_limit = min limit (total_lines - safe_offset) in
+  let safe_limit = max 0 safe_limit in
+  let selected = ref [] in
+  for i = safe_offset to safe_offset + safe_limit - 1 do
+    match List.nth_opt lines i with
+    | Some line -> selected := line :: !selected
+    | None -> ()
+  done;
+  (safe_offset, safe_limit, List.rev !selected)
+
+let read_with_pagination ~display_path ~validated_path ~offset ~limit :
+    (ok, read_error) result =
+  try
+    if not (Sys.file_exists validated_path) then
+      Error (File_not_found { path = display_path })
+    else if Sys.is_directory validated_path then
+      Error (Path_is_directory { path = display_path })
+    else if is_binary_file validated_path then
+      Error (Binary_file { path = display_path })
+    else
+      let max = max_file_size in
+      let size = (Unix.stat validated_path).Unix.st_size in
+      if size > max then
+        Error (Too_large { path = display_path; size; max })
+      else
+        let content =
+          In_channel.with_open_text validated_path In_channel.input_all
+        in
+        let lines = String.split_on_char '\n' content in
+        let total_lines = List.length lines in
+        let safe_offset, safe_limit, sliced =
+          slice_lines ~lines ~total_lines ~offset ~limit
+        in
+        Ok
+          { display_path
+          ; total_lines
+          ; safe_offset
+          ; safe_limit
+          ; lines = sliced
+          }
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | Sys_error detail ->
+    Error (Io_error { path = display_path; detail })
+  | Unix.Unix_error (err, fn, arg) ->
+    let detail =
+      Printf.sprintf "%s: %s(%s)" (Unix.error_message err) fn arg
+    in
+    Error (Io_error { path = display_path; detail })
+  | exn ->
+    Error
+      (Internal_error
+         { path = display_path; detail = Printexc.to_string exn })
+
+let error_kind = function
+  | Path_is_directory _ -> "path_is_directory"
+  | File_not_found _ -> "file_not_found"
+  | Binary_file _ -> "binary_file"
+  | Too_large _ -> "file_too_large"
+  | Io_error _ -> "io_error"
+  | Internal_error _ -> "internal_error"
+
+let error_message = function
+  | Path_is_directory { path } ->
+    Printf.sprintf "Path is a directory, not a file: %s" path
+  | File_not_found { path } -> Printf.sprintf "File not found: %s" path
+  | Binary_file { path } ->
+    Printf.sprintf "Binary file detected: %s" path
+  | Too_large { path; size; max } ->
+    Printf.sprintf "File too large: %s (%d bytes, max %d)" path size max
+  | Io_error { path; detail } ->
+    Printf.sprintf "Failed to read file %s: %s" path detail
+  | Internal_error { path; detail } ->
+    Printf.sprintf "Internal error reading file %s: %s" path detail
+
+let error_hint = function
+  | Path_is_directory _ ->
+    Some
+      "Use masc_code_search to find files inside the directory, or shell \
+       'ls -la <path>' to list its contents."
+  | Binary_file _ ->
+    Some
+      "Binary files are not readable through masc_code_read. Inspect via \
+       a dedicated tool if needed."
+  | Too_large _ ->
+    Some
+      "Use offset/limit pagination on a smaller window, or rg/grep for \
+       the relevant section."
+  | File_not_found _ | Io_error _ | Internal_error _ -> None
+
+let path_of = function
+  | Path_is_directory { path }
+  | File_not_found { path }
+  | Binary_file { path }
+  | Too_large { path; _ }
+  | Io_error { path; _ }
+  | Internal_error { path; _ } -> path
+
+let read_error_to_json e : Yojson.Safe.t =
+  let base =
+    [ "error", `String (error_message e)
+    ; "error_kind", `String (error_kind e)
+    ; "path", `String (path_of e)
+    ]
+  in
+  let with_hint =
+    match error_hint e with
+    | None -> base
+    | Some h -> base @ [ "hint", `String h ]
+  in
+  `Assoc with_hint
+
+let ok_to_json ~display_path o : Yojson.Safe.t =
+  `Assoc
+    [ "path", `String display_path
+    ; "offset", `Int o.safe_offset
+    ; "limit", `Int o.safe_limit
+    ; "total_lines", `Int o.total_lines
+    ; "lines", `List (List.map (fun s -> `String s) o.lines)
+    ]

--- a/lib/tool_code_read_core.mli
+++ b/lib/tool_code_read_core.mli
@@ -1,0 +1,116 @@
+(** Tool_code_read_core — SSOT for [masc_code_read] file pagination.
+
+    Both the agent-side handler ([Tool_code.handle_code_read]) and the
+    keeper-side handler ([Keeper_exec_masc.handle_keeper_masc_code_read])
+    share the same read-with-pagination pipeline. Previously each
+    handler open-coded the same six-step sequence
+    (file_exists → binary check → size check → load → split → slice)
+    and flattened every failure into the same opaque string
+    ["Failed to read file: <exn>"]. The most common runtime failure —
+    calling [masc_code_read] with a directory path — surfaced as
+    [Sys_error("...: Is a directory")] with no structured signal to
+    let the LLM switch tools.
+
+    This module replaces both clones with a single pipeline that
+    returns a typed [read_error] variant. Callers render that to JSON
+    via {!read_error_to_json}, which emits an [error_kind]
+    discriminator plus an optional [hint]. *)
+
+(** {1 Read primitives (SSOT)} *)
+
+val is_binary_file : string -> bool
+(** [is_binary_file path] is [true] iff [path] ends with one of the
+    pinned binary extensions (.so, .png, .pdf, …). Re-exported by
+    [Tool_code.is_binary_file] for wire compatibility. *)
+
+val max_file_size : int
+(** [max_file_size = 500 * 1024]. Re-exported by
+    [Tool_code.max_file_size]. *)
+
+(** {1 Typed errors} *)
+
+(** Typed failure variants from a file-read attempt.
+
+    Drift in this list = silent regression in the error envelope —
+    every variant must round-trip through {!read_error_to_json} with
+    a stable [error_kind] discriminator string. *)
+type read_error =
+  | Path_is_directory of { path : string }
+    (** Caller passed a directory path. Distinct from [File_not_found]
+        because the recovery action differs: switch to
+        [masc_code_search] or [shell "ls -la"]. *)
+  | File_not_found of { path : string }
+    (** Path does not exist on disk. *)
+  | Binary_file of { path : string }
+    (** Path matches [Tool_code.is_binary_file] (.so, .png, …). *)
+  | Too_large of { path : string; size : int; max : int }
+    (** File exceeds [Tool_code.max_file_size]. *)
+  | Io_error of { path : string; detail : string }
+    (** Captured [Sys_error] or [Unix.Unix_error] during open/read. *)
+  | Internal_error of { path : string; detail : string }
+    (** Catch-all for any other exception. Surfaced (not absorbed) so
+        unexpected failures are visible. *)
+
+(** {1 Successful read} *)
+
+type ok =
+  { display_path : string  (** Path as the caller passed it (echoed back). *)
+  ; total_lines : int
+  ; safe_offset : int
+  ; safe_limit : int
+  ; lines : string list
+  }
+(** Result of a successful pagination. *)
+
+(** {1 Pipeline} *)
+
+val read_with_pagination :
+  display_path:string ->
+  validated_path:string ->
+  offset:int ->
+  limit:int ->
+  (ok, read_error) result
+(** [read_with_pagination ~display_path ~validated_path ~offset ~limit]
+    runs the full read pipeline on the already-resolved
+    [validated_path] (the caller is expected to have run path
+    validation first — see [Tool_code.validate_read_path] /
+    [Keeper_exec_shared.resolve_keeper_read_path]).
+
+    Order of checks:
+    + [Sys.file_exists validated_path] → otherwise [File_not_found]
+    + [Sys.is_directory validated_path] → otherwise [Path_is_directory]
+    + [Tool_code.is_binary_file validated_path] → otherwise [Binary_file]
+    + [Unix.stat … .st_size > Tool_code.max_file_size] → otherwise [Too_large]
+    + open / read / split / slice — failure becomes [Io_error] (for
+      [Sys_error]/[Unix.Unix_error]) or [Internal_error] (other exn).
+
+    [Eio.Cancel.Cancelled] is re-raised unchanged so cooperative
+    cancellation is not flattened to an [Io_error]. *)
+
+val read_error_to_json : read_error -> Yojson.Safe.t
+(** [read_error_to_json e] renders [e] as a JSON object with shape
+
+    {v
+      { "error": "<human-readable message>",
+        "error_kind": "<discriminator>",
+        "path": "<display path>",
+        ["hint": "<actionable next-step>"] }
+    v}
+
+    [error_kind] values are pinned: ["path_is_directory"],
+    ["file_not_found"], ["binary_file"], ["file_too_large"],
+    ["io_error"], ["internal_error"]. *)
+
+val ok_to_json : display_path:string -> ok -> Yojson.Safe.t
+(** [ok_to_json ~display_path o] renders [o] as the legacy
+    [masc_code_read] success envelope:
+
+    {v
+      { "path": "<display path>",
+        "offset": <int>,
+        "limit": <int>,
+        "total_lines": <int>,
+        "lines": [ "..." ] }
+    v}
+
+    Kept stable for wire compatibility with existing keepers. *)

--- a/lib/tool_schemas/tool_schemas_code.ml
+++ b/lib/tool_schemas/tool_schemas_code.ml
@@ -46,7 +46,7 @@ let schemas : Masc_domain.tool_schema list =
     {
       name = "masc_code_read";
       description =
-        "Read a file with offset/limit pagination for large files. Use when inspecting source code during task execution without loading the entire file into context.";
+        "Read a single file with offset/limit pagination. Returns typed error_kind on failure (path_is_directory, file_not_found, binary_file, file_too_large, io_error). For directories use masc_code_search or shell 'ls -la'.";
       input_schema =
         `Assoc
           [

--- a/test/dune
+++ b/test/dune
@@ -1227,6 +1227,7 @@
   test_tool_code_coverage
   test_tool_code_write_coverage
   test_tool_code_read_containment
+  test_tool_code_read_directory_typed_error
   test_tool_library_coverage
   test_tool_shard_coverage
   test_context_compact_oas_coverage
@@ -1286,6 +1287,7 @@
   test_tool_code_coverage
   test_tool_code_write_coverage
   test_tool_code_read_containment
+  test_tool_code_read_directory_typed_error
   test_tool_library_coverage
   test_tool_shard_coverage
   test_context_compact_oas_coverage

--- a/test/test_tool_code_read_directory_typed_error.ml
+++ b/test/test_tool_code_read_directory_typed_error.ml
@@ -1,0 +1,240 @@
+(** Coverage tests for the [Tool_code_read_core] SSOT.
+
+    Regression #12 (masc-mcp runtime log audit 2026-05-20): LLMs
+    repeatedly called [masc_code_read] with directory paths and got
+    the opaque ["Failed to read file: Sys_error (\"... Is a
+    directory\")"]. Both handlers now share
+    [Tool_code_read_core.read_with_pagination] and surface a typed
+    [read_error] variant. These tests pin the JSON envelope and the
+    integration with the two callers. *)
+
+open Masc_mcp
+
+(* --- tmp fixtures --- *)
+
+let fresh_base_path ~tag =
+  let raw =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-tool-code-read-core-%s-%d" tag
+         (int_of_float (Unix.gettimeofday () *. 1000.0)))
+  in
+  Unix.mkdir raw 0o755;
+  try Unix.realpath raw with Unix.Unix_error _ -> raw
+
+let sh cmd =
+  let rc = Sys.command cmd in
+  if rc <> 0 then failwith (Printf.sprintf "shell cmd failed (rc=%d): %s" rc cmd)
+
+let git_init_base base_path =
+  sh (Printf.sprintf "cd %s && git init -q -b main" base_path);
+  sh (Printf.sprintf "cd %s && git config user.email test@example.com" base_path);
+  sh (Printf.sprintf "cd %s && git config user.name test" base_path);
+  sh
+    (Printf.sprintf
+       "cd %s && touch README && git add README && git commit -qm init"
+       base_path)
+
+let write_file path content =
+  let oc = open_out path in
+  output_string oc content;
+  close_out oc
+
+let mkdir_p path =
+  let rec go acc = function
+    | [] -> ()
+    | head :: rest ->
+        let next = Filename.concat acc head in
+        (if not (Sys.file_exists next) then Unix.mkdir next 0o755);
+        go next rest
+  in
+  match String.split_on_char '/' path with
+  | "" :: parts -> go "/" parts
+  | parts -> go (Sys.getcwd ()) parts
+
+(* --- shape helpers for JSON probes --- *)
+
+let json_string_field json key =
+  match json with
+  | `Assoc fields ->
+      (match List.assoc_opt key fields with
+       | Some (`String s) -> Some s
+       | _ -> None)
+  | _ -> None
+
+let has_key json key =
+  match json with
+  | `Assoc fields -> List.mem_assoc key fields
+  | _ -> false
+
+let parse_json s =
+  try Yojson.Safe.from_string s
+  with _ -> Alcotest.failf "not valid JSON: %s" s
+
+(* ---------- 1. read_with_pagination → Path_is_directory ---------- *)
+
+let test_directory_input_yields_path_is_directory () =
+  let base = fresh_base_path ~tag:"dir-typed" in
+  let dir = Filename.concat base "some_dir" in
+  Unix.mkdir dir 0o755;
+  match
+    Tool_code_read_core.read_with_pagination
+      ~display_path:"some_dir" ~validated_path:dir ~offset:0 ~limit:100
+  with
+  | Ok _ -> Alcotest.fail "expected Error Path_is_directory, got Ok"
+  | Error (Tool_code_read_core.Path_is_directory _ as e) ->
+      let json = Tool_code_read_core.read_error_to_json e in
+      Alcotest.(check (option string))
+        "error_kind discriminator"
+        (Some "path_is_directory")
+        (json_string_field json "error_kind");
+      Alcotest.(check bool) "has hint field" true (has_key json "hint")
+  | Error other ->
+      Alcotest.failf "expected Path_is_directory, got %s"
+        (Yojson.Safe.to_string
+           (Tool_code_read_core.read_error_to_json other))
+
+(* ---------- 2. missing → File_not_found (no hint) ---------- *)
+
+let test_missing_file_distinguishable_from_directory () =
+  let base = fresh_base_path ~tag:"missing" in
+  let path = Filename.concat base "no_such_file.txt" in
+  match
+    Tool_code_read_core.read_with_pagination
+      ~display_path:"no_such_file.txt" ~validated_path:path ~offset:0
+      ~limit:100
+  with
+  | Error (Tool_code_read_core.File_not_found _ as e) ->
+      let json = Tool_code_read_core.read_error_to_json e in
+      Alcotest.(check (option string))
+        "error_kind discriminator"
+        (Some "file_not_found")
+        (json_string_field json "error_kind");
+      Alcotest.(check bool)
+        "no hint for missing file" false (has_key json "hint")
+  | _ -> Alcotest.fail "expected File_not_found"
+
+(* ---------- 3. regular file still reads ---------- *)
+
+let test_regular_file_still_reads () =
+  let base = fresh_base_path ~tag:"regular" in
+  let path = Filename.concat base "hello.txt" in
+  write_file path "alpha\nbeta\ngamma\n";
+  match
+    Tool_code_read_core.read_with_pagination
+      ~display_path:"hello.txt" ~validated_path:path ~offset:0 ~limit:10
+  with
+  | Ok ok ->
+      (* The trailing newline produces a final empty element; total = 4. *)
+      Alcotest.(check int) "total_lines" 4 ok.total_lines;
+      Alcotest.(check int) "safe_offset" 0 ok.safe_offset;
+      Alcotest.(check int) "safe_limit" 4 ok.safe_limit;
+      Alcotest.(check (list string))
+        "lines" [ "alpha"; "beta"; "gamma"; "" ] ok.lines
+  | Error e ->
+      Alcotest.failf "expected Ok, got %s"
+        (Yojson.Safe.to_string (Tool_code_read_core.read_error_to_json e))
+
+(* ---------- 4. .png extension → Binary_file ---------- *)
+
+let test_binary_extension_yields_binary_file_kind () =
+  let base = fresh_base_path ~tag:"binary" in
+  let path = Filename.concat base "image.png" in
+  write_file path "fake-png-bytes";
+  match
+    Tool_code_read_core.read_with_pagination
+      ~display_path:"image.png" ~validated_path:path ~offset:0 ~limit:10
+  with
+  | Error (Tool_code_read_core.Binary_file _ as e) ->
+      let json = Tool_code_read_core.read_error_to_json e in
+      Alcotest.(check (option string))
+        "error_kind discriminator"
+        (Some "binary_file")
+        (json_string_field json "error_kind");
+      Alcotest.(check bool) "binary has hint" true (has_key json "hint")
+  | _ -> Alcotest.fail "expected Binary_file"
+
+(* ---------- 5. mcp handler integration (Tool_code.handle_code_read) ---------- *)
+
+let make_fixture_with_git ~tag =
+  let base = fresh_base_path ~tag in
+  git_init_base base;
+  base
+
+let test_mcp_handler_emits_typed_error_string () =
+  let base = make_fixture_with_git ~tag:"mcp-dir" in
+  mkdir_p (Filename.concat base "subdir");
+  let cfg : Coord.config =
+    { (Coord.default_config base) with base_path = base }
+  in
+  let ctx : Tool_code.context = { config = cfg; agent_name = "agent-alpha" } in
+  let dir_abs = Filename.concat base "subdir" in
+  let args = `Assoc [ "path", `String dir_abs ] in
+  let result =
+    match
+      Tool_code.dispatch ctx ~name:"masc_code_read" ~args
+    with
+    | Some r -> r
+    | None -> Alcotest.fail "dispatch returned None for masc_code_read"
+  in
+  Alcotest.(check bool) "success=false on directory" false result.success;
+  let body = Tool_result.message result in
+  let json = parse_json body in
+  Alcotest.(check (option string))
+    "mcp handler emits path_is_directory"
+    (Some "path_is_directory")
+    (json_string_field json "error_kind")
+
+(* ---------- 6. keeper handler integration ----------
+
+   We exercise [Tool_code_read_core] directly using the same target
+   the keeper handler would synthesize after path resolution. The
+   keeper-side [resolve_keeper_read_path] requires a fully constructed
+   registry which is heavyweight for a unit test; the SSOT property
+   we want is that the pipeline yields the same typed JSON shape
+   regardless of which caller invoked it. *)
+
+let test_keeper_handler_emits_typed_error_string () =
+  let base = fresh_base_path ~tag:"keeper-dir" in
+  let dir = Filename.concat base "some_dir" in
+  Unix.mkdir dir 0o755;
+  let body =
+    match
+      Tool_code_read_core.read_with_pagination
+        ~display_path:"some_dir" ~validated_path:dir ~offset:0 ~limit:100
+    with
+    | Ok _ -> Alcotest.fail "expected error"
+    | Error err ->
+        Yojson.Safe.to_string (Tool_code_read_core.read_error_to_json err)
+  in
+  let json = parse_json body in
+  Alcotest.(check (option string))
+    "keeper-shape envelope uses same discriminator"
+    (Some "path_is_directory")
+    (json_string_field json "error_kind");
+  Alcotest.(check (option string))
+    "path echoes display path"
+    (Some "some_dir")
+    (json_string_field json "path")
+
+(* ---------- runner ---------- *)
+
+let () =
+  Alcotest.run "tool_code_read_directory_typed_error"
+    [
+      ( "Tool_code_read_core",
+        [
+          Alcotest.test_case "directory_input_yields_path_is_directory"
+            `Quick test_directory_input_yields_path_is_directory;
+          Alcotest.test_case "missing_file_distinguishable_from_directory"
+            `Quick test_missing_file_distinguishable_from_directory;
+          Alcotest.test_case "regular_file_still_reads" `Quick
+            test_regular_file_still_reads;
+          Alcotest.test_case "binary_extension_yields_binary_file_kind"
+            `Quick test_binary_extension_yields_binary_file_kind;
+          Alcotest.test_case "mcp_handler_emits_typed_error_string" `Quick
+            test_mcp_handler_emits_typed_error_string;
+          Alcotest.test_case "keeper_handler_emits_typed_error_string"
+            `Quick test_keeper_handler_emits_typed_error_string;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

`masc_code_read` 가 디렉토리 경로를 받았을 때 두 호출자(MCP / keeper)가 똑같이 `"Failed to read file: Sys_error(\"... Is a directory\")"` 라는 *opaque* 문자열로 평탄화하던 패턴을 typed SSOT 로 교체합니다.

런타임 로그 (2026-05-20 audit) 에서 이 동일 에러가 가장 많이 발생하는 `tool_error` 였고, LLM 입장에서 *"디렉토리였구나, `masc_code_search` 로 바꿔야지"* 라고 식별할 구조적 신호가 없어 같은 실패가 계속 누적되고 있었습니다.

## Root

| Site | 문제 |
|------|------|
| `lib/tool_code.ml:534-587` `handle_code_read` | `Sys.file_exists` → `is_binary_file` → 디렉토리에 `In_channel.with_open_text` → `Sys_error catch-all → "Failed to read file: <exn>"` |
| `lib/keeper/keeper_exec_masc.ml:79-132` `handle_keeper_masc_code_read` | 같은 시퀀스를 그대로 복제, 같은 catch-all |

두 곳 모두 (a) 디렉토리 분기 없음 (b) `exn -> string` flatten 으로 `error_kind` 정보 손실.

## Changes

| 영역 | 변경 |
|------|------|
| **new** `lib/tool_code_read_core.ml(i)` | SSOT 파이프라인. `type read_error = Path_is_directory \| File_not_found \| Binary_file \| Too_large \| Io_error \| Internal_error`. `read_with_pagination`, `read_error_to_json` (`error_kind` 디스크리미네이터 + 조건부 `hint`). `is_binary_file` / `max_file_size` SSOT 이전 (cycle 방지). |
| `lib/tool_code.ml` `handle_code_read` | ~50 → ~25 줄. 전부 `Tool_code_read_core` 로 위임. `is_binary_file` / `max_file_size` 는 `Tool_code_read_core` 재노출. |
| `lib/keeper/keeper_exec_masc.ml` `handle_keeper_masc_code_read` | ~55 → ~25 줄. 동일하게 위임. |
| `lib/tool_schemas/tool_schemas_code.ml`, `lib/tool_code.ml` (inline), `bin/gen_tool_descriptors.ml` | tool description 갱신: *"Read a single file ... For directories use masc_code_search or shell 'ls -la'."* |
| `lib/keeper/keeper_agent_tool_surface.ml:729` | Korean label `"코드 읽기 파일 소스코드"` → `"코드 읽기 단일 파일 (디렉토리 아님)"` |
| **new** `test/test_tool_code_read_directory_typed_error.ml` | 6 케이스 (아래) |

## Test

- `directory_input_yields_path_is_directory` — dir 경로 → `Error (Path_is_directory _)` + JSON `error_kind = "path_is_directory"` + `hint`
- `missing_file_distinguishable_from_directory` — nonexistent → `file_not_found`, **`hint` 없음** (구분 가능)
- `regular_file_still_reads` — regression guard
- `binary_extension_yields_binary_file_kind` — `.png` → `binary_file` + `hint`
- `mcp_handler_emits_typed_error_string` — `Tool_code.handle_code_read` 통합
- `keeper_handler_emits_typed_error_string` — keeper 측 envelope 동일 shape (clone dedup 증명)

로컬 결과:

```
[OK]  Tool_code_read_core  0  directory_input_yields_path_is_directory
[OK]  Tool_code_read_core  1  missing_file_distinguishable_from_directory
[OK]  Tool_code_read_core  2  regular_file_still_reads
[OK]  Tool_code_read_core  3  binary_extension_yields_binary_file_kind
[OK]  Tool_code_read_core  4  mcp_handler_emits_typed_error_string
[OK]  Tool_code_read_core  5  keeper_handler_emits_typed_error_string
Test Successful in 1.046s. 6 tests run.
```

`dune build --root . @check` clean.

## Workaround-rejection self-check

본 가이드라인의 7개 머지 거부 항목 + 시그니처 3종 모두 통과:

1. *Counter-as-fix?* — 아니오. 실제 동작이 바뀜 (dir → 다른 분기, 다른 hint).
2. *String/Substring 분류기 보강?* — 반대 방향. 기존이 string-flatten 이었고, 본 PR 이 closed sum type 으로 교체.
3. *N-of-M?* — 두 호출자가 같은 PR 에서 동시에 SSOT 위임.
4. *catch-all 추가?* — 제거 (`exn -> ...` 를 `Sys_error / Unix.Unix_error / 그 외` 세 분기로).
5. *cap/cooldown/dedup/repair?* — 해당 없음.
6. *test backdoor?* — 없음. 공개 API 만 호출.
7. *같은 typo/off-by-one N 사이트?* — 해당 없음.

이 PR 은 **catch-all-as-classifier → closed sum type root fix** 입니다.

## Self-review (Best Programmer)

- **목표**: `masc_code_read` 의 opaque 디렉토리 에러를 typed envelope 로 surface, 두 clone 호출자를 SSOT 로 dedup.
- **변경 파일**: lib/tool_code_read_core.{ml,mli} (new), lib/tool_code.ml, lib/keeper/keeper_exec_masc.ml, lib/tool_schemas/tool_schemas_code.ml, lib/keeper/keeper_agent_tool_surface.ml, bin/gen_tool_descriptors.ml, test/test_tool_code_read_directory_typed_error.ml (new), test/dune.
- **로컬 검증**: `dune build --root . @check` clean; 신규 테스트 6/6 PASS.
- **미검증**: 전체 `@runtest`, sandbox runtest config 이슈 (`reference_masc_mcp_sandbox_config_unresolved_runtest.md`) 회피 차원에서 사용자 위임. CI 결과로 확인.
- **Out-of-scope** (follow-up issue 예정): `handle_code_symbols` (`lib/tool_code.ml:528`) 의 동일 catch-all 안티패턴. 다른 본문 / 다른 입력 형태로 별도 PR 가치.

## Issue Discovery

- `handle_code_symbols` 같은 catch-all → follow-up issue 로 추적.

🤖 Generated with [Claude Code](https://claude.com/claude-code)