### PR TITLE
fix(cdal): skip unscoped keeper verdict ledger writes

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -22,6 +22,10 @@ let registry_progress_on_event = Turn_helpers.registry_progress_on_event
 let select_cdal_proof = Turn_helpers.select_cdal_proof
 
 let cdal_task_id_for_verdict = Contract_helpers.cdal_task_id_for_verdict
+let cdal_verdict_persist_decision =
+  Contract_helpers.cdal_verdict_persist_decision
+;;
+
 let progress_keeper_tool_names_for_contract =
   Contract_helpers.progress_keeper_tool_names_for_contract
 ;;
@@ -35,6 +39,7 @@ module For_testing = struct
   let registry_progress_on_event = registry_progress_on_event
   let select_cdal_proof = select_cdal_proof
   let cdal_task_id_for_verdict = cdal_task_id_for_verdict
+  let cdal_verdict_persist_decision = cdal_verdict_persist_decision
   let progress_keeper_tool_names_for_contract =
     progress_keeper_tool_names_for_contract
   ;;
@@ -1460,7 +1465,14 @@ let run_turn
                                 kind
                                 (Printexc.to_string exn)
                           in
-                          Cdal_eval_v1.persist ?task_id verdict;
+                          (match cdal_verdict_persist_decision task_id with
+                           | `Persist_task_scoped task_id ->
+                             Cdal_eval_v1.persist ~task_id verdict
+                           | `Skip_missing_task_scope ->
+                             Log.Keeper.debug
+                               "keeper:%s contract_verdict not persisted to task \
+                                gate ledger: missing task_id/current_task_id"
+                               meta.name);
                           Keeper_turn_telemetry.log_keeper_contract_verdict
                             ~keeper_name:meta.name
                             verdict;

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -260,6 +260,11 @@ module For_testing : sig
     -> string option
   (** Selects the task scope used for keeper-side CDAL verdict persistence. *)
 
+  val cdal_verdict_persist_decision
+    :  string option
+    -> [> `Persist_task_scoped of string | `Skip_missing_task_scope ]
+  (** Selects whether a keeper-side CDAL verdict may enter the task-gate ledger. *)
+
   val progress_keeper_tool_names_for_contract
     :  allowed_tool_names:string list
     -> actual_keeper_tool_names:string list

--- a/lib/keeper/keeper_agent_run_contract_helpers.ml
+++ b/lib/keeper/keeper_agent_run_contract_helpers.ml
@@ -12,6 +12,11 @@ let cdal_task_id_for_verdict ~(current_task_id : string option)
       tool_calls
 ;;
 
+let cdal_verdict_persist_decision = function
+  | Some task_id when String.trim task_id <> "" -> `Persist_task_scoped task_id
+  | _ -> `Skip_missing_task_scope
+;;
+
 let keeper_tool_names_for_outcome
       ~(allowed_tool_names : string list)
       ~(tool_calls : Keeper_agent_result.tool_call_detail list)

--- a/lib/keeper/keeper_agent_run_contract_helpers.mli
+++ b/lib/keeper/keeper_agent_run_contract_helpers.mli
@@ -5,6 +5,9 @@ val cdal_task_id_for_verdict :
   tool_calls:Keeper_agent_result.tool_call_detail list ->
   string option
 
+val cdal_verdict_persist_decision :
+  string option -> [> `Persist_task_scoped of string | `Skip_missing_task_scope ]
+
 val progress_keeper_tool_names_for_contract :
   allowed_tool_names:string list ->
   actual_keeper_tool_names:string list ->

--- a/test/test_keeper_cdal_contract.ml
+++ b/test/test_keeper_cdal_contract.ml
@@ -178,6 +178,30 @@ let test_cdal_task_id_falls_back_to_tool_target () =
     selected
 ;;
 
+let test_cdal_verdict_persist_requires_task_scope () =
+  let decision = Keeper_agent_run.For_testing.cdal_verdict_persist_decision None in
+  check
+    bool
+    "unscoped verdict is not written to task-gate ledger"
+    true
+    (match decision with
+     | `Skip_missing_task_scope -> true
+     | `Persist_task_scoped _ -> false)
+;;
+
+let test_cdal_verdict_persist_accepts_task_scope () =
+  let decision =
+    Keeper_agent_run.For_testing.cdal_verdict_persist_decision (Some "task-cdal")
+  in
+  check
+    bool
+    "task-scoped verdict is persisted"
+    true
+    (match decision with
+     | `Persist_task_scoped task_id -> String.equal task_id "task-cdal"
+     | `Skip_missing_task_scope -> false)
+;;
+
 let () =
   Alcotest.run
     "keeper_cdal_contract"
@@ -208,6 +232,14 @@ let () =
             "falls back to lifecycle tool target for verdict scope"
             `Quick
             test_cdal_task_id_falls_back_to_tool_target
+        ; test_case
+            "skips task-gate ledger when verdict has no task scope"
+            `Quick
+            test_cdal_verdict_persist_requires_task_scope
+        ; test_case
+            "persists task-gate ledger when verdict has task scope"
+            `Quick
+            test_cdal_verdict_persist_accepts_task_scope
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- stop writing keeper CDAL verdicts into the task-gate ledger when no task_id/current_task_id can be derived
- keep scoped verdicts unchanged so task completion gates still read `_task_id` rows
- repair two current main build breaks discovered by focused `bin/main_eio` validation: dashboard_eval_feed missing eio/masc_log deps and typed bash helper mli using the wrong Keeper_tool_bash_input type name

## Verification
- `ocamlformat --check lib/keeper/keeper_agent_run_contract_helpers.ml lib/keeper/keeper_agent_run_contract_helpers.mli lib/keeper/keeper_agent_run.ml lib/keeper/keeper_agent_run.mli test/test_keeper_cdal_contract.ml lib/dashboard_eval_feed/dune lib/keeper/keeper_shell_bash_typed_input.mli`
- `env MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 MASC_SKIP_DEPS_CHECK=1 MASC_SKIP_OCAML_VERSION_CHECK=1 scripts/dune-local.sh build ./test/test_keeper_cdal_contract.exe ./test/test_eval_feed.exe ./test/test_keeper_bash_typed_input.exe ./bin/main_eio.exe`
- `./_build/default/test/test_keeper_cdal_contract.exe`
- `./_build/default/test/test_eval_feed.exe`
- `./_build/default/test/test_keeper_bash_typed_input.exe`
