### PR TITLE
refactor(keeper_context_core): extract tool-use/result pair invariants into sibling

### DIFF
--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -212,75 +212,12 @@ let message_to_json = Message_json.message_to_json
 let message_of_json = Message_json.message_of_json
 let text_of_history_jsonl_json = Message_json.text_of_history_jsonl_json
 
-let tool_use_ids_of_message (msg : Agent_sdk.Types.message) : string list =
-  List.filter_map
-    (function
-      | Agent_sdk.Types.ToolUse { id; _ } -> Some id
-      (* Only [ToolUse] carries a tool-use id; other blocks contribute none. *)
-      | Agent_sdk.Types.Text _
-      | Agent_sdk.Types.Thinking _
-      | Agent_sdk.Types.RedactedThinking _
-      | Agent_sdk.Types.ToolResult _
-      | Agent_sdk.Types.Image _
-      | Agent_sdk.Types.Document _
-      | Agent_sdk.Types.Audio _ -> None)
-    msg.content
-
-let tool_result_ids_of_message (msg : Agent_sdk.Types.message) : string list =
-  List.filter_map
-    (function
-      | Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
-      (* Only [ToolResult] carries a tool_use_id reference; others contribute none. *)
-      | Agent_sdk.Types.Text _
-      | Agent_sdk.Types.Thinking _
-      | Agent_sdk.Types.RedactedThinking _
-      | Agent_sdk.Types.ToolUse _
-      | Agent_sdk.Types.Image _
-      | Agent_sdk.Types.Document _
-      | Agent_sdk.Types.Audio _ -> None)
-    msg.content
-
-let has_tool_result_block (msg : Agent_sdk.Types.message) : bool =
-  List.exists
-    (function
-      | Agent_sdk.Types.ToolResult _ -> true
-      (* Only [ToolResult] qualifies; other blocks are not tool-result evidence. *)
-      | Agent_sdk.Types.Text _
-      | Agent_sdk.Types.Thinking _
-      | Agent_sdk.Types.RedactedThinking _
-      | Agent_sdk.Types.ToolUse _
-      | Agent_sdk.Types.Image _
-      | Agent_sdk.Types.Document _
-      | Agent_sdk.Types.Audio _ -> false)
-    msg.content
-
-(** Trim messages to at most [max_count] while preserving ToolUse/ToolResult
-    pairing.  Drops from the front.  If the drop point lands on a
-    ToolResult whose ToolUse would be the last dropped message, advance
-    the drop by 1 so the orphan ToolResult is also removed (pair stays
-    together on the dropped side).  This may yield fewer than [max_count]
-    messages but never creates orphans.
-
-    Root cause of recurring "unexpected tool_use_id" errors: the previous
-    implementation used [List.filteri (fun i _ -> i >= drop)] which splits
-    on message index, breaking mid-pair boundaries. *)
-let trim_messages_preserving_pairs
-    (messages : Agent_sdk.Types.message list) ~(max_count : int)
-    : Agent_sdk.Types.message list =
-  let n = List.length messages in
-  if n <= max_count then messages
-  else
-    let drop = n - max_count in
-    (* If the first kept message would be an orphan ToolResult,
-       drop it too so the pair stays together on the removed side. *)
-    let effective_drop =
-      match List.nth_opt messages drop with
-      | Some msg when has_tool_result_block msg ->
-        (* Advance drop to skip the orphan ToolResult *)
-        drop + 1
-      | _ -> drop
-    in
-    List.filteri (fun i _ -> i >= effective_drop) messages
+(* Tool use/result pair invariants extracted to
+   [Keeper_context_tool_message_pairs] (godfile decomp). *)
+let tool_use_ids_of_message = Keeper_context_tool_message_pairs.tool_use_ids_of_message
+let tool_result_ids_of_message = Keeper_context_tool_message_pairs.tool_result_ids_of_message
+let has_tool_result_block = Keeper_context_tool_message_pairs.has_tool_result_block
+let trim_messages_preserving_pairs = Keeper_context_tool_message_pairs.trim_messages_preserving_pairs
 
 let tool_result_text_of_block
     ~(tool_use_id : string)

--- a/lib/keeper/keeper_context_tool_message_pairs.ml
+++ b/lib/keeper/keeper_context_tool_message_pairs.ml
@@ -1,0 +1,82 @@
+(* Tool-use / tool-result block pair invariants for keeper messages.
+
+   Extracted from [Keeper_context_core] (godfile decomp). All
+   functions are pure projections over the message-content variant
+   and total over [Agent_sdk.Types] (exhaustive matches, no catch-all). *)
+
+let tool_use_ids_of_message (msg : Agent_sdk.Types.message) : string list =
+  List.filter_map
+    (function
+      | Agent_sdk.Types.ToolUse { id; _ } -> Some id
+      (* Only [ToolUse] carries a tool-use id; other blocks contribute none. *)
+      | Agent_sdk.Types.Text _
+      | Agent_sdk.Types.Thinking _
+      | Agent_sdk.Types.RedactedThinking _
+      | Agent_sdk.Types.ToolResult _
+      | Agent_sdk.Types.Image _
+      | Agent_sdk.Types.Document _
+      | Agent_sdk.Types.Audio _ -> None)
+    msg.content
+;;
+
+let tool_result_ids_of_message (msg : Agent_sdk.Types.message) : string list =
+  List.filter_map
+    (function
+      | Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
+      (* Only [ToolResult] carries a tool_use_id reference; others contribute none. *)
+      | Agent_sdk.Types.Text _
+      | Agent_sdk.Types.Thinking _
+      | Agent_sdk.Types.RedactedThinking _
+      | Agent_sdk.Types.ToolUse _
+      | Agent_sdk.Types.Image _
+      | Agent_sdk.Types.Document _
+      | Agent_sdk.Types.Audio _ -> None)
+    msg.content
+;;
+
+let has_tool_result_block (msg : Agent_sdk.Types.message) : bool =
+  List.exists
+    (function
+      | Agent_sdk.Types.ToolResult _ -> true
+      (* Only [ToolResult] qualifies; other blocks are not tool-result evidence. *)
+      | Agent_sdk.Types.Text _
+      | Agent_sdk.Types.Thinking _
+      | Agent_sdk.Types.RedactedThinking _
+      | Agent_sdk.Types.ToolUse _
+      | Agent_sdk.Types.Image _
+      | Agent_sdk.Types.Document _
+      | Agent_sdk.Types.Audio _ -> false)
+    msg.content
+;;
+
+(** Trim messages to at most [max_count] while preserving ToolUse/ToolResult
+    pairing.  Drops from the front.  If the drop point lands on a
+    ToolResult whose ToolUse would be the last dropped message, advance
+    the drop by 1 so the orphan ToolResult is also removed (pair stays
+    together on the dropped side).  This may yield fewer than [max_count]
+    messages but never creates orphans.
+
+    Root cause of recurring "unexpected tool_use_id" errors: the previous
+    implementation used [List.filteri (fun i _ -> i >= drop)] which splits
+    on message index, breaking mid-pair boundaries. *)
+let trim_messages_preserving_pairs
+      (messages : Agent_sdk.Types.message list)
+      ~(max_count : int)
+  : Agent_sdk.Types.message list
+  =
+  let n = List.length messages in
+  if n <= max_count
+  then messages
+  else (
+    let drop = n - max_count in
+    (* If the first kept message would be an orphan ToolResult,
+       drop it too so the pair stays together on the removed side. *)
+    let effective_drop =
+      match List.nth_opt messages drop with
+      | Some msg when has_tool_result_block msg ->
+        (* Advance drop to skip the orphan ToolResult *)
+        drop + 1
+      | _ -> drop
+    in
+    List.filteri (fun i _ -> i >= effective_drop) messages)
+;;

--- a/lib/keeper/keeper_context_tool_message_pairs.mli
+++ b/lib/keeper/keeper_context_tool_message_pairs.mli
@@ -1,0 +1,13 @@
+(** Tool-use / tool-result block pair invariants for keeper messages. *)
+
+val tool_use_ids_of_message : Agent_sdk.Types.message -> string list
+val tool_result_ids_of_message : Agent_sdk.Types.message -> string list
+val has_tool_result_block : Agent_sdk.Types.message -> bool
+
+(** Trim messages to at most [max_count] preserving ToolUse/ToolResult
+    pairing.  Drops from the front; advances the drop boundary by 1
+    when the next kept message would be an orphan [ToolResult]. *)
+val trim_messages_preserving_pairs
+  :  Agent_sdk.Types.message list
+  -> max_count:int
+  -> Agent_sdk.Types.message list


### PR DESCRIPTION
## 요약

`keeper_context_core.ml` (1471 LoC godfile) 의 tool-use/tool-result block pair invariant helper cluster 를 신규 sibling 모듈로 추출했습니다. **-63 LoC** (1471 → 1408).

keeper_context_core 첫 분해.

## 추출 surface (4 pure functions)

| 함수 | 시그니처 |
|---|---|
| `tool_use_ids_of_message` | `message -> string list` (filter_map `ToolUse.id`) |
| `tool_result_ids_of_message` | `message -> string list` (filter_map `ToolResult.tool_use_id`) |
| `has_tool_result_block` | `message -> bool` |
| `trim_messages_preserving_pairs` | `messages -> ~max_count -> messages` (orphan-aware front-drop) |

## 신규 모듈

- `lib/keeper/keeper_context_tool_message_pairs.ml` (82 LoC)
- `lib/keeper/keeper_context_tool_message_pairs.mli` (13 LoC)

## 의존성 (Stdlib + dependency module)

- `Agent_sdk.Types.{message, ToolUse, ToolResult, Text, Thinking, RedactedThinking, Image, Document, Audio}`
- `List.{filter_map, exists, length, nth_opt, filteri}`

Shared state 0. Side effect 0.

## 외부 caller 호환

- 외부 caller 0 (private helpers — 본 cluster 는 `keeper_context_core.mli` 에 노출되지 않음)
- 내부 caller 4 site (lines 369, 431, 436, 1078) → parent thin alias → 변경 0
- `test/test_keeper_lifecycle.ml:1907` 의 언급은 주석 (caller 아님)

## 검증

- [x] `dune build --root . lib/keeper` PASS
- [x] 함수 body 1-to-1 카피 (8-variant exhaustive match byte-identical)
- [x] pair-preserving trim 의 orphan-skip semantics 유지 (drop+1 advance)

## 패턴

Pure helper extraction (PR #16838 native_tool_hint, #16855 sub_board_json 와 동일). tool_use/tool_result pair invariants 는 working_context 의 checkpoint 관리와 별개 thematic concern — "message content block 의 typed projection" 책임이 명확히 분리됨.

후속 candidate: `keeper_context_core` 의 `tool_pair_repair_stats` + `repair_dangling_tool_use_messages_with_stats` + `repair_orphan_tool_result_messages_with_stats` cluster (~150 LoC, 동일 thematic) 도 본 모듈에 흡수 가능.

## Workaround Rejection Bar self-check

1. [ ] makes X visible only — NO
2. [ ] string classifier — NO
3. [ ] N-of-M — NO (4 함수 cluster 전체 이동)
4. [ ] catch-all `_ ->` 추가 — NO (existing 8-variant exhaustive match 유지)
5. [ ] cap/cooldown/dedup/repair — NO (orphan repair 는 *기존* trim semantic 보존)
6. [ ] test backdoor — NO
7. [ ] N-사이트 typo — NO

PASS — pure refactor.

## RFC

RFC-WAIVED: `keeper_context_tool_message_pairs` 는 RFC-gated subsystem 아님.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
