### PR TITLE
ci(lint): wire dashboard-ssot-agent-status.sh guard into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
             build=true
           fi
 
-          if has_match '^(bin/|lib/|test/|proto/|config/|dune-project$|dune-workspace$|.*\.opam$|scripts/install\.sh$|scripts/check-eio-conventions\.sh$|scripts/check-feature-flag-consistency\.sh$|scripts/check-toml-syntax\.sh$|scripts/validate-prompt-paths\.sh$|scripts/check-boundary-guard\.sh$|scripts/check-boundary-guard-mli-pairs\.sh$|scripts/check-ssot\.sh$|scripts/gen-grpc-descriptors\.sh$|scripts/lint/no-unknown-permissive-default\.sh$|scripts/lint/no-unknown-permissive-default\.allowlist$|scripts/lint/yojson-option-default\.py$|scripts/lint/yojson-option-default\.allowlist$|scripts/lint/no-docstring-escape-quote\.sh$|scripts/lint/no-hardcoded-colors-dashboard\.sh$|scripts/lint/no-hardcoded-colors-dashboard\.allowlist$|scripts/lint/dashboard-ssot-keeper-state\.sh$|scripts/lint/dashboard-ssot-keeper-state\.allowlist$|scripts/ci/|scripts/check-variants\.sh$|dashboard/src/)'; then
+          if has_match '^(bin/|lib/|test/|proto/|config/|dune-project$|dune-workspace$|.*\.opam$|scripts/install\.sh$|scripts/check-eio-conventions\.sh$|scripts/check-feature-flag-consistency\.sh$|scripts/check-toml-syntax\.sh$|scripts/validate-prompt-paths\.sh$|scripts/check-boundary-guard\.sh$|scripts/check-boundary-guard-mli-pairs\.sh$|scripts/check-ssot\.sh$|scripts/gen-grpc-descriptors\.sh$|scripts/lint/no-unknown-permissive-default\.sh$|scripts/lint/no-unknown-permissive-default\.allowlist$|scripts/lint/yojson-option-default\.py$|scripts/lint/yojson-option-default\.allowlist$|scripts/lint/no-docstring-escape-quote\.sh$|scripts/lint/no-hardcoded-colors-dashboard\.sh$|scripts/lint/no-hardcoded-colors-dashboard\.allowlist$|scripts/lint/dashboard-ssot-keeper-state\.sh$|scripts/lint/dashboard-ssot-keeper-state\.allowlist$|scripts/lint/dashboard-ssot-agent-status\.sh$|scripts/lint/dashboard-ssot-agent-status\.allowlist$|scripts/ci/|scripts/check-variants\.sh$|dashboard/src/)'; then
             lint=true
           fi
 
@@ -828,6 +828,9 @@ jobs:
 
       - name: Run dashboard keeper-state SSOT lint (RFC-0135 §9)
         run: bash scripts/lint/dashboard-ssot-keeper-state.sh
+
+      - name: Run dashboard agent-status SSOT lint (RFC-0139 §10)
+        run: bash scripts/lint/dashboard-ssot-agent-status.sh
 
       - name: Setup OCaml toolchain
         uses: ./.github/actions/setup-ocaml-toolchain


### PR DESCRIPTION
## Summary

Wire `scripts/lint/dashboard-ssot-agent-status.sh` into the CI lint job — RFC-0139 PR-2 (#16755) created the guard script but never wired execution. The PR body promised "lint guard 회귀 방지" but no CI job invokes it.

## Background

PR #16755 ("RFC-0139 PR-2 — agent-status lint guard + isOfflineStatus retirement") shipped:

| File | Status |
|---|---|
| `scripts/lint/dashboard-ssot-agent-status.sh` | created |
| `scripts/lint/dashboard-ssot-agent-status.allowlist` | created |
| `isOfflineStatus` helper retirement | done |
| **CI step running the guard** | **missing** |

Verified:
```bash
$ rg "dashboard-ssot" .github/workflows/ -n
.github/workflows/ci.yml:236:  ...dashboard-ssot-keeper-state\.sh$|...keeper-state\.allowlist$...
.github/workflows/ci.yml:830:  run: bash scripts/lint/dashboard-ssot-keeper-state.sh
```

Only the *sibling* RFC-0135 keeper-state guard is invoked. The agent-status guard sits dead on disk.

This is the **§1 guard-as-fix without execution** anti-pattern from CLAUDE.md Workaround Rejection Bar — and exactly the same N-of-M pattern as RFC-0138 Phase 3 Step 4 leftovers (PR #16830): one PR fixes the immediate visible thing but leaves the *execution surface* unfixed.

## Changes

`.github/workflows/ci.yml`:

1. Extend the lint-job change-detect regex (line 236) to include the new script + allowlist, so pushes that modify either trigger the lint job.
2. Add a `Run dashboard agent-status SSOT lint (RFC-0139 §10)` step right after the sibling keeper-state guard (line 830-831), mirroring its shape.

## Verification

```bash
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"  # yaml valid
$ bash scripts/lint/dashboard-ssot-agent-status.sh
RFC-0139 §10 SSOT guard: clean (0 allowlisted violation(s))
```

Guard passes on current main, so wiring it does not break CI.

## Workaround Rejection Bar self-check

- §1 텔레메트리-as-fix / guard-as-fix: this PR *fixes* the exact pattern — guard becomes live execution.
- §2 string classifier: none added.
- §3 N-of-M: closes the missing 1-of-2 site from #16755.  After this PR both keeper-state and agent-status guards run in CI.
- catch-all `_ ->`: none.
- cap/cooldown/dedup/repair: none.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
