### PR TITLE
fix(worker_runtime_helper_protocol): split run_result_of_yojson failure modes

### DIFF
--- a/lib/worker_runtime_helper_protocol.ml
+++ b/lib/worker_runtime_helper_protocol.ml
@@ -138,9 +138,36 @@ let run_result_of_yojson (json : Yojson.Safe.t) :
     } in
     Ok run_result
   with
-  | Yojson.Json_error msg -> Error ("invalid worker helper run_result JSON: " ^ msg)
-  | Type_error (msg, _) -> Error ("invalid worker helper run_result JSON: " ^ msg)
-  | Failure msg -> Error msg
+  (* Three distinct failure modes — the previous form returned the same
+     "invalid worker helper run_result JSON" string for both syntactic
+     and type-mismatch errors, and a bare [msg] (no context label) for
+     [Failure].  Operators reading the masc-mcp log now see which class
+     of failure occurred:
+
+       - [Yojson.Json_error]  → input not parseable as JSON at all
+       - [Type_error]         → JSON parsed but a [member]/[to_string]/
+                                [to_int] kind-check failed
+       - [Failure]            → numeric parse or other [failwith] from
+                                downstream helpers (now context-labelled)
+
+     [Eio.Cancel.Cancelled] is intentionally not in this list and so
+     propagates without being caught (RFC-0106).  The closed
+     exception list is safer than [with _ ->] for the same reason. *)
+  | Yojson.Json_error msg ->
+      Error
+        (Printf.sprintf
+           "worker helper run_result: JSON syntax error (%s)"
+           msg)
+  | Type_error (msg, _) ->
+      Error
+        (Printf.sprintf
+           "worker helper run_result: JSON shape mismatch (%s)"
+           msg)
+  | Failure msg ->
+      Error
+        (Printf.sprintf
+           "worker helper run_result: parse step raised Failure (%s)"
+           msg)
 
 let success_json (run_result : Worker_container_types.run_result) =
   `Assoc [ ("ok", run_result_to_yojson run_result) ]


### PR DESCRIPTION
## Summary

The catch handlers at the bottom of \`run_result_of_yojson\` conflated three distinct failure modes:

\`\`\`ocaml
| Yojson.Json_error msg -> Error (\"invalid worker helper run_result JSON: \" ^ msg)
| Type_error (msg, _)   -> Error (\"invalid worker helper run_result JSON: \" ^ msg)
| Failure msg           -> Error msg
\`\`\`

The first two used the *same* string, hiding the distinction between syntactic and shape failures. \`Failure msg\` returned the bare downstream message with no context label.

## Now

| Exception | Old string | New string |
|-----------|-----------|------------|
| \`Yojson.Json_error\` | \`\"invalid worker helper run_result JSON: <msg>\"\` | \`\"worker helper run_result: JSON syntax error (<msg>)\"\` |
| \`Type_error\` | \`\"invalid worker helper run_result JSON: <msg>\"\` (same) | \`\"worker helper run_result: JSON shape mismatch (<msg>)\"\` |
| \`Failure\` | bare \`<msg>\` | \`\"worker helper run_result: parse step raised Failure (<msg>)\"\` |

## RFC-0106 note — closed exception list is the strictly safer pattern

The catch in this function uses a *closed* list (\`Yojson.Json_error | Type_error | Failure\`), not \`with _ ->\`. \`Eio.Cancel.Cancelled\` is intentionally not listed, so it propagates without being caught — RFC-0106-safe by construction.

The iter#96-#98 RFC-0106 sweep targeted *implicit* catch-alls (\`with _ ->\`) which would have swallowed Cancelled. Closed lists do not need the defensive split; they need a *different* kind of audit — whether the listed exceptions actually carry enough information for the operator. That is the gap this PR closes.

## Sister-helper exhaustion

iter#103 (PR #16964) split \`int_option_of_yojson\` / \`float_option_of_yojson\` / \`string_list_of_yojson\` in the same file. The remaining helpers:

- \`api_response_of_yojson\` — delegates to \`Llm_provider.Cache.response_of_json\` which returns \`Some/None\` (no upstream error info). Cannot improve diagnostics without changing the upstream signature.
- \`proof_of_yojson\` — already delegates to a typed \`(t, string) result\` and surfaces the downstream message. No smell.

\`run_result_of_yojson\` was the last in-file site with a fixable diagnostic gap.

## Verification

- \`dune build --root . lib/worker_runtime_helper_protocol.ml\` — clean
- \`dune exec --root . test/test_worker_runtime.exe\` — **8/8 PASS**

## Workaround Rejection Bar self-check

- [x] §1 telemetry-as-fix: N/A — diagnostic split, no counter added
- [x] §2 string classifier: N/A — error strings are operator-facing, not routing
- [x] §3 N-of-M: this is the final fixable handler in this file (\`api_response_of_yojson\` upstream-blocked, \`proof_of_yojson\` already typed)
- [x] No catch-all \`_ ->\` added; the existing closed list is preserved (Cancelled keeps propagating)
- [x] No cap/cooldown/dedup/repair pattern

## RFC subsystem check

Not in the RFC-guarded subsystem list. No waiver needed.

## Smell-category continuation

- iter#103 (PR #16964): split 3 sister helpers in the same file
- **iter#104 (this PR)**: split the closed-list catch handlers at the end of \`run_result_of_yojson\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)