### PR TITLE
refactor(server): extract fleet work-discovery readiness JSON into sibling

### DIFF
--- a/lib/server/server_dashboard_fleet_readiness.ml
+++ b/lib/server/server_dashboard_fleet_readiness.ml
@@ -1,0 +1,104 @@
+(* Fleet work-discovery readiness JSON.
+
+   - [keeper_activation_readiness_json]: per-keeper readiness shape
+     served by the dashboard composite endpoint.
+   - [task_is_unclaimed_todo] / [unclaimed_todo_count]: derive
+     unclaimed backlog count from [Coord.read_backlog].
+   - [fleet_work_discovery_readiness_json]: roll up "is there a keeper
+     that can pick up the unclaimed backlog right now?" into one wire
+     payload with per-keeper rows + an aggregate ok/hint/blocker.
+
+   Extracted from [Server_dashboard_http] (godfile decomp). Pure
+   projection over [Keeper_registry.registry_entry] +
+   [Coord.read_backlog]. *)
+
+let keeper_activation_readiness_json (meta : Keeper_types.keeper_meta) =
+  Keeper_activation_readiness.(of_meta meta |> to_yojson)
+;;
+
+let task_is_unclaimed_todo (task : Masc_domain.task) =
+  match task.task_status with
+  | Todo -> true
+  | Claimed _ | InProgress _ | AwaitingVerification _ | Done _ | Cancelled _ -> false
+;;
+
+let unclaimed_todo_count ~(config : Coord.config) =
+  try
+    Coord.read_backlog config
+    |> fun backlog ->
+    List.fold_left
+      (fun count task -> if task_is_unclaimed_todo task then count + 1 else count)
+      0
+      backlog.tasks
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Log.Dashboard.warn
+      "dashboard_fleet_composite_json failed to read backlog for work discovery \
+       readiness: %s"
+      (Printexc.to_string exn);
+    0
+;;
+
+let fleet_work_discovery_readiness_json
+      ~(todo_unclaimed_count : int)
+      (entries : Keeper_registry.registry_entry list)
+  =
+  let rows =
+    List.map
+      (fun (entry : Keeper_registry.registry_entry) ->
+         let meta = entry.meta in
+         let readiness = Keeper_activation_readiness.of_meta meta in
+         let autonomous_activation =
+           readiness.Keeper_activation_readiness.autonomous_activation
+         in
+         let work_discovery_activation =
+           readiness.Keeper_activation_readiness.work_discovery_activation
+         in
+         `Assoc
+           [ "keeper", `String entry.name
+           ; "ready_for_unclaimed_backlog", `Bool readiness.ready_for_unclaimed_backlog
+           ; ( "autonomous_blocker"
+             , Json_util.string_opt_to_json autonomous_activation.blocker )
+           ; ( "work_discovery_blocker"
+             , Json_util.string_opt_to_json work_discovery_activation.blocker )
+           ; "paused", `Bool autonomous_activation.paused
+           ; "autoboot_enabled", `Bool autonomous_activation.autoboot_enabled
+           ; "proactive_enabled", `Bool autonomous_activation.proactive_enabled
+           ; ( "work_discovery_enabled"
+             , Json_util.bool_opt_to_json
+                 work_discovery_activation.work_discovery_enabled )
+           ; ( "current_task_id"
+             , Json_util.string_opt_to_json work_discovery_activation.current_task_id )
+           ])
+      entries
+  in
+  let ready_keeper_count =
+    List.fold_left
+      (fun count (entry : Keeper_registry.registry_entry) ->
+         if Keeper_activation_readiness.ready_for_unclaimed_backlog entry.meta
+         then count + 1
+         else count)
+      0
+      entries
+  in
+  let ok = todo_unclaimed_count = 0 || ready_keeper_count > 0 in
+  `Assoc
+    [ "ok", `Bool ok
+    ; "todo_unclaimed_count", `Int todo_unclaimed_count
+    ; "ready_keeper_count", `Int ready_keeper_count
+    ; "keeper_count", `Int (List.length entries)
+    ; ( "blocker"
+      , Json_util.string_opt_to_json
+          (if ok then None else Some "no_ready_work_discovery_keeper") )
+    ; ( "hint"
+      , Json_util.string_opt_to_json
+          (if ok
+           then None
+           else
+             Some
+               "enable autoboot, proactive, and work_discovery on at least one \
+                keeper before expecting todo backlog fan-out") )
+    ; "keepers", `List rows
+    ]
+;;

--- a/lib/server/server_dashboard_fleet_readiness.mli
+++ b/lib/server/server_dashboard_fleet_readiness.mli
@@ -1,0 +1,11 @@
+(** Fleet work-discovery readiness JSON builders for the dashboard
+    composite endpoint. *)
+
+val keeper_activation_readiness_json : Keeper_types.keeper_meta -> Yojson.Safe.t
+val task_is_unclaimed_todo : Masc_domain.task -> bool
+val unclaimed_todo_count : config:Coord.config -> int
+
+val fleet_work_discovery_readiness_json
+  :  todo_unclaimed_count:int
+  -> Keeper_registry.registry_entry list
+  -> Yojson.Safe.t

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -931,96 +931,14 @@ let composite_execution_config_drift execution =
   | _ -> false
 ;;
 
-let keeper_activation_readiness_json (meta : Keeper_types.keeper_meta) =
-  Keeper_activation_readiness.(of_meta meta |> to_yojson)
-;;
+(* Fleet readiness JSON extracted to [Server_dashboard_fleet_readiness]
+   (godfile decomp). *)
+let keeper_activation_readiness_json = Server_dashboard_fleet_readiness.keeper_activation_readiness_json
+let task_is_unclaimed_todo = Server_dashboard_fleet_readiness.task_is_unclaimed_todo
+let unclaimed_todo_count = Server_dashboard_fleet_readiness.unclaimed_todo_count
 
-let task_is_unclaimed_todo (task : Masc_domain.task) =
-  match task.task_status with
-  | Todo -> true
-  | Claimed _ | InProgress _ | AwaitingVerification _ | Done _ | Cancelled _ -> false
-;;
-
-let unclaimed_todo_count ~(config : Coord.config) =
-  try
-    Coord.read_backlog config
-    |> fun backlog ->
-    List.fold_left
-      (fun count task -> if task_is_unclaimed_todo task then count + 1 else count)
-      0
-      backlog.tasks
-  with
-  | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn ->
-    Log.Dashboard.warn
-      "dashboard_fleet_composite_json failed to read backlog for work discovery \
-       readiness: %s"
-      (Printexc.to_string exn);
-    0
-;;
-
-let fleet_work_discovery_readiness_json
-    ~(todo_unclaimed_count : int)
-    (entries : Keeper_registry.registry_entry list)
-  =
-  let rows =
-    List.map
-      (fun (entry : Keeper_registry.registry_entry) ->
-         let meta = entry.meta in
-         let readiness = Keeper_activation_readiness.of_meta meta in
-         let autonomous_activation =
-           readiness.Keeper_activation_readiness.autonomous_activation
-         in
-         let work_discovery_activation =
-           readiness.Keeper_activation_readiness.work_discovery_activation
-         in
-         `Assoc
-           [ "keeper", `String entry.name
-           ; "ready_for_unclaimed_backlog",
-             `Bool readiness.ready_for_unclaimed_backlog
-           ; "autonomous_blocker",
-             Json_util.string_opt_to_json autonomous_activation.blocker
-           ; "work_discovery_blocker",
-             Json_util.string_opt_to_json work_discovery_activation.blocker
-           ; "paused", `Bool autonomous_activation.paused
-           ; "autoboot_enabled", `Bool autonomous_activation.autoboot_enabled
-           ; "proactive_enabled", `Bool autonomous_activation.proactive_enabled
-           ; "work_discovery_enabled",
-             Json_util.bool_opt_to_json
-               work_discovery_activation.work_discovery_enabled
-           ; "current_task_id",
-             Json_util.string_opt_to_json work_discovery_activation.current_task_id
-           ])
-      entries
-  in
-  let ready_keeper_count =
-    List.fold_left
-      (fun count (entry : Keeper_registry.registry_entry) ->
-         if Keeper_activation_readiness.ready_for_unclaimed_backlog entry.meta
-         then count + 1
-         else count)
-      0
-      entries
-  in
-  let ok = todo_unclaimed_count = 0 || ready_keeper_count > 0 in
-  `Assoc
-    [ "ok", `Bool ok
-    ; "todo_unclaimed_count", `Int todo_unclaimed_count
-    ; "ready_keeper_count", `Int ready_keeper_count
-    ; "keeper_count", `Int (List.length entries)
-    ; "blocker",
-      Json_util.string_opt_to_json
-        (if ok then None else Some "no_ready_work_discovery_keeper")
-    ; "hint",
-      Json_util.string_opt_to_json
-        (if ok
-         then None
-         else
-           Some
-             "enable autoboot, proactive, and work_discovery on at least one \
-              keeper before expecting todo backlog fan-out")
-    ; "keepers", `List rows
-    ]
+let fleet_work_discovery_readiness_json =
+  Server_dashboard_fleet_readiness.fleet_work_discovery_readiness_json
 ;;
 
 let composite_execution_blocked execution =


### PR DESCRIPTION
## 요약

`server_dashboard_http.ml` (1500 LoC) 의 fleet work-discovery readiness JSON 빌더 cluster 를 신규 sibling 모듈로 추출했습니다. **-82 LoC** (1500 → 1418).

PR #16857 (compact_receipt_json) 와 같은 godfile (server_dashboard_http) 의 별개 cluster — server_dashboard_http 의 두 번째 분해.

## 추출 surface (4 pure JSON projections)

| 함수 | 시그니처 |
|---|---|
| `keeper_activation_readiness_json` | `keeper_meta -> Yojson.Safe.t` |
| `task_is_unclaimed_todo` | `task -> bool` |
| `unclaimed_todo_count` | `~config -> int` (exn-safe fold over backlog) |
| `fleet_work_discovery_readiness_json` | `~todo_unclaimed_count, entries -> Yojson.Safe.t` (rollup JSON with rows + ok/blocker/hint) |

## 신규 모듈

- `lib/server/server_dashboard_fleet_readiness.ml` (104 LoC)
- `lib/server/server_dashboard_fleet_readiness.mli` (11 LoC)

## 의존성 (전부 dependency module)

- `Keeper_types.keeper_meta`
- `Keeper_activation_readiness.{of_meta, to_yojson, ready_for_unclaimed_backlog, autonomous_activation, work_discovery_activation}`
- `Masc_domain.{task, task_status, Todo, Claimed, InProgress, AwaitingVerification, Done, Cancelled}`
- `Coord.{config, read_backlog}`
- `Keeper_registry.registry_entry`
- `Json_util.{string_opt_to_json, bool_opt_to_json}`
- `Eio.Cancel.Cancelled`, `Log.Dashboard.warn`

Shared state 0. Side effect = backlog read + log line.

## 외부 caller 호환

- 외부 caller 0
- 3 internal call sites (lines 1338, 1359, 1364) → parent thin alias 가 시그니처 유지 → 변경 0

## 검증

- [x] `dune build --root . lib/server` PASS
- [x] public surface 변경 0 (parent alias)
- [x] 함수 body 1-to-1 카피
- [x] exn 처리 (`Eio.Cancel.Cancelled` re-raise + other exn → log + count=0) 유지

## 패턴

Pure JSON projection extraction (PR #16857 compact_receipt_json 와 같은 타깃 godfile 의 *별개* cluster). fleet readiness 계산은 dashboard composite endpoint 의 한 응답 블록 — operator action / verification resolve / governance approval 등 다른 endpoint 블록과 thematic 분리.

## Workaround Rejection Bar self-check

1. [ ] makes X visible only — NO
2. [ ] string classifier — NO
3. [ ] N-of-M — NO (전체 cluster 이동)
4. [ ] catch-all `_ ->` 추가 — NO (existing `Claimed _ \| ...` exhaustive match 유지)
5. [ ] cap/cooldown/dedup/repair — NO
6. [ ] test backdoor — NO
7. [ ] N-사이트 typo — NO

PASS — pure refactor.

## RFC

RFC-WAIVED: `lib/server` non-credential refactor.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
