### PR TITLE
refactor(dashboard): extract telemetry view dispatch into telemetry-panel

### DIFF
--- a/dashboard/src/components/runtime-panel.ts
+++ b/dashboard/src/components/runtime-panel.ts
@@ -29,7 +29,7 @@ import { OasHealthChip } from './oas-health-chip'
 import { RuntimeMonitor } from './runtime-monitor'
 import { PrometheusMetrics } from './prometheus-metrics'
 import { VerificationSpecsPanel } from './verification-specs-panel'
-import { CostDashboard, type CostView } from './cost-dashboard'
+import { TelemetryPanel, isTelemetryView } from './telemetry-panel'
 import { CascadeInspector } from './cascade-inspector'
 import { RouteLink } from './common/route-link'
 
@@ -87,12 +87,6 @@ const ADVANCED_VIEW_CHIPS: Array<{ key: RuntimeView; label: string }> = [
   { key: 'prometheus', label: '메트릭' },
   { key: 'verification', label: '형식검증' },
 ]
-
-function costDiagnosticView(view: RuntimeView): CostView | null {
-  return view === 'cost' || view === 'audit' || view === 'heuristics' || view === 'stress'
-    ? view
-    : null
-}
 
 function updateViewParam(view: RuntimeView): void {
   replaceRoute(
@@ -178,7 +172,6 @@ function HiddenDiagnosticsLinks() {
 
 export function RuntimePanel() {
   const view = activeView.value
-  const costView = costDiagnosticView(view)
 
   return html`
     <div class="flex flex-col gap-4">
@@ -206,8 +199,8 @@ export function RuntimePanel() {
             <${OasHealthChip} />
             <${RuntimeMonitor} />
           `
-        : costView
-          ? html`<${CostDashboard} view=${costView} />`
+        : isTelemetryView(view)
+          ? html`<${TelemetryPanel} view=${view} />`
         : view === 'inspector'
           ? html`<${CascadeInspector} />`
         : view === 'prometheus'

--- a/dashboard/src/components/telemetry-panel.ts
+++ b/dashboard/src/components/telemetry-panel.ts
@@ -1,0 +1,33 @@
+// MASC Dashboard — runtime telemetry sub-panel.
+//
+// Hosts the four "infra/billing/audit" views that previously lived inline in
+// runtime-panel.ts: `cost`, `audit`, `heuristics`, `stress`. Today they all
+// dispatch to the same CostDashboard component (it sub-routes on the view
+// key); this module just owns the view-set membership predicate and the
+// thin render wrapper so runtime-panel.ts can ask "is this a telemetry view"
+// without enumerating the labels itself.
+//
+// Behavior is unchanged from the previous inline form: URLs, cockpit aliases
+// (audit / hr-log / hr-st / hr-mod / ct-agt / ct-mtx / ct-lat), and chip
+// strip layout (Primary vs Advanced) all stay where they are. This is a
+// pure structural extraction so a future PR can grow the telemetry surface
+// (richer dispatch, dedicated tabs, separate store) without touching
+// runtime-panel.
+
+import { html } from 'htm/preact'
+import { CostDashboard, type CostView } from './cost-dashboard'
+
+const TELEMETRY_VIEW_SET: ReadonlySet<CostView> = new Set<CostView>([
+  'cost',
+  'audit',
+  'heuristics',
+  'stress',
+])
+
+export function isTelemetryView(view: string): view is CostView {
+  return TELEMETRY_VIEW_SET.has(view as CostView)
+}
+
+export function TelemetryPanel({ view }: { view: CostView }) {
+  return html`<${CostDashboard} view=${view} />`
+}


### PR DESCRIPTION
## Goal
runtime-panel.ts에 박혀 있던 cost/audit/heuristics/stress 4-view dispatch + `costDiagnosticView` 헬퍼를 신규 `telemetry-panel.ts`로 추출. PR-4 v1(#17014) chip 그룹화 + #17025 cost-store SSOT lift의 구조적 후속. 동작 변화 0.

## Changed files
- 신규 `dashboard/src/components/telemetry-panel.ts` (~36 LoC) — `isTelemetryView` type guard + `TelemetryPanel` 래퍼
- 수정 `dashboard/src/components/runtime-panel.ts` (-10 LoC) — `costDiagnosticView` 함수 제거, `CostDashboard`/`CostView` import → `TelemetryPanel`/`isTelemetryView` 교체, dispatch 한 줄 갱신

## Self-review
- 목표: cost/audit/heuristics/stress dispatch 경계를 telemetry-panel.ts에 격리. 향후 surface 분리 또는 per-mount state 작업의 진입점
- 범위: 1 신규 + 1 수정. 36+/10- = +26 net
- 동작 변화: **0**. 같은 4 view, 같은 URL hash, 같은 cockpit alias(audit/hr-log/hr-st/hr-mod/ct-agt/ct-mtx/ct-lat), 같은 Primary/Advanced chip strip
- 로컬 검증:
  - `pnpm run typecheck` — 본 변경 관련 0 에러. (baseline: credential-settings.ts:13 TS6133 — RFC-gated, 무관)
  - `pnpm vitest run src/components/runtime-panel src/components/cost-dashboard` — **53/53 passed** (3 test files)

## 왜 이 PR이 작은가
PR-4 v2 original plan은 ~230 LoC. 본 PR은 *경계 추출만* 수행 (~36 LoC). 추가 작업 (TELEMETRY_VIEW_CHIPS 자체 owning, per-mount factory pattern, cost-store rebinding, telemetry-panel.test.ts 추가)은 별도 PR로 분리. 현재 PR은 *0 동작 변화* 안전 단위.

## Mount safety note
cost-store SSOT(#17025)가 9 signal을 모듈-레벨로 보관 중. TelemetryPanel과 CostDashboard 둘 다 mounting되면 state 공유 가능. 현재 runtime-panel은 한 번에 한 view만 렌더링 → mutual exclusion. 향후 telemetry-panel을 독립 surface로 띄울 때 factory pattern 또는 mutual exclusion 보장 필요 (cost-store.ts 인라인 주석 참조).

## References
- 형제 PR: #17014 (chip 그룹화 — MERGED), #17025 (cost-store SSOT lift — MERGED)
- Monitor IA 리뷰: `/Users/dancer/me/memory/masc-oas-dashboard-monitor-ia-report-2026-05-20.html`
- Agent D plan (PR-4 v2 original spec): task #11 description

🤖 Generated with [Claude Code](https://claude.com/claude-code)