### PR TITLE
refactor(keeper-bash): replace int_of_string try/with with int_of_string_opt

### DIFF
--- a/lib/keeper/keeper_shell_bash_repo_wide_scan.ml
+++ b/lib/keeper/keeper_shell_bash_repo_wide_scan.ml
@@ -128,10 +128,12 @@ let git_log_all_is_repo_wide args =
     else
       let has_output_limit arg =
         let t = arg.text in
-        (* -N (bare number flag like -30) *)
+        (* -N (bare number flag like -30).  See the matching
+           [int_of_string_opt] below for the rationale: option-typed
+           parse replaces exception-as-control-flow. *)
         (t <> "" && t.[0] = '-' && t <> "-" && t <> "--"
          && let digits = String.sub t 1 (String.length t - 1) in
-            try let _ = int_of_string digits in true with _ -> false)
+            Option.is_some (int_of_string_opt digits))
         (* -n N handled below: "-n" followed by a number *)
         || String.equal t "-n"
         || String.starts_with ~prefix:"--max-count" t
@@ -142,8 +144,15 @@ let git_log_all_is_repo_wide args =
           if String.equal arg.text "-n" then
             match rest with
             | n :: _ ->
-              (try let _ = int_of_string n.text in true
-               with _ -> check_limit rest)
+              (* [int_of_string_opt] removes the exception-as-control-flow
+                 pattern that previously masked the parse-failure branch.
+                 The old [try ... with _ -> _] form would have silently
+                 swallowed any exception raised by future refactors of the
+                 [int_of_string] call (and violated RFC-0106 if it ever
+                 became cancellable).  Option-typed parse is total. *)
+              (match int_of_string_opt n.text with
+               | Some _ -> true
+               | None -> check_limit rest)
             | [] -> false
           else if has_output_limit arg then true
           else check_limit rest


### PR DESCRIPTION
## Summary

`git_log_all_is_repo_wide` (in `lib/keeper/keeper_shell_bash_repo_wide_scan.ml`) used exception-as-control-flow at two sites to detect whether a `-n N` or `-N` argument carries a parseable integer:

```ocaml
(* -n N branch (line 146) *)
(try let _ = int_of_string n.text in true
 with _ -> check_limit rest)

(* -N bare-number branch (line 134) *)
try let _ = int_of_string digits in true with _ -> false
```

Both replaced with `int_of_string_opt` (option-typed total parse).

## Why root-fix over RFC-0106 band-aid

The standard RFC-0106 fix for `try ... with _ ->` is the cancelled-safety split:

```ocaml
with
| Eio.Cancel.Cancelled _ as e -> raise e
| _ -> fallback
```

That's a band-aid — the underlying exception-as-control-flow is still there. For `int_of_string` specifically, the stdlib provides `int_of_string_opt`, so the exception path can be eliminated entirely:

- Removes the implicit catch-all that would have swallowed any future non-`Failure` exception
- Makes the parse a total function — caller sees `Some/None` exhaustively
- Defends against future refactors of the call that might introduce yielding (and thus cancellation reachability)
- Matches the "Parse. Don't Validate." (Alexis King) discipline

`Sys.readdir` probing in `fd_accountant` (iter#97 PR #16951) had no `_opt` variant, so the RFC-0106 split was the right tool there. Here `int_of_string_opt` is the root fix.

## Smell category continuation

- iter#72-#95: operator-clarity (kind-discard) sweep
- iter#96-#97: RFC-0106 cancelled-safety (`pool.ml`, `fd_accountant.ml`)
- iter#98 (this PR): exception-as-control-flow root fix — same family, **better** than RFC-0106 split when stdlib `_opt` variant exists

## Test parity

Pre-existing 2/71 failures in `test_keeper_bash_safety.exe` (pipe-or-redirect block on `||` fallback patterns) are unrelated to this change. Verified by stashing the patch:

- origin/main baseline: 2/71 failures
- patched tree: same 2/71 failures, no new failures
- Build: `dune build --root . lib/keeper` clean

## Workaround Rejection Bar self-check

- [x] §1 telemetry-as-fix: N/A — this removes silent catch-all, no new counter
- [x] §2 string classifier: N/A — no string match added
- [x] §3 N-of-M: both sites in the same function fixed in this PR (no follow-up needed)
- [x] No catch-all `_ ->` added; the existing one is **removed**
- [x] No cap/cooldown/dedup/repair pattern

## RFC subsystem check

`lib/keeper/keeper_shell_bash*` is not in the RFC-guarded subsystem list (workflow-pr.md §11: credential / identity / operator / sandbox / hooks / workflow*). No RFC waiver needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)