### PR TITLE
fix(goal-store): preserve goals on stale writes

### DIFF
--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -407,9 +407,61 @@ let read_state config =
   else
     default_state ()
 
-let write_state config state =
+let goal_is_newer ~(candidate : goal) ~(current : goal) =
+  String.compare candidate.updated_at current.updated_at >= 0
+
+let merge_stale_write ~current ~candidate =
+  let candidate_by_id = Hashtbl.create (max 16 (List.length candidate.goals)) in
+  List.iter
+    (fun goal -> Hashtbl.replace candidate_by_id goal.id goal)
+    candidate.goals;
+  let seen = Hashtbl.create (max 16 (List.length current.goals)) in
+  let merged_existing =
+    List.map
+      (fun current_goal ->
+        Hashtbl.replace seen current_goal.id ();
+        match Hashtbl.find_opt candidate_by_id current_goal.id with
+        | Some candidate_goal when goal_is_newer ~candidate:candidate_goal ~current:current_goal ->
+            candidate_goal
+        | Some _ | None -> current_goal)
+      current.goals
+  in
+  let appended =
+    candidate.goals
+    |> List.filter (fun goal -> not (Hashtbl.mem seen goal.id))
+  in
+  {
+    version = max current.version candidate.version + 1;
+    updated_at = Masc_domain.now_iso ();
+    goals = merged_existing @ appended;
+  }
+
+let preserve_against_stale_write config state =
+  let path = goals_path config in
+  if Coord.path_exists config path then
+    match state_of_yojson (Coord.read_json config path) with
+    | Ok current when current.version > state.version ->
+        Log.Misc.warn
+          "goal_store: preserving current goals against stale write \
+           current_version=%d candidate_version=%d current_goals=%d \
+           candidate_goals=%d"
+          current.version state.version (List.length current.goals)
+          (List.length state.goals);
+        merge_stale_write ~current ~candidate:state
+    | Ok _ | Error _ -> state
+  else
+    state
+
+let write_state_unlocked config state =
   ensure_dirs config;
   Coord.write_json config (goals_path config) (state_to_yojson state)
+
+let write_state config state =
+  ensure_dirs config;
+  let path = goals_path config in
+  Coord.with_file_lock config path (fun () ->
+      let state = preserve_against_stale_write config state in
+      write_state_unlocked config state)
 
 let now_ms () =
   int_of_float (Time_compat.now () *. 1000.0)
@@ -429,7 +481,7 @@ let update_state config f =
   Coord.with_file_lock config lock_path (fun () ->
       let state = read_state config in
       let next_state = f state in
-      write_state config next_state;
+      write_state_unlocked config next_state;
       next_state)
 
 let get_goal config ~goal_id =
@@ -451,7 +503,7 @@ let update_goal config ~goal_id f =
               goals = replace_goal state.goals updated_goal;
             }
           in
-          write_state config next_state;
+          write_state_unlocked config next_state;
           Ok updated_goal)
 
 let delete_goal config ~goal_id =

--- a/lib/goal/goal_store.mli
+++ b/lib/goal/goal_store.mli
@@ -192,12 +192,14 @@ val read_state : Coord.config -> state
 
 val write_state : Coord.config -> state -> unit
 (** Atomic write of the canonical state to {!goals_path}.
-    Caller is responsible for serialising concurrent
-    writes — the internal mutators ({!update_goal},
-    {!delete_goal}, {!upsert_goal}, {!review_goal}) all
-    hold the file lock around their read-modify-write
-    block; raw users of {!write_state} (the test harness
-    only) should not race against them. *)
+    Takes the goal-store file lock.  When the on-disk state
+    has a newer [version] than the supplied state, [write_state]
+    preserves the newer on-disk goals and merges in any newer
+    or new rows from the supplied state instead of letting a
+    stale/partial writer truncate the store.  The internal
+    mutators ({!update_goal}, {!delete_goal}, {!upsert_goal},
+    {!review_goal}) perform their own locked read-modify-write
+    and are the preferred API for targeted changes. *)
 
 (** {1 Single-goal operations} *)
 

--- a/test/test_goal_store.ml
+++ b/test/test_goal_store.ml
@@ -185,6 +185,60 @@ let test_update_missing_goal_does_not_bump () =
   check int "version unchanged on missing update" before.version after.version;
   check string "updated_at unchanged on missing update" before.updated_at after.updated_at
 
+let test_stale_partial_write_preserves_existing_goals () =
+  with_room @@ fun config ->
+  let original_a =
+    {
+      (make_goal "goal-a" "original a") with
+      updated_at = "2026-05-21T00:00:00Z";
+    }
+  in
+  let original_b =
+    {
+      (make_goal "goal-b" "original b") with
+      updated_at = "2026-05-21T00:00:01Z";
+    }
+  in
+  Goal_store.write_state config
+    { version = 10; updated_at = "2026-05-21T00:00:01Z"; goals = [ original_a; original_b ] };
+  let stale_new_goal =
+    {
+      (make_goal "goal-new" "new from stale writer") with
+      updated_at = "2026-05-21T00:00:02Z";
+    }
+  in
+  Goal_store.write_state config
+    { version = 2; updated_at = "2026-05-21T00:00:02Z"; goals = [ stale_new_goal ] };
+  let after = Goal_store.read_state config in
+  let ids = after.goals |> List.map (fun goal -> goal.Goal_store.id) |> List.sort String.compare in
+  check (list string) "preserves existing and appends new goal"
+    [ "goal-a"; "goal-b"; "goal-new" ]
+    ids;
+  check bool "version advances past current" true (after.version > 10)
+
+let test_stale_partial_write_does_not_regress_newer_existing_goal () =
+  with_room @@ fun config ->
+  let current =
+    {
+      (make_goal "goal-a" "current title") with
+      updated_at = "2026-05-21T00:00:10Z";
+    }
+  in
+  Goal_store.write_state config
+    { version = 10; updated_at = "2026-05-21T00:00:10Z"; goals = [ current ] };
+  let stale =
+    {
+      (make_goal "goal-a" "stale title") with
+      updated_at = "2026-05-21T00:00:02Z";
+    }
+  in
+  Goal_store.write_state config
+    { version = 2; updated_at = "2026-05-21T00:00:02Z"; goals = [ stale ] };
+  let after = Goal_store.read_state config in
+  match after.goals with
+  | [ goal ] -> check string "keeps newer current row" "current title" goal.Goal_store.title
+  | _ -> fail "expected one preserved goal"
+
 let test_write_state_sanitizes_invalid_utf8_before_persisting () =
   with_room @@ fun config ->
   Safe_ops.reset_persistence_utf8_repair_stats_for_tests ();
@@ -233,5 +287,9 @@ let () =
             test_list_goals_filters_by_phase;
           test_case "missing update: no bump" `Quick
             test_update_missing_goal_does_not_bump;
+          test_case "stale partial write preserves existing goals" `Quick
+            test_stale_partial_write_preserves_existing_goals;
+          test_case "stale partial write keeps newer row" `Quick
+            test_stale_partial_write_does_not_regress_newer_existing_goal;
           test_case "write_state sanitizes invalid utf8" `Quick
             test_write_state_sanitizes_invalid_utf8_before_persisting ] ) ]


### PR DESCRIPTION
## Summary\n- Add stale-write protection to Goal_store.write_state so an older partial snapshot cannot truncate newer goals.json state.\n- Merge by goal id when on-disk version is newer: preserve current rows, accept newer duplicate rows, and append new rows from the stale writer.\n- Add regression tests for the single-goal truncation pattern observed in issue #17229.\n\n## Base\nStacked on #17164 (codex/liveness-observe-watchdog-match-20260521) because current main still has the build blockers fixed there.\n\n## Verification\n- git diff --check\n- ocamlformat --check lib/goal/goal_store.ml lib/goal/goal_store.mli test/test_goal_store.ml\n- bash scripts/ocaml-structure-ratchet.sh\n\nLocal focused Dune is blocked by the shared opam switch using agent_sdk 0.196.7, which requires evidence_role in unrelated records before this target finishes. GitHub CI should validate against the repo-pinned environment.\n\nFixes #17229