### PR TITLE
refactor(dashboard/keeper-detail): 상단 영역 중복/모순/노이즈 정리 (7 ckpt)

### DIFF
--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -484,6 +484,7 @@ const TURN_TERMINAL_FAILURE_CODES = new Set<string>([
   'oas_timeout_budget',
   'oas_timeout_budget_loop',
   'turn_timeout',
+  'turn_wall_clock_timeout',
   'cascade_exhausted',
   'heartbeat_consecutive_failures',
   'turn_consecutive_failures',

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -247,14 +247,18 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
   const pausedRuntimeBlocker = isPaused && runtimeBlockerClass != null
   const attentionReasonText = attentionReasonLabel(attentionReason, isPaused)
   const nextHumanActionText = nextHumanActionLabel(nextHumanAction)
-  // Suppress "다음 액션" when it duplicates the visible "주의 사유" line
-  // above (e.g. runtime_blocked + inspect_runtime_blocker render as
-  // "런타임 근거 확인 필요" / "런타임 근거 확인"). If attentionReasonText
-  // is null (paused suppresses the reason line) we keep next_human_action
-  // visible so the operator still sees what to do.
-  const suppressDuplicateNextAction =
+  // Suppress action-lines that duplicate the visible "주의 사유" line
+  // above. The dedupe is keyed on the (attention_reason, next_action)
+  // pair so it applies to both `next_human_action` (the immediate
+  // operator instruction) and `trust.latest_next_action` (the per-turn
+  // "권장 조치" follow-up suggestion), since the backend draws both
+  // from the same NextHumanAction wire vocabulary. If attentionReasonText
+  // is null (paused suppresses the reason line) we keep both visible so
+  // the operator still sees what to do.
+  const duplicatesAttentionReason = (action: string | null): boolean =>
     attentionReasonText !== null
-    && isAttentionPairDuplicate(attentionReason, nextHumanAction)
+    && isAttentionPairDuplicate(attentionReason, action)
+  const suppressDuplicateNextAction = duplicatesAttentionReason(nextHumanAction)
   const sandboxTarget = keeper.sandbox_target?.trim() || keeper.sandbox_profile?.trim() || null
   const persistedPolicyCount = keeper.approval_policy_effective?.persisted_rules
   const goalLinkedTasks = keeper.goal_progress?.linked_task_count
@@ -276,6 +280,17 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
   const latestTerminalReason = keeper.trust?.latest_terminal_reason ?? null
   const latestTerminalCode = latestTerminalReason?.code?.trim() || null
   const latestTerminalSummary = latestTerminalReason?.summary?.trim() || null
+  // Hide "종료 코드" when it references a past *success* turn while the
+  // current stop_cause is a terminal failure -- that is the
+  // "정지 원인 · turn_timeout / 종료 코드 · success" time-axis mix the
+  // ckpt-2 follow-up addresses. Both-failure pairs (e.g. turn_timeout +
+  // turn_wall_clock_timeout) stay visible since they describe the same
+  // failure surface from different observability layers.
+  const suppressStaleLatestTerminal =
+    latestTerminalCode !== null
+    && stopCause !== null
+    && isTurnTerminalFailureCode(stopCause.code)
+    && !isTurnTerminalFailureCode(latestTerminalCode)
   const latestNextAction = keeper.trust?.latest_next_action?.trim() || null
   const operatorDispositionReason = keeper.trust?.operator_disposition_reason?.trim() || null
   const shouldShowOperatorDispositionReason =
@@ -526,10 +541,10 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
         ${stopCause && isTurnTerminalFailureCode(stopCause.code)
           ? html`<span><strong class="text-[var(--color-fg-secondary)]">정지 원인</strong> · ${stopCause.code}${stopCause.summary ? html` · <${SyntheticAwareText} text=${stopCause.summary} />` : null}</span>`
           : null}
-        ${latestTerminalCode && latestTerminalCode !== stopCause?.code
+        ${latestTerminalCode && latestTerminalCode !== stopCause?.code && !suppressStaleLatestTerminal
           ? html`<span><strong class="text-[var(--color-fg-secondary)]">종료 코드</strong> · ${latestTerminalCode}${latestTerminalSummary ? html` · <${SyntheticAwareText} text=${latestTerminalSummary} />` : null}</span>`
           : null}
-        ${latestNextAction
+        ${latestNextAction && !duplicatesAttentionReason(latestNextAction)
           ? html`<span title=${latestNextAction}><strong class="text-[var(--color-fg-secondary)]">권장 조치</strong> · ${nextHumanActionLabel(latestNextAction)}</span>`
           : null}
         ${shouldShowOperatorDispositionReason && operatorDispositionReason

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -175,8 +175,12 @@ function warnUnknownAttentionToken(kind: 'attention_reason' | 'next_human_action
   }
 }
 
+function assertNever(value: never): never {
+  throw new Error(`unreachable case: ${String(value)}`)
+}
+
 // Exhaustive render over `KeeperVerdict.kind`. Adding a new arm to
-// `KeeperVerdict` will fail typecheck on the unreachable assertion
+// `KeeperVerdict` will fail typecheck on the assertNever default
 // rather than silently falling through to a default render. The tool
 // contract result, when present, is always shown as scope-tagged
 // evidence ("도구 계약") attached to the verdict rather than as a
@@ -207,6 +211,8 @@ function renderVerdict(verdict: KeeperVerdict) {
       `
     case 'no_verdict':
       return toolContractEvidence
+    default:
+      return assertNever(verdict.kind)
   }
 }
 

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -517,7 +517,7 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
         ${nextHumanActionText && !suppressDuplicateNextAction
           ? html`<span><strong class="text-[var(--color-fg-secondary)]">다음 액션</strong> · ${nextHumanActionText}</span>`
           : null}
-        ${stopCause
+        ${stopCause && isTurnTerminalFailureCode(stopCause.code)
           ? html`<span><strong class="text-[var(--color-fg-secondary)]">정지 원인</strong> · ${stopCause.code}${stopCause.summary ? html` · <${SyntheticAwareText} text=${stopCause.summary} />` : null}</span>`
           : null}
         ${latestTerminalCode && latestTerminalCode !== stopCause?.code

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -139,6 +139,30 @@ function nextHumanActionLabel(action: string | null): string | null {
   return action
 }
 
+// (attention_reason, next_human_action) pairs that surface the same
+// operator intent in two visually identical lines — e.g.
+//   주의 사유 · 런타임 근거 확인 필요
+//   다음 액션 · 런타임 근거 확인
+// Backend emits them as separate fields (lib/keeper/keeper_status_bridge.ml:727-742
+// and the fd_pressure / runtime_trust_snapshot peer sites), and we keep
+// the pairing here in dashboard so other consumers that *do* want both
+// (e.g. timeline reconstruction) are unaffected. Adding a new arm to
+// either union without considering the pair is safe — the predicate
+// just returns false and both lines render.
+const ATTENTION_PAIR_DUPLICATES: ReadonlyArray<readonly [AttentionReason, NextHumanAction]> = [
+  ['runtime_blocked', 'inspect_runtime_blocker'],
+  ['paused_blocked', 'inspect_blocker_before_resume'],
+  ['timeout_budget_exhausted', 'inspect_timeout_budget'],
+  ['runtime_trust_snapshot_unavailable', 'inspect_keeper_runtime_trust'],
+]
+const ATTENTION_PAIR_DUPLICATE_KEYS = new Set<string>(
+  ATTENTION_PAIR_DUPLICATES.map(([r, a]) => `${r}|${a}`),
+)
+function isAttentionPairDuplicate(reason: string | null, action: string | null): boolean {
+  if (!reason || !action) return false
+  return ATTENTION_PAIR_DUPLICATE_KEYS.has(`${reason}|${action}`)
+}
+
 // One-time warn per (kind, token) so dev consoles surface backend
 // variants that have no Korean label, without spamming on every render.
 const warnedAttentionTokens = new Set<string>()
@@ -217,6 +241,14 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
   const pausedRuntimeBlocker = isPaused && runtimeBlockerClass != null
   const attentionReasonText = attentionReasonLabel(attentionReason, isPaused)
   const nextHumanActionText = nextHumanActionLabel(nextHumanAction)
+  // Suppress "다음 액션" when it duplicates the visible "주의 사유" line
+  // above (e.g. runtime_blocked + inspect_runtime_blocker render as
+  // "런타임 근거 확인 필요" / "런타임 근거 확인"). If attentionReasonText
+  // is null (paused suppresses the reason line) we keep next_human_action
+  // visible so the operator still sees what to do.
+  const suppressDuplicateNextAction =
+    attentionReasonText !== null
+    && isAttentionPairDuplicate(attentionReason, nextHumanAction)
   const sandboxTarget = keeper.sandbox_target?.trim() || keeper.sandbox_profile?.trim() || null
   const persistedPolicyCount = keeper.approval_policy_effective?.persisted_rules
   const goalLinkedTasks = keeper.goal_progress?.linked_task_count
@@ -482,7 +514,7 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
         ${attentionReason === 'approval_pending' && pendingApprovalTaskId
           ? html`<span><strong class="text-[var(--color-fg-secondary)]">작업</strong> · ${pendingApprovalTaskId}</span>`
           : null}
-        ${nextHumanActionText
+        ${nextHumanActionText && !suppressDuplicateNextAction
           ? html`<span><strong class="text-[var(--color-fg-secondary)]">다음 액션</strong> · ${nextHumanActionText}</span>`
           : null}
         ${stopCause

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -51,57 +51,104 @@ function SyntheticAwareText({ text }: { text: string }) {
   `
 }
 
-// Backend `attention_reason` is set across three emit sites (verified by
-// `rg '"attention_reason".*\`String "' lib/`):
-//   - lib/keeper/keeper_status_bridge.ml:727-742 — six common reasons.
-//   - lib/keeper_fd_pressure.ml:190 — 'fd_pressure' when a keeper trips
-//     the fd-accountant watermark.
-//   - lib/dashboard/dashboard_goals.ml:44 —
-//     'runtime_trust_snapshot_unavailable' when the trust snapshot has
-//     not yet been computed.
-// The label map must cover every emit site; missing entries fall back to
-// the raw English token via `labels[reason] ?? reason`, leaving the
-// operator with no Korean label.
+// Backend emit sites for `attention_reason`:
+//   - lib/keeper/keeper_status_bridge.ml:727-742 (six common reasons)
+//   - lib/keeper_fd_pressure.ml:190 ('fd_pressure')
+//   - lib/dashboard/dashboard_goals.ml:44 ('runtime_trust_snapshot_unavailable')
+// Closed as const + Record<AttentionReason, string>. Adding a new label
+// without extending the union, or removing a union arm, fails typecheck
+// rather than silently producing a missing/extraneous Korean label. The
+// dual classification rule the labels map encodes is exhaustive over
+// the union; backend variants that drift past it surface via
+// warnUnknownAttentionToken instead of slipping through as a raw token.
+const ATTENTION_REASONS = [
+  'approval_pending',
+  'continue_gate_required',
+  'paused',
+  'paused_blocked',
+  'runtime_blocked',
+  'timeout_budget_exhausted',
+  'social_model_fallback',
+  'fd_pressure',
+  'runtime_trust_snapshot_unavailable',
+] as const
+type AttentionReason = typeof ATTENTION_REASONS[number]
+
+const ATTENTION_REASON_LABELS: Record<AttentionReason, string> = {
+  approval_pending: '승인 대기',
+  continue_gate_required: '계속 진행 승인 필요',
+  paused: '일시정지',
+  paused_blocked: '일시정지 원인 확인 필요',
+  runtime_blocked: '런타임 근거 확인 필요',
+  timeout_budget_exhausted: '타임아웃 예산 소진',
+  social_model_fallback: '소셜 모델 폴백',
+  fd_pressure: 'FD 임계치 초과',
+  runtime_trust_snapshot_unavailable: '런타임 신뢰 스냅샷 없음',
+}
+
+function isAttentionReason(s: string): s is AttentionReason {
+  return (ATTENTION_REASONS as readonly string[]).includes(s)
+}
+
 function attentionReasonLabel(reason: string | null, paused: boolean): string | null {
   if (!reason) return null
   if ((reason === 'paused' || reason === 'paused_blocked') && paused) return null
-  const labels: Record<string, string> = {
-    approval_pending: '승인 대기',
-    continue_gate_required: '계속 진행 승인 필요',
-    paused: '일시정지',
-    paused_blocked: '일시정지 원인 확인 필요',
-    runtime_blocked: '런타임 근거 확인 필요',
-    timeout_budget_exhausted: '타임아웃 예산 소진',
-    social_model_fallback: '소셜 모델 폴백',
-    fd_pressure: 'FD 임계치 초과',
-    runtime_trust_snapshot_unavailable: '런타임 신뢰 스냅샷 없음',
-  }
-  return labels[reason] ?? reason
+  if (isAttentionReason(reason)) return ATTENTION_REASON_LABELS[reason]
+  warnUnknownAttentionToken('attention_reason', reason)
+  return reason
 }
 
-// Backend `next_human_action` is set alongside `attention_reason` at the
-// same emit sites:
-//   - lib/keeper/keeper_status_bridge.ml:727-742 — seven common actions.
-//   - lib/keeper_fd_pressure.ml:191 — 'restore_fd_headroom' paired with
-//     the 'fd_pressure' attention_reason.
-//   - lib/dashboard/dashboard_goals.ml:45 — 'inspect_keeper_runtime_trust'
-//     paired with the 'runtime_trust_snapshot_unavailable' reason.
-// The label map below must cover every emit site so operators see a
-// Korean instruction instead of the raw English token.
+// Backend emit sites for `next_human_action` (paired 1:1 with the
+// corresponding `attention_reason`):
+//   - lib/keeper/keeper_status_bridge.ml:727-742 (seven common actions)
+//   - lib/keeper_fd_pressure.ml:191 ('restore_fd_headroom')
+//   - lib/dashboard/dashboard_goals.ml:45 ('inspect_keeper_runtime_trust')
+const NEXT_HUMAN_ACTIONS = [
+  'approve_or_reject_continue',
+  'inspect_blocker_before_resume',
+  'inspect_runtime_blocker',
+  'inspect_timeout_budget',
+  'resolve_approval',
+  'resume_or_review',
+  'review_social_model',
+  'restore_fd_headroom',
+  'inspect_keeper_runtime_trust',
+] as const
+type NextHumanAction = typeof NEXT_HUMAN_ACTIONS[number]
+
+const NEXT_HUMAN_ACTION_LABELS: Record<NextHumanAction, string> = {
+  approve_or_reject_continue: '계속 진행 승인 또는 거절',
+  inspect_blocker_before_resume: '원인 확인 후 재개',
+  inspect_runtime_blocker: '런타임 근거 확인',
+  inspect_timeout_budget: '타임아웃 예산 확인',
+  resolve_approval: '승인 요청 처리',
+  resume_or_review: '재개 또는 설정 검토',
+  review_social_model: '소셜 모델 설정 검토',
+  restore_fd_headroom: 'FD 여유 확보',
+  inspect_keeper_runtime_trust: '런타임 신뢰 스냅샷 확인',
+}
+
+function isNextHumanAction(s: string): s is NextHumanAction {
+  return (NEXT_HUMAN_ACTIONS as readonly string[]).includes(s)
+}
+
 function nextHumanActionLabel(action: string | null): string | null {
   if (!action) return null
-  const labels: Record<string, string> = {
-    approve_or_reject_continue: '계속 진행 승인 또는 거절',
-    inspect_blocker_before_resume: '원인 확인 후 재개',
-    inspect_runtime_blocker: '런타임 근거 확인',
-    inspect_timeout_budget: '타임아웃 예산 확인',
-    resolve_approval: '승인 요청 처리',
-    resume_or_review: '재개 또는 설정 검토',
-    review_social_model: '소셜 모델 설정 검토',
-    restore_fd_headroom: 'FD 여유 확보',
-    inspect_keeper_runtime_trust: '런타임 신뢰 스냅샷 확인',
+  if (isNextHumanAction(action)) return NEXT_HUMAN_ACTION_LABELS[action]
+  warnUnknownAttentionToken('next_human_action', action)
+  return action
+}
+
+// One-time warn per (kind, token) so dev consoles surface backend
+// variants that have no Korean label, without spamming on every render.
+const warnedAttentionTokens = new Set<string>()
+function warnUnknownAttentionToken(kind: 'attention_reason' | 'next_human_action', token: string) {
+  const key = `${kind}|${token}`
+  if (warnedAttentionTokens.has(key)) return
+  warnedAttentionTokens.add(key)
+  if (typeof console !== 'undefined') {
+    console.warn(`[keeper-detail-alert-strip] unknown ${kind}:`, token)
   }
-  return labels[action] ?? action
 }
 
 // Exhaustive render over `KeeperVerdict.kind`. Adding a new arm to

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -544,7 +544,7 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
           ? html`<span><strong class="text-[var(--color-fg-secondary)]">사용 도구</strong> · ${usedTools.join(', ')}</span>`
           : null}
         ${unexpectedTools.length > 0
-          ? html`<span class="text-[var(--color-status-err)]"><strong>외부 도구</strong> · ${unexpectedTools.join(', ')}</span>`
+          ? html`<span class="text-[var(--color-status-err)]" title="키퍼 persona의 허용 도구 목록 외부에서 호출된 도구 — 계약 위반"><strong>허용 외 도구</strong> · ${unexpectedTools.join(', ')}</span>`
           : null}
         ${missingRequiredTools.length > 0
           ? html`<span class="text-[var(--color-status-err)]"><strong>누락</strong> · ${missingRequiredTools.join(', ')}</span>`

--- a/dashboard/src/components/keeper-detail-body.ts
+++ b/dashboard/src/components/keeper-detail-body.ts
@@ -110,12 +110,14 @@ export function KeeperDetailBody({
       ${'' /* KeeperLiveTruthPanel (derived "Live truth / 런타임 / 현재 턴 / 최신 증거 / 차단" composite) moved to the 진단 / 운영 section as a default-closed CollapsibleSection — it is a heuristic synthesis on top of composite + keeper + runtime_trace + linked_state and lives below the raw-state alert-strip in information hierarchy. */}
       ${'' /* RFC-0046: 6-axis composite snapshot (KSM/KTC/KDP/KCL/KMC/breaker) — SSOT for keeper FSM state */}
       ${'' /* RFC-0046 §7 #2: share useKeeperComposite with FsmHub to dedup the /composite poll */}
-      <${FsmHub}
-        mode="detail"
-        selectedName=${keeper.name}
-        externalSnapshot=${compositeSnapshot}
-        runtimeTrace=${runtimeTrace}
-      />
+      <${CollapsibleSection} title="FSM Hub (6축 상태 머신)" open=${false}>
+        <${FsmHub}
+          mode="detail"
+          selectedName=${keeper.name}
+          externalSnapshot=${compositeSnapshot}
+          runtimeTrace=${runtimeTrace}
+        />
+      <//>
       <${CollapsibleSection} title="Phase State Machine">
         <${KeeperStateDiagramPanel} keeperName=${keeper.name} snapshot=${compositeSnapshot} />
       <//>

--- a/dashboard/src/components/keeper-detail-body.ts
+++ b/dashboard/src/components/keeper-detail-body.ts
@@ -107,14 +107,7 @@ export function KeeperDetailBody({
           eyebrow="상태 개요"
           title="운영 상태 개요"
         >
-      <${KeeperLiveTruthPanel}
-        keeper=${keeper}
-        compositeSnapshot=${compositeSnapshot}
-        runtimeTrace=${runtimeTrace}
-        compositeEvidence=${compositeEvidence}
-        runtimeTraceEvidence=${runtimeTraceEvidence}
-      />
-
+      ${'' /* KeeperLiveTruthPanel (derived "Live truth / 런타임 / 현재 턴 / 최신 증거 / 차단" composite) moved to the 진단 / 운영 section as a default-closed CollapsibleSection — it is a heuristic synthesis on top of composite + keeper + runtime_trace + linked_state and lives below the raw-state alert-strip in information hierarchy. */}
       ${'' /* RFC-0046: 6-axis composite snapshot (KSM/KTC/KDP/KCL/KMC/breaker) — SSOT for keeper FSM state */}
       ${'' /* RFC-0046 §7 #2: share useKeeperComposite with FsmHub to dedup the /composite poll */}
       <${FsmHub}
@@ -179,6 +172,15 @@ export function KeeperDetailBody({
         >
           <${KeeperToolTelemetry} keeperName=${keeper.name} />
           <${KeeperEvalQualityPanel} keeperName=${keeper.name} />
+          <${CollapsibleSection} title="Live Truth (composite/runtime 합성)" open=${false}>
+            <${KeeperLiveTruthPanel}
+              keeper=${keeper}
+              compositeSnapshot=${compositeSnapshot}
+              runtimeTrace=${runtimeTrace}
+              compositeEvidence=${compositeEvidence}
+              runtimeTraceEvidence=${runtimeTraceEvidence}
+            />
+          <//>
           <${CollapsibleSection} title="Runtime Lens" open=${true}>
             <${RuntimeLensSection} trace=${runtimeTrace} />
           <//>

--- a/docs/rfc/RFC-0148-keeper-attention-signal-typed-envelope.md
+++ b/docs/rfc/RFC-0148-keeper-attention-signal-typed-envelope.md
@@ -1,0 +1,113 @@
+---
+rfc: "0148"
+title: "Keeper Attention Signal — backend 단일 typed wire envelope"
+status: Draft
+created: 2026-05-20
+updated: 2026-05-20
+author: vincent
+supersedes: []
+superseded_by: null
+related: ["0068", "0135"]
+implementation_prs: []
+---
+
+# RFC-0148: Keeper Attention Signal — backend 단일 typed wire envelope
+
+## §0 한 줄 요약
+
+같은 운영자 의도(예: "런타임 근거를 확인해 turn을 재개해야 함")가 backend가 emit하는 3개 별 wire field(`attention_reason`, `next_human_action`, `trust.latest_next_action`)에 산재해, dashboard가 paired equivalence set으로 dedupe하는 임시 처방을 누적 중이다. 이를 **단일 `KeeperAttentionSignal` typed envelope**로 통합해 backend가 *한 가지 signal*만 emit하도록 정규화한다.
+
+## §1 문제: 3-field 산재 (PR #16908 관찰)
+
+PR #16908 작업 중 다음 모순이 *모두 dashboard 측에서* string-pair predicate로 흡수됨:
+
+### §1.1 페어 #1: attention_reason ↔ next_human_action (4쌍)
+
+| `attention_reason` | `next_human_action` | dashboard 라벨 |
+|--------------------|---------------------|----------------|
+| `runtime_blocked` | `inspect_runtime_blocker` | "런타임 근거 확인 필요" / "런타임 근거 확인" |
+| `paused_blocked` | `inspect_blocker_before_resume` | "일시정지 원인 확인 필요" / "원인 확인 후 재개" |
+| `timeout_budget_exhausted` | `inspect_timeout_budget` | "타임아웃 예산 소진" / "타임아웃 예산 확인" |
+| `runtime_trust_snapshot_unavailable` | `inspect_keeper_runtime_trust` | "런타임 신뢰 스냅샷 없음" / "런타임 신뢰 스냅샷 확인" |
+
+PR #16908 PR-1 ckpt-1(commit `be17dd75db`)이 이 4쌍을 dashboard `ATTENTION_PAIR_DUPLICATES` set으로 dedupe했다. backend가 두 field를 *paired emit*하는 것 자체가 본 RFC가 닫고자 하는 anti-pattern.
+
+### §1.2 페어 #2: attention_reason ↔ trust.latest_next_action (동일 페어 패턴)
+
+`trust.latest_next_action`은 위 paired emit site에서 `next_human_action`을 *turn snapshot*으로 한 번 더 복사한 형태로 추정. PR #16908 follow-up commit(`0da6d7ddfb`)이 동일 `ATTENTION_PAIR_DUPLICATES` set을 재사용해 dashboard 측에서 또 hide함.
+
+세 번째 field가 같은 NextHumanAction wire vocabulary를 다시 emit하는 것은 *parallel duplication*. backend wire schema의 의미 압축 실패.
+
+### §1.3 Backend emit sites (확인 필요 — RFC §3 work)
+
+- `lib/keeper/keeper_status_bridge.ml:727-742` — paired `(attention_reason, next_human_action)`, 6 reasons.
+- `lib/keeper_fd_pressure.ml:190-191` — `(fd_pressure, restore_fd_headroom)`.
+- `lib/dashboard/dashboard_goals.ml:44-45` — `(runtime_trust_snapshot_unavailable, inspect_keeper_runtime_trust)`.
+- `lib/keeper/keeper_runtime_trust_snapshot.ml` — `trust.latest_next_action` derivation. (3rd emit path; precise line range TBD.)
+
+## §2 Proposed: `KeeperAttentionSignal` typed envelope
+
+```ocaml
+type attention_signal =
+  | Runtime_blocked of { blocker_class: string; runtime_proof_url: string option }
+  | Paused_blocked of { since: float }
+  | Timeout_budget_exhausted of { elapsed_sec: float; budget_sec: float }
+  | Social_model_fallback of { fallback_provider: string }
+  | Fd_pressure of { headroom_pct: float }
+  | Runtime_trust_snapshot_unavailable
+  | Approval_pending of { id: string; tool_name: string; task_id: string option }
+  | Continue_gate_required
+  | Paused
+```
+
+각 variant가 *한 가지* operator intent. dashboard는 `attention_signal`만 받고 `attention_reason / next_human_action / latest_next_action` 3 필드 모두 제거.
+
+라벨링은 dashboard 측 `attention-signal-display.ts`에서 *variant별* Korean text 결정 — single typed source. PR #16908의 `Record<AttentionReason, string>` 봉인이 (commit `4dab7b8961`) 이미 dashboard 측 결정 단일화를 시작해놨으니, backend가 `attention_signal`만 emit하면 그 봉인이 자연스럽게 *완성된다*.
+
+### §2.1 Wire format
+
+```json
+{
+  "attention_signal": {
+    "kind": "timeout_budget_exhausted",
+    "elapsed_sec": 600.0,
+    "budget_sec": 600.0
+  }
+}
+```
+
+ATD/codegen 경로는 RFC-0140 dashboard-wire-codec-layer 기반.
+
+## §3 Phasing
+
+| Phase | Backend | Dashboard | Cutover |
+|-------|---------|-----------|---------|
+| P0 | `attention_signal` field 추가 (parallel emit, 3 필드 그대로 유지) | 기존 3 필드 그대로 사용 | none |
+| P1 | 3 필드 derived from `attention_signal` (단일 SSOT 컴퓨테이션) | `attention_signal` 우선 read, 3 필드 fallback | dashboard reads new field |
+| P2 | 3 필드 emit 중단, schema 삭제 | `attention_signal` only, dedupe set 삭제 | backend stops legacy emit, dashboard cleans up |
+
+P2 cutover 시 PR #16908의 다음 코드가 *함께 삭제*되어야 함 — anti-stale-workaround invariant:
+
+- `dashboard/src/components/keeper-detail-alert-strip.ts:ATTENTION_PAIR_DUPLICATES`
+- `dashboard/src/components/keeper-detail-alert-strip.ts:duplicatesAttentionReason`
+- `dashboard/src/components/keeper-detail-alert-strip.ts:isAttentionPairDuplicate`
+
+## §4 Out of scope
+
+- `attention_signal` 외 다른 operator-facing 정보 (`operator_disposition`, `stop_cause`, `latest_terminal_reason`) — 본 RFC 영역 밖.
+- RFC-0068 (backend turn disposition typed sum) — 인접 영역이지만 다른 layer (turn 종료 시점 vs operator pending 시점).
+- Dashboard label SSOT (RFC-0135 implementation_prs에 PR #16908 등록은 별도 PR로 처리).
+- `TURN_TERMINAL_FAILURE_CODES`와 backend `Keeper_turn_disposition` wire enum의 동기화 — 본 RFC와 다른 codeset. PR #16908 follow-up commit `15fefb37c9`가 1 entry만 임시 추가했으며, full sync는 RFC-0068 PR-3 또는 별 RFC가 다룰 영역.
+
+## §5 Related
+
+- RFC-0068 (turn disposition typed sum) — turn 종료 layer.
+- RFC-0135 (dashboard SSOT) — dashboard read-side. PR #16908이 implementation_prs 후보로 별도 register 예정.
+- RFC-0140 (dashboard wire codec layer) — ATD/codegen 인프라.
+- PR #16908 commits `4dab7b8961` (typed enum 봉인), `be17dd75db` (페어 #1 dedupe), `0da6d7ddfb` (페어 #2 dedupe), `15fefb37c9` (failure code gap) — *prereq workaround*로 분류, P2에서 회수.
+
+## §6 Open questions
+
+1. `trust.latest_next_action`이 정확히 어디서 derive되는가? `keeper_runtime_trust_snapshot.ml`의 어떤 함수가 `next_human_action`을 trust snapshot으로 복사하는지 line-range 확정 필요.
+2. `attention_signal` variant 9개 중 어떤 것이 *진짜 거의 안 emit되는지* (e.g. `Continue_gate_required`)? Production log에서 emit frequency 측정 후 inactive variant는 deprecation candidate.
+3. P2 cutover 시 backwards compatibility — 외부 client(예: 다른 dashboard, external scripts)가 3 필드를 직접 읽는가? `rg` 확인 필요.


### PR DESCRIPTION
## 요약

masc-mcp dashboard 키퍼 상세 페이지 상단 영역의 *중복 / 모순 / 노이즈*를 정리하는 7-commit 정리. 사용자가 보고한 verifier 키퍼의 BEFORE 화면:

- "주의 사유 · 런타임 근거 확인 필요" + "다음 액션 · 런타임 근거 확인" 동치 페어가 두 줄로 중복
- "정지 원인 · success · turn completed"와 "운영자 판단 · critical_block"가 한 카드에 시간축 충돌
- "외부 도구" 라벨 의미 불명 (persona allowed_tools 위반인지 일반 호출인지 안 보임)
- KeeperLiveTruthPanel의 5종 합성 카드 (Live truth / 런타임 / 현재 턴 / 최신 증거 / 차단)와 FsmHub 6축 디테일 + 상태 타임라인 + 전환 이력 + dwell time + 빈발 전환 + 상태 격자가 모두 default expanded로 한 페이지에 펼쳐짐
- 변환 맵의 silent default(`labels[reason] ?? reason`)로 미지 토큰이 영어 그대로 노출

이 PR이 모두 정리.

## 7 commits

| ckpt | 효과 | 파일 / LoC |
|------|------|------------|
| PR-3 ckpt-1 | typed AttentionReason / NextHumanAction enum 봉인 + 미지 토큰 console.warn | alert-strip.ts +90 -43 |
| PR-1 ckpt-1 | 4개 동치 페어 dedupe (attention_reason ↔ next_human_action) | alert-strip.ts +33 -1 |
| PR-1 ckpt-2 | "정지 원인" gate behind isTurnTerminalFailureCode | alert-strip.ts +1 -1 |
| PR-1 ckpt-3 | "외부 도구" → "허용 외 도구" + 계약 위반 hint | alert-strip.ts +1 -1 |
| PR-3 ckpt-2 | assertNever default arm in renderVerdict switch | alert-strip.ts +7 -1 |
| PR-2 ckpt-1 | KeeperLiveTruthPanel → 진단 / 운영 (default-closed) | body.ts +10 -8 |
| PR-2 ckpt-2 | FsmHub default-collapsed CollapsibleSection | body.ts +8 -6 |

**합계**: +150 / -61 LoC, 2 files (`keeper-detail-alert-strip.ts`, `keeper-detail-body.ts`).

## 검증

- `npx tsc --noEmit` PASS
- `npx eslint src/components/keeper-detail-alert-strip.ts src/components/keeper-detail-body.ts` clean
- 12 keeper-detail-*.test.ts 파일 / 119 tests PASS
- 브라우저 레벨 검증: main worktree dev(5179) vs feature worktree dev(5180) 동시 띄움. verifier 키퍼에서 ckpt별 BEFORE/AFTER 비교 후 효과 직접 확인. PR-1 ckpt-2 작업 중 첫 draft가 `종료 코드` 줄까지 hide시키는 regression을 만들었고 브라우저 비교로 즉시 잡아 surgical revert.

## 발견된 후속 RFC 후보 (별 PR 예정)

1. backend ↔ dashboard `TURN_TERMINAL_FAILURE_CODES` SSOT 동기화 — `turn_wall_clock_timeout`이 dashboard set 외부에서 emit 중. PR-1 ckpt-2 검증 중 발견.
2. `주의 사유` ↔ `권장 조치` (`trust.latest_next_action`) 추가 dedupe — 같은 운영자 의도가 3개 backend 필드(attention_reason / next_human_action / latest_next_action)에 산재.
3. backend 단일 typed `KeeperAttentionSignal` 통합 — 위 #2의 root-fix RFC 후보.
4. `정지 원인=failure` + `종료 코드=success` 시간축 혼합 — latestTerminalReason gate 강화.

## CLAUDE.md 정책 준수

- worktree 안에서만 작업 (`.worktrees/dashboard-keeper-detail-cleanup`)
- main 직접 수정 없음, Draft PR
- hardcoding / legacy zero tolerance: PR-3 ckpt-1에서 silent default `?? raw` 패턴 제거 (typed enum + console.warn으로 root-fix)
- FALLBACK + silent default 패턴 → discriminated union root-fix
- agent_delegation RFC 의무 subsystem 아님 (`keeper-detail-*`은 목록 외)