### PR TITLE
refactor(repo_manager): migrate repo_store.ml to Field_resolution (RFC-0141 PR-2)

### DIFF
--- a/lib/repo_manager/repo_store.ml
+++ b/lib/repo_manager/repo_store.ml
@@ -45,25 +45,28 @@ let status_of_string = function
 let repository_of_toml toml id =
   let ( let* ) = Result.bind in
   let path field = ["repository"; id; field] in
+  (* RFC-0141 PR-2: Type_mismatch is propagated as Error instead of being
+     silenced into [Ok default]. Missing fields still fall back to default. *)
   let find_string_default field default =
-    match Otoml.find_result toml Otoml.get_string (path field) with
-    | Ok value -> Ok value
-    | Error _ -> Ok default
+    Field_resolution.resolve_string toml (path field)
+    |> Field_resolution.or_default ~default
   in
   let find_bool_default field default =
-    match Otoml.find_result toml Otoml.get_boolean (path field) with
-    | Ok value -> Ok value
-    | Error _ -> Ok default
+    Field_resolution.resolve_bool toml (path field)
+    |> Field_resolution.or_default ~default
   in
   let find_int64_default field default =
-    match Otoml.Helpers.find_integer_result toml (path field) with
-    | Ok value -> Ok (Int64.of_int value)
-    | Error _ -> Ok default
+    match Field_resolution.resolve_int toml (path field) with
+    | Present v -> Ok (Int64.of_int v)
+    | Missing -> Ok default
+    | Type_mismatch { path; expected; message } ->
+      Error
+        (Printf.sprintf "TOML field %s: expected %s (%s)"
+           (String.concat "." path) expected message)
   in
   let find_string_list_default field default =
-    match Otoml.Helpers.find_strings_result toml (path field) with
-    | Ok value -> Ok value
-    | Error _ -> Ok default
+    Field_resolution.resolve_strings toml (path field)
+    |> Field_resolution.or_default ~default
   in
   let* name = Otoml.find_result toml Otoml.get_string (path "name") in
   let* url = Otoml.find_result toml Otoml.get_string (path "url") in


### PR DESCRIPTION
## Summary

RFC-0141 PR-2: mechanical migration of `repo_store.repository_of_toml` from the
4-site `Error _ -> Ok default` silent-failure shape to `Field_resolution.{resolve_*}`
piped through `or_default`.

## Behavioural diff

| Outcome | Before | After |
|---|---|---|
| Field absent | `Ok default` | `Ok default` (unchanged) |
| Field present, right type | `Ok value` | `Ok value` (unchanged) |
| Field present, **wrong type** | `Ok default` (silent) | `Error "<path>: expected <type>"` (loud) |

The only behavioural change is the Type_mismatch branch: a malformed
`repositories.toml` field used to collapse to its default; now it surfaces
as an error so the operator can fix the file instead of running with a
synthetic value.

## Files

- `lib/repo_manager/repo_store.ml` — 4 sites migrated, 1 file, +15 / -12

## Stack

| PR | Status |
|---|---|
| #16837 — PR-1 Field_resolution module + tests | MERGED |
| **this PR — PR-2 repo_store.ml** | **OPEN** |
| PR-3 credential_store.ml (4 sites) | pending |
| PR-4 credential_materializer.ml (2 sites) | pending |
| PR-5 ratchet regenerate + legacy helper sunset | pending |

## RFC-0088 §3 self-check

- §3.1 telemetry-as-fix: **no** — type system enforces, no counter added.
- §3.2 string classifier: **no** — typed sum variant.
- §3.3 N-of-M patch: PR-2 of declared 5-PR stack with RFC linkage; not the symptom.
- §3.4 symptom suppression: **no** — eliminates a silent default substitution.

## Test plan

- [x] `dune build --root . lib/repo_manager` — clean
- [ ] CI build_test pipeline — pending
- [ ] No new ratchet regression (PR-5 will regenerate)

RFC: `docs/rfc/RFC-0141-typed-toml-field-resolution.md`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>