### PR TITLE
fix(main): repair build break introduced by #17013 tier-admission wire-in

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.mli
+++ b/lib/cascade/cascade_attempt_fsm.mli
@@ -117,6 +117,22 @@ val emit_sdk_provider_error_metric :
 (** Convert and emit an SDK provider error. Returns the converted variant
     so callers/tests can assert the same decision without reparsing metrics. *)
 
+(** {1 Cascade saturation signal label SSOT (RFC-0153)}
+
+    Modules that emit to {!Keeper_metrics.metric_keeper_cascade_saturation_signal}
+    MUST reuse these labels and {!provider_label} so Prometheus sees one
+    coherent series across emitters (cascade FSM + keeper_turn_driver
+    Phase B.2 admission). *)
+
+val label_kind : string
+
+val label_cascade : string
+
+val provider_label : string -> string
+(** Sanitize a free-form label value before stamping it onto a Prometheus
+    counter. Empty values are remapped to a fixed placeholder and counted
+    on [metric_cascade_attempt_empty_provider_label] for root-cause tracing. *)
+
 val sdk_error_soft_rate_limited :
   Agent_sdk.Error.sdk_error -> float option option
 (** [Some (Some retry_after)] for non-quota 429 responses with a parsed

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -55,9 +55,10 @@ let emit_cascade_tier_admission_signal_metric ~cascade_name signal =
     Keeper_metrics.metric_keeper_cascade_saturation_signal
     ~labels:
       [
-        ( label_kind,
+        ( Cascade_attempt_fsm.label_kind,
           Cascade_saturation_signal.(kind signal |> kind_to_string) );
-        (label_cascade, provider_label cascade_name);
+        ( Cascade_attempt_fsm.label_cascade,
+          Cascade_attempt_fsm.provider_label cascade_name );
       ]
     ()
 

--- a/test/test_cascade_tier_admission.ml
+++ b/test/test_cascade_tier_admission.ml
@@ -235,7 +235,7 @@ let test_keeper_wire_enabled_rejects_at_capacity () =
 let test_keeper_wire_disabled_is_passthrough () =
   let t = A.create ~default_max_inflight:0 () in
   let ran = ref false in
-  let result =
+  let outcome =
     KTD.with_cascade_tier_admission_for_testing
       ~admission:t
       ~enabled:false
@@ -246,13 +246,13 @@ let test_keeper_wire_disabled_is_passthrough () =
          "ok")
   in
   bool_check "attempt ran when flag disabled" true !ran;
-  check (result string signal_testable) "disabled flag passthrough" (Ok "ok") result;
+  check (result string signal_testable) "disabled flag passthrough" (Ok "ok") outcome;
   int_check "disabled path did not touch counter" 0
     (A.current_inflight t ~tier_id:"keeper-turn")
 
 let test_keeper_wire_bypass_policy_is_passthrough () =
   let t = A.create ~default_max_inflight:0 () in
-  let result =
+  let outcome =
     KTD.with_cascade_tier_admission_for_testing
       ~admission:t
       ~enabled:true
@@ -260,7 +260,7 @@ let test_keeper_wire_bypass_policy_is_passthrough () =
       ~admission_policy:A.Bypass
       (fun () -> 7)
   in
-  check (result int signal_testable) "bypass policy passthrough" (Ok 7) result;
+  check (result int signal_testable) "bypass policy passthrough" (Ok 7) outcome;
   int_check "bypass path did not touch counter" 0
     (A.current_inflight t ~tier_id:"keeper-turn")
 


### PR DESCRIPTION
## 증상
\`dune build\` on main fails with:
\`\`\`
lib/keeper/keeper_turn_driver.ml:58: Error: Unbound value label_kind
test/test_cascade_tier_admission.ml:249: Error: This expression has type
       (string, S.t) result. This is not a function; it cannot be applied.
\`\`\`

## 근원
PR #17013 \`feat(cascade): wire tier admission into keeper attempts\` 머지 시 두 break 동시 도입. CI 의 \`Detect Changed Surfaces\` gate 가 lib/keeper 변경을 \`Build and Test\` SKIP 으로 라우팅 → latent regression. 근거: \`memory/reference_masc_mcp_ci_build_test_skips.md\`.

## 변경 (3 files / +23 / -6)

### 1. \`lib/cascade/cascade_attempt_fsm.mli\` (+16)
\`label_kind\`, \`label_cascade\`, \`provider_label\` 을 mli 에 export.
- 이 3개는 cascade saturation signal metric 의 *label SSOT*. PR #17013 의 새 emitter (\`emit_cascade_tier_admission_signal_metric\`) 가 unqualified 참조했으나, mli 가 export 안 해서 unbound.
- SSOT 보존 = 두 emitter 가 같은 label key 로 Prometheus counter 에 stamping → dashboard 일관성.

### 2. \`lib/keeper/keeper_turn_driver.ml\` (+3 / -2)
\`label_kind\` → \`Cascade_attempt_fsm.label_kind\` (3 sites). qualified ref 로 명시.

### 3. \`test/test_cascade_tier_admission.ml\` (+4 / -4)
\`open Alcotest\` 가 scope 에 있어 \`result\` testable combinator 와 \`let result = KTD.with_cascade_tier_admission_for_testing ...\` 가 shadowing. 두 신규 keeper-wire passthrough test 에서만 \`check (result string signal_testable) ... result\` 호출 — 첫 \`result\` 가 bound value (combinator 아님) 로 해석되어 "not a function" 에러.

Surgical fix: 그 두 test 의 binding 만 \`outcome\` 으로 rename. 다른 7곳의 \`let result = ...\` 는 \`check (result ...)\` 호출 안 해서 그대로 유지.

## 검증
- \`dune build --root . @check\` clean
- \`dune build --root .\` full clean
- \`./_build/default/test/test_cascade_tier_admission.exe\` — **18/18 PASS** (keeper-wire 5/5 포함)

## RFC-0088 self-check
- §1 telemetry-as-fix: N/A (counter 변경 없음)
- §2 string classifier: N/A
- §3 N-of-M: N/A — 사실 *이번 fix 가 N-of-M 회피*. shadowing 문제는 2 test 사이트, label_kind 문제는 1 사이트. 모두 한 PR.

## Follow-up 권장 (별도 issue)
\`Detect Changed Surfaces\` gate 가 lib/keeper 변경을 어떤 조건에서 SKIP 시키는지 검토. PR #17013 같은 wire-in 변경이 \`Build and Test\` 통과 없이 머지되면 본 사고가 다시 발생.

🤖 Generated with [Claude Code](https://claude.com/claude-code)