### PR TITLE
fix: unblock origin/main build (4 pre-existing errors)

### DIFF
--- a/lib/coord/coord_task_verification.ml
+++ b/lib/coord/coord_task_verification.ml
@@ -5,6 +5,7 @@
     [transition_task_r] when validating submission/verification flows. *)
 
 open Masc_domain
+include Coord_state
 
 let flatten_lock_result = function
   | Ok result -> result


### PR DESCRIPTION
# fix: unblock origin/main build (4 pre-existing errors)

## Summary

main `12396b70f4`가 4개 누락된 stanza/include/match arm 때문에 `dune build @check`가 실패하던 상태를, 4건의 surgical patch로 unblock합니다.

## Why

- Team FFF, Team DDD, Team EEE가 각각 독립 sweep으로 동일한 main 빌드 실패를 재현 확인.
- Team HHH가 위 3팀이 놓친 4번째 에러를 추가 발견: `test_dashboard_tools.ml` 내 `deprecated_alias_tool` rename mismatch (선언/사용 간 식별자 불일치).
- 4 에러 모두 main HEAD 상태에 기존 존재하던 것으로, 본 PR로 신규 도입되지 않습니다. fix는 각각 기존 패턴/대칭의 복원입니다.

## Files Changed

- `test/dune` (+1): `modules` 스탠자에 누락된 테스트 엔트리 추가 (기존 패턴 그대로 따름).
- `lib/coord/dune` (+1): `modules` 스탠자에 누락된 모듈 엔트리 추가.
- `lib/coord/coord_task_verification.ml` (+1): `include Coord_state` 추가. line 89의 타입 사용처와 일치시키는 복원.
- `lib/keeper/keeper_turn_driver.ml` (+3): `(Observe, false, *)` match arm 추가. 기존 `Enforce` 분기의 대칭형.
- `test/test_dashboard_tools.ml` (+6/-1): L383 binding과 일치하도록 symbol rename.

Total: 5 files, +12/-1.

## Tests

- `dune build @check` clean.
- `test_keeper_working_state.exe`가 cleanly link됨 (이전엔 모듈 미선언으로 링크 실패).

## Risk

Minimal. 각 fix는 새 동작 추가가 아닌 깨진 대칭의 복원입니다:

- `test/dune`, `lib/coord/dune` modules 엔트리는 동일 stanza 내 다른 모듈과 동일 패턴.
- `coord_task_verification.ml`의 `include Coord_state`는 같은 파일 line 89에서 이미 의존하는 타입을 표면화.
- `keeper_turn_driver.ml`의 `(Observe, false, *)` arm은 인접한 `Enforce` 분기의 mirror.
- `test_dashboard_tools.ml`의 rename은 L383 정의와의 일관성 회복.

## Anti-pattern Self-check (software-development.md §워크어라운드 거부)

1. 텔레메트리-as-fix: **NO** — counter/log 추가 없음.
2. String/Substring 분류기 보강: **NO** — string match 추가 없음.
3. N-of-M 패치: **NO** — 식별된 4 에러 전부 본 PR에서 해소.
4. Catch-all `_ ->` 추가: **NO** — 명시적 `(Observe, false, *)` arm.
5. Cap/cooldown/dedup/repair: **NO**.
6. Test backdoor 노출: **NO**.
7. 같은 typo를 N개 사이트에서 N번 fix: **NO** — 각 에러는 독립적.

## RFC Waiver

해당 없음. 변경 영역(`test/`, `lib/coord/`, `lib/keeper/keeper_turn_driver.ml`)은 workflow-pr.md §11이 열거하는 RFC 게이트 subsystem(credential / identity / repo_manager / operator_control / keeper_sandbox / keeper_shell / dashboard credential / `.claude/hooks/` / `instructions/workflow*`)에 포함되지 않습니다.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
