### PR TITLE
fix(task): expose no-eligible claim diagnostics

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -1042,7 +1042,17 @@ type claim_next_result = Masc_domain.claim_next_result =
       ; message : string
       }
   | Claim_next_no_unclaimed
-  | Claim_next_no_eligible of { excluded_count : int }
+  | Claim_next_no_eligible of
+      { excluded_count : int
+      ; blocked_count : int
+      ; verification_blocked_count : int
+      ; scope_excluded_count : int
+      ; required_tool_excluded_count : int
+      ; explicit_excluded_count : int
+      ; claim_pool_candidate_count : int
+      ; receipt_required_tool_blocked : bool
+      ; agent_tool_names_known : bool
+      }
   | Claim_next_error of string
 
 let link_task_execution_artifacts_r

--- a/lib/coord/coord_task.mli
+++ b/lib/coord/coord_task.mli
@@ -84,5 +84,15 @@ type claim_next_result = Masc_domain.claim_next_result =
       message : string;
     }
   | Claim_next_no_unclaimed
-  | Claim_next_no_eligible of { excluded_count : int }
+  | Claim_next_no_eligible of
+      { excluded_count : int
+      ; blocked_count : int
+      ; verification_blocked_count : int
+      ; scope_excluded_count : int
+      ; required_tool_excluded_count : int
+      ; explicit_excluded_count : int
+      ; claim_pool_candidate_count : int
+      ; receipt_required_tool_blocked : bool
+      ; agent_tool_names_known : bool
+      }
   | Claim_next_error of string

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -520,6 +520,21 @@ let claim_next_r
           | _ :: _ -> primary_eligible
           | [] -> eligible_from soft_unclaimed
         in
+        let explicit_excluded_count =
+          List.length exclude_task_ids
+          +
+          match released_task_id with
+          | Some _ -> 1
+          | None -> 0
+        in
+        let no_eligible_excluded_count =
+          List.length all_excluded
+          + List.length task_filter_excluded
+          + List.length required_tool_excluded
+        in
+        let receipt_required_tool_blocked =
+          List.exists receipt_blocks_task required_tool_excluded
+        in
         (* Helper: clear agent current_task and reset status after a legacy
          released_task_id path when no replacement task can be claimed. Delegates to
          [Coord_task.update_local_agent_state] so the agent-file write
@@ -563,10 +578,15 @@ let claim_next_r
             | None -> ());
            clear_agent_state_after_release ();
            Claim_next_no_eligible
-             { excluded_count =
-                 List.length all_excluded
-                 + List.length task_filter_excluded
-                 + List.length required_tool_excluded
+             { excluded_count = no_eligible_excluded_count
+             ; blocked_count = List.length blocked_todo
+             ; verification_blocked_count = List.length verification_blocked_todo
+             ; scope_excluded_count = List.length task_filter_excluded
+             ; required_tool_excluded_count = List.length required_tool_excluded
+             ; explicit_excluded_count
+             ; claim_pool_candidate_count = List.length unclaimed
+             ; receipt_required_tool_blocked
+             ; agent_tool_names_known = Option.is_some agent_tool_names
              }
          | _ :: _, task :: _ ->
            (* Claim this task *)
@@ -698,10 +718,21 @@ let claim_next config ~agent_name =
   | Claim_next_claimed { message; _ } -> message
   | Claim_next_no_unclaimed ->
     "No unclaimed tasks. ACTION: Stop task-checking — nothing to claim."
-  | Claim_next_no_eligible { excluded_count } ->
+  | Claim_next_no_eligible
+      { excluded_count
+      ; scope_excluded_count
+      ; required_tool_excluded_count
+      ; verification_blocked_count
+      ; _
+      } ->
     Printf.sprintf
-      "No eligible unclaimed tasks. ACTION: Stop task-checking — blocked/excluded=%d."
+      "No eligible unclaimed tasks. ACTION: Stop task-checking — \
+       blocked/excluded=%d (goal_scope_or_filter=%d, required_tools=%d, \
+       verification=%d)."
       excluded_count
+      scope_excluded_count
+      required_tool_excluded_count
+      verification_blocked_count
   | Claim_next_error e -> Printf.sprintf "Error: %s" e
 ;;
 

--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -74,8 +74,23 @@ let parse_task_contract_arg args =
    [keeper_task_create_goal_open_limit]) lived here as introduced by
    #13981. *)
 
-let active_goal_scope_json ~(meta : keeper_meta) ?matched_goal_id
-    ?excluded_count ?effective_mode ?effective_goal_ids ?fallback_reason () =
+let active_goal_scope_json
+      ~(meta : keeper_meta)
+      ?matched_goal_id
+      ?excluded_count
+      ?blocked_count
+      ?verification_blocked_count
+      ?scope_excluded_count
+      ?required_tool_excluded_count
+      ?explicit_excluded_count
+      ?claim_pool_candidate_count
+      ?receipt_required_tool_blocked
+      ?agent_tool_names_known
+      ?effective_mode
+      ?effective_goal_ids
+      ?fallback_reason
+      ()
+  =
   let scoped = meta.active_goal_ids <> [] in
   let mode =
     match effective_mode with
@@ -106,6 +121,25 @@ let active_goal_scope_json ~(meta : keeper_meta) ?matched_goal_id
     | Some count -> fields @ [ ("excluded_count", `Int count) ]
     | None -> fields
   in
+  let int_fields =
+    [ "blocked_count", blocked_count
+    ; "verification_blocked_count", verification_blocked_count
+    ; "scope_excluded_count", scope_excluded_count
+    ; "required_tool_excluded_count", required_tool_excluded_count
+    ; "explicit_excluded_count", explicit_excluded_count
+    ; "claim_pool_candidate_count", claim_pool_candidate_count
+    ]
+    |> List.filter_map (fun (name, value) ->
+      Option.map (fun count -> name, `Int count) value)
+  in
+  let bool_fields =
+    [ "receipt_required_tool_blocked", receipt_required_tool_blocked
+    ; "agent_tool_names_known", agent_tool_names_known
+    ]
+    |> List.filter_map (fun (name, value) ->
+      Option.map (fun flag -> name, `Bool flag) value)
+  in
+  let fields = fields @ int_fields @ bool_fields in
   `Assoc fields
 ;;
 
@@ -144,6 +178,21 @@ let no_eligible_action_for_claim_scope claim_goal_scope ~excluded_count =
       "ACTION: Stop task-checking — blocked/excluded=%d.%s"
       excluded_count
       scope_hint
+;;
+
+let no_eligible_blocker_summary
+      ~blocked_count
+      ~verification_blocked_count
+      ~scope_excluded_count
+      ~required_tool_excluded_count
+  =
+  Printf.sprintf
+    "Diagnostics: goal_scope_or_filter=%d, required_tools=%d, verification=%d, \
+     blocked=%d."
+    scope_excluded_count
+    required_tool_excluded_count
+    verification_blocked_count
+    blocked_count
 ;;
 
 let missing_required_tools_for_claim_scope config ~agent_tool_names ~task_filter =
@@ -412,7 +461,14 @@ let handle_keeper_task_tool
           if !auto_started_ok then message ^ " Task auto-started — begin work now."
           else message
       | Coord.Claim_next_no_unclaimed -> "No unclaimed tasks. ACTION: Stop task-checking — nothing to claim."
-      | Coord.Claim_next_no_eligible { excluded_count; _ } ->
+      | Coord.Claim_next_no_eligible
+          { excluded_count
+          ; blocked_count
+          ; verification_blocked_count
+          ; scope_excluded_count
+          ; required_tool_excluded_count
+          ; _
+          } ->
         let action =
           match
             required_tool_workflow_rejection
@@ -425,9 +481,14 @@ let handle_keeper_task_tool
             no_eligible_action_for_claim_scope claim_goal_scope ~excluded_count
         in
         Printf.sprintf
-          "No eligible tasks%s. %s"
+          "No eligible tasks%s. %s %s"
           (claim_scope_context_suffix ~meta claim_goal_scope)
           action
+          (no_eligible_blocker_summary
+             ~blocked_count
+             ~verification_blocked_count
+             ~scope_excluded_count
+             ~required_tool_excluded_count)
       | Coord.Claim_next_error e -> Printf.sprintf "Error: %s" e
     in
     let claim_scope, claimed_task_fields =
@@ -455,8 +516,28 @@ let handle_keeper_task_tool
                       Json_util.string_opt_to_json released_task_id );
                   ] );
             ] )
-      | Coord.Claim_next_no_eligible { excluded_count } ->
-          ( active_goal_scope_json ~meta ~excluded_count
+      | Coord.Claim_next_no_eligible
+          { excluded_count
+          ; blocked_count
+          ; verification_blocked_count
+          ; scope_excluded_count
+          ; required_tool_excluded_count
+          ; explicit_excluded_count
+          ; claim_pool_candidate_count
+          ; receipt_required_tool_blocked
+          ; agent_tool_names_known
+          } ->
+          ( active_goal_scope_json
+              ~meta
+              ~excluded_count
+              ~blocked_count
+              ~verification_blocked_count
+              ~scope_excluded_count
+              ~required_tool_excluded_count
+              ~explicit_excluded_count
+              ~claim_pool_candidate_count
+              ~receipt_required_tool_blocked
+              ~agent_tool_names_known
               ~effective_mode:claim_goal_scope.mode
               ~effective_goal_ids:claim_goal_scope.effective_goal_ids
               ?fallback_reason:claim_goal_scope.fallback_reason ()

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -364,23 +364,78 @@ let active_goal_phases_for_agent ctx =
         meta.active_goal_ids
   | Ok None | Error _ -> []
 
-let format_no_eligible ctx excluded_count =
+let no_eligible_diagnostics_json
+      ~excluded_count
+      ~blocked_count
+      ~verification_blocked_count
+      ~scope_excluded_count
+      ~required_tool_excluded_count
+      ~explicit_excluded_count
+      ~claim_pool_candidate_count
+      ~receipt_required_tool_blocked
+      ~agent_tool_names_known
+  =
+  `Assoc
+    [ "excluded_count", `Int excluded_count
+    ; "blocked_count", `Int blocked_count
+    ; "verification_blocked_count", `Int verification_blocked_count
+    ; "scope_excluded_count", `Int scope_excluded_count
+    ; "required_tool_excluded_count", `Int required_tool_excluded_count
+    ; "explicit_excluded_count", `Int explicit_excluded_count
+    ; "claim_pool_candidate_count", `Int claim_pool_candidate_count
+    ; "receipt_required_tool_blocked", `Bool receipt_required_tool_blocked
+    ; "agent_tool_names_known", `Bool agent_tool_names_known
+    ]
+;;
+
+let no_eligible_blocker_summary
+      ~blocked_count
+      ~verification_blocked_count
+      ~scope_excluded_count
+      ~required_tool_excluded_count
+  =
+  Printf.sprintf
+    "diagnostics: goal_scope_or_filter=%d, required_tools=%d, verification=%d, \
+     blocked=%d."
+    scope_excluded_count
+    required_tool_excluded_count
+    verification_blocked_count
+    blocked_count
+;;
+
+let format_no_eligible
+      ctx
+      ~excluded_count
+      ~blocked_count
+      ~verification_blocked_count
+      ~scope_excluded_count
+      ~required_tool_excluded_count
+  =
+  let diagnostics =
+    no_eligible_blocker_summary
+      ~blocked_count
+      ~verification_blocked_count
+      ~scope_excluded_count
+      ~required_tool_excluded_count
+  in
   match active_goal_phases_for_agent ctx with
   | [] ->
       Printf.sprintf
         "No eligible tasks available (blocked/excluded: %d). This agent has no \
          active_goal_ids — every open task is out of scope. Operator should \
-         set active_goal_ids via masc_keeper_up."
+         set active_goal_ids via masc_keeper_up. %s"
         excluded_count
+        diagnostics
   | phases ->
       Printf.sprintf
         "No eligible tasks available (blocked/excluded: %d). active goal \
          phases: [%s]. NOTE: excluded ≠ completed. If every phase above is \
          'executing', the cause is goal-scope mismatch — open tasks are \
          scoped to a goal not in this agent's active_goal_ids — not goal \
-         completion."
+         completion. %s"
         excluded_count
         (String.concat ", " phases)
+        diagnostics
 
 let handle_claim_next ?agent_tool_names ~tool_name ~start_time ctx _args =
   if not (try Coord.is_agent_joined ctx.config ~agent_name:ctx.agent_name with Sys_error _ | Stdlib.Not_found -> false) then
@@ -403,8 +458,43 @@ let handle_claim_next ?agent_tool_names ~tool_name ~start_time ctx _args =
     |> Tool_result.ok ~tool_name ~start_time
   | Coord.Claim_next_no_unclaimed ->
     Tool_result.ok ~tool_name ~start_time "No unclaimed tasks available"
-  | Coord.Claim_next_no_eligible { excluded_count; _ } ->
-    Tool_result.ok ~tool_name ~start_time (format_no_eligible ctx excluded_count)
+  | Coord.Claim_next_no_eligible
+      { excluded_count
+      ; blocked_count
+      ; verification_blocked_count
+      ; scope_excluded_count
+      ; required_tool_excluded_count
+      ; explicit_excluded_count
+      ; claim_pool_candidate_count
+      ; receipt_required_tool_blocked
+      ; agent_tool_names_known
+      } ->
+    let message =
+      format_no_eligible
+        ctx
+        ~excluded_count
+        ~blocked_count
+        ~verification_blocked_count
+        ~scope_excluded_count
+        ~required_tool_excluded_count
+    in
+    let diagnostics =
+      no_eligible_diagnostics_json
+        ~excluded_count
+        ~blocked_count
+        ~verification_blocked_count
+        ~scope_excluded_count
+        ~required_tool_excluded_count
+        ~explicit_excluded_count
+        ~claim_pool_candidate_count
+        ~receipt_required_tool_blocked
+        ~agent_tool_names_known
+    in
+    let payload =
+      `Assoc [ "message", `String message; "diagnostics", diagnostics ]
+      |> Yojson.Safe.to_string
+    in
+    Tool_result.ok ~tool_name ~start_time (message ^ "\n" ^ payload)
   | Coord.Claim_next_error e ->
     Tool_result.error ~tool_name ~start_time (Printf.sprintf "Error: %s" e)
 

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -980,5 +980,15 @@ type claim_next_result =
       message : string;
     }
   | Claim_next_no_unclaimed
-  | Claim_next_no_eligible of { excluded_count : int }
+  | Claim_next_no_eligible of
+      { excluded_count : int
+      ; blocked_count : int
+      ; verification_blocked_count : int
+      ; scope_excluded_count : int
+      ; required_tool_excluded_count : int
+      ; explicit_excluded_count : int
+      ; claim_pool_candidate_count : int
+      ; receipt_required_tool_blocked : bool
+      ; agent_tool_names_known : bool
+      }
   | Claim_next_error of string

--- a/lib/types/types_core.mli
+++ b/lib/types/types_core.mli
@@ -327,5 +327,15 @@ type claim_next_result =
       ; message : string
       }
   | Claim_next_no_unclaimed
-  | Claim_next_no_eligible of { excluded_count : int }
+  | Claim_next_no_eligible of
+      { excluded_count : int
+      ; blocked_count : int
+      ; verification_blocked_count : int
+      ; scope_excluded_count : int
+      ; required_tool_excluded_count : int
+      ; explicit_excluded_count : int
+      ; claim_pool_candidate_count : int
+      ; receipt_required_tool_blocked : bool
+      ; agent_tool_names_known : bool
+      }
   | Claim_next_error of string

--- a/test/test_claim_post_provision_hook.ml
+++ b/test/test_claim_post_provision_hook.ml
@@ -89,7 +89,7 @@ let test_claim_next_hook_failure_is_observed () =
       (failure_metric_value ~site:"claim_next" ~agent_name:"claude")
   | Coord.Claim_next_no_unclaimed ->
     fail "claim_next unexpectedly found no unclaimed task"
-  | Coord.Claim_next_no_eligible { excluded_count } ->
+  | Coord.Claim_next_no_eligible { excluded_count; _ } ->
     failf "claim_next unexpectedly found no eligible task; excluded=%d"
       excluded_count
   | Coord.Claim_next_error msg ->

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -744,7 +744,7 @@ let test_claim_next_preserves_existing_alias_owned_task () =
          (contains_substring message "already holds")
      | Coord.Claim_next_no_unclaimed ->
        fail "expected existing claim, got no_unclaimed"
-     | Coord.Claim_next_no_eligible { excluded_count } ->
+     | Coord.Claim_next_no_eligible { excluded_count; _ } ->
        fail
          (Printf.sprintf
             "expected existing claim, got no_eligible excluded=%d"
@@ -1244,8 +1244,25 @@ let test_claim_does_not_cross_goal_when_scoped_task_requires_missing_tool () =
     let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
     let json = parse_json result in
     let message = Yojson.Safe.Util.(json |> member "result" |> to_string) in
+    let claim_scope = Yojson.Safe.Util.(json |> member "claim_scope") in
     check_no_task_claimed config meta;
     check_active_goal_scope_no_fallback json ~goal_id:scoped_goal.id;
+    check
+      int
+      "verification blocker count"
+      0
+      Yojson.Safe.Util.(claim_scope |> member "verification_blocked_count" |> to_int);
+    check
+      int
+      "required tool blocker count"
+      1
+      Yojson.Safe.Util.(
+        claim_scope |> member "required_tool_excluded_count" |> to_int);
+    check
+      int
+      "scope blocker count"
+      1
+      Yojson.Safe.Util.(claim_scope |> member "scope_excluded_count" |> to_int);
     check
       bool
       "message keeps active scope"
@@ -1333,8 +1350,25 @@ let test_claim_does_not_cross_goal_when_all_scoped_tasks_unavailable () =
     let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
     let json = parse_json result in
     let message = Yojson.Safe.Util.(json |> member "result" |> to_string) in
+    let claim_scope = Yojson.Safe.Util.(json |> member "claim_scope") in
     check_no_task_claimed config meta;
     check_active_goal_scope_no_fallback json ~goal_id:scoped_goal.id;
+    check
+      int
+      "verification blocker count"
+      1
+      Yojson.Safe.Util.(claim_scope |> member "verification_blocked_count" |> to_int);
+    check
+      int
+      "scope blocker count"
+      1
+      Yojson.Safe.Util.(claim_scope |> member "scope_excluded_count" |> to_int);
+    check
+      int
+      "required tool blocker count"
+      0
+      Yojson.Safe.Util.(
+        claim_scope |> member "required_tool_excluded_count" |> to_int);
     check
       bool
       "message keeps active scope"
@@ -1433,8 +1467,25 @@ let test_claim_no_eligible_scoped_reports_scope_truth () =
     let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
     let json = parse_json result in
     let message = Yojson.Safe.Util.(json |> member "result" |> to_string) in
+    let claim_scope = Yojson.Safe.Util.(json |> member "claim_scope") in
     check_no_task_claimed config meta;
     check_active_goal_scope_no_fallback json ~goal_id:scoped_goal.id;
+    check
+      int
+      "scope blocker count"
+      1
+      Yojson.Safe.Util.(claim_scope |> member "scope_excluded_count" |> to_int);
+    check
+      int
+      "required tool blocker count"
+      1
+      Yojson.Safe.Util.(
+        claim_scope |> member "required_tool_excluded_count" |> to_int);
+    check
+      bool
+      "required tool known surface"
+      true
+      Yojson.Safe.Util.(claim_scope |> member "agent_tool_names_known" |> to_bool);
     check
       bool
       "message avoids fallback search"

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1535,6 +1535,12 @@ let () =
     in
     assert result.Tool_result.success;
     assert (str_contains result.Tool_result.legacy_message "No eligible tasks available");
+    let open Yojson.Safe.Util in
+    assert (result.Tool_result.data |> member "diagnostics"
+            |> member "required_tool_excluded_count" |> to_int
+            = 1);
+    assert (result.Tool_result.data |> member "diagnostics"
+            |> member "agent_tool_names_known" |> to_bool);
     assert_task_todo ctx;
     assert (Planning_eio.get_current_task ctx.config = None))
 


### PR DESCRIPTION
Fresh re-author of the no-eligible diagnostics slice from current origin/main. Replaces stale closed PR #17166 without carrying later CI-repair churn. Implements structured Claim_next_no_eligible counts for scope/tool/verification blockers and exposes diagnostics through keeper_task_claim and the direct task claim-next tool while preserving the legacy no-eligible text prefix. Validation: PASS ocamlformat --check on touched files; PASS bash scripts/lint-spawn-bounded.sh; PASS bash scripts/ci/check-ignore-without-comment-diff.sh --base origin/main --head HEAD; PASS git diff --check origin/main HEAD. Blocked: scripts/ocaml-structure-ratchet.sh currently fails on baseline missing .mli counts, while this diff adds no files; scripts/dune-local.sh focused build refused with code 75 because a bare Dune process is running outside the wrapper.