### PR TITLE
refactor(telemetry_unified): migrate string/bool field helpers to Json_field [Stack PR-3 recovery]

### DIFF
--- a/lib/telemetry_unified.ml
+++ b/lib/telemetry_unified.ml
@@ -448,16 +448,16 @@ let assoc_field name = function
   | _ -> None
 
 let string_field name json =
-  match assoc_field name json with
-  | Some (`String value) ->
+  match Json_field.string json name |> Json_field.to_option with
+  | None -> None
+  | Some value ->
     let value = String.trim value in
     if value = "" then None else Some value
-  | _ -> None
+;;
 
 let bool_field name json =
-  match assoc_field name json with
-  | Some (`Bool value) -> Some value
-  | _ -> None
+  Json_field.bool json name |> Json_field.to_option
+;;
 
 let drop_prefix prefix value =
   if String.starts_with ~prefix value then


### PR DESCRIPTION
## PR-3 recovery
원래 PR #16801로 진행했지만 *Draft Guard 자동 close* (MEMORY \`feedback_stacked_pr_auto_close_recovery\` 재발). PR-1 squash가 PR-2의 cascade_error_classify 변경도 흡수했고, PR-3는 PR-1 branch를 base로 했기 때문에 PR-1 머지 시 base가 사라져 close됨.

본 PR은 같은 변경을 origin/main 직접 rebase 후 신규 제출.

## Changes
- `lib/telemetry_unified.ml` 2 helper body migration (동일)
  - `string_field` — `Json_field.string + to_option` + trim+empty-filter
  - `bool_field` — `Json_field.bool + to_option`
- **6 insertions / 6 deletions**, **4 catch-all 제거**

## What survived from PR-1's stack squash
- `lib/json/json_field.{ml,mli}` — main에 존재 (PR #16790 squash)
- `lib/cascade/cascade_error_classify.ml` 3 helper migration — *main에 존재* (PR-1 squash가 PR-2 변경 흡수, 5 file +386/-35 stat)
- `lib/telemetry_unified.ml` migration — **본 PR이 closure**

## Why NOT assoc_field
원본 PR #16801 PR body와 동일 — Json_field 6 extractor는 typed value 반환, assoc_field는 raw variant lookup이라 직접 대응 없음. caller surface 변화 zero scope 유지.

## Local validation
- `dune build --root . @check` PASS (rebase clean, no merge conflict)
- 기존 34/34 telemetry tests는 PR-1 base에서 PASS 확인 완료 (이전 PR #16801 validation)

## Self-review
- [x] PR #16801 close 사고 분석 → 같은 branch 재사용 금지, 새 branch + 새 PR (MEMORY 정합)
- [x] origin/main 직접 base — stack squash 재발 회피
- [x] caller surface 변화 zero (internal helpers only)
- [x] silent failure ratchet (#16748): `variant_catchall_default` 4 감소

## Related
- audit context: lib/ silent failure 코드 스멜 감사 (2026-05-20)
- parent RFC: RFC-0142 §3 Phase 1 + amend #16767
- recovers: PR #16801 (CLOSED by Draft Guard at 2026-05-19 18:28:38)