### PR TITLE
feat(dashboard): surface fleet and cdal blockers

### DIFF
--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -666,4 +666,48 @@ describe('dashboardHealthChips', () => {
       params: { section: 'fleet-health', view: 'keeper-health' },
     })
   })
+
+  it('surfaces CDAL proof and task-scope blockers as a routed health chip', () => {
+    const chips = dashboardHealthChips({
+      connected: true,
+      counts: { keepers: 2, configured_keepers: 2 },
+      keepers: [],
+      runtimeResolution: {
+        status: 'ready',
+        warnings: [],
+        fleet_safety: null,
+        cdal: {
+          writer_status: 'proof_store_incomplete',
+          operator_action_required: true,
+          proof_store_path_drift: false,
+          proof_store: {
+            status: 'stale_incomplete_runs',
+            completeness: {
+              incomplete_run_dirs: 6,
+              stale_incomplete_run_dirs: 3,
+              terminal_incomplete_run_dirs: 1,
+            },
+          },
+          task_scope: {
+            status: 'partial_task_scope',
+            current_writer_missing_task_scope_rows: 5,
+          },
+        },
+      } as any,
+      executionError: null,
+      loading: false,
+    })
+
+    const cdal = chips.find(c => c.key === 'cdal-runtime-health')
+    expect(cdal).toMatchObject({
+      label: 'CDAL proof incomplete 6',
+      tone: 'bad',
+      route: {
+        tab: 'monitoring',
+        params: { section: 'fleet-health' },
+      },
+    })
+    expect(cdal?.detail).toContain('stale=3')
+    expect(cdal?.detail).toContain('current_missing_task_scope=5')
+  })
 })

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -3,7 +3,7 @@ import { signal } from '@preact/signals'
 import { lazy, Suspense } from 'preact/compat'
 import { useEffect } from 'preact/hooks'
 import type { RouteState, TabId } from '../types'
-import type { DashboardFleetSafetyHealth, DashboardKeeperReactionLedgerHealth, DashboardRuntimeResolution, Keeper } from '../types'
+import type { DashboardCdalHealth, DashboardFleetSafetyHealth, DashboardKeeperReactionLedgerHealth, DashboardRuntimeResolution, Keeper } from '../types'
 import { hashForRoute, navigate, route } from '../router'
 import { connected, reconnectCount, lastDisconnectedAt } from '../sse'
 import { dashboardWsOnlyEnabled } from '../dashboard-ws-cutover'
@@ -344,6 +344,46 @@ function reactionLedgerHealthChip(
   }
 }
 
+function cdalHealthChip(cdal: DashboardCdalHealth | null | undefined): DashboardHealthChip | null {
+  if (!cdal) return null
+  const writerStatus = cdal.writer_status ?? 'unknown'
+  const proofStatus = cdal.proof_store?.status ?? 'unknown'
+  const taskStatus = cdal.task_scope?.status ?? 'unknown'
+  const incomplete = cdal.proof_store?.completeness?.incomplete_run_dirs ?? 0
+  const stale = cdal.proof_store?.completeness?.stale_incomplete_run_dirs ?? 0
+  const terminal = cdal.proof_store?.completeness?.terminal_incomplete_run_dirs ?? 0
+  const currentMissing = cdal.task_scope?.current_writer_missing_task_scope_rows ?? 0
+  const requiresAction = cdal.operator_action_required === true
+  if (!requiresAction && writerStatus === 'active' && incomplete === 0 && currentMissing === 0) {
+    return null
+  }
+  const tone: DashboardHealthChipTone =
+    requiresAction || stale > 0 || currentMissing > 0 ? 'bad' : terminal > 0 || incomplete > 0 ? 'warn' : 'ok'
+  const label = stale > 0 || terminal > 0 || incomplete > 0
+    ? `CDAL proof incomplete ${incomplete}`
+    : currentMissing > 0
+      ? `CDAL task scope ${currentMissing}`
+      : `CDAL ${writerStatus}`
+  return {
+    key: 'cdal-runtime-health',
+    label,
+    detail: [
+      `writer_status=${writerStatus}`,
+      `proof_store=${proofStatus}`,
+      `task_scope=${taskStatus}`,
+      `incomplete=${incomplete}`,
+      `stale=${stale}`,
+      `terminal=${terminal}`,
+      `current_missing_task_scope=${currentMissing}`,
+    ].join(', '),
+    tone,
+    route: {
+      tab: 'monitoring',
+      params: { section: 'fleet-health' },
+    },
+  }
+}
+
 // Drill-down routes for each chip key. Centralized so the builder stays
 // readable and tests can audit the routing table separately. Returning
 // undefined keeps the chip as a static span (transport-offline,
@@ -408,6 +448,11 @@ export function dashboardHealthChips(input: DashboardHealthInput): DashboardHeal
   const reactionLedgerChip = reactionLedgerHealthChip(runtime?.fleet_safety?.keeper_reaction_ledger)
   if (reactionLedgerChip) {
     chips.push(reactionLedgerChip)
+  }
+
+  const cdalChip = cdalHealthChip(runtime?.cdal)
+  if (cdalChip) {
+    chips.push(cdalChip)
   }
 
   const configured = input.counts?.configured_keepers ?? 0

--- a/dashboard/src/components/fleet-health-panel.test.ts
+++ b/dashboard/src/components/fleet-health-panel.test.ts
@@ -41,6 +41,11 @@ const fleetMock = vi.hoisted(() => {
   }
 })
 
+const storeMock = vi.hoisted(() => ({
+  shellRuntimeResolution: { value: null as any },
+  refreshShell: vi.fn(),
+}))
+
 function replaceRoute(tab: string, params?: Record<string, string>) {
   routeSignal.value = { tab, params: params ?? {}, postId: null }
   const query = new URLSearchParams(params ?? {}).toString()
@@ -67,6 +72,11 @@ vi.mock('./fleet-data-core', () => ({
   get sharedToolQualityError() { return fleetMock.sharedToolQualityError },
   refreshSharedToolQuality: fleetMock.refreshSharedToolQuality,
   cancelSharedToolQuality: fleetMock.cancelSharedToolQuality,
+}))
+
+vi.mock('../store', () => ({
+  get shellRuntimeResolution() { return storeMock.shellRuntimeResolution },
+  refreshShell: storeMock.refreshShell,
 }))
 
 // Mock child panels to avoid real fetch calls. Each renders a data-testid marker.
@@ -101,6 +111,8 @@ describe('FleetHealthPanel', () => {
     fleetMock.sharedToolQuality.value = fleetMock.sampleToolQuality
     fleetMock.sharedToolQualityLoading.value = false
     fleetMock.sharedToolQualityError.value = null
+    storeMock.shellRuntimeResolution.value = null
+    storeMock.refreshShell.mockClear()
     fleetMock.refreshSharedToolQuality.mockClear()
     fleetMock.cancelSharedToolQuality.mockClear()
   })
@@ -120,6 +132,113 @@ describe('FleetHealthPanel', () => {
     expect(screen.queryByTestId('tool-quality-panel')).toBeNull()
     expect(screen.queryByTestId('fleet-telemetry-panel')).toBeNull()
     expect(screen.queryByTestId('governance-monitor')).toBeNull()
+  })
+
+  it('renders runtime fleet and CDAL blocker drilldown on the operations board', () => {
+    storeMock.shellRuntimeResolution.value = {
+      status: 'ready',
+      warnings: [],
+      fleet_safety: {
+        keeper_fibers: 8,
+        paused_keepers: 3,
+        keeper_fleet_no_fibers: false,
+        keeper_fd_pressure: null,
+        keeper_reaction_ledger: null,
+        paused_keepers_health: {
+          count: 3,
+          names: ['analyst', 'base', 'sangsu'],
+          running_count: 0,
+          running_names: [],
+          durable_count: 3,
+          durable_names: ['analyst', 'base', 'sangsu'],
+          autoboot_enabled_count: 3,
+          autoboot_enabled_names: ['analyst', 'base', 'sangsu'],
+          read_error_count: 0,
+          read_errors: [],
+          details: [{
+            name: 'analyst',
+            autoboot_enabled: true,
+            pause_kind: 'timeout_recoverable',
+            auto_resume_after_sec: 60,
+            persisted_auto_resume_after_sec: null,
+            auto_resume_source: 'implicit_timeout',
+            paused_elapsed_sec: 12,
+            auto_resume_remaining_sec: 48,
+            last_blocker_class: 'turn_timeout',
+            last_blocker_detail: 'turn exceeded budget',
+            missing_pause_root_cause: false,
+          }],
+        },
+        keeper_fleet_safety: {
+          status: 'degraded',
+          reason: null,
+          blocker: 'reaction_capacity_below_target',
+          admission_blocked: null,
+          admission_blocked_keepers: null,
+          blocked_keepers: null,
+          blocked_count: null,
+          running_keeper_fiber_count: 8,
+          executable_keeper_fiber_count: 13,
+          effective_reaction_capacity_count: 8,
+          executable_reaction_capacity_count: 13,
+          target_reaction_capacity_count: 17,
+          reaction_capacity_shortfall_count: 9,
+          operator_action_required: true,
+          reaction_capacity_below_target: true,
+        },
+      },
+      cdal: {
+        writer_status: 'proof_store_incomplete',
+        operator_action_required: true,
+        proof_store_path_drift: false,
+        proof_store: {
+          root: '/Users/dancer/me/.oas',
+          proofs_dir: '/Users/dancer/me/.oas/proofs',
+          exists: true,
+          latest_activity_at: '2026-05-21T03:00:00Z',
+          latest_activity_unix: 1779332400,
+          age_seconds: 30,
+          status: 'stale_incomplete_runs',
+          completeness: {
+            scan_limit: 200,
+            run_dir_entries_seen: 200,
+            scan_truncated: false,
+            run_dirs_scanned: 200,
+            completed_run_dirs: 194,
+            incomplete_run_dirs: 6,
+            stale_incomplete_run_dirs: 3,
+            terminal_incomplete_run_dirs: 1,
+            missing_manifest_run_dirs: 6,
+            missing_contract_run_dirs: 6,
+            stale_incomplete_grace_seconds: 300,
+            sample_stale_incomplete_run_ids: ['cdal-stale-a'],
+            sample_terminal_incomplete_run_ids: ['cdal-abort-a'],
+          },
+        },
+        task_scope: {
+          status: 'present',
+          recent_limit: 500,
+          recent_rows: 500,
+          task_id_rows: 500,
+          missing_task_scope_rows: 0,
+          legacy_unscoped_rows: 0,
+          current_writer_missing_task_scope_rows: 0,
+          missing_task_scope: false,
+          partial_task_scope: false,
+          current_writer_missing_task_scope: false,
+          legacy_unscoped_only: false,
+        },
+      },
+    }
+
+    render(html`<${FleetHealthPanel} />`)
+
+    expect(storeMock.refreshShell).toHaveBeenCalledWith({ force: true })
+    expect(screen.getByTestId('runtime-blocker-board')).toBeTruthy()
+    expect(screen.getByText('8/17')).toBeTruthy()
+    expect(screen.getByText('analyst')).toBeTruthy()
+    expect(screen.getAllByText('proof_store_incomplete').length).toBeGreaterThan(0)
+    expect(screen.getByText(/cdal-stale-a/)).toBeTruthy()
   })
 
   it('renders TelemetryUnified alone for view=event-log', () => {

--- a/dashboard/src/components/fleet-health-panel.ts
+++ b/dashboard/src/components/fleet-health-panel.ts
@@ -10,6 +10,12 @@ import type { ToolQualityResponse } from '../api/dashboard'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
 import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { formatMsCompact, formatNumber } from '../lib/format-number'
+import { refreshShell, shellRuntimeResolution } from '../store'
+import type {
+  DashboardCdalHealth,
+  DashboardFleetSafetyHealth,
+  DashboardPausedKeeperDetail,
+} from '../types'
 import { FilterChips } from './common/filter-chips'
 import { RouteLink } from './common/route-link'
 import { StatTile } from './common/stat-tile'
@@ -274,6 +280,190 @@ function FailureCategoryList({ quality }: { quality: ToolQualityResponse | null 
   `
 }
 
+function countText(value: number | null | undefined): string {
+  return typeof value === 'number' && Number.isFinite(value) ? formatNumber(value) : '--'
+}
+
+function secondsText(value: number | null | undefined): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return '--'
+  if (value < 60) return `${Math.max(0, Math.round(value))}s`
+  if (value < 3600) return `${Math.round(value / 60)}m`
+  return `${Math.round(value / 3600)}h`
+}
+
+function compactList(values: string[], limit = 3): string {
+  if (values.length === 0) return '--'
+  const shown = values.slice(0, limit).join(', ')
+  return values.length > limit ? `${shown} +${values.length - limit}` : shown
+}
+
+function cdalTone(cdal: DashboardCdalHealth | null): 'crit' | 'warn' | 'ok' | undefined {
+  if (!cdal) return undefined
+  if (cdal.operator_action_required === true) return 'crit'
+  return cdal.writer_status === 'active' ? 'ok' : 'warn'
+}
+
+function pausedKindText(row: DashboardPausedKeeperDetail): string {
+  const parts = [
+    row.pause_kind ?? 'unknown',
+    row.last_blocker_class ? `blocker=${row.last_blocker_class}` : null,
+    row.auto_resume_source ? `resume=${row.auto_resume_source}` : null,
+  ].filter((part): part is string => part != null)
+  return parts.join(' · ')
+}
+
+function RuntimePausedKeeperTable({ fleetSafety }: { fleetSafety: DashboardFleetSafetyHealth | null }) {
+  const details = fleetSafety?.paused_keepers_health?.details ?? []
+  const readErrors = fleetSafety?.paused_keepers_health?.read_errors ?? []
+  if (details.length === 0 && readErrors.length === 0) {
+    return html`
+      <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-5 text-center text-2xs text-[var(--color-fg-muted)]">
+        No paused keeper detail rows.
+      </div>
+    `
+  }
+  return html`
+    <div class="overflow-x-auto rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]">
+      <table class="w-full text-2xs" aria-label="Paused keeper blockers">
+        <thead>
+          <tr class="border-b border-[var(--color-border-default)] text-[var(--color-fg-muted)]">
+            <th scope="col" class="px-3 py-2 text-left font-medium">Keeper</th>
+            <th scope="col" class="px-3 py-2 text-left font-medium">Pause</th>
+            <th scope="col" class="px-3 py-2 text-right font-medium">Elapsed</th>
+            <th scope="col" class="px-3 py-2 text-right font-medium">Resume</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${details.map(row => html`
+            <tr class="border-b border-[var(--color-border-default)]/30 last:border-b-0">
+              <td class="px-3 py-2 font-mono text-[var(--color-fg-primary)]">${row.name}</td>
+              <td class="px-3 py-2 text-[var(--color-fg-secondary)]" title=${row.last_blocker_detail ?? undefined}>${pausedKindText(row)}</td>
+              <td class="px-3 py-2 text-right font-mono text-[var(--color-fg-muted)]">${secondsText(row.paused_elapsed_sec)}</td>
+              <td class="px-3 py-2 text-right font-mono text-[var(--color-fg-muted)]">${secondsText(row.auto_resume_remaining_sec)}</td>
+            </tr>
+          `)}
+          ${readErrors.map(row => html`
+            <tr class="border-b border-[var(--color-border-default)]/30 last:border-b-0">
+              <td class="px-3 py-2 font-mono text-[var(--bad-light)]">${row.keeper}</td>
+              <td class="px-3 py-2 text-[var(--bad-light)]" colspan="3">${row.error}</td>
+            </tr>
+          `)}
+        </tbody>
+      </table>
+    </div>
+  `
+}
+
+function RuntimeCdalBlock({ cdal }: { cdal: DashboardCdalHealth | null }) {
+  const proof = cdal?.proof_store
+  const completeness = proof?.completeness
+  const task = cdal?.task_scope
+  const staleSamples = completeness?.sample_stale_incomplete_run_ids ?? []
+  const terminalSamples = completeness?.sample_terminal_incomplete_run_ids ?? []
+  if (!cdal) {
+    return html`
+      <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-5 text-center text-2xs text-[var(--color-fg-muted)]">
+        CDAL runtime snapshot unavailable.
+      </div>
+    `
+  }
+  return html`
+    <div class="grid gap-2 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] p-3 text-2xs">
+      <div class="flex flex-wrap items-center justify-between gap-2">
+        <span class="font-mono text-[var(--color-fg-primary)]">${cdal.writer_status ?? 'unknown'}</span>
+        <${StatusChip}
+          label=${cdal.operator_action_required ? 'action' : 'ok'}
+          tone=${cdal.operator_action_required ? 'warn' : 'ok'}
+        />
+      </div>
+      <div class="grid gap-1 text-[var(--color-fg-muted)]">
+        <div class="flex justify-between gap-3">
+          <span>Proof store</span>
+          <span class="font-mono text-[var(--color-fg-secondary)]">${proof?.status ?? 'unknown'}</span>
+        </div>
+        <div class="flex justify-between gap-3">
+          <span>Incomplete</span>
+          <span class="font-mono text-[var(--color-fg-secondary)]">
+            ${countText(completeness?.incomplete_run_dirs)}
+            <span class="text-[var(--color-fg-disabled)]"> stale ${countText(completeness?.stale_incomplete_run_dirs)} · terminal ${countText(completeness?.terminal_incomplete_run_dirs)}</span>
+          </span>
+        </div>
+        <div class="flex justify-between gap-3">
+          <span>Task scope</span>
+          <span class="font-mono text-[var(--color-fg-secondary)]">
+            ${task?.status ?? 'unknown'}
+            <span class="text-[var(--color-fg-disabled)]"> missing ${countText(task?.missing_task_scope_rows)} · current ${countText(task?.current_writer_missing_task_scope_rows)}</span>
+          </span>
+        </div>
+        ${staleSamples.length > 0 ? html`
+          <div class="truncate" title=${staleSamples.join(', ')}>stale samples: <span class="font-mono text-[var(--color-fg-secondary)]">${compactList(staleSamples)}</span></div>
+        ` : null}
+        ${terminalSamples.length > 0 ? html`
+          <div class="truncate" title=${terminalSamples.join(', ')}>terminal samples: <span class="font-mono text-[var(--color-fg-secondary)]">${compactList(terminalSamples)}</span></div>
+        ` : null}
+      </div>
+    </div>
+  `
+}
+
+function RuntimeBlockerBoard() {
+  useEffect(() => {
+    void refreshShell({ force: true })
+  }, [])
+
+  const runtime = shellRuntimeResolution.value
+  const fleetSafety = runtime?.fleet_safety ?? null
+  const fleet = fleetSafety?.keeper_fleet_safety
+  const pausedHealth = fleetSafety?.paused_keepers_health
+  const cdal = runtime?.cdal ?? null
+  const effective = fleet?.effective_reaction_capacity_count ?? fleet?.running_keeper_fiber_count ?? fleetSafety?.keeper_fibers
+  const executable = fleet?.executable_reaction_capacity_count ?? fleet?.executable_keeper_fiber_count
+  const target = fleet?.target_reaction_capacity_count ?? fleet?.autoboot_enabled_keeper_count
+  const shortfall = fleet?.reaction_capacity_shortfall_count
+  const pausedCount = pausedHealth?.count ?? fleet?.paused_keeper_count ?? fleetSafety?.paused_keepers
+  const pausedNames = pausedHealth?.names ?? []
+  const capacityStatus = fleet?.status === 'blocked'
+    ? 'crit'
+    : fleet?.operator_action_required || fleet?.reaction_capacity_below_target
+      ? 'warn'
+      : fleet ? 'ok' : undefined
+
+  return html`
+    <section class="grid gap-3" data-testid="runtime-blocker-board">
+      <div class="grid grid-cols-1 gap-3 lg:grid-cols-3">
+        <${StatTile}
+          label="Reaction capacity"
+          value=${`${countText(effective)}/${countText(target)}`}
+          status=${capacityStatus}
+          delta=${{ direction: capacityStatus === 'ok' ? 'up' : 'down', text: `exec ${countText(executable)} · short ${countText(shortfall)}` }}
+        />
+        <${StatTile}
+          label="Paused keepers"
+          value=${countText(pausedCount)}
+          status=${pausedCount && pausedCount > 0 ? 'warn' : 'ok'}
+          delta=${{ direction: pausedCount && pausedCount > 0 ? 'down' : 'flat', text: compactList(pausedNames) }}
+        />
+        <${StatTile}
+          label="CDAL writer"
+          value=${cdal?.writer_status ?? '--'}
+          status=${cdalTone(cdal)}
+          delta=${{ direction: cdal?.operator_action_required ? 'down' : 'flat', text: cdal?.proof_store?.status ?? 'proof unknown' }}
+        />
+      </div>
+      <div class="grid grid-cols-1 gap-3 xl:grid-cols-[minmax(0,1.1fr)_minmax(18rem,0.9fr)]">
+        <div>
+          <div class="mb-2 text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Paused keeper blockers</div>
+          <${RuntimePausedKeeperTable} fleetSafety=${fleetSafety} />
+        </div>
+        <div>
+          <div class="mb-2 text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">CDAL blockers</div>
+          <${RuntimeCdalBlock} cdal=${cdal} />
+        </div>
+      </div>
+    </section>
+  `
+}
+
 function ToolMonitorDefaultBoard() {
   useEffect(() => {
     const controller = new AbortController()
@@ -368,6 +558,8 @@ function ToolMonitorDefaultBoard() {
           />
         </div>
       </div>
+
+      <${RuntimeBlockerBoard} />
 
       <div class="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1.45fr)_minmax(18rem,0.8fr)]">
         <div class="min-w-0">

--- a/dashboard/src/store-normalizers.test.ts
+++ b/dashboard/src/store-normalizers.test.ts
@@ -157,6 +157,31 @@ describe('normalizeDashboardRuntimeResolution fleet safety', () => {
     const result = normalizeDashboardRuntimeResolution(runtimeResolutionRaw({
       keeper_fibers: 1,
       paused_keepers: 3,
+      paused_keepers_health: {
+        count: 3,
+        names: ['analyst', 'base', 'sangsu'],
+        running_count: 0,
+        running_names: [],
+        durable_count: 3,
+        durable_names: ['analyst', 'base', 'sangsu'],
+        autoboot_enabled_count: 3,
+        autoboot_enabled_names: ['analyst', 'base', 'sangsu'],
+        details: [{
+          name: 'analyst',
+          autoboot_enabled: true,
+          pause_kind: 'timeout_recoverable',
+          auto_resume_after_sec: 60,
+          persisted_auto_resume_after_sec: null,
+          auto_resume_source: 'implicit_timeout',
+          paused_elapsed_sec: 12,
+          auto_resume_remaining_sec: 48,
+          last_blocker_class: 'turn_timeout',
+          last_blocker_detail: 'turn exceeded budget',
+          missing_pause_root_cause: false,
+        }],
+        read_error_count: 0,
+        read_errors: [],
+      },
       keeper_fleet_no_fibers: false,
       keeper_fd_pressure: {
         status: 'blocked',
@@ -209,6 +234,16 @@ describe('normalizeDashboardRuntimeResolution fleet safety', () => {
       keeper_fibers: 1,
       paused_keepers: 3,
       keeper_fleet_no_fibers: false,
+      paused_keepers_health: {
+        count: 3,
+        names: ['analyst', 'base', 'sangsu'],
+        details: [{
+          name: 'analyst',
+          pause_kind: 'timeout_recoverable',
+          auto_resume_source: 'implicit_timeout',
+          last_blocker_class: 'turn_timeout',
+        }],
+      },
       keeper_fd_pressure: {
         status: 'blocked',
         reason: 'fd_pressure',
@@ -247,6 +282,74 @@ describe('normalizeDashboardRuntimeResolution fleet safety', () => {
         legacy_cursor_swept_stimulus_count: 1,
         pending_stimulus_count: 0,
         read_error_count: 0,
+      },
+    })
+  })
+
+  it('parses CDAL proof and task-scope blocker fields', () => {
+    const result = normalizeDashboardRuntimeResolution(runtimeResolutionRaw({
+      cdal: {
+        writer_status: 'proof_store_incomplete',
+        operator_action_required: true,
+        proof_store_path_drift: false,
+        proof_store: {
+          root: '/Users/dancer/me/.oas',
+          proofs_dir: '/Users/dancer/me/.oas/proofs',
+          exists: true,
+          latest_activity_at: '2026-05-21T03:00:00Z',
+          latest_activity_unix: 1779332400,
+          age_seconds: 30,
+          status: 'stale_incomplete_runs',
+          completeness: {
+            scan_limit: 200,
+            run_dir_entries_seen: 200,
+            scan_truncated: false,
+            run_dirs_scanned: 200,
+            completed_run_dirs: 194,
+            incomplete_run_dirs: 6,
+            stale_incomplete_run_dirs: 3,
+            terminal_incomplete_run_dirs: 1,
+            missing_manifest_run_dirs: 6,
+            missing_contract_run_dirs: 6,
+            stale_incomplete_grace_seconds: 300,
+            sample_stale_incomplete_run_ids: ['cdal-stale-a'],
+            sample_terminal_incomplete_run_ids: ['cdal-abort-a'],
+          },
+        },
+        task_scope: {
+          status: 'partial_task_scope',
+          recent_limit: 500,
+          recent_rows: 500,
+          task_id_rows: 225,
+          missing_task_scope_rows: 275,
+          legacy_unscoped_rows: 270,
+          current_writer_missing_task_scope_rows: 5,
+          missing_task_scope: true,
+          partial_task_scope: true,
+          current_writer_missing_task_scope: true,
+          legacy_unscoped_only: false,
+        },
+      },
+    }))
+
+    expect(result?.cdal).toMatchObject({
+      writer_status: 'proof_store_incomplete',
+      operator_action_required: true,
+      proof_store: {
+        status: 'stale_incomplete_runs',
+        completeness: {
+          incomplete_run_dirs: 6,
+          stale_incomplete_run_dirs: 3,
+          terminal_incomplete_run_dirs: 1,
+          sample_stale_incomplete_run_ids: ['cdal-stale-a'],
+          sample_terminal_incomplete_run_ids: ['cdal-abort-a'],
+        },
+      },
+      task_scope: {
+        status: 'partial_task_scope',
+        legacy_unscoped_rows: 270,
+        current_writer_missing_task_scope_rows: 5,
+        current_writer_missing_task_scope: true,
       },
     })
   })

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -9,10 +9,17 @@ import type {
   DashboardExecutionContinuityBrief,
   DashboardConfigResolution,
   DashboardConfigResolutionItem,
+  DashboardCdalHealth,
+  DashboardCdalProofCompleteness,
+  DashboardCdalProofStoreHealth,
+  DashboardCdalTaskScopeHealth,
   DashboardFleetPressureHealth,
   DashboardFleetSafetyHealth,
   DashboardKeeperReactionLedgerHealth,
   DashboardKeeperReactionLedgerPendingKeeper,
+  DashboardPausedKeeperDetail,
+  DashboardPausedKeeperReadError,
+  DashboardPausedKeepersHealth,
   DashboardRuntimeDiagnostic,
   DashboardRuntimeResolution,
   KeeperRuntimeResolved,
@@ -598,6 +605,81 @@ export function normalizeDashboardRuntimeResolution(
     build,
     keeper_runtime: normalizeKeeperRuntimeResolved(raw.keeper_runtime),
     fleet_safety: normalizeDashboardFleetSafetyHealth(raw),
+    cdal: normalizeDashboardCdalHealth(raw.cdal),
+  }
+}
+
+function normalizeDashboardPausedKeeperDetail(raw: unknown): DashboardPausedKeeperDetail | null {
+  if (!isRecord(raw)) return null
+  const name = asString(raw.name)
+  if (!name) return null
+  return {
+    name,
+    autoboot_enabled: asBoolean(raw.autoboot_enabled) ?? null,
+    pause_kind: asString(raw.pause_kind) ?? null,
+    auto_resume_after_sec: asNumber(raw.auto_resume_after_sec) ?? null,
+    persisted_auto_resume_after_sec: asNumber(raw.persisted_auto_resume_after_sec) ?? null,
+    auto_resume_source: asString(raw.auto_resume_source) ?? null,
+    paused_elapsed_sec: asNumber(raw.paused_elapsed_sec) ?? null,
+    auto_resume_remaining_sec: asNumber(raw.auto_resume_remaining_sec) ?? null,
+    last_blocker_class: asString(raw.last_blocker_class) ?? null,
+    last_blocker_detail: asString(raw.last_blocker_detail) ?? null,
+    missing_pause_root_cause: asBoolean(raw.missing_pause_root_cause) ?? null,
+  }
+}
+
+function normalizeDashboardPausedKeeperReadError(raw: unknown): DashboardPausedKeeperReadError | null {
+  if (!isRecord(raw)) return null
+  const keeper = asString(raw.keeper)
+  const error = asString(raw.error)
+  if (!keeper || !error) return null
+  return { keeper, error }
+}
+
+function normalizeDashboardPausedKeepersHealth(raw: unknown): DashboardPausedKeepersHealth | null {
+  if (!isRecord(raw)) return null
+  const details = (Array.isArray(raw.details) ? raw.details : [])
+    .map(normalizeDashboardPausedKeeperDetail)
+    .filter((item): item is DashboardPausedKeeperDetail => item !== null)
+  const readErrors = (Array.isArray(raw.read_errors) ? raw.read_errors : [])
+    .map(normalizeDashboardPausedKeeperReadError)
+    .filter((item): item is DashboardPausedKeeperReadError => item !== null)
+  const names = asStringArray(raw.names)
+  const runningNames = asStringArray(raw.running_names)
+  const durableNames = asStringArray(raw.durable_names)
+  const autobootEnabledNames = asStringArray(raw.autoboot_enabled_names)
+  const count = asNumber(raw.count)
+  const runningCount = asNumber(raw.running_count)
+  const durableCount = asNumber(raw.durable_count)
+  const autobootEnabledCount = asNumber(raw.autoboot_enabled_count)
+  const readErrorCount = asNumber(raw.read_error_count)
+  if (
+    count == null
+    && runningCount == null
+    && durableCount == null
+    && autobootEnabledCount == null
+    && readErrorCount == null
+    && names.length === 0
+    && runningNames.length === 0
+    && durableNames.length === 0
+    && autobootEnabledNames.length === 0
+    && details.length === 0
+    && readErrors.length === 0
+  ) {
+    return null
+  }
+  return {
+    count: count ?? null,
+    names,
+    running_count: runningCount ?? null,
+    running_names: runningNames,
+    durable_count: durableCount ?? null,
+    durable_names: durableNames,
+    autoboot_enabled_count: autobootEnabledCount ?? null,
+    autoboot_enabled_names: autobootEnabledNames,
+    details,
+    read_error_count: readErrorCount ?? null,
+    read_errors: readErrors,
   }
 }
 
@@ -782,6 +864,7 @@ function normalizeDashboardKeeperReactionLedgerHealth(
 function normalizeDashboardFleetSafetyHealth(raw: Record<string, unknown>): DashboardFleetSafetyHealth | null {
   const keeperFibers = asNumber(raw.keeper_fibers)
   const pausedKeepers = asNumber(raw.paused_keepers)
+  const pausedKeepersHealth = normalizeDashboardPausedKeepersHealth(raw.paused_keepers_health)
   const noFibers = asBoolean(raw.keeper_fleet_no_fibers)
   const fdPressure = normalizeDashboardFleetPressureHealth(raw.keeper_fd_pressure)
   const fleetSafety = normalizeDashboardFleetPressureHealth(raw.keeper_fleet_safety)
@@ -789,6 +872,7 @@ function normalizeDashboardFleetSafetyHealth(raw: Record<string, unknown>): Dash
   if (
     keeperFibers == null
     && pausedKeepers == null
+    && pausedKeepersHealth == null
     && noFibers == null
     && fdPressure == null
     && fleetSafety == null
@@ -799,10 +883,105 @@ function normalizeDashboardFleetSafetyHealth(raw: Record<string, unknown>): Dash
   return {
     keeper_fibers: keeperFibers ?? null,
     paused_keepers: pausedKeepers ?? null,
+    paused_keepers_health: pausedKeepersHealth,
     keeper_fleet_no_fibers: noFibers ?? null,
     keeper_fd_pressure: fdPressure,
     keeper_fleet_safety: fleetSafety,
     keeper_reaction_ledger: reactionLedger,
+  }
+}
+
+function normalizeDashboardCdalProofCompleteness(raw: unknown): DashboardCdalProofCompleteness | null {
+  if (!isRecord(raw)) return null
+  const incomplete = asNumber(raw.incomplete_run_dirs)
+  const stale = asNumber(raw.stale_incomplete_run_dirs)
+  const terminal = asNumber(raw.terminal_incomplete_run_dirs)
+  const samples = asStringArray(raw.sample_stale_incomplete_run_ids)
+  const terminalSamples = asStringArray(raw.sample_terminal_incomplete_run_ids)
+  if (incomplete == null && stale == null && terminal == null && samples.length === 0 && terminalSamples.length === 0) {
+    return null
+  }
+  return {
+    scan_limit: asNumber(raw.scan_limit) ?? null,
+    run_dir_entries_seen: asNumber(raw.run_dir_entries_seen) ?? null,
+    scan_truncated: asBoolean(raw.scan_truncated) ?? null,
+    run_dirs_scanned: asNumber(raw.run_dirs_scanned) ?? null,
+    completed_run_dirs: asNumber(raw.completed_run_dirs) ?? null,
+    incomplete_run_dirs: incomplete ?? null,
+    stale_incomplete_run_dirs: stale ?? null,
+    terminal_incomplete_run_dirs: terminal ?? null,
+    missing_manifest_run_dirs: asNumber(raw.missing_manifest_run_dirs) ?? null,
+    missing_contract_run_dirs: asNumber(raw.missing_contract_run_dirs) ?? null,
+    stale_incomplete_grace_seconds: asNumber(raw.stale_incomplete_grace_seconds) ?? null,
+    sample_stale_incomplete_run_ids: samples,
+    sample_terminal_incomplete_run_ids: terminalSamples,
+  }
+}
+
+function normalizeDashboardCdalProofStoreHealth(raw: unknown): DashboardCdalProofStoreHealth | null {
+  if (!isRecord(raw)) return null
+  const status = asString(raw.status) ?? null
+  const completeness = normalizeDashboardCdalProofCompleteness(raw.completeness)
+  if (status == null && completeness == null) return null
+  return {
+    root: asString(raw.root) ?? null,
+    proofs_dir: asString(raw.proofs_dir) ?? null,
+    exists: asBoolean(raw.exists) ?? null,
+    latest_activity_at: asString(raw.latest_activity_at) ?? null,
+    latest_activity_unix: asNumber(raw.latest_activity_unix) ?? null,
+    age_seconds: asNumber(raw.age_seconds) ?? null,
+    status,
+    completeness,
+  }
+}
+
+function normalizeDashboardCdalTaskScopeHealth(raw: unknown): DashboardCdalTaskScopeHealth | null {
+  if (!isRecord(raw)) return null
+  const status = asString(raw.status) ?? null
+  const recentRows = asNumber(raw.recent_rows)
+  const missingRows = asNumber(raw.missing_task_scope_rows)
+  const legacyRows = asNumber(raw.legacy_unscoped_rows)
+  const currentMissingRows = asNumber(raw.current_writer_missing_task_scope_rows)
+  if (status == null && recentRows == null && missingRows == null && legacyRows == null && currentMissingRows == null) {
+    return null
+  }
+  return {
+    status,
+    recent_limit: asNumber(raw.recent_limit) ?? null,
+    recent_rows: recentRows ?? null,
+    task_id_rows: asNumber(raw.task_id_rows) ?? null,
+    missing_task_scope_rows: missingRows ?? null,
+    legacy_unscoped_rows: legacyRows ?? null,
+    current_writer_missing_task_scope_rows: currentMissingRows ?? null,
+    missing_task_scope: asBoolean(raw.missing_task_scope) ?? null,
+    partial_task_scope: asBoolean(raw.partial_task_scope) ?? null,
+    current_writer_missing_task_scope: asBoolean(raw.current_writer_missing_task_scope) ?? null,
+    legacy_unscoped_only: asBoolean(raw.legacy_unscoped_only) ?? null,
+  }
+}
+
+function normalizeDashboardCdalHealth(raw: unknown): DashboardCdalHealth | null {
+  if (!isRecord(raw)) return null
+  const writerStatus = asString(raw.writer_status) ?? null
+  const operatorActionRequired = asBoolean(raw.operator_action_required) ?? null
+  const proofStore = normalizeDashboardCdalProofStoreHealth(raw.proof_store)
+  const taskScope = normalizeDashboardCdalTaskScopeHealth(raw.task_scope)
+  const proofStorePathDrift = asBoolean(raw.proof_store_path_drift) ?? null
+  if (
+    writerStatus == null
+    && operatorActionRequired == null
+    && proofStorePathDrift == null
+    && proofStore == null
+    && taskScope == null
+  ) {
+    return null
+  }
+  return {
+    writer_status: writerStatus,
+    operator_action_required: operatorActionRequired,
+    proof_store_path_drift: proofStorePathDrift,
+    proof_store: proofStore,
+    task_scope: taskScope,
   }
 }
 

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -117,15 +117,99 @@ export interface DashboardRuntimeResolution {
   build: ServerBuildIdentity
   keeper_runtime: KeeperRuntimeResolved | null
   fleet_safety: DashboardFleetSafetyHealth | null
+  cdal: DashboardCdalHealth | null
 }
 
 export interface DashboardFleetSafetyHealth {
   keeper_fibers: number | null
   paused_keepers: number | null
+  paused_keepers_health: DashboardPausedKeepersHealth | null
   keeper_fleet_no_fibers: boolean | null
   keeper_fd_pressure: DashboardFleetPressureHealth | null
   keeper_fleet_safety: DashboardFleetPressureHealth | null
   keeper_reaction_ledger: DashboardKeeperReactionLedgerHealth | null
+}
+
+export interface DashboardPausedKeeperDetail {
+  name: string
+  autoboot_enabled: boolean | null
+  pause_kind: string | null
+  auto_resume_after_sec: number | null
+  persisted_auto_resume_after_sec: number | null
+  auto_resume_source: string | null
+  paused_elapsed_sec: number | null
+  auto_resume_remaining_sec: number | null
+  last_blocker_class: string | null
+  last_blocker_detail: string | null
+  missing_pause_root_cause: boolean | null
+}
+
+export interface DashboardPausedKeeperReadError {
+  keeper: string
+  error: string
+}
+
+export interface DashboardPausedKeepersHealth {
+  count: number | null
+  names: string[]
+  running_count: number | null
+  running_names: string[]
+  durable_count: number | null
+  durable_names: string[]
+  autoboot_enabled_count: number | null
+  autoboot_enabled_names: string[]
+  details: DashboardPausedKeeperDetail[]
+  read_error_count: number | null
+  read_errors: DashboardPausedKeeperReadError[]
+}
+
+export interface DashboardCdalProofCompleteness {
+  scan_limit: number | null
+  run_dir_entries_seen: number | null
+  scan_truncated: boolean | null
+  run_dirs_scanned: number | null
+  completed_run_dirs: number | null
+  incomplete_run_dirs: number | null
+  stale_incomplete_run_dirs: number | null
+  terminal_incomplete_run_dirs: number | null
+  missing_manifest_run_dirs: number | null
+  missing_contract_run_dirs: number | null
+  stale_incomplete_grace_seconds: number | null
+  sample_stale_incomplete_run_ids: string[]
+  sample_terminal_incomplete_run_ids: string[]
+}
+
+export interface DashboardCdalProofStoreHealth {
+  root: string | null
+  proofs_dir: string | null
+  exists: boolean | null
+  latest_activity_at: string | null
+  latest_activity_unix: number | null
+  age_seconds: number | null
+  status: string | null
+  completeness: DashboardCdalProofCompleteness | null
+}
+
+export interface DashboardCdalTaskScopeHealth {
+  status: string | null
+  recent_limit: number | null
+  recent_rows: number | null
+  task_id_rows: number | null
+  missing_task_scope_rows: number | null
+  legacy_unscoped_rows: number | null
+  current_writer_missing_task_scope_rows: number | null
+  missing_task_scope: boolean | null
+  partial_task_scope: boolean | null
+  current_writer_missing_task_scope: boolean | null
+  legacy_unscoped_only: boolean | null
+}
+
+export interface DashboardCdalHealth {
+  writer_status: string | null
+  operator_action_required: boolean | null
+  proof_store_path_drift: boolean | null
+  proof_store: DashboardCdalProofStoreHealth | null
+  task_scope: DashboardCdalTaskScopeHealth | null
 }
 
 export interface DashboardKeeperReactionLedgerPendingKeeper {

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -875,6 +875,7 @@ let runtime_resolution_json (config : Coord.config) =
       ; ( "deployment_state"
         , deployment_state_json ~build ~server_repo_commit ~workspace_commit
             ~resolved_base_commit ~upstream_status ~source_mismatch )
+      ; "cdal", Server_routes_http_runtime.cdal_health_json ()
       ]
       @ Server_routes_http_runtime.keeper_fleet_runtime_resolution_fields () )
 ;;

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -822,6 +822,7 @@ let keeper_fleet_runtime_resolution_base_fields
   let fields =
     [ "keeper_fibers", `Int keeper_fibers
     ; "paused_keepers", `Int (paused_keeper_count paused_keepers_json)
+    ; "paused_keepers_health", paused_keepers_json
     ; "keeper_fleet_no_fibers", `Bool (bool_field "no_running_fibers" fleet_safety)
     ; ( "keeper_fd_pressure"
       , Keeper_fd_pressure.runtime_state_json ~active_keepers:keeper_fibers

--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -250,6 +250,10 @@ let test_dashboard_tools_projection () =
         (match runtime_resolution |> member "paused_keepers" with
          | `Int _ -> true
          | _ -> false);
+      check bool "runtime paused_keepers health surfaced" true
+        (match runtime_resolution |> member "paused_keepers_health" with
+         | `Assoc _ -> true
+         | _ -> false);
       check bool "runtime keeper fd pressure surfaced" true
         (match runtime_resolution |> member "keeper_fd_pressure" with
          | `Assoc _ -> true
@@ -271,6 +275,10 @@ let test_dashboard_tools_projection () =
          | _ -> false);
       check bool "runtime keeper reaction ledger surfaced" true
         (match runtime_resolution |> member "keeper_reaction_ledger" with
+         | `Assoc _ -> true
+         | _ -> false);
+      check bool "runtime cdal health surfaced" true
+        (match runtime_resolution |> member "cdal" with
          | `Assoc _ -> true
          | _ -> false);
       check bool "build started_at surfaced" true


### PR DESCRIPTION
## Summary
- add paused keeper detail and CDAL health to dashboard runtime resolution
- render fleet capacity, paused keeper blockers, and CDAL proof/task-scope blockers on Fleet Health operations
- add health-strip CDAL warning chip and normalizer coverage

## Validation
- git diff --check
- ocamlformat --check lib/server/server_routes_http_runtime.ml lib/server/server_dashboard_http_runtime_info.ml test/test_dashboard_tools.ml
- bash scripts/ocaml-structure-ratchet.sh
- pnpm install --offline (dashboard worktree dependency hydration)
- pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/store-normalizers.test.ts src/components/dashboard-shell.test.ts src/components/fleet-health-panel.test.ts
- pnpm typecheck
- pnpm exec eslint src/components/fleet-health-panel.ts src/components/dashboard-shell.ts src/store-normalizers.ts src/components/fleet-health-panel.test.ts src/components/dashboard-shell.test.ts src/store-normalizers.test.ts (0 errors; some files ignored by eslint config)

## Known local blocker
- scripts/dune-local.sh build test/test_dashboard_tools.exe is blocked by local agent_sdk pin drift: installed OAS 6d952cb9 / agent_sdk 0.196.7 while this stack still expects 3f60ad9 / 0.196.4. Separate draft PR #17242 contains the pin/API compatibility bump.