### PR TITLE
fix(keeper): correct .mli type ref Keeper_tool_bash_input.t → bash_input

### DIFF
--- a/lib/keeper/keeper_shell_bash_typed_input.mli
+++ b/lib/keeper/keeper_shell_bash_typed_input.mli
@@ -5,8 +5,8 @@ val assoc_upsert : string -> Yojson.Safe.t -> Yojson.Safe.t -> Yojson.Safe.t
 val shell_quote_for_policy : string -> string
 
 val typed_stage_command_text : executable:string -> argv:string list -> string
-val typed_input_command_text : Keeper_tool_bash_input.t -> string
-val typed_input_has_env : Keeper_tool_bash_input.t -> bool
+val typed_input_command_text : Keeper_tool_bash_input.bash_input -> string
+val typed_input_has_env : Keeper_tool_bash_input.bash_input -> bool
 
 val typed_validation_error_text
   :  Keeper_tool_bash_input.validation_error


### PR DESCRIPTION
## Summary

`lib/keeper/keeper_shell_bash_typed_input.mli:8-9` references the non-existent type `Keeper_tool_bash_input.t`. The actual type is named `bash_input` (variant of `Exec` / `Pipeline`).

After iter#78 PR #16886 unblocks the prior dashboard_eval_feed @check break, this is the next failure in the chain.

## Root cause

PR #16870 (commit a76fa54adb, 2026-05-20) extracted projection helpers and wrote the .mli assuming the OCaml single-`t` naming convention. The upstream `Keeper_tool_bash_input` predates that convention and uses domain names. The .ml compiled because OCaml infers the type from pattern-matching `Exec` / `Pipeline` constructors — the .mli is the first site to *name* the type, exposing the gap.

## Verification

- Before: `dune build --root . lib/keeper/` → "Unbound type constructor Keeper_tool_bash_input.t"
- After: same → clean
- Sole caller `keeper_shell_bash.ml` compiles against the new signature

## Anti-pattern note

`.ml`-first authoring without re-building against `.mli` lets type names go unverified until a downstream consumer references them. If `.mli` had been authored first, OCaml would have rejected the `Exec`/`Pipeline` patterns against the wrong type immediately.

## Workaround Rejection Bar self-check
All 7 items clear — typo fix in type reference, no behavior change.

## Test plan
- [x] keeper lib builds clean
- [ ] CI green after push

🤖 Generated with [Claude Code](https://claude.com/claude-code)