### PR TITLE
chore(cascade): drop http probe url heuristic helper

### DIFF
--- a/lib/cascade/cascade_http_probe.ml
+++ b/lib/cascade/cascade_http_probe.ml
@@ -1,18 +1,5 @@
 (** See cascade_http_probe.mli for documentation. *)
 
-(* ── URL classification ─────────────────────────────────────── *)
-
-(* Re-export the shared heuristic from [Masc_network_defaults].  Keeping
-   the symbol here preserves this module's public [.mli] surface while
-   eliminating the substring literal duplicated across cascade modules.
-
-   Substring-scan classification is unreliable: a vLLM server on :11434
-   matches; an ollama on a non-default port does not. The probe's
-   [Http_probe] adapter therefore consults an explicit registry instead
-   (see [registered_urls] below); [is_ollama_url] survives only as a
-   transitional helper for legacy callers in other modules. *)
-let is_ollama_url = Masc_network_defaults.is_ollama_url
-
 (* ── Explicit URL registry (replaces substring scan inside this module) ───
    Probes only fire against URLs that callers have explicitly registered,
    eliminating the [:11434] substring heuristic's false positives. The

--- a/lib/cascade/cascade_http_probe.mli
+++ b/lib/cascade/cascade_http_probe.mli
@@ -27,20 +27,6 @@
 
     @since 0.9.8 *)
 
-(** {1 URL classification} *)
-
-(** [is_ollama_url url] mirrors the heuristic in
-    {!Cascade_client_capacity.looks_like_ollama}: any URL whose
-    host:port substring contains [:11434].  Re-exported here so
-    callers do not have to depend on both modules.
-
-    Prefer {!register_url} + {!is_registered} for new code: substring
-    matching misclassifies non-ollama servers running on :11434 and
-    misses ollama servers on non-default ports.  The {!Http_probe}
-    adapter no longer consults this function — it uses the registry
-    below. *)
-val is_ollama_url : string -> bool
-
 (** {1 Explicit URL registry}
 
     The {!Http_probe} adapter only fires against URLs that callers
@@ -86,9 +72,10 @@ val cached_capacity : ?now:float -> string -> Cascade_throttle.capacity_info opt
     Default [timeout_s] is [0.5] seconds; pass an explicit
     [?timeout_s] argument to override per-call.
 
-    Caller is responsible for picking [url]s that look like ollama
-    (use {!is_ollama_url}); calling on a non-ollama URL will fail
-    with a network error and return [None].
+    Caller is responsible for picking registered ollama-native [url]s
+    (use {!register_url} + {!is_registered} at the caller boundary);
+    calling on a non-ollama URL will fail with a network error and
+    return [None].
 
     The HTTP error path is intentionally silent — failed probes
     must never break the cascade, only deny the optimisation. *)
@@ -103,9 +90,8 @@ val try_probe
 
 (** {1 Probing many URLs} *)
 
-(** [refresh_many ~sw ~net urls] runs {!try_probe} on every URL in
-    [urls] that {!is_ollama_url} accepts and is not already covered
-    by a fresh cache entry.  Probes run sequentially in the
+(** [refresh_many ~sw ~net urls] runs {!try_probe} on every registered URL in
+    [urls] that is not already covered by a fresh cache entry.  Probes run sequentially in the
     caller's fiber; aggregate latency is bounded by [N * timeout_s]
     where [N] is the number of probes actually issued.
 

--- a/test/test_cascade_http_probe.ml
+++ b/test/test_cascade_http_probe.ml
@@ -4,7 +4,8 @@
     here — it depends on a live ollama daemon and is covered by
     manual smoke tests.  The unit surface focuses on:
 
-    - URL classification ([is_ollama_url]);
+    - explicit URL registry ([register_url], [is_registered],
+      [Http_probe.can_probe]);
     - JSON parsing ([parse_response]);
     - cache lifecycle ([cached_capacity], [cache_size],
       [cache_clear]) with explicit [now] for deterministic TTL
@@ -14,23 +15,7 @@ open Alcotest
 module P = Masc_mcp.Cascade_http_probe
 module Throttle = Masc_mcp.Cascade_throttle
 
-(* ── URL classification ─────────────────────────────────────── *)
-
-let test_is_ollama_url_positive () =
-  check bool "127.0.0.1:11434 → ollama" true
-    (P.is_ollama_url "http://127.0.0.1:11434");
-  check bool "localhost:11434 → ollama" true
-    (P.is_ollama_url "http://localhost:11434/api");
-  check bool "remote:11434 → ollama" true
-    (P.is_ollama_url "https://gpu.example.com:11434/v1")
-
-let test_is_ollama_url_negative () =
-  check bool "no port → not ollama" false
-    (P.is_ollama_url "http://gemini.example.com");
-  check bool "wrong port → not ollama" false
-    (P.is_ollama_url "http://127.0.0.1:11435");
-  check bool "empty → not ollama" false
-    (P.is_ollama_url "")
+(* ── URL canonicalization ───────────────────────────────────── *)
 
 let test_normalize_loopback_base_url () =
   check string "localhost canonicalizes to IPv4 loopback"
@@ -167,9 +152,7 @@ let test_can_probe_rejects_substring_only_match () =
 
 let () =
   run "cascade_http_probe" [
-    "is_ollama_url", [
-      test_case "positive matches" `Quick test_is_ollama_url_positive;
-      test_case "negative cases" `Quick test_is_ollama_url_negative;
+    "URL canonicalization", [
       test_case "loopback base URL canonicalization" `Quick
         test_normalize_loopback_base_url;
     ];


### PR DESCRIPTION
## Summary
- remove the public `Cascade_http_probe.is_ollama_url` transitional helper
- keep HTTP probe routing on explicit URL registration via `register_url`/`is_registered`/`Http_probe.can_probe`
- remove substring heuristic tests from the cascade HTTP probe suite

## Verification
- targeted residue search for `Cascade_http_probe.is_ollama_url`, `P.is_ollama_url`, and the transitional helper binding returned no matches in `cascade_http_probe` sources/tests
- `ocamlformat --check lib/cascade/cascade_http_probe.ml lib/cascade/cascade_http_probe.mli test/test_cascade_http_probe.ml`
- `git diff --check`
- focused Dune build for `test/test_cascade_http_probe.exe` was blocked by bare Dune processes outside `scripts/dune-local.sh` around 2026-05-21 03:41:38 KST