### PR TITLE
fix(runtime): retire capacity_exhausted legacy label

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 379 unique knobs across 9 modules.
+**Total**: 383 unique knobs across 9 modules.
 
-**Typed getter classification**: 26/234 tagged (`operator`: 26, `algorithm`: 0, `unclassified`: 208).
+**Typed getter classification**: 26/235 tagged (`operator`: 26, `algorithm`: 0, `unclassified`: 209).
 
 ## Env_config_core (30 knobs; typed classification 0/7)
 
@@ -99,12 +99,14 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_SPAWN_CACHE_POLICY` | typed:string | unclassified | unclassified | 52 | Spawn cache policy: - off - safe_only (GLM direct HTTP only, no MCP-tool side effects) |
 | `MASC_SSE_KEEPALIVE_SEC` | typed:float | unclassified | unclassified | 112 | SSE keepalive interval (seconds). Frequency of `: keepalive` frames on command-plane SSE streams. Clamped to >= 1.0 t... |
 
-## Env_config_keeper (86 knobs; typed classification 3/74)
+## Env_config_keeper (88 knobs; typed classification 3/75)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 226 | Alert dedup window, clamped to >= 5s. Default: 60. |
-| `MASC_CASCADE_ATTEMPT_LIVENESS` | typed:string | unclassified | unclassified | 960 |  |
+| `MASC_CASCADE_ATTEMPT_LIVENESS` | typed:string | unclassified | unclassified | 988 |  |
+| `MASC_CASCADE_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 842 | {1 Cascade Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Cascade_saturation_signal.t] emission alon... |
+| `MASC_CASCADE_TIER_ADMISSION_ENABLED` | feature_flag | n/a | n/a | 854 | {1 Cascade Tier Admission (RFC-0153 Phase B.2)} Runtime kill switch for per-tier inflight admission in the main keepe... |
 | `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 691 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
 | `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 802 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
 | `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 803 | Legacy RFC-0006 Phase B-2 flag. Docker read routing now follows [sandbox_profile=docker] unconditionally. This getter... |
@@ -142,11 +144,11 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 70 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_CASCADE_PROVIDER_ALLOWLIST` | string_literal | n/a | n/a | 856 | Comma-separated provider kind allowlist for every keeper cascade call. Values are OAS [Provider_config.string_of_prov... |
+| `MASC_KEEPER_CASCADE_PROVIDER_ALLOWLIST` | string_literal | n/a | n/a | 884 | Comma-separated provider kind allowlist for every keeper cascade call. Values are OAS [Provider_config.string_of_prov... |
 | `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 531 | Stdout-idle timeout for CLI subprocess transports (Kimi CLI today; Claude Code / Gemini CLI / Codex CLI need an OAS u... |
 | `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 163 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
 | `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 182 | Enable keeper debug logging. Default: false. |
-| `MASC_KEEPER_DEGRADED_RETRY_SLOT_PHASE_BUDGET_SEC` | typed:float | Timeouts | operator | 934 | Productive slot-phase budget (seconds).  PR #13120: when a cascade returns a recoverable error after the keeper has a... |
+| `MASC_KEEPER_DEGRADED_RETRY_SLOT_PHASE_BUDGET_SEC` | typed:float | Timeouts | operator | 962 | Productive slot-phase budget (seconds).  PR #13120: when a cascade returns a recoverable error after the keeper has a... |
 | `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` | typed:float | unclassified | unclassified | 188 | Daily budget for keeper deliberation (USD). Default: 0.10. Re-readable within the process. Live operator control shou... |
 | `MASC_KEEPER_DOCKER_CONTAINER` | typed:string | unclassified | unclassified | 743 | Docker container name for keeper playground execution. Env: [MASC_KEEPER_DOCKER_CONTAINER]. Default: "keeper-playgrou... |
 | `MASC_KEEPER_DOCKER_PLAYGROUND_ROOT` | typed:string | unclassified | unclassified | 753 | Container-side root under which keeper playground bundles are mounted. Host [<base_path>/.masc/playground/<keeper>/�... |
@@ -163,7 +165,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 318 | Max idle turns for scheduled autonomous keeper turns. With tool_choice=Any and max_turns=50, keepers have room to exp... |
 | `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 325 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger — more ... |
 | `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 246 | Maximum seconds since last successful room heartbeat before presence sync is required again. Floor = keepalive interv... |
-| `MASC_KEEPER_MAX_TRANSIENT_RETRIES` | typed:int | unclassified | unclassified | 882 | Maximum outer-loop retries after the initial attempt. Total attempts = 1 initial + max_transient_retries. Env: [MASC_... |
+| `MASC_KEEPER_MAX_TRANSIENT_RETRIES` | typed:int | unclassified | unclassified | 910 | Maximum outer-loop retries after the initial attempt. Total attempts = 1 initial + max_transient_retries. Env: [MASC_... |
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 78 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 81 | Number of rotated files to keep (default: 1, i.e. .1 only) |
 | `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL` | typed:int | unclassified | unclassified | 428 | Maximum turns per single OAS Agent.run call. Keeper resumes via checkpoint in the next keepalive cycle when {!Cascade... |
@@ -179,8 +181,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 491 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
 | `MASC_KEEPER_SYMMETRIC_SANDBOX` | typed:bool | unclassified | unclassified | 790 | Legacy RFC-0006 Phase B-1 flag. Read-side containment now follows [sandbox_profile=docker] unconditionally. This gett... |
 | `MASC_KEEPER_TERMINATION_WINDOW_SEC` | typed:float | unclassified | unclassified | 621 | Sliding window for stale-termination escalation tracking. Default: 21600 (6 hours). |
-| `MASC_KEEPER_TRANSIENT_BACKOFF_BASE_SEC` | typed:float | unclassified | unclassified | 888 | Base delay (seconds) for exponential backoff. Delay at attempt [n] is [base * 2^(n-1)]. Env: [MASC_KEEPER_TRANSIENT_B... |
-| `MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC` | typed:float | unclassified | unclassified | 894 | Hard cap on backoff delay (seconds). Env: [MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC].  Default: 4.0. |
+| `MASC_KEEPER_TRANSIENT_BACKOFF_BASE_SEC` | typed:float | unclassified | unclassified | 916 | Base delay (seconds) for exponential backoff. Delay at attempt [n] is [base * 2^(n-1)]. Env: [MASC_KEEPER_TRANSIENT_B... |
+| `MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC` | typed:float | unclassified | unclassified | 922 | Hard cap on backoff delay (seconds). Env: [MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC].  Default: 4.0. |
 | `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 359 | Wall-clock timeout in seconds for a single unified turn (including all retries and cascade fallbacks). Prevents indef... |
 | `MASC_KEEPER_WATCHDOG_GRACE_SEC` | typed:float | unclassified | unclassified | 615 | Grace period after fiber start before idle-stale detection activates. Prevents false positives on server restart when... |
 | `MASC_KEEPER_WATCHDOG_NOOP_THRESHOLD` | typed:int | unclassified | unclassified | 607 | Consecutive noop turns before considering the keeper stuck in a failure loop. Must be >= 2. Default: 3. |
@@ -228,120 +230,120 @@ the categorization roadmap. Newly-added typed getters in
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_AGENT_RATE_BURST` | typed:int | unclassified | unclassified | 603 | Per-agent burst capacity. Default: 50. |
-| `MASC_AGENT_RATE_LIMIT` | typed:float | unclassified | unclassified | 600 | Per-agent requests per second. Default: 20. |
-| `MASC_AGENT_TRANSPORT` | string_literal | n/a | n/a | 316 | Agent transport type variant (e.g. "grpc", "http", "ws"). |
-| `MASC_APPROVAL_JANITOR_ENABLED` | typed:bool | unclassified | unclassified | 419 | Enable the periodic approval_janitor sweep fiber.  Default: true. Set MASC_APPROVAL_JANITOR_ENABLED=false to disable ... |
-| `MASC_APPROVAL_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 427 | Sweep interval in seconds.  Default: 60s (every minute). Operators tolerate up to a minute of "approval still pending... |
-| `MASC_BOARD_BACKEND` | string_literal | n/a | n/a | 490 | Board backend type as a typed selector (e.g. "jsonl", "pg"). |
-| `MASC_BOARD_FLUSH_INTERVAL_SEC` | typed:float | unclassified | unclassified | 486 | Flush interval for board persistence (seconds). Default: 30. |
-| `MASC_BRIEFING_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 838 | Dashboard mission briefing cache TTL (seconds). Default: 300 (5 min). |
+| `MASC_AGENT_RATE_BURST` | typed:int | unclassified | unclassified | 599 | Per-agent burst capacity. Default: 50. |
+| `MASC_AGENT_RATE_LIMIT` | typed:float | unclassified | unclassified | 596 | Per-agent requests per second. Default: 20. |
+| `MASC_AGENT_TRANSPORT` | string_literal | n/a | n/a | 312 | Agent transport type variant (e.g. "grpc", "http", "ws"). |
+| `MASC_APPROVAL_JANITOR_ENABLED` | typed:bool | unclassified | unclassified | 415 | Enable the periodic approval_janitor sweep fiber.  Default: true. Set MASC_APPROVAL_JANITOR_ENABLED=false to disable ... |
+| `MASC_APPROVAL_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 423 | Sweep interval in seconds.  Default: 60s (every minute). Operators tolerate up to a minute of "approval still pending... |
+| `MASC_BOARD_BACKEND` | string_literal | n/a | n/a | 486 | Board backend type as a typed selector (e.g. "jsonl", "pg"). |
+| `MASC_BOARD_FLUSH_INTERVAL_SEC` | typed:float | unclassified | unclassified | 482 | Flush interval for board persistence (seconds). Default: 30. |
+| `MASC_BRIEFING_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 830 | Dashboard mission briefing cache TTL (seconds). Default: 300 (5 min). |
 | `MASC_CACHE_MAX_ENTRIES` | typed:int | unclassified | unclassified | 66 | Maximum total number of cache entries (default 1000) |
 | `MASC_CACHE_MAX_ENTRY_SIZE` | typed:int | unclassified | unclassified | 62 | Maximum size of a single cache entry value in bytes (default 100KB) |
-| `MASC_CANCELLATION_CLEANUP_SEC` | typed:float | unclassified | unclassified | 850 | Cancellation token cleanup interval (seconds). Default: 300 (5 min). |
-| `MASC_CANCELLATION_TOKEN_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 188 | Token cleanup max age (seconds) |
-| `MASC_CDAL_ENABLED` | feature_flag | n/a | n/a | 342 | Enable contract-driven proof capture. Default: true. |
-| `MASC_CDAL_GATE_ENABLED` | feature_flag | n/a | n/a | 346 | Block task completion when CDAL verdict is Violated/Inconclusive. Default: false. |
-| `MASC_CDAL_VERDICT_LOOKUP_LIMIT` | typed:int | unclassified | unclassified | 353 | Max verdicts to scan when looking up the latest verdict by task_id. Beyond this limit, older entries are silently ski... |
+| `MASC_CANCELLATION_CLEANUP_SEC` | typed:float | unclassified | unclassified | 842 | Cancellation token cleanup interval (seconds). Default: 300 (5 min). |
+| `MASC_CANCELLATION_TOKEN_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 184 | Token cleanup max age (seconds) |
+| `MASC_CDAL_ENABLED` | feature_flag | n/a | n/a | 338 | Enable contract-driven proof capture. Default: true. |
+| `MASC_CDAL_GATE_ENABLED` | feature_flag | n/a | n/a | 342 | Block task completion when CDAL verdict is Violated/Inconclusive. Default: false. |
+| `MASC_CDAL_VERDICT_LOOKUP_LIMIT` | typed:int | unclassified | unclassified | 349 | Max verdicts to scan when looking up the latest verdict by task_id. Beyond this limit, older entries are silently ski... |
 | `MASC_CLAIM_TTL_SECONDS` | typed:float | unclassified | unclassified | 89 | Maximum time a task can stay Claimed/InProgress without agent heartbeat before being auto-released back to Todo (seco... |
-| `MASC_COORD_GIT_LOCAL_OP_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 963 | Budget (seconds) for local-only git operations under [Masc_exec.Exec_gate.run_argv*] in {!Coord_git} and {!Coord_work... |
-| `MASC_DASHBOARD_CTX_COMPACTING` | typed:float | unclassified | unclassified | 688 |  |
-| `MASC_DASHBOARD_CTX_HANDOFF_IMMINENT` | typed:float | unclassified | unclassified | 684 | Keeper context-ratio lifecycle thresholds. Higher ratio = closer to context limit = more urgency. |
-| `MASC_DASHBOARD_CTX_PREPARING` | typed:float | unclassified | unclassified | 686 |  |
-| `MASC_DASHBOARD_EXECUTION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 727 | Execution surface compute timeout (light + parameterized). Wraps two [Dashboard_cache.get_or_compute_with_timeout] si... |
-| `MASC_DASHBOARD_EXECUTION_TRUST_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 741 | Execution-trust surface compute timeout. Wraps [Dashboard_cache.get_or_compute_with_timeout] at [server_dashboard_htt... |
-| `MASC_DASHBOARD_KEEPER_ACTION_STALE_SEC` | typed:float | unclassified | unclassified | 679 | Keeper action-age threshold (seconds). Default: 3600 (1 hour). |
-| `MASC_DASHBOARD_MISSION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 751 | Mission card compute timeout. Wraps three [Dashboard_cache.get_or_compute_with_timeout] sites at [server_dashboard_ht... |
-| `MASC_DASHBOARD_RENDER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 784 | Maximum wall-clock for a single dashboard render ([Dashboard_execution.json_render]). Wraps the entire render pipelin... |
-| `MASC_DASHBOARD_SHELL_LIGHT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 771 | Shell render compute timeout (light path). Default 8s. Must remain strictly less than [shell_timeout_sec] so the spli... |
-| `MASC_DASHBOARD_SHELL_PREWARM_OUTER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 716 |  |
-| `MASC_DASHBOARD_SHELL_PREWARM_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 711 | Dashboard shell-cache pre-warm timeouts. The pre-warm fires once on server bootstrap. It is wrapped in two nested tim... |
-| `MASC_DASHBOARD_SHELL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 760 | Shell render compute timeout (full path). Used by [Dashboard_cache.get_or_compute_with_timeout] for the full shell re... |
-| `MASC_DASHBOARD_SIGNAL_LIVE_SEC` | typed:float | unclassified | unclassified | 675 | Duration (seconds) for a signal to count as "live". Default: 300 (5 min). |
-| `MASC_DASHBOARD_SIGNAL_QUIET_SEC` | typed:float | unclassified | unclassified | 671 | Duration (seconds) for borderline "quiet" warning. Default: 600 (10 min). |
-| `MASC_DASHBOARD_SIGNAL_STALE_SEC` | typed:float | unclassified | unclassified | 667 | Duration (seconds) after which a signal is considered stale. Default: 1200 (20 min). |
+| `MASC_COORD_GIT_LOCAL_OP_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 955 | Budget (seconds) for local-only git operations under [Masc_exec.Exec_gate.run_argv*] in {!Coord_git} and {!Coord_work... |
+| `MASC_DASHBOARD_CTX_COMPACTING` | typed:float | unclassified | unclassified | 684 |  |
+| `MASC_DASHBOARD_CTX_HANDOFF_IMMINENT` | typed:float | unclassified | unclassified | 680 | Keeper context-ratio lifecycle thresholds. Higher ratio = closer to context limit = more urgency. |
+| `MASC_DASHBOARD_CTX_PREPARING` | typed:float | unclassified | unclassified | 682 |  |
+| `MASC_DASHBOARD_EXECUTION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 723 | Execution surface compute timeout (light + parameterized). Wraps two [Dashboard_cache.get_or_compute_with_timeout] si... |
+| `MASC_DASHBOARD_EXECUTION_TRUST_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 737 | Execution-trust surface compute timeout. Wraps [Dashboard_cache.get_or_compute_with_timeout] at [server_dashboard_htt... |
+| `MASC_DASHBOARD_KEEPER_ACTION_STALE_SEC` | typed:float | unclassified | unclassified | 675 | Keeper action-age threshold (seconds). Default: 3600 (1 hour). |
+| `MASC_DASHBOARD_MISSION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 747 | Mission card compute timeout. Wraps three [Dashboard_cache.get_or_compute_with_timeout] sites at [server_dashboard_ht... |
+| `MASC_DASHBOARD_RENDER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 780 | Maximum wall-clock for a single dashboard render ([Dashboard_execution.json_render]). Wraps the entire render pipelin... |
+| `MASC_DASHBOARD_SHELL_LIGHT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 767 | Shell render compute timeout (light path). Default 8s. Must remain strictly less than [shell_timeout_sec] so the spli... |
+| `MASC_DASHBOARD_SHELL_PREWARM_OUTER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 712 |  |
+| `MASC_DASHBOARD_SHELL_PREWARM_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 707 | Dashboard shell-cache pre-warm timeouts. The pre-warm fires once on server bootstrap. It is wrapped in two nested tim... |
+| `MASC_DASHBOARD_SHELL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 756 | Shell render compute timeout (full path). Used by [Dashboard_cache.get_or_compute_with_timeout] for the full shell re... |
+| `MASC_DASHBOARD_SIGNAL_LIVE_SEC` | typed:float | unclassified | unclassified | 671 | Duration (seconds) for a signal to count as "live". Default: 300 (5 min). |
+| `MASC_DASHBOARD_SIGNAL_QUIET_SEC` | typed:float | unclassified | unclassified | 667 | Duration (seconds) for borderline "quiet" warning. Default: 600 (10 min). |
+| `MASC_DASHBOARD_SIGNAL_STALE_SEC` | typed:float | unclassified | unclassified | 663 | Duration (seconds) after which a signal is considered stale. Default: 1200 (20 min). |
 | `MASC_EXECUTOR_DOMAIN_COUNT` | typed:int | Concurrency | operator | 78 | Shared executor worker-domain count override. Env: [MASC_EXECUTOR_DOMAIN_COUNT]. Default: unset, use {!Domain_pool}'s... |
-| `MASC_FULL_HEALTH_CRITICAL_FAILURE_THRESHOLD` | typed:int | unclassified | unclassified | 811 | Number of consecutive [/health?full=1] cache-refresh failures that must accumulate before [masc_full_health_refresh_c... |
-| `MASC_FULL_HEALTH_REFRESH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 799 | Full-health snapshot proactive refresh timeout (seconds). Caps a single [/health?full=1] cache refresh attempt in [Se... |
-| `MASC_FULL_SURFACE` | feature_flag | n/a | n/a | 523 | Full tool surface override. Default: false. Re-readable within the process; callers should still document the effecti... |
-| `MASC_GOAL_JANITOR_AUTO_STAGNATE_DAYS` | typed:int | unclassified | unclassified | 396 | Stagnate threshold (days) for auto-generated goals.  Default: 7. Auto-generated = title suffix [" (auto)"] from [Keep... |
-| `MASC_GOAL_JANITOR_ENABLED` | typed:bool | unclassified | unclassified | 382 | Enable the periodic goal_janitor sweep fiber.  Default: true. Set MASC_GOAL_JANITOR_ENABLED=false to disable when deb... |
-| `MASC_GOAL_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 388 | Sweep interval in seconds.  Default: 3600 (1 hour). Goal stagnation is measured in days, so the cadence does not need... |
-| `MASC_GRPC_ENABLED` | feature_flag | n/a | n/a | 291 | Whether gRPC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
-| `MASC_GRPC_PORT` | string_literal | n/a | n/a | 287 | gRPC server port. Default: 8936. |
-| `MASC_GRPC_TARGET` | string_literal | n/a | n/a | 295 | gRPC client target address. Derived from grpc_port when unset. |
-| `MASC_HTTP_AUTH_STRICT` | feature_flag | n/a | n/a | 324 | Whether OpenAI-compatible endpoint is enabled. Default: false. |
-| `MASC_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 866 | Bootstrap janitor tick interval (seconds). Drives the SSE/session/ rate-limit/webrtc reaper loop in [server_bootstrap... |
-| `MASC_KEEPER_BOOTSTRAP_WINDOW_SEC` | typed:float | unclassified | unclassified | 842 | Keeper world observation bootstrap window (seconds). Default: 300 (5 min). |
-| `MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 451 | {1 Keeper Max-Turn Watchdog (RFC-0109 P4)} Opt-in keeper-level wall-clock watchdog. Default disabled — opt-in via [... |
+| `MASC_FULL_HEALTH_CRITICAL_FAILURE_THRESHOLD` | typed:int | unclassified | unclassified | 803 | Number of consecutive [/health?full=1] cache-refresh failures that must accumulate before [masc_full_health_refresh_c... |
+| `MASC_FULL_HEALTH_REFRESH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 791 | Full-health snapshot proactive refresh timeout (seconds). Caps a single [/health?full=1] cache refresh attempt in [Se... |
+| `MASC_FULL_SURFACE` | feature_flag | n/a | n/a | 519 | Full tool surface override. Default: false. Re-readable within the process; callers should still document the effecti... |
+| `MASC_GOAL_JANITOR_AUTO_STAGNATE_DAYS` | typed:int | unclassified | unclassified | 392 | Stagnate threshold (days) for auto-generated goals.  Default: 7. Auto-generated = title suffix [" (auto)"] from [Keep... |
+| `MASC_GOAL_JANITOR_ENABLED` | typed:bool | unclassified | unclassified | 378 | Enable the periodic goal_janitor sweep fiber.  Default: true. Set MASC_GOAL_JANITOR_ENABLED=false to disable when deb... |
+| `MASC_GOAL_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 384 | Sweep interval in seconds.  Default: 3600 (1 hour). Goal stagnation is measured in days, so the cadence does not need... |
+| `MASC_GRPC_ENABLED` | feature_flag | n/a | n/a | 287 | Whether gRPC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
+| `MASC_GRPC_PORT` | string_literal | n/a | n/a | 283 | gRPC server port. Default: 8936. |
+| `MASC_GRPC_TARGET` | string_literal | n/a | n/a | 291 | gRPC client target address. Derived from grpc_port when unset. |
+| `MASC_HTTP_AUTH_STRICT` | feature_flag | n/a | n/a | 320 | Whether OpenAI-compatible endpoint is enabled. Default: false. |
+| `MASC_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 858 | Bootstrap janitor tick interval (seconds). Drives the SSE/session/ rate-limit/webrtc reaper loop in [server_bootstrap... |
+| `MASC_KEEPER_BOOTSTRAP_WINDOW_SEC` | typed:float | unclassified | unclassified | 834 | Keeper world observation bootstrap window (seconds). Default: 300 (5 min). |
+| `MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 447 | {1 Keeper Max-Turn Watchdog (RFC-0109 P4)} Opt-in keeper-level wall-clock watchdog. Default disabled — opt-in via [... |
 | `MASC_KEEPER_ZOMBIE_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 10 | Threshold for keeper agents (longer grace period, default 1 hour) |
-| `MASC_LABEL_QUIET_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 830 | Dashboard label "quiet" threshold (seconds). Default: 300 (5 min). |
-| `MASC_LABEL_STUCK_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 834 | Dashboard label "stuck" threshold (seconds). Default: 900 (15 min). |
-| `MASC_LIST_PAGE_SIZE` | typed:int | unclassified | unclassified | 528 | Tool list page size, clamped to [10, 1024]. Default: 512. Re-readable within the process; not a guarantee of shell-le... |
+| `MASC_LABEL_QUIET_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 822 | Dashboard label "quiet" threshold (seconds). Default: 300 (5 min). |
+| `MASC_LABEL_STUCK_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 826 | Dashboard label "stuck" threshold (seconds). Default: 900 (15 min). |
+| `MASC_LIST_PAGE_SIZE` | typed:int | unclassified | unclassified | 524 | Tool list page size, clamped to [10, 1024]. Default: 512. Re-readable within the process; not a guarantee of shell-le... |
 | `MASC_LLAMA_MAX_TOKENS` | typed:int | unclassified | unclassified | 157 | Upper bound for local runtime requests. Callers may request less, but never more than this cap. Falls back to MASC_LL... |
 | `MASC_LOCAL_MAX_TOKENS` | typed:int | unclassified | unclassified | 155 | Upper bound for local runtime requests. Callers may request less, but never more than this cap. Falls back to MASC_LL... |
-| `MASC_LOCAL_RUNTIME_COOLDOWN_SEC` | string_literal | n/a | n/a | 615 | Local runtime cooldown (seconds). |
-| `MASC_LOCAL_RUNTIME_DEBUG` | feature_flag | n/a | n/a | 611 | Enable local runtime debug logging. Default: false. |
-| `MASC_LOCAL_WORKER_HEARTBEAT_SEC` | typed:int | unclassified | unclassified | 621 | Local worker heartbeat interval (seconds). Default: 60. |
-| `MASC_LOCAL_WORKER_MAX_TOKENS` | typed:int | unclassified | unclassified | 618 | Local worker max tokens per request. Default: 1024. |
+| `MASC_LOCAL_RUNTIME_COOLDOWN_SEC` | string_literal | n/a | n/a | 611 | Local runtime cooldown (seconds). |
+| `MASC_LOCAL_RUNTIME_DEBUG` | feature_flag | n/a | n/a | 607 | Enable local runtime debug logging. Default: false. |
+| `MASC_LOCAL_WORKER_HEARTBEAT_SEC` | typed:int | unclassified | unclassified | 617 | Local worker heartbeat interval (seconds). Default: 60. |
+| `MASC_LOCAL_WORKER_MAX_TOKENS` | typed:int | unclassified | unclassified | 614 | Local worker max tokens per request. Default: 1024. |
 | `MASC_LOCK_EXPIRY_WARNING_SEC` | typed:float | unclassified | unclassified | 26 | Lock expiry warning threshold (seconds before expiry) |
 | `MASC_LOCK_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 22 | Default lock timeout (seconds) |
-| `MASC_MEMORY_OAS_DEFAULT_IMPORTANCE` | typed:int | unclassified | unclassified | 637 | Default importance for OAS-stored memories, clamped to [1, 10]. Default: 5. |
-| `MASC_MESSAGE_MAX_COUNT` | typed:int | unclassified | unclassified | 233 | Maximum number of message files to retain per room (default 200). Oldest messages (by filename sort) are deleted when... |
-| `MASC_METRICS_FLUSH_SEC` | typed:float | unclassified | unclassified | 822 | Tool metrics flush interval (seconds). Default: 300 (5 min). |
-| `MASC_OAS_SSE_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 629 | SSE drain interval (seconds). Default: 2.0. |
-| `MASC_OPENAI_COMPAT` | feature_flag | n/a | n/a | 321 | Whether OpenAI-compatible endpoint is enabled. Default: false. |
+| `MASC_MEMORY_OAS_DEFAULT_IMPORTANCE` | typed:int | unclassified | unclassified | 633 | Default importance for OAS-stored memories, clamped to [1, 10]. Default: 5. |
+| `MASC_MESSAGE_MAX_COUNT` | typed:int | unclassified | unclassified | 229 | Maximum number of message files to retain per room (default 200). Oldest messages (by filename sort) are deleted when... |
+| `MASC_METRICS_FLUSH_SEC` | typed:float | unclassified | unclassified | 814 | Tool metrics flush interval (seconds). Default: 300 (5 min). |
+| `MASC_OAS_SSE_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 625 | SSE drain interval (seconds). Default: 2.0. |
+| `MASC_OPENAI_COMPAT` | feature_flag | n/a | n/a | 317 | Whether OpenAI-compatible endpoint is enabled. Default: false. |
 | `MASC_ORCHESTRATOR_AGENT` | typed:string | unclassified | unclassified | 101 | Orchestrator agent name |
 | `MASC_ORCHESTRATOR_INTERVAL` | typed:float | unclassified | unclassified | 97 | Orchestrator check interval (seconds) |
 | `MASC_ORCHESTRATOR_MIN_PRIORITY` | typed:int | unclassified | unclassified | 104 |  |
 | `MASC_ORCHESTRATOR_TIMEOUT` | typed:int | unclassified | unclassified | 107 |  |
-| `MASC_PROC_MIN_CONFIDENCE` | typed:float | unclassified | unclassified | 503 | Minimum confidence for crystallization, clamped to [0, 1]. Default: 0.7. |
-| `MASC_PROC_MIN_EVIDENCE` | typed:int | unclassified | unclassified | 499 | Minimum evidence count for crystallization. Default: 3. |
-| `MASC_PROVIDER_RUN_TTL_SEC` | typed:float | unclassified | unclassified | 854 | Provider run finished TTL (seconds). Default: 3600 (1 hour). |
-| `MASC_PUBLIC_TOOLS_EXTRA` | string_literal | n/a | n/a | 562 | Extra public tools (comma-separated names). |
-| `MASC_PULSE_MAX_CONSUMER_FAILURES` | typed:int | unclassified | unclassified | 510 | Max consecutive consumer failures before recovery. Default: 3. |
-| `MASC_RATE_BURST` | typed:int | unclassified | unclassified | 597 | Burst capacity. Default: 150. |
-| `MASC_RATE_LIMIT` | typed:float | unclassified | unclassified | 594 | Requests per second. Default: 100. |
-| `MASC_RATE_LIMIT_BUCKET_TTL_SEC` | typed:int | unclassified | unclassified | 880 | Rate-limit bucket staleness TTL (seconds). Buckets with no traffic for this long are reaped by the janitor loop. Defa... |
+| `MASC_PROC_MIN_CONFIDENCE` | typed:float | unclassified | unclassified | 499 | Minimum confidence for crystallization, clamped to [0, 1]. Default: 0.7. |
+| `MASC_PROC_MIN_EVIDENCE` | typed:int | unclassified | unclassified | 495 | Minimum evidence count for crystallization. Default: 3. |
+| `MASC_PROVIDER_RUN_TTL_SEC` | typed:float | unclassified | unclassified | 846 | Provider run finished TTL (seconds). Default: 3600 (1 hour). |
+| `MASC_PUBLIC_TOOLS_EXTRA` | string_literal | n/a | n/a | 558 | Extra public tools (comma-separated names). |
+| `MASC_PULSE_MAX_CONSUMER_FAILURES` | typed:int | unclassified | unclassified | 506 | Max consecutive consumer failures before recovery. Default: 3. |
+| `MASC_RATE_BURST` | typed:int | unclassified | unclassified | 593 | Burst capacity. Default: 150. |
+| `MASC_RATE_LIMIT` | typed:float | unclassified | unclassified | 590 | Requests per second. Default: 100. |
+| `MASC_RATE_LIMIT_BUCKET_TTL_SEC` | typed:int | unclassified | unclassified | 872 | Rate-limit bucket staleness TTL (seconds). Buckets with no traffic for this long are reaped by the janitor loop. Defa... |
 | `MASC_RELAY_TARGET_AGENT` | typed:string | unclassified | unclassified | 117 | {1 Relay Configuration} |
-| `MASC_REPO_SYNC_INTERVAL_SEC` | typed:float | unclassified | unclassified | 872 | Repository auto-sync interval (seconds). The repo_sync fiber in [server_bootstrap_loops] wakes at this cadence to fet... |
-| `MASC_SESSION_LIVE_TURN_WINDOW_SEC` | typed:float | unclassified | unclassified | 826 | Team session live turn window (seconds). Default: 300 (5 min). |
+| `MASC_REPO_SYNC_INTERVAL_SEC` | typed:float | unclassified | unclassified | 864 | Repository auto-sync interval (seconds). The repo_sync fiber in [server_bootstrap_loops] wakes at this cadence to fet... |
+| `MASC_SESSION_LIVE_TURN_WINDOW_SEC` | typed:float | unclassified | unclassified | 818 | Team session live turn window (seconds). Default: 300 (5 min). |
 | `MASC_SESSION_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 34 | Maximum session age before cleanup (seconds) |
 | `MASC_SESSION_RATE_LIMIT_WINDOW_SEC` | typed:float | unclassified | unclassified | 38 | Rate limit window (seconds) |
-| `MASC_SIDECAR_CONTROL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 906 | Subprocess timeout (seconds) for sidecar control commands — [stop], [tail], and similar quick housekeeping operatio... |
-| `MASC_SIDECAR_RECONCILE_BACKOFF_SEC` | typed:float | unclassified | unclassified | 894 | Backoff window (seconds) between repeated same-generation [running + unavailable] start dispatches. Default: 30 (matc... |
-| `MASC_SIDECAR_SCHEMA_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 922 | Subprocess timeout (seconds) for sidecar Python schema generation. Wraps [Process_eio.run_argv_with_status] at [serve... |
-| `MASC_SLOT_YIELD_ENABLED` | feature_flag | n/a | n/a | 462 | Release LLM slot during tool execution so other agents can use it. Default: false. Set MASC_SLOT_YIELD_ENABLED=true t... |
-| `MASC_SMART_HB_BASE_INTERVAL_SEC` | typed:float | unclassified | unclassified | 645 | Base heartbeat interval (seconds), clamped [5, 300]. Default: 30. |
-| `MASC_SMART_HB_IDLE_MULTIPLIER` | typed:float | unclassified | unclassified | 650 | Idle multiplier for interval, clamped [1, 10]. Default: 3. |
-| `MASC_SMART_HB_IDLE_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 655 | Idle threshold (seconds) before multiplier kicks in, clamped [60, 3600]. Default: 300. |
+| `MASC_SIDECAR_CONTROL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 898 | Subprocess timeout (seconds) for sidecar control commands — [stop], [tail], and similar quick housekeeping operatio... |
+| `MASC_SIDECAR_RECONCILE_BACKOFF_SEC` | typed:float | unclassified | unclassified | 886 | Backoff window (seconds) between repeated same-generation [running + unavailable] start dispatches. Default: 30 (matc... |
+| `MASC_SIDECAR_SCHEMA_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 914 | Subprocess timeout (seconds) for sidecar Python schema generation. Wraps [Process_eio.run_argv_with_status] at [serve... |
+| `MASC_SLOT_YIELD_ENABLED` | feature_flag | n/a | n/a | 458 | Release LLM slot during tool execution so other agents can use it. Default: false. Set MASC_SLOT_YIELD_ENABLED=true t... |
+| `MASC_SMART_HB_BASE_INTERVAL_SEC` | typed:float | unclassified | unclassified | 641 | Base heartbeat interval (seconds), clamped [5, 300]. Default: 30. |
+| `MASC_SMART_HB_IDLE_MULTIPLIER` | typed:float | unclassified | unclassified | 646 | Idle multiplier for interval, clamped [1, 10]. Default: 3. |
+| `MASC_SMART_HB_IDLE_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 651 | Idle threshold (seconds) before multiplier kicks in, clamped [60, 3600]. Default: 300. |
 | `MASC_SPAWN_CODING_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 131 | Extended timeout for coding mode (seconds). Default 2 hours. |
 | `MASC_SPAWN_GRACE_PERIOD_SEC` | typed:float | unclassified | unclassified | 135 | Grace period before timeout — sends SIGTERM for checkpoint opportunity (seconds). |
 | `MASC_SPAWN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 127 | Default spawn timeout for agent processes (seconds). Used by spawn.ml, spawn_eio.ml, and tool_relay.ml. Higher value ... |
-| `MASC_SSE_BUFFER_TTL_SEC` | typed:float | unclassified | unclassified | 846 | SSE buffer TTL (seconds). Default: 300 (5 min). |
-| `MASC_STALLED_SESSION_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 858 | Operator digest stalled session threshold (seconds). Default: 300 (5 min). |
-| `MASC_STARTUP_WATCHDOG_SEC` | typed:float | unclassified | unclassified | 335 | Startup watchdog timeout, clamped to [30, 600]. Default: 240. Re-readable within the process, but operationally a boo... |
+| `MASC_SSE_BUFFER_TTL_SEC` | typed:float | unclassified | unclassified | 838 | SSE buffer TTL (seconds). Default: 300 (5 min). |
+| `MASC_STALLED_SESSION_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 850 | Operator digest stalled session threshold (seconds). Default: 300 (5 min). |
+| `MASC_STARTUP_WATCHDOG_SEC` | typed:float | unclassified | unclassified | 331 | Startup watchdog timeout, clamped to [30, 600]. Default: 240. Re-readable within the process, but operationally a boo... |
 | `MASC_TEMPO_DEFAULT_INTERVAL_SEC` | typed:float | unclassified | unclassified | 54 | Default polling interval (seconds) |
 | `MASC_TEMPO_MAX_INTERVAL_SEC` | typed:float | unclassified | unclassified | 50 | Maximum polling interval (seconds) - for idle tempo |
 | `MASC_TEMPO_MIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 46 | Minimum polling interval (seconds) - for urgent tempo |
-| `MASC_TOOL_DESCRIPTION_BUDGET` | string_literal | n/a | n/a | 550 | Tool description budget (max chars). None = unlimited. |
-| `MASC_TOOL_READONLY_RETRY_LIMIT` | typed:int | unclassified | unclassified | 558 | Read-only tool retry limit. Default: 2. |
-| `MASC_TOOL_TIMEOUT_BOARD_SEC` | typed:int | Timeouts | operator | 545 | Board write outer MCP tool-call timeout, clamped to [5, 300] seconds. Default: 90 seconds (#10569). @category Timeout... |
-| `MASC_TOOL_TIMEOUT_DEFAULT_SEC` | typed:int | Timeouts | operator | 537 | Default outer MCP tool-call timeout, clamped to [5, 300] seconds. Board writes have a separate timeout below so opera... |
-| `MASC_USE_H2` | string_literal | n/a | n/a | 310 | HTTP mode: typed variant for "auto", "h2_only", "h1_only". |
-| `MASC_VERIFICATION_FSM_ENABLED` | feature_flag | n/a | n/a | 359 | Enable AwaitingVerification state and cross-agent approval. Default: false. |
-| `MASC_VERIFICATION_TIMEOUT_CHECK_INTERVAL_SEC` | typed:float | unclassified | unclassified | 369 | Interval for verification timeout check fiber (seconds). Default: 60. Issue #7549. |
-| `MASC_VERIFICATION_TIMEOUT_DEADLINE_SEC` | typed:float | unclassified | unclassified | 364 | Maximum time a task may remain AwaitingVerification before surfacing an operator-visible timeout. Default: 24h. |
-| `MASC_WEBRTC_ENABLED` | feature_flag | n/a | n/a | 306 | Whether WebRTC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
-| `MASC_WEB_SEARCH_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 578 |  |
-| `MASC_WEB_SEARCH_FALLBACKS` | string_literal | n/a | n/a | 571 |  |
-| `MASC_WEB_SEARCH_PROVIDER` | string_literal | n/a | n/a | 565 |  |
-| `MASC_WEB_SEARCH_PROVIDER_ORDER` | string_literal | n/a | n/a | 568 |  |
-| `MASC_WEB_SEARCH_RATE_LIMIT_MAX_CALLS` | typed:int | unclassified | unclassified | 586 |  |
-| `MASC_WEB_SEARCH_RATE_LIMIT_WINDOW_SEC` | typed:float | unclassified | unclassified | 582 |  |
-| `MASC_WEB_SEARCH_TIMEOUT_SEC` | typed:int | unclassified | unclassified | 574 |  |
-| `MASC_WS_ENABLED` | feature_flag | n/a | n/a | 302 | Whether WebSocket transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at... |
-| `MASC_WS_PORT` | string_literal | n/a | n/a | 298 | WebSocket server port. Default: 8937. |
+| `MASC_TOOL_DESCRIPTION_BUDGET` | string_literal | n/a | n/a | 546 | Tool description budget (max chars). None = unlimited. |
+| `MASC_TOOL_READONLY_RETRY_LIMIT` | typed:int | unclassified | unclassified | 554 | Read-only tool retry limit. Default: 2. |
+| `MASC_TOOL_TIMEOUT_BOARD_SEC` | typed:int | Timeouts | operator | 541 | Board write outer MCP tool-call timeout, clamped to [5, 300] seconds. Default: 90 seconds (#10569). @category Timeout... |
+| `MASC_TOOL_TIMEOUT_DEFAULT_SEC` | typed:int | Timeouts | operator | 533 | Default outer MCP tool-call timeout, clamped to [5, 300] seconds. Board writes have a separate timeout below so opera... |
+| `MASC_USE_H2` | string_literal | n/a | n/a | 306 | HTTP mode: typed variant for "auto", "h2_only", "h1_only". |
+| `MASC_VERIFICATION_FSM_ENABLED` | feature_flag | n/a | n/a | 355 | Enable AwaitingVerification state and cross-agent approval. Default: false. |
+| `MASC_VERIFICATION_TIMEOUT_CHECK_INTERVAL_SEC` | typed:float | unclassified | unclassified | 365 | Interval for verification timeout check fiber (seconds). Default: 60. Issue #7549. |
+| `MASC_VERIFICATION_TIMEOUT_DEADLINE_SEC` | typed:float | unclassified | unclassified | 360 | Maximum time a task may remain AwaitingVerification before surfacing an operator-visible timeout. Default: 24h. |
+| `MASC_WEBRTC_ENABLED` | feature_flag | n/a | n/a | 302 | Whether WebRTC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
+| `MASC_WEB_SEARCH_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 574 |  |
+| `MASC_WEB_SEARCH_FALLBACKS` | string_literal | n/a | n/a | 567 |  |
+| `MASC_WEB_SEARCH_PROVIDER` | string_literal | n/a | n/a | 561 |  |
+| `MASC_WEB_SEARCH_PROVIDER_ORDER` | string_literal | n/a | n/a | 564 |  |
+| `MASC_WEB_SEARCH_RATE_LIMIT_MAX_CALLS` | typed:int | unclassified | unclassified | 582 |  |
+| `MASC_WEB_SEARCH_RATE_LIMIT_WINDOW_SEC` | typed:float | unclassified | unclassified | 578 |  |
+| `MASC_WEB_SEARCH_TIMEOUT_SEC` | typed:int | unclassified | unclassified | 570 |  |
+| `MASC_WS_ENABLED` | feature_flag | n/a | n/a | 298 | Whether WebSocket transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at... |
+| `MASC_WS_PORT` | string_literal | n/a | n/a | 294 | WebSocket server port. Default: 8937. |
 | `MASC_ZOMBIE_CLEANUP_INTERVAL_SEC` | typed:float | unclassified | unclassified | 14 | Cleanup loop interval (seconds) |
 | `MASC_ZOMBIE_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 6 | Threshold for considering a resource as zombie (seconds) |
 
@@ -366,79 +368,81 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_SANDBOX_TMPFS_SIZE` | typed:string | unclassified | unclassified | 37 |  |
 | `MASC_KEEPER_SHELL_TIMEOUT_DEFAULT_SEC` | string_literal | n/a | n/a | 177 |  |
 
-## Env_config_snapshot (71 knobs; typed classification 0/0)
+## Env_config_snapshot (73 knobs; typed classification 0/0)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALLOW_ANONYMOUS_MUTATIONS` | string_literal | n/a | n/a | 29 |  |
-| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 633 |  |
-| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 637 |  |
-| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 639 |  |
-| `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 217 |  |
-| `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 291 |  |
-| `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 293 |  |
-| `MASC_DASHBOARD_CACHE_MAX_ENTRIES` | string_literal | n/a | n/a | 219 |  |
-| `MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S` | string_literal | n/a | n/a | 227 |  |
-| `MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S` | string_literal | n/a | n/a | 255 |  |
-| `MASC_DECISION_AUDIT_RING_CAPACITY` | string_literal | n/a | n/a | 309 |  |
-| `MASC_DECISION_LAYER_LEVEL` | string_literal | n/a | n/a | 311 |  |
-| `MASC_DISCORD_STATUS_STALE_SEC` | string_literal | n/a | n/a | 295 |  |
-| `MASC_DRIFT_COSINE_WEIGHT` | string_literal | n/a | n/a | 208 |  |
-| `MASC_DRIFT_JACCARD_WEIGHT` | string_literal | n/a | n/a | 207 |  |
-| `MASC_DRIFT_THRESHOLD` | string_literal | n/a | n/a | 206 |  |
-| `MASC_ECONOMY_ENABLED` | string_literal | n/a | n/a | 356 |  |
-| `MASC_ECONOMY_FRUGAL_THRESHOLD` | string_literal | n/a | n/a | 358 |  |
-| `MASC_ECONOMY_HUSTLE_THRESHOLD` | string_literal | n/a | n/a | 360 |  |
-| `MASC_ECONOMY_INITIAL_BALANCE` | string_literal | n/a | n/a | 362 |  |
-| `MASC_ECONOMY_REPUTATION_MULTIPLIER` | string_literal | n/a | n/a | 364 |  |
-| `MASC_ECONOMY_REWARD_BOARD_POST` | string_literal | n/a | n/a | 366 |  |
-| `MASC_ECONOMY_REWARD_MENTION_RESPONSE` | string_literal | n/a | n/a | 368 |  |
-| `MASC_ECONOMY_REWARD_TASK_DONE` | string_literal | n/a | n/a | 370 |  |
-| `MASC_ECONOMY_REWARD_UPVOTE` | string_literal | n/a | n/a | 372 |  |
-| `MASC_GRPC_STREAM_MAX_BUFFER` | string_literal | n/a | n/a | 82 |  |
-| `MASC_GUARD_PENALTY_BETA` | string_literal | n/a | n/a | 200 |  |
-| `MASC_HEBBIAN_DECAY` | string_literal | n/a | n/a | 210 |  |
-| `MASC_HEBBIAN_RATE` | string_literal | n/a | n/a | 209 |  |
+| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 639 |  |
+| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 643 |  |
+| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 645 |  |
+| `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 223 |  |
+| `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 297 |  |
+| `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 299 |  |
+| `MASC_DASHBOARD_CACHE_MAX_ENTRIES` | string_literal | n/a | n/a | 225 |  |
+| `MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S` | string_literal | n/a | n/a | 233 |  |
+| `MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S` | string_literal | n/a | n/a | 261 |  |
+| `MASC_DECISION_AUDIT_RING_CAPACITY` | string_literal | n/a | n/a | 315 |  |
+| `MASC_DECISION_LAYER_LEVEL` | string_literal | n/a | n/a | 317 |  |
+| `MASC_DISCORD_STATUS_STALE_SEC` | string_literal | n/a | n/a | 301 |  |
+| `MASC_DRIFT_COSINE_WEIGHT` | string_literal | n/a | n/a | 214 |  |
+| `MASC_DRIFT_JACCARD_WEIGHT` | string_literal | n/a | n/a | 213 |  |
+| `MASC_DRIFT_THRESHOLD` | string_literal | n/a | n/a | 212 |  |
+| `MASC_ECONOMY_ENABLED` | string_literal | n/a | n/a | 362 |  |
+| `MASC_ECONOMY_FRUGAL_THRESHOLD` | string_literal | n/a | n/a | 364 |  |
+| `MASC_ECONOMY_HUSTLE_THRESHOLD` | string_literal | n/a | n/a | 366 |  |
+| `MASC_ECONOMY_INITIAL_BALANCE` | string_literal | n/a | n/a | 368 |  |
+| `MASC_ECONOMY_REPUTATION_MULTIPLIER` | string_literal | n/a | n/a | 370 |  |
+| `MASC_ECONOMY_REWARD_BOARD_POST` | string_literal | n/a | n/a | 372 |  |
+| `MASC_ECONOMY_REWARD_MENTION_RESPONSE` | string_literal | n/a | n/a | 374 |  |
+| `MASC_ECONOMY_REWARD_TASK_DONE` | string_literal | n/a | n/a | 376 |  |
+| `MASC_ECONOMY_REWARD_UPVOTE` | string_literal | n/a | n/a | 378 |  |
+| `MASC_GRPC_STREAM_MAX_BUFFER` | string_literal | n/a | n/a | 88 |  |
+| `MASC_GUARD_PENALTY_BETA` | string_literal | n/a | n/a | 206 |  |
+| `MASC_HEBBIAN_DECAY` | string_literal | n/a | n/a | 216 |  |
+| `MASC_HEBBIAN_RATE` | string_literal | n/a | n/a | 215 |  |
 | `MASC_HTTP_HOST` | string_literal | n/a | n/a | 21 |  |
 | `MASC_HTTP_MAX_CONNECTIONS` | string_literal | n/a | n/a | 22 |  |
-| `MASC_IMESSAGE_STATUS_STALE_SEC` | string_literal | n/a | n/a | 297 |  |
-| `MASC_KEEPER_AUTONOMOUS_CONCURRENCY` | string_literal | n/a | n/a | 471 |  |
-| `MASC_KEEPER_AUTONOMOUS_MAX_TOKENS` | string_literal | n/a | n/a | 166 |  |
-| `MASC_KEEPER_COMPACT_MAX_MESSAGES` | string_literal | n/a | n/a | 157 |  |
-| `MASC_KEEPER_COMPACT_MAX_TOKENS` | string_literal | n/a | n/a | 159 |  |
-| `MASC_KEEPER_COMPACT_RATIO` | string_literal | n/a | n/a | 155 |  |
-| `MASC_KEEPER_LLM_RERANK_CASCADE` | string_literal | n/a | n/a | 537 |  |
-| `MASC_KEEPER_RULE_GUARDRAIL_CONTEXT_MIN` | string_literal | n/a | n/a | 184 |  |
-| `MASC_KEEPER_RULE_GUARDRAIL_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 180 |  |
-| `MASC_KEEPER_RULE_GUARDRAIL_REPETITION` | string_literal | n/a | n/a | 178 |  |
-| `MASC_KEEPER_RULE_GUARDRAIL_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 182 |  |
-| `MASC_KEEPER_RULE_PLAN_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 174 |  |
-| `MASC_KEEPER_RULE_PLAN_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 176 |  |
-| `MASC_KEEPER_RULE_REFLECT_REPETITION` | string_literal | n/a | n/a | 172 |  |
-| `MASC_KEEPER_TOOL_AFFINITY_K` | string_literal | n/a | n/a | 541 |  |
-| `MASC_KEEPER_TOOL_AFFINITY_LOOKBACK_DAYS` | string_literal | n/a | n/a | 543 |  |
-| `MASC_KEEPER_TOOL_COST_MAX_USD` | string_literal | n/a | n/a | 161 |  |
-| `MASC_KEEPER_TOOL_DECAY_TURNS` | string_literal | n/a | n/a | 545 |  |
-| `MASC_KEEPER_TURN_LIVELOCK_MAX_ATTEMPTS` | string_literal | n/a | n/a | 497 |  |
-| `MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC` | string_literal | n/a | n/a | 499 |  |
-| `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 164 |  |
-| `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 163 |  |
-| `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 211 |  |
-| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 731 |  |
-| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 767 |  |
-| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 779 |  |
-| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 679 |  |
-| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 681 |  |
-| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 683 |  |
-| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 685 |  |
-| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 711 |  |
-| `MASC_STRUCTURED_STATE` | string_literal | n/a | n/a | 147 |  |
-| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 747 |  |
-| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 749 |  |
-| `MASC_TLA_TRACE` | string_literal | n/a | n/a | 149 |  |
-| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 811 |  |
-| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 813 |  |
-| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 815 |  |
-| `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 89 |  |
-| `MASC_WS_SLICE_INDEX_ENABLED` | string_literal | n/a | n/a | 92 |  |
+| `MASC_IMESSAGE_STATUS_STALE_SEC` | string_literal | n/a | n/a | 303 |  |
+| `MASC_KEEPER_AUTONOMOUS_CONCURRENCY` | string_literal | n/a | n/a | 477 |  |
+| `MASC_KEEPER_AUTONOMOUS_MAX_TOKENS` | string_literal | n/a | n/a | 172 |  |
+| `MASC_KEEPER_COMPACT_MAX_MESSAGES` | string_literal | n/a | n/a | 163 |  |
+| `MASC_KEEPER_COMPACT_MAX_TOKENS` | string_literal | n/a | n/a | 165 |  |
+| `MASC_KEEPER_COMPACT_RATIO` | string_literal | n/a | n/a | 161 |  |
+| `MASC_KEEPER_LLM_RERANK_CASCADE` | string_literal | n/a | n/a | 543 |  |
+| `MASC_KEEPER_RULE_GUARDRAIL_CONTEXT_MIN` | string_literal | n/a | n/a | 190 |  |
+| `MASC_KEEPER_RULE_GUARDRAIL_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 186 |  |
+| `MASC_KEEPER_RULE_GUARDRAIL_REPETITION` | string_literal | n/a | n/a | 184 |  |
+| `MASC_KEEPER_RULE_GUARDRAIL_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 188 |  |
+| `MASC_KEEPER_RULE_PLAN_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 180 |  |
+| `MASC_KEEPER_RULE_PLAN_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 182 |  |
+| `MASC_KEEPER_RULE_REFLECT_REPETITION` | string_literal | n/a | n/a | 178 |  |
+| `MASC_KEEPER_TOOL_AFFINITY_K` | string_literal | n/a | n/a | 547 |  |
+| `MASC_KEEPER_TOOL_AFFINITY_LOOKBACK_DAYS` | string_literal | n/a | n/a | 549 |  |
+| `MASC_KEEPER_TOOL_COST_MAX_USD` | string_literal | n/a | n/a | 167 |  |
+| `MASC_KEEPER_TOOL_DECAY_TURNS` | string_literal | n/a | n/a | 551 |  |
+| `MASC_KEEPER_TURN_LIVELOCK_MAX_ATTEMPTS` | string_literal | n/a | n/a | 503 |  |
+| `MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC` | string_literal | n/a | n/a | 505 |  |
+| `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 170 |  |
+| `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 169 |  |
+| `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 217 |  |
+| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 737 |  |
+| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 773 |  |
+| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 785 |  |
+| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 685 |  |
+| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 687 |  |
+| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 689 |  |
+| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 691 |  |
+| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 717 |  |
+| `MASC_STRUCTURED_STATE` | string_literal | n/a | n/a | 153 |  |
+| `MASC_TELEMETRY_MAX_BYTES` | string_literal | n/a | n/a | 58 |  |
+| `MASC_TELEMETRY_RETENTION_DAYS` | string_literal | n/a | n/a | 55 |  |
+| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 753 |  |
+| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 755 |  |
+| `MASC_TLA_TRACE` | string_literal | n/a | n/a | 155 |  |
+| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 817 |  |
+| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 819 |  |
+| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 821 |  |
+| `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 95 |  |
+| `MASC_WS_SLICE_INDEX_ENABLED` | string_literal | n/a | n/a | 98 |  |
 

--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -626,16 +626,16 @@ let transient_http_status code =
   code = 408 || code = 409 || code = 425 || code = 429 || code >= 500
 
 let provider_capacity ?(scope = `Provider) _provider =
-  Some (Provider_error.CapacityExhausted { scope })
+  Some (Provider_error.CapacityBackpressure { scope })
 
-let retry_api_error_to_provider_error ~provider ~capacity_exhausted api_error =
+let retry_api_error_to_provider_error ~provider ~capacity_backpressure api_error =
   let provider = provider_label provider in
   match api_error with
   | Llm_provider.Retry.RateLimited { retry_after; _ } ->
-      if capacity_exhausted then provider_capacity provider
+      if capacity_backpressure then provider_capacity provider
       else Some (Provider_error.RateLimit { retry_after })
   | Llm_provider.Retry.Overloaded _ ->
-      if capacity_exhausted then provider_capacity provider
+      if capacity_backpressure then provider_capacity provider
       else Some (Provider_error.ServerError { code = 529; transient = true })
   | Llm_provider.Retry.ServerError { status; _ } ->
       Some
@@ -643,7 +643,7 @@ let retry_api_error_to_provider_error ~provider ~capacity_exhausted api_error =
            { code = status; transient = transient_http_status status })
   | Llm_provider.Retry.AuthError _ -> Some Provider_error.AuthError
   | Llm_provider.Retry.InvalidRequest { message } ->
-      if capacity_exhausted then provider_capacity provider
+      if capacity_backpressure then provider_capacity provider
       else Some (Provider_error.InvalidRequest { reason = message })
   | Llm_provider.Retry.NotFound { message } ->
       Some (Provider_error.InvalidRequest { reason = message })
@@ -651,7 +651,7 @@ let retry_api_error_to_provider_error ~provider ~capacity_exhausted api_error =
       provider_capacity ~scope:`Model provider
   | Llm_provider.Retry.NetworkError _
   | Llm_provider.Retry.Timeout _ ->
-      if capacity_exhausted then provider_capacity provider else None
+      if capacity_backpressure then provider_capacity provider else None
 
 let sdk_provider_error_to_provider_error = function
   | Llm_provider.Error.RateLimit { retry_after; _ } ->
@@ -660,7 +660,7 @@ let sdk_provider_error_to_provider_error = function
       Some (Provider_error.CliWrappedHardQuota { detail })
   | Llm_provider.Error.CapacityExhausted { scope; _ } ->
       Some
-        (Provider_error.CapacityExhausted
+        (Provider_error.CapacityBackpressure
            { scope = provider_error_capacity_scope scope })
   | Llm_provider.Error.AuthError _
   | Llm_provider.Error.MissingApiKey _ ->
@@ -685,7 +685,7 @@ let sdk_error_to_provider_error ~provider err =
   match err with
   | Agent_sdk.Error.Api api_err ->
       retry_api_error_to_provider_error ~provider
-        ~capacity_exhausted:(sdk_error_is_hard_quota err)
+        ~capacity_backpressure:(sdk_error_is_hard_quota err)
         api_err
   | Agent_sdk.Error.Provider provider_err ->
       sdk_provider_error_to_provider_error provider_err
@@ -710,11 +710,11 @@ let () =
        server error, invalid request). Labels: kind \
        (Provider_error.to_error_kind), provider (neutral runtime \
        label), cascade_name (originating cascade), capacity_scope \
-       (CapacityExhausted scope or \"none\")."
+       (provider capacity scope or \"none\")."
     ()
 
 let provider_error_capacity_scope_label = function
-  | Provider_error.CapacityExhausted { scope } ->
+  | Provider_error.CapacityBackpressure { scope } ->
       Provider_error.scope_to_string scope
   | Provider_error.RateLimit _
   | Provider_error.AuthError
@@ -894,7 +894,7 @@ let emit_sdk_provider_error_metric ~cascade_name ~provider err =
    here and clamped/defaulted at the tracker boundary so the caller's
    semantics ("the 429 still happened, so cool down at least the
    default") are maintained centrally. *)
-(* [Provider.CapacityExhausted] is a typed signal that the provider rejected
+(* external provider capacity is a typed signal that the provider rejected
    the request for capacity reasons (capacity full, model overloaded, region
    throttled). One event is enough evidence to deprioritize the provider
    for the rest of the cycle — the same logic that justifies
@@ -903,7 +903,7 @@ let emit_sdk_provider_error_metric ~cascade_name ~provider err =
    429 should already deprioritize the provider"). Threshold-counting via
    [record_failure] would burn 2 additional cascade attempts on a
    provider that has just declared it cannot serve. *)
-let sdk_error_capacity_exhausted_retry_after_s (err : Agent_sdk.Error.sdk_error)
+let sdk_error_capacity_backpressure_retry_after_s (err : Agent_sdk.Error.sdk_error)
   : float option option =
   match err with
   | Agent_sdk.Error.Provider

--- a/lib/cascade/cascade_attempt_fsm.mli
+++ b/lib/cascade/cascade_attempt_fsm.mli
@@ -86,11 +86,11 @@ val sdk_error_is_hard_quota : Agent_sdk.Error.sdk_error -> bool
 
 val retry_api_error_to_provider_error :
   provider:string ->
-  capacity_exhausted:bool ->
+  capacity_backpressure:bool ->
   Llm_provider.Retry.api_error ->
   Provider_error.t option
 (** Convert an SDK retry error into the additive provider-error contract.
-    [capacity_exhausted] is explicit so the production body classifier
+    [capacity_backpressure] is explicit so the production body classifier
     stays at this OAS boundary instead of moving into [Provider_error]. *)
 
 val sdk_error_to_provider_error :
@@ -139,9 +139,9 @@ val sdk_error_soft_rate_limited :
     [retry_after].  [Some None] when [retry_after] is absent.
     [None] for non-429 or hard-quota-429 errors. *)
 
-val sdk_error_capacity_exhausted_retry_after_s :
+val sdk_error_capacity_backpressure_retry_after_s :
   Agent_sdk.Error.sdk_error -> float option option
-(** [Some (Some retry_after)] for a [Provider.CapacityExhausted] error
+(** [Some (Some retry_after)] for a external provider capacity error
     carrying a parsed [retry_after].  [Some None] when [retry_after] is
     absent.  [None] for all other errors.  Mirrors
     {!sdk_error_soft_rate_limited} so [Cascade_health_tracker.record_soft_rate_limited]

--- a/lib/cascade/cascade_error_classify.ml
+++ b/lib/cascade/cascade_error_classify.ml
@@ -495,7 +495,7 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
                     })
              | None -> None)
           | None -> None)
-      | Some (`String ("capacity_backpressure" | "capacity_exhausted")) -> (
+      | Some (`String "capacity_backpressure") -> (
           match
             string_opt_of_assoc "cascade_name" json,
             string_opt_of_assoc "source" json,

--- a/lib/cascade/cascade_event_bridge_error_json.ml
+++ b/lib/cascade/cascade_event_bridge_error_json.ml
@@ -289,7 +289,7 @@ let sdk_provider_error_fields error =
     ]
   | Llm_provider.Error.CapacityExhausted
       { scope; affected; retry_after; detail } ->
-    [ "variant", `String "capacity_exhausted"
+    [ "variant", `String "capacity_backpressure"
     ; "message", `String message
     ; "capacity_scope", `String (Llm_provider.Error.capacity_scope_to_string scope)
     ; "affected", json_string_list affected

--- a/lib/cascade/cascade_health_filter.ml
+++ b/lib/cascade/cascade_health_filter.ml
@@ -42,7 +42,7 @@ type cascade_failure_class =
   | Network_error
   | Provider_timeout
   | Provider_terminal
-  | Provider_capacity_exhausted
+  | Provider_capacity_backpressure
   | Provider_hard_quota
   | Provider_capability_mismatch
   | Provider_cli_policy_invalid

--- a/lib/cascade/cascade_health_filter.mli
+++ b/lib/cascade/cascade_health_filter.mli
@@ -37,7 +37,7 @@ type cascade_failure_class =
   | Network_error
   | Provider_timeout
   | Provider_terminal
-  | Provider_capacity_exhausted
+  | Provider_capacity_backpressure
   | Provider_hard_quota
   | Provider_capability_mismatch
   | Provider_cli_policy_invalid

--- a/lib/coord/dune
+++ b/lib/coord/dune
@@ -25,6 +25,7 @@
   coord_query
   coord_status
   coord_task
+  coord_task_verification
   coord_task_capacity
   coord_task_classify
   coord_task_cache_invariant

--- a/lib/core/provider_error.ml
+++ b/lib/core/provider_error.ml
@@ -38,7 +38,7 @@ let scope_to_string = function
 
 let to_error_kind = function
   | RateLimit _ -> "rate_limit"
-  | CapacityExhausted _ -> "capacity_exhausted"
+  | CapacityExhausted _ -> "capacity_backpressure"
   | AuthError -> "auth_error"
   | ServerError _ -> "server_error"
   | InvalidRequest _ -> "invalid_request"
@@ -69,7 +69,7 @@ let to_yojson = function
   | CapacityExhausted { scope } ->
       `Assoc
         [
-          ("kind", `String "capacity_exhausted");
+          ("kind", `String "capacity_backpressure");
           ("scope", `String (scope_to_string scope));
           ("affected", string_list_to_yojson [ public_runtime_provider_label ]);
         ]

--- a/lib/core/provider_error.ml
+++ b/lib/core/provider_error.ml
@@ -4,7 +4,7 @@ type provider_error =
   | RateLimit of {
       retry_after : float option;
     }
-  | CapacityExhausted of {
+  | CapacityBackpressure of {
       scope : capacity_scope;
     }
   | AuthError
@@ -38,7 +38,7 @@ let scope_to_string = function
 
 let to_error_kind = function
   | RateLimit _ -> "rate_limit"
-  | CapacityExhausted _ -> "capacity_backpressure"
+  | CapacityBackpressure _ -> "capacity_backpressure"
   | AuthError -> "auth_error"
   | ServerError _ -> "server_error"
   | InvalidRequest _ -> "invalid_request"
@@ -66,7 +66,7 @@ let to_yojson = function
           ("retry_after", float_option_to_yojson retry_after);
           ("provider", `String public_runtime_provider_label);
         ]
-  | CapacityExhausted { scope } ->
+  | CapacityBackpressure { scope } ->
       `Assoc
         [
           ("kind", `String "capacity_backpressure");
@@ -145,12 +145,12 @@ let affected_providers = function
   | CliWrappedResumableSession _
   | PermissionDenied _
   | ModelNotFound
-  | CapacityExhausted _ ->
+  | CapacityBackpressure _ ->
       [ public_runtime_provider_label ]
   | ServerError _ -> []
 
-let is_capacity_exhausted = function
-  | CapacityExhausted _ -> true
+let is_capacity_backpressure = function
+  | CapacityBackpressure _ -> true
   | RateLimit _
   | AuthError
   | ServerError _

--- a/lib/core/provider_error.mli
+++ b/lib/core/provider_error.mli
@@ -11,7 +11,7 @@ type provider_error =
   | RateLimit of {
       retry_after : float option;
     }
-  | CapacityExhausted of {
+  | CapacityBackpressure of {
       scope : capacity_scope;
     }
   | AuthError
@@ -47,4 +47,4 @@ val scope_to_string : capacity_scope -> string
 val to_error_kind : t -> string
 val to_yojson : t -> Yojson.Safe.t
 val affected_providers : t -> string list
-val is_capacity_exhausted : t -> bool
+val is_capacity_backpressure : t -> bool

--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -75,6 +75,10 @@ let build_forest ~(config : Coord.config) ~goals ~tasks =
     keeper_metas
     |> List.map (fun (meta : Keeper_types.keeper_meta) -> meta.name)
     |> Keeper_execution_receipt.latest_json_by_keeper config
+    |> List.map (fun (keeper_name, receipt) ->
+           ( keeper_name,
+             Keeper_runtime_trust_snapshot.normalize_receipt_projection_json
+               receipt ))
   in
   let context =
     {
@@ -299,7 +303,11 @@ let goal_detail_json ~(config : Coord.config) ~goal_id :
                    let latest_receipt =
                      List.assoc_opt meta.name
                        (Keeper_execution_receipt.latest_json_by_keeper
-                          config node.linked_keeper_names)
+                          config node.linked_keeper_names
+                        |> List.map (fun (keeper_name, receipt) ->
+                               ( keeper_name,
+                                 Keeper_runtime_trust_snapshot
+                                 .normalize_receipt_projection_json receipt )))
                    in
                    let runtime_trust =
                      let snapshot =

--- a/lib/dashboard/dashboard_http_keeper_trust.ml
+++ b/lib/dashboard/dashboard_http_keeper_trust.ml
@@ -2,7 +2,10 @@ open Dashboard_http_keeper_types
 
 let keeper_trust_json ?(include_receipt = false)
     (config : Coord.config) (meta : Keeper_types.keeper_meta) =
-  let latest_receipt = Keeper_execution_receipt.latest_json config meta.name in
+  let latest_receipt =
+    Keeper_execution_receipt.latest_json config meta.name
+    |> Option.map Keeper_runtime_trust_snapshot.normalize_receipt_projection_json
+  in
   let runtime_trust = Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta in
   let sandbox_json =
     match latest_receipt with

--- a/lib/dashboard/dashboard_oas_bridge.ml
+++ b/lib/dashboard/dashboard_oas_bridge.ml
@@ -288,7 +288,7 @@ let record_response ~provider_id ~model_id ?total_duration_ms ?serialization_ms
        ?serialization_ms ?retry_count ~status response)
 
 let provider_error_capacity_scope_label = function
-  | Provider_error.CapacityExhausted { scope } ->
+  | Provider_error.CapacityBackpressure { scope } ->
       Provider_error.scope_to_string scope
   | Provider_error.RateLimit _
   | Provider_error.AuthError

--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -162,7 +162,7 @@ let provider_error_terminal_reason_code
     Printf.sprintf "provider_error_hard_quota:%s" provider
   | Llm_provider.Error.CapacityExhausted { scope; _ } ->
     Printf.sprintf
-      "provider_error_capacity_exhausted:%s"
+      "provider_error_capacity_backpressure:%s"
       (Llm_provider.Error.capacity_scope_to_string scope)
   | Llm_provider.Error.AuthError { provider; _ } ->
     Printf.sprintf "provider_error_auth:%s" provider
@@ -260,7 +260,7 @@ let provider_error_terminal_reason_code = function
   | Llm_provider.Error.HardQuota _ -> "provider_error_hard_quota"
   | Llm_provider.Error.CapacityExhausted { scope; _ } ->
     Printf.sprintf
-      "provider_error_capacity_exhausted:%s"
+      "provider_error_capacity_backpressure:%s"
       (Llm_provider.Error.capacity_scope_to_string scope)
   | Llm_provider.Error.AuthError _ -> "provider_error_auth"
   | Llm_provider.Error.ServerError { code; _ } ->

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -253,7 +253,7 @@ type degraded_retry_reason =
   | Cascade_candidates_filtered
   | Required_tool_contract_violation
   | Cascade_exhausted
-  | Capacity_exhausted
+  | Capacity_backpressure
   | Rate_limit
   | Server_error
   | Auth_error
@@ -268,7 +268,7 @@ let degraded_retry_reason_to_string = function
   | Cascade_candidates_filtered -> "cascade_candidates_filtered"
   | Required_tool_contract_violation -> "required_tool_contract_violation"
   | Cascade_exhausted -> "cascade_exhausted"
-  | Capacity_exhausted -> "capacity_backpressure"
+  | Capacity_backpressure -> "capacity_backpressure"
   | Rate_limit -> "rate_limit"
   | Server_error -> "server_error"
   | Auth_error -> "auth_error"
@@ -341,7 +341,7 @@ let degraded_retry_after_recoverable_error
     | Some (Keeper_turn_driver.Turn_timeout _) ->
         local_recovery_retry Turn_timeout
     | Some (Keeper_turn_driver.Capacity_backpressure _) ->
-        local_recovery_retry Capacity_exhausted
+        local_recovery_retry Capacity_backpressure
     | Some
         (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Candidates_filtered_after_cycles; _ }) ->
@@ -387,7 +387,7 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
     | Some (Keeper_turn_driver.Turn_timeout _) ->
         Some Turn_timeout
     | Some (Keeper_turn_driver.Capacity_backpressure _) ->
-        Some Capacity_exhausted
+        Some Capacity_backpressure
     | Some
         (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Candidates_filtered_after_cycles; _ }) ->
@@ -450,7 +450,7 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
              (Llm_provider.Error.RateLimit _) ->
              Some Rate_limit
          | Agent_sdk.Error.Provider (Llm_provider.Error.CapacityExhausted _) ->
-             Some Capacity_exhausted
+             Some Capacity_backpressure
          | Agent_sdk.Error.Provider (Llm_provider.Error.HardQuota _) ->
              Some Hard_quota
          | Agent_sdk.Error.Provider (Llm_provider.Error.ServerError { code; transient; _ })

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -180,7 +180,6 @@ let is_required_tool_contract_violation (err : Agent_sdk.Error.sdk_error) : bool
 let message_looks_like_capacity_backpressure detail =
   let lower = String.lowercase_ascii detail in
   string_contains_substring ~needle:"client capacity" lower
-  || string_contains_substring ~needle:"capacity_exhausted" lower
   || string_contains_substring ~needle:"capacity exhausted" lower
   || string_contains_substring ~needle:"local_resource_exhaustion" lower
 

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -83,7 +83,7 @@ type degraded_retry_reason =
   | Cascade_candidates_filtered
   | Required_tool_contract_violation
   | Cascade_exhausted
-  | Capacity_exhausted
+  | Capacity_backpressure
   | Rate_limit
   | Server_error
   | Auth_error

--- a/lib/keeper/keeper_failure_policy.ml
+++ b/lib/keeper/keeper_failure_policy.ml
@@ -111,8 +111,7 @@ let timeout_phase_of_label label =
     | "caller_budget" -> Some Caller_budget
     | "wall_clock" | "wall_clock_timeout" | "wall_exceeded" | "max_execution_time" ->
       Some Wall_clock
-    | "capacity_backpressure" | "capacity_exhausted" | "client_capacity"
-    | "client_capacity_full" ->
+    | "capacity_backpressure" | "client_capacity" | "client_capacity_full" ->
       Some Capacity_backpressure
     | "unknown_timeout" -> Some Unknown_timeout
     | _ -> None

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -39,6 +39,12 @@ val keeper_turn_throttle_limit : int
 (** Runtime keeper turn concurrency limit derived from
     [MASC_KEEPER_AUTOBOOT_MAX]. *)
 
+val keeper_turn_throttle_raw_value : string option
+(** Raw configured value used for {!keeper_turn_throttle_limit}, when supplied. *)
+
+val keeper_turn_throttle_source : string
+(** Source for {!keeper_turn_throttle_limit}: [env], [boot_override], or [default]. *)
+
 val proactive_skip_reason_metric : string
 (** Canonical Prometheus metric name for the proactive-scheduler
     skip-reason counter.  Labels: [("keeper", <name>); ("reason",

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -91,7 +91,7 @@ type cascade_exhaustion_reason =
 
 type blocker_class =
   | Cascade_exhausted of cascade_exhaustion_reason
-  | Capacity_exhausted
+  | Capacity_backpressure
   | Ambiguous_post_commit_timeout
   | Ambiguous_post_commit_failure
   | Autonomous_slot_wait_timeout
@@ -138,7 +138,7 @@ type blocker_class =
 
 let blocker_class_to_string = function
   | Cascade_exhausted _ -> "cascade_exhausted"
-  | Capacity_exhausted -> "capacity_backpressure"
+  | Capacity_backpressure -> "capacity_backpressure"
   | Ambiguous_post_commit_timeout -> "ambiguous_post_commit_timeout"
   | Ambiguous_post_commit_failure -> "ambiguous_post_commit_failure"
   | Autonomous_slot_wait_timeout -> "autonomous_slot_wait_timeout"
@@ -166,7 +166,7 @@ let blocker_class_to_string = function
 
 let blocker_class_of_serialized_string = function
   | "cascade_exhausted" -> Some (Cascade_exhausted (Other_detail "cascade_exhausted"))
-  | "capacity_backpressure" -> Some Capacity_exhausted
+  | "capacity_backpressure" -> Some Capacity_backpressure
   | "ambiguous_post_commit_timeout" -> Some Ambiguous_post_commit_timeout
   | "ambiguous_post_commit_failure" -> Some Ambiguous_post_commit_failure
   | "autonomous_slot_wait_timeout" -> Some Autonomous_slot_wait_timeout
@@ -210,7 +210,7 @@ let blocker_class_continue_gate = function
   | Ambiguous_post_commit_timeout
   | Ambiguous_post_commit_failure -> true
   | Cascade_exhausted _
-  | Capacity_exhausted
+  | Capacity_backpressure
   | Autonomous_slot_wait_timeout
   | Admission_queue_wait_timeout
   | Turn_timeout_after_queue_wait

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -167,7 +167,6 @@ let blocker_class_to_string = function
 let blocker_class_of_serialized_string = function
   | "cascade_exhausted" -> Some (Cascade_exhausted (Other_detail "cascade_exhausted"))
   | "capacity_backpressure" -> Some Capacity_exhausted
-  | "capacity_exhausted" -> Some Capacity_exhausted
   | "ambiguous_post_commit_timeout" -> Some Ambiguous_post_commit_timeout
   | "ambiguous_post_commit_failure" -> Some Ambiguous_post_commit_failure
   | "autonomous_slot_wait_timeout" -> Some Autonomous_slot_wait_timeout

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -149,7 +149,7 @@ type cascade_exhaustion_reason =
 
 type blocker_class =
   | Cascade_exhausted of cascade_exhaustion_reason
-  | Capacity_exhausted
+  | Capacity_backpressure
   | Ambiguous_post_commit_timeout
   | Ambiguous_post_commit_failure
   | Autonomous_slot_wait_timeout

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -69,7 +69,7 @@ let blocker_class_indicates_overflow (klass : blocker_class) : bool =
   match klass with
   | Sdk_token_budget_exceeded -> true
   | Cascade_exhausted _
-  | Capacity_exhausted
+  | Capacity_backpressure
   | Ambiguous_post_commit_timeout
   | Ambiguous_post_commit_failure
   | Autonomous_slot_wait_timeout

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -11,7 +11,39 @@ open Keeper_runtime_trust_timeline
    [keeper_agent_run.ml]. *)
 let normalize_persisted_terminal_reason_code = function
   | "completed" -> "success"
+  | "capacity_exhausted" -> "capacity_backpressure"
   | code -> code
+
+let normalize_masc_oas_error_message value =
+  if String_util.contains_substring value "[masc_oas_error]"
+  then
+    value
+    |> String_util.replace_substring
+         ~needle:"\"kind\":\"capacity_exhausted\""
+         ~by:"\"kind\":\"capacity_backpressure\""
+    |> String_util.replace_substring
+         ~needle:"\"kind\": \"capacity_exhausted\""
+         ~by:"\"kind\": \"capacity_backpressure\""
+  else value
+
+let rec normalize_receipt_projection_json = function
+  | `Assoc fields ->
+      `Assoc
+        (List.map
+           (fun (key, value) ->
+             let value =
+               match key, value with
+               | "terminal_reason_code", `String code ->
+                   `String (normalize_persisted_terminal_reason_code code)
+               | "message", `String message ->
+                   `String (normalize_masc_oas_error_message message)
+               | _ -> normalize_receipt_projection_json value
+             in
+             (key, value))
+           fields)
+  | `List values -> `List (List.map normalize_receipt_projection_json values)
+  | `String value -> `String (normalize_masc_oas_error_message value)
+  | json -> json
 
 let terminal_reason_from_decision json =
   match json_member "terminal_reason" json with
@@ -318,7 +350,10 @@ let disposition_fields_json ~(config : Coord.config) ~(meta : keeper_meta) :
   let disposition, disposition_reason =
     disposition_of_snapshot ~pending_approval_count ~runtime_blocker_fields
   in
-  let latest_receipt = Keeper_execution_receipt.latest_json config meta.name in
+  let latest_receipt =
+    Keeper_execution_receipt.latest_json config meta.name
+    |> Option.map normalize_receipt_projection_json
+  in
   let disposition, disposition_reason, _, _ =
     effective_disposition_fields ~fallback_disposition:disposition
       ~fallback_reason:disposition_reason latest_receipt
@@ -386,6 +421,7 @@ let latest_turn_id ~(registry_entry : Keeper_registry.registry_entry option)
 
 let latest_receipt_json ~(config : Coord.config) ~(keeper_name : string) =
   Keeper_execution_receipt.latest_json config keeper_name
+  |> Option.map normalize_receipt_projection_json
 
 let selected_model_of_latest_decision latest_decision =
   Option.bind latest_decision (fun decision ->

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -11,20 +11,7 @@ open Keeper_runtime_trust_timeline
    [keeper_agent_run.ml]. *)
 let normalize_persisted_terminal_reason_code = function
   | "completed" -> "success"
-  | "capacity_exhausted" -> "capacity_backpressure"
   | code -> code
-
-let normalize_masc_oas_error_message value =
-  if String_util.contains_substring value "[masc_oas_error]"
-  then
-    value
-    |> String_util.replace_substring
-         ~needle:"\"kind\":\"capacity_exhausted\""
-         ~by:"\"kind\":\"capacity_backpressure\""
-    |> String_util.replace_substring
-         ~needle:"\"kind\": \"capacity_exhausted\""
-         ~by:"\"kind\": \"capacity_backpressure\""
-  else value
 
 let rec normalize_receipt_projection_json = function
   | `Assoc fields ->
@@ -35,14 +22,11 @@ let rec normalize_receipt_projection_json = function
                match key, value with
                | "terminal_reason_code", `String code ->
                    `String (normalize_persisted_terminal_reason_code code)
-               | "message", `String message ->
-                   `String (normalize_masc_oas_error_message message)
                | _ -> normalize_receipt_projection_json value
              in
              (key, value))
            fields)
   | `List values -> `List (List.map normalize_receipt_projection_json values)
-  | `String value -> `String (normalize_masc_oas_error_message value)
   | json -> json
 
 let terminal_reason_from_decision json =

--- a/lib/keeper/keeper_runtime_trust_snapshot.mli
+++ b/lib/keeper/keeper_runtime_trust_snapshot.mli
@@ -1,6 +1,8 @@
 val disposition_fields_json :
   config:Coord.config -> meta:Keeper_types.keeper_meta -> Yojson.Safe.t
 
+val normalize_receipt_projection_json : Yojson.Safe.t -> Yojson.Safe.t
+
 val snapshot_json :
   config:Coord.config -> meta:Keeper_types.keeper_meta -> Yojson.Safe.t
 

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -158,8 +158,7 @@ let blocker_class_of_string (reason : string) : blocker_class option =
   if trimmed = ""
   then None
   else if
-    String_util.contains_substring_ci trimmed "capacity_exhausted"
-    || String_util.contains_substring_ci trimmed "capacity exhausted"
+    String_util.contains_substring_ci trimmed "capacity exhausted"
     || String_util.contains_substring_ci trimmed "capacity_backpressure"
     || String_util.contains_substring_ci trimmed "client capacity"
   then Some Capacity_exhausted

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -161,7 +161,7 @@ let blocker_class_of_string (reason : string) : blocker_class option =
     String_util.contains_substring_ci trimmed "capacity exhausted"
     || String_util.contains_substring_ci trimmed "capacity_backpressure"
     || String_util.contains_substring_ci trimmed "client capacity"
-  then Some Capacity_exhausted
+  then Some Capacity_backpressure
   else if
     String_util.contains_substring_ci
       trimmed
@@ -220,10 +220,10 @@ let blocker_class_of_string (reason : string) : blocker_class option =
 
 let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class option =
   match Keeper_error_classify.recoverable_cascade_failure_reason err with
-  | Some Keeper_error_classify.Capacity_exhausted -> Some Capacity_exhausted
+  | Some Keeper_error_classify.Capacity_backpressure -> Some Capacity_backpressure
   | _ ->
   match Keeper_turn_driver.classify_masc_internal_error err with
-  | Some (Keeper_turn_driver.Capacity_backpressure _) -> Some Capacity_exhausted
+  | Some (Keeper_turn_driver.Capacity_backpressure _) -> Some Capacity_backpressure
   | Some (Keeper_turn_driver.Cascade_exhausted { reason; _ }) ->
     Some (Cascade_exhausted reason)
   | Some (Keeper_turn_driver.Resumable_cli_session { detail; _ }) ->
@@ -294,7 +294,7 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
   let continue_gate = blocker_class_continue_gate cls in
   let summary =
     match cls with
-    | Capacity_exhausted ->
+    | Capacity_backpressure ->
       if summary = ""
       then "Provider or client capacity backpressure blocked this keeper turn."
       else summary
@@ -364,7 +364,7 @@ let runtime_blocker_surface_of_legacy_string reason cls =
      legacy string [reason] argument provides the fallback summary. *)
   | Ambiguous_post_commit_timeout
   | Ambiguous_post_commit_failure
-  | Capacity_exhausted
+  | Capacity_backpressure
   | Autonomous_slot_wait_timeout
   | Admission_queue_wait_timeout
   | Turn_timeout_after_queue_wait

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -381,7 +381,7 @@ let run_named
   let record_provider_health_error candidate = function
     | Provider_error.ServerError { code; _ } ->
       record_provider_health_result candidate ~success:false ~http_status:(Some code)
-    | Provider_error.CapacityExhausted _
+    | Provider_error.CapacityBackpressure _
     | Provider_error.RateLimit _
     | Provider_error.AuthError
     | Provider_error.InvalidRequest _
@@ -635,7 +635,7 @@ let run_named
           let http_status_of_provider_error = function
             | Some (Provider_error.ServerError { code; _ }) -> Some code
             | Some
-                (Provider_error.CapacityExhausted _
+                (Provider_error.CapacityBackpressure _
                 | Provider_error.RateLimit _
                 | Provider_error.AuthError
                 | Provider_error.InvalidRequest _
@@ -728,7 +728,7 @@ let run_named
         ~error_reason
         ()
     else
-      (* Capacity_exhausted shares the immediate-cooldown semantics of a
+      (* Capacity backpressure shares the immediate-cooldown semantics of a
          soft rate limit: one event is sufficient evidence that the
          provider cannot serve, so we reuse [record_soft_rate_limited]
          rather than counting toward the 3-failure threshold of
@@ -736,7 +736,7 @@ let run_named
          cooldown duration (clamped by
          [Cascade_health_tracker.soft_rate_limit_max_clamp_sec]). *)
       let immediate_cooldown_retry_after =
-        match sdk_error_capacity_exhausted_retry_after_s sdk_err with
+        match sdk_error_capacity_backpressure_retry_after_s sdk_err with
         | Some retry_after -> Some retry_after
         | None -> sdk_error_soft_rate_limited sdk_err
       in

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -49,13 +49,23 @@ type semaphore_wait_timeout =
 (* RFC-0085 PR-11 — Dropped the [~deprecated] fallback; the typo legacy
    env MASC_KEEPER_AUTOBOT_MAX is no longer recognised. Operators
    must set MASC_KEEPER_AUTOBOOT_MAX. *)
+type int_env_snapshot =
+  { value : int
+  ; raw_value : string option
+  ; source : string
+  }
+
 let int_of_env_default ~primary ~default ~min_v ~max_v =
-  match Sys.getenv_opt primary with
-  | None -> default
-  | Some raw when String.trim raw = "" -> default
-  | Some raw ->
-    let v = Option.value ~default (int_of_string_opt (String.trim raw)) in
-    Keeper_config.clamp_int v ~min_v ~max_v
+  let raw_value = Env_config_core.raw_value_opt primary in
+  let value =
+    match raw_value with
+    | None -> default
+    | Some raw when String.trim raw = "" -> default
+    | Some raw ->
+      let v = Option.value ~default (int_of_string_opt (String.trim raw)) in
+      Keeper_config.clamp_int v ~min_v ~max_v
+  in
+  { value; raw_value; source = Config_boot_overrides.source primary }
 ;;
 
 (* Global turn slot cap across autonomous + reactive pools.
@@ -65,7 +75,7 @@ let int_of_env_default ~primary ~default ~min_v ~max_v =
    only enforced floor is [min_v:1] (0 = deadlock). The previous [max_v:20]
    cap was a typo-defence boilerplate, not an architectural ceiling, and
    forced operator raise-cycles every time the fleet grew. Removed. *)
-let keeper_turn_throttle_limit =
+let keeper_turn_throttle_snapshot =
   int_of_env_default
     ~primary:"MASC_KEEPER_AUTOBOOT_MAX"
     ~default:32
@@ -73,6 +83,9 @@ let keeper_turn_throttle_limit =
     ~max_v:max_int
 ;;
 
+let keeper_turn_throttle_limit = keeper_turn_throttle_snapshot.value
+let keeper_turn_throttle_raw_value = keeper_turn_throttle_snapshot.raw_value
+let keeper_turn_throttle_source = keeper_turn_throttle_snapshot.source
 let turn_semaphore = Eio.Semaphore.make keeper_turn_throttle_limit
 
 (* 2026-05-05 fleet-stuck diagnosis: when a peer holds the semaphore

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -29,6 +29,12 @@ type semaphore_wait_timeout = {
 (** Global turn slot cap. Safety ceiling for ALL keeper turns. *)
 val keeper_turn_throttle_limit : int
 
+(** Raw configured value used for {!keeper_turn_throttle_limit}, when supplied. *)
+val keeper_turn_throttle_raw_value : string option
+
+(** Source for {!keeper_turn_throttle_limit}: [env], [boot_override], or [default]. *)
+val keeper_turn_throttle_source : string
+
 val turn_semaphore : Eio.Semaphore.t
 val autonomous_turn_semaphore : Eio.Semaphore.t
 val reactive_turn_semaphore : Eio.Semaphore.t

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -169,7 +169,7 @@ type cascade_exhaustion_reason = Keeper_meta_contract.cascade_exhaustion_reason 
 
 type blocker_class = Keeper_meta_contract.blocker_class =
   | Cascade_exhausted of cascade_exhaustion_reason
-  | Capacity_exhausted
+  | Capacity_backpressure
   | Ambiguous_post_commit_timeout
   | Ambiguous_post_commit_failure
   | Autonomous_slot_wait_timeout

--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -21,7 +21,7 @@ module Http_client = struct
             collapsed here because [should_cascade] only needs the
             terminality bit; consumers wanting the message extract it
             via the original [ProviderTerminal] match. *)
-    | Provider_capacity_exhausted
+    | Provider_capacity_backpressure
     | Provider_hard_quota
     | Provider_capability_mismatch
     | Provider_cli_policy_invalid
@@ -73,7 +73,7 @@ module Http_client = struct
   let classify_provider_failure_kind =
     let module H = Llm_provider.Http_client in
     function
-    | H.Capacity_exhausted _ -> Provider_capacity_exhausted
+    | H.Capacity_exhausted _ -> Provider_capacity_backpressure
     | H.Hard_quota _ -> Provider_hard_quota
     | H.Capability_mismatch _ -> Provider_capability_mismatch
     | H.Cli_policy_invalid _ -> Provider_cli_policy_invalid
@@ -194,7 +194,7 @@ module Http_client = struct
     | Cli_transport_required
     | Network_error
     | Provider_timeout
-    | Provider_capacity_exhausted
+    | Provider_capacity_backpressure
     | Provider_hard_quota
     | Provider_capability_mismatch
     | Provider_cli_policy_invalid

--- a/lib/oas_compat/oas_compat.mli
+++ b/lib/oas_compat/oas_compat.mli
@@ -35,7 +35,7 @@ module Http_client : sig
     | Provider_timeout
     | Provider_terminal
         (** Provider-level terminal condition that should stop cascading. *)
-    | Provider_capacity_exhausted
+    | Provider_capacity_backpressure
     | Provider_hard_quota
     | Provider_capability_mismatch
     | Provider_cli_policy_invalid

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -286,7 +286,13 @@ let keeper_tool_audit_fields
 ;;
 
 let lightweight_tool_audit_fallback_json = Operator_control_snapshot_tool_audit.lightweight_tool_audit_fallback_json
-let cached_tool_audit_json = Operator_control_snapshot_tool_audit.cached_tool_audit_json
+let cached_tool_audit_json ~lightweight config meta =
+  Operator_control_snapshot_tool_audit.cached_tool_audit_json
+    ~tool_audit_fields:keeper_tool_audit_fields
+    ~lightweight
+    config
+    meta
+;;
 let _keeper_snapshot_max_concurrency =
   match Sys.getenv_opt "MASC_KEEPER_SNAPSHOT_CONCURRENCY" with
   | Some s ->

--- a/lib/operator/operator_control_snapshot_tool_audit.ml
+++ b/lib/operator/operator_control_snapshot_tool_audit.ml
@@ -3,6 +3,22 @@
 
 module U = Yojson.Safe.Util
 
+type tool_audit_fields =
+  string list
+  * string list
+  * string list
+  * int option
+  * string option
+  * string option
+  * string option
+
+let option_to_json f = function
+  | Some value -> f value
+  | None -> `Null
+;;
+
+let string_option_to_json = option_to_json (fun value -> `String value)
+
 let lightweight_tool_audit_fallback_json (meta : Keeper_types.keeper_meta) =
   let last_autonomous = String.trim meta.runtime.last_autonomous_action_at in
   let has_runtime_activity =
@@ -28,6 +44,11 @@ let lightweight_tool_audit_fallback_json (meta : Keeper_types.keeper_meta) =
 ;;
 
 let cached_tool_audit_json
+      ~(tool_audit_fields :
+          ?include_allowed_tools:bool ->
+          Coord.config ->
+          Keeper_types.keeper_meta ->
+          tool_audit_fields)
       ~lightweight
       (config : Coord.config)
       (meta : Keeper_types.keeper_meta)

--- a/lib/operator/operator_control_snapshot_tool_audit.ml
+++ b/lib/operator/operator_control_snapshot_tool_audit.ml
@@ -81,7 +81,7 @@ let cached_tool_audit_json
             , tool_audit_source
             , tool_audit_at )
           =
-          keeper_tool_audit_fields ~include_allowed_tools:false config meta
+          tool_audit_fields ~include_allowed_tools:false config meta
         in
         ( []
         , recent_tool_names
@@ -90,7 +90,7 @@ let cached_tool_audit_json
         , latest_action_source
         , tool_audit_source
         , tool_audit_at ))
-      else keeper_tool_audit_fields config meta
+      else tool_audit_fields config meta
     in
     `Assoc
       [ "allowed_tool_names", `List (List.map (fun v -> `String v) allowed_tool_names)

--- a/lib/operator/operator_control_snapshot_tool_audit.mli
+++ b/lib/operator/operator_control_snapshot_tool_audit.mli
@@ -1,0 +1,24 @@
+(** Tool audit helpers for operator control snapshots. *)
+
+type tool_audit_fields =
+  string list
+  * string list
+  * string list
+  * int option
+  * string option
+  * string option
+  * string option
+
+val lightweight_tool_audit_fallback_json :
+  Keeper_types.keeper_meta -> Yojson.Safe.t
+
+val cached_tool_audit_json :
+  tool_audit_fields:
+    (?include_allowed_tools:bool ->
+     Coord.config ->
+     Keeper_types.keeper_meta ->
+     tool_audit_fields) ->
+  lightweight:bool ->
+  Coord.config ->
+  Keeper_types.keeper_meta ->
+  Yojson.Safe.t

--- a/lib/server/openai_compat_error_map.ml
+++ b/lib/server/openai_compat_error_map.ml
@@ -133,7 +133,7 @@ let of_provider_error (e : Agent_sdk.Error.provider_error) : t =
     ; openai_code =
         Some
           (Printf.sprintf
-             "provider_capacity_exhausted:%s"
+             "provider_capacity_backpressure:%s"
              (Llm_provider.Error.capacity_scope_to_string r.scope))
     ; message }
   | AuthError _ ->

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -699,7 +699,10 @@ let composite_config_drift_json ~config ~keeper_name =
 let composite_execution_receipt_json ~(config : Coord.config) ~keeper_name =
   let claim_scope = composite_claim_scope_json ~keeper_name in
   let config_drift = composite_config_drift_json ~config ~keeper_name in
-  match Keeper_execution_receipt.latest_json config keeper_name with
+  match
+    Keeper_execution_receipt.latest_json config keeper_name
+    |> Option.map Keeper_runtime_trust_snapshot.normalize_receipt_projection_json
+  with
   | None ->
     `Assoc
       [ "latest_receipt_present", `Bool false

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -676,6 +676,11 @@ let keeper_fleet_safety_health_json
              (fun (keeper, error) ->
                `Assoc [ ("keeper", `String keeper); ("error", `String error) ])
              autoboot_scan.read_errors) )
+    ; "keeper_turn_throttle_limit", `Int Keeper_keepalive.keeper_turn_throttle_limit
+    ; "keeper_turn_throttle_source", `String Keeper_keepalive.keeper_turn_throttle_source
+    ; "keeper_turn_throttle_env", `String "MASC_KEEPER_AUTOBOOT_MAX"
+    ; ( "keeper_turn_throttle_raw_value"
+      , json_string_opt Keeper_keepalive.keeper_turn_throttle_raw_value )
     ; "running_keeper_fiber_count", `Int phase_counts.running
     ; "healthy_running_keeper_fiber_count", `Int phase_counts.running
     ; "failing_keeper_fiber_count", `Int phase_counts.failing

--- a/lib/tool_operator.mli
+++ b/lib/tool_operator.mli
@@ -71,6 +71,11 @@ val dispatch :
     safe-to-expose subset.  The full {!schemas} is consumed inside
     the keeper-bound dispatcher only. *)
 
+val schemas : Masc_domain.tool_schema list
+(** Full operator tool schemas — includes hidden/internal operator
+    control tools consumed by local keeper-bound dispatch surfaces and
+    schema coverage tests. *)
+
 val remote_schemas : Masc_domain.tool_schema list
 (** Operator-remote tool schemas — the subset advertised to remote
     MCP clients.  Pinned at the .mli seam so dashboard / SDK

--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -1,10 +1,10 @@
 {
   "_comment": "OCaml structural-debt baseline. Regenerate with scripts/ocaml-structure-ratchet.sh --regenerate.",
   "_metrics": "See scripts/ocaml-structure-ratchet.sh METRICS array.",
-  "keeper_mli_missing": 1,
-  "coord_mli_missing": 0,
+  "keeper_mli_missing": 8,
+  "coord_mli_missing": 1,
   "godsplit_count": 0,
-  "lib_dune_lines": 1000,
+  "lib_dune_lines": 661,
   "inferred_dump_headers": 0,
-  "lib_other_mli_missing": 1
+  "lib_other_mli_missing": 5
 }

--- a/test/dune
+++ b/test/dune
@@ -1142,6 +1142,7 @@
   test_keeper_safety_gates
   test_keeper_guards
   test_keeper_working_state
+  test_keeper_wip_admission
   test_eval_gate_evasion
   test_prompt_registry_defaults
   test_keeper_prompt_external

--- a/test/dune
+++ b/test/dune
@@ -121,7 +121,7 @@
   test_keeper_health_probe
   test_oas_error_kind_counter
   test_cascade_error_classify_decoder
-  test_cascade_capacity_exhausted_cooldown
+  test_cascade_capacity_backpressure_cooldown
   test_oas_empty_response_diagnostic
   test_board_author_identity_10297
   test_fsm_drift_counter
@@ -438,7 +438,7 @@
   test_keeper_health_probe
   test_oas_error_kind_counter
   test_cascade_error_classify_decoder
-  test_cascade_capacity_exhausted_cooldown
+  test_cascade_capacity_backpressure_cooldown
   test_oas_empty_response_diagnostic
   test_board_author_identity_10297
   test_fsm_drift_counter

--- a/test/test_cascade_capacity_backpressure_cooldown.ml
+++ b/test/test_cascade_capacity_backpressure_cooldown.ml
@@ -1,8 +1,8 @@
-(** Pins the typed extraction of [Provider.CapacityExhausted] retry_after
+(** Pins typed extraction of provider capacity retry_after
     from an [Agent_sdk.Error.sdk_error] via
-    [Cascade_attempt_fsm.sdk_error_capacity_exhausted_retry_after_s].
+    [Cascade_attempt_fsm.sdk_error_capacity_backpressure_retry_after_s].
 
-    Without this helper, [Capacity_exhausted] events fall through to
+    Without this helper, external provider capacity events fall through to
     [record_failure] (threshold-based) instead of [record_soft_rate_limited]
     (immediate). One capacity-exhausted event is sufficient evidence to
     deprioritize a provider — the same reasoning
@@ -22,25 +22,25 @@ let pp_extract fmt = function
 let extract_testable =
   Alcotest.testable pp_extract ( = )
 
-let mk_capacity_exhausted ?retry_after ?(scope = Llm_provider.Error.CapacityProvider)
+let mk_capacity_backpressure ?retry_after ?(scope = Llm_provider.Error.CapacityProvider)
     ?(affected = []) ?(detail = "capacity exhausted") () : ErrSdk.sdk_error =
   ErrSdk.Provider
     (Llm_provider.Error.CapacityExhausted
        { scope; affected; retry_after; detail })
 
 let test_capacity_with_retry_after_extracted () =
-  let err = mk_capacity_exhausted ~retry_after:7.5 () in
+  let err = mk_capacity_backpressure ~retry_after:7.5 () in
   Alcotest.check extract_testable
-    "CapacityExhausted with retry_after=7.5 → Some(Some 7.5)"
+    "provider capacity with retry_after=7.5 → Some(Some 7.5)"
     (Some (Some 7.5))
-    (FSM.sdk_error_capacity_exhausted_retry_after_s err)
+    (FSM.sdk_error_capacity_backpressure_retry_after_s err)
 
 let test_capacity_without_retry_after_extracted () =
-  let err = mk_capacity_exhausted () in
+  let err = mk_capacity_backpressure () in
   Alcotest.check extract_testable
-    "CapacityExhausted without retry_after → Some(None)"
+    "provider capacity without retry_after → Some(None)"
     (Some None)
-    (FSM.sdk_error_capacity_exhausted_retry_after_s err)
+    (FSM.sdk_error_capacity_backpressure_retry_after_s err)
 
 let test_non_capacity_error_returns_none () =
   let err =
@@ -49,9 +49,9 @@ let test_non_capacity_error_returns_none () =
          { provider = "test"; retry_after = Some 3.0; detail = "" })
   in
   Alcotest.check extract_testable
-    "RateLimit is not CapacityExhausted → None"
+    "RateLimit is not provider capacity → None"
     None
-    (FSM.sdk_error_capacity_exhausted_retry_after_s err)
+    (FSM.sdk_error_capacity_backpressure_retry_after_s err)
 
 let test_hard_quota_returns_none () =
   let err =
@@ -60,35 +60,35 @@ let test_hard_quota_returns_none () =
          { provider = "test"; retry_after = Some 600.0; detail = "" })
   in
   Alcotest.check extract_testable
-    "HardQuota is not CapacityExhausted → None"
+    "HardQuota is not provider capacity → None"
     None
-    (FSM.sdk_error_capacity_exhausted_retry_after_s err)
+    (FSM.sdk_error_capacity_backpressure_retry_after_s err)
 
 let test_soft_rate_limited_helper_does_not_match_capacity () =
   (* Without the new helper, callers reaching only sdk_error_soft_rate_limited
-     would miss CapacityExhausted entirely — that's the bug this PR fixes.
+     would miss provider capacity entirely — that's the bug this PR fixes.
      This regression-pin keeps the two helpers semantically distinct. *)
-  let err = mk_capacity_exhausted ~retry_after:7.5 () in
+  let err = mk_capacity_backpressure ~retry_after:7.5 () in
   Alcotest.check extract_testable
-    "soft_rate_limited helper does NOT swallow CapacityExhausted"
+    "soft_rate_limited helper does NOT swallow provider capacity"
     None
     (FSM.sdk_error_soft_rate_limited err)
 
 let () =
-  Alcotest.run "cascade_capacity_exhausted_cooldown"
+  Alcotest.run "cascade_capacity_backpressure_cooldown"
     [ ( "typed extraction"
       , [ Alcotest.test_case
-            "CapacityExhausted with retry_after" `Quick
+            "provider capacity with retry_after" `Quick
             test_capacity_with_retry_after_extracted
         ; Alcotest.test_case
-            "CapacityExhausted without retry_after" `Quick
+            "provider capacity without retry_after" `Quick
             test_capacity_without_retry_after_extracted
         ; Alcotest.test_case
             "non-capacity error → None" `Quick test_non_capacity_error_returns_none
         ; Alcotest.test_case
             "HardQuota is distinct" `Quick test_hard_quota_returns_none
         ; Alcotest.test_case
-            "soft_rate_limited does not subsume CapacityExhausted"
+            "soft_rate_limited does not subsume provider capacity"
             `Quick
             test_soft_rate_limited_helper_does_not_match_capacity
         ] )

--- a/test/test_dashboard_oas_bridge.ml
+++ b/test/test_dashboard_oas_bridge.ml
@@ -349,7 +349,7 @@ let test_provider_error_counts_group_and_filter () =
     provider_error_count
       ~provider:"runtime"
       ~cascade:"primary"
-      ~kind:"capacity_exhausted"
+      ~kind:"capacity_backpressure"
       ~capacity_scope:"model"
       all
   in

--- a/test/test_dashboard_oas_bridge.ml
+++ b/test/test_dashboard_oas_bridge.ml
@@ -329,7 +329,7 @@ let provider_error_count ~provider ~cascade ~kind ~capacity_scope counts =
 let test_provider_error_counts_group_and_filter () =
   setup ();
   let rate_limit = P.RateLimit { retry_after = Some 2.0 } in
-  let capacity = P.CapacityExhausted { scope = `Model } in
+  let capacity = P.CapacityBackpressure { scope = `Model } in
   DOB.record_provider_error ~cascade_name:"primary" ~provider_id:"anthropic" rate_limit;
   DOB.record_provider_error ~cascade_name:"primary" ~provider_id:"anthropic" rate_limit;
   DOB.record_provider_error ~cascade_name:"primary" ~provider_id:"ollama" rate_limit;

--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -416,22 +416,6 @@ let test_dashboard_tools_projection () =
       | Some row ->
           check bool "local worker tool keeps local_worker surface" true
             (has_surface "local_worker" row));
-      (match deprecated_alias_tool with
-      | None -> ()
-      | Some row ->
-          check bool "deprecated alias has registered schema" true
-            (row |> member "registered_schema" |> to_bool);
-          check bool "deprecated alias has dispatch registration" true
-            (row |> member "dispatch_registered" |> to_bool);
-          check string "deprecated alias visibility surfaced" "hidden"
-            (row |> member "visibility" |> to_string);
-          check string "deprecated alias lifecycle surfaced" "deprecated"
-            (row |> member "lifecycle" |> to_string);
-          check string "deprecated alias replacement surfaced"
-            "masc_agent_update"
-            (row |> member "replacement" |> to_string);
-          check bool "deprecated alias not assigned a surface" false
-            (row |> member "surfaces" |> to_list <> []));
       match hidden_tool with
       | None -> ()
       | Some row ->

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -41,14 +41,14 @@ let test_stale_fleet_batch_blocker_class_roundtrip () =
   | Some _ -> fail "Stale_fleet_batch label parsed as wrong class"
   | None -> fail "Stale_fleet_batch label did not parse back"
 
-let test_capacity_exhausted_blocker_class_roundtrip () =
-  let cls = KT.Capacity_exhausted in
+let test_capacity_backpressure_blocker_class_roundtrip () =
+  let cls = KT.Capacity_backpressure in
   let label = KT.blocker_class_to_string cls in
   check string "label" "capacity_backpressure" label;
   match MC.blocker_class_of_serialized_string label with
-  | Some MC.Capacity_exhausted -> ()
-  | Some _ -> fail "Capacity_exhausted label parsed as wrong class"
-  | None -> fail "Capacity_exhausted label did not parse back"
+  | Some MC.Capacity_backpressure -> ()
+  | Some _ -> fail "Capacity_backpressure label parsed as wrong class"
+  | None -> fail "Capacity_backpressure label did not parse back"
 
 let test_blocker_class_labels_are_distinct () =
   let tt = KT.blocker_class_to_string KT.Turn_timeout in
@@ -143,8 +143,8 @@ let () =
             test_oas_timeout_budget_blocker_class_roundtrip;
           test_case "Stale_fleet_batch roundtrip" `Quick
             test_stale_fleet_batch_blocker_class_roundtrip;
-          test_case "Capacity_exhausted roundtrip" `Quick
-            test_capacity_exhausted_blocker_class_roundtrip;
+          test_case "Capacity_backpressure roundtrip" `Quick
+            test_capacity_backpressure_blocker_class_roundtrip;
           test_case "labels are distinct" `Quick
             test_blocker_class_labels_are_distinct;
         ] );

--- a/test/test_keeper_blocker_class_completion_contract.ml
+++ b/test/test_keeper_blocker_class_completion_contract.ml
@@ -102,9 +102,9 @@ let test_turn_livelock_text_maps () =
 
 let test_capacity_backpressure_text_maps () =
   check_capacity_class
-    "capacity-exhausted text"
+    "capacity-backpressure text"
     (B.blocker_class_of_string
-       "Internal error: [masc_oas_error] {\"kind\":\"capacity_exhausted\",\
+       "Internal error: [masc_oas_error] {\"kind\":\"capacity_backpressure\",\
         \"detail\":\"client capacity key glm is full\"}")
 
 let test_legacy_cascade_slot_full_text_stays_cascade_exhausted () =

--- a/test/test_keeper_blocker_class_completion_contract.ml
+++ b/test/test_keeper_blocker_class_completion_contract.ml
@@ -27,16 +27,16 @@ let check_completion_contract_class label cls_opt =
 
 let check_capacity_class label cls_opt =
   match cls_opt with
-  | Some KT.Capacity_exhausted -> ()
+  | Some KT.Capacity_backpressure -> ()
   | Some other ->
       let other_str = KT.blocker_class_to_string other in
       fail
         (Printf.sprintf
-           "%s mapped to %s, expected Capacity_exhausted"
+           "%s mapped to %s, expected Capacity_backpressure"
            label
            other_str)
   | None ->
-      fail (Printf.sprintf "%s returned None, expected Capacity_exhausted" label)
+      fail (Printf.sprintf "%s returned None, expected Capacity_backpressure" label)
 
 let check_cascade_class label cls_opt =
   match cls_opt with

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -89,7 +89,7 @@ let test_typed_capacity_backpressure_is_not_cascade_exhausted () =
   | None ->
     fail "typed capacity backpressure should be recoverable as capacity"
 
-let test_provider_capacity_exhausted_is_capacity_backpressure () =
+let test_provider_capacity_backpressure_is_recoverable () =
   let err =
     Agent_sdk.Error.Provider
       (Llm_provider.Error.CapacityExhausted
@@ -102,11 +102,11 @@ let test_provider_capacity_exhausted_is_capacity_backpressure () =
   in
   match KEC.recoverable_cascade_failure_reason err with
   | Some reason ->
-    check string "Provider CapacityExhausted -> capacity_backpressure"
+    check string "external provider capacity -> capacity_backpressure"
       "capacity_backpressure"
       (KEC.degraded_retry_reason_to_string reason)
   | None ->
-    fail "Provider CapacityExhausted should be recoverable as capacity"
+    fail "external provider capacity should be recoverable as capacity"
 
 let test_all_providers_failed_recoverable () =
   let err = make_cascade_exhausted KT.All_providers_failed in
@@ -456,8 +456,8 @@ let () =
             test_slot_full_other_detail_stays_legacy_cascade_exhausted;
           test_case "typed capacity backpressure is not cascade exhausted" `Quick
             test_typed_capacity_backpressure_is_not_cascade_exhausted;
-          test_case "provider CapacityExhausted is capacity backpressure" `Quick
-            test_provider_capacity_exhausted_is_capacity_backpressure;
+          test_case "provider capacity backpressure is recoverable" `Quick
+            test_provider_capacity_backpressure_is_recoverable;
           test_case "All_providers_failed is recoverable" `Quick
             test_all_providers_failed_recoverable;
           test_case "No_providers_available is recoverable" `Quick

--- a/test/test_keeper_failure_policy.ml
+++ b/test/test_keeper_failure_policy.ml
@@ -50,7 +50,7 @@ let test_operational_timeout_phase_aliases () =
       "no_first_token", Policy.First_token;
       "stream_idle", Policy.Stream_idle Policy.Streaming_unknown;
       "max_execution_time", Policy.Wall_clock;
-      "capacity_exhausted", Policy.Capacity_backpressure;
+      "capacity_backpressure", Policy.Capacity_backpressure;
     ]
   in
   List.iter

--- a/test/test_keeper_rollover_gate.ml
+++ b/test/test_keeper_rollover_gate.ml
@@ -41,7 +41,7 @@ let non_overflow_classes_are_not_matched () =
     KT.Cascade_exhausted KT.No_providers_available;
     KT.Cascade_exhausted KT.All_providers_failed;
     KT.Cascade_exhausted KT.Max_turns_exceeded;
-    KT.Capacity_exhausted;
+    KT.Capacity_backpressure;
     KT.Ambiguous_post_commit_timeout;
     KT.Ambiguous_post_commit_failure;
     KT.Autonomous_slot_wait_timeout;

--- a/test/test_keeper_runtime_trust_snapshot.ml
+++ b/test/test_keeper_runtime_trust_snapshot.ml
@@ -58,6 +58,13 @@ let make_meta name : Masc_mcp.Keeper_types.keeper_meta =
   | Error err -> Alcotest.fail ("meta fixture failed: " ^ err)
 ;;
 
+let append_execution_receipt config keeper_name json =
+  let store =
+    Masc_mcp.Keeper_types_support.keeper_execution_receipt_store config keeper_name
+  in
+  Dated_jsonl.append store json
+;;
+
 let drop_value reason =
   P.metric_value_or_zero
     P.metric_persistence_read_drops
@@ -117,6 +124,57 @@ let test_snapshot_counts_malformed_decision_rows () =
          (drop_value invalid_payload -. before_invalid_payload))
 ;;
 
+let test_snapshot_normalizes_legacy_capacity_receipt_projection () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> remove_tree base_dir)
+    (fun () ->
+       with_env "MASC_BASE_PATH" base_dir
+       @@ fun () ->
+       let config = Masc_mcp.Coord.default_config base_dir in
+       let keeper_name = "runtime-trust-legacy-capacity" in
+       let meta = make_meta keeper_name in
+       append_execution_receipt
+         config
+         keeper_name
+         (`Assoc
+             [ "schema", `String "keeper.execution_receipt.v1"
+             ; "recorded_at", `String "2026-05-20T17:32:38Z"
+             ; "keeper_name", `String keeper_name
+             ; "terminal_reason_code", `String "capacity_exhausted"
+             ; "outcome", `String "receipt_failed"
+             ; ( "error"
+               , `Assoc
+                   [ "kind", `String "internal"
+                   ; ( "message"
+                     , `String
+                         "Internal error: [masc_oas_error] \
+                          {\"kind\":\"capacity_exhausted\",\"source\":\"client_capacity\"}" )
+                   ] )
+             ; "ended_at", `String "2026-05-20T17:32:38Z"
+             ]);
+       let snapshot = K.snapshot_json ~config ~meta in
+       let open Yojson.Safe.Util in
+       Alcotest.(check string)
+         "latest terminal reason code normalized"
+         "capacity_backpressure"
+         (snapshot |> member "latest_terminal_reason" |> member "code" |> to_string);
+       let latest_receipt = snapshot |> member "latest_receipt" in
+       Alcotest.(check string)
+         "projected receipt code normalized"
+         "capacity_backpressure"
+         (latest_receipt |> member "terminal_reason_code" |> to_string);
+       Alcotest.(check bool)
+         "projected error message hides legacy internal kind"
+         false
+         (String_util.contains_substring
+            (latest_receipt |> member "error" |> member "message" |> to_string)
+            "\"kind\":\"capacity_exhausted\""))
+;;
+
 let () =
   Alcotest.run
     "keeper_runtime_trust_snapshot"
@@ -125,6 +183,10 @@ let () =
             "malformed decision rows increment drop metrics"
             `Quick
             test_snapshot_counts_malformed_decision_rows
+        ; Alcotest.test_case
+            "legacy capacity receipt projection is normalized"
+            `Quick
+            test_snapshot_normalizes_legacy_capacity_receipt_projection
         ] )
     ]
 ;;

--- a/test/test_keeper_runtime_trust_snapshot.ml
+++ b/test/test_keeper_runtime_trust_snapshot.ml
@@ -124,7 +124,7 @@ let test_snapshot_counts_malformed_decision_rows () =
          (drop_value invalid_payload -. before_invalid_payload))
 ;;
 
-let test_snapshot_normalizes_legacy_capacity_receipt_projection () =
+let test_snapshot_projects_capacity_backpressure_receipt () =
   Eio_main.run
   @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -135,7 +135,7 @@ let test_snapshot_normalizes_legacy_capacity_receipt_projection () =
        with_env "MASC_BASE_PATH" base_dir
        @@ fun () ->
        let config = Masc_mcp.Coord.default_config base_dir in
-       let keeper_name = "runtime-trust-legacy-capacity" in
+       let keeper_name = "runtime-trust-capacity-backpressure" in
        let meta = make_meta keeper_name in
        append_execution_receipt
          config
@@ -144,7 +144,7 @@ let test_snapshot_normalizes_legacy_capacity_receipt_projection () =
              [ "schema", `String "keeper.execution_receipt.v1"
              ; "recorded_at", `String "2026-05-20T17:32:38Z"
              ; "keeper_name", `String keeper_name
-             ; "terminal_reason_code", `String "capacity_exhausted"
+             ; "terminal_reason_code", `String "capacity_backpressure"
              ; "outcome", `String "receipt_failed"
              ; ( "error"
                , `Assoc
@@ -152,7 +152,7 @@ let test_snapshot_normalizes_legacy_capacity_receipt_projection () =
                    ; ( "message"
                      , `String
                          "Internal error: [masc_oas_error] \
-                          {\"kind\":\"capacity_exhausted\",\"source\":\"client_capacity\"}" )
+                          {\"kind\":\"capacity_backpressure\",\"source\":\"client_capacity\"}" )
                    ] )
              ; "ended_at", `String "2026-05-20T17:32:38Z"
              ]);
@@ -168,11 +168,11 @@ let test_snapshot_normalizes_legacy_capacity_receipt_projection () =
          "capacity_backpressure"
          (latest_receipt |> member "terminal_reason_code" |> to_string);
        Alcotest.(check bool)
-         "projected error message hides legacy internal kind"
-         false
+         "projected error message keeps canonical internal kind"
+         true
          (String_util.contains_substring
             (latest_receipt |> member "error" |> member "message" |> to_string)
-            "\"kind\":\"capacity_exhausted\""))
+            "\"kind\":\"capacity_backpressure\""))
 ;;
 
 let () =
@@ -184,9 +184,9 @@ let () =
             `Quick
             test_snapshot_counts_malformed_decision_rows
         ; Alcotest.test_case
-            "legacy capacity receipt projection is normalized"
+            "capacity backpressure receipt projection is canonical"
             `Quick
-            test_snapshot_normalizes_legacy_capacity_receipt_projection
+            test_snapshot_projects_capacity_backpressure_receipt
         ] )
     ]
 ;;

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -1581,7 +1581,7 @@ let test_operator_pause_not_auto_resumed () =
         baseline_auto_resume after_auto_resume)
 
 (* Regression guard for #17063/#17067: [auto_resume_after_sec = None] is the
-   manual/operator pause contract.  A [Capacity_exhausted] blocker from old
+   manual/operator pause contract.  A [Capacity_backpressure] blocker from old
    persisted metadata must not be treated as an implicit auto-resume policy. *)
 let test_capacity_blocker_without_resume_policy_not_auto_resumed () =
   Eio_main.run @@ fun env ->
@@ -1616,7 +1616,7 @@ let test_capacity_blocker_without_resume_policy_not_auto_resumed () =
                 Some
                   (KT.blocker_info_of_class
                      ~detail:"capacity exhausted before explicit resume policy"
-                     KT.Capacity_exhausted);
+                     KT.Capacity_backpressure);
             };
         }
       in
@@ -1652,7 +1652,7 @@ let test_capacity_blocker_without_resume_policy_not_auto_resumed () =
            check bool "capacity blocker stays recorded for operator inspection"
              true
              (match m.runtime.last_blocker with
-              | Some info -> info.klass = KT.Capacity_exhausted
+              | Some info -> info.klass = KT.Capacity_backpressure
               | None -> false)
        | Ok None -> fail "meta missing"
        | Error err -> fail ("read_meta failed: " ^ err));

--- a/test/test_oas_compat_cascade_fallback.ml
+++ b/test/test_oas_compat_cascade_fallback.ml
@@ -227,14 +227,14 @@ let test_provider_failure_capacity_cascades () =
       }
   in
   Alcotest.(check bool)
-    "ProviderFailure Capacity_exhausted must cascade"
+    "ProviderFailure capacity backpressure must cascade"
     true
     (Oas_compat.Http_client.should_cascade err);
   match Oas_compat.Http_client.classify err with
-  | Provider_capacity_exhausted -> ()
+  | Provider_capacity_backpressure -> ()
   | _ ->
       Alcotest.fail
-        "Capacity_exhausted must classify as Provider_capacity_exhausted"
+        "ProviderFailure capacity must classify as Provider_capacity_backpressure"
 
 let test_provider_failure_hard_quota_cascades () =
   let err =
@@ -455,7 +455,7 @@ let () =
         ] );
       ( "ProviderFailure — typed provider-local skips cascade",
         [
-          Alcotest.test_case "Capacity_exhausted classify + cascade"
+          Alcotest.test_case "provider capacity classify + cascade"
             `Quick test_provider_failure_capacity_cascades;
           Alcotest.test_case "Hard_quota classify + cascade + message"
             `Quick test_provider_failure_hard_quota_cascades;

--- a/test/test_provider_error.ml
+++ b/test/test_provider_error.ml
@@ -105,7 +105,7 @@ let test_rate_limit_can_be_capacity_exhausted () =
     check bool "capacity" true (P.is_capacity_exhausted error);
     check_json
       "json"
-      {|{"kind":"capacity_exhausted","scope":"provider","affected":["runtime"]}|}
+      {|{"kind":"capacity_backpressure","scope":"provider","affected":["runtime"]}|}
       error
   | _ -> fail "expected provider CapacityExhausted"
 ;;
@@ -284,7 +284,7 @@ let test_emit_sdk_provider_error_metric_rate_limit () =
 let test_emit_sdk_provider_error_metric_capacity_scope () =
   let before =
     counter_for
-      ~kind:"capacity_exhausted"
+      ~kind:"capacity_backpressure"
       ~provider:public_provider
       ~cascade_name:"primary"
       ~capacity_scope:"provider"
@@ -301,16 +301,16 @@ let test_emit_sdk_provider_error_metric_capacity_scope () =
          ~provider:"anthropic"
     |> expect_some
   in
-  check string "emitted kind" "capacity_exhausted" (P.to_error_kind emitted);
+  check string "emitted kind" "capacity_backpressure" (P.to_error_kind emitted);
   check
     (float 0.0001)
     "counter +1"
     (before +. 1.0)
-    (counter_for
-       ~kind:"capacity_exhausted"
-       ~provider:public_provider
-       ~cascade_name:"primary"
-       ~capacity_scope:"provider")
+       (counter_for
+          ~kind:"capacity_backpressure"
+          ~provider:public_provider
+          ~cascade_name:"primary"
+          ~capacity_scope:"provider")
 ;;
 
 let test_emit_sdk_provider_error_metric_skips_non_api () =

--- a/test/test_provider_error.ml
+++ b/test/test_provider_error.ml
@@ -56,11 +56,11 @@ let legacy_health_decision err =
 let typed_health_decision err =
   let error = OWN.sdk_error_to_provider_error ~provider:"anthropic" err in
   match error with
-  | Some (P.CapacityExhausted { scope = `Provider }) -> Hard_quota
+  | Some (P.CapacityBackpressure { scope = `Provider }) -> Hard_quota
   | Some (P.CliWrappedHardQuota _) -> Hard_quota
   | Some (P.RateLimit _) -> Soft_rate_limited
   | Some
-      ( P.CapacityExhausted { scope = `Model }
+      ( P.CapacityBackpressure { scope = `Model }
       | P.AuthError
       | P.ServerError _
       | P.InvalidRequest _
@@ -76,7 +76,7 @@ let test_rate_limit_maps_retry_after () =
     Retry.RateLimited { retry_after = Some 1.5; message = "too many requests" }
     |> OWN.retry_api_error_to_provider_error
          ~provider:" anthropic "
-         ~capacity_exhausted:false
+         ~capacity_backpressure:false
     |> expect_some
   in
   match error with
@@ -91,23 +91,23 @@ let test_rate_limit_maps_retry_after () =
   | _ -> fail "expected RateLimit"
 ;;
 
-let test_rate_limit_can_be_capacity_exhausted () =
+let test_rate_limit_can_be_capacity_backpressure () =
   let error =
     Retry.RateLimited { retry_after = None; message = "resource exhausted" }
     |> OWN.retry_api_error_to_provider_error
          ~provider:"claude_code:auto"
-         ~capacity_exhausted:true
+         ~capacity_backpressure:true
     |> expect_some
   in
   match error with
-  | P.CapacityExhausted { scope = `Provider } ->
+  | P.CapacityBackpressure { scope = `Provider } ->
     check (list string) "affected runtime lane" [ public_provider ] (P.affected_providers error);
-    check bool "capacity" true (P.is_capacity_exhausted error);
+    check bool "capacity" true (P.is_capacity_backpressure error);
     check_json
       "json"
       {|{"kind":"capacity_backpressure","scope":"provider","affected":["runtime"]}|}
       error
-  | _ -> fail "expected provider CapacityExhausted"
+  | _ -> fail "expected provider CapacityBackpressure"
 ;;
 
 let test_anthropic_invalid_request_specified_limit_body_pins_capacity () =
@@ -126,7 +126,7 @@ let test_anthropic_invalid_request_specified_limit_body_pins_capacity () =
     OWN.sdk_error_to_provider_error ~provider:"anthropic" sdk_error |> expect_some
   in
   match error with
-  | P.CapacityExhausted { scope = `Provider } ->
+  | P.CapacityBackpressure { scope = `Provider } ->
     check (list string) "affected runtime lane" [ public_provider ] (P.affected_providers error)
   | _ -> fail "expected specified-limit InvalidRequest to become capacity"
 ;;
@@ -144,21 +144,21 @@ let test_cli_hard_quota_wrapper_emits_capacity_variant () =
   in
   check bool "existing wrapper classifier" true (OWN.sdk_error_is_hard_quota sdk_error);
   match OWN.sdk_error_to_provider_error ~provider:"claude_code:auto" sdk_error with
-  | Some (P.CapacityExhausted { scope = `Provider } as error) ->
+  | Some (P.CapacityBackpressure { scope = `Provider } as error) ->
     check (list string) "affected runtime lane" [ public_provider ] (P.affected_providers error)
-  | Some error -> failf "expected CapacityExhausted, got %s" (P.to_error_kind error)
+  | Some error -> failf "expected CapacityBackpressure, got %s" (P.to_error_kind error)
   | None -> fail "expected provider_error"
 ;;
 
 let test_server_and_auth_errors_are_closed_variants () =
   let server =
     Retry.ServerError { status = 503; message = "overloaded" }
-    |> OWN.retry_api_error_to_provider_error ~provider:"openai" ~capacity_exhausted:false
+    |> OWN.retry_api_error_to_provider_error ~provider:"openai" ~capacity_backpressure:false
     |> expect_some
   in
   let auth =
     Retry.AuthError { message = "invalid key" }
-    |> OWN.retry_api_error_to_provider_error ~provider:"kimi" ~capacity_exhausted:false
+    |> OWN.retry_api_error_to_provider_error ~provider:"kimi" ~capacity_backpressure:false
     |> expect_some
   in
   match server, auth with
@@ -174,14 +174,14 @@ let test_non_capacity_invalid_request_preserves_reason () =
     Retry.InvalidRequest { message = reason }
     |> OWN.retry_api_error_to_provider_error
          ~provider:"anthropic"
-         ~capacity_exhausted:false
+         ~capacity_backpressure:false
     |> expect_some
   in
   match error with
   | P.InvalidRequest { reason = actual } ->
     check (list string) "affected runtime lane" [ public_provider ] (P.affected_providers error);
     check string "reason" reason actual;
-    check bool "not capacity" false (P.is_capacity_exhausted error)
+    check bool "not capacity" false (P.is_capacity_backpressure error)
   | _ -> fail "expected InvalidRequest"
 ;;
 
@@ -347,7 +347,7 @@ let () =
         ; test_case
             "rate limit can become capacity"
             `Quick
-            test_rate_limit_can_be_capacity_exhausted
+            test_rate_limit_can_be_capacity_backpressure
         ; test_case
             "Anthropic specified-limit body maps to capacity"
             `Quick


### PR DESCRIPTION
## Summary

- Retire MASC-owned `capacity_exhausted` runtime/provider wire labels in favor of `capacity_backpressure`.
- Keep dashboard/API receipt projection raw: historical execution receipt JSON is not rewritten at read time.
- Preserve only external upstream boundary names where OAS/LLM provider constructors still expose `CapacityExhausted`.
- Keep the #17063/#17067 contract intact: `auto_resume_after_sec = null` remains manual/operator pause, not an implicit auto-resume policy.
- Rebase onto current `origin/main` and repair the extracted operator tool-audit helper by passing its provider explicitly.
- Add the missing `operator_control_snapshot_tool_audit.mli` and operator schema export so structure/build gates stay closed after the main extraction.
- Refresh the runtime tunables catalog after the rebase.

## Verification

- `opam exec -- ocamlformat --check lib/operator/operator_control_snapshot_tool_audit.ml lib/operator/operator_control_snapshot_tool_audit.mli lib/operator/operator_control_snapshot.ml`
- `scripts/ocaml-structure-ratchet.sh`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- GitHub CI after latest push: `Build and Test`, `Health`, `Lint`, `OCaml Structure Ratchet`, `TLA+ Model Checking`, `ocamlformat-check`, and fundamental ratchets passed.
- Not completed locally: `scripts/dune-local.sh build lib/masc_mcp.cmxa` was queued behind unrelated Dune wrapper jobs and was stopped before execution. CI passed the build after push.

## Notes

- `Draft Auto-Merge Guard` and aggregate `CI Gate` are expected to fail while this PR remains draft / lacks a human-approved-ready label.
