### PR TITLE
fix(governance_registry): name received kind in 4 deserialize_* catch-all errors

### DIFF
--- a/lib/governance_registry.ml
+++ b/lib/governance_registry.ml
@@ -23,11 +23,24 @@ let validate_int_range ~min ~max key v =
   if v >= min && v <= max then Ok ()
   else Error (Printf.sprintf "%s must be in [%d, %d], got %d" key min max v)
 
+(* The four [deserialize_*] helpers are passed to [Runtime_params.register]
+   as [~deserialize] callbacks.  Their [Error] strings surface directly
+   in governance-dashboard validation failures — operators reading those
+   need not only *that* the JSON was wrong-shape but *what kind* they
+   actually sent, to correlate against the surface that produced the
+   misshapen value.  The previous one-word messages ("expected number",
+   "expected integer", "expected string", "expected boolean") discarded
+   the received kind. *)
+
 let deserialize_float json =
   match json with
   | `Float f -> Ok f
   | `Int i -> Ok (float_of_int i)
-  | _ -> Error "expected number"
+  | other ->
+      Error
+        (Printf.sprintf
+           "deserialize_float: expected JSON number (`Float or `Int), got %s"
+           (Json_util.kind_name other))
 
 let deserialize_int json =
   match json with
@@ -35,18 +48,28 @@ let deserialize_int json =
   | `Float f ->
       let i = Float.to_int f in
       if Float.equal (Float.of_int i) f then Ok i
-      else Error (Printf.sprintf "expected integer, got %g" f)
-  | _ -> Error "expected integer"
+      else Error (Printf.sprintf "deserialize_int: expected integer, got %g" f)
+  | other ->
+      Error
+        (Printf.sprintf
+           "deserialize_int: expected JSON integer (`Int or whole-valued `Float), got %s"
+           (Json_util.kind_name other))
 
 let deserialize_string json =
   match json with
   | `String s -> Ok s
-  | _ -> Error "expected string"
+  | other ->
+      Error
+        (Printf.sprintf "deserialize_string: expected JSON string, got %s"
+           (Json_util.kind_name other))
 
 let deserialize_bool json =
   match json with
   | `Bool b -> Ok b
-  | _ -> Error "expected boolean"
+  | other ->
+      Error
+        (Printf.sprintf "deserialize_bool: expected JSON boolean, got %s"
+           (Json_util.kind_name other))
 
 (* ── registration combinators ───────────────────────────────── *)
 


### PR DESCRIPTION
## Goal

Operator-clarity sweep iter#72-#93. governance_registry 의 4 deserialize_* helpers 가 모두 wildcard catch-all 로 received kind 폐기. 거버넌스 대시보드 validation failure 시 operator 가 *받은 JSON 유형* 을 알지 못해 *어느 surface* 가 misshapen value 를 보냈는지 triangulate 불가.

## Sites (4 parallel)

| Line | Function | Before message | Accepted |
|---|---|---|---|
| 30 | `deserialize_float` | `"expected number"` | `Float` / `Int` |
| 39 | `deserialize_int` | `"expected integer"` | `Int` / whole-valued `Float` |
| 44 | `deserialize_string` | `"expected string"` | `String` |
| 49 | `deserialize_bool` | `"expected boolean"` | `Bool` |

각 함수가 `Runtime_params.register` 에 `~deserialize` callback 으로 전달됨 → governance 변경 결정 실패 시 그 string 이 그대로 surface.

## Fix shape

iter#86-#92 의 같은 패턴 적용:

```ocaml
(* Before *)
let deserialize_float json =
  match json with
  | `Float f -> Ok f
  | `Int i -> Ok (float_of_int i)
  | _ -> Error "expected number"

(* After *)
let deserialize_float json =
  match json with
  | `Float f -> Ok f
  | `Int i -> Ok (float_of_int i)
  | other ->
      Error
        (Printf.sprintf
           "deserialize_float: expected JSON number (\`Float or \`Int), got %s"
           (Json_util.kind_name other))
```

- `other` 명명 + `Json_util.kind_name other` 로 받은 kind 노출
- 함수명 prefix → 멀티 파라미터 동시 실패 시 1 line 자가 식별
- 허용 shape hint 유지

## Why governance specifically matters

`governance_registry.ml:30-49` 의 4 함수는 **governance change-decision** 의 deserialize entry point. RuntimeParams 가 change request 를 받으면:

1. `deserialize_X` 호출 → 수신 JSON 을 typed value 로 변환
2. 실패 시 `Error msg` 가 governance audit log + dashboard alert 로 propagate
3. Operator 가 misshapen request 의 source 를 식별해야 함

Source identification 은 received kind 가 critical:
- `wrong kind = string` → 누군가 `"42"` 보낸 (template typo)
- `wrong kind = null` → 빈 field 보낸 (validation gap upstream)
- `wrong kind = object` → 잘못된 nesting (schema 변경 mid-flight)

이전 message 는 셋 다 같게 표시 → 진단 불가.

## Self-check vs Workaround Rejection Bar §1-3

- **§1 telemetry-as-fix**: ❌ pre-existing `Error` boundary, decode 즉시 abort. Counter 추가 없음.
- **§2 string-classifier**: ❌ `Json_util.kind_name` 은 `Yojson.Safe.t` 닫힌-sum 의 typed total fn.
- **§3 N-of-M**: ❌ 4 사이트 모두 같은 function family + 같은 PR scope. `rg "deserialize_(int|float|bool|string)" lib/governance_registry.mli` = 도큐먼트만 mention, val export 없음 → 외부 caller match-on-string 없음.

## Verification

```
dune build lib/                          ✅
dune build test/test_runtime_params.exe  ✅
dune exec test/test_runtime_params.exe   → 20/20 PASS (governance_registry suite 포함)
```

Test message lock 확인:
- `rg '"expected number"|"expected integer"|"expected string"|"expected boolean"' test/`
  → `test_runtime_params.ml:32+95` 매치, 하지만 이는 *test-local inline* deserialize closures (lib 의 helper 가 아닌 자체 정의) — lib message 변경에 영향 없음 (확인됨).

## Chronic main break

`lib/keeper/keeper_trace_emit.ml:55` 의 `SM.conditions_to_json` unbound 은 origin/main 잔존. iter#90 PR #16927 + #16924 모두 1-line module rebind hotfix 보유. iter#93 PR 은 그 fix 를 worktree 에 temp 적용해 full lib/ build 검증 후 commit 전 revert. PR scope 는 governance_registry.ml 1 파일만.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>