### PR TITLE
refactor(rfc-0145): PR-4-4 extract post-turn quality metrics (MEDIUM, RFC-0136 overtake)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -206,6 +206,7 @@
   keeper_agent_prompt_metrics
   keeper_agent_tool_surface
   keeper_agent_run_contract_helpers
+  keeper_agent_run_post_turn_eval
   keeper_agent_result
   keeper_agent_error
   keeper_agent_memory_episode

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1616,101 +1616,15 @@ let run_turn
                             (Printexc.to_string exn));
                        (* Post-turn quality metrics — goal alignment + memory recall.
              Logged to decisions.jsonl for feedback loop analysis. *)
-                       (try
-                          let goal_score =
-                            Keeper_memory_recall.goal_alignment_score
-                              ~meta
-                              ~user_message:None
-                              ~assistant_reply:(Some response_text)
-                          in
-                          let used_search =
-                            List.exists
-                              (fun t -> t = "keeper_memory_search")
-                              actual_keeper_tool_names
-                          in
-                          let recall_eval =
-                            if used_search
-                            then (
-                              let bank_path =
-                                Keeper_types_support.keeper_memory_bank_path
-                                  config
-                                  meta.name
-                              in
-                              let candidates =
-                                try
-                                  Keeper_memory_recall.load_history_user_messages
-                                    ~path:bank_path
-                                    ~max_n:50
-                                with
-                                | Eio.Cancel.Cancelled _ as e -> raise e
-                                | exn ->
-                                  Prometheus.inc_counter
-                                    Keeper_metrics.metric_keeper_dispatch_event_failures
-                                    ~labels:
-                                      [ "keeper", meta.name; "site", "memory_recall" ]
-                                    ();
-                                  Log.Keeper.warn
-                                    "keeper:%s memory recall history load failed: %s"
-                                    meta.name
-                                    (Printexc.to_string exn);
-                                  []
-                              in
-                              Some
-                                (Keeper_memory_recall.evaluate_memory_recall
-                                   ~user_message:""
-                                   ~assistant_reply:response_text
-                                   ~candidates))
-                            else None
-                          in
-                          let post_turn_ms =
-                            Keeper_timing.round1
-                              ((Time_compat.now () -. post_turn_t0) *. 1000.0)
-                          in
-                          let eval_json =
-                            `Assoc
-                              ([ "ts_unix", `Float (Time_compat.now ())
-                               ; "event", `String "post_turn_eval"
-                               ; "keeper_name", `String meta.name
-                               ; "turn", `Int manifest_keeper_turn_id
-                               ; "oas_turn_count", `Int result.turns
-                               ; "goal_alignment", `Float goal_score
-                               ; ( "tools_used_count"
-                                 , `Int (List.length actual_keeper_tool_names) )
-                               ; "used_memory_search", `Bool used_search
-                               ; "post_turn_ms", `Float post_turn_ms
-                               ]
-                               @ (match result.response.telemetry with
-                                  | Some t ->
-                                    [ ( "inference_telemetry"
-                                      , Keeper_hooks_oas.inference_telemetry_to_runtime_json t )
-                                    ]
-                                  | None -> [])
-                               @
-                               match recall_eval with
-                               | Some e ->
-                                 [ "memory_recall_performed", `Bool e.performed
-                                 ; "memory_recall_passed", `Bool e.passed
-                                 ; "memory_recall_score", `Float e.final_score
-                                 ; "memory_recall_candidates", `Int e.candidate_count
-                                 ]
-                               | None -> [])
-                          in
-                          Keeper_types_support.append_jsonl_line
-                            (Keeper_types_support.keeper_decision_log_path
-                               config
-                               meta.name)
-                            eval_json
-                        with
-                        | Eio.Cancel.Cancelled _ as e -> raise e
-                        | exn ->
-                          Prometheus.inc_counter
-                            Keeper_metrics.metric_keeper_dispatch_event_failures
-                            ~labels:[ "keeper", meta.name; "site", "post_turn_eval" ]
-                            ();
-                          Log.Keeper.warn
-                            "keeper:%s post_turn_eval jsonl append failed: %s"
-                            meta.name
-                            (Printexc.to_string exn));
+                       Keeper_agent_run_post_turn_eval.log_post_turn_eval
+                         ~config
+                         ~meta
+                         ~manifest_keeper_turn_id
+                         ~oas_turn_count:result.turns
+                         ~response_text
+                         ~actual_keeper_tool_names
+                         ~post_turn_t0
+                         ~telemetry:result.response.telemetry;
                        Ok
                          { response_text
                          ; model_used = model

--- a/lib/keeper/keeper_agent_run_post_turn_eval.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_eval.ml
@@ -1,0 +1,97 @@
+let log_post_turn_eval
+      ~config
+      ~(meta : Keeper_types.keeper_meta)
+      ~manifest_keeper_turn_id
+      ~oas_turn_count
+      ~response_text
+      ~actual_keeper_tool_names
+      ~post_turn_t0
+      ~telemetry
+  =
+  try
+    let goal_score =
+      Keeper_memory_recall.goal_alignment_score
+        ~meta
+        ~user_message:None
+        ~assistant_reply:(Some response_text)
+    in
+    let used_search =
+      List.exists
+        (fun t -> t = "keeper_memory_search")
+        actual_keeper_tool_names
+    in
+    let recall_eval =
+      if used_search
+      then (
+        let bank_path =
+          Keeper_types_support.keeper_memory_bank_path config meta.name
+        in
+        let candidates =
+          try
+            Keeper_memory_recall.load_history_user_messages
+              ~path:bank_path
+              ~max_n:50
+          with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | exn ->
+            Prometheus.inc_counter
+              Keeper_metrics.metric_keeper_dispatch_event_failures
+              ~labels:[ "keeper", meta.name; "site", "memory_recall" ]
+              ();
+            Log.Keeper.warn
+              "keeper:%s memory recall history load failed: %s"
+              meta.name
+              (Printexc.to_string exn);
+            []
+        in
+        Some
+          (Keeper_memory_recall.evaluate_memory_recall
+             ~user_message:""
+             ~assistant_reply:response_text
+             ~candidates))
+      else None
+    in
+    let post_turn_ms =
+      Keeper_timing.round1 ((Time_compat.now () -. post_turn_t0) *. 1000.0)
+    in
+    let eval_json =
+      `Assoc
+        ([ "ts_unix", `Float (Time_compat.now ())
+         ; "event", `String "post_turn_eval"
+         ; "keeper_name", `String meta.name
+         ; "turn", `Int manifest_keeper_turn_id
+         ; "oas_turn_count", `Int oas_turn_count
+         ; "goal_alignment", `Float goal_score
+         ; "tools_used_count", `Int (List.length actual_keeper_tool_names)
+         ; "used_memory_search", `Bool used_search
+         ; "post_turn_ms", `Float post_turn_ms
+         ]
+         @ (match telemetry with
+            | Some t ->
+              [ "inference_telemetry", Keeper_hooks_oas.inference_telemetry_to_runtime_json t ]
+            | None -> [])
+         @
+         match recall_eval with
+         | Some e ->
+           [ "memory_recall_performed", `Bool e.performed
+           ; "memory_recall_passed", `Bool e.passed
+           ; "memory_recall_score", `Float e.final_score
+           ; "memory_recall_candidates", `Int e.candidate_count
+           ]
+         | None -> [])
+    in
+    Keeper_types_support.append_jsonl_line
+      (Keeper_types_support.keeper_decision_log_path config meta.name)
+      eval_json
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_dispatch_event_failures
+      ~labels:[ "keeper", meta.name; "site", "post_turn_eval" ]
+      ();
+    Log.Keeper.warn
+      "keeper:%s post_turn_eval jsonl append failed: %s"
+      meta.name
+      (Printexc.to_string exn)
+;;

--- a/lib/keeper/keeper_agent_run_post_turn_eval.mli
+++ b/lib/keeper/keeper_agent_run_post_turn_eval.mli
@@ -1,0 +1,25 @@
+(** RFC-0145 PR-4-4: extract post-turn quality metrics from
+    [keeper_agent_run.run_turn] Step 8 body (L1617-L1713).
+
+    Computes goal-alignment score, optional memory-recall evaluation
+    (when [keeper_memory_search] was used), and emits a single
+    [post_turn_eval] JSONL line to
+    [Keeper_types_support.keeper_decision_log_path] for feedback-loop
+    analysis.
+
+    Side effects only.  [Eio.Cancel.Cancelled] re-raised; other
+    exceptions counter ([site=post_turn_eval]) + warn log.
+
+    [recall_eval] is only computed when [used_search = true]; loading
+    the history file is best-effort (counter + warn on read failure;
+    [candidates] falls back to []). *)
+val log_post_turn_eval
+  :  config:Coord.config
+  -> meta:Keeper_types.keeper_meta
+  -> manifest_keeper_turn_id:int
+  -> oas_turn_count:int
+  -> response_text:string
+  -> actual_keeper_tool_names:string list
+  -> post_turn_t0:float
+  -> telemetry:Agent_sdk.Types.inference_telemetry option
+  -> unit


### PR DESCRIPTION
## 요약

RFC-0145 PR-4-4 — `keeper_agent_run.run_turn` Step 8 body 의 post-turn quality metrics (L1617-L1713) 을 sibling typed module 로 추출. **MEDIUM tier 첫 sub-PR**.

## 변경

| 파일 | LoC |
|------|-----|
| `lib/keeper/keeper_agent_run.ml` | **-86** |
| `lib/keeper/keeper_agent_run_post_turn_eval.{ml,mli}` | +122 |
| `lib/dune` | +1 |

## 측정

- `keeper_agent_run.ml`: 2103 → **2017 (-4.1%)** — 단일 가장 큰 단일 sub-PR
- 추정 -84, 실측 -86 (오차 +2, 정확도 98%)
- **누적 7 sub-PR (LOW 6 + PR-4-4)** = -335 LoC (2103 → **1768, -15.9%**)

## RFC-0136 추월 달성

| Metric | RFC-0136 | RFC-0145 (7 sub-PR) |
|--------|----------|---------------------|
| LoC Δ | -326 | **-335** |
| 진척률 | -15.5% | **-15.9%** |

**RFC-0145 가 RFC-0136 실측 진폭을 추월** ✓

## 보존 invariant

- recall_eval None unless used_search = true
- candidates load 실패 시 memory_recall site counter + [] fallback
- outer try-with: post_turn_eval site counter + warn
- eval_json schema (inference_telemetry + memory_recall conditional fields) 동일

## Stacked-after

LOW 6 sub-PRs (#16866/#16874/#16881/#16888/#16890/#16892). 7 영역 모두 독립 (L565/L791/L1518/L1583/L1617/L1942/L2010).

## Anti-pattern 가드

- ✅ workaround 없음
- ✅ telemetry-as-fix 아님 (기존 post_turn_eval 블록 단순 추출)
- ✅ string classifier 없음
- ✅ N-of-M 없음

## RFC

`docs/rfc/RFC-0145-keeper-agent-run-decomposition.md`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
