### PR TITLE
fix(dashboard): make HEALTH chips clickable, link FD-exhaustion errors to RFC-0097

### DIFF
--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -582,4 +582,88 @@ describe('dashboardHealthChips', () => {
     })])
     expect(chips[0]?.detail).toContain('pending=2')
   })
+
+  it('attaches drill-down routes so HEALTH chips deep-link operators to the right view', () => {
+    const chips = dashboardHealthChips({
+      connected: true,
+      counts: { keepers: 0, configured_keepers: 3 },
+      keepers: [{
+        name: 'keeper-a',
+        status: 'paused',
+        paused: true,
+      } as any],
+      runtimeResolution: {
+        status: 'warn',
+        warnings: [],
+        source_mismatch: true,
+        server_workspace_mismatch: false,
+      } as any,
+      executionError: null,
+      loading: false,
+    })
+
+    const byKey = Object.fromEntries(chips.map(c => [c.key, c]))
+
+    // source-mismatch → runtime resolution view
+    expect(byKey['source-mismatch']?.route).toEqual({
+      tab: 'monitoring',
+      params: { section: 'runtime' },
+    })
+    // paused-keepers → fleet-health (operator drills into the keeper list)
+    expect(byKey['paused-keepers']?.route).toEqual({
+      tab: 'monitoring',
+      params: { section: 'fleet-health' },
+    })
+    // no-keeper-rows → same fleet-health section (configured vs live diff)
+    expect(byKey['no-keeper-rows']?.route).toEqual({
+      tab: 'monitoring',
+      params: { section: 'fleet-health' },
+    })
+  })
+
+  it('leaves transport-offline and execution-error without routes (no useful drill-down)', () => {
+    const chips = dashboardHealthChips({
+      connected: false,
+      counts: null,
+      keepers: [],
+      runtimeResolution: null,
+      executionError: 'snapshot failed',
+      loading: false,
+    })
+
+    const byKey = Object.fromEntries(chips.map(c => [c.key, c]))
+    expect(byKey['transport-offline']?.route).toBeUndefined()
+    expect(byKey['execution-error']?.route).toBeUndefined()
+  })
+
+  it('routes the reaction-ledger chip to the reactivity monitor view', () => {
+    const chips = dashboardHealthChips({
+      connected: true,
+      counts: { keepers: 2, configured_keepers: 2 },
+      keepers: [],
+      runtimeResolution: {
+        status: 'ready',
+        warnings: [],
+        fleet_safety: {
+          keeper_reaction_ledger: {
+            status: 'degraded',
+            pending_stimulus_count: 2,
+            cursor_swept_stimulus_count: 0,
+            legacy_cursor_swept_stimulus_count: 0,
+            read_error_count: 0,
+            cursor_ack_count: 5,
+            operator_action_required: false,
+          },
+        },
+      } as any,
+      executionError: null,
+      loading: false,
+    })
+
+    const ledger = chips.find(c => c.key === 'reaction-ledger')
+    expect(ledger?.route).toEqual({
+      tab: 'monitoring',
+      params: { section: 'fleet-health', view: 'keeper-health' },
+    })
+  })
 })

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -147,11 +147,22 @@ export function ConnectionStatus() {
 
 type DashboardHealthChipTone = 'ok' | 'warn' | 'bad' | 'muted'
 
+interface DashboardHealthChipRoute {
+  tab: TabId
+  params: Record<string, string>
+}
+
 interface DashboardHealthChip {
   key: string
   label: string
   detail: string
   tone: DashboardHealthChipTone
+  // Optional drill-down route. When set, DashboardHealthStrip renders this
+  // chip as a RouteLink so operators can jump from "Source mismatch" /
+  // "Paused keepers N" / "Reaction ledger pending N" straight to the page
+  // that explains the signal. Chips without a route render as static spans
+  // (e.g. transport-offline — no view helps).
+  route?: DashboardHealthChipRoute
 }
 
 interface DashboardHealthInput {
@@ -326,6 +337,28 @@ function reactionLedgerHealthChip(
       `read_errors=${readErrors}`,
     ].join(', '),
     tone,
+    route: {
+      tab: 'monitoring',
+      params: { section: 'fleet-health', view: 'keeper-health' },
+    },
+  }
+}
+
+// Drill-down routes for each chip key. Centralized so the builder stays
+// readable and tests can audit the routing table separately. Returning
+// undefined keeps the chip as a static span (transport-offline,
+// execution-error: no view helps; hydrating/runtime-ok: nothing to drill).
+function chipRouteFor(key: string): DashboardHealthChipRoute | undefined {
+  switch (key) {
+    case 'source-mismatch':
+    case 'runtime-warning':
+      return { tab: 'monitoring', params: { section: 'runtime' } }
+    case 'paused-keepers':
+    case 'fleet-liveness-risk':
+    case 'no-keeper-rows':
+      return { tab: 'monitoring', params: { section: 'fleet-health' } }
+    default:
+      return undefined
   }
 }
 
@@ -408,7 +441,9 @@ export function dashboardHealthChips(input: DashboardHealthInput): DashboardHeal
     })
   }
 
-  return chips
+  // Attach drill-down routes via the central chipRouteFor() table. Chips
+  // that already carry an inline `route` (reaction-ledger) keep theirs.
+  return chips.map(chip => chip.route ? chip : { ...chip, route: chipRouteFor(chip.key) })
 }
 
 function healthChipClass(tone: DashboardHealthChipTone): string {
@@ -446,7 +481,16 @@ export function DashboardHealthStrip() {
       data-testid="dashboard-health-strip"
     >
       <span class="font-mono uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Health</span>
-      ${chips.map(chip => html`
+      ${chips.map(chip => chip.route ? html`
+        <${RouteLink}
+          key=${chip.key}
+          tab=${chip.route.tab}
+          params=${chip.route.params}
+          class=${`inline-flex min-h-6 items-center rounded-[var(--r-1)] border px-2 py-0.5 font-medium transition-opacity hover:opacity-80 ${healthChipClass(chip.tone)}`}
+          title=${chip.detail}
+          data-testid=${`dashboard-health-chip-${chip.key}`}
+        >${chip.label}<//>
+      ` : html`
         <span
           key=${chip.key}
           class=${`inline-flex min-h-6 items-center rounded-[var(--r-1)] border px-2 py-0.5 font-medium ${healthChipClass(chip.tone)}`}

--- a/dashboard/src/components/tool-quality-panel.test.ts
+++ b/dashboard/src/components/tool-quality-panel.test.ts
@@ -3,7 +3,7 @@ import { render } from 'preact'
 import { act } from 'preact/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ToolQualityResponse } from '../api/dashboard'
-import { filterTools, toolMatchesSearch } from './tool-quality-panel'
+import { classifyCoverageError, filterTools, toolMatchesSearch } from './tool-quality-panel'
 
 vi.setConfig({
   testTimeout: 40000,
@@ -372,6 +372,39 @@ describe('toolMatchesSearch', () => {
   it('returns false for non-matching substring', () => {
     expect(toolMatchesSearch(tool, 'xyz')).toBe(false)
     expect(toolMatchesSearch(tool, 'cascade')).toBe(false)
+  })
+})
+
+describe('classifyCoverageError', () => {
+  it('returns null for empty / missing input', () => {
+    expect(classifyCoverageError(null)).toBeNull()
+    expect(classifyCoverageError(undefined)).toBeNull()
+    expect(classifyCoverageError('')).toBeNull()
+  })
+
+  it('detects "Too many open files" → RFC-0097 fd_exhaustion hint', () => {
+    const hint = classifyCoverageError(
+      'Sys_error("Eio.Io Unix_error (Too many open files in system, \\"fstatat\\", \\"...\\")")',
+    )
+    expect(hint).not.toBeNull()
+    expect(hint?.reason).toBe('fd_exhaustion')
+    expect(hint?.href).toContain('RFC-0097')
+    expect(hint?.label).toMatch(/RFC-0097/)
+  })
+
+  it('detects raw ENFILE / EMFILE errno names', () => {
+    expect(classifyCoverageError('ENFILE: too many'))?.toMatchObject({ reason: 'fd_exhaustion' })
+    expect(classifyCoverageError('EMFILE on open'))?.toMatchObject({ reason: 'fd_exhaustion' })
+  })
+
+  it('is case-insensitive on the trigger pattern', () => {
+    expect(classifyCoverageError('TOO MANY OPEN FILES')?.reason).toBe('fd_exhaustion')
+  })
+
+  it('returns null for unrelated errors (disk full, network, etc.)', () => {
+    expect(classifyCoverageError('disk full')).toBeNull()
+    expect(classifyCoverageError('connection refused')).toBeNull()
+    expect(classifyCoverageError('append denied')).toBeNull()
   })
 })
 

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -265,11 +265,43 @@ function KeeperRateBars({ keepers }: { keepers: KeeperStat[] }) {
   `
 }
 
+// Classifier for operator-actionable error patterns. Returns a hint with a
+// canonical RFC link when the error string matches a known incident class.
+// Pure function — kept exported for unit testing in isolation.
+//
+// Pattern → RFC mapping is the SSOT for "what should operator do when they
+// see this error in the dashboard". Add new patterns here as RFCs land for
+// new failure modes.
+type CoverageErrorHint = { label: string; href: string; reason: string }
+
+export function classifyCoverageError(error: string | null | undefined): CoverageErrorHint | null {
+  if (!error) return null
+  const lower = error.toLowerCase()
+  // RFC-0097: keeper-sandbox container reuse — root fix for the 2026-05-16
+  // ENFILE storm that drove Docker_spawn_throttle + container reuse.
+  if (
+    lower.includes('too many open files')
+    || lower.includes('enfile')
+    || lower.includes('emfile')
+  ) {
+    return {
+      reason: 'fd_exhaustion',
+      label: 'FD exhaustion — see RFC-0097',
+      href: 'https://github.com/jeong-sik/masc-mcp/blob/main/docs/rfc/RFC-0097-keeper-sandbox-container-reuse.md',
+    }
+  }
+  return null
+}
+
 /**
  * Coverage-gap provenance block. The summary line stays visible (1-line warn)
  * while the long Sys_error blob hides under a closed `<details>` to reclaim
  * vertical real estate. Producer/store/surface/trace stay flat-rendered because
  * those are the triage-actionable fields; `error` is the noisy one.
+ *
+ * When the error matches a known operator-actionable pattern (e.g. FD
+ * exhaustion), a small "see RFC-XXXX" link renders below the details block —
+ * Error→Action linkage so operators don't have to grep RFCs themselves.
  *
  * Label spans use `${label + ' '}` (not adjacent siblings) so DOM textContent
  * preserves "label value" as a contiguous substring — keeps existing
@@ -277,6 +309,7 @@ function KeeperRateBars({ keepers }: { keepers: KeeperStat[] }) {
  */
 function CoverageGapBlock({ display }: { display: CoverageGapDisplay }) {
   const { structured } = display
+  const hint = classifyCoverageError(structured.error)
   return html`
     <div class="mt-1 grid gap-1 rounded-[var(--r-1)] border border-[var(--color-status-warn)]/30 bg-[var(--warn-10)]/30 px-2 py-1.5 text-3xs">
       <div class="flex items-center gap-1.5 font-medium text-[var(--color-status-warn)]">
@@ -305,6 +338,19 @@ function CoverageGapBlock({ display }: { display: CoverageGapDisplay }) {
           </summary>
           <pre class="mt-1 ml-16 max-h-32 overflow-auto rounded-[var(--r-1)] bg-[var(--bg-deepest)] p-2 font-mono text-3xs leading-snug text-[var(--color-fg-muted)] whitespace-pre-wrap break-all">${structured.error}</pre>
         </details>
+      ` : null}
+      ${hint ? html`
+        <a
+          href=${hint.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="ml-16 inline-flex items-center gap-1 self-start rounded-[var(--r-1)] border border-[var(--color-status-warn)]/40 bg-[var(--warn-10)] px-1.5 py-0.5 font-medium text-[var(--color-status-warn)] hover:bg-[var(--warn-20)]"
+          data-testid=${`coverage-gap-hint-${hint.reason}`}
+        >
+          <span aria-hidden="true">💡</span>
+          <span>${hint.label}</span>
+          <span aria-hidden="true">↗</span>
+        </a>
       ` : null}
     </div>
   `


### PR DESCRIPTION
## Summary

PR #17015 (Tool Monitor UX) 후속. 사용자 발견한 P1/P2 중 코드 영향 명확하고 RFC 트리거 영역 아닌 2건.

### 1. HEALTH chips → 클릭 가능 (deep-link)

상단 노란 배지(`HEALTH  [Source mismatch]  [Paused keepers 3]`)가 display-only `<span>`이었음. 운영자가 신호 발견 → 어디 봐야 하나? 매번 다시 찾음. 이제 의미 있는 chip은 RouteLink로 변환.

| chip key | route |
|----------|-------|
| `source-mismatch` / `runtime-warning` | `monitoring · section=runtime` |
| `paused-keepers` / `fleet-liveness-risk` / `no-keeper-rows` | `monitoring · section=fleet-health` |
| `reaction-ledger` | `monitoring · section=fleet-health, view=keeper-health` (반응성 모니터) |

`transport-offline` / `execution-error` / `hydrating` / `runtime-ok`은 plain span 유지 — 별도 drill view가 도움 안 되거나 상태 chip 자체로 충분.

### 2. Coverage gap error → RFC link hint

`CoverageGapBlock` (PR #17015에서 추가)의 collapsed `<details>` 아래에, error 텍스트가 *operator-actionable 패턴*과 매치하면 💡 RFC 링크가 자동 렌더.

현재 매핑: **"Too many open files" / ENFILE / EMFILE → RFC-0097 (keeper-sandbox container reuse)**. 2026-05-16 ENFILE storm 사후 RFC 자체가 root fix이므로, 운영자가 같은 패턴 발견 시 즉시 그 RFC로 점프.

```
⚠ coverage gaps 3: tool_call_io_append_failed
  producer  keeper_hooks_oas|...
  store     /Users/dancer/me/.masc/tool_calls
  surface   /api/v1/keepers/:name/tool-calls
  trace     trace-1777434501037-f8923
  error     Sys_error(...)                    ▸
  💡 FD exhaustion — see RFC-0097 ↗
```

추가 패턴은 `classifyCoverageError()` 한 함수에 branch 추가하면 됨 (SSOT).

## What changed

| File | Change |
|------|--------|
| `dashboard/src/components/dashboard-shell.ts` | `DashboardHealthChip.route?: { tab, params }` 추가. `chipRouteFor()` 매핑 함수 + 빌더 final `.map()` pass + `DashboardHealthStrip` branching render |
| `dashboard/src/components/tool-quality-panel.ts` | exported pure `classifyCoverageError(error)` + `CoverageGapBlock` 안에서 hint anchor 렌더 |
| `dashboard/src/components/dashboard-shell.test.ts` | 3개 신규 케이스 — route 매핑 audit, transport-offline/execution-error route 부재, reaction-ledger view 라우팅 |
| `dashboard/src/components/tool-quality-panel.test.ts` | 4개 신규 케이스 — classifier null/positive/case-insensitive/negative |

## Why this avoids the workaround anti-patterns

- **텔레메트리-as-fix 아님**: 데이터 손실 fix가 아니라 *기존 신호*의 *접근성* 향상
- **String classifier 보강 아님**: `classifyCoverageError`는 신규 typed 함수 (closed return type `CoverageErrorHint | null`), 기존 string 분류기 *확장*이 아님
- **N-of-M 아님**: chip routing은 한 패치에서 5 chip 모두, classifier는 단일 함수

## Verification

```
vitest:       46/46 PASS (added 7 cases)
tsc --noEmit: clean on changed files (pre-existing agent-roster.ts / credential-settings.ts errors untouched)
eslint:       0 errors
vite build:   ✓ 59.08s
```

## Test plan

- [ ] 대시보드 진입 시 HEALTH 배지가 hover 가능 (opacity transition)
- [ ] "Source mismatch" 클릭 → `#monitoring?section=runtime` 으로 이동
- [ ] "Paused keepers N" 클릭 → `#monitoring?section=fleet-health`
- [ ] "Reaction ledger ..." 클릭 → `#monitoring?section=fleet-health&view=keeper-health`
- [ ] "Transport offline" / "Execution refresh failed" 은 여전히 평범한 span (커서 없음)
- [ ] Tool Quality 화면에서 coverage gap error가 "Too many open files" 패턴이면 💡 hint 보임
- [ ] hint 클릭 시 새 탭으로 GitHub RFC 페이지 열림
- [ ] error가 "disk full" 같은 다른 패턴이면 hint 없음 (false positive 차단)

## Notes for review

- External link `target="_blank" rel="noopener noreferrer"` 표준 패턴
- RFC 링크는 `github.com/jeong-sik/masc-mcp/blob/main/...` 고정 URL. fork/branch 변경 시 끊김. main 트리 기준 stable로 판단.
- `chipRouteFor`에 새 chip key 추가 시 라우팅 자동 적용 — 빌더 push 사이트 수정 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
