### PR TITLE
fix(egress): demote inactive missing audit noise

### DIFF
--- a/lib/keeper/keeper_egress_audit.ml
+++ b/lib/keeper/keeper_egress_audit.ml
@@ -99,6 +99,11 @@ let format_log_line (r : result) =
          orphan_at=%s"
         r.keeper_name profile expected_path orphan_path
 
+let inactive_missing_reason (meta : Keeper_types.keeper_meta) =
+  if meta.paused then Some "paused"
+  else if not meta.autoboot_enabled then Some "autoboot_disabled"
+  else None
+
 (** Partition results by severity.  The boot hook can then route
     [Ok] at debug level and [missing]/[stale] at warn. *)
 let partition (results : result list) =

--- a/lib/keeper/keeper_egress_audit.mli
+++ b/lib/keeper/keeper_egress_audit.mli
@@ -37,5 +37,9 @@ val format_log_line : result -> string
 (** Grep-friendly one-line summary tagged
     [[egress_audit:ok|missing|stale_orphan]]. *)
 
+val inactive_missing_reason : Keeper_types.keeper_meta -> string option
+(** [Some reason] when a missing egress policy should not page operators
+    because the keeper is intentionally inactive. *)
+
 val partition : result list -> result list * result list * result list
 (** Split into [(ok, missing, stale_orphan)] in input order. *)

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -375,6 +375,16 @@ let migrate_room_to_flat (state : Mcp_server.server_state) =
 let migrate_legacy_trace_dirs (state : Mcp_server.server_state) =
   migrate_legacy_dirs_with_renames state [ ("perpetual", "traces") ]
 
+let keeper_egress_inactive_missing_reason
+    ~(metas : Keeper_types.keeper_meta list)
+    (r : Keeper_egress_audit.result) =
+  metas
+  |> List.find_opt (fun (meta : Keeper_types.keeper_meta) ->
+    String.equal meta.name r.keeper_name)
+  |> function
+  | Some meta -> Keeper_egress_audit.inactive_missing_reason meta
+  | None -> None
+
 let audit_keeper_egress_policies (state : Mcp_server.server_state) =
   (* PR-Eg2b (Leak 11): on every boot, audit each keeper's [egress.json]
      placement.  Reads only — never writes.  Writes are deferred to the
@@ -410,6 +420,14 @@ let audit_keeper_egress_policies (state : Mcp_server.server_state) =
   else begin
     let results = Keeper_egress_audit.audit_all ~config ~metas in
     let oks, missings, orphans = Keeper_egress_audit.partition results in
+    let active_missings, inactive_missings =
+      List.fold_left
+        (fun (active, inactive) r ->
+          match keeper_egress_inactive_missing_reason ~metas r with
+          | Some reason -> (active, (r, reason) :: inactive)
+          | None -> (r :: active, inactive))
+        ([], []) missings
+    in
     List.iter (fun r ->
       Log.Misc.info "%s" (Keeper_egress_audit.format_log_line r))
       oks;
@@ -417,16 +435,24 @@ let audit_keeper_egress_policies (state : Mcp_server.server_state) =
       Log.Misc.warn "%s" (Keeper_egress_audit.format_log_line r);
       Prometheus.inc_counter Prometheus.metric_egress_audit_missing
         ~labels:[("keeper", r.Keeper_egress_audit.keeper_name)] ())
-      missings;
+      active_missings;
+    List.iter
+      (fun (r, reason) ->
+        Log.Misc.info "%s inactive_reason=%s"
+          (Keeper_egress_audit.format_log_line r)
+          reason)
+      inactive_missings;
     List.iter (fun r ->
       Log.Misc.warn "%s" (Keeper_egress_audit.format_log_line r);
       Prometheus.inc_counter Prometheus.metric_egress_audit_stale_orphan
         ~labels:[("keeper", r.Keeper_egress_audit.keeper_name)] ())
       orphans;
     Log.Misc.info
-      "[egress_audit:summary] total=%d ok=%d missing=%d stale_orphan=%d"
+      "[egress_audit:summary] total=%d ok=%d missing=%d inactive_missing=%d stale_orphan=%d"
       (List.length results) (List.length oks)
-      (List.length missings) (List.length orphans)
+      (List.length active_missings)
+      (List.length inactive_missings)
+      (List.length orphans)
   end
 
 let bootstrap_server_state_blocking (state : Mcp_server.server_state) =

--- a/test/test_keeper_egress_audit.ml
+++ b/test/test_keeper_egress_audit.ml
@@ -14,7 +14,7 @@ let temp_dir () =
   Unix.mkdir path 0o755;
   path
 
-let make_meta ~name ~sandbox =
+let make_meta ?(paused = false) ?(autoboot_enabled = true) ~name ~sandbox () =
   let json =
     `Assoc
       [
@@ -24,6 +24,8 @@ let make_meta ~name ~sandbox =
         ("goal", `String "egress audit test");
         ( "sandbox_profile",
           `String (Keeper_types.sandbox_profile_to_string sandbox) );
+        ("paused", `Bool paused);
+        ("autoboot_enabled", `Bool autoboot_enabled);
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
@@ -54,7 +56,7 @@ let write_egress_at path =
 
 let test_docker_ok_when_expected_present () =
   let config = make_config () in
-  let meta = make_meta ~name:"sangsu" ~sandbox:Keeper_types.Docker in
+  let meta = make_meta ~name:"sangsu" ~sandbox:Keeper_types.Docker () in
   let expected = Masc_mcp.Keeper_shell_docker.egress_policy_path ~config ~meta in
   write_egress_at expected;
   let r = Keeper_egress_audit.audit_one ~config ~meta in
@@ -64,7 +66,7 @@ let test_docker_ok_when_expected_present () =
 
 let test_docker_stale_orphan_when_only_host_direct_present () =
   let config = make_config () in
-  let meta = make_meta ~name:"executor" ~sandbox:Keeper_types.Docker in
+  let meta = make_meta ~name:"executor" ~sandbox:Keeper_types.Docker () in
   let host_direct =
     Keeper_egress_audit.host_direct_egress_path ~config ~meta
   in
@@ -87,7 +89,7 @@ let test_docker_stale_orphan_when_only_host_direct_present () =
 
 let test_docker_missing_when_neither_present () =
   let config = make_config () in
-  let meta = make_meta ~name:"verifier" ~sandbox:Keeper_types.Docker in
+  let meta = make_meta ~name:"verifier" ~sandbox:Keeper_types.Docker () in
   let r = Keeper_egress_audit.audit_one ~config ~meta in
   match r.status with
   | Keeper_egress_audit.Missing_at_expected _ -> ()
@@ -97,7 +99,7 @@ let test_docker_missing_when_neither_present () =
 
 let test_local_ok_when_expected_present () =
   let config = make_config () in
-  let meta = make_meta ~name:"ramarama" ~sandbox:Keeper_types.Local in
+  let meta = make_meta ~name:"ramarama" ~sandbox:Keeper_types.Local () in
   let expected = Masc_mcp.Keeper_shell_docker.egress_policy_path ~config ~meta in
   write_egress_at expected;
   let r = Keeper_egress_audit.audit_one ~config ~meta in
@@ -110,7 +112,9 @@ let test_local_missing_does_not_check_orphan () =
      impossible by construction.  A missing file is always
      [Missing_at_expected]. *)
   let config = make_config () in
-  let meta = make_meta ~name:"velvet-hammer" ~sandbox:Keeper_types.Local in
+  let meta =
+    make_meta ~name:"velvet-hammer" ~sandbox:Keeper_types.Local ()
+  in
   let r = Keeper_egress_audit.audit_one ~config ~meta in
   match r.status with
   | Keeper_egress_audit.Missing_at_expected _ -> ()
@@ -120,13 +124,17 @@ let test_local_missing_does_not_check_orphan () =
 
 let test_audit_all_partitions_correctly () =
   let config = make_config () in
-  let m_ok = make_meta ~name:"sangsu" ~sandbox:Keeper_types.Docker in
+  let m_ok = make_meta ~name:"sangsu" ~sandbox:Keeper_types.Docker () in
   write_egress_at
     (Masc_mcp.Keeper_shell_docker.egress_policy_path ~config ~meta:m_ok);
-  let m_stale = make_meta ~name:"executor" ~sandbox:Keeper_types.Docker in
+  let m_stale =
+    make_meta ~name:"executor" ~sandbox:Keeper_types.Docker ()
+  in
   write_egress_at
     (Keeper_egress_audit.host_direct_egress_path ~config ~meta:m_stale);
-  let m_missing = make_meta ~name:"verifier" ~sandbox:Keeper_types.Docker in
+  let m_missing =
+    make_meta ~name:"verifier" ~sandbox:Keeper_types.Docker ()
+  in
   let results =
     Keeper_egress_audit.audit_all ~config
       ~metas:[ m_ok; m_stale; m_missing ]
@@ -144,7 +152,7 @@ let starts_with prefix s =
 
 let test_format_log_line_tags () =
   let config = make_config () in
-  let m = make_meta ~name:"sangsu" ~sandbox:Keeper_types.Docker in
+  let m = make_meta ~name:"sangsu" ~sandbox:Keeper_types.Docker () in
   let r_missing = Keeper_egress_audit.audit_one ~config ~meta:m in
   Alcotest.(check bool)
     "missing line tagged [egress_audit:missing]" true
@@ -157,6 +165,25 @@ let test_format_log_line_tags () =
     "ok line tagged [egress_audit:ok]" true
     (starts_with "[egress_audit:ok]"
        (Keeper_egress_audit.format_log_line r_ok))
+
+let test_inactive_missing_reason () =
+  let reason meta =
+    Keeper_egress_audit.inactive_missing_reason meta
+    |> Option.value ~default:""
+  in
+  Alcotest.(check string)
+    "active keeper has no suppression reason" ""
+    (reason (make_meta ~name:"active" ~sandbox:Keeper_types.Local ()));
+  Alcotest.(check string)
+    "paused suppresses missing egress warning" "paused"
+    (reason
+       (make_meta ~paused:true ~name:"paused" ~sandbox:Keeper_types.Local ()));
+  Alcotest.(check string)
+    "autoboot disabled suppresses missing egress warning"
+    "autoboot_disabled"
+    (reason
+       (make_meta ~autoboot_enabled:false ~name:"disabled"
+          ~sandbox:Keeper_types.Local ()))
 
 let () =
   Alcotest.run "Keeper Egress Audit"
@@ -182,5 +209,10 @@ let () =
       ( "log format",
         [
           Alcotest.test_case "tag prefixes" `Quick test_format_log_line_tags;
+        ] );
+      ( "warning suppression",
+        [
+          Alcotest.test_case "inactive missing reason" `Quick
+            test_inactive_missing_reason;
         ] );
     ]


### PR DESCRIPTION
## Summary
- keep egress audit WARNs for active missing policies and stale orphan drift
- demote missing egress policies for intentionally inactive keepers to INFO with inactive_reason
- avoid incrementing egress missing Prometheus counter for paused/autoboot-disabled keepers

## Verification
- ocamlformat --check lib/keeper/keeper_egress_audit.ml lib/keeper/keeper_egress_audit.mli lib/server/server_runtime_bootstrap.ml test/test_keeper_egress_audit.ml
- git diff --check origin/main...HEAD
- env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_DUNE_ALLOW_LIVE_BUILD_LOCK=1 DUNE_LOCAL_JOBS=2 scripts/dune-local.sh build test/test_keeper_egress_audit.exe
- ./_build/default/test/test_keeper_egress_audit.exe