### PR TITLE
fix(tool_misc_admin): drop silent-zero on Intlit overflow in int_arg_opt

### DIFF
--- a/lib/tool_misc_admin.ml
+++ b/lib/tool_misc_admin.ml
@@ -62,7 +62,17 @@ let bool_arg_opt args key =
 let int_arg_opt args key =
   match U.member key args with
   | `Int value -> Some value
-  | `Intlit raw -> Some (Option.value ~default:0 (Stdlib.int_of_string_opt raw))
+  (* [`Intlit raw] only appears for integers too large for the native
+     [int] domain (63-bit on 64-bit platforms).  The previous
+     implementation collapsed parse failure to [Some 0], which silently
+     corrupted overflow into a defined "zero" value — a Workaround
+     Rejection Bar §2 violation (unknown → permissive default).  By
+     composing [int_of_string_opt] into [Option.t] directly, an
+     overflow surfaces as [None], the same shape callers already
+     handle for "field missing" — no silent zero.  Small [`Intlit]
+     payloads (rare; values just above [max_int] depending on
+     platform) round-trip cleanly. *)
+  | `Intlit raw -> Stdlib.int_of_string_opt raw
   | _ -> None
 
 (* ================================================================ *)


### PR DESCRIPTION
## Summary

`int_arg_opt` (in `lib/tool_misc_admin.ml`) silently corrupted overflowing JSON integers into `Some 0`:

```ocaml
| `Intlit raw -> Some (Option.value ~default:0 (Stdlib.int_of_string_opt raw))
```

Fixed by composing `int_of_string_opt` into `Option.t` directly — overflow now surfaces as `None`, the same shape callers already handle for missing fields.

## The smell

`Intlit raw` is yojson's wrapper for integers too large for the native `int` domain (63-bit on 64-bit platforms). The previous implementation:

1. Tried to parse `raw` back into native int → `None` on overflow.
2. Substituted `0` for the parse failure via `Option.value ~default:0`.
3. Returned `Some 0` to the caller.

The single caller (`token_expiry_hours` handling at line 310) then:
- Saw `Some 0`
- Hit the `value > 0` guard
- Returned `\"token_expiry_hours must be > 0\"`

The user gets a misleading error claiming the value is non-positive when the actual problem was overflow.

## Workaround Rejection Bar §2 violation

Per `software-development.md`:

> **Unknown → Permissive Default (조용한 허용)**: 알 수 없는 입력을 에러 대신 \"편리한 기본값\"으로 매핑.  
> **규칙**: unknown 입력은 `Error`/`None`/`Unknown` 변형으로 처리. `option`을 `Some default`로 압축하지 않는다.

The `~default:0` collapse is exactly the §2 anti-pattern — `option` compressed into `Some default`.

## Fix

```ocaml
| `Intlit raw -> Stdlib.int_of_string_opt raw
```

- Small `Intlit` payloads (rare; values just above `max_int` on 32-bit) round-trip cleanly.
- Overflow surfaces as `None` (same as missing field).
- No silent zero substitution.

The caller behavior changes only for overflow:
- **Before**: overflow → `Some 0` → error \"must be > 0\" (misleading)
- **After**: overflow → `None` → fall back to `current.token_expiry_hours` (silent, but no data corruption)

Both still ignore user intent, but the latter does not silently corrupt the value. A typed overflow error (`(int, overflow_reason) result option`) would be the more principled fix; that propagates through the caller and is out of scope for this single-site clarity correction.

## Verification

- `dune build --root . lib` — clean
- No direct tests for `tool_misc_admin` (verified via `rg -l 'tool_misc_admin' test/`)
- The single caller at line 310 explicitly handles `None` (`| None -> Ok current.token_expiry_hours`)

## Workaround Rejection Bar self-check

- [x] §1 telemetry-as-fix: N/A — removes silent corruption, no counter added
- [x] §2 string classifier: N/A — no string match added
- [x] §3 N-of-M: this is the only `int_arg_opt` site with the overflow smell; `bool_arg_opt` next to it has no analogous issue (bools don't overflow)
- [x] No catch-all `_ ->` added; the existing one is unchanged (it correctly returns `None` for non-int kinds)
- [x] No cap/cooldown/dedup/repair pattern

## RFC subsystem check

`lib/tool_misc_admin.ml` is not in the RFC-guarded subsystem list. No RFC waiver needed.

## Smell-category continuation

- iter#72-#95: operator-clarity (kind-discard) sweep
- iter#96-#97: RFC-0106 cancelled-safety
- iter#98: exception-as-control-flow root fix
- **iter#99 (this PR)**: silent-zero default at boundary parser (Workaround Rejection Bar §2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)