### PR TITLE
fix(rfc-0126): replace string-classifier with typed exhaustive match in cascade_tier_admission_policy_of_priority

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -22,13 +22,19 @@ include Keeper_turn_driver_provider_attempt
 let keeper_cascade_tier_admission = Cascade_tier_admission.create ()
 
 let cascade_tier_admission_policy_of_priority priority =
-  match
-    Llm_provider.Request_priority.resolve priority
-    |> Llm_provider.Request_priority.to_string
-    |> String.lowercase_ascii
-  with
-  | "background" -> Cascade_tier_admission.Bypass
-  | _ -> Cascade_tier_admission.Required
+  (* RFC-0126: exhaustive typed match over Llm_provider.Request_priority.t
+     instead of the previous string-classifier (`to_string |> match`) so that
+     future variants in the upstream agent_sdk surface as a compile error
+     here rather than silently routing through a permissive default.
+     Semantics: only [Background] (P2 heartbeat / status ticks) bypasses
+     tier admission per Cascade_tier_admission.mli side-task starvation
+     defence; main-path priorities all require admission.  [Unspecified]
+     is unreachable after [resolve] (it maps to [Proactive]) but the arm
+     keeps the match exhaustive without a catch-all. *)
+  match Llm_provider.Request_priority.resolve priority with
+  | Background -> Cascade_tier_admission.Bypass
+  | Resume | Interactive | Proactive | Unspecified ->
+      Cascade_tier_admission.Required
 
 let with_keeper_cascade_tier_admission
     ?(admission = keeper_cascade_tier_admission)


### PR DESCRIPTION
## 증상

\`scripts/lint/no-unknown-permissive-default.sh\` Lint job이 PR #17013 머지 이후 모든 PR에서 fail합니다.

\`\`\`
##[error]#8605 family: permissive default in string-parsing match
  (symbol=cascade_tier_admission_policy_of_priority):
  | _ -> Cascade_tier_admission.Required
\`\`\`

\`scripts/lint/no-unknown-permissive-default.allowlist\`는 의도적으로 비어있으며 (script header: "Allowlist now empty. Any new entry requires a justifying comment, and self-verify will force removal once the pattern is migrated"), 새 entry 추가는 워크어라운드 거부 기준 위배 (workspace memory \`feedback_lint_string_classifier_is_workaround_not_fundamental.md\` + RFC-0126 Phase 2 monotonic-shrink ratchet 정책).

## 원인

PR #17013 (\`feat(cascade): wire tier admission into keeper attempts\`) 가 \`lib/keeper/keeper_turn_driver.ml:24\`에 다음 함수를 추가:

\`\`\`ocaml
let cascade_tier_admission_policy_of_priority priority =
  match
    Llm_provider.Request_priority.resolve priority
    |> Llm_provider.Request_priority.to_string
    |> String.lowercase_ascii
  with
  | "background" -> Cascade_tier_admission.Bypass
  | _ -> Cascade_tier_admission.Required
\`\`\`

\`_ -> Required\` catch-all은 RFC-0126 §4.1 anti-pattern (wildcard fallback). \`Llm_provider.Request_priority\` 가 closed-sum (5 variants) 이라 typed exhaustive match가 가능한데도 string으로 flatten 후 매칭하는 string-classifier 패턴.

## 수정

\`Llm_provider.Request_priority.t\` variant 인벤토리 (agent_sdk \`request_priority.mli\`에서 추출):

| Variant | 의미 | admission_policy |
|---|---|---|
| \`Resume\` | P-1: yielded slot resume | Required (main path) |
| \`Interactive\` | P0: user-facing | Required (main path) |
| \`Proactive\` | P1: agent turns | Required (main path) |
| \`Background\` | P2: heartbeat/status | **Bypass** (side task) |
| \`Unspecified\` | default → resolved to Proactive | Required (unreachable after \`resolve\`, but kept exhaustive) |

\`Cascade_tier_admission.mli\` 의 starvation defence semantics (§6.8): \`Bypass\` 는 side task (probe / memory summary / watchdog) 전용. heartbeat/status (P2 Background) 만 side task에 해당하므로 기존 \`\"background\" -> Bypass\` 매핑과 의미 동일.

\`\`\`ocaml
match Llm_provider.Request_priority.resolve priority with
| Background -> Cascade_tier_admission.Bypass
| Resume | Interactive | Proactive | Unspecified ->
    Cascade_tier_admission.Required
\`\`\`

향후 agent_sdk에 새 variant가 추가되면 컴파일러가 *여기*에서 missing-arm 에러를 내므로 silent default routing 차단 — RFC-0126 Phase 2 typed boundary 정합.

## 검증

\`\`\`
$ dune build --root .
# clean, exit 0
$ scripts/lint/no-unknown-permissive-default.sh
Scanned 1344 .ml files.
No #8605 family violations found.
$ ocamlformat --check lib/keeper/keeper_turn_driver.ml
# clean
$ dune exec --root . test/test_cascade_tier_admission.exe
Test Successful in 0.002s. 18 tests run.
\`\`\`

특히 기존 테스트 케이스 \`keeper-wire/0 (proactive maps to Required)\` 와 \`keeper-wire/1 (background maps to Bypass)\` 가 *그대로* 통과 — semantic equivalence 검증.

## 범위

- 1 파일, +13/-7 LoC
- 의미 변화 없음 (Background → Bypass, 나머지 → Required 매핑 보존)
- RFC subsystem (credential/operator/sandbox/dashboard) 미접촉, RFC 발견 체크 불필요

## 후속 가능성

- agent_sdk \`Request_priority\` 변형이 *추가*되면 컴파일러가 강제로 fix를 요구합니다 — 새 variant가 main path인지 side task인지 명시 결정 필요. 이는 의도된 효과.
- 다른 string-classifier 패턴이 lint에 잡히면 동일한 typed exhaustive match 패턴 적용 권장.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>