### PR TITLE
fix(dashboard): prewarm light shell cache

### DIFF
--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -64,6 +64,8 @@ let shell_warming = Server_dashboard_http_core_cache.shell_warming
 let _shell_warming = Server_dashboard_http_core_cache._shell_warming
 let last_good_shell = Server_dashboard_http_core_cache.last_good_shell
 let _last_good_shell = Server_dashboard_http_core_cache._last_good_shell
+let last_good_shell_light = Server_dashboard_http_core_cache.last_good_shell_light
+let _last_good_shell_light = Server_dashboard_http_core_cache._last_good_shell_light
 let with_dashboard_timeout = Server_dashboard_http_core_cache.with_dashboard_timeout
 let cache_partition_segment = Server_dashboard_http_core_cache.cache_partition_segment
 let dashboard_cache_key = Server_dashboard_http_core_cache.dashboard_cache_key
@@ -1275,10 +1277,24 @@ let dashboard_shell_bootstrap_json (config : Coord.config) : Yojson.Safe.t =
          ]
 ;;
 
-let dashboard_shell_last_good_opt () =
-  match Atomic.get last_good_shell with
-  | `Assoc [] -> None
-  | json -> Some json
+let dashboard_shell_last_good_with_source ~light () =
+  let full_last_good () =
+    match Atomic.get last_good_shell with
+    | `Assoc [] -> None
+    | json -> Some (json, "last_good")
+  in
+  if light
+  then (
+    match Atomic.get last_good_shell_light with
+    | `Assoc [] -> full_last_good ()
+    | json -> Some (json, "last_good_light"))
+  else full_last_good ()
+;;
+
+let remember_dashboard_shell_last_good ~light json =
+  if light
+  then Atomic.set last_good_shell_light json
+  else Atomic.set last_good_shell json
 ;;
 
 let is_dashboard_cache_timeout_json = function
@@ -1669,8 +1685,8 @@ let dashboard_shell_http_json
     | None -> Eio_context.get_clock_opt ()
   in
   let fallback_payload_with_source () =
-    match dashboard_shell_last_good_opt () with
-    | Some json -> json, "last_good"
+    match dashboard_shell_last_good_with_source ~light () with
+    | Some (json, source) -> json, source
     | None -> dashboard_shell_bootstrap_json config, "bootstrap"
   in
   let fallback_payload () =
@@ -1734,7 +1750,9 @@ let dashboard_shell_http_json
       in
       if is_dashboard_cache_timeout_json computed
       then timeout_fallback_payload (dashboard_shell_timeout_for ~light)
-      else computed)
+      else (
+        remember_dashboard_shell_last_good ~light computed;
+        computed))
   in
   match request with
   | None -> payload

--- a/lib/server/server_dashboard_http_core.mli
+++ b/lib/server/server_dashboard_http_core.mli
@@ -38,6 +38,7 @@ val operator_digest_cache : cached_surface
 val shell_warmed : bool Atomic.t
 val shell_warming : bool Atomic.t
 val last_good_shell : Yojson.Safe.t Atomic.t
+val last_good_shell_light : Yojson.Safe.t Atomic.t
 
 (** Late-bound broadcast callbacks — set by [Server_dashboard_http]
     after [Sse] module is in scope. *)

--- a/lib/server/server_dashboard_http_core_cache.ml
+++ b/lib/server/server_dashboard_http_core_cache.ml
@@ -23,6 +23,11 @@ let _shell_warming = shell_warming
 let last_good_shell : Yojson.Safe.t Atomic.t = Atomic.make (`Assoc [])
 let _last_good_shell = last_good_shell
 
+(** Last-known-good light shell result for first-paint requests while
+    full shell pre-warm is still running. *)
+let last_good_shell_light : Yojson.Safe.t Atomic.t = Atomic.make (`Assoc [])
+let _last_good_shell_light = last_good_shell_light
+
 (** Wrap a dashboard computation with a configurable timeout.
     Returns a partial-response JSON on timeout instead of hanging. *)
 let with_dashboard_timeout ~clock compute =

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -16,20 +16,43 @@ let warm_shell_cache (state : Mcp_server.server_state) =
     ~finally:(fun () -> Atomic.set shell_warming false)
     (fun () ->
        let t0 = Time_compat.now () in
-       try
-         let cache_key = dashboard_shell_cache_key state.Mcp_server.room_config in
-         let compute () = dashboard_shell_payload_json state.Mcp_server.room_config in
-         let result =
-           match state.Mcp_server.clock with
-           | Some clock ->
-             Dashboard_cache.get_or_compute_with_timeout
-               cache_key
-               ~ttl:15.0
-               ~clock
-               ~timeout_sec:shell_prewarm_timeout_s
-               compute
-           | None -> Dashboard_cache.get_or_compute cache_key ~ttl:15.0 compute
+       let cache_shell_payload ~light =
+         let cache_key =
+           dashboard_shell_cache_key ~light state.Mcp_server.room_config
          in
+         let compute () =
+           dashboard_shell_payload_json ~light state.Mcp_server.room_config
+         in
+         match state.Mcp_server.clock with
+         | Some clock ->
+           Dashboard_cache.get_or_compute_with_timeout
+             cache_key
+             ~ttl:15.0
+             ~clock
+             ~timeout_sec:shell_prewarm_timeout_s
+             compute
+         | None -> Dashboard_cache.get_or_compute cache_key ~ttl:15.0 compute
+       in
+       (try
+          let light_result = cache_shell_payload ~light:true in
+          if is_dashboard_cache_timeout_json light_result
+          then
+            Log.Dashboard.warn
+              "light shell cache pre-warm timed out during compute (%.0fs)"
+              shell_prewarm_timeout_s
+          else (
+            Atomic.set last_good_shell_light light_result;
+            Log.Dashboard.info
+              "light shell cache pre-warmed (%.1fms)"
+              ((Time_compat.now () -. t0) *. 1000.0))
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+          Log.Dashboard.warn
+            "light shell cache pre-warm failed: %s"
+            (Printexc.to_string exn));
+       try
+         let result = cache_shell_payload ~light:false in
          if is_dashboard_cache_timeout_json result
          then
            Log.Dashboard.warn

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -323,6 +323,85 @@ let test_dashboard_shell_http_json_prefers_last_good_while_prewarming () =
       check int "last-good counts reused" 7
         (json |> member "counts" |> member "agents" |> to_int))
 
+let test_dashboard_shell_http_json_records_light_last_good () =
+  with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  let original_light_last_good =
+    Atomic.get Lib.Server_dashboard_http.last_good_shell_light
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      Lib.Dashboard_cache.invalidate_all ();
+      Atomic.set
+        Lib.Server_dashboard_http.last_good_shell_light
+        original_light_last_good)
+    (fun () ->
+      Lib.Dashboard_cache.invalidate_all ();
+      Atomic.set Lib.Server_dashboard_http.last_good_shell_light (`Assoc []);
+      let json =
+        Lib.Server_dashboard_http_core.dashboard_shell_http_json ~light:true config
+      in
+      let cached = Atomic.get Lib.Server_dashboard_http.last_good_shell_light in
+      let open Yojson.Safe.Util in
+      check bool "light last-good populated" true (cached = json);
+      check bool "cached payload is light shell" true
+        (cached
+         |> member "projection_diagnostics"
+         |> member "light"
+         |> to_bool))
+
+let test_dashboard_shell_http_json_prefers_light_last_good_while_prewarming () =
+  with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  let original_warmed = Atomic.get Lib.Server_dashboard_http.shell_warmed in
+  let original_warming = Atomic.get Lib.Server_dashboard_http.shell_warming in
+  let original_last_good = Atomic.get Lib.Server_dashboard_http.last_good_shell in
+  let original_light_last_good =
+    Atomic.get Lib.Server_dashboard_http.last_good_shell_light
+  in
+  let full_last_good =
+    `Assoc
+      [
+        ("status", `Assoc [("project", `String "full-room")]);
+        ("counts", `Assoc [("agents", `Int 9)]);
+      ]
+  in
+  let light_last_good =
+    `Assoc
+      [
+        ("status", `Assoc [("project", `String "light-room")]);
+        ("counts", `Assoc [("agents", `Int 2)]);
+        ("projection_diagnostics", `Assoc [("light", `Bool true)]);
+      ]
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      Atomic.set Lib.Server_dashboard_http.shell_warmed original_warmed;
+      Atomic.set Lib.Server_dashboard_http.shell_warming original_warming;
+      Atomic.set Lib.Server_dashboard_http.last_good_shell original_last_good;
+      Atomic.set
+        Lib.Server_dashboard_http.last_good_shell_light
+        original_light_last_good)
+    (fun () ->
+      Atomic.set Lib.Server_dashboard_http.shell_warmed false;
+      Atomic.set Lib.Server_dashboard_http.shell_warming true;
+      Atomic.set Lib.Server_dashboard_http.last_good_shell full_last_good;
+      Atomic.set Lib.Server_dashboard_http.last_good_shell_light light_last_good;
+      let json =
+        Lib.Server_dashboard_http_core.dashboard_shell_http_json
+          ~request:(request "/api/v1/dashboard/shell?light=1")
+          ~light:true
+          config
+      in
+      let open Yojson.Safe.Util in
+      check string "light last-good project reused" "light-room"
+        (json |> member "status" |> member "project" |> to_string);
+      check int "light last-good counts reused" 2
+        (json |> member "counts" |> member "agents" |> to_int);
+      check bool "light diagnostics preserved" true
+        (json
+         |> member "projection_diagnostics"
+         |> member "light"
+         |> to_bool))
+
 let test_operator_snapshot_default_route_hydrates_first_success () =
   let source = read_file "lib/server/server_dashboard_http_core.ml" in
   check bool "operator snapshot uses first-success cache helper" true
@@ -990,6 +1069,10 @@ let () =
             test_dashboard_shell_http_json_uses_bootstrap_payload_while_prewarming;
           test_case "shell reuses last good payload while prewarming" `Quick
             test_dashboard_shell_http_json_prefers_last_good_while_prewarming;
+          test_case "shell records light last good payload" `Quick
+            test_dashboard_shell_http_json_records_light_last_good;
+          test_case "shell reuses light last good payload while prewarming" `Quick
+            test_dashboard_shell_http_json_prefers_light_last_good_while_prewarming;
           test_case "operator snapshot hydrates on first default request" `Quick
             test_operator_snapshot_default_route_hydrates_first_success;
           test_case "operator snapshot default route exposes provenance" `Quick


### PR DESCRIPTION
## Summary
- add a dedicated last-good atomic for light dashboard shell payloads
- prewarm the light shell cache before the full shell cache so first-paint light requests can reuse cached JSON
- prefer light last-good payloads during startup prewarm and timeout fallback, with regression tests

## Validation
- ocamlformat --check lib/server/server_dashboard_http_core_cache.ml lib/server/server_dashboard_http_core.ml lib/server/server_dashboard_http_core.mli lib/server/server_dashboard_http_execution_surfaces.ml test/test_dashboard_http_core.ml
- ocamlc -stop-after parsing lib/server/server_dashboard_http_core_cache.ml lib/server/server_dashboard_http_core.ml lib/server/server_dashboard_http_core.mli lib/server/server_dashboard_http_execution_surfaces.ml test/test_dashboard_http_core.ml
- git diff --check

## Not Run
- scripts/dune-local.sh build test/test_dashboard_http_core.exe: blocked because scripts/dune-local.sh detected a live bare dune build in another worktree: dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/runtime-health-observability-20260521 bin/main_eio.exe