### PR TITLE
fix(keeper): route task-state probes to task tools

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -1285,6 +1285,8 @@ let handle_keeper_bash
       task_state_file_probe_block ()
     | None when Task_probe.looks_like_http_probe cmd ->
       task_state_http_probe_block ()
+    | None when Task_probe.looks_like_discovery cmd ->
+      task_state_file_probe_block ()
     | None -> begin
     (if stripped_stderr_dev_null then
        Log.Keeper.info

--- a/lib/keeper/keeper_shell_bash_task_probe.ml
+++ b/lib/keeper/keeper_shell_bash_task_probe.ml
@@ -1,106 +1,16 @@
-(** Task-state probing detection for keeper_bash command-shape guidance.
+(** Task-state probing detection for keeper_bash command-shape guidance. *)
 
-    [lowercase_contains] is sourced from [Keeper_shell_bash_task_state] so
-    the substring matcher has a single definition in the shell-policy
-    surface (the local copy was a byte-identical duplicate of the same
-    algorithm, matching RFC-0088 §1 N-of-M classifier pattern). *)
-
-open Keeper_shell_bash_words
-
-let lowercase_contains = Keeper_shell_bash_task_state.lowercase_contains
-
-let task_state_file_probe_command_names =
-  [ "cat"; "head"; "tail"; "ls"; "find"; "rg"; "grep"; "test"; "[" ]
+let mentions_task_state_file =
+  Keeper_shell_bash_task_state.command_mentions_task_state_file
 ;;
 
-let looks_like_task_state_path_token text =
-  let text = String.lowercase_ascii text in
-  let scoped_masc = lowercase_contains text ".masc/" in
-  let scoped_worktree = lowercase_contains text ".worktrees/" in
-  (scoped_worktree && lowercase_contains text ".task.json")
-  ||
-  (scoped_masc
-   && (lowercase_contains text "backlog.json"
-       || lowercase_contains text "/tasks"
-       || lowercase_contains text "current_task.json"))
+let looks_like_http_probe =
+  Keeper_shell_bash_task_state.command_looks_like_task_state_http_probe
 ;;
 
-let rec mentions_task_state_file cmd =
-  let words = shell_words_with_boundaries cmd in
-  let rec loop = function
-    | word :: rest when word.starts_command ->
-      let command_words = strip_command_wrappers (word :: rest) in
-      (match command_words with
-       | bin :: args
-         when List.mem (command_name bin.text) task_state_file_probe_command_names
-              && List.exists
-                   (fun arg -> looks_like_task_state_path_token arg.text)
-                   args ->
-         true
-       | _ -> loop rest)
-    | _ :: rest -> loop rest
-    | [] -> false
-  in
-  loop words
-  ||
-  match shell_c_payload words with
-  | Some payload -> mentions_task_state_file payload
-  | None -> false
+let looks_like_discovery =
+  Keeper_shell_bash_task_state.command_looks_like_task_state_discovery
 ;;
 
-let rec looks_like_http_probe cmd =
-  let task_api_url text =
-    (lowercase_contains text "localhost"
-     || lowercase_contains text Masc_network_defaults.masc_http_default_host)
-    && (lowercase_contains text "/api/tasks" || lowercase_contains text "api/tasks")
-  in
-  let http_client_names = [ "curl"; "wget"; "http"; "https"; "xh" ] in
-  let words = shell_words_with_boundaries cmd in
-  let rec loop = function
-    | word :: rest when word.starts_command ->
-      let command_words = strip_command_wrappers (word :: rest) in
-      (match command_words with
-       | bin :: args
-         when List.mem (command_name bin.text) http_client_names
-              && List.exists (fun arg -> task_api_url arg.text) args ->
-         true
-       | _ -> loop rest)
-    | _ :: rest -> loop rest
-    | [] -> false
-  in
-  loop words
-  ||
-  match shell_c_payload words with
-  | Some payload -> looks_like_http_probe payload
-  | None -> false
-;;
-
-let looks_like_discovery cmd =
-  let task_state_marker =
-    lowercase_contains cmd "backlog"
-    || lowercase_contains cmd ".masc"
-    || (lowercase_contains cmd "task" && lowercase_contains cmd ".json")
-  in
-  mentions_task_state_file cmd
-  || looks_like_http_probe cmd
-  ||
-  ((lowercase_contains cmd "find repos" || lowercase_contains cmd "find .")
-   && task_state_marker)
-  ||
-  (lowercase_contains cmd "rg "
-   && lowercase_contains cmd "repos"
-   && task_state_marker)
-;;
-
-let hint =
-  "Do not inspect task state by guessing .masc/backlog.json or repo-local \
-   backlog/task files from Bash. Use keeper_tasks_list for task/backlog state \
-   and keeper_context_status for current_task_id/sandbox paths."
-;;
-
-let alternatives =
-  [ "keeper_tasks_list include_done=false"
-  ; "keeper_context_status"
-  ; "keeper_task_claim {}"
-  ]
-;;
+let hint = Keeper_shell_bash_task_state.task_state_shell_hint
+let alternatives = Keeper_shell_bash_task_state.task_state_shell_alternatives

--- a/lib/keeper/keeper_shell_bash_task_state.ml
+++ b/lib/keeper/keeper_shell_bash_task_state.ml
@@ -17,18 +17,50 @@ let lowercase_contains haystack needle =
   loop 0
 
 let task_state_file_probe_command_names =
-  [ "cat"; "head"; "tail"; "ls"; "find"; "rg"; "grep"; "test"; "[" ]
+  [ "cat"
+  ; "head"
+  ; "tail"
+  ; "ls"
+  ; "find"
+  ; "rg"
+  ; "grep"
+  ; "jq"
+  ; "sed"
+  ; "awk"
+  ; "wc"
+  ; "stat"
+  ; "file"
+  ; "realpath"
+  ; "python"
+  ; "python3"
+  ; "node"
+  ; "test"
+  ; "["
+  ]
+
+let looks_like_masc_runtime_root_token text =
+  let text = String.lowercase_ascii (String.trim text) in
+  String.equal text ".masc" || String.equal text "./.masc"
 
 let looks_like_task_state_path_token text =
   let text = String.lowercase_ascii text in
   let scoped_masc = lowercase_contains text ".masc/" in
   let scoped_worktree = lowercase_contains text ".worktrees/" in
-  (scoped_worktree && lowercase_contains text ".task.json")
+  looks_like_masc_runtime_root_token text
+  || (scoped_worktree && lowercase_contains text ".task.json")
   ||
   (scoped_masc
    && (lowercase_contains text "backlog.json"
        || lowercase_contains text "/tasks"
        || lowercase_contains text "current_task.json"))
+
+let task_state_marker cmd =
+  lowercase_contains cmd "backlog"
+  || lowercase_contains cmd ".masc"
+  || lowercase_contains cmd "current_task"
+  || lowercase_contains cmd "task_state"
+  || lowercase_contains cmd "task-state"
+  || lowercase_contains cmd ".task.json"
 
 let rec command_mentions_task_state_file cmd =
   let words = shell_words_with_boundaries cmd in
@@ -79,20 +111,15 @@ let rec command_looks_like_task_state_http_probe cmd =
   | None -> false
 
 let command_looks_like_task_state_discovery cmd =
-  let task_state_marker =
-    lowercase_contains cmd "backlog"
-    || lowercase_contains cmd ".masc"
-    || (lowercase_contains cmd "task" && lowercase_contains cmd ".json")
-  in
   command_mentions_task_state_file cmd
   || command_looks_like_task_state_http_probe cmd
   ||
-  ((lowercase_contains cmd "find repos" || lowercase_contains cmd "find .")
-   && task_state_marker)
+  (Keeper_shell_bash_repo_wide_scan.command_has_repo_wide_scan cmd
+   && task_state_marker cmd)
   ||
-  (lowercase_contains cmd "rg "
-   && lowercase_contains cmd "repos"
-   && task_state_marker)
+  ((lowercase_contains cmd "rg " || lowercase_contains cmd "grep ")
+   && lowercase_contains cmd ".masc"
+   && task_state_marker cmd)
 
 let task_state_shell_hint =
   "Do not inspect task state by guessing .masc/backlog.json or repo-local \

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -1549,6 +1549,99 @@ let test_keeper_bash_task_state_file_probe_uses_task_tools () =
   Alcotest.(check (option string)) "not returned as bash error" None
     (parse_error_field raw)
 
+let test_keeper_bash_task_state_jq_probe_uses_task_tools () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let meta = make_readonly_meta "task-jq-probe" in
+  let _ = Coord.init config ~agent_name:(Some meta.name) in
+  let playground = Filename.concat base_path (playground_path_of meta.name) in
+  ensure_dir playground;
+  let raw =
+    Keeper_exec_shell.handle_keeper_bash
+      ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None ~exec_cache:None
+      ~config ~meta
+      ~args:
+        (`Assoc
+           [ ("cmd", `String "jq '.tasks[]' .masc/backlog.json")
+           ; ("cwd", `String playground)
+           ])
+      ()
+  in
+  let json = Yojson.Safe.from_string raw in
+  Alcotest.(check bool) "jq task-state probe succeeds via autoroute" true
+    (json |> Json.member "ok" |> Json.to_bool);
+  Alcotest.(check string) "autorouted to tasks list"
+    "keeper_tasks_list"
+    (json |> Json.member "auto_routed_to_tool" |> Json.to_string);
+  Alcotest.(check string) "original error preserved"
+    "task_state_file_probe_blocked"
+    (json |> Json.member "original_error" |> Json.to_string)
+
+let test_keeper_bash_task_state_masc_rg_probe_uses_task_tools () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let meta = make_readonly_meta "task-rg-probe" in
+  let _ = Coord.init config ~agent_name:(Some meta.name) in
+  let playground = Filename.concat base_path (playground_path_of meta.name) in
+  ensure_dir playground;
+  let raw =
+    Keeper_exec_shell.handle_keeper_bash
+      ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None ~exec_cache:None
+      ~config ~meta
+      ~args:
+        (`Assoc
+           [ ("cmd", `String "rg -n current_task .masc")
+           ; ("cwd", `String playground)
+           ])
+      ()
+  in
+  let json = Yojson.Safe.from_string raw in
+  Alcotest.(check bool) ".masc rg probe succeeds via autoroute" true
+    (json |> Json.member "ok" |> Json.to_bool);
+  Alcotest.(check string) "autorouted to tasks list"
+    "keeper_tasks_list"
+    (json |> Json.member "auto_routed_to_tool" |> Json.to_string);
+  Alcotest.(check string) "original error preserved"
+    "task_state_file_probe_blocked"
+    (json |> Json.member "original_error" |> Json.to_string)
+
+let test_keeper_bash_task_state_find_discovery_uses_task_tools () =
+  with_eio_fs @@ fun () ->
+  let base_path, config = make_config () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
+  Keeper_registry.clear ();
+  let meta = make_readonly_meta "task-find-probe" in
+  let _ = Coord.init config ~agent_name:(Some meta.name) in
+  let playground = Filename.concat base_path (playground_path_of meta.name) in
+  ensure_dir playground;
+  let raw =
+    Keeper_exec_shell.handle_keeper_bash
+      ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None ~exec_cache:None
+      ~config ~meta
+      ~args:
+        (`Assoc
+           [ ("cmd", `String "find . -name current_task.json")
+           ; ("cwd", `String playground)
+           ])
+      ()
+  in
+  let json = Yojson.Safe.from_string raw in
+  Alcotest.(check bool) "find task-state discovery succeeds via autoroute" true
+    (json |> Json.member "ok" |> Json.to_bool);
+  Alcotest.(check string) "autorouted to tasks list"
+    "keeper_tasks_list"
+    (json |> Json.member "auto_routed_to_tool" |> Json.to_string);
+  Alcotest.(check string) "original error preserved"
+    "task_state_file_probe_blocked"
+    (json |> Json.member "original_error" |> Json.to_string)
+
 let test_keeper_bash_unrelated_task_json_is_not_task_state_probe () =
   with_eio_fs @@ fun () ->
   let base_path, config = make_config () in
@@ -2295,6 +2388,12 @@ let () =
         test_keeper_bash_cat_dev_null_executes;
       Alcotest.test_case "task-state file probe uses task tools" `Quick
         test_keeper_bash_task_state_file_probe_uses_task_tools;
+      Alcotest.test_case "task-state jq probe uses task tools" `Quick
+        test_keeper_bash_task_state_jq_probe_uses_task_tools;
+      Alcotest.test_case "task-state .masc rg probe uses task tools" `Quick
+        test_keeper_bash_task_state_masc_rg_probe_uses_task_tools;
+      Alcotest.test_case "task-state find discovery uses task tools" `Quick
+        test_keeper_bash_task_state_find_discovery_uses_task_tools;
       Alcotest.test_case "unrelated .task.json is normal file" `Quick
         test_keeper_bash_unrelated_task_json_is_not_task_state_probe;
       Alcotest.test_case "unrelated current_task.json is normal file" `Quick


### PR DESCRIPTION
## Summary
- route task-state shell discovery probes through keeper task tools instead of raw Bash
- collapse duplicate task-state probe detection onto the task-state policy module
- add focused coverage for jq .masc/backlog.json, rg current_task .masc, and repo-wide find current_task.json probes

## Validation
- ocamlformat --check lib/keeper/keeper_shell_bash.ml lib/keeper/keeper_shell_bash_task_probe.ml lib/keeper/keeper_shell_bash_task_state.ml test/test_keeper_bash_safety.ml
- git diff --check codex/board-duplicate-vote-quiet-20260521..HEAD
- focused dune build is queued locally behind /tmp/me-dune-local.lock; CI should validate the stack