### PR TITLE
docs(mcp): mark compat aliases as removal targets

### DIFF
--- a/docs/MCP-SURFACE-AUDIT.md
+++ b/docs/MCP-SURFACE-AUDIT.md
@@ -50,9 +50,9 @@ The key split is intentional:
 
 | Group | Public Discovery Path | Canonical Examples | Notes |
 |------|------------------------|--------------------|-------|
-| Canonical MCP tools | `tools/list` | `masc_start`, `masc_transition`, `masc_keeper_status`, `decision.create`, `experiment.start`, `trpg.dice.roll` | Default surface for normal clients |
+| Canonical MCP tools | `tools/list` | `masc_start`, `masc_transition`, `masc_keeper_status`, `masc_board_post`, `masc_web_search` | Default surface for normal clients |
 | Managed agent MCP | `/mcp/managed` | `masc_status`, `masc_tasks`, `masc_claim_next`, `masc_transition` | Internal managed-agent surface with canonical task-control tools plus curated passthrough tools; hidden call-only aliases are not supported |
-| Compatibility aliases | Deprecated and excluded from default `tools/list` | `masc_claim`, `experiment_start`, `masc_trpg_dice_roll` | Still callable for compatibility; not part of the truthful default inventory |
+| Removed alias ghosts | Not discoverable; not supported | `masc_claim`, `experiment_start`, `masc_trpg_*` | Do not preserve or reintroduce; use canonical task-control tools and current public schemas |
 | MCP prompts | `prompts/list`, `prompts/get` | `tool_help` | Explanation/help layer, not runtime prompt registry |
 | MCP resources | `resources/list/read` | `masc://status`, `masc://tasks`, `masc://tool-help-index` | Snapshot/read layer |
 | Internal prompt/runtime plane | Not MCP-discoverable | `Prompt_registry`, `data/prompts/*.json`, `config/prompts/*.md` | Used by chains, keepers, dashboard judges, and runtime execution |
@@ -75,16 +75,15 @@ flowchart TD
   MCP --> RL[resources/list read templates]
 
   TL --> Canon[Canonical tool surface]
-  TL --> Hidden[Hidden aliases not listed]
+  TL --> Hidden[Hidden/admin tools not listed]
 
   Canon --> Core[Namespace task keeper runtime]
-  Canon --> GameView[decision.* experiment.* trpg.* client.*]
   Canon --> Ecosystem[keeper always-on autonomy]
 
-  PL --> PromptSurface[MCP prompt surface: 3 prompts]
+  PL --> PromptSurface[MCP prompt surface]
   RL --> ResourceSurface[MCP resources and tool-help views]
 
-  Hidden -. direct call only .-> Compat[Compatibility aliases]
+  Hidden -. admin or internal direct call only .-> Internal[Internal surfaces]
   PromptSurface -. separate from .-> InternalPrompts[Prompt_registry data/prompts]
 ```
 
@@ -114,15 +113,12 @@ flowchart LR
   KeeperMsg --> KeeperStatus[masc_keeper_status]
 ```
 
-### 3. Game View and Legacy Alias Lane
+### 3. Removed Game View Alias Lane
 
-```mermaid
-flowchart LR
-  Canonical[decision.* experiment.* trpg.* client.*] --> PGV[tool_protocol_game_view]
-  Legacy[experiment_start masc_trpg_*] --> Alias[legacy_alias_to_canonical]
-  Alias --> PGV
-  PGV --> Runtime[experiment and TRPG handlers]
-```
+`decision.*`, `experiment.*`, `trpg.*`, `experiment_start`, and `masc_trpg_*`
+are not current MCP front-door tools. They should remain historical protocol
+notes only unless a future product decision reintroduces them through the normal
+tool schema/catalog path.
 
 ## Architecture Layers
 
@@ -132,8 +128,7 @@ flowchart TD
   Coordination --> Keeper[OAS-backed keeper runtime]
   Coordination --> Orchestration[Native chain plane]
 
-  Secondary1[Game-view dotted tools] -. canonical public alias layer .-> Coordination
-  Secondary2[Retired compatibility lanes] -. not supported front door .-> Orchestration
+  Secondary[Retired compatibility lanes] -. not supported front door .-> Orchestration
 ```
 
 ## Findings
@@ -142,12 +137,12 @@ flowchart TD
 
 - MCP server capabilities are exposed correctly for `tools`, `resources`, and `prompts`.
 - `tools/list`, `prompts/list/get`, `resources/list/read/templates/list`, pagination, and resource subscriptions are covered by passing local tests.
-- The dotted canonical names for `decision.*`, `experiment.*`, and `trpg.*` are real public tools, not just documentation fiction.
 - The public default surface remains coherent after retiring command-plane/team-session front-door exposure.
 
 ### What was confusing
 
 - Historical docs still mention team-session/command-plane as if they were canonical.
+- Historical game-view docs may still mention `decision.*`, `experiment.*`, `trpg.*`, `experiment_start`, and `masc_trpg_*`; these are not current public MCP tools.
 - `Prompt_registry` and `Mcp_prompt_surface` describe two different prompt systems; without an explicit note, they look like one broken or incomplete system.
 - `docs/spec/SPEC-INDEX.md` still contains historical descriptions that should not be treated as the current front door.
 - `Config.raw_all_tool_schemas` and `Tools.all_schemas_extended` are two different assembly lists; the former includes Config-dependent modules (Board, Compact, Agent_timeline) that the latter deliberately omits to avoid a cycle.
@@ -161,7 +156,7 @@ flowchart TD
 
 | Type | Examples | Status |
 |------|----------|--------|
-| Intentional compatibility | `masc_claim`, `experiment_start`, `masc_trpg_*` | Deprecated/default-off aliases; keep if compatibility matters |
+| Removed alias ghosts | `masc_claim`, `experiment_start`, `masc_trpg_*` | Deletion target; do not preserve for compatibility |
 | Retired front-door | `masc_collaboration_graph` | Removed from `raw_all_tool_schemas` in `config.ml` but still cited in spec docs |
 | Intentional internal-only | `Prompt_registry`, `data/prompts/*.json`, `config/prompts/*.md` | Real runtime feature, not public MCP surface |
 | Experimental but documented | `SWARM-RISC`, `GAME-VIEW-PROTOCOL` draft | Keep clearly labeled as non-canonical or draft |
@@ -187,7 +182,6 @@ flowchart TD
 - The repo already has a real operating spine:
   - `Namespace / task hygiene`
   - `Keeper runtime on OAS`
-  - optional dotted game-view aliases
 - The biggest remaining risk is documentation drift, not core protocol shape.
 
 ## SSOT Rewrite Order

--- a/lib/trajectory/trajectory.ml
+++ b/lib/trajectory/trajectory.ml
@@ -64,7 +64,8 @@ type trajectory = {
   outcome : trajectory_outcome;
   task_id : string option;
   (** Claimed task ID for cost attribution.
-      Set when keeper claims a task via masc_claim; None if no task claimed.
+      Set when keeper claims a task via masc_claim_next or masc_transition;
+      None if no task claimed.
       Enables per-task cost aggregation from trajectory summaries. *)
 }
 

--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -31,8 +31,8 @@ lib/process/process_eio.ml:535
 # manager itself. Bounded by session scope, not by per-call timeout.
 lib/server/lsp_process_manager.ml:178
 
-# lib/worker_dev_tools.ml:703 — dev-tools worker spawn. Wrapped by
+# lib/worker_dev_tools.ml:706 — dev-tools worker spawn. Wrapped by
 # Tool_resource_gate, Fd_accountant, Eio.Time.with_timeout_exn, and a fresh
 # Eio.Switch.run at the call boundary. Line renumbered by worker-dev-tools
 # split/refactor waves.
-lib/worker_dev_tools.ml:703
+lib/worker_dev_tools.ml:706

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -602,7 +602,7 @@ let test_handle_request_tools_list () =
     false
     (List.mem "masc_board_search" names);
   Alcotest.(check bool)
-    "legacy experiment_start hidden from list"
+    "removed experiment_start absent from list"
     false
     (List.mem "experiment_start" names);
   Alcotest.(check bool)
@@ -1292,137 +1292,7 @@ let test_handle_request_tools_list_include_usage_metadata () =
        (match first_tool with `Assoc fields -> fields | _ -> []));
   cleanup_dir base_path
 
-let _test_execute_tool_trpg_flow () =
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  Mcp_eio.set_net (Eio.Stdenv.net env);
-  Mcp_eio.set_clock (Eio.Stdenv.clock env);
-  let clock = Eio.Stdenv.clock env in
-  Eio.Switch.run @@ fun sw ->
-
-  let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  let roll_result =
-    Mcp_eio.execute_tool_eio ~sw ~clock state
-      ~name:"masc_trpg_dice_roll"
-      ~arguments:
-        (`Assoc
-          [
-            ("room_id", `String "room-mcp-e2e");
-            ("actor_id", `String "pc-1");
-            ("action", `String "perception");
-            ("stat_value", `Int 12);
-            ("dc", `Int 10);
-            ("raw_d20", `Int 15);
-          ])
-  in
-  Alcotest.(check bool) "dice_roll success" true roll_result.Tool_result.success;
-
-  let turn_result =
-    Mcp_eio.execute_tool_eio ~sw ~clock state
-      ~name:"masc_trpg_turn_advance"
-      ~arguments:
-        (`Assoc
-          [
-            ("room_id", `String "room-mcp-e2e");
-            ("phase", `String "round");
-          ])
-  in
-  Alcotest.(check bool) "turn_advance success" true turn_result.Tool_result.success;
-
-  let stream_result =
-    Mcp_eio.execute_tool_eio ~sw ~clock state
-      ~name:"masc_trpg_stream"
-      ~arguments:(`Assoc [ ("room_id", `String "room-mcp-e2e") ])
-  in
-  Alcotest.(check bool) "stream success" true stream_result.Tool_result.success;
-  let stream_json = Yojson.Safe.from_string (Tool_result.message stream_result) in
-  let count = stream_json |> Yojson.Safe.Util.member "count" |> Yojson.Safe.Util.to_int in
-  Alcotest.(check bool) "stream has events" true (count >= 2);
-
-  let stream_dice_result =
-    Mcp_eio.execute_tool_eio ~sw ~clock state
-      ~name:"masc_trpg_stream"
-      ~arguments:
-        (`Assoc
-          [
-            ("room_id", `String "room-mcp-e2e");
-            ("event_type", `String "dice.rolled");
-          ])
-  in
-  Alcotest.(check bool) "stream event_type filter success" true stream_dice_result.Tool_result.success;
-  let stream_dice_json = Yojson.Safe.from_string (Tool_result.message stream_dice_result) in
-  let dice_count =
-    stream_dice_json |> Yojson.Safe.Util.member "count" |> Yojson.Safe.Util.to_int
-  in
-  Alcotest.(check int) "dice-only event count" 1 dice_count;
-
-  let roll_json = Yojson.Safe.from_string (Tool_result.message roll_result) in
-  let passed = roll_json |> Yojson.Safe.Util.member "roll" |> Yojson.Safe.Util.member "passed" |> Yojson.Safe.Util.to_bool in
-  Alcotest.(check bool) "roll passed" true passed;
-
-  cleanup_dir base_path
-
 (* Governance status tool is no longer dispatched *)
-
-let _test_execute_tool_trpg_validation () =
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  Mcp_eio.set_net (Eio.Stdenv.net env);
-  Mcp_eio.set_clock (Eio.Stdenv.clock env);
-  let clock = Eio.Stdenv.clock env in
-  Eio.Switch.run @@ fun sw ->
-
-  let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  let missing_result =
-    Mcp_eio.execute_tool_eio ~sw ~clock state
-      ~name:"masc_trpg_turn_advance"
-      ~arguments:(`Assoc [])
-  in
-  Alcotest.(check bool) "missing room_id fails" false missing_result.Tool_result.success;
-  Alcotest.(check bool)
-    "missing room_id message"
-    true
-    (contains_substring (Tool_result.message missing_result) "room_id is required");
-
-  let out_of_range_result =
-    Mcp_eio.execute_tool_eio ~sw ~clock state
-      ~name:"masc_trpg_dice_roll"
-      ~arguments:
-        (`Assoc
-          [
-            ("room_id", `String "room-mcp-e2e");
-            ("actor_id", `String "pc-1");
-            ("action", `String "perception");
-            ("stat_value", `Int 12);
-            ("dc", `Int 10);
-            ("raw_d20", `Int 21);
-          ])
-  in
-  Alcotest.(check bool) "raw_d20 out-of-range fails" false out_of_range_result.Tool_result.success;
-  Alcotest.(check bool)
-    "raw_d20 out-of-range message"
-    true
-    (contains_substring (Tool_result.message out_of_range_result) "raw_d20 must be between 1 and 20");
-
-  let bad_event_type_result =
-    Mcp_eio.execute_tool_eio ~sw ~clock state
-      ~name:"masc_trpg_stream"
-      ~arguments:
-        (`Assoc
-          [
-            ("room_id", `String "room-mcp-e2e");
-            ("event_type", `String "totally.invalid");
-          ])
-  in
-  Alcotest.(check bool) "invalid event_type fails" false bad_event_type_result.Tool_result.success;
-  Alcotest.(check bool)
-    "invalid event_type message"
-    true
-    (contains_substring (Tool_result.message bad_event_type_result) "invalid event_type");
-
-  cleanup_dir base_path
 
 let test_execute_tool_explicit_agent_name_not_overridden () =
   let base_path = temp_dir () in
@@ -1842,40 +1712,6 @@ let test_execute_tool_without_mcp_session_uses_generated_identity () =
   cleanup_dir base_path
 
 (* Legacy governance convo tools are stubs; room-scoped test removed *)
-
-let _test_handle_request_tools_call_trpg () =
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  let clock = Eio.Stdenv.clock env in
-  Eio.Switch.run @@ fun sw ->
-
-  let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-
-  let request = Yojson.Safe.to_string (`Assoc [
-    ("jsonrpc", `String "2.0");
-    ("id", `Int 9);
-    ("method", `String "tools/call");
-    ("params", `Assoc [
-      ("name", `String "trpg.dice.roll");
-      ("arguments", `Assoc [
-        ("room_id", `String "room-mcp-call");
-        ("actor_id", `String "pc-1");
-        ("action", `String "perception");
-        ("stat_value", `Int 9);
-        ("dc", `Int 8);
-        ("raw_d20", `Int 12);
-      ]);
-    ]);
-  ]) in
-
-  let response = Mcp_eio.handle_request ~clock ~sw state request in
-  (match response with
-  | `Assoc fields ->
-      Alcotest.(check bool) "has result" true (List.mem_assoc "result" fields)
-  | _ -> Alcotest.fail "response not an object");
-
-  cleanup_dir base_path
 
 let test_handle_request_invalid_json () =
   Eio_main.run @@ fun env ->

--- a/test/test_orchestrator_coverage.ml
+++ b/test/test_orchestrator_coverage.ml
@@ -88,9 +88,9 @@ let test_make_orchestrator_prompt_contains_tools () =
       let _ = Str.search_forward (Str.regexp "masc_status") prompt 0 in true
     with Not_found -> false)
 
-let test_make_orchestrator_prompt_contains_claim () =
+let test_make_orchestrator_prompt_contains_transition_claim_path () =
   let prompt = Orchestrator.make_orchestrator_prompt ~port:8935 in
-  check bool "mentions masc_claim" true
+  check bool "mentions masc_transition" true
     (try
       let _ = Str.search_forward (Str.regexp "masc_transition") prompt 0 in true
     with Not_found -> false)
@@ -232,7 +232,8 @@ let () =
       test_case "basic" `Quick test_make_orchestrator_prompt_basic;
       test_case "contains mcp" `Quick test_make_orchestrator_prompt_contains_mcp;
       test_case "contains tools" `Quick test_make_orchestrator_prompt_contains_tools;
-      test_case "contains claim" `Quick test_make_orchestrator_prompt_contains_claim;
+      test_case "contains transition claim path" `Quick
+        test_make_orchestrator_prompt_contains_transition_claim_path;
       test_case "contains done" `Quick test_make_orchestrator_prompt_contains_done;
       test_case "mentions broadcast" `Quick test_make_orchestrator_prompt_mentions_broadcast;
     ];

--- a/test/test_tool_registration_consistency.ml
+++ b/test/test_tool_registration_consistency.ml
@@ -20,7 +20,7 @@ let all_schema_names =
 let test_workflow_guide_tools_exist () =
   let guide_tools = [
     "masc_start"; "masc_join"; "masc_status";
-    "masc_claim"; "masc_claim_next"; "masc_transition";
+    "masc_claim_next"; "masc_transition";
     "masc_add_task"; "masc_batch_add_tasks";
     "masc_plan_set_task";
     "masc_heartbeat"; "masc_broadcast";
@@ -130,18 +130,22 @@ let repo_path relative =
   Filename.concat (repo_root ()) relative
 
 let test_docs_do_not_reintroduce_ghost_claim_surface () =
-  let allowed_claim_docs = [ "MCP-SURFACE-AUDIT.md" ] in
+  let allowed_removed_alias_docs = [ "MCP-SURFACE-AUDIT.md" ] in
   [ "MCP-SURFACE-AUDIT.md"; "QUICK-START.md" ]
   |> List.iter (fun name ->
          let contents = read_file (doc_path name) in
          if contains_substring contents "masc_task_list" then
            Alcotest.failf "doc %s reintroduces ghost tool masc_task_list" name;
          if contains_token contents "masc_claim"
-            && not (List.mem name allowed_claim_docs)
+            && not (List.mem name allowed_removed_alias_docs)
          then
            Alcotest.failf
-             "doc %s reintroduces normative masc_claim usage outside compatibility docs"
-             name)
+             "doc %s reintroduces deprecated masc_claim alias"
+             name;
+         if contains_substring contents "keep if compatibility matters"
+            || contains_substring contents "Still callable for compatibility"
+         then
+           Alcotest.failf "doc %s preserves legacy compatibility criteria" name)
 
 let test_front_door_surfaces_do_not_reintroduce_claim_alias () =
   (* CP purge: dashboard/src/components/command/ directory deleted with the

--- a/test/test_workflow_guide.ml
+++ b/test/test_workflow_guide.ml
@@ -216,7 +216,7 @@ let check_tool_exists_in_schemas name =
 let test_next_steps_reference_real_tools () =
   let tools_to_check = [
     "masc_start"; "masc_join"; "masc_status";
-    "masc_claim"; "masc_claim_next";
+    "masc_claim_next";
     "masc_transition";
     "masc_add_task"; "masc_batch_add_tasks";
     "masc_plan_set_task";


### PR DESCRIPTION
## Summary
- replace the MCP surface audit's compatibility-preservation framing with explicit removal-target language for `masc_claim`, `experiment_start`, and `masc_trpg_*`
- remove disabled TRPG/game-view MCP tests that kept retired callable shapes alive in test code
- clean up `masc_claim` ghost references in workflow/orchestrator tests and trajectory comments

## Validation
- `ocamlformat --check lib/trajectory/trajectory.ml test/test_mcp_server_eio.ml test/test_orchestrator_coverage.ml test/test_tool_registration_consistency.ml test/test_workflow_guide.ml`
- `git diff --check`
- `bash scripts/lint/godfile-size-regression.sh`
- `bash scripts/lint/shell-legacy-purge-ratchet.sh`
- blocked: `scripts/dune-local.sh build test/test_tool_registration_consistency.exe test/test_workflow_guide.exe test/test_orchestrator_coverage.exe test/test_mcp_server_eio.exe` refused because live bare `dune build` processes are bypassing the machine-wide wrapper lock