### PR TITLE
feat(telemetry_eio): preserve exec_semantic in Tool_called success path

### DIFF
--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -54,6 +54,13 @@ type event =
          this field for every error path is tracked separately so this
          introduction PR keeps the record-shape change surgical. *)
       failure_class: Tool_result.tool_failure_class option [@default None];
+      (** Post-execution semantic classification preserved for BOTH
+         success and failure. Unlike error_* fields which are cleared
+         when [success = true], this field survives so downstream
+         consumers can reason over the execution outcome without
+         reconstructing it from [error_message] substrings.
+         Encoded as [Exec_semantic.to_kind] string for wire compat. *)
+      exec_semantic: string option [@default None];
     }
   | Tool_assigned of {
       agent_id: string;
@@ -448,8 +455,8 @@ let nonempty_error_kind_opt value =
   | None -> None
 
 let track_tool_called ?fs config ~tool_name ~success ~duration_ms ?agent_id
-    ?source ?session_id ?operation_id ?worker_run_id ?failure_class ?error_kind
-    ?error_message ?exit_code ?stderr_excerpt () =
+    ?source ?session_id ?operation_id ?worker_run_id ?failure_class ?exec_semantic
+    ?error_kind ?error_message ?exit_code ?stderr_excerpt () =
   let failure_class = if success then None else failure_class in
   let error_kind =
     if success then None else nonempty_error_kind_opt error_kind
@@ -459,6 +466,10 @@ let track_tool_called ?fs config ~tool_name ~success ~duration_ms ?agent_id
   let stderr_excerpt =
     if success then None else nonempty_opt stderr_excerpt
   in
+  (* NOTE: exec_semantic is preserved regardless of [success].
+     Unlike error_* fields which are cleared on success, the semantic
+     classification is meaningful for both success and failure paths
+     (e.g. `Ok, `Timeout, `Signaled all carry diagnostic value). *)
   track ?fs config
     (Tool_called
        {
@@ -475,6 +486,7 @@ let track_tool_called ?fs config ~tool_name ~success ~duration_ms ?agent_id
          exit_code;
          stderr_excerpt;
          failure_class;
+         exec_semantic;
        });
   if not success then
     match error_kind with

--- a/lib/telemetry_eio.mli
+++ b/lib/telemetry_eio.mli
@@ -60,6 +60,7 @@ type event =
       exit_code : int option; [@default None]
       stderr_excerpt : string option; [@default None]
       failure_class : Tool_result.tool_failure_class option; [@default None]
+      exec_semantic : string option; [@default None]
     }
   | Tool_assigned of {
       agent_id : string;
@@ -196,6 +197,7 @@ val track_tool_called :
   ?operation_id:string ->
   ?worker_run_id:string ->
   ?failure_class:Tool_result.tool_failure_class ->
+  ?exec_semantic:string ->
   ?error_kind:error_kind ->
   ?error_message:string ->
   ?exit_code:int ->


### PR DESCRIPTION
## Summary

Task: task-352 (P1)

### Problem
Tool_called telemetry event cleared exec_semantic classification on success paths, making it impossible for downstream consumers to reason about execution outcomes without reconstructing from error_message substrings.

### Solution
- Add `exec_semantic: string option` field to Tool_called record (default None)
- Add `?exec_semantic:string` parameter to `track_tool_called`
- Preserve exec_semantic regardless of success flag (unlike error_* fields which are cleared on success)
- Wire field through to track call

### Files Changed
- `lib/telemetry_eio.ml`: +14 lines (field definition, parameter, wiring, doc comments)
- `lib/telemetry_eio.mli`: +2 lines (type + function signature)

### Wire Compatibility
Optional field with `[@default None]` — no breaking change to existing consumers.