### PR TITLE
refactor(keeper_run_tools): extract task scope helpers into sibling (Lane B second)

### DIFF
--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -53,28 +53,9 @@ let freeze = Keeper_run_tools_hook_accumulator.freeze
 let merge_requested_tool_names_seen = Keeper_run_tools_hook_accumulator.merge_requested_tool_names_seen
 let record_requested_tool_names = Keeper_run_tools_hook_accumulator.record_requested_tool_names
 
-let task_scope_tool_names =
-  [ "masc_transition"
-  ; "keeper_task_done"
-  ; "keeper_task_submit_for_verification"
-  ; "keeper_task_force_done"
-  ; "keeper_task_force_release"
-  ]
-;;
-
-let json_string_opt name = function
-  | `Assoc fields ->
-    (match List.assoc_opt name fields with
-     | Some (`String value) when String.trim value <> "" -> Some (String.trim value)
-     | _ -> None)
-  | _ -> None
-;;
-
-let task_id_scope_of_tool_input ~tool_name input =
-  if List.mem tool_name task_scope_tool_names
-  then json_string_opt "task_id" input
-  else None
-;;
+let task_scope_tool_names = Keeper_run_tools_task_scope.task_scope_tool_names
+let json_string_opt = Keeper_run_tools_task_scope.json_string_opt
+let task_id_scope_of_tool_input = Keeper_run_tools_task_scope.task_id_scope_of_tool_input
 
 type tool_search_hit_partition = Tool_search.tool_search_hit_partition =
   { visible_core_hits : (string * float) list

--- a/lib/keeper/keeper_run_tools_task_scope.ml
+++ b/lib/keeper/keeper_run_tools_task_scope.ml
@@ -1,0 +1,27 @@
+(** Task-scope tool name helpers extracted from keeper_run_tools.ml.
+
+    Pure helpers for selecting task_id-scoped tools and extracting the
+    task_id from a tool input JSON object. *)
+
+let task_scope_tool_names =
+  [ "masc_transition"
+  ; "keeper_task_done"
+  ; "keeper_task_submit_for_verification"
+  ; "keeper_task_force_done"
+  ; "keeper_task_force_release"
+  ]
+;;
+
+let json_string_opt name = function
+  | `Assoc fields ->
+    (match List.assoc_opt name fields with
+     | Some (`String value) when String.trim value <> "" -> Some (String.trim value)
+     | _ -> None)
+  | _ -> None
+;;
+
+let task_id_scope_of_tool_input ~tool_name input =
+  if List.mem tool_name task_scope_tool_names
+  then json_string_opt "task_id" input
+  else None
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane B (Keeper Runtime), second cluster after #17109 (hook_accumulator)
- Small focused cluster — pure task-scope helpers.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/keeper/keeper_run_tools.ml` | 1798 | 1779 | **-19** |
| `lib/keeper/keeper_run_tools_task_scope.ml` | — | 27 | +27 |

## Moved (verbatim, no behavior change)
- `task_scope_tool_names` (list of MASC + keeper tools that consume `task_id`)
- `json_string_opt` (option-returning JSON string extractor)
- `task_id_scope_of_tool_input` (returns `task_id` only for tools in the scope list)

## Local build status
Blocked by pre-existing `keeper_turn_driver.ml:1063` partial-match warning-as-error. Fix in #17153.

## RFC-WAIVED
Extract-only sibling refactor, pure helpers, no behavior change.

Co-Authored-By: codex <noreply@anthropic.com>
