### PR TITLE
fix(keeper): expose configured github identity

### DIFF
--- a/lib/keeper/keeper_tool_github_pr.ml
+++ b/lib/keeper/keeper_tool_github_pr.ml
@@ -22,6 +22,10 @@ let binding_json (binding : Keeper_gh_env.keeper_binding) ~state =
   `Assoc
     [
       "effective_github_identity", `String binding.effective_github_identity;
+      ( "configured_github_identity",
+        match binding.github_identity with
+        | Some id -> `String id
+        | None -> `Null );
       ( "credential_scope",
         `String
           (Keeper_gh_env.credential_scope_to_string binding.credential_scope) );

--- a/lib/keeper/keeper_tool_pr_review.ml
+++ b/lib/keeper/keeper_tool_pr_review.ml
@@ -82,6 +82,10 @@ let binding_json (binding : Keeper_gh_env.keeper_binding) =
   `Assoc
     [
       "effective_github_identity", `String binding.effective_github_identity;
+      ( "configured_github_identity",
+        match binding.github_identity with
+        | Some id -> `String id
+        | None -> `Null );
       ( "credential_scope",
         `String
           (Keeper_gh_env.credential_scope_to_string binding.credential_scope) );
@@ -122,6 +126,10 @@ let identity_attestation_fields ~(config : Coord.config) (meta : keeper_meta) =
                  "credential_binding_ok", `Bool true;
                  ( "effective_github_identity",
                    `String binding.effective_github_identity );
+                 ( "configured_github_identity",
+                   match binding.github_identity with
+                   | Some id -> `String id
+                   | None -> `Null );
                  ( "credential_scope",
                    `String
                      (Keeper_gh_env.credential_scope_to_string

--- a/test/test_keeper_github_pr.ml
+++ b/test/test_keeper_github_pr.ml
@@ -232,6 +232,12 @@ let parse_string_field raw field =
 let parse_bool_field raw field =
   Yojson.Safe.from_string raw |> Json.member field |> Json.to_bool_option
 
+let parse_nested_string_field raw outer field =
+  Yojson.Safe.from_string raw
+  |> Json.member outer
+  |> Json.member field
+  |> Json.to_string_option
+
 let test_pr_list_argv_uses_repo_state_limit_json () =
   check (list string) "argv"
     [
@@ -359,6 +365,11 @@ let test_pr_create_routes_through_docker () =
   (match parse_string_field raw "via" with
    | Some via -> check string "pr create via docker" "docker" via
    | None -> Alcotest.failf "missing via in response: %s" raw);
+  check (option string) "pr create effective identity" (Some "root")
+    (parse_nested_string_field raw "credential" "effective_github_identity");
+  check (option string) "pr create configured identity omitted for root fallback"
+    None
+    (parse_nested_string_field raw "credential" "configured_github_identity");
   let log = read_file log_path in
   check bool "used docker run" true (contains_substring log "run --rm");
   check bool "uses gh pr create" true

--- a/test/test_keeper_pr_review.ml
+++ b/test/test_keeper_pr_review.ml
@@ -26,6 +26,19 @@ let with_env key value f =
       | None -> Unix.putenv key "")
     f
 
+let with_config_dir config_dir f =
+  let prior = Sys.getenv_opt "MASC_CONFIG_DIR" in
+  Fun.protect
+    ~finally:(fun () ->
+      (match prior with
+       | Some value -> Unix.putenv "MASC_CONFIG_DIR" value
+       | None -> Unix.putenv "MASC_CONFIG_DIR" "");
+      Config_dir_resolver.reset ())
+    (fun () ->
+      Unix.putenv "MASC_CONFIG_DIR" config_dir;
+      Config_dir_resolver.reset ();
+      f ())
+
 let temp_dir () =
   let dir = Filename.temp_file "keeper_pr_review_" "" in
   Unix.unlink dir;
@@ -122,6 +135,19 @@ let ensure_github_identity_bundle ~config github_identity =
     "github.com:\n\
     \    oauth_token: ghp_fake_test_token_for_docker_route\n\
     \    user: test-user\n"
+
+let with_keeper_identity_toml ~config ~keeper_name ~github_identity f =
+  let masc_dir = Filename.concat config.Coord.base_path Common.masc_dirname in
+  let config_dir = Filename.concat masc_dir "config" in
+  let keepers_dir = Filename.concat config_dir "keepers" in
+  ensure_dir keepers_dir;
+  ensure_github_identity_bundle ~config github_identity;
+  write_file
+    (Filename.concat keepers_dir (keeper_name ^ ".toml"))
+    (Printf.sprintf
+       "[keeper]\ngithub_identity = %S\ngit_identity_mode = \"github_identity\"\n"
+       github_identity);
+  with_config_dir config_dir f
 
 let fake_docker_echo_script =
   "#!/bin/sh\n\
@@ -300,7 +326,10 @@ let test_read_routes_docker_and_injects_repo_flag () =
   with_fake_docker @@ fun () ->
   setup_docker_review @@ fun ~config ~meta ->
   let log_path = Filename.concat config.Coord.base_path "docker.log" in
+  let configured_identity = "reviewer-gh" in
   with_env "KEEPER_DOCKER_LOG" log_path @@ fun () ->
+  with_keeper_identity_toml ~config ~keeper_name:meta.name
+    ~github_identity:configured_identity @@ fun () ->
   let raw =
     KTPR.handle_keeper_pr_review_read ~config ~meta
       ~args:(`Assoc [ ("pr_number", `Int 13510) ])
@@ -316,11 +345,17 @@ let test_read_routes_docker_and_injects_repo_flag () =
     (Some "reviewer")
     (parse_nested_string_field raw "identity_attestation" "keeper");
   check (option string) "read attests effective identity"
-    (Some "root")
+    (Some configured_identity)
     (parse_nested_string_field raw "identity_attestation" "effective_github_identity");
+  check (option string) "read attests configured identity"
+    (Some configured_identity)
+    (parse_nested_string_field raw "identity_attestation" "configured_github_identity");
   check (option string) "read exposes credential identity"
-    (Some "root")
+    (Some configured_identity)
     (parse_nested_string_field raw "credential" "effective_github_identity");
+  check (option string) "read exposes configured credential identity"
+    (Some configured_identity)
+    (parse_nested_string_field raw "credential" "configured_github_identity");
   check bool "read omits credential state to avoid duplicate gh auth status"
     true
     (parse_field raw "credential"
@@ -364,6 +399,9 @@ let test_comment_and_approve_route_through_docker () =
   check (option string) "comment exposes credential identity"
     (Some "root")
     (parse_nested_string_field raw "credential" "effective_github_identity");
+  check (option string) "comment exposes no configured fallback identity"
+    None
+    (parse_nested_string_field raw "credential" "configured_github_identity");
   let raw =
     KTPR.handle_keeper_pr_review_comment ~config ~meta
       ~args:


### PR DESCRIPTION
## Summary
- expose configured_github_identity beside effective_github_identity on keeper PR/review credential surfaces
- include configured identity in PR review identity_attestation
- cover explicit keeper identity and root fallback in focused tests

## Validation
- ocamlformat --check lib/keeper/keeper_tool_github_pr.ml lib/keeper/keeper_tool_pr_review.ml test/test_keeper_pr_review.ml test/test_keeper_github_pr.ml
- git diff --check origin/main...HEAD
- scripts/check-pr-hygiene.sh --base origin/main --head HEAD --duplicate-policy fail
- scripts/dune-local.sh build test/test_keeper_pr_review.exe test/test_keeper_github_pr.exe (blocked: live bare Dune processes outside scripts/dune-local.sh: capacity-backpressure-retire-fresh and @check)