### PR TITLE
refactor(shell-ir): Phase 2 dedup — drop legacy splitters in tool_code_write + worker_dev_tools_command_syntax

### DIFF
--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -71,43 +71,24 @@ type code_shell_exit_status =
   | Shell_ok_expected_nonzero of string
   | Shell_error
 
-let first_token_basename segment =
-  let trimmed = String.trim segment in
-  if String.equal trimmed "" then None
-  else
-    let len = String.length trimmed in
-    let rec find_sep i =
-      if i >= len then len
-      else
-        match trimmed.[i] with
-        | ' ' | '\t' -> i
-        | _ -> find_sep (i + 1)
-    in
-    Some (Filename.basename (String.sub trimmed 0 (find_sep 0)))
+(* RFC-0131 Phase 2 (Shell IR Promotion Goal, 2026-05-18) — the local
+   string-splitter fallback ([first_token_basename] +
+   [last_pipeline_segment]) was the last in-module shell splitter in
+   [tool_code_write].  It existed to keep exit classification working
+   when [Shell_command_gate.parse] could not produce a typed AST.
 
-let last_pipeline_segment command =
-  let len = String.length command in
-  let last_start = ref 0 in
-  let in_single = ref false in
-  let in_double = ref false in
-  let escaped = ref false in
-  for i = 0 to len - 1 do
-    let c = command.[i] in
-    if !escaped then escaped := false
-    else
-      match c with
-      | '\\' when not !in_single -> escaped := true
-      | '\'' when not !in_double -> in_single := not !in_single
-      | '"' when not !in_single -> in_double := not !in_double
-      | '|' when (not !in_single) && not !in_double -> last_start := i + 1
-      | _ -> ()
-  done;
-  String.sub command !last_start (len - !last_start)
-
+   Phase 2 explicitly removes that fallback: the facade is the only
+   parse path.  When the parser cannot lift the command, the last-stage
+   binary name is genuinely unknown — we conservatively fall through to
+   [Shell_error] instead of silently re-deriving a name from a different
+   splitter.  This matches Phase 2's rule "이 PR 이후
+   lib/tool_code_write.ml 에는 shell splitter가 없어야 한다" and the
+   Plan's separation of parse / validation / exec / classify error
+   classes. *)
 let exit_status_command_name command =
   match Shell_command_gate.parse command with
   | Ok context -> Shell_command_gate.last_stage_bin context
-  | Error _ -> first_token_basename (last_pipeline_segment command)
+  | Error _ -> None
 
 let classify_code_shell_exit ~command code =
   match code with
@@ -116,7 +97,7 @@ let classify_code_shell_exit ~command code =
       match exit_status_command_name command with
       | Some ("rg" | "grep") -> Shell_ok_expected_nonzero "no_matches"
       | Some "diff" -> Shell_ok_expected_nonzero "differences"
-      | _ -> Shell_error)
+      | Some _ | None -> Shell_error)
   | _ -> Shell_error
 
 let git_common_root path =

--- a/lib/worker_dev_tools_command_syntax.ml
+++ b/lib/worker_dev_tools_command_syntax.ml
@@ -59,60 +59,15 @@ let has_process_substitution cmd =
   contains_substring cmd "<(" || contains_substring cmd ">("
 ;;
 
-type pipeline_quote_state = Pipeline_no_quote | Pipeline_single | Pipeline_double
-
-let split_pipeline_segments cmd =
-  let len = String.length cmd in
-  let buf = Buffer.create len in
-  let push_segment segments =
-    let segment = Buffer.contents buf |> String.trim in
-    Buffer.clear buf;
-    segment :: segments
-  in
-  let rec loop quote escaped i segments =
-    if i >= len
-    then List.rev (push_segment segments)
-    else if escaped
-    then (
-      Buffer.add_char buf cmd.[i];
-      loop quote false (i + 1) segments)
-    else
-      match quote, cmd.[i] with
-      | Pipeline_single, '\'' ->
-        Buffer.add_char buf cmd.[i];
-        loop Pipeline_no_quote false (i + 1) segments
-      | Pipeline_single, _ ->
-        Buffer.add_char buf cmd.[i];
-        loop quote false (i + 1) segments
-      | Pipeline_double, '"' ->
-        Buffer.add_char buf cmd.[i];
-        loop Pipeline_no_quote false (i + 1) segments
-      | Pipeline_double, '\\' ->
-        Buffer.add_char buf cmd.[i];
-        loop quote true (i + 1) segments
-      | Pipeline_double, _ ->
-        Buffer.add_char buf cmd.[i];
-        loop quote false (i + 1) segments
-      | Pipeline_no_quote, '\'' ->
-        Buffer.add_char buf cmd.[i];
-        loop Pipeline_single false (i + 1) segments
-      | Pipeline_no_quote, '"' ->
-        Buffer.add_char buf cmd.[i];
-        loop Pipeline_double false (i + 1) segments
-      | Pipeline_no_quote, '\\' ->
-        Buffer.add_char buf cmd.[i];
-        loop quote true (i + 1) segments
-      | Pipeline_no_quote, '|' ->
-        loop Pipeline_no_quote false (i + 1) (push_segment segments)
-      | Pipeline_no_quote, _ ->
-        Buffer.add_char buf cmd.[i];
-        loop quote false (i + 1) segments
-  in
-  let segments = loop Pipeline_no_quote false 0 [] in
-  if List.exists (fun segment -> segment = "") segments
-  then Error "Pipes must separate complete allowed commands."
-  else Ok segments
-;;
+(* RFC-0131 Phase 2 (Shell IR Promotion Goal, 2026-05-18) —
+   [split_pipeline_segments] and its [pipeline_quote_state] helper were
+   the legacy string-based pipeline splitter for the Coding/Full gate.
+   [validate_command_coding_with_allowlist] now consumes the typed
+   pipeline produced by [Shell_command_gate.parse], so this string
+   splitter has no remaining caller in lib/, test/, or bin/.  Per
+   Phase 2 dedup it is removed outright; reintroducing a non-AST
+   pipeline splitter is explicitly out-of-scope and must be replaced
+   by extending the facade. *)
 
 let split_shell_tokens cmd =
   String.split_on_char ' ' cmd

--- a/lib/worker_dev_tools_command_syntax.mli
+++ b/lib/worker_dev_tools_command_syntax.mli
@@ -5,7 +5,9 @@ val has_dangerous_ampersand : string -> bool
 val contains_forbidden_shell_chars_coding : string -> bool
 val contains_substring : string -> string -> bool
 val has_process_substitution : string -> bool
-val split_pipeline_segments : string -> (string list, string) result
+(* [split_pipeline_segments] removed by RFC-0131 Phase 2 (Shell IR
+   Promotion Goal, 2026-05-18).  The string-based pipeline splitter is
+   superseded by [Shell_command_gate.parse]; no caller remains. *)
 val split_shell_tokens : string -> string list
 val strip_wrapping_quotes : string -> string
 val basename_token : string -> string


### PR DESCRIPTION
## Summary

RFC-0131 Phase 2 (Shell IR Promotion Goal, `~/me/memory/shell-ir-promotion-goal-2026-05-18.html`) — Shell Command Gate facade dedup.

`lib/tool_code_write.ml` 와 `lib/worker_dev_tools_command_syntax.ml` 에 남아있던 마지막 string 기반 shell splitter 두 곳을 제거합니다. 파서는 이제 `Shell_command_gate.parse` 한 경로뿐입니다.

## 변경 파일 (LoC: +28 / -90, net **-62**)

| 파일 | 변경 |
|---|---|
| `lib/tool_code_write.ml` | `first_token_basename`, `last_pipeline_segment` 제거. `exit_status_command_name` 의 `Error _ -> first_token_basename (last_pipeline_segment command)` fallback → `Error _ -> None`. `classify_code_shell_exit` 의 마지막 arm 도 `Some _ \| None -> Shell_error` 로 명시. |
| `lib/worker_dev_tools_command_syntax.ml` | `pipeline_quote_state` type + `split_pipeline_segments` 함수 제거 (zero callers in lib/, test/, bin/). |
| `lib/worker_dev_tools_command_syntax.mli` | `val split_pipeline_segments` 제거. |

## H6 (dead-code) verification

```
$ rg -n "first_token_basename|last_pipeline_segment|split_pipeline_segments" lib/ test/ bin/
lib/tool_code_write.ml:75:   string-splitter fallback ([first_token_basename] +
lib/tool_code_write.ml:76:   [last_pipeline_segment]) was the last in-module shell splitter in
lib/worker_dev_tools_command_syntax.mli:8:(* [split_pipeline_segments] removed by RFC-0131 Phase 2 (Shell IR
lib/worker_dev_tools_command_syntax.ml:63:   [split_pipeline_segments] and its [pipeline_quote_state] helper were
```

남은 매치는 doc-comment 안 historical 인용뿐입니다.

## HTML Phase 2 처방 인용

> `lib/tool_code_write.ml`은 local `split_pipeline_segments`, `last_pipeline_command_name`, `classify_code_shell_exit`를 갖고 있다. 이 경로는 Shell gate context로 치환한다.
>
> - `allowed_shell_commands`는 policy input으로만 유지한다.
> - exit classification은 parsed last stage의 binary name 또는 structured execution result를 사용한다.
> - pipeline split 실패가 실행 실패로 섞이지 않도록 parse/validation/exec/classify error를 분리한다.
> - 이 PR 이후 `lib/tool_code_write.ml`에는 shell splitter가 없어야 한다.

(`~/me/memory/shell-ir-promotion-goal-2026-05-18.html` Phase 2 섹션)

## Behavior preservation

`test/test_tool_code_write_coverage.exe` — origin/main baseline 과 이 브랜치에서 **동일한 6 pre-existing failure** (모두 환경 의존 sandbox config 이슈, splitter 경로와 무관). 55/61 OK 양쪽 동일.

- `rg exit 1 no-match` PASS
- `grep exit 1 no-match` PASS
- `rg exit 2 remains error` PASS
- `rg quoted regex pipe no-match` 사전부터 FAIL (env)
- `pipeline grep exit 1 no-match` 사전부터 FAIL (env)

`dune build --root . @check`: clean.

## Workaround Rejection Bar self-check (CLAUDE.md §software-development.md)

- [ ] makes X visible / instrument Y (NO — removal, not telemetry)
- [ ] string/substring/prefix classifier added (NO — classifier *removed*)
- [ ] N of M sites (NO — both target sites covered)
- [ ] catch-all `_ ->` arm added (NO)
- [ ] cap/cooldown/dedup/repair (NO)
- [ ] test backdoor (NO)
- [ ] same typo fixed N times w/o codemod (NO)

이 PR 은 dedup-removal-only root-fix.

## RFC

- `docs/rfc/RFC-0131-shell-command-gate-facade.md` (Status: Draft) — §10 PR slicing 의 PR-3 (tool_code_write caller adoption) 과 정렬. RFC body §1 "What it does" 에 명시된 `tool_code_write.ml:106-107 parse + last_stage_bin (exit classifier)` 가 이미 main에 있고, 본 PR 은 그 옆의 legacy fallback splitter 만 제거.

Phase 3 (authority flag wiring), Phase 4 (native dispatch), Phase 5+ (broader legacy purge) 는 별도 PR.

## Test plan

- [ ] `dune build --root . @check` clean
- [ ] `dune exec --root . test/test_tool_code_write_coverage.exe` shows same 55/61 OK as baseline
- [ ] `rg "first_token_basename|last_pipeline_segment|split_pipeline_segments" lib/ test/ bin/` returns doc-comments only

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
