### PR TITLE
refactor(dashboard): group runtime panel chips into Primary + Advanced strips

### DIFF
--- a/dashboard/src/components/runtime-panel.test.ts
+++ b/dashboard/src/components/runtime-panel.test.ts
@@ -161,14 +161,19 @@ describe('RuntimePanel', () => {
     await flushUi()
 
     const chips = container.querySelectorAll('[data-testid="chip"]')
+    // Chips are split across two FilterChips strips (Primary then Advanced)
+    // with a divider between them. Total count and label set unchanged; the
+    // positional order now reflects the Primary[default, providers, inspector]
+    // → Advanced[cost, audit, heuristics, stress, prometheus, verification]
+    // layout.
     expect(chips.length).toBe(9)
     expect(chips[0]?.textContent).toBe('전체')
     expect(chips[1]?.textContent).toBe('런타임')
-    expect(chips[2]?.textContent).toBe('비용 / 지연')
-    expect(chips[3]?.textContent).toBe('감사')
-    expect(chips[4]?.textContent).toBe('휴리스틱')
-    expect(chips[5]?.textContent).toBe('스트레스')
-    expect(chips[6]?.textContent).toBe('검사기')
+    expect(chips[2]?.textContent).toBe('검사기')
+    expect(chips[3]?.textContent).toBe('비용 / 지연')
+    expect(chips[4]?.textContent).toBe('감사')
+    expect(chips[5]?.textContent).toBe('휴리스틱')
+    expect(chips[6]?.textContent).toBe('스트레스')
     expect(chips[7]?.textContent).toBe('메트릭')
     expect(chips[8]?.textContent).toBe('형식검증')
   })

--- a/dashboard/src/components/runtime-panel.ts
+++ b/dashboard/src/components/runtime-panel.ts
@@ -65,14 +65,25 @@ const activeView = computed<RuntimeView>(() => {
   return isRuntimeView(v) ? v : 'default'
 })
 
-const VIEW_CHIPS: Array<{ key: RuntimeView; label: string }> = [
+// Primary chips answer the keeper-facing question "can my tools run through
+// which cascade, and why did the routing decision come out this way?"
+// Default, providers (runtime health), and inspector (cascade decisions) are
+// the views an operator opens during normal use.
+const PRIMARY_VIEW_CHIPS: Array<{ key: RuntimeView; label: string }> = [
   { key: 'default', label: '전체' },
   { key: 'providers', label: '런타임' },
+  { key: 'inspector', label: '검사기' },
+]
+
+// Advanced chips are infra/billing telemetry and formal-verification views.
+// Useful for post-mortems and audits, not for daily keeper triage. They stay
+// reachable via the same chip strip below for now; a follow-up may move
+// cost/audit/heuristics/stress into a dedicated telemetry-panel surface.
+const ADVANCED_VIEW_CHIPS: Array<{ key: RuntimeView; label: string }> = [
   { key: 'cost', label: '비용 / 지연' },
   { key: 'audit', label: '감사' },
   { key: 'heuristics', label: '휴리스틱' },
   { key: 'stress', label: '스트레스' },
-  { key: 'inspector', label: '검사기' },
   { key: 'prometheus', label: '메트릭' },
   { key: 'verification', label: '형식검증' },
 ]
@@ -171,11 +182,24 @@ export function RuntimePanel() {
 
   return html`
     <div class="flex flex-col gap-4">
-      <${FilterChips}
-        chips=${VIEW_CHIPS}
-        value=${view}
-        onChange=${updateViewParam}
-      />
+      <div class="flex flex-col gap-2">
+        <${FilterChips}
+          chips=${PRIMARY_VIEW_CHIPS}
+          value=${view}
+          onChange=${updateViewParam}
+          aria-label="Primary runtime views"
+        />
+        <div class="flex items-center gap-2 text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">
+          <span>고급 / 진단</span>
+          <span class="h-px flex-1 bg-[var(--color-border-divider)]" aria-hidden="true"></span>
+        </div>
+        <${FilterChips}
+          chips=${ADVANCED_VIEW_CHIPS}
+          value=${view}
+          onChange=${updateViewParam}
+          aria-label="Advanced runtime views"
+        />
+      </div>
       <div class="grid gap-4">
         ${view === 'providers'
           ? html`


### PR DESCRIPTION
## Goal
runtime-panel의 9-view FilterChips를 Primary(3) + Advanced(6) 두 strip으로 분리. UI 그룹화만 — view는 그대로 9개, deep-link/cockpit alias 영향 0. Monitor IA 리뷰가 식별한 keeper-facing vs infra/audit/verification 분리의 *visual* 단계.

## Changed files
- `dashboard/src/components/runtime-panel.ts` — VIEW_CHIPS 단일 배열을 PRIMARY_VIEW_CHIPS(3) + ADVANCED_VIEW_CHIPS(6)로 분할 + FilterChips 2번 렌더링 + 라벨 divider
- `dashboard/src/components/runtime-panel.test.ts` — positional assertion 순서를 Primary→Advanced 레이아웃으로 갱신 (chip count 9 유지)

## Self-review
- 목표: 9-view를 시각적으로 keeper-facing 3 vs 진단/감사 6으로 분리. *코드 동작 변화 0*.
- 범위: 1 컴포넌트 파일 + 1 테스트 파일. 41+/12-.
- 동작 변화: **0**. updateViewParam(), routes, cockpit aliases, deep-links 전부 동일.
- 로컬 검증:
  - `pnpm vitest run runtime-panel.test.ts` → 9/9 passed (638ms)
  - `pnpm typecheck` → 본 변경 관련 0 에러 (origin/main의 baseline `credential-settings.ts(13,3) TS6133`는 본 PR 무관)

## Primary vs Advanced 분류
**Primary (3)**: `default` (전체), `providers` (런타임), `inspector` (검사기). 운영자가 "keeper가 tool을 호출할 수 있는가, 어느 cascade를 통하는가, 실패 원인은?"을 묻는 일상적인 view.

**Advanced (6)**: `cost` (비용/지연), `audit` (감사), `heuristics` (휴리스틱), `stress` (스트레스), `prometheus` (메트릭), `verification` (형식검증). 사후 분석, 감사, 공식 검증용 — 일상 keeper 트리아지의 1차 질문에 답하지 않음.

## Test plan
- [x] vitest unit test (runtime-panel.test.ts 9/9)
- [ ] CI typecheck — baseline error 무관
- [ ] CI lint
- [ ] 시각 회귀: Primary strip 3-chip, divider, Advanced strip 6-chip 순으로 렌더 (스크린샷 권장)

## Why split this as v1
원래 plan은 cost/audit/heuristics/stress를 별도 `telemetry-panel.ts`로 추출(~300 LoC)하는 것. 그 작업은 CostDashboard 모듈-레벨 signal collision risk 및 라우트 forwarding 검토를 필요로 함. 본 PR-4 v1은 **visual grouping만** 수행해 IA 분리의 첫 단계를 안전하게 main에 반영. v2(컴포넌트 추출)는 별도 PR.

## References
- Monitor IA 리뷰: `/Users/dancer/me/memory/masc-oas-dashboard-monitor-ia-report-2026-05-20.html`
- 형제 PR: #17003 (navigation 주석), #17007 (status.ts helper - MERGED), #17008 (tab-refresh fallback name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)