### PR TITLE
feat(dashboard): surface runtime source drift

### DIFF
--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -222,25 +222,152 @@ let opt_commit_equal left right =
   | _ -> None
 ;;
 
+let opt_int_json = function
+  | None -> `Null
+  | Some value -> `Int value
+;;
+
+type git_upstream_status =
+  { branch : string option
+  ; upstream_ref : string option
+  ; upstream_head_commit : string option
+  ; ahead_count : int option
+  ; behind_count : int option
+  }
+
+let empty_git_upstream_status =
+  { branch = None
+  ; upstream_ref = None
+  ; upstream_head_commit = None
+  ; ahead_count = None
+  ; behind_count = None
+  }
+;;
+
+let git_upstream_status_probe_hook_for_tests :
+  (string -> git_upstream_status option) option Atomic.t
+  =
+  Atomic.make None
+;;
+
+let set_git_upstream_status_probe_hook_for_tests hook =
+  Atomic.set git_upstream_status_probe_hook_for_tests (Some hook)
+;;
+
+let clear_git_upstream_status_probe_hook_for_tests () =
+  Atomic.set git_upstream_status_probe_hook_for_tests None
+;;
+
+let git_probe_trimmed dir args =
+  let argv = [ "git"; "-C"; dir; "--no-optional-locks" ] @ args in
+  let raw_source = String.concat " " (List.map Filename.quote argv) in
+  match
+    Masc_exec.Exec_gate.run_argv_with_status
+      ~actor:(Masc_exec.Agent_id.of_string "system/runtime_info")
+      ~raw_source
+      ~summary:"dashboard runtime git upstream probe"
+      ~timeout_sec:git_rev_parse_short_probe_timeout_sec
+      argv
+  with
+  | Unix.WEXITED 0, output -> trim_to_option output
+  | _ -> None
+;;
+
+let parse_ahead_behind raw =
+  match
+    raw
+    |> String.trim
+    |> String.split_on_char '\t'
+    |> List.concat_map (String.split_on_char ' ')
+    |> List.filter (fun part -> String.trim part <> "")
+  with
+  | [ ahead; behind ] ->
+    (match int_of_string_opt ahead, int_of_string_opt behind with
+     | Some ahead, Some behind -> Some (ahead, behind)
+     | _ -> None)
+  | _ -> None
+;;
+
+let git_upstream_status path =
+  match Atomic.get git_upstream_status_probe_hook_for_tests with
+  | Some hook -> hook path
+  | None ->
+    (match trim_to_option path with
+     | None -> None
+     | Some dir when not (Sys.file_exists dir) -> None
+     | Some dir ->
+       let branch =
+         git_probe_trimmed dir [ "rev-parse"; "--abbrev-ref"; "HEAD" ]
+       in
+       let upstream_ref =
+         git_probe_trimmed
+           dir
+           [ "rev-parse"; "--abbrev-ref"; "--symbolic-full-name"; "@{upstream}" ]
+       in
+       let upstream_head_commit =
+         git_probe_trimmed dir [ "rev-parse"; "--short"; "@{upstream}" ]
+       in
+       let ahead_count, behind_count =
+         match
+           git_probe_trimmed
+             dir
+             [ "rev-list"; "--left-right"; "--count"; "HEAD...@{upstream}" ]
+         with
+         | Some raw ->
+           (match parse_ahead_behind raw with
+            | Some (ahead, behind) -> Some ahead, Some behind
+            | None -> None, None)
+         | None -> None, None
+       in
+       if branch = None
+          && upstream_ref = None
+          && upstream_head_commit = None
+          && ahead_count = None
+          && behind_count = None
+       then None
+       else
+         Some
+           { branch; upstream_ref; upstream_head_commit; ahead_count; behind_count })
+;;
+
 let deployment_state_json
       ~(build : Build_identity.t)
       ~server_repo_commit
       ~workspace_commit
       ~resolved_base_commit
+      ~upstream_status
       ~source_mismatch
   =
   let binary_commit_known = Option.is_some build.binary_commit in
   let deployed_matches_server_repo =
     opt_commit_equal build.commit server_repo_commit
   in
+  let deployed_matches_upstream =
+    opt_commit_equal build.commit upstream_status.upstream_head_commit
+  in
   let deployed_matches_runtime_repo =
     opt_commit_equal build.commit build.repo_head_commit
+  in
+  let built_matches_upstream =
+    opt_commit_equal build.binary_commit upstream_status.upstream_head_commit
   in
   let built_matches_runtime_repo =
     opt_commit_equal build.binary_commit build.repo_head_commit
   in
+  let server_repo_behind_upstream =
+    match upstream_status.behind_count with
+    | Some count -> count > 0
+    | None -> false
+  in
+  let upstream_diverged =
+    server_repo_behind_upstream
+    ||
+    match deployed_matches_upstream, built_matches_upstream with
+    | Some false, _ | _, Some false -> true
+    | _ -> false
+  in
   let status =
-    if source_mismatch
+    if source_mismatch || upstream_diverged
     then "diverged"
     else if not binary_commit_known
     then "unproven"
@@ -255,6 +382,15 @@ let deployment_state_json
     ; "status", `String status
     ; "operator_action_required", `Bool (String.equal status "diverged")
     ; "binary_commit_known", `Bool binary_commit_known
+    ; ( "upstream"
+      , `Assoc
+          [ "branch", opt_string_json upstream_status.branch
+          ; "ref", opt_string_json upstream_status.upstream_ref
+          ; "head_commit", opt_string_json upstream_status.upstream_head_commit
+          ; "ahead_count", opt_int_json upstream_status.ahead_count
+          ; "behind_count", opt_int_json upstream_status.behind_count
+          ; "source", `String "local_tracking_ref"
+          ] )
     ; ( "merged"
       , `Assoc
           [ "commit", opt_string_json server_repo_commit
@@ -290,8 +426,11 @@ let deployment_state_json
     ; ( "checks"
       , `Assoc
           [ "deployed_matches_merged", opt_bool_json deployed_matches_server_repo
+          ; "deployed_matches_upstream", opt_bool_json deployed_matches_upstream
           ; "deployed_matches_runtime_repo", opt_bool_json deployed_matches_runtime_repo
+          ; "built_matches_upstream", opt_bool_json built_matches_upstream
           ; "built_matches_runtime_repo", opt_bool_json built_matches_runtime_repo
+          ; "server_repo_behind_upstream", `Bool server_repo_behind_upstream
           ; "source_mismatch", `Bool source_mismatch
           ] )
     ]
@@ -498,6 +637,11 @@ let runtime_resolution_json (config : Coord.config) =
   let runtime_commit_known = Option.is_some runtime_commit in
   let server_repo_path = Build_identity.repo_root () in
   let server_repo_commit = Option.bind server_repo_path git_rev_parse_short in
+  let upstream_status =
+    server_repo_path
+    |> Option.bind (fun path -> git_upstream_status path)
+    |> Option.value ~default:empty_git_upstream_status
+  in
   let workspace_commit = git_rev_parse_short config.workspace_path in
   let resolved_base_commit = git_rev_parse_short config.base_path in
   let base_path_input =
@@ -590,6 +734,30 @@ let runtime_resolution_json (config : Coord.config) =
       :: acc
     else acc
   in
+  let add_upstream_drift_warning acc =
+    match upstream_status.behind_count, upstream_status.upstream_head_commit with
+    | Some behind, Some upstream when behind > 0 ->
+      let deployed =
+        Option.value ~default:"unknown" build.commit
+      in
+      let branch =
+        Option.value ~default:"detached" upstream_status.branch
+      in
+      let upstream_ref =
+        Option.value ~default:"upstream" upstream_status.upstream_ref
+      in
+      Printf.sprintf
+        "Server source branch %s is behind %s by %d commit(s); running commit \
+         %s differs from upstream %s. Fetch/build/restart from current main \
+         before trusting runtime proof."
+        branch
+        upstream_ref
+        behind
+        deployed
+        upstream
+      :: acc
+    | _ -> acc
+  in
   let add_server_workspace_mismatch_warning acc =
     if server_workspace_mismatch
     then (
@@ -655,6 +823,7 @@ let runtime_resolution_json (config : Coord.config) =
     []
     |> add_source_mismatch_warning
     |> add_binary_commit_unknown_warning
+    |> add_upstream_drift_warning
     |> add_server_workspace_mismatch_warning
     |> add_prompt_dir_mismatch_warning
     |> add_signal_warning
@@ -694,7 +863,7 @@ let runtime_resolution_json (config : Coord.config) =
       ; "build", Build_identity.to_yojson build
       ; ( "deployment_state"
         , deployment_state_json ~build ~server_repo_commit ~workspace_commit
-            ~resolved_base_commit ~source_mismatch )
+            ~resolved_base_commit ~upstream_status ~source_mismatch )
       ]
       @ Server_routes_http_runtime.keeper_fleet_runtime_resolution_fields () )
 ;;

--- a/lib/server/server_dashboard_http_runtime_info.mli
+++ b/lib/server/server_dashboard_http_runtime_info.mli
@@ -13,7 +13,7 @@
     a [module Runtime = ...] alias inside
     [test/test_dashboard_cache].
 
-    External surface (13 entries):
+    External surface (15 entries + one test record type):
     - {b runtime resolution + HTTP routes}
       ({!runtime_resolution_json},
       {!dashboard_runtime_probe_http_json},
@@ -30,6 +30,10 @@
       {!clear_git_rev_parse_short_probe_hook_for_tests},
       {!clear_git_rev_parse_short_cache_for_tests},
       {!seed_git_rev_parse_short_cache_for_tests}).
+    - {b upstream tracking-ref test seams}
+      ({!git_upstream_status},
+      {!set_git_upstream_status_probe_hook_for_tests},
+      {!clear_git_upstream_status_probe_hook_for_tests}).
 
     Internal helpers stay private at this boundary:
     local string/list helpers, runtime probe cache state,
@@ -139,3 +143,22 @@ val seed_git_rev_parse_short_cache_for_tests :
 (** Seeds the cache with [(dir, value, refreshed_at)]
     so the next {!git_rev_parse_short} call against
     [dir] reads the seeded value (subject to TTL). *)
+
+type git_upstream_status = {
+  branch : string option;
+  upstream_ref : string option;
+  upstream_head_commit : string option;
+  ahead_count : int option;
+  behind_count : int option;
+}
+(** Local tracking-ref status for the server checkout.  This deliberately
+    uses only already-fetched refs such as [@{upstream}] and does not perform
+    network access. *)
+
+val set_git_upstream_status_probe_hook_for_tests :
+  (string -> git_upstream_status option) -> unit
+(** Installs a test-only hook for upstream tracking-ref probes. *)
+
+val clear_git_upstream_status_probe_hook_for_tests : unit -> unit
+(** Removes the hook installed by
+    {!set_git_upstream_status_probe_hook_for_tests}. *)

--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -25,9 +25,19 @@ let with_stubbed_git_probe f =
   Lib.Server_dashboard_http.clear_git_rev_parse_short_cache_for_tests ();
   Lib.Server_dashboard_http.set_git_rev_parse_short_probe_hook_for_tests
     (fun _ -> Some "test");
+  Lib.Server_dashboard_http.set_git_upstream_status_probe_hook_for_tests
+    (fun _ ->
+      Some
+        { branch = Some "runtime-capacity-fix-live-20260521"
+        ; upstream_ref = Some "origin/main"
+        ; upstream_head_commit = Some "upstream"
+        ; ahead_count = Some 0
+        ; behind_count = Some 3
+        });
   Fun.protect
     ~finally:(fun () ->
       Lib.Server_dashboard_http.clear_git_rev_parse_short_probe_hook_for_tests ();
+      Lib.Server_dashboard_http.clear_git_upstream_status_probe_hook_for_tests ();
       Lib.Server_dashboard_http.clear_git_rev_parse_short_cache_for_tests ())
     f
 
@@ -212,6 +222,21 @@ let test_dashboard_tools_projection () =
          with
          | `Null | `Bool _ -> true
          | _ -> false);
+      check int "deployment state upstream behind count" 3
+        (deployment_state |> member "upstream" |> member "behind_count" |> to_int);
+      check bool "deployment state behind check surfaced" true
+        (deployment_state
+         |> member "checks"
+         |> member "server_repo_behind_upstream"
+         |> to_bool);
+      check bool "runtime upstream drift warning surfaced" true
+        (runtime_resolution
+         |> member "warnings"
+         |> to_list
+         |> List.exists (function
+           | `String warning ->
+             contains_substring ~needle:"behind origin/main by 3 commit" warning
+           | _ -> false));
       let stub_probe () =
         Atomic.set runtime_probe_calls (Atomic.get runtime_probe_calls + 1);
         `Assoc


### PR DESCRIPTION
## Summary
- add local tracking-ref drift to runtime_resolution.deployment_state without network access
- warn in runtime_resolution when the running server checkout is behind its upstream ref
- cover the drift warning and deployment_state upstream shape in dashboard tools tests

## Why
The current live server can run from a detached/stale worktree while origin/main has moved forward. /health already exposes the running repo path and commit, but operators still have to manually combine lsof/git evidence to see whether runtime proof is stale. This makes the drift visible in the existing dashboard runtime-resolution surface.

## Verification
- ocamlformat --check lib/server/server_dashboard_http_runtime_info.ml lib/server/server_dashboard_http_runtime_info.mli test/test_dashboard_tools.ml
- git diff --check origin/main

## Not run
- scripts/dune-local.sh build test/test_dashboard_tools.exe: blocked by machine-wide Dune contention. Initial wrapper run refused because a bare dune process was active; retried with MASC_DUNE_ALLOW_BARE_DUNE=1 and stopped after waiting on /tmp/me-dune-local.lock for more than 90 seconds.