### PR TITLE
fix(voice): operator-actionable error messages — URL, Sys_error payload, WSIGNALED/WSTOPPED

### DIFF
--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -276,16 +276,20 @@ let rec retry_with_backoff ~clock ~attempt ~max_attempts ~backoff_sec operation 
 
 (** Make a single HTTP POST request to the Voice MCP server. *)
 let single_voice_mcp_call ~net:_ ~uri ~headers_list ~body_str =
+  let url_str = Uri.to_string uri in
   match
-    Masc_http_client.post_sync ~url:(Uri.to_string uri)
-      ~headers:headers_list ~body:body_str ()
+    Masc_http_client.post_sync ~url:url_str ~headers:headers_list ~body:body_str ()
   with
   | Ok (code, body) when code >= 200 && code < 300 ->
     (try Ok (Yojson.Safe.from_string body) with
      | Yojson.Json_error msg ->
-       Error (Printf.sprintf "Voice MCP: invalid JSON body: %s" msg))
+       Error
+         (Printf.sprintf
+            "Voice MCP: invalid JSON body from %s: %s"
+            url_str
+            msg))
   | Ok (code, body) ->
-    Error (Printf.sprintf "HTTP %d: %s" code body)
+    Error (Printf.sprintf "Voice MCP HTTP %d from %s: %s" code url_str body)
   | Error e ->
     (* RFC-0106: re-raise Eio.Cancel.Cancelled when the surrounding fiber
        was cancelled. Masc_http_client.post_sync delegates to a piaf pool
@@ -294,7 +298,8 @@ let single_voice_mcp_call ~net:_ ~uri ~headers_list ~body_str =
        loop in [call_voice_mcp_endpoint] would sleep and re-attempt
        instead of unwinding cancellation immediately. *)
     Eio.Fiber.check ();
-    Error (Printf.sprintf "Connection error: %s" e)
+    Error
+      (Printf.sprintf "Voice MCP connection error (POST %s): %s" url_str e)
 ;;
 
 (** Extract result from MCP response *)

--- a/lib/voice/voice_bridge_transport.ml
+++ b/lib/voice/voice_bridge_transport.ml
@@ -104,23 +104,37 @@ let run_audio_http_request_to_file ~url ~headers ~body_json ~output_file =
            else (
              let detail =
                try read_file output_file with
-               | Sys_error _ -> "response too small"
+               | Sys_error msg ->
+                 Printf.sprintf "<could not read response body: %s>" msg
              in
              Error
                (Printf.sprintf
-                  "HTTP %d returned small audio payload (%d bytes): %s"
+                  "HTTP %d returned small audio payload (%d bytes) from %s: %s"
                   http_code
                   file_size
+                  url
                   detail)))
          else (
            let detail =
              try read_file output_file with
-             | Sys_error _ -> "request failed"
+             | Sys_error msg ->
+               Printf.sprintf "<could not read response body: %s>" msg
            in
-           Error (Printf.sprintf "HTTP %d: %s" http_code detail))
-       | Unix.WEXITED 28 -> Error "request timed out"
-       | Unix.WEXITED code -> Error (Printf.sprintf "curl exit %d" code)
-       | _ -> Error "curl process failed")
+           Error (Printf.sprintf "HTTP %d from %s: %s" http_code url detail))
+       | Unix.WEXITED 28 ->
+         Error
+           (Printf.sprintf
+              "request timed out (POST %s, %.0fs limit)"
+              url
+              Env_config_runtime.Voice.http_request_timeout_sec)
+       | Unix.WEXITED code ->
+         Error (Printf.sprintf "curl exit %d (POST %s)" code url)
+       | Unix.WSIGNALED signal ->
+         Error
+           (Printf.sprintf "curl killed by signal %d (POST %s)" signal url)
+       | Unix.WSTOPPED signal ->
+         Error
+           (Printf.sprintf "curl stopped by signal %d (POST %s)" signal url))
 ;;
 
 let speak_via_http_tts_to_file endpoint ~agent_id ~message ~voice ~model ~output_file =
@@ -169,15 +183,31 @@ let run_stt_multipart_request (req : Voice_runtime_overlay.stt_request) =
     (match Yojson.Safe.from_string body with
      | json -> Ok json
      | exception Yojson.Json_error msg ->
-       Error (Printf.sprintf "STT response parse error: %s" msg))
+       Error
+         (Printf.sprintf
+            "STT response parse error from %s: %s"
+            req.url
+            msg))
   | Unix.WEXITED 22 ->
     Error
       (Printf.sprintf
-         "STT HTTP error: %s"
+         "STT HTTP error from %s: %s"
+         req.url
          (if String.length body > 200 then String.sub body 0 200 else body))
-  | Unix.WEXITED 28 -> Error "STT request timed out"
-  | Unix.WEXITED code -> Error (Printf.sprintf "STT curl exit %d" code)
-  | _ -> Error "STT curl process failed"
+  | Unix.WEXITED 28 ->
+    Error
+      (Printf.sprintf
+         "STT request timed out (POST %s, %.0fs limit)"
+         req.url
+         Env_config_runtime.Voice.http_request_timeout_sec)
+  | Unix.WEXITED code ->
+    Error (Printf.sprintf "STT curl exit %d (POST %s)" code req.url)
+  | Unix.WSIGNALED signal ->
+    Error
+      (Printf.sprintf "STT curl killed by signal %d (POST %s)" signal req.url)
+  | Unix.WSTOPPED signal ->
+    Error
+      (Printf.sprintf "STT curl stopped by signal %d (POST %s)" signal req.url)
 ;;
 
 let transcribe_via_http_stt endpoint ~audio_file ~model =


### PR DESCRIPTION
## Summary

Continues operator-clarity sweep (#16787 → #16824 → #16825 → #16835 → #16850 → #16856). Strengthens **10 error sites** in `voice/` transport + MCP call layers so operators can triage failures from logs alone.

## Changes

`lib/voice/voice_bridge_transport.ml`:
- TTS path: 2× capture Sys_error payload (was `_ -> generic string`), 4× include POST URL, timeout site adds configured limit, split opaque `_ -> "curl process failed"` into named `WSIGNALED signal` / `WSTOPPED signal` arms
- STT path: 5× same treatment using `req.url`

`lib/voice/voice_bridge.ml`:
- `single_voice_mcp_call`: bind URL once, 3× include in error messages (JSON-body, HTTP, connection). RFC-0106 `Eio.Fiber.check ()` preserved verbatim

## Before / after

```
- curl process failed
+ curl killed by signal 9 (POST https://api.elevenlabs.io/v1/.../stream)

- HTTP 500: <empty>
+ HTTP 500 from https://api.elevenlabs.io/v1/.../stream: <body>

- Connection error: Connection refused
+ Voice MCP connection error (POST http://127.0.0.1:8765/mcp): Connection refused
```

## Anti-pattern rejected: Sys_error payload discard

The 2 `Sys_error _ -> "response too small" / "request failed"` sites were classic operator-opaque patterns — `Sys_error` *carries* the actual OS error string but `_` discarded it. Structurally identical to iter#72 `lib/keeper/keeper_turn.ml` `Error \"invalid keeper name\"` (PR #16824).

## Verification

- `dune build --root . lib/voice/` clean (0 warn, 0 err)
- `dune build --root . @check` blocked by pre-existing `dashboard_eval_feed.ml:127 — Unbound module Eio` — verified via `git stash` round-trip that this reproduces on `origin/main` unmodified
- 0 voice tests exist → no regression possible from message string changes

## Workaround Rejection Bar self-check

All 7 items clear. Specifically:
- Not telemetry-as-fix (this *is* the error path, not instrumentation)
- No string classifier added
- All 10 sites in single PR (no N-of-M)
- Catch-all `_ ->` *removed* (replaced with named WSIGNALED/WSTOPPED)
- No cap/cooldown/dedup/repair

## Test plan
- [x] dune build voice modules clean
- [x] pre-existing @check failure verified via git stash
- [ ] CI run after push
- [ ] Operator log review on next real voice failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)