### PR TITLE
fix(worker_runtime_helper_protocol): distinguish parse-failure causes in error strings

### DIFF
--- a/lib/worker_runtime_helper_protocol.ml
+++ b/lib/worker_runtime_helper_protocol.ml
@@ -29,12 +29,31 @@ let option_to_yojson to_json = function
 
 open Result.Syntax
 
+(* Every parse error below now distinguishes between *Intlit overflow*
+   (the digits are syntactically a number but do not fit the target
+   numeric type) and *wrong-kind* (the JSON value is not a number at
+   all).  The previous form returned the same generic string for both,
+   forcing operators to guess which path failed when the payload came
+   back malformed from a remote worker. *)
+
 let int_option_of_yojson = function
   | `Null -> Ok None
   | `Int value -> Ok (Some value)
   | `Intlit value -> (
-      match int_of_string_opt value with Some v -> Ok (Some v) | None -> Error "invalid int option in worker helper payload")
-  | _ -> Error "invalid int option in worker helper payload"
+      match int_of_string_opt value with
+      | Some v -> Ok (Some v)
+      | None ->
+          Error
+            (Printf.sprintf
+               "int option in worker helper payload: intlit overflow \
+                (digits=%s, exceeds native int range)"
+               value))
+  | other ->
+      Error
+        (Printf.sprintf
+           "int option in worker helper payload: expected null|int|intlit \
+            (kind=%s)"
+           (Json_util.kind_name other))
 
 let float_option_of_yojson = function
   | `Null -> Ok None
@@ -43,12 +62,27 @@ let float_option_of_yojson = function
   | `Intlit value -> (
       match float_of_string_opt value with
       | Some f -> Ok (Some f)
-      | None -> Error "invalid float option in worker helper payload")
+      | None ->
+          Error
+            (Printf.sprintf
+               "float option in worker helper payload: intlit not parseable \
+                as float (digits=%s)"
+               value))
   | `String value -> (
       match float_of_string_opt value with
       | Some f -> Ok (Some f)
-      | None -> Error "invalid float option in worker helper payload")
-  | _ -> Error "invalid float option in worker helper payload"
+      | None ->
+          Error
+            (Printf.sprintf
+               "float option in worker helper payload: string not parseable \
+                as float (value=%s)"
+               value))
+  | other ->
+      Error
+        (Printf.sprintf
+           "float option in worker helper payload: expected \
+            null|float|int|intlit|string (kind=%s)"
+           (Json_util.kind_name other))
 
 let string_list_of_yojson = function
   | `List values ->
@@ -56,10 +90,20 @@ let string_list_of_yojson = function
         (fun value acc ->
           match (value, acc) with
           | `String s, Ok rest -> Ok (s :: rest)
-          | _, Ok _ -> Error "invalid string list in worker helper payload"
+          | other, Ok _ ->
+              Error
+                (Printf.sprintf
+                   "string list in worker helper payload: element is not a \
+                    string (kind=%s)"
+                   (Json_util.kind_name other))
           | _, Error msg -> Error msg)
         values (Ok [])
-  | _ -> Error "invalid string list in worker helper payload"
+  | other ->
+      Error
+        (Printf.sprintf
+           "string list in worker helper payload: expected JSON array \
+            (kind=%s)"
+           (Json_util.kind_name other))
 
 let api_response_to_yojson =
   option_to_yojson Llm_provider.Cache.response_to_json


### PR DESCRIPTION
## Summary

Four \`*_of_yojson\` helpers in \`worker_runtime_helper_protocol.ml\` returned the same generic message regardless of which parse path failed. When a remote worker sends back malformed JSON, the masc-mcp log error string is the only diagnostic available — and the previous form did not distinguish:

- wrong JSON kind (e.g. an object where an int was expected)
- correct kind but \`\\\`Intlit\` overflow (digits exceed native int range)
- \`\\\`String\` payload that does not parse as float

This PR splits the error path so each cause is named, and where the payload is small + non-sensitive, the offending digits/value/kind are included.

## Helpers affected

| Helper | Sites | Distinguishes |
|--------|-------|---------------|
| \`int_option_of_yojson\` | 2 | Intlit overflow vs wrong kind |
| \`float_option_of_yojson\` | 3 | Intlit unparseable / string unparseable / wrong kind |
| \`string_list_of_yojson\` | 2 | List element wrong kind vs outer wrong kind |

(\`api_response_of_yojson\` and \`proof_of_yojson\` already delegate to typed parsers downstream — left untouched.)

## Why this boundary matters

Worker payloads cross a *binary* boundary (separate process invoked by \`Worker_runtime\`). The producer is not in the same OCaml runtime as the consumer, so the only diagnostic available when the contract breaks is the error string in the masc-mcp log — there is no Sentry frame on the worker side. That makes kind-discriminating + value-bearing errors strictly more useful here than for in-process parsers.

## Example before / after

\`\`\`
Before: \"invalid int option in worker helper payload\"
After:  \"int option in worker helper payload: intlit overflow
         (digits=999999999999999999999, exceeds native int range)\"

Before: \"invalid float option in worker helper payload\"
After:  \"float option in worker helper payload: string not parseable
         as float (value=NaN-string)\"

Before: \"invalid string list in worker helper payload\"
After:  \"string list in worker helper payload: element is not a string
         (kind=object)\"
\`\`\`

## Verification

- \`dune build --root . lib/worker_runtime_helper_protocol.ml\` — clean
- \`dune exec --root . test/test_worker_runtime.exe\` — **8/8 PASS**

Note: a separate \`origin/fix/keeper-trace-conflict-marker\` branch (commit \`c796b87d94\`) is in flight to remove an unrelated conflict marker that landed in \`lib/keeper/keeper_trace_emit.ml\` on main. The full \`lib\` build is currently broken on origin/main because of that marker. This PR does not touch keeper_trace_emit.ml; verification was done against the worker_runtime test exe directly, which is unaffected by the keeper module.

## Workaround Rejection Bar self-check

- [x] §1 telemetry-as-fix: N/A — diagnostic surface improvement
- [x] §2 string classifier: N/A — error strings are operator-facing diagnostics, not routing
- [x] §3 N-of-M: all 7 sites in the 3 helpers fixed in this PR; \`api_response_of_yojson\` and \`proof_of_yojson\` delegate to typed parsers and have no analogous smell
- [x] No catch-all \`_ ->\` added; existing ones replaced by \`other ->\` with kind info
- [x] No cap/cooldown/dedup/repair pattern

## RFC subsystem check

\`lib/worker_runtime_helper_protocol.ml\` is not in the RFC-guarded subsystem list. No RFC waiver needed.

## Smell-category continuation

- iter#102: \`cdal/violation_record.ml\` — final cdal-consumer-side kind-discard
- **iter#103 (this PR)**: worker JSON helper boundary — first cluster where Intlit overflow vs wrong-kind disambiguation actually carries the offending value into the diagnostic

🤖 Generated with [Claude Code](https://claude.com/claude-code)