### PR TITLE
fix(dashboard_eval_feed): remove unreachable Eio.Cancel.Cancelled catch arms

### DIFF
--- a/lib/dashboard_eval_feed/dashboard_eval_feed.ml
+++ b/lib/dashboard_eval_feed/dashboard_eval_feed.ml
@@ -124,7 +124,6 @@ let list_agents ~base_path =
          Sys.is_directory (Filename.concat dir name))
     |> List.sort String.compare
   with
-  | Eio.Cancel.Cancelled _ as e -> raise e
   | Sys_error msg ->
     Log.Dashboard.warn
       "[eval_feed.list_agents] eval directory unreadable at %s: %s"
@@ -141,7 +140,6 @@ let read_latest ~base_path ~agent_name ~limit =
       |> List.filter (fun f -> Filename.check_suffix f ".json")
       |> List.sort (fun a b -> String.compare b a)
     with
-    | Eio.Cancel.Cancelled _ as e -> raise e
     | Sys_error msg ->
       Log.Dashboard.warn
         "[eval_feed.read_latest] per-agent verdict directory unreadable for \


### PR DESCRIPTION
## Summary

- Remove two `Eio.Cancel.Cancelled` catch arms from `dashboard_eval_feed.ml` that reference `Eio` module unavailable in this sub-library
- These arms were unreachable dead code: `Sys.readdir` is a synchronous stdlib call that does not participate in Eio fiber cancellation
- Introduced in #16802 (silent-failure surfacing PR) as copy-paste from Eio-aware code paths

## Why

The `dashboard_eval_feed` sub-library has no `eio` dependency (dune: `libraries yojson agent_sdk masc_core`). With `warn-error=+a`, any reference to `Eio.Cancel.Cancelled` causes a compilation failure: `Unbound module Eio`.

## Test plan

- [x] `dune build --root . @lint` passes (was failing before)
- [ ] CI green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)