### PR TITLE
chore(dispatch): drop board actor canonicalize alias

### DIFF
--- a/lib/tool_inline_dispatch_extra.ml
+++ b/lib/tool_inline_dispatch_extra.ml
@@ -117,8 +117,8 @@ let record_author_legacy_mismatch claim fields =
     [ensure_board_post_author] only consulted [agent_name] when the
     caller's [author] field was empty, so any LLM that wrote a non-blank
     [author] argument bypassed identity verification.
-    [canonicalize_board_actor_field] (board_comment, board_vote,
-    comment_vote) didn't consult [agent_name] at all.
+    Board comment/vote paths also canonicalised caller fields without
+    comparing them to [agent_name].
 
     Both paths now route through this helper, which compares the
     canonical form of the caller's claim against the canonical form
@@ -211,15 +211,6 @@ let enforce_caller_identity ~tool ~field ~agent_name arguments =
             in
             `Assoc fields))
   | _ -> arguments
-
-(** Backward-compatible aliases retained for direct callers (tests,
-    HTTP handlers).  New dispatch sites should call
-    {!enforce_caller_identity} with an explicit [tool] label. *)
-let canonicalize_board_actor_field ?(tool = "unknown") ?agent_name field
-    arguments =
-  enforce_caller_identity ~tool ~field
-    ~agent_name:(Option.value ~default:"" agent_name)
-    arguments
 
 let ensure_board_post_author ~agent_name arguments =
   enforce_caller_identity ~tool:"masc_board_post" ~field:"author"

--- a/test/test_board_author_identity_10297.ml
+++ b/test/test_board_author_identity_10297.ml
@@ -8,9 +8,8 @@
     canonicalisation without comparison, so an LLM running as
     keeper [velvet-hammer] could write [author = "analyst"] and
     impersonate a different principal on the public board.
-    [canonicalize_board_actor_field] (board_comment, board_vote,
-    comment_vote) didn't even receive [agent_name] — it could not
-    have caught spoofing if it tried.
+    Board comment/vote paths also lacked an [agent_name] comparison
+    point, so they could not have caught spoofing either.
 
     These tests pin the unified [enforce_caller_identity]
     contract — the 3-branch SSOT pattern from
@@ -162,8 +161,8 @@ let test_velvet_hammer_cannot_post_as_analyst () =
 
 let test_voter_field_spoof_also_rewritten () =
   (* Vote/comment_vote calls used to bypass identity entirely
-     because [canonicalize_board_actor_field] never saw [agent_name].
-     Now they share the same gate. *)
+     because their old path never compared caller identity with
+     [agent_name].  Now they share the same gate. *)
   let before = counter_for ~tool:"masc_board_vote" ~field:"voter" in
   let result =
     D.enforce_caller_identity ~tool:"masc_board_vote" ~field:"voter"
@@ -205,8 +204,8 @@ let test_empty_ctx_preserves_legacy_canonicalisation () =
   (* If [agent_name] is somehow empty (HTTP path with no auth, test
      fixture without ctx), the helper should not invent a value but
      should still canonicalise the caller's surface form.  This
-     keeps the legacy [canonicalize_board_actor_field] semantics
-     for the empty-ctx case. *)
+     keeps the empty-ctx compatibility semantics for callers that
+     cannot provide a trusted runtime identity. *)
   let result =
     D.enforce_caller_identity ~tool:"masc_board_post" ~field:"author"
       ~agent_name:""


### PR DESCRIPTION
## Summary
- remove the unused private canonicalize_board_actor_field compatibility helper
- keep enforce_caller_identity as the single identity-enforcement helper
- update stale source/test comments that named the removed helper

## Verification
- ocamlformat --check lib/tool_inline_dispatch_extra.ml test/test_board_author_identity_10297.ml
- git diff --check
- rg -n "canonicalize_board_actor_field|Backward-compatible aliases retained" lib test scripts bin  # 0 hits
- lockf -k -t 10 /tmp/me-dune-local.lock /usr/bin/env MASC_DUNE_LOCK_HELD=1 MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=5 scripts/dune-local.sh build test/test_board_author_identity_10297.exe  # blocked: /tmp/me-dune-local.lock already locked; holder pid 88612 report-closeout-verify-20260521 focused build