### PR TITLE
fix(shell): enforce policy on typed pipeline lowering

### DIFF
--- a/lib/exec/command_gate/shell_command_gate.ml
+++ b/lib/exec/command_gate/shell_command_gate.ml
@@ -422,15 +422,12 @@ let gate_typed ?caller:_ ~ir ~allowlist ~path_policy ~sandbox () : verdict =
   | Ok stages -> apply_policy ~allowlist ~path_policy ~sandbox ~stages
 ;;
 
-let lower_typed_pipeline ?caller:_ ~stages ~sandbox () : verdict =
+let lower_typed_pipeline ?caller:_ ~stages ~allowlist ~path_policy ~sandbox ()
+    : verdict =
   (* See note on [gate] — [caller] is API-shape-only for now. *)
   match stages with
   | [] -> Cannot_parse { reason = Parse_error }
-  | _ ->
-    let stages = stages_with_sandbox ~sandbox stages in
-    (match make_context ~stages with
-     | None -> Cannot_parse { reason = Parse_error }
-     | Some context -> Allow context)
+  | _ -> apply_policy ~allowlist ~path_policy ~sandbox ~stages
 ;;
 
 let caller_tag = function

--- a/lib/exec/command_gate/shell_command_gate.mli
+++ b/lib/exec/command_gate/shell_command_gate.mli
@@ -173,18 +173,21 @@ val gate_typed
 val lower_typed_pipeline
   :  ?caller:caller
   -> stages:Masc_exec.Shell_ir.simple list
+  -> allowlist:allowlist_policy
+  -> path_policy:path_policy
   -> sandbox:sandbox_context
   -> unit
   -> verdict
 (** Lower a typed pipeline (e.g. from {!Keeper_tool_bash_input}) into
     the same {!verdict} shape. Empty input yields {!Cannot_parse
-    Parse_error}; a single stage yields [Allow] with a [Simple] AST;
-    multiple stages yield [Allow] with a non-nested
-    [Pipeline]. Nested pipelines are forbidden because the input type
-    already guarantees [Simple] stages — this helper exists so typed
-    input shares the {!verdict} surface with raw input.  [?caller] is
-    captured for the upcoming telemetry partition (RFC-0131 PR-3) and
-    does not affect the verdict. *)
+    Parse_error}; a single stage yields a [Simple] AST; multiple
+    stages yield a non-nested [Pipeline]. The resulting context then
+    runs through the same allowlist, redirect, path-policy, and
+    sandbox handling as {!gate}. Nested pipelines are forbidden
+    because the input type already guarantees [Simple] stages — this
+    helper exists so typed input shares the {!verdict} surface with raw
+    input.  [?caller] is captured for the upcoming telemetry partition
+    (RFC-0131 PR-3) and does not affect the verdict. *)
 
 (** {1 Tags for telemetry} *)
 

--- a/test/test_exec_shell_command_gate.ml
+++ b/test/test_exec_shell_command_gate.ml
@@ -337,7 +337,12 @@ let test_lower_typed_single_stage () =
     }
   in
   match
-    Gate.lower_typed_pipeline ~stages:[ stage ] ~sandbox:Gate.host_sandbox ()
+    Gate.lower_typed_pipeline
+      ~stages:[ stage ]
+      ~allowlist
+      ~path_policy:Gate.allow_all_paths
+      ~sandbox:Gate.host_sandbox
+      ()
   with
   | Gate.Allow context ->
     Alcotest.(check int) "stage count" 1 (Gate.stage_count context);
@@ -374,6 +379,8 @@ let test_lower_typed_three_stage_matches_raw () =
               ; make_stage "sort" []
               ; make_stage "head" [ "-20" ]
               ]
+      ~allowlist
+      ~path_policy:Gate.allow_all_paths
       ~sandbox:Gate.host_sandbox
       ()
   in
@@ -404,12 +411,60 @@ let test_lower_typed_three_stage_matches_raw () =
 
 let test_lower_typed_empty_is_cannot_parse () =
   match
-    Gate.lower_typed_pipeline ~stages:[] ~sandbox:Gate.host_sandbox ()
+    Gate.lower_typed_pipeline
+      ~stages:[]
+      ~allowlist
+      ~path_policy:Gate.allow_all_paths
+      ~sandbox:Gate.host_sandbox
+      ()
   with
   | Gate.Cannot_parse { reason = Gate.Parse_error } -> ()
   | other ->
     Alcotest.failf
       "empty typed pipeline must yield Cannot_parse parse_error, got %s"
+      (Gate.verdict_tag other)
+;;
+
+let test_lower_typed_applies_allowlist_policy () =
+  match
+    Gate.lower_typed_pipeline
+      ~stages:[ make_stage "rg" [ "foo" ]; make_stage "evil_cmd" [] ]
+      ~allowlist
+      ~path_policy:Gate.allow_all_paths
+      ~sandbox:Gate.host_sandbox
+      ()
+  with
+  | Gate.Reject
+      { reason = Gate.Pipeline_segment_disallowed { stage = 2; bin = "evil_cmd" }
+      ; _
+      } -> ()
+  | other ->
+    Alcotest.failf
+      "expected typed pipeline allowlist reject, got %s"
+      (Gate.verdict_tag other)
+;;
+
+let test_lower_typed_applies_path_policy () =
+  let classify ~raw_path =
+    if raw_path = "/etc/shadow" then `Deny "shadow not allowed" else `Allow
+  in
+  match
+    Gate.lower_typed_pipeline
+      ~stages:[ make_stage "cat" [ "/etc/shadow" ] ]
+      ~allowlist
+      ~path_policy:{ Gate.classify = Some classify }
+      ~sandbox:Gate.host_sandbox
+      ()
+  with
+  | Gate.Reject
+      { reason =
+          Gate.Path_outside_policy
+            { stage = 1; raw_path = "/etc/shadow"; diagnostic = "shadow not allowed" }
+      ; _
+      } -> ()
+  | other ->
+    Alcotest.failf
+      "expected typed pipeline path-policy reject, got %s"
       (Gate.verdict_tag other)
 ;;
 
@@ -772,6 +827,14 @@ let () =
             "empty typed input is Cannot_parse"
             `Quick
             test_lower_typed_empty_is_cannot_parse
+        ; Alcotest.test_case
+            "typed lowering applies allowlist policy"
+            `Quick
+            test_lower_typed_applies_allowlist_policy
+        ; Alcotest.test_case
+            "typed lowering applies path policy"
+            `Quick
+            test_lower_typed_applies_path_policy
         ; Alcotest.test_case
             "policy-aware typed gate shares raw policy surface"
             `Quick


### PR DESCRIPTION
## Summary
- make lower_typed_pipeline require the same allowlist/path/sandbox policy inputs as the Shell IR gate
- route typed pipeline lowering through apply_policy, including allowlist and path-policy rejection
- add typed lowering regression coverage for allowlist and path-policy rejection

## Stack
- Base: #17213 / codex/build-repair-keeper-wip-admission-20260521
- Rebase back to main after #17213 merges.

## Verification
- git diff --check codex/build-repair-keeper-wip-admission-20260521..HEAD
- ocamlformat --check lib/exec/command_gate/shell_command_gate.ml lib/exec/command_gate/shell_command_gate.mli test/test_exec_shell_command_gate.ml
- env DUNE_CACHE=disabled MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_exec_shell_command_gate.exe
- _build/default/test/test_exec_shell_command_gate.exe (24 tests)