### PR TITLE
refactor(board_core): extract comment rate limit tracker into sibling module

### DIFF
--- a/lib/board_comment_rate_limit.ml
+++ b/lib/board_comment_rate_limit.ml
@@ -1,0 +1,66 @@
+(** Comment rate limiting: per-author sliding-window tracker.
+
+    Extracted from [board_core.ml] (lines 60-90) as part of the godfile
+    decomp campaign. Owns a single module-level [Hashtbl] keyed by
+    author name, with each entry holding a mutable list of timestamps.
+
+    The rate window and per-window limit come from [Limits]
+    ([comment_rate_window_sec] / [comment_rate_limit]); when the limit
+    is non-positive, [check] returns [None] (rate limiting disabled).
+
+    Thread-safety: callers must hold [board_core] [with_lock store]
+    before invoking [check] / [record]. The module itself uses
+    [Stdlib.Hashtbl] (no internal locking). *)
+
+module Hashtbl = Stdlib.Hashtbl
+module List = Stdlib.List
+module Limits = Board_types.Limits
+
+let comment_timestamps : (string, float list ref) Hashtbl.t = Hashtbl.create 32
+
+let check ~author ~now =
+  let limit = Limits.comment_rate_limit in
+  if limit <= 0 then None
+  else
+    let window = Float.of_int Limits.comment_rate_window_sec in
+    match Hashtbl.find_opt comment_timestamps author with
+    | None -> None
+    | Some ts_ref ->
+      let recent = List.filter (fun t -> now -. t < window) !ts_ref in
+      ts_ref := recent;
+      if List.length recent >= limit
+      then
+        let oldest = List.hd (List.sort Stdlib.compare recent) in
+        let retry_after = window -. (now -. oldest) +. 1.0 in
+        Some retry_after
+      else None
+;;
+
+let record ~author ~now =
+  let ts_ref =
+    match Hashtbl.find_opt comment_timestamps author with
+    | Some r -> r
+    | None ->
+      let r = ref [] in
+      Hashtbl.replace comment_timestamps author r;
+      r
+  in
+  ts_ref := now :: !ts_ref
+;;
+
+let reset () = Hashtbl.clear comment_timestamps
+
+(** [sweep_stale ~now ~window] drops timestamps older than [window]
+    seconds from every author's entry, then removes any author whose
+    list became empty. Called from [board_core] [sweep] as part of the
+    larger store sweep. *)
+let sweep_stale ~now ~window =
+  let stale_authors = ref [] in
+  Hashtbl.iter
+    (fun author ts_ref ->
+       let recent = List.filter (fun t -> now -. t < window) !ts_ref in
+       if List.length recent = 0 then stale_authors := author :: !stale_authors
+       else ts_ref := recent)
+    comment_timestamps;
+  List.iter (Hashtbl.remove comment_timestamps) !stale_authors
+;;

--- a/lib/board_comment_rate_limit.mli
+++ b/lib/board_comment_rate_limit.mli
@@ -1,0 +1,26 @@
+(** Comment rate limiting: per-author sliding-window tracker.
+
+    Module-level [Hashtbl] (no internal locking); callers must already
+    hold [board_core] [with_lock store]. *)
+
+(** [check ~author ~now] returns [Some retry_after_sec] if [author]
+    has already posted [Limits.comment_rate_limit] comments in the
+    last [Limits.comment_rate_window_sec] seconds (with [retry_after]
+    rounded up by 1.0s for client clarity); [None] otherwise. When
+    [Limits.comment_rate_limit <= 0] (rate limiting disabled), always
+    returns [None]. *)
+val check : author:string -> now:float -> float option
+
+(** [record ~author ~now] appends [now] to [author]'s timestamp list.
+    Callers should invoke this AFTER a successful comment is persisted
+    (and AFTER [check] returns [None]) — otherwise the windows can
+    drift across concurrent attempts. *)
+val record : author:string -> now:float -> unit
+
+(** [reset ()] clears the tracker entirely. Test-only. *)
+val reset : unit -> unit
+
+(** [sweep_stale ~now ~window] expires per-author timestamps older
+    than [window] seconds from [now] and removes any author whose list
+    became empty. Called from the board-core sweep loop. *)
+val sweep_stale : now:float -> window:float -> unit

--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -53,41 +53,14 @@ let create_store () =
 
 (** {1 Comment Rate Limiting}
 
-    Per-author sliding window tracker.  Module-level Hashtbl avoids
-    changing the store type; all access is inside the existing
+    Per-author sliding-window tracker extracted to
+    [Board_comment_rate_limit] (godfile decomp). Module-level Hashtbl
+    avoids changing the store type; all access is inside the existing
     [with_lock store] in [add_comment_with_status]. *)
 
-let comment_timestamps : (string, float list ref) Hashtbl.t = Hashtbl.create 32
-
-let check_comment_rate_limit ~author ~now =
-  let limit = Limits.comment_rate_limit in
-  if limit <= 0 then None
-  else
-    let window = Float.of_int Limits.comment_rate_window_sec in
-    match Hashtbl.find_opt comment_timestamps author with
-    | None -> None
-    | Some ts_ref ->
-      let recent = List.filter (fun t -> now -. t < window) !ts_ref in
-      ts_ref := recent;
-      if List.length recent >= limit
-      then
-        let oldest = List.hd (List.sort Stdlib.compare recent) in
-        let retry_after = window -. (now -. oldest) +. 1.0 in
-        Some retry_after
-      else None
-
-let record_comment_timestamp ~author ~now =
-  let ts_ref =
-    match Hashtbl.find_opt comment_timestamps author with
-    | Some r -> r
-    | None ->
-      let r = ref [] in
-      Hashtbl.replace comment_timestamps author r;
-      r
-  in
-  ts_ref := now :: !ts_ref
-
-let reset_comment_rate_tracker () = Hashtbl.clear comment_timestamps
+let check_comment_rate_limit = Board_comment_rate_limit.check
+let record_comment_timestamp = Board_comment_rate_limit.record
+let reset_comment_rate_tracker = Board_comment_rate_limit.reset
 
 (** Remove [value] from the string list stored at [key] in [tbl].
     Removes the key entirely when the list becomes empty. *)
@@ -241,14 +214,7 @@ let sweep store =
         author_posts);
     (* Prune stale rate-limit entries *)
     let window = Stdlib.Float.of_int Limits.comment_rate_window_sec in
-    let stale_authors = ref [] in
-    Hashtbl.iter
-      (fun author ts_ref ->
-         let recent = List.filter (fun t -> now -. t < window) !ts_ref in
-         if List.length recent = 0 then stale_authors := author :: !stale_authors
-         else ts_ref := recent)
-      comment_timestamps;
-    List.iter (Hashtbl.remove comment_timestamps) !stale_authors;
+    Board_comment_rate_limit.sweep_stale ~now ~window;
     (* Invalidate caches if anything was swept *)
     if !removed_posts > 0 || !cap_evicted > 0 then invalidate_post_caches store;
     if !removed_comments > 0 then invalidate_comment_caches store;


### PR DESCRIPTION
## 요약

\`board_core.ml\` (godfile, 1623 LoC) 의 per-author 슬라이딩 윈도우 comment
rate-limit tracker (module-level Hashtbl + 4 함수) 를 sibling 모듈로 추출.
본 PR 머지 후 1623 → 1589 (−34, −2.1%).

## 추출된 surface

State (private):
- \`comment_timestamps : (string, float list ref) Hashtbl.t\`

Functions (aliased in board_core.ml):
- \`check_comment_rate_limit\` → \`Board_comment_rate_limit.check\`
- \`record_comment_timestamp\` → \`Board_comment_rate_limit.record\`
- \`reset_comment_rate_tracker\` → \`Board_comment_rate_limit.reset\`

New API (encapsulation 강화):
- \`Board_comment_rate_limit.sweep_stale ~now ~window\` — \`board_core.sweep\`
  의 inline \`Hashtbl.iter\` + stale-author 제거 loop 를 추출. 새 모듈이
  자신의 자료구조 소유권을 완전히 가짐.

## 작은 LoC 감소 정당화

#16786 (codex omission dedup) 와 같은 정당화:
1. **module-level mutable state 격리** — \`comment_timestamps\` Hashtbl 이
   board_core.ml 의 top-level 에서 사라짐. 향후 reader 가 rate-limit
   bookkeeping 을 transport/post-CRUD 와 분리해서 읽을 수 있음.
2. **sweep_stale 추출로 캡슐화 강화** — 새 모듈이 자기 Hashtbl 의 sweep
   까지 책임짐. board_core.sweep 은 \`window\` 만 알면 되고 내부 자료구조
   접근권한이 사라짐.
3. **Thread-safety contract 명시** — caller 가 \`with_lock store\` 를 hold
   해야 함이 .mli 에 명시됨.

## 검증

\`\`\`
$ dune build --root . @check                       # exit 0
$ _build/default/test/test_tool_board_coverage.exe # 84/85 PASS
\`\`\`

1 failure (\`schemas / 14 tool schemas / tools count\`) 는 vanilla
origin/main 에서도 동일 — pre-existing, 본 PR 무관.

## 의존성

PR #16754 (server_dashboard_shell_snapshot.ml syntax fix) commit
\`a157ad2563\` 위에 stack.

## LoC

| 파일 | LoC |
|------|-----|
| board_core.ml | 1623 → 1589 (−34) |
| board_comment_rate_limit.ml (new) | 66 |
| .mli (new) | 26 |
| 본 PR diff | +99 / −41 |

## RFC

RFC-WAIVED: pure mechanical extraction of internal helpers within
\`lib/\`. Touches no credential / identity / operator_control / sandbox /
hooks / workflow subsystem. Public surface preserved via per-function
aliases — \`board_core.mli\` unchanged.