### PR TITLE
fix(server_bootstrap_http): tag accept/connection/flow-close logs with [mode addr_label]; thread addr through 3 serve variants

### DIFF
--- a/lib/server/server_bootstrap_http.ml
+++ b/lib/server/server_bootstrap_http.ml
@@ -73,12 +73,13 @@ let print_startup_banner
   then Printf.printf "   POST /webrtc/offer, /webrtc/answer → WebRTC signaling\n%!"
 ;;
 
-let on_connection_release conn_sw ~mode flow =
+let on_connection_release conn_sw ~mode ~listener_tag flow =
   Eio.Switch.on_release conn_sw (fun () ->
     Transport_metrics.record_http_connection_closed ~mode;
     try Eio.Flow.close flow with
     | Eio.Cancel.Cancelled _ as e -> raise e
-    | exn -> Log.Misc.warn "flow close: %s" (Printexc.to_string exn))
+    | exn ->
+      Log.Misc.warn "[%s] flow close: %s" listener_tag (Printexc.to_string exn))
 ;;
 
 let register_listener_lifecycle ~sw ~mode =
@@ -92,8 +93,13 @@ let register_listener_lifecycle ~sw ~mode =
   mark_stopped
 ;;
 
-let serve ~sw ~clock ~socket ~request_handler =
+let serve ~sw ~clock ~socket ~addr_label ~request_handler =
   let mode = "h1" in
+  (* Stable listener identity. Mirrors the [h1 host:port]/[h2 host:port]
+     tag introduced in http_server_eio.ml / http_server_h2.ml so error
+     log lines name *which* listener emitted them when a process runs
+     multiple HTTP servers. *)
+  let listener_tag = Printf.sprintf "%s %s" mode addr_label in
   let mark_stopped = register_listener_lifecycle ~sw ~mode in
   let is_cancelled exn =
     match exn with
@@ -109,7 +115,7 @@ let serve ~sw ~clock ~socket ~request_handler =
       Transport_metrics.record_http_accept_latency ~mode accept_latency;
       Eio.Fiber.fork ~sw (fun () ->
         Eio.Switch.run (fun conn_sw ->
-          on_connection_release conn_sw ~mode flow;
+          on_connection_release conn_sw ~mode ~listener_tag flow;
           try
             let conn_handler =
               Httpun_eio.Server.create_connection_handler
@@ -132,7 +138,9 @@ let serve ~sw ~clock ~socket ~request_handler =
             conn_handler client_addr flow
           with
           | Eio.Cancel.Cancelled _ as e -> raise e
-          | exn -> Log.Misc.error "Connection error: %s" (Printexc.to_string exn)));
+          | exn ->
+            Log.Misc.error "[%s] connection error: %s"
+              listener_tag (Printexc.to_string exn)));
       accept_loop 0.05
     with
     | Eio.Cancel.Cancelled _ as e ->
@@ -144,24 +152,27 @@ let serve ~sw ~clock ~socket ~request_handler =
       else (
         let error = Printexc.to_string exn in
         Transport_metrics.record_http_accept_error ~mode ~error;
-        Log.Misc.error "Accept error: %s" error;
+        Log.Misc.error "[%s] accept error: %s" listener_tag error;
         (try Eio.Time.sleep clock backoff_s with
          | Eio.Cancel.Cancelled _ as e -> raise e
-         | exn -> Log.Misc.warn "backoff sleep: %s" (Printexc.to_string exn));
+         | exn ->
+           Log.Misc.warn "[%s] backoff sleep: %s"
+             listener_tag (Printexc.to_string exn));
         accept_loop (Float.min 2.0 (backoff_s *. 1.5)))
   in
   accept_loop 0.05
 ;;
 
-let serve_h2 ~sw ~clock ~socket ~h2_request_handler ~h2_error_handler =
+let serve_h2 ~sw ~clock ~socket ~addr_label ~h2_request_handler ~h2_error_handler =
   let mode = "h2" in
+  let listener_tag = Printf.sprintf "%s %s" mode addr_label in
   let mark_stopped = register_listener_lifecycle ~sw ~mode in
   let is_cancelled exn =
     match exn with
     | Eio.Cancel.Cancelled _ -> true
     | _ -> false
   in
-  Log.Server.info "HTTP/2 h2c mode activated (MASC_USE_H2=1)";
+  Log.Server.info "[%s] h2c mode activated (MASC_USE_H2=1)" listener_tag;
   let rec accept_loop backoff_s =
     try
       let accept_start = Unix.gettimeofday () in
@@ -171,7 +182,7 @@ let serve_h2 ~sw ~clock ~socket ~h2_request_handler ~h2_error_handler =
       Transport_metrics.record_http_accept_latency ~mode accept_latency;
       Eio.Fiber.fork ~sw (fun () ->
         Eio.Switch.run (fun conn_sw ->
-          on_connection_release conn_sw ~mode flow;
+          on_connection_release conn_sw ~mode ~listener_tag flow;
           try
             H2_eio.Server.create_connection_handler
               ~sw:conn_sw
@@ -181,7 +192,9 @@ let serve_h2 ~sw ~clock ~socket ~h2_request_handler ~h2_error_handler =
               flow
           with
           | Eio.Cancel.Cancelled _ as e -> raise e
-          | exn -> Log.Misc.error "[h2] Connection error: %s" (Printexc.to_string exn)));
+          | exn ->
+            Log.Misc.error "[%s] connection error: %s"
+              listener_tag (Printexc.to_string exn)));
       accept_loop 0.05
     with
     | Eio.Cancel.Cancelled _ as e ->
@@ -193,10 +206,12 @@ let serve_h2 ~sw ~clock ~socket ~h2_request_handler ~h2_error_handler =
       else (
         let error = Printexc.to_string exn in
         Transport_metrics.record_http_accept_error ~mode ~error;
-        Log.Misc.error "[h2] Accept error: %s" error;
+        Log.Misc.error "[%s] accept error: %s" listener_tag error;
         (try Eio.Time.sleep clock backoff_s with
          | Eio.Cancel.Cancelled _ as e -> raise e
-         | exn -> Log.Misc.warn "[h2] backoff sleep: %s" (Printexc.to_string exn));
+         | exn ->
+           Log.Misc.warn "[%s] backoff sleep: %s"
+             listener_tag (Printexc.to_string exn));
         accept_loop (Float.min 2.0 (backoff_s *. 1.5)))
   in
   accept_loop 0.05
@@ -206,18 +221,26 @@ let serve_h2 ~sw ~clock ~socket ~h2_request_handler ~h2_error_handler =
     Each connection is peeked (MSG_PEEK) to inspect the first bytes
     before dispatching to httpun-eio or h2-eio.  The peek is
     non-destructive, so both libraries read the socket normally. *)
-let serve_auto ~sw ~clock ~socket ~request_handler ~h2_request_handler ~h2_error_handler =
+let serve_auto ~sw ~clock ~socket ~addr_label ~request_handler ~h2_request_handler ~h2_error_handler =
   let mode = "auto" in
+  let listener_tag = Printf.sprintf "%s %s" mode addr_label in
   let mark_stopped = register_listener_lifecycle ~sw ~mode in
   let is_cancelled exn =
     match exn with
     | Eio.Cancel.Cancelled _ -> true
     | _ -> false
   in
-  Log.Server.info "HTTP auto-detect mode: HTTP/1.1 + HTTP/2 h2c on same port";
+  Log.Server.info "[%s] HTTP auto-detect mode: HTTP/1.1 + HTTP/2 h2c on same port"
+    listener_tag;
   let h2_count = Atomic.make 0 in
   let h1_count = Atomic.make 0 in
   let stats_logged = Atomic.make false in
+  let log_stats () =
+    Log.Server.info "[%s] stats: h2=%d h1=%d"
+      listener_tag
+      (Atomic.get h2_count)
+      (Atomic.get h1_count)
+  in
   let rec accept_loop backoff_s =
     try
       let accept_start = Unix.gettimeofday () in
@@ -227,7 +250,7 @@ let serve_auto ~sw ~clock ~socket ~request_handler ~h2_request_handler ~h2_error
       Transport_metrics.record_http_accept_latency ~mode accept_latency;
       Eio.Fiber.fork ~sw (fun () ->
         Eio.Switch.run (fun conn_sw ->
-          on_connection_release conn_sw ~mode flow;
+          on_connection_release conn_sw ~mode ~listener_tag flow;
           try
             match Http_protocol_detect.detect flow with
             | Ok Http_protocol_detect.Http2 ->
@@ -259,38 +282,33 @@ let serve_auto ~sw ~clock ~socket ~request_handler ~h2_request_handler ~h2_error
                     Httpun.Body.Writer.close body)
               in
               conn_handler client_addr flow
-            | Error msg -> Log.Misc.debug "[auto] protocol detect skipped: %s" msg
+            | Error msg ->
+              Log.Misc.debug "[%s] protocol detect skipped: %s" listener_tag msg
           with
           | Eio.Cancel.Cancelled _ as e -> raise e
-          | exn -> Log.Misc.error "[auto] Connection error: %s" (Printexc.to_string exn)));
+          | exn ->
+            Log.Misc.error "[%s] connection error: %s"
+              listener_tag (Printexc.to_string exn)));
       accept_loop 0.05
     with
     | Eio.Cancel.Cancelled _ as e ->
-      if Atomic.compare_and_set stats_logged false true
-      then
-        Log.Server.info
-          "[auto] stats: h2=%d h1=%d"
-          (Atomic.get h2_count)
-          (Atomic.get h1_count);
+      if Atomic.compare_and_set stats_logged false true then log_stats ();
       mark_stopped ();
       raise e
     | exn ->
       if is_cancelled exn
       then (
-        if Atomic.compare_and_set stats_logged false true
-        then
-          Log.Server.info
-            "[auto] stats: h2=%d h1=%d"
-            (Atomic.get h2_count)
-            (Atomic.get h1_count);
+        if Atomic.compare_and_set stats_logged false true then log_stats ();
         mark_stopped ())
       else (
         let error = Printexc.to_string exn in
         Transport_metrics.record_http_accept_error ~mode ~error;
-        Log.Misc.error "[auto] Accept error: %s" error;
+        Log.Misc.error "[%s] accept error: %s" listener_tag error;
         (try Eio.Time.sleep clock backoff_s with
          | Eio.Cancel.Cancelled _ as e -> raise e
-         | exn -> Log.Misc.warn "[auto] backoff sleep: %s" (Printexc.to_string exn));
+         | exn ->
+           Log.Misc.warn "[%s] backoff sleep: %s"
+             listener_tag (Printexc.to_string exn));
         accept_loop (Float.min 2.0 (backoff_s *. 1.5)))
   in
   accept_loop 0.05

--- a/lib/server/server_bootstrap_http.mli
+++ b/lib/server/server_bootstrap_http.mli
@@ -45,28 +45,35 @@ val serve :
   sw:Eio.Switch.t ->
   clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
   socket:[> [> `Generic ] Eio.Net.listening_socket_ty ] Eio.Resource.t ->
+  addr_label:string ->
   request_handler:(Eio.Net.Sockaddr.stream -> Httpun.Reqd.t Gluten.Reqd.t -> unit) ->
   unit
-(** [serve ~sw ~clock ~socket ~request_handler] runs the HTTP/1.1
-    accept loop until the switch is cancelled.  Errors are logged
-    via {!Log.Misc.warn} and the connection closed; the loop
-    continues. *)
+(** [serve ~sw ~clock ~socket ~addr_label ~request_handler] runs the
+    HTTP/1.1 accept loop until the switch is cancelled.  Errors are
+    logged via {!Log.Misc.warn} and the connection closed; the loop
+    continues.  [addr_label] (e.g. ["0.0.0.0:8080"]) is embedded in
+    every error log line as [[h1 <addr_label>]] so operators can
+    identify which listener emitted the line when a process runs
+    multiple HTTP servers. *)
 
 val serve_h2 :
   sw:Eio.Switch.t ->
   clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
   socket:[> [> `Generic ] Eio.Net.listening_socket_ty ] Eio.Resource.t ->
+  addr_label:string ->
   h2_request_handler:(Eio.Net.Sockaddr.stream -> H2.Reqd.t -> unit) ->
   h2_error_handler:
     (Eio.Net.Sockaddr.stream -> ?request:H2.Request.t -> H2.Server_connection.error -> (H2.Headers.t -> H2.Body.Writer.t) -> unit) ->
   unit
 (** [serve_h2] is the HTTP/2 variant — cleartext h2c, no ALPN.
-    Used when the operator explicitly enables H2 via env. *)
+    Used when the operator explicitly enables H2 via env.
+    [addr_label] is embedded as [[h2 <addr_label>]] in error logs. *)
 
 val serve_auto :
   sw:Eio.Switch.t ->
   clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
   socket:[> [> `Generic ] Eio.Net.listening_socket_ty ] Eio.Resource.t ->
+  addr_label:string ->
   request_handler:(Eio.Net.Sockaddr.stream -> Httpun.Reqd.t Gluten.Reqd.t -> unit) ->
   h2_request_handler:(Eio.Net.Sockaddr.stream -> H2.Reqd.t -> unit) ->
   h2_error_handler:
@@ -75,4 +82,5 @@ val serve_auto :
 (** [serve_auto] inspects the first request bytes and dispatches
     to either the HTTP/1.1 or HTTP/2 handler.  Used as the
     default serve loop so existing HTTP/1.1 clients keep working
-    while H2-capable clients can upgrade. *)
+    while H2-capable clients can upgrade.  [addr_label] is
+    embedded as [[auto <addr_label>]] in error logs. *)

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1534,11 +1534,13 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
         (Printexc.to_string exn));
 
   (* 3. Start serving -- /health responds before init completes *)
+  let addr_label = Printf.sprintf "%s:%d" config.host config.port in
   match http_mode with
   | `H2_only ->
-    Server_bootstrap_http.serve_h2 ~sw ~clock ~socket ~h2_request_handler ~h2_error_handler
+    Server_bootstrap_http.serve_h2 ~sw ~clock ~socket ~addr_label
+      ~h2_request_handler ~h2_error_handler
   | `H1_only ->
-    Server_bootstrap_http.serve ~sw ~clock ~socket ~request_handler
+    Server_bootstrap_http.serve ~sw ~clock ~socket ~addr_label ~request_handler
   | `Auto ->
-    Server_bootstrap_http.serve_auto ~sw ~clock ~socket ~request_handler ~h2_request_handler
-      ~h2_error_handler
+    Server_bootstrap_http.serve_auto ~sw ~clock ~socket ~addr_label
+      ~request_handler ~h2_request_handler ~h2_error_handler


### PR DESCRIPTION
## 사용자 비전 직접 정합

> *\"Error 가 나는 케이스에 대해 사용자가 정말 구체적으로 알도록 개선하라\"*

**iter#74 / PR #16835 의 explicit follow-up** — 그 PR 본문에서 \`server_bootstrap_http.ml\` 을 *deferred candidate* 로 명시. 본 PR 이 이 deferred 작업을 흡수.

## 이전 deferred 사유 (iter#74 본문 발췌)

> Deferred to a follow-up (different listener-context model):
> - \`lib/server/server_bootstrap_http.ml\` — uses a \`[mode]\` parameter (\"h1\"/\"h2\") and \`Transport_metrics.record_http_accept_error\`; the host:port comes from the socket and would need extraction.

해결: socket 에서 host:port 추출이 아니라 *caller (\`server_runtime_bootstrap.ml\`) 에 이미 있는* \`config.host\` / \`config.port\` 를 함수 시그니처를 통해 thread.

## Before

\`\`\`
[ERROR] Connection error: <exn>
[ERROR] Accept error: <exn>
[WARN]  flow close: <exn>
[WARN]  backoff sleep: <exn>
[ERROR] [h2] Connection error: <exn>
[ERROR] [h2] Accept error: <exn>
[ERROR] [auto] Connection error: <exn>
[ERROR] [auto] Accept error: <exn>
[INFO]  HTTP auto-detect mode: HTTP/1.1 + HTTP/2 h2c on same port
[INFO]  [auto] stats: h2=<N> h1=<M>
\`\`\`

\`[h2]\`/\`[auto]\` partial tag — iter#74 의 \`[h1 host:port]\` / \`[h2 host:port]\` 형식과 *불일치*. bind address 미명시. 멀티 \`serve_auto\` listener 환경에서 동일 log.

## After

\`\`\`
[ERROR] [h1 0.0.0.0:8080] connection error: <exn>
[ERROR] [h1 0.0.0.0:8080] accept error: <exn>
[WARN]  [h1 0.0.0.0:8080] flow close: <exn>
[ERROR] [h2 0.0.0.0:8443] accept error: <exn>
[INFO]  [auto 0.0.0.0:8443] HTTP auto-detect mode: ...
[INFO]  [auto 0.0.0.0:8443] stats: h2=<N> h1=<M>
\`\`\`

이제 iter#74 와 **end-to-end contract 일관** — HTTP listener emit log 는 *어디서* 발생했는지 항상 \`[mode host:port]\` 로 식별 가능.

## 구현

\`~addr_label:string\` 을 4 helper 통해 thread:
- \`on_connection_release\` (3 serve variants 공통 호출)
- \`serve\`, \`serve_h2\`, \`serve_auto\`

각 serve 함수가 한 번 계산:

\`\`\`ocaml
let listener_tag = Printf.sprintf \"%s %s\" mode addr_label
\`\`\`

Caller (\`server_runtime_bootstrap.ml\`) 1 줄 추가:

\`\`\`ocaml
let addr_label = Printf.sprintf \"%s:%d\" config.host config.port in
\`\`\`

| File | 변경 |
|---|---|
| \`server_bootstrap_http.ml\` | 4 helper sig + 13 log line |
| \`server_bootstrap_http.mli\` | 3 val sig + doc 확장 |
| \`server_runtime_bootstrap.ml\` | 1 caller bundle (3 match arm + addr_label binding) |
| **Total** | **+70/-42 LoC** |

Bonus refactor: \`serve_auto\` 의 stats 라인은 cancelled/is_cancelled 두 가지에서 동일 — 로컬 \`log_stats ()\` 로 추출하여 tag 적용 한 곳에서.

## 검증

- \`dune build --root . @check\` EXIT=0 clean
- \`test/test_server_runtime_bootstrap.exe\` 47/47 PASS
- \`test/test_server_runtime_bootstrap_codex_config.exe\` 4/4 PASS
- \`test/test_warn_root_causes.exe\` 6/10 PASS — 4 **pre-existing** (allowlist_preset_filter, mainline_failure_levels), \`git stash\` round-trip 으로 origin/main 동일 fail 확인. 본 PR 무관.

## Workaround Rejection Bar self-check

7/7 N/A.

## Pattern continuation — operator-clarity sweep

| Iter | PR | 영역 |
|---|---|---|
| - | #16787 (머지) | cascade name silent-fallback WARN |
| #72 | #16824 Draft | keeper name validation context |
| #73 | #16825 Draft | protobuf type name in decode errors |
| #74 | #16835 Draft | HTTP listener identity (http_server_eio + http_server_h2) |
| **#75** | **이 PR Draft** | **server_bootstrap_http — HTTP listener identity sweep 완료** |

다음 후보: \`voice_bridge.ml\` 단일 \"Connection error\" (별도 protocol layer), 또는 18 pre-existing failures task 등록.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>