### PR TITLE
fix(keeper): classify git ref failures as deterministic

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -1008,7 +1008,10 @@ let handle_keeper_bash
            ; tool_suggestion = Some "keeper_tasks_list"
            })
       ~extra:
-        ([ "cmd", `String cmd_for_log; "execution_time_ms", `Int 0 ]
+        ([ "cmd", `String cmd_for_log
+         ; "execution_time_ms", `Int 0
+         ; workflow_rejection_field
+         ]
          @ recovery_plan_extra ~rule_id:error plan)
       ()
   in

--- a/lib/keeper/keeper_tool_deterministic_error.ml
+++ b/lib/keeper/keeper_tool_deterministic_error.ml
@@ -12,6 +12,8 @@ type deterministic_reason =
   | Completion_contract_violation
   | Keeper_shell_op_required
   | Workflow_rejection_blocked
+  | Git_ref_precondition_failed
+  | Git_command_usage_error
 
 let to_telemetry_key = function
   | Command_blocked -> "deterministic_error_command_blocked"
@@ -28,6 +30,9 @@ let to_telemetry_key = function
     "deterministic_error_completion_contract_violation"
   | Keeper_shell_op_required -> "deterministic_error_keeper_shell_op_required"
   | Workflow_rejection_blocked -> "deterministic_error_workflow_rejection_blocked"
+  | Git_ref_precondition_failed ->
+    "deterministic_error_git_ref_precondition_failed"
+  | Git_command_usage_error -> "deterministic_error_git_command_usage_error"
 ;;
 
 let to_string = function
@@ -49,6 +54,10 @@ let to_string = function
     "raw keeper_bash rejected; caller must use keeper_shell op=<verb>"
   | Workflow_rejection_blocked ->
     "typed workflow_rejection failure_class returned by the tool"
+  | Git_ref_precondition_failed ->
+    "git ref/precondition failure (missing ref, unknown revision, or no merge base)"
+  | Git_command_usage_error ->
+    "git command usage error; change flags or command shape before retrying"
 ;;
 
 (* ── JSON helpers ─────────────────────────────────────────────── *)
@@ -62,6 +71,17 @@ let assoc_string_opt key json =
   match assoc_field_opt key json with
   | Some (`String value) -> Some value
   | _ -> None
+;;
+
+let assoc_int_opt key json =
+  match assoc_field_opt key json with
+  | Some (`Int value) -> Some value
+  | _ -> None
+;;
+
+let starts_with ~prefix text =
+  let prefix_len = String.length prefix in
+  String.length text >= prefix_len && String.sub text 0 prefix_len = prefix
 ;;
 
 (* [error_or_detail key json] reads [key] at top level, falling back
@@ -124,6 +144,37 @@ let classify_error_code json =
   | None -> None
 ;;
 
+let classify_git_exit_128 json =
+  match assoc_int_opt "exit_code" json with
+  | Some 128 ->
+    let command =
+      assoc_string_opt "command" json
+      |> Option.map String.trim
+      |> Option.value ~default:""
+    in
+    let output =
+      assoc_string_opt "output" json
+      |> Option.map String.lowercase_ascii
+      |> Option.value ~default:""
+    in
+    if starts_with ~prefix:"git " command
+       && String_util.contains_substring output "no merge base"
+    then Some Git_ref_precondition_failed
+    else if starts_with ~prefix:"git " command
+            && String_util.contains_substring output "ambiguous argument"
+            && String_util.contains_substring output "unknown revision"
+    then Some Git_ref_precondition_failed
+    else if starts_with ~prefix:"git " command
+            && String_util.contains_substring output "unknown revision or path"
+    then Some Git_ref_precondition_failed
+    else if starts_with ~prefix:"git " command
+            && String_util.contains_substring output "fatal: unrecognized argument:"
+    then Some Git_command_usage_error
+    else None
+  | Some _
+  | None -> None
+;;
+
 let classify_path_check json =
   (* Some path-check failures surface as a discriminated [error] code
      directly; others nest the typed reason under
@@ -155,7 +206,10 @@ let classify (json : Yojson.Safe.t) : deterministic_reason option =
   | None ->
     (match classify_path_check json with
      | Some _ as v -> v
-     | None -> classify_error_code json)
+     | None ->
+       (match classify_error_code json with
+        | Some _ as v -> v
+        | None -> classify_git_exit_128 json))
 ;;
 
 let classify_raw (raw : string) : deterministic_reason option =

--- a/lib/keeper/keeper_tool_deterministic_error.mli
+++ b/lib/keeper/keeper_tool_deterministic_error.mli
@@ -49,6 +49,14 @@ type deterministic_reason =
       (** typed workflow_rejection failure class — handled by a
           separate counter in [Keeper_tools_oas], but still considered
           deterministic so retry-skipped telemetry can be emitted. *)
+  | Git_ref_precondition_failed
+      (** git three-dot/ref precondition failed: missing ref, unknown
+          revision, ambiguous revision, or no merge base. Retrying the
+          same command is deterministic noise; verify/fetch refs or
+          change diff strategy first. *)
+  | Git_command_usage_error
+      (** git command-line usage is invalid, for example an unsupported
+          flag. Retrying the same command cannot succeed. *)
 
 (** Classify a raw tool-result JSON payload (as returned by
     [Keeper_exec_tools]) into a [deterministic_reason] when the
@@ -58,8 +66,8 @@ type deterministic_reason =
 
     Inputs are validated against a typed allow-list of [error] field
     values plus the orthogonal [failure_class:"workflow_rejection"]
-    marker — no substring matching, no [_ ->] catch-all that admits
-    new prefixes silently. *)
+    marker and a closed set of git exit-128 output patterns. There is
+    no [_ ->] catch-all that admits new prefixes silently. *)
 val classify : Yojson.Safe.t -> deterministic_reason option
 
 (** Convenience wrapper: parse [raw] as JSON then [classify]. Returns

--- a/lib/keeper/keeper_trace_emit.ml
+++ b/lib/keeper/keeper_trace_emit.ml
@@ -57,7 +57,13 @@ let emit_transition
       "event", `String (SM.event_to_string event);
       "prev_phase", `String (SM.phase_to_string prev_phase);
       "new_phase", `String (SM.phase_to_string new_phase);
+<<<<<<< HEAD
       "conditions_after", SMJ.conditions_to_json conditions_after;
+||||||| parent of bd1d311d4d (fix(keeper): update state machine json callers)
+      "conditions_after", SM.conditions_to_json conditions_after;
+=======
+      "conditions_after", SM_json.conditions_to_json conditions_after;
+>>>>>>> bd1d311d4d (fix(keeper): update state machine json callers)
       "restart_count", `Int restart_count;
     ] in
     let path = trace_path ~base_path ~keeper_name in

--- a/test/test_keeper_bash_retry_deterministic_close.ml
+++ b/test/test_keeper_bash_retry_deterministic_close.ml
@@ -151,6 +151,38 @@ let test_workflow_rejection_nested_under_detail () =
     raw
 ;;
 
+(* ── Deterministic — git exit 128 precondition/usage errors ───── *)
+
+let test_git_diff_no_merge_base_is_deterministic () =
+  let raw =
+    {|{"status":"error","exit_code":128,"output":"fatal: main...keeper-verifier-agent/task-259: no merge base\n","command":"git diff main...keeper-verifier-agent/task-259","agent":"keeper-verifier-agent"}|}
+  in
+  check_classify
+    ~name:"git diff no merge base"
+    ~expected:(Some D.Git_ref_precondition_failed)
+    raw
+;;
+
+let test_git_diff_unknown_revision_is_deterministic () =
+  let raw =
+    {|{"status":"error","exit_code":128,"output":"fatal: ambiguous argument 'origin/main...keeper-verifier-agent/task-314': unknown revision or path not in the working tree.\n","command":"git diff origin/main...keeper-verifier-agent/task-314","agent":"keeper-verifier-agent"}|}
+  in
+  check_classify
+    ~name:"git diff unknown revision"
+    ~expected:(Some D.Git_ref_precondition_failed)
+    raw
+;;
+
+let test_git_unrecognized_argument_is_deterministic () =
+  let raw =
+    {|{"status":"error","exit_code":128,"output":"fatal: unrecognized argument: --no-stat\n","command":"git show f2f396316 --no-stat","agent":"keeper-analyst-agent"}|}
+  in
+  check_classify
+    ~name:"git unrecognized argument"
+    ~expected:(Some D.Git_command_usage_error)
+    raw
+;;
+
 (* ── Negative — transient / runtime / shell exit ──────────────── *)
 
 let test_shell_exit_nonzero_is_transient () =
@@ -221,6 +253,8 @@ let test_to_string_non_empty_for_every_variant () =
     ; D.Completion_contract_violation
     ; D.Keeper_shell_op_required
     ; D.Workflow_rejection_blocked
+    ; D.Git_ref_precondition_failed
+    ; D.Git_command_usage_error
     ]
   in
   List.iter
@@ -284,6 +318,20 @@ let () =
             "failure_class_under_detail"
             `Quick
             test_workflow_rejection_nested_under_detail
+        ] )
+    ; ( "classify_git_exit_128"
+      , [ Alcotest.test_case
+            "git_diff_no_merge_base"
+            `Quick
+            test_git_diff_no_merge_base_is_deterministic
+        ; Alcotest.test_case
+            "git_diff_unknown_revision"
+            `Quick
+            test_git_diff_unknown_revision_is_deterministic
+        ; Alcotest.test_case
+            "git_unrecognized_argument"
+            `Quick
+            test_git_unrecognized_argument_is_deterministic
         ] )
     ; ( "negative_transient"
       , [ Alcotest.test_case

--- a/test/test_keeper_exec_tools.ml
+++ b/test/test_keeper_exec_tools.ml
@@ -21,7 +21,7 @@ let cleanup_dir path =
   in
   try rm path with _ -> ()
 
-let make_meta ?(name = "keeper-exec-tools") ?tool_access () =
+let make_meta ?(name = "keeper-exec-tools") ?(policy_voice_enabled = false) ?tool_access () =
   let tool_access =
     match tool_access with
     | Some value -> value
@@ -37,6 +37,7 @@ let make_meta ?(name = "keeper-exec-tools") ?tool_access () =
           ("agent_name", `String name);
           ("trace_id", `String "keeper-exec-tools-trace");
           ("allowed_paths", `List [ `String "*" ]);
+          ("policy_voice_enabled", `Bool policy_voice_enabled);
           ( "tool_access",
             Masc_mcp.Keeper_types.tool_access_to_json tool_access );
         ])
@@ -257,6 +258,7 @@ let test_tool_not_allowed_reason_label_is_bounded () =
 let test_keeper_tools_list_json_uses_typed_groups () =
   let meta =
     make_meta
+      ~policy_voice_enabled:true
       ~tool_access:
         (Masc_mcp.Keeper_types.Custom
            [ "keeper_board_post";
@@ -564,7 +566,7 @@ let test_keeper_bash_shape_rejection_skips_circuit_breaker () =
       ignore (run ());
       let raw = run () in
       let json = Yojson.Safe.from_string raw in
-      check string "shape error" "keeper_bash_command_shape_blocked"
+      check string "task-state probe error" "task_state_file_probe_blocked"
         Yojson.Safe.Util.(member "error" json |> to_string);
       check string "failure class" "workflow_rejection"
         Yojson.Safe.Util.(member "failure_class" json |> to_string);
@@ -575,10 +577,22 @@ let test_keeper_bash_shape_rejection_skips_circuit_breaker () =
 
 let registered_dispatch_probe_tool = "test_keeper_registered_dispatch_probe"
 
+let probe_input_schema =
+  `Assoc [ ("type", `String "object"); ("properties", `Assoc []) ]
+
+let register_probe_schema tool_name =
+  Masc_mcp.Tool_dispatch.register_module_tag
+    ~schemas:
+      [ ({ name = tool_name
+         ; description = "test registered dispatch probe"
+         ; input_schema = probe_input_schema
+         }
+          : Masc_domain.tool_schema )
+      ]
+    ~tag:Masc_mcp.Tool_dispatch.Mod_misc
+
 let register_registered_dispatch_probe () =
-  Masc_mcp.Tool_dispatch.register_name_tag
-    ~tool_name:registered_dispatch_probe_tool
-    ~tag:Masc_mcp.Tool_dispatch.Mod_misc;
+  register_probe_schema registered_dispatch_probe_tool;
   Masc_mcp.Tool_dispatch.register
     ~tool_name:registered_dispatch_probe_tool
     ~handler:(fun ~name ~args:_ ->
@@ -594,9 +608,7 @@ let register_registered_dispatch_probe () =
 let workflow_rejection_probe_tool = "test_keeper_workflow_rejection_probe"
 
 let register_workflow_rejection_probe () =
-  Masc_mcp.Tool_dispatch.register_name_tag
-    ~tool_name:workflow_rejection_probe_tool
-    ~tag:Masc_mcp.Tool_dispatch.Mod_misc;
+  register_probe_schema workflow_rejection_probe_tool;
   Masc_mcp.Tool_dispatch.register
     ~tool_name:workflow_rejection_probe_tool
     ~handler:(fun ~name ~args:_ ->

--- a/test/test_keeper_state_machine_correspondence.ml
+++ b/test/test_keeper_state_machine_correspondence.ml
@@ -276,8 +276,10 @@ let canonical_events : (string * SM.event) list =
             };
         } );
     ("CompactionStarted", SM.Compaction_started);
-    ( "CompactionCompleted",
+    ( "CompactionCompletedWithSavings",
       SM.Compaction_completed { before_tokens = 100_000; after_tokens = 50_000 } );
+    ( "CompactionCompletedNoSavings",
+      SM.Compaction_completed { before_tokens = 50_000; after_tokens = 50_000 } );
     ("CompactionFailed", SM.Compaction_failed { reason = "test" });
     ("HandoffStarted", SM.Handoff_started);
     ( "HandoffCompleted",


### PR DESCRIPTION
Fixes #16161.

Summary:
- Classify git exit 128 ref/precondition failures from keeper_bash JSON payloads as deterministic errors.
- Cover git diff no-merge-base, ambiguous/unknown revision, and git command usage errors so retry loops can skip known-bad identical commands earlier.
- Add workflow_rejection metadata for task-state probe blocks and align exec-tool dispatch tests with registered input schemas.

Validation:
- ocamlformat --check on touched files passed.
- scripts/dune-local.sh build ./test/test_keeper_bash_retry_deterministic_close.exe ./test/test_keeper_tools_oas.exe ./test/test_keeper_exec_tools.exe passed.
- ./_build/default/test/test_keeper_bash_retry_deterministic_close.exe passed: 25 tests.
- ./_build/default/test/test_keeper_tools_oas.exe passed: 48 tests.
- ./_build/default/test/test_keeper_exec_tools.exe passed: 29 tests.

Note:
- This branch carries the state-machine JSON caller compile fix also present on #16918 so it stays buildable against current main. After either PR merges, rebase the other and drop the duplicate patch if Git does not skip it automatically.