### PR TITLE
refactor(coord_task): extract release variants into sibling (Lane E second)

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -817,65 +817,10 @@ let transition_task_r
 ;;
 
 (** Release task back to backlog - transition wrapper *)
-let release_task_r config ~agent_name ~task_id ?expected_version ?handoff_context ()
-  : string Masc_domain.masc_result
-  =
-  transition_task_r
-    config
-    ~agent_name
-    ~task_id
-    ~action:Masc_domain.Release
-    ?expected_version
-    ?handoff_context
-    ()
-;;
-
-(** Force-release a task regardless of assignee. Keeper privilege. *)
-let force_release_task_r config ~agent_name ~task_id ?handoff_context ()
-  : string Masc_domain.masc_result
-  =
-  transition_task_r
-    config
-    ~agent_name
-    ~task_id
-    ~action:Masc_domain.Release
-    ?handoff_context
-    ~force:true
-    ()
-;;
-
-(** Force-done a task regardless of assignee. Keeper privilege. *)
-let force_done_task_r config ~agent_name ~task_id ~notes ()
-  : string Masc_domain.masc_result
-  =
-  transition_task_r
-    config
-    ~agent_name
-    ~task_id
-    ~action:Masc_domain.Done_action
-    ~notes
-    ~force:true
-    ()
-;;
-
-(** Force-cancel a task regardless of assignee. System privilege.
-    Used by [Verification_protocol.check_timeouts] to expire
-    [AwaitingVerification] tasks whose verifier deadline has passed,
-    so the FSM does not stall and re-emit Timeout posts forever. *)
-let force_cancel_task_r config ~agent_name ~task_id ~reason ()
-  : string Masc_domain.masc_result
-  =
-  transition_task_r
-    config
-    ~agent_name
-    ~task_id
-    ~action:Masc_domain.Cancel
-    ~reason
-    ~force:true
-    ()
-;;
-
-(** Cancel a task - A2A compatible *)
+let release_task_r = Coord_task_release.release_task_r
+let force_release_task_r = Coord_task_release.force_release_task_r
+let force_done_task_r = Coord_task_release.force_done_task_r
+let force_cancel_task_r = Coord_task_release.force_cancel_task_r
 let cancel_task_r config ~agent_name ~task_id ~reason : string Masc_domain.masc_result =
   if not (is_initialized config)
   then Error (Masc_domain.System Masc_domain.System_error.NotInitialized)

--- a/lib/coord/coord_task_release.ml
+++ b/lib/coord/coord_task_release.ml
@@ -1,0 +1,67 @@
+(** Coord task release variants extracted from coord_task.ml.
+
+    Provides {release,force_release,force_done,force_cancel}_task_r —
+    small helpers that delegate to [transition_task_r] with terminal
+    transitions. *)
+
+open Masc_domain
+
+let release_task_r config ~agent_name ~task_id ?expected_version ?handoff_context ()
+  : string Masc_domain.masc_result
+  =
+  transition_task_r
+    config
+    ~agent_name
+    ~task_id
+    ~action:Masc_domain.Release
+    ?expected_version
+    ?handoff_context
+    ()
+;;
+
+(** Force-release a task regardless of assignee. Keeper privilege. *)
+let force_release_task_r config ~agent_name ~task_id ?handoff_context ()
+  : string Masc_domain.masc_result
+  =
+  transition_task_r
+    config
+    ~agent_name
+    ~task_id
+    ~action:Masc_domain.Release
+    ?handoff_context
+    ~force:true
+    ()
+;;
+
+(** Force-done a task regardless of assignee. Keeper privilege. *)
+let force_done_task_r config ~agent_name ~task_id ~notes ()
+  : string Masc_domain.masc_result
+  =
+  transition_task_r
+    config
+    ~agent_name
+    ~task_id
+    ~action:Masc_domain.Done_action
+    ~notes
+    ~force:true
+    ()
+;;
+
+(** Force-cancel a task regardless of assignee. System privilege.
+    Used by [Verification_protocol.check_timeouts] to expire
+    [AwaitingVerification] tasks whose verifier deadline has passed,
+    so the FSM does not stall and re-emit Timeout posts forever. *)
+let force_cancel_task_r config ~agent_name ~task_id ~reason ()
+  : string Masc_domain.masc_result
+  =
+  transition_task_r
+    config
+    ~agent_name
+    ~task_id
+    ~action:Masc_domain.Cancel
+    ~reason
+    ~force:true
+    ()
+;;
+
+(** Cancel a task - A2A compatible *)


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane E (Coord, second cluster)
- `coord_task.ml` is 1153 LOC (post #17134). Carved out 4 release variants that all delegate to `transition_task_r` with terminal transitions.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/coord/coord_task.ml` | 1153 | 1098 | **-55** |
| `lib/coord/coord_task_release.ml` | — | 67 | +67 |

## Moved (verbatim, no behavior change)
- `release_task_r`
- `force_release_task_r`
- `force_done_task_r`
- `force_cancel_task_r`

## Local build status
Hits pre-existing partial-match warning-as-error at `lib/cascade/cascade_transport.ml:1063` (`Cascade_attempt_liveness_config.(Observe, false, _)` missing arm). Present on main HEAD, unrelated to this PR.

## RFC-WAIVED
Extract-only sibling refactor, governed by `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane E.

Co-Authored-By: codex <noreply@anthropic.com>
