### PR TITLE
refactor(cascade_transport): extract CLI MCP config JSON serializer into sibling

### DIFF
--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -103,49 +103,13 @@ let invalid_runtime_config field detail =
 
 let cli_model_override = Cascade_transport_cli_config.cli_model_override
 
-let json_of_string_pairs pairs = `Assoc (List.map (fun (k, v) -> k, `String v) pairs)
+(* CLI MCP config JSON serializer extracted to
+   [Cascade_transport_cli_mcp_config_json] (godfile decomp). *)
+let json_of_string_pairs = Cascade_transport_cli_mcp_config_json.json_of_string_pairs
+let json_of_cli_mcp_server = Cascade_transport_cli_mcp_config_json.json_of_cli_mcp_server
 
-let json_of_cli_mcp_server = function
-  | Llm_provider.Llm_transport.Stdio_server { command; args; env; _ } ->
-    `Assoc
-      [ "command", `String command
-      ; "args", `List (List.map (fun arg -> `String arg) args)
-      ; "env", json_of_string_pairs env
-      ]
-  | Llm_provider.Llm_transport.Http_server { url; headers; _ } ->
-    `Assoc [ "url", `String url; "headers", json_of_string_pairs headers ]
-;;
-
-let cli_mcp_config_json_of_policy
-      (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
-  : string option
-  =
-  let allowed_server_name name =
-    match policy.allowed_server_names with
-    | [] -> true
-    | names -> List.mem name names
-  in
-  let servers =
-    List.filter
-      (fun server ->
-         allowed_server_name (Llm_provider.Llm_transport.runtime_mcp_server_name server))
-      policy.servers
-  in
-  match servers with
-  | [] -> None
-  | servers ->
-    let config_json =
-      `Assoc
-        [ ( "mcpServers"
-          , `Assoc
-              (List.map
-                 (fun server ->
-                    ( Llm_provider.Llm_transport.runtime_mcp_server_name server
-                    , json_of_cli_mcp_server server ))
-                 servers) )
-        ]
-    in
-    Some (Yojson.Safe.to_string config_json)
+let cli_mcp_config_json_of_policy =
+  Cascade_transport_cli_mcp_config_json.cli_mcp_config_json_of_policy
 ;;
 
 let provider_caps_of_config = Provider_tool_support.oas_capabilities_of_config

--- a/lib/cascade/cascade_transport_cli_mcp_config_json.ml
+++ b/lib/cascade/cascade_transport_cli_mcp_config_json.ml
@@ -1,0 +1,54 @@
+(* CLI MCP config JSON serializer.
+
+   Builds the `{ "mcpServers": { name: { ... } } }` JSON document that
+   CLI providers (codex, claude_code, gemini variants) expect as
+   --mcp-config argv. Filters servers by the runtime mcp policy's
+   allowed_server_names whitelist (empty = allow all).
+
+   Extracted from [Cascade_transport] (godfile decomp). Pure mapping
+   over [Llm_provider.Llm_transport] values. *)
+
+let json_of_string_pairs pairs = `Assoc (List.map (fun (k, v) -> k, `String v) pairs)
+
+let json_of_cli_mcp_server = function
+  | Llm_provider.Llm_transport.Stdio_server { command; args; env; _ } ->
+    `Assoc
+      [ "command", `String command
+      ; "args", `List (List.map (fun arg -> `String arg) args)
+      ; "env", json_of_string_pairs env
+      ]
+  | Llm_provider.Llm_transport.Http_server { url; headers; _ } ->
+    `Assoc [ "url", `String url; "headers", json_of_string_pairs headers ]
+;;
+
+let cli_mcp_config_json_of_policy
+      (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
+  : string option
+  =
+  let allowed_server_name name =
+    match policy.allowed_server_names with
+    | [] -> true
+    | names -> List.mem name names
+  in
+  let servers =
+    List.filter
+      (fun server ->
+         allowed_server_name (Llm_provider.Llm_transport.runtime_mcp_server_name server))
+      policy.servers
+  in
+  match servers with
+  | [] -> None
+  | servers ->
+    let config_json =
+      `Assoc
+        [ ( "mcpServers"
+          , `Assoc
+              (List.map
+                 (fun server ->
+                    ( Llm_provider.Llm_transport.runtime_mcp_server_name server
+                    , json_of_cli_mcp_server server ))
+                 servers) )
+        ]
+    in
+    Some (Yojson.Safe.to_string config_json)
+;;

--- a/lib/cascade/cascade_transport_cli_mcp_config_json.mli
+++ b/lib/cascade/cascade_transport_cli_mcp_config_json.mli
@@ -1,0 +1,16 @@
+(** CLI MCP config JSON serializer.
+
+    Builds the [{"mcpServers": {name: {...}}}] document that CLI
+    providers (codex, claude_code, gemini variants) expect as
+    [--mcp-config] argv. Returns [None] when the runtime mcp policy's
+    allowed_server_names whitelist removes every server. *)
+
+val json_of_string_pairs : (string * string) list -> Yojson.Safe.t
+
+val json_of_cli_mcp_server
+  :  Llm_provider.Llm_transport.runtime_mcp_server
+  -> Yojson.Safe.t
+
+val cli_mcp_config_json_of_policy
+  :  Llm_provider.Llm_transport.runtime_mcp_policy
+  -> string option


### PR DESCRIPTION
## 요약

`cascade_transport.ml` (1678 LoC godfile) 의 CLI MCP config JSON serializer cluster 를 신규 sibling 모듈로 추출했습니다. **-36 LoC** (1678 → 1642).

PR #16832 (mcp_tool_classifier), #16839 (cli_argv_sanitize) 의 후속 — cascade_transport 3번째 분해.

## 추출 surface (3 pure JSON builders)

| 함수 | 시그니처 |
|---|---|
| `json_of_string_pairs` | `(string * string) list -> Yojson.Safe.t` |
| `json_of_cli_mcp_server` | `runtime_mcp_server -> Yojson.Safe.t` |
| `cli_mcp_config_json_of_policy` | `runtime_mcp_policy -> string option` |

## 신규 모듈

- `lib/cascade/cascade_transport_cli_mcp_config_json.ml` (54 LoC)
- `lib/cascade/cascade_transport_cli_mcp_config_json.mli` (16 LoC)

## 의존성 (전부 dependency module)

- `Llm_provider.Llm_transport.{Stdio_server, Http_server, runtime_mcp_server, runtime_mcp_policy, runtime_mcp_server_name}`
- `Yojson.Safe.to_string`

Shared state 0. Side effect 0 (pure mapping).

## 외부 caller 호환

- `test/test_oas_worker.ml:3511` 가 `Cascade_transport.cli_mcp_config_json_of_policy` 사용 — parent thin alias 가 그대로 노출 → 변경 0.
- `cascade_transport.mli` line-diff 없음.

## 검증

- [x] `dune build --root . lib/cascade` PASS
- [x] `.mli` surface 변경 0
- [x] 함수 body 1-to-1 카피

## 패턴

Pure helper extraction (PR #16832, #16839 와 동일 thematic separation). CLI MCP config JSON serialization 은 transport orchestration 의 책임이 아닌 cross-cutting concern — CLI provider variants (codex / claude_code / gemini) 가 `--mcp-config` argv 로 `{ "mcpServers": ... }` document 를 받음.

## Workaround Rejection Bar self-check

1. [ ] makes X visible only — NO
2. [ ] string classifier — NO
3. [ ] N-of-M — NO (전체 3 함수 이동)
4. [ ] catch-all `_ ->` 추가 — NO
5. [ ] cap/cooldown/dedup/repair — NO
6. [ ] test backdoor — NO
7. [ ] N-사이트 typo — NO

PASS — pure refactor.

## RFC

RFC-WAIVED: `lib/cascade` non-credential refactor.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
