### PR TITLE
refactor(rfc-0145): PR-9 extract Phase 5 task-link wire

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -206,6 +206,7 @@
   keeper_agent_prompt_metrics
   keeper_agent_tool_surface
   keeper_agent_run_contract_helpers
+  keeper_agent_run_task_link
   keeper_agent_result
   keeper_agent_error
   keeper_agent_memory_episode

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -2007,57 +2007,11 @@ let run_turn
           backlog and emits a Task.Linked event unconditionally, so
           calling it every turn for an unchanged trace produced lock
           contention and event-feed noise. *)
-       let () =
-         match acc.meta.current_task_id with
-         | None -> ()
-         | Some task_id ->
-           let task_id_str = Keeper_id.Task_id.to_string task_id in
-           let trace_id_str = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
-           if
-             task_link_already_recorded
-               ~keeper:meta.name
-               ~task_id:task_id_str
-               ~trace_id:trace_id_str
-           then ()
-           else (
-             (* Pass trace_id as both session_id and operation_id to match
-                the existing keeper_run_tools.ml convention (session_id
-                fields elsewhere are populated from trace_id). *)
-             let session_id = Some trace_id_str in
-             let operation_id = Some trace_id_str in
-             let result =
-               try
-                 Coord.link_task_execution_artifacts_r
-                   config
-                   ~task_id:task_id_str
-                   ?session_id
-                   ?operation_id
-                   ()
-               with
-               | Eio.Cancel.Cancelled _ as e -> raise e
-               | exn ->
-                 (* link takes a backlog file lock; an OS-level lock
-                    contention or transient I/O hiccup can raise before
-                    the function gets a chance to return Error. Convert
-                    that into a normal Error so the warn path below logs
-                    it instead of unwinding the whole keeper turn. *)
-                 Error
-                   (Masc_domain.System
-                      (Masc_domain.System_error.IoError (Printexc.to_string exn)))
-             in
-             match result with
-             | Ok _ ->
-               mark_task_link
-                 ~keeper:meta.name
-                 ~task_id:task_id_str
-                 ~trace_id:trace_id_str
-             | Error err ->
-               Log.Keeper.warn
-                 "keeper:%s link_task_execution_artifacts failed for task=%s: %s"
-                 meta.name
-                 task_id_str
-                 (Masc_domain.masc_error_to_string err))
-       in
+       Keeper_agent_run_task_link.link_if_needed
+         ~config
+         ~keeper_name:meta.name
+         ~task_id:acc.meta.current_task_id
+         ~trace_id:meta.runtime.trace_id;
        let final_result =
          match turn_result, receipt_append_outcome with
          | Error _, _ ->

--- a/lib/keeper/keeper_agent_run_task_link.ml
+++ b/lib/keeper/keeper_agent_run_task_link.ml
@@ -1,0 +1,43 @@
+let link_if_needed ~config ~keeper_name ~task_id ~trace_id =
+  match task_id with
+  | None -> ()
+  | Some task_id ->
+    let task_id_str = Keeper_id.Task_id.to_string task_id in
+    let trace_id_str = Keeper_id.Trace_id.to_string trace_id in
+    if
+      Keeper_agent_run_turn_helpers.task_link_already_recorded
+        ~keeper:keeper_name
+        ~task_id:task_id_str
+        ~trace_id:trace_id_str
+    then ()
+    else (
+      let session_id = Some trace_id_str in
+      let operation_id = Some trace_id_str in
+      let result =
+        try
+          Coord.link_task_execution_artifacts_r
+            config
+            ~task_id:task_id_str
+            ?session_id
+            ?operation_id
+            ()
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+          Error
+            (Masc_domain.System
+               (Masc_domain.System_error.IoError (Printexc.to_string exn)))
+      in
+      match result with
+      | Ok _ ->
+        Keeper_agent_run_turn_helpers.mark_task_link
+          ~keeper:keeper_name
+          ~task_id:task_id_str
+          ~trace_id:trace_id_str
+      | Error err ->
+        Log.Keeper.warn
+          "keeper:%s link_task_execution_artifacts failed for task=%s: %s"
+          keeper_name
+          task_id_str
+          (Masc_domain.masc_error_to_string err))
+;;

--- a/lib/keeper/keeper_agent_run_task_link.mli
+++ b/lib/keeper/keeper_agent_run_task_link.mli
@@ -1,0 +1,24 @@
+(** RFC-0145 PR-9: extract Phase 5 task-link wire from
+    [keeper_agent_run.run_turn] Step 8 body (L2010-L2060).
+
+    Links execution artifacts to the current task if one exists,
+    skipping when the (keeper, task, trace_id) tuple has already
+    been recorded.  Reads/writes via
+    [Coord.link_task_execution_artifacts_r], with
+    [task_link_already_recorded] / [mark_task_link] sibling
+    helpers (re-exported from [Turn_helpers]).
+
+    Lock contention or transient I/O on [link_task_execution_artifacts_r]
+    raises an exception; this wrapper catches non-[Cancelled] exceptions
+    and converts them into [Masc_domain.System (IoError ...)] so the
+    warn path logs the failure instead of unwinding the whole keeper
+    turn.
+
+    Side effects only.  [Eio.Cancel.Cancelled] re-raised.
+    No-op when [task_id = None]. *)
+val link_if_needed
+  :  config:Coord.config
+  -> keeper_name:string
+  -> task_id:Keeper_id.Task_id.t option
+  -> trace_id:Keeper_id.Trace_id.t
+  -> unit


### PR DESCRIPTION
## 요약

RFC-0145 PR-9 — `keeper_agent_run.run_turn` Step 8 body 의 Phase 5 task-link wire 블록 (L2010-L2060) 을 sibling typed module 로 추출.

## 변경

| 파일 | LoC |
|------|-----|
| `lib/keeper/keeper_agent_run.ml` | **-46** |
| `lib/keeper/keeper_agent_run_task_link.{ml,mli}` | +67 (43 ml + 24 mli) |
| `lib/dune` | +1 |

## 측정

- `keeper_agent_run.ml`: 2103 → **2057 (-2.2%)**
- 추정 -45, 실측 -46 (오차 -1, 정확도 98%)
- **PR-1 + PR-3 + PR-6 + PR-9 합 = -178 LoC** (2103 → **1925, -8.5%**)

## 패턴

- side-effect wrapper, None-no-op short-circuit
- 4-args 시그니처 (`config` + `keeper_name` + `task_id:_ option` + `trace_id`)
- caller scope re-export 대신 `Keeper_agent_run_turn_helpers` 직접 호출

## 보존 invariant

- `task_id = None` → no-op (early return)
- `task_link_already_recorded` 캐시 check 보존
- `Cancelled re-raise`, exn → `Masc_domain.System (IoError ...)` 변환 보존
- `Ok _ → mark_task_link`, `Error err → Log.Keeper.warn` 동일

## Stacked-after

PR-1 (#16866) + PR-3 (#16874) + PR-6 (#16881) — 4 영역 독립 (L565/L791/L1942/L2010), no merge conflict.

## RFC-0145 누적 진척

| PR | 영역 | LoC Δ | 상태 |
|----|-----|------|------|
| PR-1 | L565 Phase 0 telemetry | -36 | Draft #16866 |
| PR-3 | L791 Thinking blocks | -59 | Draft #16874 |
| PR-6 | L1942 Receipt failure | -37 | Draft #16881 |
| **PR-9 (이 PR)** | **L2010 Phase 5 task link** | **-46** | Draft |
| **합산** | 4 sub-PR | **-178** | RFC-0136 (-326) **55% 달성** |

`keeper_agent_run.ml`: 2103 → **1925 LoC (-8.5%)**

## Anti-pattern 가드

- ✅ workaround 없음
- ✅ telemetry-as-fix 아님
- ✅ string classifier 없음
- ✅ N-of-M 없음 (4 sub-PR 모두 *independent boundary*, single PR 외 분할 정당성 명시)

## RFC

`docs/rfc/RFC-0145-keeper-agent-run-decomposition.md`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
