### PR TITLE
fix(keeper_shell_bash): block background operator fallback

### DIFF
--- a/lib/keeper/keeper_shell_bash_shape_classifier.ml
+++ b/lib/keeper/keeper_shell_bash_shape_classifier.ml
@@ -77,6 +77,7 @@ let shell_ir_parse_failure_shape_block cmd =
   else if
     string_contains_substring scan_text "&&"
     || string_contains_substring scan_text "||"
+    || string_contains_char scan_text '&'
     || string_contains_char scan_text ';'
     || string_contains_char scan_text '\n'
     || string_contains_char scan_text '\r'

--- a/lib/keeper/keeper_shell_bash_shape_messages.ml
+++ b/lib/keeper/keeper_shell_bash_shape_messages.ml
@@ -31,8 +31,8 @@ let bash_shape_block_reason = function
     "Bash accepts one direct command. Pipes and redirects such as |, 2>&1, \
      2&1, >/dev/null, <, and | head are blocked before execution."
   | Chaining ->
-    "Bash accepts one command per call. Chaining with &&, ||, ;, or \
-     newlines is blocked before execution."
+    "Bash accepts one foreground command per call. Chaining/background \
+     control with &&, ||, &, ;, or newlines is blocked before execution."
   | Substitution ->
     "Command substitution is blocked before execution. Compute values in a \
      separate tool call and pass literal arguments."
@@ -63,8 +63,8 @@ let bash_shape_block_hint ~cmd = function
     "Do not prepend cd ... && to search commands. Pass the target repo or \
      worktree in the Grep path, or use Bash cwd with a single command."
   | Chaining ->
-    "Split the work into separate Bash calls and use the cwd argument instead \
-     of cd chaining."
+    "Split the work into separate foreground Bash calls and use the cwd \
+     argument instead of cd chaining or shell backgrounding."
   | Substitution ->
     "Run the discovery command first, then use its literal result in a second \
      Bash call."

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -365,6 +365,13 @@ let test_keeper_bash_shape_uses_shell_ir_for_quoted_literals () =
   Alcotest.(check (option string)) "parse-failure fallback remains conservative"
     (Some "substitution")
     (block_tag "echo $(complex-substitution)")
+  ;
+  Alcotest.(check (option string)) "background operator blocks"
+    (Some "chaining")
+    (block_tag "sleep 10 &")
+  ;
+  Alcotest.(check (option string)) "quoted ampersand is data" None
+    (block_tag {|echo "a & b"|})
 
 let test_keeper_bash_shell_ir_parse_failure_shape_fallback_is_quote_aware () =
   let block_tag =
@@ -388,7 +395,12 @@ let test_keeper_bash_shell_ir_parse_failure_shape_fallback_is_quote_aware () =
     (Some "substitution")
     (block_tag {|echo "$(date)"|});
   Alcotest.(check (option string)) "single-quoted substitution is data" None
-    (block_tag {|echo '$(date) > out'|})
+    (block_tag {|echo '$(date) > out'|});
+  Alcotest.(check (option string)) "background operator still blocks"
+    (Some "chaining")
+    (block_tag "sleep 10 &");
+  Alcotest.(check (option string)) "quoted ampersand stays data" None
+    (block_tag {|printf "%s\n" "a & b"|})
 
 let test_stderr_dev_null_strip_preserves_post_background_redirect () =
   let strip =


### PR DESCRIPTION
## Summary
- Treat unquoted shell background/control operator '&' as a blocked chaining shape in the keeper bash fallback classifier
- Update chaining guidance to mention foreground-only execution and shell backgrounding
- Add keeper bash safety regression checks for 'sleep 10 &' while preserving quoted ampersands as data

## Verification
- ocamlformat --check lib/keeper/keeper_shell_bash_shape_classifier.ml lib/keeper/keeper_shell_bash_shape_messages.ml test/test_keeper_bash_safety.ml
- git diff origin/main --check
- scripts/lint/godfile-size-regression.sh

## Local Dune note
- Attempted: env DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_keeper_bash_safety.exe
- Blocked by active bare Dune processes on this saturated host; no focused local Dune build completed. The regression is covered in test/test_keeper_bash_safety.ml for CI.