### PR TITLE
ci(lint): wire check-variants.sh into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -832,6 +832,9 @@ jobs:
       - name: Run dashboard agent-status SSOT lint (RFC-0139 §10)
         run: bash scripts/lint/dashboard-ssot-agent-status.sh
 
+      - name: Run cross-language variant sync checker
+        run: bash scripts/check-variants.sh
+
       - name: Setup OCaml toolchain
         uses: ./.github/actions/setup-ocaml-toolchain
 


### PR DESCRIPTION
## Summary

Wire `scripts/check-variants.sh` into the CI lint job. The script exists on disk and is listed in the CI change-detect regex (`ci.yml:236`) but no job actually executes it — *ratchet theater*: path-filter creates the illusion of CI coverage while no enforcement runs.

Same shape as PR #16840 (`dashboard-ssot-agent-status.sh` wiring). Different from #16840 in that here the path-filter exists already, making the missed wiring more deceptive.

## What it enforces

The script checks 4 cross-language variant SSOT invariants:

| Check | OCaml type | Spec/UI counterpart |
|---|---|---|
| KeeperPhase | OCaml type | TLA+ KeeperPhase |
| turn_phase | OCaml type | TLA+ KeeperCascadeLifecycle.tla TurnPhaseSet |
| cascade_state | OCaml type | TLA+ KeeperCascadeLifecycle.tla CascadeSet |
| PHASE_STYLES coverage | OCaml KeeperPhase | TypeScript PHASE_STYLES record |

Without execution, drift between OCaml and TLA+ / TypeScript silently accumulates — exactly the kind of "spec lies about reality" leak the broader RFC-0138 / RFC-0139 dead-surface audit is currently cleaning up (PRs #16830, #16840, #16842, #16843).

## Change

`.github/workflows/ci.yml` line 832-833: add `Run cross-language variant sync checker` step right after the sibling dashboard SSOT guards. Path-filter entry at line 236 already includes `check-variants\.sh$` — no regex change needed.

## Verification

```bash
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"  # yaml valid

$ bash scripts/check-variants.sh
=== Check 1: KeeperPhase (OCaml) vs TLA+(KeeperPhase) ===
OK
=== Check 2: turn_phase (OCaml) vs KeeperCascadeLifecycle.tla domain ===
OK: OCaml(turn_phase) <-> TLA+(TurnPhaseSet) in sync (7 variants)
=== Check 3: cascade_state (OCaml) vs KeeperCascadeLifecycle.tla domain ===
OK: OCaml(cascade_state) <-> TLA+(CascadeSet) in sync (5 variants)
=== Check 4: PHASE_STYLES record coverage vs KeeperPhase type ===
OK: TypeScript(KeeperPhase) <-> TypeScript(PHASE_STYLES keys) in sync (13 variants)
=== check-variants: PASS ===
```

Script passes on current main, so wiring it does not break CI.

## Workaround Rejection Bar self-check

- §1 telemetry-as-fix / guard-as-fix: this PR *fixes* the exact pattern — script becomes live execution.
- §2 string classifier: none added.
- §3 N-of-M: closes 1 of 4 remaining unwired lint guards found in audit. The other 3 (`check_silent_failure.sh`, `check-tool-error-format.sh`, `check-oas-internals.sh`) have existing findings on main — separate PRs after allowlist mechanism lands.
- catch-all / cap / cooldown / dedup / repair: none.

## Audit context

Part of the broader dead-surface sweep (Iter 2):

| PR | Surface |
|---|---|
| #16830 | `server_dashboard_http_namespace_truth` dead helper + retired-knob table |
| #16840 | `dashboard-ssot-agent-status.sh` lint guard CI wiring |
| #16842 | `select_telemetry_summary_json` .mli docstring lie |
| #16843 | 18 dead env knobs + dead `module Cli` |
| **this PR** | **`check-variants.sh` lint guard CI wiring** |

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>