### PR TITLE
feat(scripts): audit-rfc-closeout-lag --exclude-body filter + pipefail fix

### DIFF
--- a/scripts/audit-rfc-closeout-lag.sh
+++ b/scripts/audit-rfc-closeout-lag.sh
@@ -10,9 +10,15 @@
 # Active vs Implemented is a judgement call).
 #
 # Usage:
-#   bash scripts/audit-rfc-closeout-lag.sh [--since DATE] [--min N]
+#   bash scripts/audit-rfc-closeout-lag.sh [--since DATE] [--min N] [--exclude-body]
 #
-# Defaults: since=2026-04-01, min=1 (report any non-zero count).
+# Defaults: since=2026-04-01, min=1, exclude-body=false.
+#
+# --exclude-body: skip commits whose subject is RFC body or renumber
+#   (`docs(rfc):` / `chore(rfc): renumber`). Reduces false positives
+#   surfaced by the 2026-05-21 sweep where RFC-0145 and RFC-0122 were
+#   flagged purely because of body / renumber commits with no
+#   implementation behind them.
 #
 # Output (TSV on stdout, sorted by descending commit count):
 #   RFC-NNNN<TAB><commits>
@@ -26,6 +32,7 @@ set -euo pipefail
 
 since="2026-04-01"
 min_commits=1
+exclude_body=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -33,6 +40,8 @@ while [[ $# -gt 0 ]]; do
       since="$2"; shift 2 ;;
     --min)
       min_commits="$2"; shift 2 ;;
+    --exclude-body)
+      exclude_body=true; shift ;;
     -h|--help)
       sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
       exit 0 ;;
@@ -43,6 +52,14 @@ while [[ $# -gt 0 ]]; do
 done
 
 cd "$(git rev-parse --show-toplevel)"
+
+# Match commit subjects that are RFC body or renumber paperwork rather
+# than implementation. Format from `git log --oneline`:
+#   <short_sha> docs(rfc): ... RFC-NNNN ...
+#   <short_sha> chore(rfc): renumber RFC-NNNN ...
+# Anchored after the sha+space prefix so production fix() / feat()
+# subjects that mention "docs(rfc)" in their body do not get dropped.
+body_subject_pattern='^[a-f0-9]+ (docs\(rfc\)|chore\(rfc\): renumber)'
 
 # Capture RFC identifiers appearing in commit subjects on origin/main
 # within the window. Sort -u + while-read keeps the script grep-free
@@ -63,8 +80,19 @@ git log --oneline origin/main --since="$since" 2>/dev/null \
       fi
 
       # Count commit subjects that reference this RFC identifier.
-      count=$(git log --oneline origin/main --since="$since" 2>/dev/null \
-        | grep -c "${rfc}\b" || true)
+      # Disable pipefail locally so an empty intermediate grep does
+      # not abort the surrounding while-read loop.
+      set +o pipefail
+      if [[ "$exclude_body" == true ]]; then
+        count=$(git log --oneline origin/main --since="$since" 2>/dev/null \
+          | grep "${rfc}\b" \
+          | grep -vE "$body_subject_pattern" \
+          | wc -l | tr -d ' ')
+      else
+        count=$(git log --oneline origin/main --since="$since" 2>/dev/null \
+          | grep -c "${rfc}\b")
+      fi
+      set -o pipefail
 
       if [[ "$count" -ge "$min_commits" ]]; then
         printf "%s\t%d\n" "$rfc" "$count"


### PR DESCRIPTION
## Goal

\`audit-rfc-closeout-lag.sh\` (#17123) 의 known limitation 2건 fix:
1. **body-only false positive** (RFC-0145 #17182, RFC-0122 #17200) — body/renumber commits 만 으로 flag
2. **pipefail abort bug** (테스트 중 발견) — empty grep 가 while-read loop 조기 종료

## What

\`scripts/audit-rfc-closeout-lag.sh\` 변경 only. +32/-4 LoC.

### 1. \`--exclude-body\` 옵션 추가

\`docs(rfc):\` 또는 \`chore(rfc): renumber\` prefix commits 제외.

\`\`\`bash
body_subject_pattern='^[a-f0-9]+ (docs\\(rfc\\)|chore\\(rfc\\): renumber)'
\`\`\`

sha+space anchor 로 *commit subject prefix* 만 매칭. production fix()/feat() 가 본문에 "docs(rfc)" 인용해도 false drop 회피.

### 2. \`set -o pipefail\` 트랩 해결

발견 — RFC-0046..0111 만 iterate, RFC-0112+ silent drop. 원인:

\`\`\`bash
count=$(... | grep "${rfc}\\b" | grep -vE "$pat" | wc -l)
\`\`\`

intermediate \`grep\` 매칭 없음 = exit 1 → pipefail → script abort.

해결: count expression 주변 \`set +o pipefail\` 일시 비활성 + 후 복원.

\`\`\`bash
set +o pipefail
count=$(...)
set -o pipefail
\`\`\`

## Effect

| RFC | default | --exclude-body | Δ |
|-----|---------|----------------|---|
| RFC-0135 | 25 | 24 | -1 (RFC body) |
| RFC-0139 | 6 | 5 | -1 (RFC body) |
| RFC-0145 | 3 | 1 | -2 (body + renumber) |
| RFC-0122 | 2 | 1 | -1 (RFC body) |
| RFC-0125 | 2 | 1 | -1 (RFC body) |
| RFC-0070 | 1 | 1 | 0 (implementation only) |

→ RFC-0145 처럼 *body-only* 케이스가 default 에 보이고 \`--exclude-body\` 에서 사라짐. true closeout-lag 와 paperwork-only 구분.

## Verification

\`\`\`bash
$ bash scripts/audit-rfc-closeout-lag.sh | head -3
RFC-0135  25
RFC-0139   6
RFC-0126   4

$ bash scripts/audit-rfc-closeout-lag.sh --exclude-body | head -3
RFC-0135  24
RFC-0139   5
RFC-0153   3

$ bash scripts/audit-rfc-closeout-lag.sh --since 2026-05-20 --min 2 | head -3
RFC-0153   3
RFC-0145   3
RFC-0106   2
\`\`\`

세 옵션 + 조합 동작.

## Backward compat

기본 출력 변경 0. \`--exclude-body\` 미지정 시 #17123 와 동일 결과.

## Audit-sweep self-application

이전 sweep 의 false positives (RFC-0145 #17182, RFC-0122 #17200) 가 본 enhancement 의 *evidence*. README §RFC 목록 의 RFC-0145 body-only 가 그 사례.

본 PR 이후 audit-sweep 재실행 시 \`--exclude-body\` 사용 → false positive 자동 제외.

## Files

\`\`\`
1 file changed, 32 insertions(+), 4 deletions(-)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>