### PR TITLE
test(dashboard): align IDE context label ellipsis

### DIFF
--- a/dashboard/src/components/ide/ide-context-lens.test.ts
+++ b/dashboard/src/components/ide/ide-context-lens.test.ts
@@ -407,7 +407,7 @@ describe('IdeContextLens', () => {
         file: 'lib/keeper/keeper_exec_ide.ml',
         line: '22',
         surface: 'LSP',
-        label: 'This expression has type string but an int wa...',
+        label: 'This expression has type string but an int was …',
         source_id: 'diagnostic-22-ocamllsp-type-0',
       },
     })


### PR DESCRIPTION
## Summary
- align the IDE context lens diagnostic route-label expectation with the shared dashboard `truncate()` contract
- close the latest main Dashboard CI failure where the production label uses Unicode ellipsis

Fixes #16900

## Evidence
- `pnpm install --frozen-lockfile --offline`
- `pnpm vitest run --config vitest.config.ts src/components/ide/ide-context-lens.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm eslint src/components/ide/ide-context-lens.test.ts`
- `pnpm tsc --noEmit --pretty`
- `git diff --check`

## CI context
Latest main Dashboard job `76886466629` in run `26139033404` failed because `ide-context-lens.test.ts` expected ASCII `...`, while the shared truncate helper emits `…`.