### PR TITLE
refactor(server): extract board SSE event JSON projection into sibling module

### DIFF
--- a/lib/server/server_bootstrap_board_sse_events.ml
+++ b/lib/server/server_bootstrap_board_sse_events.ml
@@ -1,0 +1,75 @@
+(* Board SSE event -> JSON params projection.
+
+   Maps the [Board_dispatch.board_sse_event] sum type into the wire
+   payload broadcast on the [/sse/board] stream (post.created /
+   comment.created / vote.changed / reaction.changed).  Carries actor
+   identity through [Server_utils.board_actor_identity_json] so the
+   dashboard can route per-author UI.
+
+   Extracted from [Server_bootstrap_loops] (godfile decomp). Pure
+   mapping over [Board_dispatch] variants - no I/O, no shared state. *)
+
+let board_sse_event_params event =
+  match event with
+  | Board_dispatch.Post_created { post_id; author; title; content; post_kind; hearth } ->
+    let preview =
+      if String.length content > 200 then String.sub content 0 200 else content
+    in
+    let base =
+      [ "type", `String "post_created"
+      ; "event_type", `String "post.created"
+      ; "post_id", `String post_id
+      ; "author", `String author
+      ; "author_identity", Server_utils.board_actor_identity_json author
+      ; "title", `String title
+      ; "content", `String preview
+      ; "post_kind", `String (Board.post_kind_to_string post_kind)
+      ]
+    in
+    `Assoc
+      (match hearth with
+       | Some h -> ("hearth", `String h) :: base
+       | None -> base)
+  | Board_dispatch.Comment_added { post_id; comment_id; author } ->
+    `Assoc
+      [ "type", `String "comment_added"
+      ; "event_type", `String "comment.created"
+      ; "post_id", `String post_id
+      ; "comment_id", `String comment_id
+      ; "author", `String author
+      ; "author_identity", Server_utils.board_actor_identity_json author
+      ]
+  | Board_dispatch.Post_voted { post_id; voter; direction } ->
+    let dir = Board_votes.vote_direction_to_string direction in
+    `Assoc
+      [ "type", `String "post_voted"
+      ; "event_type", `String "vote.changed"
+      ; "target_type", `String "post"
+      ; "post_id", `String post_id
+      ; "voter", `String voter
+      ; "voter_identity", Server_utils.board_actor_identity_json voter
+      ; "direction", `String dir
+      ]
+  | Board_dispatch.Comment_voted { comment_id; voter; direction } ->
+    let dir = Board_votes.vote_direction_to_string direction in
+    `Assoc
+      [ "type", `String "comment_voted"
+      ; "event_type", `String "vote.changed"
+      ; "target_type", `String "comment"
+      ; "comment_id", `String comment_id
+      ; "voter", `String voter
+      ; "voter_identity", Server_utils.board_actor_identity_json voter
+      ; "direction", `String dir
+      ]
+  | Board_dispatch.Reaction_changed { target_type; target_id; user_id; emoji; reacted } ->
+    `Assoc
+      [ "type", `String "reaction_changed"
+      ; "event_type", `String "reaction.changed"
+      ; "target_type", `String (Board.reaction_target_type_to_string target_type)
+      ; "target_id", `String target_id
+      ; "user_id", `String user_id
+      ; "user_identity", Server_utils.board_actor_identity_json user_id
+      ; "emoji", `String emoji
+      ; "reacted", `Bool reacted
+      ]
+;;

--- a/lib/server/server_bootstrap_board_sse_events.mli
+++ b/lib/server/server_bootstrap_board_sse_events.mli
@@ -1,0 +1,6 @@
+(** Board SSE event -> JSON params projection.
+
+    Wire payload format consumed by the [/sse/board] stream and by
+    [test/test_board_sse_canonical_event_type.ml]. *)
+
+val board_sse_event_params : Board_dispatch.board_sse_event -> Yojson.Safe.t

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -41,70 +41,9 @@ let autoboot_proactive_warmup_sec ~base_warmup ~stagger_window_sec ~keeper_name 
   else base_warmup + (stable_keeper_name_hash keeper_name mod (stagger_window_sec + 1))
 ;;
 
-let board_sse_event_params event =
-  match event with
-  | Board_dispatch.Post_created { post_id; author; title; content; post_kind; hearth } ->
-    let preview =
-      if String.length content > 200 then String.sub content 0 200 else content
-    in
-    let base =
-      [ "type", `String "post_created"
-      ; "event_type", `String "post.created"
-      ; "post_id", `String post_id
-      ; "author", `String author
-      ; "author_identity", Server_utils.board_actor_identity_json author
-      ; "title", `String title
-      ; "content", `String preview
-      ; "post_kind", `String (Board.post_kind_to_string post_kind)
-      ]
-    in
-    `Assoc
-      (match hearth with
-       | Some h -> ("hearth", `String h) :: base
-       | None -> base)
-  | Board_dispatch.Comment_added { post_id; comment_id; author } ->
-    `Assoc
-      [ "type", `String "comment_added"
-      ; "event_type", `String "comment.created"
-      ; "post_id", `String post_id
-      ; "comment_id", `String comment_id
-      ; "author", `String author
-      ; "author_identity", Server_utils.board_actor_identity_json author
-      ]
-  | Board_dispatch.Post_voted { post_id; voter; direction } ->
-    let dir = Board_votes.vote_direction_to_string direction in
-    `Assoc
-      [ "type", `String "post_voted"
-      ; "event_type", `String "vote.changed"
-      ; "target_type", `String "post"
-      ; "post_id", `String post_id
-      ; "voter", `String voter
-      ; "voter_identity", Server_utils.board_actor_identity_json voter
-      ; "direction", `String dir
-      ]
-  | Board_dispatch.Comment_voted { comment_id; voter; direction } ->
-    let dir = Board_votes.vote_direction_to_string direction in
-    `Assoc
-      [ "type", `String "comment_voted"
-      ; "event_type", `String "vote.changed"
-      ; "target_type", `String "comment"
-      ; "comment_id", `String comment_id
-      ; "voter", `String voter
-      ; "voter_identity", Server_utils.board_actor_identity_json voter
-      ; "direction", `String dir
-      ]
-  | Board_dispatch.Reaction_changed { target_type; target_id; user_id; emoji; reacted } ->
-    `Assoc
-      [ "type", `String "reaction_changed"
-      ; "event_type", `String "reaction.changed"
-      ; "target_type", `String (Board.reaction_target_type_to_string target_type)
-      ; "target_id", `String target_id
-      ; "user_id", `String user_id
-      ; "user_identity", Server_utils.board_actor_identity_json user_id
-      ; "emoji", `String emoji
-      ; "reacted", `Bool reacted
-      ]
-;;
+(* Board SSE event -> JSON params projection extracted to
+   [Server_bootstrap_board_sse_events] (godfile decomp). *)
+let board_sse_event_params = Server_bootstrap_board_sse_events.board_sse_event_params
 
 module For_testing = struct
   let autoboot_proactive_warmup_sec = autoboot_proactive_warmup_sec


### PR DESCRIPTION
## 요약

`server_bootstrap_loops.ml` (1243 LoC godfile) 의 board SSE event JSON projection (5-variant sum type → wire JSON 매핑) 를 신규 sibling 모듈로 추출했습니다. **-61 LoC** (1243 → 1182).

server_bootstrap_loops 첫 분해.

## 추출 surface (1 pure 매핑)

| 함수 | 시그니처 |
|---|---|
| `board_sse_event_params` | `Board_dispatch.board_sse_event -> Yojson.Safe.t` |

5-variant pattern match:
- `Post_created` → `{type, event_type, post_id, author, title, content (preview 200), post_kind, hearth?}`
- `Comment_added` → `{type, event_type, post_id, comment_id, author}`
- `Post_voted` / `Comment_voted` → `{type, event_type, target_type, post_id|comment_id, voter, direction}`
- `Reaction_changed` → `{type, event_type, target_type, target_id, user_id, emoji, reacted}`

## 신규 모듈

- `lib/server/server_bootstrap_board_sse_events.ml` (75 LoC)
- `lib/server/server_bootstrap_board_sse_events.mli` (6 LoC)

## 의존성 (전부 dependency module)

- `Board_dispatch.{Post_created, Comment_added, Post_voted, Comment_voted, Reaction_changed}` variants + `board_sse_event` sum type
- `Board.{post_kind_to_string, reaction_target_type_to_string}`
- `Board_votes.vote_direction_to_string`
- `Server_utils.board_actor_identity_json`
- `String` (Stdlib)

Shared state 0. Side effect 0 (pure mapping).

## 외부 caller 호환

- `test/test_board_sse_canonical_event_type.ml` 3 사이트 (`Boot.board_sse_event_params`) — `For_testing.board_sse_event_params` 통해 parent module 노출 → thin alias 가 동일 surface 유지 → 변경 0
- 내부 caller 1 site at line 441 (`start_keeper_loops` body) → 변경 0

## 검증

- [x] `dune build --root . lib/server` PASS
- [x] `server_bootstrap_loops.mli` 변경 0 (`For_testing` 시그니처 동일)
- [x] 함수 body 1-to-1 카피 (5 variant 매핑 byte-identical)

## 패턴

Pure JSON projection extraction (PR #16794 Scan_summary, #16831 Summary_aggregates, #16847 logs_json, #16855 sub_board_json, #16857 compact_receipt_json 와 동일). SSE wire event 매핑은 keeper 라이프사이클 fiber 의 책임 (`start_keeper_loops` 의 814-LoC body) 가 아닌 별도 wire format concern.

## Workaround Rejection Bar self-check

1. [ ] makes X visible only — NO
2. [ ] string classifier — NO (existing 5-variant pattern match 이동만)
3. [ ] N-of-M — NO (전체 cluster 이동)
4. [ ] catch-all `_ ->` 추가 — NO (existing exhaustive match 유지)
5. [ ] cap/cooldown/dedup/repair — NO
6. [ ] test backdoor — NO
7. [ ] N-사이트 typo — NO

PASS — pure refactor.

## RFC

RFC-WAIVED: `lib/server` non-credential refactor.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
