### PR TITLE
fix(keeper): recover paused fleet auto-pause paths

### DIFF
--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -425,13 +425,30 @@ let can_transition ~from_phase ~to_phase =
       | Draining
       | Paused
       | Restarting ) ) -> false
-  (* Paused -> Running (resume) | Draining (stop) | Stopped (remove)
-     | Crashed (fiber can die while keeper is paused)
+  (* Paused -> Running (resume) | latent states exposed by resume
+     (Failing/Overflowed/HandingOff/Restarting/Offline) | Draining (stop)
+     | Stopped (remove) | Crashed (fiber can die while keeper is paused)
      | Compacting (operator invoked masc_keeper_compact on paused keeper
-     to clear an overflow-induced pause) *)
-  | Paused, (Running | Compacting | Draining | Stopped | Crashed) -> true
-  | Paused, (Offline | Failing | Overflowed | HandingOff | Paused | Restarting)
-    -> false
+     to clear an overflow-induced pause).
+
+     Operator_resume only clears [operator_paused]; it intentionally does not
+     erase already-observed launch, health, overflow, handoff, or restart conditions.
+     If one of those latches still derives a non-running phase, accepting the
+     transition lets the registry commit the resume intent and surface the real
+     blocker instead of rejecting the event and leaving the keeper permanently
+     paused. *)
+  | ( Paused
+    , ( Running
+      | Failing
+      | Overflowed
+      | Compacting
+      | HandingOff
+      | Draining
+      | Stopped
+      | Crashed
+      | Offline
+      | Restarting ) ) -> true
+  | Paused, Paused -> false
   (* Crashed -> Restarting (backoff done). Dead is covered by the global
      hard-stop/budget terminal transition above. *)
   | Crashed, Restarting -> true

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -500,6 +500,10 @@ let pause_keeper_for_overflow
     {
       meta with
       paused = true;
+      auto_resume_after_sec =
+        Keeper_supervisor_pause_policy.auto_resume_after_sec_for_policy
+          meta
+          Keeper_supervisor_pause_policy.Auto_resume_with_backoff;
       updated_at = now_iso ();
     }
   in
@@ -695,7 +699,13 @@ let make_post_turn_resilience_executor
       (Some
          (Keeper_registry.Provider_runtime_error
             { code; detail; provider_id = None; http_status = None }));
-    match sync_keeper_paused_state ~config ~meta:latest_meta ~paused:true with
+    match
+      sync_keeper_paused_state_with_resume_policy
+        ~config
+        ~meta:latest_meta
+        ~paused:true
+        ~resume_policy:Keeper_supervisor_pause_policy.Auto_resume_with_backoff
+    with
     | Ok paused_meta ->
         on_paused paused_meta;
         Ok ()

--- a/lib/keeper/keeper_unified_turn_livelock_block.ml
+++ b/lib/keeper/keeper_unified_turn_livelock_block.ml
@@ -78,6 +78,10 @@ let persist_turn_livelock_pause
   let updated =
     { meta with
       paused = true
+    ; auto_resume_after_sec =
+        Keeper_supervisor_pause_policy.auto_resume_after_sec_for_policy
+          meta
+          Keeper_supervisor_pause_policy.Auto_resume_with_backoff
     ; updated_at = Keeper_types.now_iso ()
     ; runtime = { meta.runtime with last_blocker = Some blocker }
     }

--- a/test/test_keeper_paused_cas_retain_9733.ml
+++ b/test/test_keeper_paused_cas_retain_9733.ml
@@ -57,6 +57,79 @@ let make_meta ~name =
   | Ok m -> m
   | Error e -> fail ("meta_of_json failed: " ^ e)
 
+let expected_initial_auto_resume_after_sec () =
+  Keeper_supervisor_types.next_auto_resume_after_sec
+    ~initial_sec:Env_config.KeeperSupervisor.auto_resume_initial_sec
+    ~max_sec:Env_config.KeeperSupervisor.auto_resume_max_sec
+    None
+
+let check_initial_auto_resume label actual =
+  check
+    (option (float 0.1))
+    label
+    (expected_initial_auto_resume_after_sec ())
+    actual
+
+let test_overflow_pause_marks_auto_resumable () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_dir) (fun () ->
+    let config = Coord.default_config base_dir in
+    ignore (Coord.init config ~agent_name:(Some "operator"));
+    let meta = make_meta ~name:"overflow-auto-resume-9733" in
+    (match Keeper_types.write_meta ~force:true config meta with
+     | Ok () -> ()
+     | Error e -> fail ("seed failed: " ^ e));
+    ignore (Keeper_registry.register ~base_path:base_dir meta.name meta);
+    let paused =
+      Keeper_turn_cascade_budget.pause_keeper_for_overflow
+        ~config
+        ~meta
+        ~reason:"test-overflow"
+    in
+    check bool "overflow pause returned paused=true" true paused.paused;
+    check_initial_auto_resume
+      "overflow pause gets initial auto_resume_after_sec"
+      paused.auto_resume_after_sec;
+    let persisted =
+      match Keeper_types.read_meta config meta.name with
+      | Ok (Some m) -> m
+      | Ok None -> fail "expected persisted meta"
+      | Error e -> fail ("read_meta failed: " ^ e)
+    in
+    check_initial_auto_resume
+      "persisted overflow pause gets initial auto_resume_after_sec"
+      persisted.auto_resume_after_sec)
+
+let test_sync_pause_auto_resume_flag_sets_backoff () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_dir) (fun () ->
+    let config = Coord.default_config base_dir in
+    ignore (Coord.init config ~agent_name:(Some "operator"));
+    let meta = make_meta ~name:"sync-auto-resume-9733" in
+    (match Keeper_types.write_meta ~force:true config meta with
+     | Ok () -> ()
+     | Error e -> fail ("seed failed: " ^ e));
+    ignore (Keeper_registry.register ~base_path:base_dir meta.name meta);
+    match
+      Keeper_turn_cascade_budget.sync_keeper_paused_state_with_resume_policy
+        ~config
+        ~meta
+        ~paused:true
+        ~resume_policy:Keeper_supervisor_pause_policy.Auto_resume_with_backoff
+    with
+    | Error e -> fail ("sync pause failed: " ^ e)
+    | Ok paused ->
+      check bool "sync pause returned paused=true" true paused.paused;
+      check_initial_auto_resume
+        "sync pause gets initial auto_resume_after_sec"
+        paused.auto_resume_after_sec)
+
 (* Race: overflow fiber observed unpaused at version N, decides
    to pause; heartbeat fiber bumps to version N+1 with new
    joined_room_ids; overflow fiber attempts write with stale
@@ -224,6 +297,10 @@ let () =
     [
       ( "pause-resume-merge",
         [
+          test_case "overflow pause marks auto-resumable" `Quick
+            test_overflow_pause_marks_auto_resumable;
+          test_case "sync pause auto-resume policy sets backoff" `Quick
+            test_sync_pause_auto_resume_flag_sets_backoff;
           test_case "pause: caller wins, heartbeat retained" `Quick
             test_pause_caller_wins_heartbeat_disk_wins;
           test_case "resume: caller wins, heartbeat retained" `Quick

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -262,6 +262,39 @@ let test_apply_operator_pause_resume () =
   check phase_t "-> Running" SM.Running tr2.new_phase
 ;;
 
+let test_operator_resume_from_paused_commits_latent_blockers () =
+  let cases =
+    [ ( "unhealthy turn"
+      , { running_conditions with operator_paused = true; turn_healthy = false }
+      , SM.Failing )
+    ; ( "context overflow"
+      , { running_conditions with operator_paused = true; context_overflow = true }
+      , SM.Overflowed )
+    ; ( "handoff active"
+      , { running_conditions with operator_paused = true; handoff_active = true }
+      , SM.HandingOff )
+    ; ( "restart backoff elapsed"
+      , { SM.default_conditions with
+          operator_paused = true
+        ; restart_budget_remaining = true
+        ; backoff_elapsed = true
+        }
+      , SM.Restarting )
+    ; ( "launch pending"
+      , { SM.default_conditions with operator_paused = true; launch_pending = true }
+      , SM.Offline )
+    ]
+  in
+  List.iter
+    (fun (label, conditions, expected_phase) ->
+       let tr =
+         apply_ok ~current_phase:SM.Paused ~conditions ~event:SM.Operator_resume
+       in
+       check phase_t label expected_phase tr.new_phase;
+       check bool (label ^ " clears operator pause") false tr.updated_conditions.operator_paused)
+    cases
+;;
+
 let test_apply_drain_lifecycle () =
   (* Running -> Draining -> Stopped *)
   let tr1 =
@@ -704,6 +737,17 @@ let test_can_transition_paused_to_draining () =
     "-> Draining"
     true
     (SM.can_transition ~from_phase:SM.Paused ~to_phase:SM.Draining)
+;;
+
+let test_can_transition_paused_to_latent_buffer_states () =
+  List.iter
+    (fun to_phase ->
+       check
+         bool
+         ("Paused -> " ^ SM.phase_to_string to_phase)
+         true
+         (SM.can_transition ~from_phase:SM.Paused ~to_phase))
+    [ SM.Failing; SM.Overflowed; SM.HandingOff; SM.Restarting; SM.Offline ]
 ;;
 
 let test_can_transition_paused_to_stopped () =
@@ -2534,6 +2578,10 @@ let () =
         ; test_case "compaction completed" `Quick test_apply_compaction_completed
         ; test_case "handoff lifecycle" `Quick test_apply_handoff_lifecycle
         ; test_case "pause/resume" `Quick test_apply_operator_pause_resume
+        ; test_case
+            "paused resume commits latent blockers"
+            `Quick
+            test_operator_resume_from_paused_commits_latent_blockers
         ; test_case "drain lifecycle" `Quick test_apply_drain_lifecycle
         ; test_case "drain + fiber death -> Crashed" `Quick test_apply_drain_fiber_death
         ; test_case
@@ -2622,6 +2670,10 @@ let () =
             test_can_transition_restarting_to_crashed
         ; test_case "Restarting -> Dead" `Quick test_can_transition_restarting_to_dead
         ; test_case "Paused -> Draining" `Quick test_can_transition_paused_to_draining
+        ; test_case
+            "Paused -> latent buffer states"
+            `Quick
+            test_can_transition_paused_to_latent_buffer_states
         ; test_case "Paused -> Stopped" `Quick test_can_transition_paused_to_stopped
         ; test_case
             "Running|Failing execute turns"

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -5737,6 +5737,11 @@ let test_run_keeper_cycle_livelock_block_returns_error () =
          (match Masc_mcp.Keeper_types.read_meta config meta.name with
           | Ok (Some persisted) ->
             check bool "livelock persists paused keeper" true persisted.paused;
+            check
+              bool
+              "livelock pause marks auto-resumable"
+              true
+              (Option.is_some persisted.auto_resume_after_sec);
             (match persisted.runtime.last_blocker with
              | Some blocker ->
                check


### PR DESCRIPTION
## Summary
- allow Operator_resume from Paused to commit latent blocker phases instead of rejecting resume intent
- mark overflow, resilience, and livelock auto-pause writers with Auto_resume_with_backoff
- add regression coverage for paused resume latent blockers and auto_resume_after_sec persistence

## Validation
- PASS: git diff --check origin/main...HEAD
- PASS: scripts/dune-local.sh build test/test_keeper_state_machine.exe
- PASS: _build/default/test/test_keeper_state_machine.exe (132 tests)
- BLOCKED: scripts/dune-local.sh build test/test_keeper_paused_cas_retain_9733.exe (host had concurrent bare dune build outside wrapper)
- NOT RUN: scripts/dune-local.sh build test/test_keeper_unified.exe (same host build contention)

## Notes
- Existing closed PR #16921 used the old branch/base shape, so this draft PR targets main with a fresh branch.
- Shell legacy purge is intentionally not mixed into this P0 pause fix; the audit plan gates it behind typed authority soak + lint gate.
