### PR TITLE
fix(keeper): surface capacity backpressure blockers

### DIFF
--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -24,6 +24,10 @@ val is_server_rejected_parse_error : Agent_sdk.Error.sdk_error -> bool
     by returning text/no-op where a ToolUse block was required. *)
 val is_required_tool_contract_violation : Agent_sdk.Error.sdk_error -> bool
 
+(** [true] when free-form provider/cascade detail text carries a capacity
+    backpressure signal such as provider slot exhaustion. *)
+val message_looks_like_capacity_backpressure : string -> bool
+
 (** [true] when the keeper should preserve liveness and skip consecutive
     failure counting, even if same-turn retry is still disabled. *)
 val is_auto_recoverable_turn_error : Agent_sdk.Error.sdk_error -> bool

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -91,6 +91,7 @@ type cascade_exhaustion_reason =
 
 type blocker_class =
   | Cascade_exhausted of cascade_exhaustion_reason
+  | Capacity_exhausted
   | Ambiguous_post_commit_timeout
   | Ambiguous_post_commit_failure
   | Autonomous_slot_wait_timeout
@@ -137,6 +138,7 @@ type blocker_class =
 
 let blocker_class_to_string = function
   | Cascade_exhausted _ -> "cascade_exhausted"
+  | Capacity_exhausted -> "capacity_exhausted"
   | Ambiguous_post_commit_timeout -> "ambiguous_post_commit_timeout"
   | Ambiguous_post_commit_failure -> "ambiguous_post_commit_failure"
   | Autonomous_slot_wait_timeout -> "autonomous_slot_wait_timeout"
@@ -164,6 +166,7 @@ let blocker_class_to_string = function
 
 let blocker_class_of_serialized_string = function
   | "cascade_exhausted" -> Some (Cascade_exhausted (Other_detail "cascade_exhausted"))
+  | "capacity_exhausted" -> Some Capacity_exhausted
   | "ambiguous_post_commit_timeout" -> Some Ambiguous_post_commit_timeout
   | "ambiguous_post_commit_failure" -> Some Ambiguous_post_commit_failure
   | "autonomous_slot_wait_timeout" -> Some Autonomous_slot_wait_timeout
@@ -207,6 +210,7 @@ let blocker_class_continue_gate = function
   | Ambiguous_post_commit_timeout
   | Ambiguous_post_commit_failure -> true
   | Cascade_exhausted _
+  | Capacity_exhausted
   | Autonomous_slot_wait_timeout
   | Admission_queue_wait_timeout
   | Turn_timeout_after_queue_wait

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -149,6 +149,7 @@ type cascade_exhaustion_reason =
 
 type blocker_class =
   | Cascade_exhausted of cascade_exhaustion_reason
+  | Capacity_exhausted
   | Ambiguous_post_commit_timeout
   | Ambiguous_post_commit_failure
   | Autonomous_slot_wait_timeout

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -69,6 +69,7 @@ let blocker_class_indicates_overflow (klass : blocker_class) : bool =
   match klass with
   | Sdk_token_budget_exceeded -> true
   | Cascade_exhausted _
+  | Capacity_exhausted
   | Ambiguous_post_commit_timeout
   | Ambiguous_post_commit_failure
   | Autonomous_slot_wait_timeout

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -158,6 +158,12 @@ let blocker_class_of_string (reason : string) : blocker_class option =
   if trimmed = ""
   then None
   else if
+    String_util.contains_substring_ci trimmed "capacity_exhausted"
+    || String_util.contains_substring_ci trimmed "capacity exhausted"
+    || String_util.contains_substring_ci trimmed "slot full"
+    || String_util.contains_substring_ci trimmed "client capacity"
+  then Some Capacity_exhausted
+  else if
     String_util.contains_substring_ci
       trimmed
       "turn outcome ambiguous after committed mutating tool call(s)"
@@ -214,6 +220,9 @@ let blocker_class_of_string (reason : string) : blocker_class option =
 ;;
 
 let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class option =
+  match Keeper_error_classify.recoverable_cascade_failure_reason err with
+  | Some Keeper_error_classify.Capacity_exhausted -> Some Capacity_exhausted
+  | _ ->
   match Keeper_turn_driver.classify_masc_internal_error err with
   | Some (Keeper_turn_driver.Cascade_exhausted { reason; _ }) ->
     Some (Cascade_exhausted reason)
@@ -269,6 +278,15 @@ type runtime_blocker_surface =
   ; continue_gate : bool
   }
 
+let runtime_blocker_class_label ?(summary = "") cls =
+  match cls with
+  | Capacity_exhausted -> "capacity_exhausted"
+  | Cascade_exhausted (Other_detail detail)
+    when Keeper_error_classify.message_looks_like_capacity_backpressure detail
+         || Keeper_error_classify.message_looks_like_capacity_backpressure summary ->
+      "capacity_exhausted"
+  | _ -> blocker_class_to_string cls
+
 let is_timeout_budget_blocker_class blocker_class =
   String.equal blocker_class (blocker_class_to_string Oas_timeout_budget)
   || String.equal blocker_class (blocker_class_to_string Turn_timeout)
@@ -277,10 +295,19 @@ let is_timeout_budget_blocker_class blocker_class =
 let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
   : runtime_blocker_surface
   =
-  let str = blocker_class_to_string cls in
+  let str = runtime_blocker_class_label ~summary cls in
   let continue_gate = blocker_class_continue_gate cls in
   let summary =
     match cls with
+    | Capacity_exhausted ->
+      if summary = ""
+      then "Provider or client capacity backpressure blocked this keeper turn."
+      else summary
+    | Cascade_exhausted (Other_detail _)
+      when String.equal str "capacity_exhausted" ->
+      if summary = ""
+      then "Provider or client capacity backpressure blocked this keeper turn."
+      else summary
     | Cascade_exhausted reason ->
       if summary = ""
       then cascade_exhaustion_summary reason
@@ -340,11 +367,12 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
 
 let runtime_blocker_surface_of_legacy_string reason cls =
   match cls with
-  | Cascade_exhausted _ -> runtime_blocker_surface_of_typed_class cls
+  | Cascade_exhausted _ -> runtime_blocker_surface_of_typed_class ~summary:reason cls
   (* All other blocker classes carry no embedded reason payload, so the
      legacy string [reason] argument provides the fallback summary. *)
   | Ambiguous_post_commit_timeout
   | Ambiguous_post_commit_failure
+  | Capacity_exhausted
   | Autonomous_slot_wait_timeout
   | Admission_queue_wait_timeout
   | Turn_timeout_after_queue_wait

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -169,6 +169,7 @@ type cascade_exhaustion_reason = Keeper_meta_contract.cascade_exhaustion_reason 
 
 type blocker_class = Keeper_meta_contract.blocker_class =
   | Cascade_exhausted of cascade_exhaustion_reason
+  | Capacity_exhausted
   | Ambiguous_post_commit_timeout
   | Ambiguous_post_commit_failure
   | Autonomous_slot_wait_timeout

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -240,7 +240,12 @@ let effective_autoboot_enabled name (meta : Keeper_types.keeper_meta) =
 
 let blocker_class_string (info : Keeper_types.blocker_info option) =
   match info with
-  | Some info -> Some (Keeper_types.blocker_class_to_string info.klass)
+  | Some info ->
+      let surface =
+        Keeper_status_bridge.runtime_blocker_surface_of_typed_class
+          ~summary:info.detail info.klass
+      in
+      Some surface.blocker_class
   | None -> None
 
 let blocker_detail (info : Keeper_types.blocker_info option) =

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -41,6 +41,15 @@ let test_stale_fleet_batch_blocker_class_roundtrip () =
   | Some _ -> fail "Stale_fleet_batch label parsed as wrong class"
   | None -> fail "Stale_fleet_batch label did not parse back"
 
+let test_capacity_exhausted_blocker_class_roundtrip () =
+  let cls = KT.Capacity_exhausted in
+  let label = KT.blocker_class_to_string cls in
+  check string "label" "capacity_exhausted" label;
+  match MC.blocker_class_of_serialized_string label with
+  | Some MC.Capacity_exhausted -> ()
+  | Some _ -> fail "Capacity_exhausted label parsed as wrong class"
+  | None -> fail "Capacity_exhausted label did not parse back"
+
 let test_blocker_class_labels_are_distinct () =
   let tt = KT.blocker_class_to_string KT.Turn_timeout in
   let ot = KT.blocker_class_to_string KT.Oas_timeout_budget in
@@ -134,6 +143,8 @@ let () =
             test_oas_timeout_budget_blocker_class_roundtrip;
           test_case "Stale_fleet_batch roundtrip" `Quick
             test_stale_fleet_batch_blocker_class_roundtrip;
+          test_case "Capacity_exhausted roundtrip" `Quick
+            test_capacity_exhausted_blocker_class_roundtrip;
           test_case "labels are distinct" `Quick
             test_blocker_class_labels_are_distinct;
         ] );

--- a/test/test_keeper_blocker_class_completion_contract.ml
+++ b/test/test_keeper_blocker_class_completion_contract.ml
@@ -13,6 +13,7 @@
 open Alcotest
 module KT = Masc_mcp.Keeper_types
 module B = Masc_mcp.Keeper_status_bridge
+module Owne = Masc_mcp.Keeper_turn_driver
 
 let check_completion_contract_class label cls_opt =
   match cls_opt with
@@ -23,6 +24,19 @@ let check_completion_contract_class label cls_opt =
               label other_str)
   | None ->
       fail (Printf.sprintf "%s returned None, expected Completion_contract_violation" label)
+
+let check_capacity_class label cls_opt =
+  match cls_opt with
+  | Some KT.Capacity_exhausted -> ()
+  | Some other ->
+      let other_str = KT.blocker_class_to_string other in
+      fail
+        (Printf.sprintf
+           "%s mapped to %s, expected Capacity_exhausted"
+           label
+           other_str)
+  | None ->
+      fail (Printf.sprintf "%s returned None, expected Capacity_exhausted" label)
 
 let test_completion_contract_text_maps () =
   let msg = "Completion contract [require_tool_use] violated: actionable \
@@ -73,6 +87,35 @@ let test_turn_livelock_text_maps () =
       fail ("turn livelock mapped to " ^ KT.blocker_class_to_string other)
   | None -> fail "turn livelock returned None"
 
+let test_capacity_backpressure_text_maps () =
+  check_capacity_class
+    "slot-full text"
+    (B.blocker_class_of_string
+       "Internal error: [masc_oas_error] {\"kind\":\"cascade_exhausted\",\
+        \"reason\":{\"tag\":\"other_detail\",\"message\":\"slot full, cascading \
+        to next provider\"}}")
+
+let test_capacity_backpressure_sdk_error_maps () =
+  let err =
+    Owne.sdk_error_of_masc_internal_error
+      (Owne.Cascade_exhausted
+         {
+           cascade_name = Owne.cascade_name_of_string "strict_tool_candidates";
+           reason = KT.Other_detail "slot full, cascading to next provider";
+         })
+  in
+  check_capacity_class "slot-full structured SDK error"
+    (B.blocker_class_of_sdk_error err)
+
+let test_capacity_backpressure_runtime_surface_maps_legacy_cascade () =
+  let surface =
+    B.runtime_blocker_surface_of_typed_class
+      ~summary:"slot full, cascading to next provider"
+      (KT.Cascade_exhausted (KT.Other_detail "cascade_exhausted"))
+  in
+  check string "runtime blocker class" "capacity_exhausted"
+    surface.blocker_class
+
 let () =
   run "keeper_blocker_class_completion_contract"
     [
@@ -97,5 +140,11 @@ let () =
           test_case "existing turn-timeout mapping unchanged" `Quick
             test_existing_mappings_unchanged;
           test_case "turn livelock text maps" `Quick test_turn_livelock_text_maps;
+          test_case "capacity backpressure text maps" `Quick
+            test_capacity_backpressure_text_maps;
+          test_case "capacity backpressure SDK error maps" `Quick
+            test_capacity_backpressure_sdk_error_maps;
+          test_case "capacity backpressure runtime surface maps legacy cascade" `Quick
+            test_capacity_backpressure_runtime_surface_maps_legacy_cascade;
         ] );
     ]

--- a/test/test_keeper_rollover_gate.ml
+++ b/test/test_keeper_rollover_gate.ml
@@ -41,6 +41,7 @@ let non_overflow_classes_are_not_matched () =
     KT.Cascade_exhausted KT.No_providers_available;
     KT.Cascade_exhausted KT.All_providers_failed;
     KT.Cascade_exhausted KT.Max_turns_exceeded;
+    KT.Capacity_exhausted;
     KT.Ambiguous_post_commit_timeout;
     KT.Ambiguous_post_commit_failure;
     KT.Autonomous_slot_wait_timeout;


### PR DESCRIPTION
## Summary
- add a typed capacity_exhausted keeper blocker class for provider/client backpressure
- map slot-full cascade exhaustion and raw provider CapacityExhausted SDK errors into that blocker class
- surface legacy cascade_exhausted + slot-full paused keeper records as capacity_exhausted in runtime/full-health dashboard JSON

## Verification
- ocamlformat --check lib/keeper/keeper_meta_contract.ml lib/keeper/keeper_meta_contract.mli lib/keeper/keeper_types.mli lib/keeper/keeper_status_bridge.ml lib/keeper/keeper_error_classify.mli lib/keeper/keeper_rollover.ml lib/server/server_routes_http_runtime.ml test/test_keeper_blocker_class_completion_contract.ml test/test_keeper_auto_pause_blocker_persist_12683.ml test/test_keeper_rollover_gate.ml
- git diff --check
- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_JOBS=1 scripts/dune-local.sh build test/test_keeper_error_classify_recoverable.exe test/test_keeper_blocker_class_completion_contract.exe test/test_keeper_auto_pause_blocker_persist_12683.exe test/test_keeper_rollover_gate.exe
- ./_build/default/test/test_keeper_error_classify_recoverable.exe --color=never
- ./_build/default/test/test_keeper_blocker_class_completion_contract.exe --color=never
- ./_build/default/test/test_keeper_auto_pause_blocker_persist_12683.exe --color=never
- ./_build/default/test/test_keeper_rollover_gate.exe --color=never