### PR TITLE
tools(ide): emit changed-symbols artifact

### DIFF
--- a/scripts/ide/export-symbol-graph
+++ b/scripts/ide/export-symbol-graph
@@ -20,6 +20,7 @@ from typing import Any
 
 DEFAULT_ARTIFACT = pathlib.Path("docs/generated/reverse-engineering/symbol-graph.v1.json")
 SCHEMA_VERSION = "masc.symbol_graph.v1"
+CHANGED_SYMBOLS_SCHEMA_VERSION = "masc.symbol_graph.changed_symbols.v1"
 ALLOWED_METHODS = {
     "initialize",
     "initialized",
@@ -61,6 +62,21 @@ def git_short_head(root: pathlib.Path) -> str:
     ).strip()
 
 
+def git_changed_paths(root: pathlib.Path, *, base_ref: str, head_ref: str) -> list[str]:
+    output = subprocess.check_output(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=AMR",
+            f"{base_ref}...{head_ref}",
+        ],
+        cwd=root,
+        text=True,
+    )
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
 def load_json(path: pathlib.Path) -> dict[str, Any]:
     with path.open(encoding="utf-8") as handle:
         data = json.load(handle)
@@ -95,6 +111,134 @@ def collect_languages(data: dict[str, Any]) -> set[str]:
         if isinstance(language, str) and language:
             languages.add(language)
     return languages
+
+
+def lane_summary(lane: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": lane.get("name"),
+        "issue": lane.get("issue"),
+        "goal": lane.get("goal"),
+        "tasks": lane.get("tasks", []),
+        "guard_tests": lane.get("guard_tests", []),
+    }
+
+
+def collect_lanes_by_file(data: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    lanes_by_file: dict[str, list[dict[str, Any]]] = {}
+    for lane in data.get("lanes", []):
+        if not isinstance(lane, dict):
+            continue
+        summary = lane_summary(lane)
+        for path in lane.get("primary_files", []):
+            if isinstance(path, str):
+                lanes_by_file.setdefault(path, []).append(summary)
+    return lanes_by_file
+
+
+def collect_files_by_path(data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    files_by_path: dict[str, dict[str, Any]] = {}
+    for file_row in data.get("files", []):
+        if not isinstance(file_row, dict):
+            continue
+        path = file_row.get("path")
+        if isinstance(path, str):
+            files_by_path[path] = file_row
+    return files_by_path
+
+
+def symbol_summary(symbol: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": symbol.get("id"),
+        "name": symbol.get("name"),
+        "kind": symbol.get("kind"),
+        "display_range": symbol.get("display_range"),
+        "wbs": symbol.get("wbs"),
+        "tests": symbol.get("tests", []),
+    }
+
+
+def normalize_changed_paths(changed_paths: list[str]) -> list[str]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for value in changed_paths:
+        path = repo_relative_path(value).as_posix()
+        if path in seen:
+            continue
+        normalized.append(path)
+        seen.add(path)
+    return normalized
+
+
+def changed_symbols_report(
+    data: dict[str, Any],
+    changed_paths: list[str],
+    *,
+    base_ref: str,
+    head_ref: str,
+) -> dict[str, Any]:
+    paths = normalize_changed_paths(changed_paths)
+    lanes_by_file = collect_lanes_by_file(data)
+    files_by_path = collect_files_by_path(data)
+    changed_files: list[dict[str, Any]] = []
+    missing_paths: list[str] = []
+
+    for path in paths:
+        file_row = files_by_path.get(path)
+        lanes = lanes_by_file.get(path, [])
+        if file_row is None:
+            missing_paths.append(path)
+            changed_files.append(
+                {
+                    "path": path,
+                    "in_symbol_graph": False,
+                    "language": None,
+                    "lanes": lanes,
+                    "symbols": [],
+                    "test_owners": [],
+                }
+            )
+            continue
+
+        symbols = [
+            symbol_summary(symbol)
+            for symbol in file_row.get("symbols", [])
+            if isinstance(symbol, dict)
+        ]
+        test_owners = file_row.get("test_owners", [])
+        if not isinstance(test_owners, list):
+            test_owners = []
+        changed_files.append(
+            {
+                "path": path,
+                "in_symbol_graph": True,
+                "language": file_row.get("language"),
+                "lanes": lanes,
+                "symbols": symbols,
+                "test_owners": test_owners,
+            }
+        )
+
+    omissions: list[dict[str, Any]] = []
+    if missing_paths:
+        omissions.append(
+            {
+                "code": "changed_file_not_in_symbol_graph",
+                "paths": missing_paths,
+            }
+        )
+
+    return {
+        "schema_version": CHANGED_SYMBOLS_SCHEMA_VERSION,
+        "artifact_schema_version": data.get("schema_version"),
+        "artifact_base_commit": data.get("base_commit"),
+        "repo": data.get("repo"),
+        "base_ref": base_ref,
+        "head_ref": head_ref,
+        "changed_path_count": len(paths),
+        "matched_file_count": len(paths) - len(missing_paths),
+        "changed_files": changed_files,
+        "omissions": omissions,
+    }
 
 
 def live_lsp_prereq_report(data: dict[str, Any], *, artifact: pathlib.Path) -> dict[str, Any]:
@@ -234,12 +378,19 @@ def main() -> int:
         help="print a non-mutating JSON report for live LSP executable prerequisites",
     )
     parser.add_argument(
+        "--changed-symbols",
+        action="store_true",
+        help="print a JSON impact report for files changed between --base-ref and --head-ref",
+    )
+    parser.add_argument(
         "--strict-ranges",
         action="store_true",
         help="require display_range rows to fit the current checkout even when base_commit differs",
     )
     parser.add_argument("--base-commit", help="override base_commit when used with --emit or --write")
     parser.add_argument("--generated-at", help="override generated_at when used with --emit or --write")
+    parser.add_argument("--base-ref", default="origin/main", help="base ref for --changed-symbols")
+    parser.add_argument("--head-ref", default="HEAD", help="head ref for --changed-symbols")
     args = parser.parse_args()
 
     root = repo_root()
@@ -262,6 +413,17 @@ def main() -> int:
         for error in errors:
             print(f"symbol graph error: {error}", file=sys.stderr)
         return 1
+
+    if args.changed_symbols:
+        changed_paths = git_changed_paths(root, base_ref=args.base_ref, head_ref=args.head_ref)
+        report = changed_symbols_report(
+            data,
+            changed_paths,
+            base_ref=args.base_ref,
+            head_ref=args.head_ref,
+        )
+        sys.stdout.write(dump_canonical(report))
+        return 0
 
     if args.emit:
         sys.stdout.write(dump_canonical(data))

--- a/test/dune
+++ b/test/dune
@@ -1588,6 +1588,8 @@
 
 (include stanzas/test_event_kind.inc)
 
+(include stanzas/test_export_symbol_graph.inc)
+
 (include stanzas/test_feature_flag_registry.inc)
 
 (include stanzas/test_fleet_capacity_supervisor.inc)

--- a/test/stanzas/test_export_symbol_graph.inc
+++ b/test/stanzas/test_export_symbol_graph.inc
@@ -1,0 +1,5 @@
+(rule
+ (alias runtest)
+ (deps test_export_symbol_graph.py
+       ../scripts/ide/export-symbol-graph)
+ (action (run python3 test_export_symbol_graph.py)))

--- a/test/test_export_symbol_graph.py
+++ b/test/test_export_symbol_graph.py
@@ -1,0 +1,104 @@
+import importlib.machinery
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "ide" / "export-symbol-graph"
+)
+
+
+def load_exporter_module():
+    loader = importlib.machinery.SourceFileLoader(
+        "export_symbol_graph", str(SCRIPT_PATH)
+    )
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    if spec is None:
+        raise RuntimeError(f"failed to load {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    loader.exec_module(module)
+    return module
+
+
+exporter = load_exporter_module()
+
+
+class ChangedSymbolsReportTest(unittest.TestCase):
+    def test_report_marks_known_and_unknown_changed_paths(self):
+        data = {
+            "schema_version": "masc.symbol_graph.v1",
+            "repo": "masc-mcp",
+            "base_commit": "abc123",
+            "lanes": [
+                {
+                    "name": "Keeper turn pipeline",
+                    "issue": 16079,
+                    "goal": "goal-refactor-keeper-turn-20260518",
+                    "tasks": ["task-368"],
+                    "primary_files": ["lib/a.ml"],
+                    "guard_tests": ["test/test_a.ml"],
+                }
+            ],
+            "files": [
+                {
+                    "path": "lib/a.ml",
+                    "language": "ocaml",
+                    "symbols": [
+                        {
+                            "id": "lib/a.ml::run",
+                            "name": "run",
+                            "kind": "function",
+                            "display_range": {"start_line": 10, "end_line": 20},
+                            "wbs": ["task-368"],
+                            "tests": ["test/test_a.ml"],
+                        }
+                    ],
+                    "test_owners": [
+                        {
+                            "test_path": "test/test_a.ml",
+                            "reason": "direct owner",
+                        }
+                    ],
+                }
+            ],
+        }
+
+        report = exporter.changed_symbols_report(
+            data,
+            ["lib/a.ml", "README.md", "lib/a.ml"],
+            base_ref="origin/main",
+            head_ref="HEAD",
+        )
+
+        self.assertEqual(
+            report["schema_version"],
+            "masc.symbol_graph.changed_symbols.v1",
+        )
+        self.assertEqual(report["artifact_schema_version"], "masc.symbol_graph.v1")
+        self.assertEqual(report["artifact_base_commit"], "abc123")
+        self.assertEqual(report["changed_path_count"], 2)
+        self.assertEqual(report["matched_file_count"], 1)
+
+        known = report["changed_files"][0]
+        self.assertEqual(known["path"], "lib/a.ml")
+        self.assertTrue(known["in_symbol_graph"])
+        self.assertEqual(known["language"], "ocaml")
+        self.assertEqual(known["lanes"][0]["name"], "Keeper turn pipeline")
+        self.assertEqual(known["symbols"][0]["id"], "lib/a.ml::run")
+        self.assertEqual(known["test_owners"][0]["test_path"], "test/test_a.ml")
+
+        unknown = report["changed_files"][1]
+        self.assertEqual(unknown["path"], "README.md")
+        self.assertFalse(unknown["in_symbol_graph"])
+        self.assertEqual(unknown["symbols"], [])
+        self.assertEqual(
+            report["omissions"][0]["code"], "changed_file_not_in_symbol_graph"
+        )
+        self.assertEqual(report["omissions"][0]["paths"], ["README.md"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `scripts/ide/export-symbol-graph --changed-symbols`
- emit a JSON impact report for files changed between `--base-ref` and `--head-ref`
- add a Python unit test and Dune runtest stanza for the report shaping logic

## Product impact

- User-visible change: operators can generate a changed-files symbol impact report from the checked-in reverse-engineering symbol graph before refactor PRs.

## Evidence

- PASS: `python3 -m py_compile scripts/ide/export-symbol-graph test/test_export_symbol_graph.py`
- PASS: `python3 test/test_export_symbol_graph.py`
- PASS: `ruff check scripts/ide/export-symbol-graph test/test_export_symbol_graph.py`
- PASS: `ruff format --check test/test_export_symbol_graph.py`
- PASS: `pyright --outputjson scripts/ide/export-symbol-graph test/test_export_symbol_graph.py`
- PASS: `python3 scripts/ide/export-symbol-graph --check`
- PASS: `python3 scripts/ide/export-symbol-graph --changed-symbols --base-ref origin/main --head-ref HEAD`
- PASS: `git diff --check origin/main...HEAD`
- PASS: `scripts/check-pr-hygiene.sh --base origin/main --head HEAD --duplicate-policy fail`
- BLOCKED: `scripts/dune-local.sh build @test/runtest` refused because live bare Dune processes are bypassing the machine-wide wrapper lock.

## GOAL LOOP ACT checklist

- [x] Observe — HTML backlog item identified missing changed-symbols artifact support.
- [x] Orient — existing symbol graph exporter already covered static atlas/check mode; gap was changed-files impact reporting.
- [x] Decide — add bounded read-only CLI mode and pure report-shaping test.
- [x] Act — code/test/stanza changed in the smallest bounded scope.
- [x] Verify — focused Python/lint/type/hygiene checks passed; Dune wrapper block recorded above.
- [x] Loop — no follow-up known for this slice.

## Review evidence

- Local review: checked diff, focused test coverage, and PR hygiene locally.

## Linked issue

- Relates #16080

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 8/9
provenance: direct
stages:
  - implementation
  - validation
```

## Variant addition checklist

- [x] **OCaml** — N/A, no OCaml variant changed.
- [x] **TypeScript** — N/A, no TypeScript union changed.
- [x] **TLA+ spec** — N/A, no TLA+ domain changed.
- [x] **Event / JSON schema** — N/A, script output schema is local CLI JSON only.
- [x] **`make check-variants` passes** — N/A, no variants changed.
