### PR TITLE
fix(dashboard_eval_feed): add missing eio + masc_log deps after #16802

### DIFF
--- a/lib/dashboard_eval_feed/dune
+++ b/lib/dashboard_eval_feed/dune
@@ -16,6 +16,8 @@
  (wrapped false)
  (flags (:standard -w +4))
  (libraries
+  eio
   yojson
   agent_sdk
-  masc_core))
+  masc_core
+  masc_log))


### PR DESCRIPTION
## Summary

**CRITICAL main-stability regression**. PR #16802 (merged 2026-05-20 11:52 today) added `Eio.Cancel.Cancelled` and `Log.Dashboard.warn` references but did not add `eio` or `masc_log` to the library's dune deps.

`dune build @check` against origin/main currently fails:

```
File "lib/dashboard_eval_feed/dashboard_eval_feed.ml", line 127, characters 4-7:
  | Eio.Cancel.Cancelled _ as e -> raise e
        ^^^
Error: Unbound module Eio
```

(After adding `eio`, the same shape of error surfaces for `Log` at line 129.)

## Fix

`lib/dashboard_eval_feed/dune` — add both missing libraries to `(libraries ...)`:

```diff
 (libraries
+  eio
   yojson
   agent_sdk
-  masc_core))
+  masc_core
+  masc_log))
```

## Why this regression matters

The `masc_mcp_dashboard_eval_feed` sub-library has been failing to build end-to-end since #16802 landed. Any worktree freshly checked out from origin/main (without cached `_build/`) hits the error immediately.

## Why CI didn't catch it

The `Build and Test` job in `.github/workflows/ci.yml` either:
1. Built at a scope that didn't include this sub-library, OR
2. Was admin-merged before the build completed (matches the documented pattern at `lib/server/ci.yml:556` comment + `feedback_admin_merge_can_bypass_build_ci`)

Verified by fresh worktree creation from `origin/main` HEAD (`83eac9c61c`) → `dune build @check` fails immediately on the first invocation.

## Verification

```bash
# Before:
$ opam exec -- dune build --root . @check 2>&1 | tail
Error: Unbound module Eio

# After:
$ opam exec -- dune build --root . @check
# exit 0 (clean)
```

## Workaround Rejection Bar self-check

- §1 telemetry-as-fix: not applicable, build-deps fix.
- §2 string classifier: none.
- §3 N-of-M: BOTH missing deps (`eio` + `masc_log`) added in this single commit — no partial fix that would leave the build broken with a different error.
- catch-all / cap / cooldown: none.

## Priority

Marking as **Ready** (not Draft) since this blocks fresh main builds and is a 3-line dune fix verified clean. Recommend admin-merge if CI takes too long.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>