### PR TITLE
fix(board): compute SLO metrics from JSONL

### DIFF
--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -218,6 +218,16 @@ jobs:
       - name: Run lint
         run: bash scripts/lint/yaml-syntax.sh
 
+  board-slo-extractor-fixture:
+    name: Board SLO extractor fixture
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install jq
+        run: sudo apt-get install -y -qq jq
+      - name: Run fixture test
+        run: bash scripts/test-board-slo-extractor.sh
+
   env-knob-classification:
     name: Env knob classification
     runs-on: ubuntu-latest

--- a/scripts/board-slo-extractor.sh
+++ b/scripts/board-slo-extractor.sh
@@ -34,6 +34,7 @@ readonly TASKS_FILE="$MASC_DIR/tasks/backlog.json"
 readonly POSTS_FILE="$MASC_DIR/board_posts.jsonl"
 readonly COMMENTS_FILE="$MASC_DIR/board_comments.jsonl"
 readonly TOOL_CALLS_DIR="$MASC_DIR/tool_calls"
+readonly DOCKER_PLAYGROUND_DIR="$MASC_DIR/playground/docker"
 readonly TODAY="$(date -u +%Y-%m-%d)"
 readonly LOG_TODAY="$LOGS_DIR/system_log_${TODAY}.jsonl"
 
@@ -222,6 +223,66 @@ m_docker_false_positive_24h() {
   jq -s '[.[] | select(((.event // "") + " " + (.message // "")) | contains("sandbox_image_missing"))] | length' "$LOG_TODAY"
 }
 
+m_live_defect_signatures() {
+  [[ -f "$LOG_TODAY" ]] || {
+    jq -n '{
+      project_snapshot_timeout: 0,
+      process_eio_1s_timeout: 0,
+      process_eio_5s_timeout: 0,
+      sandbox_image_missing: 0,
+      host_fd_hotspot_budget_exhausted: 0,
+      docker_worktree_gitdir_prepared: 0,
+      docker_worktree_gitdir_restored: 0
+    }'
+    return
+  }
+  jq -s '
+    def msg: (.message // "");
+    {
+      project_snapshot_timeout:
+        ([.[] | select(msg | contains("project-snapshot async shell refresh timed out"))] | length),
+      process_eio_1s_timeout:
+        ([.[] | select(msg | test("\\[Process_eio\\] Timeout after 1s"))] | length),
+      process_eio_5s_timeout:
+        ([.[] | select(msg | test("\\[Process_eio\\] Timeout after 5s"))] | length),
+      sandbox_image_missing:
+        ([.[] | select(((.event // "") + " " + msg) | contains("sandbox_image_missing"))] | length),
+      host_fd_hotspot_budget_exhausted:
+        ([.[] | select(msg | contains("host_fd_hotspot_budget_exhausted"))] | length),
+      docker_worktree_gitdir_prepared:
+        ([.[] | select(msg | contains("docker worktree gitdir path") and contains("prepared"))] | length),
+      docker_worktree_gitdir_restored:
+        ([.[] | select(msg | contains("docker worktree gitdir path") and contains("restored"))] | length)
+    }' "$LOG_TODAY"
+}
+
+m_docker_playground_worktrees() {
+  local worktrees_dirs=0
+  local worktree_entries=0
+  if [[ -d "$DOCKER_PLAYGROUND_DIR" ]]; then
+    local keeper_dir repos_dir repo_dir worktrees_dir wt_path
+    for keeper_dir in "$DOCKER_PLAYGROUND_DIR"/*; do
+      [[ -d "$keeper_dir" ]] || continue
+      repos_dir="$keeper_dir/repos"
+      [[ -d "$repos_dir" ]] || continue
+      for repo_dir in "$repos_dir"/*; do
+        [[ -d "$repo_dir" ]] || continue
+        worktrees_dir="$repo_dir/.worktrees"
+        [[ -d "$worktrees_dir" ]] || continue
+        worktrees_dirs=$((worktrees_dirs + 1))
+        for wt_path in "$worktrees_dir"/*; do
+          [[ -d "$wt_path" ]] || continue
+          worktree_entries=$((worktree_entries + 1))
+        done
+      done
+    done
+  fi
+  jq -n \
+    --argjson worktrees_dirs "$worktrees_dirs" \
+    --argjson worktree_entries "$worktree_entries" \
+    '{worktrees_dirs: $worktrees_dirs, worktree_entries: $worktree_entries}'
+}
+
 epoch_ms() {
   python3 -c 'import time; print(int(time.time()*1000))'
 }
@@ -270,6 +331,8 @@ emit_json() {
     --arg bash_failure_pct "$(m_bash_failure_pct)" \
     --arg cascade_audit_failure_pct "$(m_cascade_audit_failure_pct)" \
     --argjson docker_false_positive_24h "$(m_docker_false_positive_24h)" \
+    --argjson live_defect_signatures "$(m_live_defect_signatures)" \
+    --argjson docker_playground_worktrees "$(m_docker_playground_worktrees)" \
     --argjson dashboard_proof "$(m_dashboard_proof_endpoints)" \
     --arg live_defect_open "$(m_live_defect_issues)" \
     '{
@@ -289,6 +352,8 @@ emit_json() {
          bash_failure_pct: ($bash_failure_pct | tonumber? // null),
          cascade_audit_failure_pct: ($cascade_audit_failure_pct | tonumber? // null),
          docker_false_positive_24h: $docker_false_positive_24h,
+         live_defect_signatures: $live_defect_signatures,
+         docker_playground_worktrees: $docker_playground_worktrees,
          dashboard_proof: $dashboard_proof,
          live_defect_open: ($live_defect_open | tonumber? // null)
        }

--- a/scripts/board-slo-extractor.sh
+++ b/scripts/board-slo-extractor.sh
@@ -33,6 +33,7 @@ readonly LOGS_DIR="$MASC_DIR/logs"
 readonly TASKS_FILE="$MASC_DIR/tasks/backlog.json"
 readonly POSTS_FILE="$MASC_DIR/board_posts.jsonl"
 readonly COMMENTS_FILE="$MASC_DIR/board_comments.jsonl"
+readonly TOOL_CALLS_DIR="$MASC_DIR/tool_calls"
 readonly TODAY="$(date -u +%Y-%m-%d)"
 readonly LOG_TODAY="$LOGS_DIR/system_log_${TODAY}.jsonl"
 
@@ -40,7 +41,6 @@ WINDOW_HOURS=24
 OUTPUT_MODE=json
 DASHBOARD_HOST="http://127.0.0.1:8935"
 OFFLINE_MODE=0
-ANALYZER_TIMEOUT_SEC="${MASC_BOARD_SLO_ANALYZER_TIMEOUT_SEC:-8}"
 DASHBOARD_TIMEOUT_SEC="${MASC_BOARD_SLO_DASHBOARD_TIMEOUT_SEC:-5}"
 
 while [[ $# -gt 0 ]]; do
@@ -59,6 +59,41 @@ done
 readonly WINDOW_SEC=$(( WINDOW_HOURS * 3600 ))
 
 # --- metric primitives --------------------------------------------------------
+
+date_path_days_ago() {
+  local days_ago="$1"
+  date -u -v-"${days_ago}"d +%Y-%m/%d 2>/dev/null \
+    || date -u -d "-${days_ago} days" +%Y-%m/%d 2>/dev/null
+}
+
+date_ymd_days_ago() {
+  local days_ago="$1"
+  date -u -v-"${days_ago}"d +%Y-%m-%d 2>/dev/null \
+    || date -u -d "-${days_ago} days" +%Y-%m-%d 2>/dev/null
+}
+
+recent_dated_jsonl_files() {
+  local dir="$1"
+  local days=$(( (WINDOW_HOURS + 23) / 24 ))
+  local i rel file
+  for i in $(seq 0 "$days"); do
+    rel="$(date_path_days_ago "$i" || true)"
+    [[ -n "$rel" ]] || continue
+    file="$dir/$rel.jsonl"
+    [[ -f "$file" ]] && printf '%s\n' "$file"
+  done
+}
+
+recent_system_log_files() {
+  local days=$(( (WINDOW_HOURS + 23) / 24 ))
+  local i ymd file
+  for i in $(seq 0 "$days"); do
+    ymd="$(date_ymd_days_ago "$i" || true)"
+    [[ -n "$ymd" ]] || continue
+    file="$LOGS_DIR/system_log_${ymd}.jsonl"
+    [[ -f "$file" ]] && printf '%s\n' "$file"
+  done
+}
 
 m_open_backlog() {
   [[ -f "$TASKS_FILE" ]] || { echo "0"; return; }
@@ -99,81 +134,92 @@ m_high_churn_threads_48h() {
 
 m_warn_error_window() {
   [[ -f "$LOG_TODAY" ]] || { echo "0"; return; }
-  # level filter — accept WARN / ERROR / WARNING uppercase.
-  rg --count -e '"level":"(WARN|ERROR|WARNING)"' "$LOG_TODAY" || true
-}
-
-run_with_timeout() {
-  local timeout_sec="$1"
-  shift
-  local tmp
-  tmp="$(mktemp "${TMPDIR:-/tmp}/board-slo-extractor.XXXXXX")"
-  "$@" >"$tmp" 2>/dev/null &
-  local pid=$!
-  local elapsed=0
-  while kill -0 "$pid" 2>/dev/null; do
-    if [[ "$elapsed" -ge "$timeout_sec" ]]; then
-      kill "$pid" 2>/dev/null || true
-      wait "$pid" 2>/dev/null || true
-      rm -f "$tmp"
-      return 124
-    fi
-    sleep 1
-    elapsed=$((elapsed + 1))
-  done
-  local status=0
-  wait "$pid" || status=$?
-  cat "$tmp"
-  rm -f "$tmp"
-  return "$status"
+  jq -s '[.[] | select((.level // "") | test("^(WARN|ERROR|WARNING)$"))] | length' "$LOG_TODAY"
 }
 
 m_tool_call_success_pct() {
-  [[ "$OFFLINE_MODE" -eq 0 ]] || { echo "null"; return; }
-  # WORKAROUND: analyze-tool-call-quality.sh has no --json mode yet.
-  # 근본 해결: 별도 PR로 두 analyze-* scripts에 --json 추가 후 단일 contract 호출로 교체.
-  local script="$REPO_ROOT/scripts/analyze-tool-call-quality.sh"
-  [[ -x "$script" ]] || { echo "null"; return; }
-  local out failures total
-  out="$(run_with_timeout "$ANALYZER_TIMEOUT_SEC" "$script" "$BASE_PATH" "$WINDOW_HOURS" || true)"
-  failures="$(printf '%s\n' "$out" | rg -o '([0-9]+) failures' -r '$1' | head -1)"
-  total="$(printf '%s\n' "$out" \
-    | rg -o '[0-9]+ calls' -r '' \
-    | rg -o '[0-9]+' \
-    | awk 'BEGIN{s=0}{s+=$1}END{print s}')"
-  [[ -z "$failures" || -z "$total" || "$total" == "0" ]] && { echo "null"; return; }
-  awk -v f="$failures" -v t="$total" 'BEGIN { printf "%.2f", ((t - f) * 100.0) / t }'
+  [[ -d "$TOOL_CALLS_DIR" ]] || { echo "null"; return; }
+  local files=()
+  local file
+  while IFS= read -r file; do
+    files+=("$file")
+  done < <(recent_dated_jsonl_files "$TOOL_CALLS_DIR")
+  [[ "${#files[@]}" -gt 0 ]] || { echo "null"; return; }
+  jq -s --argjson cutoff "$(( $(date +%s) - WINDOW_SEC ))" '
+    def ts_epoch:
+      if (.ts | type) == "number" then .ts
+      elif (.ts | type) == "string" then (.ts | fromdateiso8601? // 0)
+      else 0 end;
+    [ .[] | select(ts_epoch >= $cutoff) ] as $rows
+    | ($rows | length) as $total
+    | if $total == 0 then empty
+      else
+        ([ $rows[]
+           | select(.success == true
+                    and ((if has("semantic_success") then .semantic_success else true end) != false))
+         ] | length) as $ok
+        | (($ok * 10000 / $total | floor) / 100)
+      end
+  ' "${files[@]}" 2>/dev/null || echo "null"
 }
 
 m_bash_failure_pct() {
-  [[ "$OFFLINE_MODE" -eq 0 ]] || { echo "null"; return; }
-  local script="$REPO_ROOT/scripts/analyze-keeper-bash-failures.sh"
-  [[ -x "$script" ]] || { echo "null"; return; }
-  local out
-  out="$(run_with_timeout "$ANALYZER_TIMEOUT_SEC" "$script" "$BASE_PATH" "$WINDOW_HOURS" || true)"
-  printf '%s\n' "$out" | rg -o '[Ff]ailure[^0-9]*([0-9]+\.[0-9]+)' -r '$1' | head -1 || echo "null"
+  [[ -d "$TOOL_CALLS_DIR" ]] || { echo "null"; return; }
+  local files=()
+  local file
+  while IFS= read -r file; do
+    files+=("$file")
+  done < <(recent_dated_jsonl_files "$TOOL_CALLS_DIR")
+  [[ "${#files[@]}" -gt 0 ]] || { echo "null"; return; }
+  jq -s --argjson cutoff "$(( $(date +%s) - WINDOW_SEC ))" '
+    def ts_epoch:
+      if (.ts | type) == "number" then .ts
+      elif (.ts | type) == "string" then (.ts | fromdateiso8601? // 0)
+      else 0 end;
+    def semantic_failed:
+      has("semantic_success") and .semantic_success == false;
+    [ .[] | select(ts_epoch >= $cutoff and .tool == "Bash") ] as $rows
+    | ($rows | length) as $total
+    | if $total == 0 then empty
+      else
+        ([ $rows[] | select(.success == false or semantic_failed) ] | length) as $fail
+        | (($fail * 10000 / $total | floor) / 100)
+      end
+  ' "${files[@]}" 2>/dev/null || echo "null"
 }
 
 m_cascade_audit_failure_pct() {
-  # Approximation: cascade_exhausted / cascade_attempt over window log.
-  [[ -f "$LOG_TODAY" ]] || { echo "null"; return; }
-  local exh att denom
-  exh=$(rg --count 'cascade_exhausted' "$LOG_TODAY" 2>/dev/null || echo 0)
-  att=$(rg --count 'cascade_attempt' "$LOG_TODAY" 2>/dev/null || echo 0)
-  denom="$att"
-  if [[ "$exh" -gt "$denom" ]]; then
-    # Some producers emit terminal exhaustion without a same-file attempt row.
-    # Keep the SLO percentage bounded while preserving the hard breach signal.
-    denom="$exh"
+  [[ -d "$LOGS_DIR" ]] || { echo "null"; return; }
+  local files=()
+  local file
+  while IFS= read -r file; do
+    files+=("$file")
+  done < <(recent_system_log_files)
+  if [[ "${#files[@]}" -eq 0 && -f "$LOG_TODAY" ]]; then
+    files=("$LOG_TODAY")
   fi
-  if [[ "$denom" -eq 0 ]]; then echo "null"; return; fi
-  awk -v e="$exh" -v d="$denom" 'BEGIN { printf "%.2f", (e * 100.0) / d }'
+  [[ "${#files[@]}" -gt 0 ]] || { echo "null"; return; }
+  jq -s --argjson cutoff "$(( $(date +%s) - WINDOW_SEC ))" '
+    def ts_epoch:
+      if (.ts | type) == "number" then .ts
+      elif (.ts | type) == "string" then (.ts | fromdateiso8601? // 0)
+      else 0 end;
+    [ .[]
+      | select(ts_epoch >= $cutoff)
+      | select((.details.event // .event // "") == "cascade_attempt_terminal")
+    ] as $rows
+    | ($rows | length) as $total
+    | if $total == 0 then empty
+      else
+        ([ $rows[] | select((.details.outcome // .outcome // "") == "failure") ] | length) as $fail
+        | (($fail * 10000 / $total | floor) / 100)
+      end
+  ' "${files[@]}" 2>/dev/null || echo "null"
 }
 
 m_docker_false_positive_24h() {
   [[ -f "$LOG_TODAY" ]] || { echo "0"; return; }
-  # sandbox_image_missing count from today's log.
-  rg --count 'sandbox_image_missing' "$LOG_TODAY" 2>/dev/null || echo 0
+  jq -s '[.[] | select(((.event // "") + " " + (.message // "")) | contains("sandbox_image_missing"))] | length' "$LOG_TODAY"
 }
 
 epoch_ms() {
@@ -188,7 +234,8 @@ m_dashboard_proof_endpoints() {
   for ep in "${endpoints[@]}"; do
     local code start end ms
     start=$(epoch_ms)
-    code=$(curl -sS --max-time "$DASHBOARD_TIMEOUT_SEC" -o /dev/null -w '%{http_code}' "$DASHBOARD_HOST$ep" 2>/dev/null || echo "000")
+    code="$(curl -sS --max-time "$DASHBOARD_TIMEOUT_SEC" -o /dev/null -w '%{http_code}' "$DASHBOARD_HOST$ep" 2>/dev/null || true)"
+    [[ -n "$code" ]] || code="000"
     end=$(epoch_ms)
     ms=$(( end - start ))
     [[ $first -eq 1 ]] && first=0 || out+=","

--- a/scripts/test-board-slo-extractor.sh
+++ b/scripts/test-board-slo-extractor.sh
@@ -13,6 +13,9 @@ mkdir -p "$masc_dir/tasks" "$masc_dir/logs"
 now="$(date +%s)"
 old=$((now - 200000))
 today="$(date -u +%Y-%m-%d)"
+tool_month="$(date -u +%Y-%m)"
+tool_day="$(date -u +%d)"
+mkdir -p "$masc_dir/tool_calls/$tool_month"
 
 cat >"$masc_dir/tasks/backlog.json" <<JSON
 {
@@ -41,11 +44,19 @@ done
 printf '{"id":"comment-old","post_id":"old","created_at":%s}\n' "$old" >>"$masc_dir/board_comments.jsonl"
 
 cat >"$masc_dir/logs/system_log_${today}.jsonl" <<JSONL
-{"level":"WARN","event":"cascade_attempt"}
-{"level":"ERROR","event":"cascade_attempt sandbox_image_missing"}
-{"level":"WARNING","event":"cascade_exhausted"}
-{"level":"INFO","event":"cascade_attempt"}
-{"level":"INFO","event":"cascade_attempt"}
+{"ts":$now,"level":"WARN","details":{"event":"cascade_attempt_terminal","outcome":"success"}}
+{"ts":$now,"level":"ERROR","event":"sandbox_image_missing","details":{"event":"cascade_attempt_terminal","outcome":"failure"}}
+{"ts":$now,"level":"WARNING","details":{"event":"cascade_attempt_terminal","outcome":"success"}}
+{"ts":$now,"level":"INFO","details":{"event":"cascade_attempt_terminal","outcome":"success"}}
+{"ts":$old,"level":"INFO","details":{"event":"cascade_attempt_terminal","outcome":"failure"}}
+JSONL
+
+cat >"$masc_dir/tool_calls/$tool_month/$tool_day.jsonl" <<JSONL
+{"ts":$now,"tool":"keeper_board_post","success":true,"semantic_success":true,"duration_ms":10}
+{"ts":$now,"tool":"keeper_board_comment","success":true,"duration_ms":20}
+{"ts":$now,"tool":"Bash","success":true,"semantic_success":false,"duration_ms":30}
+{"ts":$now,"tool":"Bash","success":false,"semantic_success":false,"duration_ms":40}
+{"ts":$old,"tool":"Bash","success":true,"semantic_success":true,"duration_ms":50}
 JSONL
 
 json="$(MASC_BASE_PATH="$fixture" "$REPO_ROOT/scripts/board-slo-extractor.sh" --json --offline)"
@@ -63,6 +74,8 @@ check '.metrics.posts_window == 2'
 check '.metrics.comments_window == 20'
 check '.metrics.high_churn_threads_48h == 1'
 check '.metrics.warn_error_window == 3'
+check '.metrics.tool_call_success_pct == 50'
+check '.metrics.bash_failure_pct == 100'
 check '.metrics.cascade_audit_failure_pct == 25'
 check '.metrics.docker_false_positive_24h == 1'
 check '.metrics.dashboard_proof == {}'

--- a/scripts/test-board-slo-extractor.sh
+++ b/scripts/test-board-slo-extractor.sh
@@ -48,8 +48,18 @@ cat >"$masc_dir/logs/system_log_${today}.jsonl" <<JSONL
 {"ts":$now,"level":"ERROR","event":"sandbox_image_missing","details":{"event":"cascade_attempt_terminal","outcome":"failure"}}
 {"ts":$now,"level":"WARNING","details":{"event":"cascade_attempt_terminal","outcome":"success"}}
 {"ts":$now,"level":"INFO","details":{"event":"cascade_attempt_terminal","outcome":"success"}}
+{"ts":$now,"level":"WARN","message":"project-snapshot async shell refresh timed out (5.0s)"}
+{"ts":$now,"level":"WARN","message":"[Process_eio] Timeout after 1s: '/bin/bash' '-lc' 'git status -sb 2>&1'"}
+{"ts":$now,"level":"WARN","message":"[Process_eio] Timeout after 5s (command): '/bin/bash' '-lc' 'scripts/dune-local.sh build test/test_operator_control.exe 2>&1'"}
+{"ts":$now,"level":"INFO","message":"verifier: prepared 60 docker worktree gitdir path(s) under /fixture/.masc/playground/docker/verifier"}
+{"ts":$now,"level":"INFO","message":"verifier: restored 60 docker worktree gitdir path(s) under /fixture/.masc/playground/docker/verifier"}
+{"ts":$now,"level":"ERROR","message":"docker_shell_failed: fd_pressure: host_fd_hotspot_budget_exhausted"}
 {"ts":$old,"level":"INFO","details":{"event":"cascade_attempt_terminal","outcome":"failure"}}
 JSONL
+
+mkdir -p \
+  "$masc_dir/playground/docker/verifier/repos/masc-mcp/.worktrees/task-a" \
+  "$masc_dir/playground/docker/verifier/repos/masc-mcp/.worktrees/task-b"
 
 cat >"$masc_dir/tool_calls/$tool_month/$tool_day.jsonl" <<JSONL
 {"ts":$now,"tool":"keeper_board_post","success":true,"semantic_success":true,"duration_ms":10}
@@ -73,11 +83,20 @@ check '.metrics.pending_verification_gt_48h == 1'
 check '.metrics.posts_window == 2'
 check '.metrics.comments_window == 20'
 check '.metrics.high_churn_threads_48h == 1'
-check '.metrics.warn_error_window == 3'
+check '.metrics.warn_error_window == 7'
 check '.metrics.tool_call_success_pct == 50'
 check '.metrics.bash_failure_pct == 100'
 check '.metrics.cascade_audit_failure_pct == 25'
 check '.metrics.docker_false_positive_24h == 1'
+check '.metrics.live_defect_signatures.project_snapshot_timeout == 1'
+check '.metrics.live_defect_signatures.process_eio_1s_timeout == 1'
+check '.metrics.live_defect_signatures.process_eio_5s_timeout == 1'
+check '.metrics.live_defect_signatures.sandbox_image_missing == 1'
+check '.metrics.live_defect_signatures.host_fd_hotspot_budget_exhausted == 1'
+check '.metrics.live_defect_signatures.docker_worktree_gitdir_prepared == 1'
+check '.metrics.live_defect_signatures.docker_worktree_gitdir_restored == 1'
+check '.metrics.docker_playground_worktrees.worktrees_dirs == 1'
+check '.metrics.docker_playground_worktrees.worktree_entries == 2'
 check '.metrics.dashboard_proof == {}'
 check '.metrics.live_defect_open == null'
 


### PR DESCRIPTION
Summary:
- compute tool_call_success_pct and bash_failure_pct directly from .masc/tool_calls JSONL
- compute cascade_audit_failure_pct from structured cascade_attempt_terminal rows
- normalize dashboard timeout HTTP code to 000 and add CI fixture coverage

Local checks:
- bash scripts/test-board-slo-extractor.sh
- bash scripts/lint/yaml-syntax.sh
- bash -n scripts/board-slo-extractor.sh scripts/test-board-slo-extractor.sh
- git diff --check

Live evidence:
- MASC_BASE_PATH=/Users/dancer/me scripts/board-slo-extractor.sh --json returned tool_call_success_pct=85.14, bash_failure_pct=19.21, cascade_audit_failure_pct=9.74, live_defect_open=3 at 2026-05-21T03:30:35Z.