### PR TITLE
ci: add code-smell lint gates

### DIFF
--- a/.github/workflows/code-smell-audit.yml
+++ b/.github/workflows/code-smell-audit.yml
@@ -1,0 +1,29 @@
+name: Code Smell Audit
+
+on:
+  schedule:
+    - cron: "19 3 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: code-smell-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: Weekly audit-code-smell.sh
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install ripgrep
+        run: sudo apt-get install -y -qq ripgrep
+      - name: Run audit
+        run: bash scripts/audit-code-smell.sh > code-smell-audit.md
+      - name: Upload audit artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-smell-audit
+          path: code-smell-audit.md

--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -148,6 +148,33 @@ jobs:
           BASE: ${{ github.event.pull_request.base.ref && format('origin/{0}', github.event.pull_request.base.ref) || '' }}
         run: bash scripts/lint/godfile-size-regression.sh
 
+  ignore-without-comment-new:
+    name: ignore() justification (new sites)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install ripgrep
+        run: sudo apt-get install -y -qq ripgrep
+      - name: Run lint
+        run: |
+          bash scripts/ci/check-ignore-without-comment-diff.sh \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head HEAD
+
+  magic-number-advisory:
+    name: Magic number repetition (advisory)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install ripgrep
+        run: sudo apt-get install -y -qq ripgrep
+      - name: Run lint
+        run: bash scripts/lint-magic-number.sh
+
   yaml-syntax:
     name: Workflow YAML syntax
     runs-on: ubuntu-latest

--- a/scripts/ci/check-ignore-without-comment-diff.sh
+++ b/scripts/ci/check-ignore-without-comment-diff.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Fail PRs that add a new `ignore (...)` call without an accepted
+# justification comment. Existing debt remains visible through
+# scripts/lint-ignore-without-comment.sh and scripts/audit-code-smell.sh.
+
+set -euo pipefail
+
+BASE="${BASE:-}"
+HEAD="${HEAD:-HEAD}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base) BASE="$2"; shift 2 ;;
+    --head) HEAD="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$BASE" ]]; then
+  BASE="origin/main"
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "ripgrep (rg) is required" >&2
+  exit 2
+fi
+
+tmp_added="$(mktemp)"
+tmp_unjust="$(mktemp)"
+tmp_unjust_sites="$(mktemp)"
+tmp_fail="$(mktemp)"
+trap 'rm -f "$tmp_added" "$tmp_unjust" "$tmp_unjust_sites" "$tmp_fail"' EXIT
+
+git diff --unified=0 --diff-filter=ACMR "$BASE" "$HEAD" -- '*.ml' '*.mli' \
+  | perl -ne '
+      if (/^\+\+\+ b\/(.+)$/) {
+        $file = $1;
+        next;
+      }
+      if (/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/) {
+        $line = $1 - 1;
+        next;
+      }
+      next unless defined $file;
+      if (/^\+/ && !/^\+\+\+/) {
+        $line++;
+        $body = substr($_, 1);
+        if ($body =~ /^\s*ignore\s+\(/) {
+          print "$file:$line\n";
+        }
+        next;
+      }
+      if (!/^\-/ && !/^diff --git/ && !/^index / && !/^--- /) {
+        $line++;
+      }
+    ' > "$tmp_added"
+
+if [[ ! -s "$tmp_added" ]]; then
+  echo "No new ignore() sites in PR diff."
+  exit 0
+fi
+
+cut -d: -f1 "$tmp_added" | sort -u \
+  | while IFS= read -r file; do
+      if [[ -f "$file" ]]; then
+        bash scripts/lint-ignore-without-comment.sh --target "$file" || true
+      fi
+    done > "$tmp_unjust"
+
+awk -F: '{ print $1 ":" $2 }' "$tmp_unjust" | sort -u > "$tmp_unjust_sites"
+sort -u "$tmp_added" | grep -Fxf - "$tmp_unjust_sites" > "$tmp_fail" || true
+
+if [[ -s "$tmp_fail" ]]; then
+  echo "New ignore() calls require a justification comment:"
+  while IFS= read -r site; do
+    grep -F "${site}:" "$tmp_unjust" || true
+  done < "$tmp_fail"
+  echo
+  echo "Accepted shapes: WORKAROUND, HACK, fire-and-forget, RFC-XXXX, TODO, See/see."
+  exit 1
+fi
+
+echo "New ignore() sites are justified."


### PR DESCRIPTION
## Summary
- add a PR diff gate for newly added ignore() calls without justification comments
- add magic-number repetition as an advisory Fundamental Check job
- add a weekly/manual Code Smell Audit workflow that uploads scripts/audit-code-smell.sh output

## Validation
- bash -n scripts/ci/check-ignore-without-comment-diff.sh
- bash scripts/ci/check-ignore-without-comment-diff.sh --base origin/main --head HEAD
- bash scripts/lint-magic-number.sh
- bash scripts/audit-code-smell.sh
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/fundamental-check.yml .github/workflows/code-smell-audit.yml
- git diff --check origin/main..HEAD