### PR TITLE
fix(keeper): purge legacy slot-full capacity signal

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -895,7 +895,7 @@ let emit_sdk_provider_error_metric ~cascade_name ~provider err =
    semantics ("the 429 still happened, so cool down at least the
    default") are maintained centrally. *)
 (* [Provider.CapacityExhausted] is a typed signal that the provider rejected
-   the request for capacity reasons (slot full, model overloaded, region
+   the request for capacity reasons (capacity full, model overloaded, region
    throttled). One event is enough evidence to deprioritize the provider
    for the rest of the cycle — the same logic that justifies
    [sdk_error_soft_rate_limited]'s immediate-cooldown handling (see

--- a/lib/cascade/cascade_client_capacity.mli
+++ b/lib/cascade/cascade_client_capacity.mli
@@ -12,12 +12,12 @@
 
     The counter is maintained by explicit [try_acquire] / release
     pairs at the cascade call site.  No timeout, no queueing, no
-    blocking — if no slot is free, [try_acquire] returns [None] and
+    blocking — if no permit is free, [try_acquire] returns [None] and
     the strategy's capacity filter will have already skipped this
     endpoint in its ordering.  Defense-in-depth: both the filter and
     the acquire check the same counter, so a race between filter and
-    acquire simply yields a [None] that the cascade treats as
-    [Slot_full] and tries the next candidate.
+    acquire simply yields a [None] that the cascade treats as typed
+    capacity backpressure before trying the next candidate.
 
     @since 0.9.6 *)
 
@@ -113,9 +113,9 @@ val try_acquire : string -> release option
     explicit control flow).  Returns [None] when:
     - [url] is not registered → unlimited, no counter maintained
       (caller should treat [None] as "no client cap, go ahead");
-    - [url] is registered and [process_available = 0] → slot full,
-      caller should treat [None] as [Slot_full] and try another
-      candidate.
+    - [url] is registered and [process_available = 0] → client capacity
+      unavailable; caller should treat [None] as typed backpressure and
+      try another candidate.
 
     Disambiguate these two [None] cases via {!capacity}: if
     [capacity url = None] the URL is unregistered; otherwise it is

--- a/lib/cascade/cascade_client_capacity_history.mli
+++ b/lib/cascade/cascade_client_capacity_history.mli
@@ -4,7 +4,7 @@
     Phase A ({!Cascade_client_capacity}) introduced the process-local
     semaphore.  Phase D ({!Dashboard_cascade.client_capacity_json})
     exposed the *current* snapshot.  Operators still could not answer
-    "how often was the HTTP-probe slot full in the last hour?" — this
+    "how often was HTTP-probe capacity full in the last hour?" — this
     module fills that gap by recording every transition and surfacing
     recent events via {!snapshot}.
 
@@ -24,7 +24,7 @@
     @since 0.9.9 *)
 
 (** Event kind surfaced to the dashboard.  [Acquired] / [Released] are
-    self-explanatory; [Rejected_full] captures the "slot full, caller
+    self-explanatory; [Rejected_full] captures the "capacity full, caller
     moved on to the next candidate" case that operators use as the
     saturation signal. *)
 type event_kind = Acquired | Released | Rejected_full

--- a/lib/cascade/cascade_fsm.ml
+++ b/lib/cascade/cascade_fsm.ml
@@ -9,7 +9,6 @@ type provider_outcome =
   | Call_err of Llm_provider.Http_client.http_error [@tla.symbol "call_err"]
   | Accept_rejected of { response : Llm_provider.Types.api_response; reason : string }
       [@tla.symbol "accept_rejected"]
-  | Slot_full [@tla.symbol "slot_full"]
 [@@deriving tla]
 
 type decision =
@@ -26,17 +25,6 @@ let decide ~accept_on_exhaustion ~is_last outcome =
   match outcome with
   | Call_ok resp ->
     Accept resp
-  | Slot_full ->
-    Try_next
-      {
-        last_err =
-          Some
-            (Llm_provider.Http_client.NetworkError
-               {
-                 message = "slot full, cascading to next provider";
-                 kind = Llm_provider.Http_client.Local_resource_exhaustion;
-               });
-      }
   | Accept_rejected { response; reason } ->
     if is_last && accept_on_exhaustion then
       Accept_on_exhaustion { response; reason }
@@ -100,7 +88,6 @@ let provider_outcome_to_string = function
   | Call_ok _ -> "call-ok"
   | Call_err _ -> "call-err"
   | Accept_rejected _ -> "accept-rejected"
-  | Slot_full -> "slot-full"
 
 let provider_outcome_option_to_string = function
   | Some outcome -> "some-" ^ provider_outcome_to_string outcome
@@ -122,7 +109,6 @@ let decide_and_record ~cascade_name ~accept_on_exhaustion ~is_last outcome =
    | Try_next _ ->
        let reason =
          match outcome with
-         | Slot_full -> "slot_full"
          | Accept_rejected _ -> "accept_rejected"
          | Call_err err ->
              if Cascade_health_filter.should_cascade_to_next err then

--- a/lib/cascade/cascade_fsm.mli
+++ b/lib/cascade/cascade_fsm.mli
@@ -17,7 +17,6 @@ type provider_outcome =
   | Call_err of Llm_provider.Http_client.http_error [@tla.symbol "call_err"]
   | Accept_rejected of { response : Llm_provider.Types.api_response; reason : string }
       [@tla.symbol "accept_rejected"]
-  | Slot_full [@tla.symbol "slot_full"]
 [@@deriving tla]
 
 (** {1 Cascade decision — what to do next} *)
@@ -51,8 +50,7 @@ val decide :
     - [Accept_rejected _] on last + not exhaustion → [Exhausted]
     - [Accept_rejected _] on non-last → [Try_next]
     - [Call_err _] on cascadeable error → [Try_next]
-    - [Call_err _] on non-cascadeable error → [Exhausted]
-    - [Slot_full] → [Try_next] *)
+    - [Call_err _] on non-cascadeable error → [Exhausted] *)
 
 val decide_and_record :
   cascade_name:string ->
@@ -82,7 +80,7 @@ val format_exhausted_error :
 
 val provider_outcome_to_string : provider_outcome -> string
 (** Short label for a provider outcome: ["call-ok"], ["call-err"],
-    ["accept-rejected"], ["slot-full"]. *)
+    ["accept-rejected"]. *)
 
 val provider_outcome_option_to_string : provider_outcome option -> string
 (** Same as [provider_outcome_to_string] wrapped with ["some-"] or ["none"].

--- a/lib/cascade/cascade_strategy_trace.mli
+++ b/lib/cascade/cascade_strategy_trace.mli
@@ -29,7 +29,7 @@
     - [Ordered]: strategy returned a non-empty candidate list; the caller
       proceeded with the FSM.
     - [Filtered_empty]: strategy filtered every candidate (e.g. every
-      provider in cooldown or slot-full); caller will backoff + retry.
+      provider in cooldown or capacity backpressure); caller will backoff + retry.
     - [Exhausted]: [Filtered_empty] on the last cycle, so the cascade
       gave up and returned the exhaustion error. *)
 type event_kind = Ordered | Filtered_empty | Exhausted

--- a/lib/dashboard_cascade.mli
+++ b/lib/dashboard_cascade.mli
@@ -354,7 +354,7 @@ val declared_provider_schemes_of_config : ?config_path:string -> unit -> string 
 val client_capacity_json : unit -> Yojson.Safe.t
 
 (** JSON snapshot of the {!Cascade_client_capacity_history} ring
-    buffer — per-event transitions (acquire / release / slot-full
+    buffer — per-event transitions (acquire / release / capacity-full
     rejection) recorded by the client-capacity semaphore.
 
     Complements {!client_capacity_json}: that one answers "how full

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -175,8 +175,7 @@ let is_required_tool_contract_violation (err : Agent_sdk.Error.sdk_error) : bool
 
 let message_looks_like_capacity_backpressure detail =
   let lower = String.lowercase_ascii detail in
-  string_contains_substring ~needle:"slot full" lower
-  || string_contains_substring ~needle:"client capacity" lower
+  string_contains_substring ~needle:"client capacity" lower
   || string_contains_substring ~needle:"capacity_exhausted" lower
   || string_contains_substring ~needle:"capacity exhausted" lower
   || string_contains_substring ~needle:"local_resource_exhaustion" lower

--- a/lib/keeper/keeper_failure_policy.ml
+++ b/lib/keeper/keeper_failure_policy.ml
@@ -111,8 +111,8 @@ let timeout_phase_of_label label =
     | "caller_budget" -> Some Caller_budget
     | "wall_clock" | "wall_clock_timeout" | "wall_exceeded" | "max_execution_time" ->
       Some Wall_clock
-    | "capacity_backpressure" | "capacity_exhausted" | "slot_full"
-    | "client_capacity" | "client_capacity_full" ->
+    | "capacity_backpressure" | "capacity_exhausted" | "client_capacity"
+    | "client_capacity_full" ->
       Some Capacity_backpressure
     | "unknown_timeout" -> Some Unknown_timeout
     | _ -> None

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -157,6 +157,21 @@ let blocker_class_of_string (reason : string) : blocker_class option =
   let trimmed = String.trim reason in
   if trimmed = ""
   then None
+  else if
+    String_util.contains_substring_ci trimmed "capacity_exhausted"
+    || String_util.contains_substring_ci trimmed "capacity exhausted"
+    || String_util.contains_substring_ci trimmed "capacity_backpressure"
+    || String_util.contains_substring_ci trimmed "client capacity"
+  then Some Capacity_exhausted
+  else if
+    String_util.contains_substring_ci
+      trimmed
+      "turn outcome ambiguous after committed mutating tool call(s)"
+  then
+    Some
+      (if String_util.contains_substring_ci trimmed "turn wall-clock timeout"
+       then Ambiguous_post_commit_timeout
+       else Ambiguous_post_commit_failure)
   else if String_util.contains_substring_ci trimmed "cascade_exhausted"
   then (
     let reason =
@@ -174,22 +189,6 @@ let blocker_class_of_string (reason : string) : blocker_class option =
       else Other_detail trimmed
     in
     Some (Cascade_exhausted reason))
-  else if
-    String_util.contains_substring_ci trimmed "capacity_exhausted"
-    || String_util.contains_substring_ci trimmed "capacity exhausted"
-    || String_util.contains_substring_ci trimmed "capacity_backpressure"
-    || String_util.contains_substring_ci trimmed "slot full"
-    || String_util.contains_substring_ci trimmed "client capacity"
-  then Some Capacity_exhausted
-  else if
-    String_util.contains_substring_ci
-      trimmed
-      "turn outcome ambiguous after committed mutating tool call(s)"
-  then
-    Some
-      (if String_util.contains_substring_ci trimmed "turn wall-clock timeout"
-       then Ambiguous_post_commit_timeout
-       else Ambiguous_post_commit_failure)
   else if String_util.contains_substring_ci trimmed "admission queue wait timeout"
   then Some Admission_queue_wait_timeout
   else if String_util.contains_substring_ci trimmed "autonomous turn slot wait timeout"

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -781,23 +781,6 @@ let run_named
       ~decision:(cascade_tier_admission_blocked_decision signal)
       Keeper_runtime_manifest.Pre_dispatch_blocked
   in
-  let slot_full_last_err ~is_last last_err =
-    match
-      Cascade_fsm.decide
-        ~accept_on_exhaustion:false
-        ~is_last
-        Cascade_fsm.Slot_full
-    with
-    | Cascade_fsm.Try_next { last_err = Some err }
-    | Cascade_fsm.Exhausted { last_err = Some err } ->
-      Some err
-    | Cascade_fsm.Try_next { last_err = None }
-    | Cascade_fsm.Exhausted { last_err = None } ->
-      last_err
-    | Cascade_fsm.Accept _
-    | Cascade_fsm.Accept_on_exhaustion _ ->
-      last_err
-  in
   let capacity_backpressure_source_of_http_error = function
     | Llm_provider.Http_client.NetworkError
         { kind = Llm_provider.Http_client.Local_resource_exhaustion; _ } ->
@@ -858,6 +841,18 @@ let run_named
     | None ->
       None
   in
+  let capacity_backpressure_of_pending = function
+    | Some (source, detail, retry_after_sec) ->
+      Some
+        (Capacity_backpressure
+           {
+             cascade_name = error_cascade_name;
+             source;
+             detail;
+             retry_after_sec;
+           })
+    | None -> None
+  in
   let capacity_backpressure_of_sdk_error sdk_err =
     match sdk_err with
     | Agent_sdk.Error.Provider
@@ -886,7 +881,7 @@ let run_named
   let rec try_cascade
       ?(on_success = fun ~provider_key:_ -> ())
       ?resume_checkpoint ?per_provider_timeout_s ?last_capacity_source
-      remaining last_err =
+      ?last_capacity_backpressure remaining last_err =
     match remaining with
     | [] ->
       let reason : Keeper_types.cascade_exhaustion_reason = match last_err with
@@ -966,8 +961,14 @@ let run_named
                  })
         | _ ->
           (match
-             capacity_backpressure_of_http_error
-               ?source:last_capacity_source last_err
+             match
+               capacity_backpressure_of_http_error
+                 ?source:last_capacity_source last_err
+             with
+             | Some _ as capacity_error -> capacity_error
+             | None ->
+               capacity_backpressure_of_pending
+                 last_capacity_backpressure
            with
            | Some capacity_error ->
              sdk_error_of_masc_internal_error capacity_error
@@ -999,10 +1000,10 @@ let run_named
               "cascade %s: skipping %s (provider_key=%s cooldown: %s)"
               cascade_name runtime_candidate_label runtime_candidate_label msg;
             try_cascade ~on_success ?resume_checkpoint ?per_provider_timeout_s
-              ?last_capacity_source rest last_err
+              ?last_capacity_source ?last_capacity_backpressure rest last_err
         | None ->
             try_cascade ~on_success ?resume_checkpoint ?per_provider_timeout_s
-              ?last_capacity_source rest last_err)
+              ?last_capacity_source ?last_capacity_backpressure rest last_err)
       else (
       (match health_cooldown with
        | Some (_blocked_health_key, msg) ->
@@ -1015,7 +1016,7 @@ let run_named
       match acquire_client_capacity_slot candidate with
       | `Full capacity_key ->
         emit_capacity_blocked_manifest ~capacity_key;
-        record_cascade_attempt candidate ~outcome:(`Failure "slot_full") ();
+        record_cascade_attempt candidate ~outcome:(`Failure "client_capacity_full") ();
         Cascade_legacy_runner.record_fallback_event capture
           ~from_model:runtime_candidate_label
           ~to_model:runtime_candidate_label
@@ -1026,9 +1027,13 @@ let run_named
           cascade_name
           runtime_candidate_label
           capacity_key;
-        let slot_last_err = slot_full_last_err ~is_last last_err in
+        let capacity_detail =
+          Printf.sprintf "client capacity key %s is full" capacity_key
+        in
         try_cascade ~on_success ?resume_checkpoint ?per_provider_timeout_s
-          ~last_capacity_source:Client_capacity rest slot_last_err
+          ~last_capacity_backpressure:
+            (Client_capacity, capacity_detail, None)
+          rest last_err
       | (`No_client_capacity | `Acquired _) as capacity_slot ->
       let capacity_release =
         match capacity_slot with
@@ -1187,9 +1192,13 @@ let run_named
           cascade_name
           runtime_candidate_label
           tier_admission_id;
-        let slot_last_err = slot_full_last_err ~is_last last_err in
+        let capacity_detail =
+          Printf.sprintf "tier admission %s is full" tier_admission_id
+        in
         try_cascade ~on_success ?resume_checkpoint ?per_provider_timeout_s
-          ~last_capacity_source:Tier_admission rest slot_last_err
+          ~last_capacity_backpressure:
+            (Tier_admission, capacity_detail, None)
+          rest last_err
       | Ok (result, checkpoint_after, liveness_success_sample, attempt_latency_ms) ->
       let record_accepted_liveness_sample () =
         match liveness_success_sample with
@@ -1388,8 +1397,7 @@ let run_named
                     [Cascade_fsm.provider_outcome] is flagged at compile time
                     instead of silently mapping to [None]. *)
                  | Cascade_fsm.Call_ok _
-                 | Cascade_fsm.Accept_rejected _
-                 | Cascade_fsm.Slot_full -> None
+                 | Cascade_fsm.Accept_rejected _ -> None
                in
                Cascade_fsm.Exhausted { last_err }
              else

--- a/lib/prometheus_builtin_metrics_part2.ml
+++ b/lib/prometheus_builtin_metrics_part2.ml
@@ -121,7 +121,7 @@ let register
   add
     metric_cascade_fallbacks
     "Total cascade fallback events, labeled by \
-     reason=call_err|slot_full|accept_rejected|health_filter"
+     reason=call_err|accept_rejected|health_filter"
     `Counter;
   add
     metric_cascade_providers_exhausted

--- a/lib/prometheus_cascade_metric_names.mli
+++ b/lib/prometheus_cascade_metric_names.mli
@@ -45,7 +45,7 @@ val metric_cascade_provider_health_score : string
 val metric_cascade_decisions : string
 
 (** Counter: cascade fallback transitions ([Try_next] outcomes).
-    Labels: [reason] in [call_err|slot_full|accept_rejected|health_filter]. *)
+    Labels: [reason] in [call_err|accept_rejected|health_filter]. *)
 val metric_cascade_fallbacks : string
 
 (** Counter: terminal exhaustion events emitted when a cascade has no further

--- a/test/test_cascade_capacity_exhausted_cooldown.ml
+++ b/test/test_cascade_capacity_exhausted_cooldown.ml
@@ -4,9 +4,9 @@
 
     Without this helper, [Capacity_exhausted] events fall through to
     [record_failure] (threshold-based) instead of [record_soft_rate_limited]
-    (immediate). One slot-full event is sufficient evidence to deprioritize
-    a provider — the same reasoning [Cascade_health_tracker.soft_rate_limit_cooldown_sec]
-    documents for a 429.
+    (immediate). One capacity-exhausted event is sufficient evidence to
+    deprioritize a provider — the same reasoning
+    [Cascade_health_tracker.soft_rate_limit_cooldown_sec] documents for a 429.
 
     Closes §6 R2 (admission pre-check wiring) from the 2026-05-20
     consolidated state report. *)
@@ -23,7 +23,7 @@ let extract_testable =
   Alcotest.testable pp_extract ( = )
 
 let mk_capacity_exhausted ?retry_after ?(scope = Llm_provider.Error.CapacityProvider)
-    ?(affected = []) ?(detail = "slot full") () : ErrSdk.sdk_error =
+    ?(affected = []) ?(detail = "capacity exhausted") () : ErrSdk.sdk_error =
   ErrSdk.Provider
     (Llm_provider.Error.CapacityExhausted
        { scope; affected; retry_after; detail })

--- a/test/test_keeper_blocker_class_completion_contract.ml
+++ b/test/test_keeper_blocker_class_completion_contract.ml
@@ -100,6 +100,13 @@ let test_turn_livelock_text_maps () =
       fail ("turn livelock mapped to " ^ KT.blocker_class_to_string other)
   | None -> fail "turn livelock returned None"
 
+let test_capacity_backpressure_text_maps () =
+  check_capacity_class
+    "capacity-exhausted text"
+    (B.blocker_class_of_string
+       "Internal error: [masc_oas_error] {\"kind\":\"capacity_exhausted\",\
+        \"detail\":\"client capacity key glm is full\"}")
+
 let test_legacy_cascade_slot_full_text_stays_cascade_exhausted () =
   check_cascade_class
     "legacy cascade slot-full text"
@@ -130,7 +137,6 @@ let test_capacity_backpressure_runtime_surface_preserves_legacy_cascade_class ()
   in
   check string "runtime blocker class" "cascade_exhausted"
     surface.blocker_class
-
 let () =
   run "keeper_blocker_class_completion_contract"
     [
@@ -157,6 +163,8 @@ let () =
           test_case "turn livelock text maps" `Quick test_turn_livelock_text_maps;
           test_case "legacy cascade slot-full text stays cascade_exhausted" `Quick
             test_legacy_cascade_slot_full_text_stays_cascade_exhausted;
+          test_case "capacity backpressure text maps" `Quick
+            test_capacity_backpressure_text_maps;
           test_case "capacity backpressure SDK error maps" `Quick
             test_capacity_backpressure_sdk_error_maps;
           test_case "capacity backpressure runtime surface preserves legacy cascade class" `Quick

--- a/test/test_keeper_cascade_tla_mirror.ml
+++ b/test/test_keeper_cascade_tla_mirror.ml
@@ -4,14 +4,10 @@ let test_provider_outcome_ppx_tla () =
   let open Masc_mcp.Cascade_fsm in
   Alcotest.(check (list string))
     "all_symbols provider_outcome"
-    ["call_ok"; "call_err"; "accept_rejected"; "slot_full"]
+    ["call_ok"; "call_err"; "accept_rejected"]
     all_symbols;
-  Alcotest.(check string) "Slot_full symbol" "slot_full"
-    (to_tla_symbol Slot_full);
   Alcotest.(check bool) "Call_ok is not terminal (no @tla.terminal)" false
-    (is_terminal (Call_ok (Obj.magic ())));
-  Alcotest.(check bool) "Slot_full is not terminal (no @tla.terminal)" false
-    (is_terminal Slot_full)
+    (is_terminal (Call_ok (Obj.magic ())))
 ;;
 
 let test_decide_call_ok () =
@@ -22,16 +18,6 @@ let test_decide_call_ok () =
   match d with
   | Masc_mcp.Cascade_fsm.Accept _ -> ()
   | _ -> Alcotest.fail "Call_ok must map to Accept"
-;;
-
-let test_decide_slot_full () =
-  let d =
-    Masc_mcp.Cascade_fsm.decide ~accept_on_exhaustion:false ~is_last:false
-      Slot_full
-  in
-  match d with
-  | Masc_mcp.Cascade_fsm.Try_next _ -> ()
-  | _ -> Alcotest.fail "Slot_full must map to Try_next"
 ;;
 
 let test_decide_accept_rejected () =
@@ -101,7 +87,6 @@ let () =
         ] )
     ; ( "decide"
       , [ Alcotest.test_case "Call_ok" `Quick test_decide_call_ok
-        ; Alcotest.test_case "Slot_full" `Quick test_decide_slot_full
         ; Alcotest.test_case "Accept_rejected" `Quick test_decide_accept_rejected
         ; Alcotest.test_case "Call_err" `Quick test_decide_call_err
         ] )

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -69,10 +69,6 @@ let test_slot_full_other_detail_stays_legacy_cascade_exhausted () =
     make_cascade_exhausted
       (KT.Other_detail "slot full, cascading to next provider")
   in
-  check bool "slot full is auto-recoverable" true
-    (KEC.is_auto_recoverable_turn_error err);
-  check bool "legacy slot full remains cascade_exhausted" true
-    (KEC.is_cascade_exhausted_error err);
   match KEC.recoverable_cascade_failure_reason err with
   | Some reason ->
     check string "legacy slot full -> cascade_exhausted" "cascade_exhausted"

--- a/test/test_keeper_failure_policy.ml
+++ b/test/test_keeper_failure_policy.ml
@@ -51,7 +51,6 @@ let test_operational_timeout_phase_aliases () =
       "stream_idle", Policy.Stream_idle Policy.Streaming_unknown;
       "max_execution_time", Policy.Wall_clock;
       "capacity_exhausted", Policy.Capacity_backpressure;
-      "slot-full", Policy.Capacity_backpressure;
     ]
   in
   List.iter

--- a/test/test_keeper_ocaml_tla_correspondence.ml
+++ b/test/test_keeper_ocaml_tla_correspondence.ml
@@ -108,8 +108,7 @@ let test_provider_outcomes_parity () =
       "call_err_cascadeable";
       "call_err_terminal";
       "call_err_hard_quota";
-      "accept_rejected";
-      "slot_full" ]
+      "accept_rejected" ]
   in
   let covered o =
     if o = "call_err" then
@@ -192,13 +191,6 @@ let test_accept_rejected_on_last_maps_to_exhausted () =
         "B1 ResolveExhaustedNormal: OCaml decide(Accept_rejected, \
          is_last=true, accept_on_exhaustion=false) must yield \
          Exhausted (correspondence broken)"
-
-let test_slot_full_maps_to_try_next () =
-  (* B1 covers Slot_full under the same Try_next path. *)
-  let open Masc_mcp.Cascade_fsm in
-  match decide ~accept_on_exhaustion:false ~is_last:false Slot_full with
-  | Try_next _ -> ()
-  | _ -> Alcotest.fail "Slot_full must yield Try_next"
 
 let test_accept_on_exhaustion_terminal () =
   (* B1 has no explicit "accept_on_exhaustion" phase — it is folded
@@ -354,8 +346,6 @@ let () =
         test_call_err_cascadeable_maps_to_try_next;
       test_case "Accept_rejected on last tier → Exhausted (B1.ResolveExhaustedNormal — direct decide path)" `Quick
         test_accept_rejected_on_last_maps_to_exhausted;
-      test_case "Slot_full → Try_next" `Quick
-        test_slot_full_maps_to_try_next;
       test_case "Accept_on_exhaustion → terminal success" `Quick
         test_accept_on_exhaustion_terminal;
     ];

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -108,7 +108,7 @@ let test_strike_limit_routes_through_policy_without_keeper_death () =
       decision.reason
 
 let test_capacity_phase_routes_to_provider_tuning () =
-  let err = oas_timeout_budget_error ~phase:"slot_full" in
+  let err = oas_timeout_budget_error ~phase:"capacity_backpressure" in
   match KH.oas_timeout_budget_policy_decision ~strikes:1 err with
   | None -> Alcotest.fail "expected OAS timeout budget policy decision"
   | Some decision ->


### PR DESCRIPTION
## Summary
- remove the legacy `Cascade_fsm.Slot_full` provider outcome and its `slot full, cascading to next provider` terminal error path
- keep client/tier capacity saturation as typed `capacity_backpressure` instead of cascade exhaustion
- stop string classifiers and timeout aliases from treating legacy `slot_full` text as current capacity state
- update TLA parity and policy tests to reflect the smaller provider-outcome alphabet

## Verification
- `ocamlformat --check ...`
- `git diff --check origin/main...HEAD`
- `rg -n "Slot_full|slot_full|slot-full|slot full" lib --glob "!_build/**"`
- `env MASC_DUNE_THROTTLE=0 MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_OPAM_LOCK=1 MASC_SKIP_PIN_CHECK=1 MASC_SKIP_DEPS_CHECK=1 MASC_SKIP_OCAML_VERSION_CHECK=1 DUNE_LOCAL_JOBS=2 scripts/dune-local.sh build test/test_keeper_error_classify_recoverable.exe test/test_keeper_blocker_class_completion_contract.exe test/test_cascade_capacity_exhausted_cooldown.exe test/test_cascade_error_classify_decoder.exe test/test_oas_error_kind_counter.exe test/test_keeper_cascade_tla_mirror.exe test/test_keeper_ocaml_tla_correspondence.exe test/test_keeper_failure_policy.exe test/test_oas_timeout_budget_strike.exe`
- ran all 9 focused test binaries successfully