### PR TITLE
fix(env_config): bump full_health_refresh_timeout default 8s -> 20s

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -783,12 +783,19 @@ module Dashboard = struct
 
       Caps a single [/health?full=1] cache refresh attempt in
       [Server_routes_http_runtime.start_full_health_snapshot_refresh_loop].
-      Default 8s keeps this proactive refresh independent from the
-      dashboard shell render timeout. Floor 1s prevents degenerate
-      operator overrides. *)
+      Default 20s (bumped from 8s) reduces F-6 fan-in tail: make_health_json
+      synchronously fans 17 components, and Team BBBB2 observed 27% tail
+      at 16s live override (307/24h timeouts). Bumping the floor default
+      to 20s is the bridge expected to drop tail to <10% (<50/24h).
+      Floor 1s prevents degenerate operator overrides.
+
+      WORKAROUND: This is a cap raise (§4 anti-pattern signature) accepted
+      as bridge until structural RFC lands (per-component health cache so
+      make_health_json no longer fans 17 sync calls per refresh).
+      Removal target: per-component health cache RFC (TBD). *)
   let full_health_refresh_timeout_sec =
     Float.max 1.0
-      (get_float ~default:8.0 "MASC_FULL_HEALTH_REFRESH_TIMEOUT_SEC")
+      (get_float ~default:20.0 "MASC_FULL_HEALTH_REFRESH_TIMEOUT_SEC")
 
   (** Number of consecutive [/health?full=1] cache-refresh failures
       that must accumulate before


### PR DESCRIPTION
# fix(env_config): bump full_health_refresh_timeout default 8s → 20s

## Summary

Raise `Dashboard.Full_health.refresh_timeout_sec` default from 8s to 20s in `lib/config/env_config_runtime.ml`.

## Why

- `make_health_json` synchronously fans 17 components per refresh
- Team BBBB2 (iter#27) observed 27% tail at 16s live operator override (307/24h timeouts)
- Default bump to 20s expected to drop tail to <10% (<50/24h)

## WORKAROUND label

This is a **cap raise** (workaround signature §4 — cap/cooldown/dedup/repair). Accepted as bridge until structural RFC lands (per-component health cache so make_health_json no longer fans 17 sync calls per refresh).

Sunset target: per-component health cache RFC (to be authored). Until then, this PR is acceptable per `software-development.md §Workaround Override` (production-blocking signal, deprecated path noted in inline comment).

## Risk

LOW — single floor default value. Operator override still applies at runtime. Behavior change: refresh attempts now allowed up to 20s instead of 8s. No code path / fan-out structure changed.

## Tests

Manual operator env override testing; no unit test for env defaults (would require harness change beyond scope).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
