### PR TITLE
fix(types_core,agent_identity): name received kind in 2 of_yojson catch-alls

### DIFF
--- a/lib/agent_identity.ml
+++ b/lib/agent_identity.ml
@@ -120,7 +120,20 @@ let channel_of_yojson = function
       Ok (External (normalize_channel_label s))
   | `List [ `String "Unknown"; `String s ] ->
       Ok (External (normalize_channel_label s))
-  | _ -> Error "channel_of_yojson: expected string or tagged external variant"
+  | other ->
+      (* Accepted contract is one of:
+         - bare [`String "api" | "internal" | "telegram" | ... | "<freeform>"]
+         - tagged 2-tuple [`List [`String "External"|"Unknown"; `String _]]
+         Non-conforming inputs now name the kind we actually saw, so
+         operators chasing a misshapen [channel] field can tell a
+         wrong-type bug ([`Int] / [`Null]) apart from a wrong-shape
+         tagged variant ([`List] of wrong length / wrong leading tag)
+         by reading the kind alone — without re-dumping the payload. *)
+      Error
+        (Printf.sprintf
+           "channel_of_yojson: expected JSON string (e.g. \"api\" / \"telegram\") \
+            or 2-element tagged list [\"External\"|\"Unknown\"; <label>], got %s"
+           (Json_util.kind_name other))
 
 (** Agent identity - extracted from session/request context *)
 type t = {

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -94,7 +94,16 @@ let agent_status_of_yojson = function
       (match agent_status_of_string_opt s with
        | Some status -> Ok status
        | None -> Error ("Unknown agent status: " ^ s))
-  | _ -> Error "agent_status: expected string"
+  | other ->
+      (* Mirrors the [agent_role_of_yojson] shape introduced in iter#90
+         #16927 — non-string inputs name the kind actually received so
+         operators can distinguish wrong-type ([`Int]/[`Bool] from a
+         config drift) from wrong-shape ([`Assoc]/[`Null] from a schema
+         change mid-flight) without re-parsing the offending payload. *)
+      Error
+        (Printf.sprintf
+           "agent_status_of_yojson: expected JSON string, got %s"
+           (Json_util.kind_name other))
 
 (** Agent metadata - session identification and environment info *)
 type agent_meta = {


### PR DESCRIPTION
## Goal

Operator-clarity sweep iter#72-#94, agent-identity 슬라이스. 2 parallel of_yojson 디코더의 wildcard catch-all → 명명 `other` + `Json_util.kind_name`.

## Sites

### `lib/types/types_core.ml:97` — agent_status_of_yojson

`agent_role_of_yojson` (iter#90 #16927 의 동일 파일 family) 와 같은 패턴. Status 가 `Int 123` / `Null` / `Assoc` 으로 들어왔을 때 wrong-type vs wrong-shape 구분 가능.

### `lib/agent_identity.ml:123` — channel_of_yojson

복잡한 sum: 10 specific `String _` 변형 + 1 generic `String _` + 2 tagged `List _` 변형. Wildcard 가 두 *서로 다른* 오류 클래스를 흡수:
- wrong-type ([`Int] / [`Null])
- wrong-shape tagged variant ([`List] of wrong length, wrong leading tag)

새 message 는 받은 kind + 허용 contract 둘다 출력 → operator 가 어느 카테고리인지 즉시 식별.

## Self-check vs Workaround Rejection Bar §1-3

- §1 telemetry-as-fix: ❌ pre-existing `Error` boundary, decode 즉시 abort
- §2 string-classifier: ❌ `Json_util.kind_name` 닫힌-sum typed total fn
- §3 N-of-M: ❌ 두 사이트 모두 PR scope, post-fix `rg '_ -> Error \"'` = 0

## Verification

```
dune build test/test_types_coverage.exe + test/test_agent_identity.exe  ✅
dune exec test/test_types_coverage.exe   → 188/188 PASS
dune exec test/test_agent_identity.exe   → 19/19 PASS
```

Test message lock: 두 message 모두 test literal 매치 0 (`Error _` 와일드카드 또는 `Ok` roundtrip 만 사용).

## Chronic main break

iter#90 PR #16927 + #16924 의 `keeper_trace_emit.ml` SMJ rebind hotfix 가 origin/main 미적용. 본 PR 도 worktree 에 temp 적용해 full lib/ build 검증 후 commit 전 revert. iter#90/#16924 머지 후 자동 unblock.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>