### PR TITLE
chore(keeper): drop gh output limit constant

### DIFF
--- a/lib/keeper/keeper_gh_shared.ml
+++ b/lib/keeper/keeper_gh_shared.ml
@@ -523,12 +523,6 @@ let gh_dangerous_command (cmd : string) : string option =
   | _ -> None
 ;;
 
-(** Truncate gh output to prevent context explosion.
-    65KB responses were observed causing 300s timeout via token overflow.
-    Retained for .mli backward compatibility; runtime limit comes from
-    [gh_cache.max_output_bytes] in tool_policy.toml. *)
-let max_gh_output_bytes = 8192
-
 let truncate_gh_output (out : string) : string * (string * Yojson.Safe.t) list =
   let max_bytes = Keeper_tool_policy.gh_cache_max_output_bytes () in
   let len = String.length out in

--- a/lib/keeper/keeper_gh_shared.mli
+++ b/lib/keeper/keeper_gh_shared.mli
@@ -68,10 +68,10 @@ val gh_not_found_hint :
   out:string ->
   (string * Yojson.Safe.t) list
 
-val max_gh_output_bytes : int
-
 val truncate_gh_output :
   string -> string * (string * Yojson.Safe.t) list
+(** Truncate large gh output using the runtime [gh_cache.max_output_bytes]
+    policy. *)
 
 (* ---- gh command parsers --------------------------------------- *)
 


### PR DESCRIPTION
## Summary
- remove unused `Keeper_gh_shared.max_gh_output_bytes`
- keep `truncate_gh_output` on the runtime `gh_cache.max_output_bytes` policy
- document the canonical runtime policy on the remaining public function

## Verification
- `rg -n "max_gh_output_bytes" lib test docs` returned no matches
- `ocamlformat --check lib/keeper/keeper_gh_shared.ml lib/keeper/keeper_gh_shared.mli`
- `git diff --check`
- focused Dune build for `lib/keeper/keeper_gh_shared.cmx` was blocked by `/tmp/me-dune-local.lock`; holder was PID 40209 running `test/test_exec_shell_command_gate.exe` around 2026-05-21 03:34:19 KST