### PR TITLE
refactor(keeper_run_tools): extract hook accumulator + freeze into sibling (Lane B carve-out)

### DIFF
--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -16,7 +16,7 @@ module Tool_search = Keeper_run_tools_search
     OAS hooks (before_turn, on_tool_executed) cannot return values, so
     they write into this single mutable record during Agent.run execution.
     After execution completes, {!freeze} produces an immutable snapshot. *)
-type hook_accumulator =
+type hook_accumulator = Keeper_run_tools_hook_accumulator.hook_accumulator =
   { mutable meta : Keeper_types.keeper_meta
   ; mutable tool_calls : tool_call_detail list
   ; mutable current_turn : int
@@ -33,8 +33,7 @@ type hook_accumulator =
   ; mutable contract_violation_retries : int
   }
 
-(** Immutable snapshot of hook outputs after OAS execution completes. *)
-type hook_outputs =
+type hook_outputs = Keeper_run_tools_hook_accumulator.hook_outputs =
   { out_meta : Keeper_types.keeper_meta
   ; out_tool_calls : tool_call_detail list
   ; out_completion_contract : Keeper_tool_disclosure.completion_contract
@@ -50,31 +49,9 @@ type hook_outputs =
   ; out_contract_violation_retries : int
   }
 
-let freeze (acc : hook_accumulator) : hook_outputs =
-  { out_meta = acc.meta
-  ; out_tool_calls = acc.tool_calls
-  ; out_completion_contract = acc.completion_contract
-  ; out_required_tool_use_seen = acc.required_tool_use_seen
-  ; out_keeper_surface_tool_used = acc.keeper_surface_tool_used
-  ; out_discovered = acc.discovered
-  ; out_tool_overlay = acc.tool_overlay
-  ; out_tool_surface = acc.tool_surface
-  ; out_requested_tool_names = acc.requested_tool_names
-  ; out_requested_tool_names_seen = acc.requested_tool_names_seen
-  ; out_receipt_tool_contract_result = acc.receipt_tool_contract_result
-  ; out_contract_violation_retries = acc.contract_violation_retries
-  }
-;;
-
-let merge_requested_tool_names_seen ~seen requested =
-  Keeper_types.dedupe_keep_order (seen @ requested)
-;;
-
-let record_requested_tool_names (acc : hook_accumulator) requested =
-  acc.requested_tool_names <- requested;
-  acc.requested_tool_names_seen <-
-    merge_requested_tool_names_seen ~seen:acc.requested_tool_names_seen requested
-;;
+let freeze = Keeper_run_tools_hook_accumulator.freeze
+let merge_requested_tool_names_seen = Keeper_run_tools_hook_accumulator.merge_requested_tool_names_seen
+let record_requested_tool_names = Keeper_run_tools_hook_accumulator.record_requested_tool_names
 
 let task_scope_tool_names =
   [ "masc_transition"

--- a/lib/keeper/keeper_run_tools_hook_accumulator.ml
+++ b/lib/keeper/keeper_run_tools_hook_accumulator.ml
@@ -1,0 +1,70 @@
+(** Hook accumulator + outputs for OAS Agent.run hook callbacks,
+    extracted from keeper_run_tools.ml.
+
+    OAS hooks (before_turn, on_tool_executed) cannot return values, so
+    they write into a single mutable {!hook_accumulator} during
+    Agent.run execution.  After execution completes, {!freeze} produces
+    an immutable {!hook_outputs} snapshot. *)
+
+open Keeper_types
+open Keeper_agent_tool_surface
+open Keeper_agent_result
+
+type hook_accumulator =
+  { mutable meta : Keeper_types.keeper_meta
+  ; mutable tool_calls : tool_call_detail list
+  ; mutable current_turn : int
+  ; mutable completion_contract : Keeper_tool_disclosure.completion_contract
+  ; mutable required_tool_use_seen : bool
+  ; mutable keeper_surface_tool_used : bool
+  ; mutable discovered : Keeper_discovered_tools.t
+  ; mutable tool_overlay : Agent_sdk.Tool_op.t
+  ; mutable tool_surface : tool_surface_metrics
+  ; mutable requested_tool_names : string list
+  ; mutable requested_tool_names_seen : string list
+  ; mutable receipt_tool_contract_result :
+      Keeper_execution_receipt.tool_contract_result
+  ; mutable contract_violation_retries : int
+  }
+
+type hook_outputs =
+  { out_meta : Keeper_types.keeper_meta
+  ; out_tool_calls : tool_call_detail list
+  ; out_completion_contract : Keeper_tool_disclosure.completion_contract
+  ; out_required_tool_use_seen : bool
+  ; out_keeper_surface_tool_used : bool
+  ; out_discovered : Keeper_discovered_tools.t
+  ; out_tool_overlay : Agent_sdk.Tool_op.t
+  ; out_tool_surface : tool_surface_metrics
+  ; out_requested_tool_names : string list
+  ; out_requested_tool_names_seen : string list
+  ; out_receipt_tool_contract_result :
+      Keeper_execution_receipt.tool_contract_result
+  ; out_contract_violation_retries : int
+  }
+
+let freeze (acc : hook_accumulator) : hook_outputs =
+  { out_meta = acc.meta
+  ; out_tool_calls = acc.tool_calls
+  ; out_completion_contract = acc.completion_contract
+  ; out_required_tool_use_seen = acc.required_tool_use_seen
+  ; out_keeper_surface_tool_used = acc.keeper_surface_tool_used
+  ; out_discovered = acc.discovered
+  ; out_tool_overlay = acc.tool_overlay
+  ; out_tool_surface = acc.tool_surface
+  ; out_requested_tool_names = acc.requested_tool_names
+  ; out_requested_tool_names_seen = acc.requested_tool_names_seen
+  ; out_receipt_tool_contract_result = acc.receipt_tool_contract_result
+  ; out_contract_violation_retries = acc.contract_violation_retries
+  }
+;;
+
+let merge_requested_tool_names_seen ~seen requested =
+  Keeper_types.dedupe_keep_order (seen @ requested)
+;;
+
+let record_requested_tool_names (acc : hook_accumulator) requested =
+  acc.requested_tool_names <- requested;
+  acc.requested_tool_names_seen <-
+    merge_requested_tool_names_seen ~seen:acc.requested_tool_names_seen requested
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane B (Keeper Runtime)
- `keeper_run_tools.ml` is 1825 LOC. This PR carves out the OAS hook accumulator types + their freeze/trackers (59 LOC, 2 types + 3 bindings) using **record-sharing constraint** — the same pattern already used for `tool_search_hit_partition` at line 106 of the parent.

## Type sharing pattern
Parent retains the type definition with a sharing constraint:
```ocaml
type hook_accumulator = Keeper_run_tools_hook_accumulator.hook_accumulator = {
  mutable meta : Keeper_types.keeper_meta;
  ...
}
```
This avoids the `Module.t` vs unqualified `t` identity mismatch that broke the earlier `operator_control_snapshot_action_log` extract attempt.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/keeper/keeper_run_tools.ml` | 1825 | 1802 | **-23** (net) |
| `lib/keeper/keeper_run_tools_hook_accumulator.ml` | — | 71 | +71 |

## Moved (verbatim, no behavior change)
- `type hook_accumulator` (13-field mutable record)
- `type hook_outputs` (12-field immutable record)
- `freeze : hook_accumulator -> hook_outputs`
- `merge_requested_tool_names_seen`
- `record_requested_tool_names`

## Verification
```
$ bash scripts/lint/godfile-size-regression.sh
godfile-size-regression: clean

$ dune build --root . lib/masc_mcp.cmxa
(exit 0)
```

## Constraints honored
- No new string match arms (anti-pattern §2)
- No silent default added
- No magic-number extraction
- Flat `masc_mcp` namespace, no sub-library (plan §Do Not)
- Type sharing constraint preserves all callsites — every external caller compiles unchanged
- Existing `open Keeper_types / Keeper_agent_tool_surface / Keeper_agent_result` in sibling matches parent

## RFC-WAIVED
Extract-only sibling refactor, no behavior change, governed by `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane B (Keeper Runtime).

## Follow-up sub-PR candidates
- `task_scope_tool_names` + `json_string_opt` + `task_id_scope_of_tool_input` (~32 LOC, line 79-104) — task scope cluster
- `prepare_agent_setup` (line 143, likely large) — primary handler, needs internal refactor first

Co-Authored-By: codex <noreply@anthropic.com>