### PR TITLE
feat(dashboard): couple keeper runtime projection

### DIFF
--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -755,6 +755,8 @@ describe('RuntimeLensSection', () => {
     })
 
     expect(summary.headline).toBe('조치 필요')
+    expect(summary.rows.find(row => row.label === '동기화')?.detail).toContain('tool needs_execution_progress')
+    expect(summary.rows.find(row => row.label === '동기화')?.detail).toContain('KSM running')
     expect(summary.rows.find(row => row.label === '런타임')?.value).toBe('fiber alive')
     expect(summary.rows.find(row => row.label === '현재 턴')?.value).toBe('no live turn')
     expect(summary.rows.find(row => row.label === '최신 증거')?.value).toBe('turn #7 finished')
@@ -766,6 +768,8 @@ describe('RuntimeLensSection', () => {
   })
 
   it('keeps previous receipt blockers out of the current live-turn summary', () => {
+    const trace = runtimeTraceFixture()
+    trace.runtime_lens.gaps = []
     const summary = deriveKeeperLiveTruth({
       keeper: {
         name: 'sangsu',
@@ -798,7 +802,7 @@ describe('RuntimeLensSection', () => {
           live_turn_last_progress_at: 1_778_688_699,
         },
       }),
-      runtimeTrace: runtimeTraceFixture(),
+      runtimeTrace: trace,
       runtimeResolution: null,
     })
 

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -4,17 +4,12 @@
 
 import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
-// RFC-0135 PR-5: detail panel and roster card derive blocker conditioning
-// through the same typed `KeeperOperationalState` SSOT (PR-1 #16576), so
-// `현재 차단 / 이전 차단` decisions cannot diverge between the two
-// surfaces. The `runtime_attention.blocked / needs_attention` signals
-// represent *live-execution* attention (`execution_current && blocked`,
-// see `lib/server/server_dashboard_http.ml:1114`), which is orthogonal to
-// the blocker-class-vs-stale-execution axis and stays inline below.
-import { deriveKeeperOperationalState } from '../lib/keeper-operational-state'
-import { deriveFiberAlive } from '../lib/keeper-fiber-alive'
 import { formatPct1 } from '../lib/format-number'
-import { formatDuration } from '../lib/format-time'
+import {
+  compactToken,
+  deriveKeeperRuntimeProjection,
+  type KeeperRuntimeProjectionRuntimeInput,
+} from '../lib/keeper-runtime-projection'
 import { ActionButton } from './common/button'
 import { CollapsibleSection } from './common/collapsible'
 import { DistributionBars, type DistributionItem } from './common/distribution-bars'
@@ -81,18 +76,7 @@ function SignalRow({ label, value, title }: { label: string; value: string | num
   `
 }
 
-interface KeeperLiveTruthRuntimeInput {
-  status?: string | null
-  warnings?: string[]
-  source_mismatch?: boolean
-  server_repo_path?: { path?: string | null } | null
-  server_repo_git_commit?: string | null
-  workspace_git_commit?: string | null
-  build?: {
-    commit?: string | null
-    started_at?: string | null
-  } | null
-}
+type KeeperLiveTruthRuntimeInput = KeeperRuntimeProjectionRuntimeInput
 
 export interface KeeperLiveTruthRow {
   label: string
@@ -110,82 +94,6 @@ export interface KeeperLiveTruthSummary {
   runtimeRepoLabel: string | null
 }
 
-function compactToken(value: string | null | undefined, fallback = 'unknown'): string {
-  const text = value?.trim()
-  return text ? text : fallback
-}
-
-function shortCommit(value: string | null | undefined): string | null {
-  const text = value?.trim()
-  return text ? text.slice(0, 10) : null
-}
-
-// Backend `turn_phase` SSOT = `Keeper_composite_observer.turn_phase_to_string`
-// (lib/keeper/keeper_composite_observer.ml:149-157), which emits exactly 7
-// strings: idle / prompting / routing / executing / compacting / finalizing
-// / exhausted. Only "idle" classifies as idle; the other 6 are active.
-// Empty/missing turn_phase also degrades to idle (no active turn signal).
-//
-// The previous version also matched `"stable"` and `"offline"` here.
-// Those are *different axis* vocabularies (`"stable"` belongs to
-// `KeeperCompositePhase`, `"offline"` belongs to keeper linked-state),
-// never emitted into the `turn_phase` slot. Removing them tightens this
-// classifier to the actual backend vocabulary and surfaces noun-collision
-// bugs instead of silently absorbing them.
-function isIdleTurnPhase(value: string | null | undefined): boolean {
-  const normalized = value?.trim().toLowerCase()
-  return !normalized || normalized === 'idle' || normalized === 'unknown'
-}
-
-function runtimeWarningList(runtimeResolution: KeeperLiveTruthRuntimeInput | null | undefined): string[] {
-  if (!runtimeResolution) return []
-  const warnings = Array.isArray(runtimeResolution.warnings)
-    ? runtimeResolution.warnings.filter((warning): warning is string => warning.trim() !== '')
-    : []
-  if (runtimeResolution.source_mismatch && warnings.length === 0) {
-    return ['Runtime source mismatch detected.']
-  }
-  return warnings
-}
-
-function terminalEventLabel(trace: KeeperRuntimeTraceResponse | null): {
-  value: string
-  detail: string
-  tone: StatusChipTone
-} {
-  if (!trace) {
-    return {
-      value: 'trace unavailable',
-      detail: 'runtime_trace evidence not loaded',
-      tone: 'neutral',
-    }
-  }
-  const clock = trace.runtime_lens.turn_clock
-  const keeperTurn = clock.keeper_turn_id ?? trace.turn_identity.requested_keeper_turn_id ?? trace.turn_id
-  const turnLabel = keeperTurn == null ? 'turn unknown' : `turn #${keeperTurn}`
-  const terminal = clock.terminal_event_present ? compactToken(clock.terminal_event, 'terminal present') : 'terminal missing'
-  const gapCount = trace.runtime_lens.gaps.length
-  const terminalTone: StatusChipTone =
-    gapCount > 0
-      ? 'warn'
-      : !clock.terminal_event_present
-        ? 'warn'
-        : terminal === 'turn_finished'
-          ? 'ok'
-          : 'info'
-  const detailParts = [
-    `oas ${clock.max_oas_turn_count ?? '-'}`,
-    `manifest ${clock.manifest_total_rows}`,
-    `health ${compactToken(trace.health)}`,
-    gapCount > 0 ? `${gapCount} lens gap${gapCount === 1 ? '' : 's'}` : 'no lens gaps',
-  ]
-  return {
-    value: `${turnLabel} ${terminal === 'turn_finished' ? 'finished' : terminal}`,
-    detail: detailParts.join(' · '),
-    tone: terminalTone,
-  }
-}
-
 export function deriveKeeperLiveTruth({
   keeper,
   compositeSnapshot,
@@ -197,108 +105,53 @@ export function deriveKeeperLiveTruth({
   runtimeTrace: KeeperRuntimeTraceResponse | null
   runtimeResolution?: KeeperLiveTruthRuntimeInput | null
 }): KeeperLiveTruthSummary {
-  const linkedState = linkedRuntimeState(keeper)
-  // RFC-0135 Goal-2 closeout: turn phase, display summary and phase are
-  // now per-variant axes on the typed `KeeperOperationalState`, so this
-  // surface no longer keeps its own composite-vs-flat fallback chain.
-  const opState = deriveKeeperOperationalState({
+  const projection = deriveKeeperRuntimeProjection({
     keeper,
     composite: compositeSnapshot,
+    runtimeTrace,
+    runtimeResolution,
+    linkedState: linkedRuntimeState(keeper),
   })
-  const turnPhase = compactToken(opState.turnPhase)
-  // Typed SSOT (lib/keeper-fiber-alive.ts) — preserves provenance instead of
-  // collapsing four semantically distinct signals into one OR-chain.
-  const fiberAlive = deriveFiberAlive({
-    keeper,
-    composite: compositeSnapshot,
-    linkedState,
-  }).alive
-  const activeTurn = compositeSnapshot?.is_live === true || !isIdleTurnPhase(opState.turnPhase)
 
+  const opState = projection.opState
+  const fiberAlive = projection.fiberAlive.alive
   const stuckByBlockerClass = opState.kind === 'stuck'
   const staleBlocker = opState.kind === 'running' ? opState.staleBlocker : null
   const attention = opState.attention
-  const blocked = stuckByBlockerClass || attention !== 'clean'
-  const stopRequested =
-    compositeSnapshot?.runtime_attention?.fiber_stop_requested === true
-    || compositeSnapshot?.phase_diagnosis?.conditions.stop_requested === true
-  const traceEvidence = terminalEventLabel(runtimeTrace)
-  const warnings = runtimeWarningList(runtimeResolution)
-  const headline =
-    stopRequested
-      ? '종료 신호'
-      : blocked
-        ? '조치 필요'
-        : fiberAlive && activeTurn
-          ? '턴 진행 중'
-          : fiberAlive
-            ? '대기 중'
-            : runtimeTrace
-              ? '실행 미확인'
-              : '증거 부족'
-  const tone: StatusChipTone =
-    stopRequested
-      ? 'bad'
-      : blocked || warnings.length > 0
-        ? 'warn'
-        : fiberAlive && activeTurn
-          ? 'ok'
-          : fiberAlive
-            ? 'neutral'
-            : runtimeTrace
-              ? 'warn'
-              : 'neutral'
-
-  const idleLabel =
-    typeof compositeSnapshot?.idle_seconds === 'number'
-      ? `${formatDuration(compositeSnapshot.idle_seconds)} idle`
-      : typeof keeper.last_turn_ago_s === 'number'
-        ? `${formatDuration(keeper.last_turn_ago_s)} since turn`
-        : 'idle age unknown'
-  const runtimeReason = compactToken(opState.displaySummary, 'no blocker reason')
-  const toolContract = compactToken(compositeSnapshot?.execution?.tool_contract_result ?? null, 'tool contract unknown')
+  const blocked = projection.blocked
+  const traceEvidence = projection.traceEvidence
   // guardCount / invariantFailed have moved to FsmHub mode='detail' — they
   // are rendered on the dedicated FSM lane strip directly under this panel
   // and no longer need to be projected as a row here.
-  const runtimeCommit =
-    shortCommit(runtimeResolution?.server_repo_git_commit)
-    ?? shortCommit(runtimeResolution?.build?.commit)
-  const workspaceCommit = shortCommit(runtimeResolution?.workspace_git_commit)
-  const runtimeBuildLabel = runtimeCommit
-    ? workspaceCommit && workspaceCommit !== runtimeCommit
-      ? `${runtimeCommit} vs workspace ${workspaceCommit}`
-      : runtimeCommit
-    : null
-  const runtimeRepoLabel = runtimeResolution?.server_repo_path?.path
-    ? runtimeResolution.server_repo_path.path.split('/').slice(-2).join('/')
-    : null
-
-  // RFC-0046 §4.3 partial closure (2026-05-19): the FSM row used to duplicate
-  // FsmHub mode='detail' (KSM/KTC/KDP/KCL/KMC/breaker lanes rendered directly
-  // below this panel). Dropping it here makes FsmHub the sole on-screen
-  // consumer of the composite invariant/guard axes. The remaining rows cover
-  // axes FsmHub does not (roster/linked runtime, idle-since label, terminal
-  // trace event, runtime_attention reason).
+  // The dedicated `동기화` row is the coupled projection: heartbeat/context/
+  // social/fiber/stop/trace/tool/FSM lanes move as one derived object while
+  // FsmHub still renders raw lanes below this panel.
   const fiberLabel = fiberAlive ? 'fiber alive' : 'fiber not proven'
-  const liveTurnLabel = activeTurn ? `${turnPhase} live` : 'no live turn'
+  const liveTurnLabel = projection.activeTurn ? `${projection.turnPhase} live` : 'no live turn'
   return {
-    headline,
-    tone,
-    runtimeWarnings: warnings,
-    runtimeBuildLabel,
-    runtimeRepoLabel,
+    headline: projection.headline,
+    tone: projection.tone,
+    runtimeWarnings: projection.runtimeWarnings,
+    runtimeBuildLabel: projection.runtimeBuildLabel,
+    runtimeRepoLabel: projection.runtimeRepoLabel,
     rows: [
+      {
+        label: '동기화',
+        value: projection.synchronizationLabel,
+        detail: projection.synchronizationDetail,
+        tone: projection.tone,
+      },
       {
         label: '런타임',
         value: fiberLabel,
-        detail: `roster ${keeper.status} · linked ${linkedState}`,
+        detail: `roster ${keeper.status} · linked ${projection.linkedState} · ${projection.fiberAlive.source}`,
         tone: fiberAlive ? 'ok' : 'warn',
       },
       {
         label: '현재 턴',
         value: liveTurnLabel,
-        detail: `${compositeSnapshot ? (compositeSnapshot.is_live === true ? 'is_live=true' : 'is_live=false') : 'is_live=unknown'} · ${turnPhase} · ${idleLabel}`,
-        tone: activeTurn ? 'ok' : 'neutral',
+        detail: `${compositeSnapshot ? (compositeSnapshot.is_live === true ? 'is_live=true' : 'is_live=false') : 'is_live=unknown'} · ${projection.turnPhase} · ${projection.idleLabel}`,
+        tone: projection.activeTurn ? 'ok' : 'neutral',
       },
       {
         label: '최신 증거',
@@ -321,8 +174,8 @@ export function deriveKeeperLiveTruth({
             ? compactToken(compositeSnapshot?.runtime_attention?.state, 'blocked')
             : 'none',
         detail: staleBlocker !== null
-          ? `${runtimeReason} · ${toolContract} · 이전 차단: ${staleBlocker}`
-          : `${runtimeReason} · ${toolContract}`,
+          ? `${projection.runtimeReason} · ${projection.toolContract} · 이전 차단: ${staleBlocker}`
+          : `${projection.runtimeReason} · ${projection.toolContract}`,
         tone: blocked ? 'warn' : 'ok',
       },
     ],

--- a/dashboard/src/lib/keeper-runtime-projection.test.ts
+++ b/dashboard/src/lib/keeper-runtime-projection.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Keeper } from '../types'
+import type { KeeperRuntimeTraceResponse } from '../api/keeper'
+import type { KeeperCompositeSnapshot } from '../api/schemas/keeper-composite'
+import { deriveKeeperRuntimeProjection } from './keeper-runtime-projection'
+
+const NOW_MS = Date.parse('2026-05-21T00:10:00Z')
+
+function keeper(overrides: Partial<Keeper> = {}): Keeper {
+  return {
+    name: 'sangsu',
+    status: 'active',
+    phase: 'Running',
+    keepalive_running: true,
+    ...overrides,
+  } as Keeper
+}
+
+function composite(overrides: Partial<KeeperCompositeSnapshot> = {}): KeeperCompositeSnapshot {
+  const base = {
+    keeper: 'sangsu',
+    correlation_id: 'corr-1',
+    run_id: 'run-1',
+    ts: 1,
+    phase: 'running',
+    turn_phase: 'idle',
+    decision: { stage: 'idle' },
+    cascade: { state: 'idle' },
+    compaction: { stage: 'idle' },
+    circuit_breaker: { state: 'closed' },
+    measurement: { captured: true },
+    invariants: {
+      phase_turn_alignment: true,
+      no_cascade_before_measurement: true,
+      compaction_atomicity: true,
+      event_priority_monotone: true,
+      phase_derivation_agreement: true,
+    },
+    fsm_guard_violations: 0,
+    phase_diagnosis: {
+      current_phase: 'Running',
+      derived_phase: 'Running',
+      can_execute_turn: true,
+      conditions: {
+        launch_pending: false,
+        fiber_alive: true,
+        heartbeat_healthy: true,
+        turn_healthy: true,
+        context_within_budget: true,
+        context_handoff_needed: false,
+        compaction_active: false,
+        handoff_active: false,
+        operator_paused: false,
+        stop_requested: false,
+        restart_budget_remaining: true,
+        backoff_elapsed: true,
+        guardrail_triggered: false,
+        drain_complete: false,
+        context_overflow: false,
+        compact_retry_exhausted: false,
+        terminal_failure_latched: false,
+      },
+      determining_condition: 'running_fiber_alive',
+      rows: [],
+    },
+    is_live: false,
+    last_outcome: null,
+    execution: {
+      latest_receipt_present: true,
+      recorded_at: '2026-05-21T00:00:00Z',
+      outcome: 'receipt_done',
+      terminal_reason_code: 'completed',
+      operator_disposition: 'pass',
+      operator_disposition_reason: 'healthy',
+      model_used: null,
+      stop_reason: 'completed',
+      tool_contract_result: 'satisfied_execution',
+      duration_ms: 1000,
+      error: null,
+      cascade: null,
+      tool_surface: null,
+    },
+    runtime_attention: {
+      state: 'ok',
+      needs_attention: false,
+      blocked: false,
+      fiber_stop_requested: false,
+      reason: null,
+      raw_phase: 'running',
+      is_live: false,
+      source: 'execution_receipt',
+    },
+    recommended_actions: [],
+  } as KeeperCompositeSnapshot
+  return { ...base, ...overrides } as KeeperCompositeSnapshot
+}
+
+function runtimeTrace(overrides: Partial<KeeperRuntimeTraceResponse> = {}): KeeperRuntimeTraceResponse {
+  const base = {
+    keeper: 'sangsu',
+    trace_id: 'trace-1',
+    turn_id: 7,
+    manifest_path: '/tmp/manifest.jsonl',
+    manifest_path_present: true,
+    manifest_total_rows: 6,
+    manifest_returned_rows: 6,
+    receipt_returned_rows: 1,
+    turn_identity: { requested_keeper_turn_id: 7 },
+    provider_attempts: {},
+    event_bus: {},
+    memory: {},
+    runtime_lens: {
+      turn_clock: {
+        keeper_turn_id: 7,
+        terminal_event_present: true,
+        terminal_event: 'turn_finished',
+        max_oas_turn_count: 3,
+      },
+      axes: {},
+      swimlanes: {},
+      gaps: [],
+    },
+    linked_artifacts: { receipts: [], checkpoints: [], tool_call_logs: [] },
+    manifest_rows: [],
+    receipts: [],
+    health: 'ok',
+    stale_reason: null,
+  } as unknown as KeeperRuntimeTraceResponse
+  return { ...base, ...overrides } as KeeperRuntimeTraceResponse
+}
+
+describe('deriveKeeperRuntimeProjection', () => {
+  it('couples heartbeat, context, social, fiber, stop, trace, tool, and FSM lanes', () => {
+    const projection = deriveKeeperRuntimeProjection({
+      keeper: keeper({
+        last_heartbeat: '2026-05-21T00:00:00Z',
+        context_ratio: 0.97,
+        runtime_warning_ctx_ratio: 0.95,
+        social_model_recognized: false,
+      }),
+      composite: composite({
+        phase: 'failing',
+        turn_phase: 'executing',
+        decision: { stage: 'tool_required' },
+        cascade: { state: 'degraded_retry' },
+        compaction: { stage: 'idle' },
+        circuit_breaker: { state: 'closed' },
+        execution: {
+          ...composite().execution!,
+          tool_contract_result: 'missing_required_tool_use',
+        },
+      }),
+      runtimeTrace: runtimeTrace(),
+      runtimeResolution: {
+        warnings: ['Runtime build commit differs from server repo HEAD.'],
+        source_mismatch: true,
+      },
+      nowMs: NOW_MS,
+    })
+
+    expect(projection.headline).toBe('조치 필요')
+    expect(projection.heartbeat.stale).toBe(true)
+    expect(projection.context.breach).toBe(true)
+    expect(projection.socialModel.recognized).toBe(false)
+    expect(projection.fiberAlive.alive).toBe(true)
+    expect(projection.toolContract).toBe('missing_required_tool_use')
+    expect(projection.fsmLanes.map(lane => lane.axis)).toEqual(['KSM', 'KTC', 'KDP', 'KCL', 'KMC', 'KCB'])
+    expect(projection.signals.map(signal => signal.kind)).toEqual([
+      'operational_state',
+      'ksm_phase',
+      'heartbeat',
+      'context_ratio',
+      'social_model',
+      'fiber_alive',
+      'stop_requested',
+      'runtime_trace',
+      'runtime_warning',
+      'tool_contract',
+      'fsm_raw_lanes',
+    ])
+    expect(projection.synchronizationDetail).toContain('hb stale')
+    expect(projection.synchronizationDetail).toContain('ctx breach')
+    expect(projection.synchronizationDetail).toContain('social unrecognized')
+    expect(projection.synchronizationDetail).toContain('fiber alive')
+    expect(projection.synchronizationDetail).toContain('stop clear')
+    expect(projection.synchronizationDetail).toContain('tool missing_required_tool_use')
+    expect(projection.synchronizationDetail).toContain('KSM failing')
+  })
+
+  it('lets stop requests dominate the coupled headline and tone', () => {
+    const projection = deriveKeeperRuntimeProjection({
+      keeper: keeper(),
+      composite: composite({
+        runtime_attention: {
+          ...composite().runtime_attention!,
+          fiber_stop_requested: true,
+        },
+      }),
+      nowMs: NOW_MS,
+    })
+
+    expect(projection.stopRequested).toBe(true)
+    expect(projection.headline).toBe('종료 신호')
+    expect(projection.tone).toBe('bad')
+  })
+
+  it('does not turn a stale execution receipt tool contract into current attention', () => {
+    const projection = deriveKeeperRuntimeProjection({
+      keeper: keeper(),
+      composite: composite({
+        is_live: true,
+        turn_phase: 'executing',
+        execution: {
+          ...composite().execution!,
+          tool_contract_result: 'needs_execution_progress',
+        },
+        runtime_attention: {
+          ...composite().runtime_attention!,
+          execution_current: false,
+          stale_execution_receipt: true,
+          is_live: true,
+        },
+      }),
+      runtimeTrace: runtimeTrace(),
+      nowMs: NOW_MS,
+    })
+
+    expect(projection.signals.find(signal => signal.kind === 'tool_contract')?.contributesToAttention).toBe(false)
+    expect(projection.headline).toBe('턴 진행 중')
+    expect(projection.tone).toBe('ok')
+  })
+})

--- a/dashboard/src/lib/keeper-runtime-projection.ts
+++ b/dashboard/src/lib/keeper-runtime-projection.ts
@@ -1,0 +1,569 @@
+import type { Keeper } from '../types'
+import type { KeeperRuntimeTraceResponse } from '../api/keeper'
+import type { KeeperCompositeSnapshot } from '../api/schemas/keeper-composite'
+import { ATTENTION_PHASES, isKeeperOffline } from './keeper-predicates'
+import { deriveFiberAlive, type FiberAliveDecision } from './keeper-fiber-alive'
+import {
+  deriveKeeperOperationalState,
+  type KeeperOperationalState,
+} from './keeper-operational-state'
+import { formatDuration } from './format-time'
+
+export type KeeperLinkedRuntimeState = 'offline' | 'online' | 'unlinked'
+export type KeeperRuntimeProjectionTone = 'ok' | 'warn' | 'bad' | 'info' | 'neutral'
+
+export type KeeperRuntimeProjectionSignalKind =
+  | 'operational_state'
+  | 'ksm_phase'
+  | 'heartbeat'
+  | 'context_ratio'
+  | 'social_model'
+  | 'fiber_alive'
+  | 'stop_requested'
+  | 'runtime_trace'
+  | 'runtime_warning'
+  | 'tool_contract'
+  | 'fsm_raw_lanes'
+
+export type KeeperRuntimeProjectionSignalState =
+  | 'ok'
+  | 'attention'
+  | 'bad'
+  | 'info'
+  | 'unknown'
+
+export interface KeeperRuntimeProjectionSignal {
+  readonly kind: KeeperRuntimeProjectionSignalKind
+  readonly label: string
+  readonly value: string
+  readonly detail: string
+  readonly tone: KeeperRuntimeProjectionTone
+  readonly state: KeeperRuntimeProjectionSignalState
+  readonly contributesToAttention: boolean
+  readonly hint: string | null
+}
+
+export interface KeeperRuntimeProjectionRuntimeInput {
+  readonly status?: string | null
+  readonly warnings?: string[]
+  readonly source_mismatch?: boolean
+  readonly server_repo_path?: { readonly path?: string | null } | null
+  readonly server_repo_git_commit?: string | null
+  readonly workspace_git_commit?: string | null
+  readonly build?: {
+    readonly commit?: string | null
+    readonly started_at?: string | null
+  } | null
+}
+
+export interface KeeperRuntimeProjectionFsmLane {
+  readonly axis: 'KSM' | 'KTC' | 'KDP' | 'KCL' | 'KMC' | 'KCB'
+  readonly source: string
+  readonly value: string
+  readonly contributesToAttention: boolean
+}
+
+export interface KeeperHeartbeatProjection {
+  readonly stale: boolean
+  readonly lastHeartbeat: string | null
+  readonly ageMs: number | null
+  readonly thresholdMs: number
+}
+
+export interface KeeperContextProjection {
+  readonly breach: boolean
+  readonly ratio: number | null
+  readonly threshold: number
+}
+
+export interface KeeperSocialModelProjection {
+  readonly recognized: boolean | null
+}
+
+export interface KeeperRuntimeTraceProjection {
+  readonly value: string
+  readonly detail: string
+  readonly tone: KeeperRuntimeProjectionTone
+  readonly loaded: boolean
+}
+
+export interface KeeperRuntimeProjection {
+  readonly opState: KeeperOperationalState
+  readonly linkedState: KeeperLinkedRuntimeState
+  readonly fiberAlive: FiberAliveDecision
+  readonly activeTurn: boolean
+  readonly blocked: boolean
+  readonly stopRequested: boolean
+  readonly heartbeat: KeeperHeartbeatProjection
+  readonly context: KeeperContextProjection
+  readonly socialModel: KeeperSocialModelProjection
+  readonly traceEvidence: KeeperRuntimeTraceProjection
+  readonly runtimeWarnings: string[]
+  readonly toolContract: string
+  readonly fsmLanes: KeeperRuntimeProjectionFsmLane[]
+  readonly signals: KeeperRuntimeProjectionSignal[]
+  readonly headline: string
+  readonly tone: KeeperRuntimeProjectionTone
+  readonly turnPhase: string
+  readonly idleLabel: string
+  readonly runtimeReason: string
+  readonly runtimeBuildLabel: string | null
+  readonly runtimeRepoLabel: string | null
+  readonly synchronizationLabel: string
+  readonly synchronizationDetail: string
+}
+
+interface DeriveKeeperRuntimeProjectionInput {
+  readonly keeper: Keeper
+  readonly composite: KeeperCompositeSnapshot | null
+  readonly runtimeTrace?: KeeperRuntimeTraceResponse | null
+  readonly runtimeResolution?: KeeperRuntimeProjectionRuntimeInput | null
+  readonly linkedState?: KeeperLinkedRuntimeState
+  readonly nowMs?: number
+}
+
+// 5-minute threshold for the operator-facing monitoring band. This is longer
+// than transport heartbeat checks so short SSE reconnects do not become keeper
+// attention events.
+export const KEEPER_RUNTIME_HEARTBEAT_STALE_MS = 5 * 60 * 1000
+export const KEEPER_RUNTIME_CONTEXT_ATTENTION_RATIO = 0.95
+
+export function compactToken(value: string | null | undefined, fallback = 'unknown'): string {
+  const text = value?.trim()
+  return text ? text : fallback
+}
+
+export function shortCommit(value: string | null | undefined): string | null {
+  const text = value?.trim()
+  return text ? text.slice(0, 10) : null
+}
+
+export function deriveKeeperLinkedRuntimeState(keeper: Keeper | null | undefined): KeeperLinkedRuntimeState {
+  if (!keeper) return 'unlinked'
+  if (keeper.agent?.exists === false) return 'offline'
+  return isKeeperOffline(keeper) ? 'offline' : 'online'
+}
+
+export function deriveKeeperRuntimeProjection({
+  keeper,
+  composite,
+  runtimeTrace = null,
+  runtimeResolution = null,
+  linkedState = deriveKeeperLinkedRuntimeState(keeper),
+  nowMs = Date.now(),
+}: DeriveKeeperRuntimeProjectionInput): KeeperRuntimeProjection {
+  const opState = deriveKeeperOperationalState({ keeper, composite })
+  const turnPhase = compactToken(opState.turnPhase)
+  const fiberAlive = deriveFiberAlive({ keeper, composite, linkedState })
+  const activeTurn = composite?.is_live === true || !isIdleTurnPhase(opState.turnPhase)
+  const blocked = opState.kind === 'stuck' || opState.attention !== 'clean'
+  const stopRequested =
+    composite?.runtime_attention?.fiber_stop_requested === true
+    || composite?.phase_diagnosis?.conditions.stop_requested === true
+  const heartbeat = deriveHeartbeatProjection(keeper, nowMs)
+  const context = deriveContextProjection(keeper)
+  const socialModel = deriveSocialModelProjection(keeper)
+  const traceEvidence = terminalEventLabel(runtimeTrace)
+  const runtimeWarnings = runtimeWarningList(runtimeResolution)
+  const toolContract = compactToken(composite?.execution?.tool_contract_result ?? null, 'tool contract unknown')
+  const executionCurrent =
+    composite?.runtime_attention?.execution_current !== false
+    && composite?.runtime_attention?.stale_execution_receipt !== true
+  const fsmLanes = deriveFsmLanes(composite, opState)
+  const idleLabel =
+    typeof composite?.idle_seconds === 'number'
+      ? `${formatDuration(composite.idle_seconds)} idle`
+      : typeof keeper.last_turn_ago_s === 'number'
+        ? `${formatDuration(keeper.last_turn_ago_s)} since turn`
+        : 'idle age unknown'
+  const runtimeReason = compactToken(opState.displaySummary, 'no blocker reason')
+  const runtimeCommit =
+    shortCommit(runtimeResolution?.server_repo_git_commit)
+    ?? shortCommit(runtimeResolution?.build?.commit)
+  const workspaceCommit = shortCommit(runtimeResolution?.workspace_git_commit)
+  const runtimeBuildLabel = runtimeCommit
+    ? workspaceCommit && workspaceCommit !== runtimeCommit
+      ? `${runtimeCommit} vs workspace ${workspaceCommit}`
+      : runtimeCommit
+    : null
+  const runtimeRepoLabel = runtimeResolution?.server_repo_path?.path
+    ? runtimeResolution.server_repo_path.path.split('/').slice(-2).join('/')
+    : null
+
+  const signals = buildProjectionSignals({
+    opState,
+    heartbeat,
+    context,
+    socialModel,
+    fiberAlive,
+    stopRequested,
+    traceEvidence,
+    runtimeWarnings,
+    toolContract,
+    executionCurrent,
+    fsmLanes,
+    runtimeReason,
+  })
+  const attentionSignals = signals.filter(signal => signal.contributesToAttention)
+  const headline =
+    stopRequested
+      ? '종료 신호'
+      : attentionSignals.length > 0
+        ? '조치 필요'
+        : fiberAlive.alive && activeTurn
+          ? '턴 진행 중'
+          : fiberAlive.alive
+            ? '대기 중'
+            : runtimeTrace
+              ? '실행 미확인'
+              : '증거 부족'
+  const tone: KeeperRuntimeProjectionTone =
+    stopRequested
+      ? 'bad'
+      : attentionSignals.length > 0
+        ? 'warn'
+        : fiberAlive.alive && activeTurn
+          ? 'ok'
+          : fiberAlive.alive
+            ? 'neutral'
+            : runtimeTrace
+              ? 'warn'
+              : 'neutral'
+  const synchronizationDetail = [
+    `hb ${heartbeat.stale ? 'stale' : heartbeat.lastHeartbeat ? 'fresh' : 'unknown'}`,
+    `ctx ${context.breach ? 'breach' : context.ratio === null ? 'unknown' : 'ok'}`,
+    `social ${socialModel.recognized === false ? 'unrecognized' : socialModel.recognized === true ? 'recognized' : 'unknown'}`,
+    `fiber ${fiberAlive.alive ? 'alive' : 'not_proven'}`,
+    stopRequested ? 'stop requested' : 'stop clear',
+    `tool ${toolContract}`,
+    fsmLaneSummary(fsmLanes),
+  ].join(' · ')
+
+  return {
+    opState,
+    linkedState,
+    fiberAlive,
+    activeTurn,
+    blocked,
+    stopRequested,
+    heartbeat,
+    context,
+    socialModel,
+    traceEvidence,
+    runtimeWarnings,
+    toolContract,
+    fsmLanes,
+    signals,
+    headline,
+    tone,
+    turnPhase,
+    idleLabel,
+    runtimeReason,
+    runtimeBuildLabel,
+    runtimeRepoLabel,
+    synchronizationLabel: attentionSignals.length > 0 ? `${attentionSignals.length} attention signal${attentionSignals.length === 1 ? '' : 's'}` : 'signals aligned',
+    synchronizationDetail,
+  }
+}
+
+function deriveHeartbeatProjection(keeper: Keeper, nowMs: number): KeeperHeartbeatProjection {
+  const lastHeartbeat = keeper.last_heartbeat ?? null
+  if (!lastHeartbeat) {
+    return {
+      stale: false,
+      lastHeartbeat,
+      ageMs: null,
+      thresholdMs: KEEPER_RUNTIME_HEARTBEAT_STALE_MS,
+    }
+  }
+  const ts = Date.parse(lastHeartbeat)
+  if (Number.isNaN(ts)) {
+    return {
+      stale: false,
+      lastHeartbeat,
+      ageMs: null,
+      thresholdMs: KEEPER_RUNTIME_HEARTBEAT_STALE_MS,
+    }
+  }
+  const ageMs = nowMs - ts
+  return {
+    stale: ageMs > KEEPER_RUNTIME_HEARTBEAT_STALE_MS,
+    lastHeartbeat,
+    ageMs,
+    thresholdMs: KEEPER_RUNTIME_HEARTBEAT_STALE_MS,
+  }
+}
+
+function deriveContextProjection(keeper: Keeper): KeeperContextProjection {
+  const threshold =
+    typeof keeper.runtime_warning_ctx_ratio === 'number' && Number.isFinite(keeper.runtime_warning_ctx_ratio)
+      ? keeper.runtime_warning_ctx_ratio
+      : KEEPER_RUNTIME_CONTEXT_ATTENTION_RATIO
+  const ratio =
+    typeof keeper.context_ratio === 'number' && Number.isFinite(keeper.context_ratio)
+      ? keeper.context_ratio
+      : null
+  return {
+    breach: ratio !== null && ratio >= threshold,
+    ratio,
+    threshold,
+  }
+}
+
+function deriveSocialModelProjection(keeper: Keeper): KeeperSocialModelProjection {
+  return {
+    recognized: typeof keeper.social_model_recognized === 'boolean' ? keeper.social_model_recognized : null,
+  }
+}
+
+function runtimeWarningList(runtimeResolution: KeeperRuntimeProjectionRuntimeInput | null | undefined): string[] {
+  if (!runtimeResolution) return []
+  const warnings = Array.isArray(runtimeResolution.warnings)
+    ? runtimeResolution.warnings.filter((warning): warning is string => warning.trim() !== '')
+    : []
+  if (runtimeResolution.source_mismatch && warnings.length === 0) {
+    return ['Runtime source mismatch detected.']
+  }
+  return warnings
+}
+
+function terminalEventLabel(trace: KeeperRuntimeTraceResponse | null): KeeperRuntimeTraceProjection {
+  if (!trace) {
+    return {
+      value: 'trace unavailable',
+      detail: 'runtime_trace evidence not loaded',
+      tone: 'neutral',
+      loaded: false,
+    }
+  }
+  const clock = trace.runtime_lens.turn_clock
+  const keeperTurn = clock.keeper_turn_id ?? trace.turn_identity.requested_keeper_turn_id ?? trace.turn_id
+  const turnLabel = keeperTurn == null ? 'turn unknown' : `turn #${keeperTurn}`
+  const terminal = clock.terminal_event_present ? compactToken(clock.terminal_event, 'terminal present') : 'terminal missing'
+  const gapCount = trace.runtime_lens.gaps.length
+  const terminalTone: KeeperRuntimeProjectionTone =
+    gapCount > 0
+      ? 'warn'
+      : !clock.terminal_event_present
+        ? 'warn'
+        : terminal === 'turn_finished'
+          ? 'ok'
+          : 'info'
+  const detailParts = [
+    `oas ${clock.max_oas_turn_count ?? '-'}`,
+    `manifest ${trace.manifest_total_rows}`,
+    `health ${compactToken(trace.health)}`,
+    gapCount > 0 ? `${gapCount} lens gap${gapCount === 1 ? '' : 's'}` : 'no lens gaps',
+  ]
+  return {
+    value: `${turnLabel} ${terminal === 'turn_finished' ? 'finished' : terminal}`,
+    detail: detailParts.join(' · '),
+    tone: terminalTone,
+    loaded: true,
+  }
+}
+
+function isIdleTurnPhase(value: string | null | undefined): boolean {
+  const normalized = value?.trim().toLowerCase()
+  return !normalized || normalized === 'idle' || normalized === 'unknown'
+}
+
+function deriveFsmLanes(
+  composite: KeeperCompositeSnapshot | null,
+  opState: KeeperOperationalState,
+): KeeperRuntimeProjectionFsmLane[] {
+  const phase = compactToken(composite?.phase ?? opState.phase ?? null, 'phase unknown')
+  return [
+    { axis: 'KSM', source: 'composite.phase', value: phase, contributesToAttention: phaseNeedsAttention(opState.phase ?? phase) },
+    { axis: 'KTC', source: 'composite.turn_phase', value: compactToken(composite?.turn_phase ?? null, 'turn_phase unknown'), contributesToAttention: false },
+    { axis: 'KDP', source: 'composite.decision.stage', value: compactToken(composite?.decision?.stage ?? null, 'decision unknown'), contributesToAttention: false },
+    { axis: 'KCL', source: 'composite.cascade.state', value: compactToken(composite?.cascade?.state ?? null, 'cascade unknown'), contributesToAttention: false },
+    { axis: 'KMC', source: 'composite.compaction.stage', value: compactToken(composite?.compaction?.stage ?? null, 'compaction unknown'), contributesToAttention: false },
+    { axis: 'KCB', source: 'composite.circuit_breaker.state', value: compactToken(composite?.circuit_breaker?.state ?? null, 'breaker unknown'), contributesToAttention: false },
+  ]
+}
+
+function phaseNeedsAttention(phase: string | null | undefined): boolean {
+  if (!phase) return false
+  if (ATTENTION_PHASES.has(phase)) return true
+  const normalized = phase.toLowerCase()
+  for (const attentionPhase of ATTENTION_PHASES) {
+    if (attentionPhase.toLowerCase() === normalized) return true
+  }
+  return false
+}
+
+function fsmLaneSummary(lanes: readonly KeeperRuntimeProjectionFsmLane[]): string {
+  return lanes.map(lane => `${lane.axis} ${lane.value}`).join(' / ')
+}
+
+function buildProjectionSignals({
+  opState,
+  heartbeat,
+  context,
+  socialModel,
+  fiberAlive,
+  stopRequested,
+  traceEvidence,
+  runtimeWarnings,
+  toolContract,
+  executionCurrent,
+  fsmLanes,
+  runtimeReason,
+}: {
+  readonly opState: KeeperOperationalState
+  readonly heartbeat: KeeperHeartbeatProjection
+  readonly context: KeeperContextProjection
+  readonly socialModel: KeeperSocialModelProjection
+  readonly fiberAlive: FiberAliveDecision
+  readonly stopRequested: boolean
+  readonly traceEvidence: KeeperRuntimeTraceProjection
+  readonly runtimeWarnings: readonly string[]
+  readonly toolContract: string
+  readonly executionCurrent: boolean
+  readonly fsmLanes: readonly KeeperRuntimeProjectionFsmLane[]
+  readonly runtimeReason: string
+}): KeeperRuntimeProjectionSignal[] {
+  const blockerAttention = opState.kind === 'stuck' || opState.attention !== 'clean'
+  const ksmAttention = fsmLanes.some(lane => lane.axis === 'KSM' && lane.contributesToAttention)
+  const heartbeatAge = heartbeat.ageMs === null ? 'age unknown' : `${Math.round(heartbeat.ageMs / 1000)}s old`
+  const contextValue = context.ratio === null ? 'unknown' : `${Math.round(context.ratio * 100)}%`
+  const contextThreshold = `${Math.round(context.threshold * 100)}%`
+  const socialValue =
+    socialModel.recognized === false
+      ? 'unrecognized'
+      : socialModel.recognized === true
+        ? 'recognized'
+        : 'unknown'
+  const toolAttention = executionCurrent && isExecutionAttentionCode(toolContract)
+  const blockerHint = blockerAttention && runtimeReason !== 'no blocker reason' ? runtimeReason : null
+  return [
+    {
+      kind: 'operational_state',
+      label: 'operational',
+      value: opState.kind,
+      detail: runtimeReason,
+      tone: blockerAttention ? 'warn' : 'ok',
+      state: blockerAttention ? 'attention' : 'ok',
+      contributesToAttention: blockerAttention,
+      hint: blockerHint,
+    },
+    {
+      kind: 'ksm_phase',
+      label: 'ksm',
+      value: String(opState.phase ?? 'unknown'),
+      detail: fsmLaneSummary(fsmLanes),
+      tone: ksmAttention ? 'warn' : 'ok',
+      state: ksmAttention ? 'attention' : 'ok',
+      contributesToAttention: ksmAttention,
+      hint: ksmAttention ? 'FSM phase가 복구/오류/전이 상태입니다.' : null,
+    },
+    {
+      kind: 'heartbeat',
+      label: 'heartbeat',
+      value: heartbeat.stale ? 'stale' : heartbeat.lastHeartbeat ? 'fresh' : 'unknown',
+      detail: heartbeatAge,
+      tone: heartbeat.stale ? 'warn' : 'neutral',
+      state: heartbeat.stale ? 'attention' : heartbeat.lastHeartbeat ? 'ok' : 'unknown',
+      contributesToAttention: heartbeat.stale,
+      hint: heartbeat.stale ? '오래 응답이 없어 실제 상태 확인이 필요합니다.' : null,
+    },
+    {
+      kind: 'context_ratio',
+      label: 'context',
+      value: contextValue,
+      detail: `threshold ${contextThreshold}`,
+      tone: context.breach ? 'warn' : 'neutral',
+      state: context.breach ? 'attention' : context.ratio === null ? 'unknown' : 'ok',
+      contributesToAttention: context.breach,
+      hint: context.breach ? `컨텍스트 사용량이 ${contextValue}입니다.` : null,
+    },
+    {
+      kind: 'social_model',
+      label: 'social',
+      value: socialValue,
+      detail: 'social_model_recognized',
+      tone: socialModel.recognized === false ? 'warn' : 'neutral',
+      state: socialModel.recognized === false ? 'attention' : socialModel.recognized === true ? 'ok' : 'unknown',
+      contributesToAttention: socialModel.recognized === false,
+      hint: socialModel.recognized === false ? '미인식 대화 모델 설정이 감지됐습니다.' : null,
+    },
+    {
+      kind: 'fiber_alive',
+      label: 'fiber',
+      value: fiberAlive.alive ? 'alive' : 'not_proven',
+      detail: fiberAlive.source,
+      tone: fiberAlive.alive ? 'ok' : 'warn',
+      state: fiberAlive.alive ? 'ok' : 'attention',
+      contributesToAttention: !fiberAlive.alive,
+      hint: fiberAlive.alive ? null : 'fiber 생존 증거가 없습니다.',
+    },
+    {
+      kind: 'stop_requested',
+      label: 'stop',
+      value: stopRequested ? 'requested' : 'clear',
+      detail: 'runtime_attention/phase_diagnosis',
+      tone: stopRequested ? 'bad' : 'neutral',
+      state: stopRequested ? 'bad' : 'ok',
+      contributesToAttention: stopRequested,
+      hint: stopRequested ? '종료 요청이 runtime projection에 반영됐습니다.' : null,
+    },
+    {
+      kind: 'runtime_trace',
+      label: 'trace',
+      value: traceEvidence.value,
+      detail: traceEvidence.detail,
+      tone: traceEvidence.tone,
+      state: traceEvidence.loaded ? (traceEvidence.tone === 'warn' ? 'attention' : 'ok') : 'unknown',
+      contributesToAttention: traceEvidence.loaded && traceEvidence.tone === 'warn',
+      hint: traceEvidence.loaded && traceEvidence.tone === 'warn' ? traceEvidence.detail : null,
+    },
+    {
+      kind: 'runtime_warning',
+      label: 'warnings',
+      value: runtimeWarnings.length === 0 ? 'none' : `${runtimeWarnings.length}`,
+      detail: runtimeWarnings[0] ?? 'no runtime warnings',
+      tone: runtimeWarnings.length > 0 ? 'warn' : 'neutral',
+      state: runtimeWarnings.length > 0 ? 'attention' : 'ok',
+      contributesToAttention: runtimeWarnings.length > 0,
+      hint: runtimeWarnings[0] ?? null,
+    },
+    {
+      kind: 'tool_contract',
+      label: 'tool',
+      value: toolContract,
+      detail: executionCurrent ? 'execution.tool_contract_result' : 'stale execution receipt',
+      tone: toolAttention ? 'warn' : 'neutral',
+      state: toolAttention ? 'attention' : toolContract === 'tool contract unknown' ? 'unknown' : 'ok',
+      contributesToAttention: toolAttention,
+      hint: toolAttention ? `도구 계약 결과가 ${toolContract}입니다.` : null,
+    },
+    {
+      kind: 'fsm_raw_lanes',
+      label: 'fsm',
+      value: fsmLaneSummary(fsmLanes),
+      detail: fsmLanes.map(lane => lane.source).join(' · '),
+      tone: ksmAttention ? 'warn' : 'neutral',
+      state: ksmAttention ? 'attention' : 'ok',
+      contributesToAttention: false,
+      hint: null,
+    },
+  ]
+}
+
+function isExecutionAttentionCode(value: string | null | undefined): boolean {
+  const normalized = value?.trim().toLowerCase()
+  if (!normalized || normalized === 'unknown' || normalized === 'tool contract unknown') return false
+  if (
+    normalized === 'ok'
+    || normalized === 'pass'
+    || normalized === 'allowed_in_sandbox'
+    || normalized.startsWith('satisfied')
+  ) return false
+  return normalized.includes('violat')
+    || normalized.includes('missing')
+    || normalized.includes('need')
+    || normalized.includes('fail')
+    || normalized.includes('error')
+    || normalized.includes('passive')
+}

--- a/dashboard/src/lib/monitoring-runtime.test.ts
+++ b/dashboard/src/lib/monitoring-runtime.test.ts
@@ -196,4 +196,50 @@ describe('summarizeKeeperMonitoring', () => {
       expect(summary.band.key).toBe('attention')
     })
   })
+
+  it('routes heartbeat/context/social attention through the runtime projection', () => {
+    const summary = summarizeKeeperMonitoring({
+      name: 'keeper-organism',
+      status: 'idle',
+      phase: 'Running',
+      last_heartbeat: '1970-01-01T00:00:00Z',
+      context_ratio: 0.99,
+      social_model_recognized: false,
+    } as Keeper)
+
+    expect(summary.band.key).toBe('attention')
+    expect(summary.hint).toBe('오래 응답이 없어 실제 상태 확인이 필요합니다.')
+  })
+
+  it('routes current tool-contract attention through the runtime projection', () => {
+    const compositeToolAttention = {
+      keeper: 'keeper-tool',
+      phase: 'running',
+      turn_phase: 'idle',
+      decision: { stage: 'idle' },
+      cascade: { state: 'idle' },
+      compaction: { stage: 'idle' },
+      circuit_breaker: { state: 'closed' },
+      is_live: false,
+      execution: {
+        tool_contract_result: 'missing_required_tool_use',
+      },
+      runtime_attention: {
+        blocked: false,
+        needs_attention: false,
+        execution_current: true,
+        stale_execution_receipt: false,
+      },
+    } as unknown as Parameters<typeof summarizeKeeperMonitoring>[1] extends infer C ? C : never
+    const summary = summarizeKeeperMonitoring({
+      name: 'keeper-tool',
+      status: 'idle',
+      phase: 'Running',
+      last_heartbeat: new Date().toISOString(),
+      keepalive_running: true,
+    } as Keeper, compositeToolAttention)
+
+    expect(summary.band.key).toBe('attention')
+    expect(summary.hint).toBe('도구 계약 결과가 missing_required_tool_use입니다.')
+  })
 })

--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -1,9 +1,10 @@
 import type { Agent, Keeper, PipelineStage } from '../types'
 import type { KeeperCompositeSnapshot } from '../api/schemas/keeper-composite'
-import { keeperRuntimeBlockerHint } from './keeper-runtime-display'
-import { ATTENTION_PHASES } from './keeper-predicates'
 import { parseAgentStatus } from './agent-status'
-import { deriveKeeperOperationalState, type KeeperOperationalState } from './keeper-operational-state'
+import {
+  deriveKeeperRuntimeProjection,
+  type KeeperRuntimeProjection,
+} from './keeper-runtime-projection'
 
 export type RuntimeBand = 'active' | 'attention' | 'paused' | 'offline'
 
@@ -36,13 +37,6 @@ interface MonitoringEvidence {
   phase: PhaseMeta | null
   stage: StageMeta | null
 }
-
-// 5-minute threshold for the monitoring band "attention" gate — distinct
-// from config/constants.HEARTBEAT_STALE_MS (120s) which is the SSE
-// connection liveness check. This longer window avoids false "attention"
-// badges during brief heartbeat gaps that the SSE reconnect handles.
-const MONITORING_BAND_STALE_MS = 5 * 60 * 1000
-const DEFAULT_CONTEXT_ATTENTION_RATIO = 0.95
 
 const UNKNOWN_PHASE_META: PhaseMeta = {
   key: 'unknown',
@@ -155,28 +149,10 @@ export function keeperPhaseForDisplay(
   keeper: Keeper,
   composite: KeeperCompositeSnapshot | null = null,
 ): string | null {
-  return deriveKeeperOperationalState({ keeper, composite }).phase
+  return deriveKeeperRuntimeProjection({ keeper, composite }).opState.phase
 }
 
-function isHeartbeatStale(keeper: Keeper): boolean {
-  if (!keeper.last_heartbeat) return false
-  const ts = Date.parse(keeper.last_heartbeat)
-  if (Number.isNaN(ts)) return false
-  return Date.now() - ts > MONITORING_BAND_STALE_MS
-}
-
-function contextAttentionRatio(keeper: Keeper): number {
-  const value = keeper.runtime_warning_ctx_ratio
-  return typeof value === 'number' && Number.isFinite(value)
-    ? value
-    : DEFAULT_CONTEXT_ATTENTION_RATIO
-}
-
-function keeperBand(
-  keeper: Keeper,
-  opState: KeeperOperationalState,
-  phaseKey: string,
-): RuntimeBand {
+function keeperBand(projection: KeeperRuntimeProjection): RuntimeBand {
   // RFC-0135 §13 Goal-1 (audit B1, 2026-05-20): paused / offline / stuck
   // routing collapsed into the typed sum SSOT. The two prior local
   // checks
@@ -184,49 +160,26 @@ function keeperBand(
   //   - `lifecycleKey === 'offline' | 'unbooted' | 'stopped'
   //      || OFFLINE_PHASES.has(phaseKey)` (string-set lifecycle/phase
   //      bypass)
-  // were strict subsets of `opState.kind === 'paused'` and
-  // `opState.kind === 'offline'`; routing via `deriveKeeperOperational
-  // State` removes the parallel derivation entirely.
-  if (opState.kind === 'paused') return 'paused'
-  if (opState.kind === 'offline') return 'offline'
-  // RFC-0135 PR-12: live blocker → typed state's `stuck` variant.
-  // RFC-0135 §13 Goal-2: `opState.attention !== 'clean'` is the
-  // typed-axis form of the previously-external `runtime_attention`
-  // OR-合流 (composite.runtime_attention.{blocked, needs_attention}).
-  // Both are SSOT-internal axes — `keeperBand` no longer derives them.
-  const blockerOrBackendAttention =
-    opState.kind === 'stuck' || opState.attention !== 'clean'
-  // The remaining axes (KSM phase `ATTENTION_PHASES`, heartbeat
-  // staleness, context-ratio breach, social model recognition) are
-  // **external** to the typed SSOT today — RFC-0135 §13 lists them as
-  // axis-extension candidates (`phase`, `heartbeatStale`,
-  // `contextBreach`, `socialModelRecognized`). Until those land, this
-  // OR remains, but each axis is now an explicit standalone gate so a
-  // future PR can lift them one-by-one without touching the typed-sum
-  // arms.
-  const ksmPhaseAttention = ATTENTION_PHASES.has(phaseKey)
-  const externalSignal =
-    keeper.social_model_recognized === false
-    || isHeartbeatStale(keeper)
-    || (typeof keeper.context_ratio === 'number'
-        && keeper.context_ratio >= contextAttentionRatio(keeper))
-  if (blockerOrBackendAttention || ksmPhaseAttention || externalSignal) {
+  // were strict subsets of `projection.opState.kind === 'paused'` and
+  // `projection.opState.kind === 'offline'`; routing through the runtime
+  // projection keeps monitoring aligned with detail live-truth.
+  if (projection.opState.kind === 'paused') return 'paused'
+  if (projection.opState.kind === 'offline') return 'offline'
+  if (projection.signals.some(signal => signal.contributesToAttention)) {
     return 'attention'
   }
   return 'active'
 }
 
-function keeperHint(keeper: Keeper, band: RuntimeBand, stage: StageMeta): string | null {
-  const runtimeBlocker = keeperRuntimeBlockerHint(keeper)
-  if (runtimeBlocker) return runtimeBlocker
-  if (keeper.social_model_recognized === false) {
-    return '미인식 대화 모델 설정이 감지됐습니다.'
-  }
+function keeperHint(
+  keeper: Keeper,
+  projection: KeeperRuntimeProjection,
+  band: RuntimeBand,
+  stage: StageMeta,
+): string | null {
+  const signalHint = projection.signals.find(signal => signal.contributesToAttention && signal.hint !== null)?.hint
+  if (signalHint) return signalHint
   if (band === 'paused') return '운영자가 멈춰 둔 상태입니다.'
-  if (isHeartbeatStale(keeper)) return '오래 응답이 없어 실제 상태 확인이 필요합니다.'
-  if (typeof keeper.context_ratio === 'number' && keeper.context_ratio >= contextAttentionRatio(keeper)) {
-    return `컨텍스트 사용량이 ${Math.round(keeper.context_ratio * 100)}%입니다.`
-  }
   if (band === 'attention') return stage.description
   if (band === 'offline' && keeper.generation === 0 && (keeper.turn_count ?? 0) === 0) {
     return '아직 부팅된 적 없는 등록 런타임입니다.'
@@ -239,16 +192,16 @@ export function summarizeKeeperMonitoring(
   keeper: Keeper,
   composite: KeeperCompositeSnapshot | null = null,
 ): KeeperMonitoringSummary {
-  const opState = deriveKeeperOperationalState({ keeper, composite })
-  const phaseKey = opState.phase ?? 'unknown'
+  const projection = deriveKeeperRuntimeProjection({ keeper, composite })
+  const phaseKey = projection.opState.phase ?? 'unknown'
   const stage = stageMeta(normalizeStage(keeper.pipeline_stage))
-  const band = BAND_META[keeperBand(keeper, opState, phaseKey)]
+  const band = BAND_META[keeperBand(projection)]
 
   return {
     band,
     phase: phaseMeta(phaseKey),
     stage,
-    hint: keeperHint(keeper, band.key, stage),
+    hint: keeperHint(keeper, projection, band.key, stage),
   }
 }
 

--- a/docs/rfc/RFC-0135-dashboard-keeper-operational-ssot.md
+++ b/docs/rfc/RFC-0135-dashboard-keeper-operational-ssot.md
@@ -270,10 +270,23 @@ PR-1 머지 후 PR-2~7 은 모두 같은 SSOT 호출자이므로 **동시 진행
   - `monitoring-runtime.ts` 는 `opState.phase` 를 읽고, band 계산도 같은 `opState` 인스턴스를 공유.
 - **테스트**: `keeper-operational-state.test.ts` 에 non-running variant turnPhase, displaySummary precedence, phase terminal override 케이스 추가. `keeper-detail-runtime` / `monitoring-runtime` focused tests 로 consumer 회귀 확인.
 
-이로써 HTML audit 의 Goal-2 명시 범위는 helper-level centralization 이 아니라 typed-state 공통 axis 로 닫힌다. 남은 external OR (`heartbeatStale`, `contextBreach`, `socialModelRecognized`) 는 Goal-2 명시 범위 밖의 monitoring band 신호다.
+이로써 HTML audit 의 Goal-2 명시 범위는 helper-level centralization 이 아니라 typed-state 공통 axis 로 닫힌다. Goal-2 이후 남은 external OR (`heartbeatStale`, `contextBreach`, `socialModelRecognized`) 는 typed variant arm 자체가 아니라 runtime projection layer 의 입력 신호로 다룬다.
+
+### Follow-up / 2026-05-21 — runtime organism projection
+
+- **흡수 대상**: `heartbeat stale`, `context ratio breach`, `social_model_recognized`, `fiberAlive`, `stopRequested`, `runtime trace`, `runtime warnings`, `execution.tool_contract_result`, FsmHub raw composite lanes.
+- **이전 패턴**:
+  - `monitoring-runtime.ts` 가 heartbeat/context/social/KSM phase 를 local OR-chain 으로 합류.
+  - `keeper-detail-runtime.ts` 가 fiber/stop/trace/warning/tool-contract 를 별도 derive.
+  - FsmHub raw lanes 는 아래 패널에서만 소비되어 live-truth headline 과 monitoring band 의 attention 판단과 같은 projection 으로 묶이지 않음.
+- **이후 패턴**: `dashboard/src/lib/keeper-runtime-projection.ts` 가 `KeeperRuntimeProjection` 을 생성하고, detail live-truth + monitoring band 가 같은 projection 을 소비한다. 이 projection 은 `KeeperOperationalState` 를 대체하지 않고 감싼다: typed operational state 는 core lifecycle/blocker axis, runtime projection 은 주변 생체 신호와 raw FSM lanes 를 한 tick 의 동기화된 operator view 로 결합한다.
+- **display rule**: detail live-truth 는 `동기화` row 에 projection headline/detail 을 노출하고, FsmHub 는 raw lanes 의 원본 상세 표시를 계속 담당한다. 따라서 raw truth 를 숨기지 않고 coupled summary 만 추가한다.
+- **stale receipt rule**: `runtime_attention.execution_current=false` 또는 `stale_execution_receipt=true` 이면 `execution.tool_contract_result` 는 sync detail 에 남기되 current attention 으로 승격하지 않는다.
+- **테스트**: `keeper-runtime-projection.test.ts` 가 listed signal 전체의 signal-kind set, headline/tone priority, stale receipt gating 을 검증한다. `monitoring-runtime.test.ts` 와 `keeper-detail-runtime.test.ts` 는 consumer 가 projection 을 통해 같은 attention/hint/sync row 를 읽는지 검증한다.
 
 ## §12 변경 이력
 
 - 2026-05-19 vincent — 초안 작성, 3 사례 기반 root-cause 정리, PR 시퀀스 §5.
 - 2026-05-20 vincent (via claude-code) — §13 추가, Goal-2 `attention` axis 흡수 + 후속 axes 후보 명시. audit B3 closure.
 - 2026-05-21 vincent (via codex) — Goal-2 잔여 `turnPhase`, `displaySummary`, `phase` 를 `KeeperOperationalState` 공통 axis 로 흡수.
+- 2026-05-21 vincent (via codex) — runtime organism projection 추가. heartbeat/context/social/fiber/stop/trace/warning/tool/FSM lanes 를 한 projection 으로 결합하고 detail/monitoring consumer 를 전환.


### PR DESCRIPTION
## Summary
- add KeeperRuntimeProjection to derive heartbeat, context, social model, fiber, stop, trace, warnings, tool contract, and raw FSM lane signals in one object
- route keeper detail live-truth and monitoring band/hints through that projection
- document the RFC-0135 follow-up and add focused regression tests

## Verification
- pnpm exec vitest run src/lib/keeper-runtime-projection.test.ts src/lib/monitoring-runtime.test.ts src/components/keeper-detail-runtime.test.ts
- pnpm exec tsc --noEmit --pretty false
- ./scripts/lint/dashboard-ssot-keeper-state.sh
- ./scripts/lint/dashboard-ssot-agent-status.sh
- git diff --check origin/main...HEAD