### PR TITLE
refactor(rfc-0145): PR-4-1 extract post-turn deterministic memory write

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -206,6 +206,7 @@
   keeper_agent_prompt_metrics
   keeper_agent_tool_surface
   keeper_agent_run_contract_helpers
+  keeper_agent_run_memory_write
   keeper_agent_result
   keeper_agent_error
   keeper_agent_memory_episode

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1515,57 +1515,14 @@ let run_turn
                                  )
                            | None -> ())
                         | None -> ());
-                       (* Post-turn deterministic memory write.
-             Uses meta-based fallback when [STATE] parsing fails.
-             See RFC #3646 Section 3: Det/NonDet boundary. *)
-                       (try
-                          let notes_written, kinds_written =
-                            Keeper_memory_bank.append_memory_notes_from_reply
-                              config
-                              meta
-                              ~snapshot:state_snapshot
-                              ~turn:manifest_keeper_turn_id
-                              ~reply:response_text
-                              ()
-                          in
-                          let tool_result_notes_written =
-                            if Keeper_tool_emission_hook.masc_tool_emission_enabled ()
-                            then (
-                              let tool_results =
-                                Keeper_tool_emission_hook.(
-                                  snapshot (accumulator_for_keeper meta.name))
-                              in
-                              Keeper_memory_bank.append_memory_notes_from_tool_results
-                                config
-                                meta
-                                ~turn:manifest_keeper_turn_id
-                                ~results:tool_results)
-                            else 0
-                          in
-                          let notes_written = notes_written + tool_result_notes_written in
-                          let kinds_written =
-                            if
-                              tool_result_notes_written > 0
-                              && not (List.mem "long_term" kinds_written)
-                            then kinds_written @ [ "long_term" ]
-                            else kinds_written
-                          in
-                          if notes_written > 0
-                          then
-                            Keeper_turn_telemetry.log_keeper_memory_write
-                              ~keeper_name:meta.name
-                              ~notes_written
-                              ~kinds_written
-                        with
-                        | exn ->
-                          Log.Keeper.error
-                            "keeper:%s memory_write failed: %s"
-                            meta.name
-                            (Printexc.to_string exn);
-                          Prometheus.inc_counter
-                            Keeper_metrics.metric_keeper_memory_write_failures
-                            ~labels:[ "keeper", meta.name ]
-                            ());
+                       (* Post-turn deterministic memory write.  See RFC #3646
+             Section 3: Det/NonDet boundary. *)
+                       Keeper_agent_run_memory_write.write_post_turn
+                         ~config
+                         ~meta
+                         ~state_snapshot
+                         ~turn:manifest_keeper_turn_id
+                         ~reply:response_text;
                        (* Episodic memory: create an episode from [STATE] after
               Agent.run returns, then persist and emit activity through the
               post-run memory adapter. Collaboration learning (Hebbian

--- a/lib/keeper/keeper_agent_run_memory_write.ml
+++ b/lib/keeper/keeper_agent_run_memory_write.ml
@@ -1,0 +1,49 @@
+let write_post_turn ~config ~(meta : Keeper_types.keeper_meta) ~state_snapshot ~turn ~reply =
+  try
+    let notes_written, kinds_written =
+      Keeper_memory_bank.append_memory_notes_from_reply
+        config
+        meta
+        ~snapshot:state_snapshot
+        ~turn
+        ~reply
+        ()
+    in
+    let tool_result_notes_written =
+      if Keeper_tool_emission_hook.masc_tool_emission_enabled ()
+      then (
+        let tool_results =
+          Keeper_tool_emission_hook.(snapshot (accumulator_for_keeper meta.name))
+        in
+        Keeper_memory_bank.append_memory_notes_from_tool_results
+          config
+          meta
+          ~turn
+          ~results:tool_results)
+      else 0
+    in
+    let notes_written = notes_written + tool_result_notes_written in
+    let kinds_written =
+      if
+        tool_result_notes_written > 0
+        && not (List.mem "long_term" kinds_written)
+      then kinds_written @ [ "long_term" ]
+      else kinds_written
+    in
+    if notes_written > 0
+    then
+      Keeper_turn_telemetry.log_keeper_memory_write
+        ~keeper_name:meta.name
+        ~notes_written
+        ~kinds_written
+  with
+  | exn ->
+    Log.Keeper.error
+      "keeper:%s memory_write failed: %s"
+      meta.name
+      (Printexc.to_string exn);
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_memory_write_failures
+      ~labels:[ "keeper", meta.name ]
+      ()
+;;

--- a/lib/keeper/keeper_agent_run_memory_write.mli
+++ b/lib/keeper/keeper_agent_run_memory_write.mli
@@ -1,0 +1,24 @@
+(** RFC-0145 PR-4-1: extract post-turn deterministic memory write
+    from [keeper_agent_run.run_turn] Step 8 body (L1518-L1568).
+
+    Appends keeper memory notes from the reply (deterministic path),
+    optionally augmented by tool-emission-hook accumulator results
+    when [Keeper_tool_emission_hook.masc_tool_emission_enabled]
+    returns true.  Logs aggregated counts via
+    [Keeper_turn_telemetry.log_keeper_memory_write] when any notes
+    were written.
+
+    See RFC #3646 Section 3 for the Det/NonDet boundary background.
+
+    Side effects only.  Exceptions are caught (counter +
+    error log); [Eio.Cancel.Cancelled] is *not* explicitly
+    re-raised in the original block, matching the pre-Cycle 5
+    deterministic-memory path behavior.  No-op when no notes are
+    written. *)
+val write_post_turn
+  :  config:Coord.config
+  -> meta:Keeper_types.keeper_meta
+  -> state_snapshot:Keeper_state_snapshot.t
+  -> turn:int
+  -> reply:string
+  -> unit


### PR DESCRIPTION
## 요약

RFC-0145 PR-4-1 — `keeper_agent_run.run_turn` Step 8 body 의 post-turn deterministic memory write (L1518-L1568) 을 sibling typed module 로 추출.

## 변경

| 파일 | LoC |
|------|-----|
| `lib/keeper/keeper_agent_run.ml` | **-43** |
| `lib/keeper/keeper_agent_run_memory_write.{ml,mli}` | +73 (49 ml + 24 mli) |
| `lib/dune` | +1 |

## 측정

- `keeper_agent_run.ml`: 2103 → **2060 (-2.0%)**
- 추정 -38, 실측 -43 (오차 +5, 정확도 88%)
- **누적 5 sub-PR** = -221 LoC (2103 → **1882, -10.5%**)

## 패턴

- side-effect wrapper, RFC #3646 Det 경계 보존
- 5-args (config + meta + state_snapshot + turn + reply)
- `append_memory_notes_from_reply` + tool_emission hook augmentation
- `kinds_written`에 "long_term" append + `log_keeper_memory_write` 가드

## 보존 invariant

- `masc_tool_emission_enabled` env-flag guard
- `tool_result_notes_written > 0` 시 kinds_written 자동 augment
- `notes_written > 0` 시만 log_keeper_memory_write
- exn → Log.Keeper.error + `metric_keeper_memory_write_failures`

## Stacked-after

PR-1 (#16866) + PR-3 (#16874) + PR-6 (#16881) + PR-9 (#16888). 5 영역 모두 독립 (L565/L791/L1518/L1942/L2010).

## RFC-0145 누적

| PR | LoC Δ |
|----|------|
| PR-1 | -36 |
| PR-3 | -59 |
| PR-6 | -37 |
| PR-9 | -46 |
| **PR-4-1 (이 PR)** | **-43** |
| **합산** | **-221** |

`keeper_agent_run.ml`: 2103 → **1882 (-10.5%)**. RFC-0136 (-326) **68% 달성**.

## RFC

`docs/rfc/RFC-0145-keeper-agent-run-decomposition.md`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
