### PR TITLE
fix(dashboard): replace inline crashed-phase checks with SSOT isCrashedPhase

### DIFF
--- a/dashboard/src/components/status-tray.ts
+++ b/dashboard/src/components/status-tray.ts
@@ -2,6 +2,7 @@ import { html } from 'htm/preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import { Activity, AlertTriangle, Bell, Radio, Users, X } from 'lucide-preact'
 import type { JournalEntry, Keeper, Task } from '../types'
+import { isKeeperCrashed } from '../lib/keeper-predicates'
 import { dashboardWsOnlyEnabled } from '../dashboard-ws-cutover'
 import {
   dashboardWsConnected,
@@ -180,7 +181,7 @@ function countKeeperAttention(keeperInput: readonly Keeper[]): number {
     // boundary. Comparing typed phase tokens here means crashed keepers
     // actually get counted as attention rather than silently slipping
     // past an axis-confused string match.
-    return keeper.phase === 'Crashed' || keeper.phase === 'Dead' || keeper.phase === 'Zombie'
+    return isKeeperCrashed(keeper)
   }).length
 }
 

--- a/dashboard/src/lib/keeper-predicates.test.ts
+++ b/dashboard/src/lib/keeper-predicates.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import type { Keeper } from '../types/core'
 import {
   isKeeperCrashed,
+  isCrashedPhase,
   isKeeperPaused,
   isKeeperOffline,
   isKeeperRunningExcludingRestarting,
@@ -76,6 +77,26 @@ describe('isKeeperCrashed — audit A1 (2026-05-19)', () => {
   })
   it('undefined phase ⇒ NOT crashed', () => {
     expect(isKeeperCrashed(k())).toBe(false)
+  })
+})
+
+describe('isCrashedPhase — SSE-safe casing checker', () => {
+  it.each(['Crashed', 'crashed', 'Dead', 'dead', 'Zombie', 'zombie'])(
+    'phase=%s ⇒ crashed',
+    (phase) => {
+      expect(isCrashedPhase(phase)).toBe(true)
+    },
+  )
+  it.each(['Running', 'running', 'Paused', 'Failing', 'Offline', 'Restarting'])(
+    'phase=%s ⇒ NOT crashed',
+    (phase) => {
+      expect(isCrashedPhase(phase)).toBe(false)
+    },
+  )
+  it('null/undefined ⇒ NOT crashed', () => {
+    expect(isCrashedPhase(null)).toBe(false)
+    expect(isCrashedPhase(undefined)).toBe(false)
+    expect(isCrashedPhase('')).toBe(false)
   })
 })
 

--- a/dashboard/src/lib/keeper-predicates.ts
+++ b/dashboard/src/lib/keeper-predicates.ts
@@ -56,6 +56,18 @@ export function isKeeperCrashed(keeper: Keeper): boolean {
   return typeof phase === 'string' && CRASHED_PHASES.has(phase)
 }
 
+const CRASHED_PHASES_LOWERCASE: ReadonlySet<string> = new Set<string>(
+  [...CRASHED_PHASES].map(p => p.toLowerCase()),
+)
+
+/** Checks whether a phase string (any casing) represents a crashed state.
+ *  SSE events emit lowercase phase tokens; Keeper objects use PascalCase.
+ *  This normalizes both to the same SSOT set. */
+export function isCrashedPhase(phase: string | null | undefined): boolean {
+  if (typeof phase !== 'string') return false
+  return CRASHED_PHASES.has(phase) || CRASHED_PHASES_LOWERCASE.has(phase.toLowerCase())
+}
+
 /** Structural subset of `Keeper` accepted by `isKeeperOffline`.
  *  The predicate only reads `phase` and `status`, so callers that
  *  receive narrower snapshot shapes (e.g. `OperatorKeeperSnapshot`,

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -15,6 +15,7 @@ import {
 } from './journal-entry'
 import { appendLiveToolCall } from './components/session-trace/session-trace-live-store'
 import { appendAuditEntry } from './live-store'
+import { isCrashedPhase } from './lib/keeper-predicates'
 import { dashboardBearerToken } from './api/core'
 import { parseSSEMessage } from './schemas/sse'
 import { asNumber } from './components/common/normalize'
@@ -544,7 +545,7 @@ function handleEvent(event: SSEEvent): void {
         'keepers',
         'keeper_phase_changed',
         {
-          severity: (['failing', 'crashed', 'dead'].includes((event.new_phase ?? '').toLowerCase())) ? 'error' : 'info',
+          severity: isCrashedPhase(event.new_phase) ? 'error' : 'info',
           source: event.source,
           narrativeText: `${actorLabel(event.name ?? agent)}의 상태가 ${event.prev_phase ?? '?'}에서 ${event.new_phase ?? '?'}로 전이되었습니다`,
         },


### PR DESCRIPTION
## Summary
- `sse.ts:547` 인라인 `['failing','crashed','dead']` 리스트를 SSOT `isCrashedPhase()`로 교체. 기존 코드는 `'Zombie'` 누락 + 존재하지 않는 `'failing'` 리터럴 포함
- `status-tray.ts:183` 3-literal OR 체인을 `isKeeperCrashed()` SSOT 호출로 교체
- `keeper-predicates.ts`에 `isCrashedPhase()` 추가 — PascalCase + lowercase 모두 처리

## Test plan
- [x] `isCrashedPhase` 유닛테스트 추가 (PascalCase/lowercase/null/empty)
- [ ] CI lint checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)