### PR TITLE
refactor(dashboard): add MONITOR_LANE_SECTIONS classifier to status.ts

### DIFF
--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -13,6 +13,26 @@ export type StatusSection =
   | 'feature-health'
   | 'cognition'
 
+// Monitor sidebar exposes 4 keeper-facing lanes; the remaining sections are
+// reachable only via deep links or hidden diagnostic routes. The same flag
+// lives on each entry's `hidden: true` in navigation.ts — this Set mirrors
+// that classification so the dispatcher and future grouped layouts can ask
+// without re-reading the nav config. Source of truth stays in navigation.ts.
+const MONITOR_LANE_SECTIONS: ReadonlySet<StatusSection> = new Set<StatusSection>([
+  'agents',
+  'fleet-health',
+  'runtime',
+  'observatory',
+])
+
+export function isMonitorLane(section: StatusSection): boolean {
+  return MONITOR_LANE_SECTIONS.has(section)
+}
+
+export function isHiddenDiagnostic(section: StatusSection): boolean {
+  return !MONITOR_LANE_SECTIONS.has(section)
+}
+
 const LazyAgentsUnified = lazy(async () => ({
   default: (await import('./agents-unified')).AgentsUnified,
 }))


### PR DESCRIPTION
## Goal
`dashboard/src/components/status.ts`에 `MONITOR_LANE_SECTIONS` ReadonlySet과 `isMonitorLane`/`isHiddenDiagnostic` 두 헬퍼 추가. navigation.ts의 `hidden: true` 분류를 타입 미러로 재사용 가능하게 만들어, 후속 grouped-layout 작업의 진입점 확보.

## Changed files
- `dashboard/src/components/status.ts` — 20+/0- (Set + 2 helper + 6 lines comment)

## Self-review
- 목표: 분류 SSOT는 navigation.ts 유지, status dispatcher에 타입화된 미러만 추가
- 범위: 1 파일, helper 함수 2개 + Set 1개. 호출처 추가 안 함
- 동작 변화: 0. helper들은 export됐지만 호출되지 않음 — 후속 PR이 wire
- 로컬 typecheck: 본 변경 관련 0 에러. (baseline error `credential-settings.ts(13,3) TS6133`은 origin/main에 이미 존재 — 본 PR과 무관)

## Why this PR is small on purpose
Monitor IA 리뷰가 식별한 갭 중 하나는 status.ts dispatcher가 visible lane과 hidden diagnostic을 같은 평면 switch로 처리한다는 점. 본 PR은 *classifier 추가만* 수행 (호출처 미추가). 후속 PR이 dispatcher를 grouped layout으로 재구성할 때 이 helper를 사용.

## Test plan
- [ ] CI typecheck — baseline error는 본 PR과 무관, 본 변경 관련 0
- [ ] CI lint
- [ ] 동작 회귀 없음 (호출처 없음)

## References
- Monitor IA 리뷰 리포트: `/Users/dancer/me/memory/masc-oas-dashboard-monitor-ia-report-2026-05-20.html`
- SSOT classifier 위치: `dashboard/src/config/navigation.ts` (visible 4 lane + hidden 6 diagnostic)
- 짝 PR: #17003 (navigation.ts cognition stale 주석 정정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)