### PR TITLE
fix(keeper): wire 8 callers to Keeper_state_machine_json (post-extraction cleanup)

### DIFF
--- a/lib/keeper/keeper_trace_emit.ml
+++ b/lib/keeper/keeper_trace_emit.ml
@@ -52,7 +52,7 @@ let emit_transition
       "event", `String (SM.event_to_string event);
       "prev_phase", `String (SM.phase_to_string prev_phase);
       "new_phase", `String (SM.phase_to_string new_phase);
-      "conditions_after", SM.conditions_to_json conditions_after;
+      "conditions_after", Keeper_state_machine_json.conditions_to_json conditions_after;
       "restart_count", `Int restart_count;
     ] in
     let path = trace_path ~base_path ~keeper_name in

--- a/test/test_keeper_registry_provenance.ml
+++ b/test/test_keeper_registry_provenance.ml
@@ -109,7 +109,7 @@ let test_json_serializer_none () =
       ; http_status = None
       }
   in
-  let json = KSM.event_to_json ev in
+  let json = Masc_mcp.Keeper_state_machine_json.event_to_json ev in
   let s = Yojson.Safe.to_string json in
   (check bool)
     "JSON does not include provider_id when None"
@@ -128,7 +128,7 @@ let test_json_serializer_some () =
       ; http_status = Some 502
       }
   in
-  let json = KSM.event_to_json ev in
+  let json = Masc_mcp.Keeper_state_machine_json.event_to_json ev in
   let s = Yojson.Safe.to_string json in
   (check bool)
     "JSON includes provider_id when Some"

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -2480,7 +2480,7 @@ let test_setclear_coverage () =
      If someone adds a new field to conditions but forgets to add it here,
      this check catches it by comparing against conditions_to_json output. *)
   let json_field_count =
-    match SM.conditions_to_json SM.default_conditions with
+    match Masc_mcp.Keeper_state_machine_json.conditions_to_json SM.default_conditions with
     | `Assoc pairs -> List.length pairs
     | _ -> fail "conditions_to_json did not return Assoc"
   in

--- a/test/test_keeper_state_machine_correspondence.ml
+++ b/test/test_keeper_state_machine_correspondence.ml
@@ -102,13 +102,13 @@ let ocaml_changed_fields (ev : SM.event) : string list =
   let after_t = SM.update_conditions base_t ev in
   let d_f =
     json_field_diff
-      (SM.conditions_to_json base_f)
-      (SM.conditions_to_json after_f)
+      (Masc_mcp.Keeper_state_machine_json.conditions_to_json base_f)
+      (Masc_mcp.Keeper_state_machine_json.conditions_to_json after_f)
   in
   let d_t =
     json_field_diff
-      (SM.conditions_to_json base_t)
-      (SM.conditions_to_json after_t)
+      (Masc_mcp.Keeper_state_machine_json.conditions_to_json base_t)
+      (Masc_mcp.Keeper_state_machine_json.conditions_to_json after_t)
   in
   List.sort_uniq String.compare (d_f @ d_t)
 
@@ -238,7 +238,7 @@ let load_spec_actions () =
     TLA+-only variables (e.g. [restart_count], owned by the supervisor
     layer rather than the FSM) are filtered out as out-of-scope. *)
 let conditions_field_names () : string list =
-  match SM.conditions_to_json SM.default_conditions with
+  match Masc_mcp.Keeper_state_machine_json.conditions_to_json SM.default_conditions with
   | `Assoc fs -> List.map fst fs |> List.sort String.compare
   | _ ->
       Alcotest.fail "conditions_to_json did not return a JSON object"


### PR DESCRIPTION
## Summary

origin/main 빌드 깨진 상태 (active incident). PR #16882 `refactor(keeper_state_machine): extract JSON encoders into sibling` 가 함수를 `Keeper_state_machine_json` 모듈로 옮겼지만 **8 호출 site 가 그대로 stale** — 4 파일에서 `SM.conditions_to_json` / `KSM.event_to_json` Unbound.

## 빌드 오류 (사용자 보고, 2026-05-20 17:48)

```
File "lib/keeper/keeper_trace_emit.ml", line 55:
   Error: Unbound value SM.conditions_to_json
File "test/test_keeper_registry_provenance.ml", line 112:
   Error: Unbound value KSM.event_to_json
File "test/test_keeper_state_machine_correspondence.ml", line 105:
   Error: Unbound value SM.conditions_to_json
File "test/test_keeper_state_machine.ml", line 2483:
   Error: Unbound value SM.conditions_to_json
```

## 변경

| 파일 | 호출 수 | 변경 |
|------|--------|------|
| `lib/keeper/keeper_trace_emit.ml` | 1 | `SM.conditions_to_json` → `Keeper_state_machine_json.conditions_to_json` |
| `test/test_keeper_state_machine.ml` | 1 | `SM.conditions_to_json` → `Masc_mcp.Keeper_state_machine_json.conditions_to_json` |
| `test/test_keeper_registry_provenance.ml` | 2 | `KSM.event_to_json` → `Masc_mcp.Keeper_state_machine_json.event_to_json` |
| `test/test_keeper_state_machine_correspondence.ml` | 5 | 동일 패턴 (replace_all) |

총 **8 호출 site, 4 파일**. Qualified path 사용 (별도 module alias 추가 안함).

## 원인 분석 (Workaround pattern)

- 분류: **§3 N-of-M 패치** (워크어라운드 거부 기준)
- Root cause: PR #16882 extraction 시 caller grep 누락
- 검증 누락: `rg 'SM\.conditions_to_json\|SM\.event_to_json\|KSM\.conditions_to_json\|KSM\.event_to_json' lib/ test/` 가 push 전 의무였음
- 메모리 인용: `feedback_extraction_audit_must_grep_both_bare_and_wrapped` (2026-05-09) — *bare + wrapped 양쪽 grep* 강제 규칙. 이번 사고가 정확한 재발 사례.

## 검증

- `dune build --root .` clean (warning only — duplicate library `-lzstd`, unrelated)
- `rg 'SM\.conditions_to_json\|KSM\.event_to_json\|SM\.event_to_json\|KSM\.conditions_to_json' lib/ test/` = 0 잔존

## Test plan

- [ ] CI build job green
- [ ] User 가 main worktree 에서 `dune build` 재실행 → 통과 확인
- [ ] (별도 follow-up) Backsliding lint 제안: extraction PR 가 `module X = Old_module` alias 통해 *old qualifier* 가 grep 0 인 PR 만 통과 — issue 별도

## Workaround-rejection 7/7 self-check

- [x] §1 Telemetry-as-fix — N/A (실제 callsite fix, counter 추가 없음)
- [x] §2 String classifier — N/A
- [x] §3 N-of-M — 본 PR 가 8/8 모두 fix. atomic 단일 PR.
- [x] symptom suppression — N/A
- [x] test backdoor — N/A
- [x] 같은 typo Nx fix — N/A (단일 extraction follow-up)
- [x] catch-all 추가 — N/A

## RFC-Bound subsystem note

`lib/keeper/keeper_trace_emit.ml` 는 agent_delegation policy 의 RFC-bound list (`credential_*`, `keeper_gh_*`, `host_config_*`, `operator_control*`, `dashboard credential`, `claude hooks`, `workflow*`) 에 *포함되지 않음*. trace_emit 은 일반 observability. `pr-rfc-check.sh` N/A — 본 PR 은 *기존 PR #16882 의 incomplete cleanup follow-up*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)