### PR TITLE
refactor(dashboard): name the hidden-diagnostic fallback refresh plan

### DIFF
--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -78,6 +78,17 @@ type RefreshTask =
   | 'operatorSnapshot'
   | 'operatorRoomDigest'
 
+// Monitor data ownership is partitioned by section. Two tiers:
+//   Tier 1 — visible lanes (agents / fleet-health / runtime / observatory)
+//            each declare their own view-aware or static refresh plan.
+//   Tier 2 — hidden diagnostic sections (cascade-config / doctor /
+//            transport-health / feature-health) share an identical light
+//            fallback plan. Their mounted panels own telemetry polling, so
+//            route visits only need to refresh namespace/mission context.
+//   Outliers — `journey` (execution only) and `cognition` (4-source plan
+//            with autoresearch) keep dedicated branches above.
+const HIDDEN_DIAGNOSTIC_FALLBACK_PLAN: readonly RefreshTask[] = ['namespaceTruth', 'missionSnapshot']
+
 export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params'>): RefreshTask[] {
   switch (routeState.tab) {
     case 'overview':
@@ -110,7 +121,9 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
         // Mounted fleet-health panels own telemetry/tool/governance polling.
         return ['namespaceTruth']
       }
-      return ['namespaceTruth', 'missionSnapshot']
+      // Hidden diagnostic sections fall through here. See the
+      // HIDDEN_DIAGNOSTIC_FALLBACK_PLAN definition above for the tier split.
+      return [...HIDDEN_DIAGNOSTIC_FALLBACK_PLAN]
     case 'command':
       if (routeState.params.view === 'inspector') {
         return ['inspector']


### PR DESCRIPTION
## Goal
`dashboard/src/tab-refresh.ts`의 monitoring 분기 끝 fall-through(`return ['namespaceTruth', 'missionSnapshot']`)에 이름을 부여. 4 hidden diagnostic 섹션(cascade-config / doctor / transport-health / feature-health)이 공유하는 plan임을 명시.

## Changed files
- `dashboard/src/tab-refresh.ts` — 14+/1- (const + 2-tier 주석 + 사용처 spread)

## Self-review
- 목표: 데이터 ownership 분할 구조를 코드에 가시화
- 범위: 1 파일. 새 module-level const 1개 + 인라인 주석 + return 한 줄 변경
- 동작 변화: 0. spread `[...HIDDEN_DIAGNOSTIC_FALLBACK_PLAN]`로 기존 `RefreshTask[]` 반환 타입 유지 (readonly array → mutable copy)
- 로컬 typecheck: 본 변경 관련 0 에러. (baseline error는 origin/main에 이미 존재)

## Background
Monitor IA 리뷰가 발견: tab-refresh.ts는 *이미* visible lane(view-aware plan)과 hidden diagnostic(동일 light fallback)을 다르게 다루지만, fall-through return으로 표현되어 코드에서 의도가 드러나지 않음. 본 PR은 *문서화*에 가까운 refactor — fallback에 이름을 주고, tier 분할을 인라인 주석으로 명시.

## Outliers (주석에 명시됨)
- `journey` — execution 1개만 → 별도 분기 유지
- `cognition` — 4-source plan(autoresearch 포함) → 별도 분기 유지 (hidden 상태와 모순되는 *무거운* refresh plan은 추후 IA 결정 필요)

## Test plan
- [ ] CI typecheck — readonly array spread 패턴 OK
- [ ] CI lint
- [ ] 기존 `tab-refresh.test.ts` Phase 1 contract 위반 없음 (fallback plan의 actual return value 동일)

## References
- Monitor IA 리뷰 리포트: `/Users/dancer/me/memory/masc-oas-dashboard-monitor-ia-report-2026-05-20.html`
- 형제 PR: #17003 (navigation.ts 주석), 또 하나 (status.ts MONITOR_LANE_SECTIONS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)