### PR TITLE
refactor(board_core): extract board persistence paths into sibling module

### DIFF
--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -251,56 +251,17 @@ let maybe_sweep store =
 
 (** {1 Persistence Paths} *)
 
-let board_base_path () = Env_config_core.base_path ()
-
-let board_masc_dir () =
-  Coord_utils.masc_root_dir_from
-    ~base_path:(board_base_path ())
-    ~cluster_name:(Env_config_core.cluster_name ())
-;;
-
-let persist_path () = Filename.concat (board_masc_dir ()) "board_posts.jsonl"
-let comments_path () = Filename.concat (board_masc_dir ()) "board_comments.jsonl"
-let reactions_path () = Filename.concat (board_masc_dir ()) "board_reactions.jsonl"
-let sub_boards_path () = Filename.concat (board_masc_dir ()) "board_sub_boards.jsonl"
-
-let ensure_dir path =
-  if String.equal path "" || String.equal path "." || String.equal path "/"
-  then ()
-  else Fs_compat.mkdir_p path
-;;
-
-let ensure_masc_dir () =
-  let base = board_base_path () in
-  let dir = board_masc_dir () in
-  ensure_dir base;
-  ensure_dir dir
-;;
-
-(** {1 JSONL File Rotation} *)
-
-(** Max JSONL file size before rotation (10 MB).
-    Prevents unbounded disk growth from agent feedback loops. *)
-let max_jsonl_bytes = 10 * 1024 * 1024
-
-(** Rotate a JSONL file if it exceeds [max_jsonl_bytes].
-    Keeps one backup (.1) and truncates the active file.
-    Safe: uses rename (atomic on same filesystem). *)
-let rotate_if_needed path =
-  try
-    let st = Unix.stat path in
-    if st.Unix.st_size > max_jsonl_bytes
-    then (
-      let backup = path ^ ".1" in
-      (try Sys.rename backup (path ^ ".2") with
-       | Sys_error _ -> ());
-      Sys.rename path backup;
-      Log.BoardLog.info "rotated %s (was %d bytes)" path st.Unix.st_size)
-  with
-  | Unix.Unix_error (e, fn, arg) ->
-    Log.BoardLog.warn "rotate error: %s(%s): %s" fn arg (Unix.error_message e)
-  | Sys_error msg -> Log.BoardLog.warn "rotate error: %s" msg
-;;
+(* Paths + JSONL rotation extracted to [Board_paths] (godfile decomp). *)
+let board_base_path = Board_paths.board_base_path
+let board_masc_dir = Board_paths.board_masc_dir
+let persist_path = Board_paths.persist_path
+let comments_path = Board_paths.comments_path
+let reactions_path = Board_paths.reactions_path
+let sub_boards_path = Board_paths.sub_boards_path
+let ensure_dir = Board_paths.ensure_dir
+let ensure_masc_dir = Board_paths.ensure_masc_dir
+let max_jsonl_bytes = Board_paths.max_jsonl_bytes
+let rotate_if_needed = Board_paths.rotate_if_needed
 
 include Board_core_json
 

--- a/lib/board_paths.ml
+++ b/lib/board_paths.ml
@@ -1,0 +1,53 @@
+(* Board persistence path resolvers and JSONL rotation policy.
+
+   Extracted from [Board_core] to shrink the godfile. Pure
+   path-string + filesystem-side-effect helpers. *)
+
+let board_base_path () = Env_config_core.base_path ()
+
+let board_masc_dir () =
+  Coord_utils.masc_root_dir_from
+    ~base_path:(board_base_path ())
+    ~cluster_name:(Env_config_core.cluster_name ())
+;;
+
+let persist_path () = Filename.concat (board_masc_dir ()) "board_posts.jsonl"
+let comments_path () = Filename.concat (board_masc_dir ()) "board_comments.jsonl"
+let reactions_path () = Filename.concat (board_masc_dir ()) "board_reactions.jsonl"
+let sub_boards_path () = Filename.concat (board_masc_dir ()) "board_sub_boards.jsonl"
+
+let ensure_dir path =
+  if String.equal path "" || String.equal path "." || String.equal path "/"
+  then ()
+  else Fs_compat.mkdir_p path
+;;
+
+let ensure_masc_dir () =
+  let base = board_base_path () in
+  let dir = board_masc_dir () in
+  ensure_dir base;
+  ensure_dir dir
+;;
+
+(** Max JSONL file size before rotation (10 MB).
+    Prevents unbounded disk growth from agent feedback loops. *)
+let max_jsonl_bytes = 10 * 1024 * 1024
+
+(** Rotate a JSONL file if it exceeds [max_jsonl_bytes].
+    Keeps one backup (.1) and truncates the active file.
+    Safe: uses rename (atomic on same filesystem). *)
+let rotate_if_needed path =
+  try
+    let st = Unix.stat path in
+    if st.Unix.st_size > max_jsonl_bytes
+    then (
+      let backup = path ^ ".1" in
+      (try Sys.rename backup (path ^ ".2") with
+       | Sys_error _ -> ());
+      Sys.rename path backup;
+      Log.BoardLog.info "rotated %s (was %d bytes)" path st.Unix.st_size)
+  with
+  | Unix.Unix_error (e, fn, arg) ->
+    Log.BoardLog.warn "rotate error: %s(%s): %s" fn arg (Unix.error_message e)
+  | Sys_error msg -> Log.BoardLog.warn "rotate error: %s" msg
+;;

--- a/lib/board_paths.mli
+++ b/lib/board_paths.mli
@@ -1,0 +1,16 @@
+(** Board persistence paths and JSONL rotation policy.
+
+    All paths are derived from [Env_config_core.base_path] +
+    [Env_config_core.cluster_name] via [Coord_utils.masc_root_dir_from],
+    so they reflect the active cluster at call time. *)
+
+val board_base_path : unit -> string
+val board_masc_dir : unit -> string
+val persist_path : unit -> string
+val comments_path : unit -> string
+val reactions_path : unit -> string
+val sub_boards_path : unit -> string
+val ensure_dir : string -> unit
+val ensure_masc_dir : unit -> unit
+val max_jsonl_bytes : int
+val rotate_if_needed : string -> unit


### PR DESCRIPTION
## 요약

`board_core.ml` (1589 LoC) 의 path resolver + JSONL rotation 클러스터를 신규 sibling 모듈로 추출했습니다. **-39 LoC** (1589 → 1550).

PR #16792 (Board_comment_rate_limit) 의 후속.

## 추출 surface (8 함수 + 1 상수)

| 분류 | 항목 |
|---|---|
| Path resolvers | `board_base_path`, `board_masc_dir`, `persist_path`, `comments_path`, `reactions_path`, `sub_boards_path` |
| Directory mgmt | `ensure_dir`, `ensure_masc_dir` |
| JSONL rotation | `max_jsonl_bytes` (10MB), `rotate_if_needed` |

## 신규 모듈

- `lib/board_paths.ml` (53 LoC)
- `lib/board_paths.mli` (16 LoC)

## 의존성 (전부 dependency module)

- `Env_config_core.base_path`, `Env_config_core.cluster_name`
- `Coord_utils.masc_root_dir_from`
- `Filename.concat`, `Fs_compat.mkdir_p`
- `Unix.stat`, `Sys.rename`
- `Log.BoardLog`

Shared state 0. Side effect 는 filesystem mkdir/rename + log line.

## 외부 caller 호환

- `Board` (lib/board.ml) `include Board_votes` → `Board_votes` `include Board_core` 체인을 통해 `Board.persist_path` 등 외부 caller (test/test_board_karma_ledger:300-303, test/test_board_dispatch:30/960) 모두 호환.
- parent thin alias 가 모든 surface 유지.

## 검증

- [x] `dune build --root . lib` PASS
- [x] board.mli 변경 0 (include chain auto-propagation)
- [x] 함수 body 1-to-1 카피

## 패턴

Pure helper extraction (PR #16832 cascade_transport_mcp_tool_classifier 와 동일). "path resolution + file rotation" 은 board state machine (post/comment/reaction CRUD) 의 책임이 아닌 별도 thematic concern.

## Workaround Rejection Bar self-check

1. [ ] makes X visible only — NO
2. [ ] string classifier — NO
3. [ ] N-of-M — NO (path 관련 surface 전체 이동)
4. [ ] catch-all `_ ->` 추가 — NO
5. [ ] cap/cooldown/dedup/repair — NO
6. [ ] test backdoor — NO
7. [ ] N-사이트 typo — NO

PASS — pure refactor.

## RFC

RFC-WAIVED: lib/board_core 는 RFC-gated subsystem 아님.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
