### PR TITLE
fix(ide): align bridge/test with canonical BoardPost field names

### DIFF
--- a/dashboard/src/components/ide/anchored-thread-trace-bridge.test.ts
+++ b/dashboard/src/components/ide/anchored-thread-trace-bridge.test.ts
@@ -15,7 +15,7 @@ function post(
   line?: number | null,
   filePath?: string | null,
 ): AnchoredThreadProducerInput {
-  return { id, created_at_iso: ts_iso, author_identity: keeper, line, filePath }
+  return { id, created_at: ts_iso, author_identity: keeper, line, filePath }
 }
 
 beforeEach(() => {
@@ -71,7 +71,7 @@ describe('bridgePostsToTrace — RFC-0028 PR-δ anchored-thread producer', () =>
     expect(keeperTraceState.value.events.length).toBe(0)
   })
 
-  it('skips posts with malformed created_at_iso (NaN-guard)', () => {
+  it('skips posts with malformed created_at (NaN-guard)', () => {
     bridgePostsToTrace(
       [
         post('bad', 'not-a-date', 'scholar'),

--- a/dashboard/src/components/ide/anchored-thread-trace-bridge.ts
+++ b/dashboard/src/components/ide/anchored-thread-trace-bridge.ts
@@ -18,7 +18,7 @@ import { pushTrace } from './keeper-trace-store'
  *
  * Mapping (BoardPost → KeeperTraceEvent):
  *   id         ← post.id
- *   tsMs       ← Date.parse(post.created_at_iso) (NaN-guarded)
+ *   tsMs       ← Date.parse(post.created_at) (NaN-guarded)
  *   keeperName ← post.author_identity
  *   threadId   ← post.id (BoardPost is the thread itself for now)
  *   filePath   ← post.filePath when the caller has already resolved a safe
@@ -27,14 +27,14 @@ import { pushTrace } from './keeper-trace-store'
  *                board-thread file anchor; otherwise null so consumers fall
  *                back to the keeper-level no-line bucket per RFC §5
  *
- * NaN-guard rationale: a malformed `created_at_iso` would otherwise
+ * NaN-guard rationale: a malformed `created_at` would otherwise
  * propagate `NaN` into the store and break binary-search insertion. We
  * silently skip such posts — they cannot participate in replay either.
  */
 
 export interface AnchoredThreadProducerInput {
   readonly id: string
-  readonly created_at_iso: string
+  readonly created_at: string
   readonly author_identity: string
   readonly filePath?: string | null
   readonly line?: number | null
@@ -53,7 +53,7 @@ export function bridgePostsToTrace(
   const next = new Set(alreadyEmitted)
   for (const post of posts) {
     if (next.has(post.id)) continue
-    const tsMs = Date.parse(post.created_at_iso)
+    const tsMs = Date.parse(post.created_at)
     if (!Number.isFinite(tsMs)) continue
     pushTrace({
       id: post.id,

--- a/dashboard/src/components/ide/ide-conversation-rail.test.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.test.ts
@@ -75,39 +75,55 @@ describe('IdeConversationRail', () => {
     const threads = postsToAnchoredThreads([
       {
         id: 'thread-line',
+        author: 'scholar',
         title: 'Review lib/runtime.ml:42',
         body: 'question fn:run about this line',
-        author_identity: 'scholar',
+        content: 'question fn:run about this line',
+        tags: [],
+        author_identity: { kind: 'keeper', id: 'scholar', key: 'scholar', display_name: 'scholar', raw: 'scholar' },
         votes: 0,
         comment_count: 2,
-        created_at_iso: '2026-05-05T10:00:00Z',
+        created_at: '2026-05-05T10:00:00Z',
+        updated_at: '2026-05-05T10:00:00Z',
       },
       {
         id: 'thread-file',
+        author: 'sangsu',
         title: 'File-level note',
         body: 'looks good',
-        author_identity: 'sangsu',
+        content: 'looks good',
+        tags: [],
+        author_identity: { kind: 'keeper', id: 'sangsu', key: 'sangsu', display_name: 'sangsu', raw: 'sangsu' },
         votes: 1,
         comment_count: 0,
-        created_at_iso: '2026-05-05T10:01:00Z',
+        created_at: '2026-05-05T10:01:00Z',
+        updated_at: '2026-05-05T10:01:00Z',
       },
       {
         id: 'thread-windows-path',
+        author: 'scholar',
         title: 'Review ./lib\\runtime.ml:43',
         body: 'question about normalized file path',
-        author_identity: 'scholar',
+        content: 'question about normalized file path',
+        tags: [],
+        author_identity: { kind: 'keeper', id: 'scholar', key: 'scholar', display_name: 'scholar', raw: 'scholar' },
         votes: 0,
         comment_count: 1,
-        created_at_iso: '2026-05-05T10:02:00Z',
+        created_at: '2026-05-05T10:02:00Z',
+        updated_at: '2026-05-05T10:02:00Z',
       },
       {
         id: 'thread-absolute-path',
+        author: 'scholar',
         title: 'Review /workspace/lib/runtime.ml:44',
         body: 'should not anchor unsafe absolute paths',
-        author_identity: 'scholar',
+        content: 'should not anchor unsafe absolute paths',
+        tags: [],
+        author_identity: { kind: 'keeper', id: 'scholar', key: 'scholar', display_name: 'scholar', raw: 'scholar' },
         votes: 0,
         comment_count: 1,
-        created_at_iso: '2026-05-05T10:03:00Z',
+        created_at: '2026-05-05T10:03:00Z',
+        updated_at: '2026-05-05T10:03:00Z',
       },
     ])
 
@@ -136,12 +152,16 @@ describe('IdeConversationRail', () => {
   it('does not reanchor generic board posts when the active file changes', () => {
     const posts = [{
       id: 'thread-generic',
+      author: 'sangsu',
       title: 'File-level note',
       body: 'looks good',
-      author_identity: 'sangsu',
+      content: 'looks good',
+      tags: [],
+      author_identity: { kind: 'keeper', id: 'sangsu', key: 'sangsu', display_name: 'sangsu', raw: 'sangsu' },
       votes: 1,
       comment_count: 0,
-      created_at_iso: '2026-05-05T10:01:00Z',
+      created_at: '2026-05-05T10:01:00Z',
+      updated_at: '2026-05-05T10:01:00Z',
     }]
 
     expect(postsToAnchoredThreads(posts)).toEqual([])
@@ -153,12 +173,16 @@ describe('IdeConversationRail', () => {
     const items = replayRailItems(
       [{
         id: 'thread-old',
+        author: 'sangsu',
         title: 'old thread',
         body: 'thread body',
-        author_identity: 'sangsu',
+        content: 'thread body',
+        tags: [],
+        author_identity: { kind: 'keeper', id: 'sangsu', key: 'sangsu', display_name: 'sangsu', raw: 'sangsu' },
         votes: 0,
         comment_count: 0,
-        created_at_iso: '2026-05-05T10:00:00Z',
+        created_at: '2026-05-05T10:00:00Z',
+        updated_at: '2026-05-05T10:00:00Z',
       }],
       [{
         ts_unix: Date.UTC(2026, 4, 5, 10, 1, 0) / 1000,
@@ -200,21 +224,29 @@ describe('IdeConversationRail', () => {
         return new Response(JSON.stringify([
           {
             id: 'thread-old',
+            author: 'sangsu',
             title: 'old thread',
             body: 'old thread body',
-            author_identity: 'sangsu',
+            content: 'old thread body',
+            tags: [],
+            author_identity: { kind: 'keeper', id: 'sangsu', key: 'sangsu', display_name: 'sangsu', raw: 'sangsu' },
             votes: 0,
             comment_count: 0,
-            created_at_iso: '2026-05-05T10:00:00Z',
+            created_at: '2026-05-05T10:00:00Z',
+            updated_at: '2026-05-05T10:00:00Z',
           },
           {
             id: 'thread-new',
+            author: 'scholar',
             title: 'new thread',
             body: 'new thread body',
-            author_identity: 'scholar',
+            content: 'new thread body',
+            tags: [],
+            author_identity: { kind: 'keeper', id: 'scholar', key: 'scholar', display_name: 'scholar', raw: 'scholar' },
             votes: 0,
             comment_count: 0,
-            created_at_iso: '2026-05-05T10:03:00Z',
+            created_at: '2026-05-05T10:03:00Z',
+            updated_at: '2026-05-05T10:03:00Z',
           },
         ]), { status: 200, headers: { 'Content-Type': 'application/json' } })
       }
@@ -391,12 +423,16 @@ describe('IdeConversationRail', () => {
       if (url.startsWith('/api/v1/board')) {
         return new Response(JSON.stringify([{
           id: 'thread-line',
+          author: 'scholar',
           title: 'Review lib/runtime.ml:42',
           body: 'question fn:run about this line',
-          author_identity: 'scholar',
+          content: 'question fn:run about this line',
+          tags: [],
+          author_identity: { kind: 'keeper', id: 'scholar', key: 'scholar', display_name: 'scholar', raw: 'scholar' },
           votes: 0,
           comment_count: 2,
-          created_at_iso: '2026-05-05T10:00:00Z',
+          created_at: '2026-05-05T10:00:00Z',
+          updated_at: '2026-05-05T10:00:00Z',
         }]), { status: 200, headers: { 'Content-Type': 'application/json' } })
       }
       if (url.startsWith('/api/v1/dashboard/keeper-decisions')) {
@@ -444,12 +480,16 @@ describe('IdeConversationRail', () => {
       if (url.startsWith('/api/v1/board')) {
         return new Response(JSON.stringify([{
           id: 'thread-line',
+          author: 'scholar',
           title: 'Review lib/runtime.ml:42',
           body: 'question fn:run comment:comment-1 PR 15035 task:task-runtime goal:goal-runtime branch:feat/ide-routes log:turn-7',
-          author_identity: 'scholar',
+          content: 'question fn:run comment:comment-1 PR 15035 task:task-runtime goal:goal-runtime branch:feat/ide-routes log:turn-7',
+          tags: [],
+          author_identity: { kind: 'keeper', id: 'scholar', key: 'scholar', display_name: 'scholar', raw: 'scholar' },
           votes: 0,
           comment_count: 2,
-          created_at_iso: '2026-05-05T10:00:00Z',
+          created_at: '2026-05-05T10:00:00Z',
+          updated_at: '2026-05-05T10:00:00Z',
         }]), { status: 200, headers: { 'Content-Type': 'application/json' } })
       }
       if (url.startsWith('/api/v1/dashboard/keeper-decisions')) {


### PR DESCRIPTION
## Summary
- Fix `AnchoredThreadProducerInput.created_at_iso` → `created_at` to match what `ide-conversation-rail.ts` actually passes (canonical `BoardPost.created_at`)
- Update bridge test helper and description accordingly
- Fix `ide-conversation-rail.test.ts` mock data: use `BoardActorIdentity` objects (with `raw` field) instead of plain strings, add missing required `BoardPost` fields (`author`, `content`, `tags`, `updated_at`)

## Context
PR #16986 replaced the local BoardPost type with canonical import but the bridge module still expected the old `created_at_iso` field name, causing TS compile errors on main.

## Test plan
- [x] `anchored-thread-trace-bridge.test.ts` uses `created_at` field
- [x] `ide-conversation-rail.test.ts` mock data matches canonical `BoardPost` shape
- [ ] CI TypeScript check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)