### PR TITLE
refactor(server_dashboard_http_core): extract operator broadcast/cache cluster into sibling (step 20)

### DIFF
--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -214,70 +214,17 @@ let dashboard_batch_json ?(compact = false) (config : Coord.config) : Yojson.Saf
     ]
 ;;
 
-let operator_actor_hint request =
-  match agent_from_request request with
-  | Some raw ->
-    let sanitized = sanitize_dashboard_actor_name raw in
-    if sanitized = "" then None else Some sanitized
-  | None -> None
-;;
-
-(* --- Operator proactive refresh ---
-   Default (no-param) requests are served from a background-refreshed ref.
-   Parameterized requests fall back to on-demand compute with SWR cache.
-
-   Using Proactive_refresh gives circuit breaker + exponential backoff on
-   repeated failures, matching the pattern used by execution and mission loops.
-
-   Interval: 10s (was 120s). Even if compute takes ~8s, the ref is updated
-   every ~18s worst-case, which is acceptable for dashboard SSE polling. *)
-
-(* Late-bound broadcast refs — set by server_dashboard_http.ml after
-   Sse module is in scope.  Same pattern as _broadcast_room_truth_ref. *)
-let operator_snapshot_broadcast_ref : (Yojson.Safe.t -> unit) ref =
-  ref (fun (_json : Yojson.Safe.t) -> ())
-;;
-
-let _operator_snapshot_broadcast_ref = operator_snapshot_broadcast_ref
-
-let operator_digest_broadcast_ref : (Yojson.Safe.t -> unit) ref =
-  ref (fun (_json : Yojson.Safe.t) -> ())
-;;
-
-let _operator_digest_broadcast_ref = operator_digest_broadcast_ref
-
-let operator_snapshot_cache =
-  create_cached_surface
-    (`Assoc
-        [ "status", `String "initializing"
-        ; "generated_at", `String (Masc_domain.now_iso ())
-        ])
-;;
-
-let _operator_snapshot_cache = operator_snapshot_cache
-
-let operator_digest_cache =
-  create_cached_surface
-    (`Assoc
-        [ "health", `String "initializing"
-        ; "generated_at", `String (Masc_domain.now_iso ())
-        ])
-;;
-
-let _operator_digest_cache = operator_digest_cache
-
-let operator_refresh_interval_s =
-  float_of_env_default
-    "MASC_OPERATOR_REFRESH_INTERVAL_S"
-    ~default:60.0
-    ~min_v:10.0
-    ~max_v:600.0
-;;
-
-let operator_snapshot_extra () =
-  [ "readonly_pool", Coord_utils.domain_local_pg_backend_diagnostics_json () ]
-;;
-
+let operator_actor_hint = Server_dashboard_http_core_operator.operator_actor_hint
+let operator_snapshot_broadcast_ref = Server_dashboard_http_core_operator.operator_snapshot_broadcast_ref
+let _operator_snapshot_broadcast_ref = Server_dashboard_http_core_operator._operator_snapshot_broadcast_ref
+let operator_digest_broadcast_ref = Server_dashboard_http_core_operator.operator_digest_broadcast_ref
+let _operator_digest_broadcast_ref = Server_dashboard_http_core_operator._operator_digest_broadcast_ref
+let operator_snapshot_cache = Server_dashboard_http_core_operator.operator_snapshot_cache
+let _operator_snapshot_cache = Server_dashboard_http_core_operator._operator_snapshot_cache
+let operator_digest_cache = Server_dashboard_http_core_operator.operator_digest_cache
+let _operator_digest_cache = Server_dashboard_http_core_operator._operator_digest_cache
+let operator_refresh_interval_s = Server_dashboard_http_core_operator.operator_refresh_interval_s
+let operator_snapshot_extra = Server_dashboard_http_core_operator.operator_snapshot_extra
 let json_string_opt = function
   | Some value -> `String value
   | None -> `Null

--- a/lib/server/server_dashboard_http_core_operator.ml
+++ b/lib/server/server_dashboard_http_core_operator.ml
@@ -1,0 +1,67 @@
+(** Operator broadcast + cache state cluster for dashboard HTTP core,
+    extracted from server_dashboard_http_core.ml. *)
+
+let operator_actor_hint request =
+  match agent_from_request request with
+  | Some raw ->
+    let sanitized = sanitize_dashboard_actor_name raw in
+    if sanitized = "" then None else Some sanitized
+  | None -> None
+;;
+
+(* --- Operator proactive refresh ---
+   Default (no-param) requests are served from a background-refreshed ref.
+   Parameterized requests fall back to on-demand compute with SWR cache.
+
+   Using Proactive_refresh gives circuit breaker + exponential backoff on
+   repeated failures, matching the pattern used by execution and mission loops.
+
+   Interval: 10s (was 120s). Even if compute takes ~8s, the ref is updated
+   every ~18s worst-case, which is acceptable for dashboard SSE polling. *)
+
+(* Late-bound broadcast refs — set by server_dashboard_http.ml after
+   Sse module is in scope.  Same pattern as _broadcast_room_truth_ref. *)
+let operator_snapshot_broadcast_ref : (Yojson.Safe.t -> unit) ref =
+  ref (fun (_json : Yojson.Safe.t) -> ())
+;;
+
+let _operator_snapshot_broadcast_ref = operator_snapshot_broadcast_ref
+
+let operator_digest_broadcast_ref : (Yojson.Safe.t -> unit) ref =
+  ref (fun (_json : Yojson.Safe.t) -> ())
+;;
+
+let _operator_digest_broadcast_ref = operator_digest_broadcast_ref
+
+let operator_snapshot_cache =
+  create_cached_surface
+    (`Assoc
+        [ "status", `String "initializing"
+        ; "generated_at", `String (Masc_domain.now_iso ())
+        ])
+;;
+
+let _operator_snapshot_cache = operator_snapshot_cache
+
+let operator_digest_cache =
+  create_cached_surface
+    (`Assoc
+        [ "health", `String "initializing"
+        ; "generated_at", `String (Masc_domain.now_iso ())
+        ])
+;;
+
+let _operator_digest_cache = operator_digest_cache
+
+let operator_refresh_interval_s =
+  float_of_env_default
+    "MASC_OPERATOR_REFRESH_INTERVAL_S"
+    ~default:60.0
+    ~min_v:10.0
+    ~max_v:600.0
+;;
+
+let operator_snapshot_extra () =
+  [ "readonly_pool", Coord_utils.domain_local_pg_backend_diagnostics_json () ]
+;;
+


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` step 20 (Dashboard core surface split — Operator quarter)
- Second cluster from `server_dashboard_http_core.ml` after #17126 (cache).

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/server/server_dashboard_http_core.ml` | 1748 | 1695 | **-53** |
| `lib/server/server_dashboard_http_core_operator.ml` | — | 67 | +67 |

## Moved (verbatim, no behavior change)
- `operator_actor_hint`
- `operator_snapshot_broadcast_ref`, `operator_digest_broadcast_ref` (mutable refs) + `_underscore` retainers
- `operator_snapshot_cache`, `operator_digest_cache` (cached state) + `_underscore` retainers
- `operator_refresh_interval_s`
- `operator_snapshot_extra`

11 bindings via single-line aliases — mutable refs/cache reach the sibling once at load time, aliases preserve identity for parent callers.

## Local build status
- godfile lint: clean
- Pre-existing main breakages persist (unrelated):
  - `runtime_manifest_scan.active_open_loop_count` missing field
  - `keeper_turn_driver.ml:1077-1078` redundant-case

## RFC-WAIVED
Extract-only sibling refactor.

Co-Authored-By: codex <noreply@anthropic.com>
