### PR TITLE
fix(grpc): include protobuf type name in decode error messages (15 sites)

### DIFF
--- a/lib/grpc/masc_grpc_types.ml
+++ b/lib/grpc/masc_grpc_types.ml
@@ -15,22 +15,29 @@ module P = Masc_proto.Masc_coordination.Masc.Coordination.V1
 (** Serialize a protobuf message to a binary string. *)
 let encode to_proto msg = Ocaml_protoc_plugin.Writer.contents (to_proto msg)
 
-(** Deserialize a protobuf message from a binary string. *)
-let decode_result from_proto bytes =
+(** Deserialize a protobuf message from a binary string.
+
+    [type_name] identifies the protobuf message type being decoded
+    (e.g. "JoinRequest", "ToolCallResponse"). It is embedded in the
+    error message so operators see which message type failed instead
+    of a context-free "protobuf decode error: ..." line. *)
+let decode_result ~type_name from_proto bytes =
   let reader = Ocaml_protoc_plugin.Reader.create bytes in
   match from_proto reader with
   | Ok v -> Ok v
   | Error e ->
     Error
       (Printf.sprintf
-         "protobuf decode error: %s"
+         "protobuf decode error: %s: %s"
+         type_name
          (Ocaml_protoc_plugin.Result.show_error e))
 ;;
 
 (** Deserialize a protobuf message from a binary string.
-    Raises [Invalid_argument] on parse error. *)
-let decode from_proto bytes =
-  match decode_result from_proto bytes with
+    Raises [Invalid_argument] on parse error. The exception payload
+    includes [type_name] so the bare backtrace is operator-actionable. *)
+let decode ~type_name from_proto bytes =
+  match decode_result ~type_name from_proto bytes with
   | Ok v -> v
   | Error msg -> invalid_arg msg
 ;;
@@ -104,7 +111,7 @@ module JoinRequest = struct
     }
 
   let of_bytes_result bytes =
-    match decode_result P.JoinRequest.from_proto bytes with
+    match decode_result ~type_name:"JoinRequest" P.JoinRequest.from_proto bytes with
     | Ok p ->
       Ok
         ({ agent_name = p.agent_name
@@ -137,7 +144,7 @@ module JoinResponse = struct
     }
 
   let of_bytes bytes =
-    let p = decode P.JoinResponse.from_proto bytes in
+    let p = decode ~type_name:"JoinResponse" P.JoinResponse.from_proto bytes in
     { success = p.success
     ; message = p.message
     ; session_id = p.session_id
@@ -163,7 +170,7 @@ module LeaveRequest = struct
     }
 
   let of_bytes_result bytes =
-    match decode_result P.LeaveRequest.from_proto bytes with
+    match decode_result ~type_name:"LeaveRequest" P.LeaveRequest.from_proto bytes with
     | Ok p -> Ok ({ agent_name = p.agent_name; session_id = p.session_id } : t)
     | Error _ as err -> err
   ;;
@@ -188,7 +195,7 @@ module LeaveResponse = struct
     }
 
   let of_bytes bytes =
-    let p = decode P.LeaveResponse.from_proto bytes in
+    let p = decode ~type_name:"LeaveResponse" P.LeaveResponse.from_proto bytes in
     { success = p.success; message = p.message }
   ;;
 
@@ -208,7 +215,7 @@ module HeartbeatPing = struct
     }
 
   let of_bytes_result bytes =
-    match decode_result P.HeartbeatPing.from_proto bytes with
+    match decode_result ~type_name:"HeartbeatPing" P.HeartbeatPing.from_proto bytes with
     | Ok p ->
       Ok
         ({ agent_name = p.agent_name
@@ -246,7 +253,7 @@ module HeartbeatAck = struct
     }
 
   let of_bytes bytes =
-    let p = decode P.HeartbeatAck.from_proto bytes in
+    let p = decode ~type_name:"HeartbeatAck" P.HeartbeatAck.from_proto bytes in
     { timestamp_ms = p.timestamp_ms
     ; active_agent_count = p.active_agent_count
     ; pending_task_count = p.pending_task_count
@@ -276,7 +283,7 @@ module SubscribeRequest = struct
     }
 
   let of_bytes_result bytes =
-    match decode_result P.SubscribeRequest.from_proto bytes with
+    match decode_result ~type_name:"SubscribeRequest" P.SubscribeRequest.from_proto bytes with
     | Ok p ->
       Ok
         ({ agent_name = p.agent_name
@@ -317,7 +324,7 @@ module Event = struct
     }
 
   let of_bytes bytes =
-    let p = decode P.Event.from_proto bytes in
+    let p = decode ~type_name:"Event" P.Event.from_proto bytes in
     { seq = p.seq
     ; event_type = p.event_type
     ; source_agent = p.source_agent
@@ -349,7 +356,7 @@ module ToolCallRequest = struct
     }
 
   let of_bytes_result bytes =
-    match decode_result P.ToolCallRequest.from_proto bytes with
+    match decode_result ~type_name:"ToolCallRequest" P.ToolCallRequest.from_proto bytes with
     | Ok p ->
       Ok
         ({ agent_name = p.agent_name
@@ -387,7 +394,7 @@ module ToolCallResponse = struct
     }
 
   let of_bytes bytes =
-    let p = decode P.ToolCallResponse.from_proto bytes in
+    let p = decode ~type_name:"ToolCallResponse" P.ToolCallResponse.from_proto bytes in
     { success = p.success
     ; result_json = p.result_json
     ; error_message = p.error_message
@@ -416,7 +423,7 @@ module BroadcastRequest = struct
     }
 
   let of_bytes_result bytes =
-    match decode_result P.BroadcastRequest.from_proto bytes with
+    match decode_result ~type_name:"BroadcastRequest" P.BroadcastRequest.from_proto bytes with
     | Ok p ->
       Ok ({ agent_name = p.agent_name; message = p.message; mentions = p.mentions } : t)
     | Error _ as err -> err
@@ -442,7 +449,7 @@ module BroadcastResponse = struct
     }
 
   let of_bytes bytes =
-    let p = decode P.BroadcastResponse.from_proto bytes in
+    let p = decode ~type_name:"BroadcastResponse" P.BroadcastResponse.from_proto bytes in
     { success = p.success; seq = p.seq }
   ;;
 
@@ -462,7 +469,7 @@ module StatusResponse = struct
     }
 
   let of_bytes bytes =
-    let p = decode P.StatusResponse.from_proto bytes in
+    let p = decode ~type_name:"StatusResponse" P.StatusResponse.from_proto bytes in
     { agents = List.map agent_info_of_proto p.agents
     ; tasks = List.map task_info_of_proto p.tasks
     ; message_count = p.message_count
@@ -491,7 +498,7 @@ module LspRequest = struct
     }
 
   let of_bytes_result bytes =
-    match decode_result P.LspRequest.from_proto bytes with
+    match decode_result ~type_name:"LspRequest" P.LspRequest.from_proto bytes with
     | Ok p ->
       Ok
         ({ language_id = p.language_id
@@ -528,7 +535,7 @@ module LspResponse = struct
     }
 
   let of_bytes_result bytes =
-    match decode_result P.LspResponse.from_proto bytes with
+    match decode_result ~type_name:"LspResponse" P.LspResponse.from_proto bytes with
     | Ok p ->
       Ok
         ({ jsonrpc_response_json = p.jsonrpc_response_json

--- a/test/test_grpc_coordination.ml
+++ b/test/test_grpc_coordination.ml
@@ -417,14 +417,25 @@ let test_protobuf_binary_format () =
   Alcotest.(check bool) "not JSON" true (String.length bytes = 0 || bytes.[0] <> '{')
 ;;
 
+(* These tests verify two things:
+   1. The error message starts with "protobuf decode error:" so log
+      aggregators that bucket on this prefix keep working.
+   2. The message embeds the *specific protobuf type name* that failed
+      to decode, so operators can identify the wire boundary without
+      reading the stack trace. The type_name parameter on
+      [Masc_grpc_types.decode_result] makes this an enforced contract. *)
 let test_join_request_invalid_bytes_result () =
   match T.JoinRequest.of_bytes_result malformed_protobuf with
   | Ok _ -> Alcotest.fail "expected decode failure"
   | Error msg ->
     Alcotest.(check bool)
-      "error mentions decode"
+      "error keeps 'protobuf decode error:' prefix"
       true
-      (String.starts_with ~prefix:"protobuf decode error:" msg)
+      (String.starts_with ~prefix:"protobuf decode error:" msg);
+    Alcotest.(check bool)
+      "error names the failing protobuf type (JoinRequest)"
+      true
+      (String_util.contains_substring msg"JoinRequest")
 ;;
 
 let test_tool_call_request_invalid_bytes_result () =
@@ -432,9 +443,13 @@ let test_tool_call_request_invalid_bytes_result () =
   | Ok _ -> Alcotest.fail "expected decode failure"
   | Error msg ->
     Alcotest.(check bool)
-      "error mentions decode"
+      "error keeps 'protobuf decode error:' prefix"
       true
-      (String.starts_with ~prefix:"protobuf decode error:" msg)
+      (String.starts_with ~prefix:"protobuf decode error:" msg);
+    Alcotest.(check bool)
+      "error names the failing protobuf type (ToolCallRequest)"
+      true
+      (String_util.contains_substring msg"ToolCallRequest")
 ;;
 
 let test_lsp_request_invalid_bytes_result () =
@@ -442,9 +457,13 @@ let test_lsp_request_invalid_bytes_result () =
   | Ok _ -> Alcotest.fail "expected decode failure"
   | Error msg ->
     Alcotest.(check bool)
-      "error mentions decode"
+      "error keeps 'protobuf decode error:' prefix"
       true
-      (String.starts_with ~prefix:"protobuf decode error:" msg)
+      (String.starts_with ~prefix:"protobuf decode error:" msg);
+    Alcotest.(check bool)
+      "error names the failing protobuf type (LspRequest)"
+      true
+      (String_util.contains_substring msg"LspRequest")
 ;;
 
 let test_lsp_response_invalid_bytes_result () =
@@ -452,9 +471,13 @@ let test_lsp_response_invalid_bytes_result () =
   | Ok _ -> Alcotest.fail "expected decode failure"
   | Error msg ->
     Alcotest.(check bool)
-      "error mentions decode"
+      "error keeps 'protobuf decode error:' prefix"
       true
-      (String.starts_with ~prefix:"protobuf decode error:" msg)
+      (String.starts_with ~prefix:"protobuf decode error:" msg);
+    Alcotest.(check bool)
+      "error names the failing protobuf type (LspResponse)"
+      true
+      (String_util.contains_substring msg"LspResponse")
 ;;
 
 let test_join_handler_invalid_bytes_raise_grpc_status () =


### PR DESCRIPTION
## 사용자 비전 직접 정합

> *\"Error 가 나는 케이스에 대해 사용자가 정말 구체적으로 알도록 개선하라\"*
> *(recurring /loop directive)*

본 PR 의 1차 동기는 *operator clarity* — gRPC wire boundary 에서 decode 실패가 났을 때 *어떤 message type* 이 실패했는지 즉시 알 수 있도록.

## Before

\`\`\`
protobuf decode error: <raw protobuf error>
\`\`\`

→ operator 는 backtrace 를 읽고 caller 모듈을 찾아 *추측* 해야 함. JoinRequest? ToolCallRequest? LspResponse? 모두 같은 메시지로 surface.

## After

\`\`\`
protobuf decode error: <TypeName>: <raw protobuf error>
\`\`\`

예시:
\`\`\`
protobuf decode error: JoinRequest: Wrong field type: expected int64, got string
protobuf decode error: ToolCallResponse: Premature end of buffer at offset 248
protobuf decode error: LspResponse: Unknown field tag 17
\`\`\`

이제 operator 는 즉시:
- 어떤 message type 의 wire 가 broken 인지 (JoinRequest? Response?)
- 어떤 client/server 가 mismatched proto schema 를 갖고 있는지 빠른 triage 가능
- log aggregator/dashboard 에서 type 별 분류 가능

## 구현

### Helper 변경 — \`~type_name\` 라벨

\`\`\`ocaml
let decode_result ~type_name from_proto bytes =
  let reader = Ocaml_protoc_plugin.Reader.create bytes in
  match from_proto reader with
  | Ok v -> Ok v
  | Error e ->
    Error
      (Printf.sprintf
         \"protobuf decode error: %s: %s\"
         type_name
         (Ocaml_protoc_plugin.Result.show_error e))
;;

let decode ~type_name from_proto bytes =
  match decode_result ~type_name from_proto bytes with
  | Ok v -> v
  | Error msg -> invalid_arg msg
;;
\`\`\`

\`~type_name\` 은 *labeled* 이므로 향후 새 message type 의 decode 추가 시 *컴파일러가 강제* — operator clarity 가 컴파일타임 contract 로 보장됨.

### 15 사이트 mechanical sweep (perl)

\`\`\`bash
perl -i -pe '
  s/decode_result P\.(\w+)\.from_proto bytes/decode_result ~type_name:\"\$1\" P.\$1.from_proto bytes/g;
  s/decode P\.(\w+)\.from_proto bytes/decode ~type_name:\"\$1\" P.\$1.from_proto bytes/g
' lib/grpc/masc_grpc_types.ml
\`\`\`

각 call site 는 type name 이 *양 위치* 에 있으므로 substitution 이 결정론적이고 검증 가능:

| Module | Site count |
|---|---|
| JoinRequest/Response | 2 |
| LeaveRequest/Response | 2 |
| HeartbeatPing/Ack | 2 |
| SubscribeRequest + Event | 2 |
| ToolCallRequest/Response | 2 |
| BroadcastRequest/Response | 2 |
| StatusResponse | 1 |
| LspRequest/Response | 2 |
| **Total** | **15** |

### 백워드 호환성 — prefix 보존

기존 로그 aggregator 가 \`\"protobuf decode error:\"\` prefix 로 버킷팅하므로 그 정확한 prefix 를 유지. \`[TypeName: ]\` 는 *그 prefix 뒤에* 삽입. 기존 4 invalid-bytes 테스트 (\`String.starts_with ~prefix:\"protobuf decode error:\"\`) 가 *변경 없이* 통과.

### 테스트 강화 — 새 contract lock

같은 4 테스트에 type name presence 검증 추가:

\`\`\`ocaml
Alcotest.(check bool)
  \"error keeps 'protobuf decode error:' prefix\"
  true
  (String.starts_with ~prefix:\"protobuf decode error:\" msg);
Alcotest.(check bool)
  \"error names the failing protobuf type (JoinRequest)\"
  true
  (String_util.contains_substring msg \"JoinRequest\")
\`\`\`

→ 새 contract 가 *enforced behavior* 로 lock. 향후 call site 추가가 옛 context-free 형태로 회귀하면 테스트 fail.

## 검증

- \`dune build --root . @check\` EXIT=0 clean
- \`test/test_grpc_coordination.exe\` 28/28 PASS (4 강화 테스트 type_name presence 검증)
- \`test/test_grpc_client.exe\` 15/15 PASS
- \`test/test_transport_integration.exe\` 9/9 PASS

## Workaround Rejection Bar self-check

7-item checklist 전부 N/A:
1. ❌ telemetry-as-fix (실제 type-system fix — labeled arg 컴파일타임 강제)
2. ❌ string classifier
3. ❌ N-of-M (15/15 atomically)
4. ❌ catch-all 추가
5. ❌ symptom 억제 (root: 컨텍스트 부재)
6. ❌ test backdoor
7. ❌ 반복 typo

## Pattern continuation

같은 사용자-clarity-vision 직전 시리즈:
- PR #16787 (cascade name silent-fallback WARN, 머지)
- PR #16824 / iter#72 (keeper name validation context)
- **이 PR / iter#73 (protobuf type identity)**

다음 후보: HTTP boundary error context (server_h2_gateway, http_server_eio 의 \"Accept error\" 등).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>