### PR TITLE
fix(keeper): rename Shell IR shape fallback helpers

### DIFF
--- a/docs/rfc/RFC-0131-shell-command-gate-facade.md
+++ b/docs/rfc/RFC-0131-shell-command-gate-facade.md
@@ -270,7 +270,7 @@ rg "split_pipeline_segments" lib/        # count 0
 rg "tokenize_path_args"       lib/        # count 0
 rg "path_validation_tokens"   lib/        # count 0
 rg "forbidden_shell_chars"    lib/        # count 0
-rg "raw_keeper_bash_shape_block" lib/keeper/  # count 0 or parse-failure-only helper
+rg "shell_ir_parse_failure_shape_block" lib/keeper/  # parse-failure-only helper
 ```
 
 ## 5. Workaround-rejection compliance (per CLAUDE.md §워크어라운드 거부 기준)

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -33,8 +33,8 @@ module For_testing = struct
   let keeper_bash_shape_block_tag =
     Keeper_shell_bash.For_testing.keeper_bash_shape_block_tag
 
-  let raw_keeper_bash_shape_block_tag =
-    Keeper_shell_bash.For_testing.raw_keeper_bash_shape_block_tag
+  let shell_ir_parse_failure_shape_block_tag =
+    Keeper_shell_bash.For_testing.shell_ir_parse_failure_shape_block_tag
 
   let strip_stderr_dev_null_redirects =
     Keeper_shell_bash.For_testing.strip_stderr_dev_null_redirects

--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -74,7 +74,7 @@ val handle_keeper_bash :
 module For_testing : sig
   val elapsed_duration_ms : start_time:float -> end_time:float -> int
   val keeper_bash_shape_block_tag : string -> string option
-  val raw_keeper_bash_shape_block_tag : string -> string option
+  val shell_ir_parse_failure_shape_block_tag : string -> string option
   val strip_stderr_dev_null_redirects : string -> string * bool
   val keeper_bash_shape_block_hint : string -> string option
 end

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -47,7 +47,7 @@ let has_malformed_dev_null_redirect_token =
 ;;
 let command_has_repo_wide_scan = Repo_wide_scan.command_has_repo_wide_scan
 
-let quote_aware_shape_scan_text cmd =
+let shell_ir_shape_scan_text cmd =
   let len = String.length cmd in
   let buf = Buffer.create len in
   let add_space () = Buffer.add_char buf ' ' in
@@ -96,9 +96,9 @@ let quote_aware_shape_scan_text cmd =
   in
   loop No_quote false 0
 
-let raw_keeper_bash_shape_block cmd =
+let shell_ir_parse_failure_shape_block cmd =
   let cmd, _ = strip_stderr_dev_null_redirects cmd in
-  let scan_text = quote_aware_shape_scan_text cmd in
+  let scan_text = shell_ir_shape_scan_text cmd in
   let lower = String.lowercase_ascii scan_text in
   if string_contains_substring lower "gh pr checks"
   then Some Gh_pr_checks
@@ -125,7 +125,7 @@ let raw_keeper_bash_shape_block cmd =
 
 let keeper_bash_shape_block cmd =
   let cmd, _ = strip_stderr_dev_null_redirects cmd in
-  let scan_text = quote_aware_shape_scan_text cmd in
+  let scan_text = shell_ir_shape_scan_text cmd in
   if command_has_repo_wide_scan cmd
   then Some Repo_wide_scan
   else if has_malformed_dev_null_redirect_token scan_text
@@ -136,7 +136,7 @@ let keeper_bash_shape_block cmd =
   | Masc_exec.Parsed.Parse_error _
   | Masc_exec.Parsed.Parse_aborted _
   | Masc_exec.Parsed.Too_complex _ ->
-    raw_keeper_bash_shape_block cmd
+    shell_ir_parse_failure_shape_block cmd
 
 type safe_read_fallback = {
   primary_cmd : string;
@@ -439,8 +439,8 @@ module For_testing = struct
   let keeper_bash_shape_block_tag cmd =
     Option.map bash_shape_block_tag (keeper_bash_shape_block cmd)
 
-  let raw_keeper_bash_shape_block_tag cmd =
-    Option.map bash_shape_block_tag (raw_keeper_bash_shape_block cmd)
+  let shell_ir_parse_failure_shape_block_tag cmd =
+    Option.map bash_shape_block_tag (shell_ir_parse_failure_shape_block cmd)
 
   let strip_stderr_dev_null_redirects = strip_stderr_dev_null_redirects
 

--- a/lib/keeper/keeper_shell_bash.mli
+++ b/lib/keeper/keeper_shell_bash.mli
@@ -16,7 +16,7 @@ val handle_keeper_bash :
 module For_testing : sig
   val elapsed_duration_ms : start_time:float -> end_time:float -> int
   val keeper_bash_shape_block_tag : string -> string option
-  val raw_keeper_bash_shape_block_tag : string -> string option
+  val shell_ir_parse_failure_shape_block_tag : string -> string option
   val strip_stderr_dev_null_redirects : string -> string * bool
   val keeper_bash_shape_block_hint : string -> string option
 end

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -366,8 +366,10 @@ let test_keeper_bash_shape_uses_shell_ir_for_quoted_literals () =
     (Some "substitution")
     (block_tag "echo $(complex-substitution)")
 
-let test_keeper_bash_raw_shape_fallback_is_quote_aware () =
-  let block_tag = Keeper_exec_shell.For_testing.raw_keeper_bash_shape_block_tag in
+let test_keeper_bash_shell_ir_parse_failure_shape_fallback_is_quote_aware () =
+  let block_tag =
+    Keeper_exec_shell.For_testing.shell_ir_parse_failure_shape_block_tag
+  in
   Alcotest.(check (option string)) "single-quoted redirect is data" None
     (block_tag "printf '%s\\n' '>>>'");
   Alcotest.(check (option string)) "double-quoted redirect is data" None
@@ -1968,8 +1970,9 @@ let () =
         test_keeper_bash_timeout_floor_is_not_sub_io_latency;
       Alcotest.test_case "shape guard parses quoted metachar literals" `Quick
         test_keeper_bash_shape_uses_shell_ir_for_quoted_literals;
-      Alcotest.test_case "raw shape fallback is quote-aware" `Quick
-        test_keeper_bash_raw_shape_fallback_is_quote_aware;
+      Alcotest.test_case "Shell IR parse-failure shape fallback is quote-aware"
+        `Quick
+        test_keeper_bash_shell_ir_parse_failure_shape_fallback_is_quote_aware;
       Alcotest.test_case "stderr devnull strip preserves post-background redirect"
         `Quick
         test_stderr_dev_null_strip_preserves_post_background_redirect;


### PR DESCRIPTION
## Summary

- Rename the internal quote-aware shape scan helper to `shell_ir_shape_scan_text`.
- Rename the parse-failure fallback shape helper and test-only tag facade to `shell_ir_parse_failure_shape_block*`.
- Update the bash safety test name and RFC legacy-purge reference so the old keeper/raw naming no longer leaks through this Shell IR surface.

## Scope

Naming-only change. No behavior changes intended.

This branch intentionally keeps the write set limited to the Shell IR/bash safety naming files plus the directly related RFC reference.

## Validation

- `ocamlformat --check lib/keeper/keeper_shell_bash.ml lib/keeper/keeper_shell_bash.mli lib/keeper/keeper_exec_shell.ml lib/keeper/keeper_exec_shell.mli test/test_keeper_bash_safety.ml` PASS
- `scripts/dune-local.sh build test/test_keeper_bash_safety.exe` PASS
- `env MASC_STORAGE_TYPE=filesystem MASC_BASE_PATH= GRAPHQL_API_KEY= ZAI_API_KEY= MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED=false MASC_KEEPER_DOCKER_PLAYGROUND=false _build/default/test/test_keeper_bash_safety.exe test edge 2,3` PASS
- `rg -n "quote_aware_shape_scan_text|raw_keeper_bash_shape_block" --glob '!_build/**' --glob '!.git/**'` PASS: zero hits
- `git diff --check` PASS

Full `test_keeper_bash_safety.exe` was also attempted and currently reports two unrelated readonly fallback failures (`readonly_hints 5` escaped regex pipe fallback and `readonly_hints 15` cd-scoped grep head pipeline). The touched shape-guard cases pass, and this PR does not modify the readonly fallback behavior.

## Notes

Current `main` was reported to have an unrelated committed conflict marker in `keeper_trace_emit`; I did not rebase this naming-only branch onto that broken main state and did not touch the runtime process.