### PR TITLE
[codex] Filter actionable verification queue requests

### DIFF
--- a/lib/keeper/keeper_run_tools_work_discovery.ml
+++ b/lib/keeper/keeper_run_tools_work_discovery.ml
@@ -40,6 +40,12 @@ let backlog_task_section ~config ~meta ~predicate ~title =
     None
 ;;
 
+let actionable_verification_request_ids ~(config : Coord.config) : string list =
+  Verification.list_requests config.Coord.base_path
+  |> List.filter Verification.request_is_actionable
+  |> List.map (fun (req : Verification.verification_request) -> req.id)
+;;
+
 let section_for_source ~config ~(meta : Keeper_types.keeper_meta) source =
   match source with
   | "unclaimed_tasks" ->
@@ -51,13 +57,15 @@ let section_for_source ~config ~(meta : Keeper_types.keeper_meta) source =
         t.task_status = Masc_domain.Todo)
   | "awaiting_verification_tasks"
   | "verification_tasks" ->
+    let actionable_request_ids = actionable_verification_request_ids ~config in
     backlog_task_section
       ~config
       ~meta
       ~title:"Awaiting verification tasks"
       ~predicate:(fun (t : Masc_domain.task) ->
         match t.task_status with
-        | Masc_domain.AwaitingVerification _ -> true
+        | Masc_domain.AwaitingVerification { verification_id; _ } ->
+          List.exists (String.equal verification_id) actionable_request_ids
         | _ -> false)
   | "stale_tasks" ->
     Some

--- a/lib/keeper/keeper_world_observation_inputs.ml
+++ b/lib/keeper/keeper_world_observation_inputs.ml
@@ -29,6 +29,24 @@ let claim_goal_scope_filter ?agent_tool_names ~(config : Coord.config)
   scope.task_filter
 ;;
 
+let actionable_verification_request_ids ~(config : Coord.config) : string list =
+  Verification.list_requests config.Coord.base_path
+  |> List.filter Verification.request_is_actionable
+  |> List.map (fun (req : Verification.verification_request) -> req.id)
+;;
+
+let task_has_actionable_verification actionable_request_ids
+    (task : Masc_domain.task) =
+  match task.task_status with
+  | Masc_domain.AwaitingVerification { verification_id; _ } ->
+    List.exists (String.equal verification_id) actionable_request_ids
+  | Masc_domain.Todo
+  | Masc_domain.Claimed _
+  | Masc_domain.InProgress _
+  | Masc_domain.Done _
+  | Masc_domain.Cancelled _ -> false
+;;
+
 (** Read room backlog counts. *)
 let read_backlog_counts ~allowed_tool_names ~(config : Coord.config) ~(meta : keeper_meta)
   : int * int * int * int * bool
@@ -70,16 +88,10 @@ let read_backlog_counts ~allowed_tool_names ~(config : Coord.config) ~(meta : ke
       |> List.length
     in
     let pending_verification =
+      let actionable_request_ids = actionable_verification_request_ids ~config in
       List.length
         (List.filter
-           (fun (t : Masc_domain.task) ->
-              match t.task_status with
-              | Masc_domain.AwaitingVerification _ -> true
-              | Masc_domain.Todo
-              | Masc_domain.Claimed _
-              | Masc_domain.InProgress _
-              | Masc_domain.Done _
-              | Masc_domain.Cancelled _ -> false)
+           (task_has_actionable_verification actionable_request_ids)
            backlog.tasks)
     in
     let backlog_updated_since_last_scheduled_autonomous =

--- a/lib/verification.ml
+++ b/lib/verification.ml
@@ -256,6 +256,13 @@ let request_of_yojson = function
            (Json_util.kind_name other)
            (Json_util.excerpt other))
 
+let request_status_is_actionable = function
+  | Pending | Assigned _ -> true
+  | Completed _ -> false
+
+let request_is_actionable (req : verification_request) =
+  request_status_is_actionable req.status
+
 (** ID generation — cryptographic random, 128-bit space.
 
     Prior implementation (#7544) combined [Time_compat.now ()] with

--- a/lib/verification.mli
+++ b/lib/verification.mli
@@ -46,6 +46,8 @@ type verification_request = {
 
 val request_to_yojson : verification_request -> Yojson.Safe.t
 val request_of_yojson : Yojson.Safe.t -> (verification_request, string) result
+val request_status_is_actionable : request_status -> bool
+val request_is_actionable : verification_request -> bool
 
 (** {1 Evaluation} *)
 

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -202,6 +202,21 @@ let create_pending_verification_request config ~task_id =
   | Error msg -> failwith (Printf.sprintf "create_request failed: %s" msg)
 ;;
 
+let create_verification_request config ~task_id ~request_id =
+  match
+    Verification.create_request
+      ~base_path:config.Coord.base_path
+      ~task_id
+      ~output:`Null
+      ~criteria:[]
+      ~worker:"test-worker"
+      ~request_id
+      ()
+  with
+  | Ok req -> req
+  | Error msg -> failwith (Printf.sprintf "create_request failed: %s" msg)
+;;
+
 let verification_request_by_task_id config ~task_id =
   Verification.list_requests config.Coord.base_path
   |> List.find_opt (fun (req : Verification.verification_request) ->
@@ -237,6 +252,33 @@ let cdal_verdict_of_request (req : Verification.verification_request) =
   match req.output with
   | `Assoc fields -> List.assoc_opt "cdal_verdict" fields
   | _ -> None
+;;
+
+let awaiting_verification_task ~id ~title ~verification_id =
+  let now = Masc_domain.now_iso () in
+  ({ id
+   ; title
+   ; description = "verification routing regression"
+   ; task_status =
+       Masc_domain.AwaitingVerification
+         { assignee = "test-worker"
+         ; submitted_at = now
+         ; verification_id
+         ; deadline = None
+         }
+   ; priority = 1
+   ; files = []
+   ; created_at = now
+   ; created_by = None
+   ; worktree = None
+   ; goal_id = None
+   ; stage = None
+   ; contract = None
+   ; handoff_context = None
+   ; cycle_count = 0
+   ; do_not_reclaim_reason = None
+   }
+    : Masc_domain.task)
 ;;
 
 let string_field_exn ~context name fields =
@@ -2285,6 +2327,80 @@ let test_notify_reuses_persisted_cdal_verdict_payload () =
           (cdal_verdict_run_id_exn ~context:"board meta" cdal_verdict))))
 ;;
 
+let test_rejected_verification_request_is_not_counted_or_routed () =
+  with_room (fun config ->
+    let stale_verification_id = "vrf-stale-rejected" in
+    let pending_verification_id = "vrf-live-pending" in
+    let stale_task =
+      awaiting_verification_task
+        ~id:"task-stale"
+        ~title:"Stale rejected verification"
+        ~verification_id:stale_verification_id
+    in
+    let pending_task =
+      awaiting_verification_task
+        ~id:"task-pending"
+        ~title:"Live pending verification"
+        ~verification_id:pending_verification_id
+    in
+    Coord.write_backlog
+      config
+      { tasks = [ stale_task; pending_task ]
+      ; last_updated = Masc_domain.now_iso ()
+      ; version = 2
+      };
+    let _ =
+      create_verification_request
+        config
+        ~task_id:stale_task.id
+        ~request_id:stale_verification_id
+    in
+    let _ =
+      create_verification_request
+        config
+        ~task_id:pending_task.id
+        ~request_id:pending_verification_id
+    in
+    (match
+       Verification.submit_verdict
+         ~base_path:config.Coord.base_path
+         ~req_id:stale_verification_id
+         ~verifier:"test-verifier"
+         ~verdict:(Verification.Fail "needs rework")
+     with
+     | Ok _ -> ()
+     | Error msg -> failwith (Printf.sprintf "submit_verdict failed: %s" msg));
+    let meta =
+      { (make_test_meta ()) with
+        work_discovery_enabled = Some true
+      ; work_discovery_interval_sec = Some 0
+      ; work_discovery_sources = Some [ "awaiting_verification_tasks" ]
+      }
+    in
+    let obs =
+      Keeper_world_observation.observe_direct_keeper_msg
+        ~allowed_tool_names:None
+        ~config
+        ~meta
+    in
+    check int "only actionable pending request is counted" 1
+      obs.pending_verification_count;
+    let nudge =
+      Keeper_run_tools_work_discovery.make
+        ~config
+        ~get_meta:(fun () -> meta)
+        ()
+        ()
+    in
+    match nudge with
+    | None -> fail "expected work-discovery nudge for live pending request"
+    | Some text ->
+      check bool "pending task is routed" true
+        (contains_substring text pending_task.title);
+      check bool "rejected stale task is not routed" false
+        (contains_substring text stale_task.title))
+;;
+
 (* Regression: keeper_task_done must map [result] onto the typed
    [handoff_context.summary] domain field, not just dump it into [notes]
    as an untyped blob. Previously a [result] sent by a keeper would be
@@ -2723,6 +2839,10 @@ let () =
             "notification reuses persisted CDAL verdict payload"
             `Quick
             test_notify_reuses_persisted_cdal_verdict_payload
+        ; test_case
+            "rejected requests are not counted or routed"
+            `Quick
+            test_rejected_verification_request_is_not_counted_or_routed
         ; test_case
             "notes/pr_url map to typed handoff_context fields"
             `Quick


### PR DESCRIPTION
## Summary
- add a shared actionable verification request predicate
- make pending verification counts and work-discovery routing ignore completed/rejected requests
- add regression coverage for rejected stale requests not being counted or routed

Fixes #16974

## Validation
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_task_dispatch.exe
- ./_build/default/test/test_keeper_task_dispatch.exe (57 tests)
- git diff --check