### PR TITLE
refactor(server_dashboard_http_core): extract meta-cognition cluster sibling (-76 LOC)

### DIFF
--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -1026,97 +1026,21 @@ let dashboard_shell_timeout_for ~light =
    noise in the log. Give it its own cache with a longer TTL, and on a cold
    miss warm it in the background so the shell path never blocks on the
    initial full JSONL scan. *)
-(* Meta-cognition summary cache extracted to
-   [Server_dashboard_meta_cognition_cache] (godfile decomp). *)
-module Mc_cache = Server_dashboard_meta_cognition_cache
+(* Meta-cognition summary cache + dashboard shell cache key helpers extracted to
+   [Server_dashboard_http_core_meta_cognition] (godfile decomp). *)
+module Mc_cache = Server_dashboard_http_core_meta_cognition.Mc_cache
 
-let meta_cognition_summary_ttl = Mc_cache.summary_ttl
-let meta_cognition_summary_stale_for = Mc_cache.summary_stale_for
-let meta_cognition_summary_empty_json = Mc_cache.summary_empty_json
-
-let dashboard_shell_cache_prefix (config : Coord.config) =
-  Printf.sprintf "shell:coord=%s:" config.base_path
-;;
-
-let dashboard_shell_cache_key ?(light = false) (config : Coord.config) =
-  Printf.sprintf
-    "%sworkspace=%s:mode=%s"
-    (dashboard_shell_cache_prefix config)
-    config.workspace_path
-    (if light then "light" else "full")
-;;
-
-let meta_cognition_summary_key (config : Coord.config) =
-  dashboard_cache_key config "meta_cognition_summary" "dashboard_shell"
-;;
-
-let store_last_good_meta_cognition_summary = Mc_cache.store_last_good
-let find_last_good_meta_cognition_summary = Mc_cache.find_last_good
-let clear_meta_cognition_warm_flag = Mc_cache.clear_warm_flag
-
-let schedule_meta_cognition_summary_warm (config : Coord.config) =
-  let key = meta_cognition_summary_key config in
-  let compute () =
-    let json = Meta_cognition.summary_json config in
-    Mc_cache.store_last_good key json;
-    json
-  in
-  if Mc_cache.try_acquire_warm_slot key
-  then (
-    match Eio_context.get_switch_opt () with
-    | Some sw ->
-      Eio.Fiber.fork ~sw (fun () ->
-        Eio_guard.protect
-          ~finally:(fun () -> Mc_cache.clear_warm_flag key)
-          (fun () ->
-             try
-               Dashboard_cache.invalidate key;
-               ignore
-                 (Dashboard_cache.get_or_compute
-                    key
-                    ~ttl:Mc_cache.summary_ttl
-                    compute)
-               (* Drop cached shell payloads that were rendered while the
-                     meta-cognition summary was still warming. *);
-               Dashboard_cache.invalidate_prefix (dashboard_shell_cache_prefix config)
-             with
-             | Eio.Cancel.Cancelled _ as e -> raise e
-             | exn ->
-               Log.Server.warn
-                 "dashboard shell meta_cognition warm failed: %s"
-                 (Printexc.to_string exn)))
-    | None -> Mc_cache.clear_warm_flag key)
-;;
-
-let meta_cognition_summary_cached (config : Coord.config) : Yojson.Safe.t =
-  let key = meta_cognition_summary_key config in
-  let fallback =
-    match find_last_good_meta_cognition_summary key with
-    | Some json -> json
-    | None -> meta_cognition_summary_empty_json
-  in
-  let compute () =
-    let json = Meta_cognition.summary_json config in
-    store_last_good_meta_cognition_summary key json;
-    json
-  in
-  match Dashboard_cache.peek key with
-  | Some _ ->
-    let result =
-      Dashboard_cache.get_or_compute key ~ttl:meta_cognition_summary_ttl compute
-    in
-    if result = `Null then fallback else result
-  | None ->
-    (match find_last_good_meta_cognition_summary key with
-     | Some stale ->
-       Dashboard_cache.seed_stale_if_missing
-         key
-         ~stale_for:meta_cognition_summary_stale_for
-         stale
-     | None -> ());
-    schedule_meta_cognition_summary_warm config;
-    if fallback = meta_cognition_summary_empty_json then `Null else fallback
-;;
+let meta_cognition_summary_ttl = Server_dashboard_http_core_meta_cognition.meta_cognition_summary_ttl
+let meta_cognition_summary_stale_for = Server_dashboard_http_core_meta_cognition.meta_cognition_summary_stale_for
+let meta_cognition_summary_empty_json = Server_dashboard_http_core_meta_cognition.meta_cognition_summary_empty_json
+let dashboard_shell_cache_prefix = Server_dashboard_http_core_meta_cognition.dashboard_shell_cache_prefix
+let dashboard_shell_cache_key = Server_dashboard_http_core_meta_cognition.dashboard_shell_cache_key
+let meta_cognition_summary_key = Server_dashboard_http_core_meta_cognition.meta_cognition_summary_key
+let store_last_good_meta_cognition_summary = Server_dashboard_http_core_meta_cognition.store_last_good_meta_cognition_summary
+let find_last_good_meta_cognition_summary = Server_dashboard_http_core_meta_cognition.find_last_good_meta_cognition_summary
+let clear_meta_cognition_warm_flag = Server_dashboard_http_core_meta_cognition.clear_meta_cognition_warm_flag
+let schedule_meta_cognition_summary_warm = Server_dashboard_http_core_meta_cognition.schedule_meta_cognition_summary_warm
+let meta_cognition_summary_cached = Server_dashboard_http_core_meta_cognition.meta_cognition_summary_cached
 
 let dashboard_shell_paths_json (config : Coord.config) : Yojson.Safe.t =
   Server_base_path_diagnostics.detect

--- a/lib/server/server_dashboard_http_core_meta_cognition.ml
+++ b/lib/server/server_dashboard_http_core_meta_cognition.ml
@@ -1,0 +1,99 @@
+(** Meta-cognition summary cache surface for dashboard HTTP core, extracted
+    from [server_dashboard_http_core.ml]. Wraps [Server_dashboard_meta_cognition_cache]
+    with the dashboard-cache key derivation and the warm-fork scheduler. *)
+
+open Masc_domain
+
+(* Meta-cognition summary cache extracted to
+   [Server_dashboard_meta_cognition_cache] (godfile decomp). *)
+module Mc_cache = Server_dashboard_meta_cognition_cache
+
+let dashboard_cache_key = Server_dashboard_http_core_cache.dashboard_cache_key
+
+let meta_cognition_summary_ttl = Mc_cache.summary_ttl
+let meta_cognition_summary_stale_for = Mc_cache.summary_stale_for
+let meta_cognition_summary_empty_json = Mc_cache.summary_empty_json
+
+let dashboard_shell_cache_prefix (config : Coord.config) =
+  Printf.sprintf "shell:coord=%s:" config.base_path
+;;
+
+let dashboard_shell_cache_key ?(light = false) (config : Coord.config) =
+  Printf.sprintf
+    "%sworkspace=%s:mode=%s"
+    (dashboard_shell_cache_prefix config)
+    config.workspace_path
+    (if light then "light" else "full")
+;;
+
+let meta_cognition_summary_key (config : Coord.config) =
+  dashboard_cache_key config "meta_cognition_summary" "dashboard_shell"
+;;
+
+let store_last_good_meta_cognition_summary = Mc_cache.store_last_good
+let find_last_good_meta_cognition_summary = Mc_cache.find_last_good
+let clear_meta_cognition_warm_flag = Mc_cache.clear_warm_flag
+
+let schedule_meta_cognition_summary_warm (config : Coord.config) =
+  let key = meta_cognition_summary_key config in
+  let compute () =
+    let json = Meta_cognition.summary_json config in
+    Mc_cache.store_last_good key json;
+    json
+  in
+  if Mc_cache.try_acquire_warm_slot key
+  then (
+    match Eio_context.get_switch_opt () with
+    | Some sw ->
+      Eio.Fiber.fork ~sw (fun () ->
+        Eio_guard.protect
+          ~finally:(fun () -> Mc_cache.clear_warm_flag key)
+          (fun () ->
+             try
+               Dashboard_cache.invalidate key;
+               ignore
+                 (Dashboard_cache.get_or_compute
+                    key
+                    ~ttl:Mc_cache.summary_ttl
+                    compute)
+               (* Drop cached shell payloads that were rendered while the
+                     meta-cognition summary was still warming. *);
+               Dashboard_cache.invalidate_prefix (dashboard_shell_cache_prefix config)
+             with
+             | Eio.Cancel.Cancelled _ as e -> raise e
+             | exn ->
+               Log.Server.warn
+                 "dashboard shell meta_cognition warm failed: %s"
+                 (Printexc.to_string exn)))
+    | None -> Mc_cache.clear_warm_flag key)
+;;
+
+let meta_cognition_summary_cached (config : Coord.config) : Yojson.Safe.t =
+  let key = meta_cognition_summary_key config in
+  let fallback =
+    match find_last_good_meta_cognition_summary key with
+    | Some json -> json
+    | None -> meta_cognition_summary_empty_json
+  in
+  let compute () =
+    let json = Meta_cognition.summary_json config in
+    store_last_good_meta_cognition_summary key json;
+    json
+  in
+  match Dashboard_cache.peek key with
+  | Some _ ->
+    let result =
+      Dashboard_cache.get_or_compute key ~ttl:meta_cognition_summary_ttl compute
+    in
+    if result = `Null then fallback else result
+  | None ->
+    (match find_last_good_meta_cognition_summary key with
+     | Some stale ->
+       Dashboard_cache.seed_stale_if_missing
+         key
+         ~stale_for:meta_cognition_summary_stale_for
+         stale
+     | None -> ());
+    schedule_meta_cognition_summary_warm config;
+    if fallback = meta_cognition_summary_empty_json then `Null else fallback
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` step 20 (Dashboard core surface split — meta-cognition cluster)
- Fourth sibling extracted from `server_dashboard_http_core.ml` after #17126 (cache), #17215 (operator), #17254 (json).

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/server/server_dashboard_http_core.ml` | 1648 | 1572 | **-76** |
| `lib/server/server_dashboard_http_core_meta_cognition.ml` | — | 99 | +99 |

## Moved (verbatim, no behavior change)
- `module Mc_cache = Server_dashboard_meta_cognition_cache`
- `meta_cognition_summary_ttl`, `_stale_for`, `_empty_json`
- `dashboard_shell_cache_prefix`, `dashboard_shell_cache_key`
- `meta_cognition_summary_key`
- `store_last_good_meta_cognition_summary`, `find_last_good_meta_cognition_summary`
- `clear_meta_cognition_warm_flag`
- `schedule_meta_cognition_summary_warm` (warm-fork scheduler)
- `meta_cognition_summary_cached` (cache entry point)

12 bindings via single-line aliases.

## Sibling deps
- `Server_dashboard_meta_cognition_cache` (aliased `Mc_cache`)
- `Server_dashboard_http_core_cache.dashboard_cache_key`
- `Coord`, `Meta_cognition`, `Dashboard_cache`
- `Eio_context`, `Eio.Fiber`, `Eio_guard`, `Log.Server`

No sibling -> parent cycle introduced.

## Local build status
- `dune build @check`: only pre-existing main breakage remains (`dashboard_request_timeout_s` in `server_dashboard_http_core_json.ml`, and `Agent_sdk.Tool.evidence_role`) — unrelated
- godfile lint: clean (absolute_cap=3350, new_file_cap=600)

## .mli surface
`dashboard_shell_cache_key` was the only one of these in the `.mli`. The alias keeps the public signature byte-identical.

## RFC-WAIVED
Extract-only sibling refactor.

Co-Authored-By: codex <noreply@anthropic.com>
