### PR TITLE
chore(policy): remove unused compatibility groups

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -22,10 +22,6 @@ tools = ["keeper_board_get", "keeper_board_post", "keeper_board_comment", "keepe
 [groups.board_extended]
 tools = ["keeper_board_stats", "keeper_board_search"]
 
-# Full board group: backward compat alias.
-[groups.board]
-tools = ["keeper_board_get", "keeper_board_post", "keeper_board_comment", "keeper_board_vote", "keeper_board_list", "keeper_board_curation_read", "keeper_board_curation_submit", "keeper_board_stats", "keeper_board_search"]
-
 # Coordination split: core (task lifecycle) vs extended (audit, force ops).
 [groups.coordination_core]
 tools = [
@@ -118,16 +114,6 @@ tools = [
   "masc_batch_add_tasks", "masc_agents", "masc_dashboard",
   "masc_agent_card", "masc_tool_help",
   "masc_task_history", "masc_plan_get", "masc_plan_get_task",
-  "masc_join", "masc_leave", "masc_who", "masc_heartbeat",
-  "masc_messages", "masc_broadcast",
-]
-
-# Full core: backward compat alias (essential + coordination).
-[masc.core]
-tools = [
-  "masc_status", "masc_tasks", "masc_claim_next", "masc_transition",
-  "masc_add_task", "masc_batch_add_tasks", "masc_agents", "masc_dashboard",
-  "masc_agent_card", "masc_tool_help", "masc_web_search", "masc_web_fetch",
   "masc_join", "masc_leave", "masc_who", "masc_heartbeat",
   "masc_messages", "masc_broadcast",
 ]

--- a/test/test_keeper_tool_policy_config.ml
+++ b/test/test_keeper_tool_policy_config.ml
@@ -39,6 +39,16 @@ let with_env name value f =
 let read_file path =
   In_channel.with_open_bin path In_channel.input_all
 
+let contains_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop index =
+    if index + needle_len > haystack_len then false
+    else if String.sub haystack index needle_len = needle then true
+    else loop (index + 1)
+  in
+  needle_len = 0 || loop 0
+
 let write_file path content =
   Out_channel.with_open_bin path (fun oc -> output_string oc content)
 
@@ -139,6 +149,19 @@ masc_tools = ["keeper_fs_write", "keeper_fs_delete", "masc_status"]
       | Some KTPC.All_candidates -> fail "legacy preset should be explicit subset"
       | None -> fail "legacy preset missing")
 
+let test_no_backward_compat_alias_groups () =
+  let source_root = Masc_test_deps.find_project_root () in
+  let cfg =
+    match KTPC.load ~base_path:source_root with
+    | Ok cfg -> cfg
+    | Error msg -> fail (Printf.sprintf "config load failed: %s" msg)
+  in
+  check bool "groups.board alias removed" false
+    (List.mem "board" (KTPC.group_names cfg));
+  let policy = read_file (Filename.concat source_root "config/tool_policy.toml") in
+  check bool "masc.core alias removed" false
+    (contains_substring policy "[masc.core]")
+
 (* ── preset_can_satisfy tests ───────────────────────────────── *)
 
 let load_config () =
@@ -222,6 +245,8 @@ let () =
             test_load_anchors_resolution_to_base_path_over_cwd_candidate;
           test_case "normalizes legacy fs tool names" `Quick
             test_load_normalizes_legacy_fs_tool_names;
+          test_case "no backward compat alias groups" `Quick
+            test_no_backward_compat_alias_groups;
         ] );
       ( "preset_can_satisfy",
         [


### PR DESCRIPTION
## Summary
- remove the unused groups.board backward-compat alias from tool_policy.toml
- remove the unused masc.core backward-compat alias from tool_policy.toml
- add a config ratchet test so those alias groups do not come back

## Validation
- git diff --check HEAD~1..HEAD
- rg confirms config/tool_policy.toml no longer contains backward compat alias, [groups.board], or [masc.core]
- focused scripts/dune-local.sh build test/test_keeper_tool_policy_config.exe was attempted but refused because unrelated bare Dune builds are active on this host