### PR TITLE
refactor(server): extract /health?full=1 placeholder fields into sibling

### DIFF
--- a/lib/server/server_full_health_placeholder_fields.ml
+++ b/lib/server/server_full_health_placeholder_fields.ml
@@ -1,0 +1,90 @@
+(* /health?full=1 cached-field placeholder builders.
+
+   The full-health snapshot is computed off the hot path and cached
+   for 2s. When the cache is cold (boot, refresh in flight, error), a
+   placeholder payload with [status="warming"] / ["error"] is served
+   under the same field names so the dashboard doesn't have to handle
+   "missing key" vs "present-but-warming" separately.
+
+   Extracted from [Server_routes_http_runtime] (godfile decomp). Pure
+   builders + a field-membership predicate. No I/O, no state. *)
+
+let full_health_cached_field_names =
+  [ "feature_flags"
+  ; "keeper_fibers"
+  ; "keeper_fd_pressure"
+  ; "fd_accountant"
+  ; "keeper_fleet_safety"
+  ; "keeper_reaction_ledger"
+  ; "paused_keepers"
+  ; "cdal"
+  ; "keeper_config_parse_error_count"
+  ; "keeper_config_parse_errors"
+  ; "keeper_config_unknown_key_count"
+  ; "keeper_config_unknown_keys"
+  ; "keeper_config_schema_status"
+  ; "keeper_config_schema_blocking"
+  ; "keeper_config_schema_terminal_reason"
+  ; "keeper_config_operator_action_required"
+  ; "lazy_task_boot_guard_fires_total"
+  ]
+;;
+
+let full_health_field_is_cached name =
+  List.exists (String.equal name) full_health_cached_field_names
+;;
+
+let full_health_component_placeholder ?error ~status component =
+  let error_fields =
+    match error with
+    | Some error -> [ "error", `String error ]
+    | None -> []
+  in
+  `Assoc
+    ([ "component", `String component
+     ; "status", `String status
+     ; "component_timed_out", `Bool false
+     ]
+     @ error_fields)
+;;
+
+let full_health_placeholder_fields ?error ?(status = "warming") () =
+  [ ( "feature_flags"
+    , full_health_component_placeholder ?error ~status "feature_flags" )
+  ; "keeper_fibers", `Int 0
+  ; ( "keeper_fd_pressure"
+    , full_health_component_placeholder ?error ~status "keeper_fd_pressure" )
+  ; ( "fd_accountant"
+    , full_health_component_placeholder ?error ~status "fd_accountant" )
+  ; ( "keeper_fleet_safety"
+    , full_health_component_placeholder ?error ~status "keeper_fleet_safety" )
+  ; ( "keeper_reaction_ledger"
+    , full_health_component_placeholder ?error ~status "keeper_reaction_ledger" )
+  ; ( "paused_keepers"
+    , `Assoc
+        [ "status", `String status
+        ; "count", `Int 0
+        ; "names", `List []
+        ; "component_timed_out", `Bool false
+        ] )
+  ; "cdal", full_health_component_placeholder ?error ~status "cdal"
+  ; "keeper_config_parse_error_count", `Int 0
+  ; "keeper_config_parse_errors", `List []
+  ; "keeper_config_unknown_key_count", `Int 0
+  ; "keeper_config_unknown_keys", `List []
+  ; "keeper_config_schema_status", `String status
+  ; "keeper_config_schema_blocking", `Bool false
+  ; "keeper_config_schema_terminal_reason", `String "snapshot_not_ready"
+  ; "keeper_config_operator_action_required", `Bool false
+  ; "lazy_task_boot_guard_fires_total", `Int 0
+  ]
+;;
+
+let cached_full_health_fields = function
+  | `Assoc fields ->
+    List.filter (fun (name, _) -> full_health_field_is_cached name) fields
+  | json ->
+    [ ( "full_health_payload"
+      , `Assoc [ "status", `String "unexpected_payload"; "payload", json ] )
+    ]
+;;

--- a/lib/server/server_full_health_placeholder_fields.mli
+++ b/lib/server/server_full_health_placeholder_fields.mli
@@ -1,0 +1,18 @@
+(** Placeholder builders for the cached [/health?full=1] fields. *)
+
+val full_health_cached_field_names : string list
+val full_health_field_is_cached : string -> bool
+
+val full_health_component_placeholder
+  :  ?error:string
+  -> status:string
+  -> string
+  -> Yojson.Safe.t
+
+val full_health_placeholder_fields
+  :  ?error:string
+  -> ?status:string
+  -> unit
+  -> (string * Yojson.Safe.t) list
+
+val cached_full_health_fields : Yojson.Safe.t -> (string * Yojson.Safe.t) list

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -845,88 +845,27 @@ let with_full_health_snapshot_lock f =
     ~finally:(fun () -> Stdlib.Mutex.unlock full_health_snapshot_mu)
     f
 
+(* /health?full=1 placeholder field builders extracted to
+   [Server_full_health_placeholder_fields] (godfile decomp). *)
 let full_health_cached_field_names =
-  [
-    "feature_flags";
-    "keeper_fibers";
-    "keeper_fd_pressure";
-    "fd_accountant";
-    "keeper_fleet_safety";
-    "keeper_reaction_ledger";
-    "paused_keepers";
-    "cdal";
-    "keeper_config_parse_error_count";
-    "keeper_config_parse_errors";
-    "keeper_config_unknown_key_count";
-    "keeper_config_unknown_keys";
-    "keeper_config_schema_status";
-    "keeper_config_schema_blocking";
-    "keeper_config_schema_terminal_reason";
-    "keeper_config_operator_action_required";
-    "lazy_task_boot_guard_fires_total";
-  ]
+  Server_full_health_placeholder_fields.full_health_cached_field_names
+;;
 
-let full_health_field_is_cached name =
-  List.exists (String.equal name) full_health_cached_field_names
+let full_health_field_is_cached =
+  Server_full_health_placeholder_fields.full_health_field_is_cached
+;;
 
-let full_health_component_placeholder ?error ~status component =
-  let error_fields =
-    match error with
-    | Some error -> [ ("error", `String error) ]
-    | None -> []
-  in
-  `Assoc
-    ([
-       ("component", `String component);
-       ("status", `String status);
-       ("component_timed_out", `Bool false);
-     ]
-     @ error_fields)
+let full_health_component_placeholder =
+  Server_full_health_placeholder_fields.full_health_component_placeholder
+;;
 
-let full_health_placeholder_fields ?error ?(status = "warming") () =
-  [
-    ( "feature_flags",
-      full_health_component_placeholder ?error ~status "feature_flags" );
-    ("keeper_fibers", `Int 0);
-    ( "keeper_fd_pressure",
-      full_health_component_placeholder ?error ~status "keeper_fd_pressure" );
-    ( "fd_accountant",
-      full_health_component_placeholder ?error ~status "fd_accountant" );
-    ( "keeper_fleet_safety",
-      full_health_component_placeholder ?error ~status "keeper_fleet_safety" );
-    ( "keeper_reaction_ledger",
-      full_health_component_placeholder ?error ~status "keeper_reaction_ledger" );
-    ( "paused_keepers",
-      `Assoc
-        [
-          ("status", `String status);
-          ("count", `Int 0);
-          ("names", `List []);
-          ("component_timed_out", `Bool false);
-        ] );
-    ("cdal", full_health_component_placeholder ?error ~status "cdal");
-    ("keeper_config_parse_error_count", `Int 0);
-    ("keeper_config_parse_errors", `List []);
-    ("keeper_config_unknown_key_count", `Int 0);
-    ("keeper_config_unknown_keys", `List []);
-    ("keeper_config_schema_status", `String status);
-    ("keeper_config_schema_blocking", `Bool false);
-    ("keeper_config_schema_terminal_reason", `String "snapshot_not_ready");
-    ("keeper_config_operator_action_required", `Bool false);
-    ("lazy_task_boot_guard_fires_total", `Int 0);
-  ]
+let full_health_placeholder_fields =
+  Server_full_health_placeholder_fields.full_health_placeholder_fields
+;;
 
-let cached_full_health_fields = function
-  | `Assoc fields -> List.filter (fun (name, _) -> full_health_field_is_cached name) fields
-  | json ->
-      [
-        ( "full_health_payload",
-          `Assoc
-            [
-              ("status", `String "unexpected_payload");
-              ("payload", json);
-            ] );
-      ]
+let cached_full_health_fields =
+  Server_full_health_placeholder_fields.cached_full_health_fields
+;;
 
 let duration_ms ~started_at ~finished_at =
   max 0 (int_of_float ((finished_at -. started_at) *. 1000.))


### PR DESCRIPTION
## 요약

`server_routes_http_runtime.ml` (1299 LoC) 의 `/health?full=1` placeholder builder cluster 를 신규 sibling 모듈로 추출했습니다. **-61 LoC** (1299 → 1238).

server_routes_http_runtime 첫 분해.

## 추출 surface (5 pure projections)

| 항목 | 시그니처 |
|---|---|
| `full_health_cached_field_names` | `string list` (17-entry contract) |
| `full_health_field_is_cached` | `string -> bool` |
| `full_health_component_placeholder` | `?error ~status component -> Yojson.Safe.t` |
| `full_health_placeholder_fields` | `?error ?status () -> (string * Yojson.Safe.t) list` |
| `cached_full_health_fields` | `Yojson.Safe.t -> (string * Yojson.Safe.t) list` |

## 신규 모듈

- `lib/server/server_full_health_placeholder_fields.ml` (90 LoC)
- `lib/server/server_full_health_placeholder_fields.mli` (18 LoC)

## 의존성 (Stdlib only)

- `List`, `String`

Pure constants + functions. Shared state 0.

## 외부 caller 호환

- 외부 caller 0
- 내부 사용 4 site (lines 937, 952, 1004, 1139) → parent thin alias → 변경 0
- `server_routes_http_runtime.mli` 변경 0

## 검증

- [x] `dune build --root . lib/server` PASS
- [x] 함수 body 1-to-1 카피
- [x] 17-entry `full_health_cached_field_names` byte-identical (snapshot 의 cached-field 는 dashboard 와 contract — 어떤 순서 변경도 wire 불일치)

## 패턴

Pure helper extraction (PR #16847 logs_json, #16857 compact_receipt_json, #16861 fleet_readiness, #16867 planning_json 와 동일 thematic separation). "placeholder field 생성" 은 full-health snapshot orchestration (mutex + refs + refresh fiber) 의 책임이 아닌 별도 wire-format concern.

후속 candidate: full_health_snapshot_mu + refs + with_lock + compute/store/mark_error/snapshot_metadata/refresh_loop cluster (~330 LoC state encapsulation — 본 PR 의 placeholder 와 분리 가능).

## Workaround Rejection Bar self-check

1. [ ] makes X visible only — NO
2. [ ] string classifier — NO (existing field name list 이동만)
3. [ ] N-of-M — NO (전체 cluster 이동)
4. [ ] catch-all `_ ->` 추가 — NO
5. [ ] cap/cooldown/dedup/repair — NO
6. [ ] test backdoor — NO
7. [ ] N-사이트 typo — NO

PASS — pure refactor.

## RFC

RFC-WAIVED: `lib/server` non-credential refactor.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
