### PR TITLE
refactor(server): extract keeper_runtime_trace aggregate summary builders into sibling

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -499,92 +499,13 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
    Server_dashboard_http_keeper_api_types (intra-library file split,
    2026-05-16). *)
 
-let provider_attempts_summary_json scan =
-  let attempt_rows = queue_to_list scan.provider_attempt_rows in
-  let terminal = scan.provider_terminal_row in
-  let terminal_decision_string key =
-    Option.bind terminal (fun row ->
-      json_string_member_opt key row.Keeper_runtime_manifest.decision)
-  in
-  `Assoc
-    [
-      ("started_count", `Int scan.provider_started_count);
-      ("finished_count", `Int scan.provider_finished_count);
-      ( "terminal_status",
-        json_string_opt
-          (Option.map (fun row -> row.Keeper_runtime_manifest.status) terminal) );
-      ( "terminal_model_source",
-        json_string_opt (terminal_decision_string "model_source") );
-      ( "terminal_resolved_model_source",
-        json_string_opt (terminal_decision_string "resolved_model_source") );
-      ( "terminal_capability_source",
-        json_string_opt (terminal_decision_string "capability_source") );
-      ( "terminal_fallback_authority",
-        json_string_opt (terminal_decision_string "fallback_authority") );
-      ( "terminal_provider_source_cascade",
-        json_string_opt (terminal_decision_string "provider_source_cascade") );
-      ( "terminal_error",
-        json_string_opt (terminal_decision_string "error") );
-      ( "terminal_exception_kind",
-        json_string_opt (terminal_decision_string "exception_kind") );
-      ("attempts", `List (List.map provider_attempt_row_json attempt_rows));
-    ]
+let provider_attempts_summary_json =
+  Server_dashboard_http_keeper_api_summary_aggregates.provider_attempts_summary_json
+;;
 
-let turn_identity_summary_json ?turn_id scan receipts =
-  let manifest_keeper_turn_ids =
-    scan.keeper_turn_ids
-    |> List.rev
-    |> unique_ints
-  in
-  let receipt_turn_counts =
-    receipts
-    |> List.filter_map (json_int_member_opt "turn_count")
-    |> unique_ints
-  in
-  `Assoc
-    [
-      ( "requested_keeper_turn_id",
-        match turn_id with Some value -> `Int value | None -> `Null );
-      ("manifest_keeper_turn_ids", json_int_list manifest_keeper_turn_ids);
-      ("receipt_turn_counts", json_int_list receipt_turn_counts);
-      ("max_oas_turn_count", json_int_opt scan.max_oas_turn_count);
-      ( "provider_lane_resolved_count",
-        `Int
-          (runtime_manifest_scan_event_count scan
-             Keeper_runtime_manifest.Provider_lane_resolved) );
-      ( "provider_attempt_started_count",
-        `Int
-          (runtime_manifest_scan_event_count scan
-             Keeper_runtime_manifest.Provider_attempt_started) );
-      ( "provider_attempt_finished_count",
-        `Int
-          (runtime_manifest_scan_event_count scan
-             Keeper_runtime_manifest.Provider_attempt_finished) );
-      ( "checkpoint_saved_count",
-        `Int
-          (runtime_manifest_scan_event_count scan
-             Keeper_runtime_manifest.Checkpoint_saved) );
-      ( "event_bus_correlated_count",
-        `Int
-          (runtime_manifest_scan_event_count scan
-             Keeper_runtime_manifest.Event_bus_correlated) );
-      ( "memory_injected_count",
-        `Int
-          (runtime_manifest_scan_event_count scan
-             Keeper_runtime_manifest.Memory_injected) );
-      ( "memory_flushed_count",
-        `Int
-          (runtime_manifest_scan_event_count scan
-             Keeper_runtime_manifest.Memory_flushed) );
-      ( "receipt_appended_count",
-        `Int
-          (runtime_manifest_scan_event_count scan
-             Keeper_runtime_manifest.Receipt_appended) );
-      ( "turn_finished_count",
-        `Int
-          (runtime_manifest_scan_event_count scan
-             Keeper_runtime_manifest.Turn_finished) );
-    ]
+let turn_identity_summary_json =
+  Server_dashboard_http_keeper_api_summary_aggregates.turn_identity_summary_json
+;;
 
 let keeper_runtime_trace_json (config : Coord.config) (name : string)
     ?trace_id ?turn_id ?(limit = 200) ()

--- a/lib/server/server_dashboard_http_keeper_api_summary_aggregates.ml
+++ b/lib/server/server_dashboard_http_keeper_api_summary_aggregates.ml
@@ -1,0 +1,112 @@
+(* Aggregate summary JSON builders consumed by
+   [Server_dashboard_http_keeper_api.keeper_runtime_trace_json]:
+     - provider attempts terminal/list aggregation
+     - turn-identity counts derived from manifest scan + receipt rows
+
+   Pulled out of [server_dashboard_http_keeper_api.ml] to shrink the
+   godfile.  All inputs are typed values from sibling modules so there
+   is no shared state. *)
+
+open Server_dashboard_http_keeper_runtime_manifest_scan
+open Server_dashboard_http_keeper_api_types
+
+module Scan_summary = Server_dashboard_http_keeper_api_scan_summary
+
+let provider_attempts_summary_json (scan : runtime_manifest_scan) : Yojson.Safe.t =
+  let attempt_rows = queue_to_list scan.provider_attempt_rows in
+  let terminal = scan.provider_terminal_row in
+  let terminal_decision_string key =
+    Option.bind terminal (fun row ->
+      json_string_member_opt key row.Keeper_runtime_manifest.decision)
+  in
+  `Assoc
+    [ "started_count", `Int scan.provider_started_count
+    ; "finished_count", `Int scan.provider_finished_count
+    ; ( "terminal_status"
+      , json_string_opt
+          (Option.map (fun row -> row.Keeper_runtime_manifest.status) terminal) )
+    ; "terminal_model_source", json_string_opt (terminal_decision_string "model_source")
+    ; ( "terminal_resolved_model_source"
+      , json_string_opt (terminal_decision_string "resolved_model_source") )
+    ; ( "terminal_capability_source"
+      , json_string_opt (terminal_decision_string "capability_source") )
+    ; ( "terminal_fallback_authority"
+      , json_string_opt (terminal_decision_string "fallback_authority") )
+    ; ( "terminal_provider_source_cascade"
+      , json_string_opt (terminal_decision_string "provider_source_cascade") )
+    ; "terminal_error", json_string_opt (terminal_decision_string "error")
+    ; ( "terminal_exception_kind"
+      , json_string_opt (terminal_decision_string "exception_kind") )
+    ; "attempts", `List (List.map provider_attempt_row_json attempt_rows)
+    ]
+;;
+
+let turn_identity_summary_json
+      ?turn_id
+      (scan : runtime_manifest_scan)
+      (receipts : Yojson.Safe.t list)
+  : Yojson.Safe.t
+  =
+  let manifest_keeper_turn_ids =
+    scan.keeper_turn_ids |> List.rev |> Scan_summary.unique_ints
+  in
+  let receipt_turn_counts =
+    receipts
+    |> List.filter_map (json_int_member_opt "turn_count")
+    |> Scan_summary.unique_ints
+  in
+  `Assoc
+    [ ( "requested_keeper_turn_id"
+      , match turn_id with
+        | Some value -> `Int value
+        | None -> `Null )
+    ; "manifest_keeper_turn_ids", Scan_summary.json_int_list manifest_keeper_turn_ids
+    ; "receipt_turn_counts", Scan_summary.json_int_list receipt_turn_counts
+    ; "max_oas_turn_count", Scan_summary.json_int_opt scan.max_oas_turn_count
+    ; ( "provider_lane_resolved_count"
+      , `Int
+          (runtime_manifest_scan_event_count
+             scan
+             Keeper_runtime_manifest.Provider_lane_resolved) )
+    ; ( "provider_attempt_started_count"
+      , `Int
+          (runtime_manifest_scan_event_count
+             scan
+             Keeper_runtime_manifest.Provider_attempt_started) )
+    ; ( "provider_attempt_finished_count"
+      , `Int
+          (runtime_manifest_scan_event_count
+             scan
+             Keeper_runtime_manifest.Provider_attempt_finished) )
+    ; ( "checkpoint_saved_count"
+      , `Int
+          (runtime_manifest_scan_event_count
+             scan
+             Keeper_runtime_manifest.Checkpoint_saved) )
+    ; ( "event_bus_correlated_count"
+      , `Int
+          (runtime_manifest_scan_event_count
+             scan
+             Keeper_runtime_manifest.Event_bus_correlated) )
+    ; ( "memory_injected_count"
+      , `Int
+          (runtime_manifest_scan_event_count
+             scan
+             Keeper_runtime_manifest.Memory_injected) )
+    ; ( "memory_flushed_count"
+      , `Int
+          (runtime_manifest_scan_event_count
+             scan
+             Keeper_runtime_manifest.Memory_flushed) )
+    ; ( "receipt_appended_count"
+      , `Int
+          (runtime_manifest_scan_event_count
+             scan
+             Keeper_runtime_manifest.Receipt_appended) )
+    ; ( "turn_finished_count"
+      , `Int
+          (runtime_manifest_scan_event_count
+             scan
+             Keeper_runtime_manifest.Turn_finished) )
+    ]
+;;

--- a/lib/server/server_dashboard_http_keeper_api_summary_aggregates.mli
+++ b/lib/server/server_dashboard_http_keeper_api_summary_aggregates.mli
@@ -1,0 +1,12 @@
+(** Aggregate summary JSON builders consumed by
+    [Server_dashboard_http_keeper_api.keeper_runtime_trace_json]. *)
+
+val provider_attempts_summary_json
+  :  Server_dashboard_http_keeper_runtime_manifest_scan.runtime_manifest_scan
+  -> Yojson.Safe.t
+
+val turn_identity_summary_json
+  :  ?turn_id:int
+  -> Server_dashboard_http_keeper_runtime_manifest_scan.runtime_manifest_scan
+  -> Yojson.Safe.t list
+  -> Yojson.Safe.t


### PR DESCRIPTION
## 요약

`server_dashboard_http_keeper_api.ml` (1994 LoC, godfile top-3 server lib) 의 두 aggregate summary JSON builder 를 신규 sibling 모듈로 추출했습니다. **-79 LoC** (1994 → 1915).

PR #16794 (Scan_summary 추출) 의 후속.

## 추출 surface

| 함수 | 입력 | 출력 |
|---|---|---|
| `provider_attempts_summary_json` | `runtime_manifest_scan` | 11-field provider terminal/list aggregation |
| `turn_identity_summary_json` | `?turn_id, runtime_manifest_scan, receipts` | 13-field manifest-scan + receipt count aggregation |

## 신규 모듈

- `lib/server/server_dashboard_http_keeper_api_summary_aggregates.ml` (112 LoC)
- `lib/server/server_dashboard_http_keeper_api_summary_aggregates.mli` (12 LoC)

## 의존성 (전부 sibling/dep — godfile state 의존 0)

- `Server_dashboard_http_keeper_runtime_manifest_scan`: `runtime_manifest_scan`, `queue_to_list`, `runtime_manifest_scan_event_count`
- `Server_dashboard_http_keeper_api_types`: `provider_attempt_row_json`, `json_string_opt`, `json_string_member_opt`, `json_int_member_opt`
- `Server_dashboard_http_keeper_api_scan_summary` (PR #16794): `unique_ints`, `json_int_list`, `json_int_opt`
- `Keeper_runtime_manifest`: variant constructors

## 외부 caller 검증

```
$ rg -n "provider_attempts_summary_json|turn_identity_summary_json" lib/ test/ bin/
lib/server/.../server_dashboard_http_keeper_api.ml:691-692
  (only inside keeper_runtime_trace_json, this file's own consumer)
```

외부 caller 0. parent 내 thin alias 로 호환 유지:

```ocaml
let provider_attempts_summary_json =
  Server_dashboard_http_keeper_api_summary_aggregates.provider_attempts_summary_json
;;
let turn_identity_summary_json =
  Server_dashboard_http_keeper_api_summary_aggregates.turn_identity_summary_json
;;
```

## 검증

- [x] `dune build --root . lib/server` PASS
- [x] 외부 caller 0 (위 grep)
- [x] 함수 body 1-to-1 카피 (record field 명, variant ctor 명 동일)
- [x] alias 가 typed val 시그니처 만족

## 패턴

Pure JSON builders 추출 (PR #16794 와 동일). `Scan_summary` 가 receipt row + event count primitive 를 다루고, `Summary_aggregates` 가 그 위 surface 에서 cross-cutting aggregation (provider 11 field + turn-identity 13 field) 을 노출. 두 모듈 다 stateless / dependency-only.

## Workaround Rejection Bar self-check

1. [ ] makes X visible only — NO
2. [ ] string classifier — NO
3. [ ] N-of-M — NO (2 함수 전체 이동)
4. [ ] catch-all `_ ->` 추가 — NO
5. [ ] cap/cooldown/dedup/repair — NO
6. [ ] test backdoor — NO
7. [ ] N-사이트 typo — NO

PASS — pure refactor.

## RFC

RFC-WAIVED: `lib/server` non-credential refactor — RFC-gated subsystem 아님.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
