### PR TITLE
refactor(cascade_transport): extract label-resolution helpers + type into sibling (Lane D second)

### DIFF
--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -71,35 +71,13 @@ let record_codex_cli_omission = Codex_omission_dedup.record_codex_cli_omission
     Explicit model-label execution must never silently substitute a
     discovery-only model. Callers are expected to validate labels
     before reaching this helper. *)
-type label_resolution_error = Invalid_model_label of string
+type label_resolution_error = Cascade_transport_label_resolution.label_resolution_error =
+  | Invalid_model_label of string
 
-let label_resolution_error_to_string = function
-  | Invalid_model_label label -> Printf.sprintf "invalid model label %S" label
-;;
-
-let label_resolution_error_to_sdk_error err =
-  Agent_sdk.Error.Config
-    (Agent_sdk.Error.InvalidConfig
-       { field = "model_label"; detail = label_resolution_error_to_string err })
-;;
-
-let resolve_provider_config_of_label (label : string)
-  : (Llm_provider.Provider_config.t, label_resolution_error) result
-  =
-  match Cascade_config.parse_model_string label with
-  | Some pc -> Ok pc
-  | None ->
-    Log.error
-      ~ctx:"oas_worker_exec"
-      "refusing unresolved explicit model label=%S; execution never falls back to \
-       discovery-only models"
-      label;
-    Error (Invalid_model_label label)
-;;
-
-let invalid_runtime_config field detail =
-  Agent_sdk.Error.Config (Agent_sdk.Error.InvalidConfig { field; detail })
-;;
+let label_resolution_error_to_string = Cascade_transport_label_resolution.label_resolution_error_to_string
+let label_resolution_error_to_sdk_error = Cascade_transport_label_resolution.label_resolution_error_to_sdk_error
+let resolve_provider_config_of_label = Cascade_transport_label_resolution.resolve_provider_config_of_label
+let invalid_runtime_config = Cascade_transport_label_resolution.invalid_runtime_config
 
 let cli_model_override = Cascade_transport_cli_config.cli_model_override
 

--- a/lib/cascade/cascade_transport_label_resolution.ml
+++ b/lib/cascade/cascade_transport_label_resolution.ml
@@ -1,0 +1,37 @@
+(** Model-label resolution errors + resolver, extracted from
+    cascade_transport.ml.
+
+    Maps a string label to a {!Llm_provider.Provider_config.t} via
+    {!Cascade_config.parse_model_string}; unresolved labels become
+    [Error (Invalid_model_label _)] — execution never falls back to
+    discovery-only models. *)
+
+type label_resolution_error = Invalid_model_label of string
+
+let label_resolution_error_to_string = function
+  | Invalid_model_label label -> Printf.sprintf "invalid model label %S" label
+;;
+
+let label_resolution_error_to_sdk_error err =
+  Agent_sdk.Error.Config
+    (Agent_sdk.Error.InvalidConfig
+       { field = "model_label"; detail = label_resolution_error_to_string err })
+;;
+
+let resolve_provider_config_of_label (label : string)
+  : (Llm_provider.Provider_config.t, label_resolution_error) result
+  =
+  match Cascade_config.parse_model_string label with
+  | Some pc -> Ok pc
+  | None ->
+    Log.error
+      ~ctx:"oas_worker_exec"
+      "refusing unresolved explicit model label=%S; execution never falls back to \
+       discovery-only models"
+      label;
+    Error (Invalid_model_label label)
+;;
+
+let invalid_runtime_config field detail =
+  Agent_sdk.Error.Config (Agent_sdk.Error.InvalidConfig { field; detail })
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane D (Cascade/Tools, second cluster)
- `cascade_transport.ml` is 1520 LOC (post #17138 merge). Carved out label-resolution error type + 4 helpers into a sibling using type-sharing constraint.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/cascade/cascade_transport.ml` | 1520 | 1498 | **-22** |
| `lib/cascade/cascade_transport_label_resolution.ml` | — | 38 | +38 |

## Moved (verbatim, no behavior change)
- `type label_resolution_error = Invalid_model_label of string`
- `label_resolution_error_to_string`
- `label_resolution_error_to_sdk_error`
- `resolve_provider_config_of_label`
- `invalid_runtime_config`

## Type sharing pattern
```ocaml
type label_resolution_error =
  Cascade_transport_label_resolution.label_resolution_error =
  | Invalid_model_label of string
```
This preserves external callsites (`cascade_runner.ml`, etc.) that construct/match `Invalid_model_label` without any qualifier change.

## Local build status
Local `dune build` hit a **pre-existing** partial-match warning-as-error at `lib/cascade/cascade_transport.ml:1063-1072` (`Cascade_attempt_liveness_config.(Observe, false, _)` missing arm). This is unrelated to this PR — present on main HEAD. Will rebuild green once that fix lands on main.

## RFC-WAIVED
Extract-only sibling refactor, no behavior change, governed by `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane D.

Co-Authored-By: codex <noreply@anthropic.com>
