### PR TITLE
fix(keeper): classify egress blocks as policy rejections

### DIFF
--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -232,13 +232,20 @@ let failure_class_of_tool_result_payload payload =
       ~context:"Keeper_exec_tools.failure_class_of_tool_result_payload"
       payload
   with
-  | Ok json -> Safe_ops.json_string_opt "failure_class" json
+  | Ok json ->
+    (match Safe_ops.json_string_opt "failure_class" json with
+     | Some _ as failure_class -> failure_class
+     | None ->
+       (match Safe_ops.json_string_opt "error" json with
+        | Some "egress_blocked" -> Some "policy_rejection"
+        | Some _
+        | None -> None))
   | Error _ -> None
 ;;
 
 let should_apply_circuit_breaker_to_failure_payload payload =
   match failure_class_of_tool_result_payload payload with
-  | Some "workflow_rejection" -> false
+  | Some ("policy_rejection" | "workflow_rejection") -> false
   | Some _
   | None -> true
 ;;

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -88,7 +88,20 @@ let failure_class_of_tool_error_json json =
   in
   match direct with
   | Some _ -> direct
-  | None -> nested
+  | None ->
+    (match nested with
+     | Some _ -> nested
+     | None ->
+       let direct_error = Safe_ops.json_string_opt "error" json in
+       let nested_error =
+         match Yojson.Safe.Util.member "detail" json with
+         | `Assoc _ as detail -> Safe_ops.json_string_opt "error" detail
+         | _ -> None
+       in
+       match direct_error, nested_error with
+       | Some "egress_blocked", _
+       | _, Some "egress_blocked" -> Some "policy_rejection"
+       | _ -> None)
 
 let failure_class_of_tool_error_text error =
   try

--- a/test/test_keeper_exec_tools.ml
+++ b/test/test_keeper_exec_tools.ml
@@ -527,6 +527,9 @@ let test_workflow_rejection_payload_skips_circuit_breaker () =
       ~fields:[ "failure_class", `String "workflow_rejection" ]
       workflow_rejection_message
   in
+  let egress_payload =
+    {|{"ok":false,"error":"egress_blocked","attempted":"localhost","allowed":["*.github.com"]}|}
+  in
   let runtime_payload =
     KES.error_json
       ~fields:[ "failure_class", `String "runtime_failure" ]
@@ -536,6 +539,10 @@ let test_workflow_rejection_payload_skips_circuit_breaker () =
     (KET.failure_class_of_tool_result_payload workflow_payload);
   check bool "workflow rejection does not trip circuit breaker" false
     (KET.should_apply_circuit_breaker_to_failure_payload workflow_payload);
+  check (option string) "infers egress policy class" (Some "policy_rejection")
+    (KET.failure_class_of_tool_result_payload egress_payload);
+  check bool "egress policy rejection does not trip circuit breaker" false
+    (KET.should_apply_circuit_breaker_to_failure_payload egress_payload);
   check bool "runtime failure still trips circuit breaker" true
     (KET.should_apply_circuit_breaker_to_failure_payload runtime_payload)
 

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -1116,6 +1116,34 @@ let test_on_tool_error_workflow_rejection_logs_warn_without_callback_failure () 
   | None -> fail "expected workflow rejection to be logged as keeper WARN"
 ;;
 
+let test_on_tool_error_egress_blocked_logs_policy_warn_without_callback_failure
+    () =
+  let keeper = "callback-on-tool-egress-blocked-keeper" in
+  let hooks = make_test_hooks keeper in
+  let hook = require_hook "on_tool_error" hooks.on_tool_error in
+  let before = lifecycle_callback_failure_count ~keeper ~callback:"on_tool_error" in
+  let before_seq = latest_log_seq () in
+  let error =
+    {|{"ok":false,"error":"egress_blocked","attempted":"localhost","allowed":["*.github.com"]}|}
+  in
+  check_continue
+    "on_tool_error egress blocked"
+    (hook (Agent_sdk.Hooks.OnToolError { tool_name = "Bash"; error }));
+  let after = lifecycle_callback_failure_count ~keeper ~callback:"on_tool_error" in
+  check
+    (float 0.001)
+    "egress blocked does not increment callback failures"
+    0.0
+    (after -. before);
+  match
+    find_keeper_log_since
+      ~since_seq:before_seq
+      ~message_substring:("keeper:" ^ keeper ^ " tool_policy_rejection: Bash")
+  with
+  | Some entry -> check string "log level" "WARN" (Log.level_to_string entry.level)
+  | None -> fail "expected egress block to be logged as keeper policy WARN"
+;;
+
 let test_on_tool_error_blob_workflow_rejection_logs_warn_without_callback_failure
     () =
   let keeper = "callback-on-tool-blob-workflow-rejection-keeper" in
@@ -1773,6 +1801,10 @@ let () =
             "on_tool_error workflow rejection logs warn"
             `Quick
             test_on_tool_error_workflow_rejection_logs_warn_without_callback_failure
+        ; test_case
+            "on_tool_error egress block logs policy warn"
+            `Quick
+            test_on_tool_error_egress_blocked_logs_policy_warn_without_callback_failure
         ; test_case
             "on_tool_error blob workflow rejection logs warn"
             `Quick


### PR DESCRIPTION
## Summary\n- infer policy_rejection for raw egress_blocked tool payloads that omit failure_class\n- keep policy_rejection out of keeper circuit breaker accounting\n- log OAS hook egress blocks as keeper policy WARN instead of callback/runtime failures\n\n## Validation\n- ocamlformat --check lib/keeper/keeper_exec_tools.ml lib/keeper/keeper_hooks_oas.ml test/test_keeper_exec_tools.ml test/test_keeper_hooks_oas_telemetry.ml\n- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=/private/tmp/masc-egress-blocked-policy-build-20260520 scripts/dune-local.sh build test/test_keeper_exec_tools.exe test/test_keeper_hooks_oas_telemetry.exe\n- /private/tmp/masc-egress-blocked-policy-build-20260520/default/test/test_keeper_exec_tools.exe test --show-errors --color=never execute_keeper_tool_call_with_outcome 11\n- /private/tmp/masc-egress-blocked-policy-build-20260520/default/test/test_keeper_hooks_oas_telemetry.exe test --show-errors --color=never hook_introspection 4\n- git diff --check\n\nFixes #16864