### PR TITLE
[codex] Add Keeper tool-name projection boundary

### DIFF
--- a/lib/keeper/keeper_tool_name_projection.ml
+++ b/lib/keeper/keeper_tool_name_projection.ml
@@ -1,0 +1,107 @@
+(** Projection from internal keeper tool IDs to active model-facing names. *)
+
+type context =
+  | Model_facing
+  | Internal_audit
+
+type model_resolution =
+  | Use_public_name of
+      { public_name : string
+      ; internal_name : string
+      }
+  | Use_internal_name of { internal_name : string }
+  | No_visible_name of
+      { internal_name : string
+      ; public_names : string list
+      }
+  | Unknown_name of string
+
+let visible_set visible_tool_names =
+  let tbl = Hashtbl.create (List.length visible_tool_names) in
+  List.iter (fun name -> Hashtbl.replace tbl name ()) visible_tool_names;
+  tbl
+;;
+
+let public_aliases_for_internal_name internal_name =
+  Keeper_tool_alias.public_names ()
+  |> List.filter (fun public_name ->
+    match Keeper_tool_alias.route public_name with
+    | Some route -> String.equal route.internal_name internal_name
+    | None -> false)
+;;
+
+let resolve_model_name ~(visible_tool_names : string list) (name : string) =
+  let visible = visible_set visible_tool_names in
+  let stripped = Keeper_tool_alias.strip_mcp_masc_prefix name in
+  let internal_name =
+    match Keeper_tool_alias.canonical_internal_name stripped with
+    | Some internal_name -> internal_name
+    | None -> stripped
+  in
+  let public_names = public_aliases_for_internal_name internal_name in
+  let visible_public_name =
+    List.find_opt (fun public_name -> Hashtbl.mem visible public_name) public_names
+  in
+  match visible_public_name with
+  | Some public_name -> Use_public_name { public_name; internal_name }
+  | None when Hashtbl.mem visible internal_name -> Use_internal_name { internal_name }
+  | None when public_names <> [] || Keeper_tool_alias.is_known_internal internal_name ->
+    No_visible_name { internal_name; public_names }
+  | None -> Unknown_name name
+;;
+
+let model_name ~visible_tool_names name =
+  match resolve_model_name ~visible_tool_names name with
+  | Use_public_name { public_name; _ } -> Some public_name
+  | Use_internal_name { internal_name } -> Some internal_name
+  | No_visible_name _ | Unknown_name _ -> None
+;;
+
+let render_reference ~context ~visible_tool_names name =
+  match context with
+  | Internal_audit -> name
+  | Model_facing ->
+    (match resolve_model_name ~visible_tool_names name with
+     | Use_public_name { public_name; _ } -> public_name
+     | Use_internal_name { internal_name } -> internal_name
+     | No_visible_name { internal_name; public_names } ->
+       let alias_hint =
+         match public_names with
+         | [] -> ""
+         | aliases ->
+           Printf.sprintf
+             " Public alias%s when visible: %s."
+             (if List.length aliases = 1 then "" else "es")
+             (String.concat " or " aliases)
+       in
+       Printf.sprintf
+         "No active schema name is visible for %s. Report the blocker instead \
+          of inventing an internal tool call.%s"
+         internal_name
+         alias_hint
+     | Unknown_name unknown ->
+       Printf.sprintf
+         "Unknown tool name %s. Use only names listed in the active schema."
+         unknown)
+;;
+
+let blocker_guidance ~visible_tool_names internal_name =
+  match resolve_model_name ~visible_tool_names internal_name with
+  | No_visible_name { internal_name; public_names } ->
+    let alias_sentence =
+      match public_names with
+      | [] -> ""
+      | aliases ->
+        Printf.sprintf
+          " Public alias%s when visible: %s."
+          (if List.length aliases = 1 then "" else "es")
+          (String.concat " or " aliases)
+    in
+    Some
+      (Printf.sprintf
+         "No model-facing tool for %s is visible in this turn; report the \
+          blocker instead of inventing internal tool names.%s"
+         internal_name
+         alias_sentence)
+  | Use_public_name _ | Use_internal_name _ | Unknown_name _ -> None
+;;

--- a/lib/keeper/keeper_tool_name_projection.mli
+++ b/lib/keeper/keeper_tool_name_projection.mli
@@ -1,0 +1,69 @@
+(** Keeper_tool_name_projection -- model-facing names for keeper tools.
+
+    This module is the narrow boundary between internal handler IDs
+    ([keeper_bash], [keeper_shell], ...) and names the model may spell in
+    the active tool schema ([Bash], [Read], ...). It deliberately delegates
+    alias truth to {!Keeper_tool_alias}; do not add another mapping table
+    here. *)
+
+type context =
+  | Model_facing
+      (** Prompt, recovery, nudge, and tool-call correction text. *)
+  | Internal_audit
+      (** Logs, metrics, docs, and tests that explicitly discuss internals. *)
+
+type model_resolution =
+  | Use_public_name of
+      { public_name : string
+      ; internal_name : string
+      }
+      (** A public alias is visible; model-facing text should use it. *)
+  | Use_internal_name of { internal_name : string }
+      (** The internal name itself is visible in this turn's active schema. *)
+  | No_visible_name of
+      { internal_name : string
+      ; public_names : string list
+      }
+      (** The internal tool is known, but no callable model-facing name is
+          visible in this turn. *)
+  | Unknown_name of string
+      (** The supplied name is not recognised as public, public-MCP, or
+          internal. *)
+
+val public_aliases_for_internal_name : string -> string list
+(** All public LLM-native aliases backed by [internal_name], in
+    {!Keeper_tool_alias.public_names} order. *)
+
+val resolve_model_name
+  :  visible_tool_names:string list
+  -> string
+  -> model_resolution
+(** Resolve an internal handler name to the name model-facing text may
+    mention under the current active schema. Public aliases win over
+    visible internal names, so mixed surfaces still prefer public names. *)
+
+val model_name
+  :  visible_tool_names:string list
+  -> string
+  -> string option
+(** Convenience wrapper over {!resolve_model_name}. Returns [None] when the
+    tool is known but absent from the active schema, or unknown. *)
+
+val render_reference
+  :  context:context
+  -> visible_tool_names:string list
+  -> string
+  -> string
+(** Render a short reference suitable for user/model-facing text. In
+    [Model_facing] context, hidden internal names are never returned as the
+    callable suggestion. In [Internal_audit] context, the internal name is
+    returned verbatim because the caller has explicitly opted into internal
+    nomenclature. *)
+
+val blocker_guidance
+  :  visible_tool_names:string list
+  -> string
+  -> string option
+(** If [internal_name] has no model-callable name in the active schema,
+    return guidance that tells the model to report the blocker instead of
+    inventing an internal tool call. *)

--- a/test/dune
+++ b/test/dune
@@ -210,6 +210,7 @@
   test_keeper_toml
   test_keeper_runtime_toml
   test_keeper_tool_policy_config
+  test_keeper_tool_name_projection
   test_keeper_tool_resolution
   test_dispatch_disclosure_parity
   test_coord_worktree_policy_path
@@ -527,6 +528,7 @@
   test_keeper_toml
   test_keeper_runtime_toml
   test_keeper_tool_policy_config
+  test_keeper_tool_name_projection
   test_keeper_tool_resolution
   test_dispatch_disclosure_parity
   test_coord_worktree_policy_path

--- a/test/test_keeper_tool_name_projection.ml
+++ b/test/test_keeper_tool_name_projection.ml
@@ -1,0 +1,109 @@
+open Alcotest
+
+module Projection = Masc_mcp.Keeper_tool_name_projection
+
+let contains needle haystack =
+  let nlen = String.length needle in
+  let hlen = String.length haystack in
+  let rec loop i =
+    if i + nlen > hlen
+    then false
+    else if String.sub haystack i nlen = needle
+    then true
+    else loop (i + 1)
+  in
+  loop 0
+;;
+
+let check_contains label needle text = check bool label true (contains needle text)
+let check_not_contains label needle text = check bool label false (contains needle text)
+
+let test_visible_public_alias_wins () =
+  check
+    (option string)
+    "keeper_bash projects to visible Bash"
+    (Some "Bash")
+    (Projection.model_name ~visible_tool_names:[ "Bash" ] "keeper_bash");
+  match
+    Projection.resolve_model_name ~visible_tool_names:[ "keeper_bash"; "Bash" ]
+      "keeper_bash"
+  with
+  | Use_public_name { public_name; internal_name } ->
+    check string "public alias" "Bash" public_name;
+    check string "internal handler" "keeper_bash" internal_name
+  | _ -> fail "expected visible public alias to win over visible internal name"
+;;
+
+let test_hidden_alias_reports_blocker () =
+  check
+    (option string)
+    "hidden keeper_bash has no model-callable name"
+    None
+    (Projection.model_name ~visible_tool_names:[ "Read" ] "keeper_bash");
+  let text =
+    Projection.render_reference
+      ~context:Model_facing
+      ~visible_tool_names:[ "Read" ]
+      "keeper_bash"
+  in
+  check_contains "blocker text mentions no active schema name" "No active schema name" text;
+  check_contains "blocker text mentions public alias" "Bash" text;
+  check_contains "blocker text tells report" "Report the blocker" text
+;;
+
+let test_internal_audit_context_is_explicit () =
+  let model_text =
+    Projection.render_reference
+      ~context:Model_facing
+      ~visible_tool_names:[ "Bash" ]
+      "keeper_bash"
+  in
+  check string "model-facing context uses public alias" "Bash" model_text;
+  let audit_text =
+    Projection.render_reference
+      ~context:Internal_audit
+      ~visible_tool_names:[ "Bash" ]
+      "keeper_bash"
+  in
+  check string "audit context may name internal handler" "keeper_bash" audit_text
+;;
+
+let test_unknown_name_does_not_gain_alias () =
+  let text =
+    Projection.render_reference
+      ~context:Model_facing
+      ~visible_tool_names:[ "Bash" ]
+      "keeper_not_real"
+  in
+  check_contains "unknown guidance names unknown" "Unknown tool name keeper_not_real" text;
+  check_not_contains "unknown guidance does not suggest Bash" "Use Bash" text
+;;
+
+let test_blocker_guidance_only_when_hidden () =
+  check
+    (option string)
+    "visible alias has no blocker"
+    None
+    (Projection.blocker_guidance ~visible_tool_names:[ "Bash" ] "keeper_bash");
+  match Projection.blocker_guidance ~visible_tool_names:[ "Read" ] "keeper_bash" with
+  | None -> fail "expected hidden alias blocker guidance"
+  | Some text ->
+    check_contains "blocker names internal subject" "keeper_bash" text;
+    check_contains "blocker lists public alias" "Bash" text
+;;
+
+let () =
+  run
+    "keeper_tool_name_projection"
+    [ ( "projection"
+      , [ test_case "visible public alias wins" `Quick test_visible_public_alias_wins
+        ; test_case "hidden alias reports blocker" `Quick test_hidden_alias_reports_blocker
+        ; test_case "internal audit context is explicit" `Quick
+            test_internal_audit_context_is_explicit
+        ; test_case "unknown name does not gain alias" `Quick
+            test_unknown_name_does_not_gain_alias
+        ; test_case "blocker guidance only when hidden" `Quick
+            test_blocker_guidance_only_when_hidden
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

- Add `Keeper_tool_name_projection` as the explicit boundary between internal keeper handler IDs and model-visible active schema names.
- Delegate alias truth to `Keeper_tool_alias` so this does not introduce a second mapping table.
- Add focused tests for public-alias preference, hidden-alias blocker guidance, explicit internal/audit context, and unknown-name behavior.

## Why

PR #17016 removed known leaks of `keeper_bash` / `keeper_shell` from model-facing recovery text, but that was containment. This PR starts the architectural path from issue #17023 by making public-name projection a reusable SSOT.

## Validation

- `ocamlformat --check lib/keeper/keeper_tool_name_projection.mli lib/keeper/keeper_tool_name_projection.ml test/test_keeper_tool_name_projection.ml`
- `git diff --check`
- `env DUNE_BUILD_DIR=/private/tmp/masc-pr-b-dune-build MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_tool_name_projection.exe`

## Notes

- PR-A evidence: an isolated focused build of `test/test_keeper_bash_safety.exe test/test_keeper_readonly_hints.exe` passed with `DUNE_BUILD_DIR=/private/tmp/masc-pr-a-dune-build`, confirming the earlier `Keeper_exec_shell` interface mismatch was stale/concurrent build state rather than a surviving code interface bug.
