### PR TITLE
fix(dashboard): separate active vs paused keeper counts

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -231,6 +231,7 @@ describe('countRuntimeKinds', () => {
     expect(result).toEqual({
       agents: 0,
       keepers: 1,
+      pausedKeepers: 0,
       totalRuntimes: 1,
     })
   })
@@ -258,6 +259,7 @@ describe('countRuntimeKinds', () => {
     expect(result).toEqual({
       agents: 0,
       keepers: 1,
+      pausedKeepers: 0,
       totalRuntimes: 1,
     })
   })
@@ -286,6 +288,7 @@ describe('countRuntimeKinds', () => {
     expect(result).toEqual({
       agents: 0,
       keepers: 1,
+      pausedKeepers: 0,
       totalRuntimes: 1,
     })
   })
@@ -310,6 +313,7 @@ describe('countRuntimeKinds', () => {
     expect(result).toEqual({
       agents: 1,
       keepers: 1,
+      pausedKeepers: 0,
       totalRuntimes: 2,
     })
   })

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -436,16 +436,19 @@ function countAgentsByStatus(
 export function countRuntimeKinds(
   agentList: Agent[],
   keeperList: Keeper[],
-): { agents: number; keepers: number; totalRuntimes: number } {
+): { agents: number; keepers: number; pausedKeepers: number; totalRuntimes: number } {
   const runtimeKeepers = runtimeBackedKeepers(keeperList)
   const rosterAgents = buildAgentRoster(agentList, runtimeKeepers)
   const keeperLookup = buildKeeperRuntimeLookup(runtimeKeepers)
-  const keeperCount = scopeAgentsByKeeperFilter(rosterAgents, runtimeKeepers, 'keeper-only', keeperLookup).length
+  const allKeepers = scopeAgentsByKeeperFilter(rosterAgents, runtimeKeepers, 'keeper-only', keeperLookup)
+  const pausedKeepers = allKeepers.filter(a => isKeeperPaused(a.keeper)).length
+  const runningKeepers = allKeepers.length - pausedKeepers
   const agentCount = scopeAgentsByKeeperFilter(rosterAgents, runtimeKeepers, 'agent-only', keeperLookup).length
 
   return {
     agents: agentCount,
-    keepers: keeperCount,
+    keepers: runningKeepers,
+    pausedKeepers,
     totalRuntimes: rosterAgents.length,
   }
 }
@@ -496,15 +499,18 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
   // Derive runtime kind counts from memoized roster (avoids duplicate buildAgentRoster call)
   const liveRuntimeCounts = useMemo(() => {
-    const keeperCount = scopeAgentsByKeeperFilter(rosterAgents, runtimeKeeperList, 'keeper-only', keeperRuntimeLookup).length
+    const allKeepers = scopeAgentsByKeeperFilter(rosterAgents, runtimeKeeperList, 'keeper-only', keeperRuntimeLookup)
+    const pausedCount = allKeepers.filter(a => isKeeperPaused(a.keeper)).length
+    const runningCount = allKeepers.length - pausedCount
     const agentCount = scopeAgentsByKeeperFilter(rosterAgents, runtimeKeeperList, 'agent-only', keeperRuntimeLookup).length
-    return { agents: agentCount, keepers: keeperCount, totalRuntimes: rosterAgents.length }
+    return { agents: agentCount, keepers: runningCount, pausedKeepers: pausedCount, totalRuntimes: rosterAgents.length }
   }, [rosterAgents, runtimeKeeperList, keeperRuntimeLookup])
 
   const runtimeCounts = resolveRuntimeCounts({
     executionLoaded: executionLoaded.value,
     agentsCount: liveRuntimeCounts.agents,
     keepersCount: liveRuntimeCounts.keepers,
+    pausedKeepersCount: liveRuntimeCounts.pausedKeepers,
     namespaceTruthCounts: namespaceTruth.value?.root.counts,
     namespaceTruthConfiguredKeepers: namespaceTruth.value?.root.configured_keepers,
     shellCounts: shellCounts.value,
@@ -621,10 +627,11 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     title: FILTER_META[key].description,
   }))
   const liveKeepers = runtimeCounts.live.keepers
+  const livePausedKeepers = runtimeCounts.live.pausedKeepers
   const configuredKeepers = runtimeCounts.configured.keepers
-  const configuredKeeperDelta = Math.max(0, configuredKeepers - liveKeepers)
+  const configuredKeeperDelta = Math.max(0, configuredKeepers - liveKeepers - livePausedKeepers)
   const scopeLabel = keeperFilter === 'keeper-only'
-    ? `키퍼 활성 ${liveKeepers}개 / 설정 ${configuredKeepers}개`
+    ? `키퍼 활성 ${liveKeepers}개${livePausedKeepers > 0 ? ` / 일시정지 ${livePausedKeepers}개` : ''} / 설정 ${configuredKeepers}개`
     : keeperFilter === 'agent-only'
       ? `일반 에이전트 ${runtimeCounts.live.agents}개`
       : `에이전트/키퍼 활성 ${runtimeCounts.live.totalRuntimes}개 / 설정 ${runtimeCounts.configured.totalRuntimes}개`

--- a/dashboard/src/components/agents-unified.test.ts
+++ b/dashboard/src/components/agents-unified.test.ts
@@ -74,7 +74,7 @@ vi.mock('../namespace-truth-store', () => ({
 }))
 vi.mock('../runtime-counts', () => ({
   resolveRuntimeCounts: vi.fn(() => ({
-    live: { agents: 0, keepers: 0, tasks: 0, totalRuntimes: 0, available: false },
+    live: { agents: 0, keepers: 0, pausedKeepers: 0, tasks: 0, totalRuntimes: 0, available: false },
     configured: { keepers: 0, totalRuntimes: 0, source: 'none' },
     source: 'unknown',
   })),
@@ -88,7 +88,7 @@ const mockResolveRuntimeCounts = vi.mocked(resolveRuntimeCounts)
 const runtimeCounts = (
   overrides: Partial<ReturnType<typeof resolveRuntimeCounts>>,
 ): ReturnType<typeof resolveRuntimeCounts> => ({
-  live: { agents: 0, keepers: 0, tasks: 0, totalRuntimes: 0, available: false },
+  live: { agents: 0, keepers: 0, pausedKeepers: 0, tasks: 0, totalRuntimes: 0, available: false },
   configured: { keepers: 0, totalRuntimes: 0, source: 'none' },
   source: 'unknown',
   ...overrides,
@@ -166,7 +166,7 @@ describe('AgentsUnified', () => {
 
   it('shows runtime truth banner when a configured baseline is known', () => {
     mockResolveRuntimeCounts.mockReturnValue(runtimeCounts({
-      live: { agents: 3, keepers: 2, tasks: 0, totalRuntimes: 5, available: true },
+      live: { agents: 3, keepers: 2, pausedKeepers: 0, tasks: 0, totalRuntimes: 5, available: true },
       configured: { keepers: 4, totalRuntimes: 7, source: 'namespace-truth' },
       source: 'execution',
     }))
@@ -179,7 +179,7 @@ describe('AgentsUnified', () => {
 
   it('shows runtime truth banner without delta when live equals configured', () => {
     mockResolveRuntimeCounts.mockReturnValue(runtimeCounts({
-      live: { agents: 3, keepers: 2, tasks: 0, totalRuntimes: 5, available: true },
+      live: { agents: 3, keepers: 2, pausedKeepers: 0, tasks: 0, totalRuntimes: 5, available: true },
       configured: { keepers: 2, totalRuntimes: 5, source: 'namespace-truth' },
       source: 'execution',
     }))
@@ -190,7 +190,7 @@ describe('AgentsUnified', () => {
 
   it('hides runtime truth banner when no configured baseline is available', () => {
     mockResolveRuntimeCounts.mockReturnValue(runtimeCounts({
-      live: { agents: 3, keepers: 2, tasks: 0, totalRuntimes: 5, available: true },
+      live: { agents: 3, keepers: 2, pausedKeepers: 0, tasks: 0, totalRuntimes: 5, available: true },
       configured: { keepers: 0, totalRuntimes: 0, source: 'none' },
       source: 'execution',
     }))

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -63,14 +63,16 @@ export function AgentsUnified() {
     executionLoaded: executionLoaded.value,
     agentsCount: liveRuntimeCounts.agents,
     keepersCount: liveRuntimeCounts.keepers,
+    pausedKeepersCount: liveRuntimeCounts.pausedKeepers,
     namespaceTruthCounts: namespaceTruth.value?.root.counts,
     namespaceTruthConfiguredKeepers: namespaceTruth.value?.root.configured_keepers,
     shellCounts: shellCounts.value,
     shellConfiguredKeepers: shellCounts.value?.configured_keepers,
   })
   const liveKeepers = runtimeCounts.live.keepers
+  const livePausedKeepers = runtimeCounts.live.pausedKeepers
   const configuredKeepers = runtimeCounts.configured.keepers
-  const configuredKeeperDelta = Math.max(0, configuredKeepers - liveKeepers)
+  const configuredKeeperDelta = Math.max(0, configuredKeepers - liveKeepers - livePausedKeepers)
   const sourceLabel = runtimeCountSourceLabel(runtimeCounts.source)
   function chipCount(id: AgentsView): number | null {
     if (id === 'all') return runtimeCounts.live.totalRuntimes
@@ -101,7 +103,7 @@ export function AgentsUnified() {
       ${runtimeCounts.configured.source !== 'none' ? html`
         <div class="monitor-muted-panel flex w-fit flex-wrap items-center gap-2 px-3 py-2 text-xs text-[var(--color-fg-muted)]">
           <span class="text-2xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">runtime truth</span>
-          <span>활성 keeper ${liveKeepers} · 설정 keeper ${configuredKeepers}${configuredKeeperDelta > 0 ? html` · 일시정지/미기동 ${configuredKeeperDelta}` : ''}</span>
+          <span>활성 keeper ${liveKeepers}${livePausedKeepers > 0 ? html` · 일시정지 ${livePausedKeepers}` : ''} · 설정 keeper ${configuredKeepers}${configuredKeeperDelta > 0 ? html` · 미기동 ${configuredKeeperDelta}` : ''}</span>
           <span class="text-2xs text-[var(--color-fg-muted)]">source: ${sourceLabel}</span>
         </div>
       ` : null}

--- a/dashboard/src/runtime-counts.test.ts
+++ b/dashboard/src/runtime-counts.test.ts
@@ -17,7 +17,7 @@ describe('resolveRuntimeCounts', () => {
       namespaceTruthConfiguredKeepers: 5,
       shellCounts: { agents: 1, keepers: 1, tasks: 4 },
     })).toEqual({
-      live: { agents: 0, keepers: 0, tasks: 0, totalRuntimes: 0, available: false },
+      live: { agents: 0, keepers: 0, pausedKeepers: 0, tasks: 0, totalRuntimes: 0, available: false },
       configured: { keepers: 5, totalRuntimes: 5, source: 'namespace-truth' },
       source: 'project-snapshot',
     })
@@ -31,7 +31,7 @@ describe('resolveRuntimeCounts', () => {
       shellCounts: { agents: 4, keepers: 1, tasks: 9 },
       shellConfiguredKeepers: 3,
     })).toEqual({
-      live: { agents: 0, keepers: 0, tasks: 0, totalRuntimes: 0, available: false },
+      live: { agents: 0, keepers: 0, pausedKeepers: 0, tasks: 0, totalRuntimes: 0, available: false },
       configured: { keepers: 3, totalRuntimes: 5, source: 'shell' },
       source: 'shell',
     })
@@ -46,7 +46,7 @@ describe('resolveRuntimeCounts', () => {
       shellCounts: { agents: 6, keepers: 1, tasks: 9, total_runtimes: 8 },
       shellConfiguredKeepers: 7,
     })).toEqual({
-      live: { agents: 0, keepers: 0, tasks: 0, totalRuntimes: 0, available: false },
+      live: { agents: 0, keepers: 0, pausedKeepers: 0, tasks: 0, totalRuntimes: 0, available: false },
       configured: { keepers: 7, totalRuntimes: 8, source: 'shell' },
       source: 'shell',
     })
@@ -59,7 +59,7 @@ describe('resolveRuntimeCounts', () => {
       keepersCount: 0,
       namespaceTruthCounts: { agents: 2, keepers: 3, tasks: 12 },
     })).toEqual({
-      live: { agents: 0, keepers: 0, tasks: 0, totalRuntimes: 0, available: false },
+      live: { agents: 0, keepers: 0, pausedKeepers: 0, tasks: 0, totalRuntimes: 0, available: false },
       configured: { keepers: 3, totalRuntimes: 5, source: 'namespace-truth' },
       source: 'project-snapshot',
     })
@@ -74,7 +74,7 @@ describe('resolveRuntimeCounts', () => {
       namespaceTruthCounts: { agents: 2, keepers: 3, tasks: 12 },
       namespaceTruthConfiguredKeepers: 5,
     })).toEqual({
-      live: { agents: 2, keepers: 3, tasks: 1, totalRuntimes: 5, available: true },
+      live: { agents: 2, keepers: 3, pausedKeepers: 0, tasks: 1, totalRuntimes: 5, available: true },
       configured: { keepers: 5, totalRuntimes: 5, source: 'namespace-truth' },
       source: 'execution',
     })
@@ -90,7 +90,7 @@ describe('resolveRuntimeCounts', () => {
       shellCounts: { agents: 13, keepers: 12, tasks: 103, total_runtimes: 25 },
       shellConfiguredKeepers: 14,
     })).toEqual({
-      live: { agents: 0, keepers: 12, tasks: 0, totalRuntimes: 12, available: false },
+      live: { agents: 0, keepers: 12, pausedKeepers: 0, tasks: 0, totalRuntimes: 12, available: false },
       configured: { keepers: 14, totalRuntimes: 14, source: 'namespace-truth' },
       source: 'partial',
     })
@@ -104,7 +104,7 @@ describe('resolveRuntimeCounts', () => {
       namespaceTruthCounts: { agents: 2, keepers: 3, tasks: 12 },
       namespaceTruthConfiguredKeepers: 4,
     })).toEqual({
-      live: { agents: 0, keepers: 0, tasks: 0, totalRuntimes: 0, available: true },
+      live: { agents: 0, keepers: 0, pausedKeepers: 0, tasks: 0, totalRuntimes: 0, available: true },
       configured: { keepers: 4, totalRuntimes: 5, source: 'namespace-truth' },
       source: 'project-snapshot',
     })
@@ -121,7 +121,7 @@ describe('resolveRuntimeCounts', () => {
       namespaceTruthCounts: { agents: 0, keepers: 16, tasks: 0 },
       namespaceTruthConfiguredKeepers: 16,
     })).toEqual({
-      live: { agents: 0, keepers: 2, tasks: 0, totalRuntimes: 2, available: true },
+      live: { agents: 0, keepers: 2, pausedKeepers: 0, tasks: 0, totalRuntimes: 2, available: true },
       configured: { keepers: 16, totalRuntimes: 16, source: 'namespace-truth' },
       source: 'execution',
     })
@@ -133,7 +133,7 @@ describe('resolveRuntimeCounts', () => {
       agentsCount: 0,
       keepersCount: 0,
     })).toEqual({
-      live: { agents: 0, keepers: 0, tasks: 0, totalRuntimes: 0, available: false },
+      live: { agents: 0, keepers: 0, pausedKeepers: 0, tasks: 0, totalRuntimes: 0, available: false },
       configured: { keepers: 0, totalRuntimes: 0, source: 'none' },
       source: 'unknown',
     })
@@ -173,15 +173,23 @@ describe('configuredCountSourceLabel', () => {
 describe('formatActiveOverConfigured', () => {
   it('formats keeper counts as "활성 N / 설정 M"', () => {
     const counts = {
-      live: { agents: 0, keepers: 2, tasks: 0, totalRuntimes: 2, available: true },
+      live: { agents: 0, keepers: 2, pausedKeepers: 0, tasks: 0, totalRuntimes: 2, available: true },
       configured: { keepers: 16, totalRuntimes: 16, source: 'namespace-truth' as const },
     }
     expect(formatActiveOverConfigured(counts, 'keeper')).toBe('활성 2 / 설정 16')
   })
 
+  it('includes paused count in keeper formatting when paused keepers exist', () => {
+    const counts = {
+      live: { agents: 0, keepers: 4, pausedKeepers: 3, tasks: 0, totalRuntimes: 4, available: true },
+      configured: { keepers: 24, totalRuntimes: 24, source: 'namespace-truth' as const },
+    }
+    expect(formatActiveOverConfigured(counts, 'keeper')).toBe('활성 4 / 일시정지 3 / 설정 24')
+  })
+
   it('formats runtime totals as "활성 N / 설정 M"', () => {
     const counts = {
-      live: { agents: 3, keepers: 2, tasks: 0, totalRuntimes: 5, available: true },
+      live: { agents: 3, keepers: 2, pausedKeepers: 0, tasks: 0, totalRuntimes: 5, available: true },
       configured: { keepers: 16, totalRuntimes: 20, source: 'namespace-truth' as const },
     }
     expect(formatActiveOverConfigured(counts, 'runtime')).toBe('활성 5 / 설정 20')
@@ -189,7 +197,7 @@ describe('formatActiveOverConfigured', () => {
 
   it('defaults kind to "keeper" when omitted', () => {
     const counts = {
-      live: { agents: 0, keepers: 0, tasks: 0, totalRuntimes: 0, available: false },
+      live: { agents: 0, keepers: 0, pausedKeepers: 0, tasks: 0, totalRuntimes: 0, available: false },
       configured: { keepers: 0, totalRuntimes: 0, source: 'none' as const },
     }
     expect(formatActiveOverConfigured(counts)).toBe('활성 0 / 설정 0')

--- a/dashboard/src/runtime-counts.ts
+++ b/dashboard/src/runtime-counts.ts
@@ -12,6 +12,7 @@ export type ConfiguredCountSource = 'namespace-truth' | 'shell' | 'none'
 export interface LiveRuntimeView {
   agents: number
   keepers: number
+  pausedKeepers: number
   tasks: number
   totalRuntimes: number
   available: boolean
@@ -33,6 +34,7 @@ interface ResolveRuntimeCountsOptions {
   executionLoaded: boolean
   agentsCount: number
   keepersCount: number
+  pausedKeepersCount?: number
   tasksCount?: number
   namespaceTruthCounts?: DashboardNamespaceTruthResponse['root']['counts']
   namespaceTruthConfiguredKeepers?: number
@@ -120,6 +122,7 @@ export function resolveRuntimeCounts({
   executionLoaded,
   agentsCount,
   keepersCount,
+  pausedKeepersCount = 0,
   tasksCount = 0,
   namespaceTruthCounts,
   namespaceTruthConfiguredKeepers,
@@ -128,10 +131,12 @@ export function resolveRuntimeCounts({
 }: ResolveRuntimeCountsOptions): RuntimeCounts {
   const liveAgents = normalizeCount(agentsCount)
   const liveKeepers = normalizeCount(keepersCount)
+  const livePausedKeepers = normalizeCount(pausedKeepersCount)
   const liveTasks = normalizeCount(tasksCount)
   const live: LiveRuntimeView = {
     agents: liveAgents,
     keepers: liveKeepers,
+    pausedKeepers: livePausedKeepers,
     tasks: liveTasks,
     totalRuntimes: liveAgents + liveKeepers,
     available: executionLoaded,
@@ -186,9 +191,16 @@ export function formatActiveOverConfigured(
   counts: Pick<RuntimeCounts, 'live' | 'configured'>,
   kind: 'keeper' | 'runtime' = 'keeper',
 ): string {
-  const active = kind === 'keeper' ? counts.live.keepers : counts.live.totalRuntimes
-  const configured = kind === 'keeper' ? counts.configured.keepers : counts.configured.totalRuntimes
-  return `활성 ${active} / 설정 ${configured}`
+  if (kind === 'keeper') {
+    const running = counts.live.keepers
+    const paused = counts.live.pausedKeepers
+    const configured = counts.configured.keepers
+    const parts = [`활성 ${running}`]
+    if (paused > 0) parts.push(`일시정지 ${paused}`)
+    parts.push(`설정 ${configured}`)
+    return parts.join(' / ')
+  }
+  return `활성 ${counts.live.totalRuntimes} / 설정 ${counts.configured.totalRuntimes}`
 }
 
 interface ExecutionFallbackStateOptions {


### PR DESCRIPTION
## Summary
- **"활성 keeper"** 라벨이 paused-but-registered keeper까지 포함해 실제 running keeper 수와 불일치 (예: "활성 7"인데 실제 busy는 4)
- `countRuntimeKinds`가 `isKeeperPaused` predicate로 running vs paused를 분리 카운트
- UI: `활성 4 · 일시정지 3 · 설정 24 · 미기동 N` 형태로 상태별 표시
- `LiveRuntimeView`에 `pausedKeepers` 필드 추가, `formatActiveOverConfigured`가 paused 세그먼트 포함

## Test plan
- [x] TypeScript `--noEmit` 통과 (env vitest/preact/valibot 오류 외)
- [x] `runtime-counts.test.ts` 모든 케이스에 `pausedKeepers: 0` 추가 + paused nonzero 신규 케이스
- [x] `agent-roster.test.ts` `countRuntimeKinds` 반환값에 `pausedKeepers` 추가
- [x] `agents-unified.test.ts` mock에 `pausedKeepers` 필드 추가
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)