### PR TITLE
refactor(dashboard): exhaustive `tone` switch + assertExhaustive helper in turn-budget-gauge

### DIFF
--- a/dashboard/src/components/turn-budget-gauge.ts
+++ b/dashboard/src/components/turn-budget-gauge.ts
@@ -50,23 +50,32 @@ export function deriveBudgetGaugeState(keeper: Keeper): BudgetGaugeState | null 
   return { used, max, ratio, tone, remaining }
 }
 
+// Exhaustive-by-design assertion. If [BudgetGaugeState['tone']] gains a
+// new variant, tsc fails here with "Type 'X' is not assignable to type
+// 'never'" instead of silently routing the new tone through the prior
+// `case 'ok': default:` collapse. TypeScript-side mirror of the OCaml
+// anti-pattern-#4 fix in PR #16747 (FSM exhaustive match).
+function assertExhaustive(value: never, context: string): never {
+  throw new Error(`assertExhaustive: unexpected ${context} value: ${String(value)}`)
+}
+
 // Tone-to-CSS helper
 function toneColor(tone: BudgetGaugeState['tone']): string {
   switch (tone) {
     case 'bad':  return 'var(--bad-light)'
     case 'warn': return 'var(--color-status-warn)'
-    case 'ok':
-    default:     return 'var(--color-status-ok)'
+    case 'ok':   return 'var(--color-status-ok)'
   }
+  return assertExhaustive(tone, 'BudgetGaugeState.tone')
 }
 
 function toneLabel(tone: BudgetGaugeState['tone']): string {
   switch (tone) {
     case 'bad':  return '예산 초과 위험'
     case 'warn': return '예산 경고'
-    case 'ok':
-    default:     return '예산 양호'
+    case 'ok':   return '예산 양호'
   }
+  return assertExhaustive(tone, 'BudgetGaugeState.tone')
 }
 
 // ── Per-keeper row ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`toneColor` and `toneLabel` in `dashboard/src/components/turn-budget-gauge.ts` both used `case 'ok': default:` collapse:

```ts
function toneColor(tone: BudgetGaugeState['tone']): string {
  switch (tone) {
    case 'bad':  return 'var(--bad-light)'
    case 'warn': return 'var(--color-status-warn)'
    case 'ok':
    default:     return 'var(--color-status-ok)'
  }
}
```

With `tone: 'ok' | 'warn' | 'bad'` as a closed 3-tag union, a future variant (e.g. `'pending'`) would **silently** route through the `'ok'` default — wrong value, no compile error.

This is the TypeScript-side equivalent of the OCaml FSM Sparse Match anti-pattern (`software-development.md` §4), already closed for `can_transition` and `apply_event` in PRs #16747 / #16759.

## Fix

Introduced an `assertExhaustive` helper at module scope:

```ts
function assertExhaustive(value: never, context: string): never {
  throw new Error(`assertExhaustive: unexpected ${context} value: ${String(value)}`)
}
```

Both switches now have explicit `case 'ok'` arms and end with:

```ts
return assertExhaustive(tone, 'BudgetGaugeState.tone')
```

If `BudgetGaugeState['tone']` gains a new variant, tsc fails with **"Argument of type 'X' is not assignable to parameter of type 'never'"** at *both* sites.

## Compile-time canary verified

Transiently added `'pending'` to the tone union. `pnpm tsc --noEmit` produced:

```
src/components/turn-budget-gauge.ts(69,27): error TS2345:
  Argument of type '"pending"' is not assignable to parameter of type 'never'.
src/components/turn-budget-gauge.ts(78,27): error TS2345:
  Argument of type '"pending"' is not assignable to parameter of type 'never'.
```

Both sites surface the error simultaneously — defense in depth.

## Verification

- `pnpm tsc --noEmit` EXIT=0 (with current 3-tag union).
- `pnpm vitest run turn-budget-gauge`: **9/9 PASS** (existing behavior preserved — `'ok'` still returns the same color/label values).
- +13/-6 LoC, single file.
- 0 caller surface change.

## Iter#70 context

First TypeScript-side application of the anti-pattern-#4 sweep:

| PR | Site | Language |
|---|---|---|
| #16747 | `can_transition` (10 sites) | OCaml |
| #16759 | `apply_event` `current_phase` | OCaml |
| **this PR** | `turn-budget-gauge` tone (2 sites) | **TypeScript** |

A 4th appearance of the `assertExhaustive` pattern would warrant extracting it to a shared dashboard utility (`src/lib/exhaustive.ts` or similar) — not needed yet at 1 site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>