### PR TITLE
fix(dashboard): normalize legacy capacity receipts

### DIFF
--- a/lib/coord/coord_task_verification.ml
+++ b/lib/coord/coord_task_verification.ml
@@ -86,6 +86,6 @@ let verification_submission_evidence_refs task ~notes handoff_context =
   let notes_refs =
     if notes_have_verification_artifact_ref notes then [ notes ] else []
   in
-  normalized_string_list (contract_refs @ handoff_refs @ summary_refs @ notes_refs)
+  Coord_state.normalized_string_list
+    (contract_refs @ handoff_refs @ summary_refs @ notes_refs)
   |> List.filter evidence_ref_has_verification_artifact_ref
-

--- a/lib/coord/dune
+++ b/lib/coord/dune
@@ -35,6 +35,7 @@
   coord_task_receipts
   coord_task_schedule
   coord_task_transition_executor
+  coord_task_verification
   coord_verification_store
   event_kind
   coord_git

--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -75,6 +75,10 @@ let build_forest ~(config : Coord.config) ~goals ~tasks =
     keeper_metas
     |> List.map (fun (meta : Keeper_types.keeper_meta) -> meta.name)
     |> Keeper_execution_receipt.latest_json_by_keeper config
+    |> List.map (fun (keeper_name, receipt) ->
+           ( keeper_name,
+             Keeper_runtime_trust_snapshot.normalize_receipt_projection_json
+               receipt ))
   in
   let context =
     {
@@ -299,7 +303,11 @@ let goal_detail_json ~(config : Coord.config) ~goal_id :
                    let latest_receipt =
                      List.assoc_opt meta.name
                        (Keeper_execution_receipt.latest_json_by_keeper
-                          config node.linked_keeper_names)
+                          config node.linked_keeper_names
+                        |> List.map (fun (keeper_name, receipt) ->
+                               ( keeper_name,
+                                 Keeper_runtime_trust_snapshot
+                                 .normalize_receipt_projection_json receipt )))
                    in
                    let runtime_trust =
                      let snapshot =

--- a/lib/dashboard/dashboard_http_keeper_trust.ml
+++ b/lib/dashboard/dashboard_http_keeper_trust.ml
@@ -2,7 +2,10 @@ open Dashboard_http_keeper_types
 
 let keeper_trust_json ?(include_receipt = false)
     (config : Coord.config) (meta : Keeper_types.keeper_meta) =
-  let latest_receipt = Keeper_execution_receipt.latest_json config meta.name in
+  let latest_receipt =
+    Keeper_execution_receipt.latest_json config meta.name
+    |> Option.map Keeper_runtime_trust_snapshot.normalize_receipt_projection_json
+  in
   let runtime_trust = Keeper_runtime_trust_snapshot.snapshot_json ~config ~meta in
   let sandbox_json =
     match latest_receipt with

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -11,7 +11,39 @@ open Keeper_runtime_trust_timeline
    [keeper_agent_run.ml]. *)
 let normalize_persisted_terminal_reason_code = function
   | "completed" -> "success"
+  | "capacity_exhausted" -> "capacity_backpressure"
   | code -> code
+
+let normalize_masc_oas_error_message value =
+  if String_util.contains_substring value "[masc_oas_error]"
+  then
+    value
+    |> String_util.replace_substring
+         ~needle:"\"kind\":\"capacity_exhausted\""
+         ~by:"\"kind\":\"capacity_backpressure\""
+    |> String_util.replace_substring
+         ~needle:"\"kind\": \"capacity_exhausted\""
+         ~by:"\"kind\": \"capacity_backpressure\""
+  else value
+
+let rec normalize_receipt_projection_json = function
+  | `Assoc fields ->
+      `Assoc
+        (List.map
+           (fun (key, value) ->
+             let value =
+               match key, value with
+               | "terminal_reason_code", `String code ->
+                   `String (normalize_persisted_terminal_reason_code code)
+               | "message", `String message ->
+                   `String (normalize_masc_oas_error_message message)
+               | _ -> normalize_receipt_projection_json value
+             in
+             (key, value))
+           fields)
+  | `List values -> `List (List.map normalize_receipt_projection_json values)
+  | `String value -> `String (normalize_masc_oas_error_message value)
+  | json -> json
 
 let terminal_reason_from_decision json =
   match json_member "terminal_reason" json with
@@ -318,7 +350,10 @@ let disposition_fields_json ~(config : Coord.config) ~(meta : keeper_meta) :
   let disposition, disposition_reason =
     disposition_of_snapshot ~pending_approval_count ~runtime_blocker_fields
   in
-  let latest_receipt = Keeper_execution_receipt.latest_json config meta.name in
+  let latest_receipt =
+    Keeper_execution_receipt.latest_json config meta.name
+    |> Option.map normalize_receipt_projection_json
+  in
   let disposition, disposition_reason, _, _ =
     effective_disposition_fields ~fallback_disposition:disposition
       ~fallback_reason:disposition_reason latest_receipt
@@ -386,6 +421,7 @@ let latest_turn_id ~(registry_entry : Keeper_registry.registry_entry option)
 
 let latest_receipt_json ~(config : Coord.config) ~(keeper_name : string) =
   Keeper_execution_receipt.latest_json config keeper_name
+  |> Option.map normalize_receipt_projection_json
 
 let selected_model_of_latest_decision latest_decision =
   Option.bind latest_decision (fun decision ->

--- a/lib/keeper/keeper_runtime_trust_snapshot.mli
+++ b/lib/keeper/keeper_runtime_trust_snapshot.mli
@@ -1,6 +1,8 @@
 val disposition_fields_json :
   config:Coord.config -> meta:Keeper_types.keeper_meta -> Yojson.Safe.t
 
+val normalize_receipt_projection_json : Yojson.Safe.t -> Yojson.Safe.t
+
 val snapshot_json :
   config:Coord.config -> meta:Keeper_types.keeper_meta -> Yojson.Safe.t
 

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -1067,6 +1067,9 @@ let run_named
           "oas_max_execution_time_observe_liveness"
         | Cascade_attempt_liveness_config.Off, _, Some _ -> "legacy_outer_wall"
         | Cascade_attempt_liveness_config.Off, _, None -> "oas_max_execution_time"
+        | Cascade_attempt_liveness_config.Observe, false, Some _ -> "legacy_outer_wall"
+        | Cascade_attempt_liveness_config.Observe, false, None ->
+          "oas_max_execution_time"
         | Cascade_attempt_liveness_config.Enforce, false, Some _ -> "legacy_outer_wall"
         | Cascade_attempt_liveness_config.Enforce, false, None ->
           "oas_max_execution_time"

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -699,7 +699,10 @@ let composite_config_drift_json ~config ~keeper_name =
 let composite_execution_receipt_json ~(config : Coord.config) ~keeper_name =
   let claim_scope = composite_claim_scope_json ~keeper_name in
   let config_drift = composite_config_drift_json ~config ~keeper_name in
-  match Keeper_execution_receipt.latest_json config keeper_name with
+  match
+    Keeper_execution_receipt.latest_json config keeper_name
+    |> Option.map Keeper_runtime_trust_snapshot.normalize_receipt_projection_json
+  with
   | None ->
     `Assoc
       [ "latest_receipt_present", `Bool false

--- a/test/dune
+++ b/test/dune
@@ -1142,6 +1142,7 @@
   test_http_protocol_detect
   test_keeper_safety_gates
   test_keeper_guards
+  test_keeper_working_state
   test_eval_gate_evasion
   test_prompt_registry_defaults
   test_keeper_prompt_external

--- a/test/test_keeper_runtime_trust_snapshot.ml
+++ b/test/test_keeper_runtime_trust_snapshot.ml
@@ -58,6 +58,13 @@ let make_meta name : Masc_mcp.Keeper_types.keeper_meta =
   | Error err -> Alcotest.fail ("meta fixture failed: " ^ err)
 ;;
 
+let append_execution_receipt config keeper_name json =
+  let store =
+    Masc_mcp.Keeper_types_support.keeper_execution_receipt_store config keeper_name
+  in
+  Dated_jsonl.append store json
+;;
+
 let drop_value reason =
   P.metric_value_or_zero
     P.metric_persistence_read_drops
@@ -117,6 +124,57 @@ let test_snapshot_counts_malformed_decision_rows () =
          (drop_value invalid_payload -. before_invalid_payload))
 ;;
 
+let test_snapshot_normalizes_legacy_capacity_receipt_projection () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> remove_tree base_dir)
+    (fun () ->
+       with_env "MASC_BASE_PATH" base_dir
+       @@ fun () ->
+       let config = Masc_mcp.Coord.default_config base_dir in
+       let keeper_name = "runtime-trust-legacy-capacity" in
+       let meta = make_meta keeper_name in
+       append_execution_receipt
+         config
+         keeper_name
+         (`Assoc
+             [ "schema", `String "keeper.execution_receipt.v1"
+             ; "recorded_at", `String "2026-05-20T17:32:38Z"
+             ; "keeper_name", `String keeper_name
+             ; "terminal_reason_code", `String "capacity_exhausted"
+             ; "outcome", `String "receipt_failed"
+             ; ( "error"
+               , `Assoc
+                   [ "kind", `String "internal"
+                   ; ( "message"
+                     , `String
+                         "Internal error: [masc_oas_error] \
+                          {\"kind\":\"capacity_exhausted\",\"source\":\"client_capacity\"}" )
+                   ] )
+             ; "ended_at", `String "2026-05-20T17:32:38Z"
+             ]);
+       let snapshot = K.snapshot_json ~config ~meta in
+       let open Yojson.Safe.Util in
+       Alcotest.(check string)
+         "latest terminal reason code normalized"
+         "capacity_backpressure"
+         (snapshot |> member "latest_terminal_reason" |> member "code" |> to_string);
+       let latest_receipt = snapshot |> member "latest_receipt" in
+       Alcotest.(check string)
+         "projected receipt code normalized"
+         "capacity_backpressure"
+         (latest_receipt |> member "terminal_reason_code" |> to_string);
+       Alcotest.(check bool)
+         "projected error message hides legacy internal kind"
+         false
+         (String_util.contains_substring
+            (latest_receipt |> member "error" |> member "message" |> to_string)
+            "\"kind\":\"capacity_exhausted\""))
+;;
+
 let () =
   Alcotest.run
     "keeper_runtime_trust_snapshot"
@@ -125,6 +183,10 @@ let () =
             "malformed decision rows increment drop metrics"
             `Quick
             test_snapshot_counts_malformed_decision_rows
+        ; Alcotest.test_case
+            "legacy capacity receipt projection is normalized"
+            `Quick
+            test_snapshot_normalizes_legacy_capacity_receipt_projection
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- Normalize persisted legacy `capacity_exhausted` receipt codes to `capacity_backpressure` at dashboard/API projection boundaries.
- Rewrite MASC internal receipt error-message payloads from `kind=capacity_exhausted` to `kind=capacity_backpressure` without changing archival JSONL files.
- Apply the same projection helper to keeper trust, goal fallback, and composite execution receipt surfaces.
- Include minimal latest-main build-unblock fixes discovered during focused Dune verification.

## Root Cause
Historical execution receipts still store the old `terminal_reason_code=capacity_exhausted` and embedded `[masc_oas_error] {"kind":"capacity_exhausted"}` strings. Runtime blocker metadata had been cleaned up, but API projections returned those historical receipts raw.

## Validation
- `ocamlformat --check lib/keeper/keeper_runtime_trust_snapshot.ml lib/keeper/keeper_runtime_trust_snapshot.mli lib/dashboard/dashboard_http_keeper_trust.ml lib/dashboard/dashboard_goals.ml lib/server/server_dashboard_http.ml test/test_keeper_runtime_trust_snapshot.ml lib/coord/coord_task_verification.ml lib/keeper/keeper_turn_driver.ml`
- `git diff --check`
- `env DUNE_CACHE=disabled MASC_DUNE_THROTTLE=0 MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_OPAM_LOCK=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_keeper_runtime_trust_snapshot.exe`
- `./_build/default/test/test_keeper_runtime_trust_snapshot.exe`
- Live 8935 patched binary check: health `fleet=ok`, `keeper_fibers=17`, `paused=0`; all 17 keeper config API payloads had `capacity_exhausted` count 0.