### PR TITLE
refactor(dashboard): extract fetchCredentials() SSOT

### DIFF
--- a/dashboard/src/api/credentials.ts
+++ b/dashboard/src/api/credentials.ts
@@ -42,6 +42,7 @@ export function coerceCredentialType(raw: unknown): CredentialType {
   return 'github'
 }
 
+import { get } from './core'
 import { isRecord } from '../lib/type-guards'
 export { isRecord }
 
@@ -57,6 +58,11 @@ export function parseCredentialState(raw: unknown): CredentialState | null {
         : null,
     reason: typeof raw.reason === 'string' ? raw.reason : null,
   }
+}
+
+export async function fetchCredentials(): Promise<Credential[]> {
+  const data = await get<unknown>('/api/v1/credentials')
+  return normalizeCredentialsResponse(data)
 }
 
 export function normalizeCredentialsResponse(data: unknown): Credential[] {

--- a/dashboard/src/components/add-repo-dialog.ts
+++ b/dashboard/src/components/add-repo-dialog.ts
@@ -3,8 +3,8 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { get, post } from '../api/core'
-import { normalizeCredentialsResponse } from '../api/credentials'
+import { post } from '../api/core'
+import { fetchCredentials } from '../api/credentials'
 import { showToast } from './common/toast'
 import { fetchRepositories, showAddRepoDialog } from './repo-sidebar'
 import { X } from 'lucide-preact'
@@ -58,8 +58,7 @@ function closeAddRepoDialog(): void {
 async function loadCredentials(): Promise<void> {
   credentialsLoading.value = true
   try {
-    const raw = await get<unknown>('/api/v1/credentials')
-    const creds = normalizeCredentialsResponse(raw)
+    const creds = await fetchCredentials()
     credentialsResource.value = creds
       .map(c => ({ id: c.id, name: c.name || c.username }))
       .filter(opt => opt.id && opt.name)

--- a/dashboard/src/components/credential-settings.ts
+++ b/dashboard/src/components/credential-settings.ts
@@ -3,10 +3,10 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { del, get, post } from '../api/core'
+import { del, post } from '../api/core'
 import {
+  fetchCredentials,
   coerceCredentialType,
-  normalizeCredentialsResponse,
   type Credential,
   type CredentialCreatePayload,
   type CredentialOauthMethod,
@@ -53,11 +53,6 @@ const addDraft = signal<CredentialCreatePayload>({
 })
 
 // ── API ──────────────────────────────────────────────────
-
-async function fetchCredentials(): Promise<Credential[]> {
-  const data = await get<unknown>('/api/v1/credentials')
-  return normalizeCredentialsResponse(data)
-}
 
 async function createCredential(payload: CredentialCreatePayload): Promise<void> {
   await post('/api/v1/credentials', buildCredentialCreateRequest(payload))

--- a/dashboard/src/components/keeper-repo-mapping.ts
+++ b/dashboard/src/components/keeper-repo-mapping.ts
@@ -6,7 +6,7 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { get, post } from '../api/core'
 import {
-  normalizeCredentialsResponse,
+  fetchCredentials,
   type CredentialState,
   type CredentialType,
 } from '../api/credentials'
@@ -88,9 +88,8 @@ async function fetchRepositories(): Promise<RepositoryOption[]> {
   }))
 }
 
-async function fetchCredentials(): Promise<KeeperCredentialOption[]> {
-  const data = await get<unknown>('/api/v1/credentials')
-  return normalizeCredentialsResponse(data).filter(cred => cred.id !== '')
+async function fetchCredentialOptions(): Promise<KeeperCredentialOption[]> {
+  return (await fetchCredentials()).filter(cred => cred.id !== '')
 }
 
 async function fetchKeeperRepoMappings(): Promise<KeeperRepoMapping[]> {
@@ -226,7 +225,7 @@ export async function loadKeeperRepoMappings(options?: { force?: boolean }): Pro
   const loadCredentials = async () => {
     if (!force && credentialsState.value.status === 'loaded') return
     if (force) credentialsResource.reset()
-    await credentialsResource.load(() => fetchCredentials())
+    await credentialsResource.load(() => fetchCredentialOptions())
   }
 
   const loadMappings = async () => {


### PR DESCRIPTION
## Summary
- Centralized `fetchCredentials()` into `api/credentials.ts` — single source of truth for credential API fetching
- 3 components (credential-settings, keeper-repo-mapping, add-repo-dialog) previously had inline `get('/api/v1/credentials')` + `normalizeCredentialsResponse()` duplication
- `keeper-repo-mapping.ts` local `fetchCredentials` renamed to `fetchCredentialOptions` to avoid name collision with the new centralized import

## Test plan
- [ ] Dashboard credentials page loads correctly
- [ ] Keeper-repo mapping credential dropdown works
- [ ] Add-repo dialog credential selection works
- [ ] CI lint/type checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)