### PR TITLE
refactor(repo_manager): migrate credential_store.ml optional fields to Field_resolution (RFC-0141 PR-3)

### DIFF
--- a/lib/repo_manager/credential_store.ml
+++ b/lib/repo_manager/credential_store.ml
@@ -70,29 +70,23 @@ let credential_of_toml toml id =
   let* cred_type_str = Otoml.find_result toml Otoml.get_string (path "type") in
   let* cred_type = credential_type_of_string cred_type_str in
   let* username = Otoml.find_result toml Otoml.get_string (path "username") in
-  let gh_config_dir =
-    match Otoml.find_result toml Otoml.get_string (path "gh_config_dir") with
-    | Ok dir -> Some dir
-    | Error _ -> None
+  (* RFC-0141 PR-3: lift optional fields through [Field_resolution] so a
+     wrong-type value in [credentials.toml] surfaces as [Error] instead of
+     being silenced into [None]. *)
+  let optional_string field =
+    match Field_resolution.resolve_string toml (path field) with
+    | Present v -> Ok (Some v)
+    | Missing -> Ok None
+    | Type_mismatch { path; expected; message } ->
+      Error
+        (Printf.sprintf "TOML field %s: expected %s (%s)"
+           (String.concat "." path) expected message)
   in
-  let ssh_key_path =
-    match Otoml.find_result toml Otoml.get_string (path "ssh_key_path") with
-    | Ok path -> Some path
-    | Error _ -> None
-  in
-  let gpg_key_id =
-    match Otoml.find_result toml Otoml.get_string (path "gpg_key_id") with
-    | Ok id -> Some id
-    | Error _ -> None
-  in
+  let* gh_config_dir = optional_string "gh_config_dir" in
+  let* ssh_key_path = optional_string "ssh_key_path" in
+  let* gpg_key_id = optional_string "gpg_key_id" in
   let state = credential_state_of_toml toml id in
-  let token_sha256_prefix =
-    match
-      Otoml.find_result toml Otoml.get_string (path "token_sha256_prefix")
-    with
-    | Ok s -> Some s
-    | Error _ -> None
-  in
+  let* token_sha256_prefix = optional_string "token_sha256_prefix" in
   Ok
     {
       id;


### PR DESCRIPTION
## Summary

RFC-0141 PR-3: migrate 4 optional-string sites in `credential_store.credential_of_toml`
from the silent-failure shape `Error _ -> None` to Field_resolution-based
Result monad extraction.

Migrated fields:
- `credential.<id>.gh_config_dir`
- `credential.<id>.ssh_key_path`
- `credential.<id>.gpg_key_id`
- `credential.<id>.token_sha256_prefix`

## Behavioural diff

| Outcome | Before | After |
|---|---|---|
| Field absent | `None` | `Ok None` (unchanged) |
| Field present, right type | `Some v` | `Ok (Some v)` (unchanged) |
| Field present, wrong type | `None` (silent) | `Error "<path>: expected string"` (loud) |

## Out of scope (this PR)

- `state` field at line 50 → complex multi-state semantics in
  `credential_state_of_toml`, deferred.
- `Otoml.find_result toml Fun.id ["credential"]` at line 160 → structural
  lookup using `Fun.id` accessor; Type_mismatch handled by subsequent match
  arms. Not a Field_resolution candidate.

## Files

- `lib/repo_manager/credential_store.ml` — 4 sites consolidated through
  a local `optional_string` helper, +15 / -21.

## Stack

| PR | Status |
|---|---|
| #16837 — PR-1 Field_resolution module + tests | MERGED |
| #16887 — PR-2 repo_store.ml | OPEN |
| **this PR — PR-3 credential_store.ml** | **OPEN** |
| PR-4 credential_materializer.ml (2 sites) | pending |
| PR-5 ratchet regenerate + legacy helper sunset | pending |

PR-2 and PR-3 are independent (different files, both based on origin/main
post-PR-1 merge).

## RFC-0088 §3 self-check

- §3.1 telemetry-as-fix: **no**
- §3.2 string classifier: **no** — typed sum variant
- §3.3 N-of-M patch: PR-3 of declared 5-PR stack, RFC linkage explicit
- §3.4 symptom suppression: **no** — eliminates silent default substitution

## Test plan

- [x] \`dune build --root . lib/repo_manager\` clean
- [ ] CI build_test pipeline
- [ ] No new ratchet regression (PR-5 will regenerate)

RFC: \`docs/rfc/RFC-0141-typed-toml-field-resolution.md\`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>