### PR TITLE
fix(worker_helper): label bare Failure handler in 2 sister sites

### DIFF
--- a/lib/worker_execution_spec.ml
+++ b/lib/worker_execution_spec.ml
@@ -128,7 +128,15 @@ let of_yojson (json : Yojson.Safe.t) =
        with
        | Yojson.Json_error msg -> Error ("worker execution spec JSON error: " ^ msg)
        | Type_error (msg, _) -> Error ("worker execution spec type error: " ^ msg)
-       | Failure msg -> Error msg)
+       (* Context-label the bare Failure so the operator reading the log
+          can tell a worker-spec parse failure apart from any other
+          [failwith] / [int_of_string] failure that bubbles up from
+          downstream helpers. *)
+       | Failure msg ->
+           Error
+             (Printf.sprintf
+                "worker execution spec: parse step raised Failure (%s)"
+                msg))
   | other ->
       Error
         (Printf.sprintf "worker execution spec must be a JSON object, got %s: %s"

--- a/lib/worker_runtime_helper_protocol.ml
+++ b/lib/worker_runtime_helper_protocol.ml
@@ -264,5 +264,12 @@ let parse_stdout (stdout : string) :
             Ok (Error { message; kind })
         | _ -> Error "worker helper stdout did not contain ok or error")
   with
-  | Failure msg -> Error msg
+  (* Context-label the bare Failure so the operator reading the log
+     can tell a parse_stdout failure apart from any other [failwith]
+     that bubbles up from a downstream helper. *)
+  | Failure msg ->
+      Error
+        (Printf.sprintf
+           "worker helper parse_stdout: parse step raised Failure (%s)"
+           msg)
   | Yojson.Json_error msg -> Error ("invalid worker helper JSON: " ^ msg)


### PR DESCRIPTION
## Summary

Two sister sites in the worker_helper domain had a bare \`| Failure msg -> Error msg\` in their closed-list catch:

- \`worker_execution_spec.of_yojson:131\`
- \`worker_runtime_helper_protocol.parse_stdout:267\`

Both sit alongside other arms that carry a context prefix (\"worker execution spec: ...\" / \"worker helper ...: ...\"), so the bare \`Failure\` arm produced an operator-facing error message that could not be distinguished from any other unlabelled \`failwith\` bubbling up from downstream helpers.

## Now

| Site | Old | New |
|------|-----|-----|
| \`worker_execution_spec:131\` | bare \`<msg>\` | \`\"worker execution spec: parse step raised Failure (<msg>)\"\` |
| \`worker_runtime_helper_protocol:267\` | bare \`<msg>\` | \`\"worker helper parse_stdout: parse step raised Failure (<msg>)\"\` |

Mirrors the form iter#104 (PR #16969) used in \`run_result_of_yojson\`.

## Closed-list pattern preserved

Neither catch is widened — the closed list (\`Failure | Yojson.Json_error | ...\`) is the same. \`Eio.Cancel.Cancelled\` is intentionally still not in the list and continues to propagate (RFC-0106 safe).

## Sister-site survey

\`repo_manager/repo_store.ml\` has the same bare \`Failure msg -> Error msg\` pattern, but it sits inside the RFC-guarded \`lib/repo_manager/\` subsystem (workflow-pr.md §11). That site is left for a separate PR with an RFC waiver.

## Verification

- \`dune build --root . lib/worker_execution_spec.ml lib/worker_runtime_helper_protocol.ml\` — clean
- \`dune exec --root . test/test_worker_runtime.exe\` — **8/8 PASS** (same exe covers both modules)

## Workaround Rejection Bar self-check

- [x] §1 telemetry-as-fix: N/A — diagnostic-label widening only
- [x] §2 string classifier: N/A — error strings are operator-facing, not routing
- [x] §3 N-of-M: this PR closes the 2 non-RFC-guarded sister sites in one shot; the third (\`repo_store\`) is RFC-blocked and noted
- [x] No catch-all \`_ ->\` added; existing closed list preserved
- [x] No cap/cooldown/dedup/repair pattern

## RFC subsystem check

\`lib/worker_execution_spec.ml\` and \`lib/worker_runtime_helper_protocol.ml\` are not in the RFC-guarded subsystem list. No waiver needed.

## Smell-category continuation

- iter#103 (PR #16964): split 3 sister helpers (\`int/float/string_list_of_yojson\`)
- iter#104 (PR #16969): split closed-list catch handlers in \`run_result_of_yojson\`
- **iter#105 (this PR)**: bare-Failure cleanup in 2 sister sites, completing the worker_helper domain (except the RFC-blocked \`repo_store\` site)

🤖 Generated with [Claude Code](https://claude.com/claude-code)