### PR TITLE
[codex] fix(keeper): type capacity backpressure errors

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -753,6 +753,7 @@ let review
               | Some (Keeper_turn_driver.No_tool_capable_provider _) -> true
               | Some
                   ( Keeper_turn_driver.Cascade_exhausted _
+                  | Keeper_turn_driver.Capacity_backpressure _
                   | Keeper_turn_driver.Resumable_cli_session _
                   | Keeper_turn_driver.Accept_rejected _
                   | Keeper_turn_driver.Admission_queue_timeout _

--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -136,6 +136,7 @@ let sdk_error_to_cascade_outcome (err : Agent_sdk.Error.sdk_error)
      through to the structured [match err with] below to derive the cascade
      outcome from the raw [sdk_error] payload. *)
   | Some (Cascade_error_classify.Cascade_exhausted _)
+  | Some (Cascade_error_classify.Capacity_backpressure _)
   | Some (Cascade_error_classify.No_tool_capable_provider _)
   | Some (Cascade_error_classify.Accept_rejected _)
   | Some (Cascade_error_classify.Admission_queue_timeout _)
@@ -950,6 +951,7 @@ let sdk_error_is_max_turns_exceeded (err : Agent_sdk.Error.sdk_error) : bool =
          { reason = Keeper_types.Other_detail detail; _ }) ->
       message_looks_like_cli_wrapped_max_turns detail
   | Some (Cascade_error_classify.Cascade_exhausted _)
+  | Some (Cascade_error_classify.Capacity_backpressure _)
   | Some (Cascade_error_classify.Resumable_cli_session _)
   | Some (Cascade_error_classify.No_tool_capable_provider _)
   | Some (Cascade_error_classify.Accept_rejected _)

--- a/lib/cascade/cascade_error_classify.ml
+++ b/lib/cascade/cascade_error_classify.ml
@@ -18,10 +18,35 @@ type provider_rejection = {
   reason : string;
 }
 
+type capacity_backpressure_source =
+  | Provider_capacity
+  | Client_capacity
+  | Tier_admission
+  | Cascade_slot
+
+let capacity_backpressure_source_to_string = function
+  | Provider_capacity -> "provider_capacity"
+  | Client_capacity -> "client_capacity"
+  | Tier_admission -> "tier_admission"
+  | Cascade_slot -> "cascade_slot"
+
+let capacity_backpressure_source_of_string = function
+  | "provider_capacity" -> Some Provider_capacity
+  | "client_capacity" -> Some Client_capacity
+  | "tier_admission" -> Some Tier_admission
+  | "cascade_slot" -> Some Cascade_slot
+  | _ -> None
+
 type masc_internal_error =
   | Cascade_exhausted of {
       cascade_name : cascade_name;
       reason : Keeper_types.cascade_exhaustion_reason;
+    }
+  | Capacity_backpressure of {
+      cascade_name : cascade_name;
+      source : capacity_backpressure_source;
+      detail : string;
+      retry_after_sec : float option;
     }
   | Resumable_cli_session of {
       cascade_name : cascade_name;
@@ -121,6 +146,16 @@ let masc_internal_error_to_json = function
         ("kind", `String "cascade_exhausted");
         ("cascade_name", `String cascade_name);
         ("reason", Keeper_types.cascade_exhaustion_reason_to_json reason);
+      ]
+  | Capacity_backpressure { cascade_name; source; detail; retry_after_sec } ->
+    let cascade_name = cascade_name_to_string cascade_name in
+    `Assoc
+      [
+        ("kind", `String "capacity_exhausted");
+        ("cascade_name", `String cascade_name);
+        ("source", `String (capacity_backpressure_source_to_string source));
+        ("detail", `String detail);
+        ("retry_after_sec", Json_util.float_opt_to_json retry_after_sec);
       ]
   | Resumable_cli_session { cascade_name; detail; exit_code } ->
     let cascade_name = cascade_name_to_string cascade_name in
@@ -232,6 +267,19 @@ let summarize_provider_rejections rejections =
   | reasons -> String.concat "; " reasons
 
 let summary_of_masc_internal_error = function
+  | Capacity_backpressure { cascade_name; source; detail; retry_after_sec } ->
+      let retry_after =
+        match retry_after_sec with
+        | Some value -> Printf.sprintf "; retry_after=%.1fs" value
+        | None -> ""
+      in
+      Some
+        (Printf.sprintf
+           "Capacity backpressure blocked cascade %s; source=%s; detail=%s%s"
+           (cascade_name_to_string cascade_name)
+           (capacity_backpressure_source_to_string source)
+           detail
+           retry_after)
   | No_tool_capable_provider
       {
         cascade_name;
@@ -311,7 +359,7 @@ let () =
     ~help:
       "Total MASC-internal errors emitted as Agent_sdk.Error.Internal \
        payloads, classified by structured error kind. Labels: \
-       kind (cascade_exhausted | resumable_cli_session | \
+       kind (cascade_exhausted | capacity_exhausted | resumable_cli_session | \
        no_tool_capable_provider | accept_rejected | \
        admission_queue_timeout | admission_queue_rejected | \
        turn_timeout | oas_timeout_budget | max_tokens_ceiling_violation | \
@@ -322,6 +370,7 @@ let () =
 
 let kind_of_masc_internal_error = function
   | Cascade_exhausted _ -> "cascade_exhausted"
+  | Capacity_backpressure _ -> "capacity_exhausted"
   | Resumable_cli_session _ -> "resumable_cli_session"
   | No_tool_capable_provider _ -> "no_tool_capable_provider"
   | Accept_rejected _ -> "accept_rejected"
@@ -354,6 +403,7 @@ let kind_of_masc_internal_error = function
     some configurations and Grafana group-bys lose the row). *)
 let cascade_name_of_masc_internal_error = function
   | Cascade_exhausted { cascade_name; _ }
+  | Capacity_backpressure { cascade_name; _ }
   | Resumable_cli_session { cascade_name; _ }
   | No_tool_capable_provider { cascade_name; _ }
   | Admission_queue_timeout { cascade_name; _ }
@@ -445,6 +495,26 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
                     })
              | None -> None)
           | None -> None)
+      | Some (`String "capacity_exhausted") -> (
+          match
+            string_opt_of_assoc "cascade_name" json,
+            string_opt_of_assoc "source" json,
+            string_opt_of_assoc "detail" json
+          with
+          | Some cascade_name, Some source, Some detail ->
+            (match capacity_backpressure_source_of_string source with
+             | Some source ->
+               Some
+                 (Capacity_backpressure
+                    {
+                      cascade_name = cascade_name_of_string cascade_name;
+                      source;
+                      detail;
+                      retry_after_sec =
+                        float_opt_of_assoc "retry_after_sec" json;
+                    })
+             | None -> None)
+          | _ -> None)
       | Some (`String "resumable_cli_session") -> (
           match string_opt_of_assoc "cascade_name" json, string_opt_of_assoc "detail" json with
           | Some cascade_name, Some detail ->

--- a/lib/cascade/cascade_error_classify.mli
+++ b/lib/cascade/cascade_error_classify.mli
@@ -19,10 +19,22 @@ type provider_rejection = {
   reason : string;
 }
 
+type capacity_backpressure_source =
+  | Provider_capacity
+  | Client_capacity
+  | Tier_admission
+  | Cascade_slot
+
 type masc_internal_error =
   | Cascade_exhausted of {
       cascade_name : cascade_name;
       reason : Keeper_types.cascade_exhaustion_reason;
+    }
+  | Capacity_backpressure of {
+      cascade_name : cascade_name;
+      source : capacity_backpressure_source;
+      detail : string;
+      retry_after_sec : float option;
     }
   | Resumable_cli_session of {
       cascade_name : cascade_name;
@@ -78,6 +90,9 @@ val masc_internal_error_to_json : masc_internal_error -> Yojson.Safe.t
 val summary_of_masc_internal_error : masc_internal_error -> string option
 (** Operator-facing concise summary for structured errors where the raw JSON
     payload is too noisy for dashboard cards. *)
+
+val capacity_backpressure_source_to_string :
+  capacity_backpressure_source -> string
 
 val sdk_error_of_masc_internal_error : masc_internal_error -> Agent_sdk.Error.sdk_error
 (** Convert a [masc_internal_error] to an SDK error, bumping the

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -197,6 +197,8 @@ let is_auto_recoverable_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error
       Keeper_turn_driver.message_looks_like_cli_wrapped_hard_quota detail
       || Keeper_turn_driver.message_looks_like_cli_wrapped_max_turns detail
       || message_looks_like_capacity_backpressure detail
+  | Some (Keeper_turn_driver.Capacity_backpressure _) ->
+      true
   | Some (Keeper_turn_driver.Cascade_exhausted _) ->
       false
   | Some (Keeper_turn_driver.No_tool_capable_provider _)
@@ -215,6 +217,7 @@ let is_resumable_cli_session_error (err : Agent_sdk.Error.sdk_error) : bool =
   match Keeper_turn_driver.classify_masc_internal_error err with
   | Some (Keeper_turn_driver.Resumable_cli_session _) -> true
   | Some (Keeper_turn_driver.Cascade_exhausted _)
+  | Some (Keeper_turn_driver.Capacity_backpressure _)
   | Some (Keeper_turn_driver.No_tool_capable_provider _)
   | Some (Keeper_turn_driver.Accept_rejected _)
   | Some (Keeper_turn_driver.Admission_queue_timeout _)
@@ -335,6 +338,8 @@ let degraded_retry_after_recoverable_error
         local_recovery_retry Oas_timeout_budget
     | Some (Keeper_turn_driver.Turn_timeout _) ->
         local_recovery_retry Turn_timeout
+    | Some (Keeper_turn_driver.Capacity_backpressure _) ->
+        local_recovery_retry Capacity_exhausted
     | Some
         (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Candidates_filtered_after_cycles; _ }) ->
@@ -379,6 +384,8 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
         Some Oas_timeout_budget
     | Some (Keeper_turn_driver.Turn_timeout _) ->
         Some Turn_timeout
+    | Some (Keeper_turn_driver.Capacity_backpressure _) ->
+        Some Capacity_exhausted
     | Some
         (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Candidates_filtered_after_cycles; _ }) ->
@@ -668,6 +675,7 @@ let is_auto_recoverable_turn_error (err : Agent_sdk.Error.sdk_error) : bool =
 let should_warn_keeper_cycle_failed (err : Agent_sdk.Error.sdk_error) : bool =
   match Keeper_turn_driver.classify_masc_internal_error err with
   | Some (Keeper_turn_driver.Oas_timeout_budget _) -> true
+  | Some (Keeper_turn_driver.Capacity_backpressure _) -> true
   | Some (Keeper_turn_driver.Cascade_exhausted _)
   | Some (Keeper_turn_driver.Resumable_cli_session _)
   | Some (Keeper_turn_driver.No_tool_capable_provider _)
@@ -710,6 +718,7 @@ let is_ambiguous_side_effect_error (err : Agent_sdk.Error.sdk_error) : bool =
       | Agent_sdk.Error.A2a _ -> false)
   (* All other MASC-internal classifications are unambiguous failures. *)
   | Some (Keeper_turn_driver.Cascade_exhausted _)
+  | Some (Keeper_turn_driver.Capacity_backpressure _)
   | Some (Keeper_turn_driver.No_tool_capable_provider _)
   | Some (Keeper_turn_driver.Accept_rejected _)
   | Some (Keeper_turn_driver.Resumable_cli_session _)
@@ -888,6 +897,7 @@ let is_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Some (Keeper_turn_driver.Resumable_cli_session _)
   | Some (Keeper_turn_driver.No_tool_capable_provider _)
   | Some (Keeper_turn_driver.Accept_rejected _) -> true
+  | Some (Keeper_turn_driver.Capacity_backpressure _)
   | Some (Keeper_turn_driver.Admission_queue_timeout _)
   | Some (Keeper_turn_driver.Admission_queue_rejected _)
   | Some (Keeper_turn_driver.Oas_timeout_budget _)

--- a/lib/keeper/keeper_heartbeat_loop_observations.ml
+++ b/lib/keeper/keeper_heartbeat_loop_observations.ml
@@ -146,6 +146,7 @@ let is_oas_timeout_budget_error (err : Agent_sdk.Error.sdk_error) =
   | Some (Keeper_turn_driver.Oas_timeout_budget _) -> true
   | Some
       ( Keeper_turn_driver.Cascade_exhausted _
+      | Keeper_turn_driver.Capacity_backpressure _
       | Keeper_turn_driver.Resumable_cli_session _
       | Keeper_turn_driver.No_tool_capable_provider _
       | Keeper_turn_driver.Accept_rejected _
@@ -184,6 +185,7 @@ let oas_timeout_budget_policy_decision
             }))
   | Some
       ( Keeper_turn_driver.Cascade_exhausted _
+      | Keeper_turn_driver.Capacity_backpressure _
       | Keeper_turn_driver.Resumable_cli_session _
       | Keeper_turn_driver.No_tool_capable_provider _
       | Keeper_turn_driver.Accept_rejected _

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -224,6 +224,7 @@ let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class
   | Some Keeper_error_classify.Capacity_exhausted -> Some Capacity_exhausted
   | _ ->
   match Keeper_turn_driver.classify_masc_internal_error err with
+  | Some (Keeper_turn_driver.Capacity_backpressure _) -> Some Capacity_exhausted
   | Some (Keeper_turn_driver.Cascade_exhausted { reason; _ }) ->
     Some (Cascade_exhausted reason)
   | Some (Keeper_turn_driver.Resumable_cli_session { detail; _ }) ->
@@ -313,6 +314,8 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
       then cascade_exhaustion_summary reason
       else (
         match Keeper_turn_driver.classify_masc_internal_error_of_string summary with
+        | Some (Keeper_turn_driver.Capacity_backpressure _) ->
+          "Provider or client capacity backpressure blocked this keeper turn."
         | Some (Keeper_turn_driver.Cascade_exhausted { reason = structured_reason; _ }) ->
           let reason =
             match structured_reason with

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -244,6 +244,7 @@ let degraded_retry_bypasses_slot_phase_guard
       true
   | Some
       ( Keeper_turn_driver.Cascade_exhausted _
+      | Keeper_turn_driver.Capacity_backpressure _
       | Keeper_turn_driver.Resumable_cli_session _
       | Keeper_turn_driver.No_tool_capable_provider _
       | Keeper_turn_driver.Accept_rejected _

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -880,9 +880,95 @@ let run_named
     | Cascade_fsm.Accept_on_exhaustion _ ->
       last_err
   in
+  let capacity_backpressure_source_of_http_error = function
+    | Llm_provider.Http_client.NetworkError
+        { kind = Llm_provider.Http_client.Local_resource_exhaustion; _ } ->
+      Some Cascade_slot
+    | Llm_provider.Http_client.ProviderFailure
+        { kind = Llm_provider.Http_client.Capacity_exhausted _; _ } ->
+      Some Provider_capacity
+    | Llm_provider.Http_client.HttpError _
+    | Llm_provider.Http_client.NetworkError _
+    | Llm_provider.Http_client.TimeoutError _
+    | Llm_provider.Http_client.AcceptRejected _
+    | Llm_provider.Http_client.CliTransportRequired _
+    | Llm_provider.Http_client.ProviderTerminal _
+    | Llm_provider.Http_client.ProviderFailure _ ->
+      None
+  in
+  let capacity_backpressure_of_http_error ?source last_err =
+    match last_err with
+    | Some
+        (Llm_provider.Http_client.ProviderFailure
+           {
+             kind =
+               Llm_provider.Http_client.Capacity_exhausted
+                 { retry_after; _ };
+             message;
+           }) ->
+      Some
+        (Capacity_backpressure
+           {
+             cascade_name = error_cascade_name;
+             source =
+               Option.value source ~default:Provider_capacity;
+             detail = message;
+             retry_after_sec = retry_after;
+           })
+    | Some
+        (Llm_provider.Http_client.NetworkError
+           {
+             kind = Llm_provider.Http_client.Local_resource_exhaustion;
+             message;
+           }) ->
+      Some
+        (Capacity_backpressure
+           {
+             cascade_name = error_cascade_name;
+             source = Option.value source ~default:Cascade_slot;
+             detail = message;
+             retry_after_sec = None;
+           })
+    | Some
+        (Llm_provider.Http_client.HttpError _
+        | Llm_provider.Http_client.NetworkError _
+        | Llm_provider.Http_client.TimeoutError _
+        | Llm_provider.Http_client.AcceptRejected _
+        | Llm_provider.Http_client.CliTransportRequired _
+        | Llm_provider.Http_client.ProviderTerminal _
+        | Llm_provider.Http_client.ProviderFailure _)
+    | None ->
+      None
+  in
+  let capacity_backpressure_of_sdk_error sdk_err =
+    match sdk_err with
+    | Agent_sdk.Error.Provider
+        (Llm_provider.Error.CapacityExhausted { retry_after; detail; _ }) ->
+      Some
+        (sdk_error_of_masc_internal_error
+           (Capacity_backpressure
+              {
+                cascade_name = error_cascade_name;
+                source = Provider_capacity;
+                detail;
+                retry_after_sec = retry_after;
+              }))
+    | Agent_sdk.Error.Api _
+    | Agent_sdk.Error.Provider _
+    | Agent_sdk.Error.Agent _
+    | Agent_sdk.Error.Mcp _
+    | Agent_sdk.Error.Config _
+    | Agent_sdk.Error.Serialization _
+    | Agent_sdk.Error.Io _
+    | Agent_sdk.Error.Orchestration _
+    | Agent_sdk.Error.A2a _
+    | Agent_sdk.Error.Internal _ ->
+      None
+  in
   let rec try_cascade
       ?(on_success = fun ~provider_key:_ -> ())
-      ?resume_checkpoint ?per_provider_timeout_s remaining last_err =
+      ?resume_checkpoint ?per_provider_timeout_s ?last_capacity_source
+      remaining last_err =
     match remaining with
     | [] ->
       let reason : Keeper_types.cascade_exhaustion_reason = match last_err with
@@ -961,12 +1047,19 @@ let run_named
                    exit_code = resumable_cli_session_exit_code reason;
                  })
         | _ ->
-            sdk_error_of_masc_internal_error
-              (Cascade_exhausted
-                 {
-                   cascade_name = error_cascade_name;
-                   reason;
-                 })
+          (match
+             capacity_backpressure_of_http_error
+               ?source:last_capacity_source last_err
+           with
+           | Some capacity_error ->
+             sdk_error_of_masc_internal_error capacity_error
+           | None ->
+             sdk_error_of_masc_internal_error
+               (Cascade_exhausted
+                  {
+                    cascade_name = error_cascade_name;
+                    reason;
+                  }))
       in
       Error
         terminal_error
@@ -988,10 +1081,10 @@ let run_named
               "cascade %s: skipping %s (provider_key=%s cooldown: %s)"
               cascade_name runtime_candidate_label runtime_candidate_label msg;
             try_cascade ~on_success ?resume_checkpoint ?per_provider_timeout_s
-              rest last_err
+              ?last_capacity_source rest last_err
         | None ->
             try_cascade ~on_success ?resume_checkpoint ?per_provider_timeout_s
-              rest last_err)
+              ?last_capacity_source rest last_err)
       else (
       (match health_cooldown with
        | Some (_blocked_health_key, msg) ->
@@ -1017,7 +1110,7 @@ let run_named
           capacity_key;
         let slot_last_err = slot_full_last_err ~is_last last_err in
         try_cascade ~on_success ?resume_checkpoint ?per_provider_timeout_s
-          rest slot_last_err
+          ~last_capacity_source:Client_capacity rest slot_last_err
       | (`No_client_capacity | `Acquired _) as capacity_slot ->
       let capacity_release =
         match capacity_slot with
@@ -1178,7 +1271,7 @@ let run_named
           tier_admission_id;
         let slot_last_err = slot_full_last_err ~is_last last_err in
         try_cascade ~on_success ?resume_checkpoint ?per_provider_timeout_s
-          rest slot_last_err
+          ~last_capacity_source:Tier_admission rest slot_last_err
       | Ok (result, checkpoint_after, liveness_success_sample, attempt_latency_ms) ->
       let record_accepted_liveness_sample () =
         match liveness_success_sample with
@@ -1443,8 +1536,12 @@ let run_named
                 else
                   next_resume
               in
+              let last_capacity_source =
+                Option.bind new_err capacity_backpressure_source_of_http_error
+              in
               try_cascade
                 ?resume_checkpoint:retry_resume_checkpoint
+                ?last_capacity_source
                 (filter_provider_health_fail_open rest)
                 new_err
             | Cascade_fsm.Exhausted _ ->
@@ -1464,7 +1561,10 @@ let run_named
               in
               log "cascade %s exhausted: all tiers failed (last runtime=%s, error=%s)"
                 cascade_name runtime_candidate_label (Agent_sdk.Error.to_string sdk_err);
-              Error sdk_err
+              Error
+                (Option.value
+                   (capacity_backpressure_of_sdk_error sdk_err)
+                   ~default:sdk_err)
             (* [Accept] / [Accept_on_exhaustion] are reachable only from
                [Cascade_fsm.Call_ok] / [Accept_rejected] outcomes, but this
                branch handles a [Call_err] outcome so the FSM cannot return

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -21,10 +21,22 @@ type provider_rejection = {
   reason : string;
 }
 
+type capacity_backpressure_source =
+  | Provider_capacity
+  | Client_capacity
+  | Tier_admission
+  | Cascade_slot
+
 type masc_internal_error =
   | Cascade_exhausted of {
       cascade_name : cascade_name;
       reason : Keeper_types.cascade_exhaustion_reason;
+    }
+  | Capacity_backpressure of {
+      cascade_name : cascade_name;
+      source : capacity_backpressure_source;
+      detail : string;
+      retry_after_sec : float option;
     }
   | Resumable_cli_session of {
       cascade_name : cascade_name;
@@ -76,6 +88,9 @@ type masc_internal_error =
 val masc_internal_error_to_json : masc_internal_error -> Yojson.Safe.t
 
 val summary_of_masc_internal_error : masc_internal_error -> string option
+
+val capacity_backpressure_source_to_string :
+  capacity_backpressure_source -> string
 
 val sdk_error_of_masc_internal_error :
   masc_internal_error -> Agent_sdk.Error.sdk_error

--- a/lib/keeper/keeper_turn_terminal.ml
+++ b/lib/keeper/keeper_turn_terminal.ml
@@ -128,6 +128,8 @@ let of_failure ?(post_commit_ambiguous = false) ?(tool_call_count = 0) ~raw_erro
     match Keeper_turn_driver.classify_masc_internal_error err with
     | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
       make ~source:"typed_error" "oas_timeout_budget"
+    | Some (Keeper_turn_driver.Capacity_backpressure _) ->
+      make ~source:"typed_error" "capacity_exhausted"
     | Some (Keeper_turn_driver.Turn_timeout _) ->
       make ~source:"typed_error" "turn_wall_clock_timeout"
     | _ ->

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -1038,6 +1038,10 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
             Option.value
               ~default:reason
               (Keeper_turn_driver.summary_of_masc_internal_error err)
+        | Some (Keeper_turn_driver.Capacity_backpressure _ as err) ->
+            Option.value
+              ~default:reason
+              (Keeper_turn_driver.summary_of_masc_internal_error err)
         | Some (Keeper_turn_driver.No_tool_capable_provider _ as err) -> (
             match Keeper_turn_driver.summary_of_masc_internal_error err with
             | Some summary -> summary
@@ -1057,6 +1061,7 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
             | Keeper_turn_driver.Admission_queue_timeout _
             | Keeper_turn_driver.Admission_queue_rejected _
             | Keeper_turn_driver.Resumable_cli_session _
+            | Keeper_turn_driver.Capacity_backpressure _
             | Keeper_turn_driver.No_tool_capable_provider _) ->
             true
         | Some _ | None -> false)

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -124,6 +124,14 @@ let cascade_exhausted_failure_reason_of_raw_error ~detail raw_error =
          ; provider_id = None
          ; http_status = None
          })
+  | Some (Cascade_error_classify.Capacity_backpressure { detail = capacity_detail; _ }) ->
+    Some
+      (Keeper_registry.Provider_runtime_error
+         { code = "capacity_exhausted"
+         ; detail = capacity_detail
+         ; provider_id = None
+         ; http_status = None
+         })
   | Some
       ( Cascade_error_classify.Resumable_cli_session _
       | Cascade_error_classify.No_tool_capable_provider _

--- a/test/test_cascade_error_classify_decoder.ml
+++ b/test/test_cascade_error_classify_decoder.ml
@@ -106,6 +106,41 @@ let test_roundtrip_bare_string_reason () =
       reason
   | _ -> Alcotest.fail "expected Cascade_exhausted"
 
+let test_roundtrip_capacity_backpressure () =
+  let payload =
+    `Assoc
+      [ ("kind", `String "capacity_exhausted")
+      ; ("cascade_name", `String "primary")
+      ; ("source", `String "client_capacity")
+      ; ("detail", `String "client capacity key glm is full")
+      ; ("retry_after_sec", `Float 2.5)
+      ]
+  in
+  let decoded =
+    Classify.classify_masc_internal_error_of_string (wrap_masc_oas_error payload)
+  in
+  match decoded with
+  | Some
+      (Classify.Capacity_backpressure
+         { cascade_name; source; detail; retry_after_sec }) ->
+    Alcotest.(check string)
+      "cascade name preserved"
+      "primary"
+      (Classify.cascade_name_to_string cascade_name);
+    Alcotest.(check string)
+      "source preserved"
+      "client_capacity"
+      (Classify.capacity_backpressure_source_to_string source);
+    Alcotest.(check string)
+      "detail preserved"
+      "client capacity key glm is full"
+      detail;
+    Alcotest.(check (option (float 0.001)))
+      "retry_after preserved"
+      (Some 2.5)
+      retry_after_sec
+  | _ -> Alcotest.fail "expected Capacity_backpressure"
+
 (* --- schema-drift cases: must return None ---------------------------- *)
 
 let test_unknown_reason_tag_decodes_to_none () =
@@ -171,6 +206,8 @@ let () =
             test_roundtrip_structural_attempt_timeout
         ; Alcotest.test_case
             "bare string reason" `Quick test_roundtrip_bare_string_reason
+        ; Alcotest.test_case
+            "capacity backpressure" `Quick test_roundtrip_capacity_backpressure
         ] )
     ; ( "schema-drift → None"
       , [ Alcotest.test_case

--- a/test/test_keeper_blocker_class_completion_contract.ml
+++ b/test/test_keeper_blocker_class_completion_contract.ml
@@ -98,13 +98,15 @@ let test_capacity_backpressure_text_maps () =
 let test_capacity_backpressure_sdk_error_maps () =
   let err =
     Owne.sdk_error_of_masc_internal_error
-      (Owne.Cascade_exhausted
+      (Owne.Capacity_backpressure
          {
            cascade_name = Owne.cascade_name_of_string "strict_tool_candidates";
-           reason = KT.Other_detail "slot full, cascading to next provider";
+           source = Owne.Client_capacity;
+           detail = "client capacity key glm is full";
+           retry_after_sec = None;
          })
   in
-  check_capacity_class "slot-full structured SDK error"
+  check_capacity_class "typed capacity structured SDK error"
     (B.blocker_class_of_sdk_error err)
 
 let test_capacity_backpressure_runtime_surface_maps_legacy_cascade () =

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -28,6 +28,17 @@ let make_cascade_exhausted reason =
     (Owne.Cascade_exhausted
        { cascade_name = cascade_name "test_cascade"; reason })
 
+let make_capacity_backpressure ?(source = Owne.Client_capacity)
+    ?(detail = "client capacity key glm is full") () =
+  Owne.sdk_error_of_masc_internal_error
+    (Owne.Capacity_backpressure
+       {
+         cascade_name = cascade_name "test_cascade";
+         source;
+         detail;
+         retry_after_sec = None;
+       })
+
 let make_no_tool_capable () =
   Owne.sdk_error_of_masc_internal_error
     (Owne.No_tool_capable_provider
@@ -60,14 +71,27 @@ let test_slot_full_other_detail_is_capacity_backpressure () =
   in
   check bool "slot full is auto-recoverable" true
     (KEC.is_auto_recoverable_turn_error err);
-  check bool "slot full remains cascade_exhausted" true
+  check bool "legacy slot full remains cascade_exhausted" true
     (KEC.is_cascade_exhausted_error err);
   match KEC.recoverable_cascade_failure_reason err with
   | Some reason ->
-    check string "slot full -> capacity_exhausted" "capacity_exhausted"
+    check string "legacy slot full -> capacity_exhausted" "capacity_exhausted"
       (KEC.degraded_retry_reason_to_string reason)
   | None ->
     fail "slot full should be capacity-backpressure recoverable"
+
+let test_typed_capacity_backpressure_is_not_cascade_exhausted () =
+  let err = make_capacity_backpressure () in
+  check bool "typed capacity is auto-recoverable" true
+    (KEC.is_auto_recoverable_turn_error err);
+  check bool "typed capacity is not cascade_exhausted" false
+    (KEC.is_cascade_exhausted_error err);
+  match KEC.recoverable_cascade_failure_reason err with
+  | Some reason ->
+    check string "typed capacity -> capacity_exhausted" "capacity_exhausted"
+      (KEC.degraded_retry_reason_to_string reason)
+  | None ->
+    fail "typed capacity backpressure should be recoverable as capacity"
 
 let test_provider_capacity_exhausted_is_capacity_backpressure () =
   let err =
@@ -422,6 +446,8 @@ let () =
             test_other_detail_generic_recoverable;
           test_case "slot full Other_detail is capacity backpressure" `Quick
             test_slot_full_other_detail_is_capacity_backpressure;
+          test_case "typed capacity backpressure is not cascade exhausted" `Quick
+            test_typed_capacity_backpressure_is_not_cascade_exhausted;
           test_case "provider CapacityExhausted is capacity backpressure" `Quick
             test_provider_capacity_exhausted_is_capacity_backpressure;
           test_case "All_providers_failed is recoverable" `Quick

--- a/test/test_oas_error_kind_counter.ml
+++ b/test/test_oas_error_kind_counter.ml
@@ -78,6 +78,25 @@ let test_cascade_exhausted_kind () =
     (before +. 1.0)
     (counter_for ~cascade_name kind)
 
+let test_capacity_backpressure_kind () =
+  let kind = "capacity_exhausted" in
+  let cascade_name = "primary" in
+  let before = counter_for ~cascade_name kind in
+  let _ =
+    OWN.sdk_error_of_masc_internal_error
+      (OWN.Capacity_backpressure
+         {
+           cascade_name = typed_cascade_name cascade_name;
+           source = OWN.Client_capacity;
+           detail = "client capacity key glm is full";
+           retry_after_sec = None;
+         })
+  in
+  Alcotest.(check (float 0.0001))
+    "capacity_exhausted{cascade_name=primary} counter +1"
+    (before +. 1.0)
+    (counter_for ~cascade_name kind)
+
 let test_resumable_cli_session_kind () =
   let kind = "resumable_cli_session" in
   let cascade_name = "primary" in
@@ -384,6 +403,8 @@ let () =
             test_turn_timeout_kind;
           Alcotest.test_case "cascade_exhausted" `Quick
             test_cascade_exhausted_kind;
+          Alcotest.test_case "capacity_exhausted" `Quick
+            test_capacity_backpressure_kind;
           Alcotest.test_case "resumable_cli_session" `Quick
             test_resumable_cli_session_kind;
           Alcotest.test_case "no_tool_capable_provider" `Quick


### PR DESCRIPTION
## Summary
- Add typed `Capacity_backpressure` internal errors with source/detail/retry metadata.
- Emit typed capacity for client capacity, tier admission, cascade slot, and provider `CapacityExhausted` terminal paths.
- Update recoverability, status, terminal, metric, and decoder surfaces so new capacity events are no longer reported as generic cascade exhaustion.
- Keep legacy slot/client capacity string detection only as a fallback for old payloads/status text.

## Root Cause
Capacity/backpressure states were being collapsed into `cascade_exhausted` plus free-form `Other_detail`, so downstream code had to infer resource pressure through string heuristics.

## Validation
- PASS: `scripts/dune-local.sh build test/test_cascade_error_classify_decoder.exe test/test_keeper_error_classify_recoverable.exe test/test_keeper_blocker_class_completion_contract.exe test/test_oas_error_kind_counter.exe`
- PASS: direct test executables: 7 + 25 + 10 + 17 tests
- PASS: `git diff --check`
- PASS: `scripts/check-sdk-independence.sh` in `oas`

## Notes
- No `oas` code changes in this branch.
- Legacy capacity string fallback remains intentionally for historical payload compatibility.
- `test_keeper_tools_oas.exe` was not rebuilt in this worktree because the local Dune queue was saturated; the existing workflow-rejection source/test coverage was inspected separately.