### PR TITLE
refactor(shell): hide dead coding metachar helpers

### DIFF
--- a/lib/worker_dev_tools_command_syntax.ml
+++ b/lib/worker_dev_tools_command_syntax.ml
@@ -9,7 +9,6 @@
     Still blocks [;] [`] [$] and control chars.
     [&] is checked at pattern level: [>&] (redirect) is allowed,
     [&&] (chaining) and standalone [&] (background) are blocked. *)
-let forbidden_shell_chars_coding_base = [ ';'; '`'; '$'; '\n'; '\r' ]
 
 (** Returns [true] if [cmd] contains a dangerous [&] usage.
     [>&] in redirect context (e.g. [2>&1]) is safe; [&&] and standalone [&]

--- a/lib/worker_dev_tools_command_syntax.mli
+++ b/lib/worker_dev_tools_command_syntax.mli
@@ -1,5 +1,3 @@
-val forbidden_shell_chars_coding_base : char list
-val has_dangerous_ampersand : string -> bool
 val contains_forbidden_shell_chars_coding : string -> bool
 val contains_substring : string -> string -> bool
 val has_process_substitution : string -> bool

--- a/scripts/lint/shell-legacy-purge-ratchet.baseline
+++ b/scripts/lint/shell-legacy-purge-ratchet.baseline
@@ -6,5 +6,5 @@
 # counts; no PR may raise them.
 tokenize_path_args 4
 path_validation_tokens 4
-forbidden_shell_chars 15
+forbidden_shell_chars 13
 raw_keeper_bash_shape_block 0


### PR DESCRIPTION
## Summary
- delete the unused forbidden_shell_chars_coding_base value
- stop exporting has_dangerous_ampersand; it is only an implementation detail of contains_forbidden_shell_chars_coding
- lower shell legacy purge ratchet forbidden_shell_chars baseline from 15 to 13

## Validation
- PASS: bash scripts/lint/shell-legacy-purge-ratchet.sh
- PASS: git diff --check
- BLOCKED locally: scripts/dune-local.sh build test/test_worker_dev_tools.exe test/test_exec_shell_command_gate.exe; wrapper refused because bare dune builds are running elsewhere on the host (PIDs 38435, 42461, 27391). CI should provide the OCaml compile/test signal.

## Notes
- I did not remove contains_forbidden_shell_chars_coding itself in this slice because that flips the pinned legacy corpus behavior for glob/brace/backslash rows and should be handled as an explicit Shell IR authority migration.