### PR TITLE
fix(worktree_live_context): surface 2 silent file/dir-read failures via warn

### DIFF
--- a/lib/worktree_live_context.ml
+++ b/lib/worktree_live_context.ml
@@ -71,7 +71,22 @@ let nearest_git_root path =
       let parent = Filename.dirname dir in
       if String.equal parent dir then None else walk parent
   in
-  try walk path with Sys_error _ -> None
+  (* Silent [Sys_error _ -> None] previously hid two cases behind
+     "no git root found": (1) walked all the way to filesystem root
+     without finding [.git] (expected outcome), (2) Sys.file_exists
+     raised mid-walk due to permission denied or broken symlink. The
+     dashboard / keeper code paths that consume this value use None
+     as "not a git repo" — case (2) misleads them when the path *is*
+     a git repo but transiently unreadable. *)
+  try walk path with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | Sys_error msg ->
+    Log.Coord.warn
+      "[worktree_live_context.nearest_git_root] walk failed at %s: %s; \
+       returning None"
+      path
+      msg;
+    None
 
 let repo_root_for ~base_path =
   if not (Coord_git.has_git_marker base_path) then None
@@ -180,12 +195,28 @@ let state_file ~repo_root ~actor_key =
     (Printf.sprintf "%s.git-status-hash" safe_key)
 
 let read_file_if_exists path =
+  (* Silent [Sys_error _ -> None] previously hid two cases behind
+     "file not present": (1) file_exists returned false (returns None
+     via the else branch — expected), (2) TOCTOU race between
+     file_exists and load_file, permission denied, or broken symlink
+     (Sys_error → silent None — surprise). The cached-hash consumers
+     of this helper interpret None as "no cached value" — case (2)
+     forces a cache miss + recompute on every call against an
+     unreadable path, silently. *)
   try
     if Fs_compat.file_exists path then
       Some (String.trim (Fs_compat.load_file path))
     else
       None
-  with Sys_error _ -> None
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | Sys_error msg ->
+    Log.Coord.warn
+      "[worktree_live_context.read_file_if_exists] read failed at %s: %s; \
+       returning None"
+      path
+      msg;
+    None
 
 let write_text path content =
   Fs_compat.mkdir_p (Filename.dirname path);


### PR DESCRIPTION
## Summary

Two sites in `lib/worktree_live_context.ml` swallowed `Sys_error _ -> None` without log:

| Function | Line | What's hidden |
|---|---|---|
| `nearest_git_root` | 66 | Walked to FS root w/o `.git` (expected) vs `Sys.file_exists` raised mid-walk (permission, broken symlink) |
| `read_file_if_exists` | 182 | File genuinely absent (`file_exists` false, expected) vs TOCTOU race / permission / broken symlink (Sys_error) |

Consumers (dashboard / keeper code paths checking "is this a git repo" or "do we have a cached hash") interpret `None` as the non-pathological case — the silent path silently forces wrong behavior:
- Cache miss + recompute on every call against an unreadable path
- "not a git repo" against a real-but-unreadable repo

## Fix

Both sites now:
- Re-raise `Eio.Cancel.Cancelled` explicitly (RFC-0106).
- Log `Log.Coord.warn` with path + `Sys_error` message before returning `None`.
- Preserve the `None` caller surface.

## Pattern continuity (silent-failure series, 9 PRs)

| PR | Surface | Status |
|---|---|---|
| #16712 | cascade_http_probe transport | merged |
| #16720 | dashboard SSE hydration | merged |
| #16724 | sidecar route reads | merged |
| #16725 | 7 tool_coord/tool_task safe_* wrappers | merged |
| #16729 | MCP join-state gate | merged |
| #16737 | lib/ 3 sites | merged |
| #16802 | dashboard_eval_feed 2 sites | Draft |
| **this PR** | worktree_live_context 2 sites | Draft |

## Verification

- `dune build --root . @check` EXIT=0 (with #16805 hotfix cherry-picked locally; **main is currently broken by #16761 rename regression** — hotfix in flight separately as #16805).
- +33/-2 LoC, single file.
- 0 caller surface change.

## Iter#69 context

Side-discovered a main regression while doing iter#69's audit (`Server_dashboard_shell_snapshot` module unbound after #16761 rename). Pushed separate Ready hotfix as **#16805**. CI for this PR will pass once #16805 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>