### PR TITLE
fix(keeper): demote contract exhaustion log severity

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -1322,7 +1322,12 @@ let run_named
               Cascade_legacy_runner.record_cascade ~keeper_name
                 ~cascade_name:error_cascade_name
                 ~outcome:`Failure ~observation:(Some observation) ();
-              Log.Misc.error "cascade %s exhausted: all tiers failed (last runtime=%s, error=%s)"
+              let log =
+                if sdk_error_is_required_tool_contract_violation sdk_err then
+                  Log.Misc.warn
+                else Log.Misc.error
+              in
+              log "cascade %s exhausted: all tiers failed (last runtime=%s, error=%s)"
                 cascade_name runtime_candidate_label (Agent_sdk.Error.to_string sdk_err);
               Error sdk_err
             (* [Accept] / [Accept_on_exhaustion] are reachable only from

--- a/test/dune
+++ b/test/dune
@@ -1469,6 +1469,8 @@
 
 (include stanzas/test_keeper_production_readiness_gate.inc)
 
+(include stanzas/test_keeper_turn_driver_exhaustion_log_source.inc)
+
 (include stanzas/test_cdal_ledger_health_10115.inc)
 
 (include stanzas/test_cdal_runtime_health_15748.inc)

--- a/test/stanzas/test_keeper_turn_driver_exhaustion_log_source.inc
+++ b/test/stanzas/test_keeper_turn_driver_exhaustion_log_source.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_turn_driver_exhaustion_log_source)
+ (modules test_keeper_turn_driver_exhaustion_log_source)
+ (libraries alcotest str))

--- a/test/test_keeper_turn_driver_exhaustion_log_source.ml
+++ b/test/test_keeper_turn_driver_exhaustion_log_source.ml
@@ -1,0 +1,91 @@
+(** Source guard for cascade exhaustion log severity.
+
+    [require_tool_use] completion-contract violations are deterministic
+    provider/model behavior and already have typed handling. They should remain
+    visible, but not inflate the operator ERROR stream when every cascade tier
+    returns the same contract violation. *)
+
+open Alcotest
+
+let source_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root -> root
+  | None -> Sys.getcwd ()
+
+let load_source rel =
+  let path = Filename.concat (source_root ()) rel in
+  if not (Sys.file_exists path) then
+    failwith (Printf.sprintf "source file not found: %s" path)
+  else
+    let ic = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () -> In_channel.input_all ic)
+
+let contains ~needle haystack =
+  let re = Str.regexp_string needle in
+  try
+    ignore (Str.search_forward re haystack 0);
+    true
+  with Not_found -> false
+
+let count_occurrences ~needle haystack =
+  let nlen = String.length needle in
+  if nlen = 0 then 0
+  else
+    let re = Str.regexp_string needle in
+    let rec loop pos acc =
+      match Str.search_forward re haystack pos with
+      | exception Not_found -> acc
+      | _ ->
+        let next = Str.match_end () in
+        loop next (acc + 1)
+    in
+    loop 0 0
+
+let window_around ~anchor ~before ~after haystack =
+  let re = Str.regexp_string anchor in
+  try
+    let pos = Str.search_forward re haystack 0 in
+    let start = max 0 (pos - before) in
+    let limit = min (String.length haystack) (pos + String.length anchor + after) in
+    Some (String.sub haystack start (limit - start))
+  with Not_found -> None
+
+let target = "lib/keeper/keeper_turn_driver.ml"
+
+let test_completion_contract_exhaustion_is_warn () =
+  let src = load_source target in
+  let anchor = "log \"cascade %s exhausted: all tiers failed" in
+  match window_around ~anchor ~before:260 ~after:120 src with
+  | None -> fail "completion-contract severity branch missing"
+  | Some block ->
+    check bool "contract predicate guards exhaustion log" true
+      (contains
+         ~needle:"if sdk_error_is_required_tool_contract_violation sdk_err then"
+         block);
+    check bool "contract exhaustion uses warn" true
+      (contains ~needle:"Log.Misc.warn" block);
+    check bool "non-contract fallback remains error" true
+      (contains ~needle:"else Log.Misc.error" block);
+    check bool "guard applies to all-tiers-failed exhaustion log" true
+      (contains
+         ~needle:"log \"cascade %s exhausted: all tiers failed"
+         block)
+
+let test_no_unconditional_error_for_all_tiers_failed () =
+  let src = load_source target in
+  check int "all-tiers-failed cascade exhaustion is not unconditional ERROR" 0
+    (count_occurrences
+       ~needle:"Log.Misc.error \"cascade %s exhausted: all tiers failed"
+       src)
+
+let () =
+  run "keeper_turn_driver_exhaustion_log_source"
+    [ ( "completion-contract"
+      , [ test_case "contract exhaustion logs warn" `Quick
+            test_completion_contract_exhaustion_is_warn
+        ; test_case "all-tiers-failed log is guarded" `Quick
+            test_no_unconditional_error_for_all_tiers_failed
+        ] )
+    ]


### PR DESCRIPTION
## Summary
- Demote all-tiers-failed cascade exhaustion logs from ERROR to WARN when the underlying SDK error is a typed require_tool_use completion-contract violation.
- Preserve ERROR severity for non-contract cascade exhaustion.
- Add a source guard so the all-tiers-failed log cannot regress to an unconditional ERROR.

## Validation
- ocamlformat --check lib/keeper/keeper_turn_driver.ml test/test_keeper_turn_driver_exhaustion_log_source.ml
- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=/private/tmp/masc-completion-contract-log-build-20260520 scripts/dune-local.sh build test/test_keeper_turn_driver_exhaustion_log_source.exe test/test_keeper_unified.exe
- /private/tmp/masc-completion-contract-log-build-20260520/default/test/test_keeper_turn_driver_exhaustion_log_source.exe --show-errors --color=never
- /private/tmp/masc-completion-contract-log-build-20260520/default/test/test_keeper_unified.exe test --show-errors --color=never transient_network_error 34-48
- git diff --check

## Note
- A broader local run of transient_network_error exposed pre-existing unrelated failure at case 62, max_execution_time_s cascade exhaustion. Tracked separately as #16848. The focused completion-contract/cascade cases passed.