### PR TITLE
refactor(cascade_transport): extract MCP policy header helpers sibling (-56 LOC)

### DIFF
--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -110,74 +110,18 @@ let dedupe_preserve_order (items : string list) =
 ;;
 
 let upsert_http_header = Cascade_transport_authorization.upsert_http_header
-let trim_nonempty value =
-  match value with
-  | Some raw ->
-    let trimmed = String.trim raw in
-    if String.equal trimmed "" then None else Some trimmed
-  | None -> None
-;;
-
-let first_nonempty_env names =
-  List.find_map (fun name -> Sys.getenv_opt name |> trim_nonempty) names
-;;
-
+(* trim_nonempty + first_nonempty_env + runtime-MCP policy header helpers
+   extracted to [Cascade_transport_mcp_policy_helpers] (godfile decomp). *)
+let trim_nonempty = Cascade_transport_mcp_policy_helpers.trim_nonempty
+let first_nonempty_env = Cascade_transport_mcp_policy_helpers.first_nonempty_env
 let keeper_name_of_agent_name = Cascade_transport_authorization.keeper_name_of_agent_name
 
-let runtime_mcp_policy_with_masc_agent_name
-      ?(include_internal_token = true)
-      ~(agent_name : string)
-      (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
-  =
-  let agent_name = String.trim agent_name in
-  if String.equal agent_name ""
-  then policy
-  else (
-    let servers =
-      List.map
-        (function
-          | Llm_provider.Llm_transport.Http_server ({ name; headers; _ } as server)
-            when String.equal name "masc" ->
-            let headers =
-              upsert_http_header ~key:"x-masc-agent-name" ~value:agent_name headers
-            in
-            let headers =
-              if include_internal_token
-              then (
-                match
-                  ( first_nonempty_env [ "MASC_INTERNAL_MCP_TOKEN" ]
-                  , keeper_name_of_agent_name agent_name )
-                with
-                | Some token, Some _ ->
-                  upsert_http_header ~key:"x-masc-internal-token" ~value:token headers
-                | _ -> headers)
-              else headers
-            in
-            let headers =
-              match keeper_name_of_agent_name agent_name with
-              | Some keeper_name ->
-                upsert_http_header ~key:"x-masc-keeper-name" ~value:keeper_name headers
-              | None -> headers
-            in
-            Llm_provider.Llm_transport.Http_server { server with headers }
-          | server -> server)
-        policy.servers
-    in
-    { policy with servers })
+let runtime_mcp_policy_with_masc_agent_name =
+  Cascade_transport_mcp_policy_helpers.runtime_mcp_policy_with_masc_agent_name
 ;;
 
-let runtime_mcp_policy_without_http_headers
-      (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
-  =
-  let servers =
-    List.map
-      (function
-        | Llm_provider.Llm_transport.Http_server server ->
-          Llm_provider.Llm_transport.Http_server { server with headers = [] }
-        | server -> server)
-      policy.servers
-  in
-  { policy with servers }
+let runtime_mcp_policy_without_http_headers =
+  Cascade_transport_mcp_policy_helpers.runtime_mcp_policy_without_http_headers
 ;;
 
 let is_authorization_header = Cascade_transport_authorization.is_authorization_header

--- a/lib/cascade/cascade_transport_mcp_policy_helpers.ml
+++ b/lib/cascade/cascade_transport_mcp_policy_helpers.ml
@@ -1,0 +1,80 @@
+(** Runtime-MCP policy header helpers, extracted from
+    [cascade_transport.ml]. Two pure transforms over
+    [Llm_provider.Llm_transport.runtime_mcp_policy]:
+
+    - [runtime_mcp_policy_with_masc_agent_name] injects x-masc-agent-name
+      (+ optional internal token / keeper-name) into the "masc" HTTP
+      server headers.
+    - [runtime_mcp_policy_without_http_headers] strips all headers from
+      every HTTP server. *)
+
+let upsert_http_header = Cascade_transport_authorization.upsert_http_header
+let keeper_name_of_agent_name = Cascade_transport_authorization.keeper_name_of_agent_name
+
+let trim_nonempty value =
+  match value with
+  | Some raw ->
+    let trimmed = String.trim raw in
+    if String.equal trimmed "" then None else Some trimmed
+  | None -> None
+;;
+
+let first_nonempty_env names =
+  List.find_map (fun name -> Sys.getenv_opt name |> trim_nonempty) names
+;;
+
+let runtime_mcp_policy_with_masc_agent_name
+      ?(include_internal_token = true)
+      ~(agent_name : string)
+      (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
+  =
+  let agent_name = String.trim agent_name in
+  if String.equal agent_name ""
+  then policy
+  else (
+    let servers =
+      List.map
+        (function
+          | Llm_provider.Llm_transport.Http_server ({ name; headers; _ } as server)
+            when String.equal name "masc" ->
+            let headers =
+              upsert_http_header ~key:"x-masc-agent-name" ~value:agent_name headers
+            in
+            let headers =
+              if include_internal_token
+              then (
+                match
+                  ( first_nonempty_env [ "MASC_INTERNAL_MCP_TOKEN" ]
+                  , keeper_name_of_agent_name agent_name )
+                with
+                | Some token, Some _ ->
+                  upsert_http_header ~key:"x-masc-internal-token" ~value:token headers
+                | _ -> headers)
+              else headers
+            in
+            let headers =
+              match keeper_name_of_agent_name agent_name with
+              | Some keeper_name ->
+                upsert_http_header ~key:"x-masc-keeper-name" ~value:keeper_name headers
+              | None -> headers
+            in
+            Llm_provider.Llm_transport.Http_server { server with headers }
+          | server -> server)
+        policy.servers
+    in
+    { policy with servers })
+;;
+
+let runtime_mcp_policy_without_http_headers
+      (policy : Llm_provider.Llm_transport.runtime_mcp_policy)
+  =
+  let servers =
+    List.map
+      (function
+        | Llm_provider.Llm_transport.Http_server server ->
+          Llm_provider.Llm_transport.Http_server { server with headers = [] }
+        | server -> server)
+      policy.servers
+  in
+  { policy with servers }
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane D (Cascade)
- Next sibling extracted from `cascade_transport.ml` after the auth + label_res clusters already shipped.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/cascade/cascade_transport.ml` | 1498 | 1442 | **-56** |
| `lib/cascade/cascade_transport_mcp_policy_helpers.ml` | — | 80 | +80 |

## Moved (verbatim, no behavior change)
- `trim_nonempty : string option -> string option`
- `first_nonempty_env : string list -> string option` (env-resolution helper)
- `runtime_mcp_policy_with_masc_agent_name` (inject x-masc-agent-name + x-masc-internal-token + x-masc-keeper-name headers into "masc" HTTP server entry)
- `runtime_mcp_policy_without_http_headers` (strip all HTTP headers from every HTTP server)

4 single-line aliases in parent.

## In-file caller preservation
`first_nonempty_env` is still called from 3 other sites inside `cascade_transport.ml` (originally lines 338, 362, 526). The parent alias keeps these working without source changes.

## .mli surface
`runtime_mcp_policy_with_masc_agent_name` is the only one in the public `.mli`. The parent alias preserves the byte-identical signature.

## Sibling deps
- `Llm_provider.Llm_transport.*` — external
- `Cascade_transport_authorization.upsert_http_header`
- `Cascade_transport_authorization.keeper_name_of_agent_name`
- `String`, `List`, `Option`, `Sys` — std

No sibling -> parent cycle.

## Local build status
- `dune build @check`: only pre-existing main breakage remains (`violation_detail`, `Masc_log`, plus prior ones) — unrelated
- godfile lint: clean (absolute_cap=3350, new_file_cap=600)

## RFC-WAIVED
Extract-only sibling refactor.

Co-Authored-By: codex <noreply@anthropic.com>
