### PR TITLE
refactor(keeper_shell_bash): extract shape classifier

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -163,6 +163,7 @@
    keeper_shell_bash_task_state
    keeper_shell_bash_shape_messages
    keeper_shell_bash_shape_ir
+   keeper_shell_bash_shape_classifier
    keeper_shell_bash
    keeper_shell_ops
    keeper_exec_shell

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -6,6 +6,7 @@ open Keeper_shell_bash_shape_messages
 open Keeper_shell_bash_task_state
 open Keeper_shell_bash_words
 module Task_probe = Keeper_shell_bash_task_probe
+module Shape_classifier = Keeper_shell_bash_shape_classifier
 
 (* RFC-0084 host-config-cleanup-B — bash binary path migration.
    Resolves the host bash binary once at module-init from the typed
@@ -21,9 +22,6 @@ let elapsed_duration_ms ~start_time ~end_time =
   | _ when elapsed_ms < 1. -> 1
   | _ -> int_of_float elapsed_ms
 
-let string_contains_char s ch = String.exists (Char.equal ch) s
-let string_contains_substring s needle = String_util.contains_substring s needle
-
 (* gh-pr native-tool routing hints extracted to
    [Keeper_shell_bash_native_tool_hint] (godfile decomp). *)
 type native_tool_hint = Keeper_shell_bash_native_tool_hint.native_tool_hint =
@@ -37,106 +35,11 @@ type native_tool_hint = Keeper_shell_bash_native_tool_hint.native_tool_hint =
 let gh_pr_native_tool_hint = Keeper_shell_bash_native_tool_hint.gh_pr_native_tool_hint
 let native_tool_diagnosis = Keeper_shell_bash_native_tool_hint.native_tool_diagnosis
 
-(* Repo-wide scan detection extracted to [Keeper_shell_bash_repo_wide_scan]
-   (godfile decomp). The two predicates referenced below are aliased so
-   downstream call sites stay byte-identical. *)
-module Repo_wide_scan = Keeper_shell_bash_repo_wide_scan
-
-let has_malformed_dev_null_redirect_token =
-  Repo_wide_scan.has_malformed_dev_null_redirect_token
+let shell_ir_shape_scan_text = Shape_classifier.shell_ir_shape_scan_text
+let shell_ir_parse_failure_shape_block =
+  Shape_classifier.shell_ir_parse_failure_shape_block
 ;;
-let command_has_repo_wide_scan = Repo_wide_scan.command_has_repo_wide_scan
-
-let shell_ir_shape_scan_text cmd =
-  let len = String.length cmd in
-  let buf = Buffer.create len in
-  let add_space () = Buffer.add_char buf ' ' in
-  let rec loop quote_state escaped i =
-    if i >= len
-    then Buffer.contents buf
-    else if escaped
-    then (
-      add_space ();
-      loop quote_state false (i + 1))
-    else (
-      match quote_state, cmd.[i] with
-      | Single_quote, '\'' ->
-        add_space ();
-        loop No_quote false (i + 1)
-      | Single_quote, _ ->
-        add_space ();
-        loop Single_quote false (i + 1)
-      | Double_quote, '"' ->
-        add_space ();
-        loop No_quote false (i + 1)
-      | Double_quote, '\\' ->
-        add_space ();
-        loop Double_quote true (i + 1)
-      | Double_quote, '$' when i + 1 < len && Char.equal cmd.[i + 1] '(' ->
-        Buffer.add_string buf "$(";
-        loop Double_quote false (i + 2)
-      | Double_quote, '`' ->
-        Buffer.add_char buf '`';
-        loop Double_quote false (i + 1)
-      | Double_quote, _ ->
-        add_space ();
-        loop Double_quote false (i + 1)
-      | No_quote, '\'' ->
-        add_space ();
-        loop Single_quote false (i + 1)
-      | No_quote, '"' ->
-        add_space ();
-        loop Double_quote false (i + 1)
-      | No_quote, '\\' ->
-        add_space ();
-        loop No_quote true (i + 1)
-      | No_quote, ch ->
-        Buffer.add_char buf ch;
-        loop No_quote false (i + 1))
-  in
-  loop No_quote false 0
-
-let shell_ir_parse_failure_shape_block cmd =
-  let cmd, _ = strip_stderr_dev_null_redirects cmd in
-  let scan_text = shell_ir_shape_scan_text cmd in
-  let lower = String.lowercase_ascii scan_text in
-  if string_contains_substring lower "gh pr checks"
-  then Some Gh_pr_checks
-  else if command_has_repo_wide_scan cmd
-  then Some Repo_wide_scan
-  else if has_malformed_dev_null_redirect_token scan_text
-  then Some Pipe_or_redirect
-  else if
-    string_contains_char scan_text '|'
-    || string_contains_char scan_text '>'
-    || string_contains_char scan_text '<'
-  then Some Pipe_or_redirect
-  else if
-    string_contains_substring scan_text "&&"
-    || string_contains_substring scan_text "||"
-    || string_contains_char scan_text ';'
-    || string_contains_char scan_text '\n'
-    || string_contains_char scan_text '\r'
-  then Some Chaining
-  else if
-    string_contains_substring scan_text "$(" || string_contains_char scan_text '`'
-  then Some Substitution
-  else None
-
-let keeper_bash_shape_block cmd =
-  let cmd, _ = strip_stderr_dev_null_redirects cmd in
-  let scan_text = shell_ir_shape_scan_text cmd in
-  if command_has_repo_wide_scan cmd
-  then Some Repo_wide_scan
-  else if has_malformed_dev_null_redirect_token scan_text
-  then Some Pipe_or_redirect
-  else
-  match Masc_exec_bash_parser.Bash.parse_string cmd with
-  | Masc_exec.Parsed.Parsed ir -> parsed_keeper_bash_shape_block ir
-  | Masc_exec.Parsed.Parse_error _
-  | Masc_exec.Parsed.Parse_aborted _
-  | Masc_exec.Parsed.Too_complex _ ->
-    shell_ir_parse_failure_shape_block cmd
+let keeper_bash_shape_block = Shape_classifier.keeper_bash_shape_block
 
 type safe_read_fallback = {
   primary_cmd : string;

--- a/lib/keeper/keeper_shell_bash_shape_classifier.ml
+++ b/lib/keeper/keeper_shell_bash_shape_classifier.ml
@@ -1,0 +1,102 @@
+(** Command-shape classifier for {!Keeper_shell_bash}. *)
+
+open Keeper_shell_bash_redirects
+open Keeper_shell_bash_shape_ir
+open Keeper_shell_bash_shape_messages
+open Keeper_shell_bash_words
+
+module Repo_wide_scan = Keeper_shell_bash_repo_wide_scan
+
+let string_contains_char s ch = String.exists (Char.equal ch) s
+let string_contains_substring s needle = String_util.contains_substring s needle
+
+let shell_ir_shape_scan_text cmd =
+  let len = String.length cmd in
+  let buf = Buffer.create len in
+  let add_space () = Buffer.add_char buf ' ' in
+  let rec loop quote_state escaped i =
+    if i >= len
+    then Buffer.contents buf
+    else if escaped
+    then (
+      add_space ();
+      loop quote_state false (i + 1))
+    else (
+      match quote_state, cmd.[i] with
+      | Single_quote, '\'' ->
+        add_space ();
+        loop No_quote false (i + 1)
+      | Single_quote, _ ->
+        add_space ();
+        loop Single_quote false (i + 1)
+      | Double_quote, '"' ->
+        add_space ();
+        loop No_quote false (i + 1)
+      | Double_quote, '\\' ->
+        add_space ();
+        loop Double_quote true (i + 1)
+      | Double_quote, '$' when i + 1 < len && Char.equal cmd.[i + 1] '(' ->
+        Buffer.add_string buf "$(";
+        loop Double_quote false (i + 2)
+      | Double_quote, '`' ->
+        Buffer.add_char buf '`';
+        loop Double_quote false (i + 1)
+      | Double_quote, _ ->
+        add_space ();
+        loop Double_quote false (i + 1)
+      | No_quote, '\'' ->
+        add_space ();
+        loop Single_quote false (i + 1)
+      | No_quote, '"' ->
+        add_space ();
+        loop Double_quote false (i + 1)
+      | No_quote, '\\' ->
+        add_space ();
+        loop No_quote true (i + 1)
+      | No_quote, ch ->
+        Buffer.add_char buf ch;
+        loop No_quote false (i + 1))
+  in
+  loop No_quote false 0
+
+let shell_ir_parse_failure_shape_block cmd =
+  let cmd, _ = strip_stderr_dev_null_redirects cmd in
+  let scan_text = shell_ir_shape_scan_text cmd in
+  let lower = String.lowercase_ascii scan_text in
+  if string_contains_substring lower "gh pr checks"
+  then Some Gh_pr_checks
+  else if Repo_wide_scan.command_has_repo_wide_scan cmd
+  then Some Repo_wide_scan
+  else if Repo_wide_scan.has_malformed_dev_null_redirect_token scan_text
+  then Some Pipe_or_redirect
+  else if
+    string_contains_char scan_text '|'
+    || string_contains_char scan_text '>'
+    || string_contains_char scan_text '<'
+  then Some Pipe_or_redirect
+  else if
+    string_contains_substring scan_text "&&"
+    || string_contains_substring scan_text "||"
+    || string_contains_char scan_text ';'
+    || string_contains_char scan_text '\n'
+    || string_contains_char scan_text '\r'
+  then Some Chaining
+  else if
+    string_contains_substring scan_text "$(" || string_contains_char scan_text '`'
+  then Some Substitution
+  else None
+
+let keeper_bash_shape_block cmd =
+  let cmd, _ = strip_stderr_dev_null_redirects cmd in
+  let scan_text = shell_ir_shape_scan_text cmd in
+  if Repo_wide_scan.command_has_repo_wide_scan cmd
+  then Some Repo_wide_scan
+  else if Repo_wide_scan.has_malformed_dev_null_redirect_token scan_text
+  then Some Pipe_or_redirect
+  else
+    match Masc_exec_bash_parser.Bash.parse_string cmd with
+    | Masc_exec.Parsed.Parsed ir -> parsed_keeper_bash_shape_block ir
+    | Masc_exec.Parsed.Parse_error _
+    | Masc_exec.Parsed.Parse_aborted _
+    | Masc_exec.Parsed.Too_complex _ ->
+      shell_ir_parse_failure_shape_block cmd

--- a/lib/keeper/keeper_shell_bash_shape_classifier.mli
+++ b/lib/keeper/keeper_shell_bash_shape_classifier.mli
@@ -1,0 +1,9 @@
+(** Command-shape classifier for {!Keeper_shell_bash}. *)
+
+val shell_ir_shape_scan_text : string -> string
+
+val shell_ir_parse_failure_shape_block :
+  string -> Keeper_shell_bash_shape_messages.bash_shape_block option
+
+val keeper_bash_shape_block :
+  string -> Keeper_shell_bash_shape_messages.bash_shape_block option


### PR DESCRIPTION
## Summary
- Extract bash command-shape scan/classification logic into Keeper_shell_bash_shape_classifier
- Keep Keeper_shell_bash public/testing aliases intact for existing callers
- Register the new helper module in lib/dune

## Verification
- ocamlformat --check lib/keeper/keeper_shell_bash.ml lib/keeper/keeper_shell_bash_shape_classifier.ml lib/keeper/keeper_shell_bash_shape_classifier.mli
- git diff origin/main --check
- scripts/lint/godfile-size-regression.sh
- rg risk scan on new helper module: clean

## Local Dune note
- Attempted: env DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_keeper_bash_safety.exe
- Blocked by existing machine-wide/bare Dune processes and long-held /tmp/me-dune-local.lock; no local Dune compile completed in this saturated session. Draft PR is left for CI validation.