### PR TITLE
docs(dashboard): correct stale cognition promote comment

### DIFF
--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -240,10 +240,12 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       description: 'Keeper cognition drill-down.',
       params: { section: 'cognition' },
       hidden: true,
-      // Surface wiring complete: 7-view FilterChips (overview, keeper,
-      // token-stats, decisions, memory, episodes, autoresearch) + deep-link
-      // navigate target from KeeperCognitionInspector. Promoted to main nav
-      // 2026-05-17 — sidebar entry was the only missing piece.
+      // Hidden 2026-05-20: 7-view FilterChips (overview, keeper, token-stats,
+      // decisions, memory, episodes, autoresearch) and KeeperCognitionInspector
+      // deep links remain functional, but the sidebar entry is intentionally
+      // suppressed pending the cognition→keeper-detail Cognition section
+      // absorption (tracked in the Monitor IA review). The earlier 2026-05-17
+      // promotion was reverted by #16977 (Improve dashboard monitor IA).
     },
   ],
   command: [


### PR DESCRIPTION
## Goal
`dashboard/src/config/navigation.ts:243-247`의 cognition 항목에 달린 "Promoted to main nav 2026-05-17" 주석이 같은 항목의 `hidden: true` 플래그와 직접 모순됨. PR #16977 (Improve dashboard monitor IA)이 promotion을 되돌리며 코드는 갱신했지만 주석은 미수정. 사실 정정.

## Changed files
- `dashboard/src/config/navigation.ts` — 주석만 6+/4-

## Self-review
- 목표: stale 주석을 현재 상태(hidden 유지 사유 + 작동 중인 deep link + 향후 흡수 plan)로 교체
- 범위: 1 파일, 주석 전용, 런타임/타입 영향 0
- 로컬 검증: comment-only change, lint/test 실행 생략 가능 (TypeScript 주석은 컴파일러 무영향)
- 미검증: 없음

## Why not include code change
1. 같은 영역의 IA 작업(cognition → keeper-detail Cognition section 흡수)은 5 파일 수정 + cockpit 단축키 deep-link redirect를 필요로 함. 별도 PR로 분리하여 안전성 확보.
2. 본 PR은 *코드 동작 변화 0*. 후속 PR이 들어오기 전까지 주석이 거짓 진술인 상태를 우선 해소.

## Test plan
- [ ] lint pass (comment-only, expected)
- [ ] 코드 변경이 없으므로 dashboard 빌드/테스트 영향 없음

## References
- Monitor IA review report: `/Users/dancer/me/memory/masc-oas-dashboard-monitor-ia-report-2026-05-20.html`
- Promotion 회귀 commit: `64a692454b` (#16977 Improve dashboard monitor IA)
- 후속 cognition 흡수 plan: cognition-plane.ts의 7 view → keeper-detail-body.ts의 신규 Cognition section + FilterChips 패턴 재사용. 별도 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)