### PR TITLE
fix(keeper-fsm): allow paused resume into latent blockers

### DIFF
--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -425,13 +425,30 @@ let can_transition ~from_phase ~to_phase =
       | Draining
       | Paused
       | Restarting ) ) -> false
-  (* Paused -> Running (resume) | Draining (stop) | Stopped (remove)
-     | Crashed (fiber can die while keeper is paused)
+  (* Paused -> Running (resume) | latent states exposed by resume
+     (Failing/Overflowed/HandingOff/Restarting/Offline) | Draining (stop)
+     | Stopped (remove) | Crashed (fiber can die while keeper is paused)
      | Compacting (operator invoked masc_keeper_compact on paused keeper
-     to clear an overflow-induced pause) *)
-  | Paused, (Running | Compacting | Draining | Stopped | Crashed) -> true
-  | Paused, (Offline | Failing | Overflowed | HandingOff | Paused | Restarting)
-    -> false
+     to clear an overflow-induced pause).
+
+     Operator_resume only clears [operator_paused]; it intentionally does not
+     erase already-observed launch, health, overflow, handoff, or restart conditions.
+     If one of those latches still derives a non-running phase, accepting the
+     transition lets the registry commit the resume intent and surface the real
+     blocker instead of rejecting the event and leaving the keeper permanently
+     paused. *)
+  | ( Paused
+    , ( Running
+      | Failing
+      | Overflowed
+      | Compacting
+      | HandingOff
+      | Draining
+      | Stopped
+      | Crashed
+      | Offline
+      | Restarting ) ) -> true
+  | Paused, Paused -> false
   (* Crashed -> Restarting (backoff done). Dead is covered by the global
      hard-stop/budget terminal transition above. *)
   | Crashed, Restarting -> true

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -262,6 +262,39 @@ let test_apply_operator_pause_resume () =
   check phase_t "-> Running" SM.Running tr2.new_phase
 ;;
 
+let test_operator_resume_from_paused_commits_latent_blockers () =
+  let cases =
+    [ ( "unhealthy turn"
+      , { running_conditions with operator_paused = true; turn_healthy = false }
+      , SM.Failing )
+    ; ( "context overflow"
+      , { running_conditions with operator_paused = true; context_overflow = true }
+      , SM.Overflowed )
+    ; ( "handoff active"
+      , { running_conditions with operator_paused = true; handoff_active = true }
+      , SM.HandingOff )
+    ; ( "restart backoff elapsed"
+      , { SM.default_conditions with
+          operator_paused = true
+        ; restart_budget_remaining = true
+        ; backoff_elapsed = true
+        }
+      , SM.Restarting )
+    ; ( "launch pending"
+      , { SM.default_conditions with operator_paused = true; launch_pending = true }
+      , SM.Offline )
+    ]
+  in
+  List.iter
+    (fun (label, conditions, expected_phase) ->
+       let tr =
+         apply_ok ~current_phase:SM.Paused ~conditions ~event:SM.Operator_resume
+       in
+       check phase_t label expected_phase tr.new_phase;
+       check bool (label ^ " clears operator pause") false tr.updated_conditions.operator_paused)
+    cases
+;;
+
 let test_apply_drain_lifecycle () =
   (* Running -> Draining -> Stopped *)
   let tr1 =
@@ -704,6 +737,17 @@ let test_can_transition_paused_to_draining () =
     "-> Draining"
     true
     (SM.can_transition ~from_phase:SM.Paused ~to_phase:SM.Draining)
+;;
+
+let test_can_transition_paused_to_latent_buffer_states () =
+  List.iter
+    (fun to_phase ->
+       check
+         bool
+         ("Paused -> " ^ SM.phase_to_string to_phase)
+         true
+         (SM.can_transition ~from_phase:SM.Paused ~to_phase))
+    [ SM.Failing; SM.Overflowed; SM.HandingOff; SM.Restarting; SM.Offline ]
 ;;
 
 let test_can_transition_paused_to_stopped () =
@@ -2534,6 +2578,10 @@ let () =
         ; test_case "compaction completed" `Quick test_apply_compaction_completed
         ; test_case "handoff lifecycle" `Quick test_apply_handoff_lifecycle
         ; test_case "pause/resume" `Quick test_apply_operator_pause_resume
+        ; test_case
+            "paused resume commits latent blockers"
+            `Quick
+            test_operator_resume_from_paused_commits_latent_blockers
         ; test_case "drain lifecycle" `Quick test_apply_drain_lifecycle
         ; test_case "drain + fiber death -> Crashed" `Quick test_apply_drain_fiber_death
         ; test_case
@@ -2622,6 +2670,10 @@ let () =
             test_can_transition_restarting_to_crashed
         ; test_case "Restarting -> Dead" `Quick test_can_transition_restarting_to_dead
         ; test_case "Paused -> Draining" `Quick test_can_transition_paused_to_draining
+        ; test_case
+            "Paused -> latent buffer states"
+            `Quick
+            test_can_transition_paused_to_latent_buffer_states
         ; test_case "Paused -> Stopped" `Quick test_can_transition_paused_to_stopped
         ; test_case
             "Running|Failing execute turns"


### PR DESCRIPTION
Replaces closed #16916 after PR queue cleanup.\n\nStacked on #16924 so the keeper FSM hotfix no longer carries stale test JSON-module changes.\n\nLocal verification:\n- ocamlformat --check lib/keeper/keeper_state_machine.ml test/test_keeper_state_machine.ml\n- scripts/dune-local.sh build test/test_keeper_state_machine.exe