### PR TITLE
fix(gh): require operator gate for pr ready and merge

### DIFF
--- a/lib/gh_command_validation.ml
+++ b/lib/gh_command_validation.ml
@@ -32,13 +32,14 @@ let gh_allowed_commands =
     - [R0_Read]: no state mutation. gh view/list, api GET, status,
       search. Free to run; only org allowlist gate.
     - [R1_Reversible]: mutates state but recoverable via inverse op.
-      pr create/close/reopen/merge/ready/comment/edit, issue
+      pr create/close/reopen/comment/edit, issue
       create/close/reopen, label create/delete, run cancel. Allowed
       + caller is expected to emit an audit event.
     - [R2_Irreversible]: cannot be undone via a gh inverse op.
-      repo delete/archive/transfer/rename, release delete, secret
-      delete, auth logout/token, ssh-key delete, workflow disable,
-      api --method DELETE, graphql mutation delete*/remove*/transfer*.
+      pr merge/ready, repo delete/archive/transfer/rename, release
+      delete, secret delete, auth logout/token, ssh-key delete,
+      workflow disable, api --method DELETE, graphql mutation
+      delete*/remove*/transfer*.
       Must route through a structured keeper tool that carries
       operator-approval semantics. *)
 type gh_reversibility =
@@ -57,6 +58,7 @@ let string_of_gh_reversibility = function
     re-registrable but signing/deploy keys mid-CI break. *)
 let gh_irreversible_ops =
   [
+    ("pr",       ["merge"; "ready"]);
     ("repo",     ["delete"; "archive"; "transfer"; "rename"]);
     ("release",  ["delete"]);
     ("secret",   ["delete"; "remove"]);
@@ -73,8 +75,8 @@ let gh_irreversible_ops =
     Allowed via op=gh but callers should audit. *)
 let gh_reversible_mutations =
   [
-    ("pr",      ["create"; "close"; "reopen"; "merge"; "ready";
-                 "edit"; "comment"; "review"; "lock"; "unlock"]);
+    ("pr",      ["create"; "close"; "reopen"; "edit"; "comment";
+                 "review"; "lock"; "unlock"]);
     ("issue",   ["create"; "close"; "reopen"; "edit"; "comment";
                  "lock"; "unlock"; "develop"; "pin"; "unpin"]);
     ("label",   ["create"; "edit"; "delete"; "clone"]);
@@ -335,6 +337,11 @@ let classify_gh_reversibility cmd =
     to a generic message. *)
 let structured_tool_hint_for_r2 cmd =
   match extract_gh_command_pair cmd with
+  | (Some "pr", Some ("merge" | "ready")) ->
+    Some "Do not use generic gh for PR ready/merge on agent PRs. \
+          Use the environment-gated Approve Agent PR workflow after \
+          human review, then merge only after required checks are green \
+          and hard-stop labels are gone."
   | (Some "repo", Some ("delete" | "archive" | "transfer" | "rename")) ->
     Some "Use an operator-approved path: open a board post describing \
           the intent and wait for operator action. No keeper tool \

--- a/lib/gh_command_validation.mli
+++ b/lib/gh_command_validation.mli
@@ -33,7 +33,8 @@ type gh_reversibility =
       (** Read-only command; no mutation possible. *)
   | R1_Reversible
       (** Mutating command whose effect can be undone (PR/issue
-          merge or close, comment edit, label apply). *)
+          close, comment edit, label apply). PR ready/merge is
+          operator-only for agent safety. *)
   | R2_Irreversible
       (** Mutating command that destroys state [gh] cannot
           restore (repo / release / secret / ssh-key / auth /
@@ -90,10 +91,10 @@ val is_gh_dangerous_operation : string -> bool
     delete-or-transfer mutations). *)
 
 val is_gh_workflow_operation : string -> bool
-(** [true] iff the command is a normal workflow mutation
+(** [true] iff the command is a workflow mutation
     (pr merge / pr close / issue close / project close / api
-    /merge or state=closed). Legitimate for coding-preset keepers
-    but still gated for lower-privilege presets. *)
+    /merge or state=closed). PR ready/merge is additionally classified
+    as R2/operator-only so generic keeper gh cannot bypass draft gates. *)
 
 val is_gh_pr_merge : string -> bool
 (** [true] iff the command is specifically [gh pr merge ...]. *)

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -961,6 +961,18 @@ let () =
         | Error msg ->
           Alcotest.(check bool) "archive blocked" true
             (contains_substring msg "blocked for safety"));
+      Alcotest.test_case "rejects generic pr ready" `Quick (fun () ->
+        match Worker_dev_tools.validate_gh_command "pr ready 123" with
+        | Ok () -> Alcotest.fail "expected pr ready blocked"
+        | Error msg ->
+          Alcotest.(check bool) "ready blocked" true
+            (contains_substring msg "blocked for safety"));
+      Alcotest.test_case "rejects generic pr merge" `Quick (fun () ->
+        match Worker_dev_tools.validate_gh_command "pr merge 123 --squash" with
+        | Ok () -> Alcotest.fail "expected pr merge blocked"
+        | Error msg ->
+          Alcotest.(check bool) "merge blocked" true
+            (contains_substring msg "blocked for safety"));
       Alcotest.test_case "skips org check when allowed_orgs empty" `Quick (fun () ->
         match
           Worker_dev_tools.validate_gh_command ~allowed_orgs:[]
@@ -1065,10 +1077,6 @@ let () =
           (Worker_dev_tools.classify_gh_reversibility
              "pr create --title foo --body bar"
            = Worker_dev_tools.R1_Reversible));
-      Alcotest.test_case "R1: pr merge" `Quick (fun () ->
-        Alcotest.(check bool) "R1" true
-          (Worker_dev_tools.classify_gh_reversibility "pr merge 123 --squash"
-           = Worker_dev_tools.R1_Reversible));
       Alcotest.test_case "R1: issue close" `Quick (fun () ->
         Alcotest.(check bool) "R1" true
           (Worker_dev_tools.classify_gh_reversibility "issue close 456"
@@ -1093,6 +1101,14 @@ let () =
            = Worker_dev_tools.R1_Reversible));
 
       (* R2 — irreversible *)
+      Alcotest.test_case "R2: pr merge" `Quick (fun () ->
+        Alcotest.(check bool) "R2" true
+          (Worker_dev_tools.classify_gh_reversibility "pr merge 123 --squash"
+           = Worker_dev_tools.R2_Irreversible));
+      Alcotest.test_case "R2: pr ready" `Quick (fun () ->
+        Alcotest.(check bool) "R2" true
+          (Worker_dev_tools.classify_gh_reversibility "pr ready 123"
+           = Worker_dev_tools.R2_Irreversible));
       Alcotest.test_case "R2: repo delete" `Quick (fun () ->
         Alcotest.(check bool) "R2" true
           (Worker_dev_tools.classify_gh_reversibility "repo delete jeong-sik/foo"


### PR DESCRIPTION
## Summary

- Classify generic `gh pr ready` and `gh pr merge` as R2/operator-only.
- Make `validate_gh_command` reject those commands in the generic keeper `op=gh` path.
- Add focused tests so the draft/merge bypass cannot return through the reversible mutation classifier.

## Product impact

Agent-authored PRs should no longer be able to bypass draft, hard-stop label, and CI policy by calling generic `gh pr ready` or `gh pr merge`. Those actions must go through the explicit human approval workflow.

## Evidence

Issue #17017 showed that wrapper-created draft PRs could still be marked ready and merged through an admin/user-token path even when:

- the PR had `agent-pr` and `do-not-merge`
- the immediate `Draft Auto-Merge Guard` status was failing
- the PR Automation guard check was failing

The latest reproduction was PR #17060.

## Review evidence

- `ocamlformat --check lib/gh_command_validation.ml lib/gh_command_validation.mli test/test_worker_dev_tools.ml`
- `git diff --check origin/main`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_worker_dev_tools.exe test/test_keeper_bash_retry_deterministic_close.exe test/test_keeper_github_read_only.exe`

## Linked issue

Fixes #17017.
