### PR TITLE
feat(dashboard): classify disk-pressure errors → RFC-0122 hint

### DIFF
--- a/dashboard/src/components/common/coverage-gap-block.ts
+++ b/dashboard/src/components/common/coverage-gap-block.ts
@@ -14,20 +14,47 @@ export type CoverageErrorHint = {
   href: string
 }
 
+// Substring vocabulary mirrors backend SSOT in
+// `lib/keeper_disk_pressure.ml` (`is_disk_exhaustion_text`) so the
+// dashboard reaches the same classification the runtime already acts on.
+// Add new patterns here only when (a) backend has a matching typed
+// detector, and (b) there is a canonical RFC describing the operator
+// remediation.
+const FD_EXHAUSTION_NEEDLES = [
+  'too many open files',
+  'enfile',
+  'emfile',
+] as const
+
+const DISK_EXHAUSTION_NEEDLES = [
+  'no space left on device',
+  'enospc',
+  'disk quota exceeded',
+  'quota exceeded',
+  'disk full',
+  'not enough space',
+] as const
+
 export function classifyCoverageError(error: string | null | undefined): CoverageErrorHint | null {
   if (!error) return null
   const lower = error.toLowerCase()
   // RFC-0097: keeper-sandbox container reuse — root fix for the 2026-05-16
   // ENFILE storm that drove Docker_spawn_throttle + container reuse.
-  if (
-    lower.includes('too many open files')
-    || lower.includes('enfile')
-    || lower.includes('emfile')
-  ) {
+  if (FD_EXHAUSTION_NEEDLES.some(needle => lower.includes(needle))) {
     return {
       reason: 'fd_exhaustion',
       label: 'FD exhaustion — see RFC-0097',
       href: 'https://github.com/jeong-sik/masc-mcp/blob/main/docs/rfc/RFC-0097-keeper-sandbox-container-reuse.md',
+    }
+  }
+  // RFC-0122: keeper disk pressure circuit breaker — mirrors backend
+  // detector at `lib/keeper_disk_pressure.ml:55` which trips spawn slot
+  // admission on these substrings.
+  if (DISK_EXHAUSTION_NEEDLES.some(needle => lower.includes(needle))) {
+    return {
+      reason: 'disk_exhaustion',
+      label: 'Disk pressure — see RFC-0122',
+      href: 'https://github.com/jeong-sik/masc-mcp/blob/main/docs/rfc/RFC-0122-keeper-disk-pressure.md',
     }
   }
   return null

--- a/dashboard/src/components/tool-quality-panel.test.ts
+++ b/dashboard/src/components/tool-quality-panel.test.ts
@@ -474,10 +474,29 @@ describe('classifyCoverageError', () => {
     expect(classifyCoverageError('TOO MANY OPEN FILES')?.reason).toBe('fd_exhaustion')
   })
 
-  it('returns null for unrelated errors (disk full, network, etc.)', () => {
-    expect(classifyCoverageError('disk full')).toBeNull()
+  it('detects ENOSPC / disk-full → RFC-0122 disk_exhaustion hint', () => {
+    const hint = classifyCoverageError(
+      'Sys_error("Eio.Io Unix_error (No space left on device, \\"write\\", \\"...\\")")',
+    )
+    expect(hint).not.toBeNull()
+    expect(hint?.reason).toBe('disk_exhaustion')
+    expect(hint?.href).toContain('RFC-0122')
+    expect(hint?.label).toMatch(/RFC-0122/)
+  })
+
+  it('detects disk-pressure substrings shared with backend SSOT', () => {
+    // Mirrors lib/keeper_disk_pressure.ml `is_disk_exhaustion_text` vocabulary
+    expect(classifyCoverageError('disk full')?.reason).toBe('disk_exhaustion')
+    expect(classifyCoverageError('ENOSPC on append')?.reason).toBe('disk_exhaustion')
+    expect(classifyCoverageError('Disk quota exceeded')?.reason).toBe('disk_exhaustion')
+    expect(classifyCoverageError('quota exceeded')?.reason).toBe('disk_exhaustion')
+    expect(classifyCoverageError('not enough space available')?.reason).toBe('disk_exhaustion')
+  })
+
+  it('returns null for unrelated errors (network, permission, etc.)', () => {
     expect(classifyCoverageError('connection refused')).toBeNull()
     expect(classifyCoverageError('append denied')).toBeNull()
+    expect(classifyCoverageError('permission denied')).toBeNull()
   })
 })
 


### PR DESCRIPTION
## Goal

`classifyCoverageError`에 두 번째 패턴 추가 — disk exhaustion 에러가 RFC-0122 (keeper disk pressure circuit breaker) 로 연결되도록.

PR #17042 가 `CoverageGapBlock` 을 common 모듈로 승격한 직후의 자연스러운 follow-up. SSOT 위에 한 패턴 추가.

## Why

Backend SSOT 가 이미 같은 분류를 수행 중. `lib/keeper_disk_pressure.ml:55-65` 의 `is_disk_exhaustion_text` 가 6개 substring 으로 spawn-slot admission 을 trip 함:

| 패턴 |
|------|
| \`no space left on device\` |
| \`enospc\` |
| \`disk quota exceeded\` |
| \`quota exceeded\` |
| \`disk full\` |
| \`not enough space\` |

Dashboard 에서 같은 에러 문자열을 보고도 operator 가 *왜* 쓰기가 막혔는지 한 번에 인지 못 함 → backend 가 이미 한 분류를 그대로 미러링.

## What

- \`dashboard/src/components/common/coverage-gap-block.ts\`:
  - \`FD_EXHAUSTION_NEEDLES\` / \`DISK_EXHAUSTION_NEEDLES\` 를 \`as const\` 배열로 추출 → 두 패턴 목록의 SSOT 한 자리
  - \`classifyCoverageError\` 에 RFC-0122 분기 추가 (disk_exhaustion / "Disk pressure — see RFC-0122")
  - 인용 주석: backend SSOT 위치 + 추가 기준 ("backend typed detector + canonical RFC 동시 존재 시에만")
- \`dashboard/src/components/tool-quality-panel.test.ts\`:
  - 기존 \`'disk full' → null\` 케이스 삭제, RFC-0122 hint 어설션으로 교체
  - 6개 backend needle 전수 케이스 추가
  - "unrelated errors" 케이스에 disk-full 제거하고 permission/network 만 유지

## Verification

\`\`\`
vitest:    37/37 PASS (classifyCoverageError describe block)
tsc:       0 errors in changed files
eslint:    0 errors / 0 warnings on src files
vite:      ✓ 16.95s
\`\`\`

Wider vitest 의 23개 실패는 origin/main pristine 에서도 동일 → pre-existing, 본 변경과 무관 (agents-unified / git-graph-panel / keeper-conditions-divergent / ide-* / cytoscape-fsm).

## Anti-pattern check

CLAUDE.md 워크어라운드 거부 시그니처 self-check:

- ❌ 텔레메트리-as-fix? 아님. 분류 자체는 이미 backend 에서 typed action (circuit breaker trip) 을 수행 중. 본 PR 은 그 분류를 dashboard 에 미러링.
- ⚠️ String/Substring 분류기 추가? 일부. 다만 render-side hint 영역 + backend 가 이미 동일 substring SSOT 보유 → backend 가 typed 화될 때 dashboard 도 자동으로 따라가는 follow-up 가능. RFC-0042 가 닫는 영역과는 다름 (decode vocabulary 가 아닌 OS error string).
- ❌ N-of-M? 아님. 두 패턴 모두 한 PR.
- ❌ catch-all _ ->? 아님.
- ❌ cap/cooldown/dedup/repair? 아님.

**Future improvement (out of scope):** backend 가 \`error_class: "disk_exhaustion" | "fd_exhaustion"\` 같은 typed enum 을 emit 하고 frontend 는 dictionary lookup 만 하는 구조. RFC-level work.

## Files

- \`dashboard/src/components/common/coverage-gap-block.ts\`
- \`dashboard/src/components/tool-quality-panel.test.ts\`

\`\`\`
2 files changed, 53 insertions(+), 7 deletions(-)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>