### PR TITLE
fix(shell): route typed keeper bash through shell gate

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -833,6 +833,13 @@ let typed_gate_allowlist_policy mode : Exec_shell_gate.allowlist_policy =
 
 let typed_gate_sandbox target : Exec_shell_gate.sandbox_context = { target }
 
+let typed_gate_legendary_verdict_kind = function
+  | Exec_shell_gate.Allow _ -> Legendary_counters.Allow
+  | Exec_shell_gate.Reject _ -> Legendary_counters.Reject
+  | Exec_shell_gate.Cannot_parse _
+  | Exec_shell_gate.Too_complex _ -> Legendary_counters.Cannot_parse
+;;
+
 let typed_gate_error_json ~cmd_for_log ~cwd verdict =
   let verdict_tag = Exec_shell_gate.verdict_tag verdict in
   let reason_tag, diagnostic =
@@ -968,6 +975,9 @@ let handle_keeper_bash_typed
                 ~sandbox:(typed_gate_sandbox dispatch_sandbox)
                 ()
             in
+            Legendary_counters.incr_shell_gate
+              ~caller:Legendary_counters.Keeper_shell_bash
+              ~verdict:(typed_gate_legendary_verdict_kind gate_verdict);
             (match gate_verdict with
              | Exec_shell_gate.Allow gate_context ->
                let path_validation =
@@ -983,9 +993,9 @@ let handle_keeper_bash_typed
                      ~workdir:cwd
                      cmd
                in
-               (match path_validation with
-                | Error e -> error_json ~fields:[ "blocked_cmd", `String cmd_for_log ] e
-                | Ok () ->
+                (match path_validation with
+                 | Error e -> error_json ~fields:[ "blocked_cmd", `String cmd_for_log ] e
+                 | Ok () ->
                let env_snap =
                  Cancel_safe.protect
                    ~on_exn:(fun _ -> None)

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -984,6 +984,7 @@ let test_keeper_bash_typed_exec_runs_via_shell_ir () =
   let base_path, config = make_config () in
   Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
   Keeper_registry.clear ();
+  Masc_mcp.Legendary_counters.reset ();
   let meta = make_readonly_meta "typed-exec" in
   let playground = Filename.concat base_path (playground_path_of meta.name) in
   ensure_dir playground;
@@ -1011,6 +1012,9 @@ let test_keeper_bash_typed_exec_runs_via_shell_ir () =
     (json |> Json.member "shell_ir_gate" |> Json.to_string);
   Alcotest.(check int) "typed gate stage count" 1
     (json |> Json.member "shell_ir_stage_count" |> Json.to_int);
+  let counters = Masc_mcp.Legendary_counters.snapshot () in
+  Alcotest.(check int) "typed gate counter allow" 1
+    counters.shell_gate_keeper_shell_bash_allow;
   Alcotest.(check bool) "output from native argv" true
     (json
      |> Json.member "output"
@@ -1022,6 +1026,7 @@ let test_keeper_bash_typed_pipeline_runs_via_shell_ir () =
   let base_path, config = make_config () in
   Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
   Keeper_registry.clear ();
+  Masc_mcp.Legendary_counters.reset ();
   let meta = make_readonly_meta "typed-pipeline" in
   let playground = Filename.concat base_path (playground_path_of meta.name) in
   ensure_dir playground;
@@ -1058,6 +1063,9 @@ let test_keeper_bash_typed_pipeline_runs_via_shell_ir () =
     (json |> Json.member "shell_ir_gate" |> Json.to_string);
   Alcotest.(check int) "typed gate stage count" 2
     (json |> Json.member "shell_ir_stage_count" |> Json.to_int);
+  let counters = Masc_mcp.Legendary_counters.snapshot () in
+  Alcotest.(check int) "typed pipeline gate counter allow" 1
+    counters.shell_gate_keeper_shell_bash_allow;
   Alcotest.(check bool) "wc sees piped stdin" true
     (json
      |> Json.member "output"


### PR DESCRIPTION
## Summary
- route typed keeper_bash exec/pipeline input through the Shell IR command gate before dispatch
- dispatch the gate-approved AST instead of the raw typed IR
- surface shell_ir_gate and shell_ir_stage_count in keeper_bash JSON results
- increment keeper shell gate legendary counters for typed keeper_bash verdicts

## Stack
- Base: #17213 / codex/build-repair-keeper-wip-admission-20260521
- Rebase back to main after #17213 merges.

## Verification
- git diff --check codex/build-repair-keeper-wip-admission-20260521..HEAD
- ocamlformat --check lib/keeper/keeper_shell_bash.ml test/test_keeper_bash_safety.ml
- env DUNE_CACHE=disabled MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_bash_safety.exe test/test_legendary_counters.exe
- _build/default/test/test_keeper_bash_safety.exe (77 tests)
- _build/default/test/test_legendary_counters.exe (18 tests)