### PR TITLE
fix(keeper): suppress repeated workflow rejection actions

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -83,12 +83,26 @@ let max_consecutive_failures = Env_config.KeeperToolExec.max_consecutive_tool_fa
 type failure_counts =
   { table : (string, int) Hashtbl.t
   ; workflow_table : (string, int) Hashtbl.t
+  ; workflow_block_table : (string, workflow_rejection_block) Hashtbl.t
   ; mutex : Mutex.t
   }
 
+and workflow_rejection_block =
+  { count : int
+  ; rule_id : string option
+  ; tool_suggestion : string option
+  ; hint : string option
+  }
+
 let create_failure_counts () =
-  { table = Hashtbl.create 16; workflow_table = Hashtbl.create 16; mutex = Mutex.create () }
+  { table = Hashtbl.create 16
+  ; workflow_table = Hashtbl.create 16
+  ; workflow_block_table = Hashtbl.create 16
+  ; mutex = Mutex.create ()
+  }
 ;;
+
+let reset_tool_retry_dedupe_for_testing = Keeper_tool_retry_state.reset_for_test
 
 let failure_count_get counts key =
   Mutex.protect counts.mutex (fun () ->
@@ -216,6 +230,29 @@ let workflow_rejection_count_reset counts =
   Mutex.protect counts.mutex (fun () -> Hashtbl.clear counts.workflow_table)
 ;;
 
+let workflow_rejection_scope_block_get counts key =
+  Mutex.protect counts.mutex (fun () ->
+    Hashtbl.find_opt counts.workflow_block_table key)
+;;
+
+let workflow_rejection_scope_block_record counts key info =
+  Mutex.protect counts.mutex (fun () ->
+    let previous_count =
+      match Hashtbl.find_opt counts.workflow_block_table key with
+      | Some block -> block.count
+      | None -> 0
+    in
+    let block =
+      { count = previous_count + 1
+      ; rule_id = info.rule_id
+      ; tool_suggestion = info.tool_suggestion
+      ; hint = info.hint
+      }
+    in
+    Hashtbl.replace counts.workflow_block_table key block;
+    block.count)
+;;
+
 let workflow_rejection_recovery_instruction ~tool_name ~count info =
   match info.tool_suggestion with
   | Some next_tool when count >= 2 ->
@@ -263,6 +300,105 @@ let workflow_rejection_recovery_fields ~tool_name ~count raw =
     ]
     @ optional_string "required_next_tool" info.tool_suggestion
     @ if count >= 2 then [ "workflow_rejection_loop", `Bool true ] else []
+;;
+
+let json_nonempty_string_opt key json =
+  match json_assoc_field_opt key json with
+  | Some (`String value) ->
+    let value = String.trim value in
+    if String.equal value "" then None else Some value
+  | _ -> None
+;;
+
+let json_has_nonempty_evidence_refs json =
+  let nonempty_string = function
+    | `String value -> not (String.equal (String.trim value) "")
+    | _ -> false
+  in
+  match json_assoc_field_opt "handoff_context" json with
+  | Some (`Assoc fields) ->
+    (match List.assoc_opt "evidence_refs" fields with
+     | Some (`List refs) -> List.exists nonempty_string refs
+     | _ -> false)
+  | _ -> false
+;;
+
+let workflow_submit_evidence_marker json =
+  if Option.is_some (json_nonempty_string_opt "pr_url" json)
+     || json_has_nonempty_evidence_refs json
+  then "has_evidence"
+  else "missing_evidence"
+;;
+
+let workflow_scope_key_of_input ~tool_name input =
+  let task_id_part json = json_nonempty_string_opt "task_id" json in
+  match input with
+  | `Assoc _ as json ->
+    (match tool_name with
+     | "masc_transition" ->
+       (match json_nonempty_string_opt "action" json, task_id_part json with
+        | None, _ | _, None -> None
+        | Some action, Some task_id ->
+          let correction_marker =
+            if String.equal action "submit_for_verification"
+            then ":" ^ workflow_submit_evidence_marker json
+            else ""
+          in
+          Some
+            (Printf.sprintf
+               "%s:action=%s:task=%s%s"
+               tool_name
+               action
+               task_id
+               correction_marker))
+     | "keeper_task_done"
+     | "keeper_task_submit_for_verification" ->
+       (match task_id_part json with
+        | None -> None
+        | Some task_id ->
+          let correction_marker =
+            if String.equal tool_name "keeper_task_submit_for_verification"
+            then ":" ^ workflow_submit_evidence_marker json
+            else ""
+          in
+          Some (Printf.sprintf "%s:task=%s%s" tool_name task_id correction_marker))
+     | "keeper_task_claim" -> Some "keeper_task_claim"
+     | _ -> None)
+  | _ -> None
+;;
+
+let workflow_rejection_scope_block_fields ~tool_name block =
+  let optional_string key = function
+    | Some value -> [ key, `String value ]
+    | None -> []
+  in
+  let recovery =
+    [ "count", `Int (block.count + 1)
+    ; "instruction"
+      , `String
+          (workflow_rejection_recovery_instruction
+             ~tool_name
+             ~count:(block.count + 1)
+             { rule_id = block.rule_id
+             ; tool_suggestion = block.tool_suggestion
+             ; hint = block.hint
+             })
+    ]
+    @ optional_string "rule_id" block.rule_id
+    @ optional_string "tool_suggestion" block.tool_suggestion
+    @ optional_string "hint" block.hint
+  in
+  [ "self_correction_required", `Bool true
+  ; "do_not_retry_tool", `String tool_name
+  ; "workflow_rejection_recovery", `Assoc recovery
+  ; "workflow_rejection_loop", `Bool true
+  ; "retry_skipped", `Bool true
+  ; "retry_skipped_reason", `String "deterministic_workflow_scope_blocked"
+  ; ( "retry_skipped_explanation"
+    , `String
+        "previous workflow_rejection for this task/action scope requires a different next step" )
+  ]
+  @ optional_string "required_next_tool" block.tool_suggestion
 ;;
 
 let recovery_plan_json_opt json =
@@ -604,7 +740,43 @@ let make_keeper_tool_handler
         let output_text = normalize_tool_result ~success:false msg in
         Tool_result.error ~tool_name:name ~start_time:t0 output_text)
       else (
-        let execute_with_observers () =
+        match
+          Option.bind
+            (workflow_scope_key_of_input ~tool_name:name input)
+            (workflow_rejection_scope_block_get failure_counts)
+        with
+        | Some block ->
+          Prometheus.inc_counter
+            Keeper_metrics.metric_keeper_tools_oas_failures
+            ~labels:[ "tool", name; "site", "workflow_scope_blocked" ]
+            ();
+          Log.Keeper.warn
+            "tool %s workflow rejection retry skipped for same task/action scope"
+            name;
+          let raw_result =
+            Yojson.Safe.to_string
+              (`Assoc
+                  [ "ok", `Bool false
+                  ; "error", `String "workflow_rejection_open_loop_blocked"
+                  ; "failure_class", `String "workflow_rejection"
+                  ; "recoverable", `Bool false
+                  ; "error_class", `String "deterministic"
+                  ])
+          in
+          let output_text =
+            normalize_tool_result
+              ~workflow_rejection_recovery_fields:
+                (workflow_rejection_scope_block_fields ~tool_name:name block)
+              ~success:false
+              raw_result
+          in
+          Tool_result.error
+            ~failure_class:(Some Tool_result.Workflow_rejection)
+            ~tool_name:name
+            ~start_time:t0
+            output_text
+        | None ->
+          let execute_with_observers () =
           let t0 = Time_compat.now () in
           try
           let result, duration_ms =
@@ -655,6 +827,14 @@ let make_keeper_tool_handler
                 | Some info ->
                   let family_key = workflow_rejection_family_key ~tool_name:name info in
                   let count = workflow_rejection_count_record failure_counts family_key in
+                  (match workflow_scope_key_of_input ~tool_name:name input with
+                   | Some scope_key ->
+                     ignore
+                       (workflow_rejection_scope_block_record
+                          failure_counts
+                          scope_key
+                          info)
+                   | None -> ());
                   workflow_rejection_recovery_fields ~tool_name:name ~count raw_result
                 | None -> [])
               else []

--- a/lib/keeper/keeper_tools_oas.mli
+++ b/lib/keeper/keeper_tools_oas.mli
@@ -47,6 +47,11 @@ type failure_counts
 
 val create_failure_counts : unit -> failure_counts
 
+(** Reset process-global retry-log dedupe state. Test-only entry point
+    for suites that assert the first occurrence of a tool failure emits
+    at ERROR. *)
+val reset_tool_retry_dedupe_for_testing : unit -> unit
+
 (** Normalize a raw tool result string into the canonical JSON
     envelope. Success → [{"ok":true,"result":...}]; failure →
     [{"ok":false,"error":...,"detail":...}], preserving structured

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -675,11 +675,12 @@ let test_error_result_logs_at_error_level () =
        ensure_read_repo_dir config meta;
        let tools = make_registered_tools ~config ~meta ~ctx_snapshot () in
        let tool = find_read_tool tools in
+       Keeper_tools_oas.reset_tool_retry_dedupe_for_testing ();
        let baseline = latest_log_seq () in
        (match
          Tool.execute
            tool
-            (read_args meta "missing-file-for-keeper-tools-oas.txt")
+            (read_args meta "log-level-only-missing-file-for-keeper-tools-oas.txt")
         with
         | Error _ -> ()
         | Ok _ -> fail "missing file should be surfaced as tool error");
@@ -1294,6 +1295,108 @@ let test_workflow_rejection_same_args_short_circuits_after_first_failure () =
        | Ok _ -> fail "same workflow rejection should be blocked before execution")
 ;;
 
+let test_workflow_rejection_scope_blocks_transition_variants () =
+  with_env "MASC_VERIFICATION_FSM_ENABLED" "true" (fun () ->
+    let meta =
+      make_test_meta
+        ~name:"test-keeper-workflow-scope"
+        ~allowed_paths:[ "*" ]
+        ()
+    in
+    let ctx_snapshot = make_test_ctx () in
+    let dir =
+      Filename.concat
+        (Filename.get_temp_dir_name ())
+        (Printf.sprintf "test_keeper_tools_workflow_scope_%d" (Random.int 100000))
+    in
+    let previous_dispatch = !(Keeper_exec_shared.tag_dispatch_fn) in
+    (try Unix.mkdir dir 0o755 with
+     | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+    Fun.protect
+      ~finally:(fun () ->
+        Keeper_exec_shared.tag_dispatch_fn := previous_dispatch;
+        rm_rf dir)
+      (fun () ->
+         Eio_main.run
+         @@ fun env ->
+         Fs_compat.set_fs (Eio.Stdenv.fs env);
+         Keeper_exec_shared.tag_dispatch_fn := Keeper_tag_dispatch.dispatch;
+         let config = Coord.default_config dir in
+         ignore (Coord.init config ~agent_name:(Some meta.agent_name));
+         ignore
+           (Coord.add_task
+              config
+              ~title:"Needs verification evidence"
+              ~priority:1
+              ~description:"");
+         ignore (Coord.claim_task config ~agent_name:meta.agent_name ~task_id:"task-001");
+         let tools = make_registered_tools ~config ~meta ~ctx_snapshot () in
+         let transition = find_tool "masc_transition" tools in
+         let first_args =
+           `Assoc
+             [ "agent_name", `String meta.agent_name
+             ; "task_id", `String "task-001"
+             ; "action", `String "submit_for_verification"
+             ; "notes", `String "Implementation complete."
+             ]
+         in
+         (match Tool.execute transition first_args with
+          | Error { Agent_sdk.Types.message; _ } ->
+            let json = parse message in
+            check
+              string
+              "first rejection class"
+              "workflow_rejection"
+              (json_string "failure_class" json);
+            check
+              bool
+              "first rejection is not scope blocker"
+              false
+              (String.equal "workflow_rejection_open_loop_blocked" (json_string "error" json));
+            check
+              bool
+              "first rejection asks self correction"
+              true
+              (json_bool "self_correction_required" json)
+          | Ok _ -> fail "missing verification evidence should reject");
+         let variant_args =
+           `Assoc
+             [ "agent_name", `String meta.agent_name
+             ; "task_id", `String "task-001"
+             ; "action", `String "submit_for_verification"
+             ; "notes", `String "Still complete, no PR evidence."
+             ]
+         in
+         (match Tool.execute transition variant_args with
+          | Error { Agent_sdk.Types.message; _ } ->
+            let json = parse message in
+            check
+              string
+              "variant blocked by workflow scope"
+              "workflow_rejection_open_loop_blocked"
+              (json_string "error" json);
+            check bool "scope loop marked" true (json_bool "workflow_rejection_loop" json);
+            check
+              string
+              "scope retry skipped reason"
+              "deterministic_workflow_scope_blocked"
+              (json_string "retry_skipped_reason" json)
+          | Ok _ -> fail "same task/action missing-evidence variant should be blocked");
+         let corrected_args =
+           `Assoc
+             [ "agent_name", `String meta.agent_name
+             ; "task_id", `String "task-001"
+             ; "action", `String "submit_for_verification"
+             ; "notes", `String "Implementation complete with PR evidence."
+             ; "pr_url", `String "https://github.com/jeong-sik/masc-mcp/pull/12345"
+             ]
+         in
+         match Tool.execute transition corrected_args with
+         | Ok _ -> ()
+         | Error { Agent_sdk.Types.message; _ } ->
+           fail ("corrected evidence-bearing call should not be scope-blocked: " ^ message)))
+;;
+
 let test_normalize_failure_plain_text () =
   let raw = "tool keeper_bash failed (3/5): Unix_error(ENOENT)" in
   let normalized = Keeper_tools_oas.normalize_tool_result ~success:false raw in
@@ -1576,6 +1679,10 @@ let () =
             "workflow rejection same args stops after first failure"
             `Quick
             test_workflow_rejection_same_args_short_circuits_after_first_failure
+        ; test_case
+            "workflow rejection task/action variants stop after first failure"
+            `Quick
+            test_workflow_rejection_scope_blocks_transition_variants
         ; test_case
             "failure plain text wraps as error"
             `Quick


### PR DESCRIPTION
## Summary

- add keeper-local workflow rejection scope memory for OAS tool execution
- block repeated workflow actions for the same task/action scope after a deterministic workflow rejection
- keep corrected submit-for-verification calls with real evidence unblocked
- reset retry-log dedupe state in the keeper tools test where the test asserts first-error log level

## Root Cause

The existing deterministic guard only short-circuited exact tool and argument repeats. Keepers could still vary notes or adjacent arguments and re-hit the same deterministic workflow rejection, such as missing verification evidence or blocked task/action transitions.

## Validation

- ocamlformat --check lib/keeper/keeper_tools_oas.ml lib/keeper/keeper_tools_oas.mli test/test_keeper_tools_oas.ml
- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_JOBS=1 scripts/dune-local.sh build test/test_keeper_tools_oas.exe
- ./_build/default/test/test_keeper_tools_oas.exe test normalize_tool_result 9-10 --color=never --show-errors
- ./_build/default/test/test_keeper_tools_oas.exe --color=never --show-errors
