### PR TITLE
fix(dashboard): surface 'unknown' repo status instead of silently coercing to 'active'

### DIFF
--- a/dashboard/src/api/repositories.ts
+++ b/dashboard/src/api/repositories.ts
@@ -1,6 +1,6 @@
 import { get, post, type GetOptions } from './core'
 
-export type RepoStatus = 'active' | 'paused' | 'error'
+export type RepoStatus = 'active' | 'paused' | 'error' | 'unknown'
 
 export interface Repository {
   id: string
@@ -17,12 +17,17 @@ export interface Repository {
 }
 
 export function normalizeRepoStatus(raw: string | undefined): RepoStatus {
+  // Anti-pattern §2 escape: previously the `default` arm coerced unknown
+  // statuses to `'active'`, silently hiding malformed wire data. Map only
+  // recognized strings to first-class statuses; anything else surfaces as
+  // `'unknown'` so the UI can render an explicit warning state instead of
+  // pretending the repo is healthy.
   switch (raw?.toLowerCase()) {
     case 'active': return 'active'
     case 'paused': return 'paused'
-    case 'cloning': return 'active'
+    case 'cloning': return 'active' // intermediate state, treated as active
     case 'error': return 'error'
-    default: return 'active'
+    default: return 'unknown'
   }
 }
 

--- a/dashboard/src/components/repo-detail-panel.test.ts
+++ b/dashboard/src/components/repo-detail-panel.test.ts
@@ -140,10 +140,14 @@ describe('normalizeRepoStatus', () => {
     expect(normalizeRepoStatus(input)).toBe(expected)
   })
 
-  it('defaults to active for unknown or undefined input', () => {
-    expect(normalizeRepoStatus(undefined)).toBe('active')
-    expect(normalizeRepoStatus('unknown')).toBe('active')
-    expect(normalizeRepoStatus('')).toBe('active')
+  it("returns 'unknown' for unrecognized or missing input instead of coercing to 'active'", () => {
+    // Anti-pattern §2 escape: the previous default arm silently produced
+    // 'active' for any unrecognized status. 'unknown' now surfaces the
+    // malformed wire data so the UI renders an explicit warning state.
+    expect(normalizeRepoStatus(undefined)).toBe('unknown')
+    expect(normalizeRepoStatus('unknown')).toBe('unknown')
+    expect(normalizeRepoStatus('')).toBe('unknown')
+    expect(normalizeRepoStatus('garbled')).toBe('unknown')
   })
 })
 

--- a/dashboard/src/components/repo-detail-panel.ts
+++ b/dashboard/src/components/repo-detail-panel.ts
@@ -105,6 +105,7 @@ const REPO_STATUS_LABEL: Record<RepoStatus, string> = {
   active: '활성',
   paused: '일시정지',
   error: '오류',
+  unknown: '알 수 없음',
 }
 
 function InfoRow({

--- a/dashboard/src/components/repo-sidebar.test.ts
+++ b/dashboard/src/components/repo-sidebar.test.ts
@@ -15,9 +15,13 @@ describe("normalizeRepoStatus", () => {
   it("maps error", () => {
     expect(normalizeRepoStatus("error")).toBe("error")
   })
-  it("defaults unknown to active", () => {
-    expect(normalizeRepoStatus("unknown")).toBe("active")
-    expect(normalizeRepoStatus(undefined)).toBe("active")
+  it("returns 'unknown' for unrecognized strings instead of silently coercing to 'active'", () => {
+    // Anti-pattern §2 escape: prior behavior coerced any unrecognized
+    // status to 'active', silently hiding malformed wire data. The
+    // 'unknown' variant now surfaces it explicitly so the UI can warn.
+    expect(normalizeRepoStatus("unknown")).toBe("unknown")
+    expect(normalizeRepoStatus(undefined)).toBe("unknown")
+    expect(normalizeRepoStatus("garbled")).toBe("unknown")
   })
   it("is case-insensitive", () => {
     expect(normalizeRepoStatus("ACTIVE")).toBe("active")
@@ -50,12 +54,14 @@ describe("normalizeRepository", () => {
   it("returns null when id and name missing", () => {
     expect(normalizeRepository({})).toBeNull()
   })
-  it("builds minimal repo", () => {
+  it("builds minimal repo with 'unknown' status when wire data lacks status", () => {
+    // Status is now derived from the wire string; a missing field falls
+    // through to 'unknown' instead of being coerced to 'active'.
     const r = normalizeRepository({ id: "r1", name: "Repo" }) as Repository
     expect(r.id).toBe("r1")
     expect(r.name).toBe("Repo")
     expect(r.default_branch).toBe("main")
-    expect(r.status).toBe("active")
+    expect(r.status).toBe("unknown")
     expect(r.auto_sync).toBe(false)
     expect(r.sync_interval).toBe(300)
     expect(r.credential_id).toBeNull()

--- a/dashboard/src/components/repo-sidebar.ts
+++ b/dashboard/src/components/repo-sidebar.ts
@@ -13,7 +13,7 @@ import {
 import { createAsyncResource } from '../lib/async-state'
 import { LoadingState, ErrorState } from './common/feedback-state'
 import { showToast } from './common/toast'
-import { Plus, GitBranch, AlertCircle, PauseCircle, CheckCircle2, Search } from 'lucide-preact'
+import { Plus, GitBranch, AlertCircle, PauseCircle, CheckCircle2, HelpCircle, Search } from 'lucide-preact'
 
 export type { Repository, RepoStatus } from '../api/repositories'
 export {
@@ -105,18 +105,24 @@ function StatusIcon({ status }: { status: RepoStatus }) {
       return html`<${PauseCircle} size=${14} class="text-[var(--color-status-warn)]" aria-hidden="true" />`
     case 'error':
       return html`<${AlertCircle} size=${14} class="text-[var(--color-status-err)]" aria-hidden="true" />`
+    case 'unknown':
+      // Explicit unknown state surfaces malformed/missing wire data instead
+      // of silently coercing it to 'active' (anti-pattern §2 escape).
+      return html`<${HelpCircle} size=${14} class="text-[var(--color-fg-muted)]" aria-hidden="true" />`
   }
 }
 
 function StatusLabel({ status }: { status: RepoStatus }) {
-  const label = status === 'active' ? '활성' : status === 'paused' ? '일시정지' : '오류'
-  const colorClass =
-    status === 'active'
-      ? 'text-[var(--color-status-ok)]'
-      : status === 'paused'
-        ? 'text-[var(--color-status-warn)]'
-        : 'text-[var(--color-status-err)]'
-  return html`<span class="text-2xs font-medium ${colorClass}">${label}</span>`
+  switch (status) {
+    case 'active':
+      return html`<span class="text-2xs font-medium text-[var(--color-status-ok)]">활성</span>`
+    case 'paused':
+      return html`<span class="text-2xs font-medium text-[var(--color-status-warn)]">일시정지</span>`
+    case 'error':
+      return html`<span class="text-2xs font-medium text-[var(--color-status-err)]">오류</span>`
+    case 'unknown':
+      return html`<span class="text-2xs font-medium text-[var(--color-fg-muted)]">알 수 없음</span>`
+  }
 }
 
 // ── Component ────────────────────────────────────────────


### PR DESCRIPTION
## Goal
`normalizeRepoStatus(raw)`의 `default: return 'active'`은 anti-pattern §2 "Unknown → Permissive Default"의 정확한 사례. 잘못된 wire data가 *조용히* 'active'로 표시되어 사용자가 비활성 repo를 활성으로 오인. `RepoStatus`에 `'unknown'` variant 추가해 fail-loud로 전환.

## Changed files (5)
- `dashboard/src/api/repositories.ts` — `RepoStatus` 타입에 `'unknown'` 추가, `normalizeRepoStatus` default 분기를 `'unknown'`으로 전환, 의도된 `'cloning' → 'active'` alias 주석 보존
- `dashboard/src/components/repo-sidebar.ts` — `StatusIcon`/`StatusLabel`에 `'unknown'` 케이스 추가 (`HelpCircle` muted icon + "알 수 없음" 라벨)
- `dashboard/src/components/repo-detail-panel.ts` — `REPO_STATUS_LABEL` Record에 `unknown: '알 수 없음'` 추가
- `dashboard/src/components/repo-sidebar.test.ts` — anti-pattern을 잠그던 2 assertion 정정
- `dashboard/src/components/repo-detail-panel.test.ts` — 동일

## Self-review
- 목표: silent default coercion 제거, 명시적 unknown variant 도입
- 범위: 5 파일, 43+/21-. 컴포넌트 + 테스트 정정. **호출처 모두 exhaustive 처리** (typecheck enforce).
- 동작 변화: **있음 — 의도된 user-visible** 회귀 회복:
  - 이전: 알 수 없는 status가 UI에서 green check + "활성"으로 표시 (silent)
  - 이후: 알 수 없는 status가 UI에서 muted HelpCircle + "알 수 없음"으로 표시 (loud)
- 로컬 검증:
  - `pnpm run typecheck` — 0 errors (모든 `RepoStatus` 소비자 exhaustive)
  - `pnpm vitest run src/api/repositories src/components/repo-sidebar src/components/repo-detail-panel` — **51/51 passed**

## 안티패턴 §2 사례 발견 경로
audit agent 작업으로 발견: OCaml은 lint ratchet으로 0건 violation, TypeScript에 2 HIGH severity 사이트 잔존. 이번 PR이 그 첫 번째. 두 번째(`journal-entry.ts::normalizeJournalSource`)는 별도 PR.

## 테스트 *역설* 발견
기존 테스트 2건 (`repo-sidebar.test.ts:18-21` + `repo-detail-panel.test.ts:143-147`)이 *anti-pattern §2 동작 자체를 assertion으로 잠금* — `expect(normalizeRepoStatus('unknown')).toBe('active')`. 본 PR은 해당 assertion을 fail-loud 버전으로 정정하고 `'garbled'` 추가 fixture로 closed-set guard 확장.

## References
- 본 세션 #17029 (agent-roster paused count silent regression — 동일 패턴)
- 최근 main의 typed-match recovery: #17057 / #17058 / #17059 / RFC-0126 / RFC-0153 / RFC-0154
- audit 보고: task #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)