### PR TITLE
chore(cascade): drop no-producer event publishers

### DIFF
--- a/docs/SYSTEM-EVENT-AND-SNAPSHOT-INVENTORY.md
+++ b/docs/SYSTEM-EVENT-AND-SNAPSHOT-INVENTORY.md
@@ -175,7 +175,7 @@ Source of accepted event names on the dashboard side: `dashboard/src/types/sse.t
 | Board and notification compatibility | `board_post`, `masc/board_post`, `board_comment`, `masc/board_comment`, `board_delete`, `masc/board_delete`, `post_created`, `comment_added`, `post_voted`, `comment_voted` |
 | Keeper direct SSE | `keeper_heartbeat`, `keeper_handoff`, `masc/keeper_handoff`, `keeper_compaction`, `masc/keeper_compaction`, `keeper_guardrail`, `masc/keeper_guardrail`, `keeper_phase_changed`, `keeper_composite_changed`, `keeper_tool_call`, `masc/keeper_tool_call`, `keeper_tool_skipped`, `keeper_turn_complete`, `masc/keeper_turn_complete` |
 | Approval / governance | `client_input_approved`, `client_input_rejected`, `client_input_updated`, `governance_param_changed`, `approval:pending`, `approval:resolved` |
-| OAS bridge | `oas:masc:autonomy:agent_selected`, `oas:masc:autonomy:agent_decision`, `oas:masc:autonomy:agent_action_executed`, `oas:masc:keeper:snapshot`, `oas:masc:keeper:lifecycle`, `oas:masc:trust_updated`, `oas:masc:reputation_changed`, `oas:agent_started`, `oas:agent_completed`, `oas:tool_called`, `oas:tool_completed`, `oas:turn_started`, `oas:turn_completed`, `oas:context_compacted`, `oas:task_state_changed`, `oas:masc:harness:verdict_recorded`, `oas:masc:harness:pre_compact`, `oas:masc:harness:handoff` |
+| OAS bridge | `oas:masc:keeper:snapshot`, `oas:masc:keeper:lifecycle`, `oas:agent_started`, `oas:agent_completed`, `oas:tool_called`, `oas:tool_completed`, `oas:turn_started`, `oas:turn_completed`, `oas:context_compacted`, `oas:task_state_changed`, `oas:masc:harness:verdict_recorded`, `oas:masc:harness:pre_compact`, `oas:masc:harness:handoff` |
 | Server-push snapshots | `room_truth_snapshot`, `namespace_truth_snapshot`, `execution_snapshot`, `operator_snapshot`, `operator_digest`, `transport_health_snapshot` |
 
 ### 2. OAS custom events published by MASC
@@ -189,13 +189,8 @@ These originate in `lib/oas_events.ml` and are later relayed by `oas_event_bridg
 | `masc:board_post` | board post created |
 | `masc:task_transition` | task state transition |
 | `masc:heartbeat_recovered` | agent recovered from timeout |
-| `masc:autonomy:agent_selected` | autonomy selector chose an agent |
-| `masc:autonomy:agent_decision` | autonomy decision chosen |
-| `masc:autonomy:agent_action_executed` | autonomy action executed |
 | `masc:keeper:snapshot` | keeper heartbeat snapshot |
 | `masc:keeper:lifecycle` | keeper lifecycle update |
-| `masc:trust_updated` | trust score changed |
-| `masc:reputation_changed` | reputation changed |
 | `masc:institution_episode` | institution episode recorded |
 | `masc:harness:verdict_recorded` | harness verdict persisted |
 | `masc:harness:pre_compact` | pre-compaction observation |

--- a/docs/spec/13-oas-integration.md
+++ b/docs/spec/13-oas-integration.md
@@ -349,13 +349,8 @@ MASC 조율 이벤트를 OAS `Event_bus`에 `Custom("masc:<type>", json)` 형식
 | `masc:board_post` | board post 생성 |
 | `masc:task_transition` | task 상태 변경 |
 | `masc:heartbeat_recovered` | timeout 복구 |
-| `masc:autonomy:agent_selected` | Thompson Sampling 선택 |
-| `masc:autonomy:agent_decision` | MODEL 행동 결정 |
-| `masc:autonomy:agent_action_executed` | 행동 실행 완료 |
 | `masc:keeper:snapshot` | keeper 상태 스냅샷 |
 | `masc:keeper:lifecycle` | keeper 시작/중단/충돌/재시작 |
-| `masc:trust_updated` | 신뢰 점수 갱신 |
-| `masc:reputation_changed` | 평판 변경 |
 | `masc:institution_episode` | institution 에피소드 기록 |
 
 ### 8.2 SSE Relay (oas_event_bridge.ml)

--- a/lib/cascade/cascade_events.ml
+++ b/lib/cascade/cascade_events.ml
@@ -1,9 +1,9 @@
-(** MASC Event_bus publishers for runtime/social events.
+(** MASC Event_bus publishers for runtime events.
 
     Publishes MASC coordination events (broadcasts, heartbeats, board
-    posts, task transitions, keeper lifecycle, trust/reputation) to the
-    MASC-owned Event_bus. Events follow dot-separated snake_case naming
-    per OAS Custom-name convention: [masc.broadcast], [masc.heartbeat],
+    posts, task transitions, keeper lifecycle, audit) to the MASC-owned
+    Event_bus. Events follow dot-separated snake_case naming per OAS
+    Custom-name convention: [masc.broadcast], [masc.heartbeat],
     [masc.keeper.lifecycle], ...
 
     The [bus] argument is accepted for backward compatibility but
@@ -60,66 +60,6 @@ let publish_task_transition (_bus : Agent_sdk.Event_bus.t) ~agent_name ~task_id
     ("timestamp", `Float (Time_compat.now ()));
   ] in
   masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("masc.task_transition", payload)))
-
-(** {1 Autonomy Agent Lifecycle Events}
-
-    These three publishers were scaffolded in #1060 (OAS v0.23
-    integration, 2026-03-16) for the Thompson autonomy decision pipeline
-    but the producer side was never wired. They are kept (rather than
-    deleted like the truly-dead surfaces in #8857 [delete] tier)
-    because the Thompson autonomy area is still an open RFC. Tag with
-    @deprecated so consumers see the no-producer signal at compile time
-    if they try to subscribe; remove the annotations when a producer
-    finally lands. *)
-
-(** Publish an agent selection event (Thompson Sampling result).
-    Emitted after [select_agents_with_thompson] in keeper_heartbeat.
-    @deprecated Unused since #1060 (no producer wired). Tracked as
-    [mark scaffolding] tier of #8857; planned wiring in Thompson
-    autonomy RFC (open). *)
-let publish_agent_selected (_bus : Agent_sdk.Event_bus.t) ~agent_name ~trigger
-    ~thompson_score ~final_score =
-  let payload = `Assoc [
-    ("agent_name", `String agent_name);
-    ("trigger", `String trigger);
-    ("thompson_score", `Float thompson_score);
-    ("final_score", `Float final_score);
-    ("timestamp", `Float (Time_compat.now ()));
-  ] in
-  masc_publish
-    (Agent_sdk.Event_bus.mk_event (Custom ("masc.autonomy.agent_selected", payload)))
-
-(** Publish an agent action decision event (MODEL decision result).
-    Emitted after MODEL decides post/comment/upvote/skip.
-    @deprecated Unused since #1060 (no producer wired). Tracked as
-    [mark scaffolding] tier of #8857; planned wiring in Thompson
-    autonomy RFC (open). *)
-let publish_agent_decision (_bus : Agent_sdk.Event_bus.t) ~agent_name ~action
-    ~trigger_reason =
-  let payload = `Assoc [
-    ("agent_name", `String agent_name);
-    ("action", `String action);
-    ("trigger_reason", `String trigger_reason);
-    ("timestamp", `Float (Time_compat.now ()));
-  ] in
-  masc_publish
-    (Agent_sdk.Event_bus.mk_event (Custom ("masc.autonomy.agent_decision", payload)))
-
-(** Publish an action execution result event.
-    Emitted after an agent's action (post/comment/upvote) completes.
-    @deprecated Unused since #1060 (no producer wired). Tracked as
-    [mark scaffolding] tier of #8857; planned wiring in Thompson
-    autonomy RFC (open). *)
-let publish_agent_action_executed (_bus : Agent_sdk.Event_bus.t) ~agent_name
-    ~action ~success =
-  let payload = `Assoc [
-    ("agent_name", `String agent_name);
-    ("action", `String action);
-    ("success", `Bool success);
-    ("timestamp", `Float (Time_compat.now ()));
-  ] in
-  masc_publish
-    (Agent_sdk.Event_bus.mk_event (Custom ("masc.autonomy.agent_action_executed", payload)))
 
 (** {1 Keeper Snapshot Events} *)
 
@@ -242,40 +182,3 @@ let publish_audit_event ~id ~ts ~actor ~kind ?target ~summary ~severity
     ("payload", payload_json);
   ] in
   masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("masc.audit_event", event_payload)))
-
-(** {1 Phase 4: Social Events}
-
-    These two publishers were scaffolded in #1060 (OAS v0.23
-    integration, 2026-03-16) for the Phase 4 social network feature
-    (trust + reputation between agents). The producer side was never
-    wired and Phase 4 has not shipped. Tagged @deprecated so consumers
-    see the no-producer signal at compile time; remove the annotations
-    when Phase 4 producers land. Tracked as [mark scaffolding] tier
-    of #8857. *)
-
-(** Publish a trust score update between two agents.
-    @deprecated Unused since #1060 (no producer wired). Tracked as
-    [mark scaffolding] tier of #8857; planned wiring with Phase 4
-    social network feature (open). *)
-let publish_trust_updated (_bus : Agent_sdk.Event_bus.t) ~agent_a ~agent_b ~trust_score =
-  let payload = `Assoc [
-    ("agent_a", `String agent_a);
-    ("agent_b", `String agent_b);
-    ("trust_score", `Float trust_score);
-    ("timestamp", `Float (Time_compat.now ()));
-  ] in
-  masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("masc.trust_updated", payload)))
-
-(** Publish a reputation change event.
-    @deprecated Unused since #1060 (no producer wired). Tracked as
-    [mark scaffolding] tier of #8857; planned wiring with Phase 4
-    social network feature (open). *)
-let publish_reputation_changed (_bus : Agent_sdk.Event_bus.t) ~agent_name ~old_score ~new_score ~trend =
-  let payload = `Assoc [
-    ("agent_name", `String agent_name);
-    ("old_score", `Float old_score);
-    ("new_score", `Float new_score);
-    ("trend", `String trend);
-    ("timestamp", `Float (Time_compat.now ()));
-  ] in
-  masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("masc.reputation_changed", payload)))

--- a/lib/cascade/cascade_events.mli
+++ b/lib/cascade/cascade_events.mli
@@ -1,12 +1,11 @@
-(** Cascade_events — MASC Event_bus publishers for runtime / social
-    events.
+(** Cascade_events — MASC Event_bus publishers for runtime events.
 
     Publishes MASC coordination events (broadcasts, heartbeats,
-    board posts, task transitions, keeper lifecycle, trust /
-    reputation) to the **MASC-owned** Event_bus.  Events follow
-    dot-separated snake_case naming per OAS Custom-name
-    convention: [masc.broadcast], [masc.heartbeat],
-    [masc.keeper.lifecycle], ...
+    board posts, task transitions, keeper lifecycle, audit) to the
+    **MASC-owned** Event_bus.  Events follow dot-separated
+    snake_case naming per OAS Custom-name convention:
+    [masc.broadcast], [masc.heartbeat], [masc.keeper.lifecycle],
+    ...
 
     The [bus] argument is accepted for backward compatibility
     but ignored — every publish routes to
@@ -118,39 +117,6 @@ val publish_keeper_dead :
     [detail]) so subscribers can filter on a stable topic and
     pull the structured fields directly. *)
 
-(** {1 Autonomy lifecycle (deprecated — no producer)} *)
-
-val publish_agent_selected :
-  Agent_sdk.Event_bus.t ->
-  agent_name:string ->
-  trigger:string ->
-  thompson_score:float ->
-  final_score:float ->
-  unit
-[@@deprecated "Unused since #1060 (no producer wired). Tracked \
-               as 'mark scaffolding' tier of #8857; planned \
-               wiring in Thompson autonomy RFC (open)."]
-
-val publish_agent_decision :
-  Agent_sdk.Event_bus.t ->
-  agent_name:string ->
-  action:string ->
-  trigger_reason:string ->
-  unit
-[@@deprecated "Unused since #1060 (no producer wired). Tracked \
-               as 'mark scaffolding' tier of #8857; planned \
-               wiring in Thompson autonomy RFC (open)."]
-
-val publish_agent_action_executed :
-  Agent_sdk.Event_bus.t ->
-  agent_name:string ->
-  action:string ->
-  success:bool ->
-  unit
-[@@deprecated "Unused since #1060 (no producer wired). Tracked \
-               as 'mark scaffolding' tier of #8857; planned \
-               wiring in Thompson autonomy RFC (open)."]
-
 (** {1 Audit Ledger Events} *)
 
 val publish_audit_event :
@@ -171,28 +137,3 @@ val publish_audit_event :
     via SSE without polling.
 
     Shape: [{id, ts, actor, kind, target?, summary, severity, payload?}]. *)
-
-(** {1 Phase 4 social (deprecated — no producer)} *)
-
-val publish_trust_updated :
-  Agent_sdk.Event_bus.t ->
-  agent_a:string ->
-  agent_b:string ->
-  trust_score:float ->
-  unit
-[@@deprecated "Unused since #1060 (no producer wired). Tracked \
-               as 'mark scaffolding' tier of #8857; planned \
-               wiring with Phase 4 social network feature \
-               (open)."]
-
-val publish_reputation_changed :
-  Agent_sdk.Event_bus.t ->
-  agent_name:string ->
-  old_score:float ->
-  new_score:float ->
-  trend:string ->
-  unit
-[@@deprecated "Unused since #1060 (no producer wired). Tracked \
-               as 'mark scaffolding' tier of #8857; planned \
-               wiring with Phase 4 social network feature \
-               (open)."]

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -335,9 +335,9 @@ let start_keeper_loops
   in
   (* Create and install the MASC-owned Event_bus alongside OAS's.
      MASC domain events (masc.broadcast, masc.heartbeat, masc.keeper.*,
-     masc.autonomy.*, masc.harness.*, masc.trust_updated, ...) publish
-     here per OAS event_bus.mli:103-107 boundary. Dashboard SSE consumers
-     see both channels as one stream — the relay translates masc.* →
+     masc.harness.*, ...) publish here per OAS event_bus.mli:103-107
+     boundary. Dashboard SSE consumers see both channels as one stream
+     — the relay translates masc.* →
      masc:* on the wire for backward compatibility. *)
   let masc_event_bus =
     Masc_event_bus_policy.create_bus Masc_event_bus_policy.masc_domain


### PR DESCRIPTION
## Summary
- remove deprecated Cascade_events publishers that had zero producers/callers
- drop stale autonomy/trust event names from event inventory docs
- trim bootstrap comment so runtime event ownership only lists live MASC surfaces

## Verification
- ocamlformat --check lib/cascade/cascade_events.ml lib/cascade/cascade_events.mli lib/server/server_bootstrap_loops.ml
- git diff --check
- rg -n deletion target patterns lib test docs scripts bin => 0 hits
- Dune wrapper attempted with lockf, blocked by /tmp/me-dune-local.lock held by another worktree