### PR TITLE
fix(cdal/labeling,effect_evidence): name kind + enumerate field status in 3 boundary parse errors

### DIFF
--- a/lib/cdal/effect_evidence.ml
+++ b/lib/cdal/effect_evidence.ml
@@ -48,7 +48,12 @@ let of_json (json : Yojson.Safe.t) : t =
 let of_json_list (json : Yojson.Safe.t) : (t list, string) result =
   match json with
   | `List items -> Ok (List.map of_json items)
-  | _ -> Error "expected JSON array of effect evidence records"
+  | other ->
+    Error
+      (Printf.sprintf
+         "Effect_evidence.of_json_list: expected JSON array of effect evidence \
+          records, got %s"
+         (Json_util.kind_name other))
 ;;
 
 let any_source_path_present events = List.exists is_populated events

--- a/lib/cdal/labeling.ml
+++ b/lib/cdal/labeling.ml
@@ -150,8 +150,42 @@ let labeled_verdict_of_json = function
         Ok { verdict; label; labeler; note; labeled_at }
       | Error e, _ -> Error (Printf.sprintf "verdict: %s" e)
       | _, Error e -> Error (Printf.sprintf "label: %s" e))
-    | _ -> Error "missing or invalid fields in labeled_verdict")
-  | _ -> Error "labeled_verdict: expected JSON object"
+    | _ ->
+      (* Field-by-field status so the operator reading the parse failure
+         sees exactly which field caused the wide-arm match to fall
+         through.  The 4-tuple match above requires:
+           - [verdict] present (any JSON value, parsed downstream)
+           - [label] / [labeler] / [labeled_at] present as [`String _]
+         Anything else lands here.  Naming each field's status avoids
+         the previous "missing or invalid" ambiguity which left
+         operators unable to tell a missing field from a wrong-type
+         field. *)
+      let verdict_status =
+        match List.assoc_opt "verdict" fields with
+        | Some _ -> "present"
+        | None -> "missing"
+      in
+      let string_field_status name =
+        match List.assoc_opt name fields with
+        | Some (`String _) -> "ok"
+        | Some other ->
+          Printf.sprintf "wrong-kind=%s" (Json_util.kind_name other)
+        | None -> "missing"
+      in
+      Error
+        (Printf.sprintf
+           "labeled_verdict: field status — verdict=%s, label=%s, \
+            labeler=%s, labeled_at=%s (label/labeler/labeled_at must be \
+            JSON strings; verdict accepts any JSON)"
+           verdict_status
+           (string_field_status "label")
+           (string_field_status "labeler")
+           (string_field_status "labeled_at")))
+  | other ->
+    Error
+      (Printf.sprintf
+         "labeled_verdict: expected JSON object, got %s"
+         (Json_util.kind_name other))
 
 let confusion_summary_to_json c =
   `Assoc


### PR DESCRIPTION
## Goal

Operator-clarity sweep iter#72-#95 의 cdal/ 슬라이스. 3 사이트, 2 파일, RFC-0056 isolated sub-lib.

## Sites

| File:Line | Function | Fix Shape |
|---|---|---|
| `effect_evidence.ml:51` | `of_json_list` | wildcard → `Json_util.kind_name other` |
| `labeling.ml:154` | `labeled_verdict_of_json` (outer) | 동일 |
| `labeling.ml:153` | `labeled_verdict_of_json` (inner 4-tuple) | **enumerated field status** (more substantive) |

## Fix shape — substantive: `labeling.ml:153`

이 사이트가 가장 가치 있는 fix. 4-tuple match 가 absorbs **두 distinct failure classes**:
- 필드 missing (`None`)
- 필드 present with wrong kind (`Some (\`Int _)` for `String _` slot)

이전 single-string error 는 어느 class 인지/어느 field 인지 모두 모름 → operator 가 misshapen JSON 을 re-parse 해야 진단. 새 error:

```
labeled_verdict: field status — verdict=present, label=ok,
labeler=wrong-kind=int, labeled_at=missing (label/labeler/labeled_at
must be JSON strings; verdict accepts any JSON)
```

3 string fields: `missing` / `ok` / `wrong-kind=<name>` via `Json_util.kind_name`.
`verdict` (any JSON 수용, downstream `Cdal_types.contract_verdict_of_json` 가 처리): present/missing 만.

## Multi-mode wildcard 의 *진단 비용*

지금까지 iter#72-#94 의 wildcard 는 대부분 *단일 class* (wrong-kind only). `labeling.ml:153` 은 *multi-mode* — missing OR wrong-type-of-4-fields 흡수. 이런 사이트에서는 단순 `kind_name` 만으로는 부족 — per-field enumeration 이 right move.

## Self-check vs Workaround Rejection Bar §1-3

- §1 telemetry-as-fix: ❌ pre-existing `Error` boundary, decode abort
- §2 string-classifier: ❌ `Json_util.kind_name` 닫힌-sum typed total fn
- §3 N-of-M: ❌ 3 사이트 모두 cdal/ family 같은 PR. Post-fix `rg '_ -> Error \"' lib/cdal/effect_evidence.ml lib/cdal/labeling.ml` = 0 매치.

## Verification

```
dune build lib/cdal/                                  ✅ (RFC-0056 isolated)
dune build test/test_labeling.exe                     ✅
dune build test/test_effect_evidence_source_path.exe  ✅
dune exec test/test_labeling.exe                      → 11/11 PASS
dune exec test/test_effect_evidence_source_path.exe   → 13/13 PASS
```

Test 메시지 lock 0 (둘다 `Ok roundtrip` / `Error _` 와일드카드).

## Chronic main break

iter#90 PR #16927 + #16924 의 `keeper_trace_emit.ml` SMJ rebind hotfix 가 origin/main 미적용. PR 은 worktree temp-fix → full lib + test exe build 검증 → commit 전 revert. iter#90/#16924 머지 후 자동 unblock.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>