### PR TITLE
refactor(server_dashboard_http_core): extract cache + timeout + diagnostics helpers into sibling (step 20)

### DIFF
--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -57,88 +57,21 @@ include Dashboard_http_helpers
 include Dashboard_http_monitoring
 include Dashboard_http_keeper
 
-let dashboard_request_timeout_s = 30.0
-
-(** Track whether shell cache has been populated at least once.
-    Atomic.t for cross-domain visibility: read from executor pool
-    worker domains via namespace-truth and warmup helpers. *)
-let shell_warmed : bool Atomic.t = Atomic.make false
-let _shell_warmed = shell_warmed
-
-(** Track whether the startup shell pre-warm fiber is still building the
-    first payload. Cold HTTP requests use this to serve a bootstrap payload
-    instead of blocking on the same expensive shell projection. *)
-let shell_warming : bool Atomic.t = Atomic.make false
-let _shell_warming = shell_warming
-
-(** Last-known-good shell result for graceful degradation on timeout. *)
-let last_good_shell : Yojson.Safe.t Atomic.t = Atomic.make (`Assoc [])
-let _last_good_shell = last_good_shell
-
-(** Wrap a dashboard computation with a configurable timeout.
-    Returns a partial-response JSON on timeout instead of hanging. *)
-let with_dashboard_timeout ~clock compute =
-  match
-    Eio.Time.with_timeout clock dashboard_request_timeout_s (fun () -> Ok (compute ()))
-  with
-  | Ok v -> v
-  | Error `Timeout ->
-    `Assoc
-      [ "error", `String "timeout"
-      ; "partial", `Bool true
-      ; ( "message"
-        , `String
-            (Printf.sprintf
-               "Dashboard computation timed out after %.0fs."
-               dashboard_request_timeout_s) )
-      ; "generated_at", `String (Masc_domain.now_iso ())
-      ]
-;;
-
-let cache_partition_segment (_config : Coord.config) = "default"
-
-let dashboard_cache_key (config : Coord.config) prefix suffix =
-  Printf.sprintf
-    "%s:%s:%s:%s"
-    prefix
-    config.base_path
-    (cache_partition_segment config)
-    suffix
-;;
-
-let dashboard_mission_timeout_s = Env_config_runtime.Dashboard.mission_timeout_sec
-
-let attach_projection_diagnostics json diagnostics =
-  match json with
-  | `Assoc fields -> `Assoc (("projection_diagnostics", diagnostics) :: fields)
-  | other -> other
-;;
-
-let projection_diagnostics_json ~surface ~started_at ~extra json =
-  let build_ms = int_of_float ((Unix.gettimeofday () -. started_at) *. 1000.0) in
-  let payload_bytes = String.length (Yojson.Safe.to_string json) in
-  `Assoc
-    ([ "surface", `String surface
-     ; "build_ms", `Int build_ms
-     ; "payload_bytes", `Int payload_bytes
-     ; "generated_at", `String (Masc_domain.now_iso ())
-     ]
-     @ extra)
-;;
-
-let with_projection_diagnostics ~surface ~started_at ~extra json =
-  attach_projection_diagnostics
-    json
-    (projection_diagnostics_json ~surface ~started_at ~extra json)
-;;
-
-let initialized_json_opt ?(allow_initializing = false) = function
-  | `Assoc fields as json ->
-    (match List.assoc_opt "status" fields with
-     | Some (`String "initializing") when not allow_initializing -> None
-     | _ -> Some json)
-  | _ -> None
-;;
+let dashboard_request_timeout_s = Server_dashboard_http_core_cache.dashboard_request_timeout_s
+let shell_warmed = Server_dashboard_http_core_cache.shell_warmed
+let _shell_warmed = Server_dashboard_http_core_cache._shell_warmed
+let shell_warming = Server_dashboard_http_core_cache.shell_warming
+let _shell_warming = Server_dashboard_http_core_cache._shell_warming
+let last_good_shell = Server_dashboard_http_core_cache.last_good_shell
+let _last_good_shell = Server_dashboard_http_core_cache._last_good_shell
+let with_dashboard_timeout = Server_dashboard_http_core_cache.with_dashboard_timeout
+let cache_partition_segment = Server_dashboard_http_core_cache.cache_partition_segment
+let dashboard_cache_key = Server_dashboard_http_core_cache.dashboard_cache_key
+let dashboard_mission_timeout_s = Server_dashboard_http_core_cache.dashboard_mission_timeout_s
+let attach_projection_diagnostics = Server_dashboard_http_core_cache.attach_projection_diagnostics
+let projection_diagnostics_json = Server_dashboard_http_core_cache.projection_diagnostics_json
+let with_projection_diagnostics = Server_dashboard_http_core_cache.with_projection_diagnostics
+let initialized_json_opt = Server_dashboard_http_core_cache.initialized_json_opt
 
 let dashboard_batch_json ?(compact = false) (config : Coord.config) : Yojson.Safe.t =
   let room_state = Coord.read_state config in

--- a/lib/server/server_dashboard_http_core_cache.ml
+++ b/lib/server/server_dashboard_http_core_cache.ml
@@ -1,0 +1,89 @@
+(** Cache key + timeout + projection-diagnostics helpers for dashboard
+    HTTP core, extracted from server_dashboard_http_core.ml.
+
+    Pure helpers + a few atomic shell-warmup state cells.  Atomic state
+    is initialised once on sibling load — observably identical to the
+    pre-extraction top-level lets. *)
+
+let dashboard_request_timeout_s = 30.0
+
+(** Track whether shell cache has been populated at least once.
+    Atomic.t for cross-domain visibility: read from executor pool
+    worker domains via namespace-truth and warmup helpers. *)
+let shell_warmed : bool Atomic.t = Atomic.make false
+let _shell_warmed = shell_warmed
+
+(** Track whether the startup shell pre-warm fiber is still building the
+    first payload. Cold HTTP requests use this to serve a bootstrap payload
+    instead of blocking on the same expensive shell projection. *)
+let shell_warming : bool Atomic.t = Atomic.make false
+let _shell_warming = shell_warming
+
+(** Last-known-good shell result for graceful degradation on timeout. *)
+let last_good_shell : Yojson.Safe.t Atomic.t = Atomic.make (`Assoc [])
+let _last_good_shell = last_good_shell
+
+(** Wrap a dashboard computation with a configurable timeout.
+    Returns a partial-response JSON on timeout instead of hanging. *)
+let with_dashboard_timeout ~clock compute =
+  match
+    Eio.Time.with_timeout clock dashboard_request_timeout_s (fun () -> Ok (compute ()))
+  with
+  | Ok v -> v
+  | Error `Timeout ->
+    `Assoc
+      [ "error", `String "timeout"
+      ; "partial", `Bool true
+      ; ( "message"
+        , `String
+            (Printf.sprintf
+               "Dashboard computation timed out after %.0fs."
+               dashboard_request_timeout_s) )
+      ; "generated_at", `String (Masc_domain.now_iso ())
+      ]
+;;
+
+let cache_partition_segment (_config : Coord.config) = "default"
+
+let dashboard_cache_key (config : Coord.config) prefix suffix =
+  Printf.sprintf
+    "%s:%s:%s:%s"
+    prefix
+    config.base_path
+    (cache_partition_segment config)
+    suffix
+;;
+
+let dashboard_mission_timeout_s = Env_config_runtime.Dashboard.mission_timeout_sec
+
+let attach_projection_diagnostics json diagnostics =
+  match json with
+  | `Assoc fields -> `Assoc (("projection_diagnostics", diagnostics) :: fields)
+  | other -> other
+;;
+
+let projection_diagnostics_json ~surface ~started_at ~extra json =
+  let build_ms = int_of_float ((Unix.gettimeofday () -. started_at) *. 1000.0) in
+  let payload_bytes = String.length (Yojson.Safe.to_string json) in
+  `Assoc
+    ([ "surface", `String surface
+     ; "build_ms", `Int build_ms
+     ; "payload_bytes", `Int payload_bytes
+     ; "generated_at", `String (Masc_domain.now_iso ())
+     ]
+     @ extra)
+;;
+
+let with_projection_diagnostics ~surface ~started_at ~extra json =
+  attach_projection_diagnostics
+    json
+    (projection_diagnostics_json ~surface ~started_at ~extra json)
+;;
+
+let initialized_json_opt ?(allow_initializing = false) = function
+  | `Assoc fields as json ->
+    (match List.assoc_opt "status" fields with
+     | Some (`String "initializing") when not allow_initializing -> None
+     | _ -> Some json)
+  | _ -> None
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` step 20 (Dashboard core surface split)
- `server_dashboard_http_core.ml` is 1815 LOC. Carved out cache + timeout + projection-diagnostics helpers (82 LOC, 15 bindings) into a sibling.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/server/server_dashboard_http_core.ml` | 1815 | 1748 | **-67** |
| `lib/server/server_dashboard_http_core_cache.ml` | — | 89 | +89 |

## Moved (verbatim, no behavior change)
- `dashboard_request_timeout_s` constant
- 3 atomic shell-warmup cells (`shell_warmed`, `shell_warming`, `last_good_shell`) + their `_underscore` re-bindings
- `with_dashboard_timeout`
- `cache_partition_segment`, `dashboard_cache_key`
- `dashboard_mission_timeout_s` (env-derived)
- `attach_projection_diagnostics`, `projection_diagnostics_json`, `with_projection_diagnostics`
- `initialized_json_opt`

15 bindings total via single-line aliases in parent.

## Module-init discipline
The 3 atomic cells (`Atomic.make`) are initialised once when the sibling loads — observably identical to the pre-extraction top-level `let` because parent's alias points to the same atomic reference.

## Verification
- `bash scripts/lint/godfile-size-regression.sh`: clean
- `dune build --root . lib/masc_mcp.cmxa`: exit 0

## Constraints honored
- No new string match arms (anti-pattern §2)
- No silent default
- No magic-number extraction (`30.0` timeout literal stays verbatim)
- Flat `masc_mcp` namespace, no sub-library

## RFC-WAIVED
Extract-only sibling refactor, no behavior change, governed by `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` step 20.

Co-Authored-By: codex <noreply@anthropic.com>
