### PR TITLE
fix(keeper): remove trace emit conflict marker

### DIFF
--- a/lib/keeper/keeper_trace_emit.ml
+++ b/lib/keeper/keeper_trace_emit.ml
@@ -57,13 +57,7 @@ let emit_transition
       "event", `String (SM.event_to_string event);
       "prev_phase", `String (SM.phase_to_string prev_phase);
       "new_phase", `String (SM.phase_to_string new_phase);
-<<<<<<< HEAD
       "conditions_after", SMJ.conditions_to_json conditions_after;
-||||||| parent of bd1d311d4d (fix(keeper): update state machine json callers)
-      "conditions_after", SM.conditions_to_json conditions_after;
-=======
-      "conditions_after", SM_json.conditions_to_json conditions_after;
->>>>>>> bd1d311d4d (fix(keeper): update state machine json callers)
       "restart_count", `Int restart_count;
     ] in
     let path = trace_path ~base_path ~keeper_name in


### PR DESCRIPTION
## Summary
- remove committed conflict markers from keeper_trace_emit
- keep the current SMJ.conditions_to_json projection path

## Verification
- scripts/dune-local.sh build bin/main_eio.exe test/test_keeper_state_machine_correspondence.exe
- _build/default/test/test_keeper_state_machine_correspondence.exe
- ocamlformat --check lib/keeper/keeper_trace_emit.ml
- rg -n '^(<<<<<<<|>>>>>>>|\|\|\|\|\|\|\|)' lib/keeper/keeper_trace_emit.ml
- git diff --check

## Runtime note
Latest main currently cannot rebuild/start 8935 because this conflict marker is on main. Runtime recovery should run from this branch until merged, then be switched back to main.