### PR TITLE
feat(keeper_cascade_profile): WARN-once on raw cascade name silent fallback

### DIFF
--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -419,6 +419,13 @@ let system_catalog_names ?config_path () =
 let logged_invalid_fallback : (string * string, unit) Hashtbl.t =
   Hashtbl.create 4
 
+(** Track raw cascade names that did not resolve to any live catalog
+    member so the resolve-live silent-fallback WARN fires once per
+    distinct unresolved name. Bounded by the number of distinct typo /
+    stale-reference names seen during the process lifetime — typical
+    operator workloads keep this in the low single digits. *)
+let logged_unresolved_raw : (string, unit) Hashtbl.t = Hashtbl.create 4
+
 let fallback_cascade_for ?config_path name =
   let public_name = normalized_query_name ?config_path name in
   if String.equal public_name "" then None
@@ -520,8 +527,23 @@ let resolve_live_with_catalog ~catalog raw =
        member.  Silently falls back to [Keeper_turn] default —
        operator's intended cascade is invalidated.  Distinct from
        iter-30 [route_resolve_fallback] which catches the
-       route-table path; this is the direct-raw-name path. *)
+       route-table path; this is the direct-raw-name path.
+
+       2026-05-20: counter alone was not enough — operators were
+       reading Prometheus but the cascade name that failed to
+       resolve was not in the metric (cardinality bound).  Surface
+       the unresolved name in a WARN line that fires once per
+       distinct raw value so operators can fix the typo / stale
+       cascade.toml entry without grepping the audit JSONL. *)
     Cascade_metrics.on_resolve_live_fallback ();
+    if not (Hashtbl.mem logged_unresolved_raw trimmed) then begin
+      Hashtbl.add logged_unresolved_raw trimmed ();
+      Log.Misc.warn
+        "[CascadeConfig] cascade name %S did not resolve to any catalog \
+         member; falling back to [Keeper_turn] default — check cascade.toml \
+         for typo or stale reference"
+        trimmed
+    end;
     Cascade_routes.fallback_name_for_catalog Keeper_turn ~catalog
   end
 


### PR DESCRIPTION
## 요약

- `keeper_cascade_profile.ml:518-526` 의 raw cascade name silent fallback (typo / stale reference) 가 `masc_cascade_resolve_live_fallback_total` counter 만 emit — *어떤 이름이* 실패했는지 cardinality 제약으로 metric 에 담을 수 없었음
- WARN-once log 추가 (key = trimmed raw name, `Hashtbl.mem` 가드)
- 같은 모듈 상단 `fallback_cascade_for` (line 442-451) 의 `logged_invalid_fallback` Hashtbl 패턴 그대로 재사용 → SSOT 일관성
- 동작 보존 — fallback 여전히 발생, counter 여전히 증가

## 배경

`memory/masc-mcp-code-flowchart-audit-2026-05-20.html` §6 CASCADE HIGH (5a) — 6-subsystem flowchart audit 의 정량 개선 대상.

Operator 가 Prometheus 에서 `resolve_live_fallback` rate 가 올라가는 것을 봐도 *어느 cascade name 이 typo* 인지 모름. WARN-once 가 그 정보 채움.

## 패턴

PR #16771 (MemoryRecallReadErrors), PR #16778 (CompactionNegativeSavings) 과 같은 audit 의 정량 개선 시리즈. 모두 *silent path 에 bounded-cardinality signal 부착, 동작 보존* 원칙.

## 변경

| 파일 | 변경 |
|---|---|
| `lib/keeper/keeper_cascade_profile.ml` | `logged_unresolved_raw` Hashtbl + raw name 첫 등장 시 WARN-once |

24 insertions / 1 deletion.

## 검증

- `dune build --root . @check` PASS (exit 0)
- 동작 보존 확인: fallback path 의 metric incr / route return 모두 그대로

## 측정 가능한 개선

- Operator 가 Prometheus 만 보고도 fallback 발생 *사실* 알았다면, 이제 첫 발생 시 *어느 raw name* 도 log 로 알 수 있음
- 메모리 누수 위험 낮음: raw name 분포가 typo / stale ref 로 자연스럽게 bounded (low single digits)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>