### PR TITLE
fix(cdal_runtime/mode_enforcer): kind-aware violation parse errors

### DIFF
--- a/lib/cdal_runtime/effect_evidence.mli
+++ b/lib/cdal_runtime/effect_evidence.mli
@@ -81,3 +81,11 @@ val make
 
 val to_json : t -> Yojson.Safe.t
 val of_json : Yojson.Safe.t -> (t, string) result
+
+(** [json_kind_name j] returns a short label for the JSON kind ([null],
+    [bool], [int], [intlit], [float], [string], [object], [array],
+    [tuple], [variant]).  Pure, side-effect-free; used by sibling
+    [Mode_enforcer] for kind-discriminating parse-error messages so the
+    sub-library keeps a single inline copy (RFC-0056 leaf isolation
+    forbids reaching for [Json_util.kind_name] in [masc_core]). *)
+val json_kind_name : Yojson.Safe.t -> string

--- a/lib/cdal_runtime/mode_enforcer.ml
+++ b/lib/cdal_runtime/mode_enforcer.ml
@@ -7,6 +7,17 @@ type tool_effect_class =
 (* Backward-compatible alias. *)
 type mutation_class = tool_effect_class
 
+(* Kind-name helper for parse-error diagnostics.  [lib/cdal_runtime/] is
+   intentionally decoupled from [masc_core] (RFC-OAS-011 producer-side
+   isolation), so [Json_util.kind_name] is not reachable without breaking
+   the leaf-isolation invariant.  The sibling [Effect_evidence] module
+   in this same sub-library already exposes a [json_kind_name : Yojson.Safe.t
+   -> string] (line ~178); reuse it instead of inlining a second copy,
+   to keep the sub-library to a single SSOT for this diagnostic surface.
+   A yojson-only micro-leaf library (lib/shared_types/json_kind.ml,
+   noted in PR #16915) would lift this further once available. *)
+let json_kind_name = Effect_evidence.json_kind_name
+
 type violation_kind =
   | Mutating_in_diagnose
   | External_in_draft
@@ -29,7 +40,15 @@ let violation_kind_to_yojson v = `String (violation_kind_to_string v)
 
 let violation_kind_of_yojson = function
   | `String s -> violation_kind_of_string s
-  | j -> Error (Printf.sprintf "expected string, got %s" (Yojson.Safe.to_string j))
+  | other ->
+    (* Report kind only; the previous [Yojson.Safe.to_string j] form
+       inlined the full payload which can be arbitrarily large
+       (e.g. an [`Assoc] with nested arrays) and pollutes the error
+       string and any downstream log line. *)
+    Error
+      (Printf.sprintf
+         "violation_kind_of_yojson: expected JSON string (kind=%s)"
+         (json_kind_name other))
 ;;
 
 type violation =
@@ -68,8 +87,48 @@ let violation_of_yojson = function
         | Ok effective_mode, Ok violation_kind ->
           Ok { ts; tool_name; input_summary; effective_mode; violation_kind }
         | Error e, _ | _, Error e -> Error e)
-     | _ -> Error "missing or invalid fields in violation")
-  | _ -> Error "violation: expected JSON object"
+     | _ ->
+       (* Per-field status so the operator reading the parse failure
+          sees exactly which field caused the 5-tuple match to fall
+          through.  [ts] must be a [`Float]; [tool_name] /
+          [input_summary] must be [`String]; [effective_mode] and
+          [violation_kind] must be present (any JSON, parsed
+          downstream).  The previous "missing or invalid fields"
+          string conflated all of these into a single message. *)
+       let float_field_status name =
+         match List.assoc_opt name fields with
+         | Some (`Float _) -> "ok"
+         | Some other -> Printf.sprintf "wrong-kind=%s" (json_kind_name other)
+         | None -> "missing"
+       in
+       let string_field_status name =
+         match List.assoc_opt name fields with
+         | Some (`String _) -> "ok"
+         | Some other -> Printf.sprintf "wrong-kind=%s" (json_kind_name other)
+         | None -> "missing"
+       in
+       let presence_status name =
+         match List.assoc_opt name fields with
+         | Some _ -> "present"
+         | None -> "missing"
+       in
+       Error
+         (Printf.sprintf
+            "violation: field status — ts=%s, tool_name=%s, \
+             input_summary=%s, effective_mode=%s, violation_kind=%s \
+             (ts must be a JSON number; tool_name/input_summary must \
+             be JSON strings; effective_mode/violation_kind accept any \
+             JSON and are parsed downstream)"
+            (float_field_status "ts")
+            (string_field_status "tool_name")
+            (string_field_status "input_summary")
+            (presence_status "effective_mode")
+            (presence_status "violation_kind")))
+  | other ->
+    Error
+      (Printf.sprintf
+         "violation_of_yojson: expected JSON object (kind=%s)"
+         (json_kind_name other))
 ;;
 
 type token_snapshot =


### PR DESCRIPTION
## Summary

Three operator-clarity smells fixed in \`lib/cdal_runtime/mode_enforcer.ml\`, all at the CDAL violation record JSON boundary (operator-facing parse errors for tool-effect enforcement decisions).

## Smell 1 — full-payload diagnostic blast (1 site)

\`violation_kind_of_yojson\`:

\`\`\`ocaml
| j -> Error (Printf.sprintf \"expected string, got %s\" (Yojson.Safe.to_string j))
\`\`\`

\`Yojson.Safe.to_string j\` inlines the full payload into the error string. For a nested \`\\\`Assoc\` (or any large object) this pollutes the error and every downstream log line. Replaced with kind-only reporting via \`Effect_evidence.json_kind_name\`.

## Smell 2 — conflated 5-field tuple match failure (1 site)

\`violation_of_yojson\` returned \"missing or invalid fields in violation\" regardless of which field actually caused the tuple match to fall through. Replaced with per-field status — \`ts\`/\`tool_name\`/\`input_summary\`/\`effective_mode\`/\`violation_kind\` — using the same field-by-field status pattern iter#95 applied to \`cdal/labeling.ml\`'s 4-tuple match.

Sample new error:

\`\`\`
violation: field status — ts=missing, tool_name=ok, input_summary=wrong-kind=int,
effective_mode=present, violation_kind=missing (ts must be a JSON number;
tool_name/input_summary must be JSON strings; effective_mode/violation_kind
accept any JSON and are parsed downstream)
\`\`\`

## Smell 3 — kind-discard at outer match (1 site)

Generic \`\"violation: expected JSON object\"\` replaced with \`\"expected JSON object (kind=<actual>)\"\`.

## SSOT — single inline copy of [json_kind_name] in the sub-library

The first attempt added a *second* inline \`json_kind_name\` to \`mode_enforcer.ml\`, which would have been a Workaround Rejection Bar §3 N-of-M violation (sibling \`Effect_evidence\` in the same sub-library already had a private copy).

Fix: reuse the sibling helper. One line is added to \`effect_evidence.mli\` to expose \`val json_kind_name : Yojson.Safe.t -> string\` inside the sub-library. \`mode_enforcer.ml\` then does \`let json_kind_name = Effect_evidence.json_kind_name\` to keep the call sites short.

RFC-0056 leaf isolation forbids reaching for \`Json_util.kind_name\` in \`masc_core\` from this producer-side library — the sibling-module reuse is the local SSOT for now. A repo-wide micro-leaf \`lib/shared_types/json_kind.ml\` was noted as an RFC candidate in PR #16915.

## Verification

- \`dune build --root . lib/cdal_runtime\` — clean
- \`dune exec --root . test/test_cdal_mode_enforcer.exe\` — 13/13 PASS

## Workaround Rejection Bar self-check

- [x] §1 telemetry-as-fix: N/A — improves diagnostic surface, no counter added
- [x] §2 string classifier: N/A — \`kind=%s\` is diagnostic, not a routing decision
- [x] §3 N-of-M: avoided by reusing sibling helper (initial draft would have violated; corrected before commit)
- [x] No catch-all \`_ ->\` added; existing ones replaced with \`other ->\` carrying kind info
- [x] No cap/cooldown/dedup/repair pattern

## RFC subsystem check

\`lib/cdal_runtime/\` is not in the RFC-guarded subsystem list. No RFC waiver needed.

## Smell-category continuation

- iter#100: IDE annotation boundary (RFC-0128 IDE diagnosis surface)
- **iter#101 (this PR)**: CDAL violation record boundary (RFC-OAS-011 enforcement decision surface)
- Pattern: mixed cluster — kind-discard + payload-blast + tuple-match conflation, all in one \`*_of_yojson\` function

🤖 Generated with [Claude Code](https://claude.com/claude-code)