### PR TITLE
[codex] Fix main CI build and structure ratchet blockers

### DIFF
--- a/lib/cascade/cascade_transport_authorization.mli
+++ b/lib/cascade/cascade_transport_authorization.mli
@@ -1,0 +1,21 @@
+(** Authorization header helpers for cascade runtime MCP transport. *)
+
+val upsert_http_header :
+  key:string -> value:string -> (string * string) list -> (string * string) list
+
+val keeper_name_of_agent_name : string -> string option
+val is_authorization_header : string * string -> bool
+
+val authorization_header_from_policy :
+  Llm_provider.Llm_transport.runtime_mcp_policy -> (string * string) option
+
+val per_keeper_authorization_header :
+  agent_name:string -> (string * string) option
+
+val runtime_mcp_policy_uses_bound_actor_tools :
+  Llm_provider.Llm_transport.runtime_mcp_policy -> bool
+
+val add_masc_authorization_header :
+  string * string ->
+  Llm_provider.Llm_transport.runtime_mcp_policy ->
+  Llm_provider.Llm_transport.runtime_mcp_policy

--- a/lib/cascade/cascade_transport_label_resolution.mli
+++ b/lib/cascade/cascade_transport_label_resolution.mli
@@ -1,0 +1,11 @@
+(** Model-label resolution for cascade runtime transport. *)
+
+type label_resolution_error = Invalid_model_label of string
+
+val label_resolution_error_to_string : label_resolution_error -> string
+val label_resolution_error_to_sdk_error : label_resolution_error -> Agent_sdk.Error.sdk_error
+
+val resolve_provider_config_of_label :
+  string -> (Llm_provider.Provider_config.t, label_resolution_error) result
+
+val invalid_runtime_config : string -> string -> Agent_sdk.Error.sdk_error

--- a/lib/coord/coord_task_verification.mli
+++ b/lib/coord/coord_task_verification.mli
@@ -1,0 +1,15 @@
+(** Verification-evidence helpers for coord task lifecycle. *)
+
+val flatten_lock_result : (('a, 'b) result, 'b) result -> ('a, 'b) result
+val contains_substring_ci : string -> string -> bool
+val is_placeholder_verification_evidence : string -> bool
+val text_has_verification_artifact_ref : string -> bool
+val evidence_ref_has_verification_artifact_ref : string -> bool
+val notes_have_verification_artifact_ref : string -> bool
+val verification_evidence_error_message : string
+
+val verification_submission_evidence_refs :
+  Masc_domain.task ->
+  notes:string ->
+  Masc_domain.task_handoff_context option ->
+  string list

--- a/lib/keeper/keeper_heartbeat_loop_in_turn_pulse.mli
+++ b/lib/keeper/keeper_heartbeat_loop_in_turn_pulse.mli
@@ -1,0 +1,19 @@
+(** In-turn liveness pulse helpers for the keeper heartbeat loop. *)
+
+open Keeper_types
+
+val in_turn_liveness_pulse_interval_sec : unit -> float
+
+val with_in_turn_liveness_pulse_for_test :
+  sw:Eio.Switch.t ->
+  clock:_ Eio.Time.clock ->
+  interval_sec:float ->
+  tick:(unit -> unit) ->
+  (unit -> 'a) ->
+  'a
+
+val emit_in_turn_liveness_pulse :
+  ctx:_ context -> meta:keeper_meta -> unit
+
+val with_in_turn_liveness_pulse :
+  ctx:_ context -> meta:keeper_meta -> stop:bool Atomic.t -> (unit -> 'a) -> 'a

--- a/lib/keeper/keeper_run_tools_hook_accumulator.mli
+++ b/lib/keeper/keeper_run_tools_hook_accumulator.mli
@@ -1,0 +1,42 @@
+(** Hook accumulator + immutable outputs for OAS Agent.run callbacks. *)
+
+type hook_accumulator =
+  { mutable meta : Keeper_types.keeper_meta
+  ; mutable tool_calls : Keeper_agent_result.tool_call_detail list
+  ; mutable current_turn : int
+  ; mutable completion_contract : Keeper_tool_disclosure.completion_contract
+  ; mutable required_tool_use_seen : bool
+  ; mutable keeper_surface_tool_used : bool
+  ; mutable discovered : Keeper_discovered_tools.t
+  ; mutable tool_overlay : Agent_sdk.Tool_op.t
+  ; mutable tool_surface : Keeper_agent_tool_surface.tool_surface_metrics
+  ; mutable requested_tool_names : string list
+  ; mutable requested_tool_names_seen : string list
+  ; mutable receipt_tool_contract_result :
+      Keeper_execution_receipt.tool_contract_result
+  ; mutable contract_violation_retries : int
+  }
+
+type hook_outputs =
+  { out_meta : Keeper_types.keeper_meta
+  ; out_tool_calls : Keeper_agent_result.tool_call_detail list
+  ; out_completion_contract : Keeper_tool_disclosure.completion_contract
+  ; out_required_tool_use_seen : bool
+  ; out_keeper_surface_tool_used : bool
+  ; out_discovered : Keeper_discovered_tools.t
+  ; out_tool_overlay : Agent_sdk.Tool_op.t
+  ; out_tool_surface : Keeper_agent_tool_surface.tool_surface_metrics
+  ; out_requested_tool_names : string list
+  ; out_requested_tool_names_seen : string list
+  ; out_receipt_tool_contract_result :
+      Keeper_execution_receipt.tool_contract_result
+  ; out_contract_violation_retries : int
+  }
+
+val freeze : hook_accumulator -> hook_outputs
+
+val merge_requested_tool_names_seen :
+  seen:string list -> string list -> string list
+
+val record_requested_tool_names :
+  hook_accumulator -> string list -> unit

--- a/lib/keeper/keeper_run_tools_task_scope.mli
+++ b/lib/keeper/keeper_run_tools_task_scope.mli
@@ -1,0 +1,7 @@
+(** Task-scoped tool helpers for keeper run tools. *)
+
+val task_scope_tool_names : string list
+val json_string_opt : string -> Yojson.Safe.t -> string option
+
+val task_id_scope_of_tool_input :
+  tool_name:string -> Yojson.Safe.t -> string option

--- a/lib/keeper/keeper_turn_driver_admission.mli
+++ b/lib/keeper/keeper_turn_driver_admission.mli
@@ -1,0 +1,28 @@
+(** Cascade tier admission helpers for keeper turn driver. *)
+
+val keeper_cascade_tier_admission : Cascade_tier_admission.t
+
+val cascade_tier_admission_policy_of_priority :
+  Llm_provider.Request_priority.t -> Cascade_tier_admission.admission_policy
+
+val with_keeper_cascade_tier_admission :
+  ?admission:Cascade_tier_admission.t ->
+  ?enabled:bool ->
+  tier_id:Cascade_tier_admission.tier_id ->
+  admission_policy:Cascade_tier_admission.admission_policy ->
+  (unit -> 'a) ->
+  ('a, Cascade_saturation_signal.t) result
+
+val cascade_tier_admission_blocked_decision :
+  Cascade_saturation_signal.t -> Yojson.Safe.t
+
+val emit_cascade_tier_admission_signal_metric :
+  cascade_name:string -> Cascade_saturation_signal.t -> unit
+
+val release_client_capacity_quietly : (unit -> unit) option -> unit
+val provider_config_identity_key : Llm_provider.Provider_config.t -> int
+
+val runtime_candidates_of_tiered_providers :
+  Cascade_catalog_runtime_named_providers.tiered_provider list ->
+  Llm_provider.Provider_config.t list ->
+  Cascade_runtime_candidate.t list

--- a/lib/keeper/keeper_unified_metrics_broadcast.mli
+++ b/lib/keeper/keeper_unified_metrics_broadcast.mli
@@ -1,0 +1,8 @@
+(** Keeper lifecycle SSE broadcast helpers. *)
+
+val broadcast_lifecycle_events :
+  name:string ->
+  turn_generation:int ->
+  compaction:Keeper_exec_context.compaction_event ->
+  handoff_json:Yojson.Safe.t option ->
+  unit

--- a/lib/keeper/keeper_unified_metrics_failure.mli
+++ b/lib/keeper/keeper_unified_metrics_failure.mli
@@ -1,0 +1,13 @@
+(** Failure-path metric update for a unified keeper cycle. *)
+
+val update_metrics_from_failure :
+  Keeper_types.keeper_meta ->
+  latency_ms:int ->
+  observation:Keeper_world_observation.world_observation ->
+  reason:string ->
+  ?is_transient:bool ->
+  ?social_state:Keeper_social_model.social_state ->
+  ?social_transition_reason:string ->
+  ?sdk_error:Agent_sdk.Error.sdk_error ->
+  unit ->
+  Keeper_types.keeper_meta

--- a/lib/keeper/keeper_unified_metrics_result.mli
+++ b/lib/keeper/keeper_unified_metrics_result.mli
@@ -1,0 +1,13 @@
+(** Success-path metric update for a unified keeper cycle. *)
+
+val update_metrics_from_result :
+  Keeper_types.keeper_meta ->
+  latency_ms:int ->
+  observation:Keeper_world_observation.world_observation ->
+  ?is_autonomous_turn:bool ->
+  ?update_proactive_rt:bool ->
+  ?social_state:Keeper_social_model.social_state ->
+  ?social_transition_reason:string ->
+  ?context_max:int ->
+  Keeper_agent_run.run_result ->
+  Keeper_types.keeper_meta

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -213,79 +213,9 @@ let recent_messages_json config =
 let merge_tool_name_lists = Operator_control_snapshot_tool_names.merge_tool_name_lists
 let tool_names_of_recent_json = Operator_control_snapshot_tool_names.tool_names_of_recent_json
 let collect_recent_tool_names = Operator_control_snapshot_tool_names.collect_recent_tool_names
-let recent_tool_names_from_files config keeper_name =
-  let decision_lines =
-    let path = Keeper_types.keeper_decision_log_path config keeper_name in
-    if Fs_compat.file_exists path
-    then Keeper_memory.read_file_tail_lines path ~max_bytes:120000 ~max_lines:120
-    else []
-  in
-  let metrics_lines =
-    let store = Keeper_types.keeper_metrics_store config keeper_name in
-    let dated = Dated_jsonl.read_recent_lines store 120 in
-    if dated <> []
-    then dated
-    else (
-      let path = Keeper_types.keeper_metrics_path config keeper_name in
-      Keeper_memory.read_file_tail_lines path ~max_bytes:120000 ~max_lines:120)
-  in
-  merge_tool_name_lists
-    (collect_recent_tool_names decision_lines)
-    (collect_recent_tool_names metrics_lines)
-;;
-
-let keeper_tool_audit_fields
-      ?(include_allowed_tools = true)
-      config
-      (meta : Keeper_types.keeper_meta)
-  =
-  let fallback_allowed =
-    if include_allowed_tools then Keeper_exec_tools.keeper_allowed_tool_names meta else []
-  in
-  let recent_tool_names = recent_tool_names_from_files config meta.name in
-  let last_autonomous = String.trim meta.runtime.last_autonomous_action_at in
-  let fallback_snapshot =
-    match
-      Keeper_exec_status_metrics.latest_tool_audit_snapshot_from_files
-        config
-        ~keeper_name:meta.name
-    with
-    | Some snapshot ->
-      { snapshot with
-        tool_audit_at =
-          (match snapshot.tool_audit_source, snapshot.tool_audit_at with
-           | Some _, None when last_autonomous <> "" -> Some last_autonomous
-           | Some _, None -> Some meta.updated_at
-           | _ -> snapshot.tool_audit_at)
-      }
-    | None ->
-      let has_runtime_activity =
-        last_autonomous <> ""
-        || meta.runtime.autonomous_turn_count > 0
-        || meta.runtime.autonomous_action_count > 0
-      in
-      { Keeper_exec_status_metrics.empty_tool_audit_snapshot with
-        latest_tool_call_count = (if has_runtime_activity then Some 0 else None)
-      ; tool_audit_source =
-          (if has_runtime_activity then Some "keeper_runtime_meta" else None)
-      ; tool_audit_at =
-          (if last_autonomous <> ""
-           then Some last_autonomous
-           else if has_runtime_activity
-           then Some meta.updated_at
-           else None)
-      }
-  in
-  ( fallback_allowed
-  , recent_tool_names
-  , fallback_snapshot.latest_tool_names
-  , fallback_snapshot.latest_tool_call_count
-  , fallback_snapshot.latest_action_source
-  , fallback_snapshot.tool_audit_source
-  , fallback_snapshot.tool_audit_at )
-;;
-
 let lightweight_tool_audit_fallback_json = Operator_control_snapshot_tool_audit.lightweight_tool_audit_fallback_json
+let recent_tool_names_from_files = Operator_control_snapshot_tool_audit.recent_tool_names_from_files
+let keeper_tool_audit_fields = Operator_control_snapshot_tool_audit.keeper_tool_audit_fields
 let cached_tool_audit_json = Operator_control_snapshot_tool_audit.cached_tool_audit_json
 let _keeper_snapshot_max_concurrency =
   match Sys.getenv_opt "MASC_KEEPER_SNAPSHOT_CONCURRENCY" with

--- a/lib/operator/operator_control_snapshot_tool_audit.ml
+++ b/lib/operator/operator_control_snapshot_tool_audit.ml
@@ -3,6 +3,11 @@
 
 module U = Yojson.Safe.Util
 
+let option_to_json = Operator_pending_confirm.option_to_json
+let string_option_to_json = Operator_pending_confirm.string_option_to_json
+let merge_tool_name_lists = Operator_control_snapshot_tool_names.merge_tool_name_lists
+let collect_recent_tool_names = Operator_control_snapshot_tool_names.collect_recent_tool_names
+
 let lightweight_tool_audit_fallback_json (meta : Keeper_types.keeper_meta) =
   let last_autonomous = String.trim meta.runtime.last_autonomous_action_at in
   let has_runtime_activity =
@@ -25,6 +30,78 @@ let lightweight_tool_audit_fallback_json (meta : Keeper_types.keeper_meta) =
         then `String meta.updated_at
         else `Null )
     ]
+;;
+
+let recent_tool_names_from_files config keeper_name =
+  let decision_lines =
+    let path = Keeper_types.keeper_decision_log_path config keeper_name in
+    if Fs_compat.file_exists path
+    then Keeper_memory.read_file_tail_lines path ~max_bytes:120000 ~max_lines:120
+    else []
+  in
+  let metrics_lines =
+    let store = Keeper_types.keeper_metrics_store config keeper_name in
+    let dated = Dated_jsonl.read_recent_lines store 120 in
+    if dated <> []
+    then dated
+    else (
+      let path = Keeper_types.keeper_metrics_path config keeper_name in
+      Keeper_memory.read_file_tail_lines path ~max_bytes:120000 ~max_lines:120)
+  in
+  merge_tool_name_lists
+    (collect_recent_tool_names decision_lines)
+    (collect_recent_tool_names metrics_lines)
+;;
+
+let keeper_tool_audit_fields
+      ?(include_allowed_tools = true)
+      config
+      (meta : Keeper_types.keeper_meta)
+  =
+  let fallback_allowed =
+    if include_allowed_tools then Keeper_exec_tools.keeper_allowed_tool_names meta else []
+  in
+  let recent_tool_names = recent_tool_names_from_files config meta.name in
+  let last_autonomous = String.trim meta.runtime.last_autonomous_action_at in
+  let fallback_snapshot =
+    match
+      Keeper_exec_status_metrics.latest_tool_audit_snapshot_from_files
+        config
+        ~keeper_name:meta.name
+    with
+    | Some snapshot ->
+      { snapshot with
+        tool_audit_at =
+          (match snapshot.tool_audit_source, snapshot.tool_audit_at with
+           | Some _, None when last_autonomous <> "" -> Some last_autonomous
+           | Some _, None -> Some meta.updated_at
+           | _ -> snapshot.tool_audit_at)
+      }
+    | None ->
+      let has_runtime_activity =
+        last_autonomous <> ""
+        || meta.runtime.autonomous_turn_count > 0
+        || meta.runtime.autonomous_action_count > 0
+      in
+      { Keeper_exec_status_metrics.empty_tool_audit_snapshot with
+        latest_tool_call_count = (if has_runtime_activity then Some 0 else None)
+      ; tool_audit_source =
+          (if has_runtime_activity then Some "keeper_runtime_meta" else None)
+      ; tool_audit_at =
+          (if last_autonomous <> ""
+           then Some last_autonomous
+           else if has_runtime_activity
+           then Some meta.updated_at
+           else None)
+      }
+  in
+  ( fallback_allowed
+  , recent_tool_names
+  , fallback_snapshot.latest_tool_names
+  , fallback_snapshot.latest_tool_call_count
+  , fallback_snapshot.latest_action_source
+  , fallback_snapshot.tool_audit_source
+  , fallback_snapshot.tool_audit_at )
 ;;
 
 let cached_tool_audit_json

--- a/lib/operator/operator_control_snapshot_tool_audit.mli
+++ b/lib/operator/operator_control_snapshot_tool_audit.mli
@@ -1,0 +1,21 @@
+(** Tool audit helpers for operator control snapshot. *)
+
+val lightweight_tool_audit_fallback_json :
+  Keeper_types.keeper_meta -> Yojson.Safe.t
+
+val recent_tool_names_from_files : Coord.config -> string -> string list
+
+val keeper_tool_audit_fields :
+  ?include_allowed_tools:bool ->
+  Coord.config ->
+  Keeper_types.keeper_meta ->
+  string list
+  * string list
+  * string list
+  * int option
+  * string option
+  * string option
+  * string option
+
+val cached_tool_audit_json :
+  lightweight:bool -> Coord.config -> Keeper_types.keeper_meta -> Yojson.Safe.t

--- a/lib/operator/operator_control_snapshot_tool_names.mli
+++ b/lib/operator/operator_control_snapshot_tool_names.mli
@@ -1,0 +1,5 @@
+(** Tool-name extraction + dedupe helpers for operator control snapshot. *)
+
+val merge_tool_name_lists : string list -> string list -> string list
+val tool_names_of_recent_json : Yojson.Safe.t -> string list
+val collect_recent_tool_names : ?limit:int -> string list -> string list

--- a/lib/server/server_runtime_bootstrap_legacy_migration.mli
+++ b/lib/server/server_runtime_bootstrap_legacy_migration.mli
@@ -1,0 +1,12 @@
+(** Legacy directory migration helpers for server runtime bootstrap. *)
+
+val keeper_meta_updated_ts : Keeper_types.keeper_meta -> float
+
+val should_promote_legacy_keeper_meta :
+  legacy_path:string -> current_path:string -> bool
+
+val migrate_legacy_dirs_with_renames :
+  Mcp_server.server_state -> (string * string) list -> unit
+
+val migrate_legacy_dirs : Mcp_server.server_state -> unit
+val migrate_legacy_keeper_dirs_blocking : Mcp_server.server_state -> unit

--- a/lib/tool_operator.mli
+++ b/lib/tool_operator.mli
@@ -71,6 +71,9 @@ val dispatch :
     safe-to-expose subset.  The full {!schemas} is consumed inside
     the keeper-bound dispatcher only. *)
 
+val schemas : Masc_domain.tool_schema list
+(** Full operator tool schemas for local/internal MCP catalogs. *)
+
 val remote_schemas : Masc_domain.tool_schema list
 (** Operator-remote tool schemas — the subset advertised to remote
     MCP clients.  Pinned at the .mli seam so dashboard / SDK

--- a/test/dune
+++ b/test/dune
@@ -1142,6 +1142,7 @@
   test_keeper_safety_gates
   test_keeper_guards
   test_keeper_working_state
+  test_keeper_wip_admission
   test_eval_gate_evasion
   test_prompt_registry_defaults
   test_keeper_prompt_external

--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -416,7 +416,7 @@ let test_dashboard_tools_projection () =
       | Some row ->
           check bool "local worker tool keeps local_worker surface" true
             (has_surface "local_worker" row));
-      (match deprecated_alias_tool with
+      (match removed_alias_tool with
       | None -> ()
       | Some row ->
           check bool "deprecated alias has registered schema" true


### PR DESCRIPTION
## Summary

Fixes #17222.

This repairs the current main CI blockers that were also blocking #17156:

- move the extracted operator tool-audit helpers into `operator_control_snapshot_tool_audit`, keeping parent aliases in `operator_control_snapshot`
- restore the `test_keeper_wip_admission` module registration in `test/dune`
- add small curated `.mli` files for newly extracted modules so the OCaml structure ratchet passes without regenerating the baseline

## Why

`operator_control_snapshot_tool_audit` was extracted into a sibling module but still called `keeper_tool_audit_fields` as if it lived in scope. CI then failed with `Unbound value keeper_tool_audit_fields`.

The test executable name `test_keeper_wip_admission` was present in the test stanza, but the `(modules ...)` list omitted the module, causing Dune to reject the stanza.

The structure ratchet also failed on newly extracted modules without sibling `.mli` files.

## Validation

- `opam exec -- ocamlformat --check ...`
- `git diff --check`
- `scripts/ocaml-structure-ratchet.sh`
- `scripts/lint-spawn-bounded.sh`

Local focused Dune compile was attempted with `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build lib/masc_mcp.cmxa test/test_keeper_wip_admission.exe`, but this machine's shared opam switch is currently pinned above this branch's expected `agent_sdk` floor. The compile reaches pre-existing SDK mismatch errors in files outside this PR (`Tool.evidence_role` missing in existing records), so CI is the authoritative build check for this branch pin.
