### PR TITLE
refactor(keeper_context_core): extract tool block text renderers into sibling

### DIFF
--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -282,38 +282,19 @@ let trim_messages_preserving_pairs
     in
     List.filteri (fun i _ -> i >= effective_drop) messages
 
-let tool_result_text_of_block
-    ~(tool_use_id : string)
-    ~(content : string)
-    ~(json : Yojson.Safe.t option) : string =
-  let content = Inference_utils.sanitize_text_utf8 (String.trim content) in
-  if content <> "" then content
-  else
-    match json with
-    | Some value ->
-        (* Stringify json only when it fits the per-result cap. Larger
-           payloads collapse to a stub so a single orphan-repair pass
-           cannot inflate one Text block to multi-MB and trigger the same
-           escape-depth blow-up that motivated the artifact-store work
-           (see [tool_blob_store] and the tool-output-washing series). *)
-        let serialized = Yojson.Safe.to_string value in
-        let len = String.length serialized in
-        if len <= default_max_checkpoint_tool_result_chars then serialized
-        else
-          Printf.sprintf "[tool:json id:%s bytes:%d elided]" tool_use_id len
-    | None -> Printf.sprintf "[tool result %s]" tool_use_id
+(* Tool block text renderers extracted to
+   [Keeper_context_tool_text_block] (godfile decomp). Parent wrapper
+   injects [default_max_checkpoint_tool_result_chars] so the existing
+   surface (no [~max_chars] arg) stays byte-compatible for callers. *)
+let tool_result_text_of_block ~tool_use_id ~content ~json =
+  Keeper_context_tool_text_block.tool_result_text_of_block
+    ~tool_use_id
+    ~content
+    ~json
+    ~max_chars:default_max_checkpoint_tool_result_chars
+;;
 
-let tool_use_text_of_block
-    ~(tool_use_id : string)
-    ~(tool_name : string)
-    ~(input : Yojson.Safe.t) : string =
-  let tool_name = Inference_utils.sanitize_text_utf8 (String.trim tool_name) in
-  let tool_use_id = Inference_utils.sanitize_text_utf8 (String.trim tool_use_id) in
-  let tool_name =
-    if tool_name = "" then "unknown_tool" else tool_name
-  in
-  let input_json = Yojson.Safe.to_string input |> Inference_utils.sanitize_text_utf8 in
-  Printf.sprintf "[tool use %s %s input=%s]" tool_name tool_use_id input_json
+let tool_use_text_of_block = Keeper_context_tool_text_block.tool_use_text_of_block
 
 type tool_pair_repair_stats =
   { downgraded_tool_uses : int

--- a/lib/keeper/keeper_context_tool_text_block.ml
+++ b/lib/keeper/keeper_context_tool_text_block.ml
@@ -1,0 +1,52 @@
+(* Tool-use / tool-result block text renderers for the keeper context.
+
+   These build the *text-block fallback* shown when a structured
+   ToolUse/ToolResult message must be flattened into plain text - for
+   downgrade fallbacks (orphan repair) and for verifier-facing
+   serializations.
+
+   Cap-aware: ToolResult JSON over [max_chars] collapses to a stub so
+   one orphan-repair pass cannot inflate one Text block to multi-MB
+   and trigger the same escape-depth blow-up that motivated the
+   artifact-store work (see [tool_blob_store] + tool-output-washing
+   series).
+
+   Extracted from [Keeper_context_core] (godfile decomp). Pure mapping
+   over the input - the per-result cap is injected by the caller so
+   this module has no dependency on parent constants. *)
+
+let tool_result_text_of_block
+      ~(tool_use_id : string)
+      ~(content : string)
+      ~(json : Yojson.Safe.t option)
+      ~(max_chars : int)
+  : string
+  =
+  let content = Inference_utils.sanitize_text_utf8 (String.trim content) in
+  if content <> ""
+  then content
+  else (
+    match json with
+    | Some value ->
+      let serialized = Yojson.Safe.to_string value in
+      let len = String.length serialized in
+      if len <= max_chars
+      then serialized
+      else Printf.sprintf "[tool:json id:%s bytes:%d elided]" tool_use_id len
+    | None -> Printf.sprintf "[tool result %s]" tool_use_id)
+;;
+
+let tool_use_text_of_block
+      ~(tool_use_id : string)
+      ~(tool_name : string)
+      ~(input : Yojson.Safe.t)
+  : string
+  =
+  let tool_name = Inference_utils.sanitize_text_utf8 (String.trim tool_name) in
+  let tool_use_id = Inference_utils.sanitize_text_utf8 (String.trim tool_use_id) in
+  let tool_name = if tool_name = "" then "unknown_tool" else tool_name in
+  let input_json =
+    Yojson.Safe.to_string input |> Inference_utils.sanitize_text_utf8
+  in
+  Printf.sprintf "[tool use %s %s input=%s]" tool_name tool_use_id input_json
+;;

--- a/lib/keeper/keeper_context_tool_text_block.mli
+++ b/lib/keeper/keeper_context_tool_text_block.mli
@@ -1,0 +1,19 @@
+(** Tool-use / tool-result block text renderers. *)
+
+(** Build the text fallback for a ToolResult.  When [content] is empty,
+    serialize [json] if it fits within [max_chars]; otherwise emit
+    [\[tool:json id:_ bytes:_ elided\]]. *)
+val tool_result_text_of_block
+  :  tool_use_id:string
+  -> content:string
+  -> json:Yojson.Safe.t option
+  -> max_chars:int
+  -> string
+
+(** Build the text fallback for a ToolUse, sanitizing [tool_name] /
+    [tool_use_id] and serializing [input] inline. *)
+val tool_use_text_of_block
+  :  tool_use_id:string
+  -> tool_name:string
+  -> input:Yojson.Safe.t
+  -> string


### PR DESCRIPTION
## 요약

`keeper_context_core.ml` (1471 LoC godfile) 의 tool block text renderer cluster 를 신규 sibling 모듈로 추출했습니다. **-19 LoC** (1471 → 1452).

PR #16884 (tool_message_pairs) 와 같은 godfile 의 두 번째 분해. 본 추출은 **단독 LoC reduction 이 작지만 (-19)** 후속 `tool_pair_repair` 추출의 prerequisite — repair 함수들이 본 cluster 의 text renderer 를 호출하므로 먼저 분리.

## 추출 surface (2 pure renderers)

| 함수 | 시그니처 |
|---|---|
| `tool_result_text_of_block` | `~tool_use_id ~content ~json ~max_chars -> string` |
| `tool_use_text_of_block` | `~tool_use_id ~tool_name ~input -> string` |

## 신규 모듈

- `lib/keeper/keeper_context_tool_text_block.ml` (52 LoC)
- `lib/keeper/keeper_context_tool_text_block.mli` (19 LoC)

## 패턴: dependency-injection extraction

- sibling 이 parent 상수 (`default_max_checkpoint_tool_result_chars`) 를 *직접 참조 안 함* — `~max_chars` 로 inject 받음
- parent wrapper 가 상수 주입 → 기존 caller signature 는 그대로 (4 arg, no `~max_chars`):

```ocaml
let tool_result_text_of_block ~tool_use_id ~content ~json =
  Keeper_context_tool_text_block.tool_result_text_of_block
    ~tool_use_id ~content ~json
    ~max_chars:default_max_checkpoint_tool_result_chars
```

이전 24 PR 의 single-pattern alias 와 차이: sibling 이 자유로워져서 다른 caller 가 다른 cap 으로 호출 가능 (e.g. test 가 작은 cap, repair sibling 이 다른 cap).

## 의존성 (Stdlib + dependency module)

- `Inference_utils.sanitize_text_utf8`
- `Yojson.Safe.{t, to_string}`
- `String.trim`, `Printf.sprintf`

Shared state 0. Side effect 0.

## 외부 caller 호환

- `test/test_keeper_context_core_dedup.ml` 5 site (`C.tool_result_text_of_block`) → parent wrapper 가 기존 `~tool_use_id ~content ~json` signature 유지 → 변경 0
- `keeper_context_core.mli` 의 `tool_result_text_of_block` 시그니처 변경 0 (wrapper 가 surface 유지)
- `tool_use_text_of_block` 는 `.mli` 미노출 (private)

## 검증

- [x] `dune build --root . lib/keeper` PASS
- [x] 함수 body 1-to-1 카피 + max_chars 외부 주입
- [x] escape-bomb 보호 semantic byte-identical (json bytes > max_chars → `[tool:json id:_ bytes:_ elided]`)

## 패턴

**Dependency-injection extraction**. 기존 patterns 와 차이는 sibling 이 parent 상수를 *직접 참조하지 않고* signature 에 받음.

후속 candidate: `tool_pair_repair_stats` + `repair_dangling_tool_use_messages_with_stats` + `repair_orphan_tool_result_messages_with_stats` cluster (~150 LoC) 가 본 모듈의 text renderer 를 호출 — 본 PR 머지 후 추출 가능.

## Workaround Rejection Bar self-check

1. [ ] makes X visible only — NO
2. [ ] string classifier — NO
3. [ ] N-of-M — NO (전체 cluster 이동)
4. [ ] catch-all `_ ->` 추가 — NO
5. [ ] cap/cooldown/dedup/repair — NO (cap 은 *기존* 8K char limit; 새 cap 추가 아님)
6. [ ] test backdoor — NO
7. [ ] N-사이트 typo — NO

PASS — pure refactor + DI improvement.

## RFC

RFC-WAIVED: `keeper_context_tool_text_block` 는 RFC-gated subsystem 아님.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
