### PR TITLE
[codex] Fix worker spawn allowlist drift

### DIFF
--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -31,8 +31,8 @@ lib/process/process_eio.ml:535
 # manager itself. Bounded by session scope, not by per-call timeout.
 lib/server/lsp_process_manager.ml:178
 
-# lib/worker_dev_tools.ml:1283 — dev-tools worker spawn. Wrapped by
+# lib/worker_dev_tools.ml:1204 — dev-tools worker spawn. Wrapped by
 # Tool_resource_gate, Fd_accountant, Eio.Time.with_timeout_exn, and a fresh
 # Eio.Switch.run at the call boundary. Line renumbered by worker-dev-tools
 # split/refactor waves.
-lib/worker_dev_tools.ml:1283
+lib/worker_dev_tools.ml:1204


### PR DESCRIPTION
Summary
- Update scripts/lint-spawn-bounded.allowlist for the worker_dev_tools.ml line shift introduced by #17084.
- No runtime code changes.

Validation
- bash scripts/lint-spawn-bounded.sh
- git diff --check origin/main..HEAD