### PR TITLE
fix(keeper): surface provider-blocked backlog

### DIFF
--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -194,6 +194,8 @@ let append_decision_record
               ("context_ratio", `Float observation.context_ratio);
               ("unclaimed_task_count", `Int observation.unclaimed_task_count);
               ("claimable_task_count", `Int observation.claimable_task_count);
+              ( "provider_capacity_blocked_task_count",
+                `Int observation.provider_capacity_blocked_task_count );
               ( "claim_blocked_task_count",
                 `Int
                   (max 0

--- a/lib/keeper/keeper_unified_metrics_support.ml
+++ b/lib/keeper/keeper_unified_metrics_support.ml
@@ -491,6 +491,8 @@ let observed_triggers_of_observation
   if observation.pending_scope_messages <> [] then add "scope_message";
   if observation.unclaimed_task_count > 0 then add "new_unclaimed_task";
   if observation.claimable_task_count > 0 then add "claimable_task";
+  if observation.provider_capacity_blocked_task_count > 0 then
+    add "provider_capacity_blocked_backlog";
   if observation.failed_task_count > 0 then add "failed_task";
   let _ = meta in
   if observation.pending_verification_count > 0 then
@@ -568,7 +570,13 @@ let observed_affordances_of_observation
     | Some meta -> work_discovery_allows_task_audit meta
     | None -> true
   in
-  if observation.claimable_task_count > 0 && source_allows_task_claim then
+  if observation.provider_capacity_blocked_task_count > 0 then
+    add "provider_capacity_blocked";
+  if
+    observation.claimable_task_count > 0
+    && observation.provider_capacity_blocked_task_count = 0
+    && source_allows_task_claim
+  then
     add "task_claim";
   if observation.failed_task_count > 0 && source_allows_task_audit then
     add "task_audit";

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -374,6 +374,7 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
   let claim_tool_available = tool_allowed "keeper_task_claim" in
   let show_claim_guidance =
     observation.claimable_task_count > 0
+    && observation.provider_capacity_blocked_task_count = 0
     && Keeper_unified_metrics.work_discovery_allows_task_claim meta
     && claim_tool_available
     && not meta.paused
@@ -452,6 +453,7 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
   if
     observation.unclaimed_task_count > 0
     || observation.claimable_task_count > 0
+    || observation.provider_capacity_blocked_task_count > 0
     || observation.failed_task_count > 0
     || observation.active_agent_count > 0
   then (
@@ -469,6 +471,21 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
     then
       Buffer.add_string ubuf
         "- Claimable tasks for this keeper: 0\n";
+    let keeper_or_scope_blocked =
+      max 0
+        (observation.unclaimed_task_count
+         - observation.claimable_task_count)
+    in
+    if keeper_or_scope_blocked > 0 then
+      Buffer.add_string ubuf
+        (Printf.sprintf
+           "- Blocked by keeper/tool/goal scope: %d\n"
+           keeper_or_scope_blocked);
+    if observation.provider_capacity_blocked_task_count > 0 then
+      Buffer.add_string ubuf
+        (Printf.sprintf
+           "- Provider-capacity blocked claimable tasks: %d\n"
+           observation.provider_capacity_blocked_task_count);
     if observation.failed_task_count > 0 then
       Buffer.add_string ubuf
         (Printf.sprintf "- Failed tasks: %d\n" observation.failed_task_count);

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -37,6 +37,7 @@ type world_observation =
   ; economic_pressure : Agent_economy.pressure_mode
   ; unclaimed_task_count : int
   ; claimable_task_count : int
+  ; provider_capacity_blocked_task_count : int
   ; failed_task_count : int
   ; pending_verification_count : int
   ; backlog_updated_since_last_scheduled_autonomous : bool
@@ -452,6 +453,87 @@ let collect_board_events_without_advancing_cursor
     ~meta
 ;;
 
+let fallback_cascade_for_provider_cooldown
+      ~(base_cascade : string)
+      ~(effective_cascade : string)
+  : string option
+  =
+  let normalized_base = Keeper_cascade_profile.normalize_declared_name base_cascade in
+  let normalized_effective =
+    Keeper_cascade_profile.normalize_declared_name effective_cascade
+  in
+  if not (String.equal normalized_effective normalized_base)
+  then Some normalized_base
+  else if
+    String.equal normalized_effective Keeper_config.local_only_cascade_name
+    || String.equal normalized_effective (Keeper_config.default_cascade_name ())
+  then None
+  else Some (Keeper_config.default_cascade_name ())
+;;
+
+let provider_cooldown_remaining_sec_for_cascade
+      ~(cascade_name : Keeper_cascade_profile.runtime_name)
+  : int option
+  =
+  let runtime_health_keys =
+    Cascade_runtime.models_of_cascade_name cascade_name
+    |> Cascade_runtime_candidate.runtime_health_keys_of_labels
+  in
+  match runtime_health_keys with
+  | [] -> None
+  | _ ->
+    let provider_infos =
+      List.map
+        (fun provider_key ->
+           Cascade_health_tracker.provider_info
+             Cascade_health_tracker.global
+             ~provider_key)
+        runtime_health_keys
+    in
+    if not (List.for_all Option.is_some provider_infos)
+    then None
+    else (
+      let provider_infos = List.filter_map Fun.id provider_infos in
+      if
+        not
+          (List.for_all
+             (fun info -> info.Cascade_health_tracker.in_cooldown)
+             provider_infos)
+      then None
+      else (
+        let now = Time_compat.now () in
+        provider_infos
+        |> List.filter_map (fun info -> info.Cascade_health_tracker.cooldown_expires_at)
+        |> List.map (fun expires_at ->
+          int_of_float (Float.max 0.0 (Float.ceil (expires_at -. now))))
+        |> function
+        | [] -> Some 0
+        | first :: rest -> Some (List.fold_left min first rest)))
+;;
+
+let provider_capacity_blocked_task_count
+      ?(provider_cooldown_remaining_sec = provider_cooldown_remaining_sec_for_cascade)
+      ~(meta : keeper_meta)
+      ~(claimable_task_count : int)
+      ()
+  =
+  if claimable_task_count <= 0
+  then 0
+  else (
+    let cascade_name = cascade_name_of_meta meta in
+    match
+      provider_cooldown_remaining_sec
+        ~cascade_name:(Keeper_cascade_profile.runtime_name_of_string cascade_name)
+    with
+    | Some _
+      when Option.is_none
+             (fallback_cascade_for_provider_cooldown
+                ~base_cascade:cascade_name
+                ~effective_cascade:cascade_name) ->
+      claimable_task_count
+    | Some _ | None -> 0)
+;;
+
 let observe
       ~allowed_tool_names
       ~(pending_board_events : pending_board_event list option)
@@ -469,6 +551,9 @@ let observe
       , backlog_updated_since_last_scheduled_autonomous )
     =
     read_backlog_counts ~allowed_tool_names ~config ~meta
+  in
+  let provider_capacity_blocked_task_count =
+    provider_capacity_blocked_task_count ~meta ~claimable_task_count ()
   in
   let active_agent_count = count_active_agents ~config in
   let idle_seconds = compute_idle_seconds ~meta in
@@ -519,6 +604,7 @@ let observe
   ; economic_pressure
   ; unclaimed_task_count
   ; claimable_task_count
+  ; provider_capacity_blocked_task_count
   ; failed_task_count
   ; pending_verification_count
   ; backlog_updated_since_last_scheduled_autonomous
@@ -542,6 +628,9 @@ let observe_direct_keeper_msg
     =
     read_backlog_counts ~allowed_tool_names ~config ~meta
   in
+  let provider_capacity_blocked_task_count =
+    provider_capacity_blocked_task_count ~meta ~claimable_task_count ()
+  in
   { pending_mentions = []
   ; pending_board_events = []
   ; pending_scope_messages = []
@@ -558,6 +647,7 @@ let observe_direct_keeper_msg
       Agent_economy.economic_pressure ~base_path:config.base_path ~agent_name:meta.name
   ; unclaimed_task_count
   ; claimable_task_count
+  ; provider_capacity_blocked_task_count
   ; failed_task_count
   ; pending_verification_count
   ; backlog_updated_since_last_scheduled_autonomous
@@ -681,64 +771,6 @@ let effective_scheduled_autonomous_cooldown
 ;;
 
 let effective_proactive_cooldown = effective_scheduled_autonomous_cooldown
-
-let fallback_cascade_for_provider_cooldown
-      ~(base_cascade : string)
-      ~(effective_cascade : string)
-  : string option
-  =
-  let normalized_base = Keeper_cascade_profile.normalize_declared_name base_cascade in
-  let normalized_effective =
-    Keeper_cascade_profile.normalize_declared_name effective_cascade
-  in
-  if not (String.equal normalized_effective normalized_base)
-  then Some normalized_base
-  else if
-    String.equal normalized_effective Keeper_config.local_only_cascade_name
-    || String.equal normalized_effective (Keeper_config.default_cascade_name ())
-  then None
-  else Some (Keeper_config.default_cascade_name ())
-;;
-
-let provider_cooldown_remaining_sec_for_cascade
-      ~(cascade_name : Keeper_cascade_profile.runtime_name)
-  : int option
-  =
-  let runtime_health_keys =
-    Cascade_runtime.models_of_cascade_name cascade_name
-    |> Cascade_runtime_candidate.runtime_health_keys_of_labels
-  in
-  match runtime_health_keys with
-  | [] -> None
-  | _ ->
-    let provider_infos =
-      List.map
-        (fun provider_key ->
-           Cascade_health_tracker.provider_info
-             Cascade_health_tracker.global
-             ~provider_key)
-        runtime_health_keys
-    in
-    if not (List.for_all Option.is_some provider_infos)
-    then None
-    else (
-      let provider_infos = List.filter_map Fun.id provider_infos in
-      if
-        not
-          (List.for_all
-             (fun info -> info.Cascade_health_tracker.in_cooldown)
-             provider_infos)
-      then None
-      else (
-        let now = Time_compat.now () in
-        provider_infos
-        |> List.filter_map (fun info -> info.Cascade_health_tracker.cooldown_expires_at)
-        |> List.map (fun expires_at ->
-          int_of_float (Float.max 0.0 (Float.ceil (expires_at -. now))))
-        |> function
-        | [] -> Some 0
-        | first :: rest -> Some (List.fold_left min first rest)))
-;;
 
 let entropic_oscillation_interval_sec = 600
 let entropic_oscillation_probability_percent = 5

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -70,6 +70,10 @@ type world_observation = {
   (** Number of unclaimed tasks this keeper can claim with its current tool
       surface. This is a matched subset of [unclaimed_task_count]. *)
 
+  provider_capacity_blocked_task_count : int;
+  (** Number of otherwise-claimable tasks currently held back by provider
+      capacity/cooldown when no fail-open cascade is available. *)
+
   failed_task_count : int;
   (** Number of failed/cancelled tasks in the room backlog. *)
 
@@ -278,6 +282,14 @@ val effective_proactive_cooldown :
 
 val provider_cooldown_remaining_sec_for_cascade :
   cascade_name:Keeper_cascade_profile.runtime_name -> int option
+
+val provider_capacity_blocked_task_count :
+  ?provider_cooldown_remaining_sec:
+    (cascade_name:Keeper_cascade_profile.runtime_name -> int option) ->
+  meta:Keeper_types.keeper_meta ->
+  claimable_task_count:int ->
+  unit ->
+  int
 
 val entropic_oscillation_interval_sec : int
 (** Minimum scheduled-autonomous silence before entropy injection can wake a

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -251,6 +251,7 @@ let base_observation : WO.world_observation =
   ; economic_pressure = AE.Normal
   ; unclaimed_task_count = 0
   ; claimable_task_count = 0
+  ; provider_capacity_blocked_task_count = 0
   ; failed_task_count = 0
   ; pending_verification_count = 0
   ; backlog_updated_since_last_scheduled_autonomous = false
@@ -1265,6 +1266,41 @@ let test_provider_cooldown_blocks_scheduled_turn_when_work_is_ready () =
            | _ -> false)
          (first :: rest)
      | WO.Run _ -> false)
+;;
+
+let test_provider_capacity_blocked_backlog_count_requires_non_fail_open_cooldown () =
+  let default_meta =
+    Masc_mcp.Keeper_types.set_cascade_name
+      (Masc_mcp.Keeper_config.default_cascade_name ())
+      minimal_meta
+  in
+  let blocked =
+    WO.provider_capacity_blocked_task_count
+      ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> Some 3599)
+      ~meta:default_meta
+      ~claimable_task_count:3
+      ()
+  in
+  check int "default cascade cooldown blocks claimable backlog" 3 blocked;
+  let healthy =
+    WO.provider_capacity_blocked_task_count
+      ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> None)
+      ~meta:default_meta
+      ~claimable_task_count:3
+      ()
+  in
+  check int "healthy provider leaves backlog unblocked" 0 healthy;
+  let fail_open_meta =
+    Masc_mcp.Keeper_types.set_cascade_name "scoring" minimal_meta
+  in
+  let fail_open_blocked =
+    WO.provider_capacity_blocked_task_count
+      ~provider_cooldown_remaining_sec:(fun ~cascade_name:_ -> Some 3599)
+      ~meta:fail_open_meta
+      ~claimable_task_count:3
+      ()
+  in
+  check int "fallback-capable cascade is not counted as blocked" 0 fail_open_blocked
 ;;
 
 let test_provider_cooldown_keeps_scheduled_turn_open_when_fail_open_exists () =
@@ -2965,6 +3001,30 @@ let test_prompt_room_state_section () =
        | Not_found -> false
      in
      found)
+;;
+
+let test_prompt_surfaces_provider_capacity_blocked_backlog () =
+  let obs =
+    { base_observation with
+      unclaimed_task_count = 5
+    ; claimable_task_count = 3
+    ; provider_capacity_blocked_task_count = 3
+    ; active_agent_count = 5
+    }
+  in
+  let _sys, user =
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs ()
+  in
+  check
+    bool
+    "namespace exposes provider-capacity blocked backlog"
+    true
+    (contains_substring user "Provider-capacity blocked claimable tasks: 3");
+  check
+    bool
+    "provider-blocked backlog suppresses immediate claim guidance"
+    false
+    (contains_substring user "### Immediate Task Move")
 ;;
 
 let test_prompt_includes_claim_first_guidance () =
@@ -10976,6 +11036,10 @@ let () =
             `Quick
             test_provider_cooldown_blocks_scheduled_turn_when_work_is_ready
         ; test_case
+            "provider cooldown blocks claimable backlog count"
+            `Quick
+            test_provider_capacity_blocked_backlog_count_requires_non_fail_open_cooldown
+        ; test_case
             "provider cooldown keeps scheduled turn open when fail-open exists"
             `Quick
             test_provider_cooldown_keeps_scheduled_turn_open_when_fail_open_exists
@@ -11151,6 +11215,10 @@ let () =
             `Quick
             test_prompt_orders_stable_sections_before_reactive_sections
         ; test_case "room state section" `Quick test_prompt_room_state_section
+        ; test_case
+            "room state surfaces provider-capacity blocked backlog"
+            `Quick
+            test_prompt_surfaces_provider_capacity_blocked_backlog
         ; test_case
             "claim first guidance"
             `Quick

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -18,6 +18,7 @@ let base_observation : WO.world_observation =
     economic_pressure = AE.Normal;
     unclaimed_task_count = 0;
     claimable_task_count = 0;
+    provider_capacity_blocked_task_count = 0;
     failed_task_count = 0;
     pending_verification_count = 0;
     backlog_updated_since_last_scheduled_autonomous = false;
@@ -134,6 +135,21 @@ let test_task_claim_present_for_claimable_backlog () =
   check bool "task_claim present for matched backlog" true
     (List.mem "task_claim" affordances)
 
+let test_task_claim_suppressed_for_provider_blocked_backlog () =
+  let obs =
+    {
+      base_observation with
+      unclaimed_task_count = 3;
+      claimable_task_count = 1;
+      provider_capacity_blocked_task_count = 1;
+    }
+  in
+  let affordances = UM.observed_affordances_of_observation obs in
+  check bool "task_claim absent while provider capacity blocks work" false
+    (List.mem "task_claim" affordances);
+  check bool "provider capacity affordance present" true
+    (List.mem "provider_capacity_blocked" affordances)
+
 let test_janitor_discovery_sources_do_not_force_task_claim () =
   let meta =
     {
@@ -184,6 +200,19 @@ let test_backlog_trigger_split () =
   check bool "matched backlog trigger is explicit" true
     (List.mem "claimable_task" triggers)
 
+let test_provider_capacity_blocked_trigger () =
+  let obs =
+    {
+      base_observation with
+      unclaimed_task_count = 3;
+      claimable_task_count = 1;
+      provider_capacity_blocked_task_count = 1;
+    }
+  in
+  let triggers = UM.observed_triggers_of_observation obs in
+  check bool "provider capacity trigger is explicit" true
+    (List.mem "provider_capacity_blocked_backlog" triggers)
+
 let test_pending_verification_trigger_for_keeper () =
   let meta = { minimal_meta with mention_targets = [ "scholar" ] } in
   let obs = { base_observation with pending_verification_count = 5 } in
@@ -220,12 +249,17 @@ let () =
           test_case "affordance: task claim present for claimable backlog" `Quick
             test_task_claim_present_for_claimable_backlog;
           test_case
+            "affordance: provider block suppresses task claim"
+            `Quick test_task_claim_suppressed_for_provider_blocked_backlog;
+          test_case
             "affordance: janitor discovery sources do not force task claim"
             `Quick test_janitor_discovery_sources_do_not_force_task_claim;
           test_case "affordance: unclaimed discovery source keeps task claim"
             `Quick test_unclaimed_discovery_source_keeps_task_claim;
           test_case "trigger: absolute and matched backlog split" `Quick
             test_backlog_trigger_split;
+          test_case "trigger: provider capacity blocked backlog" `Quick
+            test_provider_capacity_blocked_trigger;
           test_case "trigger: keeper sees pending_verification" `Quick
             test_pending_verification_trigger_for_keeper;
           test_case


### PR DESCRIPTION
## Summary
- add provider_capacity_blocked_task_count to keeper world observations
- expose provider-blocked backlog in metrics/triggers/prompt namespace state
- suppress task_claim affordance and immediate claim guidance while claimable work is blocked by provider cooldown without fail-open

Closes #16975.

## Verification
- opam exec -- ocamlformat --check lib/keeper/keeper_world_observation.ml lib/keeper/keeper_world_observation.mli lib/keeper/keeper_unified_metrics_support.ml lib/keeper/keeper_unified_metrics.ml lib/keeper/keeper_unified_prompt.ml test/test_keeper_unified.ml test/test_keeper_unified_verification_surface.ml
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_unified.exe test/test_keeper_unified_verification_surface.exe
- ./_build/default/test/test_keeper_unified_verification_surface.exe
- ./_build/default/test/test_keeper_unified.exe test world_observation 25
- ./_build/default/test/test_keeper_unified.exe test unified_prompt 25
- git diff --check HEAD~1..HEAD

## Known baseline
- Full ./_build/default/test/test_keeper_unified.exe -q currently has 3 failures on main as well; tracked separately in #17056.