### PR TITLE
refactor(server): extract cascade profile gate into sibling module

### DIFF
--- a/lib/server/server_dashboard_cascade_profile_gate.ml
+++ b/lib/server/server_dashboard_cascade_profile_gate.ml
@@ -1,0 +1,122 @@
+(** Dashboard cascade profile gate — determines which cascade profiles
+    are assignable to a keeper, distinguishing
+    {[
+      valid_profiles
+    ]} from
+    {[
+      invalid_profiles
+    ]}
+    and
+    {[
+      invalid_assignments
+    ]}.
+
+    Extracted from [server_routes_http_routes_dashboard.ml] (lines
+    14-184) as part of the godfile decomp campaign. Owns the pure
+    profile-classification pipeline that feeds the dashboard cascade
+    assignment UI; runtime snapshot ([Cascade_catalog_runtime]) is
+    consulted first, with a fallback to the on-disk validator
+    ([Cascade_catalog_validator]) when the snapshot is unavailable. *)
+
+type t = {
+  valid_profiles : string list;
+  invalid_profiles : (string * string list) list;
+  invalid_assignments : (string * string list) list;
+}
+
+let compute () : t =
+  let config_path = Cascade_runtime.cascade_config_path () in
+  let keeper_assignable_profiles =
+    Keeper_cascade_profile.keeper_catalog_names ?config_path ()
+    |> List.sort_uniq String.compare
+  in
+  let keeper_assignable_profile profile =
+    keeper_assignable_profiles = [] || List.mem profile keeper_assignable_profiles
+  in
+  let fallback_invalid_profiles =
+    match config_path with
+    | None -> []
+    | Some path ->
+        Cascade_catalog_validator.error_messages_by_profile
+          ~config_path:path
+  in
+  match Cascade_catalog_runtime.known_profile_names () with
+  | Ok raw_validated_profiles ->
+      let validated_profiles =
+        raw_validated_profiles |> List.sort_uniq String.compare
+      in
+      let invalid_profiles =
+        (Cascade_catalog_runtime.invalid_profile_errors ()
+         @ fallback_invalid_profiles)
+        |> Dashboard_cascade.invalid_profiles_with_internal_names
+      in
+      let keeper_profiles =
+        raw_validated_profiles
+        |> List.filter keeper_assignable_profile
+        |> List.sort_uniq String.compare
+      in
+      let candidate_profiles =
+        if keeper_profiles = [] then validated_profiles else keeper_profiles
+      in
+      let known_internal_profiles =
+        (match config_path with
+         | None -> raw_validated_profiles
+         | Some path ->
+             Cascade_catalog_validator.discover_profiles_for_diagnostics
+               ~config_path:path)
+        |> List.sort_uniq String.compare
+      in
+      let invalid_assignments =
+        Dashboard_cascade.invalid_assignments_for_public_profiles
+          ~known_internal_profiles
+          ~invalid_profiles candidate_profiles
+      in
+      let valid_profiles =
+        candidate_profiles
+        |> List.filter (fun profile ->
+               List.mem profile validated_profiles
+               && not (List.mem_assoc profile invalid_assignments))
+      in
+      { valid_profiles; invalid_profiles; invalid_assignments }
+  | Error detail ->
+      Log.Keeper.warn
+        "cascade_profile_gate: validated runtime snapshot unavailable: %s"
+        detail;
+      let invalid_profiles =
+        Dashboard_cascade.invalid_profiles_with_internal_names
+          fallback_invalid_profiles
+      in
+      let known_internal_profiles =
+        (match config_path with
+         | None -> []
+         | Some path ->
+             Cascade_catalog_validator.discover_profiles_for_diagnostics
+               ~config_path:path)
+        |> List.sort_uniq String.compare
+      in
+      let keeper_profiles =
+        known_internal_profiles
+        |> List.filter keeper_assignable_profile
+        |> List.sort_uniq String.compare
+      in
+      let candidate_profiles =
+        if keeper_profiles = [] then known_internal_profiles else keeper_profiles
+      in
+      let invalid_assignments =
+        Dashboard_cascade.invalid_assignments_for_public_profiles
+          ~known_internal_profiles ~invalid_profiles candidate_profiles
+      in
+      let invalid_names = List.map fst invalid_assignments in
+      let valid_profiles =
+        candidate_profiles
+        |> List.filter (fun profile -> not (List.mem profile invalid_names))
+      in
+      { valid_profiles; invalid_profiles; invalid_assignments }
+;;
+
+let available_profiles () : string list = (compute ()).valid_profiles
+let invalid_profiles () : (string * string list) list = (compute ()).invalid_profiles
+
+let invalid_assignment_profiles () : (string * string list) list =
+  (compute ()).invalid_assignments
+;;

--- a/lib/server/server_dashboard_cascade_profile_gate.mli
+++ b/lib/server/server_dashboard_cascade_profile_gate.mli
@@ -1,0 +1,35 @@
+(** Dashboard cascade profile gate — determines which cascade
+    profiles are assignable to a keeper.
+
+    Pure derivation pipeline over [Cascade_catalog_runtime] (preferred)
+    + [Cascade_catalog_validator] (fallback on snapshot unavailability)
+    + [Keeper_cascade_profile.keeper_catalog_names] (keeper-assignable
+    filter). *)
+
+(** Result of one gate computation:
+    - [valid_profiles]: assignable profile names;
+    - [invalid_profiles]: profile → error message list (config /
+      validator-level errors);
+    - [invalid_assignments]: profile → reason list (public profile
+      that resolves to an invalid internal profile). *)
+type t = {
+  valid_profiles : string list;
+  invalid_profiles : (string * string list) list;
+  invalid_assignments : (string * string list) list;
+}
+
+(** [compute ()] runs the gate end-to-end and returns the
+    classification for the current cascade config. Reads the runtime
+    snapshot first; falls back to the on-disk validator when the
+    snapshot is in an error state (logs a WARN line in that case). *)
+val compute : unit -> t
+
+(** [available_profiles ()] is [(compute ()).valid_profiles]. *)
+val available_profiles : unit -> string list
+
+(** [invalid_profiles ()] is [(compute ()).invalid_profiles]. *)
+val invalid_profiles : unit -> (string * string list) list
+
+(** [invalid_assignment_profiles ()] is
+    [(compute ()).invalid_assignments]. *)
+val invalid_assignment_profiles : unit -> (string * string list) list

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -11,7 +11,13 @@ module Runtime = Server_routes_http_runtime
 module Keeper_stream = Server_routes_http_keeper_stream
 module Keeper_api = Server_dashboard_http_keeper_api
 
-type cascade_profile_gate = {
+(* Cascade profile gate extracted to
+   [Server_dashboard_cascade_profile_gate] (godfile decomp). Type +
+   constructor functions re-exported via transparent alias so the
+   internal call sites stay byte-identical. *)
+module Cascade_profile_gate = Server_dashboard_cascade_profile_gate
+
+type cascade_profile_gate = Cascade_profile_gate.t = {
   valid_profiles : string list;
   invalid_profiles : (string * string list) list;
   invalid_assignments : (string * string list) list;
@@ -84,103 +90,10 @@ let dashboard_logs_json ~config ~limit ~level_filter ~min_level ~module_filter
 module Provider_logs = Server_routes_http_dashboard_provider_logs
 
 
-let cascade_profile_gate () : cascade_profile_gate =
-  let config_path = Cascade_runtime.cascade_config_path () in
-  let keeper_assignable_profiles =
-    Keeper_cascade_profile.keeper_catalog_names ?config_path ()
-    |> List.sort_uniq String.compare
-  in
-  let keeper_assignable_profile profile =
-    keeper_assignable_profiles = [] || List.mem profile keeper_assignable_profiles
-  in
-  let fallback_invalid_profiles =
-    match config_path with
-    | None -> []
-    | Some path ->
-        Cascade_catalog_validator.error_messages_by_profile
-          ~config_path:path
-  in
-  match Cascade_catalog_runtime.known_profile_names () with
-  | Ok raw_validated_profiles ->
-      let validated_profiles =
-        raw_validated_profiles |> List.sort_uniq String.compare
-      in
-      let invalid_profiles =
-        (Cascade_catalog_runtime.invalid_profile_errors ()
-         @ fallback_invalid_profiles)
-        |> Dashboard_cascade.invalid_profiles_with_internal_names
-      in
-      let keeper_profiles =
-        raw_validated_profiles
-        |> List.filter keeper_assignable_profile
-        |> List.sort_uniq String.compare
-      in
-      let candidate_profiles =
-        if keeper_profiles = [] then validated_profiles else keeper_profiles
-      in
-      let known_internal_profiles =
-        (match config_path with
-         | None -> raw_validated_profiles
-         | Some path ->
-             Cascade_catalog_validator.discover_profiles_for_diagnostics
-               ~config_path:path)
-        |> List.sort_uniq String.compare
-      in
-      let invalid_assignments =
-        Dashboard_cascade.invalid_assignments_for_public_profiles
-          ~known_internal_profiles
-          ~invalid_profiles candidate_profiles
-      in
-      let valid_profiles =
-        candidate_profiles
-        |> List.filter (fun profile ->
-               List.mem profile validated_profiles
-               && not (List.mem_assoc profile invalid_assignments))
-      in
-      { valid_profiles; invalid_profiles; invalid_assignments }
-  | Error detail ->
-      Log.Keeper.warn
-        "cascade_profile_gate: validated runtime snapshot unavailable: %s"
-        detail;
-      let invalid_profiles =
-        Dashboard_cascade.invalid_profiles_with_internal_names
-          fallback_invalid_profiles
-      in
-      let known_internal_profiles =
-        (match config_path with
-         | None -> []
-         | Some path ->
-             Cascade_catalog_validator.discover_profiles_for_diagnostics
-               ~config_path:path)
-        |> List.sort_uniq String.compare
-      in
-      let keeper_profiles =
-        known_internal_profiles
-        |> List.filter keeper_assignable_profile
-        |> List.sort_uniq String.compare
-      in
-      let candidate_profiles =
-        if keeper_profiles = [] then known_internal_profiles else keeper_profiles
-      in
-      let invalid_assignments =
-        Dashboard_cascade.invalid_assignments_for_public_profiles
-          ~known_internal_profiles ~invalid_profiles candidate_profiles
-      in
-      let invalid_names = List.map fst invalid_assignments in
-      let valid_profiles =
-        candidate_profiles
-        |> List.filter (fun profile -> not (List.mem profile invalid_names))
-      in
-      { valid_profiles; invalid_profiles; invalid_assignments }
-
-let available_cascade_profiles () : string list =
-  (cascade_profile_gate ()).valid_profiles
-
-let invalid_cascade_profiles () : (string * string list) list =
-  (cascade_profile_gate ()).invalid_profiles
-
-let invalid_cascade_assignment_profiles () : (string * string list) list =
-  (cascade_profile_gate ()).invalid_assignments
+let cascade_profile_gate = Cascade_profile_gate.compute
+let available_cascade_profiles = Cascade_profile_gate.available_profiles
+let invalid_cascade_profiles = Cascade_profile_gate.invalid_profiles
+let invalid_cascade_assignment_profiles = Cascade_profile_gate.invalid_assignment_profiles
 
 (* [telemetry_summary_cache_key] moved to
    [Server_dashboard_shell_snapshot] (Phase 3 Step 2) where the only


### PR DESCRIPTION
## 요약

\`server_routes_http_routes_dashboard.ml\` (godfile, 1731 LoC) 의 dashboard
cascade profile classification 파이프라인 (lines 14-184) 을 sibling
모듈로 추출. 본 PR 머지 후 1731 → 1644 (−87, −5.0%).

## 추출된 surface

- \`type cascade_profile_gate\` (valid / invalid / invalid_assignments)
- \`compute ()\` — runtime snapshot 우선
  (\`Cascade_catalog_runtime\`), 스냅샷 에러 시 validator fallback
  (\`Cascade_catalog_validator\`)
- \`available_profiles\` / \`invalid_profiles\` / \`invalid_assignment_profiles\`
  — \`.valid_profiles\` / \`.invalid_profiles\` / \`.invalid_assignments\`
  projection

## 패턴

이전 PR (#16770 등) 의 *transparent type alias + per-function alias*:
- 새 모듈은 \`Cascade_runtime\`, \`Keeper_cascade_profile\`,
  \`Cascade_catalog_validator\`, \`Cascade_catalog_runtime\`,
  \`Dashboard_cascade\` 만 의존 (모두 upstream).
- \`type cascade_profile_gate = Cascade_profile_gate.t = { ... }\`
  re-export 로 내부 호출처 (lines 1639/1674/1675) byte-identical 유지.

## 검증

\`\`\`
$ dune build --root . @check    # exit 0
\`\`\`

4 함수 모두 0 external qualified caller. 내부 호출만 — alias 로 보존.

## LoC

| 파일 | LoC |
|------|-----|
| server_routes_http_routes_dashboard.ml | 1731 → 1644 (−87) |
| server_dashboard_cascade_profile_gate.ml (new) | 122 |
| .mli (new) | 35 |
| 본 PR diff | +168 / −98 |

## RFC

RFC-WAIVED: pure mechanical extraction of internal helpers within
\`lib/server/\`. cascade profile gate 는 *keeper 에게 할당 가능한 profile
이 무엇인가* 만 결정 — authorization / token / keeper credential 에
접근하지 않음. Public surface preserved via transparent type alias.