### PR TITLE
refactor(rfc-0145): PR-3 extract thinking-block trajectory persistence

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -206,6 +206,7 @@
   keeper_agent_prompt_metrics
   keeper_agent_tool_surface
   keeper_agent_run_contract_helpers
+  keeper_agent_run_thinking_persist
   keeper_agent_result
   keeper_agent_error
   keeper_agent_memory_episode

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -793,69 +793,10 @@ let run_turn
            Trajectory.increment_turn is never called here — the keeper
            uses OAS Agent.run which manages its own internal call count.
            Consumers should treat turn=0 as "turn not tracked in keeper path". *)
-                 (match trajectory_acc with
-                  | Some acc ->
-                    let now = Time_compat.now () in
-                    let now_iso = Masc_domain.now_iso () in
-                    List.iter
-                      (function
-                        | Agent_sdk.Types.Thinking { content; _ } ->
-                          let entry : Trajectory.thinking_entry =
-                            { ts = now
-                            ; ts_iso = now_iso
-                            ; turn = acc.Trajectory.turn
-                            ; content
-                            ; content_length = String.length content
-                            ; redacted = false
-                            }
-                          in
-                          (try
-                             Trajectory.append_thinking
-                               ~masc_root:acc.Trajectory.masc_root
-                               ~keeper_name:acc.Trajectory.keeper_name
-                               ~trace_id:acc.Trajectory.trace_id
-                               entry
-                           with
-                           | Eio.Cancel.Cancelled _ as e -> raise e
-                           | exn ->
-                             Log.Keeper.error
-                               "keeper:%s thinking persist failed: %s"
-                               meta.name
-                               (Printexc.to_string exn);
-                             Prometheus.inc_counter
-                               Keeper_metrics.metric_keeper_thinking_persist_failures
-                               ~labels:[ "keeper", meta.name ]
-                               ())
-                        | Agent_sdk.Types.RedactedThinking _ ->
-                          let entry : Trajectory.thinking_entry =
-                            { ts = now
-                            ; ts_iso = now_iso
-                            ; turn = acc.Trajectory.turn
-                            ; content = "[redacted]"
-                            ; content_length = 0
-                            ; redacted = true
-                            }
-                          in
-                          (try
-                             Trajectory.append_thinking
-                               ~masc_root:acc.Trajectory.masc_root
-                               ~keeper_name:acc.Trajectory.keeper_name
-                               ~trace_id:acc.Trajectory.trace_id
-                               entry
-                           with
-                           | Eio.Cancel.Cancelled _ as e -> raise e
-                           | exn ->
-                             Log.Keeper.error
-                               "keeper:%s redacted thinking persist failed: %s"
-                               meta.name
-                               (Printexc.to_string exn);
-                             Prometheus.inc_counter
-                               Keeper_metrics.metric_keeper_thinking_persist_failures
-                               ~labels:[ "keeper", meta.name ]
-                               ())
-                        | _ -> ())
-                      result.response.content
-                  | None -> ());
+                 Keeper_agent_run_thinking_persist.persist
+                   ~trajectory_acc
+                   ~content:result.response.content
+                   ~keeper_name:meta.name;
                  let reported_tool_names =
                    List.filter_map
                      (function

--- a/lib/keeper/keeper_agent_run_thinking_persist.ml
+++ b/lib/keeper/keeper_agent_run_thinking_persist.ml
@@ -1,0 +1,65 @@
+let persist ~trajectory_acc ~content ~keeper_name =
+  match trajectory_acc with
+  | None -> ()
+  | Some acc ->
+    let now = Time_compat.now () in
+    let now_iso = Masc_domain.now_iso () in
+    List.iter
+      (function
+        | Agent_sdk.Types.Thinking { content; _ } ->
+          let entry : Trajectory.thinking_entry =
+            { ts = now
+            ; ts_iso = now_iso
+            ; turn = acc.Trajectory.turn
+            ; content
+            ; content_length = String.length content
+            ; redacted = false
+            }
+          in
+          (try
+             Trajectory.append_thinking
+               ~masc_root:acc.Trajectory.masc_root
+               ~keeper_name:acc.Trajectory.keeper_name
+               ~trace_id:acc.Trajectory.trace_id
+               entry
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn ->
+             Log.Keeper.error
+               "keeper:%s thinking persist failed: %s"
+               keeper_name
+               (Printexc.to_string exn);
+             Prometheus.inc_counter
+               Keeper_metrics.metric_keeper_thinking_persist_failures
+               ~labels:[ "keeper", keeper_name ]
+               ())
+        | Agent_sdk.Types.RedactedThinking _ ->
+          let entry : Trajectory.thinking_entry =
+            { ts = now
+            ; ts_iso = now_iso
+            ; turn = acc.Trajectory.turn
+            ; content = "[redacted]"
+            ; content_length = 0
+            ; redacted = true
+            }
+          in
+          (try
+             Trajectory.append_thinking
+               ~masc_root:acc.Trajectory.masc_root
+               ~keeper_name:acc.Trajectory.keeper_name
+               ~trace_id:acc.Trajectory.trace_id
+               entry
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn ->
+             Log.Keeper.error
+               "keeper:%s redacted thinking persist failed: %s"
+               keeper_name
+               (Printexc.to_string exn);
+             Prometheus.inc_counter
+               Keeper_metrics.metric_keeper_thinking_persist_failures
+               ~labels:[ "keeper", keeper_name ]
+               ())
+        | _ -> ())
+      content
+;;

--- a/lib/keeper/keeper_agent_run_thinking_persist.mli
+++ b/lib/keeper/keeper_agent_run_thinking_persist.mli
@@ -1,0 +1,19 @@
+(** RFC-0145 PR-3: extract thinking-block extraction & trajectory
+    persistence from [keeper_agent_run.run_turn] Step 8 body
+    (L791-L858).
+
+    Iterates over the model response content; for each
+    [Agent_sdk.Types.Thinking { content; _ }] / [RedactedThinking _]
+    item, builds a [Trajectory.thinking_entry] and appends to the
+    JSONL via {!Trajectory.append_thinking}.
+
+    Side effects only.  [Eio.Cancel.Cancelled] is re-raised; other
+    exceptions log an error and increment
+    [Keeper_metrics.metric_keeper_thinking_persist_failures].
+
+    No-op when [trajectory_acc = None]. *)
+val persist
+  :  trajectory_acc:Trajectory.accumulator option
+  -> content:Agent_sdk.Types.content list
+  -> keeper_name:string
+  -> unit


### PR DESCRIPTION
## 요약

RFC-0145 PR-3 — `keeper_agent_run.run_turn` Step 8 body 의 thinking-block trajectory persistence 블록 (L791-L858) 을 sibling typed module 로 추출.

## 변경

| 파일 | LoC |
|------|-----|
| `lib/keeper/keeper_agent_run.ml` | **-59** |
| `lib/keeper/keeper_agent_run_thinking_persist.{ml,mli}` | +84 (65 ml + 19 mli) |
| `lib/dune` | +1 |

## 측정

- `keeper_agent_run.ml`: 2103 → **2044 (-2.8%)**
- 추정 -62, 실측 -59 (오차 +3, 정확도 95%)
- **PR-1 (#16866) + PR-3 합쳐 = -95 LoC** (2103 → 2008, -4.5%)

## 패턴 (RFC-0136 PR-4-c 학습)

- side-effect wrapper, no return
- 3-args 시그니처 (`trajectory_acc:_ option` + `content` + `keeper_name`)
- `Cancelled re-raise` + `exn -> error log + counter`
- Thinking + RedactedThinking dual-path 보존 (`content_length` + `redacted=true/false`)
- `_ -> ()` catch-all on `Agent_sdk.Types.content` preserved

## 보존 invariant

- `trajectory_acc = None` no-op preserved
- Thinking: actual content + content_length + redacted=false
- RedactedThinking: "[redacted]" + content_length=0 + redacted=true
- `Cancelled re-raise` → outer cleanup observes
- `metric_keeper_thinking_persist_failures` counter labels 동일

## Stacked-after

PR-1 (#16866, Draft) — 독립 영역 L791 vs L565, no merge conflict.

## Anti-pattern 가드

- ✅ workaround 없음 (typed wrapper)
- ✅ telemetry-as-fix 아님
- ✅ string classifier 없음
- ✅ N-of-M 없음 (단일 추출 boundary)

## RFC

`docs/rfc/RFC-0145-keeper-agent-run-decomposition.md`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
