### PR TITLE
refactor(dashboard): credential SSOT — extract API functions from component

### DIFF
--- a/dashboard/src/api/credentials.ts
+++ b/dashboard/src/api/credentials.ts
@@ -42,7 +42,7 @@ export function coerceCredentialType(raw: unknown): CredentialType {
   return 'github'
 }
 
-import { get } from './core'
+import { get, post, del } from './core'
 import { isRecord } from '../lib/type-guards'
 export { isRecord }
 
@@ -63,6 +63,51 @@ export function parseCredentialState(raw: unknown): CredentialState | null {
 export async function fetchCredentials(): Promise<Credential[]> {
   const data = await get<unknown>('/api/v1/credentials')
   return normalizeCredentialsResponse(data)
+}
+
+export async function createCredential(payload: CredentialCreatePayload): Promise<void> {
+  await post('/api/v1/credentials', buildCredentialCreateRequest(payload))
+}
+
+export async function deleteCredential(id: string): Promise<void> {
+  await del(`/api/v1/credentials/${encodeURIComponent(id)}`)
+}
+
+// --- Helpers ---
+
+export function sanitizeOptionalString(value: string | null | undefined): string | null {
+  const trimmed = value?.trim() ?? ''
+  return trimmed === '' ? null : trimmed
+}
+
+function shellQuote(value: string): string {
+  return `'${value.split("'").join("'\\''")}'`
+}
+
+export function githubLoginCommand(ghConfigDir: string | null | undefined): string | null {
+  const dir = sanitizeOptionalString(ghConfigDir)
+  if (!dir) return null
+  return `GH_CONFIG_DIR=${shellQuote(dir)} gh auth login --hostname github.com --git-protocol https --web --clipboard`
+}
+
+export function buildCredentialCreateRequest(payload: CredentialCreatePayload): Record<string, unknown> {
+  const ghConfigDir = sanitizeOptionalString(payload.gh_config_dir)
+  const sshKeyPath = sanitizeOptionalString(payload.ssh_key_path)
+  const gpgKeyId = sanitizeOptionalString(payload.gpg_key_id)
+  const oauthMethod =
+    payload.type === 'github'
+      ? payload.oauth_method === 'with_token' ? 'with_token' : 'web'
+      : 'web'
+  return {
+    id: payload.id.trim(),
+    cred_type: payload.type,
+    username: (payload.username || payload.name).trim(),
+    gh_config_dir: ghConfigDir,
+    ssh_key_path: sshKeyPath,
+    gpg_key_id: gpgKeyId,
+    oauth_method: oauthMethod,
+    token: oauthMethod === 'with_token' ? sanitizeOptionalString(payload.token) : null,
+  }
 }
 
 export function normalizeCredentialsResponse(data: unknown): Credential[] {

--- a/dashboard/src/components/credential-settings.test.ts
+++ b/dashboard/src/components/credential-settings.test.ts
@@ -2,16 +2,18 @@
 import { describe, expect, it } from "vitest"
 import {
   buildCredentialCreateRequest,
+  githubLoginCommand,
+  sanitizeOptionalString,
+} from "../api/credentials"
+import {
   coerceCredentialType,
   credentialStateBadgeClass,
   credentialStateLabel,
   credentialTypeBadgeClass,
   credentialTypeLabel,
-  githubLoginCommand,
   isRecord,
   normalizeCredentialsResponse,
   parseCredentialState,
-  sanitizeOptionalString,
 } from "./credential-settings"
 
 describe("coerceCredentialType", () => {

--- a/dashboard/src/components/credential-settings.ts
+++ b/dashboard/src/components/credential-settings.ts
@@ -3,10 +3,14 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { del, post } from '../api/core'
 import {
   fetchCredentials,
+  createCredential,
+  deleteCredential,
   coerceCredentialType,
+  sanitizeOptionalString,
+  githubLoginCommand,
+  buildCredentialCreateRequest,
   type Credential,
   type CredentialCreatePayload,
   type CredentialOauthMethod,
@@ -52,17 +56,7 @@ const addDraft = signal<CredentialCreatePayload>({
   description: '',
 })
 
-// ── API ──────────────────────────────────────────────────
-
-async function createCredential(payload: CredentialCreatePayload): Promise<void> {
-  await post('/api/v1/credentials', buildCredentialCreateRequest(payload))
-}
-
-async function deleteCredential(id: string): Promise<void> {
-  await del(`/api/v1/credentials/${encodeURIComponent(id)}`)
-}
-
-// ── Helpers ──────────────────────────────────────────────
+// ── UI Helpers ────────────────────────────────────────────
 
 export function credentialTypeLabel(type: CredentialType): string {
   switch (type) {
@@ -106,41 +100,6 @@ export function credentialStateBadgeClass(state: CredentialState | null | undefi
       return 'bg-[var(--color-bg-elevated)] text-text-dim border-[var(--color-border-default)]'
     default:
       return 'bg-[var(--color-bg-elevated)] text-text-muted border-[var(--color-border-default)]'
-  }
-}
-
-export function sanitizeOptionalString(value: string | null | undefined): string | null {
-  const trimmed = value?.trim() ?? ''
-  return trimmed === '' ? null : trimmed
-}
-
-function shellQuote(value: string): string {
-  return `'${value.split("'").join("'\\''")}'`
-}
-
-export function githubLoginCommand(ghConfigDir: string | null | undefined): string | null {
-  const dir = sanitizeOptionalString(ghConfigDir)
-  if (!dir) return null
-  return `GH_CONFIG_DIR=${shellQuote(dir)} gh auth login --hostname github.com --git-protocol https --web --clipboard`
-}
-
-export function buildCredentialCreateRequest(payload: CredentialCreatePayload): Record<string, unknown> {
-  const ghConfigDir = sanitizeOptionalString(payload.gh_config_dir)
-  const sshKeyPath = sanitizeOptionalString(payload.ssh_key_path)
-  const gpgKeyId = sanitizeOptionalString(payload.gpg_key_id)
-  const oauthMethod =
-    payload.type === 'github'
-      ? payload.oauth_method === 'with_token' ? 'with_token' : 'web'
-      : 'web'
-  return {
-    id: payload.id.trim(),
-    cred_type: payload.type,
-    username: (payload.username || payload.name).trim(),
-    gh_config_dir: ghConfigDir,
-    ssh_key_path: sshKeyPath,
-    gpg_key_id: gpgKeyId,
-    oauth_method: oauthMethod,
-    token: oauthMethod === 'with_token' ? sanitizeOptionalString(payload.token) : null,
   }
 }
 

--- a/dashboard/src/components/keeper-repo-mapping.ts
+++ b/dashboard/src/components/keeper-repo-mapping.ts
@@ -17,8 +17,8 @@ import { ErrorState, LoadingState } from './common/feedback-state'
 import {
   credentialStateBadgeClass,
   credentialStateLabel,
-  githubLoginCommand,
 } from './credential-settings'
+import { githubLoginCommand } from '../api/credentials'
 import type { Keeper } from '../types'
 
 // ── Types ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Extract `createCredential`, `deleteCredential`, `sanitizeOptionalString`, `githubLoginCommand`, `buildCredentialCreateRequest` from `credential-settings.ts` component to `api/credentials.ts` API module
- Update 3 consumer files to import from the canonical API module instead of the component
- No behavior changes — pure move refactoring

## Test plan
- [x] TypeScript check passes on all 4 modified files
- [ ] Existing `credential-settings.test.ts` tests pass (imports split but same test surface)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>