### PR TITLE
chore(http): rename error body wire-shape test

### DIFF
--- a/lib/server/server_mcp_transport_http_respond.ml
+++ b/lib/server/server_mcp_transport_http_respond.ml
@@ -43,14 +43,11 @@ let mcp_headers = Server_mcp_transport_http_headers.mcp_headers
 
 let json_headers = Server_mcp_transport_http_headers.json_headers
 
-(* RFC-0098 — typed SSOT for transport-boundary error envelopes.
-   New code should call [respond_mcp_error] with the typed
-   [Mcp_error_code.t] variant; the per-code factories below remain
-   as [@@deprecated] thin delegations during the migration window. *)
+(* RFC-0098 — typed SSOT for transport-boundary error envelopes. *)
 
 (** Pure-JSON body builder shared by [respond_mcp_error] and
-    [mcp_internal_error_json]. Splitting it out makes the wire-shape
-    diffable and testable without instantiating an [Httpun.Reqd.t]. *)
+    SSE batch builders. Splitting it out makes the wire shape diffable
+    and testable without instantiating an [Httpun.Reqd.t]. *)
 let error_body ?(id = `Null) ?data ~(code : Mcp_error_code.t) msg :
     Yojson.Safe.t =
   let error_fields =
@@ -100,14 +97,10 @@ let respond_mcp_error ?(extra_headers = []) ?data ?id
   in
   safe_respond_with_string reqd response body
 
-(* RFC-0098 PR-4 — legacy [respond_mcp_auth_error] /
-   [respond_mcp_internal_error] / [mcp_internal_error_json] removed.
-   PR-3 (#15793) migrated all 10 in-tree callers to [respond_mcp_error
-   ~code:...] / [error_body ~code:...]. The wrappers carried no
-   semantics beyond delegation and are gone. [respond_not_ready] is
-   intentionally retained — it runs before [json_headers] /
-   [session_id] are available; widening [respond_mcp_error] to the
-   pre-runtime case is a separate concern. *)
+(* [respond_not_ready] is intentionally retained outside
+   [respond_mcp_error]: it runs before [json_headers] / [session_id]
+   are available. Widening [respond_mcp_error] to the pre-runtime case
+   is a separate concern. *)
 
 let respond_not_ready ~(deps : Server_mcp_transport_http_types.deps) request reqd =
   let origin = deps.get_origin request in
@@ -162,6 +155,3 @@ let respond_sse_rate_limited ~(deps : Server_mcp_transport_http_types.deps) ~ori
   in
   let response = Httpun.Response.create ~headers `Too_many_requests in
   safe_respond_with_string reqd response body
-
-(* RFC-0098 PR-4: [mcp_internal_error_json] removed.
-   Call [error_body ~code:Mcp_error_code.Internal_error ...] directly. *)

--- a/lib/server/server_mcp_transport_http_respond.mli
+++ b/lib/server/server_mcp_transport_http_respond.mli
@@ -34,11 +34,6 @@ val json_headers :
     this module so a future "rebrand the json content type" change
     must touch one site. *)
 
-(* RFC-0098 PR-4: legacy [respond_mcp_auth_error] /
-   [respond_mcp_internal_error] removed. Use [respond_mcp_error
-   ~code:Mcp_error_code.Auth_error] / [~code:Mcp_error_code.Internal_error]
-   directly. *)
-
 val respond_not_ready :
   deps:Server_mcp_transport_http_types.deps ->
   Httpun.Request.t ->
@@ -89,9 +84,6 @@ val respond_sse_rate_limited :
     [sse_connection_rate_limited]; dashboards / log greps depend on
     the exact spelling. *)
 
-(* RFC-0098 PR-4: legacy [mcp_internal_error_json] removed. Use
-   [error_body ~code:Mcp_error_code.Internal_error ...] directly. *)
-
 val error_body :
   ?id:Yojson.Safe.t ->
   ?data:Yojson.Safe.t ->
@@ -107,8 +99,7 @@ val error_body :
     Defaults: [id = `Null] (per JSON-RPC 2.0 §5.1), no [data] field.
 
     Used internally by {!respond_mcp_error}; exposed here for callers
-    that build SSE batch frames (the {!mcp_internal_error_json}
-    use-case generalised to any {!Mcp_error_code.t}). *)
+    that build SSE batch frames with any {!Mcp_error_code.t}. *)
 
 val respond_mcp_error :
   ?extra_headers:(string * string) list ->
@@ -144,9 +135,5 @@ val respond_mcp_error :
     - [Backpressure_shed] adds [retry-after: 1].
 
     [extra_headers] are prepended; {!json_headers} append.  The
-    function never raises (uses the same safe_respond_with_string
-    helper as the legacy factories).
-
-    PR-1 (RFC-0098) introduces this SSOT in parallel with the legacy
-    four factories. PR-2 migrates the legacy factories to thin
-    delegations and marks them [@@deprecated]. *)
+    function never raises; response writes go through the module's
+    guarded response helper. *)

--- a/test/dune
+++ b/test/dune
@@ -44,7 +44,7 @@
   test_auth_error_kind
   test_auth_error_kind_dashboard_fallback
   test_mcp_error_code
-  test_error_body_delegation
+  test_error_body_wire_shape
   test_session_lifecycle_event
   test_fd_accountant
   test_auth_login
@@ -364,7 +364,7 @@
   test_auth_error_kind
   test_auth_error_kind_dashboard_fallback
   test_mcp_error_code
-  test_error_body_delegation
+  test_error_body_wire_shape
   test_session_lifecycle_event
   test_fd_accountant
   test_auth_login

--- a/test/test_error_body_wire_shape.ml
+++ b/test/test_error_body_wire_shape.ml
@@ -1,13 +1,8 @@
 (** Wire-shape assertions for [error_body] — the RFC-0098 SSOT.
 
-    Originally written at PR-2 to assert *parity* between legacy
-    [mcp_internal_error_json] and the new [error_body]. PR-4 removed
-    the legacy function entirely; what remains is the standalone
-    wire-shape contract for [error_body], plus a regression guard
-    pinning the JSON-RPC 2.0 §5.1 [["id": null]] compliance fix
-    introduced in PR-2.
-
-    File name retained to keep git-blame continuity across PR-2 → PR-4. *)
+    The tests pin the standalone JSON-RPC error-body contract and the
+    JSON-RPC 2.0 §5.1 [["id": null]] compliance fix introduced in
+    PR-2. *)
 
 open Alcotest
 module R = Masc_mcp.Server_mcp_transport_http_respond
@@ -106,7 +101,7 @@ let test_wire_byte_change_documented () =
        must include id:null per JSON-RPC 2.0 §5.1"
 
 let () =
-  Alcotest.run "Error_body_delegation"
+  Alcotest.run "Error_body_wire_shape"
     [
       ( "error_body wire shape",
         [


### PR DESCRIPTION
## Summary
- rename test_error_body_delegation to test_error_body_wire_shape after delegation wrappers were removed
- update test/dune references
- trim stale RFC-0098 legacy-wrapper tombstone comments from the HTTP response module

## Verification
- ocamlformat --check lib/server/server_mcp_transport_http_respond.ml lib/server/server_mcp_transport_http_respond.mli test/test_error_body_wire_shape.ml
- git diff --check
- rg -n stale legacy-wrapper/test names lib/server test/dune test/test_error_body_wire_shape.ml => 0 hits
- Dune wrapper attempted for test/test_error_body_wire_shape.exe, blocked by /tmp/me-dune-local.lock held by another worktree