### PR TITLE
fix(dashboard): monitoring tab test defaultParams alignment

### DIFF
--- a/dashboard/src/components/dashboard-surface-tabs.test.ts
+++ b/dashboard/src/components/dashboard-surface-tabs.test.ts
@@ -73,7 +73,7 @@ describe('DashboardSurfaceTabs', () => {
     overviewTab.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
 
     expect(document.activeElement).toBe(monitorTab)
-    expect(navigate).toHaveBeenCalledWith('monitoring', { section: 'runtime' })
+    expect(navigate).toHaveBeenCalledWith('monitoring', { section: 'agents' })
   })
 
   it('jumps to the last surface on End', () => {


### PR DESCRIPTION
## Summary
- Fix `dashboard-surface-tabs.test.ts` assertion to expect `{ section: 'agents' }`
  matching the navigation config's `defaultParams` for the monitoring surface

## Context
The monitoring surface defaultParams was changed to `{ section: 'agents' }` in
`config/navigation.ts` but the test still expected `{ section: 'runtime' }`,
causing a persistent CI Dashboard check failure on unrelated PRs.

## Test plan
- [ ] Dashboard CI check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)