### PR TITLE
docs(scripts): add audit-rfc-closeout-lag.sh — surface Draft RFCs with merged implementation commits

### DIFF
--- a/scripts/audit-rfc-closeout-lag.sh
+++ b/scripts/audit-rfc-closeout-lag.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# audit-rfc-closeout-lag.sh — Surface RFCs whose status: Draft has been
+# left behind while implementation commits already landed on origin/main.
+#
+# Background: 2026-05-21 audit found 20+ Draft RFCs whose RFC-NNNN
+# identifier appears in main commit subjects. The frontmatter status
+# update is a manual step performed by the RFC author after every
+# phase; that discipline often slips. This script makes the lag
+# observable without prescribing a fix (don't auto-flip status —
+# Active vs Implemented is a judgement call).
+#
+# Usage:
+#   bash scripts/audit-rfc-closeout-lag.sh [--since DATE] [--min N]
+#
+# Defaults: since=2026-04-01, min=1 (report any non-zero count).
+#
+# Output (TSV on stdout, sorted by descending commit count):
+#   RFC-NNNN<TAB><commits>
+#
+# Exit status: always 0 unless a tooling error occurs. The audit is
+# observational, not a gate.
+#
+# See: docs/rfc/README.md §Status, memory/feedback_rfc_closeout_lag_systemic_pattern_2026_05_21.md
+
+set -euo pipefail
+
+since="2026-04-01"
+min_commits=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --since)
+      since="$2"; shift 2 ;;
+    --min)
+      min_commits="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *)
+      echo "unknown flag: $1" >&2
+      exit 2 ;;
+  esac
+done
+
+cd "$(git rev-parse --show-toplevel)"
+
+# Capture RFC identifiers appearing in commit subjects on origin/main
+# within the window. Sort -u + while-read keeps the script grep-free
+# in the loop body.
+git log --oneline origin/main --since="$since" 2>/dev/null \
+  | grep -oE "RFC-[0-9]+" \
+  | sort -u \
+  | while read -r rfc; do
+      # Find a frontmatter file for this RFC. Multi-phase RFCs may have
+      # several files sharing the number; we only need the main spec.
+      spec=$(ls "docs/rfc/${rfc}"-*.md 2>/dev/null | head -1)
+      [[ -z "$spec" ]] && continue
+
+      # Only flag entries that are still Draft. Active and Implemented
+      # are intentional states — don't report them.
+      if ! grep -q '^status: Draft' "$spec"; then
+        continue
+      fi
+
+      # Count commit subjects that reference this RFC identifier.
+      count=$(git log --oneline origin/main --since="$since" 2>/dev/null \
+        | grep -c "${rfc}\b" || true)
+
+      if [[ "$count" -ge "$min_commits" ]]; then
+        printf "%s\t%d\n" "$rfc" "$count"
+      fi
+    done \
+  | sort -t$'\t' -k2 -n -r


### PR DESCRIPTION
## Goal

2026-05-21 audit 발견 — **20+ Draft RFC** 가 자기 RFC-NNNN 인용된 main commits 가 있는데 frontmatter \`status: Draft\` 잔존. closeout discipline 가 *RFC author self-discipline* 에만 의존. 본 PR 이 lag 를 *관찰 가능* 하게 만드는 audit 도구 추가.

## What

\`scripts/audit-rfc-closeout-lag.sh\` 신규 — Draft RFC 중 main commits 에 인용된 사이트 surface.

\`\`\`bash
bash scripts/audit-rfc-closeout-lag.sh [--since DATE] [--min N]
\`\`\`

Output: TSV (RFC-NNNN<TAB>count) sorted descending.
Exit status: always 0 — observational, not a gate.

## Sample output (이 commit 실행 시)

\`\`\`
RFC-0135  25
RFC-0131   7
RFC-0139   6
RFC-0141   4
RFC-0126   4
RFC-0153   3
RFC-0145   3
RFC-0132   3
...
\`\`\`

15 RFC closeout-lag 자동 식별.

## Why audit, not lint

frontmatter status 가 *Active* 인지 *Implemented* 인지는 *judgement call*:
- Phase count
- dead branch 제거 여부
- Sunset window (예: RFC-0154 §4 의 14-day soak)
- Phase-별 closeout commit 존재 여부

CI auto-flip 부적합 — RFC-0142 처럼 *partial* 인 경우 잘못된 Implemented 부착 위험. **audit + 수동 sweep 결정** 이 정합.

## Design

| 결정 | 이유 |
|------|------|
| TSV 출력 | grep/awk 친화, 다른 script 와 pipe 가능 |
| Default `--min 1` | 모든 lag 표시. transient 1-commit 케이스 사용자 결정 |
| Default `--since 2026-04-01` | masc-mcp 의 active 작업 window. 사용자 override 가능 |
| Exit 0 always | observational, not gate. CI 통합 시 사용자가 별도 wrapper 작성 |
| `scripts/audit-*` family 위치 | 기존 \`audit-code-smell.sh\` 와 같은 디렉토리 |

## Verification

\`\`\`bash
$ bash scripts/audit-rfc-closeout-lag.sh | head -3
RFC-0135  25
RFC-0131   7
RFC-0139   6

$ bash scripts/audit-rfc-closeout-lag.sh --min 5 | head -3
RFC-0135  25
RFC-0131   7
RFC-0139   6

$ bash scripts/audit-rfc-closeout-lag.sh --since 2026-05-20 | head -3
RFC-0153   3
RFC-0145   3
RFC-0141   3
\`\`\`

세 옵션 모두 동작.

## 자기 사례 (2026-05-20~21)

본 PR 작성 직전 24h 안 발견된 closeout-lag 사례 — 본 script 가 더 일찍 있었으면 사전 감지 가능했을 사례:

- **RFC-0148**: PR-1 (#16948) + PR-2 (#16958) 머지 → 24h Draft 잔존 → closeout #17093 (§5.1 hallucination) → follow-up #17110
- **RFC-0142**: Phase 1 부분 머지 (4 PR) → Draft 잔존 → progress audit #17114 (Draft → Active)

\`feedback_rfc_closeout_lag_systemic_pattern_2026_05_21.md\` 에 동일 audit 명령 인용 + 패턴 분석.

## Files

\`\`\`
1 file changed, 73 insertions(+)
  scripts/audit-rfc-closeout-lag.sh (new, +73)
\`\`\`

## Anti-pattern check

| 항목 | 결과 |
|------|------|
| §1 텔레메트리-as-fix | ❌ |
| §2 string/substring 분류기 추가 | ❌ |
| §3 N-of-M | ❌ |
| §4 catch-all \`_->\` | ❌ |
| §5 cap/cooldown/dedup/repair | ❌ |
| §6 test backdoor | ❌ |
| §7 같은 typo N-N fix | ❌ |

audit 도구라 fix-shape 안티패턴 모두 N/A.

## 다음 후보 (사용자 결정 영역)

본 audit 결과 기반:
- **RFC-0135 progress audit** (25 commits, 최대 lag) — 별도 PR
- 1-commit RFC 들 batch sweep — RFC 별 진행 상태 검증 필요
- CI lint wrapper — 본 script + ratchet baseline 으로 차단

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>