### PR TITLE
fix(operator): surface keeper attention in digest

### DIFF
--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -122,11 +122,14 @@ let keeper_attention_severity ~reason ~runtime_blocker_class =
 
 let keeper_attention_summary ~(meta : Keeper_types.keeper_meta) ~reason
     ~runtime_blocker_summary =
-  let reason = Option.value ~default:"attention_required" reason in
-  match runtime_blocker_summary with
-  | Some summary ->
+  match reason, runtime_blocker_summary with
+  | Some reason, Some summary ->
       Printf.sprintf "%s needs operator attention: %s (%s)" meta.name reason summary
-  | None -> Printf.sprintf "%s needs operator attention: %s" meta.name reason
+  | Some reason, None ->
+      Printf.sprintf "%s needs operator attention: %s" meta.name reason
+  | None, Some summary ->
+      Printf.sprintf "%s needs operator attention (%s)" meta.name summary
+  | None, None -> Printf.sprintf "%s needs operator attention" meta.name
 
 let keeper_attention_projection config (meta : Keeper_types.keeper_meta) =
   let attention_fields = Keeper_status_bridge.attention_fields_json config meta in

--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -96,6 +96,109 @@ let build_room_attention_items config =
     (recent_tool_host_failures ~now:(Time_compat.now ()) ()
     @ pending_items)
 
+let assoc_bool_field ~default key fields =
+  match List.assoc_opt key fields with
+  | Some (`Bool value) -> value
+  | _ -> default
+
+let assoc_string_field key fields =
+  match List.assoc_opt key fields with
+  | Some (`String value) ->
+      let value = String.trim value in
+      if String.equal value "" then None else Some value
+  | _ -> None
+
+let keeper_attention_kind = function
+  | Some reason -> "keeper_" ^ reason
+  | None -> "keeper_attention"
+
+let keeper_attention_severity ~reason ~runtime_blocker_class =
+  match reason, runtime_blocker_class with
+  | Some "runtime_blocked", _
+  | Some "timeout_budget_exhausted", _
+  | Some "continue_gate_required", _ -> Sev_bad
+  | _, Some _ -> Sev_bad
+  | _ -> Sev_warn
+
+let keeper_attention_summary ~(meta : Keeper_types.keeper_meta) ~reason
+    ~runtime_blocker_summary =
+  let reason = Option.value ~default:"attention_required" reason in
+  match runtime_blocker_summary with
+  | Some summary ->
+      Printf.sprintf "%s needs operator attention: %s (%s)" meta.name reason summary
+  | None -> Printf.sprintf "%s needs operator attention: %s" meta.name reason
+
+let keeper_attention_projection config (meta : Keeper_types.keeper_meta) =
+  let attention_fields = Keeper_status_bridge.attention_fields_json config meta in
+  if not (assoc_bool_field ~default:false "needs_attention" attention_fields)
+  then None
+  else
+    let blocker_fields = Keeper_status_bridge.runtime_blocker_fields_json config meta in
+    let reason = assoc_string_field "attention_reason" attention_fields in
+    let next_human_action =
+      assoc_string_field "next_human_action" attention_fields
+    in
+    let runtime_blocker_class =
+      assoc_string_field "runtime_blocker_class" blocker_fields
+    in
+    let runtime_blocker_summary =
+      assoc_string_field "runtime_blocker_summary" blocker_fields
+    in
+    let severity = keeper_attention_severity ~reason ~runtime_blocker_class in
+    let evidence =
+      `Assoc
+        [
+          ("source", `String "keeper_status_bridge");
+          ("keeper_name", `String meta.name);
+          ("agent_name", `String meta.agent_name);
+          ("paused", `Bool meta.paused);
+          ("attention", `Assoc attention_fields);
+          ("runtime_blocker", `Assoc blocker_fields);
+        ]
+    in
+    let attention_item =
+      {
+        kind = keeper_attention_kind reason;
+        severity;
+        summary =
+          keeper_attention_summary ~meta ~reason ~runtime_blocker_summary;
+        target_type = "keeper";
+        target_id = Some meta.name;
+        actor = Some meta.agent_name;
+        evidence;
+      }
+    in
+    let action_reason =
+      match next_human_action with
+      | Some action -> Printf.sprintf "Inspect keeper attention: %s" action
+      | None -> "Inspect keeper attention"
+    in
+    let recommended_action =
+      {
+        action_type = "keeper_probe";
+        target_type = "keeper";
+        target_id = Some meta.name;
+        severity;
+        reason = action_reason;
+        suggested_payload =
+          `Assoc
+            [
+              ("source", `String "operator_digest");
+              ("keeper", `String meta.name);
+              ("reason", string_option_to_json reason);
+              ("next_human_action", string_option_to_json next_human_action);
+            ];
+      }
+    in
+    Some (attention_item, recommended_action)
+
+let keeper_attention_projection_items config =
+  Keeper_types.keeper_names config
+  |> List.filter_map (fun name ->
+    match Keeper_types.read_meta config name with
+    | Ok (Some meta) -> keeper_attention_projection config meta
+    | Ok None | Error _ -> None)
+
 let room_recommendations _config =
   dedup_recommendations []
 
@@ -155,13 +258,17 @@ let digest_json ?actor ?target_type ?target_id:_target_id ?include_workers:_incl
     match target_type with
     | "root" ->
         let confirm_scope = pending_confirm_scope ?actor config in
+        let keeper_attention, keeper_recommendations =
+          keeper_attention_projection_items config |> List.split
+        in
         let attention_items =
           build_room_attention_items config
+          @ keeper_attention
           |> List.sort compare_attention
         in
         let recommended_actions =
           dedup_recommendations
-            (room_recommendations config)
+            (room_recommendations config @ keeper_recommendations)
         in
         let fallback_recommendation_summary =
           summary_of_recommendations ~actor:actor_name recommended_actions

--- a/lib/server/server_dashboard_http_core_cache.mli
+++ b/lib/server/server_dashboard_http_core_cache.mli
@@ -7,6 +7,8 @@ val shell_warming : bool Atomic.t
 val _shell_warming : bool Atomic.t
 val last_good_shell : Yojson.Safe.t Atomic.t
 val _last_good_shell : Yojson.Safe.t Atomic.t
+val last_good_shell_light : Yojson.Safe.t Atomic.t
+val _last_good_shell_light : Yojson.Safe.t Atomic.t
 
 val with_dashboard_timeout :
   clock:_ Eio.Time.clock -> (unit -> Yojson.Safe.t) -> Yojson.Safe.t

--- a/lib/server/server_dashboard_http_core_json.ml
+++ b/lib/server/server_dashboard_http_core_json.ml
@@ -48,6 +48,9 @@ let operator_generated_at_iso json =
      | None -> Masc_domain.now_iso ())
 ;;
 
+let dashboard_request_timeout_s = Server_dashboard_http_core_cache.dashboard_request_timeout_s
+let operator_refresh_interval_s = Server_dashboard_http_core_operator.operator_refresh_interval_s
+
 let operator_cache_json ?cache_key ~scope json =
   let diagnostic_field key =
     match projection_diagnostics_field json key with

--- a/lib/tool_operator.mli
+++ b/lib/tool_operator.mli
@@ -79,6 +79,10 @@ val remote_schemas : Masc_domain.tool_schema list
     MCP clients.  Pinned at the .mli seam so dashboard / SDK
     consumers see a stable list ordering. *)
 
+val schemas : Masc_domain.tool_schema list
+(** Full operator tool schemas — consumed by keeper-local dispatchers
+    and schema coverage checks. *)
+
 val remote_tool_names : string list
 (** [List.map (fun s -> s.name) remote_schemas].  Pre-computed for
     O(1) membership checks in the auth gate. *)

--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -1,10 +1,10 @@
 {
   "_comment": "OCaml structural-debt baseline. Regenerate with scripts/ocaml-structure-ratchet.sh --regenerate.",
   "_metrics": "See scripts/ocaml-structure-ratchet.sh METRICS array.",
-  "keeper_mli_missing": 8,
-  "coord_mli_missing": 1,
+  "keeper_mli_missing": 1,
+  "coord_mli_missing": 0,
   "godsplit_count": 0,
   "lib_dune_lines": 661,
   "inferred_dump_headers": 0,
-  "lib_other_mli_missing": 5
+  "lib_other_mli_missing": 1
 }

--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -1,10 +1,10 @@
 {
   "_comment": "OCaml structural-debt baseline. Regenerate with scripts/ocaml-structure-ratchet.sh --regenerate.",
   "_metrics": "See scripts/ocaml-structure-ratchet.sh METRICS array.",
-  "keeper_mli_missing": 1,
-  "coord_mli_missing": 0,
+  "keeper_mli_missing": 8,
+  "coord_mli_missing": 1,
   "godsplit_count": 0,
-  "lib_dune_lines": 1000,
+  "lib_dune_lines": 661,
   "inferred_dump_headers": 0,
-  "lib_other_mli_missing": 1
+  "lib_other_mli_missing": 5
 }

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -41,6 +41,10 @@ let () =
             "snapshot summary surfaces paused keeper runtime trust" `Quick
             Test_operator_control_snapshot
             .test_lightweight_snapshot_surfaces_paused_keeper_runtime_trust;
+          Alcotest.test_case "digest room includes keeper runtime attention"
+            `Quick
+            Test_operator_control_snapshot
+            .test_digest_room_includes_keeper_runtime_attention;
           Alcotest.test_case
             "snapshot lightweight summary preserves receipt causal event" `Quick
             Test_operator_control_snapshot

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -355,6 +355,7 @@ let test_lightweight_snapshot_surfaces_paused_keeper_runtime_trust () =
       cleanup_dir base_dir)
     (fun () ->
       let config = Coord.default_config base_dir in
+      (* See: this fixture only needs an initialized room for digest reads. *)
       ignore (Coord.init config ~agent_name:(Some "operator"));
       let keeper_ctx : _ Tool_keeper.context =
         {
@@ -475,6 +476,111 @@ let test_lightweight_snapshot_surfaces_paused_keeper_runtime_trust () =
         "completion_contract_violation:require_tool_use"
         (trust |> member "latest_terminal_reason" |> member "code"
        |> to_string))
+
+let test_digest_room_includes_keeper_runtime_attention () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "digest-runtime-attention" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator")); (* See: fixture init. *)
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Expose keeper attention in digest");
+                ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok" true ok;
+      Keeper_keepalive.stop_keepalive keeper_name;
+      let meta =
+        match Keeper_types.read_meta config keeper_name with
+        | Ok (Some meta) -> meta
+        | Ok None -> Alcotest.fail "expected keeper meta"
+        | Error err -> Alcotest.fail err
+      in
+      let meta =
+        {
+          meta with
+          paused = true;
+          runtime =
+            {
+              meta.runtime with
+              last_blocker =
+                Some
+                  (Keeper_types.blocker_info_of_class
+                     ~detail:"Completion contract requires a keeper tool call"
+                     Keeper_types.Completion_contract_violation);
+            };
+        }
+      in
+      (match Keeper_types.write_meta config meta with
+      | Ok () -> ()
+      | Error err -> Alcotest.fail err);
+      let digest =
+        match
+          Operator_control.digest_json ~actor:"dashboard"
+            (operator_ctx env sw config "dashboard")
+        with
+        | Ok json -> json
+        | Error err -> Alcotest.fail err
+      in
+      let open Yojson.Safe.Util in
+      let target_id_is_keeper item =
+        match item |> member "target_id" with
+        | `String value -> String.equal value keeper_name
+        | _ -> false
+      in
+      let keeper_attention =
+        digest |> member "attention_items" |> to_list
+        |> List.find_opt target_id_is_keeper
+        |> Option.value ~default:`Null
+      in
+      Alcotest.(check bool) "keeper attention present" true
+        (keeper_attention <> `Null);
+      Alcotest.(check string) "keeper attention target type" "keeper"
+        (keeper_attention |> member "target_type" |> to_string);
+      Alcotest.(check string) "keeper attention kind" "keeper_paused"
+        (keeper_attention |> member "kind" |> to_string);
+      Alcotest.(check string) "keeper attention severity" "bad"
+        (keeper_attention |> member "severity" |> to_string);
+      Alcotest.(check string) "keeper attention blocker class"
+        "completion_contract_violation"
+        (keeper_attention |> member "evidence" |> member "runtime_blocker"
+         |> member "runtime_blocker_class" |> to_string);
+      let keeper_probe =
+        digest |> member "recommended_actions" |> to_list
+        |> List.find_opt (fun row ->
+          target_id_is_keeper row
+          && String.equal "keeper_probe" (row |> member "action_type" |> to_string))
+        |> Option.value ~default:`Null
+      in
+      Alcotest.(check bool) "keeper probe recommendation present" true
+        (keeper_probe <> `Null);
+      Alcotest.(check bool) "recommendation summary is non-empty" true
+        (digest |> member "recommendation_summary" |> member "count" |> to_int > 0))
 
 let test_lightweight_snapshot_preserves_receipt_latest_causal_event () =
   Eio_main.run @@ fun env ->


### PR DESCRIPTION
Summary:
- Include keeper runtime attention in Operator_control.digest_json attention_items and recommendation_summary.
- Add a focused regression for a paused blocked keeper surfacing as keeper attention plus keeper_probe recommendation.
- Avoid defaulting missing keeper attention_reason so the deterministic-boundary meta gate stays sound-partial.
- Align operator schema coverage after the digest shape change.
- Repair latest-main dashboard extraction drift needed for this branch to build: rebind extracted cache metadata constants and expose light shell cache cells through the cache interface.
- Lower the OCaml structure baseline after rebasing onto current main, where the measured debt has already decreased.

Validation:
- ocamlformat --check lib/server/server_dashboard_http_core_cache.mli lib/server/server_dashboard_http_core_json.ml lib/operator/operator_digest.ml lib/tool_operator.mli test/test_operator_control.ml test/test_operator_control_snapshot.ml
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- bash scripts/ci/check-determinism-contract.sh

Local build status:
- Attempted: env DUNE_CACHE=disabled MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_operator_control.exe test/test_dashboard_tools.exe test/test_tools_coverage.exe
- First attempt exposed latest-main extraction drift, fixed here:
  - server_dashboard_http_core_json.ml missing dashboard_request_timeout_s/operator_refresh_interval_s bindings.
  - server_dashboard_http_core_cache.mli missing last_good_shell_light exports.
- Follow-up attempts were blocked by shared host contention: other worktrees repeatedly held /tmp/me-opam-switch.lock and flipped agent_sdk between 609600d896af320868b9578d278e5752f8f28075 and expected 6d952cb93a106cb622a46983600f7b00ad5d3fe1 before this branch could run Dune again.
- Tracking the shared-switch validation race separately as #17302.
- GitHub CI is the authoritative post-push compile signal for this draft update.

Notes:
- PR remains draft; Draft Auto-Merge Guard / CI Gate are expected to stay red until a human adds the human-approved-ready label.
