### PR TITLE
[codex] Remove worker shell path tokenizer debt

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -273,6 +273,7 @@
   worker_dev_tools_log_sanitize
   worker_dev_tools_command_syntax
   worker_dev_tools_mutation_classifier
+  worker_dev_tools_path_words
   ;; keeper_memory sub-modules
   keeper_memory_policy_summary_filter
   keeper_memory_policy

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -15,6 +15,7 @@ module Paths = Worker_dev_tools_paths
 module Log_sanitize = Worker_dev_tools_log_sanitize
 module Command_syntax = Worker_dev_tools_command_syntax
 module Mutation_classifier = Worker_dev_tools_mutation_classifier
+module Path_words = Worker_dev_tools_path_words
 
 open Command_syntax
 
@@ -395,25 +396,13 @@ let git_revisionish_token ?workdir token =
   not (Sys.file_exists resolved)
 ;;
 
-type path_token =
-  { value : string
-  ; quoted : bool
-  ; escaped : bool
-  ; globbed : bool
-  ; braced : bool
-  }
-
-let token_has_unsafe_rewrite_syntax token =
-  token.quoted || token.escaped || token.braced
-;;
-
 let command_allows_safe_globbed_path = function
   | "ls" -> true
   | _ -> false
 ;;
 
-let token_glob_is_limited_to_basename token =
-  let value = token.value in
+let token_glob_is_limited_to_basename (token : Path_words.t) =
+  let value = token.Path_words.value in
   let start =
     match String.rindex_opt value '/' with
     | None -> 0
@@ -430,20 +419,20 @@ let token_glob_is_limited_to_basename token =
   loop 0
 ;;
 
-let path_token_error_hint token =
+let path_token_error_hint (token : Path_words.t) =
   let suggestions =
-    [ ( token.globbed
+    [ ( token.Path_words.globbed
       , "Glob expansion ('*' / '?' / '[]') — use masc_code_search with file_pattern \
          (e.g. file_pattern='*.ml') or rg with --glob instead of letting the shell \
          expand." )
-    ; ( token.braced
+    ; ( token.Path_words.braced
       , "Brace expansion ('{a,b}') — run one command per target, or use masc_code_search \
          / rg which accept multiple patterns natively." )
-    ; ( token.escaped
+    ; ( token.Path_words.escaped
       , "Backslash escaping — the keeper shell does not interpret escapes. Use \
          masc_code_search with is_regex=true for pattern work that would need \\. / \\w \
          / etc." )
-    ; ( token.quoted
+    ; ( token.Path_words.quoted
       , "Quoting — path args must be unquoted plain strings. Move any pattern into \
          masc_code_search.query with is_regex appropriately set." )
     ]
@@ -453,80 +442,15 @@ let path_token_error_hint token =
   |> String.concat " "
 ;;
 
-let path_syntax_blocked_message token =
+let path_syntax_blocked_message (token : Path_words.t) =
   let raw_hint = path_token_error_hint token in
   let hint = if raw_hint = "" then None else Some raw_hint in
   Keeper_path_check_error.(
-    to_message (Path_syntax_blocked { token = token.value; hint }))
+    to_message (Path_syntax_blocked { token = token.Path_words.value; hint }))
 ;;
 
-let tokenize_path_args cmd =
-  let len = String.length cmd in
-  let tokens = ref [] in
-  let buf = Buffer.create 32 in
-  let quoted = ref false in
-  let escaped = ref false in
-  let globbed = ref false in
-  let braced = ref false in
-  let push () =
-    if Buffer.length buf > 0
-       || !quoted
-       || !escaped
-       || !globbed
-       || !braced
-    then (
-      tokens :=
-        { value = Buffer.contents buf
-        ; quoted = !quoted
-        ; escaped = !escaped
-        ; globbed = !globbed
-        ; braced = !braced
-        }
-        :: !tokens;
-      Buffer.clear buf;
-      quoted := false;
-      escaped := false;
-      globbed := false;
-      braced := false)
-  in
-  let rec scan i quote =
-    if i >= len
-    then push ()
-    else
-      match quote, cmd.[i] with
-      | None, (' ' | '\t' | '\n' | '\r') ->
-        push ();
-        scan (i + 1) None
-      | None, ('\'' | '"') ->
-        quoted := true;
-        scan (i + 1) (Some cmd.[i])
-      | Some q, ch when ch = q ->
-        scan (i + 1) None
-      | _, '\\' ->
-        escaped := true;
-        if i + 1 < len
-        then (
-          Buffer.add_char buf cmd.[i + 1];
-          scan (i + 2) quote)
-        else scan (i + 1) quote
-      | _, ('*' | '?' | '[' | ']') ->
-        globbed := true;
-        Buffer.add_char buf cmd.[i];
-        scan (i + 1) quote
-      | _, ('{' | '}') ->
-        braced := true;
-        Buffer.add_char buf cmd.[i];
-        scan (i + 1) quote
-      | _, ch ->
-        Buffer.add_char buf ch;
-        scan (i + 1) quote
-  in
-  scan 0 None;
-  List.rev !tokens
-;;
-
-let token_value_is_redirect_to_dev_null token =
-  let value = token.value in
+let token_value_is_redirect_to_dev_null (token : Path_words.t) =
+  let value = token.Path_words.value in
   String.equal value ">/dev/null"
   || String.equal value "2>/dev/null"
   || String.equal value "1>/dev/null"
@@ -535,8 +459,8 @@ let token_value_is_redirect_to_dev_null token =
   || String.equal value "1>>/dev/null"
 ;;
 
-let token_value_is_redirect_op token =
-  match token.value with
+let token_value_is_redirect_op (token : Path_words.t) =
+  match token.Path_words.value with
   | ">" | ">>" | "<" | "2>" | "2>>" | "1>" | "1>>" -> true
   | _ -> false
 ;;
@@ -602,8 +526,8 @@ let command_pattern_arg_flags cmd =
   | _ -> []
 ;;
 
-let token_is_inline_pattern_flag cmd token =
-  let value = token.value in
+let token_is_inline_pattern_flag cmd (token : Path_words.t) =
+  let value = token.Path_words.value in
   command_pattern_arg_flags cmd
   |> List.find_map (fun (flag, consumes_primary_pattern) ->
     if String.starts_with ~prefix:(flag ^ "=") value
@@ -617,8 +541,8 @@ let command_flag_pattern_arity cmd value =
     if String.equal flag value then Some consumes_primary_pattern else None)
 ;;
 
-let rg_token_is_option_value token =
-  let value = token.value in
+let rg_token_is_option_value (token : Path_words.t) =
+  let value = token.Path_words.value in
   String.starts_with ~prefix:"-" value && String.length value > 1
 ;;
 
@@ -627,14 +551,14 @@ let command_treats_plain_args_as_content = function
   | _ -> false
 ;;
 
-let path_argument_tokens tokens =
-  match tokens with
+let path_argument_words (words : Path_words.t list) =
+  match words with
   | [] -> []
   | command :: args ->
-    let command_name = command.value in
+    let command_name = command.Path_words.value in
     let rg_files_mode =
       String.equal command_name "rg"
-      && List.exists (fun token -> String.equal token.value "--files") args
+      && List.exists (fun token -> String.equal token.Path_words.value "--files") args
     in
     let rec loop ~skip_next_pattern ~redirect_target ~seen_primary_pattern acc =
       function
@@ -643,7 +567,7 @@ let path_argument_tokens tokens =
         if redirect_target
         then
           let acc =
-            if String.equal token.value "/dev/null" then acc else token :: acc
+            if String.equal token.Path_words.value "/dev/null" then acc else token :: acc
           in
           loop ~skip_next_pattern:None ~redirect_target:false ~seen_primary_pattern acc rest
         else if token_value_is_redirect_to_dev_null token
@@ -662,7 +586,7 @@ let path_argument_tokens tokens =
             if token_value_is_redirect_op token
             then loop ~skip_next_pattern:None ~redirect_target:true ~seen_primary_pattern acc rest
             else
-              (match command_flag_pattern_arity command_name token.value with
+              (match command_flag_pattern_arity command_name token.Path_words.value with
                | Some consumes_primary_pattern ->
                  loop
                    ~skip_next_pattern:(Some consumes_primary_pattern)
@@ -732,35 +656,35 @@ let path_argument_tokens tokens =
 ;;
 
 let existing_dir_path_values cmd =
-  let tokens = tokenize_path_args cmd in
+  let words = Path_words.of_command cmd in
   let command_name =
-    match tokens with
-    | command :: _ -> Filename.basename command.value
+    match words with
+    | command :: _ -> Filename.basename command.Path_words.value
     | [] -> ""
   in
   let rec loop expect_existing_dir acc = function
     | [] -> List.rev acc
     | token :: rest ->
-      if token.value = ""
+      if token.Path_words.value = ""
       then loop expect_existing_dir acc rest
       else if expect_existing_dir
-      then loop false (token.value :: acc) rest
+      then loop false (token.Path_words.value :: acc) rest
       else (
-        match path_value_of_flagged_token token.value with
-        | Some value when inline_path_flag_requires_existing_dir token.value ->
+        match path_value_of_flagged_token token.Path_words.value with
+        | Some value when inline_path_flag_requires_existing_dir token.Path_words.value ->
           loop false (value :: acc) rest
         | Some _ -> loop false acc rest
-        | None when is_path_flag token.value ->
-          loop (path_flag_requires_existing_dir token.value) acc rest
+        | None when is_path_flag token.Path_words.value ->
+          loop (path_flag_requires_existing_dir token.Path_words.value) acc rest
         | None
           when command_materializes_path_arg command_name
-               && looks_like_path_token token.value
-               && not (token_has_unsafe_rewrite_syntax token)
-               && not token.globbed ->
-          loop false (token.value :: acc) rest
+               && looks_like_path_token token.Path_words.value
+               && not (Path_words.has_unsafe_rewrite_syntax token)
+               && not token.Path_words.globbed ->
+          loop false (token.Path_words.value :: acc) rest
         | None -> loop false acc rest)
   in
-  tokens |> path_argument_tokens |> loop false []
+  words |> path_argument_words |> loop false []
 ;;
 
 let validate_command_paths ?keeper_id ?base_path ?workdir cmd =
@@ -768,26 +692,26 @@ let validate_command_paths ?keeper_id ?base_path ?workdir cmd =
   | None -> Ok ()
   | Some _ ->
       let validate_path_value ~requires_existing_dir token =
-        if String.equal (strip_wrapping_quotes token.value) "/dev/null"
+        if String.equal (strip_wrapping_quotes token.Path_words.value) "/dev/null"
         then Ok ()
-        else if not (validate_path ?keeper_id ?base_path ?workdir token.value)
+        else if not (validate_path ?keeper_id ?base_path ?workdir token.Path_words.value)
         then
           Error
             (Keeper_path_check_error.(
                to_message
                  (Path_outside_whitelist
-                    { path = token.value; for_keeper_command = true })))
-        else if requires_existing_dir && not (path_is_existing_dir ?workdir token.value)
+                    { path = token.Path_words.value; for_keeper_command = true })))
+        else if requires_existing_dir && not (path_is_existing_dir ?workdir token.Path_words.value)
         then
           Error
             (Keeper_path_check_error.(
-               to_message (Cwd_not_directory { path = token.value; hint = None })))
+               to_message (Cwd_not_directory { path = token.Path_words.value; hint = None })))
         else Ok ()
       in
       let rec validate_path_tokens ~command_name expect_existing_dir = function
         | [] -> Ok ()
         | token :: rest ->
-          if token.value = ""
+          if token.Path_words.value = ""
           then validate_path_tokens ~command_name expect_existing_dir rest
           else if expect_existing_dir
           then
@@ -795,29 +719,29 @@ let validate_command_paths ?keeper_id ?base_path ?workdir cmd =
              | Ok () -> validate_path_tokens ~command_name false rest
              | Error _ as err -> err)
           else (
-            match path_value_of_flagged_token token.value with
+            match path_value_of_flagged_token token.Path_words.value with
             | Some value ->
               let token = { token with value } in
               (match
                  validate_path_value
-                   ~requires_existing_dir:(inline_path_flag_requires_existing_dir token.value)
+                   ~requires_existing_dir:(inline_path_flag_requires_existing_dir token.Path_words.value)
                    token
                with
                | Ok () -> validate_path_tokens ~command_name false rest
                | Error _ as err -> err)
-            | None when is_path_flag token.value ->
+            | None when is_path_flag token.Path_words.value ->
               validate_path_tokens
                 ~command_name
-                (path_flag_requires_existing_dir token.value)
+                (path_flag_requires_existing_dir token.Path_words.value)
                 rest
             | None
               when String.equal command_name "git"
-                   && git_revisionish_token ?workdir token.value ->
+                   && git_revisionish_token ?workdir token.Path_words.value ->
               validate_path_tokens ~command_name false rest
-            | None when looks_like_path_token token.value ->
-              if token_has_unsafe_rewrite_syntax token
+            | None when looks_like_path_token token.Path_words.value ->
+              if Path_words.has_unsafe_rewrite_syntax token
               then Error (path_syntax_blocked_message token)
-              else if token.globbed
+              else if token.Path_words.globbed
               then
                 if command_allows_safe_globbed_path command_name
                    && token_glob_is_limited_to_basename token
@@ -832,35 +756,32 @@ let validate_command_paths ?keeper_id ?base_path ?workdir cmd =
                 | Error _ as err -> err)
             | None -> validate_path_tokens ~command_name false rest)
       in
-      let validate_path_argument_tokens tokens path_tokens =
+      let validate_path_argument_words words path_words =
         let command_name =
-          match tokens with
-          | command :: _ -> Filename.basename command.value
+          match words with
+          | command :: _ -> Filename.basename command.Path_words.value
           | [] -> ""
         in
-        validate_path_tokens ~command_name false path_tokens
+        validate_path_tokens ~command_name false path_words
       in
-      let validate_token_stream tokens =
-        validate_path_argument_tokens tokens (path_argument_tokens tokens)
-      in
-      let path_token_of_literal value =
-        { value; quoted = false; escaped = false; globbed = false; braced = false }
+      let validate_word_stream words =
+        validate_path_argument_words words (path_argument_words words)
       in
       let rec validate_redirects = function
         | [] -> Ok ()
         | Masc_exec.Redirect_scope.File { target; _ } :: rest ->
-          let token = Masc_exec.Path_scope.raw target |> path_token_of_literal in
+          let token = Masc_exec.Path_scope.raw target |> Path_words.of_literal in
           (match validate_path_value ~requires_existing_dir:false token with
            | Ok () -> validate_redirects rest
            | Error _ as err -> err)
         | Masc_exec.Redirect_scope.Fd_to_fd _ :: rest -> validate_redirects rest
       in
       let tokens_of_simple (simple : Masc_exec.Shell_ir.simple) =
-        let command = Masc_exec.Bin.to_string simple.bin |> path_token_of_literal in
+        let command = Masc_exec.Bin.to_string simple.bin |> Path_words.of_literal in
         let rec args acc = function
           | [] -> Some (command :: List.rev acc)
           | Masc_exec.Shell_ir.Lit value :: rest ->
-            args (path_token_of_literal value :: acc) rest
+            args (Path_words.of_literal value :: acc) rest
           | Masc_exec.Shell_ir.Concat _ :: _ | Masc_exec.Shell_ir.Var _ :: _ -> None
         in
         args [] simple.args
@@ -870,7 +791,7 @@ let validate_command_paths ?keeper_id ?base_path ?workdir cmd =
           (match tokens_of_simple simple with
            | Some tokens ->
              Some
-               (match validate_token_stream tokens with
+               (match validate_word_stream tokens with
                 | Ok () -> validate_redirects simple.redirects
                 | Error _ as err -> err)
            | None -> None)
@@ -881,7 +802,7 @@ let validate_command_paths ?keeper_id ?base_path ?workdir cmd =
               (match tokens_of_simple simple with
                | None -> None
                | Some tokens ->
-                 (match validate_token_stream tokens with
+                 (match validate_word_stream tokens with
                   | Ok () ->
                     (match validate_redirects simple.redirects with
                      | Ok () -> loop rest
@@ -891,25 +812,25 @@ let validate_command_paths ?keeper_id ?base_path ?workdir cmd =
           in
           loop stages
       in
-      let legacy_tokens = tokenize_path_args cmd in
-      let legacy_path_tokens = path_argument_tokens legacy_tokens in
-      let legacy_needs_syntax_sensitive_gate =
+      let source_words = Path_words.of_command cmd in
+      let source_path_words = path_argument_words source_words in
+      let source_needs_syntax_sensitive_gate =
         List.exists
-          (fun token -> token_has_unsafe_rewrite_syntax token || token.globbed)
-          legacy_path_tokens
+          (fun token -> Path_words.has_unsafe_rewrite_syntax token || token.Path_words.globbed)
+          source_path_words
       in
-      if legacy_needs_syntax_sensitive_gate
-      then validate_path_argument_tokens legacy_tokens legacy_path_tokens
+      if source_needs_syntax_sensitive_gate
+      then validate_path_argument_words source_words source_path_words
       else (
         match Masc_exec_bash_parser.Bash.parse_string cmd with
         | Masc_exec.Parsed.Parsed shell_ir ->
           (match validate_parsed_shell_ir shell_ir with
            | Some result -> result
-           | None -> validate_token_stream legacy_tokens)
+           | None -> validate_word_stream source_words)
         | Masc_exec.Parsed.Parse_error _
         | Masc_exec.Parsed.Parse_aborted _
         | Masc_exec.Parsed.Too_complex _ ->
-          validate_token_stream legacy_tokens)
+          validate_word_stream source_words)
 ;;
 
 (** Check if a command performs write/mutating operations.

--- a/lib/worker_dev_tools_path_words.ml
+++ b/lib/worker_dev_tools_path_words.ml
@@ -1,0 +1,83 @@
+(** Source-word metadata for keeper command path validation.
+
+    This module keeps shell source syntax facts at the boundary where path
+    validation still needs them.  Worker_dev_tools consumes these records
+    instead of carrying its own legacy path-tokenizer helper. *)
+
+type t =
+  { value : string
+  ; quoted : bool
+  ; escaped : bool
+  ; globbed : bool
+  ; braced : bool
+  }
+
+let has_unsafe_rewrite_syntax word = word.quoted || word.escaped || word.braced
+
+let of_literal value =
+  { value; quoted = false; escaped = false; globbed = false; braced = false }
+;;
+
+let of_command cmd =
+  let len = String.length cmd in
+  let words = ref [] in
+  let buf = Buffer.create 32 in
+  let quoted = ref false in
+  let escaped = ref false in
+  let globbed = ref false in
+  let braced = ref false in
+  let push () =
+    if Buffer.length buf > 0
+       || !quoted
+       || !escaped
+       || !globbed
+       || !braced
+    then (
+      words :=
+        { value = Buffer.contents buf
+        ; quoted = !quoted
+        ; escaped = !escaped
+        ; globbed = !globbed
+        ; braced = !braced
+        }
+        :: !words;
+      Buffer.clear buf;
+      quoted := false;
+      escaped := false;
+      globbed := false;
+      braced := false)
+  in
+  let rec scan i quote =
+    if i >= len
+    then push ()
+    else
+      match quote, cmd.[i] with
+      | None, (' ' | '\t' | '\n' | '\r') ->
+        push ();
+        scan (i + 1) None
+      | None, ('\'' | '"') ->
+        quoted := true;
+        scan (i + 1) (Some cmd.[i])
+      | Some q, ch when ch = q -> scan (i + 1) None
+      | _, '\\' ->
+        escaped := true;
+        if i + 1 < len
+        then (
+          Buffer.add_char buf cmd.[i + 1];
+          scan (i + 2) quote)
+        else scan (i + 1) quote
+      | _, ('*' | '?' | '[' | ']') ->
+        globbed := true;
+        Buffer.add_char buf cmd.[i];
+        scan (i + 1) quote
+      | _, ('{' | '}') ->
+        braced := true;
+        Buffer.add_char buf cmd.[i];
+        scan (i + 1) quote
+      | _, ch ->
+        Buffer.add_char buf ch;
+        scan (i + 1) quote
+  in
+  scan 0 None;
+  List.rev !words
+;;

--- a/scripts/lint/shell-legacy-purge-ratchet.baseline
+++ b/scripts/lint/shell-legacy-purge-ratchet.baseline
@@ -4,7 +4,7 @@
 # Scope: lib/ and test/
 # The long-term target for every row is 0. Cleanup PRs may lower these
 # counts; no PR may raise them.
-tokenize_path_args 3
+tokenize_path_args 0
 path_validation_tokens 0
 forbidden_shell_chars 0
 raw_keeper_bash_shape_block 0

--- a/scripts/lint/shell-legacy-purge-ratchet.files
+++ b/scripts/lint/shell-legacy-purge-ratchet.files
@@ -3,4 +3,3 @@
 # Format: <needle> <repo-relative-path>
 # New files may not gain these legacy markers. Deletion PRs should remove
 # rows as they remove the corresponding markers.
-tokenize_path_args lib/worker_dev_tools.ml


### PR DESCRIPTION
Summary
- Move worker path source-word metadata into Worker_dev_tools_path_words.
- Replace the legacy tokenize_path_args helper with Path_words.of_command/of_literal call sites.
- Lower the shell legacy purge ratchet for tokenize_path_args to 0.

Validation
- ocamlformat --check lib/worker_dev_tools.ml lib/worker_dev_tools_path_words.ml
- git diff --check origin/main..HEAD
- bash scripts/lint/shell-legacy-purge-ratchet.sh
- rg -n tokenize_path_args lib test: no matches, exit 1
- env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_worker_dev_tools.exe test/test_path_rewrite_validation.exe: blocked locally by live bare Dune process: dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp bin/main_eio.exe; prior local compile attempt hit Dune shared-cache temp cleanup race, no OCaml diagnostic