### PR TITLE
refactor(keeper_shell_bash): extract typed input projections into sibling

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -587,54 +587,15 @@ let bash_shape_block_result ~cmd ~cmd_for_log ~env_snapshot block =
        ~env_snapshot
        ())
 
-let has_typed_bash_input_key = function
-  | `Assoc fields ->
-    List.exists
-      (fun (key, _) ->
-         String.equal key "executable"
-         || String.equal key "pipeline"
-         || String.equal key "stages")
-      fields
-  | _ -> false
-
-let assoc_upsert key value = function
-  | `Assoc fields ->
-    `Assoc ((key, value) :: List.filter (fun (k, _) -> not (String.equal k key)) fields)
-  | other -> other
-
-let shell_quote_for_policy token =
-  let safe_char = function
-    | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' | '-' | '.' | '/' | ':' | '=' | ',' ->
-      true
-    | _ -> false
-  in
-  if String.length token > 0 && String.for_all safe_char token
-  then token
-  else
-    let parts = String.split_on_char '\'' token in
-    "'" ^ String.concat "'\\''" parts ^ "'"
-
-let typed_stage_command_text ~executable ~argv =
-  executable :: argv
-  |> List.map shell_quote_for_policy
-  |> String.concat " "
-
-let typed_input_command_text = function
-  | Keeper_tool_bash_input.Exec { executable; argv; _ } ->
-    typed_stage_command_text ~executable ~argv
-  | Keeper_tool_bash_input.Pipeline { stages; _ } ->
-    stages
-    |> List.map (fun (stage : Keeper_tool_bash_input.exec_stage) ->
-      typed_stage_command_text ~executable:stage.executable ~argv:stage.argv)
-    |> String.concat " | "
-
-let typed_input_has_env = function
-  | Keeper_tool_bash_input.Exec { env; _ }
-  | Keeper_tool_bash_input.Pipeline { env; _ } ->
-    env <> []
-
-let typed_validation_error_text error =
-  Format.asprintf "%a" Keeper_tool_bash_input.pp_validation_error error
+(* Typed keeper_bash input projections extracted to
+   [Keeper_shell_bash_typed_input] (godfile decomp). *)
+let has_typed_bash_input_key = Keeper_shell_bash_typed_input.has_typed_bash_input_key
+let assoc_upsert = Keeper_shell_bash_typed_input.assoc_upsert
+let shell_quote_for_policy = Keeper_shell_bash_typed_input.shell_quote_for_policy
+let typed_stage_command_text = Keeper_shell_bash_typed_input.typed_stage_command_text
+let typed_input_command_text = Keeper_shell_bash_typed_input.typed_input_command_text
+let typed_input_has_env = Keeper_shell_bash_typed_input.typed_input_has_env
+let typed_validation_error_text = Keeper_shell_bash_typed_input.typed_validation_error_text
 
 let normalize_path_for_keeper_bash_containment path =
   Keeper_alerting_path.normalize_path_for_check path

--- a/lib/keeper/keeper_shell_bash_typed_input.ml
+++ b/lib/keeper/keeper_shell_bash_typed_input.ml
@@ -1,0 +1,65 @@
+(* Typed keeper_bash input projections.
+
+   Static helpers around [Keeper_tool_bash_input] - quote a token for
+   policy strings, render an [Exec]/[Pipeline] back to a shell-command
+   string (for policy validation + auditing), inspect whether env was
+   provided, and pretty-print a validation error.
+
+   Extracted from [Keeper_shell_bash] (godfile decomp). Pure mapping
+   over typed input + Stdlib. *)
+
+let has_typed_bash_input_key = function
+  | `Assoc fields ->
+    List.exists
+      (fun (key, _) ->
+         String.equal key "executable"
+         || String.equal key "pipeline"
+         || String.equal key "stages")
+      fields
+  | _ -> false
+;;
+
+let assoc_upsert key value = function
+  | `Assoc fields ->
+    `Assoc ((key, value) :: List.filter (fun (k, _) -> not (String.equal k key)) fields)
+  | other -> other
+;;
+
+let shell_quote_for_policy token =
+  let safe_char = function
+    | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' | '-' | '.' | '/' | ':' | '=' | ',' ->
+      true
+    | _ -> false
+  in
+  if String.length token > 0 && String.for_all safe_char token
+  then token
+  else (
+    let parts = String.split_on_char '\'' token in
+    "'" ^ String.concat "'\\''" parts ^ "'")
+;;
+
+let typed_stage_command_text ~executable ~argv =
+  executable :: argv
+  |> List.map shell_quote_for_policy
+  |> String.concat " "
+;;
+
+let typed_input_command_text = function
+  | Keeper_tool_bash_input.Exec { executable; argv; _ } ->
+    typed_stage_command_text ~executable ~argv
+  | Keeper_tool_bash_input.Pipeline { stages; _ } ->
+    stages
+    |> List.map (fun (stage : Keeper_tool_bash_input.exec_stage) ->
+      typed_stage_command_text ~executable:stage.executable ~argv:stage.argv)
+    |> String.concat " | "
+;;
+
+let typed_input_has_env = function
+  | Keeper_tool_bash_input.Exec { env; _ }
+  | Keeper_tool_bash_input.Pipeline { env; _ } ->
+    env <> []
+;;
+
+let typed_validation_error_text error =
+  Format.asprintf "%a" Keeper_tool_bash_input.pp_validation_error error
+;;

--- a/lib/keeper/keeper_shell_bash_typed_input.mli
+++ b/lib/keeper/keeper_shell_bash_typed_input.mli
@@ -1,0 +1,13 @@
+(** Typed keeper_bash input projections (quote, render, validate). *)
+
+val has_typed_bash_input_key : Yojson.Safe.t -> bool
+val assoc_upsert : string -> Yojson.Safe.t -> Yojson.Safe.t -> Yojson.Safe.t
+val shell_quote_for_policy : string -> string
+
+val typed_stage_command_text : executable:string -> argv:string list -> string
+val typed_input_command_text : Keeper_tool_bash_input.t -> string
+val typed_input_has_env : Keeper_tool_bash_input.t -> bool
+
+val typed_validation_error_text
+  :  Keeper_tool_bash_input.validation_error
+  -> string


### PR DESCRIPTION
## 요약

`keeper_shell_bash.ml` (1986 LoC post-#16838 / #16758 base) 의 typed bash input projection cluster (7 함수) 를 신규 sibling 모듈로 추출했습니다. **-39 LoC** (1986 → 1947).

PR #16758 (Repo_wide_scan) + #16838 (native_tool_hint) 의 후속 — keeper_shell_bash 세 번째 분해.

## 추출 surface (7 pure functions)

| 함수 | 시그니처 |
|---|---|
| `has_typed_bash_input_key` | `Yojson.Safe.t -> bool` (executable/pipeline/stages 키 검사) |
| `assoc_upsert` | `string -> Yojson.Safe.t -> Yojson.Safe.t -> Yojson.Safe.t` |
| `shell_quote_for_policy` | `string -> string` |
| `typed_stage_command_text` | `~executable ~argv -> string` |
| `typed_input_command_text` | `Keeper_tool_bash_input.t -> string` |
| `typed_input_has_env` | `Keeper_tool_bash_input.t -> bool` |
| `typed_validation_error_text` | `validation_error -> string` |

## 신규 모듈

- `lib/keeper/keeper_shell_bash_typed_input.ml` (65 LoC)
- `lib/keeper/keeper_shell_bash_typed_input.mli` (13 LoC)

## 의존성 (Stdlib + dependency module)

- `Keeper_tool_bash_input.{Exec, Pipeline, exec_stage, t, validation_error, pp_validation_error}`
- `Format.asprintf`
- `String`, `List` (Stdlib)

Shared state 0. Side effect 0 (pure mapping).

## 외부 caller 호환

- 외부 caller 0
- 1 internal call site at line 775 (parent body) → parent thin alias → 변경 0
- `keeper_shell_bash.mli` 변경 0

## 검증

- [x] `dune build --root . lib/keeper` PASS
- [x] public surface 변경 0 (parent alias 호환)
- [x] 함수 body 1-to-1 카피

## 패턴

Pure helper extraction (PR #16770 stimulus_intake, #16838 native_tool_hint 와 동일 패턴). typed bash input projection 은 bash command parsing / sandbox containment 의 책임이 아닌 별도 thematic concern — typed argv 의 shell-string 렌더 + validation error 포맷팅.

## Workaround Rejection Bar self-check

1. [ ] makes X visible only — NO
2. [ ] string classifier — NO
3. [ ] N-of-M — NO (전체 cluster 이동)
4. [ ] catch-all `_ ->` 추가 — NO (existing `| _ -> false`/`| other -> other` 유지)
5. [ ] cap/cooldown/dedup/repair — NO
6. [ ] test backdoor — NO
7. [ ] N-사이트 typo — NO

PASS — pure refactor.

## RFC

RFC-WAIVED: `keeper_shell_bash_typed_input` 는 RFC-gated subsystem 아님.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
