### PR TITLE
feat(lib): RFC-0154 caller migration to ~exn — activate errno priority at 6 sites

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -689,7 +689,7 @@ let make_hooks
                  ~stale_reason:"trajectory_append_failed"
                  ~keeper_name
                  ~trace_id
-                 ~error:(Printexc.to_string exn)
+                 ~exn
                  ())
              acc
              entry);

--- a/lib/keeper/keeper_hooks_oas_gate_attempt.ml
+++ b/lib/keeper/keeper_hooks_oas_gate_attempt.ml
@@ -151,7 +151,7 @@ let record_pre_tool_gate_attempt
             ~stale_reason:stale_reason_trajectory_append
             ~keeper_name
             ~trace_id
-            ~error:(Printexc.to_string exn)
+            ~exn
             ())
         acc
         entry

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -126,7 +126,7 @@ let init ?cluster_name ~base_path () =
          ~durable_store:dir
          ~dashboard_surface:"/api/v1/keepers/:name/tool-calls"
          ~stale_reason:"tool_call_io_init_failed"
-         ~error:(Printexc.to_string exn)
+         ~exn
          ()
      with
      | Eio.Cancel.Cancelled _ as cancel -> raise cancel
@@ -180,6 +180,7 @@ let record_append_coverage_gap ~store ~keeper_name ~tool_name ?trace_id exn =
       ~keeper_name
       ?trace_id
       ~error:(Printf.sprintf "%s/%s: %s" keeper_name tool_name (Printexc.to_string exn))
+      ~exn
       ()
   with
   | Eio.Cancel.Cancelled _ as cancel -> raise cancel

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -345,7 +345,7 @@ let record_runtime_mcp_trajectory_coverage_gap
       ~stale_reason
       ~keeper_name
       ~trace_id
-      ~error:(Printexc.to_string exn)
+      ~exn
       ()
   with
   | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/tool_usage_log.ml
+++ b/lib/tool_usage_log.ml
@@ -183,6 +183,7 @@ let record_coverage_gap ~masc_root ~durable_store ~stale_reason ?caller
       ~dashboard_surface
       ~stale_reason
       ~error
+      ~exn
       ()
   with
   | Eio.Cancel.Cancelled _ as cancel -> raise cancel


### PR DESCRIPTION
## Goal

RFC-0154 의 PR-2 (#17078) 가 \`Telemetry_coverage_gap.record\` 에 \`?exn:exn\` optional 추가. 본 PR 이 13 caller 중 *exn 객체 가용한 6 사이트* 에 \`~exn\` 활성화 — errno priority path 사용.

RFC: #17059 (Merged). PR-2: #17078 (Merged). Closeout: #17080 (Merged).

## What

| 사이트 | 패턴 | 변경 |
|--------|------|------|
| \`mcp_server_eio_call_tool.ml:339\` | Group A: \`~error:(Printexc.to_string exn)\` | \`~error\` 제거, \`~exn\` 추가 |
| \`keeper_tool_call_log.ml:122\` | Group A: 동일 | 동일 |
| \`keeper_tool_call_log.ml:173\` | Group B: \`Printf.sprintf "%s/%s: %s" ...\` | \`~error\` 보존 (context prefix) + \`~exn\` 추가 |
| \`keeper/keeper_hooks_oas.ml:681\` | Group A | \`~error\` → \`~exn\` |
| \`keeper/keeper_hooks_oas_gate_attempt.ml:143\` | Group A | \`~error\` → \`~exn\` |
| \`tool_usage_log.ml:178\` | Group B: \`error\` binding (context + Printexc 합성) | \`~error\` 보존 + \`~exn\` 추가 |

총 5 파일 / 6 사이트 / +6/-4 LoC.

## Effect

\`record\` 함수의 \`derive_error_and_class\` (PR-2 #17078 도입):

\`\`\`ocaml
match exn, error with
| Some e, Some explicit ->
    let cls = System_error_class.classify_exn e in  (* errno priority *)
    (Some explicit, Some cls)
| Some e, None ->
    let cls = System_error_class.classify_exn e in
    (Some (Printexc.to_string e), Some cls)
| None, Some s ->
    let cls = System_error_class.classify_string s in  (* substring fallback *)
    ...
\`\`\`

본 PR 머지 후 6 사이트는 \`classify_exn\` 적중 → \`Unix.Unix_error _\` 가 errno 직접 매칭. 이전엔 \`Printexc.to_string exn\` 의 free-form output 을 \`classify_string\` 가 다시 substring scan.

**정밀도 향상 예시**: \`Unix_error (EMFILE, "open", "/path")\` 가 \`Sys_error\` wrapper 안에 있을 때, \`Printexc.to_string\` 가 \`"Sys_error(\"Eio.Io Unix_error (Too many open files, ...)\")\"\` 같은 형태로 *문자열로 round-trip*. \`classify_string\` 이 "too many open files" substring 잡으면 정상 분류, 그러나 errno 매칭이 더 단단.

Wire \`error_class\` 값 자체는 두 path 모두 같은 케이스에서 같은 값 (\`fd_exhaustion\`). errno priority 는 *string surface 가 패턴 매칭에서 빠지는 edge case* 에 의미.

## Group B 의 의미

\`~error\` 보존이 *왜* 필요한가:
- caller 의 sprintf 가 *추가 컨텍스트* 를 담음 (\`keeper_name/tool_name: ...\`, \`outcome=.../error=...\`)
- 그 컨텍스트가 operator-facing wire payload 의 가치
- \`record\` 에 \`~error:explicit + ~exn:e\` 둘 다 전달 시: explicit 가 wire 의 \`error\` 필드, exn 이 \`error_class\` 분류 입력

## 남은 7 caller (Group C — exn 객체 미접근)

\`keeper_runtime_manifest.ml:517\` / \`keeper/keeper_agent_run_receipt_append.ml:27\` / \`keeper/keeper_agent_memory_episode.ml:9\` / \`keeper/keeper_callback_failure.ml:20\` / \`keeper/keeper_lifecycle_hooks.ml:39\` / \`keeper/keeper_turn_helpers.ml:142\` / \`keeper_tool_call_log.ml:199\` / \`tool_usage_log.ml:344\`

이 사이트들은 함수가 \`~error:string\` 만 받음 — exn 객체 안 가짐. \`classify_string\` 으로 typed tag 생성 가능 (PR-2 의 default 경로). 변경 안 함.

**상위 함수가 exn 객체 가진 경우**: 그 위 layer 가 \`error\` arg + \`exn\` arg 둘 다 전달하도록 *signature 변경* 필요 — RFC-0154 scope 밖. Out-of-scope.

## Verification

\`\`\`
dune build @check:  clean
diff:               5 files / +6 / -4
git push:           clean
\`\`\`

테스트 추가 없음 — 6 사이트 코드 변경의 *동작* 변화 없음 (wire \`error_class\` 값 동일, errno priority 만 활성화). PR-2 의 \`test_system_error_class\` 21 케이스가 *errno priority + string fallback* 모두 커버.

## Workaround Rejection Bar self-check

| 항목 | 결과 |
|------|------|
| §1 텔레메트리-as-fix | ❌ |
| §2 string/substring 분류기 추가 | ❌ (오히려 string round-trip 우회) |
| §3 N-of-M | ⚠️ 6 of 13 — 의도 있음. 나머지 7 사이트는 exn 객체 부재로 *기술적으로 변경 불가*. surgical scope. |
| §4 catch-all \`_->\` | ❌ |
| §5 cap/cooldown/dedup/repair | ❌ |
| §6 test backdoor | ❌ |
| §7 같은 typo N-N fix | ❌ |

§3 가 약간 트리거하지만 *exn 객체 가용성* 이 객관적 기준. 7 caller signature 까지 변경하면 RFC scope 폭증 — surgical 원칙 위반.

## Files

\`\`\`
5 files changed, 6 insertions(+), 4 deletions(-)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>