### PR TITLE
fix(dashboard): decouple full-health refresh timeout

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -787,13 +787,9 @@ module Dashboard = struct
 
       Caps a single [/health?full=1] cache refresh attempt in
       [Server_routes_http_runtime.start_full_health_snapshot_refresh_loop].
-      Default 8s preserves the pre-extraction literal at
-      [server_routes_http_runtime.ml:807]. The effective value is then
-      clamped to be at least [shell_timeout_sec] so the full-health
-      refresh budget never undershoots the dashboard shell render
-      budget (the test
-      [test_full_health_refresh_budget_tracks_shell_budget] enforces
-      this).  Floor 1s prevents degenerate operator overrides. *)
+      Default 8s keeps this proactive refresh independent from the
+      dashboard shell render timeout. Floor 1s prevents degenerate
+      operator overrides. *)
   let full_health_refresh_timeout_sec =
     Float.max 1.0
       (get_float ~default:8.0 "MASC_FULL_HEALTH_REFRESH_TIMEOUT_SEC")

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -1021,8 +1021,7 @@ let full_health_refresh_requested = ref false
    bookkeeping. *)
 let full_health_consecutive_failures = ref 0
 let full_health_refresh_timeout_sec =
-  Float.max Env_config_runtime.Dashboard.full_health_refresh_timeout_sec
-    Env_config_runtime.Dashboard.shell_timeout_sec
+  Env_config_runtime.Dashboard.full_health_refresh_timeout_sec
 ;;
 
 let full_health_critical_failure_threshold =

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1361,12 +1361,15 @@ let test_health_response_full_query_uses_snapshot_cache () =
      | `Assoc _ -> true
      | _ -> false)
 
-let test_full_health_refresh_budget_tracks_shell_budget () =
+let test_full_health_refresh_timeout_is_independent_from_shell_budget () =
   let interval_sec, timeout_sec =
     Server_routes_http_runtime.For_testing.full_health_refresh_timing ()
   in
-  Alcotest.(check bool) "full health timeout covers shell full budget" true
-    (timeout_sec >= Env_config_runtime.Dashboard.shell_timeout_sec);
+  Alcotest.(check float 0.001) "full health timeout uses dedicated budget"
+    Env_config_runtime.Dashboard.full_health_refresh_timeout_sec
+    timeout_sec;
+  Alcotest.(check bool) "full health timeout is below shell full budget" true
+    (timeout_sec < Env_config_runtime.Dashboard.shell_timeout_sec);
   Alcotest.(check bool) "full health interval exceeds timeout" true
     (interval_sec > timeout_sec)
 
@@ -2954,8 +2957,9 @@ let () =
             test_health_response_default_is_light_probe;
           Alcotest.test_case "full health query uses snapshot cache" `Quick
             test_health_response_full_query_uses_snapshot_cache;
-          Alcotest.test_case "full health refresh budget tracks shell budget"
-            `Quick test_full_health_refresh_budget_tracks_shell_budget;
+          Alcotest.test_case "full health refresh timeout is independent"
+            `Quick
+            test_full_health_refresh_timeout_is_independent_from_shell_budget;
           Alcotest.test_case
             "full health refresh timeout preserves last snapshot" `Quick
             test_full_health_refresh_timeout_preserves_last_snapshot;


### PR DESCRIPTION
## Summary

- Remove the shell-timeout clamp from full-health proactive refresh.
- Update the env-config documentation so the full-health timeout is described as an independent refresh budget.
- Replace the old coupling test with an independence test for the full-health refresh timing.

## Product impact

`/health?full=1` refresh failures now stay scoped to the full-health snapshot refresh budget instead of inheriting the dashboard shell render budget. This keeps dashboard shell responsiveness and full-health refresh behavior from looking like the same failure mode.

## Evidence

- `ocamlformat --check lib/server/server_routes_http_runtime.ml lib/config/env_config_runtime.ml test/test_server_runtime_bootstrap.ml`
- `git diff --check`
- Focused Dune for `test/test_server_runtime_bootstrap.exe` is pending behind the same repo-local Dune queue tracked by #17030.

## Review evidence

- The change is limited to the refresh timeout constant, its config comment, and the existing timing test.
- `Proactive_refresh`, dashboard telemetry routes, and dashboard cache code were intentionally left untouched.

## Linked issue

- Follow-up from the remaining-work HTML report P0: split full-health refresh timeout from dashboard shell/read-path timeout.
- Related blocker: #17030.
