### PR TITLE
chore(tools): drop register capabilities alias

### DIFF
--- a/docs/spec/03-room-coordination.md
+++ b/docs/spec/03-room-coordination.md
@@ -617,7 +617,6 @@ Docker-style `{agent_type}-{adjective}-{animal}`:
 |------|------|
 | `masc_agents` | 에이전트 목록 (상태, 좀비 여부 포함) |
 | `masc_agent_update` | 에이전트 상태/능력 갱신 |
-| `masc_register_capabilities` | Deprecated compatibility alias. Use `masc_agent_update` for capability updates. |
 | `masc_find_by_capability` | 능력 기반 에이전트 검색 |
 | `masc_get_metrics` | 에이전트 성과 메트릭 |
 | `masc_agent_fitness` | 에이전트 적합도 평가 |

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -132,7 +132,6 @@ let affected_resource_ids_for_tool = function
   | "masc_plan_clear_task" -> task_resource_ids
   | "masc_join"
   | "masc_leave"
-  | "masc_register_capabilities"
   | "masc_heartbeat"
   | "masc_suspend" -> agent_resource_ids
   | "masc_broadcast" | "masc_portal_open" | "masc_portal_send" | "masc_portal_close" ->

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -243,7 +243,6 @@ let custom_tool_titles : (string * string) list = [
   (* Agents *)
   ("masc_agents", "List Agent Details");
   ("masc_agent_update", "Update Agent Profile");
-  ("masc_register_capabilities", "Register Agent Capabilities");
   (* Heartbeat *)
   ("masc_heartbeat", "Send Heartbeat");
   (* Operations *)

--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -64,11 +64,6 @@ let handle_agents ctx args =
   in
   Tool_result.quick_ok (Yojson.Safe.to_string json)
 
-(** Handle masc_register_capabilities *)
-let handle_register_capabilities ctx args =
-  let capabilities = get_string_list args "capabilities" in
-  Tool_result.quick_ok (Coord.register_capabilities ctx.config ~agent_name:ctx.agent_name ~capabilities)
-
 (** Handle masc_agent_update *)
 let handle_agent_update ctx args =
   let status = get_string_opt args "status" in
@@ -329,7 +324,6 @@ let handle_agent_card ctx args =
 let dispatch ctx ~name ~args =
   match name with
   | "masc_agents" -> Some (handle_agents ctx args)
-  | "masc_register_capabilities" -> Some (handle_register_capabilities ctx args)
   | "masc_agent_update" -> Some (handle_agent_update ctx args)
   | "masc_get_metrics" -> Some (handle_get_metrics ctx args)
   | "masc_agent_fitness" -> Some (handle_agent_fitness ctx args)
@@ -344,22 +338,18 @@ let schemas = Tool_schemas_agent.schemas
 
 let tool_spec_read_only =
   [ "masc_agents"; "masc_agent_card" ]
-let tool_spec_requires_join = [ "masc_register_capabilities" ]
+let tool_spec_requires_join = []
 
 let tool_required_permission = function
   | "masc_agents" | "masc_agent_fitness" | "masc_agent_card"
   | "masc_get_metrics" ->
       Some Masc_domain.CanReadState
-  | "masc_register_capabilities" | "masc_agent_update" ->
-      Some Masc_domain.CanBroadcast
+  | "masc_agent_update" -> Some Masc_domain.CanBroadcast
   | _ -> None
 
 let () =
   List.iter
     (fun (s : Masc_domain.tool_schema) ->
-      let deprecated_register_capabilities =
-        String.equal s.name "masc_register_capabilities"
-      in
       Tool_spec.register
         (Tool_spec.create
            ~name:s.name
@@ -370,25 +360,6 @@ let () =
            ~is_read_only:(List.mem s.name tool_spec_read_only)
            ~is_idempotent:(List.mem s.name tool_spec_read_only)
            ~requires_join:(List.mem s.name tool_spec_requires_join)
-           ~visibility:
-             (if deprecated_register_capabilities
-              then Tool_catalog.Hidden
-              else Tool_catalog.Default)
-           ~lifecycle:
-             (if deprecated_register_capabilities
-              then Tool_catalog.Deprecated
-              else Tool_catalog.Active)
-           ?replacement:
-             (if deprecated_register_capabilities
-              then Some "masc_agent_update"
-              else None)
-           ?reason:
-             (if deprecated_register_capabilities
-              then
-                Some
-                  "Deprecated compatibility alias. Use masc_agent_update with capabilities instead."
-              else None)
-           ~allow_direct_call_when_hidden:deprecated_register_capabilities
            ?required_permission:(tool_required_permission s.name)
            ()))
     schemas

--- a/lib/tool_agent.mli
+++ b/lib/tool_agent.mli
@@ -28,9 +28,6 @@ val schemas : Masc_domain.tool_schema list
 (** Handle masc_agents *)
 val handle_agents : context -> Yojson.Safe.t -> Tool_result.t
 
-(** Handle masc_register_capabilities *)
-val handle_register_capabilities : context -> Yojson.Safe.t -> Tool_result.t
-
 (** Handle masc_agent_update *)
 val handle_agent_update : context -> Yojson.Safe.t -> Tool_result.t
 

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -235,9 +235,6 @@ let explicit_metadata : (string * metadata) list =
     ("masc_plan_set_task", actor_bound_masc_coordination_tool);
     ( "masc_broadcast",
       { masc_coordination_tool with required_permission = Some Masc_domain.CanBroadcast } );
-    ( "masc_register_capabilities",
-      deprecated ~replacement:"masc_agent_update" ~allow_direct_call_when_hidden:true
-        "Deprecated compatibility alias. Use masc_agent_update with capabilities instead." );
     ( "masc_messages",
       { readonly_tool with required_permission = Some Masc_domain.CanReadState } );
     ( "masc_who",

--- a/lib/tool_catalog_inference.ml
+++ b/lib/tool_catalog_inference.ml
@@ -231,7 +231,6 @@ let inferred_effect_domain_of_typed_tool_name = function
   | TN.Masc TM.Plan_init
   | TN.Masc TM.Plan_set_task
   | TN.Masc TM.Plan_update
-  | TN.Masc TM.Register_capabilities
   | TN.Masc TM.Release_task
   | TN.Masc TM.Reset
   | TN.Masc TM.Coord_status
@@ -423,7 +422,6 @@ let tool_group_of_typed_tool_name = function
       | TM.Operator_digest
       | TM.Operator_snapshot
       | TM.Pause
-      | TM.Register_capabilities
       | TM.Release_task
       | TM.Reset
       | TM.Resume

--- a/lib/tool_dispatch.ml
+++ b/lib/tool_dispatch.ml
@@ -322,8 +322,7 @@ let static_tag_of_tool_name (tool : Tool_name.t) : module_tag option =
     | Agent_card
     | Agent_update
     | Agents
-    | Get_metrics
-    | Register_capabilities -> Some Mod_agent
+    | Get_metrics -> Some Mod_agent
     | Autoresearch_cycle
     | Autoresearch_inject
     | Autoresearch_record_finding

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -327,7 +327,6 @@ module Masc = struct
     | Plan_init
     | Plan_set_task
     | Plan_update
-    | Register_capabilities
     | Release_task
     | Reset
     | Coord_status
@@ -442,7 +441,6 @@ module Masc = struct
     | Plan_init -> "masc_plan_init"
     | Plan_set_task -> "masc_plan_set_task"
     | Plan_update -> "masc_plan_update"
-    | Register_capabilities -> "masc_register_capabilities"
     | Release_task -> "masc_release_task"
     | Reset -> "masc_reset"
     | Coord_status -> "masc_room_status"
@@ -558,7 +556,6 @@ module Masc = struct
     | "masc_plan_init" -> Some Plan_init
     | "masc_plan_set_task" -> Some Plan_set_task
     | "masc_plan_update" -> Some Plan_update
-    | "masc_register_capabilities" -> Some Register_capabilities
     | "masc_release_task" -> Some Release_task
     | "masc_reset" -> Some Reset
     | "masc_room_status" -> Some Coord_status

--- a/lib/tool_name.mli
+++ b/lib/tool_name.mli
@@ -154,7 +154,6 @@ module Masc : sig
     | Plan_init
     | Plan_set_task
     | Plan_update
-    | Register_capabilities
     | Release_task
     | Reset
     | Coord_status

--- a/lib/tool_permission_map.ml
+++ b/lib/tool_permission_map.ml
@@ -83,7 +83,6 @@ let legacy_permission_entries : (string * permission) list =
   ; "masc_webrtc_offer", CanBroadcast
   ; "masc_webrtc_answer", CanBroadcast
   ; "channel_gate", CanBroadcast
-  ; "masc_register_capabilities", CanBroadcast
   ; "masc_agent_update", CanBroadcast
   ; "masc_spawn", CanBroadcast
   ; "masc_operator_action", CanBroadcast

--- a/lib/tool_resource_gate.ml
+++ b/lib/tool_resource_gate.ml
@@ -293,7 +293,6 @@ let classify_masc_tool (tool : Tool_name.Masc.t) =
   | Plan_init
   | Plan_set_task
   | Plan_update
-  | Register_capabilities
   | Release_task
   | Reset
   | Set_current_task

--- a/lib/tool_schemas/tool_schemas_agent.ml
+++ b/lib/tool_schemas/tool_schemas_agent.ml
@@ -73,27 +73,6 @@ let schemas : tool_schema list = [
     ];
   };
   {
-    name = "masc_register_capabilities";
-    description = "Register your skill tags so other agents can discover you by capability.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("agent_name", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Your agent name");
-        ]);
-        ("capabilities", `Assoc [
-          ("type", `String "array");
-          ("items", `Assoc [("type", `String "string")]);
-          ("description", `String "List of your capabilities (e.g., ['typescript', 'testing'])");
-        ]);
-      ]);
-      ("required", `List [`String "agent_name"; `String "capabilities"]);
-      ("additionalProperties", `Bool false);
-    ];
-  };
-
-  {
     name = "masc_get_metrics";
     description = "Fetch raw performance metrics for an agent: task completion, timing, error rates, collaboration history.";
     input_schema = `Assoc [

--- a/lib/tool_schemas/tool_schemas_agent.mli
+++ b/lib/tool_schemas/tool_schemas_agent.mli
@@ -19,6 +19,5 @@ val agent_card_action_enum_strings : string list
 val collaboration_format_enum_strings : string list
 
 (** Tool schemas: [masc_agents], [masc_agent_update],
-    [masc_agent_fitness], [masc_register_capabilities],
-    [masc_get_metrics], [masc_agent_card]. *)
+    [masc_agent_fitness], [masc_get_metrics], [masc_agent_card]. *)
 val schemas : Masc_domain.tool_schema list

--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -275,15 +275,15 @@ let test_dashboard_tools_projection () =
       let public_tool = find_tool "masc_status" in
       let spawned_agent_tool = find_tool "masc_workflow_guide" in
       let local_worker_tool = find_tool "masc_worktree_create" in
-      let deprecated_alias_tool = find_tool "masc_register_capabilities" in
+      let removed_alias_tool = find_tool "masc_register_capabilities" in
       check bool "includes hidden tool" true (Option.is_some hidden_tool);
       check bool "includes public tool" true (Option.is_some public_tool);
       check bool "includes spawned agent tool" true
         (Option.is_some spawned_agent_tool);
       check bool "includes local worker tool" true
         (Option.is_some local_worker_tool);
-      check bool "includes deprecated alias tool" true
-        (Option.is_some deprecated_alias_tool);
+      check bool "omits removed register_capabilities alias" false
+        (Option.is_some removed_alias_tool);
       (match public_tool with
       | None -> ()
       | Some row ->

--- a/test/test_tool_agent_coverage.ml
+++ b/test/test_tool_agent_coverage.ml
@@ -1,9 +1,8 @@
 (** Coverage tests for Tool_agent — Agent management, fitness, and meta-cognition
 
     Tests dispatch routing, handler execution, helper functions for:
-    masc_agents, masc_register_capabilities, masc_agent_update,
-    masc_get_metrics, masc_agent_fitness, masc_collaboration_graph,
-    masc_agent_card
+    masc_agents, masc_agent_update, masc_get_metrics, masc_agent_fitness,
+    masc_collaboration_graph, masc_agent_card
 *)
 module Tool_args = Tool_args
 module Tool_result = Tool_result
@@ -128,10 +127,10 @@ let test_dispatch_agents () =
   Alcotest.(check bool) "agents dispatches" true (result <> None);
   )
 
-let test_dispatch_register_capabilities () =
+let test_dispatch_register_capabilities_removed () =
   with_ctx (fun ctx ->
   let result = Tool_agent.dispatch ctx ~name:"masc_register_capabilities" ~args:(`Assoc []) in
-  Alcotest.(check bool) "register_capabilities dispatches" true (result <> None);
+  Alcotest.(check bool) "register_capabilities removed" true (result = None);
   )
 
 let test_dispatch_agent_update () =
@@ -178,17 +177,6 @@ let test_handle_agent_card_rejects_unknown_action () =
   Alcotest.(check bool) "agent card rejects" false result.Tool_result.success;
   Alcotest.(check bool) "mentions invalid action" true
     (String.contains result.Tool_result.legacy_message 'b');
-  )
-
-(* ============================================================
-   Handler tests — register_capabilities
-   ============================================================ *)
-
-let test_register_capabilities () =
-  with_ctx (fun ctx ->
-  let args = `Assoc [("capabilities", `List [`String "test"; `String "code"])] in
-  let result = Tool_agent.handle_register_capabilities ctx args in
-  Alcotest.(check bool) "registers capabilities" true result.Tool_result.success;
   )
 
 (* ============================================================
@@ -412,7 +400,8 @@ let () =
     ("dispatch", [
       Alcotest.test_case "unknown returns None" `Quick test_dispatch_unknown;
       Alcotest.test_case "agents dispatches" `Quick test_dispatch_agents;
-      Alcotest.test_case "register_capabilities dispatches" `Quick test_dispatch_register_capabilities;
+      Alcotest.test_case "register_capabilities removed" `Quick
+        test_dispatch_register_capabilities_removed;
       Alcotest.test_case "agent_update dispatches" `Quick test_dispatch_agent_update;
       Alcotest.test_case "agent_card dispatches" `Quick test_dispatch_agent_card;
     ]);
@@ -421,9 +410,6 @@ let () =
       Alcotest.test_case "handle_agent_card" `Quick test_handle_agent_card;
       Alcotest.test_case "handle_agent_card rejects unknown action" `Quick
         test_handle_agent_card_rejects_unknown_action;
-    ]);
-    ("register_capabilities", [
-      Alcotest.test_case "with capabilities" `Quick test_register_capabilities;
     ]);
     ("agent_update", [
       Alcotest.test_case "status update" `Quick test_agent_update_status;

--- a/test/test_tool_name.ml
+++ b/test/test_tool_name.ml
@@ -37,7 +37,7 @@ let all_masc : Tool_name.Masc.t list =
   ; Operation_pause; Operation_start; Operation_status; Operation_stop
   ; Operator_action; Operator_confirm; Operator_digest; Operator_snapshot
   ; Plan_clear_task; Plan_get; Plan_get_task; Plan_init; Plan_set_task
-  ; Plan_update; Register_capabilities; Release_task; Reset; Coord_status
+  ; Plan_update; Release_task; Reset; Coord_status
   ; Set_current_task; Status; Task_history; Tasks; Tool_grant; Tool_help
   ; Tool_list; Tool_revoke; Transition; Update_priority; Web_search; Who
   ; Workflow_guide; Worktree_create; Worktree_list; Worktree_remove

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -439,15 +439,10 @@ let test_masc_agents_schema () =
   | None -> Alcotest.fail "masc_agents not found"
   | Some _ -> ()
 
-let test_masc_register_capabilities_schema () =
+let test_masc_register_capabilities_removed () =
   match find_tool "masc_register_capabilities" with
-  | None -> Alcotest.fail "masc_register_capabilities not found"
-  | Some schema ->
-      match get_json_assoc "properties" schema.input_schema with
-      | Some props ->
-          Alcotest.(check bool) "has agent_name" true (List.mem_assoc "agent_name" props);
-          Alcotest.(check bool) "has capabilities" true (List.mem_assoc "capabilities" props)
-      | None -> Alcotest.fail "masc_register_capabilities missing properties"
+  | None -> ()
+  | Some _ -> Alcotest.fail "masc_register_capabilities should be removed"
 
 (* test_masc_find_by_capability_schema removed: tool pruned *)
 
@@ -901,7 +896,8 @@ let () =
     ];
     "agent_tools", [
       Alcotest.test_case "agents" `Quick test_masc_agents_schema;
-      Alcotest.test_case "register_capabilities" `Quick test_masc_register_capabilities_schema;
+      Alcotest.test_case "register_capabilities removed" `Quick
+        test_masc_register_capabilities_removed;
       (* find_by_capability removed: tool pruned *)
     ];
     "plan_tools", [


### PR DESCRIPTION
## Summary
- remove the deprecated hidden `masc_register_capabilities` alias from schema, dispatch, catalog metadata, typed names, permission/resource classification, and docs
- keep the canonical `masc_agent_update` capabilities path
- convert tests from alias-present assertions to alias-removed ratchets

## Verification
- `ocamlformat --check lib/tool_agent.ml lib/tool_agent.mli lib/tool_schemas/tool_schemas_agent.ml lib/tool_schemas/tool_schemas_agent.mli lib/tool_catalog.ml lib/tool_dispatch.ml lib/tool_name.ml lib/tool_name.mli lib/tool_catalog_inference.ml lib/tool_resource_gate.ml lib/mcp_server_eio_protocol.ml lib/mcp_server_eio_tool_profile.ml lib/tool_permission_map.ml test/test_dashboard_tools.ml test/test_tool_agent_coverage.ml test/test_tool_name.ml test/test_tools_coverage.ml`
- `git diff --check`
- `git grep -n "masc_register_capabilities\|Register_capabilities\|handle_register_capabilities" -- lib docs config scripts` returned 0 hits

## Local Dune
- attempted `scripts/dune-local.sh build test/test_tool_agent_coverage.exe test/test_tools_coverage.exe test/test_dashboard_tools.exe test/test_tool_name.exe`
- blocked by another long-running wrapper lock: `extract-worker-dev-tools-path-validation/scripts/dune-local.sh build lib/masc_mcp.cma test/test_worker_dev_tools.exe test/test_path_rewrite_validation.exe`
