### PR TITLE
[codex] Fix Keeper Bash recovery hints

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -473,51 +473,44 @@ let shell_rewrite_plan ?(confidence = "medium") ~next_tool ~next_args ~instructi
     () =
   { next_tool; next_args; instruction; reason; confidence }
 
-let keeper_shell_rewrite_args op fields = ("op", `String op) :: fields
-
 let command_block_recovery_plan ~cmd:_ reason hint =
   match reason with
   | Worker_dev_tools.Command_not_allowed name when String_util.equals_ci name "gh" ->
     Some
       (shell_rewrite_plan
          ~confidence:"high"
-         ~next_tool:"keeper_shell"
-         ~next_args:
-           (keeper_shell_rewrite_args "gh" [ "cmd", `String "pr list --state open" ])
+         ~next_tool:"keeper_pr_list"
+         ~next_args:[ "state", `String "open" ]
          ~instruction:hint
-         ~reason:"gh_requires_structured_shell_op"
+         ~reason:"gh_requires_native_pr_tool"
          ())
   | Worker_dev_tools.Command_not_allowed _ ->
     Some
       (shell_rewrite_plan
-         ~next_tool:"keeper_shell"
+         ~next_tool:"Grep"
          ~next_args:
-           (keeper_shell_rewrite_args
-              "rg"
-              [ "pattern", `String "SEARCH_TERM"; "path", `String "SCOPED_PATH" ])
+           [ "pattern", `String "SEARCH_TERM"; "path", `String "SCOPED_PATH" ]
          ~instruction:hint
-         ~reason:"command_not_allowed_use_structured_op"
+         ~reason:"command_not_allowed_use_visible_search_tool"
          ())
   | Chain_or_redirect | Pipes_not_allowed ->
     Some
       (shell_rewrite_plan
          ~confidence:"high"
-         ~next_tool:"keeper_shell"
+         ~next_tool:"Grep"
          ~next_args:
-           (keeper_shell_rewrite_args
-              "rg"
-              [ "pattern", `String "SEARCH_TERM"; "path", `String "SCOPED_PATH" ])
+           [ "pattern", `String "SEARCH_TERM"; "path", `String "SCOPED_PATH" ]
          ~instruction:hint
-         ~reason:"shell_shape_requires_structured_op"
+         ~reason:"shell_shape_requires_visible_search_tool"
          ())
   | Injection | Process_substitution ->
     Some
       (shell_rewrite_plan
-         ~next_tool:"keeper_shell"
+         ~next_tool:"Bash"
          ~next_args:
-           (keeper_shell_rewrite_args
-              "rg"
-              [ "pattern", `String "DISCOVERY_TERM"; "path", `String "SCOPED_PATH" ])
+           [ "command", `String "DISCOVERY_COMMAND_WITHOUT_SUBSTITUTION"
+           ; "cwd", `String "REPO_OR_WORKTREE_CWD"
+           ]
          ~instruction:hint
          ~reason:"shell_injection_requires_discovery_first"
          ())
@@ -525,24 +518,24 @@ let command_block_recovery_plan ~cmd:_ reason hint =
     Some
       (shell_rewrite_plan
          ~confidence:"high"
-         ~next_tool:"keeper_bash"
-         ~next_args:[ "cmd", `String "scripts/dune-local.sh build <target>" ]
+         ~next_tool:"Bash"
+         ~next_args:[ "command", `String "scripts/dune-local.sh build <target>" ]
          ~instruction:hint
          ~reason:"dune_must_use_local_wrapper"
          ())
   | Unsafe_redirect ->
     Some
       (shell_rewrite_plan
-         ~next_tool:"keeper_fs_edit"
-         ~next_args:[ "path", `String "FILE_PATH"; "content", `String "CONTENT" ]
+         ~next_tool:"Write"
+         ~next_args:[ "file_path", `String "FILE_PATH"; "content", `String "CONTENT" ]
          ~instruction:hint
          ~reason:"redirect_requires_file_edit_tool"
          ())
   | Empty_command ->
     Some
       (shell_rewrite_plan
-         ~next_tool:"keeper_shell"
-         ~next_args:(keeper_shell_rewrite_args "ls" [ "path", `String "." ])
+         ~next_tool:"Bash"
+         ~next_args:[ "command", `String "ls ." ]
          ~instruction:hint
          ~reason:"empty_command_requires_explicit_op"
          ())
@@ -572,9 +565,14 @@ let bash_shape_block_result ~cmd ~cmd_for_log ~env_snapshot block =
                  | Gh_pr_checks -> Some "keeper_pr_status"
                  | _ when Task_probe.looks_like_discovery cmd ->
                    Some "keeper_tasks_list"
-                 | Pipe_or_redirect -> Some "keeper_shell"
-                 | Repo_wide_scan -> Some "keeper_shell"
-                 | Chaining | Substitution -> None);
+                 | Pipe_or_redirect when command_looks_like_search_pipeline cmd ->
+                   Some "Grep"
+                 | Pipe_or_redirect -> Some "Bash"
+                 | Repo_wide_scan
+                   when command_looks_like_repo_wide_git_log_grep cmd ->
+                   Some "Bash"
+                 | Repo_wide_scan -> Some "Grep"
+                 | Chaining | Substitution -> Some "Bash");
             })
        ~extra:
          ([
@@ -584,6 +582,123 @@ let bash_shape_block_result ~cmd ~cmd_for_log ~env_snapshot block =
             "execution_time_ms", `Int 0;
           ]
           @ recovery_extra)
+       ~env_snapshot
+       ())
+
+let strip_wrapping_single_or_double_quotes value =
+  let len = String.length value in
+  if len >= 2
+     && ((Char.equal value.[0] '"' && Char.equal value.[len - 1] '"')
+         || (Char.equal value.[0] '\'' && Char.equal value.[len - 1] '\''))
+  then String.sub value 1 (len - 2)
+  else value
+
+let rec strip_leading_dot_slash value =
+  if String.length value >= 2
+     && Char.equal value.[0] '.'
+     && Char.equal value.[1] '/'
+  then strip_leading_dot_slash (String.sub value 2 (String.length value - 2))
+  else value
+
+let path_suffix_under ~prefix path =
+  let prefix = Keeper_alerting_path.strip_trailing_slashes prefix in
+  let path = Keeper_alerting_path.strip_trailing_slashes path in
+  if String.equal path prefix
+  then Some ""
+  else (
+    let prefix_with_sep = prefix ^ "/" in
+    if String.starts_with ~prefix:prefix_with_sep path
+    then
+      Some
+        (String.sub path (String.length prefix_with_sep)
+           (String.length path - String.length prefix_with_sep))
+    else None)
+
+let keeper_sandbox_relative_cwd ~(config : Coord.config) ~(meta : keeper_meta) ~cwd =
+  let root = Keeper_alerting_path.project_root_of_config config in
+  let sandbox_root =
+    Filename.concat root (Keeper_sandbox.allowed_root_rel_of_meta ~meta)
+    |> Keeper_alerting_path.normalize_path_for_check_stripped
+  in
+  let cwd = Keeper_alerting_path.normalize_path_for_check_stripped cwd in
+  path_suffix_under ~prefix:sandbox_root cwd
+
+let normalized_relative_path_token value =
+  value
+  |> String.trim
+  |> strip_wrapping_single_or_double_quotes
+  |> strip_leading_dot_slash
+  |> Keeper_alerting_path.strip_trailing_slashes
+
+let doubled_cwd_relative_path_plan ~(config : Coord.config) ~(meta : keeper_meta) ~cwd
+      ~cmd =
+  match keeper_sandbox_relative_cwd ~config ~meta ~cwd with
+  | None | Some "" -> None
+  | Some cwd_rel ->
+    let cwd_rel = Keeper_alerting_path.strip_trailing_slashes cwd_rel in
+    Worker_dev_tools.existing_dir_path_values cmd
+    |> List.find_map (fun raw_path ->
+      let path = normalized_relative_path_token raw_path in
+      match path_suffix_under ~prefix:cwd_rel path with
+      | None -> None
+      | Some suffix ->
+        let corrected_path = if suffix = "" then "." else suffix in
+        let corrected_cmd =
+          String_util.replace_substring ~needle:raw_path ~by:corrected_path cmd
+        in
+        let hint =
+          Printf.sprintf
+            "The command path %S already includes cwd %S, so Bash resolves it as \
+             %S/%S. Retry with Bash { \"command\": %S, \"cwd\": %S }, or keep \
+             command=%S and set cwd to the sandbox root. Do not combine both."
+            raw_path
+            cwd_rel
+            cwd_rel
+            raw_path
+            corrected_cmd
+            cwd_rel
+            cmd
+        in
+        Some
+          (shell_rewrite_plan
+             ~confidence:"high"
+             ~next_tool:"Bash"
+             ~next_args:[ "command", `String corrected_cmd; "cwd", `String cwd_rel ]
+             ~instruction:hint
+             ~reason:"cwd_path_prefix_duplicated"
+             ()))
+
+let doubled_cwd_relative_path_result ~cmd ~cmd_for_log ~cwd ~plan ~env_snapshot =
+  let rule_id = "keeper_bash_cwd_path_prefix_duplicated" in
+  Yojson.Safe.to_string
+    (Exec_core.blocked_result_json
+       ~cmd
+       ~error:"keeper_bash_cwd_path_prefix_duplicated"
+       ~reason:
+         "A relative command path repeats the current cwd prefix, which would \
+          make Bash look under cwd/cwd instead of the intended directory."
+       ~hint:plan.instruction
+       ~alternatives:
+         [
+           "Remove the repeated cwd prefix from the command path.";
+           "Or set cwd to the sandbox root and keep the repos/REPO/... path.";
+         ]
+       ~diag:
+         (Some
+            {
+              Exec_core.rule_id;
+              explanation =
+                "The shell cwd and a command path carry the same sandbox-relative \
+                 repo prefix.";
+              rewrite = Some plan.instruction;
+              tool_suggestion = Some plan.next_tool;
+            })
+       ~extra:
+         ([ "execution_time_ms", `Int 0
+          ; "cmd", `String cmd_for_log
+          ; "cwd", `String cwd
+          ]
+          @ recovery_plan_extra ~rule_id plan)
        ~env_snapshot
        ())
 
@@ -1315,6 +1430,15 @@ let handle_keeper_bash
       else (base_profile, base_network_mode, false)
     in
     let sandbox_root = Keeper_sandbox.allowed_root_rel_of_meta ~meta in
+    match doubled_cwd_relative_path_plan ~config ~meta ~cwd ~cmd:validation_cmd with
+    | Some plan ->
+      doubled_cwd_relative_path_result
+        ~cmd
+        ~cmd_for_log
+        ~cwd
+        ~plan
+        ~env_snapshot:env_snap
+    | None ->
     match keeper_bash_shape_block cmd with
     | Some block when
       Option.is_none safe_read_fallback
@@ -1382,17 +1506,17 @@ let handle_keeper_bash
            ~reason:
              "git checkout/switch/branch mutations require a write-enabled preset \
               (Coding/Delivery/Full) and a keeper-owned sandbox repo or \
-              worktree. Clone into your sandbox first \
-              (keeper_shell op=git_clone), then create or enter a worktree \
-              under repos/<repo>/.worktrees/<task>."
+              worktree. Clone into your sandbox with the visible clone tool, \
+              then create or enter a worktree under \
+              repos/<repo>/.worktrees/<task>."
            ~hint:(Printf.sprintf
                     "Use cwd=%srepos/REPO/.worktrees/TASK"
                     sandbox_root)
            ~alternatives:
              [ Printf.sprintf
-                 "Clone the repo first: keeper_shell op=git_clone, then use cwd=%srepos/REPO/.worktrees/TASK."
+                 "Clone the repo first with the visible clone tool, then use cwd=%srepos/REPO/.worktrees/TASK."
                  sandbox_root
-             ; "Use keeper_shell op=git op_cmd='branch -a' to list available branches."
+             ; "Use Bash command='git branch -a' with cwd set to the repo to list available branches."
              ]
            ~retryability:Exec_core.Operator_required
            ~diag:
@@ -1401,7 +1525,7 @@ let handle_keeper_bash
                         "git checkout/switch/branch mutations need a write-enabled preset and a sandbox clone."
                     ; rewrite =
                         Some (Printf.sprintf
-                          "First: keeper_shell op=git_clone. Then: set cwd=%srepos/REPO/.worktrees/TASK"
+                          "First clone the repo with the visible clone tool. Then set cwd=%srepos/REPO/.worktrees/TASK"
                           sandbox_root)
                     ; tool_suggestion = None })
            ~extra:[ "cmd", `String cmd_for_log; "execution_time_ms", `Int 0 ]
@@ -1418,7 +1542,7 @@ let handle_keeper_bash
              "This command modifies state (git push/commit, make deploy, etc.). \
               A write-enabled preset (Coding/Delivery/Full) is required."
            ~alternatives:
-             [ "Read-only alternatives: use keeper_bash for git log, git diff, git status."
+             [ "Read-only alternatives: use Bash for git log, git diff, git status."
              ; "If you need write access, ask the operator to assign a Coding/Delivery/Full preset."
              ]
            ~retryability:Exec_core.Operator_required
@@ -1445,11 +1569,11 @@ let handle_keeper_bash
            ~error:"write_outside_playground_blocked"
            ~reason:
              (Printf.sprintf
-                "Write operations (git push/commit, make deploy, etc.) \
+                 "Write operations (git push/commit, make deploy, etc.) \
                  must run with cwd inside your keeper-owned sandbox clone \
                  or one of its worktrees under %srepos/<repo>/.worktrees/. \
-                 Open a sandbox clone first with keeper_shell op=git_clone \
-                 if needed, then use masc_worktree_create and set cwd to \
+                 Open a sandbox clone first with the visible clone tool if \
+                 needed, then use masc_worktree_create and set cwd to \
                  the returned worktree path."
                 sandbox_root)
            ~hint:(Printf.sprintf
@@ -1458,10 +1582,10 @@ let handle_keeper_bash
                     sandbox_root)
            ~alternatives:
              [ Printf.sprintf
-                 "Clone into your sandbox: keeper_shell op=git_clone, then cd to %srepos/REPO/."
+                 "Clone into your sandbox with the visible clone tool, then set cwd to %srepos/REPO/."
                  sandbox_root
              ; "Create a worktree inside your sandbox with masc_worktree_create."
-             ; "Use keeper_bash with a cwd pointing to your sandbox worktree."
+             ; "Use Bash with a cwd pointing to your sandbox worktree."
              ]
            ~retryability:Exec_core.Operator_required
            ~diag:
@@ -1470,7 +1594,7 @@ let handle_keeper_bash
                         "Write operations must run inside the keeper sandbox. The current cwd is outside the sandbox root."
                     ; rewrite =
                         Some (Printf.sprintf
-                          "Clone into sandbox: keeper_shell op=git_clone, then set cwd=%srepos/REPO/.worktrees/TASK"
+                          "Clone into sandbox with the visible clone tool, then set cwd=%srepos/REPO/.worktrees/TASK"
                           sandbox_root)
                     ; tool_suggestion = None })
            ~extra:[ "cmd", `String cmd_for_log; "cwd", `String cwd; "execution_time_ms", `Int 0 ]
@@ -1554,16 +1678,20 @@ let handle_keeper_bash
           match reason with
           | Worker_dev_tools.Command_not_allowed name
             when String_util.equals_ci name "gh" ->
-            "`gh` is not allowed via keeper_bash. Use keeper_shell with \
-             op=\"gh\" (e.g. keeper_shell op=gh cmd=\"pr list --state open\")."
+            "`gh` is not allowed through raw Bash in this context. Use the \
+             dedicated keeper_pr_* tool when the task is about PRs; otherwise \
+             retry only with a visible GitHub tool or a Bash command allowed by \
+             the active policy."
           | Chain_or_redirect | Pipes_not_allowed | Unsafe_redirect ->
-            "Use separate tool calls instead of chaining. Call keeper_bash once per command."
+            "Use separate tool calls instead of chaining. Call Bash once per command."
           | Direct_dune_invocation ->
             "Use scripts/dune-local.sh instead of bare dune so local builds share the machine-wide lock."
           | Injection | Process_substitution ->
-            "Avoid shell metacharacters. Use keeper_shell with a specific op (rg, find, ls) instead."
+            "Avoid shell metacharacters. Run the discovery command first, then \
+             pass the literal result to the next visible tool."
           | Command_not_allowed _ ->
-            "Check the command for blocked patterns. Use keeper_shell for structured ops (rg, ls, find)."
+            "Check the command for blocked patterns. Use Grep, Read, or one \
+             scoped Bash command depending on the active schema."
           | Empty_command -> "Provide a non-empty command string."
         in
         let hint =
@@ -1575,11 +1703,11 @@ let handle_keeper_bash
           match reason with
           | Worker_dev_tools.Command_not_allowed name
             when String_util.equals_ci name "gh" ->
-            [ "Use keeper_shell with op=\"gh\" for GitHub CLI operations."
-            ; "Example: keeper_shell op=gh cmd=\"pr list --state open\"."
+            [ "Use keeper_pr_list / keeper_pr_status for PR operations when visible."
+            ; "For non-PR GitHub reads, use a single policy-allowed Bash command with --repo OWNER/REPO."
             ]
           | Chain_or_redirect | Pipes_not_allowed | Unsafe_redirect ->
-            [ "Break the pipeline into separate keeper_bash calls."
+            [ "Break the pipeline into separate Bash calls."
             ; "Save intermediate output to a file, then process it in the next call."
             ]
           | Direct_dune_invocation ->
@@ -1587,16 +1715,16 @@ let handle_keeper_bash
             ; "Do not run bare dune build/test/exec in local agent shells."
             ]
           | Injection | Process_substitution ->
-            [ "Use keeper_shell with a specific op (rg, find, ls) for structured queries."
+            [ "Run the discovery command first, then reuse the literal output."
             ; "Avoid $(...) and backtick substitution in commands."
             ]
           | Command_not_allowed _ ->
-            [ "Use keeper_shell for structured ops (rg, ls, find)."
+            [ "Use Grep for searches, Read for one file, or Bash for one allowed command."
             ; "Check if the command is available under a different name or op."
             ]
           | Empty_command ->
             [ "Provide a non-empty command string."
-            ; "Example: keeper_bash cmd='ls -la lib/'."
+            ; "Example: Bash command='ls -la lib/' cwd='repos/REPO'."
             ]
         in
         let alternatives =

--- a/lib/keeper/keeper_shell_bash_shape_messages.ml
+++ b/lib/keeper/keeper_shell_bash_shape_messages.ml
@@ -27,18 +27,18 @@ let bash_shape_block_reason = function
     "gh pr checks exits non-zero when checks are red. That is useful status \
      data, but it trips keeper shell failure and circuit-breaker accounting."
   | Pipe_or_redirect ->
-    "keeper_bash accepts one direct command. Pipes and redirects such as |, \
-     2>&1, 2&1, >/dev/null, <, and | head are blocked before execution."
+    "Bash accepts one direct command. Pipes and redirects such as |, 2>&1, \
+     2&1, >/dev/null, <, and | head are blocked before execution."
   | Chaining ->
-    "keeper_bash accepts one command per call. Chaining with &&, ||, ;, or \
+    "Bash accepts one command per call. Chaining with &&, ||, ;, or \
      newlines is blocked before execution."
   | Substitution ->
     "Command substitution is blocked before execution. Compute values in a \
      separate tool call and pass literal arguments."
   | Repo_wide_scan ->
-    "Repo-wide recursive scans are blocked in raw keeper_bash. Under long \
-     running Keeper fleets they can stampede Docker bind mounts and exhaust \
-     host file descriptors."
+    "Repo-wide recursive scans are blocked in raw Bash. Under long-running \
+     Keeper fleets they can stampede Docker bind mounts and exhaust host file \
+     descriptors."
 
 let bash_shape_block_hint ~cmd = function
   | _ when command_looks_like_task_state_discovery cmd -> task_state_shell_hint
@@ -47,38 +47,37 @@ let bash_shape_block_hint ~cmd = function
      pr view NUMBER --repo OWNER/REPO --json \
      statusCheckRollup,mergeStateStatus,isDraft."
   | Pipe_or_redirect when command_looks_like_search_pipeline cmd ->
-    "Do not pipe grep/rg through keeper_bash. Use keeper_shell op=rg with a \
-     scoped path and pattern instead; if the command starts with cd, pass that \
-     directory as cwd instead of using cd &&."
+    "Do not pipe grep/rg through Bash. Use Grep with a scoped path and \
+     pattern instead; if the command starts with cd, put that directory in the \
+     Grep path or use Bash cwd for a single command."
   | Pipe_or_redirect when
       command_looks_like_find_pipeline cmd || lowercase_contains cmd "find " ->
-    "Do not pipe find through keeper_bash. Use keeper_shell op=find with path, \
-     pattern, and limit instead of | head; if the command needs multiple -name \
-     globs, run one keeper_shell op=find call per pattern."
+    "Do not pipe find through Bash. Remove | head and run one scoped Bash find \
+     command with cwd set when needed; if the command needs multiple -name \
+     globs, run one Bash call per pattern."
   | Pipe_or_redirect ->
     "Remove the pipe or redirect. Run the primary command once and summarize \
-     the returned output; use keeper_shell op=head/tail for file slices."
+     the returned output; use Read for file slices."
   | Chaining when command_looks_like_cd_chained_search cmd ->
     "Do not prepend cd ... && to search commands. Pass the target repo or \
-     worktree as cwd and use keeper_shell op=rg with a scoped path."
+     worktree in the Grep path, or use Bash cwd with a single command."
   | Chaining ->
-    "Split the work into separate keeper_bash calls and use the cwd argument \
-     instead of cd chaining."
+    "Split the work into separate Bash calls and use the cwd argument instead \
+     of cd chaining."
   | Substitution ->
     "Run the discovery command first, then use its literal result in a second \
-     keeper_bash call."
+     Bash call."
   | Repo_wide_scan ->
     if command_looks_like_repo_wide_git_log_grep cmd then
-      "Do not use raw Bash for repo-wide git history grep. Use keeper_shell \
-       op=git_log with cwd set to the repo/worktree, count=5, and grep=<term>."
+      "Do not use raw Bash for repo-wide git history grep. Use Bash command=\"git \
+       log --oneline -5 --grep=<term>\" with cwd set to the repo/worktree."
     else if command_looks_like_repo_wide_rg cmd then
-      "Do not scan repos/ from raw keeper_bash. Use keeper_shell op=rg with a \
-       scoped path such as repos/masc-mcp/lib or repos/oas/src, plus type/glob \
-       filters."
+      "Do not scan repos/ from raw Bash. Use Grep with a scoped path such as \
+       repos/masc-mcp/lib or repos/oas/src, plus type/glob filters."
     else
-      "Use keeper_shell op=rg/find with a scoped path such as lib/, test/, or a \
-       specific repos/REPO subdirectory; avoid scanning . or repos/ from raw \
-       bash."
+      "Use Grep, or one scoped Bash find command, with a path such as lib/, \
+       test/, or a specific repos/REPO subdirectory; avoid scanning . or repos/ \
+       from raw Bash."
 
 let bash_shape_block_alternatives ~cmd = function
   | _ when command_looks_like_task_state_discovery cmd -> task_state_shell_alternatives
@@ -92,59 +91,59 @@ let bash_shape_block_alternatives ~cmd = function
     if command_looks_like_search_pipeline cmd
     then
       [
-        "keeper_shell op=rg pattern=search-term path=lib glob=*.ml";
-        "keeper_shell op=rg pattern=search-term path=repos/REPO/lib glob=*.ml";
-        "keeper_bash cmd='git status' cwd='repos/REPO'";
+        "Grep pattern=search-term path=lib glob=*.ml";
+        "Grep pattern=search-term path=repos/REPO/lib glob=*.ml";
+        "Bash command='git status --short' cwd='repos/REPO'";
       ]
     else if command_looks_like_find_pipeline cmd || lowercase_contains cmd "find "
     then
       [
-        "keeper_shell op=find path=repos/REPO/.worktrees/TASK pattern='*.ml' limit=30";
-        "keeper_shell op=find path=repos/REPO/.worktrees/TASK pattern='*.mli' limit=30";
-        "keeper_shell op=find path=lib pattern='*.ml' limit=30";
+        "Bash command='find . -name \"*.ml\"' cwd='repos/REPO/.worktrees/TASK'";
+        "Bash command='find . -name \"*.mli\"' cwd='repos/REPO/.worktrees/TASK'";
+        "Bash command='find lib -name \"*.ml\"' cwd='repos/REPO'";
       ]
     else
       [
-        "keeper_bash cmd='ls lib/'";
-        "keeper_shell op=head path=file/path lines=20";
-        "keeper_shell op=rg pattern=search-term path=dir/path";
+        "Bash command='ls lib/' cwd='repos/REPO'";
+        "Read file_path=file/path";
+        "Grep pattern=search-term path=dir/path";
       ]
   | Chaining ->
     if command_looks_like_cd_chained_search cmd
     then
       [
-        "keeper_shell op=rg pattern=search-term path=lib glob=*.ml";
-        "keeper_bash cmd='git status' cwd='repos/REPO'";
+        "Grep pattern=search-term path=repos/REPO/lib glob=*.ml";
+        "Bash command='git status --short' cwd='repos/REPO'";
       ]
     else
       [
-        "keeper_bash cmd='git status' cwd='repos/REPO'";
-        "keeper_bash cmd='git log -1' cwd='repos/REPO'";
+        "Bash command='git status --short' cwd='repos/REPO'";
+        "Bash command='git log -1' cwd='repos/REPO'";
       ]
   | Substitution ->
     [
-      "keeper_bash cmd='rg --files lib'";
-      "keeper_bash cmd='cat path/from/previous-step'";
+      "Bash command='rg --files lib' cwd='repos/REPO'";
+      "Read file_path=path/from/previous-step";
     ]
   | Repo_wide_scan ->
     if command_looks_like_repo_wide_git_log_grep cmd
     then
       [
-        "keeper_shell op=git_log cwd=repos/REPO count=5 grep=search-term";
-        "keeper_shell op=git_log cwd=repos/REPO/.worktrees/TASK count=5 grep=search-term";
+        "Bash command='git log --oneline -5 --grep=search-term' cwd='repos/REPO'";
+        "Bash command='git log --oneline -5 --grep=search-term' cwd='repos/REPO/.worktrees/TASK'";
       ]
     else if command_looks_like_repo_wide_rg cmd
     then
       [
-        "keeper_shell op=rg pattern=search-term path=repos/masc-mcp/lib glob=*.ml";
-        "keeper_shell op=rg pattern=search-term path=repos/oas/src glob=*.ml";
-        "keeper_shell op=find path=repos/REPO/lib pattern='*.ml'";
+        "Grep pattern=search-term path=repos/masc-mcp/lib glob=*.ml";
+        "Grep pattern=search-term path=repos/oas/src glob=*.ml";
+        "Bash command='find lib -name \"*.ml\"' cwd='repos/REPO'";
       ]
     else
       [
-        "keeper_shell op=rg pattern=search-term path=lib";
-        "keeper_shell op=find path=lib pattern='*.ml'";
-        "keeper_bash cmd='git log --oneline -20'";
+        "Grep pattern=search-term path=lib";
+        "Bash command='find lib -name \"*.ml\"' cwd='repos/REPO'";
+        "Bash command='git log --oneline -20' cwd='repos/REPO'";
       ]
 
 let recovery_plan_to_json plan =
@@ -160,9 +159,6 @@ let recovery_plan_to_json plan =
 
 let plan ?(confidence = "medium") ~next_tool ~next_args ~instruction ~reason () =
   { next_tool; next_args; instruction; reason; confidence }
-
-let keeper_shell_args op fields =
-  ("op", `String op) :: fields
 
 let bash_shape_block_recovery_plan ~cmd = function
   | _ when command_looks_like_task_state_discovery cmd ->
@@ -189,14 +185,12 @@ let bash_shape_block_recovery_plan ~cmd = function
     Some
       (plan
          ~confidence:"high"
-         ~next_tool:"keeper_shell"
+         ~next_tool:"Grep"
          ~next_args:
-           (keeper_shell_args
-              "rg"
-              [ "pattern", `String "SEARCH_TERM"
-              ; "path", `String "SCOPED_PATH"
-              ; "glob", `String "*.ml"
-              ])
+           [ "pattern", `String "SEARCH_TERM"
+           ; "path", `String "SCOPED_PATH"
+           ; "glob", `String "*.ml"
+           ]
          ~instruction:(bash_shape_block_hint ~cmd Pipe_or_redirect)
          ~reason:"pipe_to_head_rewrite"
          ())
@@ -205,25 +199,22 @@ let bash_shape_block_recovery_plan ~cmd = function
     Some
       (plan
          ~confidence:"high"
-         ~next_tool:"keeper_shell"
+         ~next_tool:"Bash"
          ~next_args:
-           (keeper_shell_args
-              "find"
-              [ "path", `String "SCOPED_PATH"
-              ; "pattern", `String "FILE_GLOB"
-              ; "limit", `Int 30
-              ])
+           [ "command", `String "find . -name FILE_GLOB"
+           ; "cwd", `String "SCOPED_REPO_OR_WORKTREE_CWD"
+           ]
          ~instruction:(bash_shape_block_hint ~cmd Pipe_or_redirect)
          ~reason:"find_head_rewrite"
          ())
   | Pipe_or_redirect ->
     Some
       (plan
-         ~next_tool:"keeper_shell"
+         ~next_tool:"Bash"
          ~next_args:
-           (keeper_shell_args
-              "head"
-              [ "path", `String "FILE_PATH"; "lines", `Int 80 ])
+           [ "command", `String "PRIMARY_COMMAND_WITHOUT_PIPE_OR_REDIRECT"
+           ; "cwd", `String "REPO_OR_WORKTREE_CWD"
+           ]
          ~instruction:(bash_shape_block_hint ~cmd Pipe_or_redirect)
          ~reason:"pipe_or_redirect_blocked"
          ())
@@ -231,36 +222,34 @@ let bash_shape_block_recovery_plan ~cmd = function
     Some
       (plan
          ~confidence:"high"
-         ~next_tool:"keeper_shell"
+         ~next_tool:"Grep"
          ~next_args:
-           (keeper_shell_args
-              "rg"
-              [ "cwd", `String "REPO_OR_WORKTREE_CWD"
-              ; "pattern", `String "SEARCH_TERM"
-              ; "path", `String "SCOPED_PATH"
-              ])
+           [ "pattern", `String "SEARCH_TERM"
+           ; "path", `String "REPO_OR_WORKTREE_CWD/SCOPED_PATH"
+           ; "glob", `String "*.ml"
+           ]
          ~instruction:(bash_shape_block_hint ~cmd Chaining)
          ~reason:"cd_chained_search_rewrite"
          ())
   | Chaining ->
     Some
       (plan
-         ~next_tool:"keeper_shell"
+         ~next_tool:"Bash"
          ~next_args:
-           (keeper_shell_args
-              "rg"
-              [ "pattern", `String "SEARCH_TERM"; "path", `String "SCOPED_PATH" ])
+           [ "command", `String "SINGLE_COMMAND"
+           ; "cwd", `String "REPO_OR_WORKTREE_CWD"
+           ]
          ~instruction:(bash_shape_block_hint ~cmd Chaining)
          ~reason:"command_chaining_blocked"
          ())
   | Substitution ->
     Some
       (plan
-         ~next_tool:"keeper_shell"
+         ~next_tool:"Bash"
          ~next_args:
-           (keeper_shell_args
-              "rg"
-              [ "pattern", `String "DISCOVERY_TERM"; "path", `String "SCOPED_PATH" ])
+           [ "command", `String "DISCOVERY_COMMAND_WITHOUT_SUBSTITUTION"
+           ; "cwd", `String "REPO_OR_WORKTREE_CWD"
+           ]
          ~instruction:(bash_shape_block_hint ~cmd Substitution)
          ~reason:"substitution_requires_discovery_first"
          ())
@@ -269,14 +258,11 @@ let bash_shape_block_recovery_plan ~cmd = function
       Some
         (plan
            ~confidence:"high"
-           ~next_tool:"keeper_shell"
+           ~next_tool:"Bash"
            ~next_args:
-             (keeper_shell_args
-                "git_log"
-                [ "cwd", `String "REPO_OR_WORKTREE_CWD"
-                ; "count", `Int 5
-                ; "grep", `String "SEARCH_TERM"
-                ])
+             [ "command", `String "git log --oneline -5 --grep=SEARCH_TERM"
+             ; "cwd", `String "REPO_OR_WORKTREE_CWD"
+             ]
            ~instruction:(bash_shape_block_hint ~cmd Repo_wide_scan)
            ~reason:"repo_wide_git_history_scan_blocked"
            ())
@@ -284,14 +270,12 @@ let bash_shape_block_recovery_plan ~cmd = function
       Some
         (plan
            ~confidence:"high"
-           ~next_tool:"keeper_shell"
+           ~next_tool:"Grep"
            ~next_args:
-             (keeper_shell_args
-                "rg"
-                [ "pattern", `String "SEARCH_TERM"
-                ; "path", `String "SCOPED_PATH"
-                ; "glob", `String "*.ml"
-                ])
+             [ "pattern", `String "SEARCH_TERM"
+             ; "path", `String "SCOPED_PATH"
+             ; "glob", `String "*.ml"
+             ]
            ~instruction:(bash_shape_block_hint ~cmd Repo_wide_scan)
            ~reason:"repo_wide_scan_blocked"
            ())

--- a/lib/keeper/keeper_shell_bash_task_probe.ml
+++ b/lib/keeper/keeper_shell_bash_task_probe.ml
@@ -94,9 +94,8 @@ let looks_like_discovery cmd =
 
 let hint =
   "Do not inspect task state by guessing .masc/backlog.json or repo-local \
-   backlog/task files from keeper_bash. Use keeper_tasks_list for \
-   task/backlog state and keeper_context_status for current_task_id/sandbox \
-   paths."
+   backlog/task files from Bash. Use keeper_tasks_list for task/backlog state \
+   and keeper_context_status for current_task_id/sandbox paths."
 ;;
 
 let alternatives =

--- a/lib/keeper/keeper_shell_bash_task_state.ml
+++ b/lib/keeper/keeper_shell_bash_task_state.ml
@@ -96,9 +96,8 @@ let command_looks_like_task_state_discovery cmd =
 
 let task_state_shell_hint =
   "Do not inspect task state by guessing .masc/backlog.json or repo-local \
-   backlog/task files from keeper_bash. Use keeper_tasks_list for \
-   task/backlog state and keeper_context_status for current_task_id/sandbox \
-   paths."
+   backlog/task files from Bash. Use keeper_tasks_list for task/backlog state \
+   and keeper_context_status for current_task_id/sandbox paths."
 
 let task_state_shell_alternatives =
   [ "keeper_tasks_list include_done=false"

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -435,8 +435,8 @@ let resolve_sandbox_root_git_cwd ~(config : Coord.config) ~(meta : keeper_meta) 
           (Printf.sprintf
              "sandbox root cannot run git/gh: mount point %s is not a git repository and \
               no sandbox git clones exist under repos/. First clone a repo with \
-              keeper_shell op=git_clone path=\"repos/<repo>\", then retry with \
-              cwd=\"repos/<repo>\" or cwd=\"repos/<repo>/.worktrees/<task>\"."
+              the visible clone tool, then retry with cwd=\"repos/<repo>\" or \
+              cwd=\"repos/<repo>/.worktrees/<task>\"."
              host_root) )
     | example_repo :: _ as many ->
       (* #10680: keeper-executor-agent saw 17 events / 5min in a single
@@ -461,12 +461,9 @@ let resolve_sandbox_root_git_cwd ~(config : Coord.config) ~(meta : keeper_meta) 
           (Printf.sprintf
              "sandbox root cannot run git/gh: mount point %s is not a git repository and \
               multiple sandbox repos exist. Set cwd explicitly before retrying. Example \
-              next call: Bash { \"command\": %S, \"cwd\": %S }. Legacy internal form: \
-              keeper_bash { \"cmd\": %S, \"cwd\": %S }. Available repos: %s. Do not \
-              retry the same cmd from sandbox root."
+              next call: Bash { \"command\": %S, \"cwd\": %S }. Available repos: %s. \
+              Do not retry the same cmd from sandbox root."
              host_root
-             suggested_cmd
-             suggested_cwd
              suggested_cmd
              suggested_cwd
              (String.concat ", " many)) )))

--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -919,11 +919,10 @@ let handle_keeper_shell
          ; "op", `String op
          ; "error", `String "keeper_shell_bash_deprecated"
          ; "hint", `String
-             "keeper_shell is now structured-only and no longer executes \
-              op=bash. Use Bash or keeper_bash for command execution; use \
-              keeper_shell only for structured ops such as rg, ls, cat, \
-              git_status, git_log, git_diff, git_clone, and gh."
-         ; "suggested_tool", `String "keeper_bash"
+             "The structured shell no longer executes op=bash. Use the public \
+              Bash tool for command execution; use Grep and Read for search and \
+              file inspection when they are visible."
+         ; "suggested_tool", `String "Bash"
          ; "suggested_public_tool", `String "Bash"
          ; "supported_ops",
              `List

--- a/lib/keeper/keeper_tool_deterministic_error.ml
+++ b/lib/keeper/keeper_tool_deterministic_error.ml
@@ -39,7 +39,7 @@ let to_string = function
   | Command_blocked ->
     "keeper shell command blocked by policy; follow recovery_plan instead"
   | Command_shape_blocked ->
-    "keeper_bash command-shape blocked (pipes/redirects/chaining/substitution/scan)"
+    "Bash command-shape blocked (pipes/redirects/chaining/substitution/scan)"
   | Task_state_probe_blocked ->
     "raw shell task-state probe blocked; use keeper task/context tools"
   | Destructive_operation_blocked ->
@@ -51,7 +51,7 @@ let to_string = function
   | Completion_contract_violation ->
     "keeper completion contract violated (e.g. require_tool_use)"
   | Keeper_shell_op_required ->
-    "raw keeper_bash rejected; caller must use keeper_shell op=<verb>"
+    "raw Bash rejected; caller must use the visible structured tool from the recovery plan"
   | Workflow_rejection_blocked ->
     "typed workflow_rejection failure_class returned by the tool"
   | Git_ref_precondition_failed ->

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -474,15 +474,15 @@ let test_keeper_bash_repo_wide_scan_hints_use_structured_tools () =
     (match tag with Some "repo_wide_scan" -> true | _ -> false);
   (match hint cmd with
    | Some msg ->
-     Alcotest.(check bool) "git history hint points to git_log" true
-       (String_util.contains_substring msg "keeper_shell op=git_log");
+     Alcotest.(check bool) "git history hint points to Bash git log" true
+       (String_util.contains_substring msg "Bash command=\"git log");
      Alcotest.(check bool) "git history hint mentions grep" true
        (String_util.contains_substring msg "grep=<term>")
    | None -> Alcotest.fail "expected repo-wide git log hint");
   (match hint {|rg "add_comment" repos/ --include '*.ml' --include '*.mli' -l|} with
    | Some msg ->
-     Alcotest.(check bool) "rg hint points to structured rg" true
-       (String_util.contains_substring msg "keeper_shell op=rg");
+     Alcotest.(check bool) "rg hint points to Grep" true
+       (String_util.contains_substring msg "Use Grep");
      Alcotest.(check bool) "rg hint discourages repos root" true
        (String_util.contains_substring msg "Do not scan repos/")
    | None -> Alcotest.fail "expected repo-wide rg hint")
@@ -1153,6 +1153,46 @@ let test_keeper_bash_single_repo_root_recovers_top_level_find () =
      |> Json.to_string
      |> fun output -> String_util.contains_substring output "marker.ml")
 
+let test_keeper_bash_blocks_doubled_repo_prefix_with_public_alias_plan () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let meta = make_readonly_meta "double-prefix-bash" in
+  let playground = Filename.concat base_path (playground_path_of meta.name) in
+  let repo_root = Filename.concat playground "repos/masc-mcp" in
+  ensure_dir (Filename.concat repo_root ".worktrees");
+  let raw =
+    Keeper_exec_shell.handle_keeper_bash
+      ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None ~exec_cache:None
+      ~config ~meta
+      ~args:
+        (`Assoc
+          [
+            ("cmd", `String "ls repos/masc-mcp/.worktrees/");
+            ("cwd", `String repo_root);
+          ])
+      ()
+  in
+  let json = Yojson.Safe.from_string raw in
+  let recovery_plan = Json.member "recovery_plan" json in
+  let next_args = Json.member "next_args" recovery_plan in
+  Alcotest.(check bool) "double-prefix is blocked before exec" false
+    (json |> Json.member "ok" |> Json.to_bool);
+  Alcotest.(check (option string))
+    "double-prefix error"
+    (Some "keeper_bash_cwd_path_prefix_duplicated")
+    (parse_error_field raw);
+  Alcotest.(check string) "required next tool uses public alias" "Bash"
+    (Json.member "required_next_tool" json |> Json.to_string);
+  Alcotest.(check string) "rewritten command removes duplicated repo prefix"
+    "ls .worktrees"
+    (Json.member "command" next_args |> Json.to_string);
+  Alcotest.(check string) "rewritten cwd remains repo-relative"
+    "repos/masc-mcp"
+    (Json.member "cwd" next_args |> Json.to_string)
+
 let test_keeper_bash_safe_rg_fallback_allows_escaped_regex_pipe () =
   with_eio_fs @@ fun () ->
   let base_path, config = make_config () in
@@ -1650,12 +1690,12 @@ let test_keeper_shell_bash_op_is_deprecated () =
   (match parse_hint raw with
    | None -> Alcotest.fail ("expected hint field, got: " ^ raw)
    | Some hint ->
-     Alcotest.(check bool) "hint points to keeper_bash" true
-       (String_util.contains_substring hint "keeper_bash");
      Alcotest.(check bool) "hint points to Bash alias" true
        (String_util.contains_substring hint "Bash");
-     Alcotest.(check bool) "hint keeps keeper_shell structured" true
-       (String_util.contains_substring hint "structured ops"))
+     Alcotest.(check bool) "hint avoids internal keeper_bash" false
+       (String_util.contains_substring hint "keeper_bash");
+     Alcotest.(check bool) "hint avoids internal keeper_shell" false
+       (String_util.contains_substring hint "keeper_shell"))
 
 let test_keeper_shell_bash_op_does_not_execute () =
   with_eio_fs @@ fun () ->
@@ -2029,6 +2069,8 @@ let () =
         test_keeper_bash_safe_cd_fallback_executes_scoped_read;
       Alcotest.test_case "single repo root recovers top-level find" `Quick
         test_keeper_bash_single_repo_root_recovers_top_level_find;
+      Alcotest.test_case "double repo prefix gets public Bash recovery plan" `Quick
+        test_keeper_bash_blocks_doubled_repo_prefix_with_public_alias_plan;
       Alcotest.test_case "safe rg fallback allows escaped regex pipe" `Quick
         test_keeper_bash_safe_rg_fallback_allows_escaped_regex_pipe;
       Alcotest.test_case "safe dev-null redirect executes scoped grep" `Quick

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -1206,8 +1206,8 @@ let test_sandbox_root_git_cwd_zero_repo_blocks_before_exec () =
   | Some msg ->
     Alcotest.(check bool) "mentions no sandbox clones" true
       (contains_substring msg "no sandbox git clones");
-    Alcotest.(check bool) "mentions git_clone recovery" true
-      (contains_substring msg "keeper_shell op=git_clone");
+    Alcotest.(check bool) "mentions clone recovery" true
+      (contains_substring msg "visible clone tool");
     Alcotest.(check bool) "mentions cwd recovery" true
       (contains_substring msg "cwd=\"repos/<repo>\"")
 
@@ -1558,12 +1558,13 @@ let test_bash_blocks_validator_safe_pipe_redirect_with_recovery_plan () =
     (parse_string_field raw "error");
   Alcotest.(check string)
     "required next tool"
-    "keeper_shell"
+    "Bash"
     (Json.member "required_next_tool" json |> Json.to_string);
   Alcotest.(check string)
-    "recovery op"
-    "head"
-    Yojson.Safe.Util.(recovery_plan |> member "next_args" |> member "op" |> to_string);
+    "recovery command placeholder"
+    "PRIMARY_COMMAND_WITHOUT_PIPE_OR_REDIRECT"
+    Yojson.Safe.Util.(
+      recovery_plan |> member "next_args" |> member "command" |> to_string);
   Alcotest.(check bool) "docker was not invoked" false
     (Sys.file_exists log_path)
 
@@ -1694,16 +1695,16 @@ let test_bash_search_pipeline_exposes_structured_recovery_plan () =
     (parse_string_field raw "shape_block");
   Alcotest.(check string)
     "required_next_tool"
-    "keeper_shell"
+    "Grep"
     (Json.member "required_next_tool" json |> Json.to_string);
   Alcotest.(check string)
     "recovery next tool"
-    "keeper_shell"
+    "Grep"
     (Json.member "next_tool" recovery_plan |> Json.to_string);
   Alcotest.(check string)
-    "recovery op"
-    "rg"
-    (Json.member "op" next_args |> Json.to_string);
+    "recovery pattern"
+    "SEARCH_TERM"
+    (Json.member "pattern" next_args |> Json.to_string);
   Alcotest.(check bool)
     "same args retry forbidden"
     true

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -1220,7 +1220,7 @@ let test_workflow_rejection_recovery_fields_mark_loop () =
 
 let test_deterministic_recovery_plan_fields_promote_next_tool () =
   let raw =
-    {|{"ok":false,"error":"command_blocked","recovery_plan":{"kind":"structured_tool_rewrite","next_tool":"keeper_shell","next_args":{"op":"rg","path":"lib"},"instruction":"Use keeper_shell op=rg.","reason":"shell_shape_requires_structured_op","confidence":"high","do_not_retry_same_args":true}}|}
+    {|{"ok":false,"error":"command_blocked","recovery_plan":{"kind":"structured_tool_rewrite","next_tool":"Grep","next_args":{"pattern":"term","path":"lib"},"instruction":"Use Grep with a scoped path.","reason":"shell_shape_requires_visible_search_tool","confidence":"high","do_not_retry_same_args":true}}|}
   in
   let fields = Keeper_tools_oas.deterministic_recovery_plan_fields raw in
   let normalized =
@@ -1230,14 +1230,14 @@ let test_deterministic_recovery_plan_fields_promote_next_tool () =
       raw
   in
   let json = parse normalized in
-  check string "required next tool" "keeper_shell" (json_string "required_next_tool" json);
+  check string "required next tool" "Grep" (json_string "required_next_tool" json);
   let plan = Yojson.Safe.Util.member "recovery_plan" json in
-  check string "plan next tool" "keeper_shell" (json_string "next_tool" plan);
+  check string "plan next tool" "Grep" (json_string "next_tool" plan);
   check
     string
-    "plan op"
-    "rg"
-    Yojson.Safe.Util.(member "next_args" plan |> member "op" |> to_string)
+    "plan pattern"
+    "term"
+    Yojson.Safe.Util.(member "next_args" plan |> member "pattern" |> to_string)
 ;;
 
 let test_workflow_rejection_same_args_short_circuits_after_first_failure () =


### PR DESCRIPTION
## Summary

- Sync model-facing Keeper Bash recovery guidance to public aliases (`Bash`, `Grep`, `Read`, `Write`) instead of internal `keeper_shell` / `keeper_bash` examples.
- Add a pre-exec guard for `cwd=repos/REPO` plus command paths that repeat `repos/REPO/...`, returning a structured public `Bash` recovery plan before the Docker/path failure.
- Update task-state and Docker cwd hints plus focused tests for the new recovery surfaces.

## Proof / validation

- Live prompt drift proof: repo `config/prompts` and `/Users/dancer/me/.masc/config/prompts` matched via `diff -qr`; `/api/v1/prompts` showed no overrides and no `keeper_shell op=` / `keeper_bash cmd=` in effective Keeper prompt text.
- Runtime override proof: `/Users/dancer/me/.masc/prompt_overrides.json` is `{}` after backing up and clearing the stale `keeper.world` override.
- Static checks: `ocamlformat --check` on touched OCaml files passed; `git diff --check` passed; targeted grep for old internal recovery hint patterns returned no matches.
- Focused Dune check attempted: `scripts/dune-local.sh build test/test_keeper_bash_safety.exe test/test_keeper_shell_docker_route.exe test/test_keeper_tools_oas.exe`. It was blocked twice by unrelated live `dune build` processes outside the wrapper, with `dune-local` refusing to start to protect the machine-wide Dune lock.

## Notes

This is a draft PR because local focused Dune validation is still blocked by unrelated host-level Dune activity; CI should provide the full compile/test signal once scheduled.