### PR TITLE
refactor(cascade_transport): extract MCP tool classifier into sibling module

### DIFF
--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -425,37 +425,28 @@ let cli_runtime_mcp_jsons
   dedupe_preserve_order (base @ request_json)
 ;;
 
-let public_mcp_tool_names_of_oas_tools (tools : Agent_sdk.Tool.t list) =
-  List.map (fun (tool : Agent_sdk.Tool.t) -> tool.schema.name) tools
+let public_mcp_tool_names_of_oas_tools =
+  Cascade_transport_mcp_tool_classifier.public_mcp_tool_names_of_oas_tools
 ;;
 
-let public_mcp_tools_of_oas_tools (tools : Agent_sdk.Tool.t list) =
-  List.filter
-    (fun (tool : Agent_sdk.Tool.t) -> Tool_catalog.is_public_mcp tool.schema.name)
-    tools
+let public_mcp_tools_of_oas_tools =
+  Cascade_transport_mcp_tool_classifier.public_mcp_tools_of_oas_tools
 ;;
 
-let tool_names_are_public_mcp (tool_names : string list) =
-  tool_names <> [] && List.for_all Tool_catalog.is_public_mcp tool_names
+let tool_names_are_public_mcp =
+  Cascade_transport_mcp_tool_classifier.tool_names_are_public_mcp
 ;;
 
-let runtime_mcp_tool_requires_bound_actor tool_name =
-  Tool_catalog.requires_actor_binding tool_name
+let runtime_mcp_tool_requires_bound_actor =
+  Cascade_transport_mcp_tool_classifier.runtime_mcp_tool_requires_bound_actor
 ;;
 
-let public_mcp_tool_requires_bound_actor tool_name =
-  Tool_catalog.is_public_mcp tool_name && runtime_mcp_tool_requires_bound_actor tool_name
+let public_mcp_tool_requires_bound_actor =
+  Cascade_transport_mcp_tool_classifier.public_mcp_tool_requires_bound_actor
 ;;
 
-let tool_names_are_runtime_mcp ?(allow_keeper_internal = false) (tool_names : string list)
-  =
-  tool_names <> []
-  && List.for_all
-       (fun tool_name ->
-          Tool_catalog.is_public_mcp tool_name
-          || (allow_keeper_internal
-              && Tool_catalog.is_on_surface Tool_catalog.Keeper_internal tool_name))
-       tool_names
+let tool_names_are_runtime_mcp =
+  Cascade_transport_mcp_tool_classifier.tool_names_are_runtime_mcp
 ;;
 
 let trim_nonempty_string raw =

--- a/lib/cascade/cascade_transport_mcp_tool_classifier.ml
+++ b/lib/cascade/cascade_transport_mcp_tool_classifier.ml
@@ -1,0 +1,38 @@
+(* MCP tool surface classification.
+
+   Pulled out of [cascade_transport.ml] to shrink the godfile. Pure
+   functions over Tool_catalog membership predicates - no shared state,
+   no I/O. *)
+
+let public_mcp_tool_names_of_oas_tools (tools : Agent_sdk.Tool.t list) =
+  List.map (fun (tool : Agent_sdk.Tool.t) -> tool.schema.name) tools
+;;
+
+let public_mcp_tools_of_oas_tools (tools : Agent_sdk.Tool.t list) =
+  List.filter
+    (fun (tool : Agent_sdk.Tool.t) -> Tool_catalog.is_public_mcp tool.schema.name)
+    tools
+;;
+
+let tool_names_are_public_mcp (tool_names : string list) =
+  tool_names <> [] && List.for_all Tool_catalog.is_public_mcp tool_names
+;;
+
+let runtime_mcp_tool_requires_bound_actor tool_name =
+  Tool_catalog.requires_actor_binding tool_name
+;;
+
+let public_mcp_tool_requires_bound_actor tool_name =
+  Tool_catalog.is_public_mcp tool_name && runtime_mcp_tool_requires_bound_actor tool_name
+;;
+
+let tool_names_are_runtime_mcp ?(allow_keeper_internal = false) (tool_names : string list)
+  =
+  tool_names <> []
+  && List.for_all
+       (fun tool_name ->
+          Tool_catalog.is_public_mcp tool_name
+          || (allow_keeper_internal
+              && Tool_catalog.is_on_surface Tool_catalog.Keeper_internal tool_name))
+       tool_names
+;;

--- a/lib/cascade/cascade_transport_mcp_tool_classifier.mli
+++ b/lib/cascade/cascade_transport_mcp_tool_classifier.mli
@@ -1,0 +1,14 @@
+(** MCP tool surface classification: which OAS tool names are exposed as
+    public MCP, which require bound-actor authentication, and which name
+    sets can be routed as runtime MCP. *)
+
+val public_mcp_tool_names_of_oas_tools : Agent_sdk.Tool.t list -> string list
+val public_mcp_tools_of_oas_tools : Agent_sdk.Tool.t list -> Agent_sdk.Tool.t list
+val tool_names_are_public_mcp : string list -> bool
+val runtime_mcp_tool_requires_bound_actor : string -> bool
+val public_mcp_tool_requires_bound_actor : string -> bool
+
+val tool_names_are_runtime_mcp
+  :  ?allow_keeper_internal:bool
+  -> string list
+  -> bool


### PR DESCRIPTION
## 요약

`cascade_transport.ml` (1678 LoC godfile) 의 6개 MCP tool surface 분류 함수를 신규 sibling 모듈로 추출했습니다. **-9 LoC** (1678 → 1669). LoC 감소는 작지만 thematic boundary 분리.

## 추출 surface (6 pure boolean classifiers)

| 함수 | 입력 | 출력 |
|---|---|---|
| `public_mcp_tool_names_of_oas_tools` | OAS tool list | name list |
| `public_mcp_tools_of_oas_tools` | OAS tool list | filtered tool list |
| `tool_names_are_public_mcp` | name list | bool |
| `runtime_mcp_tool_requires_bound_actor` | name | bool |
| `public_mcp_tool_requires_bound_actor` | name | bool |
| `tool_names_are_runtime_mcp` | `?allow_keeper_internal`, name list | bool |

## 신규 모듈

- `lib/cascade/cascade_transport_mcp_tool_classifier.ml` (38 LoC)
- `lib/cascade/cascade_transport_mcp_tool_classifier.mli` (14 LoC)

## 의존성 (전부 dependency module — godfile state 0)

- `Tool_catalog`: `is_public_mcp`, `requires_actor_binding`, `is_on_surface`, `Keeper_internal`
- `Agent_sdk.Tool.t`

Pure boolean functions — shared state 없음, side effect 없음.

## 외부 caller 호환

- `Cascade_runner` (line 163-186): `Cascade_transport.public_mcp_*` 형태로 re-export — parent thin alias 가 동일 surface 유지하므로 변경 0.
- `test/test_oas_worker.ml:3421`: `Cascade_runner.runtime_mcp_tool_requires_bound_actor` 사용 — 동일하게 영향 없음.

`cascade_transport.mli` 의 `val` 시그니처는 그대로 — public surface 변경 0.

## 검증

- [x] `dune build --root . lib/cascade` PASS
- [x] `cascade_transport.mli` line-diff = 0 (alias 만 변경)
- [x] 함수 body 1-to-1 카피

## 패턴

Pure helper extraction (PR #16794 Scan_summary, #16831 Summary_aggregates 와 동일). 이 PR 은 LoC reduction 보다 **thematic separation** 이 목적 — "MCP tool 분류" 는 cascade transport (provider/CLI/runtime orchestration) 의 책임이 아님.

## Workaround Rejection Bar self-check

1. [ ] makes X visible only — NO
2. [ ] string classifier — NO (existing function 이동만, 새 classifier 추가 없음)
3. [ ] N-of-M — NO (6 함수 모두 이동)
4. [ ] catch-all `_ ->` 추가 — NO
5. [ ] cap/cooldown/dedup/repair — NO
6. [ ] test backdoor — NO
7. [ ] N-사이트 typo — NO

PASS — pure refactor.

## RFC

RFC-WAIVED: `lib/cascade` non-credential refactor.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
