### PR TITLE
chore(keeper): reject host network mode alias

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -400,8 +400,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
             | None ->
                 Error
                   (Printf.sprintf
-                     "invalid network_mode '%s' (allowed: none, inherit; \
-                     deprecated alias: host)"
+                     "invalid network_mode '%s' (allowed: none, inherit)"
                      raw))
         | None -> Ok ())
   in

--- a/lib/keeper/keeper_types_profile_sandbox.ml
+++ b/lib/keeper/keeper_types_profile_sandbox.ml
@@ -96,11 +96,6 @@ let network_mode_of_string raw =
   match String.trim (String.lowercase_ascii raw) with
   | "none" -> Some Network_none
   | "inherit" -> Some Network_inherit
-  | "host" ->
-    Log.Keeper.warn
-      "network_mode=\"host\" is a deprecated alias for \"inherit\"; \
-       update TOML to use \"inherit\"";
-    Some Network_inherit
   | _ -> None
 ;;
 

--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -53,8 +53,8 @@ let test_named_keeper_docker_defaults () =
           defaults.persona_name;
         check (option string) (name ^ " sandbox_profile") (Some "docker")
           (Option.map KTP.sandbox_profile_to_string defaults.sandbox_profile);
-        (* After the host→inherit alias migration, all three docker keepers
-           request [Network_inherit] so keeper_bash can dispatch git/gh. *)
+        (* Docker keepers request [Network_inherit] so keeper_bash can dispatch
+           git/gh. *)
         check (option string) (name ^ " network_mode") (Some "inherit")
           (Option.map KTP.network_mode_to_string defaults.network_mode);
         check (option string) (name ^ " github_identity")
@@ -941,26 +941,15 @@ let test_network_mode_rejects_unknown () =
   | Ok _ -> fail "network_mode=bogus should be rejected"
   | Error e ->
       let lowered = String.lowercase_ascii e in
-      let contains needle =
-        let nl = String.length needle in
-        let hl = String.length lowered in
-        let found = ref false in
-        if nl <= hl then
-          for i = 0 to hl - nl do
-            if String.sub lowered i nl = needle then found := true
-          done;
-        !found
-      in
       check bool "error mentions invalid network_mode" true
-        (contains "invalid network_mode");
-      check bool "error mentions deprecated alias" true
-        (contains "host")
+        (contains ~needle:"invalid network_mode" lowered);
+      check bool "error lists canonical values" true
+        (contains ~needle:"allowed: none, inherit" lowered)
 
-(** Accept [network_mode = "host"] as a deprecated alias for "inherit".
-    Ensures operators migrating from docker-run terminology are not
-    silently dropped to persona defaults.  The loader emits a warning and
-    the parsed value equals [Network_inherit]. *)
-let test_network_mode_accepts_host_alias () =
+(** Reject [network_mode = "host"] instead of treating it as an alias.
+    The closed network_mode enum is [none | inherit]; Docker's "--network host"
+    is an execution detail derived downstream from [Network_inherit]. *)
+let test_network_mode_rejects_host_alias () =
   let result =
     with_temp_toml
       "[keeper]\nname = \"hosttest\"\nsandbox_profile = \"docker\"\n\
@@ -968,10 +957,17 @@ let test_network_mode_accepts_host_alias () =
       KTP.load_keeper_toml
   in
   match result with
-  | Error e -> fail (Printf.sprintf "host alias should be accepted: %s" e)
-  | Ok (_loaded_name, defaults) ->
-      check (option string) "host alias maps to inherit" (Some "inherit")
-        (Option.map KTP.network_mode_to_string defaults.network_mode)
+  | Ok _ -> fail "network_mode=host should be rejected"
+  | Error e ->
+      let lowered = String.lowercase_ascii e in
+      check bool "error mentions invalid network_mode" true
+        (contains ~needle:"invalid network_mode" lowered);
+      check bool "error mentions raw host value" true
+        (contains ~needle:"'host'" lowered);
+      check bool "error lists canonical values" true
+        (contains ~needle:"allowed: none, inherit" lowered);
+      check bool "error does not mention deprecated alias" false
+        (contains ~needle:"deprecated alias" lowered)
 
 (** Regression: classify_toml_failure_reason must bucket raw error strings
     into a small cardinality set so the Prometheus label set stays bounded. *)
@@ -1079,8 +1075,8 @@ let () =
         [
           test_case "rejects unknown network_mode" `Quick
             test_network_mode_rejects_unknown;
-          test_case "accepts host as deprecated alias for inherit" `Quick
-            test_network_mode_accepts_host_alias;
+          test_case "rejects host network_mode alias" `Quick
+            test_network_mode_rejects_host_alias;
           test_case "classifies failures into bounded label set" `Quick
             test_classify_toml_failure_reason_buckets;
           test_case "surfaces typed config parse errors" `Quick


### PR DESCRIPTION
## Summary
- remove the TOML/parser compatibility path that mapped network_mode="host" to Network_inherit
- make invalid network_mode errors list only canonical values: none, inherit
- replace the old host-alias acceptance test with a rejection regression test

## Verification
- ocamlformat --check lib/keeper/keeper_types_profile_sandbox.ml lib/keeper/keeper_types_profile.ml test/test_keeper_toml_config_validation.ml
- git diff --check
- rg -n 'deprecated alias: host|deprecated alias for "inherit"|host alias maps to inherit|test_network_mode_accepts_host_alias|accepts host as deprecated alias|error mentions deprecated alias|host→inherit' lib test docs scripts bin config
- rg -n 'network_mode="host"|network_mode = "host"' lib docs scripts bin config
- blocked: lockf -k -t 10 /tmp/me-dune-local.lock /usr/bin/env MASC_DUNE_LOCK_HELD=1 MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=5 scripts/dune-local.sh build test/test_keeper_toml_config_validation.exe (lock held by PID 579, report-closeout-verify-20260521 focused build, checked 2026-05-21 03:11:14 KST)