### PR TITLE
refactor(dashboard): drop 3 dead store signals (telemetry-as-fix removal)

### DIFF
--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -13,8 +13,6 @@ import type {
   BoardSortMode,
   Goal,
   RefreshOptions,
-  DashboardExecutionSessionBrief,
-  DashboardExecutionQueueItem,
   DashboardExecutionWorkerSupportBrief,
   DashboardExecutionContinuityBrief,
   DashboardExecutionResponse,
@@ -25,7 +23,6 @@ import type {
   DashboardConfigResolution,
   DashboardRuntimeResolution,
   DashboardShellAuthSummary,
-  DashboardShellMetaCognitionSummary,
   DashboardShellResponse,
   DashboardCoordinationFsmEvidence,
   DashboardCoordinationFsmProduct,
@@ -57,14 +54,12 @@ import { normalizeNamespaceTruth } from './namespace-truth-normalizers'
 import { hydrateGoalTreeSnapshot } from './goal-tree-state'
 import {
   normalizeAgent, normalizeTask, normalizeMessage,
-  normalizeExecutionQueueItem,
   normalizeExecutionWorkerSupportBrief,
   normalizeExecutionContinuityBrief,
   mergeMessages,
   normalizeServerStatus, mergeServerStatus,
   normalizeDashboardConfigResolution,
   normalizeDashboardRuntimeResolution,
-  normalizeShellMetaCognitionSummary,
 } from './store-normalizers'
 
 // --- Shell counts (lightweight fallback from /dashboard/shell) ---
@@ -78,7 +73,6 @@ interface ShellCounts {
 }
 
 export const shellCounts = signal<ShellCounts | null>(null)
-export const shellMetaCognition = signal<DashboardShellMetaCognitionSummary | null>(null)
 export const shellAuthSummary = signal<DashboardShellAuthSummary | null>(null)
 export const shellConfigResolution = signal<DashboardConfigResolution | null>(null)
 export const shellRuntimeResolution = signal<DashboardRuntimeResolution | null>(null)
@@ -93,8 +87,6 @@ export const serverStatus = signal<ServerStatus | null>(null)
 export const executionLoaded = signal(false)
 export const executionLoading = signal(false)
 export const executionError = signal<string | null>(null)
-export const executionSessionBriefs = signal<DashboardExecutionSessionBrief[]>([])
-export const executionQueue = signal<DashboardExecutionQueueItem[]>([])
 export const executionWorkerSupportBriefs = signal<DashboardExecutionWorkerSupportBrief[]>([])
 export const executionContinuityBriefs = signal<DashboardExecutionContinuityBrief[]>([])
 
@@ -786,7 +778,6 @@ export function hydrateShellSnapshot(data: DashboardShellResponse, opts?: { ligh
       configured_keepers: data.configured_keepers ?? 0,
     }
   }
-  shellMetaCognition.value = normalizeShellMetaCognitionSummary(data.meta_cognition)
   shellAuthSummary.value = normalizedAuth
   const normalizedConfigResolution = normalizeDashboardConfigResolution(data.config_resolution)
   const normalizedRuntimeResolution = normalizeDashboardRuntimeResolution(data.runtime_resolution)
@@ -849,10 +840,6 @@ export function hydrateExecutionSnapshot(data: DashboardExecutionResponse): void
     .filter((row): row is Message => row !== null)
   messages.value = roomChanged ? executionMessages : mergeMessages(messages.value, executionMessages)
   keepers.value = normalizeKeepers(data.keepers)
-  const normalizedQueue = (Array.isArray(data.execution_queue) ? data.execution_queue : Array.isArray(data.priority_queue) ? data.priority_queue : [])
-    .map(normalizeExecutionQueueItem)
-    .filter((row): row is DashboardExecutionQueueItem => row !== null)
-  setArrayByKeyIfChanged(executionQueue, normalizedQueue, row => row.id)
   const normalizedWorkerBriefs = (Array.isArray(data.worker_support_briefs) ? data.worker_support_briefs : Array.isArray(data.worker_briefs) ? data.worker_briefs : [])
     .map(normalizeExecutionWorkerSupportBrief)
     .filter((row): row is DashboardExecutionWorkerSupportBrief => row !== null)


### PR DESCRIPTION
## Summary

Three signals in `dashboard/src/store.ts` are exported and written by the store but **never read by any panel/component anywhere in the codebase**. Pure write-only telemetry-as-fix anti-pattern: data is plumbed in but never reaches operator UI.

This is the §1 Workaround Rejection Bar pattern (CLAUDE.md) on the FRONTEND side, matching the backend dead-surface sweep across PR #16830~#16858.

## Findings

| Signal | Pattern | Backend feed |
|---|---|---|
| `shellMetaCognition` | write-only (L789 set from `data.meta_cognition`) | `normalizeShellMetaCognitionSummary(data.meta_cognition)` |
| `executionSessionBriefs` | declared but never written or read | (no feed) |
| `executionQueue` | write-only (L855 `setArrayByKeyIfChanged` from `data.execution_queue`/`data.priority_queue`) | `normalizeExecutionQueueItem` map+filter |

Verified zero readers via:

```bash
$ rg "shellMetaCognition" dashboard/src/ -n  # only declaration + write at L789
$ rg "executionSessionBriefs" dashboard/src/ -n  # only declaration
$ rg "\bexecutionQueue\b" dashboard/src/ -n  # only declaration + write at L855
```

The 4th candidate from the audit (`oasLastKeeperTick`) was REJECTED as false-positive — it IS read by `oasHealthSummary` computed signal, which is consumed by `components/oas-health-chip.ts`. The earlier audit relied on direct symbol search; cross-signal computed dependencies need follow-up trace. Verified in code.

## Code paths removed

- L789 `shellMetaCognition.value = normalizeShellMetaCognitionSummary(data.meta_cognition)` — write into dead signal
- L852-855 normalize+filter+write code path for `executionQueue` — work done but result thrown into dead signal
- 3 signal declarations (L81, L96, L97)

Type imports (`DashboardShellMetaCognitionSummary`, `DashboardExecutionSessionBrief`, `DashboardExecutionQueueItem`) and normalizer imports (`normalizeShellMetaCognitionSummary`, `normalizeExecutionQueueItem`) removed from store.ts. **The underlying type/normalizer definitions REMAIN** in `types/dashboard-execution.ts` and `store-normalizers.ts` — they are still used by `namespace-truth-normalizers.ts` and tests.

## Verification

```bash
$ /path/to/dashboard/node_modules/.bin/tsc --noEmit -p tsconfig.json 2>&1 \
    | rg "shellMetaCognition|executionSessionBriefs|executionQueue|DashboardExecutionQueueItem|DashboardExecutionSessionBrief|DashboardShellMetaCognitionSummary"
# 0 hits — no errors related to removed symbols
```

All tsc errors that appear are environmental (missing module typings — `vitest`, `@preact/signals`, `@testing-library/preact`) because pnpm install hasn't run in this fresh worktree. The removed symbols compile cleanly against the main checkout's node_modules.

## Workaround Rejection Bar self-check

- §1 **telemetry-as-fix**: this PR REMOVES the exact pattern — 3 signals instrumented (written) but never made visible (read). Data was being normalized + stored but never reached any operator UI.
- §2 string classifier: none.
- §3 N-of-M: 3 signals removed atomically. Audit also flagged `normalizeExecutionTone`, `normalizeExecutionHandoff`, `normalizeBuildIdentity`, `normalizeAgentStatus`, `normalizeTaskStatus`, `messageSortKey` exports in `store-normalizers.ts` as 0-caller — those are separate normalizer functions, deferred to a follow-up PR (needs broader frontend audit including SSR/dynamic-import paths).
- catch-all / cap / cooldown: none.

## Audit context (Iter 3, dead-surface sweep)

| PR | Surface |
|---|---|
| #16830 | namespace_truth retired-knob surface |
| #16840 | dashboard-ssot-agent-status.sh CI wiring |
| #16842 | select_telemetry_summary_json .mli docstring |
| #16843 | 18 dead env knobs + dead `module Cli` |
| #16851 | check-variants.sh CI wiring (ratchet theater) |
| #16853 | 2 .mli surface count drift |
| #16858 | 3 orphan scripts in `scripts/` |
| **this PR** | **3 dead frontend store signals (write-only telemetry-as-fix)** |

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>