### PR TITLE
fix(keeper): warn on self-correcting tool errors

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -79,6 +79,48 @@ let idle_decision_to_label = function
   | Agent_sdk.Hooks.AdjustParams _ -> "adjust_params"
   | Agent_sdk.Hooks.ElicitInput _ -> "elicit_input"
 
+let failure_class_of_tool_error_json json =
+  let direct = Safe_ops.json_string_opt "failure_class" json in
+  let nested =
+    match Yojson.Safe.Util.member "detail" json with
+    | `Assoc _ as detail -> Safe_ops.json_string_opt "failure_class" detail
+    | _ -> None
+  in
+  match direct with
+  | Some _ -> direct
+  | None -> nested
+
+let failure_class_of_tool_error_text error =
+  try
+    let json = Yojson.Safe.from_string error in
+    failure_class_of_tool_error_json json
+  with
+  | _ -> None
+
+let tool_error_failure_class ?base_path error =
+  match Tool_output.decode_from_oas error with
+  | Tool_output.Inline inline -> failure_class_of_tool_error_text inline
+  | Tool_output.Stored { sha256; preview; _ } ->
+    let from_store =
+      match base_path with
+      | None -> None
+      | Some base_path ->
+        Safe_ops.protect ~default:None (fun () ->
+            let store = Tool_blob_store.create ~base_path in
+            match Tool_blob_store.fetch store ~sha256 with
+            | Some payload -> failure_class_of_tool_error_text payload
+            | None -> None)
+    in
+    (match from_store with
+     | Some _ -> from_store
+     | None -> failure_class_of_tool_error_text preview)
+
+let self_correcting_tool_failure_class ?base_path error =
+  match tool_error_failure_class ?base_path error with
+  | Some ("workflow_rejection" | "policy_rejection" as failure_class) ->
+    Some failure_class
+  | _ -> None
+
 module Gate_attempt = Keeper_hooks_oas_gate_attempt
 
 let render_pre_tool_gate_output = Gate_attempt.render_pre_tool_gate_output
@@ -715,49 +757,59 @@ let make_hooks
 
     on_tool_error = Some (function
       | Agent_sdk.Hooks.OnToolError { tool_name; error } ->
-        (* Always increment the durable Prometheus signal: noise
-           dedupe is a log-surface concern only; the counter carries
-           the count for dashboards and alert rules. *)
-        Prometheus.inc_counter
-          Keeper_metrics.metric_keeper_lifecycle_callback_failures
-          ~labels:[(label_keeper, (!meta_ref).name); (label_callback, callback_label_on_tool_error)]
-          ();
-        (* λ-HOOK-ERROR (2026-05-19) — typed dedupe of repeated
-           [on_tool_error] hook ERROR lines. system_log 1000-line
-           sample (keeper:verifier × Bash × 2, lifecycle-worker-fast-1
-           × masc_worktree_create × 2, lifecycle-reviewer-fast-1 ×
-           keeper_pr_review_comment × 2, analyst × masc_transition ×
-           2) shows the same (keeper, tool, error) triple recurring
-           across time; only the first occurrence carries
-           operator-visible ERROR value. See
-           lib/keeper_tool_hook_error_state for rationale. *)
         let keeper_name = (!meta_ref).name in
-        let error_signature = Keeper_tool_hook_error_state.normalize error in
-        (match
-           Keeper_tool_hook_error_state.record
-             ~keeper_name
-             ~tool_name
-             ~error_signature
-             ()
-         with
-         | `First ->
-           Log.Keeper.error "keeper:%s tool_error: %s — %s"
-             keeper_name tool_name error
-         | `Repeated n ->
-           Log.Keeper.debug
-             "keeper:%s tool_error repeated (total=%d, dedup): %s — %s"
-             keeper_name n tool_name error
-         | `Threshold_silence n ->
-           Log.Keeper.error
-             "keeper:%s tool_error threshold-silence after %d identical: %s — %s"
-             keeper_name n tool_name error;
+        (match self_correcting_tool_failure_class ~base_path:config.base_path error with
+         | Some failure_class ->
+           Log.Keeper.warn "keeper:%s tool_%s: %s — %s"
+             keeper_name failure_class tool_name error
+         | None ->
+           (* Always increment the durable Prometheus signal for real
+              tool/runtime failures: noise dedupe is a log-surface concern
+              only; the counter carries the count for dashboards and alert
+              rules. Deterministic workflow/policy rejections are handled
+              above as self-correcting control flow. *)
            Prometheus.inc_counter
              Keeper_metrics.metric_keeper_lifecycle_callback_failures
              ~labels:
                [ (label_keeper, keeper_name)
-               ; (label_callback, "on_tool_error_threshold_silence")
+               ; (label_callback, callback_label_on_tool_error)
                ]
-             ());
+             ();
+           (* λ-HOOK-ERROR (2026-05-19) — typed dedupe of repeated
+              [on_tool_error] hook ERROR lines. system_log 1000-line
+              sample (keeper:verifier × Bash × 2, lifecycle-worker-fast-1
+              × masc_worktree_create × 2, lifecycle-reviewer-fast-1 ×
+              keeper_pr_review_comment × 2, analyst × masc_transition ×
+              2) shows the same (keeper, tool, error) triple recurring
+              across time; only the first occurrence carries
+              operator-visible ERROR value. See
+              lib/keeper_tool_hook_error_state for rationale. *)
+           let error_signature = Keeper_tool_hook_error_state.normalize error in
+           (match
+              Keeper_tool_hook_error_state.record
+                ~keeper_name
+                ~tool_name
+                ~error_signature
+                ()
+            with
+            | `First ->
+              Log.Keeper.error "keeper:%s tool_error: %s — %s"
+                keeper_name tool_name error
+            | `Repeated n ->
+              Log.Keeper.debug
+                "keeper:%s tool_error repeated (total=%d, dedup): %s — %s"
+                keeper_name n tool_name error
+            | `Threshold_silence n ->
+              Log.Keeper.error
+                "keeper:%s tool_error threshold-silence after %d identical: %s — %s"
+                keeper_name n tool_name error;
+              Prometheus.inc_counter
+                Keeper_metrics.metric_keeper_lifecycle_callback_failures
+                ~labels:
+                  [ (label_keeper, keeper_name)
+                  ; (label_callback, "on_tool_error_threshold_silence")
+                  ]
+                ()));
         Agent_sdk.Hooks.Continue
       | _ -> Agent_sdk.Hooks.Continue);
 

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -80,11 +80,29 @@ let make_test_hooks keeper_name =
   Hooks.make_hooks ~config ~meta_ref ~generation:1 ()
 ;;
 
+let make_test_hooks_at_root keeper_name root =
+  let config = Masc_mcp.Coord.default_config root in
+  let meta_ref = ref (make_meta keeper_name) in
+  Hooks.make_hooks ~config ~meta_ref ~generation:1 ()
+;;
+
 let lifecycle_callback_failure_count ~keeper ~callback =
   Masc_mcp.Prometheus.metric_value_or_zero
     Masc_mcp.Keeper_metrics.metric_keeper_lifecycle_callback_failures
     ~labels:[ "keeper", keeper; "callback", callback ]
     ()
+;;
+
+let latest_log_seq () =
+  match Log.Ring.recent ~limit:1 () with
+  | entry :: _ -> entry.Log.Ring.seq
+  | [] -> -1
+;;
+
+let find_keeper_log_since ~since_seq ~message_substring =
+  Log.Ring.recent ~limit:50 ~module_filter:"Keeper" ~since_seq ()
+  |> List.find_opt (fun (entry : Log.Ring.entry) ->
+         String_util.contains_substring entry.message message_substring)
 ;;
 
 let on_stop_count ~keeper ~stop_reason =
@@ -1071,6 +1089,67 @@ let test_on_tool_error_hook_records_callback_failure_metric () =
   check (float 0.001) "on_tool_error counter increments" 1.0 (after -. before)
 ;;
 
+let test_on_tool_error_workflow_rejection_logs_warn_without_callback_failure () =
+  let keeper = "callback-on-tool-workflow-rejection-keeper" in
+  let hooks = make_test_hooks keeper in
+  let hook = require_hook "on_tool_error" hooks.on_tool_error in
+  let before = lifecycle_callback_failure_count ~keeper ~callback:"on_tool_error" in
+  let before_seq = latest_log_seq () in
+  let error =
+    {|{"ok":false,"error":"keeper_bash_command_shape_blocked","failure_class":"workflow_rejection"}|}
+  in
+  check_continue
+    "on_tool_error workflow rejection"
+    (hook (Agent_sdk.Hooks.OnToolError { tool_name = "Bash"; error }));
+  let after = lifecycle_callback_failure_count ~keeper ~callback:"on_tool_error" in
+  check
+    (float 0.001)
+    "workflow rejection does not increment callback failures"
+    0.0
+    (after -. before);
+  match
+    find_keeper_log_since
+      ~since_seq:before_seq
+      ~message_substring:("keeper:" ^ keeper ^ " tool_workflow_rejection: Bash")
+  with
+  | Some entry -> check string "log level" "WARN" (Log.level_to_string entry.level)
+  | None -> fail "expected workflow rejection to be logged as keeper WARN"
+;;
+
+let test_on_tool_error_blob_workflow_rejection_logs_warn_without_callback_failure
+    () =
+  let keeper = "callback-on-tool-blob-workflow-rejection-keeper" in
+  let root = temp_dir () in
+  let hooks = make_test_hooks_at_root keeper root in
+  let hook = require_hook "on_tool_error" hooks.on_tool_error in
+  let before = lifecycle_callback_failure_count ~keeper ~callback:"on_tool_error" in
+  let before_seq = latest_log_seq () in
+  let payload =
+    Printf.sprintf
+      {|{"ok":false,"error":"keeper_bash_command_shape_blocked","padding":"%s","detail":{"failure_class":"workflow_rejection"}}|}
+      (String.make 260 'x')
+  in
+  let store = Tool_blob_store.create ~base_path:root in
+  let error = Tool_blob_store.put store ~bytes:payload ~mime:"text/plain" in
+  let error = Tool_output.encode_for_oas error in
+  check_continue
+    "on_tool_error blob workflow rejection"
+    (hook (Agent_sdk.Hooks.OnToolError { tool_name = "Bash"; error }));
+  let after = lifecycle_callback_failure_count ~keeper ~callback:"on_tool_error" in
+  check
+    (float 0.001)
+    "blob workflow rejection does not increment callback failures"
+    0.0
+    (after -. before);
+  match
+    find_keeper_log_since
+      ~since_seq:before_seq
+      ~message_substring:("keeper:" ^ keeper ^ " tool_workflow_rejection: Bash")
+  with
+  | Some entry -> check string "blob log level" "WARN" (Log.level_to_string entry.level)
+  | None -> fail "expected blob workflow rejection to be logged as keeper WARN"
+;;
+
 let test_on_stop_hook_records_stop_reason_metric () =
   let keeper = "callback-on-stop-keeper" in
   let hooks = make_test_hooks keeper in
@@ -1690,6 +1769,14 @@ let () =
             "on_tool_error records callback metric"
             `Quick
             test_on_tool_error_hook_records_callback_failure_metric
+        ; test_case
+            "on_tool_error workflow rejection logs warn"
+            `Quick
+            test_on_tool_error_workflow_rejection_logs_warn_without_callback_failure
+        ; test_case
+            "on_tool_error blob workflow rejection logs warn"
+            `Quick
+            test_on_tool_error_blob_workflow_rejection_logs_warn_without_callback_failure
         ; test_case
             "on_stop records stop reason metric"
             `Quick


### PR DESCRIPTION
Summary:
- Classify keeper on_tool_error payloads with failure_class=workflow_rejection or policy_rejection as self-correcting control flow.
- Hydrate [masc:blob ...] tool errors from Tool_blob_store before classifying, with preview fallback.
- Keep genuine tool/runtime failures on the existing ERROR counter and dedupe path.

Context:
- Fresh live log scan still showed keeper_bash command-shape workflow rejections emitted again as Keeper ERROR lines via on_tool_error.
- This is a narrow replacement for the relevant part of closed do-not-merge PR #16304.

Verification:
- ocamlformat --check lib/keeper/keeper_hooks_oas.ml test/test_keeper_hooks_oas_telemetry.ml
- git diff --check origin/main...HEAD
- env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_DUNE_ALLOW_LIVE_BUILD_LOCK=1 DUNE_LOCAL_JOBS=2 scripts/dune-local.sh build test/test_keeper_hooks_oas_telemetry.exe
- ./_build/default/test/test_keeper_hooks_oas_telemetry.exe test hook_introspection 2-4 --show-errors