### PR TITLE
fix(dashboard): lift safe autonomy docker probe timeout

### DIFF
--- a/lib/dashboard/dashboard_safe_autonomy.ml
+++ b/lib/dashboard/dashboard_safe_autonomy.ml
@@ -768,15 +768,15 @@ let build_keeper_snapshot
   }
 
 (* The safe-autonomy screen renders one row per keeper. Its Docker probe is
-   intentionally much shorter than interactive sandbox-status calls, and the
+   intentionally shorter than interactive sandbox-status calls, and the
    fleet renderer batches the base-path-scoped container listing once per
    payload before filtering by keeper in memory.
 
-   Floor at 1.0s rather than 0.25s: [Process_eio] timeouts surface
-   through [Log.warn]-style sites that format duration with [%.0f],
-   which would render the 0.25s budget as "0s" and confuse operators
-   reading "command timed out after 0s".  1.0s produces a
-   self-explanatory diagnostic when Docker is genuinely slow.
+   Use the dashboard exec-timeout SSOT instead of a local 1s literal. A 1s
+   ceiling produced false-positive [Process_eio] warnings for routine
+   Docker listings on loaded macOS hosts, while the dashboard caller's 3s
+   default still keeps the hot path bounded and operator-tunable through
+   [MASC_EXEC_TIMEOUT_DASHBOARD_SEC].
 
    [Keeper_sandbox_runtime.list_containers] internally runs TWO
    sequential Docker commands (`docker ps` then `docker inspect`),
@@ -784,7 +784,11 @@ let build_keeper_snapshot
    fleet rather than once per keeper, a stalled Docker daemon costs about
    [2 * timeout_sec] per render instead of [2 * timeout_sec * keeper_count].
 *)
-let sandbox_live_probe_timeout_sec = 1.0
+let sandbox_live_probe_timeout_sec =
+  max 1.0
+    (Env_config_exec_timeout.timeout_sec
+       ~caller:Env_config_exec_timeout.Dashboard
+       ())
 
 let dashboard_sandbox_containers ~(config : Coord.config) keepers =
   if

--- a/test/test_dashboard_safe_autonomy.ml
+++ b/test/test_dashboard_safe_autonomy.ml
@@ -256,6 +256,13 @@ let test_sandbox_live_probe_is_batched_for_dashboard () =
     check bool "slow docker probe is batched" true (elapsed_sec < 3.5);
     let per_keeper = Yojson.Safe.Util.(json |> member "per_keeper" |> to_list) in
     check int "docker keeper count" 4 (List.length per_keeper);
+    check bool "2s docker listing is not reported as a timeout" true
+      (List.for_all
+         (fun keeper ->
+           Yojson.Safe.Util.(
+             keeper |> member "sandbox_live" |> member "container_error")
+           = `Null)
+         per_keeper);
     check bool "playground repo git enrichment skipped" true
       (List.for_all
          (fun keeper ->


### PR DESCRIPTION
## Summary
- route safe-autonomy Docker live probe timeout through Env_config_exec_timeout.Dashboard instead of a local 1s literal
- keep the dashboard hot path bounded while letting loaded hosts use the 3s dashboard default / MASC_EXEC_TIMEOUT_DASHBOARD_SEC
- add regression coverage that a 2s fake Docker listing is not reported as container_error

## Verification
- ocamlformat --check lib/dashboard/dashboard_safe_autonomy.ml test/test_dashboard_safe_autonomy.ml
- git diff --check origin/main...HEAD
- scripts/dune-local.sh build test/test_dashboard_safe_autonomy.exe (blocked: live bare dune processes outside scripts/dune-local.sh; did not kill or override other sessions)

Refs #16179
Refs #15931