### PR TITLE
fix(shared_types): expose JSON shape in 4 newtype of_json errors

### DIFF
--- a/lib/shared_types/artifact_id.ml
+++ b/lib/shared_types/artifact_id.ml
@@ -83,4 +83,8 @@ let to_json t = `String t
 
 let of_json = function
   | `String s -> of_string s
-  | _ -> Error "Artifact_id.of_json: expected string"
+  | other ->
+    Error
+      (Printf.sprintf
+         "Artifact_id.of_json: expected string, got %s"
+         (Json_kind.name other))

--- a/lib/shared_types/budget.ml
+++ b/lib/shared_types/budget.ml
@@ -51,15 +51,23 @@ let of_json = function
     let get_int k =
       match List.assoc_opt k fields with
       | Some (`Int i) -> Ok i
-      | Some _ -> Error (Printf.sprintf "Budget.of_json: %s not int" k)
-      | None -> Error (Printf.sprintf "Budget.of_json: missing %s" k)
+      | Some other ->
+        Error
+          (Printf.sprintf
+             "Budget.of_json: field %S has wrong type (expected int, got %s)"
+             k (Json_kind.name other))
+      | None -> Error (Printf.sprintf "Budget.of_json: missing field %S" k)
     in
     let get_float k =
       match List.assoc_opt k fields with
       | Some (`Float f) -> Ok f
       | Some (`Int i) -> Ok (float_of_int i)
-      | Some _ -> Error (Printf.sprintf "Budget.of_json: %s not float" k)
-      | None -> Error (Printf.sprintf "Budget.of_json: missing %s" k)
+      | Some other ->
+        Error
+          (Printf.sprintf
+             "Budget.of_json: field %S has wrong type (expected float or int, got %s)"
+             k (Json_kind.name other))
+      | None -> Error (Printf.sprintf "Budget.of_json: missing field %S" k)
     in
     (match get_int "tokens", get_int "turns", get_int "time_ms", get_float "cost_usd" with
      | Ok tokens, Ok turns, Ok time_ms, Ok cost_usd ->
@@ -68,4 +76,8 @@ let of_json = function
      | _, Error e, _, _
      | _, _, Error e, _
      | _, _, _, Error e -> Error e)
-  | _ -> Error "Budget.of_json: expected object"
+  | other ->
+    Error
+      (Printf.sprintf
+         "Budget.of_json: expected JSON object, got %s"
+         (Json_kind.name other))

--- a/lib/shared_types/confidence.ml
+++ b/lib/shared_types/confidence.ml
@@ -25,4 +25,8 @@ let to_json t = `Float t
 let of_json = function
   | `Float f -> Ok (make f)
   | `Int i -> Ok (make (float_of_int i))
-  | _ -> Error "Confidence.of_json: expected float or int"
+  | other ->
+    Error
+      (Printf.sprintf
+         "Confidence.of_json: expected float or int, got %s"
+         (Json_kind.name other))

--- a/lib/shared_types/json_kind.ml
+++ b/lib/shared_types/json_kind.ml
@@ -1,0 +1,22 @@
+(* Local kind diagnostic for shared_types of_json error messages.
+
+   Duplicates the canonical [Json_util.kind_name] from
+   [lib/core/json_util.ml:149] because [shared_types] is a leaf
+   library (only deps: unix, yojson) and cannot reach
+   [masc_core.Json_util] without introducing an upward dependency.
+
+   Same situation noted in [lib/shared_audit/envelope.ml] (iter#86,
+   PR #16914) — current count: 5 inline duplicates of the same
+   total mapping across the tree.  RFC candidate: a shared
+   sub-leaf module for json kind diagnostics.  This file is the
+   first consolidation step *within* shared_types itself. *)
+
+let name : Yojson.Safe.t -> string = function
+  | `Null -> "null"
+  | `Bool _ -> "bool"
+  | `Int _ -> "int"
+  | `Intlit _ -> "int"
+  | `Float _ -> "float"
+  | `String _ -> "string"
+  | `Assoc _ -> "object"
+  | `List _ -> "array"

--- a/lib/shared_types/json_kind.mli
+++ b/lib/shared_types/json_kind.mli
@@ -1,0 +1,7 @@
+(** Total mapping from [Yojson.Safe.t] to its kind name string.
+
+    Used in [of_json] error messages so operators see which JSON
+    kind arrived rather than a bare "expected X" label.  Returns
+    one of {{!{["null"; "bool"; "int"; "float"; "string";
+    "object"; "array"]}}}. *)
+val name : Yojson.Safe.t -> string

--- a/lib/shared_types/timestamp.ml
+++ b/lib/shared_types/timestamp.ml
@@ -15,4 +15,8 @@ let to_json t = `Float t
 let of_json = function
   | `Float f -> Ok f
   | `Int i -> Ok (float_of_int i)
-  | _ -> Error "Timestamp.of_json: expected float or int"
+  | other ->
+    Error
+      (Printf.sprintf
+         "Timestamp.of_json: expected float or int, got %s"
+         (Json_kind.name other))


### PR DESCRIPTION
## Summary

Iter#87 of FSM/TLA+/clarity sweep — operator-clarity chain:
**#16903 → #16907 → #16911 → #16914 → this**.

All four \`shared_types\` newtype modules had opaque catch-all arms in their \`of_json\` entry points that discarded the observed JSON kind. \`Budget\` additionally collapsed *missing field* and *field present with wrong type* into a shared message.

| File | Before | After |
|------|--------|-------|
| \`budget.ml\` (3 sites) | \`%s not int\` / \`%s not float\` / \`expected object\` | split missing-vs-wrong-kind + kind name |
| \`confidence.ml\` (1 site) | \`expected float or int\` | + \`got <kind>\` |
| \`artifact_id.ml\` (1 site) | \`expected string\` | + \`got <kind>\` |
| \`timestamp.ml\` (1 site) | \`expected float or int\` | + \`got <kind>\` |

## New helper

\`lib/shared_types/json_kind.{ml,mli}\` — 8-line total mapping over \`Yojson.Safe.t\`.

**Why a new file** instead of using existing canonical \`lib/core/json_util.ml:149\`:

- \`shared_types\` is a leaf library (deps: \`unix\`, \`yojson\` only)
- Reaching \`masc_core.Json_util\` introduces an upward dep
- \`shared_types\` is loaded by many lower components *precisely because* it does not know about masc_core

## RFC trajectory

The same 8-line \`kind_name\` helper is now duplicated in **6 places**:
- \`lib/core/json_util.ml:149\` (canonical)
- \`lib/shared_audit/envelope.ml\` (inline, iter#86 #16914)
- \`lib/shared_types/json_kind.ml\` (this PR — new)
- Plus pattern-matched inline in: \`board_attachment_meta\`, \`mcp_server_eio_tool_profile\`, \`keeper_id\`, \`mcp_sdk_adapter_masc\`

**6 copies = past the 5-copy RFC threshold noted in iter#86**. Follow-up RFC will factor out a \`json_diagnostics\` sub-leaf library shared by all current copies.

## Caller verification

\`\`\`
$ rg -n '\"Budget\\.of_json|\"Confidence\\.of_json|\"Artifact_id\\.of_json|\"Timestamp\\.of_json' lib/ test/ -g '!shared_types/**'
(0 hits)
\`\`\`

Zero external callers pattern-match on the literal Error text — the longer message is purely additive operator information.

## Workaround Rejection Bar 7-item self-check

| # | Check | Result |
|---|-------|--------|
| 1 | telemetry-as-fix? | ❌ |
| 2 | string classifier? | ❌ — Json_kind.name is a closed total mapping |
| 3 | N-of-M? | ❌ — all 4 shared_types modules with of_json covered; resilience_outcome has no of_json |
| 4 | catch-all add? | ❌ — REPLACING \`_ ->\` with named \`other\` patterns |
| 5 | symptom suppression? | ❌ |
| 6 | test backdoor? | ❌ |
| 7 | codemod miss? | ❌ — file-by-file audit of lib/shared_types/ |

## Verification

- \`dune build lib/shared_types/shared_types.a\`: clean
- 6 files, +61/-8 (4 ml modules + 2 new ml/mli for Json_kind)

🤖 Generated with [Claude Code](https://claude.com/claude-code)