### PR TITLE
ci(release): restore macOS native deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,12 +51,26 @@ jobs:
           scripts/opam-pin-external-deps.sh --with-compact-protocol
 
 
-      - name: Install libpq (macOS)
+      - name: Install native dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew install libpq
-          echo "$(brew --prefix libpq)/bin" >> "$GITHUB_PATH"
-          echo "PKG_CONFIG_PATH=$(brew --prefix libpq)/lib/pkgconfig" >> "$GITHUB_ENV"
+          brew install libpq openssl@3
+
+          libpq_prefix="$(brew --prefix libpq)"
+          openssl_prefix="$(brew --prefix openssl@3)"
+
+          {
+            echo "$libpq_prefix/bin"
+            echo "$openssl_prefix/bin"
+          } >> "$GITHUB_PATH"
+
+          {
+            echo "PKG_CONFIG_PATH=$openssl_prefix/lib/pkgconfig:$libpq_prefix/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+            echo "CPATH=$openssl_prefix/include:${CPATH:-}"
+            echo "LIBRARY_PATH=$openssl_prefix/lib:${LIBRARY_PATH:-}"
+            echo "CPPFLAGS=-I$openssl_prefix/include ${CPPFLAGS:-}"
+            echo "LDFLAGS=-L$openssl_prefix/lib ${LDFLAGS:-}"
+          } >> "$GITHUB_ENV"
 
       - name: Refresh apt index
         if: runner.os == 'Linux'

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Current package version: v0.19.27
 > Latest changelog entry: v0.19.27 (2026-05-20)
-> Latest published GitHub release: v0.19.22 (2026-05-17)
+> Latest published GitHub release: v0.19.27 (2026-05-20)
 > Updated: 2026-05-20
 
 This roadmap is the 6-8 week operating view for `masc-mcp`.

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -11,7 +11,7 @@ code_refs:
 
 > Current package version: v0.19.27
 > Latest changelog entry: v0.19.27 (2026-05-20)
-> Latest published GitHub release: v0.19.22 (2026-05-17)
+> Latest published GitHub release: v0.19.27 (2026-05-20)
 > Updated: 2026-05-20
 > Release line: pre-1.0 (`0.y.z`); legacy `v2.*` tags are frozen history
 


### PR DESCRIPTION
## Summary
- install openssl@3 with libpq for the macOS release build lane
- export OpenSSL pkg-config, include, and library search paths for piaf C stubs
- sync ROADMAP and product plan published release truth to v0.19.27

## Verification
- scripts/check-version-truth.sh
- bash scripts/check-doc-truth.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'
- git diff --check