### PR TITLE
fix: repair main build after PR #17013 (cascade tier admission)

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.mli
+++ b/lib/cascade/cascade_attempt_fsm.mli
@@ -151,3 +151,17 @@ val resolve_provider_api_key_env_name :
 
 val provider_auth_hint_marker : string
 val openai_compat_not_found_hint_marker : string
+
+(** {1 Saturation-signal metric labels and provider sanitiser} *)
+
+val label_kind : string
+(** Prometheus label key for the saturation-signal kind. *)
+
+val label_cascade : string
+(** Prometheus label key for the cascade name. *)
+
+val provider_label : string -> string
+(** Sanitise an upstream-supplied provider string into a Prometheus
+    label value; empty/blank inputs emit a callstack-tagged warning
+    via {!Prometheus.metric_cascade_attempt_empty_provider_label} and
+    fall back to a fixed placeholder. *)

--- a/test/test_cascade_tier_admission.ml
+++ b/test/test_cascade_tier_admission.ml
@@ -235,7 +235,7 @@ let test_keeper_wire_enabled_rejects_at_capacity () =
 let test_keeper_wire_disabled_is_passthrough () =
   let t = A.create ~default_max_inflight:0 () in
   let ran = ref false in
-  let result =
+  let outcome =
     KTD.with_cascade_tier_admission_for_testing
       ~admission:t
       ~enabled:false
@@ -246,13 +246,13 @@ let test_keeper_wire_disabled_is_passthrough () =
          "ok")
   in
   bool_check "attempt ran when flag disabled" true !ran;
-  check (result string signal_testable) "disabled flag passthrough" (Ok "ok") result;
+  check (result string signal_testable) "disabled flag passthrough" (Ok "ok") outcome;
   int_check "disabled path did not touch counter" 0
     (A.current_inflight t ~tier_id:"keeper-turn")
 
 let test_keeper_wire_bypass_policy_is_passthrough () =
   let t = A.create ~default_max_inflight:0 () in
-  let result =
+  let outcome =
     KTD.with_cascade_tier_admission_for_testing
       ~admission:t
       ~enabled:true
@@ -260,7 +260,7 @@ let test_keeper_wire_bypass_policy_is_passthrough () =
       ~admission_policy:A.Bypass
       (fun () -> 7)
   in
-  check (result int signal_testable) "bypass policy passthrough" (Ok 7) result;
+  check (result int signal_testable) "bypass policy passthrough" (Ok 7) outcome;
   int_check "bypass path did not touch counter" 0
     (A.current_inflight t ~tier_id:"keeper-turn")
 


### PR DESCRIPTION
## 증상

origin/main (`4d41eb6d4c`) 에서 `dune build` 가 두 곳에서 실패합니다.

### 1. lib/keeper/keeper_turn_driver.ml:58
\`\`\`
Error: Unbound value label_kind
\`\`\`
\`emit_cascade_tier_admission_signal_metric\` 함수가 \`label_kind\`, \`label_cascade\`, \`provider_label\` 셋을 참조하지만 모두 \`cascade_attempt_fsm.ml\` 내부 private let binding으로 \`.mli\`에 노출되지 않은 상태입니다. \`keeper_turn_driver.ml\` 이 \`include Cascade_attempt_fsm\` 하지만, explicit \`.mli\`를 가진 모듈의 include는 \`val\`-declared symbol만 surface하므로 이 세 가지는 facade를 통과해도 unreachable.

### 2. test/test_cascade_tier_admission.ml:249, :263
\`\`\`
Error: This expression has type (string, S.t) result
       This is not a function; it cannot be applied.
\`\`\`
두 테스트 케이스가 \`let result = ...\`로 로컬 바인딩을 두는데 이게 Alcotest의 \`result\` combinator (\`open Alcotest\`로 가져온 것)를 shadow합니다. 다음 줄 \`check (result string signal_testable) ... result\`에서 컴파일러가 로컬 값을 함수처럼 적용하려 함.

## 원인

두 에러 모두 **PR #17013 (\`feat(cascade): wire tier admission into keeper attempts\`)** 에서 들어왔습니다. CI sandbox path filter (메모리 SSOT: \`feedback_ci_sandbox_path_filter_masks_syntax_bugs.md\`) 가 \`lib/keeper/\` 와 \`test/\` 변경에서 또 syntax-level error를 마스킹한 동일 패턴입니다 — 이번 세션 *3번째* 재발 (#16988→#16996, 그리고 지금).

## 수정

**lib/cascade/cascade_attempt_fsm.mli** — 3개 val 추가:
- \`val label_kind : string\`
- \`val label_cascade : string\`
- \`val provider_label : string -> string\`

이 세 가지는 같은 \`metric_keeper_cascade_saturation_signal\` 메트릭의 SSOT 라벨 키 + provider 문자열 sanitiser입니다. 자매 emission site (\`cascade_attempt_fsm.ml:867 maybe_emit_cascade_saturation_signal\`) 이 이미 동일 상수를 사용하므로 *추상화 추가가 아니라 기존 SSOT를 노출*하는 변경입니다.

**test/test_cascade_tier_admission.ml** — 두 케이스의 \`let result\` → \`let outcome\` 리네임. 의미 변화 없음.

## 검증

\`\`\`
$ dune build --root .
# clean, exit 0 (macOS ld zstd 중복 warning은 무해)
$ dune exec --root . test/test_cascade_tier_admission.exe
Test Successful in 0.002s. 18 tests run.
$ ocamlformat --check test/test_cascade_tier_admission.ml lib/cascade/cascade_attempt_fsm.mli
# clean
\`\`\`

## 범위

- 2 파일, +18/-4 LoC
- production code 행동 변화 없음 (val 노출은 ABI 확장, 기존 caller에 무영향)
- RFC subsystem (credential/operator/sandbox/dashboard) 미접촉, RFC 발견 체크 불필요

## 후속

이 PR 머지 후 version bump PR (\`release/v0.19.26\`) 를 띄울 예정입니다 (별도 worktree에서 대기 중). 깨진 main 위에서 release point cutting하는 안티패턴 회피.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>