### PR TITLE
fix(dashboard): type generic board post fixture

### DIFF
--- a/dashboard/src/components/ide/ide-conversation-rail.test.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.test.ts
@@ -12,6 +12,7 @@ import { activeIdeFile, ideContextFocus } from './ide-state'
 import { clearTraces, keeperTraceState } from './keeper-trace-store'
 import { ideReplayUntilMs, setIdeReplayUntilMs } from './ide-replay-state'
 import { cursorOverlaySignal } from './keeper-cursor-overlay'
+import type { BoardPost } from '../../types/core'
 
 function stubEmptyConversationFetch(): void {
   vi.stubGlobal('fetch', vi.fn(async (url: string) => {
@@ -150,7 +151,7 @@ describe('IdeConversationRail', () => {
   })
 
   it('does not reanchor generic board posts when the active file changes', () => {
-    const posts = [{
+    const posts: BoardPost[] = [{
       id: 'thread-generic',
       author: 'sangsu',
       title: 'File-level note',


### PR DESCRIPTION
## Summary
- type the generic IDE conversation board-post fixture as BoardPost so author_identity.kind stays narrowed to the canonical literal union
- unblocks Dashboard typecheck failures seen on current PR merge refs

## Validation
- pnpm install --offline --frozen-lockfile
- pnpm run typecheck
- git diff --check