### PR TITLE
fix(dashboard): surface 'unknown' journal source instead of silently coercing to 'sse'

### DIFF
--- a/dashboard/src/journal-entry.test.ts
+++ b/dashboard/src/journal-entry.test.ts
@@ -4,6 +4,7 @@ import {
   isErrorJournalEntry,
   journalSeverity,
   normalizeJournalSeverity,
+  normalizeJournalSource,
 } from './journal-entry'
 import type { JournalEntry } from './types'
 
@@ -34,5 +35,31 @@ describe('journal severity helpers', () => {
     expect(journalSeverity(makeEntry({ eventType: 'broadcast', text: '[WARN] retrying stream reconnect' }))).toBe('info')
     expect(journalSeverity(makeEntry({ eventType: 'broadcast', text: 'error budget update' }))).toBe('info')
     expect(journalSeverity(makeEntry({ eventType: 'broadcast', text: '' }))).toBe('info')
+  })
+})
+
+describe('normalizeJournalSource', () => {
+  it('maps each recognized source string to its first-class variant', () => {
+    expect(normalizeJournalSource('structured')).toBe('structured')
+    expect(normalizeJournalSource('legacy_stderr')).toBe('legacy_stderr')
+    expect(normalizeJournalSource('legacy_traceln')).toBe('legacy_traceln')
+    expect(normalizeJournalSource('sse')).toBe('sse')
+  })
+
+  it('is case-insensitive and trims whitespace', () => {
+    expect(normalizeJournalSource('  Structured ')).toBe('structured')
+    expect(normalizeJournalSource('SSE')).toBe('sse')
+  })
+
+  it("returns 'unknown' for unrecognized strings instead of silently coercing to 'sse'", () => {
+    // Anti-pattern §2 escape: the previous default arm classified every
+    // unrecognized source as a normal SSE event, so a malformed wire
+    // record looked indistinguishable from a real SSE entry downstream.
+    // The 'unknown' variant surfaces the parse failure explicitly.
+    expect(normalizeJournalSource(null)).toBe('unknown')
+    expect(normalizeJournalSource(undefined)).toBe('unknown')
+    expect(normalizeJournalSource('')).toBe('unknown')
+    expect(normalizeJournalSource('garbled')).toBe('unknown')
+    expect(normalizeJournalSource('streamed')).toBe('unknown')
   })
 })

--- a/dashboard/src/journal-entry.ts
+++ b/dashboard/src/journal-entry.ts
@@ -22,6 +22,11 @@ export function normalizeJournalSeverity(value: string | null | undefined): Jour
 }
 
 export function normalizeJournalSource(value: string | null | undefined): JournalSource {
+  // Anti-pattern §2 escape: the prior default arm silently coerced
+  // unrecognized values to `'sse'`, classifying malformed wire data as a
+  // normal SSE event. Mirror `normalizeJournalSeverity`'s explicit
+  // `'unknown'` variant so downstream filters/UI can tell when a journal
+  // record arrived with a source we cannot parse.
   switch ((value ?? '').trim().toLowerCase()) {
     case 'structured':
       return 'structured'
@@ -29,8 +34,10 @@ export function normalizeJournalSource(value: string | null | undefined): Journa
       return 'legacy_stderr'
     case 'legacy_traceln':
       return 'legacy_traceln'
-    default:
+    case 'sse':
       return 'sse'
+    default:
+      return 'unknown'
   }
 }
 

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -81,7 +81,11 @@ export type SSEEventType =
   | 'oas:masc:audit_event'
 
 export type JournalSeverity = 'debug' | 'info' | 'warn' | 'error' | 'unknown'
-export type JournalSource = 'structured' | 'legacy_stderr' | 'legacy_traceln' | 'sse'
+// Closed set of journal sources. `'unknown'` is a first-class variant
+// (mirroring JournalSeverity) so that `normalizeJournalSource` can fail
+// loud on unrecognized wire data instead of silently coercing it to
+// `'sse'`. Source of truth: see `normalizeJournalSource` in journal-entry.ts.
+export type JournalSource = 'structured' | 'legacy_stderr' | 'legacy_traceln' | 'sse' | 'unknown'
 
 // --- Attribution envelope ---
 // Structured verdict metadata for gate decisions. Emitted alongside existing


### PR DESCRIPTION
## Goal
`normalizeJournalSource(value)`의 `default: return 'sse'`는 anti-pattern §2 "Unknown → Permissive Default". 잘못된 wire data가 *정상 SSE event*로 분류되어 분석/필터링이 잘못된 카테고리로 라우팅. `JournalSeverity`가 이미 가진 `'unknown'` variant 패턴을 `JournalSource`에도 도입.

## Changed files (3)
- `dashboard/src/types/sse.ts` — `JournalSource` 유니온에 `'unknown'` 추가 + SSOT 주석
- `dashboard/src/journal-entry.ts` — `normalizeJournalSource` default를 `'unknown'`으로 전환, `'sse'`도 명시적 case로 (이전엔 default가 흡수)
- `dashboard/src/journal-entry.test.ts` — regression-lock 3 describe 블록 추가 (recognized 4값 / case+trim / fail-loud 5값)

## Self-review
- 목표: silent default 제거, 명시적 typed variant 도입 (`JournalSeverity` 패턴 정합)
- 범위: 3 파일, 40+/2-. 컴포넌트 미터치 (JournalEntry.source가 optional)
- 동작 변화: **있음 — 의도된 회복**:
  - 이전: 알 수 없는 source string이 'sse'로 분류 → SSE 카테고리에 noise 누적
  - 이후: 'unknown'으로 분류 → 명시적 분리 가능
- 로컬 검증:
  - `pnpm run typecheck` — 0 errors (JournalEntry.source optional이라 consumer 변경 불필요)
  - `pnpm vitest run src/journal-entry src/sse` — **31/31 passed** (기존 28 + 신규 3)

## 짝 PR (anti-pattern §2 sweep)
| PR | 사이트 | default 변화 |
|---|---|---|
| #17065 | `normalizeRepoStatus` | silent 'active' → 'unknown' |
| **이 PR** | `normalizeJournalSource` | silent 'sse' → 'unknown' |

이 2 PR이 audit이 식별한 2 HIGH severity 사이트 모두 닫음. 나머지 8 LOW는 UI color/fallback으로 safe-by-design.

## References
- 본 세션 #17029 (paused count silent regression — 동일 패턴)
- OCaml 측 RFC-0126/RFC-0153/RFC-0154 typed-match sweep
- audit task #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)