### PR TITLE
fix(dashboard): consistent error.message unwrap in keeper-actions console.warn

### DIFF
--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -50,7 +50,10 @@ async function refreshDashboardState(): Promise<void> {
   try {
     await refreshDashboard({ force: true })
   } catch (err) {
-    console.warn('[keeper-runtime] dashboard refresh failed', err)
+    console.warn(
+      '[keeper-runtime] dashboard refresh failed',
+      err instanceof Error ? err.message : err,
+    )
   }
 }
 
@@ -136,7 +139,10 @@ export async function loadFullKeeperHistory(name: string): Promise<void> {
       // yet."  Logging surfaces the parse failure to DevTools while
       // normalizeStatusDetail still degrades gracefully (uses raw
       // text + null parsed).
-      console.warn('[keeper] masc_keeper_status response parse failed', { keeperName, err })
+      console.warn(
+        `[keeper] masc_keeper_status response parse failed for ${keeperName}:`,
+        err instanceof Error ? err.message : err,
+      )
       parsed = null
     }
     const detail = normalizeStatusDetail(keeperName, text, parsed)


### PR DESCRIPTION
## Summary

2 outlier `console.warn(..., err)` calls in `dashboard/src/keeper-actions.ts` (lines 53, 139) don't follow the file's dominant `err instanceof Error ? err.message : err` pattern (5/7 sites already use it). This PR makes it 7/7.

## Why this matters

`err` Error object renders inconsistently across browsers — Chrome expands into stack, Safari may render outer object wrapper as `[object Object]`. The ternary produces a deterministic single-line message scannable in any DevTools log column.

## Pattern stats

- This file: 5/7 → 7/7
- Whole `dashboard/src/`: 175 occurrences of same pattern — adoption dominant. Future RFC can extract `errorMessage(unknown): string` helper to migrate all 175 in one sweep. This PR's scope is one-file consistency.

## Verification

- `pnpm typecheck` clean
- `pnpm lint` clean (1 unrelated pre-existing warning)
- No tests reference these specific message strings

## Workaround Rejection Bar self-check
All 7 clear — log-message consistency fix, no behavior change.

## Test plan
- [x] typecheck + lint
- [ ] CI green after push

🤖 Generated with [Claude Code](https://claude.com/claude-code)