### PR TITLE
fix(shared_audit): expose JSON shape in Envelope.of_json errors

### DIFF
--- a/lib/shared_audit/envelope.ml
+++ b/lib/shared_audit/envelope.ml
@@ -68,18 +68,51 @@ let to_json t =
     "prev_hash", prev;
   ]
 
+(* Local [kind_name] — [shared_audit] is a leaf library that cannot
+   depend on [masc_core.Json_util].  Same total mapping as the
+   canonical helper (lib/core/json_util.ml:149); duplicated rather
+   than introducing an upward dependency.  RFC candidate: extract a
+   shared sub-leaf module for json kind diagnostics. *)
+let kind_name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "int"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"
+
 let of_json = function
   | `Assoc fields ->
+    (* Distinguish *missing field* from *field present with wrong
+       kind* — audit-chain corruption forensics needs to know which.
+       Missing = upstream writer dropped the field (schema drift);
+       wrong-kind = payload corruption between write and read. *)
     let get_string k =
       match List.assoc_opt k fields with
       | Some (`String s) -> Ok s
-      | _ -> Error (Printf.sprintf "Envelope.of_json: missing or bad %s" k)
+      | Some other ->
+        Error
+          (Printf.sprintf
+             "Envelope.of_json: field %S has wrong type (expected \
+              string, got %s)"
+             k (kind_name other))
+      | None ->
+        Error (Printf.sprintf "Envelope.of_json: missing field %S" k)
     in
     let get_float k =
       match List.assoc_opt k fields with
       | Some (`Float f) -> Ok f
       | Some (`Int i) -> Ok (float_of_int i)
-      | _ -> Error (Printf.sprintf "Envelope.of_json: missing or bad %s" k)
+      | Some other ->
+        Error
+          (Printf.sprintf
+             "Envelope.of_json: field %S has wrong type (expected \
+              float or int, got %s)"
+             k (kind_name other))
+      | None ->
+        Error (Printf.sprintf "Envelope.of_json: missing field %S" k)
     in
     let get_payload () =
       match List.assoc_opt "payload" fields with
@@ -91,7 +124,12 @@ let of_json = function
       | Some `Null -> Ok None
       | Some (`String s) -> Ok (Some s)
       | None -> Ok None
-      | _ -> Error "Envelope.of_json: bad prev_hash"
+      | Some other ->
+        Error
+          (Printf.sprintf
+             "Envelope.of_json: bad prev_hash (expected string or \
+              null, got %s)"
+             (kind_name other))
     in
     (match
        get_string "id",
@@ -107,4 +145,8 @@ let of_json = function
      | _, _, Error e, _, _
      | _, _, _, Error e, _
      | _, _, _, _, Error e -> Error e)
-  | _ -> Error "Envelope.of_json: expected object"
+  | other ->
+    Error
+      (Printf.sprintf
+         "Envelope.of_json: expected JSON object, got %s"
+         (kind_name other))


### PR DESCRIPTION
## Summary

Iter#86 of FSM/TLA+/clarity sweep — continues operator-clarity chain:
**#16903 (iter#83) → #16907 (iter#84) → #16911 (iter#85) → this**.

\`Envelope\` carries append-only audit-chain entries. When \`of_json\` rejects an input the operator is doing forensics on a possibly-corrupted log — *maximum context* is the difference between \"schema drift\" vs \"transport corruption\" diagnosis.

Four catch-all arms discarded information already in scope at \`lib/shared_audit/envelope.ml:76, 82, 94, 110\`.

## Before/After

| Site | Before | After |
|------|--------|-------|
| L76 get_string | \`missing or bad %s\` (collapses 2 causes) | \`missing field\` vs \`wrong type (expected string, got %s)\` |
| L82 get_float | same collapse | same split + \`expected float or int, got %s\` |
| L94 get_prev_hash | \`bad prev_hash\` (discards kind) | \`expected string or null, got %s\` |
| L110 outer | \`expected object\` (discards kind) | \`expected JSON object, got %s\` |

## RFC candidate noted in code

\`shared_audit\` is a leaf library that cannot depend on \`masc_core.Json_util\` — an inline \`kind_name\` helper duplicates the canonical mapping from \`lib/core/json_util.ml:149\`. **Current count = 4 duplicated copies of the same 8-line function** across the tree. RFC candidate: extract a shared sub-leaf module for json kind diagnostics.

Sites already using the pattern:
- \`lib/core/json_util.ml:149\` (canonical)
- \`lib/board_attachment_meta.ml\` × 5
- \`lib/mcp_server_eio_tool_profile.ml\` × 5
- \`lib/keeper/keeper_id.ml:111\`
- \`lib/mcp_sdk_adapter_masc.ml\` × 2 (iter#85 #16911)
- \`lib/shared_audit/envelope.ml\` × 4 (this PR)

## Caller verification

- \`lib/resilience/audit.ml:85\` — pure passthrough alias
- \`lib/shared_audit/store.ml:7\` — pipes Error string into log
- \`test/\` — 0 sites pattern-match on the literal error text

## Workaround Rejection Bar 7-item self-check

| # | Check | Result |
|---|-------|--------|
| 1 | telemetry-as-fix? | ❌ — no counter, fixing message |
| 2 | string classifier? | ❌ — kind_name is closed total mapping |
| 3 | N-of-M? | ❌ — all 4 catch-alls in same of_json function, one PR |
| 4 | catch-all add? | ❌ — REPLACING 4 \`_ ->\` arms with named patterns |
| 5 | symptom suppression? | ❌ |
| 6 | test backdoor? | ❌ |
| 7 | codemod miss? | ❌ — file fully covered |

## Verification

- \`dune build lib/shared_audit/shared_audit.a\`: clean
- 1 file, +46/-4

🤖 Generated with [Claude Code](https://claude.com/claude-code)