### PR TITLE
chore: surface Docker playground fanout on main

### DIFF
--- a/docs/COMMAND-PLANE-RUNBOOK.md
+++ b/docs/COMMAND-PLANE-RUNBOOK.md
@@ -206,6 +206,12 @@ count. Keep the script above as the default visibility path. Set a positive
 `MASC_KEEPER_HOST_FD_HOTSPOT_HEADROOM` only for a deliberately conservative
 operator session.
 
+The status script prints `Top worktree fanout by keeper/repo` and a
+`top_fanout_cleanup_dry_run_command=` for the largest keeper/repo bucket. Use
+that targeted dry-run first when `worktree_entries` is high but
+`top_holder_fd_count=0`; it separates broad playground pressure from an active
+Docker Desktop FD holder spike.
+
 For a broader host check, `scripts/nofile-status.sh` includes this same Docker
 playground section when `MASC_BASE_PATH` or `MASC_DOCKER_PLAYGROUND_ROOT` is
 set. Its `hotspot_status=warning` output is advisory: review the printed

--- a/scripts/docker-playground-fd-status.sh
+++ b/scripts/docker-playground-fd-status.sh
@@ -114,6 +114,30 @@ else
   echo "0 none none none"
 fi
 
+emit_top_fanout_action() {
+  [ -s "$fanout_tmp" ] || return 0
+  local top_fanout_line top_fanout_count top_fanout_keeper top_fanout_repo
+  local quoted_root quoted_keeper quoted_repo
+  top_fanout_line="$(sort -rn "$fanout_tmp" | head -n 1)"
+  set -- $top_fanout_line
+  top_fanout_count="${1:-0}"
+  top_fanout_keeper="${2:-}"
+  top_fanout_repo="${3:-}"
+  [ "$top_fanout_count" -gt 0 ] || return 0
+  [ -n "$top_fanout_keeper" ] || return 0
+  [ -n "$top_fanout_repo" ] || return 0
+  quoted_root="$(printf '%q' "$ROOT")"
+  quoted_keeper="$(printf '%q' "$top_fanout_keeper")"
+  quoted_repo="$(printf '%q' "$top_fanout_repo")"
+  echo "top_fanout_count=$top_fanout_count"
+  echo "top_fanout_keeper=$top_fanout_keeper"
+  echo "top_fanout_repo=$top_fanout_repo"
+  echo "top_fanout_cleanup_dry_run_command=scripts/cleanup-docker-playground-worktrees.sh --root $quoted_root --keeper $quoted_keeper --repo $quoted_repo --days 7"
+  echo "top_fanout_broken_dry_run_command=scripts/cleanup-docker-playground-worktrees.sh --root $quoted_root --keeper $quoted_keeper --repo $quoted_repo --days 7 --include-broken"
+}
+
+emit_top_fanout_action
+
 emit_hotspot_status() {
   local hotspot_status="ok"
   local hotspot_reasons=""

--- a/scripts/docker-playground-fd-status.sh
+++ b/scripts/docker-playground-fd-status.sh
@@ -63,6 +63,16 @@ ROOT="${ROOT%/}"
 worktrees_dirs=0
 worktree_entries=0
 top_holder_fd_count=0
+fanout_tmp="$(mktemp "${TMPDIR:-/tmp}/masc-docker-playground-fanout.XXXXXX")"
+holders_tmp=""
+
+cleanup_tmp() {
+  rm -f "$fanout_tmp"
+  if [ -n "$holders_tmp" ]; then
+    rm -f "$holders_tmp"
+  fi
+}
+trap cleanup_tmp EXIT
 
 if [ -d "$ROOT" ]; then
   for keeper_dir in "$ROOT"/*; do
@@ -73,11 +83,18 @@ if [ -d "$ROOT" ]; then
       [ -d "$repo_dir" ] || continue
       worktrees_dir="$repo_dir/.worktrees"
       [ -d "$worktrees_dir" ] || continue
+      repo_entries=0
       worktrees_dirs=$((worktrees_dirs + 1))
       for wt_path in "$worktrees_dir"/*; do
         [ -d "$wt_path" ] || continue
         worktree_entries=$((worktree_entries + 1))
+        repo_entries=$((repo_entries + 1))
       done
+      if [ "$repo_entries" -gt 0 ]; then
+        printf '%s %s %s %s\n' "$repo_entries" \
+          "$(basename "$keeper_dir")" "$(basename "$repo_dir")" "$worktrees_dir" \
+          >>"$fanout_tmp"
+      fi
     done
   done
 fi
@@ -87,6 +104,15 @@ echo "worktrees_dirs=$worktrees_dirs"
 echo "worktree_entries=$worktree_entries"
 echo "worktree_warn_threshold=$WORKTREE_WARN"
 echo "fd_warn_threshold=$FD_WARN"
+
+echo ""
+echo "Top worktree fanout by keeper/repo:"
+echo "worktree_fanout_columns=count keeper repo worktrees_dir"
+if [ -s "$fanout_tmp" ]; then
+  sort -rn "$fanout_tmp" | head -n "$LIMIT"
+else
+  echo "0 none none none"
+fi
 
 emit_hotspot_status() {
   local hotspot_status="ok"
@@ -125,7 +151,6 @@ fi
 echo ""
 echo "Top FD holders referencing root:"
 holders_tmp="$(mktemp "${TMPDIR:-/tmp}/masc-docker-playground-fd.XXXXXX")"
-trap 'rm -f "$holders_tmp"' EXIT
 if lsof -n -P +c 64 2>/dev/null \
   | awk -v root="$ROOT/" '
       NR > 1 {

--- a/test/test_docker_playground_gc_script.ml
+++ b/test/test_docker_playground_gc_script.ml
@@ -146,6 +146,11 @@ EOF
     in
     check bool "worktree entries surfaced" true
       (contains_substring stdout "worktree_entries=2");
+    check bool "worktree fanout columns surfaced" true
+      (contains_substring stdout
+         "worktree_fanout_columns=count keeper repo worktrees_dir");
+    check bool "keeper fanout row surfaced" true
+      (contains_substring stdout "2 keeper-a masc-mcp");
     check bool "top holder count surfaced" true
       (contains_substring stdout "top_holder_fd_count=2");
     check bool "warning surfaced" true
@@ -181,7 +186,9 @@ let test_status_warns_on_worktree_hotspot_when_lsof_fails () =
     check bool "worktree-only warning surfaced" true
       (contains_substring stdout "hotspot_status=warning");
     check bool "worktree reason surfaced" true
-      (contains_substring stdout "hotspot_reasons=worktree_entries"))
+      (contains_substring stdout "hotspot_reasons=worktree_entries");
+    check bool "fanout still surfaces on lsof failure" true
+      (contains_substring stdout "2 keeper-a masc-mcp"))
 
 let test_dry_run_lists_stale_clean_worktree () =
   with_temp_dir "docker-playground-gc-dry-run" (fun dir ->

--- a/test/test_docker_playground_gc_script.ml
+++ b/test/test_docker_playground_gc_script.ml
@@ -151,6 +151,9 @@ EOF
          "worktree_fanout_columns=count keeper repo worktrees_dir");
     check bool "keeper fanout row surfaced" true
       (contains_substring stdout "2 keeper-a masc-mcp");
+    check bool "top fanout cleanup command surfaced" true
+      (contains_substring stdout
+         "top_fanout_cleanup_dry_run_command=");
     check bool "top holder count surfaced" true
       (contains_substring stdout "top_holder_fd_count=2");
     check bool "warning surfaced" true
@@ -188,7 +191,10 @@ let test_status_warns_on_worktree_hotspot_when_lsof_fails () =
     check bool "worktree reason surfaced" true
       (contains_substring stdout "hotspot_reasons=worktree_entries");
     check bool "fanout still surfaces on lsof failure" true
-      (contains_substring stdout "2 keeper-a masc-mcp"))
+      (contains_substring stdout "2 keeper-a masc-mcp");
+    check bool "top fanout action still surfaces on lsof failure" true
+      (contains_substring stdout
+         "top_fanout_cleanup_dry_run_command="))
 
 let test_dry_run_lists_stale_clean_worktree () =
   with_temp_dir "docker-playground-gc-dry-run" (fun dir ->


### PR DESCRIPTION
Fresh current-main reauthor of the useful #17235 behavior after the stacked #17210 base was closed.\n\nChanges:\n- Adds Docker playground worktree fanout rows by keeper/repo to scripts/docker-playground-fd-status.sh.\n- Emits targeted cleanup dry-run commands for the top fanout bucket.\n- Documents the status/cleanup loop in docs/COMMAND-PLANE-RUNBOOK.md and updates the script regression test.\n\nLocal evidence:\n- git diff --check origin/main..HEAD\n- bash -n scripts/docker-playground-fd-status.sh\n- ocamlformat --check test/test_docker_playground_gc_script.ml\n- live smoke: worktree_entries=147, top_fanout=verifier/masc-mcp=30, hotspot_reasons=worktree_entries\n- targeted cleanup dry-run: scanned=30 candidates=0 recent=30 dirty=0 active=0 broken=0\n\nDune note: scripts/dune-local.sh build test/test_docker_playground_gc_script.exe was attempted twice but refused with code 75 because another session is running bare dune build --root . @check outside the wrapper.