### PR TITLE
fix(dashboard_eval_feed): surface 2 silent directory-read failures via warn

### DIFF
--- a/lib/dashboard_eval_feed/dashboard_eval_feed.ml
+++ b/lib/dashboard_eval_feed/dashboard_eval_feed.ml
@@ -108,6 +108,13 @@ let eval_base ~base_path =
 let eval_dir ~base_path ~agent_name =
   Filename.concat (eval_base ~base_path) agent_name
 
+(* Silent [Sys_error _ -> []] previously hid two distinct failure modes
+   behind "no agents have eval data": (1) the eval directory is
+   legitimately empty (expected during fresh boot before any verdict
+   write), (2) the directory is unreadable due to permission denied,
+   missing parent, or filesystem unavailability. Operators staring at
+   an empty Eval Feed pane need to tell these apart. Same pattern as
+   #16712, #16720, #16724, #16725, #16729 (silent-failure series). *)
 let list_agents ~base_path =
   let dir = eval_base ~base_path in
   try
@@ -116,7 +123,14 @@ let list_agents ~base_path =
     |> List.filter (fun name ->
          Sys.is_directory (Filename.concat dir name))
     |> List.sort String.compare
-  with Sys_error _ -> []
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | Sys_error msg ->
+    Log.Dashboard.warn
+      "[eval_feed.list_agents] eval directory unreadable at %s: %s"
+      dir
+      msg;
+    []
 
 let read_latest ~base_path ~agent_name ~limit =
   let dir = eval_dir ~base_path ~agent_name in
@@ -126,7 +140,16 @@ let read_latest ~base_path ~agent_name ~limit =
       |> Array.to_list
       |> List.filter (fun f -> Filename.check_suffix f ".json")
       |> List.sort (fun a b -> String.compare b a)
-    with Sys_error _ -> []
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | Sys_error msg ->
+      Log.Dashboard.warn
+        "[eval_feed.read_latest] per-agent verdict directory unreadable for \
+         %s at %s: %s"
+        agent_name
+        dir
+        msg;
+      []
   in
   let rec collect acc remaining = function
     | [] -> List.rev acc


### PR DESCRIPTION
## Summary

`list_agents` and `read_latest` in `lib/dashboard_eval_feed/dashboard_eval_feed.ml` (the dashboard Eval Feed pane data source) both collapsed `Sys_error _ -> []` without log:

```ocaml
try Sys.readdir dir |> ... with Sys_error _ -> []
```

Operators staring at "Eval Feed: no agents" in the dashboard couldn't tell apart:

| Case | Meaning | Today |
|---|---|---|
| (1) Directory legitimately empty | Fresh boot before any verdict write (per-agent dirs are created on demand) | `[]` (correct) |
| (2) Directory unreadable | Permission denied, missing parent, FS unavailability, path drift mid-startup | `[]` (silent — wrong) |

Operationally distinct, identical UI output.

## Fix

Both sites now:
- Re-raise `Eio.Cancel.Cancelled` explicitly (RFC-0106).
- Log `Log.Dashboard.warn` with directory path + `Sys_error` message before returning `[]`.
- Preserve the `[]` caller surface.

## Pattern continuity (silent-failure series)

| PR | Surface | Status |
|---|---|---|
| #16712 | cascade_http_probe transport failures | merged |
| #16720 | dashboard SSE hydration | merged |
| #16724 | sidecar route reads | merged |
| #16725 | 7 tool_coord/tool_task safe_* wrappers | merged |
| #16729 | MCP join-state gate | merged |
| #16737 | lib/ 3 sites (institution / voice / playground_repo_cache) | merged |
| **this PR** | dashboard_eval_feed 2 sites | Draft |

## Verification

- `dune build --root . @check` EXIT=0.
- +25/-3 LoC, single file modification.
- 0 caller surface change.

## Iter#68 context

Extends 7-PR silent-failure series to the dashboard Eval Feed surface. The next likely cluster is `lib/dashboard.ml:249` (count_lock_files recursive), but that needs a wrapper-level log to avoid recursive log spam — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>