### PR TITLE
fix(test): repair full-health timeout assertion

### DIFF
--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1365,7 +1365,7 @@ let test_full_health_refresh_timeout_is_independent_from_shell_budget () =
   let interval_sec, timeout_sec =
     Server_routes_http_runtime.For_testing.full_health_refresh_timing ()
   in
-  Alcotest.(check float 0.001) "full health timeout uses dedicated budget"
+  Alcotest.(check (float 0.001)) "full health timeout uses dedicated budget"
     Env_config_runtime.Dashboard.full_health_refresh_timeout_sec
     timeout_sec;
   Alcotest.(check bool) "full health timeout is below shell full budget" true


### PR DESCRIPTION
## Summary

- Fix the Alcotest float assertion introduced by the full-health refresh timeout independence test.

## Product impact

Repairs the focused test target after #17047 merged the timeout decoupling change. This is a one-line compile fix for the test assertion, not a behavior change.

## Evidence

- `ocamlformat --check test/test_server_runtime_bootstrap.ml`
- `git diff --check`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_server_runtime_bootstrap.exe`

## Review evidence

- The change is limited to `Alcotest.(check (float 0.001))`, matching the expected testable-module form.

## Linked issue

- Follow-up to #17047.
- Related workflow blocker: #17017.
- Related Dune contention tracker: #17030.
