### PR TITLE
refactor(dashboard): drop dead retired-knob surface from namespace_truth helper

### DIFF
--- a/lib/server/server_dashboard_http_namespace_truth.ml
+++ b/lib/server/server_dashboard_http_namespace_truth.ml
@@ -7,11 +7,6 @@ module Namespace_truth_support = Server_dashboard_http_namespace_truth_support
 
 let namespace_truth_shell_refreshing : bool Atomic.t = Atomic.make false
 
-let float_of_env_default_with_legacy ~canonical ~legacy ~default ~min_v ~max_v =
-  match Sys.getenv_opt canonical with
-  | Some _ -> float_of_env_default canonical ~default ~min_v ~max_v
-  | None -> float_of_env_default legacy ~default ~min_v ~max_v
-
 (* RFC-0138 Phase 3 Step 4 — fallback timeouts are now hard-coded
    module constants.  Step 3 (#16738) wired /project-snapshot through
    [Dashboard_snapshot], so this fallback path is taken at most once

--- a/lib/server/server_dashboard_http_namespace_truth.mli
+++ b/lib/server/server_dashboard_http_namespace_truth.mli
@@ -47,19 +47,22 @@ val dashboard_namespace_truth_http_json :
     exists, composes the HTTP response from cached shell + proactive
     execution state immediately and forks a bounded shell refresh in
     the request switch (stale-while-revalidate).  The refresh timeout
-    is controlled by [MASC_NAMESPACE_TRUTH_SHELL_REFRESH_TIMEOUT_S]
-    (default 5.0s).
+    is 5.0s (module-level constant [namespace_truth_shell_refresh_timeout_s]
+    in the .ml).
 
     First seed: when no last-good shell exists yet, does one bounded
     synchronous shell attempt before composing shell + execution +
-    command summaries with per-fiber timeouts:
-
-    | Env var | Default | Used for |
-    | --- | --- | --- |
-    | [MASC_NAMESPACE_TRUTH_WARM_TIMEOUT_S] | 8.0s | base warm |
-    | [MASC_NAMESPACE_TRUTH_COLD_TIMEOUT_S] | 15.0s | base cold |
-    | [MASC_NAMESPACE_TRUTH_SHELL_FIBER_TIMEOUT_S] | 12.0s | shell warm cap |
-    | [MASC_NAMESPACE_TRUTH_COLD_SAFETY_MARGIN_S] | 4.0s | cold shell safety |
+    command summaries with per-fiber timeouts.  The four timeout
+    constants (warm 8.0s, cold 15.0s, shell-fiber cap 12.0s, cold
+    safety margin 4.0s) were previously tunable via
+    [MASC_NAMESPACE_TRUTH_*_TIMEOUT_S] env vars; RFC-0138 Phase 3
+    Step 4 (#16752) retired those knobs because Step 3 (#16738)
+    wired /project-snapshot through {!Dashboard_snapshot}, so this
+    fallback path is taken at most once per process lifetime
+    (cold-start before the refresh fiber's first publish) and no
+    longer carries steady-state load worth tuning.  See the
+    module-level [namespace_truth_*_timeout_s] bindings in the .ml
+    for the current values.
 
     Shell timeout (cold) = max(cold_timeout, shell_fiber + safety) —
     must exceed the inner cache timeout to avoid the double-timeout


### PR DESCRIPTION
## Summary

Drop two dead surfaces left behind by RFC-0138 Phase 3 Step 4 (#16752):

1. **`float_of_env_default_with_legacy` helper** — zero callers after #16752 removed the only call site.
2. **`.mli` env-var table** advertising 4 retired knobs as active tunables — operator UX bug (silent no-op when set).

## Background

PR #16752 retired the four `MASC_NAMESPACE_TRUTH_*_TIMEOUT_S` env knobs and replaced them with module-level hard-coded constants, because Step 3 (#16738) wired `/project-snapshot` through `Dashboard_snapshot` and the fallback path is now taken at most once per process lifetime (cold-start).

Three exposure layers were not cleaned at the time:

| Surface | Status before this PR | Action |
| --- | --- | --- |
| `/api/v1/dashboard/config` runtime endpoint | already correctly omits (verified: 0/310 env hits on running server `bf142ff67f`) | no change |
| `docs/runtime-tunables.md` | cleaned by #16777 | already done |
| `server_dashboard_http_namespace_truth.mli` env-var table | **still advertising 4 retired knobs as active tunables** | **this PR** |
| `float_of_env_default_with_legacy` helper | zero callers (`rg --type ocaml` returns only the declaration) | **this PR** |

## Live evidence

```bash
# Running server commit (8h uptime):
curl -s http://localhost:8935/health | jq .build.commit  # bf142ff67f

# Retired knobs in live /api/v1/dashboard/config:
python3 -c "import json; d=json.load(open('/tmp/dash-cfg.json'))
envs=set()
def gather(o):
    if isinstance(o,dict):
        for k,v in o.items():
            if k=='env' and isinstance(v,str): envs.add(v)
            elif isinstance(v,(dict,list)): gather(v)
    elif isinstance(o,list):
        for e in o: gather(e)
gather(d)
for k in ['MASC_NAMESPACE_TRUTH_COLD_TIMEOUT_S','MASC_NAMESPACE_TRUTH_WARM_TIMEOUT_S','MASC_NAMESPACE_TRUTH_SHELL_FIBER_TIMEOUT_S','MASC_NAMESPACE_TRUTH_COLD_SAFETY_MARGIN_S','MASC_NAMESPACE_TRUTH_SHELL_REFRESH_TIMEOUT_S','MASC_NAMESPACE_TRUTH_WARM_ESCAPE_S']:
    print(k, 'STILL EXPOSED' if k in envs else 'OK (removed)')"
# All 6: OK (removed)
```

Backend exposure is already clean — this PR closes the developer-facing `.mli` contract gap so the documentation matches reality.

## Changes

### `lib/server/server_dashboard_http_namespace_truth.ml`

Remove the 4-line dead helper:

```ocaml
let float_of_env_default_with_legacy ~canonical ~legacy ~default ~min_v ~max_v =
  match Sys.getenv_opt canonical with
  | Some _ -> float_of_env_default canonical ~default ~min_v ~max_v
  | None -> float_of_env_default legacy ~default ~min_v ~max_v
```

### `lib/server/server_dashboard_http_namespace_truth.mli`

Rewrite the env-var table as prose citing the RFC-0138 Step 4 retire decision and #16752, pointing readers to the module-level `namespace_truth_*_timeout_s` bindings for the current values. The `MASC_NAMESPACE_TRUTH_SHELL_REFRESH_TIMEOUT_S` reference at line 50 is similarly demoted to a `.ml` cross-reference.

## Verification

- `dune build @check` from worktree → exit 0
- `rg "MASC_NAMESPACE_TRUTH_" --type ocaml` after this PR → only past-tense closeout comments remain (e.g. `lib/server/server_bootstrap_loops.ml:1228`, `lib/dashboard/dashboard_snapshot.ml:95`, `lib/server/server_dashboard_snapshot_select.mli:103`, `lib/config/env_config_snapshot.ml:271`).  None claim active tunability.
- `rg "float_of_env_default_with_legacy" --type ocaml` after this PR → 0 hits.

## Workaround Rejection Bar self-check

- §1 텔레메트리-as-fix: not applicable, dead-code/dead-doc removal.
- §2 string classifier: none added.
- §3 N-of-M: this PR closes the two remaining sites left behind by #16752; verified no other surfaces exist across `.ml`/`.mli`/`.md`/`.toml`/`.yaml`/`.json`/`.ts`/`.tsx`.
- catch-all `_ ->`: none.
- cap/cooldown/dedup/repair: none.
- 7-check pass.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
