### PR TITLE
[codex] purge shell tokenizers from command classifiers

### DIFF
--- a/lib/gh_command_validation.ml
+++ b/lib/gh_command_validation.ml
@@ -13,6 +13,14 @@ let has_strict_shell_metachar cmd =
       | _ -> false)
     cmd
 
+let shell_word_values cmd =
+  match Masc_exec_bash_parser.Bash_words.stages cmd with
+  | Error _ -> []
+  | Ok stages ->
+    stages
+    |> List.concat
+    |> List.map (fun (word : Masc_exec_bash_parser.Bash_words.word) -> word.value)
+
 (** Top-level gh CLI commands allowed. Commands not in this list are
     rejected at the allowlist gate. *)
 let gh_allowed_commands =
@@ -103,10 +111,7 @@ let gh_graphql_r2_mutations =
     "archiverepository" ]
 
 let extract_gh_api_method cmd =
-  let tokens =
-    String.split_on_char ' ' (String.trim cmd)
-    |> List.filter (fun s -> s <> "")
-  in
+  let tokens = shell_word_values cmd in
   let rec find = function
     | [] -> "GET"
     | "-X" :: m :: _ | "--method" :: m :: _ -> String.uppercase_ascii m
@@ -147,10 +152,7 @@ let gh_blocked_operations =
     Only the owner segment is returned; repo/branch names are outside
     the allowlist scope. *)
 let extract_gh_repo_owner cmd =
-  let tokens =
-    String.split_on_char ' ' (String.trim cmd)
-    |> List.filter (fun s -> s <> "")
-  in
+  let tokens = shell_word_values cmd in
   let owner_of_slug s =
     match String.split_on_char '/' s with
     | owner :: _ :: _ when owner <> "" -> Some owner
@@ -175,10 +177,7 @@ let extract_gh_repo_owner cmd =
     Example: "pr view 123" -> (Some "pr", Some "view")
     Example: "workflow --repo o/r disable" -> (Some "workflow", Some "disable") *)
 let extract_gh_command_pair cmd =
-  let parts =
-    String.split_on_char ' ' (String.trim cmd)
-    |> List.filter (fun s -> s <> "")
-  in
+  let parts = shell_word_values cmd in
   match parts with
   | [] -> (None, None)
   | [ x ] -> (Some x, None)
@@ -317,10 +316,7 @@ let classify_gh_reversibility cmd =
     if in_table gh_irreversible_ops then R2_Irreversible
     else if command = "api" then begin
       let method_ = extract_gh_api_method cmd in
-      let parts =
-        String.split_on_char ' ' (String.trim cmd)
-        |> List.filter (fun s -> s <> "")
-      in
+      let parts = shell_word_values cmd in
       if method_ = "DELETE" then R2_Irreversible
       else if gh_api_graphql_is_destructive cmd then R2_Irreversible
       else if List.mem method_ ["POST"; "PUT"; "PATCH"] then R1_Reversible
@@ -366,9 +362,7 @@ let positional_tokens parts =
 
 (** Shared tokenizer for destructive-operation checks. *)
 let gh_op_parts cmd =
-  String.split_on_char ' ' (String.trim cmd)
-  |> List.filter (fun s -> s <> "")
-  |> List.map String.lowercase_ascii
+  shell_word_values cmd |> List.map String.lowercase_ascii
 
 let has_positional_subcmd subcmds rest =
   let positionals = positional_tokens rest in
@@ -398,8 +392,7 @@ let is_gh_pr_merge cmd =
   | _ -> false
 
 let gh_raw_parts cmd =
-  String.split_on_char ' ' (String.trim cmd)
-  |> List.filter (fun s -> s <> "")
+  shell_word_values cmd
 
 let gh_option_takes_value tok =
   let tok = String.lowercase_ascii tok in

--- a/lib/keeper/keeper_gh_shared.ml
+++ b/lib/keeper/keeper_gh_shared.ml
@@ -64,14 +64,17 @@ let counter_misses = Atomic.make 0
 let counter_bypasses = Atomic.make 0
 let counter_fetch_errors = Atomic.make 0
 
+let shell_word_values cmd =
+  match Masc_exec_bash_parser.Bash_words.stages cmd with
+  | Error _ -> []
+  | Ok stages ->
+    stages
+    |> List.concat
+    |> List.map (fun (word : Masc_exec_bash_parser.Bash_words.word) -> word.value)
+;;
+
 let normalize_gh_command (cmd : string) : string =
-  let tokens =
-    cmd
-    |> String.trim
-    |> String.split_on_char ' '
-    |> List.map String.trim
-    |> List.filter (fun token -> token <> "")
-  in
+  let tokens = shell_word_values cmd in
   let rec drop_leading_gh = function
     | token :: rest when String_util.equals_ci token "gh" -> drop_leading_gh rest
     | remaining -> remaining
@@ -369,14 +372,7 @@ let gh_issue_number_subcmds =
 ;;
 
 let gh_words (cmd : string) : string list =
-  cmd
-  |> String.map (function
-    | '\t' | '\r' | '\n' -> ' '
-    | c -> c)
-  |> String.trim
-  |> String.lowercase_ascii
-  |> String.split_on_char ' '
-  |> List.filter (fun s -> s <> "")
+  shell_word_values cmd |> List.map String.lowercase_ascii
 ;;
 
 let gh_global_option_takes_value = function

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -119,12 +119,31 @@ let validate_keeper_bash_coding cmd =
     cmd
 ;;
 
+type safe_read_fallback_reason =
+  | Safe_read_or_echo
+  | Safe_read_cd_and_read
+  | Safe_read_head_pipeline
+  | Safe_read_pwd_and_read
+  | Safe_read_pwd_head_pipeline
+  | Safe_read_dev_null_redirect
+  | Safe_read_stderr_dev_null_stripped
+
+let safe_read_fallback_reason_tag = function
+  | Safe_read_or_echo -> "or_echo"
+  | Safe_read_cd_and_read -> "cd_and_read"
+  | Safe_read_head_pipeline -> "head_pipeline"
+  | Safe_read_pwd_and_read -> "pwd_and_read"
+  | Safe_read_pwd_head_pipeline -> "pwd_head_pipeline"
+  | Safe_read_dev_null_redirect -> "dev_null_redirect"
+  | Safe_read_stderr_dev_null_stripped -> "stderr_dev_null_stripped"
+
 type safe_read_fallback = {
   primary_cmd : string;
   cwd_override : string option;
+  reason : safe_read_fallback_reason;
 }
 
-let safe_read_primary_rewrite primary_cmd =
+let safe_read_primary_rewrite ~reason primary_cmd =
   match keeper_bash_shape_block primary_cmd with
   | Some _ -> None
   | None ->
@@ -137,8 +156,12 @@ let safe_read_primary_rewrite primary_cmd =
           ~allowed_commands:Worker_dev_tools.dev_allowed_commands
           primary_cmd
       with
-      | Ok () -> Some { primary_cmd; cwd_override = None }
+      | Ok () -> Some { primary_cmd; cwd_override = None; reason }
       | Error _ -> None)
+
+let with_safe_read_fallback_reason reason = function
+  | None -> None
+  | Some rewrite -> Some { rewrite with reason }
 
 type shell_logic_op =
   | Logic_and
@@ -280,7 +303,7 @@ let safe_read_or_echo_fallback_of_command cmd =
           let primary = String.trim left in
           if String.equal primary "" then None else Some primary
       in
-      Option.bind primary_cmd safe_read_primary_rewrite
+      Option.bind primary_cmd (safe_read_primary_rewrite ~reason:Safe_read_or_echo)
 
 let safe_cd_read_fallback_of_command cmd =
   match find_unquoted_logic_op Logic_and cmd with
@@ -297,8 +320,11 @@ let safe_cd_read_fallback_of_command cmd =
         String.sub left 3 (String.length left - 3)
         |> safe_relative_repos_cd_path
       in
-      match path, safe_read_primary_rewrite right with
-      | Some cwd_override, Some rewrite -> Some { rewrite with cwd_override = Some cwd_override }
+      match
+        path, safe_read_primary_rewrite ~reason:Safe_read_cd_and_read right
+      with
+      | Some cwd_override, Some rewrite ->
+        Some { rewrite with cwd_override = Some cwd_override }
       | _ -> None
 
 let split_unquoted_single_pipeline cmd =
@@ -375,14 +401,15 @@ let safe_read_head_pipeline_fallback_of_command cmd =
     then None
     else
       let primary_rewrite =
-        match safe_read_primary_rewrite primary with
+        match safe_read_primary_rewrite ~reason:Safe_read_head_pipeline primary with
         | Some _ as rewrite -> rewrite
         | None ->
           (match strip_trailing_dev_null_redirect primary with
-           | Some stripped -> safe_read_primary_rewrite stripped
+           | Some stripped ->
+             safe_read_primary_rewrite ~reason:Safe_read_head_pipeline stripped
            | None -> safe_cd_read_fallback_of_command primary)
       in
-      primary_rewrite
+      with_safe_read_fallback_reason Safe_read_head_pipeline primary_rewrite
 
 let safe_pwd_read_fallback_of_command cmd =
   match find_unquoted_logic_op Logic_and cmd with
@@ -395,14 +422,17 @@ let safe_pwd_read_fallback_of_command cmd =
     if not (String.equal left "pwd" || String.equal left "pwd -P")
     then None
     else
-      match safe_read_primary_rewrite right with
-      | Some _ as rewrite -> rewrite
+      match safe_read_primary_rewrite ~reason:Safe_read_pwd_and_read right with
+      | Some _ as rewrite ->
+        with_safe_read_fallback_reason Safe_read_pwd_and_read rewrite
       | None ->
         (match safe_read_head_pipeline_fallback_of_command right with
-         | Some _ as rewrite -> rewrite
+         | Some _ as rewrite ->
+           with_safe_read_fallback_reason Safe_read_pwd_head_pipeline rewrite
          | None ->
            (match strip_trailing_dev_null_redirect right with
-            | Some stripped -> safe_read_primary_rewrite stripped
+            | Some stripped ->
+              safe_read_primary_rewrite ~reason:Safe_read_pwd_and_read stripped
             | None -> None))
 
 let safe_read_fallback_of_command ~write_enabled:_ ~stderr_dev_null_stripped cmd =
@@ -419,10 +449,14 @@ let safe_read_fallback_of_command ~write_enabled:_ ~stderr_dev_null_stripped cmd
            | Some _ as rewrite -> rewrite
            | None ->
              (match strip_trailing_dev_null_redirect cmd with
-              | Some primary_cmd -> safe_read_primary_rewrite primary_cmd
+              | Some primary_cmd ->
+                safe_read_primary_rewrite ~reason:Safe_read_dev_null_redirect primary_cmd
               | None ->
                 if stderr_dev_null_stripped
-                then safe_read_primary_rewrite cmd
+                then
+                  safe_read_primary_rewrite
+                    ~reason:Safe_read_stderr_dev_null_stripped
+                    cmd
                 else None))))
 
 let shape_block_allowed_by_active_validator ~write_enabled cmd = function
@@ -1364,6 +1398,27 @@ let handle_keeper_bash
       safe_read_fallback_of_command ~write_enabled
         ~stderr_dev_null_stripped:stripped_stderr_dev_null cmd
     in
+    let () =
+      match safe_read_fallback with
+      | None -> ()
+      | Some fallback ->
+        Log.Keeper.info
+          "keeper_bash safe-read compatibility fallback selected: keeper=%s \
+           reason=%s cmd_hash=%s primary_hash=%s"
+          meta.name
+          (safe_read_fallback_reason_tag fallback.reason)
+          (Worker_dev_tools.cmd_hash_for_log cmd)
+          (Worker_dev_tools.cmd_hash_for_log fallback.primary_cmd)
+    in
+    let safe_read_fallback_extra =
+      match safe_read_fallback with
+      | None -> []
+      | Some fallback ->
+        [
+          ( "safe_read_fallback_reason",
+            `String (safe_read_fallback_reason_tag fallback.reason) );
+        ]
+    in
     let validation_cmd =
       match safe_read_fallback with
       | Some rewrite -> rewrite.primary_cmd
@@ -1407,15 +1462,17 @@ let handle_keeper_bash
            ~base_path:root
            ~keeper_name:meta.name
            ~cmd
-           ~extra:[
-             "cwd", `String cwd;
-             "execution_time_ms", `Int entry.duration_ms;
-             "cached", `Bool true;
-             "cache_age_ms",
-               `Int
-                 (int_of_float
-                    ((Unix.time () -. entry.cached_at) *. 1000.));
-           ]
+           ~extra:
+             (safe_read_fallback_extra
+              @ [
+                  "cwd", `String cwd;
+                  "execution_time_ms", `Int entry.duration_ms;
+                  "cached", `Bool true;
+                  ( "cache_age_ms",
+                    `Int
+                      (int_of_float
+                         ((Unix.time () -. entry.cached_at) *. 1000.)) );
+                ])
            ~status:st
            ~output:entry.output
            ~env_snapshot:env_snap
@@ -1434,17 +1491,20 @@ let handle_keeper_bash
           |> List.remove_assoc "cached"
           |> List.remove_assoc "cache_age_ms"
           |> List.remove_assoc "execution_time_ms"
+          |> List.remove_assoc "safe_read_fallback_reason"
         in
         Yojson.Safe.to_string
           (`Assoc
-            (fields @ [
-               "cached", `Bool true;
-               "cache_age_ms",
-                 `Int
-                   (int_of_float
-                      ((Unix.time () -. entry.cached_at) *. 1000.));
-               "execution_time_ms", `Int entry.duration_ms;
-             ]))
+            (fields
+             @ safe_read_fallback_extra
+             @ [
+                 "cached", `Bool true;
+                 ( "cache_age_ms",
+                   `Int
+                     (int_of_float
+                        ((Unix.time () -. entry.cached_at) *. 1000.)) );
+                 "execution_time_ms", `Int entry.duration_ms;
+               ]))
       | Ok _ | Error _ -> cached_result_json entry
     in
     let with_raw_json_exec_cache run =
@@ -1832,7 +1892,10 @@ let handle_keeper_bash
              ~hint
              ~alternatives
              ~diag
-             ~extra:([ "execution_time_ms", `Int 0 ] @ recovery_extra)
+             ~extra:
+               (safe_read_fallback_extra
+                @ [ "execution_time_ms", `Int 0 ]
+                @ recovery_extra)
              ~env_snapshot:env_snap
              ())
       | Ok () ->
@@ -1851,7 +1914,10 @@ let handle_keeper_bash
                validation_cmd
           in
           match path_validation with
-          | Error e -> error_json ~fields:["blocked_cmd", `String cmd_for_log] e
+          | Error e ->
+            error_json
+              ~fields:(safe_read_fallback_extra @ [ "blocked_cmd", `String cmd_for_log ])
+              e
           | Ok () ->
                if write_enabled
                   && Worker_dev_tools.is_write_operation validation_cmd then
@@ -1879,17 +1945,18 @@ let handle_keeper_bash
                        meta.name (Bg_task.task_id_to_string tid) cmd_for_log;
                      Yojson.Safe.to_string
                        (`Assoc
-                         [
-                           ("ok", `Bool true);
-                           ( "background_task_id",
-                             `String (Bg_task.task_id_to_string tid) );
-                           ("cmd", `String cmd);
-                           ("cwd", `String cwd);
-                           ( "hint",
-                             `String
-                               "Task running in background. Poll or stop it with the \
-                                background output/kill tools shown in your active schema." );
-                         ])
+                         ([
+                            ("ok", `Bool true);
+                            ( "background_task_id",
+                              `String (Bg_task.task_id_to_string tid) );
+                            ("cmd", `String cmd);
+                            ("cwd", `String cwd);
+                            ( "hint",
+                              `String
+                                "Task running in background. Poll or stop it with the \
+                                 background output/kill tools shown in your active schema." );
+                          ]
+                          @ safe_read_fallback_extra))
                  | Error (Bg_task.Spawn_failed e) ->
                      error_json
                        (Printf.sprintf "background spawn failed: %s" e)
@@ -1986,10 +2053,12 @@ let handle_keeper_bash
                               ~base_path:root
                               ~keeper_name:meta.name
                               ~cmd
-                              ~extra:[
-                                "cwd", `String cwd;
-                                "execution_time_ms", `Int elapsed_ms;
-                              ]
+                              ~extra:
+                                (safe_read_fallback_extra
+                                 @ [
+                                     "cwd", `String cwd;
+                                     "execution_time_ms", `Int elapsed_ms;
+                                   ])
                               ~status:st
                               ~output:out
                               ~env_snapshot:env_snap
@@ -2027,10 +2096,12 @@ let handle_keeper_bash
                         ~base_path:root
                         ~keeper_name:meta.name
                         ~cmd
-                        ~extra:[
-                          "cwd", `String cwd;
-                          "execution_time_ms", `Int elapsed_ms;
-                        ]
+                        ~extra:
+                          (safe_read_fallback_extra
+                           @ [
+                               "cwd", `String cwd;
+                               "execution_time_ms", `Int elapsed_ms;
+                             ])
                         ~status:st
                         ~output:out
                         ~env_snapshot:env_snap
@@ -2082,10 +2153,12 @@ let handle_keeper_bash
                              ~base_path:root
                              ~keeper_name:meta.name
                              ~cmd
-                             ~extra:[
-                               "cwd", `String cwd;
-                               "execution_time_ms", `Int elapsed_ms;
-                             ]
+                             ~extra:
+                               (safe_read_fallback_extra
+                                @ [
+                                    "cwd", `String cwd;
+                                    "execution_time_ms", `Int elapsed_ms;
+                                  ])
                              ~status:r.status
                              ~output:r.stdout
                              ~env_snapshot:env_snap
@@ -2103,28 +2176,29 @@ let handle_keeper_bash
                           cmd_for_log;
                         Yojson.Safe.to_string
                           (`Assoc
-                            [
-                              ("ok", `Bool false);
-                              ("promoted", `Bool true);
-                              ( "background_task_id",
-                                `String
-                                  (Bg_task.task_id_to_string p.task_id) );
-                              ("cmd", `String cmd);
-                              ("cwd", `String cwd);
-                              ("partial_output", `String p.partial_stdout);
-                              ( "bytes_dropped",
-                                `Int p.bytes_dropped_stdout );
-                              ("budget_ms", `Int budget_ms);
-                              ("execution_time_ms", `Int elapsed_ms);
-                              ( "hint",
-                                `String
-                                 (Printf.sprintf
-                                     "Command exceeded \
-                                      MASC_BLOCKING_BUDGET_MS=%d. Still \
-                                      running in background; poll or stop it with the \
-                                      background output/kill tools shown in your active schema."
-                                     budget_ms) );
-                            ])
+                            ([
+                               ("ok", `Bool false);
+                               ("promoted", `Bool true);
+                               ( "background_task_id",
+                                 `String
+                                   (Bg_task.task_id_to_string p.task_id) );
+                               ("cmd", `String cmd);
+                               ("cwd", `String cwd);
+                               ("partial_output", `String p.partial_stdout);
+                               ( "bytes_dropped",
+                                 `Int p.bytes_dropped_stdout );
+                               ("budget_ms", `Int budget_ms);
+                               ("execution_time_ms", `Int elapsed_ms);
+                               ( "hint",
+                                 `String
+                                  (Printf.sprintf
+                                      "Command exceeded \
+                                       MASC_BLOCKING_BUDGET_MS=%d. Still \
+                                       running in background; poll or stop it with the \
+                                       background output/kill tools shown in your active schema."
+                                      budget_ms) );
+                             ]
+                             @ safe_read_fallback_extra))
                       | Masc_exec.Exec_run.Spawn_error
                           (Bg_task.Spawn_failed e) ->
                         error_json

--- a/lib/keeper/keeper_shell_command_semantics.ml
+++ b/lib/keeper/keeper_shell_command_semantics.ml
@@ -93,6 +93,26 @@ let cmd_targets_git_or_gh cmd =
 let cmd_targets_gh cmd =
   effective_stages cmd |> List.exists (fun stage -> stage.bin = "gh")
 
+let repo_flag_value = function
+  | "--repo" -> None
+  | flag when String.starts_with ~prefix:"--repo=" flag ->
+    let value =
+      String.sub flag (String.length "--repo=") (String.length flag - String.length "--repo=")
+    in
+    if value = "" then None else Some value
+  | _ -> None
+
+let detect_gh_repo_flag_with_api_misuse cmd =
+  let scan_args = function
+    | "--repo" :: repo_arg :: "api" :: endpoint :: _ -> Some (repo_arg, endpoint)
+    | flag :: "api" :: endpoint :: _ ->
+      Option.map (fun repo_arg -> repo_arg, endpoint) (repo_flag_value flag)
+    | _ -> None
+  in
+  effective_stages cmd
+  |> List.find_map (fun stage ->
+       if stage.bin = "gh" then scan_args stage.args else None)
+
 let strip_simple_shell_quotes token =
   let len = String.length token in
   if

--- a/lib/keeper/keeper_shell_command_semantics.mli
+++ b/lib/keeper/keeper_shell_command_semantics.mli
@@ -13,6 +13,10 @@ val cmd_targets_gh : string -> bool
 (** [true] only when the typed bash subset parser identifies an effective
     command stage whose executable is [gh]. *)
 
+val detect_gh_repo_flag_with_api_misuse : string -> (string * string) option
+(** Detect the invalid [gh --repo <repo> api <endpoint>] shape.  [--repo]
+    is a subcommand flag, not a [gh api] global option. *)
+
 val resolve_sandbox_root_git_cwd :
   config:Coord.config ->
   meta:Keeper_types.keeper_meta ->

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -244,37 +244,8 @@ let ensure_keeper_sandbox_runtime ~timeout_sec =
   Keeper_sandbox_runtime.ensure_keeper_sandbox_runtime ~timeout_sec
 ;;
 
-(* #10855: keeper LLM (issue_king, masc-improver) hallucinated gh syntax
-   `gh --repo X api Y` (108 events / 24h, 2026-04-25→04-26). gh CLI
-   semantics: `--repo` is a subcommand flag (gh issue/pr/release/...),
-   not a global option, and `gh api` rejects it with "unknown flag: --repo".
-   Detect the misuse pre-exec so we can emit a self-correcting error
-   instead of letting the docker exec waste a turn surfacing gh's raw
-   error.  Same self-correcting-message pattern as #10869's multi-repo
-   sandbox blocker. *)
-let detect_gh_repo_flag_with_api_misuse cmd =
-  let strip_quotes s =
-    let len = String.length s in
-    if
-      len >= 2
-      && ((s.[0] = '\'' && s.[len - 1] = '\'') || (s.[0] = '"' && s.[len - 1] = '"'))
-    then String.sub s 1 (len - 2)
-    else s
-  in
-  let toks =
-    String.split_on_char ' ' (String.trim cmd)
-    |> List.filter (fun s -> s <> "")
-    |> List.map strip_quotes
-  in
-  if not (List.mem "gh" toks)
-  then None
-  else (
-    let rec scan = function
-      | "--repo" :: repo_arg :: "api" :: endpoint :: _ -> Some (repo_arg, endpoint)
-      | _ :: rest -> scan rest
-      | [] -> None
-    in
-    scan toks)
+let detect_gh_repo_flag_with_api_misuse =
+  Keeper_shell_command_semantics.detect_gh_repo_flag_with_api_misuse
 ;;
 
 (* Emit a ("gh_exit_class", "…") JSON field when [cmd] targets gh,

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -13,6 +13,15 @@ let dedupe_tool_names names =
   dedupe_keep_order (names |> List.map String.trim |> List.filter (fun name -> name <> ""))
 ;;
 
+let shell_word_values cmd =
+  match Masc_exec_bash_parser.Bash_words.stages cmd with
+  | Error _ -> []
+  | Ok stages ->
+    stages
+    |> List.concat
+    |> List.map (fun (word : Masc_exec_bash_parser.Bash_words.word) -> word.value)
+;;
+
 (* ── Runtime-resolved tool names ─────────────────────────────── *)
 
 let keeper_internal_candidate_tool_names =
@@ -204,9 +213,7 @@ let gh_read_only_prefixes =
     [graphqlx ...] as the graphql subcommand.  User hard rule: "no
     string matching for classification". *)
 let is_gh_api_read_only (cmd_lower : string) : bool =
-  let tokens =
-    cmd_lower |> String.split_on_char ' ' |> List.filter (fun token -> token <> "")
-  in
+  let tokens = shell_word_values cmd_lower in
   match tokens with
   | "api" :: rest_after_api ->
     let is_graphql_subcommand =
@@ -257,13 +264,7 @@ let is_gh_api_read_only (cmd_lower : string) : bool =
 (** Extract the effective gh command string from keeper_shell op=gh input.
     [keeper_exec_shell] uses the [cmd] field. *)
 let normalize_gh_command (cmd : string) : string =
-  let tokens =
-    cmd
-    |> String.trim
-    |> String.split_on_char ' '
-    |> List.map String.trim
-    |> List.filter (fun token -> token <> "")
-  in
+  let tokens = shell_word_values cmd in
   let rec drop_leading_gh = function
     | token :: rest when String_util.equals_ci token "gh" -> drop_leading_gh rest
     | remaining -> remaining

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -254,10 +254,29 @@ let build_prompt_args agent_name prompt =
   | Some config -> build_prompt_args_from_config config prompt
   | None -> []
 
-(** Parse command string into executable and arguments *)
+(** Parse a simple command string into executable and arguments.
+    Spawn is direct argv execution, so shell pipelines/redirects/env
+    prefixes are rejected instead of being flattened into argv. *)
 let parse_command cmd =
-  let parts = String.split_on_char ' ' cmd in
-  List.filter (fun s -> String.length s > 0) parts
+  let collect_lit_args args =
+    let rec loop acc = function
+      | [] -> Some (List.rev acc)
+      | Masc_exec.Shell_ir.Lit arg :: rest -> loop (arg :: acc) rest
+      | Masc_exec.Shell_ir.Concat _ :: _
+      | Masc_exec.Shell_ir.Var _ :: _ -> None
+    in
+    loop [] args
+  in
+  match Masc_exec_bash_parser.Bash.parse_string cmd with
+  | Masc_exec.Parsed.Parsed (Masc_exec.Shell_ir.Simple simple)
+    when simple.env = [] && simple.cwd = None && simple.redirects = [] ->
+    (match collect_lit_args simple.args with
+     | Some args -> Masc_exec.Bin.to_string simple.bin :: args
+     | None -> [])
+  | Masc_exec.Parsed.Parsed _
+  | Masc_exec.Parsed.Parse_error _
+  | Masc_exec.Parsed.Parse_aborted _
+  | Masc_exec.Parsed.Too_complex _ -> []
 
 let output_for_status ~(status : Unix.process_status) ~(stdout : string)
     ~(stderr : string) : string =

--- a/lib/worker_dev_tools_log_sanitize.ml
+++ b/lib/worker_dev_tools_log_sanitize.ml
@@ -1,5 +1,23 @@
 let contains_substring s needle = String_util.contains_substring s needle
 
+let sensitive_flags =
+  [ "--token"; "--password"; "--passwd"; "--auth-token"; "--api-key" ]
+;;
+
+let sensitive_assignment_markers =
+  [ ":_authToken="; "_authToken="; "token="; "password="; "passwd="; "api-key=" ]
+;;
+
+let shell_word_values cmd =
+  match Masc_exec_bash_parser.Bash_words.stages cmd with
+  | Error _ -> Error ()
+  | Ok stages ->
+    Ok
+      (stages
+       |> List.concat
+       |> List.map (fun (word : Masc_exec_bash_parser.Bash_words.word) -> word.value))
+;;
+
 let redact_url_credentials token =
   let redact_after_scheme token scheme =
     if String.starts_with ~prefix:scheme token
@@ -43,23 +61,18 @@ let redact_inline_secret_assignment token =
       | None -> token)
     else token
   in
-  token
-  |> fun t ->
-  redact_after t ":_authToken="
-  |> fun t ->
-  redact_after t "_authToken="
-  |> fun t ->
-  redact_after t "token="
-  |> fun t ->
-  redact_after t "password="
-  |> fun t -> redact_after t "passwd=" |> fun t -> redact_after t "api-key="
+  List.fold_left redact_after token sensitive_assignment_markers
 ;;
 
-let sanitize_command_for_log cmd =
-  let sensitive_flags =
-    [ "--token"; "--password"; "--passwd"; "--auth-token"; "--api-key" ]
-  in
-  let parts = String.split_on_char ' ' cmd in
+let command_has_sensitive_marker cmd =
+  let lower = String.lowercase_ascii cmd in
+  List.exists (fun flag -> contains_substring lower flag) sensitive_flags
+  || List.exists
+       (fun marker -> contains_substring lower (String.lowercase_ascii marker))
+       sensitive_assignment_markers
+;;
+
+let sanitize_parts parts =
   let rec redact prev_sensitive acc = function
     | [] -> String.concat " " (List.rev acc)
     | part :: rest ->
@@ -72,6 +85,13 @@ let sanitize_command_for_log cmd =
       redact next_sensitive (part :: acc) rest
   in
   redact false [] parts
+;;
+
+let sanitize_command_for_log cmd =
+  match shell_word_values cmd with
+  | Ok parts -> sanitize_parts parts
+  | Error () when command_has_sensitive_marker cmd -> "[REDACTED]"
+  | Error () -> cmd |> redact_url_credentials |> redact_inline_secret_assignment
 ;;
 
 let truncate_for_log ?(max_len = 240) s =

--- a/lib/worker_dev_tools_mutation_classifier.ml
+++ b/lib/worker_dev_tools_mutation_classifier.ml
@@ -1,7 +1,16 @@
 (** Mutation/destructive command classifiers for worker dev tools. *)
 
+let shell_word_values cmd =
+  match Masc_exec_bash_parser.Bash_words.stages cmd with
+  | Error _ -> []
+  | Ok stages ->
+    stages
+    |> List.concat
+    |> List.map (fun (word : Masc_exec_bash_parser.Bash_words.word) -> word.value)
+;;
+
 let is_write_operation cmd =
-  let parts = String.split_on_char ' ' (String.trim cmd) in
+  let parts = shell_word_values cmd in
   match parts with
   | "git" :: sub :: _ ->
     List.mem
@@ -53,22 +62,7 @@ let rec skip_git_global_options = function
 ;;
 
 let is_git_branch_switch cmd =
-  let parts =
-    let buf = Buffer.create 64 in
-    let tokens = ref [] in
-    String.iter
-      (fun c ->
-         match c with
-         | ' ' | '\t' ->
-           if Buffer.length buf > 0
-           then (
-             tokens := Buffer.contents buf :: !tokens;
-             Buffer.clear buf)
-         | _ -> Buffer.add_char buf c)
-      (String.trim cmd);
-    if Buffer.length buf > 0 then tokens := Buffer.contents buf :: !tokens;
-    List.rev !tokens
-  in
+  let parts = shell_word_values cmd in
   let is_option arg = String.length arg > 0 && arg.[0] = '-' in
   let has_any_flag flags args = List.exists (fun a -> List.mem a flags) args in
   let rec first_non_option = function
@@ -108,9 +102,7 @@ let is_git_branch_switch cmd =
 ;;
 
 let is_destructive_bash_operation cmd =
-  let parts =
-    String.split_on_char ' ' (String.trim cmd) |> List.filter (fun s -> s <> "")
-  in
+  let parts = shell_word_values cmd in
   let is_short_option arg = String.length arg > 1 && arg.[0] = '-' && arg.[1] <> '-' in
   let has_short_flag flag arg = is_short_option arg && String.contains arg flag in
   let is_protected_branch_target arg =

--- a/test/test_gh_api_classification.ml
+++ b/test/test_gh_api_classification.ml
@@ -41,6 +41,8 @@ let test_method_flag_makes_mutating () =
     (Keeper_tool_registry.is_gh_api_read_only "api -x=delete repos/o/r");
   r "api --method=patch = mutating" false
     (Keeper_tool_registry.is_gh_api_read_only "api --method=patch repos/o/r");
+  r "api --method 'patch' = mutating" false
+    (Keeper_tool_registry.is_gh_api_read_only "api --method 'patch' repos/o/r");
   r "api -X GET = read-only (explicit GET)" true
     (Keeper_tool_registry.is_gh_api_read_only "api -x get repos/o/r")
 

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -979,6 +979,12 @@ let parse_error_field raw =
   |> Json.member "error"
   |> Json.to_string_option
 
+let check_safe_read_fallback_reason expected json =
+  Alcotest.(check (option string))
+    "safe read fallback reason"
+    (Some expected)
+    (json |> Json.member "safe_read_fallback_reason" |> Json.to_string_option)
+
 let test_keeper_bash_typed_exec_runs_via_shell_ir () =
   with_eio_fs @@ fun () ->
   let base_path, config = make_config () in
@@ -1121,6 +1127,7 @@ let test_keeper_bash_safe_dev_null_echo_fallback_executes_primary () =
   let json = Yojson.Safe.from_string raw in
   Alcotest.(check bool) "fallback command succeeds" true
     (json |> Json.member "ok" |> Json.to_bool);
+  check_safe_read_fallback_reason "or_echo" json;
   Alcotest.(check bool) "primary command ran" true
     (json
      |> Json.member "output"
@@ -1153,6 +1160,7 @@ let test_keeper_bash_safe_dev_null_redirect_executes_scoped_ls () =
   let json = Yojson.Safe.from_string raw in
   Alcotest.(check bool) "direct dev-null ls succeeds" true
     (json |> Json.member "ok" |> Json.to_bool);
+  check_safe_read_fallback_reason "stderr_dev_null_stripped" json;
   Alcotest.(check bool) "ls output is preserved" true
     (json
      |> Json.member "output"
@@ -1187,6 +1195,7 @@ let test_keeper_bash_safe_fallback_works_for_write_enabled_keeper () =
   let json = Yojson.Safe.from_string raw in
   Alcotest.(check bool) "write-enabled fallback command succeeds" true
     (json |> Json.member "ok" |> Json.to_bool);
+  check_safe_read_fallback_reason "or_echo" json;
   Alcotest.(check bool) "primary cat ran" true
     (json
      |> Json.member "output"
@@ -1218,6 +1227,7 @@ let test_keeper_bash_safe_cd_fallback_executes_scoped_read () =
   let json = Yojson.Safe.from_string raw in
   Alcotest.(check bool) "cd fallback command succeeds" true
     (json |> Json.member "ok" |> Json.to_bool);
+  check_safe_read_fallback_reason "cd_and_read" json;
   Alcotest.(check bool) "read command ran after cd" true
     (json
      |> Json.member "output"
@@ -1244,6 +1254,7 @@ let test_keeper_bash_safe_pwd_fallback_executes_scoped_ls () =
   let json = Yojson.Safe.from_string raw in
   Alcotest.(check bool) "pwd && ls fallback succeeds" true
     (json |> Json.member "ok" |> Json.to_bool);
+  check_safe_read_fallback_reason "pwd_and_read" json;
   Alcotest.(check bool) "ls output is preserved" true
     (json
      |> Json.member "output"
@@ -1278,6 +1289,7 @@ let test_keeper_bash_safe_pwd_fallback_executes_head_pipeline () =
   let json = Yojson.Safe.from_string raw in
   Alcotest.(check bool) "pwd && find | head fallback succeeds" true
     (json |> Json.member "ok" |> Json.to_bool);
+  check_safe_read_fallback_reason "pwd_head_pipeline" json;
   Alcotest.(check bool) "find output is preserved" true
     (json
      |> Json.member "output"
@@ -1402,6 +1414,7 @@ let test_keeper_bash_safe_rg_fallback_allows_escaped_regex_pipe () =
   let json = Yojson.Safe.from_string raw in
   Alcotest.(check bool) "rg fallback command succeeds" true
     (json |> Json.member "ok" |> Json.to_bool);
+  check_safe_read_fallback_reason "or_echo" json;
   Alcotest.(check bool) "fallback echo ran on no match" true
     (json
      |> Json.member "output"
@@ -1439,6 +1452,7 @@ let test_keeper_bash_safe_dev_null_redirect_executes_scoped_grep () =
   let json = Yojson.Safe.from_string raw in
   Alcotest.(check bool) "direct dev-null grep succeeds" true
     (json |> Json.member "ok" |> Json.to_bool);
+  check_safe_read_fallback_reason "stderr_dev_null_stripped" json;
   Alcotest.(check bool) "grep found scoped file" true
     (json
      |> Json.member "output"
@@ -1476,6 +1490,7 @@ let test_keeper_bash_safe_head_pipeline_executes_scoped_cat () =
   let json = Yojson.Safe.from_string raw in
   Alcotest.(check bool) "safe cat | head succeeds" true
     (json |> Json.member "ok" |> Json.to_bool);
+  check_safe_read_fallback_reason "head_pipeline" json;
   Alcotest.(check bool) "cat output is preserved" true
     (json
      |> Json.member "output"
@@ -1743,6 +1758,7 @@ let test_keeper_bash_safe_head_pipeline_executes_cd_scoped_grep () =
   let json = Yojson.Safe.from_string raw in
   Alcotest.(check bool) "safe grep | head succeeds" true
     (json |> Json.member "ok" |> Json.to_bool);
+  check_safe_read_fallback_reason "head_pipeline" json;
   Alcotest.(check bool) "grep output is preserved" true
     (json
      |> Json.member "output"
@@ -1787,6 +1803,7 @@ let test_keeper_bash_safe_head_pipeline_executes_scoped_find () =
   let json = Yojson.Safe.from_string raw in
   Alcotest.(check bool) "safe find | head succeeds" true
     (json |> Json.member "ok" |> Json.to_bool);
+  check_safe_read_fallback_reason "head_pipeline" json;
   let output = json |> Json.member "output" |> Json.to_string in
   Alcotest.(check bool) "find output includes ml file" true
     (String_util.contains_substring output "needle.ml");

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -1913,6 +1913,8 @@ let test_git_write_classification () =
     true (is_branch_switch "git checkout -b my-feature");
   Alcotest.(check bool) "switch is branch switch"
     true (is_branch_switch "git switch -c my-feature");
+  Alcotest.(check bool) "switch after quoted -C path is branch switch"
+    true (is_branch_switch "git -C 'repo dir' switch my-feature");
   (* git push: write op, allowed in playground *)
   Alcotest.(check bool) "push is write" true (is_write "git push origin my-branch");
   Alcotest.(check bool) "commit is write" true (is_write "git commit -m 'msg'");

--- a/test/test_keeper_github_read_only.ml
+++ b/test/test_keeper_github_read_only.ml
@@ -216,9 +216,20 @@ let test_prefixed_gh_command_normalization () =
     (match Keeper_gh_shared.extract_gh_target_number "gh pr view 123" with
      | Some (Keeper_gh_shared.PR, n) -> Some n
      | _ -> None);
+  Alcotest.(check (option int)) "quoted target number is parsed"
+    (Some 123)
+    (match Keeper_gh_shared.extract_gh_target_number "gh pr view '123'" with
+     | Some (Keeper_gh_shared.PR, n) -> Some n
+     | _ -> None);
   Alcotest.(check (option string)) "prefixed gh parser still finds mutation"
     (Some "pr")
     (match Keeper_gh_shared.gh_mutates_entity "gh pr merge 123" with
+     | Some Keeper_gh_shared.PR -> Some "pr"
+     | Some Keeper_gh_shared.Issue -> Some "issue"
+     | None -> None);
+  Alcotest.(check (option string)) "quoted mutation subcommand is parsed"
+    (Some "pr")
+    (match Keeper_gh_shared.gh_mutates_entity "gh pr 'merge' 123" with
      | Some Keeper_gh_shared.PR -> Some "pr"
      | Some Keeper_gh_shared.Issue -> Some "issue"
      | None -> None);

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -1279,6 +1279,34 @@ let test_sandbox_root_git_cwd_cd_chain_is_not_interpreted () =
     None
     error
 
+let test_gh_repo_api_misuse_uses_shell_semantics () =
+  let check label expected cmd =
+    Alcotest.(check (option (pair string string)))
+      label
+      expected
+      (Keeper_shell_command_semantics.detect_gh_repo_flag_with_api_misuse cmd);
+    Alcotest.(check (option (pair string string)))
+      (label ^ " docker alias")
+      expected
+      (Keeper_shell_docker.detect_gh_repo_flag_with_api_misuse cmd)
+  in
+  check
+    "quoted repo arg"
+    (Some ("jeong-sik/masc-mcp", "repos/jeong-sik/masc-mcp/actions/runs"))
+    "gh --repo 'jeong-sik/masc-mcp' api repos/jeong-sik/masc-mcp/actions/runs";
+  check
+    "repo equals form"
+    (Some ("jeong-sik/masc-mcp", "repos/jeong-sik/masc-mcp/pulls"))
+    "gh --repo=jeong-sik/masc-mcp api repos/jeong-sik/masc-mcp/pulls";
+  check
+    "env prefix"
+    (Some ("jeong-sik/masc-mcp", "repos/jeong-sik/masc-mcp/issues"))
+    "env GH_TOKEN=redacted gh --repo jeong-sik/masc-mcp api repos/jeong-sik/masc-mcp/issues";
+  check
+    "subcommand repo flag is fine"
+    None
+    "gh pr view --repo jeong-sik/masc-mcp 17214"
+
 let test_git_creds_skips_missing_ssh_auth_sock () =
   with_fake_docker fake_docker_echo_script @@ fun () ->
   setup ~sandbox:Keeper_types.Docker
@@ -1964,5 +1992,9 @@ let () =
             "sandbox-root git cd-chain is not interpreted by cwd policy"
             `Quick
             test_sandbox_root_git_cwd_cd_chain_is_not_interpreted;
+          Alcotest.test_case
+            "gh --repo api misuse uses shell semantics"
+            `Quick
+            test_gh_repo_api_misuse_uses_shell_semantics;
         ] );
     ]

--- a/test/test_spawn.ml
+++ b/test/test_spawn.ml
@@ -151,6 +151,19 @@ let test_masc_mcp_tools () =
     (List.mem "mcp__masc__masc_tool_revoke" Spawn.masc_mcp_tools);
   ()
 
+let test_parse_command_preserves_quoted_args () =
+  Alcotest.(check (list string)) "quoted arg preserved"
+    [ "claude"; "--output-format"; "json value"; "-p" ]
+    (Spawn.parse_command "claude --output-format 'json value' -p")
+
+let test_parse_command_rejects_shell_pipeline () =
+  Alcotest.(check (list string)) "pipeline rejected" []
+    (Spawn.parse_command "claude -p prompt | cat")
+
+let test_parse_command_rejects_malformed_quote () =
+  Alcotest.(check (list string)) "malformed quote rejected" []
+    (Spawn.parse_command "claude -p 'unterminated")
+
 let test_spawn_bare_ollama_rejected () =
   if Option.value ~default:"" (Sys.getenv_opt "OLLAMA_DEFAULT_MODEL") |> String.trim = ""
   then (
@@ -197,6 +210,12 @@ let tests = [
   Alcotest.test_case "result_to_string failure" `Quick test_result_to_string_failure;
   Alcotest.test_case "result_to_json" `Quick test_result_to_json;
   Alcotest.test_case "masc_mcp_tools populated" `Quick test_masc_mcp_tools;
+  Alcotest.test_case "parse_command preserves quoted args" `Quick
+    test_parse_command_preserves_quoted_args;
+  Alcotest.test_case "parse_command rejects shell pipeline" `Quick
+    test_parse_command_rejects_shell_pipeline;
+  Alcotest.test_case "parse_command rejects malformed quote" `Quick
+    test_parse_command_rejects_malformed_quote;
   Alcotest.test_case "bare ollama rejected" `Quick test_spawn_bare_ollama_rejected;
   Alcotest.test_case "spawn failure surfaces stderr" `Quick
     test_spawn_failure_surfaces_stderr;

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -893,6 +893,10 @@ let () =
       Alcotest.test_case "blocks push refspec to main" `Quick (fun () ->
         Alcotest.(check bool) "push refspec main" true
           (Worker_dev_tools.is_destructive_bash_operation "git push origin HEAD:main"));
+      Alcotest.test_case "blocks quoted push refspec to main" `Quick (fun () ->
+        Alcotest.(check bool) "quoted push refspec main" true
+          (Worker_dev_tools.is_destructive_bash_operation
+             "git push origin 'HEAD:main'"));
       Alcotest.test_case "blocks push refs heads main" `Quick (fun () ->
         Alcotest.(check bool) "push refs/heads/main" true
           (Worker_dev_tools.is_destructive_bash_operation "git push origin refs/heads/main"));
@@ -905,6 +909,9 @@ let () =
       Alcotest.test_case "blocks git reset --hard" `Quick (fun () ->
         Alcotest.(check bool) "reset hard" true
           (Worker_dev_tools.is_destructive_bash_operation "git reset --hard HEAD~1"));
+      Alcotest.test_case "blocks quoted git reset --hard" `Quick (fun () ->
+        Alcotest.(check bool) "quoted reset hard" true
+          (Worker_dev_tools.is_destructive_bash_operation "git reset '--hard' HEAD~1"));
       Alcotest.test_case "allows git reset (soft)" `Quick (fun () ->
         Alcotest.(check bool) "reset soft" false
           (Worker_dev_tools.is_destructive_bash_operation "git reset HEAD~1"));
@@ -950,6 +957,10 @@ let () =
         Alcotest.(check (option string)) "match-head-commit skipped" (Some "5934")
           (Worker_dev_tools.gh_pr_merge_target
              "pr merge --match-head-commit abc123 5934"));
+      Alcotest.test_case "skips quoted match-head-commit value" `Quick (fun () ->
+        Alcotest.(check (option string)) "quoted match-head-commit skipped" (Some "5934")
+          (Worker_dev_tools.gh_pr_merge_target
+             "pr merge --match-head-commit 'abc 123' 5934"));
     ];
     "sanitize_command_for_log", [
       Alcotest.test_case "redacts url credentials" `Quick (fun () ->
@@ -1032,6 +1043,13 @@ let () =
         match
           Worker_dev_tools.validate_gh_command ~allowed_orgs:["jeong-sik"]
             "pr view --repo jeong-sik/masc-mcp 123"
+        with
+        | Ok () -> ()
+        | Error msg -> Alcotest.failf "expected ok, got %s" msg);
+      Alcotest.test_case "allows quoted repo in allowed_orgs" `Quick (fun () ->
+        match
+          Worker_dev_tools.validate_gh_command ~allowed_orgs:["jeong-sik"]
+            "pr view --repo 'jeong-sik/masc-mcp' 123"
         with
         | Ok () -> ()
         | Error msg -> Alcotest.failf "expected ok, got %s" msg);
@@ -1133,6 +1151,11 @@ let () =
         Alcotest.(check bool) "R1" true
           (Worker_dev_tools.classify_gh_reversibility
              "api --method POST repos/jeong-sik/foo/issues"
+           = Worker_dev_tools.R1_Reversible));
+      Alcotest.test_case "R1: api quoted --method PATCH" `Quick (fun () ->
+        Alcotest.(check bool) "R1" true
+          (Worker_dev_tools.classify_gh_reversibility
+             "api --method 'PATCH' repos/jeong-sik/foo/issues/1"
            = Worker_dev_tools.R1_Reversible));
       Alcotest.test_case "R1: api with -f field (implicit POST)" `Quick (fun () ->
         Alcotest.(check bool) "R1" true

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -990,6 +990,22 @@ let () =
           (contains_substring redacted "secret-value");
         Alcotest.(check bool) "placeholder added" true
           (contains_substring redacted "--token [REDACTED]"));
+      Alcotest.test_case "redacts quoted sensitive flag values" `Quick (fun () ->
+        let redacted =
+          Worker_dev_tools.sanitize_command_for_log
+            "gh api --token 'secret value' /user"
+        in
+        Alcotest.(check bool) "quoted secret removed" false
+          (contains_substring redacted "secret value");
+        Alcotest.(check bool) "placeholder added" true
+          (contains_substring redacted "--token [REDACTED]"));
+      Alcotest.test_case "fail-closes malformed sensitive command" `Quick (fun () ->
+        let redacted =
+          Worker_dev_tools.sanitize_command_for_log
+            "gh api --token 'secret value"
+        in
+        Alcotest.(check string) "malformed sensitive command redacted"
+          "[REDACTED]" redacted);
     ];
     "validate_gh_command", [
       Alcotest.test_case "accepts allowed subcommand with no repo flag" `Quick (fun () ->


### PR DESCRIPTION
## Summary
- replace ad hoc whitespace token splitting in gh command validation, keeper gh classifiers, worker mutation/destructive classifiers, command log sanitization, and spawn argv construction with shared bash parser / shell semantics
- centralize docker `gh --repo ... api ...` misuse detection in `Keeper_shell_command_semantics`
- keep spawn parsing fail-closed for shell pipelines, redirects, and env prefixes instead of flattening shell syntax into argv
- expose the safe-read fallback reason in keeper bash safety handling
- add quoted/env-prefix regression coverage for gh repo parsing, gh method classification, keeper gh target/mutation parsing, command log sanitization, spawn parsing, docker gh-api misuse detection, and safe-read fallback reason
- rebase onto current `origin/main`; stale structure-ratchet and runtime-tunables commits were dropped because those changes are already upstream

## Validation
- `opam exec -- ocamlformat --check` on touched OCaml/test files
- `git diff --check origin/main...HEAD`
- `bash scripts/lint/shell-legacy-purge-ratchet.sh`
- `scripts/lint-spawn-bounded.sh`
- `scripts/ocaml-structure-ratchet.sh` - PASS, only lib_dune_lines below-baseline hint remains
- `scripts/check-oas-pin.sh` - PASS; OAS pin verified at 6d952cb93a106cb622a46983600f7b00ad5d3fe1 and API surface fingerprint matches
- focused `scripts/dune-local.sh build ...` not rerun from this rebase worktree because /tmp/me-dune-local.lock is already held by several other worktrees, including an older #17214 focused test queue

## Notes
- Current PR head after rebase: 516f4b15b5f1e83b353e33c352d74a5c22b05ba
- GitHub checks for this head are queued after the force-with-lease push
- `Draft Auto-Merge Guard` is expected to fail while the PR remains draft