### PR TITLE
fix(dashboard/tool-quality): collapse Sys_error blob, label trend window, widen cascade column

### DIFF
--- a/dashboard/src/components/common/source-health.test.ts
+++ b/dashboard/src/components/common/source-health.test.ts
@@ -48,6 +48,16 @@ describe('coverageGapDisplay', () => {
         'trace trace-tool-call-gap',
         'error append denied',
       ],
+      structured: {
+        reason: 'tool_call_io_append_failed',
+        fields: [
+          { label: 'producer', value: 'keeper_tool_call_log.append' },
+          { label: 'store', value: '.masc/tool_calls' },
+          { label: 'surface', value: '/api/v1/keepers/:name/tool-calls' },
+          { label: 'trace', value: 'trace-tool-call-gap' },
+        ],
+        error: 'append denied',
+      },
     })
   })
 
@@ -89,6 +99,16 @@ describe('coverageGapDisplay', () => {
         'trace NEW-trace',
         'error NEW-error',
       ],
+      structured: {
+        reason: 'NEW_reason',
+        fields: [
+          { label: 'producer', value: 'NEW-producer' },
+          { label: 'store', value: 'NEW-store' },
+          { label: 'surface', value: 'NEW-surface' },
+          { label: 'trace', value: 'NEW-trace' },
+        ],
+        error: 'NEW-error',
+      },
     })
   })
 })

--- a/dashboard/src/components/common/source-health.ts
+++ b/dashboard/src/components/common/source-health.ts
@@ -52,10 +52,20 @@ function latestCoverageGap(d: TelemetryFreshnessMetadata): TelemetryCoverageGap 
   return gaps[gaps.length - 1] ?? null
 }
 
+export type CoverageGapField = { label: string; value: string }
+
 export type CoverageGapDisplay = {
   count: number
   summary: string
   details: string[]
+  // Structured split of `details` so panels can render error text inside a
+  // collapsible block while keeping producer/store/surface/trace visible.
+  // `details` remains the flat SSOT for callers that just want strings.
+  structured: {
+    reason: string
+    fields: CoverageGapField[]
+    error: string | null
+  }
 }
 
 /** Build compact operator-visible coverage-gap details for freshness lines. */
@@ -76,9 +86,15 @@ export function coverageGapDisplay(d: TelemetryFreshnessMetadata): CoverageGapDi
     .filter((entry): entry is [string, string] => entry[1] != null)
     .map(([label, value]) => `${label} ${value}`)
 
+  const fields: CoverageGapField[] = rawDetails
+    .filter((entry): entry is [string, string] => entry[1] != null && entry[0] !== 'error')
+    .map(([label, value]) => ({ label, value }))
+  const errorValue = nonEmpty(gap?.error)
+
   return {
     count,
     summary: `coverage gaps ${count}: ${reason}`,
     details,
+    structured: { reason, fields, error: errorValue },
   }
 }

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -16,7 +16,12 @@ import {
   sharedToolQualityLoading,
 } from './fleet-data-core'
 import { route } from '../router'
-import { sourceHealthClass, freshnessText, coverageGapDisplay } from './common/source-health'
+import {
+  sourceHealthClass,
+  freshnessText,
+  coverageGapDisplay,
+  type CoverageGapDisplay,
+} from './common/source-health'
 
 const TOOL_QUALITY_WINDOW_HOURS = 24
 
@@ -219,9 +224,12 @@ function TrendSparkline({ points }: { points: HourlyPoint[] }) {
 
   return html`
     <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3">
-      <div class="flex items-center justify-between mb-1.5">
+      <div class="flex items-baseline justify-between mb-1.5 gap-2">
         <${Eyebrow}>성공률 추이</${Eyebrow}>
-        <span class="text-xs font-mono" style="color:${lineColor}">${lastRate.toFixed(1)}%</span>
+        <div class="flex items-baseline gap-1.5 leading-tight">
+          <span class="text-3xs text-[var(--color-fg-disabled)]">최근 1시간</span>
+          <span class="text-xs font-mono" style="color:${lineColor}">${lastRate.toFixed(1)}%</span>
+        </div>
       </div>
       <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded-[var(--r-1)] w-full" role="img" aria-label="성공률 추이 차트" style="background:var(--bg-deepest);">
         ${bars.map(b => html`
@@ -246,13 +254,58 @@ function KeeperRateBars({ keepers }: { keepers: KeeperStat[] }) {
         const textColor = k.success_pct >= 95 ? 'text-[var(--color-status-ok)]' : k.success_pct >= 90 ? 'text-[var(--color-status-warn)]' : 'text-[var(--bad-light)]'
         return html`
           <div class="flex items-center gap-2 text-2xs">
-            <span class="w-24 truncate text-[var(--color-fg-disabled)] font-mono" title=${k.name}>${k.name}</span>
+            <span class="w-40 truncate text-[var(--color-fg-disabled)] font-mono" title=${k.name}>${k.name}</span>
             <${ProgressBar} pct=${k.success_pct} size="sm" class=${fillClass} trackClass="flex-1 bg-[var(--bg-subtle)]" />
             <span class="w-12 text-right font-mono ${textColor}">${k.success_pct.toFixed(1)}%</span>
             <span class="w-10 text-right text-[var(--color-fg-disabled)]">${k.calls}</span>
           </div>
         `
       })}
+    </div>
+  `
+}
+
+/**
+ * Coverage-gap provenance block. The summary line stays visible (1-line warn)
+ * while the long Sys_error blob hides under a closed `<details>` to reclaim
+ * vertical real estate. Producer/store/surface/trace stay flat-rendered because
+ * those are the triage-actionable fields; `error` is the noisy one.
+ *
+ * Label spans use `${label + ' '}` (not adjacent siblings) so DOM textContent
+ * preserves "label value" as a contiguous substring — keeps existing
+ * text-search tests working without format-coupling.
+ */
+function CoverageGapBlock({ display }: { display: CoverageGapDisplay }) {
+  const { structured } = display
+  return html`
+    <div class="mt-1 grid gap-1 rounded-[var(--r-1)] border border-[var(--color-status-warn)]/30 bg-[var(--warn-10)]/30 px-2 py-1.5 text-3xs">
+      <div class="flex items-center gap-1.5 font-medium text-[var(--color-status-warn)]">
+        <span aria-hidden="true">⚠</span>
+        <span>${display.summary}</span>
+      </div>
+      ${structured.fields.length > 0 ? html`
+        <div class="grid gap-0.5 font-mono">
+          ${structured.fields.map(({ label, value }) => html`
+            <div class="flex items-baseline">
+              <span class="w-16 shrink-0 text-[var(--color-fg-disabled)] uppercase tracking-wide">${label + ' '}</span>
+              <span class="min-w-0 break-all text-[var(--color-fg-muted)]">${value}</span>
+            </div>
+          `)}
+        </div>
+      ` : null}
+      ${structured.error ? html`
+        <details class="group">
+          <summary class="flex items-baseline cursor-pointer list-none [&::-webkit-details-marker]:hidden font-mono">
+            <span class="w-16 shrink-0 uppercase tracking-wide text-[var(--color-fg-disabled)]">error </span>
+            <span class="min-w-0 flex-1 truncate text-[var(--color-fg-muted)] group-open:hidden">${structured.error}</span>
+            <span class="ml-2 shrink-0 text-[var(--color-fg-disabled)]" aria-hidden="true">
+              <span class="group-open:hidden">▸</span>
+              <span class="hidden group-open:inline">▾</span>
+            </span>
+          </summary>
+          <pre class="mt-1 ml-16 max-h-32 overflow-auto rounded-[var(--r-1)] bg-[var(--bg-deepest)] p-2 font-mono text-3xs leading-snug text-[var(--color-fg-muted)] whitespace-pre-wrap break-all">${structured.error}</pre>
+        </details>
+      ` : null}
     </div>
   `
 }
@@ -319,19 +372,16 @@ export function ToolQualityPanel() {
             <span class="mx-1" aria-hidden="true">·</span>
             <span>${(d.entry_count ?? d.total).toLocaleString()} rows</span>
           </div>
-          ${coverageGap ? html`
-            <div class="mt-1 grid gap-0.5 text-3xs text-[var(--color-status-warn)]">
-              <span>${coverageGap.summary}</span>
-              ${coverageGap.details.map(detail => html`<span class="font-mono break-all">${detail}</span>`)}
-            </div>
-          ` : null}
+          ${coverageGap ? html`<${CoverageGapBlock} display=${coverageGap} />` : null}
         </div>
-        <button
-          class="text-3xs px-2 py-0.5 rounded-[var(--r-1)] bg-[var(--bg-subtle)] text-[var(--color-fg-disabled)] hover:text-[var(--text)]"
-          onClick=${handleRefreshToolQualityClick}
-          aria-label="도구 품질 새로고침"
-        >새로고침</button>
-        <span class="text-3xs text-[var(--color-fg-disabled)]">${formatAutoRefreshLabel(TELEMETRY_AUTO_REFRESH_MS)}</span>
+        <div class="flex flex-col items-end gap-0.5 leading-tight shrink-0">
+          <button
+            class="text-3xs px-2 py-0.5 rounded-[var(--r-1)] bg-[var(--bg-subtle)] text-[var(--color-fg-disabled)] hover:text-[var(--text)]"
+            onClick=${handleRefreshToolQualityClick}
+            aria-label="도구 품질 새로고침"
+          >새로고침</button>
+          <span class="text-3xs text-[var(--color-fg-disabled)]">${formatAutoRefreshLabel(TELEMETRY_AUTO_REFRESH_MS)}</span>
+        </div>
       </div>
 
       <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">


### PR DESCRIPTION
## Summary

Tool Quality view (`#monitoring?view=tool-quality`) 화면 개선. 운영자 피드백 기반 P0 3건 + P1 1건 묶음.

**Before**: Eio.Io `Sys_error("...")` 전체 stack trace가 인라인으로 노출되어 화면 50%+ 차지, 정작 triage-actionable chips (producer/store/surface/trace) 가시성 낮음. KPI 79.8%와 trend endpoint 82.4% 두 숫자가 같은 화면에 라벨 없이 공존.

**After**:
- coverage gap: 1-line warn 헤더 (`⚠ coverage gaps N: <reason>`) + 정렬된 chips + collapsible `<details>`로 raw error 압축
- trend endpoint: `최근 1시간` 라벨 추가 → window-wide KPI와 의미 분리
- cascade row: `w-24` → `w-40` (`tier-group.strict_tool_only` 같은 긴 이름 truncate 해소)
- refresh control: 버튼 + auto-refresh 상태를 수직 stack으로 그룹화

## What changed

| File | Change |
|------|--------|
| `dashboard/src/components/common/source-health.ts` | `CoverageGapDisplay`에 `structured: { reason, fields[], error }` 추가. 평면 `details` 배열은 SSOT 유지 (다른 패널 호환). |
| `dashboard/src/components/tool-quality-panel.ts` | 새 `CoverageGapBlock` 컴포넌트, trend 라벨, cascade 너비, refresh 그룹화 |
| `dashboard/src/components/common/source-health.test.ts` | `toEqual` expectation에 `structured` 필드 추가 |

## Why this avoids the workaround anti-patterns

- 텔레메트리-as-fix 아님: 데이터 손실 수정이 아니라 *이미 있는* coverage gap 정보의 *표시 방식* 개선
- String 분류기 아님: `structured.error` 분리는 `coverageGapDisplay`의 단일 함수에서 1번 수행, 호출자는 typed access
- N-of-M 아님: 한 PR에서 source-health + tool-quality-panel 모두 업데이트

## Verification

```
vitest:       39/39 PASS (tool-quality-panel, source-health, fleet-health-panel)
tsc --noEmit: clean (pre-existing credential-settings warning unchanged)
vite build:   ✓ built in 19.91s
eslint:       clean on modified files
```

`tool-quality-panel.test.ts`의 substring assertion (`textContent.toContain('producer keeper_...')` 등) 6건 모두 유지 — 새 컴포넌트가 `${label + ' '}` 패턴으로 label/value를 DOM textContent에서 인접하게 유지.

## Test plan

- [ ] `/monitoring?section=fleet-health&view=tool-quality` 진입 시 coverage gap이 있는 환경에서:
  - [ ] 1-line warn 헤더가 보이는가
  - [ ] producer/store/surface/trace 4 chip이 정렬되어 보이는가
  - [ ] error 행이 closed 상태로 시작하는가 (▸ 마커 + 1-line truncated preview)
  - [ ] 클릭 시 `<pre>` 블록으로 전체 stack trace가 노출되는가
- [ ] hourly trend 우상단에 `최근 1시간` 라벨 + 수치가 보이는가
- [ ] 캐스케이드 라벨 `tier-group.…` truncate 해소되었는가
- [ ] 새로고침 + Auto-refresh 30s 가 수직으로 정렬되는가
- [ ] coverage gap 없는 환경에서는 새 블록이 나타나지 않는가 (기존 동작 유지)

## Notes for review

- `<details open>` 사용 안 함 → 기본 closed. 운영자 클릭 1번 더 필요하지만 화면 압축 우선 결정.
- `node_modules` symlink는 worktree 검증 용도, commit 안 됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
