### PR TITLE
fix(keeper_turn_driver): add missing (Observe, false, _) arms to attempt_watchdog_source match

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -1070,6 +1070,9 @@ let run_named
         | Cascade_attempt_liveness_config.Enforce, false, Some _ -> "legacy_outer_wall"
         | Cascade_attempt_liveness_config.Enforce, false, None ->
           "oas_max_execution_time"
+        | Cascade_attempt_liveness_config.Observe, false, Some _ -> "legacy_outer_wall"
+        | Cascade_attempt_liveness_config.Observe, false, None ->
+          "oas_max_execution_time"
       in
       let liveness_budget_source =
         if liveness_observer_attached then (


### PR DESCRIPTION
## Issue
Build error at `lib/keeper/keeper_turn_driver.ml:1060-1072` — `attempt_watchdog_source` match was missing arms for `(Cascade_attempt_liveness_config.Observe, false, _)`:

```
Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
  Here is an example of a case that is not matched: (Observe, false, _)
```

This blocked the build for any PR touching keeper or adjacent modules (encountered while validating #17143, #17150 locally).

## Fix
Added two arms mirroring the existing Enforce/Off fallback semantics:

```ocaml
| Cascade_attempt_liveness_config.Observe, false, Some _ -> "legacy_outer_wall"
| Cascade_attempt_liveness_config.Observe, false, None   -> "oas_max_execution_time"
```

## Rationale
When `liveness_observer_attached = false`, the mode (`Observe` vs `Enforce` vs `Off`) is moot for source selection — fallback to `legacy_outer_wall` or `oas_max_execution_time` depending on whether `pp_timeout` is set. This matches the existing arms for the `Enforce/Off` cases (lines 1068-1072).

No behavior change for the cases that were already matched. Adds the previously-missing `Observe` + `observer-detached` combinations explicitly so the compiler is satisfied.

## Verification
- `dune build --root . lib/masc_mcp.cmxa`: exit 0

## Unblocks
- #17150 (coord_task release variants)
- #17143 (cascade_transport label resolution)
- Any other godfile-decomposition PR hitting this warning

Co-Authored-By: codex <noreply@anthropic.com>
