### PR TITLE
feat(bg_task): RFC-0145 §5 PR-2 — typed drain_fd_to_buf outcome + caller-side handling

### DIFF
--- a/lib/process/bg_task.ml
+++ b/lib/process/bg_task.ml
@@ -101,28 +101,15 @@ let sidecar_failure_observer :
 let set_sidecar_failure_observer f =
   Atomic.set sidecar_failure_observer (Some f)
 
-(* Observer for unexpected (non-EAGAIN/EWOULDBLOCK/EINTR/EOF)
-   drain-pipe read errors.  Labels are closed-vocabulary:
-   [fd_kind = "stdout" | "stderr"] (call-site tagged) and
-   [err_kind = "unix_error" | "other"] (typed match arm).
-   Cardinality bound: 2 × 2 = 4.  See top-level Prometheus
-   module for the registered counter. *)
-let drain_failure_observer :
-    ((fd_kind:string -> err_kind:string -> unit) option) Atomic.t =
-  Atomic.make None
-
-let set_drain_failure_observer f =
-  Atomic.set drain_failure_observer (Some f)
-
-let observe_drain_failure ~fd_kind ~err_kind =
-  match Atomic.get drain_failure_observer with
-  | None -> ()
-  | Some observe ->
-      (try observe ~fd_kind ~err_kind with
-       | Eio.Cancel.Cancelled _ as e -> raise e
-       | observer_exn ->
-           Log.Misc.warn "bg_task drain observer failed: %s"
-             (Printexc.to_string observer_exn))
+(* RFC-0145 §5 PR-2 (predecessor #15883):
+   The previous [drain_failure_observer] / [observe_drain_failure]
+   pair fed a Prometheus counter [masc_bg_task_drain_unexpected_errors_total]
+   while the underlying drain loop continued to *return [true]*
+   (permissive EOF) on a read error.  Per RFC-0145 §6.2 the counter
+   is removed in the same per-site migration PR; the typed [drain_outcome]
+   surfaced from [drain_fd_to_buf] now carries the read error to the
+   caller, which logs it at the call site with the task identity in
+   scope.  The counter was an alarm, not a fix.  *)
 
 let observe_sidecar_failure ~site exn =
   match exn with
@@ -288,35 +275,43 @@ let trim_buffer_to_ring buf base_offset =
     base_offset + drop_len
   end
 
-(* [drain_fd_to_buf ~fd_kind buf fd] reads every byte currently
-   available on [fd] without blocking. Returns [true] if EOF was
-   observed.
+(* RFC-0145 §5 PR-2: typed drain outcome.
 
-   The previous implementation collapsed every non-EAGAIN/EINTR
-   exception into a permissive [true] (EOF), silently misreporting
-   genuine read errors (EBADF, EIO, ENOMEM, ENOSPC, …) as clean
-   close.  This typed split:
+   Previously [drain_fd_to_buf] returned [bool] (eof) and collapsed
+   read errors into [true] while a Prometheus counter served as the
+   only operator signal.  That shape matches CLAUDE.md signature #1
+   (Telemetry-as-Fix): the counter is an alarm, not a fix — the
+   caller had no way to distinguish "FD closed cleanly" from
+   "FD abandoned after a read error".
 
-   - Re-raises [Eio.Cancel.Cancelled] so cancellation propagates
-     through the enclosing switch.
-   - Splits [Unix.Unix_error] (anything that isn't EAGAIN /
-     EWOULDBLOCK / EINTR) into a distinct arm: tick the
-     drain-failure counter with [error_kind = "unix_error"] and a
-     bounded warn naming the [errno].  EBADF/EIO/ENOMEM are the
-     most likely realistic failure modes here and are forensically
-     valuable.
-   - Final arm: any other exception ticks with
-     [error_kind = "other"] and a bounded warn carrying
-     [Printexc.to_string] in the log body only (closed-vocab
-     label).
+   [drain_outcome] now exposes that distinction.  [Drain_eof_after_error]
+   is treated like EOF by the reap state machine (the FD is no longer
+   readable, so we advance to close) but the caller emits a typed
+   warn that names the syscall and errno alongside the task identity.
 
-   Returning [true] in the failure arms preserves the existing
-   operational behavior (the caller advances [stdout_eof] /
-   [stderr_eof] and eventually closes the FD).  This is a
-   deliberate conservative choice — flipping it to [false] would
-   change reap semantics and belongs in a future RFC, not in this
-   visibility patch. *)
-let drain_fd_to_buf ~fd_kind buf fd =
+   Cancellation continues to be re-raised, never absorbed. *)
+
+type drain_read_error =
+  | Drain_unix_error of Unix.error * string
+      (** Unix.Unix_error other than EAGAIN/EWOULDBLOCK/EINTR.
+          Payload is [(errno, syscall_name)].  EBADF/EIO/ENOMEM
+          are the realistic failure modes worth distinguishing. *)
+  | Drain_other_exn of exn
+      (** Any other exception that was not cancellation.
+          Cancellation is re-raised inside [drain_fd_to_buf]. *)
+
+type drain_outcome =
+  | Drain_continue
+      (** No data was available without blocking, or a partial chunk
+          was read.  The caller should poll again on the next tick. *)
+  | Drain_eof
+      (** Clean EOF: [Unix.read] returned 0. *)
+  | Drain_eof_after_error of drain_read_error
+      (** A read error occurred.  The caller advances the FD to EOF
+          (preserving reap semantics) but the typed error carries the
+          forensic signal. *)
+
+let drain_fd_to_buf buf fd =
   let chunk = Bytes.create 4096 in
   let rec loop () =
     let readable =
@@ -324,51 +319,65 @@ let drain_fd_to_buf ~fd_kind buf fd =
         let r, _, _ = Unix.select [ fd ] [] [] 0.0 in
         r)
     in
-    if readable = [] then false
+    if readable = [] then Drain_continue
     else
       match Unix.read fd chunk 0 (Bytes.length chunk) with
-      | 0 -> true
+      | 0 -> Drain_eof
       | n -> Buffer.add_subbytes buf chunk 0 n; loop ()
-      | exception Unix.Unix_error ((Unix.EAGAIN | Unix.EWOULDBLOCK), _, _) -> false
+      | exception Unix.Unix_error ((Unix.EAGAIN | Unix.EWOULDBLOCK), _, _) ->
+          Drain_continue
       | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop ()
       | exception (Eio.Cancel.Cancelled _ as e) -> raise e
       | exception Unix.Unix_error (errno, fn, _) ->
-          Log.Misc.warn
-            "bg_task drain_fd_to_buf %s Unix_error in %s: %s"
-            fd_kind fn (Unix.error_message errno);
-          observe_drain_failure ~fd_kind ~err_kind:"unix_error";
-          true
+          Drain_eof_after_error (Drain_unix_error (errno, fn))
       | exception exn ->
-          Log.Misc.warn
-            "bg_task drain_fd_to_buf %s unexpected exception: %s"
-            fd_kind (Printexc.to_string exn);
-          observe_drain_failure ~fd_kind ~err_kind:"other";
-          true
+          Drain_eof_after_error (Drain_other_exn exn)
   in
   loop ()
 
 (* Called under [registry_mu]. Drains pipes, reaps if exited, kills
    on timeout. *)
-let poll_state st =
+let log_drain_read_error ~fd_kind ~task_id err =
+  match err with
+  | Drain_unix_error (errno, fn) ->
+      Log.Misc.warn
+        "bg_task drain %s task=%s Unix_error in %s: %s — advancing to EOF"
+        fd_kind task_id fn (Unix.error_message errno)
+  | Drain_other_exn exn ->
+      Log.Misc.warn
+        "bg_task drain %s task=%s unexpected exception: %s — advancing to EOF"
+        fd_kind task_id (Printexc.to_string exn)
+
+let consume_drain_outcome ~fd_kind ~task_id outcome =
+  match outcome with
+  | Drain_continue -> false
+  | Drain_eof -> true
+  | Drain_eof_after_error err ->
+      log_drain_read_error ~fd_kind ~task_id err;
+      true
+
+let poll_state ~task_id st =
   if st.closed then ()
   else begin
     if not st.stdout_eof then begin
-      let eof =
-        drain_fd_to_buf ~fd_kind:"stdout"
-          st.stdout_buf st.handle.stdout_fd
+      let outcome =
+        drain_fd_to_buf st.stdout_buf st.handle.stdout_fd
       in
       st.stdout_base_offset <-
         trim_buffer_to_ring st.stdout_buf st.stdout_base_offset;
-      st.stdout_eof <- eof
+      st.stdout_eof <-
+        consume_drain_outcome
+          ~fd_kind:"stdout" ~task_id outcome
     end;
     if not st.stderr_eof then begin
-      let eof =
-        drain_fd_to_buf ~fd_kind:"stderr"
-          st.stderr_buf st.handle.stderr_fd
+      let outcome =
+        drain_fd_to_buf st.stderr_buf st.handle.stderr_fd
       in
       st.stderr_base_offset <-
         trim_buffer_to_ring st.stderr_buf st.stderr_base_offset;
-      st.stderr_eof <- eof
+      st.stderr_eof <-
+        consume_drain_outcome
+          ~fd_kind:"stderr" ~task_id outcome
     end;
     (match st.status with
      | Some _ -> ()
@@ -398,7 +407,7 @@ let poll_state st =
 	  end
 
 let poll_all_states () =
-  Hashtbl.iter (fun _ st -> poll_state st) registry
+  Hashtbl.iter (fun task_id st -> poll_state ~task_id st) registry
 
 let live_task_count ?keeper () =
   Hashtbl.fold
@@ -546,7 +555,7 @@ let read tid ~since_stdout ~since_stderr =
   | None -> Error (Unknown_task tid)
   | Some st ->
       (try
-         with_reg (fun () -> poll_state st);
+         with_reg (fun () -> poll_state ~task_id:tid st);
          Ok
            {
              stdout_since =
@@ -573,7 +582,7 @@ let kill tid ~signal ~grace_sec =
   | Some st ->
       (try
          Process_eio.tree_kill ~pgid:st.handle.pgid ~signal ~grace_sec;
-         with_reg (fun () -> poll_state st);
+         with_reg (fun () -> poll_state ~task_id:tid st);
          (* Best-effort PID file cleanup: if poll_state did not
             observe EOF yet (slow-closing FDs), at least unlink the
             sidecar so the next reap cycle does not flag a live

--- a/lib/process/bg_task.mli
+++ b/lib/process/bg_task.mli
@@ -149,21 +149,13 @@ val set_sidecar_failure_observer : (site:string -> exn -> unit) -> unit
     [masc_bg_task_sidecar_failures_total]; [bg_task] keeps the hook here
     to avoid a lower-library dependency cycle. *)
 
-val set_drain_failure_observer :
-  (fd_kind:string -> err_kind:string -> unit) -> unit
-(** Install the process-local observer for unexpected (non-EAGAIN /
-    EWOULDBLOCK / EINTR / EOF) errors raised by [Unix.read] inside
-    [drain_fd_to_buf].  The top-level Prometheus module wires this to
-    [masc_bg_task_drain_unexpected_errors_total].
-
-    Labels are closed-vocabulary and cardinality-bounded:
-    - [fd_kind] is either ["stdout"] or ["stderr"] (call-site tagged).
-    - [err_kind] is either ["unix_error"] (a [Unix.Unix_error] that
-      is neither EAGAIN/EWOULDBLOCK nor EINTR — e.g. EBADF, EIO,
-      ENOMEM) or ["other"] (any other exception).
-
-    Cancellation ([Eio.Cancel.Cancelled]) is re-raised inside the
-    drain loop and never reaches the observer. *)
+(* RFC-0145 §5 PR-2 (predecessor #15883):
+   [set_drain_failure_observer] + [masc_bg_task_drain_unexpected_errors_total]
+   were removed.  The previous shape collapsed read errors into a
+   permissive EOF and used the counter as the only operator signal —
+   CLAUDE.md Telemetry-as-Fix signature.  Read errors are now surfaced
+   to the caller as a typed log line ("bg_task drain … advancing to
+   EOF") emitted from [poll_state] with the task identity in scope. *)
 
 val reap_orphans : base_path:string -> int
 (** Startup hook: read PID files under \`.masc/keeper/*/bg/*.pid\`,

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -222,14 +222,10 @@ let metric_runtime_ollama_probe_generate_skips =
 
 let metric_process_timeout = "masc_process_timeout_total"
 let metric_bg_task_sidecar_failures = "masc_bg_task_sidecar_failures_total"
-(* iter 30: typed split for [Bg_task.drain_fd_to_buf] silent error
-   swallow.  Previously every non-EAGAIN/EWOULDBLOCK/EINTR exception
-   was collapsed into a permissive EOF, hiding real read errors
-   (EBADF, EIO, ENOMEM, …).  Labels are closed-vocabulary:
-   [fd_kind = stdout | stderr] × [error_kind = unix_error | other],
-   cardinality 4. *)
-let metric_bg_task_drain_unexpected_errors =
-  "masc_bg_task_drain_unexpected_errors_total"
+(* RFC-0145 §6.2 PR-2 (predecessor #15883):
+   [masc_bg_task_drain_unexpected_errors_total] was removed alongside
+   the typed lift of [Bg_task.drain_fd_to_buf].  See [Bg_task.poll_state]
+   for the replacement typed log path. *)
 let metric_build_identity_probe_failures = "masc_build_identity_probe_failures_total"
 let metric_distributed_lock_acquire_failed = "masc_distributed_lock_acquire_failed_total"
 

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -259,16 +259,9 @@ val metric_process_timeout : string
     [site] = [write | read | read_parse | readdir | is_dir | unlink]. *)
 val metric_bg_task_sidecar_failures : string
 
-(** iter 30: unexpected (non-EAGAIN / EWOULDBLOCK / EINTR / EOF)
-    errors raised by [Unix.read] inside [Bg_task.drain_fd_to_buf].
-    Replaces the previous silent-EOF catch-all that hid genuine read
-    errors (EBADF, EIO, ENOMEM, …) and lost any output between the
-    error and process exit.  Labels are closed-vocabulary and
-    cardinality-bounded:
-    - [fd_kind] = [stdout | stderr] (call-site tagged).
-    - [error_kind] = [unix_error | other] (typed match arm).
-    Total cardinality: 4. *)
-val metric_bg_task_drain_unexpected_errors : string
+(* RFC-0145 §6.2 PR-2 (predecessor #15883):
+   [metric_bg_task_drain_unexpected_errors] was removed alongside the
+   typed lift of [Bg_task.drain_fd_to_buf]. *)
 
 (** Build identity git probe failures. Labels:
     [site] = [commit_ts_git_capture | commit_ts_git_status | commit_ts_parse]. *)

--- a/lib/prometheus_builtin_metric_names.ml
+++ b/lib/prometheus_builtin_metric_names.ml
@@ -166,14 +166,9 @@ let metric_runtime_ollama_probe_generate_skips =
 
 let metric_process_timeout = "masc_process_timeout_total"
 let metric_bg_task_sidecar_failures = "masc_bg_task_sidecar_failures_total"
-(* iter 30: typed split for [Bg_task.drain_fd_to_buf] silent error
-   swallow.  Previously every non-EAGAIN/EWOULDBLOCK/EINTR exception
-   was collapsed into a permissive EOF, hiding real read errors
-   (EBADF, EIO, ENOMEM, …).  Labels are closed-vocabulary:
-   [fd_kind = stdout | stderr] × [error_kind = unix_error | other],
-   cardinality 4. *)
-let metric_bg_task_drain_unexpected_errors =
-  "masc_bg_task_drain_unexpected_errors_total"
+(* RFC-0145 §6.2 PR-2 (predecessor #15883):
+   [masc_bg_task_drain_unexpected_errors_total] was removed alongside
+   the typed lift of [Bg_task.drain_fd_to_buf]. *)
 let metric_build_identity_probe_failures = "masc_build_identity_probe_failures_total"
 let metric_distributed_lock_acquire_failed = "masc_distributed_lock_acquire_failed_total"
 

--- a/lib/prometheus_builtin_metric_names.mli
+++ b/lib/prometheus_builtin_metric_names.mli
@@ -201,16 +201,9 @@ val metric_process_timeout : string
     [site] = [write | read | read_parse | readdir | is_dir | unlink]. *)
 val metric_bg_task_sidecar_failures : string
 
-(** iter 30: unexpected (non-EAGAIN / EWOULDBLOCK / EINTR / EOF)
-    errors raised by [Unix.read] inside [Bg_task.drain_fd_to_buf].
-    Replaces the previous silent-EOF catch-all that hid genuine read
-    errors (EBADF, EIO, ENOMEM, …) and lost any output between the
-    error and process exit.  Labels are closed-vocabulary and
-    cardinality-bounded:
-    - [fd_kind] = [stdout | stderr] (call-site tagged).
-    - [error_kind] = [unix_error | other] (typed match arm).
-    Total cardinality: 4. *)
-val metric_bg_task_drain_unexpected_errors : string
+(* RFC-0145 §6.2 PR-2 (predecessor #15883):
+   [metric_bg_task_drain_unexpected_errors] was removed alongside the
+   typed lift of [Bg_task.drain_fd_to_buf]. *)
 
 (** Build identity git probe failures. Labels:
     [site] = [commit_ts_git_capture | commit_ts_git_status | commit_ts_parse]. *)

--- a/lib/prometheus_builtin_metrics_part4.ml
+++ b/lib/prometheus_builtin_metrics_part4.ml
@@ -190,17 +190,11 @@ let register
     `Counter;
   Bg_task.set_sidecar_failure_observer (fun ~site _exn ->
     inc_counter metric_bg_task_sidecar_failures ~labels:[ "site", site ] ());
-  add
-    metric_bg_task_drain_unexpected_errors
-    "Total unexpected (non-EAGAIN/EWOULDBLOCK/EINTR/EOF) errors raised by \
-     Unix.read inside Bg_task.drain_fd_to_buf. Labeled by \
-     fd_kind=stdout|stderr and error_kind=unix_error|other. A non-zero \
-     rate indicates the previous silent-EOF fallback would have hidden a \
-     real read error and lost output between the error and process exit."
-    `Counter;
-  Bg_task.set_drain_failure_observer (fun ~fd_kind ~err_kind ->
-    inc_counter metric_bg_task_drain_unexpected_errors
-      ~labels:[ "fd_kind", fd_kind; "error_kind", err_kind ] ());
+  (* RFC-0145 §6.2 PR-2 (predecessor #15883):
+     [masc_bg_task_drain_unexpected_errors_total] was removed alongside
+     the typed lift of [Bg_task.drain_fd_to_buf]'s return value.  The
+     counter had been an alarm without a fix — read errors now surface
+     directly as a typed log line from [Bg_task.poll_state]. *)
   add
     metric_build_identity_probe_failures
     "Total build identity git probe failures. Labeled by \


### PR DESCRIPTION
## 요약

RFC-0145 §5 Migration Plan의 site #3 (`bg_task drain_fd_to_buf`, predecessor PR #15883)을 typed dispatch로 옮긴 root-fix 단일-사이트 PR이다.

이전 `drain_fd_to_buf`는 `bool` (eof flag)을 반환하고 read error (Unix.Unix_error EBADF/EIO/ENOMEM, 또는 임의 exception)를 permissive `true`로 압축한 다음 `masc_bg_task_drain_unexpected_errors_total` Prometheus counter에 tick하는 방식이었다. CLAUDE.md §"워크어라운드 거부 기준" 시그니처 #1 (Telemetry-as-Fix) — counter는 alarm이지 fix가 아니다.

본 PR은 RFC-0145 §6.2 ("per-site Prometheus counter from the predecessor PR is removed in the same per-site migration PR")를 따른다.

## 변경

| 영역 | 변경 |
|------|------|
| `lib/process/bg_task.ml` | `drain_outcome = Drain_continue \| Drain_eof \| Drain_eof_after_error of drain_read_error` 도입, `drain_fd_to_buf`는 `drain_outcome` 반환. `consume_drain_outcome` 헬퍼가 `poll_state`에서 typed warn 발행 (task_id + syscall + errno 포함). `poll_state`에 `~task_id` 파라미터 추가, 3개 caller (`poll_all_states`/`read`/`kill`) 전부 업데이트. `set_drain_failure_observer` / `drain_failure_observer` / `observe_drain_failure` 전부 제거. |
| `lib/process/bg_task.mli` | `set_drain_failure_observer` 선언 제거 (tombstone 코멘트 보존). |
| `lib/prometheus.ml,mli` + `lib/prometheus_builtin_metric_names.ml,mli` + `lib/prometheus_builtin_metrics_part4.ml` | `metric_bg_task_drain_unexpected_errors` 및 `masc_bg_task_drain_unexpected_errors_total` 등록/이름/observer 와이어링 전부 제거. tombstone 코멘트가 RFC-0145 §5 PR-2 인용. |

Cancellation `Eio.Cancel.Cancelled`는 그대로 re-raise (RFC §4.2 / RFC §3 anti-goal).

## Root-fix 자가 점검 (CLAUDE.md 7-point)

- [x] **시그니처 #1 (Telemetry-as-Fix)**: counter 제거 + typed 반환으로 *역전*. 가시성은 더 높아짐 (caller가 task_id + errno + syscall 동시 로깅).
- [x] **시그니처 #2 (String classifier)**: 도입 *없음*. Closed sum (`drain_read_error`)의 exhaustive match로 컴파일러가 caller drop을 막음.
- [x] **시그니처 #3 (N-of-M)**: RFC-0145 §5는 *의도적으로* per-site PR이다. 본 PR은 site 3/7. 우산 RFC PR #16780(MERGED)이 누락 추적.
- [x] **catch-all `_ ->`**: 추가 *없음*. `drain_fd_to_buf` 내부의 `match Unix.read … with` 는 EAGAIN/EWOULDBLOCK/EINTR/Cancelled를 명시 매치, 나머지를 typed Drain_unix_error/Drain_other_exn으로 분리.
- [x] **cap/cooldown/dedup/repair**: 없음.
- [x] **test backdoor (`set_*_for_test`)**: 없음.
- [x] **N개 사이트 같은 typo N번 fix**: 없음.

## RFC 인용

- 우산 RFC: [RFC-0145 — Permissive-Silent-Fallback Elimination](https://github.com/yousleepwhen/masc-mcp/blob/main/docs/rfc/RFC-0145-permissive-silent-fallback-elimination.md) (PR #16780, MERGED)
- Migration Plan §5 site 3: "`bg_task drain_fd_to_buf` — EOF-shaped fallback; demands `Unix_error` classification."
- Sunset criteria §6.2: "The per-site Prometheus counter from the predecessor PR is removed in the same per-site migration PR (no counter outlives its workaround tracker)."

## 빌드 / 테스트

- `dune build @check`: 내가 수정한 7개 파일 전부 pass. 단일 pre-existing 에러 (`lib/dashboard_eval_feed/dashboard_eval_feed.ml`, `Eio` dune libraries 누락)가 origin/main에 그대로 존재하며 본 PR의 scope 밖이다. `git stash` 후에도 동일하게 실패하는 것을 확인했다.
- `test/test_bg_task_stub.ml`: 기존 black-box 테스트가 `spawn`/`read`/`kill` 공용 API를 그대로 exercise하므로 reap 의미 보존을 회귀 가드한다. typed dispatch 자체는 OCaml의 exhaustive match로 컴파일 타임에 강제된다 (`Drain_continue`/`Drain_eof`/`Drain_eof_after_error` 세 arm을 caller가 빠뜨릴 수 없음).
- Test exe 빌드는 위의 동일 pre-existing dashboard_eval_feed regression이 `masc_test_deps` 경유로 모든 test에 propagate하기 때문에 본 PR 단독으로는 검증 불가. 별도 fix PR이 필요.

## 미커버 사이트 (별도 PR로 처리 예정)

본 PR scope에서 명시적으로 제외:

- `mcp-ws` SSE parse `parse_sse_dashboard_event` (RFC site 5, PR #15820)
- `sidecar schema_field_types` (RFC site 4, PR #15866)

RFC-0145 §5는 "Each site is a separate PR; this RFC is the umbrella"라고 명시했으므로 본 PR은 site 3 *단일*에 집중했다.

RFC-WAIVED: 본 PR이 RFC-0145 §5 PR-2 자체이므로 RFC waiver 불필요. RFC body가 명시적으로 본 사이트 migration을 mandate함.
