### PR TITLE
refactor(dashboard): drop dead exports on 6 internal-only normalizer functions

### DIFF
--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -27,7 +27,7 @@ import type {
 
 // --- Data fetchers ---
 
-export function normalizeAgentStatus(value: unknown): Agent['status'] {
+function normalizeAgentStatus(value: unknown): Agent['status'] {
   const raw = typeof value === 'string' ? value.trim().toLowerCase() : ''
   if (
     raw === 'active'
@@ -44,7 +44,7 @@ export function normalizeAgentStatus(value: unknown): Agent['status'] {
   return undefined
 }
 
-export function normalizeTaskStatus(value: unknown): Task['status'] {
+function normalizeTaskStatus(value: unknown): Task['status'] {
   const raw = typeof value === 'string' ? value.trim().toLowerCase() : ''
   if (
     raw === 'todo'
@@ -167,7 +167,7 @@ export function normalizeMessage(raw: unknown): Message | null {
   }
 }
 
-export function normalizeExecutionTone(value: unknown): DashboardExecutionQueueItem['severity'] {
+function normalizeExecutionTone(value: unknown): DashboardExecutionQueueItem['severity'] {
   const raw = typeof value === 'string' ? value.toLowerCase() : ''
   if (raw === 'ok' || raw === 'warn' || raw === 'bad') return raw
   return undefined
@@ -193,7 +193,7 @@ export function normalizeExecutionSummary(raw: unknown): DashboardExecutionSumma
   }
 }
 
-export function normalizeExecutionHandoff(raw: unknown): DashboardExecutionHandoff | null {
+function normalizeExecutionHandoff(raw: unknown): DashboardExecutionHandoff | null {
   if (!isRecord(raw)) return null
   const surface = asString(raw.surface)
   const label = asString(raw.label)
@@ -841,7 +841,7 @@ export function normalizeRecommendedAction(raw: unknown): OperatorRecommendedAct
   }
 }
 
-export function messageSortKey(message: Message): number {
+function messageSortKey(message: Message): number {
   if (typeof message.seq === 'number' && Number.isFinite(message.seq)) return message.seq
   const parsed = Date.parse(message.timestamp ?? '')
   return Number.isNaN(parsed) ? 0 : parsed
@@ -867,7 +867,7 @@ export function mergeMessages(current: Message[], incoming: Message[]): Message[
     .slice(-500)
 }
 
-export function normalizeBuildIdentity(raw: unknown): ServerStatus['build'] | undefined {
+function normalizeBuildIdentity(raw: unknown): ServerStatus['build'] | undefined {
   if (!isRecord(raw)) return undefined
   const releaseVersion = asString(raw.release_version)
   const startedAt = toIsoTimestamp(raw.started_at)


### PR DESCRIPTION
## Summary

Six functions in `dashboard/src/store-normalizers.ts` are declared `export function` but have ZERO external importers anywhere in the repo. They ARE used internally by other functions in the same file. The `export` keyword on each is dead; the functions themselves are live.

Internal-only subcategory of the dead-export pattern (not full-removal candidates — PR #16862 handled true write-only dead signals).

## Findings

| Function | Internal callers (same file) | External callers | Action |
|---|---|---|---|
| `normalizeAgentStatus` (L30) | L72 | 0 | drop `export` |
| `normalizeTaskStatus` (L47) | L138 | 0 | drop `export` |
| `normalizeExecutionTone` (L170) | L232, L320, L353 | 0 | drop `export` |
| `normalizeExecutionHandoff` (L196) | L255-257, L288-290 | 0 | drop `export` |
| `messageSortKey` (L844) | L866 | 0 | drop `export` |
| `normalizeBuildIdentity` (L870) | L577, L889 | 0 | drop `export` |

Note: `store.ts:1071` re-exports everything via `export * from './store-normalizers'` (barrel), but no downstream consumer imports any of these 6 names by identifier (verified repo-wide).

## RFC-0140 cross-check

RFC-0140 cites `normalizeAgentStatus`/`normalizeTaskStatus`/`normalizeExecutionTone` only as **migration targets** to be consolidated into a typed codec layer in PR-7. They are explicitly NOT future public-API surface. Reducing the public surface here strengthens the future consolidation case.

## Verification

```bash
$ /path/to/main/dashboard/node_modules/.bin/tsc --noEmit -p tsconfig.json 2>&1 \
    | rg "normalizeAgentStatus|normalizeTaskStatus|normalizeExecutionTone|normalizeExecutionHandoff|normalizeBuildIdentity|messageSortKey"
# 0 hits — no tsc errors related to these 6 names
```

All tsc errors that DO appear are environmental (missing module typings — `vitest`, `@preact/signals`) because pnpm install hasn't run in this fresh worktree.

## Workaround Rejection Bar self-check

- §1 telemetry-as-fix: not applicable, dead-export reduction (not data path).
- §2 string classifier: none.
- §3 N-of-M: 6 functions modified atomically. Verified via repo-wide grep + RFC-0140 cross-check.
- catch-all / cap / cooldown: none.

## Audit context (Iter 4)

| PR | Surface |
|---|---|
| #16830~#16862 | (Iter 1-3 dead surfaces) |
| **this PR** | **6 dead `export` keywords on internal-only normalizers** |

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>