### PR TITLE
refactor(keeper_shell_docker): extract nested-container runtime detection into sibling

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -208,197 +208,34 @@ let effective_sandbox_profile ~(meta : keeper_meta) ~in_playground =
 
 (* ── Nested runtime detection ──────────────────────────── *)
 
-let nested_container_runtime_tokens = [ "docker"; "podman"; "nerdctl"; "buildah" ]
+(* Nested-container runtime detection extracted to
+   [Keeper_shell_docker_nested_runtime] (godfile decomp). *)
+module Nested_runtime = Keeper_shell_docker_nested_runtime
 
-let sandbox_socket_markers =
-  [ "/var/run/docker.sock"
-  ; "/run/docker.sock"
-  ; "/run/podman/podman.sock"
-  ; "podman.sock"
-  ; "containerd.sock"
-  ; "buildkitd.sock"
-  ]
-;;
+let nested_container_runtime_tokens = Nested_runtime.nested_container_runtime_tokens
+let sandbox_socket_markers = Nested_runtime.sandbox_socket_markers
 
-type shell_guard_token =
+type shell_guard_token = Nested_runtime.shell_guard_token =
   | Guard_word of string * bool
   | Guard_separator
 
-let shell_guard_tokens cmd =
-  let flush_word acc buf quoted =
-    if Buffer.length buf = 0
-    then acc
-    else (
-      let word = Buffer.contents buf |> String.lowercase_ascii in
-      Buffer.clear buf;
-      Guard_word (word, quoted) :: acc)
-  in
-  let len = String.length cmd in
-  let rec loop i quote quoted acc buf =
-    if i >= len
-    then List.rev (flush_word acc buf quoted)
-    else (
-      match quote, cmd.[i] with
-      | Some q, c when c = q -> loop (i + 1) None true acc buf
-      | Some _, c ->
-        Buffer.add_char buf c;
-        loop (i + 1) quote quoted acc buf
-      | None, (('\'' | '"') as q) -> loop (i + 1) (Some q) true acc buf
-      | None, (' ' | '\t' | '\r' | '\n') ->
-        let acc = flush_word acc buf quoted in
-        loop (i + 1) None false acc buf
-      | None, (';' | '|') ->
-        let acc = Guard_separator :: flush_word acc buf quoted in
-        loop (i + 1) None false acc buf
-      | None, '&' ->
-        let acc =
-          if i + 1 < len && cmd.[i + 1] = '&'
-          then Guard_separator :: flush_word acc buf quoted
-          else flush_word acc buf quoted
-        in
-        loop
-          (if i + 1 < len && cmd.[i + 1] = '&' then i + 2 else i + 1)
-          None
-          false
-          acc
-          buf
-      | None, c ->
-        Buffer.add_char buf c;
-        loop (i + 1) None quoted acc buf)
-  in
-  loop 0 None false [] (Buffer.create 32)
+let shell_guard_tokens = Nested_runtime.shell_guard_tokens
+let shell_assignment_like = Nested_runtime.shell_assignment_like
+let env_option_takes_arg = Nested_runtime.env_option_takes_arg
+let env_option_like = Nested_runtime.env_option_like
+let env_split_string_inline_value = Nested_runtime.env_split_string_inline_value
+let shell_interpreter_names = Nested_runtime.shell_interpreter_names
+let is_shell_interpreter = Nested_runtime.is_shell_interpreter
+let word_contains_runtime_token = Nested_runtime.word_contains_runtime_token
+let shell_c_payload = Nested_runtime.shell_c_payload
+let command_word_mentions_nested_runtime = Nested_runtime.command_word_mentions_nested_runtime
+
+let command_substitution_mentions_nested_runtime =
+  Nested_runtime.command_substitution_mentions_nested_runtime
 ;;
 
-let shell_assignment_like word =
-  match String.index_opt word '=' with
-  | None | Some 0 -> false
-  | Some idx ->
-    let ok_char = function
-      | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' -> true
-      | _ -> false
-    in
-    String.for_all ok_char (String.sub word 0 idx)
-;;
-
-let env_option_takes_arg = function
-  | "-u" | "--unset" | "-c" | "--chdir" -> true
-  | _ -> false
-;;
-
-let env_option_like word = String.length word > 0 && word.[0] = '-'
-
-let env_split_string_inline_value word =
-  let prefix = "--split-string=" in
-  if String.starts_with ~prefix word
-  then
-    Some
-      (String.sub word (String.length prefix) (String.length word - String.length prefix))
-  else None
-;;
-
-let shell_interpreter_names = [ "bash"; "sh"; "zsh" ]
-let is_shell_interpreter word = List.mem (Filename.basename word) shell_interpreter_names
-
-let word_contains_runtime_token text token =
-  String.equal (Filename.basename text) token
-  || String.starts_with ~prefix:("$(" ^ token) text
-  || String.starts_with ~prefix:("`" ^ token) text
-;;
-
-let shell_c_payload = function
-  | Guard_word (shell, false) :: rest when is_shell_interpreter shell ->
-    let rec loop = function
-      | [] -> None
-      | Guard_word (flag, false) :: Guard_word (payload, _) :: _
-        when String.length flag > 1 && flag.[0] = '-' && String.contains flag 'c' ->
-        Some payload
-      | Guard_word (flag, false) :: rest when String.length flag > 0 && flag.[0] = '-' ->
-        loop rest
-      | _ -> None
-    in
-    loop rest
-  | _ -> None
-;;
-
-let command_word_mentions_nested_runtime tokens =
-  let rec scan expect_command in_env skip_env_arg = function
-    | [] -> false
-    | Guard_separator :: rest -> scan true false false rest
-    | Guard_word (word, _) :: rest ->
-      if not expect_command
-      then scan false false false rest
-      else if in_env
-      then scan_env_word word skip_env_arg rest
-      else scan_command_word word rest
-  and scan_command_word word rest =
-    if List.exists (word_contains_runtime_token word) nested_container_runtime_tokens
-    then true
-    else if word = "sudo" || word = "command" || word = "time"
-    then scan true false false rest
-    else if word = "env"
-    then scan true true false rest
-    else if shell_assignment_like word
-    then scan true false false rest
-    else scan false false false rest
-  and scan_env_word word skip_env_arg rest =
-    if skip_env_arg
-    then scan true true false rest
-    else if word = "--"
-    then scan true false false rest
-    else if word = "-s" || word = "--split-string"
-    then (
-      match rest with
-      | Guard_word (split_arg, _) :: tail ->
-        nested_in_split_arg split_arg || scan true true false tail
-      | _ -> false)
-    else (
-      match env_split_string_inline_value word with
-      | Some split_arg -> nested_in_split_arg split_arg || scan true true false rest
-      | None ->
-        if shell_assignment_like word
-        then scan true true false rest
-        else if env_option_takes_arg word
-        then scan true true true rest
-        else if env_option_like word
-        then scan true true false rest
-        else scan_command_word word rest)
-  and nested_in_split_arg split_arg =
-    scan true false false (shell_guard_tokens split_arg)
-  in
-  scan true false false tokens
-;;
-
-let command_substitution_mentions_nested_runtime tokens =
-  List.exists
-    (function
-      | Guard_word (word, false)
-        when String.starts_with ~prefix:"$(" word || String.starts_with ~prefix:"`" word
-        -> List.exists (word_contains_runtime_token word) nested_container_runtime_tokens
-      | _ -> false)
-    tokens
-;;
-
-let unquoted_word_mentions_socket_marker tokens =
-  List.exists
-    (function
-      | Guard_word (word, false) ->
-        List.exists
-          (fun marker -> String_util.contains_substring word marker)
-          sandbox_socket_markers
-      | _ -> false)
-    tokens
-;;
-
-let rec command_uses_nested_container_runtime cmd =
-  let tokens = shell_guard_tokens cmd in
-  command_word_mentions_nested_runtime tokens
-  || command_substitution_mentions_nested_runtime tokens
-  || unquoted_word_mentions_socket_marker tokens
-  ||
-  match shell_c_payload tokens with
-  | None -> false
-  | Some payload -> command_uses_nested_container_runtime payload
-;;
+let unquoted_word_mentions_socket_marker = Nested_runtime.unquoted_word_mentions_socket_marker
+let command_uses_nested_container_runtime = Nested_runtime.command_uses_nested_container_runtime
 
 (* ── Sandbox runtime preflight ─────────────────────────── *)
 

--- a/lib/keeper/keeper_shell_docker_nested_runtime.ml
+++ b/lib/keeper/keeper_shell_docker_nested_runtime.ml
@@ -1,0 +1,208 @@
+(* Nested-container runtime detection for keeper_bash sandboxing.
+
+   When the sandbox profile forbids spawning Docker/Podman/nerdctl/
+   buildah from inside a sandboxed keeper, this module statically
+   detects whether a given shell command would trigger such a spawn.
+
+   Detection covers:
+   - direct command word (incl. `sudo`/`command`/`time`/`env` chains
+     and inline `VAR=value` env assignments)
+   - command substitution `$(...)` / backticks
+   - bare references to container daemon sockets (docker/podman/
+     containerd/buildkit)
+   - `sh -c '...'` payloads (recursive)
+
+   Extracted from [Keeper_shell_docker] (godfile decomp). Pure shell
+   tokenizer + classifier - no I/O, no shared state. *)
+
+let nested_container_runtime_tokens = [ "docker"; "podman"; "nerdctl"; "buildah" ]
+
+let sandbox_socket_markers =
+  [ "/var/run/docker.sock"
+  ; "/run/docker.sock"
+  ; "/run/podman/podman.sock"
+  ; "podman.sock"
+  ; "containerd.sock"
+  ; "buildkitd.sock"
+  ]
+;;
+
+type shell_guard_token =
+  | Guard_word of string * bool
+  | Guard_separator
+
+let shell_guard_tokens cmd =
+  let flush_word acc buf quoted =
+    if Buffer.length buf = 0
+    then acc
+    else (
+      let word = Buffer.contents buf |> String.lowercase_ascii in
+      Buffer.clear buf;
+      Guard_word (word, quoted) :: acc)
+  in
+  let len = String.length cmd in
+  let rec loop i quote quoted acc buf =
+    if i >= len
+    then List.rev (flush_word acc buf quoted)
+    else (
+      match quote, cmd.[i] with
+      | Some q, c when c = q -> loop (i + 1) None true acc buf
+      | Some _, c ->
+        Buffer.add_char buf c;
+        loop (i + 1) quote quoted acc buf
+      | None, (('\'' | '"') as q) -> loop (i + 1) (Some q) true acc buf
+      | None, (' ' | '\t' | '\r' | '\n') ->
+        let acc = flush_word acc buf quoted in
+        loop (i + 1) None false acc buf
+      | None, (';' | '|') ->
+        let acc = Guard_separator :: flush_word acc buf quoted in
+        loop (i + 1) None false acc buf
+      | None, '&' ->
+        let acc =
+          if i + 1 < len && cmd.[i + 1] = '&'
+          then Guard_separator :: flush_word acc buf quoted
+          else flush_word acc buf quoted
+        in
+        loop
+          (if i + 1 < len && cmd.[i + 1] = '&' then i + 2 else i + 1)
+          None
+          false
+          acc
+          buf
+      | None, c ->
+        Buffer.add_char buf c;
+        loop (i + 1) None quoted acc buf)
+  in
+  loop 0 None false [] (Buffer.create 32)
+;;
+
+let shell_assignment_like word =
+  match String.index_opt word '=' with
+  | None | Some 0 -> false
+  | Some idx ->
+    let ok_char = function
+      | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' -> true
+      | _ -> false
+    in
+    String.for_all ok_char (String.sub word 0 idx)
+;;
+
+let env_option_takes_arg = function
+  | "-u" | "--unset" | "-c" | "--chdir" -> true
+  | _ -> false
+;;
+
+let env_option_like word = String.length word > 0 && word.[0] = '-'
+
+let env_split_string_inline_value word =
+  let prefix = "--split-string=" in
+  if String.starts_with ~prefix word
+  then
+    Some
+      (String.sub word (String.length prefix) (String.length word - String.length prefix))
+  else None
+;;
+
+let shell_interpreter_names = [ "bash"; "sh"; "zsh" ]
+let is_shell_interpreter word = List.mem (Filename.basename word) shell_interpreter_names
+
+let word_contains_runtime_token text token =
+  String.equal (Filename.basename text) token
+  || String.starts_with ~prefix:("$(" ^ token) text
+  || String.starts_with ~prefix:("`" ^ token) text
+;;
+
+let shell_c_payload = function
+  | Guard_word (shell, false) :: rest when is_shell_interpreter shell ->
+    let rec loop = function
+      | [] -> None
+      | Guard_word (flag, false) :: Guard_word (payload, _) :: _
+        when String.length flag > 1 && flag.[0] = '-' && String.contains flag 'c' ->
+        Some payload
+      | Guard_word (flag, false) :: rest when String.length flag > 0 && flag.[0] = '-' ->
+        loop rest
+      | _ -> None
+    in
+    loop rest
+  | _ -> None
+;;
+
+let command_word_mentions_nested_runtime tokens =
+  let rec scan expect_command in_env skip_env_arg = function
+    | [] -> false
+    | Guard_separator :: rest -> scan true false false rest
+    | Guard_word (word, _) :: rest ->
+      if not expect_command
+      then scan false false false rest
+      else if in_env
+      then scan_env_word word skip_env_arg rest
+      else scan_command_word word rest
+  and scan_command_word word rest =
+    if List.exists (word_contains_runtime_token word) nested_container_runtime_tokens
+    then true
+    else if word = "sudo" || word = "command" || word = "time"
+    then scan true false false rest
+    else if word = "env"
+    then scan true true false rest
+    else if shell_assignment_like word
+    then scan true false false rest
+    else scan false false false rest
+  and scan_env_word word skip_env_arg rest =
+    if skip_env_arg
+    then scan true true false rest
+    else if word = "--"
+    then scan true false false rest
+    else if word = "-s" || word = "--split-string"
+    then (
+      match rest with
+      | Guard_word (split_arg, _) :: tail ->
+        nested_in_split_arg split_arg || scan true true false tail
+      | _ -> false)
+    else (
+      match env_split_string_inline_value word with
+      | Some split_arg -> nested_in_split_arg split_arg || scan true true false rest
+      | None ->
+        if shell_assignment_like word
+        then scan true true false rest
+        else if env_option_takes_arg word
+        then scan true true true rest
+        else if env_option_like word
+        then scan true true false rest
+        else scan_command_word word rest)
+  and nested_in_split_arg split_arg =
+    scan true false false (shell_guard_tokens split_arg)
+  in
+  scan true false false tokens
+;;
+
+let command_substitution_mentions_nested_runtime tokens =
+  List.exists
+    (function
+      | Guard_word (word, false)
+        when String.starts_with ~prefix:"$(" word || String.starts_with ~prefix:"`" word
+        -> List.exists (word_contains_runtime_token word) nested_container_runtime_tokens
+      | _ -> false)
+    tokens
+;;
+
+let unquoted_word_mentions_socket_marker tokens =
+  List.exists
+    (function
+      | Guard_word (word, false) ->
+        List.exists
+          (fun marker -> String_util.contains_substring word marker)
+          sandbox_socket_markers
+      | _ -> false)
+    tokens
+;;
+
+let rec command_uses_nested_container_runtime cmd =
+  let tokens = shell_guard_tokens cmd in
+  command_word_mentions_nested_runtime tokens
+  || command_substitution_mentions_nested_runtime tokens
+  || unquoted_word_mentions_socket_marker tokens
+  ||
+  match shell_c_payload tokens with
+  | None -> false
+  | Some payload -> command_uses_nested_container_runtime payload
+;;

--- a/lib/keeper/keeper_shell_docker_nested_runtime.mli
+++ b/lib/keeper/keeper_shell_docker_nested_runtime.mli
@@ -1,0 +1,29 @@
+(** Nested-container runtime detection for keeper_bash sandboxing.
+
+    Statically detects whether a shell command would spawn a nested
+    Docker/Podman/nerdctl/buildah runtime (or touch a container daemon
+    socket) when the sandbox profile forbids escape. *)
+
+val nested_container_runtime_tokens : string list
+val sandbox_socket_markers : string list
+
+type shell_guard_token =
+  | Guard_word of string * bool
+  | Guard_separator
+
+val shell_guard_tokens : string -> shell_guard_token list
+
+val shell_assignment_like : string -> bool
+val env_option_takes_arg : string -> bool
+val env_option_like : string -> bool
+val env_split_string_inline_value : string -> string option
+
+val shell_interpreter_names : string list
+val is_shell_interpreter : string -> bool
+val word_contains_runtime_token : string -> string -> bool
+val shell_c_payload : shell_guard_token list -> string option
+val command_word_mentions_nested_runtime : shell_guard_token list -> bool
+val command_substitution_mentions_nested_runtime : shell_guard_token list -> bool
+val unquoted_word_mentions_socket_marker : shell_guard_token list -> bool
+
+val command_uses_nested_container_runtime : string -> bool


### PR DESCRIPTION
## 요약

`keeper_shell_docker.ml` (1567 LoC post-#16796) 의 nested-container runtime detection cluster 를 신규 sibling 모듈로 추출했습니다. **-163 LoC** (1567 → 1404). 본 세션 최대 LoC reduction.

PR #16796 (docker_exec_failure) 의 후속.

## 추출 surface (2 상수 + 1 타입 + 14 함수)

| 분류 | 항목 |
|---|---|
| 상수 | `nested_container_runtime_tokens` (docker/podman/nerdctl/buildah), `sandbox_socket_markers` (6 daemon sockets) |
| 타입 | `shell_guard_token = Guard_word of string * bool \| Guard_separator` |
| Tokenizer | `shell_guard_tokens` (quote-aware shell word splitter) |
| Pattern helpers | `shell_assignment_like`, `env_option_takes_arg`, `env_option_like`, `env_split_string_inline_value`, `is_shell_interpreter`, `word_contains_runtime_token`, `shell_c_payload` |
| Detectors | `command_word_mentions_nested_runtime` (env-aware command scan with `sudo`/`command`/`time`/`env` chains), `command_substitution_mentions_nested_runtime`, `unquoted_word_mentions_socket_marker`, `command_uses_nested_container_runtime` (recursive `sh -c` payload analyzer) |

## 신규 모듈

- `lib/keeper/keeper_shell_docker_nested_runtime.ml` (208 LoC)
- `lib/keeper/keeper_shell_docker_nested_runtime.mli` (29 LoC)

## 의존성 (Stdlib + dependency module only)

- `Buffer`, `String`, `List`, `Filename`
- `String_util.contains_substring`

Shared state 0. Side effect 0 (pure shell tokenizer + classifier).

## 외부 caller 호환

- `test/test_keeper_bash_safety.ml` 10+ 사이트 (`Keeper_shell_docker.command_uses_nested_container_runtime`) → parent thin alias 로 그대로 호환.
- `keeper_shell_docker.mli` line-diff 0.

## 검증

- [x] `dune build --root . lib/keeper` PASS
- [x] transparent `shell_guard_token` alias 로 caller pattern match 호환
- [x] 함수 body 1-to-1 카피

## 패턴

Pure helper extraction with transparent type alias (PR #16770 keeper_heartbeat_stimulus_intake, #16838 native_tool_hint 와 동일). "sandbox escape detection (nested container runtime)" 는 docker exec orchestration (preflight check, mount path 변환, command rewrite) 와 별개 thematic concern — keeper_shell_docker 의 본 책임은 sandbox container exec wiring 이고, "spawn 차단 분석" 은 그 위 layer.

## Workaround Rejection Bar self-check

1. [ ] makes X visible only — NO
2. [ ] string classifier — NO (existing token list + recursive shell tokenizer 이동만; 새 분류기 추가 없음)
3. [ ] N-of-M — NO (전체 cluster 이동)
4. [ ] catch-all `_ ->` 추가 — NO
5. [ ] cap/cooldown/dedup/repair — NO
6. [ ] test backdoor — NO
7. [ ] N-사이트 typo — NO

PASS — pure refactor.

## RFC

RFC-WAIVED: `keeper_shell_docker_nested_runtime` 는 RFC-gated subsystem 아님. shell tokenizer + classifier 로 credential/auth 처리 부재.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
