### PR TITLE
fix(cdal): bound proof health scan

### DIFF
--- a/lib/cdal_runtime_health.ml
+++ b/lib/cdal_runtime_health.ml
@@ -105,6 +105,43 @@ let take n xs =
   loop n [] xs
 ;;
 
+let all_digits value =
+  let rec loop i =
+    i = String.length value
+    || match value.[i] with
+       | '0' .. '9' -> loop (i + 1)
+       | _ -> false
+  in
+  not (String.equal value "") && loop 0
+;;
+
+let cdal_run_id_timestamp run_id =
+  match String.split_on_char '-' run_id with
+  | "cdal" :: ts :: _ when all_digits ts -> Some ts
+  | _ -> None
+;;
+
+let compare_numeric_string left right =
+  match Int.compare (String.length left) (String.length right) with
+  | 0 -> String.compare left right
+  | cmp -> cmp
+;;
+
+let compare_run_id_recent_first left right =
+  match cdal_run_id_timestamp left, cdal_run_id_timestamp right with
+  | Some left_ts, Some right_ts ->
+      let cmp = compare_numeric_string right_ts left_ts in
+      if cmp = 0 then String.compare left right else cmp
+  | Some _, None -> -1
+  | None, Some _ -> 1
+  | None, None -> String.compare left right
+;;
+
+let bounded_recent_run_ids ~scan_limit run_ids =
+  let scan_limit = max 0 scan_limit in
+  run_ids |> List.sort compare_run_id_recent_first |> take scan_limit
+;;
+
 let proof_root_default () = Proof_store.default_config.root
 
 let proof_root_candidates configured_root =
@@ -127,11 +164,14 @@ let proof_completeness_json
       ?(stale_incomplete_grace_seconds = 300.0)
       config
   =
+  let scan_limit = max 0 scan_limit in
   let proofs_dir = Proof_store.proofs_dir config in
   if not (is_dir proofs_dir)
   then
     `Assoc
       [ "scan_limit", `Int scan_limit
+      ; "run_dir_entries_seen", `Int 0
+      ; "scan_truncated", `Bool false
       ; "run_dirs_scanned", `Int 0
       ; "completed_run_dirs", `Int 0
       ; "incomplete_run_dirs", `Int 0
@@ -146,8 +186,11 @@ let proof_completeness_json
       try Sys.readdir proofs_dir |> Array.to_list with
       | Sys_error _ -> []
     in
+    let run_dir_entries_seen = List.length run_ids in
+    let scan_truncated = run_dir_entries_seen > scan_limit in
+    let bounded_run_ids = bounded_recent_run_ids ~scan_limit run_ids in
     let run_infos =
-      run_ids
+      bounded_run_ids
       |> List.filter (fun run_id -> is_dir (proof_run_dir config ~run_id))
       |> List.filter_map (fun run_id ->
         match run_latest_mtime config ~run_id with
@@ -181,6 +224,8 @@ let proof_completeness_json
       run_infos;
     `Assoc
       [ "scan_limit", `Int scan_limit
+      ; "run_dir_entries_seen", `Int run_dir_entries_seen
+      ; "scan_truncated", `Bool scan_truncated
       ; "run_dirs_scanned", `Int (List.length run_infos)
       ; "completed_run_dirs", `Int !completed
       ; "incomplete_run_dirs", `Int !incomplete

--- a/test/test_cdal_runtime_health_15748.ml
+++ b/test/test_cdal_runtime_health_15748.ml
@@ -118,6 +118,13 @@ let member_int key json =
     Alcotest.failf "expected int field %s, got %s" key (Yojson.Safe.to_string other)
 ;;
 
+let member_bool key json =
+  match Yojson.Safe.Util.member key json with
+  | `Bool value -> value
+  | other ->
+    Alcotest.failf "expected bool field %s, got %s" key (Yojson.Safe.to_string other)
+;;
+
 let list_field key json =
   match Yojson.Safe.Util.member key json with
   | `List values -> values
@@ -310,6 +317,53 @@ let test_recent_incomplete_proof_store_is_in_flight () =
     (member_int "stale_incomplete_run_dirs" (nested "completeness" proof_store))
 ;;
 
+let test_proof_scan_limit_caps_recent_run_walk () =
+  with_temp_dir @@ fun dir ->
+  let base_dir = Filename.concat dir "cdal_verdicts" in
+  let proof_root = Filename.concat dir ".oas" in
+  let now = Time_compat.now () in
+  ignore
+    (write_ledger_row
+       ~base_dir
+       ~mtime:now
+       (`Assoc [ "_task_id", `String "task-15748"; "run_id", `String "run-task" ]));
+  for i = 0 to 29 do
+    make_proof_run
+      ~mtime:(now -. 100.0)
+      ~manifest:true
+      ~contract:true
+      proof_root
+      (Printf.sprintf "cdal-%013d-complete" (1000 + i))
+  done;
+  make_proof_run
+    ~mtime:(now -. 1000.0)
+    proof_root
+    "cdal-9999999999999-stale-incomplete";
+  let json =
+    H.snapshot_json
+      ~base_dir
+      ~proof_root
+      ~now
+      ~stale_age_seconds:600.0
+      ~recent_limit:20
+      ~proof_scan_limit:5
+      ~stale_incomplete_run_seconds:300.0
+      ()
+  in
+  Alcotest.(check string)
+    "writer_status"
+    "proof_store_incomplete"
+    (member_string "writer_status" json);
+  let completeness = nested "completeness" (nested "proof_store" json) in
+  Alcotest.(check int) "entries seen" 31 (member_int "run_dir_entries_seen" completeness);
+  Alcotest.(check bool) "scan truncated" true (member_bool "scan_truncated" completeness);
+  Alcotest.(check int) "run dirs scanned" 5 (member_int "run_dirs_scanned" completeness);
+  Alcotest.(check int)
+    "stale incomplete run count"
+    1
+    (member_int "stale_incomplete_run_dirs" completeness)
+;;
+
 let test_dormant_writer_status () =
   with_temp_dir @@ fun dir ->
   let base_dir = Filename.concat dir "cdal_verdicts" in
@@ -407,6 +461,10 @@ let () =
             "recent incomplete proof store is in flight"
             `Quick
             test_recent_incomplete_proof_store_is_in_flight
+        ; Alcotest.test_case
+            "proof scan limit caps recent run walk"
+            `Quick
+            test_proof_scan_limit_caps_recent_run_walk
         ; Alcotest.test_case "dormant" `Quick test_dormant_writer_status
         ; Alcotest.test_case
             "alternate proof stores ignore home .oas"


### PR DESCRIPTION
## Summary
- bound CDAL proof completeness scans before per-run stat walks
- sort CDAL run IDs by embedded timestamp so the bounded sample still favors recent runs
- expose scan_truncated/run_dir_entries_seen in the health JSON

## Verification
- scripts/dune-local.sh build test/test_cdal_runtime_health_15748.exe
- ./_build/default/test/test_cdal_runtime_health_15748.exe