### PR TITLE
fix(keeper): keep state template anchor in normal prompt

### DIFF
--- a/lib/keeper/keeper_state_block_prompt.ml
+++ b/lib/keeper/keeper_state_block_prompt.ml
@@ -17,5 +17,6 @@ let instruction_text =
   String.concat "\n"
     [
       "For non-direct keeper turns, end every response with a [STATE]...[/STATE] block unless a more specific turn-level output guard says continuity is runtime-managed:";
+      Printf.sprintf "State block template: %s." field_summary;
       template_text;
     ]

--- a/test/test_keeper_prompt_external.ml
+++ b/test/test_keeper_prompt_external.ml
@@ -112,6 +112,28 @@ let test_system_prompt_includes_continuity_contract () =
         "constitution still present" true
         (contains_substring prompt "PR merge rules"))
 
+let test_system_prompt_includes_state_block_template_anchor () =
+  with_repo_root_cwd (fun () ->
+      Lib.Keeper_prompt_external.reset_cache ();
+      let prompt =
+        Lib.Keeper_prompt.build_keeper_system_prompt
+          ~goal:"verify prompt anchors"
+          ~short_goal:"keep state template anchored"
+          ~mid_goal:"avoid noisy recovery fallback"
+          ~long_goal:"keep continuity prompt stable"
+          ~will:"maintain coherent identity"
+          ~needs:"runtime truth"
+          ~desires:"observable progress"
+          ~instructions:""
+          ()
+      in
+      Alcotest.(check bool)
+        "state block template anchor present" true
+        (contains_substring prompt "State block template");
+      Alcotest.(check bool)
+        "normal prompt does not need recovery fallback" false
+        (contains_substring prompt "Recovery guard"))
+
 let test_missing_returns_none () =
   with_repo_root_cwd (fun () ->
       Lib.Keeper_prompt_external.reset_cache ();
@@ -174,6 +196,9 @@ let () =
             test_loads_continuity_contract;
           Alcotest.test_case "system prompt includes continuity_contract"
             `Quick test_system_prompt_includes_continuity_contract;
+          Alcotest.test_case
+            "system prompt includes state block template anchor" `Quick
+            test_system_prompt_includes_state_block_template_anchor;
           Alcotest.test_case "missing returns None" `Quick
             test_missing_returns_none;
           Alcotest.test_case "second lookup uses cache" `Quick


### PR DESCRIPTION
## Summary

- Add the missing `State block template` critical anchor to the normal keeper state-block instruction.
- Add a regression test proving the normal keeper system prompt carries the anchor without appending the recovery guard.

## Product impact

Live logs show repeated `build_keeper_system_prompt: critical prompt anchors missing (state_block_template); appending recovery guard` warnings. The state template itself was present, but the normal prompt missed the exact critical anchor phrase, so the runtime treated healthy prompts as degraded. This reduces noisy prompt fallback behavior and keeps continuity guidance in the primary prompt path.

## Evidence

- Latest 1h live counter: `other=472`, representative example is the missing `state_block_template` prompt-anchor warning.
- Code inspection: `Keeper_prompt.critical_prompt_anchors` requires `State block template`; `Keeper_state_block_prompt.instruction_text` included the template but not that anchor phrase.

## Review evidence

- `ocamlformat --check lib/keeper/keeper_state_block_prompt.ml test/test_keeper_prompt_external.ml`
- `git diff --check`
- `ocamlc -c lib/keeper/keeper_state_block_prompt.mli -o /private/tmp/keeper_state_block_prompt.cmi`
- `ocamlc -I /private/tmp -c lib/keeper/keeper_state_block_prompt.ml -o /private/tmp/keeper_state_block_prompt.cmo`
- focused Dune attempted but blocked by shared machine-wide Dune contention:
  `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_prompt_external.exe`

## Linked issue

Follow-up from the MASC/OAS remaining-work report.
