### PR TITLE
refactor(timeout): centralize load-bearing floors

### DIFF
--- a/lib/config/env_config_sandbox.ml
+++ b/lib/config/env_config_sandbox.ml
@@ -149,15 +149,18 @@ module Shell_timeout = struct
      Exhaustive match (warning 4) so a new bucket forces a deliberate
      floor/non-floor classification here, once, rather than at every
      call site that branches on it. *)
-  let is_floor_bucket : bucket -> bool = function
-    | Gh_min -> true
-    | Io | Read | Git_meta | User_max | Cleanup_rm | Unknown _ -> false
+  let timeout_floor : bucket -> Timeout_floor.t option = function
+    | Gh_min -> Some Timeout_floor.Tool_dispatch
+    | Io | Read | Git_meta | User_max | Cleanup_rm | Unknown _ -> None
+
+  let is_floor_bucket bucket =
+    Option.is_some (timeout_floor bucket)
 
   let known_default_sec = function
     | Io -> Some 30.0
     | Read -> Some 15.0
     | Git_meta -> Some 5.0
-    | Gh_min -> Some 15.0
+    | Gh_min -> Some (Timeout_floor.default_sec Timeout_floor.Tool_dispatch)
     | User_max -> Some 180.0
     | Cleanup_rm -> Some 5.0
     | Unknown _ -> None
@@ -186,11 +189,12 @@ module Shell_timeout = struct
     | None -> None
 
   let timeout_sec ~bucket () =
-    if is_floor_bucket bucket then
+    match timeout_floor bucket with
+    | Some floor ->
       (* Read-only floor — see .mli.  Operators MUST NOT lower this
          via env; doing so cascades 401 retries (#8688). *)
-      15.0
-    else
+      Timeout_floor.default_sec floor
+    | None ->
       let per_bucket_env = per_bucket_env_var ~bucket in
       match trimmed_value_opt per_bucket_env with
       | Some v ->

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -318,12 +318,13 @@ type docker_shell_result =
    This minimum applies only to the [docker run] path, not to
    [docker exec] against a warm container. *)
 let docker_run_min_timeout_sec =
-  let default = 20.0 in
+  let floor = Timeout_floor.Docker_run in
+  let default = Timeout_floor.default_sec floor in
   let raw =
     try float_of_string (Sys.getenv "MASC_KEEPER_DOCKER_RUN_MIN_TIMEOUT_SEC")
     with Not_found | Failure _ -> default
   in
-  Float.max 1.0 raw
+  Timeout_floor.clamp floor raw
 
 let docker_cleanup_rm_timeout_sec () =
   Env_config_sandbox.Shell_timeout.timeout_sec

--- a/lib/keeper/keeper_shell_docker.mli
+++ b/lib/keeper/keeper_shell_docker.mli
@@ -124,7 +124,7 @@ type docker_shell_result =
     ([gh_min_timeout_sec = 15s], #8688) plus 5s headroom for image
     pull and container creation.  Operators can override via
     [MASC_KEEPER_DOCKER_RUN_MIN_TIMEOUT_SEC] (read once at module
-    load, floor 1s). *)
+    load, clamped to [Timeout_floor.Docker_run]). *)
 val docker_run_min_timeout_sec : float
 
 (** Run [cmd] inside the keeper Docker sandbox; clamps

--- a/lib/keeper/keeper_shell_shared.ml
+++ b/lib/keeper/keeper_shell_shared.ml
@@ -69,9 +69,17 @@ let user_timeout_max_sec = env_float "MASC_KEEPER_USER_TIMEOUT_MAX_SEC" 180.0
 (* Floor for gh op timeout_sec. GitHub API + gh auth handshake is
    usually 3-10s; previous floors (1s, then 5s) produced 41
    gh_command_timed_out rejections in 2 days, every single one at
-   timeout_sec=5 (#8688). 15s keeps keepers from requesting a
-   sub-network-latency timeout without masking genuine hangs. *)
-let gh_min_timeout_sec = 15.0
+   timeout_sec=5 (#8688). [Timeout_floor.Tool_dispatch] keeps keepers
+   from requesting a sub-network-latency timeout without masking
+   genuine hangs. *)
+let gh_min_timeout_sec =
+  Timeout_floor.default_sec Timeout_floor.Tool_dispatch
+;;
+
+(* Public shell metadata timeout used by git-status helpers. The playground
+   repo-cache writer keeps its own copy in the lower-level coord module so
+   Coord_worktree can update the same cache without depending on this file. *)
+let git_meta_timeout_sec = env_float "MASC_KEEPER_GIT_META_TIMEOUT_SEC" 5.0
 
 (* Floor applied to caller-supplied [timeout_sec] for keeper_bash when
    the command runs through the *native* (non-Docker) executor.  The
@@ -81,14 +89,15 @@ let gh_min_timeout_sec = 15.0
    10-60s on top of the actual command — see runtime log issue #5
    (2026-05-20).  Keeping a separate native floor avoids penalising
    the host-side fast path for the Docker path's overhead. *)
-let keeper_bash_native_min_timeout_sec = 5.0
+let keeper_bash_native_min_timeout_sec =
+  Timeout_floor.default_sec Timeout_floor.Native_shell
+;;
 
-(* Public shell metadata timeout used by git-status helpers. The playground
-   repo-cache writer keeps its own copy in the lower-level coord module so
-   Coord_worktree can update the same cache without depending on this file. *)
-let git_meta_timeout_sec = env_float "MASC_KEEPER_GIT_META_TIMEOUT_SEC" 5.0
-
-let clamp_shell_timeout ?(min_sec = 1.0) ~default args =
+let clamp_shell_timeout
+      ?(min_sec = Timeout_floor.default_sec Timeout_floor.Native_shell)
+      ~default
+      args
+  =
   Safe_ops.json_float ~default "timeout_sec" args
   |> fun n -> max min_sec (min user_timeout_max_sec n)
 

--- a/lib/keeper/keeper_shell_shared.mli
+++ b/lib/keeper/keeper_shell_shared.mli
@@ -94,8 +94,9 @@ val clamp_shell_timeout :
   ?min_sec:float -> default:float -> Yojson.Safe.t -> float
 (** [clamp_shell_timeout ?min_sec ~default args] reads the
     optional [timeout_sec] field from [args], clamps it to
-    [\[min_sec, user_timeout_max_sec\]] (default [min_sec=1.0]),
-    and falls back to [default] when absent. *)
+    [\[min_sec, user_timeout_max_sec\]] (default:
+    [Timeout_floor.Native_shell]), and falls back to [default] when
+    absent. *)
 
 (** {1 Word + git-token tokenization} *)
 

--- a/lib/timeout_floor.ml
+++ b/lib/timeout_floor.ml
@@ -1,0 +1,31 @@
+type t =
+  | Docker_run
+  | Native_shell
+  | Tool_dispatch
+  | Llm_call
+  | Other of string
+
+let to_string = function
+  | Docker_run -> "docker_run"
+  | Native_shell -> "native_shell"
+  | Tool_dispatch -> "tool_dispatch"
+  | Llm_call -> "llm_call"
+  | Other name -> name
+;;
+
+let default_sec = function
+  | Docker_run -> 20.0
+  | Native_shell -> 5.0
+  | Tool_dispatch -> 15.0
+  | Llm_call -> 1.0
+  | Other _ -> 1.0
+;;
+
+let clamp floor value =
+  Float.max (default_sec floor) value
+;;
+
+let is_load_bearing = function
+  | Docker_run | Native_shell | Tool_dispatch -> true
+  | Llm_call | Other _ -> false
+;;

--- a/lib/timeout_floor.mli
+++ b/lib/timeout_floor.mli
@@ -1,0 +1,18 @@
+(** Typed timeout floors for load-bearing timeout clamps.
+
+    Floors differ from ordinary defaults: lowering them can reintroduce
+    known failure modes such as sub-network-latency gh calls or Docker
+    cold-start truncation. Keep those decisions in one typed table
+    instead of scattering magic literals at call sites. *)
+
+type t =
+  | Docker_run
+  | Native_shell
+  | Tool_dispatch
+  | Llm_call
+  | Other of string
+
+val to_string : t -> string
+val default_sec : t -> float
+val clamp : t -> float -> float
+val is_load_bearing : t -> bool

--- a/test/dune
+++ b/test/dune
@@ -128,6 +128,7 @@
   test_fsm_drift_counter
   test_gc_sampler
   test_process_timeout_counter
+  test_timeout_floor
   test_git_fetch_timeout_9587
   test_inference_utils
   test_auth_ambiguous_lookup_9786

--- a/test/test_timeout_floor.ml
+++ b/test/test_timeout_floor.ml
@@ -1,0 +1,45 @@
+open Masc_mcp
+
+let check_float name expected actual =
+  Alcotest.(check (float 0.0001)) name expected actual
+;;
+
+let test_default_table () =
+  check_float "docker run" 20.0 (Timeout_floor.default_sec Timeout_floor.Docker_run);
+  check_float "native shell" 5.0 (Timeout_floor.default_sec Timeout_floor.Native_shell);
+  check_float "tool dispatch" 15.0 (Timeout_floor.default_sec Timeout_floor.Tool_dispatch);
+  check_float "llm call" 1.0 (Timeout_floor.default_sec Timeout_floor.Llm_call)
+;;
+
+let test_clamp () =
+  check_float "raises low docker timeout" 20.0
+    (Timeout_floor.clamp Timeout_floor.Docker_run 1.0);
+  check_float "preserves higher docker timeout" 30.0
+    (Timeout_floor.clamp Timeout_floor.Docker_run 30.0)
+;;
+
+let test_load_bearing () =
+  Alcotest.(check bool)
+    "docker"
+    true
+    (Timeout_floor.is_load_bearing Timeout_floor.Docker_run);
+  Alcotest.(check bool)
+    "tool"
+    true
+    (Timeout_floor.is_load_bearing Timeout_floor.Tool_dispatch);
+  Alcotest.(check bool)
+    "llm"
+    false
+    (Timeout_floor.is_load_bearing Timeout_floor.Llm_call)
+;;
+
+let () =
+  Alcotest.run
+    "timeout_floor"
+    [ ( "typed floors"
+      , [ Alcotest.test_case "defaults" `Quick test_default_table
+        ; Alcotest.test_case "clamp" `Quick test_clamp
+        ; Alcotest.test_case "load-bearing" `Quick test_load_bearing
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

- add typed `Timeout_floor` table for load-bearing timeout floors
- route gh/tool dispatch, native shell, and Docker run floors through the typed table
- keep existing public constants while removing scattered `15.0` / `5.0` / `20.0` floor literals from the touched call sites
- add focused `test_timeout_floor` coverage for defaults, clamp behavior, and load-bearing classification

## Behavior note

`MASC_KEEPER_DOCKER_RUN_MIN_TIMEOUT_SEC` remains an override for raising Docker run minimums, but values below the typed `Docker_run` floor now clamp back to 20s. That matches the variable name and prevents the old cold-start timeout failure from being reintroduced by a too-low override.

## Verification

- `ocamlformat --check lib/timeout_floor.ml lib/timeout_floor.mli lib/keeper/keeper_shell_shared.ml lib/keeper/keeper_shell_shared.mli lib/keeper/keeper_shell_docker.ml lib/keeper/keeper_shell_docker.mli lib/config/env_config_sandbox.ml test/test_timeout_floor.ml`
- `git diff --check origin/main...HEAD`
- `ocamlc -c -o /private/tmp/timeout_floor.cmi lib/timeout_floor.mli`
- `ocamlc -c -I /private/tmp -o /private/tmp/timeout_floor.cmo lib/timeout_floor.ml`
- `scripts/lint/timeout-env-ceiling.sh`
- legacy literal sweep over touched call sites for old floor literals / boolean gh floor arms

Local focused Dune build was not run because `/tmp/me-dune-local.lock` is still held by another long-running worktree process; GitHub CI should be treated as the authoritative Dune result for this branch.
