### PR TITLE
fix(unreachable): replace 2 bare 'assert false' with invalid_arg + context

### DIFF
--- a/lib/exec/command_gate/shell_command_gate.ml
+++ b/lib/exec/command_gate/shell_command_gate.ml
@@ -95,8 +95,16 @@ let flatten_ir : SI.t -> flatten_result = function
             | SI.Simple s -> s
             | SI.Pipeline _ ->
               (* Unreachable: nested check above already excluded
-                 pipeline-of-pipeline shapes. *)
-              assert false)
+                 pipeline-of-pipeline shapes. [invalid_arg] (not
+                 [assert false]) per the convention in
+                 keeper_turn_fsm.ml:284 — operators reading a crash
+                 dump see *which* caller invariant was violated
+                 without cross-referencing line numbers. *)
+              invalid_arg
+                "Shell_command_gate.flatten_ir: caller invariant — \
+                 nested-pipeline pre-check above already excluded \
+                 SI.Pipeline from this map but SI.Pipeline reached \
+                 the second pass")
           stages
       in
       Flat_pipeline simples

--- a/lib/llm_metric_bridge.ml
+++ b/lib/llm_metric_bridge.ml
@@ -290,8 +290,14 @@ let ms_invalid_reason = function
   | Ms_valid _ ->
     (* Unreachable — caller only invokes on invalid branches. The
        exhaustive match is preserved here so adding a new invalid
-       variant in [ms_duration] forces a compile error here too. *)
-    assert false
+       variant in [ms_duration] forces a compile error here too.
+       [invalid_arg] (not [assert false]) per the convention in
+       keeper_turn_fsm.ml:284 — operators reading a crash dump
+       see *which* caller invariant was violated without
+       cross-referencing line numbers. *)
+    invalid_arg
+      "Llm_metric_bridge.ms_invalid_reason: caller invariant — function \
+       only accepts Ms_invalid_* variants but received Ms_valid"
 
 let streaming_first_chunk_invalid_metric =
   Prometheus.metric_llm_provider_streaming_first_chunk_invalid


### PR DESCRIPTION
## 사용자 비전 직접 정합

> *\"Error 가 나는 케이스에 대해 사용자가 정말 구체적으로 알도록 개선하라\"*

본 PR 은 *이미 codebase 에 존재하는 convention 을 위반하던 2 사이트* 를 정렬.

## Convention (이미 keeper_turn_fsm.ml:284 에 명시)

> [Invalid_argument] (not [assert false]) carries an explicit message into the re-raise backtrace. Operators reading a crash dump or test failure see the violating transition + reason without having to cross-reference the WARN line by keeper/turn id.

## Before — context-free crash dumps

\`\`\`
Fatal error: exception Assertion_failed(\"llm_metric_bridge.ml\", 294, 4)
\`\`\`

operator 는 file:line:col 만 보고, *어떤 caller invariant* 가 깨졌는지 알 수 없음. 두 사이트는 *주석에 \"Unreachable —\"* 라고 적혀있지만 crash dump 에는 그 약속이 남지 않음.

## After — function-qualified, invariant-naming exception

\`\`\`
Fatal error: exception Invalid_argument(
  \"Llm_metric_bridge.ms_invalid_reason: caller invariant — function \\
   only accepts Ms_invalid_* variants but received Ms_valid\")
\`\`\`

이제 crash dump 만 보고 즉시:
- 어느 함수의 invariant 가 violated 인지
- 어떤 입력이 잘못된 것인지
- 어떤 caller assumption 이 깨졌는지

## 변경 사이트 (2)

| File:Line | Function | Caller invariant |
|---|---|---|
| \`lib/llm_metric_bridge.ml:294\` | \`ms_invalid_reason\` | caller 만 invalid 변형 호출 (Ms_valid 차단) |
| \`lib/exec/command_gate/shell_command_gate.ml:99\` | \`flatten_ir\` | nested-pipeline pre-check 이 이미 SI.Pipeline 제거 |

각 사이트는 *exhaustive match* shape 유지 — \`ms_duration\` 또는 \`SI.t\` 에 새 variant 추가 시 컴파일러가 여전히 에러.

## Convention reference

- \`lib/keeper/keeper_turn_fsm.ml:284\` — codebase 최초의 \"invalid_arg over assert false\" 명시
- iter#73 / PR #16825 (grpc decode \`~type_name\`) — 동일 가족 패턴 (crash payload 가 operator-actionable)

## 검증

- \`dune build --root . @check\` EXIT=0 clean
- \`test/test_llm_metric_bridge.exe\` 12/12 PASS
- \`test/test_shell_command_gate.exe\` 17/17 PASS
- \`test/test_exec_shell_command_gate.exe\` 14/15 PASS — 1 **pre-existing** (phase_0_corpus / baseline.jsonl pinned), \`git stash\` round-trip 으로 origin/main 동일 확인. 본 PR 무관.

## Workaround Rejection Bar self-check

7/7 N/A.

## Pattern continuation — operator-clarity sweep

| Iter | PR | 영역 |
|---|---|---|
| - | #16787 (머지) | cascade name silent-fallback WARN |
| #72 | #16824 Draft | keeper name validation context |
| #73 | #16825 Draft | protobuf type name in decode errors |
| #74 | #16835 Draft | HTTP listener identity (eio + h2) |
| #75 | #16850 Draft | server_bootstrap_http listener identity completion |
| **#76** | **이 PR Draft** | **assert false → invalid_arg with caller-invariant message** |

다음 후보:
- 18 pre-existing failures (allowlist_preset_filter, mainline_failure_levels, source_guard, etc.) task 등록
- voice_bridge.ml \"Connection error\" 단일 사이트
- 다른 영역 (dashboard / FSM / stub)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>