### PR TITLE
fix(cdal_loader): tighten read_json_file catch — split Yojson.Json_error, drop catch-all

### DIFF
--- a/lib/cdal/cdal_loader.ml
+++ b/lib/cdal/cdal_loader.ml
@@ -44,11 +44,20 @@ type read_error =
   | File_not_found of string
   | Parse_error of string
 
+(* Closed-list catch — [Yojson.Safe.from_file] documents [Sys_error]
+   for IO failure and [Yojson.Json_error] for parse failure; the prior
+   catch-all [exn -> ... Printexc.to_string exn] both flattened the
+   yojson message into a less-precise [Printexc] dump and silently
+   absorbed any *other* unexpected exception (an asyncio leak, an
+   OS-level [Out_of_memory], a malformed assertion in a downstream
+   patch).  Letting those propagate is safer than absorbing them
+   under the [Parse_error] label.  [Eio.Cancel.Cancelled] is
+   explicitly re-raised per RFC-0106. *)
 let read_json_file path =
   try Ok (Yojson.Safe.from_file path) with
   | Sys_error msg -> Error (File_not_found msg)
+  | Yojson.Json_error msg -> Error (Parse_error msg)
   | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn -> Error (Parse_error (Printexc.to_string exn))
 ;;
 
 (* ================================================================ *)


### PR DESCRIPTION
## Summary

`lib/cdal/cdal_loader.ml#L47-52` — `read_json_file` was using a catch-all `exn -> Error (Parse_error (Printexc.to_string exn))` after the explicit `Sys_error` arm. This had two operator costs:

1. **Yojson.Json_error message obscured** — routed through `Printexc.to_string`, which prefixes the constructor name (`Yojson.Json_error("...")`) instead of letting the library's own line-aware message through.
2. **Unrelated exceptions silently absorbed** under a `Parse_error` label. An `Out_of_memory`, an asyncio leak, a downstream assertion failure — all became "parse_error" in the dashboard, which is misleading.

## Change

Explicit `Yojson.Json_error msg` arm; remove the catch-all so other exceptions propagate as bugs (signal, not absorbed noise).

```ocaml
let read_json_file path =
  try Ok (Yojson.Safe.from_file path) with
  | Sys_error msg -> Error (File_not_found msg)
  | Yojson.Json_error msg -> Error (Parse_error msg)
  | Eio.Cancel.Cancelled _ as e -> raise e
;;
```

## Why this isn't a workaround

* §1 telemetry-as-fix: no — this *tightens* the catch surface
* §2 string-classifier: no — typed exception split, no string matching
* §3 N-of-M: no — sole catch site for this helper

`Eio.Cancel.Cancelled` continues to propagate via `raise e` per RFC-0106.

## Verification

| Check | Result |
|---|---|
| `dune build --root . lib/cdal` | clean |
| `dune test --root . test/test_cdal_loader.exe` | 9/9 PASS |
| Test surface | unchanged — existing `Error (Manifest_parse_error _)` / `Error (Contract_parse_error _)` wildcards still match |

## Stacking

Follow-up to #16984 (iter#107) — which widened `File_not_found` to carry the `Sys_error` reason. This iter targets the *other* arm of the same `try`. Base is `origin/main` since #16984 merged.

## Sweep context

Iter#108 of /loop FSM/TLA+/error-clarity sweep. Cumulative iter#72-#108: **20 MERGED** + 12 Draft BLOCKED + 1 PENDING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)