### PR TITLE
fix(telemetry): bound date-split store retention

### DIFF
--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -95,6 +95,8 @@ resolved config root는 별도 탐색 규칙을 가진다: `MASC_CONFIG_DIR` -> 
 | `LLAMA_DEFAULT_MODEL` | string | `explicit-model-required` | 로컬 기본 모델 |
 | `MASC_LOCAL_MAX_TOKENS` | int | 32768 | 로컬 LLM max_tokens 상한 (fallback: `MASC_LLAMA_MAX_TOKENS`) |
 | `MASC_CANCELLATION_TOKEN_MAX_AGE_SEC` | float | 3600.0 | 취소 토큰 최대 수명 |
+| `MASC_TELEMETRY_RETENTION_DAYS` | int | 30 | `.masc/telemetry/YYYY-MM/DD.jsonl` day-file retention. 양수는 override, 0 이하는 retention 비활성화 |
+| `MASC_TELEMETRY_MAX_BYTES` | int | 52428800 | `.masc/telemetry` byte cap. 오래된 완료 day-file부터 삭제하며 현재 day-file은 보존. 양수는 override, 0 이하는 cap 비활성화 |
 | `NEO4J_URI` | string | `bolt://turntable.proxy.rlwy.net:11490` | Neo4j 접속 URI |
 | `NEO4J_HTTP_URI` | string | `""` | Neo4j HTTP API URI |
 | `NEO4J_USER` | string | `"neo4j"` | Neo4j 사용자 |

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -52,6 +52,12 @@ let runtime_entries =
       "Release LLM slot during tool execution (feature flag)";
     entry ~default:"true" Env_config_core.telemetry_enabled_env_key
       "Enable telemetry collection";
+    entry ~default:"30" "MASC_TELEMETRY_RETENTION_DAYS"
+      "Telemetry JSONL day-file retention days. Positive values override; \
+       non-positive disables retention.";
+    entry ~default:"52428800" "MASC_TELEMETRY_MAX_BYTES"
+      "Telemetry JSONL byte cap. Positive values override; non-positive \
+       disables byte-cap pruning.";
   ]
 
 let rate_limiting_entries =

--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -18,6 +18,7 @@ type t = {
   base_dir : string;
   mutex : Eio.Mutex.t Atomic.t;
   retention_days : int option;
+  max_bytes : int option;
   last_prune_day : string option Atomic.t;
 }
 
@@ -54,7 +55,7 @@ let mutex_for_base_dir ~base_dir =
         Hashtbl.add mutex_registry key cell;
         cell)
 
-let create ~base_dir ?mutex ?retention_days () =
+let create ~base_dir ?mutex ?retention_days ?max_bytes () =
   let mutex =
     match mutex with
     | Some mutex -> Atomic.make mutex
@@ -65,7 +66,18 @@ let create ~base_dir ?mutex ?retention_days () =
     | Some days when days > 0 -> Some days
     | _ -> None
   in
-  { base_dir; mutex; retention_days; last_prune_day = Atomic.make None }
+  let max_bytes =
+    match max_bytes with
+    | Some bytes when bytes > 0 -> Some bytes
+    | _ -> None
+  in
+  {
+    base_dir;
+    mutex;
+    retention_days;
+    max_bytes;
+    last_prune_day = Atomic.make None;
+  }
 
 let base_dir t = t.base_dir
 
@@ -132,6 +144,26 @@ let count_non_empty_lines path =
          with End_of_file -> ());
         !count)
     with Sys_error _ -> 0
+
+let file_size path =
+  try (Unix.stat path).Unix.st_size with
+  | Unix.Unix_error _ | Sys_error _ -> 0
+
+let day_file_paths_oldest_first base_dir =
+  list_month_dirs base_dir
+  |> List.rev
+  |> List.concat_map (fun month ->
+       let month_path = Filename.concat base_dir month in
+       list_day_files month_path
+       |> List.rev
+       |> List.map (fun day -> (month_path, Filename.concat month_path day)))
+
+let remove_file_and_empty_month ~month_path path =
+  try
+    Sys.remove path;
+    (try Unix.rmdir month_path with Unix.Unix_error _ -> ());
+    true
+  with Sys_error _ -> false
 
 (** Read the last [n] non-empty lines from a file without loading the entire
     file into memory.  Reads backwards in 8 KB chunks from the end.
@@ -233,6 +265,27 @@ let prune_unlocked t ~days =
     !deleted
   end
 
+let prune_to_max_bytes_unlocked t ~max_bytes ~keep_path =
+  if max_bytes <= 0 then 0
+  else begin
+    let files = day_file_paths_oldest_first t.base_dir in
+    let total =
+      List.fold_left (fun acc (_, path) -> acc + file_size path) 0 files
+    in
+    let remaining = ref total in
+    let deleted = ref 0 in
+    List.iter
+      (fun (month_path, path) ->
+         if !remaining > max_bytes && not (String.equal path keep_path) then
+           let bytes = file_size path in
+           if remove_file_and_empty_month ~month_path path then begin
+             remaining := max 0 (!remaining - bytes);
+             incr deleted
+           end)
+      files;
+    !deleted
+  end
+
 (* ── Public API ───────────────────────────────────────── *)
 
 let append_inner t json =
@@ -248,15 +301,24 @@ let append_inner t json =
   Eio.Mutex.use_ro mutex (fun () ->
     let dated = Jsonl_writer.dated_path_now ~base_dir:t.base_dir in
     Jsonl_writer.append_jsonl ~path:dated.path json;
-    match t.retention_days with
+    (match t.retention_days with
+     | None -> ()
+     | Some days ->
+       let today = dated.month_dir ^ "/" ^ dated.day_file in
+       if
+         not
+           (Option.equal String.equal
+              (Atomic.get t.last_prune_day)
+              (Some today))
+       then begin
+         ignore (prune_unlocked t ~days : int);
+         Atomic.set t.last_prune_day (Some today)
+       end);
+    match t.max_bytes with
     | None -> ()
-    | Some days ->
-      let today = dated.month_dir ^ "/" ^ dated.day_file in
-      if not (Option.equal String.equal (Atomic.get t.last_prune_day) (Some today))
-      then begin
-        ignore (prune_unlocked t ~days : int);
-        Atomic.set t.last_prune_day (Some today)
-      end)
+    | Some max_bytes ->
+      ignore
+        (prune_to_max_bytes_unlocked t ~max_bytes ~keep_path:dated.path : int))
 
 let append t json =
   (Atomic.get append_guard) (fun () -> append_inner t json)

--- a/lib/dated_jsonl/dated_jsonl.mli
+++ b/lib/dated_jsonl/dated_jsonl.mli
@@ -8,11 +8,19 @@ type t
 (** Opaque handle.  Holds [base_dir] and the append mutex. *)
 
 val create :
-  base_dir:string -> ?mutex:Eio.Mutex.t -> ?retention_days:int -> unit -> t
+  base_dir:string ->
+  ?mutex:Eio.Mutex.t ->
+  ?retention_days:int ->
+  ?max_bytes:int ->
+  unit ->
+  t
 (** [create ~base_dir ()] builds a store rooted at [base_dir].
     An optional [mutex] can be injected to bypass the shared registry
     (useful for testing).  When [?retention_days] is positive, [append]
-    performs an opportunistic once-per-process-day prune of older day-files. *)
+    performs an opportunistic once-per-process-day prune of older day-files.
+    When [?max_bytes] is positive, [append] prunes oldest completed day-files
+    until the store is at or below the cap, while preserving the current
+    day-file. *)
 
 val base_dir : t -> string
 (** Return the base directory of this store. *)

--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -129,13 +129,39 @@ let telemetry_file config =
 let telemetry_store_cache : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 4
 let telemetry_store_cache_mu = Eio.Mutex.create ()
 
+let telemetry_retention_days_env = "MASC_TELEMETRY_RETENTION_DAYS"
+let telemetry_max_bytes_env = "MASC_TELEMETRY_MAX_BYTES"
+let default_telemetry_retention_days = 30
+let default_telemetry_max_bytes = 52_428_800
+
+let positive_int_env_with_default key ~default =
+  match Sys.getenv_opt key with
+  | None -> Some default
+  | Some raw ->
+    (match int_of_string_opt (String.trim raw) with
+     | Some value when value > 0 -> Some value
+     | Some _ -> None
+     | None -> Some default)
+
+let telemetry_retention_days () =
+  positive_int_env_with_default telemetry_retention_days_env
+    ~default:default_telemetry_retention_days
+
+let telemetry_max_bytes () =
+  positive_int_env_with_default telemetry_max_bytes_env
+    ~default:default_telemetry_max_bytes
+
 let get_telemetry_store config : Dated_jsonl.t =
   let base = Filename.concat (Coord_utils.masc_dir config) "telemetry" in
   Eio_guard.with_mutex telemetry_store_cache_mu (fun () ->
     match Hashtbl.find_opt telemetry_store_cache base with
     | Some store -> store
     | None ->
-      let store = Dated_jsonl.create ~base_dir:base () in
+      let retention_days = telemetry_retention_days () in
+      let max_bytes = telemetry_max_bytes () in
+      let store =
+        Dated_jsonl.create ~base_dir:base ?retention_days ?max_bytes ()
+      in
       Hashtbl.replace telemetry_store_cache base store;
       store)
 

--- a/lib/telemetry_eio.mli
+++ b/lib/telemetry_eio.mli
@@ -14,7 +14,13 @@
     [observe_telemetry_drop] / [report_telemetry_drop],
     [read_all_events_from_path], [event_to_json], [track], and the
     [nonempty_opt] string utility) are hidden — callers consume the
-    typed event ADT and the convenience emitters / readers only. *)
+    typed event ADT and the convenience emitters / readers only.
+
+    The date-split telemetry store applies bounded retention by default:
+    [MASC_TELEMETRY_RETENTION_DAYS] defaults to 30 and
+    [MASC_TELEMETRY_MAX_BYTES] defaults to 52428800. Positive values override;
+    non-positive values disable the matching bound. The byte cap prunes oldest
+    completed day-files while preserving the current day-file. *)
 
 type config = Coord_utils.config
 

--- a/test/test_dated_jsonl.ml
+++ b/test/test_dated_jsonl.ml
@@ -247,6 +247,33 @@ let test_prune_zero_days () =
   let deleted = Dated_jsonl.prune store ~days:0 in
   check int "zero days prunes nothing" 0 deleted
 
+let test_max_bytes_prunes_oldest_completed_day_files () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "dated_jsonl_max_bytes" in
+  let old_file_1 = Filename.concat (Filename.concat dir "2020-01") "01.jsonl" in
+  let old_file_2 = Filename.concat (Filename.concat dir "2020-01") "02.jsonl" in
+  write_dated_file dir "2020-01" "01"
+    [ Printf.sprintf {|{"payload":"%s"}|} (String.make 80 'a') ];
+  write_dated_file dir "2020-01" "02"
+    [ Printf.sprintf {|{"payload":"%s"}|} (String.make 80 'b') ];
+  let store = Dated_jsonl.create ~base_dir:dir ~max_bytes:120 () in
+  Dated_jsonl.append store (make_json 1);
+  check bool "oldest file removed" false (Sys.file_exists old_file_1);
+  check bool "second old file removed" false (Sys.file_exists old_file_2);
+  check (list int) "current day survives" [ 1 ]
+    (Dated_jsonl.read_recent store 10 |> List.map json_i)
+
+let test_max_bytes_preserves_current_day_file () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "dated_jsonl_max_bytes_current" in
+  let store = Dated_jsonl.create ~base_dir:dir ~max_bytes:1 () in
+  Dated_jsonl.append store
+    (`Assoc [ ("payload", `String (String.make 128 'x')) ]);
+  check int "current file row survives tiny cap" 1
+    (List.length (Dated_jsonl.read_recent store 10))
+
 (* ── concurrent append safety ──────────────────────────── *)
 
 let test_concurrent_append () =
@@ -315,6 +342,10 @@ let () =
         [
           test_case "removes old files" `Quick test_prune;
           test_case "zero days safe" `Quick test_prune_zero_days;
+          test_case "max bytes prunes oldest completed day-files" `Quick
+            test_max_bytes_prunes_oldest_completed_day_files;
+          test_case "max bytes preserves current day-file" `Quick
+            test_max_bytes_preserves_current_day_file;
         ] );
       ( "concurrent",
         [

--- a/test/test_telemetry_eio_coverage.ml
+++ b/test/test_telemetry_eio_coverage.ml
@@ -33,6 +33,42 @@ let cleanup_dir dir =
   in
   try rm dir with _ -> ()
 
+let with_env key value f =
+  let prior = Sys.getenv_opt key in
+  Unix.putenv key value;
+  let restore () =
+    match prior with
+    | Some old -> Unix.putenv key old
+    | None -> Unix.putenv key ""
+  in
+  match f () with
+  | result ->
+      restore ();
+      result
+  | exception exn ->
+      restore ();
+      raise exn
+
+let with_temp_dir f =
+  let dir = temp_dir () in
+  match f dir with
+  | result ->
+      cleanup_dir dir;
+      result
+  | exception exn ->
+      cleanup_dir dir;
+      raise exn
+
+let telemetry_dir base_dir =
+  Filename.concat (Filename.concat base_dir ".masc") "telemetry"
+
+let write_dated_file dir month day lines =
+  let month_dir = Filename.concat dir month in
+  Fs_compat.mkdir_p month_dir;
+  Fs_compat.append_file
+    (Filename.concat month_dir (day ^ ".jsonl"))
+    (String.concat "\n" lines ^ "\n")
+
 (* ============================================================
    event Type Tests
    ============================================================ *)
@@ -547,6 +583,48 @@ let test_summarize_tool_usage_reads_date_split_store_without_fs () =
       check int "usage count" 1 stats.count;
       check bool "telemetry available" true summary.telemetry_available)
 
+let test_track_applies_default_retention_days () =
+  with_env "MASC_TELEMETRY_RETENTION_DAYS" "" (fun () ->
+    with_env "MASC_TELEMETRY_MAX_BYTES" "0" (fun () ->
+      with_temp_dir (fun base_dir ->
+        Eio_main.run @@ fun env ->
+        Fs_compat.set_fs (Eio.Stdenv.fs env);
+        let config = Coord.default_config base_dir in
+        let telemetry_dir = telemetry_dir base_dir in
+        let old_file =
+          Filename.concat (Filename.concat telemetry_dir "2020-01") "01.jsonl"
+        in
+        write_dated_file telemetry_dir "2020-01" "01" [ {|{"old":true}|} ];
+        Telemetry_eio.track_agent_joined config ~agent_id:"retention-test" ();
+        check bool "old telemetry file pruned by default retention" false
+          (Sys.file_exists old_file))))
+
+let test_track_applies_telemetry_max_bytes () =
+  with_env "MASC_TELEMETRY_RETENTION_DAYS" "0" (fun () ->
+    with_env "MASC_TELEMETRY_MAX_BYTES" "120" (fun () ->
+      with_temp_dir (fun base_dir ->
+        Eio_main.run @@ fun env ->
+        Fs_compat.set_fs (Eio.Stdenv.fs env);
+        let config = Coord.default_config base_dir in
+        let telemetry_dir = telemetry_dir base_dir in
+        let old_file_1 =
+          Filename.concat (Filename.concat telemetry_dir "2020-01") "01.jsonl"
+        in
+        let old_file_2 =
+          Filename.concat (Filename.concat telemetry_dir "2020-01") "02.jsonl"
+        in
+        write_dated_file telemetry_dir "2020-01" "01"
+          [ Printf.sprintf {|{"payload":"%s"}|} (String.make 80 'a') ];
+        write_dated_file telemetry_dir "2020-01" "02"
+          [ Printf.sprintf {|{"payload":"%s"}|} (String.make 80 'b') ];
+        Telemetry_eio.track_agent_joined config ~agent_id:"max-bytes-test" ();
+        check bool "old telemetry file 1 pruned by max bytes" false
+          (Sys.file_exists old_file_1);
+        check bool "old telemetry file 2 pruned by max bytes" false
+          (Sys.file_exists old_file_2);
+        check int "current row remains readable" 1
+          (List.length (Telemetry_eio.read_all_events config)))))
+
 (* ============================================================
    Test Runners
    ============================================================ *)
@@ -620,5 +698,9 @@ let () =
     "store_reads", [
       test_case "summarize_tool_usage reads date-split store" `Quick
         test_summarize_tool_usage_reads_date_split_store_without_fs;
+      test_case "track applies default retention days" `Quick
+        test_track_applies_default_retention_days;
+      test_case "track applies telemetry max bytes" `Quick
+        test_track_applies_telemetry_max_bytes;
     ];
   ]


### PR DESCRIPTION
## Summary
- Add optional max_bytes support to Dated_jsonl and prune oldest completed day-files while preserving the active day-file.
- Configure Telemetry_eio with bounded defaults: MASC_TELEMETRY_RETENTION_DAYS=30 and MASC_TELEMETRY_MAX_BYTES=52428800, with non-positive values disabling each bound.
- Add regression coverage for Dated_jsonl max-byte pruning and Telemetry_eio retention/byte-cap env wiring, plus config docs/snapshot entries.

## Verification
- ocamlformat --check lib/dated_jsonl/dated_jsonl.ml lib/dated_jsonl/dated_jsonl.mli lib/telemetry_eio.ml lib/telemetry_eio.mli test/test_dated_jsonl.ml test/test_telemetry_eio_coverage.ml lib/config/env_config_snapshot.ml
- ocamlc -stop-after parsing -impl lib/dated_jsonl/dated_jsonl.ml
- ocamlc -stop-after parsing -intf lib/dated_jsonl/dated_jsonl.mli
- ocamlc -stop-after parsing -impl lib/telemetry_eio.ml
- ocamlc -stop-after parsing -intf lib/telemetry_eio.mli
- ocamlc -stop-after parsing -impl test/test_dated_jsonl.ml
- ocamlc -stop-after parsing -impl test/test_telemetry_eio_coverage.ml
- ocamlc -stop-after parsing -impl lib/config/env_config_snapshot.ml
- git diff --check origin/main...HEAD

## Local Dune caveat
- scripts/dune-local.sh build test/test_dated_jsonl.exe test/test_telemetry_eio_coverage.exe was attempted, but the wrapper refused to start because other sessions had live bare Dune processes bypassing the machine-wide lock. The refusal was from scripts/dune-local.sh, not a compile failure in this branch.
