### PR TITLE
refactor(keeper_heartbeat_loop): extract visibility-gate primitives into sibling

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -1167,46 +1167,20 @@ let dispatch_recurring_keepalive
     otherwise any keeper with [current_task_id=Some _] is blocked
     from ever running a turn (discovered 2026-04-25 — 8/14 keepers
     frozen with claimed tasks). *)
-let smart_heartbeat_cycle_continues (d : Keeper_heartbeat_smart.decision) : bool =
-  match d with
-  | Keeper_heartbeat_smart.Skip_busy | Keeper_heartbeat_smart.Emit -> true
-  | Keeper_heartbeat_smart.Skip_idle _ -> false
+(* Visibility-gate primitives extracted to
+   [Keeper_heartbeat_visibility_gate] (godfile decomp). *)
+let smart_heartbeat_cycle_continues =
+  Keeper_heartbeat_visibility_gate.smart_heartbeat_cycle_continues
 ;;
 
-let cycle_continues_after_wake
-      (d : Keeper_heartbeat_smart.decision)
-      (outcome : Keeper_keepalive_signal.sleep_outcome)
-  : bool
-  =
-  match d, outcome with
-  | Keeper_heartbeat_smart.Skip_idle _, Keeper_keepalive_signal.Woken -> true
-  | _, _ -> smart_heartbeat_cycle_continues d
+let cycle_continues_after_wake = Keeper_heartbeat_visibility_gate.cycle_continues_after_wake
+
+let unobserved_visibility_idle_window_s =
+  Keeper_heartbeat_visibility_gate.unobserved_visibility_idle_window_s
 ;;
 
-let unobserved_visibility_idle_window_s = 900.0
-
-let visible_consumer_count () =
-  Sse.client_count_by_kind Sse.Observer + Sse.external_subscriber_count ()
-;;
-
-let visibility_gate_decision
-      ~(visible_consumers : int)
-      ~(has_pending_signal : bool)
-      ~(now : float)
-      ~(last_heartbeat_cycle_ts : float)
-      (decision : Keeper_heartbeat_smart.decision)
-  : Keeper_heartbeat_smart.decision
-  =
-  match decision with
-  | Keeper_heartbeat_smart.Emit
-    when visible_consumers <= 0
-         && (not has_pending_signal)
-         && last_heartbeat_cycle_ts > 0.0
-         && now -. last_heartbeat_cycle_ts < unobserved_visibility_idle_window_s ->
-    Keeper_heartbeat_smart.Skip_idle
-      (last_heartbeat_cycle_ts +. unobserved_visibility_idle_window_s)
-  | _ -> decision
-;;
+let visible_consumer_count = Keeper_heartbeat_visibility_gate.visible_consumer_count
+let visibility_gate_decision = Keeper_heartbeat_visibility_gate.visibility_gate_decision
 
 let run_smart_heartbeat_gate
       ~(config : Coord.config)

--- a/lib/keeper/keeper_heartbeat_visibility_gate.ml
+++ b/lib/keeper/keeper_heartbeat_visibility_gate.ml
@@ -1,0 +1,56 @@
+(* Pure visibility-gate primitives for the smart-heartbeat policy.
+
+   Two layers:
+
+   1. [smart_heartbeat_cycle_continues] / [cycle_continues_after_wake]:
+      decide whether a [Skip_idle] decision should still permit cycle
+      progress (after a wake signal).
+   2. [visibility_gate_decision]: downgrade [Emit] to [Skip_idle] when
+      no SSE consumer is observing and no pending signal demands a
+      cycle (consumer-driven idle backoff).
+
+   Extracted from [Keeper_heartbeat_loop] (godfile decomp). Pure
+   functions over typed inputs - no I/O, no shared state. Side input
+   on [visible_consumer_count] is the live SSE registry, kept here
+   because the read is the only purpose of the helper. *)
+
+let smart_heartbeat_cycle_continues (d : Keeper_heartbeat_smart.decision) : bool =
+  match d with
+  | Keeper_heartbeat_smart.Skip_busy | Keeper_heartbeat_smart.Emit -> true
+  | Keeper_heartbeat_smart.Skip_idle _ -> false
+;;
+
+let cycle_continues_after_wake
+      (d : Keeper_heartbeat_smart.decision)
+      (outcome : Keeper_keepalive_signal.sleep_outcome)
+  : bool
+  =
+  match d, outcome with
+  | Keeper_heartbeat_smart.Skip_idle _, Keeper_keepalive_signal.Woken -> true
+  | _, _ -> smart_heartbeat_cycle_continues d
+;;
+
+let unobserved_visibility_idle_window_s = 900.0
+
+let visible_consumer_count () =
+  Sse.client_count_by_kind Sse.Observer + Sse.external_subscriber_count ()
+;;
+
+let visibility_gate_decision
+      ~(visible_consumers : int)
+      ~(has_pending_signal : bool)
+      ~(now : float)
+      ~(last_heartbeat_cycle_ts : float)
+      (decision : Keeper_heartbeat_smart.decision)
+  : Keeper_heartbeat_smart.decision
+  =
+  match decision with
+  | Keeper_heartbeat_smart.Emit
+    when visible_consumers <= 0
+         && (not has_pending_signal)
+         && last_heartbeat_cycle_ts > 0.0
+         && now -. last_heartbeat_cycle_ts < unobserved_visibility_idle_window_s ->
+    Keeper_heartbeat_smart.Skip_idle
+      (last_heartbeat_cycle_ts +. unobserved_visibility_idle_window_s)
+  | _ -> decision
+;;

--- a/lib/keeper/keeper_heartbeat_visibility_gate.mli
+++ b/lib/keeper/keeper_heartbeat_visibility_gate.mli
@@ -1,0 +1,27 @@
+(** Pure visibility-gate primitives for the smart-heartbeat policy.
+
+    Two concerns:
+    - Cycle continuation after a [Keeper_heartbeat_smart.decision]
+      (with optional [Keeper_keepalive_signal.sleep_outcome] refinement
+      for the [Skip_idle + Woken] promotion case).
+    - Consumer-driven idle backoff: if no SSE consumer is observing
+      and no pending signal forces a cycle, downgrade [Emit] to
+      [Skip_idle] until [unobserved_visibility_idle_window_s] elapses. *)
+
+val smart_heartbeat_cycle_continues : Keeper_heartbeat_smart.decision -> bool
+
+val cycle_continues_after_wake
+  :  Keeper_heartbeat_smart.decision
+  -> Keeper_keepalive_signal.sleep_outcome
+  -> bool
+
+val unobserved_visibility_idle_window_s : float
+val visible_consumer_count : unit -> int
+
+val visibility_gate_decision
+  :  visible_consumers:int
+  -> has_pending_signal:bool
+  -> now:float
+  -> last_heartbeat_cycle_ts:float
+  -> Keeper_heartbeat_smart.decision
+  -> Keeper_heartbeat_smart.decision


### PR DESCRIPTION
## 요약

`keeper_heartbeat_loop.ml` (1733 LoC) 의 visibility-gate primitive cluster (4 functions + 1 constant) 를 신규 sibling 모듈로 추출했습니다. **-26 LoC** (1733 → 1707).

PR #16770 (keeper_heartbeat_stimulus_intake) 의 후속 — keeper_heartbeat_loop 두 번째 분해.

## 추출 surface

| 항목 | 시그니처 |
|---|---|
| `smart_heartbeat_cycle_continues` | `decision -> bool` |
| `cycle_continues_after_wake` | `decision -> sleep_outcome -> bool` |
| `unobserved_visibility_idle_window_s` | `float` (900s) |
| `visible_consumer_count` | `unit -> int` |
| `visibility_gate_decision` | `~visible_consumers ~has_pending_signal ~now ~last_heartbeat_cycle_ts -> decision -> decision` |

## 신규 모듈

- `lib/keeper/keeper_heartbeat_visibility_gate.ml` (56 LoC)
- `lib/keeper/keeper_heartbeat_visibility_gate.mli` (27 LoC)

## 의존성 (전부 dependency module — shared state 0)

- `Keeper_heartbeat_smart.{decision, Emit, Skip_busy, Skip_idle}`
- `Keeper_keepalive_signal.{sleep_outcome, Woken}`
- `Sse.{Observer, client_count_by_kind, external_subscriber_count}`

`visible_consumer_count` 만 side effect (SSE registry read). 나머지 4 항목 pure.

## 외부 caller 호환

- `test/test_smart_heartbeat_keepalive.ml` 10 사이트 (KK.smart_heartbeat_cycle_continues, KK.visibility_gate_decision, KK.cycle_continues_after_wake) → parent thin alias 로 그대로 호환.
- `keeper_heartbeat_loop.mli` line-diff 0.

## 검증

- [x] `dune build --root . lib/keeper` PASS
- [x] `.mli` surface 변경 0
- [x] test 사이트 변경 0

## 패턴

Pure helper extraction (PR #16838 native_tool_hint, #16832 mcp_tool_classifier 와 동일). heartbeat smart decision 의 "visibility/idle gate" 책임은 heartbeat loop orchestration (Eio.Fiber, registry I/O, snapshot write) 의 책임 아님 — 한 godfile 에 묶어둘 이유 없음.

`run_smart_heartbeat_gate` (157 LoC, 5 ref/callback inject 필요) 는 본 PR 에서 미이동 — 별도 사이클 candidate.

## Workaround Rejection Bar self-check

1. [ ] makes X visible only — NO
2. [ ] string classifier — NO
3. [ ] N-of-M — NO (전체 cluster 이동)
4. [ ] catch-all `_ ->` 추가 — NO (existing `| _ -> decision` 유지)
5. [ ] cap/cooldown/dedup/repair — NO (gate 는 backpressure consumer 측에 이미 구현된 정책)
6. [ ] test backdoor — NO
7. [ ] N-사이트 typo — NO

PASS — pure refactor.

## RFC

RFC-WAIVED: `keeper_heartbeat_visibility_gate` 는 RFC-gated subsystem 아님.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
