### PR TITLE
docs(rfc-0144): extend §3 with #15792 + #15808 (replaces #16869 — narrow slice)

### DIFF
--- a/docs/rfc/RFC-0144-workaround-sunset-keeper-dedup-carryover.md
+++ b/docs/rfc/RFC-0144-workaround-sunset-keeper-dedup-carryover.md
@@ -53,6 +53,15 @@ PR #16470 retry dedup applies uniformly to *all* tool retry failures. Its root-f
 - Per-tool failure rate root fixes (each tool's `error_kind` traces back to the table above).
 - `lib/keeper/keeper_tool_retry_state.ml` `Threshold_silence` semantics — once root rate drops, threshold trips disappear and the dedup becomes inert.
 
+### Cluster B carryovers (added 2026-05-20)
+
+2026-05-20 audit에서 sub-agent triage가 `audit-requested INTENTIONAL`로 면죄했으나 main 에이전트 sample-verify 시 워크어라운드로 재분류된 두 PR. 메모리 `feedback_subagent_pr_body_self_justification_must_be_traced` 신규 등록.
+
+| 추가 항목 | PR | 시그니처 | Override 부여 | removal target |
+|---|---|---|---|---|
+| `tool_call_pair_fabrication` counter | masc-mcp#15792 | Repair / Sanitize | Counter retroactive sunset | RFC-0145 §5 PR-1 머지 후 |
+| `compact_audit_drain_burst` counter | masc-mcp#15808 | Telemetry-as-fix | Counter retroactive sunset | RFC-0145 §5 PR-2 머지 후 |
+
 ## 4. Sunset criteria
 
 ### Per-`error_kind` sunset (PR #16389)


### PR DESCRIPTION
## 요약

#16869 (CLOSED, \"failing required checks ... narrow slice\") 의 narrow replacement. **Docs-only**, RFC-0144 §3 에 Cluster B carryovers sub-table 2 row 만 추가.

## 변경 내용

- `docs/rfc/RFC-0144-workaround-sunset-keeper-dedup-carryover.md` §3 끝부분에 신규 sub-table `### Cluster B carryovers (added 2026-05-20)` 추가.
- 2 row:
  - `tool_call_pair_fabrication` counter (masc-mcp#15792) — Repair / Sanitize 시그니처, removal target = RFC-0145 §5 PR-1 머지 후.
  - `compact_audit_drain_burst` counter (masc-mcp#15808) — Telemetry-as-fix 시그니처, removal target = RFC-0145 §5 PR-2 머지 후.
- 인라인 1-2줄 설명: Cluster B audit 결과 sub-agent face-saving 면죄가 main 에이전트 sample-verify로 뒤집힌 케이스. 메모리 `feedback_subagent_pr_body_self_justification_must_be_traced` 신규 등록 인용.

`+9 / -0`. §1/§2/§4~§7, 인라인 주석, 다른 RFC, 코드 — **무변경**.

## #16869 와의 차이

#16869 는 5개 인라인 주석 + §1/§2/§4/§6/§7 광범위 갱신 + extensions 메타데이터 라인까지 포함 → required checks 실패. 본 PR 은 §3 sub-table only.

## 검증

- Docs-only. lint 외 영향 없음.
- main 직접 작업 없음. Worktree: `.worktrees/rfc-0144-sub-table-narrow-2026-05-20` (branch: `docs/rfc-0144-sub-table-narrow`, base: origin/main).
- Draft 유지. `gh pr ready` 미수행.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>