### PR TITLE
fix(masc_http_client/pool): re-raise Eio.Cancel.Cancelled in 2 RFC-0106 violations

### DIFF
--- a/lib/masc_http_client/pool.ml
+++ b/lib/masc_http_client/pool.ml
@@ -147,7 +147,16 @@ let evict_expired_entries t now =
     !evicted_clients)
   |> List.iter (fun c ->
        try Piaf.Client.shutdown c
-       with _ -> () (* shutdown is best-effort; pool already dropped the ref *))
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | _ -> ()
+       (* Shutdown is best-effort; the pool already dropped the ref so
+          a Piaf-level error here cannot leak a client.  But
+          [Eio.Cancel.Cancelled] must propagate so the enclosing fiber
+          honors structured-concurrency cancellation (RFC-0106) — the
+          previous bare [with _ -> ()] silently swallowed Cancelled,
+          letting a dying fiber finish iterating clients instead of
+          unwinding promptly. *))
 
 let start_eviction_fiber t =
   Eio.Fiber.fork ~sw:t.sw (fun () ->
@@ -242,7 +251,15 @@ let count_idle t =
 let release t key client ~close_only =
   let now =
     try Eio.Time.now (Eio.Stdenv.clock t.env)
-    with _ -> 0.0  (* if clock is gone we're tearing down anyway *)
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | _ -> 0.0
+    (* If the clock effect raises a non-Cancel exception we are in a
+       teardown/shutdown shape and 0.0 is a safe fallback — the only
+       use of [now] below is for the [last_used] field on a parked
+       entry which will get evicted on the next tick.  But Cancelled
+       must propagate per RFC-0106 so the surrounding fiber unwinds
+       instead of parking a client during a structured cancellation. *)
   in
   let should_park =
     not close_only


### PR DESCRIPTION
## Goal

Smell category 전환 — operator-clarity sweep (iter#72-#95) 의 *catch-all kind-discard* 에서 **RFC-0106 cancelled-safety** 로 이동. 2 사이트 same file.

## Sites

### `pool.ml:148-150` — Piaf.Client.shutdown 이터레이션

```ocaml
|> List.iter (fun c ->
     try Piaf.Client.shutdown c
     with _ -> ())  (* ❌ swallows Cancelled *)
```

Eviction tick 에서 expired client 들 shutdown. `with _ ->` 이 *Piaf 레벨 에러* (의도) 와 함께 `Eio.Cancel.Cancelled` 까지 흡수 → 죽어가는 fiber 가 unwind 대신 N clients 모두 shutdown 시도하며 cooperative-cancellation 깨짐.

### `pool.ml:242-246` — Eio.Time.now in release

```ocaml
let now =
  try Eio.Time.now (Eio.Stdenv.clock t.env)
  with _ -> 0.0  (* ❌ swallows Cancelled *)
in
```

Release path 에서 `last_used` 타임스탬프용. Cancelled 발생 시 fiber unwind 해야 하는데 0.0 으로 fall through → client 가 cancellation 중에 park 됨.

## Fix (RFC-0106 표준 패턴)

```ocaml
try ...
with
| Eio.Cancel.Cancelled _ as e -> raise e
| _ -> <fallback>
```

각 사이트에 *왜* non-Cancel 은 fallback 가능한지 + *왜* Cancelled 는 propagate 필수인지 inline comment 확장.

## Self-check vs Workaround Rejection Bar §1-3

- §1 telemetry-as-fix: ❌ correctness fix, visibility 아님. Counter 추가 없음.
- §2 string-classifier: ❌ closed-form RFC-0106 패턴 (typed catch arm).
- §3 N-of-M: ❌ 본 파일의 2 `with _ ->` 모두 처리. 다른 candidates (`credential_materializer.ml`, `fd_accountant.ml`, `keeper_shell_bash_repo_wide_scan.ml`) 는 별 PR 분리 — credential_materializer 는 project guard 의해 RFC 참조 필수, 다른 둘은 subsystem owner 다름.

## Verification

```
dune build lib/masc_http_client/          ✅
dune build test/test_pool.exe             ✅
dune build test/test_pool_metrics.exe     ✅
dune exec test/test_pool.exe              → 19/19 PASS
dune exec test/test_pool_metrics.exe      → 5/5 PASS
```

## Chronic main break update

iter#90 PR #16927 머지됨 (commit `0490c3dbad`) — `keeper_trace_emit.ml` SMJ rebind 가 origin/main 에 적용되어 iter#89-#95 의 temp-fix workaround 가 더 이상 불필요. 이번 PR 은 origin/main 그대로 사용, chronic break workaround 없음.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>