### PR TITLE
test(keeper): align phase gate source contracts

### DIFF
--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -5859,7 +5859,7 @@ let test_run_keeper_cycle_records_trajectory_source_contract () =
     "livelock block has durable terminal reason"
     true
     (source_file_contains
-       "lib/keeper/keeper_unified_turn.ml"
+       "lib/keeper/keeper_unified_turn_livelock_block.ml"
        "Printf.sprintf \"turn_livelock:%s\"")
 ;;
 
@@ -6007,7 +6007,7 @@ let test_run_keeper_cycle_surfaces_side_effect_failures_source_contract () =
     true
     (source_file_contains
        "lib/keeper/keeper_turn_helpers.ml"
-       "Keeper_registry.record_error ~base_path:config.base_path");
+       "Keeper_registry_error_recording.record ~base_path:config.base_path");
   check
     bool
     "trajectory finalize is not silently ignored"
@@ -6054,7 +6054,7 @@ let test_run_keeper_cycle_surfaces_side_effect_failures_source_contract () =
     "discovery helper guards keeper setup"
     true
     (source_file_contains
-       "lib/keeper/keeper_unified_turn.ml"
+       "lib/keeper/keeper_unified_turn_pre_dispatch.ml"
        "ensure_local_discovery_ready model_labels");
   check
     bool


### PR DESCRIPTION
## Summary
- update phase_gate source-contract checks to follow keeper module extractions
- point livelock terminal-reason checks at the extracted livelock handler
- point side-effect error recording and discovery preflight checks at their current modules

## Verification
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_unified.exe test/test_keeper_unified_turn_pipeline_records.exe test/test_keeper_runtime_manifest.exe
- ./_build/default/test/test_keeper_unified.exe test phase_gate --show-errors
- ./_build/default/test/test_keeper_unified.exe test transient_network_error --show-errors
- ./_build/default/test/test_keeper_unified_turn_pipeline_records.exe --show-errors
- ./_build/default/test/test_keeper_runtime_manifest.exe --show-errors

Refs #16079. Unblocks task-372 close-out evidence after the existing turn-pipeline PR #16215.