### PR TITLE
fix(cdal): finalize proof health and task scope

### DIFF
--- a/lib/cdal_runtime/proof_capture.ml
+++ b/lib/cdal_runtime/proof_capture.ml
@@ -36,7 +36,54 @@ type state =
   ; mutable pending_tool : pending_tool option
   ; mutable trace_count : int
   ; mutable enforcer : Mode_enforcer.state option
+  ; mutable terminal_recorded : bool
   }
+
+let pending_mutex = Stdlib.Mutex.create ()
+let pending_states : state list ref = ref []
+let at_exit_registered = ref false
+
+let with_pending_lock f =
+  Stdlib.Mutex.lock pending_mutex;
+  Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock pending_mutex) f
+;;
+
+let record_abort_marker st ~reason =
+  if not st.terminal_recorded
+  then (
+    Proof_store.write_terminal_marker
+      st.store
+      ~run_id:st.run_id
+      ~marker:Proof_store.Aborted
+      ~reason;
+    st.terminal_recorded <- true)
+;;
+
+let unregister_pending st =
+  with_pending_lock (fun () ->
+    pending_states := List.filter (fun pending -> pending != st) !pending_states)
+;;
+
+let abort_pending_at_exit () =
+  let pending =
+    with_pending_lock (fun () ->
+      let pending = !pending_states in
+      pending_states := [];
+      pending)
+  in
+  List.iter
+    (fun st -> record_abort_marker st ~reason:"process_exit_before_finalize")
+    pending
+;;
+
+let register_pending st =
+  with_pending_lock (fun () ->
+    if not !at_exit_registered
+    then (
+      at_exit abort_pending_at_exit;
+      at_exit_registered := true);
+    pending_states := st :: !pending_states)
+;;
 
 let generate_run_id () =
   let now = Unix.gettimeofday () in
@@ -60,7 +107,11 @@ let create ~store ~contract ~mode_decision ~capability_snapshot ?scope () =
   ; pending_tool = None
   ; trace_count = 0
   ; enforcer = None
+  ; terminal_recorded = false
   }
+  |> fun st ->
+  register_pending st;
+  st
 ;;
 
 let run_id st = st.run_id
@@ -281,6 +332,12 @@ let collect_evidence_refs st =
     List.rev !refs
 ;;
 
+let abort st ~reason =
+  complete_pending_tool st ~output:None ~error:(Some reason);
+  record_abort_marker st ~reason;
+  unregister_pending st
+;;
+
 let finalize st ~result_status =
   complete_pending_tool st ~output:None ~error:None;
   let now = Unix.gettimeofday () in
@@ -313,5 +370,15 @@ let finalize st ~result_status =
   in
   Proof_store.write_manifest st.store ~run_id:st.run_id proof;
   Proof_store.write_contract st.store ~run_id:st.run_id st.contract;
+  if Proof_store.run_has_manifest_and_contract st.store ~run_id:st.run_id
+  then Proof_store.write_finalized_marker st.store ~run_id:st.run_id
+  else
+    Proof_store.write_terminal_marker
+      st.store
+      ~run_id:st.run_id
+      ~marker:Proof_store.Aborted
+      ~reason:"finalize_missing_manifest_or_contract";
+  st.terminal_recorded <- true;
+  unregister_pending st;
   proof
 ;;

--- a/lib/cdal_runtime/proof_capture.mli
+++ b/lib/cdal_runtime/proof_capture.mli
@@ -29,6 +29,10 @@ val hooks : state -> Hooks.hooks
     return the assembled proof bundle. *)
 val finalize : state -> result_status:Cdal_proof.result_status -> Cdal_proof.t
 
+(** Mark an initialized run as terminal without a complete proof bundle.
+    Used by guards when a run cannot reach [finalize]. *)
+val abort : state -> reason:string -> unit
+
 val run_id : state -> string
 
 (** Attach an enforcer state for evidence enrichment at finalize time. *)

--- a/lib/cdal_runtime/proof_store.ml
+++ b/lib/cdal_runtime/proof_store.ml
@@ -6,6 +6,11 @@ type resolved_ref =
   ; path : string
   }
 
+type terminal_marker =
+  | Aborted
+  | Skipped
+  | Tombstoned
+
 open Result_syntax
 
 let env_non_empty key =
@@ -42,19 +47,72 @@ let manifest_path config ~run_id =
   Filename.concat (run_dir config ~run_id) "manifest.json"
 ;;
 
+let run_status_path config ~run_id =
+  Filename.concat (run_dir config ~run_id) "status.json"
+;;
+
 let log_error context = function
   | Ok () -> ()
   | Error err -> Printf.eprintf "[proof_store] %s: %s\n%!" context (Error.to_string err)
 ;;
 
-let init_run config ~run_id =
-  log_error "mkdir traces" (Fs_result.ensure_dir (traces_dir config ~run_id));
-  log_error "mkdir evidence" (Fs_result.ensure_dir (evidence_dir config ~run_id))
-;;
-
 let write_json context path json =
   let content = Yojson.Safe.pretty_to_string json ^ "\n" in
   log_error context (Fs_result.write_file path content)
+;;
+
+let status_marker_name = "cdal_proof_run_status"
+
+let terminal_marker_to_string = function
+  | Aborted -> "aborted"
+  | Skipped -> "skipped"
+  | Tombstoned -> "tombstoned"
+;;
+
+let is_terminal_status = function
+  | "aborted" | "skipped" | "tombstoned" -> true
+  | _ -> false
+;;
+
+let write_run_status config ~run_id ~status ?reason () =
+  let fields =
+    [ "schema_version", `Int 1
+    ; "marker", `String status_marker_name
+    ; "run_id", `String run_id
+    ; "status", `String status
+    ; "updated_at", `Float (Unix.gettimeofday ())
+    ]
+  in
+  let fields =
+    match reason with
+    | None -> fields
+    | Some value -> ("reason", `String value) :: fields
+  in
+  write_json "write run status" (run_status_path config ~run_id) (`Assoc fields)
+;;
+
+let init_run config ~run_id =
+  log_error "mkdir traces" (Fs_result.ensure_dir (traces_dir config ~run_id));
+  log_error "mkdir evidence" (Fs_result.ensure_dir (evidence_dir config ~run_id));
+  write_run_status config ~run_id ~status:"initialized" ()
+;;
+
+let run_has_manifest_and_contract config ~run_id =
+  Sys.file_exists (manifest_path config ~run_id)
+  && Sys.file_exists (contract_path config ~run_id)
+;;
+
+let write_finalized_marker config ~run_id =
+  write_run_status config ~run_id ~status:"finalized" ()
+;;
+
+let write_terminal_marker config ~run_id ~marker ~reason =
+  write_run_status
+    config
+    ~run_id
+    ~status:(terminal_marker_to_string marker)
+    ~reason
+    ()
 ;;
 
 let write_manifest config ~run_id proof =
@@ -123,6 +181,20 @@ let read_json_path path =
   let* content = Fs_result.read_file path |> map_error Error.to_string in
   try Ok (Yojson.Safe.from_string content) with
   | Yojson.Json_error msg -> Error (Printf.sprintf "JSON parse error in %s: %s" path msg)
+;;
+
+let has_terminal_marker config ~run_id =
+  let path = run_status_path config ~run_id in
+  if not (Sys.file_exists path)
+  then false
+  else (
+    match read_json_path path with
+    | Error _ -> false
+    | Ok (`Assoc fields) ->
+      (match List.assoc_opt "status" fields with
+       | Some (`String status) -> is_terminal_status status
+       | _ -> false)
+    | Ok _ -> false)
 ;;
 
 let read_json config ref_ =

--- a/lib/cdal_runtime/proof_store.mli
+++ b/lib/cdal_runtime/proof_store.mli
@@ -18,6 +18,11 @@ type resolved_ref =
   ; path : string
   }
 
+type terminal_marker =
+  | Aborted
+  | Skipped
+  | Tombstoned
+
 val default_config : config
 
 (** Directory containing all proof run bundles for [config]. *)
@@ -26,6 +31,28 @@ val proofs_dir : config -> string
 
 (** Create directory structure for a new run. *)
 val init_run : config -> run_id:string -> unit
+
+(** Path to status.json for a run. *)
+val run_status_path : config -> run_id:string -> string
+
+(** True when manifest.json and contract.json are both present. *)
+val run_has_manifest_and_contract : config -> run_id:string -> bool
+
+(** Write an explicit terminal marker for an initialized run that will not
+    produce a complete manifest/contract bundle. *)
+val write_terminal_marker
+  :  config
+  -> run_id:string
+  -> marker:terminal_marker
+  -> reason:string
+  -> unit
+
+(** Mark a run complete after manifest.json and contract.json have both
+    been written. Health still treats the files themselves as authoritative. *)
+val write_finalized_marker : config -> run_id:string -> unit
+
+(** True when status.json carries an explicit terminal marker. *)
+val has_terminal_marker : config -> run_id:string -> bool
 
 (** Write the 15-field proof manifest. *)
 val write_manifest : config -> run_id:string -> Cdal_proof.t -> unit

--- a/lib/cdal_runtime_health.ml
+++ b/lib/cdal_runtime_health.ml
@@ -311,6 +311,27 @@ let assoc_string key = function
 
 let has_task_scope json = Option.is_some (assoc_string "_task_id" json)
 
+let task_scope_counts recent =
+  let indexed = List.mapi (fun index row -> index, row) recent in
+  let latest_task_scoped_index =
+    List.fold_left
+      (fun acc (index, row) -> if has_task_scope row then Some index else acc)
+      None
+      indexed
+  in
+  List.fold_left
+    (fun (task_id_rows, legacy_unscoped_rows, current_unscoped_rows) (index, row) ->
+       if has_task_scope row
+       then task_id_rows + 1, legacy_unscoped_rows, current_unscoped_rows
+       else (
+         match latest_task_scoped_index with
+         | Some scoped_index when index < scoped_index ->
+           task_id_rows, legacy_unscoped_rows + 1, current_unscoped_rows
+         | _ -> task_id_rows, legacy_unscoped_rows, current_unscoped_rows + 1))
+    (0, 0, 0)
+    indexed
+;;
+
 let task_scope_json ?base_dir ?(recent_limit = Env_config_runtime.Cdal.verdict_lookup_limit ()) ()
   =
   let ledger = Cdal_verdict_gate.ledger_health_report ?base_dir () in
@@ -318,13 +339,15 @@ let task_scope_json ?base_dir ?(recent_limit = Env_config_runtime.Cdal.verdict_l
   try
     let recent = Dated_jsonl.read_recent store recent_limit in
     let recent_rows = List.length recent in
-    let task_id_rows = List.fold_left (fun n row -> if has_task_scope row then n + 1 else n) 0 recent in
+    let task_id_rows, legacy_unscoped_rows, current_unscoped_rows =
+      task_scope_counts recent
+    in
     let status =
       if recent_rows = 0
       then "missing_ledger"
       else if task_id_rows = 0
       then "missing_task_scope"
-      else if task_id_rows < recent_rows
+      else if current_unscoped_rows > 0
       then "partial_task_scope"
       else "present"
     in
@@ -335,8 +358,14 @@ let task_scope_json ?base_dir ?(recent_limit = Env_config_runtime.Cdal.verdict_l
       ; "recent_rows", `Int recent_rows
       ; "task_id_rows", `Int task_id_rows
       ; "missing_task_scope_rows", `Int missing_task_scope_rows
+      ; "legacy_unscoped_rows", `Int legacy_unscoped_rows
+      ; "current_writer_missing_task_scope_rows", `Int current_unscoped_rows
       ; "missing_task_scope", `Bool (recent_rows > 0 && missing_task_scope_rows > 0)
       ; "partial_task_scope", `Bool (task_id_rows > 0 && missing_task_scope_rows > 0)
+      ; "current_writer_missing_task_scope", `Bool (current_unscoped_rows > 0)
+      ; "legacy_unscoped_only"
+        , `Bool
+            (task_id_rows > 0 && legacy_unscoped_rows > 0 && current_unscoped_rows = 0)
       ]
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -346,8 +375,12 @@ let task_scope_json ?base_dir ?(recent_limit = Env_config_runtime.Cdal.verdict_l
       ; "recent_rows", `Int 0
       ; "task_id_rows", `Int 0
       ; "missing_task_scope_rows", `Int 0
+      ; "legacy_unscoped_rows", `Int 0
+      ; "current_writer_missing_task_scope_rows", `Int 0
       ; "missing_task_scope", `Bool false
       ; "partial_task_scope", `Bool false
+      ; "current_writer_missing_task_scope", `Bool false
+      ; "legacy_unscoped_only", `Bool false
       ; "error", `String (Printexc.to_string exn)
       ]
 ;;

--- a/lib/cdal_runtime_health.ml
+++ b/lib/cdal_runtime_health.ml
@@ -88,6 +88,7 @@ let run_latest_mtime config ~run_id =
   [ stat_mtime run_dir
   ; stat_mtime (Proof_store.manifest_path config ~run_id)
   ; stat_mtime (proof_contract_path config ~run_id)
+  ; stat_mtime (Proof_store.run_status_path config ~run_id)
   ; stat_mtime traces_dir
   ; max_child_mtime traces_dir
   ; stat_mtime evidence_dir
@@ -176,10 +177,12 @@ let proof_completeness_json
       ; "completed_run_dirs", `Int 0
       ; "incomplete_run_dirs", `Int 0
       ; "stale_incomplete_run_dirs", `Int 0
+      ; "terminal_incomplete_run_dirs", `Int 0
       ; "missing_manifest_run_dirs", `Int 0
       ; "missing_contract_run_dirs", `Int 0
       ; "stale_incomplete_grace_seconds", `Float stale_incomplete_grace_seconds
       ; "sample_stale_incomplete_run_ids", `List []
+      ; "sample_terminal_incomplete_run_ids", `List []
       ]
   else (
     let run_ids =
@@ -203,15 +206,22 @@ let proof_completeness_json
     let completed = ref 0 in
     let incomplete = ref 0 in
     let stale_incomplete = ref 0 in
+    let terminal_incomplete = ref 0 in
     let missing_manifest = ref 0 in
     let missing_contract = ref 0 in
     let stale_samples = ref [] in
+    let terminal_samples = ref [] in
     List.iter
       (fun (run_id, mtime) ->
          let has_manifest = file_exists (Proof_store.manifest_path config ~run_id) in
          let has_contract = file_exists (proof_contract_path config ~run_id) in
          if has_manifest && has_contract
          then incr completed
+         else if Proof_store.has_terminal_marker config ~run_id
+         then (
+           incr terminal_incomplete;
+           if List.length !terminal_samples < 5
+           then terminal_samples := run_id :: !terminal_samples)
          else (
            incr incomplete;
            if not has_manifest then incr missing_manifest;
@@ -230,11 +240,14 @@ let proof_completeness_json
       ; "completed_run_dirs", `Int !completed
       ; "incomplete_run_dirs", `Int !incomplete
       ; "stale_incomplete_run_dirs", `Int !stale_incomplete
+      ; "terminal_incomplete_run_dirs", `Int !terminal_incomplete
       ; "missing_manifest_run_dirs", `Int !missing_manifest
       ; "missing_contract_run_dirs", `Int !missing_contract
       ; "stale_incomplete_grace_seconds", `Float stale_incomplete_grace_seconds
       ; ( "sample_stale_incomplete_run_ids"
         , `List (List.rev_map (fun run_id -> `String run_id) !stale_samples) )
+      ; ( "sample_terminal_incomplete_run_ids"
+        , `List (List.rev_map (fun run_id -> `String run_id) !terminal_samples) )
       ])
 ;;
 

--- a/lib/cdal_runtime_health.ml
+++ b/lib/cdal_runtime_health.ml
@@ -313,9 +313,12 @@ let has_task_scope json = Option.is_some (assoc_string "_task_id" json)
 
 let task_scope_counts recent =
   let indexed = List.mapi (fun index row -> index, row) recent in
-  let latest_task_scoped_index =
+  let first_task_scoped_index =
     List.fold_left
-      (fun acc (index, row) -> if has_task_scope row then Some index else acc)
+      (fun acc (index, row) ->
+         match acc with
+         | Some _ -> acc
+         | None -> if has_task_scope row then Some index else None)
       None
       indexed
   in
@@ -324,7 +327,7 @@ let task_scope_counts recent =
        if has_task_scope row
        then task_id_rows + 1, legacy_unscoped_rows, current_unscoped_rows
        else (
-         match latest_task_scoped_index with
+         match first_task_scoped_index with
          | Some scoped_index when index < scoped_index ->
            task_id_rows, legacy_unscoped_rows + 1, current_unscoped_rows
          | _ -> task_id_rows, legacy_unscoped_rows, current_unscoped_rows + 1))

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -57,6 +57,45 @@ let task_scope_tool_names = Keeper_run_tools_task_scope.task_scope_tool_names
 let json_string_opt = Keeper_run_tools_task_scope.json_string_opt
 let task_id_scope_of_tool_input = Keeper_run_tools_task_scope.task_id_scope_of_tool_input
 
+let first_some left right =
+  match left with
+  | Some _ -> left
+  | None -> right
+;;
+
+let current_task_id_of_meta (meta : Keeper_types.keeper_meta) =
+  Option.map Keeper_id.Task_id.to_string meta.current_task_id
+;;
+
+let task_id_scope_of_claim_output ~tool_name output_text =
+  if not (List.mem tool_name [ "keeper_task_claim"; "masc_claim_next" ])
+  then None
+  else (
+    let output_text =
+      match Tool_output.decode_from_oas output_text with
+      | Tool_output.Stored { preview; _ } -> preview
+      | Tool_output.Inline value -> value
+    in
+    try
+      match Yojson.Safe.from_string (Safe_ops.sanitize_text_utf8 output_text) with
+      | `Assoc fields ->
+        (match List.assoc_opt "result" fields with
+         | Some result ->
+           first_some (json_string_opt "task_id" result) (json_string_opt "task_id" (`Assoc fields))
+         | None -> json_string_opt "task_id" (`Assoc fields))
+      | _ -> None
+    with
+    | Yojson.Json_error _ -> None)
+;;
+
+let task_id_scope_of_tool_call ~tool_name ~input ~output_text ~meta =
+  first_some
+    (task_id_scope_of_tool_input ~tool_name input)
+    (first_some
+       (task_id_scope_of_claim_output ~tool_name output_text)
+       (current_task_id_of_meta meta))
+;;
+
 type tool_search_hit_partition = Tool_search.tool_search_hit_partition =
   { visible_core_hits : (string * float) list
   ; discoverable_hits : (string * float) list
@@ -1151,12 +1190,12 @@ let prepare_agent_setup
             then "ok"
             else "ok_no_progress"
           in
-          let task_id = task_id_scope_of_tool_input ~tool_name input in
           (match Keeper_registry.get ~base_path:config.base_path meta.name with
            | Some entry ->
              acc.meta <- entry.meta;
              meta_ref := entry.meta
            | None -> ());
+          let task_id = task_id_scope_of_tool_call ~tool_name ~input ~output_text ~meta:acc.meta in
           acc.tool_calls
           <- { tool_name
              ; provider

--- a/test/test_cdal_runtime_health_15748.ml
+++ b/test/test_cdal_runtime_health_15748.ml
@@ -240,11 +240,13 @@ let test_legacy_unscoped_rows_do_not_mark_current_writer_partial () =
   with_temp_dir @@ fun dir ->
   let base_dir = Filename.concat dir "cdal_verdicts" in
   let proof_root = Filename.concat dir ".oas" in
+  (* See fixture setup: the written ledger path is irrelevant here. *)
   ignore (write_ledger_row ~base_dir (`Assoc [ "run_id", `String "run-legacy" ]));
   ignore
     (write_ledger_row
        ~base_dir
        (`Assoc [ "_task_id", `String "task-15748"; "run_id", `String "run-task" ]));
+  (* See fixture setup: only the proof root side effect is asserted. *)
   ignore (make_proof_root proof_root);
   let json =
     H.snapshot_json
@@ -269,6 +271,56 @@ let test_legacy_unscoped_rows_do_not_mark_current_writer_partial () =
   Alcotest.(check bool)
     "legacy-only marker"
     true
+    (member_bool "legacy_unscoped_only" task_scope)
+;;
+
+let test_interleaved_unscoped_rows_mark_current_writer_partial () =
+  with_temp_dir @@ fun dir ->
+  let base_dir = Filename.concat dir "cdal_verdicts" in
+  let proof_root = Filename.concat dir ".oas" in
+  (* See fixture setup: the written ledger path is irrelevant here. *)
+  ignore
+    (write_ledger_row
+       ~base_dir
+       (`Assoc [ "_task_id", `String "task-old"; "run_id", `String "run-old" ]));
+  (* See fixture setup: the written ledger path is irrelevant here. *)
+  ignore (write_ledger_row ~base_dir (`Assoc [ "run_id", `String "run-no-task" ]));
+  (* See fixture setup: the written ledger path is irrelevant here. *)
+  ignore
+    (write_ledger_row
+       ~base_dir
+       (`Assoc [ "_task_id", `String "task-new"; "run_id", `String "run-new" ]));
+  (* See fixture setup: only the proof root side effect is asserted. *)
+  ignore (make_proof_root proof_root);
+  let json =
+    H.snapshot_json
+      ~base_dir
+      ~proof_root
+      ~now:(Time_compat.now ())
+      ~stale_age_seconds:60.0
+      ~recent_limit:20
+      ()
+  in
+  Alcotest.(check string)
+    "writer_status"
+    "partial_task_scope"
+    (member_string "writer_status" json);
+  let task_scope = nested "task_scope" json in
+  Alcotest.(check string)
+    "task scope status"
+    "partial_task_scope"
+    (member_string "status" task_scope);
+  Alcotest.(check int)
+    "legacy unscoped rows"
+    0
+    (member_int "legacy_unscoped_rows" task_scope);
+  Alcotest.(check int)
+    "current writer missing task rows"
+    1
+    (member_int "current_writer_missing_task_scope_rows" task_scope);
+  Alcotest.(check bool)
+    "legacy-only marker"
+    false
     (member_bool "legacy_unscoped_only" task_scope)
 ;;
 
@@ -556,6 +608,10 @@ let () =
             "legacy unscoped rows do not mark current writer partial"
             `Quick
             test_legacy_unscoped_rows_do_not_mark_current_writer_partial
+        ; Alcotest.test_case
+            "interleaved unscoped rows mark current writer partial"
+            `Quick
+            test_interleaved_unscoped_rows_mark_current_writer_partial
         ; Alcotest.test_case "active" `Quick test_active_writer_status
         ; Alcotest.test_case
             "stale incomplete proof store"

--- a/test/test_cdal_runtime_health_15748.ml
+++ b/test/test_cdal_runtime_health_15748.ml
@@ -76,7 +76,14 @@ let make_proof_root ?mtime root =
   proofs_dir
 ;;
 
-let make_proof_run ?mtime ?(manifest = false) ?(contract = false) root run_id =
+let make_proof_run
+      ?mtime
+      ?terminal_marker
+      ?(manifest = false)
+      ?(contract = false)
+      root
+      run_id
+  =
   let proofs_dir = make_proof_root root in
   let run_dir = Filename.concat proofs_dir run_id in
   let traces_dir = Filename.concat run_dir "tool_traces" in
@@ -86,6 +93,14 @@ let make_proof_run ?mtime ?(manifest = false) ?(contract = false) root run_id =
   if manifest then write_file (Filename.concat run_dir "manifest.json") "{}\n";
   if contract then write_file (Filename.concat run_dir "contract.json") "{}\n";
   Option.iter
+    (fun marker ->
+       Masc_mcp_cdal_runtime.Proof_store.write_terminal_marker
+         { root }
+         ~run_id
+         ~marker
+         ~reason:"test_terminal_marker")
+    terminal_marker;
+  Option.iter
     (fun ts ->
        List.iter
          (fun path -> if Sys.file_exists path then Unix.utimes path ts ts)
@@ -94,6 +109,7 @@ let make_proof_run ?mtime ?(manifest = false) ?(contract = false) root run_id =
          ; evidence_dir
          ; Filename.concat run_dir "manifest.json"
          ; Filename.concat run_dir "contract.json"
+         ; Filename.concat run_dir "status.json"
          ];
        Unix.utimes proofs_dir ts ts)
     mtime
@@ -317,6 +333,49 @@ let test_recent_incomplete_proof_store_is_in_flight () =
     (member_int "stale_incomplete_run_dirs" (nested "completeness" proof_store))
 ;;
 
+let test_terminal_incomplete_proof_store_is_distinct () =
+  with_temp_dir @@ fun dir ->
+  let base_dir = Filename.concat dir "cdal_verdicts" in
+  let proof_root = Filename.concat dir ".oas" in
+  let now = Time_compat.now () in
+  ignore
+    (write_ledger_row
+       ~base_dir
+       ~mtime:now
+       (`Assoc [ "_task_id", `String "task-15748"; "run_id", `String "run-task" ]));
+  make_proof_run
+    ~mtime:(now -. 1000.0)
+    ~terminal_marker:Masc_mcp_cdal_runtime.Proof_store.Aborted
+    proof_root
+    "cdal-terminal-incomplete";
+  let json =
+    H.snapshot_json
+      ~base_dir
+      ~proof_root
+      ~now
+      ~stale_age_seconds:600.0
+      ~recent_limit:20
+      ~proof_scan_limit:20
+      ~stale_incomplete_run_seconds:300.0
+      ()
+  in
+  Alcotest.(check string) "writer_status" "active" (member_string "writer_status" json);
+  let proof_store = nested "proof_store" json in
+  Alcotest.(check string)
+    "proof store status"
+    "active"
+    (member_string "status" proof_store);
+  let completeness = nested "completeness" proof_store in
+  Alcotest.(check int)
+    "terminal incomplete run count"
+    1
+    (member_int "terminal_incomplete_run_dirs" completeness);
+  Alcotest.(check int)
+    "stale incomplete run count"
+    0
+    (member_int "stale_incomplete_run_dirs" completeness)
+;;
+
 let test_proof_scan_limit_caps_recent_run_walk () =
   with_temp_dir @@ fun dir ->
   let base_dir = Filename.concat dir "cdal_verdicts" in
@@ -461,6 +520,10 @@ let () =
             "recent incomplete proof store is in flight"
             `Quick
             test_recent_incomplete_proof_store_is_in_flight
+        ; Alcotest.test_case
+            "terminal incomplete proof store is distinct"
+            `Quick
+            test_terminal_incomplete_proof_store_is_distinct
         ; Alcotest.test_case
             "proof scan limit caps recent run walk"
             `Quick

--- a/test/test_cdal_runtime_health_15748.ml
+++ b/test/test_cdal_runtime_health_15748.ml
@@ -229,6 +229,47 @@ let test_partial_task_scope_status () =
     "missing task rows"
     1
     (member_int "missing_task_scope_rows" task_scope)
+  ;
+  Alcotest.(check int)
+    "current writer missing task rows"
+    1
+    (member_int "current_writer_missing_task_scope_rows" task_scope)
+;;
+
+let test_legacy_unscoped_rows_do_not_mark_current_writer_partial () =
+  with_temp_dir @@ fun dir ->
+  let base_dir = Filename.concat dir "cdal_verdicts" in
+  let proof_root = Filename.concat dir ".oas" in
+  ignore (write_ledger_row ~base_dir (`Assoc [ "run_id", `String "run-legacy" ]));
+  ignore
+    (write_ledger_row
+       ~base_dir
+       (`Assoc [ "_task_id", `String "task-15748"; "run_id", `String "run-task" ]));
+  ignore (make_proof_root proof_root);
+  let json =
+    H.snapshot_json
+      ~base_dir
+      ~proof_root
+      ~now:(Time_compat.now ())
+      ~stale_age_seconds:60.0
+      ~recent_limit:20
+      ()
+  in
+  Alcotest.(check string) "writer_status" "active" (member_string "writer_status" json);
+  let task_scope = nested "task_scope" json in
+  Alcotest.(check string) "task scope status" "present" (member_string "status" task_scope);
+  Alcotest.(check int)
+    "legacy unscoped rows"
+    1
+    (member_int "legacy_unscoped_rows" task_scope);
+  Alcotest.(check int)
+    "current writer missing task rows"
+    0
+    (member_int "current_writer_missing_task_scope_rows" task_scope);
+  Alcotest.(check bool)
+    "legacy-only marker"
+    true
+    (member_bool "legacy_unscoped_only" task_scope)
 ;;
 
 let test_active_writer_status () =
@@ -511,6 +552,10 @@ let () =
       , [ Alcotest.test_case "missing" `Quick test_missing_writer_status
         ; Alcotest.test_case "missing task scope" `Quick test_missing_task_scope_status
         ; Alcotest.test_case "partial task scope" `Quick test_partial_task_scope_status
+        ; Alcotest.test_case
+            "legacy unscoped rows do not mark current writer partial"
+            `Quick
+            test_legacy_unscoped_rows_do_not_mark_current_writer_partial
         ; Alcotest.test_case "active" `Quick test_active_writer_status
         ; Alcotest.test_case
             "stale incomplete proof store"


### PR DESCRIPTION
## Summary
- add CDAL proof-run status markers so initialized runs become finalized or terminal instead of indistinguishable stale incomplete directories
- make runtime health separate terminal incomplete proof runs from stale incomplete runs
- distinguish legacy unscoped verdict ledger rows from current-writer missing task scope
- broaden keeper tool-call task scope extraction from input, claim output, or refreshed current_task_id

## Validation
- git diff --check HEAD~2..HEAD
- ocamlformat --check lib/cdal_runtime/proof_capture.ml lib/cdal_runtime/proof_capture.mli lib/cdal_runtime/proof_store.ml lib/cdal_runtime/proof_store.mli lib/cdal_runtime_health.ml lib/keeper/keeper_run_tools.ml test/test_cdal_runtime_health_15748.ml
- bash scripts/ocaml-structure-ratchet.sh
- MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_cdal_runtime_health_15748.exe (blocked by shared agent_sdk evidence_role mismatch in lib/cdal_runtime/mode_enforcer.ml and lib/tool_bridge.ml)