### PR TITLE
fix(rfc-0106): propagate Cancelled in anti_rationalization + gate_protocol N-of-M omissions

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -396,6 +396,10 @@ let parse_review_verdict_from_json (args : Yojson.Safe.t) : (verdict, string) re
     | other -> Error (sprintf "unexpected review verdict value: %s" other)
   with
   | Type_error (msg, _) -> Error (sprintf "review verdict JSON type error: %s" msg)
+  (* RFC-0106 — cancellation MUST propagate; the file's other parsers
+     (see line ~244) already do this, so the catch-all here was an
+     N-of-M omission within the same module. *)
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn -> Error (sprintf "review verdict JSON parse error: %s" (Printexc.to_string exn))
 ;;
 

--- a/lib/gate/gate_protocol.ml
+++ b/lib/gate/gate_protocol.ml
@@ -122,6 +122,9 @@ let inbound_of_json json =
     }
   with
   | Yojson.Json_error e -> Error ("invalid json: " ^ e)
+  (* RFC-0106 — cancellation MUST propagate; the catch-all here
+     would otherwise classify a fiber cancel as a "parse error". *)
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn -> Error ("parse error: " ^ Printexc.to_string exn)
 
 let outbound_to_json out =


### PR DESCRIPTION
## Summary

Broader scan of 16 `| exn -> Error (...Printexc.to_string exn)` catch-alls in `lib/` reveals **all but 2 sites** already follow RFC-0106 (explicit `Eio.Cancel.Cancelled _ as e -> raise e` before the catch-all). This is the N-of-M closure for the two surviving omissions.

## Scan result

| Site | RFC-0106? |
|---|---|
| `lib/autoresearch_knowledge.ml:106` | ✅ |
| `lib/cdal/violation_record.ml:53` | ✅ |
| `lib/cdal/cdal_loader.ml:51` (iter#108) | ✅ |
| `lib/verifier_oas.ml:196` | ✅ |
| `lib/masc_http_client/pool.ml:497` | ✅ |
| `lib/backend/backend.ml:444` | ✅ |
| `lib/server/server_dashboard_http_link_preview.ml:170,456` | ✅ |
| `lib/server/lsp_process_manager.ml:219` | ✅ |
| `lib/cascade/cascade_http_probe.ml:194` | ✅ |
| `lib/voice/voice_bridge.ml:887` | ✅ |
| `lib/keeper/keeper_meta_json_parse.ml:734` | ✅ |
| `lib/keeper/keeper_turn_cascade_budget.ml:790` | ✅ |
| `lib/keeper/keeper_persona_authoring.ml:608` | ✅ |
| `lib/keeper/keeper_runtime_manifest.ml:559` | ✅ |
| `lib/keeper/keeper_checkpoint_store.ml:242` | ✅ |
| **`lib/anti_rationalization.ml:399`** | **❌ → fixed** |
| **`lib/gate/gate_protocol.ml:125`** | **❌ → fixed** |

## Why this isn't a workaround

* §1 telemetry-as-fix: no — adds a *raise*, not a counter
* §2 string-classifier: no — typed exception split, no string matching
* §3 N-of-M: this PR **is** the N-of-M closure. Audit-driven; scan covered all 16 sister sites.

## Operator impact

Under fiber cancel (timeout, supervisor abort, SIGTERM-driven shutdown), the cancel now propagates instead of being mislabelled as `"review verdict JSON parse error"` / `"parse error: Eio.Cancel.Cancelled(...)"` in the dashboard.

## Verification

| Check | Result |
|---|---|
| `dune build --root . lib/anti_rationalization.ml lib/gate` | clean |
| `dune build` 4 anti_rationalization tests | clean |

## Sweep context

Iter#109 of /loop FSM/TLA+/error-clarity sweep.  Follow-up to iter#107 (#16984 MERGED) / iter#108 (#16990 OPEN) cdal_loader.ml work on the same pattern axis (catch-arm tightening + closed-list discipline).

Cumulative iter#72-#109: **20 MERGED** + 12 Draft BLOCKED + 2 PENDING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)