### PR TITLE
ci: ignore current PR in axis stale check

### DIFF
--- a/scripts/pr_axis_check.py
+++ b/scripts/pr_axis_check.py
@@ -265,6 +265,8 @@ def check_pr_axis_stale(
 
     for merged in recently_merged:
         merged_num = merged["number"]
+        if merged_num == pr_number:
+            continue
         merged_title = merged["title"]
         merged_files = {node["path"] for node in merged.get("files", {}).get("nodes", [])}
 


### PR DESCRIPTION
Summary:
- Ignore the current PR number when PR Axis Cross-Check compares an open PR against recently merged PRs.
- Prevent the checker from reporting a PR as stale against itself when the recent-merge query returns the same PR number.

Validation:
- pyright --outputjson scripts/pr_axis_check.py
- ruff check scripts/pr_axis_check.py
- python3 scripts/pr_axis_check.py --pr 17233 --hours 24 --limit 20
- git diff --check origin/main...HEAD

Context:
- Observed on #17233 after it was merged: PR Axis Cross-Check reported `#17233` as the blocking merged PR for `#17233`.
