### PR TITLE
refactor(dashboard): remove dead credential import

### DIFF
--- a/dashboard/src/components/common/virtual-list.ts
+++ b/dashboard/src/components/common/virtual-list.ts
@@ -84,7 +84,6 @@ export function VirtualList<T>({
       acc[i + 1] = (acc[i] ?? 0) + h
     }
     return acc
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dynamicMode, items, measureTick, estimatedItemHeight, getKey])
 
   useEffect(() => {

--- a/dashboard/src/components/credential-settings.ts
+++ b/dashboard/src/components/credential-settings.ts
@@ -10,7 +10,6 @@ import {
   coerceCredentialType,
   sanitizeOptionalString,
   githubLoginCommand,
-  buildCredentialCreateRequest,
   type Credential,
   type CredentialCreatePayload,
   type CredentialOauthMethod,


### PR DESCRIPTION
## Summary
- remove an unused credential request builder import that blocked dashboard typecheck
- remove an unused `react-hooks/exhaustive-deps` disable directive from `VirtualList`

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`
