### PR TITLE
fix(logs): demote deterministic pre-rejection noise

### DIFF
--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -516,7 +516,10 @@ let vote ~voter ~post_id ~direction =
        emit_board_sse_event
          (Post_voted { post_id; voter; direction })
    | Error e ->
-       Log.BoardLog.warn
+       (match e with
+        | Board_types.Post_not_found _ | Board_types.Comment_not_found _ ->
+            Log.BoardLog.info
+        | _ -> Log.BoardLog.warn)
          "board vote failed: post_id=%s voter=%s: %s"
          post_id voter (Board_types.show_board_error e));
   result
@@ -535,7 +538,10 @@ let vote_comment ~voter ~comment_id ~direction =
        emit_board_sse_event
          (Comment_voted { comment_id; voter; direction })
    | Error e ->
-       Log.BoardLog.warn
+       (match e with
+        | Board_types.Post_not_found _ | Board_types.Comment_not_found _ ->
+            Log.BoardLog.info
+        | _ -> Log.BoardLog.warn)
          "board vote_comment failed: comment_id=%s voter=%s: %s"
          comment_id voter (Board_types.show_board_error e));
   result
@@ -558,7 +564,10 @@ let toggle_reaction ~target_type ~target_id ~user_id ~emoji =
               reacted = toggled.reacted;
             })
    | Error e ->
-       Log.BoardLog.warn
+       (match e with
+        | Board_types.Post_not_found _ | Board_types.Comment_not_found _ ->
+            Log.BoardLog.info
+        | _ -> Log.BoardLog.warn)
          "board reaction failed: target=%s:%s user=%s emoji=%s: %s"
          (Board.reaction_target_type_to_string target_type)
          target_id user_id emoji (Board_types.show_board_error e));

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -1028,7 +1028,7 @@ let handle_keeper_bash
       Keeper_metrics.metric_keeper_shell_bash_failures
       ~labels:[("keeper", meta.name); ("site", "gh_pr_native_tool")]
       ();
-    Log.Keeper.warn
+    Log.Keeper.info
       "keeper_bash gh pr command routed to native tool: keeper=%s rule=%s cmd=%s"
       meta.name hint.rule_id cmd_for_log;
     Yojson.Safe.to_string
@@ -1049,7 +1049,7 @@ let handle_keeper_bash
       Keeper_metrics.metric_keeper_shell_bash_failures
       ~labels:[("keeper", meta.name); ("site", "tool_invoked_as_shell")]
       ();
-    Log.Keeper.warn
+    Log.Keeper.info
       "keeper_bash direct tool command blocked: keeper=%s tool=%s cmd=%s"
       meta.name tool_name cmd_for_log;
     Yojson.Safe.to_string
@@ -1427,7 +1427,7 @@ let handle_keeper_bash
           ; ("shape_block", bash_shape_block_tag block)
           ]
         ();
-      Log.Keeper.warn
+      Log.Keeper.info
         "keeper_bash command-shape blocked: keeper=%s block=%s cmd=%s"
         meta.name (bash_shape_block_tag block) cmd_for_log;
       bash_shape_block_result ~cmd ~cmd_for_log ~env_snapshot:env_snap block


### PR DESCRIPTION
## Summary
- demote duplicate keeper_bash deterministic pre-rejection logs from WARN to INFO
- keep the structured deterministic error result path and Prometheus counters intact
- demote board vote/reaction missing-target pre-logs to INFO while leaving non-target board failures at WARN

## Evidence
Fresh stale-runtime audit after the previous fixes still showed repeated WARN carriers that duplicate already-classified deterministic outcomes:

- `keeper_bash direct tool command blocked`
- `keeper_bash command-shape blocked`
- `keeper_bash gh pr command routed to native tool`
- `board vote failed: ... Post_not_found`

The actionable tool results remain workflow/policy rejections; these pre-logs should not keep inflating WARN volume.

## Tests
- `ocamlformat --check lib/keeper/keeper_shell_bash.ml lib/board_dispatch.ml`
- `git diff --check origin/main...HEAD`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=/private/tmp/masc-deterministic-prelog-main-build-20260520 scripts/dune-local.sh build test/test_keeper_bash_safety.exe test/test_board_dispatch.exe`
- `/private/tmp/masc-deterministic-prelog-main-build-20260520/default/test/test_keeper_bash_safety.exe test --show-errors --color=never negative_path 1,2`
- `/private/tmp/masc-deterministic-prelog-main-build-20260520/default/test/test_keeper_bash_safety.exe test --show-errors --color=never edge 7`
- `/private/tmp/masc-deterministic-prelog-main-build-20260520/default/test/test_board_dispatch.exe test --show-errors --color=never votes`
- `/private/tmp/masc-deterministic-prelog-main-build-20260520/default/test/test_board_dispatch.exe test --show-errors --color=never reactions`

Based on `main` after #16805 merged.
