### PR TITLE
fix(build): restore main test exe compilation

### DIFF
--- a/lib/dashboard_eval_feed/dune
+++ b/lib/dashboard_eval_feed/dune
@@ -2,7 +2,8 @@
 ; masc_mcp namespace. Stacked on Phase 1D (briefing_compactors).
 ;
 ; Dashboard_eval_feed is dependency-leaf: stdlib + Yojson + Agent_sdk
-; (external) + Json_util/Safe_ops (masc_core sub-library). 178+59 LoC,
+; (external) + Eio cancellation + dashboard logging + Json_util/Safe_ops
+; (masc_core sub-library). 178+59 LoC,
 ; fan-in 5 (3 lib + 1 test, all callers verified leaf-clean against
 ; the new sub-library boundary).
 ;
@@ -17,5 +18,7 @@
  (flags (:standard -w +4))
  (libraries
   yojson
+  eio
   agent_sdk
+  masc_log
   masc_core))

--- a/lib/keeper/keeper_shell_bash_typed_input.mli
+++ b/lib/keeper/keeper_shell_bash_typed_input.mli
@@ -5,8 +5,8 @@ val assoc_upsert : string -> Yojson.Safe.t -> Yojson.Safe.t -> Yojson.Safe.t
 val shell_quote_for_policy : string -> string
 
 val typed_stage_command_text : executable:string -> argv:string list -> string
-val typed_input_command_text : Keeper_tool_bash_input.t -> string
-val typed_input_has_env : Keeper_tool_bash_input.t -> bool
+val typed_input_command_text : Keeper_tool_bash_input.bash_input -> string
+val typed_input_has_env : Keeper_tool_bash_input.bash_input -> bool
 
 val typed_validation_error_text
   :  Keeper_tool_bash_input.validation_error


### PR DESCRIPTION
## Summary
- add missing `eio` dependency for `Eio.Cancel.Cancelled` in `dashboard_eval_feed`
- add missing `masc_log` dependency for `Log.Dashboard.warn`
- fix `Keeper_shell_bash_typed_input.mli` to expose `Keeper_tool_bash_input.bash_input` instead of nonexistent `Keeper_tool_bash_input.t`

## Validation
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=/private/tmp/masc-dashboard-eval-feed-eio-dep-build-20260520 scripts/dune-local.sh build test/test_dashboard_keeper_feature_proof.exe`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=/private/tmp/masc-main-check-hotfix-16879-20260520 scripts/dune-local.sh build @check`
- `git diff --check origin/main...HEAD`

Fixes #16871
Fixes #16883