### PR TITLE
feat(masc_log): System_log_category closed-sum module (RFC-0155 PR-1)

### DIFF
--- a/lib/masc_log/dune
+++ b/lib/masc_log/dune
@@ -3,7 +3,7 @@
  (name masc_log)
  (public_name masc_mcp.masc_log)
  (wrapped false)
- (modules log)
+ (modules log system_log_category)
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags (:standard -w +4))
  (libraries unix yojson time_compat eio fs_compat))

--- a/lib/masc_log/system_log_category.ml
+++ b/lib/masc_log/system_log_category.ml
@@ -1,0 +1,68 @@
+type t =
+  | Task_ownership_ambiguity_current_task_unset
+  | State_store_current_task_path_corruption
+  | Config_env_allowlist_drift
+  | Telemetry_or_metadata_parse_drop
+  | Host_fd_pressure
+  | Docker_start_pressure
+  | Keeper_stale_watchdog_lifecycle
+  | Oas_timeout_budget
+  | Provider_cascade_exhaustion
+  | Required_tool_contract_mismatch
+  | Task_state_probe_misuse
+  | Verifier_action_guard
+  | Network_error_other
+  | Other_boundary_unclassified of { hint : string }
+
+let to_string = function
+  | Task_ownership_ambiguity_current_task_unset ->
+      "task_ownership_ambiguity_current_task_unset"
+  | State_store_current_task_path_corruption ->
+      "state_store_current_task_path_corruption"
+  | Config_env_allowlist_drift -> "config_env_allowlist_drift"
+  | Telemetry_or_metadata_parse_drop -> "telemetry_or_metadata_parse_drop"
+  | Host_fd_pressure -> "host_fd_pressure"
+  | Docker_start_pressure -> "docker_start_pressure"
+  | Keeper_stale_watchdog_lifecycle -> "keeper_stale_watchdog_lifecycle"
+  | Oas_timeout_budget -> "oas_timeout_budget"
+  | Provider_cascade_exhaustion -> "provider_cascade_exhaustion"
+  | Required_tool_contract_mismatch -> "required_tool_contract_mismatch"
+  | Task_state_probe_misuse -> "task_state_probe_misuse"
+  | Verifier_action_guard -> "verifier_action_guard"
+  | Network_error_other -> "network_error_other"
+  | Other_boundary_unclassified { hint } -> Printf.sprintf "other:%s" hint
+
+let all =
+  [
+    Task_ownership_ambiguity_current_task_unset;
+    State_store_current_task_path_corruption;
+    Config_env_allowlist_drift;
+    Telemetry_or_metadata_parse_drop;
+    Host_fd_pressure;
+    Docker_start_pressure;
+    Keeper_stale_watchdog_lifecycle;
+    Oas_timeout_budget;
+    Provider_cascade_exhaustion;
+    Required_tool_contract_mismatch;
+    Task_state_probe_misuse;
+    Verifier_action_guard;
+    Network_error_other;
+  ]
+
+let of_string_opt = function
+  | "task_ownership_ambiguity_current_task_unset" ->
+      Some Task_ownership_ambiguity_current_task_unset
+  | "state_store_current_task_path_corruption" ->
+      Some State_store_current_task_path_corruption
+  | "config_env_allowlist_drift" -> Some Config_env_allowlist_drift
+  | "telemetry_or_metadata_parse_drop" -> Some Telemetry_or_metadata_parse_drop
+  | "host_fd_pressure" -> Some Host_fd_pressure
+  | "docker_start_pressure" -> Some Docker_start_pressure
+  | "keeper_stale_watchdog_lifecycle" -> Some Keeper_stale_watchdog_lifecycle
+  | "oas_timeout_budget" -> Some Oas_timeout_budget
+  | "provider_cascade_exhaustion" -> Some Provider_cascade_exhaustion
+  | "required_tool_contract_mismatch" -> Some Required_tool_contract_mismatch
+  | "task_state_probe_misuse" -> Some Task_state_probe_misuse
+  | "verifier_action_guard" -> Some Verifier_action_guard
+  | "network_error_other" -> Some Network_error_other
+  | _ -> None

--- a/lib/masc_log/system_log_category.mli
+++ b/lib/masc_log/system_log_category.mli
@@ -1,0 +1,41 @@
+(** Closed-sum SSOT for operator-facing log categories.
+
+    RFC-0155: replaces post-hoc substring-match classification in
+    [memory/masc-oas-log-reduction-measure.py:76] with an emit-side
+    typed variant. New categories require compile-time exhaustive match
+    update on every reader. *)
+
+type t =
+  | Task_ownership_ambiguity_current_task_unset
+  | State_store_current_task_path_corruption
+  | Config_env_allowlist_drift
+  | Telemetry_or_metadata_parse_drop
+  | Host_fd_pressure
+  | Docker_start_pressure
+  | Keeper_stale_watchdog_lifecycle
+  | Oas_timeout_budget
+  | Provider_cascade_exhaustion
+  | Required_tool_contract_mismatch
+  | Task_state_probe_misuse
+  | Verifier_action_guard
+  | Network_error_other
+  | Other_boundary_unclassified of { hint : string }
+(** 14 variants reverse-engineered from [measure.py:system_category]
+    (PR #17146 reference). [Other_boundary_unclassified] is reserved
+    for external boundary noise; its [hint] is the trace for promoting
+    to a typed variant when frequency justifies. *)
+
+val to_string : t -> string
+(** Stable JSON-safe label. Constructor name in lowercase
+    snake_case (matches the strings measure.py currently produces).
+    [Other_boundary_unclassified] becomes
+    [Printf.sprintf "other:%s" hint] for routing parity. *)
+
+val of_string_opt : string -> t option
+(** Inverse for known variants. [Other_boundary_unclassified] cannot
+    be reconstructed via this function — it requires explicit
+    construction with a hint at emit boundary. *)
+
+val all : t list
+(** Enumeration of structural variants (excludes [Other_boundary_unclassified]).
+    Used by exhaustiveness tests and downstream tooling. *)

--- a/test/dune
+++ b/test/dune
@@ -49,6 +49,7 @@
   test_fd_accountant
   test_auth_login
   test_audit_log
+  test_system_log_category
   test_governance_anomaly
   test_http_negotiation
   test_mcp_h1_h2_admission_parity
@@ -369,6 +370,7 @@
   test_fd_accountant
   test_auth_login
   test_audit_log
+  test_system_log_category
   test_governance_anomaly
   test_http_negotiation
   test_mcp_h1_h2_admission_parity

--- a/test/test_system_log_category.ml
+++ b/test/test_system_log_category.ml
@@ -1,6 +1,8 @@
-(* Tests for [Masc_log.System_log_category] — RFC-0155 PR-1 scout. *)
+(* Tests for [System_log_category] — RFC-0155 PR-1 scout.
+   The [masc_log] library is [(wrapped false)], so its modules
+   (Log, System_log_category) are top-level. No [Masc_log.] prefix. *)
 
-module C = Masc_log.System_log_category
+module C = System_log_category
 
 let test_to_string_stable () =
   Alcotest.(check string)

--- a/test/test_system_log_category.ml
+++ b/test/test_system_log_category.ml
@@ -1,0 +1,62 @@
+(* Tests for [Masc_log.System_log_category] — RFC-0155 PR-1 scout. *)
+
+module C = Masc_log.System_log_category
+
+let test_to_string_stable () =
+  Alcotest.(check string)
+    "task_ownership label"
+    "task_ownership_ambiguity_current_task_unset"
+    (C.to_string C.Task_ownership_ambiguity_current_task_unset);
+  Alcotest.(check string) "fd_pressure label" "host_fd_pressure"
+    (C.to_string C.Host_fd_pressure);
+  Alcotest.(check string) "other_boundary label" "other:lex_error"
+    (C.to_string (C.Other_boundary_unclassified { hint = "lex_error" }))
+
+let test_round_trip_known_variants () =
+  List.iter
+    (fun variant ->
+      let label = C.to_string variant in
+      match C.of_string_opt label with
+      | Some recovered when recovered = variant -> ()
+      | Some _ ->
+          Alcotest.failf "round-trip mismatch for %s" label
+      | None -> Alcotest.failf "of_string_opt returned None for %s" label)
+    C.all
+
+let test_all_count () =
+  (* 13 structural variants; Other_boundary_unclassified excluded. *)
+  Alcotest.(check int) "all enumeration size" 13 (List.length C.all)
+
+let test_unknown_string_returns_none () =
+  Alcotest.(check (option string))
+    "unknown label" None
+    (Option.map C.to_string (C.of_string_opt "totally_unknown_category"))
+
+let test_other_not_in_all () =
+  (* Other_boundary_unclassified must NOT be in [all]: it requires explicit
+     construction at emit boundary with a [hint]. *)
+  let any_other =
+    List.exists
+      (function
+        | C.Other_boundary_unclassified _ -> true
+        | _ -> false)
+      C.all
+  in
+  Alcotest.(check bool) "Other_boundary_unclassified excluded from all" false
+    any_other
+
+let () =
+  Alcotest.run "system_log_category"
+    [
+      ( "labels",
+        [
+          Alcotest.test_case "to_string stable" `Quick test_to_string_stable;
+          Alcotest.test_case "round-trip known variants" `Quick
+            test_round_trip_known_variants;
+          Alcotest.test_case "all enumeration size" `Quick test_all_count;
+          Alcotest.test_case "unknown -> None" `Quick
+            test_unknown_string_returns_none;
+          Alcotest.test_case "Other excluded from all" `Quick
+            test_other_not_in_all;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

RFC-0155 PR-1 (scout): adds `Masc_log.System_log_category` closed-sum module — the typed SSOT for operator-facing log categories.

This is the **minimal module-only base PR**. Log API change (`?category` optional) + emit-site migration land in PR-2/PR-3 once this is reviewed.

## Files

- `lib/masc_log/system_log_category.mli` (new, 39 lines) — closed-sum `t` with 14 variants + `to_string` / `of_string_opt` / `all`.
- `lib/masc_log/system_log_category.ml` (new, 64 lines) — implementations.
- `lib/masc_log/dune` — adds `system_log_category` to `(modules ...)`.
- `test/test_system_log_category.ml` (new, 64 lines) — 5 Alcotest cases.
- `test/dune` — adds `test_system_log_category` to the two `(tests ...)` stanzas where peer tests like `test_audit_log` are registered.

## Variants (14)

Reverse-engineered from `memory/masc-oas-log-reduction-measure.py:76 system_category()`. Each variant maps 1-to-1 to a category measure.py currently extracts via post-hoc substring match:

```
Task_ownership_ambiguity_current_task_unset
State_store_current_task_path_corruption
Config_env_allowlist_drift
Telemetry_or_metadata_parse_drop
Host_fd_pressure
Docker_start_pressure
Keeper_stale_watchdog_lifecycle
Oas_timeout_budget
Provider_cascade_exhaustion
Required_tool_contract_mismatch
Task_state_probe_misuse
Verifier_action_guard
Network_error_other
Other_boundary_unclassified of { hint : string }
```

`Other_boundary_unclassified` requires an explicit `hint` at the emit boundary — it is the trace for promoting to a typed variant when frequency justifies (per RFC-0155 §2.1).

## Anti-pattern self-check (`software-development.md` §Workaround Rejection Bar)

| 시그니처 | 회피 여부 | 이유 |
|---|---|---|
| §1 텔레메트리-as-fix | YES | Module is the *typed SSOT*, not a counter. No drop/visibility counter added. |
| §2 String 분류기 | YES | `of_string_opt` is the *reader side* of the typed SSOT, designed to *replace* measure.py substring match (in PR-3). |
| §3 N-of-M | YES | PR-1 is `lib/masc_log/` only — single-module surface. No partial site migration in this PR. |
| Test backdoor | YES | No `set_for_test` / `reset_for_test`. Type is value-only. |

## Review evidence

- `dune build --root . lib/masc_log` PASS — `_build/default/lib/masc_log/.masc_log.objs/byte/system_log_category.cmi` generated.
- Local `dune build test/test_system_log_category.exe` blocked by a **pre-existing** issue at `test/dune:918` (`test_keeper_working_state` not listed in the `(modules ...)` field of its stanza, unrelated to this PR). CI environment is expected to either reach the same error (pre-existing) or compile the new test through the unaffected stanza path. This will be addressed in a follow-up if CI fails on `test_system_log_category`.

## Phasing (per RFC-0155)

- **PR-1 (this)** — module + tests only. NO Log API change.
- **PR-2 (next)** — `Log.warn`/`Log.error` `?category` optional arg + JSONL envelope `category` field + Wave A scout 5-10 sites (board_dispatch.ml, heuristic_metrics.ml, board_votes.ml).
- **PR-3** — Wave B sweep (~20 files).
- **PR-4** — Wave C legacy purge (`?category` → required, `measure.py:system_category` deleted).

## Linked

- RFC-0155 (this PR's design): `docs/rfc/RFC-0155-system-log-category-typed-ssot.md` (merged via #17146).
- Source audit: `memory/masc-oas-log-reduction-goal-2026-05-18.html`.
- Sister: RFC-0148 (Tool_error LLM-facing), RFC-0154 (System_error_class operator-facing) — same parse-don't-validate pattern.
