### PR TITLE
fix(ide): add symbol graph live LSP doctor

### DIFF
--- a/docs/design/lsp-symbol-graph-exporter.md
+++ b/docs/design/lsp-symbol-graph-exporter.md
@@ -140,6 +140,23 @@ pretend stale static line numbers are current-main coordinates. It does not
 call `/api/v1/ide/lsp`, does not add a runtime route, and does not mutate task,
 keeper, git, dashboard, or cache state.
 
+## Live LSP Prerequisites
+
+The static seed check is intentionally not a live exporter proof. To verify
+whether the local runner can attempt a future live export, run:
+
+```bash
+scripts/ide/export-symbol-graph --doctor-live-lsp
+```
+
+The doctor prints JSON for the languages present in the artifact and checks
+only executable availability, currently `ocaml-lsp-server` for OCaml files and
+`typescript-language-server` for TypeScript files. It does not call
+`/api/v1/ide/lsp`, open a WebSocket, spawn LSP servers, update
+`live_lsp_invoked`, or rewrite the checked-in artifact. Missing executables are
+an explicit live-export prerequisite blocker, not a reason to refresh
+`base_commit` or static line ranges from heuristics.
+
 To reproduce the seed payload as canonical JSON during a documentation PR:
 
 ```bash

--- a/docs/generated/reverse-engineering/symbol-graph.v1.json
+++ b/docs/generated/reverse-engineering/symbol-graph.v1.json
@@ -12,6 +12,15 @@
     ],
     "manifest": "docs/design/lsp-symbol-graph-exporter.md",
     "check_command": "scripts/ide/export-symbol-graph --check",
+    "live_lsp_prereq_command": "scripts/ide/export-symbol-graph --doctor-live-lsp",
+    "required_live_lsp_executables": {
+      "ocaml": [
+        "ocaml-lsp-server"
+      ],
+      "typescript": [
+        "typescript-language-server"
+      ]
+    },
     "emit_command": "scripts/ide/export-symbol-graph --emit > docs/generated/reverse-engineering/symbol-graph.v1.json",
     "live_lsp_invoked": false,
     "notes": "Initial task-387 snapshot is a base-commit-bound static seed from base_commit. display_range values are not current-main coordinates. Later exporter PRs should replace static ranges with live LSP responses."
@@ -698,6 +707,11 @@
       "code": "base_commit_bound_static_ranges",
       "reason": "Static display ranges are valid only for base_commit 22f3665e5218 and may drift as main changes; they must not be treated as current-main coordinates.",
       "follow_up": "Refresh the artifact through the read-only exporter before using line ranges for refactor execution."
+    },
+    {
+      "code": "live_lsp_prerequisites_not_part_of_static_check",
+      "reason": "The static seed validator proves schema and path/test ownership only. Live export also requires local language-server executables, checked separately by scripts/ide/export-symbol-graph --doctor-live-lsp.",
+      "follow_up": "Install or pin ocaml-lsp-server and typescript-language-server before replacing static ranges with live LSP documentSymbol/references responses."
     },
     {
       "code": "call_edges_curated",

--- a/scripts/ide/export-symbol-graph
+++ b/scripts/ide/export-symbol-graph
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import json
 import pathlib
+import shutil
 import subprocess
 import sys
 from typing import Any
@@ -40,6 +41,10 @@ DENIED_METHODS = {
     "textDocument/formatting",
     "textDocument/rangeFormatting",
     "textDocument/codeAction",
+}
+LIVE_LSP_EXECUTABLES = {
+    "ocaml": ["ocaml-lsp-server"],
+    "typescript": ["typescript-language-server"],
 }
 
 
@@ -81,6 +86,54 @@ def collect_tests(data: dict[str, Any]) -> set[str]:
         for symbol in file_row.get("symbols", []):
             tests.update(symbol.get("tests", []))
     return tests
+
+
+def collect_languages(data: dict[str, Any]) -> set[str]:
+    languages: set[str] = set()
+    for file_row in data.get("files", []):
+        language = file_row.get("language")
+        if isinstance(language, str) and language:
+            languages.add(language)
+    return languages
+
+
+def live_lsp_prereq_report(data: dict[str, Any], *, artifact: pathlib.Path) -> dict[str, Any]:
+    languages = sorted(collect_languages(data))
+    commands: dict[str, list[dict[str, Any]]] = {}
+    ready = True
+    for language in languages:
+        required = LIVE_LSP_EXECUTABLES.get(language, [])
+        rows: list[dict[str, Any]] = []
+        for command in required:
+            found_path = shutil.which(command)
+            found = found_path is not None
+            ready = ready and found
+            rows.append(
+                {
+                    "command": command,
+                    "found": found,
+                    "path": found_path,
+                }
+            )
+        commands[language] = rows
+    source = data.get("source", {})
+    if not isinstance(source, dict):
+        source = {}
+    return {
+        "schema_version": "masc.symbol_graph.live_lsp_prereq.v1",
+        "artifact": str(artifact),
+        "artifact_schema_version": data.get("schema_version"),
+        "artifact_collection_mode": data.get("collection_mode"),
+        "artifact_live_lsp_invoked": source.get("live_lsp_invoked"),
+        "languages": languages,
+        "commands": commands,
+        "ready": ready,
+        "note": (
+            "This doctor checks local executable prerequisites only. It does not "
+            "call /api/v1/ide/lsp, open a WebSocket, spawn LSP servers, or mutate "
+            "the checked-in artifact."
+        ),
+    }
 
 
 def validate(data: dict[str, Any], root: pathlib.Path, *, check_current_ranges: bool) -> list[str]:
@@ -175,6 +228,12 @@ def main() -> int:
     parser.add_argument("--emit", action="store_true", help="validate and print canonical JSON to stdout")
     parser.add_argument("--write", action="store_true", help="validate and rewrite the artifact canonically")
     parser.add_argument(
+        "--doctor-live-lsp",
+        "--live-lsp-prereq-report",
+        action="store_true",
+        help="print a non-mutating JSON report for live LSP executable prerequisites",
+    )
+    parser.add_argument(
         "--strict-ranges",
         action="store_true",
         help="require display_range rows to fit the current checkout even when base_commit differs",
@@ -190,6 +249,10 @@ def main() -> int:
         data["base_commit"] = args.base_commit
     if args.generated_at:
         data["generated_at"] = args.generated_at
+
+    if args.doctor_live_lsp:
+        sys.stdout.write(dump_canonical(live_lsp_prereq_report(data, artifact=artifact)))
+        return 0
 
     current_head = git_short_head(root)
     base_commit = str(data.get("base_commit", ""))


### PR DESCRIPTION
## Summary
- Add scripts/ide/export-symbol-graph --doctor-live-lsp / --live-lsp-prereq-report
- Report live LSP executable prerequisites as JSON without calling /api/v1/ide/lsp or mutating artifacts
- Document that static seed validation, strict current-range drift, and live-LSP readiness are separate proofs
- Add stable artifact metadata for required live LSP executables and the doctor command

## Verification
- python3 -m py_compile scripts/ide/export-symbol-graph
- scripts/ide/export-symbol-graph --check
- scripts/ide/export-symbol-graph --doctor-live-lsp
- scripts/ide/export-symbol-graph --strict-ranges --check (expected failure: stale static ranges for keeper_heartbeat_loop, keeper_unified_turn, tool_task)
- jq empty docs/generated/reverse-engineering/symbol-graph.v1.json
- rg "lsp-symbol-graph-exporter" docs/reverse-engineering-design.html docs/design/lsp-symbol-graph-exporter.md
- rg "masc.symbol_graph.v1|task-386|task-387" docs/design/lsp-symbol-graph-exporter.md
- xmllint --html --noout docs/reverse-engineering-design.html (exit 0 with existing HTML5 tag warnings)
- git diff --check