### PR TITLE
fix(mcp_sdk_adapter): expose payload shape in parse_list errors

### DIFF
--- a/lib/mcp_sdk_adapter_masc.ml
+++ b/lib/mcp_sdk_adapter_masc.ml
@@ -87,8 +87,17 @@ let parse_list parser field_name = function
               | Error msg, _ | _, Error msg -> Error msg)
             (Ok []) items
           |> Result.map List.rev
-      | _ -> Error ("Missing " ^ field_name))
-  | _ -> Error "Invalid response payload"
+      | Some other ->
+          Error
+            (Printf.sprintf
+               "Field %S has wrong type: expected JSON array, got %s"
+               field_name (Json_util.kind_name other))
+      | None -> Error ("Missing " ^ field_name))
+  | other ->
+      Error
+        (Printf.sprintf
+           "Invalid response payload: expected JSON object, got %s"
+           (Json_util.kind_name other))
 
 let tool_result_of_response response =
   match response_result response with


### PR DESCRIPTION
## Summary

Iter#85 of FSM/TLA+/clarity sweep — continues operator-clarity chain:
**#16903 (iter#83) → #16907 (iter#84) → this**.

Two catch-all arms in `parse_list` at `lib/mcp_sdk_adapter_masc.ml:79-91` discarded information already in scope:

```ocaml
| _ -> Error ("Missing " ^ field_name)   (* line 90 — collapsed two distinct cases *)
| _ -> Error "Invalid response payload"  (* line 91 — discarded JSON kind *)
```

After:

```ocaml
| Some other ->
    Error (Printf.sprintf
       "Field %S has wrong type: expected JSON array, got %s"
       field_name (Json_util.kind_name other))
| None -> Error ("Missing " ^ field_name)
| other ->
    Error (Printf.sprintf
       "Invalid response payload: expected JSON object, got %s"
       (Json_util.kind_name other))
```

`Json_util.kind_name` returns total `{null,bool,int,float,string,object,array}` over `Yojson.Safe.t` (`lib/core/json_util.ml:149`). Same pattern adopted in `Keeper_id.Uid.of_json` and 5 sites in `Mcp_server_eio_tool_profile`.

## Why this matters

When an MCP SDK response arrives malformed, operators previously saw:

- `Error "Missing contents"` — ambiguous: field absent, OR field present with wrong type?
- `Error "Invalid response payload"` — what did we receive? `null`? a quoted string? a misrouted list?

After this fix the message names the JSON kind we got, so the operator can decide if the upstream transport corrupted the envelope, if the SDK lib version drifted, or if the tool returned a misshapen body.

## Workaround Rejection Bar 7-item self-check

| # | Check | Result |
|---|-------|--------|
| 1 | telemetry-as-fix? | ❌ — not adding a counter, fixing message |
| 2 | string classifier? | ❌ — no startsWith/prefix, only kind_name lookup |
| 3 | N-of-M? | ❌ — single file, both arms covered |
| 4 | catch-all add? | ❌ — REPLACING two `_ ->` arms with named patterns |
| 5 | symptom suppression? | ❌ — fixing info loss, not suppressing |
| 6 | test backdoor? | ❌ |
| 7 | codemod miss? | ❌ — only `parse_list` in file |

## Caller verification

```
$ rg -n "Invalid response payload|Missing tools/call result" --type=ml --type=ts
lib/mcp_sdk_adapter_masc.ml:99   (* the new producer *)
lib/mcp_sdk_adapter_masc.ml:111  (* unrelated Missing tools/call result *)
```

0 external callers pattern-match on the literal — message text propagates to logs/errors as opaque payload, so the longer form is purely additive operator info.

## Verification

- Local `dune build @check`: clean (after pre-existing iter#79 .mli workaround temporarily applied to unblock the test exe — reverted before commit; iter scope is the single mcp_sdk_adapter file)
- Diff: 1 file, +11/-2

## Notes

Pre-existing main break: `lib/keeper/keeper_shell_bash_typed_input.mli:8` still declares `Keeper_tool_bash_input.t` (should be `bash_input`) — iter#79 territory, blocks test exe build alone. This PR's lib-level changes build cleanly without needing the .mli fix; only the test exe needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)