### PR TITLE
refactor(keeper_turn_driver): extract cascade-tier admission helpers into sibling (Lane B carve-out)

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -19,111 +19,29 @@ include Keeper_turn_driver_helpers
 
 include Keeper_turn_driver_provider_attempt
 
-let keeper_cascade_tier_admission = Cascade_tier_admission.create ()
+let keeper_cascade_tier_admission =
+  Keeper_turn_driver_admission.keeper_cascade_tier_admission
 
-let cascade_tier_admission_policy_of_priority priority =
-  (* RFC-0126: exhaustive typed match over Llm_provider.Request_priority.t
-     instead of the previous string-classifier (`to_string |> match`) so that
-     future variants in the upstream agent_sdk surface as a compile error
-     here rather than silently routing through a permissive default.
-     Semantics: only [Background] (P2 heartbeat / status ticks) bypasses
-     tier admission per Cascade_tier_admission.mli side-task starvation
-     defence; main-path priorities all require admission.  [Unspecified]
-     is unreachable after [resolve] (it maps to [Proactive]) but the arm
-     keeps the match exhaustive without a catch-all. *)
-  match Llm_provider.Request_priority.resolve priority with
-  | Background -> Cascade_tier_admission.Bypass
-  | Resume | Interactive | Proactive | Unspecified ->
-      Cascade_tier_admission.Required
+let cascade_tier_admission_policy_of_priority =
+  Keeper_turn_driver_admission.cascade_tier_admission_policy_of_priority
 
-let with_keeper_cascade_tier_admission
-    ?(admission = keeper_cascade_tier_admission)
-    ?(enabled = Env_config_keeper.CascadeTierAdmission.enabled ())
-    ~tier_id
-    ~admission_policy
-    f =
-  if enabled
-  then
-    Cascade_tier_admission.with_admission admission ~tier_id
-      ~admission_policy f
-  else
-    Ok (f ())
+let with_keeper_cascade_tier_admission =
+  Keeper_turn_driver_admission.with_keeper_cascade_tier_admission
 
-let cascade_tier_admission_blocked_decision signal =
-  `Assoc
-    [
-      ("blocker", `String "cascade_tier_admission_full");
-      ("signal", Cascade_saturation_signal.to_yojson signal);
-    ]
+let cascade_tier_admission_blocked_decision =
+  Keeper_turn_driver_admission.cascade_tier_admission_blocked_decision
 
-let emit_cascade_tier_admission_signal_metric ~cascade_name signal =
-  Prometheus.inc_counter
-    Keeper_metrics.metric_keeper_cascade_saturation_signal
-    ~labels:
-      [
-        ( Cascade_attempt_fsm.label_kind,
-          Cascade_saturation_signal.(kind signal |> kind_to_string) );
-        ( Cascade_attempt_fsm.label_cascade,
-          Cascade_attempt_fsm.provider_label cascade_name );
-      ]
-    ()
+let emit_cascade_tier_admission_signal_metric =
+  Keeper_turn_driver_admission.emit_cascade_tier_admission_signal_metric
 
-let release_client_capacity_quietly = function
-  | None -> ()
-  | Some release ->
-      (match release () with
-       | () -> ()
-       | exception _ -> ())
+let release_client_capacity_quietly =
+  Keeper_turn_driver_admission.release_client_capacity_quietly
 
-let provider_config_identity_key (cfg : Llm_provider.Provider_config.t) =
-  Hashtbl.hash
-    ( Llm_provider.Provider_config.string_of_provider_kind cfg.kind,
-      cfg.model_id,
-      cfg.base_url,
-      cfg.request_path,
-      cfg.api_key,
-      cfg.headers,
-      cfg.supports_tool_choice_override )
+let provider_config_identity_key =
+  Keeper_turn_driver_admission.provider_config_identity_key
 
-let runtime_candidates_of_tiered_providers tiered_providers provider_cfgs =
-  let tier_index = Hashtbl.create (List.length tiered_providers) in
-  List.iter
-    (fun (tiered : Cascade_catalog_runtime_named_providers.tiered_provider) ->
-       let key = provider_config_identity_key tiered.provider_cfg in
-       let queue =
-         match Hashtbl.find_opt tier_index key with
-         | Some queue -> queue
-         | None ->
-           let queue = Queue.create () in
-           Hashtbl.add tier_index key queue;
-           queue
-       in
-       Queue.add tiered.tier_id queue)
-    tiered_providers;
-  List.map
-    (fun provider_cfg ->
-       let tier_id =
-         match Hashtbl.find_opt tier_index (provider_config_identity_key provider_cfg) with
-         | Some queue when not (Queue.is_empty queue) -> Some (Queue.pop queue)
-         | _ -> None
-       in
-        Cascade_runtime_candidate.of_provider_config ?tier_id provider_cfg)
-    provider_cfgs
-
-(* ================================================================ *)
-(* Facade-only: run_named, run_model_by_label, and MASC tool bridges  *)
-(* ================================================================ *)
-
-(** Run a single Agent.run() call with MASC-driven cascade model fallback.
-
-    MASC drives the cascade FSM directly:
-    - Resolves cascade providers from cascade.toml
-    - For each provider, runs OAS with a single provider
-    - Uses Cascade_fsm.decide to determine next action on failure
-    - Cascade loop runs inside Admission_queue permit
-
-    @param accept Optional response validator. Default accepts all.
-    @since Phase 2 — MASC-driven cascade FSM *)
+let runtime_candidates_of_tiered_providers =
+  Keeper_turn_driver_admission.runtime_candidates_of_tiered_providers
 let run_named
     ~cascade_name
     ?base_path

--- a/lib/keeper/keeper_turn_driver_admission.ml
+++ b/lib/keeper/keeper_turn_driver_admission.ml
@@ -1,0 +1,115 @@
+(** Keeper cascade tier admission helpers + provider candidate identity,
+    extracted from keeper_turn_driver.ml — sibling pattern (same flat
+    masc_mcp library, no sub-library).
+
+    Used by the keeper turn driver's [run_named] entry to gate cascade
+    attempts via [Cascade_tier_admission] and to map tiered providers
+    to runtime candidates with deterministic tier ids. *)
+
+open Result.Syntax
+
+let keeper_cascade_tier_admission = Cascade_tier_admission.create ()
+
+let cascade_tier_admission_policy_of_priority priority =
+  (* RFC-0126: exhaustive typed match over Llm_provider.Request_priority.t
+     instead of the previous string-classifier (`to_string |> match`) so that
+     future variants in the upstream agent_sdk surface as a compile error
+     here rather than silently routing through a permissive default.
+     Semantics: only [Background] (P2 heartbeat / status ticks) bypasses
+     tier admission per Cascade_tier_admission.mli side-task starvation
+     defence; main-path priorities all require admission.  [Unspecified]
+     is unreachable after [resolve] (it maps to [Proactive]) but the arm
+     keeps the match exhaustive without a catch-all. *)
+  match Llm_provider.Request_priority.resolve priority with
+  | Background -> Cascade_tier_admission.Bypass
+  | Resume | Interactive | Proactive | Unspecified ->
+      Cascade_tier_admission.Required
+
+let with_keeper_cascade_tier_admission
+    ?(admission = keeper_cascade_tier_admission)
+    ?(enabled = Env_config_keeper.CascadeTierAdmission.enabled ())
+    ~tier_id
+    ~admission_policy
+    f =
+  if enabled
+  then
+    Cascade_tier_admission.with_admission admission ~tier_id
+      ~admission_policy f
+  else
+    Ok (f ())
+
+let cascade_tier_admission_blocked_decision signal =
+  `Assoc
+    [
+      ("blocker", `String "cascade_tier_admission_full");
+      ("signal", Cascade_saturation_signal.to_yojson signal);
+    ]
+
+let emit_cascade_tier_admission_signal_metric ~cascade_name signal =
+  Prometheus.inc_counter
+    Keeper_metrics.metric_keeper_cascade_saturation_signal
+    ~labels:
+      [
+        ( Cascade_attempt_fsm.label_kind,
+          Cascade_saturation_signal.(kind signal |> kind_to_string) );
+        ( Cascade_attempt_fsm.label_cascade,
+          Cascade_attempt_fsm.provider_label cascade_name );
+      ]
+    ()
+
+let release_client_capacity_quietly = function
+  | None -> ()
+  | Some release ->
+      (match release () with
+       | () -> ()
+       | exception _ -> ())
+
+let provider_config_identity_key (cfg : Llm_provider.Provider_config.t) =
+  Hashtbl.hash
+    ( Llm_provider.Provider_config.string_of_provider_kind cfg.kind,
+      cfg.model_id,
+      cfg.base_url,
+      cfg.request_path,
+      cfg.api_key,
+      cfg.headers,
+      cfg.supports_tool_choice_override )
+
+let runtime_candidates_of_tiered_providers tiered_providers provider_cfgs =
+  let tier_index = Hashtbl.create (List.length tiered_providers) in
+  List.iter
+    (fun (tiered : Cascade_catalog_runtime_named_providers.tiered_provider) ->
+       let key = provider_config_identity_key tiered.provider_cfg in
+       let queue =
+         match Hashtbl.find_opt tier_index key with
+         | Some queue -> queue
+         | None ->
+           let queue = Queue.create () in
+           Hashtbl.add tier_index key queue;
+           queue
+       in
+       Queue.add tiered.tier_id queue)
+    tiered_providers;
+  List.map
+    (fun provider_cfg ->
+       let tier_id =
+         match Hashtbl.find_opt tier_index (provider_config_identity_key provider_cfg) with
+         | Some queue when not (Queue.is_empty queue) -> Some (Queue.pop queue)
+         | _ -> None
+       in
+        Cascade_runtime_candidate.of_provider_config ?tier_id provider_cfg)
+    provider_cfgs
+
+(* ================================================================ *)
+(* Facade-only: run_named, run_model_by_label, and MASC tool bridges  *)
+(* ================================================================ *)
+
+(** Run a single Agent.run() call with MASC-driven cascade model fallback.
+
+    MASC drives the cascade FSM directly:
+    - Resolves cascade providers from cascade.toml
+    - For each provider, runs OAS with a single provider
+    - Uses Cascade_fsm.decide to determine next action on failure
+    - Cascade loop runs inside Admission_queue permit
+
+    @param accept Optional response validator. Default accepts all.
+    @since Phase 2 — MASC-driven cascade FSM *)


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane B (Keeper Runtime)
- `keeper_turn_driver.ml` is 1733 LOC, with `run_named` taking ~1595 LOC. This PR carves out the top-of-file admission + provider-candidate helpers (105 LOC, 8 bindings) so `run_named` is the next clean target.
- Sibling pattern (flat `masc_mcp`, no sub-library)

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/keeper/keeper_turn_driver.ml` | 1733 | 1651 | **-82** (net) |
| `lib/keeper/keeper_turn_driver_admission.ml` | — | 115 | +115 |

(105 LOC moved + 23 aliases written back; sibling has 10 lines of module header on top of 105 moved.)

## Moved bindings (verbatim, no behavior change)
1. `keeper_cascade_tier_admission` (module-init side effect — single admission instance)
2. `cascade_tier_admission_policy_of_priority` (RFC-0126 exhaustive variant match)
3. `with_keeper_cascade_tier_admission`
4. `cascade_tier_admission_blocked_decision`
5. `emit_cascade_tier_admission_signal_metric`
6. `release_client_capacity_quietly`
7. `provider_config_identity_key`
8. `runtime_candidates_of_tiered_providers`

## Module-init discipline
`Cascade_tier_admission.create ()` runs once when the sibling loads. The alias `let keeper_cascade_tier_admission = Keeper_turn_driver_admission.keeper_cascade_tier_admission` points to the same instance — observable behaviour identical to the original top-level `let`.

## Verification
```
$ bash scripts/lint/godfile-size-regression.sh
godfile-size-regression: clean

$ dune build --root . lib/masc_mcp.cmxa
(exit 0)
```

## .mli policy for this PR
No explicit `.mli` for the sibling — OCaml infers signatures from the `.ml`. Reason: `Cascade_tier_admission.admission_policy` type name was non-obvious and avoiding a wrong contract is safer than a guess. Follow-up PR can lock the contract explicitly.

## Constraints honored
- No new string match arms (anti-pattern §2)
- No silent default added
- No magic-number extraction
- Flat `masc_mcp` namespace, no sub-library (plan §Do Not)
- Caller compatibility: parent `.mli` (line 274, 278) still exposes the same surface via the aliases

## RFC-WAIVED
Extract-only sibling refactor, no behavior change, governed by `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane B (Keeper Runtime).

## Follow-up sub-PR candidates
- `run_named` itself (~1595 LOC) needs internal refactor before further extraction — schedule under RFC.
- Add explicit `.mli` to `keeper_turn_driver_admission.mli` once contract is reviewed.

Co-Authored-By: codex <noreply@anthropic.com>