### PR TITLE
fix(keeper): mark auto-pause writers recoverable

### DIFF
--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -57,6 +57,12 @@ let oas_timeout_guard_sec = 15.0
 
 let min_oas_timeout_budget_sec = 15.0
 
+let next_auto_resume_after_sec previous =
+  Keeper_supervisor_types.next_auto_resume_after_sec
+    ~initial_sec:Env_config.KeeperSupervisor.auto_resume_initial_sec
+    ~max_sec:Env_config.KeeperSupervisor.auto_resume_max_sec
+    previous
+
 type oas_timeout_budget_resolution = {
   effective_timeout_sec : float;
   adaptive_timeout_sec : float;
@@ -500,6 +506,7 @@ let pause_keeper_for_overflow
     {
       meta with
       paused = true;
+      auto_resume_after_sec = next_auto_resume_after_sec meta.auto_resume_after_sec;
       updated_at = now_iso ();
     }
   in
@@ -557,13 +564,21 @@ let pause_keeper_for_overflow
   paused_meta
 
 let sync_keeper_paused_state
+    ?(auto_resume = false)
     ~(config : Coord.config)
     ~(meta : keeper_meta)
-    ~(paused : bool) : (keeper_meta, string) result =
+    ~(paused : bool)
+    () : (keeper_meta, string) result =
+  let auto_resume_after_sec =
+    if paused && auto_resume then
+      next_auto_resume_after_sec meta.auto_resume_after_sec
+    else meta.auto_resume_after_sec
+  in
   let synced_meta =
     {
       meta with
       paused;
+      auto_resume_after_sec;
       updated_at = now_iso ();
     }
   in
@@ -670,7 +685,14 @@ let make_post_turn_resilience_executor
       (Some
          (Keeper_registry.Provider_runtime_error
             { code; detail; provider_id = None; http_status = None }));
-    match sync_keeper_paused_state ~config ~meta:latest_meta ~paused:true with
+    match
+      sync_keeper_paused_state
+        ~auto_resume:true
+        ~config
+        ~meta:latest_meta
+        ~paused:true
+        ()
+    with
     | Ok paused_meta ->
         on_paused paused_meta;
         Ok ()
@@ -814,7 +836,7 @@ let enqueue_partial_commit_continue_gate
       match decision with
       | Agent_sdk.Hooks.Approve
       | Agent_sdk.Hooks.Edit _ ->
-        (match sync_keeper_paused_state ~config ~meta:latest_meta ~paused:false with
+        (match sync_keeper_paused_state ~config ~meta:latest_meta ~paused:false () with
          | Ok resumed_meta ->
              Keeper_registry.set_failure_reason ~base_path:config.base_path meta.name None;
              Keeper_registry.reset_turn_failures ~base_path:config.base_path meta.name;
@@ -830,7 +852,7 @@ let enqueue_partial_commit_continue_gate
                ~labels:[("keeper", meta.name); ("site", Keeper_cascade_sync_failure_site.(to_label Resume_sync))]
                ()
       | Agent_sdk.Hooks.Reject reason ->
-        (match sync_keeper_paused_state ~config ~meta:latest_meta ~paused:true with
+        (match sync_keeper_paused_state ~config ~meta:latest_meta ~paused:true () with
          | Ok paused_meta ->
              Keeper_registry.set_failure_reason
                ~base_path:config.base_path meta.name

--- a/lib/keeper/keeper_turn_cascade_budget.mli
+++ b/lib/keeper/keeper_turn_cascade_budget.mli
@@ -205,11 +205,16 @@ val pause_keeper_for_overflow :
     paused meta. *)
 
 val sync_keeper_paused_state :
+  ?auto_resume:bool ->
   config:Coord.config ->
   meta:keeper_meta ->
   paused:bool ->
+  unit ->
   (keeper_meta, string) result
 (** Persist paused/resumed state before mutating the live registry/phase.
+    [auto_resume] means the pause is supervisor-recoverable and should receive
+    the standard exponential auto-resume backoff.
+
     Returns [Error] when disk sync fails so callers can surface the failure
     instead of silently diverging runtime vs persisted state. *)
 

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1442,7 +1442,7 @@ let run_keeper_cycle
                         meta.name
                         (Some failure_reason);
                       match
-                        sync_keeper_paused_state ~config ~meta:updated_meta ~paused:true
+                        sync_keeper_paused_state ~config ~meta:updated_meta ~paused:true ()
                       with
                       | Ok paused_meta ->
                         let approval_id =

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -150,9 +150,11 @@ val resolved_max_context_for_turn : meta:Keeper_types.keeper_meta -> string list
     Returns [Error] when disk sync fails so callers can surface the failure
     instead of silently diverging runtime vs persisted state. *)
 val sync_keeper_paused_state
-  :  config:Coord.config
+  :  ?auto_resume:bool
+  -> config:Coord.config
   -> meta:Keeper_types.keeper_meta
   -> paused:bool
+  -> unit
   -> (Keeper_types.keeper_meta, string) result
 
 (** Required-tool contract failures are persistent keeper/provider contract

--- a/lib/keeper/keeper_unified_turn_failure.ml
+++ b/lib/keeper/keeper_unified_turn_failure.ml
@@ -66,6 +66,7 @@ let record_failure_and_maybe_escalate
           ~config
           ~meta:pause_meta
           ~paused:true
+          ()
       with
       | Ok _ ->
         if cascade_auto_paused

--- a/lib/keeper/keeper_unified_turn_livelock_block.ml
+++ b/lib/keeper/keeper_unified_turn_livelock_block.ml
@@ -16,6 +16,13 @@ let gate_kind_of_livelock_reason ~keeper_name reason =
     Keeper_livelock_state.Attempts_exhausted
 ;;
 
+let next_auto_resume_after_sec previous =
+  Keeper_supervisor_types.next_auto_resume_after_sec
+    ~initial_sec:Env_config.KeeperSupervisor.auto_resume_initial_sec
+    ~max_sec:Env_config.KeeperSupervisor.auto_resume_max_sec
+    previous
+;;
+
 let record_escalation_log ~keeper_name ~keeper_turn_id ~turn_id ~reason_string ~gate_kind =
   match Keeper_livelock_state.record_block ~keeper:keeper_name ~gate_kind () with
   | `First ->
@@ -78,6 +85,7 @@ let persist_turn_livelock_pause
   let updated =
     { meta with
       paused = true
+    ; auto_resume_after_sec = next_auto_resume_after_sec meta.auto_resume_after_sec
     ; updated_at = Keeper_types.now_iso ()
     ; runtime = { meta.runtime with last_blocker = Some blocker }
     }

--- a/test/test_keeper_paused_cas_retain_9733.ml
+++ b/test/test_keeper_paused_cas_retain_9733.ml
@@ -57,6 +57,80 @@ let make_meta ~name =
   | Ok m -> m
   | Error e -> fail ("meta_of_json failed: " ^ e)
 
+let expected_initial_auto_resume_after_sec () =
+  Keeper_supervisor_types.next_auto_resume_after_sec
+    ~initial_sec:Env_config.KeeperSupervisor.auto_resume_initial_sec
+    ~max_sec:Env_config.KeeperSupervisor.auto_resume_max_sec
+    None
+
+let check_initial_auto_resume label actual =
+  check
+    (option (float 0.1))
+    label
+    (expected_initial_auto_resume_after_sec ())
+    actual
+
+let test_overflow_pause_marks_auto_resumable () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_dir) (fun () ->
+    let config = Coord.default_config base_dir in
+    ignore (Coord.init config ~agent_name:(Some "operator"));
+    let meta = make_meta ~name:"overflow-auto-resume-9733" in
+    (match Keeper_types.write_meta ~force:true config meta with
+     | Ok () -> ()
+     | Error e -> fail ("seed failed: " ^ e));
+    ignore (Keeper_registry.register ~base_path:base_dir meta.name meta);
+    let paused =
+      Keeper_turn_cascade_budget.pause_keeper_for_overflow
+        ~config
+        ~meta
+        ~reason:"test-overflow"
+    in
+    check bool "overflow pause returned paused=true" true paused.paused;
+    check_initial_auto_resume
+      "overflow pause gets initial auto_resume_after_sec"
+      paused.auto_resume_after_sec;
+    let persisted =
+      match Keeper_types.read_meta config meta.name with
+      | Ok (Some m) -> m
+      | Ok None -> fail "expected persisted meta"
+      | Error e -> fail ("read_meta failed: " ^ e)
+    in
+    check_initial_auto_resume
+      "persisted overflow pause gets initial auto_resume_after_sec"
+      persisted.auto_resume_after_sec)
+
+let test_sync_pause_auto_resume_flag_sets_backoff () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_dir) (fun () ->
+    let config = Coord.default_config base_dir in
+    ignore (Coord.init config ~agent_name:(Some "operator"));
+    let meta = make_meta ~name:"sync-auto-resume-9733" in
+    (match Keeper_types.write_meta ~force:true config meta with
+     | Ok () -> ()
+     | Error e -> fail ("seed failed: " ^ e));
+    ignore (Keeper_registry.register ~base_path:base_dir meta.name meta);
+    match
+      Keeper_turn_cascade_budget.sync_keeper_paused_state
+        ~auto_resume:true
+        ~config
+        ~meta
+        ~paused:true
+        ()
+    with
+    | Error e -> fail ("sync pause failed: " ^ e)
+    | Ok paused ->
+      check bool "sync pause returned paused=true" true paused.paused;
+      check_initial_auto_resume
+        "sync pause gets initial auto_resume_after_sec"
+        paused.auto_resume_after_sec)
+
 (* Race: overflow fiber observed unpaused at version N, decides
    to pause; heartbeat fiber bumps to version N+1 with new
    joined_room_ids; overflow fiber attempts write with stale
@@ -167,12 +241,22 @@ let test_resume_caller_wins_heartbeat_disk_wins () =
 
 let () =
   run "Keeper paused-field CAS retain (#9733)"
-    [
-      ( "pause-resume-merge",
-        [
-          test_case "pause: caller wins, heartbeat retained" `Quick
-            test_pause_caller_wins_heartbeat_disk_wins;
-          test_case "resume: caller wins, heartbeat retained" `Quick
-            test_resume_caller_wins_heartbeat_disk_wins;
-        ] );
+    [ ( "pause-resume-merge"
+      , [ test_case
+            "overflow pause marks auto-resumable"
+            `Quick
+            test_overflow_pause_marks_auto_resumable
+        ; test_case
+            "sync pause auto-resume flag sets backoff"
+            `Quick
+            test_sync_pause_auto_resume_flag_sets_backoff
+        ; test_case
+            "pause: caller wins, heartbeat retained"
+            `Quick
+            test_pause_caller_wins_heartbeat_disk_wins
+        ; test_case
+            "resume: caller wins, heartbeat retained"
+            `Quick
+            test_resume_caller_wins_heartbeat_disk_wins
+        ] )
     ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -5697,6 +5697,11 @@ let test_run_keeper_cycle_livelock_block_returns_error () =
          (match Masc_mcp.Keeper_types.read_meta config meta.name with
           | Ok (Some persisted) ->
             check bool "livelock persists paused keeper" true persisted.paused;
+            check
+              bool
+              "livelock pause marks auto-resumable"
+              true
+              (Option.is_some persisted.auto_resume_after_sec);
             (match persisted.runtime.last_blocker with
              | Some blocker ->
                check
@@ -6095,7 +6100,7 @@ let test_sync_keeper_paused_state_surfaces_write_failure_without_mutating_regist
        let keepers_path = Filename.concat masc_root "keepers" in
        let oc = open_out_bin keepers_path in
        close_out oc;
-       match UT.sync_keeper_paused_state ~config ~meta ~paused:true with
+       match UT.sync_keeper_paused_state ~config ~meta ~paused:true () with
        | Ok _ -> fail "expected paused-state sync failure"
        | Error msg ->
          check


### PR DESCRIPTION
## Summary
- mark overflow retry-exhausted pauses with the existing supervisor auto-resume backoff
- add an explicit ~auto_resume flag to sync_keeper_paused_state and use it for post-turn resilience pauses only
- mark turn-livelock pauses with the same backoff so Phase 3.5 can sweep them

## Why
The pause investigation found S3/S4/S5 emitters persisted paused=true without auto_resume_after_sec. The supervisor auto-resume sweep only considers durable pauses with auto_resume_after_sec, so those paths could stay paused indefinitely.

This does not change operator/approval/manual pauses by default. Existing sync_keeper_paused_state callers keep the old behavior unless they pass ~auto_resume:true.

## Validation
- ocamlformat --check lib/keeper/keeper_turn_cascade_budget.ml lib/keeper/keeper_turn_cascade_budget.mli lib/keeper/keeper_unified_turn.mli lib/keeper/keeper_unified_turn_livelock_block.ml test/test_keeper_paused_cas_retain_9733.ml test/test_keeper_unified.ml
- git diff --check
- scripts/dune-local.sh build test/test_keeper_paused_cas_retain_9733.exe test/test_keeper_unified.exe attempted, blocked by unrelated live bare Dune process: /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-verification-cdal-verdict-payload-16486