### PR TITLE
chore(cdal): drop mutation class alias

### DIFF
--- a/lib/cdal_runtime/contract_runner.ml
+++ b/lib/cdal_runtime/contract_runner.ml
@@ -120,7 +120,7 @@ let run
         |> List.filter_map (fun (t : Tool.t) ->
           match t.descriptor with
           | Some d ->
-            Option.bind d.Tool.mutation_class Mode_enforcer.mutation_class_of_string
+            Option.bind d.Tool.mutation_class Mode_enforcer.tool_effect_class_of_string
             |> Option.map (fun cls -> t.schema.name, cls)
           | None -> None)
       in

--- a/lib/cdal_runtime/mode_enforcer.ml
+++ b/lib/cdal_runtime/mode_enforcer.ml
@@ -4,9 +4,6 @@ type tool_effect_class =
   | External_effect
   | Shell_dynamic
 
-(* Backward-compatible alias. *)
-type mutation_class = tool_effect_class
-
 (* Kind-name helper for parse-error diagnostics.  [lib/cdal_runtime/] is
    intentionally decoupled from [masc_core] (RFC-OAS-011 producer-side
    isolation), so [Json_util.kind_name] is not reachable without breaking
@@ -327,9 +324,6 @@ let tool_effect_class_of_string = function
   | "shell_dynamic" -> Some Shell_dynamic
   | _ -> None
 ;;
-
-(* Backward-compatible alias *)
-let mutation_class_of_string = tool_effect_class_of_string
 
 (* ── Builtin descriptor derivation ─────────────────────────────── *)
 

--- a/lib/cdal_runtime/mode_enforcer.mli
+++ b/lib/cdal_runtime/mode_enforcer.mli
@@ -18,9 +18,6 @@ type tool_effect_class =
   | External_effect
   | Shell_dynamic
 
-(** Backward-compatible alias for [tool_effect_class]. *)
-type mutation_class = tool_effect_class
-
 type violation_kind =
   | Mutating_in_diagnose
   | External_in_draft
@@ -85,9 +82,6 @@ val register_tool_class : string -> tool_effect_class -> unit
     Accepted values: "read_only", "workspace", "workspace_mutating",
     "local_mutation", "external", "external_effect", "shell_dynamic". *)
 val tool_effect_class_of_string : string -> tool_effect_class option
-
-(** Backward-compatible alias for [tool_effect_class_of_string]. *)
-val mutation_class_of_string : string -> mutation_class option
 
 (** Derive a [Tool.descriptor] from the builtin registry for a given tool name.
     Returns [None] for unknown tools.


### PR DESCRIPTION
## Summary
- remove the public Mode_enforcer.mutation_class compatibility type alias
- remove Mode_enforcer.mutation_class_of_string and route descriptor parsing through tool_effect_class_of_string
- keep Tool.descriptor.mutation_class wire field unchanged while internal CDAL runtime API uses canonical tool_effect_class names

## Verification
- ocamlformat --check lib/cdal_runtime/mode_enforcer.ml lib/cdal_runtime/mode_enforcer.mli lib/cdal_runtime/contract_runner.ml
- git diff --check
- rg -n "mutation_class_of_string|type mutation_class|Backward-compatible alias for \[tool_effect_class\]" lib test  # 0 hits
- lockf -k -t 10 /tmp/me-dune-local.lock /usr/bin/env MASC_DUNE_LOCK_HELD=1 MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=5 scripts/dune-local.sh build test/test_cdal_mode_enforcer.exe  # blocked: /tmp/me-dune-local.lock already locked