### PR TITLE
refactor(keeper_supervisor): extract cleanup_dead_tombstone sibling (-100 LOC)

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -815,114 +815,14 @@ let reconcile_keepalive_keepers (ctx : _ context) =
     (int_of_float ((Time_compat.now () -. t0) *. 1000.0))
 ;;
 
+(* Dead-tombstone cleanup extracted to
+   [Keeper_supervisor_cleanup_tombstone] (godfile decomp). publish_lifecycle is
+   injected explicitly to avoid sibling -> parent cycle. *)
 let cleanup_dead_tombstone (ctx : _ context) (entry : Keeper_registry.registry_entry) =
-  match read_meta ctx.config entry.name with
-  | Ok (Some meta) ->
-    let persisted_paused =
-      if meta.paused
-      then true
-      else (
-        (* #9733: dead tombstone cleanup writes [paused = true] —
-             cycle-owned field — while heartbeat fibers can still
-             update the same record's heartbeat-owned fields.  Use
-             the same merged-CAS retry as the resume + overflow-pause
-             paths so a parallel heartbeat write doesn't make this
-             write fail and leave the keeper unpaused on disk while
-             the supervisor proceeds to unregister it. *)
-        match
-          write_meta_with_merge
-            ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
-            ctx.config
-            { meta with paused = true }
-        with
-        | Ok () -> true
-        | Error err when is_version_conflict_error err ->
-          Prometheus.inc_counter
-            Keeper_metrics.metric_keeper_write_meta_failures
-            ~labels:[ "keeper", entry.name; "phase", "dead_cleanup_cas_race" ]
-            ();
-          Log.Keeper.warn
-            "%s: dead tombstone cleanup paused write lost CAS race after retries: %s"
-            entry.name
-            err;
-          false
-        | Error err ->
-          Prometheus.inc_counter
-            Keeper_metrics.metric_keeper_write_meta_failures
-            ~labels:[ "keeper", entry.name; "phase", "dead_cleanup" ]
-            ();
-          Log.Keeper.warn
-            "%s: dead tombstone cleanup paused write failed: %s"
-            entry.name
-            err;
-          false)
-    in
-    Keeper_registry.unregister ~base_path:ctx.config.base_path entry.name;
-    Keeper_tool_emission_hook.drop_keeper_accumulator entry.name;
-    if persisted_paused
-    then (
-      publish_lifecycle
-        ~event:
-          (Keeper_lifecycle_events.Custom_event
-             { verb = Keeper_lifecycle_events.Dead_cleaned; phase = None })
-        entry.name
-        "paused meta persisted"
-        ();
-      Log.Keeper.info "%s: dead tombstone cleaned up" entry.name)
-    else (
-      publish_lifecycle
-        ~event:
-          (Keeper_lifecycle_events.Custom_event
-             { verb = Keeper_lifecycle_events.Dead_cleaned; phase = None })
-        entry.name
-        "meta write failed, unregistered anyway"
-        ();
-      Log.Keeper.warn
-        "%s: dead tombstone unregistered despite meta write failure"
-        entry.name;
-      Prometheus.inc_counter
-        Keeper_metrics.metric_keeper_supervisor_cleanup_failures
-        ~labels:
-          [ "keeper", entry.name
-          ; ("site", Keeper_supervisor_cleanup_failure_site.(to_label Dead_tombstone_meta_write))
-          ]
-        ())
-  | Ok None ->
-    Keeper_registry.unregister ~base_path:ctx.config.base_path entry.name;
-    Keeper_tool_emission_hook.drop_keeper_accumulator entry.name;
-    publish_lifecycle
-      ~event:
-        (Keeper_lifecycle_events.Custom_event
-           { verb = Keeper_lifecycle_events.Dead_cleaned; phase = None })
-      entry.name
-      "meta missing"
-      ();
-    Log.Keeper.warn "%s: dead tombstone unregistered (meta missing)" entry.name;
-    Prometheus.inc_counter
-      Keeper_metrics.metric_keeper_supervisor_cleanup_failures
-      ~labels:
-        [ "keeper", entry.name
-        ; ("site", Keeper_supervisor_cleanup_failure_site.(to_label Dead_tombstone_meta_missing))
-        ]
-      ()
-  | Error err ->
-    Keeper_registry.unregister ~base_path:ctx.config.base_path entry.name;
-    Keeper_tool_emission_hook.drop_keeper_accumulator entry.name;
-    publish_lifecycle
-      ~event:
-        (Keeper_lifecycle_events.Custom_event
-           { verb = Keeper_lifecycle_events.Dead_cleaned; phase = None })
-      entry.name
-      (Printf.sprintf "meta read error: %s" err)
-      ();
-    Log.Keeper.warn "%s: dead tombstone unregistered (meta error: %s)" entry.name err;
-    Prometheus.inc_counter
-      Keeper_metrics.metric_keeper_supervisor_cleanup_failures
-      ~labels:
-        [ "keeper", entry.name
-        ; ("site", Keeper_supervisor_cleanup_failure_site.(to_label Dead_tombstone_meta_error))
-        ]
-      ()
+  Keeper_supervisor_cleanup_tombstone.cleanup_dead_tombstone
+    ~publish_lifecycle
+    ctx
+    entry
 ;;
 
 (** Cohort key from structured failure_reason ADT.

--- a/lib/keeper/keeper_supervisor_cleanup_tombstone.ml
+++ b/lib/keeper/keeper_supervisor_cleanup_tombstone.ml
@@ -1,0 +1,125 @@
+(** Dead-tombstone cleanup for the keeper supervisor, extracted from
+    [keeper_supervisor.ml]. The cleanup CASes [paused = true] (merging
+    heartbeat-owned fields), unregisters the keeper, drops its tool
+    emission accumulator, and emits the [Dead_cleaned] lifecycle event.
+
+    [publish_lifecycle] is injected explicitly so the sibling does not
+    reach back into the supervisor godfile (mirrors the pattern already
+    used by [Keeper_supervisor_self_preservation.apply]). *)
+
+open Keeper_types
+open Keeper_execution
+
+let cleanup_dead_tombstone
+      ~publish_lifecycle
+      (ctx : _ context)
+      (entry : Keeper_registry.registry_entry)
+  =
+  match read_meta ctx.config entry.name with
+  | Ok (Some meta) ->
+    let persisted_paused =
+      if meta.paused
+      then true
+      else (
+        (* #9733: dead tombstone cleanup writes [paused = true] —
+             cycle-owned field — while heartbeat fibers can still
+             update the same record's heartbeat-owned fields.  Use
+             the same merged-CAS retry as the resume + overflow-pause
+             paths so a parallel heartbeat write doesn't make this
+             write fail and leave the keeper unpaused on disk while
+             the supervisor proceeds to unregister it. *)
+        match
+          write_meta_with_merge
+            ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+            ctx.config
+            { meta with paused = true }
+        with
+        | Ok () -> true
+        | Error err when is_version_conflict_error err ->
+          Prometheus.inc_counter
+            Keeper_metrics.metric_keeper_write_meta_failures
+            ~labels:[ "keeper", entry.name; "phase", "dead_cleanup_cas_race" ]
+            ();
+          Log.Keeper.warn
+            "%s: dead tombstone cleanup paused write lost CAS race after retries: %s"
+            entry.name
+            err;
+          false
+        | Error err ->
+          Prometheus.inc_counter
+            Keeper_metrics.metric_keeper_write_meta_failures
+            ~labels:[ "keeper", entry.name; "phase", "dead_cleanup" ]
+            ();
+          Log.Keeper.warn
+            "%s: dead tombstone cleanup paused write failed: %s"
+            entry.name
+            err;
+          false)
+    in
+    Keeper_registry.unregister ~base_path:ctx.config.base_path entry.name;
+    Keeper_tool_emission_hook.drop_keeper_accumulator entry.name;
+    if persisted_paused
+    then (
+      publish_lifecycle
+        ~event:
+          (Keeper_lifecycle_events.Custom_event
+             { verb = Keeper_lifecycle_events.Dead_cleaned; phase = None })
+        entry.name
+        "paused meta persisted"
+        ();
+      Log.Keeper.info "%s: dead tombstone cleaned up" entry.name)
+    else (
+      publish_lifecycle
+        ~event:
+          (Keeper_lifecycle_events.Custom_event
+             { verb = Keeper_lifecycle_events.Dead_cleaned; phase = None })
+        entry.name
+        "meta write failed, unregistered anyway"
+        ();
+      Log.Keeper.warn
+        "%s: dead tombstone unregistered despite meta write failure"
+        entry.name;
+      Prometheus.inc_counter
+        Keeper_metrics.metric_keeper_supervisor_cleanup_failures
+        ~labels:
+          [ "keeper", entry.name
+          ; ("site", Keeper_supervisor_cleanup_failure_site.(to_label Dead_tombstone_meta_write))
+          ]
+        ())
+  | Ok None ->
+    Keeper_registry.unregister ~base_path:ctx.config.base_path entry.name;
+    Keeper_tool_emission_hook.drop_keeper_accumulator entry.name;
+    publish_lifecycle
+      ~event:
+        (Keeper_lifecycle_events.Custom_event
+           { verb = Keeper_lifecycle_events.Dead_cleaned; phase = None })
+      entry.name
+      "meta missing"
+      ();
+    Log.Keeper.warn "%s: dead tombstone unregistered (meta missing)" entry.name;
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_supervisor_cleanup_failures
+      ~labels:
+        [ "keeper", entry.name
+        ; ("site", Keeper_supervisor_cleanup_failure_site.(to_label Dead_tombstone_meta_missing))
+        ]
+      ()
+  | Error err ->
+    Keeper_registry.unregister ~base_path:ctx.config.base_path entry.name;
+    Keeper_tool_emission_hook.drop_keeper_accumulator entry.name;
+    publish_lifecycle
+      ~event:
+        (Keeper_lifecycle_events.Custom_event
+           { verb = Keeper_lifecycle_events.Dead_cleaned; phase = None })
+      entry.name
+      (Printf.sprintf "meta read error: %s" err)
+      ();
+    Log.Keeper.warn "%s: dead tombstone unregistered (meta error: %s)" entry.name err;
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_supervisor_cleanup_failures
+      ~labels:
+        [ "keeper", entry.name
+        ; ("site", Keeper_supervisor_cleanup_failure_site.(to_label Dead_tombstone_meta_error))
+        ]
+      ()
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane B (Keeper Runtime)
- **First** sibling extracted from `keeper_supervisor.ml` (1632 LOC) — historically protected by `sweep_and_recover` co-location, but `cleanup_dead_tombstone` is isolable.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/keeper/keeper_supervisor.ml` | 1632 | 1532 | **-100** |
| `lib/keeper/keeper_supervisor_cleanup_tombstone.ml` | — | 125 | +125 |

## Moved (verbatim, no behavior change)
- `cleanup_dead_tombstone` — 108 LOC body, three meta-read branches (Some / None / Error), CAS-with-merge for paused field, lifecycle emission for each path.

## Cycle-avoidance pattern
`publish_lifecycle` lives in the supervisor godfile. Rather than duplicate, the sibling signature is

```ocaml
val cleanup_dead_tombstone :
  publish_lifecycle:(event:Keeper_lifecycle_events.lifecycle_event ->
                     string -> string -> unit -> unit) ->
  _ context -> Keeper_registry.registry_entry -> unit
```

Parent retains a 5-line adapter that injects `publish_lifecycle`. Same pattern already used by `Keeper_supervisor_self_preservation.apply ~publish_lifecycle`.

## Caller impact
Single internal caller at `sweep_and_recover` (line 1253 in new file, was 1357). Adapter preserves the `ctx -> entry -> unit` signature byte-identically.

## Sibling deps
- `Keeper_types` / `Keeper_execution` (opened)
- `Keeper_meta_merge.heartbeat_fields_from_disk`
- `Keeper_registry`, `Keeper_tool_emission_hook`, `Keeper_lifecycle_events`
- `Keeper_supervisor_cleanup_failure_site` (already a sibling)
- `Prometheus`, `Keeper_metrics`, `Log.Keeper`

No sibling -> parent cycle.

## Local build status
- `dune build @check`: only pre-existing main breakage remains (`dashboard_request_timeout_s`, `called_tools`, `evidence_role`) — unrelated
- godfile lint: clean (absolute_cap=3350, new_file_cap=600)

## RFC-WAIVED
Extract-only sibling refactor with documented callback injection.

Co-Authored-By: codex <noreply@anthropic.com>
