### PR TITLE
fix(cascade): name source path in IO/JSON parse errors (2 sites)

### DIFF
--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -186,10 +186,21 @@ let load_toml_in_memory ~emit_telemetry config_path =
    in-memory [Yojson.Safe.t] view for internal consumers. *)
 let load_catalog_source_impl ~emit_telemetry path =
   try load_toml_in_memory ~emit_telemetry path with
-  | Sys_error msg -> Error msg
+  (* All four arms now name the cascade source path so the operator
+     reading the error knows *which* cascade.toml failed.  The bare
+     [Sys_error msg] previously emitted only the OCaml stdlib message
+     (often "permission denied" or "is a directory") with no file
+     identification — same string regardless of which cascade file
+     was being loaded. *)
+  | Sys_error msg ->
+    Error (Printf.sprintf "cascade source IO error (path=%s): %s" path msg)
   | Unix.Unix_error (err, fn, arg) ->
-    Error (Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message err))
-  | Yojson.Json_error msg -> Error (Printf.sprintf "JSON error: %s" msg)
+    Error
+      (Printf.sprintf
+         "cascade source Unix error (path=%s): %s(%s): %s"
+         path fn arg (Unix.error_message err))
+  | Yojson.Json_error msg ->
+    Error (Printf.sprintf "cascade source JSON error (path=%s): %s" path msg)
   | End_of_file ->
     (* [Fs_compat.load_file_unix] reads [in_channel_length] first, then
        [really_input_string len]. If the file is truncated between the

--- a/lib/cascade/cascade_toml_materializer.ml
+++ b/lib/cascade/cascade_toml_materializer.ml
@@ -438,7 +438,16 @@ let render_toml_file_to_json_string toml_path =
     let content = Fs_compat.load_file toml_path in
     render_toml_string_to_json_string content
   with
-  | Sys_error msg -> Error msg
+  (* Name the source path: the bare [Sys_error msg] previously gave
+     only "no such file or directory" / "permission denied" with no
+     file identification.  Callers (cascade routing config, fallback
+     materialization) need to know *which* TOML failed so they can
+     hand the operator a specific path to check. *)
+  | Sys_error msg ->
+    Error
+      (Printf.sprintf
+         "cascade TOML file IO error (path=%s): %s"
+         toml_path msg)
 ;;
 
 let render_toml_to_json_string ~config_path =


### PR DESCRIPTION
## Summary

Two cascade loaders surfaced \`Sys_error\` / \`Unix.Unix_error\` / \`Yojson.Json_error\` without naming which cascade file failed:

- \`load_catalog_source_impl\` in \`cascade_config_loader.ml:188\`
- \`render_toml_file_to_json_string\` in \`cascade_toml_materializer.ml:436\`

The operator reading the masc-mcp log saw only the OCaml stdlib message (\"permission denied\" / \"no such file or directory\" / etc.) with no file identification. Same string regardless of *which* \`cascade.toml\` was being loaded — an obstacle when several cascade files coexist in the configured search path.

## Fix

Both functions take a \`path\` / \`toml_path\` argument already, so the fix is local: include the path in every catch arm's error string.

**Before:**
\`\`\`
\"permission denied\"
\`\`\`

**After:**
\`\`\`
\"cascade source IO error (path=/etc/masc/cascade.toml): permission denied\"
\"cascade TOML file IO error (path=/tmp/test.toml): No such file or directory\"
\`\`\`

The \`End_of_file\` arm in \`cascade_config_loader\` already included the path — left unchanged. All Sys_error / Unix / Json_error arms now match that form.

## RFC-0106 note

Closed-list catch pattern preserved. \`Eio.Cancel.Cancelled\` is intentionally not in either list and continues to propagate.

## Sister-site survey

\`lib/repo_manager/repo_store.ml\` has the same bare \`Sys_error msg -> Error msg\` pattern but sits inside the RFC-guarded subsystem (workflow-pr.md §11). Left for a separate PR with an RFC waiver.

## Verification

- \`dune build --root . lib/cascade\` — clean
- No direct test exists for either function (verified \`rg -l\` on test/); upstream tests cover the success path

## Workaround Rejection Bar self-check

- [x] §1 telemetry-as-fix: N/A — diagnostic widening only
- [x] §2 string classifier: N/A — error strings are operator-facing, not routing
- [x] §3 N-of-M: this PR closes both non-RFC-guarded sites in cascade/; the RFC-blocked \`repo_store\` site is explicitly noted
- [x] No catch-all \`_ ->\` added; existing closed list preserved
- [x] No cap/cooldown/dedup/repair pattern

## RFC subsystem check

\`lib/cascade/\` is not in the RFC-guarded subsystem list. No waiver needed.

## Smell-category continuation

- iter#103-#105: worker_helper domain (5 sites across 2 files)
- **iter#106 (this PR)**: cascade domain (2 sites across 2 files) — IO-error path-naming sub-category of the closed-list-arm operator-clarity sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)