### PR TITLE
refactor(cascade_transport): extract CLI argv UTF-8 sanitization into sibling

### DIFF
--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -1433,59 +1433,22 @@ let make_per_call_switch_transport
   }
 ;;
 
+(* CLI argv UTF-8 sanitization extracted to
+   [Cascade_transport_cli_argv_sanitize] (godfile decomp). *)
 let sanitize_runtime_mcp_server_for_cli =
-  let sanitize = Inference_utils.sanitize_text_utf8 in
-  function
-  | Llm_provider.Llm_transport.Stdio_server { name; command; args; env } ->
-    Llm_provider.Llm_transport.Stdio_server
-      { name = sanitize name
-      ; command = sanitize command
-      ; args = List.map sanitize args
-      ; env = List.map (fun (key, value) -> sanitize key, sanitize value) env
-      }
-  | Llm_provider.Llm_transport.Http_server { name; url; headers } ->
-    Llm_provider.Llm_transport.Http_server
-      { name = sanitize name
-      ; url = sanitize url
-      ; headers = List.map (fun (key, value) -> sanitize key, sanitize value) headers
-      }
+  Cascade_transport_cli_argv_sanitize.sanitize_runtime_mcp_server_for_cli
 ;;
 
-let sanitize_runtime_mcp_policy_for_cli
-      (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
-  =
-  let sanitize = Inference_utils.sanitize_text_utf8 in
-  { policy with
-    servers = List.map sanitize_runtime_mcp_server_for_cli policy.servers
-  ; allowed_server_names = List.map sanitize policy.allowed_server_names
-  ; allowed_tool_names = List.map sanitize policy.allowed_tool_names
-  ; permission_mode = Option.map sanitize policy.permission_mode
-  ; approval_mode = Option.map sanitize policy.approval_mode
-  }
+let sanitize_runtime_mcp_policy_for_cli =
+  Cascade_transport_cli_argv_sanitize.sanitize_runtime_mcp_policy_for_cli
 ;;
 
-let sanitize_cli_completion_request_for_argv
-      (req : Llm_provider.Llm_transport.completion_request)
-  =
-  { req with
-    config =
-      { req.config with
-        system_prompt =
-          Option.map Inference_utils.sanitize_text_utf8 req.config.system_prompt
-      }
-  ; messages = Inference_utils.sanitize_messages_utf8 req.messages
-  ; runtime_mcp_policy =
-      Option.map sanitize_runtime_mcp_policy_for_cli req.runtime_mcp_policy
-  }
+let sanitize_cli_completion_request_for_argv =
+  Cascade_transport_cli_argv_sanitize.sanitize_cli_completion_request_for_argv
 ;;
 
-let make_cli_argv_sanitizing_transport (transport : Llm_provider.Llm_transport.t) =
-  { Llm_provider.Llm_transport.complete_sync =
-      (fun req -> transport.complete_sync (sanitize_cli_completion_request_for_argv req))
-  ; complete_stream =
-      (fun ?on_telemetry:_ ~on_event req ->
-        transport.complete_stream ~on_event (sanitize_cli_completion_request_for_argv req))
-  }
+let make_cli_argv_sanitizing_transport =
+  Cascade_transport_cli_argv_sanitize.make_cli_argv_sanitizing_transport
 ;;
 
 (** Registry of non-HTTP transport constructors keyed by provider kind.

--- a/lib/cascade/cascade_transport_cli_argv_sanitize.ml
+++ b/lib/cascade/cascade_transport_cli_argv_sanitize.ml
@@ -1,0 +1,64 @@
+(* UTF-8 argv sanitization for CLI-driven LLM transports.
+
+   CLI-bound providers (codex, claude_code, gemini, json-stream variants)
+   cannot accept invalid UTF-8 in argv/env/payload without misbehaving;
+   this layer scrubs strings through [Inference_utils.sanitize_text_utf8]
+   before they cross the transport boundary.
+
+   Extracted from [Cascade_transport] (godfile decomp). All functions
+   are pure mappings over [Llm_provider.Llm_transport] values. *)
+
+let sanitize_runtime_mcp_server_for_cli =
+  let sanitize = Inference_utils.sanitize_text_utf8 in
+  function
+  | Llm_provider.Llm_transport.Stdio_server { name; command; args; env } ->
+    Llm_provider.Llm_transport.Stdio_server
+      { name = sanitize name
+      ; command = sanitize command
+      ; args = List.map sanitize args
+      ; env = List.map (fun (key, value) -> sanitize key, sanitize value) env
+      }
+  | Llm_provider.Llm_transport.Http_server { name; url; headers } ->
+    Llm_provider.Llm_transport.Http_server
+      { name = sanitize name
+      ; url = sanitize url
+      ; headers = List.map (fun (key, value) -> sanitize key, sanitize value) headers
+      }
+;;
+
+let sanitize_runtime_mcp_policy_for_cli
+      (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
+  =
+  let sanitize = Inference_utils.sanitize_text_utf8 in
+  { policy with
+    servers = List.map sanitize_runtime_mcp_server_for_cli policy.servers
+  ; allowed_server_names = List.map sanitize policy.allowed_server_names
+  ; allowed_tool_names = List.map sanitize policy.allowed_tool_names
+  ; permission_mode = Option.map sanitize policy.permission_mode
+  ; approval_mode = Option.map sanitize policy.approval_mode
+  }
+;;
+
+let sanitize_cli_completion_request_for_argv
+      (req : Llm_provider.Llm_transport.completion_request)
+  =
+  { req with
+    config =
+      { req.config with
+        system_prompt =
+          Option.map Inference_utils.sanitize_text_utf8 req.config.system_prompt
+      }
+  ; messages = Inference_utils.sanitize_messages_utf8 req.messages
+  ; runtime_mcp_policy =
+      Option.map sanitize_runtime_mcp_policy_for_cli req.runtime_mcp_policy
+  }
+;;
+
+let make_cli_argv_sanitizing_transport (transport : Llm_provider.Llm_transport.t) =
+  { Llm_provider.Llm_transport.complete_sync =
+      (fun req -> transport.complete_sync (sanitize_cli_completion_request_for_argv req))
+  ; complete_stream =
+      (fun ?on_telemetry:_ ~on_event req ->
+         transport.complete_stream ~on_event (sanitize_cli_completion_request_for_argv req))
+  }
+;;

--- a/lib/cascade/cascade_transport_cli_argv_sanitize.mli
+++ b/lib/cascade/cascade_transport_cli_argv_sanitize.mli
@@ -1,0 +1,21 @@
+(** UTF-8 argv sanitization for CLI-driven LLM transports.
+
+    CLI providers reject invalid UTF-8 in argv/env/payloads; these
+    helpers scrub strings through [Inference_utils.sanitize_text_utf8]
+    before the request crosses the transport boundary. *)
+
+val sanitize_runtime_mcp_server_for_cli
+  :  Llm_provider.Llm_transport.runtime_mcp_server
+  -> Llm_provider.Llm_transport.runtime_mcp_server
+
+val sanitize_runtime_mcp_policy_for_cli
+  :  Llm_provider.Llm_transport.runtime_mcp_policy
+  -> Llm_provider.Llm_transport.runtime_mcp_policy
+
+val sanitize_cli_completion_request_for_argv
+  :  Llm_provider.Llm_transport.completion_request
+  -> Llm_provider.Llm_transport.completion_request
+
+val make_cli_argv_sanitizing_transport
+  :  Llm_provider.Llm_transport.t
+  -> Llm_provider.Llm_transport.t


### PR DESCRIPTION
## 요약

`cascade_transport.ml` (1669 LoC post-#16832) 의 CLI argv UTF-8 sanitization cluster 를 신규 sibling 모듈로 추출했습니다. **-28 LoC** (1669 → 1641).

## 추출 surface (4 pure mappings)

| 함수 | 입력 → 출력 |
|---|---|
| `sanitize_runtime_mcp_server_for_cli` | `runtime_mcp_server` → 동형 (UTF-8 scrubbed) |
| `sanitize_runtime_mcp_policy_for_cli` | `runtime_mcp_policy` → 동형 |
| `sanitize_cli_completion_request_for_argv` | `completion_request` → 동형 |
| `make_cli_argv_sanitizing_transport` | `transport.t` → wrapped `transport.t` |

## 신규 모듈

- `lib/cascade/cascade_transport_cli_argv_sanitize.ml` (64 LoC)
- `lib/cascade/cascade_transport_cli_argv_sanitize.mli` (21 LoC)

## 의존성 (전부 dependency module)

- `Inference_utils.sanitize_text_utf8`, `Inference_utils.sanitize_messages_utf8`
- `Llm_provider.Llm_transport.{Stdio_server, Http_server, runtime_mcp_policy, completion_request, t}`

Shared state 0. Side effect 0 (pure mapping).

## 외부 caller 호환

- `test/test_oas_worker.ml:4538` 가 `Cascade_transport.sanitize_cli_completion_request_for_argv` 사용 — parent thin alias 가 그대로 노출 → 변경 0.
- `cascade_transport.mli` line-diff 없음.

## 검증

- [x] `dune build --root . lib/cascade` PASS
- [x] `.mli` surface 변경 0
- [x] 함수 body 1-to-1 카피

## 패턴

Pure helper extraction (PR #16832 mcp_tool_classifier 와 동일 thematic separation). UTF-8 argv sanitization 은 transport orchestration (provider selection, runtime mcp policy 결합) 의 책임이 아닌 cross-cutting concern — CLI provider variants (codex / claude_code / gemini / json-stream) 가 invalid UTF-8 을 거부하므로 transport boundary 앞에서 scrubbing.

## Workaround Rejection Bar self-check

1. [ ] makes X visible only — NO
2. [ ] string classifier — NO
3. [ ] N-of-M — NO (전체 4 함수 이동)
4. [ ] catch-all `_ ->` 추가 — NO
5. [ ] cap/cooldown/dedup/repair — NO (sanitization 은 protocol boundary enforcement)
6. [ ] test backdoor — NO
7. [ ] N-사이트 typo — NO

PASS — pure refactor.

## RFC

RFC-WAIVED: `lib/cascade` non-credential refactor. UTF-8 normalization 은 credential 헤더 처리 아님.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
