### PR TITLE
fix(keeper): operator-actionable 'invalid keeper name' errors + drop 6 no-op string concats

### DIFF
--- a/lib/keeper/keeper_exec_persona.ml
+++ b/lib/keeper/keeper_exec_persona.ml
@@ -99,7 +99,13 @@ let validate_resolved_keeper_create_json (json : Yojson.Safe.t) : string list =
     Safe_ops.json_bool ~default:false "policy_voice_enabled" json
   in
   let mention_targets = Safe_ops.json_string_list "mention_targets" json in
-  if not (validate_name name) then errors := "invalid keeper name" :: !errors;
+  if not (validate_name name) then
+    errors :=
+      Printf.sprintf
+        "invalid keeper name %S (must be non-empty and match \
+         [A-Za-z0-9._-]+; see Keeper_config.validate_name)"
+        name
+      :: !errors;
   if goal = "" then errors := "goal is required" :: !errors;
   if mention_targets = [] then
     errors := "mention_targets is required" :: !errors;

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -272,7 +272,11 @@ let handle_keeper_list ctx args : tool_result =
 let handle_keeper_trajectory ctx args : tool_result =
   let requested_name = String.trim (get_string args "name" "") in
   if not (validate_name requested_name) then
-    (false, "invalid keeper name")
+    ( false,
+      Printf.sprintf
+        "invalid keeper name %S (must be non-empty and match \
+         [A-Za-z0-9._-]+; see Keeper_config.validate_name)"
+        requested_name )
   else
     match read_meta_resolved ctx.config requested_name with
     | Error e -> (false, "read error: " ^ e)
@@ -308,7 +312,11 @@ let handle_keeper_trajectory ctx args : tool_result =
 let handle_keeper_eval ctx args : tool_result =
   let requested_name = String.trim (get_string args "name" "") in
   if not (validate_name requested_name) then
-    (false, "invalid keeper name")
+    ( false,
+      Printf.sprintf
+        "invalid keeper name %S (must be non-empty and match \
+         [A-Za-z0-9._-]+; see Keeper_config.validate_name)"
+        requested_name )
   else
     match read_meta_resolved ctx.config requested_name with
     | Error e -> (false, "read error: " ^ e)

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -96,10 +96,14 @@ let apply_tail_order order items =
 let resolve_status_target (ctx : _ context) args =
   let requested_name = effective_status_name ctx args in
   if not (validate_name requested_name) then
-    Error "invalid keeper name"
+    Error
+      (Printf.sprintf
+         "invalid keeper name %S (must be non-empty and match \
+          [A-Za-z0-9._-]+; see Keeper_config.validate_name)"
+         requested_name)
   else
     match read_meta_resolved ctx.config requested_name with
-    | Error e -> Error ("" ^ e)
+    | Error e -> Error e
     | Ok (Some (resolved_name, meta)) -> Ok (resolved_name, meta)
     | Ok None ->
         (match keeper_name_from_agent_name requested_name with

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -133,7 +133,11 @@ let preflight_keeper_msg ctx args : (unit, string) result =
   let name = get_string args "name" "" in
   let message = get_string args "message" "" in
   if not (validate_name name) then
-    Error "invalid keeper name"
+    Error
+      (Printf.sprintf
+         "invalid keeper name %S (must be non-empty and match \
+          [A-Za-z0-9._-]+; see Keeper_config.validate_name)"
+         name)
   else if message = "" then
     Error "message is required"
   else
@@ -142,16 +146,16 @@ let preflight_keeper_msg ctx args : (unit, string) result =
     | Error e -> Error e
     | Ok _ ->
     (match reject_legacy_model_args ~tool_name:"masc_keeper_msg" args with
-    | Error e -> Error ("" ^ e)
+    | Error e -> Error e
     | Ok () ->
     (match reject_removed_keeper_input_keys ~tool_name:"masc_keeper_msg" args with
-    | Error e -> Error ("" ^ e)
+    | Error e -> Error e
     | Ok () ->
     (match reject_removed_keeper_msg_input_keys ~tool_name:"masc_keeper_msg" args with
-    | Error e -> Error ("" ^ e)
+    | Error e -> Error e
     | Ok () ->
     match ensure_keeper_exists ~ctx ~name with
-    | Error e -> Error ("" ^ e)
+    | Error e -> Error e
     | Ok meta ->
       match resolve_turn_cascade_name meta with
       | Error e -> Error e
@@ -170,7 +174,7 @@ let preflight_keeper_msg ctx args : (unit, string) result =
             effective_model_labels_for_turn meta
         in
         match ensure_api_keys_for_labels effective_models with
-        | Error e -> Error ("" ^ e)
+        | Error e -> Error e
         | Ok () ->
           Keeper_turn_helpers.ensure_local_discovery_ready effective_models))))
 
@@ -187,7 +191,11 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
   let name = get_string args "name" "" in
   let message = get_string args "message" "" in
   if not (validate_name name) then
-    (false, "invalid keeper name")
+    ( false,
+      Printf.sprintf
+        "invalid keeper name %S (must be non-empty and match \
+         [A-Za-z0-9._-]+; see Keeper_config.validate_name)"
+        name )
   else if message = "" then
     (false, "message is required")
   else

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -11,7 +11,11 @@ type tool_result = Keeper_types.tool_result
 let handle_keeper_down ctx args : tool_result =
   let requested_name = String.trim (get_string args "name" "") in
   if not (validate_name requested_name) then
-    (false, "invalid keeper name")
+    ( false,
+      Printf.sprintf
+        "invalid keeper name %S (must be non-empty and match \
+         [A-Za-z0-9._-]+; see Keeper_config.validate_name)"
+        requested_name )
   else
     let remove_meta = get_bool args "remove_meta" false in
     let remove_session = get_bool args "remove_session" false in


### PR DESCRIPTION
## 사용자 비전 직접 정합

> *\"Error 가 나는 케이스에 대해 사용자가 정말 구체적으로 알도록 개선하라\"*
> *(recurring /loop directive)*

이번 PR 의 1차 동기는 *operator clarity* — keeper tool 이 reject 했을 때 operator 가 무엇을 어떻게 고쳐야 할지를 즉시 알 수 있도록.

## 변경 (5 files, +43/-13)

### (A) 'invalid keeper name' 6 사이트 — *name 값* + *validation rule* 포함

Before:
\`\`\`ocaml
if not (validate_name name) then Error \"invalid keeper name\"
\`\`\`

After (모든 6 사이트 동일 형식):
\`\`\`ocaml
if not (validate_name name) then
  Error (Printf.sprintf
    \"invalid keeper name %S (must be non-empty and match \
     [A-Za-z0-9._-]+; see Keeper_config.validate_name)\"
    name)
\`\`\`

이제 operator 는 즉시:
- 자신이 *실제로 보낸* name (%S 인용 → empty/whitespace/unicode 가시화)
- 정확한 regex contract
- validator 위치 (self-serve 가능)

**Consistency rationale**: codebase 의 *나머지 5 invalid-keeper-name 사이트*는 이미 name 을 포함했음:
- \`server_dashboard_http_keeper_api.ml\` 4 사이트
- \`keeper_types_profile.ml\` 2 사이트
- \`tool_keeper_persona_audit.ml\` 1 사이트 (list form)

본 PR 은 keeper-tool 6 사이트를 이 기존 패턴에 정렬.

### (B) \`Error (\"\" ^ e)\` 6 사이트 — no-op concat 제거

\`\"\" ^ e\` = \`e\`. 6 사이트 모두 mechanical noise. 추측: 리팩토링에서 prefix string 제거됐지만 \`^\` 연산자가 남음. 코드 reader 에게 *\"이 branch 가 context 를 추가한다\"* 는 잘못된 신호.

### Site 분포

| File | (A) | (B) |
|---|---|---|
| keeper_turn.ml | 1 | 5 |
| keeper_status_detail.ml | 1 | 1 |
| keeper_status.ml | 2 | - |
| keeper_turn_lifecycle.ml | 1 | - |
| keeper_exec_persona.ml | 1 | - |
| **Total** | **6** | **6** |

## Workaround Rejection Bar self-check

7-item checklist:
1. ❌ \"makes X visible\" 만 — N/A (실제 fix)
2. ❌ string classifier 추가 — N/A
3. ❌ N-of-M 자인 — N/A (5+6 = 11/11 invalid-name 사이트 *전체* 일관성 회복)
4. ❌ catch-all 추가 — N/A
5. ❌ symptom 억제 — N/A (root: bare error context 부재)
6. ❌ test backdoor — N/A
7. ❌ 같은 typo N번 fix — N/A (mechanical sweep, not a typo)

## 검증

- \`dune build --root . @check\` EXIT=0 clean
- \`test/test_keeper_unified.exe\` 302/305 PASS
- 3 failures (transient_network_error #62, phase_gate #4, #6) 는 **origin/main HEAD 에서도 동일하게 재현** (verified via \`git stash\` round-trip) → 본 PR 무관, pre-existing.
- 테스트 lock 확인: \`rg '\"invalid keeper name\"' test/\` EXIT=1 (0 sites) — 메시지 변경에 의한 회귀 없음.

## Pattern continuation

같은 사용자-clarity-vision 영역의 직전 머지:
- PR #16787 (\`keeper_cascade_profile\` WARN-once on raw cascade name silent fallback, 2026-05-19 머지)

이번 PR 은 그 후속 — *cascade* 식별자 clarity 다음이 *keeper name* 식별자 clarity.

## Co-Authored-By

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>