### PR TITLE
[codex] fix(shell): gate worker shell exec through exec gate

### DIFF
--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -5,7 +5,8 @@
     file modifications).
 
     file_read/file_write use OCaml stdlib (no Eio filesystem capability needed).
-    shell_exec uses Eio.Process with fiber-based timeout.
+    shell_exec validates commands locally and routes execution through
+    Exec_gate.
 
     Safety classification helpers are defined in [Shell_safety_types]
     and re-exported here for backward compat. *)
@@ -1108,7 +1109,7 @@ let attribution_of_validation ~cmd (result : (unit, block_reason) result) : Attr
 let make_shell_exec_with_allowlist
       ~workdir
       ~on_exec
-      ~proc_mgr
+      ~proc_mgr:_
       ~clock
       ~allowed_commands
       ~description
@@ -1213,61 +1214,56 @@ let make_shell_exec_with_allowlist
                      ~error_message:message
                      (tool_error ~recoverable:true message))
                  (fun () ->
-                    let buf = Buffer.create 1024 in
-                    let wrapped_command =
+                    let cwd =
                       match workdir with
-                      | Some dir when String.trim dir <> "" ->
-                        Printf.sprintf "cd %s && %s" (Filename.quote dir) command
-                      | _ -> command
+                      | Some dir when String.trim dir <> "" -> Some dir
+                      | Some _ | None -> None
+                    in
+                    let argv = [ (Host_config.host ()).host_sh; "-c"; command ] in
+                    let raw_source =
+                      String.concat " " (List.map Filename.quote argv)
                     in
                     let result =
                       try
                         let status, output =
                           Fd_accountant.with_slot ~kind:Sandbox_exec (fun () ->
-                            Eio.Time.with_timeout_exn clock timeout (fun () ->
-                              Eio.Switch.run
-                              @@ fun sw ->
-                              let stdout_r, stdout_w =
-                                Eio.Process.pipe ~sw proc_mgr
-                              in
-                              let proc =
-                                Eio.Process.spawn
-                                  ~sw
-                                  proc_mgr
-                                  ~stdout:stdout_w
-                                  [ "sh"; "-c"; wrapped_command ^ " 2>&1" ]
-                              in
-                              Eio.Flow.close stdout_w;
-                              (try
-                                 Eio.Flow.copy stdout_r (Eio.Flow.buffer_sink buf);
-                                 Eio.Flow.close stdout_r
-                               with
-                               | Eio.Cancel.Cancelled _ as e ->
-                                 (try Eio.Flow.close stdout_r with
-                                  | Eio.Cancel.Cancelled _ as ce -> raise ce
-                                  | _ -> ());
-                                 raise e);
-                              let status = Eio.Process.await proc in
-                              status, Buffer.contents buf))
+                            Masc_exec.Exec_gate.run_argv_with_status
+                              ~actor:`Tool_local_runtime
+                              ~raw_source
+                              ~summary:"worker shell_exec command execution"
+                              ~timeout_sec:timeout
+                              ?cwd
+                              argv)
                         in
                         match status with
-                        | `Exited 0 -> Ok { Agent_sdk.Types.content = output }
-                        | `Exited code ->
+                        | Unix.WEXITED 0 -> Ok { Agent_sdk.Types.content = output }
+                        | Unix.WEXITED 124 ->
+                          tool_error
+                            ~recoverable:true
+                            (Printf.sprintf
+                               "Timeout after %.0fs: %s\n%s"
+                               timeout
+                               command
+                               output)
+                        | Unix.WEXITED code ->
                           tool_error (Printf.sprintf "Exit code %d:\n%s" code output)
-                        | `Signaled sig_num ->
+                        | Unix.WSIGNALED sig_num ->
                           tool_error
                             ~recoverable:(sig_num = Sys.sigterm)
                             (Printf.sprintf "Killed by signal %d:\n%s" sig_num output)
+                        | Unix.WSTOPPED sig_num ->
+                          tool_error
+                            ~recoverable:true
+                            (Printf.sprintf "Stopped by signal %d:\n%s" sig_num output)
                       with
                       | Eio.Time.Timeout ->
-                        let output = Buffer.contents buf in
                         tool_error
                           ~recoverable:true
                           (Printf.sprintf
                              "Timeout after %.0fs: %s\n%s"
                              timeout
                              command
-                             output)
+                             "")
                     in
                     record_result result)
              with

--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -19,20 +19,14 @@
 # lib/bounded_proc/bounded_proc.ml:17  — the canonical helper itself.
 lib/bounded_proc/bounded_proc.ml:17
 
-# lib/process/process_eio.ml:504, 535 — `spawn_and_drain_{stdout,both}`.
+# lib/process/process_eio.ml:486, 517 — `spawn_and_drain_{stdout,both}`.
 # Private functions. Every caller (run_argv*, run_argv_with_status*,
 # run_argv_with_stdin*) wraps in `Eio.Time.with_timeout_exn clk timeout_sec`
 # + `Eio.Switch.run` and the process-wide spawn guard.
-lib/process/process_eio.ml:504
-lib/process/process_eio.ml:535
+lib/process/process_eio.ml:486
+lib/process/process_eio.ml:517
 
 # lib/server/lsp_process_manager.ml:178 — LSP child process. Lifetime is
 # bound to the LSP session switch; idle eviction handled by the LSP
 # manager itself. Bounded by session scope, not by per-call timeout.
 lib/server/lsp_process_manager.ml:178
-
-# lib/worker_dev_tools.ml:1234 — dev-tools worker spawn. Wrapped by
-# Tool_resource_gate, Fd_accountant, Eio.Time.with_timeout_exn, and a fresh
-# Eio.Switch.run at the call boundary. Line renumbered by worker-dev-tools
-# split/refactor waves.
-lib/worker_dev_tools.ml:1234

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -349,6 +349,42 @@ let test_shell_exec_echo () =
    | Error { Agent_sdk.Types.message = e; _ } ->
      Alcotest.fail (Printf.sprintf "expected Ok, got Error: %s" e))
 
+let test_shell_exec_uses_exec_gate_cwd () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let proc_mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
+  let workdir = Filename.temp_file "wdt_shell_exec_cwd_" "" in
+  Fun.protect
+    ~finally:(fun () ->
+      Exec_tap.disable ();
+      try cleanup_path workdir with _ -> ())
+    (fun () ->
+       Sys.remove workdir;
+       Unix.mkdir workdir 0o755;
+       let captured = ref [] in
+       Exec_tap.enable ~writer:(fun line -> captured := line :: !captured);
+       let tools = Worker_dev_tools.make_tools ~proc_mgr ~clock ~workdir () in
+       let tool = find_tool "shell_exec" tools in
+       match Tool.execute tool (`Assoc [ ("command", `String "pwd") ]) with
+       | Error { Agent_sdk.Types.message = e; _ } ->
+         Alcotest.fail (Printf.sprintf "shell_exec failed: %s" e)
+       | Ok { Agent_sdk.Types.content = output } ->
+         Alcotest.(check string) "pwd output" (workdir ^ "\n") output;
+         let process_line =
+           List.find_opt
+             (fun line ->
+                contains_substring
+                  line
+                  "\"kind\":\"Process_eio.run_argv_with_status\"")
+             !captured
+         in
+         (match process_line with
+          | None -> Alcotest.fail "shell_exec did not route through Exec_gate/Process_eio"
+          | Some line ->
+            Alcotest.(check bool) "cwd recorded" true (contains_substring line ("\"cwd\":\"" ^ workdir ^ "\""));
+            Alcotest.(check bool) "no cd wrapper" false (contains_substring line "cd ")))
+
 let test_shell_exec_blocked_command () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -644,6 +680,8 @@ let () =
     ];
     "shell_exec", [
       Alcotest.test_case "echo hello" `Quick test_shell_exec_echo;
+      Alcotest.test_case "uses Exec_gate cwd" `Quick
+        test_shell_exec_uses_exec_gate_cwd;
       Alcotest.test_case "blocked command" `Quick test_shell_exec_blocked_command;
       Alcotest.test_case "env wrapper blocked command" `Quick
         test_shell_exec_blocks_env_wrapped_disallowed_command;


### PR DESCRIPTION
## Summary

Follow-up to #17156. This removes the remaining direct `Eio.Process.spawn` path from `Worker_dev_tools.shell_exec` and routes worker shell execution through `Masc_exec.Exec_gate.run_argv_with_status`.

Changes:
- use Exec_gate with explicit `cwd` instead of wrapping commands as `cd <dir> && <command>`
- keep worker command validation/resource accounting in place before execution
- remove the stale `worker_dev_tools.ml` entry from `scripts/lint-spawn-bounded.allowlist`
- add a regression test that captures Exec_tap output and verifies `shell_exec` records cwd without a `cd` shell wrapper

## Validation

Passed locally:
- `opam exec -- ocamlformat --check lib/worker_dev_tools.ml test/test_worker_dev_tools.ml`
- `git diff --check origin/main...HEAD`
- `scripts/lint-spawn-bounded.sh`
- `bash scripts/lint/shell-legacy-purge-ratchet.sh`
- `scripts/check-oas-pin.sh`

Blocked / base drift:
- `scripts/dune-local.sh build test/test_worker_dev_tools.exe` was refused because a bare `dune build` process was already running outside the machine-wide wrapper guard.
- `scripts/ocaml-structure-ratchet.sh` currently fails on `origin/main`-level structure debt (`keeper_mli_missing`, `lib_dune_lines`), tracked separately by #17239 / #17219. This PR does not touch `lib/dune` or `lib/keeper`.