### PR TITLE
test(dashboard): repair runtime truth drift checks

### DIFF
--- a/dashboard/src/components/agents-unified.test.ts
+++ b/dashboard/src/components/agents-unified.test.ts
@@ -174,7 +174,7 @@ describe('AgentsUnified', () => {
     expect(container.textContent).toContain('runtime truth')
     expect(container.textContent).toContain('활성 keeper 2')
     expect(container.textContent).toContain('설정 keeper 4')
-    expect(container.textContent).toContain('일시정지/미기동 2')
+    expect(container.textContent).toContain('미기동 2')
   })
 
   it('shows runtime truth banner without delta when live equals configured', () => {
@@ -185,7 +185,7 @@ describe('AgentsUnified', () => {
     }))
     render(h(AgentsUnified, null), container)
     expect(container.textContent).toContain('runtime truth')
-    expect(container.textContent).not.toContain('일시정지/미기동')
+    expect(container.textContent).not.toContain('미기동')
   })
 
   it('hides runtime truth banner when no configured baseline is available', () => {

--- a/dashboard/src/components/keeper-conditions-divergent.ts
+++ b/dashboard/src/components/keeper-conditions-divergent.ts
@@ -23,10 +23,10 @@ import type { Keeper, KeeperConditions, KeeperPhase } from '../types'
 
 type DivergenceFn = (value: boolean, phase: KeeperPhase | null | undefined) => string | null
 
-const isOperating = (p: KeeperPhase | null | undefined): boolean =>
+export const isOperating = (p: KeeperPhase | null | undefined): boolean =>
   p === 'Running' || p === 'Failing' || p === 'Overflowed'
 
-const isTerminated = (p: KeeperPhase | null | undefined): boolean =>
+export const isTerminated = (p: KeeperPhase | null | undefined): boolean =>
   p === 'Stopped' || p === 'Dead' || p === 'Crashed'
 
 /** Rule table — each entry returns a ko-language reason when divergent,


### PR DESCRIPTION
## Summary
- export `isOperating` / `isTerminated` so the existing divergence tests can exercise the helper truth table
- align `AgentsUnified` runtime truth assertions with current UI copy: configured keeper delta renders as `미기동 N`

## Context
Latest main had the journal-source fix merged, plus #17074 board mock repair, but the Dashboard lane still failed on these two drift checks.

## Verification
- `pnpm run typecheck`
- `pnpm vitest run src/components/agents-unified.test.ts src/components/keeper-conditions-divergent.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm vitest run src/journal-entry src/sse src/components/keeper-conditions-divergent.test.ts src/components/ide/ide-conversation-rail.test.ts src/components/agents-unified.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `git diff --check`