### PR TITLE
refactor(keeper): preserve actionable signal context

### DIFF
--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -68,6 +68,16 @@ jobs:
       - name: Run lint
         run: bash scripts/lint/shell-legacy-purge-ratchet.sh
 
+  no-actionable-signal-bool-context:
+    name: No actionable signal bool context
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install ripgrep
+        run: sudo apt-get install -y -qq ripgrep
+      - name: Run lint
+        run: bash scripts/lint/no-actionable-signal-bool-context.sh
+
   no-provider-name-hardcoding:
     name: Provider name hardcoding ratchet
     runs-on: ubuntu-latest

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1056,24 +1056,31 @@ let run_turn
                        |> Keeper_contract_classifier.classify_actionable_signal_for_tools
                             ~allowed_tool_names:all_tool_names
                    in
-                   let actionable_signal_context =
+                   let tool_gate_required =
                      Keeper_agent_tool_surface
                      .turn_affordances_require_tool_gate_with_allowed
                        ~allowed_tool_names:all_tool_names
                        turn_affordances
-                     || Keeper_contract_classifier.is_actionable actionable_signal_kind
+                   in
+                   let actionable_signal_context =
+                     Keeper_contract_classifier.make_actionable_signal_context
+                       ~tool_gate_required
+                       ~actionable_signal:actionable_signal_kind
                    in
                    let actionable_tool_contract_violation_reason =
                      if
-                       actionable_signal_context
+                       Keeper_contract_classifier.is_actionable_signal_context
+                         actionable_signal_context
                        && progress_keeper_tool_names = []
                        && no_progress_success_tool_names <> []
                      then
                        Some
                          (Printf.sprintf
-                            "actionable keeper signal was present, but the model only \
-                             used idempotent setup tools that made no execution \
+                            "actionable keeper context (%s) was present, but the model \
+                             only used idempotent setup tools that made no execution \
                              progress: %s"
+                            (Keeper_contract_classifier.actionable_signal_context_label
+                               actionable_signal_context)
                             (String.concat ", " no_progress_success_tool_names))
                      else
                        Keeper_tool_disclosure.actionable_tool_contract_violation_reason

--- a/lib/keeper/keeper_contract_classifier.ml
+++ b/lib/keeper/keeper_contract_classifier.ml
@@ -4,6 +4,11 @@ type actionable_signal =
   | Has_discovered_work
   | No_actionable_signal
 
+type actionable_signal_context =
+  | No_actionable_signal_context
+  | Turn_affordance_requires_tool
+  | Keeper_world_signal of actionable_signal
+
 type contract_status =
   | Tool_surface_mismatch of { missing : string list }
   | Missing_required_tool_use
@@ -18,6 +23,11 @@ let actionable_signal_label = function
   | Has_board_activity -> "has_board_activity"
   | Has_discovered_work -> "has_discovered_work"
   | No_actionable_signal -> "no_actionable_signal"
+
+let actionable_signal_context_label = function
+  | No_actionable_signal_context -> "no_actionable_signal_context"
+  | Turn_affordance_requires_tool -> "turn_affordance_requires_tool"
+  | Keeper_world_signal signal -> actionable_signal_label signal
 
 let contract_status_label = function
   | Tool_surface_mismatch _ -> "tool_surface_mismatch"
@@ -91,9 +101,21 @@ let classify_actionable_signal_for_tools ~(allowed_tool_names : string list) o =
 let classify_actionable_signal_with_allowed_tools =
   classify_actionable_signal_for_tools
 
+let make_actionable_signal_context ~tool_gate_required ~actionable_signal =
+  if tool_gate_required
+  then Turn_affordance_requires_tool
+  else
+    match actionable_signal with
+    | No_actionable_signal -> No_actionable_signal_context
+    | signal -> Keeper_world_signal signal
+
 let is_actionable = function
   | No_actionable_signal -> false
   | Has_unclaimed_tasks | Has_board_activity | Has_discovered_work -> true
+
+let is_actionable_signal_context = function
+  | No_actionable_signal_context -> false
+  | Turn_affordance_requires_tool | Keeper_world_signal _ -> true
 
 let requires_tool_support_for_allowed_tools ~(allowed_tool_names : string list) o =
   o

--- a/lib/keeper/keeper_contract_classifier.mli
+++ b/lib/keeper/keeper_contract_classifier.mli
@@ -8,6 +8,11 @@ type actionable_signal =
       (** Caller observed neither tasks, board activity, nor
           discovered-work markers in the structured world snapshot. *)
 
+type actionable_signal_context = private
+  | No_actionable_signal_context
+  | Turn_affordance_requires_tool
+  | Keeper_world_signal of actionable_signal
+
 type contract_status =
   | Tool_surface_mismatch of { missing : string list }
   | Missing_required_tool_use
@@ -18,6 +23,7 @@ type contract_status =
   | Satisfied_execution
 
 val actionable_signal_label : actionable_signal -> string
+val actionable_signal_context_label : actionable_signal_context -> string
 val contract_status_label : contract_status -> string
 val pp_contract_status : Format.formatter -> contract_status -> unit
 
@@ -55,15 +61,11 @@ val of_keeper_world_observation :
     The precedence reflects the action ladder a keeper should
     descend: a claimable task is the highest-leverage move; engaging
     with board activity is next; discovery hints are the weakest
-    signal. The current heuristic at [keeper_agent_run.ml:2285-2298]
-    short-circuits as a single boolean and discards the precedence;
-    routing decisions made on top of [actionable_signal] can choose
-    differently for each variant.
+    signal.
 
     Boolean-compatible:
     [classify_actionable_signal o <> No_actionable_signal]
-    is the structured equivalent of the existing
-    [actionable_signal_context = true]. *)
+    is the structured equivalent of a required actionable context. *)
 val classify_actionable_signal : world_observation -> actionable_signal
 
 (** Like [classify_actionable_signal], but skips a candidate signal when
@@ -88,7 +90,14 @@ val classify_actionable_signal_with_allowed_tools :
 val requires_tool_support_for_allowed_tools :
   allowed_tool_names:string list -> world_observation -> bool
 
+val make_actionable_signal_context
+  :  tool_gate_required:bool
+  -> actionable_signal:actionable_signal
+  -> actionable_signal_context
+
 (** [is_actionable s] is [false] iff [s = No_actionable_signal].
     Provided so callers comparing the structured signal against the
     legacy boolean can do so without a manual pattern match. *)
 val is_actionable : actionable_signal -> bool
+
+val is_actionable_signal_context : actionable_signal_context -> bool

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -642,18 +642,32 @@ let record_require_tool_use_violation
     ()
 ;;
 
+let actionable_signal_context_phrase = function
+  | Keeper_contract_classifier.No_actionable_signal_context -> None
+  | Keeper_contract_classifier.Turn_affordance_requires_tool ->
+      Some "actionable keeper tool gate (turn_affordance_requires_tool)"
+  | Keeper_contract_classifier.Keeper_world_signal signal ->
+      Some
+        (Printf.sprintf
+           "actionable keeper signal (%s)"
+           (Keeper_contract_classifier.actionable_signal_label signal))
+;;
+
 let actionable_tool_contract_violation_reason
       ~(claim_context_allowed : bool)
-      ~(actionable_signal_context : bool)
+      ~(actionable_signal_context :
+          Keeper_contract_classifier.actionable_signal_context)
       ~(tool_names : string list)
   : string option
   =
-  if not actionable_signal_context
-  then None
-  else (
+  match actionable_signal_context_phrase actionable_signal_context with
+  | None -> None
+  | Some context_phrase ->
     match tool_names with
     | [] ->
-      Some "actionable keeper signal was present, but the model called no keeper tools"
+      Some
+        (Printf.sprintf "%s was present, but the model called no keeper tools"
+           context_phrase)
     | names
       when List.exists
              (if claim_context_allowed
@@ -665,14 +679,16 @@ let actionable_tool_contract_violation_reason
            && not (List.exists is_owned_task_progress_tool_name names) ->
       Some
         (Printf.sprintf
-           "actionable keeper signal was present for an owned active task, but the model \
-            only used passive/claim/stay_silent tools without execution progress: %s"
+           "%s was present for an owned active task, but the model only used \
+            passive/claim/stay_silent tools without execution progress: %s"
+           context_phrase
            (String.concat ", " names))
     | names when List.exists is_stay_silent_tool_name names ->
       Some
         (Printf.sprintf
-           "actionable keeper signal was present, but the model used keeper_stay_silent \
-            without typed no-work proof: %s"
+           "%s was present, but the model used keeper_stay_silent without typed \
+            no-work proof: %s"
+           context_phrase
            (String.concat ", " names))
     | names
       when List.for_all
@@ -680,17 +696,18 @@ let actionable_tool_contract_violation_reason
              names ->
       Some
         (Printf.sprintf
-           "actionable keeper signal was present, but the model only used passive \
-            status/read tools: %s"
+           "%s was present, but the model only used passive status/read tools: %s"
+           context_phrase
            (String.concat ", " names))
     | names
       when (not claim_context_allowed) && List.for_all is_claim_context_tool_name names ->
       Some
         (Printf.sprintf
-           "actionable keeper signal was present, but the model only used claim/context \
-            tools without execution progress: %s"
+           "%s was present, but the model only used claim/context tools without execution \
+            progress: %s"
+           context_phrase
            (String.concat ", " names))
-    | _ -> None)
+    | _ -> None
 ;;
 
 let normalize_response_text ~(text : string) ~(tool_names : string list) ()

--- a/lib/keeper/keeper_tool_disclosure.mli
+++ b/lib/keeper/keeper_tool_disclosure.mli
@@ -234,7 +234,7 @@ val record_require_tool_use_violation
     actionable signal context does not apply. *)
 val actionable_tool_contract_violation_reason
   :  claim_context_allowed:bool
-  -> actionable_signal_context:bool
+  -> actionable_signal_context:Keeper_contract_classifier.actionable_signal_context
   -> tool_names:string list
   -> string option
 

--- a/scripts/lint/no-actionable-signal-bool-context.sh
+++ b/scripts/lint/no-actionable-signal-bool-context.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+patterns=(
+  "actionable_signal_context:true"
+  "actionable_signal_context:false"
+  "actionable_signal_context:bool"
+  "actionable_signal_context : bool"
+)
+
+failed=0
+for pattern in "${patterns[@]}"; do
+  if rg -n --fixed-strings "$pattern" lib test; then
+    echo "no-actionable-signal-bool-context: forbidden legacy bool context: $pattern" >&2
+    failed=1
+  fi
+done
+
+if [[ "$failed" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "no-actionable-signal-bool-context: PASS"

--- a/test/test_keeper_unified_claim_progress.ml
+++ b/test/test_keeper_unified_claim_progress.ml
@@ -4,6 +4,18 @@ module KAR = Masc_mcp.Keeper_agent_run
 module KCC = Masc_mcp.Keeper_contract_classifier
 module KTD = Masc_mcp.Keeper_tool_disclosure
 
+let unclaimed_task_context =
+  KCC.make_actionable_signal_context
+    ~tool_gate_required:false
+    ~actionable_signal:KCC.Has_unclaimed_tasks
+;;
+
+let no_actionable_context =
+  KCC.make_actionable_signal_context
+    ~tool_gate_required:false
+    ~actionable_signal:KCC.No_actionable_signal
+;;
+
 let contains_substring haystack needle =
   let hay_len = String.length haystack in
   let needle_len = String.length needle in
@@ -126,7 +138,7 @@ let test_actionable_tool_contract_allows_execution_tools () =
     None
     (KTD.actionable_tool_contract_violation_reason
        ~claim_context_allowed:true
-       ~actionable_signal_context:true
+       ~actionable_signal_context:unclaimed_task_context
        ~tool_names:[ "keeper_bash"; "masc_status" ]);
   check
     (option string)
@@ -134,12 +146,12 @@ let test_actionable_tool_contract_allows_execution_tools () =
     None
     (KTD.actionable_tool_contract_violation_reason
        ~claim_context_allowed:true
-       ~actionable_signal_context:true
+       ~actionable_signal_context:unclaimed_task_context
        ~tool_names:[ "keeper_board_comment" ]);
   (match
      KTD.actionable_tool_contract_violation_reason
        ~claim_context_allowed:false
-       ~actionable_signal_context:true
+       ~actionable_signal_context:unclaimed_task_context
        ~tool_names:[ "keeper_board_post"; "keeper_tasks_list" ]
    with
    | Some reason ->
@@ -155,7 +167,7 @@ let test_actionable_tool_contract_allows_execution_tools () =
     None
     (KTD.actionable_tool_contract_violation_reason
        ~claim_context_allowed:false
-       ~actionable_signal_context:true
+       ~actionable_signal_context:unclaimed_task_context
        ~tool_names:[ "masc_worktree_create" ]);
   check
     (option string)
@@ -163,7 +175,7 @@ let test_actionable_tool_contract_allows_execution_tools () =
     None
     (KTD.actionable_tool_contract_violation_reason
        ~claim_context_allowed:false
-       ~actionable_signal_context:true
+       ~actionable_signal_context:unclaimed_task_context
        ~tool_names:[ "keeper_pr_create" ]);
   check
     (option string)
@@ -171,7 +183,7 @@ let test_actionable_tool_contract_allows_execution_tools () =
     None
     (KTD.actionable_tool_contract_violation_reason
        ~claim_context_allowed:true
-       ~actionable_signal_context:false
+       ~actionable_signal_context:no_actionable_context
        ~tool_names:[])
 ;;
 
@@ -224,7 +236,7 @@ let test_stay_silent_requires_typed_no_work_proof_on_actionable_signal () =
   (match
      KTD.actionable_tool_contract_violation_reason
        ~claim_context_allowed:true
-       ~actionable_signal_context:true
+       ~actionable_signal_context:unclaimed_task_context
        ~tool_names:[ "keeper_stay_silent"; "keeper_tasks_list" ]
    with
    | Some reason ->
@@ -240,7 +252,7 @@ let test_stay_silent_requires_typed_no_work_proof_on_actionable_signal () =
     None
     (KTD.actionable_tool_contract_violation_reason
        ~claim_context_allowed:true
-       ~actionable_signal_context:true
+       ~actionable_signal_context:unclaimed_task_context
        ~tool_names:[ "keeper_board_comment"; "keeper_stay_silent" ]);
   check
     (option string)
@@ -248,7 +260,7 @@ let test_stay_silent_requires_typed_no_work_proof_on_actionable_signal () =
     None
     (KTD.actionable_tool_contract_violation_reason
        ~claim_context_allowed:false
-       ~actionable_signal_context:true
+       ~actionable_signal_context:unclaimed_task_context
        ~tool_names:[ "keeper_bash"; "keeper_stay_silent" ]);
   check
     (option string)
@@ -256,7 +268,7 @@ let test_stay_silent_requires_typed_no_work_proof_on_actionable_signal () =
     None
     (KTD.actionable_tool_contract_violation_reason
        ~claim_context_allowed:true
-       ~actionable_signal_context:false
+       ~actionable_signal_context:no_actionable_context
        ~tool_names:[ "keeper_stay_silent" ]);
   check
     bool
@@ -265,7 +277,7 @@ let test_stay_silent_requires_typed_no_work_proof_on_actionable_signal () =
     (Option.is_some
        (KTD.actionable_tool_contract_violation_reason
           ~claim_context_allowed:true
-          ~actionable_signal_context:true
+          ~actionable_signal_context:unclaimed_task_context
           ~tool_names:[ "keeper_tasks_list"; "masc_status" ]))
 ;;
 

--- a/test/test_keeper_unified_completion_contract.ml
+++ b/test/test_keeper_unified_completion_contract.ml
@@ -1,6 +1,25 @@
 open Alcotest
 
+module KCC = Masc_mcp.Keeper_contract_classifier
 module KTD = Masc_mcp.Keeper_tool_disclosure
+
+let unclaimed_task_context =
+  KCC.make_actionable_signal_context
+    ~tool_gate_required:false
+    ~actionable_signal:KCC.Has_unclaimed_tasks
+;;
+
+let board_activity_context =
+  KCC.make_actionable_signal_context
+    ~tool_gate_required:false
+    ~actionable_signal:KCC.Has_board_activity
+;;
+
+let tool_gate_context =
+  KCC.make_actionable_signal_context
+    ~tool_gate_required:true
+    ~actionable_signal:KCC.No_actionable_signal
+;;
 
 let contains_substring haystack needle =
   let hay_len = String.length haystack in
@@ -145,7 +164,7 @@ let test_actionable_tool_contract_flags_no_tools () =
   match
     KTD.actionable_tool_contract_violation_reason
       ~claim_context_allowed:true
-      ~actionable_signal_context:true
+      ~actionable_signal_context:unclaimed_task_context
       ~tool_names:[]
   with
   | Some reason ->
@@ -153,15 +172,36 @@ let test_actionable_tool_contract_flags_no_tools () =
       bool
       "reason mentions no keeper tools"
       true
-      (contains_substring reason "no keeper tools")
+      (contains_substring reason "no keeper tools");
+    check
+      bool
+      "reason preserves signal kind"
+      true
+      (contains_substring reason "has_unclaimed_tasks")
   | None -> fail "expected actionable no-tool violation"
+;;
+
+let test_actionable_tool_contract_preserves_turn_gate_context () =
+  match
+    KTD.actionable_tool_contract_violation_reason
+      ~claim_context_allowed:true
+      ~actionable_signal_context:tool_gate_context
+      ~tool_names:[]
+  with
+  | Some reason ->
+    check
+      bool
+      "reason preserves turn affordance gate"
+      true
+      (contains_substring reason "turn_affordance_requires_tool")
+  | None -> fail "expected tool-gate no-tool violation"
 ;;
 
 let test_actionable_tool_contract_flags_passive_only_tools () =
   match
     KTD.actionable_tool_contract_violation_reason
       ~claim_context_allowed:true
-      ~actionable_signal_context:true
+      ~actionable_signal_context:board_activity_context
       ~tool_names:[ "keeper_board_get"; "masc_status" ]
   with
   | Some reason ->
@@ -169,7 +209,12 @@ let test_actionable_tool_contract_flags_passive_only_tools () =
       bool
       "reason mentions passive tools"
       true
-      (contains_substring reason "passive status/read tools")
+      (contains_substring reason "passive status/read tools");
+    check
+      bool
+      "reason preserves board signal kind"
+      true
+      (contains_substring reason "has_board_activity")
   | None -> fail "expected actionable passive-only violation"
 ;;
 
@@ -178,7 +223,7 @@ let test_actionable_tool_contract_rejects_claim_context_when_already_claimed () 
     match
       KTD.actionable_tool_contract_violation_reason
         ~claim_context_allowed:false
-        ~actionable_signal_context:true
+        ~actionable_signal_context:unclaimed_task_context
         ~tool_names:[ "keeper_task_claim" ]
     with
     | Some reason ->
@@ -195,7 +240,7 @@ let test_actionable_tool_contract_rejects_claim_context_when_already_claimed () 
     None
     (KTD.actionable_tool_contract_violation_reason
        ~claim_context_allowed:true
-       ~actionable_signal_context:true
+       ~actionable_signal_context:unclaimed_task_context
        ~tool_names:[ "keeper_task_claim" ])
 ;;
 
@@ -204,7 +249,7 @@ let test_actionable_tool_contract_rejects_stay_silent_when_already_claimed () =
     match
       KTD.actionable_tool_contract_violation_reason
         ~claim_context_allowed:false
-        ~actionable_signal_context:true
+        ~actionable_signal_context:unclaimed_task_context
         ~tool_names
     with
     | Some reason ->
@@ -231,7 +276,7 @@ let test_actionable_tool_contract_rejects_stay_silent_when_already_claimed () =
     None
     (KTD.actionable_tool_contract_violation_reason
        ~claim_context_allowed:false
-       ~actionable_signal_context:true
+       ~actionable_signal_context:unclaimed_task_context
        ~tool_names:[ "keeper_task_done" ])
 ;;
 
@@ -279,6 +324,10 @@ let () =
             "actionable signal rejects no tools"
             `Quick
             test_actionable_tool_contract_flags_no_tools
+        ; test_case
+            "actionable signal preserves turn-gate context"
+            `Quick
+            test_actionable_tool_contract_preserves_turn_gate_context
         ; test_case
             "actionable signal rejects passive-only tools"
             `Quick

--- a/test/test_keeper_unified_tool_observation.ml
+++ b/test/test_keeper_unified_tool_observation.ml
@@ -1,6 +1,13 @@
 open Alcotest
 
+module KCC = Masc_mcp.Keeper_contract_classifier
 module KTD = Masc_mcp.Keeper_tool_disclosure
+
+let unclaimed_task_context =
+  KCC.make_actionable_signal_context
+    ~tool_gate_required:false
+    ~actionable_signal:KCC.Has_unclaimed_tasks
+;;
 
 let test_tool_usage_delta_uses_registry_counts () =
   let before = [ "keeper_board_post", 1; "keeper_fs_read", 0; "keeper_voice_agent", 2 ] in
@@ -94,7 +101,7 @@ let test_final_keeper_tool_names_accepts_reported_mcp_keeper_tool () =
     None
     (KTD.actionable_tool_contract_violation_reason
        ~claim_context_allowed:true
-       ~actionable_signal_context:true
+       ~actionable_signal_context:unclaimed_task_context
        ~tool_names:final_tools)
 ;;
 


### PR DESCRIPTION
## Summary
- replace the final actionable_signal_context bool collapse with typed Keeper_contract_classifier.actionable_signal_context
- preserve turn-affordance gate vs. concrete keeper-world signal labels in contract violation reasons
- add a fundamental-check lint guard blocking actionable_signal_context:true/false regressions

## Verification
- ocamlformat --check lib/keeper/keeper_contract_classifier.ml lib/keeper/keeper_contract_classifier.mli lib/keeper/keeper_tool_disclosure.ml lib/keeper/keeper_tool_disclosure.mli lib/keeper/keeper_agent_run.ml test/test_keeper_unified_completion_contract.ml test/test_keeper_unified_claim_progress.ml test/test_keeper_unified_tool_observation.ml
- bash scripts/lint/no-actionable-signal-bool-context.sh
- bash scripts/lint/yaml-syntax.sh
- bash -n scripts/lint/no-actionable-signal-bool-context.sh
- git diff --check

## Local build note
- scripts/dune-local.sh build test/test_keeper_unified_completion_contract.exe test/test_keeper_unified_claim_progress.exe test/test_keeper_unified_tool_observation.exe was blocked by existing bare Dune processes outside scripts/dune-local.sh:
  - runtime-latest-main-20260520 bin/main_eio.exe
  - purge-legacy-slot-full-20260521 test/test_keeper_error_classify_recoverable.exe
  - dune build --root . lib/masc_mcp.cmxa