### PR TITLE
fix(dashboard): repair runtime upstream status bind

### DIFF
--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -650,8 +650,7 @@ let runtime_resolution_json (config : Coord.config) =
   let server_repo_path = Build_identity.repo_root () in
   let server_repo_commit = Option.bind server_repo_path git_rev_parse_short in
   let upstream_status =
-    server_repo_path
-    |> Option.bind (fun path -> git_upstream_status path)
+    Option.bind server_repo_path git_upstream_status
     |> Option.value ~default:empty_git_upstream_status
   in
   let workspace_commit = git_rev_parse_short config.workspace_path in


### PR DESCRIPTION
## Summary
- repair runtime upstream status bind so Option.bind receives the server repo path as its first argument
- preserves the live runtime fix currently running from fix/runtime-upstream-bind-20260520

## Verification
- ocamlformat --check lib/server/server_dashboard_http_runtime_info.ml
- git diff --check origin/main
- live 8935 server is currently running the source commit c2bdb7892d with this repair

Focused Dune for main_eio.exe is still blocked by machine-wide Dune contention from other worktrees.