### PR TITLE
fix(fs_compat): include 1-based line number in parse_jsonl_lines malformed log

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -470,9 +470,16 @@ let mkdir_p (path : string) : unit =
 
 (** Parse pre-read string lines as JSONL.
     Use when lines come from [Keeper_memory.read_file_tail_lines] or
-    other non-file sources.  Logs malformed lines with [source] tag. *)
+    other non-file sources.  Logs malformed lines with [source] tag.
+
+    Matches [fold_jsonl]'s line-tracking semantics: [line_no] is
+    1-based, increments only on non-blank lines so it tracks the
+    {b printed} JSONL row number an operator would see in [cat -n].
+    Aligns with the file-level diagnostic at line 559 ("line %d") so
+    a malformed log from either path uses the same coordinate system. *)
 let parse_jsonl_lines ~(source : string) (lines : string list) : Yojson.Safe.t list * int =
   let malformed = ref 0 in
+  let line_no = ref 0 in
   let parsed =
     List.filter_map
       (fun line ->
@@ -480,11 +487,16 @@ let parse_jsonl_lines ~(source : string) (lines : string list) : Yojson.Safe.t l
          if String.equal trimmed ""
          then None
          else (
+           incr line_no;
            match Yojson.Safe.from_string trimmed with
            | json -> Some json
            | exception Yojson.Json_error msg ->
              incr malformed;
-             Stdlib.Printf.eprintf "[fs_compat] malformed JSONL (%s): %s\n%!" source msg;
+             Stdlib.Printf.eprintf
+               "[fs_compat] malformed JSONL (%s) line %d: %s\n%!"
+               source
+               !line_no
+               msg;
              None))
       lines
   in


### PR DESCRIPTION
## Summary

`parse_jsonl_lines` emits stderr on malformed lines but *not* the file-relative line number, while the sibling `fold_jsonl` (same file, line 559) already does. Operators reading interleaved stderr from both paths see two coordinate systems.

## Fix

Track 1-based line_no incrementing only on non-blank lines (matches `fold_jsonl`'s "printed JSONL row number an operator sees in `cat -n`" semantics, doc-commented at line 549).

## Before / after

```
- [fs_compat] malformed JSONL (path): Line 1, bytes 5-9: Unexpected character 'X'
+ [fs_compat] malformed JSONL (path) line 7: Line 1, bytes 5-9: Unexpected character 'X'
```

`line 7` is file-relative; `Line 1, bytes 5-9` is Yojson's intra-line position.

## Continuation

Operator-clarity sweep iter#72→#73→#74→#75→#76→#77→#80→#81→this. Same shape: bound coordinate discarded next surface.

## Verification

- fs_compat lib clean
- test_fs_compat 11/11, test_tool_call_replay_harness 6/6 PASS
- Test substring `"malformed JSONL line"` in tool_call_replay_harness comes from a *different* error path (Tool_call_replay_harness.errorf), not affected
- Verified with iter#78+#79 pre-existing main breaks temporarily applied locally to unblock test exe build, then reverted — diff scope-clean

## Workaround Rejection Bar self-check
All 7 clear. Aligns 2 sibling diagnostics that were already supposed to be aligned.

## Test plan
- [x] 11/11 + 6/6 PASS
- [ ] CI green after push

🤖 Generated with [Claude Code](https://claude.com/claude-code)