### PR TITLE
fix(ide): remove yojson dead arms

### DIFF
--- a/lib/ide/ide_annotation_types.ml
+++ b/lib/ide/ide_annotation_types.ml
@@ -8,7 +8,7 @@
 (* Local kind-name helper for parse-error diagnostics.  [lib/ide/] does
    not depend on [masc_core], so we inline the kind-name discrimination
    rather than import [Json_util.kind_name] (RFC-0056 leaf-isolation
-   invariant).  The 8 cases below mirror the closed set of
+   invariant).  The cases below mirror the closed set of
    [Yojson.Safe.t] variants — exhaustive by construction. *)
 let json_kind_name = function
   | `Null -> "null"
@@ -19,8 +19,6 @@ let json_kind_name = function
   | `String _ -> "string"
   | `Assoc _ -> "object"
   | `List _ -> "array"
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 ;;
 
 type annotation_kind =


### PR DESCRIPTION
## Summary
- Remove unreachable `Tuple/`Variant arms from IDE annotation JSON kind diagnostics
- Update the local comment to match Yojson 3 Safe.t variants

## Verification
- scripts/lint/no-yojson-3-dead-arms.sh
- ocamlformat --check lib/ide/ide_annotation_types.ml
- git diff --check
- scripts/dune-local.sh build test/test_ide_annotations.exe
- ./_build/default/test/test_ide_annotations.exe --show-errors

Follow-up for #16918 post-merge CI failure: No yojson 3.0 dead arms.