### PR TITLE
refactor(coord): improve docstrings in Coord_task_transition_executor (#16078)

### DIFF
--- a/lib/coord/coord_task_transition_executor.ml
+++ b/lib/coord/coord_task_transition_executor.ml
@@ -1,4 +1,9 @@
-(** Build the persisted task/backlog shape for task lifecycle transitions. *)
+(** Extract task lifecycle transition executor
+    
+    This module was extracted from [Coord_task] as part of #16078.
+    It owns the pure backlog-shape construction for task lifecycle
+    transitions: normalizing tasks before status changes, computing
+    release counters, and building the persisted backlog update. *)
 
 open Masc_domain
 

--- a/lib/coord/coord_task_transition_executor.mli
+++ b/lib/coord/coord_task_transition_executor.mli
@@ -1,8 +1,12 @@
-(** Build the persisted task/backlog shape for task lifecycle transitions.
+(** Extract task lifecycle transition executor
 
-    This module owns the mutation plan that sits between
-    {!Coord_task_lifecycle.decide} and the storage/event side effects in
-    {!Coord_task.transition_task_r}. *)
+    This module was extracted from [Coord_task] as part of #16078.
+    It owns the pure backlog-shape construction for task lifecycle
+    transitions: normalizing tasks before status changes, computing
+    release counters, and building the persisted backlog update.
+
+    It sits between {!Coord_task_lifecycle.decide} and the
+    storage/event side effects in {!Coord_task.transition_task_r}. *)
 
 type transition_backlog_update =
   { backlog : Masc_domain.backlog


### PR DESCRIPTION
## Summary

Part of #16078 — Extract task lifecycle transition executor.

Updates the module-level documentation in both `coord_task_transition_executor.ml` and `.mli` to clearly describe:

- The extraction origin from `Coord_task`
- The module's purpose: pure backlog-shape construction for task lifecycle transitions
- Its position between `Coord_task_lifecycle.decide` and the storage/event side effects in `Coord_task.transition_task_r`

## Changes
- `lib/coord/coord_task_transition_executor.ml`: expanded module header docstring
- `lib/coord/coord_task_transition_executor.mli`: updated interface docstring to match

## Testing
- `scripts/dune-local.sh build lib/coord/coord_task_transition_executor.ml` ✅ (compiles clean)

## Task
Closes task-375