### PR TITLE
fix(task): demote invalid transition workflow rejections

### DIFF
--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -35,6 +35,13 @@ let result_to_response ~tool_name ~start_time = function
   | Ok msg -> Tool_result.ok ~tool_name ~start_time msg
   | Error e -> Tool_result.error ~tool_name ~start_time (Masc_domain.masc_error_to_string e)
 
+let log_task_transition_failed err =
+  let message = Masc_domain.masc_error_to_string err in
+  match err with
+  | Masc_domain.Task (Masc_domain.Task_error.InvalidState _) ->
+      Log.Task.warn "task transition failed: %s" message
+  | _ -> Log.Task.error "task transition failed: %s" message
+
 include Tool_task_payloads
 
 let is_registered_keeper_agent_alias_name config agent_name =
@@ -690,7 +697,7 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
   in
   match completion_state_error with
   | Some err ->
-    Log.Task.error "task transition failed: %s" (Masc_domain.masc_error_to_string err);
+    log_task_transition_failed err;
     result_to_response ~tool_name ~start_time (Error err)
   | None ->
   let completion_owned_by_caller =
@@ -995,7 +1002,7 @@ and handle_transition ?agent_tool_names ~tool_name ~start_time ctx args =
                  ~task_id ())
         | Masc_domain.Claim | Masc_domain.Start | Masc_domain.Done_action | Masc_domain.Cancel | Masc_domain.Release -> ())
    | Error err ->
-       Log.Task.error "task transition failed: %s" (Masc_domain.masc_error_to_string err));
+       log_task_transition_failed err);
   (* Record metrics *)
   (match result, action with
    | Ok _, Masc_domain.Done_action ->

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -691,6 +691,11 @@ let () = test "handle_transition_start_on_todo_points_at_claim_first" (fun () ->
      fallthrough branch. The enriched error must name masc_transition
      action=claim as the next concrete call. *)
   let ctx = make_test_ctx () in
+  let before_seq =
+    match Log.Ring.recent ~limit:1 () with
+    | entry :: _ -> entry.Log.Ring.seq
+    | [] -> -1
+  in
   let _ =
     Tool_task.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
       (`Assoc [ ("title", `String "Start-without-claim") ])
@@ -707,7 +712,21 @@ let () = test "handle_transition_start_on_todo_points_at_claim_first" (fun () ->
   assert (str_contains result.Tool_result.legacy_message "Invalid transition");
   assert (str_contains result.Tool_result.legacy_message "todo");
   assert (str_contains result.Tool_result.legacy_message "Remediation");
-  assert (str_contains result.Tool_result.legacy_message "action=claim")
+  assert (str_contains result.Tool_result.legacy_message "action=claim");
+  let task_entries =
+    Log.Ring.recent ~limit:50 ~module_filter:"Task" ~since_seq:before_seq ()
+  in
+  match
+    List.find_opt
+      (fun (entry : Log.Ring.entry) ->
+         str_contains entry.message "task transition failed:"
+         && str_contains entry.message "Invalid transition: todo -> start")
+      task_entries
+  with
+  | Some entry ->
+      assert (Log.level_to_string entry.level = "WARN")
+  | None ->
+      failwith "expected invalid transition to be logged through Task ring"
 )
 
 let () = test "handle_transition_release_by_nonowner_redirects_to_board_post"


### PR DESCRIPTION
Summary:
- Demote typed Task_error.InvalidState transition failures from ERROR to WARN while preserving failure responses.
- Add regression coverage for todo -> start workflow rejection logging through the Task ring.

Context:
- Live 2h log scan showed task.claim_release_oscillation noise from deterministic workflow rejections; this keeps real runtime/system failures at ERROR while InvalidState guidance remains operator-visible as WARN.

Verification:
- ocamlformat --check lib/tool_task.ml test/test_tool_task_coverage.ml
- git diff --check
- env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_DUNE_ALLOW_LIVE_BUILD_LOCK=1 DUNE_LOCAL_JOBS=2 scripts/dune-local.sh build test/test_tool_task_coverage.exe
- ./_build/default/test/test_tool_task_coverage.exe test coverage 19 --show-errors