### PR TITLE
refactor(server_dashboard_http_core): extract operator query/metadata sibling (-119 LOC)

### DIFF
--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -237,135 +237,16 @@ let projection_diagnostics_field = Server_dashboard_http_core_json.projection_di
 let operator_generated_at_iso = Server_dashboard_http_core_json.operator_generated_at_iso
 let operator_cache_json = Server_dashboard_http_core_json.operator_cache_json
 
-let operator_retention_json ~(config : Coord.config) ~scope ~producer =
-  `Assoc
-    [ "scope", `String scope
-    ; "coordination_root", `String config.base_path
-    ; "workspace_path", `String config.workspace_path
-    ; "producer", `String producer
-    ; "store_kind", `String "process_cache"
-    ; "cache_surface", `String "Server_dashboard_http_core.cached_surface"
-    ; "http_swr_ttl_s", `Float 5.0
-    ; "background_refresh_interval_s", `Float operator_refresh_interval_s
-    ; "request_timeout_s", `Float dashboard_request_timeout_s
-    ; ( "cache_policy"
-      , `String
-          "default route uses proactive cached_surface; parameterized route uses HTTP stale-while-revalidate"
-      )
-    ]
-;;
-
-let operator_snapshot_query_json ~actor ~view ~include_messages ~include_keepers
-    ~lightweight_summary ~default_summary_request =
-  let effective_view =
-    match view with
-    | Some value -> value
-    | None -> if default_summary_request then "summary" else "full"
-  in
-  `Assoc
-    [ "actor", json_string_opt actor
-    ; "view", json_string_opt view
-    ; "effective_actor", `String (Option.value ~default:"dashboard" actor)
-    ; "effective_view", `String effective_view
-    ; "include_messages", `Bool include_messages
-    ; "include_keepers", `Bool include_keepers
-    ; "lightweight_summary", `Bool lightweight_summary
-    ; "default_summary_request", `Bool default_summary_request
-    ]
-;;
-
-let operator_digest_query_json ~actor ~target_type ~target_id ~include_workers
-    ~effective_target_type ~default_namespace_request =
-  `Assoc
-    [ "actor", json_string_opt actor
-    ; "target_type", json_string_opt target_type
-    ; "target_id", json_string_opt target_id
-    ; "effective_target_type", `String effective_target_type
-    ; "include_workers", json_bool_opt include_workers
-    ; "default_namespace_request", `Bool default_namespace_request
-    ]
-;;
-
-let with_operator_surface_metadata
-    ~config
-    ?cache_key
-    ~dashboard_surface
-    ~source
-    ~scope
-    ~producer
-    ~query
-    json =
-  match json with
-  | `Assoc fields ->
-    let generated_at = operator_generated_at_iso json in
-    let metadata =
-      [ "dashboard_surface", `String dashboard_surface
-      ; "source", `String source
-      ; "generated_at_iso", `String generated_at
-      ; "retention", operator_retention_json ~config ~scope ~producer
-      ; "query", query
-      ; "cache", operator_cache_json ?cache_key ~scope json
-      ]
-    in
-    let metadata_keys =
-      [ "dashboard_surface"
-      ; "source"
-      ; "generated_at_iso"
-      ; "retention"
-      ; "query"
-      ; "cache"
-      ]
-    in
-    let fields =
-      List.filter (fun (key, _) -> not (List.mem key metadata_keys)) fields
-    in
-    `Assoc (metadata @ fields)
-  | other -> other
-;;
-
-let with_operator_snapshot_metadata ~config ?cache_key ~query json =
-  with_operator_surface_metadata
-    ~config
-    ?cache_key
-    ~dashboard_surface:"/api/v1/operator"
-    ~source:"operator_snapshot_read_model"
-    ~scope:"operator_snapshot"
-    ~producer:"Operator_control.snapshot_json"
-    ~query
-    json
-;;
-
-let with_operator_digest_metadata ~config ?cache_key ~query json =
-  with_operator_surface_metadata
-    ~config
-    ?cache_key
-    ~dashboard_surface:"/api/v1/operator/digest"
-    ~source:"operator_digest_read_model"
-    ~scope:"operator_digest"
-    ~producer:"Operator_control.digest_json"
-    ~query
-    json
-;;
-
-let operator_snapshot_default_query () =
-  operator_snapshot_query_json
-    ~actor:None
-    ~view:None
-    ~include_messages:true
-    ~include_keepers:true
-    ~lightweight_summary:true
-    ~default_summary_request:true
-;;
-
-let operator_digest_default_query () =
-  operator_digest_query_json
-    ~actor:None
-    ~target_type:None
-    ~target_id:None
-    ~include_workers:None
-    ~effective_target_type:"root"
-    ~default_namespace_request:true
-;;
+(* Operator query-JSON + envelope metadata helpers extracted to
+   [Server_dashboard_http_core_operator_query] (godfile decomp). *)
+let operator_retention_json = Server_dashboard_http_core_operator_query.operator_retention_json
+let operator_snapshot_query_json = Server_dashboard_http_core_operator_query.operator_snapshot_query_json
+let operator_digest_query_json = Server_dashboard_http_core_operator_query.operator_digest_query_json
+let with_operator_surface_metadata = Server_dashboard_http_core_operator_query.with_operator_surface_metadata
+let with_operator_snapshot_metadata = Server_dashboard_http_core_operator_query.with_operator_snapshot_metadata
+let with_operator_digest_metadata = Server_dashboard_http_core_operator_query.with_operator_digest_metadata
+let operator_snapshot_default_query = Server_dashboard_http_core_operator_query.operator_snapshot_default_query
+let operator_digest_default_query = Server_dashboard_http_core_operator_query.operator_digest_default_query
 
 let start_operator_snapshot_refresh_loop ~state ~sw ~clock =
   let config = state.Mcp_server.room_config in

--- a/lib/server/server_dashboard_http_core_operator_query.ml
+++ b/lib/server/server_dashboard_http_core_operator_query.ml
@@ -1,0 +1,146 @@
+(** Operator query-JSON metadata helpers, extracted from
+    [server_dashboard_http_core.ml]. Pure builders for the
+    [/api/v1/operator] + [/api/v1/operator/digest] response envelopes
+    (retention metadata, query echo, surface wrapping, default queries).
+    No side effects, no I/O. *)
+
+open Masc_domain
+
+(* Sibling dependencies — already extracted in earlier godfile decomp PRs. *)
+let json_string_opt = Server_dashboard_http_core_json.json_string_opt
+let json_bool_opt = Server_dashboard_http_core_json.json_bool_opt
+let operator_generated_at_iso = Server_dashboard_http_core_json.operator_generated_at_iso
+let operator_cache_json = Server_dashboard_http_core_json.operator_cache_json
+
+let operator_refresh_interval_s = Server_dashboard_http_core_operator.operator_refresh_interval_s
+let dashboard_request_timeout_s = Server_dashboard_http_core_cache.dashboard_request_timeout_s
+
+let operator_retention_json ~(config : Coord.config) ~scope ~producer =
+  `Assoc
+    [ "scope", `String scope
+    ; "coordination_root", `String config.base_path
+    ; "workspace_path", `String config.workspace_path
+    ; "producer", `String producer
+    ; "store_kind", `String "process_cache"
+    ; "cache_surface", `String "Server_dashboard_http_core.cached_surface"
+    ; "http_swr_ttl_s", `Float 5.0
+    ; "background_refresh_interval_s", `Float operator_refresh_interval_s
+    ; "request_timeout_s", `Float dashboard_request_timeout_s
+    ; ( "cache_policy"
+      , `String
+          "default route uses proactive cached_surface; parameterized route uses HTTP stale-while-revalidate"
+      )
+    ]
+;;
+
+let operator_snapshot_query_json ~actor ~view ~include_messages ~include_keepers
+    ~lightweight_summary ~default_summary_request =
+  let effective_view =
+    match view with
+    | Some value -> value
+    | None -> if default_summary_request then "summary" else "full"
+  in
+  `Assoc
+    [ "actor", json_string_opt actor
+    ; "view", json_string_opt view
+    ; "effective_actor", `String (Option.value ~default:"dashboard" actor)
+    ; "effective_view", `String effective_view
+    ; "include_messages", `Bool include_messages
+    ; "include_keepers", `Bool include_keepers
+    ; "lightweight_summary", `Bool lightweight_summary
+    ; "default_summary_request", `Bool default_summary_request
+    ]
+;;
+
+let operator_digest_query_json ~actor ~target_type ~target_id ~include_workers
+    ~effective_target_type ~default_namespace_request =
+  `Assoc
+    [ "actor", json_string_opt actor
+    ; "target_type", json_string_opt target_type
+    ; "target_id", json_string_opt target_id
+    ; "effective_target_type", `String effective_target_type
+    ; "include_workers", json_bool_opt include_workers
+    ; "default_namespace_request", `Bool default_namespace_request
+    ]
+;;
+
+let with_operator_surface_metadata
+    ~config
+    ?cache_key
+    ~dashboard_surface
+    ~source
+    ~scope
+    ~producer
+    ~query
+    json =
+  match json with
+  | `Assoc fields ->
+    let generated_at = operator_generated_at_iso json in
+    let metadata =
+      [ "dashboard_surface", `String dashboard_surface
+      ; "source", `String source
+      ; "generated_at_iso", `String generated_at
+      ; "retention", operator_retention_json ~config ~scope ~producer
+      ; "query", query
+      ; "cache", operator_cache_json ?cache_key ~scope json
+      ]
+    in
+    let metadata_keys =
+      [ "dashboard_surface"
+      ; "source"
+      ; "generated_at_iso"
+      ; "retention"
+      ; "query"
+      ; "cache"
+      ]
+    in
+    let fields =
+      List.filter (fun (key, _) -> not (List.mem key metadata_keys)) fields
+    in
+    `Assoc (metadata @ fields)
+  | other -> other
+;;
+
+let with_operator_snapshot_metadata ~config ?cache_key ~query json =
+  with_operator_surface_metadata
+    ~config
+    ?cache_key
+    ~dashboard_surface:"/api/v1/operator"
+    ~source:"operator_snapshot_read_model"
+    ~scope:"operator_snapshot"
+    ~producer:"Operator_control.snapshot_json"
+    ~query
+    json
+;;
+
+let with_operator_digest_metadata ~config ?cache_key ~query json =
+  with_operator_surface_metadata
+    ~config
+    ?cache_key
+    ~dashboard_surface:"/api/v1/operator/digest"
+    ~source:"operator_digest_read_model"
+    ~scope:"operator_digest"
+    ~producer:"Operator_control.digest_json"
+    ~query
+    json
+;;
+
+let operator_snapshot_default_query () =
+  operator_snapshot_query_json
+    ~actor:None
+    ~view:None
+    ~include_messages:true
+    ~include_keepers:true
+    ~lightweight_summary:true
+    ~default_summary_request:true
+;;
+
+let operator_digest_default_query () =
+  operator_digest_query_json
+    ~actor:None
+    ~target_type:None
+    ~target_id:None
+    ~include_workers:None
+    ~effective_target_type:"root"
+    ~default_namespace_request:true
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` step 20 (Dashboard core surface split — operator query/metadata cluster)
- 5th sibling extracted from `server_dashboard_http_core.ml` after #17126 (cache), #17215 (operator), #17254 (json), #17274 (meta-cognition).

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/server/server_dashboard_http_core.ml` | 1572 | 1453 | **-119** |
| `lib/server/server_dashboard_http_core_operator_query.ml` | — | 146 | +146 |

## Moved (verbatim, no behavior change)
- `operator_retention_json` — retention envelope (coordination_root, workspace, TTL, etc.)
- `operator_snapshot_query_json` — snapshot query echo with effective_view derivation
- `operator_digest_query_json` — digest query echo
- `with_operator_surface_metadata` — generic envelope wrapper (dashboard_surface + source + retention + query + cache)
- `with_operator_snapshot_metadata` — scope-bound wrapper for `/api/v1/operator`
- `with_operator_digest_metadata` — scope-bound wrapper for `/api/v1/operator/digest`
- `operator_snapshot_default_query` — defaults for unparameterized snapshot
- `operator_digest_default_query` — defaults for unparameterized digest

8 single-line aliases in parent.

## Why this cluster is safe
- Pure JSON-builder functions, no side effects, no I/O.
- All external deps are already extracted siblings: `Server_dashboard_http_core_json` (5 helpers), `Server_dashboard_http_core_operator` (refresh_interval), `Server_dashboard_http_core_cache` (request_timeout).
- No external module reaches into these by name (none in `.mli`, no cross-module callers).

## Sibling deps
- `Masc_domain` (opened, for `Coord.config`)
- `Server_dashboard_http_core_json` — json_string_opt, json_bool_opt, operator_generated_at_iso, operator_cache_json
- `Server_dashboard_http_core_operator` — operator_refresh_interval_s
- `Server_dashboard_http_core_cache` — dashboard_request_timeout_s

No sibling -> parent cycle introduced.

## Local build status
- `dune build @check`: only pre-existing main breakages remain (`Timeout_floor` unbound, Worker_runtime dep cycle, `evidence_role`, `violation_detail`, `cdal_health_json` unbound, `called_tools`) — unrelated
- godfile lint: clean (absolute_cap=3350, new_file_cap=600)

## RFC-WAIVED
Extract-only sibling refactor.

Co-Authored-By: codex <noreply@anthropic.com>
