### PR TITLE
refactor(keeper): extract rotation attempt reducer

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -376,21 +376,15 @@ let run_keeper_cycle
                      (err : Agent_sdk.Error.sdk_error)
                  =
                  let attempt : Keeper_execution_receipt.cascade_rotation_attempt =
-                   { from_cascade
-                   ; to_cascade =
-                       Keeper_execution_receipt.cascade_name_of_string retry.next_cascade
-                   ; reason = retry.fallback_reason
-                   ; outcome
-                   ; slot_release_at_phase
-                   ; productive_phase_elapsed_ms
-                   ; retry_phase_elapsed_ms
-                   ; error_kind =
-                       Some
-                         (Keeper_execution_receipt.error_kind_of_string
-                            (sdk_error_kind err))
-                   ; error_message = Some (Agent_sdk.Error.to_string err)
-                   ; recorded_at = now_iso ()
-                   }
+                   Keeper_unified_turn_rotation_attempt.build
+                     ~recorded_at:(now_iso ())
+                     ?slot_release_at_phase
+                     ?productive_phase_elapsed_ms
+                     ?retry_phase_elapsed_ms
+                     ~from_cascade
+                     ~retry
+                     ~outcome
+                     err
                  in
                  cascade_rotation_attempts := attempt :: !cascade_rotation_attempts
                in

--- a/lib/keeper/keeper_unified_turn_rotation_attempt.ml
+++ b/lib/keeper/keeper_unified_turn_rotation_attempt.ml
@@ -1,0 +1,26 @@
+let build
+      ~recorded_at
+      ?slot_release_at_phase
+      ?productive_phase_elapsed_ms
+      ?retry_phase_elapsed_ms
+      ~(from_cascade : Keeper_execution_receipt.cascade_name)
+      ~(retry : Keeper_error_classify.degraded_retry)
+      ~(outcome : Keeper_execution_receipt.cascade_rotation_outcome)
+      (err : Agent_sdk.Error.sdk_error)
+  : Keeper_execution_receipt.cascade_rotation_attempt
+  =
+  { from_cascade
+  ; to_cascade = Keeper_execution_receipt.cascade_name_of_string retry.next_cascade
+  ; reason = retry.fallback_reason
+  ; outcome
+  ; slot_release_at_phase
+  ; productive_phase_elapsed_ms
+  ; retry_phase_elapsed_ms
+  ; error_kind =
+      Some
+        (Keeper_execution_receipt.error_kind_of_string
+           (Keeper_agent_error.sdk_error_kind err))
+  ; error_message = Some (Agent_sdk.Error.to_string err)
+  ; recorded_at
+  }
+;;

--- a/lib/keeper/keeper_unified_turn_rotation_attempt.mli
+++ b/lib/keeper/keeper_unified_turn_rotation_attempt.mli
@@ -1,0 +1,16 @@
+(** Pure reducer for cascade rotation attempt receipt rows.
+
+    The keeper turn driver owns impure timing and mutable accumulation. This
+    module owns the deterministic projection from a degraded retry decision plus
+    its terminal error into the receipt row persisted at the end of the turn. *)
+
+val build
+  :  recorded_at:string
+  -> ?slot_release_at_phase:Keeper_execution_receipt.slot_release_phase
+  -> ?productive_phase_elapsed_ms:int
+  -> ?retry_phase_elapsed_ms:int
+  -> from_cascade:Keeper_execution_receipt.cascade_name
+  -> retry:Keeper_error_classify.degraded_retry
+  -> outcome:Keeper_execution_receipt.cascade_rotation_outcome
+  -> Agent_sdk.Error.sdk_error
+  -> Keeper_execution_receipt.cascade_rotation_attempt

--- a/test/test_keeper_unified_turn_pipeline_records.ml
+++ b/test/test_keeper_unified_turn_pipeline_records.ml
@@ -3,6 +3,9 @@ open Alcotest
 module KRun = Masc_mcp.Keeper_turn_driver
 module KP = Masc_mcp.Keeper_state_machine
 module UT = Masc_mcp.Keeper_unified_turn
+module Rotation_attempt = Masc_mcp.Keeper_unified_turn_rotation_attempt
+module Receipt = Masc_mcp.Keeper_execution_receipt
+module EC = Masc_mcp.Keeper_error_classify
 
 let test_turn_plan_phase_gate_records_typed_contract () =
   let open Yojson.Safe.Util in
@@ -150,6 +153,68 @@ let test_provider_attempt_records_manifest_decision_contract () =
   check string "finished error" "Eio.Time.Timeout" (finished |> member "error" |> to_string)
 ;;
 
+let test_rotation_attempt_builder_records_retry_decision () =
+  let retry : EC.degraded_retry =
+    { next_cascade = "tool_required_fallback"
+    ; fallback_reason = EC.Required_tool_contract_violation
+    }
+  in
+  let err = Agent_sdk.Error.Internal "forced tool-choice contract failure" in
+  let attempt =
+    Rotation_attempt.build
+      ~recorded_at:"2026-05-20T00:00:00Z"
+      ~slot_release_at_phase:Receipt.Retry_scheduled
+      ~productive_phase_elapsed_ms:1234
+      ~retry_phase_elapsed_ms:56
+      ~from_cascade:(Receipt.cascade_name_of_string "default")
+      ~retry
+      ~outcome:Receipt.Rotation_retry_scheduled
+      err
+  in
+  check
+    string
+    "from cascade"
+    "default"
+    (Receipt.cascade_name_to_string attempt.from_cascade);
+  check
+    string
+    "to cascade"
+    "tool_required_fallback"
+    (Receipt.cascade_name_to_string attempt.to_cascade);
+  check
+    string
+    "fallback reason"
+    "required_tool_contract_violation"
+    (EC.degraded_retry_reason_to_string attempt.reason);
+  check
+    string
+    "outcome"
+    "retry_scheduled"
+    (Receipt.cascade_rotation_outcome_to_string attempt.outcome);
+  check
+    (option string)
+    "slot release phase"
+    (Some "retry_scheduled")
+    (Option.map Receipt.slot_release_phase_to_string attempt.slot_release_at_phase);
+  check
+    (option int)
+    "productive phase ms"
+    (Some 1234)
+    attempt.productive_phase_elapsed_ms;
+  check (option int) "retry phase ms" (Some 56) attempt.retry_phase_elapsed_ms;
+  check
+    (option string)
+    "error kind"
+    (Some "internal")
+    (Option.map Receipt.error_kind_to_string attempt.error_kind);
+  check
+    (option string)
+    "error message"
+    (Some (Agent_sdk.Error.to_string err))
+    attempt.error_message;
+  check string "recorded at" "2026-05-20T00:00:00Z" attempt.recorded_at
+;;
+
 let () =
   run
     "keeper_unified_turn_pipeline_records"
@@ -162,6 +227,10 @@ let () =
             "provider attempt emits typed manifest records"
             `Quick
             test_provider_attempt_records_manifest_decision_contract
+        ; test_case
+            "rotation attempt builder records degraded retry decision"
+            `Quick
+            test_rotation_attempt_builder_records_retry_decision
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- Extract cascade rotation attempt receipt-row construction from keeper_unified_turn into Keeper_unified_turn_rotation_attempt
- Keep the turn loop impure wrapper limited to timestamping and appending to the local accumulator
- Add focused pipeline-record test coverage for the pure degraded-retry projection

## Verification
- ocamlformat --check lib/keeper/keeper_unified_turn_rotation_attempt.ml lib/keeper/keeper_unified_turn_rotation_attempt.mli lib/keeper/keeper_unified_turn.ml test/test_keeper_unified_turn_pipeline_records.ml
- rg -n "Stdlib\.Lazy\.(force|from_val)|Fun\.protect|Mutex\.(lock|unlock)|failwith|assert false|Eio\.traceln|Sys\.(readdir|command)" lib/keeper/keeper_unified_turn_rotation_attempt.ml lib/keeper/keeper_unified_turn_rotation_attempt.mli (no matches)
- git diff --check
- scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD

## Not run
- scripts/dune-local.sh build test/test_keeper_unified_turn_pipeline_records.exe: refused by local wrapper because multiple bare machine-wide dune processes are already running; leaving compile/test proof to PR CI to avoid adding host pressure.