### PR TITLE
chore(keeper): drop actionable signal classifier alias

### DIFF
--- a/lib/keeper/keeper_contract_classifier.ml
+++ b/lib/keeper/keeper_contract_classifier.ml
@@ -98,9 +98,6 @@ let classify_actionable_signal_for_tools ~(allowed_tool_names : string list) o =
   then Has_discovered_work
   else No_actionable_signal
 
-let classify_actionable_signal_with_allowed_tools =
-  classify_actionable_signal_for_tools
-
 let make_actionable_signal_context ~tool_gate_required ~actionable_signal =
   if tool_gate_required
   then Turn_affordance_requires_tool

--- a/lib/keeper/keeper_contract_classifier.mli
+++ b/lib/keeper/keeper_contract_classifier.mli
@@ -78,10 +78,6 @@ val classify_actionable_signal : world_observation -> actionable_signal
 val classify_actionable_signal_for_tools :
   allowed_tool_names:string list -> world_observation -> actionable_signal
 
-(** Backward-compatible alias for [classify_actionable_signal_for_tools]. *)
-val classify_actionable_signal_with_allowed_tools :
-  allowed_tool_names:string list -> world_observation -> actionable_signal
-
 (** [requires_tool_support_for_allowed_tools ~allowed_tool_names o] is true
     when [o] carries an actionable signal that can be satisfied by at least
     one tool in [allowed_tool_names]. Use this before provider routing so the

--- a/scripts/lint/no-actionable-signal-bool-context.sh
+++ b/scripts/lint/no-actionable-signal-bool-context.sh
@@ -6,12 +6,13 @@ patterns=(
   "actionable_signal_context:false"
   "actionable_signal_context:bool"
   "actionable_signal_context : bool"
+  "classify_actionable_signal_with_allowed_tools"
 )
 
 failed=0
 for pattern in "${patterns[@]}"; do
   if rg -n --fixed-strings "$pattern" lib test; then
-    echo "no-actionable-signal-bool-context: forbidden legacy bool context: $pattern" >&2
+    echo "no-actionable-signal-bool-context: forbidden legacy actionable signal marker: $pattern" >&2
     failed=1
   fi
 done

--- a/test/test_keeper_classifier_helper.ml
+++ b/test/test_keeper_classifier_helper.ml
@@ -45,29 +45,29 @@ let test_discovered_only_when_no_other () =
 let test_allowed_tools_preserve_fallback_precedence () =
   Alcotest.check s "board wins when claim tools are hidden"
     C.Has_board_activity
-    (C.classify_actionable_signal_with_allowed_tools
+    (C.classify_actionable_signal_for_tools
        ~allowed_tool_names:[ "keeper_board_post" ]
        (obs ~tasks:2 ~board:1 ()));
   Alcotest.check s "discovered wins when claim and board tools are hidden"
     C.Has_discovered_work
-    (C.classify_actionable_signal_with_allowed_tools
+    (C.classify_actionable_signal_for_tools
        ~allowed_tool_names:[ "keeper_tasks_audit" ]
        (obs ~tasks:2 ~board:1 ~discovered:true ()));
   Alcotest.check s "no unwinnable signal without action tools"
     C.No_actionable_signal
-    (C.classify_actionable_signal_with_allowed_tools
+    (C.classify_actionable_signal_for_tools
        ~allowed_tool_names:[ "keeper_tasks_list"; "masc_status" ]
        (obs ~tasks:2 ~board:1 ~discovered:true ()))
 
 let test_allowed_tools_keep_top_priority_when_actionable () =
   Alcotest.check s "unclaimed wins with claim tool visible"
     C.Has_unclaimed_tasks
-    (C.classify_actionable_signal_with_allowed_tools
+    (C.classify_actionable_signal_for_tools
        ~allowed_tool_names:[ "keeper_task_claim"; "keeper_board_post" ]
        (obs ~tasks:2 ~board:1 ~discovered:true ()));
   Alcotest.check s "board wins over discovered with board tool visible"
     C.Has_board_activity
-    (C.classify_actionable_signal_with_allowed_tools
+    (C.classify_actionable_signal_for_tools
        ~allowed_tool_names:[ "keeper_board_comment"; "keeper_tasks_audit" ]
        (obs ~board:1 ~discovered:true ()))
 

--- a/test/test_keeper_contract_classifier_pure.ml
+++ b/test/test_keeper_contract_classifier_pure.ml
@@ -143,18 +143,6 @@ let test_classify_for_tools_no_actionable_when_no_tools () =
     KCC.No_actionable_signal
     (KCC.classify_actionable_signal_for_tools ~allowed_tool_names:allowed o)
 
-let test_classify_for_tools_alias_matches () =
-  let o = make_obs ~tasks:1 ~board:0 ~discovered:false in
-  let allowed = [ "keeper_task_claim" ] in
-  let direct =
-    KCC.classify_actionable_signal_for_tools ~allowed_tool_names:allowed o
-  in
-  let aliased =
-    KCC.classify_actionable_signal_with_allowed_tools ~allowed_tool_names:allowed
-      o
-  in
-  check_signal "alias matches direct" direct aliased
-
 let test_requires_tool_support_for_allowed_tools_true () =
   let o = make_obs ~tasks:1 ~board:0 ~discovered:false in
   check_bool "claimable task + claim tool requires tool-capable provider" true
@@ -214,8 +202,6 @@ let () =
             test_classify_for_tools_keeps_unclaimed_with_claim_tool;
           Alcotest.test_case "no matching tool → none" `Quick
             test_classify_for_tools_no_actionable_when_no_tools;
-          Alcotest.test_case "alias matches direct" `Quick
-            test_classify_for_tools_alias_matches;
           Alcotest.test_case "matching actionable signal requires tool support"
             `Quick test_requires_tool_support_for_allowed_tools_true;
           Alcotest.test_case


### PR DESCRIPTION
## Summary
- remove the backward-compatible classify_actionable_signal_with_allowed_tools alias
- migrate tests to the canonical classify_actionable_signal_for_tools function
- extend the actionable-signal lint guard to prevent alias reintroduction

## Verification
- ocamlformat --check lib/keeper/keeper_contract_classifier.ml lib/keeper/keeper_contract_classifier.mli test/test_keeper_classifier_helper.ml test/test_keeper_contract_classifier_pure.ml
- bash scripts/lint/no-actionable-signal-bool-context.sh
- bash -n scripts/lint/no-actionable-signal-bool-context.sh
- rg -n "classify_actionable_signal_with_allowed_tools" lib test (0 hits)
- git diff --check

## Local build note
- scripts/dune-local.sh build test/test_keeper_classifier_helper.exe test/test_keeper_contract_classifier_pure.exe was blocked by existing bare Dune processes outside scripts/dune-local.sh.