### PR TITLE
ci(lint): freeze MASC_*_TIMEOUT env knob count at 57 (RFC-0138 §7)

### DIFF
--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -68,6 +68,16 @@ jobs:
       - name: Run lint
         run: bash scripts/lint/shell-legacy-purge-ratchet.sh
 
+  timeout-env-ceiling:
+    name: Timeout env knob ceiling ratchet (RFC-0138)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install ripgrep
+        run: sudo apt-get install -y -qq ripgrep
+      - name: Run lint
+        run: bash scripts/lint/timeout-env-ceiling.sh
+
   no-actionable-signal-bool-context:
     name: No actionable signal bool context
     runs-on: ubuntu-latest

--- a/scripts/lint/timeout-env-ceiling.baseline
+++ b/scripts/lint/timeout-env-ceiling.baseline
@@ -1,0 +1,4 @@
+# Distinct MASC_*_TIMEOUT* env var names in lib/ (production).
+# Regenerated 2026-05-20T18:06:45Z.
+# RFC-0138 §7 acceptance ceiling — see scripts/lint/timeout-env-ceiling.sh.
+57

--- a/scripts/lint/timeout-env-ceiling.sh
+++ b/scripts/lint/timeout-env-ceiling.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Timeout env knob ceiling ratchet.
+#
+# RFC-0138 §7 acceptance criterion: "All 14 timeout env variables enumerated
+# in §4 marked deprecated with a sunset date". This guard freezes the current
+# `MASC_*_TIMEOUT*` distinct-name count in lib/ as a monotone-decrease ceiling.
+# New knobs cannot accumulate silently — every addition forces an explicit
+# baseline update + commit-msg `RFC-WAIVED:` marker.
+#
+# Anti-pattern §1 (telemetry-as-fix) self-check: this is *enforcement* at the
+# config-knob surface, not a counter. Reducing the knob count requires deleting
+# code paths; the ratchet only fails forward growth.
+#
+# Usage:
+#   bash scripts/lint/timeout-env-ceiling.sh
+#   bash scripts/lint/timeout-env-ceiling.sh --print
+#   bash scripts/lint/timeout-env-ceiling.sh --regenerate
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BASELINE="${ROOT}/scripts/lint/timeout-env-ceiling.baseline"
+PATTERN='MASC_[A-Z_]+_TIMEOUT[A-Z_]*'
+SCOPE=(lib)
+
+for tool in rg sort wc tr; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "[timeout-env-ceiling] required tool missing: $tool" >&2
+    exit 1
+  }
+done
+
+current_count() {
+  (
+    set +o pipefail
+    cd "$ROOT"
+    rg --no-filename --no-line-number -No "$PATTERN" "${SCOPE[@]}" 2>/dev/null \
+      | sort -u \
+      | wc -l \
+      | tr -d ' '
+  )
+}
+
+current_names() {
+  cd "$ROOT"
+  rg --no-filename --no-line-number -No "$PATTERN" "${SCOPE[@]}" 2>/dev/null \
+    | sort -u
+}
+
+baseline_count() {
+  if [ ! -f "$BASELINE" ]; then
+    echo "[timeout-env-ceiling] baseline file missing: $BASELINE" >&2
+    echo "Run --regenerate to create it." >&2
+    exit 1
+  fi
+  # Strip comments and blank lines; first non-empty token is the count.
+  awk '
+    /^[[:space:]]*#/ { next }
+    NF == 0 { next }
+    { print $1; exit }
+  ' "$BASELINE"
+}
+
+case "${1:-}" in
+  --print)
+    current_names
+    exit 0
+    ;;
+  --regenerate)
+    count="$(current_count)"
+    {
+      echo "# Distinct MASC_*_TIMEOUT* env var names in lib/ (production).
+# Regenerated $(date -u +%Y-%m-%dT%H:%M:%SZ).
+# RFC-0138 §7 acceptance ceiling — see scripts/lint/timeout-env-ceiling.sh."
+      echo "$count"
+    } > "$BASELINE"
+    echo "[timeout-env-ceiling] baseline regenerated: $count"
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "[timeout-env-ceiling] unknown arg: $1" >&2
+    echo "Usage: $0 [--print|--regenerate]" >&2
+    exit 2
+    ;;
+esac
+
+current="$(current_count)"
+baseline="$(baseline_count)"
+
+echo "[timeout-env-ceiling] distinct MASC_*_TIMEOUT names in lib/: current=$current baseline=$baseline"
+
+if [ "$current" -gt "$baseline" ]; then
+  echo
+  echo "FAIL: MASC_*_TIMEOUT distinct env var count grew from $baseline to $current"
+  echo
+  echo "RFC-0138 §7 acceptance criterion: limit timeout env knob proliferation."
+  echo "Adding a new MASC_*_TIMEOUT knob is allowed when justified by an RFC or"
+  echo "by retirement of an older knob in the same PR. To proceed:"
+  echo "  1. Run: bash scripts/lint/timeout-env-ceiling.sh --regenerate"
+  echo "  2. Commit the updated baseline."
+  echo "  3. Add 'RFC-WAIVED: <rfc-id-or-1-line-reason>' to the commit message."
+  echo
+  echo "Current distinct names (lib/ only):"
+  current_names | sed 's/^/  /'
+  exit 1
+fi
+
+echo "PASS"


### PR DESCRIPTION
## Summary

Adds a monotone-decrease **ratchet** that freezes the current `MASC_*_TIMEOUT*` distinct-env-var count in `lib/` (production) at **57**. New timeout knobs cannot accumulate silently — every addition forces an explicit baseline update plus a commit-message `RFC-WAIVED:` marker.

## Motivation

- **RFC-0138 §7 acceptance criterion** (unsatisfied): *"All 14 timeout env variables enumerated in §4 marked deprecated with a sunset date"*.
- `memory/masc-mcp-dashboard-slow-endpoint-analysis-2026-05-19` audit identified "Action 15 — CI lint guard absent" as a P1 root-cause for `Cap/Cooldown` signature 1 recurrence (`software-development.md` §Workaround Rejection Bar). RFC-0138 retired 4 `MASC_NAMESPACE_TRUTH_*_TIMEOUT_S` knobs via PR #16752 / #16761, but no structural guard prevented re-growth.
- Current baseline (lib/ production only): **57 distinct env var names**, top 3:
  - `MASC_KEEPER_TURN_TIMEOUT_SEC` (20 refs)
  - `MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT` (14 refs)
  - `MASC_TOOL_TIMEOUT_DEFAULT_SEC` (13 refs)

## Anti-pattern self-check (`software-development.md` §Workaround Rejection Bar)

| 시그니처 | 회피 여부 | 이유 |
|---|---|---|
| §1 텔레메트리-as-fix | YES | This is *enforcement* at the config-knob surface (count gate at CI), not a runtime counter. No drop counter or visibility WARN added. |
| §2 String 분류기 | YES | The regex `MASC_[A-Z_]+_TIMEOUT[A-Z_]*` is the *language of env var names*, not a domain classifier — it matches the structural pattern of the surface we want to limit. |
| §3 N-of-M | YES | Single ceiling for *all* distinct env names; reducing the count requires deleting code paths, growing the count requires explicit baseline update + `RFC-WAIVED:`. |
| Cap/cooldown/dedup | YES | This is the *prevention* of cap-style workaround accumulation (Sig 1's recurrence cure). No new cap/cooldown introduced. |

## Files

- `scripts/lint/timeout-env-ceiling.sh` (new, 100 lines) — script with `--print` / `--regenerate` modes, baseline-comparison ratchet.
- `scripts/lint/timeout-env-ceiling.baseline` (new) — `57` (auto-generated via `--regenerate`).
- `.github/workflows/fundamental-check.yml` — new `timeout-env-ceiling` step alongside other ratchets (pattern matches `shell-legacy-purge-ratchet`).

## Review evidence

- `bash scripts/lint/timeout-env-ceiling.sh` locally: `PASS` (current=57 == baseline=57).
- `bash scripts/lint/timeout-env-ceiling.sh --print | wc -l` = `57` (matches baseline).
- `bash scripts/lint/timeout-env-ceiling.sh --regenerate` produces identical baseline on idempotent re-run.
- CI step follows the existing pattern at lines 61-69 (`shell-legacy-purge-ratchet`).

## How to lower the ceiling (future PRs)

When retiring a knob:
1. Delete the env read site(s) in `lib/`.
2. Run `bash scripts/lint/timeout-env-ceiling.sh --regenerate` to update baseline downward.
3. Commit both — no `RFC-WAIVED:` needed for *reductions*.

## How to legitimately raise the ceiling

When a new knob is required by an RFC:
1. Add the env read site.
2. Run `--regenerate` and commit the new baseline.
3. Add `RFC-WAIVED: RFC-NNNN <one-line reason>` to the commit message.

## Linked

- RFC-0138 §7 acceptance criterion (unsatisfied prior to this PR).
- `memory/masc-mcp-dashboard-slow-endpoint-analysis-2026-05-19` Action 15.
- Predecessors closing other Cap/Cooldown recurrence: `feat(ci): silent-failure ratchet` #16748, `ci(shell): ratchet legacy shell purge debt` #17010.
