### PR TITLE
test: register keeper working state module

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -1142,6 +1142,7 @@
   test_http_protocol_detect
   test_keeper_safety_gates
   test_keeper_guards
+  test_keeper_working_state
   test_eval_gate_evasion
   test_prompt_registry_defaults
   test_keeper_prompt_external


### PR DESCRIPTION
## Summary\n\n- add `test_keeper_working_state` to the explicit modules list in the existing Group 3 test stanza\n- fixes the names/modules mismatch tracked in #17189\n\n## Verification\n\n- `git diff --check`\n- `rg -n "test_keeper_working_state" test/dune` shows the test in both names and modules lists\n- attempted `lockf -k -t 10 /tmp/me-dune-local.lock /usr/bin/env MASC_DUNE_LOCK_HELD=1 MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=5 scripts/dune-local.sh build test/test_agent_identity.exe`; the previous #17189 stanza error is gone, then current `origin/main` compile blockers surface in `Coord_task_verification` and `keeper_turn_driver`, recorded as #17195\n\n[근거] command evidence captured locally on 2026-05-21 03:57 KST; confidence High.