### PR TITLE
fix(ci): restore OCaml structure interfaces

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop_semaphore_timeout.mli
+++ b/lib/keeper/keeper_heartbeat_loop_semaphore_timeout.mli
@@ -1,0 +1,31 @@
+(** Semaphore-wait timeout helpers for the keeper heartbeat loop. *)
+
+type semaphore_wait_observation_kind =
+  Keeper_heartbeat_loop_observations.semaphore_wait_observation_kind =
+  | Semaphore_wait_pending
+  | Semaphore_wait_timeout
+
+val record_semaphore_wait_observation
+  :  ?phase_label:string
+  -> base_path:string
+  -> keeper_name:string
+  -> channel:Keeper_world_observation.keeper_cycle_channel
+  -> kind:semaphore_wait_observation_kind
+  -> unit
+  -> unit
+
+val semaphore_wait_timeout_blocker_class
+  :  Keeper_turn_slot.semaphore_wait_timeout
+  -> Keeper_types.blocker_class
+
+val semaphore_wait_timeout_diagnostics
+  :  cascade_name:string
+  -> Keeper_turn_slot.semaphore_wait_timeout
+  -> string * string
+
+val handle_semaphore_wait_timeout
+  :  ctx:'a Keeper_types.context
+  -> meta_after_triage:Keeper_types.keeper_meta
+  -> turn_decision:Keeper_world_observation.keeper_cycle_decision
+  -> Keeper_turn_slot.semaphore_wait_timeout
+  -> Keeper_types.keeper_meta

--- a/lib/server/server_dashboard_http_core_json.ml
+++ b/lib/server/server_dashboard_http_core_json.ml
@@ -70,8 +70,9 @@ let operator_cache_json ?cache_key ~scope json =
     ; "stale_age_ms", diagnostic_field "stale_age_ms"
     ; "request_cache_key", json_string_opt cache_key
     ; "request_cache_ttl_s", `Float 5.0
-    ; "request_timeout_s", `Float dashboard_request_timeout_s
-    ; "background_refresh_interval_s", `Float operator_refresh_interval_s
+    ; "request_timeout_s", `Float Server_dashboard_http_core_cache.dashboard_request_timeout_s
+    ; ( "background_refresh_interval_s"
+      , `Float Server_dashboard_http_core_operator.operator_refresh_interval_s )
     ; "policy", `String "cached_surface plus HTTP stale-while-revalidate"
     ]
 ;;

--- a/lib/server/server_dashboard_http_core_json.mli
+++ b/lib/server/server_dashboard_http_core_json.mli
@@ -1,0 +1,16 @@
+(** JSON helpers for dashboard HTTP core projections. *)
+
+val json_string_opt : string option -> Yojson.Safe.t
+val json_bool_opt : bool option -> Yojson.Safe.t
+val json_assoc_field_opt : string -> Yojson.Safe.t -> Yojson.Safe.t option
+val json_assoc_string_opt : string -> Yojson.Safe.t -> string option
+val json_assoc_int_opt : string -> Yojson.Safe.t -> int option
+val projection_diagnostics_fields : Yojson.Safe.t -> (string * Yojson.Safe.t) list
+val projection_diagnostics_field : Yojson.Safe.t -> string -> Yojson.Safe.t option
+val operator_generated_at_iso : Yojson.Safe.t -> string
+
+val operator_cache_json
+  :  ?cache_key:string
+  -> scope:string
+  -> Yojson.Safe.t
+  -> Yojson.Safe.t


### PR DESCRIPTION
## Summary
- add missing interfaces for extracted keeper/dashboard helper modules
- qualify dashboard JSON timeout constants inside the extracted module
- restore ocaml-structure-ratchet counts to the committed baseline

## Verification
- git diff --check
- ocamlformat --check lib/keeper/keeper_heartbeat_loop_semaphore_timeout.mli lib/server/server_dashboard_http_core_json.ml lib/server/server_dashboard_http_core_json.mli
- scripts/ocaml-structure-ratchet.sh
- focused dune build attempted, but local /tmp/me-dune-local.lock was held by another worktree build