### PR TITLE
fix(anti_rationalization,eval_harness): name kind in 2 boundary parse errors + bound unbounded entry dump

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -181,13 +181,26 @@ let parse_excuse_patterns_json (json : Yojson.Safe.t)
             Error (Printf.sprintf "String too long (max %d chars)" max_excuse_pattern_len)
           else validate ((pat, reason) :: acc) rest
         | item :: _ ->
+          (* [Yojson.Safe.to_string] could dump an entire malformed
+             entry (potentially MB of payload if someone pasted a JSON
+             blob into the config).  [Json_util.excerpt] caps at 160
+             chars + appends "..."  so the warn line emitted by
+             [load_excuse_patterns] stays bounded. *)
           Error
             (Printf.sprintf
-               "Invalid pattern entry: expected [string, string], got %s"
-               (Yojson.Safe.to_string item))
+               "Invalid pattern entry at index %d: expected [string, string], got %s"
+               (List.length acc)
+               (Json_util.excerpt item))
       in
       validate [] items)
-  | _ -> Error "Expected JSON array of [pattern, reason] pairs"
+  | other ->
+    (* Bind the actual JSON kind so [load_excuse_patterns]' warn line
+       tells operators wrong-type ([`Assoc] / [`String]) apart from
+       null / wrong-shape bugs without re-parsing the offending file. *)
+    Error
+      (Printf.sprintf
+         "parse_excuse_patterns_json: expected JSON array of [pattern, reason] pairs, got %s"
+         (Json_util.kind_name other))
 ;;
 
 (** Load excuse patterns from config/excuse_patterns.json.

--- a/lib/eval_harness.ml
+++ b/lib/eval_harness.ml
@@ -453,7 +453,18 @@ let load_scenarios_from_file (path : string) : (scenario list, string) result =
           (match scenario_of_json json with
            | Ok s -> Ok [s]
            | Error e -> Error e)
-      | _ -> Error "Expected JSON array or object"
+      | other ->
+          (* Bind the received kind so operators reading the load
+             failure can distinguish a wrong-type bug ([`Null] from
+             an empty file, [`Int] / [`Bool] from a single-line typo)
+             from a wrong-shape bug ([`List] of non-objects which is
+             handled by the [`List items] arm above and surfaces a
+             different "Parse errors:" prefix). *)
+          Error
+            (Printf.sprintf
+               "load_scenarios_from_file: expected JSON array of scenarios \
+                or a single scenario object, got %s (path=%S)"
+               (Json_util.kind_name other) path)
     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
       Error (Printf.sprintf "Failed to load scenarios: %s" (Printexc.to_string exn))
 


### PR DESCRIPTION
## Goal

Operator-clarity sweep iter#72-#91 의 2 parallel 사이트:
- `lib/anti_rationalization.ml:183-190` — wrong-kind discard **+** unbounded entry dump
- `lib/eval_harness.ml:451-456` — wrong-kind discard

각각 wildcard catch-all 이 받은 JSON kind 를 버려 wrong-type vs wrong-shape 진단 정보를 차단. 한 사이트 ([anti_rationalization.ml:187](https://github.com/jeong-sik/masc-mcp/blob/main/lib/anti_rationalization.ml#L187)) 는 추가로 `Yojson.Safe.to_string item` 으로 multi-MB payload 가 통째로 log 에 dump 될 수 있는 unbounded 문제도 있었음.

## Changes

### `lib/anti_rationalization.ml`

**Before** (line 183-190):
```ocaml
| item :: _ ->
  Error
    (Printf.sprintf
       "Invalid pattern entry: expected [string, string], got %s"
       (Yojson.Safe.to_string item))
in
validate [] items)
| _ -> Error "Expected JSON array of [pattern, reason] pairs"
```

**After**:
```ocaml
| item :: _ ->
  Error
    (Printf.sprintf
       "Invalid pattern entry at index %d: expected [string, string], got %s"
       (List.length acc)
       (Json_util.excerpt item))      (* 160-char cap *)
in
validate [] items)
| other ->
  Error
    (Printf.sprintf
       "parse_excuse_patterns_json: expected JSON array of [pattern, reason] pairs, got %s"
       (Json_util.kind_name other))
```

- 187: `Yojson.Safe.to_string item` (unbounded) → `Json_util.excerpt item` (160-char + ...). Caller `load_excuse_patterns` forwards 이 string 을 `Log.Misc.warn` 으로 직송 — 사용자가 config 에 paste 한 거대 JSON blob 이 그대로 log 폭주를 일으킬 수 있는 위험 차단. 추가로 entry index 도 message 에 포함 (config file line 매칭 용이).
- 190: `_` → `other` + `Json_util.kind_name other`. Wrong-type bug ([\`Assoc] / [\`String] 파일 — 누군가 object 를 array 자리에) vs null/wrong-shape bug 구분 가능.

### `lib/eval_harness.ml`

**Before** (line 451-456):
```ocaml
| `Assoc _ -> ...
| _ -> Error "Expected JSON array or object"
```

**After**:
```ocaml
| `Assoc _ -> ...
| other ->
    Error
      (Printf.sprintf
         "load_scenarios_from_file: expected JSON array of scenarios \
          or a single scenario object, got %s (path=%S)"
         (Json_util.kind_name other) path)
```

- 받은 kind + 파일 path 둘다 message 에 포함 — operator 가 *어느 파일의 wrong-type/shape* 인지 즉시 식별 가능.
- 기존 cancelled catch-all (line 457) 은 이미 RFC-0106 compliance.

## Self-check vs Workaround Rejection Bar §1-3

- **§1 telemetry-as-fix**: ❌ 둘다 pre-existing `Error` boundary, decode 즉시 단절. Diagnostic string 만 확장 — counter 추가 없음.
- **§2 string-classifier**: ❌ `Json_util.kind_name` 은 `Yojson.Safe.t` 의 typed total fn (closed sum) — runtime string match 추가 아님.
- **§3 N-of-M**: ❌ 두 사이트 모두 본 PR scope. `rg 'Expected JSON array (of|or)' lib/` = 두 사이트만 (다른 caller 잔존 없음 확인).

## Verification

```
dune build lib/ test/test_eval_harness.exe test/test_anti_rationalization_coverage.exe
dune exec test/test_eval_harness.exe                → 22/22 PASS
dune exec test/test_anti_rationalization_coverage.exe → all parse_verdict + find_excuse PASS
```

Test message lock 검사: `rg "Expected JSON array or object|Expected JSON array of \[pattern" test/` → 0 매치. 변경된 두 error string 모두 test 에서 literal match 없음.

## Chronic main break note

`lib/keeper/keeper_trace_emit.ml:55` 의 `SM.conditions_to_json` unbound (수정: `SMJ.conditions_to_json`) 은 origin/main 에 잔존. iter#90 PR #16927 이 1-line module rebind hotfix 보유. iter#91 PR 은 그 hotfix 를 *temp* 로 worktree 에 적용해 lib/ + test exe build 검증 후, **commit 전 revert** 하여 PR scope 는 2 clarity 사이트만 포함. iter#90 머지 후 iter#91 도 자연 unblock 예상.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>