### PR TITLE
refactor(operator_control_snapshot): extract tool-name helpers into sibling (Lane F)

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -210,64 +210,9 @@ let recent_messages_json config =
   |> fun rows -> `List rows
 ;;
 
-let merge_tool_name_lists primary secondary =
-  let seen = Hashtbl.create 16 in
-  let add acc raw_name =
-    let name = String.trim raw_name in
-    if name = "" || Hashtbl.mem seen name
-    then acc
-    else (
-      Hashtbl.replace seen name ();
-      name :: acc)
-  in
-  List.rev (List.fold_left add [] (List.concat [ primary; secondary ]))
-;;
-
-let tool_names_of_recent_json (json : Yojson.Safe.t) =
-  let tools_used =
-    match U.member "tools_used" json with
-    | `List items ->
-      List.filter_map
-        (function
-          | `String value ->
-            let trimmed = String.trim value in
-            if trimmed = "" then None else Some trimmed
-          | _ -> None)
-        items
-    | _ -> []
-  in
-  let single_tool =
-    match U.member "tool" json with
-    | `String value ->
-      let trimmed = String.trim value in
-      if trimmed = "" then [] else [ trimmed ]
-    | _ -> []
-  in
-  merge_tool_name_lists single_tool tools_used
-;;
-
-let collect_recent_tool_names ?(limit = 8) (lines : string list) =
-  let ordered = List.rev lines in
-  let rec loop acc remaining = function
-    | _ when remaining <= 0 -> List.rev acc
-    | [] -> List.rev acc
-    | line :: rest ->
-      (try
-         let json = Yojson.Safe.from_string line in
-         let tools = tool_names_of_recent_json json in
-         let merged = merge_tool_name_lists (List.rev acc) tools in
-         let capped =
-           if List.length merged <= limit
-           then merged
-           else List.filteri (fun idx _ -> idx < limit) merged
-         in
-         loop (List.rev capped) (limit - List.length capped) rest
-       with
-       | Yojson.Json_error _ -> loop acc remaining rest)
-  in
-  loop [] limit ordered
-;;
-
+let merge_tool_name_lists = Operator_control_snapshot_tool_names.merge_tool_name_lists
+let tool_names_of_recent_json = Operator_control_snapshot_tool_names.tool_names_of_recent_json
+let collect_recent_tool_names = Operator_control_snapshot_tool_names.collect_recent_tool_names
 let recent_tool_names_from_files config keeper_name =
   let decision_lines =
     let path = Keeper_types.keeper_decision_log_path config keeper_name in

--- a/lib/operator/operator_control_snapshot_tool_names.ml
+++ b/lib/operator/operator_control_snapshot_tool_names.ml
@@ -1,0 +1,66 @@
+(** Tool-name extraction + dedupe helpers for operator control snapshot,
+    extracted from operator_control_snapshot.ml.
+
+    Pure JSON/string helpers used to surface the recent tools a keeper
+    has called in the operator's "recent" view. *)
+
+module U = Yojson.Safe.Util
+
+let merge_tool_name_lists primary secondary =
+  let seen = Hashtbl.create 16 in
+  let add acc raw_name =
+    let name = String.trim raw_name in
+    if name = "" || Hashtbl.mem seen name
+    then acc
+    else (
+      Hashtbl.replace seen name ();
+      name :: acc)
+  in
+  List.rev (List.fold_left add [] (List.concat [ primary; secondary ]))
+;;
+
+let tool_names_of_recent_json (json : Yojson.Safe.t) =
+  let tools_used =
+    match U.member "tools_used" json with
+    | `List items ->
+      List.filter_map
+        (function
+          | `String value ->
+            let trimmed = String.trim value in
+            if trimmed = "" then None else Some trimmed
+          | _ -> None)
+        items
+    | _ -> []
+  in
+  let single_tool =
+    match U.member "tool" json with
+    | `String value ->
+      let trimmed = String.trim value in
+      if trimmed = "" then [] else [ trimmed ]
+    | _ -> []
+  in
+  merge_tool_name_lists single_tool tools_used
+;;
+
+let collect_recent_tool_names ?(limit = 8) (lines : string list) =
+  let ordered = List.rev lines in
+  let rec loop acc remaining = function
+    | _ when remaining <= 0 -> List.rev acc
+    | [] -> List.rev acc
+    | line :: rest ->
+      (try
+         let json = Yojson.Safe.from_string line in
+         let tools = tool_names_of_recent_json json in
+         let merged = merge_tool_name_lists (List.rev acc) tools in
+         let capped =
+           if List.length merged <= limit
+           then merged
+           else List.filteri (fun idx _ -> idx < limit) merged
+         in
+         loop (List.rev capped) (limit - List.length capped) rest
+       with
+       | Yojson.Json_error _ -> loop acc remaining rest)
+  in
+  loop [] limit ordered
+;;
+


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane F (Operator/voice/backend)
- `operator_control_snapshot.ml` is 1662 LOC. Carved out 3 pure tool-name helpers (no type dependency) into a sibling.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/operator/operator_control_snapshot.ml` | 1662 | 1607 | **-55** |
| `lib/operator/operator_control_snapshot_tool_names.ml` | — | 66 | +66 |

## Moved (verbatim, no behavior change)
- `merge_tool_name_lists` (dedupe via Hashtbl)
- `tool_names_of_recent_json` (Yojson member walk)
- `collect_recent_tool_names` (bounded list scan)

All 3 are pure string-list helpers — no type sharing constraint needed, 0 external callers (internal use only).

## Verification
- `bash scripts/lint/godfile-size-regression.sh`: clean
- `dune build --root . lib/masc_mcp.cmxa`: local build interrupted by timeout (180s); CI will provide authoritative result

## Constraints honored
- No new string match arms (anti-pattern §2)
- No silent default
- No magic-number extraction (`limit = 8` literal stays verbatim in `collect_recent_tool_names` signature)
- Flat `masc_mcp` namespace, no sub-library

## RFC-WAIVED
Extract-only sibling refactor, pure helpers, no behavior change, governed by `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane F.

Co-Authored-By: codex <noreply@anthropic.com>
