### PR TITLE
refactor(server_dashboard_http_core): extract JSON helpers cluster into sibling (step 20)

### DIFF
--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -227,80 +227,15 @@ let operator_digest_cache = Server_dashboard_http_core_operator.operator_digest_
 let _operator_digest_cache = Server_dashboard_http_core_operator._operator_digest_cache
 let operator_refresh_interval_s = Server_dashboard_http_core_operator.operator_refresh_interval_s
 let operator_snapshot_extra = Server_dashboard_http_core_operator.operator_snapshot_extra
-let json_string_opt = function
-  | Some value -> `String value
-  | None -> `Null
-;;
-
-let json_bool_opt = function
-  | Some value -> `Bool value
-  | None -> `Null
-;;
-
-let json_assoc_field_opt key = function
-  | `Assoc fields -> List.assoc_opt key fields
-  | _ -> None
-;;
-
-let json_assoc_string_opt key json =
-  match json_assoc_field_opt key json with
-  | Some (`String value) -> Some value
-  | _ -> None
-;;
-
-let json_assoc_int_opt key json =
-  match json_assoc_field_opt key json with
-  | Some (`Int value) -> Some value
-  | Some (`Float value) -> Some (int_of_float value)
-  | _ -> None
-;;
-
-let projection_diagnostics_fields json =
-  match json_assoc_field_opt "projection_diagnostics" json with
-  | Some (`Assoc fields) -> fields
-  | _ -> []
-;;
-
-let projection_diagnostics_field json key =
-  List.assoc_opt key (projection_diagnostics_fields json)
-;;
-
-let operator_generated_at_iso json =
-  match projection_diagnostics_field json "generated_at" with
-  | Some (`String value) -> value
-  | _ ->
-    (match json_assoc_string_opt "generated_at" json with
-     | Some value -> value
-     | None -> Masc_domain.now_iso ())
-;;
-
-let operator_cache_json ?cache_key ~scope json =
-  let diagnostic_field key =
-    match projection_diagnostics_field json key with
-    | Some value -> value
-    | None -> `Null
-  in
-  let cache_state =
-    match projection_diagnostics_field json "cache_state" with
-    | Some (`String value) -> value
-    | _ -> "request_swr_or_inline_compute"
-  in
-  `Assoc
-    [ "scope", `String scope
-    ; "cache_state", `String cache_state
-    ; "projection_surface", diagnostic_field "surface"
-    ; "last_success_at", diagnostic_field "last_success_at"
-    ; "last_attempt_at", diagnostic_field "last_attempt_at"
-    ; "last_error_at", diagnostic_field "last_error_at"
-    ; "stale_reason", diagnostic_field "stale_reason"
-    ; "stale_age_ms", diagnostic_field "stale_age_ms"
-    ; "request_cache_key", json_string_opt cache_key
-    ; "request_cache_ttl_s", `Float 5.0
-    ; "request_timeout_s", `Float dashboard_request_timeout_s
-    ; "background_refresh_interval_s", `Float operator_refresh_interval_s
-    ; "policy", `String "cached_surface plus HTTP stale-while-revalidate"
-    ]
-;;
+let json_string_opt = Server_dashboard_http_core_json.json_string_opt
+let json_bool_opt = Server_dashboard_http_core_json.json_bool_opt
+let json_assoc_field_opt = Server_dashboard_http_core_json.json_assoc_field_opt
+let json_assoc_string_opt = Server_dashboard_http_core_json.json_assoc_string_opt
+let json_assoc_int_opt = Server_dashboard_http_core_json.json_assoc_int_opt
+let projection_diagnostics_fields = Server_dashboard_http_core_json.projection_diagnostics_fields
+let projection_diagnostics_field = Server_dashboard_http_core_json.projection_diagnostics_field
+let operator_generated_at_iso = Server_dashboard_http_core_json.operator_generated_at_iso
+let operator_cache_json = Server_dashboard_http_core_json.operator_cache_json
 
 let operator_retention_json ~(config : Coord.config) ~scope ~producer =
   `Assoc

--- a/lib/server/server_dashboard_http_core_json.ml
+++ b/lib/server/server_dashboard_http_core_json.ml
@@ -1,0 +1,77 @@
+(** JSON helpers + projection-diagnostic field readers + operator
+    cache JSON wrapper, extracted from server_dashboard_http_core.ml. *)
+
+let json_string_opt = function
+  | Some value -> `String value
+  | None -> `Null
+;;
+
+let json_bool_opt = function
+  | Some value -> `Bool value
+  | None -> `Null
+;;
+
+let json_assoc_field_opt key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+;;
+
+let json_assoc_string_opt key json =
+  match json_assoc_field_opt key json with
+  | Some (`String value) -> Some value
+  | _ -> None
+;;
+
+let json_assoc_int_opt key json =
+  match json_assoc_field_opt key json with
+  | Some (`Int value) -> Some value
+  | Some (`Float value) -> Some (int_of_float value)
+  | _ -> None
+;;
+
+let projection_diagnostics_fields json =
+  match json_assoc_field_opt "projection_diagnostics" json with
+  | Some (`Assoc fields) -> fields
+  | _ -> []
+;;
+
+let projection_diagnostics_field json key =
+  List.assoc_opt key (projection_diagnostics_fields json)
+;;
+
+let operator_generated_at_iso json =
+  match projection_diagnostics_field json "generated_at" with
+  | Some (`String value) -> value
+  | _ ->
+    (match json_assoc_string_opt "generated_at" json with
+     | Some value -> value
+     | None -> Masc_domain.now_iso ())
+;;
+
+let operator_cache_json ?cache_key ~scope json =
+  let diagnostic_field key =
+    match projection_diagnostics_field json key with
+    | Some value -> value
+    | None -> `Null
+  in
+  let cache_state =
+    match projection_diagnostics_field json "cache_state" with
+    | Some (`String value) -> value
+    | _ -> "request_swr_or_inline_compute"
+  in
+  `Assoc
+    [ "scope", `String scope
+    ; "cache_state", `String cache_state
+    ; "projection_surface", diagnostic_field "surface"
+    ; "last_success_at", diagnostic_field "last_success_at"
+    ; "last_attempt_at", diagnostic_field "last_attempt_at"
+    ; "last_error_at", diagnostic_field "last_error_at"
+    ; "stale_reason", diagnostic_field "stale_reason"
+    ; "stale_age_ms", diagnostic_field "stale_age_ms"
+    ; "request_cache_key", json_string_opt cache_key
+    ; "request_cache_ttl_s", `Float 5.0
+    ; "request_timeout_s", `Float dashboard_request_timeout_s
+    ; "background_refresh_interval_s", `Float operator_refresh_interval_s
+    ; "policy", `String "cached_surface plus HTTP stale-while-revalidate"
+    ]
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` step 20 (Dashboard core surface split — JSON helpers cluster)
- Third cluster from `server_dashboard_http_core.ml` after #17126 (cache) and #17215 (operator).

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/server/server_dashboard_http_core.ml` | 1713 | 1648 | **-65** |
| `lib/server/server_dashboard_http_core_json.ml` | — | 77 | +77 |

## Moved (verbatim, no behavior change)
- 5 json_* helpers (json_string_opt, json_bool_opt, json_assoc_field_opt, json_assoc_string_opt, json_assoc_int_opt)
- projection_diagnostics_fields, projection_diagnostics_field
- operator_generated_at_iso
- operator_cache_json

9 bindings via single-line aliases.

## Local build status
- godfile lint: clean
- Pre-existing main breakage (unrelated): `Agent_sdk.Tool` missing `evidence_role` field at line 262

## RFC-WAIVED
Extract-only sibling refactor.

Co-Authored-By: codex <noreply@anthropic.com>
