### PR TITLE
fix(keeper): downgrade repeated gate rejection logs

### DIFF
--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -186,6 +186,81 @@ let gate_decision_is_rejection = function
   | Gate_override | Gate_approval_required -> true
   | Gate_continue -> false
 
+type gate_rejection_log_severity =
+  | Gate_rejection_first_warn
+  | Gate_rejection_repeat_info of int
+  | Gate_rejection_repeat_debug of int
+
+let gate_rejection_log_severity_to_string = function
+  | Gate_rejection_first_warn -> "warn"
+  | Gate_rejection_repeat_info _ -> "info"
+  | Gate_rejection_repeat_debug _ -> "debug"
+
+let gate_rejection_log_counts : (string * string * string * string, int) Hashtbl.t =
+  Hashtbl.create 64
+
+let gate_rejection_log_counts_mu = Mutex.create ()
+
+let reset_gate_rejection_log_counts () =
+  Mutex.protect gate_rejection_log_counts_mu (fun () ->
+    Hashtbl.clear gate_rejection_log_counts)
+
+let record_gate_rejection_log_severity ?reason_key
+    ~keeper_name ~stage ~tool_name ~reason_code () =
+  let reason_key = Option.value ~default:reason_code reason_key in
+  let key = (keeper_name, stage, tool_name, reason_key) in
+  Mutex.protect gate_rejection_log_counts_mu (fun () ->
+    let count =
+      match Hashtbl.find_opt gate_rejection_log_counts key with
+      | Some n -> n + 1
+      | None -> 1
+    in
+    Hashtbl.replace gate_rejection_log_counts key count;
+    match count with
+    | 1 -> Gate_rejection_first_warn
+    | 2 -> Gate_rejection_repeat_info count
+    | _ -> Gate_rejection_repeat_debug count)
+
+let planner_alternative_for_gate ~stage ~tool_name =
+  match stage with
+  | "streak_gate" ->
+    Printf.sprintf
+      "planner_alternative=\"stop retrying %s; choose a different tool, batch remaining work, or call keeper_stay_silent\""
+      tool_name
+  | "keeper_deny" ->
+    "planner_alternative=\"choose an allowed replacement tool, change plan, or request operator approval\""
+  | "cost_gate" ->
+    "planner_alternative=\"stop tool use, summarize progress, or request a budget increase before retrying\""
+  | "destructive_guard" ->
+    "planner_alternative=\"use a safe read-only command, narrow the path, or request operator approval\""
+  | _ ->
+    "planner_alternative=\"change plan, choose a different tool, or call keeper_stay_silent\""
+
+let log_gate_rejection ?reason_key ~keeper_name ~stage ~tool_name ~reason_code fmt =
+  Printf.ksprintf
+    (fun message ->
+       match
+         record_gate_rejection_log_severity ?reason_key
+           ~keeper_name ~stage ~tool_name ~reason_code ()
+       with
+       | Gate_rejection_first_warn -> Log.Keeper.warn "%s" message
+       | Gate_rejection_repeat_info count ->
+         Log.Keeper.info "%s repeat_count=%d %s"
+           message count (planner_alternative_for_gate ~stage ~tool_name)
+       | Gate_rejection_repeat_debug count ->
+         Log.Keeper.debug "%s repeat_count=%d %s"
+           message count (planner_alternative_for_gate ~stage ~tool_name))
+    fmt
+
+module For_testing = struct
+  let reset_gate_rejection_log_counts = reset_gate_rejection_log_counts
+
+  let record_gate_rejection_log_severity =
+    record_gate_rejection_log_severity
+
+  let planner_alternative_for_gate = planner_alternative_for_gate
+end
+
 type gate_decision_event = {
   stage : string;
   keeper_name : string;
@@ -456,7 +531,9 @@ let streak_guard
           Keeper_metrics.metric_keeper_guards_failures
           ~labels:[("keeper", keeper_name); ("site", "streak_gate")]
           ();
-        Log.Keeper.warn
+        log_gate_rejection
+          ~keeper_name ~stage:"streak_gate" ~tool_name
+          ~reason_code:"streak_gate"
           "keeper:%s streak_gate: %s called %d times consecutively, blocking"
           keeper_name tool_name new_count;
         broadcast_tool_skipped
@@ -497,7 +574,10 @@ let deny_guard
           Keeper_metrics.metric_keeper_guards_failures
           ~labels:[("keeper", keeper_name); ("site", "deny_list")]
           ();
-        Log.Keeper.warn "keeper:%s deny list: blocked %s"
+        log_gate_rejection
+          ~keeper_name ~stage:"keeper_deny" ~tool_name
+          ~reason_code:"keeper_deny"
+          "keeper:%s deny list: blocked %s"
           keeper_name tool_name;
         broadcast_tool_skipped
           ~keeper_name ~tool_name ~reason_code:"keeper_deny";
@@ -542,7 +622,9 @@ let cost_guard
            Keeper_metrics.metric_keeper_guards_failures
            ~labels:[("keeper", keeper_name); ("site", "cost_gate")]
            ();
-         Log.Keeper.warn
+         log_gate_rejection
+           ~keeper_name ~stage:"cost_gate" ~tool_name
+           ~reason_code:"cost_gate"
            "keeper:%s cost gate: $%.4f >= $%.4f limit, skipping %s"
            keeper_name accumulated_cost_usd limit tool_name;
          broadcast_tool_skipped
@@ -592,7 +674,9 @@ let destructive_guard
              Keeper_metrics.metric_keeper_guards_failures
              ~labels:[("keeper", keeper_name); ("site", "destructive_guard")]
              ();
-           Log.Keeper.warn
+           log_gate_rejection
+             ~keeper_name ~stage:"destructive_guard" ~tool_name
+             ~reason_code:"destructive_guard" ~reason_key:pattern
              "keeper:%s destructive pattern in %s: '%s' (%s)"
              keeper_name tool_name pattern desc;
            broadcast_tool_skipped

--- a/lib/keeper/keeper_guards.mli
+++ b/lib/keeper/keeper_guards.mli
@@ -58,6 +58,17 @@ val gate_decision_to_string : gate_decision -> string
 
 val gate_decision_is_rejection : gate_decision -> bool
 
+(** Log severity for repeated gate rejections.  The first sighting stays WARN;
+    repeated sightings downgrade so a bad plan does not flood WARN logs every
+    keeper cycle. *)
+type gate_rejection_log_severity =
+  | Gate_rejection_first_warn
+  | Gate_rejection_repeat_info of int
+  | Gate_rejection_repeat_debug of int
+
+val gate_rejection_log_severity_to_string :
+  gate_rejection_log_severity -> string
+
 (** Telemetry payload reported to the gate observer. *)
 type gate_decision_event =
   { stage : string
@@ -202,3 +213,19 @@ val build_chain :
   pre_tool_use_guard:
     (tool_name:string -> input:Yojson.Safe.t -> string option) ->
   Agent_sdk.Hooks.hooks
+
+module For_testing : sig
+  val reset_gate_rejection_log_counts : unit -> unit
+
+  val record_gate_rejection_log_severity :
+    ?reason_key:string ->
+    keeper_name:string ->
+    stage:string ->
+    tool_name:string ->
+    reason_code:string ->
+    unit ->
+    gate_rejection_log_severity
+
+  val planner_alternative_for_gate :
+    stage:string -> tool_name:string -> string
+end

--- a/test/test_keeper_guards.ml
+++ b/test/test_keeper_guards.ml
@@ -172,6 +172,79 @@ let test_gate_decision_vocabulary () =
   check bool "approval rejects" true
     (KG.gate_decision_is_rejection KG.Gate_approval_required)
 
+let test_gate_rejection_log_severity_splits_repeats () =
+  KG.For_testing.reset_gate_rejection_log_counts ();
+  Fun.protect
+    ~finally:KG.For_testing.reset_gate_rejection_log_counts
+    (fun () ->
+      let next () =
+        KG.For_testing.record_gate_rejection_log_severity
+          ~keeper_name:"test_keeper"
+          ~stage:"keeper_deny"
+          ~tool_name:"dangerous_tool"
+          ~reason_code:"keeper_deny"
+          ()
+      in
+      check string "first rejection is warn" "warn"
+        (KG.gate_rejection_log_severity_to_string (next ()));
+      (match next () with
+       | KG.Gate_rejection_repeat_info 2 -> ()
+       | severity ->
+         failf "expected second rejection info/2, got %s"
+           (KG.gate_rejection_log_severity_to_string severity));
+      (match next () with
+       | KG.Gate_rejection_repeat_debug 3 -> ()
+       | severity ->
+         failf "expected third rejection debug/3, got %s"
+           (KG.gate_rejection_log_severity_to_string severity)))
+
+let test_gate_rejection_log_severity_keys_by_rejection () =
+  KG.For_testing.reset_gate_rejection_log_counts ();
+  Fun.protect
+    ~finally:KG.For_testing.reset_gate_rejection_log_counts
+    (fun () ->
+      let record ?reason_key ~tool_name () =
+        KG.For_testing.record_gate_rejection_log_severity
+          ?reason_key
+          ~keeper_name:"test_keeper"
+          ~stage:"destructive_guard"
+          ~tool_name
+          ~reason_code:"destructive_guard"
+          ()
+      in
+      let first = record ~reason_key:"rm -rf" ~tool_name:"shell_exec" () in
+      let repeat = record ~reason_key:"rm -rf" ~tool_name:"shell_exec" () in
+      let different_tool =
+        record ~reason_key:"rm -rf" ~tool_name:"keeper_bash" ()
+      in
+      let different_reason =
+        record ~reason_key:"chmod 777" ~tool_name:"shell_exec" ()
+      in
+      check string "first key warns" "warn"
+        (KG.gate_rejection_log_severity_to_string first);
+      check string "same key repeats as info" "info"
+        (KG.gate_rejection_log_severity_to_string repeat);
+      check string "different tool has own first warn" "warn"
+        (KG.gate_rejection_log_severity_to_string different_tool);
+      check string "different reason has own first warn" "warn"
+        (KG.gate_rejection_log_severity_to_string different_reason))
+
+let test_gate_rejection_planner_alternative () =
+  let streak =
+    KG.For_testing.planner_alternative_for_gate
+      ~stage:"streak_gate" ~tool_name:"keeper_fs_read"
+  in
+  check bool "includes structured field" true
+    (contains_substring streak "planner_alternative=");
+  check bool "names retry alternative" true
+    (contains_substring streak "keeper_stay_silent");
+  let destructive =
+    KG.For_testing.planner_alternative_for_gate
+      ~stage:"destructive_guard" ~tool_name:"shell_exec"
+  in
+  check bool "destructive suggests safe command" true
+    (contains_substring destructive "safe read-only command")
+
 (* ----------------------------------------------------------------- *)
 (* Individual guard tests                                              *)
 (* ----------------------------------------------------------------- *)
@@ -498,6 +571,12 @@ let () = run "Keeper_guards" [
     test_case "pre-tool gate output preserves source" `Quick
       test_render_pre_tool_gate_output_preserves_source;
     test_case "gate decision vocabulary" `Quick test_gate_decision_vocabulary;
+    test_case "gate rejection log severity splits repeats" `Quick
+      test_gate_rejection_log_severity_splits_repeats;
+    test_case "gate rejection log severity keys by rejection" `Quick
+      test_gate_rejection_log_severity_keys_by_rejection;
+    test_case "gate rejection planner alternative" `Quick
+      test_gate_rejection_planner_alternative;
   ];
   "deny_guard", [
     test_case "blocks denied tool" `Quick test_deny_guard_blocks;


### PR DESCRIPTION
## Summary
- Add keeper guard rejection log severity state: first matching rejection stays WARN, second repeats at INFO, and later repeats downgrade to DEBUG.
- Include a `planner_alternative` hint on downgraded repeat logs so repeated gate failures point the planner toward a different next step.
- Apply the split to streak, deny-list, cost, and destructive guard rejection warnings while preserving metrics, gate events, and inline override text.
- Cover repeat severity/keying and planner-alternative strings in `test_keeper_guards`.

## Validation
- `ocamlformat --check lib/keeper/keeper_guards.ml lib/keeper/keeper_guards.mli test/test_keeper_guards.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_guards.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_guards.mli`
- `ocamlc -stop-after parsing test/test_keeper_guards.ml`
- `git diff --check origin/main...HEAD`
- `scripts/dune-local.sh build test/test_keeper_guards.exe` was attempted, but `scripts/dune-local.sh` refused to start because unrelated live bare `dune build` processes were bypassing the machine-wide Dune lock.