### PR TITLE
fix(test): repair test_cascade_saturation_signal_phase_a2 build break

### DIFF
--- a/test/test_cascade_saturation_signal_phase_a2.ml
+++ b/test/test_cascade_saturation_signal_phase_a2.ml
@@ -7,34 +7,30 @@
     - [Keeper_metrics.metric_keeper_cascade_saturation_signal] follows
       the [masc_keeper_*_total] naming convention. *)
 
+open Masc_mcp
+
 let test_env_flag_defaults_off () =
-  (* Ensure the env var is unset for this test; if a sibling test
-     leaks a value, [Sys.getenv_opt] would observe it. We do not
-     mutate the environment here — masc-mcp test/dune already
-     scrubs externally-visible MASC_* values. *)
-  let unset =
-    try
-      Unix.unsetenv "MASC_CASCADE_SATURATION_SIGNAL_ENABLED";
-      true
-    with _ -> false
-  in
-  if not unset then
-    Alcotest.skip ()
-  else
-    Alcotest.(check bool)
-      "default false"
-      false
-      (Masc_mcp.Env_config_keeper.CascadeSaturationSignal.enabled ())
+  (* masc-mcp test/dune scrubs externally-visible MASC_* env vars for
+     the test process, so the flag is observed as unset here. If a
+     sibling test leaks a non-empty value, skip rather than mutate the
+     environment (OCaml stdlib's [Unix] module exposes no [unsetenv]). *)
+  match Sys.getenv_opt "MASC_CASCADE_SATURATION_SIGNAL_ENABLED" with
+  | Some v when v <> "" -> Alcotest.skip ()
+  | _ ->
+      Alcotest.(check bool)
+        "default false"
+        false
+        (Env_config_keeper.CascadeSaturationSignal.enabled ())
 
 let test_metric_name_format () =
-  let name = Masc_mcp.Keeper_metrics.metric_keeper_cascade_saturation_signal in
+  let name = Keeper_metrics.metric_keeper_cascade_saturation_signal in
   Alcotest.(check string)
     "metric name exact"
     "masc_keeper_cascade_saturation_signal_total"
     name
 
 let test_metric_name_naming_convention () =
-  let name = Masc_mcp.Keeper_metrics.metric_keeper_cascade_saturation_signal in
+  let name = Keeper_metrics.metric_keeper_cascade_saturation_signal in
   let starts_with prefix str =
     String.length str >= String.length prefix
     && String.sub str 0 (String.length prefix) = prefix


### PR DESCRIPTION
## 증상

`dune build`가 `origin/main` (8b86ce1a59) 에서 실패합니다.

```
File "test/test_cascade_saturation_signal_phase_a2.ml", line 17, characters 6-19:
17 |       Unix.unsetenv "MASC_CASCADE_SATURATION_SIGNAL_ENABLED";
           ^^^^^^^^^^^^^
Error: Unbound value Unix.unsetenv
```

수정 후 추가로 발견된 두 번째 컴파일 에러:

```
Error: Unbound module Masc_mcp.Env_config_keeper
```

## 원인

PR #16988 (RFC-0153 Phase A.2) 머지된 테스트 파일에 두 가지 독립적 컴파일 에러가 있습니다:

1. **`Unix.unsetenv` 미존재** — OCaml stdlib `Unix` 모듈은 `getenv`/`putenv`/`environment`만 노출하고 POSIX `unsetenv(3)` wrapper는 제공하지 않습니다. 게다가 원본 코드의 주석은 *"We do not mutate the environment here — test/dune scrubs MASC_*"* 라고 명시하는데 정작 코드는 mutate 시도 — 의도와 코드가 모순.

2. **잘못된 모듈 qualifier** — `Env_config_keeper`는 `masc_config` 라이브러리 (`wrapped false`) 소속이므로 bare 접근 (`Env_config_keeper.X`)이지 `Masc_mcp.Env_config_keeper.X`가 아닙니다. `Keeper_metrics`는 반대로 `masc_mcp` 내부 모듈이라 `Masc_mcp.Keeper_metrics` 또는 `open Masc_mcp` 후 bare가 필요.

PR #16988 CI는 green이었지만 sandbox path filter (메모리 `feedback_ci_sandbox_path_filter_masks_syntax_bugs.md`)가 test/ 변경의 build 단계를 마스킹한 패턴과 정확히 일치합니다.

## 수정

`test/test_cascade_saturation_signal_phase_a2.ml`:

- 환경 변수 mutation 블록 제거 → `Sys.getenv_opt` + skip-on-leak. isolation은 이미 `test/dune` 의 `(env-vars (MASC_BASE_PATH ""))` 같은 stanza와 동일 패턴으로 dune이 보장합니다. 워크어라운드 도입 없음, 기존 보안망에 위탁.
- `Masc_mcp.Env_config_keeper` → `Env_config_keeper` (masc_config 직접 접근).
- `open Masc_mcp` 추가 → `Keeper_metrics` bare 접근 (test_memory_oas_5tier 등 다른 테스트와 동일 컨벤션).

## 검증

```
$ dune build --root .
# clean, exit 0
$ dune exec --root . test/test_cascade_saturation_signal_phase_a2.exe
Testing 'cascade_saturation_signal_phase_a2'.
  [OK]          env-flag             0   default off.
  [OK]          metric-name          0   exact.
  [OK]          metric-name          1   convention.
Test Successful in 0.014s. 3 tests run.
```

3/3 PASS. Phase A.2 의 원래 의도 (env 미설정 시 default false + metric naming convention) 모두 검증됩니다.

## 범위

- 단일 파일, test/ 디렉토리 한정
- `lib/`, RFC subsystem (credential/operator/sandbox/dashboard), CI/hook, workflow 문서 영역 — 건드리지 않음
- RFC 발견 체크 불필요 (test-only build fix)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>