### PR TITLE
feat(keeper): classify cascade backpressure causes

### DIFF
--- a/lib/keeper/keeper_health_probe.ml
+++ b/lib/keeper/keeper_health_probe.ml
@@ -9,6 +9,121 @@ type health_status =
   | Healthy
   | Unhealthy of string
 
+type runtime_pressure_class =
+  | Client_capacity_full
+  | Tier_admission_full
+  | Provider_capacity
+  | Provider_dns_failure
+  | Provider_timeout
+  | Provider_error
+  | Oas_timeout_budget
+  | Turn_stale_timeout
+  | Keeper_liveness_failure
+  | Tool_contract_failure
+  | Runtime_failure
+
+let runtime_pressure_class_to_string = function
+  | Client_capacity_full -> "client_capacity_full"
+  | Tier_admission_full -> "tier_admission_full"
+  | Provider_capacity -> "provider_capacity"
+  | Provider_dns_failure -> "provider_dns_failure"
+  | Provider_timeout -> "provider_timeout"
+  | Provider_error -> "provider_error"
+  | Oas_timeout_budget -> "oas_timeout_budget"
+  | Turn_stale_timeout -> "turn_stale_timeout"
+  | Keeper_liveness_failure -> "keeper_liveness_failure"
+  | Tool_contract_failure -> "tool_contract_failure"
+  | Runtime_failure -> "runtime_failure"
+;;
+
+let runtime_pressure_class_of_label label =
+  match String.lowercase_ascii (String.trim label) with
+  | "client_capacity_full" | "client_capacity" -> Some Client_capacity_full
+  | "tier_admission_full" | "tier_admission" -> Some Tier_admission_full
+  | "provider_capacity" | "provider_capacity_full" | "capacity_backpressure" ->
+    Some Provider_capacity
+  | "provider_dns_failure" | "provider_dns" -> Some Provider_dns_failure
+  | "provider_timeout" -> Some Provider_timeout
+  | "provider_error" | "provider_runtime_error" -> Some Provider_error
+  | "oas_timeout_budget" | "oas_timeout_budget_loop" -> Some Oas_timeout_budget
+  | "turn_stale_timeout" | "stale_turn_timeout" -> Some Turn_stale_timeout
+  | "keeper_liveness_failure" | "heartbeat_failures" | "turn_failures" ->
+    Some Keeper_liveness_failure
+  | "tool_contract_failure" | "tool_required_unsatisfied" ->
+    Some Tool_contract_failure
+  | "runtime_failure" | "fiber_unresolved" | "exception" -> Some Runtime_failure
+  | _ -> None
+;;
+
+let provider_runtime_pressure_class ~code ~detail ~http_status =
+  let contains needle =
+    String_util.contains_substring_ci code needle
+    || String_util.contains_substring_ci detail needle
+  in
+  let http_is_any statuses =
+    match http_status with
+    | Some status -> List.mem status statuses
+    | None -> false
+  in
+  if
+    contains "client_capacity"
+    || contains "client capacity"
+    || contains "client_capacity_full"
+  then Client_capacity_full
+  else if
+    contains "tier_admission"
+    || contains "inflight_capacity_full"
+    || contains "strict_tool_candidates"
+    || contains "tier="
+  then Tier_admission_full
+  else if
+    contains "capacity_backpressure"
+    || contains "capacity exhausted"
+    || contains "capacity_exhausted"
+    || contains "rate limit"
+    || contains "rate_limited"
+    || contains "overloaded"
+    || http_is_any [ 429; 529 ]
+  then Provider_capacity
+  else if
+    contains "getaddrinfo"
+    || contains "dns"
+    || contains "enotfound"
+    || contains "nxdomain"
+    || contains "nodename nor servname"
+  then Provider_dns_failure
+  else if
+    contains "timeout"
+    || contains "timed out"
+    || contains "no_first_token"
+    || contains "inter_chunk_idle"
+    || contains "max_execution_time"
+    || contains "wall-clock timeout"
+    || http_is_any [ 408; 504; 524 ]
+  then Provider_timeout
+  else Provider_error
+;;
+
+let runtime_pressure_class_of_failure_reason = function
+  | Some (Keeper_registry.Oas_timeout_budget_loop _) -> Some Oas_timeout_budget
+  | Some (Keeper_registry.Provider_runtime_error { code; detail; http_status; _ }) ->
+    Some (provider_runtime_pressure_class ~code ~detail ~http_status)
+  | Some (Keeper_registry.Stale_turn_timeout _) -> Some Turn_stale_timeout
+  | Some
+      ( Keeper_registry.Heartbeat_consecutive_failures _
+      | Keeper_registry.Turn_consecutive_failures _ ) ->
+    Some Keeper_liveness_failure
+  | Some (Keeper_registry.Tool_required_unsatisfied _) -> Some Tool_contract_failure
+  | Some
+      ( Keeper_registry.Fiber_unresolved
+      | Keeper_registry.Exception _
+      | Keeper_registry.Stale_termination_storm _
+      | Keeper_registry.Stale_fleet_batch _
+      | Keeper_registry.Ambiguous_partial_commit _ ) ->
+    Some Runtime_failure
+  | None -> None
+;;
+
 (** Per-keeper, per-item health cache.
     Key: (keeper_name, item_id). Value: (status, timestamp). *)
 let health_cache : (string * string, health_status * float) Hashtbl.t = Hashtbl.create 16
@@ -95,6 +210,85 @@ let max_failed_allowed_for_cascade ~total =
   max 1 (total / 10)
 ;;
 
+type cascade_scan_acc =
+  { total : int
+  ; failed : int
+  ; failure_reasons : Keeper_registry.failure_reason option list
+  }
+
+let empty_cascade_scan_acc =
+  { total = 0; failed = 0; failure_reasons = [] }
+;;
+
+let dominant_runtime_pressure_class failure_reasons =
+  let counts = Hashtbl.create 8 in
+  List.iter
+    (fun reason ->
+       match runtime_pressure_class_of_failure_reason reason with
+       | None -> ()
+       | Some cls ->
+         let label = runtime_pressure_class_to_string cls in
+         let n =
+           match Hashtbl.find_opt counts label with
+           | Some n -> n
+           | None -> 0
+         in
+         Hashtbl.replace counts label (n + 1))
+    failure_reasons;
+  let ranked =
+    counts
+    |> Hashtbl.to_seq
+    |> List.of_seq
+    |> List.sort (fun (label_a, count_a) (label_b, count_b) ->
+      match compare count_b count_a with
+      | 0 -> String.compare label_a label_b
+      | n -> n)
+  in
+  match ranked with
+  | (label, _) :: _ -> Some label
+  | [] -> None
+;;
+
+let cascade_failure_reason acc =
+  match dominant_runtime_pressure_class acc.failure_reasons with
+  | Some label -> "failure_ratio:" ^ label
+  | None -> "failure_ratio"
+;;
+
+let scan_cascade_health ~base_path =
+  let entries = Keeper_registry.all ~base_path () in
+  let by_cascade = Hashtbl.create 8 in
+  List.iter
+    (fun (entry : Keeper_registry.registry_entry) ->
+       let cascade = Keeper_types.cascade_name_of_meta entry.meta in
+       let acc =
+         match Hashtbl.find_opt by_cascade cascade with
+         | Some acc -> acc
+         | None -> empty_cascade_scan_acc
+       in
+       let failed = is_terminal_unhealthy entry.phase in
+       let acc' =
+         { total = acc.total + 1
+         ; failed = acc.failed + if failed then 1 else 0
+         ; failure_reasons =
+             (if failed
+              then entry.last_failure_reason :: acc.failure_reasons
+              else acc.failure_reasons)
+         }
+       in
+       Hashtbl.replace by_cascade cascade acc')
+    entries;
+  Hashtbl.fold
+    (fun cascade acc rows ->
+       let healthy =
+         if acc.total <= 0 then true
+         else acc.failed <= max_failed_allowed_for_cascade ~total:acc.total
+       in
+       (cascade, healthy, acc) :: rows)
+    by_cascade
+    []
+;;
+
 (** Compute health per cascade from registry entries.
     Returns (cascade_name, is_healthy).
 
@@ -108,28 +302,8 @@ let max_failed_allowed_for_cascade ~total =
     Per-item health is updated via [record_item_result] after each
     turn. *)
 let check_cascade_health ~base_path =
-  let entries = Keeper_registry.all ~base_path () in
-  let by_cascade = Hashtbl.create 8 in
-  List.iter
-    (fun (entry : Keeper_registry.registry_entry) ->
-       let cascade = Keeper_types.cascade_name_of_meta entry.meta in
-       let total, failed =
-         match Hashtbl.find_opt by_cascade cascade with
-         | Some pair -> pair
-         | None -> 0, 0
-       in
-       let failed' = if is_terminal_unhealthy entry.phase then failed + 1 else failed in
-       Hashtbl.replace by_cascade cascade (total + 1, failed'))
-    entries;
-  Hashtbl.fold
-    (fun cascade (total, failed) acc ->
-       let healthy =
-         if total <= 0 then true
-         else failed <= max_failed_allowed_for_cascade ~total
-       in
-       (cascade, healthy) :: acc)
-    by_cascade
-    []
+  scan_cascade_health ~base_path
+  |> List.map (fun (cascade, healthy, _acc) -> cascade, healthy)
 ;;
 
 (* ------------------------------------------------------------------ *)
@@ -137,10 +311,12 @@ let check_cascade_health ~base_path =
 (* ------------------------------------------------------------------ *)
 
 let run_once ~base_path =
-  let results = check_cascade_health ~base_path in
+  let results = scan_cascade_health ~base_path in
   List.iter
-    (fun (cascade, healthy) ->
-       let status = if healthy then Healthy else Unhealthy "failure_ratio" in
+    (fun (cascade, healthy, acc) ->
+       let status =
+         if healthy then Healthy else Unhealthy (cascade_failure_reason acc)
+       in
        set_cascade_status ~cascade_name:cascade status)
     results
 ;;

--- a/lib/keeper/keeper_health_probe.mli
+++ b/lib/keeper/keeper_health_probe.mli
@@ -13,6 +13,29 @@ type health_status =
   | Healthy
   | Unhealthy of string
 
+(** Runtime pressure classes used to explain an unhealthy cascade.
+    These labels are intentionally low-cardinality because they are
+    persisted into skip observations and surfaced in fleet diagnostics. *)
+type runtime_pressure_class =
+  | Client_capacity_full
+  | Tier_admission_full
+  | Provider_capacity
+  | Provider_dns_failure
+  | Provider_timeout
+  | Provider_error
+  | Oas_timeout_budget
+  | Turn_stale_timeout
+  | Keeper_liveness_failure
+  | Tool_contract_failure
+  | Runtime_failure
+
+val runtime_pressure_class_to_string : runtime_pressure_class -> string
+val runtime_pressure_class_of_label : string -> runtime_pressure_class option
+
+val runtime_pressure_class_of_failure_reason
+  :  Keeper_registry.failure_reason option
+  -> runtime_pressure_class option
+
 (** {1 Per-item health (RFC-0041)} *)
 
 (** [is_item_healthy ~keeper_name ~item_id] returns the cached health

--- a/lib/keeper/keeper_heartbeat_loop_observations.ml
+++ b/lib/keeper/keeper_heartbeat_loop_observations.ml
@@ -4,6 +4,19 @@ type semaphore_wait_observation_kind =
   | Semaphore_wait_pending
   | Semaphore_wait_timeout
 
+let skip_reason_component raw =
+  let normalized = String.lowercase_ascii (String.trim raw) in
+  let mapped =
+    String.map
+      (function
+        | ('a' .. 'z' | '0' .. '9' | '_') as c -> c
+        | '-' -> '_'
+        | _ -> '_')
+      normalized
+  in
+  if String.equal mapped "" then "unknown" else mapped
+;;
+
 let semaphore_wait_observation_reasons ?phase_label ~kind ~channel () =
   let kind_reason =
     match kind with
@@ -15,10 +28,28 @@ let semaphore_wait_observation_reasons ?phase_label ~kind ~channel () =
     | Some phase -> "phase_" ^ phase
     | None -> "peers_holding_slot"
   in
-  [ kind_reason
-  ; wait_reason
-  ; "channel_" ^ Keeper_world_observation.channel_to_string channel
-  ]
+  let class_reason =
+    match kind with
+    | Semaphore_wait_pending -> None
+    | Semaphore_wait_timeout ->
+      let class_label =
+        match Option.map skip_reason_component phase_label with
+        | Some "autonomous_queue_head" -> "admission_queue_wait_timeout"
+        | Some "autonomous_slot" -> "autonomous_slot_wait_timeout"
+        | Some ("reactive_slot" | "turn_slot") -> "turn_slot_wait_timeout"
+        | Some _ | None -> "slot_wait_timeout"
+      in
+      Some ("class_" ^ class_label)
+  in
+  let base =
+    [ kind_reason
+    ; wait_reason
+    ; "channel_" ^ Keeper_world_observation.channel_to_string channel
+    ]
+  in
+  match class_reason with
+  | Some reason -> base @ [ reason ]
+  | None -> base
 ;;
 
 let record_semaphore_wait_observation
@@ -42,17 +73,28 @@ type cascade_backpressure_decision =
       reason : string;
     }
 
-let skip_reason_component raw =
-  let normalized = String.lowercase_ascii (String.trim raw) in
-  let mapped =
-    String.map
-      (function
-        | ('a' .. 'z' | '0' .. '9' | '_') as c -> c
-        | '-' -> '_'
-        | _ -> '_')
-      normalized
+let strip_prefix ~prefix value =
+  if String.starts_with ~prefix value
+  then
+    Some
+      (String.sub
+         value
+         (String.length prefix)
+         (String.length value - String.length prefix))
+  else None
+;;
+
+let cascade_backpressure_class_reason ~reason =
+  let component = skip_reason_component reason in
+  let label =
+    match strip_prefix ~prefix:"failure_ratio_" component with
+    | Some suffix -> suffix
+    | None -> component
   in
-  if String.equal mapped "" then "unknown" else mapped
+  match Keeper_health_probe.runtime_pressure_class_of_label label with
+  | Some cls ->
+    Some ("class_" ^ Keeper_health_probe.runtime_pressure_class_to_string cls)
+  | None -> None
 ;;
 
 let cascade_backpressure_observation_reasons ~reason =
@@ -61,10 +103,13 @@ let cascade_backpressure_observation_reasons ~reason =
     then "cascade_resilience"
     else "cascade_unhealthy"
   in
-  [ "cascade_backpressure"
-  ; category
-  ; "reason_" ^ skip_reason_component reason
-  ]
+  let base = [ "cascade_backpressure"; category ] in
+  let class_reasons =
+    match cascade_backpressure_class_reason ~reason with
+    | Some class_reason -> [ class_reason ]
+    | None -> []
+  in
+  base @ class_reasons @ [ "reason_" ^ skip_reason_component reason ]
 ;;
 
 let cascade_resilience_backpressure_reason

--- a/test/test_keeper_health_probe.ml
+++ b/test/test_keeper_health_probe.ml
@@ -147,8 +147,10 @@ let test_run_once_records_specific_failure_ratio_reason () =
   in
   let register_crashed name reason =
     let meta = make_meta ~cascade_name name in
+    (* See: fixture setup only needs the registry side effect. *)
     ignore (R.register ~base_path:base_dir name meta);
     R.set_failure_reason ~base_path:base_dir name (Some reason);
+    (* See: fixture setup only needs the terminal-event side effect. *)
     ignore
       (R.dispatch_event
          ~base_path:base_dir

--- a/test/test_keeper_health_probe.ml
+++ b/test/test_keeper_health_probe.ml
@@ -4,7 +4,10 @@
    tests in test_keeper_supervisor.ml. *)
 
 module H = Masc_mcp.Keeper_health_probe
+module R = Masc_mcp.Keeper_registry
 module KSM = Masc_mcp.Keeper_state_machine
+
+let pressure_label_t = Alcotest.(option string)
 
 let pp_status fmt = function
   | H.Unknown -> Format.fprintf fmt "Unknown"
@@ -22,6 +25,30 @@ let status_eq a b =
 
 let status_t = Alcotest.testable pp_status status_eq
 
+let make_meta ?cascade_name name =
+  let fields =
+    [
+      ("name", `String name);
+      ("agent_name", `String name);
+      ("trace_id", `String ("trace-" ^ name));
+    ]
+  in
+  let fields =
+    match cascade_name with
+    | Some cascade_name -> ("cascade_name", `String cascade_name) :: fields
+    | None -> fields
+  in
+  match Masc_test_deps.meta_of_json_fixture (`Assoc fields) with
+  | Ok meta -> meta
+  | Error err -> Alcotest.fail ("make_meta failed: " ^ err)
+;;
+
+let pressure_label_of_failure_reason reason =
+  Option.map
+    H.runtime_pressure_class_to_string
+    (H.runtime_pressure_class_of_failure_reason (Some reason))
+;;
+
 let test_get_cascade_status_default_unknown () =
   Alcotest.check
     status_t
@@ -35,6 +62,125 @@ let test_check_cascade_health_all_healthy () =
   Sys.remove base_dir;
   let results = Masc_mcp.Keeper_health_probe.check_cascade_health ~base_path:base_dir in
   Alcotest.(check int) "empty registry = no cascades" 0 (List.length results)
+;;
+
+let test_runtime_pressure_classifier () =
+  Alcotest.check
+    pressure_label_t
+    "client capacity"
+    (Some "client_capacity_full")
+    (pressure_label_of_failure_reason
+       (R.Provider_runtime_error
+          { code = "capacity_backpressure"
+          ; detail = "source=client_capacity; all client slots full"
+          ; provider_id = None
+          ; http_status = None
+          }));
+  Alcotest.check
+    pressure_label_t
+    "tier admission"
+    (Some "tier_admission_full")
+    (pressure_label_of_failure_reason
+       (R.Provider_runtime_error
+          { code = "capacity_backpressure"
+          ; detail = "inflight_capacity_full tier=strict_tool_candidates"
+          ; provider_id = None
+          ; http_status = None
+          }));
+  Alcotest.check
+    pressure_label_t
+    "provider capacity"
+    (Some "provider_capacity")
+    (pressure_label_of_failure_reason
+       (R.Provider_runtime_error
+          { code = "provider_capacity_backpressure"
+          ; detail = "rate limit"
+          ; provider_id = Some "openai"
+          ; http_status = Some 429
+          }));
+  Alcotest.check
+    pressure_label_t
+    "provider dns"
+    (Some "provider_dns_failure")
+    (pressure_label_of_failure_reason
+       (R.Provider_runtime_error
+          { code = "provider_error"
+          ; detail = "getaddrinfo ENOTFOUND api.z.ai"
+          ; provider_id = Some "zai"
+          ; http_status = None
+          }));
+  Alcotest.check
+    pressure_label_t
+    "provider timeout"
+    (Some "provider_timeout")
+    (pressure_label_of_failure_reason
+       (R.Provider_runtime_error
+          { code = "provider_error"
+          ; detail = "inter_chunk_idle timeout"
+          ; provider_id = None
+          ; http_status = Some 504
+          }));
+  Alcotest.check
+    pressure_label_t
+    "provider error"
+    (Some "provider_error")
+    (pressure_label_of_failure_reason
+       (R.Provider_runtime_error
+          { code = "provider_error"
+          ; detail = "unexpected provider failure"
+          ; provider_id = None
+          ; http_status = Some 500
+          }));
+  Alcotest.check
+    pressure_label_t
+    "oas timeout"
+    (Some "oas_timeout_budget")
+    (pressure_label_of_failure_reason (R.Oas_timeout_budget_loop { count = 2 }))
+;;
+
+let test_run_once_records_specific_failure_ratio_reason () =
+  R.clear ();
+  let base_dir = Filename.temp_file "probe-pressure-" "" in
+  Sys.remove base_dir;
+  let cascade_name =
+    Printf.sprintf "probe-provider-dns-%d" (Unix.getpid ())
+  in
+  let register_crashed name reason =
+    let meta = make_meta ~cascade_name name in
+    ignore (R.register ~base_path:base_dir name meta);
+    R.set_failure_reason ~base_path:base_dir name (Some reason);
+    ignore
+      (R.dispatch_event
+         ~base_path:base_dir
+         name
+         (KSM.Fiber_terminated
+            { outcome = "test"; provider_id = None; http_status = None }))
+  in
+  Fun.protect
+    ~finally:R.clear
+    (fun () ->
+       register_crashed
+         "provider-dns-a"
+         (R.Provider_runtime_error
+            { code = "provider_error"
+            ; detail = "getaddrinfo ENOTFOUND api.z.ai"
+            ; provider_id = Some "zai"
+            ; http_status = None
+            });
+       register_crashed
+         "provider-dns-b"
+         (R.Provider_runtime_error
+            { code = "provider_error"
+            ; detail = "getaddrinfo ENOTFOUND api.z.ai"
+            ; provider_id = Some "zai"
+            ; http_status = None
+            });
+       H.run_once ~base_path:base_dir;
+       Alcotest.check
+         status_t
+         "unhealthy reason carries dominant runtime pressure"
+         (H.Unhealthy "failure_ratio:provider_dns_failure")
+         (H.get_cascade_status ~cascade_name))
 ;;
 
 (* ------------------------------------------------------------------ *)
@@ -141,6 +287,14 @@ let () =
             "empty_registry_all_healthy"
             `Quick
             test_check_cascade_health_all_healthy
+        ; Alcotest.test_case
+            "runtime_pressure_classifier"
+            `Quick
+            test_runtime_pressure_classifier
+        ; Alcotest.test_case
+            "run_once_records_specific_failure_ratio_reason"
+            `Quick
+            test_run_once_records_specific_failure_ratio_reason
         ] )
     ; ( "phase_predicate"
       , [ Alcotest.test_case

--- a/test/test_keeper_semaphore_wait_counter.ml
+++ b/test/test_keeper_semaphore_wait_counter.ml
@@ -214,6 +214,7 @@ let test_wait_observation_reason_labels () =
       "semaphore_wait_timeout";
       "peers_holding_slot";
       "channel_scheduled_autonomous";
+      "class_slot_wait_timeout";
     ]
     (Masc_mcp.Keeper_heartbeat_loop.semaphore_wait_observation_reasons
        ~kind:Masc_mcp.Keeper_heartbeat_loop.Semaphore_wait_timeout
@@ -225,6 +226,7 @@ let test_wait_observation_reason_labels () =
       "semaphore_wait_timeout";
       "phase_autonomous_queue_head";
       "channel_scheduled_autonomous";
+      "class_admission_queue_wait_timeout";
     ]
     (Masc_mcp.Keeper_heartbeat_loop.semaphore_wait_observation_reasons
        ~phase_label:"autonomous_queue_head"
@@ -308,6 +310,16 @@ let test_cascade_backpressure_reason_labels () =
     "cascade backpressure reasons"
     [ "cascade_backpressure"; "cascade_unhealthy"; "reason_failure_ratio_" ]
     (KHL.cascade_backpressure_observation_reasons ~reason:"Failure Ratio!");
+  Alcotest.(check (list string))
+    "provider dns cascade backpressure reasons"
+    [
+      "cascade_backpressure";
+      "cascade_unhealthy";
+      "class_provider_dns_failure";
+      "reason_failure_ratio_provider_dns_failure";
+    ]
+    (KHL.cascade_backpressure_observation_reasons
+       ~reason:"failure_ratio:provider_dns_failure");
   Alcotest.(check (list string))
     "cascade resilience backpressure reasons"
     [


### PR DESCRIPTION
## Summary
- add low-cardinality runtime pressure classes for unhealthy cascade diagnosis
- preserve the existing cascade health boolean API while writing specific Unhealthy reasons such as failure_ratio:provider_dns_failure
- stamp semaphore/cascade skip observations with class_* labels for turn-slot and provider backpressure routing

## Verification
- git diff --check
- ocamlformat --check lib/keeper/keeper_health_probe.ml lib/keeper/keeper_health_probe.mli lib/keeper/keeper_heartbeat_loop_observations.ml test/test_keeper_health_probe.ml test/test_keeper_semaphore_wait_counter.ml
- bash scripts/ocaml-structure-ratchet.sh

## Local build note
- scripts/dune-local.sh build test/test_keeper_health_probe.exe test/test_keeper_semaphore_wait_counter.exe could not complete locally because the machine had long-running wrapper/bare Dune contention across other worktrees; CI should provide the compile proof for this draft.