### PR TITLE
fix(verifier): include cdal verdict in submit payload

### DIFF
--- a/lib/keeper/keeper_trace_emit.ml
+++ b/lib/keeper/keeper_trace_emit.ml
@@ -57,13 +57,7 @@ let emit_transition
       "event", `String (SM.event_to_string event);
       "prev_phase", `String (SM.phase_to_string prev_phase);
       "new_phase", `String (SM.phase_to_string new_phase);
-<<<<<<< HEAD
       "conditions_after", SMJ.conditions_to_json conditions_after;
-||||||| parent of bd1d311d4d (fix(keeper): update state machine json callers)
-      "conditions_after", SM.conditions_to_json conditions_after;
-=======
-      "conditions_after", SM_json.conditions_to_json conditions_after;
->>>>>>> bd1d311d4d (fix(keeper): update state machine json callers)
       "restart_count", `Int restart_count;
     ] in
     let path = trace_path ~base_path ~keeper_name in

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -22,6 +22,7 @@
 type submit_request_spec =
   { criteria : Verification.criterion list
   ; output : Yojson.Safe.t
+  ; cdal_verdict : Cdal_types.contract_verdict option
   ; request_kind : string
   ; request_summary : string
   ; next_action : string
@@ -48,6 +49,19 @@ let deliverable_claims_completion ~task_id deliverable =
         normalized
       || String.starts_with ~prefix:"completed" normalized)
 
+let latest_cdal_verdict ~task_id =
+  Cdal_verdict_gate.lookup_latest_verdict
+    ~warn_on_missing:false
+    ~task_id
+    ()
+
+let cdal_verdict_payload ~task_id = function
+  | None -> `Null
+  | Some verdict ->
+    (match Cdal_types.contract_verdict_to_json verdict with
+     | `Assoc fields -> `Assoc (("task_id", `String task_id) :: fields)
+     | other -> other)
+
 let submit_request_spec ~(config : Coord.config) ~(task : Masc_domain.task)
     ~assignee ~evidence_refs =
   let request_kind, request_summary, next_action, board_type, board_title, board_content =
@@ -71,6 +85,8 @@ let submit_request_spec ~(config : Coord.config) ~(task : Masc_domain.task)
           Printf.sprintf "Verification requested for task %s (%s) by %s"
             task.id task.title assignee )
   in
+  let cdal_verdict = latest_cdal_verdict ~task_id:task.id in
+  let cdal_verdict_json = cdal_verdict_payload ~task_id:task.id cdal_verdict in
   let criteria = List.map (fun s -> Verification.Custom s)
     (match task.contract with
      | Some c -> c.completion_contract
@@ -82,10 +98,12 @@ let submit_request_spec ~(config : Coord.config) ~(task : Masc_domain.task)
       ("request_kind", `String request_kind);
       ("request_summary", `String request_summary);
       ("next_action", `String next_action);
+      ("cdal_verdict", cdal_verdict_json);
     ]
   in
   { criteria
   ; output
+  ; cdal_verdict
   ; request_kind
   ; request_summary
   ; next_action
@@ -144,6 +162,7 @@ let notify_submit_for_verification ~(config : Coord.config)
     ("criteria", `List (List.map Verification.criterion_to_yojson spec.criteria));
     ("request_kind", `String spec.request_kind);
     ("next_action", `String spec.next_action);
+    ("cdal_verdict", cdal_verdict_payload ~task_id:task.id spec.cdal_verdict);
   ] in
   let () =
     match Board_dispatch.create_post
@@ -168,6 +187,7 @@ let notify_submit_for_verification ~(config : Coord.config)
     ("verification_id", `String verification_id);
     ("worker", `String assignee);
     ("evidence_refs", `List (List.map (fun s -> `String s) evidence_refs));
+    ("cdal_verdict", cdal_verdict_payload ~task_id:task.id spec.cdal_verdict);
     ("timestamp", `Float (Time_compat.now ()));
   ]);
   ()

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -62,6 +62,19 @@ let cdal_verdict_payload ~task_id = function
      | `Assoc fields -> `Assoc (("task_id", `String task_id) :: fields)
      | other -> other)
 
+let cdal_verdict_payload_of_request_output = function
+  | `Assoc fields -> List.assoc_opt "cdal_verdict" fields
+  | _ -> None
+
+let persisted_cdal_verdict_payload ~base_path ~task_id ~verification_id
+    ~fallback =
+  match Verification.load_request base_path verification_id with
+  | Ok request when String.equal request.Verification.task_id task_id ->
+    (match cdal_verdict_payload_of_request_output request.output with
+     | Some payload -> payload
+     | None -> fallback)
+  | Ok _ | Error _ -> fallback
+
 let submit_request_spec ~(config : Coord.config) ~(task : Masc_domain.task)
     ~assignee ~evidence_refs =
   let request_kind, request_summary, next_action, board_type, board_title, board_content =
@@ -153,6 +166,13 @@ let create_submit_request ~(config : Coord.config)
 let notify_submit_for_verification ~(config : Coord.config)
     ~(task : Masc_domain.task) ~assignee ~verification_id ~evidence_refs =
   let spec = submit_request_spec ~config ~task ~assignee ~evidence_refs in
+  let cdal_verdict_json =
+    persisted_cdal_verdict_payload
+      ~base_path:config.Coord.base_path
+      ~task_id:task.id
+      ~verification_id
+      ~fallback:(cdal_verdict_payload ~task_id:task.id spec.cdal_verdict)
+  in
   let meta_json = `Assoc [
     ("type", `String spec.board_type);
     ("task_id", `String task.id);
@@ -162,7 +182,7 @@ let notify_submit_for_verification ~(config : Coord.config)
     ("criteria", `List (List.map Verification.criterion_to_yojson spec.criteria));
     ("request_kind", `String spec.request_kind);
     ("next_action", `String spec.next_action);
-    ("cdal_verdict", cdal_verdict_payload ~task_id:task.id spec.cdal_verdict);
+    ("cdal_verdict", cdal_verdict_json);
   ] in
   let () =
     match Board_dispatch.create_post
@@ -187,7 +207,7 @@ let notify_submit_for_verification ~(config : Coord.config)
     ("verification_id", `String verification_id);
     ("worker", `String assignee);
     ("evidence_refs", `List (List.map (fun s -> `String s) evidence_refs));
-    ("cdal_verdict", cdal_verdict_payload ~task_id:task.id spec.cdal_verdict);
+    ("cdal_verdict", cdal_verdict_json);
     ("timestamp", `Float (Time_compat.now ()));
   ]);
   ()

--- a/lib/verification_protocol.mli
+++ b/lib/verification_protocol.mli
@@ -33,8 +33,11 @@ val create_submit_request :
   (unit, string) result
 (** [create_submit_request ~config ~task ~assignee ~verification_id
       ~evidence_refs] persists a board post for the verification
-    request.  Returns [Error _] when board persistence fails or
-    the task does not satisfy the contract gap pre-check. *)
+    request.  The persisted request output includes the latest
+    task-scoped [cdal_verdict] when one exists, or [null] when the
+    ledger has no verdict for the task.  Returns [Error _] when
+    board persistence fails or the task does not satisfy the
+    contract gap pre-check. *)
 
 val notify_submit_for_verification :
   config:Coord.config ->
@@ -46,7 +49,9 @@ val notify_submit_for_verification :
 (** [notify_submit_for_verification ...] emits the
     [masc/verification/requested] SSE event without mutating state.
     Used by callers that have already created the board post via
-    {!create_submit_request} but need a separate SSE broadcast. *)
+    {!create_submit_request} but need a separate SSE broadcast.
+    The board meta and SSE payload mirror the [cdal_verdict] field
+    from the persisted request output. *)
 
 val on_submit_for_verification :
   config:Coord.config ->

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -50,6 +50,16 @@ let with_env name value f =
     f
 ;;
 
+let with_temp_board_base dir f =
+  Fun.protect
+    ~finally:(fun () -> Board.reset_global_for_test ())
+    (fun () ->
+       with_env "MASC_BASE_PATH_INPUT" None (fun () ->
+         with_env "MASC_BASE_PATH" (Some dir) (fun () ->
+           Board.reset_global_for_test ();
+           f ())))
+;;
+
 let with_temp_data_dir f =
   let dir = Filename.temp_dir "test_keeper_task_cdal_" "" in
   let rec rm path =
@@ -227,6 +237,29 @@ let cdal_verdict_of_request (req : Verification.verification_request) =
   match req.output with
   | `Assoc fields -> List.assoc_opt "cdal_verdict" fields
   | _ -> None
+;;
+
+let string_field_exn ~context name fields =
+  match List.assoc_opt name fields with
+  | Some (`String value) -> value
+  | Some other ->
+    fail
+      (Printf.sprintf
+         "expected string field %s in %s, got %s"
+         name
+         context
+         (Yojson.Safe.to_string other))
+  | None -> fail (Printf.sprintf "expected string field %s in %s" name context)
+;;
+
+let cdal_verdict_run_id_exn ~context = function
+  | `Assoc fields -> string_field_exn ~context "run_id" fields
+  | other ->
+    fail
+      (Printf.sprintf
+         "expected cdal_verdict object in %s, got %s"
+         context
+         (Yojson.Safe.to_string other))
 ;;
 
 (* Temp directory setup following test_keeper_tools_oas.ml pattern.
@@ -2178,6 +2211,80 @@ let test_submit_for_verification_includes_cdal_verdict_payload () =
           | _ -> fail "expected keeper_task_submit_for_verification to succeed"))))
 ;;
 
+let test_notify_reuses_persisted_cdal_verdict_payload () =
+  ensure_rng ();
+  with_temp_data_dir (fun data_dir ->
+    with_temp_board_base data_dir (fun () ->
+      with_room (fun config ->
+        let contract = strict_contract ~verify_gate_evidence:[ "pr_url" ] () in
+        let _ =
+          Coord.add_task
+            ~contract
+            config
+            ~title:"Verification notify CDAL snapshot task"
+            ~priority:1
+            ~description:"should reuse persisted CDAL verdict for notifications"
+        in
+        let task = only_task config in
+        let task_id = task.id in
+        let verification_id = "vrf-notify-cdal-snapshot" in
+        Cdal_eval_v1.persist
+          ~task_id
+          (make_cdal_verdict ~run_id:"run-persisted-snapshot" ());
+        (match
+           Verification_protocol.create_submit_request
+             ~config
+             ~task
+             ~assignee:"worker-a"
+             ~verification_id
+             ~evidence_refs:[ "pr:https://github.com/jeong-sik/masc-mcp/pull/16486" ]
+         with
+         | Ok () -> ()
+         | Error msg -> fail ("create_submit_request failed: " ^ msg));
+        Cdal_eval_v1.persist
+          ~task_id
+          (make_cdal_verdict ~run_id:"run-newer-ledger-entry" ());
+        Verification_protocol.notify_submit_for_verification
+          ~config
+          ~task
+          ~assignee:"worker-a"
+          ~verification_id
+          ~evidence_refs:[ "pr:https://github.com/jeong-sik/masc-mcp/pull/16486" ];
+        let post =
+          Board_dispatch.list_posts ~hearth:"verification" ~limit:20 ()
+          |> List.find_opt (fun (post : Board.post) ->
+            match post.meta_json with
+            | Some (`Assoc fields) ->
+              (match List.assoc_opt "task_id" fields with
+               | Some (`String value) -> String.equal value task_id
+               | _ -> false)
+            | _ -> false)
+          |> function
+          | Some post -> post
+          | None -> fail "expected verification board post for task"
+        in
+        let meta_fields =
+          match post.meta_json with
+          | Some (`Assoc fields) -> fields
+          | Some other ->
+            fail
+              (Printf.sprintf
+                 "expected board meta object, got %s"
+                 (Yojson.Safe.to_string other))
+          | None -> fail "expected board meta"
+        in
+        let cdal_verdict =
+          match List.assoc_opt "cdal_verdict" meta_fields with
+          | Some payload -> payload
+          | None -> fail "expected cdal_verdict in board meta"
+        in
+        check
+          string
+          "notification reuses persisted cdal verdict"
+          "run-persisted-snapshot"
+          (cdal_verdict_run_id_exn ~context:"board meta" cdal_verdict))))
+;;
+
 (* Regression: keeper_task_done must map [result] onto the typed
    [handoff_context.summary] domain field, not just dump it into [notes]
    as an untyped blob. Previously a [result] sent by a keeper would be
@@ -2612,6 +2719,10 @@ let () =
             "includes task-scoped CDAL verdict payload"
             `Quick
             test_submit_for_verification_includes_cdal_verdict_payload
+        ; test_case
+            "notification reuses persisted CDAL verdict payload"
+            `Quick
+            test_notify_reuses_persisted_cdal_verdict_payload
         ; test_case
             "notes/pr_url map to typed handoff_context fields"
             `Quick

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -1,4 +1,5 @@
 module Types = Masc_domain
+module CT = Cdal_types
 
 (** Tests for keeper_task_claim and keeper_task_done tool dispatch. *)
 
@@ -47,6 +48,22 @@ let with_env name value f =
       | Some v -> Unix.putenv name v
       | None -> Unix.putenv name "")
     f
+;;
+
+let with_temp_data_dir f =
+  let dir = Filename.temp_dir "test_keeper_task_cdal_" "" in
+  let rec rm path =
+    if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun name -> rm (Filename.concat path name));
+      Unix.rmdir path)
+    else Sys.remove path
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      try rm dir with
+      | _ -> ())
+    (fun () -> with_env "MASC_DATA_DIR" (Some dir) (fun () -> f dir))
 ;;
 
 let only_task config =
@@ -120,6 +137,35 @@ let strict_contract ?(verify_gate_evidence = []) () : Masc_domain.task_contract 
   }
 ;;
 
+let make_cdal_verdict ?(run_id = "test-submit-cdal-verdict")
+    ?(contract_id = "md5:test-submit-contract") () : CT.contract_verdict =
+  let basis_input =
+    Printf.sprintf
+      "%s|%s|%s"
+      contract_id
+      CT.loader_semantics_version_phase1
+      CT.schema_compat_mode_v1
+  in
+  let basis_hash = "md5:" ^ (Digest.string basis_input |> Digest.to_hex) in
+  let verdict_without_hash : CT.contract_verdict =
+    { run_id
+    ; contract_id
+    ; claim_scope = CT.claim_scope_phase1
+    ; judgment_basis_hash = basis_hash
+    ; judgment_hash = ""
+    ; loader_semantics_version = CT.loader_semantics_version_phase1
+    ; schema_compat_mode = CT.schema_compat_mode_v1
+    ; status = CT.Satisfied
+    ; findings = []
+    ; completeness_gaps = []
+    ; check_results = []
+    }
+  in
+  { verdict_without_hash with
+    judgment_hash = CT.compute_judgment_hash verdict_without_hash
+  }
+;;
+
 let contract_requiring_tools required_tools : Masc_domain.task_contract =
   { strict = false
   ; completion_contract = []
@@ -175,6 +221,12 @@ let evidence_refs_of_request (req : Verification.verification_request) =
          refs
      | _ -> [])
   | _ -> []
+;;
+
+let cdal_verdict_of_request (req : Verification.verification_request) =
+  match req.output with
+  | `Assoc fields -> List.assoc_opt "cdal_verdict" fields
+  | _ -> None
 ;;
 
 (* Temp directory setup following test_keeper_tools_oas.ml pattern.
@@ -2059,6 +2111,73 @@ let test_submit_for_verification_transitions_task () =
         | _ -> fail "expected keeper_task_submit_for_verification to succeed")))
 ;;
 
+let test_submit_for_verification_includes_cdal_verdict_payload () =
+  ensure_rng ();
+  with_env "MASC_VERIFICATION_FSM_ENABLED" (Some "true") (fun () ->
+    with_env "MASC_CDAL_GATE_ENABLED" (Some "false") (fun () ->
+      with_temp_data_dir (fun _data_dir ->
+        with_room (fun config ->
+          let meta = make_test_meta () in
+          let contract = strict_contract ~verify_gate_evidence:[ "pr_url" ] () in
+          let _ =
+            Coord.add_task
+              ~contract
+              config
+              ~title:"Verification submit CDAL payload task"
+              ~priority:1
+              ~description:"should carry CDAL verdict into verification payload"
+          in
+          let task_id = (only_task config).id in
+          let run_id = "run-submit-cdal-payload" in
+          let verdict = make_cdal_verdict ~run_id () in
+          Cdal_eval_v1.persist ~task_id verdict;
+          ignore (call_tool config meta "keeper_task_claim" (`Assoc []));
+          let result =
+            call_tool
+              config
+              meta
+              "keeper_task_submit_for_verification"
+              (`Assoc
+                  [ "task_id", `String task_id
+                  ; "notes", `String "tests pass locally"
+                  ; ( "pr_url"
+                    , `String "https://github.com/jeong-sik/masc-mcp/pull/16486" )
+                  ])
+          in
+          let json = parse_json result in
+          match Yojson.Safe.Util.member "ok" json with
+          | `Bool true ->
+            let request = verification_request_by_task_id config ~task_id in
+            (match cdal_verdict_of_request request with
+             | Some (`Assoc fields) ->
+               let string_field name =
+                 match List.assoc_opt name fields with
+                 | Some (`String value) -> value
+                 | Some other ->
+                   fail
+                     (Printf.sprintf
+                        "expected string field %s in cdal_verdict, got %s"
+                        name
+                        (Yojson.Safe.to_string other))
+                 | None ->
+                   fail
+                     (Printf.sprintf
+                        "expected string field %s in cdal_verdict"
+                        name)
+               in
+               check string "cdal task id" task_id (string_field "task_id");
+               check string "cdal run id" run_id (string_field "run_id");
+               check string "cdal status" "satisfied" (string_field "status")
+             | Some `Null -> fail "expected persisted cdal_verdict, got null"
+             | Some other ->
+               fail
+                 (Printf.sprintf
+                    "expected cdal_verdict object, got %s"
+                    (Yojson.Safe.to_string other))
+             | None -> fail "expected cdal_verdict in verification request output")
+          | _ -> fail "expected keeper_task_submit_for_verification to succeed"))))
+;;
+
 (* Regression: keeper_task_done must map [result] onto the typed
    [handoff_context.summary] domain field, not just dump it into [notes]
    as an untyped blob. Previously a [result] sent by a keeper would be
@@ -2489,6 +2608,10 @@ let () =
             "transitions task"
             `Quick
             test_submit_for_verification_transitions_task
+        ; test_case
+            "includes task-scoped CDAL verdict payload"
+            `Quick
+            test_submit_for_verification_includes_cdal_verdict_payload
         ; test_case
             "notes/pr_url map to typed handoff_context fields"
             `Quick


### PR DESCRIPTION
Summary: include the latest task-scoped CDAL verdict in verification request output, board metadata, and SSE payload; add regression coverage for keeper_task_submit_for_verification carrying a persisted verdict. Fixes #16486. Validation: ocamlformat --check lib/verification_protocol.ml lib/verification_protocol.mli test/test_keeper_task_dispatch.ml; scripts/dune-local.sh build ./test/test_keeper_task_dispatch.exe ./test/test_verification_fsm.exe ./test/test_cdal_verdict_gate.exe; ./_build/default/test/test_keeper_task_dispatch.exe; ./_build/default/test/test_verification_fsm.exe; ./_build/default/test/test_cdal_verdict_gate.exe.