### PR TITLE
chore(coord): purge room readiness aliases

### DIFF
--- a/lib/coord_assertions.ml
+++ b/lib/coord_assertions.ml
@@ -29,7 +29,7 @@ type agent_state =
   }
 
 type assertion_kind =
-  | Room_set (* legacy alias: namespace_ready *)
+  | Room_set
   | Joined
   | Task_claimed
   | Current_task_set
@@ -50,7 +50,7 @@ let all_assertion_kinds =
 let valid_assertion_strings = List.map assertion_kind_to_string all_assertion_kinds
 
 let assertion_kind_of_string_lenient = function
-  | "room_set" | "namespace_ready" | "project_ready" -> Some Room_set
+  | "room_set" -> Some Room_set
   | "joined" -> Some Joined
   | "task_claimed" -> Some Task_claimed
   | "current_task_set" -> Some Current_task_set
@@ -101,9 +101,7 @@ let check_assertion st assertion =
 
 let state_to_json st =
   `Assoc
-    [ "project_ready", `Bool st.room_set
-    ; "namespace_ready", `Bool st.room_set
-    ; "room_set", `Bool st.room_set
+    [ "room_set", `Bool st.room_set
     ; "joined", `Bool st.joined
     ; "task_claimed", `Bool st.task_claimed
     ; "current_task_set", `Bool st.current_task_set
@@ -116,7 +114,7 @@ let handle_check ~(inspect_state : context -> agent_state) ~tool_name ~start_tim
   =
   let st = inspect_state ctx in
   let default_assertions =
-    [ "project_ready"; "joined"; "task_claimed"; "current_task_set"; "worktree_active" ]
+    [ "room_set"; "joined"; "task_claimed"; "current_task_set"; "worktree_active" ]
   in
   let assertions =
     match Yojson.Safe.Util.member "assertions" args with

--- a/lib/coord_assertions.mli
+++ b/lib/coord_assertions.mli
@@ -41,7 +41,7 @@ type agent_state =
     pinned. *)
 type assertion_kind =
   | Room_set
-  (** Project root configured (legacy aliases: [namespace_ready], [project_ready]). *)
+  (** Project root configured. *)
   | Joined (** Agent has joined the project namespace. *)
   | Task_claimed (** Agent owns at least one claimed task. *)
   | Current_task_set (** [current_task] is set, fresh, and unambiguous. *)
@@ -65,17 +65,15 @@ val all_assertion_kinds : assertion_kind list
 val valid_assertion_strings : string list
 
 (** [assertion_kind_of_string_lenient s] parses an assertion
-    name leniently: in addition to the canonical
-    [assertion_kind_to_string] outputs, it accepts the legacy
-    aliases [namespace_ready] / [project_ready] (both -> [Room_set]).
+    name from the canonical [assertion_kind_to_string] outputs.
 
     Returns [None] for any other input — the {!handle_check}
     handler reports unknown assertions as a passing failure with
     a fix hint listing {!valid_assertion_strings}.
 
-    Adding a new alias requires touching this function explicitly;
-    .mli hides the alias set on purpose so a future "be more
-    lenient" PR must extend the contract. *)
+    Adding a new accepted string requires touching this function
+    explicitly; .mli hides the parse set on purpose so a future
+    compatibility PR must extend the contract. *)
 val assertion_kind_of_string_lenient : string -> assertion_kind option
 
 (** {1 Tool entry point} *)
@@ -90,9 +88,8 @@ val assertion_kind_of_string_lenient : string -> assertion_kind option
     - [args] is the raw JSON-RPC params.  Recognises an optional
       [assertions: [<string>...]] array; missing or non-list values
       fall back to the canonical defaults (the five
-      [project_ready / joined / task_claimed / current_task_set /
-      worktree_active] strings — note [project_ready] is the legacy
-      alias for [room_set]).  An empty list also falls back to
+      [room_set / joined / task_claimed / current_task_set /
+      worktree_active] strings.  An empty list also falls back to
       defaults so callers cannot accidentally pass nothing.
 
     {2 Return value}

--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -715,9 +715,7 @@ let inspect_state ctx =
 
 let state_to_json st =
   `Assoc
-    [ "project_ready", `Bool st.room_set
-    ; "namespace_ready", `Bool st.room_set
-    ; "room_set", `Bool st.room_set
+    [ "room_set", `Bool st.room_set
     ; "joined", `Bool st.joined
     ; "task_claimed", `Bool st.task_claimed
     ; "current_task_set", `Bool st.current_task_set

--- a/lib/tool_schemas/tool_schemas_coord_core.ml
+++ b/lib/tool_schemas/tool_schemas_coord_core.ml
@@ -84,7 +84,7 @@ Pair with masc_workflow_guide for next-step recommendations.";
              `List
                (List.map (fun s -> `String s) assertion_kind_enum_strings));
           ]);
-          ("description", `String "List of state assertions to check. Each returns true/false with a fix hint if false. Canonical readiness key is 'room_set'; 'project_ready' and 'namespace_ready' are accepted aliases at the parser layer.");
+          ("description", `String "List of state assertions to check. Each returns true/false with a fix hint if false. Canonical readiness key is 'room_set'.");
         ]);
       ]);
       ("required", `List [`String "assertions"]);

--- a/lib/workflow_guide.ml
+++ b/lib/workflow_guide.ml
@@ -23,7 +23,7 @@ let empty = { next_steps = []; preconditions = []; common_mistakes = [] }
 
 let s tool reason = { tool; reason }
 
-let project_ready = "project_ready"
+let room_set_assertion = "room_set"
 
 let transition_action args =
   let open Yojson.Safe.Util in
@@ -55,7 +55,7 @@ let after_join ~success =
         [ s "masc_status" "Check current namespace state and available tasks";
           s "masc_transition" "Claim an existing task if available (action=claim)";
           s "masc_add_task" "Create a new task if none exist" ];
-      preconditions = [ project_ready ];
+      preconditions = [ room_set_assertion ];
       common_mistakes =
         [ "Skipping masc_status — you may duplicate work another agent claimed" ] }
   else
@@ -70,7 +70,7 @@ let after_status ~success =
         [ s "masc_transition" "Claim a task from the available list (action=claim)";
           s "masc_add_task" "Add a new task if the list is empty";
           s "masc_workflow_guide" "Get personalized guidance for your current state" ];
-      preconditions = [ project_ready; "joined" ];
+      preconditions = [ room_set_assertion; "joined" ];
       common_mistakes = [] }
   else
     { next_steps =
@@ -84,14 +84,14 @@ let after_claim_auto_bound ~success =
     { next_steps =
         [ s "masc_worktree_create" "Create an isolated worktree for this task";
           s "masc_heartbeat" "Signal liveness before starting long work" ];
-      preconditions = [ project_ready; "joined" ];
+      preconditions = [ room_set_assertion; "joined" ];
       common_mistakes =
         [ "Forgetting masc_worktree_create — working on main branch directly" ] }
   else
     { next_steps =
         [ s "masc_status" "Check which tasks are available";
           s "masc_add_task" "Create a task if none exist" ];
-      preconditions = [ project_ready; "joined" ];
+      preconditions = [ room_set_assertion; "joined" ];
       common_mistakes = [] }
 
 let after_transition_claim ~success =
@@ -99,14 +99,14 @@ let after_transition_claim ~success =
     { next_steps =
         [ s "masc_worktree_create" "Create an isolated worktree for this task";
           s "masc_heartbeat" "Signal liveness before starting long work" ];
-      preconditions = [ project_ready; "joined" ];
+      preconditions = [ room_set_assertion; "joined" ];
       common_mistakes =
         [ "Forgetting masc_worktree_create — working on main branch directly" ] }
   else
     { next_steps =
         [ s "masc_status" "Check which tasks are available";
           s "masc_add_task" "Create a task if none exist" ];
-      preconditions = [ project_ready; "joined" ];
+      preconditions = [ room_set_assertion; "joined" ];
       common_mistakes = [] }
 
 let after_transition_start ~success =
@@ -115,13 +115,13 @@ let after_transition_start ~success =
         [ s "masc_heartbeat" "Signal liveness before and during longer work";
           s "masc_broadcast" "Share that you started active implementation";
           s "masc_transition" "Mark the task complete when implementation is finished (action=done)" ];
-      preconditions = [ project_ready; "joined"; "task_claimed"; "current_task_set" ];
+      preconditions = [ room_set_assertion; "joined"; "task_claimed"; "current_task_set" ];
       common_mistakes = [] }
   else
     { next_steps =
         [ s "masc_status" "Check the task state before retrying the transition";
           s "masc_workflow_guide" "Inspect your current namespace/task readiness" ];
-      preconditions = [ project_ready; "joined" ];
+      preconditions = [ room_set_assertion; "joined" ];
       common_mistakes = [] }
 
 let after_transition_release_or_cancel ~success =
@@ -130,13 +130,13 @@ let after_transition_release_or_cancel ~success =
         [ s "masc_status" "Check the remaining backlog after releasing or cancelling the task";
           s "masc_transition" "Claim another task if work should continue (action=claim)";
           s "masc_add_task" "Create a replacement task only if the cancelled work still needs tracking" ];
-      preconditions = [ project_ready; "joined" ];
+      preconditions = [ room_set_assertion; "joined" ];
       common_mistakes = [] }
   else
     { next_steps =
         [ s "masc_status" "Check task state and ownership before retrying";
           s "masc_workflow_guide" "Inspect your current namespace/task readiness" ];
-      preconditions = [ project_ready; "joined" ];
+      preconditions = [ room_set_assertion; "joined" ];
       common_mistakes = [] }
 
 let after_transition_generic ~success =
@@ -144,14 +144,14 @@ let after_transition_generic ~success =
     { next_steps =
         [ s "masc_status" "Refresh namespace state after the transition";
           s "masc_workflow_guide" "Inspect the next recommended step for your current state" ];
-      preconditions = [ project_ready; "joined" ];
+      preconditions = [ room_set_assertion; "joined" ];
       common_mistakes =
         [ "masc_transition follow-up depends on action. claim should auto-bind current_task, while done/release/cancel may clear it." ] }
   else
     { next_steps =
         [ s "masc_status" "Check task state before retrying the transition";
           s "masc_workflow_guide" "Inspect your current namespace/task readiness" ];
-      preconditions = [ project_ready; "joined" ];
+      preconditions = [ room_set_assertion; "joined" ];
       common_mistakes = [] }
 
 let after_add_task ~success =
@@ -159,13 +159,13 @@ let after_add_task ~success =
     { next_steps =
         [ s "masc_transition" "Claim the task you just created (action=claim)";
           s "masc_status" "Verify the task appears in the list" ];
-      preconditions = [ project_ready; "joined" ];
+      preconditions = [ room_set_assertion; "joined" ];
       common_mistakes =
         [ "Creating a task without claiming it — another agent may take it" ] }
   else
     { next_steps =
         [ s "masc_status" "Check namespace state for errors" ];
-      preconditions = [ project_ready; "joined" ];
+      preconditions = [ room_set_assertion; "joined" ];
       common_mistakes = [] }
 
 let after_plan_set_task ~success =
@@ -173,13 +173,13 @@ let after_plan_set_task ~success =
     { next_steps =
         [ s "masc_worktree_create" "Create worktree for isolated work";
           s "masc_heartbeat" "Signal liveness before starting long work" ];
-      preconditions = [ project_ready; "joined"; "task_claimed" ];
+      preconditions = [ room_set_assertion; "joined"; "task_claimed" ];
       common_mistakes = [] }
   else
     { next_steps =
         [ s "masc_transition" "Claim a task first (action=claim)";
           s "masc_status" "Verify your claimed task exists" ];
-      preconditions = [ project_ready; "joined" ];
+      preconditions = [ room_set_assertion; "joined" ];
       common_mistakes =
         [ "Calling plan_set_task without a claimed task" ] }
 
@@ -188,7 +188,7 @@ let after_heartbeat ~success =
     { next_steps =
         [ s "masc_broadcast" "Share progress with other agents";
           s "masc_transition" "Mark task complete when finished (action=done)" ];
-      preconditions = [ project_ready; "joined" ];
+      preconditions = [ room_set_assertion; "joined" ];
       common_mistakes = [] }
   else
     { next_steps =
@@ -202,12 +202,12 @@ let after_done ~success =
         [ s "masc_status" "Check for remaining tasks";
           s "masc_transition" "Pick up the next task (action=claim)";
           s "masc_leave" "Leave the namespace if all work is complete" ];
-      preconditions = [ project_ready; "joined" ];
+      preconditions = [ room_set_assertion; "joined" ];
       common_mistakes = [] }
   else
     { next_steps =
         [ s "masc_status" "Check task state — it may already be completed" ];
-      preconditions = [ project_ready; "joined" ];
+      preconditions = [ room_set_assertion; "joined" ];
       common_mistakes = [] }
 
 (* ── Common tools ────────────────────────────────────────────────── *)
@@ -216,12 +216,12 @@ let after_broadcast ~success =
   if success then
     { next_steps =
         [ s "masc_heartbeat" "Keep your presence alive" ];
-      preconditions = [ project_ready; "joined" ];
+      preconditions = [ room_set_assertion; "joined" ];
       common_mistakes = [] }
   else
     { next_steps =
         [ s "masc_join" "Ensure you are in the namespace" ];
-      preconditions = [ project_ready ];
+      preconditions = [ room_set_assertion ];
       common_mistakes = [] }
 
 let after_worktree_create ~success =
@@ -229,13 +229,13 @@ let after_worktree_create ~success =
     { next_steps =
         [ s "masc_heartbeat" "Signal liveness before starting work";
           s "masc_broadcast" "Let other agents know you started work" ];
-      preconditions = [ project_ready; "joined"; "task_claimed" ];
+      preconditions = [ room_set_assertion; "joined"; "task_claimed" ];
       common_mistakes = [] }
   else
     { next_steps =
         [ s "masc_plan_set_task" "Ensure current_task is set";
           s "masc_status" "Check namespace configuration" ];
-      preconditions = [ project_ready; "joined"; "task_claimed" ];
+      preconditions = [ room_set_assertion; "joined"; "task_claimed" ];
       common_mistakes = [] }
 
 (* ── Main dispatch ───────────────────────────────────────────────── *)
@@ -334,7 +334,7 @@ let current_state_guidance ~room_set ~joined ~task_claimed
   else if not joined then
     { next_steps =
         [ s "masc_join" "Register your agent identity in the project namespace" ];
-      preconditions = [ project_ready ];
+      preconditions = [ room_set_assertion ];
       common_mistakes =
         [ "Operating without joining — other agents cannot see or coordinate with you" ] }
   else if not task_claimed then
@@ -342,20 +342,20 @@ let current_state_guidance ~room_set ~joined ~task_claimed
         [ s "masc_status" "Check available tasks";
           s "masc_transition" "Claim an existing task (action=claim)";
           s "masc_add_task" "Create a new task if none exist" ];
-      preconditions = [ project_ready; "joined" ];
+      preconditions = [ room_set_assertion; "joined" ];
       common_mistakes =
         [ "Modifying code without a claimed task — changes are untracked" ] }
   else if not current_task_set then
     { next_steps =
         [ s "masc_plan_set_task" "Bind your claimed task as current_task" ];
-      preconditions = [ project_ready; "joined"; "task_claimed" ];
+      preconditions = [ room_set_assertion; "joined"; "task_claimed" ];
       common_mistakes =
-        [ "Legacy or out-of-band claim paths can leave planning current_task stale. Call masc_plan_set_task to realign." ] }
+        [ "Out-of-band claim paths can leave planning current_task stale. Call masc_plan_set_task to realign." ] }
   else if not worktree_active then
     { next_steps =
         [ s "masc_worktree_create" "Create an isolated git worktree for this task";
           s "masc_heartbeat" "Signal liveness if worktree is not needed" ];
-      preconditions = [ project_ready; "joined"; "task_claimed"; "current_task_set" ];
+      preconditions = [ room_set_assertion; "joined"; "task_claimed"; "current_task_set" ];
       common_mistakes =
         [ "Working directly on main branch without a worktree" ] }
   else if session_active then
@@ -363,12 +363,12 @@ let current_state_guidance ~room_set ~joined ~task_claimed
         [ s "masc_status" "Refresh repo coordination state";
           s "masc_heartbeat" "Keep your presence alive during work";
           s "masc_transition" "Mark the task complete when work is done (action=done)" ];
-      preconditions = [ project_ready; "joined"; "task_claimed"; "current_task_set"; "worktree_active"; "session_active" ];
+      preconditions = [ room_set_assertion; "joined"; "task_claimed"; "current_task_set"; "worktree_active"; "session_active" ];
       common_mistakes = [] }
   else
     { next_steps =
         [ s "masc_heartbeat" "Signal liveness while working";
           s "masc_broadcast" "Share progress with teammates";
           s "masc_transition" "Mark task complete when finished (action=done)" ];
-      preconditions = [ project_ready; "joined"; "task_claimed"; "current_task_set"; "worktree_active" ];
+      preconditions = [ room_set_assertion; "joined"; "task_claimed"; "current_task_set"; "worktree_active" ];
       common_mistakes = [] }

--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -31,8 +31,8 @@ lib/process/process_eio.ml:535
 # manager itself. Bounded by session scope, not by per-call timeout.
 lib/server/lsp_process_manager.ml:178
 
-# lib/worker_dev_tools.ml:1204 — dev-tools worker spawn. Wrapped by
+# lib/worker_dev_tools.ml:703 — dev-tools worker spawn. Wrapped by
 # Tool_resource_gate, Fd_accountant, Eio.Time.with_timeout_exn, and a fresh
 # Eio.Switch.run at the call boundary. Line renumbered by worker-dev-tools
 # split/refactor waves.
-lib/worker_dev_tools.ml:1204
+lib/worker_dev_tools.ml:703

--- a/test/test_tool_coord_coverage.ml
+++ b/test/test_tool_coord_coverage.ml
@@ -810,14 +810,14 @@ let () =
 ;;
 
 let () =
-  test "dispatch_check_project_ready_alias" (fun () ->
+  test "dispatch_check_room_set" (fun () ->
     let ctx = make_test_ctx () in
     let _ = Coord.init ctx.config ~agent_name:(Some "test-agent") in
     match
       Tool_coord.dispatch
         ctx
         ~name:"masc_check"
-        ~args:(`Assoc [ "assertions", `List [ `String "project_ready" ] ])
+        ~args:(`Assoc [ "assertions", `List [ `String "room_set" ] ])
     with
     | Some result ->
       assert result.success;

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -1014,7 +1014,7 @@ let () =
     ];
     "assertion_kind_ssot", [
       (* Issue #8636: 3-way drift on masc_check assertion vocabulary —
-         schema enum (5), handler match (5 + namespace_ready alias),
+         schema enum (5), handler match (5 + deprecated alias),
          default fallback (4 — missing worktree_active). The fix
          introduces [Tool_coord.assertion_kind] variant + helpers and
          a cycle-safe schema mirror in Tool_schemas_coord_core. These
@@ -1042,12 +1042,12 @@ let () =
         Alcotest.(check (list string)) "schema mirror == SSOT"
           Masc_mcp.Tool_coord.valid_assertion_strings
           Tool_schemas_coord_core.assertion_kind_enum_strings);
-      Alcotest.test_case "lenient parser accepts namespace_ready alias" `Quick (fun () ->
+      Alcotest.test_case "parser accepts canonical room_set" `Quick (fun () ->
         let module C = Masc_mcp.Tool_coord in
-        match C.assertion_kind_of_string_lenient "namespace_ready" with
+        match C.assertion_kind_of_string_lenient "room_set" with
         | Some C.Room_set -> ()
-        | Some _ -> Alcotest.fail "alias should map to Room_set"
-        | None -> Alcotest.fail "alias should parse");
+        | Some _ -> Alcotest.fail "room_set should map to Room_set"
+        | None -> Alcotest.fail "room_set should parse");
       Alcotest.test_case "lenient parser rejects unknown" `Quick (fun () ->
         Alcotest.(check bool) "unknown -> None" true
           (Masc_mcp.Tool_coord.assertion_kind_of_string_lenient

--- a/test/test_workflow_guide.ml
+++ b/test/test_workflow_guide.ml
@@ -25,11 +25,6 @@ let check_has_precondition g expected =
     (Printf.sprintf "preconditions contain %s" expected)
     true (List.mem expected g.WG.preconditions)
 
-let check_lacks_precondition g unexpected =
-  check bool
-    (Printf.sprintf "preconditions omit %s" unexpected)
-    false (List.mem unexpected g.WG.preconditions)
-
 (* ── Golden Path 1: Coord/Task Hygiene ────────────────────────────── *)
 
 let test_start_success () =
@@ -47,8 +42,7 @@ let test_join_success () =
   let g = WG.next_steps ~tool_name:"masc_join" ~success:true in
   check_has_tool g.next_steps "masc_status";
   check_has_tool g.next_steps "masc_transition";
-  check_has_precondition g "project_ready";
-  check_lacks_precondition g "room_set"
+  check_has_precondition g "room_set"
 
 let test_join_failure () =
   let g = WG.next_steps ~tool_name:"masc_join" ~success:false in
@@ -178,20 +172,17 @@ let test_transition_claim_call_guidance () =
   check_has_tool g.next_steps "masc_worktree_create";
   check bool "claim guidance omits plan_set_task" false
     (List.exists (fun (s : WG.step) -> s.tool = "masc_plan_set_task") g.next_steps);
-  check_has_precondition g "project_ready";
-  check_lacks_precondition g "room_set"
+  check_has_precondition g "room_set"
 
-let test_add_task_success_uses_project_ready () =
+let test_add_task_success_uses_room_set () =
   let g = WG.next_steps ~tool_name:"masc_add_task" ~success:true in
   check_has_tool g.next_steps "masc_transition";
-  check_has_precondition g "project_ready";
-  check_lacks_precondition g "room_set"
+  check_has_precondition g "room_set"
 
-let test_broadcast_success_uses_project_ready () =
+let test_broadcast_success_uses_room_set () =
   let g = WG.next_steps ~tool_name:"masc_broadcast" ~success:true in
   check_has_tool g.next_steps "masc_heartbeat";
-  check_has_precondition g "project_ready";
-  check_lacks_precondition g "room_set"
+  check_has_precondition g "room_set"
 
 let test_transition_done_call_guidance () =
   let g =
@@ -262,8 +253,8 @@ let () =
       test_case "complete_task removed" `Quick test_complete_task_removed;
       test_case "transition generic is safe" `Quick test_transition_generic_is_safe;
       test_case "transition claim call guidance" `Quick test_transition_claim_call_guidance;
-      test_case "add_task uses project_ready" `Quick test_add_task_success_uses_project_ready;
-      test_case "broadcast uses project_ready" `Quick test_broadcast_success_uses_project_ready;
+      test_case "add_task uses room_set" `Quick test_add_task_success_uses_room_set;
+      test_case "broadcast uses room_set" `Quick test_broadcast_success_uses_room_set;
       test_case "transition done call guidance" `Quick test_transition_done_call_guidance;
       test_case "transition release call guidance" `Quick test_transition_release_call_guidance;
     ];


### PR DESCRIPTION
## Summary
- make room_set the only readiness assertion string for masc_check
- remove project_ready/namespace_ready from status JSON, schema help, and workflow guidance
- update focused tests to assert the canonical room_set surface
- refresh spawn-bounded allowlist line drift caused by current main

## Verification
- ocamlformat --check touched OCaml files
- git diff --check
- rg -n "project_ready|namespace_ready" lib test docs scripts bin dashboard config => 0 hits
- bash scripts/lint-spawn-bounded.sh
- Dune wrapper attempted for focused coord/workflow tests, blocked by /tmp/me-dune-local.lock held by another worktree