### PR TITLE
fix(lint-spawn-bounded): drift allowlist 495/526 → 504/535 (process_eio.ml)

### DIFF
--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -19,12 +19,12 @@
 # lib/bounded_proc/bounded_proc.ml:17  — the canonical helper itself.
 lib/bounded_proc/bounded_proc.ml:17
 
-# lib/process/process_eio.ml:495, 526 — `spawn_and_drain_{stdout,both}`.
+# lib/process/process_eio.ml:504, 535 — `spawn_and_drain_{stdout,both}`.
 # Private functions. Every caller (run_argv*, run_argv_with_status*,
 # run_argv_with_stdin*) wraps in `Eio.Time.with_timeout_exn clk timeout_sec`
 # + `Eio.Switch.run` and the process-wide spawn guard.
-lib/process/process_eio.ml:495
-lib/process/process_eio.ml:526
+lib/process/process_eio.ml:504
+lib/process/process_eio.ml:535
 
 # lib/server/lsp_process_manager.ml:178 — LSP child process. Lifetime is
 # bound to the LSP session switch; idle eviction handled by the LSP


### PR DESCRIPTION
## Summary
- `#16942` (process_eio orphan-pipe fix) 가 +9 line 추가 → `spawn_and_drain_{stdout,both}` spawn site 가 **495/526 → 504/535** shift
- allowlist line number + comment 동기화
- 모든 in-flight PR (#16948 #16949 #16951 등) 의 Spawn-bounded ratchet 가드 unblock

## 영향
- 현재 모든 agent/사용자 open PR 이 `Spawn-bounded ratchet` 가드에 FAIL
- 본 1-file/3-line hotfix 머지 시 → 다른 PR rebase 후 CI 통과

## Verification
```
$ bash scripts/lint-spawn-bounded.sh
lint-spawn-bounded: PASS (5 spawn site(s), all in allowlist)
```

## 워크어라운드 거부 체크리스트 (RFC-0148 §10)

7항목 self-check:
1. [x] visibility-only 아님 — 실제 lint script unblock
2. [x] string/substring classifier 아님 — exact line match
3. [x] N-of-M 아님 — 2 사이트 모두 fix
4. [x] catch-all 추가 아님
5. [x] cap/cooldown/dedup/repair 아님
6. [x] test backdoor 아님
7. [x] 같은 typo N번 fix 아님

## RFC-WAIVED
`scripts/lint-spawn-bounded.allowlist` 는 RFC subsystem 매핑 외. drift sync only.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>