### PR TITLE
[codex] Document dashboard runtime time boundary

### DIFF
--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -411,6 +411,7 @@ let keeper_fleet_meta_scan ?(include_paused_details = true) config =
   (* The dashboard light shell needs fleet counts on every header refresh.
      Keep this as a single pass over keeper meta so it does not repeat the
      paused, autoboot, and bootable scans on the hot path. *)
+  (* NDT-OK: request-boundary wall clock only for dashboard pause-age display. *)
   let now = Unix.gettimeofday () in
   let configured_names = Keeper_types.configured_keeper_names config in
   let all_names =


### PR DESCRIPTION
## Summary

- Add an explicit `NDT-OK` rationale for the dashboard runtime health wall-clock read introduced by #16981.

## Why

#16981 was merged with the intended light-shell runtime-health speedup, but the CI DET/NDT ratchet flagged the new `Unix.gettimeofday ()` site as undocumented non-determinism. The timestamp is request-boundary data used only to compute dashboard pause-age display fields, not a deterministic scheduling or parsing decision.

## Validation

- `git diff --check`
- `ocamlformat --check lib/server/server_routes_http_runtime.ml`
- `bash scripts/ci/check-determinism-contract.sh`
- `scripts/dune-local.sh build bin/main_eio.exe`
