### PR TITLE
refactor(keeper_shell_bash): extract gh-pr native-tool routing hints into sibling

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -24,82 +24,18 @@ let elapsed_duration_ms ~start_time ~end_time =
 let string_contains_char s ch = String.exists (Char.equal ch) s
 let string_contains_substring s needle = String_util.contains_substring s needle
 
-type native_tool_hint = {
-  rule_id : string;
-  tool_suggestion : string;
-  rewrite : string;
-  hint : string;
-  alternatives : string list;
-}
-
-let gh_pr_native_tool_hint cmd =
-  let make ~rule_id ~tool_suggestion ~rewrite ~hint ~alternatives =
-    Some { rule_id; tool_suggestion; rewrite; hint; alternatives }
-  in
-  match cmd_gh_pr_native_subcommand cmd with
-  | Some Gh_pr_list ->
-    make
-      ~rule_id:"gh_pr_list_requires_keeper_pr_list"
-      ~tool_suggestion:"keeper_pr_list"
-      ~rewrite:"Use keeper_pr_list with the same repo/state/search intent."
-      ~hint:
-        "Do not call gh pr list through keeper_bash. Use keeper_pr_list so PR \
-         reads are routed through the native PR tool surface."
-      ~alternatives:
-        [ "keeper_pr_list repo=OWNER/REPO state=open"
-        ; "keeper_pr_list repo=OWNER/REPO search=term"
-        ]
-  | Some Gh_pr_status ->
-    make
-      ~rule_id:"gh_pr_status_requires_keeper_pr_status"
-      ~tool_suggestion:"keeper_pr_status"
-      ~rewrite:"Use keeper_pr_status for PR state, checks, draft state, and mergeability."
-      ~hint:
-        "Do not call gh pr view/status/checks through keeper_bash. Use \
-         keeper_pr_status so PR status reads are captured by the native PR \
-         receipt path."
-      ~alternatives:
-        [ "keeper_pr_status pr=NUMBER repo=OWNER/REPO"
-        ; "keeper_pr_status head=BRANCH repo=OWNER/REPO"
-        ]
-  | Some Gh_pr_diff ->
-    make
-      ~rule_id:"gh_pr_diff_requires_keeper_pr_review_read"
-      ~tool_suggestion:"keeper_pr_review_read"
-      ~rewrite:"Use keeper_pr_review_read for PR diff/review context reads."
-      ~hint:
-        "Do not call gh pr diff through keeper_bash. Use \
-         keeper_pr_review_read so review context is read through the PR review \
-         tool surface."
-      ~alternatives:
-        [ "keeper_pr_review_read pr=NUMBER repo=OWNER/REPO"
-        ; "keeper_pr_status pr=NUMBER repo=OWNER/REPO"
-        ]
-  | Some Gh_pr_review ->
-    make
-      ~rule_id:"gh_pr_review_requires_keeper_pr_review_comment"
-      ~tool_suggestion:"keeper_pr_review_comment"
-      ~rewrite:"Use keeper_pr_review_comment for PR review comments or review actions."
-      ~hint:
-        "Do not call gh pr review/comment through keeper_bash. Use \
-         keeper_pr_review_comment so review actions keep approval and audit \
-         receipts."
-      ~alternatives:
-        [ "keeper_pr_review_comment pr=NUMBER repo=OWNER/REPO body=..."
-        ; "keeper_pr_review_read pr=NUMBER repo=OWNER/REPO"
-        ]
-  | None -> None
-;;
-
-let native_tool_diagnosis hint =
-  { Exec_core.rule_id = hint.rule_id
-  ; explanation =
-      "Raw GitHub PR commands are blocked in keeper_bash; the native PR tool \
-       surface preserves routing, audit, and retry receipts."
-  ; rewrite = Some hint.rewrite
-  ; tool_suggestion = Some hint.tool_suggestion
+(* gh-pr native-tool routing hints extracted to
+   [Keeper_shell_bash_native_tool_hint] (godfile decomp). *)
+type native_tool_hint = Keeper_shell_bash_native_tool_hint.native_tool_hint =
+  { rule_id : string
+  ; tool_suggestion : string
+  ; rewrite : string
+  ; hint : string
+  ; alternatives : string list
   }
-;;
+
+let gh_pr_native_tool_hint = Keeper_shell_bash_native_tool_hint.gh_pr_native_tool_hint
+let native_tool_diagnosis = Keeper_shell_bash_native_tool_hint.native_tool_diagnosis
 
 (* Repo-wide scan detection extracted to [Keeper_shell_bash_repo_wide_scan]
    (godfile decomp). The two predicates referenced below are aliased so

--- a/lib/keeper/keeper_shell_bash_native_tool_hint.ml
+++ b/lib/keeper/keeper_shell_bash_native_tool_hint.ml
@@ -1,0 +1,88 @@
+(* gh-pr native-tool routing hints for keeper_bash.
+
+   When a [gh pr <list|status|diff|review>] command would be accepted
+   by keeper_bash, surface the corresponding keeper_pr_* native tool
+   suggestion so the PR action keeps its native-tool receipt path
+   (audit/approval/retry).
+
+   Extracted from [Keeper_shell_bash] (godfile decomp). Pure mapping
+   over [Keeper_shell_bash_words.cmd_gh_pr_native_subcommand]. *)
+
+open Keeper_shell_bash_words
+
+type native_tool_hint =
+  { rule_id : string
+  ; tool_suggestion : string
+  ; rewrite : string
+  ; hint : string
+  ; alternatives : string list
+  }
+
+let gh_pr_native_tool_hint cmd =
+  let make ~rule_id ~tool_suggestion ~rewrite ~hint ~alternatives =
+    Some { rule_id; tool_suggestion; rewrite; hint; alternatives }
+  in
+  match cmd_gh_pr_native_subcommand cmd with
+  | Some Gh_pr_list ->
+    make
+      ~rule_id:"gh_pr_list_requires_keeper_pr_list"
+      ~tool_suggestion:"keeper_pr_list"
+      ~rewrite:"Use keeper_pr_list with the same repo/state/search intent."
+      ~hint:
+        "Do not call gh pr list through keeper_bash. Use keeper_pr_list so PR \
+         reads are routed through the native PR tool surface."
+      ~alternatives:
+        [ "keeper_pr_list repo=OWNER/REPO state=open"
+        ; "keeper_pr_list repo=OWNER/REPO search=term"
+        ]
+  | Some Gh_pr_status ->
+    make
+      ~rule_id:"gh_pr_status_requires_keeper_pr_status"
+      ~tool_suggestion:"keeper_pr_status"
+      ~rewrite:"Use keeper_pr_status for PR state, checks, draft state, and mergeability."
+      ~hint:
+        "Do not call gh pr view/status/checks through keeper_bash. Use \
+         keeper_pr_status so PR status reads are captured by the native PR \
+         receipt path."
+      ~alternatives:
+        [ "keeper_pr_status pr=NUMBER repo=OWNER/REPO"
+        ; "keeper_pr_status head=BRANCH repo=OWNER/REPO"
+        ]
+  | Some Gh_pr_diff ->
+    make
+      ~rule_id:"gh_pr_diff_requires_keeper_pr_review_read"
+      ~tool_suggestion:"keeper_pr_review_read"
+      ~rewrite:"Use keeper_pr_review_read for PR diff/review context reads."
+      ~hint:
+        "Do not call gh pr diff through keeper_bash. Use \
+         keeper_pr_review_read so review context is read through the PR review \
+         tool surface."
+      ~alternatives:
+        [ "keeper_pr_review_read pr=NUMBER repo=OWNER/REPO"
+        ; "keeper_pr_status pr=NUMBER repo=OWNER/REPO"
+        ]
+  | Some Gh_pr_review ->
+    make
+      ~rule_id:"gh_pr_review_requires_keeper_pr_review_comment"
+      ~tool_suggestion:"keeper_pr_review_comment"
+      ~rewrite:"Use keeper_pr_review_comment for PR review comments or review actions."
+      ~hint:
+        "Do not call gh pr review/comment through keeper_bash. Use \
+         keeper_pr_review_comment so review actions keep approval and audit \
+         receipts."
+      ~alternatives:
+        [ "keeper_pr_review_comment pr=NUMBER repo=OWNER/REPO body=..."
+        ; "keeper_pr_review_read pr=NUMBER repo=OWNER/REPO"
+        ]
+  | None -> None
+;;
+
+let native_tool_diagnosis hint =
+  { Exec_core.rule_id = hint.rule_id
+  ; explanation =
+      "Raw GitHub PR commands are blocked in keeper_bash; the native PR tool \
+       surface preserves routing, audit, and retry receipts."
+  ; rewrite = Some hint.rewrite
+  ; tool_suggestion = Some hint.tool_suggestion
+  }
+;;

--- a/lib/keeper/keeper_shell_bash_native_tool_hint.mli
+++ b/lib/keeper/keeper_shell_bash_native_tool_hint.mli
@@ -1,0 +1,17 @@
+(** gh-pr native-tool routing hints for keeper_bash. *)
+
+type native_tool_hint =
+  { rule_id : string
+  ; tool_suggestion : string
+  ; rewrite : string
+  ; hint : string
+  ; alternatives : string list
+  }
+
+(** Map a raw shell command to the corresponding keeper_pr_* tool
+    suggestion when it would otherwise call [gh pr <subcommand>]
+    directly. Returns [None] for commands outside the gh-pr surface. *)
+val gh_pr_native_tool_hint : string -> native_tool_hint option
+
+(** Wrap a [native_tool_hint] into the [Exec_core] diagnostic record. *)
+val native_tool_diagnosis : native_tool_hint -> Exec_core.diagnosis


### PR DESCRIPTION
## 요약

`keeper_shell_bash.ml` (2050 LoC godfile) 의 gh-pr native-tool routing hint cluster 를 신규 sibling 모듈로 추출했습니다. **-64 LoC** (2050 → 1986).

PR #16758 (Repo_wide_scan) 의 후속 — keeper_shell_bash 두번째 분해.

## 추출 surface

| 항목 | 시그니처 |
|---|---|
| `type native_tool_hint` | `{ rule_id; tool_suggestion; rewrite; hint; alternatives }` record |
| `gh_pr_native_tool_hint` | `string -> native_tool_hint option` |
| `native_tool_diagnosis` | `native_tool_hint -> Exec_core.diagnosis` |

## 신규 모듈

- `lib/keeper/keeper_shell_bash_native_tool_hint.ml` (88 LoC)
- `lib/keeper/keeper_shell_bash_native_tool_hint.mli` (17 LoC)

## 의존성 (전부 dependency module)

- `Keeper_shell_bash_words`: `cmd_gh_pr_native_subcommand`, `Gh_pr_list`/`Status`/`Diff`/`Review` variants
- `Exec_core.diagnosis` record type

Shared state 0. Side effect 0 (pure mapping).

## 외부 caller 검증

```
$ rg "gh_pr_native_tool_hint|native_tool_diagnosis|native_tool_hint" \
    lib/ test/ bin/ | grep -v keeper_shell_bash.ml
(no output)
```

모든 4 caller site 가 parent 내부. parent thin alias 로 호환 유지:

```ocaml
type native_tool_hint = Keeper_shell_bash_native_tool_hint.native_tool_hint = { ... }
let gh_pr_native_tool_hint = Keeper_shell_bash_native_tool_hint.gh_pr_native_tool_hint
let native_tool_diagnosis = Keeper_shell_bash_native_tool_hint.native_tool_diagnosis
```

## 검증

- [x] `dune build --root . lib/keeper` PASS
- [x] transparent record alias — caller signature 변경 0
- [x] 4 caller site 모두 parent (내부 호환)

## 패턴

Transparent type alias re-export (PR #16770 keeper_heartbeat_stimulus_intake 와 유사). gh-pr surface routing hint 는 keeper_bash command validation 의 *부속 책임* (native tool 권장 메시지) — bash parsing/policy 본체 책임 아님.

## Workaround Rejection Bar self-check

1. [ ] makes X visible only — NO
2. [ ] string classifier — NO (existing 4 분기 이동만)
3. [ ] N-of-M — NO (전체 cluster 이동)
4. [ ] catch-all `_ ->` 추가 — NO (existing `None -> None` 유지)
5. [ ] cap/cooldown/dedup/repair — NO
6. [ ] test backdoor — NO
7. [ ] N-사이트 typo — NO

PASS — pure refactor.

## RFC

RFC-WAIVED: routing hint 는 native tool 권장 message produce 만 — credential/auth 처리 부재. `keeper_shell_bash_*` 는 RFC-gated subsystem 목록 (credential_*, keeper_gh_*, host_config_*, operator_control*, hooks, workflow*) 에 없음.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
