### PR TITLE
refactor(server): extract compact-receipt JSON builders into sibling module

### DIFF
--- a/lib/server/server_dashboard_compact_receipt_json.ml
+++ b/lib/server/server_dashboard_compact_receipt_json.ml
@@ -1,0 +1,123 @@
+(* Compact-receipt JSON builders for the dashboard composite endpoint.
+
+   The dashboard composite surface ships a *summary* of the most recent
+   keeper receipt (error / cascade / tool-surface blocks) rather than
+   the raw receipt JSON.  These helpers do the field projection +
+   truncation so the wire payload stays bounded.
+
+   Extracted from [Server_dashboard_http] (godfile decomp). Pure JSON
+   mapping over receipt-shaped [Yojson.Safe.t] values.  No shared
+   state, no I/O. *)
+
+let compact_preview ~max_chars text =
+  let text = String.trim text in
+  if String.length text <= max_chars
+  then text, false
+  else String.sub text 0 max_chars ^ "...", true
+;;
+
+(* Local member-lookup helper.  The parent's [json_member] returns
+   `Null on miss; matching that shape lets the caller pattern-match
+   on `Assoc / `Null without options. *)
+let json_member key = function
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some v -> v
+     | None -> `Null)
+  | _ -> `Null
+;;
+
+let json_string key json = Json_util.get_string json key
+let json_int key json = Json_util.get_int json key
+let json_bool key json = Json_util.get_bool json key
+
+let compact_receipt_error_json receipt =
+  match json_member "error" receipt with
+  | `Assoc _ as error ->
+    let kind = json_string "kind" error in
+    let message = json_string "message" error in
+    let message_preview, message_truncated =
+      match message with
+      | Some value -> compact_preview ~max_chars:900 value
+      | None -> "", false
+    in
+    `Assoc
+      [ "kind", Json_util.string_opt_to_json kind
+      ; ( "message_preview"
+        , match message with
+          | Some _ -> `String message_preview
+          | None -> `Null )
+      ; "message_truncated", `Bool message_truncated
+      ]
+  | _ -> `Null
+;;
+
+let compact_receipt_cascade_json receipt =
+  match json_member "cascade" receipt with
+  | `Assoc _ as cascade ->
+    `Assoc
+      [ "name", Json_util.string_opt_to_json (json_string "name" cascade)
+      ; "selected_model", `Null
+      ; "attempt_count", Json_util.int_opt_to_json (json_int "attempt_count" cascade)
+      ; ( "fallback_applied"
+        , Json_util.bool_opt_to_json (json_bool "fallback_applied" cascade) )
+      ; "outcome", Json_util.string_opt_to_json (json_string "outcome" cascade)
+      ; ( "degraded_retry_applied"
+        , Json_util.bool_opt_to_json (json_bool "degraded_retry_applied" cascade) )
+      ; ( "degraded_retry_cascade"
+        , Json_util.string_opt_to_json (json_string "degraded_retry_cascade" cascade) )
+      ; ( "fallback_reason"
+        , Json_util.string_opt_to_json (json_string "fallback_reason" cascade) )
+      ]
+  | _ -> `Null
+;;
+
+let compact_receipt_tool_surface_json receipt =
+  let surface =
+    match json_member "tool_surface" receipt with
+    | `Assoc _ as surface -> surface
+    | _ -> json_member "tool_contract" receipt
+  in
+  match surface with
+  | `Assoc _ as surface ->
+    let tool_requirement = json_string "tool_requirement" surface in
+    let unexpected_tools = Json_util.get_string_list receipt "unexpected_tools" in
+    let turn_lane =
+      (* Wire values come from [Keeper_agent_tool_surface.tool_requirement_to_yojson]
+         (lib/keeper/keeper_agent_tool_surface.ml): "required", "optional", "none".
+         The earlier "no_tools" literal never fired because [No_tools] serializes
+         to "none" — leaving turn_lane=null on no-tool receipts that omit an
+         explicit turn_lane. *)
+      match json_string "turn_lane" surface, tool_requirement with
+      | Some value, _ -> Some value
+      | None, Some "required" -> Some "tool_required"
+      | None, Some "optional" -> Some "tool_optional"
+      | None, Some "none" -> Some "text_only"
+      | None, _ -> None
+    in
+    `Assoc
+      [ "tool_requirement", Json_util.string_opt_to_json tool_requirement
+      ; "turn_lane", Json_util.string_opt_to_json turn_lane
+      ; ( "tool_surface_class"
+        , Json_util.string_opt_to_json (json_string "tool_surface_class" surface) )
+      ; ( "visible_tool_count"
+        , Json_util.int_opt_to_json (json_int "visible_tool_count" surface) )
+      ; ( "tool_gate_enabled"
+        , Json_util.bool_opt_to_json (json_bool "tool_gate_enabled" surface) )
+      ; ( "tool_surface_fallback_used"
+        , Json_util.bool_opt_to_json
+            (json_bool "tool_surface_fallback_used" surface) )
+      ; ( "missing_required_tools"
+        , Json_util.json_string_list
+            (Json_util.get_string_list surface "missing_required_tools") )
+      ; ( "required_tools"
+        , Json_util.json_string_list (Json_util.get_string_list surface "required_tools")
+        )
+      ; ( "required_tool_candidates"
+        , Json_util.json_string_list
+            (Json_util.get_string_list surface "required_tool_candidates") )
+      ; "unexpected_tools", Json_util.json_string_list unexpected_tools
+      ; "unexpected_tool_count", `Int (List.length unexpected_tools)
+      ]
+  | _ -> `Null
+;;

--- a/lib/server/server_dashboard_compact_receipt_json.mli
+++ b/lib/server/server_dashboard_compact_receipt_json.mli
@@ -1,0 +1,9 @@
+(** Compact-receipt JSON builders for the dashboard composite endpoint. *)
+
+(** Truncate to [max_chars] (after [String.trim]) with a trailing
+    ["..."] when truncated.  Returns [(text, truncated_flag)]. *)
+val compact_preview : max_chars:int -> string -> string * bool
+
+val compact_receipt_error_json : Yojson.Safe.t -> Yojson.Safe.t
+val compact_receipt_cascade_json : Yojson.Safe.t -> Yojson.Safe.t
+val compact_receipt_tool_surface_json : Yojson.Safe.t -> Yojson.Safe.t

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -507,95 +507,13 @@ let json_int key json = Json_util.get_int json key
 let json_float key json = Json_util.get_float json key
 let json_bool key json = Json_util.get_bool json key
 
-let compact_receipt_error_json receipt =
-  match json_member "error" receipt with
-  | `Assoc _ as error ->
-    let kind = json_string "kind" error in
-    let message = json_string "message" error in
-    let message_preview, message_truncated =
-      match message with
-      | Some value -> compact_preview ~max_chars:900 value
-      | None -> "", false
-    in
-    `Assoc
-      [ "kind", Json_util.string_opt_to_json kind
-      ; ( "message_preview"
-        , match message with
-          | Some _ -> `String message_preview
-          | None -> `Null )
-      ; "message_truncated", `Bool message_truncated
-      ]
-  | _ -> `Null
-;;
+(* Compact-receipt JSON builders extracted to
+   [Server_dashboard_compact_receipt_json] (godfile decomp). *)
+let compact_receipt_error_json = Server_dashboard_compact_receipt_json.compact_receipt_error_json
+let compact_receipt_cascade_json = Server_dashboard_compact_receipt_json.compact_receipt_cascade_json
 
-let compact_receipt_cascade_json receipt =
-  match json_member "cascade" receipt with
-  | `Assoc _ as cascade ->
-    `Assoc
-      [ "name", Json_util.string_opt_to_json (json_string "name" cascade)
-      ; "selected_model", `Null
-      ; "attempt_count", Json_util.int_opt_to_json (json_int "attempt_count" cascade)
-      ; ( "fallback_applied"
-        , Json_util.bool_opt_to_json (json_bool "fallback_applied" cascade) )
-      ; "outcome", Json_util.string_opt_to_json (json_string "outcome" cascade)
-      ; ( "degraded_retry_applied"
-        , Json_util.bool_opt_to_json (json_bool "degraded_retry_applied" cascade) )
-      ; ( "degraded_retry_cascade"
-        , Json_util.string_opt_to_json (json_string "degraded_retry_cascade" cascade) )
-      ; ( "fallback_reason"
-        , Json_util.string_opt_to_json (json_string "fallback_reason" cascade) )
-      ]
-  | _ -> `Null
-;;
-
-let compact_receipt_tool_surface_json receipt =
-  let surface =
-    match json_member "tool_surface" receipt with
-    | `Assoc _ as surface -> surface
-    | _ -> json_member "tool_contract" receipt
-  in
-  match surface with
-  | `Assoc _ as surface ->
-    let tool_requirement = json_string "tool_requirement" surface in
-    let unexpected_tools = Json_util.get_string_list receipt "unexpected_tools" in
-    let turn_lane =
-      (* Wire values come from [Keeper_agent_tool_surface.tool_requirement_to_yojson]
-         (lib/keeper/keeper_agent_tool_surface.ml): "required", "optional", "none".
-         The earlier "no_tools" literal never fired because [No_tools] serializes
-         to "none" — leaving turn_lane=null on no-tool receipts that omit an
-         explicit turn_lane. *)
-      match json_string "turn_lane" surface, tool_requirement with
-      | Some value, _ -> Some value
-      | None, Some "required" -> Some "tool_required"
-      | None, Some "optional" -> Some "tool_optional"
-      | None, Some "none" -> Some "text_only"
-      | None, _ -> None
-    in
-    `Assoc
-      [ "tool_requirement", Json_util.string_opt_to_json tool_requirement
-      ; "turn_lane", Json_util.string_opt_to_json turn_lane
-      ; ( "tool_surface_class"
-        , Json_util.string_opt_to_json (json_string "tool_surface_class" surface) )
-      ; ( "visible_tool_count"
-        , Json_util.int_opt_to_json (json_int "visible_tool_count" surface) )
-      ; ( "tool_gate_enabled"
-        , Json_util.bool_opt_to_json (json_bool "tool_gate_enabled" surface) )
-      ; ( "tool_surface_fallback_used"
-        , Json_util.bool_opt_to_json
-            (json_bool "tool_surface_fallback_used" surface) )
-      ; ( "missing_required_tools"
-        , Json_util.json_string_list
-            (Json_util.get_string_list surface "missing_required_tools") )
-      ; ( "required_tools"
-        , Json_util.json_string_list (Json_util.get_string_list surface "required_tools")
-        )
-      ; ( "required_tool_candidates"
-        , Json_util.json_string_list
-            (Json_util.get_string_list surface "required_tool_candidates") )
-      ; "unexpected_tools", Json_util.json_string_list unexpected_tools
-      ; "unexpected_tool_count", `Int (List.length unexpected_tools)
-      ]
-  | _ -> `Null
+let compact_receipt_tool_surface_json =
+  Server_dashboard_compact_receipt_json.compact_receipt_tool_surface_json
 ;;
 
 let json_number key json =


### PR DESCRIPTION
## 요약

`server_dashboard_http.ml` (1500 LoC) 의 dashboard composite endpoint 용 compact-receipt JSON builder cluster 를 신규 sibling 모듈로 추출했습니다. **-82 LoC** (1500 → 1418).

server_dashboard_http 첫 분해.

## 추출 surface (3 pure JSON builders + 1 helper)

| 함수 | 시그니처 |
|---|---|
| `compact_preview` | `~max_chars -> string -> string * bool` (truncate + ellipsis) |
| `compact_receipt_error_json` | `Yojson.Safe.t -> Yojson.Safe.t` (kind + preview + truncated flag) |
| `compact_receipt_cascade_json` | `Yojson.Safe.t -> Yojson.Safe.t` (name/attempt_count/fallback_*/outcome) |
| `compact_receipt_tool_surface_json` | `Yojson.Safe.t -> Yojson.Safe.t` (tool_requirement→turn_lane 매핑 + surface fields) |

## 신규 모듈

- `lib/server/server_dashboard_compact_receipt_json.ml` (123 LoC)
- `lib/server/server_dashboard_compact_receipt_json.mli` (9 LoC)

## 의존성 (전부 dependency module)

- `Json_util.{get_string, get_int, get_bool, get_string_list, string_opt_to_json, int_opt_to_json, bool_opt_to_json, json_string_list}`
- `String`, `List` (Stdlib)

Shared state 0. Side effect 0 (pure JSON mapping).

## 외부 caller 호환

- 외부 caller 0 (`compact_receipt_*` 는 parent module 외부에서 호출 안 됨)
- 내부 caller 3 site at lines 821-823 (`composite_execution_receipt_json`) → parent thin alias 가 시그니처 유지 → 변경 0
- `compact_preview` + `json_member`/`json_string`/`_int`/`_bool` 는 parent 가 다른 자리에서도 사용하므로 parent 에 그대로 유지 (sibling 에서 동일 헬퍼 재정의 — file 경계가 명확해야 sibling standalone build 가능)

## 검증

- [x] `dune build --root . lib/server` PASS
- [x] public surface 변경 0 (parent alias 호환)
- [x] 함수 body 1-to-1 카피
- [x] `turn_lane` 매핑 (required→tool_required, optional→tool_optional, none→text_only) byte-identical 보존

## 패턴

Pure JSON builder extraction (PR #16794, #16831, #16847, #16855 와 동일). "composite receipt 의 compact projection" 은 dashboard endpoint 의 wire shape 책임으로, `composite_execution_receipt_json` 한 caller 가 3개 함수를 묶어 사용 — 응답 조합 (composite) 와 별개로 분리 가능.

## Workaround Rejection Bar self-check

1. [ ] makes X visible only — NO
2. [ ] string classifier — NO (existing tool_requirement→turn_lane 매핑 5분기 이동만)
3. [ ] N-of-M — NO (전체 cluster 이동)
4. [ ] catch-all `_ ->` 추가 — NO (existing `| _ -> `Null` 유지)
5. [ ] cap/cooldown/dedup/repair — NO
6. [ ] test backdoor — NO
7. [ ] N-사이트 typo — NO

PASS — pure refactor.

## RFC

RFC-WAIVED: `lib/server` non-credential refactor.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
