### PR TITLE
fix(cdal/violation_record): name JSON kind in of_json_list parse error

### DIFF
--- a/lib/cdal/violation_record.ml
+++ b/lib/cdal/violation_record.ml
@@ -64,7 +64,12 @@ let of_json_list (json : Yojson.Safe.t) : (t list, string) result =
          | Error e -> Error e)
     in
     parse [] items
-  | _ -> Error "expected JSON array of violation records"
+  | other ->
+    Error
+      (Printf.sprintf
+         "violation_record.of_json_list: expected JSON array of violation \
+          records (kind=%s)"
+         (Json_util.kind_name other))
 ;;
 
 let minimum_required_mode (v : t) : Masc_mcp_cdal_runtime.Execution_mode.t =


### PR DESCRIPTION
## Summary

\`of_json_list\` in \`lib/cdal/violation_record.ml\` returned a generic message regardless of the actual JSON kind received:

\`\`\`ocaml
| _ -> Error \"expected JSON array of violation records\"
\`\`\`

Replaced with kind-discriminating form using \`Json_util.kind_name\` — the canonical helper already in use by sibling \`cdal/\` modules.

## Smell completion in [lib/cdal/]

This was the last generic kind-discard in the \`lib/cdal/\` sub-library:

| File | Status |
|------|--------|
| \`cdal/effect_evidence.ml:56\` | already uses \`Json_util.kind_name\` (iter#95) |
| \`cdal/labeling.ml:172, 188\` | already uses \`Json_util.kind_name\` (iter#95) |
| \`cdal/violation_record.ml:67\` | **this PR** |

Producer-side (\`lib/cdal_runtime/\`) sweep was completed in iter#101 (PR #16960) using \`Effect_evidence.json_kind_name\` (sibling helper, because masc_core import would break RFC-OAS-011 leaf isolation).

## Verification

- \`dune build --root . lib/cdal\` — clean
- No direct test for \`violation_record.of_json_list\` (verified via \`rg -n 'violation_record' test/\`); the only mention is an unrelated effect-evidence test referencing the path as a string

## Workaround Rejection Bar self-check

- [x] §1 telemetry-as-fix: N/A — improves diagnostic surface
- [x] §2 string classifier: N/A — \`kind=%s\` is diagnostic, not routing
- [x] §3 N-of-M: this PR closes the last cdal/ site
- [x] No catch-all \`_ ->\` added; the existing one is replaced by \`other ->\`
- [x] No cap/cooldown/dedup/repair pattern

## RFC subsystem check

\`lib/cdal/\` is not in the RFC-guarded subsystem list. No RFC waiver needed.

## Smell-category continuation

- iter#95: \`cdal/effect_evidence.ml\`, \`cdal/labeling.ml\` (kind-discard + tuple-conflation)
- iter#101 (PR #16960): \`cdal_runtime/mode_enforcer.ml\` (3 sites)
- **iter#102 (this PR)**: \`cdal/violation_record.ml\` — final cdal-consumer-side site

🤖 Generated with [Claude Code](https://claude.com/claude-code)