### PR TITLE
fix(worker): classify local tool telemetry failures on main

### DIFF
--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -330,6 +330,14 @@ let build_oas_mcp_tools ~sw ~auth_token ~session_id ~worker_name =
                }))
     listed_schemas
 
+let local_worker_failure_class_of_error_kind = function
+  | Worker_dev_tools.Path_blocked -> Tool_result.Policy_rejection
+  | Worker_dev_tools.Command_blocked -> Tool_result.Workflow_rejection
+  | Worker_dev_tools.File_read_error
+  | Worker_dev_tools.File_write_error
+  | Worker_dev_tools.Shell_error ->
+    Tool_result.Runtime_failure
+
 let build_local_shell_tools ~room_config ~worker_name ~workdir =
   match Process_eio.get_proc_mgr (), Process_eio.get_clock () with
   | Ok proc_mgr, Ok clock -> (
@@ -350,9 +358,12 @@ let build_local_shell_tools ~room_config ~worker_name ~workdir =
                     |> Telemetry_eio.error_kind_of_string)
                   error_kind
               in
+              let failure_class =
+                Option.map local_worker_failure_class_of_error_kind error_kind
+              in
               Telemetry_eio.track_tool_called ~fs config ~tool_name ~success
                 ~duration_ms ~agent_id:worker_name
-                ?error_kind:kind ?error_message ()
+                ?failure_class ?error_kind:kind ?error_message ()
             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
               Log.LocalWorker.warn "telemetry error for %s/%s: %s"
                 worker_name tool_name (Printexc.to_string exn))

--- a/test/test_worker_container_coverage.ml
+++ b/test/test_worker_container_coverage.ml
@@ -21,6 +21,26 @@ let worker_usage ?cost_usd ~input_tokens ~output_tokens () :
     cost_usd;
   }
 
+let find_tool name tools =
+  List.find (fun (t : Agent_sdk.Tool.t) -> String.equal t.schema.name name) tools
+
+let rec cleanup_path path =
+  if Sys.file_exists path then
+    match Unix.lstat path with
+    | { Unix.st_kind = Unix.S_DIR; _ } ->
+      Array.iter
+        (fun child -> cleanup_path (Filename.concat path child))
+        (Sys.readdir path);
+      Unix.rmdir path
+    | _ -> Unix.unlink path
+
+let explicit_events config =
+  Telemetry_eio.read_all_events config
+  |> List.filter (fun (record : Telemetry_eio.event_record) ->
+         match record.event with
+         | Telemetry_eio.Agent_joined _ -> false
+         | _ -> true)
+
 let test_parse_text_tool_calls_single () =
   let content =
     {|mcp__masc__masc_keeper_msg(name="keeper-alpha", message="[local64-smoke-01] manager decide online for hybrid smoke")|}
@@ -79,6 +99,58 @@ let test_mcp_endpoint_url_does_not_leak_token () =
     in
     check string "mcp url stays clean" "http://127.0.0.1:8935/mcp" url)
 
+let test_local_shell_failure_class_reaches_tool_called () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Process_eio.reset_for_testing ();
+  Process_eio.init ~cwd_default:(Eio.Stdenv.cwd env)
+    ~proc_mgr:(Eio.Stdenv.process_mgr env) ~clock:(Eio.Stdenv.clock env);
+  let base_dir = Filename.temp_file "worker_container_telemetry_" "" in
+  Sys.remove base_dir;
+  Unix.mkdir base_dir 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      Process_eio.reset_for_testing ();
+      cleanup_path base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      (* See test setup: Coord.init side effect creates the room store. *)
+      ignore (Coord.init config ~agent_name:(Some "owner"));
+      let tools =
+        match
+          Worker_container.build_local_shell_tools
+            ~room_config:(Some config)
+            ~worker_name:"local-worker-test"
+            ~workdir:base_dir
+        with
+        | Ok tools -> tools
+        | Error err -> failf "expected local shell tools: %s" err
+      in
+      let shell = find_tool "shell_exec" tools in
+      (match
+         Agent_sdk.Tool.execute shell
+           (`Assoc [ "command", `String "rm -rf /" ])
+       with
+       | Error _ -> ()
+       | Ok _ -> fail "blocked shell command should fail");
+      match
+        explicit_events config
+        |> List.find_opt (fun (record : Telemetry_eio.event_record) ->
+               match record.event with
+               | Telemetry_eio.Tool_called r ->
+                 String.equal r.tool_name "shell_exec" && not r.success
+               | _ -> false)
+      with
+      | Some { Telemetry_eio.event = Telemetry_eio.Tool_called r; _ } ->
+        check (option string) "error_kind"
+          (Some "command_blocked")
+          (Option.map Telemetry_eio.error_kind_to_string r.error_kind);
+        check (option string) "failure_class"
+          (Some "workflow_rejection")
+          (Option.map Tool_result.tool_failure_class_to_string r.failure_class)
+      | Some _ -> fail "expected Tool_called"
+      | None -> fail "missing failed shell_exec telemetry")
+
 let () =
   run "Worker_runtime"
     [
@@ -94,5 +166,7 @@ let () =
             test_merge_usage_sums_costs_when_both_present;
           test_case "mcp endpoint url does not leak token" `Quick
             test_mcp_endpoint_url_does_not_leak_token;
+          test_case "local shell failure_class reaches telemetry" `Quick
+            test_local_shell_failure_class_reaches_tool_called;
         ] );
     ]


### PR DESCRIPTION
Fresh current-main reauthor of the useful #17225 behavior after the stacked #17210 base was closed.\n\nChanges:\n- Maps Worker_dev_tools failure categories into typed Tool_result failure classes before Telemetry_eio.Tool_called is written.\n- Preserves blocked local shell execution as success=false with error_kind=command_blocked and failure_class=workflow_rejection.\n- Adds worker container coverage for typed local-tool failure causality.\n\nLocal evidence:\n- git diff --check origin/main..HEAD\n- ocamlformat --check lib/local/worker_container.ml test/test_worker_container_coverage.ml\n\nDune note: scripts/dune-local.sh build test/test_worker_container_coverage.exe was attempted but refused with code 75 because another session is running bare dune build --root ... outside scripts/dune-local.sh.