### PR TITLE
fix(keeper_state_machine): admit all derive_phase outputs from Paused row

### DIFF
--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -425,13 +425,32 @@ let can_transition ~from_phase ~to_phase =
       | Draining
       | Paused
       | Restarting ) ) -> false
-  (* Paused -> Running (resume) | Draining (stop) | Stopped (remove)
-     | Crashed (fiber can die while keeper is paused)
-     | Compacting (operator invoked masc_keeper_compact on paused keeper
-     to clear an overflow-induced pause) *)
-  | Paused, (Running | Compacting | Draining | Stopped | Crashed) -> true
-  | Paused, (Offline | Failing | Overflowed | HandingOff | Paused | Restarting)
-    -> false
+  (* Paused -> any non-terminal phase derive_phase can return.
+     Operator_resume flips [operator_paused=false]; the next derive_phase
+     consults priorities 0-10, any of which may fire if a latched condition
+     remained while paused (turn_healthy=false, context_overflow=true,
+     handoff_active=true, fiber_alive=false, ...). Matrix MUST admit every
+     phase derive_phase can produce — otherwise apply_event returns
+     Invalid_transition and the conditions update is discarded, leading
+     to silent livelock (Operator_resume can never escape Paused).
+     Incident: albini 2026-05-20T01:21Z, RFC-0072 follow-up.
+       Failing    <- !heartbeat_healthy OR !turn_healthy (P9) OR guardrail (P6)
+       Overflowed <- context_overflow && !compact_retry_exhausted (P8c)
+       HandingOff <- handoff_active (P8a)
+       Restarting <- !fiber_alive && restart_budget_remaining && backoff_elapsed (P4)
+       Offline    <- launch_pending && !fiber_alive (P2, edge case) *)
+  | ( Paused
+    , ( Running
+      | Compacting
+      | Draining
+      | Stopped
+      | Crashed
+      | Failing
+      | Overflowed
+      | HandingOff
+      | Restarting
+      | Offline ) ) -> true
+  | Paused, Paused -> false
   (* Crashed -> Restarting (backoff done). Dead is covered by the global
      hard-stop/budget terminal transition above. *)
   | Crashed, Restarting -> true


### PR DESCRIPTION
## 요약

`can_transition` matrix의 Paused row가 `derive_phase`가 산출 가능한 phase를 일부만 허용했다. `Operator_resume` 시 paused 상태에서 latched된 health/overflow/handoff condition이 살아 있으면 `derive_phase`가 `Failing`/`Overflowed`/`HandingOff`/`Restarting` 등을 반환했지만 matrix가 reject — `apply_event`가 conditions update를 통째로 폐기하고 livelock.

## 사고 evidence

```
2026-05-20T01:21:46Z (~/me/.masc/logs/system_log_2026-05-20.jsonl seq 83764)
registry: dispatch_event rejected name=albini
error=invalid_transition: paused -> failing
(event operator_resume caused derive_phase to produce failing from paused,
 but this transition is not in the matrix)
```

이후 albini는 turn 25에서 **13시간+** 동안 `keeper cycle skipped in non-executable phase=paused` 반복 (seq 83769 ~ 96260).

## 원인

`lib/keeper/keeper_state_machine.ml:432-434`의 Paused row가 5개 transition 누락:

| Paused → ? | derive_phase 트리거 |
|---|---|
| Failing | `!heartbeat_healthy ∨ !turn_healthy` (P9) ∨ `guardrail_triggered` (P6) |
| Overflowed | `context_overflow ∧ !compact_retry_exhausted` (P8c) |
| HandingOff | `handoff_active` (P8a) |
| Restarting | `!fiber_alive ∧ restart_budget_remaining ∧ backoff_elapsed` (P4) |
| Offline | `launch_pending ∧ !fiber_alive` (P2 edge case) |

`derive_phase`(line 538-607)와 `can_transition`(line 350-455)이 **두 개의 독립 SSOT**이며, 컴파일 타임에 `derive_phase 출력 ⊆ 출발 phase 허용 도착` 강제 가드가 없다.

## 수정

`lib/keeper/keeper_state_machine.ml` Paused row에 `Failing | Overflowed | HandingOff | Restarting | Offline` 추가. 이제 derive_phase가 산출 가능한 모든 non-terminal phase는 matrix admit.

```ocaml
| ( Paused
  , ( Running | Compacting | Draining | Stopped | Crashed
    | Failing | Overflowed | HandingOff | Restarting | Offline ) ) -> true
| Paused, Paused -> false
```

terminal(Stopped/Dead/Zombie)은 universal arm으로 이미 처리됨.

## 왜 기존 invariant test가 못 잡았나

`test_invariant_derive_matches_matrix` (test/test_keeper_state_machine.ml:2068)이 derive↔matrix consistency를 검사하지만 phase별 **minimum-condition fixture**만 사용:

```ocaml
| SM.Paused -> { running_conditions with operator_paused = true }
```

이 fixture에서 Operator_resume 시 derive_phase는 priority 10 Running 반환 → 정상 path만 검증. **multi-latched** 케이스 (paused + !heartbeat_healthy)는 빠져 있다. 

→ 별도 follow-up PR에서 test fixture를 강화: worst-case latched conditions로 모든 phase 검사.

## RFC 정합

RFC-0072 `keeper-sub-fsm-transitions-typed` follow-up. sparse `_ -> false` catch-all 제거 작업의 의미적 잔여물. 본 PR은 hotfix이며, 근본 fix는:
- RFC-0046 (FSM hub SSOT)로 derive_phase ↔ can_transition 단일화
- property test 강화 (PBT chaos generator에 paused + multi-latched 시드)

별도 RFC issue로 propose 예정.

## 영향 / 테스트

- **변경**: `lib/keeper/keeper_state_machine.ml` 26 insertions, 7 deletions
- **컴파일**: hotfix 자체는 syntax/type 통과. 단 `origin/main`의 별개 latent regression (`SM.conditions_to_json`, `KSM.event_to_json` unbound 4 sites)이 sandbox build를 실패시킴 — 본 PR과 무관, 별도 사고.
- **테스트**: 신규 regression test 추가 보류 (main build green 의존). PR body에 명시.

## Test plan

- [ ] `lib/keeper/keeper_state_machine.ml` 빌드 (main의 다른 build error 해결 후)
- [ ] `test_keeper_state_machine_pbt.ml` 10000-case chaos가 invariant 위반 없이 통과
- [ ] albini regression: paused + !heartbeat_healthy condition으로 Operator_resume 시 Failing 도달 확인
- [ ] follow-up PR에서 multi-latched fixture로 `test_invariant_derive_matches_matrix` 강화

## 운영 unstuck

본 hotfix는 *재발 차단*. 현재 stuck 상태인 keeper들은 별도 운영 절차로 unstuck 필요:
- `masc_keeper_up` 13회 batch (paused=true 13 keeper) — 본 PR과 독립
- albini는 cascade tool-policy 차단 (별개 case) — 별도 추적

자세한 사고 보고서: `/tmp/masc-keeper-fleet-pause-investigation-2026-05-20.html` (조사단 4 agent 종합)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
