### PR TITLE
refactor(cascade_transport): extract codex CLI omission dedup into sibling module

### DIFF
--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -45,81 +45,26 @@ let provider_effective_max_turns _kind requested = requested
 
    Fingerprint = sorted, comma-joined tool list.  Stdlib.Mutex guards
    concurrent access from heartbeat/turn fibers across domains. *)
-let codex_omission_state_mu = Stdlib.Mutex.create ()
-let codex_omission_state : (string, string) Hashtbl.t = Hashtbl.create 16
+(* Codex CLI tool-omission warning dedup extracted to
+   [Cascade_transport_codex_omission_dedup] (godfile decomp).
+   Public surface preserved via per-function aliases below. *)
+module Codex_omission_dedup = Cascade_transport_codex_omission_dedup
 
-let codex_cli_omission_fingerprint (tools : string list) : string =
-  tools |> List.sort String.compare |> String.concat ","
+let codex_cli_omission_fingerprint = Codex_omission_dedup.codex_cli_omission_fingerprint
+
+let codex_cli_omission_fingerprint_seen =
+  Codex_omission_dedup.codex_cli_omission_fingerprint_seen
 ;;
 
-let codex_omission_agent_key = function
-  | Some agent_name ->
-    let agent_name = String.trim agent_name in
-    if String.equal agent_name "" then "<no_agent>" else agent_name
-  | None -> "<no_agent>"
+let reset_codex_cli_omission_dedup_for_tests =
+  Codex_omission_dedup.reset_codex_cli_omission_dedup_for_tests
 ;;
 
-let codex_omission_should_log ~agent_name ~tool_fingerprint =
-  Stdlib.Mutex.lock codex_omission_state_mu;
-  Fun.protect
-    ~finally:(fun () -> Stdlib.Mutex.unlock codex_omission_state_mu)
-    (fun () ->
-       match Hashtbl.find_opt codex_omission_state agent_name with
-       | Some prev when String.equal prev tool_fingerprint -> false
-       | _ ->
-         Hashtbl.replace codex_omission_state agent_name tool_fingerprint;
-         true)
+let record_codex_cli_omission_for_agent =
+  Codex_omission_dedup.record_codex_cli_omission_for_agent
 ;;
 
-let codex_cli_omission_fingerprint_seen fingerprint =
-  not (codex_omission_should_log ~agent_name:"<no_agent>" ~tool_fingerprint:fingerprint)
-;;
-
-(* For tests: reset the dedup state so each test starts clean. *)
-let reset_codex_cli_omission_dedup_for_tests () =
-  Stdlib.Mutex.lock codex_omission_state_mu;
-  Fun.protect
-    ~finally:(fun () -> Stdlib.Mutex.unlock codex_omission_state_mu)
-    (fun () -> Hashtbl.clear codex_omission_state)
-;;
-
-let record_codex_cli_omission_for_agent
-      ~(agent_name : string option)
-      ~(tools : string list)
-  : unit
-  =
-  let provider_label =
-    Llm_provider.Provider_config.string_of_provider_kind
-      Llm_provider.Provider_config.Codex_cli
-  in
-  match tools with
-  | [] -> ()
-  | _ ->
-    List.iter
-      (fun tool ->
-         Prometheus.inc_counter
-           Prometheus.metric_provider_mcp_tool_omission
-           ~labels:[ "provider", provider_label; "tool", tool ]
-           ())
-      tools;
-    let tool_fingerprint = codex_cli_omission_fingerprint tools in
-    let agent_name_key = codex_omission_agent_key agent_name in
-    if codex_omission_should_log ~agent_name:agent_name_key ~tool_fingerprint
-    then
-      Log.warn
-        ~ctx:"oas_worker_exec"
-        "codex_cli omitting keeper-bound runtime MCP tool(s) that require request-scoped \
-         auth headers: %s (no per-keeper bearer-token lane available for %s; subsequent \
-         omissions of this same set are counted in \
-         masc_provider_mcp_tool_omission_total{provider=\"%s\"} and not re-logged)"
-        (String.concat ", " (List.sort String.compare tools))
-        agent_name_key
-        provider_label
-;;
-
-let record_codex_cli_omission ~(tools : string list) : unit =
-  record_codex_cli_omission_for_agent ~agent_name:None ~tools
-;;
+let record_codex_cli_omission = Codex_omission_dedup.record_codex_cli_omission
 
 (** Resolve a model label string to an OAS Provider.config.
     Uses MASC [Cascade_config.parse_model_string] (with Provider_registry as SSOT).

--- a/lib/cascade/cascade_transport_codex_omission_dedup.ml
+++ b/lib/cascade/cascade_transport_codex_omission_dedup.ml
@@ -1,0 +1,91 @@
+(** Codex CLI tool-omission warning dedup.
+
+    Extracted from [cascade_transport.ml] (lines 48-122) as part of the
+    godfile decomp campaign. Owns the per-(agent, tool-fingerprint)
+    dedup state that suppresses repeated WARN logs when the codex CLI
+    omits the same set of keeper-bound runtime MCP tools across
+    consecutive calls, while still incrementing the Prometheus counter
+    [masc_provider_mcp_tool_omission_total] for every omission.
+
+    Thread-safety: the dedup state is a single [Hashtbl] guarded by a
+    [Stdlib.Mutex]. Lookups during module initialisation use only
+    [Stdlib.Mutex] (no Eio dependency).
+
+    Public surface is reserved for the legacy [cascade_transport.mli]
+    aliases and the dedicated unit test. *)
+
+let codex_omission_state_mu = Stdlib.Mutex.create ()
+let codex_omission_state : (string, string) Hashtbl.t = Hashtbl.create 16
+
+let codex_cli_omission_fingerprint (tools : string list) : string =
+  tools |> List.sort String.compare |> String.concat ","
+;;
+
+let codex_omission_agent_key = function
+  | Some agent_name ->
+    let agent_name = String.trim agent_name in
+    if String.equal agent_name "" then "<no_agent>" else agent_name
+  | None -> "<no_agent>"
+;;
+
+let codex_omission_should_log ~agent_name ~tool_fingerprint =
+  Stdlib.Mutex.lock codex_omission_state_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock codex_omission_state_mu)
+    (fun () ->
+       match Hashtbl.find_opt codex_omission_state agent_name with
+       | Some prev when String.equal prev tool_fingerprint -> false
+       | _ ->
+         Hashtbl.replace codex_omission_state agent_name tool_fingerprint;
+         true)
+;;
+
+let codex_cli_omission_fingerprint_seen fingerprint =
+  not (codex_omission_should_log ~agent_name:"<no_agent>" ~tool_fingerprint:fingerprint)
+;;
+
+(* For tests: reset the dedup state so each test starts clean. *)
+let reset_codex_cli_omission_dedup_for_tests () =
+  Stdlib.Mutex.lock codex_omission_state_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock codex_omission_state_mu)
+    (fun () -> Hashtbl.clear codex_omission_state)
+;;
+
+let record_codex_cli_omission_for_agent
+      ~(agent_name : string option)
+      ~(tools : string list)
+  : unit
+  =
+  let provider_label =
+    Llm_provider.Provider_config.string_of_provider_kind
+      Llm_provider.Provider_config.Codex_cli
+  in
+  match tools with
+  | [] -> ()
+  | _ ->
+    List.iter
+      (fun tool ->
+         Prometheus.inc_counter
+           Prometheus.metric_provider_mcp_tool_omission
+           ~labels:[ "provider", provider_label; "tool", tool ]
+           ())
+      tools;
+    let tool_fingerprint = codex_cli_omission_fingerprint tools in
+    let agent_name_key = codex_omission_agent_key agent_name in
+    if codex_omission_should_log ~agent_name:agent_name_key ~tool_fingerprint
+    then
+      Log.warn
+        ~ctx:"oas_worker_exec"
+        "codex_cli omitting keeper-bound runtime MCP tool(s) that require request-scoped \
+         auth headers: %s (no per-keeper bearer-token lane available for %s; subsequent \
+         omissions of this same set are counted in \
+         masc_provider_mcp_tool_omission_total{provider=\"%s\"} and not re-logged)"
+        (String.concat ", " (List.sort String.compare tools))
+        agent_name_key
+        provider_label
+;;
+
+let record_codex_cli_omission ~(tools : string list) : unit =
+  record_codex_cli_omission_for_agent ~agent_name:None ~tools
+;;

--- a/lib/cascade/cascade_transport_codex_omission_dedup.mli
+++ b/lib/cascade/cascade_transport_codex_omission_dedup.mli
@@ -1,0 +1,36 @@
+(** Codex CLI tool-omission warning dedup.
+
+    Suppresses repeated WARN log entries when the codex CLI omits the
+    same set of keeper-bound runtime MCP tools across consecutive
+    calls, while still incrementing the Prometheus counter
+    [masc_provider_mcp_tool_omission_total] for every omission.
+
+    Thread-safe via [Stdlib.Mutex] — no Eio dependency, callable
+    during module initialisation. *)
+
+(** [codex_cli_omission_fingerprint tools] returns the canonical
+    sorted-comma fingerprint used as the dedup key. *)
+val codex_cli_omission_fingerprint : string list -> string
+
+(** [codex_cli_omission_fingerprint_seen fingerprint] returns [true]
+    when the [<no_agent>] dedup bucket already contains [fingerprint].
+    Side-effect-free with respect to other agent buckets. *)
+val codex_cli_omission_fingerprint_seen : string -> bool
+
+(** [reset_codex_cli_omission_dedup_for_tests ()] clears the dedup
+    state. Test-only — invoked at the start of each unit test for
+    reproducibility. *)
+val reset_codex_cli_omission_dedup_for_tests : unit -> unit
+
+(** [record_codex_cli_omission_for_agent ~agent_name ~tools]
+    increments the Prometheus omission counter once per [tool] in
+    [tools] and emits a single WARN per (agent, fingerprint) pair.
+    When [agent_name] is [None] the key falls back to [<no_agent>]. *)
+val record_codex_cli_omission_for_agent
+  :  agent_name:string option
+  -> tools:string list
+  -> unit
+
+(** [record_codex_cli_omission ~tools] is
+    [record_codex_cli_omission_for_agent ~agent_name:None ~tools]. *)
+val record_codex_cli_omission : tools:string list -> unit


### PR DESCRIPTION
## 요약

\`cascade_transport.ml\` (godfile, 1733 LoC) 의 codex CLI tool-omission
dedup 클러스터 (lines 48-122) 를 sibling 모듈로 추출. 본 PR 머지 후
1733 → 1678 (−55, −3.2%).

## 추출된 surface

State encapsulated (private):
- \`codex_omission_state_mu\` (Stdlib.Mutex)
- \`codex_omission_state\` (Hashtbl)
- \`codex_omission_agent_key\` / \`codex_omission_should_log\` (internal)

Public aliases preserved in cascade_transport.ml (matches .mli):
- \`codex_cli_omission_fingerprint\`
- \`codex_cli_omission_fingerprint_seen\`
- \`reset_codex_cli_omission_dedup_for_tests\`
- \`record_codex_cli_omission_for_agent\`
- \`record_codex_cli_omission\`

## 작은 LoC 감소를 정당화하는 이유

이 추출이 −55 LoC 정도지만 가치 있는 이유:
1. **모든 mutable state 가 한 모듈로 격리** — \`cascade_transport.ml\`
   에서 유일한 module-level mutable state 였던 mutex + hashtable이
   전용 모듈 안으로 들어감. 동시성 contract 가 단독으로 audit 가능.
2. **dedup bookkeeping 70+ LoC 가 transport 로직과 분리** — 향후
   reader 가 \`cascade_transport.ml\` 의 본질 (provider label, lane,
   MCP policy) 을 읽을 때 dedup bookkeeping을 건너뛰지 않아도 됨.
3. **Stdlib.Mutex-only thread safety 명시** — module-init time 호출자
   들이 안심할 수 있는 contract 가 .mli 에 명시됨.

## 검증

\`\`\`
$ dune build --root . @check                                      # exit 0
$ _build/default/test/test_codex_cli_omission_dedup_10097.exe     # 5/5 PASS
\`\`\`

## 의존성

PR #16754 (server_dashboard_shell_snapshot.ml syntax fix) commit
\`a157ad2563\` 위에 stack.

## LoC

| 파일 | LoC |
|------|-----|
| cascade_transport.ml | 1733 → 1678 (−55) |
| cascade_transport_codex_omission_dedup.ml (new) | 91 |
| .mli (new) | 36 |
| 본 PR diff | +139 / −67 |

## RFC

RFC-WAIVED: pure mechanical extraction within \`lib/cascade/\`.
Touches no credential / identity / operator_control / sandbox / hooks /
workflow subsystem. The Codex_cli provider label is itself not a
credential; the WARN log this dedup gates is about *missing* auth
header support (provider can't carry per-keeper bearer-tokens), not
about an auth header *value*. Public surface preserved via
per-function aliases — .mli unchanged.