### PR TITLE
fix(ci): add dashboard dev token interface

### DIFF
--- a/lib/server/server_routes_http_dashboard_dev_token.mli
+++ b/lib/server/server_routes_http_dashboard_dev_token.mli
@@ -1,0 +1,28 @@
+(** Dashboard dev-token file and minting helpers for dashboard routes. *)
+
+val dashboard_dev_actor_name : string
+val dashboard_dev_token_path : string -> string
+val legacy_dashboard_dev_token_path : string -> string
+val remove_dashboard_dev_token_file_if_exists : string -> unit
+
+type dashboard_dev_token_candidate =
+  | Reusable of string
+  | Rotate
+
+val classify_dashboard_dev_token_candidate
+  :  base_path:string
+  -> string
+  -> (dashboard_dev_token_candidate, string) result
+
+val read_reusable_dashboard_dev_token
+  :  base_path:string
+  -> string
+  -> (string option, string) result
+
+val persist_dashboard_dev_token
+  :  base_path:string
+  -> string
+  -> (unit, string) result
+
+val mint_dashboard_dev_token : string -> (string, string) result
+val ensure_dashboard_dev_token : string -> (string, string) result


### PR DESCRIPTION
## Summary
- add an explicit interface for the dashboard dev-token extraction module
- restore ocaml-structure-ratchet lib_other_mli_missing to the committed baseline after #17282

## Verification
- git diff --check
- ocamlformat --check lib/server/server_routes_http_dashboard_dev_token.mli
- scripts/ocaml-structure-ratchet.sh