### PR TITLE
fix(cascade): expose provider timeout watchdog provenance

### DIFF
--- a/lib/cascade/cascade_runtime_candidate.ml
+++ b/lib/cascade/cascade_runtime_candidate.ml
@@ -351,12 +351,40 @@ let has_recovery_evidence candidate =
 let local_runtime_attempt_timeout_floor_s =
   Cascade_attempt_liveness.bootstrap.attempt_wall_max
 
-let effective_attempt_timeout_s ~is_last:_ ~configured_timeout_s candidate =
+type attempt_timeout_resolution =
+  { timeout_s : float option
+  ; source : string
+  }
+
+let effective_attempt_timeout_resolution ~is_last:_ ~configured_timeout_s candidate =
   if Llm_provider.Provider_config.is_local candidate.provider_cfg then
     match configured_timeout_s with
-    | None -> Some local_runtime_attempt_timeout_floor_s
-    | Some timeout_s -> Some (Float.max timeout_s local_runtime_attempt_timeout_floor_s)
-  else configured_timeout_s
+    | None ->
+      { timeout_s = Some local_runtime_attempt_timeout_floor_s
+      ; source = "local_runtime_floor"
+      }
+    | Some timeout_s when timeout_s < local_runtime_attempt_timeout_floor_s ->
+      { timeout_s = Some local_runtime_attempt_timeout_floor_s
+      ; source = "configured_lifted_to_local_runtime_floor"
+      }
+    | Some timeout_s ->
+      { timeout_s = Some timeout_s
+      ; source = "configured_per_provider_timeout"
+      }
+  else
+    match configured_timeout_s with
+    | None -> { timeout_s = None; source = "unset_oas_default" }
+    | Some timeout_s ->
+      { timeout_s = Some timeout_s
+      ; source = "configured_per_provider_timeout"
+      }
+
+let effective_attempt_timeout_s ~is_last ~configured_timeout_s candidate =
+  (effective_attempt_timeout_resolution
+     ~is_last
+     ~configured_timeout_s
+     candidate)
+    .timeout_s
 
 let resolve_tool_lane_for_oas_tools
     ?agent_name

--- a/lib/cascade/cascade_runtime_candidate.mli
+++ b/lib/cascade/cascade_runtime_candidate.mli
@@ -54,6 +54,17 @@ val provider_label : t -> string
 val first_health_cooldown : t -> (string * string) option
 val has_recovery_evidence : t -> bool
 
+type attempt_timeout_resolution =
+  { timeout_s : float option
+  ; source : string
+  }
+
+val effective_attempt_timeout_resolution :
+  is_last:bool -> configured_timeout_s:float option -> t -> attempt_timeout_resolution
+(** Effective attempt timeout plus bounded source label for runtime manifests.
+    Source labels are policy provenance only; they must not expose concrete
+    provider or model identifiers. *)
+
 val effective_attempt_timeout_s :
   is_last:bool -> configured_timeout_s:float option -> t -> float option
 (** Effective attempt timeout passed to OAS for this candidate. Local runtime

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -1042,17 +1042,57 @@ let run_named
         | `Full _ -> None
       in
       Log.Misc.debug "cascade %s: trying %s (is_last=%b)" cascade_name runtime_candidate_label is_last;
-      let pp_timeout =
-        Cascade_runtime_candidate.effective_attempt_timeout_s
+      let timeout_resolution =
+        Cascade_runtime_candidate.effective_attempt_timeout_resolution
           ~is_last
           ~configured_timeout_s:per_provider_timeout_s
           candidate
+      in
+      let pp_timeout = timeout_resolution.timeout_s in
+      let liveness_mode = Cascade_attempt_liveness_config.current_mode () in
+      let liveness_observer_attached =
+        match liveness_mode with
+        | Cascade_attempt_liveness_config.Off -> false
+        | Cascade_attempt_liveness_config.Observe
+        | Cascade_attempt_liveness_config.Enforce ->
+          true
+      in
+      let attempt_watchdog_source =
+        match liveness_mode, liveness_observer_attached, pp_timeout with
+        | Cascade_attempt_liveness_config.Enforce, true, _ ->
+          "liveness_observer_enforce"
+        | Cascade_attempt_liveness_config.Observe, true, Some _ ->
+          "legacy_outer_wall_observe_liveness"
+        | Cascade_attempt_liveness_config.Observe, true, None ->
+          "oas_max_execution_time_observe_liveness"
+        | Cascade_attempt_liveness_config.Off, _, Some _ -> "legacy_outer_wall"
+        | Cascade_attempt_liveness_config.Off, _, None -> "oas_max_execution_time"
+        | Cascade_attempt_liveness_config.Enforce, false, Some _ -> "legacy_outer_wall"
+        | Cascade_attempt_liveness_config.Enforce, false, None ->
+          "oas_max_execution_time"
+      in
+      let liveness_budget_source =
+        if liveness_observer_attached then (
+          let resolved_budget =
+            Cascade_attempt_liveness_config.budget_for_candidate
+              ~candidate_key:Cascade_attempt_liveness_config.runtime_candidate_key
+          in
+          Some
+            (Cascade_attempt_liveness_config.budget_source_label
+               resolved_budget.source))
+        else
+          None
       in
       let attempt_started_at = Unix.gettimeofday () in
       let started_record =
         { started_provenance = provider_attempt_provenance
         ; started_is_last = is_last
         ; started_per_provider_timeout_s = pp_timeout
+        ; started_attempt_timeout_source = timeout_resolution.source
+        ; started_attempt_watchdog_source = attempt_watchdog_source
+        ; started_liveness_mode =
+            Cascade_attempt_liveness_config.mode_label liveness_mode
+        ; started_liveness_budget_source = liveness_budget_source
         }
       in
       let provider_attempt_finished_emitted = ref false in

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -172,6 +172,10 @@ type provider_attempt_started_record =
   { started_provenance : provider_attempt_provenance
   ; started_is_last : bool
   ; started_per_provider_timeout_s : float option
+  ; started_attempt_timeout_source : string
+  ; started_attempt_watchdog_source : string
+  ; started_liveness_mode : string
+  ; started_liveness_budget_source : string option
   }
 
 type provider_attempt_finished_record =

--- a/lib/keeper/keeper_turn_driver_provider_attempt.ml
+++ b/lib/keeper/keeper_turn_driver_provider_attempt.ml
@@ -57,6 +57,10 @@ type provider_attempt_started_record =
   { started_provenance : provider_attempt_provenance
   ; started_is_last : bool
   ; started_per_provider_timeout_s : float option
+  ; started_attempt_timeout_source : string
+  ; started_attempt_watchdog_source : string
+  ; started_liveness_mode : string
+  ; started_liveness_budget_source : string option
   }
 
 type provider_attempt_finished_record =
@@ -77,6 +81,17 @@ let provider_attempt_started_decision record =
            match record.started_per_provider_timeout_s with
            | None -> `Null
            | Some timeout -> `Float timeout );
+         ( "attempt_timeout_s",
+           match record.started_per_provider_timeout_s with
+           | None -> `Null
+           | Some timeout -> `Float timeout );
+         ("attempt_timeout_source", `String record.started_attempt_timeout_source);
+         ("attempt_watchdog_source", `String record.started_attempt_watchdog_source);
+         ("liveness_mode", `String record.started_liveness_mode);
+         ( "liveness_budget_source",
+           match record.started_liveness_budget_source with
+           | None -> `Null
+           | Some source -> `String source );
        ])
 ;;
 

--- a/lib/keeper/keeper_turn_driver_provider_attempt.mli
+++ b/lib/keeper/keeper_turn_driver_provider_attempt.mli
@@ -26,6 +26,10 @@ type provider_attempt_started_record =
   { started_provenance : provider_attempt_provenance
   ; started_is_last : bool
   ; started_per_provider_timeout_s : float option
+  ; started_attempt_timeout_source : string
+  ; started_attempt_watchdog_source : string
+  ; started_liveness_mode : string
+  ; started_liveness_budget_source : string option
   }
 
 type provider_attempt_finished_record =

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -389,6 +389,10 @@ let test_json_roundtrip () =
             ("provider_kind", `String "openai");
             ("model_id", `String "gpt-test");
             ("response_model", `String "gpt-test");
+            ("per_provider_timeout_s", `Float 12.5);
+            ("attempt_timeout_s", `Float 12.5);
+            ("attempt_timeout_source", `String "configured_per_provider_timeout");
+            ("attempt_watchdog_source", `String "liveness_observer_enforce");
       ])
       ~receipt_path:"/tmp/receipt.jsonl" ~checkpoint_path:"/tmp/checkpoint.json"
       ~tool_call_log_path:"/tmp/tool-calls.jsonl" ()
@@ -437,6 +441,22 @@ let test_json_roundtrip () =
         "manifest decision omits response model"
         false
         (json_has_key "response_model" emitted_decision);
+      Alcotest.(check bool)
+        "manifest decision omits retired per-provider timeout key"
+        false
+        (json_has_key "per_provider_timeout_s" emitted_decision);
+      Alcotest.(check bool)
+        "manifest decision preserves attempt timeout"
+        true
+        (json_has_key "attempt_timeout_s" emitted_decision);
+      Alcotest.(check bool)
+        "manifest decision preserves attempt timeout source"
+        true
+        (json_has_key "attempt_timeout_source" emitted_decision);
+      Alcotest.(check bool)
+        "manifest decision preserves attempt watchdog source"
+        true
+        (json_has_key "attempt_watchdog_source" emitted_decision);
       let retired_top_level_json =
         `Assoc
           [

--- a/test/test_keeper_unified_turn_pipeline_records.ml
+++ b/test/test_keeper_unified_turn_pipeline_records.ml
@@ -106,6 +106,10 @@ let test_provider_attempt_records_manifest_decision_contract () =
       { started_provenance = provenance
       ; started_is_last = false
       ; started_per_provider_timeout_s = Some 12.5
+      ; started_attempt_timeout_source = "configured_per_provider_timeout"
+      ; started_attempt_watchdog_source = "liveness_observer_enforce"
+      ; started_liveness_mode = "enforce"
+      ; started_liveness_budget_source = Some "bootstrap"
       }
   in
   check
@@ -124,6 +128,31 @@ let test_provider_attempt_records_manifest_decision_contract () =
     "started timeout"
     12.5
     (started |> member "per_provider_timeout_s" |> to_float);
+  check
+    (float 0.0)
+    "started public attempt timeout"
+    12.5
+    (started |> member "attempt_timeout_s" |> to_float);
+  check
+    string
+    "started timeout source"
+    "configured_per_provider_timeout"
+    (started |> member "attempt_timeout_source" |> to_string);
+  check
+    string
+    "started watchdog source"
+    "liveness_observer_enforce"
+    (started |> member "attempt_watchdog_source" |> to_string);
+  check
+    string
+    "started liveness mode"
+    "enforce"
+    (started |> member "liveness_mode" |> to_string);
+  check
+    string
+    "started liveness budget source"
+    "bootstrap"
+    (started |> member "liveness_budget_source" |> to_string);
   let finished =
     KRun.provider_attempt_finished_decision
       { finished_provenance = provenance

--- a/test/test_oas_worker_provider_labels.ml
+++ b/test/test_oas_worker_provider_labels.ml
@@ -133,6 +133,25 @@ let provider_timeout ?(is_last = false) ?configured provider_cfg =
     candidate
 ;;
 
+let provider_timeout_resolution ?(is_last = false) ?configured provider_cfg =
+  let candidate = Cascade_runtime_candidate.of_provider_config provider_cfg in
+  Cascade_runtime_candidate.effective_attempt_timeout_resolution
+    ~is_last
+    ~configured_timeout_s:configured
+    candidate
+;;
+
+let check_timeout_resolution label expected_timeout expected_source actual =
+  check_timeout_opt
+    (label ^ " timeout")
+    expected_timeout
+    actual.Cascade_runtime_candidate.timeout_s;
+  Alcotest.(check string)
+    (label ^ " source")
+    expected_source
+    actual.Cascade_runtime_candidate.source
+;;
+
 let test_provider_attempt_timeout_passes_claude_code_configured_timeout () =
   check_timeout_opt
     "claude_code configured attempt timeout passes through"
@@ -175,6 +194,30 @@ let test_provider_attempt_timeout_passes_final_configured_timeout () =
     (provider_timeout
        ~is_last:true
        ~configured:300.0
+       (make_openai_compat_provider_cfg ~base_url:"https://api.example.test/v1" ()))
+;;
+
+let test_provider_attempt_timeout_resolution_sources () =
+  check_timeout_resolution
+    "claude_code configured timeout"
+    (Some 300.0)
+    "configured_per_provider_timeout"
+    (provider_timeout_resolution ~configured:300.0 (make_claude_code_provider_cfg ()));
+  check_timeout_resolution
+    "ollama lifted configured timeout"
+    (Some local_runtime_timeout_floor_s)
+    "configured_lifted_to_local_runtime_floor"
+    (provider_timeout_resolution ~configured:60.0 (make_ollama_provider_cfg ()));
+  check_timeout_resolution
+    "ollama default timeout"
+    (Some local_runtime_timeout_floor_s)
+    "local_runtime_floor"
+    (provider_timeout_resolution (make_ollama_provider_cfg ()));
+  check_timeout_resolution
+    "openai compat unset timeout"
+    None
+    "unset_oas_default"
+    (provider_timeout_resolution
        (make_openai_compat_provider_cfg ~base_url:"https://api.example.test/v1" ()))
 ;;
 
@@ -240,6 +283,10 @@ let cases =
       "provider timeout passes final configured timeout"
       `Quick
       test_provider_attempt_timeout_passes_final_configured_timeout
+  ; Alcotest.test_case
+      "provider timeout resolution records bounded source labels"
+      `Quick
+      test_provider_attempt_timeout_resolution_sources
   ; Alcotest.test_case
       "cascade provider labels preserve registered openai_compat family"
       `Quick


### PR DESCRIPTION
## Summary
- add bounded timeout-resolution provenance for cascade runtime candidates without changing existing timeout behavior
- emit provider-attempt started manifest fields for attempt timeout, timeout source, watchdog source, liveness mode, and liveness budget source
- cover raw decision contract, public manifest redaction/preservation, and timeout source labels in tests

## Verification
- PASS: ocamlformat --check lib/cascade/cascade_runtime_candidate.ml lib/cascade/cascade_runtime_candidate.mli lib/keeper/keeper_turn_driver.ml lib/keeper/keeper_turn_driver.mli lib/keeper/keeper_turn_driver_provider_attempt.ml lib/keeper/keeper_turn_driver_provider_attempt.mli test/test_keeper_runtime_manifest.ml test/test_keeper_unified_turn_pipeline_records.ml test/test_oas_worker_provider_labels.ml
- PASS: git diff --check HEAD~1..HEAD
- BLOCKED locally: scripts/dune-local.sh build test/test_keeper_unified_turn_pipeline_records.exe test/test_oas_worker_provider_labels.exe test/test_oas_timeout_budget_strike.exe test/test_cascade_attempt_outer_wall.exe test/test_oas_compat_cascade_fallback.exe test/test_oas_worker_sdk_error.exe (wrapper refused because bare Dune processes were already running on the host)