### PR TITLE
fix(keeper): recover legacy capacity pauses

### DIFF
--- a/lib/keeper/keeper_supervisor_types.ml
+++ b/lib/keeper/keeper_supervisor_types.ml
@@ -119,9 +119,20 @@ let paused_meta_requires_reconcile_recovery (meta : keeper_meta) =
   | None -> false
 ;;
 
+let paused_meta_is_legacy_capacity_auto_pause (meta : keeper_meta) =
+  meta.paused
+  && Option.is_none meta.auto_resume_after_sec
+  &&
+  match meta.runtime.last_blocker with
+  | Some info -> info.klass = Capacity_exhausted
+  | None -> false
+;;
+
 let paused_meta_auto_resume_due ~now (meta : keeper_meta) =
   if (not meta.paused) || paused_meta_requires_reconcile_recovery meta
   then false
+  else if paused_meta_is_legacy_capacity_auto_pause meta
+  then true
   else
     match meta.auto_resume_after_sec with
     | None -> false

--- a/lib/keeper/keeper_supervisor_types.mli
+++ b/lib/keeper/keeper_supervisor_types.mli
@@ -63,10 +63,12 @@ val paused_meta_requires_reconcile_recovery : keeper_meta -> bool
 
 val paused_meta_auto_resume_due : now:float -> keeper_meta -> bool
 (** True when [meta] is an auto-paused keeper whose self-healing backoff has
-    elapsed.  Intentional/operator pauses ([auto_resume_after_sec = None])
-    and reconcile-gated pauses are excluded.  This pure predicate deliberately
-    does not inspect cascade health or approval queues; callers that can see
-    those runtime surfaces must still apply them before mutating state. *)
+    elapsed.  Intentional/operator pauses ([auto_resume_after_sec = None]) are
+    excluded unless the meta matches the legacy capacity-exhausted auto-pause
+    shape written before the resume-policy field was populated. Reconcile-gated
+    pauses are always excluded.  This pure predicate deliberately does not
+    inspect cascade health or approval queues; callers that can see those
+    runtime surfaces must still apply them before mutating state. *)
 
 val cohort_key_of_reason : Keeper_registry.failure_reason option -> string
 (** Map a structured failure_reason to a cohort key for self-preservation grouping. *)

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -129,6 +129,11 @@ let () =
           Alcotest.test_case "keeper up resumes auto-paused keeper" `Quick
             Test_operator_control_keeper.test_keeper_up_resumes_auto_paused_keeper;
           Alcotest.test_case
+            "legacy capacity pause without backoff is auto-recoverable"
+            `Quick
+            Test_operator_control_keeper
+            .test_legacy_capacity_pause_without_backoff_is_auto_recoverable;
+          Alcotest.test_case
             "keeper up keeps paused keeper behind continue gate" `Quick
             Test_operator_control_keeper
             .test_keeper_up_keeps_paused_keeper_with_continue_gate_blocker;

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -1500,6 +1500,61 @@ let test_keeper_up_resumes_auto_paused_keeper () =
         (Option.is_none
            (Masc_mcp.Keeper_turn_livelock.current_state ~keeper:keeper_name)))
 
+let test_legacy_capacity_pause_without_backoff_is_auto_recoverable () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  let base_dir = temp_dir () in
+  let keeper_name = "legacy-capacity-paused-keeper" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      let meta =
+        seed_keeper_meta_exn config keeper_name
+          ~goal:"Recover a legacy capacity pause"
+      in
+      let paused_with blocker =
+        {
+          meta with
+          paused = true;
+          auto_resume_after_sec = None;
+          runtime = { meta.runtime with last_blocker = blocker };
+        }
+      in
+      let legacy_capacity =
+        paused_with
+          (Some (Keeper_types.blocker_info_of_class
+                   ~detail:"legacy capacity pause"
+                   Keeper_types.Capacity_exhausted))
+      in
+      let operator_pause = paused_with None in
+      let continue_gate_pause =
+        paused_with
+          (Some (Keeper_types.blocker_info_of_class
+                   ~detail:"mutating tool timed out"
+                   Keeper_types.Ambiguous_post_commit_timeout))
+      in
+      let due meta =
+        Keeper_supervisor_types.paused_meta_auto_resume_due
+          ~now:1900000000.0 meta
+      in
+      Alcotest.(check bool)
+        "legacy capacity pause without backoff is recoverable"
+        true
+        (due legacy_capacity);
+      Alcotest.(check bool)
+        "operator pause without blocker stays manual"
+        false
+        (due operator_pause);
+      Alcotest.(check bool)
+        "continue-gated pause stays manual"
+        false
+        (due continue_gate_pause))
+
 let test_keeper_up_keeps_paused_keeper_with_continue_gate_blocker () =
   Eio_main.run @@ fun env ->
   ensure_fs env;


### PR DESCRIPTION
Closes #17063

## Summary
- Treat legacy paused=true capacity_exhausted meta with missing auto_resume_after_sec as auto-recoverable.
- Keep operator/manual pauses and continue-gated pauses manual.
- Add focused operator-control coverage.

## Verification
- opam exec -- ocamlformat --check lib/keeper/keeper_supervisor_types.ml lib/keeper/keeper_supervisor_types.mli test/test_operator_control_keeper.ml test/test_operator_control.ml
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_operator_control.exe
- ./_build/default/test/test_operator_control.exe test --color=never --show-errors operator 33