### PR TITLE
refactor(server): extract dashboard planning + goals JSON into sibling

### DIFF
--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -441,51 +441,11 @@ let dashboard_verification_resolve_http_json
           ])
 ;;
 
-let dashboard_planning_http_json ~(config : Coord.config) : Yojson.Safe.t =
-  let goals = Goal_store.list_goals config () in
-  let rollup = Goal_store.compute_rollup goals in
-  let task_rollup =
-    dashboard_tasks_safe config
-    |> List.fold_left
-         (fun (todo, claimed, running, done_count, cancelled) (task : Masc_domain.task) ->
-            match task.task_status with
-            | Todo -> todo + 1, claimed, running, done_count, cancelled
-            | Claimed _ -> todo, claimed + 1, running, done_count, cancelled
-            | InProgress _ | AwaitingVerification _ ->
-              todo, claimed, running + 1, done_count, cancelled
-            | Done _ -> todo, claimed, running, done_count + 1, cancelled
-            | Cancelled _ -> todo, claimed, running, done_count, cancelled + 1)
-         (0, 0, 0, 0, 0)
-  in
-  let todo_count, claimed_count, running_count, done_count, cancelled_count =
-    task_rollup
-  in
-  `Assoc
-    [ "generated_at", `String (Masc_domain.now_iso ())
-    ; "goals", `List (List.map Goal_store.goal_to_yojson goals)
-    ; "rollup", Goal_store.rollup_to_yojson rollup
-    ; ( "task_backlog"
-      , `Assoc
-          [ "todo", `Int todo_count
-          ; "claimed", `Int claimed_count
-          ; "in_progress", `Int running_count
-          ; "done", `Int done_count
-          ; "cancelled", `Int cancelled_count
-          ] )
-    ; "coordination_fsm", Coordination_product_snapshot.safe_build_tool_yojson config
-    ]
-;;
-
-let dashboard_goals_tree_http_json ~(config : Coord.config) : Yojson.Safe.t =
-  Dashboard_goals.dashboard_goals_tree_json ~config
-;;
-
-let dashboard_goals_snapshot_json ~(config : Coord.config) : Yojson.Safe.t =
-  `Assoc
-    [ "planning", dashboard_planning_http_json ~config
-    ; "tree", dashboard_goals_tree_http_json ~config
-    ]
-;;
+(* Dashboard planning + goals JSON extracted to
+   [Server_dashboard_planning_json] (godfile decomp). *)
+let dashboard_planning_http_json = Server_dashboard_planning_json.dashboard_planning_http_json
+let dashboard_goals_tree_http_json = Server_dashboard_planning_json.dashboard_goals_tree_http_json
+let dashboard_goals_snapshot_json = Server_dashboard_planning_json.dashboard_goals_snapshot_json
 
 let compact_preview ~max_chars text =
   let text = String.trim text in

--- a/lib/server/server_dashboard_planning_json.ml
+++ b/lib/server/server_dashboard_planning_json.ml
@@ -1,0 +1,56 @@
+(* Dashboard planning + goals JSON.
+
+   - [dashboard_planning_http_json]: planning view that rolls up goals
+     + task backlog status counts + coordination FSM snapshot.
+   - [dashboard_goals_tree_http_json]: tree view (delegates to
+     [Dashboard_goals]).
+   - [dashboard_goals_snapshot_json]: composite (planning + tree).
+
+   Extracted from [Server_dashboard_http] (godfile decomp). Pure
+   projection over goal store + backlog reader. *)
+
+let dashboard_planning_http_json ~(config : Coord.config) : Yojson.Safe.t =
+  let goals = Goal_store.list_goals config () in
+  let rollup = Goal_store.compute_rollup goals in
+  let task_rollup =
+    Server_dashboard_http_core_entities.dashboard_tasks_safe config
+    |> List.fold_left
+         (fun (todo, claimed, running, done_count, cancelled) (task : Masc_domain.task) ->
+            match task.task_status with
+            | Todo -> todo + 1, claimed, running, done_count, cancelled
+            | Claimed _ -> todo, claimed + 1, running, done_count, cancelled
+            | InProgress _ | AwaitingVerification _ ->
+              todo, claimed, running + 1, done_count, cancelled
+            | Done _ -> todo, claimed, running, done_count + 1, cancelled
+            | Cancelled _ -> todo, claimed, running, done_count, cancelled + 1)
+         (0, 0, 0, 0, 0)
+  in
+  let todo_count, claimed_count, running_count, done_count, cancelled_count =
+    task_rollup
+  in
+  `Assoc
+    [ "generated_at", `String (Masc_domain.now_iso ())
+    ; "goals", `List (List.map Goal_store.goal_to_yojson goals)
+    ; "rollup", Goal_store.rollup_to_yojson rollup
+    ; ( "task_backlog"
+      , `Assoc
+          [ "todo", `Int todo_count
+          ; "claimed", `Int claimed_count
+          ; "in_progress", `Int running_count
+          ; "done", `Int done_count
+          ; "cancelled", `Int cancelled_count
+          ] )
+    ; "coordination_fsm", Coordination_product_snapshot.safe_build_tool_yojson config
+    ]
+;;
+
+let dashboard_goals_tree_http_json ~(config : Coord.config) : Yojson.Safe.t =
+  Dashboard_goals.dashboard_goals_tree_json ~config
+;;
+
+let dashboard_goals_snapshot_json ~(config : Coord.config) : Yojson.Safe.t =
+  `Assoc
+    [ "planning", dashboard_planning_http_json ~config
+    ; "tree", dashboard_goals_tree_http_json ~config
+    ]
+;;

--- a/lib/server/server_dashboard_planning_json.mli
+++ b/lib/server/server_dashboard_planning_json.mli
@@ -1,0 +1,5 @@
+(** Dashboard planning + goals JSON. *)
+
+val dashboard_planning_http_json : config:Coord.config -> Yojson.Safe.t
+val dashboard_goals_tree_http_json : config:Coord.config -> Yojson.Safe.t
+val dashboard_goals_snapshot_json : config:Coord.config -> Yojson.Safe.t


### PR DESCRIPTION
## 요약

`server_dashboard_http.ml` (1500 LoC) 의 planning / goals tree / snapshot JSON 빌더 cluster 를 신규 sibling 모듈로 추출했습니다. **-40 LoC** (1500 → 1460).

PR #16857 (compact_receipt_json) + #16861 (fleet_readiness) 의 후속 — server_dashboard_http 세 번째 분해.

## 추출 surface (3 pure JSON projections)

| 함수 | 시그니처 |
|---|---|
| `dashboard_planning_http_json` | `~config -> Yojson.Safe.t` (goals + rollup + 5-state task backlog + FSM snapshot) |
| `dashboard_goals_tree_http_json` | `~config -> Yojson.Safe.t` (thin delegate) |
| `dashboard_goals_snapshot_json` | `~config -> Yojson.Safe.t` (planning + tree 합성) |

## 신규 모듈

- `lib/server/server_dashboard_planning_json.ml` (56 LoC)
- `lib/server/server_dashboard_planning_json.mli` (5 LoC)

## 의존성 (전부 dependency module)

- `Goal_store.{list_goals, compute_rollup, goal_to_yojson, rollup_to_yojson}`
- `Masc_domain.{task, task_status, Todo, Claimed, InProgress, AwaitingVerification, Done, Cancelled, now_iso}`
- `Coord.config`
- `Server_dashboard_http_core_entities.dashboard_tasks_safe` (parent 의 alias 가 아닌 sibling 명시 참조 → standalone build)
- `Coordination_product_snapshot.safe_build_tool_yojson`
- `Dashboard_goals.dashboard_goals_tree_json`

Shared state 0. Pure projection.

## 외부 caller 호환

- `test/test_dashboard_http_core.ml` 2 사이트 (line 468, 549) → `Lib.Server_dashboard_http.dashboard_planning_http_json` → parent thin alias 호환 → 변경 0
- `lib/server/server_h2_gateway.ml:753` → 동일 alias 호환 → 변경 0
- `server_dashboard_http.mli` 변경 0

## 검증

- [x] `dune build --root . lib/server` PASS
- [x] 함수 body 1-to-1 카피 (5-state task_status fold byte-identical)
- [x] exhaustive match (5 variants) 유지

## 패턴

Pure JSON projection extraction (PR #16847 logs_json, #16857 compact_receipt_json, #16861 fleet_readiness 와 동일). server_dashboard_http godfile 의 3번째 cluster — 본 PR + 두 선행 PR 누적 시 LoC 감소 **−204** (1500 → 1296 if all merge).

## Workaround Rejection Bar self-check

1. [ ] makes X visible only — NO
2. [ ] string classifier — NO
3. [ ] N-of-M — NO (전체 3 함수 이동)
4. [ ] catch-all `_ ->` 추가 — NO (existing 5-variant exhaustive match 유지)
5. [ ] cap/cooldown/dedup/repair — NO
6. [ ] test backdoor — NO
7. [ ] N-사이트 typo — NO

PASS — pure refactor.

## RFC

RFC-WAIVED: `lib/server` non-credential refactor.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
