### PR TITLE
test(keeper): reject implicit capacity auto-resume

### DIFF
--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -1580,6 +1580,93 @@ let test_operator_pause_not_auto_resumed () =
       check (float 0.001) "metric_keeper_auto_resumed_total NOT incremented"
         baseline_auto_resume after_auto_resume)
 
+(* Regression guard for #17063/#17067: [auto_resume_after_sec = None] is the
+   manual/operator pause contract.  A [Capacity_exhausted] blocker from old
+   persisted metadata must not be treated as an implicit auto-resume policy. *)
+let test_capacity_blocker_without_resume_policy_not_auto_resumed () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  with_config_dir @@ fun config_dir ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Reg.clear ();
+      Masc_mcp.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc_mcp.Coord.default_config base_dir in
+      ignore (Masc_mcp.Coord.init config ~agent_name:(Some "supervisor"));
+      let name = "capacity-paused-without-resume-policy" in
+      write_keeper_toml config_dir ~name;
+      let two_hours_ago =
+        let t = Unix.gmtime (Unix.time () -. 7200.0) in
+        Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+          (t.tm_year + 1900) (t.tm_mon + 1) t.tm_mday
+          t.tm_hour t.tm_min t.tm_sec
+      in
+      let paused_meta =
+        { (make_meta name) with
+          paused = true;
+          auto_resume_after_sec = None;
+          updated_at = two_hours_ago;
+          runtime =
+            { (make_meta name).runtime with
+              last_blocker =
+                Some
+                  (KT.blocker_info_of_class
+                     ~detail:"capacity exhausted before explicit resume policy"
+                     KT.Capacity_exhausted);
+            };
+        }
+      in
+      check bool "capacity blocker without resume policy is not due"
+        false
+        (Masc_mcp.Keeper_supervisor_types.paused_meta_auto_resume_due
+           ~now:(Unix.time ())
+           paused_meta);
+      (match KT.write_meta config paused_meta with
+       | Ok () -> ()
+       | Error err -> fail err);
+      check bool "precondition: capacity pause is not bootable" false
+        (List.mem name (KR.bootable_keeper_names config));
+      let baseline_auto_resume =
+        Masc_mcp.Prometheus.metric_total
+          Masc_mcp.Keeper_metrics.metric_keeper_auto_resumed_total
+      in
+      let ctx : _ KT.context =
+        {
+          config;
+          agent_name = "supervisor";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = Some (Eio.Stdenv.net env);
+        }
+      in
+      Sup.sweep_and_recover ctx;
+      (match KT.read_meta config name with
+       | Ok (Some m) ->
+           check bool "meta.paused stays true without explicit resume policy"
+             true m.paused;
+           check bool "capacity blocker stays recorded for operator inspection"
+             true
+             (match m.runtime.last_blocker with
+              | Some info -> info.klass = KT.Capacity_exhausted
+              | None -> false)
+       | Ok None -> fail "meta missing"
+       | Error err -> fail ("read_meta failed: " ^ err));
+      check bool "capacity pause remains out of bootable set" false
+        (List.mem name (KR.bootable_keeper_names config));
+      check bool "capacity pause is not reconciled into registry" false
+        (Reg.is_registered ~base_path:config.base_path name);
+      let after_auto_resume =
+        Masc_mcp.Prometheus.metric_total
+          Masc_mcp.Keeper_metrics.metric_keeper_auto_resumed_total
+      in
+      check (float 0.001) "metric_keeper_auto_resumed_total NOT incremented"
+        baseline_auto_resume after_auto_resume)
+
 (* Regression test: initial delay is capped at max_sec even when
    MASC_KEEPER_AUTO_RESUME_INITIAL_SEC > MASC_KEEPER_AUTO_RESUME_MAX_SEC.
    The None -> initial_sec path must apply Float.min max_sec initial_sec. *)
@@ -1819,6 +1906,8 @@ let () =
         test_sweep_auto_resumes_after_backoff;
       test_case "operator pause (None) is NOT auto-resumed by sweep" `Quick
         test_operator_pause_not_auto_resumed;
+      test_case "capacity blocker without resume policy is NOT auto-resumed"
+        `Quick test_capacity_blocker_without_resume_policy_not_auto_resumed;
       test_case "initial delay capped at max_sec when initial > max (regression)" `Quick
         test_initial_auto_resume_capped_at_max;
       test_case "persisted blocker survives unregister" `Quick


### PR DESCRIPTION
Refs #17063

## Summary
- Add a regression guard that `auto_resume_after_sec = None` remains the manual/operator pause contract.
- Prove a paused keeper with `last_blocker = capacity_exhausted` is not directly auto-resumable without an explicit resume policy.
- Cover both the pure `paused_meta_auto_resume_due` predicate and the supervisor sweep path.

## Tests
- ocamlformat --check test/test_keeper_supervisor.ml
- scripts/dune-local.sh build test/test_keeper_supervisor.exe
- ./_build/default/test/test_keeper_supervisor.exe test --color=never --show-errors self_healing_circuit_breaker

Note: post-rebase wrapper build is queued locally behind other `dune-local.sh` work; CI is the current post-push verifier.