### PR TITLE
refactor(keeper_shell_docker): extract docker exec failure pipeline into sibling module

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -8,116 +8,24 @@
 open Keeper_types
 open Keeper_exec_shared
 
-(* docker exec 실패 시 진단성 보강용 helper. 이전 message format
-   `failed (image): <output>` 에서 output 이 empty 면 진단 불가
-   (cycle22 fleet log: 30분간 5건 발생, detail 모두 empty).
-   exit/signal status + output empty placeholder 로 root cause 식별
-   가능하게 한다. *)
-let docker_exec_status_label = function
-  | Unix.WEXITED n -> Printf.sprintf "exit=%d" n
-  | Unix.WSIGNALED n -> Printf.sprintf "signal=%d" n
-  | Unix.WSTOPPED n -> Printf.sprintf "stopped=%d" n
+(* Docker exec failure formatting + recording extracted to
+   [Keeper_shell_docker_exec_failure] (godfile decomp). Local aliases
+   keep call sites byte-identical.
+
+   Previous message format `failed (image): <output>` lost diagnosability
+   when output was empty (cycle22 fleet log: 30분간 5건, detail empty).
+   Exit/signal status + empty placeholder identify root cause. *)
+module Exec_failure = Keeper_shell_docker_exec_failure
+
+let docker_exec_status_label = Exec_failure.docker_exec_status_label
+let docker_exec_failure_message_internal = Exec_failure.docker_exec_failure_message_internal
+let docker_exec_failure_message = Exec_failure.docker_exec_failure_message
+
+let docker_exec_failure_message_with_context =
+  Exec_failure.docker_exec_failure_message_with_context
 ;;
 
-let docker_exec_failure_message_internal
-      ?base_path_hash
-      ?keeper_name
-      ?container_kind
-      ?network_label
-      ~image
-      ~status
-      ~output
-      ()
-  =
-  let truncated = Keeper_sandbox_runtime.docker_failure_output_for_log output in
-  let output_label = if String.trim truncated = "" then "<no output>" else truncated in
-  let missing_cwd_hint =
-    if
-      String_util.contains_substring output "cd:"
-      && String_util.contains_substring output "No such file or directory"
-    then
-      " hint=cwd_not_directory: create or repair the sandbox repo/worktree first \
-       (keeper_shell op=git_clone, then git_worktree/masc_worktree_create for \
-       repos/<repo>/.worktrees/<task>)."
-    else ""
-  in
-  let mount_failure_context =
-    Keeper_sandbox_runtime.docker_mount_failure_context_suffix
-      ?base_path_hash
-      ?keeper_name
-      ~image
-      ~status_label:(docker_exec_status_label status)
-      ?container_kind
-      ?network_label
-      output
-  in
-  Printf.sprintf
-    "sandbox docker exec failed (%s, %s): %s%s%s"
-    image
-    (docker_exec_status_label status)
-    output_label
-    missing_cwd_hint
-    mount_failure_context
-;;
-
-let docker_exec_failure_message ~image ~status ~output =
-  docker_exec_failure_message_internal ~image ~status ~output ()
-;;
-
-let docker_exec_failure_message_with_context
-      ~base_path_hash
-      ~keeper_name
-      ~container_kind
-      ~network_label
-      ~image
-      ~status
-      ~output
-  =
-  docker_exec_failure_message_internal
-    ~base_path_hash
-    ~keeper_name
-    ~container_kind
-    ~network_label
-    ~image
-    ~status
-    ~output
-    ()
-;;
-
-let record_docker_exec_failure
-      ~(config : Coord.config)
-      ~(meta : keeper_meta)
-      ~image
-      ~container_kind
-      ~network_label
-      ~status
-      ~output
-  =
-  let base_path_hash = Keeper_sandbox_runtime.base_path_hash config.base_path in
-  let status_label = docker_exec_status_label status in
-  let message =
-    docker_exec_failure_message_with_context
-      ~base_path_hash
-      ~keeper_name:meta.name
-      ~container_kind
-      ~network_label
-      ~image
-      ~status
-      ~output
-  in
-  let details =
-    Keeper_sandbox_runtime.docker_mount_failure_details
-      ~base_path_hash
-      ~keeper_name:meta.name
-      ~image
-      ~status_label
-      ~container_kind
-      ~network_label
-      ~output
-      ()
-  in
-  Keeper_registry_error_recording.record ?details ~base_path:config.base_path meta.name message
-;;
+let record_docker_exec_failure = Exec_failure.record_docker_exec_failure
 
 let path_exists path =
   try Sys.file_exists path with

--- a/lib/keeper/keeper_shell_docker_exec_failure.ml
+++ b/lib/keeper/keeper_shell_docker_exec_failure.ml
@@ -1,0 +1,125 @@
+(** Docker exec failure formatting + recording.
+
+    Extracted from [keeper_shell_docker.ml] (lines 16-120) as part of
+    the godfile decomp campaign. Owns the failure-message pipeline:
+
+    1. [docker_exec_status_label] — exit-status → wire label
+    2. [docker_exec_failure_message_internal] — full message with
+       optional context (base_path_hash, keeper_name, container_kind,
+       network_label) + missing-cwd hint + mount-failure context
+       suffix.
+    3. [docker_exec_failure_message] — context-less convenience
+       wrapper (kept for an existing external caller).
+    4. [docker_exec_failure_message_with_context] — required-context
+       wrapper used by [record_docker_exec_failure].
+    5. [record_docker_exec_failure] — persists the failure on the
+       keeper registry (via [Keeper_registry_error_recording.record])
+       along with structured [docker_mount_failure_details]. *)
+
+open Keeper_types
+
+let docker_exec_status_label = function
+  | Unix.WEXITED n -> Printf.sprintf "exit=%d" n
+  | Unix.WSIGNALED n -> Printf.sprintf "signal=%d" n
+  | Unix.WSTOPPED n -> Printf.sprintf "stopped=%d" n
+;;
+
+let docker_exec_failure_message_internal
+      ?base_path_hash
+      ?keeper_name
+      ?container_kind
+      ?network_label
+      ~image
+      ~status
+      ~output
+      ()
+  =
+  let truncated = Keeper_sandbox_runtime.docker_failure_output_for_log output in
+  let output_label = if String.trim truncated = "" then "<no output>" else truncated in
+  let missing_cwd_hint =
+    if
+      String_util.contains_substring output "cd:"
+      && String_util.contains_substring output "No such file or directory"
+    then
+      " hint=cwd_not_directory: create or repair the sandbox repo/worktree first \
+       (keeper_shell op=git_clone, then git_worktree/masc_worktree_create for \
+       repos/<repo>/.worktrees/<task>)."
+    else ""
+  in
+  let mount_failure_context =
+    Keeper_sandbox_runtime.docker_mount_failure_context_suffix
+      ?base_path_hash
+      ?keeper_name
+      ~image
+      ~status_label:(docker_exec_status_label status)
+      ?container_kind
+      ?network_label
+      output
+  in
+  Printf.sprintf
+    "sandbox docker exec failed (%s, %s): %s%s%s"
+    image
+    (docker_exec_status_label status)
+    output_label
+    missing_cwd_hint
+    mount_failure_context
+;;
+
+let docker_exec_failure_message ~image ~status ~output =
+  docker_exec_failure_message_internal ~image ~status ~output ()
+;;
+
+let docker_exec_failure_message_with_context
+      ~base_path_hash
+      ~keeper_name
+      ~container_kind
+      ~network_label
+      ~image
+      ~status
+      ~output
+  =
+  docker_exec_failure_message_internal
+    ~base_path_hash
+    ~keeper_name
+    ~container_kind
+    ~network_label
+    ~image
+    ~status
+    ~output
+    ()
+;;
+
+let record_docker_exec_failure
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+      ~image
+      ~container_kind
+      ~network_label
+      ~status
+      ~output
+  =
+  let base_path_hash = Keeper_sandbox_runtime.base_path_hash config.base_path in
+  let status_label = docker_exec_status_label status in
+  let message =
+    docker_exec_failure_message_with_context
+      ~base_path_hash
+      ~keeper_name:meta.name
+      ~container_kind
+      ~network_label
+      ~image
+      ~status
+      ~output
+  in
+  let details =
+    Keeper_sandbox_runtime.docker_mount_failure_details
+      ~base_path_hash
+      ~keeper_name:meta.name
+      ~image
+      ~status_label
+      ~container_kind
+      ~network_label
+      ~output
+      ()
+  in
+  Keeper_registry_error_recording.record ?details ~base_path:config.base_path meta.name message
+;;

--- a/lib/keeper/keeper_shell_docker_exec_failure.mli
+++ b/lib/keeper/keeper_shell_docker_exec_failure.mli
@@ -1,0 +1,61 @@
+(** Docker exec failure formatting + recording.
+
+    Single-concern module: format a structured failure message from a
+    [Unix.process_status] + raw output, and (optionally) persist it on
+    the keeper registry with [docker_mount_failure_details] for the
+    dashboard. *)
+
+open Keeper_types
+
+(** [docker_exec_status_label status] returns the wire label for
+    [status] (one of [exit=N], [signal=N], [stopped=N]). *)
+val docker_exec_status_label : Unix.process_status -> string
+
+(** [docker_exec_failure_message_internal ?base_path_hash ?keeper_name
+      ?container_kind ?network_label ~image ~status ~output ()] returns
+    the full human-readable failure message. Optional context fields
+    enable the mount-failure context suffix. *)
+val docker_exec_failure_message_internal
+  :  ?base_path_hash:string
+  -> ?keeper_name:string
+  -> ?container_kind:string
+  -> ?network_label:string
+  -> image:string
+  -> status:Unix.process_status
+  -> output:string
+  -> unit
+  -> string
+
+(** [docker_exec_failure_message ~image ~status ~output] is the
+    context-less convenience wrapper. *)
+val docker_exec_failure_message
+  :  image:string
+  -> status:Unix.process_status
+  -> output:string
+  -> string
+
+(** [docker_exec_failure_message_with_context …] is the
+    required-context wrapper used by [record_docker_exec_failure]. *)
+val docker_exec_failure_message_with_context
+  :  base_path_hash:string
+  -> keeper_name:string
+  -> container_kind:string
+  -> network_label:string
+  -> image:string
+  -> status:Unix.process_status
+  -> output:string
+  -> string
+
+(** [record_docker_exec_failure ~config ~meta ~image ~container_kind
+      ~network_label ~status ~output] persists the failure via
+    [Keeper_registry_error_recording.record], attaching
+    [docker_mount_failure_details] for the dashboard. *)
+val record_docker_exec_failure
+  :  config:Coord.config
+  -> meta:keeper_meta
+  -> image:string
+  -> container_kind:string
+  -> network_label:string
+  -> status:Unix.process_status
+  -> output:string
+  -> unit


### PR DESCRIPTION
## 요약

\`keeper_shell_docker.ml\` (godfile, 1659 LoC) 의 Docker exec failure
formatting + recording 파이프라인 (lines 16-120) 을 sibling 모듈로 추출.
본 PR 머지 후 1659 → 1567 (−92, −5.5%).

## 추출된 함수 (5)

- \`docker_exec_status_label\` — \`Unix.process_status\` → 와이어 레이블
- \`docker_exec_failure_message_internal\` — 전체 메시지 (image + status
  + truncated output + missing-cwd hint + mount-failure context suffix)
- \`docker_exec_failure_message\` — context 없는 wrapper (외부 caller 1)
- \`docker_exec_failure_message_with_context\` — 필수 context 받는 wrapper
- \`record_docker_exec_failure\` — \`Keeper_registry_error_recording.record\`
  로 영속화 + dashboard용 \`docker_mount_failure_details\` 첨부

5 함수가 동일 concern (docker exec 실패를 진단가능하게 만들기) 의 호출
스택 각 layer. cycle22 fleet log 30분 5건 empty-detail blind spot 으로
도입된 코드.

## 패턴

이전 PR 과 동일한 *alias re-export*:
- 새 모듈은 \`Keeper_types\` 만 open. upstream \`Keeper_sandbox_runtime\`
  + \`Keeper_registry_error_recording\` 호출. cycle 없음.
- \`keeper_shell_docker.ml\` 가 5 함수 모두 alias 재노출. 호출처
  byte-identical.

## 검증

\`\`\`
$ dune build --root . @check    # exit 0
\`\`\`

전용 단위 테스트 없음 — integration path 로 \`Keeper_registry_error_recording\`
부수효과 확인 (\`test_keeper_shell_docker_route\` 등).

## LoC

| 파일 | LoC |
|------|-----|
| keeper_shell_docker.ml | 1659 → 1567 (−92) |
| keeper_shell_docker_exec_failure.ml (new) | 125 |
| .mli (new) | 61 |
| 본 PR diff | +199 / −105 |

## RFC

RFC-WAIVED: pure mechanical extraction of internal helpers within
\`lib/keeper/\`. \`keeper_shell_*\` 는 RFC-gated subsystem 리스트
(credential / identity / operator_control / sandbox / hooks /
workflow) 에 없음. 추출된 함수는 *이미 실패한* docker exec output 을
포맷+영속화만 함 — docker exec 자체를 실행하지 않고 credential 이나
sandbox containment 정책에 접근하지 않음. 공개 surface 유지.