### PR TITLE
fix(tool_profile): expose cursor parse failure mode in 2 sites

### DIFF
--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -395,7 +395,18 @@ let decode_cursor_offset = function
   | Some raw -> (
       match int_of_string_opt raw with
       | Some offset when offset >= 0 -> Ok offset
-      | _ -> Error "Invalid params: cursor must be a non-negative integer string")
+      | Some offset ->
+          Error
+            (Printf.sprintf
+               "Invalid params: cursor offset must be non-negative \
+                (parsed %d from %S)"
+               offset raw)
+      | None ->
+          Error
+            (Printf.sprintf
+               "Invalid params: cursor must be a non-negative integer \
+                string (could not parse %S as an integer)"
+               raw))
 
 let rec drop_list n = function
   | xs when n <= 0 -> xs
@@ -552,7 +563,25 @@ let page_items_with_cursor ~kind items cursor =
     | Some encoded -> (
         match decode_cursor ~kind encoded with
         | Some value when value >= 0 -> Ok value
-        | _ -> Error "Invalid params: cursor is invalid")
+        | Some value ->
+            Error
+              (Printf.sprintf
+                 "Invalid params: cursor decoded to negative offset %d \
+                  (kind=%S, encoded=%S)"
+                 value kind encoded)
+        | None ->
+            (* [decode_cursor] returns [None] for three different
+               failure modes (base64 decode failed / kind-prefix
+               mismatch / int_of_string_opt failed).  Promoting it to
+               [(int, string) result] is a separate change because it
+               is the second [decode_cursor] in the tree (the other
+               lives in [graphql_api]) and the [int option] contract
+               is exercised by both. *)
+            Error
+              (Printf.sprintf
+                 "Invalid params: cursor %S could not be decoded \
+                  (expected base64-encoded \"%s:<non-negative int>\")"
+                 encoded kind))
   in
   let rec drop n xs =
     match (n, xs) with

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -2369,9 +2369,13 @@ let test_handle_request_resources_templates_rejects_invalid_cursor () =
   in
   let response = Mcp_eio.handle_request ~clock ~sw state request in
   Alcotest.(check int) "invalid params code" (-32602) (error_code_exn response);
-  Alcotest.(check string) "invalid cursor error"
-    "Invalid params: cursor is invalid"
-    (error_message_exn response);
+  let msg = error_message_exn response in
+  Alcotest.(check bool)
+    "invalid cursor error preserves contract label" true
+    (contains_substring msg "Invalid params: cursor");
+  Alcotest.(check bool)
+    "invalid cursor error names received string" true
+    (contains_substring msg "not-base64");
   cleanup_dir base_path
 
 let test_handle_request_prompts_list_rejects_invalid_cursor () =
@@ -2393,9 +2397,13 @@ let test_handle_request_prompts_list_rejects_invalid_cursor () =
   in
   let response = Mcp_eio.handle_request ~clock ~sw state request in
   Alcotest.(check int) "invalid params code" (-32602) (error_code_exn response);
-  Alcotest.(check string) "invalid cursor error"
-    "Invalid params: cursor is invalid"
-    (error_message_exn response);
+  let msg = error_message_exn response in
+  Alcotest.(check bool)
+    "invalid cursor error preserves contract label" true
+    (contains_substring msg "Invalid params: cursor");
+  Alcotest.(check bool)
+    "invalid cursor error names received string" true
+    (contains_substring msg "bad-cursor");
   cleanup_dir base_path
 
 let test_handle_request_prompts_list_non_empty () =


### PR DESCRIPTION
## Summary

Iter#89 of FSM/TLA+/clarity sweep — operator-clarity chain:
**#16903 → #16907 → #16911 → #16914 → #16915/#16919 (open) → this**.

Two catch-alls in \`lib/mcp_server_eio_tool_profile.ml:398, 555\` collapsed multiple failure modes into a single opaque message.

## Before/After

| Site | Before | After |
|------|--------|-------|
| L398 decode_cursor_offset | \`cursor must be a non-negative integer string\` | split \`Some offset (parsed %d from %S)\` vs \`None (could not parse %S as integer)\` |
| L555 page_items_with_cursor | \`cursor is invalid\` | split \`Some value (negative offset %d, kind=%S, encoded=%S)\` vs \`None (could not decode %S, expected base64-encoded \"kind:int\")\` |

The 2 catch-alls collapsed 5 distinct failure modes total. This PR keeps the failure modes typed at the call site without changing the upstream \`decode_cursor : ... -> int option\` contract (sibling \`decode_cursor\` in \`lib/graphql_api.ml\` has 3 callers — coordinated upgrade is deferred to a follow-up).

The existing site at line 380 already uses the \`Json_util.kind_name other\` pattern (5 sites in this file), so this PR aligns the 2 remaining catch-alls with that house style.

## Test impact

Two \`Alcotest.(check string)\` assertions in \`test/test_mcp_server_eio.ml\` were locked to the exact previous literal. Per feedback memory \`feedback_dead_defensive_cleanup_must_check_test_lock\`: mirror-update + convert to substring assertion:

- assert contract label \`\"Invalid params: cursor\"\` survives (future enrichment can extend without re-breaking)
- assert the user-provided cursor string appears (operator-traceability)

Both modified tests PASS locally.

## Pre-existing main break

\`lib/keeper/keeper_trace_emit.ml:55\` references missing \`SM.conditions_to_json\` (similar to iter#79's \`Keeper_tool_bash_input.t\`). Worked around locally by temporarily replacing the call with \`\\\`Null\` to enable test exe build; reverted before commit. Iter scope is only the two PR files.

## Workaround Rejection Bar 7-item self-check

| # | Check | Result |
|---|-------|--------|
| 1 | telemetry-as-fix? | ❌ |
| 2 | string classifier? | ❌ |
| 3 | N-of-M? | ❌ — both sites + paired test fix |
| 4 | catch-all add? | ❌ — REPLACING \`_ ->\` with named \`Some other \| None\` |
| 5 | symptom suppression? | ❌ |
| 6 | test backdoor? | ❌ — test became *less* lock-strict, reducing brittleness |
| 7 | codemod miss? | ❌ |

## Verification

- \`dune build lib/.../Mcp_server_eio_tool_profile.cmi\`: clean
- \`dune build test/test_mcp_server_eio.exe\` + run: 2 modified cursor tests PASS
- 2 files, +45/-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)