### PR TITLE
fix(ci): unblock main @check (post-#16802 eio dep + post-#16870 type rename)

### DIFF
--- a/lib/dashboard_eval_feed/dune
+++ b/lib/dashboard_eval_feed/dune
@@ -2,7 +2,8 @@
 ; masc_mcp namespace. Stacked on Phase 1D (briefing_compactors).
 ;
 ; Dashboard_eval_feed is dependency-leaf: stdlib + Yojson + Agent_sdk
-; (external) + Json_util/Safe_ops (masc_core sub-library). 178+59 LoC,
+; (external) + Json_util/Safe_ops (masc_core sub-library) + Eio.Cancel
+; for cancellation re-raise (added 2026-05-20 with #16802). 178+59 LoC,
 ; fan-in 5 (3 lib + 1 test, all callers verified leaf-clean against
 ; the new sub-library boundary).
 ;
@@ -18,4 +19,6 @@
  (libraries
   yojson
   agent_sdk
+  eio
+  masc_log
   masc_core))

--- a/lib/keeper/keeper_shell_bash_typed_input.mli
+++ b/lib/keeper/keeper_shell_bash_typed_input.mli
@@ -5,8 +5,8 @@ val assoc_upsert : string -> Yojson.Safe.t -> Yojson.Safe.t -> Yojson.Safe.t
 val shell_quote_for_policy : string -> string
 
 val typed_stage_command_text : executable:string -> argv:string list -> string
-val typed_input_command_text : Keeper_tool_bash_input.t -> string
-val typed_input_has_env : Keeper_tool_bash_input.t -> bool
+val typed_input_command_text : Keeper_tool_bash_input.bash_input -> string
+val typed_input_has_env : Keeper_tool_bash_input.bash_input -> bool
 
 val typed_validation_error_text
   :  Keeper_tool_bash_input.validation_error


### PR DESCRIPTION
## Summary

Two pre-existing main breakages, both confirmed locally via
\`dune build --root . @check\` EXIT≠0 on \`origin/main\` \`a8ebbeb28b\`.

Both fixes are mechanical and unblock the entire in-flight PR cascade
(every Draft against current main is failing CI for these reasons).

## Fixes

### 1. \`lib/dashboard_eval_feed/dune\` — missing eio + masc_log deps

#16802 (merged 2h ago) added \`Eio.Cancel.Cancelled\` re-raise and
\`Log.Dashboard.warn\` to \`dashboard_eval_feed.ml\` without updating
the sub-library's dune dep list. Sub-library was declared
dependency-leaf (stdlib + Yojson + Agent_sdk + masc_core) but now
genuinely needs \`eio\` + \`masc_log\`.

### 2. \`lib/keeper/keeper_shell_bash_typed_input.mli\` — typo

#16870 (merged 4h ago) introduced the .mli with \`Keeper_tool_bash_input.t\`
references, but the underlying type defined in \`keeper_tool_bash_input.mli\`
is named \`bash_input\`, not \`t\`. The .ml implementation matches on
\`.Exec\` / \`.Pipeline\` constructors of \`bash_input\`, confirming intent.

Zero downstream callers reference \`Keeper_tool_bash_input.t\` (grep verified).
Safe mechanical rename.

## Anti-pattern echo

Both match \`feedback_ci_sandbox_path_filter_masks_syntax_bugs\` (2026-05-20):
PR author's local sandbox-aware build passes (path filter limits
compilation to changed files) but full @check fails because untouched
downstream consumers re-typecheck against the modified surface.

This is the second occurrence today. The pattern is mature enough to
warrant a CI safeguard: a parallel \`dune build --root . @check\` (no
sandbox filter) as a hard gate before merge. Tracked separately.

## Files

- \`lib/dashboard_eval_feed/dune\` — +2 -1 (eio + masc_log lines)
- \`lib/keeper/keeper_shell_bash_typed_input.mli\` — +2 -2 (type rename ×2)

## Test plan

- [x] \`dune build --root . @check\` EXIT=0 locally (was failing)
- [ ] CI: Build and Test + Lint + Health green
- [ ] Cascade: 5 in-flight PRs unblocked

## In-flight cascade beneficiaries

- #16860 RFC-0143 PR-1 keeper_cascade_profile bridge
- #16887 RFC-0141 PR-2 repo_store
- #16889 RFC-0141 PR-3 credential_store
- #16894 RFC-0142 PR-4 dashboard_http_helpers
- #16899 RFC-0142 PR-5 server_dashboard_http

All 5 share the same CI failure signature and will benefit from
this fix landing.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>