### PR TITLE
refactor(timeout): centralize process timeout origins

### DIFF
--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -557,7 +557,7 @@ let () = Atomic.set Coord_hooks.cache_desync_cleared_fn record_cache_desync_clea
    the small set of commands MASC actually invokes (~10-20 series). *)
 let process_timeout_metric = Prometheus.metric_process_timeout
 
-let record_process_timeout ~program ~timeout_sec ~stage =
+let record_process_timeout ~program ~timeout_sec ~origin =
   (* Bucket the raw float to keep Prometheus cardinality bounded — a
      [Printf.sprintf "%.0f"] of caller-supplied seconds would mint a
      new series per distinct value.  Five closed buckets preserve the
@@ -565,15 +565,15 @@ let record_process_timeout ~program ~timeout_sec ~stage =
      guaranteeing the label set never grows beyond
      [Timeout_bucket]'s variant arity.
 
-     [stage] is a closed 3-variant label (slot_wait | spawn | command)
+     [origin] is a closed process-origin label (slot_wait | spawn | command)
      so the total cardinality stays bounded by
-     [program × bucket × stage] (~10-20 × 5 × 3 ≈ 300 series). *)
-  Prometheus.inc_counter
-    process_timeout_metric
+     [program × bucket × origin] (~10-20 × 5 × 3 ≈ 300 series). *)
+  let stage_label = Timeout_origin.to_label origin in
+  Prometheus.inc_counter process_timeout_metric
     ~labels:
       [ "program", program
       ; ("timeout_bucket", Timeout_bucket.(to_label (of_seconds timeout_sec)))
-      ; ("stage", Process_eio.timeout_stage_to_string stage)
+      ; "stage", stage_label
       ]
     ()
 ;;

--- a/lib/coord.mli
+++ b/lib/coord.mli
@@ -75,14 +75,14 @@ val process_timeout_metric : string
 (** Canonical Prometheus metric for [Process_eio] timeouts
     ([masc_process_timeout_total]).  Labels: [program] (argv0
     basename, e.g. ["git"], ["gh"]), [timeout_bucket] (configured budget
-    bucket, e.g. ["ge_15s_lt_60s"]), [stage] (closed 3-variant from
-    {!Process_eio.timeout_stage}: [slot_wait] | [spawn] | [command]).
+    bucket, e.g. ["ge_15s_lt_60s"]), [stage] (closed process origins from
+    {!Timeout_origin}: [slot_wait] | [spawn] | [command]).
     Exposed so tests and Grafana rules can pin the name. *)
 
 val record_process_timeout :
   program:string ->
   timeout_sec:float ->
-  stage:Process_eio.timeout_stage ->
+  origin:Timeout_origin.t ->
   unit
 (** Increment {!process_timeout_metric}.  Wired to
     {!Process_eio.process_timeout_observer_fn} at module load so every

--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -23,28 +23,10 @@ type runtime = {
     after [init] has published the runtime on the main domain. *)
 let runtime_state : runtime option Atomic.t = Atomic.make None
 
-(** Stage at which an [Eio.Time.with_timeout_exn] budget was exhausted.
+(** Origin at which an [Eio.Time.with_timeout_exn] budget was exhausted.
 
-    [Slot_wait] is reserved for callers that wrap [run_argv*] with their
-    own slot/semaphore wait and want to attribute a timeout to slot
-    contention rather than to the subprocess itself; the [Process_eio]
-    layer never emits it directly because [with_timeout_exn] starts the
-    clock after slot acquisition.
-
-    [Spawn] fires if the timeout trips before the Eio process spawn call
-    or [Unix.create_process_env] returns — i.e. the
-    process creation syscall itself stalled (docker daemon backpressure,
-    container cold start during [docker run]).
-
-    [Command] fires once the child has been created and we are draining
-    pipes or awaiting exit — this is the “normal” timeout case where the
-    subprocess itself is slow. *)
-type timeout_stage = Slot_wait | Spawn | Command
-
-let timeout_stage_to_string = function
-  | Slot_wait -> "slot_wait"
-  | Spawn -> "spawn"
-  | Command -> "command"
+    The vocabulary is centralized in [Timeout_origin].  [Process_eio] only
+    emits [Slot_wait], [Spawn], and [Command] origins. *)
 
 (** Observability hook: invoked when an Eio process call hits its
     [timeout_sec] budget.  Default no-op so the lower [masc_process]
@@ -53,21 +35,21 @@ let timeout_stage_to_string = function
 
     Cardinality: callers should pass [program = Filename.basename argv0]
     (~10-20 distinct programs fleet-wide); [timeout_sec] is the per-call
-    budget (a few discrete values: 15.0, 60.0, ...); [stage] has
-    3 closed-variant labels (slot_wait | spawn | command) — total label
-    cardinality is bounded by [program × bucket × stage]. *)
+    budget (a few discrete values: 15.0, 60.0, ...); [origin] is restricted
+    to [Timeout_origin.process_origins] — total label cardinality is bounded
+    by [program × bucket × origin]. *)
 let process_timeout_observer_fn :
-    (program:string -> timeout_sec:float -> stage:timeout_stage -> unit) Atomic.t =
-  Atomic.make (fun ~program:_ ~timeout_sec:_ ~stage:_ -> ())
+    (program:string -> timeout_sec:float -> origin:Timeout_origin.t -> unit) Atomic.t =
+  Atomic.make (fun ~program:_ ~timeout_sec:_ ~origin:_ -> ())
 
 let argv_program = function
   | [] -> "<empty>"
   | prog :: _ -> Filename.basename prog
 
-let observe_process_timeout argv ~timeout_sec ~stage =
+let observe_process_timeout argv ~timeout_sec ~origin =
   try
     (Atomic.get process_timeout_observer_fn)
-      ~program:(argv_program argv) ~timeout_sec ~stage
+      ~program:(argv_program argv) ~timeout_sec ~origin
   with exn ->
     Log.Misc.warn "[Process_eio] timeout observer failed: %s"
       (Printexc.to_string exn)
@@ -434,7 +416,7 @@ let with_unix_capture ?env ?cwd ?stdin_content ?(capture_stderr = false)
                  [create_process_env] returns (see line above where
                  [deadline] is computed), so any timeout here is always
                  attributable to the running child. *)
-              observe_process_timeout argv ~timeout_sec ~stage:Command;
+              observe_process_timeout argv ~timeout_sec ~origin:Timeout_origin.Command;
             cleanup ();
             on_success status stdout stderr)
      with
@@ -509,7 +491,7 @@ let spawn_and_drain_stdout ?phase_ref ~sw pm ~cwd ?env ?stdin_source argv stdout
   (* spawn returned — any further timeout is attributable to the
      child, not to process creation.  Callers thread [phase_ref] so the
      timeout branches can label the metric accordingly. *)
-  Option.iter (fun r -> r := Command) phase_ref;
+  Option.iter (fun r -> r := Timeout_origin.Command) phase_ref;
   Eio.Flow.close stdout_w;
   (* Drain to EOF before await — pipe close is switch-managed on cancel. *)
   (try
@@ -538,7 +520,7 @@ let spawn_and_drain_both ?phase_ref ~sw pm ~cwd ?env ?stdin_source argv stdout_b
       ~stderr:stderr_w
       argv
   in
-  Option.iter (fun r -> r := Command) phase_ref;
+  Option.iter (fun r -> r := Timeout_origin.Command) phase_ref;
   Eio.Flow.close stdout_w;
   Eio.Flow.close stderr_w;
   (try
@@ -570,7 +552,7 @@ let run_argv ?(timeout_sec = default_timeout_sec) ?env (argv : string list) : st
         | Ok pm, Ok clk, Ok cwd ->
             let buf = Buffer.create default_buffer_size in
             let label = String.concat " " (List.map Filename.quote argv) in
-            let phase_ref = ref Spawn in
+            let phase_ref = ref Timeout_origin.Spawn in
             try
               Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
                   Eio.Switch.run (fun sw ->
@@ -579,8 +561,8 @@ let run_argv ?(timeout_sec = default_timeout_sec) ?env (argv : string list) : st
             with
             | Eio.Time.Timeout ->
                 Log.Misc.warn "[Process_eio] Timeout after %.0fs (%s): %s"
-                  timeout_sec (timeout_stage_to_string !phase_ref) label;
-                observe_process_timeout argv ~timeout_sec ~stage:!phase_ref;
+                  timeout_sec (Timeout_origin.to_label !phase_ref) label;
+                observe_process_timeout argv ~timeout_sec ~origin:!phase_ref;
                 process_error_output ~label
                   ~reason:(Printf.sprintf "timeout after %.0fs" timeout_sec) ()
             | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -608,7 +590,7 @@ let run_argv_with_stdin ?(timeout_sec = default_timeout_sec) ?env ~(stdin_conten
             let buf = Buffer.create default_buffer_size in
             let label = String.concat " " (List.map Filename.quote argv) in
             let stdin_source = Eio.Flow.string_source stdin_content in
-            let phase_ref = ref Spawn in
+            let phase_ref = ref Timeout_origin.Spawn in
             try
               Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
                   Eio.Switch.run (fun sw ->
@@ -619,8 +601,8 @@ let run_argv_with_stdin ?(timeout_sec = default_timeout_sec) ?env ~(stdin_conten
             with
             | Eio.Time.Timeout ->
                 Log.Misc.warn "[Process_eio] Timeout after %.0fs (%s): %s"
-                  timeout_sec (timeout_stage_to_string !phase_ref) label;
-                observe_process_timeout argv ~timeout_sec ~stage:!phase_ref;
+                  timeout_sec (Timeout_origin.to_label !phase_ref) label;
+                observe_process_timeout argv ~timeout_sec ~origin:!phase_ref;
                 process_error_output ~label
                   ~reason:(Printf.sprintf "timeout after %.0fs" timeout_sec) ()
             | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -661,7 +643,7 @@ let run_argv_with_stdin_and_status_split
             let stderr_buf = Buffer.create default_buffer_size in
             let label = String.concat " " (List.map Filename.quote argv) in
             let stdin_source = Eio.Flow.string_source stdin_content in
-            let phase_ref = ref Spawn in
+            let phase_ref = ref Timeout_origin.Spawn in
             try
               Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
                   let unix_status =
@@ -675,8 +657,8 @@ let run_argv_with_stdin_and_status_split
             with
             | Eio.Time.Timeout ->
                 Log.Misc.warn "[Process_eio] Timeout after %.0fs (%s): %s"
-                  timeout_sec (timeout_stage_to_string !phase_ref) label;
-                observe_process_timeout argv ~timeout_sec ~stage:!phase_ref;
+                  timeout_sec (Timeout_origin.to_label !phase_ref) label;
+                observe_process_timeout argv ~timeout_sec ~origin:!phase_ref;
                 let timeout_status = Unix.WEXITED 124 in
                 let stdout = Buffer.contents stdout_buf in
                 let stderr = Buffer.contents stderr_buf in
@@ -735,7 +717,7 @@ let run_argv_with_status_split ?(timeout_sec = default_timeout_sec) ?env ?cwd
             let stdout_buf = Buffer.create default_buffer_size in
             let stderr_buf = Buffer.create 256 in
             let label = String.concat " " (List.map Filename.quote argv) in
-            let phase_ref = ref Spawn in
+            let phase_ref = ref Timeout_origin.Spawn in
             try
               Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
                   let unix_status =
@@ -749,8 +731,8 @@ let run_argv_with_status_split ?(timeout_sec = default_timeout_sec) ?env ?cwd
             with
             | Eio.Time.Timeout ->
                 Log.Misc.warn "[Process_eio] Timeout after %.0fs (%s): %s"
-                  timeout_sec (timeout_stage_to_string !phase_ref) label;
-                observe_process_timeout argv ~timeout_sec ~stage:!phase_ref;
+                  timeout_sec (Timeout_origin.to_label !phase_ref) label;
+                observe_process_timeout argv ~timeout_sec ~origin:!phase_ref;
                 let timeout_status = Unix.WEXITED 124 in
                 let stdout = Buffer.contents stdout_buf in
                 let stderr = Buffer.contents stderr_buf in

--- a/lib/process/process_eio.mli
+++ b/lib/process/process_eio.mli
@@ -25,35 +25,31 @@ val should_retry_unix_fallback : exn -> bool
 
 (** {1 Observability hook (#9632)} *)
 
-(** Stage at which a [run_argv*] timeout budget was exhausted.
+(** Origin at which a [run_argv*] timeout budget was exhausted.
 
-    - [Slot_wait] — reserved for callers that wrap [run_argv*] with their
+    - [Timeout_origin.Slot_wait] — reserved for callers that wrap [run_argv*] with their
       own slot/semaphore (e.g. [Docker_spawn_throttle.with_slot]) and want
       to attribute a timeout to slot contention.  Not emitted by
       [Process_eio] directly because [Eio.Time.with_timeout_exn] starts
       the clock after slot acquisition.
-    - [Spawn] — timeout fired before [Eio.Process.spawn] returned, i.e.
+    - [Timeout_origin.Spawn] — timeout fired before [Eio.Process.spawn] returned, i.e.
       process creation itself stalled (docker daemon backpressure, container
       cold start during [docker run]).
-    - [Command] — timeout fired after the child was created and while
+    - [Timeout_origin.Command] — timeout fired after the child was created and while
       draining pipes or awaiting exit; the normal “command was slow” case.
 
-    Closed sum so [lib/coord.ml] can label
-    [masc_process_timeout_total] without per-call string allocation. *)
-type timeout_stage = Slot_wait | Spawn | Command
-
-val timeout_stage_to_string : timeout_stage -> string
-(** [timeout_stage_to_string Slot_wait = "slot_wait"], etc.  Exposed so
-    log lines and Prometheus labels share one vocabulary. *)
+    The closed vocabulary lives in [Timeout_origin] so process timeouts,
+    LLM timeouts, dashboard refreshes, and health probes cannot drift into
+    separate stringly vocabularies. *)
 
 val process_timeout_observer_fn :
-  (program:string -> timeout_sec:float -> stage:timeout_stage -> unit) Atomic.t
+  (program:string -> timeout_sec:float -> origin:Timeout_origin.t -> unit) Atomic.t
 (** Hook fired from every [run_argv*] timeout branch.  Default no-op so
     [masc_process] carries no [Prometheus] dependency.  [lib/coord.ml]
     wires it at module load to emit [masc_process_timeout_total].
-    [program] is [Filename.basename argv0] (~10-20 distinct programs
-    fleet-wide); [stage] is a closed 3-variant label so the metric’s
-    total cardinality stays bounded by [program × bucket × stage]. *)
+    [program] is [Filename.basename argv0] (~10-20 distinct programs fleet-wide);
+    [origin] is one of {!Timeout_origin.process_origins}, so the metric’s
+    total cardinality stays bounded by [program × bucket × origin]. *)
 
 val argv_program : string list -> string
 (** [argv_program argv] returns [Filename.basename argv0] (or

--- a/lib/prometheus_builtin_metrics_part4.ml
+++ b/lib/prometheus_builtin_metrics_part4.ml
@@ -179,7 +179,7 @@ let register
     "Total subprocess executions that exceeded their configured timeout. Labeled by \
      program, timeout_bucket (Timeout_bucket.to_label: lt_1s | ge_1s_lt_15s | \
      ge_15s_lt_60s | ge_60s_lt_300s | ge_300s), and stage \
-     (Process_eio.timeout_stage: slot_wait | spawn | command — distinguishes \
+     (Timeout_origin process origin: slot_wait | spawn | command — distinguishes \
      timeouts spent waiting for an external slot, in process creation, or in the \
      running child)."
     `Counter;

--- a/lib/timeout_origin.ml
+++ b/lib/timeout_origin.ml
@@ -1,0 +1,47 @@
+type t =
+  | Slot_wait
+  | Spawn
+  | Command
+  | Llm_response
+  | Dashboard_refresh
+  | Health_probe
+  | Other of string
+
+let standard =
+  [ Slot_wait; Spawn; Command; Llm_response; Dashboard_refresh; Health_probe ]
+;;
+
+let process_origins = [ Slot_wait; Spawn; Command ]
+
+let is_process_origin = function
+  | Slot_wait | Spawn | Command -> true
+  | Llm_response | Dashboard_refresh | Health_probe | Other _ -> false
+;;
+
+let sanitize_other_label raw =
+  let raw = String.lowercase_ascii (String.trim raw) in
+  let max_len = 64 in
+  let len = min (String.length raw) max_len in
+  let buf = Buffer.create len in
+  for i = 0 to len - 1 do
+    match raw.[i] with
+    | 'a' .. 'z'
+    | '0' .. '9'
+    | '_' -> Buffer.add_char buf raw.[i]
+    | '-' | ' ' | ':' | '/' | '.' -> Buffer.add_char buf '_'
+    | _ -> ()
+  done;
+  match Buffer.contents buf with
+  | "" -> "other"
+  | label -> "other_" ^ label
+;;
+
+let to_label = function
+  | Slot_wait -> "slot_wait"
+  | Spawn -> "spawn"
+  | Command -> "command"
+  | Llm_response -> "llm_response"
+  | Dashboard_refresh -> "dashboard_refresh"
+  | Health_probe -> "health_probe"
+  | Other label -> sanitize_other_label label
+;;

--- a/lib/timeout_origin.mli
+++ b/lib/timeout_origin.mli
@@ -1,0 +1,22 @@
+(** Typed timeout origin labels shared by timeout telemetry emitters. *)
+
+type t =
+  | Slot_wait
+  | Spawn
+  | Command
+  | Llm_response
+  | Dashboard_refresh
+  | Health_probe
+  | Other of string
+
+val to_label : t -> string
+(** Stable wire label for metrics and JSON payloads. *)
+
+val standard : t list
+(** Bounded, first-class origins with stable labels. *)
+
+val process_origins : t list
+(** Origins emitted by [Process_eio] subprocess timeouts. *)
+
+val is_process_origin : t -> bool
+(** True for [Slot_wait], [Spawn], and [Command]. *)

--- a/test/dune
+++ b/test/dune
@@ -130,6 +130,7 @@
   test_gc_sampler
   test_process_timeout_counter
   test_timeout_floor
+  test_timeout_origin
   test_git_fetch_timeout_9587
   test_inference_utils
   test_auth_ambiguous_lookup_9786

--- a/test/test_process_eio_coverage.ml
+++ b/test/test_process_eio_coverage.ml
@@ -98,8 +98,8 @@ let with_timeout_observer f =
   let previous = Atomic.get Process_eio.process_timeout_observer_fn in
   let seen = ref [] in
   Atomic.set Process_eio.process_timeout_observer_fn
-    (fun ~program ~timeout_sec ~stage ->
-       seen := (program, timeout_sec, Process_eio.timeout_stage_to_string stage) :: !seen);
+    (fun ~program ~timeout_sec ~origin ->
+       seen := (program, timeout_sec, Timeout_origin.to_label origin) :: !seen);
   Fun.protect
     ~finally:(fun () ->
       Atomic.set Process_eio.process_timeout_observer_fn previous)

--- a/test/test_process_timeout_counter.ml
+++ b/test/test_process_timeout_counter.ml
@@ -18,13 +18,13 @@
    directly for counter mechanics, and [Process_eio.argv_program]
    for the cardinality-bounding helper. *)
 
-let counter_for ?(stage = Process_eio.Command) ~program ~timeout_sec () =
+let counter_for ?(origin = Timeout_origin.Command) ~program ~timeout_sec () =
   Masc_mcp.Prometheus.metric_value_or_zero
     Masc_mcp.Coord.process_timeout_metric
     ~labels:
       [ "program", program
       ; ("timeout_bucket", Masc_mcp.Timeout_bucket.(to_label (of_seconds timeout_sec)))
-      ; ("stage", Process_eio.timeout_stage_to_string stage)
+      ; ("stage", Timeout_origin.to_label origin)
       ]
     ()
 ;;
@@ -73,18 +73,18 @@ let test_argv_program_empty () =
 let test_record_increments () =
   let program = "test_program_9632" in
   let timeout_sec = 15.0 in
-  let stage = Process_eio.Command in
-  let before = counter_for ~program ~timeout_sec ~stage () in
-  Masc_mcp.Coord.record_process_timeout ~program ~timeout_sec ~stage;
+  let origin = Timeout_origin.Command in
+  let before = counter_for ~program ~timeout_sec ~origin () in
+  Masc_mcp.Coord.record_process_timeout ~program ~timeout_sec ~origin;
   Alcotest.(check (float 0.0001))
     "+1 on call"
     (before +. 1.0)
-    (counter_for ~program ~timeout_sec ~stage ());
-  Masc_mcp.Coord.record_process_timeout ~program ~timeout_sec ~stage;
+    (counter_for ~program ~timeout_sec ~origin ());
+  Masc_mcp.Coord.record_process_timeout ~program ~timeout_sec ~origin;
   Alcotest.(check (float 0.0001))
     "+1 again"
     (before +. 2.0)
-    (counter_for ~program ~timeout_sec ~stage ())
+    (counter_for ~program ~timeout_sec ~origin ())
 ;;
 
 let test_program_isolation () =
@@ -92,30 +92,30 @@ let test_program_isolation () =
   let timeout_sec = 60.0 in
   let prog_a = "isolation_a_9632" in
   let prog_b = "isolation_b_9632" in
-  let stage = Process_eio.Command in
-  let before_a = counter_for ~program:prog_a ~timeout_sec ~stage () in
-  Masc_mcp.Coord.record_process_timeout ~program:prog_b ~timeout_sec ~stage;
+  let origin = Timeout_origin.Command in
+  let before_a = counter_for ~program:prog_a ~timeout_sec ~origin () in
+  Masc_mcp.Coord.record_process_timeout ~program:prog_b ~timeout_sec ~origin;
   Alcotest.(check (float 0.0001))
     "program A unchanged"
     before_a
-    (counter_for ~program:prog_a ~timeout_sec ~stage ())
+    (counter_for ~program:prog_a ~timeout_sec ~origin ())
 ;;
 
 let test_timeout_sec_isolation () =
   (* Same program with two budgets must split into separate series. *)
   let program = "budget_split_9632" in
-  let stage = Process_eio.Command in
-  let before_15 = counter_for ~program ~timeout_sec:15.0 ~stage () in
-  let before_60 = counter_for ~program ~timeout_sec:60.0 ~stage () in
-  Masc_mcp.Coord.record_process_timeout ~program ~timeout_sec:15.0 ~stage;
+  let origin = Timeout_origin.Command in
+  let before_15 = counter_for ~program ~timeout_sec:15.0 ~origin () in
+  let before_60 = counter_for ~program ~timeout_sec:60.0 ~origin () in
+  Masc_mcp.Coord.record_process_timeout ~program ~timeout_sec:15.0 ~origin;
   Alcotest.(check (float 0.0001))
     "15s budget +1"
     (before_15 +. 1.0)
-    (counter_for ~program ~timeout_sec:15.0 ~stage ());
+    (counter_for ~program ~timeout_sec:15.0 ~origin ());
   Alcotest.(check (float 0.0001))
     "60s budget unchanged"
     before_60
-    (counter_for ~program ~timeout_sec:60.0 ~stage ())
+    (counter_for ~program ~timeout_sec:60.0 ~origin ())
 ;;
 
 let test_stage_isolation () =
@@ -123,34 +123,34 @@ let test_stage_isolation () =
   let program = "stage_split_9632" in
   let timeout_sec = 15.0 in
   let before_cmd =
-    counter_for ~program ~timeout_sec ~stage:Process_eio.Command ()
+    counter_for ~program ~timeout_sec ~origin:Timeout_origin.Command ()
   in
   let before_spawn =
-    counter_for ~program ~timeout_sec ~stage:Process_eio.Spawn ()
+    counter_for ~program ~timeout_sec ~origin:Timeout_origin.Spawn ()
   in
   Masc_mcp.Coord.record_process_timeout
     ~program
     ~timeout_sec
-    ~stage:Process_eio.Spawn;
+    ~origin:Timeout_origin.Spawn;
   Alcotest.(check (float 0.0001))
     "spawn stage +1"
     (before_spawn +. 1.0)
-    (counter_for ~program ~timeout_sec ~stage:Process_eio.Spawn ());
+    (counter_for ~program ~timeout_sec ~origin:Timeout_origin.Spawn ());
   Alcotest.(check (float 0.0001))
     "command stage unchanged"
     before_cmd
-    (counter_for ~program ~timeout_sec ~stage:Process_eio.Command ())
+    (counter_for ~program ~timeout_sec ~origin:Timeout_origin.Command ())
 ;;
 
 let test_stage_label_vocabulary () =
   (* Pin the wire-format label strings so a future rename surfaces here
      and not as a silent dashboard regression. *)
   Alcotest.(check string) "slot_wait label" "slot_wait"
-    (Process_eio.timeout_stage_to_string Process_eio.Slot_wait);
+    (Timeout_origin.to_label Timeout_origin.Slot_wait);
   Alcotest.(check string) "spawn label" "spawn"
-    (Process_eio.timeout_stage_to_string Process_eio.Spawn);
+    (Timeout_origin.to_label Timeout_origin.Spawn);
   Alcotest.(check string) "command label" "command"
-    (Process_eio.timeout_stage_to_string Process_eio.Command)
+    (Timeout_origin.to_label Timeout_origin.Command)
 ;;
 
 (* Pin the boundary semantics + label vocabulary so a future refactor

--- a/test/test_timeout_origin.ml
+++ b/test/test_timeout_origin.ml
@@ -1,0 +1,59 @@
+open Masc_mcp
+
+let test_standard_labels () =
+  let cases =
+    [ Timeout_origin.Slot_wait, "slot_wait"
+    ; Timeout_origin.Spawn, "spawn"
+    ; Timeout_origin.Command, "command"
+    ; Timeout_origin.Llm_response, "llm_response"
+    ; Timeout_origin.Dashboard_refresh, "dashboard_refresh"
+    ; Timeout_origin.Health_probe, "health_probe"
+    ; Timeout_origin.Other "Provider/Read Timeout", "other_provider_read_timeout"
+    ]
+  in
+  List.iter
+    (fun (origin, expected) ->
+      Alcotest.(check string) expected expected (Timeout_origin.to_label origin))
+    cases
+;;
+
+let test_process_origin_subset () =
+  Alcotest.(check bool)
+    "slot wait is process"
+    true
+    (Timeout_origin.is_process_origin Timeout_origin.Slot_wait);
+  Alcotest.(check bool)
+    "spawn is process"
+    true
+    (Timeout_origin.is_process_origin Timeout_origin.Spawn);
+  Alcotest.(check bool)
+    "command is process"
+    true
+    (Timeout_origin.is_process_origin Timeout_origin.Command);
+  Alcotest.(check bool)
+    "llm is not process"
+    false
+    (Timeout_origin.is_process_origin Timeout_origin.Llm_response)
+;;
+
+let test_other_label_sanitization () =
+  Alcotest.(check string)
+    "empty other stays bounded"
+    "other"
+    (Timeout_origin.to_label (Timeout_origin.Other " "));
+  Alcotest.(check string)
+    "punctuation removed"
+    "other_provider_timeout_1"
+    (Timeout_origin.to_label (Timeout_origin.Other "Provider Timeout #1"))
+;;
+
+let () =
+  Alcotest.run
+    "timeout_origin"
+    [ ( "typed origins"
+      , [ Alcotest.test_case "standard labels" `Quick test_standard_labels
+        ; Alcotest.test_case "process subset" `Quick test_process_origin_subset
+        ; Alcotest.test_case "other sanitization" `Quick test_other_label_sanitization
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- add a typed Timeout_origin module for shared timeout-origin labels
- remove Process_eio's local timeout_stage type/string converter and wire subprocess timeout metrics through Timeout_origin.t
- update process timeout metric tests and add Timeout_origin label/subset coverage

## Verification
- ocamlformat --check lib/timeout_origin.ml lib/timeout_origin.mli lib/process/process_eio.ml lib/process/process_eio.mli lib/coord.ml lib/coord.mli lib/prometheus_builtin_metrics_part4.ml test/test_timeout_origin.ml test/test_process_timeout_counter.ml test/test_process_eio_coverage.ml
- git diff --check origin/main...HEAD
- rg -n 'timeout_stage|timeout_stage_to_string|Process_eio\.(Command|Spawn|Slot_wait)|stage:Process_eio\.timeout_stage' lib test (no matches)
- ocamlc -c lib/timeout_origin.mli && ocamlc -c lib/timeout_origin.ml

Note: focused scripts/dune-local.sh build was blocked by an existing bare dune build outside the wrapper on this host; CI should run the full compile.