### PR TITLE
chore(keeper): drop proactive cooldown alias

### DIFF
--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -770,8 +770,6 @@ let effective_scheduled_autonomous_cooldown
     max floor (int_of_float (float_of_int effective_base *. factor)))
 ;;
 
-let effective_proactive_cooldown = effective_scheduled_autonomous_cooldown
-
 let entropic_oscillation_interval_sec = 600
 let entropic_oscillation_probability_percent = 5
 

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -275,11 +275,6 @@ val effective_scheduled_autonomous_cooldown :
   base_cooldown:int -> since_last:int ->
   ?consecutive_noop_count:int -> unit -> int
 
-(** Backward-compatible alias for the pre-rename helper name. *)
-val effective_proactive_cooldown :
-  base_cooldown:int -> since_last:int ->
-  ?consecutive_noop_count:int -> unit -> int
-
 val provider_cooldown_remaining_sec_for_cascade :
   cascade_name:Keeper_cascade_profile.runtime_name -> int option
 


### PR DESCRIPTION
## Summary
- remove the unused Keeper_world_observation.effective_proactive_cooldown compatibility alias
- keep effective_scheduled_autonomous_cooldown as the single exported helper name

## Verification
- ocamlformat --check lib/keeper/keeper_world_observation.ml lib/keeper/keeper_world_observation.mli
- git diff --check
- rg -n "effective_proactive_cooldown|pre-rename helper name" lib test scripts bin  # 0 hits
- lockf -k -t 10 /tmp/me-dune-local.lock /usr/bin/env MASC_DUNE_LOCK_HELD=1 MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=5 scripts/dune-local.sh build lib/masc_mcp.cmxa  # blocked: /tmp/me-dune-local.lock already locked