### PR TITLE
fix(lint): refresh spawn-bounded allowlist for process_eio.ml line drift

### DIFF
--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -19,12 +19,14 @@
 # lib/bounded_proc/bounded_proc.ml:17  — the canonical helper itself.
 lib/bounded_proc/bounded_proc.ml:17
 
-# lib/process/process_eio.ml:466, 493 — `spawn_and_drain_{stdout,both}`.
-# Private functions. Every caller (run_argv*, run_argv_with_status*,
+# lib/process/process_eio.ml:35, 495, 526 — doc-comment reference + `spawn_and_drain_{stdout,both}`.
+# Line 35: doc-comment reference only (not a real spawn call).
+# Lines 495, 526: Private functions. Every caller (run_argv*, run_argv_with_status*,
 # run_argv_with_stdin*) wraps in `Eio.Time.with_timeout_exn clk timeout_sec`
 # + `Eio.Switch.run` and the process-wide spawn guard.
-lib/process/process_eio.ml:466
-lib/process/process_eio.ml:493
+lib/process/process_eio.ml:35
+lib/process/process_eio.ml:495
+lib/process/process_eio.ml:526
 
 # lib/server/lsp_process_manager.ml:178 — LSP child process. Lifetime is
 # bound to the LSP session switch; idle eviction handled by the LSP


### PR DESCRIPTION
## Summary
- `process_eio.ml`의 spawn site 라인 번호가 recent refactors로 인해 466/493 → 495/526으로 이동
- Line 35 doc-comment 참조도 ratchet에 잡혀서 allowlist에 추가 (실제 spawn 아님)
- Spawn-bounded ratchet PASS 확인

## Test plan
- [x] `bash scripts/lint-spawn-bounded.sh` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)