### PR TITLE
docs(rfc): RFC-0070 progress audit — Draft → Active, +#16666, audit-sweep last

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -109,7 +109,7 @@ implementation_prs: []             # [14181, 14550] 형식 (정수). RFC body �
 | 0067 | Goal-Scope Observation→Claim Atomicity | Draft | 44c383150 2026-05-11 | 구 RFC-0057 — collision 해결 (#14672) |
 | 0068 | Typed `Keeper_turn_disposition` (operator-facing closed sum) | Draft | (pending #14692) | 구 RFC-0047 — collision 해결 |
 | 0069 | Awareness Channel Split | Active | f762e88a2 2026-04-30 | 구 awareness-channel-split.md (PR-1.7) — PR-1.7a 머지 #12129, PR-1.7b/c 미완 |
-| 0070 | Keeper Sandbox Runtime — Pure/Edge Separation | Draft | (pending #14714) | depends on RFC-0036 Phase A, extends RFC-0006 Phase B-2 |
+| 0070 | Keeper Sandbox Runtime — Pure/Edge Separation | Active | (this PR) 2026-05-21 | depends on RFC-0036 Phase A, extends RFC-0006 Phase B-2. §2 G1-G5 goal plan (deterministic ID / typed daemon errors / JSON-format probe / cleanup state machine / mockable executor). **16 implementation_prs 머지**: initial 15 PR batch (#14714..#14989, 2026-05-12 sprint) + #16666 (`Sandbox_error closed sum per §2 G2`, 2026-05-19). Per-goal Phase→PR table 은 sprint author 책임 (audit boundary). Status promoted Draft → Active. |
 | 0071 | Exhaustive Match Sweep Codemod — Eliminate N-of-M `_ -> false/None` Anti-Pattern | Draft | #14881 2026-05-12 | body written by this PR; lib/core/dune reference (#14888) realized. Related RFC-0042, RFC-0068. |
 | 0072 | Type-encoded keeper sub-FSM transitions (cascade + turn_phase) | Draft | 2026-05-12 | follows PR #14887 + #14893 decision-axis precedent. |
 | 0073 | Tool Readiness Probe — Typed Precondition + Runtime Gap Disclosure | Draft | (this PR) | Tool readiness package — RFC-0073/0074/0075/0076 coordinated. |

--- a/docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md
+++ b/docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md
@@ -1,14 +1,55 @@
 ---
 rfc: "0070"
 title: "Keeper Sandbox Runtime — Pure/Edge Separation"
-status: Draft
+status: Active
 created: 2026-05-12
-updated: 2026-05-12
+updated: 2026-05-21
 author: yousleepwhen
 supersedes: []
 superseded_by: null
 related: ["0002", "0003", "0006", "0036"]
-implementation_prs: [14714, 14741, 14821, 14827, 14889, 14899, 14934, 14940, 14947, 14951, 14956, 14970, 14973, 14980, 14989]
+implementation_prs: [14714, 14741, 14821, 14827, 14889, 14899, 14934, 14940, 14947, 14951, 14956, 14970, 14973, 14980, 14989, 16666]
+---
+
+## Progress audit (2026-05-21)
+
+Status promoted Draft → Active. 16 implementation PRs landed against
+the §2 G1-G5 goal plan; per-goal completion mapping deferred to
+sprint author.
+
+### implementation_prs reconciliation
+
+Previous list ended at #14989 (15 PRs from the initial 2026-05-12
+sprint). PR #16666 (2026-05-19, `feat(keeper/sandbox): typed
+Sandbox_error closed sum per RFC-0070 §2 G2`) explicitly cites G2
+and is the only RFC-0070 commit since 2026-04-01. Added to the
+list for total 16.
+
+### Audit boundary
+
+The G1-G5 goal table (§2) does not enumerate phase-bound PR slots
+the way newer RFCs (e.g. RFC-0131, RFC-0142) do — the original
+work landed before the phase-slot convention solidified. A
+per-goal Phase→PR table requires reading each of the 16 merged PRs
+to classify which goal it advanced (G1 deterministic ID / G2 typed
+errors / G3 JSON-format probe / G4 cleanup state machine / G5
+mockable executor). That is sprint author territory, not a sweep
+audit responsibility.
+
+### Why Active, not Implemented
+
+- 16 PRs is consistent with all five goals having shipped at least
+  in part, but the per-goal verification work has not been done in
+  this audit.
+- `feature/RFC-0070-*` branches in the worktree list suggest some
+  follow-up is in flight (not enumerated here).
+- Implemented status requires explicit closeout commit confirming
+  G1-G5 acceptance criteria; that work belongs to the sprint
+  author.
+
+`Active` is the minimum honest update: the RFC has clearly moved
+past Draft, but Implemented is not yet defensible.
+
 ---
 
 # RFC-0070: Keeper Sandbox Runtime — Pure/Edge Separation


### PR DESCRIPTION
## Goal

RFC-0070 가 audit-sweep 의 *마지막 unaudited single-impl RFC*. implementation_prs 15 PR 끝에 #16666 (2026-05-19 G2 typed Sandbox_error) 누락 + status Draft. \`audit-rfc-closeout-lag.sh\` 19번째 적용.

## What

| 파일 | 변경 |
|------|------|
| \`docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md\` | status Draft → Active, +#16666 (16 PR), Progress audit + audit boundary 명시 |
| \`docs/rfc/README.md\` | RFC-0070 entry 갱신 (`(pending #14714)` → current state) |

코드 변경 0.

## implementation_prs 보강

Before: \`[14714..14989]\` (15 PR, 2026-05-12 initial sprint)
After: \`+[16666]\` = 16 PR

#16666 (2026-05-19) 가 §2 G2 explicit 인용 commit subject.

## Per-goal mapping deferred

§2 G1-G5 goal plan:
- G1 Deterministic ID
- G2 Typed daemon errors
- G3 JSON-format docker probe
- G4 Cleanup as state machine
- G5 Mock-able executor

16 PR 각각이 어느 goal 에 속하는지 *audit 안 함* — sprint author 영역. 이전 audit (RFC-0135 #17206) 와 같은 *audit boundary* 원칙 적용.

## Audit boundary 원칙 정착

본 PR 이 *3번째* "Phase→PR 매핑 deferred" 적용:
- #17142 (RFC-0131, 7 PR): mixed naming, 부분 매핑
- #17206 (RFC-0135, 23 PR): full deferral
- **본 PR (RFC-0070, 16 PR): full deferral**

→ audit-sweep 의 *작업 분담 원칙*: sweep audit 는 *visible discrepancy* (status/implementation_prs/README) 만, *semantic phase mapping* 은 sprint author.

## --exclude-body 의 마지막 적용

#17202 enhancement 후 처리된 single-implementation-commit RFC:
- RFC-0092 #17203 (Active)
- RFC-0137 #17204 (Active)
- RFC-0129 #17205 (Implemented)
- **RFC-0070 (본 PR, Active)**

→ enhanced filter 의 *unique candidate pool* 모두 소진.

## 누적 audit-sweep — 19 PR (final?)

| 종류 | 사례 수 |
|------|---------|
| Draft → Active (partial) | **12** (본 PR 포함) |
| Draft → Implemented | 2 |
| README fix | 1 |
| audit script | 2 |
| related-only | 1 |
| 최대 lag | 1 |

→ **자율 sweep 완전 소진** confirmed.

## Files

\`\`\`
2 files changed, 45 insertions(+), 4 deletions(-)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>