### PR TITLE
fix(mcp): remove legacy caller identity fallbacks

### DIFF
--- a/lib/mcp_server_eio.mli
+++ b/lib/mcp_server_eio.mli
@@ -97,7 +97,7 @@ val create_state_eio :
 
     @param clock Eio time clock for Session_eio timeout operations
     @param sw Eio.Switch for structured concurrency
-    @param mcp_session_id Optional HTTP MCP session ID for agent_name persistence
+    @param mcp_session_id Optional HTTP MCP session ID for identity continuity
     @param state Server state
     @param request_str Raw JSON-RPC request string
     @return JSON response *)

--- a/lib/mcp_server_eio_caller_identity.ml
+++ b/lib/mcp_server_eio_caller_identity.ml
@@ -179,22 +179,13 @@ let resolve_explicit_joined_alias ~config ~room_initialized ~log_mcp_exn
 let resolve ~(config : Coord_utils_backend_setup.config) ~tool_name ~arguments ~identity ~cached_resolved_agent
     ~mcp_session_id ~auth_token ~internal_keeper_runtime ~room_initialized
     ~read_mcp_session_agent ~read_term_session_agent ~log_mcp_exn =
-  let arg_get_string_opt key =
-    match Safe_ops.json_string_opt key arguments with
-    | Some "" -> None
-    | other -> other
-  in
   let explicit_agent_name = caller_agent_name_from_arguments arguments in
   let has_explicit_agent_name = Option.is_some explicit_agent_name in
   let agent_name =
     resolve_initial_agent_name ~identity ~cached_resolved_agent ~mcp_session_id
       ~explicit_agent_name ~read_mcp_session_agent ~read_term_session_agent
   in
-  let token =
-    match auth_token with
-    | Some _ as token -> token
-    | None -> arg_get_string_opt "token"
-  in
+  let token = auth_token in
   let verified_internal_keeper_runtime =
     internal_keeper_runtime
     &&

--- a/lib/mcp_server_eio_caller_identity.ml
+++ b/lib/mcp_server_eio_caller_identity.ml
@@ -75,7 +75,7 @@ let resolve_owner_keeper_identity config owner_name =
   loop candidates
 
 let resolve_initial_agent_name ~identity ~cached_resolved_agent ~mcp_session_id
-    ~explicit_agent_name ~read_mcp_session_agent ~read_term_session_agent =
+    ~explicit_agent_name ~read_mcp_session_agent =
   let identity_session_prefix =
     let len = min 8 (String.length identity.Agent_identity.session_key) in
     if len = 0 then
@@ -97,17 +97,7 @@ let resolve_initial_agent_name ~identity ~cached_resolved_agent ~mcp_session_id
           else (
             match read_mcp_session_agent () with
             | Some name -> name
-            | None ->
-                if Option.is_some mcp_session_id then
-                  generated_fallback_agent_name
-                else (
-                  match read_term_session_agent () with
-                  | Some name ->
-                      Log.Mcp.warn
-                        "[deprecated] agent name resolved via /tmp TERM file — migrate to \
-                         Agent_identity";
-                      name
-                  | None -> generated_fallback_agent_name)))
+            | None -> generated_fallback_agent_name))
 
 let resolve_auth_fallback_agent_name
     ~(config : Coord_utils_backend_setup.config)
@@ -178,12 +168,12 @@ let resolve_explicit_joined_alias ~config ~room_initialized ~log_mcp_exn
 
 let resolve ~(config : Coord_utils_backend_setup.config) ~tool_name ~arguments ~identity ~cached_resolved_agent
     ~mcp_session_id ~auth_token ~internal_keeper_runtime ~room_initialized
-    ~read_mcp_session_agent ~read_term_session_agent ~log_mcp_exn =
+    ~read_mcp_session_agent ~log_mcp_exn =
   let explicit_agent_name = caller_agent_name_from_arguments arguments in
   let has_explicit_agent_name = Option.is_some explicit_agent_name in
   let agent_name =
     resolve_initial_agent_name ~identity ~cached_resolved_agent ~mcp_session_id
-      ~explicit_agent_name ~read_mcp_session_agent ~read_term_session_agent
+      ~explicit_agent_name ~read_mcp_session_agent
   in
   let token = auth_token in
   let verified_internal_keeper_runtime =
@@ -220,16 +210,8 @@ let resolve ~(config : Coord_utils_backend_setup.config) ~tool_name ~arguments ~
   in
   let persisted_agent_name () =
     if should_read_legacy_persisted_agent_name ~has_explicit_agent_name ~agent_name
-    then
-      match read_mcp_session_agent () with
-      | Some n -> Some n
-      | None ->
-          if Option.is_some mcp_session_id then
-            None
-          else
-            read_term_session_agent ()
-    else
-      None
+    then read_mcp_session_agent ()
+    else None
   in
   let agent_name =
     match persisted_agent_name () with

--- a/lib/mcp_server_eio_caller_identity.ml
+++ b/lib/mcp_server_eio_caller_identity.ml
@@ -13,9 +13,6 @@ type t = {
 let silent_auth_token_error_kind err =
   Auth_error_kind.to_string (Auth_error_kind.classify err)
 
-let should_read_legacy_persisted_agent_name ~has_explicit_agent_name ~agent_name =
-  (not has_explicit_agent_name) && Agent_name_kind.is_ephemeral agent_name
-
 let caller_agent_name_from_arguments arguments =
   let nonempty_nonunknown key =
     match Safe_ops.json_string_opt key arguments with
@@ -74,8 +71,7 @@ let resolve_owner_keeper_identity config owner_name =
   in
   loop candidates
 
-let resolve_initial_agent_name ~identity ~cached_resolved_agent ~mcp_session_id
-    ~explicit_agent_name ~read_mcp_session_agent =
+let resolve_initial_agent_name ~identity ~cached_resolved_agent ~explicit_agent_name =
   let identity_session_prefix =
     let len = min 8 (String.length identity.Agent_identity.session_key) in
     if len = 0 then
@@ -94,10 +90,8 @@ let resolve_initial_agent_name ~identity ~cached_resolved_agent ~mcp_session_id
       | None ->
           if identity.Agent_identity.agent_name <> "" then
             identity.Agent_identity.agent_name
-          else (
-            match read_mcp_session_agent () with
-            | Some name -> name
-            | None -> generated_fallback_agent_name))
+          else
+            generated_fallback_agent_name)
 
 let resolve_auth_fallback_agent_name
     ~(config : Coord_utils_backend_setup.config)
@@ -166,14 +160,13 @@ let resolve_explicit_joined_alias ~config ~room_initialized ~log_mcp_exn
   else
     agent_name
 
-let resolve ~(config : Coord_utils_backend_setup.config) ~tool_name ~arguments ~identity ~cached_resolved_agent
-    ~mcp_session_id ~auth_token ~internal_keeper_runtime ~room_initialized
-    ~read_mcp_session_agent ~log_mcp_exn =
+let resolve ~(config : Coord_utils_backend_setup.config) ~tool_name ~arguments ~identity
+    ~cached_resolved_agent ~auth_token ~internal_keeper_runtime ~room_initialized
+    ~log_mcp_exn =
   let explicit_agent_name = caller_agent_name_from_arguments arguments in
   let has_explicit_agent_name = Option.is_some explicit_agent_name in
   let agent_name =
-    resolve_initial_agent_name ~identity ~cached_resolved_agent ~mcp_session_id
-      ~explicit_agent_name ~read_mcp_session_agent
+    resolve_initial_agent_name ~identity ~cached_resolved_agent ~explicit_agent_name
   in
   let token = auth_token in
   let verified_internal_keeper_runtime =
@@ -207,20 +200,6 @@ let resolve ~(config : Coord_utils_backend_setup.config) ~tool_name ~arguments ~
       Some (direct_call_block_message tool_name)
     else
       None
-  in
-  let persisted_agent_name () =
-    if should_read_legacy_persisted_agent_name ~has_explicit_agent_name ~agent_name
-    then read_mcp_session_agent ()
-    else None
-  in
-  let agent_name =
-    match persisted_agent_name () with
-    | Some persisted
-      when Nickname.is_generated_nickname persisted
-           && (not has_explicit_agent_name)
-           && not (Nickname.is_generated_nickname agent_name) ->
-        persisted
-    | _ -> agent_name
   in
   let agent_name =
     resolve_auth_fallback_agent_name ~config ~token ~has_explicit_agent_name

--- a/lib/mcp_server_eio_caller_identity.mli
+++ b/lib/mcp_server_eio_caller_identity.mli
@@ -10,9 +10,6 @@ type t = {
   mode_gate_error : string option;
 }
 
-val should_read_legacy_persisted_agent_name :
-  has_explicit_agent_name:bool -> agent_name:string -> bool
-
 val caller_agent_name_from_arguments : Yojson.Safe.t -> string option
 
 val resolve :
@@ -21,10 +18,8 @@ val resolve :
   arguments:Yojson.Safe.t ->
   identity:Agent_identity.t ->
   cached_resolved_agent:string option ->
-  mcp_session_id:string option ->
   auth_token:string option ->
   internal_keeper_runtime:bool ->
   room_initialized:(unit -> bool) ->
-  read_mcp_session_agent:(unit -> string option) ->
   log_mcp_exn:(label:string -> exn -> unit) ->
   t

--- a/lib/mcp_server_eio_caller_identity.mli
+++ b/lib/mcp_server_eio_caller_identity.mli
@@ -26,6 +26,5 @@ val resolve :
   internal_keeper_runtime:bool ->
   room_initialized:(unit -> bool) ->
   read_mcp_session_agent:(unit -> string option) ->
-  read_term_session_agent:(unit -> string option) ->
   log_mcp_exn:(label:string -> exn -> unit) ->
   t

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -200,26 +200,12 @@ let execute_tool_eio
        | Eio.Io _ as exn ->
          Log.Misc.warn "write_mcp_session_agent: %s" (Printexc.to_string exn))
   in
-  let read_term_session_agent () =
-    if Option.is_some mcp_session_id
-    then None
-    else (
-      match Sys.getenv_opt "TERM_SESSION_ID" with
-      | None -> None
-      | Some sid ->
-        let file = Filename.concat agent_runtime_root (Printf.sprintf ".masc_agent_%s" sid) in
-        (try
-           let name = Fs_compat.load_file file |> String.trim in
-           if name = "" then None else Some name
-         with
-         | Sys_error _ -> None))
-  in
   let caller_identity =
     Mcp_server_eio_caller_identity.resolve ~config ~tool_name:name ~arguments
       ~identity ~cached_resolved_agent ~mcp_session_id ~auth_token
       ~internal_keeper_runtime
       ~room_initialized:(fun () -> !room_init_cached)
-      ~read_mcp_session_agent ~read_term_session_agent ~log_mcp_exn
+      ~read_mcp_session_agent ~log_mcp_exn
   in
   let agent_name = caller_identity.agent_name in
   let token = caller_identity.token in
@@ -358,22 +344,6 @@ let execute_tool_eio
          with
          | Invalid_argument _ -> fallback
        in
-       let write_term_session_agent nickname =
-         if Option.is_some mcp_session_id
-         then ()
-         else (
-           match Sys.getenv_opt "TERM_SESSION_ID" with
-           | None -> ()
-           | Some sid ->
-             let file = Filename.concat agent_runtime_root (Printf.sprintf ".masc_agent_%s" sid) in
-             (try Fs_compat.save_file file nickname with
-              | Eio.Cancel.Cancelled _ as e -> raise e
-              | e ->
-                Log.Misc.error
-                  "Failed to write agent file %s: %s"
-                  file
-                  (Printexc.to_string e)))
-       in
        (* Auto-init/auto-join for better UX.
      - Auto-init only when auth is disabled (avoid side effects in secured rooms).
      - Auto-join when allowed by auth (and safe for token-based auth). *)
@@ -471,7 +441,6 @@ let execute_tool_eio
                 Log.Mcp.info "Auto-joined for %s: %s -> %s" name agent_name nickname;
                 (* Persist nickname so subsequent calls can use it. *)
                 write_mcp_session_agent nickname;
-                write_term_session_agent nickname;
                 let (_ : Session.session) =
                   Session.register registry ~agent_name:nickname
                 in

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -8,14 +8,6 @@
 let log_mcp_exn = Mcp_server_eio_helpers.log_mcp_exn
 let wait_for_message_eio = Mcp_server_eio_helpers.wait_for_message_eio
 
-(* RFC-0084 host-config-cleanup-D — agent runtime root migration.
-   Resolves the host runtime root once at module-init from the typed
-   [Host_config.agent_runtime_root] field; the 5 cross-process
-   agent-identity scratch files below reference the bound name so a
-   future PR can flip the typed surface to a base-path-relative
-   layout without touching this module's call sites. *)
-let agent_runtime_root = (Host_config.host ()).agent_runtime_root
-
 (* #10699 Family A — "Join required" surfaces 28 / 24h events for
    masc_transition + masc_claim_next while the underlying keeper had
    joined under its canonical name at boot via
@@ -96,12 +88,6 @@ let resolve_join_state ~room_initialized ~join_required ~agent_name ~base_path ~
       | Error _ -> false))
 ;;
 
-
-let should_read_legacy_persisted_agent_name ~has_explicit_agent_name ~agent_name =
-  Mcp_server_eio_caller_identity.should_read_legacy_persisted_agent_name
-    ~has_explicit_agent_name ~agent_name
-;;
-
 let caller_agent_name_from_arguments arguments =
   Mcp_server_eio_caller_identity.caller_agent_name_from_arguments arguments
 ;;
@@ -145,7 +131,7 @@ let execute_tool_eio
       ~arguments
   =
   (* clock parameter used for Session_eio.wait_for_message *)
-  (* mcp_session_id: HTTP MCP session ID for agent_name persistence across tool calls *)
+  (* mcp_session_id: HTTP MCP session ID for in-process identity continuity. *)
   let module U = Yojson.Safe.Util in
   (* Defensive: refresh Eio global context for downstream helpers that still
      consult the ambient switch/clock during a request. Tests may leave a
@@ -161,51 +147,23 @@ let execute_tool_eio
      Updated after auto-init succeeds. *)
   let room_init_cached = ref (Coord.is_initialized config) in
   (* Fix 4: Check resolved-name cache for fast identity resolution.
-     On 2nd+ call in the same MCP session, the cached name lets us skip
-     legacy /tmp file reads in the fallback paths below. *)
+     On 2nd+ call in the same MCP session, the cached name preserves the
+     nickname selected by the prior join without relying on sidecar files. *)
   let cached_resolved_agent =
     Option.bind mcp_session_id Agent_registry_eio.get_resolved_name
   in
   let identity = Agent_registry_eio.get_or_create_identity ?mcp_session_id arguments in
   Log.Mcp.debug "[Identity] %s" (Agent_identity.to_display_string identity);
-  (* Deprecated: /tmp file-based agent identity. Use Agent_identity system instead.
-     Kept for backward compat with pre-identity MCP clients. Remove when
-     deprecation log shows zero hits over a release cycle. *)
-  let read_mcp_session_agent () =
-    match mcp_session_id with
-    | None -> None
-    | Some sid ->
-      let file = Filename.concat agent_runtime_root (Printf.sprintf ".masc_agent_mcp_%s" sid) in
-      (try
-         let name = Fs_compat.load_file file |> String.trim in
-         if name = ""
-         then None
-         else (
-           Log.Mcp.warn
-             "[deprecated] agent name resolved via /tmp file for session %s — migrate to \
-              Agent_identity"
-             sid;
-           Some name)
-       with
-       | Sys_error _ | Eio.Io _ -> None)
-  in
-  (* Deprecated: write agent name to /tmp file. *)
-  let write_mcp_session_agent agent_name =
+  let record_mcp_session_agent agent_name =
     match mcp_session_id with
     | None -> ()
-    | Some sid ->
-      let file = Filename.concat agent_runtime_root (Printf.sprintf ".masc_agent_mcp_%s" sid) in
-      (try Fs_compat.save_file file agent_name with
-       | Sys_error msg -> Log.Misc.warn "write_mcp_session_agent: %s" msg
-       | Eio.Io _ as exn ->
-         Log.Misc.warn "write_mcp_session_agent: %s" (Printexc.to_string exn))
+    | Some sid -> Agent_registry_eio.set_resolved_name sid agent_name
   in
   let caller_identity =
     Mcp_server_eio_caller_identity.resolve ~config ~tool_name:name ~arguments
-      ~identity ~cached_resolved_agent ~mcp_session_id ~auth_token
-      ~internal_keeper_runtime
+      ~identity ~cached_resolved_agent ~auth_token ~internal_keeper_runtime
       ~room_initialized:(fun () -> !room_init_cached)
-      ~read_mcp_session_agent ~log_mcp_exn
+      ~log_mcp_exn
   in
   let agent_name = caller_identity.agent_name in
   let token = caller_identity.token in
@@ -214,10 +172,8 @@ let execute_tool_eio
   in
   let owner_keeper_identity = caller_identity.owner_keeper_identity in
   let mode_gate_error = caller_identity.mode_gate_error in
-  (* Cache resolved agent_name for this session (Fix 4) *)
-  (match mcp_session_id with
-   | Some sid -> Agent_registry_eio.set_resolved_name sid agent_name
-   | None -> ());
+  (* Cache resolved agent_name for this session (Fix 4). *)
+  record_mcp_session_agent agent_name;
   let is_system_internal_tool =
     Tool_catalog.is_on_surface Tool_catalog.System_internal name
   in
@@ -439,8 +395,8 @@ let execute_tool_eio
                   extract_nickname_from_join_result ~fallback:agent_name join_result
                 in
                 Log.Mcp.info "Auto-joined for %s: %s -> %s" name agent_name nickname;
-                (* Persist nickname so subsequent calls can use it. *)
-                write_mcp_session_agent nickname;
+                (* Remember nickname so subsequent calls in this MCP session can use it. *)
+                record_mcp_session_agent nickname;
                 let (_ : Session.session) =
                   Session.register registry ~agent_name:nickname
                 in
@@ -720,7 +676,7 @@ let execute_tool_eio
                      ; clock
                      ; arguments = coerced_args
                      ; mcp_session_id
-                     ; write_mcp_session_agent
+                     ; record_mcp_session_agent
                      ; wait_for_message =
                          (fun registry ~agent_name ~timeout ->
                            wait_for_message_eio ~clock registry ~agent_name ~timeout)

--- a/lib/mcp_server_eio_execute.mli
+++ b/lib/mcp_server_eio_execute.mli
@@ -2,12 +2,10 @@
     plus the join-state resolver shared with the keeper
     onboarding path.
 
-    The .ml is 919 lines.  Only a small set of entries reach callers:
-    - {!resolve_join_state} and
-      {!should_read_legacy_persisted_agent_name} —
-      [test/test_mcp_server_eio.ml] exercises both to
-      verify the join-required + ephemeral-name fallback
-      decisions stay consistent across refactors.
+    Only a small set of entries reach callers:
+    - {!resolve_join_state} —
+      [test/test_mcp_server_eio.ml] exercises the join-required
+      decisions to keep alias handling consistent across refactors.
     - {!caller_agent_name_from_arguments} — isolates the
       HTTP [_agent_name] vs legacy [agent_name] precedence
       contract without running the full dispatcher.
@@ -47,27 +45,10 @@ val resolve_join_state :
     - [agent_name = "unknown"] → [false] (sentinel name).
     - Otherwise probes [check_join agent_name]; on miss,
       tries an alias chain via {!Agent_name_kind.is_ephemeral}
-      and the [base_path]-derived persisted name lookup.
+      and the [base_path]-derived identity aliases.
 
     [check_join] is injected so tests can drive the
     resolver against a deterministic registry. *)
-
-(** {1 Legacy ephemeral fallback} *)
-
-val should_read_legacy_persisted_agent_name :
-  has_explicit_agent_name:bool ->
-  agent_name:string ->
-  bool
-(** Returns [true] when the dispatcher should attempt to
-    recover an agent_name from the legacy persisted
-    sidecar (used by the operator surface during the
-    transition off the persisted name file).
-
-    Triggers iff the request did not pass [agent_name]
-    explicitly AND the resolved [agent_name] is in the
-    {b ephemeral} class ([_ephemeral_*] / unknown
-    sentinels).  Tested directly to keep the legacy /
-    explicit path split honest. *)
 
 val caller_agent_name_from_arguments : Yojson.Safe.t -> string option
 (** Returns the explicit caller identity carried in [tools/call]

--- a/lib/server/server_mcp_actor_injection.ml
+++ b/lib/server/server_mcp_actor_injection.ml
@@ -3,8 +3,9 @@
     canonical caller identity, so a stale browser-supplied [_agent_name]
     must be overwritten. The legacy argument-scoped [token] is also removed
     when HTTP auth is present so stale MCP bodies cannot override the
-    transport token. Legacy [agent_name] is left untouched because some tools
-    use it as a domain argument rather than caller identity. *)
+    transport token; without HTTP auth, caller identity resolution ignores the
+    argument token. Legacy [agent_name] is left untouched because some tools use
+    it as a domain argument rather than caller identity. *)
 let inject_agent_name_into_body ?(rewrite_existing = false) ?(strip_token = false)
     ~agent_name body_str =
   try

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -41,7 +41,7 @@ type context = Tool_inline_dispatch_types.context = {
   clock : float Eio.Time.clock_ty Eio.Resource.t;
   arguments : Yojson.Safe.t;
   mcp_session_id : string option;
-  write_mcp_session_agent : string -> unit;
+  record_mcp_session_agent : string -> unit;
   wait_for_message :
     Session.registry ->
     agent_name:string ->

--- a/lib/tool_inline_dispatch.mli
+++ b/lib/tool_inline_dispatch.mli
@@ -19,7 +19,7 @@ type context = Tool_inline_dispatch_types.context = {
   clock : float Eio.Time.clock_ty Eio.Resource.t;
   arguments : Yojson.Safe.t;
   mcp_session_id : string option;
-  write_mcp_session_agent : string -> unit;
+  record_mcp_session_agent : string -> unit;
   wait_for_message :
     Session.registry ->
     agent_name:string ->

--- a/lib/tool_inline_dispatch_coord.ml
+++ b/lib/tool_inline_dispatch_coord.ml
@@ -23,12 +23,6 @@ module Float = Stdlib.Float
 
 open Tool_inline_dispatch_types
 
-(* RFC-0084 host-config-cleanup-D — agent runtime root migration.
-   Resolves the host runtime root once at module-init from the typed
-   [Host_config.agent_runtime_root] field; the 2 cross-process
-   agent-identity scratch files below reference the bound name. *)
-let agent_runtime_root = (Host_config.host ()).agent_runtime_root
-
 (** Argument extraction helpers bound to ctx.arguments. *)
 let arg_get_string ctx key default =
   Safe_ops.json_string ~default key ctx.arguments
@@ -223,19 +217,10 @@ let handle_join ~tool_name ~start_time (ctx : context) : tool_result option =
       with Invalid_argument _ -> agent_name
     in
     let _ = Session.register registry ~agent_name:nickname in
-    ctx.write_mcp_session_agent nickname;
-    Log.Misc.debug "[sid=%s] masc_join: saved nickname=%s to MCP session (original=%s)" sid nickname agent_name;
-    if Option.is_none mcp_session_id then begin
-      Log.Misc.warn "[sid=%s] [deprecated] writing agent name to /tmp file for TERM session — migrate to Agent_identity" sid;
-      let term_session_id = Option.value ~default:"default" (Sys.getenv_opt "TERM_SESSION_ID") in
-      let agent_file = Filename.concat agent_runtime_root (Printf.sprintf ".masc_agent_%s" term_session_id) in
-      (try
-        Fs_compat.save_file agent_file nickname
-      with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | e ->
-        Log.Misc.error "[sid=%s] Failed to write agent file %s: %s" sid agent_file (Stdlib.Printexc.to_string e))
-    end;
+    ctx.record_mcp_session_agent nickname;
+    Log.Misc.debug
+      "[sid=%s] masc_join: recorded nickname=%s for MCP session (original=%s)"
+      sid nickname agent_name;
     let institution_welcome = match state.Mcp_server.fs with
       | Some fs ->
           (try Institution_eio.load_and_format_for_welcome ~fs config
@@ -296,7 +281,6 @@ let handle_leave ~tool_name ~start_time (ctx : context) : tool_result option =
   let agent_name = ctx.agent_name in
   let registry = ctx.registry in
   let state = ctx.state in
-  let mcp_session_id = ctx.mcp_session_id in
   let leave_event = `Assoc [
     ("type", `String "masc/agent_left");
     ("agent_name", `String agent_name);
@@ -306,9 +290,4 @@ let handle_leave ~tool_name ~start_time (ctx : context) : tool_result option =
   Mcp_server.sse_broadcast state leave_event;
   let result = Coord.leave config ~agent_name in
   Session.unregister registry ~agent_name;
-  if Option.is_none mcp_session_id then begin
-    let session_id = Option.value ~default:"default" (Sys.getenv_opt "TERM_SESSION_ID") in
-    let agent_file = Filename.concat agent_runtime_root (Printf.sprintf ".masc_agent_%s" session_id) in
-    Safe_ops.remove_file_logged ~context:"masc_leave" agent_file
-  end;
   Some (Tool_result.ok ~tool_name ~start_time result)

--- a/lib/tool_inline_dispatch_types.ml
+++ b/lib/tool_inline_dispatch_types.ml
@@ -33,8 +33,8 @@ type context = {
   clock : float Eio.Time.clock_ty Eio.Resource.t;
   arguments : Yojson.Safe.t;
   mcp_session_id : string option;
-  (** Write agent name to MCP session file for HTTP persistence *)
-  write_mcp_session_agent : string -> unit;
+  (** Record the resolved agent name for this MCP session. *)
+  record_mcp_session_agent : string -> unit;
   (** Wait for a message from a given agent *)
   wait_for_message :
     Session.registry ->

--- a/lib/tool_inline_dispatch_types.mli
+++ b/lib/tool_inline_dispatch_types.mli
@@ -20,8 +20,8 @@ type context = {
   clock : float Eio.Time.clock_ty Eio.Resource.t;
   arguments : Yojson.Safe.t;
   mcp_session_id : string option;
-  write_mcp_session_agent : string -> unit;
-      (** Write agent name to MCP session file for HTTP persistence. *)
+  record_mcp_session_agent : string -> unit;
+      (** Record the resolved agent name for this MCP session. *)
   wait_for_message :
     Session.registry ->
     agent_name:string ->

--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -31,8 +31,8 @@ lib/process/process_eio.ml:535
 # manager itself. Bounded by session scope, not by per-call timeout.
 lib/server/lsp_process_manager.ml:178
 
-# lib/worker_dev_tools.ml:1204 — dev-tools worker spawn. Wrapped by
+# lib/worker_dev_tools.ml:703 — dev-tools worker spawn. Wrapped by
 # Tool_resource_gate, Fd_accountant, Eio.Time.with_timeout_exn, and a fresh
 # Eio.Switch.run at the call boundary. Line renumbered by worker-dev-tools
 # split/refactor waves.
-lib/worker_dev_tools.ml:1204
+lib/worker_dev_tools.ml:703

--- a/test/test_host_config_resolution.ml
+++ b/test/test_host_config_resolution.ml
@@ -63,10 +63,10 @@ let test_resolve_with_base_path () =
   | Ok t ->
     (check bool)
       "agent_runtime_root is base-path-relative \
-       (RFC-0084 §1.5 migration target for /tmp/.masc_agent_* 7 sites)"
+       (RFC-0084 §1.5 typed runtime root)"
       true
       (String.length t.agent_runtime_root > 0
-       && t.agent_runtime_root <> "/tmp/.masc_agent");
+       && String.starts_with ~prefix:"/tmp/test-masc/" t.agent_runtime_root);
     (check bool)
       "cred_root is base-path-relative when explicit base provided"
       true

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1797,13 +1797,13 @@ let test_execute_tool_http_auth_token_overrides_stale_argument_token () =
     result.token;
   cleanup_dir base_path
 
-let test_execute_tool_legacy_argument_token_still_authorizes_without_http_auth () =
+let test_execute_tool_legacy_argument_token_ignored_without_http_auth () =
   let base_path = temp_dir () in
   let config = Masc_mcp.Coord.default_config base_path in
   let identity =
     test_agent_identity
-      ~uuid:"legacy-token-fallback-test"
-      ~session_key:"legacy-token-fallback-session"
+      ~uuid:"legacy-token-ignored-test"
+      ~session_key:"legacy-token-ignored-session"
   in
   let result =
     Masc_mcp.Mcp_server_eio_caller_identity.resolve ~config
@@ -1817,8 +1817,8 @@ let test_execute_tool_legacy_argument_token_still_authorizes_without_http_auth (
       ~log_mcp_exn:(fun ~label:_ _ -> ())
   in
   Alcotest.(check (option string))
-    "legacy argument token remains fallback without HTTP auth"
-    (Some "legacy-argument-token")
+    "legacy argument token ignored without HTTP auth"
+    None
     result.token;
   cleanup_dir base_path
 
@@ -3011,8 +3011,8 @@ let eio_tests = [
     test_execute_tool_add_task_with_admin_token_without_join;
   "http auth token overrides stale argument token", `Quick,
     test_execute_tool_http_auth_token_overrides_stale_argument_token;
-  "legacy argument token still authorizes without http auth", `Quick,
-    test_execute_tool_legacy_argument_token_still_authorizes_without_http_auth;
+  "legacy argument token ignored without http auth", `Quick,
+    test_execute_tool_legacy_argument_token_ignored_without_http_auth;
   "mcp session ignores term persistence", `Quick, test_execute_tool_mcp_session_ignores_term_persistence;
   (* Legacy governance convo room test removed *)
 ]

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1435,18 +1435,16 @@ let test_execute_tool_explicit_agent_name_not_overridden () =
   let resolve arguments =
     Masc_mcp.Mcp_server_eio_caller_identity.resolve ~config
       ~tool_name:"masc_join" ~arguments ~identity
-      ~cached_resolved_agent:(Some "persisted-stale-nickname")
-      ~mcp_session_id:(Some "mcp-explicit-agent-name-regression")
+      ~cached_resolved_agent:(Some "cached-stale-nickname")
       ~auth_token:None ~internal_keeper_runtime:false
       ~room_initialized:(fun () -> false)
-      ~read_mcp_session_agent:(fun () -> Some "persisted-stale-nickname")
       ~log_mcp_exn:(fun ~label:_ _ -> ())
   in
   let codex =
     resolve (`Assoc [ ("agent_name", `String "codex") ])
   in
   Alcotest.(check string)
-    "explicit legacy agent_name wins over stale cache"
+    "explicit agent_name wins over stale cache"
     "codex" codex.agent_name;
   let gemini =
     resolve (`Assoc [ ("_agent_name", `String "gemini"); ("agent_name", `String "codex") ])
@@ -1454,6 +1452,11 @@ let test_execute_tool_explicit_agent_name_not_overridden () =
   Alcotest.(check string)
     "internal _agent_name wins over legacy agent_name"
     "gemini" gemini.agent_name;
+  let cached = resolve (`Assoc []) in
+  Alcotest.(check string)
+    "cached session identity wins over generated fallback"
+    "cached-stale-nickname"
+    cached.agent_name;
 
   cleanup_dir base_path
 
@@ -1473,10 +1476,8 @@ let test_execute_tool_explicit_alias_reuses_joined_nickname () =
       ~tool_name:"masc_transition"
       ~arguments:(`Assoc [ ("agent_name", `String "alpha-agent") ])
       ~identity ~cached_resolved_agent:None
-      ~mcp_session_id:(Some "mcp-explicit-alias-reuse-regression")
       ~auth_token:None ~internal_keeper_runtime:false
       ~room_initialized:(fun () -> true)
-      ~read_mcp_session_agent:(fun () -> None)
       ~log_mcp_exn:(fun ~label:_ _ -> ())
   in
   Alcotest.(check string)
@@ -1781,11 +1782,10 @@ let test_execute_tool_http_auth_token_overrides_stale_argument_token () =
     Masc_mcp.Mcp_server_eio_caller_identity.resolve ~config
       ~tool_name:"masc_status"
       ~arguments:(`Assoc [ ("token", `String "stale-argument-token") ])
-      ~identity ~cached_resolved_agent:None ~mcp_session_id:None
+      ~identity ~cached_resolved_agent:None
       ~auth_token:(Some "http-auth-token")
       ~internal_keeper_runtime:false
       ~room_initialized:(fun () -> true)
-      ~read_mcp_session_agent:(fun () -> None)
       ~log_mcp_exn:(fun ~label:_ _ -> ())
   in
   Alcotest.(check (option string))
@@ -1806,10 +1806,9 @@ let test_execute_tool_legacy_argument_token_ignored_without_http_auth () =
     Masc_mcp.Mcp_server_eio_caller_identity.resolve ~config
       ~tool_name:"masc_status"
       ~arguments:(`Assoc [ ("token", `String "legacy-argument-token") ])
-      ~identity ~cached_resolved_agent:None ~mcp_session_id:None
+      ~identity ~cached_resolved_agent:None
       ~auth_token:None ~internal_keeper_runtime:false
       ~room_initialized:(fun () -> true)
-      ~read_mcp_session_agent:(fun () -> None)
       ~log_mcp_exn:(fun ~label:_ _ -> ())
   in
   Alcotest.(check (option string))
@@ -1831,10 +1830,8 @@ let test_execute_tool_without_mcp_session_uses_generated_identity () =
       ~tool_name:"masc_broadcast"
       ~arguments:(`Assoc [ ("message", `String "generated identity check") ])
       ~identity ~cached_resolved_agent:None
-      ~mcp_session_id:None
       ~auth_token:None ~internal_keeper_runtime:false
       ~room_initialized:(fun () -> true)
-      ~read_mcp_session_agent:(fun () -> None)
       ~log_mcp_exn:(fun ~label:_ _ -> ())
   in
   Alcotest.(check string)

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1440,7 +1440,6 @@ let test_execute_tool_explicit_agent_name_not_overridden () =
       ~auth_token:None ~internal_keeper_runtime:false
       ~room_initialized:(fun () -> false)
       ~read_mcp_session_agent:(fun () -> Some "persisted-stale-nickname")
-      ~read_term_session_agent:(fun () -> Some "term-stale-nickname")
       ~log_mcp_exn:(fun ~label:_ _ -> ())
   in
   let codex =
@@ -1478,7 +1477,6 @@ let test_execute_tool_explicit_alias_reuses_joined_nickname () =
       ~auth_token:None ~internal_keeper_runtime:false
       ~room_initialized:(fun () -> true)
       ~read_mcp_session_agent:(fun () -> None)
-      ~read_term_session_agent:(fun () -> None)
       ~log_mcp_exn:(fun ~label:_ _ -> ())
   in
   Alcotest.(check string)
@@ -1788,7 +1786,6 @@ let test_execute_tool_http_auth_token_overrides_stale_argument_token () =
       ~internal_keeper_runtime:false
       ~room_initialized:(fun () -> true)
       ~read_mcp_session_agent:(fun () -> None)
-      ~read_term_session_agent:(fun () -> None)
       ~log_mcp_exn:(fun ~label:_ _ -> ())
   in
   Alcotest.(check (option string))
@@ -1813,7 +1810,6 @@ let test_execute_tool_legacy_argument_token_ignored_without_http_auth () =
       ~auth_token:None ~internal_keeper_runtime:false
       ~room_initialized:(fun () -> true)
       ~read_mcp_session_agent:(fun () -> None)
-      ~read_term_session_agent:(fun () -> None)
       ~log_mcp_exn:(fun ~label:_ _ -> ())
   in
   Alcotest.(check (option string))
@@ -1822,28 +1818,29 @@ let test_execute_tool_legacy_argument_token_ignored_without_http_auth () =
     result.token;
   cleanup_dir base_path
 
-let test_execute_tool_mcp_session_ignores_term_persistence () =
+let test_execute_tool_without_mcp_session_uses_generated_identity () =
   let base_path = temp_dir () in
   let config = Masc_mcp.Coord.default_config base_path in
   let identity =
-    test_agent_identity ~uuid:"mcp-term-isolation-test" ~session_key:"mcpterm00"
+    test_agent_identity
+      ~uuid:"generated-identity-no-session-test"
+      ~session_key:"nosess00"
   in
   let result =
     Masc_mcp.Mcp_server_eio_caller_identity.resolve ~config
       ~tool_name:"masc_broadcast"
-      ~arguments:(`Assoc [ ("message", `String "term isolation check") ])
+      ~arguments:(`Assoc [ ("message", `String "generated identity check") ])
       ~identity ~cached_resolved_agent:None
-      ~mcp_session_id:(Some "mcp-term-isolation-regression")
+      ~mcp_session_id:None
       ~auth_token:None ~internal_keeper_runtime:false
       ~room_initialized:(fun () -> true)
       ~read_mcp_session_agent:(fun () -> None)
-      ~read_term_session_agent:(fun () -> Some "intruder-sage-tiger")
       ~log_mcp_exn:(fun ~label:_ _ -> ())
   in
-  Alcotest.(check bool)
-    "mcp session must not reuse TERM_SESSION_ID persisted nickname"
-    false
-    (String.equal "intruder-sage-tiger" result.agent_name);
+  Alcotest.(check string)
+    "generated fallback"
+    "agent-nosess00"
+    result.agent_name;
 
   cleanup_dir base_path
 
@@ -3013,7 +3010,8 @@ let eio_tests = [
     test_execute_tool_http_auth_token_overrides_stale_argument_token;
   "legacy argument token ignored without http auth", `Quick,
     test_execute_tool_legacy_argument_token_ignored_without_http_auth;
-  "mcp session ignores term persistence", `Quick, test_execute_tool_mcp_session_ignores_term_persistence;
+  "without mcp session uses generated identity", `Quick,
+    test_execute_tool_without_mcp_session_uses_generated_identity;
   (* Legacy governance convo room test removed *)
 ]
 

--- a/test/test_mcp_server_eio_join_state.ml
+++ b/test/test_mcp_server_eio_join_state.ml
@@ -77,24 +77,6 @@ let test_resolve_join_state_unknown_alias_stays_false () =
   in
   Alcotest.(check bool) "non-keeper input stays unjoined" false joined
 
-let test_should_read_legacy_persisted_agent_name () =
-  let should_read =
-    Masc_mcp.Mcp_server_eio_caller_identity
-    .should_read_legacy_persisted_agent_name
-  in
-  Alcotest.(check bool)
-    "ephemeral fallback reads legacy state"
-    true
-    (should_read ~has_explicit_agent_name:false ~agent_name:"agent-12345678");
-  Alcotest.(check bool)
-    "stable nickname skips legacy read"
-    false
-    (should_read ~has_explicit_agent_name:false ~agent_name:"codex-swift-fox");
-  Alcotest.(check bool)
-    "explicit agent name skips legacy read"
-    false
-    (should_read ~has_explicit_agent_name:true ~agent_name:"agent-12345678")
-
 let () =
   Alcotest.run
     "Mcp_server_eio_join_state"
@@ -114,8 +96,5 @@ let () =
         ; ( "resolve_join_state unknown alias stays false"
           , `Quick
           , test_resolve_join_state_unknown_alias_stays_false )
-        ; ( "legacy persisted agent read only for ephemeral names"
-          , `Quick
-          , test_should_read_legacy_persisted_agent_name )
         ] )
     ]

--- a/test/test_pr_d_agent_runtime_migration.ml
+++ b/test/test_pr_d_agent_runtime_migration.ml
@@ -1,29 +1,15 @@
 open Alcotest
 
-(** RFC-0084 host-config-cleanup-D — agent runtime root migration.
+(** RFC-0084 host-config-cleanup-D — retired agent scratch-file runtime.
 
-    PR-D migrates the 7 cross-process agent-identity scratch-file
-    literals (`/tmp/.masc_agent[_mcp]_<sid>`) across 2 modules to
-    the typed [Host_config.agent_runtime_root] field:
-
-    - lib/mcp_server_eio_execute.ml (5 sites at 191, 210, 253, 331,
-      570 in PR-1 audit; lines may have shifted by ±N after PR-D's
-      module-init binding inserted earlier in the file)
-    - lib/tool_inline_dispatch_coord.ml (2 sites at 187, 267)
-
-    Each module has its own module-init binding because the modules
-    don't share a common ancestor other than [Host_config] itself.
-
-    Out of PR-D scope (intentional, separate follow-up cleanup):
-    - The [Sys.getenv_opt "TERM_SESSION_ID" |> Option.value
-      ~default:"default"] silent-collision issue documented in
-      03-hardcode-path-audit.md Top10 #5.  PR-D is a pure
-      typed-surface migration; the [default:"default"] fail-loud
-      conversion belongs in its own PR so its behaviour change
-      lands in isolation. *)
+    The old `/tmp/.masc_agent[_mcp]_<sid>` bridge was first moved behind
+    [Host_config.agent_runtime_root], then removed once
+    [Agent_registry_eio] owned MCP-session identity continuity.  This
+    ratchet keeps the old sidecar file surface from coming back in the
+    dispatcher modules. *)
 
 let pinned_tmp_agent_literal_count = 0
-let pinned_agent_runtime_root_binding_count = 2
+let pinned_agent_runtime_root_binding_count = 0
 
 let read_file path =
   match In_channel.with_open_text path In_channel.input_all with
@@ -73,7 +59,7 @@ let test_no_tmp_agent_literals_in_consumers () =
   in
   (check int)
     "literal occurrences of `/tmp/.masc_agent[_mcp]_<sid>` in the 2 \
-     consumer modules must be 0 after PR-D"
+     consumer modules must remain 0"
     pinned_tmp_agent_literal_count total
 ;;
 
@@ -83,8 +69,7 @@ let test_agent_runtime_root_binding_count () =
       ~needle:"Host_config.host ()"
   in
   (check int)
-    "Host_config.host invoked exactly once per \
-     consumer module (2 modules)"
+    "dispatcher modules no longer bind Host_config.agent_runtime_root"
     pinned_agent_runtime_root_binding_count occurrences
 ;;
 
@@ -99,7 +84,7 @@ let test_agent_runtime_root_field_value () =
 
 let () =
   run
-    "PR-D host-config-cleanup-D (agent runtime root)"
+    "agent scratch-file runtime ratchet"
     [ ( "pr-d-agent-runtime"
       , [ test_case "no-tmp-agent-literals-in-consumers" `Quick
             test_no_tmp_agent_literals_in_consumers


### PR DESCRIPTION
## Summary
- stop treating `tools/call` argument field `token` as a caller identity/auth token when HTTP auth is absent
- keep HTTP auth token precedence intact when both HTTP auth and stale argument token are present
- remove the `/tmp/.masc_agent_<TERM_SESSION_ID>` caller identity read/write fallback; no-session calls now use the generated `Agent_identity.session_key` fallback
- remove the MCP-session sidecar identity bridge (`.masc_agent_mcp_<session>`); session continuity now uses `Agent_registry_eio` resolved-name cache only
- update MCP caller identity and scratch-file ratchet tests to lock the new rejection/generated/cache behavior

## Validation
- `opam exec -- ocamlformat --check lib/mcp_server_eio.mli lib/mcp_server_eio_caller_identity.ml lib/mcp_server_eio_caller_identity.mli lib/mcp_server_eio_execute.ml lib/mcp_server_eio_execute.mli lib/tool_inline_dispatch.ml lib/tool_inline_dispatch.mli lib/tool_inline_dispatch_coord.ml lib/tool_inline_dispatch_types.ml lib/tool_inline_dispatch_types.mli test/test_host_config_resolution.ml test/test_mcp_server_eio.ml test/test_mcp_server_eio_join_state.ml test/test_pr_d_agent_runtime_migration.ml`
- `git diff --check`
- `bash scripts/lint/shell-legacy-purge-ratchet.sh`
- `bash scripts/lint/godfile-size-regression.sh`
- blocked: `scripts/dune-local.sh build test/test_mcp_server_eio.exe test/test_mcp_server_eio_join_state.exe test/test_pr_d_agent_runtime_migration.exe test/test_host_config_resolution.exe` exited 75 because live bare `dune build` processes are bypassing the machine-wide wrapper lock

## Rejected Legacy Criterion
- Closed #17063 after rejecting the steady-state rule `paused=true && last_blocker=capacity_exhausted && auto_resume_after_sec=null => auto-recoverable`; `auto_resume_after_sec=null` remains the manual/operator pause contract.