### PR TITLE
refactor(keeper_unified_metrics): extract broadcast_lifecycle_events into sibling (Lane A)

### DIFF
--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -945,71 +945,8 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
          ()
    | _ -> ())
 
-let broadcast_lifecycle_events ~(name : string)
-    ~(turn_generation : int)
-    ~(compaction : Keeper_exec_context.compaction_event)
-    ~(handoff_json : Yojson.Safe.t option) : unit =
-  let now_ts = Time_compat.now () in
-  (if compaction.applied then
-     try
-       Sse.broadcast
-         (`Assoc
-           [
-             ("type", `String "keeper_compaction");
-             ("name", `String name);
-             ("generation", `Int turn_generation);
-             ("before_tokens", `Int compaction.before_tokens);
-             ("after_tokens", `Int compaction.after_tokens);
-             ("saved_tokens", `Int compaction.saved_tokens);
-             ( "trigger",
-               match compaction.trigger with
-               | Some trigger -> `String (Compaction_trigger.to_label trigger)
-               | None ->
-                   `String
-                     (Keeper_exec_context.compaction_decision_to_string
-                        compaction.decision) );
-             ( "trigger_detail",
-               match compaction.trigger with
-               | Some trigger -> Compaction_trigger.to_detail_json trigger
-               | None -> `Null );
-             ("ts_unix", `Float now_ts);
-           ])
-     with
-     | Eio.Cancel.Cancelled _ as e -> raise e
-     | exn ->
-         Log.Keeper.error "compaction SSE broadcast failed: %s"
-           (Printexc.to_string exn);
-         Prometheus.inc_counter Keeper_metrics.metric_keeper_metrics_sse_failures ~labels:[("kind", Keeper_metrics_sse_failure_kind.(to_label Compaction))] ());
-  match handoff_json with
-  | Some ((`Assoc _ as handoff)) ->
-      let from_generation =
-        Safe_ops.json_int ~default:turn_generation "from_generation" handoff
-      in
-      let to_generation =
-        Safe_ops.json_int ~default:(from_generation + 1) "to_generation" handoff
-      in
-      let to_model = Safe_ops.json_string ~default:"" "to_model" handoff in
-      (try
-         Sse.broadcast
-           (`Assoc
-             [
-               ("type", `String "keeper_handoff");
-               ("name", `String name);
-               ("from_generation", `Int from_generation);
-               ("to_generation", `Int to_generation);
-               ("from_model", `Null);
-               ("to_model",
-                if String.trim to_model = "" then `Null else `String to_model);
-               ("ts_unix", `Float now_ts);
-             ])
-       with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn ->
-          Log.Keeper.error "handoff SSE broadcast failed: %s"
-            (Printexc.to_string exn);
-          Prometheus.inc_counter Keeper_metrics.metric_keeper_metrics_sse_failures ~labels:[("kind", Keeper_metrics_sse_failure_kind.(to_label Handoff))] ())
-  | _ -> ()
-
+let broadcast_lifecycle_events =
+  Keeper_unified_metrics_broadcast.broadcast_lifecycle_events
 let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
     ~(observation : Keeper_world_observation.world_observation)
     ~(reason : string) ?(is_transient = false) ?social_state

--- a/lib/keeper/keeper_unified_metrics_broadcast.ml
+++ b/lib/keeper/keeper_unified_metrics_broadcast.ml
@@ -1,0 +1,74 @@
+(** Keeper lifecycle SSE broadcast helpers — compaction and handoff events —
+    extracted from keeper_unified_metrics.ml.
+
+    Pure write-only side-effects (SSE broadcast + failure counter); no
+    keeper lifecycle state owned here. *)
+
+open Keeper_types
+open Keeper_exec_context
+
+let broadcast_lifecycle_events ~(name : string)
+    ~(turn_generation : int)
+    ~(compaction : Keeper_exec_context.compaction_event)
+    ~(handoff_json : Yojson.Safe.t option) : unit =
+  let now_ts = Time_compat.now () in
+  (if compaction.applied then
+     try
+       Sse.broadcast
+         (`Assoc
+           [
+             ("type", `String "keeper_compaction");
+             ("name", `String name);
+             ("generation", `Int turn_generation);
+             ("before_tokens", `Int compaction.before_tokens);
+             ("after_tokens", `Int compaction.after_tokens);
+             ("saved_tokens", `Int compaction.saved_tokens);
+             ( "trigger",
+               match compaction.trigger with
+               | Some trigger -> `String (Compaction_trigger.to_label trigger)
+               | None ->
+                   `String
+                     (Keeper_exec_context.compaction_decision_to_string
+                        compaction.decision) );
+             ( "trigger_detail",
+               match compaction.trigger with
+               | Some trigger -> Compaction_trigger.to_detail_json trigger
+               | None -> `Null );
+             ("ts_unix", `Float now_ts);
+           ])
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+         Log.Keeper.error "compaction SSE broadcast failed: %s"
+           (Printexc.to_string exn);
+         Prometheus.inc_counter Keeper_metrics.metric_keeper_metrics_sse_failures ~labels:[("kind", Keeper_metrics_sse_failure_kind.(to_label Compaction))] ());
+  match handoff_json with
+  | Some ((`Assoc _ as handoff)) ->
+      let from_generation =
+        Safe_ops.json_int ~default:turn_generation "from_generation" handoff
+      in
+      let to_generation =
+        Safe_ops.json_int ~default:(from_generation + 1) "to_generation" handoff
+      in
+      let to_model = Safe_ops.json_string ~default:"" "to_model" handoff in
+      (try
+         Sse.broadcast
+           (`Assoc
+             [
+               ("type", `String "keeper_handoff");
+               ("name", `String name);
+               ("from_generation", `Int from_generation);
+               ("to_generation", `Int to_generation);
+               ("from_model", `Null);
+               ("to_model",
+                if String.trim to_model = "" then `Null else `String to_model);
+               ("ts_unix", `Float now_ts);
+             ])
+       with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+          Log.Keeper.error "handoff SSE broadcast failed: %s"
+            (Printexc.to_string exn);
+          Prometheus.inc_counter Keeper_metrics.metric_keeper_metrics_sse_failures ~labels:[("kind", Keeper_metrics_sse_failure_kind.(to_label Handoff))] ())
+  | _ -> ()
+


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane A (Metrics)
- `keeper_unified_metrics.ml` is 1182 LOC. Carved out `broadcast_lifecycle_events` (compaction + handoff SSE) into a sibling — pure write-only side-effects (SSE broadcast + failure counter).

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/keeper/keeper_unified_metrics.ml` | 1182 | 1119 | **-63** |
| `lib/keeper/keeper_unified_metrics_broadcast.ml` | — | 74 | +74 |

## Moved (verbatim, no behavior change)
- `broadcast_lifecycle_events ~name ~turn_generation ~compaction ~handoff_json` (compaction SSE + handoff SSE)

2 external callers (`keeper_unified_turn_success`, `keeper_turn`) compile unchanged via single-line alias in parent.

## Verification
- `bash scripts/lint/godfile-size-regression.sh`: clean
- `dune build --root . lib/masc_mcp.cmxa`: exit 0

## Constraints honored
- No new string match arms (anti-pattern §2)
- No silent default
- No magic-number extraction
- Flat `masc_mcp` namespace, no sub-library
- mli line 217 still exposes `broadcast_lifecycle_events` via alias
- Cancel-aware error handling preserved (`Eio.Cancel.Cancelled _ as e -> raise e`)

## RFC-WAIVED
Extract-only sibling refactor, no behavior change, governed by `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane A.

## Follow-up candidates (keeper_unified_metrics remaining clusters)
- `append_decision_record` (~448 LOC, biggest) — needs internal refactor first
- `update_metrics_from_result` (~239 LOC)
- `append_metrics_snapshot` (~243 LOC)
- `update_metrics_from_failure` (~170 LOC)

Co-Authored-By: codex <noreply@anthropic.com>
