### PR TITLE
refactor(dashboard): lift cost-dashboard signals + LoadState types into cost-store

### DIFF
--- a/dashboard/src/components/cost-dashboard.ts
+++ b/dashboard/src/components/cost-dashboard.ts
@@ -12,7 +12,7 @@
 // new `/api/v1/dashboard/keeper-costs` endpoint.
 
 import { html } from 'htm/preact'
-import { signal, computed } from '@preact/signals'
+import { computed } from '@preact/signals'
 import {
   fetchRuntimeModelMetrics,
   fetchKeeperCostMetrics,
@@ -30,9 +30,7 @@ import {
   type StressEvent,
   type AgentStressRow,
   type AuditEntry,
-  type AuditLedgerResponse,
   type KeeperDecision,
-  type KeeperDecisionsResponse,
   type DashboardFeedMetadata,
 } from '../api/dashboard'
 import { LoadingState, ErrorState } from './common/feedback-state'
@@ -54,6 +52,18 @@ import {
   auditRouteParams,
   auditLogRouteParams,
 } from './cost/cost-types'
+import {
+  type ModelLoadState,
+  viewMode,
+  modelState,
+  keeperState,
+  heuristicState,
+  stressState,
+  coverageState,
+  auditLedgerState,
+  keeperDecisionsState,
+  windowMinutes,
+} from './cost/cost-store'
 import { formatTokens, severityClass } from './cost/cost-formatters'
 import {
   severityBuckets,
@@ -82,56 +92,8 @@ export {
   summarizeAuditKinds,
 }
 
-type ModelLoadState =
-  | { status: 'idle' }
-  | { status: 'loading' }
-  | { status: 'loaded'; data: DashboardRuntimeModelMetric[]; latencyBuckets: LatencyBucket[]; windowMinutes: number }
-  | { status: 'error'; message: string }
-
-type KeeperLoadState =
-  | { status: 'idle' }
-  | { status: 'loading' }
-  | { status: 'loaded'; data: KeeperCostMetric[]; windowMinutes: number }
-  | { status: 'error'; message: string }
-
-type HeuristicLoadState =
-  | { status: 'idle' }
-  | { status: 'loading' }
-  | { status: 'loaded'; data: HeuristicEvent[]; limit: number; meta: DashboardFeedMetadata }
-  | { status: 'error'; message: string }
-
-type StressLoadState =
-  | { status: 'idle' }
-  | { status: 'loading' }
-  | { status: 'loaded'; events: StressEvent[]; board: AgentStressRow[]; limit: number; meta: DashboardFeedMetadata }
-  | { status: 'error'; message: string }
-
-type CoverageLoadState =
-  | { status: 'idle' }
-  | { status: 'loading' }
-  | { status: 'loaded'; data: HeuristicCoverage }
-  | { status: 'error'; message: string }
-
-type AuditLedgerLoadState =
-  | { status: 'idle' }
-  | { status: 'loading' }
-  | { status: 'loaded'; data: AuditLedgerResponse }
-  | { status: 'error'; message: string }
-
-type KeeperDecisionsLoadState =
-  | { status: 'idle' }
-  | { status: 'loading' }
-  | { status: 'loaded'; data: KeeperDecisionsResponse }
-  | { status: 'error'; message: string }
-
-const viewMode = signal<ViewMode>('model')
-const modelState = signal<ModelLoadState>({ status: 'idle' })
-const keeperState = signal<KeeperLoadState>({ status: 'idle' })
-const heuristicState = signal<HeuristicLoadState>({ status: 'idle' })
-const stressState = signal<StressLoadState>({ status: 'idle' })
-const coverageState = signal<CoverageLoadState>({ status: 'idle' })
-const auditLedgerState = signal<AuditLedgerLoadState>({ status: 'idle' })
-const keeperDecisionsState = signal<KeeperDecisionsLoadState>({ status: 'idle' })
+// Type definitions and signal SSOT live in `./cost/cost-store`. This file
+// stays focused on view logic + load functions that mutate them.
 function cleanRouteParam(value: string | undefined): string | null {
   const trimmed = value?.trim()
   return trimmed ? trimmed : null
@@ -154,7 +116,6 @@ const WINDOW_OPTIONS: Array<{ key: number; label: string }> = [
   { key: DEFAULT_WINDOW_MINUTES_24H, label: '24시간' },
 ]
 
-const windowMinutes = signal<number>(60)
 
 const COST_FOCUS_COCKPIT_TABS: Record<CostFocus, string> = {
   agent: 'ct-agt',

--- a/dashboard/src/components/cost/cost-store.ts
+++ b/dashboard/src/components/cost/cost-store.ts
@@ -1,0 +1,80 @@
+// MASC Dashboard — cost dashboard shared state
+//
+// Module-level Preact signals consumed by cost-dashboard.ts and (in the
+// future) other panels that surface the same telemetry. Centralizing the
+// store here means the host components stop owning the SSOT directly and
+// can be swapped (e.g. extracting Advanced telemetry into a dedicated
+// surface) without breaking the data flow.
+//
+// Mount safety note: these signals are singletons; if two host components
+// mount simultaneously they share state. The current cost-dashboard host
+// guards against that by rendering exactly one view at a time, but any
+// future re-host MUST preserve mutual exclusion or migrate to a factory
+// pattern (per-mount instances).
+
+import { signal } from '@preact/signals'
+import type {
+  DashboardRuntimeModelMetric,
+  KeeperCostMetric,
+  LatencyBucket,
+  HeuristicEvent,
+  HeuristicCoverage,
+  StressEvent,
+  AgentStressRow,
+  AuditLedgerResponse,
+  KeeperDecisionsResponse,
+  DashboardFeedMetadata,
+} from '../../api/dashboard'
+import type { ViewMode } from './cost-types'
+
+export type ModelLoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'loaded'; data: DashboardRuntimeModelMetric[]; latencyBuckets: LatencyBucket[]; windowMinutes: number }
+  | { status: 'error'; message: string }
+
+export type KeeperLoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'loaded'; data: KeeperCostMetric[]; windowMinutes: number }
+  | { status: 'error'; message: string }
+
+export type HeuristicLoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'loaded'; data: HeuristicEvent[]; limit: number; meta: DashboardFeedMetadata }
+  | { status: 'error'; message: string }
+
+export type StressLoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'loaded'; events: StressEvent[]; board: AgentStressRow[]; limit: number; meta: DashboardFeedMetadata }
+  | { status: 'error'; message: string }
+
+export type CoverageLoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'loaded'; data: HeuristicCoverage }
+  | { status: 'error'; message: string }
+
+export type AuditLedgerLoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'loaded'; data: AuditLedgerResponse }
+  | { status: 'error'; message: string }
+
+export type KeeperDecisionsLoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'loaded'; data: KeeperDecisionsResponse }
+  | { status: 'error'; message: string }
+
+export const viewMode = signal<ViewMode>('model')
+export const modelState = signal<ModelLoadState>({ status: 'idle' })
+export const keeperState = signal<KeeperLoadState>({ status: 'idle' })
+export const heuristicState = signal<HeuristicLoadState>({ status: 'idle' })
+export const stressState = signal<StressLoadState>({ status: 'idle' })
+export const coverageState = signal<CoverageLoadState>({ status: 'idle' })
+export const auditLedgerState = signal<AuditLedgerLoadState>({ status: 'idle' })
+export const keeperDecisionsState = signal<KeeperDecisionsLoadState>({ status: 'idle' })
+export const windowMinutes = signal<number>(60)


### PR DESCRIPTION
## Goal
cost-dashboard.ts(1439 LoC)에 박혀 있던 9 모듈-레벨 Preact signal + 7 LoadState 합타입을 신규 `./cost/cost-store.ts`로 추출. SSOT 분리. 동작 변화 0.

## Changed files
- 신규 `dashboard/src/components/cost/cost-store.ts` (~95 LoC) — 9 signal export + 7 LoadState type export
- 수정 `dashboard/src/components/cost-dashboard.ts` (-54 LoC) — 9 signal/7 type 정의 제거, import로 대체. `signal` import 및 미사용 api 타입 2개(`AuditLedgerResponse`/`KeeperDecisionsResponse`) 정리

## Self-review
- 목표: PR-4 v2 (telemetry-panel.ts 추출) prereq + cost-dashboard godfile 분해 한 걸음
- 범위: 1 신규 + 1 수정. 95+/54- = +41 net (모듈 분리 오버헤드)
- 동작 변화: **0**. Preact signal mutation 은 reference-stable, `modelState.value = ...` 호출 그대로 동작
- 로컬 검증:
  - `pnpm run typecheck` — 본 변경 관련 0 에러
    - 사전 존재 baseline: agent-roster.ts(444,65), (503,65) TS2339 + credential-settings.ts(13,3) TS6133 — 본 PR 무관
  - `pnpm vitest run src/components/cost-dashboard` — **44/44 passed**

## 외부 영향 검증
`rg "from .*cost-dashboard" src/ test/` 결과 외부 import 1건: `runtime-panel.ts:32 import { CostDashboard, type CostView } from './cost-dashboard'`. 옮긴 signal/type 어느 것도 외부에서 import되지 않음. 안전한 내부 리팩터.

## Mount safety note (코드 주석에도 명시)
9 signal은 여전히 module-level singleton. 향후 두 host가 동시 mount되면 state 공유. 현재 cost-dashboard host는 한 번에 한 view만 렌더링해서 충돌 없음. PR-4 v2 telemetry-panel 추출 시 mutual exclusion 유지 또는 factory pattern으로 전환 필요 (별도 PR).

## 왜 이 PR이 작은가
PR-4 v2 (telemetry-panel.ts 추출) 진입 전 prereq. signal store 분리 자체는 mechanical = 머지 risk 작음. telemetry-panel 추출 본체는 ~230 LoC + cockpit alias 라우팅 검증 필요해서 별도 PR로 분리.

## References
- RFC-0050 PR-1 `./cost/` 모듈화 패턴: cost-dashboard.ts:84-101 re-export comment 참조
- Monitor IA 리뷰: `/Users/dancer/me/memory/masc-oas-dashboard-monitor-ia-report-2026-05-20.html`
- 형제 PR (모두 머지됨): #17003, #17007, #17008, #17014

🤖 Generated with [Claude Code](https://claude.com/claude-code)