### PR TITLE
[codex] Gate keeper claims by required execution tools

### DIFF
--- a/lib/coord/coord_task_classify.ml
+++ b/lib/coord/coord_task_classify.ml
@@ -275,7 +275,7 @@ let required_tool_claim_guard config ~agent_name ?agent_tool_names task =
         (Masc_domain.Task
            (Masc_domain.Task_error.InvalidState
               (Printf.sprintf
-                 "Task %s requires tool(s) unavailable to %s: %s"
+                 "Workflow rejected: task %s requires tool(s) unavailable to %s: %s"
                  task.id
                  agent_name
                  (String.concat ", " missing)))))

--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -146,6 +146,35 @@ let no_eligible_action_for_claim_scope claim_goal_scope ~excluded_count =
       scope_hint
 ;;
 
+let missing_required_tools_for_claim_scope config ~agent_tool_names ~task_filter =
+  Coord.get_tasks_raw config
+  |> List.filter Coord_task_schedule.task_is_claim_pool_candidate
+  |> List.filter task_filter
+  |> List.concat_map (fun task ->
+       Coord_task_classify.missing_required_tools
+         ~allowed:agent_tool_names
+         (Coord_task_schedule.task_required_tools task))
+  |> List.sort_uniq String.compare
+;;
+
+let required_tool_workflow_rejection config ~agent_tool_names claim_goal_scope =
+  match claim_goal_scope.Keeper_runtime_contract.mode with
+  | "active_goal_ids" -> None
+  | _ -> (
+    match
+      missing_required_tools_for_claim_scope
+        config
+        ~agent_tool_names
+        ~task_filter:claim_goal_scope.Keeper_runtime_contract.task_filter
+    with
+    | [] -> None
+    | missing ->
+      Some
+        (Printf.sprintf
+           "Workflow rejected: this keeper lacks required execution/repo tool(s): %s. Route the task to a coding/verifier keeper or update required_tools."
+           (String.concat ", " missing)))
+;;
+
 let find_task_goal_id config task_id =
   Coord.get_tasks_raw config
   |> List.find_map (fun (task : Masc_domain.task) ->
@@ -384,10 +413,21 @@ let handle_keeper_task_tool
           else message
       | Coord.Claim_next_no_unclaimed -> "No unclaimed tasks. ACTION: Stop task-checking — nothing to claim."
       | Coord.Claim_next_no_eligible { excluded_count; _ } ->
+        let action =
+          match
+            required_tool_workflow_rejection
+              config
+              ~agent_tool_names
+              claim_goal_scope
+          with
+          | Some rejection -> rejection
+          | None ->
+            no_eligible_action_for_claim_scope claim_goal_scope ~excluded_count
+        in
         Printf.sprintf
           "No eligible tasks%s. %s"
           (claim_scope_context_suffix ~meta claim_goal_scope)
-          (no_eligible_action_for_claim_scope claim_goal_scope ~excluded_count)
+          action
       | Coord.Claim_next_error e -> Printf.sprintf "Error: %s" e
     in
     let claim_scope, claimed_task_fields =

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -1444,6 +1444,36 @@ let test_claim_skips_required_tools_without_access () =
     | None -> fail "expected fallback task to be claimed")
 ;;
 
+let test_board_only_claim_rejects_required_execution_tool_task () =
+  with_room (fun config ->
+    let meta =
+      make_meta_with_tools
+        [ "keeper_task_claim"; "keeper_board_post"; "keeper_board_comment" ]
+    in
+    let _ =
+      Coord.add_task
+        ~contract:(contract_requiring_tools [ "keeper_bash" ])
+        config
+        ~title:"Needs execution"
+        ~priority:1
+        ~description:"requires shell execution"
+    in
+    let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
+    let json = parse_json result in
+    let message = Yojson.Safe.Util.(json |> member "result" |> to_string) in
+    check_no_task_claimed config meta;
+    check
+      bool
+      "workflow rejection"
+      true
+      (contains_substring message "Workflow rejected");
+    check
+      bool
+      "missing keeper_bash named"
+      true
+      (contains_substring message "keeper_bash"))
+;;
+
 let test_claim_allows_required_tools_with_access () =
   with_room (fun config ->
     let meta =
@@ -2642,6 +2672,10 @@ let () =
             "claim skips tasks requiring missing tools"
             `Quick
             test_claim_skips_required_tools_without_access
+        ; test_case
+            "board-only claim rejects task requiring execution tools"
+            `Quick
+            test_board_only_claim_rejects_required_execution_tool_task
         ; test_case
             "claim allows tasks requiring available tools"
             `Quick


### PR DESCRIPTION
## Summary
- surface workflow rejection when a keeper lacks required execution or repo tools
- preserve active-goal scoped claim guidance when the issue is scope repair rather than all-task claimability
- add regression coverage for board-only keepers attempting execution-required tasks

Fixes #16972

## Validation
- scripts/dune-local.sh build test/test_keeper_task_dispatch.exe
- ./_build/default/test/test_keeper_task_dispatch.exe (57 tests)
- git diff --check