### PR TITLE
refactor(keeper_heartbeat_loop): extract semaphore_wait_timeout sibling (-100 LOC)

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -587,117 +587,17 @@ let run_keeper_cycle_with_slot
     updated
 ;;
 
-let semaphore_wait_timeout_blocker_class
-      (timeout : Keeper_turn_slot.semaphore_wait_timeout)
-  =
-  match timeout.timeout_phase with
-  | Keeper_turn_slot.Autonomous_queue_head -> Keeper_types.Admission_queue_wait_timeout
-  | Keeper_turn_slot.Autonomous_slot -> Keeper_types.Autonomous_slot_wait_timeout
-  | Keeper_turn_slot.Reactive_slot | Keeper_turn_slot.Turn_slot ->
-    Keeper_types.Turn_timeout_after_queue_wait
+let semaphore_wait_timeout_blocker_class =
+  Keeper_heartbeat_loop_semaphore_timeout.semaphore_wait_timeout_blocker_class
 ;;
 
-let semaphore_wait_timeout_diagnostics
-      ~cascade_name
-      (timeout : Keeper_turn_slot.semaphore_wait_timeout)
-  =
-  let phase_label =
-    Keeper_turn_slot.semaphore_wait_phase_to_string timeout.timeout_phase
-  in
-  let queue_ahead_text =
-    match timeout.timeout_phase, timeout.timeout_queue_ahead with
-    | Keeper_turn_slot.Autonomous_queue_head, Some ahead ->
-      Printf.sprintf " queue_blocker=autonomous_fifo queue_ahead=%d" ahead
-    | Keeper_turn_slot.Autonomous_queue_head, None ->
-      " queue_blocker=autonomous_fifo queue_ahead=unknown"
-    | _, Some ahead -> Printf.sprintf " queue_ahead=%d" ahead
-    | _, None -> ""
-  in
-  let persisted_blocker =
-    Printf.sprintf
-      "skipped: semaphore wait > %.0fs phase=%s (cascade=%s%s queue_depth=%d \
-       autonomous_available=%d reactive_available=%d turn_available=%d)"
-      timeout.timeout_wait_sec
-      phase_label
-      cascade_name
-      queue_ahead_text
-      timeout.timeout_queue_depth
-      timeout.timeout_autonomous_available
-      timeout.timeout_reactive_available
-      timeout.timeout_turn_available
-  in
-  let log_diagnostic =
-    match timeout.timeout_phase with
-    | Keeper_turn_slot.Autonomous_queue_head ->
-      let ahead_text =
-        match timeout.timeout_queue_ahead with
-        | Some ahead -> string_of_int ahead
-        | None -> "unknown"
-      in
-      Printf.sprintf
-        "%s queue_head=[blocker=autonomous_fifo ahead=%s depth=%d]"
-        persisted_blocker
-        ahead_text
-        timeout.timeout_queue_depth
-    | Keeper_turn_slot.Autonomous_slot
-    | Keeper_turn_slot.Reactive_slot
-    | Keeper_turn_slot.Turn_slot ->
-      let holder_text =
-        match timeout.timeout_holders with
-        | [] -> "none"
-        | holders ->
-          holders
-          |> List.map (fun (name, age) -> Printf.sprintf "%s/%.0fs" name age)
-          |> String.concat ", "
-      in
-      Printf.sprintf "%s holders=[%s]" persisted_blocker holder_text
-  in
-  persisted_blocker, log_diagnostic
+let semaphore_wait_timeout_diagnostics =
+  Keeper_heartbeat_loop_semaphore_timeout.semaphore_wait_timeout_diagnostics
 ;;
 
-(** Handle semaphore wait timeout for legacy path. *)
-let handle_semaphore_wait_timeout
-      ~ctx
-      ~meta_after_triage
-      ~(turn_decision : Keeper_world_observation.keeper_cycle_decision)
-      (timeout : Keeper_turn_slot.semaphore_wait_timeout)
-  =
-  let phase_label =
-    Keeper_turn_slot.semaphore_wait_phase_to_string timeout.timeout_phase
-  in
-  record_semaphore_wait_observation
-    ~base_path:ctx.config.base_path
-    ~keeper_name:meta_after_triage.name
-    ~channel:turn_decision.channel
-    ~phase_label
-    ~kind:Semaphore_wait_timeout
-    ();
-  let persisted_blocker, log_diagnostic =
-    semaphore_wait_timeout_diagnostics
-      ~cascade_name:(cascade_name_of_meta meta_after_triage)
-      timeout
-  in
-  let blocker_class = semaphore_wait_timeout_blocker_class timeout in
-  Log.Keeper.warn "%s: skipping turn (%s)" meta_after_triage.name log_diagnostic;
-  Prometheus.inc_counter
-    Keeper_metrics.metric_keeper_semaphore_wait_timeout
-    ~labels:
-      [ "keeper", meta_after_triage.name
-      ; "channel", Keeper_world_observation.channel_to_string turn_decision.channel
-      ]
-    ();
-  Keeper_types.map_runtime
-    (fun rt ->
-       { rt with
-         last_blocker =
-           Some
-             (Keeper_meta_contract.blocker_info_of_class
-                ~detail:persisted_blocker
-                blocker_class)
-       })
-    meta_after_triage
+let handle_semaphore_wait_timeout =
+  Keeper_heartbeat_loop_semaphore_timeout.handle_semaphore_wait_timeout
 ;;
-
 let run_keepalive_unified_turn
       ~(ctx : _ context)
       ~(meta_after_triage : keeper_meta)

--- a/lib/keeper/keeper_heartbeat_loop_semaphore_timeout.ml
+++ b/lib/keeper/keeper_heartbeat_loop_semaphore_timeout.ml
@@ -1,0 +1,127 @@
+(** Semaphore-wait timeout helpers for the heartbeat loop, extracted from
+    [keeper_heartbeat_loop.ml]. Holds the blocker-class mapping, diagnostic
+    formatter, and the [handle_semaphore_wait_timeout] entry used by the
+    legacy heartbeat path. *)
+
+open Keeper_types
+module Observations = Keeper_heartbeat_loop_observations
+
+(* Re-export the kind constructors so the body below can write
+   [~kind:Semaphore_wait_timeout] without an Observations. prefix. *)
+type semaphore_wait_observation_kind = Observations.semaphore_wait_observation_kind =
+  | Semaphore_wait_pending
+  | Semaphore_wait_timeout
+
+let record_semaphore_wait_observation = Observations.record_semaphore_wait_observation
+
+let semaphore_wait_timeout_blocker_class
+      (timeout : Keeper_turn_slot.semaphore_wait_timeout)
+  =
+  match timeout.timeout_phase with
+  | Keeper_turn_slot.Autonomous_queue_head -> Keeper_types.Admission_queue_wait_timeout
+  | Keeper_turn_slot.Autonomous_slot -> Keeper_types.Autonomous_slot_wait_timeout
+  | Keeper_turn_slot.Reactive_slot | Keeper_turn_slot.Turn_slot ->
+    Keeper_types.Turn_timeout_after_queue_wait
+;;
+
+let semaphore_wait_timeout_diagnostics
+      ~cascade_name
+      (timeout : Keeper_turn_slot.semaphore_wait_timeout)
+  =
+  let phase_label =
+    Keeper_turn_slot.semaphore_wait_phase_to_string timeout.timeout_phase
+  in
+  let queue_ahead_text =
+    match timeout.timeout_phase, timeout.timeout_queue_ahead with
+    | Keeper_turn_slot.Autonomous_queue_head, Some ahead ->
+      Printf.sprintf " queue_blocker=autonomous_fifo queue_ahead=%d" ahead
+    | Keeper_turn_slot.Autonomous_queue_head, None ->
+      " queue_blocker=autonomous_fifo queue_ahead=unknown"
+    | _, Some ahead -> Printf.sprintf " queue_ahead=%d" ahead
+    | _, None -> ""
+  in
+  let persisted_blocker =
+    Printf.sprintf
+      "skipped: semaphore wait > %.0fs phase=%s (cascade=%s%s queue_depth=%d \
+       autonomous_available=%d reactive_available=%d turn_available=%d)"
+      timeout.timeout_wait_sec
+      phase_label
+      cascade_name
+      queue_ahead_text
+      timeout.timeout_queue_depth
+      timeout.timeout_autonomous_available
+      timeout.timeout_reactive_available
+      timeout.timeout_turn_available
+  in
+  let log_diagnostic =
+    match timeout.timeout_phase with
+    | Keeper_turn_slot.Autonomous_queue_head ->
+      let ahead_text =
+        match timeout.timeout_queue_ahead with
+        | Some ahead -> string_of_int ahead
+        | None -> "unknown"
+      in
+      Printf.sprintf
+        "%s queue_head=[blocker=autonomous_fifo ahead=%s depth=%d]"
+        persisted_blocker
+        ahead_text
+        timeout.timeout_queue_depth
+    | Keeper_turn_slot.Autonomous_slot
+    | Keeper_turn_slot.Reactive_slot
+    | Keeper_turn_slot.Turn_slot ->
+      let holder_text =
+        match timeout.timeout_holders with
+        | [] -> "none"
+        | holders ->
+          holders
+          |> List.map (fun (name, age) -> Printf.sprintf "%s/%.0fs" name age)
+          |> String.concat ", "
+      in
+      Printf.sprintf "%s holders=[%s]" persisted_blocker holder_text
+  in
+  persisted_blocker, log_diagnostic
+;;
+
+(** Handle semaphore wait timeout for legacy path. *)
+let handle_semaphore_wait_timeout
+      ~ctx
+      ~meta_after_triage
+      ~(turn_decision : Keeper_world_observation.keeper_cycle_decision)
+      (timeout : Keeper_turn_slot.semaphore_wait_timeout)
+  =
+  let phase_label =
+    Keeper_turn_slot.semaphore_wait_phase_to_string timeout.timeout_phase
+  in
+  record_semaphore_wait_observation
+    ~base_path:ctx.config.base_path
+    ~keeper_name:meta_after_triage.name
+    ~channel:turn_decision.channel
+    ~phase_label
+    ~kind:Semaphore_wait_timeout
+    ();
+  let persisted_blocker, log_diagnostic =
+    semaphore_wait_timeout_diagnostics
+      ~cascade_name:(cascade_name_of_meta meta_after_triage)
+      timeout
+  in
+  let blocker_class = semaphore_wait_timeout_blocker_class timeout in
+  Log.Keeper.warn "%s: skipping turn (%s)" meta_after_triage.name log_diagnostic;
+  Prometheus.inc_counter
+    Keeper_metrics.metric_keeper_semaphore_wait_timeout
+    ~labels:
+      [ "keeper", meta_after_triage.name
+      ; "channel", Keeper_world_observation.channel_to_string turn_decision.channel
+      ]
+    ();
+  Keeper_types.map_runtime
+    (fun rt ->
+       { rt with
+         last_blocker =
+           Some
+             (Keeper_meta_contract.blocker_info_of_class
+                ~detail:persisted_blocker
+                blocker_class)
+       })
+    meta_after_triage
+;;
+


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane B (Keeper Runtime), `keeper_heartbeat_loop.ml` cluster #4
- Carved out the semaphore-wait-timeout helpers (~111 LOC, three functions) into a sibling.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/keeper/keeper_heartbeat_loop.ml` | 1607 | 1507 | **-100** |
| `lib/keeper/keeper_heartbeat_loop_semaphore_timeout.ml` | — | 127 | +127 |

## Moved (verbatim, no behavior change)
- `semaphore_wait_timeout_blocker_class`
- `semaphore_wait_timeout_diagnostics`
- `handle_semaphore_wait_timeout`

Parent file keeps three single-line aliases — callers unaffected.

## Sibling deps
- `Keeper_types` (opened) — provides `cascade_name_of_meta`, `map_runtime`, `keeper_meta`
- `Keeper_heartbeat_loop_observations` — `record_semaphore_wait_observation`, kind type re-exported transparently

No sibling -> parent cycle introduced.

## Local build status
- `dune build @check`: only pre-existing main breakage (`Agent_sdk.Tool.evidence_role`) remains, unrelated
- godfile lint: clean (absolute_cap=3350, new_file_cap=600)

## RFC-WAIVED
Extract-only sibling refactor.

Co-Authored-By: codex <noreply@anthropic.com>
