### PR TITLE
[codex] Fix dashboard health truth shell path

### DIFF
--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -465,13 +465,17 @@ const errorPanelOpen = signal(false)
 export function ErrorCounterBadge() {
   const count = unacknowledgedCount.value
   const open = errorPanelOpen.value
+  const label = count > 0
+    ? `${count} unacknowledged dashboard errors`
+    : 'No dashboard errors'
 
   return html`
     <div class="relative" role="status">
       <button
         type="button"
         class="flex items-center gap-1.5 cursor-pointer rounded-[var(--r-1)] px-1 py-0.5 transition-colors hover:bg-[var(--color-bg-elevated)] ${count > 0 ? 'text-[var(--color-status-err)]' : 'text-[var(--color-fg-muted)]'}"
-        title=${count > 0 ? `${count} unacknowledged errors` : 'No errors'}
+        title=${label}
+        aria-label=${label}
         onClick=${() => { errorPanelOpen.value = !errorPanelOpen.value }}
         aria-expanded=${open}
         aria-haspopup="true"
@@ -702,17 +706,17 @@ function HealthIndicator({ collapsed }: { collapsed?: boolean }) {
 
   if (!live) {
     dotClass = 'bg-[var(--color-status-err)]'
-    label = 'Offline'
+    label = 'Transport offline'
   } else if (!snap) {
     dotClass = 'bg-[var(--color-fg-muted)]'
-    label = missionLoading.value ? 'Loading' : 'Idle'
+    label = missionLoading.value ? 'Mission loading' : 'Mission idle'
   } else if (blockers > 0 || attentionCount > 0) {
     dotClass = 'bg-[var(--color-status-warn)]'
     const total = blockers + attentionCount
-    label = `Attention ${total}`
+    label = `Mission attention ${total}`
   } else {
     dotClass = 'bg-[var(--color-status-ok)]'
-    label = 'Healthy'
+    label = 'Mission healthy'
   }
 
   const attentionLines = attentionCount > 0 ? summarizeAttentionPreview(attentionQueue) : []

--- a/dashboard/src/components/status-tray.ts
+++ b/dashboard/src/components/status-tray.ts
@@ -239,12 +239,12 @@ export function summarizeStatusTray(input: StatusTrayInput): StatusTraySummary {
         label: 'Client',
         value: silent
           ? heartbeatFresh ? pongLatency : 'silent'
-          : `${input.wsEventCount60s}/60s`,
+          : `${input.wsEventCount60s} deltas/min`,
         detail: silent
           ? heartbeatFresh
             ? `client WS channel is idle; heartbeat pong ${Math.floor(pongAgeMs / 1000)}s ago`
             : 'client WS channel is open but no recent event or heartbeat pong has arrived'
-          : `last event ${Math.floor(silentMs / 1000)}s ago`,
+          : `last applied route delta ${Math.floor(silentMs / 1000)}s ago`,
       }
     }
   } else {
@@ -403,7 +403,7 @@ function PopoverContent({
             <div class="mt-0.5 text-sm font-semibold tabular-nums">${summary.counts.reconnectCount}</div>
           </div>
           <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1.5">
-            <div class="font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">WS events</div>
+            <div class="font-mono text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">WS deltas</div>
             <div class="mt-0.5 text-sm font-semibold tabular-nums">${summary.counts.wsEventCount60s}/60s</div>
           </div>
         </div>

--- a/dashboard/src/components/transport-beacon.test.ts
+++ b/dashboard/src/components/transport-beacon.test.ts
@@ -91,7 +91,7 @@ describe('computeBeaconView', () => {
       eventCount60s: 12,
     }))
     expect(view.state).toBe('green')
-    expect(view.label).toContain('12 events / 60s')
+    expect(view.label).toContain('12 deltas / 60s')
     expect(view.title).toContain('Client WS mode')
   })
 

--- a/dashboard/src/components/transport-beacon.ts
+++ b/dashboard/src/components/transport-beacon.ts
@@ -99,8 +99,8 @@ export function computeBeaconView(args: {
   }
   return {
     state: 'green',
-    label: `Client WS · open · ${args.eventCount60s} events / 60s`,
-    title: `Client WS mode active. Last event ${Math.floor(silentMs / 1000)}s ago.`,
+    label: `Client WS · open · ${args.eventCount60s} deltas / 60s`,
+    title: `Client WS mode active. Last applied route delta ${Math.floor(silentMs / 1000)}s ago. Heartbeats are shown separately when route deltas are idle.`,
   }
 }
 

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -366,6 +366,13 @@ let json_assoc_string_opt key json =
   | _ -> None
 ;;
 
+let json_assoc_int_opt key json =
+  match json_assoc_field_opt key json with
+  | Some (`Int value) -> Some value
+  | Some (`Float value) -> Some (int_of_float value)
+  | _ -> None
+;;
+
 let projection_diagnostics_fields json =
   match json_assoc_field_opt "projection_diagnostics" json with
   | Some (`Assoc fields) -> fields
@@ -1173,6 +1180,10 @@ let dashboard_general_agent_count =
   Server_dashboard_http_core_entities.dashboard_general_agent_count
 ;;
 
+let dashboard_general_agent_count_light =
+  Server_dashboard_http_core_entities.dashboard_general_agent_count_light
+;;
+
 let provider_capacity_json = Server_dashboard_http_core_entities.provider_capacity_json
 
 (* #10544: light mode is meant to skip the heavy belief/tension evaluation
@@ -1459,20 +1470,36 @@ let dashboard_shell_payload_json
     let status_json, status_ms =
       measure_ms "status" (fun () -> dashboard_shell_status_json config)
     in
-    let agents, agents_ms =
-      measure_ms "agents" (fun () -> dashboard_agents_safe config)
+    let general_agents, agents_ms =
+      if light
+      then measure_ms "agents" (fun () -> dashboard_general_agent_count_light config)
+      else (
+        let agents, agents_ms =
+          measure_ms "agents" (fun () -> dashboard_agents_safe config)
+        in
+        dashboard_general_agent_count agents, agents_ms)
     in
-    let general_agents = dashboard_general_agent_count agents in
     let tasks, tasks_ms = measure_ms "tasks" (fun () -> dashboard_tasks_safe config) in
-    let active_keepers, keepers_ms =
-      measure_ms "keepers" (fun () -> running_keeper_count config)
-    in
     let configured_keepers, configured_keepers_ms =
       measure_ms "configured_keepers" (fun () -> keeper_count config)
     in
     let meta_cognition_r = ref (`Null, 0) in
     let config_resolution_r = ref (`Null, 0) in
     let runtime_resolution_r = ref (`Null, 0) in
+    let active_keepers, keepers_ms =
+      if light
+      then (
+        let runtime_resolution_json, runtime_resolution_ms =
+          measure_json_projection "runtime_resolution" (fun () ->
+            Server_dashboard_http_runtime_info.light_runtime_resolution_json config)
+        in
+        runtime_resolution_r := (runtime_resolution_json, runtime_resolution_ms);
+        ( Option.value
+            ~default:0
+            (json_assoc_int_opt "keeper_fibers" runtime_resolution_json)
+        , 0 ))
+      else measure_ms "keepers" (fun () -> running_keeper_count config)
+    in
     if light
     then
       meta_cognition_r

--- a/lib/server/server_dashboard_http_core_entities.ml
+++ b/lib/server/server_dashboard_http_core_entities.ml
@@ -92,6 +92,53 @@ let dashboard_message_json (message : Masc_domain.message) =
 let dashboard_tasks_safe config = Coord.get_tasks_safe config
 let dashboard_agents_safe config = Coord.get_active_agents config
 
+let json_assoc_string_opt key = function
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`String value) -> Some value
+     | _ -> None)
+  | _ -> None
+;;
+
+let active_agent_summary_json json =
+  match json_assoc_string_opt "status" json with
+  | Some status ->
+    (match String.lowercase_ascii (String.trim status) with
+     | "active" | "busy" | "listening" ->
+       let agent_type =
+         json_assoc_string_opt "agent_type" json
+         |> Option.value ~default:"unknown"
+         |> String.trim
+         |> String.lowercase_ascii
+       in
+       Some agent_type
+     | "inactive" -> None
+     | _ -> None)
+  | None -> None
+;;
+
+let dashboard_general_agent_count_light config =
+  if not (Coord.root_is_initialized config)
+  then 0
+  else
+    Coord.list_dir config (Coord.agents_dir config)
+    |> List.fold_left
+         (fun count name ->
+           if name = ""
+              || String.contains name '/'
+              || not (Filename.check_suffix name ".json")
+           then count
+           else (
+             let path = Filename.concat (Coord.agents_dir config) name in
+             match Coord.read_json_result config path with
+             | Ok json ->
+               (match active_agent_summary_json json with
+                | Some agent_type when not (String.equal agent_type "keeper") -> count + 1
+                | Some _ | None -> count)
+             | Error _ -> count))
+         0
+;;
+
 let dashboard_messages_safe config ~since_seq ~limit =
   Coord.get_messages_raw config ~since_seq ~limit
 ;;

--- a/lib/server/server_dashboard_http_core_entities.mli
+++ b/lib/server/server_dashboard_http_core_entities.mli
@@ -5,6 +5,11 @@ val dashboard_message_json : Masc_domain.message -> Yojson.Safe.t
 val dashboard_tasks_safe : Coord.config -> Masc_domain.task list
 val dashboard_agents_safe : Coord.config -> Masc_domain.agent list
 
+val dashboard_general_agent_count_light : Coord.config -> int
+(** Cheap active non-keeper agent count for [/api/v1/dashboard/shell?light=true].
+    Reads only the small status/type summary fields instead of materializing
+    full agent records or running repair. *)
+
 val dashboard_messages_safe :
   Coord.config -> since_seq:int -> limit:int -> Masc_domain.message list
 

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -515,7 +515,8 @@ let runtime_resolution_json (config : Coord.config) =
     |> Option.value ~default:config.workspace_path
   in
   let prompt_markdown_dir =
-    Prompt_registry.get_markdown_dir () |> Option.value ~default:""
+    Prompt_registry.get_markdown_dir ()
+    |> Option.value ~default:(Config_dir_resolver.prompts_dir ())
   in
   let expected_prompt_dir = Config_dir_resolver.prompts_dir () in
   let prompt_dir_mismatch =
@@ -696,6 +697,88 @@ let runtime_resolution_json (config : Coord.config) =
             ~resolved_base_commit ~source_mismatch )
       ]
       @ Server_routes_http_runtime.keeper_fleet_runtime_resolution_fields () )
+;;
+
+let light_runtime_resolution_json (config : Coord.config) =
+  let build = Build_identity.current () in
+  let base_path_input =
+    Env_config_core.base_path_source_opt ()
+    |> Option.map snd
+    |> Option.value ~default:config.workspace_path
+  in
+  let prompt_markdown_dir =
+    Prompt_registry.get_markdown_dir ()
+    |> Option.value ~default:(Config_dir_resolver.prompts_dir ())
+  in
+  let server_repo_path = Build_identity.repo_root () in
+  let server_workspace_mismatch =
+    match server_repo_path with
+    | Some path ->
+      not
+        (same_normalized_path path config.workspace_path
+         || same_normalized_path path config.base_path)
+    | None -> false
+  in
+  let fleet_fields =
+    Server_routes_http_runtime.keeper_fleet_runtime_resolution_light_fields ()
+  in
+  let fleet_safety =
+    match List.assoc_opt "keeper_fleet_safety" fleet_fields with
+    | Some ((`Assoc _) as json) -> Some json
+    | _ -> None
+  in
+  let fleet_warning =
+    match fleet_safety with
+    | Some (`Assoc fields) ->
+      let status =
+        match List.assoc_opt "status" fields with
+        | Some (`String status) -> status
+        | _ -> "unknown"
+      in
+      let operator_action_required =
+        match List.assoc_opt "operator_action_required" fields with
+        | Some (`Bool value) -> value
+        | _ -> false
+      in
+      (not (String.equal status "ok")) || operator_action_required
+    | _ -> false
+  in
+  let warnings =
+    []
+    |> (fun acc ->
+         if server_workspace_mismatch
+         then
+           "Server binary checkout differs from dashboard workspace/base path."
+           :: acc
+         else acc)
+    |> (fun acc ->
+         if fleet_warning
+         then "Keeper fleet safety is degraded; inspect keeper_fleet_safety." :: acc
+         else acc)
+    |> List.rev
+  in
+  let status = if warnings = [] then "ready" else "warn" in
+  `Assoc
+    ( [ "status", `String status
+      ; "warnings", `List (List.map (fun warning -> `String warning) warnings)
+      ; "base_path", path_item_json ~source:"input" base_path_input
+      ; "workspace_path", path_item_json ~source:"workspace" config.workspace_path
+      ; "resolved_base_path", path_item_json ~source:"resolved_base" config.base_path
+      ; "data_root", path_item_json ~source:"runtime_data" (Coord.masc_root_dir config)
+      ; "prompt_markdown_dir", path_item_json ~source:"prompt_registry" prompt_markdown_dir
+      ; ( "server_repo_path"
+        , match server_repo_path with
+          | Some path -> path_item_json ~source:"server_binary" path
+          | None ->
+            `Assoc
+              [ "path", `Null; "exists", `Bool false; "source", `String "server_binary" ] )
+      ; "source_mismatch", `Bool false
+      ; "server_workspace_mismatch", `Bool server_workspace_mismatch
+      ; "diagnostics", `List []
+      ; ("keeper_runtime", Keeper_runtime_resolved.(current () |> to_yojson))
+      ; "build", Build_identity.to_yojson build
+      ]
+      @ fleet_fields )
 ;;
 
 (* 30-second TTL chosen to match the dashboard frontend's natural refresh

--- a/lib/server/server_dashboard_http_runtime_info.mli
+++ b/lib/server/server_dashboard_http_runtime_info.mli
@@ -48,6 +48,12 @@ val runtime_resolution_json : Coord.config -> Yojson.Safe.t
     Reached unqualified through the
     [Server_dashboard_http_core] cascade consumer. *)
 
+val light_runtime_resolution_json : Coord.config -> Yojson.Safe.t
+(** Renders the cheap runtime/fleet subset used by
+    [/api/v1/dashboard/shell?light=true].  This keeps the shell health strip
+    aligned with [/health] fleet safety without running git probes or other
+    heavy runtime-resolution checks on the header hot path. *)
+
 (** {1 Dashboard HTTP routes} *)
 
 val dashboard_runtime_probe_http_json :

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -618,24 +618,27 @@ let current_room_base_path_opt () =
   | Some state -> Some state.Mcp_server.room_config.base_path
   | None -> None
 
-let keeper_fleet_runtime_resolution_base_fields () =
+let keeper_fleet_runtime_resolution_base_fields ?(include_reaction_ledger = true) () =
   let base_path = current_room_base_path_opt () in
   let phase_counts = keeper_phase_counts ?base_path () in
   let keeper_fibers = phase_counts.running in
   let paused_keepers_json = paused_keepers_health_json () in
-  let reaction_ledger_json = keeper_reaction_ledger_health_json () in
   let fleet_safety =
     keeper_fleet_safety_health_json ~phase_counts ~paused_keepers_json
   in
-  [ "keeper_fibers", `Int keeper_fibers
-  ; "paused_keepers", `Int (paused_keeper_count paused_keepers_json)
-  ; "keeper_fleet_no_fibers", `Bool (bool_field "no_running_fibers" fleet_safety)
-  ; ( "keeper_fd_pressure"
-    , Keeper_fd_pressure.runtime_state_json ~active_keepers:keeper_fibers
-        ~starting_keepers:0 ~requested_keepers:24 () )
-  ; "keeper_fleet_safety", fleet_safety
-  ; "keeper_reaction_ledger", reaction_ledger_json
-  ]
+  let fields =
+    [ "keeper_fibers", `Int keeper_fibers
+    ; "paused_keepers", `Int (paused_keeper_count paused_keepers_json)
+    ; "keeper_fleet_no_fibers", `Bool (bool_field "no_running_fibers" fleet_safety)
+    ; ( "keeper_fd_pressure"
+      , Keeper_fd_pressure.runtime_state_json ~active_keepers:keeper_fibers
+          ~starting_keepers:0 ~requested_keepers:24 () )
+    ; "keeper_fleet_safety", fleet_safety
+    ]
+  in
+  if include_reaction_ledger
+  then fields @ [ "keeper_reaction_ledger", keeper_reaction_ledger_health_json () ]
+  else fields
 ;;
 
 let fd_accountant_snapshot_json () =
@@ -661,6 +664,11 @@ let fd_accountant_snapshot_json () =
 
 let keeper_fleet_runtime_resolution_fields () =
   keeper_fleet_runtime_resolution_base_fields ()
+  @ [ "fd_accountant", fd_accountant_snapshot_json () ]
+;;
+
+let keeper_fleet_runtime_resolution_light_fields () =
+  keeper_fleet_runtime_resolution_base_fields ~include_reaction_ledger:false ()
   @ [ "fd_accountant", fd_accountant_snapshot_json () ]
 ;;
 

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -238,6 +238,12 @@ val keeper_fleet_runtime_resolution_fields : unit -> (string * Yojson.Safe.t) li
     shell can show the same backpressure source as [/health] without scraping
     Prometheus. *)
 
+val keeper_fleet_runtime_resolution_light_fields :
+  unit -> (string * Yojson.Safe.t) list
+(** Like {!keeper_fleet_runtime_resolution_fields}, but omits the
+    reaction-ledger JSONL scan for the [/api/v1/dashboard/shell?light=true]
+    header hot path. *)
+
 val health_handler : Httpun.Request.t -> Httpun.Reqd.t -> unit
 (** [health_handler request reqd] writes {!make_health_response_json} as the
     response body. *)

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -2,6 +2,7 @@ module Types = Masc_domain
 
 module Lib = Masc_mcp
 module Auth = Masc_mcp.Auth
+module Coord = Masc_mcp.Coord
 
 open Alcotest
 
@@ -796,6 +797,68 @@ let test_shell_snapshot_wire_light_variant_bypasses_snapshot () =
     (json |> member "wire_sentinel" = `Null);
   Lib.Dashboard_snapshot.reset_for_test ()
 
+let test_dashboard_shell_light_includes_runtime_health_ssot () =
+  with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  let json =
+    Lib.Server_dashboard_http_core.dashboard_shell_http_json ~light:true config
+  in
+  let open Yojson.Safe.Util in
+  let runtime_resolution = json |> member "runtime_resolution" in
+  let keeper_fibers = runtime_resolution |> member "keeper_fibers" |> to_int in
+  Alcotest.(check bool)
+    "light shell exposes runtime_resolution object"
+    true
+    (match runtime_resolution with
+     | `Assoc _ -> true
+     | _ -> false);
+  Alcotest.(check int)
+    "light shell keeper count follows runtime health keeper_fibers"
+    keeper_fibers
+    (json |> member "counts" |> member "keepers" |> to_int);
+  Alcotest.(check bool)
+    "light shell exposes fleet safety"
+    true
+    (match runtime_resolution |> member "keeper_fleet_safety" with
+     | `Assoc _ -> true
+     | _ -> false);
+  Alcotest.(check bool)
+    "light shell exposes fd accountant"
+    true
+    (match runtime_resolution |> member "fd_accountant" with
+     | `Assoc _ -> true
+     | _ -> false)
+
+let test_dashboard_shell_light_counts_agents_from_summary_fields () =
+  with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  ignore (Coord.init config ~agent_name:None);
+  let write_agent ~name ~agent_type ~status =
+    let path =
+      Filename.concat (Coord.agents_dir config) (Coord.safe_filename name ^ ".json")
+    in
+    Coord.write_json
+      config
+      path
+      (`Assoc
+        [ "name", `String name
+        ; "agent_type", `String agent_type
+        ; "status", `String status
+        ; "capabilities", `List []
+        ; "joined_at", `String "2026-05-20T00:00:00Z"
+        ; "last_seen", `String "2026-05-20T00:00:00Z"
+        ])
+  in
+  write_agent ~name:"codex-active" ~agent_type:"codex" ~status:"active";
+  write_agent ~name:"keeper-active" ~agent_type:"keeper" ~status:"busy";
+  write_agent ~name:"codex-inactive" ~agent_type:"codex" ~status:"inactive";
+  let json =
+    Lib.Server_dashboard_http_core.dashboard_shell_http_json ~light:true config
+  in
+  let open Yojson.Safe.Util in
+  Alcotest.(check int)
+    "light shell counts active non-keeper agents from summary fields"
+    1
+    (json |> member "counts" |> member "agents" |> to_int)
+
 (* RFC-0138 Phase 3 Step 2 — /tools and /telemetry/summary wire tests.
 
    Cover the new selector matrix on
@@ -963,6 +1026,10 @@ let () =
             test_shell_snapshot_wire_falls_back_when_empty;
           test_case "RFC-0138 shell wire light variant bypasses snapshot" `Quick
             test_shell_snapshot_wire_light_variant_bypasses_snapshot;
+          test_case "light shell carries runtime health SSOT" `Quick
+            test_dashboard_shell_light_includes_runtime_health_ssot;
+          test_case "light shell counts agents from summary fields" `Quick
+            test_dashboard_shell_light_counts_agents_from_summary_fields;
           test_case "RFC-0138 tools wire returns snapshot when actor omitted" `Quick
             test_tools_snapshot_wire_returns_snapshot_when_actor_omitted;
           test_case "RFC-0138 telemetry_summary wire returns snapshot" `Quick


### PR DESCRIPTION
## Summary

- Align dashboard light-shell health with `/health` fleet safety by returning a cheap `runtime_resolution` subset and deriving keeper count from `keeper_fibers`.
- Keep `/api/v1/dashboard/shell?light=true` out of the heavy agent/keeper projection path: agent counts now read summary fields only, and keeper runtime omits the reaction-ledger JSONL scan.
- Clarify UI labels so `Client WS` reports route deltas, the bell reports dashboard errors, and the left rail status reports mission state rather than generic server health.

## Root Cause

The dashboard header was using `shell?light=true`, but that payload omitted runtime health SSOT data and still paid for heavy active-agent and keeper scans. On the live server, the old light shell took 8.23s with `agents_ms=4546` and `keepers_ms=3098`, while `/health` already showed the real fleet state as degraded with one keeper fiber and a reaction-capacity shortfall.

## Validation

- `git diff --check`
- `ocamlformat --check lib/server/server_dashboard_http_core_entities.ml lib/server/server_dashboard_http_core_entities.mli lib/server/server_dashboard_http_core.ml test/test_dashboard_http_core.ml lib/server/server_routes_http_runtime.ml lib/server/server_routes_http_runtime.mli lib/server/server_dashboard_http_runtime_info.ml lib/server/server_dashboard_http_runtime_info.mli`
- `pnpm --dir dashboard exec tsc --noEmit --pretty`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/transport-beacon.test.ts src/components/status-tray.test.ts src/components/dashboard-shell.test.ts --no-file-parallelism --maxWorkers=1`
- `scripts/dune-local.sh build test/test_dashboard_http_core.exe`
- `./_build/default/test/test_dashboard_http_core.exe`
- `scripts/dune-local.sh build bin/main_eio.exe`
