### PR TITLE
fix(dashboard): retain full-health timeout marker

### DIFF
--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -31,8 +31,8 @@ let runtime_state : runtime option Atomic.t = Atomic.make None
     layer never emits it directly because [with_timeout_exn] starts the
     clock after slot acquisition.
 
-    [Spawn] fires if the timeout trips before
-    [Eio.Process.spawn] / [Unix.create_process_env] returns — i.e. the
+    [Spawn] fires if the timeout trips before the Eio process spawn call
+    or [Unix.create_process_env] returns — i.e. the
     process creation syscall itself stalled (docker daemon backpressure,
     container cold start during [docker run]).
 

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -966,6 +966,9 @@ let store_full_health_snapshot snapshot =
       | None -> full_health_consecutive_failures := 0
       | Some _ -> ())
 
+let full_health_refresh_timeout_error error =
+  String_util.contains_substring error "refresh_timeout label=full_health_snapshot"
+
 let mark_full_health_snapshot_error exn =
   let now = Unix.gettimeofday () in
   let error = Printexc.to_string exn in
@@ -1047,7 +1050,10 @@ let full_health_snapshot_metadata ~now ~refresh_in_flight ~refresh_started_at
     match (refresh_in_flight, refresh_started_at) with
     | true, Some started_at ->
         now -. started_at > full_health_refresh_timeout_sec
-    | _ -> false
+    | _ ->
+        (match snapshot with
+         | Some { error = Some error; _ } -> full_health_refresh_timeout_error error
+         | _ -> false)
   in
   let snapshot_age_ms, computed_at, duration_ms, error, stale_since_ts, status =
     match snapshot with
@@ -1165,6 +1171,8 @@ module For_testing = struct
 
   let refresh_full_health_snapshot_now ?(listener = "http/1.1") request =
     refresh_full_health_snapshot_sync ~listener request
+
+  let mark_full_health_snapshot_error = mark_full_health_snapshot_error
 
   let full_health_refresh_timing () =
     (full_health_refresh_interval_sec, full_health_refresh_timeout_sec)

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -219,6 +219,9 @@ module For_testing : sig
     ?listener:string -> Httpun.Request.t -> unit
   (** Synchronously recomputes and stores the cached full-health snapshot. *)
 
+  val mark_full_health_snapshot_error : exn -> unit
+  (** Records a failed background refresh without recomputing the snapshot. *)
+
   val full_health_refresh_timing : unit -> float * float
   (** Returns [(interval_sec, timeout_sec)] for the full-health refresh loop. *)
 end

--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -19,12 +19,10 @@
 # lib/bounded_proc/bounded_proc.ml:17  — the canonical helper itself.
 lib/bounded_proc/bounded_proc.ml:17
 
-# lib/process/process_eio.ml:35, 495, 526 — doc-comment reference + `spawn_and_drain_{stdout,both}`.
-# Line 35: doc-comment reference only (not a real spawn call).
-# Lines 495, 526: Private functions. Every caller (run_argv*, run_argv_with_status*,
+# lib/process/process_eio.ml:495, 526 — `spawn_and_drain_{stdout,both}`.
+# Private functions. Every caller (run_argv*, run_argv_with_status*,
 # run_argv_with_stdin*) wraps in `Eio.Time.with_timeout_exn clk timeout_sec`
 # + `Eio.Switch.run` and the process-wide spawn guard.
-lib/process/process_eio.ml:35
 lib/process/process_eio.ml:495
 lib/process/process_eio.ml:526
 

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1370,6 +1370,35 @@ let test_full_health_refresh_budget_tracks_shell_budget () =
   Alcotest.(check bool) "full health interval exceeds timeout" true
     (interval_sec > timeout_sec)
 
+let test_full_health_refresh_timeout_preserves_last_snapshot () =
+  Server_routes_http_runtime.For_testing.reset_full_health_snapshot ();
+  let request = Httpun.Request.create `GET "/health?full=1" in
+  Server_routes_http_runtime.For_testing.refresh_full_health_snapshot_now request;
+  let before = Server_routes_http_runtime.make_health_response_json request in
+  let open Yojson.Safe.Util in
+  let before_reaction_ledger = before |> member "keeper_reaction_ledger" in
+  let timeout_error =
+    Failure
+      "refresh_timeout label=full_health_snapshot phase=refresh timeout_s=16.0 \
+       elapsed_s=17.0"
+  in
+  Server_routes_http_runtime.For_testing.mark_full_health_snapshot_error timeout_error;
+  let after = Server_routes_http_runtime.make_health_response_json request in
+  Alcotest.(check string) "timeout marks snapshot error" "error"
+    (after |> member "full_health_snapshot" |> member "status" |> to_string);
+  Alcotest.(check bool) "timeout marks timed out component" true
+    (after |> member "full_health_snapshot" |> member "component_timed_out"
+     |> to_bool);
+  Alcotest.(check string) "timeout error is surfaced" (Printexc.to_string timeout_error)
+    (after |> member "full_health_snapshot" |> member "error" |> to_string);
+  Alcotest.(check bool) "timeout records stale-since timestamp" true
+    (match after |> member "full_health_snapshot" |> member "stale_since_ts" with
+     | `Float _ | `Int _ -> true
+     | _ -> false);
+  Alcotest.(check string) "timeout preserves previous heavy fields"
+    (Yojson.Safe.to_string before_reaction_ledger)
+    (after |> member "keeper_reaction_ledger" |> Yojson.Safe.to_string)
+
 let test_health_response_survives_deleted_cwd () =
   with_temp_dir "health-deleted-cwd" (fun dir ->
       let deleted_cwd = Filename.concat dir "deleted-cwd" in
@@ -2927,6 +2956,9 @@ let () =
             test_health_response_full_query_uses_snapshot_cache;
           Alcotest.test_case "full health refresh budget tracks shell budget"
             `Quick test_full_health_refresh_budget_tracks_shell_budget;
+          Alcotest.test_case
+            "full health refresh timeout preserves last snapshot" `Quick
+            test_full_health_refresh_timeout_preserves_last_snapshot;
           Alcotest.test_case "health response survives deleted cwd" `Quick
             test_health_response_survives_deleted_cwd;
           Alcotest.test_case "readiness false before init" `Quick


### PR DESCRIPTION
## Summary
- preserve the merged last-good full-health snapshot behavior while keeping timeout failures visible as component_timed_out in full_health_snapshot metadata
- expose For_testing.mark_full_health_snapshot_error for direct regression coverage
- add a bootstrap test that confirms timeout error, stale_since_ts, and preserved heavy fields

## Verification
- ocamlformat --check lib/server/server_routes_http_runtime.ml lib/server/server_routes_http_runtime.mli test/test_server_runtime_bootstrap.ml
- ./_build/default/test/test_server_runtime_bootstrap.exe test bootstrap 39-41 --show-errors

## Local build note
- Attempted: env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_DUNE_ALLOW_LIVE_BUILD_LOCK=1 DUNE_LOCAL_JOBS=2 scripts/dune-local.sh build test/test_server_runtime_bootstrap.exe bin/main_eio.exe
- Not completed locally because /tmp/me-dune-local.lock was held by another root checkout bin/main_eio.exe build; draft PR CI should be the build authority for this branch.