### PR TITLE
feat(cascade): add required-tool capability boundary

### DIFF
--- a/lib/cascade/cascade_candidate_skip_reason.ml
+++ b/lib/cascade/cascade_candidate_skip_reason.ml
@@ -1,0 +1,17 @@
+(** Routing-affecting pre-dispatch skip reasons. *)
+
+type t =
+  | Required_tool_unsupported of { missing : string list }
+
+let to_manifest_tag = function
+  | Required_tool_unsupported _ -> "required_tool_unsupported"
+
+let to_yojson ~candidate reason =
+  match reason with
+  | Required_tool_unsupported { missing } ->
+    `Assoc
+      [
+        ("kind", `String (to_manifest_tag reason));
+        ("candidate", `String candidate);
+        ("missing", `List (List.map (fun tool -> `String tool) missing));
+      ]

--- a/lib/cascade/cascade_candidate_skip_reason.mli
+++ b/lib/cascade/cascade_candidate_skip_reason.mli
@@ -1,0 +1,11 @@
+(** Routing-affecting reason for skipping a cascade candidate before
+    provider dispatch.
+
+    This is intentionally separate from [Cascade_preflight_state.reason], which
+    controls health log-cadence only and does not own routing semantics. *)
+
+type t =
+  | Required_tool_unsupported of { missing : string list }
+
+val to_manifest_tag : t -> string
+val to_yojson : candidate:string -> t -> Yojson.Safe.t

--- a/lib/cascade/provider_capability.ml
+++ b/lib/cascade/provider_capability.ml
@@ -1,0 +1,126 @@
+(** Provider capability snapshots for pre-dispatch required-tool checks. *)
+
+type t =
+  { provider_name : string
+  ; satisfying_tools_snapshot : string list option
+  ; tool_choice_support : bool option
+  }
+
+type unsupported =
+  { missing_tools : string list
+  ; tool_choice_required : bool
+  ; tool_choice_supported : bool option
+  }
+
+type decision =
+  | Can_satisfy
+  | Cannot_satisfy of unsupported
+  | Capability_unknown
+
+let unknown ~provider_name =
+  { provider_name; satisfying_tools_snapshot = None; tool_choice_support = None }
+
+let strip_mcp_prefix name =
+  let prefix = "mcp__" in
+  if String.starts_with ~prefix name then
+    match String.split_on_char '_' name with
+    | "mcp" :: "" :: _server :: "" :: rest when rest <> [] ->
+      String.concat "_" rest
+    | _ -> name
+  else name
+
+let canonical_tool_name name = strip_mcp_prefix (String.trim name)
+
+let dedupe_keep_order values =
+  let rec loop seen acc = function
+    | [] -> List.rev acc
+    | value :: rest when List.mem value seen -> loop seen acc rest
+    | value :: rest -> loop (value :: seen) (value :: acc) rest
+  in
+  loop [] [] values
+
+let dedupe_canonical tools =
+  tools |> List.map canonical_tool_name |> dedupe_keep_order
+
+let known ~provider_name ~satisfying_tools ~tool_choice_support =
+  {
+    provider_name;
+    satisfying_tools_snapshot = Some (dedupe_canonical satisfying_tools);
+    tool_choice_support = Some tool_choice_support;
+  }
+
+let missing_required_tools t ~(required_tools : string list) =
+  match t.satisfying_tools_snapshot with
+  | None -> None
+  | Some satisfying_tools ->
+    let satisfying_tools = dedupe_canonical satisfying_tools in
+    let required_tools = dedupe_canonical required_tools in
+    Some
+      (List.filter
+         (fun required -> not (List.mem required satisfying_tools))
+         required_tools)
+
+let decide_required_action ?(require_tool_choice = true) t ~required_tools =
+  let missing = missing_required_tools t ~required_tools in
+  let tool_choice_blocks =
+    require_tool_choice && t.tool_choice_support = Some false
+  in
+  match missing, tool_choice_blocks, require_tool_choice, t.tool_choice_support with
+  | Some missing_tools, _, _, _ when missing_tools <> [] ->
+    Cannot_satisfy
+      {
+        missing_tools;
+        tool_choice_required = require_tool_choice;
+        tool_choice_supported = t.tool_choice_support;
+      }
+  | _, true, _, _ ->
+    Cannot_satisfy
+      {
+        missing_tools = [];
+        tool_choice_required = true;
+        tool_choice_supported = Some false;
+      }
+  | Some [], _, false, _ -> Can_satisfy
+  | Some [], _, true, Some true -> Can_satisfy
+  | None, _, false, _ when required_tools = [] -> Can_satisfy
+  | None, _, true, Some true when required_tools = [] -> Can_satisfy
+  | _ -> Capability_unknown
+
+let can_satisfy_required_action ?require_tool_choice t ~required_tools =
+  match decide_required_action ?require_tool_choice t ~required_tools with
+  | Can_satisfy -> Some true
+  | Cannot_satisfy _ -> Some false
+  | Capability_unknown -> None
+
+let filtered_missing_tools t required_tools =
+  match missing_required_tools t ~required_tools with
+  | Some missing -> missing
+  | None -> []
+
+let filter_candidates_for_required_tools
+    ?(require_tool_choice = true)
+    candidates
+    ~required_tools =
+  let passed_rev, filtered_rev =
+    List.fold_left
+      (fun (passed, filtered) candidate ->
+        match
+          can_satisfy_required_action
+            ~require_tool_choice
+            candidate
+            ~required_tools
+        with
+        | Some false ->
+          let missing = filtered_missing_tools candidate required_tools in
+          passed, (candidate, missing) :: filtered
+        | Some true | None -> candidate :: passed, filtered)
+      ([], [])
+      candidates
+  in
+  List.rev passed_rev, List.rev filtered_rev
+
+let record_pre_dispatch_required_tool_filtered ~provider ~missing_count =
+  Prometheus.inc_counter
+    Prometheus.metric_cascade_pre_dispatch_required_tool_filtered
+    ~labels:[ "provider", provider; "missing_count", string_of_int missing_count ]
+    ()

--- a/lib/cascade/provider_capability.mli
+++ b/lib/cascade/provider_capability.mli
@@ -1,0 +1,48 @@
+(** Provider capability snapshot used at the cascade boundary before
+    dispatching to OAS.
+
+    Phase A wires the boundary with [unknown] snapshots only, so routing
+    behavior is unchanged. Later phases can replace the snapshot producer with
+    provider/OAS evidence and the same decision function becomes active. *)
+
+type t =
+  { provider_name : string
+  ; satisfying_tools_snapshot : string list option
+  ; tool_choice_support : bool option
+  }
+
+type unsupported =
+  { missing_tools : string list
+  ; tool_choice_required : bool
+  ; tool_choice_supported : bool option
+  }
+
+type decision =
+  | Can_satisfy
+  | Cannot_satisfy of unsupported
+  | Capability_unknown
+
+val unknown : provider_name:string -> t
+
+val known :
+  provider_name:string ->
+  satisfying_tools:string list ->
+  tool_choice_support:bool ->
+  t
+
+val missing_required_tools : t -> required_tools:string list -> string list option
+
+val decide_required_action :
+  ?require_tool_choice:bool -> t -> required_tools:string list -> decision
+
+val can_satisfy_required_action :
+  ?require_tool_choice:bool -> t -> required_tools:string list -> bool option
+
+val filter_candidates_for_required_tools :
+  ?require_tool_choice:bool ->
+  t list ->
+  required_tools:string list ->
+  t list * (t * string list) list
+
+val record_pre_dispatch_required_tool_filtered :
+  provider:string -> missing_count:int -> unit

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -984,6 +984,14 @@ let run_named
         terminal_error
     | candidate :: rest ->
       Eio_guard.fair_yield (); (* P0: keep fast-fail cascades scheduler-fair. *)
+      (* Phase A: no provider snapshot is available yet, so the boundary returns
+         [Capability_unknown] and preserves routing. Later phases only swap in
+         a real snapshot producer at this call site. *)
+      ignore
+        (Provider_capability.decide_required_action
+           (Provider_capability.unknown
+              ~provider_name:(Cascade_runtime_candidate.provider_label candidate))
+           ~required_tools:runtime_manifest_required_tool_names);
       let tier_admission_id = Cascade_runtime_candidate.tier_id candidate in
       let health_cooldown =
         Cascade_runtime_candidate.first_health_cooldown candidate

--- a/lib/prometheus_builtin_metrics_part5.ml
+++ b/lib/prometheus_builtin_metrics_part5.ml
@@ -393,6 +393,11 @@ let register
   add metric_cascade_strategy_decisions "Cascade strategy decisions by outcome." `Counter;
   add metric_cascade_capacity_events "Cascade capacity events by type." `Counter;
   add
+    metric_cascade_pre_dispatch_required_tool_filtered
+    "Required-tool candidates filtered before provider dispatch. Labels: [provider, \
+     missing_count]."
+    `Counter;
+  add
     metric_cascade_ttfb_seconds
     "Time from cascade attempt start to first non-Done chunk (TTFT). Labels: [cascade, \
      provider] where provider is a bounded public provider bucket."

--- a/lib/prometheus_cascade_metric_names.ml
+++ b/lib/prometheus_cascade_metric_names.ml
@@ -20,6 +20,10 @@ let metric_cascade_providers_exhausted = "masc_cascade_providers_exhausted_total
 let metric_cascade_routing_phase_overrides = "masc_cascade_routing_phase_overrides_total"
 let metric_cascade_server_error_skip_total = "masc_cascade_server_error_skip_total"
 
+let metric_cascade_pre_dispatch_required_tool_filtered =
+  "masc_cascade_pre_dispatch_required_tool_filtered_total"
+;;
+
 let metric_cascade_fallback_cycle_detected_total =
   "masc_cascade_fallback_cycle_detected_total"
 ;;

--- a/lib/prometheus_cascade_metric_names.mli
+++ b/lib/prometheus_cascade_metric_names.mli
@@ -60,6 +60,10 @@ val metric_cascade_routing_phase_overrides : string
     score decay for a provider. Labels: [provider_key]. *)
 val metric_cascade_server_error_skip_total : string
 
+(** Total required-tool candidates filtered before provider dispatch.
+    Labels: [provider], [missing_count]. *)
+val metric_cascade_pre_dispatch_required_tool_filtered : string
+
 (** Total cascade fallback_cascade cycles detected during [load_catalog].
     A cycle means a provider stall propagates through every cascade in the loop
     silently for 600s+ without escaping. Labels: [cascade] (the entry point of

--- a/test/dune
+++ b/test/dune
@@ -342,6 +342,7 @@
   test_workspace_routes_keeper
   test_workspace_tree_exclusions
   test_provider_capability_matrix
+  test_provider_capability_required_action
   test_effect_evidence_source_path
   test_cognitive_gravity
   test_intentional_projection
@@ -665,6 +666,7 @@
   test_actionable_path_action
   test_stale_kill_class
   test_provider_capability_matrix
+  test_provider_capability_required_action
   test_provider_error
   test_keeper_synthetic_marker
   test_keeper_turn_fsm_wired_sites

--- a/test/test_provider_capability_required_action.ml
+++ b/test/test_provider_capability_required_action.ml
@@ -1,0 +1,169 @@
+open Alcotest
+
+module Capability = Masc_mcp.Provider_capability
+module Skip_reason = Masc_mcp.Cascade_candidate_skip_reason
+
+let bool_option =
+  testable
+    (Fmt.of_to_string (function
+       | None -> "None"
+       | Some true -> "Some true"
+       | Some false -> "Some false"))
+    ( = )
+
+let provider_names providers =
+  List.map (fun (p : Capability.t) -> p.provider_name) providers
+
+let filtered_names filtered =
+  List.map (fun ((p : Capability.t), _missing) -> p.provider_name) filtered
+
+let test_unknown_snapshot_is_non_filtering () =
+  let candidate = Capability.unknown ~provider_name:"glm" in
+  check
+    bool_option
+    "unknown capability passes through"
+    None
+    (Capability.can_satisfy_required_action
+       candidate
+       ~required_tools:[ "keeper_bash" ])
+
+let test_known_snapshot_satisfies_required_tools () =
+  let candidate =
+    Capability.known
+      ~provider_name:"claude"
+      ~satisfying_tools:[ "mcp__masc__keeper_bash"; "keeper_task_claim" ]
+      ~tool_choice_support:true
+  in
+  check
+    bool_option
+    "known matching snapshot satisfies"
+    (Some true)
+    (Capability.can_satisfy_required_action
+       candidate
+       ~required_tools:[ "keeper_bash" ])
+
+let test_known_snapshot_reports_missing_tools () =
+  let candidate =
+    Capability.known
+      ~provider_name:"ollama"
+      ~satisfying_tools:[ "keeper_task_claim" ]
+      ~tool_choice_support:true
+  in
+  check
+    (option (list string))
+    "missing tools are canonicalized"
+    (Some [ "keeper_bash" ])
+    (Capability.missing_required_tools
+       candidate
+       ~required_tools:[ "mcp__masc__keeper_bash" ]);
+  check
+    bool_option
+    "missing tool rejects"
+    (Some false)
+    (Capability.can_satisfy_required_action
+       candidate
+       ~required_tools:[ "keeper_bash" ])
+
+let test_strict_tool_choice_support_is_separate_from_tool_presence () =
+  let candidate =
+    Capability.known
+      ~provider_name:"local-inline"
+      ~satisfying_tools:[ "keeper_bash" ]
+      ~tool_choice_support:false
+  in
+  check
+    bool_option
+    "strict mode rejects provider without tool_choice"
+    (Some false)
+    (Capability.can_satisfy_required_action
+       candidate
+       ~required_tools:[ "keeper_bash" ]);
+  check
+    bool_option
+    "advisory mode accepts tool-capable provider"
+    (Some true)
+    (Capability.can_satisfy_required_action
+       ~require_tool_choice:false
+       candidate
+       ~required_tools:[ "keeper_bash" ])
+
+let test_filter_candidates_preserves_order_and_missing_evidence () =
+  let unknown = Capability.unknown ~provider_name:"unknown" in
+  let good =
+    Capability.known
+      ~provider_name:"good"
+      ~satisfying_tools:[ "keeper_bash" ]
+      ~tool_choice_support:true
+  in
+  let missing =
+    Capability.known
+      ~provider_name:"missing"
+      ~satisfying_tools:[ "keeper_task_claim" ]
+      ~tool_choice_support:true
+  in
+  let passed, filtered =
+    Capability.filter_candidates_for_required_tools
+      [ unknown; missing; good ]
+      ~required_tools:[ "keeper_bash" ]
+  in
+  check (list string) "passed order" [ "unknown"; "good" ] (provider_names passed);
+  check (list string) "filtered order" [ "missing" ] (filtered_names filtered);
+  check
+    (list string)
+    "filtered missing evidence"
+    [ "keeper_bash" ]
+    (match filtered with
+     | [ (_candidate, missing_tools) ] -> missing_tools
+     | _ -> fail "expected one filtered candidate")
+
+let test_skip_reason_manifest_shape () =
+  let json =
+    Skip_reason.to_yojson
+      ~candidate:"glm"
+      (Skip_reason.Required_tool_unsupported { missing = [ "keeper_bash" ] })
+  in
+  check
+    string
+    "tag"
+    "required_tool_unsupported"
+    (Yojson.Safe.Util.(json |> member "kind" |> to_string));
+  check
+    string
+    "candidate"
+    "glm"
+    (Yojson.Safe.Util.(json |> member "candidate" |> to_string));
+  check
+    (list string)
+    "missing"
+    [ "keeper_bash" ]
+    (Yojson.Safe.Util.(json |> member "missing" |> to_list |> List.map to_string))
+
+let () =
+  run
+    "provider_capability_required_action"
+    [
+      ( "decision",
+        [
+          test_case
+            "unknown snapshot is non-filtering"
+            `Quick
+            test_unknown_snapshot_is_non_filtering;
+          test_case
+            "known snapshot satisfies required tools"
+            `Quick
+            test_known_snapshot_satisfies_required_tools;
+          test_case
+            "known snapshot reports missing tools"
+            `Quick
+            test_known_snapshot_reports_missing_tools;
+          test_case
+            "strict tool_choice support is separate"
+            `Quick
+            test_strict_tool_choice_support_is_separate_from_tool_presence;
+          test_case
+            "filter preserves order and missing evidence"
+            `Quick
+            test_filter_candidates_preserves_order_and_missing_evidence;
+          test_case "skip reason manifest shape" `Quick test_skip_reason_manifest_shape;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- add Provider_capability as the typed pre-dispatch required-tool capability boundary
- add Cascade_candidate_skip_reason for routing-affecting skip reasons distinct from health cadence
- wire the Phase A unknown-snapshot decision point into try_cascade without changing routing behavior
- register the pre-dispatch filtered metric and add focused tests for strict vs advisory tool_choice decisions

## Validation
- ocamlformat --check lib/cascade/provider_capability.ml lib/cascade/provider_capability.mli lib/cascade/cascade_candidate_skip_reason.ml lib/cascade/cascade_candidate_skip_reason.mli lib/prometheus_cascade_metric_names.ml lib/prometheus_cascade_metric_names.mli lib/prometheus_builtin_metrics_part5.ml lib/keeper/keeper_turn_driver.ml test/test_provider_capability_required_action.ml
- git diff --check origin/main...HEAD
- scripts/dune-local.sh build test/test_provider_capability_required_action.exe
- ./_build/default/test/test_provider_capability_required_action.exe
- scripts/check-pr-hygiene.sh --base codex/oas-pin-1967-main-20260521

## Notes
- Phase A intentionally uses unknown snapshots, so candidates still pass through. Phase B/C can replace the snapshot producer and activate filtering at the existing call site.
- The focused Dune build and test passed on the same change before the final main rebase. A post-rebase rerun was queued, but the machine-wide Dune lock kept being taken by unrelated worktrees; I canceled that queued rerun to avoid leaving a local session running.