### PR TITLE
fix(dashboard): hydrate Keeper before counting paused keepers in agent-roster

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -441,7 +441,14 @@ export function countRuntimeKinds(
   const rosterAgents = buildAgentRoster(agentList, runtimeKeepers)
   const keeperLookup = buildKeeperRuntimeLookup(runtimeKeepers)
   const allKeepers = scopeAgentsByKeeperFilter(rosterAgents, runtimeKeepers, 'keeper-only', keeperLookup)
-  const pausedKeepers = allKeepers.filter(a => isKeeperPaused(a.keeper)).length
+  // Hydrate the Keeper from the lookup before asking whether it is paused.
+  // Agent rows only carry `keeper_id`/`keeper_name`, not the full Keeper, so
+  // `a.keeper` was undefined here and `isKeeperPaused(undefined)` silently
+  // returned false, leaving the paused count stuck at 0.
+  const pausedKeepers = allKeepers.filter(a => {
+    const keeper = findKeeperRuntimeForAgent(a, keeperLookup)
+    return keeper ? isKeeperPaused(keeper) : false
+  }).length
   const runningKeepers = allKeepers.length - pausedKeepers
   const agentCount = scopeAgentsByKeeperFilter(rosterAgents, runtimeKeepers, 'agent-only', keeperLookup).length
 
@@ -500,7 +507,12 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   // Derive runtime kind counts from memoized roster (avoids duplicate buildAgentRoster call)
   const liveRuntimeCounts = useMemo(() => {
     const allKeepers = scopeAgentsByKeeperFilter(rosterAgents, runtimeKeeperList, 'keeper-only', keeperRuntimeLookup)
-    const pausedCount = allKeepers.filter(a => isKeeperPaused(a.keeper)).length
+    // See countRuntimeKinds(): Agent rows expose only keeper identifiers, so
+    // `a.keeper` is undefined and isKeeperPaused needs the hydrated Keeper.
+    const pausedCount = allKeepers.filter(a => {
+      const keeper = findKeeperRuntimeForAgent(a, keeperRuntimeLookup)
+      return keeper ? isKeeperPaused(keeper) : false
+    }).length
     const runningCount = allKeepers.length - pausedCount
     const agentCount = scopeAgentsByKeeperFilter(rosterAgents, runtimeKeeperList, 'agent-only', keeperRuntimeLookup).length
     return { agents: agentCount, keepers: runningCount, pausedKeepers: pausedCount, totalRuntimes: rosterAgents.length }


### PR DESCRIPTION
## Goal
`agent-roster.ts:444, 503` 두 곳의 `a.keeper` 접근은 *타입 에러*가 아니라 **실제 런타임 버그**. Agent 레코드는 `keeper_id`/`keeper_name`만 가짐 → `a.keeper` 영구 undefined → `isKeeperPaused(undefined)` 영구 false → **paused keeper count = 0** (every fleet, silent). PR #17009가 도입한 "active vs paused split" 카운터가 무효 상태였음.

## Changed files
- `dashboard/src/components/agent-roster.ts` — 14+/2- (2 호출지점 hydration + 인라인 설명 주석)

## Self-review
- 목표: `findKeeperRuntimeForAgent(agent, lookup)` (line 175-189에 이미 존재하는 helper) 로 hydrate 후 `isKeeperPaused(keeper)` 호출. PR #17009 의도(runtime/paused 분리)를 실제 동작하게 복원.
- 범위: 1 파일, 2 호출지점, 14+/2-
- 동작 변화: **있음 (의도된 회복)**. 모든 fleet에서 `pausedKeepers` 가 항상 `0` → 실제 paused 수로 변경. dashboard runtime-truth pane의 active/paused 분리가 비로소 의미 있게 표시됨.
- 로컬 검증:
  - `pnpm run typecheck` — agent-roster TS2339 2건 모두 해소. 잔존 baseline: `credential-settings.ts:13 TS6133` 무관.
  - `pnpm vitest run src/components/agent-roster` — **16/16 passed**

## 안티패턴 §2 "Unknown → Permissive Default" 정확한 사례
`software-development.md`의 anti-pattern §2가 가리키는 사례 본보기. `isKeeperPaused(undefined)`가 silent false로 빠지면서 buggy "permissive default"를 만들었음. 본 PR은 진단된 안티패턴을 root-fix.

## Background
agent audit 발견 — `Agent` type(`dashboard/src/types/core.ts:12-34`)은 `keeper_name?` / `keeper_id?` 만 정의. `keeper` 속성은 type에도, runtime `buildAgentRoster()` 결과에도 없음. `findKeeperRuntimeForAgent` 라는 lookup helper가 이미 존재하므로 fix는 mechanical.

## CI typecheck 게이트 관찰 (별도 escalate)
별개 audit으로 dashboard CI(`.github/workflows/ci.yml:944`)가 `pnpm run typecheck`를 실행하나 path filter 또는 다른 게이트로 #17009 머지 시 skipped된 것으로 추정. 본 PR이 머지된 후 typecheck enforcement가 부활하면 credential-settings.ts:13 baseline error가 CI를 막을 수 있음 — 그 fix는 agent_delegation gate로 사용자 권한.

## Test plan
- [x] vitest unit test (agent-roster.test.ts 16/16)
- [ ] CI typecheck — agent-roster 관련 0 에러 확인
- [ ] 시각 확인: dashboard runtime-truth pane에서 paused count가 실제 N으로 표시되는지 (회귀 회복)

## References
- 안티패턴 §2: `~/me/instructions/software-development.md` "Unknown → Permissive Default"
- 원본 PR #17009 (active vs paused split — paused count 의도)
- helper `findKeeperRuntimeForAgent`: dashboard/src/components/agent-roster.ts:175-189
- 자매 PR: #17025 (cost-store lift Draft)

🤖 Generated with [Claude Code](https://claude.com/claude-code)