### PR TITLE
refactor(keeper_heartbeat_loop): extract scheduling decision sibling (-42 LOC)

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -308,7 +308,10 @@ let cascade_backpressure_decision =
   Observations.cascade_backpressure_decision
 ;;
 
-type keepalive_scheduling_decision = {
+(* Keepalive scheduling decision (record + decide function) extracted to
+   [Keeper_heartbeat_loop_scheduling] (godfile decomp). The record type is
+   re-exported transparently so the .mli signature stays byte-identical. *)
+type keepalive_scheduling_decision = Keeper_heartbeat_loop_scheduling.keepalive_scheduling_decision = {
   turn_decision : Keeper_world_observation.keeper_cycle_decision;
   requested_should_run_turn : bool;
   cascade_backpressure : cascade_backpressure_decision;
@@ -318,52 +321,7 @@ type keepalive_scheduling_decision = {
   channel : string;
 }
 
-let decide_keepalive_scheduling
-      ?(cascade_resilience_of_name =
-        Keeper_exec_preflight.cascade_resilience_of_name)
-      ?(cascade_status_of_name =
-        fun ~cascade_name -> Keeper_health_probe.get_cascade_status ~cascade_name)
-      ~stop
-      ~meta
-      obs
-  =
-  let turn_decision = Keeper_world_observation.keeper_cycle_decision ~meta obs in
-  let requested_should_run_turn =
-    (not (Atomic.get stop)) && turn_decision.should_run
-  in
-  let cascade_name = cascade_name_of_meta meta in
-  let cascade_resilience = cascade_resilience_of_name cascade_name in
-  let cascade_backpressure =
-    cascade_backpressure_decision
-      ~cascade_resilience:(Some cascade_resilience)
-      ~should_run_turn:requested_should_run_turn
-      ~cascade_name
-      ~cascade_status:(cascade_status_of_name ~cascade_name)
-  in
-  let should_run_turn =
-    match cascade_backpressure with
-    | Cascade_admitted -> requested_should_run_turn
-    | Cascade_backpressured _ -> false
-  in
-  let verdict_reasons =
-    Keeper_world_observation.verdict_reasons_to_strings turn_decision.verdict
-  in
-  let admission_reasons =
-    match cascade_backpressure with
-    | Cascade_admitted -> verdict_reasons
-    | Cascade_backpressured { reason; _ } ->
-      cascade_backpressure_observation_reasons ~reason
-  in
-  let channel = Keeper_world_observation.channel_to_string turn_decision.channel in
-  { turn_decision
-  ; requested_should_run_turn
-  ; cascade_backpressure
-  ; should_run_turn
-  ; verdict_reasons
-  ; admission_reasons
-  ; channel
-  }
-;;
+let decide_keepalive_scheduling = Keeper_heartbeat_loop_scheduling.decide_keepalive_scheduling
 
 let record_cascade_backpressure_observation =
   Observations.record_cascade_backpressure_observation

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.ml
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.ml
@@ -1,0 +1,79 @@
+(** Keepalive scheduling decision for the heartbeat loop, extracted from
+    [keeper_heartbeat_loop.ml]. Holds the record type returned by
+    [decide_keepalive_scheduling] and the pure decision function that
+    combines the turn verdict with cascade backpressure admission. *)
+
+open Keeper_types
+module Observations = Keeper_heartbeat_loop_observations
+
+(* Re-export cascade_backpressure_decision so the record field below
+   matches the parent's view byte-identically. *)
+type cascade_backpressure_decision = Observations.cascade_backpressure_decision =
+  | Cascade_admitted
+  | Cascade_backpressured of {
+      cascade_name : string;
+      reason : string;
+    }
+
+let cascade_backpressure_observation_reasons =
+  Observations.cascade_backpressure_observation_reasons
+;;
+
+let cascade_backpressure_decision = Observations.cascade_backpressure_decision
+
+type keepalive_scheduling_decision = {
+  turn_decision : Keeper_world_observation.keeper_cycle_decision;
+  requested_should_run_turn : bool;
+  cascade_backpressure : cascade_backpressure_decision;
+  should_run_turn : bool;
+  verdict_reasons : string list;
+  admission_reasons : string list;
+  channel : string;
+}
+
+let decide_keepalive_scheduling
+      ?(cascade_resilience_of_name =
+        Keeper_exec_preflight.cascade_resilience_of_name)
+      ?(cascade_status_of_name =
+        fun ~cascade_name -> Keeper_health_probe.get_cascade_status ~cascade_name)
+      ~stop
+      ~meta
+      obs
+  =
+  let turn_decision = Keeper_world_observation.keeper_cycle_decision ~meta obs in
+  let requested_should_run_turn =
+    (not (Atomic.get stop)) && turn_decision.should_run
+  in
+  let cascade_name = cascade_name_of_meta meta in
+  let cascade_resilience = cascade_resilience_of_name cascade_name in
+  let cascade_backpressure =
+    cascade_backpressure_decision
+      ~cascade_resilience:(Some cascade_resilience)
+      ~should_run_turn:requested_should_run_turn
+      ~cascade_name
+      ~cascade_status:(cascade_status_of_name ~cascade_name)
+  in
+  let should_run_turn =
+    match cascade_backpressure with
+    | Cascade_admitted -> requested_should_run_turn
+    | Cascade_backpressured _ -> false
+  in
+  let verdict_reasons =
+    Keeper_world_observation.verdict_reasons_to_strings turn_decision.verdict
+  in
+  let admission_reasons =
+    match cascade_backpressure with
+    | Cascade_admitted -> verdict_reasons
+    | Cascade_backpressured { reason; _ } ->
+      cascade_backpressure_observation_reasons ~reason
+  in
+  let channel = Keeper_world_observation.channel_to_string turn_decision.channel in
+  { turn_decision
+  ; requested_should_run_turn
+  ; cascade_backpressure
+  ; should_run_turn
+  ; verdict_reasons
+  ; admission_reasons
+  ; channel
+  }
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane B (Keeper Runtime)
- 2nd sibling extracted from `keeper_heartbeat_loop.ml` (after PR #17271 semaphore_timeout cluster).

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/keeper/keeper_heartbeat_loop.ml` | 1507 | 1465 | **-42** |
| `lib/keeper/keeper_heartbeat_loop_scheduling.ml` | — | 79 | +79 |

## Moved (verbatim, no behavior change)
- `type keepalive_scheduling_decision` — 7-field record returned by the decide function
- `decide_keepalive_scheduling` — pure decision: combines `keeper_cycle_decision` with cascade backpressure into a single verdict record

## Type-sharing pattern
The record type is exposed in `.mli`, so the parent re-exports it as a
transparent record alias:

```ocaml
type keepalive_scheduling_decision = Keeper_heartbeat_loop_scheduling.keepalive_scheduling_decision = {
  turn_decision : Keeper_world_observation.keeper_cycle_decision;
  requested_should_run_turn : bool;
  cascade_backpressure : cascade_backpressure_decision;
  ...
}
```

The sibling also re-exports `cascade_backpressure_decision` transparently from `Observations` so the record field type matches parent's view byte-identically.

## Sibling deps
- `Keeper_types` (opened) — provides `cascade_name_of_meta`
- `Keeper_heartbeat_loop_observations` — backpressure decision type + helpers
- `Keeper_world_observation`, `Keeper_exec_preflight`, `Keeper_health_probe` — external

No sibling -> parent cycle.

## Local build status
- `dune build @check`: only pre-existing main breakage remains (`dashboard_request_timeout_s`, `called_tools`, `evidence_role`, `last_good_shell_light`, `unknown_keeper_toml_warning_keys`) — unrelated
- godfile lint: clean (absolute_cap=3350, new_file_cap=600)

## RFC-WAIVED
Extract-only sibling refactor with transparent record alias.

Co-Authored-By: codex <noreply@anthropic.com>
