### PR TITLE
fix(dashboard/tool-quality): trend sparkline hover tooltip, axis labels, reference line

### DIFF
--- a/dashboard/src/components/tool-quality-panel.test.ts
+++ b/dashboard/src/components/tool-quality-panel.test.ts
@@ -3,7 +3,13 @@ import { render } from 'preact'
 import { act } from 'preact/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ToolQualityResponse } from '../api/dashboard'
-import { classifyCoverageError, filterTools, toolMatchesSearch } from './tool-quality-panel'
+import {
+  classifyCoverageError,
+  filterTools,
+  pickAxisLabelIndices,
+  rateColorVar,
+  toolMatchesSearch,
+} from './tool-quality-panel'
 
 vi.setConfig({
   testTimeout: 40000,
@@ -46,6 +52,16 @@ const payloadWithCascadeBuckets = {
       success_pct: 100,
     },
   ],
+}
+
+const payloadWithHourlyTrend = {
+  ...payload,
+  hourly_trend: Array.from({ length: 24 }, (_, i) => ({
+    hour: `2026-05-20T${String(i).padStart(2, '0')}:00`,
+    calls: 100 + i * 5,
+    success: 90 + i * 4,
+    success_rate: 88 + (i % 6),
+  })),
 }
 
 const payloadWithCoverageGap = {
@@ -182,6 +198,63 @@ describe('ToolQualityPanel', () => {
 
     expect(container.textContent).toContain('캐스케이드별')
     expect(container.textContent).toContain('local_qwen3_27b_only')
+  })
+
+  it('renders the trend sparkline with multiple axis labels and bucket hit areas', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okJson(payloadWithHourlyTrend))
+    vi.stubGlobal('fetch', fetchMock)
+    const { ToolQualityPanel } = await import('./tool-quality-panel')
+
+    await act(async () => {
+      render(html`<${ToolQualityPanel} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    const svg = container.querySelector('[data-testid="trend-sparkline-svg"]')
+    expect(svg).not.toBeNull()
+    // 24 invisible bucket hit areas — one per hourly point — so hover is reliable
+    expect(container.querySelectorAll('[data-testid^="trend-bucket-"]').length).toBe(24)
+    // Axis labels: 4 timestamps for 24-point series (not just edges).
+    // pickAxisLabelIndices(24) → [0, 8, 16, 23] so we expect the corresponding
+    // hour strings to render. The `hour.slice(5)` formatting strips the year.
+    expect(container.textContent).toContain('5-20T00')
+    expect(container.textContent).toContain('5-20T23')
+    // Verify a middle-bucket hour label is also rendered (pickAxisLabelIndices(24) → [0, 8, 16, 23])
+    expect(container.textContent).toContain('5-20T08')
+    expect(container.textContent).toContain('5-20T16')
+  })
+
+  it('shows a tooltip when a trend bucket is hovered', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okJson(payloadWithHourlyTrend))
+    vi.stubGlobal('fetch', fetchMock)
+    const { ToolQualityPanel } = await import('./tool-quality-panel')
+
+    await act(async () => {
+      render(html`<${ToolQualityPanel} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    // Initially no tooltip
+    expect(container.querySelector('[data-testid="trend-tooltip"]')).toBeNull()
+
+    const bucket10 = container.querySelector('[data-testid="trend-bucket-10"]')
+    expect(bucket10).not.toBeNull()
+
+    await act(async () => {
+      bucket10?.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }))
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    const tooltip = container.querySelector('[data-testid="trend-tooltip"]')
+    expect(tooltip).not.toBeNull()
+    // Hour 10 has success_rate = 88 + (10 % 6) = 92, calls = 100 + 10*5 = 150, success = 90 + 10*4 = 130 → fail=20
+    expect(tooltip?.textContent).toContain('2026-05-20T10:00')
+    expect(tooltip?.textContent).toContain('92.0%')
+    expect(tooltip?.textContent).toContain('150')
+    expect(tooltip?.textContent).toContain('20')
   })
 
   it('renders tool-quality coverage gap provenance', async () => {
@@ -405,6 +478,47 @@ describe('classifyCoverageError', () => {
     expect(classifyCoverageError('disk full')).toBeNull()
     expect(classifyCoverageError('connection refused')).toBeNull()
     expect(classifyCoverageError('append denied')).toBeNull()
+  })
+})
+
+describe('rateColorVar', () => {
+  it('returns ok tone for 95% and above', () => {
+    expect(rateColorVar(100)).toContain('status-ok')
+    expect(rateColorVar(95)).toContain('status-ok')
+  })
+
+  it('returns warn tone for 90% to <95%', () => {
+    expect(rateColorVar(94.9)).toContain('status-warn')
+    expect(rateColorVar(90)).toContain('status-warn')
+  })
+
+  it('returns err tone below 90%', () => {
+    expect(rateColorVar(89.9)).toContain('status-err')
+    expect(rateColorVar(0)).toContain('status-err')
+  })
+})
+
+describe('pickAxisLabelIndices', () => {
+  it('returns edges for very short series (≤2)', () => {
+    expect(pickAxisLabelIndices(2)).toEqual([0, 1])
+  })
+
+  it('returns only edges for short series (≤6)', () => {
+    expect(pickAxisLabelIndices(4)).toEqual([0, 3])
+    expect(pickAxisLabelIndices(6)).toEqual([0, 5])
+  })
+
+  it('returns 4 evenly-spaced indices for longer series', () => {
+    expect(pickAxisLabelIndices(24)).toEqual([0, 8, 16, 23])
+    expect(pickAxisLabelIndices(12)).toEqual([0, 4, 8, 11])
+  })
+
+  it('always includes both edges as first and last entries', () => {
+    for (const n of [7, 10, 24, 48, 100]) {
+      const indices = pickAxisLabelIndices(n)
+      expect(indices[0]).toBe(0)
+      expect(indices[indices.length - 1]).toBe(n - 1)
+    }
   })
 })
 

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { computed, signal } from '@preact/signals'
-import { useEffect } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 import { type ToolQualityResponse } from '../api/dashboard'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
 import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
@@ -198,29 +198,45 @@ function ToolTable({
   `
 }
 
+// Tone classifier shared between trend header and tooltip — keeps the
+// thresholds in one place so a tooltip never disagrees with the headline.
+export function rateColorVar(rate: number): string {
+  if (rate >= 95) return 'var(--color-status-ok)'
+  if (rate >= 90) return 'var(--color-status-warn)'
+  return 'var(--color-status-err)'
+}
+
+// Pick ~4 evenly-spaced indices for x-axis labels, always including first
+// and last. For very short ranges (≤6 points), only the edges are shown.
+export function pickAxisLabelIndices(n: number): number[] {
+  if (n <= 2) return [0, n - 1]
+  if (n <= 6) return [0, n - 1]
+  return [0, Math.floor(n / 3), Math.floor((2 * n) / 3), n - 1]
+}
+
 function TrendSparkline({ points }: { points: HourlyPoint[] }) {
   if (points.length < 2) return null
+  // Hover state is component-local and ephemeral — useState (not signal) so
+  // it lives with the mount and is dropped on unmount without manual cleanup.
+  const [activeIdx, setActiveIdx] = useState<number | null>(null)
+
   const W = 200, H = 40, pad = 2
   const n = points.length
   const maxCalls = Math.max(...points.map(p => p.calls), 1)
 
-  // Success rate line
-  const rateLine = points.map((p, i) => {
-    const x = pad + (i / (n - 1)) * (W - 2 * pad)
-    const y = H - pad - (p.success_rate / 100) * (H - 2 * pad)
-    return `${x.toFixed(1)},${y.toFixed(1)}`
-  }).join(' ')
+  const xOf = (i: number) => pad + (i / (n - 1)) * (W - 2 * pad)
+  const yRate = (rate: number) => H - pad - (rate / 100) * (H - 2 * pad)
 
-  // Call volume bars
+  const rateLine = points.map((p, i) => `${xOf(i).toFixed(1)},${yRate(p.success_rate).toFixed(1)}`).join(' ')
+
   const barW = Math.max(1, ((W - 2 * pad) / n) * 0.6)
-  const bars = points.map((p, i) => {
-    const x = pad + (i / (n - 1)) * (W - 2 * pad) - barW / 2
-    const barH = (p.calls / maxCalls) * (H - 2 * pad)
-    return { x, y: H - pad - barH, w: barW, h: barH, failures: p.calls - p.success }
-  })
+  const colW = (W - 2 * pad) / n  // full-height invisible hit area per bucket
 
   const lastRate = points[points.length - 1]?.success_rate ?? 0
-  const lineColor = lastRate >= 95 ? 'var(--color-status-ok)' : lastRate >= 90 ? 'var(--color-status-warn)' : 'var(--color-status-err)'
+  const lineColor = rateColorVar(lastRate)
+
+  const active = activeIdx != null ? points[activeIdx] : null
+  const labelIndices = pickAxisLabelIndices(n)
 
   return html`
     <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3">
@@ -231,15 +247,97 @@ function TrendSparkline({ points }: { points: HourlyPoint[] }) {
           <span class="text-xs font-mono" style="color:${lineColor}">${lastRate.toFixed(1)}%</span>
         </div>
       </div>
-      <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded-[var(--r-1)] w-full" role="img" aria-label="성공률 추이 차트" style="background:var(--bg-deepest);">
-        ${bars.map(b => html`
-          <rect x="${b.x.toFixed(1)}" y="${b.y.toFixed(1)}" width="${b.w.toFixed(1)}" height="${b.h.toFixed(1)}" fill="${b.failures > 0 ? 'var(--bad-20)' : 'var(--ok-soft)'}" rx="0.5" />
-        `)}
-        <polyline points="${rateLine}" fill="none" stroke="${lineColor}" stroke-width="1.5"/>
-      </svg>
-      <div class="flex justify-between mt-1 text-3xs text-[var(--color-fg-disabled)] font-mono">
-        <span>${points[0]?.hour?.slice(5) ?? ''}</span>
-        <span>${points[points.length - 1]?.hour?.slice(5) ?? ''}</span>
+      <div class="relative">
+        <svg
+          viewBox="0 0 ${W} ${H}"
+          width="${W}"
+          height="${H}"
+          class="rounded-[var(--r-1)] w-full"
+          role="img"
+          aria-label="성공률 추이 차트 — ${n}시간 호버하면 시간별 상세"
+          data-testid="trend-sparkline-svg"
+          style="background:var(--bg-deepest);"
+          onMouseLeave=${() => setActiveIdx(null)}
+        >
+          <!-- 100% reference line so operators can read absolute rate, not just delta -->
+          <line x1="${pad}" y1="${pad.toFixed(1)}" x2="${W - pad}" y2="${pad.toFixed(1)}"
+            stroke="var(--color-border-default)" stroke-width="0.3" stroke-dasharray="1 1.5" />
+
+          ${points.map((p, i) => {
+            const x = xOf(i) - barW / 2
+            const barH = (p.calls / maxCalls) * (H - 2 * pad)
+            const y = H - pad - barH
+            const failures = p.calls - p.success
+            const isActive = i === activeIdx
+            return html`<rect
+              x="${x.toFixed(1)}" y="${y.toFixed(1)}"
+              width="${barW.toFixed(1)}" height="${barH.toFixed(1)}"
+              fill="${failures > 0 ? 'var(--bad-20)' : 'var(--ok-soft)'}"
+              opacity="${isActive ? '1' : '0.85'}"
+              rx="0.5" />`
+          })}
+
+          <polyline points="${rateLine}" fill="none" stroke="${lineColor}" stroke-width="1.5"/>
+
+          ${points.map((p, i) => {
+            const isActive = i === activeIdx
+            return html`<circle
+              cx="${xOf(i).toFixed(1)}" cy="${yRate(p.success_rate).toFixed(1)}"
+              r="${isActive ? '2.2' : '1.2'}"
+              fill="${lineColor}" />`
+          })}
+
+          ${activeIdx != null ? html`<line
+            x1="${xOf(activeIdx).toFixed(1)}" y1="${pad}"
+            x2="${xOf(activeIdx).toFixed(1)}" y2="${H - pad}"
+            stroke="${lineColor}" stroke-width="0.4" stroke-dasharray="1 1" opacity="0.55" />` : null}
+
+          <!-- Invisible hit areas — full column height per bucket so the
+               mouse target is the bucket region, not just the bar pixels. -->
+          ${points.map((_, i) => {
+            const x = xOf(i) - colW / 2
+            return html`<rect
+              x="${x.toFixed(1)}" y="0"
+              width="${colW.toFixed(1)}" height="${H}"
+              fill="transparent"
+              data-testid=${`trend-bucket-${i}`}
+              onMouseEnter=${() => setActiveIdx(i)}
+              style="cursor:crosshair" />`
+          })}
+        </svg>
+
+        ${active && activeIdx != null ? html`
+          <div
+            class="pointer-events-none absolute z-10 -translate-x-1/2 -translate-y-full -mt-1 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1 text-3xs font-mono shadow-lg whitespace-nowrap"
+            style="left:${((xOf(activeIdx) / W) * 100).toFixed(1)}%; top:0"
+            role="tooltip"
+            data-testid="trend-tooltip"
+          >
+            <div class="text-[var(--color-fg-primary)]">${active.hour}</div>
+            <div style="color:${rateColorVar(active.success_rate)}">${active.success_rate.toFixed(1)}%</div>
+            <div class="text-[var(--color-fg-disabled)]">
+              ${active.calls.toLocaleString()} calls · ${(active.calls - active.success).toLocaleString()} fail
+            </div>
+          </div>
+        ` : null}
+      </div>
+
+      <!-- Multiple x-axis labels (was: only start/end). Absolute positioning
+           inside a relative container so labels line up with their data point. -->
+      <div class="relative mt-1 h-3 text-3xs text-[var(--color-fg-disabled)] font-mono">
+        ${labelIndices.map(i => {
+          const xPct = (xOf(i) / W) * 100
+          // Edge labels get edge-anchored to avoid clipping outside the box.
+          const transform = i === 0
+            ? 'translateX(0)'
+            : i === n - 1
+              ? 'translateX(-100%)'
+              : 'translateX(-50%)'
+          return html`<span
+            class="absolute"
+            style="left:${xPct.toFixed(1)}%; transform:${transform}"
+          >${points[i]?.hour?.slice(5) ?? ''}</span>`
+        })}
       </div>
     </div>
   `


### PR DESCRIPTION
## Summary

Tool Quality 화면의 24h success-rate sparkline 가독성/상호작용 개선. PR #17022 머지 후속.

**Before**: 200×40 SVG, 시작/끝 hour 라벨 2개만, hover 상호작용 없음. 운영자가 특정 시각의 calls/failures 절대값을 알려면 event log 별도 조회 필요.

**After**: hover tooltip + point markers + middle axis labels + 100% reference line + vertical active guide.

## Changes

| 개선 | 구현 |
|------|------|
| **Hover tooltip** | 각 hourly bucket에 full-height invisible hit-area + `useState<number\|null>` hover state. tooltip은 absolute-positioned, hour/rate/calls/fail 표시 |
| **Point markers** | line 위 각 데이터 포인트에 `<circle r=1.2>` (active 시 r=2.2). hover affordance |
| **Middle axis labels** | start/end 2개 → start/~1/3/~2/3/end 4개. `pickAxisLabelIndices(n)` 분리 |
| **100% reference line** | dashed horizontal at y=top. 절대 천장 대비 차이를 시각적으로 |
| **Active vertical guide** | 활성 bucket에 dashed vertical line. tooltip-data 연결성 강조 |

Helper 함수 두 개 exported pure로 분리:
- `rateColorVar(rate)` — 95/90 threshold (헤더-tooltip tone 통일 SSOT)
- `pickAxisLabelIndices(n)` — axis label 인덱스 계산

## Verification

```
vitest:       69/69 PASS  (+11 신규 case: pickAxisLabelIndices 4, rateColorVar 3, sparkline 2, classifier 2[from #17022])
tsc:          changed files clean
eslint:       0 errors
vite build:   ✓ 11.87s
```

## Why not signals for hover state

Component-local ephemeral state (`useState`)가 자연. `signal()`은 cross-component shared나 module-level persistent에 쓰는 게 일관성. dashboard 코드베이스 다른 곳 (예: `errorPanelOpen` in dashboard-shell.ts)도 signal로 두긴 했지만 hover는 mount lifecycle에 묶여야 cleanup이 자동.

## Test plan

- [ ] `#monitoring?view=tool-quality` 진입 시 trend chart에 24개 hour 라벨이 *분포*되어 표시되는가 (시작/끝뿐 아니라 중간 2개도)
- [ ] 차트 위 마우스 hover 시 tooltip이 나타나는가
  - [ ] tooltip 내용: `2026-05-20T13:00` `92.4%` `1,243 calls · 95 fail`
- [ ] hover 중 활성 bucket에 vertical dashed guide가 보이는가
- [ ] 활성 point marker가 더 크게 표시되는가 (r=2.2)
- [ ] 차트에서 마우스가 벗어나면 tooltip 사라지는가
- [ ] data point가 2개뿐일 때 (`pickAxisLabelIndices(2)`) edge 2개만 라벨로 표시되는가
- [ ] 모바일(터치)에서 차트가 깨지지 않는가 (hover 없음, 표시만 정적)

## Notes for review

- viewBox는 200×40 그대로 유지 — SVG는 `w-full`이라 표시 크기는 컨테이너 width 종속. coordinate space만 좁고 표시는 충분히 큼.
- tooltip에 `pointer-events-none` 명시 → 호버 시 자기 자신을 가리는 일 없음.
- ARIA: `role="tooltip"` + `aria-label`에 동적 시간 수 (`24시간`) 포함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
