### PR TITLE
refactor(keeper): share bounded event dedupe state

### DIFF
--- a/lib/bounded_event_dedupe/bounded_event_dedupe.ml
+++ b/lib/bounded_event_dedupe/bounded_event_dedupe.ml
@@ -1,0 +1,109 @@
+type entry =
+  { mutable count : int
+  ; mutable threshold_emitted : bool
+  }
+
+type t =
+  { state : (string, entry) Hashtbl.t
+  ; mutex : Mutex.t
+  }
+
+type occurrence_outcome =
+  | First
+  | Repeated of int
+
+type threshold_payload =
+  { count : int
+  ; threshold : int
+  }
+
+type threshold_outcome =
+  | First_threshold
+  | Repeated_threshold of int
+  | Threshold of threshold_payload
+
+let default_normalize_length_cap = 80
+let component_separator = "\x00"
+let create ?(initial_capacity = 32) () =
+  { state = Hashtbl.create initial_capacity; mutex = Mutex.create () }
+;;
+
+let key components = String.concat component_separator components
+
+let is_ws = function
+  | ' ' | '\t' | '\r' | '\n' -> true
+  | _ -> false
+;;
+
+let lowercase_ascii = function
+  | 'A' .. 'Z' as c -> Char.chr (Char.code c + 32)
+  | c -> c
+;;
+
+let normalize_signature ?(length_cap = default_normalize_length_cap) raw =
+  let n = String.length raw in
+  let buf = Buffer.create (min n length_cap) in
+  let rec walk i prev_was_space =
+    if i >= n
+    then ()
+    else (
+      let c = String.unsafe_get raw i in
+      if is_ws c
+      then (
+        if not prev_was_space then Buffer.add_char buf ' ';
+        walk (i + 1) true)
+      else (
+        Buffer.add_char buf (lowercase_ascii c);
+        walk (i + 1) false))
+  in
+  walk 0 true;
+  let s = Buffer.contents buf in
+  let len = String.length s in
+  let s =
+    if len > 0 && Char.equal (String.unsafe_get s (len - 1)) ' '
+    then String.sub s 0 (len - 1)
+    else s
+  in
+  if String.length s > length_cap then String.sub s 0 length_cap else s
+;;
+
+let with_lock t f = Mutex.protect t.mutex f
+
+let make_entry () = { count = 1; threshold_emitted = false }
+
+let record t ~key =
+  with_lock t (fun () ->
+    match Hashtbl.find_opt t.state key with
+    | None ->
+      Hashtbl.replace t.state key (make_entry ());
+      First
+    | Some entry ->
+      entry.count <- entry.count + 1;
+      Repeated entry.count)
+;;
+
+let record_threshold t ~key ~threshold =
+  with_lock t (fun () ->
+    match Hashtbl.find_opt t.state key with
+    | None ->
+      Hashtbl.replace t.state key (make_entry ());
+      First_threshold
+    | Some entry ->
+      entry.count <- entry.count + 1;
+      if entry.count >= threshold && not entry.threshold_emitted
+      then (
+        entry.threshold_emitted <- true;
+        Threshold { count = entry.count; threshold })
+      else Repeated_threshold entry.count)
+;;
+
+let reset t = with_lock t (fun () -> Hashtbl.reset t.state)
+let remove t ~key = with_lock t (fun () -> Hashtbl.remove t.state key)
+let cardinality t = with_lock t (fun () -> Hashtbl.length t.state)
+
+let count t ~key =
+  with_lock t (fun () ->
+    match Hashtbl.find_opt t.state key with
+    | None -> 0
+    | Some entry -> entry.count)
+;;

--- a/lib/bounded_event_dedupe/bounded_event_dedupe.mli
+++ b/lib/bounded_event_dedupe/bounded_event_dedupe.mli
@@ -1,0 +1,48 @@
+(** Small stdlib-only state machine for per-fingerprint event dedupe.
+
+    The module owns the repeated [Hashtbl + Mutex + threshold-once]
+    mechanics used by keeper/task log-noise reducers. Domain modules
+    still own their typed classifiers, public outcomes, metric labels,
+    and reset policy. *)
+
+type t
+
+type occurrence_outcome =
+  | First
+  | Repeated of int
+
+type threshold_payload =
+  { count : int
+  ; threshold : int
+  }
+
+type threshold_outcome =
+  | First_threshold
+  | Repeated_threshold of int
+  | Threshold of threshold_payload
+
+val default_normalize_length_cap : int
+
+(** [normalize_signature raw] trims leading/trailing ASCII whitespace,
+    collapses whitespace runs to one space, lowercases ASCII letters,
+    preserves non-ASCII bytes, and truncates to [length_cap] bytes. *)
+val normalize_signature : ?length_cap:int -> string -> string
+
+(** Build a collision-resistant string key from already-typed
+    fingerprint components. The separator is outside normal textual
+    labels, avoiding the prefix-collision bug of raw concatenation. *)
+val key : string list -> string
+
+val create : ?initial_capacity:int -> unit -> t
+val record : t -> key:string -> occurrence_outcome
+
+(** [record_threshold t ~key ~threshold] records an occurrence and
+    returns [Threshold] at most once for that key. The first occurrence
+    always returns [First_threshold]; thresholding starts on repeats so
+    existing first-ERROR behaviour is preserved. *)
+val record_threshold : t -> key:string -> threshold:int -> threshold_outcome
+
+val reset : t -> unit
+val remove : t -> key:string -> unit
+val cardinality : t -> int
+val count : t -> key:string -> int

--- a/lib/bounded_event_dedupe/dune
+++ b/lib/bounded_event_dedupe/dune
@@ -1,0 +1,11 @@
+; Bounded_event_dedupe — shared stdlib-only event dedupe state machine
+; for keeper/task log-noise reducers. Domain modules keep their typed
+; public APIs; this leaf owns the repeated Hashtbl + Mutex + threshold
+; mechanics so future reducers do not fork another bespoke state clone.
+(include_subdirs no)
+
+(library
+ (name masc_mcp_bounded_event_dedupe)
+ (public_name masc_mcp.bounded_event_dedupe)
+ (wrapped false)
+ (libraries))

--- a/lib/dune
+++ b/lib/dune
@@ -493,26 +493,29 @@
    ;; extracted to lib/compaction_trigger/. 94+45 LoC, deps: stdlib +
    ;; Yojson + masc_log. Compaction trigger heuristic + JSON serializer.
    masc_mcp.compaction_trigger
+   ;; Bounded_event_dedupe — shared stdlib-only Hashtbl + Mutex +
+   ;; threshold-once state machine for keeper/task log-noise reducers.
+   masc_mcp.bounded_event_dedupe
    ;; Keeper_recording_error_state — typed dedupe state for
    ;; Keeper_registry.record_error log noise (MASC/OAS Error-Warn
-   ;; Reduction Goal §P6). Stdlib-only leaf so the standalone test
-   ;; executable can link in seconds without the main library.
+   ;; Reduction Goal §P6). Domain adapter over Bounded_event_dedupe so
+   ;; the standalone test executable can link in seconds without the
+   ;; main library.
    masc_mcp.keeper_recording_error_state
    ;; ETA-LIVELOCK (2026-05-19): typed escalation state for the
    ;; Keeper_turn_livelock dispatch-guard log noise (~15K ERROR/day
    ;; from 4 keepers re-blocking the same turn_id every ~30 s).
-   ;; Stdlib-only leaf; mirrors the keeper_recording_error_state
-   ;; pattern so the standalone alcotest builds without dragging
-   ;; the main library.
+   ;; Domain adapter over Bounded_event_dedupe so the standalone
+   ;; alcotest builds without dragging the main library.
    masc_mcp.keeper_livelock_state
    ;; IOTA-RETRY (2026-05-19): typed dedupe state for the
    ;; Keeper_tools_oas retry-loop ERROR log noise (12+ events from
    ;; 5+ tools in a 1000-line system_log sample — keeper_bash x4,
    ;; masc_worktree_create x2, keeper_pr_review_comment x2,
    ;; masc_transition x2, Bash x2). Single emit site at
-   ;; lib/keeper/keeper_tools_oas.ml:733. Stdlib-only leaf;
-   ;; mirrors the keeper_livelock_state pattern so the standalone
-   ;; alcotest builds in seconds without dragging the main library.
+   ;; lib/keeper/keeper_tools_oas.ml:733. Domain adapter over
+   ;; Bounded_event_dedupe so the standalone alcotest builds in seconds
+   ;; without dragging the main library.
    masc_mcp.keeper_tool_retry_state
    ;; LAMBDA-HOOK-ERROR (2026-05-19): typed dedupe state for the
    ;; Keeper_hooks_oas on_tool_error hook ERROR log noise (8 events
@@ -522,9 +525,8 @@
    ;; keeper_pr_review_comment, analyst × masc_transition). Single
    ;; emit site at lib/keeper/keeper_hooks_oas.ml:720. Sibling of
    ;; keeper_tool_retry_state with a (keeper, tool, signature) key.
-   ;; Stdlib-only leaf; mirrors the keeper_tool_retry_state pattern so
-   ;; the standalone alcotest builds in seconds without dragging the
-   ;; main library.
+   ;; Domain adapter over Bounded_event_dedupe so the standalone
+   ;; alcotest builds in seconds without dragging the main library.
    masc_mcp.keeper_tool_hook_error_state
    ;; RFC-0086 Phase 2.B prereq — Tool_catalog_surfaces (lib/ root, 554+103 LoC)
    ;; extracted to lib/tool_catalog_surfaces/. deps: Agent_sdk + stdlib only.

--- a/lib/keeper_livelock_state/dune
+++ b/lib/keeper_livelock_state/dune
@@ -12,10 +12,10 @@
 ; explicit Threshold_park ERROR plus a Prometheus counter, so
 ; operators see one durable signal instead of a flapping stream.
 ;
-; This sub-library hosts the classifier (closed sum type) and the
-; in-memory state behind a Mutex. Pure stdlib (Hashtbl + Mutex);
-; no Eio link so the standalone test executable builds in seconds
-; without dragging the main library.
+; This sub-library hosts the livelock classifier/contract and uses
+; Bounded_event_dedupe for the shared in-memory state machine. Pure
+; stdlib; no Eio link so the standalone test executable builds in
+; seconds without dragging the main library.
 ;
 ; (include_subdirs no) opts out of the parent (include_subdirs
 ; unqualified). (wrapped false) keeps the bare identifier
@@ -27,4 +27,4 @@
  (name masc_mcp_keeper_livelock_state)
  (public_name masc_mcp.keeper_livelock_state)
  (wrapped false)
- (libraries))
+ (libraries masc_mcp.bounded_event_dedupe))

--- a/lib/keeper_livelock_state/keeper_livelock_state.ml
+++ b/lib/keeper_livelock_state/keeper_livelock_state.ml
@@ -2,15 +2,13 @@
 
    See [.mli] for the rationale and the production system_log evidence
    that motivates the noise-dedupe layer. This module is intentionally
-   stdlib-only (Hashtbl + Mutex) so it can be linked into both the
-   main library and a standalone Alcotest executable without dragging
-   Eio in.
+   backed by the stdlib-only [Bounded_event_dedupe] state machine, so it
+   can be linked into both the main library and a standalone Alcotest
+   executable without dragging Eio in.
 
-   Threading: the in-memory [Hashtbl.t] is guarded by a single
-   [Mutex.t]. All public entry points take and release the lock in
-   a critical section that performs only [Hashtbl] manipulation and
-   integer arithmetic; no allocations of caller-visible records
-   happen while the lock is held, so contention is bounded.
+   Threading: [Bounded_event_dedupe] guards the in-memory table with a
+   single [Mutex.t]. All public entry points perform only key creation
+   and integer state updates, so contention is bounded.
 
    Memory: there is no eviction policy. The set of distinct
    [(keeper, gate_kind)] fingerprints is bounded by
@@ -58,32 +56,16 @@ type record_outcome =
   | `Threshold_park of threshold_park_payload
   ]
 
-type entry =
-  { mutable count : int
-  ; mutable parked_emitted : bool
-        (* True once a [`Threshold_park] outcome has been returned for
-           this entry, so subsequent calls return [`Repeated] not
-           another [`Threshold_park]. *)
-  }
-
-let make_entry () = { count = 0; parked_emitted = false }
-
 (* Fingerprint key. [gate_kind] is small and total, so we project it
    to its string label and concat with the keeper name and a null
    separator. The separator avoids the collision risk of
    [keeper ^ kind] when a keeper name happens to be a prefix of
    another keeper name plus the kind label. *)
 let key ~keeper ~gate_kind =
-  String.concat "\x00" [ keeper; gate_kind_to_string gate_kind ]
+  Bounded_event_dedupe.key [ keeper; gate_kind_to_string gate_kind ]
 ;;
 
-let state : (string, entry) Hashtbl.t = Hashtbl.create 32
-let mutex = Mutex.create ()
-
-let with_lock f =
-  Mutex.lock mutex;
-  Fun.protect ~finally:(fun () -> Mutex.unlock mutex) f
-;;
+let state = Bounded_event_dedupe.create ()
 
 let record_block
   ?(park_threshold = default_park_threshold)
@@ -93,41 +75,28 @@ let record_block
   : record_outcome
   =
   let k = key ~keeper ~gate_kind in
-  with_lock (fun () ->
-    match Hashtbl.find_opt state k with
-    | None ->
-      let e = make_entry () in
-      e.count <- 1;
-      Hashtbl.replace state k e;
-      `First
-    | Some e ->
-      e.count <- e.count + 1;
-      if e.count >= park_threshold && not e.parked_emitted
-      then (
-        e.parked_emitted <- true;
-        `Threshold_park { count = e.count; park_threshold })
-      else `Repeated e.count)
+  match Bounded_event_dedupe.record_threshold state ~key:k ~threshold:park_threshold with
+  | Bounded_event_dedupe.First_threshold -> `First
+  | Bounded_event_dedupe.Repeated_threshold count -> `Repeated count
+  | Bounded_event_dedupe.Threshold { count; threshold } ->
+    `Threshold_park { count; park_threshold = threshold }
 ;;
 
 let reset_for_keeper ~(keeper : string) : unit =
-  with_lock (fun () ->
-    List.iter
-      (fun gk ->
-        let k = key ~keeper ~gate_kind:gk in
-        Hashtbl.remove state k)
-      all_gate_kinds)
+  List.iter
+    (fun gk ->
+      let k = key ~keeper ~gate_kind:gk in
+      Bounded_event_dedupe.remove state ~key:k)
+    all_gate_kinds
 ;;
 
-let reset_for_test () : unit = with_lock (fun () -> Hashtbl.clear state)
+let reset_for_test () : unit = Bounded_event_dedupe.reset state
 
 let cardinality () : int =
-  with_lock (fun () -> Hashtbl.length state)
+  Bounded_event_dedupe.cardinality state
 ;;
 
 let block_count ~(keeper : string) ~(gate_kind : gate_kind) : int =
   let k = key ~keeper ~gate_kind in
-  with_lock (fun () ->
-    match Hashtbl.find_opt state k with
-    | None -> 0
-    | Some e -> e.count)
+  Bounded_event_dedupe.count state ~key:k
 ;;

--- a/lib/keeper_recording_error_state/dune
+++ b/lib/keeper_recording_error_state/dune
@@ -7,9 +7,9 @@
 ; pair emissions in 30-minute slices (system_log_2026-05-16 sample,
 ; 299 events/day; verifier sandbox_docker ~48%).
 ;
-; This sub-library hosts the classifier (closed sum type) and the
-; in-memory dedupe Hashtbl behind a Mutex. Pure stdlib (Digest +
-; Hashtbl + Mutex + String); no Eio link so the standalone test
+; This sub-library hosts the classifier/contract and uses
+; Bounded_event_dedupe for the shared in-memory state machine. Pure
+; stdlib (Digest + bounded dedupe); no Eio link so the standalone test
 ; executable builds in seconds without dragging the main library.
 ;
 ; (include_subdirs no) opts out of the parent (include_subdirs
@@ -22,4 +22,4 @@
  (name masc_mcp_keeper_recording_error_state)
  (public_name masc_mcp.keeper_recording_error_state)
  (wrapped false)
- (libraries))
+ (libraries masc_mcp.bounded_event_dedupe))

--- a/lib/keeper_recording_error_state/keeper_recording_error_state.ml
+++ b/lib/keeper_recording_error_state/keeper_recording_error_state.ml
@@ -6,13 +6,12 @@
 (* Dedupe state for [Keeper_registry.record_error] noise.
 
    See [.mli] for the rationale. This module is intentionally stdlib-only
-   (Digest + Hashtbl + Mutex + String) so it can be linked into both the
+   (Digest + [Bounded_event_dedupe]) so it can be linked into both the
    main library and standalone unit tests without dragging Eio in.
 
-   Threading: the in-memory [Hashtbl.t] is guarded by a [Mutex.t]. All
-   public entry points take and release the lock; the lock is never held
-   across allocations of caller-visible records, so contention is
-   bounded.
+   Threading: [Bounded_event_dedupe] guards the in-memory table with a
+   [Mutex.t]. Public entry points perform only key creation and integer
+   state updates, so contention is bounded.
 
    Memory: there is no eviction policy. The MASC server lifetime is in
    the hour-to-day range; the number of distinct [(keeper, error)]
@@ -130,27 +129,16 @@ type record_outcome =
    a short, stable identifier with negligible collision risk across
    <1k cardinality. *)
 let fingerprint ~keeper ~error =
-  keeper ^ "|" ^ Digest.to_hex (Digest.string error)
+  Bounded_event_dedupe.key [ keeper; Digest.to_hex (Digest.string error) ]
 ;;
 
-let mu = Mutex.create ()
-let counts : (string, int) Hashtbl.t = Hashtbl.create 256
+let state = Bounded_event_dedupe.create ~initial_capacity:256 ()
 
 let record ~keeper ~error =
   let key = fingerprint ~keeper ~error in
-  Mutex.lock mu;
-  let outcome =
-    match Hashtbl.find_opt counts key with
-    | None ->
-      Hashtbl.add counts key 1;
-      `First
-    | Some n ->
-      let n' = n + 1 in
-      Hashtbl.replace counts key n';
-      `Repeated n'
-  in
-  Mutex.unlock mu;
-  outcome
+  match Bounded_event_dedupe.record state ~key with
+  | Bounded_event_dedupe.First -> `First
+  | Bounded_event_dedupe.Repeated count -> `Repeated count
 ;;
 
 let classify_outcome ~keeper ~error =
@@ -160,14 +148,9 @@ let classify_outcome ~keeper ~error =
 ;;
 
 let reset_for_test () =
-  Mutex.lock mu;
-  Hashtbl.reset counts;
-  Mutex.unlock mu
+  Bounded_event_dedupe.reset state
 ;;
 
 let cardinality () =
-  Mutex.lock mu;
-  let n = Hashtbl.length counts in
-  Mutex.unlock mu;
-  n
+  Bounded_event_dedupe.cardinality state
 ;;

--- a/lib/keeper_tool_hook_error_state/dune
+++ b/lib/keeper_tool_hook_error_state/dune
@@ -16,15 +16,15 @@
 ; events in 1000 lines.
 ;
 ; Sibling of [Keeper_tool_retry_state] (lib/keeper_tool_retry_state/).
-; Same shape, deliberately separate: the retry module keys on
-; (tool, signature) for the per-cycle 1→2→3 retry ladder, while this
-; module keys on (keeper, tool, signature) for the cross-time
-; per-keeper hook firings. Composition would force the smaller key
-; shape on the hook site — wrong direction.
+; The domain contract is deliberately separate: the retry module keys
+; on (tool, signature) for the per-cycle 1→2→3 retry ladder, while
+; this module keys on (keeper, tool, signature) for the cross-time
+; per-keeper hook firings. Both share only the generic bounded event
+; dedupe state machine.
 ;
-; Pure stdlib (Hashtbl + Mutex + String); no Eio link so the
-; standalone test executable builds in seconds without dragging the
-; main masc_mcp library.
+; Pure stdlib via Bounded_event_dedupe; no Eio link so the standalone
+; test executable builds in seconds without dragging the main masc_mcp
+; library.
 ;
 ; (include_subdirs no) opts out of the parent (include_subdirs
 ; unqualified). (wrapped false) keeps the bare identifier
@@ -36,4 +36,4 @@
  (name masc_mcp_keeper_tool_hook_error_state)
  (public_name masc_mcp.keeper_tool_hook_error_state)
  (wrapped false)
- (libraries))
+ (libraries masc_mcp.bounded_event_dedupe))

--- a/lib/keeper_tool_hook_error_state/keeper_tool_hook_error_state.ml
+++ b/lib/keeper_tool_hook_error_state/keeper_tool_hook_error_state.ml
@@ -2,22 +2,21 @@
 
    See the .mli for the rationale and the production system_log evidence
    that motivates this noise-dedupe layer. The module is intentionally
-   stdlib-only (Hashtbl + Mutex + String) so it can be linked into both
-   the main library and a standalone Alcotest executable without dragging
-   Eio in.
+   backed by the stdlib-only [Bounded_event_dedupe] state machine, so
+   it can be linked into both the main library and a standalone Alcotest
+   executable without dragging Eio in.
 
    Sibling of [Keeper_tool_retry_state] (lib/keeper_tool_retry_state/).
-   Same shape, different fingerprint dimension: the retry module keys on
-   [(tool, signature)] because the retry loop iterates within a single
-   keeper context, while this module keys on [(keeper, tool, signature)]
-   because the hook fires per-keeper and two different keepers seeing
-   the same tool error are legitimately distinct ERROR events.
+   Same state-machine shape, different fingerprint dimension: the retry
+   module keys on [(tool, signature)] because the retry loop iterates
+   within a single keeper context, while this module keys on [(keeper,
+   tool, signature)] because the hook fires per-keeper and two different
+   keepers seeing the same tool error are legitimately distinct ERROR
+   events.
 
-   Threading: the in-memory [Hashtbl.t] is guarded by a single [Mutex.t].
-   All public entry points take and release the lock in a critical
-   section that performs only [Hashtbl] manipulation and integer
-   arithmetic; no allocations of caller-visible records happen while the
-   lock is held, so contention is bounded.
+   Threading: [Bounded_event_dedupe] guards the in-memory table with a
+   single [Mutex.t]. All public entry points perform only key creation
+   and integer state updates, so contention is bounded.
 
    Memory: there is no eviction policy. The set of distinct
    (keeper_name, tool_name, error_signature) fingerprints is bounded by
@@ -48,76 +47,13 @@ let default_silence_threshold = 5
    (timestamps, paths, request IDs, PR numbers) that follow are
    deliberately dropped from the fingerprint so the dedupe layer can
    converge. *)
-let normalize_length_cap = 80
-
-(* ── normalize ────────────────────────────────────────────────────
-
-   Total, idempotent projection of an arbitrary error string to a
-   stable fingerprint suffix. Steps:
-
-   1. Walk the bytes; whitespace runs (ASCII space, tab, CR, LF) are
-      collapsed to a single space. Leading whitespace is dropped.
-   2. ASCII letters [A]–[Z] are lowercased; non-ASCII bytes pass
-      through untouched.
-   3. After the walk, trailing whitespace is trimmed and the result
-      is truncated to [normalize_length_cap] bytes.
-
-   Pure stdlib (Buffer + Bytes + Char). No regex. *)
-
-let is_ws c =
-  match c with
-  | ' ' | '\t' | '\r' | '\n' -> true
-  | _ -> false
-;;
-
-let lowercase_ascii c =
-  match c with
-  | 'A' .. 'Z' -> Char.chr (Char.code c + 32)
-  | _ -> c
-;;
+let normalize_length_cap = Bounded_event_dedupe.default_normalize_length_cap
 
 let normalize (raw : string) : string =
-  let n = String.length raw in
-  let buf = Buffer.create (min n normalize_length_cap) in
-  let prev_was_space = ref true (* drop leading whitespace *) in
-  let i = ref 0 in
-  while !i < n do
-    let c = String.unsafe_get raw !i in
-    if is_ws c
-    then (
-      if not !prev_was_space
-      then (
-        Buffer.add_char buf ' ';
-        prev_was_space := true))
-    else (
-      Buffer.add_char buf (lowercase_ascii c);
-      prev_was_space := false);
-    incr i
-  done;
-  let s = Buffer.contents buf in
-  let s =
-    (* trim trailing whitespace introduced by the walk above. The
-       collapse step preserves at most one trailing space when the
-       input ended on whitespace; strip it. *)
-    let len = String.length s in
-    if len > 0 && Char.equal (String.unsafe_get s (len - 1)) ' '
-    then String.sub s 0 (len - 1)
-    else s
-  in
-  if String.length s > normalize_length_cap
-  then String.sub s 0 normalize_length_cap
-  else s
+  Bounded_event_dedupe.normalize_signature
+    ~length_cap:normalize_length_cap
+    raw
 ;;
-
-type entry =
-  { mutable count : int
-  ; mutable silenced_emitted : bool
-        (* True once a [`Threshold_silence] outcome has been returned
-           for this entry, so subsequent calls return [`Repeated]
-           rather than re-firing the silence outcome. *)
-  }
-
-let make_entry () = { count = 0; silenced_emitted = false }
 
 (* Fingerprint key. [keeper_name], [tool_name], and [error_signature]
    are concatenated with a null separator. The separator avoids the
@@ -125,16 +61,10 @@ let make_entry () = { count = 0; silenced_emitted = false }
    to be a prefix of another component's neighbour (e.g. tool name
    "ab" + signature "cd" vs tool name "a" + signature "bcd"). *)
 let key ~keeper_name ~tool_name ~error_signature =
-  String.concat "\x00" [ keeper_name; tool_name; error_signature ]
+  Bounded_event_dedupe.key [ keeper_name; tool_name; error_signature ]
 ;;
 
-let state : (string, entry) Hashtbl.t = Hashtbl.create 32
-let mutex = Mutex.create ()
-
-let with_lock f =
-  Mutex.lock mutex;
-  Fun.protect ~finally:(fun () -> Mutex.unlock mutex) f
-;;
+let state = Bounded_event_dedupe.create ()
 
 let record
   ?(silence_threshold = default_silence_threshold)
@@ -145,26 +75,17 @@ let record
   : outcome
   =
   let k = key ~keeper_name ~tool_name ~error_signature in
-  with_lock (fun () ->
-    match Hashtbl.find_opt state k with
-    | None ->
-      let e = make_entry () in
-      e.count <- 1;
-      Hashtbl.replace state k e;
-      `First
-    | Some e ->
-      e.count <- e.count + 1;
-      if e.count >= silence_threshold && not e.silenced_emitted
-      then (
-        e.silenced_emitted <- true;
-        `Threshold_silence e.count)
-      else `Repeated e.count)
+  match Bounded_event_dedupe.record_threshold state ~key:k ~threshold:silence_threshold with
+  | Bounded_event_dedupe.First_threshold -> `First
+  | Bounded_event_dedupe.Repeated_threshold count -> `Repeated count
+  | Bounded_event_dedupe.Threshold { count; threshold = _ } ->
+    `Threshold_silence count
 ;;
 
-let reset_for_test () : unit = with_lock (fun () -> Hashtbl.clear state)
+let reset_for_test () : unit = Bounded_event_dedupe.reset state
 
 let cardinality () : int =
-  with_lock (fun () -> Hashtbl.length state)
+  Bounded_event_dedupe.cardinality state
 ;;
 
 let occurrence_count
@@ -174,8 +95,5 @@ let occurrence_count
   : int
   =
   let k = key ~keeper_name ~tool_name ~error_signature in
-  with_lock (fun () ->
-    match Hashtbl.find_opt state k with
-    | None -> 0
-    | Some e -> e.count)
+  Bounded_event_dedupe.count state ~key:k
 ;;

--- a/lib/keeper_tool_hook_error_state/keeper_tool_hook_error_state.mli
+++ b/lib/keeper_tool_hook_error_state/keeper_tool_hook_error_state.mli
@@ -31,17 +31,16 @@
 
     Relationship to [Keeper_tool_retry_state]
     ─────────────────────────────────────────
-    Sibling module, deliberately separate. The retry-state module
-    keys on [(tool_name, error_signature)] because its caller is the
-    supervisor's retry loop where the *same* keeper retries the
-    *same* tool 1→2→3 times within one cycle. This module keys on
-    [(keeper_name, tool_name, error_signature)] because its caller is
-    the OAS hook chain installed per-keeper — two different keepers
-    hitting the "same" tool error from independent code paths are
-    legitimately distinct ERROR events and must not collapse. The
-    fingerprint shapes differ; the dedupe state lives in different
-    Hashtbls; reuse via composition would force the smaller key shape
-    on the hook site, which is the wrong direction.
+    Sibling module, deliberately separate at the domain boundary. The
+    retry-state module keys on [(tool_name, error_signature)] because
+    its caller is the supervisor's retry loop where the *same* keeper
+    retries the *same* tool 1→2→3 times within one cycle. This module
+    keys on [(keeper_name, tool_name, error_signature)] because its
+    caller is the OAS hook chain installed per-keeper — two different
+    keepers hitting the "same" tool error from independent code paths
+    are legitimately distinct ERROR events and must not collapse. The
+    fingerprint shapes differ, while the generic count/threshold state
+    machine is shared through [Bounded_event_dedupe].
 
     Workaround posture
     ──────────────────

--- a/lib/keeper_tool_retry_state/dune
+++ b/lib/keeper_tool_retry_state/dune
@@ -20,9 +20,9 @@
 ; the existing Prometheus counter (metric_keeper_tools_oas_failures)
 ; carries the durable signal.
 ;
-; This sub-library hosts the classifier (closed sum type) and the
-; in-memory state behind a Mutex. Pure stdlib (Hashtbl + Mutex +
-; String); no Eio link so the standalone test executable builds in
+; This sub-library hosts the public retry classifier/contract and uses
+; Bounded_event_dedupe for the shared in-memory state machine. Pure
+; stdlib; no Eio link so the standalone test executable builds in
 ; seconds without dragging the main masc_mcp library.
 ;
 ; (include_subdirs no) opts out of the parent (include_subdirs
@@ -35,4 +35,4 @@
  (name masc_mcp_keeper_tool_retry_state)
  (public_name masc_mcp.keeper_tool_retry_state)
  (wrapped false)
- (libraries))
+ (libraries masc_mcp.bounded_event_dedupe))

--- a/lib/keeper_tool_retry_state/keeper_tool_retry_state.ml
+++ b/lib/keeper_tool_retry_state/keeper_tool_retry_state.ml
@@ -2,15 +2,13 @@
 
    See the .mli for the rationale and the production system_log evidence
    that motivates this noise-dedupe layer. The module is intentionally
-   stdlib-only (Hashtbl + Mutex + String) so it can be linked into both
-   the main library and a standalone Alcotest executable without dragging
-   Eio in.
+   backed by the stdlib-only [Bounded_event_dedupe] state machine, so
+   it can be linked into both the main library and a standalone Alcotest
+   executable without dragging Eio in.
 
-   Threading: the in-memory [Hashtbl.t] is guarded by a single [Mutex.t].
-   All public entry points take and release the lock in a critical
-   section that performs only [Hashtbl] manipulation and integer
-   arithmetic; no allocations of caller-visible records happen while the
-   lock is held, so contention is bounded.
+   Threading: [Bounded_event_dedupe] guards the in-memory table with a
+   single [Mutex.t]. All public entry points perform only key creation
+   and integer state updates, so contention is bounded.
 
    Memory: there is no eviction policy. The set of distinct
    (tool_name, error_signature) fingerprints is bounded by
@@ -39,93 +37,23 @@ let default_silence_threshold = 5
    stable description (the high-signal portion). Variable payloads
    (timestamps, paths, request IDs) that follow are deliberately
    dropped from the fingerprint so the dedupe layer can converge. *)
-let normalize_length_cap = 80
-
-(* ── normalize ────────────────────────────────────────────────────
-
-   Total, idempotent projection of an arbitrary error string to a
-   stable fingerprint suffix. Steps:
-
-   1. Walk the bytes; whitespace runs (ASCII space, tab, CR, LF) are
-      collapsed to a single space. Leading whitespace is dropped.
-   2. ASCII letters [A]–[Z] are lowercased; non-ASCII bytes pass
-      through untouched.
-   3. After the walk, trailing whitespace is trimmed and the result
-      is truncated to [normalize_length_cap] bytes.
-
-   Pure stdlib (Buffer + Bytes + Char). No regex; no lossy regex was
-   considered because the plan explicitly forbids it. *)
-
-let is_ws c =
-  match c with
-  | ' ' | '\t' | '\r' | '\n' -> true
-  | _ -> false
-;;
-
-let lowercase_ascii c =
-  match c with
-  | 'A' .. 'Z' -> Char.chr (Char.code c + 32)
-  | _ -> c
-;;
+let normalize_length_cap = Bounded_event_dedupe.default_normalize_length_cap
 
 let normalize (raw : string) : string =
-  let n = String.length raw in
-  let buf = Buffer.create (min n normalize_length_cap) in
-  let prev_was_space = ref true (* drop leading whitespace *) in
-  let i = ref 0 in
-  while !i < n do
-    let c = String.unsafe_get raw !i in
-    if is_ws c
-    then (
-      if not !prev_was_space
-      then (
-        Buffer.add_char buf ' ';
-        prev_was_space := true))
-    else (
-      Buffer.add_char buf (lowercase_ascii c);
-      prev_was_space := false);
-    incr i
-  done;
-  let s = Buffer.contents buf in
-  let s =
-    (* trim trailing whitespace introduced by the walk above. The
-       collapse step preserves at most one trailing space when the
-       input ended on whitespace; strip it. *)
-    let len = String.length s in
-    if len > 0 && Char.equal (String.unsafe_get s (len - 1)) ' '
-    then String.sub s 0 (len - 1)
-    else s
-  in
-  if String.length s > normalize_length_cap
-  then String.sub s 0 normalize_length_cap
-  else s
+  Bounded_event_dedupe.normalize_signature
+    ~length_cap:normalize_length_cap
+    raw
 ;;
-
-type entry =
-  { mutable count : int
-  ; mutable silenced_emitted : bool
-        (* True once a [`Threshold_silence] outcome has been returned
-           for this entry, so subsequent calls return [`Repeated]
-           rather than re-firing the silence outcome. *)
-  }
-
-let make_entry () = { count = 0; silenced_emitted = false }
 
 (* Fingerprint key. [tool_name] and [error_signature] are concatenated
    with a null separator. The separator avoids the collision risk of
    [tool ^ signature] when a tool name happens to be a prefix of another
    tool name plus its signature. *)
 let key ~tool_name ~error_signature =
-  String.concat "\x00" [ tool_name; error_signature ]
+  Bounded_event_dedupe.key [ tool_name; error_signature ]
 ;;
 
-let state : (string, entry) Hashtbl.t = Hashtbl.create 32
-let mutex = Mutex.create ()
-
-let with_lock f =
-  Mutex.lock mutex;
-  Fun.protect ~finally:(fun () -> Mutex.unlock mutex) f
-;;
+let state = Bounded_event_dedupe.create ()
 
 let record
   ?(silence_threshold = default_silence_threshold)
@@ -142,26 +70,17 @@ let record
      here is intentional and documented. *)
   ignore attempt;
   let k = key ~tool_name ~error_signature in
-  with_lock (fun () ->
-    match Hashtbl.find_opt state k with
-    | None ->
-      let e = make_entry () in
-      e.count <- 1;
-      Hashtbl.replace state k e;
-      `First
-    | Some e ->
-      e.count <- e.count + 1;
-      if e.count >= silence_threshold && not e.silenced_emitted
-      then (
-        e.silenced_emitted <- true;
-        `Threshold_silence e.count)
-      else `Repeated e.count)
+  match Bounded_event_dedupe.record_threshold state ~key:k ~threshold:silence_threshold with
+  | Bounded_event_dedupe.First_threshold -> `First
+  | Bounded_event_dedupe.Repeated_threshold count -> `Repeated count
+  | Bounded_event_dedupe.Threshold { count; threshold = _ } ->
+    `Threshold_silence count
 ;;
 
-let reset_for_test () : unit = with_lock (fun () -> Hashtbl.clear state)
+let reset_for_test () : unit = Bounded_event_dedupe.reset state
 
 let cardinality () : int =
-  with_lock (fun () -> Hashtbl.length state)
+  Bounded_event_dedupe.cardinality state
 ;;
 
 let occurrence_count
@@ -170,8 +89,5 @@ let occurrence_count
   : int
   =
   let k = key ~tool_name ~error_signature in
-  with_lock (fun () ->
-    match Hashtbl.find_opt state k with
-    | None -> 0
-    | Some e -> e.count)
+  Bounded_event_dedupe.count state ~key:k
 ;;

--- a/lib/task_transition_state/dune
+++ b/lib/task_transition_state/dune
@@ -3,4 +3,5 @@
  (name task_transition_state)
  (public_name masc_mcp.task_transition_state)
  (modules task_transition_state)
+ (libraries masc_mcp.bounded_event_dedupe)
  (flags (:standard -w +4)))

--- a/lib/task_transition_state/task_transition_state.ml
+++ b/lib/task_transition_state/task_transition_state.ml
@@ -284,15 +284,10 @@ let default_silence_threshold : int = 10
 
 (* ── In-memory state ──────────────────────────────────────────────── *)
 
-(* Per-task entry: count of failures keyed by [family]. We use a
-   nested Hashtbl so [reset_for_task] is O(families-for-task). *)
-type per_task = (family, int) Hashtbl.t
+let state = Bounded_event_dedupe.create ~initial_capacity:64 ()
 
-let state_mutex : Stdlib.Mutex.t = Stdlib.Mutex.create ()
-let state : (string, per_task) Hashtbl.t = Hashtbl.create 64
-
-let with_lock (f : unit -> 'a) : 'a =
-  Stdlib.Mutex.protect state_mutex f
+let key ~task_id ~family =
+  Bounded_event_dedupe.key [ task_id; family_to_string family ]
 
 let record_invalid_state
     ?(silence_threshold = default_silence_threshold)
@@ -301,40 +296,26 @@ let record_invalid_state
     ()
     : record_outcome
   =
-  with_lock (fun () ->
-    let per_task =
-      match Hashtbl.find_opt state task_id with
-      | Some t -> t
-      | None ->
-        let t = Hashtbl.create 4 in
-        Hashtbl.replace state task_id t;
-        t
-    in
-    let prev = Option.value (Hashtbl.find_opt per_task family) ~default:0 in
-    let next = prev + 1 in
-    Hashtbl.replace per_task family next;
-    if next = 1
-    then `First
-    else if next = silence_threshold
-    then `Threshold_silence { count = next; silence_threshold }
-    else `Repeated next)
+  let key = key ~task_id ~family in
+  match Bounded_event_dedupe.record_threshold state ~key ~threshold:silence_threshold with
+  | Bounded_event_dedupe.First_threshold -> `First
+  | Bounded_event_dedupe.Repeated_threshold count -> `Repeated count
+  | Bounded_event_dedupe.Threshold { count; threshold } ->
+    `Threshold_silence { count; silence_threshold = threshold }
 
 let reset_for_task ~(task_id : string) : unit =
-  with_lock (fun () -> Hashtbl.remove state task_id)
+  List.iter
+    (fun family ->
+      let key = key ~task_id ~family in
+      Bounded_event_dedupe.remove state ~key)
+    all_families
 
 let reset_for_test () : unit =
-  with_lock (fun () -> Hashtbl.reset state)
+  Bounded_event_dedupe.reset state
 
 let cardinality () : int =
-  with_lock (fun () ->
-    Hashtbl.fold
-      (fun _task_id per_task acc -> acc + Hashtbl.length per_task)
-      state
-      0)
+  Bounded_event_dedupe.cardinality state
 
 let failure_count ~(task_id : string) ~(family : family) : int =
-  with_lock (fun () ->
-    match Hashtbl.find_opt state task_id with
-    | None -> 0
-    | Some per_task ->
-      Option.value (Hashtbl.find_opt per_task family) ~default:0)
+  let key = key ~task_id ~family in
+  Bounded_event_dedupe.count state ~key

--- a/test/bounded_event_dedupe/dune
+++ b/test/bounded_event_dedupe/dune
@@ -1,0 +1,4 @@
+; Standalone alcotest for the shared stdlib-only dedupe state machine.
+(tests
+ (names test_bounded_event_dedupe)
+ (libraries alcotest masc_mcp.bounded_event_dedupe))

--- a/test/bounded_event_dedupe/test_bounded_event_dedupe.ml
+++ b/test/bounded_event_dedupe/test_bounded_event_dedupe.ml
@@ -1,0 +1,79 @@
+module D = Bounded_event_dedupe
+
+let test_normalize_signature () =
+  Alcotest.(check string)
+    "normalizes whitespace and ASCII case"
+    "error: path blocked"
+    (D.normalize_signature " \tERROR:\nPath   BLOCKED  ");
+  Alcotest.(check int)
+    "applies byte cap"
+    4
+    (String.length (D.normalize_signature ~length_cap:4 "abcdef"))
+;;
+
+let test_key_uses_separator () =
+  Alcotest.(check bool)
+    "component boundaries are preserved"
+    true
+    (not (String.equal (D.key [ "ab"; "c" ]) (D.key [ "a"; "bc" ])))
+;;
+
+let test_record_counts_occurrences () =
+  let state = D.create () in
+  (match D.record state ~key:"alpha" with
+   | D.First -> ()
+   | D.Repeated _ -> Alcotest.fail "first occurrence should be First");
+  (match D.record state ~key:"alpha" with
+   | D.Repeated 2 -> ()
+   | D.First -> Alcotest.fail "second occurrence should be Repeated"
+   | D.Repeated n -> Alcotest.failf "second count should be 2, got %d" n);
+  Alcotest.(check int) "count" 2 (D.count state ~key:"alpha");
+  Alcotest.(check int) "cardinality" 1 (D.cardinality state)
+;;
+
+let test_threshold_fires_once () =
+  let state = D.create () in
+  let threshold = 3 in
+  let _ : D.threshold_outcome =
+    D.record_threshold state ~key:"alpha" ~threshold
+  in
+  (match D.record_threshold state ~key:"alpha" ~threshold with
+   | D.Repeated_threshold 2 -> ()
+   | _ -> Alcotest.fail "second occurrence should be a repeat");
+  (match D.record_threshold state ~key:"alpha" ~threshold with
+   | D.Threshold { count = 3; threshold = 3 } -> ()
+   | _ -> Alcotest.fail "third occurrence should trip threshold");
+  (match D.record_threshold state ~key:"alpha" ~threshold with
+   | D.Repeated_threshold 4 -> ()
+   | _ -> Alcotest.fail "threshold should not fire twice");
+  (match D.record_threshold state ~key:"alpha" ~threshold:5 with
+   | D.Repeated_threshold 5 -> ()
+   | _ -> Alcotest.fail "changed threshold should not re-fire")
+;;
+
+let test_remove_and_reset () =
+  let state = D.create () in
+  let _ : D.occurrence_outcome = D.record state ~key:"alpha" in
+  let _ : D.occurrence_outcome = D.record state ~key:"beta" in
+  D.remove state ~key:"alpha";
+  Alcotest.(check int) "alpha removed" 0 (D.count state ~key:"alpha");
+  Alcotest.(check int) "beta remains" 1 (D.count state ~key:"beta");
+  D.reset state;
+  Alcotest.(check int) "reset clears all" 0 (D.cardinality state)
+;;
+
+let () =
+  Alcotest.run
+    "Bounded_event_dedupe"
+    [ ( "state"
+      , [ Alcotest.test_case "normalize_signature" `Quick test_normalize_signature
+        ; Alcotest.test_case "key separator" `Quick test_key_uses_separator
+        ; Alcotest.test_case
+            "record counts occurrences"
+            `Quick
+            test_record_counts_occurrences
+        ; Alcotest.test_case "threshold fires once" `Quick test_threshold_fires_once
+        ; Alcotest.test_case "remove and reset" `Quick test_remove_and_reset
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

- add `Bounded_event_dedupe`, a stdlib-only shared key/count/threshold-once state machine for keeper/task log-noise reducers
- replace bespoke `Hashtbl`/`Mutex` clones in keeper retry, hook error, livelock, registry recording error, and task transition state modules
- preserve existing public outcome variants and call-site contracts while moving normalization/key/threshold mechanics into one tested leaf

## Verification

- `ocamlformat --check lib/bounded_event_dedupe/bounded_event_dedupe.ml lib/bounded_event_dedupe/bounded_event_dedupe.mli lib/keeper_tool_retry_state/keeper_tool_retry_state.ml lib/keeper_tool_hook_error_state/keeper_tool_hook_error_state.ml lib/keeper_tool_hook_error_state/keeper_tool_hook_error_state.mli lib/keeper_livelock_state/keeper_livelock_state.ml lib/task_transition_state/task_transition_state.ml lib/keeper_recording_error_state/keeper_recording_error_state.ml test/bounded_event_dedupe/test_bounded_event_dedupe.ml`
- `git diff --check origin/main...HEAD`
- `ocamlc` direct compile of:
  - `lib/bounded_event_dedupe/bounded_event_dedupe.{mli,ml}`
  - `lib/keeper_tool_retry_state/keeper_tool_retry_state.{mli,ml}`
  - `lib/keeper_tool_hook_error_state/keeper_tool_hook_error_state.{mli,ml}`
  - `lib/keeper_livelock_state/keeper_livelock_state.{mli,ml}`
  - `lib/task_transition_state/task_transition_state.{mli,ml}`
  - `lib/keeper_recording_error_state/keeper_recording_error_state.{mli,ml}`
- legacy clone sweep: no direct adapter-local `type entry`, `let mutex`, `let counts`, `with_lock`, or state `Hashtbl` patterns remain in the five migrated adapter modules

Local focused Dune build was attempted, but `/tmp/me-dune-local.lock` is still held by another long-running worktree process; GitHub CI should be treated as the authoritative Dune result for this branch.
