### PR TITLE
fix(ci): arm draft guard status immediately

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -24,7 +24,10 @@ permissions:
 # feature/ds-v2-dialog-anim-wiring, fix/ir3-checkpoint-error).
 concurrency:
   group: pr-automation-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  # Do not cancel in-flight guard runs. A burst of opened/labeled/ready events can
+  # otherwise leave only CANCELLED Draft Auto-Merge Guard checks during the short
+  # ready-to-merge window for agent PRs.
+  cancel-in-progress: false
 
 jobs:
   draft-automerge-guard:

--- a/scripts/pr-open.sh
+++ b/scripts/pr-open.sh
@@ -132,6 +132,33 @@ ensure_pr_is_draft() {
   fi
 }
 
+arm_agent_draft_guard_status() {
+  local pr_number="$1"
+  local pr_meta
+  local pr_url
+  local head_sha
+
+  pr_meta="$(
+    gh pr view "$pr_number" --repo "$repo" --json url,headRefOid \
+      --jq '.url + " " + .headRefOid'
+  )"
+  pr_url="${pr_meta% *}"
+  head_sha="${pr_meta##* }"
+
+  if [[ -z "$head_sha" || "$head_sha" == "$pr_url" ]]; then
+    echo "could not resolve PR #$pr_number head SHA for immediate draft guard status" >&2
+    exit 1
+  fi
+
+  gh api "repos/$repo/statuses/$head_sha" \
+    --method POST \
+    -f state=failure \
+    -f context="Draft Auto-Merge Guard" \
+    -f description="Agent PR requires Approve Agent PR before ready/merge" \
+    -f target_url="$pr_url" \
+    >/dev/null
+}
+
 repo=""
 base="main"
 title=""
@@ -248,6 +275,9 @@ if [[ ${#labels[@]} -gt 0 ]]; then
   gh api "repos/$repo/issues/$pr_number/labels" --method POST --input - <<< "$label_json" >/dev/null
   ensure_pr_is_draft "$pr_number" "label application"
 fi
+
+arm_agent_draft_guard_status "$pr_number"
+ensure_pr_is_draft "$pr_number" "guard status arming"
 
 pr_url="$(gh pr view "$pr_number" --repo "$repo" --json url --jq .url)"
 echo "PR: $pr_url"

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -505,7 +505,16 @@ let test_pr_automation_draft_guard_contracts () =
        "hard-stop label present");
   check bool "pr automation hard-stop participates in guarded decision" true
     (file_contains_pattern ".github/workflows/pr-automation.yml"
-       "presentHardStopLabels.length > 0")
+       "presentHardStopLabels.length > 0");
+  check bool "pr automation does not cancel in-flight guard runs" true
+    (file_contains_pattern ".github/workflows/pr-automation.yml"
+       "cancel-in-progress: false");
+  check bool "pr-open arms immediate draft guard status" true
+    (file_contains_pattern "scripts/pr-open.sh"
+       "arm_agent_draft_guard_status");
+  check bool "pr-open posts Draft Auto-Merge Guard failure status" true
+    (file_contains_pattern "scripts/pr-open.sh"
+       {|context="Draft Auto-Merge Guard"|})
 
 let test_health_and_ci_runner_diagnostics () =
   check bool "health snapshot records baseline source" true

--- a/test/test_pr_open_script.ml
+++ b/test/test_pr_open_script.ml
@@ -91,6 +91,7 @@ let make_fake_gh dir =
 set -eu
 log_file="${FAKE_GH_LOG:?}"
 labels_file="${FAKE_GH_LABELS:?}"
+statuses_file="${FAKE_GH_STATUSES:-$labels_file.statuses}"
 draft_file="${FAKE_GH_DRAFT_STATE_FILE:-$labels_file.draft}"
 cmd1="${1:-}"
 cmd2="${2:-}"
@@ -114,6 +115,9 @@ case "${cmd1}:${cmd2}" in
       *"state,isDraft,mergeStateStatus,headRefOid,url"*)
         printf 'state=OPEN draft=%s mergeState=CLEAN head=abc123\nurl=https://github.com/example/test/pull/42\n' "$draft_state"
         ;;
+      *"url,headRefOid"*)
+        printf 'https://github.com/example/test/pull/42 abc123\n'
+        ;;
       *"state,isDraft"*)
         printf 'OPEN %s\n' "$draft_state"
         ;;
@@ -133,7 +137,15 @@ case "${cmd1}:${cmd2}" in
     printf 'true\n' >"$draft_file"
     ;;
   api:*)
-    cat >"$labels_file"
+    case "${2:-}" in
+      */statuses/*)
+        cat >>"$statuses_file"
+        printf '\n' >>"$statuses_file"
+        ;;
+      *)
+        cat >"$labels_file"
+        ;;
+    esac
     ;;
   label:list)
     printf '[]\n'
@@ -230,8 +242,13 @@ let test_script_runs_under_system_bash_without_watch () =
         (contains_substring stderr "mapfile: command not found");
       let log = read_file gh_log in
       check bool "creates draft PR" true (contains_substring log "pr create");
+      check bool "arms immediate draft guard status" true
+        (contains_substring log "api repos/example/test/statuses/abc123");
       check bool "skips watched checks with --no-watch" false
         (contains_substring log "pr checks");
+      check bool "sets draft guard status failure" true
+        (contains_substring (read_file (gh_labels ^ ".statuses"))
+           "Draft Auto-Merge Guard");
       let labels = read_file gh_labels in
       check bool "adds enhancement label for code changes" true
         (contains_substring labels "\"enhancement\"");


### PR DESCRIPTION
## Summary

- Stop cancelling in-flight PR Automation guard runs for the same PR.
- Have `scripts/pr-open.sh` immediately post a failing `Draft Auto-Merge Guard` status to the PR head SHA.
- Extend script/source tests so the wrapper-level immediate guard is covered.

## Product impact

This closes the observed ready-to-merge window where wrapper-created agent PRs (#17046, #17047, #17055) were marked ready and merged while the Actions guard checks were still queued or cancelled. The wrapper now arms the required guard context immediately, before delayed GitHub Actions runs can catch up.

## Evidence

- `bash -n scripts/pr-open.sh`
- `ocamlformat --check test/test_pr_open_script.ml test/test_ci_hardening_source.ml`
- `git diff --check`
- Focused Dune target `test/test_pr_open_script.exe test/test_ci_hardening_source.exe` was blocked by the shared Dune lock; #17030 tracks that host-level validation contention.
- Live smoke on this PR: `gh pr view 17060 --json state,isDraft,mergeStateStatus,statusCheckRollup` shows `OPEN`, `isDraft=true`, `mergeStateStatus=BLOCKED`, and a `StatusContext` named `Draft Auto-Merge Guard` with `state=FAILURE`.

## Review evidence

- `gh api repos/<repo>/issues/<pr>/events` for #17055 showed `agent-pr` and `do-not-merge` labels at 14:42:51Z, `ready_for_review` at 14:43:39Z, then merge at 14:43:44Z.
- #17055 status rollup showed early `Draft Auto-Merge Guard` runs cancelled during the same window.
- The patch therefore addresses both the cancellation race and the missing immediate required-context signal.

## Linked issue

- Fixes the concrete guard failure tracked in #17017.
- Related validation contention: #17030.
