### PR TITLE
chore(identity): drop archetype fallback wrapper

### DIFF
--- a/lib/agent_identity.ml
+++ b/lib/agent_identity.ml
@@ -395,17 +395,6 @@ let archetype_of_string_opt = function
   | "generalist" | "" -> Some Generalist
   | _ -> None
 
-(** Back-compat wrapper: callers that have no other recovery still
-    fall back to [Generalist] but a warning is logged so the typo /
-    drift becomes operator-visible. *)
-let archetype_of_string s =
-  match archetype_of_string_opt s with
-  | Some v -> v
-  | None ->
-      Log.Misc.warn
-        "archetype_of_string: unknown wire string %S → Generalist fallback (#8691)" s;
-      Generalist
-
 let archetype_emoji = function
   | Melchior -> "🔬"
   | Balthasar -> "🪞"
@@ -416,8 +405,15 @@ let archetype_emoji = function
 (** Get archetype from identity metadata *)
 let get_archetype identity =
   match List.assoc_opt "archetype" identity.metadata with
-  | Some s -> archetype_of_string s
   | None -> Generalist
+  | Some s -> (
+      match archetype_of_string_opt s with
+      | Some archetype -> archetype
+      | None ->
+          Log.Misc.warn
+            "get_archetype: unknown archetype metadata %S → Generalist fallback (#8691)"
+            s;
+          Generalist)
 
 (** Set archetype in identity metadata *)
 let set_archetype identity archetype =

--- a/lib/agent_identity.mli
+++ b/lib/agent_identity.mli
@@ -95,13 +95,9 @@ type archetype =
 val archetype_to_string : archetype -> string
 
 (** Strict parse: returns [None] when the wire string is not one of the
-    canonical archetype labels (with aliases). Prefer this over
-    [archetype_of_string] for new code so drift is visible. Issue #8691. *)
+    canonical archetype labels (with aliases), so drift is visible at the
+    caller boundary. Issue #8691. *)
 val archetype_of_string_opt : string -> archetype option
-
-(** Back-compat parse: returns [Generalist] on unknown strings and
-    logs a warning so the typo is operator-visible. Issue #8691. *)
-val archetype_of_string : string -> archetype
 
 val archetype_emoji : archetype -> string
 

--- a/test/test_agent_identity.ml
+++ b/test/test_agent_identity.ml
@@ -134,6 +134,32 @@ let test_channel_yojson_backward_compat () =
        (Agent_identity.channel_to_yojson
           (Agent_identity.External "  Custom-Edge  ")))
 
+let pp_archetype fmt archetype =
+  Format.fprintf fmt "%s" (Agent_identity.archetype_to_string archetype)
+
+let archetype = testable pp_archetype ( = )
+
+let test_archetype_parser_strict () =
+  check (option archetype) "canonical" (Some Agent_identity.Melchior)
+    (Agent_identity.archetype_of_string_opt "melchior");
+  check (option archetype) "alias" (Some Agent_identity.Casper)
+    (Agent_identity.archetype_of_string_opt "planner");
+  check (option archetype) "generalist explicit" (Some Agent_identity.Generalist)
+    (Agent_identity.archetype_of_string_opt "generalist");
+  check (option archetype) "unknown is drift" None
+    (Agent_identity.archetype_of_string_opt "planner-ish")
+
+let test_get_archetype_fallback_is_boundary_local () =
+  let base = Agent_identity.from_agent_name "archetype-agent" in
+  check archetype "known metadata" Agent_identity.Melchior
+    (Agent_identity.get_archetype
+       { base with Agent_identity.metadata = [ ("archetype", "tech") ] });
+  check archetype "unknown metadata fallback" Agent_identity.Generalist
+    (Agent_identity.get_archetype
+       { base with Agent_identity.metadata = [ ("archetype", "planner-ish") ] });
+  check archetype "missing metadata fallback" Agent_identity.Generalist
+    (Agent_identity.get_archetype base)
+
 let test_same_agent () =
   let id1 = Agent_identity.from_agent_name "agent-a" in
   let id2 = { id1 with Agent_identity.last_seen = Unix.gettimeofday () +. 100.0 } in
@@ -271,6 +297,9 @@ let () =
       test_case "channel_normalization" `Quick test_channel_normalization;
       test_case "channel_yojson_backward_compat" `Quick
         test_channel_yojson_backward_compat;
+      test_case "archetype_parser_strict" `Quick test_archetype_parser_strict;
+      test_case "get_archetype_fallback_is_boundary_local" `Quick
+        test_get_archetype_fallback_is_boundary_local;
       test_case "same_agent" `Quick test_same_agent;
       test_case "to_display_string" `Quick test_to_display_string;
       test_case "to_display_string_empty_session_key" `Quick test_to_display_string_empty_session_key;


### PR DESCRIPTION
## Summary\n\n- remove the public `Agent_identity.archetype_of_string` back-compat fallback wrapper\n- route `get_archetype` through the strict `archetype_of_string_opt` parser and keep the `Generalist` fallback local to that metadata boundary\n- add focused tests for strict parsing and the boundary-local fallback\n\n## Verification\n\n- `ocamlformat --check lib/agent_identity.ml lib/agent_identity.mli test/test_agent_identity.ml`\n- `git diff --check`\n- `rg -n "\barchetype_of_string\b|Back-compat parse: returns \[Generalist\]|Back-compat wrapper: callers" lib/agent_identity.ml lib/agent_identity.mli test/test_agent_identity.ml` returned no matches\n- attempted `lockf -k -t 10 /tmp/me-dune-local.lock /usr/bin/env MASC_DUNE_LOCK_HELD=1 MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=5 scripts/dune-local.sh build test/test_agent_identity.exe`; blocked before target compile by pre-existing `origin/main` Dune stanza mismatch: `test_keeper_working_state` is in `test/dune` names but missing from that stanza's explicit modules list. Recorded as #17189.\n\n[근거] command evidence captured locally on 2026-05-21 03:49 KST; confidence High.