### PR TITLE
refactor(shell): dedupe strict metachar gate

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.mli
+++ b/lib/cascade/cascade_attempt_fsm.mli
@@ -101,11 +101,6 @@ val sdk_error_to_provider_error :
 val provider_error_total_metric : string
 (** Prometheus counter for additive provider-error variant emission. *)
 
-val label_kind : string
-val label_cascade : string
-val provider_label : string -> string
-(** Shared Prometheus label helpers re-exported by {!Keeper_turn_driver}. *)
-
 val emit_provider_error_metric :
   cascade_name:Cascade_error_classify.cascade_name ->
   provider:string ->
@@ -156,3 +151,17 @@ val resolve_provider_api_key_env_name :
 
 val provider_auth_hint_marker : string
 val openai_compat_not_found_hint_marker : string
+
+(** {1 Saturation-signal metric labels and provider sanitiser} *)
+
+val label_kind : string
+(** Prometheus label key for the saturation-signal kind. *)
+
+val label_cascade : string
+(** Prometheus label key for the cascade name. *)
+
+val provider_label : string -> string
+(** Sanitise an upstream-supplied provider string into a Prometheus
+    label value; empty/blank inputs emit a callstack-tagged warning
+    via {!Prometheus.metric_cascade_attempt_empty_provider_label} and
+    fall back to a fixed placeholder. *)

--- a/lib/cascade/cascade_attempt_fsm.mli
+++ b/lib/cascade/cascade_attempt_fsm.mli
@@ -101,6 +101,11 @@ val sdk_error_to_provider_error :
 val provider_error_total_metric : string
 (** Prometheus counter for additive provider-error variant emission. *)
 
+val label_kind : string
+val label_cascade : string
+val provider_label : string -> string
+(** Shared Prometheus label helpers re-exported by {!Keeper_turn_driver}. *)
+
 val emit_provider_error_metric :
   cascade_name:Cascade_error_classify.cascade_name ->
   provider:string ->

--- a/lib/gh_command_validation.ml
+++ b/lib/gh_command_validation.ml
@@ -21,6 +21,8 @@ let contains_forbidden_shell_chars cmd =
       | _ -> false)
     cmd
 
+let has_strict_shell_metachar = contains_forbidden_shell_chars
+
 (** Top-level gh CLI commands allowed. Commands not in this list are
     rejected at the allowlist gate. *)
 let gh_allowed_commands =
@@ -214,7 +216,7 @@ let extract_gh_command_pair cmd =
 let validate_gh_command ?(allowed_orgs = []) cmd =
   let trimmed = String.trim cmd in
   if trimmed = "" then Error "gh command must not be empty"
-  else if contains_forbidden_shell_chars trimmed then
+  else if has_strict_shell_metachar trimmed then
     Error
       "Blocked: chaining/redirect in gh command. Use a single subcommand. \
        Good: cmd='pr list --state open'. Bad: cmd='pr list && echo done'."

--- a/lib/gh_command_validation.mli
+++ b/lib/gh_command_validation.mli
@@ -11,8 +11,7 @@
     that grades a command as R0 (read-only), R1 (reversible mutation),
     or R2 (irreversible) for the operator-approval flow.
 
-    Internal helpers ([forbidden_shell_chars],
-    [contains_forbidden_shell_chars], [gh_allowed_commands],
+    Internal helpers ([forbidden_shell_chars], [gh_allowed_commands],
     [gh_irreversible_ops], [gh_reversible_mutations],
     [gh_graphql_r2_mutations], [gh_blocked_operations],
     [gh_api_destructive_patterns], [gh_graphql_destructive_mutations],
@@ -59,6 +58,10 @@ val validate_gh_command :
 
     [allowed_orgs] is consulted only when the command carries an
     explicit [--repo OWNER/REPO]; [[]] disables that check. *)
+
+val has_strict_shell_metachar : string -> bool
+(** Shared scanner for the legacy single-command allowlist gate. It rejects
+    shell chaining, pipe, redirect, substitution, and control characters. *)
 
 val extract_gh_repo_owner : string -> string option
 (** Returns the [OWNER] portion of an explicit [--repo OWNER/REPO]

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -187,7 +187,7 @@ let validate_command_with_allowlist ~allowed_commands cmd =
   let trimmed = String.trim cmd in
   if trimmed = ""
   then Error Empty_command
-  else if contains_forbidden_shell_chars trimmed
+  else if Gh_command_validation.has_strict_shell_metachar trimmed
   then Error Chain_or_redirect
   else if invokes_direct_dune trimmed
   then Error Direct_dune_invocation

--- a/lib/worker_dev_tools_command_syntax.ml
+++ b/lib/worker_dev_tools_command_syntax.ml
@@ -4,20 +4,6 @@
     but worker_dev_tools still keeps a small legacy lexer for strict mode,
     fallback parsing, and path-token extraction. *)
 
-(* Mirror of [Gh_command_validation.forbidden_shell_chars].  Kept as a
-   list for docs/tests; the scan uses a closed pattern match below so the
-   per-byte check compiles to a jump table instead of an O(M) list walk
-   over [cmd]. *)
-let forbidden_shell_chars = [ ';'; '|'; '&'; '>'; '<'; '`'; '$'; '\n'; '\r' ]
-
-let contains_forbidden_shell_chars cmd =
-  String.exists
-    (function
-      | ';' | '|' | '&' | '>' | '<' | '`' | '$' | '\n' | '\r' -> true
-      | _ -> false)
-    cmd
-;;
-
 (** Relaxed metacharacter set for Coding/Full preset keepers.
     Allows [|] (pipes) and fd-to-fd redirects like [2>&1].
     Still blocks [;] [`] [$] and control chars.

--- a/lib/worker_dev_tools_command_syntax.mli
+++ b/lib/worker_dev_tools_command_syntax.mli
@@ -1,5 +1,3 @@
-val forbidden_shell_chars : char list
-val contains_forbidden_shell_chars : string -> bool
 val forbidden_shell_chars_coding_base : char list
 val has_dangerous_ampersand : string -> bool
 val contains_forbidden_shell_chars_coding : string -> bool

--- a/scripts/lint/shell-legacy-purge-ratchet.baseline
+++ b/scripts/lint/shell-legacy-purge-ratchet.baseline
@@ -6,5 +6,5 @@
 # counts; no PR may raise them.
 tokenize_path_args 4
 path_validation_tokens 4
-forbidden_shell_chars 22
+forbidden_shell_chars 15
 raw_keeper_bash_shape_block 0

--- a/test/test_cascade_tier_admission.ml
+++ b/test/test_cascade_tier_admission.ml
@@ -235,7 +235,7 @@ let test_keeper_wire_enabled_rejects_at_capacity () =
 let test_keeper_wire_disabled_is_passthrough () =
   let t = A.create ~default_max_inflight:0 () in
   let ran = ref false in
-  let result =
+  let outcome =
     KTD.with_cascade_tier_admission_for_testing
       ~admission:t
       ~enabled:false
@@ -246,13 +246,13 @@ let test_keeper_wire_disabled_is_passthrough () =
          "ok")
   in
   bool_check "attempt ran when flag disabled" true !ran;
-  check (result string signal_testable) "disabled flag passthrough" (Ok "ok") result;
+  check (result string signal_testable) "disabled flag passthrough" (Ok "ok") outcome;
   int_check "disabled path did not touch counter" 0
     (A.current_inflight t ~tier_id:"keeper-turn")
 
 let test_keeper_wire_bypass_policy_is_passthrough () =
   let t = A.create ~default_max_inflight:0 () in
-  let result =
+  let outcome =
     KTD.with_cascade_tier_admission_for_testing
       ~admission:t
       ~enabled:true
@@ -260,7 +260,7 @@ let test_keeper_wire_bypass_policy_is_passthrough () =
       ~admission_policy:A.Bypass
       (fun () -> 7)
   in
-  check (result int signal_testable) "bypass policy passthrough" (Ok 7) result;
+  check (result int signal_testable) "bypass policy passthrough" (Ok 7) outcome;
   int_check "bypass path did not touch counter" 0
     (A.current_inflight t ~tier_id:"keeper-turn")
 


### PR DESCRIPTION
## Summary
- repair latest main tier-admission compile/test surface exposed during focused validation
- expose the cascade saturation metric label helpers used by Keeper_turn_driver
- dedupe Worker_dev_tools strict shell metachar scanning onto Gh_command_validation and delete the duplicate Command_syntax copy
- lower shell legacy purge ratchet forbidden_shell_chars baseline from 22 to 15

## Validation
- PASS: bash scripts/lint/shell-legacy-purge-ratchet.sh
- PASS: git diff --check
- BLOCKED locally: scripts/dune-local.sh build test/test_worker_dev_tools.exe test/test_path_rewrite_validation.exe test/test_exec_shell_command_gate.exe test/test_gh_command_blocked_message_10561.exe test/test_cascade_tier_admission.exe; wrapper refused because a bare dune build is still running in .worktrees/fix/cascade-tier-admission-test-shadow (PID 74870). CI should provide the focused build signal.

## Next deletion slice
- after this lands, remove/rename the remaining forbidden_shell_chars_coding legacy surface once Shell_command_gate semantic reject reasons fully cover the Coding/Full path.