### PR TITLE
refactor(shell): reuse path token scan for dir materialization

### DIFF
--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -732,8 +732,9 @@ let path_validation_tokens tokens =
 ;;
 
 let existing_dir_path_values cmd =
+  let tokens = tokenize_path_args cmd in
   let command_name =
-    match tokenize_path_args cmd with
+    match tokens with
     | command :: _ -> Filename.basename command.value
     | [] -> ""
   in
@@ -759,7 +760,7 @@ let existing_dir_path_values cmd =
           loop false (token.value :: acc) rest
         | None -> loop false acc rest)
   in
-  cmd |> tokenize_path_args |> path_validation_tokens |> loop false []
+  tokens |> path_validation_tokens |> loop false []
 ;;
 
 let validate_command_paths ?keeper_id ?base_path ?workdir cmd =

--- a/scripts/lint/shell-legacy-purge-ratchet.baseline
+++ b/scripts/lint/shell-legacy-purge-ratchet.baseline
@@ -4,7 +4,7 @@
 # Scope: lib/ and test/
 # The long-term target for every row is 0. Cleanup PRs may lower these
 # counts; no PR may raise them.
-tokenize_path_args 4
+tokenize_path_args 3
 path_validation_tokens 4
 forbidden_shell_chars 13
 raw_keeper_bash_shape_block 0


### PR DESCRIPTION
## Summary
- reuse the existing path-token stream in existing_dir_path_values instead of tokenizing the same command twice
- lower shell legacy purge ratchet tokenize_path_args baseline from 4 to 3

## Validation
- PASS: bash scripts/lint/shell-legacy-purge-ratchet.sh
- PASS: git diff --check
- PASS: ocamlformat --check lib/worker_dev_tools.ml
- BLOCKED locally: scripts/dune-local.sh build test/test_worker_dev_tools.exe test/test_path_rewrite_validation.exe; wrapper refused because bare dune builds are running elsewhere on the host (PIDs 77222, 38435). CI should provide the OCaml compile/test signal.

## Notes
- This is a behavior-preserving cleanup. Full raw path-tokenizer removal still depends on parser metadata for quote/glob/brace/escape-sensitive path diagnostics.