### PR TITLE
refactor(dashboard): promote CoverageGapBlock to common, share across tool-quality and fleet-health

### DIFF
--- a/dashboard/src/components/common/coverage-gap-block.ts
+++ b/dashboard/src/components/common/coverage-gap-block.ts
@@ -1,0 +1,100 @@
+import { html } from 'htm/preact'
+import type { CoverageGapDisplay } from './source-health'
+
+// Operator-actionable error pattern classifier. Returns a hint with a
+// canonical RFC link when the error string matches a known incident class.
+// Pure function — exported for unit testing in isolation.
+//
+// Pattern → RFC mapping is the SSOT for "what should an operator do when
+// they see this error in the dashboard". Add new patterns here as RFCs
+// land for new failure modes.
+export type CoverageErrorHint = {
+  reason: string
+  label: string
+  href: string
+}
+
+export function classifyCoverageError(error: string | null | undefined): CoverageErrorHint | null {
+  if (!error) return null
+  const lower = error.toLowerCase()
+  // RFC-0097: keeper-sandbox container reuse — root fix for the 2026-05-16
+  // ENFILE storm that drove Docker_spawn_throttle + container reuse.
+  if (
+    lower.includes('too many open files')
+    || lower.includes('enfile')
+    || lower.includes('emfile')
+  ) {
+    return {
+      reason: 'fd_exhaustion',
+      label: 'FD exhaustion — see RFC-0097',
+      href: 'https://github.com/jeong-sik/masc-mcp/blob/main/docs/rfc/RFC-0097-keeper-sandbox-container-reuse.md',
+    }
+  }
+  return null
+}
+
+/**
+ * Coverage-gap provenance block. Shared by tool-quality-panel and
+ * fleet-health-panel Operations view so the collapsible-error UX is the
+ * same regardless of which surface the operator lands on.
+ *
+ * Visual hierarchy (top → bottom):
+ *  1. Warn-tone summary line (`⚠ coverage gaps N: <reason>`)
+ *  2. Triage chips (producer / store / surface / trace) — always visible
+ *  3. Error blob inside a closed `<details>` (1-line truncated preview
+ *     when closed, full `<pre>` block when open)
+ *  4. Optional "see RFC-XXXX" anchor when the error matches a known
+ *     incident class (see `classifyCoverageError`)
+ *
+ * Label spans use `${label + ' '}` (not adjacent siblings) so DOM
+ * textContent preserves "label value" as a contiguous substring —
+ * keeps text-search-based tests stable across format changes.
+ */
+export function CoverageGapBlock({ display }: { display: CoverageGapDisplay }) {
+  const { structured } = display
+  const hint = classifyCoverageError(structured.error)
+  return html`
+    <div class="mt-1 grid gap-1 rounded-[var(--r-1)] border border-[var(--color-status-warn)]/30 bg-[var(--warn-10)]/30 px-2 py-1.5 text-3xs" data-testid="coverage-gap-block">
+      <div class="flex items-center gap-1.5 font-medium text-[var(--color-status-warn)]">
+        <span aria-hidden="true">⚠</span>
+        <span>${display.summary}</span>
+      </div>
+      ${structured.fields.length > 0 ? html`
+        <div class="grid gap-0.5 font-mono">
+          ${structured.fields.map(({ label, value }) => html`
+            <div class="flex items-baseline">
+              <span class="w-16 shrink-0 text-[var(--color-fg-disabled)] uppercase tracking-wide">${label + ' '}</span>
+              <span class="min-w-0 break-all text-[var(--color-fg-muted)]">${value}</span>
+            </div>
+          `)}
+        </div>
+      ` : null}
+      ${structured.error ? html`
+        <details class="group">
+          <summary class="flex items-baseline cursor-pointer list-none [&::-webkit-details-marker]:hidden font-mono">
+            <span class="w-16 shrink-0 uppercase tracking-wide text-[var(--color-fg-disabled)]">error </span>
+            <span class="min-w-0 flex-1 truncate text-[var(--color-fg-muted)] group-open:hidden">${structured.error}</span>
+            <span class="ml-2 shrink-0 text-[var(--color-fg-disabled)]" aria-hidden="true">
+              <span class="group-open:hidden">▸</span>
+              <span class="hidden group-open:inline">▾</span>
+            </span>
+          </summary>
+          <pre class="mt-1 ml-16 max-h-32 overflow-auto rounded-[var(--r-1)] bg-[var(--bg-deepest)] p-2 font-mono text-3xs leading-snug text-[var(--color-fg-muted)] whitespace-pre-wrap break-all">${structured.error}</pre>
+        </details>
+      ` : null}
+      ${hint ? html`
+        <a
+          href=${hint.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="ml-16 inline-flex items-center gap-1 self-start rounded-[var(--r-1)] border border-[var(--color-status-warn)]/40 bg-[var(--warn-10)] px-1.5 py-0.5 font-medium text-[var(--color-status-warn)] hover:bg-[var(--warn-20)]"
+          data-testid=${`coverage-gap-hint-${hint.reason}`}
+        >
+          <span aria-hidden="true">💡</span>
+          <span>${hint.label}</span>
+          <span aria-hidden="true">↗</span>
+        </a>
+      ` : null}
+    </div>
+  `
+}

--- a/dashboard/src/components/fleet-health-panel.ts
+++ b/dashboard/src/components/fleet-health-panel.ts
@@ -28,6 +28,7 @@ import {
   sharedToolQualityLoading,
 } from './fleet-data-core'
 import { coverageGapDisplay, freshnessText, sourceHealthClass } from './common/source-health'
+import { CoverageGapBlock } from './common/coverage-gap-block'
 
 type FleetHealthView = 'default' | 'event-log' | 'comparison' | 'tool-quality' | 'governance' | 'attribution' | 'keeper-health'
 
@@ -334,9 +335,8 @@ function ToolMonitorDefaultBoard() {
         ` : null}
 
         ${coverageGap ? html`
-          <div class="mt-3 grid gap-0.5 rounded-[var(--r-1)] border border-[var(--color-status-warn)]/40 bg-[var(--warn-10)] px-3 py-2 text-3xs text-[var(--color-status-warn)]">
-            <span>${coverageGap.summary}</span>
-            ${coverageGap.details.slice(0, 2).map(detail => html`<span class="font-mono break-all">${detail}</span>`)}
+          <div class="mt-3">
+            <${CoverageGapBlock} display=${coverageGap} />
           </div>
         ` : null}
       </div>

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -20,8 +20,13 @@ import {
   sourceHealthClass,
   freshnessText,
   coverageGapDisplay,
-  type CoverageGapDisplay,
 } from './common/source-health'
+import { CoverageGapBlock, classifyCoverageError } from './common/coverage-gap-block'
+
+// Re-export for backward compatibility with existing tests that imported
+// classifyCoverageError from this module. The SSOT now lives in
+// `./common/coverage-gap-block`; this alias keeps test fixtures working.
+export { classifyCoverageError }
 
 const TOOL_QUALITY_WINDOW_HOURS = 24
 
@@ -359,97 +364,6 @@ function KeeperRateBars({ keepers }: { keepers: KeeperStat[] }) {
           </div>
         `
       })}
-    </div>
-  `
-}
-
-// Classifier for operator-actionable error patterns. Returns a hint with a
-// canonical RFC link when the error string matches a known incident class.
-// Pure function — kept exported for unit testing in isolation.
-//
-// Pattern → RFC mapping is the SSOT for "what should operator do when they
-// see this error in the dashboard". Add new patterns here as RFCs land for
-// new failure modes.
-type CoverageErrorHint = { label: string; href: string; reason: string }
-
-export function classifyCoverageError(error: string | null | undefined): CoverageErrorHint | null {
-  if (!error) return null
-  const lower = error.toLowerCase()
-  // RFC-0097: keeper-sandbox container reuse — root fix for the 2026-05-16
-  // ENFILE storm that drove Docker_spawn_throttle + container reuse.
-  if (
-    lower.includes('too many open files')
-    || lower.includes('enfile')
-    || lower.includes('emfile')
-  ) {
-    return {
-      reason: 'fd_exhaustion',
-      label: 'FD exhaustion — see RFC-0097',
-      href: 'https://github.com/jeong-sik/masc-mcp/blob/main/docs/rfc/RFC-0097-keeper-sandbox-container-reuse.md',
-    }
-  }
-  return null
-}
-
-/**
- * Coverage-gap provenance block. The summary line stays visible (1-line warn)
- * while the long Sys_error blob hides under a closed `<details>` to reclaim
- * vertical real estate. Producer/store/surface/trace stay flat-rendered because
- * those are the triage-actionable fields; `error` is the noisy one.
- *
- * When the error matches a known operator-actionable pattern (e.g. FD
- * exhaustion), a small "see RFC-XXXX" link renders below the details block —
- * Error→Action linkage so operators don't have to grep RFCs themselves.
- *
- * Label spans use `${label + ' '}` (not adjacent siblings) so DOM textContent
- * preserves "label value" as a contiguous substring — keeps existing
- * text-search tests working without format-coupling.
- */
-function CoverageGapBlock({ display }: { display: CoverageGapDisplay }) {
-  const { structured } = display
-  const hint = classifyCoverageError(structured.error)
-  return html`
-    <div class="mt-1 grid gap-1 rounded-[var(--r-1)] border border-[var(--color-status-warn)]/30 bg-[var(--warn-10)]/30 px-2 py-1.5 text-3xs">
-      <div class="flex items-center gap-1.5 font-medium text-[var(--color-status-warn)]">
-        <span aria-hidden="true">⚠</span>
-        <span>${display.summary}</span>
-      </div>
-      ${structured.fields.length > 0 ? html`
-        <div class="grid gap-0.5 font-mono">
-          ${structured.fields.map(({ label, value }) => html`
-            <div class="flex items-baseline">
-              <span class="w-16 shrink-0 text-[var(--color-fg-disabled)] uppercase tracking-wide">${label + ' '}</span>
-              <span class="min-w-0 break-all text-[var(--color-fg-muted)]">${value}</span>
-            </div>
-          `)}
-        </div>
-      ` : null}
-      ${structured.error ? html`
-        <details class="group">
-          <summary class="flex items-baseline cursor-pointer list-none [&::-webkit-details-marker]:hidden font-mono">
-            <span class="w-16 shrink-0 uppercase tracking-wide text-[var(--color-fg-disabled)]">error </span>
-            <span class="min-w-0 flex-1 truncate text-[var(--color-fg-muted)] group-open:hidden">${structured.error}</span>
-            <span class="ml-2 shrink-0 text-[var(--color-fg-disabled)]" aria-hidden="true">
-              <span class="group-open:hidden">▸</span>
-              <span class="hidden group-open:inline">▾</span>
-            </span>
-          </summary>
-          <pre class="mt-1 ml-16 max-h-32 overflow-auto rounded-[var(--r-1)] bg-[var(--bg-deepest)] p-2 font-mono text-3xs leading-snug text-[var(--color-fg-muted)] whitespace-pre-wrap break-all">${structured.error}</pre>
-        </details>
-      ` : null}
-      ${hint ? html`
-        <a
-          href=${hint.href}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="ml-16 inline-flex items-center gap-1 self-start rounded-[var(--r-1)] border border-[var(--color-status-warn)]/40 bg-[var(--warn-10)] px-1.5 py-0.5 font-medium text-[var(--color-status-warn)] hover:bg-[var(--warn-20)]"
-          data-testid=${`coverage-gap-hint-${hint.reason}`}
-        >
-          <span aria-hidden="true">💡</span>
-          <span>${hint.label}</span>
-          <span aria-hidden="true">↗</span>
-        </a>
-      ` : null}
     </div>
   `
 }


### PR DESCRIPTION
## Summary

PR #17015에서 도입한 `CoverageGapBlock`을 `dashboard/src/components/common/`으로 승격해 두 panel이 공유.

**Before**: tool-quality-panel은 풍부한 collapsible UX, fleet-health-panel Operations 뷰는 *같은 데이터를 다르게* 렌더 (`summary` + `details.slice(0, 2)`만). 운영자가 어디서 보느냐에 따라 정보량과 시각이 다름.

**After**: 두 surface 모두 같은 컴포넌트 — 동일한 warn 헤더 / triage chips / collapsed error / RFC link UX.

## Changes

| File | Change |
|------|--------|
| `common/coverage-gap-block.ts` (new) | `CoverageGapBlock` + `classifyCoverageError` SSOT. data-testid="coverage-gap-block" 추가 (panel-agnostic integration test 가능) |
| `tool-quality-panel.ts` | -98 lines. inline 컴포넌트 제거, common에서 import. `classifyCoverageError` re-export로 기존 test import path 호환 |
| `fleet-health-panel.ts` | inline 5-line render → `<CoverageGapBlock>`. Operations 카드가 *부분 정보* (slice(0,2))에서 *full provenance + collapsible error*로 |

## Why this matters

- **SSOT**: collapsible 로직 / RFC hint / label spacing trick (`${label + ' '}`) 한 곳에서 관리. 새 RFC 추가 시 한 함수만 수정.
- **운영자 경험 통일**: HEALTH 배지 hover로 coverage gap 확인 vs Tool Quality 직접 진입에서 같은 정보. 인지 부담 감소.
- **fleet-health-panel 즉시 개선**: side-effect로 Operations 뷰가 *모든* triage 정보 (producer/store/surface/trace/error 5개 다) 노출. 이전 2개 truncation 사라짐.

## Why this avoids the workaround anti-patterns

- **N-of-M 패치 아님**: 한 PR에서 두 surface 모두 SSOT 적용. CLAUDE.md §워크어라운드 거부 §3 정확히 회피.
- **중복 제거**: 동일 데이터의 두 가지 다른 표시 형식 → 단일 형식.

## Verification

```
vitest:       53/53 PASS (tool-quality + fleet-health + source-health)
tsc:          changed files clean
eslint:       0 errors
vite build:   ✓ 11.98s
```

기존 통합 테스트 (`coverage gaps N: <reason>` substring assertion 등)가 SSOT 변경 후에도 그대로 통과 — 추출이 *동일한* render 산출물 보존.

## Test plan

- [ ] `#monitoring?view=tool-quality` 진입 시 coverage gap 블록이 PR #17015과 동일하게 보이는가 (no regression)
- [ ] `#monitoring?section=fleet-health` (Operations 뷰) 진입 시 coverage gap이 *새 collapsible 형식*으로 표시
  - [ ] 5개 triage chip (producer/store/surface/trace/error) 모두 노출
  - [ ] error는 `<details>` 안에 closed default
  - [ ] FD 패턴 매치 시 RFC-0097 link hint
- [ ] 두 surface가 *시각적으로 동일*한 박스 디자인

## Notes for review

- `classifyCoverageError`를 tool-quality-panel.ts에서 re-export — 기존 test import 경로 깨지 않기 위함. 후속 PR에서 import 경로 직접 common으로 이전 가능.
- common 모듈 자체의 단위 테스트는 보류 — render 산출물은 기존 panel 통합 테스트가 검증. 필요 시 별도 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
