### PR TITLE
fix(keeper): consume OAS required-tool hints

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -731,23 +731,40 @@ let run_turn
                      acc.contract_violation_retries <-
                        acc.contract_violation_retries + 1;
                      let satisfying_tools =
-                       Keeper_agent_tool_surface
-                       .generic_required_tool_candidate_names
-                         ~has_current_task:
-                           (Option.is_some
-                              (owned_active_task_id_for_meta
-                                 ~config ~meta:acc.meta))
-                         ~turn_affordances
-                         ~allowed_tool_names:
-                           acc.tool_surface.required_tool_candidate_names
+                       let local_tools =
+                         Keeper_agent_tool_surface
+                         .generic_required_tool_candidate_names
+                           ~has_current_task:
+                             (Option.is_some
+                                (owned_active_task_id_for_meta
+                                   ~config ~meta:acc.meta))
+                           ~turn_affordances
+                           ~allowed_tool_names:
+                             acc.tool_surface.required_tool_candidate_names
+                       in
+                       let oas_tools =
+                         Keeper_tool_disclosure
+                         .satisfying_tools_from_contract_violation_reason
+                           violation_reason
+                       in
+                       Keeper_types.dedupe_keep_order (oas_tools @ local_tools)
+                     in
+                     let retry_action =
+                       match satisfying_tools with
+                       | [] ->
+                         "No currently visible tool can satisfy this contract; \
+                          emit a concise blocker instead."
+                       | tools ->
+                         Printf.sprintf
+                           "You MUST call one of these tools: %s."
+                           (String.concat ", " tools)
                      in
                      let retry_feedback =
                        Printf.sprintf
                          "[CONTRACT VIOLATION] Your previous response was \
-                          rejected: %s. You MUST call one of these tools: \
-                          %s. Do NOT respond with text only."
+                          rejected: %s. %s Do NOT respond with text only."
                          violation_reason
-                         (String.concat ", " satisfying_tools)
+                         retry_action
                      in
                      (* Append violation feedback as a User message so the
                         model sees why its response was rejected. *)

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -1484,15 +1484,24 @@ let prepare_agent_setup
                       |> List.filteri (fun i _ -> i < 8)
                       |> String.concat ", "
                     in
+                    let retry_action =
+                      if preview = ""
+                      then
+                        "No currently visible tool can satisfy this contract; \
+                         emit a concise blocker instead."
+                      else
+                        Printf.sprintf
+                          "You MUST call one of these tools NOW: %s."
+                          preview
+                    in
                     append_ctx
                       ctx
                       (Printf.sprintf
                          "[CONTRACT VIOLATION RETRY] Your previous Agent.run \
                           attempt was rejected because you did not call a \
-                          required tool. You MUST call one of these tools NOW: \
-                          %s. Do NOT respond with text only, do NOT substitute \
+                          required tool. %s Do NOT respond with text only, do NOT substitute \
                           status or read-only tools."
-                         preview)
+                         retry_action)
                   else ctx
                 in
                 if computed_surface.is_warning_zone

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -540,6 +540,27 @@ let required_tool_satisfaction_for_turn
   | _ -> required_tool_satisfaction_for_required_names ~satisfying_tools ~required_tool_names call
 ;;
 
+let parse_tool_csv text =
+  text
+  |> String.split_on_char ','
+  |> List.map String.trim
+  |> List.filter (fun tool -> tool <> "")
+  |> Keeper_types.dedupe_keep_order
+;;
+
+let satisfying_tools_from_contract_violation_reason reason =
+  let marker = "Satisfying tools for this contract: [" in
+  match String_util.find_substring reason marker with
+  | None -> []
+  | Some marker_start ->
+    let tools_start = marker_start + String.length marker in
+    (match String_util.find_substring ~pos:tools_start reason "]" with
+     | None -> []
+     | Some tools_end ->
+       String.sub reason tools_start (tools_end - tools_start)
+       |> parse_tool_csv)
+;;
+
 let classify_tool_progress name =
   if is_keeper_observation_alias name
   then Passive_status

--- a/lib/keeper/keeper_tool_disclosure.mli
+++ b/lib/keeper/keeper_tool_disclosure.mli
@@ -205,6 +205,15 @@ val required_tool_satisfaction_for_turn
   -> Agent_sdk.Completion_contract.tool_call
   -> (unit, string) result
 
+(** Extract OAS completion-contract satisfying-tool hints from an error reason.
+
+    OAS v0.196.4 appends a line shaped like
+    ["Satisfying tools for this contract: [keeper_board_post, masc_broadcast]"].
+    Keeper recovery prompts consume this so retry guidance does not lose the
+    provider-side violation detail. Returns [] when the reason has no hint or
+    the hint is empty. *)
+val satisfying_tools_from_contract_violation_reason : string -> string list
+
 (** Project a tool name to its [tool_progress_class]. *)
 val classify_tool_progress : string -> tool_progress_class
 

--- a/test/test_keeper_unified_required_tools.ml
+++ b/test/test_keeper_unified_required_tools.ml
@@ -192,6 +192,32 @@ let test_satisfying_tools_for_turn_computes_from_affordances () =
   check (list string) "unknown affordance yields empty" [] empty
 ;;
 
+let test_contract_violation_reason_extracts_oas_satisfying_tools () =
+  let reason =
+    "required tool contract unsatisfied: model called [masc_status], but no call \
+     satisfied the required-tool predicate\n\
+     Satisfying tools for this contract: [keeper_board_post, masc_broadcast]"
+  in
+  check
+    (list string)
+    "extract OAS satisfying tools"
+    [ "keeper_board_post"; "masc_broadcast" ]
+    (KTD.satisfying_tools_from_contract_violation_reason reason);
+  check
+    (list string)
+    "dedupe and trim"
+    [ "keeper_board_post"; "masc_broadcast" ]
+    (KTD.satisfying_tools_from_contract_violation_reason
+       "Satisfying tools for this contract: [ keeper_board_post, masc_broadcast, \
+        keeper_board_post ]");
+  check
+    (list string)
+    "missing hint"
+    []
+    (KTD.satisfying_tools_from_contract_violation_reason
+       "required tool contract unsatisfied: model called []")
+;;
+
 let () =
   run
     "keeper_unified_required_tools"
@@ -220,6 +246,10 @@ let () =
             "satisfying_tools_for_turn computes from affordances"
             `Quick
             test_satisfying_tools_for_turn_computes_from_affordances
+        ; test_case
+            "contract violation reason extracts OAS satisfying tools"
+            `Quick
+            test_contract_violation_reason_extracts_oas_satisfying_tools
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

- Parse OAS completion-contract satisfying-tool hints from `CompletionContractViolation` reason text.
- Prefer those OAS-provided satisfying tools when composing required-tool retry guidance.
- Avoid emitting empty "You MUST call one of these tools" retry prompts when no visible tool can satisfy the contract.

## Product impact

Required-tool recovery now preserves provider-side detail from the OAS v0.196.4 bump instead of falling back to generic local candidates only. This reduces cases where keeper recovery and OAS validation describe different tool expectations.

## Evidence

- `ocamlformat --check lib/keeper/keeper_tool_disclosure.ml lib/keeper/keeper_tool_disclosure.mli lib/keeper/keeper_agent_run.ml lib/keeper/keeper_run_tools.ml test/test_keeper_unified_required_tools.ml`
- `git diff --check`
- `scripts/check-oas-pin.sh --local-only` -> `main@3f60ad9cc075ca675ca33e6dc8503759336e4f1f`, base version `v0.196.4`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_unified_required_tools.exe`

## Review evidence

- Added a focused unit test for parsing OAS satisfying-tool hints, trimming, and de-duplication.
- Diff is limited to keeper required-tool retry prompt construction and the disclosure helper.

## Linked issue

- Follow-up from the remaining-work HTML report P0: consume OAS v0.196.2+ typed required-tool violation detail in MASC recovery.
- Related blocker: #17030.
