### PR TITLE
refactor(server): extract dashboard /logs JSON builder into sibling module

### DIFF
--- a/lib/server/server_dashboard_logs_json.ml
+++ b/lib/server/server_dashboard_logs_json.ml
@@ -1,0 +1,85 @@
+(* Dashboard /logs endpoint JSON builder.
+
+   Wraps a slice of [Log.Ring] entries with retention metadata,
+   the applied query parameters, and cursor information (latest_seq /
+   oldest_seq) so the dashboard can fetch deltas via [since_seq].
+
+   Extracted from [Server_routes_http_routes_dashboard] (godfile decomp).
+   Pure JSON builder over [Log.Ring.entry list] - the ring read happens
+   in the caller. *)
+
+let option_int_json = function
+  | Some value -> `Int value
+  | None -> `Null
+;;
+
+let option_string_json = function
+  | Some value -> `String value
+  | None -> `Null
+;;
+
+let store_path ~masc_root =
+  Filename.concat
+    (Filename.concat masc_root "logs")
+    (Printf.sprintf
+       "system_log_%s.jsonl"
+       (Log.format_utc_date_of (Unix.gettimeofday ())))
+;;
+
+let build
+      ~(config : Coord.config)
+      ~limit
+      ~level_filter
+      ~min_level
+      ~module_filter
+      ~since_seq
+      (entries : Log.Ring.entry list)
+  : Yojson.Safe.t
+  =
+  let masc_root = Coord.masc_root_dir config in
+  let newest =
+    match entries with
+    | [] -> None
+    | entry :: _ -> Some entry
+  in
+  let oldest = List.fold_left (fun _ entry -> Some entry) None entries in
+  let entry_seq_json = Option.map (fun (entry : Log.Ring.entry) -> entry.seq) in
+  let entry_ts_json = Option.map (fun (entry : Log.Ring.entry) -> entry.ts) in
+  match Log.Ring.to_json entries with
+  | `Assoc fields ->
+    `Assoc
+      ([ "generated_at_iso", `String (Masc_domain.now_iso ())
+       ; "dashboard_surface", `String "/api/v1/dashboard/logs"
+       ; "source", `String "masc_log_ring"
+       ; ( "retention"
+         , `Assoc
+             [ "scope", `String "dashboard_logs"
+             ; "coordination_root", `String masc_root
+             ; "buffer", `String "Log.Ring"
+             ; "capacity", `Int Log.Ring.capacity
+             ; "durable_store", `String (store_path ~masc_root)
+             ; "file_pattern", `String "system_log_YYYY-MM-DD.jsonl"
+             ; "keep_days", `Int 7
+             ; ( "cache_policy"
+               , `String
+                   "uncached; reads in-memory ring backed by daily JSONL sink; \
+                    delta cursor via since_seq" )
+             ] )
+       ; ( "query"
+         , `Assoc
+             [ "limit", `Int limit
+             ; "level", `String level_filter
+             ; ( "applied_level"
+               , `String (Log.level_to_string (Log.level_of_string level_filter)) )
+             ; "min_level", `Int min_level
+             ; "module", `String module_filter
+             ; "since_seq", option_int_json since_seq
+             ] )
+       ; "returned", `Int (List.length entries)
+       ; "latest_seq", option_int_json (entry_seq_json newest)
+       ; "oldest_seq", option_int_json (entry_seq_json oldest)
+       ; "latest_ts_iso", option_string_json (entry_ts_json newest)
+       ]
+       @ fields)
+  | json -> json
+;;

--- a/lib/server/server_dashboard_logs_json.mli
+++ b/lib/server/server_dashboard_logs_json.mli
@@ -1,0 +1,13 @@
+(** Dashboard [/logs] endpoint JSON builder. *)
+
+val store_path : masc_root:string -> string
+
+val build
+  :  config:Coord.config
+  -> limit:int
+  -> level_filter:string
+  -> min_level:int
+  -> module_filter:string
+  -> since_seq:int option
+  -> Log.Ring.entry list
+  -> Yojson.Safe.t

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -31,61 +31,10 @@ let option_string_json = function
   | Some value -> `String value
   | None -> `Null
 
-let dashboard_logs_store_path ~masc_root =
-  Filename.concat
-    (Filename.concat masc_root "logs")
-    (Printf.sprintf "system_log_%s.jsonl"
-       (Log.format_utc_date_of (Unix.gettimeofday ())))
-
-let dashboard_logs_json ~config ~limit ~level_filter ~min_level ~module_filter
-    ~since_seq entries =
-  let masc_root = Coord.masc_root_dir config in
-  let newest = match entries with [] -> None | entry :: _ -> Some entry in
-  let oldest = List.fold_left (fun _ entry -> Some entry) None entries in
-  let entry_seq_json = Option.map (fun (entry : Log.Ring.entry) -> entry.seq) in
-  let entry_ts_json = Option.map (fun (entry : Log.Ring.entry) -> entry.ts) in
-  match Log.Ring.to_json entries with
-  | `Assoc fields ->
-      `Assoc
-        ([
-           ("generated_at_iso", `String (Masc_domain.now_iso ()));
-           ("dashboard_surface", `String "/api/v1/dashboard/logs");
-           ("source", `String "masc_log_ring");
-           ( "retention",
-             `Assoc
-               [
-                 ("scope", `String "dashboard_logs");
-                 ("coordination_root", `String masc_root);
-                 ("buffer", `String "Log.Ring");
-                 ("capacity", `Int Log.Ring.capacity);
-                 ( "durable_store",
-                   `String (dashboard_logs_store_path ~masc_root) );
-                 ("file_pattern", `String "system_log_YYYY-MM-DD.jsonl");
-                 ("keep_days", `Int 7);
-                 ( "cache_policy",
-                   `String
-                     "uncached; reads in-memory ring backed by daily JSONL sink; delta cursor via since_seq"
-                 );
-               ] );
-           ( "query",
-             `Assoc
-               [
-                 ("limit", `Int limit);
-                 ("level", `String level_filter);
-                 ( "applied_level",
-                   `String (Log.level_to_string (Log.level_of_string level_filter))
-                 );
-                 ("min_level", `Int min_level);
-                 ("module", `String module_filter);
-                 ("since_seq", option_int_json since_seq);
-               ] );
-           ("returned", `Int (List.length entries));
-           ("latest_seq", option_int_json (entry_seq_json newest));
-           ("oldest_seq", option_int_json (entry_seq_json oldest));
-           ("latest_ts_iso", option_string_json (entry_ts_json newest));
-         ]
-        @ fields)
-  | json -> json
+(* Dashboard /logs JSON builder extracted to
+   [Server_dashboard_logs_json] (godfile decomp). *)
+let dashboard_logs_store_path = Server_dashboard_logs_json.store_path
+let dashboard_logs_json = Server_dashboard_logs_json.build
 
 module Provider_logs = Server_routes_http_dashboard_provider_logs
 


### PR DESCRIPTION
## 요약

`server_routes_http_routes_dashboard.ml` (1645 LoC) 의 dashboard `/logs` endpoint JSON builder 를 신규 sibling 모듈로 추출했습니다. **-51 LoC** (1645 → 1594).

PR #16799 (cascade_profile_gate) 의 후속 — server_routes_http_routes_dashboard 두 번째 분해.

## 추출 surface

| 항목 | 시그니처 |
|---|---|
| `store_path` | `~masc_root:string -> string` |
| `build` | `~config ~limit ~level_filter ~min_level ~module_filter ~since_seq -> Log.Ring.entry list -> Yojson.Safe.t` |

내부 helper: `option_int_json`, `option_string_json` (각 3 LoC).

## 신규 모듈

- `lib/server/server_dashboard_logs_json.ml` (85 LoC)
- `lib/server/server_dashboard_logs_json.mli` (13 LoC)

## 의존성 (전부 dependency module)

- `Log.Ring.{entry, capacity, to_json}` + `Log.level_to_string` + `Log.level_of_string` + `Log.format_utc_date_of`
- `Coord.config` / `Coord.masc_root_dir`
- `Masc_domain.now_iso`
- `Filename.concat`, `Printf.sprintf`, `Unix.gettimeofday`

Shared state 0. Pure JSON builder over input list.

## 외부 caller 호환

- 외부 caller 0 (`dashboard_logs_*` 는 모듈 외부에서 호출되지 않음)
- 1 internal call at line 507 (`handle_dashboard_logs` handler) → parent alias 가 `dashboard_logs_json` 시그니처 유지

## 검증

- [x] `dune build --root . lib/server` PASS
- [x] public surface 변경 0 (parent alias 로 호환)
- [x] 함수 body 1-to-1 카피

## 패턴

Pure JSON builder extraction (PR #16794 Scan_summary, #16831 Summary_aggregates 와 동일). `/logs` 응답은 4-block 조합 (Log.Ring 슬라이스 + retention metadata + query echo + cursor) — dashboard route 의 transport (HTTP request 파싱, 권한 체크) 와 별개 thematic concern.

## Workaround Rejection Bar self-check

1. [ ] makes X visible only — NO
2. [ ] string classifier — NO
3. [ ] N-of-M — NO (전체 cluster 이동)
4. [ ] catch-all `_ ->` 추가 — NO (existing `| json -> json` 유지)
5. [ ] cap/cooldown/dedup/repair — NO
6. [ ] test backdoor — NO
7. [ ] N-사이트 typo — NO

PASS — pure refactor.

## RFC

RFC-WAIVED: `lib/server` non-credential refactor.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
