### PR TITLE
fix(run_eio + ids): operator-actionable context in 3 decode error paths

### DIFF
--- a/lib/run_eio.ml
+++ b/lib/run_eio.ml
@@ -107,11 +107,18 @@ let write_run config (run : run_record) =
 let read_run config task_id : (run_record, string) result =
   let path = run_json_path config task_id in
   if not (path_exists config path) then
-    Error (Printf.sprintf "Run not found for task %s" task_id)
+    Error (Printf.sprintf "Run not found for task %s (expected at %s)" task_id path)
   else
     match run_record_of_json (read_json config path) with
     | Some r -> Ok r
-    | None -> Error "Failed to parse run.json"
+    | None ->
+      Error
+        (Printf.sprintf
+           "Failed to parse run.json at %s (task %s) — file exists but \
+            run_record_of_json returned None; check schema drift or \
+            truncated write"
+           path
+           task_id)
 
 (** Initialize run for task *)
 let init config ~task_id ~agent_name : (run_record, string) result =

--- a/lib/types/ids.ml
+++ b/lib/types/ids.ml
@@ -227,9 +227,27 @@ let make_global_id ~type_ id =
   Base64.encode_string raw
 
 let decode_global_id s =
+  (* Truncate the input preview to bound log size when [s] is large
+     (callers receive arbitrary strings from external systems). 32 bytes
+     is enough to identify the shape (type prefix, length class) without
+     dumping a full malicious payload into the error path. *)
+  let preview =
+    if String.length s <= 32 then s
+    else Printf.sprintf "%s… (%d bytes total)" (String.sub s 0 32) (String.length s)
+  in
   match Base64.decode s with
   | Ok decoded -> (
       match String.split_on_char ':' decoded with
       | type_ :: rest -> Ok (type_, String.concat ":" rest)
-      | _ -> Error "Invalid global ID format")
-  | Error _ -> Error "Invalid base64"
+      | _ ->
+        Error
+          (Printf.sprintf
+             "Invalid global ID format: decoded %S missing 'type:id' separator (input %S)"
+             decoded
+             preview))
+  | Error (`Msg b64_msg) ->
+    Error
+      (Printf.sprintf
+         "Invalid base64: %s (input %S)"
+         b64_msg
+         preview)


### PR DESCRIPTION
## Summary

3 error sites in 2 files where context was in scope but discarded.

## Sites

`lib/run_eio.ml:114` — `Error \"Failed to parse run.json\"`:
- Path + task_id in scope but unused
- Now includes both + an operator hint: "file exists but parse returned None — check schema drift or truncated write"
- Bonus: sibling `Run not found` path also gains the expected path

`lib/types/ids.ml:235` — `Error _ -> Error \"Invalid base64\"`:
- `Base64.decode` returns `(string, [> \`Msg of string ]) result` — the \`Msg payload was discarded
- Now: `Invalid base64: <decode-supplied msg> (input \"<32-byte preview>...\")`
- Truncation pattern matches iter#73 #16825 type_name

`lib/types/ids.ml:234` — `Error \"Invalid global ID format\"`:
- Sibling arm — now includes the decoded payload (UTF-8 safe post-base64) and same input preview

## Continuation

Operator-clarity sweep iter#72→#73→#74→#75→#76→#77→#80→#81→#82→this.

## Verification

- types + run_eio cmx builds clean
- 33/33 test_run_eio_coverage PASS
- 0 test references to the literal strings
- Verified with iter#78+#79 pre-existing main breaks temporarily applied locally then reverted — diff scope-clean

## Workaround Rejection Bar self-check
All 7 clear. Notable: catch-all `Error _` removed (replaced with `\`Msg b64_msg`).

## Test plan
- [x] 33/33 PASS
- [ ] CI green after push

🤖 Generated with [Claude Code](https://claude.com/claude-code)