### PR TITLE
fix(keeper): enforce cascade tier admission

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -75,6 +75,8 @@ type state = Cascade_catalog_runtime_cache.state =
 type secondary_resolution =
   Cascade_catalog_runtime_named_providers.secondary_resolution = {
   providers : Llm_provider.Provider_config.t list;
+  tiered_providers :
+    Cascade_catalog_runtime_named_providers.tiered_provider list;
   secondary_resolver :
     int ->
     Llm_provider.Provider_config.t ->

--- a/lib/cascade/cascade_catalog_runtime.mli
+++ b/lib/cascade/cascade_catalog_runtime.mli
@@ -134,13 +134,15 @@ val resolve_named_providers_strict :
 
 type secondary_resolution = {
   providers : Llm_provider.Provider_config.t list;
+  tiered_providers : Cascade_catalog_runtime_named_providers.tiered_provider list;
   secondary_resolver :
     int -> Llm_provider.Provider_config.t ->
     Llm_provider.Provider_config.t option;
 }
-(** Providers resolved from a named cascade plus an index-aware secondary
-    lookup derived from the same ordered entries. The resolver is pure
-    over this snapshot and does not re-read or re-rotate catalog state. *)
+(** Providers resolved from a named cascade plus their admission tier
+    identities and an index-aware secondary lookup derived from the same
+    ordered entries. The resolver is pure over this snapshot and does
+    not re-read or re-rotate catalog state. *)
 
 val resolve_named_providers_strict_with_secondary_resolver :
   ?sw:Eio.Switch.t ->

--- a/lib/cascade/cascade_catalog_runtime_named_providers.ml
+++ b/lib/cascade/cascade_catalog_runtime_named_providers.ml
@@ -18,12 +18,17 @@ let candidate_key_of_cfg (cfg : Llm_provider.Provider_config.t) =
       cfg.headers,
       cfg.supports_tool_choice_override )
 
+type tiered_provider = {
+  provider_cfg : Llm_provider.Provider_config.t;
+  tier_id : string;
+}
+
 let direct_candidate_providers (profile : profile_snapshot) =
   List.map
     (fun (candidate : candidate_runtime) -> candidate.provider_cfg)
     profile.candidates
 
-let direct_candidate_providers_ordered_by_entries
+let direct_candidates_ordered_by_entries
     (profile : profile_snapshot)
     (ordered_entries : Cascade_config_loader.weighted_entry list) =
   match profile.candidates with
@@ -52,7 +57,7 @@ let direct_candidate_providers_ordered_by_entries
         match Hashtbl.find_opt index model_string with
         | Some q when not (Queue.is_empty q) ->
             let candidate = Queue.pop q in
-            Some candidate.provider_cfg
+            Some candidate
         | _ -> None
       in
       let ordered =
@@ -62,7 +67,31 @@ let direct_candidate_providers_ordered_by_entries
           ordered_entries
       in
       if List.length ordered = List.length candidates then ordered
-      else direct_candidate_providers profile
+      else profile.candidates
+
+let direct_candidate_providers_ordered_by_entries
+    (profile : profile_snapshot)
+    (ordered_entries : Cascade_config_loader.weighted_entry list) =
+  direct_candidates_ordered_by_entries profile ordered_entries
+  |> List.map (fun (candidate : candidate_runtime) -> candidate.provider_cfg)
+
+let tier_id_for_candidate (profile : profile_snapshot) _candidate =
+  profile.name
+
+let tiered_provider_of_candidate
+    profile
+    (candidate : candidate_runtime)
+    : tiered_provider =
+  {
+    provider_cfg = candidate.provider_cfg;
+    tier_id = tier_id_for_candidate profile candidate;
+  }
+
+let tiered_providers_of_ordered_entries ~(profile : profile_snapshot)
+    ~cascade_name:_
+    (ordered_entries : Cascade_config_loader.weighted_entry list) =
+  direct_candidates_ordered_by_entries profile ordered_entries
+  |> List.map (tiered_provider_of_candidate profile)
 
 let provider_configs_of_ordered_entries ~(profile : profile_snapshot)
     ~cascade_name:_
@@ -186,6 +215,7 @@ let resolve_named_providers_strict ?sw ?net ?clock ?provider_filter
 
 type secondary_resolution = {
   providers : Llm_provider.Provider_config.t list;
+  tiered_providers : tiered_provider list;
   secondary_resolver :
     int ->
     Llm_provider.Provider_config.t ->
@@ -224,13 +254,17 @@ let resolve_named_providers_strict_with_secondary_resolver ?sw ?net ?clock
       in
       let parsed_pairs =
         let direct_pairs =
-          direct_candidate_providers_ordered_by_entries profile
-            ordered_entries
-          |> List.map (fun cfg -> (cfg, None))
+          tiered_providers_of_ordered_entries ~profile
+            ~cascade_name:normalized ordered_entries
+          |> List.map (fun tiered -> (tiered, None))
         in
         direct_pairs
       in
-      let primaries = List.map fst parsed_pairs in
+      let primaries =
+        List.map
+          (fun (tiered, _) -> tiered.provider_cfg)
+          parsed_pairs
+      in
       (match
          Cascade_config.apply_provider_filter_strict ~provider_filter
            ~label:normalized primaries
@@ -247,7 +281,7 @@ let resolve_named_providers_strict_with_secondary_resolver ?sw ?net ?clock
          let filtered_pairs =
            parsed_pairs
            |> List.filter (fun (primary, _) ->
-                  provider_filter_allows primary)
+                  provider_filter_allows primary.provider_cfg)
            |> List.map (fun (primary, secondary) ->
                   let secondary =
                     match secondary with
@@ -256,7 +290,12 @@ let resolve_named_providers_strict_with_secondary_resolver ?sw ?net ?clock
                   in
                   (primary, secondary))
          in
-         let providers = List.map fst filtered_pairs in
+         let tiered_providers = List.map fst filtered_pairs in
+         let providers =
+           List.map
+             (fun tiered -> tiered.provider_cfg)
+             tiered_providers
+         in
          if providers = [] then (
            Cascade_metrics.on_resolve_failure ~cascade:normalized
              ~reason:"no_callable_providers";
@@ -273,12 +312,12 @@ let resolve_named_providers_strict_with_secondary_resolver ?sw ?net ?clock
              else
                let indexed_primary, secondary = slots.(provider_index) in
                if
-                 candidate_key_of_cfg indexed_primary
+                 candidate_key_of_cfg indexed_primary.provider_cfg
                  = candidate_key_of_cfg primary
                then secondary
                else None
            in
-           Ok { providers; secondary_resolver })
+           Ok { providers; tiered_providers; secondary_resolver })
 
 (* Deprecated compatibility hook for RFC-0027 PR-9b dual-track resolution.
    Declarative cascade execution now carries typed [Provider_config]

--- a/lib/cascade/cascade_catalog_runtime_named_providers.mli
+++ b/lib/cascade/cascade_catalog_runtime_named_providers.mli
@@ -24,8 +24,14 @@ val resolve_named_providers_strict :
   unit ->
   (Llm_provider.Provider_config.t list, string) result
 
+type tiered_provider = {
+  provider_cfg : Llm_provider.Provider_config.t;
+  tier_id : string;
+}
+
 type secondary_resolution = {
   providers : Llm_provider.Provider_config.t list;
+  tiered_providers : tiered_provider list;
   secondary_resolver :
     int ->
     Llm_provider.Provider_config.t ->

--- a/lib/cascade/cascade_runtime_candidate.ml
+++ b/lib/cascade/cascade_runtime_candidate.ml
@@ -1,5 +1,6 @@
 type t =
   { provider_cfg : Llm_provider.Provider_config.t
+  ; tier_id : string
   ; health_key : string
   ; model_health_key : string
   ; capacity_key : string
@@ -161,17 +162,23 @@ let capacity_key_of_config (cfg : Llm_provider.Provider_config.t) =
 let http_probe_url_of_config (cfg : Llm_provider.Provider_config.t) =
   Cascade_http_probe_url.of_provider_config cfg
 
-let of_provider_config provider_cfg =
+let default_tier_id_of_config provider_cfg =
+  provider_health_key_of_config provider_cfg
+
+let of_provider_config ?tier_id provider_cfg =
   let health_key = provider_health_key_of_config provider_cfg in
   let model_health_key = provider_model_health_key_of_config provider_cfg in
+  let tier_id = Option.value tier_id ~default:(default_tier_id_of_config provider_cfg) in
   { provider_cfg
+  ; tier_id
   ; health_key
   ; model_health_key
   ; capacity_key = capacity_key_of_config provider_cfg
   ; http_probe_url = http_probe_url_of_config provider_cfg
   }
 
-let of_provider_configs provider_cfgs = List.map of_provider_config provider_cfgs
+let of_provider_configs provider_cfgs =
+  List.map (fun provider_cfg -> of_provider_config provider_cfg) provider_cfgs
 
 let runtime_url_of_label label =
   match Provider_kind_resolver.resolve label with
@@ -303,6 +310,7 @@ let threshold_multipliers_of_runtime_id runtime_id =
   1.0, 1.0
 
 let health_key candidate = candidate.health_key
+let tier_id candidate = candidate.tier_id
 let model_health_key candidate = candidate.model_health_key
 let provider_label candidate =
   provider_label_of_model_label

--- a/lib/cascade/cascade_runtime_candidate.mli
+++ b/lib/cascade/cascade_runtime_candidate.mli
@@ -12,7 +12,7 @@ type context_window_hint =
   ; is_local_model : bool
   }
 
-val of_provider_config : Llm_provider.Provider_config.t -> t
+val of_provider_config : ?tier_id:string -> Llm_provider.Provider_config.t -> t
 val of_provider_configs : Llm_provider.Provider_config.t list -> t list
 
 val runtime_url_of_label : string -> string option
@@ -44,6 +44,7 @@ val context_window_hint_of_labels : string list -> context_window_hint
 val threshold_multipliers_of_runtime_id : string -> float * float
 
 val health_key : t -> string
+val tier_id : t -> string
 val model_health_key : t -> string
 val health_keys : t -> string list
 val provider_label : t -> string

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -842,6 +842,18 @@ module CascadeSaturationSignal = struct
     get_bool ~default:false "MASC_CASCADE_SATURATION_SIGNAL_ENABLED"
 end
 
+(** {1 Cascade Tier Admission (RFC-0153 Phase B.2)}
+
+    Runtime kill switch for per-tier inflight admission in the main keeper
+    cascade path. Default on: RFC-0153 Phase B.2 is intended to prevent
+    keeper stampedes before provider dispatch. Operators can set the flag
+    false as an emergency rollback without also disabling the additive Phase
+    A.2 saturation-signal metric. *)
+module CascadeTierAdmission = struct
+  let enabled () =
+    Feature_flag_registry.get_bool "MASC_CASCADE_TIER_ADMISSION_ENABLED"
+end
+
 (** {1 Cascade Runtime Overrides}
 
     Runtime-only narrowing of the MASC cascade provider set. The underlying

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -311,6 +311,18 @@ module CascadeSaturationSignal : sig
       string label, or control-flow path. *)
 end
 
+(** {1 Cascade Tier Admission (RFC-0153 Phase B.2)} *)
+
+module CascadeTierAdmission : sig
+  val enabled : unit -> bool
+  (** [MASC_CASCADE_TIER_ADMISSION_ENABLED] flag. Default true.
+
+      When true, the main keeper cascade path enforces per-tier inflight
+      admission before provider dispatch. Set false only as an emergency
+      rollback; it is intentionally independent from Phase A.2 metric
+      emission. *)
+end
+
 (** {1 Cascade runtime overrides} *)
 
 module KeeperCascade : sig

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -105,6 +105,11 @@ let all_flags : flag list = [
     default = true; category = "keeper";
     lifecycle = Active; since = "2.163.0" };
 
+  { env_name = "MASC_CASCADE_TIER_ADMISSION_ENABLED";
+    description = "Enforce per-tier cascade inflight admission before provider dispatch";
+    default = true; category = "keeper";
+    lifecycle = Active; since = "2.243.0" };
+
   { env_name = "MASC_KEEPER_ALERT_ENABLED";
     description = "Master switch for keeper interesting alert detection";
     default = true; category = "keeper";

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -38,7 +38,7 @@ let cascade_tier_admission_policy_of_priority priority =
 
 let with_keeper_cascade_tier_admission
     ?(admission = keeper_cascade_tier_admission)
-    ?(enabled = Env_config_keeper.CascadeSaturationSignal.enabled ())
+    ?(enabled = Env_config_keeper.CascadeTierAdmission.enabled ())
     ~tier_id
     ~admission_policy
     f =
@@ -74,6 +74,41 @@ let release_client_capacity_quietly = function
       (match release () with
        | () -> ()
        | exception _ -> ())
+
+let provider_config_identity_key (cfg : Llm_provider.Provider_config.t) =
+  Hashtbl.hash
+    ( Llm_provider.Provider_config.string_of_provider_kind cfg.kind,
+      cfg.model_id,
+      cfg.base_url,
+      cfg.request_path,
+      cfg.api_key,
+      cfg.headers,
+      cfg.supports_tool_choice_override )
+
+let runtime_candidates_of_tiered_providers tiered_providers provider_cfgs =
+  let tier_index = Hashtbl.create (List.length tiered_providers) in
+  List.iter
+    (fun (tiered : Cascade_catalog_runtime_named_providers.tiered_provider) ->
+       let key = provider_config_identity_key tiered.provider_cfg in
+       let queue =
+         match Hashtbl.find_opt tier_index key with
+         | Some queue -> queue
+         | None ->
+           let queue = Queue.create () in
+           Hashtbl.add tier_index key queue;
+           queue
+       in
+       Queue.add tiered.tier_id queue)
+    tiered_providers;
+  List.map
+    (fun provider_cfg ->
+       let tier_id =
+         match Hashtbl.find_opt tier_index (provider_config_identity_key provider_cfg) with
+         | Some queue when not (Queue.is_empty queue) -> Some (Queue.pop queue)
+         | _ -> None
+       in
+        Cascade_runtime_candidate.of_provider_config ?tier_id provider_cfg)
+    provider_cfgs
 
 (* ================================================================ *)
 (* Facade-only: run_named, run_model_by_label, and MASC tool bridges  *)
@@ -172,7 +207,10 @@ let run_named
     || keeper_internal_tools_require_materialized_runtime_surface
          ~keeper_name tools
   in
-  let configured_labels_result, candidate_cfgs_result, secondary_resolver =
+  let ( configured_labels_result,
+        candidate_cfgs_result,
+        tiered_providers_result,
+        secondary_resolver ) =
     let named_resolution =
       Cascade_catalog_runtime
       .resolve_named_providers_strict_with_secondary_resolver
@@ -183,6 +221,11 @@ let run_named
       | Ok resolution -> Ok resolution.providers
       | Error detail -> Error detail
     in
+    let tiered_providers_result =
+      match named_resolution with
+      | Ok resolution -> Ok resolution.tiered_providers
+      | Error detail -> Error detail
+    in
     let secondary_resolver =
       match named_resolution with
       | Ok resolution -> Some resolution.secondary_resolver
@@ -190,16 +233,17 @@ let run_named
     in
     ( Cascade_runtime.models_of_cascade_name_result runtime_cascade_name,
       candidate_cfgs_result,
+      tiered_providers_result,
       secondary_resolver )
   in
-  (match configured_labels_result, candidate_cfgs_result with
-   | Error detail, _ | _, Error detail ->
+  (match configured_labels_result, candidate_cfgs_result, tiered_providers_result with
+   | Error detail, _, _ | _, Error detail, _ | _, _, Error detail ->
        Log.Misc.error "cascade %s: %s" cascade_name detail;
        Error (cascade_catalog_error_to_sdk_error detail)
-   | Ok configured_labels, Ok candidate_cfgs ->
+   | Ok configured_labels, Ok candidate_cfgs, Ok tiered_providers ->
   let original_candidate_cfgs = candidate_cfgs in
   let original_candidates =
-    Cascade_runtime_candidate.of_provider_configs original_candidate_cfgs
+    runtime_candidates_of_tiered_providers tiered_providers original_candidate_cfgs
   in
   let tool_filtered_candidate_cfgs =
     filter_candidate_providers_for_tool_support
@@ -216,7 +260,7 @@ let run_named
   let original_candidate_count = List.length original_candidate_cfgs in
   let tool_filtered_candidate_count = List.length tool_filtered_candidate_cfgs in
   let tool_filtered_candidates =
-    Cascade_runtime_candidate.of_provider_configs tool_filtered_candidate_cfgs
+    runtime_candidates_of_tiered_providers tiered_providers tool_filtered_candidate_cfgs
   in
   let health_filtered_candidates =
     tool_filtered_candidates
@@ -561,7 +605,6 @@ let run_named
   let tier_admission_policy =
     cascade_tier_admission_policy_of_priority queue_priority
   in
-  let tier_admission_id = cascade_name in
   (* MASC-driven cascade FSM: try each provider, decide on failure.
      Extracted to [Keeper_turn_driver_try_provider.run_try_provider] via
      explicit [try_provider_ctx] record (RFC-0051 PR-3a). *)
@@ -929,6 +972,7 @@ let run_named
         terminal_error
     | candidate :: rest ->
       Eio_guard.fair_yield (); (* P0: keep fast-fail cascades scheduler-fair. *)
+      let tier_admission_id = Cascade_runtime_candidate.tier_id candidate in
       let health_cooldown =
         Cascade_runtime_candidate.first_health_cooldown candidate
       in
@@ -1035,7 +1079,8 @@ let run_named
         with_keeper_cascade_tier_admission
           ~tier_id:tier_admission_id
           ~admission_policy:tier_admission_policy
-          (fun () -> Eio.Switch.run (fun provider_attempt_sw ->
+          (fun () ->
+             Eio.Switch.run (fun provider_attempt_sw ->
           Option.iter
             (fun release -> Eio.Switch.on_release provider_attempt_sw release)
             capacity_release;

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -1006,8 +1006,6 @@ type full_health_snapshot = {
   stale_since_ts : float option;
 }
 
-let full_health_snapshot_ttl_sec = 2.0
-
 let full_health_snapshot_mu = Stdlib.Mutex.create ()
 let full_health_snapshot = ref None
 let full_health_refresh_in_flight = ref false
@@ -1030,6 +1028,10 @@ let full_health_critical_failure_threshold =
 
 let full_health_refresh_interval_sec =
   Float.max 30.0 (full_health_refresh_timeout_sec +. 5.0)
+;;
+
+let full_health_snapshot_ttl_sec =
+  Float.max 60.0 (full_health_refresh_interval_sec *. 2.0)
 ;;
 
 let with_full_health_snapshot_lock f =
@@ -1373,7 +1375,9 @@ module For_testing = struct
   let mark_full_health_snapshot_error = mark_full_health_snapshot_error
 
   let full_health_refresh_timing () =
-    (full_health_refresh_interval_sec, full_health_refresh_timeout_sec)
+    ( full_health_refresh_interval_sec,
+      full_health_refresh_timeout_sec,
+      full_health_snapshot_ttl_sec )
 end
 
 let full_health_requested request =

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -222,8 +222,8 @@ module For_testing : sig
   val mark_full_health_snapshot_error : exn -> unit
   (** Records a failed background refresh without recomputing the snapshot. *)
 
-  val full_health_refresh_timing : unit -> float * float
-  (** Returns [(interval_sec, timeout_sec)] for the full-health refresh loop. *)
+  val full_health_refresh_timing : unit -> float * float * float
+  (** Returns [(interval_sec, timeout_sec, ttl_sec)] for full-health refresh. *)
 end
 
 val keeper_fleet_runtime_resolution_fields : unit -> (string * Yojson.Safe.t) list

--- a/test/test_cascade_declarative_hotpath.ml
+++ b/test/test_cascade_declarative_hotpath.ml
@@ -495,6 +495,51 @@ target = "tier-group.glm-coding-with-spark"
          "expected one provider config, got %d"
          (List.length cfgs))
 
+let test_runtime_resolution_preserves_tier_id () =
+  let toml =
+    {|
+[providers.ollama_cloud]
+protocol = "ollama-http"
+endpoint = "https://ollama.com"
+
+[providers.ollama_cloud.credentials]
+type = "env"
+key = "OLLAMA_CLOUD_API_KEY"
+
+[models.ollama-cloud-default]
+api-name = "glm-5.1"
+max-context = 128000
+tools-support = true
+streaming = true
+
+[ollama_cloud.ollama-cloud-default]
+
+[tier.ollama_cloud_primary]
+members = ["ollama_cloud.ollama-cloud-default"]
+strategy = "failover"
+
+[tier-group.glm-coding-with-spark]
+tiers = ["ollama_cloud_primary"]
+strategy = "failover"
+fallback = false
+|}
+  in
+  with_env "OLLAMA_CLOUD_API_KEY" "test-token" @@ fun () ->
+  with_temp_cascade_config toml @@ fun () ->
+  match
+    Masc_mcp.Cascade_catalog_runtime.resolve_named_providers_strict_with_secondary_resolver
+      ~cascade_name:"tier-group.glm-coding-with-spark"
+      ()
+  with
+  | Error err -> fail err
+  | Ok { tiered_providers = [ tiered ]; _ } ->
+    check string "tier id" "tier-group.glm-coding-with-spark" tiered.tier_id
+  | Ok resolution ->
+    fail
+      (Printf.sprintf
+         "expected one tiered provider, got %d"
+         (List.length resolution.tiered_providers))
+
 (* --- RFC-0058 Phase 8: partial parse --- *)
 
 (* Reproduces the 2026-05-17 keeper-skip incident: a stale [<ghost>.<m>]
@@ -780,6 +825,10 @@ let () =
           "runtime resolution uses direct declarative Provider_config"
           `Quick
           test_runtime_resolution_uses_direct_declarative_provider_config;
+        test_case
+          "runtime resolution preserves admission tier id"
+          `Quick
+          test_runtime_resolution_preserves_tier_id;
       ];
       "phase8_partial_parse",
       [

--- a/test/test_cascade_tier_admission.ml
+++ b/test/test_cascade_tier_admission.ml
@@ -199,6 +199,14 @@ let test_keeper_policy_proactive_required () =
   | A.Required -> ()
   | A.Bypass -> Alcotest.fail "proactive keeper turns must require admission"
 
+let test_keeper_policy_interactive_required () =
+  match
+    KTD.cascade_tier_admission_policy_of_priority
+      Llm_provider.Request_priority.Interactive
+  with
+  | A.Required -> ()
+  | A.Bypass -> Alcotest.fail "interactive keeper turns must require admission"
+
 let test_keeper_policy_background_bypass () =
   match
     KTD.cascade_tier_admission_policy_of_priority
@@ -235,7 +243,7 @@ let test_keeper_wire_enabled_rejects_at_capacity () =
 let test_keeper_wire_disabled_is_passthrough () =
   let t = A.create ~default_max_inflight:0 () in
   let ran = ref false in
-  let outcome =
+  let admission_result =
     KTD.with_cascade_tier_admission_for_testing
       ~admission:t
       ~enabled:false
@@ -246,13 +254,17 @@ let test_keeper_wire_disabled_is_passthrough () =
          "ok")
   in
   bool_check "attempt ran when flag disabled" true !ran;
-  check (result string signal_testable) "disabled flag passthrough" (Ok "ok") outcome;
+  check
+    (result string signal_testable)
+    "disabled flag passthrough"
+    (Ok "ok")
+    admission_result;
   int_check "disabled path did not touch counter" 0
     (A.current_inflight t ~tier_id:"keeper-turn")
 
 let test_keeper_wire_bypass_policy_is_passthrough () =
   let t = A.create ~default_max_inflight:0 () in
-  let outcome =
+  let admission_result =
     KTD.with_cascade_tier_admission_for_testing
       ~admission:t
       ~enabled:true
@@ -260,7 +272,11 @@ let test_keeper_wire_bypass_policy_is_passthrough () =
       ~admission_policy:A.Bypass
       (fun () -> 7)
   in
-  check (result int signal_testable) "bypass policy passthrough" (Ok 7) outcome;
+  check
+    (result int signal_testable)
+    "bypass policy passthrough"
+    (Ok 7)
+    admission_result;
   int_check "bypass path did not touch counter" 0
     (A.current_inflight t ~tier_id:"keeper-turn")
 
@@ -299,6 +315,8 @@ let suite =
     ( "keeper-wire",
       [ test_case "proactive maps to Required" `Quick
           test_keeper_policy_proactive_required;
+        test_case "interactive maps to Required" `Quick
+          test_keeper_policy_interactive_required;
         test_case "background maps to Bypass" `Quick
           test_keeper_policy_background_bypass;
         test_case "enabled path rejects at capacity" `Quick

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1362,7 +1362,7 @@ let test_health_response_full_query_uses_snapshot_cache () =
      | _ -> false)
 
 let test_full_health_refresh_timeout_is_independent_from_shell_budget () =
-  let interval_sec, timeout_sec =
+  let interval_sec, timeout_sec, ttl_sec =
     Server_routes_http_runtime.For_testing.full_health_refresh_timing ()
   in
   Alcotest.(check (float 0.001)) "full health timeout uses dedicated budget"
@@ -1371,7 +1371,9 @@ let test_full_health_refresh_timeout_is_independent_from_shell_budget () =
   Alcotest.(check bool) "full health timeout is below shell full budget" true
     (timeout_sec < Env_config_runtime.Dashboard.shell_timeout_sec);
   Alcotest.(check bool) "full health interval exceeds timeout" true
-    (interval_sec > timeout_sec)
+    (interval_sec > timeout_sec);
+  Alcotest.(check bool) "snapshot ttl covers refresh interval" true
+    (ttl_sec >= interval_sec *. 2.0)
 
 let test_full_health_refresh_timeout_preserves_last_snapshot () =
   Server_routes_http_runtime.For_testing.reset_full_health_snapshot ();


### PR DESCRIPTION
## Summary

- preserve cascade tier identity through runtime provider resolution and keeper dispatch
- add default-on `MASC_CASCADE_TIER_ADMISSION_ENABLED` and gate provider attempts with per-tier admission
- harden full health snapshot TTL so cached full health survives between background refreshes
- add regression coverage for tier-id preservation, keeper admission policy, and full-health cache timing

## Verification

- `git diff --check main..HEAD`
- `ocamlformat --check lib/cascade/cascade_catalog_runtime.ml lib/cascade/cascade_catalog_runtime.mli lib/cascade/cascade_catalog_runtime_named_providers.ml lib/cascade/cascade_catalog_runtime_named_providers.mli lib/cascade/cascade_runtime_candidate.ml lib/cascade/cascade_runtime_candidate.mli lib/config/env_config_keeper.ml lib/config/env_config_keeper.mli lib/config/feature_flag_registry.ml lib/keeper/keeper_turn_driver.ml lib/keeper/keeper_turn_driver.mli lib/server/server_routes_http_runtime.ml lib/server/server_routes_http_runtime.mli test/test_cascade_declarative_hotpath.ml test/test_cascade_tier_admission.ml test/test_server_runtime_bootstrap.ml`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_cascade_tier_admission.exe test/test_server_runtime_bootstrap.exe test/test_cascade_declarative_hotpath.exe`
- `./_build/default/test/test_cascade_tier_admission.exe`
- `./_build/default/test/test_cascade_declarative_hotpath.exe`
- `./_build/default/test/test_server_runtime_bootstrap.exe test --show-errors bootstrap 39-42`

## Notes

- The full bootstrap suite has a pre-existing unrelated failure in `bootstrap 23 blocking bootstrap promotes legacy keepers`; tracked separately as #17040.