### PR TITLE
fix(streamable_http): include Yojson parse error msg in 400 response body

### DIFF
--- a/lib/streamable_http.ml
+++ b/lib/streamable_http.ml
@@ -141,8 +141,15 @@ let handle_post ?session_id ~body ?request_handler () =
   in
 
   match json_result with
-  | Error _ ->
-      (Error_response (400, "Invalid JSON"), None)
+  | Error parse_msg ->
+      (* Include the parser's position-bearing message in the 400 response
+         body. Yojson.Json_error carries "at line N, char M: <reason>",
+         which is bounded by the parser regardless of body size — no info
+         leak to the same client that sent the malformed body. Without
+         this, operators staring at a 400 cannot tell apart "trailing
+         comma at char 487" from "body was a binary blob". *)
+      ( Error_response (400, Printf.sprintf "Invalid JSON: %s" parse_msg),
+        None )
 
   | Ok json ->
       (* Find or create session if session_id provided *)

--- a/test/test_streamable_http.ml
+++ b/test/test_streamable_http.ml
@@ -46,12 +46,35 @@ let test_handle_post_valid_json () =
   | _ ->
       Alcotest.fail "expected Json_response"
 
+let contains_substring ~needle haystack =
+  let n = String.length needle in
+  let h = String.length haystack in
+  if n = 0 || n > h then n = 0
+  else (
+    let rec scan i =
+      if i + n > h then false
+      else if String.sub haystack i n = needle then true
+      else scan (i + 1)
+    in
+    scan 0)
+;;
+
 let test_handle_post_invalid_json () =
   let body = "not valid json" in
   let (response, _session) = SH.handle_post ~body () in
   match response with
-  | SH.Error_response (code, _msg) ->
-      Alcotest.(check int) "400 error" 400 code
+  | SH.Error_response (code, msg) ->
+      Alcotest.(check int) "400 error" 400 code;
+      (* The message must name itself as a JSON failure so operators
+         scanning logs can distinguish from other 400 paths (batch
+         rejection, internal validation, etc.). *)
+      Alcotest.(check bool) "msg labels itself 'Invalid JSON'" true
+        (contains_substring ~needle:"Invalid JSON" msg);
+      (* The message must carry the Yojson parser detail (position or
+         token reason) so the operator can locate the malformation
+         without re-running with debug logs. *)
+      Alcotest.(check bool) "msg longer than the bare label" true
+        (String.length msg > String.length "Invalid JSON")
   | _ ->
       Alcotest.fail "expected Error_response"
 


### PR DESCRIPTION
## Summary

`lib/streamable_http.ml:144` discards `Yojson.Json_error msg` via `Error _` and returns a bare 400 `\"Invalid JSON\"`. The msg is bound on line 130 only to be erased one line below.

## Before / after

```
- 400 Invalid JSON
+ 400 Invalid JSON: Line 1, bytes 0-3:
+ Unexpected character 'n'
```

Bounded by the parser regardless of body size. No info leak back to the same client that already sent the bad body.

## Continuation

Operator-clarity sweep iter#72→#73→#74→#75→#76→#77→#80→this. Same shape each time: payload bound then discarded next line.

## Test strengthening

`test_handle_post_invalid_json` previously asserted only `code = 400` with `_msg`. Now asserts:
1. msg contains literal `Invalid JSON` (label preserved)
2. msg is longer than the bare label (regression lock)

## Verification

- Streamable_http cmx clean
- 10/10 test_streamable_http PASS (verified with iter#78+#79 pre-existing main breaks temporarily applied locally, then reverted before commit — diff is scope-clean: 2 files only)

## Workaround Rejection Bar self-check
All 7 clear. Strengthens existing error path, removes a `_` catch.

## Test plan
- [x] cmx + 10/10 PASS
- [ ] CI green after push

🤖 Generated with [Claude Code](https://claude.com/claude-code)