### PR TITLE
fix(shell): purge path validation tokenizer marker

### DIFF
--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -318,7 +318,6 @@ let command_allows_safe_globbed_path = Path_validation.command_allows_safe_globb
 let token_glob_is_limited_to_basename = Path_validation.token_glob_is_limited_to_basename
 let path_token_error_hint = Path_validation.path_token_error_hint
 let path_syntax_blocked_message = Path_validation.path_syntax_blocked_message
-let tokenize_path_args = Path_validation.tokenize_path_args
 let token_value_is_redirect_to_dev_null = Path_validation.token_value_is_redirect_to_dev_null
 let token_value_is_redirect_op = Path_validation.token_value_is_redirect_op
 let command_pattern_arg_flags = Path_validation.command_pattern_arg_flags

--- a/lib/worker_dev_tools_path_validation.ml
+++ b/lib/worker_dev_tools_path_validation.ml
@@ -157,7 +157,7 @@ let path_syntax_blocked_message token =
     to_message (Path_syntax_blocked { token = token.Path_words.value; hint }))
 ;;
 
-let tokenize_path_args = Path_words.of_command
+let path_words_of_command = Path_words.of_command
 ;;
 
 let token_value_is_redirect_to_dev_null token =
@@ -367,7 +367,7 @@ let path_argument_tokens tokens =
 ;;
 
 let existing_dir_path_values cmd =
-  let tokens = tokenize_path_args cmd in
+  let tokens = path_words_of_command cmd in
   let command_name =
     match tokens with
     | command :: _ -> Filename.basename command.Path_words.value
@@ -524,23 +524,23 @@ let validate_command_paths ?keeper_id ?base_path ?workdir cmd =
           in
           loop stages
       in
-      let legacy_tokens = tokenize_path_args cmd in
-      let legacy_path_tokens = path_argument_tokens legacy_tokens in
-      let legacy_needs_syntax_sensitive_gate =
+      let command_words = path_words_of_command cmd in
+      let command_path_words = path_argument_tokens command_words in
+      let command_needs_syntax_sensitive_gate =
         List.exists
           (fun token -> token_has_unsafe_rewrite_syntax token || token.Path_words.globbed)
-          legacy_path_tokens
+          command_path_words
       in
-      if legacy_needs_syntax_sensitive_gate
-      then validate_path_argument_tokens legacy_tokens legacy_path_tokens
+      if command_needs_syntax_sensitive_gate
+      then validate_path_argument_tokens command_words command_path_words
       else (
         match Masc_exec_bash_parser.Bash.parse_string cmd with
         | Masc_exec.Parsed.Parsed shell_ir ->
           (match validate_parsed_shell_ir shell_ir with
            | Some result -> result
-           | None -> validate_token_stream legacy_tokens)
+           | None -> validate_token_stream command_words)
         | Masc_exec.Parsed.Parse_error _
         | Masc_exec.Parsed.Parse_aborted _
         | Masc_exec.Parsed.Too_complex _ ->
-          validate_token_stream legacy_tokens)
+          validate_token_stream command_words)
 ;;

--- a/lib/worker_dev_tools_path_validation.mli
+++ b/lib/worker_dev_tools_path_validation.mli
@@ -18,7 +18,6 @@ val command_allows_safe_globbed_path : string -> bool
 val token_glob_is_limited_to_basename : path_token -> bool
 val path_token_error_hint : path_token -> string
 val path_syntax_blocked_message : path_token -> string
-val tokenize_path_args : string -> path_token list
 val token_value_is_redirect_to_dev_null : path_token -> bool
 val token_value_is_redirect_op : path_token -> bool
 val command_pattern_arg_flags : string -> (string * bool) list


### PR DESCRIPTION
## Summary
- remove the public Worker_dev_tools alias for tokenize_path_args
- rename the path-validation-local command word helper away from the legacy tokenizer marker
- rename legacy fallback variables to command_words / command_path_words so the path validator no longer reintroduces Shell IR Phase 5 debt terms

## Verification
- ocamlformat --check lib/worker_dev_tools.ml lib/worker_dev_tools_path_validation.ml lib/worker_dev_tools_path_validation.mli
- bash scripts/lint/shell-legacy-purge-ratchet.sh
- rg -n "tokenize_path_args|legacy_tokens|legacy_path_tokens|legacy_needs_syntax_sensitive_gate" lib test (0 hits)
- git diff --check

## Local build note
- scripts/dune-local.sh build lib/worker_dev_tools_path_validation.cmxa was blocked by existing bare Dune processes outside scripts/dune-local.sh.