### PR TITLE
chore(config): drop llama runtime alias

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -168,10 +168,6 @@ module Local_runtime = struct
     | None -> Env_config_core.masc_http_base_url () ^ "/mcp"
 end
 
-(** Backward-compatible alias so existing [Env_config.Llama] references
-    continue to compile without changes. *)
-module Llama = Local_runtime
-
 module Ollama = struct
   let server_url =
     get_string ~default:Masc_network_defaults.ollama_default_url "OLLAMA_SERVER_URL"

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -98,9 +98,6 @@ module Local_runtime : sig
   val mcp_url : unit -> string
 end
 
-module Llama = Local_runtime
-(** Backward-compatible alias for {!Local_runtime}. *)
-
 module Ollama : sig
   val server_url : string
   val default_model : string

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -285,7 +285,7 @@ let llama_snapshot binding =
   let discovered_models, status, available, note =
     let endpoint =
       binding_endpoint_url binding
-      |> Option.value ~default:Env_config_runtime.Llama.server_url
+      |> Option.value ~default:Env_config_runtime.Local_runtime.server_url
     in
     match Tool_local_runtime_core.fetch_models_at endpoint with
     | Ok (_url, models) -> (models, "online", true, None)

--- a/lib/local/local_runtime_pool.ml
+++ b/lib/local/local_runtime_pool.ml
@@ -238,7 +238,7 @@ let normalize_runtime_json json =
         }
 
 let default_runtime () =
-  let base_url = Env_config.Llama.server_url in
+  let base_url = Env_config.Local_runtime.server_url in
   {
     id = runtime_id_of_base_url base_url;
     base_url;
@@ -285,7 +285,7 @@ let current_fingerprint () =
   String.concat "||"
     [
       String.concat "," (Llm_provider.Discovery.endpoints_from_env ());
-      Env_config.Llama.server_url;
+      Env_config.Local_runtime.server_url;
       Option.value ~default:"" (Env_config.Local_runtime.worker_model_opt ());
       Option.value ~default:""
         (Env_config.Worker.local_runtime_cooldown_sec_opt ());

--- a/lib/tool_local_runtime.ml
+++ b/lib/tool_local_runtime.ml
@@ -52,7 +52,7 @@ let handle_models _ctx : tool_result =
             ( "result",
               `Assoc
                 [
-                  ("server_url", `String Env_config.Llama.server_url);
+                  ("server_url", `String Env_config.Local_runtime.server_url);
                   ("endpoint", `String url);
                   ("source", `String "llama.cpp /v1/models");
                   ("models", `List (List.map (fun m -> `String m) models));

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -286,7 +286,7 @@ let run_bench ?model_id ?runtime_pool ~parallelism ~rounds ~prompt ~max_tokens
       Ok
         (`Assoc
           [
-            ("server_url", `String Env_config.Llama.server_url);
+            ("server_url", `String Env_config.Local_runtime.server_url);
             ("source", `String "oas_complete");
             ("model_id", string_opt_to_json model_id);
             ("runtime_pool", string_opt_to_json runtime_pool);

--- a/lib/tool_local_runtime_core.ml
+++ b/lib/tool_local_runtime_core.ml
@@ -216,4 +216,4 @@ let fetch_models_at base_url =
   | Unix.WSTOPPED sig_num ->
       Error (Printf.sprintf "llama models request stopped by signal %d" sig_num)
 
-let fetch_models () = fetch_models_at Env_config.Llama.server_url
+let fetch_models () = fetch_models_at Env_config.Local_runtime.server_url

--- a/lib/tool_local_runtime_core.mli
+++ b/lib/tool_local_runtime_core.mli
@@ -154,4 +154,4 @@ val fetch_models_at :
 
 val fetch_models : unit -> (string * string list, string) Result.t
 (** Convenience wrapper over {!fetch_models_at} using
-    {!Env_config.Llama.server_url} as the base URL. *)
+    {!Env_config.Local_runtime.server_url} as the base URL. *)

--- a/lib/tool_local_runtime_status.ml
+++ b/lib/tool_local_runtime_status.ml
@@ -112,10 +112,10 @@ let runtime_status_json ?(include_models = true) () =
   in
   `Assoc
     [
-      ("server_url", `String Env_config.Llama.server_url);
+      ("server_url", `String Env_config.Local_runtime.server_url);
       ("endpoint",
        `String
-         (Env_config.Llama.server_url
+         (Env_config.Local_runtime.server_url
           ^ Masc_network_defaults.openai_models_path));
       ("source", `String "llama.cpp runtime");
       ("models", `List (List.map (fun model -> `String model) models));

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -576,8 +576,8 @@ let runtime_verify_json_legacy ?runtime_pool ?expected_slots ?expected_ctx
     [
       ("checked_at", `String (Masc_domain.now_iso ()));
       ("runtime_pool", string_opt_to_json runtime_pool);
-      ("provider_base_url", `String Env_config.Llama.server_url);
-      ("slot_url", `String Env_config.Llama.server_url);
+      ("provider_base_url", `String Env_config.Local_runtime.server_url);
+      ("slot_url", `String Env_config.Local_runtime.server_url);
       ("provider_reachable", `Bool (provider_reachable && has_runtimes));
       ("slot_reachable", `Bool (slot_reachable && has_runtimes));
       ("chat_completion_compatible", `Bool true);


### PR DESCRIPTION
## Summary
- remove the Env_config_runtime.Llama / Env_config.Llama module alias
- migrate local runtime callers to Env_config.Local_runtime / Env_config_runtime.Local_runtime
- keep LLAMA_* environment variables intact as the runtime compatibility contract

## Verification
- ocamlformat --check lib/config/env_config_runtime.ml lib/config/env_config_runtime.mli lib/dashboard_provider_runs.ml lib/local/local_runtime_pool.ml lib/tool_local_runtime.ml lib/tool_local_runtime_bench.ml lib/tool_local_runtime_core.ml lib/tool_local_runtime_core.mli lib/tool_local_runtime_status.ml lib/tool_local_runtime_verify.ml
- git diff --check
- rg -n "Env_config_runtime\\.Llama|Env_config\\.Llama|module Llama = Local_runtime|Backward-compatible alias for \\{!Local_runtime\\}|existing \\[Env_config\\.Llama\\]" lib test scripts bin  # 0 hits
- lockf -k -t 10 /tmp/me-dune-local.lock /usr/bin/env MASC_DUNE_LOCK_HELD=1 MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=5 scripts/dune-local.sh build lib/masc_mcp.cmxa  # blocked: /tmp/me-dune-local.lock already locked