### PR TITLE
refactor(dashboard): extract phase sets to SSOT + remove dead exports

### DIFF
--- a/dashboard/src/components/keeper-conditions-divergent.ts
+++ b/dashboard/src/components/keeper-conditions-divergent.ts
@@ -23,10 +23,10 @@ import type { Keeper, KeeperConditions, KeeperPhase } from '../types'
 
 type DivergenceFn = (value: boolean, phase: KeeperPhase | null | undefined) => string | null
 
-export const isOperating = (p: KeeperPhase | null | undefined): boolean =>
+const isOperating = (p: KeeperPhase | null | undefined): boolean =>
   p === 'Running' || p === 'Failing' || p === 'Overflowed'
 
-export const isTerminated = (p: KeeperPhase | null | undefined): boolean =>
+const isTerminated = (p: KeeperPhase | null | undefined): boolean =>
   p === 'Stopped' || p === 'Dead' || p === 'Crashed'
 
 /** Rule table — each entry returns a ko-language reason when divergent,

--- a/dashboard/src/components/keeper-phase-indicator.ts
+++ b/dashboard/src/components/keeper-phase-indicator.ts
@@ -15,6 +15,7 @@
 import { html } from 'htm/preact'
 import type { KeeperPhase } from '../types'
 import { toKeeperPhase } from '../keeper-store-normalize'
+import { BUFFER_PHASES } from '../lib/keeper-predicates'
 import { formatDuration } from '../lib/format-time'
 
 interface PhaseStyle {
@@ -62,7 +63,8 @@ const PHASE_STYLES: Record<KeeperPhase, PhaseStyle> = {
   Zombie:     { label: '좀비',         color: 'var(--bad-light)',  bg: 'var(--bad-10)',    border: 'var(--bad-20)',     glow: STRONG_GLOW,   icon: '☠' },
 }
 
-const BUFFER_PHASES = new Set<string>(['Failing', 'Overflowed', 'Compacting', 'HandingOff', 'Draining', 'Restarting'])
+// BUFFER_PHASES now imported from keeper-predicates.ts (SSOT).
+// Previously defined locally — see RFC-0135 PR-SSOT.
 
 function getPhaseStyle(phase: KeeperPhase | string | null | undefined): PhaseStyle {
   if (!phase) return PHASE_STYLES.Offline

--- a/dashboard/src/lib/keeper-predicates.ts
+++ b/dashboard/src/lib/keeper-predicates.ts
@@ -171,6 +171,29 @@ const RUNNING_PHASES_EXCLUDING_RESTARTING: ReadonlySet<string> = new Set<string>
  *  to `running`. When `KeeperOperationalState` gains a dedicated
  *  `restarting` variant (RFC-0135 follow-up Goal-2), this predicate
  *  collapses to that check. */
+// RFC-0135 PR-SSOT: ATTENTION_PHASES — phases that indicate the keeper
+// needs operator attention (error, recovery, or transitional states).
+// Previously defined locally in monitoring-runtime.ts as a private Set
+// and partially duplicated as BUFFER_PHASES in keeper-phase-indicator.ts.
+// Both sites now import from here.
+export const ATTENTION_PHASES: ReadonlySet<string> = new Set<string>([
+  'Failing',
+  'Overflowed',
+  'Compacting',
+  'HandingOff',
+  'Draining',
+  'Crashed',
+  'Restarting',
+])
+
+// BUFFER_PHASES — subset of ATTENTION_PHASES used for visual pulse
+// animation in keeper-phase-indicator.ts. Excludes `Crashed` (terminal
+// failure gets a static badge, not a pulse). Derived from the SSOT so
+// adding a new attention phase auto-updates the animation gate.
+export const BUFFER_PHASES: ReadonlySet<string> = new Set<string>(
+  [...ATTENTION_PHASES].filter(p => p !== 'Crashed'),
+)
+
 export function isKeeperRunningExcludingRestarting(keeper: Keeper): boolean {
   const status = (keeper.status ?? '').toLowerCase()
   if (RUNNING_STATUS_TOKENS.has(status)) return true

--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -6,6 +6,7 @@ import { keeperDisplayStatus, keeperRuntimeBlockerHint } from './keeper-runtime-
 // (previously lines 39-55, 159-180) duplicated BACKEND_PHASE_MAP +
 // PHASE_ID_MAP elsewhere; the three maps drifted independently.
 import { toKeeperPhase } from '../keeper-store-normalize'
+import { ATTENTION_PHASES } from './keeper-predicates'
 import { parseAgentStatus } from './agent-status'
 // RFC-0135 PR-12 + PR-14d: route blocker visibility through the typed
 // SSOT (stale vs live distinction) and consume composite-preferred
@@ -46,10 +47,15 @@ interface MonitoringEvidence {
   stage: StageMeta | null
 }
 
-const HEARTBEAT_STALE_MS = 5 * 60 * 1000
+// 5-minute threshold for the monitoring band "attention" gate — distinct
+// from config/constants.HEARTBEAT_STALE_MS (120s) which is the SSE
+// connection liveness check. This longer window avoids false "attention"
+// badges during brief heartbeat gaps that the SSE reconnect handles.
+const MONITORING_BAND_STALE_MS = 5 * 60 * 1000
 const DEFAULT_CONTEXT_ATTENTION_RATIO = 0.95
 
-const ATTENTION_PHASES = new Set<string>(['Failing', 'Overflowed', 'Compacting', 'HandingOff', 'Draining', 'Crashed', 'Restarting'])
+// ATTENTION_PHASES now imported from keeper-predicates.ts (SSOT).
+// Previously defined locally — see RFC-0135 PR-SSOT.
 
 const UNKNOWN_PHASE_META: PhaseMeta = {
   key: 'unknown',
@@ -184,7 +190,7 @@ function isHeartbeatStale(keeper: Keeper): boolean {
   if (!keeper.last_heartbeat) return false
   const ts = Date.parse(keeper.last_heartbeat)
   if (Number.isNaN(ts)) return false
-  return Date.now() - ts > HEARTBEAT_STALE_MS
+  return Date.now() - ts > MONITORING_BAND_STALE_MS
 }
 
 function contextAttentionRatio(keeper: Keeper): number {


### PR DESCRIPTION
## Summary
- Extract `ATTENTION_PHASES` (7 phases) and `BUFFER_PHASES` (6 phases, minus Crashed) to `lib/keeper-predicates.ts` as SSOT exports
- `monitoring-runtime.ts` and `keeper-phase-indicator.ts` now import from SSOT instead of defining local duplicates
- Remove dead `export` from `isOperating`/`isTerminated` in `keeper-conditions-divergent.ts` (zero external consumers)
- Rename `HEARTBEAT_STALE_MS` → `MONITORING_BAND_STALE_MS` in monitoring-runtime.ts to disambiguate from `config/constants.HEARTBEAT_STALE_MS` (120s vs 300s, different purposes)

## Test plan
- [x] `pnpm --filter masc-dashboard exec tsc --noEmit` passes (only pre-existing credential-settings.ts warning)
- [ ] Manual: dashboard keeper list shows phase badges correctly
- [ ] Manual: monitoring band "attention" triggers on same phases as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)