### PR TITLE
refactor(cascade_transport): extract authorization-header helpers into sibling (Lane D)

### DIFF
--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -131,17 +131,7 @@ let dedupe_preserve_order (items : string list) =
     items
 ;;
 
-let upsert_http_header ~key ~value headers =
-  let key_lc = String.lowercase_ascii key in
-  let retained =
-    List.filter
-      (fun (existing_key, _) ->
-         not (String.equal (String.lowercase_ascii existing_key) key_lc))
-      headers
-  in
-  (key, value) :: retained
-;;
-
+let upsert_http_header = Cascade_transport_authorization.upsert_http_header
 let trim_nonempty value =
   match value with
   | Some raw ->
@@ -154,20 +144,7 @@ let first_nonempty_env names =
   List.find_map (fun name -> Sys.getenv_opt name |> trim_nonempty) names
 ;;
 
-let keeper_name_of_agent_name agent_name =
-  let prefix = "keeper-" in
-  let suffix = "-agent" in
-  let value = String.trim agent_name in
-  let vlen = String.length value in
-  let plen = String.length prefix in
-  let slen = String.length suffix in
-  if
-    vlen > plen + slen
-    && String.sub value 0 plen = prefix
-    && String.sub value (vlen - slen) slen = suffix
-  then Some (String.sub value plen (vlen - plen - slen))
-  else None
-;;
+let keeper_name_of_agent_name = Cascade_transport_authorization.keeper_name_of_agent_name
 
 let runtime_mcp_policy_with_masc_agent_name
       ?(include_internal_token = true)
@@ -225,64 +202,11 @@ let runtime_mcp_policy_without_http_headers
   { policy with servers }
 ;;
 
-let is_authorization_header (key, value) =
-  String.equal (String.lowercase_ascii (String.trim key)) "authorization"
-  && String.starts_with ~prefix:"Bearer " (String.trim value)
-;;
-
-let authorization_header_from_policy
-      (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
-  =
-  List.find_map
-    (function
-      | Llm_provider.Llm_transport.Http_server { name = "masc"; headers; _ } ->
-        List.find_opt is_authorization_header headers
-      (* Only the [Http_server] entry whose [name = "masc"] carries the
-         per-request Authorization header. Other named [Http_server]s and
-         [Stdio_server]s contribute no auth header on this lane. New
-         transport variants must re-decide explicitly. *)
-      | Llm_provider.Llm_transport.Http_server _
-      | Llm_provider.Llm_transport.Stdio_server _ -> None)
-    policy.servers
-;;
-
-let per_keeper_authorization_header ~agent_name =
-  match keeper_name_of_agent_name agent_name with
-  | None -> None
-  | Some _ ->
-    let base_path = Env_config_core.base_path () in
-    Auth.load_raw_token base_path ~agent_name
-    |> Option.map (fun raw -> "Authorization", "Bearer " ^ raw)
-;;
-
-let runtime_mcp_policy_uses_bound_actor_tools
-      (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
-  =
-  List.exists Tool_catalog.requires_actor_binding policy.allowed_tool_names
-;;
-
-let add_masc_authorization_header
-      authorization_header
-      (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
-  =
-  let servers =
-    List.map
-      (function
-        | Llm_provider.Llm_transport.Http_server ({ name = "masc"; headers; _ } as server)
-          ->
-          Llm_provider.Llm_transport.Http_server
-            { server with
-              headers =
-                upsert_http_header
-                  ~key:(fst authorization_header)
-                  ~value:(snd authorization_header)
-                  headers
-            }
-        | server -> server)
-      policy.servers
-  in
-  { policy with servers }
-;;
+let is_authorization_header = Cascade_transport_authorization.is_authorization_header
+let authorization_header_from_policy = Cascade_transport_authorization.authorization_header_from_policy
+let per_keeper_authorization_header = Cascade_transport_authorization.per_keeper_authorization_header
+let runtime_mcp_policy_uses_bound_actor_tools = Cascade_transport_authorization.runtime_mcp_policy_uses_bound_actor_tools
+let add_masc_authorization_header = Cascade_transport_authorization.add_masc_authorization_header
 
 let codex_cli_can_auth_keeper_bound_runtime_mcp ~agent_name policy =
   runtime_mcp_policy_uses_bound_actor_tools policy

--- a/lib/cascade/cascade_transport_authorization.ml
+++ b/lib/cascade/cascade_transport_authorization.ml
@@ -1,0 +1,90 @@
+(** Authorization header helpers for cascade runtime MCP transport,
+    extracted from cascade_transport.ml.
+
+    Pure functions over runtime-MCP policy + per-keeper auth headers;
+    no protocol/transport state owned here. *)
+
+let upsert_http_header ~key ~value headers =
+  let key_lc = String.lowercase_ascii key in
+  let retained =
+    List.filter
+      (fun (existing_key, _) ->
+         not (String.equal (String.lowercase_ascii existing_key) key_lc))
+      headers
+  in
+  (key, value) :: retained
+;;
+
+let keeper_name_of_agent_name agent_name =
+  let prefix = "keeper-" in
+  let suffix = "-agent" in
+  let value = String.trim agent_name in
+  let vlen = String.length value in
+  let plen = String.length prefix in
+  let slen = String.length suffix in
+  if
+    vlen > plen + slen
+    && String.sub value 0 plen = prefix
+    && String.sub value (vlen - slen) slen = suffix
+  then Some (String.sub value plen (vlen - plen - slen))
+  else None
+;;
+
+let is_authorization_header (key, value) =
+  String.equal (String.lowercase_ascii (String.trim key)) "authorization"
+  && String.starts_with ~prefix:"Bearer " (String.trim value)
+;;
+
+let authorization_header_from_policy
+      (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
+  =
+  List.find_map
+    (function
+      | Llm_provider.Llm_transport.Http_server { name = "masc"; headers; _ } ->
+        List.find_opt is_authorization_header headers
+      (* Only the [Http_server] entry whose [name = "masc"] carries the
+         per-request Authorization header. Other named [Http_server]s and
+         [Stdio_server]s contribute no auth header on this lane. New
+         transport variants must re-decide explicitly. *)
+      | Llm_provider.Llm_transport.Http_server _
+      | Llm_provider.Llm_transport.Stdio_server _ -> None)
+    policy.servers
+;;
+
+let per_keeper_authorization_header ~agent_name =
+  match keeper_name_of_agent_name agent_name with
+  | None -> None
+  | Some _ ->
+    let base_path = Env_config_core.base_path () in
+    Auth.load_raw_token base_path ~agent_name
+    |> Option.map (fun raw -> "Authorization", "Bearer " ^ raw)
+;;
+
+let runtime_mcp_policy_uses_bound_actor_tools
+      (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
+  =
+  List.exists Tool_catalog.requires_actor_binding policy.allowed_tool_names
+;;
+
+let add_masc_authorization_header
+      authorization_header
+      (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
+  =
+  let servers =
+    List.map
+      (function
+        | Llm_provider.Llm_transport.Http_server ({ name = "masc"; headers; _ } as server)
+          ->
+          Llm_provider.Llm_transport.Http_server
+            { server with
+              headers =
+                upsert_http_header
+                  ~key:(fst authorization_header)
+                  ~value:(snd authorization_header)
+                  headers
+            }
+        | server -> server)
+      policy.servers
+  in
+  { policy with servers }
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane D (Cascade/Tools)
- `cascade_transport.ml` is 1596 LOC. Carved out auth-header + keeper-name + http-header-upsert helpers into a sibling.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/cascade/cascade_transport.ml` | 1596 | 1520 | **-76** |
| `lib/cascade/cascade_transport_authorization.ml` | — | 85 | +85 |

## Moved (verbatim, no behavior change)
- `upsert_http_header` (helper used by auth + other policy builders)
- `keeper_name_of_agent_name` (agent-name → keeper-name extraction)
- `is_authorization_header`
- `authorization_header_from_policy`
- `per_keeper_authorization_header`
- `runtime_mcp_policy_uses_bound_actor_tools`
- `add_masc_authorization_header`

Both `upsert_http_header` and `keeper_name_of_agent_name` retain parent aliases — other callsites in `cascade_transport.ml` compile unchanged.

## Verification
- `bash scripts/lint/godfile-size-regression.sh`: clean
- `dune build --root . lib/masc_mcp.cmxa`: exit 0

## Build sequence (transparency)
3 builds: first revealed `keeper_name_of_agent_name` unbound, second revealed `upsert_http_header` unbound, third clean. Both helpers moved + parent aliased.

## RFC-WAIVED
Extract-only sibling refactor, no behavior change, governed by `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane D (first carve-out).

Co-Authored-By: codex <noreply@anthropic.com>
