### PR TITLE
refactor(coord): classify fd pressure from exceptions

### DIFF
--- a/lib/coord/coord_gc.ml
+++ b/lib/coord/coord_gc.ml
@@ -53,7 +53,7 @@ let cleanup_zombies
   let scan_paths =
     try if Sys.file_exists agents_path then [ agents_path ] else [] with
     | Eio.Cancel.Cancelled _ as e -> raise e
-    | exn when is_fd_pressure_text (Printexc.to_string exn) ->
+    | exn when is_fd_pressure_exn exn ->
       Log.Gc.warn
         "cleanup_zombies: skipping scan while agent directory is unreadable due to FD pressure: %s"
         (Printexc.to_string exn);
@@ -68,7 +68,7 @@ let cleanup_zombies
       let names =
         try Some (Sys.readdir agents_path) with
         | Eio.Cancel.Cancelled _ as e -> raise e
-        | exn when is_fd_pressure_text (Printexc.to_string exn) ->
+        | exn when is_fd_pressure_exn exn ->
           Log.Gc.warn
             "cleanup_zombies: skipping directory %s while FD pressure is active: %s"
             agents_path
@@ -82,7 +82,7 @@ let cleanup_zombies
         Coord_query.safe_yield ();
         if Filename.check_suffix name ".json" then begin
           let path = Filename.concat agents_path name in
-          match read_agent_with_repair config path with
+          match read_agent_with_repair_result config path with
           | Ok agent
             when (not (List.exists (fun (n, _) -> n = agent.name) !zombie_entries)) &&
                  Coord_resilience.Zombie.is_zombie_for_agent
@@ -93,11 +93,12 @@ let cleanup_zombies
                    agent.last_seen ->
               zombie_entries := (agent.name, path) :: !zombie_entries
           | Ok _ -> () (* not a zombie, skip *)
-          | Error err when is_fd_pressure_text err ->
+          | Error (Agent_fd_pressure exn) ->
               Log.Gc.warn
                 "cleanup_zombies: skipping quarantine for %s because read failed under FD pressure: %s"
-                name err
-          | Error err ->
+                name
+                (Printexc.to_string exn)
+          | Error (Agent_read_error err) ->
               (* #7947: previously deleted the file outright, losing
                  current_task/meta with no postmortem trail.  Quarantine
                  to path.broken-<unix_ms> so operators can inspect the

--- a/lib/coord/coord_utils_ops.ml
+++ b/lib/coord/coord_utils_ops.ml
@@ -148,6 +148,27 @@ let read_json_local path =
 let read_json_local_result path =
   Safe_ops.read_json_file_safe path
 
+type read_json_error =
+  | Json_read_exn of exn
+  | Json_read_error of string
+
+let parse_json_content_result ~context content =
+  let trimmed = String.trim content in
+  if trimmed = "" then Ok (`Assoc [])
+  else Safe_ops.parse_json_safe ~context trimmed
+
+let read_json_local_result_exn path =
+  try
+    if not (Sys.file_exists path) then
+      Error (Json_read_error (Printf.sprintf "File not found: %s" path))
+    else
+      Fs_compat.load_file path
+      |> parse_json_content_result ~context:path
+      |> Result.map_error (fun msg -> Json_read_error msg)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> Error (Json_read_exn exn)
+
 let json_to_pretty_utf8 json =
   json |> Safe_ops.sanitize_json_utf8 |> Yojson.Safe.pretty_to_string
 
@@ -239,11 +260,6 @@ let read_json config path =
   | None -> read_json_local path
 
 let read_json_result config path =
-  let parse_backend_json ~context content =
-    let trimmed = String.trim content in
-    if trimmed = "" then Ok (`Assoc [])
-    else Safe_ops.parse_json_safe ~context trimmed
-  in
   match key_of_path config path with
   | Some key -> begin
       match config.backend with
@@ -251,7 +267,7 @@ let read_json_result config path =
       | Memory _ | FileSystem _ ->
       match backend_get config ~key with
       | Ok (Some content) ->
-          parse_backend_json ~context:"read_json_result" content
+          parse_json_content_result ~context:"read_json_result" content
       | Ok None -> Ok (`Assoc [])
       | Error e ->
           Error
@@ -403,11 +419,8 @@ let agent_json_needs_repair = function
       | Some _ -> false)
   | _ -> false
 
-(* RFC-0154 PR-2: substring vocabulary lives in
-   [System_error_class.classify_string] now.  Wrapper preserved for the
-   one local [read_agent_with_repair] caller below. *)
-let is_fd_pressure_text detail =
-  match System_error_class.classify_string detail with
+let is_fd_pressure_exn exn =
+  match System_error_class.classify_exn exn with
   | System_error_class.Fd_exhaustion -> true
   | System_error_class.Disk_exhaustion
   | System_error_class.Permission_denied
@@ -416,22 +429,64 @@ let is_fd_pressure_text detail =
   | System_error_class.Other _ -> false
 ;;
 
-let read_agent_with_repair config path =
-  (match read_json_result config path with
-   | Error msg when is_fd_pressure_text msg ->
-     Error ("fd_pressure_io: " ^ msg)
-   | Ok _
-   | Error _ ->
-  let json = read_json config path in
-  match Masc_domain.agent_of_yojson json with
-  | Ok agent as ok ->
+type read_agent_error =
+  | Agent_fd_pressure of exn
+  | Agent_read_error of string
+
+let read_agent_json_from_backend config key =
+  match backend_get config ~key with
+  | Ok (Some content) ->
+    parse_json_content_result ~context:"read_agent_with_repair" content
+    |> Result.map_error (fun msg -> Json_read_error msg)
+  | Ok None -> Ok (`Assoc [])
+  | Error e ->
+    Error
+      (Json_read_error
+         (Printf.sprintf
+            "[read_agent_with_repair] backend_get failed for %s: %s"
+            key
+            (Backend_types.show_error e)))
+
+let read_agent_json_result config path =
+  match key_of_path config path with
+  | Some key ->
+    (match config.backend with
+     | FileSystem _ ->
+       (match
+          (try Ok (Sys.file_exists path) with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn -> Error (Json_read_exn exn))
+        with
+        | Ok true -> read_json_local_result_exn path
+        | Ok false -> read_agent_json_from_backend config key
+        | Error _ as err -> err)
+     | Memory _ -> read_agent_json_from_backend config key)
+  | None -> read_json_local_result_exn path
+
+let read_agent_with_repair_result config path =
+  match read_agent_json_result config path with
+  | Error (Json_read_exn exn) when is_fd_pressure_exn exn ->
+    Error (Agent_fd_pressure exn)
+  | Error (Json_read_exn exn) -> Error (Agent_read_error (Printexc.to_string exn))
+  | Error (Json_read_error msg) -> Error (Agent_read_error msg)
+  | Ok json ->
+    (match Masc_domain.agent_of_yojson json with
+     | Ok agent ->
       if agent_json_needs_repair json then (
         Log.Coord.warn
           "agent state repair: repaired agent JSON and rewrote canonical state for %s"
           path;
         write_json config path (Masc_domain.agent_to_yojson agent));
-      ok
-  | Error _ as error -> error)
+      Ok agent
+     | Error msg -> Error (Agent_read_error msg))
+
+let read_agent_with_repair config path =
+  match read_agent_with_repair_result config path with
+  | Ok agent -> Ok agent
+  | Error (Agent_fd_pressure exn) ->
+    let detail = Printexc.to_string exn in
+    Error ("fd_pressure_io: " ^ detail)
+  | Error (Agent_read_error msg) -> Error msg
 
 (* ============================================ *)
 (* File locking                                 *)

--- a/lib/coord/coord_utils_ops.mli
+++ b/lib/coord/coord_utils_ops.mli
@@ -96,9 +96,16 @@ val read_json_opt : config -> string -> Yojson.Safe.t option
     pre-canonical-form) and needs rewriting. *)
 val agent_json_needs_repair : Yojson.Safe.t -> bool
 
-val is_fd_pressure_text : string -> bool
-(** [true] for OS/resource-pressure text that means an agent file could not be
-    opened, not that it is malformed. *)
+val is_fd_pressure_exn : exn -> bool
+(** [true] for typed OS/resource-pressure exceptions that mean an agent file
+    could not be opened, not that it is malformed. *)
+
+type read_agent_error =
+  | Agent_fd_pressure of exn
+  | Agent_read_error of string
+
+val read_agent_with_repair_result :
+  config -> string -> (agent, read_agent_error) result
 
 (** Read an agent JSON and rewrite it in canonical form when the
     [last_seen] repair predicate fires. *)

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -1089,17 +1089,22 @@ let test_cleanup_zombies_removes_broken_agent_file () =
       false (Sys.file_exists path)
   )
 
-let test_fd_pressure_text_classification () =
+let test_fd_pressure_exn_classification () =
   Alcotest.(check bool)
-    "EMFILE text is resource pressure, not malformed JSON"
+    "EMFILE is resource pressure, not malformed JSON"
     true
-    (Coord.is_fd_pressure_text
-       {|[read_json_result] backend_get failed for agents:keeper.json:
-         Eio.Io Unix_error (Too many open files in system, "openat", "/tmp/keeper.json")|});
+    (Coord.is_fd_pressure_exn
+       (Unix.Unix_error (Unix.EMFILE, "openat", "/tmp/keeper.json")));
   Alcotest.(check bool)
-    "schema errors are not resource pressure"
+    "ENFILE is resource pressure, not malformed JSON"
+    true
+    (Coord.is_fd_pressure_exn
+       (Unix.Unix_error (Unix.ENFILE, "openat", "/tmp/keeper.json")));
+  Alcotest.(check bool)
+    "other Unix errors are not FD pressure"
     false
-    (Coord.is_fd_pressure_text "Types_core.agent.last_seen (last_seen=<missing>)")
+    (Coord.is_fd_pressure_exn
+       (Unix.Unix_error (Unix.ETIMEDOUT, "connect", "api")))
 
 let test_cleanup_zombies_preserves_non_json_files () =
   with_test_env (fun config ->
@@ -1932,7 +1937,7 @@ let () =
       Alcotest.test_case "cleanup spares recent keeper" `Quick test_cleanup_zombies_spares_recent_keeper;
       Alcotest.test_case "cleanup spares type keeper" `Quick test_cleanup_zombies_spares_type_keeper;
       Alcotest.test_case "cleanup removes broken agent file" `Quick test_cleanup_zombies_removes_broken_agent_file;
-      Alcotest.test_case "fd pressure text is not broken JSON" `Quick test_fd_pressure_text_classification;
+      Alcotest.test_case "fd pressure exn is not broken JSON" `Quick test_fd_pressure_exn_classification;
       Alcotest.test_case "cleanup preserves non-json files" `Quick test_cleanup_zombies_preserves_non_json_files;
     ];
 


### PR DESCRIPTION
## Summary
- replace the Coord GC fd-pressure substring classifier with `System_error_class.classify_exn`
- add a typed `read_agent_with_repair_result` path so GC can distinguish FD pressure from malformed agent JSON without parsing error strings
- update `test_room` coverage to assert EMFILE/ENFILE true and unrelated Unix errors false

## Verification
- `rg -n "is_fd_pressure_text|Coord\\.is_fd_pressure_text|fd_pressure.*string" lib/coord test/test_room.ml` returns no matches
- `ocamlformat --check lib/coord/coord_utils_ops.ml lib/coord/coord_utils_ops.mli lib/coord/coord_gc.ml test/test_room.ml`
- `git diff --check origin/main...HEAD`
- attempted `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build ./test/test_room.exe`, but local Dune was blocked by the shared lock queue before completion; PR CI is the authoritative compile/test gate
