### PR TITLE
ci(shell): ratchet legacy shell purge debt

### DIFF
--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -58,6 +58,16 @@ jobs:
       - name: Run lint
         run: bash scripts/lint/provider-adapter-removal-ratchet.sh
 
+  shell-legacy-purge-ratchet:
+    name: Shell legacy purge ratchet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install ripgrep
+        run: sudo apt-get install -y -qq ripgrep
+      - name: Run lint
+        run: bash scripts/lint/shell-legacy-purge-ratchet.sh
+
   no-provider-name-hardcoding:
     name: Provider name hardcoding ratchet
     runs-on: ubuntu-latest

--- a/scripts/lint/shell-legacy-purge-ratchet.baseline
+++ b/scripts/lint/shell-legacy-purge-ratchet.baseline
@@ -1,0 +1,10 @@
+# Shell legacy purge ratchet baseline.
+#
+# Format: <needle> <max-hit-count>
+# Scope: lib/ and test/
+# The long-term target for every row is 0. Cleanup PRs may lower these
+# counts; no PR may raise them.
+tokenize_path_args 4
+path_validation_tokens 4
+forbidden_shell_chars 22
+raw_keeper_bash_shape_block 0

--- a/scripts/lint/shell-legacy-purge-ratchet.files
+++ b/scripts/lint/shell-legacy-purge-ratchet.files
@@ -1,0 +1,14 @@
+# Shell legacy purge ratchet file baseline.
+#
+# Format: <needle> <repo-relative-path>
+# New files may not gain these legacy markers. Deletion PRs should remove
+# rows as they remove the corresponding markers.
+tokenize_path_args lib/worker_dev_tools.ml
+path_validation_tokens lib/worker_dev_tools.ml
+forbidden_shell_chars lib/gh_command_validation.ml
+forbidden_shell_chars lib/gh_command_validation.mli
+forbidden_shell_chars lib/worker_dev_tools.ml
+forbidden_shell_chars lib/worker_dev_tools_command_syntax.ml
+forbidden_shell_chars lib/worker_dev_tools_command_syntax.mli
+forbidden_shell_chars test/fixtures/shell_gate/baseline.jsonl
+forbidden_shell_chars test/test_exec_shell_command_gate.ml

--- a/scripts/lint/shell-legacy-purge-ratchet.sh
+++ b/scripts/lint/shell-legacy-purge-ratchet.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Shell legacy purge ratchet.
+#
+# The Shell IR Phase 5 cleanup target is to remove the remaining legacy
+# string-tokenizer/path-scanner markers from lib/ and test/. This guard
+# freezes the current debt while deletion PRs drive the baselines down to 0.
+#
+# Usage:
+#   bash scripts/lint/shell-legacy-purge-ratchet.sh
+#   bash scripts/lint/shell-legacy-purge-ratchet.sh --print
+#   bash scripts/lint/shell-legacy-purge-ratchet.sh --regenerate
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+COUNT_BASELINE="${ROOT}/scripts/lint/shell-legacy-purge-ratchet.baseline"
+FILE_BASELINE="${ROOT}/scripts/lint/shell-legacy-purge-ratchet.files"
+NEEDLES=(
+  "tokenize_path_args"
+  "path_validation_tokens"
+  "forbidden_shell_chars"
+  "raw_keeper_bash_shape_block"
+)
+SCOPE=(lib test)
+
+for tool in awk comm mktemp rg sed sort tr wc; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "[shell-legacy-purge-ratchet] required tool missing: $tool" >&2
+    exit 1
+  }
+done
+
+current_count() {
+  local needle="$1"
+  (
+    set +o pipefail
+    cd "$ROOT"
+    rg --fixed-strings -n "$needle" "${SCOPE[@]}" 2>/dev/null \
+      | wc -l \
+      | tr -d ' '
+  )
+}
+
+baseline_count() {
+  local needle="$1"
+  awk -v needle="$needle" '
+    $0 ~ /^[[:space:]]*#/ || NF == 0 { next }
+    $1 == needle { print $2; found = 1 }
+    END { if (!found) print 0 }
+  ' "$COUNT_BASELINE"
+}
+
+current_files() {
+  local needle="$1"
+  (
+    set +o pipefail
+    cd "$ROOT"
+    rg --fixed-strings -l "$needle" "${SCOPE[@]}" 2>/dev/null \
+      | sort -u
+  )
+}
+
+baseline_files() {
+  local needle="$1"
+  awk -v needle="$needle" '
+    $0 ~ /^[[:space:]]*#/ || NF == 0 { next }
+    $1 == needle { print $2 }
+  ' "$FILE_BASELINE" | sort -u
+}
+
+print_counts() {
+  printf "%-34s %9s  %9s\n" "needle" "current" "baseline"
+  echo "--------------------------------------------------------"
+  local needle
+  for needle in "${NEEDLES[@]}"; do
+    printf "%-34s %9s  %9s\n" \
+      "$needle" \
+      "$(current_count "$needle")" \
+      "$(baseline_count "$needle")"
+  done
+}
+
+regenerate() {
+  {
+    echo "# Shell legacy purge ratchet baseline."
+    echo "#"
+    echo "# Format: <needle> <max-hit-count>"
+    echo "# Scope: lib/ and test/"
+    echo "# The long-term target for every row is 0. Cleanup PRs may lower these"
+    echo "# counts; no PR may raise them."
+    local needle
+    for needle in "${NEEDLES[@]}"; do
+      printf "%s %s\n" "$needle" "$(current_count "$needle")"
+    done
+  } >"$COUNT_BASELINE"
+
+  {
+    echo "# Shell legacy purge ratchet file baseline."
+    echo "#"
+    echo "# Format: <needle> <repo-relative-path>"
+    echo "# New files may not gain these legacy markers. Deletion PRs should remove"
+    echo "# rows as they remove the corresponding markers."
+    local needle path
+    for needle in "${NEEDLES[@]}"; do
+      while IFS= read -r path; do
+        [[ -n "$path" ]] || continue
+        printf "%s %s\n" "$needle" "$path"
+      done < <(current_files "$needle")
+    done
+  } >"$FILE_BASELINE"
+
+  echo "[shell-legacy-purge-ratchet] regenerated baselines"
+}
+
+check() {
+  local needle current baseline current_tmp baseline_tmp new_tmp drift=0
+  current_tmp="$(mktemp -t shell-legacy-current.XXXXXX)"
+  baseline_tmp="$(mktemp -t shell-legacy-baseline.XXXXXX)"
+  new_tmp="$(mktemp -t shell-legacy-new.XXXXXX)"
+  trap 'rm -f "$current_tmp" "$baseline_tmp" "$new_tmp"' RETURN
+
+  for needle in "${NEEDLES[@]}"; do
+    current="$(current_count "$needle")"
+    baseline="$(baseline_count "$needle")"
+    if (( current > baseline )); then
+      echo "[shell-legacy-purge-ratchet] DRIFT UP: ${needle} current=${current} baseline=${baseline}" >&2
+      echo "  remove the new legacy marker or lower the existing debt first." >&2
+      drift=1
+    elif (( current < baseline )); then
+      echo "[shell-legacy-purge-ratchet] SHRANK: ${needle} current=${current} baseline=${baseline}"
+      echo "  update scripts/lint/shell-legacy-purge-ratchet.baseline in the cleanup PR."
+    fi
+
+    current_files "$needle" >"$current_tmp"
+    baseline_files "$needle" >"$baseline_tmp"
+    comm -13 "$baseline_tmp" "$current_tmp" >"$new_tmp"
+    if [[ -s "$new_tmp" ]]; then
+      echo "[shell-legacy-purge-ratchet] DRIFT UP: new files contain ${needle}" >&2
+      sed 's/^/  - /' "$new_tmp" >&2
+      echo "  do not move or expand legacy shell tokenizer/path-scanner code." >&2
+      drift=1
+    fi
+  done
+
+  return "$drift"
+}
+
+case "${1:-}" in
+  --print)
+    print_counts
+    ;;
+  --regenerate)
+    regenerate
+    ;;
+  "")
+    print_counts
+    if check; then
+      echo
+      echo "[shell-legacy-purge-ratchet] OK"
+      exit 0
+    else
+      echo
+      echo "[shell-legacy-purge-ratchet] FAIL - current exceeds baseline" >&2
+      exit 2
+    fi
+    ;;
+  *)
+    echo "Usage: $0 [--print|--regenerate]" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add a Shell legacy purge ratchet for the remaining tokenizer/path-scanner markers in lib/ and test/
- freeze current counts for tokenize_path_args, path_validation_tokens, forbidden_shell_chars, and raw_keeper_bash_shape_block
- wire the guard into Fundamental Check so cleanup PRs can ratchet counts down and new legacy spread is blocked

## Validation
- PASS: bash -n scripts/lint/shell-legacy-purge-ratchet.sh
- PASS: bash scripts/lint/shell-legacy-purge-ratchet.sh
- PASS: bash scripts/lint/yaml-syntax.sh
- PASS: git diff --check --cached

## Next
- deletion slice 1: move validate_command_paths to parsed Shell IR only, then lower tokenize_path_args/path_validation_tokens baselines
- deletion slice 2: rename/remove forbidden_shell_chars legacy APIs after strict/coding validators consume semantic reject reasons
