### PR TITLE
[codex] Reject empty verification evidence before queueing

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -20,18 +20,84 @@ let flatten_lock_result = function
   | Ok result -> result
   | Error e -> Error e
 
-let verification_submission_evidence_refs task handoff_context =
+let contains_substring_ci text needle =
+  let text = String.lowercase_ascii text in
+  let needle = String.lowercase_ascii needle in
+  let text_len = String.length text in
+  let needle_len = String.length needle in
+  let rec loop idx =
+    if needle_len = 0 then true
+    else if idx + needle_len > text_len then false
+    else if String.equal (String.sub text idx needle_len) needle then true
+    else loop (idx + 1)
+  in
+  loop 0
+
+let is_placeholder_verification_evidence value =
+  let value = value |> String.trim |> String.lowercase_ascii in
+  let placeholders =
+    [ ""; "-"; "draft"; "n/a"; "na"; "none"; "null"; "pending"; "tbd"; "todo"; "unknown" ]
+  in
+  List.mem value placeholders
+
+let text_has_verification_artifact_ref text =
+  let text = String.trim text in
+  let has_github_pull =
+    contains_substring_ci text "github.com/"
+    && contains_substring_ci text "/pull/"
+  in
+  let has_pr_shorthand =
+    contains_substring_ci text "#"
+    && (contains_substring_ci text "pr "
+        || contains_substring_ci text "pr:"
+        || contains_substring_ci text "pull request")
+  in
+  let has_explicit_artifact =
+    [ "artifact:"; "artifact://"; "file:"; "path:"; "commit:"; "branch:" ]
+    |> List.exists (contains_substring_ci text)
+  in
+  has_github_pull || has_pr_shorthand || has_explicit_artifact
+
+let evidence_ref_has_verification_artifact_ref value =
+  let value = String.trim value in
+  (not (is_placeholder_verification_evidence value))
+  && (text_has_verification_artifact_ref value
+      || contains_substring_ci value "github.com/"
+      || String.contains value '/'
+      || String.contains value '.')
+
+let notes_have_verification_artifact_ref notes =
+  let notes = String.trim notes in
+  (not (is_placeholder_verification_evidence notes))
+  && text_has_verification_artifact_ref notes
+
+let verification_evidence_error_message =
+  "submit_for_verification requires verification evidence: include pr_url \
+   for the draft PR, a PR # reference, or an explicit \
+   artifact/file/path/commit/branch reference in notes."
+
+let verification_submission_evidence_refs task ~notes handoff_context =
   let contract_refs =
     match task.contract with
     | Some c -> c.verify_gate_evidence @ c.required_evidence
     | None -> []
   in
-  let handoff_refs =
-    match handoff_context with
-    | Some (hc : Masc_domain.task_handoff_context) -> hc.evidence_refs
-    | None -> []
+  let handoff_refs, summary_refs =
+    match
+      match handoff_context with
+      | Some _ -> handoff_context
+      | None -> task.handoff_context
+    with
+    | Some (hc : Masc_domain.task_handoff_context) ->
+      ( hc.evidence_refs
+      , if notes_have_verification_artifact_ref hc.summary then [ hc.summary ] else [] )
+    | None -> ([], [])
   in
-  normalized_string_list (contract_refs @ handoff_refs)
+  let notes_refs =
+    if notes_have_verification_artifact_ref notes then [ notes ] else []
+  in
+  normalized_string_list (contract_refs @ handoff_refs @ summary_refs @ notes_refs)
+  |> List.filter evidence_ref_has_verification_artifact_ref
 
 let transition_task_r
       config
@@ -268,22 +334,31 @@ let transition_task_r
           | ( (Masc_domain.Submit_for_verification | Masc_domain.Submit_pr_evidence)
             , _
             , Masc_domain.AwaitingVerification { assignee; verification_id; _ }
-            , Some prepare ) ->
+            , prepare_opt ) ->
             let evidence_refs =
-              verification_submission_evidence_refs task handoff_context
+              verification_submission_evidence_refs task ~notes handoff_context
             in
-            (match prepare ~task ~assignee ~verification_id ~evidence_refs with
-             | Ok () -> Ok ()
-             | Error e ->
-               Error
-                 (Masc_domain.System
-                    (Masc_domain.System_error.IoError
-                       (Printf.sprintf
-                          "verification request creation failed before status transition \
-                           (task=%s vrf=%s): %s"
-                          task_id
-                          verification_id
-                          e))))
+            if evidence_refs = [] then
+              Error
+                (Masc_domain.Task
+                   (Masc_domain.Task_error.InvalidState
+                      verification_evidence_error_message))
+            else
+              (match prepare_opt with
+               | None -> Ok ()
+               | Some prepare ->
+                 (match prepare ~task ~assignee ~verification_id ~evidence_refs with
+                  | Ok () -> Ok ()
+                  | Error e ->
+                    Error
+                      (Masc_domain.System
+                         (Masc_domain.System_error.IoError
+                            (Printf.sprintf
+                               "verification request creation failed before status transition \
+                                (task=%s vrf=%s): %s"
+                               task_id
+                               verification_id
+                               e)))))
           | ( (Masc_domain.Submit_for_verification | Masc_domain.Submit_pr_evidence)
             , _
             , _

--- a/lib/tool_task_completion_review.ml
+++ b/lib/tool_task_completion_review.ml
@@ -144,15 +144,43 @@ let verification_submission_evidence_error ~notes ~handoff_context =
        for the draft PR, a PR # reference, or an explicit \
        artifact/file/path/commit/branch reference in notes."
 
-let verification_evidence_refs_for_task (task : Masc_domain.task) =
+let verification_evidence_error_message =
+  "submit_for_verification requires verification evidence: include pr_url \
+   for the draft PR, a PR # reference, or an explicit \
+   artifact/file/path/commit/branch reference in notes."
+
+let concrete_verification_evidence_refs ?(notes = "") ?handoff_context
+    (task : Masc_domain.task) =
   let contract_refs =
     match task.contract with
-    | Some contract -> contract.verify_gate_evidence
+    | Some contract -> contract.verify_gate_evidence @ contract.required_evidence
     | None -> []
   in
   let handoff_refs =
-    match task.handoff_context with
+    match
+      match handoff_context with
+      | Some _ -> handoff_context
+      | None -> task.handoff_context
+    with
     | Some handoff_context -> handoff_context.evidence_refs
     | None -> []
   in
-  non_empty_trimmed_strings (contract_refs @ handoff_refs)
+  let summary_refs =
+    match
+      match handoff_context with
+      | Some _ -> handoff_context
+      | None -> task.handoff_context
+    with
+    | Some handoff_context when notes_have_verification_artifact_ref handoff_context.summary ->
+      [ handoff_context.summary ]
+    | _ -> []
+  in
+  let notes_refs =
+    if notes_have_verification_artifact_ref notes then [ notes ] else []
+  in
+  contract_refs @ handoff_refs @ summary_refs @ notes_refs
+  |> non_empty_trimmed_strings
+  |> List.filter evidence_ref_has_verification_artifact_ref
+
+let verification_evidence_refs_for_task (task : Masc_domain.task) =
+  concrete_verification_evidence_refs task

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -1987,7 +1987,11 @@ let test_done_redirects_default_contract_task_to_verification_fsm () =
          | None -> fail "expected default verification contract");
         let req = verification_request_by_task_id config ~task_id in
         check bool "criteria populated" true (req.criteria <> []);
-        check bool "evidence refs populated" true (evidence_refs_of_request req <> [])
+        check
+          (list string)
+          "evidence refs use concrete completion evidence"
+          [ "Implemented change and ran focused checks. commit:abc123" ]
+          (evidence_refs_of_request req)
       | _ -> fail "expected keeper_task_done to redirect into verification FSM"))
 ;;
 

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -104,6 +104,33 @@ let add_required_evidence_only_task config =
   | Some t -> t.id
   | None -> Alcotest.fail "new task not found after add_task"
 
+let add_placeholder_evidence_task config =
+  let existing_ids =
+    Coord.read_backlog config
+    |> fun backlog -> List.map (fun (t : Masc_domain.task) -> t.id) backlog.tasks
+  in
+  let contract : Masc_domain.task_contract = {
+    strict = true;
+    completion_contract = ["tests pass"];
+    required_tools = [];
+    required_evidence = ["completion_notes"];
+    inspect_gate_evidence = [];
+    verify_gate_evidence = ["pr_url_or_artifact_ref"];
+    links = { operation_id = None; session_id = None; autoresearch_loop_id = None };
+  } in
+  let _msg =
+    Coord.add_task ~contract config ~title:"placeholder evidence task"
+      ~priority:3 ~description:"placeholder evidence must not open verification"
+  in
+  let backlog = Coord.read_backlog config in
+  match
+    List.find_opt
+      (fun (t : Masc_domain.task) -> not (List.mem t.id existing_ids))
+      backlog.tasks
+  with
+  | Some t -> t.id
+  | None -> Alcotest.fail "new task not found after add_task"
+
 let claim_and_start config agent_name task_id =
   let _ = Coord.transition_task_r config ~agent_name ~task_id
     ~action:Masc_domain.Claim () in
@@ -263,6 +290,33 @@ let test_submit_prepare_failure_keeps_task_in_progress () =
           r.task_id = task_id)
       in
       Alcotest.(check int) "no orphan request" 0 (List.length reqs))
+
+let test_submit_rejects_placeholder_evidence_before_request () =
+  with_temp_config ~fsm_enabled:true (fun config ->
+    let task_id = add_placeholder_evidence_task config in
+    claim_and_start config "worker" task_id;
+    let prepare_called = ref false in
+    let result =
+      Coord.transition_task_r config ~agent_name:"worker"
+        ~task_id ~action:Masc_domain.Submit_for_verification
+        ~notes:"implementation complete"
+        ~prepare_verification_request:
+          (fun ~task:_ ~assignee:_ ~verification_id:_ ~evidence_refs:_ ->
+             prepare_called := true;
+             Ok ())
+        ()
+    in
+    match result with
+    | Ok _ -> Alcotest.fail "submit should reject placeholder-only evidence"
+    | Error e ->
+      Alcotest.(check bool) "prepare not called" false !prepare_called;
+      Alcotest.(check string) "status remains in_progress" "in_progress"
+        (status_string config task_id);
+      let msg = Masc_domain.show_masc_error e in
+      Alcotest.(check bool) "error mentions evidence" true
+        (Astring.String.is_infix
+           ~affix:"requires verification evidence"
+           msg))
 
 let test_submit_retry_records_request_created_backlog_orphan_policy () =
   with_temp_config ~fsm_enabled:true (fun config ->
@@ -980,6 +1034,8 @@ let () =
         `Quick test_submit_for_verification_from_claimed_moves_to_awaiting;
       Alcotest.test_case "submit prepare failure keeps task in_progress"
         `Quick test_submit_prepare_failure_keeps_task_in_progress;
+      Alcotest.test_case "submit rejects placeholder evidence before request"
+        `Quick test_submit_rejects_placeholder_evidence_before_request;
       Alcotest.test_case
         "submit retry records request-created backlog orphan policy"
         `Quick


### PR DESCRIPTION
## Summary
- reject empty or placeholder-only verification evidence before creating verification requests
- filter concrete evidence refs consistently for task transition and notification surfaces
- add direct FSM coverage for placeholder-only evidence rejection

Fixes #16971

## Validation
- scripts/dune-local.sh build test/test_verification_fsm.exe
- ./_build/default/test/test_verification_fsm.exe (25 tests)
- scripts/dune-local.sh build test/test_keeper_task_dispatch.exe
- ./_build/default/test/test_keeper_task_dispatch.exe (56 tests)
- git diff --check