### PR TITLE
chore(env): drop docker env args alias

### DIFF
--- a/lib/env_git_noninteractive.ml
+++ b/lib/env_git_noninteractive.ml
@@ -24,8 +24,6 @@ let env_pairs =
 let docker_args =
   List.concat_map (fun (k, v) -> [ "-e"; k ^ "=" ^ v ]) env
 
-let docker_env_args = docker_args
-
 let key_of_entry entry =
   match String.index_opt entry '=' with
   | None -> entry

--- a/lib/env_git_noninteractive.mli
+++ b/lib/env_git_noninteractive.mli
@@ -22,9 +22,6 @@ val env_pairs : string list
 val docker_args : string list
 (** Flattened ["-e"; "K=V"; ...] pairs for direct [docker run] argv. *)
 
-val docker_env_args : string list
-(** Backwards-compatible alias for {!docker_args}. *)
-
 val inject_into_environment : string array -> string array
 (** Prepend {!env_pairs} to [env], stripping any pre-existing entries
     with matching keys so the canonical value wins. Preserves the order of


### PR DESCRIPTION
## Summary
- remove the unused `Env_git_noninteractive.docker_env_args` compatibility alias
- keep `docker_args` as the single canonical Docker env argv helper
- shrink the public mli surface so new callers cannot re-adopt the legacy alias

## Verification
- `rg -n "docker_env_args" lib test docs` returned no matches
- `ocamlformat --check lib/env_git_noninteractive.ml lib/env_git_noninteractive.mli`
- `git diff --check`
- focused Dune build for `test/test_env_git_noninteractive.exe` was blocked by `/tmp/me-dune-local.lock`; holder was PID 81046 running `test/test_keeper_bash_safety.exe` around 2026-05-21 03:29:12 KST