### PR TITLE
refactor(dashboard): typed membership-parse replaces 5 unsafe `as KeeperDiagnostic['<field>']` casts

### DIFF
--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -106,17 +106,74 @@ export function isVisibleDirectConversationEntry(entry: KeeperConversationEntry)
 
 // --- Normalizers ---
 
+// Closed runtime mirrors of the 5 narrow string unions inside
+// KeeperDiagnostic. The previous 5 `as KeeperDiagnostic['<field>']` casts
+// trusted whatever backend string arrived; these sets enforce the
+// boundary so an unrecognized value returns null (caller decides
+// fallback). Same shape as toKeeperPhase / toKeeperLifecycleState /
+// toPipelineStage (PRs #16745, #16788, #16791).
+//
+// Each set is typed as `KeeperDiagnostic['<field>']` (indexed access)
+// so drift between the set and the underlying private union in
+// types/core.ts surfaces as a tsc error here — no separate type
+// export needed.
+const KEEPER_HEALTH_STATES: ReadonlySet<NonNullable<KeeperDiagnostic['health_state']>> =
+  new Set<NonNullable<KeeperDiagnostic['health_state']>>([
+    'healthy', 'idle', 'stale', 'degraded', 'offline',
+  ])
+
+const KEEPER_QUIET_REASONS: ReadonlySet<NonNullable<KeeperDiagnostic['quiet_reason']>> =
+  new Set<NonNullable<KeeperDiagnostic['quiet_reason']>>([
+    'quiet_hours', 'min_gap', 'no_recent_activity', 'disabled',
+    'startup', 'model_error', 'graphql_error', 'never_started', 'unknown',
+  ])
+
+const KEEPER_NEXT_ACTION_PATHS: ReadonlySet<NonNullable<KeeperDiagnostic['next_action_path']>> =
+  new Set<NonNullable<KeeperDiagnostic['next_action_path']>>([
+    'direct_message', 'manual_social_sweep', 'probe', 'recover',
+  ])
+
+const KEEPER_REPLY_STATUSES: ReadonlySet<NonNullable<KeeperDiagnostic['last_reply_status']>> =
+  new Set<NonNullable<KeeperDiagnostic['last_reply_status']>>([
+    'never', 'awaiting_reply', 'delivered', 'fresh', 'stale', 'error', 'unknown',
+  ])
+
+const KEEPER_CONTINUITY_STATES: ReadonlySet<NonNullable<KeeperDiagnostic['continuity_state']>> =
+  new Set<NonNullable<KeeperDiagnostic['continuity_state']>>([
+    'not_running', 'recovering', 'healthy', 'disabled', 'offline',
+  ])
+
+// Generic typed-parse helper. Returns the input value typed as `T` if
+// `set` accepts it, else `null`. Callers compose with `?? <default>`
+// for the fallback. This pattern is repeated 3 times in other dashboard
+// modules (toKeeperPhase / toKeeperLifecycleState / toPipelineStage) —
+// a future refactor could extract it to a shared module if it appears
+// at a 4th boundary.
+function membershipParse<T extends string>(
+  set: ReadonlySet<T>,
+  raw: string | null | undefined,
+): T | null {
+  if (!raw) return null
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+  return set.has(trimmed as T) ? (trimmed as T) : null
+}
+
 export function normalizeKeeperDiagnostic(raw: unknown): KeeperDiagnostic | null {
   if (!isRecord(raw)) return null
-  const healthState = asString(raw.health_state)
-  const nextActionPath = asString(raw.next_action_path)
-  const lastReplyStatus = asString(raw.last_reply_status)
+  const healthState = membershipParse(KEEPER_HEALTH_STATES, asString(raw.health_state))
+  const nextActionPath = membershipParse(KEEPER_NEXT_ACTION_PATHS, asString(raw.next_action_path))
+  const lastReplyStatus = membershipParse(KEEPER_REPLY_STATUSES, asString(raw.last_reply_status))
+  // Reject the diagnostic entirely if any required field is invalid;
+  // the previous behaviour rejected when these were empty strings, so
+  // we preserve "reject on bad input" semantics while strengthening
+  // from "non-empty string" to "valid union member".
   if (!healthState || !nextActionPath || !lastReplyStatus) return null
   return {
-    health_state: healthState as KeeperDiagnostic['health_state'],
-    quiet_reason: (asString(raw.quiet_reason) ?? null) as KeeperDiagnostic['quiet_reason'],
-    next_action_path: nextActionPath as KeeperDiagnostic['next_action_path'],
-    last_reply_status: lastReplyStatus as KeeperDiagnostic['last_reply_status'],
+    health_state: healthState,
+    quiet_reason: membershipParse(KEEPER_QUIET_REASONS, asString(raw.quiet_reason)),
+    next_action_path: nextActionPath,
+    last_reply_status: lastReplyStatus,
     last_reply_at: toIsoTimestamp(raw.last_reply_at) ?? null, // undefined->null: field is string|null
     last_reply_preview: asString(raw.last_reply_preview) ?? null,
     last_error: asString(raw.last_error) ?? null,
@@ -124,8 +181,7 @@ export function normalizeKeeperDiagnostic(raw: unknown): KeeperDiagnostic | null
     recoverable: typeof raw.recoverable === 'boolean' ? raw.recoverable : undefined,
     summary: asString(raw.summary),
     keepalive_running: typeof raw.keepalive_running === 'boolean' ? raw.keepalive_running : undefined,
-    continuity_state:
-      (asString(raw.continuity_state) ?? null) as KeeperDiagnostic['continuity_state'],
+    continuity_state: membershipParse(KEEPER_CONTINUITY_STATES, asString(raw.continuity_state)),
     continuity_summary: asString(raw.continuity_summary) ?? null,
   }
 }


### PR DESCRIPTION
## Summary

`normalizeKeeperDiagnostic` at `dashboard/src/keeper-state.ts:109` used **5** `as KeeperDiagnostic['<field>']` casts directly on `asString(raw.<field>)`:

| Field | Cast (before) | Union (target) |
|---|---|---|
| `health_state` | `healthState as KeeperDiagnostic['health_state']` | `KeeperHealthState` (5 tags) |
| `quiet_reason` | `(asString(raw.quiet_reason) ?? null) as KeeperDiagnostic['quiet_reason']` | `KeeperQuietReason \| null` (9 tags) |
| `next_action_path` | `nextActionPath as KeeperDiagnostic['next_action_path']` | `KeeperNextActionPath` (4 tags) |
| `last_reply_status` | `lastReplyStatus as KeeperDiagnostic['last_reply_status']` | `KeeperReplyStatus` (7 tags) |
| `continuity_state` | `(asString(raw.continuity_state) ?? null) as KeeperDiagnostic['continuity_state']` | `KeeperContinuityState \| null` (5 tags) |

Each cast trusted whatever string arrived from the backend payload. A typo, new enum variant, or drift would be **silently** typed as the narrow union, polluting downstream typed code with values outside the union.

## Generic `membershipParse` helper

The `ReadonlySet`-based pattern now repeats 4× across the codebase (this PR + 3 priors). Introduced a single inline generic helper:

```ts
function membershipParse<T extends string>(
  set: ReadonlySet<T>,
  raw: string | null | undefined,
): T | null {
  if (!raw) return null
  const trimmed = raw.trim()
  if (!trimmed) return null
  return set.has(trimmed as T) ? (trimmed as T) : null
}
```

Used at all 5 sites with 5 const Sets typed as `ReadonlySet<NonNullable<KeeperDiagnostic['<field>']>>` — **indexed access**, no need to export the underlying private union types from `types/core.ts`.

If `KeeperDiagnostic`'s field type drifts from the const set, tsc fails compilation here, surfacing the drift at the boundary site.

## Behavior change (intentional, narrows the typed surface)

| Scenario | Before | After |
|---|---|---|
| Valid backend string | passes through (typed) | passes through (typed) |
| Invalid string in nullable field | passes through as lying union value | → `null` |
| Invalid string in required field | passes through as lying union value | rejects whole diagnostic (same as prior empty-string rejection at line 114) |

This narrows the surface — a backend drift that previously rendered as an unknown UI string now becomes "missing field" or "no diagnostic". Operators tracking drift should inspect the raw wire payload (kept in `JournalEntry`, separate surface).

## Verification

- `cd dashboard && pnpm tsc --noEmit` EXIT=0.
- `pnpm vitest run keeper-state`: **18/18 PASS** (existing tests still pass — the prior `as` casts were lying but no test happened to exercise an invalid-string input).
- +65/-9 LoC, single file.

## 4-PR sweep summary

| Boundary | Parser | PR |
|---|---|---|
| KeeperPhase (14 tags) | `toKeeperPhase` | #16745 |
| KeeperLifecycleState (13 tags) | `toKeeperLifecycleState` | #16788 |
| PipelineStage (11 tags) | `toPipelineStage` | #16791 |
| KeeperDiagnostic × 5 (30 tags total) | `membershipParse` | **this PR** |

A 5th appearance of the pattern would warrant extracting `membershipParse` to a shared module.

## Iter#67 context

Closes the dashboard `as <NarrowUnion>` cast anti-pattern across the major typed boundary surfaces. Future cast violations now diverge from this established 4-PR convention, easier to spot in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>