### PR TITLE
docs(keeper): steer raw scans to structured tools

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -47,7 +47,7 @@ Public tool examples:
   BAD:  Bash command="cd repos && ls"                   (chaining blocked)
   GOOD: Bash command="ls repos"
   BAD:  Bash command="find /home/keeper -name \"board\" 2>/dev/null" (quoted pattern + redirect blocked)
-  GOOD: Bash command="find . -maxdepth 3 -name board"
+  GOOD: keeper_shell op=find path=. pattern=board limit=50 when visible; otherwise Bash command="find . -maxdepth 3 -name board" cwd=repos/REPO
   BAD:  Bash command="find repos/masc-mcp/lib -name nickname*" (glob expansion blocked)
   GOOD: Grep pattern="nickname" path=repos/masc-mcp/lib glob="*.ml"
   BAD:  Bash command="rg -n \"foo\\|bar\" repos/masc-mcp/lib 2>/dev/null | head -20"
@@ -84,7 +84,7 @@ Public tool examples:
 File operations:
 - Read a specific file: Read (preferred for single files) when visible.
 - Search file contents: Grep with pattern=regex, path=dir/path (optional: type=ml, glob="*.ts") when visible.
-- Find files by name: prefer Grep for content, or one scoped Bash `find` without pipes/redirects when Bash is visible.
+- Find files by name: prefer `keeper_shell op=find` when visible; otherwise use Grep for content search, and use one scoped Bash `find` only as a last fallback with cwd set to the repo/worktree.
 - List directory contents: one scoped Bash `ls path` when Bash is visible.
 - Git history: Bash command="git log --oneline -10" with cwd inside the target repo/worktree.
 - Git status: Bash command="git status --short" with cwd inside the target repo/worktree.

--- a/lib/keeper/keeper_shell_bash_shape_messages.ml
+++ b/lib/keeper/keeper_shell_bash_shape_messages.ml
@@ -99,9 +99,9 @@ let bash_shape_block_alternatives ~cmd = function
     else if command_looks_like_find_pipeline cmd || lowercase_contains cmd "find "
     then
       [
-        "Bash command='find . -name \"*.ml\"' cwd='repos/REPO/.worktrees/TASK'";
-        "Bash command='find . -name \"*.mli\"' cwd='repos/REPO/.worktrees/TASK'";
-        "Bash command='find lib -name \"*.ml\"' cwd='repos/REPO'";
+        "keeper_shell op=find path=lib pattern=*.ml limit=50 when visible";
+        "keeper_shell op=find path=. pattern=*.mli limit=50 cwd=repos/REPO/.worktrees/TASK when visible";
+        "Bash command='find lib -name \"*.ml\"' cwd='repos/REPO' only if no structured search/listing tool is visible";
       ]
     else
       [
@@ -123,7 +123,8 @@ let bash_shape_block_alternatives ~cmd = function
       ]
   | Substitution ->
     [
-      "Bash command='rg --files lib' cwd='repos/REPO'";
+      "keeper_shell op=find path=lib pattern=* limit=100 when visible";
+      "Grep pattern=search-term path=lib";
       "Read file_path=path/from/previous-step";
     ]
   | Repo_wide_scan ->
@@ -138,12 +139,12 @@ let bash_shape_block_alternatives ~cmd = function
       [
         "Grep pattern=search-term path=repos/masc-mcp/lib glob=*.ml";
         "Grep pattern=search-term path=repos/oas/src glob=*.ml";
-        "Bash command='find lib -name \"*.ml\"' cwd='repos/REPO'";
+        "keeper_shell op=find path=lib pattern=*.ml limit=100 when visible";
       ]
     else
       [
         "Grep pattern=search-term path=lib";
-        "Bash command='find lib -name \"*.ml\"' cwd='repos/REPO'";
+        "keeper_shell op=find path=lib pattern=*.ml limit=100 when visible";
         "Bash command='git log --oneline -20' cwd='repos/REPO'";
       ]
 

--- a/lib/tool_shard_types_schemas_bash.ml
+++ b/lib/tool_shard_types_schemas_bash.ml
@@ -171,7 +171,8 @@ let keeper_bash_cmd_field =
       ; ( "description"
         , `String
             "Single command only. No chaining/control syntax or file redirects. \
-             Example: 'scripts/dune-local.sh build', 'rg pattern lib/'" )
+             Example: 'scripts/dune-local.sh build', 'git status --short'. For \
+             read-only search/listing, prefer keeper_shell/Grep when visible." )
       ] )
 ;;
 
@@ -180,15 +181,16 @@ let legacy_v0_description =
    accepted during the typed-argv migration; prefer executable/argv for one process \
    or pipeline/stages for explicit Shell IR pipelines. No chaining/control syntax \
    (&&, ||, ;), command substitution, background operators, or file redirects. Good: \
-   cmd='scripts/dune-local.sh build', executable='rg' argv=['pattern','lib/'], \
-   pipeline=[{executable='rg',...}, {executable='head',...}]. Bad: cmd='cd x && dune \
-   build', cmd='echo hi > out.txt'. Runs in the keeper sandbox by default; use cwd \
-   to target an explicit allowed directory. Paths resolve automatically — never \
+   cmd='scripts/dune-local.sh build', executable='git' argv=['status','--short'], \
+   pipeline=[{executable='git',...}, {executable='head',...}]. Bad: cmd='cd x && \
+   dune build', cmd='echo hi > out.txt'. Runs in the keeper sandbox by default; use \
+   cwd to target an explicit allowed directory. Paths resolve automatically — never \
    include host storage prefixes such as '.masc/playground/your-name/' in cwd. Use \
    'repos/X' instead. Sandbox root is NOT a git repository: git/gh calls require \
    cwd='repos/<REPO_NAME>' (or the worktree path under it). 'not a git repository' \
    or 'path_outside_sandbox' from the sandbox root means you forgot the cwd. For \
-   read-only ops use keeper_shell, for file edits use keeper_fs_edit. Set \
+   read-only search/listing use keeper_shell or Grep when visible; for file edits use \
+   keeper_fs_edit. Set \
    run_in_background=true for long-running tasks (returns background_task_id; poll \
    with keeper_bash_output, terminate with keeper_bash_kill)."
 ;;
@@ -197,15 +199,16 @@ let typed_v1_description =
   "Execute one command through the keeper_bash safety gates via typed argv. Use \
    executable/argv for one process, or pipeline/stages for explicit Shell IR \
    pipelines. The legacy 'cmd' string field is no longer accepted — shell \
-   metacharacters in argv are data, not syntax. Good: executable='rg' \
-   argv=['pattern','lib/'], pipeline=[{executable='rg',...}, \
+   metacharacters in argv are data, not syntax. Good: executable='git' \
+   argv=['status','--short'], pipeline=[{executable='git',...}, \
    {executable='head',...}]. Runs in the keeper sandbox by default; use cwd to \
    target an explicit allowed directory. Paths resolve automatically — never \
    include host storage prefixes such as '.masc/playground/your-name/' in cwd. Use \
    'repos/X' instead. Sandbox root is NOT a git repository: git/gh calls require \
    cwd='repos/<REPO_NAME>' (or the worktree path under it). 'not a git repository' \
    or 'path_outside_sandbox' from the sandbox root means you forgot the cwd. For \
-   read-only ops use keeper_shell, for file edits use keeper_fs_edit. Set \
+   read-only search/listing use keeper_shell or Grep when visible; for file edits use \
+   keeper_fs_edit. Set \
    run_in_background=true for long-running tasks (returns background_task_id; poll \
    with keeper_bash_output, terminate with keeper_bash_kill)."
 ;;

--- a/test/test_keeper_bash_descriptor_variant.ml
+++ b/test/test_keeper_bash_descriptor_variant.ml
@@ -124,6 +124,36 @@ let test_description_changes_with_variant () =
     (Astring.String.is_infix ~affix:"Good: cmd=" typed.description)
 ;;
 
+let test_descriptions_do_not_advertise_raw_search_scans () =
+  let tools_for variant =
+    Variant.coding_keeper_bridge_tools_for_variant ~variant
+    |> find_bash_schema
+  in
+  let legacy = tools_for Variant.Legacy_v0 in
+  let typed = tools_for Variant.Typed_v1 in
+  let combined =
+    String.concat
+      "\n"
+      [
+        legacy.description;
+        typed.description;
+        pp_json legacy.input_schema;
+        pp_json typed.input_schema;
+      ]
+  in
+  List.iter
+    (fun forbidden ->
+      Alcotest.(check bool)
+        ("descriptor omits " ^ forbidden)
+        false
+        (Astring.String.is_infix ~affix:forbidden combined))
+    [ "rg pattern lib/"; "executable='rg'"; "{executable='rg'" ];
+  Alcotest.(check bool)
+    "descriptor points read-only search to structured tools"
+    true
+    (Astring.String.is_infix ~affix:"keeper_shell or Grep" combined)
+;;
+
 let test_sibling_schemas_invariant_across_variants () =
   let legacy_tools =
     Variant.coding_keeper_bridge_tools_for_variant
@@ -160,6 +190,8 @@ let () =
         ; Alcotest.test_case "typed_v1 drops cmd" `Quick test_typed_v1_drops_cmd
         ; Alcotest.test_case "description changes with variant" `Quick
             test_description_changes_with_variant
+        ; Alcotest.test_case "descriptions avoid raw search scans" `Quick
+            test_descriptions_do_not_advertise_raw_search_scans
         ; Alcotest.test_case "sibling schemas invariant" `Quick
             test_sibling_schemas_invariant_across_variants
         ] )


### PR DESCRIPTION
## Summary
- remove raw rg scan examples from keeper_bash descriptors
- steer filename discovery/search hints toward keeper_shell/Grep before Bash find
- add descriptor coverage so Bash descriptions do not advertise raw search scans

## Checks
- ocamlformat --check lib/tool_shard_types_schemas_bash.ml lib/keeper/keeper_shell_bash_shape_messages.ml test/test_keeper_bash_descriptor_variant.ml
- git diff --check origin/main..HEAD

Focused Dune was not started: scripts/dune-local.sh refused because bare Dune builds are already active in other worktrees.