### PR TITLE
feat(keeper): add WIP admission cap policy

### DIFF
--- a/lib/keeper/keeper_wip_admission.ml
+++ b/lib/keeper/keeper_wip_admission.ml
@@ -1,0 +1,178 @@
+(** Pure WIP admission policy for keeper-owned implementation work. *)
+
+type category =
+  | Feature
+  | Fix
+  | Refactor
+  | Docs
+  | Chore
+  | Ci
+  | Test
+  | Other of string
+
+let normalize value =
+  value |> String.trim |> String.lowercase_ascii
+
+let category_to_string = function
+  | Feature -> "feature"
+  | Fix -> "fix"
+  | Refactor -> "refactor"
+  | Docs -> "docs"
+  | Chore -> "chore"
+  | Ci -> "ci"
+  | Test -> "test"
+  | Other value -> normalize value
+
+let category_of_string value =
+  match normalize value with
+  | "feature" | "feat" -> Feature
+  | "fix" -> Fix
+  | "refactor" -> Refactor
+  | "docs" | "doc" -> Docs
+  | "chore" -> Chore
+  | "ci" -> Ci
+  | "test" | "tests" -> Test
+  | "" -> Other "other"
+  | value -> Other value
+
+type scope = {
+  repo : string;
+  goal_id : string option;
+  category : category;
+}
+
+type caps = {
+  max_global : int option;
+  max_per_repo : int option;
+  max_per_goal : int option;
+  max_per_category : int option;
+}
+
+let default_caps =
+  { max_global = Some 16
+  ; max_per_repo = Some 6
+  ; max_per_goal = Some 3
+  ; max_per_category = Some 4
+  }
+
+type active_item = {
+  id : string;
+  scope : scope;
+}
+
+type reject_reason =
+  | Global_cap
+  | Repo_cap
+  | Goal_cap
+  | Category_cap
+
+let reject_reason_to_string = function
+  | Global_cap -> "global_cap"
+  | Repo_cap -> "repo_cap"
+  | Goal_cap -> "goal_cap"
+  | Category_cap -> "category_cap"
+
+type rejection = {
+  reason : reject_reason;
+  current : int;
+  limit : int;
+  scope_key : string;
+}
+
+type decision =
+  | Admit of { active_count_after_admit : int }
+  | Reject of rejection
+
+let same_string a b =
+  String.equal (normalize a) (normalize b)
+
+let same_goal a b =
+  match a, b with
+  | Some a, Some b -> same_string a b
+  | None, None -> true
+  | _ -> false
+
+let same_category a b =
+  String.equal (category_to_string a) (category_to_string b)
+
+let count_matching predicate active =
+  active |> List.filter predicate |> List.length
+
+let global_key = "global"
+
+let repo_key repo =
+  Printf.sprintf "repo:%s" (normalize repo)
+
+let goal_key = function
+  | Some goal_id -> Printf.sprintf "goal:%s" (normalize goal_id)
+  | None -> "goal:<none>"
+
+let category_key category =
+  Printf.sprintf "category:%s" (category_to_string category)
+
+let active_counts ~scope active =
+  [ global_key, List.length active
+  ; ( repo_key scope.repo,
+      count_matching (fun item -> same_string item.scope.repo scope.repo) active )
+  ; ( goal_key scope.goal_id,
+      count_matching
+        (fun item -> same_goal item.scope.goal_id scope.goal_id)
+        active )
+  ; ( category_key scope.category,
+      count_matching
+        (fun item -> same_category item.scope.category scope.category)
+        active )
+  ]
+
+let reject_if_at_cap reason scope_key current = function
+  | Some limit when limit >= 0 && current >= limit ->
+    Some (Reject { reason; current; limit; scope_key })
+  | _ -> None
+
+let first_rejection checks =
+  List.find_map Fun.id checks
+
+let decide ?(caps = default_caps) active ~scope =
+  let global_count = List.length active in
+  let repo_count =
+    count_matching (fun item -> same_string item.scope.repo scope.repo) active
+  in
+  let goal_count =
+    count_matching
+      (fun item -> same_goal item.scope.goal_id scope.goal_id)
+      active
+  in
+  let category_count =
+    count_matching
+      (fun item -> same_category item.scope.category scope.category)
+      active
+  in
+  match
+    first_rejection
+      [ reject_if_at_cap Global_cap global_key global_count caps.max_global
+      ; reject_if_at_cap Repo_cap (repo_key scope.repo) repo_count caps.max_per_repo
+      ; reject_if_at_cap Goal_cap (goal_key scope.goal_id) goal_count
+          caps.max_per_goal
+      ; reject_if_at_cap Category_cap
+          (category_key scope.category)
+          category_count
+          caps.max_per_category
+      ]
+  with
+  | Some rejection -> rejection
+  | None -> Admit { active_count_after_admit = global_count + 1 }
+
+let decision_to_json = function
+  | Admit { active_count_after_admit } ->
+    `Assoc
+      [ ("admitted", `Bool true)
+      ; ("active_count_after_admit", `Int active_count_after_admit)
+      ]
+  | Reject { reason; current; limit; scope_key } ->
+    `Assoc
+      [ ("admitted", `Bool false)
+      ; ("reason", `String (reject_reason_to_string reason))
+      ; ("current", `Int current)
+      ; ("limit", `Int limit)
+      ; ("scope_key", `String scope_key)
+      ]

--- a/lib/keeper/keeper_wip_admission.mli
+++ b/lib/keeper/keeper_wip_admission.mli
@@ -1,0 +1,64 @@
+(** Pure WIP admission policy for keeper-owned implementation work. *)
+
+type category =
+  | Feature
+  | Fix
+  | Refactor
+  | Docs
+  | Chore
+  | Ci
+  | Test
+  | Other of string
+
+val category_to_string : category -> string
+val category_of_string : string -> category
+
+type scope = {
+  repo : string;
+  goal_id : string option;
+  category : category;
+}
+
+type caps = {
+  max_global : int option;
+  max_per_repo : int option;
+  max_per_goal : int option;
+  max_per_category : int option;
+}
+
+val default_caps : caps
+
+type active_item = {
+  id : string;
+  scope : scope;
+}
+
+type reject_reason =
+  | Global_cap
+  | Repo_cap
+  | Goal_cap
+  | Category_cap
+
+val reject_reason_to_string : reject_reason -> string
+
+type rejection = {
+  reason : reject_reason;
+  current : int;
+  limit : int;
+  scope_key : string;
+}
+
+type decision =
+  | Admit of { active_count_after_admit : int }
+  | Reject of rejection
+
+val active_counts :
+  scope:scope -> active_item list -> (string * int) list
+
+val decide :
+  ?caps:caps ->
+  active_item list ->
+  scope:scope ->
+  decision
+
+val decision_to_json : decision -> Yojson.Safe.t

--- a/test/dune
+++ b/test/dune
@@ -914,6 +914,7 @@
   test_keeper_safety_gates
   test_keeper_guards
   test_keeper_working_state
+  test_keeper_wip_admission
   test_eval_gate_evasion
   test_prompt_registry_defaults
   test_keeper_prompt_external

--- a/test/test_keeper_wip_admission.ml
+++ b/test/test_keeper_wip_admission.ml
@@ -1,0 +1,104 @@
+open Alcotest
+
+module Admission = Masc_mcp.Keeper_wip_admission
+
+let scope ?goal_id ?(category = Admission.Fix) repo =
+  { Admission.repo; goal_id; category }
+
+let item ?goal_id ?(category = Admission.Fix) repo id =
+  { Admission.id; scope = scope ?goal_id ~category repo }
+
+let caps =
+  { Admission.max_global = Some 10
+  ; max_per_repo = Some 2
+  ; max_per_goal = Some 1
+  ; max_per_category = Some 3
+  }
+
+let test_admits_below_caps () =
+  let active = [ item ~goal_id:"goal-a" "repo-a" "one" ] in
+  match Admission.decide ~caps active ~scope:(scope ~goal_id:"goal-b" "repo-a") with
+  | Admission.Admit { active_count_after_admit } ->
+    check int "active after admit" 2 active_count_after_admit
+  | Reject rejection ->
+    fail
+      (Printf.sprintf "unexpected reject: %s"
+         (Admission.reject_reason_to_string rejection.reason))
+
+let test_rejects_repo_cap_before_goal_cap () =
+  let active =
+    [ item ~goal_id:"goal-a" "repo-a" "one"
+    ; item ~goal_id:"goal-b" "repo-a" "two"
+    ]
+  in
+  match Admission.decide ~caps active ~scope:(scope ~goal_id:"goal-c" "repo-a") with
+  | Admission.Admit _ -> fail "expected repo cap rejection"
+  | Reject rejection ->
+    check string "reason" "repo_cap"
+      (Admission.reject_reason_to_string rejection.reason);
+    check int "current" 2 rejection.current;
+    check int "limit" 2 rejection.limit;
+    check string "scope key" "repo:repo-a" rejection.scope_key
+
+let test_rejects_goal_cap () =
+  let active = [ item ~goal_id:"goal-a" "repo-a" "one" ] in
+  match Admission.decide ~caps active ~scope:(scope ~goal_id:"goal-a" "repo-b") with
+  | Admission.Admit _ -> fail "expected goal cap rejection"
+  | Reject rejection ->
+    check string "reason" "goal_cap"
+      (Admission.reject_reason_to_string rejection.reason);
+    check string "scope key" "goal:goal-a" rejection.scope_key
+
+let test_rejects_category_cap_across_repos () =
+  let active =
+    [ item ~category:Admission.Refactor "repo-a" "one"
+    ; item ~category:Admission.Refactor "repo-b" "two"
+    ; item ~category:Admission.Refactor "repo-c" "three"
+    ]
+  in
+  match Admission.decide ~caps active ~scope:(scope ~category:Admission.Refactor "repo-d") with
+  | Admission.Admit _ -> fail "expected category cap rejection"
+  | Reject rejection ->
+    check string "reason" "category_cap"
+      (Admission.reject_reason_to_string rejection.reason);
+    check string "scope key" "category:refactor" rejection.scope_key
+
+let test_active_counts_surface_all_axes () =
+  let active =
+    [ item ~goal_id:"goal-a" ~category:Admission.Fix "repo-a" "one"
+    ; item ~goal_id:"goal-b" ~category:Admission.Docs "repo-a" "two"
+    ; item ~goal_id:"goal-a" ~category:Admission.Fix "repo-b" "three"
+    ]
+  in
+  let counts = Admission.active_counts ~scope:(scope ~goal_id:"goal-a" "repo-a") active in
+  check (list (pair string int)) "counts"
+    [ "global", 3; "repo:repo-a", 2; "goal:goal-a", 2; "category:fix", 2 ]
+    counts
+
+let test_decision_json_rejects_with_scope_key () =
+  let decision =
+    Admission.decide
+      ~caps:{ caps with max_global = Some 0 }
+      [] ~scope:(scope "repo-a")
+  in
+  let json = Admission.decision_to_json decision in
+  check string "reason" "global_cap"
+    Yojson.Safe.Util.(json |> member "reason" |> to_string);
+  check string "scope key" "global"
+    Yojson.Safe.Util.(json |> member "scope_key" |> to_string)
+
+let () =
+  run "Keeper_wip_admission"
+    [ ( "caps"
+      , [ test_case "admits below caps" `Quick test_admits_below_caps
+        ; test_case "rejects repo cap before goal cap" `Quick
+            test_rejects_repo_cap_before_goal_cap
+        ; test_case "rejects goal cap" `Quick test_rejects_goal_cap
+        ; test_case "rejects category cap across repos" `Quick
+            test_rejects_category_cap_across_repos
+        ; test_case "active counts surface all axes" `Quick
+            test_active_counts_surface_all_axes
+        ; test_case "decision JSON rejects with scope key" `Quick
+            test_decision_json_rejects_with_scope_key
+        ] )
+    ]


### PR DESCRIPTION
## Summary
- add pure Keeper_wip_admission policy for global/repo/goal/category WIP caps
- expose typed rejection reasons and scope keys for dashboard/runtime wiring
- cover admit/reject ordering, per-axis counts, and decision JSON in tests

## Validation
- ocamlformat --check lib/keeper/keeper_wip_admission.ml lib/keeper/keeper_wip_admission.mli test/test_keeper_wip_admission.ml
- ocamlfind ocamlc -w +a -package yojson -c -I /private/tmp -o /private/tmp/keeper_wip_admission.cmi lib/keeper/keeper_wip_admission.mli
- ocamlfind ocamlc -w +a -package yojson -c -I /private/tmp -intf-suffix .mli -o /private/tmp/keeper_wip_admission.cmo lib/keeper/keeper_wip_admission.ml
- ocamlc -stop-after parsing test/test_keeper_wip_admission.ml
- git diff --check origin/main...HEAD

## Not run
- scripts/dune-local.sh build test/test_keeper_wip_admission.exe: refused because other sessions are running bare dune build outside scripts/dune-local.sh