### PR TITLE
fix(keeper): keep legacy slot-full as cascade exhausted

### DIFF
--- a/lib/cascade/cascade_error_classify.ml
+++ b/lib/cascade/cascade_error_classify.ml
@@ -151,7 +151,7 @@ let masc_internal_error_to_json = function
     let cascade_name = cascade_name_to_string cascade_name in
     `Assoc
       [
-        ("kind", `String "capacity_exhausted");
+        ("kind", `String "capacity_backpressure");
         ("cascade_name", `String cascade_name);
         ("source", `String (capacity_backpressure_source_to_string source));
         ("detail", `String detail);
@@ -359,7 +359,7 @@ let () =
     ~help:
       "Total MASC-internal errors emitted as Agent_sdk.Error.Internal \
        payloads, classified by structured error kind. Labels: \
-       kind (cascade_exhausted | capacity_exhausted | resumable_cli_session | \
+       kind (cascade_exhausted | capacity_backpressure | resumable_cli_session | \
        no_tool_capable_provider | accept_rejected | \
        admission_queue_timeout | admission_queue_rejected | \
        turn_timeout | oas_timeout_budget | max_tokens_ceiling_violation | \
@@ -370,7 +370,7 @@ let () =
 
 let kind_of_masc_internal_error = function
   | Cascade_exhausted _ -> "cascade_exhausted"
-  | Capacity_backpressure _ -> "capacity_exhausted"
+  | Capacity_backpressure _ -> "capacity_backpressure"
   | Resumable_cli_session _ -> "resumable_cli_session"
   | No_tool_capable_provider _ -> "no_tool_capable_provider"
   | Accept_rejected _ -> "accept_rejected"
@@ -495,7 +495,7 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
                     })
              | None -> None)
           | None -> None)
-      | Some (`String "capacity_exhausted") -> (
+      | Some (`String ("capacity_backpressure" | "capacity_exhausted")) -> (
           match
             string_opt_of_assoc "cascade_name" json,
             string_opt_of_assoc "source" json,

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -266,7 +266,7 @@ let degraded_retry_reason_to_string = function
   | Cascade_candidates_filtered -> "cascade_candidates_filtered"
   | Required_tool_contract_violation -> "required_tool_contract_violation"
   | Cascade_exhausted -> "cascade_exhausted"
-  | Capacity_exhausted -> "capacity_exhausted"
+  | Capacity_exhausted -> "capacity_backpressure"
   | Rate_limit -> "rate_limit"
   | Server_error -> "server_error"
   | Auth_error -> "auth_error"
@@ -357,7 +357,7 @@ let degraded_retry_after_recoverable_error
         (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Other_detail detail; _ })
       when message_looks_like_capacity_backpressure detail ->
-        local_recovery_retry Capacity_exhausted
+        local_recovery_retry Cascade_exhausted
     | Some (Keeper_turn_driver.Cascade_exhausted _)
     | Some (Keeper_turn_driver.No_tool_capable_provider _)
     | Some (Keeper_turn_driver.Accept_rejected _)
@@ -403,7 +403,7 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
         (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Other_detail detail; _ })
       when message_looks_like_capacity_backpressure detail ->
-        Some Capacity_exhausted
+        Some Cascade_exhausted
     | Some (Keeper_turn_driver.Cascade_exhausted _) ->
         (* Generic cascade exhaustion: all candidates failed without a more
            specific reason. Treat as recoverable so declarative

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -138,7 +138,7 @@ type blocker_class =
 
 let blocker_class_to_string = function
   | Cascade_exhausted _ -> "cascade_exhausted"
-  | Capacity_exhausted -> "capacity_exhausted"
+  | Capacity_exhausted -> "capacity_backpressure"
   | Ambiguous_post_commit_timeout -> "ambiguous_post_commit_timeout"
   | Ambiguous_post_commit_failure -> "ambiguous_post_commit_failure"
   | Autonomous_slot_wait_timeout -> "autonomous_slot_wait_timeout"
@@ -166,6 +166,7 @@ let blocker_class_to_string = function
 
 let blocker_class_of_serialized_string = function
   | "cascade_exhausted" -> Some (Cascade_exhausted (Other_detail "cascade_exhausted"))
+  | "capacity_backpressure" -> Some Capacity_exhausted
   | "capacity_exhausted" -> Some Capacity_exhausted
   | "ambiguous_post_commit_timeout" -> Some Ambiguous_post_commit_timeout
   | "ambiguous_post_commit_failure" -> Some Ambiguous_post_commit_failure

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -157,21 +157,6 @@ let blocker_class_of_string (reason : string) : blocker_class option =
   let trimmed = String.trim reason in
   if trimmed = ""
   then None
-  else if
-    String_util.contains_substring_ci trimmed "capacity_exhausted"
-    || String_util.contains_substring_ci trimmed "capacity exhausted"
-    || String_util.contains_substring_ci trimmed "slot full"
-    || String_util.contains_substring_ci trimmed "client capacity"
-  then Some Capacity_exhausted
-  else if
-    String_util.contains_substring_ci
-      trimmed
-      "turn outcome ambiguous after committed mutating tool call(s)"
-  then
-    Some
-      (if String_util.contains_substring_ci trimmed "turn wall-clock timeout"
-       then Ambiguous_post_commit_timeout
-       else Ambiguous_post_commit_failure)
   else if String_util.contains_substring_ci trimmed "cascade_exhausted"
   then (
     let reason =
@@ -189,6 +174,22 @@ let blocker_class_of_string (reason : string) : blocker_class option =
       else Other_detail trimmed
     in
     Some (Cascade_exhausted reason))
+  else if
+    String_util.contains_substring_ci trimmed "capacity_exhausted"
+    || String_util.contains_substring_ci trimmed "capacity exhausted"
+    || String_util.contains_substring_ci trimmed "capacity_backpressure"
+    || String_util.contains_substring_ci trimmed "slot full"
+    || String_util.contains_substring_ci trimmed "client capacity"
+  then Some Capacity_exhausted
+  else if
+    String_util.contains_substring_ci
+      trimmed
+      "turn outcome ambiguous after committed mutating tool call(s)"
+  then
+    Some
+      (if String_util.contains_substring_ci trimmed "turn wall-clock timeout"
+       then Ambiguous_post_commit_timeout
+       else Ambiguous_post_commit_failure)
   else if String_util.contains_substring_ci trimmed "admission queue wait timeout"
   then Some Admission_queue_wait_timeout
   else if String_util.contains_substring_ci trimmed "autonomous turn slot wait timeout"
@@ -281,11 +282,6 @@ type runtime_blocker_surface =
 
 let runtime_blocker_class_label ?(summary = "") cls =
   match cls with
-  | Capacity_exhausted -> "capacity_exhausted"
-  | Cascade_exhausted (Other_detail detail)
-    when Keeper_error_classify.message_looks_like_capacity_backpressure detail
-         || Keeper_error_classify.message_looks_like_capacity_backpressure summary ->
-      "capacity_exhausted"
   | _ -> blocker_class_to_string cls
 
 let is_timeout_budget_blocker_class blocker_class =
@@ -301,11 +297,6 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
   let summary =
     match cls with
     | Capacity_exhausted ->
-      if summary = ""
-      then "Provider or client capacity backpressure blocked this keeper turn."
-      else summary
-    | Cascade_exhausted (Other_detail _)
-      when String.equal str "capacity_exhausted" ->
       if summary = ""
       then "Provider or client capacity backpressure blocked this keeper turn."
       else summary

--- a/lib/keeper/keeper_turn_terminal.ml
+++ b/lib/keeper/keeper_turn_terminal.ml
@@ -129,7 +129,7 @@ let of_failure ?(post_commit_ambiguous = false) ?(tool_call_count = 0) ~raw_erro
     | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
       make ~source:"typed_error" "oas_timeout_budget"
     | Some (Keeper_turn_driver.Capacity_backpressure _) ->
-      make ~source:"typed_error" "capacity_exhausted"
+      make ~source:"typed_error" "capacity_backpressure"
     | Some (Keeper_turn_driver.Turn_timeout _) ->
       make ~source:"typed_error" "turn_wall_clock_timeout"
     | _ ->

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -127,7 +127,7 @@ let cascade_exhausted_failure_reason_of_raw_error ~detail raw_error =
   | Some (Cascade_error_classify.Capacity_backpressure { detail = capacity_detail; _ }) ->
     Some
       (Keeper_registry.Provider_runtime_error
-         { code = "capacity_exhausted"
+         { code = "capacity_backpressure"
          ; detail = capacity_detail
          ; provider_id = None
          ; http_status = None

--- a/test/test_cascade_error_classify_decoder.ml
+++ b/test/test_cascade_error_classify_decoder.ml
@@ -109,7 +109,7 @@ let test_roundtrip_bare_string_reason () =
 let test_roundtrip_capacity_backpressure () =
   let payload =
     `Assoc
-      [ ("kind", `String "capacity_exhausted")
+      [ ("kind", `String "capacity_backpressure")
       ; ("cascade_name", `String "primary")
       ; ("source", `String "client_capacity")
       ; ("detail", `String "client capacity key glm is full")

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -44,7 +44,7 @@ let test_stale_fleet_batch_blocker_class_roundtrip () =
 let test_capacity_exhausted_blocker_class_roundtrip () =
   let cls = KT.Capacity_exhausted in
   let label = KT.blocker_class_to_string cls in
-  check string "label" "capacity_exhausted" label;
+  check string "label" "capacity_backpressure" label;
   match MC.blocker_class_of_serialized_string label with
   | Some MC.Capacity_exhausted -> ()
   | Some _ -> fail "Capacity_exhausted label parsed as wrong class"

--- a/test/test_keeper_blocker_class_completion_contract.ml
+++ b/test/test_keeper_blocker_class_completion_contract.ml
@@ -38,6 +38,19 @@ let check_capacity_class label cls_opt =
   | None ->
       fail (Printf.sprintf "%s returned None, expected Capacity_exhausted" label)
 
+let check_cascade_class label cls_opt =
+  match cls_opt with
+  | Some (KT.Cascade_exhausted _) -> ()
+  | Some other ->
+      let other_str = KT.blocker_class_to_string other in
+      fail
+        (Printf.sprintf
+           "%s mapped to %s, expected Cascade_exhausted"
+           label
+           other_str)
+  | None ->
+      fail (Printf.sprintf "%s returned None, expected Cascade_exhausted" label)
+
 let test_completion_contract_text_maps () =
   let msg = "Completion contract [require_tool_use] violated: actionable \
              keeper signal was present, but the model used \
@@ -87,9 +100,9 @@ let test_turn_livelock_text_maps () =
       fail ("turn livelock mapped to " ^ KT.blocker_class_to_string other)
   | None -> fail "turn livelock returned None"
 
-let test_capacity_backpressure_text_maps () =
-  check_capacity_class
-    "slot-full text"
+let test_legacy_cascade_slot_full_text_stays_cascade_exhausted () =
+  check_cascade_class
+    "legacy cascade slot-full text"
     (B.blocker_class_of_string
        "Internal error: [masc_oas_error] {\"kind\":\"cascade_exhausted\",\
         \"reason\":{\"tag\":\"other_detail\",\"message\":\"slot full, cascading \
@@ -109,13 +122,13 @@ let test_capacity_backpressure_sdk_error_maps () =
   check_capacity_class "typed capacity structured SDK error"
     (B.blocker_class_of_sdk_error err)
 
-let test_capacity_backpressure_runtime_surface_maps_legacy_cascade () =
+let test_capacity_backpressure_runtime_surface_preserves_legacy_cascade_class () =
   let surface =
     B.runtime_blocker_surface_of_typed_class
       ~summary:"slot full, cascading to next provider"
       (KT.Cascade_exhausted (KT.Other_detail "cascade_exhausted"))
   in
-  check string "runtime blocker class" "capacity_exhausted"
+  check string "runtime blocker class" "cascade_exhausted"
     surface.blocker_class
 
 let () =
@@ -142,11 +155,11 @@ let () =
           test_case "existing turn-timeout mapping unchanged" `Quick
             test_existing_mappings_unchanged;
           test_case "turn livelock text maps" `Quick test_turn_livelock_text_maps;
-          test_case "capacity backpressure text maps" `Quick
-            test_capacity_backpressure_text_maps;
+          test_case "legacy cascade slot-full text stays cascade_exhausted" `Quick
+            test_legacy_cascade_slot_full_text_stays_cascade_exhausted;
           test_case "capacity backpressure SDK error maps" `Quick
             test_capacity_backpressure_sdk_error_maps;
-          test_case "capacity backpressure runtime surface maps legacy cascade" `Quick
-            test_capacity_backpressure_runtime_surface_maps_legacy_cascade;
+          test_case "capacity backpressure runtime surface preserves legacy cascade class" `Quick
+            test_capacity_backpressure_runtime_surface_preserves_legacy_cascade_class;
         ] );
     ]

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -64,7 +64,7 @@ let test_other_detail_generic_recoverable () =
   | None ->
     fail "Generic Cascade_exhausted with Other_detail should be recoverable"
 
-let test_slot_full_other_detail_is_capacity_backpressure () =
+let test_slot_full_other_detail_stays_legacy_cascade_exhausted () =
   let err =
     make_cascade_exhausted
       (KT.Other_detail "slot full, cascading to next provider")
@@ -75,10 +75,10 @@ let test_slot_full_other_detail_is_capacity_backpressure () =
     (KEC.is_cascade_exhausted_error err);
   match KEC.recoverable_cascade_failure_reason err with
   | Some reason ->
-    check string "legacy slot full -> capacity_exhausted" "capacity_exhausted"
+    check string "legacy slot full -> cascade_exhausted" "cascade_exhausted"
       (KEC.degraded_retry_reason_to_string reason)
   | None ->
-    fail "slot full should be capacity-backpressure recoverable"
+    fail "slot full should be cascade-exhausted recoverable"
 
 let test_typed_capacity_backpressure_is_not_cascade_exhausted () =
   let err = make_capacity_backpressure () in
@@ -88,7 +88,7 @@ let test_typed_capacity_backpressure_is_not_cascade_exhausted () =
     (KEC.is_cascade_exhausted_error err);
   match KEC.recoverable_cascade_failure_reason err with
   | Some reason ->
-    check string "typed capacity -> capacity_exhausted" "capacity_exhausted"
+    check string "typed capacity -> capacity_backpressure" "capacity_backpressure"
       (KEC.degraded_retry_reason_to_string reason)
   | None ->
     fail "typed capacity backpressure should be recoverable as capacity"
@@ -106,8 +106,8 @@ let test_provider_capacity_exhausted_is_capacity_backpressure () =
   in
   match KEC.recoverable_cascade_failure_reason err with
   | Some reason ->
-    check string "Provider CapacityExhausted -> capacity_exhausted"
-      "capacity_exhausted"
+    check string "Provider CapacityExhausted -> capacity_backpressure"
+      "capacity_backpressure"
       (KEC.degraded_retry_reason_to_string reason)
   | None ->
     fail "Provider CapacityExhausted should be recoverable as capacity"
@@ -444,8 +444,8 @@ let () =
             test_auto_recoverable_cascade_exhausted_is_still_cascade_exhausted;
           test_case "Other_detail (non-quota) is recoverable" `Quick
             test_other_detail_generic_recoverable;
-          test_case "slot full Other_detail is capacity backpressure" `Quick
-            test_slot_full_other_detail_is_capacity_backpressure;
+          test_case "slot full Other_detail stays legacy cascade exhausted" `Quick
+            test_slot_full_other_detail_stays_legacy_cascade_exhausted;
           test_case "typed capacity backpressure is not cascade exhausted" `Quick
             test_typed_capacity_backpressure_is_not_cascade_exhausted;
           test_case "provider CapacityExhausted is capacity backpressure" `Quick

--- a/test/test_oas_error_kind_counter.ml
+++ b/test/test_oas_error_kind_counter.ml
@@ -79,7 +79,7 @@ let test_cascade_exhausted_kind () =
     (counter_for ~cascade_name kind)
 
 let test_capacity_backpressure_kind () =
-  let kind = "capacity_exhausted" in
+  let kind = "capacity_backpressure" in
   let cascade_name = "primary" in
   let before = counter_for ~cascade_name kind in
   let _ =
@@ -93,7 +93,7 @@ let test_capacity_backpressure_kind () =
          })
   in
   Alcotest.(check (float 0.0001))
-    "capacity_exhausted{cascade_name=primary} counter +1"
+    "capacity_backpressure{cascade_name=primary} counter +1"
     (before +. 1.0)
     (counter_for ~cascade_name kind)
 
@@ -403,7 +403,7 @@ let () =
             test_turn_timeout_kind;
           Alcotest.test_case "cascade_exhausted" `Quick
             test_cascade_exhausted_kind;
-          Alcotest.test_case "capacity_exhausted" `Quick
+          Alcotest.test_case "capacity_backpressure" `Quick
             test_capacity_backpressure_kind;
           Alcotest.test_case "resumable_cli_session" `Quick
             test_resumable_cli_session_kind;


### PR DESCRIPTION
## Summary

- stop promoting legacy cascade_exhausted + slot-full text into capacity_exhausted on keeper status surfaces
- rename new MASC runtime/status capacity wire labels from capacity_exhausted to capacity_backpressure
- keep legacy capacity_exhausted parsing for persisted metadata/backward compatibility
- update regression coverage for status bridge and recoverable cascade classification

Fixes #17096.

## Verification

- `ocamlformat --check lib/keeper/keeper_status_bridge.ml lib/keeper/keeper_error_classify.ml lib/keeper/keeper_meta_contract.ml lib/cascade/cascade_error_classify.ml lib/keeper/keeper_turn_terminal.ml lib/keeper/keeper_unified_turn_types.ml test/test_keeper_blocker_class_completion_contract.ml test/test_keeper_error_classify_recoverable.ml test/test_keeper_auto_pause_blocker_persist_12683.ml test/test_cascade_error_classify_decoder.ml test/test_oas_error_kind_counter.ml`
- `git diff --check`

Local focused Dune build was queued behind the host-wide `/tmp/me-dune-local.lock` for over 8 minutes and was cancelled to avoid adding more local load; PR CI should run the compile/test gate.
