### PR TITLE
refactor(rfc-0145): PR-1 extract Phase 0 wake-time payload telemetry

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -206,6 +206,7 @@
   keeper_agent_prompt_metrics
   keeper_agent_tool_surface
   keeper_agent_run_contract_helpers
+  keeper_agent_run_phase_0_telemetry
   keeper_agent_result
   keeper_agent_error
   keeper_agent_memory_episode

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -562,51 +562,15 @@ let run_turn
             }
             : Cascade_runner.cli_transport_overrides)
        in
-       (* Phase 0: wake-time payload telemetry (Option C baseline).
-       Entire block is dead code when MASC_PAYLOAD_TELEMETRY is unset.
-       Compute logic lives in [Keeper_wake_telemetry] for unit tests;
-       exceptions from the telemetry path never abort the LLM call. *)
-       let () =
-         if Env_config_keeper.KeeperTelemetry.payload_telemetry_enabled ()
-         then (
-           try
-             let sizes =
-               Keeper_wake_telemetry.compute_sizes
-                 ~system_prompt:turn_system_prompt
-                 ~tools
-                 ~history_messages
-                 ~user_message
-             in
-             let model_id =
-               match Keeper_model_labels.configured_model_labels_of_meta meta with
-               | m :: _ -> m
-               | [] -> "auto"
-             in
-             let _event : Dashboard_harness_health.wake_payload_event =
-               Dashboard_harness_health.record_wake_payload
-                 ~keeper_name:meta.name
-                 ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-                 ~turn_index:start_turn_count
-                 ~model_id
-                 ~context_window:max_context
-                 ~approx_body_bytes:sizes.approx_body_bytes
-                 ~system_prompt_bytes:sizes.system_prompt_bytes
-                 ~tool_defs_bytes:sizes.tool_defs_bytes
-                 ~messages_bytes:sizes.messages_bytes
-                 ~message_count:sizes.message_count
-                 ~role_counts:sizes.role_counts
-                 ~tool_count:sizes.tool_count
-                 ~has_compact_happened:pre_dispatch_compacted
-             in
-             ()
-           with
-           | Eio.Cancel.Cancelled _ as e -> raise e
-           | exn ->
-             Log.Harness.warn
-               "[wake_payload] telemetry failed keeper=%s: %s"
-               meta.name
-               (Printexc.to_string exn))
-       in
+       Keeper_agent_run_phase_0_telemetry.emit_if_enabled
+         ~meta
+         ~system_prompt:turn_system_prompt
+         ~tools
+         ~history_messages
+         ~user_message
+         ~turn_index:start_turn_count
+         ~max_context
+         ~pre_dispatch_compacted;
        let turn_result =
          match pre_dispatch_checkpoint_error with
          | Some err -> Error err

--- a/lib/keeper/keeper_agent_run_phase_0_telemetry.ml
+++ b/lib/keeper/keeper_agent_run_phase_0_telemetry.ml
@@ -1,0 +1,50 @@
+let emit_if_enabled
+      ~(meta : Keeper_types.keeper_meta)
+      ~system_prompt
+      ~tools
+      ~history_messages
+      ~user_message
+      ~turn_index
+      ~max_context
+      ~pre_dispatch_compacted
+  =
+  if Env_config_keeper.KeeperTelemetry.payload_telemetry_enabled ()
+  then (
+    try
+      let sizes =
+        Keeper_wake_telemetry.compute_sizes
+          ~system_prompt
+          ~tools
+          ~history_messages
+          ~user_message
+      in
+      let model_id =
+        match Keeper_model_labels.configured_model_labels_of_meta meta with
+        | m :: _ -> m
+        | [] -> "auto"
+      in
+      let _event : Dashboard_harness_health.wake_payload_event =
+        Dashboard_harness_health.record_wake_payload
+          ~keeper_name:meta.name
+          ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+          ~turn_index
+          ~model_id
+          ~context_window:max_context
+          ~approx_body_bytes:sizes.approx_body_bytes
+          ~system_prompt_bytes:sizes.system_prompt_bytes
+          ~tool_defs_bytes:sizes.tool_defs_bytes
+          ~messages_bytes:sizes.messages_bytes
+          ~message_count:sizes.message_count
+          ~role_counts:sizes.role_counts
+          ~tool_count:sizes.tool_count
+          ~has_compact_happened:pre_dispatch_compacted
+      in
+      ()
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Log.Harness.warn
+        "[wake_payload] telemetry failed keeper=%s: %s"
+        meta.name
+        (Printexc.to_string exn))
+;;

--- a/lib/keeper/keeper_agent_run_phase_0_telemetry.mli
+++ b/lib/keeper/keeper_agent_run_phase_0_telemetry.mli
@@ -1,0 +1,21 @@
+(** RFC-0145 PR-1: extract Phase 0 wake-time payload telemetry from
+    [keeper_agent_run.run_turn] Step 8 body (L565-L609).
+
+    Dead-code when [MASC_PAYLOAD_TELEMETRY] is unset.  Compute logic
+    lives in [Keeper_wake_telemetry]; this module is the env-flag
+    guard + [Dashboard_harness_health.record_wake_payload] call site.
+    Exceptions from the telemetry path never abort the LLM call.
+
+    Side effects only (Option C baseline metrics).
+    [Eio.Cancel.Cancelled] is re-raised so the outer turn cleanup
+    handler observes the cancellation; other exceptions log a WARN. *)
+val emit_if_enabled
+  :  meta:Keeper_types.keeper_meta
+  -> system_prompt:string
+  -> tools:Agent_sdk.Tool_op.t list
+  -> history_messages:Agent_sdk.Types.message list
+  -> user_message:string
+  -> turn_index:int
+  -> max_context:int
+  -> pre_dispatch_compacted:bool
+  -> unit


### PR DESCRIPTION
## 요약

RFC-0145 PR-1 — `keeper_agent_run.run_turn` Step 8 body 의 Phase 0 wake-time payload telemetry 블록 (L565-L609) 을 sibling typed wrapper 로 추출.

## 변경

| 파일 | 변경 | LoC |
|------|------|-----|
| `lib/keeper/keeper_agent_run.ml` | inline 블록 → wrapper 호출 | **-36** |
| `lib/keeper/keeper_agent_run_phase_0_telemetry.ml` | 새 모듈 | +50 |
| `lib/keeper/keeper_agent_run_phase_0_telemetry.mli` | 새 mli | +21 |
| `lib/dune` | private_modules 등록 | +1 |

## 측정

- `keeper_agent_run.ml`: 2103 → **2067 LoC (-1.7%)**
- 추정 -35, 실측 -36 (오차 +1)

## 패턴 (RFC-0136 PR-4-c 학습 적용)

- side-effect wrapper, no return
- `Env_config_keeper.KeeperTelemetry.payload_telemetry_enabled()` env-flag guard 보존
- `Eio.Cancel.Cancelled` re-raise 보존 (outer cleanup 정합)
- 12 `record_wake_payload` 호출 labeled args 모두 보존
- 8-args wrapper (`meta` + 7 captures)

## RFC-0145 PR-1 done criteria 충족

- [x] `keeper_agent_run_phase_0_telemetry.{ml,mli}` 생성
- [x] inline 블록 → wrapper 호출 교체
- [x] `wc -l keeper_agent_run.ml` 감소 ≥ 30 LoC (36)
- [ ] `dune build @check` 통과 (CI 검증)
- [ ] Best Programmer self-review

## 보존 invariant

- Dead-code when MASC_PAYLOAD_TELEMETRY unset (env guard 보존)
- Cancelled re-raise → outer cleanup observes cancellation
- Other exn → `Log.Harness.warn` (silent failure 아님)
- 모든 12 record_wake_payload args 동일

## Anti-pattern 가드

- ✅ workaround 없음 (typed wrapper)
- ✅ telemetry-as-fix 아님 (기존 telemetry block 단순 추출)
- ✅ string classifier 없음
- ✅ N-of-M 없음 (단일 분리된 boundary)

## RFC

`docs/rfc/RFC-0145-keeper-agent-run-decomposition.md`

## RFC-0145 progress

| PR | LOC Δ | 측정 |
|----|------|------|
| **PR-1 (이 PR)** | **-36** | ✅ |
| PR-3 Thinking blocks | -62 추정 | 사전 분석 |
| PR-6 Receipt failure | -48 추정 | 사전 분석 |
| PR-9 Phase 5 wire | -45 추정 | 사전 분석 |
| PR-4-1/4-3/4-4 | -148 추정 | 사전 분석 |

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
