### PR TITLE
chore(pr): require direct evidence schema

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,23 @@
 <!-- Tests, harness runs, screenshots, logs, or other proof. -->
 - If tool-call behavior or provider tool support changed: include replay-harness or `ToolCallContract` evidence.
 
+## Direct evidence
+
+<!--
+Agent PR evidence schema. Classify each proof stage by provenance:
+direct = keeper/agent performed it through its own tool surface;
+operator_proxy = a human/operator ran it for the agent;
+mixed = direct and operator_proxy stages both exist;
+n/a = not applicable for this PR.
+-->
+
+```yaml
+schema_version: 1
+direct_ratio: 0/0
+provenance: n/a
+stages: []
+```
+
 ## GOAL LOOP ACT checklist
 
 <!-- Complete this section for operational/runtime fixes. Leave unchecked items with a brief N/A reason. -->

--- a/scripts/pr-open.sh
+++ b/scripts/pr-open.sh
@@ -34,6 +34,7 @@ validate_pr_body_file() {
   local path="$1"
   local missing=()
   local heading
+  local schema_errors=()
 
   if [[ ! -f "$path" ]]; then
     echo "body file not found: $path" >&2
@@ -44,6 +45,7 @@ validate_pr_body_file() {
     "## Summary" \
     "## Product impact" \
     "## Evidence" \
+    "## Direct evidence" \
     "## Review evidence" \
     "## Linked issue"
   do
@@ -56,6 +58,23 @@ validate_pr_body_file() {
     echo "body file is missing required PR hygiene sections:" >&2
     printf '  - %s\n' "${missing[@]}" >&2
     echo "expected headings from .github/pull_request_template.md" >&2
+    exit 1
+  fi
+
+  if ! grep -Eq '^[[:space:]]*schema_version:[[:space:]]*1([[:space:]]|$)' "$path"; then
+    schema_errors+=("schema_version: 1")
+  fi
+  if ! grep -Eq '^[[:space:]]*direct_ratio:[[:space:]]*([0-9]+/[0-9]+|n/a|N/A)([[:space:]]|$)' "$path"; then
+    schema_errors+=("direct_ratio: <direct>/<total> or n/a")
+  fi
+  if ! grep -Eq '^[[:space:]]*provenance:[[:space:]]*(direct|operator_proxy|mixed|n/a)([[:space:]]|$)' "$path"; then
+    schema_errors+=("provenance: direct|operator_proxy|mixed|n/a")
+  fi
+
+  if [[ ${#schema_errors[@]} -gt 0 ]]; then
+    echo "body file is missing required Direct evidence schema fields:" >&2
+    printf '  - %s\n' "${schema_errors[@]}" >&2
+    echo "expected a Direct evidence block with schema_version, direct_ratio, and provenance" >&2
     exit 1
   fi
 }

--- a/test/test_pr_open_script.ml
+++ b/test/test_pr_open_script.ml
@@ -25,6 +25,26 @@ let read_file path =
 let write_file path content =
   Out_channel.with_open_bin path (fun oc -> output_string oc content)
 
+let valid_pr_body =
+  "## Summary\n\
+   Test body\n\n\
+   ## Product impact\n\
+   - Promise affected: `none/internal`\n\
+   - User-visible change: none\n\n\
+   ## Evidence\n\
+   - local script test\n\n\
+   ## Direct evidence\n\n\
+   ```yaml\n\
+   schema_version: 1\n\
+   direct_ratio: 0/0\n\
+   provenance: n/a\n\
+   stages: []\n\
+   ```\n\n\
+   ## Review evidence\n\
+   - not applicable for script test\n\n\
+   ## Linked issue\n\
+   - Refs #1234\n"
+
 let rec rm_rf path =
   if Sys.file_exists path then
     if Sys.is_directory path then begin
@@ -213,8 +233,7 @@ let test_script_runs_under_system_bash_without_watch () =
       let gh_log = Filename.concat dir "gh.log" in
       let gh_labels = Filename.concat dir "gh-labels.json" in
       let body_file = Filename.concat dir "body.md" in
-      write_file body_file
-        "## Summary\nTest body\n\n## Product impact\n- Promise affected: `none/internal`\n- User-visible change: none\n\n## Evidence\n- local script test\n\n## Review evidence\n- not applicable for script test\n\n## Linked issue\n- Refs #1234\n";
+      write_file body_file valid_pr_body;
       let path =
         Printf.sprintf "%s:%s" fake_gh_dir
           (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
@@ -266,8 +285,7 @@ let test_script_restores_draft_when_create_returns_ready () =
       let gh_log = Filename.concat dir "gh.log" in
       let gh_labels = Filename.concat dir "gh-labels.json" in
       let body_file = Filename.concat dir "body.md" in
-      write_file body_file
-        "## Summary\nTest body\n\n## Product impact\n- Promise affected: `none/internal`\n- User-visible change: none\n\n## Evidence\n- local script test\n\n## Review evidence\n- not applicable for script test\n\n## Linked issue\n- Refs #13253\n";
+      write_file body_file valid_pr_body;
       let path =
         Printf.sprintf "%s:%s" fake_gh_dir
           (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
@@ -308,8 +326,7 @@ let test_script_prints_final_status_after_watch () =
       let gh_log = Filename.concat dir "gh.log" in
       let gh_labels = Filename.concat dir "gh-labels.json" in
       let body_file = Filename.concat dir "body.md" in
-      write_file body_file
-        "## Summary\nTest body\n\n## Product impact\n- Promise affected: `none/internal`\n- User-visible change: none\n\n## Evidence\n- local script test\n\n## Review evidence\n- not applicable for script test\n\n## Linked issue\n- Refs #1234\n";
+      write_file body_file valid_pr_body;
       let path =
         Printf.sprintf "%s:%s" fake_gh_dir
           (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
@@ -374,9 +391,61 @@ let test_script_rejects_body_missing_required_sections () =
         (contains_substring stderr "body file is missing required PR hygiene sections:");
       check bool "mentions product impact heading" true
         (contains_substring stderr "## Product impact");
+      check bool "mentions direct evidence heading" true
+        (contains_substring stderr "## Direct evidence");
       check bool "mentions linked issue heading" true
         (contains_substring stderr "## Linked issue");
       check bool "gh never invoked before validation" false
+        (Sys.file_exists gh_log))
+
+let test_script_rejects_body_missing_direct_evidence_schema () =
+  with_temp_dir "pr-open-script-missing-direct-evidence-schema" (fun dir ->
+      init_repo_with_remote dir;
+      let fake_gh_dir = make_fake_gh dir in
+      let gh_log = Filename.concat dir "gh.log" in
+      let gh_labels = Filename.concat dir "gh-labels.json" in
+      let body_file = Filename.concat dir "body.md" in
+      write_file body_file
+        "## Summary\n\
+         Test body\n\n\
+         ## Product impact\n\
+         - Promise affected: `none/internal`\n\
+         - User-visible change: none\n\n\
+         ## Evidence\n\
+         - local script test\n\n\
+         ## Direct evidence\n\
+         - direct proof not classified yet\n\n\
+         ## Review evidence\n\
+         - not applicable for script test\n\n\
+         ## Linked issue\n\
+         - Refs #1234\n";
+      let path =
+        Printf.sprintf "%s:%s" fake_gh_dir
+          (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
+      in
+      let env =
+        [
+          ("PATH", path);
+          ("FAKE_GH_LOG", gh_log);
+          ("FAKE_GH_LABELS", gh_labels);
+        ]
+      in
+      let cmd =
+        Printf.sprintf "/bin/bash %s --repo %s --title %s --body-file %s --no-watch"
+          (quote (script_path ()))
+          (quote "example/test")
+          (quote "fix: reject direct evidence drift")
+          (quote body_file)
+      in
+      let code, stdout, stderr = run_shell ~cwd:dir ~env cmd in
+      check bool "command fails" true (code <> 0);
+      check bool "stdout empty" true (String.trim stdout = "");
+      check bool "mentions direct evidence schema failure" true
+        (contains_substring stderr
+           "body file is missing required Direct evidence schema fields:");
+      check bool "mentions direct_ratio" true
+        (contains_substring stderr "direct_ratio");
+      check bool "gh never invoked before direct evidence validation" false
         (Sys.file_exists gh_log))
 
 let test_script_rejects_staged_changes_before_push () =
@@ -386,8 +455,7 @@ let test_script_rejects_staged_changes_before_push () =
       let gh_log = Filename.concat dir "gh.log" in
       let gh_labels = Filename.concat dir "gh-labels.json" in
       let body_file = Filename.concat dir "body.md" in
-      write_file body_file
-        "## Summary\nTest body\n\n## Product impact\n- Promise affected: `none/internal`\n- User-visible change: none\n\n## Evidence\n- local script test\n\n## Review evidence\n- not applicable for script test\n\n## Linked issue\n- Refs #1234\n";
+      write_file body_file valid_pr_body;
       write_file (Filename.concat dir "lib/staged.ml") "let staged = true\n";
       ignore (run_shell_ok ~cwd:dir "git add lib/staged.ml");
       let path =
@@ -433,6 +501,8 @@ let () =
             test_script_prints_final_status_after_watch;
           test_case "rejects body missing required sections" `Quick
             test_script_rejects_body_missing_required_sections;
+          test_case "rejects body missing direct evidence schema" `Quick
+            test_script_rejects_body_missing_direct_evidence_schema;
           test_case "rejects staged changes before push" `Quick
             test_script_rejects_staged_changes_before_push;
         ] );


### PR DESCRIPTION
## Summary

Require agent PR bodies to carry a Direct evidence schema with `schema_version`, `direct_ratio`, and `provenance`.

## Product impact

- Promise affected: `agent PR auditability`
- User-visible change: agent-authored PRs opened through `scripts/pr-open.sh` now need explicit direct/operator_proxy evidence classification.

## Evidence

- `ocamlformat --check test/test_pr_open_script.ml`
- `bash -n scripts/pr-open.sh`
- `git diff --check origin/main...HEAD`
- `scripts/check-pr-hygiene.sh --base origin/main --head HEAD --duplicate-policy fail`
- `scripts/dune-local.sh build test/test_pr_open_script.exe` blocked by existing bare Dune processes outside `scripts/dune-local.sh`.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 4/4
provenance: direct
stages:
  - name: edit
    provenance: direct
    evidence: "Codex patch in worktree codex/direct-evidence-pr-body-main-20260521"
  - name: ocamlformat
    provenance: direct
    evidence: "ocamlformat --check test/test_pr_open_script.ml"
  - name: shell_syntax
    provenance: direct
    evidence: "bash -n scripts/pr-open.sh"
  - name: pr_hygiene
    provenance: direct
    evidence: "scripts/check-pr-hygiene.sh --base origin/main --head HEAD --duplicate-policy fail"
```

## GOAL LOOP ACT checklist

- [x] Observe — H4 follow-up called out missing direct/operator_proxy evidence classification.
- [x] Orient — this is the PR body schema enforcement slice, separate from dashboard proof aggregation.
- [x] Decide — template and `pr-open.sh` validation are the smallest entry point for new agent PRs.
- [x] Act — added template section, script validation, and script tests.
- [x] Verify — local non-Dune checks pass; focused Dune was attempted and blocked by existing bare Dune processes.
- [x] Loop — remaining H4 slices: role/preset scheduler preflight and larger PR lifecycle FSM/admission caps.

## Review evidence

- Not run; local schema/test harness change only.

## Linked issue

- Relates #17290
