### PR TITLE
refactor(dashboard): replace raw fetch() with api/core SSOT utilities

### DIFF
--- a/dashboard/src/api/attribution.ts
+++ b/dashboard/src/api/attribution.ts
@@ -6,21 +6,14 @@
 // the dashboard is the only consumer.
 
 import { get, type GetOptions } from './core'
+import {
+  type AttributionOrigin,
+  type AttributionOutcome,
+  type Attribution as SseAttribution,
+} from '../types/sse'
 
-export type AttributionOrigin = 'det' | 'nondet'
-
-export type AttributionOutcome =
-  | { kind: 'passed' }
-  | { kind: 'policy_failed'; reason: string }
-  | { kind: 'transition_blocked'; from_state: string; to_state: string; reason: string }
-  | { kind: 'partial_pass'; score: number; rationale: string }
-
-export interface Attribution {
-  origin: AttributionOrigin
-  gate: string
-  evidence: unknown
-  outcome: AttributionOutcome
-}
+export type { AttributionOrigin, AttributionOutcome }
+export type Attribution = SseAttribution
 
 export interface AttributionEvent {
   attribution: Attribution

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -400,9 +400,7 @@ function normalizeBoardPost(raw: unknown): BoardPost | null {
     || (raw.updated_at !== undefined ? toIsoTimestamp(raw.updated_at) : createdAt)
   const titleRaw = asString(raw.title, '').trim()
   const title = sanitizeBoardTitle(titleRaw, body)
-  const tags = Array.isArray(raw.tags)
-    ? raw.tags.filter((item): item is string => typeof item === 'string' && item.trim() !== '')
-    : []
+  const tags = asStringList(raw.tags)
   const reactions = Array.isArray(raw.reactions)
     ? raw.reactions
         .map(normalizeBoardReactionSummary)

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -12,7 +12,7 @@ import type {
   GovernanceDecisionItem, GovernanceExecutedRoute,
   GovernanceGuardrailState, GovernanceJudgeSummary, GovernanceJudgment,
   KeeperApprovalQueueItem,
-  GovernanceResolvedAction, GovernanceTimelineEvent, PendingConfirmation,
+  GovernanceResolvedAction, GovernanceTimelineEvent,
   SubBoard, SubBoardAccess,
 } from '../types'
 

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -1,6 +1,7 @@
 import { currentDashboardActor, get, post, del, put, withRetries, defaultBoardVoter } from './core'
 import { isRecord, asNullableString, asString, asNumber, asInt, asStringList } from '../components/common/normalize'
 import { asKeeperApprovalRiskLevel } from '../lib/governance-risk-level'
+import { normalizePendingConfirmation } from '../pending-confirm'
 import { timeBoardRequest } from '../board-metrics'
 import type {
   BoardActorIdentity, BoardPost, BoardComment, BoardReactionSummary,
@@ -45,21 +46,8 @@ export function asNullableIsoTimestamp(value: unknown): string | null {
   return null
 }
 
-export function normalizePendingConfirmation(raw: unknown): PendingConfirmation | null {
-  if (!isRecord(raw)) return null
-  const confirmToken = asString(raw.confirm_token ?? raw.token, '').trim()
-  if (!confirmToken) return null
-  return {
-    confirm_token: confirmToken,
-    actor: asNullableString(raw.actor) ?? undefined,
-    action_type: asNullableString(raw.action_type) ?? undefined,
-    target_type: asNullableString(raw.target_type) ?? undefined,
-    target_id: asNullableString(raw.target_id),
-    delegated_tool: asNullableString(raw.delegated_tool) ?? undefined,
-    created_at: asNullableIsoTimestamp(raw.created_at) ?? undefined,
-    preview: raw.preview,
-  }
-}
+// normalizePendingConfirmation re-exported from pending-confirm.ts (SSOT)
+export { normalizePendingConfirmation }
 
 export function normalizeKeeperApprovalQueueItem(raw: unknown): KeeperApprovalQueueItem | null {
   if (!isRecord(raw)) return null

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -283,9 +283,7 @@ const DASHBOARD_BOOTSTRAP_WARM_PATHS = new Set([
   '/api/v1/dashboard/mission',
 ])
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
+import { isRecord } from '../lib/type-guards'
 
 interface ErrorResponseInfo {
   detail?: string

--- a/dashboard/src/api/credentials.ts
+++ b/dashboard/src/api/credentials.ts
@@ -42,9 +42,8 @@ export function coerceCredentialType(raw: unknown): CredentialType {
   return 'github'
 }
 
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
+import { isRecord } from '../lib/type-guards'
+export { isRecord }
 
 export function parseCredentialState(raw: unknown): CredentialState | null {
   if (!isRecord(raw)) return null

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -12,6 +12,7 @@ import {
 import { normalizePendingConfirmation } from '../pending-confirm'
 import { normalizeKeeperTrustTerminalReason } from '../keeper-store-normalize'
 import { currentDashboardActor, get, post, withRetries, NAMESPACE_TRUTH_GET_TIMEOUT_MS } from './core'
+import { DEFAULT_WINDOW_MINUTES_24H } from '../config/constants'
 import {
   parseAgentRelationsResponse,
   type AgentRelationsResponse,
@@ -960,7 +961,7 @@ function decodeKeeperCostMetricsResponse(raw: unknown): KeeperCostMetricsRespons
 }
 
 export async function fetchKeeperCostMetrics(
-  windowMinutes = 1440,
+  windowMinutes = DEFAULT_WINDOW_MINUTES_24H,
   opts?: AbortableRequestOptions,
 ): Promise<KeeperCostMetricsResponse> {
   const raw = await get<Record<string, unknown>>(`/api/v1/dashboard/keeper-costs?window=${windowMinutes}`, { signal: opts?.signal })
@@ -3311,13 +3312,13 @@ function decodeCostLatencyResponse(raw: unknown): CostLatencyResponse | null {
     p50: asNumber(raw.p50) ?? null,
     p95: asNumber(raw.p95) ?? null,
     total_cost_usd: asNumber(raw.total_cost_usd) ?? 0,
-    window_minutes: asNumber(raw.window_minutes) ?? 1440,
+    window_minutes: asNumber(raw.window_minutes) ?? DEFAULT_WINDOW_MINUTES_24H,
     generated_at: asNumber(raw.generated_at) ?? 0,
   }
 }
 
 export async function fetchCostLatency(
-  windowMinutes = 1440,
+  windowMinutes = DEFAULT_WINDOW_MINUTES_24H,
   opts?: AbortableRequestOptions,
 ): Promise<CostLatencyResponse> {
   const raw = await get<Record<string, unknown>>(

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -8,8 +8,8 @@ import {
   normalizeGovernanceJudgeSummary,
   normalizeGovernanceJudgment,
   normalizeKeeperApprovalQueueItem,
-  normalizePendingConfirmation,
 } from './board'
+import { normalizePendingConfirmation } from '../pending-confirm'
 import { normalizeKeeperTrustTerminalReason } from '../keeper-store-normalize'
 import { currentDashboardActor, get, post, withRetries, NAMESPACE_TRUTH_GET_TIMEOUT_MS } from './core'
 import {

--- a/dashboard/src/api/ide.ts
+++ b/dashboard/src/api/ide.ts
@@ -122,6 +122,4 @@ export async function fetchIdePresence(
   return raw.data
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
+import { isRecord } from '../lib/type-guards'

--- a/dashboard/src/components/activity-swimlane.ts
+++ b/dashboard/src/components/activity-swimlane.ts
@@ -14,6 +14,7 @@ import { selectedNodeId, highlightedAgentId } from './activity-graph-selection'
 import { formatDurationMs } from '../lib/format-time'
 import { createManagedAsyncResource } from '../lib/async-state'
 import { escapeHtml, tooltipHtml } from '../lib/escape-html'
+import { truncate } from '../lib/truncate'
 import 'vis-timeline/styles/vis-timeline-graph2d.css'
 
 const swimlaneResource = createManagedAsyncResource<SwimlaneResponse | null>(null)
@@ -31,9 +32,6 @@ interface SwimlaneTimelineItem {
   style: string
 }
 
-function truncateLabel(value: string, max = 20): string {
-  return value.length > max ? `${value.slice(0, max - 2)}..` : value
-}
 
 function syncHighlightedGroups(
   container: HTMLDivElement,
@@ -127,7 +125,7 @@ export function ActivitySwimlane({ since }: { since?: string }) {
       const duration = formatDurationMs(span.end_ms - span.start_ms)
       const itemId = idCounter++
       const title = tooltipHtml([span.label || span.kind, `종류: ${span.kind}`, `지속: ${duration}`])
-      const content = span.label ? escapeHtml(truncateLabel(span.label)) : ''
+      const content = span.label ? escapeHtml(truncate(span.label, 20)) : ''
 
       const agentItemIds = itemIdsByAgent.get(span.agent) ?? []
       agentItemIds.push(itemId)

--- a/dashboard/src/components/add-repo-dialog.ts
+++ b/dashboard/src/components/add-repo-dialog.ts
@@ -4,6 +4,7 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { get, post } from '../api/core'
+import { normalizeCredentialsResponse } from '../api/credentials'
 import { showToast } from './common/toast'
 import { fetchRepositories, showAddRepoDialog } from './repo-sidebar'
 import { X } from 'lucide-preact'
@@ -58,27 +59,10 @@ async function loadCredentials(): Promise<void> {
   credentialsLoading.value = true
   try {
     const raw = await get<unknown>('/api/v1/credentials')
-    const rows = Array.isArray(raw)
-      ? raw
-      : raw && typeof raw === 'object' && Array.isArray((raw as Record<string, unknown>).credentials)
-        ? (raw as Record<string, unknown>).credentials as unknown[]
-        : []
-    const options: CredentialOption[] = rows
-      .filter((item): item is Record<string, unknown> =>
-        item !== null && typeof item === 'object',
-      )
-      .map(item => ({
-        id: typeof item.id === 'string' ? item.id : '',
-        name: typeof item.name === 'string'
-          ? item.name
-          : typeof item.username === 'string'
-            ? item.username
-            : typeof item.id === 'string'
-              ? item.id
-              : '',
-      }))
+    const creds = normalizeCredentialsResponse(raw)
+    credentialsResource.value = creds
+      .map(c => ({ id: c.id, name: c.name || c.username }))
       .filter(opt => opt.id && opt.name)
-    credentialsResource.value = options
   } catch (err) {
     console.warn('[add-repo-dialog] credentials load failed', err)
     credentialsResource.value = []

--- a/dashboard/src/components/attribution-panel.test.ts
+++ b/dashboard/src/components/attribution-panel.test.ts
@@ -14,7 +14,7 @@ function makeEvent(
     attribution: {
       origin: overrides.origin ?? 'det',
       gate: overrides.gate ?? 'cdal_verdict',
-      evidence: null,
+      evidence: {},
       outcome: overrides.outcome ?? { kind: 'passed' },
     },
     recorded_at: overrides.recorded_at ?? 1_700_000_000,

--- a/dashboard/src/components/attribution-panel.ts
+++ b/dashboard/src/components/attribution-panel.ts
@@ -20,6 +20,7 @@ import { ErrorState, LoadingState } from './common/feedback-state'
 import { EmptyState } from './common/empty-state'
 import { TextInput } from './common/input'
 import { highlightMatch } from '../lib/highlight-match'
+import { unixSecondsToDate } from '../lib/format-time'
 
 const POLL_INTERVAL_MS = 5_000
 const RECENT_LIMIT = 50
@@ -62,7 +63,7 @@ function originBadgeClass(origin: Attribution['origin']): string {
 }
 
 function formatTs(recordedAt: number): string {
-  const d = new Date(recordedAt * 1000)
+  const d = unixSecondsToDate(recordedAt)
   return d.toLocaleTimeString('ko-KR', { hour12: false })
 }
 

--- a/dashboard/src/components/board/board-moderation-surface.ts
+++ b/dashboard/src/components/board/board-moderation-surface.ts
@@ -18,6 +18,7 @@ import { SurfaceCard } from '../common/card'
 import { TimeAgo } from '../common/time-ago'
 import { showToast } from '../common/toast'
 import { currentCanonicalDashboardActor } from '../../lib/dashboard-session-actor'
+import { unixSecondsToDate } from '../../lib/format-time'
 
 type QueueFilter = 'open' | 'resolved' | 'all'
 
@@ -57,7 +58,7 @@ function resolvedQuery(filter: QueueFilter): boolean | undefined {
 }
 
 function queueTimestamp(entry: BoardModerationQueueEntry): string {
-  return entry.flagged_at_iso ?? new Date(entry.flagged_at * 1000).toISOString()
+  return entry.flagged_at_iso ?? unixSecondsToDate(entry.flagged_at).toISOString()
 }
 
 function QueueRow({

--- a/dashboard/src/components/board/composer-v2.ts
+++ b/dashboard/src/components/board/composer-v2.ts
@@ -17,6 +17,14 @@ import {
   STATE_BLOCK_TEMPLATE,
 } from '../ops/ops-state'
 import { isKeeperOffline } from '../../lib/keeper-predicates'
+import {
+  keeperNameFromTarget,
+  mentionQueryFromMessage,
+  trailingMentionNameFromMessage,
+  onlineKeeperNameForMention,
+  mentionCandidates,
+  replaceTrailingMentionDraft,
+} from '../../lib/mention-utils'
 
 export type ComposerV2Mode = 'broadcast' | 'dm' | 'state-block'
 
@@ -40,17 +48,6 @@ export interface ComposerV2Request {
   }
 }
 
-interface OnlineKeeper {
-  name: string
-  status?: string
-}
-
-interface MentionCandidate {
-  name: string
-  status?: string
-  selected: boolean
-}
-
 const MODE_OPTIONS: Array<{ value: ComposerV2Mode; label: string; description: string }> = [
   { value: 'broadcast', label: 'Broadcast', description: 'Room broadcast' },
   { value: 'dm', label: 'DM', description: 'Keeper DM' },
@@ -62,49 +59,6 @@ const MENTION_LISTBOX_ID = 'composer-v2-mention-listbox'
 function normalizeRoomId(roomId: string | null | undefined): string {
   const normalized = roomId?.trim().replace(/^#+/, '')
   return normalized || 'default'
-}
-
-function keeperNameFromTarget(value: string): string | null {
-  if (!value.startsWith('keeper:')) return null
-  const name = value.slice('keeper:'.length).trim()
-  return name || null
-}
-
-function mentionQueryFromMessage(message: string): string | null {
-  const match = message.match(/(?:^|\s)@([A-Za-z0-9_.-]*)$/)
-  return match?.[1] ?? null
-}
-
-function trailingMentionNameFromMessage(message: string): string | null {
-  const match = message.match(/(?:^|\s)@([A-Za-z0-9_.-]+)\s*$/)
-  return match?.[1] ?? null
-}
-
-function onlineKeeperNameForMention(onlineKeepers: OnlineKeeper[], mentionName: string | null): string | null {
-  if (!mentionName) return null
-  const normalized = mentionName.toLowerCase()
-  return onlineKeepers.find(keeper => keeper.name.toLowerCase() === normalized)?.name ?? null
-}
-
-function mentionCandidates(onlineKeepers: OnlineKeeper[], query: string | null, selectedKeeper: string | null): MentionCandidate[] {
-  const normalizedQuery = query?.toLowerCase() ?? ''
-  return onlineKeepers
-    .filter(keeper => normalizedQuery === '' || keeper.name.toLowerCase().includes(normalizedQuery))
-    .map(keeper => ({
-      name: keeper.name,
-      status: keeper.status,
-      selected: keeper.name === selectedKeeper,
-    }))
-    .sort((a, b) => Number(b.selected) - Number(a.selected) || a.name.localeCompare(b.name))
-    .slice(0, 5)
-}
-
-function replaceTrailingMentionDraft(message: string, keeperName: string): string {
-  if (/(?:^|\s)@[A-Za-z0-9_.-]*$/.test(message)) {
-    return message.replace(/(^|\s)@[A-Za-z0-9_.-]*$/, `$1@${keeperName} `)
-  }
-  const spacer = message.trimEnd().length > 0 ? ' ' : ''
-  return `${message.trimEnd()}${spacer}@${keeperName} `
 }
 
 function modeIcon(mode: ComposerV2Mode) {

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -11,6 +11,7 @@ import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
 import { fetchGateKeepers, type GateKeeperInfo } from '../api/gate'
+import { SECONDS_PER_MINUTE, SECONDS_PER_HOUR, SECONDS_PER_DAY } from '../lib/format-time'
 import {
   fetchCascadeClientCapacity,
   fetchCascadeClientCapacityHistory,
@@ -873,10 +874,10 @@ function fmtRelativeTime(tsSec: number): string {
   const deltaSec = Date.now() / 1000 - tsSec
   if (!Number.isFinite(deltaSec) || deltaSec < 0) return '방금'
   if (deltaSec < 1) return '방금'
-  if (deltaSec < 60) return `${Math.floor(deltaSec)}초 전`
-  if (deltaSec < 3600) return `${Math.floor(deltaSec / 60)}분 전`
-  if (deltaSec < 86400) return `${Math.floor(deltaSec / 3600)}시간 전`
-  return `${Math.floor(deltaSec / 86400)}일 전`
+  if (deltaSec < SECONDS_PER_MINUTE) return `${Math.floor(deltaSec)}초 전`
+  if (deltaSec < SECONDS_PER_HOUR) return `${Math.floor(deltaSec / SECONDS_PER_MINUTE)}분 전`
+  if (deltaSec < SECONDS_PER_DAY) return `${Math.floor(deltaSec / SECONDS_PER_HOUR)}시간 전`
+  return `${Math.floor(deltaSec / SECONDS_PER_DAY)}일 전`
 }
 
 function eventKindTone(kind: CascadeCapacityEventKind): 'ok' | 'neutral' | 'bad' {

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -11,7 +11,7 @@ import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
 import { fetchGateKeepers, type GateKeeperInfo } from '../api/gate'
-import { SECONDS_PER_MINUTE, SECONDS_PER_HOUR, SECONDS_PER_DAY } from '../lib/format-time'
+import { formatTimeAgo } from '../lib/format-time'
 import {
   fetchCascadeClientCapacity,
   fetchCascadeClientCapacityHistory,
@@ -870,15 +870,6 @@ function capacityTone(entry: CascadeClientCapacityEntry): 'ok' | 'warn' | 'bad' 
   return 'ok'
 }
 
-function fmtRelativeTime(tsSec: number): string {
-  const deltaSec = Date.now() / 1000 - tsSec
-  if (!Number.isFinite(deltaSec) || deltaSec < 0) return '방금'
-  if (deltaSec < 1) return '방금'
-  if (deltaSec < SECONDS_PER_MINUTE) return `${Math.floor(deltaSec)}초 전`
-  if (deltaSec < SECONDS_PER_HOUR) return `${Math.floor(deltaSec / SECONDS_PER_MINUTE)}분 전`
-  if (deltaSec < SECONDS_PER_DAY) return `${Math.floor(deltaSec / SECONDS_PER_HOUR)}시간 전`
-  return `${Math.floor(deltaSec / SECONDS_PER_DAY)}일 전`
-}
 
 function eventKindTone(kind: CascadeCapacityEventKind): 'ok' | 'neutral' | 'bad' {
   switch (kind) {
@@ -1019,7 +1010,7 @@ function StrategyTraceTable({
           const tone = traceKindTone(e.kind)
           return html`
           <tr class="border-b border-[var(--color-border-default)] last:border-b-0">
-            <td class="py-1 text-[var(--color-fg-muted)] tabular-nums">${fmtRelativeTime(e.ts)}</td>
+            <td class="py-1 text-[var(--color-fg-muted)] tabular-nums">${formatTimeAgo(e.ts)}</td>
             <td class="py-1"><code class="text-[var(--color-fg-primary)]">${e.cascade_name}</code></td>
             <td class="py-1 text-[var(--color-fg-muted)]">${e.strategy}</td>
             <${NumCell}>${e.cycle}</${NumCell}>
@@ -1054,7 +1045,7 @@ function ClientCapacityHistoryTable({
           const tone = eventKindTone(e.kind)
           return html`
           <tr class="border-b border-[var(--color-border-default)] last:border-b-0">
-            <td class="py-1 text-[var(--color-fg-muted)] tabular-nums">${fmtRelativeTime(e.ts)}</td>
+            <td class="py-1 text-[var(--color-fg-muted)] tabular-nums">${formatTimeAgo(e.ts)}</td>
             <td class="py-1"><${StatusChip} tone=${tone}>${eventKindLabel(e.kind)}<//></td>
             <td class="py-1"><code class="text-[var(--color-fg-primary)]">${e.key}</code></td>
             <${NumCell}>${e.active_after}</${NumCell}>

--- a/dashboard/src/components/cascade-waterfall.ts
+++ b/dashboard/src/components/cascade-waterfall.ts
@@ -19,6 +19,7 @@ import {
 } from '../api/dashboard-cascade'
 import { LoadingState, ErrorState } from './common/feedback-state'
 import { TimeAgo } from './common/time-ago'
+import { formatMsCompact } from '../lib/format-number'
 
 // ── Module-level signals ──────────────────────────────────────────────────
 
@@ -86,8 +87,7 @@ export function cascadeKindTone(kind: string): {
 /** Normalise backoff_ms into a human-readable string. */
 export function formatBackoff(ms: number): string {
   if (ms <= 0) return '-'
-  if (ms < 1000) return `${ms}ms`
-  return `${(ms / 1000).toFixed(1)}s`
+  return formatMsCompact(ms)
 }
 
 /** Cap bar width at 100% based on the max candidates_in across visible events. */

--- a/dashboard/src/components/chronicle/chronicle-navigator.ts
+++ b/dashboard/src/components/chronicle/chronicle-navigator.ts
@@ -6,6 +6,7 @@ import {
   chronicleLaneLabel,
 } from './chronicle-model'
 import type { ChronicleEvent, ChronicleLane } from './chronicle-types'
+import { formatTimeHmsMs } from '../../lib/format-time'
 
 interface ChronicleNavigatorProps {
   events: readonly ChronicleEvent[]
@@ -23,11 +24,7 @@ const LANE_TONE: Record<ChronicleLane, string> = {
   conversation: 'border-[var(--color-status-warn)]',
 }
 
-function formatTime(timestamp: number): string {
-  const date = new Date(timestamp)
-  if (!Number.isFinite(date.getTime())) return '--:--:--'
-  return `${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}:${date.getSeconds().toString().padStart(2, '0')}`
-}
+const formatTime = formatTimeHmsMs
 
 function formatMetadataValue(value: unknown): string {
   if (value == null) return ''

--- a/dashboard/src/components/cockpit/cockpit.ts
+++ b/dashboard/src/components/cockpit/cockpit.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { capitalize } from '../../lib/format-string'
 import { Activity, ArrowUpRight, Brain, Code2, GitBranch, MessageSquare } from 'lucide-preact'
 import type { ComponentChildren } from 'preact'
 import {
@@ -121,7 +122,7 @@ function displayLabel(entrypoint: CockpitEntrypoint): string {
   return source
     .split('-')
     .filter(Boolean)
-    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .map(part => capitalize(part))
     .join(' ')
 }
 

--- a/dashboard/src/components/common/agent-conversation.ts
+++ b/dashboard/src/components/common/agent-conversation.ts
@@ -3,7 +3,7 @@
 // Zero-dependency fallback (no external graph library).
 
 import { html } from 'htm/preact'
-import { formatDateTimeIso } from '../../lib/format-time'
+import { formatDateTimeIso, formatTimeHmMs } from '../../lib/format-time'
 
 export interface ConversationMessage {
   id: string
@@ -35,11 +35,7 @@ interface AgentConversationProps {
   testId?: string
 }
 
-function formatTime(ts: number): string {
-  const d = new Date(ts)
-  if (!Number.isFinite(d.getTime())) return '--:--'
-  return d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })
-}
+const formatTime = formatTimeHmMs
 
 
 export function summarizeAgentConversation(messages: ConversationMessage[]): AgentConversationSummary {

--- a/dashboard/src/components/common/agent-conversation.ts
+++ b/dashboard/src/components/common/agent-conversation.ts
@@ -3,6 +3,7 @@
 // Zero-dependency fallback (no external graph library).
 
 import { html } from 'htm/preact'
+import { formatDateTimeIso } from '../../lib/format-time'
 
 export interface ConversationMessage {
   id: string
@@ -40,11 +41,6 @@ function formatTime(ts: number): string {
   return d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })
 }
 
-function formatDateTime(ts: number): string | undefined {
-  const d = new Date(ts)
-  if (!Number.isFinite(d.getTime())) return undefined
-  return d.toISOString()
-}
 
 export function summarizeAgentConversation(messages: ConversationMessage[]): AgentConversationSummary {
   const ids = new Set(messages.map(msg => msg.id))
@@ -126,7 +122,7 @@ function MessageBubble({
       >
         ${msg.content}
       </div>
-      <time class="text-3xs text-[var(--color-fg-muted)]" datetime=${formatDateTime(msg.timestamp)}>
+      <time class="text-3xs text-[var(--color-fg-muted)]" datetime=${formatDateTimeIso(msg.timestamp)}>
         ${formatTime(msg.timestamp)}
       </time>
     </article>

--- a/dashboard/src/components/common/agent-memory.ts
+++ b/dashboard/src/components/common/agent-memory.ts
@@ -6,7 +6,7 @@
 import { html } from 'htm/preact'
 import { useMemo } from 'preact/hooks'
 import { formatPct1 } from '../../lib/format-number'
-import { formatDateTimeIso } from '../../lib/format-time'
+import { formatDateTimeIso, formatTimeHmMs } from '../../lib/format-time'
 
 export interface MemoryEntry {
   id: string
@@ -39,11 +39,7 @@ interface AgentMemoryProps {
 
 const SHORT_TERM_LIMIT = 10
 
-function formatTime(ts: number): string {
-  const d = new Date(ts)
-  if (!Number.isFinite(d.getTime())) return '--:--'
-  return `${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}`
-}
+const formatTime = formatTimeHmMs
 
 
 export function getVisibleShortTermMemory(entries: MemoryEntry[]): MemoryEntry[] {

--- a/dashboard/src/components/common/agent-memory.ts
+++ b/dashboard/src/components/common/agent-memory.ts
@@ -6,6 +6,7 @@
 import { html } from 'htm/preact'
 import { useMemo } from 'preact/hooks'
 import { formatPct1 } from '../../lib/format-number'
+import { formatDateTimeIso } from '../../lib/format-time'
 
 export interface MemoryEntry {
   id: string
@@ -44,11 +45,6 @@ function formatTime(ts: number): string {
   return `${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}`
 }
 
-function formatDateTime(ts: number): string | undefined {
-  const d = new Date(ts)
-  if (!Number.isFinite(d.getTime())) return undefined
-  return d.toISOString()
-}
 
 export function getVisibleShortTermMemory(entries: MemoryEntry[]): MemoryEntry[] {
   return entries
@@ -178,7 +174,7 @@ export function AgentMemory({ entries, testId }: AgentMemoryProps) {
                       <span class="min-w-0 flex-1 truncate text-[var(--color-fg-primary)]">${e.content}</span>
                       <time
                         class="shrink-0 text-3xs text-[var(--color-fg-secondary)]"
-                        datetime=${formatDateTime(e.timestamp)}
+                        datetime=${formatDateTimeIso(e.timestamp)}
                         >${formatTime(e.timestamp)}</time
                       >
                     </div>

--- a/dashboard/src/components/common/dashboard-feed-source-strip.ts
+++ b/dashboard/src/components/common/dashboard-feed-source-strip.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { asNullableString } from './normalize'
 
 export interface DashboardFeedSourceMetadata {
   dashboard_surface?: string
@@ -7,12 +8,9 @@ export interface DashboardFeedSourceMetadata {
   generated_at_iso?: string
 }
 
-function nonEmptyString(value: unknown): string | null {
-  return typeof value === 'string' && value.trim() !== '' ? value : null
-}
 
 function retentionValue(meta: DashboardFeedSourceMetadata): string | null {
-  const direct = nonEmptyString(meta.retention?.durable_store)
+  const direct = asNullableString(meta.retention?.durable_store)
   if (direct) return direct
 
   const stores = meta.retention?.durable_stores

--- a/dashboard/src/components/common/event-stream.ts
+++ b/dashboard/src/components/common/event-stream.ts
@@ -5,6 +5,7 @@
 
 import { html } from 'htm/preact'
 import { useMemo } from 'preact/hooks'
+import { formatDateTimeIso } from '../../lib/format-time'
 
 export interface StreamEvent {
   id: string
@@ -98,11 +99,6 @@ function formatTime(ts: number): string {
   return `${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}:${d.getSeconds().toString().padStart(2, '0')}`
 }
 
-function formatDateTime(ts: number): string | undefined {
-  const d = new Date(ts)
-  if (!Number.isFinite(d.getTime())) return undefined
-  return d.toISOString()
-}
 
 export function getVisibleStreamEvents(events: StreamEvent[], maxItems: number): StreamEvent[] {
   const itemLimit = Number.isFinite(maxItems) ? Math.max(0, Math.floor(maxItems)) : 0
@@ -604,7 +600,7 @@ export function EventStream({
                     ></span>
                     <time
                       class="shrink-0 font-mono text-3xs text-[var(--color-fg-secondary)] tabular-nums"
-                      datetime=${formatDateTime(e.timestamp)}
+                      datetime=${formatDateTimeIso(e.timestamp)}
                       >${formatTime(e.timestamp)}</time
                     >
                     ${e.source

--- a/dashboard/src/components/common/event-stream.ts
+++ b/dashboard/src/components/common/event-stream.ts
@@ -5,7 +5,7 @@
 
 import { html } from 'htm/preact'
 import { useMemo } from 'preact/hooks'
-import { formatDateTimeIso } from '../../lib/format-time'
+import { formatDateTimeIso, formatTimeHmsMs } from '../../lib/format-time'
 
 export interface StreamEvent {
   id: string
@@ -93,11 +93,7 @@ function levelLabel(level: string): string {
   return level === 'error' ? '에러' : level === 'warn' ? '경고' : '정보'
 }
 
-function formatTime(ts: number): string {
-  const d = new Date(ts)
-  if (!Number.isFinite(d.getTime())) return '--:--:--'
-  return `${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}:${d.getSeconds().toString().padStart(2, '0')}`
-}
+const formatTime = formatTimeHmsMs
 
 
 export function getVisibleStreamEvents(events: StreamEvent[], maxItems: number): StreamEvent[] {

--- a/dashboard/src/components/common/failure-history.ts
+++ b/dashboard/src/components/common/failure-history.ts
@@ -4,6 +4,7 @@
 // Displays failure frequency, error types, and correlation summary.
 
 import { html } from 'htm/preact'
+import { formatDateTimeIso } from '../../lib/format-time'
 
 export interface FailureEntry {
   id: string
@@ -66,12 +67,6 @@ function formatTime(ts: number): string {
   })
 }
 
-function formatDateTime(ts: number): string | undefined {
-  if (!Number.isFinite(ts)) return undefined
-  const d = new Date(ts)
-  if (!Number.isFinite(d.getTime())) return undefined
-  return d.toISOString()
-}
 
 export function failureEntryStatus(failure: FailureEntry): FailureEntryStatus {
   if (failure.resolved) return 'resolved'
@@ -256,7 +251,7 @@ export function FailureHistory({
                     ${f.agentId.slice(0, 8)}
                   </span>
                   <span class="text-xs text-[var(--color-fg-secondary)]">·</span>
-                  <time class="text-xs text-[var(--color-fg-secondary)]" datetime=${formatDateTime(f.timestamp)}>
+                  <time class="text-xs text-[var(--color-fg-secondary)]" datetime=${formatDateTimeIso(f.timestamp)}>
                     ${formatTime(f.timestamp)}
                   </time>
                 </div>

--- a/dashboard/src/components/common/normalize.ts
+++ b/dashboard/src/components/common/normalize.ts
@@ -97,6 +97,24 @@ export function positiveLine(value: unknown): number | undefined {
   return /^[1-9]\d*$/.test(trimmed) ? Number.parseInt(trimmed, 10) : undefined
 }
 
+export interface CodeLocation {
+  readonly filePath: string
+  readonly line?: number
+}
+
+export function extractCodeLocation(record: Record<string, unknown> | null): CodeLocation | null {
+  if (!record) return null
+  const filePath =
+    asNullableString(record.file_path)
+    ?? asNullableString(record.path)
+    ?? asNullableString(record.file)
+  if (!filePath) return null
+  return {
+    filePath,
+    line: positiveLine(record.line) ?? positiveLine(record.line_start) ?? positiveLine(record.lineno),
+  }
+}
+
 export function toIsoTimestamp(value: unknown): string | undefined {
   if (typeof value === 'string' && value.trim() !== '') return value
   if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return undefined

--- a/dashboard/src/components/common/normalize.ts
+++ b/dashboard/src/components/common/normalize.ts
@@ -2,6 +2,7 @@
 // Single source of truth — all dashboard modules import from here.
 
 import { isRecord } from '../../lib/type-guards'
+import { unixSecondsToDate } from '../../lib/format-time'
 export { isRecord }
 
 export function asString(value: unknown): string | undefined
@@ -178,5 +179,5 @@ export function hasRouteContext(context: MutableRouteContext): boolean {
 export function toIsoTimestamp(value: unknown): string | undefined {
   if (typeof value === 'string' && value.trim() !== '') return value
   if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return undefined
-  return new Date(value * 1000).toISOString()
+  return unixSecondsToDate(value).toISOString()
 }

--- a/dashboard/src/components/common/normalize.ts
+++ b/dashboard/src/components/common/normalize.ts
@@ -115,6 +115,67 @@ export function extractCodeLocation(record: Record<string, unknown> | null): Cod
   }
 }
 
+export interface MutableRouteContext {
+  filePath?: string
+  line?: number
+  goalId?: string
+  taskId?: string
+  boardPostId?: string
+  commentId?: string
+  prId?: string
+  gitRef?: string
+  logId?: string
+  sessionId?: string
+  operationId?: string
+  workerRunId?: string
+}
+
+export function mergeRouteRecord(
+  context: MutableRouteContext,
+  record: Record<string, unknown> | null,
+  overwrite = false,
+): void {
+  if (!record) return
+  const location = extractCodeLocation(record)
+  if (location?.filePath && (overwrite || context.filePath === undefined)) context.filePath = location.filePath
+  if (location?.line !== undefined && (overwrite || context.line === undefined)) context.line = location.line
+
+  const goalId = idString(record.goal_id)
+  if (goalId && (overwrite || context.goalId === undefined)) context.goalId = goalId
+  const taskId = idString(record.task_id)
+  if (taskId && (overwrite || context.taskId === undefined)) context.taskId = taskId
+  const boardPostId = idString(record.board_post_id) ?? idString(record.post_id)
+  if (boardPostId && (overwrite || context.boardPostId === undefined)) context.boardPostId = boardPostId
+  const commentId = idString(record.comment_id) ?? idString(record.reply_id) ?? idString(record.comment_number)
+  if (commentId && (overwrite || context.commentId === undefined)) context.commentId = commentId
+  const prId = idString(record.pr_id) ?? idString(record.pull_request) ?? idString(record.pr_number)
+  if (prId && (overwrite || context.prId === undefined)) context.prId = prId
+  const gitRef = idString(record.git_ref) ?? idString(record.commit) ?? idString(record.branch)
+  if (gitRef && (overwrite || context.gitRef === undefined)) context.gitRef = gitRef
+  const logId = idString(record.log_id)
+  if (logId && (overwrite || context.logId === undefined)) context.logId = logId
+  const sessionId = idString(record.session_id)
+  if (sessionId && (overwrite || context.sessionId === undefined)) context.sessionId = sessionId
+  const operationId = idString(record.operation_id)
+  if (operationId && (overwrite || context.operationId === undefined)) context.operationId = operationId
+  const workerRunId = idString(record.worker_run_id)
+  if (workerRunId && (overwrite || context.workerRunId === undefined)) context.workerRunId = workerRunId
+}
+
+export function hasRouteContext(context: MutableRouteContext): boolean {
+  return context.filePath !== undefined
+    || context.goalId !== undefined
+    || context.taskId !== undefined
+    || context.boardPostId !== undefined
+    || context.commentId !== undefined
+    || context.prId !== undefined
+    || context.gitRef !== undefined
+    || context.logId !== undefined
+    || context.sessionId !== undefined
+    || context.operationId !== undefined
+    || context.workerRunId !== undefined
+}
+
 export function toIsoTimestamp(value: unknown): string | undefined {
   if (typeof value === 'string' && value.trim() !== '') return value
   if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return undefined

--- a/dashboard/src/components/common/normalize.ts
+++ b/dashboard/src/components/common/normalize.ts
@@ -53,6 +53,10 @@ export function asNullableString(value: unknown): string | null {
   return asString(value) ?? null
 }
 
+export function asRecord(value: unknown): Record<string, unknown> | null {
+  return isRecord(value) ? value : null
+}
+
 export function asStringList(value: unknown): string[] {
   if (!Array.isArray(value)) return []
   return value

--- a/dashboard/src/components/common/normalize.ts
+++ b/dashboard/src/components/common/normalize.ts
@@ -82,6 +82,13 @@ export function extractArray(value: unknown, keys: string[] = []): unknown[] {
   return []
 }
 
+export function positiveLine(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isSafeInteger(value) && value >= 1) return value
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return /^[1-9]\d*$/.test(trimmed) ? Number.parseInt(trimmed, 10) : undefined
+}
+
 export function toIsoTimestamp(value: unknown): string | undefined {
   if (typeof value === 'string' && value.trim() !== '') return value
   if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return undefined

--- a/dashboard/src/components/common/normalize.ts
+++ b/dashboard/src/components/common/normalize.ts
@@ -1,9 +1,8 @@
 // Shared type-safe normalization utilities for unknown API/SSE payloads.
 // Single source of truth — all dashboard modules import from here.
 
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
+import { isRecord } from '../../lib/type-guards'
+export { isRecord }
 
 export function asString(value: unknown): string | undefined
 export function asString(value: unknown, fallback: string): string

--- a/dashboard/src/components/common/normalize.ts
+++ b/dashboard/src/components/common/normalize.ts
@@ -82,6 +82,14 @@ export function extractArray(value: unknown, keys: string[] = []): unknown[] {
   return []
 }
 
+export function idString(value: unknown): string | undefined {
+  const text = asNullableString(value)
+  if (text) return text
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 1
+    ? String(value)
+    : undefined
+}
+
 export function positiveLine(value: unknown): number | undefined {
   if (typeof value === 'number' && Number.isSafeInteger(value) && value >= 1) return value
   if (typeof value !== 'string') return undefined

--- a/dashboard/src/components/common/version-history.ts
+++ b/dashboard/src/components/common/version-history.ts
@@ -5,6 +5,7 @@
 import { html } from 'htm/preact'
 import { useMemo } from 'preact/hooks'
 import { useId } from '../../../design-system/headless-preact/use-id'
+import { formatRelativeAgeMs } from '../../lib/format-time'
 
 export interface VersionSnapshot {
   id: string
@@ -92,17 +93,7 @@ export function summarizeVersionHistory(
   }
 }
 
-function formatRelativeTime(ts: number): string {
-  const diff = Date.now() - ts
-  const sec = Math.floor(diff / 1000)
-  if (sec < 60) return `${sec}초 전`
-  const min = Math.floor(sec / 60)
-  if (min < 60) return `${min}분 전`
-  const hr = Math.floor(min / 60)
-  if (hr < 24) return `${hr}시간 전`
-  const day = Math.floor(hr / 24)
-  return `${day}일 전`
-}
+
 
 function snapshotAriaLabel(snapshot: VersionSnapshot, state: VersionSnapshotState): string {
   const stateLabel = state === 'current' ? '현재 버전' : '이전 버전'
@@ -219,7 +210,7 @@ export function VersionHistory({
                       </div>
                       <div class="mt-0.5 text-3xs text-[var(--color-fg-secondary)]">
                         ${snap.author} ·
-                        <time datetime=${timestampIso}>${formatRelativeTime(snap.timestamp)}</time>
+                        <time datetime=${timestampIso}>${formatRelativeAgeMs(Date.now() - snap.timestamp)}</time>
                         <span class="ml-2 text-[var(--ok)]">+${snap.changes.added}</span>
                         <span class="ml-1 text-[var(--warn)]">~${snap.changes.modified}</span>
                         <span class="ml-1 text-[var(--err)]">-${snap.changes.deleted}</span>

--- a/dashboard/src/components/connector-config-form.test.ts
+++ b/dashboard/src/components/connector-config-form.test.ts
@@ -12,9 +12,19 @@ import {
   _testGetFieldHint,
 } from './connector-config-form'
 
+// Mock api/core — the component uses get/post instead of raw fetch,
+// so we intercept at the module boundary for reliable test control.
+vi.mock('../api/core', () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+}))
+
+import { get, post } from '../api/core'
+
+const mockedGet = vi.mocked(get)
+const mockedPost = vi.mocked(post)
+
 const flushUi = async () => {
-  // Three Promise.resolve cycles cover: schema fetch → JSON parse →
-  // current-values fetch → JSON parse → setEntry → render.
   await Promise.resolve()
   await Promise.resolve()
   await Promise.resolve()
@@ -99,6 +109,8 @@ describe('ConnectorConfigToggle', () => {
   afterEach(() => {
     document.body.removeChild(container)
     vi.restoreAllMocks()
+    mockedGet.mockReset()
+    mockedPost.mockReset()
   })
 
   it('renders ⚙ Config button with aria-expanded=false initially', () => {
@@ -110,19 +122,14 @@ describe('ConnectorConfigToggle', () => {
   })
 
   it('flips aria-expanded to true when clicked', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ ok: true, id: 'discord', schema: { properties: {}, required: [] } }), {
-        status: 200,
-      }),
-    )
+    mockedGet.mockResolvedValue({ ok: true, id: 'discord', schema: { properties: {}, required: [] } })
     render(html`<${ConnectorConfigToggle} connectorId="discord" />`, container)
     const btn = container.querySelector('button')!
     btn.click()
     await flushUi()
     expect(btn.getAttribute('aria-expanded')).toBe('true')
-    expect(fetchSpy).toHaveBeenCalledWith(
+    expect(mockedGet).toHaveBeenCalledWith(
       expect.stringContaining('/api/v1/sidecar/schema?name=discord'),
-      expect.any(Object),
     )
   })
 })
@@ -137,6 +144,8 @@ describe('ConnectorConfigForm', () => {
   afterEach(() => {
     document.body.removeChild(container)
     vi.restoreAllMocks()
+    mockedGet.mockReset()
+    mockedPost.mockReset()
   })
 
   it('renders nothing while closed', () => {
@@ -145,21 +154,16 @@ describe('ConnectorConfigForm', () => {
   })
 
   it('Save button stays disabled while a required field is empty', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          ok: true,
-          id: 'discord',
-          schema: {
-            properties: {
-              DISCORD_BOT_TOKEN: { type: 'string' },
-            },
-            required: ['DISCORD_BOT_TOKEN'],
-          },
-        }),
-        { status: 200 },
-      ),
-    )
+    mockedGet.mockResolvedValue({
+      ok: true,
+      id: 'discord',
+      schema: {
+        properties: {
+          DISCORD_BOT_TOKEN: { type: 'string' },
+        },
+        required: ['DISCORD_BOT_TOKEN'],
+      },
+    })
     render(html`
       <div>
         <${ConnectorConfigToggle} connectorId="discord" />
@@ -179,31 +183,22 @@ describe('ConnectorConfigForm', () => {
   })
 
   it('Save button POSTs to /api/v1/sidecar/config when required field is filled', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    mockedGet
       // 1) schema GET
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            ok: true,
-            id: 'discord',
-            schema: {
-              properties: {
-                GATE_BASE_URL: { type: 'string', default: 'http://localhost:8935' },
-              },
-              required: [],
-            },
-          }),
-          { status: 200 },
-        ),
-      )
+      .mockResolvedValueOnce({
+        ok: true,
+        id: 'discord',
+        schema: {
+          properties: {
+            GATE_BASE_URL: { type: 'string', default: 'http://localhost:8935' },
+          },
+          required: [],
+        },
+      })
       // 2) current-values GET (no file yet)
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ ok: true, exists: false, values: {} }), { status: 200 }),
-      )
-      // 3) save POST
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ ok: true, id: 'discord', written_fields: 1 }), { status: 200 }),
-      )
+      .mockResolvedValueOnce({ ok: true, exists: false, values: {} })
+    // 3) save POST
+    mockedPost.mockResolvedValueOnce({ ok: true, id: 'discord', written_fields: 1 })
 
     render(html`
       <div>
@@ -222,37 +217,33 @@ describe('ConnectorConfigForm', () => {
     await flushUi()
     await flushUi()
 
-    expect(fetchSpy).toHaveBeenCalledTimes(3)
-    const saveCall = fetchSpy.mock.calls[2]
+    expect(mockedGet).toHaveBeenCalledTimes(2)
+    expect(mockedPost).toHaveBeenCalledTimes(1)
+    const saveCall = mockedPost.mock.calls[0]
     expect(saveCall?.[0]).toContain('/api/v1/sidecar/config?name=discord')
-    expect(saveCall?.[1]?.method).toBe('POST')
-    expect(saveCall?.[1]?.body).toContain('GATE_BASE_URL')
+    expect(JSON.stringify(saveCall?.[1])).toContain('GATE_BASE_URL')
   })
 
   it('after Save success, restart button POSTs stop then start in order', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    mockedGet
       // 1) schema GET
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            ok: true,
-            id: 'discord',
-            schema: {
-              properties: { GATE_BASE_URL: { type: 'string', default: 'http://localhost:8935' } },
-              required: [],
-            },
-          }),
-          { status: 200 },
-        ),
-      )
+      .mockResolvedValueOnce({
+        ok: true,
+        id: 'discord',
+        schema: {
+          properties: { GATE_BASE_URL: { type: 'string', default: 'http://localhost:8935' } },
+          required: [],
+        },
+      })
       // 2) current-values GET
-      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, exists: false, values: {} }), { status: 200 }))
+      .mockResolvedValueOnce({ ok: true, exists: false, values: {} })
+    mockedPost
       // 3) save POST
-      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+      .mockResolvedValueOnce({ ok: true })
       // 4) stop POST
-      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, signaled: true }), { status: 200 }))
+      .mockResolvedValueOnce({ ok: true, signaled: true })
       // 5) start POST
-      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 202 }))
+      .mockResolvedValueOnce({ ok: true })
 
     render(html`
       <div>
@@ -278,28 +269,24 @@ describe('ConnectorConfigForm', () => {
     await new Promise(r => setTimeout(r, 1000))
     await flushUi()
 
-    expect(fetchSpy).toHaveBeenCalledTimes(5)
-    expect(fetchSpy.mock.calls[3]?.[0]).toContain('/api/v1/sidecar/stop?name=discord')
-    expect(fetchSpy.mock.calls[4]?.[0]).toContain('/api/v1/sidecar/start?name=discord')
+    expect(mockedGet).toHaveBeenCalledTimes(2)
+    expect(mockedPost).toHaveBeenCalledTimes(3)
+    expect(mockedPost.mock.calls[1]?.[0]).toContain('/api/v1/sidecar/stop?name=discord')
+    expect(mockedPost.mock.calls[2]?.[0]).toContain('/api/v1/sidecar/start?name=discord')
   })
 
   it('renders where-to-find hint block for DISCORD_BOT_TOKEN when schema contains it', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          ok: true,
-          id: 'discord',
-          schema: {
-            properties: {
-              DISCORD_BOT_TOKEN: { type: 'string' },
-              GATE_BASE_URL: { type: 'string', default: 'http://localhost:8935' },
-            },
-            required: ['DISCORD_BOT_TOKEN'],
-          },
-        }),
-        { status: 200 },
-      ),
-    )
+    mockedGet.mockResolvedValue({
+      ok: true,
+      id: 'discord',
+      schema: {
+        properties: {
+          DISCORD_BOT_TOKEN: { type: 'string' },
+          GATE_BASE_URL: { type: 'string', default: 'http://localhost:8935' },
+        },
+        required: ['DISCORD_BOT_TOKEN'],
+      },
+    })
     render(html`
       <div>
         <${ConnectorConfigToggle} connectorId="discord" />
@@ -319,19 +306,14 @@ describe('ConnectorConfigForm', () => {
 
 
   it('auto-restart OFF by default; Save button label stays "Save"; single POST on click', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch')
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            ok: true,
-            id: 'discord',
-            schema: { properties: { GATE_BASE_URL: { type: 'string', default: 'http://x' } }, required: [] },
-          }),
-          { status: 200 },
-        ),
-      )
-      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, exists: false, values: {} }), { status: 200 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 })) // config POST
+    mockedGet
+      .mockResolvedValueOnce({
+        ok: true,
+        id: 'discord',
+        schema: { properties: { GATE_BASE_URL: { type: 'string', default: 'http://x' } }, required: [] },
+      })
+      .mockResolvedValueOnce({ ok: true, exists: false, values: {} })
+    mockedPost.mockResolvedValueOnce({ ok: true })
 
     render(html`
       <div>
@@ -353,26 +335,23 @@ describe('ConnectorConfigForm', () => {
     saveBtn.click()
     await flushUi()
     await flushUi()
-    // schema + values + config POST, no stop/start
-    expect(fetchSpy).toHaveBeenCalledTimes(3)
+    // schema + values GET + config POST, no stop/start
+    expect(mockedGet).toHaveBeenCalledTimes(2)
+    expect(mockedPost).toHaveBeenCalledTimes(1)
   })
 
   it('auto-restart ON: Save button becomes "Save & Apply" and chains config→stop→start', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch')
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            ok: true,
-            id: 'discord',
-            schema: { properties: { GATE_BASE_URL: { type: 'string', default: 'http://x' } }, required: [] },
-          }),
-          { status: 200 },
-        ),
-      )
-      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, exists: false, values: {} }), { status: 200 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 })) // config
-      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, signaled: true }), { status: 200 })) // stop
-      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 202 })) // start
+    mockedGet
+      .mockResolvedValueOnce({
+        ok: true,
+        id: 'discord',
+        schema: { properties: { GATE_BASE_URL: { type: 'string', default: 'http://x' } }, required: [] },
+      })
+      .mockResolvedValueOnce({ ok: true, exists: false, values: {} })
+    mockedPost
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: true, signaled: true })
+      .mockResolvedValueOnce({ ok: true })
 
     render(html`
       <div>
@@ -395,29 +374,25 @@ describe('ConnectorConfigForm', () => {
     await new Promise(r => setTimeout(r, 1000))
     await flushUi()
 
-    expect(fetchSpy).toHaveBeenCalledTimes(5)
-    const urls = fetchSpy.mock.calls.slice(2).map(c => String(c[0]))
-    expect(urls[0]).toContain('/api/v1/sidecar/config?name=discord')
-    expect(urls[1]).toContain('/api/v1/sidecar/stop?name=discord')
-    expect(urls[2]).toContain('/api/v1/sidecar/start?name=discord')
+    expect(mockedGet).toHaveBeenCalledTimes(2)
+    expect(mockedPost).toHaveBeenCalledTimes(3)
+    expect(mockedPost.mock.calls[0]?.[0]).toContain('/api/v1/sidecar/config?name=discord')
+    expect(mockedPost.mock.calls[1]?.[0]).toContain('/api/v1/sidecar/stop?name=discord')
+    expect(mockedPost.mock.calls[2]?.[0]).toContain('/api/v1/sidecar/start?name=discord')
   })
 
   it('auto-restart soft-stop: if stop rejects, start still fires', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch')
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            ok: true,
-            id: 'discord',
-            schema: { properties: { GATE_BASE_URL: { type: 'string', default: 'http://x' } }, required: [] },
-          }),
-          { status: 200 },
-        ),
-      )
-      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, exists: false, values: {} }), { status: 200 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 })) // config
-      .mockRejectedValueOnce(new Error('stop refused')) // stop rejects
-      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 202 })) // start still fires
+    mockedGet
+      .mockResolvedValueOnce({
+        ok: true,
+        id: 'discord',
+        schema: { properties: { GATE_BASE_URL: { type: 'string', default: 'http://x' } }, required: [] },
+      })
+      .mockResolvedValueOnce({ ok: true, exists: false, values: {} })
+    mockedPost
+      .mockResolvedValueOnce({ ok: true })
+      .mockRejectedValueOnce(new Error('stop refused'))
+      .mockResolvedValueOnce({ ok: true })
 
     render(html`
       <div>
@@ -437,29 +412,24 @@ describe('ConnectorConfigForm', () => {
     await new Promise(r => setTimeout(r, 1000))
     await flushUi()
 
-    expect(fetchSpy).toHaveBeenCalledTimes(5)
-    const last = fetchSpy.mock.calls.slice(-2).map(c => String(c[0]))
-    expect(last[0]).toContain('/sidecar/stop')
-    expect(last[1]).toContain('/sidecar/start')
+    expect(mockedGet).toHaveBeenCalledTimes(2)
+    expect(mockedPost).toHaveBeenCalledTimes(3)
+    expect(mockedPost.mock.calls[1]?.[0]).toContain('/sidecar/stop')
+    expect(mockedPost.mock.calls[2]?.[0]).toContain('/sidecar/start')
   })
 
   it('after toggle + fetch, renders required field marker and password input for token', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          ok: true,
-          id: 'discord',
-          schema: {
-            properties: {
-              DISCORD_BOT_TOKEN: { type: 'string', title: 'Discord Bot Token' },
-              GATE_BASE_URL: { type: 'string', default: 'http://localhost:8935' },
-            },
-            required: ['DISCORD_BOT_TOKEN'],
-          },
-        }),
-        { status: 200 },
-      ),
-    )
+    mockedGet.mockResolvedValue({
+      ok: true,
+      id: 'discord',
+      schema: {
+        properties: {
+          DISCORD_BOT_TOKEN: { type: 'string', title: 'Discord Bot Token' },
+          GATE_BASE_URL: { type: 'string', default: 'http://localhost:8935' },
+        },
+        required: ['DISCORD_BOT_TOKEN'],
+      },
+    })
 
     render(html`
       <div>

--- a/dashboard/src/components/connector-config-form.ts
+++ b/dashboard/src/components/connector-config-form.ts
@@ -27,7 +27,7 @@ import { LoadingState } from './common/feedback-state'
 import { TextInput } from './common/input'
 import { SurfaceCard } from './common/card'
 import { showToast } from './common/toast'
-import { authHeaders } from '../api/core'
+import { get, post } from '../api/core'
 
 type FieldType = 'string' | 'integer' | 'number' | 'boolean' | 'unknown'
 
@@ -176,15 +176,8 @@ interface ConfigReadResponse {
 }
 
 async function fetchCurrentValues(id: string): Promise<Record<string, string>> {
-  // 4xx is fine here — most likely cause is "config.toml never written" or
-  // tool_auth not configured for the read. Either way the form should fall
-  // back to schema defaults rather than block on the prefill.
   try {
-    const res = await fetch(`/api/v1/sidecar/config?name=${encodeURIComponent(id)}`, {
-      headers: { ...authHeaders(), Accept: 'application/json' },
-    })
-    if (!res.ok) return {}
-    const data = (await res.json()) as ConfigReadResponse
+    const data = await get<ConfigReadResponse>(`/api/v1/sidecar/config?name=${encodeURIComponent(id)}`)
     if (!data.ok || !data.exists) return {}
     return data.values ?? {}
   } catch {
@@ -195,18 +188,12 @@ async function fetchCurrentValues(id: string): Promise<Record<string, string>> {
 async function fetchSchema(id: string) {
   setEntry(id, { loading: true, error: null })
   try {
-    const res = await fetch(`/api/v1/sidecar/schema?name=${encodeURIComponent(id)}`, {
-      headers: { ...authHeaders(), Accept: 'application/json' },
-    })
-    if (!res.ok) throw new Error(`HTTP ${res.status}`)
-    const data = (await res.json()) as SchemaResponse
+    const data = await get<SchemaResponse>(`/api/v1/sidecar/schema?name=${encodeURIComponent(id)}`)
     if (!data.ok) throw new Error('schema response missing ok=true')
     const fields = parseSchema(data)
     const current = await fetchCurrentValues(id)
     const values: Record<string, string> = {}
     for (const f of fields) {
-      // Operator's saved value wins over schema default; we keep the
-      // empty string only when the operator has explicitly cleared it.
       values[f.name] = current[f.name] ?? defaultToString(f.default)
     }
     setEntry(id, { fields, values, loading: false })
@@ -233,24 +220,9 @@ async function saveConfig(id: string) {
   }
   setEntry(id, { saving: true })
   try {
-    const res = await fetch(`/api/v1/sidecar/config?name=${encodeURIComponent(id)}`, {
-      method: 'POST',
-      headers: {
-        ...authHeaders(),
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
-      },
-      body: JSON.stringify(entry.values),
-    })
-    if (!res.ok) {
-      const text = await res.text()
-      throw new Error(`HTTP ${res.status}${text ? `: ${text.slice(0, 200)}` : ''}`)
-    }
+    await post(`/api/v1/sidecar/config?name=${encodeURIComponent(id)}`, entry.values)
     setEntry(id, { saving: false, lastSavedAt: Date.now() })
     if (getEntry(id).autoRestart) {
-      // Auto-restart path: apply-config chains save → apply so the
-      // operator doesn't have to click 🔄. "apply" is a soft restart —
-      // stop is best-effort (sidecar may be down), start is strict.
       showToast(`${id} config 저장됨 — 자동 적용 중...`, 'success', 1500)
       await applyConfigChange(id)
     } else {
@@ -269,19 +241,12 @@ async function applyConfigChange(id: string) {
   setEntry(id, { restarting: true })
   try {
     try {
-      await fetch(`/api/v1/sidecar/stop?name=${encodeURIComponent(id)}`, {
-        method: 'POST',
-        headers: { ...authHeaders(), Accept: 'application/json' },
-      })
+      await post(`/api/v1/sidecar/stop?name=${encodeURIComponent(id)}`, {})
     } catch {
       // Stop failures are non-fatal here — target might not be running.
     }
     await new Promise(r => setTimeout(r, 800))
-    const startRes = await fetch(`/api/v1/sidecar/start?name=${encodeURIComponent(id)}`, {
-      method: 'POST',
-      headers: { ...authHeaders(), Accept: 'application/json' },
-    })
-    if (!startRes.ok) throw new Error(`start HTTP ${startRes.status}`)
+    await post(`/api/v1/sidecar/start?name=${encodeURIComponent(id)}`, {})
     showToast(`${id} 재시작 완료 — 새 config 적용됨`, 'success', 2400)
   } catch (err) {
     showToast(err instanceof Error ? err.message : 'apply failed', 'error')

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -6,6 +6,7 @@ import { signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import type { ComponentChildren } from 'preact'
 import { post } from '../api/core'
+import { DEFAULT_MASC_ORIGIN } from '../config/constants'
 import {
   fetchGateConnectors,
   fetchGateKeepers,
@@ -685,7 +686,7 @@ function ConnectorLivePanel({
     label: 'Browser → Server',
     state: connectorError ? 'down' : 'ok',
     detail: connectorError ? 'gate fetch failed' : 'live',
-    hint: connectorError ? `${connector?.gate_base_url || 'localhost:8935'} 에서 서버 확인` : '',
+    hint: connectorError ? `${connector?.gate_base_url || DEFAULT_MASC_ORIGIN} 에서 서버 확인` : '',
   }
   const serverDot: LivenessDot = (() => {
     if (!connector?.available) {

--- a/dashboard/src/components/cost-dashboard.ts
+++ b/dashboard/src/components/cost-dashboard.ts
@@ -39,6 +39,7 @@ import { LoadingState, ErrorState } from './common/feedback-state'
 import { StatTile } from './common/stat-tile'
 import { FilterChips } from './common/filter-chips'
 import { formatCost, formatPct1 } from '../lib/format-number'
+import { unixSecondsToDate } from '../lib/format-time'
 import { replaceRoute, route } from '../router'
 import {
   type ViewMode,
@@ -645,7 +646,7 @@ function FeedSourceStrip({ meta }: { meta: DashboardFeedMetadata }) {
 
 function HeuristicLog({ events, limit, meta }: { events: HeuristicEvent[]; limit: number; meta: DashboardFeedMetadata }) {
   const fmtTime = (ts: number): string => {
-    const d = new Date(ts * 1000)
+    const d = unixSecondsToDate(ts)
     return d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
   }
 
@@ -696,7 +697,7 @@ function HeuristicLog({ events, limit, meta }: { events: HeuristicEvent[]; limit
 
 function StressBoard({ rows, events, limit, meta }: { rows: AgentStressRow[]; events: StressEvent[]; limit: number; meta: DashboardFeedMetadata }) {
   const fmtTime = (ts: number): string => {
-    const d = new Date(ts * 1000)
+    const d = unixSecondsToDate(ts)
     return d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
   }
 
@@ -1075,7 +1076,7 @@ function AuditLedgerBoard({ entries, count, focus, logId }: { entries: AuditEntr
 function KeeperDecisionsBoard({ events, limit, meta }: { events: KeeperDecision[]; limit: number; meta: DashboardFeedMetadata }) {
   const fmtTime = (ts: number | null): string => {
     if (ts == null) return '—'
-    const d = new Date(ts * 1000)
+    const d = unixSecondsToDate(ts)
     return d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
   }
 

--- a/dashboard/src/components/cost-dashboard.ts
+++ b/dashboard/src/components/cost-dashboard.ts
@@ -40,6 +40,7 @@ import { StatTile } from './common/stat-tile'
 import { FilterChips } from './common/filter-chips'
 import { formatCost, formatPct1 } from '../lib/format-number'
 import { unixSecondsToDate } from '../lib/format-time'
+import { DEFAULT_WINDOW_MINUTES_24H } from '../config/constants'
 import { replaceRoute, route } from '../router'
 import {
   type ViewMode,
@@ -150,7 +151,7 @@ const WINDOW_OPTIONS: Array<{ key: number; label: string }> = [
   { key: 30, label: '30분' },
   { key: 60, label: '1시간' },
   { key: 360, label: '6시간' },
-  { key: 1440, label: '24시간' },
+  { key: DEFAULT_WINDOW_MINUTES_24H, label: '24시간' },
 ]
 
 const windowMinutes = signal<number>(60)

--- a/dashboard/src/components/credential-settings.ts
+++ b/dashboard/src/components/credential-settings.ts
@@ -3,7 +3,7 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { authHeaders, get, post } from '../api/core'
+import { del, get, post } from '../api/core'
 import {
   coerceCredentialType,
   normalizeCredentialsResponse,
@@ -64,14 +64,7 @@ async function createCredential(payload: CredentialCreatePayload): Promise<void>
 }
 
 async function deleteCredential(id: string): Promise<void> {
-  const res = await fetch(`/api/v1/credentials/${encodeURIComponent(id)}`, {
-    method: 'DELETE',
-    headers: authHeaders(),
-  })
-  if (!res.ok) {
-    const text = await res.text().catch(() => '삭제 요청 실패')
-    throw new Error(text)
-  }
+  await del(`/api/v1/credentials/${encodeURIComponent(id)}`)
 }
 
 // ── Helpers ──────────────────────────────────────────────

--- a/dashboard/src/components/doctor-panel.ts
+++ b/dashboard/src/components/doctor-panel.ts
@@ -6,6 +6,7 @@
 // Backend contract: see `docs/DOCTOR-ARCHITECTURE.md` "Backend endpoint" section.
 
 import { html } from 'htm/preact'
+import { capitalize } from '../lib/format-string'
 import { useSignal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { get } from '../api/core'
@@ -105,7 +106,7 @@ function severityBandKind(code: number): BandKind {
 // for display; config kind renders as "설정".
 export function doctorHeading(entry: DoctorEntry): string {
   if (entry.kind === 'config') return '설정'
-  return entry.name.charAt(0).toUpperCase() + entry.name.slice(1)
+  return capitalize(entry.name)
 }
 
 // Aggregate breakdown string, e.g. "6건 진단 · 정상 3 · 경고 2 · 오류 1".

--- a/dashboard/src/components/excuse-patterns.ts
+++ b/dashboard/src/components/excuse-patterns.ts
@@ -37,8 +37,9 @@ function handleSave(event: Event) {
     }).finally(() => {
       saving.value = false
     })
-  } catch (err: any) {
-    saveMessage.value = `잘못된 형식: ${err.message}`
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    saveMessage.value = `잘못된 형식: ${msg}`
   }
 }
 

--- a/dashboard/src/components/feature-health.ts
+++ b/dashboard/src/components/feature-health.ts
@@ -3,6 +3,7 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
+import { capitalize } from '../lib/format-string'
 import { get } from '../api/core'
 import { createAsyncResource, type AsyncResource } from '../lib/async-state'
 import { formatTimeAgo } from '../lib/format-time'
@@ -163,7 +164,7 @@ function FeatureItem({ item }: { item: FeatureHealthItem }) {
 }
 
 function CategorySection({ category, categoryData }: { category: string; categoryData: { total: number; enabled: number; features: FeatureHealthItem[] } }) {
-  const categoryLabel = category.charAt(0).toUpperCase() + category.slice(1)
+  const categoryLabel = capitalize(category)
   const enabledRatio = categoryData.total > 0 ? Math.round((categoryData.enabled / categoryData.total) * 100) : 0
 
   return html`

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -29,6 +29,7 @@ import type {
 import { fleetCompositeSnapshot } from '../composite-signals'
 import { dispatchOperatorAction } from '../operator-store'
 import { showToast } from './common/toast'
+import { unixSecondsToDate } from '../lib/format-time'
 import { TextInput } from './common/input'
 import {
   displayState,
@@ -1035,7 +1036,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
       <header class="flex flex-wrap items-baseline gap-3 border-b border-[var(--color-border-default)] p-3">
         <h2 class="text-sm font-semibold text-[var(--color-fg-muted)]">Fleet 통합 (KSM × KTC × KDP × KCL × KMC × KCB)</h2>
         <span class="text-xs text-[var(--color-fg-muted)]0">
-          키퍼 ${data.count}명 · ${new Date(data.generated_at * 1000).toLocaleTimeString()} 업데이트
+          키퍼 ${data.count}명 · ${unixSecondsToDate(data.generated_at).toLocaleTimeString()} 업데이트
         </span>
         <${TextInput}
           type="search"

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -3,6 +3,7 @@ import type { DashboardNamespaceTruthResponse } from '../types'
 import { telemetrySourceLabel } from '../config/telemetry-sources'
 import type { Keeper, StopCause } from '../types'
 import { formatElapsedCompact } from '../lib/format-time'
+import { formatMsCompact } from '../lib/format-number'
 import { normalizeStopCause } from '../lib/stop-cause'
 import {
   keeperActivityDisplay,
@@ -537,8 +538,7 @@ export function formatPercent(value: number | null, digits = 0): string {
 
 export function formatLatency(ms: number): string {
   if (!Number.isFinite(ms) || ms <= 0) return '-'
-  if (ms < 1000) return `${Math.round(ms)}ms`
-  return `${(ms / 1000).toFixed(1)}s`
+  return formatMsCompact(ms)
 }
 
 export function formatActivity(seconds: number | null): string {

--- a/dashboard/src/components/fsm-hub-derivations.ts
+++ b/dashboard/src/components/fsm-hub-derivations.ts
@@ -1,4 +1,5 @@
 import type { KeeperCompositeSnapshot } from '../api/keeper'
+import { unixSecondsToDate } from '../lib/format-time'
 
 import {
   type CompositeObservation,
@@ -269,7 +270,7 @@ export function deriveTimeAxisTicks(
   const ticks: TimeAxisTick[] = []
   for (let ts = firstTick; ts <= spanEnd && ticks.length < maxTicks; ts += step) {
     if (ts <= spanStart) continue
-    ticks.push({ ts, label: formatter.format(new Date(ts * 1000)) })
+    ticks.push({ ts, label: formatter.format(unixSecondsToDate(ts)) })
   }
   return ticks
 }

--- a/dashboard/src/components/fsm-hub-pipeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-pipeline-panels.ts
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 
 import type { KeeperCompositeSnapshot } from '../api/keeper'
 import { nowSecondsSignal, useNowSecondsTicker } from '../lib/now-signal'
+import { getPhaseStyle } from './keeper-phase-indicator'
 
 import {
   type CompositeObservation,
@@ -285,24 +286,8 @@ export function HeroPhase({
     return undefined
   }, [snapshot.phase])
 
-  // Wire format is lowercase (phase_to_string in keeper_state_machine.ml).
-  // 12 emitted phases get an explicit tone; unmapped falls through to neutral accent.
-  const phaseColor: Record<string, string> = {
-    running: 'text-[var(--color-status-ok)]',
-    offline: 'text-[var(--color-fg-disabled)]',
-    stopped: 'text-[var(--color-fg-disabled)]',
-    overflowed: 'text-[var(--color-status-warn)]',
-    compacting: 'text-[var(--color-status-warn)]',
-    handing_off: 'text-[var(--color-accent-fg)]',
-    failing: 'text-[var(--bad-light)]',
-    crashed: 'text-[var(--bad-light)]',
-    dead: 'text-[var(--bad-light)]',
-    zombie: 'text-[var(--bad-light)]',
-    draining: 'text-[var(--color-status-warn)]',
-    paused: 'text-[var(--color-status-warn)]',
-    restarting: 'text-[var(--color-status-warn)]',
-  }
-  const color = phaseColor[snapshot.phase] ?? 'text-[var(--color-accent-fg)]'
+  const phaseStyle = getPhaseStyle(snapshot.phase)
+  const color = `text-[${phaseStyle.color}]`
   const heldFor = phaseSince != null ? fmtDuration(Math.max(0, now - phaseSince)) : null
   // `collapsed_from` is set by the backend only when phase has collapsed onto
   // a parent projection (e.g. a 7-phase composite Stable). The backend

--- a/dashboard/src/components/fsm-hub-timeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-timeline-panels.ts
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef } from 'preact/hooks'
 import { DashedNotice } from './common/dashed-notice'
 import { TextInput } from './common/input'
 import { nowSecondsSignal, useNowSecondsTicker } from '../lib/now-signal'
+import { unixSecondsToDate } from '../lib/format-time'
 
 import {
   type CompositeObservation,
@@ -164,7 +165,7 @@ export function SwimlaneTimeline({
     ...(showSeconds ? { second: '2-digit' } : {}),
     hour12: false,
   })
-  const fmtAbs = (ts: number) => absFormatter.format(new Date(ts * 1000))
+  const fmtAbs = (ts: number) => absFormatter.format(unixSecondsToDate(ts))
   const laneDensity: Record<string, number> = {}
   let busiestLane = ''
   let busiestCount = 0

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useReducer, useRef, useState } from 'preact/hooks'
 import { InlineSpinner } from './common/inline-spinner'
 import { DialogOverlay } from './common/dialog'
 import { TextInput } from './common/input'
+import { formatMsCompact } from '../lib/format-number'
 
 import {
   fetchKeeperComposite,
@@ -130,11 +131,7 @@ function shortText(value: string | null | undefined, max = 80): string {
   return text.length > max ? `${text.slice(0, max)}...` : text
 }
 
-function formatMs(ms: number | null | undefined): string {
-  if (ms == null || !Number.isFinite(ms) || ms < 0) return ''
-  if (ms >= 1000) return `${Math.round(ms / 1000)}s`
-  return `${Math.round(ms)}ms`
-}
+const formatMs = formatMsCompact
 
 function executionReceiptTone(execution: KeeperCompositeExecution | undefined): 'ok' | 'warn' | 'bad' | 'muted' {
   if (!execution?.latest_receipt_present) return 'muted'

--- a/dashboard/src/components/goal-loop-panel.ts
+++ b/dashboard/src/components/goal-loop-panel.ts
@@ -8,6 +8,7 @@ import { Table, type TableColumn } from './common/table'
 import { Drawer } from './common/drawer'
 import { CollapsibleSection } from './common/collapsible'
 import { fetchGoalLoopStatus } from '../api/goal-loop'
+import { formatMsCompact } from '../lib/format-number'
 import {
   GOAL_LOOP_PHASES,
   auditCatalogSummary,
@@ -57,7 +58,7 @@ function formatValue(value: unknown, format: MetricFormat): string {
       return displayValue(value)
     case 'duration_ms':
       if (typeof value === 'number' && Number.isFinite(value))
-        return value >= 1000 ? `${(value / 1000).toFixed(2)}s` : `${value.toFixed(0)}ms`
+        return formatMsCompact(value)
       return displayValue(value)
     case 'boolean':
       if (typeof value === 'boolean') return value ? 'yes' : 'no'

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -3,6 +3,7 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { useEffect, useMemo } from 'preact/hooks'
+import { SECONDS_PER_HOUR } from '../../lib/format-time'
 import { fetchDashboardGoalDetail, fetchDashboardGoalsTree } from '../../api/dashboard'
 import {
   goalTreeData as treeData,
@@ -1229,7 +1230,7 @@ function GoalDetailPanel({
           <${DetailMetric} label="목표 검증" value=${selectedNode.pending_verification_count} tone=${selectedNode.pending_verification_count > 0 ? 'warn' : 'default'} />
           <${DetailMetric} label="인프라 위험" value=${selectedNode.infra_risk_count} tone=${selectedNode.infra_risk_count > 0 ? 'bad' : 'default'} />
           <${DetailMetric} label="연결 출처" value=${selectedNode.linkage_source} tone=${selectedNode.linkage_warning_count > 0 ? 'warn' : 'default'} />
-          <${DetailMetric} label="최근 활동" value=${selectedNode.stagnation_seconds > 0 ? `${Math.floor(selectedNode.stagnation_seconds / 3600)}h idle` : 'now'} tone=${selectedNode.badges.includes('stalled') ? 'warn' : 'default'} />
+          <${DetailMetric} label="최근 활동" value=${selectedNode.stagnation_seconds > 0 ? `${Math.floor(selectedNode.stagnation_seconds / SECONDS_PER_HOUR)}h idle` : 'now'} tone=${selectedNode.badges.includes('stalled') ? 'warn' : 'default'} />
         </div>
 
         <${GoalVerificationEvidencePanel} summary=${verificationSummary} />

--- a/dashboard/src/components/goals/task-detail-overlay.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.ts
@@ -1,6 +1,7 @@
 // Task detail overlay — opens when clicking a task title in the kanban board
 
 import { html } from 'htm/preact'
+import type { VNode } from 'preact'
 import { useRef } from 'preact/hooks'
 import { Check, X, ArrowRight, Dot, UserPlus } from 'lucide-preact'
 import { DialogOverlay } from '../common/dialog'
@@ -44,7 +45,7 @@ function SectionTitle({ children }: { children: unknown }) {
 
 // -- Event timeline (inline, NormalizedTaskEvent shape) --------------
 
-function eventBadge(label: string): { icon: any; color: string } {
+function eventBadge(label: string): { icon: VNode; color: string } {
   switch (label) {
     case 'claim':
     case 'claimed': return { icon: html`<${UserPlus} size=${14} />`, color: 'text-accent-fg' }

--- a/dashboard/src/components/goals/task-stale-alert.ts
+++ b/dashboard/src/components/goals/task-stale-alert.ts
@@ -13,6 +13,7 @@ import { computed } from '@preact/signals'
 import { tasks } from '../../store'
 import { navigate } from '../../router'
 import type { Task } from '../../types'
+import { SECONDS_PER_MINUTE, SECONDS_PER_HOUR, SECONDS_PER_DAY } from '../../lib/format-time'
 
 // 30 minutes in seconds. Matches the spec's "claim_age ends in `h` or
 // > 10 minutes" rule of thumb but lifted slightly to avoid noise on
@@ -34,10 +35,10 @@ function ageSeconds(task: Task, nowMs = Date.now()): number | null {
 }
 
 function ageLabel(s: number): string {
-  if (s < 60) return `${s}s`
-  if (s < 3600) return `${Math.floor(s / 60)}m`
-  if (s < 86400) return `${Math.floor(s / 3600)}h`
-  return `${Math.floor(s / 86400)}d`
+  if (s < SECONDS_PER_MINUTE) return `${s}s`
+  if (s < SECONDS_PER_HOUR) return `${Math.floor(s / SECONDS_PER_MINUTE)}m`
+  if (s < SECONDS_PER_DAY) return `${Math.floor(s / SECONDS_PER_HOUR)}h`
+  return `${Math.floor(s / SECONDS_PER_DAY)}d`
 }
 
 export function deriveStaleTaskEntries(taskList: Task[], nowMs = Date.now()): StaleEntry[] {

--- a/dashboard/src/components/governance-monitor.ts
+++ b/dashboard/src/components/governance-monitor.ts
@@ -8,6 +8,7 @@ import { ErrorState, LoadingState } from './common/feedback-state'
 import { Select } from './common/select'
 import { TextInput } from './common/input'
 import { StatTile } from './common/stat-tile'
+import { isRecord } from './common/normalize'
 import { StatusChip } from './common/status-chip'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
 import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
@@ -57,10 +58,6 @@ interface GovernanceToolEvents {
   window_minutes: number
   tool_rejections: ToolRejection[]
   approval_queue: ApprovalQueue
-}
-
-function isRecord(v: unknown): v is Record<string, unknown> {
-  return typeof v === 'object' && v !== null && !Array.isArray(v)
 }
 
 async function fetchGovernanceToolEvents(

--- a/dashboard/src/components/governance-utils.ts
+++ b/dashboard/src/components/governance-utils.ts
@@ -1,4 +1,5 @@
 import type { GovernanceDecisionItem } from '../types'
+import { SECONDS_PER_HOUR, SECONDS_PER_DAY, SECONDS_PER_MINUTE } from '../lib/format-time'
 
 export type GovernanceFilter = 'open' | 'pending_ruling' | 'needs_human_gate' | 'executed' | 'blocked'
 
@@ -48,7 +49,7 @@ export function kindLabel(value: string): string {
 
 export function formatAgeSummary(seconds: number | null | undefined): string | null {
   if (seconds == null) return null
-  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`
-  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`
-  return `${Math.floor(seconds / 86400)}d`
+  if (seconds < SECONDS_PER_HOUR) return `${Math.floor(seconds / SECONDS_PER_MINUTE)}m`
+  if (seconds < SECONDS_PER_DAY) return `${Math.floor(seconds / SECONDS_PER_HOUR)}h`
+  return `${Math.floor(seconds / SECONDS_PER_DAY)}d`
 }

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -4,6 +4,7 @@ import { AlertTriangle } from 'lucide-preact'
 import { useEffect, useMemo } from 'preact/hooks'
 import type { GovernanceJudgeSummary, KeeperApprovalQueueItem, KeeperApprovalRule } from '../types'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
+import { SECONDS_PER_DAY } from '../lib/format-time'
 import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { Card } from './common/card'
 import type { KpiCellKind } from './kpi-shared'
@@ -80,7 +81,7 @@ function GovernanceSummaryStrip() {
   const judge = data?.judge
   const oldestAge = summary?.oldest_open_case_age_s
   const lastActivityAge = summary?.last_activity_age_s
-  const isStale = (oldestAge != null && oldestAge > 86400) || (lastActivityAge != null && lastActivityAge > 86400)
+  const isStale = (oldestAge != null && oldestAge > SECONDS_PER_DAY) || (lastActivityAge != null && lastActivityAge > SECONDS_PER_DAY)
   const judgmentCount = data?.judgments?.length ?? 0
   const approvalCount = data?.approval_queue?.length ?? summary?.needs_human_gate ?? 0
   const judgeOnlyLabel =

--- a/dashboard/src/components/ide/code-document-store.ts
+++ b/dashboard/src/components/ide/code-document-store.ts
@@ -1,5 +1,6 @@
 import { signal } from '@preact/signals'
 import { fetchIdeRegions, type IdeCodeRegion } from '../../api/ide'
+import { isRecord } from '../common/normalize'
 
 export interface CodeDocumentSource {
   readonly file_path: string | null
@@ -137,8 +138,4 @@ function normalizeMaxLines(value: number | undefined): number {
 
 function normalizeNonEmptyString(value: unknown): string | null {
   return typeof value === 'string' && value.trim() !== '' ? value.trim() : null
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }

--- a/dashboard/src/components/ide/code-document-store.ts
+++ b/dashboard/src/components/ide/code-document-store.ts
@@ -1,6 +1,6 @@
 import { signal } from '@preact/signals'
 import { fetchIdeRegions, type IdeCodeRegion } from '../../api/ide'
-import { isRecord } from '../common/normalize'
+import { isRecord, asNullableString } from '../common/normalize'
 
 export interface CodeDocumentSource {
   readonly file_path: string | null
@@ -95,8 +95,8 @@ export function createCodeDocumentStore(
 
 function normalizeSource(source: unknown, maxLines: number): CodeDocumentSnapshot | null {
   if (!isRecord(source)) return null
-  const filePath = normalizeNonEmptyString(source.file_path)
-  const language = normalizeNonEmptyString(source.language)
+  const filePath = asNullableString(source.file_path)
+  const language = asNullableString(source.language)
   if (!filePath || !language || typeof source.content !== 'string') return null
 
   const content = source.content.replace(/\r\n?/g, '\n')
@@ -136,6 +136,3 @@ function normalizeMaxLines(value: number | undefined): number {
   return 5_000
 }
 
-function normalizeNonEmptyString(value: unknown): string | null {
-  return typeof value === 'string' && value.trim() !== '' ? value.trim() : null
-}

--- a/dashboard/src/components/ide/ide-activity-panel.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { get } from '../../api/core'
+import { asRecord } from '../common/normalize'
 import { keeperHueIndex } from '../../../design-system/headless-core/keeper-line-ownership'
 import type { IdeAnnotation } from '../../api/schemas/ide-annotations'
 import type { UnifiedDiffRow } from '../../api/workspace'
@@ -222,12 +223,12 @@ function contextFromPayloadAndTags(
 function mergePayloadContext(next: MutableRunActivityContext, payload: unknown): void {
   if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) return
   const record = payload as Record<string, unknown>
-  mergeContextRecord(next, nestedRecord(record.context))
-  mergeContextRecord(next, nestedRecord(record.evidence_ref))
-  const failureEnvelope = nestedRecord(record.failure_envelope)
-  mergeContextRecord(next, nestedRecord(failureEnvelope?.evidence_ref))
-  mergeContextRecord(next, nestedRecord(record.tool_args))
-  mergeContextRecord(next, nestedRecord(record.input))
+  mergeContextRecord(next, asRecord(record.context))
+  mergeContextRecord(next, asRecord(record.evidence_ref))
+  const failureEnvelope = asRecord(record.failure_envelope)
+  mergeContextRecord(next, asRecord(failureEnvelope?.evidence_ref))
+  mergeContextRecord(next, asRecord(record.tool_args))
+  mergeContextRecord(next, asRecord(record.input))
   mergeContextRecord(next, record, true)
 }
 
@@ -272,12 +273,6 @@ function mergeContextRecord(
   if (operationId && (overwrite || next.operation_id === undefined)) next.operation_id = operationId
   const workerRunId = stringValue(record.worker_run_id)
   if (workerRunId && (overwrite || next.worker_run_id === undefined)) next.worker_run_id = workerRunId
-}
-
-function nestedRecord(value: unknown): Record<string, unknown> | null {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-    ? value as Record<string, unknown>
-    : null
 }
 
 function mergeTagContext(next: MutableRunActivityContext, rawTag: string): void {

--- a/dashboard/src/components/ide/ide-activity-panel.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
+import { get } from '../../api/core'
 import { keeperHueIndex } from '../../../design-system/headless-core/keeper-line-ownership'
 import type { IdeAnnotation } from '../../api/schemas/ide-annotations'
 import type { UnifiedDiffRow } from '../../api/workspace'
@@ -195,9 +196,7 @@ function mapApiEvent(event: ApiActivityEvent, roomId: string): RunActivityEvent 
 
 async function fetchActivityEvents(): Promise<ActivityFetchResult> {
   try {
-    const res = await fetch('/api/v1/activity/events?limit=50')
-    if (!res.ok) return { events: EMPTY_ACTIVITY, roomId: DEFAULT_ROOM_ID, ok: false }
-    const data: ApiActivityResponse = await res.json()
+    const data = await get<ApiActivityResponse>('/api/v1/activity/events?limit=50')
     const rawEvents = data.events
     if (!Array.isArray(rawEvents) || rawEvents.length === 0) {
       return { events: EMPTY_ACTIVITY, roomId: DEFAULT_ROOM_ID, ok: true }

--- a/dashboard/src/components/ide/ide-context-lens.ts
+++ b/dashboard/src/components/ide/ide-context-lens.ts
@@ -9,6 +9,7 @@ import type { AnchoredThread } from './anchored-thread-rail-store'
 import type { KeeperCursorOverlay } from './keeper-cursor-overlay'
 import type { RunActivityEvent } from './run-activity-store'
 import { focusIdeContextAnchor, normalizeIdeContextFilePath, normalizeIdeContextLine } from './ide-state'
+import { truncate } from '../../lib/truncate'
 
 type SurfaceStatus = 'linked' | 'quiet'
 
@@ -1274,7 +1275,3 @@ function cleanId(value: string | null | undefined): string | null {
   return trimmed ? trimmed : null
 }
 
-function truncate(value: string, maxLength: number): string {
-  if (value.length <= maxLength) return value
-  return `${value.slice(0, Math.max(0, maxLength - 3))}...`
-}

--- a/dashboard/src/components/ide/ide-conversation-rail.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
+import { get } from '../../api/core'
 import { bridgePostsToTrace } from './anchored-thread-trace-bridge'
 import { bridgeCascadeEventsToTrace } from './cascade-hop-trace-bridge'
 import { bridgeDecisionsToTrace } from './decision-log-trace-bridge'
@@ -88,9 +89,7 @@ type ReplayRailItem =
 
 async function fetchBoardPosts(): Promise<ReadonlyArray<BoardPost>> {
   try {
-    const res = await fetch('/api/v1/board?limit=20&exclude_system=true&exclude_automation=true')
-    if (!res.ok) return EMPTY_POSTS
-    const data = await res.json()
+    const data = await get<unknown>('/api/v1/board?limit=20&exclude_system=true&exclude_automation=true')
     if (Array.isArray(data) && data.length > 0) return data as BoardPost[]
     return EMPTY_POSTS
   } catch {

--- a/dashboard/src/components/ide/ide-lsp-client.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.ts
@@ -381,7 +381,6 @@ class LspConnection {
 
     ws.onopen = () => {
       if (this.disposed) { ws.close(); return }
-      console.log('[LSP] WebSocket connected')
       this.initialize()
     }
 
@@ -395,7 +394,6 @@ class LspConnection {
     }
 
     ws.onclose = () => {
-      console.log('[LSP] WebSocket closed')
       this.initialized = false
       if (!this.disposed) {
         setTimeout(() => { if (!this.disposed) this.connect() }, 5000)
@@ -470,7 +468,6 @@ class LspConnection {
       })
       this.sendNotification('initialized', {})
       this.initialized = true
-      console.log('[LSP] initialized')
     } catch (err) {
       if (!this.disposed) {
         console.error('[LSP] initialize failed:', err)

--- a/dashboard/src/components/ide/ide-lsp-client.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.ts
@@ -16,6 +16,7 @@ import {
 import { StateField, StateEffect, RangeSetBuilder, type Extension } from '@codemirror/state'
 import { signal } from '@preact/signals'
 import { normalizeIdeContextFilePath } from './ide-state'
+import { DEFAULT_MASC_ORIGIN } from '../../config/constants'
 
 const DEFAULT_LANGUAGE_ID = 'text' as const
 
@@ -373,7 +374,7 @@ class LspConnection {
 
   connect(): void {
     if (this.disposed) return
-    const origin = typeof window !== 'undefined' ? window.location.origin : 'http://localhost:8935'
+    const origin = typeof window !== 'undefined' ? window.location.origin : DEFAULT_MASC_ORIGIN
     const wsUrl = origin.replace(/^http/, 'ws') + '/api/v1/ide/lsp'
     const ws = new WebSocket(wsUrl)
     this.ws = ws

--- a/dashboard/src/components/ide/ide-presence-strip.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.ts
@@ -1,5 +1,7 @@
 import { html } from 'htm/preact'
 import { useEffect, useMemo, useState } from 'preact/hooks'
+import { fetchWithTimeout, get } from '../../api/core'
+import { DEFAULT_GET_TIMEOUT_MS } from '../../config/constants'
 import { KeeperBadge } from '../keeper-badge'
 import {
   createKeeperPresenceStore,
@@ -144,13 +146,19 @@ export function parseWorktreeSSE(body: string): WorktreeEntry[] {
   return entries
 }
 
-/** Fetch worktree status from the SSE endpoint. Returns [] on failure. */
+/** Fetch worktree status from the SSE endpoint. Returns [] on failure.
+ *  Uses fetchWithTimeout directly because the endpoint returns SSE-formatted
+ *  text (data: lines), not JSON — get<T>() would fail at JSON.parse. */
 async function fetchWorktreeEntries(): Promise<WorktreeEntry[]> {
   try {
-    const res = await fetch('/api/dashboard/worktree-status')
+    const res = await fetchWithTimeout(
+      '/api/dashboard/worktree-status',
+      { headers: {} },
+      DEFAULT_GET_TIMEOUT_MS,
+    )
     if (!res.ok) return []
-    const body = await res.text()
-    return parseWorktreeSSE(body)
+    const text = await res.text()
+    return parseWorktreeSSE(text)
   } catch {
     return []
   }
@@ -163,18 +171,13 @@ interface PresenceData {
 
 async function fetchPresence(): Promise<PresenceData> {
   try {
-    const [agentsRes, statusRes, worktrees] = await Promise.all([
-      fetch('/api/v1/agents?limit=20'),
-      fetch('/api/v1/status'),
+    const [agentsData, statusData, worktrees] = await Promise.all([
+      get<{ agents: ApiAgent[] }>('/api/v1/agents?limit=20'),
+      get<ApiStatus>('/api/v1/status'),
       fetchWorktreeEntries(),
     ])
-    if (!agentsRes.ok || !statusRes.ok) {
-      return { snapshot: disconnectedSnapshot('api_unavailable'), worktrees }
-    }
-    const agentsData = await agentsRes.json()
-    const statusData = await statusRes.json()
     const agents: ApiAgent[] = Array.isArray(agentsData.agents) ? agentsData.agents : []
-    const snapshot = agentsToPresence(agents, statusData as ApiStatus, worktrees)
+    const snapshot = agentsToPresence(agents, statusData, worktrees)
     return { snapshot, worktrees }
   } catch {
     return { snapshot: disconnectedSnapshot('fetch_failed'), worktrees: [] }

--- a/dashboard/src/components/ide/ide-presence-strip.ts
+++ b/dashboard/src/components/ide/ide-presence-strip.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { useEffect, useMemo, useState } from 'preact/hooks'
-import { fetchWithTimeout, get } from '../../api/core'
+import { authHeaders, fetchWithTimeout, get } from '../../api/core'
 import { DEFAULT_GET_TIMEOUT_MS } from '../../config/constants'
 import { KeeperBadge } from '../keeper-badge'
 import {
@@ -153,7 +153,7 @@ async function fetchWorktreeEntries(): Promise<WorktreeEntry[]> {
   try {
     const res = await fetchWithTimeout(
       '/api/dashboard/worktree-status',
-      { headers: {} },
+      { headers: authHeaders() },
       DEFAULT_GET_TIMEOUT_MS,
     )
     if (!res.ok) return []

--- a/dashboard/src/components/ide/inspector-keeper-bdi.ts
+++ b/dashboard/src/components/ide/inspector-keeper-bdi.ts
@@ -2,6 +2,7 @@ import { computed } from '@preact/signals'
 import { html } from 'htm/preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import { activeKeeperName } from '../../keeper-state'
+import { get } from '../../api/core'
 import { bridgeBdiSnapshotsToTrace } from './bdi-snapshot-trace-bridge'
 import { asBoolean, asNumber, asString, isRecord, toIsoTimestamp } from '../common/normalize'
 import { clearPins, headPinnedKeeper, pinKeeper } from './multi-keeper-pin-store'
@@ -128,9 +129,12 @@ export function normalizeKeeperBdiSnapshot(raw: unknown): KeeperBdiSnapshot | nu
 }
 
 async function fetchKeeperBdiSnapshot(keeperName: string, signal: AbortSignal): Promise<KeeperBdiSnapshot | null> {
-  const res = await fetch(`/api/v1/keepers/${encodeURIComponent(keeperName)}/bdi-snapshot`, { signal })
-  if (!res.ok) return null
-  return normalizeKeeperBdiSnapshot(await res.json())
+  try {
+    const raw = await get<unknown>(`/api/v1/keepers/${encodeURIComponent(keeperName)}/bdi-snapshot`, { signal })
+    return normalizeKeeperBdiSnapshot(raw)
+  } catch {
+    return null
+  }
 }
 
 function useInspectorKeeperPin(): InspectorKeeperPin | null {

--- a/dashboard/src/components/ide/inspector-multi-keeper-bdi.ts
+++ b/dashboard/src/components/ide/inspector-multi-keeper-bdi.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
+import { get } from '../../api/core'
 import {
   BdiRouteLinks,
   InspectorKeeperBDI,
@@ -167,17 +168,12 @@ function useKeeperBdiSnapshot(keeperName: string, pollMs: number): KeeperBdiSlot
 
     const refresh = async () => {
       try {
-        const res = await fetch(
+        const raw = await get<unknown>(
           `/api/v1/keepers/${encodeURIComponent(name)}/bdi-snapshot`,
           { signal: controller.signal },
         )
         if (controller.signal.aborted) return
-        if (!res.ok) {
-          setError('snapshot unavailable')
-          setSnapshot(null)
-          return
-        }
-        const next = normalizeKeeperBdiSnapshot(await res.json())
+        const next = normalizeKeeperBdiSnapshot(raw)
         if (controller.signal.aborted) return
         setSnapshot(next)
         setError(next ? null : 'snapshot unavailable')

--- a/dashboard/src/components/ide/keeper-presence-store.ts
+++ b/dashboard/src/components/ide/keeper-presence-store.ts
@@ -1,4 +1,5 @@
 import { signal } from '@preact/signals'
+import { isRecord } from '../common/normalize'
 
 export type KeeperPresenceStatus = 'active' | 'idle' | 'blocked'
 
@@ -177,10 +178,6 @@ function compareEntries(a: KeeperPresenceEntry, b: KeeperPresenceEntry): number 
   if (statusDelta !== 0) return statusDelta
   if (a.last_seen_ms !== b.last_seen_ms) return b.last_seen_ms - a.last_seen_ms
   return a.keeper_id.localeCompare(b.keeper_id)
-}
-
-function isRecord(value: unknown): value is UnknownRecord {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 function hasNonEmptyString(record: UnknownRecord, key: string): boolean {

--- a/dashboard/src/components/ide/run-activity-store.ts
+++ b/dashboard/src/components/ide/run-activity-store.ts
@@ -7,6 +7,7 @@
  */
 
 import { signal } from '@preact/signals'
+import { isRecord } from '../common/normalize'
 
 const DEFAULT_MAX_EVENTS = 200
 const RUN_ACTIVITY_VERBS = [
@@ -147,10 +148,6 @@ function validEventForRun(event: unknown, runId: string): event is RunActivityEv
   if (event.tags !== undefined && !isStringArray(event.tags)) return false
   if (event.context !== undefined && !isRunActivityContext(event.context)) return false
   return Number.isFinite(event.timestamp_ms)
-}
-
-function isRecord(value: unknown): value is UnknownRecord {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 function hasNonEmptyString(record: UnknownRecord, key: string): boolean {

--- a/dashboard/src/components/journey-waterfall-state.ts
+++ b/dashboard/src/components/journey-waterfall-state.ts
@@ -4,6 +4,7 @@ import type {
   TrajectoryResponse,
 } from '../api/dashboard'
 import type { KeeperRuntimeTraceResponse } from '../api/keeper'
+import { asNullableString } from './common/normalize'
 import type { Keeper } from '../types'
 import {
   buildTraceEvents,
@@ -114,16 +115,12 @@ const EMPTY_TIMELINE: AgentTimelineResponse = {
   },
 }
 
-function stringValue(value: unknown): string | null {
-  return typeof value === 'string' && value.trim() !== '' ? value : null
-}
-
 function numberValue(value: unknown): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null
 }
 
 function traceEventSource(event: UnifiedTraceEvent): WaterfallEntrySource {
-  const origin = stringValue(event.detail.trace_origin)
+  const origin = asNullableString(event.detail.trace_origin)
   if (origin === 'trajectory+tool_call_log') return 'trajectory+tool_call_log'
   if (origin === 'tool_call_log') return 'tool_call_log'
   if (origin === 'trajectory') return 'trajectory'
@@ -131,7 +128,7 @@ function traceEventSource(event: UnifiedTraceEvent): WaterfallEntrySource {
 }
 
 function traceEventTraceId(event: UnifiedTraceEvent): string | null {
-  return stringValue(event.detail.trace_id)
+  return asNullableString(event.detail.trace_id)
 }
 
 function traceEventStatus(event: UnifiedTraceEvent): WaterfallEntryStatus {

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -12,7 +12,7 @@ import {
   updateKeeperCascade,
   type CascadeInvalidProfile,
 } from '../api/dashboard'
-import type { KeeperConfigUpdatePayload } from '../api/dashboard'
+import type { KeeperConfigUpdatePayload, SandboxProfile, SandboxNetworkMode, SharedMemoryScope } from '../api/dashboard'
 import type { GoalTreeNode, KeeperConfig, KeeperHookSlot } from '../types'
 import type { KeeperConfigLoadStatus } from './keeper-detail-source'
 import { formatTokens, formatPct, formatCost } from '../lib/format-number'
@@ -123,9 +123,6 @@ function buildPayload(draft: EditDraft, orig: KeeperConfig): KeeperConfigUpdateP
 }
 
 // Runtime config draft for sandbox/proactive/compaction/handoff inline editing
-export type SandboxProfile = 'local' | 'docker'
-export type SandboxNetworkMode = 'none' | 'inherit'
-export type SharedMemoryScope = 'disabled' | 'room'
 
 export type RuntimeDraft = {
   sandbox_profile: SandboxProfile

--- a/dashboard/src/components/keeper-detail-ctx-utils.ts
+++ b/dashboard/src/components/keeper-detail-ctx-utils.ts
@@ -1,4 +1,5 @@
 import type { PromptSegmentTelemetry } from '../types'
+import { SECONDS_PER_MINUTE, SECONDS_PER_HOUR } from '../lib/format-time'
 
 // ── Context pressure thresholds (shared across KPIs, charts) ─
 export const CTX_CRITICAL_PCT = 85
@@ -77,7 +78,7 @@ export function filterCtxCompositionEntries(
 }
 
 export function formatDuration(sec: number): string {
-  if (sec < 60) return `${sec}초`
-  if (sec < 3600) return `${Math.floor(sec / 60)}분`
-  return `${Math.floor(sec / 3600)}시간 ${Math.floor((sec % 3600) / 60)}분`
+  if (sec < SECONDS_PER_MINUTE) return `${sec}초`
+  if (sec < SECONDS_PER_HOUR) return `${Math.floor(sec / SECONDS_PER_MINUTE)}분`
+  return `${Math.floor(sec / SECONDS_PER_HOUR)}시간 ${Math.floor((sec % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE)}분`
 }

--- a/dashboard/src/components/keeper-detail-ctx-utils.ts
+++ b/dashboard/src/components/keeper-detail-ctx-utils.ts
@@ -1,5 +1,7 @@
 import type { PromptSegmentTelemetry } from '../types'
-import { SECONDS_PER_MINUTE, SECONDS_PER_HOUR } from '../lib/format-time'
+
+// Re-export formatDurationCompound from SSOT for backward-compatible consumers.
+export { formatDurationCompound as formatDuration } from '../lib/format-time'
 
 // ── Context pressure thresholds (shared across KPIs, charts) ─
 export const CTX_CRITICAL_PCT = 85
@@ -75,10 +77,4 @@ export function filterCtxCompositionEntries(
     if (key.toLowerCase().includes(needle)) return true
     return ctxSegmentLabel(key).toLowerCase().includes(needle)
   })
-}
-
-export function formatDuration(sec: number): string {
-  if (sec < SECONDS_PER_MINUTE) return `${sec}초`
-  if (sec < SECONDS_PER_HOUR) return `${Math.floor(sec / SECONDS_PER_MINUTE)}분`
-  return `${Math.floor(sec / SECONDS_PER_HOUR)}시간 ${Math.floor((sec % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE)}분`
 }

--- a/dashboard/src/components/keeper-detail-history.ts
+++ b/dashboard/src/components/keeper-detail-history.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
 import { formatPct1 } from '../lib/format-number'
+import { unixSecondsToDate } from '../lib/format-time'
 import { ActionButton } from './common/button'
 import { requestConfirm } from './common/confirm-dialog'
 import {
@@ -30,7 +31,7 @@ export function MonoBadge({ children }: { children: unknown }) {
 
 function formatCheckpointTime(timestamp: number): string {
   if (!Number.isFinite(timestamp) || timestamp <= 0) return '-'
-  return new Date(timestamp * 1000).toLocaleString('ko-KR', {
+  return unixSecondsToDate(timestamp).toLocaleString('ko-KR', {
     hour12: false,
   })
 }

--- a/dashboard/src/components/keeper-eval-quality.ts
+++ b/dashboard/src/components/keeper-eval-quality.ts
@@ -10,6 +10,7 @@ import type { KeeperEvalResponse, EvalSnapshot, EvalLayerResult } from '../api/k
 import { ProgressBar } from './common/progress-bar'
 import { Eyebrow } from './common/eyebrow'
 import { StatusChip, type StatusChipTone } from './common/status-chip'
+import { SECONDS_PER_DAY } from '../lib/format-time'
 
 // ── Per-keeper cached state ─────────────────────────────
 
@@ -118,7 +119,7 @@ function LayerResultRow({ layer }: { layer: EvalLayerResult }) {
 function computeTrend(snapshots: EvalSnapshot[]): { oldCoverage: number; newCoverage: number; deltaPercent: number } | null {
   if (snapshots.length < 2) return null
   const now = Date.now() / 1000
-  const cutoff24h = now - 86400
+  const cutoff24h = now - SECONDS_PER_DAY
   const recent = snapshots.filter(s => s.timestamp >= cutoff24h)
   const older = snapshots.filter(s => s.timestamp < cutoff24h)
   if (recent.length === 0) return null

--- a/dashboard/src/components/keeper-reactivity-monitor.ts
+++ b/dashboard/src/components/keeper-reactivity-monitor.ts
@@ -23,6 +23,7 @@ import { TurnBudgetGaugePanel } from './turn-budget-gauge'
 import { parsePrometheusText, type ParsedMetric } from './prometheus-metrics'
 import { isKeeperCrashed, isKeeperPaused } from '../lib/keeper-predicates'
 import { fetchWithTimeout, authHeaders } from '../api/core'
+import { PROMETHEUS_FETCH_TIMEOUT_MS } from '../config/constants'
 import { TimeAgo } from './common/time-ago'
 import { LoadingState, ErrorRecoverable } from './common/feedback-state'
 import { EmptyState } from './common/empty-state'
@@ -172,7 +173,7 @@ export function extractBatchTerminations(
 // ── Prometheus fetch ───────────────────────────────────────────────────────
 
 async function fetchMetricsText(): Promise<string> {
-  const res = await fetchWithTimeout('/metrics', { headers: authHeaders() }, 10_000)
+  const res = await fetchWithTimeout('/metrics', { headers: authHeaders() }, PROMETHEUS_FETCH_TIMEOUT_MS)
   if (!res.ok) throw new Error(`/metrics returned ${res.status}`)
   return res.text()
 }

--- a/dashboard/src/components/keeper-repo-mapping.ts
+++ b/dashboard/src/components/keeper-repo-mapping.ts
@@ -10,6 +10,7 @@ import {
   type CredentialState,
   type CredentialType,
 } from '../api/credentials'
+import { fetchRepositoriesList } from '../api/repositories'
 import { createAsyncResource } from '../lib/async-state'
 import { showToast } from './common/toast'
 import { ErrorState, LoadingState } from './common/feedback-state'
@@ -79,23 +80,12 @@ async function fetchKeepers(): Promise<Keeper[]> {
 }
 
 async function fetchRepositories(): Promise<RepositoryOption[]> {
-  const data = await get<unknown>('/api/v1/repositories')
-  const rows = Array.isArray(data)
-    ? data
-    : data && typeof data === 'object' && Array.isArray((data as Record<string, unknown>).repositories)
-      ? (data as Record<string, unknown>).repositories as unknown[]
-      : []
-  if (Array.isArray(rows)) {
-    return rows.map((row: unknown): RepositoryOption => {
-      const r = row as Record<string, unknown>
-      return {
-        id: String(r.id ?? ''),
-        name: String(r.name ?? r.id ?? ''),
-        url: r.url ? String(r.url) : undefined,
-      }
-    })
-  }
-  return []
+  const repos = await fetchRepositoriesList()
+  return repos.map(r => ({
+    id: r.id,
+    name: r.name,
+    url: r.url || undefined,
+  }))
 }
 
 async function fetchCredentials(): Promise<KeeperCredentialOption[]> {

--- a/dashboard/src/components/keeper-supervisor-diagnostics.ts
+++ b/dashboard/src/components/keeper-supervisor-diagnostics.ts
@@ -5,7 +5,7 @@
 import { html } from 'htm/preact'
 import { formatPct, formatPct1 } from '../lib/format-number'
 import { signal } from '@preact/signals'
-import { formatTimeAgo } from '../lib/format-time'
+import { formatTimeAgo, SECONDS_PER_MINUTE, SECONDS_PER_HOUR } from '../lib/format-time'
 import { FilterChips } from './common/filter-chips'
 import { PanelCard } from './common/panel-card'
 import { ProgressBar } from './common/progress-bar'
@@ -145,7 +145,7 @@ export function SupervisorDiagnosticsPanel({ keeper }: { keeper: Keeper }) {
         ${typeof dead_eta_sec === 'number' && dead_eta_sec > 0 && dead_since == null ? html`
           <div class="flex items-center justify-between">
             <${MutedLabel}>종료 예상</${MutedLabel}>
-            <span class="text-2xs font-mono" style="color: ${budgetPct >= 50 ? 'var(--amber-bright)' : 'var(--color-fg-primary)'}">${dead_eta_sec >= 3600 ? (dead_eta_sec / 3600).toFixed(1) + 'h' : (dead_eta_sec / 60).toFixed(0) + 'm'} 후</span>
+            <span class="text-2xs font-mono" style="color: ${budgetPct >= 50 ? 'var(--amber-bright)' : 'var(--color-fg-primary)'}">${dead_eta_sec >= SECONDS_PER_HOUR ? (dead_eta_sec / SECONDS_PER_HOUR).toFixed(1) + 'h' : (dead_eta_sec / SECONDS_PER_MINUTE).toFixed(0) + 'm'} 후</span>
           </div>
         ` : null}
         ${last_failure_reason ? html`

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -8,6 +8,7 @@ import { fetchKeeperToolCalls } from '../api/dashboard'
 import type { ToolCallEntry, ToolCallsResponse, TelemetryFreshnessMetadata } from '../api/dashboard'
 import { formatTimeHms } from '../lib/format-time'
 import { LoadingState } from './common/feedback-state'
+import { asNullableString, asRecord } from './common/normalize'
 import { SectionCap } from './common/section-cap'
 import { toolCategory, formatDuration, durationColor } from './tool-call-shared'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
@@ -86,10 +87,6 @@ type MutableToolRouteContext = {
   -readonly [K in keyof ToolRouteContextFields]?: ToolRouteContextFields[K]
 }
 
-function stringField(value: unknown): string | null {
-  return typeof value === 'string' && value.trim() !== '' ? value.trim() : null
-}
-
 function positiveLine(value: unknown): number | undefined {
   if (typeof value === 'number' && Number.isSafeInteger(value) && value >= 1) return value
   if (typeof value !== 'string') return undefined
@@ -98,22 +95,16 @@ function positiveLine(value: unknown): number | undefined {
 }
 
 function idString(value: unknown): string | undefined {
-  const text = stringField(value)
+  const text = asNullableString(value)
   if (text) return text
   return typeof value === 'number' && Number.isSafeInteger(value) && value >= 1
     ? String(value)
     : undefined
 }
 
-function nestedRecord(value: unknown): Record<string, unknown> | null {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-    ? value as Record<string, unknown>
-    : null
-}
-
 function parseInputRecord(input: string): Record<string, unknown> | null {
   try {
-    return nestedRecord(JSON.parse(input))
+    return asRecord(JSON.parse(input))
   } catch {
     return null
   }
@@ -122,9 +113,9 @@ function parseInputRecord(input: string): Record<string, unknown> | null {
 function codeLocationFromRecord(record: Record<string, unknown> | null): Pick<ToolRouteContextFields, 'filePath' | 'line'> | null {
   if (!record) return null
   const filePath =
-    stringField(record.file_path)
-    ?? stringField(record.path)
-    ?? stringField(record.file)
+    asNullableString(record.file_path)
+    ?? asNullableString(record.path)
+    ?? asNullableString(record.file)
   if (!filePath) return null
   return {
     filePath,
@@ -174,13 +165,13 @@ function mergeToolInputContext(
     mergeToolInputContext(context, parseInputRecord(input), depth + 1)
     return
   }
-  const record = nestedRecord(input)
+  const record = asRecord(input)
   if (!record) return
-  const failureEnvelope = nestedRecord(record.failure_envelope)
-  mergeToolRouteRecord(context, nestedRecord(record.context))
-  mergeToolRouteRecord(context, nestedRecord(record.evidence_ref))
-  mergeToolRouteRecord(context, nestedRecord(failureEnvelope?.evidence_ref))
-  mergeToolRouteRecord(context, nestedRecord(record.tool_args))
+  const failureEnvelope = asRecord(record.failure_envelope)
+  mergeToolRouteRecord(context, asRecord(record.context))
+  mergeToolRouteRecord(context, asRecord(record.evidence_ref))
+  mergeToolRouteRecord(context, asRecord(failureEnvelope?.evidence_ref))
+  mergeToolRouteRecord(context, asRecord(record.tool_args))
   mergeToolInputContext(context, record.input, depth + 1)
   mergeToolRouteRecord(context, record, true)
 }

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -8,7 +8,7 @@ import { fetchKeeperToolCalls } from '../api/dashboard'
 import type { ToolCallEntry, ToolCallsResponse, TelemetryFreshnessMetadata } from '../api/dashboard'
 import { formatTimeHms } from '../lib/format-time'
 import { LoadingState } from './common/feedback-state'
-import { asNullableString, asRecord, positiveLine, idString } from './common/normalize'
+import { asRecord, idString, extractCodeLocation } from './common/normalize'
 import { SectionCap } from './common/section-cap'
 import { toolCategory, formatDuration, durationColor } from './tool-call-shared'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
@@ -95,26 +95,13 @@ function parseInputRecord(input: string): Record<string, unknown> | null {
   }
 }
 
-function codeLocationFromRecord(record: Record<string, unknown> | null): Pick<ToolRouteContextFields, 'filePath' | 'line'> | null {
-  if (!record) return null
-  const filePath =
-    asNullableString(record.file_path)
-    ?? asNullableString(record.path)
-    ?? asNullableString(record.file)
-  if (!filePath) return null
-  return {
-    filePath,
-    line: positiveLine(record.line) ?? positiveLine(record.line_start) ?? positiveLine(record.lineno),
-  }
-}
-
 function mergeToolRouteRecord(
   context: MutableToolRouteContext,
   record: Record<string, unknown> | null,
   overwrite = false,
 ): void {
   if (!record) return
-  const location = codeLocationFromRecord(record)
+  const location = extractCodeLocation(record)
   if (location?.filePath && (overwrite || context.filePath === undefined)) context.filePath = location.filePath
   if (location?.line !== undefined && (overwrite || context.line === undefined)) context.line = location.line
 

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -8,7 +8,7 @@ import { fetchKeeperToolCalls } from '../api/dashboard'
 import type { ToolCallEntry, ToolCallsResponse, TelemetryFreshnessMetadata } from '../api/dashboard'
 import { formatTimeHms } from '../lib/format-time'
 import { LoadingState } from './common/feedback-state'
-import { asNullableString, asRecord, positiveLine } from './common/normalize'
+import { asNullableString, asRecord, positiveLine, idString } from './common/normalize'
 import { SectionCap } from './common/section-cap'
 import { toolCategory, formatDuration, durationColor } from './tool-call-shared'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
@@ -85,14 +85,6 @@ type ToolRouteContextFields = Pick<
 >
 type MutableToolRouteContext = {
   -readonly [K in keyof ToolRouteContextFields]?: ToolRouteContextFields[K]
-}
-
-function idString(value: unknown): string | undefined {
-  const text = asNullableString(value)
-  if (text) return text
-  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 1
-    ? String(value)
-    : undefined
 }
 
 function parseInputRecord(input: string): Record<string, unknown> | null {

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -8,7 +8,7 @@ import { fetchKeeperToolCalls } from '../api/dashboard'
 import type { ToolCallEntry, ToolCallsResponse, TelemetryFreshnessMetadata } from '../api/dashboard'
 import { formatTimeHms } from '../lib/format-time'
 import { LoadingState } from './common/feedback-state'
-import { asRecord, idString, extractCodeLocation } from './common/normalize'
+import { asRecord, mergeRouteRecord, hasRouteContext, type MutableRouteContext } from './common/normalize'
 import { SectionCap } from './common/section-cap'
 import { toolCategory, formatDuration, durationColor } from './tool-call-shared'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
@@ -20,7 +20,6 @@ import { coverageGapDisplay, sourceHealthClass, freshnessText } from './common/s
 import {
   openIdeContextRouteLink,
   routeLinksForContext,
-  type IdeContextRouteContext,
   type IdeContextRouteLink,
 } from './ide/ide-context-lens'
 
@@ -68,25 +67,6 @@ function tryPrettyJson(s: string): string | null {
   }
 }
 
-type ToolRouteContextFields = Pick<
-  IdeContextRouteContext,
-  | 'filePath'
-  | 'line'
-  | 'goalId'
-  | 'taskId'
-  | 'boardPostId'
-  | 'commentId'
-  | 'prId'
-  | 'gitRef'
-  | 'logId'
-  | 'sessionId'
-  | 'operationId'
-  | 'workerRunId'
->
-type MutableToolRouteContext = {
-  -readonly [K in keyof ToolRouteContextFields]?: ToolRouteContextFields[K]
-}
-
 function parseInputRecord(input: string): Record<string, unknown> | null {
   try {
     return asRecord(JSON.parse(input))
@@ -95,40 +75,8 @@ function parseInputRecord(input: string): Record<string, unknown> | null {
   }
 }
 
-function mergeToolRouteRecord(
-  context: MutableToolRouteContext,
-  record: Record<string, unknown> | null,
-  overwrite = false,
-): void {
-  if (!record) return
-  const location = extractCodeLocation(record)
-  if (location?.filePath && (overwrite || context.filePath === undefined)) context.filePath = location.filePath
-  if (location?.line !== undefined && (overwrite || context.line === undefined)) context.line = location.line
-
-  const goalId = idString(record.goal_id)
-  if (goalId && (overwrite || context.goalId === undefined)) context.goalId = goalId
-  const taskId = idString(record.task_id)
-  if (taskId && (overwrite || context.taskId === undefined)) context.taskId = taskId
-  const boardPostId = idString(record.board_post_id) ?? idString(record.post_id)
-  if (boardPostId && (overwrite || context.boardPostId === undefined)) context.boardPostId = boardPostId
-  const commentId = idString(record.comment_id) ?? idString(record.reply_id) ?? idString(record.comment_number)
-  if (commentId && (overwrite || context.commentId === undefined)) context.commentId = commentId
-  const prId = idString(record.pr_id) ?? idString(record.pull_request) ?? idString(record.pr_number)
-  if (prId && (overwrite || context.prId === undefined)) context.prId = prId
-  const gitRef = idString(record.git_ref) ?? idString(record.commit) ?? idString(record.branch)
-  if (gitRef && (overwrite || context.gitRef === undefined)) context.gitRef = gitRef
-  const logId = idString(record.log_id)
-  if (logId && (overwrite || context.logId === undefined)) context.logId = logId
-  const sessionId = idString(record.session_id)
-  if (sessionId && (overwrite || context.sessionId === undefined)) context.sessionId = sessionId
-  const operationId = idString(record.operation_id)
-  if (operationId && (overwrite || context.operationId === undefined)) context.operationId = operationId
-  const workerRunId = idString(record.worker_run_id)
-  if (workerRunId && (overwrite || context.workerRunId === undefined)) context.workerRunId = workerRunId
-}
-
 function mergeToolInputContext(
-  context: MutableToolRouteContext,
+  context: MutableRouteContext,
   input: unknown,
   depth = 0,
 ): void {
@@ -140,32 +88,18 @@ function mergeToolInputContext(
   const record = asRecord(input)
   if (!record) return
   const failureEnvelope = asRecord(record.failure_envelope)
-  mergeToolRouteRecord(context, asRecord(record.context))
-  mergeToolRouteRecord(context, asRecord(record.evidence_ref))
-  mergeToolRouteRecord(context, asRecord(failureEnvelope?.evidence_ref))
-  mergeToolRouteRecord(context, asRecord(record.tool_args))
+  mergeRouteRecord(context, asRecord(record.context))
+  mergeRouteRecord(context, asRecord(record.evidence_ref))
+  mergeRouteRecord(context, asRecord(failureEnvelope?.evidence_ref))
+  mergeRouteRecord(context, asRecord(record.tool_args))
   mergeToolInputContext(context, record.input, depth + 1)
-  mergeToolRouteRecord(context, record, true)
-}
-
-function hasToolRouteContext(context: MutableToolRouteContext): boolean {
-  return context.filePath !== undefined
-    || context.goalId !== undefined
-    || context.taskId !== undefined
-    || context.boardPostId !== undefined
-    || context.commentId !== undefined
-    || context.prId !== undefined
-    || context.gitRef !== undefined
-    || context.logId !== undefined
-    || context.sessionId !== undefined
-    || context.operationId !== undefined
-    || context.workerRunId !== undefined
+  mergeRouteRecord(context, record, true)
 }
 
 function toolCallRouteLinks(entry: ToolCallEntry): ReadonlyArray<IdeContextRouteLink> {
-  const context: MutableToolRouteContext = {}
+  const context: MutableRouteContext = {}
   mergeToolInputContext(context, entry.input)
-  if (!hasToolRouteContext(context)) return []
+  if (!hasRouteContext(context)) return []
   const links = routeLinksForContext({
     ...context,
     surface: 'Tool',

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -8,7 +8,7 @@ import { fetchKeeperToolCalls } from '../api/dashboard'
 import type { ToolCallEntry, ToolCallsResponse, TelemetryFreshnessMetadata } from '../api/dashboard'
 import { formatTimeHms } from '../lib/format-time'
 import { LoadingState } from './common/feedback-state'
-import { asNullableString, asRecord } from './common/normalize'
+import { asNullableString, asRecord, positiveLine } from './common/normalize'
 import { SectionCap } from './common/section-cap'
 import { toolCategory, formatDuration, durationColor } from './tool-call-shared'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
@@ -85,13 +85,6 @@ type ToolRouteContextFields = Pick<
 >
 type MutableToolRouteContext = {
   -readonly [K in keyof ToolRouteContextFields]?: ToolRouteContextFields[K]
-}
-
-function positiveLine(value: unknown): number | undefined {
-  if (typeof value === 'number' && Number.isSafeInteger(value) && value >= 1) return value
-  if (typeof value !== 'string') return undefined
-  const trimmed = value.trim()
-  return /^[1-9]\d*$/.test(trimmed) ? Number.parseInt(trimmed, 10) : undefined
 }
 
 function idString(value: unknown): string | undefined {

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -9,7 +9,7 @@ import type {
   ProviderLogTailResponse,
 } from '../api/dashboard.js'
 import { VirtualList } from './common/virtual-list'
-import { asRecord, asNullableString, idString, extractCodeLocation } from './common/normalize'
+import { asRecord, asNullableString, mergeRouteRecord, hasRouteContext, type MutableRouteContext } from './common/normalize'
 import { TextInput } from './common/input'
 import { Select } from './common/select'
 import { Checkbox } from './common/checkbox'
@@ -19,7 +19,6 @@ import { StatusChip } from './common/status-chip'
 import {
   openIdeContextRouteLink,
   routeLinksForContext,
-  type IdeContextRouteContext,
   type IdeContextRouteLink,
 } from './ide/ide-context-lens'
 import type { LogsResponse } from '../api/schemas/logs'
@@ -94,25 +93,6 @@ type FailureEnvelope = {
   evidence_ref: Record<string, unknown> | null
 }
 
-type LogRouteContextFields = Pick<
-  IdeContextRouteContext,
-  | 'filePath'
-  | 'line'
-  | 'goalId'
-  | 'taskId'
-  | 'boardPostId'
-  | 'commentId'
-  | 'prId'
-  | 'gitRef'
-  | 'logId'
-  | 'sessionId'
-  | 'operationId'
-  | 'workerRunId'
->
-type MutableLogRouteContext = {
-  -readonly [K in keyof LogRouteContextFields]?: LogRouteContextFields[K]
-}
-
 function normalizedLevel(entry: LogEntry): string {
   // RFC-0079: backend now emits a typed level via Log.Ring.entry_to_json.
   // The schema rejects rows without `level`, so the read-side fallback
@@ -181,52 +161,6 @@ function interpolateStructuredMessage(
     rendered = rendered.replace(/%[sd]/, value)
   }
   return rendered
-}
-
-function mergeLogRouteRecord(
-  context: MutableLogRouteContext,
-  record: Record<string, unknown> | null,
-  overwrite = false,
-): void {
-  if (!record) return
-  const location = extractCodeLocation(record)
-  if (location && (overwrite || context.filePath === undefined)) context.filePath = location.filePath
-  if (location?.line !== undefined && (overwrite || context.line === undefined)) context.line = location.line
-
-  const goalId = idString(record.goal_id)
-  if (goalId && (overwrite || context.goalId === undefined)) context.goalId = goalId
-  const taskId = idString(record.task_id)
-  if (taskId && (overwrite || context.taskId === undefined)) context.taskId = taskId
-  const boardPostId = idString(record.board_post_id) ?? idString(record.post_id)
-  if (boardPostId && (overwrite || context.boardPostId === undefined)) context.boardPostId = boardPostId
-  const commentId = idString(record.comment_id) ?? idString(record.reply_id) ?? idString(record.comment_number)
-  if (commentId && (overwrite || context.commentId === undefined)) context.commentId = commentId
-  const prId = idString(record.pr_id) ?? idString(record.pull_request) ?? idString(record.pr_number)
-  if (prId && (overwrite || context.prId === undefined)) context.prId = prId
-  const gitRef = idString(record.git_ref) ?? idString(record.commit) ?? idString(record.branch)
-  if (gitRef && (overwrite || context.gitRef === undefined)) context.gitRef = gitRef
-  const logId = idString(record.log_id)
-  if (logId && (overwrite || context.logId === undefined)) context.logId = logId
-  const sessionId = idString(record.session_id)
-  if (sessionId && (overwrite || context.sessionId === undefined)) context.sessionId = sessionId
-  const operationId = idString(record.operation_id)
-  if (operationId && (overwrite || context.operationId === undefined)) context.operationId = operationId
-  const workerRunId = idString(record.worker_run_id)
-  if (workerRunId && (overwrite || context.workerRunId === undefined)) context.workerRunId = workerRunId
-}
-
-function hasLogRouteContext(context: MutableLogRouteContext): boolean {
-  return context.filePath !== undefined
-    || context.goalId !== undefined
-    || context.taskId !== undefined
-    || context.boardPostId !== undefined
-    || context.commentId !== undefined
-    || context.prId !== undefined
-    || context.gitRef !== undefined
-    || context.logId !== undefined
-    || context.sessionId !== undefined
-    || context.operationId !== undefined
-    || context.workerRunId !== undefined
 }
 
 function failureEnvelope(entry: LogEntry): FailureEnvelope | null {
@@ -310,14 +244,14 @@ export function summarizeLogWindow(entries: LogEntry[]): LogWindowSummary {
 export function logRouteLinks(entry: LogEntry): ReadonlyArray<IdeContextRouteLink> {
   const details = entryDetails(entry)
   const failureEnvelopeRecord = asRecord(details?.failure_envelope)
-  const context: MutableLogRouteContext = {}
-  mergeLogRouteRecord(context, asRecord(details?.context))
-  mergeLogRouteRecord(context, asRecord(details?.evidence_ref))
-  mergeLogRouteRecord(context, asRecord(failureEnvelopeRecord?.evidence_ref))
-  mergeLogRouteRecord(context, asRecord(details?.tool_args))
-  mergeLogRouteRecord(context, asRecord(details?.input))
-  mergeLogRouteRecord(context, details, true)
-  if (!hasLogRouteContext(context)) return []
+  const context: MutableRouteContext = {}
+  mergeRouteRecord(context, asRecord(details?.context))
+  mergeRouteRecord(context, asRecord(details?.evidence_ref))
+  mergeRouteRecord(context, asRecord(failureEnvelopeRecord?.evidence_ref))
+  mergeRouteRecord(context, asRecord(details?.tool_args))
+  mergeRouteRecord(context, asRecord(details?.input))
+  mergeRouteRecord(context, details, true)
+  if (!hasRouteContext(context)) return []
   return routeLinksForContext({
     ...context,
     surface: 'Log',

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -9,6 +9,7 @@ import type {
   ProviderLogTailResponse,
 } from '../api/dashboard.js'
 import { VirtualList } from './common/virtual-list'
+import { asRecord } from './common/normalize'
 import { TextInput } from './common/input'
 import { Select } from './common/select'
 import { Checkbox } from './common/checkbox'
@@ -187,11 +188,6 @@ function interpolateStructuredMessage(
   return rendered
 }
 
-function nestedRecord(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
-  return value as Record<string, unknown>
-}
-
 function nestedString(value: unknown): string | null {
   if (typeof value !== 'string') return null
   const trimmed = value.trim()
@@ -276,7 +272,7 @@ function hasLogRouteContext(context: MutableLogRouteContext): boolean {
 
 function failureEnvelope(entry: LogEntry): FailureEnvelope | null {
   const details = entryDetails(entry)
-  const envelope = nestedRecord(details?.failure_envelope)
+  const envelope = asRecord(details?.failure_envelope)
   if (!envelope) return null
 
   const surface = nestedString(envelope.surface)
@@ -299,7 +295,7 @@ function failureEnvelope(entry: LogEntry): FailureEnvelope | null {
     summary,
     recoverability,
     operator_action: nestedString(envelope.operator_action),
-    evidence_ref: nestedRecord(envelope.evidence_ref),
+    evidence_ref: asRecord(envelope.evidence_ref),
   }
 }
 
@@ -354,13 +350,13 @@ export function summarizeLogWindow(entries: LogEntry[]): LogWindowSummary {
 
 export function logRouteLinks(entry: LogEntry): ReadonlyArray<IdeContextRouteLink> {
   const details = entryDetails(entry)
-  const failureEnvelopeRecord = nestedRecord(details?.failure_envelope)
+  const failureEnvelopeRecord = asRecord(details?.failure_envelope)
   const context: MutableLogRouteContext = {}
-  mergeLogRouteRecord(context, nestedRecord(details?.context))
-  mergeLogRouteRecord(context, nestedRecord(details?.evidence_ref))
-  mergeLogRouteRecord(context, nestedRecord(failureEnvelopeRecord?.evidence_ref))
-  mergeLogRouteRecord(context, nestedRecord(details?.tool_args))
-  mergeLogRouteRecord(context, nestedRecord(details?.input))
+  mergeLogRouteRecord(context, asRecord(details?.context))
+  mergeLogRouteRecord(context, asRecord(details?.evidence_ref))
+  mergeLogRouteRecord(context, asRecord(failureEnvelopeRecord?.evidence_ref))
+  mergeLogRouteRecord(context, asRecord(details?.tool_args))
+  mergeLogRouteRecord(context, asRecord(details?.input))
   mergeLogRouteRecord(context, details, true)
   if (!hasLogRouteContext(context)) return []
   return routeLinksForContext({

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -9,7 +9,7 @@ import type {
   ProviderLogTailResponse,
 } from '../api/dashboard.js'
 import { VirtualList } from './common/virtual-list'
-import { asRecord, asNullableString, positiveLine } from './common/normalize'
+import { asRecord, asNullableString, positiveLine, idString } from './common/normalize'
 import { TextInput } from './common/input'
 import { Select } from './common/select'
 import { Checkbox } from './common/checkbox'
@@ -186,14 +186,6 @@ function interpolateStructuredMessage(
     rendered = rendered.replace(/%[sd]/, value)
   }
   return rendered
-}
-
-function idString(value: unknown): string | undefined {
-  const text = asNullableString(value)
-  if (text) return text
-  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 1
-    ? String(value)
-    : undefined
 }
 
 function codeLocationFromRecord(record: Record<string, unknown> | null): LogCodeLocation | null {

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -9,7 +9,7 @@ import type {
   ProviderLogTailResponse,
 } from '../api/dashboard.js'
 import { VirtualList } from './common/virtual-list'
-import { asRecord, asNullableString } from './common/normalize'
+import { asRecord, asNullableString, positiveLine } from './common/normalize'
 import { TextInput } from './common/input'
 import { Select } from './common/select'
 import { Checkbox } from './common/checkbox'
@@ -186,13 +186,6 @@ function interpolateStructuredMessage(
     rendered = rendered.replace(/%[sd]/, value)
   }
   return rendered
-}
-
-function positiveLine(value: unknown): number | undefined {
-  if (typeof value === 'number' && Number.isSafeInteger(value) && value >= 1) return value
-  if (typeof value !== 'string') return undefined
-  const trimmed = value.trim()
-  return /^[1-9]\d*$/.test(trimmed) ? Number.parseInt(trimmed, 10) : undefined
 }
 
 function idString(value: unknown): string | undefined {

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -9,7 +9,7 @@ import type {
   ProviderLogTailResponse,
 } from '../api/dashboard.js'
 import { VirtualList } from './common/virtual-list'
-import { asRecord, asNullableString, positiveLine, idString } from './common/normalize'
+import { asRecord, asNullableString, idString, extractCodeLocation } from './common/normalize'
 import { TextInput } from './common/input'
 import { Select } from './common/select'
 import { Checkbox } from './common/checkbox'
@@ -92,11 +92,6 @@ type FailureEnvelope = {
   recoverability: string
   operator_action: string | null
   evidence_ref: Record<string, unknown> | null
-}
-
-interface LogCodeLocation {
-  readonly filePath: string
-  readonly line?: number
 }
 
 type LogRouteContextFields = Pick<
@@ -188,28 +183,13 @@ function interpolateStructuredMessage(
   return rendered
 }
 
-function codeLocationFromRecord(record: Record<string, unknown> | null): LogCodeLocation | null {
-  if (!record) return null
-  const filePath =
-    asNullableString(record.file_path)
-    ?? asNullableString(record.path)
-    ?? asNullableString(record.file)
-  if (filePath) {
-    return {
-      filePath,
-      line: positiveLine(record.line) ?? positiveLine(record.line_start) ?? positiveLine(record.lineno),
-    }
-  }
-  return null
-}
-
 function mergeLogRouteRecord(
   context: MutableLogRouteContext,
   record: Record<string, unknown> | null,
   overwrite = false,
 ): void {
   if (!record) return
-  const location = codeLocationFromRecord(record)
+  const location = extractCodeLocation(record)
   if (location && (overwrite || context.filePath === undefined)) context.filePath = location.filePath
   if (location?.line !== undefined && (overwrite || context.line === undefined)) context.line = location.line
 

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -9,7 +9,7 @@ import type {
   ProviderLogTailResponse,
 } from '../api/dashboard.js'
 import { VirtualList } from './common/virtual-list'
-import { asRecord } from './common/normalize'
+import { asRecord, asNullableString } from './common/normalize'
 import { TextInput } from './common/input'
 import { Select } from './common/select'
 import { Checkbox } from './common/checkbox'
@@ -188,12 +188,6 @@ function interpolateStructuredMessage(
   return rendered
 }
 
-function nestedString(value: unknown): string | null {
-  if (typeof value !== 'string') return null
-  const trimmed = value.trim()
-  return trimmed === '' ? null : trimmed
-}
-
 function positiveLine(value: unknown): number | undefined {
   if (typeof value === 'number' && Number.isSafeInteger(value) && value >= 1) return value
   if (typeof value !== 'string') return undefined
@@ -202,7 +196,7 @@ function positiveLine(value: unknown): number | undefined {
 }
 
 function idString(value: unknown): string | undefined {
-  const text = nestedString(value)
+  const text = asNullableString(value)
   if (text) return text
   return typeof value === 'number' && Number.isSafeInteger(value) && value >= 1
     ? String(value)
@@ -212,9 +206,9 @@ function idString(value: unknown): string | undefined {
 function codeLocationFromRecord(record: Record<string, unknown> | null): LogCodeLocation | null {
   if (!record) return null
   const filePath =
-    nestedString(record.file_path)
-    ?? nestedString(record.path)
-    ?? nestedString(record.file)
+    asNullableString(record.file_path)
+    ?? asNullableString(record.path)
+    ?? asNullableString(record.file)
   if (filePath) {
     return {
       filePath,
@@ -275,12 +269,12 @@ function failureEnvelope(entry: LogEntry): FailureEnvelope | null {
   const envelope = asRecord(details?.failure_envelope)
   if (!envelope) return null
 
-  const surface = nestedString(envelope.surface)
-  const entityKind = nestedString(envelope.entity_kind)
-  const causeCode = nestedString(envelope.cause_code)
-  const severity = nestedString(envelope.severity)
-  const summary = nestedString(envelope.summary)
-  const recoverability = nestedString(envelope.recoverability)
+  const surface = asNullableString(envelope.surface)
+  const entityKind = asNullableString(envelope.entity_kind)
+  const causeCode = asNullableString(envelope.cause_code)
+  const severity = asNullableString(envelope.severity)
+  const summary = asNullableString(envelope.summary)
+  const recoverability = asNullableString(envelope.recoverability)
 
   if (!surface || !entityKind || !causeCode || !severity || !summary || !recoverability) {
     return null
@@ -289,12 +283,12 @@ function failureEnvelope(entry: LogEntry): FailureEnvelope | null {
   return {
     surface,
     entity_kind: entityKind,
-    entity_id: nestedString(envelope.entity_id),
+    entity_id: asNullableString(envelope.entity_id),
     cause_code: causeCode,
     severity,
     summary,
     recoverability,
-    operator_action: nestedString(envelope.operator_action),
+    operator_action: asNullableString(envelope.operator_action),
     evidence_ref: asRecord(envelope.evidence_ref),
   }
 }

--- a/dashboard/src/components/oas-health-chip.ts
+++ b/dashboard/src/components/oas-health-chip.ts
@@ -7,17 +7,14 @@ import { oasHealthSummary, oasAgentEvents, oasKeeperSnapshots } from '../store'
 import { Card } from './common/card'
 import { StatTile } from './common/stat-tile'
 import { EmptyState } from './common/empty-state'
+import { formatRelativeAgeMs } from '../lib/format-time'
 import type { OasAgentEvent, OasHealthSummary, OasKeeperSnapshot } from '../types/oas'
 
 const STALE_MS = 60_000
 
 function formatLastTick(tick: number | null): string {
   if (tick == null) return '—'
-  const delta = Date.now() - tick
-  if (delta < 1000) return '방금'
-  if (delta < 60_000) return `${Math.floor(delta / 1000)}초 전`
-  if (delta < 3_600_000) return `${Math.floor(delta / 60_000)}분 전`
-  return `${Math.floor(delta / 3_600_000)}시간 전`
+  return formatRelativeAgeMs(Date.now() - tick)
 }
 
 const EVENT_TYPE_LABELS: Record<OasAgentEvent['type'], string> = {

--- a/dashboard/src/components/ops/quick-intervene.ts
+++ b/dashboard/src/components/ops/quick-intervene.ts
@@ -25,23 +25,21 @@ import {
 } from './ops-state'
 import { executeAction } from './helpers'
 import { isKeeperOffline } from '../../lib/keeper-predicates'
+import {
+  type OnlineKeeper,
+  keeperNameFromTarget,
+  mentionQueryFromMessage,
+  trailingMentionNameFromMessage,
+  onlineKeeperNameForMention,
+  mentionCandidates,
+  replaceTrailingMentionDraft,
+} from '../../lib/mention-utils'
 
 interface ComposerTarget {
   action_type: 'broadcast' | 'keeper_message'
   target_type: 'root' | 'keeper'
   target_id?: string
   label: string
-}
-
-interface OnlineKeeper {
-  name: string
-  status?: string
-}
-
-interface MentionCandidate {
-  name: string
-  status?: string
-  selected: boolean
 }
 
 const MODE_OPTIONS: Array<{ value: QuickComposerMode, label: string, description: string }> = [
@@ -51,49 +49,6 @@ const MODE_OPTIONS: Array<{ value: QuickComposerMode, label: string, description
 ]
 
 const MENTION_LISTBOX_ID = 'quick-intervene-mention-listbox'
-
-function keeperNameFromTarget(value: string): string | null {
-  if (!value.startsWith('keeper:')) return null
-  const name = value.slice('keeper:'.length).trim()
-  return name || null
-}
-
-function mentionQueryFromMessage(message: string): string | null {
-  const match = message.match(/(?:^|\s)@([A-Za-z0-9_.-]*)$/)
-  return match?.[1] ?? null
-}
-
-function trailingMentionNameFromMessage(message: string): string | null {
-  const match = message.match(/(?:^|\s)@([A-Za-z0-9_.-]+)\s*$/)
-  return match?.[1] ?? null
-}
-
-function onlineKeeperNameForMention(onlineKeepers: OnlineKeeper[], mentionName: string | null): string | null {
-  if (!mentionName) return null
-  const normalized = mentionName.toLowerCase()
-  return onlineKeepers.find(keeper => keeper.name.toLowerCase() === normalized)?.name ?? null
-}
-
-function mentionCandidates(onlineKeepers: OnlineKeeper[], query: string | null, selectedKeeper: string | null): MentionCandidate[] {
-  const normalizedQuery = query?.toLowerCase() ?? ''
-  return onlineKeepers
-    .filter(keeper => normalizedQuery === '' || keeper.name.toLowerCase().includes(normalizedQuery))
-    .map(keeper => ({
-      name: keeper.name,
-      status: keeper.status,
-      selected: keeper.name === selectedKeeper,
-    }))
-    .sort((a, b) => Number(b.selected) - Number(a.selected) || a.name.localeCompare(b.name))
-    .slice(0, 5)
-}
-
-function replaceTrailingMentionDraft(message: string, keeperName: string): string {
-  if (/(?:^|\s)@[A-Za-z0-9_.-]*$/.test(message)) {
-    return message.replace(/(^|\s)@[A-Za-z0-9_.-]*$/, `$1@${keeperName} `)
-  }
-  const spacer = message.trimEnd().length > 0 ? ' ' : ''
-  return `${message.trimEnd()}${spacer}@${keeperName} `
-}
 
 function chooseMentionTarget(keeperName: string): void {
   quickTarget.value = `keeper:${keeperName}`

--- a/dashboard/src/components/overview/agent-avatar.ts
+++ b/dashboard/src/components/overview/agent-avatar.ts
@@ -9,6 +9,7 @@ import {
   PIXEL_TEMPLATES,
   type AvatarPalette,
 } from '../../config/avatar-palettes'
+import { trimText } from '../../lib/truncate'
 
 type AvatarSize = 'sm' | 'md' | 'lg' | 'xl'
 
@@ -70,13 +71,6 @@ function handleKeyActivate(onClick?: () => void) {
   }
 }
 
-function truncateWork(text: string | null | undefined, max = 20): string | null {
-  if (!text) return null
-  const clean = text.replace(/\s+/g, ' ').trim()
-  if (!clean) return null
-  return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean
-}
-
 export function AgentAvatar({
   name,
   status,
@@ -110,7 +104,7 @@ export function AgentAvatar({
   }
 
   const dotClass = activityDotClass(activityAge ?? null)
-  const bubbleText = truncateWork(currentWork)
+  const bubbleText = trimText(currentWork, 20)
 
   const avatar = html`
     <div

--- a/dashboard/src/components/prometheus-metrics.ts
+++ b/dashboard/src/components/prometheus-metrics.ts
@@ -9,6 +9,7 @@ import { EmptyState } from './common/empty-state'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { TextInput } from './common/input'
 import { fetchWithTimeout, authHeaders } from '../api/core'
+import { PROMETHEUS_FETCH_TIMEOUT_MS } from '../config/constants'
 import { navigate } from '../router'
 
 // --- Prometheus text format parser ---
@@ -195,7 +196,7 @@ async function fetchPrometheusText(signal?: AbortSignal): Promise<string> {
   const res = await fetchWithTimeout(
     '/metrics',
     { headers: authHeaders(), signal },
-    10_000,
+    PROMETHEUS_FETCH_TIMEOUT_MS,
   )
   if (!res.ok) throw new Error(`/metrics returned ${res.status}`)
   return res.text()

--- a/dashboard/src/components/repo-detail-panel.test.ts
+++ b/dashboard/src/components/repo-detail-panel.test.ts
@@ -4,9 +4,9 @@ import {
   normalizeBranch,
   unwrapRepository,
   branchRows,
-  normalizeRepoStatus,
   formatDate,
 } from './repo-detail-panel'
+import { normalizeRepoStatus } from './repo-sidebar'
 import type { BranchInfo } from './repo-detail-panel'
 
 describe('normalizeBranch', () => {

--- a/dashboard/src/components/repo-detail-panel.ts
+++ b/dashboard/src/components/repo-detail-panel.ts
@@ -6,7 +6,7 @@ import { signal } from '@preact/signals'
 import { get } from '../api/core'
 import { createAsyncResource } from '../lib/async-state'
 import { LoadingState, ErrorState, EmptyState } from './common/feedback-state'
-import { selectedRepoId, syncRepository, deleteRepository, type Repository, type RepoStatus } from './repo-sidebar'
+import { selectedRepoId, syncRepository, deleteRepository, normalizeRepoStatus, type Repository, type RepoStatus } from './repo-sidebar'
 import { requestConfirm } from './common/confirm-dialog'
 import { StatusBadge as CommonStatusBadge } from './common/status-badge'
 import { unixSecondsToDate } from '../lib/format-time'
@@ -89,16 +89,6 @@ export async function loadRepoBranches(id: string): Promise<void> {
     const raw = await get<unknown>(`/api/v1/repositories/${encodeURIComponent(id)}/branches`)
     return branchRows(raw).map(normalizeBranch).filter((b): b is BranchInfo => b !== null)
   })
-}
-
-export function normalizeRepoStatus(raw: string | undefined): RepoStatus {
-  switch (raw?.toLowerCase()) {
-    case 'active': return 'active'
-    case 'paused': return 'paused'
-    case 'cloning': return 'active'
-    case 'error': return 'error'
-    default: return 'active'
-  }
 }
 
 export function resetRepoDetail(): void {

--- a/dashboard/src/components/repo-detail-panel.ts
+++ b/dashboard/src/components/repo-detail-panel.ts
@@ -9,6 +9,7 @@ import { LoadingState, ErrorState, EmptyState } from './common/feedback-state'
 import { selectedRepoId, syncRepository, deleteRepository, type Repository, type RepoStatus } from './repo-sidebar'
 import { requestConfirm } from './common/confirm-dialog'
 import { StatusBadge as CommonStatusBadge } from './common/status-badge'
+import { unixSecondsToDate } from '../lib/format-time'
 import { Trash2, GitBranch, Clock, Calendar, Folder, Link, Shield, RefreshCw } from 'lucide-preact'
 
 // ── Branch type ──────────────────────────────────────────
@@ -117,7 +118,7 @@ const REPO_STATUS_LABEL: Record<RepoStatus, string> = {
 export function formatDate(value: string | number | null): string {
   if (value === null || value === '') return '--'
   try {
-    const d = typeof value === 'number' ? new Date(value * 1000) : new Date(value)
+    const d = typeof value === 'number' ? unixSecondsToDate(value) : new Date(value)
     if (Number.isNaN(d.getTime())) return String(value)
     return d.toLocaleString('ko-KR', {
       year: 'numeric',

--- a/dashboard/src/components/repo-detail-panel.ts
+++ b/dashboard/src/components/repo-detail-panel.ts
@@ -9,7 +9,9 @@ import { LoadingState, ErrorState, EmptyState } from './common/feedback-state'
 import { selectedRepoId, syncRepository, deleteRepository, normalizeRepoStatus, type Repository, type RepoStatus } from './repo-sidebar'
 import { requestConfirm } from './common/confirm-dialog'
 import { StatusBadge as CommonStatusBadge } from './common/status-badge'
-import { unixSecondsToDate } from '../lib/format-time'
+import { formatDateTimeKo as formatDate } from '../lib/format-time'
+// Re-export for backward-compatible test imports
+export { formatDateTimeKo as formatDate } from '../lib/format-time'
 import { Trash2, GitBranch, Clock, Calendar, Folder, Link, Shield, RefreshCw } from 'lucide-preact'
 
 // ── Branch type ──────────────────────────────────────────
@@ -103,23 +105,6 @@ const REPO_STATUS_LABEL: Record<RepoStatus, string> = {
   active: '활성',
   paused: '일시정지',
   error: '오류',
-}
-
-export function formatDate(value: string | number | null): string {
-  if (value === null || value === '') return '--'
-  try {
-    const d = typeof value === 'number' ? unixSecondsToDate(value) : new Date(value)
-    if (Number.isNaN(d.getTime())) return String(value)
-    return d.toLocaleString('ko-KR', {
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-    })
-  } catch {
-    return String(value)
-  }
 }
 
 function InfoRow({

--- a/dashboard/src/components/repo-sidebar.ts
+++ b/dashboard/src/components/repo-sidebar.ts
@@ -3,7 +3,7 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { authHeaders, post } from '../api/core'
+import { del, post } from '../api/core'
 import {
   discoverRepositories,
   fetchRepositoriesList,
@@ -52,14 +52,7 @@ export async function syncRepository(id: string): Promise<void> {
 
 export async function deleteRepository(id: string): Promise<void> {
   try {
-    const res = await fetch(`/api/v1/repositories/${encodeURIComponent(id)}`, {
-      method: 'DELETE',
-      headers: authHeaders(),
-    })
-    if (!res.ok) {
-      const text = await res.text().catch(() => '삭제 실패')
-      throw new Error(text || '삭제 실패')
-    }
+    await del(`/api/v1/repositories/${encodeURIComponent(id)}`)
     showToast('저장소 삭제 완료', 'success')
     await fetchRepositories()
     if (selectedRepoId.value === id) {

--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -8,6 +8,7 @@ import { TimeAgo } from '../common/time-ago'
 import { Markdown } from '../common/markdown'
 import { ProgressBar } from '../common/progress-bar'
 import { truncate } from '../../lib/truncate'
+import { asNullableString, asRecord } from '../common/normalize'
 import { formatCost } from '../../lib/format-number'
 import { toolCategory, durationColor, formatDuration, formatArgs as sharedFormatArgs } from '../tool-call-shared'
 import { SectionHeader } from '../common/section-header'
@@ -174,12 +175,8 @@ type MutableTraceRouteContext = {
   -readonly [K in keyof TraceRouteContextFields]?: TraceRouteContextFields[K]
 }
 
-function stringField(value: unknown): string | null {
-  return typeof value === 'string' && value.trim() !== '' ? value.trim() : null
-}
-
 function stringishField(value: unknown): string | null {
-  if (typeof value === 'string') return stringField(value)
+  if (typeof value === 'string') return asNullableString(value)
   if (typeof value === 'number' && Number.isFinite(value)) return String(value)
   return null
 }
@@ -192,9 +189,9 @@ function positiveLine(value: unknown): number | undefined {
 
 function recordCodeLocation(value: Record<string, unknown>): TraceCodeLocation | null {
   const filePath =
-    stringField(value.file_path)
-    ?? stringField(value.path)
-    ?? stringField(value.file)
+    asNullableString(value.file_path)
+    ?? asNullableString(value.path)
+    ?? asNullableString(value.file)
   if (filePath) {
     return {
       filePath,
@@ -227,10 +224,10 @@ function toolCallCodeRouteLink(event: UnifiedTraceEvent): IdeContextRouteLink | 
 
 export function traceRouteLinks(event: UnifiedTraceEvent): ReadonlyArray<IdeContextRouteLink> {
   const context: MutableTraceRouteContext = {}
-  mergeTraceRouteRecord(context, nestedRecord(event.detail.context))
-  mergeTraceRouteRecord(context, nestedRecord(event.detail.evidence_ref))
-  mergeTraceRouteRecord(context, nestedRecord(event.detail.tool_args))
-  mergeTraceRouteRecord(context, nestedRecord(event.detail.input))
+  mergeTraceRouteRecord(context, asRecord(event.detail.context))
+  mergeTraceRouteRecord(context, asRecord(event.detail.evidence_ref))
+  mergeTraceRouteRecord(context, asRecord(event.detail.tool_args))
+  mergeTraceRouteRecord(context, asRecord(event.detail.input))
   mergeTraceRouteRecord(context, event.detail, true)
 
   const parsedArgs = event.toolArgs ? parseJsonLikeData(event.toolArgs) : null
@@ -316,12 +313,6 @@ function mergeTraceRouteRecord(
   if (operationId && (overwrite || context.operationId === undefined)) context.operationId = operationId
   const workerRunId = firstStringish(record, ['worker_run_id', 'workerRunId'])
   if (workerRunId && (overwrite || context.workerRunId === undefined)) context.workerRunId = workerRunId
-}
-
-function nestedRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === 'object' && !Array.isArray(value)
-    ? value as Record<string, unknown>
-    : null
 }
 
 function firstStringish(record: Record<string, unknown>, keys: ReadonlyArray<string>): string | null {

--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -8,7 +8,7 @@ import { TimeAgo } from '../common/time-ago'
 import { Markdown } from '../common/markdown'
 import { ProgressBar } from '../common/progress-bar'
 import { truncate } from '../../lib/truncate'
-import { asNullableString, asRecord, positiveLine } from '../common/normalize'
+import { asNullableString, asRecord, extractCodeLocation, type CodeLocation } from '../common/normalize'
 import { formatCost } from '../../lib/format-number'
 import { toolCategory, durationColor, formatDuration, formatArgs as sharedFormatArgs } from '../tool-call-shared'
 import { SectionHeader } from '../common/section-header'
@@ -150,10 +150,7 @@ function formatArgs(args: Record<string, unknown> | string): string {
   return sharedFormatArgs(args)
 }
 
-interface TraceCodeLocation {
-  readonly filePath: string
-  readonly line?: number
-}
+type TraceCodeLocation = CodeLocation
 
 type TraceRouteContextFields = Pick<
   IdeContextRouteContext,
@@ -182,16 +179,8 @@ function stringishField(value: unknown): string | null {
 }
 
 function recordCodeLocation(value: Record<string, unknown>): TraceCodeLocation | null {
-  const filePath =
-    asNullableString(value.file_path)
-    ?? asNullableString(value.path)
-    ?? asNullableString(value.file)
-  if (filePath) {
-    return {
-      filePath,
-      line: positiveLine(value.line) ?? positiveLine(value.line_start) ?? positiveLine(value.lineno),
-    }
-  }
+  const direct = extractCodeLocation(value)
+  if (direct) return direct
 
   const input = value.input
   if (input && typeof input === 'object' && !Array.isArray(input)) {

--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -8,7 +8,7 @@ import { TimeAgo } from '../common/time-ago'
 import { Markdown } from '../common/markdown'
 import { ProgressBar } from '../common/progress-bar'
 import { truncate } from '../../lib/truncate'
-import { asNullableString, asRecord } from '../common/normalize'
+import { asNullableString, asRecord, positiveLine } from '../common/normalize'
 import { formatCost } from '../../lib/format-number'
 import { toolCategory, durationColor, formatDuration, formatArgs as sharedFormatArgs } from '../tool-call-shared'
 import { SectionHeader } from '../common/section-header'
@@ -179,12 +179,6 @@ function stringishField(value: unknown): string | null {
   if (typeof value === 'string') return asNullableString(value)
   if (typeof value === 'number' && Number.isFinite(value)) return String(value)
   return null
-}
-
-function positiveLine(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 1
-    ? value
-    : undefined
 }
 
 function recordCodeLocation(value: Record<string, unknown>): TraceCodeLocation | null {

--- a/dashboard/src/components/sidecar-log-viewer.ts
+++ b/dashboard/src/components/sidecar-log-viewer.ts
@@ -15,6 +15,7 @@ import { TextInput } from './common/input'
 import { get } from '../api/core'
 import { SurfaceCard } from './common/card'
 import { SkeletonText } from './common/skeleton'
+import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
 
 interface LogResponse {
   ok: boolean
@@ -174,7 +175,7 @@ export function SidecarLogViewer({ connectorId }: { connectorId: string }) {
       if (getEntry(connectorId).open) {
         void fetchLogs(connectorId, getEntry(connectorId).requestedLines)
       }
-    }, 30000)
+    }, TELEMETRY_AUTO_REFRESH_MS)
     return () => clearInterval(id)
   }, [connectorId])
 

--- a/dashboard/src/components/sidecar-log-viewer.ts
+++ b/dashboard/src/components/sidecar-log-viewer.ts
@@ -12,7 +12,7 @@ import { useEffect } from 'preact/hooks'
 import { signal } from '@preact/signals'
 import { ActionButton } from './common/button'
 import { TextInput } from './common/input'
-import { authHeaders } from '../api/core'
+import { get } from '../api/core'
 import { SurfaceCard } from './common/card'
 import { SkeletonText } from './common/skeleton'
 
@@ -95,11 +95,7 @@ function setEntry(id: string, patch: Partial<LogEntry>) {
 async function fetchLogs(id: string, lines: number) {
   setEntry(id, { loading: true, error: null, requestedLines: lines })
   try {
-    const res = await fetch(`/api/v1/sidecar/logs?name=${encodeURIComponent(id)}&lines=${lines}`, {
-      headers: { ...authHeaders(), Accept: 'application/json' },
-    })
-    if (!res.ok) throw new Error(`HTTP ${res.status}`)
-    const data = (await res.json()) as LogResponse
+    const data = await get<LogResponse>(`/api/v1/sidecar/logs?name=${encodeURIComponent(id)}&lines=${lines}`)
     setEntry(id, {
       lines: data.lines ?? [],
       logPath: data.log_path ?? '',

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -30,7 +30,7 @@ import { ringFocusClasses } from './common/ring'
 import { StatTile } from './common/stat-tile'
 import { coverageGapDisplay } from './common/source-health'
 import { TimeAgo } from './common/time-ago'
-import { asNullableString, asRecord } from './common/normalize'
+import { asNullableString, asRecord, asStringArray } from './common/normalize'
 
 interface StoreSnapshot {
   keepers: number
@@ -143,10 +143,6 @@ function formatTs(ts: number): string {
   })
 }
 
-function normalizeStringArray(value: unknown): string[] {
-  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && item.trim() !== '') : []
-}
-
 function recordField(value: unknown, key: string): unknown {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined
   return (value as Record<string, unknown>)[key]
@@ -239,7 +235,7 @@ function telemetryToolName(entry: TelemetryEntry): string | null {
       ?? asNullableString(recordField(entry.action_radius, 'tool_name'))
   }
   if (entry.source === 'execution_receipt') {
-    return normalizeStringArray(entry.canonical_tools)[0]
+    return asStringArray(entry.canonical_tools)[0]
       ?? asNullableString(recordField(entry.action_radius, 'tool_name'))
   }
   return null
@@ -427,7 +423,7 @@ function entryPreview(e: TelemetryEntry): string {
     case 'keeper_metric': {
       const name = asNullableString(e.name) ?? '-'
       const channel = asNullableString(e.channel) ?? '-'
-      const tools = normalizeStringArray(e.tools_used)
+      const tools = asStringArray(e.tools_used)
       const toolCount = typeof e.tool_call_count === 'number' ? e.tool_call_count : tools.length
       return `${name} [${channel}] tools=${toolCount}`
     }

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -20,7 +20,7 @@ import {
 import { replaceRoute, route } from '../router'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
 import { TELEMETRY_SOURCE_META, telemetrySourceMeta } from '../config/telemetry-sources'
-import { formatElapsedCompact } from '../lib/format-time'
+import { formatElapsedCompact, unixSecondsToDate } from '../lib/format-time'
 import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { isAbortError } from '../lib/async-state'
 import { Btn } from './btn'
@@ -136,7 +136,7 @@ function entryTimestamp(e: TelemetryEntry): number {
 
 function formatTs(ts: number): string {
   if (ts === 0) return '-'
-  const d = new Date(ts * 1000)
+  const d = unixSecondsToDate(ts)
   return d.toLocaleString('ko-KR', {
     month: '2-digit', day: '2-digit',
     hour: '2-digit', minute: '2-digit', second: '2-digit',

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -30,6 +30,7 @@ import { ringFocusClasses } from './common/ring'
 import { StatTile } from './common/stat-tile'
 import { coverageGapDisplay } from './common/source-health'
 import { TimeAgo } from './common/time-ago'
+import { asNullableString, asRecord } from './common/normalize'
 
 interface StoreSnapshot {
   keepers: number
@@ -142,10 +143,6 @@ function formatTs(ts: number): string {
   })
 }
 
-function normalizeText(value: unknown): string | null {
-  return typeof value === 'string' && value.trim() !== '' ? value.trim() : null
-}
-
 function normalizeStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && item.trim() !== '') : []
 }
@@ -153,11 +150,6 @@ function normalizeStringArray(value: unknown): string[] {
 function recordField(value: unknown, key: string): unknown {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined
   return (value as Record<string, unknown>)[key]
-}
-
-function recordValue(value: unknown): Record<string, unknown> | null {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null
-  return value as Record<string, unknown>
 }
 
 function normalizeNumber(value: unknown): number | null {
@@ -170,7 +162,7 @@ function normalizeNumber(value: unknown): number | null {
 }
 
 function telemetrySourceFromRouteParam(value: unknown): TelemetrySource | '' {
-  const source = normalizeText(value)
+  const source = asNullableString(value)
   return source && source in TELEMETRY_SOURCE_META ? (source as TelemetrySource) : ''
 }
 
@@ -183,7 +175,7 @@ function uniqueStrings(values: Array<string | null | undefined>): string[] {
   const seen = new Set<string>()
   const result: string[] = []
   for (const value of values) {
-    const normalized = normalizeText(value)
+    const normalized = asNullableString(value)
     if (!normalized || seen.has(normalized)) continue
     seen.add(normalized)
     result.push(normalized)
@@ -198,9 +190,9 @@ function compactId(value: string | null | undefined, prefix: string): string | n
 
 function telemetryScopeBadges(entry: TelemetryEntry): string[] {
   return [
-    compactId(normalizeText(entry.session_id), 'S'),
-    compactId(normalizeText(entry.operation_id), 'OP'),
-    compactId(normalizeText(entry.worker_run_id), 'WR'),
+    compactId(asNullableString(entry.session_id), 'S'),
+    compactId(asNullableString(entry.operation_id), 'OP'),
+    compactId(asNullableString(entry.worker_run_id), 'WR'),
   ].filter((value): value is string => Boolean(value))
 }
 
@@ -208,10 +200,10 @@ function telemetryRouteFocusFromParams(
   params: Record<string, string | undefined>,
 ): TelemetryRouteFocus | null {
   const focus = {
-    sessionId: normalizeText(params.session_id),
-    operationId: normalizeText(params.operation_id),
-    workerRunId: normalizeText(params.worker_run_id),
-    query: normalizeText(params.q),
+    sessionId: asNullableString(params.session_id),
+    operationId: asNullableString(params.operation_id),
+    workerRunId: asNullableString(params.worker_run_id),
+    query: asNullableString(params.q),
   }
   return focus.sessionId || focus.operationId || focus.workerRunId || focus.query
     ? focus
@@ -241,14 +233,14 @@ function telemetryRouteFocusBadges(focus: TelemetryRouteFocus): ReadonlyArray<{ 
 }
 
 function telemetryToolName(entry: TelemetryEntry): string | null {
-  if (entry.source === 'tool_call_io') return normalizeText(entry.tool)
+  if (entry.source === 'tool_call_io') return asNullableString(entry.tool)
   if (entry.source === 'tool_usage' || entry.source === 'tool_metric' || entry.source === 'trajectory_tool_call') {
-    return normalizeText(entry.tool_name)
-      ?? normalizeText(recordField(entry.action_radius, 'tool_name'))
+    return asNullableString(entry.tool_name)
+      ?? asNullableString(recordField(entry.action_radius, 'tool_name'))
   }
   if (entry.source === 'execution_receipt') {
     return normalizeStringArray(entry.canonical_tools)[0]
-      ?? normalizeText(recordField(entry.action_radius, 'tool_name'))
+      ?? asNullableString(recordField(entry.action_radius, 'tool_name'))
   }
   return null
 }
@@ -261,37 +253,37 @@ function canonicalToolName(value: string | null): string | null {
     const segments = value.split('__')
     // segments: ['mcp', '<server>', '<tool>'] — take the last non-empty segment
     const tool = segments.length >= 3 ? segments[segments.length - 1] : value
-    return normalizeText(tool ?? value)
+    return asNullableString(tool ?? value)
   }
-  return normalizeText(value)
+  return asNullableString(value)
 }
 
 function telemetryPayloadRecord(entry: TelemetryEntry): Record<string, unknown> | null {
-  const direct = recordValue(entry.payload)
+  const direct = asRecord(entry.payload)
   if (direct) return direct
   if (Array.isArray(entry.payload)) {
-    return recordValue(entry.payload[1])
+    return asRecord(entry.payload[1])
   }
   return null
 }
 
 function telemetryPayloadKind(entry: TelemetryEntry): string | null {
-  if (Array.isArray(entry.payload)) return normalizeText(entry.payload[0])
-  return normalizeText(recordField(entry.payload, 'kind'))
-    ?? normalizeText(recordField(entry.payload, 'event_type'))
+  if (Array.isArray(entry.payload)) return asNullableString(entry.payload[0])
+  return asNullableString(recordField(entry.payload, 'kind'))
+    ?? asNullableString(recordField(entry.payload, 'event_type'))
 }
 
 function telemetryPayloadProviderParts(entry: TelemetryEntry): string[] {
   const payload = telemetryPayloadRecord(entry)
   if (!payload) return []
   return uniqueStrings([
-    normalizeText(recordField(payload, 'provider_kind')),
-    normalizeText(recordField(payload, 'provider')),
-    normalizeText(recordField(payload, 'model_id')),
-    normalizeText(recordField(payload, 'provider_model_id')),
-    normalizeText(recordField(payload, 'model')),
-    normalizeText(recordField(payload, 'base_url')),
-    normalizeText(recordField(payload, 'endpoint')),
+    asNullableString(recordField(payload, 'provider_kind')),
+    asNullableString(recordField(payload, 'provider')),
+    asNullableString(recordField(payload, 'model_id')),
+    asNullableString(recordField(payload, 'provider_model_id')),
+    asNullableString(recordField(payload, 'model')),
+    asNullableString(recordField(payload, 'base_url')),
+    asNullableString(recordField(payload, 'endpoint')),
   ])
 }
 
@@ -313,33 +305,33 @@ function telemetryTurn(entry: TelemetryEntry): number | null {
 
 function telemetryTurnActor(entry: TelemetryEntry): string | null {
   const payload = telemetryPayloadRecord(entry)
-  return normalizeText(entry.agent_name)
-    ?? normalizeText(recordField(payload, 'agent_name'))
-    ?? normalizeText(recordField(entry.runtime_contract, 'agent_name'))
-    ?? normalizeText(entry.keeper_name)
-    ?? normalizeText(recordField(entry.runtime_contract, 'keeper_name'))
-    ?? normalizeText(entry.keeper)
-    ?? normalizeText(entry.name)
-    ?? normalizeText(entry.caller)
-    ?? normalizeText(entry.agent)
+  return asNullableString(entry.agent_name)
+    ?? asNullableString(recordField(payload, 'agent_name'))
+    ?? asNullableString(recordField(entry.runtime_contract, 'agent_name'))
+    ?? asNullableString(entry.keeper_name)
+    ?? asNullableString(recordField(entry.runtime_contract, 'keeper_name'))
+    ?? asNullableString(entry.keeper)
+    ?? asNullableString(entry.name)
+    ?? asNullableString(entry.caller)
+    ?? asNullableString(entry.agent)
 }
 
 function telemetryRunScope(entry: TelemetryEntry): string | null {
   const payload = telemetryPayloadRecord(entry)
   const session =
-    normalizeText(entry.session_id)
-    ?? normalizeText(recordField(payload, 'session_id'))
-    ?? normalizeText(recordField(entry.runtime_contract, 'session_id'))
+    asNullableString(entry.session_id)
+    ?? asNullableString(recordField(payload, 'session_id'))
+    ?? asNullableString(recordField(entry.runtime_contract, 'session_id'))
   if (session) return `S:${session}`
   const operation =
-    normalizeText(entry.operation_id)
-    ?? normalizeText(recordField(payload, 'operation_id'))
-    ?? normalizeText(recordField(entry.runtime_contract, 'operation_id'))
+    asNullableString(entry.operation_id)
+    ?? asNullableString(recordField(payload, 'operation_id'))
+    ?? asNullableString(recordField(entry.runtime_contract, 'operation_id'))
   if (operation) return `OP:${operation}`
   const workerRun =
-    normalizeText(entry.worker_run_id)
-    ?? normalizeText(recordField(payload, 'worker_run_id'))
-    ?? normalizeText(recordField(entry.runtime_contract, 'worker_run_id'))
+    asNullableString(entry.worker_run_id)
+    ?? asNullableString(recordField(payload, 'worker_run_id'))
+    ?? asNullableString(recordField(entry.runtime_contract, 'worker_run_id'))
   if (workerRun) return `WR:${workerRun}`
   return null
 }
@@ -380,11 +372,11 @@ const FLEET_POLLING_OAS_EVENT_TYPES = new Set([
 ])
 
 function isFleetPollingEntry(entry: TelemetryEntry): boolean {
-  if (entry.source === 'keeper_metric' && normalizeText(entry.channel) === 'heartbeat') {
+  if (entry.source === 'keeper_metric' && asNullableString(entry.channel) === 'heartbeat') {
     return true
   }
   if (entry.source === 'oas_event') {
-    const eventType = normalizeText(entry.event_type) ?? normalizeText(entry.type)
+    const eventType = asNullableString(entry.event_type) ?? asNullableString(entry.type)
     if (eventType != null && FLEET_POLLING_OAS_EVENT_TYPES.has(eventType)) return true
   }
   return false
@@ -413,14 +405,14 @@ function entryGroupingDescriptor(entry: TelemetryEntry): {
   if (!tool || !NOISY_TOOL_NAMES.has(tool)) return null
 
   const scope =
-    normalizeText(entry.session_id)
-    ?? normalizeText(entry.operation_id)
-    ?? normalizeText(entry.worker_run_id)
-    ?? normalizeText(entry.keeper)
-    ?? normalizeText(entry.keeper_name)
-    ?? normalizeText(entry.name)
-    ?? normalizeText(entry.caller)
-    ?? normalizeText(entry.agent_name)
+    asNullableString(entry.session_id)
+    ?? asNullableString(entry.operation_id)
+    ?? asNullableString(entry.worker_run_id)
+    ?? asNullableString(entry.keeper)
+    ?? asNullableString(entry.keeper_name)
+    ?? asNullableString(entry.name)
+    ?? asNullableString(entry.caller)
+    ?? asNullableString(entry.agent_name)
     ?? 'global'
 
   return {
@@ -433,8 +425,8 @@ function entryGroupingDescriptor(entry: TelemetryEntry): {
 function entryPreview(e: TelemetryEntry): string {
   switch (e.source) {
     case 'keeper_metric': {
-      const name = normalizeText(e.name) ?? '-'
-      const channel = normalizeText(e.channel) ?? '-'
+      const name = asNullableString(e.name) ?? '-'
+      const channel = asNullableString(e.channel) ?? '-'
       const tools = normalizeStringArray(e.tools_used)
       const toolCount = typeof e.tool_call_count === 'number' ? e.tool_call_count : tools.length
       return `${name} [${channel}] tools=${toolCount}`
@@ -446,8 +438,8 @@ function entryPreview(e: TelemetryEntry): string {
         const detail = event[1] as Record<string, unknown> | undefined
         if (detail) {
           const parts = [
-            normalizeText(detail.agent_id as string),
-            normalizeText(detail.tool_name as string),
+            asNullableString(detail.agent_id as string),
+            asNullableString(detail.tool_name as string),
           ].filter(Boolean)
           return parts.length > 0 ? `${tag}: ${parts.join(' -> ')}` : tag
         }
@@ -456,31 +448,31 @@ function entryPreview(e: TelemetryEntry): string {
       return String(event ?? '')
     }
     case 'tool_call_io': {
-      const tool = normalizeText(e.tool) ?? ''
-      const keeper = normalizeText(e.keeper) ?? ''
+      const tool = asNullableString(e.tool) ?? ''
+      const keeper = asNullableString(e.keeper) ?? ''
       return `${keeper} -> ${tool}`
     }
     case 'trajectory_tool_call': {
       const tool = telemetryToolName(e) ?? '(unknown tool)'
       const keeper =
-        normalizeText(e.keeper_name)
-        ?? normalizeText(recordField(e.runtime_contract, 'keeper_name'))
-        ?? normalizeText(e.keeper)
+        asNullableString(e.keeper_name)
+        ?? asNullableString(recordField(e.runtime_contract, 'keeper_name'))
+        ?? asNullableString(e.keeper)
         ?? '(unknown keeper)'
       return `${keeper} -> ${tool}`
     }
     case 'tool_usage': {
-      const tool = normalizeText(e.tool_name) ?? ''
-      const caller = normalizeText(e.caller) ?? ''
+      const tool = asNullableString(e.tool_name) ?? ''
+      const caller = asNullableString(e.caller) ?? ''
       return `${caller || 'unknown'} -> ${tool}`
     }
     case 'oas_event': {
-      const eventType = normalizeText(e.event_type) ?? normalizeText(e.type) ?? '(unknown event_type)'
+      const eventType = asNullableString(e.event_type) ?? asNullableString(e.type) ?? '(unknown event_type)'
       const payloadKind = telemetryPayloadKind(e)
       const agentName = telemetryTurnActor(e)
-      const toolName = normalizeText(e.tool_name) ?? normalizeText(recordField(telemetryPayloadRecord(e), 'tool_name'))
+      const toolName = asNullableString(e.tool_name) ?? asNullableString(recordField(telemetryPayloadRecord(e), 'tool_name'))
       const turn = telemetryTurn(e)
-      const taskId = normalizeText(e.task_id)
+      const taskId = asNullableString(e.task_id)
       const parts = [
         payloadKind,
         agentName,
@@ -492,18 +484,18 @@ function entryPreview(e: TelemetryEntry): string {
       return parts.length > 0 ? `${eventType}: ${parts.join(' · ')}` : eventType
     }
     case 'execution_receipt': {
-      const keeper = normalizeText(e.keeper_name) ?? normalizeText(e.agent_name) ?? '(unknown keeper)'
-      const outcome = normalizeText(e.outcome) ?? normalizeText(e.operator_disposition) ?? '(no outcome)'
-      const reason = normalizeText(e.terminal_reason_code)
+      const keeper = asNullableString(e.keeper_name) ?? asNullableString(e.agent_name) ?? '(unknown keeper)'
+      const outcome = asNullableString(e.outcome) ?? asNullableString(e.operator_disposition) ?? '(no outcome)'
+      const reason = asNullableString(e.terminal_reason_code)
       return reason ? `${keeper} receipt ${outcome} (${reason})` : `${keeper} receipt ${outcome}`
     }
     case 'goal_event': {
-      const goal = normalizeText(e.goal_id) ?? '(unknown goal)'
-      const eventType = normalizeText(e.event_type) ?? '(unknown event_type)'
+      const goal = asNullableString(e.goal_id) ?? '(unknown goal)'
+      const eventType = asNullableString(e.event_type) ?? '(unknown event_type)'
       return `${goal} ${eventType}`
     }
     case 'tool_metric': {
-      const tool = normalizeText(e.tool_name) ?? ''
+      const tool = asNullableString(e.tool_name) ?? ''
       const dur = typeof e.duration_ms === 'number' ? e.duration_ms : null
       return `${tool} ${dur != null ? dur.toFixed(0) + 'ms' : ''}`
     }
@@ -553,9 +545,9 @@ function telemetryDisplayItemHaystack(item: TelemetryDisplayItem): string {
 }
 
 function telemetryEntryMatchesRouteFocus(entry: TelemetryEntry, focus: TelemetryRouteFocus): boolean {
-  if (focus.sessionId && normalizeText(entry.session_id) !== focus.sessionId) return false
-  if (focus.operationId && normalizeText(entry.operation_id) !== focus.operationId) return false
-  if (focus.workerRunId && normalizeText(entry.worker_run_id) !== focus.workerRunId) return false
+  if (focus.sessionId && asNullableString(entry.session_id) !== focus.sessionId) return false
+  if (focus.operationId && asNullableString(entry.operation_id) !== focus.operationId) return false
+  if (focus.workerRunId && asNullableString(entry.worker_run_id) !== focus.workerRunId) return false
   if (focus.query && !telemetryEntryHaystack(entry).toLowerCase().includes(focus.query.toLowerCase())) return false
   return true
 }

--- a/dashboard/src/components/tlc-results-panel.ts
+++ b/dashboard/src/components/tlc-results-panel.ts
@@ -9,6 +9,7 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
+import { TLA_POLL_INTERVAL_MS } from '../config/constants'
 import {
   fetchTlcResults,
   type TlaSpecCategory,
@@ -205,7 +206,7 @@ export function TlcResultsPanel() {
 
   useEffect(() => {
     void loadTlcResults(resource)
-    const id = setInterval(() => void loadTlcResults(resource), 60_000)
+    const id = setInterval(() => void loadTlcResults(resource), TLA_POLL_INTERVAL_MS)
     return () => { clearInterval(id); resource.cancel() }
   }, [resource])
 

--- a/dashboard/src/components/tool-call-shared.ts
+++ b/dashboard/src/components/tool-call-shared.ts
@@ -2,6 +2,7 @@
 // and tool-call-timeline components.
 
 import { truncate } from '../lib/truncate'
+import { formatMsCompact } from '../lib/format-number'
 
 // ── Constants ────────────────────────────────────────────
 
@@ -83,12 +84,7 @@ export function toolCategory(name: string): ToolCategoryResult {
 }
 
 /** Format duration as human-readable string with unit. */
-export function formatDuration(ms: number): string {
-  const rounded = Math.round(ms)
-  if (rounded < 1000) return `${rounded}ms`
-  if (rounded < 60_000) return `${(rounded / 1000).toFixed(1)}s`
-  return `${(rounded / 60_000).toFixed(1)}m`
-}
+export const formatDuration = formatMsCompact
 
 /** Summarize a list of trajectory entries: total duration, success count, error count. */
 export function summarizeEntries(entries: Array<{ duration_ms?: number; error?: string | null }>): {

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -109,11 +109,8 @@ const successColor = computed(() => {
 // tool table later moves out of this panel.
 const toolSearchQuery = signal('')
 
-export function toolMatchesSearch(tool: Pick<ToolStat, 'name'>, query: string): boolean {
-  const q = query.trim().toLowerCase()
-  if (q === '') return true
-  return tool.name.toLowerCase().includes(q)
-}
+// Re-export from SSOT — identical logic in tool-metrics.ts
+export { toolMatchesSearch } from './tool-metrics'
 
 export function filterTools<T extends Pick<ToolStat, 'name'>>(tools: T[], query: string): T[] {
   const q = query.trim().toLowerCase()

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -4,6 +4,7 @@ import { signal } from '@preact/signals'
 import { lastEvent } from '../sse'
 import type { SSEEvent } from '../types'
 import { FetchScheduler } from '../lib/fetch-scheduler'
+import { SECONDS_PER_MINUTE, SECONDS_PER_HOUR } from '../lib/format-time'
 import {
   fetchTransportHealth,
   decodeTransportHealthData,
@@ -156,9 +157,9 @@ export function formatFloat(value: number): string {
 }
 
 export function formatIdle(seconds: number): string {
-  if (seconds < 60) return `${Math.round(seconds)}s`
-  if (seconds < 3600) return `${Math.round(seconds / 60)}m`
-  return `${Math.round(seconds / 3600)}h`
+  if (seconds < SECONDS_PER_MINUTE) return `${Math.round(seconds)}s`
+  if (seconds < SECONDS_PER_HOUR) return `${Math.round(seconds / SECONDS_PER_MINUTE)}m`
+  return `${Math.round(seconds / SECONDS_PER_HOUR)}h`
 }
 
 export function compactId(value: string): string {

--- a/dashboard/src/components/verification-requests-panel.ts
+++ b/dashboard/src/components/verification-requests-panel.ts
@@ -27,6 +27,7 @@ import { Card } from './common/card'
 import { EmptyState } from './common/empty-state'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { StatusChip } from './common/status-chip'
+import { SECONDS_PER_MINUTE, SECONDS_PER_HOUR, SECONDS_PER_DAY } from '../lib/format-time'
 import { FilterChips } from './common/filter-chips'
 import { TextInput } from './common/input'
 import type { ManagedAsyncResource } from '../lib/async-state'
@@ -189,10 +190,10 @@ function relativeTime(ts: string): string {
   const ms = parseIso(ts)
   if (ms == null) return ts
   const delta = (Date.now() - ms) / 1000
-  if (delta < 60) return `${Math.floor(delta)}초 전`
-  if (delta < 3600) return `${Math.floor(delta / 60)}분 전`
-  if (delta < 86400) return `${Math.floor(delta / 3600)}시간 전`
-  return `${Math.floor(delta / 86400)}일 전`
+  if (delta < SECONDS_PER_MINUTE) return `${Math.floor(delta)}초 전`
+  if (delta < SECONDS_PER_HOUR) return `${Math.floor(delta / SECONDS_PER_MINUTE)}분 전`
+  if (delta < SECONDS_PER_DAY) return `${Math.floor(delta / SECONDS_PER_HOUR)}시간 전`
+  return `${Math.floor(delta / SECONDS_PER_DAY)}일 전`
 }
 
 // ── Action handler ────────────────────────────────────

--- a/dashboard/src/components/verification-requests-panel.ts
+++ b/dashboard/src/components/verification-requests-panel.ts
@@ -27,7 +27,7 @@ import { Card } from './common/card'
 import { EmptyState } from './common/empty-state'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { StatusChip } from './common/status-chip'
-import { SECONDS_PER_MINUTE, SECONDS_PER_HOUR, SECONDS_PER_DAY } from '../lib/format-time'
+import { relativeTime } from '../lib/format-time'
 import { FilterChips } from './common/filter-chips'
 import { TextInput } from './common/input'
 import type { ManagedAsyncResource } from '../lib/async-state'
@@ -176,24 +176,6 @@ function verdictTone(v: VerificationRequestVerdict): 'ok' | 'warn' | 'bad' {
     case 'fail': return 'bad'
     case null: return 'warn'
   }
-}
-
-// ── Formatting helpers ────────────────────────────────
-
-function parseIso(ts: string | null | undefined): number | null {
-  if (!ts) return null
-  const n = Date.parse(ts)
-  return Number.isNaN(n) ? null : n
-}
-
-function relativeTime(ts: string): string {
-  const ms = parseIso(ts)
-  if (ms == null) return ts
-  const delta = (Date.now() - ms) / 1000
-  if (delta < SECONDS_PER_MINUTE) return `${Math.floor(delta)}초 전`
-  if (delta < SECONDS_PER_HOUR) return `${Math.floor(delta / SECONDS_PER_MINUTE)}분 전`
-  if (delta < SECONDS_PER_DAY) return `${Math.floor(delta / SECONDS_PER_HOUR)}시간 전`
-  return `${Math.floor(delta / SECONDS_PER_DAY)}일 전`
 }
 
 // ── Action handler ────────────────────────────────────

--- a/dashboard/src/components/verification-specs-panel.ts
+++ b/dashboard/src/components/verification-specs-panel.ts
@@ -11,6 +11,7 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
+import { TLA_POLL_INTERVAL_MS } from '../config/constants'
 import {
   fetchTlaSpecs,
   type TlaSpecCategory,
@@ -116,7 +117,7 @@ export function VerificationSpecsPanel() {
 
   useEffect(() => {
     void loadSpecs(resource)
-    const id = setInterval(() => void loadSpecs(resource), 60_000)
+    const id = setInterval(() => void loadSpecs(resource), TLA_POLL_INTERVAL_MS)
     return () => { clearInterval(id); resource.cancel() }
   }, [resource])
 

--- a/dashboard/src/config/constants.ts
+++ b/dashboard/src/config/constants.ts
@@ -102,3 +102,6 @@ export const TLA_POLL_INTERVAL_MS = 60_000
 
 // --- Prometheus /metrics fetch timeout ---
 export const PROMETHEUS_FETCH_TIMEOUT_MS = 10_000
+
+// --- Default query window (minutes) ---
+export const DEFAULT_WINDOW_MINUTES_24H = 1440

--- a/dashboard/src/config/constants.ts
+++ b/dashboard/src/config/constants.ts
@@ -99,3 +99,6 @@ export const AUTORESEARCH_DEFAULT_MODEL = 'glm'
 
 // --- TLA+ verification panel poll interval ---
 export const TLA_POLL_INTERVAL_MS = 60_000
+
+// --- Prometheus /metrics fetch timeout ---
+export const PROMETHEUS_FETCH_TIMEOUT_MS = 10_000

--- a/dashboard/src/config/constants.ts
+++ b/dashboard/src/config/constants.ts
@@ -1,6 +1,12 @@
 // Centralized dashboard constants.
 // Change a value here to adjust behavior across the entire dashboard.
 
+// --- MASC server defaults ---
+// SSOT: ~/me/instructions/workspaces.md Infrastructure Endpoints
+export const DEFAULT_MASC_HOST = 'localhost'
+export const DEFAULT_MASC_PORT = 8935
+export const DEFAULT_MASC_ORIGIN = `http://${DEFAULT_MASC_HOST}:${DEFAULT_MASC_PORT}`
+
 // --- HTTP timeouts (milliseconds) ---
 // Backend dashboard timeout is 30s; frontend must wait slightly longer.
 export const DEFAULT_GET_TIMEOUT_MS = 35_000
@@ -19,6 +25,12 @@ export const MCP_INIT_COOLDOWN_MS = 2_000
 // a reconnect by the client side.
 export const DASHBOARD_WS_RPC_TIMEOUT_MS = 30_000
 export const DASHBOARD_WS_HEARTBEAT_INTERVAL_MS = 30_000
+
+// --- Transport retry defaults (shared by all transport implementations) ---
+// Exponential backoff for transport-level reconnection.  Distinct from
+// RECONNECT_* (which caps at 60s for SSE/dashboard-WS reconnect storms).
+export const TRANSPORT_RETRY_BASE_MS = 1_000
+export const TRANSPORT_RETRY_MAX_MS = 30_000
 
 // --- Reconnect backoff (shared by SSE and dashboard WS) ---
 // Cap at 60s with plus/minus 1s jitter to break reconnect storms when the server is

--- a/dashboard/src/config/constants.ts
+++ b/dashboard/src/config/constants.ts
@@ -96,3 +96,6 @@ export const HEATMAP_COLORS = [
 export const AUTORESEARCH_DEFAULT_MAX_CYCLES = 100
 export const AUTORESEARCH_DEFAULT_CYCLE_TIMEOUT_S = 300
 export const AUTORESEARCH_DEFAULT_MODEL = 'glm'
+
+// --- TLA+ verification panel poll interval ---
+export const TLA_POLL_INTERVAL_MS = 60_000

--- a/dashboard/src/lib/format-number.ts
+++ b/dashboard/src/lib/format-number.ts
@@ -40,3 +40,13 @@ export function formatCost(value: number | null | undefined, fallback = '--'): s
   if (value < 0.01) return `$${value.toFixed(4)}`
   return `$${value.toFixed(2)}`
 }
+
+/** Format millisecond duration as compact string: "3ms", "1.5s", "2.3m".
+ *  Returns fallback for null/NaN/undefined/negative. */
+export function formatMsCompact(ms: number | null | undefined, fallback = ''): string {
+  if (typeof ms !== 'number' || !Number.isFinite(ms) || ms < 0) return fallback
+  const rounded = Math.round(ms)
+  if (rounded < 1000) return `${rounded}ms`
+  if (rounded < 60_000) return `${(rounded / 1000).toFixed(1)}s`
+  return `${(rounded / 60_000).toFixed(1)}m`
+}

--- a/dashboard/src/lib/format-string.ts
+++ b/dashboard/src/lib/format-string.ts
@@ -1,0 +1,7 @@
+// Unified string formatting utilities.
+
+/** Capitalize first character. Returns empty string unchanged. */
+export function capitalize(text: string): string {
+  if (!text) return text
+  return text.charAt(0).toUpperCase() + text.slice(1)
+}

--- a/dashboard/src/lib/format-time.ts
+++ b/dashboard/src/lib/format-time.ts
@@ -52,6 +52,21 @@ export function formatDuration(seconds?: number | null): string {
   return `${Math.round(seconds / SECONDS_PER_DAY)}일`
 }
 
+/** Format duration in seconds as Korean text with compound units — "2시간 30분", "1시간 0분".
+ *  Returns '확인 필요' for invalid. */
+export function formatDurationCompound(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return '확인 필요'
+  const totalMinutes = Math.floor(seconds / SECONDS_PER_MINUTE)
+  const totalHours = Math.floor(totalMinutes / 60)
+
+  if (totalHours >= 1) {
+    const remainMinutes = totalMinutes % 60
+    return `${totalHours}시간 ${remainMinutes}분`
+  }
+  if (totalMinutes >= 1) return `${totalMinutes}분`
+  return `${Math.round(seconds)}초`
+}
+
 /** Format duration in milliseconds as Korean text — "5분", "2시간 30분", "1일 3시간". */
 export function formatDurationMs(ms: number): string {
   if (ms < 0) ms = 0

--- a/dashboard/src/lib/format-time.ts
+++ b/dashboard/src/lib/format-time.ts
@@ -114,6 +114,14 @@ export function formatTimeAgoEn(iso: string): string {
   return `${Math.floor(diff / SECONDS_PER_DAY)}d ago`
 }
 
+/** Format millisecond timestamp as ISO string. Returns undefined for invalid. */
+export function formatDateTimeIso(ts: number): string | undefined {
+  if (!Number.isFinite(ts)) return undefined
+  const d = new Date(ts)
+  if (!Number.isFinite(d.getTime())) return undefined
+  return d.toISOString()
+}
+
 /** Format a numeric delta with sign prefix. */
 export function formatDelta(delta: number, decimals = 4): string {
   const sign = delta >= 0 ? '+' : ''

--- a/dashboard/src/lib/format-time.ts
+++ b/dashboard/src/lib/format-time.ts
@@ -103,6 +103,25 @@ export function formatTimeAgo(ts: string | number): string {
   return formatRelativeSec(Math.max(0, Math.floor((now - then) / 1000)))
 }
 
+/** Format any date value (ISO string, unix seconds, or null) as Korean localized datetime.
+ *  Returns '--' for null/empty, raw value for invalid dates. */
+export function formatDateTimeKo(value: string | number | null): string {
+  if (value === null || value === '') return '--'
+  try {
+    const d = typeof value === 'number' ? unixSecondsToDate(value) : new Date(value)
+    if (Number.isNaN(d.getTime())) return String(value)
+    return d.toLocaleString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  } catch {
+    return String(value)
+  }
+}
+
 /** Format unix timestamp (seconds) as "MM. DD. HH:MM" in ko-KR locale. */
 export function formatTimestampKo(ts: number): string {
   return unixSecondsToDate(ts).toLocaleString('ko-KR', {

--- a/dashboard/src/lib/format-time.ts
+++ b/dashboard/src/lib/format-time.ts
@@ -122,6 +122,26 @@ export function formatDateTimeIso(ts: number): string | undefined {
   return d.toISOString()
 }
 
+/** Format ms timestamp as "HH:MM:SS". Returns fallback for invalid. */
+export function formatTimeHmsMs(tsMs: number, fallback = '--:--:--'): string {
+  if (!Number.isFinite(tsMs)) return fallback
+  const d = new Date(tsMs)
+  if (!Number.isFinite(d.getTime())) return fallback
+  return d.toLocaleTimeString('ko-KR', {
+    hour: '2-digit', minute: '2-digit', second: '2-digit',
+  })
+}
+
+/** Format ms timestamp as "HH:MM". Returns fallback for invalid. */
+export function formatTimeHmMs(tsMs: number, fallback = '--:--'): string {
+  if (!Number.isFinite(tsMs)) return fallback
+  const d = new Date(tsMs)
+  if (!Number.isFinite(d.getTime())) return fallback
+  return d.toLocaleTimeString('ko-KR', {
+    hour: '2-digit', minute: '2-digit',
+  })
+}
+
 /** Format a numeric delta with sign prefix. */
 export function formatDelta(delta: number, decimals = 4): string {
   const sign = delta >= 0 ? '+' : ''

--- a/dashboard/src/lib/format-time.ts
+++ b/dashboard/src/lib/format-time.ts
@@ -18,6 +18,11 @@ export function normalizeTimestampMs(ts: number): number {
   return ts < UNIX_MS_THRESHOLD ? ts * 1000 : ts
 }
 
+/** Convert unix-seconds timestamp to Date. SSOT for the `new Date(ts * 1000)` pattern. */
+export function unixSecondsToDate(ts: number): Date {
+  return new Date(ts * 1000)
+}
+
 export function formatRelativeAgeMs(ageMs: number): string {
   return formatRelativeSec(Math.max(0, Math.round(ageMs / 1000)))
 }
@@ -85,7 +90,7 @@ export function formatTimeAgo(ts: string | number): string {
 
 /** Format unix timestamp (seconds) as "MM. DD. HH:MM" in ko-KR locale. */
 export function formatTimestampKo(ts: number): string {
-  return new Date(ts * 1000).toLocaleString('ko-KR', {
+  return unixSecondsToDate(ts).toLocaleString('ko-KR', {
     month: '2-digit',
     day: '2-digit',
     hour: '2-digit',
@@ -97,7 +102,7 @@ export function formatTimestampKo(ts: number): string {
 
 /** Format unix-seconds timestamp as "HH:MM:SS" (24h, ko-KR). */
 export function formatTimeHms(tsUnixSec: number): string {
-  return new Date(tsUnixSec * 1000).toLocaleTimeString('ko-KR', {
+  return unixSecondsToDate(tsUnixSec).toLocaleTimeString('ko-KR', {
     hour: '2-digit', minute: '2-digit', second: '2-digit',
   })
 }

--- a/dashboard/src/lib/format-time.ts
+++ b/dashboard/src/lib/format-time.ts
@@ -1,13 +1,17 @@
 // Unified time formatting utilities.
 
+export const SECONDS_PER_MINUTE = 60
+export const SECONDS_PER_HOUR = 3600
+export const SECONDS_PER_DAY = 86400
+
 const rtf = new Intl.RelativeTimeFormat('ko', { numeric: 'auto' })
 const UNIX_MS_THRESHOLD = 1_000_000_000_000
 
 export function formatRelativeSec(deltaSec: number): string {
-  if (deltaSec < 60) return rtf.format(-deltaSec, 'second')
-  if (deltaSec < 3600) return rtf.format(-Math.round(deltaSec / 60), 'minute')
-  if (deltaSec < 86400) return rtf.format(-Math.round(deltaSec / 3600), 'hour')
-  return rtf.format(-Math.round(deltaSec / 86400), 'day')
+  if (deltaSec < SECONDS_PER_MINUTE) return rtf.format(-deltaSec, 'second')
+  if (deltaSec < SECONDS_PER_HOUR) return rtf.format(-Math.round(deltaSec / SECONDS_PER_MINUTE), 'minute')
+  if (deltaSec < SECONDS_PER_DAY) return rtf.format(-Math.round(deltaSec / SECONDS_PER_HOUR), 'hour')
+  return rtf.format(-Math.round(deltaSec / SECONDS_PER_DAY), 'day')
 }
 
 export function normalizeTimestampMs(ts: number): number {
@@ -29,18 +33,18 @@ export function relativeTime(iso?: string | null, fallback = '정보 없음'): s
 /** Format elapsed seconds — "3초", "5분", "2시간". Returns '정보 없음' for invalid. */
 export function formatElapsed(value?: number | null): string {
   if (typeof value !== 'number' || !Number.isFinite(value)) return '정보 없음'
-  if (value < 60) return `${Math.round(value)}초`
-  if (value < 3600) return `${Math.round(value / 60)}분`
-  return `${Math.round(value / 3600)}시간`
+  if (value < SECONDS_PER_MINUTE) return `${Math.round(value)}초`
+  if (value < SECONDS_PER_HOUR) return `${Math.round(value / SECONDS_PER_MINUTE)}분`
+  return `${Math.round(value / SECONDS_PER_HOUR)}시간`
 }
 
 /** Format duration in seconds as Korean text — includes days. Returns '확인 필요' for invalid. */
 export function formatDuration(seconds?: number | null): string {
   if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds < 0) return '확인 필요'
-  if (seconds < 60) return `${Math.round(seconds)}초`
-  if (seconds < 3600) return `${Math.round(seconds / 60)}분`
-  if (seconds < 86400) return `${Math.round(seconds / 3600)}시간`
-  return `${Math.round(seconds / 86400)}일`
+  if (seconds < SECONDS_PER_MINUTE) return `${Math.round(seconds)}초`
+  if (seconds < SECONDS_PER_HOUR) return `${Math.round(seconds / SECONDS_PER_MINUTE)}분`
+  if (seconds < SECONDS_PER_DAY) return `${Math.round(seconds / SECONDS_PER_HOUR)}시간`
+  return `${Math.round(seconds / SECONDS_PER_DAY)}일`
 }
 
 /** Format duration in milliseconds as Korean text — "5분", "2시간 30분", "1일 3시간". */
@@ -64,9 +68,9 @@ export function formatDurationMs(ms: number): string {
 /** Format elapsed seconds in compact English — "3s", "5m", "2h 30m". */
 export function formatElapsedCompact(seconds?: number | null): string {
   if (seconds == null) return ''
-  if (seconds < 60) return `${Math.round(seconds)}s`
-  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${Math.round(seconds % 60)}s`
-  return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`
+  if (seconds < SECONDS_PER_MINUTE) return `${Math.round(seconds)}s`
+  if (seconds < SECONDS_PER_HOUR) return `${Math.floor(seconds / SECONDS_PER_MINUTE)}m ${Math.round(seconds % SECONDS_PER_MINUTE)}s`
+  return `${Math.floor(seconds / SECONDS_PER_HOUR)}h ${Math.floor((seconds % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE)}m`
 }
 
 /** Format timestamp (string or number) as relative time. Handles unix seconds and ms. */
@@ -104,10 +108,10 @@ export function formatTimeAgoEn(iso: string): string {
   if (iso === 'never') return 'never'
   const diff = (Date.now() - new Date(iso).getTime()) / 1000
   if (Number.isNaN(diff)) return 'unknown'
-  if (diff < 60) return 'just now'
-  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
-  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
-  return `${Math.floor(diff / 86400)}d ago`
+  if (diff < SECONDS_PER_MINUTE) return 'just now'
+  if (diff < SECONDS_PER_HOUR) return `${Math.floor(diff / SECONDS_PER_MINUTE)}m ago`
+  if (diff < SECONDS_PER_DAY) return `${Math.floor(diff / SECONDS_PER_HOUR)}h ago`
+  return `${Math.floor(diff / SECONDS_PER_DAY)}d ago`
 }
 
 /** Format a numeric delta with sign prefix. */

--- a/dashboard/src/lib/mention-utils.ts
+++ b/dashboard/src/lib/mention-utils.ts
@@ -1,0 +1,56 @@
+// Shared mention utilities — SSOT for keeper mention UI logic.
+// Used by composer-v2.ts and quick-intervene.ts.
+
+export interface OnlineKeeper {
+  name: string
+  status?: string
+}
+
+export interface MentionCandidate {
+  name: string
+  status?: string
+  selected: boolean
+}
+
+export function keeperNameFromTarget(value: string): string | null {
+  if (!value.startsWith('keeper:')) return null
+  const name = value.slice('keeper:'.length).trim()
+  return name || null
+}
+
+export function mentionQueryFromMessage(message: string): string | null {
+  const match = message.match(/(?:^|\s)@([A-Za-z0-9_.-]*)$/)
+  return match?.[1] ?? null
+}
+
+export function trailingMentionNameFromMessage(message: string): string | null {
+  const match = message.match(/(?:^|\s)@([A-Za-z0-9_.-]+)\s*$/)
+  return match?.[1] ?? null
+}
+
+export function onlineKeeperNameForMention(onlineKeepers: OnlineKeeper[], mentionName: string | null): string | null {
+  if (!mentionName) return null
+  const normalized = mentionName.toLowerCase()
+  return onlineKeepers.find(keeper => keeper.name.toLowerCase() === normalized)?.name ?? null
+}
+
+export function mentionCandidates(onlineKeepers: OnlineKeeper[], query: string | null, selectedKeeper: string | null): MentionCandidate[] {
+  const normalizedQuery = query?.toLowerCase() ?? ''
+  return onlineKeepers
+    .filter(keeper => normalizedQuery === '' || keeper.name.toLowerCase().includes(normalizedQuery))
+    .map(keeper => ({
+      name: keeper.name,
+      status: keeper.status,
+      selected: keeper.name === selectedKeeper,
+    }))
+    .sort((a, b) => Number(b.selected) - Number(a.selected) || a.name.localeCompare(b.name))
+    .slice(0, 5)
+}
+
+export function replaceTrailingMentionDraft(message: string, keeperName: string): string {
+  if (/(?:^|\s)@[A-Za-z0-9_.-]*$/.test(message)) {
+    return message.replace(/(^|\s)@[A-Za-z0-9_.-]*$/, `$1@${keeperName} `)
+  }
+  const spacer = message.trimEnd().length > 0 ? ' ' : ''
+  return `${message.trimEnd()}${spacer}@${keeperName} `
+}

--- a/dashboard/src/lib/stop-cause.ts
+++ b/dashboard/src/lib/stop-cause.ts
@@ -13,9 +13,7 @@ function humanize(code: string): string {
     .trim()
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value != null && typeof value === 'object' && !Array.isArray(value)
-}
+import { isRecord } from './type-guards'
 
 function coerceRawStopCause(raw: unknown): StopCause | null {
   if (!isRecord(raw)) return null

--- a/dashboard/src/lib/type-guards.ts
+++ b/dashboard/src/lib/type-guards.ts
@@ -1,0 +1,6 @@
+// Low-level type guards shared across all layers (api/, lib/, schemas/, components/).
+
+/** Check if a value is a plain object (not null, not array). */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/dashboard/src/mission-normalizers-entities.ts
+++ b/dashboard/src/mission-normalizers-entities.ts
@@ -1,4 +1,4 @@
-import { isRecord, asString, asNumber, extractArray } from './components/common/normalize'
+import { isRecord, asString, asNumber, asStringArray, extractArray } from './components/common/normalize'
 import {
   normalizeAttentionItem,
   normalizeRecommendedAction,
@@ -31,15 +31,9 @@ export function normalizeAttentionQueueItem(raw: unknown): DashboardMissionAtten
     target_type: targetType,
     target_id: asString(raw.target_id) ?? null,
     top_action: normalizeRecommendedAction(raw.top_action),
-    related_session_ids: extractArray(raw.related_session_ids)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
-    related_agent_names: extractArray(raw.related_agent_names)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
-    evidence_preview: extractArray(raw.evidence_preview)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
+    related_session_ids: asStringArray(raw.related_session_ids),
+    related_agent_names: asStringArray(raw.related_agent_names),
+    evidence_preview: asStringArray(raw.evidence_preview),
     last_seen_at: asString(raw.last_seen_at) ?? null,
   }
 }
@@ -57,9 +51,7 @@ export function normalizeSessionBrief(raw: unknown): DashboardMissionSessionBrie
     namespace: asString(raw.namespace) ?? null,
     status: asString(raw.status),
     health: asString(raw.health),
-    member_names: extractArray(raw.member_names)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
+    member_names: asStringArray(raw.member_names),
     started_at: asString(raw.started_at) ?? null,
     elapsed_sec: asNumber(raw.elapsed_sec) ?? null,
     operation_id: asString(raw.operation_id) ?? null,
@@ -89,9 +81,7 @@ export function normalizeParticipantPreview(raw: unknown): DashboardMissionParti
     current_work: asString(raw.current_work) ?? null,
     recent_input_preview: asString(raw.recent_input_preview) ?? null,
     recent_output_preview: asString(raw.recent_output_preview) ?? null,
-    recent_tool_names: extractArray(raw.recent_tool_names)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
+    recent_tool_names: asStringArray(raw.recent_tool_names),
     last_activity_at: asString(raw.last_activity_at) ?? null,
   }
 }
@@ -153,9 +143,7 @@ export function normalizeAgentBrief(raw: unknown): DashboardMissionAgentBrief | 
     archived_reason: asString(raw.archived_reason) ?? null,
     status: asString(raw.status),
     where: asString(raw.where) ?? null,
-    with_whom: extractArray(raw.with_whom)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
+    with_whom: asStringArray(raw.with_whom),
     current_work: asString(raw.current_work) ?? null,
     related_session_id: asString(raw.related_session_id) ?? null,
     related_attention_count: asNumber(raw.related_attention_count) ?? 0,
@@ -177,9 +165,7 @@ export function normalizeAgentBrief(raw: unknown): DashboardMissionAgentBrief | 
         : undefined,
     recent_output_preview: asString(raw.recent_output_preview) ?? null,
     recent_input_preview: asString(raw.recent_input_preview) ?? null,
-    recent_tool_names: extractArray(raw.recent_tool_names)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
+    recent_tool_names: asStringArray(raw.recent_tool_names),
   }
 }
 
@@ -196,9 +182,7 @@ export function normalizeKeeperBrief(raw: unknown): DashboardMissionKeeperBrief 
     last_turn_ago_s: asNumber(raw.last_turn_ago_s) ?? null,
     current_work: asString(raw.current_work) ?? null,
     last_autonomous_action_at: asString(raw.last_autonomous_action_at) ?? null,
-    latest_tool_names: extractArray(raw.latest_tool_names)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
+    latest_tool_names: asStringArray(raw.latest_tool_names),
     latest_tool_call_count: asNumber(raw.latest_tool_call_count) ?? null,
     tool_audit_source: asString(raw.tool_audit_source) ?? null,
     tool_audit_at: asString(raw.tool_audit_at) ?? null,

--- a/dashboard/src/mission-normalizers.ts
+++ b/dashboard/src/mission-normalizers.ts
@@ -1,4 +1,4 @@
-import { isRecord, asString, asNumber, asBoolean, extractArray } from './components/common/normalize'
+import { isRecord, asString, asNumber, asBoolean, extractArray, asStringArray } from './components/common/normalize'
 import { normalizePendingConfirmation } from './pending-confirm'
 import {
   normalizeAttentionItem,
@@ -65,42 +65,28 @@ function normalizeWorkerRunEvidence(raw: unknown): DashboardProofWorkerRunEviden
     proof_execution_mode: asString(raw.proof_execution_mode) ?? null,
     proof_evidence_count: asNumber(raw.proof_evidence_count),
     checkpoint_ref: asString(raw.checkpoint_ref) ?? null,
-    tool_trace_refs: extractArray(raw.tool_trace_refs)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
-    raw_evidence_refs: extractArray(raw.raw_evidence_refs)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
+    tool_trace_refs: asStringArray(raw.tool_trace_refs),
+    raw_evidence_refs: asStringArray(raw.raw_evidence_refs),
     worker_name: asString(raw.worker_name) ?? null,
     status: asString(raw.status) ?? null,
     mode: asString(raw.mode) ?? null,
     wait_mode: asString(raw.wait_mode) ?? null,
     trace_capability: asString(raw.trace_capability) ?? null,
     trace_validated: asBoolean(raw.trace_validated),
-    validation_failures: extractArray(raw.validation_failures)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
+    validation_failures: asStringArray(raw.validation_failures),
     success: asBoolean(raw.success),
     requested_worker_class: asString(raw.requested_worker_class) ?? null,
     requested_worker_size: asString(raw.requested_worker_size) ?? null,
     tool_surface_status: asString(raw.tool_surface_status) ?? null,
     tool_surface_source: asString(raw.tool_surface_source) ?? null,
-    tool_surface_names: extractArray(raw.tool_surface_names)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
-    tool_surface_masc_names: extractArray(raw.tool_surface_masc_names)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
-    tool_surface_shell_names: extractArray(raw.tool_surface_shell_names)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
+    tool_surface_names: asStringArray(raw.tool_surface_names),
+    tool_surface_masc_names: asStringArray(raw.tool_surface_masc_names),
+    tool_surface_shell_names: asStringArray(raw.tool_surface_shell_names),
     tool_surface_count: asNumber(raw.tool_surface_count),
     resolved_runtime: asString(raw.resolved_runtime) ?? null,
     resolved_model: asString(raw.resolved_model) ?? null,
     routing_reason: asString(raw.routing_reason) ?? null,
-    tool_names: extractArray(raw.tool_names)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
+    tool_names: asStringArray(raw.tool_names),
     tool_call_count: asNumber(raw.tool_call_count),
     output_preview: asString(raw.output_preview) ?? null,
     record_count: asNumber(raw.record_count),
@@ -109,9 +95,7 @@ function normalizeWorkerRunEvidence(raw: unknown): DashboardProofWorkerRunEviden
     stop_reason: asString(raw.stop_reason) ?? null,
     failure_reason: asString(raw.failure_reason) ?? null,
     error: asString(raw.error) ?? null,
-    evidence_refs: extractArray(raw.evidence_refs)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
+    evidence_refs: asStringArray(raw.evidence_refs),
     ts_iso: asString(raw.ts_iso) ?? null,
   }
 }
@@ -141,26 +125,14 @@ function normalizeSessionWorkerRuns(raw: unknown): DashboardMissionSessionWorker
     completed_success_count: asNumber(raw.completed_success_count),
     completed_failed_count: asNumber(raw.completed_failed_count),
     in_flight_count: asNumber(raw.in_flight_count),
-    in_flight_run_ids: extractArray(raw.in_flight_run_ids)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
-    in_flight_actor_names: extractArray(raw.in_flight_actor_names)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
+    in_flight_run_ids: asStringArray(raw.in_flight_run_ids),
+    in_flight_actor_names: asStringArray(raw.in_flight_actor_names),
     ready_worker_count: asNumber(raw.ready_worker_count),
-    ready_worker_names: extractArray(raw.ready_worker_names)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
-    delegate_ready_worker_names: extractArray(raw.delegate_ready_worker_names)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
-    blocked_worker_names: extractArray(raw.blocked_worker_names)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
+    ready_worker_names: asStringArray(raw.ready_worker_names),
+    delegate_ready_worker_names: asStringArray(raw.delegate_ready_worker_names),
+    blocked_worker_names: asStringArray(raw.blocked_worker_names),
     pending_worker_count: asNumber(raw.pending_worker_count),
-    pending_worker_names: extractArray(raw.pending_worker_names)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
+    pending_worker_names: asStringArray(raw.pending_worker_names),
     worker_readiness: extractArray(raw.worker_readiness)
       .map(normalizeWorkerReadiness)
       .filter((item): item is DashboardMissionWorkerReadiness => item !== null),
@@ -180,9 +152,7 @@ function normalizeKeeper(raw: unknown): OperatorKeeperSnapshot | null {
     status: asString(raw.status),
     context_ratio: asNumber(raw.context_ratio),
     generation: asNumber(raw.generation),
-    active_goal_ids: extractArray(raw.active_goal_ids)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
+    active_goal_ids: asStringArray(raw.active_goal_ids),
     last_autonomous_action_at: asString(raw.last_autonomous_action_at) ?? null,
     last_turn_ago_s: asNumber(raw.last_turn_ago_s),
     model: asString(raw.model),
@@ -342,9 +312,7 @@ function normalizeBriefingSection(raw: unknown): DashboardMissionBriefingSection
       || asString(raw.evidence_quality) === 'missing'
         ? (asString(raw.evidence_quality) as DashboardMissionBriefingSection['evidence_quality'])
         : undefined,
-    evidence: extractArray(raw.evidence)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
+    evidence: asStringArray(raw.evidence),
   }
 }
 
@@ -386,9 +354,7 @@ export function normalizeMissionBriefing(raw: unknown): DashboardMissionBriefing
     summary: asString(root.summary) ?? null,
     model: asString(root.model) ?? null,
     ttl_sec: asNumber(root.ttl_sec),
-    criteria: extractArray(root.criteria)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
+    criteria: asStringArray(root.criteria),
     basis: {
       namespace: asString(basis.namespace) ?? null,
       crew_count: asNumber(basis.crew_count),

--- a/dashboard/src/mission-normalizers.ts
+++ b/dashboard/src/mission-normalizers.ts
@@ -1,4 +1,5 @@
 import { isRecord, asString, asNumber, asBoolean, extractArray } from './components/common/normalize'
+import { normalizePendingConfirmation } from './pending-confirm'
 import {
   normalizeAttentionItem,
   normalizeRecommendedAction,
@@ -192,21 +193,7 @@ function normalizeKeeper(raw: unknown): OperatorKeeperSnapshot | null {
   }
 }
 
-function normalizePendingConfirmation(raw: unknown): PendingConfirmation | null {
-  if (!isRecord(raw)) return null
-  const token = asString(raw.confirm_token) ?? asString(raw.token)
-  if (!token) return null
-  return {
-    confirm_token: token,
-    actor: asString(raw.actor),
-    action_type: asString(raw.action_type),
-    target_type: asString(raw.target_type),
-    target_id: asString(raw.target_id) ?? null,
-    delegated_tool: asString(raw.delegated_tool),
-    created_at: asString(raw.created_at),
-    preview: raw.preview,
-  }
-}
+// normalizePendingConfirmation imported from pending-confirm.ts (SSOT)
 
 function normalizeActionDescriptor(raw: unknown): OperatorActionDescriptor | null {
   if (!isRecord(raw)) return null

--- a/dashboard/src/namespace-truth-normalizers.ts
+++ b/dashboard/src/namespace-truth-normalizers.ts
@@ -7,6 +7,7 @@ import {
   normalizeRecommendedAction,
   normalizeShellMetaCognitionSummary,
 } from './store-normalizers'
+import { normalizePendingConfirmSummary } from './pending-confirm'
 import type {
   DashboardAttentionEvent,
   DashboardNamespaceTruthAttentionSummary,
@@ -19,29 +20,7 @@ import type {
   PendingConfirmSummary,
 } from './types'
 
-function normalizePendingConfirmSummary(raw: unknown): PendingConfirmSummary | null {
-  if (!isRecord(raw)) return null
-  return {
-    actor_filter: asString(raw.actor_filter) ?? null,
-    filter_active: asBoolean(raw.filter_active) ?? false,
-    visible_count: asNumber(raw.visible_count) ?? 0,
-    total_count: asNumber(raw.total_count) ?? 0,
-    hidden_count: asNumber(raw.hidden_count) ?? 0,
-    hidden_actors: asStringArray(raw.hidden_actors),
-    confirm_required_actions: extractArray(raw.confirm_required_actions).flatMap(item => {
-      if (!isRecord(item)) return []
-      const actionType = asString(item.action_type)
-      const targetType = asString(item.target_type)
-      if (!actionType || !targetType) return []
-      return [{
-        action_type: actionType,
-        target_type: targetType,
-        description: asString(item.description),
-        confirm_required: asBoolean(item.confirm_required),
-      }]
-    }),
-  }
-}
+// normalizePendingConfirmSummary imported from pending-confirm.ts (SSOT)
 
 function normalizeAttentionSummary(raw: unknown): DashboardNamespaceTruthAttentionSummary | null {
   if (!isRecord(raw)) return null

--- a/dashboard/src/namespace-truth-normalizers.ts
+++ b/dashboard/src/namespace-truth-normalizers.ts
@@ -17,7 +17,6 @@ import type {
   DashboardReadinessSummary,
   DashboardNamespaceTruthRecommendationSummary,
   DashboardNamespaceTruthResponse,
-  PendingConfirmSummary,
 } from './types'
 
 // normalizePendingConfirmSummary imported from pending-confirm.ts (SSOT)

--- a/dashboard/src/operator-actions.ts
+++ b/dashboard/src/operator-actions.ts
@@ -9,6 +9,7 @@ import type {
   OperatorActionLogEntry,
   OperatorActionRequest,
   OperatorActionResult,
+  RefreshOptions,
 } from './types'
 import { registerOperatorRefresh } from './sse-store'
 import { UI_REFRESH_TTL_MS } from './config/constants'
@@ -27,10 +28,6 @@ import {
 import { normalizeOperatorSnapshot, normalizeOperatorDigest } from './operator-normalizers'
 
 let nextLogId = 1
-
-interface RefreshOptions {
-  force?: boolean
-}
 
 let snapshotRefreshInflight: Promise<void> | null = null
 let roomDigestRefreshInflight: Promise<void> | null = null

--- a/dashboard/src/operator-normalizers.ts
+++ b/dashboard/src/operator-normalizers.ts
@@ -6,6 +6,10 @@ import {
   normalizePendingConfirmSummary,
 } from './pending-confirm'
 import { normalizeKeeperTrust } from './keeper-store-normalize'
+import {
+  normalizeAttentionItem,
+  normalizeRecommendedAction,
+} from './store-normalizers'
 import type {
   AdmissionQueueSnapshot,
   Message,
@@ -59,41 +63,6 @@ function normalizeStringRecord(raw: unknown): Record<string, string> | undefined
     })
     .filter((entry): entry is [string, string] => entry !== null)
   return entries.length > 0 ? Object.fromEntries(entries) : undefined
-}
-
-function normalizeAttentionItem(raw: unknown): OperatorAttentionItem | null {
-  if (!isRecord(raw)) return null
-  const kind = asString(raw.kind)
-  const summary = asString(raw.summary)
-  const targetType = asString(raw.target_type)
-  if (!kind || !summary || !targetType) return null
-  return {
-    kind,
-    severity: asString(raw.severity) ?? 'unknown',
-    summary,
-    target_type: targetType,
-    target_id: asString(raw.target_id) ?? null,
-    actor: asString(raw.actor) ?? null,
-    evidence: raw.evidence,
-  }
-}
-
-function normalizeRecommendedAction(raw: unknown): OperatorRecommendedAction | null {
-  if (!isRecord(raw)) return null
-  const actionType = asString(raw.action_type)
-  const targetType = asString(raw.target_type)
-  const reason = asString(raw.reason)
-  if (!actionType || !targetType || !reason) return null
-  return {
-    action_type: actionType,
-    target_type: targetType,
-    target_id: asString(raw.target_id) ?? null,
-    severity: asString(raw.severity) ?? 'unknown',
-    reason,
-    confirm_required: asBoolean(raw.confirm_required),
-    suggested_payload: raw.suggested_payload,
-    preview: raw.preview,
-  }
 }
 
 function normalizeOperatorJudgeRuntime(raw: unknown): OperatorJudgeRuntime | null {

--- a/dashboard/src/refresh-scope.ts
+++ b/dashboard/src/refresh-scope.ts
@@ -1,6 +1,6 @@
 import type { RouteState } from './types'
 
-type RouteRefreshTarget = 'execution' | 'board' | 'operator' | 'activity'
+export type RouteRefreshTarget = 'execution' | 'board' | 'operator' | 'activity'
 
 export function routeWantsRefreshTarget(
   routeState: Pick<RouteState, 'tab' | 'params'>,

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -146,9 +146,7 @@ function fail<T = never>(path: string | undefined, message: string): SafeParseRe
   return { success: false, error: { issues: [{ path, message }] } }
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === 'object' && !Array.isArray(value)
-}
+import { isRecord } from '../lib/type-guards'
 
 function isIgnorableMcpNotification(value: unknown): boolean {
   if (!isRecord(value)) return false

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -55,7 +55,7 @@ import { hydrateGoalTreeSnapshot } from './goal-tree-state'
 import { showToast } from './components/common/toast'
 import type { ErrorCode } from './types/error'
 import { route } from './router'
-import { routeWantsRefreshTarget } from './refresh-scope'
+import { routeWantsRefreshTarget, type RouteRefreshTarget } from './refresh-scope'
 import {
   PERIODIC_REFRESH_DEV_MS,
   PERIODIC_REFRESH_PROD_MS,
@@ -120,7 +120,7 @@ function scheduleRefresh(key: string, fn: () => void, delayMs = SSE_DEFAULT_DEBO
 // Simple events that map directly to a debounced refresh target.
 // Complex events (conditional logic, async imports) use named handlers below.
 
-type RefreshTarget = 'execution' | 'board' | 'operator' | 'activity'
+type RefreshTarget = RouteRefreshTarget
 
 interface SimpleRoute {
   target: RefreshTarget

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -17,6 +17,7 @@ import { appendLiveToolCall } from './components/session-trace/session-trace-liv
 import { appendAuditEntry } from './live-store'
 import { dashboardBearerToken } from './api/core'
 import { parseSSEMessage } from './schemas/sse'
+import { asNumber } from './components/common/normalize'
 import { RingBuffer } from './lib/ring-buffer'
 import { createSseTransport } from './transports/sse-transport'
 import type { Transport } from './transports/transport'
@@ -112,10 +113,6 @@ function projectedActorLabel(raw: string | undefined, displayName: string | unde
 
 function asString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() !== '' ? value : undefined
-}
-
-function asNumber(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
 }
 
 function formatTaskNarrative(agent: string, taskId?: string, status?: string): string {

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -49,7 +49,7 @@ import {
 import { groupByKey } from './components/common/collection'
 import { setArrayByKeyIfChanged } from './signal-utils'
 import { FetchScheduler } from './lib/fetch-scheduler'
-import { isRecord, asString, asNumber } from './components/common/normalize'
+import { isRecord, asString, asNumber, asStringArray } from './components/common/normalize'
 import { setCanonicalDashboardActor } from './lib/dashboard-session-actor'
 import { timeBoardRequest } from './board-metrics'
 import { namespaceTruth, namespaceTruthError, namespaceTruthInitializing } from './namespace-truth-signals'
@@ -585,22 +585,12 @@ export async function refreshDashboard(opts?: RefreshOptions): Promise<void> {
   return inflightDashboardRefresh
 }
 
-function normalizeStringList(raw: unknown): string[] {
-  if (Array.isArray(raw)) {
-    return raw.filter((value): value is string =>
-      typeof value === 'string' && value.trim() !== '',
-    )
-  }
-  if (typeof raw === 'string' && raw.trim() !== '') return [raw]
-  return []
-}
-
 function normalizeCoordinationFsmRefs(raw: unknown): DashboardCoordinationFsmRefs {
   const refsRecord = isRecord(raw) ? raw : {}
   return {
     goal_id: asString(refsRecord.goal_id) ?? null,
-    task_ids: normalizeStringList(refsRecord.task_ids),
-    post_ids: normalizeStringList(refsRecord.post_ids),
+    task_ids: asStringArray(refsRecord.task_ids),
+    post_ids: asStringArray(refsRecord.post_ids),
     agent_name: asString(refsRecord.agent_name) ?? null,
   }
 }

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -12,6 +12,7 @@ import type {
   ServerStatus,
   BoardSortMode,
   Goal,
+  RefreshOptions,
   DashboardExecutionSessionBrief,
   DashboardExecutionQueueItem,
   DashboardExecutionWorkerSupportBrief,
@@ -509,10 +510,7 @@ export const staleKeepers: ReadonlySignal<Set<string>> = computed(() => {
 
 // --- Refresh orchestration ---
 
-interface RefreshOptions {
-  force?: boolean
-  light?: boolean
-}
+// RefreshOptions imported from types/core.ts (SSOT)
 
 // TTL values from config/constants.ts
 

--- a/dashboard/src/transports/grpc-transport.ts
+++ b/dashboard/src/transports/grpc-transport.ts
@@ -26,9 +26,10 @@ import type {
   LspResponse,
 } from '../grpc/masc_coordination_pb'
 
-const DEFAULT_RETRY_BASE_MS = 1000
-/** Default retry ceiling.  Exported for callers that need it. */
-export const DEFAULT_RETRY_MAX_MS = 30000
+import { TRANSPORT_RETRY_BASE_MS, TRANSPORT_RETRY_MAX_MS } from '../config/constants'
+
+/** Re-export for callers that need the transport retry ceiling. */
+export const DEFAULT_RETRY_MAX_MS = TRANSPORT_RETRY_MAX_MS
 
 /** Encode a JSON payload into a gRPC-web binary frame.
  *  Frame: [flag:1][length:4][payload:N]
@@ -105,7 +106,7 @@ interface GrpcTransportState {
 function createState(): GrpcTransportState {
   return {
     listeners: [],
-    retryMs: DEFAULT_RETRY_BASE_MS,
+    retryMs: TRANSPORT_RETRY_BASE_MS,
     reconnectTimer: null,
     connected: false,
     abortController: null,

--- a/dashboard/src/transports/http-streamable-transport.ts
+++ b/dashboard/src/transports/http-streamable-transport.ts
@@ -1,12 +1,10 @@
 import type { Transport, TransportEvent, TransportOptions } from './transport'
-
-const DEFAULT_RETRY_BASE_MS = 1000
-const DEFAULT_RETRY_MAX_MS = 30000
+import { TRANSPORT_RETRY_BASE_MS, TRANSPORT_RETRY_MAX_MS } from '../config/constants'
 
 export function createHttpStreamableTransport(url: string, opts: TransportOptions = {}): Transport {
   let abortController: AbortController | null = null
   let listeners: Array<(event: TransportEvent) => void> = []
-  let retryMs = opts.retryBaseMs ?? DEFAULT_RETRY_BASE_MS
+  let retryMs = opts.retryBaseMs ?? TRANSPORT_RETRY_BASE_MS
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null
   let connected = false
 
@@ -32,7 +30,7 @@ export function createHttpStreamableTransport(url: string, opts: TransportOption
           throw new Error(`HTTP ${res.status}`)
         }
         connected = true
-        retryMs = opts.retryBaseMs ?? DEFAULT_RETRY_BASE_MS
+        retryMs = opts.retryBaseMs ?? TRANSPORT_RETRY_BASE_MS
         notify({ type: 'open' })
         const reader = res.body.getReader()
         const decoder = new TextDecoder()
@@ -61,7 +59,7 @@ export function createHttpStreamableTransport(url: string, opts: TransportOption
       .finally(() => {
         abortController = null
         if (!signal.aborted) {
-          const maxMs = opts.retryMaxMs ?? DEFAULT_RETRY_MAX_MS
+          const maxMs = opts.retryMaxMs ?? TRANSPORT_RETRY_MAX_MS
           reconnectTimer = setTimeout(connect, Math.min(retryMs, maxMs))
           retryMs = Math.min(retryMs * 2, maxMs)
         }

--- a/dashboard/src/transports/sse-transport.ts
+++ b/dashboard/src/transports/sse-transport.ts
@@ -1,12 +1,10 @@
 import type { Transport, TransportEvent, TransportOptions } from './transport'
-
-const DEFAULT_RETRY_BASE_MS = 1000
-const DEFAULT_RETRY_MAX_MS = 30000
+import { TRANSPORT_RETRY_BASE_MS, TRANSPORT_RETRY_MAX_MS } from '../config/constants'
 
 export function createSseTransport(url: string, opts: TransportOptions = {}): Transport {
   let source: EventSource | null = null
   let listeners: Array<(event: TransportEvent) => void> = []
-  let retryMs = opts.retryBaseMs ?? DEFAULT_RETRY_BASE_MS
+  let retryMs = opts.retryBaseMs ?? TRANSPORT_RETRY_BASE_MS
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null
   let connected = false
 
@@ -20,7 +18,7 @@ export function createSseTransport(url: string, opts: TransportOptions = {}): Tr
       source = new EventSource(url)
       source.onopen = () => {
         connected = true
-        retryMs = opts.retryBaseMs ?? DEFAULT_RETRY_BASE_MS
+        retryMs = opts.retryBaseMs ?? TRANSPORT_RETRY_BASE_MS
         notify({ type: 'open' })
       }
       source.onmessage = (ev) => {
@@ -36,7 +34,7 @@ export function createSseTransport(url: string, opts: TransportOptions = {}): Tr
         notify({ type: 'error', error: new Error('SSE transport error') })
         source?.close()
         source = null
-        const maxMs = opts.retryMaxMs ?? DEFAULT_RETRY_MAX_MS
+        const maxMs = opts.retryMaxMs ?? TRANSPORT_RETRY_MAX_MS
         reconnectTimer = setTimeout(connect, Math.min(retryMs, maxMs))
         retryMs = Math.min(retryMs * 2, maxMs)
       }

--- a/dashboard/src/transports/websocket-transport.ts
+++ b/dashboard/src/transports/websocket-transport.ts
@@ -1,13 +1,12 @@
 import type { Transport, TransportEvent, TransportOptions } from './transport'
+import { TRANSPORT_RETRY_BASE_MS, TRANSPORT_RETRY_MAX_MS } from '../config/constants'
 
-const DEFAULT_RETRY_BASE_MS = 1000
-const DEFAULT_RETRY_MAX_MS = 30000
-const DEFAULT_HEARTBEAT_MS = 30000
+const DEFAULT_HEARTBEAT_MS = 30_000
 
 export function createWebSocketTransport(url: string, opts: TransportOptions = {}): Transport {
   let ws: WebSocket | null = null
   let listeners: Array<(event: TransportEvent) => void> = []
-  let retryMs = opts.retryBaseMs ?? DEFAULT_RETRY_BASE_MS
+  let retryMs = opts.retryBaseMs ?? TRANSPORT_RETRY_BASE_MS
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null
   let connected = false
@@ -22,7 +21,7 @@ export function createWebSocketTransport(url: string, opts: TransportOptions = {
       ws = new WebSocket(url)
       ws.onopen = () => {
         connected = true
-        retryMs = opts.retryBaseMs ?? DEFAULT_RETRY_BASE_MS
+        retryMs = opts.retryBaseMs ?? TRANSPORT_RETRY_BASE_MS
         notify({ type: 'open' })
         const heartbeat = opts.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_MS
         if (heartbeat > 0) {
@@ -53,7 +52,7 @@ export function createWebSocketTransport(url: string, opts: TransportOptions = {
         }
         ws = null
         notify({ type: 'close' })
-        const maxMs = opts.retryMaxMs ?? DEFAULT_RETRY_MAX_MS
+        const maxMs = opts.retryMaxMs ?? TRANSPORT_RETRY_MAX_MS
         reconnectTimer = setTimeout(connect, Math.min(retryMs, maxMs))
         retryMs = Math.min(retryMs * 2, maxMs)
       }

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1,5 +1,12 @@
 // MASC Dashboard — Core entity types (Agent, Task, Message, Board, Keeper)
 
+// --- Shared options ---
+
+export interface RefreshOptions {
+  force?: boolean
+  light?: boolean
+}
+
 // --- Core entities ---
 
 export interface Agent {

--- a/dashboard/src/workflow-context.ts
+++ b/dashboard/src/workflow-context.ts
@@ -1,17 +1,13 @@
 import { signal } from '@preact/signals'
 import type { OperatorRecommendedAction, RouteState } from './types'
-import { isRecord } from './components/common/normalize'
+import { isRecord, asNullableString, asRecord } from './components/common/normalize'
 import { isRootTarget } from './components/ops/helpers'
 
 const STORAGE_KEY = 'masc_dashboard_workflow_context'
 const CONTEXT_TTL_MS = 15 * 60 * 1000
 
-function asString(value: unknown): string | null {
-  return typeof value === 'string' && value.trim() !== '' ? value.trim() : null
-}
-
 function asDisplayString(value: unknown): string | null {
-  const text = asString(value)
+  const text = asNullableString(value)
   if (text) return text
   if (typeof value === 'number' && Number.isFinite(value)) return String(value)
   return null
@@ -44,33 +40,29 @@ export interface DashboardWorkflowContext {
   created_at: string
 }
 
-function normalizePayload(value: unknown): Record<string, unknown> | null {
-  return isRecord(value) ? value : null
-}
-
 function parseStoredContext(raw: string | null): DashboardWorkflowContext | null {
   if (!raw) return null
   try {
     const parsed = JSON.parse(raw) as unknown
     if (!isRecord(parsed)) return null
-    const id = asString(parsed.id)
-    const sourceSurface = asString(parsed.source_surface)
-    const sourceLabel = asString(parsed.source_label)
-    const summary = asString(parsed.summary)
-    const createdAt = asString(parsed.created_at)
+    const id = asNullableString(parsed.id)
+    const sourceSurface = asNullableString(parsed.source_surface)
+    const sourceLabel = asNullableString(parsed.source_label)
+    const summary = asNullableString(parsed.summary)
+    const createdAt = asNullableString(parsed.created_at)
     if (!id || (sourceSurface !== 'mission' && sourceSurface !== 'execution') || !sourceLabel || !summary || !createdAt) return null
     return {
       id,
       source_surface: sourceSurface,
       source_label: sourceLabel,
-      action_type: asString(parsed.action_type),
-      target_type: asString(parsed.target_type),
-      target_id: asString(parsed.target_id),
-      focus_kind: asString(parsed.focus_kind),
-      operation_id: asString(parsed.operation_id),
+      action_type: asNullableString(parsed.action_type),
+      target_type: asNullableString(parsed.target_type),
+      target_id: asNullableString(parsed.target_id),
+      focus_kind: asNullableString(parsed.focus_kind),
+      operation_id: asNullableString(parsed.operation_id),
       summary,
-      payload_preview: asString(parsed.payload_preview),
-      suggested_payload: normalizePayload(parsed.suggested_payload),
+      payload_preview: asNullableString(parsed.payload_preview),
+      suggested_payload: asRecord(parsed.suggested_payload),
       preview: parsed.preview ?? null,
       evidence: parsed.evidence ?? null,
       created_at: createdAt,
@@ -102,10 +94,10 @@ export function extractActionPayload(
   action?: OperatorRecommendedAction | null,
 ): Record<string, unknown> | null {
   if (!action) return null
-  const direct = normalizePayload(action.suggested_payload)
+  const direct = asRecord(action.suggested_payload)
   if (direct) return direct
   if (isRecord(action.preview)) {
-    const previewPayload = normalizePayload(action.preview.payload)
+    const previewPayload = asRecord(action.preview.payload)
     if (previewPayload) return previewPayload
   }
   return null


### PR DESCRIPTION
## Summary
- **api/core SSOT**: 4 components bypassed `api/core` with raw `fetch()` — converted to `get`/`post`/`del` helpers
- **Magic number extraction**: Added `SECONDS_PER_MINUTE`/`SECONDS_PER_HOUR`/`SECONDS_PER_DAY` to `format-time.ts` as SSOT; replaced `60`/`3600`/`86400` in 10 component files

### api/core dedup (commit 1)
- repo-sidebar.ts: `deleteRepository()` → `del()`
- credential-settings.ts: `deleteCredential()` → `del()`
- sidecar-log-viewer.ts: `fetchLogs()` → `get<T>()`
- connector-config-form.ts: 4 sites → `get<T>()` / `post()`

### SECONDS_PER_DAY extraction (commit 2)
- governance.ts, governance-utils.ts, cascade-config-panel.ts, verification-requests-panel.ts, task-stale-alert.ts, keeper-eval-quality.ts

### SECONDS_PER_MINUTE/HOUR (commit 3)
- keeper-detail-ctx-utils.ts, transport-health.ts, keeper-supervisor-diagnostics.ts

## Impact
- **-88 lines net**: Eliminated duplicated timeout/retry/auth-header logic + magic numbers
- Consistent error handling via `ApiRequestError` across all API calls
- Single source of truth for time-unit constants
- TypeScript type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)