### PR TITLE
chore(pr-tools): drop number pr alias

### DIFF
--- a/lib/keeper/keeper_hooks_oas_pr_metrics.ml
+++ b/lib/keeper/keeper_hooks_oas_pr_metrics.ml
@@ -40,12 +40,10 @@ let pr_review_action_metric_event_of_tool_io
              action;
              pr_number =
                first_some
-                 (first_some
-                    (match output_json with
-                     | Some json -> json_int_opt "pr_number" json
-                     | None -> None)
-                    (json_int_opt "pr_number" input))
-                 (json_int_opt "number" input);
+                 (match output_json with
+                  | Some json -> json_int_opt "pr_number" json
+                  | None -> None)
+                 (json_int_opt "pr_number" input);
              comment_id = None;
              success;
              route_via;
@@ -71,12 +69,10 @@ let pr_review_action_metric_event_of_tool_io
           action = "REPLY";
           pr_number =
             first_some
-              (first_some
-                 (match output_json with
-                  | Some json -> json_int_opt "pr_number" json
-                  | None -> None)
-                 (json_int_opt "pr_number" input))
-              (json_int_opt "number" input);
+              (match output_json with
+               | Some json -> json_int_opt "pr_number" json
+               | None -> None)
+              (json_int_opt "pr_number" input);
           comment_id =
             first_some
               (match output_json with
@@ -426,4 +422,3 @@ let append_pr_work_action_metrics
            Dated_jsonl.append store
              (Inference_utils.sanitize_json_utf8 snapshot))
         events
-

--- a/lib/keeper/keeper_tool_pr_review.ml
+++ b/lib/keeper/keeper_tool_pr_review.ml
@@ -130,11 +130,7 @@ let identity_attestation_fields ~(config : Coord.config) (meta : keeper_meta) =
                ]) );
       ]
 
-(* Both "pr_number" and "number" are accepted for schema-drift compat. *)
-let pr_number_of_args args =
-  let from_pr = Safe_ops.json_int ~default:0 "pr_number" args in
-  if from_pr <> 0 then from_pr
-  else Safe_ops.json_int ~default:0 "number" args
+let pr_number_of_args args = Safe_ops.json_int ~default:0 "pr_number" args
 
 type pr_review_exec_result =
   { status : Unix.process_status

--- a/lib/keeper/keeper_tool_pr_review.mli
+++ b/lib/keeper/keeper_tool_pr_review.mli
@@ -13,8 +13,7 @@ val all_pr_review_events : pr_review_event list
 val valid_pr_review_event_strings : string list
 val pr_review_mutation_preset_ok : Keeper_types.tool_preset option -> bool
 
-(** Both ["pr_number"] and ["number"] are accepted for schema-drift
-    compatibility across keeper PR tools. *)
+(** Canonical PR number parser for keeper PR tools. *)
 val pr_number_of_args : Yojson.Safe.t -> int
 
 (** Detect "PR not found" markers in [gh] CLI output (REST 404 + GraphQL

--- a/lib/tool_shard_types_schemas_github_pr.ml
+++ b/lib/tool_shard_types_schemas_github_pr.ml
@@ -48,7 +48,7 @@ let keeper_github_pr_tools : Masc_domain.tool_schema list =
   ; { name = "keeper_pr_status"
     ; description =
         "Read one GitHub PR status/details with keeper-scoped credentials. Runs \
-         credential preflight before gh. Pass pr_number (preferred) or number."
+         credential preflight before gh. Pass pr_number."
     ; input_schema =
         `Assoc
           [ "type", `String "object"
@@ -70,14 +70,10 @@ let keeper_github_pr_tools : Masc_domain.tool_schema list =
                 ; ( "pr_number"
                   , `Assoc
                       [ "type", `String "integer"
-                      ; "description", `String "PR number (preferred field name)"
-                      ] )
-                ; ( "number"
-                  , `Assoc
-                      [ "type", `String "integer"
-                      ; "description", `String "PR number (legacy alias for pr_number)"
+                      ; "description", `String "PR number"
                       ] )
                 ] )
+          ; "required", `List [ `String "pr_number" ]
           ]
     }
   ; { name = "keeper_pr_create"

--- a/lib/tool_shard_types_schemas_pr_review.ml
+++ b/lib/tool_shard_types_schemas_pr_review.ml
@@ -8,7 +8,7 @@ let keeper_pr_review_tools : Masc_domain.tool_schema list =
     ; description =
         "Read PR metadata, diff, reviews, and comments. Returns title, body, changed \
          files, review threads, and truncated diff (max 64KB). Read-only. Pass the PR \
-         number as `pr_number` (preferred) or `number` (legacy alias)."
+         number as `pr_number`."
     ; input_schema =
         `Assoc
           [ "type", `String "object"
@@ -22,19 +22,10 @@ let keeper_pr_review_tools : Masc_domain.tool_schema list =
                 ; ( "pr_number"
                   , `Assoc
                       [ "type", `String "integer"
-                      ; "description", `String "PR number (preferred field name)"
-                      ] )
-                ; ( "number"
-                  , `Assoc
-                      [ "type", `String "integer"
-                      ; "description", `String "PR number (legacy alias for pr_number)"
+                      ; "description", `String "PR number"
                       ] )
                 ] )
-          ; (* No `required` for the number — the handler reads either
-         pr_number or number and emits a clear error if both are
-         missing. Schema-level required=[number] rejected callers
-         that learned the historical pr_number key. *)
-            "required", `List [ `String "repo" ]
+          ; "required", `List [ `String "repo"; `String "pr_number" ]
           ]
     }
   ; { name = "keeper_pr_review_comment"
@@ -42,8 +33,7 @@ let keeper_pr_review_tools : Masc_domain.tool_schema list =
         "Submit a PR review with optional inline comments. Events: COMMENT, APPROVE, \
          REQUEST_CHANGES. Requires research, delivery, coding, or full preset. Use \
          REQUEST_CHANGES for actionable blockers; use APPROVE only when the draft proof \
-         preflight permits it. Pass the PR number as `pr_number` (preferred) or `number` \
-         (legacy alias)."
+         preflight permits it. Pass the PR number as `pr_number`."
     ; input_schema =
         `Assoc
           [ "type", `String "object"
@@ -57,12 +47,7 @@ let keeper_pr_review_tools : Masc_domain.tool_schema list =
                 ; ( "pr_number"
                   , `Assoc
                       [ "type", `String "integer"
-                      ; "description", `String "PR number (preferred field name)"
-                      ] )
-                ; ( "number"
-                  , `Assoc
-                      [ "type", `String "integer"
-                      ; "description", `String "PR number (legacy alias for pr_number)"
+                      ; "description", `String "PR number"
                       ] )
                 ; ( "body"
                   , `Assoc
@@ -94,14 +79,14 @@ let keeper_pr_review_tools : Masc_domain.tool_schema list =
                       ; "description", `String "Line number for inline comment (optional)"
                       ] )
                 ] )
-          ; "required", `List [ `String "repo"; `String "body"; `String "event" ]
+          ; "required"
+            , `List [ `String "repo"; `String "pr_number"; `String "body"; `String "event" ]
           ]
     }
   ; { name = "keeper_pr_review_reply"
     ; description =
         "Reply to a specific PR review comment. Requires research, delivery, coding, or \
-         full preset. Pass the PR number as `pr_number` (preferred) or `number` (legacy \
-         alias)."
+         full preset. Pass the PR number as `pr_number`."
     ; input_schema =
         `Assoc
           [ "type", `String "object"
@@ -115,12 +100,7 @@ let keeper_pr_review_tools : Masc_domain.tool_schema list =
                 ; ( "pr_number"
                   , `Assoc
                       [ "type", `String "integer"
-                      ; "description", `String "PR number (preferred field name)"
-                      ] )
-                ; ( "number"
-                  , `Assoc
-                      [ "type", `String "integer"
-                      ; "description", `String "PR number (legacy alias for pr_number)"
+                      ; "description", `String "PR number"
                       ] )
                 ; ( "comment_id"
                   , `Assoc
@@ -133,7 +113,9 @@ let keeper_pr_review_tools : Masc_domain.tool_schema list =
                       ; "description", `String "Reply body text"
                       ] )
                 ] )
-          ; "required", `List [ `String "repo"; `String "comment_id"; `String "body" ]
+          ; "required"
+            , `List
+                [ `String "repo"; `String "pr_number"; `String "comment_id"; `String "body" ]
           ]
     }
   ]

--- a/test/test_keeper_hooks_oas_telemetry.ml
+++ b/test/test_keeper_hooks_oas_telemetry.ml
@@ -1303,7 +1303,7 @@ let test_pr_review_action_metric_marks_structured_failure () =
     |> require_pr_review_event "failed approve"
   in
   check string "action fallback from input" "APPROVE" event.action;
-  check (option int) "number fallback" (Some 42) event.pr_number;
+  check (option int) "legacy number ignored" None event.pr_number;
   check bool "structured ok=false wins" false event.success
 ;;
 
@@ -1333,7 +1333,7 @@ let test_pr_review_action_metric_observes_invalid_output_json () =
     |> require_pr_review_event "invalid output json"
   in
   check string "action fallback from input" "COMMENT" event.action;
-  check (option int) "number fallback" (Some 7) event.pr_number;
+  check (option int) "legacy number ignored" None event.pr_number;
   check
     (float 0.001)
     "parse failure counted"

--- a/test/test_keeper_pr_review.ml
+++ b/test/test_keeper_pr_review.ml
@@ -260,6 +260,15 @@ let test_social_preset_cannot_mutate_pr_reviews () =
     (KTPR.pr_review_mutation_preset_ok
        (Some Masc_mcp.Keeper_types.Social))
 
+let test_pr_number_of_args_uses_canonical_key_only () =
+  check int "canonical pr_number" 42
+    (KTPR.pr_number_of_args (`Assoc [ "pr_number", `Int 42 ]));
+  check int "legacy number ignored" 0
+    (KTPR.pr_number_of_args (`Assoc [ "number", `Int 42 ]));
+  check int "pr_number wins" 7
+    (KTPR.pr_number_of_args
+       (`Assoc [ "number", `Int 42; "pr_number", `Int 7 ]))
+
 let test_detects_rest_404 () =
   let sample =
     "failed to run git: HTTP 404: Not Found \
@@ -515,6 +524,10 @@ let () =
         test_research_preset_can_mutate_pr_reviews;
       test_case "social preset cannot mutate PR reviews" `Quick
         test_social_preset_cannot_mutate_pr_reviews;
+    ];
+    "args", [
+      test_case "pr_number is canonical" `Quick
+        test_pr_number_of_args_uses_canonical_key_only;
     ];
     "pr_not_found_in_output", [
       test_case "REST 404 (HTTP 404: Not Found)" `Quick test_detects_rest_404;


### PR DESCRIPTION
## Summary
- remove the legacy `number` PR input alias from keeper PR schemas and handler parsing
- require the canonical `pr_number` field in PR tool schemas
- stop PR action telemetry from using input-side `number` fallback

## Verification
- `ocamlformat --check` on all changed OCaml files
- `git diff --check`
- residue search for legacy `number`/`pr_number` alias patterns across `lib`, `test`, and `docs` returned no matches
- focused Dune build was blocked by `/tmp/me-dune-local.lock`; holder was PID 74300 running the keeper error/working-state test build around 2026-05-21 03:23:36 KST