### PR TITLE
refactor(telemetry_unified): migrate string/bool field helpers to Json_field [Stack PR-3]

### DIFF
--- a/lib/telemetry_unified.ml
+++ b/lib/telemetry_unified.ml
@@ -448,16 +448,16 @@ let assoc_field name = function
   | _ -> None
 
 let string_field name json =
-  match assoc_field name json with
-  | Some (`String value) ->
+  match Json_field.string json name |> Json_field.to_option with
+  | None -> None
+  | Some value ->
     let value = String.trim value in
     if value = "" then None else Some value
-  | _ -> None
+;;
 
 let bool_field name json =
-  match assoc_field name json with
-  | Some (`Bool value) -> Some value
-  | _ -> None
+  Json_field.bool json name |> Json_field.to_option
+;;
 
 let drop_prefix prefix value =
   if String.starts_with ~prefix value then


### PR DESCRIPTION
Supersedes closed #16801 (conflicted after #16790 merge).

Migrate string/bool field extraction in `telemetry_unified` to use the new `Json_field` typed helpers from #16790.

Co-Authored-By: keeper-executor-agent <executor-keeper@masc.local>