### PR TITLE
test(keeper_state_machine): regression for albini Paused resume livelock

### DIFF
--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -262,6 +262,112 @@ let test_apply_operator_pause_resume () =
   check phase_t "-> Running" SM.Running tr2.new_phase
 ;;
 
+(** REGRESSION 2026-05-20T01:21:46Z (albini livelock).
+    Operator_resume from Paused with latched [!heartbeat_healthy] must
+    transition to Failing (derive_phase priority 9), not silently reject
+    with Invalid_transition.
+
+    Bug: can_transition Paused row admitted only
+    {Running, Compacting, Draining, Stopped, Crashed} but derive_phase
+    could produce Failing from latched health conditions. The matrix
+    rejected, apply_event discarded the conditions update, and
+    operator_paused remained true → livelock.
+
+    keeper "albini" sat in Paused turn 25 for 13h+ with
+    [keeper cycle skipped in non-executable phase=paused] repeating
+    until manual intervention. RFC-0072 follow-up. *)
+let test_regression_albini_paused_resume_unhealthy_2026_05_20 () =
+  let paused_unhealthy =
+    { running_conditions with
+      operator_paused = true
+    ; heartbeat_healthy = false
+    ; turn_healthy = true
+    }
+  in
+  check phase_t "starts at Paused" SM.Paused (SM.derive_phase paused_unhealthy);
+  let tr =
+    apply_ok
+      ~current_phase:SM.Paused
+      ~conditions:paused_unhealthy
+      ~event:SM.Operator_resume
+  in
+  check phase_t
+    "Paused + !heartbeat_healthy + Operator_resume -> Failing (P9)"
+    SM.Failing
+    tr.new_phase;
+  check bool
+    "operator_paused cleared"
+    false
+    tr.updated_conditions.operator_paused
+;;
+
+(** REGRESSION variant — turn_healthy latched (same livelock surface). *)
+let test_regression_paused_resume_turn_unhealthy () =
+  let paused_turn_unhealthy =
+    { running_conditions with
+      operator_paused = true
+    ; heartbeat_healthy = true
+    ; turn_healthy = false
+    }
+  in
+  check phase_t "starts at Paused" SM.Paused (SM.derive_phase paused_turn_unhealthy);
+  let tr =
+    apply_ok
+      ~current_phase:SM.Paused
+      ~conditions:paused_turn_unhealthy
+      ~event:SM.Operator_resume
+  in
+  check phase_t
+    "Paused + !turn_healthy + Operator_resume -> Failing"
+    SM.Failing
+    tr.new_phase
+;;
+
+(** REGRESSION variant — context_overflow latched while paused (overflow path). *)
+let test_regression_paused_resume_overflow () =
+  let paused_overflow =
+    { running_conditions with
+      operator_paused = true
+    ; context_overflow = true
+    ; compact_retry_exhausted = false (* not exhausted -> Overflowed, not Paused *)
+    }
+  in
+  (* operator_paused has higher priority than context_overflow in derive_phase,
+     so the keeper IS in Paused at rest. *)
+  check phase_t "starts at Paused" SM.Paused (SM.derive_phase paused_overflow);
+  let tr =
+    apply_ok
+      ~current_phase:SM.Paused
+      ~conditions:paused_overflow
+      ~event:SM.Operator_resume
+  in
+  check phase_t
+    "Paused + context_overflow + Operator_resume -> Overflowed (P8c)"
+    SM.Overflowed
+    tr.new_phase
+;;
+
+(** REGRESSION variant — handoff_active latched while paused. *)
+let test_regression_paused_resume_handoff () =
+  let paused_handoff =
+    { running_conditions with
+      operator_paused = true
+    ; handoff_active = true
+    }
+  in
+  check phase_t "starts at Paused" SM.Paused (SM.derive_phase paused_handoff);
+  let tr =
+    apply_ok
+      ~current_phase:SM.Paused
+      ~conditions:paused_handoff
+      ~event:SM.Operator_resume
+  in
+  check phase_t
+    "Paused + handoff_active + Operator_resume -> HandingOff (P8a)"
+    SM.HandingOff
+    tr.new_phase
+;;
+
 let test_apply_drain_lifecycle () =
   (* Running -> Draining -> Stopped *)
   let tr1 =
@@ -2534,6 +2640,22 @@ let () =
         ; test_case "compaction completed" `Quick test_apply_compaction_completed
         ; test_case "handoff lifecycle" `Quick test_apply_handoff_lifecycle
         ; test_case "pause/resume" `Quick test_apply_operator_pause_resume
+        ; test_case
+            "REGRESSION 2026-05-20 albini: Paused + !heartbeat + resume -> Failing"
+            `Quick
+            test_regression_albini_paused_resume_unhealthy_2026_05_20
+        ; test_case
+            "REGRESSION: Paused + !turn_healthy + resume -> Failing"
+            `Quick
+            test_regression_paused_resume_turn_unhealthy
+        ; test_case
+            "REGRESSION: Paused + context_overflow + resume -> Overflowed"
+            `Quick
+            test_regression_paused_resume_overflow
+        ; test_case
+            "REGRESSION: Paused + handoff_active + resume -> HandingOff"
+            `Quick
+            test_regression_paused_resume_handoff
         ; test_case "drain lifecycle" `Quick test_apply_drain_lifecycle
         ; test_case "drain + fiber death -> Crashed" `Quick test_apply_drain_fiber_death
         ; test_case


### PR DESCRIPTION
## 요약

2026-05-20T01:21Z albini Paused livelock의 4 regression test 추가. multi-latched fixture (paused + !heartbeat / paused + !turn_healthy / paused + context_overflow / paused + handoff_active)로 matrix gap을 명시 검증.

## 왜 기존 invariant test가 못 잡았나

\`test_invariant_derive_matches_matrix\` (test/test_keeper_state_machine.ml:2068)이 phase별 **minimum-condition fixture**만 사용:

\`\`\`ocaml
| SM.Paused -> { running_conditions with operator_paused = true }
\`\`\`

이 fixture에서 \`Operator_resume\` 시 derive_phase는 priority 10 Running 반환 → 정상 path만 검증. **multi-latched** 케이스가 빠져 있다. albini는 paused 중에 heartbeat가 latched unhealthy 상태에서 resume 시도 → derive priority 9 Failing → matrix reject → livelock.

## 본 PR 추가 test

| Test | Latched condition | 기대 phase | derive priority |
|---|---|---|---|
| \`test_regression_albini_paused_resume_unhealthy_2026_05_20\` | \`!heartbeat_healthy\` | Failing | P9 |
| \`test_regression_paused_resume_turn_unhealthy\` | \`!turn_healthy\` | Failing | P9 |
| \`test_regression_paused_resume_overflow\` | \`context_overflow\` | Overflowed | P8c |
| \`test_regression_paused_resume_handoff\` | \`handoff_active\` | HandingOff | P8a |

각 test는 named regression이며 incident timestamp가 docstring에 기재돼 future audit으로 link 가능.

## Dependency

- **Depends on #16934** (FSM hotfix): \`can_transition\` Paused row가 \`{Failing, Overflowed, HandingOff, Restarting, Offline}\` 5개 transition을 admit해야 통과. #16934 없이는 4 test 전부 \`Invalid_transition\`으로 fail.
- **Stacked on #16938** (build fix): main의 \`SM.conditions_to_json\` unbound 4 sites를 fix해야 test_keeper_state_machine.ml이 컴파일됨.

머지 순서: #16938 → #16934 → 본 PR.

## Follow-up (별도 RFC)

본 PR은 specific regression. **광역 강화** (모든 phase × multi-latched 조합 invariant)는 별도 RFC:
- \`test_invariant_derive_matches_matrix\` fixture를 phase별 list로 확장
- 또는 PBT chaos generator에 phase별 multi-latched seed 추가

이는 derive_phase ↔ can_transition single-SSOT 통합 (RFC-0046 영역)과 함께 다룰 주제.

## 검증

- [x] \`dune build @check\` clean (stack base + 본 변경)
- [ ] #16934 머지 후 4 test pass 확인
- [ ] #16934 없는 상태에서 4 test fail 확인 (negative case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)