### PR TITLE
fix(keeper): auto-resume cascade failure pauses

### DIFF
--- a/lib/keeper/keeper_supervisor_pause_policy.ml
+++ b/lib/keeper/keeper_supervisor_pause_policy.ml
@@ -25,6 +25,14 @@ type crash_pause_resume_policy =
   | Manual_resume_required
   | Auto_resume_with_backoff
 
+let auto_resume_after_sec_for_policy meta = function
+  | Manual_resume_required -> None
+  | Auto_resume_with_backoff ->
+    let initial_sec = Env_config.KeeperSupervisor.auto_resume_initial_sec in
+    let max_sec = Env_config.KeeperSupervisor.auto_resume_max_sec in
+    next_auto_resume_after_sec ~initial_sec ~max_sec meta.auto_resume_after_sec
+;;
+
 let handle_crash_auto_pause
       ~publish_phase_lifecycle
       (ctx : _ context)
@@ -38,13 +46,8 @@ let handle_crash_auto_pause
   =
   (match read_meta ctx.config entry.name with
    | Ok (Some meta) ->
-     let initial_sec = Env_config.KeeperSupervisor.auto_resume_initial_sec in
-     let max_sec = Env_config.KeeperSupervisor.auto_resume_max_sec in
      let auto_resume_after_sec =
-       match resume_policy with
-       | Manual_resume_required -> None
-       | Auto_resume_with_backoff ->
-         next_auto_resume_after_sec ~initial_sec ~max_sec meta.auto_resume_after_sec
+       auto_resume_after_sec_for_policy meta resume_policy
      in
      let blocker_text =
        let existing =

--- a/lib/keeper/keeper_supervisor_pause_policy.mli
+++ b/lib/keeper/keeper_supervisor_pause_policy.mli
@@ -18,6 +18,13 @@ type crash_pause_resume_policy =
   | Manual_resume_required
   | Auto_resume_with_backoff
 
+(** Resolve the persisted [auto_resume_after_sec] value for [resume_policy]
+    using the global keeper supervisor back-off knobs. *)
+val auto_resume_after_sec_for_policy
+  :  Keeper_types.keeper_meta
+  -> crash_pause_resume_policy
+  -> float option
+
 (** [handle_crash_auto_pause ~publish_phase_lifecycle ctx entry
       ~reason_tag ~metric_name ~lifecycle_detail ~log_message
       ~blocker_class ~resume_policy] persists [paused=true] on disk,

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -556,14 +556,22 @@ let pause_keeper_for_overflow
     meta.name reason;
   paused_meta
 
-let sync_keeper_paused_state
+let sync_keeper_paused_state_impl
+    ~(resume_policy : Keeper_supervisor_pause_policy.crash_pause_resume_policy option)
     ~(config : Coord.config)
     ~(meta : keeper_meta)
     ~(paused : bool) : (keeper_meta, string) result =
+  let auto_resume_after_sec =
+    match paused, resume_policy with
+    | true, Some policy ->
+      Keeper_supervisor_pause_policy.auto_resume_after_sec_for_policy meta policy
+    | _ -> meta.auto_resume_after_sec
+  in
   let synced_meta =
     {
       meta with
       paused;
+      auto_resume_after_sec;
       updated_at = now_iso ();
     }
   in
@@ -615,6 +623,23 @@ let sync_keeper_paused_state
                ~side_effect:"resume sync fiber wakeup"
                "registry entry missing after metadata update");
       Ok synced_meta
+
+let sync_keeper_paused_state ~(config : Coord.config) ~(meta : keeper_meta) ~paused
+  =
+  sync_keeper_paused_state_impl ~resume_policy:None ~config ~meta ~paused
+
+let sync_keeper_paused_state_with_resume_policy
+    ~(config : Coord.config)
+    ~(meta : keeper_meta)
+    ~(paused : bool)
+    ~(resume_policy : Keeper_supervisor_pause_policy.crash_pause_resume_policy)
+  : (keeper_meta, string) result
+  =
+  sync_keeper_paused_state_impl
+    ~resume_policy:(Some resume_policy)
+    ~config
+    ~meta
+    ~paused
 
 let current_keeper_meta ~(config : Coord.config) ~(fallback_meta : keeper_meta) =
   match Keeper_registry.get ~base_path:config.base_path fallback_meta.name with

--- a/lib/keeper/keeper_turn_cascade_budget.mli
+++ b/lib/keeper/keeper_turn_cascade_budget.mli
@@ -213,6 +213,16 @@ val sync_keeper_paused_state :
     Returns [Error] when disk sync fails so callers can surface the failure
     instead of silently diverging runtime vs persisted state. *)
 
+val sync_keeper_paused_state_with_resume_policy :
+  config:Coord.config ->
+  meta:keeper_meta ->
+  paused:bool ->
+  resume_policy:Keeper_supervisor_pause_policy.crash_pause_resume_policy ->
+  (keeper_meta, string) result
+(** Like {!sync_keeper_paused_state}, but also applies [resume_policy] when
+    pausing so automatic pause paths can enter the supervisor self-healing
+    sweep instead of becoming an indefinite manual pause. *)
+
 val current_keeper_meta :
   config:Coord.config ->
   fallback_meta:keeper_meta ->

--- a/lib/keeper/keeper_unified_turn_failure.ml
+++ b/lib/keeper/keeper_unified_turn_failure.ml
@@ -62,10 +62,11 @@ let record_failure_and_maybe_escalate
         else updated_meta
       in
       match
-        Keeper_turn_cascade_budget.sync_keeper_paused_state
+        Keeper_turn_cascade_budget.sync_keeper_paused_state_with_resume_policy
           ~config
           ~meta:pause_meta
           ~paused:true
+          ~resume_policy:Keeper_supervisor_pause_policy.Auto_resume_with_backoff
       with
       | Ok _ ->
         if cascade_auto_paused

--- a/test/test_keeper_paused_cas_retain_9733.ml
+++ b/test/test_keeper_paused_cas_retain_9733.ml
@@ -165,6 +165,60 @@ let test_resume_caller_wins_heartbeat_disk_wins () =
       "joined_room_ids = [r1; r3] (disk wins on heartbeat field)"
       ["r1"; "r3"] final.joined_room_ids)
 
+let test_pause_sync_sets_auto_resume_backoff () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      let m0 =
+        let m = make_meta ~name:"auto-resume-pause-152" in
+        { m with paused = false; auto_resume_after_sec = None }
+      in
+      (match Keeper_types.write_meta ~force:true config m0 with
+       | Ok () -> ()
+       | Error e -> fail ("seed failed: " ^ e));
+      ignore (Keeper_registry.register ~base_path:base_dir m0.name m0);
+      let paused =
+        match
+          Keeper_turn_cascade_budget.sync_keeper_paused_state_with_resume_policy
+            ~config
+            ~meta:m0
+            ~paused:true
+            ~resume_policy:Keeper_supervisor_pause_policy.Auto_resume_with_backoff
+        with
+        | Ok paused -> paused
+        | Error e -> fail ("pause sync failed: " ^ e)
+      in
+      check bool "paused" true paused.paused;
+      let pause_delay =
+        match paused.auto_resume_after_sec with
+        | Some sec -> sec
+        | None -> fail "expected auto_resume_after_sec"
+      in
+      check bool "auto resume delay is positive" true (pause_delay > 0.0);
+      let persisted =
+        match Keeper_types.read_meta config m0.name with
+        | Ok (Some m) -> m
+        | Ok None -> fail "persisted meta missing"
+        | Error e -> fail ("persisted read failed: " ^ e)
+      in
+      check bool "persisted paused" true persisted.paused;
+      check bool "persisted auto resume delay" true
+        (persisted.auto_resume_after_sec = paused.auto_resume_after_sec);
+      match Keeper_registry.get ~base_path:base_dir m0.name with
+      | Some entry ->
+        check bool "registry paused" true entry.meta.paused;
+        check bool "registry auto resume delay" true
+          (entry.meta.auto_resume_after_sec = paused.auto_resume_after_sec)
+      | None -> fail "registry entry missing")
+
 let () =
   run "Keeper paused-field CAS retain (#9733)"
     [
@@ -174,5 +228,7 @@ let () =
             test_pause_caller_wins_heartbeat_disk_wins;
           test_case "resume: caller wins, heartbeat retained" `Quick
             test_resume_caller_wins_heartbeat_disk_wins;
+          test_case "pause: auto-resume policy persists backoff" `Quick
+            test_pause_sync_sets_auto_resume_backoff;
         ] );
     ]


### PR DESCRIPTION
## Summary
- route cascade/tool failure auto-pause through the keeper auto-resume backoff policy
- keep existing manual pause sync unchanged while adding an explicit policy-aware pause sync helper
- add a regression test proving paused metadata persists auto_resume_after_sec to disk and registry

## Verification
- scripts/dune-local.sh build test/test_keeper_paused_cas_retain_9733.exe test/test_keeper_cascade_auto_pause_task074.exe test/test_keeper_error_classify_recoverable.exe test/test_keeper_unified.exe test/test_keeper_supervisor.exe test/test_supervisor_start_predicate.exe test/test_keeper_turn_livelock_10121.exe
- _build/default/test/test_keeper_paused_cas_retain_9733.exe
- _build/default/test/test_keeper_cascade_auto_pause_task074.exe
- _build/default/test/test_keeper_error_classify_recoverable.exe
- ocamlformat --check changed OCaml files