### PR TITLE
fix(http): tag accept/connection/flow-close error logs with [protocol host:port] listener identity

### DIFF
--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -720,6 +720,15 @@ let run ~sw ~net ~clock config routes =
       effective_host config.port config.host;
   Printf.printf "   Graceful shutdown: SIGTERM/SIGINT supported\n%!";
 
+  (* Stable listener identity. Embedded in every error log below so
+     operators can tell which listener emitted the line when the
+     process runs multiple HTTP servers (HTTP/1.1 here vs HTTP/2 in
+     http_server_h2.ml vs admin/health sub-servers). The protocol tag
+     "h1" mirrors the "h2" tag used by http_server_h2.ml. *)
+  let listener_tag =
+    Printf.sprintf "h1 %s:%d" effective_host config.port
+  in
+
   let initial_backoff_s = 0.05 in
   let max_backoff_s = 1.0 in
   let backoff_s = ref initial_backoff_s in
@@ -749,8 +758,8 @@ let run ~sw ~net ~clock config routes =
                try Eio.Flow.close flow with
                | Eio.Cancel.Cancelled _ as e -> raise e
                | exn ->
-                 Log.Http.warn "[http-eio] flow close failed: %s"
-                   (Printexc.to_string exn));
+                 Log.Http.warn "[%s] flow close failed: %s"
+                   listener_tag (Printexc.to_string exn));
              try
                Httpun_eio.Server.create_connection_handler
                  ~sw:conn_sw
@@ -761,12 +770,13 @@ let run ~sw ~net ~clock config routes =
              with
              | Eio.Cancel.Cancelled _ as e -> raise e
              | exn ->
-               Log.Http.error "Connection error: %s" (Printexc.to_string exn)))
+               Log.Http.error "[%s] connection error: %s"
+                 listener_tag (Printexc.to_string exn)))
        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
          if is_cancelled exn then raise exn;
          let delay = !backoff_s in
-         Log.Http.error "Accept error: %s (backoff %.2fs)"
-           (Printexc.to_string exn) delay;
+         Log.Http.error "[%s] accept error: %s (backoff %.2fs)"
+           listener_tag (Printexc.to_string exn) delay;
          Eio.Time.sleep clock delay;
          bump_backoff ());
       accept_loop ()
@@ -774,8 +784,8 @@ let run ~sw ~net ~clock config routes =
       if is_cancelled exn then ()
       else
         let delay = !backoff_s in
-        Log.Http.error "Accept loop error: %s (backoff %.2fs)"
-          (Printexc.to_string exn) delay;
+        Log.Http.error "[%s] accept loop error: %s (backoff %.2fs)"
+          listener_tag (Printexc.to_string exn) delay;
         Eio.Time.sleep clock delay;
         bump_backoff ();
         accept_loop ()

--- a/lib/http_server_h2.ml
+++ b/lib/http_server_h2.ml
@@ -267,6 +267,15 @@ let run ~sw ~net ~clock config request_handler =
   Printf.printf "MASC MCP Server (HTTP/2) listening on http://%s:%d\n" config.host config.port;
   Printf.printf "   HTTP/2 multiplexing: unlimited SSE streams per connection\n%!";
 
+  (* Stable listener identity. Embedded in every error log below so
+     operators can tell which listener emitted the line when the
+     process runs multiple HTTP servers (HTTP/2 here vs HTTP/1.1 in
+     http_server_eio.ml vs admin/health sub-servers). Mirrors the
+     "h1" listener_tag pattern in http_server_eio.ml. *)
+  let listener_tag =
+    Printf.sprintf "h2 %s:%d" config.host config.port
+  in
+
   let initial_backoff_s = 0.05 in
   let max_backoff_s = 1.0 in
   let backoff_s = ref initial_backoff_s in
@@ -289,7 +298,8 @@ let run ~sw ~net ~clock config request_handler =
               try Eio.Flow.close flow with
               | Eio.Cancel.Cancelled _ as e -> raise e
               | exn ->
-                Log.Misc.error "[h2] flow close failed: %s" (Printexc.to_string exn)
+                Log.Misc.error "[%s] flow close failed: %s"
+                  listener_tag (Printexc.to_string exn)
             );
             try
               H2_eio.Server.create_connection_handler
@@ -301,14 +311,15 @@ let run ~sw ~net ~clock config request_handler =
             with
             | Eio.Cancel.Cancelled _ as e -> raise e
             | exn ->
-              Log.Http.error "Connection error: %s" (Printexc.to_string exn)
+              Log.Http.error "[%s] connection error: %s"
+                listener_tag (Printexc.to_string exn)
           )
         )
       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
         if is_cancelled exn then raise exn;
         let delay = !backoff_s in
-        Log.Http.error "Accept error: %s (backoff %.2fs)"
-          (Printexc.to_string exn) delay;
+        Log.Http.error "[%s] accept error: %s (backoff %.2fs)"
+          listener_tag (Printexc.to_string exn) delay;
         Eio.Time.sleep clock delay;
         bump_backoff ());
       accept_loop ()
@@ -316,8 +327,8 @@ let run ~sw ~net ~clock config request_handler =
       if is_cancelled exn then ()
       else begin
         let delay = !backoff_s in
-        Log.Http.error "Accept loop error: %s (backoff %.2fs)"
-          (Printexc.to_string exn) delay;
+        Log.Http.error "[%s] accept loop error: %s (backoff %.2fs)"
+          listener_tag (Printexc.to_string exn) delay;
         Eio.Time.sleep clock delay;
         bump_backoff ();
         accept_loop ()


### PR DESCRIPTION
## 사용자 비전 직접 정합

> *\"Error 가 나는 케이스에 대해 사용자가 정말 구체적으로 알도록 개선하라\"*

본 PR 의 1차 동기는 *operator clarity* — HTTP listener 에서 error 가 났을 때 *어느 listener* 가 emit 했는지 즉시 알 수 있도록.

## Before

\`\`\`
[ERROR] Accept error: Unix.Unix_error(EMFILE, \"accept\", ...) (backoff 0.20s)
[ERROR] Connection error: <exn>
[ERROR] Accept loop error: <exn> (backoff 0.40s)
[WARN]  [http-eio] flow close failed: <exn>          # h1 partial tag
[ERROR] [h2] flow close failed: <exn>                # h2 partial tag, address 없음
\`\`\`

여러 HTTP listener (h1 + h2 + admin/health) 가 동일 프로세스에 있을 때 *어느 것* 의 에러인지 추적 불가. 기존 \`[h2]\` 같은 partial tag 도 bind address 가 없어서 *여러 h2 listener* 가 다른 포트에 있으면 동일 log.

## After

\`\`\`
[ERROR] [h1 0.0.0.0:8080] accept error: <exn> (backoff 0.20s)
[ERROR] [h2 0.0.0.0:8443] connection error: <exn>
[WARN]  [h1 0.0.0.0:8080] flow close failed: <exn>
\`\`\`

이제 operator 는:
- protocol identity (h1 vs h2) 한눈에
- bind host:port (멀티 listener 환경 분리 가능)
- log 라인 listener 별 grep/filter

## 구현

각 모듈이 startup 직후 stable \`listener_tag\` 한 번 계산, 모든 error/warn log 가 \`[%s]\` prefix 로 embed:

\`\`\`ocaml
(* http_server_eio.ml *)
let listener_tag = Printf.sprintf \"h1 %s:%d\" effective_host config.port

(* http_server_h2.ml *)
let listener_tag = Printf.sprintf \"h2 %s:%d\" config.host config.port
\`\`\`

\`MASC MCP Server listening on http://...\` startup banner 가 이미 operator 에게 같은 identity expose — 새 tag 는 그것과 일관됨.

| File | 사이트 |
|---|---|
| http_server_eio.ml | 4 ([h1 host:port]: flow close warn, connection error, accept error, accept loop error) |
| http_server_h2.ml | 4 ([h2 host:port]: 같은 셋, 기존 partial \"[h2]\" tag 를 full version 으로 교체) |

## Scope — Deferred candidates

다른 listener-context model 이라 본 PR 에서 제외:
- \`lib/server/server_bootstrap_http.ml\` — \`mode\` parameter (\"h1\"/\"h2\") + \`Transport_metrics.record_http_accept_error\` 사용. host:port 는 socket 에서 추출 필요. 같은 패턴 적용 가능하지만 metrics 까지 건드려서 diff 커짐.
- \`lib/voice/voice_bridge.ml\` — 별도 protocol layer 의 single \"Connection error\".

후속 iter 후보로 노트.

## 검증

- \`dune build --root . @check\` EXIT=0 clean
- \`test/test_compression.exe\` 15/15 PASS
- \`test/test_reqd_invalid_state_swallow.exe\` 1/1 PASS
- \`test/test_http_server_eio.exe\` 28/29 PASS — 1 **pre-existing** (default max_connections), \`git stash\` round-trip 으로 origin/main 에서도 동일 fail 확인
- \`test/test_http_server_eio_coverage.exe\` 14/15 PASS — 1 pre-existing (같은 default_config root)
- \`test/test_ci_hardening_source.exe\` 42/59 PASS — 17 pre-existing (source_guard contracts), 모두 origin/main 재현
- 19 failures 모두 pre-existing, 본 PR 무관

## Workaround Rejection Bar self-check

7/7 N/A:
1. ❌ telemetry-as-fix (real fix — embedded identity)
2. ❌ string classifier
3. ❌ N-of-M (8/8 atomic)
4. ❌ catch-all 추가
5. ❌ symptom 억제
6. ❌ test backdoor
7. ❌ 반복 typo

## Pattern continuation — operator-clarity sweep

| Iter | PR | 영역 |
|---|---|---|
| - | #16787 (머지) | cascade name silent-fallback WARN |
| #72 | #16824 Draft | keeper name validation context |
| #73 | #16825 Draft | protobuf type name in decode errors |
| **#74** | **이 PR Draft** | **HTTP listener identity in error logs** |

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>