### PR TITLE
fix(cdal_loader): preserve Sys_error reason in File_not_found read_error

### DIFF
--- a/lib/cdal/cdal_loader.ml
+++ b/lib/cdal/cdal_loader.ml
@@ -35,13 +35,18 @@ let load_error_to_string = function
 (* File I/O helpers                                                  *)
 (* ================================================================ *)
 
+(* [File_not_found] carries the original [Sys_error] message so the
+   operator log preserves *why* the read failed (permission denied,
+   bad path syntax, dangling symlink, ENOSPC on a temp probe, …)
+   rather than collapsing every cause to a single "not found" label.
+   The path itself is supplied by the caller via [Result.map_error]. *)
 type read_error =
-  | File_not_found
+  | File_not_found of string
   | Parse_error of string
 
 let read_json_file path =
   try Ok (Yojson.Safe.from_file path) with
-  | Sys_error _ -> Error File_not_found
+  | Sys_error msg -> Error (File_not_found msg)
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn -> Error (Parse_error (Printexc.to_string exn))
 ;;
@@ -63,7 +68,8 @@ let load
   let* manifest_json =
     read_json_file manifest_path
     |> Result.map_error (function
-      | File_not_found -> Manifest_not_found manifest_path
+      | File_not_found reason ->
+        Manifest_not_found (Printf.sprintf "%s (%s)" manifest_path reason)
       | Parse_error msg -> Manifest_parse_error msg)
   in
   let* manifest_proof =
@@ -87,7 +93,8 @@ let load
     let* contract_json =
       read_json_file contract_path
       |> Result.map_error (function
-        | File_not_found -> Contract_not_found contract_path
+        | File_not_found reason ->
+          Contract_not_found (Printf.sprintf "%s (%s)" contract_path reason)
         | Parse_error msg -> Contract_parse_error msg)
     in
     (* 4. Decode contract with Agent_sdk *)


### PR DESCRIPTION
## Summary

`lib/cdal/cdal_loader.ml#L42-46` — `read_json_file` was collapsing every `Sys_error` cause into a single nullary `File_not_found` variant. The caller-side `Result.map_error` attached the path but the *reason* string (permission denied / dangling symlink / path-syntax / probe-time ENOSPC / …) was discarded before reaching the operator log.

## Change

Widen `read_error.File_not_found` to carry the original `Sys_error` message, then append it on the caller side so the resulting `Manifest_not_found` / `Contract_not_found` field reads `<path> (<reason>)` instead of just `<path>`.

```ocaml
type read_error =
  | File_not_found of string  (* underlying Sys_error message *)
  | Parse_error of string

let read_json_file path =
  try Ok (Yojson.Safe.from_file path) with
  | Sys_error msg -> Error (File_not_found msg)
  ...

(* caller *)
| File_not_found reason ->
  Manifest_not_found (Printf.sprintf "%s (%s)" manifest_path reason)
```

## Why this isn't a workaround

* §1 telemetry-as-fix: no — the variant *carries the value*, not a counter
* §2 string-classifier: no — no string-based dispatch added; the message is operator-display only and the typed shape narrowed (nullary → unary)
* §3 N-of-M: no — both `read_json_file` call sites updated together

`Eio.Cancel.Cancelled` continues to propagate via `raise e` (RFC-0106).

## Verification

| Check | Result |
|---|---|
| `dune build --root . lib/cdal` | clean |
| `dune test --root . test/test_cdal_loader.exe` | 9/9 PASS |
| Test surface | unchanged — existing `Error (Manifest_not_found _)` wildcards still match |
| `load_error_to_string` output format | unchanged (still single string field) |

## Sister sites

Cluster-fix complete within this module. No other `read_error` definitions exist (grep verified).

## Sweep context

Iter#107 of /loop FSM/TLA+/error-clarity sweep. Cumulative iter#72-#107: **19 MERGED** + 12 Draft BLOCKED + 1 PENDING.

This is a continuation of the *operator-clarity* category targeted by iter#103–#106 (worker_helper Intlit overflow, run_result catch split, bare-Failure label, cascade IO path-naming). iter#107 hits the same pattern in a *typed-variant signature widening* form rather than a `try ... with` catch split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)