### PR TITLE
refactor(rfc-0145): PR-4-3 extract post-turn memory bank compaction (LOW 6 complete)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -206,6 +206,7 @@
   keeper_agent_prompt_metrics
   keeper_agent_tool_surface
   keeper_agent_run_contract_helpers
+  keeper_agent_run_memory_compact
   keeper_agent_result
   keeper_agent_error
   keeper_agent_memory_episode

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1580,40 +1580,12 @@ let run_turn
                          ~snapshot:state_snapshot
                          ();
                        (* Memory bank compaction: dedup + consolidate if over threshold. *)
-                       (try
-                          let memory_summarizer =
-                            Keeper_memory_llm_summary.make
-                              ?provider_filter
-                              ~cascade_name:cascade_name_string
-                              ~keeper_name:meta.name
-                              ()
-                          in
-                          let compaction =
-                            Keeper_memory_bank.compact_memory_bank_if_needed
-                              ?summarizer:memory_summarizer
-                              config
-                              meta
-                          in
-                          if compaction.performed
-                          then
-                            Log.Keeper.info
-                              "keeper:%s memory_compacted before=%d after=%d dropped=%d"
-                              meta.name
-                              compaction.before_notes
-                              compaction.after_notes
-                              compaction.dropped_notes
-                        with
-                        | Eio.Cancel.Cancelled _ as e -> raise e
-                        | exn ->
-                          Prometheus.inc_counter
-                            Keeper_metrics.metric_keeper_dispatch_event_failures
-                            ~labels:[ "keeper", meta.name; "site", "compaction" ]
-                            ();
-                          Log.Keeper.warn
-                            "keeper:%s cascade=%s compaction failed: %s"
-                            meta.name
-                            (Keeper_types.cascade_name_of_meta meta)
-                            (Printexc.to_string exn));
+                       Keeper_agent_run_memory_compact.compact_if_needed
+                         ~config
+                         ~meta
+                         ~cascade_name_string
+                         ?provider_filter
+                         ();
                        (* Post-turn quality metrics — goal alignment + memory recall.
              Logged to decisions.jsonl for feedback loop analysis. *)
                        (try

--- a/lib/keeper/keeper_agent_run_memory_compact.ml
+++ b/lib/keeper/keeper_agent_run_memory_compact.ml
@@ -1,0 +1,36 @@
+let compact_if_needed ~config ~(meta : Keeper_types.keeper_meta) ~cascade_name_string ?provider_filter () =
+  try
+    let memory_summarizer =
+      Keeper_memory_llm_summary.make
+        ?provider_filter
+        ~cascade_name:cascade_name_string
+        ~keeper_name:meta.name
+        ()
+    in
+    let compaction =
+      Keeper_memory_bank.compact_memory_bank_if_needed
+        ?summarizer:memory_summarizer
+        config
+        meta
+    in
+    if compaction.performed
+    then
+      Log.Keeper.info
+        "keeper:%s memory_compacted before=%d after=%d dropped=%d"
+        meta.name
+        compaction.before_notes
+        compaction.after_notes
+        compaction.dropped_notes
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_dispatch_event_failures
+      ~labels:[ "keeper", meta.name; "site", "compaction" ]
+      ();
+    Log.Keeper.warn
+      "keeper:%s cascade=%s compaction failed: %s"
+      meta.name
+      (Keeper_types.cascade_name_of_meta meta)
+      (Printexc.to_string exn)
+;;

--- a/lib/keeper/keeper_agent_run_memory_compact.mli
+++ b/lib/keeper/keeper_agent_run_memory_compact.mli
@@ -1,0 +1,18 @@
+(** RFC-0145 PR-4-3: extract post-turn memory bank compaction from
+    [keeper_agent_run.run_turn] Step 8 body (L1583-L1616).
+
+    Builds an [Keeper_memory_llm_summary] summarizer (cascade-aware)
+    and invokes
+    [Keeper_memory_bank.compact_memory_bank_if_needed]; logs an info
+    line when compaction was performed (before/after/dropped notes).
+
+    Side effects only.  [Eio.Cancel.Cancelled] re-raised;
+    other exceptions counter + warn log under the
+    [site=compaction] label. *)
+val compact_if_needed
+  :  config:Coord.config
+  -> meta:Keeper_types.keeper_meta
+  -> cascade_name_string:string
+  -> ?provider_filter:Cascade_runner.provider_filter
+  -> unit
+  -> unit


### PR DESCRIPTION
## 요약

RFC-0145 PR-4-3 — `keeper_agent_run.run_turn` Step 8 body 의 post-turn memory bank compaction (L1583-L1616) 을 sibling typed module 로 추출.

## 변경

| 파일 | LoC |
|------|-----|
| `lib/keeper/keeper_agent_run.ml` | **-28** |
| `lib/keeper/keeper_agent_run_memory_compact.{ml,mli}` | +54 |
| `lib/dune` | +1 |

## 측정

- `keeper_agent_run.ml`: 2103 → **2075 (-1.3%)**
- 추정 -26, 실측 -28 (오차 +2, 정확도 92%)
- **누적 6 LOW sub-PR** = -249 LoC (2103 → **1854, -11.8%**)

## RFC-0145 LOW 6 sub-PR 완성!

| PR | LOC Δ |
|----|------|
| PR-1 Phase 0 telemetry | -36 |
| PR-3 Thinking blocks | -59 |
| PR-6 Receipt failure | -37 |
| PR-9 Phase 5 wire | -46 |
| PR-4-1 Memory write | -43 |
| **PR-4-3 (이 PR)** | **-28** |
| **LOW 6 합산** | **-249** |

audit 누적 추정 -254 → 실측 -249 (정확도 98%).

`keeper_agent_run.ml`: 2103 → **1854 LoC (-11.8%)**. RFC-0136 (-326, -15.5%) **76% 달성**.

## 보존 invariant

- Cancelled re-raise
- exn → dispatch_event_failures counter (site=compaction) + warn
- compaction.performed gate → Log.Keeper.info before/after/dropped

## Stacked-after

PR-1/3/6/9/4-1 (#16866/#16874/#16881/#16888/#16890). 6 영역 모두 독립.

## RFC

`docs/rfc/RFC-0145-keeper-agent-run-decomposition.md`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
