### PR TITLE
fix(dashboard_eval_feed): add eio + masc_log dune deps — unblocks @check

### DIFF
--- a/lib/dashboard_eval_feed/dune
+++ b/lib/dashboard_eval_feed/dune
@@ -2,9 +2,10 @@
 ; masc_mcp namespace. Stacked on Phase 1D (briefing_compactors).
 ;
 ; Dashboard_eval_feed is dependency-leaf: stdlib + Yojson + Agent_sdk
-; (external) + Json_util/Safe_ops (masc_core sub-library). 178+59 LoC,
-; fan-in 5 (3 lib + 1 test, all callers verified leaf-clean against
-; the new sub-library boundary).
+; (external) + Json_util/Safe_ops (masc_core sub-library) + eio (for
+; RFC-0106 Cancelled re-raise arms). 178+59 LoC, fan-in 5 (3 lib + 1
+; test, all callers verified leaf-clean against the new sub-library
+; boundary).
 ;
 ; (include_subdirs no) opts out of parent's (include_subdirs unqualified).
 ; (wrapped false) keeps the top-level identifier `Dashboard_eval_feed`.
@@ -18,4 +19,6 @@
  (libraries
   yojson
   agent_sdk
+  eio
+  masc_log
   masc_core))


### PR DESCRIPTION
## Summary

`lib/dashboard_eval_feed/dashboard_eval_feed.ml` references `Eio.Cancel.Cancelled` (2 sites, RFC-0106) and `Log.Dashboard.warn` (2 sites, operator-visibility from #16802) but the sub-lib's `(libraries ...)` stanza doesn't declare `eio` or `masc_log`.

Result: `dune build --root . @check` fails here and blocks the whole repo's @check target. This is what prevented iter#75 / iter#76 / iter#77 from running full @check.

## Root cause

PR #16802 (2026-05-19, silent-failure surface series) added the warn-on-Sys_error paths to the extracted sub-library but the dune deps closure was not updated. Reproducible standalone: `dune build --root . lib/dashboard_eval_feed/` → "Unbound module Eio".

## Why not unlock via behavior change

Both arms are load-bearing — removing either re-introduces the silent-failure / silent-cancel anti-patterns those PRs were created to close.

## Verification

- Before: standalone build → "Unbound module Eio"
- After: standalone build → clean
- `@check` now advances past this sub-lib and surfaces an *independent* pre-existing break in `lib/keeper/keeper_shell_bash_typed_input.mli:8` (RFC-0092 PR-4 area, commit a8ebbeb28b #16872) — not this PR's scope

## Workaround Rejection Bar self-check

All 7 items clear. This is a pure dependency-declaration fix — declares deps the code already uses.

## Surface impact

`masc_log` is already a workspace-wide dep (~30 consumers). `eio` is workspace-wide. No new transitive deps beyond what the workspace already pulls.

## Test plan
- [x] standalone sub-lib build clean
- [x] @check advances past this sub-lib (next failure unrelated)
- [ ] CI green after push

🤖 Generated with [Claude Code](https://claude.com/claude-code)