### PR TITLE
fix(voice_bridge_transport): split process_status wildcard into named WSIGNALED/WSTOPPED arms (2 sites)

### DIFF
--- a/lib/voice/voice_bridge_transport.ml
+++ b/lib/voice/voice_bridge_transport.ml
@@ -120,7 +120,19 @@ let run_audio_http_request_to_file ~url ~headers ~body_json ~output_file =
            Error (Printf.sprintf "HTTP %d: %s" http_code detail))
        | Unix.WEXITED 28 -> Error "request timed out"
        | Unix.WEXITED code -> Error (Printf.sprintf "curl exit %d" code)
-       | _ -> Error "curl process failed")
+       (* [Unix.process_status] is a closed sum of WEXITED / WSIGNALED
+          / WSTOPPED — the previous [| _ -> "curl process failed"]
+          discarded both the variant and the signal number, leaving
+          operators unable to distinguish OOM-kill (SIGKILL=9) /
+          deadline-kill (SIGTERM=15) / Ctrl-C (SIGINT=2) / pipe break
+          (SIGPIPE=13).  Naming both arms makes the dispatch typed
+          exhaustive and surfaces [sig_num] so [kill -l <n>] decodes
+          it.  Mirrors sibling pattern in
+          [lib/tool_local_runtime_http.ml:79-82]. *)
+       | Unix.WSIGNALED sig_num ->
+         Error (Printf.sprintf "TTS curl killed by signal %d" sig_num)
+       | Unix.WSTOPPED sig_num ->
+         Error (Printf.sprintf "TTS curl stopped by signal %d" sig_num))
 ;;
 
 let speak_via_http_tts_to_file endpoint ~agent_id ~message ~voice ~model ~output_file =
@@ -177,7 +189,13 @@ let run_stt_multipart_request (req : Voice_runtime_overlay.stt_request) =
          (if String.length body > 200 then String.sub body 0 200 else body))
   | Unix.WEXITED 28 -> Error "STT request timed out"
   | Unix.WEXITED code -> Error (Printf.sprintf "STT curl exit %d" code)
-  | _ -> Error "STT curl process failed"
+  (* See sibling TTS dispatch above (line ~121) for rationale: closed-sum
+     named arms over [Unix.process_status] expose the signal number
+     that the previous wildcard discarded. *)
+  | Unix.WSIGNALED sig_num ->
+    Error (Printf.sprintf "STT curl killed by signal %d" sig_num)
+  | Unix.WSTOPPED sig_num ->
+    Error (Printf.sprintf "STT curl stopped by signal %d" sig_num)
 ;;
 
 let transcribe_via_http_stt endpoint ~audio_file ~model =


### PR DESCRIPTION
## Goal

Operator-clarity sweep iter#72-#92 의 voice subsystem 슬라이스. `Unix.process_status` wildcard 가 2 사이트에서 signal 정보 폐기.

## Sites

| Line | Function | 영향 |
|---|---|---|
| 121-123 | `speak_via_http_tts_to_file` (TTS audio HTTP) | curl killed/stopped 시 signal number 잃음 |
| 178-180 | `run_stt_multipart_request` (STT multipart upload) | 동일 |

## Diagnostic gap

`| _ -> Error "...curl process failed"` 는 다음 둘을 폐기:

1. **Variant**: `WSIGNALED` (signal 으로 kill) vs `WSTOPPED` (signal 으로 pause, 보통 SIGSTOP) — 개념적으로 다른 failure 모드
2. **sig_num**: 9 (SIGKILL — OOM-killer 의도) / 15 (SIGTERM — supervisor 의도) / 2 (SIGINT — Ctrl-C) / 13 (SIGPIPE — peer 끊김)

Operator 가 OOM-kill 과 deadline-kill 을 구분 못함 → 다른 mitigation (memory tuning vs timeout 조정) 필요한데 진단 불가.

## Fix

`Unix.process_status` 는 닫힌 sum `{WEXITED, WSIGNALED, WSTOPPED}` — 3 변형 모두 명명하면 typed exhaustive match + wildcard arm 사라짐:

```ocaml
(* Before *)
| Unix.WEXITED 28 -> Error "STT request timed out"
| Unix.WEXITED code -> Error (Printf.sprintf "STT curl exit %d" code)
| _ -> Error "STT curl process failed"

(* After *)
| Unix.WEXITED 28 -> Error "STT request timed out"
| Unix.WEXITED code -> Error (Printf.sprintf "STT curl exit %d" code)
| Unix.WSIGNALED sig_num ->
  Error (Printf.sprintf "STT curl killed by signal %d" sig_num)
| Unix.WSTOPPED sig_num ->
  Error (Printf.sprintf "STT curl stopped by signal %d" sig_num)
```

**Operator decode**: `kill -l 9` → `KILL`, `kill -l 15` → `TERM`, `kill -l 13` → `PIPE`.

## Sibling consistency

`lib/tool_local_runtime_http.ml:79-82` + 129-131 already uses 동일한 `WSIGNALED sig_num` / `WSTOPPED sig_num` 패턴 — 이번 변경이 voice subsystem 을 codebase 표준에 정렬.

## Self-check vs Workaround Rejection Bar §1-3

- **§1 telemetry-as-fix**: ❌ pre-existing `Error` boundary, decode 즉시 abort. Diagnostic string 만 확장.
- **§2 string-classifier**: ❌ match 는 `Unix.process_status` 닫힌-sum 생성자 — runtime string 매치 추가 아님.
- **§3 N-of-M**: ❌ 같은 파일 2 사이트 모두 PR scope. 사후 검증: `rg "process failed" lib/voice/` → 0 매치.

## Verification

```
dune build lib/                                ✅
dune build test/test_voice_config.exe          ✅
dune build test/test_voice_runtime_overlay.exe ✅
dune exec test/test_voice_config.exe           → 5/5 PASS
dune exec test/test_voice_runtime_overlay.exe  → 6/6 PASS
```

Test message lock 검사: `rg "STT curl process failed|curl process failed" test/` → 0 매치. 변경된 두 error string 모두 test 에서 literal 매치 없음.

## Chronic main break note

`lib/keeper/keeper_trace_emit.ml:55` `SM.conditions_to_json` unbound 은 origin/main 잔존. iter#90 PR #16927 + iter#92 의 [PR #16924](https://github.com/jeong-sik/masc-mcp/pull/16924) 모두 1-line module rebind hotfix 보유 (alias 명만 차이: `SMJ` vs `SM_json`). iter#92 PR 은 그 fix 를 worktree 에 temp 적용해 full lib/ build 검증 후 commit 전 revert. iter#90 또는 #16924 머지 시 iter#92 자동 unblock.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>