### PR TITLE
feat(lib): RFC-0154 PR-1 — System_error_class typed SSOT module

### DIFF
--- a/lib/system_error_class.ml
+++ b/lib/system_error_class.ml
@@ -1,0 +1,81 @@
+(* RFC-0154 PR-1.  SSOT for OS-level / runtime error classification.
+   See system_error_class.mli for the contract.  This module is intentionally
+   total and dependency-free (only [String_util] and [Unix]) so that PR-2 can
+   thread it through [Telemetry_coverage_gap.record] and the four pre-existing
+   inline substring matchers without taking on new transitive deps. *)
+
+type t =
+  | Fd_exhaustion
+  | Disk_exhaustion
+  | Permission_denied
+  | Connection_refused
+  | Timeout
+  | Other of string
+
+(* Vocabulary union of the four pre-existing inline matchers documented in
+   RFC-0154 §1.1.  Add a new entry here only when paired with a backend
+   reactor + RFC (see .mli docstring). *)
+
+let fd_needles =
+  [ "too many open files"
+  ; "emfile"
+  ; "enfile"
+  ; "file descriptor"
+  ; "os error 24"
+  ; "execve: too many open files"
+  ]
+
+let disk_needles =
+  [ "no space left on device"
+  ; "enospc"
+  ; "disk quota exceeded"
+  ; "quota exceeded"
+  ; "disk full"
+  ; "not enough space"
+  ]
+
+let permission_needles =
+  [ "permission denied"
+  ; "eacces"
+  ; "eperm"
+  ; "operation not permitted"
+  ]
+
+let connection_refused_needles = [ "connection refused"; "econnrefused" ]
+
+let timeout_needles = [ "etimedout"; "timed out"; "operation timed out" ]
+
+let any_match s needles = List.exists (String_util.contains_substring_ci s) needles
+
+let classify_string s =
+  if String.length s = 0 then Other s
+  else if any_match s fd_needles then Fd_exhaustion
+  else if any_match s disk_needles then Disk_exhaustion
+  else if any_match s permission_needles then Permission_denied
+  else if any_match s connection_refused_needles then Connection_refused
+  else if any_match s timeout_needles then Timeout
+  else Other s
+
+let classify_exn = function
+  | Unix.Unix_error ((Unix.EMFILE | Unix.ENFILE), _, _) -> Fd_exhaustion
+  | Unix.Unix_error (Unix.ENOSPC, _, _) -> Disk_exhaustion
+  | Unix.Unix_error ((Unix.EACCES | Unix.EPERM), _, _) -> Permission_denied
+  | Unix.Unix_error (Unix.ECONNREFUSED, _, _) -> Connection_refused
+  | Unix.Unix_error (Unix.ETIMEDOUT, _, _) -> Timeout
+  | exn -> classify_string (Printexc.to_string exn)
+
+let to_short_tag = function
+  | Fd_exhaustion -> "fd_exhaustion"
+  | Disk_exhaustion -> "disk_exhaustion"
+  | Permission_denied -> "permission_denied"
+  | Connection_refused -> "connection_refused"
+  | Timeout -> "timeout"
+  | Other _ -> "other"
+
+let to_raw_text = function
+  | Fd_exhaustion -> "fd_exhaustion"
+  | Disk_exhaustion -> "disk_exhaustion"
+  | Permission_denied -> "permission_denied"
+  | Connection_refused -> "connection_refused"
+  | Timeout -> "timeout"
+  | Other s -> s

--- a/lib/system_error_class.mli
+++ b/lib/system_error_class.mli
@@ -1,0 +1,51 @@
+(** SSOT for OS-level / runtime error classification surfaced to MASC
+    fleet reactors (FD pressure circuit breaker, disk pressure circuit
+    breaker, dashboard coverage-gap hint).
+
+    RFC-0154 §3.1.
+
+    A new named variant is added only when (a) a backend reactor exists
+    for the failure mode and (b) a canonical RFC describes the operator
+    remediation.  Otherwise the original message is preserved verbatim
+    in [Other s] — parse-don't-validate escape hatch, not a catch-all. *)
+
+type t =
+  | Fd_exhaustion
+      (** RFC-0097.  [Unix.EMFILE] / [Unix.ENFILE], or substrings
+          ["too many open files"], ["emfile"], ["enfile"],
+          ["file descriptor"], ["os error 24"]. *)
+  | Disk_exhaustion
+      (** RFC-0122.  [Unix.ENOSPC], or substrings
+          ["no space left on device"], ["enospc"],
+          ["disk quota exceeded"], ["quota exceeded"], ["disk full"],
+          ["not enough space"]. *)
+  | Permission_denied
+      (** [Unix.EACCES] / [Unix.EPERM], or substrings
+          ["permission denied"], ["eacces"], ["eperm"],
+          ["operation not permitted"]. *)
+  | Connection_refused
+      (** [Unix.ECONNREFUSED], or substrings ["connection refused"],
+          ["econnrefused"]. *)
+  | Timeout
+      (** [Unix.ETIMEDOUT], or substrings ["etimedout"], ["timed out"],
+          ["operation timed out"]. *)
+  | Other of string
+      (** Unclassified error.  The string is the verbatim input that
+          [classify_string] received, preserving original casing. *)
+
+val classify_exn : exn -> t
+(** Errno match on [Unix.Unix_error _] takes priority.  Other
+    exceptions fall through to [classify_string (Printexc.to_string exn)]. *)
+
+val classify_string : string -> t
+(** Case-insensitive substring match against the unified vocabulary.
+    Returns [Other s] (original casing preserved) when no class matches. *)
+
+val to_short_tag : t -> string
+(** Stable wire-format tag.  Returns one of:
+    ["fd_exhaustion"], ["disk_exhaustion"], ["permission_denied"],
+    ["connection_refused"], ["timeout"], ["other"]. *)
+
+val to_raw_text : t -> string
+(** Display text.  Named variants return their short tag; [Other s]
+    returns [s] verbatim. *)

--- a/test/dune
+++ b/test/dune
@@ -939,6 +939,7 @@
   test_goal_store
   test_goal_verification
   test_string_util
+  test_system_error_class
   test_set_util
   test_board_core_payload
   test_board_attachment_meta
@@ -1166,6 +1167,7 @@
   test_goal_store
   test_goal_verification
   test_string_util
+  test_system_error_class
   test_set_util
   test_board_core_payload
   test_board_attachment_meta

--- a/test/test_system_error_class.ml
+++ b/test/test_system_error_class.ml
@@ -1,0 +1,173 @@
+(** RFC-0154 PR-1.  Unit tests for the typed System_error_class SSOT.
+
+    Covers (a) errno → variant priority over substring matching,
+    (b) substring vocabulary union of the four pre-existing inline
+    matchers, (c) [Other s] verbatim preservation including original
+    casing, and (d) wire-tag stability for downstream consumers. *)
+
+open Alcotest
+
+module S = Masc_mcp.System_error_class
+
+let tag = testable Fmt.string String.equal
+
+let check_tag label expected actual = check tag label expected (S.to_short_tag actual)
+
+(* ---- classify_string: errno-keyword substrings ---- *)
+
+let test_classify_string_fd_too_many_open_files () =
+  check_tag "too many open files" "fd_exhaustion"
+    (S.classify_string "Sys_error(\"Eio.Io Unix_error (Too many open files in system, ...)\")")
+
+let test_classify_string_fd_errno_substrings () =
+  check_tag "ENFILE" "fd_exhaustion" (S.classify_string "ENFILE: too many");
+  check_tag "EMFILE" "fd_exhaustion" (S.classify_string "EMFILE on open");
+  check_tag "file descriptor" "fd_exhaustion" (S.classify_string "Too many file descriptors");
+  check_tag "os error 24" "fd_exhaustion" (S.classify_string "io error: os error 24")
+
+let test_classify_string_disk_substrings () =
+  check_tag "no space left" "disk_exhaustion"
+    (S.classify_string "No space left on device, \"write\", \"/tmp/x\"");
+  check_tag "ENOSPC" "disk_exhaustion" (S.classify_string "ENOSPC on append");
+  check_tag "disk quota" "disk_exhaustion" (S.classify_string "Disk quota exceeded");
+  check_tag "quota exceeded" "disk_exhaustion" (S.classify_string "Quota exceeded");
+  check_tag "disk full" "disk_exhaustion" (S.classify_string "disk full");
+  check_tag "not enough space" "disk_exhaustion" (S.classify_string "not enough space available")
+
+let test_classify_string_permission_substrings () =
+  check_tag "permission denied" "permission_denied" (S.classify_string "Permission denied");
+  check_tag "EACCES" "permission_denied" (S.classify_string "EACCES on open");
+  check_tag "EPERM" "permission_denied" (S.classify_string "EPERM: cannot bind");
+  check_tag "operation not permitted" "permission_denied"
+    (S.classify_string "Operation not permitted")
+
+let test_classify_string_connection_refused () =
+  check_tag "connection refused" "connection_refused" (S.classify_string "Connection refused");
+  check_tag "ECONNREFUSED" "connection_refused" (S.classify_string "ECONNREFUSED on connect")
+
+let test_classify_string_timeout () =
+  check_tag "ETIMEDOUT" "timeout" (S.classify_string "ETIMEDOUT on read");
+  check_tag "timed out" "timeout" (S.classify_string "connect: timed out");
+  check_tag "operation timed out" "timeout" (S.classify_string "Operation timed out")
+
+(* ---- classify_string: case-insensitive ---- *)
+
+let test_classify_string_case_insensitive () =
+  check_tag "uppercase FD" "fd_exhaustion" (S.classify_string "TOO MANY OPEN FILES");
+  check_tag "mixed case disk" "disk_exhaustion" (S.classify_string "Disk FULL")
+
+(* ---- classify_string: unclassified → Other s verbatim ---- *)
+
+let test_classify_string_other_preserves_input () =
+  let raw = "Unrelated_error(BadCert)" in
+  match S.classify_string raw with
+  | S.Other s ->
+    check string "Other preserves original casing" raw s;
+    check_tag "tag is 'other'" "other" (S.Other s)
+  | _ -> fail "expected Other variant"
+
+let test_classify_string_empty_input () =
+  check_tag "empty string → Other" "other" (S.classify_string "")
+
+(* ---- classify_exn: errno priority over string match ---- *)
+
+let test_classify_exn_errno_emfile () =
+  check_tag "EMFILE" "fd_exhaustion"
+    (S.classify_exn (Unix.Unix_error (Unix.EMFILE, "open", "/tmp")))
+
+let test_classify_exn_errno_enfile () =
+  check_tag "ENFILE" "fd_exhaustion"
+    (S.classify_exn (Unix.Unix_error (Unix.ENFILE, "open", "/tmp")))
+
+let test_classify_exn_errno_enospc () =
+  check_tag "ENOSPC" "disk_exhaustion"
+    (S.classify_exn (Unix.Unix_error (Unix.ENOSPC, "write", "/tmp")))
+
+let test_classify_exn_errno_eacces () =
+  check_tag "EACCES" "permission_denied"
+    (S.classify_exn (Unix.Unix_error (Unix.EACCES, "open", "/etc/shadow")))
+
+let test_classify_exn_errno_eperm () =
+  check_tag "EPERM" "permission_denied"
+    (S.classify_exn (Unix.Unix_error (Unix.EPERM, "bind", "")))
+
+let test_classify_exn_errno_econnrefused () =
+  check_tag "ECONNREFUSED" "connection_refused"
+    (S.classify_exn (Unix.Unix_error (Unix.ECONNREFUSED, "connect", "")))
+
+let test_classify_exn_errno_etimedout () =
+  check_tag "ETIMEDOUT" "timeout"
+    (S.classify_exn (Unix.Unix_error (Unix.ETIMEDOUT, "read", "")))
+
+(* Regression: errno priority means an EMFILE Unix_error must classify
+   as fd_exhaustion even though Printexc.to_string would also surface
+   "Too many open files" via the substring path.  Both paths must
+   agree, and the errno path must execute first. *)
+let test_classify_exn_errno_priority_over_string () =
+  check_tag "Unix_error errno path wins" "fd_exhaustion"
+    (S.classify_exn (Unix.Unix_error (Unix.EMFILE, "syscall", "arg")))
+
+(* Falls back to string classify for non-Unix_error exceptions. *)
+let test_classify_exn_fallback_to_string () =
+  check_tag "Sys_error falls through to string" "disk_exhaustion"
+    (S.classify_exn (Sys_error "No space left on device"));
+  check_tag "Failure falls through to other" "other"
+    (S.classify_exn (Failure "unrelated"))
+
+(* ---- to_short_tag / to_raw_text contract ---- *)
+
+let test_to_short_tag_all_variants () =
+  check string "Fd_exhaustion" "fd_exhaustion" (S.to_short_tag S.Fd_exhaustion);
+  check string "Disk_exhaustion" "disk_exhaustion" (S.to_short_tag S.Disk_exhaustion);
+  check string "Permission_denied" "permission_denied" (S.to_short_tag S.Permission_denied);
+  check string "Connection_refused" "connection_refused"
+    (S.to_short_tag S.Connection_refused);
+  check string "Timeout" "timeout" (S.to_short_tag S.Timeout);
+  check string "Other" "other" (S.to_short_tag (S.Other "anything"))
+
+let test_to_raw_text_other_returns_input () =
+  check string "Other returns verbatim payload" "Original_Error_Message"
+    (S.to_raw_text (S.Other "Original_Error_Message"))
+
+let test_to_raw_text_named_returns_short_label () =
+  check string "Fd_exhaustion canonical text" "fd_exhaustion"
+    (S.to_raw_text S.Fd_exhaustion);
+  check string "Disk_exhaustion canonical text" "disk_exhaustion"
+    (S.to_raw_text S.Disk_exhaustion)
+
+let () =
+  run "system_error_class"
+    [ ( "classify_string"
+      , [ test_case "FD: too many open files" `Quick test_classify_string_fd_too_many_open_files
+        ; test_case "FD: errno substrings" `Quick test_classify_string_fd_errno_substrings
+        ; test_case "Disk: substrings" `Quick test_classify_string_disk_substrings
+        ; test_case "Permission: substrings" `Quick
+            test_classify_string_permission_substrings
+        ; test_case "Connection refused" `Quick test_classify_string_connection_refused
+        ; test_case "Timeout" `Quick test_classify_string_timeout
+        ; test_case "case-insensitive" `Quick test_classify_string_case_insensitive
+        ; test_case "Other preserves input" `Quick test_classify_string_other_preserves_input
+        ; test_case "empty string" `Quick test_classify_string_empty_input
+        ] )
+    ; ( "classify_exn"
+      , [ test_case "EMFILE" `Quick test_classify_exn_errno_emfile
+        ; test_case "ENFILE" `Quick test_classify_exn_errno_enfile
+        ; test_case "ENOSPC" `Quick test_classify_exn_errno_enospc
+        ; test_case "EACCES" `Quick test_classify_exn_errno_eacces
+        ; test_case "EPERM" `Quick test_classify_exn_errno_eperm
+        ; test_case "ECONNREFUSED" `Quick test_classify_exn_errno_econnrefused
+        ; test_case "ETIMEDOUT" `Quick test_classify_exn_errno_etimedout
+        ; test_case "errno priority over string match" `Quick
+            test_classify_exn_errno_priority_over_string
+        ; test_case "fallback to classify_string" `Quick
+            test_classify_exn_fallback_to_string
+        ] )
+    ; ( "wire format"
+      , [ test_case "to_short_tag covers all variants" `Quick
+            test_to_short_tag_all_variants
+        ; test_case "to_raw_text on Other returns input" `Quick
+            test_to_raw_text_other_returns_input
+        ; test_case "to_raw_text on named returns short label" `Quick
+            test_to_raw_text_named_returns_short_label
+        ] )
+    ]


### PR DESCRIPTION
## Goal

RFC-0154 §5 Phase plan **PR-1 (모듈 + tests, 의존성 없음, dead code 안전)**. Typed closed-sum SSOT 모듈 도입만; caller migration / dashboard cutover 는 PR-2/PR-3.

RFC: #17059 (머지됨)

## What

- \`lib/system_error_class.ml\` — typed closed sum + classify_exn / classify_string / to_short_tag / to_raw_text
- \`lib/system_error_class.mli\` — 공개 contract + 각 variant 의 RFC 참조 docstring
- \`test/test_system_error_class.ml\` — 21 Alcotest 케이스
- \`test/dune\` — \`test_system_error_class\` registration (2 곳)

## Module contract

\`\`\`ocaml
type t =
  | Fd_exhaustion       (* RFC-0097 *)
  | Disk_exhaustion     (* RFC-0122 *)
  | Permission_denied
  | Connection_refused
  | Timeout
  | Other of string     (* parse-don't-validate escape hatch *)

val classify_exn : exn -> t
val classify_string : string -> t
val to_short_tag : t -> string
val to_raw_text : t -> string
\`\`\`

### Errno priority over string match

\`classify_exn\` 의 첫 분기가 \`Unix.Unix_error _\` errno match — \`Printexc.to_string\` 의 free-form output 에 의존하지 않음. 7 errno → variant:

| errno | variant |
|-------|---------|
| EMFILE / ENFILE | Fd_exhaustion |
| ENOSPC | Disk_exhaustion |
| EACCES / EPERM | Permission_denied |
| ECONNREFUSED | Connection_refused |
| ETIMEDOUT | Timeout |

### Substring vocabulary (4 inline matcher union)

\`classify_string\` 가 사용하는 vocabulary 는 RFC-0154 §1.1 의 4 사이트 합집합:

| 사이트 | needles |
|--------|---------|
| \`keeper_fd_pressure.ml:97\` | 6 (FD) |
| \`keeper_disk_pressure.ml:55\` | 6 (Disk) |
| \`coord_utils_ops.ml:410\` | 6 (FD 복붙) |
| \`keeper_stale_watchdog.ml:203\` | 1 (FD 단독) |

본 PR 은 vocabulary 를 *흡수만*. PR-2 가 4 사이트 → SSOT 치환.

### parse-don't-validate

\`Other of string\` 은 *typed escape hatch*, *catch-all 이 아님*. variant 안에 unclassified string 을 *명시적으로* 담아 호출자가 그 상태를 인지하도록 강제.

## Why now (RFC §5 Phase plan PR-1)

- **의존성 없음**: \`String_util.contains_substring_ci\` + \`Unix\` 외 0 의존
- **caller 0**: 본 PR 머지 후 모듈은 dead code 로 잔존 — PR-2 보류 가능하고 단독 revert 안전
- **PR-2 prereq**: \`Telemetry_coverage_gap.record ~error_class\` 시그니처 확장이 본 모듈 의존

## Verification

\`\`\`
dune build @check:    clean (0 warning, 0 error)
dune exec test:       21/21 PASS (5ms)
  classify_string:  9
  classify_exn:     9
  wire format:      3
\`\`\`

테스트 영역:
- classify_string: FD/Disk/Permission/Connection/Timeout 5 클래스 substring 매칭 + case-insensitive + Other 케이스 + 빈 문자열
- classify_exn: 7 errno + errno priority over string match + Sys_error fallback
- wire format: to_short_tag 전체 variant 커버, to_raw_text on Other = 원본 verbatim, to_raw_text on named = canonical short label

## Workaround Rejection Bar self-check

| 항목 | 본 PR |
|------|------|
| §1 텔레메트리-as-fix | ❌ (counter 추가 없음) |
| §2 string/substring 분류기 추가 | ❌ (오히려 4 inline matcher → 1 typed SSOT **dedup** 준비) |
| §3 N-of-M | ❌ (이 자체가 N-of-M 박멸 prereq) |
| §4 catch-all \`_->\` | ❌ (\`Other of string\` 명시) |
| §5 cap/cooldown/dedup/repair | ❌ |
| §6 test backdoor | ❌ |
| §7 같은 typo N-N fix | ❌ |

전부 통과.

## Files

- \`lib/system_error_class.ml\` (신규, 80 LoC)
- \`lib/system_error_class.mli\` (신규, 50 LoC)
- \`test/test_system_error_class.ml\` (신규, 165 LoC)
- \`test/dune\` (registration 2 곳)

\`\`\`
4 files changed, 307 insertions(+)
\`\`\`

## Next (RFC-0154 §5)

- PR-2: \`Telemetry_coverage_gap.record ~error_class\` 시그니처 추가 + 13 caller codemod + 4 inline matcher → SSOT 치환
- PR-3: Dashboard \`classifyCoverageError\` → \`errorClassFromBackend\` lookup
- PR-4: Wire schema v2 (\`error_class\` required)
- Closeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>