### PR TITLE
[codex] fix(shell): validate wrapper targets

### DIFF
--- a/lib/keeper/keeper_tool_bash_input.ml
+++ b/lib/keeper/keeper_tool_bash_input.ml
@@ -244,6 +244,26 @@ let check_env env =
   loop env
 ;;
 
+let check_wrapper_target ~mode ~wrapper_name = function
+  | None -> Error (Empty_argv { executable = wrapper_name })
+  | Some target when is_allowed ~mode target -> Ok ()
+  | Some target -> Error (Executable_not_allowlisted { name = target; mode })
+;;
+
+let check_wrapper_exec_target ~mode ~executable ~argv =
+  match executable with
+  | "env" ->
+    check_wrapper_target
+      ~mode
+      ~wrapper_name:"env"
+      (Worker_dev_tools_command_syntax.command_after_env_prefix argv)
+  | "opam" -> (
+    match Worker_dev_tools_command_syntax.opam_exec_command_name argv with
+    | Some "opam" -> Ok ()
+    | target -> check_wrapper_target ~mode ~wrapper_name:"opam" target)
+  | _ -> Ok ()
+;;
+
 let check_exec ~mode ~executable ~argv ~cwd ~env =
   let ( let* ) = Result.bind in
   if not (is_allowed ~mode executable)
@@ -252,6 +272,7 @@ let check_exec ~mode ~executable ~argv ~cwd ~env =
     let* () =
       if argv = [] then Ok () else check_argv ~executable argv
     in
+    let* () = check_wrapper_exec_target ~mode ~executable ~argv in
     let* () = check_cwd cwd in
     let* () = check_env env in
     Ok ()

--- a/lib/keeper/keeper_tool_bash_input.mli
+++ b/lib/keeper/keeper_tool_bash_input.mli
@@ -11,8 +11,11 @@
 
     {2 Design constraints}
 
-    - **No string parsing**.  Validation is membership against
+    - **No shell-string parsing**.  Validation is membership against
       {!Dev_exec_allowlist} plus structural checks on argv/cwd.
+      Allowlisted wrapper executables ([env], [opam exec]) are resolved
+      over explicit argv tokens and their effective target executable is
+      checked against the same allowlist.
     - **Execve-style argv semantics**.  Each token in [argv] is passed
       verbatim to the child process; the implementation invokes the
       executable directly (no [/bin/sh -c "..."] wrapping).  Therefore

--- a/lib/server/server_dashboard_http_core_meta_cognition.mli
+++ b/lib/server/server_dashboard_http_core_meta_cognition.mli
@@ -1,0 +1,25 @@
+(** Meta-cognition summary cache helpers for dashboard HTTP core. *)
+
+module Mc_cache : module type of Server_dashboard_meta_cognition_cache
+
+val meta_cognition_summary_ttl : float
+
+val meta_cognition_summary_stale_for : float
+
+val meta_cognition_summary_empty_json : Yojson.Safe.t
+
+val dashboard_shell_cache_prefix : Coord.config -> string
+
+val dashboard_shell_cache_key : ?light:bool -> Coord.config -> string
+
+val meta_cognition_summary_key : Coord.config -> string
+
+val store_last_good_meta_cognition_summary : string -> Yojson.Safe.t -> unit
+
+val find_last_good_meta_cognition_summary : string -> Yojson.Safe.t option
+
+val clear_meta_cognition_warm_flag : string -> unit
+
+val schedule_meta_cognition_summary_warm : Coord.config -> unit
+
+val meta_cognition_summary_cached : Coord.config -> Yojson.Safe.t

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -783,20 +783,21 @@ let handle_code_git ~tool_name ~start_time ctx args =
             | Some cfg -> Keeper_tool_policy_config.clone_depth cfg
             | None -> 0
           in
-          let depth_flag =
-            if depth > 0 then Printf.sprintf " --depth %d" depth else ""
-          in
+          let depth_args = if depth > 0 then [ "--depth"; string_of_int depth ] else [] in
           let timeout = match get_policy_config ~base_path:ctx.config.Coord.base_path with
             | Some cfg -> Keeper_tool_policy_config.clone_timeout_sec cfg
             | None -> 120.0
           in
-          let cmd = ["sh"; "-c";
-                     Printf.sprintf "cd %s && git clone%s %s"
-                       (Filename.quote abs_cwd)
-                       depth_flag
-                       (Filename.quote clone_url)]
-          in
-          match Masc_exec.Exec_gate.run_argv_with_status ~actor:`Coord_git ~raw_source:(String.concat " " cmd) ~summary:"git clone" ~timeout_sec:timeout cmd with
+          let cmd = [ "git"; "clone" ] @ depth_args @ [ clone_url ] in
+          match
+            Masc_exec.Exec_gate.run_argv_with_status
+              ~actor:`Coord_git
+              ~raw_source:(String.concat " " cmd)
+              ~summary:"git clone"
+              ~timeout_sec:timeout
+              ~cwd:abs_cwd
+              cmd
+          with
           | Unix.WEXITED code, output ->
             let response =
               `Assoc
@@ -845,18 +846,22 @@ let handle_code_git ~tool_name ~start_time ctx args =
           (missing_cwd_error_json ctx ~cwd ~resolved_cwd:dir ~action ())
       | Ok cwd_opt ->
         let dir = match cwd_opt with Some d -> d | None -> "." in
-        let cmd = ["sh"; "-c";
-                   Printf.sprintf "cd %s && git %s %s"
-                     (Filename.quote dir)
-                     action
-                     (String.concat " " (List.map Filename.quote git_args))]
-        in
+        let cmd = "git" :: action :: git_args in
         let env_opt =
           if String.equal action "commit" then
             Some (Keeper_identity.git_env_for_keeper ~keeper_name:ctx.agent_name)
           else None
         in
-        match Masc_exec.Exec_gate.run_argv_with_status ~actor:`Coord_git ~raw_source:(String.concat " " cmd) ~summary:"git action execution" ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Shell ()) ?env:env_opt cmd with
+        match
+          Masc_exec.Exec_gate.run_argv_with_status
+            ~actor:`Coord_git
+            ~raw_source:(String.concat " " cmd)
+            ~summary:"git action execution"
+            ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Shell ())
+            ?env:env_opt
+            ~cwd:dir
+            cmd
+        with
         | Unix.WEXITED code, output ->
           let response =
             `Assoc

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -66,66 +66,16 @@ let code_shell_allowlist_policy
   { allowed_commands; allow_pipes; redirect_allowed = true }
 ;;
 
-let code_shell_block_reason_of_reject
-      (reason : Exec_shell_gate.reject_reason)
-  : Worker_dev_tools.block_reason =
-  match reason with
-  | Command_not_in_allowlist { bin }
-  | Pipeline_segment_disallowed { bin; _ } -> Command_not_allowed bin
-  | Pipes_not_allowed _ -> Pipes_not_allowed
-  | Redirect_disallowed_in_caller _
-  | Path_outside_policy _ -> Unsafe_redirect
-;;
-
-let code_shell_block_reason_of_too_complex
-      (reason : Exec_shell_gate.too_complex_reason)
-  : Worker_dev_tools.block_reason =
-  match reason with
-  | Unsupported_construct `Proc_subst -> Process_substitution
-  | Unsupported_construct (`Heredoc | `Here_string | `Redirect) -> Unsafe_redirect
-  | Unsupported_nested_pipeline
-  | Unsupported_construct
-      ( `Cmd_subst
-      | `Subshell
-      | `Arith_expansion
-      | `Control_flow
-      | `Logic_op
-      | `Function_def
-      | `Glob_brace
-      | `Background
-      | `Unknown_construct _ ) -> Injection
-;;
-
 let validate_code_shell_command_block_reason
       ?(allow_pipes = true)
       ~(allowed_commands : string list)
       command
   =
-  let trimmed = String.trim command in
-  if String.equal trimmed ""
-  then Error Worker_dev_tools.Empty_command
-  else (
-    match
-      Exec_shell_gate.gate
-        ~caller:Exec_shell_gate.Tool_code_write
-        ~raw:trimmed
-        ~allowlist:(code_shell_allowlist_policy ~allow_pipes ~allowed_commands ())
-        ~path_policy:Exec_shell_gate.allow_all_paths
-        ~sandbox:Exec_shell_gate.host_sandbox
-        ()
-    with
-    | Allow context ->
-      if context.Exec_shell_gate.invokes_direct_dune
-      then Error Worker_dev_tools.Direct_dune_invocation
-      else Ok ()
-    | Reject { context; reason; _ } ->
-      (match reason with
-       | Pipes_not_allowed _ -> Error Worker_dev_tools.Pipes_not_allowed
-       | _ when context.Exec_shell_gate.invokes_direct_dune ->
-         Error Worker_dev_tools.Direct_dune_invocation
-       | _ -> Error (code_shell_block_reason_of_reject reason))
-    | Cannot_parse _ -> Error Worker_dev_tools.Injection
-    | Too_complex { reason } -> Error (code_shell_block_reason_of_too_complex reason))
+  Worker_dev_tools.validate_command_coding_with_allowlist
+    ~caller:Exec_shell_gate.Tool_code_write
+    ~allow_pipes
+    ~allowed_commands
+    command
 ;;
 
 let validate_code_shell_command (command : string) : (unit, string) Result.t =
@@ -726,41 +676,54 @@ let handle_code_shell ~tool_name ~start_time ctx args =
                   ~command ())
          | Ok cwd_opt ->
              let safe_timeout = Float.of_int (max 5 (min 120 timeout)) in
-             let cmd_parts = ["sh"; "-c"; command] in
-             let full_cmd =
+             let path_workdir =
                match cwd_opt with
-               | None -> cmd_parts
-               | Some dir ->
-                   [ "sh"; "-c"; Printf.sprintf "cd %s && %s"
-                       (Filename.quote dir) command ]
+               | Some dir -> dir
+               | None -> Sys.getcwd ()
              in
-             match Masc_exec.Exec_gate.run_argv_with_status ~actor:`Tool_local_runtime ~raw_source:(String.concat " " full_cmd) ~summary:"shell command execution" ~timeout_sec:safe_timeout full_cmd with
-             | Unix.WEXITED code, output ->
-                 let exit_status = classify_code_shell_exit ~command code in
-                 let response_fields =
-                   [
-                     ( "status",
-                       `String (match exit_status with Shell_error -> "error" | _ -> "ok") );
-                     ("exit_code", `Int code);
-                     ("output", `String (truncate_output output));
-                     ("command", `String command);
-                     ("agent", `String ctx.agent_name);
-                   ]
-                   @
-                   match exit_status with
-                   | Shell_ok_expected_nonzero reason ->
-                       [ ("exit_semantics", `String reason) ]
-                   | Shell_ok | Shell_error -> []
-                 in
-                 let response = `Assoc response_fields in
-                 (match exit_status with
-                  | Shell_ok | Shell_ok_expected_nonzero _ ->
-                      fun msg -> Tool_result.ok ~tool_name ~start_time msg
-                  | Shell_error ->
-                      fun msg -> Tool_result.error ~tool_name ~start_time msg)
-                   (Yojson.Safe.pretty_to_string response)
-             | _, output ->
-                 Tool_result.error ~tool_name ~start_time (Printf.sprintf "Command failed: %s" (truncate_output output)))
+             match Worker_dev_tools.validate_command_paths ~workdir:path_workdir command with
+             | Error reason ->
+                 Tool_result.error ~tool_name ~start_time
+                   ~failure_class:(Some Tool_result.Policy_rejection)
+                   reason
+             | Ok () ->
+                 let full_cmd = [(Host_config.host ()).host_sh; "-c"; command] in
+                 match
+                   Masc_exec.Exec_gate.run_argv_with_status
+                     ~actor:`Tool_local_runtime
+                     ~raw_source:(String.concat " " full_cmd)
+                     ~summary:"shell command execution"
+                     ~timeout_sec:safe_timeout
+                     ?cwd:cwd_opt
+                     full_cmd
+                 with
+                 | Unix.WEXITED code, output ->
+                     let exit_status = classify_code_shell_exit ~command code in
+                     let response_fields =
+                       [
+                         ( "status",
+                           `String (match exit_status with Shell_error -> "error" | _ -> "ok") );
+                         ("exit_code", `Int code);
+                         ("output", `String (truncate_output output));
+                         ("command", `String command);
+                         ("agent", `String ctx.agent_name);
+                       ]
+                       @
+                       match exit_status with
+                       | Shell_ok_expected_nonzero reason ->
+                           [ ("exit_semantics", `String reason) ]
+                       | Shell_ok | Shell_error -> []
+                     in
+                     let response = `Assoc response_fields in
+                     (match exit_status with
+                      | Shell_ok | Shell_ok_expected_nonzero _ ->
+                          fun msg -> Tool_result.ok ~tool_name ~start_time msg
+                      | Shell_error ->
+                          fun msg -> Tool_result.error ~tool_name ~start_time msg)
+                       (Yojson.Safe.pretty_to_string response)
+                 | _, output ->
+                     Tool_result.error ~tool_name ~start_time
+                       (Printf.sprintf "Command failed: %s" (truncate_output output)))
 
 (* Handler: masc_code_git — Git operations *)
 let code_git_route_fields (ctx : context) =

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -764,6 +764,8 @@ let make_shell_exec_with_allowlist
                tool_error message
              | Ok () ->
               let timeout =
+                (* DET-OK: absent request timeout uses a fixed policy default;
+                   runtime nondeterminism is only in subprocess execution. *)
                 Worker_tool_input.extract_float "timeout_s" input
                 |> Option.value ~default:30.0
                 |> Float.min 120.0

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -764,10 +764,9 @@ let make_shell_exec_with_allowlist
                tool_error message
              | Ok () ->
               let timeout =
-                (* DET-OK: absent request timeout uses a fixed policy default;
-                   runtime nondeterminism is only in subprocess execution. *)
                 Worker_tool_input.extract_float "timeout_s" input
                 |> Option.value ~default:30.0
+                   (* DET-OK: fixed policy default for absent shell timeout. *)
                 |> Float.min 120.0
               in
               (try

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -13,9 +13,12 @@
 include Gate_diff_types
 module Paths = Worker_dev_tools_paths
 module Log_sanitize = Worker_dev_tools_log_sanitize
+module Command_syntax = Worker_dev_tools_command_syntax
 module Mutation_classifier = Worker_dev_tools_mutation_classifier
 module Path_validation = Worker_dev_tools_path_validation
 module Exec_shell_gate = Masc_exec_command_gate.Shell_command_gate
+
+open Command_syntax
 
 (* --- Safety validation --- *)
 
@@ -182,10 +185,10 @@ let block_reason_to_string_with_allowlist ~allowed_commands = function
   | reason -> block_reason_to_string reason
 ;;
 
-let first_shell_word_command_name cmd =
-  match Masc_exec_bash_parser.Bash_words.stages cmd with
-  | Ok ((word :: _) :: _) -> Some (Filename.basename word.Masc_exec_bash_parser.Bash_words.value)
-  | Ok ([] :: _) | Ok [] | Error _ -> None
+let validate_command_name_with_allowlist ~allowed_commands = function
+  | None -> Error Empty_command
+  | Some name when List.mem name allowed_commands -> Ok ()
+  | Some name -> Error (Command_not_allowed name)
 ;;
 
 let validate_command_with_allowlist ~allowed_commands cmd =
@@ -196,11 +199,17 @@ let validate_command_with_allowlist ~allowed_commands cmd =
   then Error Chain_or_redirect
   else if Exec_shell_gate.raw_invokes_direct_dune trimmed
   then Error Direct_dune_invocation
-  else (
-    match first_shell_word_command_name trimmed with
-    | None -> Error Empty_command
-    | Some name when List.mem name allowed_commands -> Ok ()
-    | Some name -> Error (Command_not_allowed name))
+  else
+    match segment_command_name trimmed with
+    | Some _ as command ->
+      validate_command_name_with_allowlist ~allowed_commands command
+    | None ->
+      (* [env] without a target prints the ambient process environment.
+         Treat wrappers that do not resolve to a real command as blocked
+         instead of falling back to the allowlisted [env] binary. *)
+      (match extract_command_name trimmed with
+       | Some name -> Error (Command_not_allowed name)
+       | None -> Error Empty_command)
 ;;
 
 let validate_command ?caller:_ cmd =
@@ -210,6 +219,94 @@ let validate_command ?caller:_ cmd =
 let coding_allowlist_policy ?(allow_pipes = true) ~allowed_commands () :
   Exec_shell_gate.allowlist_policy =
   { allowed_commands; allow_pipes; redirect_allowed = true }
+;;
+
+let rec shell_ir_literal_text = function
+  | Masc_exec.Shell_ir.Lit text -> Some text
+  | Masc_exec.Shell_ir.Concat parts ->
+    let rec loop acc = function
+      | [] -> Some (String.concat "" (List.rev acc))
+      | part :: rest ->
+        (match shell_ir_literal_text part with
+         | Some text -> loop (text :: acc) rest
+         | None -> None)
+    in
+    loop [] parts
+  | Masc_exec.Shell_ir.Var _ -> None
+;;
+
+let simple_literal_args (simple : Masc_exec.Shell_ir.simple) =
+  let rec loop acc = function
+    | [] -> Some (List.rev acc)
+    | arg :: rest ->
+      (match shell_ir_literal_text arg with
+       | Some text -> loop (text :: acc) rest
+       | None -> None)
+  in
+  loop [] simple.Masc_exec.Shell_ir.args
+;;
+
+let validate_wrapper_target ~allowed_commands ~wrapper_name = function
+  | None -> Error (Command_not_allowed wrapper_name)
+  | Some "dune" -> Error Direct_dune_invocation
+  | Some name ->
+    validate_command_name_with_allowlist
+      ~allowed_commands
+      (Some name)
+;;
+
+let validate_env_wrapped_stage ~allowed_commands
+      (simple : Masc_exec.Shell_ir.simple)
+  =
+  let bin = Masc_exec.Bin.to_string simple.Masc_exec.Shell_ir.bin in
+  if not (String.equal bin "env")
+  then Ok ()
+  else
+    match simple_literal_args simple with
+    | None -> Error Injection
+    | Some args ->
+      validate_wrapper_target
+        ~allowed_commands
+        ~wrapper_name:"env"
+        (command_after_env_prefix args)
+;;
+
+let validate_opam_exec_wrapped_stage ~allowed_commands
+      (simple : Masc_exec.Shell_ir.simple)
+  =
+  let bin = Masc_exec.Bin.to_string simple.Masc_exec.Shell_ir.bin in
+  if not (String.equal bin "opam")
+  then Ok ()
+  else
+    match simple_literal_args simple with
+    | None -> Error Injection
+    | Some args ->
+      (match opam_exec_command_name args with
+       | Some "opam" -> Ok ()
+       | command ->
+         validate_wrapper_target
+           ~allowed_commands
+           ~wrapper_name:"opam"
+           command)
+;;
+
+let validate_wrapped_stages ~allowed_commands ast =
+  let rec loop = function
+    | Masc_exec.Shell_ir.Simple simple -> (
+      match validate_env_wrapped_stage ~allowed_commands simple with
+      | Ok () -> validate_opam_exec_wrapped_stage ~allowed_commands simple
+      | Error _ as error -> error)
+    | Masc_exec.Shell_ir.Pipeline stages ->
+      let rec loop_stages = function
+        | [] -> Ok ()
+        | stage :: rest ->
+          (match loop stage with
+           | Ok () -> loop_stages rest
+           | Error _ as error -> error)
+      in
+      loop_stages stages
+  in
+  loop ast
 ;;
 
 let block_reason_of_exec_reject : Exec_shell_gate.reject_reason -> block_reason = function
@@ -285,7 +382,7 @@ let validate_command_coding_with_allowlist
     | Allow context ->
       if context.Exec_shell_gate.invokes_direct_dune
       then Error Direct_dune_invocation
-      else Ok ()
+      else validate_wrapped_stages ~allowed_commands context.Exec_shell_gate.ast
     | Reject { context; reason; _ } ->
       (match reason with
        | Pipes_not_allowed _ -> Error Pipes_not_allowed
@@ -647,12 +744,31 @@ let make_shell_exec_with_allowlist
               on_exec;
             tool_error (block_reason_to_string reason)
           | Ok () ->
-            let timeout =
-              Worker_tool_input.extract_float "timeout_s" input
-              |> Option.value ~default:30.0
-              |> Float.min 120.0
+            let path_workdir =
+              match workdir with
+              | Some dir when String.trim dir <> "" -> dir
+              | Some _ | None -> Sys.getcwd ()
             in
-            (try
+            (match validate_command_paths ~workdir:path_workdir command with
+             | Error message ->
+               Option.iter
+                 (fun (f : tool_exec_observer) ->
+                    f
+                      ~tool_name:"shell_exec"
+                      ~success:false
+                      ~duration_ms:0
+                      ~error_kind:Path_blocked
+                      ~error_message:message
+                      ())
+                 on_exec;
+               tool_error message
+             | Ok () ->
+              let timeout =
+                Worker_tool_input.extract_float "timeout_s" input
+                |> Option.value ~default:30.0
+                |> Float.min 120.0
+              in
+              (try
                let started = Time_compat.now () in
                let record_result ?error_message result =
                  let duration_ms =
@@ -758,6 +874,7 @@ let make_shell_exec_with_allowlist
                       ())
                  on_exec;
                tool_error (Printf.sprintf "Command failed: %s" exn_msg))))
+            )
 ;;
 
 let make_shell_exec ~workdir ~on_exec ~proc_mgr ~clock =

--- a/lib/worker_dev_tools_command_syntax.ml
+++ b/lib/worker_dev_tools_command_syntax.ml
@@ -1,8 +1,21 @@
-(** Shell word helpers for worker path policy.
+(** Shell word helpers for worker path and transparent-wrapper policy.
 
     Command-shape validation is owned by
     [Masc_exec_command_gate.Shell_command_gate]. This module keeps only
-    path-token normalization helpers that operate on parser-provided words. *)
+    path-token normalization helpers plus explicit argv/word helpers for
+    transparent wrappers such as [env] and [opam exec]. *)
+
+let split_shell_tokens cmd =
+  match Masc_exec_bash_parser.Bash_words.stages cmd with
+  | Ok [ words ] ->
+    words
+    |> List.map (fun word -> word.Masc_exec_bash_parser.Bash_words.value)
+    |> List.filter (fun token -> token <> "")
+  | Ok _ | Error _ ->
+    String.split_on_char ' ' cmd
+    |> List.map String.trim
+    |> List.filter (fun token -> token <> "")
+;;
 
 let strip_wrapping_quotes token =
   let len = String.length token in
@@ -14,4 +27,127 @@ let strip_wrapping_quotes token =
     then String.sub token 1 (len - 2)
     else token)
   else token
+;;
+
+let basename_token token = Filename.basename (strip_wrapping_quotes token)
+
+let is_env_assignment token =
+  let token = strip_wrapping_quotes token in
+  match String.index_opt token '=' with
+  | Some idx ->
+    idx > 0
+    && not (String.contains (String.sub token 0 idx) '/')
+    && not (String.starts_with ~prefix:"-" token)
+  | None -> false
+;;
+
+let rec skip_env_assignments_tokens = function
+  | [] -> None
+  | token :: rest ->
+    let token = strip_wrapping_quotes token in
+    if is_env_assignment token then skip_env_assignments_tokens rest else Some (token :: rest)
+;;
+
+let rec command_after_env_prefix_tokens = function
+  | [] -> None
+  | token :: rest ->
+    let token = strip_wrapping_quotes token in
+    if is_env_assignment token || token = "-" || token = "-i"
+       || token = "--ignore-environment" || token = "-0" || token = "--null"
+    then command_after_env_prefix_tokens rest
+    else if token = "--"
+    then skip_env_assignments_tokens rest
+    else if token = "-S" || token = "--split-string"
+    then (
+      match rest with
+      | arg :: rest -> (
+        match
+          command_after_env_prefix_tokens (split_shell_tokens (strip_wrapping_quotes arg))
+        with
+        | Some _ as command -> command
+        | None -> command_after_env_prefix_tokens rest)
+      | [] -> None)
+    else if String.starts_with ~prefix:"--split-string=" token
+    then
+      let prefix = "--split-string=" in
+      let arg =
+        String.sub token (String.length prefix) (String.length token - String.length prefix)
+      in
+      command_after_env_prefix_tokens (split_shell_tokens (strip_wrapping_quotes arg))
+    else if token = "-u" || token = "--unset" || token = "-C" || token = "--chdir"
+    then (
+      match rest with
+      | _ :: rest -> command_after_env_prefix_tokens rest
+      | [] -> None)
+    else if String.starts_with ~prefix:"-u" token
+            || String.starts_with ~prefix:"--unset=" token
+            || String.starts_with ~prefix:"--chdir=" token
+    then command_after_env_prefix_tokens rest
+    else Some (token :: rest)
+;;
+
+let opam_exec_command_tokens rest =
+  match rest with
+  | sub :: rest when String.equal (basename_token sub) "exec" ->
+    let rec find_sentinel = function
+      | [] -> None
+      | "--" :: rest -> skip_env_assignments_tokens rest
+      | _ :: rest -> find_sentinel rest
+    in
+    let rec find_command_without_sentinel = function
+      | [] -> None
+      | token :: rest ->
+        let token = strip_wrapping_quotes token in
+        if is_env_assignment token
+        then find_command_without_sentinel rest
+        else if token = "--switch" || token = "--color" || token = "--root" || token = "--cli"
+        then (
+          match rest with
+          | _ :: rest -> find_command_without_sentinel rest
+          | [] -> None)
+        else if String.starts_with ~prefix:"--switch=" token
+                || String.starts_with ~prefix:"--color=" token
+                || String.starts_with ~prefix:"--root=" token
+                || String.starts_with ~prefix:"--cli=" token
+                || String.starts_with ~prefix:"-" token
+        then find_command_without_sentinel rest
+        else Some (token :: rest)
+    in
+    (match find_sentinel rest with
+     | Some _ as command -> command
+     | None -> find_command_without_sentinel rest)
+  | [] -> Some [ "opam" ]
+  | _non_exec_subcommand :: _rest -> Some [ "opam" ]
+;;
+
+let rec effective_command_name_from_tokens = function
+  | [] -> None
+  | token :: rest -> (
+    match basename_token token with
+    | "env" ->
+      Option.bind (command_after_env_prefix_tokens rest) effective_command_name_from_tokens
+    | "opam" ->
+      (match opam_exec_command_tokens rest with
+       | Some [ "opam" ] -> Some "opam"
+       | Some tokens -> effective_command_name_from_tokens tokens
+       | None -> None)
+    | name -> Some name)
+;;
+
+let command_after_env_prefix tokens =
+  Option.bind (command_after_env_prefix_tokens tokens) effective_command_name_from_tokens
+;;
+
+let opam_exec_command_name tokens =
+  Option.bind (opam_exec_command_tokens tokens) effective_command_name_from_tokens
+;;
+
+let segment_command_name segment =
+  effective_command_name_from_tokens (split_shell_tokens segment)
+;;
+
+let extract_command_name cmd =
+  match split_shell_tokens cmd with
+  | token :: _ -> Some (basename_token token)
+  | [] -> None
 ;;

--- a/lib/worker_dev_tools_command_syntax.mli
+++ b/lib/worker_dev_tools_command_syntax.mli
@@ -1,3 +1,22 @@
-(** Shell word helpers for worker path policy. *)
+(** Shell word helpers for worker path and transparent-wrapper policy. *)
 
 val strip_wrapping_quotes : string -> string
+
+val command_after_env_prefix : string list -> string option
+(** Resolve the effective command name from argv words following an [env]
+    executable. Environment assignments and supported env options are skipped;
+    transparent nested wrappers are resolved recursively. *)
+
+val opam_exec_command_name : string list -> string option
+(** Resolve the effective command name for argv words following an [opam]
+    executable. [opam exec] targets are resolved recursively; non-exec opam
+    subcommands resolve to [Some "opam"]. *)
+
+val segment_command_name : string -> string option
+(** Resolve the effective command name of a shell segment, including transparent
+    [env] and [opam exec] wrappers. *)
+
+val extract_command_name : string -> string option
+(** Return the basename of the first shell token without resolving transparent
+    wrappers. Intended for diagnostics when {!segment_command_name} has no
+    effective target. *)

--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -31,8 +31,8 @@ lib/process/process_eio.ml:535
 # manager itself. Bounded by session scope, not by per-call timeout.
 lib/server/lsp_process_manager.ml:178
 
-# lib/worker_dev_tools.ml:706 — dev-tools worker spawn. Wrapped by
+# lib/worker_dev_tools.ml:824 — dev-tools worker spawn. Wrapped by
 # Tool_resource_gate, Fd_accountant, Eio.Time.with_timeout_exn, and a fresh
 # Eio.Switch.run at the call boundary. Line renumbered by worker-dev-tools
 # split/refactor waves.
-lib/worker_dev_tools.ml:706
+lib/worker_dev_tools.ml:824

--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -31,8 +31,8 @@ lib/process/process_eio.ml:535
 # manager itself. Bounded by session scope, not by per-call timeout.
 lib/server/lsp_process_manager.ml:178
 
-# lib/worker_dev_tools.ml:824 — dev-tools worker spawn. Wrapped by
+# lib/worker_dev_tools.ml:823 — dev-tools worker spawn. Wrapped by
 # Tool_resource_gate, Fd_accountant, Eio.Time.with_timeout_exn, and a fresh
 # Eio.Switch.run at the call boundary. Line renumbered by worker-dev-tools
 # split/refactor waves.
-lib/worker_dev_tools.ml:824
+lib/worker_dev_tools.ml:823

--- a/test/test_keeper_bash_typed_input.ml
+++ b/test/test_keeper_bash_typed_input.ml
@@ -169,6 +169,62 @@ let test_pipeline_stage_executable_check () =
     (typed_ok input)
 ;;
 
+let expect_not_allowlisted ~target input =
+  match Bash_input.validate ~mode:Bash_input.Dev_full input with
+  | Error (Bash_input.Executable_not_allowlisted { name; _ }) ->
+    Alcotest.(check string) "blocked target" target name
+  | Error error ->
+    Alcotest.failf
+      "expected Executable_not_allowlisted %S, got %a"
+      target
+      Bash_input.pp_validation_error
+      error
+  | Ok () -> Alcotest.failf "expected %S to be blocked" target
+;;
+
+let test_wrapper_exec_target_allowlist () =
+  List.iter
+    (fun input -> expect_not_allowlisted ~target:"rm" input)
+    [ mk_exec "env" [ "rm"; "-rf"; "/" ]
+    ; mk_exec "opam" [ "exec"; "--"; "rm"; "-rf"; "/" ]
+    ; mk_exec "env" [ "opam"; "exec"; "--"; "rm"; "-rf"; "/" ]
+    ; mk_exec "opam" [ "exec"; "--"; "env"; "rm"; "-rf"; "/" ]
+    ; Bash_input.Pipeline
+        { stages =
+            [ { executable = "rg"; argv = [ "pattern" ] }
+            ; { executable = "env"; argv = [ "rm"; "-rf"; "/" ] }
+            ]
+        ; cwd = None
+        ; env = []
+        }
+    ];
+  List.iter
+    (fun input ->
+      match Bash_input.validate ~mode:Bash_input.Dev_full input with
+      | Ok () -> ()
+      | Error error ->
+        Alcotest.failf
+          "expected wrapper target to be allowed, got %a"
+          Bash_input.pp_validation_error
+          error)
+    [ mk_exec "env" [ "git"; "status" ]
+    ; mk_exec "opam" [ "exec"; "--"; "git"; "status" ]
+    ; mk_exec "env" [ "opam"; "exec"; "--"; "git"; "status" ]
+    ; mk_exec "opam" [ "exec"; "--"; "env"; "FOO=bar"; "git"; "status" ]
+    ]
+;;
+
+let test_standalone_env_rejected () =
+  match Bash_input.validate ~mode:Bash_input.Dev_full (mk_exec "env" []) with
+  | Error (Bash_input.Empty_argv { executable = "env" }) -> ()
+  | Error error ->
+    Alcotest.failf
+      "expected standalone env to be rejected as empty wrapper, got %a"
+      Bash_input.pp_validation_error
+      error
+  | Ok () -> Alcotest.fail "standalone env should not be accepted"
+;;
+
 let test_of_json_exec () =
   let input =
     parse_json_exn
@@ -437,6 +493,14 @@ let suite =
           "pipeline_stage_executable_check"
           `Quick
           test_pipeline_stage_executable_check
+      ; Alcotest.test_case
+          "wrapper_exec_target_allowlist"
+          `Quick
+          test_wrapper_exec_target_allowlist
+      ; Alcotest.test_case
+          "standalone_env_rejected"
+          `Quick
+          test_standalone_env_rejected
       ; Alcotest.test_case "of_json_exec" `Quick test_of_json_exec
       ; Alcotest.test_case "of_json_pipeline" `Quick test_of_json_pipeline
       ; Alcotest.test_case

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -89,6 +89,10 @@ let rec mkdir_p dir =
 let write_file path content =
   Out_channel.with_open_bin path (fun oc -> output_string oc content)
 
+let write_executable path content =
+  write_file path content;
+  Unix.chmod path 0o755
+
 let policy_toml ?(denied_repos = []) allowed_orgs =
   let array items =
     items |> List.map (Printf.sprintf "%S") |> String.concat ", "
@@ -685,6 +689,51 @@ let test_code_git_status_marks_docker_keeper_route () =
   check string "brokered via" "brokered" (json_string_field "via" msg);
   check string "brokered route" "brokered" (json_string_field "route_via" msg)
 
+let test_code_git_status_uses_direct_git_argv () =
+  let base_path = fresh_base_path () in
+  let config = make_config base_path in
+  let cwd = Filename.concat base_path ".masc/playground/test-agent/repos/repo" in
+  mkdir_p cwd;
+  let fake_bin = Filename.concat base_path "fake-bin" in
+  mkdir_p fake_bin;
+  let git_pwd_file = Filename.concat base_path "git-pwd.txt" in
+  let git_argv_file = Filename.concat base_path "git-argv.txt" in
+  write_executable
+    (Filename.concat fake_bin "git")
+    (Printf.sprintf
+       "#!/bin/sh\n\
+        printf '%%s\\n' \"$PWD\" > %s\n\
+        printf '%%s\\n' \"$@\" > %s\n\
+        exit 0\n"
+       (Filename.quote git_pwd_file)
+       (Filename.quote git_argv_file));
+  write_executable
+    (Filename.concat fake_bin "sh")
+    "#!/bin/sh\necho unexpected shell >&2\nexit 42\n";
+  let old_path = Option.value (Sys.getenv_opt "PATH") ~default:"" in
+  let ctx =
+    { Tool_code_write.config;
+      agent_name = "test-agent";
+    }
+  in
+  let args =
+    `Assoc
+      [
+        ("action", `String "status");
+        ("args", `List [ `String "--short;touch"; `String "owned" ]);
+        ("cwd", `String cwd);
+      ]
+  in
+  with_trimmed_env "PATH" (Some (fake_bin ^ ":" ^ old_path)) @@ fun () ->
+  let ok, msg = dispatch_exn ctx ~name:"masc_code_git" ~args in
+  check bool "status succeeds through fake git" true ok;
+  check string "git cwd" cwd
+    (String.trim (Stdlib.In_channel.read_all git_pwd_file));
+  check string "git argv stays literal" "status\n--short;touch\nowned"
+    (String.trim (Stdlib.In_channel.read_all git_argv_file));
+  check bool "shell was not invoked" false
+    (msg_contains ~needle:"unexpected shell" msg)
+
 let test_code_edit_identical_replacement_is_noop () =
   let base_path = fresh_base_path () in
   let config = make_config base_path in
@@ -1138,6 +1187,8 @@ let () =
         test_code_git_checkout_dot_blocked_before_cwd_validation;
       test_case "status marks docker keeper route" `Quick
         test_code_git_status_marks_docker_keeper_route;
+      test_case "status uses direct git argv" `Quick
+        test_code_git_status_uses_direct_git_argv;
       test_case "missing docker cwd reports worktree hint" `Quick
         test_code_git_missing_docker_cwd_reports_worktree_hint;
     ]);

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -89,6 +89,8 @@ let rec mkdir_p dir =
 let write_file path content =
   Out_channel.with_open_bin path (fun oc -> output_string oc content)
 
+let read_file path = In_channel.with_open_text path In_channel.input_all
+
 let write_executable path content =
   write_file path content;
   Unix.chmod path 0o755
@@ -727,10 +729,9 @@ let test_code_git_status_uses_direct_git_argv () =
   with_trimmed_env "PATH" (Some (fake_bin ^ ":" ^ old_path)) @@ fun () ->
   let ok, msg = dispatch_exn ctx ~name:"masc_code_git" ~args in
   check bool "status succeeds through fake git" true ok;
-  check string "git cwd" cwd
-    (String.trim (Stdlib.In_channel.read_all git_pwd_file));
+  check string "git cwd" cwd (String.trim (read_file git_pwd_file));
   check string "git argv stays literal" "status\n--short;touch\nowned"
-    (String.trim (Stdlib.In_channel.read_all git_argv_file));
+    (String.trim (read_file git_argv_file));
   check bool "shell was not invoked" false
     (msg_contains ~needle:"unexpected shell" msg)
 

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -417,6 +417,38 @@ let test_validate_code_shell_command_rejects_pipe_to_disallowed () =
   | Ok () ->
       fail "expected pipe-to-disallowed-command to be rejected by allowlist"
 
+let test_validate_code_shell_command_rejects_wrapped_disallowed () =
+  let cases =
+    [
+      "env rm -rf /";
+      "opam exec -- rm -rf /";
+      "env opam exec -- rm -rf /";
+      "opam exec -- env rm -rf /";
+    ]
+  in
+  List.iter
+    (fun command ->
+      match Tool_code_write.validate_code_shell_command command with
+      | Error reason ->
+          check bool ("wrapped target rejected: " ^ command) true
+            (msg_contains ~needle:"rm" reason)
+      | Ok () ->
+          fail ("expected wrapped disallowed target to be rejected: " ^ command))
+    cases
+
+let test_validate_code_shell_command_allows_wrapped_allowed () =
+  List.iter
+    (fun command ->
+      check (result unit string) ("wrapped allowed: " ^ command)
+        (Ok ())
+        (Tool_code_write.validate_code_shell_command command))
+    [
+      "env FOO=bar git status";
+      "opam exec -- git status";
+      "env opam exec -- git status";
+      "opam exec -- env FOO=bar git status";
+    ]
+
 let test_validate_code_shell_command_allows_dune_local_build () =
   check (result unit string) "dune-local build allowed" (Ok ())
     (Tool_code_write.validate_code_shell_command
@@ -506,6 +538,26 @@ let test_code_shell_command_shape_block_is_workflow_rejection () =
        result.legacy_message);
   check (option string) "command shape is workflow rejection"
     (Some "workflow_rejection")
+    (Option.map
+       Tool_result.tool_failure_class_to_string
+       (Tool_result.failure_class result))
+
+let test_code_shell_blocks_outside_path_arg () =
+  let ctx = make_ctx () in
+  let result =
+    dispatch_result_exn ctx ~name:"masc_code_shell"
+      ~args:
+        (`Assoc
+          [
+            ("command", `String "cat /etc/passwd");
+            ("timeout", `Int 5);
+          ])
+  in
+  check bool "outside path rejected" false result.success;
+  check bool "error mentions outside path" true
+    (msg_contains ~needle:"outside" result.legacy_message);
+  check (option string) "outside path is policy rejection"
+    (Some "policy_rejection")
     (Option.map
        Tool_result.tool_failure_class_to_string
        (Tool_result.failure_class result))
@@ -753,10 +805,9 @@ let test_code_shell_cross_agent_playground_is_policy_rejection () =
        Tool_result.tool_failure_class_to_string
        (Tool_result.failure_class result))
 
+let code_shell_repo_fixture = "lib/tool_code_write.ml"
+
 let test_code_shell_rg_exit_one_no_matches_is_success () =
-  with_temp_dir "tool-code-shell-rg" @@ fun dir ->
-  let fixture = Filename.concat dir "sample.ml" in
-  write_file fixture "let present = 1\n";
   let ctx = make_ctx () in
   let args =
     `Assoc
@@ -764,7 +815,7 @@ let test_code_shell_rg_exit_one_no_matches_is_success () =
         ( "command",
           `String
             (Printf.sprintf "rg __masc_code_shell_16015_no_match__ %s"
-               (Filename.quote fixture)) );
+               code_shell_repo_fixture) );
         ("timeout", `Int 5);
       ]
   in
@@ -776,9 +827,6 @@ let test_code_shell_rg_exit_one_no_matches_is_success () =
     (json_string_field "exit_semantics" msg)
 
 let test_code_shell_rg_quoted_regex_pipe_no_match_is_success () =
-  with_temp_dir "tool-code-shell-rg-regex-pipe" @@ fun dir ->
-  let fixture = Filename.concat dir "sample.ml" in
-  write_file fixture "let present = 1\n";
   let ctx = make_ctx () in
   let args =
     `Assoc
@@ -786,7 +834,7 @@ let test_code_shell_rg_quoted_regex_pipe_no_match_is_success () =
         ( "command",
           `String
             (Printf.sprintf "rg \"missing_one\\|missing_two\" %s -l"
-               (Filename.quote fixture)) );
+               code_shell_repo_fixture) );
         ("timeout", `Int 5);
       ]
   in
@@ -798,9 +846,6 @@ let test_code_shell_rg_quoted_regex_pipe_no_match_is_success () =
     (json_string_field "exit_semantics" msg)
 
 let test_code_shell_grep_exit_one_no_matches_is_success () =
-  with_temp_dir "tool-code-shell-grep" @@ fun dir ->
-  let fixture = Filename.concat dir "sample.txt" in
-  write_file fixture "present\n";
   let ctx = make_ctx () in
   let args =
     `Assoc
@@ -808,7 +853,7 @@ let test_code_shell_grep_exit_one_no_matches_is_success () =
         ( "command",
           `String
             (Printf.sprintf "grep __masc_code_shell_16015_no_match__ %s"
-               (Filename.quote fixture)) );
+               code_shell_repo_fixture) );
         ("timeout", `Int 5);
       ]
   in
@@ -820,9 +865,6 @@ let test_code_shell_grep_exit_one_no_matches_is_success () =
     (json_string_field "exit_semantics" msg)
 
 let test_code_shell_pipeline_grep_exit_one_no_matches_is_success () =
-  with_temp_dir "tool-code-shell-pipe-grep" @@ fun dir ->
-  let fixture = Filename.concat dir "sample.txt" in
-  write_file fixture "present\n";
   let ctx = make_ctx () in
   let args =
     `Assoc
@@ -830,7 +872,7 @@ let test_code_shell_pipeline_grep_exit_one_no_matches_is_success () =
         ( "command",
           `String
             (Printf.sprintf "cat %s 2>&1 | grep __masc_code_shell_no_match__"
-               (Filename.quote fixture)) );
+               code_shell_repo_fixture) );
         ("timeout", `Int 5);
       ]
   in
@@ -1110,6 +1152,10 @@ let () =
         test_validate_code_shell_command_allows_pipe;
       test_case "rejects pipe to disallowed command" `Quick
         test_validate_code_shell_command_rejects_pipe_to_disallowed;
+      test_case "rejects wrapped disallowed command" `Quick
+        test_validate_code_shell_command_rejects_wrapped_disallowed;
+      test_case "allows wrapped allowed command" `Quick
+        test_validate_code_shell_command_allows_wrapped_allowed;
       test_case "allows dune-local build" `Quick
         test_validate_code_shell_command_allows_dune_local_build;
       Alcotest.test_case "rejects direct dune" `Quick
@@ -1130,6 +1176,8 @@ let () =
         test_validate_code_shell_command_rejects_semicolon;
       test_case "command shape block is workflow rejection" `Quick
         test_code_shell_command_shape_block_is_workflow_rejection;
+      test_case "outside path arg is policy rejection" `Quick
+        test_code_shell_blocks_outside_path_arg;
       test_case "missing docker cwd reports worktree hint" `Quick
         test_code_shell_missing_docker_cwd_reports_worktree_hint;
       test_case "cross-agent playground cwd is policy rejection" `Quick

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -364,6 +364,44 @@ let test_shell_exec_blocked_command () =
        (String.length msg > 0)
    | Ok _ -> Alcotest.fail "should reject rm -rf /")
 
+let test_shell_exec_blocks_env_wrapped_disallowed_command () =
+  let cases =
+    [
+      ("env rm -rf /", "rm");
+      ("env", "env");
+      ("opam exec -- rm -rf /", "rm");
+      ("env opam exec -- rm -rf /", "rm");
+      ("opam exec -- env rm -rf /", "rm");
+    ]
+  in
+  List.iter
+    (fun (cmd, blocked) ->
+      match Worker_dev_tools.validate_command cmd with
+      | Error (Worker_dev_tools.Command_not_allowed got) when String.equal got blocked -> ()
+      | Error reason ->
+        Alcotest.fail
+          ("wrong rejection for " ^ cmd ^ ": "
+           ^ Worker_dev_tools.block_reason_to_string reason)
+      | Ok () -> Alcotest.fail ("env command should be blocked: " ^ cmd))
+    cases
+
+let test_shell_exec_blocks_outside_path_arg () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let proc_mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
+  let tools = Worker_dev_tools.make_tools ~proc_mgr ~clock () in
+  let tool = find_tool "shell_exec" tools in
+  match Tool.execute tool (`Assoc [ "command", `String "cat /etc/passwd" ]) with
+  | Error { Agent_sdk.Types.message = msg; _ } ->
+    Alcotest.(check bool)
+      "mentions path outside whitelist"
+      true
+      (String_util.contains_substring_ci msg "outside")
+  | Ok { Agent_sdk.Types.content } ->
+    Alcotest.fail
+      ("shell_exec should block outside path before execution: " ^ content)
+
 let test_tool_exec_observer_bridges_to_telemetry () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -607,6 +645,10 @@ let () =
     "shell_exec", [
       Alcotest.test_case "echo hello" `Quick test_shell_exec_echo;
       Alcotest.test_case "blocked command" `Quick test_shell_exec_blocked_command;
+      Alcotest.test_case "env wrapper blocked command" `Quick
+        test_shell_exec_blocks_env_wrapped_disallowed_command;
+      Alcotest.test_case "outside path arg blocked" `Quick
+        test_shell_exec_blocks_outside_path_arg;
       Alcotest.test_case "observer bridges to telemetry" `Quick
         test_tool_exec_observer_bridges_to_telemetry;
       Alcotest.test_case "reject shell metacharacters" `Quick
@@ -719,6 +761,45 @@ let () =
             "env --chdir repos/masc-mcp -- dune build";
             "env -i -- DUNE_JOBS=1 dune build";
           ]);
+      Alcotest.test_case "blocks env-wrapped disallowed command" `Quick (fun () ->
+        List.iter
+          (fun cmd ->
+            match Worker_dev_tools.validate_command_coding cmd with
+            | Error (Worker_dev_tools.Command_not_allowed "rm") -> ()
+            | Error e ->
+              Alcotest.fail
+                ("wrong rejection for " ^ cmd ^ ": "
+                 ^ Worker_dev_tools.block_reason_to_string e)
+            | Ok () ->
+              Alcotest.fail ("should reject env-wrapped disallowed command: " ^ cmd))
+          [
+            "env rm -rf /";
+            "env -- rm -rf /";
+            "env FOO=bar rm -rf /";
+            "env opam exec -- rm -rf /";
+            "git status | env rm -rf /";
+          ]);
+      Alcotest.test_case "blocks standalone env dump" `Quick (fun () ->
+        match Worker_dev_tools.validate_command_coding "env" with
+        | Error (Worker_dev_tools.Command_not_allowed "env") -> ()
+        | Error e ->
+          Alcotest.fail
+            ("wrong rejection: " ^ Worker_dev_tools.block_reason_to_string e)
+        | Ok () -> Alcotest.fail "standalone env should be blocked");
+      Alcotest.test_case "allows env-wrapped allowed command" `Quick (fun () ->
+        List.iter
+          (fun cmd ->
+            match Worker_dev_tools.validate_command_coding cmd with
+            | Ok () -> ()
+            | Error e ->
+              Alcotest.fail
+                ("should allow env-wrapped allowed command " ^ cmd ^ ": "
+                 ^ Worker_dev_tools.block_reason_to_string e))
+          [
+            "env FOO=bar git status";
+            "env -- git status";
+            "env -i -- FOO=bar git status | head -5";
+          ]);
       Alcotest.test_case "blocks opam-exec direct dune" `Quick (fun () ->
         match
           Worker_dev_tools.validate_command_coding
@@ -742,6 +823,43 @@ let () =
             "opam exec --switch=default -- dune build";
             "opam exec --color never -- dune build";
           ]);
+      Alcotest.test_case "blocks opam-exec wrapped disallowed command" `Quick
+        (fun () ->
+           List.iter
+             (fun cmd ->
+               match Worker_dev_tools.validate_command_coding cmd with
+               | Error (Worker_dev_tools.Command_not_allowed "rm") -> ()
+               | Error e ->
+                 Alcotest.fail
+                   ("wrong rejection for " ^ cmd ^ ": "
+                    ^ Worker_dev_tools.block_reason_to_string e)
+               | Ok () ->
+                 Alcotest.fail
+                   ("should reject opam-exec wrapped disallowed command: " ^ cmd))
+             [
+               "opam exec -- rm -rf /";
+               "opam exec --switch default -- rm -rf /";
+               "opam exec -- env rm -rf /";
+               "env opam exec -- rm -rf /";
+               "git status | opam exec -- rm -rf /";
+             ]);
+      Alcotest.test_case "allows opam-exec wrapped allowed command" `Quick
+        (fun () ->
+           List.iter
+             (fun cmd ->
+               match Worker_dev_tools.validate_command_coding cmd with
+               | Ok () -> ()
+               | Error e ->
+                 Alcotest.fail
+                   ("should allow opam-exec wrapped allowed command " ^ cmd ^ ": "
+                    ^ Worker_dev_tools.block_reason_to_string e))
+             [
+               "opam exec -- git status";
+               "opam exec --switch default -- git status";
+               "env opam exec -- git status";
+               "opam exec -- env FOO=bar git status";
+               "opam exec -- git status | head -5";
+             ]);
       Alcotest.test_case "blocks semicolon" `Quick (fun () ->
         match Worker_dev_tools.validate_command_coding "ls; rm -rf /" with
         | Error _ -> ()


### PR DESCRIPTION
## Summary
- resolve shell wrapper chains recursively so env/opam exec cannot hide the real target executable
- validate strict shell_exec and Coding/Full raw shell commands through the wrapper-aware resolver
- apply the same target allowlist check to typed keeper_bash executable/argv inputs before lowering to Shell_ir
- add path-token validation before /bin/sh execution for shell_exec and masc_code_shell
- switch masc_code_shell to Exec_gate cwd instead of injecting cd into shell strings, and resolve the shell via Host_config.host_sh
- execute masc_code_git clone/status/diff/etc through direct git argv plus Exec_gate cwd instead of sh -c
- add regression coverage for env rm, standalone env dumps, env/opam exec wrappers in pipelines, nested env+opam wrappers, typed wrapper inputs, outside-path args, code-shell outside-path args, direct code-git argv execution, wrapper-preserved allowed commands, and portable file-read coverage on CI OCaml
- rebase onto current main after #17214 and later main CI/interface fixes; keep only the remaining server .mli structure-ratchet fix not already on main

## Validation
- `opam exec -- ocamlformat --check` on touched .ml/.mli test files
- `git diff --check origin/main...HEAD`
- `scripts/lint-spawn-bounded.sh` - PASS
- `bash scripts/lint/shell-legacy-purge-ratchet.sh` - PASS
- `scripts/ocaml-structure-ratchet.sh` - PASS; lib_other_mli_missing is below-baseline hint
- `scripts/check-oas-pin.sh` - currently blocked locally by shared opam switch pin mismatch (`agent_sdk` pinned at 6d952cb..., repo expects 609600d...); bounded repair attempt could not acquire `/tmp/me-opam-switch.lock`
- `lockf -k -t 1 /tmp/me-dune-local.lock ... scripts/dune-local.sh build lib/masc_mcp.cmxa` - not completed locally because `/tmp/me-dune-local.lock` was already held by other worktrees