### PR TITLE
refactor(server): extract scan-summary JSON helpers from dashboard keeper API godfile

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -138,101 +138,25 @@ let linked_artifact_json = Checkpoints.linked_artifact_json
 
 include Server_dashboard_http_keeper_runtime_manifest_scan
 
-let receipt_row_matches ?turn_id keeper_name trace_id json =
-  let keeper_matches = json_string_member_opt "keeper_name" json = Some keeper_name in
-  let trace_matches = json_string_member_opt "trace_id" json = Some trace_id in
-  let turn_matches =
-    match turn_id with
-    | None -> false
-    | Some wanted -> json_int_member_opt "turn_count" json = Some wanted
-  in
-  keeper_matches && (trace_matches || turn_matches)
+(* Runtime-manifest receipt matching + scan-summary JSON helpers
+   extracted to [Server_dashboard_http_keeper_api_scan_summary]
+   (godfile decomp). Local aliases keep call sites byte-identical. *)
+module Scan_summary = Server_dashboard_http_keeper_api_scan_summary
 
-let read_receipt_rows ~keeper_name ~trace_id ?turn_id paths =
-  paths
-  |> List.concat_map (fun path ->
-       Fs_compat.fold_jsonl_lines
-         ~init:[]
-         ~f:(fun acc ~line_no:_ json ->
-           if receipt_row_matches ?turn_id keeper_name trace_id json then
-             json :: acc
-           else acc)
-         path
-       |> List.rev)
-
-let unique_ints values =
-  values
-  |> List.sort_uniq Int.compare
-
-let json_int_list values =
-  `List (List.map (fun value -> `Int value) values)
-
-let json_int_opt = function
-  | None -> `Null
-  | Some value -> `Int value
-
-let json_string_list values =
-  `List (List.map (fun value -> `String value) values)
-
-let event_bus_summary_json scan =
-  let correlation_ids =
-    scan.event_bus_correlation_ids
-    |> List.rev
-    |> Json_util.dedupe_keep_order
-  in
-  let run_ids =
-    scan.event_bus_run_ids |> List.rev |> Json_util.dedupe_keep_order
-  in
-  let last_compaction =
-    match scan.last_compaction with
-    | Some value -> value
-    | None -> `Null
-  in
-  `Assoc
-    [
-      ("event_bus_correlated_count", `Int scan.event_bus_count);
-      ("correlation_ids", json_string_list correlation_ids);
-      ("run_ids", json_string_list run_ids);
-      ( "context_compact_started_count",
-        `Int scan.context_compact_started_count );
-      ( "context_compacted_count",
-        `Int scan.context_compacted_count );
-      ("last_compaction", last_compaction);
-    ]
-
-let memory_summary_json scan =
-  `Assoc
-    [
-      ("memory_injected_count", `Int scan.memory_injected_count);
-      ( "memory_injected_present_count",
-        `Int scan.memory_injected_present_count );
-      ("memory_flushed_count", `Int scan.memory_flushed_count);
-      ("memory_flush_success_count", `Int scan.memory_flush_success_count);
-      ("memory_flush_error_count", `Int scan.memory_flush_error_count);
-      ("episodes_flushed", `Int scan.episodes_flushed);
-      ("procedures_flushed", `Int scan.procedures_flushed);
-    ]
+let receipt_row_matches = Scan_summary.receipt_row_matches
+let read_receipt_rows = Scan_summary.read_receipt_rows
+let unique_ints = Scan_summary.unique_ints
+let json_int_list = Scan_summary.json_int_list
+let json_int_opt = Scan_summary.json_int_opt
+let json_string_list = Scan_summary.json_string_list
+let event_bus_summary_json = Scan_summary.event_bus_summary_json
+let memory_summary_json = Scan_summary.memory_summary_json
 
 include Server_dashboard_http_keeper_runtime_lens_swimlane
 
-let max_int_list_opt values =
-  List.fold_left
-    (fun acc value ->
-      match acc with
-      | None -> Some value
-      | Some existing -> Some (max existing value))
-    None
-    values
-
-let selected_keeper_turn_id ?turn_id scan =
-  match turn_id with
-  | Some value -> Some value
-  | None -> max_int_list_opt scan.keeper_turn_ids
-
-let terminal_event_present_for_turn ?keeper_turn_id scan =
-  match keeper_turn_id with
-  | Some value -> List.mem value scan.terminal_keeper_turn_ids
-  | None -> scan.has_terminal
+let max_int_list_opt = Scan_summary.max_int_list_opt
+let selected_keeper_turn_id = Scan_summary.selected_keeper_turn_id
+let terminal_event_present_for_turn = Scan_summary.terminal_event_present_for_turn
 
 (* first_string_opt / first_int_opt / string_has_prefix moved to
    Server_dashboard_http_keeper_api_types (intra-library file split,

--- a/lib/server/server_dashboard_http_keeper_api_scan_summary.ml
+++ b/lib/server/server_dashboard_http_keeper_api_scan_summary.ml
@@ -1,0 +1,117 @@
+(** Runtime-manifest scan: receipt-matching + summary-JSON helpers.
+
+    Extracted from [server_dashboard_http_keeper_api.ml] (lines
+    141-235) as part of the godfile decomp campaign. Pure helper
+    functions over the
+    [Server_dashboard_http_keeper_runtime_manifest_scan.runtime_manifest_scan] record and
+    JSONL receipt rows on disk.
+
+    Surface ownership:
+    - receipt row matching ({!receipt_row_matches}, {!read_receipt_rows})
+      — operate on raw [Yojson.Safe.t] rows + paths;
+    - generic JSON helpers ({!unique_ints}, {!json_int_list},
+      {!json_int_opt}, {!json_string_list}) — local single-use sugar;
+    - per-section scan summaries ({!event_bus_summary_json},
+      {!memory_summary_json}) — fold the manifest scan record into a
+      single [`Assoc] for dashboard payload;
+    - turn-id selection helpers ({!max_int_list_opt},
+      {!selected_keeper_turn_id}, {!terminal_event_present_for_turn})
+      — used to pick the active keeper turn for runtime-lens. *)
+
+open Server_dashboard_http_keeper_api_types
+
+let receipt_row_matches ?turn_id keeper_name trace_id json =
+  let keeper_matches = json_string_member_opt "keeper_name" json = Some keeper_name in
+  let trace_matches = json_string_member_opt "trace_id" json = Some trace_id in
+  let turn_matches =
+    match turn_id with
+    | None -> false
+    | Some wanted -> json_int_member_opt "turn_count" json = Some wanted
+  in
+  keeper_matches && (trace_matches || turn_matches)
+;;
+
+let read_receipt_rows ~keeper_name ~trace_id ?turn_id paths =
+  paths
+  |> List.concat_map (fun path ->
+    Fs_compat.fold_jsonl_lines
+      ~init:[]
+      ~f:(fun acc ~line_no:_ json ->
+        if receipt_row_matches ?turn_id keeper_name trace_id json then json :: acc else acc)
+      path
+    |> List.rev)
+;;
+
+let unique_ints values = values |> List.sort_uniq Int.compare
+let json_int_list values = `List (List.map (fun value -> `Int value) values)
+
+let json_int_opt = function
+  | None -> `Null
+  | Some value -> `Int value
+;;
+
+let json_string_list values = `List (List.map (fun value -> `String value) values)
+
+let event_bus_summary_json
+      (scan : Server_dashboard_http_keeper_runtime_manifest_scan.runtime_manifest_scan)
+  =
+  let correlation_ids =
+    scan.event_bus_correlation_ids |> List.rev |> Json_util.dedupe_keep_order
+  in
+  let run_ids = scan.event_bus_run_ids |> List.rev |> Json_util.dedupe_keep_order in
+  let last_compaction =
+    match scan.last_compaction with
+    | Some value -> value
+    | None -> `Null
+  in
+  `Assoc
+    [ "event_bus_correlated_count", `Int scan.event_bus_count
+    ; "correlation_ids", json_string_list correlation_ids
+    ; "run_ids", json_string_list run_ids
+    ; "context_compact_started_count", `Int scan.context_compact_started_count
+    ; "context_compacted_count", `Int scan.context_compacted_count
+    ; "last_compaction", last_compaction
+    ]
+;;
+
+let memory_summary_json
+      (scan : Server_dashboard_http_keeper_runtime_manifest_scan.runtime_manifest_scan)
+  =
+  `Assoc
+    [ "memory_injected_count", `Int scan.memory_injected_count
+    ; "memory_injected_present_count", `Int scan.memory_injected_present_count
+    ; "memory_flushed_count", `Int scan.memory_flushed_count
+    ; "memory_flush_success_count", `Int scan.memory_flush_success_count
+    ; "memory_flush_error_count", `Int scan.memory_flush_error_count
+    ; "episodes_flushed", `Int scan.episodes_flushed
+    ; "procedures_flushed", `Int scan.procedures_flushed
+    ]
+;;
+
+let max_int_list_opt values =
+  List.fold_left
+    (fun acc value ->
+       match acc with
+       | None -> Some value
+       | Some existing -> Some (max existing value))
+    None
+    values
+;;
+
+let selected_keeper_turn_id
+      ?turn_id
+      (scan : Server_dashboard_http_keeper_runtime_manifest_scan.runtime_manifest_scan)
+  =
+  match turn_id with
+  | Some value -> Some value
+  | None -> max_int_list_opt scan.keeper_turn_ids
+;;
+
+let terminal_event_present_for_turn
+      ?keeper_turn_id
+      (scan : Server_dashboard_http_keeper_runtime_manifest_scan.runtime_manifest_scan)
+  =
+  match keeper_turn_id with
+  | Some value -> List.mem value scan.terminal_keeper_turn_ids
+  | None -> scan.has_terminal
+;;

--- a/lib/server/server_dashboard_http_keeper_api_scan_summary.mli
+++ b/lib/server/server_dashboard_http_keeper_api_scan_summary.mli
@@ -1,0 +1,77 @@
+(** Runtime-manifest scan: receipt-matching + summary-JSON helpers.
+
+    Pure helpers over [Server_dashboard_http_keeper_runtime_manifest_scan]
+    state and JSONL receipt rows on disk. No side effects beyond
+    reading the receipt files in {!read_receipt_rows}. *)
+
+(** [receipt_row_matches ?turn_id keeper_name trace_id json] returns
+    [true] when [json] is a receipt row whose [keeper_name] equals
+    [keeper_name] AND whose [trace_id] or [turn_count] matches the
+    arguments. When [turn_id] is [None], only [trace_id] matching is
+    considered. *)
+val receipt_row_matches
+  :  ?turn_id:int
+  -> string
+  -> string
+  -> Yojson.Safe.t
+  -> bool
+
+(** [read_receipt_rows ~keeper_name ~trace_id ?turn_id paths] reads
+    every JSONL receipt under [paths] and returns the rows that match
+    {!receipt_row_matches}. Result is in file order; subsequent
+    [paths] are concatenated. *)
+val read_receipt_rows
+  :  keeper_name:string
+  -> trace_id:string
+  -> ?turn_id:int
+  -> string list
+  -> Yojson.Safe.t list
+
+(** [unique_ints values] returns [values] in ascending order with
+    duplicates removed. *)
+val unique_ints : int list -> int list
+
+(** [json_int_list values] wraps [values] as [`List] of [`Int]. *)
+val json_int_list : int list -> Yojson.Safe.t
+
+(** [json_int_opt v] returns [`Int n] when [v = Some n], [`Null]
+    otherwise. *)
+val json_int_opt : int option -> Yojson.Safe.t
+
+(** [json_string_list values] wraps [values] as [`List] of [`String]. *)
+val json_string_list : string list -> Yojson.Safe.t
+
+(** [event_bus_summary_json scan] folds the event-bus / context-compact
+    counters out of [scan] into a single [`Assoc] payload for the
+    dashboard. Correlation IDs and run IDs are reversed and
+    deduplicated (preserving first-seen order). *)
+val event_bus_summary_json
+  :  Server_dashboard_http_keeper_runtime_manifest_scan.runtime_manifest_scan
+  -> Yojson.Safe.t
+
+(** [memory_summary_json scan] returns an [`Assoc] of the seven
+    memory-related counters held in [scan]. *)
+val memory_summary_json
+  :  Server_dashboard_http_keeper_runtime_manifest_scan.runtime_manifest_scan
+  -> Yojson.Safe.t
+
+(** [max_int_list_opt values] returns the maximum element of [values],
+    or [None] when [values] is empty. *)
+val max_int_list_opt : int list -> int option
+
+(** [selected_keeper_turn_id ?turn_id scan] returns [Some n] when
+    [turn_id = Some n], otherwise the maximum [keeper_turn_ids] in
+    [scan] (or [None] when the list is empty). *)
+val selected_keeper_turn_id
+  :  ?turn_id:int
+  -> Server_dashboard_http_keeper_runtime_manifest_scan.runtime_manifest_scan
+  -> int option
+
+(** [terminal_event_present_for_turn ?keeper_turn_id scan] returns
+    [true] when the manifest scan saw a terminal event for the
+    specified turn (or any terminal event when [keeper_turn_id] is
+    [None]). *)
+val terminal_event_present_for_turn
+  :  ?keeper_turn_id:int
+  -> Server_dashboard_http_keeper_runtime_manifest_scan.runtime_manifest_scan
+  -> bool


### PR DESCRIPTION
## 요약

\`server_dashboard_http_keeper_api.ml\` (godfile, 2070 LoC) 의
runtime-manifest scan summary + receipt-matching helper 클러스터
(lines 141-235) 를 sibling 모듈로 추출. 본 PR 머지 후 2070 → 1994
(−76, −3.7%).

## 추출된 함수

- \`receipt_row_matches\` / \`read_receipt_rows\` — JSONL receipt rows
  fold + (keeper_name, trace_id, ?turn_id) match
- \`unique_ints\` / \`json_int_list\` / \`json_int_opt\` /
  \`json_string_list\` — single-use JSON sugar
- \`event_bus_summary_json\` / \`memory_summary_json\` —
  runtime_manifest_scan record → \`\`\`Assoc\`\`\` dashboard payload
- \`max_int_list_opt\` / \`selected_keeper_turn_id\` /
  \`terminal_event_present_for_turn\` — turn-id selection helpers

## 패턴

이전 PR (#16786, #16792) 의 *alias re-export* 패턴:
- 새 모듈 \`Server_dashboard_http_keeper_api_scan_summary\` 가 types 모듈
  + runtime_manifest_scan record 만 의존. back-edge 없음.
- 11 함수 모두 0 external qualified caller (rg 확인). 
- 공개 surface 는 parent 의 alias 로 byte-identical 유지.

## 검증

\`\`\`
$ dune build --root . @check    # exit 0
\`\`\`

관련 단위 테스트 없음 — integration path 로만 호출됨.

## LoC

| 파일 | LoC |
|------|-----|
| server_dashboard_http_keeper_api.ml | 2070 → 1994 (−76) |
| server_dashboard_http_keeper_api_scan_summary.ml (new) | 117 |
| .mli (new) | 77 |
| 본 PR diff | +209 / −91 |

## RFC

RFC-WAIVED: pure mechanical extraction of internal helpers within
\`lib/server/\`. Touches no credential / identity / operator_control /
sandbox / hooks / workflow subsystem. Public surface preserved.