### PR TITLE
refactor(rfc-0145): PR-6 extract receipt-append safety escalation

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -206,6 +206,7 @@
   keeper_agent_prompt_metrics
   keeper_agent_tool_surface
   keeper_agent_run_contract_helpers
+  keeper_agent_run_receipt_append
   keeper_agent_result
   keeper_agent_error
   keeper_agent_memory_episode

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1950,52 +1950,15 @@ let run_turn
        coverage-gap helper is still called so the gap surface keeps
        working; the difference is the caller now sees the failure too. *)
        let receipt_append_outcome : (unit, string) result =
-         try
-           Keeper_execution_receipt.append config receipt;
-           append_receipt_manifest
-             ~site:"receipt_appended"
-             Keeper_runtime_manifest.Receipt_appended;
-           Ok ()
-         with
-         | Eio.Cancel.Cancelled _ as e -> raise e
-         | exn ->
-           let err_msg = Printexc.to_string exn in
-           Prometheus.inc_counter
-             Keeper_metrics.metric_keeper_dispatch_event_failures
-             ~labels:[ "keeper", meta.name; "site", "receipt_append" ]
-             ();
-           Log.Keeper.warn
-             "keeper:%s execution_receipt append failed: %s"
-             meta.name
-             err_msg;
-           (try
-              let masc_root = Coord.masc_root_dir config in
-              Telemetry_coverage_gap.record
-                ~masc_root
-                ~source:"execution_receipt"
-                ~producer:"keeper_agent_run.execution_receipt"
-                ~durable_store:
-                  (Filename.concat
-                     (Filename.concat (Filename.concat masc_root "keepers") meta.name)
-                     "execution-receipts")
-                ~dashboard_surface:"/api/v1/dashboard/execution-trust"
-                ~stale_reason:"execution_receipt_append_failed"
-                ~keeper_name:meta.name
-                ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-                ~error:err_msg
-                ()
-            with
-            | Eio.Cancel.Cancelled _ as e -> raise e
-            | gap_exn ->
-              Prometheus.inc_counter
-                Keeper_metrics.metric_keeper_dispatch_event_failures
-                ~labels:[ "keeper", meta.name; "site", "coverage_gap_append" ]
-                ();
-              Log.Keeper.warn
-                "keeper:%s execution_receipt coverage gap append failed: %s"
-                meta.name
-                (Printexc.to_string gap_exn));
-           Error err_msg
+         Keeper_agent_run_receipt_append.append_with_coverage_gap
+           ~config
+           ~receipt
+           ~keeper_name:meta.name
+           ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+           ~on_appended:(fun () ->
+             append_receipt_manifest
+               ~site:"receipt_appended"
+               Keeper_runtime_manifest.Receipt_appended)
        in
        (* Phase 5: wire goal/task/board with keeper tool results.
           Link execution artifacts to the current task if one exists.

--- a/lib/keeper/keeper_agent_run_receipt_append.ml
+++ b/lib/keeper/keeper_agent_run_receipt_append.ml
@@ -1,0 +1,53 @@
+let append_with_coverage_gap
+      ~config
+      ~receipt
+      ~keeper_name
+      ~trace_id
+      ~on_appended
+  : (unit, string) result
+  =
+  try
+    Keeper_execution_receipt.append config receipt;
+    on_appended ();
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    let err_msg = Printexc.to_string exn in
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_dispatch_event_failures
+      ~labels:[ "keeper", keeper_name; "site", "receipt_append" ]
+      ();
+    Log.Keeper.warn
+      "keeper:%s execution_receipt append failed: %s"
+      keeper_name
+      err_msg;
+    (try
+       let masc_root = Coord.masc_root_dir config in
+       Telemetry_coverage_gap.record
+         ~masc_root
+         ~source:"execution_receipt"
+         ~producer:"keeper_agent_run.execution_receipt"
+         ~durable_store:
+           (Filename.concat
+              (Filename.concat (Filename.concat masc_root "keepers") keeper_name)
+              "execution-receipts")
+         ~dashboard_surface:"/api/v1/dashboard/execution-trust"
+         ~stale_reason:"execution_receipt_append_failed"
+         ~keeper_name
+         ~trace_id
+         ~error:err_msg
+         ()
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | gap_exn ->
+       Prometheus.inc_counter
+         Keeper_metrics.metric_keeper_dispatch_event_failures
+         ~labels:[ "keeper", keeper_name; "site", "coverage_gap_append" ]
+         ();
+       Log.Keeper.warn
+         "keeper:%s execution_receipt coverage gap append failed: %s"
+         keeper_name
+         (Printexc.to_string gap_exn));
+    Error err_msg
+;;

--- a/lib/keeper/keeper_agent_run_receipt_append.mli
+++ b/lib/keeper/keeper_agent_run_receipt_append.mli
@@ -1,0 +1,28 @@
+(** RFC-0145 PR-6: extract receipt-append safety escalation from
+    [keeper_agent_run.run_turn] Step 8 body (L1942-L1999).
+
+    Cycle 5 [EveryTurnHasTerminalReceipt] safety invariant
+    (KeeperTurnFSM / KeeperOutcomesConservation specs): a turn whose
+    authoritative receipt is silently dropped cannot be reported as
+    Ok.  Pre-Cycle 5 the catch arm logged a WARN, recorded a
+    coverage-gap and let [turn_result] fall through unchanged.  This
+    wrapper preserves the Cycle 5 escalation: the caller observes a
+    typed [(unit, string) result], and an [Ok _] turn_result combined
+    with an [Error _] receipt outcome surfaces a structured internal
+    error to the caller's [match turn_result with Ok _ | Error _].
+
+    Side effects:
+    - on success: append receipt + invoke [on_appended] for
+      [Keeper_runtime_manifest.Receipt_appended] manifest log
+    - on exn: increment failure counter, log warn, record
+      coverage-gap, return [Error err_msg]
+
+    [Eio.Cancel.Cancelled] re-raised on both the append and the
+    coverage-gap try-with blocks. *)
+val append_with_coverage_gap
+  :  config:Coord.config
+  -> receipt:Keeper_execution_receipt.t
+  -> keeper_name:string
+  -> trace_id:string
+  -> on_appended:(unit -> unit)
+  -> (unit, string) result


### PR DESCRIPTION
## 요약

RFC-0145 PR-6 — `keeper_agent_run.run_turn` Step 8 body 의 Tier A2 / Cycle 5 receipt-append safety escalation 블록 (L1942-L1999) 을 sibling typed module 로 추출.

## 변경

| 파일 | LoC |
|------|-----|
| `lib/keeper/keeper_agent_run.ml` | **-37** |
| `lib/keeper/keeper_agent_run_receipt_append.{ml,mli}` | +81 (53 ml + 28 mli) |
| `lib/dune` | +1 |

## 측정

- `keeper_agent_run.ml`: 2103 → **2066 (-1.8%)**
- 추정 -48, 실측 -37 (오차 -11, 정확도 77%)
- **PR-1 + PR-3 + PR-6 합 = -132 LoC** (2103 → **1971, -6.3%**)

## 보존 invariant (Cycle 5 [EveryTurnHasTerminalReceipt])

- Typed `(unit, string) result` 반환 (Cycle 5 escalation core)
- `Cancelled re-raise` (append + coverage_gap 둘 다)
- `exn → counter + warn + coverage_gap.record + Error err_msg`
- `Ok _, Error err_msg` caller match 보존 (turn_result vs receipt_append_outcome)
- 모든 11 Telemetry_coverage_gap.record labeled args 동일
- `durable_store` Filename.concat 경로 동일

## 패턴 (RFC-0136 PR-4-c)

- typed Result boundary
- 5-args wrapper + `on_appended` callback 으로 caller scope 의 `append_receipt_manifest` 전달
- inner coverage-gap try-with 격리

## Stacked-after

- PR-1 (#16866, Draft) — L565 영역, 독립
- PR-3 (#16874, Draft) — L791 영역, 독립
- PR-6 (이 PR) — L1942 영역, 독립

세 영역 모두 *완전 독립* — no merge conflict.

## Anti-pattern 가드

- ✅ workaround 없음 (typed wrapper, Cycle 5 invariant 보존)
- ✅ telemetry-as-fix 아님 (기존 escalation 로직 단순 추출)
- ✅ string classifier 없음
- ✅ N-of-M 없음 (단일 boundary)

## RFC

`docs/rfc/RFC-0145-keeper-agent-run-decomposition.md`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
