### PR TITLE
fix(keeper): add recovery for direct tool shell calls

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -1081,6 +1081,43 @@ let handle_keeper_bash
          ())
   in
   let direct_tool_command_block ~tool_policy_visible tool_name =
+    let hint =
+      if tool_policy_visible
+      then
+        Printf.sprintf
+          "%s is a MASC tool, not a shell command. Call the %s tool directly \
+           with JSON arguments instead of using Bash."
+          tool_name tool_name
+      else
+        Printf.sprintf
+          "%s looks like a MASC tool, not a shell command, but it is not \
+           visible in this keeper's tool policy. Do not run it through Bash; \
+           pick a visible tool or update the keeper tool policy."
+          tool_name
+    in
+    let recovery_extra =
+      if tool_policy_visible
+      then (
+        let plan =
+          shell_rewrite_plan
+            ~confidence:"high"
+            ~next_tool:tool_name
+            ~next_args:[]
+            ~instruction:hint
+            ~reason:"direct_tool_invoked_as_shell"
+            ()
+        in
+        recovery_plan_extra ~rule_id:"tool_invoked_as_shell_command" plan)
+      else
+        [ "do_not_retry_tool", `String "keeper_bash"
+        ; "do_not_retry_same_args", `Bool true
+        ; "recovery_rule_id", `String "tool_invoked_as_shell_command"
+        ; ( "operator_action"
+          , `String
+              "Expose the requested tool in this keeper's tool policy or pick \
+               one of the currently visible structured tools." )
+        ]
+    in
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_shell_bash_failures
       ~labels:[("keeper", meta.name); ("site", "tool_invoked_as_shell")]
@@ -1090,30 +1127,17 @@ let handle_keeper_bash
       meta.name tool_name cmd_for_log;
     Yojson.Safe.to_string
       (`Assoc
-         [ "ok", `Bool false
-         ; "error", `String "tool_invoked_as_shell_command"
-         ; workflow_rejection_field
-         ; "tool", `String tool_name
-         ; "cmd", `String cmd_for_log
-         ; "hint",
-           `String
-             (if tool_policy_visible
-              then
-                Printf.sprintf
-                  "%s is a MASC tool, not a shell command. Call the %s \
-                   tool directly with JSON arguments instead of using Bash."
-                  tool_name tool_name
-              else
-                Printf.sprintf
-                  "%s looks like a MASC tool, not a shell command, but it \
-                   is not visible in this keeper's tool policy. Do not run \
-                   it through Bash; pick a visible tool or update the keeper \
-                   tool policy."
-                  tool_name)
-         ; "suggested_tool", `String tool_name
-         ; "tool_policy_visible", `Bool tool_policy_visible
-         ; "retryable", `Bool true
-         ])
+         ([ "ok", `Bool false
+          ; "error", `String "tool_invoked_as_shell_command"
+          ; workflow_rejection_field
+          ; "tool", `String tool_name
+          ; "cmd", `String cmd_for_log
+          ; "hint", `String hint
+          ; "suggested_tool", `String tool_name
+          ; "tool_policy_visible", `Bool tool_policy_visible
+          ; "retryable", `Bool true
+          ]
+          @ recovery_extra))
   in
   let json_of_raw raw =
     match Yojson.Safe.from_string raw with

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -2003,6 +2003,19 @@ let test_bash_blocks_direct_masc_tool_command () =
     (String_util.contains_substring
        (Json.member "hint" json |> Json.to_string)
        "keeper_tasks_list tool");
+  Alcotest.(check (option string))
+    "required next tool"
+    (Some "keeper_tasks_list")
+    (Json.member "required_next_tool" json |> Json.to_string_option);
+  Alcotest.(check (option string))
+    "do not retry bash"
+    (Some "keeper_bash")
+    (Json.member "do_not_retry_tool" json |> Json.to_string_option);
+  let recovery_plan = Json.member "recovery_plan" json in
+  Alcotest.(check (option string))
+    "recovery plan points to tool"
+    (Some "keeper_tasks_list")
+    (Json.member "next_tool" recovery_plan |> Json.to_string_option);
   let raw =
     Keeper_exec_shell.handle_keeper_bash
       ~turn_sandbox_factory:None
@@ -2018,7 +2031,15 @@ let test_bash_blocks_direct_masc_tool_command () =
   Alcotest.(check bool)
     "non-visible tool-like command still blocked"
     false
-    (Json.member "tool_policy_visible" json |> Json.to_bool)
+    (Json.member "tool_policy_visible" json |> Json.to_bool);
+  Alcotest.(check (option string))
+    "non-visible still suppresses bash retry"
+    (Some "keeper_bash")
+    (Json.member "do_not_retry_tool" json |> Json.to_string_option);
+  Alcotest.(check (option string))
+    "non-visible does not require unavailable tool"
+    None
+    (Json.member "required_next_tool" json |> Json.to_string_option)
 
 let test_bash_blocks_gh_pr_list_with_native_pr_hint () =
   with_eio_fs @@ fun () ->


### PR DESCRIPTION
## Summary
- Add structured recovery for Bash calls that are actually MASC tool names.
- Visible tools now return `recovery_plan`, `required_next_tool`, `do_not_retry_tool`, and `do_not_retry_same_args`.
- Non-visible tool-like commands still block Bash retry without requiring an unavailable tool.

## Verification
- `git diff --check HEAD~1..HEAD`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_bash_safety.exe`
- `./_build/default/test/test_keeper_bash_safety.exe` (76 tests)