### PR TITLE
fix(keeper): keep 524 out of same-cascade retry

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -72,11 +72,15 @@ let is_transient_network_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.Api (Overloaded _) -> true
   | Agent_sdk.Error.Api (ServerError { status = 503; _ }) -> true
   (* Cloudflare 52x timeout family — origin server unreachable or
-     slow to respond.  No LLM request was processed, so safe to retry.
+     slow to respond.
      522 = Connection timed out (TCP handshake failed).
-     524 = A timeout occurred (origin responded too slowly). *)
+     524 = A timeout occurred after the origin accepted the request; keep it
+     out of the same-cascade transient retry path so it can short-circuit into
+     the degraded cascade rotation server_error path instead. *)
   | Agent_sdk.Error.Api (ServerError { status = 522; _ }) -> true
-  | Agent_sdk.Error.Api (ServerError { status = 524; _ }) -> true
+  | Agent_sdk.Error.Api (ServerError { status = 524; _ }) -> false
+  | Agent_sdk.Error.Provider (Llm_provider.Error.ServerError { code = 524; _ }) ->
+      false
   | Agent_sdk.Error.Provider (Llm_provider.Error.ServerError { transient; _ }) ->
       transient
   (* Non-transient API errors. *)

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -347,6 +347,18 @@ let test_server_error_502_is_recoverable () =
   | None ->
     fail "ServerError 502 should be recoverable (trigger cascade rotation)"
 
+let test_server_error_524_is_recoverable_rotation_not_transient_retry () =
+  let err =
+    Agent_sdk.Error.Api
+      (Retry.ServerError { status = 524; message = "a timeout occurred" })
+  in
+  check bool "524 not same-cascade transient" false (KEC.is_transient_network_error err);
+  match KEC.recoverable_cascade_failure_reason err with
+  | Some reason ->
+    check string "524 -> server_error" "server_error" (KEC.degraded_retry_reason_to_string reason)
+  | None ->
+    fail "ServerError 524 should remain recoverable through degraded rotation"
+
 let test_auth_error_is_recoverable () =
   (* 401/403 auth errors: the current cascade's credentials are invalid.
      A different cascade with different credentials may succeed. *)
@@ -468,6 +480,8 @@ let () =
             test_server_error_503_is_recoverable;
           test_case "ServerError 502 is recoverable" `Quick
             test_server_error_502_is_recoverable;
+          test_case "ServerError 524 is rotation recoverable but not transient retry" `Quick
+            test_server_error_524_is_recoverable_rotation_not_transient_retry;
           test_case "AuthError is recoverable" `Quick
             test_auth_error_is_recoverable;
           test_case "hard quota keeps hard_quota label" `Quick

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -11591,12 +11591,12 @@ let () =
                        { status = 522
                        ; message = "Connection timed out"
                        }))))
-        ; test_case "ServerError 524 (Cloudflare gateway timeout) detected" `Quick
+        ; test_case "ServerError 524 short-circuits same-cascade transient retry" `Quick
           (fun () ->
             check
               bool
-              "524 cloudflare timeout is transient"
-              true
+              "524 cloudflare timeout is not same-cascade transient"
+              false
               (EC.is_transient_network_error
                  (Agent_sdk.Error.Api
                     (ServerError


### PR DESCRIPTION
## Summary
- treat HTTP 524 as a degraded-rotation server_error instead of a same-cascade transient retry
- keep HTTP 522 on the transient retry path
- add coverage that 524 remains recoverable through cascade rotation while short-circuiting transient retry

## Verification
- PASS: ocamlformat --check lib/keeper/keeper_error_classify.ml test/test_keeper_unified.ml test/test_keeper_error_classify_recoverable.ml
- PASS: git diff --check
- BLOCKED locally: scripts/dune-local.sh build test/test_keeper_error_classify_recoverable.exe test/test_keeper_unified.exe (wrapper refused because bare Dune processes were already running on the host)