### PR TITLE
chore(spawn): remove spawn_sync alias

### DIFF
--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -440,9 +440,6 @@ let spawn ~agent_name ~prompt ?timeout_seconds ?working_dir () =
       cost_usd = None;
     })
 
-(** Spawn and wait for result (synchronous) *)
-let spawn_sync = spawn
-
 let int_opt_to_json = Json_util.int_opt_to_json
 let float_opt_to_json = Json_util.float_opt_to_json
 

--- a/lib/spawn.mli
+++ b/lib/spawn.mli
@@ -77,12 +77,6 @@ val spawn :
   ?timeout_seconds:int -> ?working_dir:string -> unit ->
   spawn_result
 
-(** Deprecated alias for {!spawn}. *)
-val spawn_sync :
-  agent_name:string -> prompt:string ->
-  ?timeout_seconds:int -> ?working_dir:string -> unit ->
-  spawn_result
-
 (** {1 Result Formatting} *)
 
 val int_opt_to_json : int option -> Yojson.Safe.t

--- a/test/test_spawn_coverage.ml
+++ b/test/test_spawn_coverage.ml
@@ -643,15 +643,6 @@ let test_result_to_string_has_output () =
      with Not_found -> false)
 
 (* ============================================================
-   spawn_sync alias Tests
-   ============================================================ *)
-
-let test_spawn_sync_is_spawn () =
-  (* Just verify spawn_sync is the same function as spawn (alias test) *)
-  let _ : (agent_name:string -> prompt:string -> ?timeout_seconds:int -> ?working_dir:string -> unit -> Spawn.spawn_result) = Spawn.spawn_sync in
-  ()
-
-(* ============================================================
    Test Runners
    ============================================================ *)
 
@@ -761,8 +752,5 @@ let () =
       test_case "failure" `Quick test_result_to_string_failure;
       test_case "has elapsed" `Quick test_result_to_string_has_elapsed;
       test_case "has output" `Quick test_result_to_string_has_output;
-    ];
-    "spawn_sync", [
-      test_case "alias" `Quick test_spawn_sync_is_spawn;
     ];
   ]


### PR DESCRIPTION
## Summary
- remove the deprecated Spawn.spawn_sync alias from the public interface and implementation
- delete the alias-only coverage test

## Validation
- git diff --check HEAD~1..HEAD
- rg -n "spawn_sync" --glob "!_build/**" returns no matches
- focused scripts/dune-local.sh build test/test_spawn_coverage.exe was attempted but refused because unrelated bare Dune builds are active on this host