### PR TITLE
fix(keeper): warn on policy-handled OAS timeout cycles

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -665,6 +665,21 @@ let is_auto_recoverable_turn_error (err : Agent_sdk.Error.sdk_error) : bool =
   || is_resumable_cli_session_error err
   || is_auto_recoverable_cascade_exhausted_error err
 
+let should_warn_keeper_cycle_failed (err : Agent_sdk.Error.sdk_error) : bool =
+  match Keeper_turn_driver.classify_masc_internal_error err with
+  | Some (Keeper_turn_driver.Oas_timeout_budget _) -> true
+  | Some (Keeper_turn_driver.Cascade_exhausted _)
+  | Some (Keeper_turn_driver.Resumable_cli_session _)
+  | Some (Keeper_turn_driver.No_tool_capable_provider _)
+  | Some (Keeper_turn_driver.Accept_rejected _)
+  | Some (Keeper_turn_driver.Admission_queue_timeout _)
+  | Some (Keeper_turn_driver.Admission_queue_rejected _)
+  | Some (Keeper_turn_driver.Turn_timeout _)
+  | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
+  | Some (Keeper_turn_driver.Ambiguous_post_commit _)
+  | None ->
+    false
+
 let ambiguous_side_effect_error_prefix =
   "turn outcome ambiguous after committed mutating tool call(s)"
 

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -32,6 +32,12 @@ val message_looks_like_capacity_backpressure : string -> bool
     failure counting, even if same-turn retry is still disabled. *)
 val is_auto_recoverable_turn_error : Agent_sdk.Error.sdk_error -> bool
 
+(** [true] when the turn runner should record the immediate
+    ["keeper cycle FAILED"] line as WARN instead of ERROR because the
+    heartbeat policy layer will handle the failure as a provider/OAS budget
+    strike with cooldown or work-level pause. *)
+val should_warn_keeper_cycle_failed : Agent_sdk.Error.sdk_error -> bool
+
 (** Reclassify any post-commit turn error as a persistent integrity error when
     mutating tool calls already committed in the same turn. *)
 val reclassify_error_after_side_effect :

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1368,7 +1368,12 @@ let run_keeper_cycle
                     (Keeper_turn_fsm.Failed
                        (Keeper_turn_fsm.Failure_provider_error
                           { kind = sdk_error_kind err; detail = short_preview e_str }));
-                  Log.Keeper.error
+                  let log_keeper_cycle_failed =
+                    if EC.should_warn_keeper_cycle_failed err
+                    then Log.Keeper.warn
+                    else Log.Keeper.error
+                  in
+                  log_keeper_cycle_failed
                     "%s: keeper cycle FAILED cascade=%s max_context=%d context_budget=%d \
                      primary_budget=%d requested_override=%s latency=%dms%s error=%s"
                     meta.name
@@ -1386,6 +1391,8 @@ let run_keeper_cycle
                      then " (server parse rejection, auto-recoverable)"
                      else if is_transient
                      then " (transient, cooldown preserved)"
+                     else if EC.should_warn_keeper_cycle_failed err
+                     then " (oas_timeout_budget, policy handled)"
                      else "")
                     (short_preview e_str);
                   Prometheus.inc_counter

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -4,6 +4,7 @@ module KH = Keeper_heartbeat_loop
 module KFP = Keeper_failure_policy
 module KK = Keeper_keepalive
 module KTD = Keeper_turn_driver
+module EC = Keeper_error_classify
 
 let with_reset keeper f =
   KK.reset_budget_exhaustion ~keeper_name:keeper;
@@ -68,6 +69,20 @@ let oas_timeout_budget_error ~phase =
        ; min_required_sec = 15.0
        ; phase
        })
+
+let turn_timeout_error () =
+  KTD.sdk_error_of_masc_internal_error (KTD.Turn_timeout { elapsed_sec = 600.0 })
+
+let test_cycle_failed_log_level_is_policy_aware () =
+  Alcotest.(check bool)
+    "oas timeout budget cycle failure is warn"
+    true
+    (EC.should_warn_keeper_cycle_failed
+       (oas_timeout_budget_error ~phase:"cascade_attempt_watchdog"));
+  Alcotest.(check bool)
+    "turn wall-clock timeout remains error"
+    false
+    (EC.should_warn_keeper_cycle_failed (turn_timeout_error ()))
 
 let test_strike_limit_routes_through_policy_without_keeper_death () =
   let err = oas_timeout_budget_error ~phase:"stream_idle:streaming_thinking" in
@@ -146,6 +161,8 @@ let () =
         Alcotest.test_case "reset clears" `Quick test_reset_clears;
         Alcotest.test_case "strike limit soft-backoffs without crash" `Quick
           test_strike_limit_is_soft_backoff;
+        Alcotest.test_case "cycle failure log level is policy-aware" `Quick
+          test_cycle_failed_log_level_is_policy_aware;
         Alcotest.test_case "strike limit uses policy, not keeper death" `Quick
           test_strike_limit_routes_through_policy_without_keeper_death;
         Alcotest.test_case "capacity phase routes to provider tuning" `Quick


### PR DESCRIPTION
## Summary
- classify structured `oas_timeout_budget` turn failures as policy-handled cycle failures
- record the immediate `keeper cycle FAILED` line as WARN for that class, while keeping true turn wall-clock timeout and other failures at ERROR
- add regression coverage to keep OAS budget failures distinct from turn timeout failures

## Why
Recent stale-runtime log audit still shows provider/OAS timeout as one of the top WARN/ERROR buckets. The heartbeat layer already turns repeated `oas_timeout_budget` into soft-fail/provider-cooldown policy, but the turn runner emits a raw ERROR first. This PR removes that raw ERROR for policy-handled OAS budget exhaustion without hiding real runtime failures.

## Verification
- `ocamlformat --check lib/keeper/keeper_error_classify.ml lib/keeper/keeper_error_classify.mli lib/keeper/keeper_unified_turn.ml test/test_oas_timeout_budget_strike.ml`
- `git diff --check`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=/private/tmp/masc-oas-timeout-warn-build-20260520-0610 scripts/dune-local.sh build test/test_oas_timeout_budget_strike.exe`
- `/private/tmp/masc-oas-timeout-warn-build-20260520-0610/default/test/test_oas_timeout_budget_strike.exe` (9 tests)

## Notes
- Stacked on #16805 because current `origin/main` still has the known `Server_dashboard_shell_snapshot` build blocker.
- Remains draft/no `human-approved-ready` by policy.