### PR TITLE
fix(parser): parse safe quoted bash args

### DIFF
--- a/lib/exec/parser/bash_lexer.mll
+++ b/lib/exec/parser/bash_lexer.mll
@@ -24,6 +24,14 @@ let word_char = [^ ' ' '\t' '\n' '\r' '|' '<' '>' '&' ';' '(' ')'
                    '\'' '"' '$' '`' '\\' '=' '{' '}' '!' '*' '?']
 let word = word_char+
 
+(* Prefix for a single shell word that continues with quoted literal
+   content, e.g. [--include="*.ml"].  This keeps common argv-shaped
+   options inside the typed parser without accepting glob metachars in
+   unquoted positions. *)
+let word_prefix_char = [^ ' ' '\t' '\n' '\r' '|' '<' '>' '&' ';' '(' ')'
+                          '\'' '"' '$' '`' '\\' '{' '}' '!' '*' '?']
+let word_prefix = word_prefix_char+
+
 (* Single-quote string: literal, no escape processing, no nested
    single quote allowed (bash semantics — there is no way to embed
    a single quote inside a '...' string).  Matched content becomes
@@ -34,22 +42,26 @@ let word = word_char+
 let sq_body = [^ '\'' '\n']*
 
 (* Double-quote string: A1 skeleton treats it as a literal whose body
-   excludes the four metachars bash would interpret inside "..." —
-   backslash escapes ('\"', '\\', '\$', '\`'), variable expansion ($FOO,
-   ${FOO}), command substitution (`cmd`, $(cmd)), and embedded newlines.
-   Any of those chars inside the body breaks the lex → Parse_error,
+   excludes the metachars bash would interpret inside "..." — variable
+   expansion ($FOO, ${FOO}), command substitution (`cmd`, $(cmd)), and
+   embedded newlines.  Backslash stays rejected except for [\|], which
+   is a common regex literal in rg/grep patterns and is still literal
+   under bash double quotes.  Any other excluded char inside the body
+   breaks the lex → Parse_error,
    which is the correct fail-closed behavior for the subset.  The most
    common caller shapes (rg "pattern", git commit -m "message",
    echo "hello world") have none of those chars and land as one WORD
    token, mirroring the single-quote rule's space-preservation guarantee.
    Upgrade path: later PR widens dq_body to support escape sequences by
    capturing in a sub-rule that unescapes into a Buffer. *)
-let dq_body = [^ '"' '\n' '\\' '$' '`']*
+let dq_char = [^ '"' '\n' '\\' '$' '`'] | "\\|"
+let dq_body = dq_char*
 
 rule token = parse
   | [' ' '\t']+    { token lexbuf }
   | '\n'           { incr_tokens (); Lexing.new_line lexbuf; token lexbuf }
   | '|'            { incr_tokens (); PIPE }
+  | (word_prefix as prefix) '"' (dq_body as s) '"' { incr_tokens (); WORD (prefix ^ s) }
   | '\'' (sq_body as s) '\'' { incr_tokens (); WORD s }
   | '"' (dq_body as s) '"' { incr_tokens (); WORD s }
   | word as w      { incr_tokens (); WORD w }

--- a/lib/exec/test/test_bash_parser.ml
+++ b/lib/exec/test/test_bash_parser.ml
@@ -263,6 +263,39 @@ let test_double_quote_rg_pattern () =
      | _ -> assert false)
   | _ -> assert false
 
+let test_double_quote_with_escaped_regex_pipe () =
+  (* [\|] inside double quotes is literal regex payload for rg/grep,
+     not a shell pipeline.  Keeping it in the typed parser lets the
+     keeper safe-read fallback use normal argv validation. *)
+  match Bash.parse_string {|rg -n "ghost\|task" lib/|} with
+  | Parsed.Parsed (Shell_ir.Simple s) ->
+    assert (Bin.to_string s.bin = "rg");
+    (match s.args with
+     | [
+         Shell_ir.Lit "-n";
+         Shell_ir.Lit {|ghost\|task|};
+         Shell_ir.Lit "lib/";
+       ] -> ()
+     | _ -> assert false)
+  | _ -> assert false
+
+let test_word_with_double_quoted_suffix () =
+  (* Bash treats [--include="*.ml"] as one argv item.  The unquoted
+     prefix is inert option text; the quoted suffix carries the glob
+     literal without opening the unquoted glob surface. *)
+  match Bash.parse_string {|grep -rn "exec_semantic" lib/ --include="*.ml"|} with
+  | Parsed.Parsed (Shell_ir.Simple s) ->
+    assert (Bin.to_string s.bin = "grep");
+    (match s.args with
+     | [
+         Shell_ir.Lit "-rn";
+         Shell_ir.Lit "exec_semantic";
+         Shell_ir.Lit "lib/";
+         Shell_ir.Lit "--include=*.ml";
+       ] -> ()
+     | _ -> assert false)
+  | _ -> assert false
+
 let test_double_quote_with_dollar_rejected () =
   (* Variable expansion is subset-excluded at the A1 layer — any '$'
      inside "..." breaks the lex so Parse_error surfaces rather than
@@ -326,6 +359,8 @@ let () =
   test_double_quoted_empty ();
   test_double_quote_with_pipe_metachar ();
   test_double_quote_rg_pattern ();
+  test_double_quote_with_escaped_regex_pipe ();
+  test_word_with_double_quoted_suffix ();
   test_double_quote_with_dollar_rejected ();
   test_double_quote_with_backslash_rejected ();
   test_double_quote_with_backtick_rejected ();


### PR DESCRIPTION
## Summary
- Extend the Bash subset lexer for safe argv shapes used by keeper read fallbacks.
- Preserve typed Shell IR parsing for escaped regex pipes inside double quotes.
- Parse quoted suffix words like --include="*.ml" as one argv item without adding a keeper raw-string bypass.
- Refresh the spawn-bounded allowlist line after CI reported existing line drift.

## Tests
- ocamlformat --check lib/exec/test/test_bash_parser.ml
- ocamlformat --check lib/exec/parser/bash_lexer.mll
- scripts/dune-local.sh build lib/exec/test/test_bash_parser.exe test/test_keeper_bash_safety.exe
- ./_build/default/lib/exec/test/test_bash_parser.exe
- ./_build/default/test/test_keeper_bash_safety.exe
- scripts/dune-local.sh build test/test_keeper_gh_timeout_floor.exe test/test_types.exe
- ./_build/default/test/test_keeper_gh_timeout_floor.exe
- ./_build/default/test/test_types.exe
- scripts/lint-spawn-bounded.sh