### PR TITLE
feat(shell-ir): RFC-0092 PR-4 MASC_BASH_TYPED_AUTHORITY 플래그 predicate

### DIFF
--- a/lib/exec/command_gate/shell_command_gate.ml
+++ b/lib/exec/command_gate/shell_command_gate.ml
@@ -319,3 +319,19 @@ let last_stage_bin context =
 ;;
 
 let is_pipeline context = List.length context.stage_bins > 1
+
+(* RFC-0092 Phase C authority — facade-side predicate.
+
+   This sub-library cannot depend on [masc_mcp.gate_diff_types]
+   (which lives in the root masc_mcp library and would introduce a
+   cycle), so the env read is duplicated here.  The truthy-value set
+   must stay byte-for-byte identical to [Gate_diff_types.
+   typed_authority_enabled] — both predicates are the single
+   operator-facing SSOT for [MASC_BASH_TYPED_AUTHORITY] and divergence
+   would silently break the authority flip.  If a future RFC promotes
+   the predicate to a shared dep, delete this copy. *)
+let is_authoritative () =
+  match Sys.getenv_opt "MASC_BASH_TYPED_AUTHORITY" with
+  | Some ("1" | "true" | "TRUE" | "yes" | "on") -> true
+  | _ -> false
+;;

--- a/lib/exec/command_gate/shell_command_gate.mli
+++ b/lib/exec/command_gate/shell_command_gate.mli
@@ -187,3 +187,28 @@ val too_complex_reason_tag : too_complex_reason -> string
 val stage_count : parsed_context -> int
 val last_stage_bin : parsed_context -> string option
 val is_pipeline : parsed_context -> bool
+
+(** {1 Authority flag (RFC-0092 Phase C)} *)
+
+val is_authoritative : unit -> bool
+(** [is_authoritative ()] returns [true] iff the
+    [MASC_BASH_TYPED_AUTHORITY] environment variable is set to one of
+    the documented truthy values: [1], [true], [TRUE], [yes], [on].
+    Default off — no behavior change while unset.
+
+    This is the facade-side mirror of
+    [Masc_mcp.Gate_diff_types.typed_authority_enabled].  Both
+    predicates intentionally share the same truthy-value set; the
+    duplication exists because this sub-library
+    ([masc_exec_command_gate]) cannot depend on the root [masc_mcp]
+    library without introducing a cycle.
+
+    Consumers outside the keeper boundary (Phase 1 facade callers
+    listed in the {!caller} sum) should prefer this predicate;
+    consumers inside the root [masc_mcp] library should use
+    [Masc_mcp.Gate_diff_types.typed_authority_enabled].  Both return
+    the same bool at any given env-var state.
+
+    Predicate-only stage: this PR does not change facade behavior
+    when the flag is on — the authority decision-arm wiring lands in
+    a follow-up so risk stays measurable. *)

--- a/lib/gate_diff_types.ml
+++ b/lib/gate_diff_types.ml
@@ -195,3 +195,16 @@ let typed_advisor_log_enabled () =
   match Sys.getenv_opt "MASC_BASH_TYPED_ADVISOR" with
   | Some ("1" | "true" | "TRUE" | "yes" | "on" | "log") -> true
   | _ -> false
+
+(* RFC-0092 Phase C authority — predicate-only stage of PR-4.
+
+   Default off; no behavior change while unset.  Read each call (not
+   lazy) so operators can flip the env var mid-process for ops drills
+   and rollback without restarting the keeper fleet — same property
+   the advisor predicate has.  The narrower truthy set (no "log"
+   alias) is intentional: "log" only makes sense for measurement, not
+   decisions. *)
+let typed_authority_enabled () =
+  match Sys.getenv_opt "MASC_BASH_TYPED_AUTHORITY" with
+  | Some ("1" | "true" | "TRUE" | "yes" | "on") -> true
+  | _ -> false

--- a/lib/gate_diff_types.mli
+++ b/lib/gate_diff_types.mli
@@ -190,5 +190,29 @@ val typed_advisor_log_enabled : unit -> bool
     the documented truthy values: [1], [true], [TRUE], [yes], [on],
     [log].  Default off — the typed-validation parity-measurement
     counters do not increment until an operator opts in.  Phase C
-    will flip authority via a separate [MASC_BASH_TYPED_AUTHORITY]
-    flag in a follow-up PR. *)
+    flips authority via the separate {!typed_authority_enabled}
+    flag below; advisor logging remains independent so operators
+    can keep parity counters running after authority is enabled. *)
+
+val typed_authority_enabled : unit -> bool
+(** RFC-0092 Phase C authority opt-in — predicate-only stage of PR-4.
+    Returns [true] iff the [MASC_BASH_TYPED_AUTHORITY] environment
+    variable is set to one of the documented truthy values: [1],
+    [true], [TRUE], [yes], [on].  Default off — *no behavior change
+    while unset*.  When set, downstream callers (planned:
+    [keeper_shell_bash]) treat the typed {!Shell_ir_validator} verdict
+    as authoritative for [Allow]/[Reject] cases and fall back to the
+    legacy substring gate on [Cannot_parse], per RFC-0092 §4.3.  This
+    predicate is the SSOT operators flip; consumers must not read
+    [Sys.getenv] directly for this flag.
+
+    Distinct from {!typed_advisor_log_enabled}: the advisor flag gates
+    *measurement* (parity counters), the authority flag gates
+    *decision*.  An operator may run with advisor on + authority off
+    (Phase B observation) or advisor off + authority on (Phase C
+    after parity criterion met); the two flags are independent
+    booleans by design.
+
+    Truthy-value set is intentionally narrower than the advisor flag
+    (no [log] alias) because [log] only makes sense for measurement,
+    not decisions. *)

--- a/test/dune
+++ b/test/dune
@@ -324,6 +324,7 @@
   test_exec_shell_command_gate
   test_shell_ir_validator
   test_typed_advisor_counters
+  test_typed_authority_flag
   test_auth_resolve_labels
   test_keeper_classifier_helper
   test_persona_tool_reachability
@@ -645,6 +646,7 @@
   test_exec_shell_command_gate
   test_shell_ir_validator
   test_typed_advisor_counters
+  test_typed_authority_flag
   test_auth_resolve_labels
   test_keeper_classifier_helper
   test_persona_tool_reachability

--- a/test/test_typed_authority_flag.ml
+++ b/test/test_typed_authority_flag.ml
@@ -1,0 +1,124 @@
+(** RFC-0092 Phase C — tests for the [MASC_BASH_TYPED_AUTHORITY] flag
+    predicate.
+
+    Two SSOT predicates ship in this PR; both must read the same
+    env var and return the same bool at any given env state:
+
+    - [Masc_mcp.Gate_diff_types.typed_authority_enabled] (root lib)
+    - [Masc_exec_command_gate.Shell_command_gate.is_authoritative]
+      (facade sub-library)
+
+    The duplicate exists because the facade sub-library cannot depend
+    on the root [masc_mcp] library without a cycle; this test pins
+    the two predicates to identical truthy-value semantics so silent
+    divergence at the SSOT layer fails CI rather than only surfacing
+    when the authority decision-arm wiring lands in a follow-up.
+
+    No in-process caching (the predicates re-read [Sys.getenv_opt]
+    each call), so each case can [Unix.putenv] inline.  The
+    [Fun.protect ~finally] restore pattern matches
+    [test_typed_advisor_counters.ml]'s default-off case so the test
+    file does not leak env state to subsequent test executables in
+    the same Alcotest sweep. *)
+
+module Root = Masc_mcp.Gate_diff_types
+module Facade = Masc_exec_command_gate.Shell_command_gate
+
+let env_var = "MASC_BASH_TYPED_AUTHORITY"
+
+(* Snapshot + restore so the test fixture is self-contained — the
+   test runner shares the OS process with subsequent test exes when
+   chained, and a leaked truthy value would silently turn authority
+   on for them. *)
+let with_env value f =
+  let prev = Sys.getenv_opt env_var in
+  Unix.putenv env_var value;
+  Fun.protect
+    ~finally:(fun () ->
+      match prev with
+      | None -> Unix.putenv env_var ""
+      | Some v -> Unix.putenv env_var v)
+    f
+;;
+
+let check_both ~label ~expected =
+  Alcotest.(check bool)
+    (Printf.sprintf "%s — root predicate" label)
+    expected
+    (Root.typed_authority_enabled ());
+  Alcotest.(check bool)
+    (Printf.sprintf "%s — facade predicate" label)
+    expected
+    (Facade.is_authoritative ())
+;;
+
+let test_unset_is_off () =
+  (* Saved+restored so we don't depend on the parent shell's state. *)
+  let prev = Sys.getenv_opt env_var in
+  Unix.putenv env_var "";
+  Fun.protect
+    ~finally:(fun () ->
+      match prev with
+      | None -> Unix.putenv env_var ""
+      | Some v -> Unix.putenv env_var v)
+    (fun () -> check_both ~label:"empty env" ~expected:false)
+;;
+
+let test_truthy_values_turn_on () =
+  List.iter
+    (fun v ->
+      with_env v (fun () ->
+        check_both ~label:(Printf.sprintf "env=%S" v) ~expected:true))
+    [ "1"; "true"; "TRUE"; "yes"; "on" ]
+;;
+
+let test_falsy_and_arbitrary_values_stay_off () =
+  (* "log" is intentionally *not* a truthy value for the authority
+     flag — RFC-0092 §4.3 reserves "log" for the advisor flag only.
+     Mixing them would let an operator turn decisions on while
+     thinking they only enabled measurement. *)
+  List.iter
+    (fun v ->
+      with_env v (fun () ->
+        check_both ~label:(Printf.sprintf "env=%S" v) ~expected:false))
+    [ "0"; "false"; "FALSE"; "no"; "off"; "log"; "2"; "anything-else"; "" ]
+;;
+
+let test_predicates_stay_in_sync_per_value () =
+  (* Belt-and-suspenders: even if the two predicate impls diverge in
+     a future refactor, this assertion catches drift directly. *)
+  List.iter
+    (fun v ->
+      with_env v (fun () ->
+        let root = Root.typed_authority_enabled () in
+        let facade = Facade.is_authoritative () in
+        Alcotest.(check bool)
+          (Printf.sprintf "root/facade agree on env=%S" v)
+          root
+          facade))
+    [ ""; "1"; "true"; "TRUE"; "yes"; "on"; "log"; "0"; "false"; "garbage" ]
+;;
+
+let () =
+  Alcotest.run
+    "typed_authority_flag"
+    [ ( "predicate"
+      , [ Alcotest.test_case
+            "unset env → off"
+            `Quick
+            test_unset_is_off
+        ; Alcotest.test_case
+            "documented truthy values → on"
+            `Quick
+            test_truthy_values_turn_on
+        ; Alcotest.test_case
+            "falsy + arbitrary values → off"
+            `Quick
+            test_falsy_and_arbitrary_values_stay_off
+        ; Alcotest.test_case
+            "root and facade predicates agree"
+            `Quick
+            test_predicates_stay_in_sync_per_value
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 목표

Shell IR Promotion Goal Plan (2026-05-18, `memory/shell-ir-promotion-goal-2026-05-18.html`) **Phase 3** — RFC-0092 **PR-4 (Phase C authority flip)** 의 predicate-only 단계.

H6 사전 검증: `MASC_BASH_TYPED_AUTHORITY` 는 `lib/gate_diff_types.mli:193` 의 forward-reference doc 한 줄에서만 언급되고, 실제 impl site는 0건이었음. 본 PR은 operator-facing 술어를 SSOT 로 추가해 후속 `keeper_shell_bash` 결정-arm wiring 이 읽을 수 있게 한다.

Plan HTML Phase 3 처방 인용:
> 기존 `MASC_BASH_TYPED_ADVISOR` 는 유지하고, `MASC_BASH_TYPED_AUTHORITY` 를 별도 flag로 추가한다.
> authority off: legacy verdict와 Shell IR verdict를 모두 기록하되 기존 동작 유지.

RFC-0092 §4.3 / PR-4 항목:
> Add a second flag `MASC_BASH_TYPED_AUTHORITY=1`. When set: typed advisor's `Reject` returns the JSON error; typed `Allow` proceeds; typed `Cannot_parse` falls back to legacy verdict.

본 PR은 RFC-0092 PR-4 의 **predicate 단계만** 다루며, `keeper_shell_bash.ml` decision-arm wiring 은 follow-up. risk 를 단계화하기 위함. Phase 4 (native dispatch via `Exec_dispatch`) 은 본 PR scope 밖.

## 변경 (LoC +206 / -2, 6 files)

| File | 변경 |
|---|---|
| `lib/gate_diff_types.ml/.mli` | `typed_authority_enabled : unit -> bool` 신규. `Worker_dev_tools` 가 `include module type of Gate_diff_types` 로 자동 재노출. |
| `lib/exec/command_gate/shell_command_gate.ml/.mli` | `is_authoritative : unit -> bool` 신규 (Phase 1 facade SSOT). |
| `test/test_typed_authority_flag.ml` | 신규 — 4 Alcotest case. |
| `test/dune` | 새 test exe 등록. |

### 새 API

- `Masc_mcp.Gate_diff_types.typed_authority_enabled () : bool` — root lib SSOT.
- `Masc_exec_command_gate.Shell_command_gate.is_authoritative () : bool` — facade sub-library mirror.

### Truthy-value set (의도적으로 advisor flag 보다 좁음)

- **on**: `1` / `true` / `TRUE` / `yes` / `on`
- **off**: 그 외 모두. **`log` 는 명시적 off** — RFC-0092 §4.3 가 `log` 를 measurement 전용으로 reserve.

## Dark-launch

**Default off** — env var 미설정 또는 위 truthy 값이 아니면 `false` 반환. 어떤 caller도 아직 predicate를 읽지 않으므로 **본 PR로 인한 동작 변화는 0**. operator 가 `MASC_BASH_TYPED_AUTHORITY=true` 를 명시적으로 설정해야 후속 PR 에서 활성화됨.

## 두 술어가 분리된 이유

`lib/exec/command_gate/` 는 `masc_exec_command_gate` sub-library 로, `masc_exec` + `masc_exec_bash_parser` 만 의존. 만약 root `masc_mcp.Gate_diff_types` 를 의존하면 의존성 cycle 발생. 따라서 facade 측에 env-read 를 중복하되, truthy set 을 byte-equal 로 pin 하고 root↔facade agreement matrix 테스트로 drift 차단.

## 테스트 (4 case, Alcotest)

1. **unset env → off** — 양쪽 술어 모두 `false`.
2. **5 documented truthy values → on** — `1` / `true` / `TRUE` / `yes` / `on` 각각에서 양쪽 술어 모두 `true`.
3. **10 falsy/arbitrary values → off** — `0` / `false` / `FALSE` / `no` / `off` / `log` / `2` / `anything-else` / `""` 모두 `false`. **`log` 는 advisor 와 다르게 off** 임을 명시 pin.
4. **root↔facade agreement matrix** — 10 env value 각각에서 두 술어가 동일한 bool 반환 확인 (drift 회귀 차단).

각 case 는 `Sys.getenv_opt` snapshot + `Fun.protect` restore 로 fixture self-contained.

## Build & test 상태

- `lib/gate_diff_types.ml/.mli` — `dune build --root . lib/gate_diff_types.ml` clean.
- `lib/exec/command_gate/shell_command_gate.ml/.mli` — `dune build --root . lib/exec/command_gate/` clean.
- `test/test_typed_authority_flag.exe` — **빌드 차단**: pre-existing `Unbound module Eio` in `lib/dashboard_eval_feed/dashboard_eval_feed.ml:127` (PR #16802 follow-up, 모든 test exe 영향). 별도 이슈 #16871 로 등록. origin/main pristine checkout 에서 동일 재현 확인 — 본 PR 변경과 무관.

## RFC reuse

신규 RFC 작성 없음 — RFC-0092 §4.3 + §7 PR-4 가 본 PR scope 를 이미 정의. RFC body 업데이트 불필요 (predicate 추가는 PR-4 의 일부).

## Workaround-rejection 7-point self-check

- [ ] "makes X visible" / "instrument Y" 만 수행 — **NO** (typed predicate 추가, no telemetry-as-fix)
- [ ] string/substring/prefix 분류기 추가 — **NO** (closed truthy-string list — RFC §4.3 명세된 SSOT)
- [ ] "PR #N only fixed K of M sites" 자인 — **NO**
- [ ] catch-all `_ ->` 추가 — **NO** (의도적 default 동작)
- [ ] cap/cooldown/dedup/repair 으로 symptom 억제 — **NO**
- [ ] test backdoor 노출 — **NO**
- [ ] 같은 typo/off-by-one 을 N 사이트에서 N 번 fix — **NO**

✗ 해당 없음.

## Related

- Goal: `~/me/memory/shell-ir-promotion-goal-2026-05-18.html` Phase 3
- RFC: `docs/rfc/RFC-0092-keeper-shell-bash-typed-validation.md` §4.3, §7 (PR-4)
- Discovery: #16871 (dashboard_eval_feed Eio dep — 본 PR test 실행 차단, 무관 main 회귀)
- Phase 2 PR #16834 (Draft) — 독립 진행 가능, 본 PR base=origin/main