### PR TITLE
[codex] classify 524 gateway backpressure

### DIFF
--- a/lib/coord/coord_task_verification.ml
+++ b/lib/coord/coord_task_verification.ml
@@ -87,6 +87,5 @@ let verification_submission_evidence_refs task ~notes handoff_context =
   let notes_refs =
     if notes_have_verification_artifact_ref notes then [ notes ] else []
   in
-  Coord_state.normalized_string_list
-    (contract_refs @ handoff_refs @ summary_refs @ notes_refs)
+  Coord_state.normalized_string_list (contract_refs @ handoff_refs @ summary_refs @ notes_refs)
   |> List.filter evidence_ref_has_verification_artifact_ref

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -184,6 +184,20 @@ let message_looks_like_capacity_backpressure detail =
   || string_contains_substring ~needle:"capacity exhausted" lower
   || string_contains_substring ~needle:"local_resource_exhaustion" lower
 
+let message_looks_like_gateway_backpressure detail =
+  let lower = String.lowercase_ascii detail in
+  string_contains_substring ~needle:"server error 524" lower
+  || string_contains_substring ~needle:"error code: 524" lower
+  || string_contains_substring ~needle:"status 524" lower
+  || string_contains_substring ~needle:"status=524" lower
+  || string_contains_substring ~needle:"cloudflare gateway timeout" lower
+
+(* 524 is Cloudflare's "origin responded too slowly" timeout. At keeper
+   orchestration level this means the current provider lane is saturated or
+   unhealthy enough that rotating/cooling it as backpressure is more useful
+   than lumping it into a generic server_error bucket. *)
+let is_gateway_backpressure_status status = status = 524
+
 let is_auto_recoverable_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error) : bool =
   match Keeper_turn_driver.classify_masc_internal_error err with
   | Some
@@ -199,6 +213,7 @@ let is_auto_recoverable_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error
          { reason = Keeper_types.Other_detail detail; _ }) ->
       Keeper_turn_driver.message_looks_like_cli_wrapped_hard_quota detail
       || Keeper_turn_driver.message_looks_like_cli_wrapped_max_turns detail
+      || message_looks_like_gateway_backpressure detail
       || message_looks_like_capacity_backpressure detail
   | Some (Keeper_turn_driver.Capacity_backpressure _) ->
       true
@@ -367,6 +382,11 @@ let degraded_retry_after_recoverable_error
     | Some
         (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Other_detail detail; _ })
+      when message_looks_like_gateway_backpressure detail ->
+        local_recovery_retry Capacity_exhausted
+    | Some
+        (Keeper_turn_driver.Cascade_exhausted
+           { reason = Keeper_types.Other_detail detail; _ })
       when message_looks_like_capacity_backpressure detail ->
         local_recovery_retry Cascade_exhausted
     | Some (Keeper_turn_driver.Cascade_exhausted _)
@@ -418,6 +438,11 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
     | Some
         (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Other_detail detail; _ })
+      when message_looks_like_gateway_backpressure detail ->
+        Some Capacity_exhausted
+    | Some
+        (Keeper_turn_driver.Cascade_exhausted
+           { reason = Keeper_types.Other_detail detail; _ })
       when message_looks_like_capacity_backpressure detail ->
         Some Cascade_exhausted
     | Some (Keeper_turn_driver.Cascade_exhausted _) ->
@@ -460,6 +485,11 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
         (match err with
          | Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited _) ->
              Some Rate_limit
+         | Agent_sdk.Error.Api (Llm_provider.Retry.Overloaded _) ->
+             Some Capacity_exhausted
+         | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError { status; _ })
+           when is_gateway_backpressure_status status ->
+             Some Capacity_exhausted
          | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError { status; _ })
            when status >= 500 ->
              Some Server_error
@@ -472,6 +502,9 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
              Some Capacity_exhausted
          | Agent_sdk.Error.Provider (Llm_provider.Error.HardQuota _) ->
              Some Hard_quota
+         | Agent_sdk.Error.Provider (Llm_provider.Error.ServerError { code; _ })
+           when is_gateway_backpressure_status code ->
+             Some Capacity_exhausted
          | Agent_sdk.Error.Provider (Llm_provider.Error.ServerError { code; transient; _ })
            when transient || code >= 500 ->
              Some Server_error
@@ -494,7 +527,6 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
          (* Sub-500 server errors (4xx already handled above for AuthError /
             RateLimited) are not classified as recoverable cascade failures. *)
          | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError _)
-         | Agent_sdk.Error.Api (Llm_provider.Retry.Overloaded _)
          | Agent_sdk.Error.Api (Llm_provider.Retry.InvalidRequest _)
          | Agent_sdk.Error.Api (Llm_provider.Retry.NotFound _)
          | Agent_sdk.Error.Api (Llm_provider.Retry.ContextOverflow _)

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -111,6 +111,7 @@ val fallback_cascade_for_unavailable_profile :
     Status-code-aware rotation: raw API errors that are not wrapped in a MASC
     internal error are also classified when a different cascade may succeed:
     - [RateLimited] (non-hard-quota) → ["rate_limit"]
+    - [Overloaded] and Cloudflare 524 → ["capacity_backpressure"]
     - [ServerError] with status >= 500 → ["server_error"]
     - [AuthError] → ["auth_error"]
 

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -347,7 +347,7 @@ let test_server_error_502_is_recoverable () =
   | None ->
     fail "ServerError 502 should be recoverable (trigger cascade rotation)"
 
-let test_server_error_524_is_recoverable_rotation_not_transient_retry () =
+let test_server_error_524_is_capacity_backpressure_rotation_not_transient_retry () =
   let err =
     Agent_sdk.Error.Api
       (Retry.ServerError { status = 524; message = "a timeout occurred" })
@@ -355,10 +355,24 @@ let test_server_error_524_is_recoverable_rotation_not_transient_retry () =
   check bool "524 not same-cascade transient" false (KEC.is_transient_network_error err);
   match KEC.recoverable_cascade_failure_reason err with
   | Some reason ->
-    check string "524 -> server_error" "server_error" (KEC.degraded_retry_reason_to_string reason)
+    check string "524 -> capacity_backpressure" "capacity_backpressure"
+      (KEC.degraded_retry_reason_to_string reason)
   | None ->
-    fail "ServerError 524 should remain recoverable through degraded rotation"
+    fail "ServerError 524 should be recoverable as capacity backpressure"
 
+let test_wrapped_524_is_capacity_backpressure () =
+  let err =
+    make_cascade_exhausted
+      (KT.Other_detail
+         "all tiers failed (last runtime=runtime, error=Server error 524: error \
+          code: 524)")
+  in
+  match KEC.recoverable_cascade_failure_reason err with
+  | Some reason ->
+    check string "wrapped 524 -> capacity_backpressure" "capacity_backpressure"
+      (KEC.degraded_retry_reason_to_string reason)
+  | None ->
+    fail "Wrapped ServerError 524 should be recoverable as capacity backpressure"
 let test_auth_error_is_recoverable () =
   (* 401/403 auth errors: the current cascade's credentials are invalid.
      A different cascade with different credentials may succeed. *)
@@ -480,8 +494,12 @@ let () =
             test_server_error_503_is_recoverable;
           test_case "ServerError 502 is recoverable" `Quick
             test_server_error_502_is_recoverable;
-          test_case "ServerError 524 is rotation recoverable but not transient retry" `Quick
-            test_server_error_524_is_recoverable_rotation_not_transient_retry;
+          test_case
+            "ServerError 524 is capacity backpressure but not transient retry"
+            `Quick
+            test_server_error_524_is_capacity_backpressure_rotation_not_transient_retry;
+          test_case "wrapped ServerError 524 is capacity backpressure" `Quick
+            test_wrapped_524_is_capacity_backpressure;
           test_case "AuthError is recoverable" `Quick
             test_auth_error_is_recoverable;
           test_case "hard quota keeps hard_quota label" `Quick


### PR DESCRIPTION
Summary:
- classify raw and wrapped Cloudflare 524 failures as capacity_backpressure for degraded cascade rotation
- classify API Overloaded as capacity_backpressure instead of falling through as non-recoverable
- repair latest main Dune/extraction compile issues exposed during verification
- remove stale dashboard deprecated-alias assertion and make the temp git fixture respect the no-direct-main hook
- add curated MLIs for extracted modules instead of regenerating the OCaml structure ratchet baseline
- refresh generated runtime tunables docs with the repo generator

Validation:
- ocamlformat --check test/test_dashboard_tools.ml lib/coord/coord_task_verification.mli lib/keeper/keeper_heartbeat_loop_in_turn_pulse.mli lib/keeper/keeper_run_tools_hook_accumulator.mli lib/keeper/keeper_turn_driver_admission.mli lib/keeper/keeper_types_profile.mli lib/keeper/keeper_unified_metrics_broadcast.mli lib/cascade/cascade_transport_authorization.mli lib/cascade/cascade_transport_label_resolution.mli lib/operator/operator_control_snapshot_tool_names.mli lib/server/server_dashboard_http_core_cache.mli
- git diff --check
- git diff --check HEAD
- bash scripts/ocaml-structure-ratchet.sh
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_dashboard_tools.exe test/test_keeper_error_classify_recoverable.exe test/test_keeper_task_dispatch.exe test/test_verification_fsm.exe test/test_keeper_unified_turn_pipeline_records.exe test/test_keeper_runtime_manifest.exe
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_dashboard_tools.exe
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_toml.exe test/test_dashboard_tools.exe
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh exec ./bin/env_knob_catalog.exe -- docs/runtime-tunables.md
- _build/default/test/test_dashboard_tools.exe
- _build/default/test/test_keeper_error_classify_recoverable.exe
- _build/default/test/test_keeper_task_dispatch.exe
- _build/default/test/test_verification_fsm.exe
- _build/default/test/test_keeper_unified_turn_pipeline_records.exe
- _build/default/test/test_keeper_runtime_manifest.exe
- bash scripts/check-pr-sync.sh --head-branch codex/report-closeout-verify-20260521 --expected-head-sha 73e5bcc686f1f1b1bdbd34ddb6d791be872fcd12 --pr-number 17179 --remote origin

Notes:
- _build/default/test/test_keeper_toml.exe was built after the MLI fix; direct local execution still requires a resolved cascade config root and is not used as a local pass signal in this worktree.
- Manual workflow_dispatch CI is being used for branch verification because GitHub did not attach a fresh pull_request CI run after the draft-branch push.