### PR TITLE
fix(health): classify full snapshot timeout fallbacks

### DIFF
--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -1004,6 +1004,7 @@ type full_health_snapshot = {
   duration_ms : int;
   error : string option;
   stale_since_ts : float option;
+  last_good_available : bool;
 }
 
 let full_health_snapshot_mu = Stdlib.Mutex.create ()
@@ -1064,7 +1065,8 @@ let full_health_cached_field_names =
 let full_health_field_is_cached name =
   List.exists (String.equal name) full_health_cached_field_names
 
-let full_health_component_placeholder ?error ~status component =
+let full_health_component_placeholder ?error ?(component_timed_out = false) ~status
+    component =
   let error_fields =
     match error with
     | Some error -> [ ("error", `String error) ]
@@ -1074,32 +1076,40 @@ let full_health_component_placeholder ?error ~status component =
     ([
        ("component", `String component);
        ("status", `String status);
-       ("component_timed_out", `Bool false);
+       ("component_timed_out", `Bool component_timed_out);
      ]
      @ error_fields)
 
-let full_health_placeholder_fields ?error ?(status = "warming") () =
+let full_health_placeholder_fields ?error ?(component_timed_out = false)
+    ?(status = "warming") () =
   [
     ( "feature_flags",
-      full_health_component_placeholder ?error ~status "feature_flags" );
+      full_health_component_placeholder ?error ~component_timed_out ~status
+        "feature_flags" );
     ("keeper_fibers", `Int 0);
     ( "keeper_fd_pressure",
-      full_health_component_placeholder ?error ~status "keeper_fd_pressure" );
+      full_health_component_placeholder ?error ~component_timed_out ~status
+        "keeper_fd_pressure" );
     ( "fd_accountant",
-      full_health_component_placeholder ?error ~status "fd_accountant" );
+      full_health_component_placeholder ?error ~component_timed_out ~status
+        "fd_accountant" );
     ( "keeper_fleet_safety",
-      full_health_component_placeholder ?error ~status "keeper_fleet_safety" );
+      full_health_component_placeholder ?error ~component_timed_out ~status
+        "keeper_fleet_safety" );
     ( "keeper_reaction_ledger",
-      full_health_component_placeholder ?error ~status "keeper_reaction_ledger" );
+      full_health_component_placeholder ?error ~component_timed_out ~status
+        "keeper_reaction_ledger" );
     ( "paused_keepers",
       `Assoc
         [
           ("status", `String status);
           ("count", `Int 0);
           ("names", `List []);
-          ("component_timed_out", `Bool false);
+          ("component_timed_out", `Bool component_timed_out);
         ] );
-    ("cdal", full_health_component_placeholder ?error ~status "cdal");
+    ( "cdal",
+      full_health_component_placeholder ?error ~component_timed_out ~status
+        "cdal" );
     ("keeper_config_parse_error_count", `Int 0);
     ("keeper_config_parse_errors", `List []);
     ("keeper_config_unknown_key_count", `Int 0);
@@ -1137,6 +1147,7 @@ let compute_full_health_snapshot ?(listener = "http/1.1") request =
       duration_ms = duration_ms ~started_at ~finished_at;
       error = None;
       stale_since_ts = None;
+      last_good_available = true;
     }
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -1149,6 +1160,7 @@ let compute_full_health_snapshot ?(listener = "http/1.1") request =
         duration_ms = duration_ms ~started_at ~finished_at;
         error = Some error;
         stale_since_ts = Some finished_at;
+        last_good_available = false;
       }
 
 let store_full_health_snapshot snapshot =
@@ -1172,19 +1184,22 @@ let full_health_refresh_timeout_error error =
 let mark_full_health_snapshot_error exn =
   let now = Unix.gettimeofday () in
   let error = Printexc.to_string exn in
+  let timed_out = full_health_refresh_timeout_error error in
   with_full_health_snapshot_lock (fun () ->
       (* Partial degradation: preserve the last successful snapshot's
          per-component [fields] and overwrite only the [error] /
          [stale_since_ts] / refresh-bookkeeping signals.  If we have
          no prior snapshot (warm path on cold boot), fall back to the
          all-error placeholder so the field set stays well-typed. *)
-      let preserved_fields, prior_stale_since =
+      let preserved_fields, preserved_computed_at, preserved_duration_ms,
+          prior_stale_since, last_good_available =
         match !full_health_snapshot with
-        | Some s when Option.is_none s.error ->
-            (* Previous snapshot was clean — keep its component
-               fields, this is a fresh failure so [stale_since_ts]
-               starts at [now]. *)
-            (s.fields, None)
+        | Some s when s.last_good_available ->
+            (* A last-good payload exists — keep its component fields
+               and preserve [computed_at] so [snapshot_age_ms]
+               remains the age of the payload rather than the age of
+               the failed refresh attempt. *)
+            (s.fields, s.computed_at, s.duration_ms, s.stale_since_ts, true)
         | Some s ->
             (* Previous snapshot was already an error placeholder —
                keep whatever [fields] it had (which may itself be
@@ -1192,11 +1207,24 @@ let mark_full_health_snapshot_error exn =
                success) and DO NOT overwrite the [stale_since_ts]
                timestamp.  This pins [stale_since_ts] to the FIRST
                failure of the current outage. *)
-            (s.fields, s.stale_since_ts)
+            ( s.fields,
+              s.computed_at,
+              s.duration_ms,
+              s.stale_since_ts,
+              s.last_good_available )
         | None ->
             (* Cold boot — no prior snapshot.  Fall back to the
-               original all-error placeholder behaviour. *)
-            (full_health_placeholder_fields ~error ~status:"error" (), None)
+               original placeholder shape, but classify refresh
+               timeouts as [timeout] instead of generic [error] so
+               operators can distinguish "no last-good payload yet"
+               from a stale last-good fallback. *)
+            let status = if timed_out then "timeout" else "error" in
+            ( full_health_placeholder_fields ~error
+                ~component_timed_out:timed_out ~status (),
+              now,
+              0,
+              None,
+              false )
       in
       let stale_since_ts =
         match prior_stale_since with
@@ -1207,10 +1235,11 @@ let mark_full_health_snapshot_error exn =
         Some
           {
             fields = preserved_fields;
-            computed_at = now;
-            duration_ms = 0;
+            computed_at = preserved_computed_at;
+            duration_ms = preserved_duration_ms;
             error = Some error;
             stale_since_ts;
+            last_good_available;
           };
       full_health_refresh_in_flight := false;
       full_health_refresh_started_at := None;
@@ -1261,6 +1290,8 @@ let full_health_snapshot_metadata ~now ~refresh_in_flight ~refresh_started_at
     | Some snapshot ->
         let status =
           match snapshot.error with
+          | Some _ when snapshot.last_good_available -> "stale"
+          | Some error when full_health_refresh_timeout_error error -> "timeout"
           | Some _ -> "error"
           | None when snapshot_is_stale ~now snapshot -> "stale"
           | None -> "ready"
@@ -1294,6 +1325,7 @@ let full_health_snapshot_metadata ~now ~refresh_in_flight ~refresh_started_at
         `Int (int_of_float (full_health_refresh_timeout_sec *. 1000.)) );
       ("component_timed_out", `Bool component_timed_out);
       ("error", error);
+      ("last_good_available", `Bool (Option.fold ~none:false ~some:(fun s -> s.last_good_available) snapshot));
       (* [stale_since_ts] is the wall-clock of the FIRST failure of
          the current outage; null when the snapshot is fresh.
          Consumers should prefer this over [computed_at_unix] for

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1389,10 +1389,13 @@ let test_full_health_refresh_timeout_preserves_last_snapshot () =
   in
   Server_routes_http_runtime.For_testing.mark_full_health_snapshot_error timeout_error;
   let after = Server_routes_http_runtime.make_health_response_json request in
-  Alcotest.(check string) "timeout marks snapshot error" "error"
+  Alcotest.(check string) "timeout marks snapshot stale" "stale"
     (after |> member "full_health_snapshot" |> member "status" |> to_string);
   Alcotest.(check bool) "timeout marks timed out component" true
     (after |> member "full_health_snapshot" |> member "component_timed_out"
+     |> to_bool);
+  Alcotest.(check bool) "timeout keeps last-good marker" true
+    (after |> member "full_health_snapshot" |> member "last_good_available"
      |> to_bool);
   Alcotest.(check string) "timeout error is surfaced" (Printexc.to_string timeout_error)
     (after |> member "full_health_snapshot" |> member "error" |> to_string);
@@ -1403,6 +1406,28 @@ let test_full_health_refresh_timeout_preserves_last_snapshot () =
   Alcotest.(check string) "timeout preserves previous heavy fields"
     (Yojson.Safe.to_string before_reaction_ledger)
     (after |> member "keeper_reaction_ledger" |> Yojson.Safe.to_string)
+
+let test_full_health_cold_refresh_timeout_is_timeout_not_error () =
+  Server_routes_http_runtime.For_testing.reset_full_health_snapshot ();
+  let request = Httpun.Request.create `GET "/health?full=1" in
+  let timeout_error =
+    Failure
+      "refresh_timeout label=full_health_snapshot phase=refresh timeout_s=16.0 \
+       elapsed_s=17.0"
+  in
+  Server_routes_http_runtime.For_testing.mark_full_health_snapshot_error timeout_error;
+  let after = Server_routes_http_runtime.make_health_response_json request in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string) "cold timeout status" "timeout"
+    (after |> member "full_health_snapshot" |> member "status" |> to_string);
+  Alcotest.(check bool) "cold timeout marks metadata timeout" true
+    (after |> member "full_health_snapshot" |> member "component_timed_out"
+     |> to_bool);
+  Alcotest.(check bool) "cold timeout has no last good" false
+    (after |> member "full_health_snapshot" |> member "last_good_available"
+     |> to_bool);
+  Alcotest.(check bool) "cold timeout marks component timeout" true
+    (after |> member "cdal" |> member "component_timed_out" |> to_bool)
 
 let test_health_response_survives_deleted_cwd () =
   with_temp_dir "health-deleted-cwd" (fun dir ->
@@ -2965,6 +2990,9 @@ let () =
           Alcotest.test_case
             "full health refresh timeout preserves last snapshot" `Quick
             test_full_health_refresh_timeout_preserves_last_snapshot;
+          Alcotest.test_case
+            "full health cold refresh timeout is timeout" `Quick
+            test_full_health_cold_refresh_timeout_is_timeout_not_error;
           Alcotest.test_case "health response survives deleted cwd" `Quick
             test_health_response_survives_deleted_cwd;
           Alcotest.test_case "readiness false before init" `Quick


### PR DESCRIPTION
## Summary
- classify /health?full=1 refresh timeouts with last-good payloads as stale instead of error
- classify cold-start refresh timeouts without last-good payloads as timeout
- expose last_good_available metadata and component_timed_out markers for placeholder sections
- add bootstrap tests for stale fallback and cold timeout behavior

## Validation
- git diff --check origin/main..HEAD
- ocamlformat --check lib/server/server_routes_http_runtime.ml test/test_server_runtime_bootstrap.ml
- ocamlc -stop-after parsing -impl lib/server/server_routes_http_runtime.ml
- ocamlc -stop-after parsing -impl test/test_server_runtime_bootstrap.ml

## Local caveat
- scripts/dune-local.sh build test/test_server_runtime_bootstrap.exe was attempted but refused to start because a bare dune build was already running outside scripts/dune-local.sh: PID 30472, dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp bin/main_eio.exe. This draft PR leaves CI as the full Dune verification path.