### PR TITLE
refactor(eio_context): drop unused masc_log opam dep

### DIFF
--- a/lib/eio_context/dune
+++ b/lib/eio_context/dune
@@ -6,4 +6,4 @@
  (modules eio_context)
  ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 enabled. Leaf util sublib.
  (flags (:standard -w +4))
- (libraries eio eio.unix uri masc_log ca-certs tls tls-eio domain-name))
+ (libraries eio eio.unix uri ca-certs tls tls-eio domain-name))


### PR DESCRIPTION
## Summary

\`lib/eio_context/dune:9\` declares \`masc_log\` as a library dependency, but neither \`lib/eio_context/eio_context.ml\` (211 LoC) nor \`lib/eio_context/eio_context.mli\` (96 LoC) references the \`Log\` module.

This is the **mirror** of PR #16877's missing-dep audit (Eio/Log added to dashboard_eval_feed). Symmetric pattern — unused dep accreted in a leaf sublib without ever being consumed.

## Verification

\`\`\`bash
$ /usr/bin/grep -c \"Log\" lib/eio_context/eio_context.ml lib/eio_context/eio_context.mli
lib/eio_context/eio_context.ml:0
lib/eio_context/eio_context.mli:0

$ opam exec -- dune build --root . lib/eio_context/  # exit 0 after dep removal
\`\`\`

Sibling lib audit (~35 \`lib/*/dune\` files) found 0 other unused deps; PPX/derivers and \`unix\`/\`threads.posix\`/\`str\` correctly excluded as false-positive risks.

## Workaround Rejection Bar self-check

- §1 telemetry-as-fix: not applicable.
- §2 string classifier: none.
- §3 N-of-M: single-line dep removal in single file; verified no sibling dune file shares the same dep-drift pattern.
- catch-all / cap / cooldown: none.

## Build dependency

Builds clean locally after cherry-picking the in-flight #16879 main-build hotfix.

## Audit context (Iter 6)

| PR | Surface |
|---|---|
| #16830~#16897 | (Iter 1-5 dead surfaces) |
| **this PR** | **1 unused \`masc_log\` opam dep in \`lib/eio_context/dune\`** |

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>