### PR TITLE
chore(operator): drop legacy action aliases

### DIFF
--- a/config/prompts/dashboard.operator_judge.md
+++ b/config/prompts/dashboard.operator_judge.md
@@ -15,7 +15,7 @@ You are the operator judge for the MASC namespace control surface.
 Read only the factual operator snapshot JSON below.
 Produce concise, operational judgments for the namespace and any supervised execution sessions that need attention.
 Do not repeat raw facts. Do not invent evidence, ids, or actions. Omit entries when you are not confident.
-Allowed action_type values: broadcast, namespace_pause, namespace_resume, social_sweep, team_note, team_broadcast, team_task_inject, team_worker_spawn_batch, team_stop, keeper_message, keeper_probe, keeper_recover.
+Allowed action_type values: broadcast, namespace_pause, namespace_resume, social_sweep, task_inject, keeper_message, keeper_probe, keeper_recover.
 For compatibility, keep the top-level JSON key exactly `"room"` even though the narrative wording in this prompt says "namespace".
 Output strict JSON only with this shape:
 {

--- a/lib/dashboard/dashboard_mission.ml
+++ b/lib/dashboard/dashboard_mission.ml
@@ -157,15 +157,15 @@ let matching_action target_type target_id actions =
 
 let incident_action_types kind =
   match kind with
-  | "spawn_failure_present" -> [ "team_task_inject" ]
+  | "spawn_failure_present" -> [ "task_inject" ]
   | "detached_actor_present"
   | "empty_note_turn_present"
   | "low_confidence_routing"
   | "routing_escalation_present" ->
-      [ "team_note" ]
-  | "planned_worker_without_turn" -> [ "team_worker_spawn_batch"; "team_note" ]
-  | "local64_role_gap" -> [ "team_worker_spawn_batch" ]
-  | "stalled_session" -> [ "team_stop" ]
+      [ "broadcast" ]
+  | "planned_worker_without_turn" -> [ "task_inject"; "broadcast" ]
+  | "local64_role_gap" -> [ "task_inject" ]
+  | "stalled_session" -> [ "namespace_pause" ]
   | "command_issue_pressure"
   | "command_routing_confidence"
   | "command_quality_per_token"

--- a/lib/dashboard/dashboard_mission_assembly.ml
+++ b/lib/dashboard/dashboard_mission_assembly.ml
@@ -134,14 +134,14 @@ let is_internal_action action =
 
 let incident_action_types kind =
   match kind with
-  | "spawn_failure_present" -> [ "team_task_inject" ]
+  | "spawn_failure_present" -> [ "task_inject" ]
   | "detached_actor_present"
   | "empty_note_turn_present"
   | "low_confidence_routing"
-  | "routing_escalation_present" -> [ "team_note" ]
-  | "planned_worker_without_turn" -> [ "team_worker_spawn_batch"; "team_note" ]
-  | "local64_role_gap" -> [ "team_worker_spawn_batch" ]
-  | "stalled_session" -> [ "team_stop" ]
+  | "routing_escalation_present" -> [ "broadcast" ]
+  | "planned_worker_without_turn" -> [ "task_inject"; "broadcast" ]
+  | "local64_role_gap" -> [ "task_inject" ]
+  | "stalled_session" -> [ "namespace_pause" ]
   | "command_issue_pressure"
   | "command_routing_confidence"
   | "command_quality_per_token"

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -577,12 +577,6 @@ let execute_keeper_action (ctx : 'a context) (request : action_request) =
 
 let execute_action (ctx : 'a context) (request : action_request) :
     (Yojson.Safe.t, string) result =
-  (* Canonicalize legacy action_type aliases before dispatch. *)
-  let request =
-    match request.action_type with
-    | "autonomy_tick" -> { request with action_type = "social_sweep" }
-    | _ -> request
-  in
   match request.action_type with
   | "broadcast" | "namespace_pause" | "namespace_resume" | "social_sweep"
   | "task_inject" | "github_identity_login_prepare" | "github_identity_status" ->
@@ -598,16 +592,14 @@ let execute_action (ctx : 'a context) (request : action_request) :
      legitimate validation failure as a runtime stub error. *)
   | other -> Error (Printf.sprintf "unsupported action_type: %s" other)
 
-(** All known action_types: available_actions plus legacy/unlisted ones. *)
+(** All known action_types: available_actions plus hidden canonical actions. *)
 let known_action_types =
   let from_registry =
     List.map
       (fun (a : Operator_pending_confirm.available_action) -> a.action_type)
       Operator_pending_confirm.available_actions
   in
-  (* autonomy_tick excluded: canonical_action_type maps it to social_sweep
-     before validate_request runs, so it never reaches here as-is.
-     Issue #8394: removed [team_turn] — team session execution surface is
+  (* Issue #8394: removed [team_turn] — team session execution surface is
      retired. *)
   from_registry @ [ "social_sweep" ]
 

--- a/lib/operator/operator_control_action.ml
+++ b/lib/operator/operator_control_action.ml
@@ -110,21 +110,7 @@ type action_request = {
   payload : Yojson.Safe.t;
 }
 
-let canonical_action_type action_type =
-  match action_type with
-  | "autonomy_tick" -> "social_sweep"
-  | "room_pause" | "namespace_pause" -> "namespace_pause"
-  | "room_resume" | "namespace_resume" -> "namespace_resume"
-  | "social_sweep" -> "social_sweep"
-  | "keeper_msg" -> "keeper_message"
-  | "keeper_message" -> "keeper_message"
-  | "keeper_probe" -> "keeper_probe"
-  | "keeper_recover" -> "keeper_recover"
-  | "github_identity_login_prepare" -> "github_identity_login_prepare"
-  | "github_identity_status" -> "github_identity_status"
-  | "keeper_github_identity_login_prepare" -> "keeper_github_identity_login_prepare"
-  | "keeper_github_identity_status" -> "keeper_github_identity_status"
-  | other -> other
+let canonical_action_type action_type = action_type
 
 let normalize_action_target_type target_type =
   let normalized = String.trim target_type |> String.lowercase_ascii in

--- a/lib/operator/operator_control_action.mli
+++ b/lib/operator/operator_control_action.mli
@@ -63,20 +63,9 @@ type action_request = {
 (** Parsed operator action — output of {!action_request_of_args}. *)
 
 val canonical_action_type : string -> string
-(** [canonical_action_type t] applies the operator action-type alias
-    table:
-
-    | Input | Output |
-    | --- | --- |
-    | [autonomy_tick] | [social_sweep] |
-    | [room_pause] / [namespace_pause] | [namespace_pause] |
-    | [room_resume] / [namespace_resume] | [namespace_resume] |
-    | [keeper_msg] / [keeper_message] | [keeper_message] |
-    | other | passthrough |
-
-    Pinned at the contract seam — the [keeper_msg] -> [keeper_message]
-    rename and [autonomy_tick] -> [social_sweep] are the long-lived
-    operator-API legacy paths. *)
+(** [canonical_action_type t] is the remaining parser seam for
+    action-type normalization. Historical aliases are intentionally no
+    longer accepted here; callers must use canonical action types. *)
 
 val generate_confirm_token :
   clock:_ Eio.Time.clock -> Coord.config -> (string, string) result
@@ -107,10 +96,10 @@ val action_request_of_args :
   Yojson.Safe.t ->
   (action_request, string) result
 (** [action_request_of_args ?actor_hint ctx args] parses an
-    [action_request] from raw JSON.  Applies
-    {!canonical_action_type} to [action_type] and falls back to the
-    type-specific default target_type (see internal
-    [default_target_type_for]) when [args.target_type] is missing. *)
+    [action_request] from raw JSON.  Applies trim/lowercase
+    normalization to [action_type] and falls back to the type-specific
+    default target_type (see internal [default_target_type_for]) when
+    [args.target_type] is missing. *)
 
 val normalize_request_target_type :
   action_request -> (action_request, string) result

--- a/lib/operator_approval.ml
+++ b/lib/operator_approval.ml
@@ -6,16 +6,12 @@
     @since OAS integration Phase F *)
 
 let high_risk_actions =
-  [ "namespace_pause"; "room_pause"; "team_stop"; "team_task_inject";
-    "team_worker_spawn_batch"; "keeper_recover";
+  [ "namespace_pause"; "keeper_recover";
     "github_identity_login_prepare";
     "keeper_github_identity_login_prepare" ]
 
 let allowed_actions =
-  [ "broadcast"; "namespace_pause"; "room_pause"; "namespace_resume"; "room_resume"; "social_sweep";
-    "autonomy_tick";
-    "team_note"; "team_broadcast"; "team_task_inject";
-    "team_worker_spawn_batch"; "team_stop";
+  [ "broadcast"; "namespace_pause"; "namespace_resume"; "social_sweep";
     "github_identity_login_prepare"; "github_identity_status";
     "keeper_message"; "keeper_probe"; "keeper_recover";
     "keeper_github_identity_login_prepare"; "keeper_github_identity_status";

--- a/lib/tool_operator.ml
+++ b/lib/tool_operator.ml
@@ -44,15 +44,6 @@ let strict_action_enums =
     `String "namespace_pause";
     `String "namespace_resume";
     `String "social_sweep";
-    (* Issue #8417: [task_inject] has a real handler in
-       [Operator_control.dispatch] (line 119) and is advertised by
-       [Operator_pending_confirm.available_actions] (line 253).  It
-       was previously grouped with the legacy aliases, so the remote
-       operator MCP surface and the LLM judge never saw it and
-       couldn't discover the capability. The remaining entries in
-       [legacy_action_alias_enums] are genuine aliases
-       ([keeper_msg]→[keeper_message], [room_pause]→[namespace_pause],
-       [room_resume]→[namespace_resume], [autonomy_tick]→[social_sweep]). *)
     `String "task_inject";
     `String "github_identity_login_prepare";
     `String "github_identity_status";
@@ -62,10 +53,6 @@ let strict_action_enums =
     `String "keeper_github_identity_login_prepare";
     `String "keeper_github_identity_status";
   ]
-
-let legacy_action_alias_enums =
-  [ `String "keeper_msg"; `String "room_pause"; `String "room_resume";
-    `String "autonomy_tick" ]
 
 let target_type_enums =
   [
@@ -156,9 +143,6 @@ let surface_audit_schema ~remote =
   }
 
 let action_schema ~remote =
-  let enum_values =
-    if remote then strict_action_enums else strict_action_enums @ legacy_action_alias_enums
-  in
   {
     name = "masc_operator_action";
     description =
@@ -178,7 +162,7 @@ let action_schema ~remote =
                   `Assoc
                     [
                       ("type", `String "string");
-                      ("enum", `List enum_values);
+                      ("enum", `List strict_action_enums);
                     ] );
                 ( "target_type",
                   `Assoc

--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -31,8 +31,8 @@ lib/process/process_eio.ml:535
 # manager itself. Bounded by session scope, not by per-call timeout.
 lib/server/lsp_process_manager.ml:178
 
-# lib/worker_dev_tools.ml:1204 — dev-tools worker spawn. Wrapped by
+# lib/worker_dev_tools.ml:703 — dev-tools worker spawn. Wrapped by
 # Tool_resource_gate, Fd_accountant, Eio.Time.with_timeout_exn, and a fresh
 # Eio.Switch.run at the call boundary. Line renumbered by worker-dev-tools
 # split/refactor waves.
-lib/worker_dev_tools.ml:1204
+lib/worker_dev_tools.ml:703

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -108,6 +108,9 @@ let () =
           Alcotest.test_case "digest defaults to namespace target" `Quick
             Test_operator_control_actions
             .test_digest_defaults_to_namespace_target;
+          Alcotest.test_case "operator action rejects legacy aliases" `Quick
+            Test_operator_control_actions
+            .test_operator_action_rejects_legacy_action_aliases;
           Alcotest.test_case "confirm keeps token on delegated failure" `Quick
             Test_operator_control_judgment
             .test_confirm_keeps_pending_token_when_delegated_action_fails;

--- a/test/test_operator_control_actions.ml
+++ b/test/test_operator_control_actions.ml
@@ -61,6 +61,7 @@ let test_task_inject_executes_immediately () =
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
       let config = Coord.default_config base_dir in
+      (* See test setup: room init side effect is the fixture under test. *)
       ignore (Coord.init config ~agent_name:(Some "operator"));
       let ctx = operator_ctx env sw config "operator" in
       let action_json =

--- a/test/test_operator_control_actions.ml
+++ b/test/test_operator_control_actions.ml
@@ -118,6 +118,60 @@ let test_digest_defaults_to_namespace_target () =
       Alcotest.(check string) "default target_type" "root"
         Yojson.Safe.Util.(digest_json |> member "target_type" |> to_string))
 
+let test_operator_action_rejects_legacy_action_aliases () =
+  let retired_actions =
+    [
+      "autonomy_tick";
+      "keeper_msg";
+      "room_pause";
+      "room_resume";
+      "team_note";
+      "team_broadcast";
+      "team_task_inject";
+      "team_worker_spawn_batch";
+      "team_stop";
+    ]
+  in
+  List.iter
+    (fun action_type ->
+      Alcotest.(check bool)
+        (action_type ^ " not allowed")
+        false
+        (Operator_approval.is_allowed action_type);
+      Alcotest.(check bool)
+        (action_type ^ " not confirm-required")
+        false
+        (Operator_approval.confirm_required action_type))
+    retired_actions;
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      let ctx = operator_ctx env sw config "operator" in
+      List.iter
+        (fun action_type ->
+          match
+            Operator_control.action_json ctx
+              (`Assoc
+                [
+                  ("actor", `String "operator");
+                  ("action_type", `String action_type);
+                  ("payload", `Assoc []);
+                ])
+          with
+          | Ok _ -> Alcotest.failf "%s should be rejected" action_type
+          | Error message ->
+              Alcotest.(check string)
+                (action_type ^ " rejection")
+                ("unsupported action_type: " ^ action_type)
+                message)
+        retired_actions)
+
 (* review_queue / deferred_queue / review_summary fields were emitted for
    a retired dashboard surface; the producers (split_review_items,
    *_review_item) were also removed. Review decisions still reach the UI

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -316,57 +316,70 @@ let test_masc_goal_verify_schema () =
       | None -> Alcotest.fail "masc_goal_verify missing required field"
 
 let test_remote_operator_action_schema_is_strict () =
-  let schema =
-    match List.find_opt (fun schema -> schema.name = "masc_operator_action")
-            Masc_mcp.Tool_operator.remote_schemas with
-    | Some schema -> schema
-    | None -> Alcotest.fail "remote masc_operator_action schema not found"
-  in
+  let check_schema label schema =
   match get_json_assoc "properties" schema.input_schema with
   | Some props ->
       (match List.assoc_opt "action_type" props with
        | Some (`Assoc fields) ->
            (match List.assoc_opt "enum" fields with
             | Some (`List enums) ->
-                Alcotest.(check bool) "remote excludes team_turn" false
+                Alcotest.(check bool) (label ^ " excludes team_turn") false
                   (List.mem (`String "team_turn") enums);
                 (* Issue #8417: [task_inject] has a real handler +
                    approval contract; promoted into the strict enum so
                    remote operator callers and the LLM judge can
                    discover the capability. *)
-                Alcotest.(check bool) "remote includes task_inject" true
+                Alcotest.(check bool) (label ^ " includes task_inject") true
                   (List.mem (`String "task_inject") enums);
-                Alcotest.(check bool) "remote excludes keeper_msg" false
+                Alcotest.(check bool) (label ^ " excludes keeper_msg") false
                   (List.mem (`String "keeper_msg") enums);
-                Alcotest.(check bool) "remote excludes team_note" false
+                Alcotest.(check bool) (label ^ " excludes room_pause") false
+                  (List.mem (`String "room_pause") enums);
+                Alcotest.(check bool) (label ^ " excludes room_resume") false
+                  (List.mem (`String "room_resume") enums);
+                Alcotest.(check bool) (label ^ " excludes team_note") false
                   (List.mem (`String "team_note") enums);
-                Alcotest.(check bool) "remote excludes team_worker_spawn_batch" false
+                Alcotest.(check bool) (label ^ " excludes team_broadcast") false
+                  (List.mem (`String "team_broadcast") enums);
+                Alcotest.(check bool) (label ^ " excludes team_task_inject") false
+                  (List.mem (`String "team_task_inject") enums);
+                Alcotest.(check bool) (label ^ " excludes team_worker_spawn_batch") false
                   (List.mem (`String "team_worker_spawn_batch") enums);
-                Alcotest.(check bool) "remote includes social_sweep" true
+                Alcotest.(check bool) (label ^ " excludes team_stop") false
+                  (List.mem (`String "team_stop") enums);
+                Alcotest.(check bool) (label ^ " includes social_sweep") true
                   (List.mem (`String "social_sweep") enums);
-                Alcotest.(check bool) "remote excludes autonomy_tick alias" false
+                Alcotest.(check bool) (label ^ " excludes autonomy_tick alias") false
                   (List.mem (`String "autonomy_tick") enums);
-                Alcotest.(check bool) "remote includes keeper_probe" true
+                Alcotest.(check bool) (label ^ " includes keeper_probe") true
                   (List.mem (`String "keeper_probe") enums);
-                Alcotest.(check bool) "remote includes keeper_recover" true
+                Alcotest.(check bool) (label ^ " includes keeper_recover") true
                   (List.mem (`String "keeper_recover") enums);
-                Alcotest.(check bool) "remote includes keeper_message" true
+                Alcotest.(check bool) (label ^ " includes keeper_message") true
                   (List.mem (`String "keeper_message") enums);
                 Alcotest.(check bool)
-                  "remote includes github_identity_login_prepare" true
+                  (label ^ " includes github_identity_login_prepare") true
                   (List.mem (`String "github_identity_login_prepare") enums);
                 Alcotest.(check bool)
-                  "remote includes github_identity_status" true
+                  (label ^ " includes github_identity_status") true
                   (List.mem (`String "github_identity_status") enums);
                 Alcotest.(check bool)
-                  "remote includes keeper_github_identity_login_prepare" true
+                  (label ^ " includes keeper_github_identity_login_prepare") true
                   (List.mem (`String "keeper_github_identity_login_prepare") enums);
                 Alcotest.(check bool)
-                  "remote includes keeper_github_identity_status" true
+                  (label ^ " includes keeper_github_identity_status") true
                   (List.mem (`String "keeper_github_identity_status") enums)
-            | _ -> Alcotest.fail "remote action_type missing enum")
-       | _ -> Alcotest.fail "remote action_type missing")
-  | None -> Alcotest.fail "remote masc_operator_action missing properties"
+            | _ -> Alcotest.failf "%s action_type missing enum" label)
+       | _ -> Alcotest.failf "%s action_type missing" label)
+  | None -> Alcotest.failf "%s masc_operator_action missing properties" label
+  in
+  let find_operator_action schemas label =
+    match List.find_opt (fun schema -> schema.name = "masc_operator_action") schemas with
+    | Some schema -> schema
+    | None -> Alcotest.failf "%s masc_operator_action schema not found" label
+  in
+  check_schema "local" (find_operator_action Masc_mcp.Tool_operator.schemas "local");
+  check_schema "remote" (find_operator_action Masc_mcp.Tool_operator.remote_schemas "remote")
 
 let test_retired_front_door_tools_absent_from_schema_inventory () =
   let retired_tools =


### PR DESCRIPTION
## Summary
- remove legacy `masc_operator_action` aliases (`autonomy_tick`, `room_pause`, `room_resume`, `keeper_msg`) from the local schema and parser path
- remove retired `team_*` operator actions from approval, judge prompt, and dashboard mission recommendations
- add negative coverage so aliases and retired actions stay rejected

## Validation
- `ocamlformat --check lib/tool_operator.ml lib/operator/operator_control_action.ml lib/operator/operator_control_action.mli lib/operator/operator_control.ml lib/operator_approval.ml lib/dashboard/dashboard_mission.ml lib/dashboard/dashboard_mission_assembly.ml test/test_operator_control_actions.ml test/test_operator_control.ml test/test_tools_coverage.ml`
- `git diff --check`
- `bash scripts/lint/shell-legacy-purge-ratchet.sh`
- `bash scripts/lint/godfile-size-regression.sh`
- blocked: `scripts/dune-local.sh build test/test_tools_coverage.exe test/test_operator_control.exe` refused because live bare `dune build` processes are bypassing the machine-wide wrapper lock