### PR TITLE
feat(keeper): project working state sidecar

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -771,6 +771,7 @@ export interface KeeperRuntimeLensContextAxis {
   checkpoint_loaded_count: number
   checkpoint_saved_count: number
   state_snapshot_sidecar_saved_count: number
+  active_open_loop_count: number
   last_compaction: unknown
 }
 
@@ -1129,6 +1130,7 @@ function parseRuntimeLensContextAxis(raw: unknown): KeeperRuntimeLensContextAxis
     checkpoint_loaded_count: numberField(obj, 'checkpoint_loaded_count'),
     checkpoint_saved_count: numberField(obj, 'checkpoint_saved_count'),
     state_snapshot_sidecar_saved_count: numberField(obj, 'state_snapshot_sidecar_saved_count'),
+    active_open_loop_count: numberField(obj, 'active_open_loop_count'),
     last_compaction: obj.last_compaction ?? null,
   }
 }

--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -545,6 +545,7 @@ describe('RuntimeLensSection', () => {
             checkpoint_loaded_count: 1,
             checkpoint_saved_count: 1,
             state_snapshot_sidecar_saved_count: 1,
+            active_open_loop_count: 2,
             last_compaction: null,
           },
           memory: {
@@ -722,6 +723,8 @@ describe('RuntimeLensSection', () => {
     expect(screen.getByText('keeper_bash, keeper_pr_create')).toBeInTheDocument()
     expect(screen.getByText('network proof')).toBeInTheDocument()
     expect(screen.getByText('inherit')).toBeInTheDocument()
+    expect(screen.getByText('working loops')).toBeInTheDocument()
+    expect(screen.getAllByText('2').length).toBeGreaterThan(0)
     expect(screen.getByText('provider attempts')).toBeInTheDocument()
     expect(screen.getAllByText('1/1').length).toBeGreaterThan(0)
     expect(screen.getByText('provider terminal')).toBeInTheDocument()

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -968,6 +968,7 @@ export function RuntimeLensSection({
         <${SignalRow} label="proof tools" value=${formatLensList(proof.tools)} />
         <${SignalRow} label="network proof" value=${formatLensList(proof.network_modes)} />
         <${SignalRow} label="context compaction" value=${formatRatioPair({ numerator: context.context_compacted_count, denominator: context.context_compact_started_count })} />
+        <${SignalRow} label="working loops" value=${context.active_open_loop_count} />
         <${SignalRow} label="memory flush" value=${formatIndependentCounters({ leftLabel: 'success', leftValue: memory.memory_flush_success_count, rightLabel: 'error', rightValue: memory.memory_flush_error_count })} />
         <${SignalRow} label="trace id" value=${compactToken(trace.trace_id)} />
         <${SignalRow}

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1278,20 +1278,37 @@ let run_turn
                     let latest_state_snapshot_sidecar_path =
                       Filename.concat session.session_dir "state-snapshot.latest.json"
                     in
+                    let state_snapshot_ts = Masc_domain.now_iso () in
+                    let state_snapshot_updated_at_unix = Time_compat.now () in
+                    let working_state =
+                      Keeper_working_state_projector.of_state_snapshot
+                        ~keeper_name:meta.name
+                        ~trace_id
+                        ~keeper_turn_id:manifest_keeper_turn_id
+                        ~updated_at_iso:state_snapshot_ts
+                        ~updated_at_unix:state_snapshot_updated_at_unix
+                        state_snapshot
+                    in
+                    let active_open_loop_count =
+                      Keeper_working_state.active_open_loop_count working_state
+                    in
                     let state_snapshot_payload =
                       `Assoc
                         [
                           ("schema_version", `Int 1);
-                          ("ts", `String (Masc_domain.now_iso ()));
+                          ("ts", `String state_snapshot_ts);
                           ("keeper_name", `String meta.name);
                           ("agent_name", `String meta.agent_name);
                           ("trace_id", `String trace_id);
                           ("generation", `Int generation);
                           ("keeper_turn_id", `Int manifest_keeper_turn_id);
                           ("oas_turn_count", `Int result.turns);
+                          ("active_open_loop_count", `Int active_open_loop_count);
                           ( "state_snapshot",
                             Keeper_memory_policy.keeper_state_snapshot_to_json
                               state_snapshot );
+                          ( "working_state",
+                            Keeper_working_state.to_json working_state );
                         ]
                     in
                     let state_snapshot_sidecar_saved =
@@ -1349,6 +1366,13 @@ let run_turn
                               `String latest_state_snapshot_sidecar_path );
                             ( "state_snapshot_sidecar_saved",
                               `Bool state_snapshot_sidecar_saved );
+                            ( "active_open_loop_count",
+                              `Int active_open_loop_count );
+                            ( "working_state_prompt_digest_ids",
+                              `List
+                                (List.map
+                                   (fun id -> `String id)
+                                   working_state.prompt_digest_ids) );
                             ( "source",
                               `String state_snapshot_source );
                           ])

--- a/lib/keeper/keeper_working_state_projector.ml
+++ b/lib/keeper/keeper_working_state_projector.ml
@@ -1,0 +1,85 @@
+(** Deterministic projection from keeper continuity snapshots to working state. *)
+
+module Snapshot = Keeper_memory_policy
+module State = Keeper_working_state
+
+type source_field =
+  | Next_item
+  | Open_question
+
+let source_field_name = function
+  | Next_item -> "next_items"
+  | Open_question -> "open_questions"
+
+let source_field_why = function
+  | Next_item -> "keeper_state_snapshot.next_items"
+  | Open_question -> "keeper_state_snapshot.open_questions"
+
+let trim_nonempty value =
+  let value = String.trim value in
+  if String.equal value "" then None else Some value
+
+let dedupe_keep_order values =
+  let rec loop seen acc = function
+    | [] -> List.rev acc
+    | value :: rest when List.mem value seen -> loop seen acc rest
+    | value :: rest -> loop (value :: seen) (value :: acc) rest
+  in
+  loop [] [] values
+
+let normalized_items values =
+  values |> List.filter_map trim_nonempty |> dedupe_keep_order
+
+let digest12 text =
+  let digest = Digest.string text |> Digest.to_hex in
+  String.sub digest 0 12
+
+let loop_id ~source ~index text =
+  Printf.sprintf "snapshot-%s-%02d-%s"
+    (source_field_name source)
+    (index + 1)
+    (digest12 text)
+
+let evidence_refs ~trace_id ~keeper_turn_id ~source ~index =
+  [ State.make_evidence_ref ~kind:"trace_id" ~target:trace_id
+  ; State.make_evidence_ref ~kind:"keeper_turn_id"
+      ~target:(string_of_int keeper_turn_id)
+  ; State.make_evidence_ref ~kind:"state_snapshot_field"
+      ~target:
+        (Printf.sprintf "%s[%d]" (source_field_name source) index)
+  ]
+
+let six_w ~keeper_name ~trace_id ~updated_at_iso ~source text =
+  State.make_six_w ~who:keeper_name ~what:text ~when_:updated_at_iso
+    ~where_:(Printf.sprintf "trace:%s" trace_id)
+    ~why:(source_field_why source)
+    ~how:"projected from the latest keeper state snapshot sidecar"
+
+let loops_of_items ~keeper_name ~trace_id ~keeper_turn_id ~updated_at_iso
+    ~updated_at_unix ~source items =
+  items
+  |> List.mapi (fun index text ->
+         State.make_loop
+           ~id:(loop_id ~source ~index text)
+           ~title:text
+           ~six_w:(six_w ~keeper_name ~trace_id ~updated_at_iso ~source text)
+           ~evidence_refs:(evidence_refs ~trace_id ~keeper_turn_id ~source ~index)
+           ~updated_at_unix
+           ())
+
+let of_state_snapshot ~keeper_name ~trace_id ~keeper_turn_id ~updated_at_iso
+    ~updated_at_unix (snapshot : Snapshot.keeper_state_snapshot) =
+  let next_items = normalized_items snapshot.next_items in
+  let open_questions = normalized_items snapshot.open_questions in
+  let active_loops =
+    loops_of_items ~keeper_name ~trace_id ~keeper_turn_id ~updated_at_iso
+      ~updated_at_unix ~source:Next_item next_items
+    @ loops_of_items ~keeper_name ~trace_id ~keeper_turn_id ~updated_at_iso
+        ~updated_at_unix ~source:Open_question open_questions
+  in
+  State.compact { State.empty with active_loops }
+
+let active_open_loop_count_of_state_snapshot
+    (snapshot : Snapshot.keeper_state_snapshot) =
+  List.length (normalized_items snapshot.next_items)
+  + List.length (normalized_items snapshot.open_questions)

--- a/lib/keeper/keeper_working_state_projector.mli
+++ b/lib/keeper/keeper_working_state_projector.mli
@@ -1,0 +1,13 @@
+(** Deterministic projection from keeper continuity snapshots to working state. *)
+
+val of_state_snapshot :
+  keeper_name:string ->
+  trace_id:string ->
+  keeper_turn_id:int ->
+  updated_at_iso:string ->
+  updated_at_unix:float ->
+  Keeper_memory_policy.keeper_state_snapshot ->
+  Keeper_working_state.t
+
+val active_open_loop_count_of_state_snapshot :
+  Keeper_memory_policy.keeper_state_snapshot -> int

--- a/lib/server/server_dashboard_http_keeper_api_runtime_lens.ml
+++ b/lib/server/server_dashboard_http_keeper_api_runtime_lens.ml
@@ -227,6 +227,9 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
                       (runtime_lens_event_count scan
                          Keeper_runtime_manifest.State_snapshot_sidecar_saved)
                   );
+                  ( "active_open_loop_count",
+                    `Int
+                      (Option.value scan.active_open_loop_count ~default:0) );
                   ( "last_compaction",
                     match scan.last_compaction with
                     | Some value -> value

--- a/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
@@ -35,6 +35,7 @@ type runtime_manifest_scan =
   ; mutable latest_pre_dispatch_blocked_row : Keeper_runtime_manifest.t option
   ; mutable context_injected_count : int
   ; mutable context_compacted_event_count : int
+  ; mutable active_open_loop_count : int option
   ; mutable provider_started_count : int
   ; mutable provider_finished_count : int
   ; mutable provider_terminal_row : Keeper_runtime_manifest.t option
@@ -70,6 +71,7 @@ let make_runtime_manifest_scan ~path ~limit =
   ; latest_pre_dispatch_blocked_row = None
   ; context_injected_count = 0
   ; context_compacted_event_count = 0
+  ; active_open_loop_count = None
   ; provider_started_count = 0
   ; provider_finished_count = 0
   ; provider_terminal_row = None
@@ -127,6 +129,10 @@ let update_runtime_manifest_scan scan row =
      scan.context_injected_count <- scan.context_injected_count + 1
    | Keeper_runtime_manifest.Context_compacted ->
      scan.context_compacted_event_count <- scan.context_compacted_event_count + 1
+   | Keeper_runtime_manifest.State_snapshot_sidecar_saved ->
+     scan.active_open_loop_count <-
+       json_int_member_opt "active_open_loop_count"
+         row.Keeper_runtime_manifest.decision
    | Keeper_runtime_manifest.Event_bus_correlated ->
      let decision = row.Keeper_runtime_manifest.decision in
      scan.event_bus_count <- scan.event_bus_count + 1;

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -1151,6 +1151,12 @@ let test_runtime_trace_lens_summarizes_tool_axis () =
         (M.make ~ts:"2026-05-13T00:00:02Z" ~keeper_name
            ~trace_id ~keeper_turn_id ~event:M.Turn_finished ~status:"error"
            ());
+      append_manifest_or_fail config
+        (M.make ~ts:"2026-05-13T00:00:03Z" ~keeper_name
+           ~trace_id ~keeper_turn_id
+           ~event:M.State_snapshot_sidecar_saved ~status:"saved"
+           ~decision:(`Assoc [ ("active_open_loop_count", `Int 3) ])
+           ());
       let status, json =
         Masc_mcp.Server_dashboard_http_keeper_api.keeper_runtime_trace_json
           config keeper_name ~trace_id ~turn_id:keeper_turn_id ()
@@ -1177,6 +1183,7 @@ let test_runtime_trace_lens_summarizes_tool_axis () =
       in
       let claim_scope = Yojson.Safe.Util.(axes |> member "claim_scope") in
       let config_drift = Yojson.Safe.Util.(axes |> member "config_drift") in
+      let context = Yojson.Safe.Util.(axes |> member "context") in
       Alcotest.(check (list string))
         "lens requested tools"
         [ "read_file" ]
@@ -1221,6 +1228,10 @@ let test_runtime_trace_lens_summarizes_tool_axis () =
         "lens config drift surfaces missing keeper meta"
         "keeper_missing"
         Yojson.Safe.Util.(config_drift |> member "status" |> to_string);
+      Alcotest.(check int)
+        "lens active open loop count"
+        3
+        (json_int_member "active_open_loop_count" context);
       let api_manifest_rows =
         Yojson.Safe.Util.(json |> member "manifest_rows" |> to_list)
       in

--- a/test/test_keeper_working_state.ml
+++ b/test/test_keeper_working_state.ml
@@ -108,6 +108,28 @@ let test_json_roundtrip () =
     check int "resolved count" 1 (List.length decoded.resolved_loops);
     check bool "valid" true (Result.is_ok (WS.validate decoded))
 
+let test_projector_maps_snapshot_items_to_active_loops () =
+  let snapshot =
+    { Masc_mcp.Keeper_memory_policy.empty_keeper_state_snapshot with
+      next_items = [ "finish PR"; " "; "finish PR" ]
+    ; open_questions = [ "check CI?" ]
+    }
+  in
+  let state =
+    Masc_mcp.Keeper_working_state_projector.of_state_snapshot
+      ~keeper_name:"keeper-a"
+      ~trace_id:"trace-1"
+      ~keeper_turn_id:7
+      ~updated_at_iso:"2026-05-21T02:00:00+09:00"
+      ~updated_at_unix:3.0
+      snapshot
+  in
+  check int "deduped active loop count" 2 (WS.active_open_loop_count state);
+  check (list string) "digest covers active loops"
+    (List.map (fun loop -> loop.WS.id) state.active_loops)
+    state.prompt_digest_ids;
+  check bool "valid projected state" true (Result.is_ok (WS.validate state))
+
 let () =
   run "Keeper_working_state"
     [
@@ -128,5 +150,7 @@ let () =
           test_case "active loop must appear in digest" `Quick
             test_validate_rejects_active_missing_from_digest;
           test_case "json roundtrip" `Quick test_json_roundtrip;
+          test_case "projector maps snapshot items to active loops" `Quick
+            test_projector_maps_snapshot_items_to_active_loops;
         ] );
     ]


### PR DESCRIPTION
## Summary
- project keeper state snapshots into a deterministic Keeper_working_state sidecar payload
- persist active_open_loop_count with the state snapshot sidecar manifest event
- expose active_open_loop_count through the runtime lens and dashboard row

## Validation
- ocamlformat --check lib/keeper/keeper_working_state_projector.ml lib/keeper/keeper_working_state_projector.mli lib/keeper/keeper_agent_run.ml lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml lib/server/server_dashboard_http_keeper_api_runtime_lens.ml test/test_keeper_working_state.ml test/test_keeper_runtime_manifest.ml
- ocamlc -stop-after parsing lib/keeper/keeper_working_state_projector.ml
- ocamlc -stop-after parsing test/test_keeper_working_state.ml
- git diff --check origin/main...HEAD
- pnpm --dir dashboard typecheck
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/api/keeper.test.ts src/components/keeper-detail-runtime.test.ts --no-file-parallelism --maxWorkers=1

## Not run
- scripts/dune-local.sh build test/test_keeper_working_state.exe test/test_keeper_runtime_manifest.exe: refused because other sessions are running bare dune build outside scripts/dune-local.sh