### PR TITLE
fix(ids, keeper_id): operator-actionable Trace_id / Task_id validation errors

### DIFF
--- a/lib/keeper/keeper_id.ml
+++ b/lib/keeper/keeper_id.ml
@@ -20,13 +20,34 @@ module Keeper_name = struct
   let equal = String.equal
 end
 
+(* Bounded preview for id validation error messages — these ids
+   originate from external requests / config / JSON; full dump risks
+   log spam on bad input. 32 bytes matches the pattern from iter#83
+   [decode_global_id] (#16903) and iter#84 [Ids.Trace_id]. *)
+let preview_id s =
+  if String.length s <= 32 then s
+  else Printf.sprintf "%s… (%d bytes total)" (String.sub s 0 32) (String.length s)
+;;
+
 module Trace_id = struct
   type t = string
   let is_valid s =
     s <> "." && s <> ".." && Keeper_name.is_valid s
   let of_string s =
     if is_valid s then Ok s
-    else Error "Invalid trace_id"
+    else (
+      (* Branch on specific failure so operators see which constraint
+         rejected the input rather than the bare label.  Order matches
+         [is_valid]'s short-circuit evaluation. *)
+      let reason =
+        if String.equal s "." then "reserved name '.'"
+        else if String.equal s ".." then "reserved name '..'"
+        else if String.length s = 0 then "empty string"
+        else if String.length s > 64
+        then Printf.sprintf "length %d exceeds 64" (String.length s)
+        else "contains characters outside [A-Za-z0-9_-]"
+      in
+      Error (Printf.sprintf "Invalid trace_id %S: %s" (preview_id s) reason))
   let to_string s = s
   let equal = String.equal
 end
@@ -36,7 +57,9 @@ module Task_id = struct
   let is_valid s = String.length s > 0
   let of_string s =
     if is_valid s then Ok s
-    else Error "Invalid task_id"
+    else
+      Error
+        (Printf.sprintf "Invalid task_id %S: empty string" (preview_id s))
   let to_string s = s
   let equal = String.equal
 end

--- a/lib/types/ids.ml
+++ b/lib/types/ids.ml
@@ -176,18 +176,48 @@ end = struct
   module Trace_id = struct
     type t = string
     let is_valid s = s <> "." && s <> ".." && Keeper_name.is_valid s
+
+    (* Bounded preview for error messages — trace_id inputs originate
+       from external requests / config files; full dump risks log
+       spam on bad input. 32 bytes matches the pattern from iter#83
+       [decode_global_id] (#16903). *)
+    let preview s =
+      if String.length s <= 32 then s
+      else Printf.sprintf "%s… (%d bytes total)" (String.sub s 0 32) (String.length s)
+
     let of_string s =
       if is_valid s then Ok s
-      else Error "Invalid trace_id"
+      else (
+        (* Branch on the specific failure so operators see which
+           constraint rejected the input rather than the bare label.
+           Order matches [is_valid]'s short-circuit evaluation. *)
+        let reason =
+          if String.equal s "." then "reserved name '.'"
+          else if String.equal s ".." then "reserved name '..'"
+          else if String.length s = 0 then "empty string"
+          else if String.length s > 64
+          then Printf.sprintf "length %d exceeds 64" (String.length s)
+          else "contains characters outside [A-Za-z0-9_-]"
+        in
+        Error (Printf.sprintf "Invalid trace_id %S: %s" (preview s) reason))
     let to_string s = s
     let equal = String.equal
   end
   module Task_id = struct
     type t = string
     let is_valid s = String.length s > 0
+
+    (* Same 32-byte preview pattern as [Trace_id.preview] for log
+       size bounding on external input. *)
+    let preview s =
+      if String.length s <= 32 then s
+      else Printf.sprintf "%s… (%d bytes total)" (String.sub s 0 32) (String.length s)
+
     let of_string s =
       if is_valid s then Ok s
-      else Error "Invalid task_id"
+      else
+        Error
+          (Printf.sprintf "Invalid task_id %S: empty string" (preview s))
     let to_string s = s
     let equal = String.equal
   end


### PR DESCRIPTION
## Summary

`Trace_id.of_string` and `Task_id.of_string` are defined identically in two sibling modules (`lib/types/ids.ml` + `lib/keeper/keeper_id.ml`) and both used bare labels `\"Invalid trace_id\"` / `\"Invalid task_id\"`. Operators saw neither the input nor *which constraint* rejected it.

## Fix

Branch on failure reason + bounded 32-byte preview (matches iter#83 #16903 pattern):

```
Invalid trace_id "..": reserved name '..'
Invalid trace_id "with spaces": contains characters outside [A-Za-z0-9_-]
Invalid trace_id "<65-char>": length 65 exceeds 64
Invalid task_id "": empty string
```

## Why both modules

`keeper_id.ml:23-42` duplicates `ids.ml:176-194` verbatim. Aligning both copies in one PR prevents the second-discovery iter pattern. The duplication itself deserves a future RFC to canonicalize.

## Caller impact

13 lib + 2 test callers. All propagate Error string into logs/upstream; none pattern-match on literal `\"Invalid trace_id\"` / `\"Invalid task_id\"` (0 test hits).

## Verification

- types + keeper libs build clean
- 5/5 test_keeper_id PASS
- Verified with iter#78+#79 pre-existing main breaks temporarily applied locally then reverted — diff scope-clean

## Workaround Rejection Bar self-check
All 7 clear. The 2-module duplication is *pre-existing*; this PR aligns error messages, not creates the duplication.

## Continuation
Operator-clarity sweep iter#72→#73→#74→#75→#76→#77→#80→#81→#82→#83→this.

## Test plan
- [x] 5/5 PASS
- [ ] CI green after push

🤖 Generated with [Claude Code](https://claude.com/claude-code)