### PR TITLE
fix(tool_code): RFC-0148 PR-2 leak — 2 remaining Tool_result.error/Printexc sites + backsliding guard

### DIFF
--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -88,6 +88,16 @@ jobs:
       - name: Run lint
         run: bash scripts/lint/no-provider-name-hardcoding.sh --fail
 
+  no-tool-result-error-printexc:
+    name: RFC-0148 backsliding guard (no Tool_result.error + Printexc.to_string)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install ripgrep
+        run: sudo apt-get install -y -qq ripgrep
+      - name: Run lint
+        run: bash scripts/lint/no-tool-result-error-printexc.sh
+
   no-runtime-literal-outside-boundary-redaction:
     name: Boundary redaction SSOT enforcement (RFC-0132 PR-3)
     runs-on: ubuntu-latest

--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -514,7 +514,12 @@ let handle_code_symbols ~tool_name ~start_time ctx args =
               ] in
               Tool_result.ok ~tool_name ~start_time (Yojson.Safe.to_string response)
             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-              Tool_result.error ~tool_name ~start_time (Printf.sprintf "Failed to read file: %s" (Stdlib.Printexc.to_string exn))
+              let err =
+                Tool_error.of_exn
+                  ~detail:(Printf.sprintf "Failed to read file: %s" (Stdlib.Printexc.to_string exn))
+                  exn
+              in
+              Tool_result.error ~tool_name ~start_time (Tool_error.to_string err)
           end
         end
   end

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -604,7 +604,12 @@ let handle_code_delete ~tool_name ~start_time ctx args =
             ("agent", `String ctx.agent_name);
           ]
         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-          Tool_result.error ~tool_name ~start_time (Printf.sprintf "Delete failed: %s" (Stdlib.Printexc.to_string exn))
+          let err =
+            Tool_error.of_exn
+              ~detail:(Printf.sprintf "Delete failed: %s" (Stdlib.Printexc.to_string exn))
+              exn
+          in
+          Tool_result.error ~tool_name ~start_time (Tool_error.to_string err)
       end
   end
 

--- a/scripts/lint/no-tool-result-error-printexc.sh
+++ b/scripts/lint/no-tool-result-error-printexc.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# RFC-0148 §5.4 backsliding guard.
+#
+# Reject lines in lib/tool_*.ml that route a raw exception text into
+# Tool_result.error on the same line. The closed-sum surface
+# (Tool_error.t, lib/tool_error.ml) is the SSOT; new failure surfaces
+# must go through Tool_error.of_exn so the LLM sees a typed `kind`
+# tag instead of a free-form Printexc.to_string blob.
+#
+# Pattern matched (line-level): a line containing both `Tool_result.error`
+# and `Printexc.to_string` — the historical N-of-M leak shape.
+#
+# Allowed shape after migration:
+#
+#   let err = Tool_error.of_exn ~detail:"..." exn in
+#   Tool_result.error ~tool_name ~start_time (Tool_error.to_string err)
+#
+# That form keeps `Printexc.to_string` on a *different* line (inside the
+# ~detail builder) and routes the LLM-facing value through Tool_error.
+#
+# Exit 1 if any violating line is found.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+# rg may exit non-zero when there are zero matches; absorb that.
+matches="$(rg --line-number 'Tool_result\.error' lib/tool_*.ml 2>/dev/null || true)"
+
+violations=0
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  if echo "$line" | grep -q 'Printexc\.to_string'; then
+    echo "ERROR: Tool_result.error must not embed Printexc.to_string inline (use Tool_error.of_exn): $line"
+    violations=$((violations + 1))
+  fi
+done <<< "$matches"
+
+if [[ $violations -gt 0 ]]; then
+  echo ""
+  echo "Found $violations RFC-0148 backsliding site(s)."
+  echo "Route the exception through Tool_error.of_exn (lib/tool_error.mli) and"
+  echo "pass Tool_error.to_string to Tool_result.error. See RFC-0148 §5.4."
+  exit 1
+fi
+
+echo "OK: no RFC-0148 backsliding sites in lib/tool_*.ml"
+exit 0


### PR DESCRIPTION
## Goal

RFC-0148 closeout (#17093) §5.1 가 \`rg 'Tool_result\\.error.*Printexc\\.to_string' lib/tool_*.ml\` 0 hits 라고 표시 — **hallucination**. 재측정 결과 **2 사이트 잔존**. 본 PR 이 누락 codemod + RFC §5.4 의 backsliding lint 도입.

## 발견 사실 (2026-05-21)

\`\`\`
$ rg -n 'Tool_result\\.error' lib/tool_*.ml | rg 'Printexc'
lib/tool_code.ml:517           Tool_result.error ~tool_name ~start_time (Printf.sprintf "Failed to read file: %s" (Stdlib.Printexc.to_string exn))
lib/tool_code_write.ml:607     Tool_result.error ~tool_name ~start_time (Printf.sprintf "Delete failed: %s" (Stdlib.Printexc.to_string exn))
\`\`\`

PR #16958 (RFC-0148 PR-2) 가 6 LLM-facing 사이트 codemod 라고 했지만 위 2 사이트가 *line-drift* 또는 *late merge* 로 누락. 내가 closeout #17093 작성 시 *실측 검증 안 함* — \`feedback_keeper_hallucinated_audit_cascade\` 패턴 재발.

## What

| 파일 | 변경 |
|------|------|
| \`lib/tool_code.ml:517\` | \`Tool_result.error (Printf.sprintf "%s: %s" "Failed to read file" Printexc.to_string)\` → \`Tool_error.of_exn ~detail:"…" exn\` 거쳐 \`Tool_error.to_string err\` |
| \`lib/tool_code_write.ml:607\` | 동일 패턴 ("Delete failed: …") |
| \`scripts/lint/no-tool-result-error-printexc.sh\` 신규 | line-level grep gate (\`Tool_result.error\` + \`Printexc.to_string\` 같은 줄 = fail) |
| \`.github/workflows/fundamental-check.yml\` | 새 job \`no-tool-result-error-printexc\` 추가 |

## Wire 영향

operator-facing 메시지 *보존*:
- before: \`"Failed to read file: Sys_error(...)"\`
- after: \`"internal_error: Failed to read file: Sys_error(...)"\` (kind prefix 추가 + 원본 detail 보존)

errno priority *활성화*: \`Tool_error.of_exn\` 내부에서 \`System_error_class.classify_exn\` 호출 → \`Unix.Unix_error _\` 가 \`Resource_exhausted\` / \`Permission_denied\` typed variant 으로 분류.

## Lint script 동작

\`\`\`bash
$ bash scripts/lint/no-tool-result-error-printexc.sh
OK: no RFC-0148 backsliding sites in lib/tool_*.ml
\`\`\`

매칭 시:
\`\`\`
ERROR: Tool_result.error must not embed Printexc.to_string inline (use Tool_error.of_exn): <file>:<line>
Found N RFC-0148 backsliding site(s).
\`\`\`

Allowed shape (lint 통과):
\`\`\`ocaml
let err = Tool_error.of_exn ~detail:"..." exn in
Tool_result.error ~tool_name ~start_time (Tool_error.to_string err)
\`\`\`

\`Printexc.to_string\` 가 *다른 line* (detail builder 안) 에 있어 line-level grep 미매칭.

## Verification

\`\`\`
dune build @check:                                    clean
bash scripts/lint/no-tool-result-error-printexc.sh:   OK (0 hits)
re-grep 후:                                            0 hits in lib/tool_*.ml
\`\`\`

## Workaround Rejection Bar self-check

| 항목 | 결과 |
|------|------|
| §1 텔레메트리-as-fix | ❌ |
| §2 string/substring 분류기 추가 | ❌ (오히려 typed surface 로 routing) |
| §3 N-of-M | ⚠️ **본 PR 자체가 N-of-M closure** — PR #16958 의 미완 2 사이트 마무리 + lint guard 로 *다음* N-of-M 방지 |
| §4 catch-all \`_->\` | ❌ |
| §5 cap/cooldown/dedup/repair | ❌ |
| §6 test backdoor | ❌ |
| §7 같은 typo N-N fix | ❌ |

§3 가 *완료* 형태. PR-2 (#16958) 의 audit hallucination 으로 남았던 사이트 청소. lint 가 미래 N-of-M 차단.

## Files

\`\`\`
4 files changed, 70 insertions(+), 2 deletions(-)
  .github/workflows/fundamental-check.yml | +10
  lib/tool_code.ml                        | +6 / -1
  lib/tool_code_write.ml                  | +6 / -1
  scripts/lint/no-tool-result-error-printexc.sh (new, +47)
\`\`\`

## Closeout audit (RFC-0148 §5 재검증)

| 항목 | 본 PR 전 | 본 PR 후 |
|------|---------|---------|
| §5.1 \`Tool_result.error.*Printexc.to_string\` lib/tool_*.ml | ✗ 2 hits | ✅ 0 hits |
| §5.2 codemod helper (\`Tool_error.of_exn\`) | ✅ | ✅ |
| §5.3 Alcotest 7 cases | ✅ | ✅ |
| §5.4 CI backsliding lint | ⏸ pending | ✅ wired |
| §5.5 LLM-side acceptance (1-week prod) | ⏸ pending | ⏸ pending |

본 PR 머지 시 RFC-0148 의 §5.1 ✅ 가 *진짜로* 달성됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>