### PR TITLE
fix(verification): expire legacy pending requests

### DIFF
--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -358,6 +358,27 @@ let on_reject_verification ~(config : Coord.config)
     notify_reject_verification ~task_id ~verifier ~verification_id ~reason;
     Ok ()
 
+let awaiting_verification_deadline
+      ~(submitted_at : string)
+      ~(deadline : string option)
+  =
+  match deadline with
+  | Some deadline ->
+    (match Masc_domain.parse_iso8601_opt deadline with
+     | Some deadline_ts -> Some ("deadline", deadline, deadline_ts)
+     | None -> None)
+  | None ->
+    (match Masc_domain.parse_iso8601_opt submitted_at with
+     | Some submitted_ts ->
+       let deadline_ts =
+         submitted_ts +. Env_config_runtime.Verification.timeout_deadline_seconds ()
+       in
+       Some
+         ( "submitted_at_fallback"
+         , Masc_domain.iso8601_of_unix_seconds deadline_ts
+         , deadline_ts )
+     | None -> None)
+
 let check_timeouts ~(config : Coord.config) =
   if not (Env_config_runtime.Verification.fsm_enabled ()) then ()
   else
@@ -366,15 +387,22 @@ let check_timeouts ~(config : Coord.config) =
       let now = Time_compat.now () in
       List.iter (fun (task : Masc_domain.task) ->
         match task.task_status with
-        | Masc_domain.AwaitingVerification { assignee; verification_id; deadline = Some dl; _ } ->
-          (match Masc_domain.parse_iso8601_opt dl with
-           | Some deadline_ts when now > deadline_ts ->
+        | Masc_domain.AwaitingVerification
+            { assignee; verification_id; submitted_at; deadline } ->
+          (match awaiting_verification_deadline ~submitted_at ~deadline with
+           | Some (deadline_source, dl, deadline_ts)
+             when now > deadline_ts ->
+             let deadline_note =
+               match deadline_source with
+               | "deadline" -> dl
+               | _ -> Printf.sprintf "%s (derived from submitted_at)" dl
+             in
              let () =
                match Board_dispatch.create_post
                  ~author:"system"
                  ~content:(Printf.sprintf
                    "Verification timeout: task %s (%s) by %s — no verifier responded within deadline %s"
-                   task.id task.title assignee dl)
+                   task.id task.title assignee deadline_note)
                  ~title:(Printf.sprintf "Timeout: %s" task.title)
                  ~post_kind:Board.System_post
                  ~meta_json:(`Assoc [
@@ -382,7 +410,9 @@ let check_timeouts ~(config : Coord.config) =
                    ("task_id", `String task.id);
                    ("verification_id", `String verification_id);
                    ("assignee", `String assignee);
+                   ("submitted_at", `String submitted_at);
                    ("deadline", `String dl);
+                   ("deadline_source", `String deadline_source);
                  ])
                  ~visibility:Board.Internal
                  ~hearth:"verification"
@@ -399,6 +429,8 @@ let check_timeouts ~(config : Coord.config) =
                ("task_id", `String task.id);
                ("verification_id", `String verification_id);
                ("assignee", `String assignee);
+               ("deadline", `String dl);
+               ("deadline_source", `String deadline_source);
                ("timestamp", `Float now);
              ]);
              (* Transition the task out of AwaitingVerification so the next
@@ -407,8 +439,8 @@ let check_timeouts ~(config : Coord.config) =
                 cycle re-creates the same board entry. *)
              let cancel_reason =
                Printf.sprintf
-                 "verification deadline exceeded (assignee=%s, vrf=%s, deadline=%s)"
-                 assignee verification_id dl
+                 "verification deadline exceeded (assignee=%s, vrf=%s, deadline=%s, source=%s)"
+                 assignee verification_id dl deadline_source
              in
              (match
                 Coord.force_cancel_task_r
@@ -426,10 +458,11 @@ let check_timeouts ~(config : Coord.config) =
                   (Masc_domain.show_masc_error e))
            | Some _ -> ()
            | None -> ())
-        | Todo | Claimed _ | InProgress _ | AwaitingVerification { deadline = None; _ } | Done _ | Cancelled _ -> ()
+        | Todo | Claimed _ | InProgress _ | Done _ | Cancelled _ -> ()
       ) backlog.tasks
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->
       Log.Task.error "verification timeout check failed: %s"
         (Printexc.to_string exn)
+;;

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -980,6 +980,31 @@ let force_deadline_past config task_id =
   in
   Coord.write_backlog config { backlog with tasks = new_tasks }
 
+let force_missing_deadline_submitted_at_past config task_id =
+  let backlog = Coord.read_backlog config in
+  let timeout = Env_config_runtime.Verification.timeout_deadline_seconds () in
+  let submitted_at =
+    Masc_domain.iso8601_of_unix_seconds
+      (Time_compat.now () -. timeout -. 3600.0)
+  in
+  let new_tasks =
+    List.map
+      (fun (t : Masc_domain.task) ->
+         if t.id <> task_id
+         then t
+         else
+           match t.task_status with
+           | Masc_domain.AwaitingVerification fields ->
+             { t with
+               task_status =
+                 Masc_domain.AwaitingVerification
+                   { fields with submitted_at; deadline = None }
+             }
+           | _ -> t)
+      backlog.tasks
+  in
+  Coord.write_backlog config { backlog with tasks = new_tasks }
+
 let test_check_timeouts_transitions_awaiting_to_cancelled () =
   with_temp_config ~fsm_enabled:true (fun config ->
     let task_id = add_strict_task config in
@@ -1001,6 +1026,33 @@ let test_check_timeouts_transitions_awaiting_to_cancelled () =
       Alcotest.(check bool)
         "reason mentions verification deadline" true
         (Astring.String.is_infix ~affix:"verification deadline" reason_str)
+    | _ -> Alcotest.fail "task is not Cancelled after check_timeouts")
+
+let test_check_timeouts_transitions_legacy_missing_deadline () =
+  with_temp_config ~fsm_enabled:true (fun config ->
+    let task_id = add_strict_task config in
+    claim_and_start config "worker" task_id;
+    (match
+       Coord.transition_task_r
+         config
+         ~agent_name:"worker"
+         ~task_id
+         ~action:Masc_domain.Submit_for_verification
+         ()
+     with
+     | Error e -> Alcotest.fail ("submit failed: " ^ Masc_domain.show_masc_error e)
+     | Ok _ -> ());
+    force_missing_deadline_submitted_at_past config task_id;
+    Verification_protocol.check_timeouts ~config;
+    Alcotest.(check string) "post-check status" "cancelled"
+      (status_string config task_id);
+    match get_task config task_id with
+    | Some { task_status = Masc_domain.Cancelled { reason; _ }; _ } ->
+      let reason_str = Option.value reason ~default:"" in
+      Alcotest.(check bool)
+        "reason records fallback source"
+        true
+        (Astring.String.is_infix ~affix:"source=submitted_at_fallback" reason_str)
     | _ -> Alcotest.fail "task is not Cancelled after check_timeouts")
 
 let test_check_timeouts_idempotent_after_cancel () =
@@ -1086,6 +1138,10 @@ let () =
     ("timeout_check", [
       Alcotest.test_case "check_timeouts transitions AwaitingVerification to Cancelled"
         `Quick test_check_timeouts_transitions_awaiting_to_cancelled;
+      Alcotest.test_case
+        "check_timeouts expires legacy AwaitingVerification without deadline"
+        `Quick
+        test_check_timeouts_transitions_legacy_missing_deadline;
       Alcotest.test_case "check_timeouts is idempotent after cancellation"
         `Quick test_check_timeouts_idempotent_after_cancel;
     ]);


### PR DESCRIPTION
Fresh re-author of the pending-verification drain slice from current origin/main. Replaces stale closed PR #17175 without carrying later CI-repair churn.\n\nBehavior:\n- Derive a fallback timeout deadline for legacy AwaitingVerification rows with deadline=null from submitted_at + MASC_VERIFICATION_TIMEOUT_DEADLINE_SEC.\n- Emit timeout metadata with deadline_source before force-cancelling expired pending verification tasks.\n- Add regression coverage in test_verification_fsm.\n\nValidation:\n- PASS ocamlformat --check lib/verification_protocol.ml test/test_verification_fsm.ml\n- PASS bash scripts/lint-spawn-bounded.sh\n- PASS bash scripts/ci/check-ignore-without-comment-diff.sh --base origin/main --head HEAD\n- PASS git diff --check origin/main HEAD\n- Local focused Dune was not run: scripts/dune-local.sh build test/test_verification_fsm.exe waited behind an existing wrapper-held machine-wide Dune lock for >30s, so I stopped my waiting process and left type/test authority to PR CI.\n\nKnown base-health dependency:\n- Current origin/main health debt is being repaired in #17210. #17210 now has OCaml Structure Ratchet passing after 4af380c591, with long Health/Build/Lint jobs still pending at PR creation time.