### PR TITLE
refactor(server): migrate dashboard_http local json helpers to Json_field (RFC-0142 PR-5)

### DIFF
--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -516,17 +516,22 @@ let compact_receipt_tool_surface_json =
   Server_dashboard_compact_receipt_json.compact_receipt_tool_surface_json
 ;;
 
+(* RFC-0142 PR-5: lift the silent [| _ -> None] catch-all through
+   [Json_field.{float,assoc} |> to_option] so Wrong_shape becomes
+   structurally distinct from Field_absent. Caller semantics
+   unchanged: both legacy and new shapes return [None] on missing
+   key or mismatched JSON variant. [Json_field.float] accepts both
+   [`Float] and [`Int] (returning [float_of_int i]), matching the
+   legacy 2-arm match. *)
+
 let json_number key json =
-  match json_member key json with
-  | `Float value -> Some value
-  | `Int value -> Some (float_of_int value)
-  | _ -> None
+  Json_field.float json key |> Json_field.to_option
 ;;
 
 let json_assoc key json =
-  match json_member key json with
-  | `Assoc _ as value -> Some value
-  | _ -> None
+  Json_field.assoc json key
+  |> Json_field.to_option
+  |> Option.map (fun fields -> `Assoc fields)
 ;;
 
 let string_has_prefix ~prefix value =


### PR DESCRIPTION
## Summary

RFC-0142 PR-5: fourth [Json_field] consumer. Migrates the 2 local
silent catch-all helpers in [server_dashboard_http.ml] (1418 LoC file)
through [Json_field |> to_option].

## Migrated helpers (2 sites)

| Helper | Before | After |
|---|---|---|
| \`json_number\` | \`Float / Int / _ -> None\` | \`Json_field.float \|> to_option\` |
| \`json_assoc\` | \`Assoc _ as v -> Some v / _ -> None\` | \`Json_field.assoc \|> Option.map \\\`Assoc\` |

\`Json_field.float\` already accepts both \`\\\`Float\` and \`\\\`Int\` (returning
\`float_of_int i\`), matching the legacy 2-arm match exactly.

## Behavioural diff

Caller-visible semantics: **unchanged**. Wrong_shape collapses to None.

Type-system: Field_absent vs Wrong_shape now structurally distinct.

## Out of scope

- \`json_member\` is the defensive \`\\\`Assoc-only-else-Null wrapper used by
  30+ call sites in this file. Not the silent-failure pattern itself.
  Eliminating it requires touching all callers — bigger than RFC-0142
  mechanical migration scope.

## Files

- \`lib/server/server_dashboard_http.ml\` — 2 sites, +12 / -7

## RFC-0142 progress

| PR | File | Sites | Status |
|---|---|---|---|
| #16790 PR-1 | Json_field module + tests | foundation | MERGED |
| (squash) PR-2 | cascade_error_classify | 3 | MERGED |
| (squash) PR-3 | telemetry_unified | 2 | MERGED |
| #16894 PR-4 | dashboard_http_helpers | 4 | OPEN |
| **this PR** | server_dashboard_http (local) | 2 | OPEN |

## RFC-0088 §3 self-check

- §3.1 telemetry-as-fix: **no**
- §3.2 string classifier: **no**
- §3.3 N-of-M patch: PR-5 of RFC-0142 stack; each migration is a
  separable consumer and the file selection follows §4 boundary scan.
- §3.4 symptom suppression: **no** — eliminates catch-all.

## Test plan

- [x] \`dune build --root . lib/server/server_dashboard_http.ml\` clean
- [ ] CI build_test pipeline

RFC: \`docs/rfc/RFC-0142-typed-yojson-field-extraction.md\`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>