### PR TITLE
refactor(dashboard): move telemetry chip definitions into telemetry-panel

### DIFF
--- a/dashboard/src/components/runtime-panel.ts
+++ b/dashboard/src/components/runtime-panel.ts
@@ -29,7 +29,7 @@ import { OasHealthChip } from './oas-health-chip'
 import { RuntimeMonitor } from './runtime-monitor'
 import { PrometheusMetrics } from './prometheus-metrics'
 import { VerificationSpecsPanel } from './verification-specs-panel'
-import { TelemetryPanel, isTelemetryView } from './telemetry-panel'
+import { TelemetryPanel, isTelemetryView, TELEMETRY_VIEW_CHIPS } from './telemetry-panel'
 import { CascadeInspector } from './cascade-inspector'
 import { RouteLink } from './common/route-link'
 
@@ -75,15 +75,13 @@ const PRIMARY_VIEW_CHIPS: Array<{ key: RuntimeView; label: string }> = [
   { key: 'inspector', label: '검사기' },
 ]
 
-// Advanced chips are infra/billing telemetry and formal-verification views.
-// Useful for post-mortems and audits, not for daily keeper triage. They stay
-// reachable via the same chip strip below for now; a follow-up may move
-// cost/audit/heuristics/stress into a dedicated telemetry-panel surface.
+// Advanced chips are infra/billing telemetry plus the raw / formal layers.
+// The first four chips (cost / audit / heuristics / stress) are owned by
+// telemetry-panel.ts — both their labels and their dispatch live there.
+// The remaining two (prometheus / verification) stay inline because
+// runtime-panel still renders them directly.
 const ADVANCED_VIEW_CHIPS: Array<{ key: RuntimeView; label: string }> = [
-  { key: 'cost', label: '비용 / 지연' },
-  { key: 'audit', label: '감사' },
-  { key: 'heuristics', label: '휴리스틱' },
-  { key: 'stress', label: '스트레스' },
+  ...TELEMETRY_VIEW_CHIPS,
   { key: 'prometheus', label: '메트릭' },
   { key: 'verification', label: '형식검증' },
 ]

--- a/dashboard/src/components/telemetry-panel.test.ts
+++ b/dashboard/src/components/telemetry-panel.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  isTelemetryView,
+  TELEMETRY_VIEW_CHIPS,
+  type TelemetryView,
+} from './telemetry-panel'
+
+describe('isTelemetryView', () => {
+  it('returns true for each telemetry view key', () => {
+    expect(isTelemetryView('cost')).toBe(true)
+    expect(isTelemetryView('audit')).toBe(true)
+    expect(isTelemetryView('heuristics')).toBe(true)
+    expect(isTelemetryView('stress')).toBe(true)
+  })
+
+  it('returns false for primary runtime views', () => {
+    expect(isTelemetryView('default')).toBe(false)
+    expect(isTelemetryView('providers')).toBe(false)
+    expect(isTelemetryView('inspector')).toBe(false)
+  })
+
+  it('returns false for raw / verification advanced views', () => {
+    // prometheus and verification live next to telemetry on the Advanced
+    // chip strip but are NOT routed through TelemetryPanel.
+    expect(isTelemetryView('prometheus')).toBe(false)
+    expect(isTelemetryView('verification')).toBe(false)
+  })
+
+  it('returns false for unknown strings (closed-set guard)', () => {
+    expect(isTelemetryView('')).toBe(false)
+    expect(isTelemetryView('cost-extra')).toBe(false)
+    expect(isTelemetryView('audit ')).toBe(false)
+    expect(isTelemetryView('COST')).toBe(false)
+  })
+})
+
+describe('TELEMETRY_VIEW_CHIPS', () => {
+  it('exposes exactly the four telemetry view keys', () => {
+    const keys = TELEMETRY_VIEW_CHIPS.map(chip => chip.key)
+    expect(keys).toEqual(['cost', 'audit', 'heuristics', 'stress'])
+  })
+
+  it('every chip key passes isTelemetryView (round-trip consistency)', () => {
+    for (const chip of TELEMETRY_VIEW_CHIPS) {
+      expect(isTelemetryView(chip.key)).toBe(true)
+    }
+  })
+
+  it('every chip carries a non-empty Korean label', () => {
+    for (const chip of TELEMETRY_VIEW_CHIPS) {
+      expect(chip.label.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('TelemetryView type narrows out CostView keys that telemetry-panel does not render', () => {
+    // Pin the assignment direction: TelemetryView ⊆ chip key set,
+    // chip key set ⊆ TelemetryView. If CostView ever extends with a key
+    // that telemetry-panel should also render, this assignment will fail.
+    const allowed: TelemetryView[] = TELEMETRY_VIEW_CHIPS.map(chip => chip.key)
+    expect(allowed).toHaveLength(TELEMETRY_VIEW_CHIPS.length)
+  })
+})

--- a/dashboard/src/components/telemetry-panel.ts
+++ b/dashboard/src/components/telemetry-panel.ts
@@ -17,17 +17,30 @@
 import { html } from 'htm/preact'
 import { CostDashboard, type CostView } from './cost-dashboard'
 
-const TELEMETRY_VIEW_SET: ReadonlySet<CostView> = new Set<CostView>([
-  'cost',
-  'audit',
-  'heuristics',
-  'stress',
-])
+// Telemetry-panel handles only the four "infra/billing/audit" subkeys of
+// CostView (CostView itself includes `decisions`, which this panel does
+// NOT render). Extract narrows the closed set so callers spreading
+// TELEMETRY_VIEW_CHIPS into RuntimeView-typed strips stay sound.
+export type TelemetryView = Extract<CostView, 'cost' | 'audit' | 'heuristics' | 'stress'>
 
-export function isTelemetryView(view: string): view is CostView {
-  return TELEMETRY_VIEW_SET.has(view as CostView)
+// Single SSOT for the four telemetry chip definitions. Host components
+// import this list to render the Advanced chip strip — the labels live
+// next to the dispatch logic instead of being duplicated in runtime-panel.
+export const TELEMETRY_VIEW_CHIPS: ReadonlyArray<{ key: TelemetryView; label: string }> = [
+  { key: 'cost', label: '비용 / 지연' },
+  { key: 'audit', label: '감사' },
+  { key: 'heuristics', label: '휴리스틱' },
+  { key: 'stress', label: '스트레스' },
+]
+
+const TELEMETRY_VIEW_SET: ReadonlySet<TelemetryView> = new Set<TelemetryView>(
+  TELEMETRY_VIEW_CHIPS.map(chip => chip.key),
+)
+
+export function isTelemetryView(view: string): view is TelemetryView {
+  return TELEMETRY_VIEW_SET.has(view as TelemetryView)
 }
 
-export function TelemetryPanel({ view }: { view: CostView }) {
+export function TelemetryPanel({ view }: { view: TelemetryView }) {
   return html`<${CostDashboard} view=${view} />`
 }


### PR DESCRIPTION
## Goal
#17044(telemetry view dispatch 추출) + #17014(chip Primary/Advanced 분리)의 자연 후속. 4 telemetry chip 정의(cost/audit/heuristics/stress)를 runtime-panel.ts에서 telemetry-panel.ts로 *ownership* 이동. 동작 변화 0.

## Changed files
- `dashboard/src/components/telemetry-panel.ts` (+13 LoC) — `TELEMETRY_VIEW_CHIPS` 추가, `TelemetryView` extract type 도입, `isTelemetryView`/`TelemetryPanel` signature 좁힘
- `dashboard/src/components/runtime-panel.ts` (~5 LoC) — ADVANCED_VIEW_CHIPS에서 4 chip literal을 `...TELEMETRY_VIEW_CHIPS` spread로 대체
- 신규 `dashboard/src/components/telemetry-panel.test.ts` (~60 LoC, 8 case) — #17044 squash race로 누락된 테스트 복원 + TELEMETRY_VIEW_CHIPS 라운드-트립 잠금

## Self-review
- 목표: chip 라벨 owning location을 dispatch logic과 일치시킴. 이전: runtime-panel이 4개 chip literal 보유 + telemetry-panel이 dispatch / 이후: telemetry-panel이 둘 다.
- 범위: 3 파일. 92+/18-.
- 동작 변화: **0**. 같은 chip 4개, 같은 라벨, 같은 strip 레이아웃, 같은 URL hash, 같은 cockpit alias
- TypeScript narrowing: `CostView`는 `'decisions'` 포함 → ADVANCED_VIEW_CHIPS(key: RuntimeView)에 spread 시 RuntimeView 불일치 → `TelemetryView = Extract<CostView, 4 keys>`로 좁힘 → typecheck pass
- 로컬 검증:
  - `pnpm run typecheck` — **0 errors** (origin/main도 0이라 baseline clean)
  - `pnpm vitest run src/components/telemetry-panel src/components/runtime-panel` — **17/17** (telemetry 8 + runtime 9)

## Test 복원 배경
#17044 머지 시 squash race로 2번째 commit(`5c89550460` test) 누락 — push 23:26:51 / merge commit 23:26:54 = 3초 차. 본 PR의 telemetry-panel.test.ts는 같은 내용 + TELEMETRY_VIEW_CHIPS 라운드-트립 4 case 추가.

## References
- 형제 PR (모두 머지됨): #17014 (chip 그룹화), #17025 (cost-store SSOT lift), #17044 (telemetry-panel 추출), #17045 (credential-settings 1-line fix), #17029 (agent-roster paused fix)
- Monitor IA 리뷰: `/Users/dancer/me/memory/masc-oas-dashboard-monitor-ia-report-2026-05-20.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)