### PR TITLE
chore(dashboard): drop cascade provider json alias

### DIFF
--- a/lib/dashboard_cascade_health.ml
+++ b/lib/dashboard_cascade_health.ml
@@ -141,10 +141,3 @@ let provider_entry_to_json
      ]
      @ perf_fields)
 ;;
-
-(** Back-compat alias: older call sites may still reference the previous
-    serializer name.  Keeping it as a thin wrapper keeps the diff in
-    this PR focused on the health_json merge. *)
-let provider_info_to_json (info : Health.provider_info) : Yojson.Safe.t =
-  provider_entry_to_json ~declared:false info
-;;

--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -31,8 +31,8 @@ lib/process/process_eio.ml:535
 # manager itself. Bounded by session scope, not by per-call timeout.
 lib/server/lsp_process_manager.ml:178
 
-# lib/worker_dev_tools.ml:703 — dev-tools worker spawn. Wrapped by
+# lib/worker_dev_tools.ml:706 — dev-tools worker spawn. Wrapped by
 # Tool_resource_gate, Fd_accountant, Eio.Time.with_timeout_exn, and a fresh
 # Eio.Switch.run at the call boundary. Line renumbered by worker-dev-tools
 # split/refactor waves.
-lib/worker_dev_tools.ml:703
+lib/worker_dev_tools.ml:706


### PR DESCRIPTION
## Summary
- remove the dead `Dashboard_cascade_health.provider_info_to_json` back-compat alias
- keep `provider_entry_to_json` as the only dashboard cascade health serializer
- leave the unrelated cascade trust persistence helper unchanged

## Verification
- `bash scripts/lint-spawn-bounded.sh`
- `opam exec -- ocamlformat --check lib/dashboard_cascade_health.ml`
- `git diff --check origin/main...HEAD`
- `bash scripts/lint/godfile-size-regression.sh`
- targeted residue search for `Dashboard_cascade_health.provider_info_to_json` / dashboard `provider_info_to_json` returned no matches in `lib/dashboard_cascade_health.ml`, `test`, and `docs`
- focused Dune build `scripts/dune-local.sh build lib/dashboard_cascade_health.cmx` is currently blocked by external bare Dune processes: PID 8622 (`test/test_dashboard_tools.exe`) and PID 60376 (`test/test_keeper_bash_safety.exe test/test_keeper_docker_read.exe`)
