### PR TITLE
test(keeper): align max execution cascade fixture

### DIFF
--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -8323,13 +8323,12 @@ let test_degraded_retry_slot_phase_allows_oas_timeout_local_recovery () =
 ;;
 
 let max_execution_time_cascade_exhausted_error () =
+  let detail = "Agent execution exceeded max_execution_time_s (276.561292)" in
   Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
     (Masc_mcp.Keeper_turn_driver.Cascade_exhausted
        {
          cascade_name = oas_error_cascade_name "strict_tool_candidates";
-         reason =
-           Keeper_types.Other_detail
-             "Agent execution exceeded max_execution_time_s (276.561292)";
+         reason = Keeper_types.cascade_exhaustion_reason_from_message detail;
        })
 ;;
 


### PR DESCRIPTION
## Summary
- Align the max_execution_time_s cascade exhaustion test fixture with the production SSOT helper.
- Use `Keeper_types.cascade_exhaustion_reason_from_message` so the fixture becomes `Structural_attempt_timeout`, matching the real cascade-exhaustion path described by the code comments.
- Fixes #16848.

## Validation
- ocamlformat --check test/test_keeper_unified.ml
- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=/private/tmp/masc-max-execution-slot-phase-build-20260520 scripts/dune-local.sh build test/test_keeper_unified.exe
- /private/tmp/masc-max-execution-slot-phase-build-20260520/default/test/test_keeper_unified.exe test --show-errors --color=never transient_network_error 61-63
- git diff --check