### PR TITLE
ci(release): pin base path in binary smoke

### DIFF
--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -31,8 +31,8 @@ lib/process/process_eio.ml:535
 # manager itself. Bounded by session scope, not by per-call timeout.
 lib/server/lsp_process_manager.ml:178
 
-# lib/worker_dev_tools.ml:1281 — dev-tools worker spawn. Wrapped by
+# lib/worker_dev_tools.ml:1283 — dev-tools worker spawn. Wrapped by
 # Tool_resource_gate, Fd_accountant, Eio.Time.with_timeout_exn, and a fresh
 # Eio.Switch.run at the call boundary. Line renumbered by worker-dev-tools
 # split/refactor waves.
-lib/worker_dev_tools.ml:1281
+lib/worker_dev_tools.ml:1283

--- a/scripts/release-binary-smoke.sh
+++ b/scripts/release-binary-smoke.sh
@@ -39,7 +39,9 @@ cp config/tool_policy.toml "$tmp/.masc/config/tool_policy.toml"
 
 log="$tmp/boot.log"
 echo "smoke: booting $BINARY on :$PORT under $tmp"
-"$BINARY" --base-path "$tmp" --port "$PORT" >"$log" 2>&1 &
+MASC_BASE_PATH="$tmp" \
+MASC_BASE_PATH_INPUT="$tmp" \
+  "$BINARY" --base-path "$tmp" --port "$PORT" >"$log" 2>&1 &
 PID=$!
 
 # Poll for either a FATAL line or the listening line. Bound by BOOT_WAIT_SEC.
@@ -70,7 +72,10 @@ esac
 
 # --- README ↔ CLI subcommand drift -------------------------------------------
 help_txt="$tmp/help.txt"
-TERM=dumb "$BINARY" --help=plain >"$help_txt" 2>/dev/null || true
+MASC_BASE_PATH="$tmp" \
+MASC_BASE_PATH_INPUT="$tmp" \
+TERM=dumb \
+  "$BINARY" --help=plain >"$help_txt" 2>/dev/null || true
 
 # cmdliner Cmd.group prints subcommands under the "COMMANDS" section, with
 # 7-space indent (subcommand name) followed by deeper indent (description).


### PR DESCRIPTION
## Summary
- pin MASC_BASE_PATH/MASC_BASE_PATH_INPUT for release binary boot smoke
- run README drift help check under the same isolated smoke root

## Verification
- bash -n scripts/release-binary-smoke.sh
- git diff --check
- scripts/dune-local.sh build bin/main_eio.exe
- scripts/release-binary-smoke.sh _build/default/bin/main_eio.exe