### PR TITLE
test(dashboard/ide): align board mock shape with fetchBoard v1 schema

### DIFF
--- a/dashboard/src/components/ide/ide-conversation-rail.test.ts
+++ b/dashboard/src/components/ide/ide-conversation-rail.test.ts
@@ -17,7 +17,10 @@ import type { BoardPost } from '../../types/core'
 function stubEmptyConversationFetch(): void {
   vi.stubGlobal('fetch', vi.fn(async (url: string) => {
     if (url.startsWith('/api/v1/board')) {
-      return new Response(JSON.stringify([]), {
+      // `fetchBoard()` expects the v1 schema `{ posts: [...] }` shape
+      // (board.ts:707-712). Raw `[]` left `raw.posts` undefined and the
+      // rail never picked up the mocked thread; mocks updated to match.
+      return new Response(JSON.stringify({ posts: [] }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       })
@@ -222,7 +225,7 @@ describe('IdeConversationRail', () => {
   it('uses one replay cursor for thread, decision, and cascade rail items', async () => {
     const fetchMock = vi.fn(async (url: string) => {
       if (url.startsWith('/api/v1/board')) {
-        return new Response(JSON.stringify([
+        return new Response(JSON.stringify({ posts: [
           {
             id: 'thread-old',
             author: 'sangsu',
@@ -249,7 +252,7 @@ describe('IdeConversationRail', () => {
             created_at: '2026-05-05T10:03:00Z',
             updated_at: '2026-05-05T10:03:00Z',
           },
-        ]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        ] }), { status: 200, headers: { 'Content-Type': 'application/json' } })
       }
       if (url.startsWith('/api/v1/dashboard/keeper-decisions')) {
         return new Response(JSON.stringify({
@@ -331,7 +334,7 @@ describe('IdeConversationRail', () => {
     }
     vi.stubGlobal('fetch', vi.fn(async (url: string) => {
       if (url.startsWith('/api/v1/board')) {
-        return new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        return new Response(JSON.stringify({ posts: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } })
       }
       if (url.startsWith('/api/v1/dashboard/keeper-decisions')) {
         return new Response(JSON.stringify({
@@ -422,7 +425,7 @@ describe('IdeConversationRail', () => {
   it('focuses the editor line when a line-anchored board thread is clicked', async () => {
     vi.stubGlobal('fetch', vi.fn(async (url: string) => {
       if (url.startsWith('/api/v1/board')) {
-        return new Response(JSON.stringify([{
+        return new Response(JSON.stringify({ posts: [{
           id: 'thread-line',
           author: 'scholar',
           title: 'Review lib/runtime.ml:42',
@@ -434,7 +437,7 @@ describe('IdeConversationRail', () => {
           comment_count: 2,
           created_at: '2026-05-05T10:00:00Z',
           updated_at: '2026-05-05T10:00:00Z',
-        }]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        }] }), { status: 200, headers: { 'Content-Type': 'application/json' } })
       }
       if (url.startsWith('/api/v1/dashboard/keeper-decisions')) {
         return new Response(JSON.stringify({ events: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } })
@@ -479,7 +482,7 @@ describe('IdeConversationRail', () => {
   it('renders route links for board thread code, planning, review, and keeper context', async () => {
     vi.stubGlobal('fetch', vi.fn(async (url: string) => {
       if (url.startsWith('/api/v1/board')) {
-        return new Response(JSON.stringify([{
+        return new Response(JSON.stringify({ posts: [{
           id: 'thread-line',
           author: 'scholar',
           title: 'Review lib/runtime.ml:42',
@@ -491,7 +494,7 @@ describe('IdeConversationRail', () => {
           comment_count: 2,
           created_at: '2026-05-05T10:00:00Z',
           updated_at: '2026-05-05T10:00:00Z',
-        }]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        }] }), { status: 200, headers: { 'Content-Type': 'application/json' } })
       }
       if (url.startsWith('/api/v1/dashboard/keeper-decisions')) {
         return new Response(JSON.stringify({ events: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } })


### PR DESCRIPTION
## Goal
origin/main에서 `ide-conversation-rail.test.ts` 3 테스트가 fail 중 (vitest baseline 위반). 본 PR이 root cause인 mock shape mismatch를 정정.

## Bug
`fetchBoard()` (`src/api/board.ts:707-712`)는 v1 스키마 `{ posts: [...] }`를 받음:
```ts
const raw = await get<{ posts?: unknown[] }>(`/api/v1/board${qs ? `?${qs}` : ''}`)
const posts = Array.isArray(raw.posts) ? raw.posts.map(...).filter(...) : []
```

`ide-conversation-rail.test.ts`는 5 위치에서 `JSON.stringify([...])`로 bare array를 응답 → `raw.posts === undefined` → `posts = []` → rail에 "no conversation activity" 렌더 → 3 assertion fail.

## Changed files (1)
- `dashboard/src/components/ide/ide-conversation-rail.test.ts` — 11+/8-, 5 mock 위치 모두 `{ posts: [...] }` shape으로 wrap + 첫 위치(stubEmptyConversationFetch)에 schema contract 주석

## Self-review
- 목표: vitest baseline 회복. dashboard CI job 차단 해소.
- 범위: 1 파일, test mock only. **production 코드 무변경**.
- 동작 변화: 0 (mock 정정만, 컴포넌트/API 무변경)
- 로컬 검증: `pnpm vitest run src/components/ide/ide-conversation-rail.test.ts` — **9/9 passed** (이전 3 fail / 6 pass)

## 영향
이 fail은 origin/main에서 reproducible — 본 세션 PR과 무관한 *베이스라인 회귀*. dashboard 파일 건드리는 모든 in-flight PR (예: #17068)의 CI Dashboard job이 자동 fail되던 원인. 머지 시 그 PR들의 CI도 회복.

## Probable root cause (참고)
recent dashboard PR sweep (예: #16809 `replace raw fetch() with api/core SSOT utilities`, #16986 `replace local BoardPost type`, #17005 `type generic board post fixture`)이 fetchBoard wire schema를 v1로 정렬하면서 ide-conversation-rail.test.ts mock 정정을 누락. 본 PR이 그 누락 마무리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)