### PR TITLE
fix(keeper): unify workflow rejection warn envelope

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -927,7 +927,18 @@ let make_keeper_tool_handler
               Keeper_metrics.metric_keeper_tools_oas_failures
               ~labels:[ "tool", name; "site", "error_result" ]
               ();
-            (match deterministic_reason, is_workflow_rejection with
+            (* Workflow rejections can arrive either through the
+               deterministic classifier or as a raw failure_class. Normalize
+               the WARN envelope so one root cause does not split across two
+               operator-visible signatures. *)
+            let unified_reason =
+              match deterministic_reason, is_workflow_rejection with
+              | Some _, _ -> deterministic_reason
+              | None, true ->
+                Some Keeper_tool_deterministic_error.Workflow_rejection_blocked
+              | None, false -> None
+            in
+            (match unified_reason, is_workflow_rejection with
              | Some reason, _ ->
                Log.Keeper.warn
                  "tool %s deterministic error (retry skipped, reason=%s): %s"
@@ -935,9 +946,13 @@ let make_keeper_tool_handler
                  (Keeper_tool_deterministic_error.to_telemetry_key reason)
                  detail
              | None, true ->
+               (* Unreachable by construction (see [unified_reason]
+                  above); kept for exhaustiveness. *)
                Log.Keeper.warn
-                 "tool %s returned workflow rejection: %s"
+                 "tool %s deterministic error (retry skipped, reason=%s): %s"
                  name
+                 (Keeper_tool_deterministic_error.to_telemetry_key
+                    Keeper_tool_deterministic_error.Workflow_rejection_blocked)
                  detail
              | None, false ->
                (* MASC/OAS Error-Warn Reduction Goal §P3 adjacency
@@ -1000,6 +1015,8 @@ let make_keeper_tool_handler
                       ; "site", "retry_threshold_silence"
                       ]
                     ()));
+            (* Preserve existing retry-skipped and counter semantics; only
+               the human-readable WARN envelope is unified above. *)
             (match deterministic_reason with
              | Some reason ->
                Prometheus.inc_counter


### PR DESCRIPTION
## Summary

`Log.Keeper.warn` emitted *two distinct* envelopes for the same root cause when a tool returned a workflow rejection: one path went through `deterministic_reason` (with `reason=workflow_rejection_blocked`), and one path went through `is_workflow_rejection` (with no reason key). One root cause split into two operator-visible signatures.

Normalize before the WARN branch by computing `unified_reason` from both inputs, so the rejection always carries the typed `Workflow_rejection_blocked` reason key.

## Why

Operator dashboard groups WARN events by reason key. The split routing meant `workflow_rejection` count was under-reported on one half of the call graph, and the same string showed up in two different shapes in `system_log`.

This is a typed unification — both arms now produce identical `reason=workflow_rejection_blocked` telemetry. The exhaustive match is preserved (the `None, true` arm is now unreachable by construction but kept for exhaustiveness, as commented).

## Files Changed

| 파일 | LoC | 변경 |
|---|---|---|
| `lib/keeper/keeper_tools_oas.ml` | +19/-2 | `unified_reason` normalizer before WARN dispatch; preserve retry+counter semantics |

## Tests

Manual: existing `test_keeper_tools_oas` suite covers the WARN branch — unchanged after diff (reason key now stable across both arms).

No new test case added — assertion would lock the WARN string format, which `feedback_tests_locking_anti_pattern_behavior.md` cautions against. Reviewer should verify telemetry parity by reading `unified_reason` body.

## Risk

- LOW. Single-file, single-function change. The `None, true` arm becomes unreachable by construction but is preserved as catch-all-equivalent (with same WARN format as the `Some _` arm). No public surface change.
- Counter semantics unchanged — `Prometheus.inc_counter` lines below the WARN are untouched.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
