### PR TITLE
refactor(board_core): extract sub-board JSON serde + member parser into sibling

### DIFF
--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -409,18 +409,10 @@ let append_comment (c : comment) =
   | Sys_error msg -> record_persist_error ~where:"append_comment" msg
 ;;
 
-let sub_board_access_to_string = function
-  | Open -> "open"
-  | Members_only -> "members_only"
-  | Owner_only -> "owner_only"
-;;
-
-let sub_board_access_of_string_opt = function
-  | "open" -> Some Open
-  | "members_only" -> Some Members_only
-  | "owner_only" -> Some Owner_only
-  | _ -> None
-;;
+(* Sub-board JSON serde + member parser extracted to
+   [Board_sub_board_json] (godfile decomp). *)
+let sub_board_access_to_string = Board_sub_board_json.sub_board_access_to_string
+let sub_board_access_of_string_opt = Board_sub_board_json.sub_board_access_of_string_opt
 
 let sub_board_post_counts_unlocked store =
   let counts = Hashtbl.create 64 in
@@ -1294,77 +1286,11 @@ let toggle_reaction store ~target_type ~target_id ~user_id ~emoji
 
 (** {1 SubBoard Operations} *)
 
-let sub_board_to_yojson (sb : sub_board) : Yojson.Safe.t =
-  `Assoc
-    [ "id", `String (Sub_board_id.to_string sb.id)
-    ; "slug", `String sb.slug
-    ; "name", `String sb.name
-    ; "description", `String sb.description
-    ; "owner", `String (Agent_id.to_string sb.owner)
-    ; "members", `List (List.map (fun id -> `String (Agent_id.to_string id)) sb.members)
-    ; "access", `String (sub_board_access_to_string sb.access)
-    ; "created_at", `Float sb.created_at
-    ; "post_count", `Int sb.post_count
-    ]
-;;
-
-let dedupe_agent_ids ids =
-  let rec loop seen acc = function
-    | [] -> List.rev acc
-    | id :: rest ->
-      let name = Agent_id.to_string id in
-      if List.mem name seen
-      then loop seen acc rest
-      else loop (name :: seen) (id :: acc) rest
-  in
-  loop [] [] ids
-;;
-
-let parse_sub_board_members ~owner members =
-  let rec loop acc = function
-    | [] -> Ok (dedupe_agent_ids (owner :: List.rev acc))
-    | member_name :: rest ->
-      (match Agent_id.of_string member_name with
-       | Ok member_id -> loop (member_id :: acc) rest
-       | Error e -> Error e)
-  in
-  loop [] members
-;;
-
-let parse_sub_board_members_lenient ~owner members =
-  members
-  |> List.filter_map (fun member_name ->
-    match Agent_id.of_string member_name with
-    | Ok member_id -> Some member_id
-    | Error _ -> None)
-  |> fun parsed -> dedupe_agent_ids (owner :: parsed)
-;;
-
-let sub_board_of_yojson (json : Yojson.Safe.t) : sub_board option =
-  let open Safe_ops in
-  match json with
-  | `Assoc _ ->
-    let id_s = json_string_opt "id" json |> Option.value ~default:"" in
-    let slug = json_string_opt "slug" json |> Option.value ~default:"" in
-    let name = json_string_opt "name" json |> Option.value ~default:"" in
-    let description = json_string_opt "description" json |> Option.value ~default:"" in
-    let owner_s = json_string_opt "owner" json |> Option.value ~default:"" in
-    let access_s = json_string_opt "access" json |> Option.value ~default:"open" in
-    let created_at = json_float_opt "created_at" json |> Option.value ~default:0.0 in
-    let post_count = json_int_opt "post_count" json |> Option.value ~default:0 in
-    let member_names = json_string_list "members" json in
-    (match
-       ( Sub_board_id.of_string id_s
-       , Agent_id.of_string owner_s
-       , sub_board_access_of_string_opt access_s )
-     with
-     | Ok id, Ok owner, Some access when slug <> "" ->
-       let members = parse_sub_board_members_lenient ~owner member_names in
-       Some
-         { id; slug; name; description; owner; members; access; created_at; post_count }
-     | _ -> None)
-  | _ -> None
-;;
+let sub_board_to_yojson = Board_sub_board_json.sub_board_to_yojson
+let dedupe_agent_ids = Board_sub_board_json.dedupe_agent_ids
+let parse_sub_board_members = Board_sub_board_json.parse_sub_board_members
+let parse_sub_board_members_lenient = Board_sub_board_json.parse_sub_board_members_lenient
+let sub_board_of_yojson = Board_sub_board_json.sub_board_of_yojson
 
 let sub_boards_jsonl_unlocked store =
   let buf = Buffer.create 1024 in

--- a/lib/board_sub_board_json.ml
+++ b/lib/board_sub_board_json.ml
@@ -1,0 +1,95 @@
+(* Sub-board JSON serializer + member-list parser.
+
+   - Access mode <-> string conversion ([sub_board_access] variant).
+   - [sub_board] record <-> Yojson.Safe.t (used by HTTP routes, the
+     board tool surface, and the JSONL store rewrite path).
+   - Owner-injecting member-list parser (strict + lenient).
+
+   Extracted from [Board_core] (godfile decomp). Pure mapping. *)
+
+open Board_types
+
+let sub_board_access_to_string = function
+  | Open -> "open"
+  | Members_only -> "members_only"
+  | Owner_only -> "owner_only"
+;;
+
+let sub_board_access_of_string_opt = function
+  | "open" -> Some Open
+  | "members_only" -> Some Members_only
+  | "owner_only" -> Some Owner_only
+  | _ -> None
+;;
+
+let sub_board_to_yojson (sb : sub_board) : Yojson.Safe.t =
+  `Assoc
+    [ "id", `String (Sub_board_id.to_string sb.id)
+    ; "slug", `String sb.slug
+    ; "name", `String sb.name
+    ; "description", `String sb.description
+    ; "owner", `String (Agent_id.to_string sb.owner)
+    ; "members", `List (List.map (fun id -> `String (Agent_id.to_string id)) sb.members)
+    ; "access", `String (sub_board_access_to_string sb.access)
+    ; "created_at", `Float sb.created_at
+    ; "post_count", `Int sb.post_count
+    ]
+;;
+
+let dedupe_agent_ids ids =
+  let rec loop seen acc = function
+    | [] -> List.rev acc
+    | id :: rest ->
+      let name = Agent_id.to_string id in
+      if List.mem name seen
+      then loop seen acc rest
+      else loop (name :: seen) (id :: acc) rest
+  in
+  loop [] [] ids
+;;
+
+let parse_sub_board_members ~owner members =
+  let rec loop acc = function
+    | [] -> Ok (dedupe_agent_ids (owner :: List.rev acc))
+    | member_name :: rest ->
+      (match Agent_id.of_string member_name with
+       | Ok member_id -> loop (member_id :: acc) rest
+       | Error e -> Error e)
+  in
+  loop [] members
+;;
+
+let parse_sub_board_members_lenient ~owner members =
+  members
+  |> List.filter_map (fun member_name ->
+    match Agent_id.of_string member_name with
+    | Ok member_id -> Some member_id
+    | Error _ -> None)
+  |> fun parsed -> dedupe_agent_ids (owner :: parsed)
+;;
+
+let sub_board_of_yojson (json : Yojson.Safe.t) : sub_board option =
+  let open Safe_ops in
+  match json with
+  | `Assoc _ ->
+    let id_s = json_string_opt "id" json |> Option.value ~default:"" in
+    let slug = json_string_opt "slug" json |> Option.value ~default:"" in
+    let name = json_string_opt "name" json |> Option.value ~default:"" in
+    let description = json_string_opt "description" json |> Option.value ~default:"" in
+    let owner_s = json_string_opt "owner" json |> Option.value ~default:"" in
+    let access_s = json_string_opt "access" json |> Option.value ~default:"open" in
+    let created_at = json_float_opt "created_at" json |> Option.value ~default:0.0 in
+    let post_count = json_int_opt "post_count" json |> Option.value ~default:0 in
+    let member_names = json_string_list "members" json in
+    (match
+       ( Sub_board_id.of_string id_s
+       , Agent_id.of_string owner_s
+       , sub_board_access_of_string_opt access_s )
+     with
+     | Ok id, Ok owner, Some access when slug <> "" ->
+       let members = parse_sub_board_members_lenient ~owner member_names in
+       Some
+         { id; slug; name; description; owner; members; access; created_at; post_count }
+     | _ -> None)
+  | _ -> None
+;;

--- a/lib/board_sub_board_json.mli
+++ b/lib/board_sub_board_json.mli
@@ -1,0 +1,23 @@
+(** Sub-board JSON serializer + member-list parser. *)
+
+open Board_types
+
+val sub_board_access_to_string : sub_board_access -> string
+val sub_board_access_of_string_opt : string -> sub_board_access option
+val sub_board_to_yojson : sub_board -> Yojson.Safe.t
+val sub_board_of_yojson : Yojson.Safe.t -> sub_board option
+
+val dedupe_agent_ids : Agent_id.t list -> Agent_id.t list
+
+(** Parse a member-name list with owner injected, failing on the first
+    invalid agent id. *)
+val parse_sub_board_members
+  :  owner:Agent_id.t
+  -> string list
+  -> (Agent_id.t list, board_error) result
+
+(** Same as [parse_sub_board_members] but skips invalid agent ids. *)
+val parse_sub_board_members_lenient
+  :  owner:Agent_id.t
+  -> string list
+  -> Agent_id.t list


### PR DESCRIPTION
## 요약

`board_core.ml` (1589 LoC) 의 sub-board JSON serde + access mode 변환 + 멤버 리스트 파서 cluster 를 신규 sibling 모듈로 추출했습니다. **-74 LoC** (1589 → 1515).

PR #16836 (board_paths) 의 후속 — board_core 두 번째 분해.

## 추출 surface (7 pure functions)

| 함수 | 시그니처 |
|---|---|
| `sub_board_access_to_string` | `sub_board_access -> string` |
| `sub_board_access_of_string_opt` | `string -> sub_board_access option` |
| `sub_board_to_yojson` | `sub_board -> Yojson.Safe.t` |
| `sub_board_of_yojson` | `Yojson.Safe.t -> sub_board option` |
| `dedupe_agent_ids` | `Agent_id.t list -> Agent_id.t list` |
| `parse_sub_board_members` | `~owner -> string list -> (Agent_id.t list, board_error) result` |
| `parse_sub_board_members_lenient` | `~owner -> string list -> Agent_id.t list` |

## 신규 모듈

- `lib/board_sub_board_json.ml` (95 LoC)
- `lib/board_sub_board_json.mli` (23 LoC)

## 의존성 (전부 dependency module)

- `Board_types` (`sub_board`, `sub_board_access`, `board_error`, `Agent_id`)
- `Sub_board_id`, `Agent_id` (id 모듈)
- `Safe_ops.{json_string_opt, json_float_opt, json_int_opt, json_string_list}`

Shared state 0. Side effect 0 (pure mapping).

## 외부 caller 호환

- `lib/board_votes.ml:525` (`sub_board_of_yojson` via include chain) → 그대로 호환
- `bin/main_eio.ml:320`, `lib/tool_board_sub_board.ml`, `server_routes_http_routes_activity.ml`, `server_h2_gateway_routes_extra.ml` (모두 `Board.sub_board_*` via include chain) → parent thin alias 가 surface 유지 → 변경 0
- `board_core.mli` line-diff 0

## 검증

- [x] `dune build --root . lib` PASS
- [x] `board_core.mli` 변경 0 (parent alias)
- [x] 함수 body 1-to-1 카피
- [x] `.mli` 정정 1건: `parse_sub_board_members` 의 result 두 번째 인자가 `string` 이 아니라 `board_error` — `Agent_id.of_string` 의 실제 시그니처에 맞춤

## 패턴

Pure JSON serde extraction (PR #16832 mcp_tool_classifier, #16839 cli_argv_sanitize, #16847 logs_json 와 동일 thematic separation). sub_board CRUD orchestration (validate/create/update) 와 별개로 *sub_board ↔ JSON wire format* 책임이 명확히 분리됨.

## Workaround Rejection Bar self-check

1. [ ] makes X visible only — NO
2. [ ] string classifier — NO (existing access ↔ string 변환만 이동)
3. [ ] N-of-M — NO (전체 7 함수 이동)
4. [ ] catch-all `_ ->` 추가 — NO (existing `| _ -> None`/`| _ -> false` 유지)
5. [ ] cap/cooldown/dedup/repair — NO
6. [ ] test backdoor — NO
7. [ ] N-사이트 typo — NO

PASS — pure refactor.

## RFC

RFC-WAIVED: `lib/board_sub_board_json` 은 RFC-gated subsystem 아님.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
