### PR TITLE
fix(dashboard): update snapshot selector module refs

### DIFF
--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -1476,7 +1476,7 @@ let dashboard_bootstrap_http_json
          well as /project-snapshot.  Without this wire, the
          "fallback runs ≤1× per process" claim in #16738 is false for
          bootstrap-driven loads. *)
-      Server_dashboard_shell_snapshot.select_project_snapshot_json
+      Server_dashboard_snapshot_select.select_project_snapshot_json
         ~state ~sw ~clock request)
   in
   let goals =

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -708,7 +708,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                  router (see server_routes_http_routes_dashboard.ml).
                  Without this, H/2 clients bypass Dashboard_snapshot
                  entirely and the cold-start fallback claim is false. *)
-              Server_dashboard_shell_snapshot.select_project_snapshot_json
+              Server_dashboard_snapshot_select.select_project_snapshot_json
                 ~state ~sw ~clock httpun_request
             in
             h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors)


### PR DESCRIPTION
## Summary
- update dashboard bootstrap and H/2 project snapshot routes to use the renamed Server_dashboard_snapshot_select module
- restore latest main bin/main_eio.exe compilation after the server_dashboard_shell_snapshot -> server_dashboard_snapshot_select rename

## Verification
- ocamlformat --check lib/server/server_dashboard_http.ml lib/server/server_h2_gateway.ml
- git diff --check
- DUNE_BUILD_DIR=/private/tmp/masc-main-snapshot-select-build-20260520-0335 MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_LOCAL_JOBS=2 scripts/dune-local.sh build bin/main_eio.exe