### PR TITLE
fix(fd_accountant): re-raise Eio.Cancel.Cancelled in 2 RFC-0106 violations

### DIFF
--- a/lib/server/fd_accountant.ml
+++ b/lib/server/fd_accountant.ml
@@ -67,9 +67,15 @@ let held_kinds_key : held_kind list Eio.Fiber.key = Eio.Fiber.create_key ()
 
 let held_kinds () =
   (* NDT-OK: fiber-local runtime state only prevents same-fiber slot
-     double-accounting; policy decisions stay outside this boundary. *)
+     double-accounting; policy decisions stay outside this boundary.
+     [Eio.Fiber.get] is normally a fiber-local HashMap lookup that
+     does not raise, but defend against future Eio changes with the
+     RFC-0106 standard split: Cancelled propagates so the fiber
+     unwinds; anything else falls back to the empty default. *)
   try Option.value ~default:[] (Eio.Fiber.get held_kinds_key)
-  with _ -> []
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | _ -> []
 
 let active_held_kinds () =
   List.filter (fun held -> Atomic.get held.active) (held_kinds ())
@@ -198,7 +204,15 @@ let read_fd_open () =
         (try
            let entries = Sys.readdir dir in
            Array.length entries
-         with _ -> try_dirs rest)
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | _ -> try_dirs rest)
+         (* [Sys.readdir] raising on a non-existent path is *expected*
+            (we are probing 3 platform-dependent candidates and the
+            first hit wins).  [Eio.Cancel.Cancelled] is not a probe
+            miss — the fiber is being cancelled and must unwind
+            instead of walking through the remaining candidates
+            (RFC-0106). *)
   in
   try_dirs candidates
 


### PR DESCRIPTION
## Goal

RFC-0106 cancelled-safety sweep iter#96 의 직접 후속. `lib/server/fd_accountant.ml` 의 2 `with _ ->` 사이트.

## Sites

### `fd_accountant.ml:68-72` — held_kinds ()

Fiber-local key 읽기. 일반적으로 raise 안 하지만 *defensive* fix — Cancelled 가 silently 흡수되지 않도록.

```ocaml
(* Before *)
try Option.value ~default:[] (Eio.Fiber.get held_kinds_key)
with _ -> []

(* After *)
try Option.value ~default:[] (Eio.Fiber.get held_kinds_key)
with
| Eio.Cancel.Cancelled _ as e -> raise e
| _ -> []
```

### `fd_accountant.ml:195-201` — try_dirs probing

3개 platform-dependent FD-dir candidate probe. `Sys.readdir` 가 non-existent 에서 raise = *expected* (probe miss → next candidate). 그러나 Cancelled 는 probe miss 아님.

## Fix 형식 + comment 확장

각 사이트에:
- (a) 어떤 non-Cancel 예외 가 fallback 가능한지
- (b) 왜 Cancelled 가 propagate 해야 하는지
inline comment 명시.

## Self-check vs Workaround Rejection Bar §1-3

- §1 telemetry-as-fix: ❌ correctness fix, counter 추가 없음
- §2 string-classifier: ❌ closed-form typed catch arm
- §3 N-of-M: ❌ 본 파일 2 사이트 모두 PR scope. Sibling pool.ml = iter#96 #16949 처리됨. `keeper_shell_bash_repo_wide_scan.ml` = 다른 subsystem owner, 별 PR 분리.

## Verification

```
dune build lib/                          ✅
dune build test/test_fd_accountant.exe   ✅
dune exec test/test_fd_accountant.exe    → 20/20 PASS
```

## Iter#96 PR #16949 = sibling pattern

같은 RFC-0106 fix 패턴 (iter#96 PR [#16949](https://github.com/jeong-sik/masc-mcp/pull/16949) — `masc_http_client/pool.ml` 2 사이트). Trader 가 동시 머지하면 conflict 위험 0 (다른 파일).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>