### PR TITLE
fix(keeper_state_machine_json): update 4 callers after #16882 extract

### DIFF
--- a/lib/keeper/keeper_trace_emit.ml
+++ b/lib/keeper/keeper_trace_emit.ml
@@ -4,6 +4,7 @@
     conditions_to_json 재사용으로 14필드 전체 기록. *)
 
 module SM = Keeper_state_machine
+module SMJ = Keeper_state_machine_json
 
 (* This flag is queried from registry/test code that can run before an Eio
    scheduler exists, so it cannot depend on Eio.Lazy.  Use a plain
@@ -52,7 +53,7 @@ let emit_transition
       "event", `String (SM.event_to_string event);
       "prev_phase", `String (SM.phase_to_string prev_phase);
       "new_phase", `String (SM.phase_to_string new_phase);
-      "conditions_after", SM.conditions_to_json conditions_after;
+      "conditions_after", SMJ.conditions_to_json conditions_after;
       "restart_count", `Int restart_count;
     ] in
     let path = trace_path ~base_path ~keeper_name in

--- a/test/test_keeper_registry_provenance.ml
+++ b/test/test_keeper_registry_provenance.ml
@@ -17,6 +17,7 @@
 open Alcotest
 
 module KSM = Masc_mcp.Keeper_state_machine
+module KSMJ = Masc_mcp.Keeper_state_machine_json
 module R = Masc_mcp.Keeper_registry
 
 let test_fiber_terminated_carrier_none () =
@@ -109,7 +110,7 @@ let test_json_serializer_none () =
       ; http_status = None
       }
   in
-  let json = KSM.event_to_json ev in
+  let json = KSMJ.event_to_json ev in
   let s = Yojson.Safe.to_string json in
   (check bool)
     "JSON does not include provider_id when None"
@@ -128,7 +129,7 @@ let test_json_serializer_some () =
       ; http_status = Some 502
       }
   in
-  let json = KSM.event_to_json ev in
+  let json = KSMJ.event_to_json ev in
   let s = Yojson.Safe.to_string json in
   (check bool)
     "JSON includes provider_id when Some"

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -10,6 +10,7 @@
 
 open Alcotest
 module SM = Masc_mcp.Keeper_state_machine
+module SMJ = Masc_mcp.Keeper_state_machine_json
 module Meas = Masc_mcp.Keeper_measurement
 module Guard = Masc_mcp.Keeper_guard
 module KSP = Test_keeper_state_machine_preconditions
@@ -2480,7 +2481,7 @@ let test_setclear_coverage () =
      If someone adds a new field to conditions but forgets to add it here,
      this check catches it by comparing against conditions_to_json output. *)
   let json_field_count =
-    match SM.conditions_to_json SM.default_conditions with
+    match SMJ.conditions_to_json SM.default_conditions with
     | `Assoc pairs -> List.length pairs
     | _ -> fail "conditions_to_json did not return Assoc"
   in

--- a/test/test_keeper_state_machine_correspondence.ml
+++ b/test/test_keeper_state_machine_correspondence.ml
@@ -55,6 +55,7 @@
 
 open Alcotest
 module SM = Masc_mcp.Keeper_state_machine
+module SMJ = Masc_mcp.Keeper_state_machine_json
 
 (* ── OCaml-side change-set computation ─────────────────────── *)
 
@@ -102,13 +103,13 @@ let ocaml_changed_fields (ev : SM.event) : string list =
   let after_t = SM.update_conditions base_t ev in
   let d_f =
     json_field_diff
-      (SM.conditions_to_json base_f)
-      (SM.conditions_to_json after_f)
+      (SMJ.conditions_to_json base_f)
+      (SMJ.conditions_to_json after_f)
   in
   let d_t =
     json_field_diff
-      (SM.conditions_to_json base_t)
-      (SM.conditions_to_json after_t)
+      (SMJ.conditions_to_json base_t)
+      (SMJ.conditions_to_json after_t)
   in
   List.sort_uniq String.compare (d_f @ d_t)
 
@@ -238,7 +239,7 @@ let load_spec_actions () =
     TLA+-only variables (e.g. [restart_count], owned by the supervisor
     layer rather than the FSM) are filtered out as out-of-scope. *)
 let conditions_field_names () : string list =
-  match SM.conditions_to_json SM.default_conditions with
+  match SMJ.conditions_to_json SM.default_conditions with
   | `Assoc fs -> List.map fst fs |> List.sort String.compare
   | _ ->
       Alcotest.fail "conditions_to_json did not return a JSON object"


### PR DESCRIPTION
## 요약

PR #16882이 `Keeper_state_machine`에서 4개 JSON encoder를 sibling 모듈 `Keeper_state_machine_json`로 추출했지만, **4 caller가 옛 이름을 유지**해 latent Unbound value error 발생. CI sandbox path filter가 `Detect Changed Surfaces` gate에 의해 mask. `dune build @check` on `origin/main`이 4 error 그대로 재현.

## 영향

`test_keeper_state_machine.ml` (2878 LoC)이 build 안 됨 → 다음이 막힘:
- albini livelock regression test 추가 (PR #16934 follow-up)
- 기존 invariant test 강화 (multi-latched fixture)

## 변경

각 caller에 `module S(K)MJ = ...Keeper_state_machine_json` alias 추가 + 호출만 rewrite. 함수 정의는 #16882에서 이미 옮겨졌고 시그니처 동일. 의미 변경 없음.

| File | Change |
|---|---|
| lib/keeper/keeper_trace_emit.ml | +alias, line 55 `SM` → `SMJ` |
| test/test_keeper_registry_provenance.ml | +alias, line 113/132 `KSM` → `KSMJ` |
| test/test_keeper_state_machine_correspondence.ml | +alias, 6 sites `SM` → `SMJ` |
| test/test_keeper_state_machine.ml | +alias, line 2483 `SM` → `SMJ` |

`+13 / -9`, 4 files.

## 검증

- [x] `dune build @check` clean (baseline reproduced 4 errors → 0 errors)
- [ ] CI fleet (admin-merge 후)

## RFC 정합

RFC 영역 외 (refactor follow-up). RFC-WAIVED 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)