### PR TITLE
fix(keeper): use FSM JSON module for trace conditions

### DIFF
--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -425,13 +425,30 @@ let can_transition ~from_phase ~to_phase =
       | Draining
       | Paused
       | Restarting ) ) -> false
-  (* Paused -> Running (resume) | Draining (stop) | Stopped (remove)
-     | Crashed (fiber can die while keeper is paused)
+  (* Paused -> Running (resume) | latent states exposed by resume
+     (Failing/Overflowed/HandingOff/Restarting/Offline) | Draining (stop)
+     | Stopped (remove) | Crashed (fiber can die while keeper is paused)
      | Compacting (operator invoked masc_keeper_compact on paused keeper
-     to clear an overflow-induced pause) *)
-  | Paused, (Running | Compacting | Draining | Stopped | Crashed) -> true
-  | Paused, (Offline | Failing | Overflowed | HandingOff | Paused | Restarting)
-    -> false
+     to clear an overflow-induced pause).
+
+     Operator_resume only clears [operator_paused]; it intentionally does not
+     erase already-observed launch, health, overflow, handoff, or restart conditions.
+     If one of those latches still derives a non-running phase, accepting the
+     transition lets the registry commit the resume intent and surface the real
+     blocker instead of rejecting the event and leaving the keeper permanently
+     paused. *)
+  | ( Paused
+    , ( Running
+      | Failing
+      | Overflowed
+      | Compacting
+      | HandingOff
+      | Draining
+      | Stopped
+      | Crashed
+      | Offline
+      | Restarting ) ) -> true
+  | Paused, Paused -> false
   (* Crashed -> Restarting (backoff done). Dead is covered by the global
      hard-stop/budget terminal transition above. *)
   | Crashed, Restarting -> true

--- a/lib/keeper/keeper_trace_emit.ml
+++ b/lib/keeper/keeper_trace_emit.ml
@@ -4,6 +4,7 @@
     conditions_to_json 재사용으로 14필드 전체 기록. *)
 
 module SM = Keeper_state_machine
+module SM_json = Keeper_state_machine_json
 
 (* This flag is queried from registry/test code that can run before an Eio
    scheduler exists, so it cannot depend on Eio.Lazy.  Use a plain
@@ -52,7 +53,7 @@ let emit_transition
       "event", `String (SM.event_to_string event);
       "prev_phase", `String (SM.phase_to_string prev_phase);
       "new_phase", `String (SM.phase_to_string new_phase);
-      "conditions_after", SM.conditions_to_json conditions_after;
+      "conditions_after", SM_json.conditions_to_json conditions_after;
       "restart_count", `Int restart_count;
     ] in
     let path = trace_path ~base_path ~keeper_name in

--- a/test/test_keeper_registry_provenance.ml
+++ b/test/test_keeper_registry_provenance.ml
@@ -17,6 +17,7 @@
 open Alcotest
 
 module KSM = Masc_mcp.Keeper_state_machine
+module KSM_json = Masc_mcp.Keeper_state_machine_json
 module R = Masc_mcp.Keeper_registry
 
 let test_fiber_terminated_carrier_none () =
@@ -109,7 +110,7 @@ let test_json_serializer_none () =
       ; http_status = None
       }
   in
-  let json = KSM.event_to_json ev in
+  let json = KSM_json.event_to_json ev in
   let s = Yojson.Safe.to_string json in
   (check bool)
     "JSON does not include provider_id when None"
@@ -128,7 +129,7 @@ let test_json_serializer_some () =
       ; http_status = Some 502
       }
   in
-  let json = KSM.event_to_json ev in
+  let json = KSM_json.event_to_json ev in
   let s = Yojson.Safe.to_string json in
   (check bool)
     "JSON includes provider_id when Some"

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -262,6 +262,39 @@ let test_apply_operator_pause_resume () =
   check phase_t "-> Running" SM.Running tr2.new_phase
 ;;
 
+let test_operator_resume_from_paused_commits_latent_blockers () =
+  let cases =
+    [ ( "unhealthy turn"
+      , { running_conditions with operator_paused = true; turn_healthy = false }
+      , SM.Failing )
+    ; ( "context overflow"
+      , { running_conditions with operator_paused = true; context_overflow = true }
+      , SM.Overflowed )
+    ; ( "handoff active"
+      , { running_conditions with operator_paused = true; handoff_active = true }
+      , SM.HandingOff )
+    ; ( "restart backoff elapsed"
+      , { SM.default_conditions with
+          operator_paused = true
+        ; restart_budget_remaining = true
+        ; backoff_elapsed = true
+        }
+      , SM.Restarting )
+    ; ( "launch pending"
+      , { SM.default_conditions with operator_paused = true; launch_pending = true }
+      , SM.Offline )
+    ]
+  in
+  List.iter
+    (fun (label, conditions, expected_phase) ->
+       let tr =
+         apply_ok ~current_phase:SM.Paused ~conditions ~event:SM.Operator_resume
+       in
+       check phase_t label expected_phase tr.new_phase;
+       check bool (label ^ " clears operator pause") false tr.updated_conditions.operator_paused)
+    cases
+;;
+
 let test_apply_drain_lifecycle () =
   (* Running -> Draining -> Stopped *)
   let tr1 =
@@ -704,6 +737,17 @@ let test_can_transition_paused_to_draining () =
     "-> Draining"
     true
     (SM.can_transition ~from_phase:SM.Paused ~to_phase:SM.Draining)
+;;
+
+let test_can_transition_paused_to_latent_buffer_states () =
+  List.iter
+    (fun to_phase ->
+       check
+         bool
+         ("Paused -> " ^ SM.phase_to_string to_phase)
+         true
+         (SM.can_transition ~from_phase:SM.Paused ~to_phase))
+    [ SM.Failing; SM.Overflowed; SM.HandingOff; SM.Restarting; SM.Offline ]
 ;;
 
 let test_can_transition_paused_to_stopped () =
@@ -2534,6 +2578,10 @@ let () =
         ; test_case "compaction completed" `Quick test_apply_compaction_completed
         ; test_case "handoff lifecycle" `Quick test_apply_handoff_lifecycle
         ; test_case "pause/resume" `Quick test_apply_operator_pause_resume
+        ; test_case
+            "paused resume commits latent blockers"
+            `Quick
+            test_operator_resume_from_paused_commits_latent_blockers
         ; test_case "drain lifecycle" `Quick test_apply_drain_lifecycle
         ; test_case "drain + fiber death -> Crashed" `Quick test_apply_drain_fiber_death
         ; test_case
@@ -2622,6 +2670,10 @@ let () =
             test_can_transition_restarting_to_crashed
         ; test_case "Restarting -> Dead" `Quick test_can_transition_restarting_to_dead
         ; test_case "Paused -> Draining" `Quick test_can_transition_paused_to_draining
+        ; test_case
+            "Paused -> latent buffer states"
+            `Quick
+            test_can_transition_paused_to_latent_buffer_states
         ; test_case "Paused -> Stopped" `Quick test_can_transition_paused_to_stopped
         ; test_case
             "Running|Failing execute turns"

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -10,6 +10,7 @@
 
 open Alcotest
 module SM = Masc_mcp.Keeper_state_machine
+module SM_json = Masc_mcp.Keeper_state_machine_json
 module Meas = Masc_mcp.Keeper_measurement
 module Guard = Masc_mcp.Keeper_guard
 module KSP = Test_keeper_state_machine_preconditions
@@ -2480,7 +2481,7 @@ let test_setclear_coverage () =
      If someone adds a new field to conditions but forgets to add it here,
      this check catches it by comparing against conditions_to_json output. *)
   let json_field_count =
-    match SM.conditions_to_json SM.default_conditions with
+    match SM_json.conditions_to_json SM.default_conditions with
     | `Assoc pairs -> List.length pairs
     | _ -> fail "conditions_to_json did not return Assoc"
   in

--- a/test/test_keeper_state_machine_correspondence.ml
+++ b/test/test_keeper_state_machine_correspondence.ml
@@ -55,6 +55,7 @@
 
 open Alcotest
 module SM = Masc_mcp.Keeper_state_machine
+module SM_json = Masc_mcp.Keeper_state_machine_json
 
 (* ── OCaml-side change-set computation ─────────────────────── *)
 
@@ -102,13 +103,13 @@ let ocaml_changed_fields (ev : SM.event) : string list =
   let after_t = SM.update_conditions base_t ev in
   let d_f =
     json_field_diff
-      (SM.conditions_to_json base_f)
-      (SM.conditions_to_json after_f)
+      (SM_json.conditions_to_json base_f)
+      (SM_json.conditions_to_json after_f)
   in
   let d_t =
     json_field_diff
-      (SM.conditions_to_json base_t)
-      (SM.conditions_to_json after_t)
+      (SM_json.conditions_to_json base_t)
+      (SM_json.conditions_to_json after_t)
   in
   List.sort_uniq String.compare (d_f @ d_t)
 
@@ -238,7 +239,7 @@ let load_spec_actions () =
     TLA+-only variables (e.g. [restart_count], owned by the supervisor
     layer rather than the FSM) are filtered out as out-of-scope. *)
 let conditions_field_names () : string list =
-  match SM.conditions_to_json SM.default_conditions with
+  match SM_json.conditions_to_json SM.default_conditions with
   | `Assoc fs -> List.map fst fs |> List.sort String.compare
   | _ ->
       Alcotest.fail "conditions_to_json did not return a JSON object"


### PR DESCRIPTION
## Summary
- fix keeper_trace_emit compile error by using Keeper_state_machine_json.conditions_to_json
- keep Keeper_state_machine as the source for FSM event/phase/condition types

## Verification
- ocamlformat --check lib/keeper/keeper_trace_emit.ml
- git diff --check
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_goal_tools.exe
- ./_build/default/test/test_goal_tools.exe --show-errors

This unblocks the #16078 task-376 focused test build.