### PR TITLE
docs(test): replace stale #9419 issue refs in test_ci_hardening_source TODOs

### DIFF
--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -583,7 +583,10 @@ let test_health_and_ci_runner_diagnostics () =
        "(enabled_if (= %{env:MASC_INCLUDE_OPERATOR_CONTROL=true} \"true\"))")
 
 let test_release_truth_contracts () =
-  (* TODO: uncomment when Doc Truth CI job is wired (#9419 follow-up) *)
+  (* TODO: uncomment when ci.yml emits the exact strings "name: Doc Truth"
+     and `check "doc-truth"   "$DOC_TRUTH_RESULT"`. The doc-truth scope
+     output + scripts/check-doc-truth.sh are wired but the workflow
+     names/aggregator-string assertions below are not yet stable. *)
   (* check bool "ci workflow defines doc truth job" true
     (file_contains_pattern ".github/workflows/ci.yml" "name: Doc Truth");
   check bool "ci workflow exports doc truth scope output" true
@@ -665,7 +668,10 @@ let test_release_truth_contracts () =
   check bool "main nightly uses retrying dependency installer" true
     (file_contains_pattern ".github/workflows/main-nightly-health.yml"
        "uses: ./.github/actions/install-ocaml-deps");
-  (* TODO: uncomment when ci_core fanout comment is added (#9419 follow-up) *)
+  (* TODO: uncomment when ci.yml adds the exact comment
+     "Note: tla is intentionally NOT forced on by ci_core." near the
+     ci_core fanout (the fanout itself exists; only the documentation
+     comment is missing). *)
   (* check bool "ci core fanout intentionally excludes tla" true
     (file_contains_pattern ".github/workflows/ci.yml"
        "Note: tla is intentionally NOT forced on by ci_core."); *)


### PR DESCRIPTION
## Summary

Two `(* TODO: ... #9419 follow-up *)` comments in `test/test_ci_hardening_source.ml` reference a closed-but-unrelated GitHub issue. Issue #9419 was closed 2026-04-22 with title \"dune build fails in cascade_fsm record literal\" — no connection to the Doc Truth CI job or the ci_core fanout work the TODOs describe.

## Background

The TODOs themselves describe REAL pending work that is partially landed. The Iter 4 audit verified:

| TODO | Current state | What's missing |
|---|---|---|
| L586 \"Doc Truth CI job\" | `scripts/check-doc-truth.sh` + scope output + ci_core fanout entry exist | Exact strings `name: Doc Truth` and `check \"doc-truth\"   \"$DOC_TRUTH_RESULT\"` in ci.yml |
| L668 \"ci_core fanout comment\" | Fanout loop exists at ci.yml:678 | Documentation comment `Note: tla is intentionally NOT forced on by ci_core.` |

The TODOs stay; the *issue reference* is the only stale part.

## Change

Replace `#9419 follow-up` with inline rationale describing the exact strings that need to appear, so the next reader doesn't waste time on the wrong issue.

## Workaround Rejection Bar self-check

- §1 telemetry-as-fix: not applicable, comment update.
- §2 string classifier: none.
- §3 N-of-M: 2 TODO blocks updated atomically. Verified no other `#9419` references in the codebase that need similar treatment.
- catch-all / cap / cooldown: none.

## Audit context (Iter 4)

| PR | Surface |
|---|---|
| #16830~#16868 | (Iter 1-3 + early Iter 4 dead surfaces) |
| #16868 | 6 internal-only normalizer dead-exports |
| #16877 | CRITICAL build break fix (eio + masc_log deps after #16802) |
| **this PR** | **2 stale TODO #9419 refs** |

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>