### PR TITLE
fix(keeper): demote repeated guardrail blocks

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -82,6 +82,7 @@ let max_consecutive_failures = Env_config.KeeperToolExec.max_consecutive_tool_fa
 
 type failure_counts =
   { table : (string, int) Hashtbl.t
+  ; block_log_table : (string, int) Hashtbl.t
   ; workflow_table : (string, int) Hashtbl.t
   ; workflow_block_table : (string, workflow_rejection_block) Hashtbl.t
   ; mutex : Mutex.t
@@ -96,6 +97,7 @@ and workflow_rejection_block =
 
 let create_failure_counts () =
   { table = Hashtbl.create 16
+  ; block_log_table = Hashtbl.create 16
   ; workflow_table = Hashtbl.create 16
   ; workflow_block_table = Hashtbl.create 16
   ; mutex = Mutex.create ()
@@ -121,7 +123,20 @@ let failure_count_record_failure counts key =
 ;;
 
 let failure_count_reset counts key =
-  Mutex.protect counts.mutex (fun () -> Hashtbl.remove counts.table key)
+  Mutex.protect counts.mutex (fun () ->
+    Hashtbl.remove counts.table key;
+    Hashtbl.remove counts.block_log_table key)
+;;
+
+let failure_block_count_record counts key =
+  Mutex.protect counts.mutex (fun () ->
+    let next =
+      match Hashtbl.find_opt counts.block_log_table key with
+      | Some n -> n + 1
+      | None -> 1
+    in
+    Hashtbl.replace counts.block_log_table key next;
+    next)
 ;;
 
 (* MASC/OAS Error-Warn Reduction Goal 2026-05-18, P2 reducer:
@@ -227,7 +242,9 @@ let workflow_rejection_count_record counts key =
 ;;
 
 let workflow_rejection_count_reset counts =
-  Mutex.protect counts.mutex (fun () -> Hashtbl.clear counts.workflow_table)
+  Mutex.protect counts.mutex (fun () ->
+    Hashtbl.clear counts.workflow_table;
+    Hashtbl.clear counts.block_log_table)
 ;;
 
 let workflow_rejection_scope_block_get counts key =
@@ -723,21 +740,56 @@ let make_keeper_tool_handler
       let prior_fails = failure_count_get failure_counts key in
       if prior_fails >= max_consecutive_failures
       then (
+        let block_count = failure_block_count_record failure_counts key in
         Prometheus.inc_counter
           Keeper_metrics.metric_keeper_tools_oas_failures
           ~labels:[ "tool", name; "site", "blocked" ]
           ();
-        Log.Keeper.warn
-          "tool %s blocked after %d consecutive failures (same args)"
-          name
-          prior_fails;
+        (if block_count = 1 then
+           Log.Keeper.warn
+             "tool %s blocked after %d consecutive failures (same args)"
+             name
+             prior_fails
+         else
+           Log.Keeper.info
+             "tool %s repeated guardrail block suppressed to INFO \
+              (same args, block_count=%d)"
+             name
+             block_count);
         let msg =
           Printf.sprintf
             "This tool has failed %d times in a row with the same arguments. Try a \
-             different approach or different arguments."
+             different approach or different arguments. Do not retry the same tool \
+             payload."
             prior_fails
         in
-        let output_text = normalize_tool_result ~success:false msg in
+        let raw_result =
+          Yojson.Safe.to_string
+            (`Assoc
+                [ "ok", `Bool false
+                ; "error", `String msg
+                ; "failure_class", `String "policy_rejection"
+                ; "recoverable", `Bool true
+                ; "error_class", `String "deterministic"
+                ; "guardrail", `String "same_args_repeated_failure"
+                ; "guardrail_repeat_count", `Int block_count
+                ; ( "recovery_plan"
+                  , `Assoc
+                      [ ( "instruction"
+                        , `String
+                            "Change the arguments, inspect the previous error, or choose a \
+                             different allowed tool; do not call the same tool payload again."
+                        )
+                      ; ( "alternatives"
+                        , `List
+                            [ `String "change_arguments"
+                            ; `String "choose_different_tool"
+                            ; `String "inspect_previous_error"
+                            ] )
+                      ] )
+                ])
+        in
+        let output_text = normalize_tool_result ~success:false raw_result in
         Tool_result.error ~tool_name:name ~start_time:t0 output_text)
       else (
         match

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -788,7 +788,29 @@ let test_repeated_error_results_are_blocked () =
            bool
            "guardrail blocks repeated failures"
            true
-           (is_guardrail_message message)
+           (is_guardrail_message message);
+         (match Tool.execute tool args with
+          | Error { Agent_sdk.Types.message = repeated_message; _ } ->
+            let json = Yojson.Safe.from_string repeated_message in
+            let detail = Yojson.Safe.Util.member "detail" json in
+            check
+              string
+              "same-args guardrail marker"
+              "same_args_repeated_failure"
+              Yojson.Safe.Util.(member "guardrail" detail |> to_string);
+            check
+              int
+              "repeated guardrail block count"
+              2
+              Yojson.Safe.Util.(member "guardrail_repeat_count" detail |> to_int);
+            check
+              bool
+              "recovery plan is surfaced"
+              true
+              (match Yojson.Safe.Util.member "recovery_plan" detail with
+               | `Assoc _ -> true
+               | _ -> false)
+          | Ok _ -> fail "guardrail should keep blocking repeated payload")
        | Ok _ -> fail "guardrail should block the repeated failure")
 ;;
 


### PR DESCRIPTION
## Summary
- Demote repeated same-args tool guardrail blocks after the first block from WARN to INFO.
- Add a structured same-args guardrail marker, repeat count, and recovery plan so the next model turn has a concrete alternative instead of retrying the same payload.
- Extend `test_repeated_error_results_are_blocked` to assert repeat metadata and recovery plan surfacing.

## Report item
- `Guardrail severity split` from `masc-oas-uncovered-after-cycle-2026-05-20.html`: first block remains WARN; repeated blocks no longer spam WARN and carry planner guidance.

## Validation
- `ocamlformat --check lib/keeper/keeper_tools_oas.ml test/test_keeper_tools_oas.ml`
- `git diff --check origin/codex/main-health-current-verify-20260521...HEAD`
- `scripts/check-pr-hygiene.sh --base origin/codex/main-health-current-verify-20260521`

## Local build note
- `scripts/dune-local.sh build test/test_keeper_tools_oas.exe` was blocked by shared local `agent_sdk` pin drift: repo expects `3f60ad9...`, shared switch is pinned at OAS `6d952cb...` / 0.196.7.
- I did not downgrade the shared switch. `MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_tools_oas.exe` reaches compile but fails in unrelated SDK-interface sites (`Tool.t.evidence_role`) that require a separate downstream OAS pin bump slice.