### PR TITLE
refactor(server): extract shell projection-timing tracker into sibling module

### DIFF
--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -1374,17 +1374,20 @@ let is_dashboard_cache_timeout_json = function
   | _ -> false
 ;;
 
-type shell_projection_timing =
+module Shell_projection_trace = Server_dashboard_shell_projection_trace
+
+type shell_projection_timing = Shell_projection_trace.shell_projection_timing =
   { projection_label : string
   ; projection_ms : int
   }
 
 type shell_projection_trace_status =
+  Shell_projection_trace.shell_projection_trace_status =
   | Shell_trace_running
   | Shell_trace_finished
   | Shell_trace_failed
 
-type shell_projection_trace =
+type shell_projection_trace = Shell_projection_trace.shell_projection_trace =
   { trace_light : bool
   ; trace_started_at : float
   ; mutable trace_status : shell_projection_trace_status
@@ -1394,6 +1397,7 @@ type shell_projection_trace =
   }
 
 type shell_projection_trace_snapshot =
+  Shell_projection_trace.shell_projection_trace_snapshot =
   { snapshot_status : shell_projection_trace_status
   ; snapshot_light : bool
   ; snapshot_elapsed_ms : int
@@ -1402,133 +1406,17 @@ type shell_projection_trace_snapshot =
   ; snapshot_finished_at : float option
   }
 
-let shell_projection_trace_mu = Stdlib.Mutex.create ()
-
-let shell_projection_traces : (string, shell_projection_trace) Hashtbl.t =
-  Hashtbl.create 16
-;;
-
-let shell_trace_status_string = function
-  | Shell_trace_running -> "running"
-  | Shell_trace_finished -> "finished"
-  | Shell_trace_failed -> "failed"
-;;
-
-let shell_projection_timing_top timings =
-  timings
-  |> List.sort (fun left right -> compare right.projection_ms left.projection_ms)
-  |> List.filteri (fun idx _ -> idx < 5)
-;;
-
-let shell_projection_timing_json timing =
-  `Assoc [ "label", `String timing.projection_label; "ms", `Int timing.projection_ms ]
-;;
-
-let shell_projection_timing_log timings =
-  match shell_projection_timing_top timings with
-  | [] -> "none"
-  | top ->
-    top
-    |> List.map (fun timing ->
-      Printf.sprintf "%s=%dms" timing.projection_label timing.projection_ms)
-    |> String.concat ","
-;;
-
-let shell_projection_trace_start ~cache_key ~light =
-  let trace =
-    { trace_light = light
-    ; trace_started_at = Unix.gettimeofday ()
-    ; trace_status = Shell_trace_running
-    ; trace_active = []
-    ; trace_completed = []
-    ; trace_finished_at = None
-    }
-  in
-  Stdlib.Mutex.protect shell_projection_trace_mu (fun () ->
-    Hashtbl.replace shell_projection_traces cache_key trace);
-  trace
-;;
-
-let shell_projection_trace_start_projection trace label =
-  Stdlib.Mutex.protect shell_projection_trace_mu (fun () ->
-    if not (List.mem label trace.trace_active)
-    then trace.trace_active <- label :: trace.trace_active)
-;;
-
-let shell_projection_trace_finish_projection trace label elapsed_ms =
-  Stdlib.Mutex.protect shell_projection_trace_mu (fun () ->
-    trace.trace_active
-    <- List.filter (fun active -> not (String.equal active label)) trace.trace_active;
-    trace.trace_completed
-    <- { projection_label = label; projection_ms = elapsed_ms }
-       :: List.filter
-            (fun timing -> not (String.equal timing.projection_label label))
-            trace.trace_completed)
-;;
-
-let shell_projection_trace_finish ?(clear_active = true) trace status =
-  Stdlib.Mutex.protect shell_projection_trace_mu (fun () ->
-    trace.trace_status <- status;
-    trace.trace_finished_at <- Some (Unix.gettimeofday ());
-    if clear_active then trace.trace_active <- [])
-;;
-
-let shell_projection_trace_snapshot cache_key =
-  Stdlib.Mutex.protect shell_projection_trace_mu (fun () ->
-    match Hashtbl.find_opt shell_projection_traces cache_key with
-    | None -> None
-    | Some trace ->
-      let now_ts = Unix.gettimeofday () in
-      let finished_at = trace.trace_finished_at in
-      let elapsed_until = Option.value finished_at ~default:now_ts in
-      Some
-        { snapshot_status = trace.trace_status
-        ; snapshot_light = trace.trace_light
-        ; snapshot_elapsed_ms =
-            int_of_float ((elapsed_until -. trace.trace_started_at) *. 1000.0)
-        ; snapshot_active = trace.trace_active
-        ; snapshot_completed = trace.trace_completed
-        ; snapshot_finished_at = finished_at
-        })
-;;
-
-let shell_projection_trace_diagnostics cache_key =
-  match shell_projection_trace_snapshot cache_key with
-  | None ->
-    [ "projection_timing_status", `String "none"
-    ; "projection_timing_active", `List []
-    ; "projection_timing_top", `List []
-    ]
-  | Some snapshot ->
-    [ ( "projection_timing_status"
-      , `String (shell_trace_status_string snapshot.snapshot_status) )
-    ; "projection_timing_light", `Bool snapshot.snapshot_light
-    ; "projection_timing_elapsed_ms", `Int snapshot.snapshot_elapsed_ms
-    ; ( "projection_timing_active"
-      , `List (List.rev snapshot.snapshot_active |> List.map (fun label -> `String label))
-      )
-    ; ( "projection_timing_top"
-      , `List
-          (shell_projection_timing_top snapshot.snapshot_completed
-           |> List.map shell_projection_timing_json) )
-    ; ( "projection_timing_finished_at"
-      , match snapshot.snapshot_finished_at with
-        | Some ts -> `Float ts
-        | None -> `Null )
-    ]
-;;
-
-let shell_projection_trace_log cache_key =
-  match shell_projection_trace_snapshot cache_key with
-  | None -> "none", "none", "none", 0
-  | Some snapshot ->
-    ( shell_trace_status_string snapshot.snapshot_status
-    , (match List.rev snapshot.snapshot_active with
-       | [] -> "none"
-       | active -> String.concat "," active)
-    , shell_projection_timing_log snapshot.snapshot_completed
-    , snapshot.snapshot_elapsed_ms )
-;;
+let shell_trace_status_string = Shell_projection_trace.status_string
+let shell_projection_timing_top = Shell_projection_trace.timing_top
+let shell_projection_timing_json = Shell_projection_trace.timing_json
+let shell_projection_timing_log = Shell_projection_trace.timing_log
+let shell_projection_trace_start = Shell_projection_trace.start
+let shell_projection_trace_start_projection = Shell_projection_trace.start_projection
+let shell_projection_trace_finish_projection = Shell_projection_trace.finish_projection
+let shell_projection_trace_finish = Shell_projection_trace.finish
+let shell_projection_trace_snapshot = Shell_projection_trace.snapshot
+let shell_projection_trace_diagnostics = Shell_projection_trace.diagnostics
+let shell_projection_trace_log = Shell_projection_trace.log
 
 (* Closed mapping from internal projection labels to Server_timing phases.
    Total over the label set actually emitted by [dashboard_shell_payload_json];

--- a/lib/server/server_dashboard_shell_projection_trace.ml
+++ b/lib/server/server_dashboard_shell_projection_trace.ml
@@ -1,0 +1,153 @@
+(* Per-request projection-timing tracker for dashboard shell endpoints.
+
+   Encapsulates the mutable trace state (Hashtbl + Stdlib.Mutex) and the
+   start/finish/snapshot lifecycle. Each cache_key (typically a config
+   partition + light flag) gets exactly one trace; later starts overwrite. *)
+
+type shell_projection_timing =
+  { projection_label : string
+  ; projection_ms : int
+  }
+
+type shell_projection_trace_status =
+  | Shell_trace_running
+  | Shell_trace_finished
+  | Shell_trace_failed
+
+type shell_projection_trace =
+  { trace_light : bool
+  ; trace_started_at : float
+  ; mutable trace_status : shell_projection_trace_status
+  ; mutable trace_active : string list
+  ; mutable trace_completed : shell_projection_timing list
+  ; mutable trace_finished_at : float option
+  }
+
+type shell_projection_trace_snapshot =
+  { snapshot_status : shell_projection_trace_status
+  ; snapshot_light : bool
+  ; snapshot_elapsed_ms : int
+  ; snapshot_active : string list
+  ; snapshot_completed : shell_projection_timing list
+  ; snapshot_finished_at : float option
+  }
+
+let mu = Stdlib.Mutex.create ()
+let traces : (string, shell_projection_trace) Hashtbl.t = Hashtbl.create 16
+
+let status_string = function
+  | Shell_trace_running -> "running"
+  | Shell_trace_finished -> "finished"
+  | Shell_trace_failed -> "failed"
+;;
+
+let timing_top timings =
+  timings
+  |> List.sort (fun left right -> compare right.projection_ms left.projection_ms)
+  |> List.filteri (fun idx _ -> idx < 5)
+;;
+
+let timing_json timing =
+  `Assoc [ "label", `String timing.projection_label; "ms", `Int timing.projection_ms ]
+;;
+
+let timing_log timings =
+  match timing_top timings with
+  | [] -> "none"
+  | top ->
+    top
+    |> List.map (fun timing ->
+      Printf.sprintf "%s=%dms" timing.projection_label timing.projection_ms)
+    |> String.concat ","
+;;
+
+let start ~cache_key ~light =
+  let trace =
+    { trace_light = light
+    ; trace_started_at = Unix.gettimeofday ()
+    ; trace_status = Shell_trace_running
+    ; trace_active = []
+    ; trace_completed = []
+    ; trace_finished_at = None
+    }
+  in
+  Stdlib.Mutex.protect mu (fun () -> Hashtbl.replace traces cache_key trace);
+  trace
+;;
+
+let start_projection trace label =
+  Stdlib.Mutex.protect mu (fun () ->
+    if not (List.mem label trace.trace_active)
+    then trace.trace_active <- label :: trace.trace_active)
+;;
+
+let finish_projection trace label elapsed_ms =
+  Stdlib.Mutex.protect mu (fun () ->
+    trace.trace_active
+    <- List.filter (fun active -> not (String.equal active label)) trace.trace_active;
+    trace.trace_completed
+    <- { projection_label = label; projection_ms = elapsed_ms }
+       :: List.filter
+            (fun timing -> not (String.equal timing.projection_label label))
+            trace.trace_completed)
+;;
+
+let finish ?(clear_active = true) trace status =
+  Stdlib.Mutex.protect mu (fun () ->
+    trace.trace_status <- status;
+    trace.trace_finished_at <- Some (Unix.gettimeofday ());
+    if clear_active then trace.trace_active <- [])
+;;
+
+let snapshot cache_key =
+  Stdlib.Mutex.protect mu (fun () ->
+    match Hashtbl.find_opt traces cache_key with
+    | None -> None
+    | Some trace ->
+      let now_ts = Unix.gettimeofday () in
+      let finished_at = trace.trace_finished_at in
+      let elapsed_until = Option.value finished_at ~default:now_ts in
+      Some
+        { snapshot_status = trace.trace_status
+        ; snapshot_light = trace.trace_light
+        ; snapshot_elapsed_ms =
+            int_of_float ((elapsed_until -. trace.trace_started_at) *. 1000.0)
+        ; snapshot_active = trace.trace_active
+        ; snapshot_completed = trace.trace_completed
+        ; snapshot_finished_at = finished_at
+        })
+;;
+
+let diagnostics cache_key =
+  match snapshot cache_key with
+  | None ->
+    [ "projection_timing_status", `String "none"
+    ; "projection_timing_active", `List []
+    ; "projection_timing_top", `List []
+    ]
+  | Some snap ->
+    [ "projection_timing_status", `String (status_string snap.snapshot_status)
+    ; "projection_timing_light", `Bool snap.snapshot_light
+    ; "projection_timing_elapsed_ms", `Int snap.snapshot_elapsed_ms
+    ; ( "projection_timing_active"
+      , `List (List.rev snap.snapshot_active |> List.map (fun label -> `String label)) )
+    ; ( "projection_timing_top"
+      , `List (timing_top snap.snapshot_completed |> List.map timing_json) )
+    ; ( "projection_timing_finished_at"
+      , match snap.snapshot_finished_at with
+        | Some ts -> `Float ts
+        | None -> `Null )
+    ]
+;;
+
+let log cache_key =
+  match snapshot cache_key with
+  | None -> "none", "none", "none", 0
+  | Some snap ->
+    ( status_string snap.snapshot_status
+    , (match List.rev snap.snapshot_active with
+       | [] -> "none"
+       | active -> String.concat "," active)
+    , timing_log snap.snapshot_completed
+    , snap.snapshot_elapsed_ms )
+;;

--- a/lib/server/server_dashboard_shell_projection_trace.mli
+++ b/lib/server/server_dashboard_shell_projection_trace.mli
@@ -1,0 +1,52 @@
+(** Per-request projection-timing tracker for dashboard shell endpoints.
+
+    Used by [Server_dashboard_http_core] to annotate the response with
+    per-projection elapsed-ms breakdowns and to expose the in-flight set
+    on the diagnostics endpoint. *)
+
+type shell_projection_timing =
+  { projection_label : string
+  ; projection_ms : int
+  }
+
+type shell_projection_trace_status =
+  | Shell_trace_running
+  | Shell_trace_finished
+  | Shell_trace_failed
+
+type shell_projection_trace =
+  { trace_light : bool
+  ; trace_started_at : float
+  ; mutable trace_status : shell_projection_trace_status
+  ; mutable trace_active : string list
+  ; mutable trace_completed : shell_projection_timing list
+  ; mutable trace_finished_at : float option
+  }
+
+type shell_projection_trace_snapshot =
+  { snapshot_status : shell_projection_trace_status
+  ; snapshot_light : bool
+  ; snapshot_elapsed_ms : int
+  ; snapshot_active : string list
+  ; snapshot_completed : shell_projection_timing list
+  ; snapshot_finished_at : float option
+  }
+
+val status_string : shell_projection_trace_status -> string
+val timing_top : shell_projection_timing list -> shell_projection_timing list
+val timing_json : shell_projection_timing -> Yojson.Safe.t
+val timing_log : shell_projection_timing list -> string
+
+val start : cache_key:string -> light:bool -> shell_projection_trace
+val start_projection : shell_projection_trace -> string -> unit
+val finish_projection : shell_projection_trace -> string -> int -> unit
+
+val finish
+  :  ?clear_active:bool
+  -> shell_projection_trace
+  -> shell_projection_trace_status
+  -> unit
+
+val snapshot : string -> shell_projection_trace_snapshot option
+val diagnostics : string -> (string * Yojson.Safe.t) list
+val log : string -> string * string * string * int


### PR DESCRIPTION
## 요약

`server_dashboard_http_core.ml` (1929 LoC godfile) 의 per-request projection-timing tracker 를 신규 sibling 모듈로 추출했습니다. **-112 LoC** (1929 → 1817).

## 추출 cluster

| 분류 | 항목 |
|---|---|
| Types (4) | `shell_projection_timing`, `shell_projection_trace_status`, `shell_projection_trace`, `shell_projection_trace_snapshot` |
| State | `mu : Stdlib.Mutex.t`, `traces : (string, shell_projection_trace) Hashtbl.t` |
| Helpers (4) | `status_string`, `timing_top`, `timing_json`, `timing_log` |
| Lifecycle (4) | `start`, `start_projection`, `finish_projection`, `finish` |
| Derived (3) | `snapshot`, `diagnostics`, `log` |

## 신규 모듈

- `lib/server/server_dashboard_shell_projection_trace.ml` (153 LoC)
- `lib/server/server_dashboard_shell_projection_trace.mli` (52 LoC)

## 보존

Parent (`server_dashboard_http_core.ml`) 는 transparent record/sum type alias 와 thin let-alias 로 기존 surface 를 그대로 노출합니다. caller 변경 0.

```ocaml
module Shell_projection_trace = Server_dashboard_shell_projection_trace

type shell_projection_timing = Shell_projection_trace.shell_projection_timing = { ... }
...
let shell_projection_trace_start = Shell_projection_trace.start
```

## 외부 caller 검증

```
$ grep -rn "shell_projection_trace\|shell_projection_timing\|\
shell_projection_label_to_phase\|shell_trace_status_string" lib/ test/ bin/ \
    | grep -v "server_dashboard_http_core.ml"
(no output)
```

모든 caller 가 parent module 내부.

## 검증

- [x] `dune build --root . @check` PASS
- [x] `dune build --root . lib/server` PASS
- [x] 외부 caller 0 (위 grep)
- [x] type 은 transparent alias — record field/variant constructor 호환

## 패턴

State encapsulation pattern. PR #16786 (cascade codex omission dedup) + #16792 (board comment rate limit) 와 동일 구조 — mutex-protected mutable state 를 sibling 으로 격리하고 parent 는 re-export shim 만 유지.

후속 candidate: parent 내부 자체 caller 를 `Shell_projection_trace.` 직접 참조로 마이그레이션하면 thin shim 도 제거 가능 (별도 PR).

## Workaround Rejection Bar self-check

1. [ ] makes X visible only — NO (lifecycle/state owner 이동)
2. [ ] string classifier — NO
3. [ ] N-of-M — NO (전체 cluster 한 번에 이동)
4. [ ] catch-all `_ ->` 추가 — NO
5. [ ] cap/cooldown/dedup/repair — NO (pure refactor)
6. [ ] test backdoor — NO
7. [ ] N-사이트 typo — NO

PASS — pure refactor, behavior 동일.

## RFC

RFC-WAIVED: `lib/server` (non-credential, non-keeper-gh, non-host-config, non-operator-control, non-hooks, non-workflow-docs) — RFC-gated subsystem 아님 (per `~/me/CLAUDE.md <agent_delegation>`).

`bash ~/me/scripts/pr-rfc-check.sh` exit 0.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
