### PR TITLE
docs(mli): fix surface count drift in server_dashboard_http + execution_surfaces

### DIFF
--- a/lib/server/server_dashboard_http.mli
+++ b/lib/server/server_dashboard_http.mli
@@ -1,13 +1,14 @@
 (** Server_dashboard_http — Dashboard HTTP handlers (facade).
 
-    Cascade-includes 4 sub-modules so callers reach the
+    Cascade-includes 5 sub-modules so callers reach the
     dashboard surface through a single namespace:
     - {!Server_dashboard_http_core}
     - {!Server_dashboard_http_runtime_info}
     - {!Server_dashboard_http_execution_surfaces}
     - {!Server_dashboard_http_namespace_truth}
+    - {!Server_dashboard_http_memory_subsystems}
 
-    Plus 18 own helpers + 1 type — board / memory /
+    Plus 21 own helpers + 1 type — board / memory /
     governance / verification / planning / goals /
     keeper composite / fleet composite / operator
     action+confirm HTTP route entries.

--- a/lib/server/server_dashboard_http_execution_surfaces.mli
+++ b/lib/server/server_dashboard_http_execution_surfaces.mli
@@ -12,7 +12,7 @@
     [test/test_types.ml] for the
     lifecycle-event patcher family.
 
-    External surface (17 entries):
+    External surface (21 entries):
     - {b cache cells} ({!execution_cache},
       {!broadcast_namespace_truth_ref}) reached by
       [server_dashboard_http_namespace_truth] for
@@ -42,17 +42,22 @@
       [test/test_types] inline-aliases this module to
       assert every SSOT keeper-lifecycle event is
       handled (#8396).
+    - {b SSE-event row patchers}
+      ({!patch_keeper_row},
+      {!patch_surface_json_for_running_keepers}) —
+      pinned because [test/test_dashboard_execution]
+      tests their null-agent-shape tolerance directly
+      (test_patch_keeper_row_tolerates_null_agent_shape /
+      test_patch_surface_json_for_running_keepers_tolerates_null_agent).
 
     Internal helpers stay private at this boundary
-    (~15 internal lets — [shell_prewarm_timeout_s],
+    (~13 internal lets — [shell_prewarm_timeout_s],
     [_last_broadcast_hash] /
     [_broadcast_hash_mu] / [broadcast_cached_surface],
     [_transport_health_cache],
-    [keeper_agent_status_opt] / [patched_keeper_status]
-    / [patch_keeper_row] / [patch_keeper_rows]
-    SSE-event row patcher family,
-    [running_keeper_names] /
-    [patch_surface_json_for_running_keepers],
+    [keeper_agent_status_opt] / [patched_keeper_status],
+    [patch_keeper_rows] SSE-event row patcher helper,
+    [running_keeper_names],
     [patchexecution_cache_for_keeper] /
     [patch_operator_snapshot_cache_for_keeper],
     [transport_health_cache_diagnostics]). *)


### PR DESCRIPTION
## Summary

Two `.mli` files in `lib/server/` drift on declared external-surface counts and structure. Operators / new contributors reading the contract build wrong mental models. Same N-of-M doc-drift pattern as PR #16842 (`select_telemetry_summary_json` docstring lie).

## Findings

### 1. `lib/server/server_dashboard_http.mli` L1-13

| Claim | Reality | Drift |
|---|---|---|
| "Cascade-includes **4** sub-modules" | 5 includes (`server_dashboard_http.ml:3-6,149` adds `include Server_dashboard_http_memory_subsystems`) | wrong count + missing module in bullet list |
| "**18** own helpers + 1 type" | 21 vals | wrong count |

### 2. `lib/server/server_dashboard_http_execution_surfaces.mli` L15, 46-58

| Claim | Reality | Drift |
|---|---|---|
| "External surface (**17 entries**)" | 21 vals | wrong count |
| "Internal helpers stay private" listing `patch_keeper_row` and `patch_surface_json_for_running_keepers` | Both ARE `val` in the .mli (L203, L206) and are pinned by `test/test_dashboard_execution.ml:1170,1189` direct calls | private-vs-public contradiction |

The patcher symbols are public-by-test-requirement — same pattern as the existing lifecycle-event patcher block (pinned by `test/test_types`, #8396). The prose should reflect that.

## Changes

### `server_dashboard_http.mli`
- 4 → 5 sub-modules count
- 18 → 21 own helpers count
- Add `Server_dashboard_http_memory_subsystems` to the bullet list

### `server_dashboard_http_execution_surfaces.mli`
- 17 → 21 external surface count
- Move `patch_keeper_row` / `patch_surface_json_for_running_keepers` out of "Internal helpers" prose into a new "SSE-event row patchers" external bullet with the test pin rationale
- Adjust internal helper count: ~15 → ~13 (accounting for the two moved out)

## Out of scope

The `patchexecution_cache_for_keeper` typo (missing underscore between "patch" and "execution") exists in the actual function name at `server_dashboard_http_execution_surfaces.ml:509`. The .mli prose correctly references the actual symbol name. Fixing the function name itself is a separate refactor (renames + call-site updates).

## Verification

```bash
$ opam exec -- dune build --root . @check  # exit 0
$ rg "^val " lib/server/server_dashboard_http.mli | wc -l  # 21
$ rg "^val " lib/server/server_dashboard_http_execution_surfaces.mli | wc -l  # 21
$ rg "^include" lib/server/server_dashboard_http.ml | wc -l  # 5
```

## Workaround Rejection Bar self-check

- §1 telemetry-as-fix: not applicable, docstring correction.
- §2 string classifier: none.
- §3 N-of-M: 2 .mli files in one commit. Verified no other `lib/server/*.mli` has "N entries" / "N own helpers" / "N sub-modules" count claims at risk of drift.
- catch-all / cap / cooldown: none.

## Audit context

| PR | Surface |
|---|---|
| #16830 | `server_dashboard_http_namespace_truth` dead helper + retired-knob table |
| #16840 | `dashboard-ssot-agent-status.sh` lint guard CI wiring |
| #16842 | `select_telemetry_summary_json` .mli docstring lie (Dashboard_cache claim) |
| #16843 | 18 dead env knobs + dead `module Cli` |
| #16851 | `check-variants.sh` lint guard CI wiring (ratchet theater fix) |
| **this PR** | **2 .mli surface count + private-vs-public drift fixes** |

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>