### PR TITLE
chore(keeper): remove shell bash compatibility op

### DIFF
--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -402,9 +402,9 @@ gate에서 거부된다. 파이프라인은 active preset/validator가 모든 se
 허용하는 경우에만 통과할 수 있다. 필요한 경우 호출을 나눠 발행하고,
 검색/파일/히스토리는 `keeper_shell`의 구조화 op를 우선 사용한다.
 
-`keeper_shell op=bash`는 더 이상 명령을 실행하지 않는 legacy/deprecated
-경로다. 실제 명령 실행은 `Bash`/`keeper_bash`가 담당하고, Legendary Bash
-gate와 write/sandbox 정책도 그 경로에만 적용된다.
+`keeper_shell op=bash`는 지원하지 않는다. 실제 명령 실행은
+`Bash`/`keeper_bash`가 담당하고, Legendary Bash gate와 write/sandbox
+정책도 그 경로에만 적용된다.
 
 | 필드 | 기본값 | 의미 |
 | --- | --- | --- |

--- a/docs/LEGENDARY-BASH-RUNBOOK.md
+++ b/docs/LEGENDARY-BASH-RUNBOOK.md
@@ -31,8 +31,7 @@ flipping the remaining defaults.
   structured-shell boundary around it.
 - `keeper_shell` is not a raw command execution surface. It owns structured ops
   such as `rg`, `ls`, `cat`, `git_status`, `git_log`, `git_diff`, `git_clone`,
-  and `gh`; `keeper_shell op=bash` is a deprecated non-executing compatibility
-  response.
+  and `gh`; `keeper_shell op=bash` is unsupported.
 - Does not cover: the cascade verifier itself or the approval layer for
   MCP tools. Those are separate surfaces.
 

--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -912,24 +912,6 @@ let handle_keeper_shell
       error_json ~fields:[ "op", `String op ]
         (Printf.sprintf "Unknown git_worktree action '%s'. Use: list, add." other)
     end
-  | "bash" ->
-    Yojson.Safe.to_string
-      (`Assoc
-         [ "ok", `Bool false
-         ; "op", `String op
-         ; "error", `String "keeper_shell_bash_deprecated"
-         ; "hint", `String
-             "The structured shell no longer executes op=bash. Use the public \
-              Bash tool for command execution; use Grep and Read for search and \
-              file inspection when they are visible."
-         ; "suggested_tool", `String "Bash"
-         ; "suggested_public_tool", `String "Bash"
-         ; "supported_ops",
-             `List
-               (List.map
-                  (fun s -> `String s)
-                  Keeper_shell_shared.valid_shell_op_strings)
-         ])
   | "git_clone" ->
     (* Clone a repo into this keeper's playground repos directory.
        Sandboxed: always targets .masc/playground/<keeper_name>/repos/<repo_name>.

--- a/lib/keeper/keeper_tool_deterministic_error.ml
+++ b/lib/keeper/keeper_tool_deterministic_error.ml
@@ -111,7 +111,6 @@ let reason_of_error_code = function
   | "gh_command_blocked" -> Some Policy_blocked
   | "gh_irreversible_blocked" -> Some Policy_blocked
   | "completion_contract_violation" -> Some Completion_contract_violation
-  | "keeper_shell_bash_deprecated" -> Some Keeper_shell_op_required
   | "keeper_pr_create_requires_git_cwd" -> Some Keeper_shell_op_required
   | _ -> None
 ;;

--- a/test/test_keeper_bash_retry_deterministic_close.ml
+++ b/test/test_keeper_bash_retry_deterministic_close.ml
@@ -92,9 +92,9 @@ let test_completion_contract_violation () =
 ;;
 
 let test_keeper_shell_op_required () =
-  let raw = {|{"ok":false,"error":"keeper_shell_bash_deprecated"}|} in
+  let raw = {|{"ok":false,"error":"keeper_pr_create_requires_git_cwd"}|} in
   check_classify
-    ~name:"keeper_shell_bash_deprecated"
+    ~name:"keeper_pr_create_requires_git_cwd"
     ~expected:(Some D.Keeper_shell_op_required)
     raw
 ;;

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -1963,12 +1963,12 @@ let test_keeper_shell_ls_recovers_doubled_playground_prefix () =
   Alcotest.(check string) "path normalized to repos root" repos
     (json |> Json.member "path" |> Json.to_string)
 
-let test_keeper_shell_bash_op_is_deprecated () =
+let test_keeper_shell_bash_op_is_unsupported () =
   with_eio_fs @@ fun () ->
   let base_path, config = make_config () in
   Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
   Keeper_registry.clear ();
-  let meta = make_readonly_meta "bash-deprecated" in
+  let meta = make_readonly_meta "bash-unsupported" in
   let raw =
     Keeper_exec_shell.handle_keeper_shell
       ~turn_sandbox_factory:None ~exec_cache:None
@@ -1978,17 +1978,12 @@ let test_keeper_shell_bash_op_is_deprecated () =
         ("command", `String "git status && git log --oneline -5");
       ])
   in
-  Alcotest.(check (option string)) "error is deprecation"
-    (Some "keeper_shell_bash_deprecated") (parse_error_field raw);
-  (match parse_hint raw with
-   | None -> Alcotest.fail ("expected hint field, got: " ^ raw)
-   | Some hint ->
-     Alcotest.(check bool) "hint points to Bash alias" true
-       (String_util.contains_substring hint "Bash");
-     Alcotest.(check bool) "hint avoids internal keeper_bash" false
-       (String_util.contains_substring hint "keeper_bash");
-     Alcotest.(check bool) "hint avoids internal keeper_shell" false
-       (String_util.contains_substring hint "keeper_shell"))
+  Alcotest.(check (option string)) "error is unsupported"
+    (Some "unsupported_op") (parse_error_field raw);
+  let json = Yojson.Safe.from_string raw in
+  let supported_ops = json |> Json.member "supported_ops" |> Json.to_list in
+  Alcotest.(check bool) "bash not supported" false
+    (List.mem (`String "bash") supported_ops)
 
 let test_keeper_shell_bash_op_does_not_execute () =
   with_eio_fs @@ fun () ->
@@ -2010,9 +2005,9 @@ let test_keeper_shell_bash_op_does_not_execute () =
         ("command", `String "touch should-not-exist");
       ])
   in
-  Alcotest.(check (option string)) "error is deprecation"
-    (Some "keeper_shell_bash_deprecated") (parse_error_field raw);
-  Alcotest.(check bool) "legacy bash op did not execute" false
+  Alcotest.(check (option string)) "error is unsupported"
+    (Some "unsupported_op") (parse_error_field raw);
+  Alcotest.(check bool) "bash op did not execute" false
     (Sys.file_exists marker)
 
 let test_git_write_classification () =
@@ -2431,8 +2426,8 @@ let () =
         test_keeper_shell_find_accepts_name_alias;
       Alcotest.test_case "doubled playground prefix auto-recovers" `Quick
         test_keeper_shell_ls_recovers_doubled_playground_prefix;
-      Alcotest.test_case "op=bash is deprecated" `Quick
-        test_keeper_shell_bash_op_is_deprecated;
+      Alcotest.test_case "op=bash is unsupported" `Quick
+        test_keeper_shell_bash_op_is_unsupported;
       Alcotest.test_case "op=bash does not execute" `Quick
         test_keeper_shell_bash_op_does_not_execute;
     ]);

--- a/test/test_keeper_exec_shell_cwd_response.ml
+++ b/test/test_keeper_exec_shell_cwd_response.ml
@@ -79,15 +79,14 @@ let test_render_docker_process_result_uses_cwd_response () =
          ~affix:"Keeper_cwd_response.to_yojson_response"
          src)
 
-let test_bash_op_has_no_runtime_cwd_field () =
+let test_bash_op_has_no_special_runtime_branch () =
   match find_source_path () with
   | None -> ()
   | Some path ->
     let src = read_source path in
-    check bool "legacy op=bash deprecation exists" true
-      (Astring.String.is_infix
-         ~affix:"keeper_shell_bash_deprecated" src);
-    check bool "legacy op=bash cwd_field removed" false
+    check bool "legacy op=bash branch removed" false
+      (Astring.String.is_infix ~affix:"| \"bash\" ->" src);
+    check bool "legacy op=bash cwd_field absent" false
       (Astring.String.is_infix ~affix:"let cwd_field" src)
 
 let test_git_log_runtime_branch_uses_cwd_response () =
@@ -98,8 +97,8 @@ let test_git_log_runtime_branch_uses_cwd_response () =
     (* The git_log runtime branch builds its own cwd_response.
        Verify at least 2 distinct [cwd_response = Keeper_cwd_response.docker]
        constructions in the file (render_docker + git_log; the
-       generic op=bash branch is now a non-executing deprecation
-       response and no longer constructs cwd responses). *)
+       generic op=bash branch was removed and now falls through the
+       unsupported-op response, so it no longer constructs cwd responses). *)
     let docker_ctor_uses =
       count_substring src "Keeper_cwd_response.docker ~host_cwd:cwd"
     in
@@ -161,8 +160,8 @@ let () =
             "render_docker_process_result wires Cwd_response"
             `Quick
             test_render_docker_process_result_uses_cwd_response
-        ; test_case "op=bash has no runtime cwd field" `Quick
-            test_bash_op_has_no_runtime_cwd_field
+        ; test_case "op=bash has no special runtime branch" `Quick
+            test_bash_op_has_no_special_runtime_branch
         ; test_case
             "git_log runtime branch wires Cwd_response"
             `Quick test_git_log_runtime_branch_uses_cwd_response


### PR DESCRIPTION
## Summary
- remove the keeper_shell op=bash special compatibility branch so it falls through unsupported_op
- remove the keeper_shell_bash_deprecated deterministic error mapping
- update tests and docs from deprecated compatibility to unsupported op semantics

## Validation
- git diff --check HEAD~1..HEAD
- rg sweep confirms keeper_shell_bash_deprecated and deprecated op=bash wording no longer remain
- focused scripts/dune-local.sh build test/test_keeper_bash_safety.exe test/test_keeper_exec_shell_cwd_response.exe test/test_keeper_bash_retry_deterministic_close.exe was attempted but refused because unrelated bare Dune builds are active on this host