### PR TITLE
docs(dashboard): refresh stale runtime-panel header after telemetry split

### DIFF
--- a/dashboard/src/components/runtime-panel.ts
+++ b/dashboard/src/components/runtime-panel.ts
@@ -1,6 +1,7 @@
-// RuntimePanel — Phase 4 runtime section with FilterChips toggle.
-// Wraps OasHealthChip, RuntimeMonitor, PrometheusMetrics,
-// VerificationSpecsPanel with view switching.
+// RuntimePanel — Monitor "Cascade & Runtime" lane.
+// Renders OasHealthChip / RuntimeMonitor / PrometheusMetrics /
+// VerificationSpecsPanel / CascadeInspector inline, and delegates the four
+// telemetry views to TelemetryPanel (cost / audit / heuristics / stress).
 //
 // Progressive-disclosure default view (density reduction, 2026-04):
 //   Signal layer     — OasHealthChip always expanded (summary StatCells)
@@ -8,14 +9,17 @@
 //   Raw layer        — Prometheus metrics, Formal specs via CollapsibleSection (closed)
 // NN/g progressive disclosure: respect working-memory limits, defer detail.
 //
-// Explicit drill-down via FilterChips remains unchanged:
+// Explicit drill-down via FilterChips, split into two strips (PR #17014):
+//   Primary strip   — default · providers · inspector
+//   Advanced strip  — cost · audit · heuristics · stress · prometheus · verification
+//                     (the first four are spread from TELEMETRY_VIEW_CHIPS,
+//                      owned by telemetry-panel.ts; PR #17044 / #17052)
+//
+// Per-view dispatch:
 //   default      — Signal strip + collapsed diagnostic/raw accordions
 //   providers    — OAS health chip + runtime monitor only
-//   cost         — model/keeper cost and latency only
-//   audit        — dashboard audit ledger
-//   heuristics   — heuristic firing log + coverage by module
-//   stress       — agent stress events
-//   inspector    — cascade strategy trace/provider health drill-down
+//   inspector    — cascade strategy trace / provider health drill-down
+//   cost / audit / heuristics / stress — TelemetryPanel → CostDashboard
 //   prometheus   — raw Prometheus metrics only
 //   verification — formal specs only
 // Pattern: mirrors fleet-health-panel.ts (unidirectional flow via URL).


### PR DESCRIPTION
## Goal
`dashboard/src/components/runtime-panel.ts` 헤더 주석이 다중 refactor(#17014 + #17044 + #17052) 이후 stale. 주석만 갱신, 코드 무변경.

## Changed files
- `dashboard/src/components/runtime-panel.ts` — 13+/9-, 헤더 주석 22 라인 → 25 라인

## Stale 항목 정정
1. "Wraps OasHealthChip, RuntimeMonitor, PrometheusMetrics, VerificationSpecsPanel" → TelemetryPanel + CascadeInspector 누락 추가
2. "FilterChips remains unchanged" → **거짓**, PR #17014에서 Primary/Advanced 두 strip으로 분리됨
3. Per-view dispatch 목록: cost/audit/heuristics/stress가 inline branch라고 적혀 있지만 TelemetryPanel 위임으로 변경됨 (#17044/#17052)

## Self-review
- 목표: 헤더 주석을 현재 코드 상태로 정정. 사실 오류 제거 + 관련 PR 번호 인용
- 범위: 1 파일, 주석 전용
- 동작 변화: **0**. TypeScript 컴파일에 0 영향
- Progressive-disclosure 섹션은 유지(default view 동작은 그대로)

## References
- #17014 chip 그룹화 (MERGED)
- #17044 TelemetryPanel 추출 (MERGED)
- #17052 TELEMETRY_VIEW_CHIPS ownership (MERGED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)