### PR TITLE
refactor(server): extract meta-cognition cache state into sibling module

### DIFF
--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -1198,23 +1198,13 @@ let dashboard_shell_timeout_for ~light =
    noise in the log. Give it its own cache with a longer TTL, and on a cold
    miss warm it in the background so the shell path never blocks on the
    initial full JSONL scan. *)
-let meta_cognition_summary_ttl = 120.0
-let meta_cognition_warm_mu = Eio.Mutex.create ()
-let meta_cognition_warm_inflight : (string, unit) Hashtbl.t = Hashtbl.create 4
-let meta_cognition_last_good_mu = Eio.Mutex.create ()
-let meta_cognition_last_good : (string, Yojson.Safe.t) Hashtbl.t = Hashtbl.create 4
-let meta_cognition_summary_stale_for = meta_cognition_summary_ttl *. 3.0
+(* Meta-cognition summary cache extracted to
+   [Server_dashboard_meta_cognition_cache] (godfile decomp). *)
+module Mc_cache = Server_dashboard_meta_cognition_cache
 
-let meta_cognition_summary_empty_json =
-  `Assoc
-    [ "stagnation_score", `Float 0.0
-    ; "belief_count", `Int 0
-    ; "contested_belief_count", `Int 0
-    ; "dominant_belief", `Null
-    ; "top_tension", `Null
-    ; "top_desire", `Null
-    ]
-;;
+let meta_cognition_summary_ttl = Mc_cache.summary_ttl
+let meta_cognition_summary_stale_for = Mc_cache.summary_stale_for
+let meta_cognition_summary_empty_json = Mc_cache.summary_empty_json
 
 let dashboard_shell_cache_prefix (config : Coord.config) =
   Printf.sprintf "shell:coord=%s:" config.base_path
@@ -1232,50 +1222,31 @@ let meta_cognition_summary_key (config : Coord.config) =
   dashboard_cache_key config "meta_cognition_summary" "dashboard_shell"
 ;;
 
-let store_last_good_meta_cognition_summary key json =
-  Eio_guard.with_mutex meta_cognition_last_good_mu (fun () ->
-    Hashtbl.replace meta_cognition_last_good key json)
-;;
-
-let find_last_good_meta_cognition_summary key =
-  Eio_guard.with_mutex meta_cognition_last_good_mu (fun () ->
-    Hashtbl.find_opt meta_cognition_last_good key)
-;;
-
-let clear_meta_cognition_warm_flag key =
-  Eio_guard.with_mutex meta_cognition_warm_mu (fun () ->
-    Hashtbl.remove meta_cognition_warm_inflight key)
-;;
+let store_last_good_meta_cognition_summary = Mc_cache.store_last_good
+let find_last_good_meta_cognition_summary = Mc_cache.find_last_good
+let clear_meta_cognition_warm_flag = Mc_cache.clear_warm_flag
 
 let schedule_meta_cognition_summary_warm (config : Coord.config) =
   let key = meta_cognition_summary_key config in
   let compute () =
     let json = Meta_cognition.summary_json config in
-    store_last_good_meta_cognition_summary key json;
+    Mc_cache.store_last_good key json;
     json
   in
-  let should_start =
-    Eio_guard.with_mutex meta_cognition_warm_mu (fun () ->
-      if Hashtbl.mem meta_cognition_warm_inflight key
-      then false
-      else (
-        Hashtbl.replace meta_cognition_warm_inflight key ();
-        true))
-  in
-  if should_start
+  if Mc_cache.try_acquire_warm_slot key
   then (
     match Eio_context.get_switch_opt () with
     | Some sw ->
       Eio.Fiber.fork ~sw (fun () ->
         Eio_guard.protect
-          ~finally:(fun () -> clear_meta_cognition_warm_flag key)
+          ~finally:(fun () -> Mc_cache.clear_warm_flag key)
           (fun () ->
              try
                Dashboard_cache.invalidate key;
                ignore
                  (Dashboard_cache.get_or_compute
                     key
-                    ~ttl:meta_cognition_summary_ttl
+                    ~ttl:Mc_cache.summary_ttl
                     compute)
                (* Drop cached shell payloads that were rendered while the
                      meta-cognition summary was still warming. *);
@@ -1286,7 +1257,7 @@ let schedule_meta_cognition_summary_warm (config : Coord.config) =
                Log.Server.warn
                  "dashboard shell meta_cognition warm failed: %s"
                  (Printexc.to_string exn)))
-    | None -> clear_meta_cognition_warm_flag key)
+    | None -> Mc_cache.clear_warm_flag key)
 ;;
 
 let meta_cognition_summary_cached (config : Coord.config) : Yojson.Safe.t =

--- a/lib/server/server_dashboard_meta_cognition_cache.ml
+++ b/lib/server/server_dashboard_meta_cognition_cache.ml
@@ -1,0 +1,53 @@
+(* Meta-cognition summary cache for dashboard shell endpoints.
+
+   Encapsulates two parallel per-config tables:
+   - [warm_inflight]: dedup table so concurrent shell requests only
+     spawn one warming fiber per cache key.
+   - [last_good]: most recent successful summary, used as a fallback
+     while the warm fiber is in flight (avoid `Null surface).
+
+   Pulled out of [Server_dashboard_http_core] to shrink the godfile.
+   Side effects are isolated to two Eio mutexes + two Hashtbls. *)
+
+let summary_ttl = 120.0
+let summary_stale_for = summary_ttl *. 3.0
+
+let summary_empty_json =
+  `Assoc
+    [ "stagnation_score", `Float 0.0
+    ; "belief_count", `Int 0
+    ; "contested_belief_count", `Int 0
+    ; "dominant_belief", `Null
+    ; "top_tension", `Null
+    ; "top_desire", `Null
+    ]
+;;
+
+let warm_mu = Eio.Mutex.create ()
+let warm_inflight : (string, unit) Hashtbl.t = Hashtbl.create 4
+let last_good_mu = Eio.Mutex.create ()
+let last_good : (string, Yojson.Safe.t) Hashtbl.t = Hashtbl.create 4
+
+let store_last_good key json =
+  Eio_guard.with_mutex last_good_mu (fun () -> Hashtbl.replace last_good key json)
+;;
+
+let find_last_good key =
+  Eio_guard.with_mutex last_good_mu (fun () -> Hashtbl.find_opt last_good key)
+;;
+
+let clear_warm_flag key =
+  Eio_guard.with_mutex warm_mu (fun () -> Hashtbl.remove warm_inflight key)
+;;
+
+(** Claim the warm slot for [key]. Returns [true] when this caller acquired
+    the slot (and is responsible for the subsequent [clear_warm_flag] call);
+    returns [false] when another caller is already warming the same key. *)
+let try_acquire_warm_slot key =
+  Eio_guard.with_mutex warm_mu (fun () ->
+    if Hashtbl.mem warm_inflight key
+    then false
+    else (
+      Hashtbl.replace warm_inflight key ();
+      true))
+;;

--- a/lib/server/server_dashboard_meta_cognition_cache.mli
+++ b/lib/server/server_dashboard_meta_cognition_cache.mli
@@ -1,0 +1,17 @@
+(** Meta-cognition summary cache for dashboard shell endpoints.
+
+    Encapsulates per-cache-key warm-inflight dedup and last-good
+    fallback tables, plus the TTL/stale-window constants used by
+    callers in [Server_dashboard_http_core]. *)
+
+val summary_ttl : float
+val summary_stale_for : float
+val summary_empty_json : Yojson.Safe.t
+
+val store_last_good : string -> Yojson.Safe.t -> unit
+val find_last_good : string -> Yojson.Safe.t option
+val clear_warm_flag : string -> unit
+
+(** Claim the warm slot for [key]; returns [true] when this caller
+    acquired the slot, [false] when another fiber is already warming. *)
+val try_acquire_warm_slot : string -> bool


### PR DESCRIPTION
## 요약

`server_dashboard_http_core.ml` (1929 LoC godfile) 의 meta-cognition cache state (Eio mutex + Hashtbl 두 쌍 + helpers) 를 신규 sibling 모듈로 추출했습니다. **-29 LoC** (1929 → 1900).

PR #16828 (shell_projection_trace) 후속 — server_dashboard_http_core 두 번째 분해.

## 추출 surface

| 분류 | 항목 |
|---|---|
| 상수 | `summary_ttl` (120s), `summary_stale_for`, `summary_empty_json` |
| State | `warm_mu`, `warm_inflight`, `last_good_mu`, `last_good` (encapsulated) |
| Functions | `store_last_good`, `find_last_good`, `clear_warm_flag` |
| **New helper** | `try_acquire_warm_slot` (replaces inline `Hashtbl.mem`/`replace` race-prone pattern) |

## 신규 모듈

- `lib/server/server_dashboard_meta_cognition_cache.ml` (53 LoC)
- `lib/server/server_dashboard_meta_cognition_cache.mli` (17 LoC)

## Parent 유지 사항 (의도적)

- `dashboard_shell_cache_prefix`, `dashboard_shell_cache_key`: line 1556, 1841 등 4 사이트에서 사용 → parent 유지
- `meta_cognition_summary_key`: parent-local `dashboard_cache_key` 의존 → parent 유지
- `schedule_meta_cognition_summary_warm`, `meta_cognition_summary_cached`: `Eio.Fiber` + `Dashboard_cache` orchestration → parent 유지

## 의존성 (신규 모듈)

- `Eio.Mutex.create`
- `Hashtbl`
- `Eio_guard.with_mutex`
- `Yojson.Safe.t`

Side effect = mutex-protected hashtable replace/remove.

## 검증

- [x] `dune build --root . lib/server` PASS
- [x] `try_acquire_warm_slot` 는 기존 inline dedup 과 byte-equivalent (mem-then-replace single-mutex window)
- [x] public surface 변경 0 (parent alias 로 호환)

## 패턴

State encapsulation (PR #16828 shell_projection_trace, #16786 cascade_transport_codex_omission_dedup, #16792 board_comment_rate_limit 와 동일).

`try_acquire_warm_slot` 은 raw `Hashtbl.mem`/`Hashtbl.replace` race-condition pattern 을 typed primitive 로 좁히는 작은 개선 — 호출자가 "claim" 의미를 명시할 수 있게 되고, mutex window 가 단일 critical section 으로 인라인된다.

## Workaround Rejection Bar self-check

1. [ ] makes X visible only — NO (state owner 이동 + 헬퍼 추가)
2. [ ] string classifier — NO
3. [ ] N-of-M — NO (전체 state cluster 이동)
4. [ ] catch-all `_ ->` 추가 — NO
5. [ ] cap/cooldown/dedup/repair — `try_acquire_warm_slot` 은 새 dedup 추가가 아니라 *기존* dedup 의 typed surface 추출 (raw mem/replace 압축)
6. [ ] test backdoor — NO
7. [ ] N-사이트 typo — NO

PASS — refactor + small typed-primitive improvement.

## RFC

RFC-WAIVED: `lib/server` non-credential refactor.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
