### PR TITLE
feat(cascade): wire tier admission into keeper attempts

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -19,6 +19,55 @@ include Keeper_turn_driver_helpers
 
 include Keeper_turn_driver_provider_attempt
 
+let keeper_cascade_tier_admission = Cascade_tier_admission.create ()
+
+let cascade_tier_admission_policy_of_priority priority =
+  match
+    Llm_provider.Request_priority.resolve priority
+    |> Llm_provider.Request_priority.to_string
+    |> String.lowercase_ascii
+  with
+  | "background" -> Cascade_tier_admission.Bypass
+  | _ -> Cascade_tier_admission.Required
+
+let with_keeper_cascade_tier_admission
+    ?(admission = keeper_cascade_tier_admission)
+    ?(enabled = Env_config_keeper.CascadeSaturationSignal.enabled ())
+    ~tier_id
+    ~admission_policy
+    f =
+  if enabled
+  then
+    Cascade_tier_admission.with_admission admission ~tier_id
+      ~admission_policy f
+  else
+    Ok (f ())
+
+let cascade_tier_admission_blocked_decision signal =
+  `Assoc
+    [
+      ("blocker", `String "cascade_tier_admission_full");
+      ("signal", Cascade_saturation_signal.to_yojson signal);
+    ]
+
+let emit_cascade_tier_admission_signal_metric ~cascade_name signal =
+  Prometheus.inc_counter
+    Keeper_metrics.metric_keeper_cascade_saturation_signal
+    ~labels:
+      [
+        ( label_kind,
+          Cascade_saturation_signal.(kind signal |> kind_to_string) );
+        (label_cascade, provider_label cascade_name);
+      ]
+    ()
+
+let release_client_capacity_quietly = function
+  | None -> ()
+  | Some release ->
+      (match release () with
+       | () -> ()
+       | exception _ -> ())
+
 (* ================================================================ *)
 (* Facade-only: run_named, run_model_by_label, and MASC tool bridges  *)
 (* ================================================================ *)
@@ -502,6 +551,10 @@ let run_named
   let queue_priority =
     Option.value priority ~default:Llm_provider.Request_priority.Proactive
   in
+  let tier_admission_policy =
+    cascade_tier_admission_policy_of_priority queue_priority
+  in
+  let tier_admission_id = cascade_name in
   (* MASC-driven cascade FSM: try each provider, decide on failure.
      Extracted to [Keeper_turn_driver_try_provider.run_try_provider] via
      explicit [try_provider_ctx] record (RFC-0051 PR-3a). *)
@@ -754,6 +807,29 @@ let run_named
       ~decision:(client_capacity_full_decision ~capacity_key)
       Keeper_runtime_manifest.Pre_dispatch_blocked
   in
+  let emit_tier_admission_blocked_manifest signal =
+    emit_runtime_manifest
+      ~status:"blocked"
+      ~decision:(cascade_tier_admission_blocked_decision signal)
+      Keeper_runtime_manifest.Pre_dispatch_blocked
+  in
+  let slot_full_last_err ~is_last last_err =
+    match
+      Cascade_fsm.decide
+        ~accept_on_exhaustion:false
+        ~is_last
+        Cascade_fsm.Slot_full
+    with
+    | Cascade_fsm.Try_next { last_err = Some err }
+    | Cascade_fsm.Exhausted { last_err = Some err } ->
+      Some err
+    | Cascade_fsm.Try_next { last_err = None }
+    | Cascade_fsm.Exhausted { last_err = None } ->
+      last_err
+    | Cascade_fsm.Accept _
+    | Cascade_fsm.Accept_on_exhaustion _ ->
+      last_err
+  in
   let rec try_cascade
       ?(on_success = fun ~provider_key:_ -> ())
       ?resume_checkpoint ?per_provider_timeout_s remaining last_err =
@@ -888,23 +964,7 @@ let run_named
           cascade_name
           runtime_candidate_label
           capacity_key;
-        let slot_last_err =
-          match
-            Cascade_fsm.decide
-              ~accept_on_exhaustion:false
-              ~is_last
-              Cascade_fsm.Slot_full
-          with
-          | Cascade_fsm.Try_next { last_err = Some err }
-          | Cascade_fsm.Exhausted { last_err = Some err } ->
-            Some err
-          | Cascade_fsm.Try_next { last_err = None }
-          | Cascade_fsm.Exhausted { last_err = None } ->
-            last_err
-          | Cascade_fsm.Accept _
-          | Cascade_fsm.Accept_on_exhaustion _ ->
-            last_err
-        in
+        let slot_last_err = slot_full_last_err ~is_last last_err in
         try_cascade ~on_success ?resume_checkpoint ?per_provider_timeout_s
           rest slot_last_err
       | (`No_client_capacity | `Acquired _) as capacity_slot ->
@@ -964,8 +1024,11 @@ let run_named
         Cascade_legacy_runner.record_attempt_terminal capture
           ~model_id:runtime_candidate_label ~latency_ms ~error
       in
-      let (result, checkpoint_after, liveness_success_sample, attempt_latency_ms) =
-        Eio.Switch.run (fun provider_attempt_sw ->
+      let attempt_with_admission =
+        with_keeper_cascade_tier_admission
+          ~tier_id:tier_admission_id
+          ~admission_policy:tier_admission_policy
+          (fun () -> Eio.Switch.run (fun provider_attempt_sw ->
           Option.iter
             (fun release -> Eio.Switch.on_release provider_attempt_sw release)
             capacity_release;
@@ -1043,8 +1106,28 @@ let run_named
               ~exception_kind:status
               attempt_latency_ms;
             record_attempt_terminal ~error:(Some error) attempt_latency_ms;
-            Printexc.raise_with_backtrace exn bt)
+            Printexc.raise_with_backtrace exn bt))
       in
+      match attempt_with_admission with
+      | Error signal ->
+        release_client_capacity_quietly capacity_release;
+        emit_tier_admission_blocked_manifest signal;
+        emit_cascade_tier_admission_signal_metric ~cascade_name signal;
+        record_cascade_attempt candidate ~outcome:(`Failure "tier_admission_full") ();
+        Cascade_legacy_runner.record_fallback_event capture
+          ~from_model:runtime_candidate_label
+          ~to_model:runtime_candidate_label
+          ~reason:"tier_admission_full";
+        Log.Misc.info
+          "[cascade-fallback] cascade %s: %s skipped because tier admission \
+           %s is full, trying next"
+          cascade_name
+          runtime_candidate_label
+          tier_admission_id;
+        let slot_last_err = slot_full_last_err ~is_last last_err in
+        try_cascade ~on_success ?resume_checkpoint ?per_provider_timeout_s
+          rest slot_last_err
+      | Ok (result, checkpoint_after, liveness_success_sample, attempt_latency_ms) ->
       let record_accepted_liveness_sample () =
         match liveness_success_sample with
         | None -> ()
@@ -1489,4 +1572,10 @@ module For_testing = struct
   let missing_required_tool_names_after_lane_by_name =
     missing_required_tool_names_after_lane_by_name
   let success_selected_model_raw = success_selected_model_raw
+  let cascade_tier_admission_policy_of_priority =
+    cascade_tier_admission_policy_of_priority
+  let with_cascade_tier_admission_for_testing
+      ~admission ~enabled ~tier_id ~admission_policy f =
+    with_keeper_cascade_tier_admission ~admission ~enabled ~tier_id
+      ~admission_policy f
 end

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -255,4 +255,16 @@ module For_testing : sig
     string list
 
   val success_selected_model_raw : Cascade_runtime_candidate.t -> string option
+
+  val cascade_tier_admission_policy_of_priority :
+    Llm_provider.Request_priority.t ->
+    Cascade_tier_admission.admission_policy
+
+  val with_cascade_tier_admission_for_testing :
+    admission:Cascade_tier_admission.t ->
+    enabled:bool ->
+    tier_id:string ->
+    admission_policy:Cascade_tier_admission.admission_policy ->
+    (unit -> 'a) ->
+    ('a, Cascade_saturation_signal.t) result
 end

--- a/test/test_cascade_tier_admission.ml
+++ b/test/test_cascade_tier_admission.ml
@@ -13,6 +13,9 @@ open Alcotest
 
 module A = Masc_mcp.Cascade_tier_admission
 module S = Masc_mcp.Cascade_saturation_signal
+module KTD = Masc_mcp.Keeper_turn_driver.For_testing
+
+let signal_testable = testable S.pp S.equal
 
 let int_check msg expected actual =
   check int msg expected actual
@@ -186,6 +189,81 @@ let test_tiers_are_independent () =
     (A.current_inflight t ~tier_id:"B");
   int_check "A released to 0" 0 (A.current_inflight t ~tier_id:"A")
 
+(* {1 Keeper turn driver wire-in} *)
+
+let test_keeper_policy_proactive_required () =
+  match
+    KTD.cascade_tier_admission_policy_of_priority
+      Llm_provider.Request_priority.Proactive
+  with
+  | A.Required -> ()
+  | A.Bypass -> Alcotest.fail "proactive keeper turns must require admission"
+
+let test_keeper_policy_background_bypass () =
+  match
+    KTD.cascade_tier_admission_policy_of_priority
+      Llm_provider.Request_priority.Background
+  with
+  | A.Bypass -> ()
+  | A.Required -> Alcotest.fail "background side tasks must bypass admission"
+
+let test_keeper_wire_enabled_rejects_at_capacity () =
+  let t = A.create ~default_max_inflight:1 () in
+  (match A.try_acquire t ~tier_id:"keeper-turn" with
+   | A.Granted _ -> ()
+   | A.Capacity_full _ -> Alcotest.fail "expected setup acquire to succeed");
+  let ran = ref false in
+  let result =
+    KTD.with_cascade_tier_admission_for_testing
+      ~admission:t
+      ~enabled:true
+      ~tier_id:"keeper-turn"
+      ~admission_policy:A.Required
+      (fun () ->
+         ran := true;
+         ())
+  in
+  bool_check "provider attempt not run at capacity" false !ran;
+  (match result with
+   | Ok () -> Alcotest.fail "expected tier admission rejection"
+   | Error (S.Inflight_capacity_full { tier_id; max_inflight }) ->
+       check string "tier id echoed" "keeper-turn" tier_id;
+       int_check "max inflight echoed" 1 max_inflight
+   | Error _ -> Alcotest.fail "wrong saturation signal");
+  A.release t ~tier_id:"keeper-turn"
+
+let test_keeper_wire_disabled_is_passthrough () =
+  let t = A.create ~default_max_inflight:0 () in
+  let ran = ref false in
+  let result =
+    KTD.with_cascade_tier_admission_for_testing
+      ~admission:t
+      ~enabled:false
+      ~tier_id:"keeper-turn"
+      ~admission_policy:A.Required
+      (fun () ->
+         ran := true;
+         "ok")
+  in
+  bool_check "attempt ran when flag disabled" true !ran;
+  check (result string signal_testable) "disabled flag passthrough" (Ok "ok") result;
+  int_check "disabled path did not touch counter" 0
+    (A.current_inflight t ~tier_id:"keeper-turn")
+
+let test_keeper_wire_bypass_policy_is_passthrough () =
+  let t = A.create ~default_max_inflight:0 () in
+  let result =
+    KTD.with_cascade_tier_admission_for_testing
+      ~admission:t
+      ~enabled:true
+      ~tier_id:"keeper-turn"
+      ~admission_policy:A.Bypass
+      (fun () -> 7)
+  in
+  check (result int signal_testable) "bypass policy passthrough" (Ok 7) result;
+  int_check "bypass path did not touch counter" 0
+    (A.current_inflight t ~tier_id:"keeper-turn")
+
 (* {1 driver} *)
 
 let suite =
@@ -218,6 +296,18 @@ let suite =
       ] );
     ( "isolation",
       [ test_case "tiers independent" `Quick test_tiers_are_independent ] );
+    ( "keeper-wire",
+      [ test_case "proactive maps to Required" `Quick
+          test_keeper_policy_proactive_required;
+        test_case "background maps to Bypass" `Quick
+          test_keeper_policy_background_bypass;
+        test_case "enabled path rejects at capacity" `Quick
+          test_keeper_wire_enabled_rejects_at_capacity;
+        test_case "disabled flag is passthrough" `Quick
+          test_keeper_wire_disabled_is_passthrough;
+        test_case "bypass policy is passthrough" `Quick
+          test_keeper_wire_bypass_policy_is_passthrough;
+      ] );
   ]
 
 let () = Alcotest.run "cascade_tier_admission" suite


### PR DESCRIPTION
## Summary
- wire Cascade_tier_admission into the keeper provider-attempt path behind MASC_CASCADE_SATURATION_SIGNAL_ENABLED
- emit manifest/metric evidence when a tier is full and continue the cascade as Slot_full
- expose focused For_testing hooks and add keeper wire-in tests

## Validation
- git diff --check HEAD~1..HEAD
- ocamlformat --check lib/keeper/keeper_turn_driver.ml lib/keeper/keeper_turn_driver.mli test/test_cascade_tier_admission.ml

## Pending local validation
- scripts/dune-local.sh build test/test_cascade_tier_admission.exe is pending because another bare dune build is currently running outside scripts/dune-local.sh on the shared machine. This PR is draft until that focused build or CI proves the OCaml build.
