### PR TITLE
refactor(keeper_registry): extract error tracking helpers

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -192,6 +192,7 @@
   keeper_current_task_reconcile keeper_checkpoint_store
   keeper_registry_orphan_drops
   keeper_registry_spawn_slots
+  keeper_registry_error_tracking
   keeper_text_processing
   keeper_summarizer
   keeper_context_core_message_json

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -28,6 +28,7 @@ let registry : registry_entry StringMap.t Atomic.t = Atomic.make StringMap.empty
 let running_count_atomic = Atomic.make 0
 module Orphan_drops = Keeper_registry_orphan_drops
 module Spawn_slots = Keeper_registry_spawn_slots
+module Error_tracking = Keeper_registry_error_tracking
 
 (** CAS loop for clamped decrement.  [Atomic.fetch_and_add _ (-1)] can
     leave the counter negative if increment/decrement paths interleave,
@@ -124,8 +125,6 @@ let update_entry_if_registered ~base_path name f =
   in
   loop ()
 ;;
-
-let max_crash_log_entries = 5
 
 let register_with_state
       ~base_path
@@ -394,70 +393,20 @@ let () =
 ;;
 
 let mark_dead ~base_path name ~at =
-  (* Same metric is also incremented at line ~1907 via
-     `phase_to_string tr.new_phase`, which emits lowercase wire format
-     (`dead`, `running`, `handing_off`, ...). The historical hardcoded
-     `"Dead"` here split the time series in two — `to_phase="Dead"`
-     from this site vs `to_phase="dead"` from the transition path —
-     so any Prometheus consumer aggregating on `to_phase` undercounted
-     deaths. Route through `phase_to_string` so both emit sites share
-     the SSOT casing. `from_phase` stays as the literal sentinel
-     `"direct"` to flag transition-bypass writes. *)
-  Prometheus.inc_counter
-    Keeper_metrics.metric_keeper_lifecycle_transitions
-    ~labels:
-      [ "keeper", name
-      ; "from_phase", "direct"
-      ; "to_phase", Keeper_state_machine.phase_to_string Dead
-      ]
-    ();
-  Log.Keeper.error "registry: marking keeper dead name=%s at=%.0f" name at;
-  update_entry ~base_path name (fun entry ->
-    if entry.phase <> Dead
-    then (
-      (* Enumerate every phase so the compiler flags any new variant.
-         Only the Running phase contributes to [running_count_atomic];
-         all other phases were never counted, so transitioning to
-         Dead from them must not decrement. Same FSM Sparse Match
-         anti-pattern as PR #14857 (this file's [is_running]). *)
-      (match entry.phase with
-       | Running -> decr_running_count_clamped ()
-       | Offline
-       | Failing
-       | Overflowed
-       | Compacting
-       | HandingOff
-       | Draining
-       | Paused
-       | Stopped
-       | Crashed
-       | Restarting
-       | Dead
-       | Zombie -> ());
-      let conditions =
-        { Keeper_state_machine.default_conditions with
-          launch_pending = false
-        ; fiber_alive = false
-        ; restart_budget_remaining = false
-        }
-      in
-      let phase = Keeper_state_machine.derive_phase conditions in
-      { entry with dead_since_ts = Some at; phase; conditions })
-    else
-      { entry with dead_since_ts = Some (Option.value ~default:at entry.dead_since_ts) })
+  Error_tracking.mark_dead
+    ~base_path
+    name
+    ~at
+    ~decr_running_count_clamped
+    ~update_entry
 ;;
 
 let record_restart ~base_path name =
-  Log.Keeper.warn "registry: recording restart name=%s" name;
-  update_entry ~base_path name (fun e ->
-    { e with restart_count = e.restart_count + 1; last_restart_ts = Time_compat.now () })
+  Error_tracking.record_restart ~base_path name ~update_entry
 ;;
 
-(* CAS write helper for the [last_error] slot, exposed for
-   Keeper_registry_error_recording.record (which holds the Log + Prometheus
-   dedup logic). *)
 let set_last_error_entry ~base_path ~name err =
-  update_entry ~base_path name (fun e -> { e with last_error = Some err })
+  Error_tracking.set_last_error_entry ~base_path ~name err ~update_entry
 ;;
 
 (* record_error (MASC/OAS Error-Warn Reduction Goal §P6 dedup logic) moved to
@@ -466,15 +415,15 @@ let set_last_error_entry ~base_path ~name err =
    module directly. *)
 
 let clear_error ~base_path name =
-  update_entry ~base_path name (fun e -> { e with last_error = None })
+  Error_tracking.clear_error ~base_path name ~update_entry
 ;;
 
 let set_failure_reason ~base_path name reason =
-  update_entry ~base_path name (fun e -> { e with last_failure_reason = reason })
+  Error_tracking.set_failure_reason ~base_path name reason ~update_entry
 ;;
 
 let set_last_correlation_id ~base_path name cid =
-  update_entry ~base_path name (fun e -> { e with last_event_bus_correlation = Some cid })
+  Error_tracking.set_last_correlation_id ~base_path name cid ~update_entry
 ;;
 
 (* SSE broadcast helpers (broadcast_composite_changed /
@@ -1048,12 +997,7 @@ let count_running ?base_path () =
 ;;
 
 let record_crash ~base_path name ts msg =
-  Log.Keeper.error "registry: recording crash name=%s msg=%s" name msg;
-  update_entry ~base_path name (fun e ->
-    { e with
-      crash_log =
-        List.filteri (fun i _ -> i < max_crash_log_entries) ((ts, msg) :: e.crash_log)
-    })
+  Error_tracking.record_crash ~base_path name ts msg ~update_entry
 ;;
 
 let set_grpc_close ~base_path name close_fn =
@@ -1162,14 +1106,13 @@ let crash_log_of ~base_path name =
 ;;
 
 let restore_supervisor_state ~base_path name ~restart_count ~last_restart_ts ~crash_log =
-  update_entry ~base_path name (fun e ->
-    { e with
-      restart_count
-    ; last_restart_ts
-    ; dead_since_ts = None
-    ; crash_log
-    ; last_failure_reason = None
-    })
+  Error_tracking.restore_supervisor_state
+    ~base_path
+    name
+    ~restart_count
+    ~last_restart_ts
+    ~crash_log
+    ~update_entry
 ;;
 
 let get_last_agent_count ~base_path name =

--- a/lib/keeper/keeper_registry_error_tracking.ml
+++ b/lib/keeper/keeper_registry_error_tracking.ml
@@ -1,0 +1,103 @@
+(** Error/failure tracking mutations for {!Keeper_registry}. *)
+
+open Keeper_registry_types
+
+let max_crash_log_entries = 5
+
+let mark_dead ~base_path name ~at ~decr_running_count_clamped ~update_entry =
+  (* Same metric is also incremented by transition dispatch via
+     [phase_to_string tr.new_phase], which emits lowercase wire format
+     ([dead], [running], [handing_off], ...). Route this direct-write path
+     through the same SSOT casing so Prometheus consumers do not split the
+     time series. *)
+  Prometheus.inc_counter
+    Keeper_metrics.metric_keeper_lifecycle_transitions
+    ~labels:
+      [ "keeper", name
+      ; "from_phase", "direct"
+      ; "to_phase", Keeper_state_machine.phase_to_string Dead
+      ]
+    ();
+  Log.Keeper.error "registry: marking keeper dead name=%s at=%.0f" name at;
+  update_entry ~base_path name (fun entry ->
+    if entry.phase <> Dead
+    then (
+      (* Enumerate every phase so the compiler flags any new variant. Only
+         [Running] contributes to [running_count_atomic] in the parent module;
+         all other phases were never counted, so transitioning from them must
+         not decrement. *)
+      (match entry.phase with
+       | Running -> decr_running_count_clamped ()
+       | Offline
+       | Failing
+       | Overflowed
+       | Compacting
+       | HandingOff
+       | Draining
+       | Paused
+       | Stopped
+       | Crashed
+       | Restarting
+       | Dead
+       | Zombie -> ());
+      let conditions =
+        { Keeper_state_machine.default_conditions with
+          launch_pending = false
+        ; fiber_alive = false
+        ; restart_budget_remaining = false
+        }
+      in
+      let phase = Keeper_state_machine.derive_phase conditions in
+      { entry with dead_since_ts = Some at; phase; conditions })
+    else
+      { entry with dead_since_ts = Some (Option.value ~default:at entry.dead_since_ts) })
+;;
+
+let record_restart ~base_path name ~update_entry =
+  Log.Keeper.warn "registry: recording restart name=%s" name;
+  update_entry ~base_path name (fun e ->
+    { e with restart_count = e.restart_count + 1; last_restart_ts = Time_compat.now () })
+;;
+
+let set_last_error_entry ~base_path ~name err ~update_entry =
+  update_entry ~base_path name (fun e -> { e with last_error = Some err })
+;;
+
+let clear_error ~base_path name ~update_entry =
+  update_entry ~base_path name (fun e -> { e with last_error = None })
+;;
+
+let set_failure_reason ~base_path name reason ~update_entry =
+  update_entry ~base_path name (fun e -> { e with last_failure_reason = reason })
+;;
+
+let set_last_correlation_id ~base_path name cid ~update_entry =
+  update_entry ~base_path name (fun e -> { e with last_event_bus_correlation = Some cid })
+;;
+
+let record_crash ~base_path name ts msg ~update_entry =
+  Log.Keeper.error "registry: recording crash name=%s msg=%s" name msg;
+  update_entry ~base_path name (fun e ->
+    { e with
+      crash_log =
+        List.filteri (fun i _ -> i < max_crash_log_entries) ((ts, msg) :: e.crash_log)
+    })
+;;
+
+let restore_supervisor_state
+      ~base_path
+      name
+      ~restart_count
+      ~last_restart_ts
+      ~crash_log
+      ~update_entry
+  =
+  update_entry ~base_path name (fun e ->
+    { e with
+      restart_count
+    ; last_restart_ts
+    ; dead_since_ts = None
+    ; crash_log
+    ; last_failure_reason = None
+    })
+;;

--- a/lib/keeper/keeper_registry_error_tracking.mli
+++ b/lib/keeper/keeper_registry_error_tracking.mli
@@ -1,0 +1,65 @@
+(** Error/failure tracking mutations for {!Keeper_registry}.
+
+    The central registry owns the Atomic CAS loop. This sibling module owns
+    the field-level update logic; callers pass the parent CAS helper into each
+    function. *)
+
+open Keeper_registry_types
+
+val mark_dead :
+  base_path:string ->
+  string ->
+  at:float ->
+  decr_running_count_clamped:(unit -> unit) ->
+  update_entry:(base_path:string -> string -> (registry_entry -> registry_entry) -> unit) ->
+  unit
+
+val record_restart :
+  base_path:string ->
+  string ->
+  update_entry:(base_path:string -> string -> (registry_entry -> registry_entry) -> unit) ->
+  unit
+
+val set_last_error_entry :
+  base_path:string ->
+  name:string ->
+  string ->
+  update_entry:(base_path:string -> string -> (registry_entry -> registry_entry) -> unit) ->
+  unit
+
+val clear_error :
+  base_path:string ->
+  string ->
+  update_entry:(base_path:string -> string -> (registry_entry -> registry_entry) -> unit) ->
+  unit
+
+val set_failure_reason :
+  base_path:string ->
+  string ->
+  failure_reason option ->
+  update_entry:(base_path:string -> string -> (registry_entry -> registry_entry) -> unit) ->
+  unit
+
+val set_last_correlation_id :
+  base_path:string ->
+  string ->
+  string ->
+  update_entry:(base_path:string -> string -> (registry_entry -> registry_entry) -> unit) ->
+  unit
+
+val record_crash :
+  base_path:string ->
+  string ->
+  float ->
+  string ->
+  update_entry:(base_path:string -> string -> (registry_entry -> registry_entry) -> unit) ->
+  unit
+
+val restore_supervisor_state :
+  base_path:string ->
+  string ->
+  restart_count:int ->
+  last_restart_ts:float ->
+  crash_log:(float * string) list ->
+  update_entry:(base_path:string -> string -> (registry_entry -> registry_entry) -> unit) ->
+  unit


### PR DESCRIPTION
## Summary
- Extract keeper registry error/failure/crash tracking field updates into Keeper_registry_error_tracking
- Keep Keeper_registry as the sole owner of the Atomic CAS update_entry loop and running-count decrement
- Register the new helper module in lib/dune

## Verification
- ocamlformat --check lib/keeper/keeper_registry_error_tracking.ml lib/keeper/keeper_registry_error_tracking.mli lib/keeper/keeper_registry.ml
- git diff origin/main --check
- scripts/lint/godfile-size-regression.sh
- rg risk scan on new helper module: clean

## Local Dune note
- Attempted: env DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build lib/masc_mcp.cma
- Blocked by existing machine-wide/bare Dune processes and long-held /tmp/me-dune-local.lock; no local Dune compile completed in this saturated session. Draft PR is left for CI validation.