### PR TITLE
refactor(operator_control_snapshot): extract runtime status helpers sibling (-62 LOC)

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -91,78 +91,16 @@ let merge_json_objects left right =
 ;;
 
 let action_log_path config = Filename.concat (operator_dir config) "action_log.jsonl"
-let remote_confirm_ttl_seconds = 900.0
 let iso_of_unix = Dashboard_utils.iso_of_unix
-
-let runtime_status_from_live_signal (agent_status_json : Yojson.Safe.t) =
-  let runtime_status =
-    match Keeper_exec_status.agent_status_text agent_status_json with
-    | ("active" | "busy" | "listening" | "idle") as status -> Some status
-    | _ -> None
-  in
-  let has_live_signal =
-    Keeper_exec_status.agent_runtime_has_live_signal agent_status_json
-  in
-  let is_zombie = Safe_ops.json_bool ~default:false "is_zombie" agent_status_json in
-  match runtime_status, has_live_signal, is_zombie with
-  | Some status, true, false -> Some status
-  | _ -> None
-;;
-
-let health_state_allows_runtime_status_override (diagnostic : Yojson.Safe.t) =
-  let kh =
-    Safe_ops.json_string ~default:"offline" "health_state" diagnostic
-    |> Keeper_exec_status.keeper_health_of_string
-  in
-  match kh with
-  | Keeper_types.KH_stale | KH_degraded | KH_zombie | KH_dead -> false
-  | KH_healthy | KH_idle | KH_offline -> true
-;;
-
-let align_keeper_runtime_status
-      ~(surface_status : string)
-      ~(diagnostic : Yojson.Safe.t)
-      ~(agent_status_json : Yojson.Safe.t)
-      ~(keepalive_running : bool)
-  : string
-  =
-  if not keepalive_running
-  then surface_status
-  else (
-    let normalized_surface = String.lowercase_ascii (String.trim surface_status) in
-    let runtime_status =
-      if health_state_allows_runtime_status_override diagnostic
-      then runtime_status_from_live_signal agent_status_json
-      else None
-    in
-    match normalized_surface, runtime_status with
-    | ("inactive" | "offline"), Some status -> status
-    | _ -> surface_status)
-;;
-
-let remote_client_type_of_context (ctx : 'a context) =
-  match ctx.mcp_session_id with
-  | Some _ -> "mcp_remote"
-  | None -> "local_api"
-;;
-
-let max_turns_override_source = function
-  | Some n
-    when n >= Keeper_runtime_resolved.max_turns_per_call_min
-         && n <= Keeper_runtime_resolved.max_turns_per_call_max -> "override"
-  | Some _ -> "override_invalid"
-  | None -> "env"
-;;
-
-let operator_server_profile_json =
-  `Assoc
-    [ "name", `String "operator_remote_v1"
-    ; "transport", `String "mcp_streamable_http"
-    ; "auth", `String "bearer_token"
-    ; "confirm_ttl_seconds", `Float remote_confirm_ttl_seconds
-    ; "curated_tool_count", `Int 4
-    ]
-;;
+(* remote_confirm_ttl_seconds + runtime-status alignment helpers
+   extracted to [Operator_control_snapshot_runtime_status] (godfile decomp). *)
+let remote_confirm_ttl_seconds = Operator_control_snapshot_runtime_status.remote_confirm_ttl_seconds
+let runtime_status_from_live_signal = Operator_control_snapshot_runtime_status.runtime_status_from_live_signal
+let health_state_allows_runtime_status_override = Operator_control_snapshot_runtime_status.health_state_allows_runtime_status_override
+let align_keeper_runtime_status = Operator_control_snapshot_runtime_status.align_keeper_runtime_status
+let remote_client_type_of_context = Operator_control_snapshot_runtime_status.remote_client_type_of_context
+let max_turns_override_source = Operator_control_snapshot_runtime_status.max_turns_override_source
+let operator_server_profile_json = Operator_control_snapshot_runtime_status.operator_server_profile_json
 
 let action_log_entry_to_yojson (entry : action_log_entry) =
   `Assoc

--- a/lib/operator/operator_control_snapshot_runtime_status.ml
+++ b/lib/operator/operator_control_snapshot_runtime_status.ml
@@ -1,0 +1,79 @@
+(** Runtime-status alignment helpers for operator_control snapshot,
+    extracted from [operator_control_snapshot.ml]. Pure derivations over
+    diagnostic + agent-status JSON that decide when to override the
+    surface status with a live-signal-backed runtime status, plus small
+    context-derivation helpers. *)
+
+open Operator_pending_confirm
+
+let remote_confirm_ttl_seconds = 900.0
+
+let runtime_status_from_live_signal (agent_status_json : Yojson.Safe.t) =
+  let runtime_status =
+    match Keeper_exec_status.agent_status_text agent_status_json with
+    | ("active" | "busy" | "listening" | "idle") as status -> Some status
+    | _ -> None
+  in
+  let has_live_signal =
+    Keeper_exec_status.agent_runtime_has_live_signal agent_status_json
+  in
+  let is_zombie = Safe_ops.json_bool ~default:false "is_zombie" agent_status_json in
+  match runtime_status, has_live_signal, is_zombie with
+  | Some status, true, false -> Some status
+  | _ -> None
+;;
+
+let health_state_allows_runtime_status_override (diagnostic : Yojson.Safe.t) =
+  let kh =
+    Safe_ops.json_string ~default:"offline" "health_state" diagnostic
+    |> Keeper_exec_status.keeper_health_of_string
+  in
+  match kh with
+  | Keeper_types.KH_stale | KH_degraded | KH_zombie | KH_dead -> false
+  | KH_healthy | KH_idle | KH_offline -> true
+;;
+
+let align_keeper_runtime_status
+      ~(surface_status : string)
+      ~(diagnostic : Yojson.Safe.t)
+      ~(agent_status_json : Yojson.Safe.t)
+      ~(keepalive_running : bool)
+  : string
+  =
+  if not keepalive_running
+  then surface_status
+  else (
+    let normalized_surface = String.lowercase_ascii (String.trim surface_status) in
+    let runtime_status =
+      if health_state_allows_runtime_status_override diagnostic
+      then runtime_status_from_live_signal agent_status_json
+      else None
+    in
+    match normalized_surface, runtime_status with
+    | ("inactive" | "offline"), Some status -> status
+    | _ -> surface_status)
+;;
+
+let remote_client_type_of_context (ctx : 'a context) =
+  match ctx.mcp_session_id with
+  | Some _ -> "mcp_remote"
+  | None -> "local_api"
+;;
+
+let max_turns_override_source = function
+  | Some n
+    when n >= Keeper_runtime_resolved.max_turns_per_call_min
+         && n <= Keeper_runtime_resolved.max_turns_per_call_max -> "override"
+  | Some _ -> "override_invalid"
+  | None -> "env"
+;;
+
+let operator_server_profile_json =
+  `Assoc
+    [ "name", `String "operator_remote_v1"
+    ; "transport", `String "mcp_streamable_http"
+    ; "auth", `String "bearer_token"
+    ; "confirm_ttl_seconds", `Float remote_confirm_ttl_seconds
+    ; "curated_tool_count", `Int 4
+    ]
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane F (Operator)
- 5th sibling extracted from `operator_control_snapshot.ml` after the tool_names + tool_audit + trust clusters already shipped.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/operator/operator_control_snapshot.ml` | 1386 | 1324 | **-62** |
| `lib/operator/operator_control_snapshot_runtime_status.ml` | — | 79 | +79 |

## Moved (verbatim, no behavior change)
- `remote_confirm_ttl_seconds` — 900.0s TTL constant
- `runtime_status_from_live_signal` — agent_status_text + live_signal + zombie discriminator
- `health_state_allows_runtime_status_override` — closed-set health-state gate
- `align_keeper_runtime_status` — surface vs runtime status reconciler (returns runtime status only when surface is inactive/offline AND health gate permits)
- `remote_client_type_of_context` — mcp_remote / local_api derivation
- `max_turns_override_source` — override / override_invalid / env classifier
- `operator_server_profile_json` — operator_remote_v1 server descriptor

7 single-line aliases in parent.

## External callers preserved
Via `Operator_control` include chain (operator_control includes operator_control_action which includes operator_control_snapshot):
- `operator_control.ml:620` — `remote_confirm_ttl_seconds` (TTL arithmetic)
- `operator_control.ml:654, 682, 726, 747, 770, 811` — `remote_client_type_of_context` (6 sites)

All work unchanged through parent alias.

## Sibling deps
- `Operator_pending_confirm` (opened) — provides `'a context`
- `Keeper_exec_status` — agent_status_text, agent_runtime_has_live_signal, keeper_health_of_string
- `Safe_ops` — json_bool, json_string with defaults
- `Keeper_types` — KH_* health-state variants
- `Keeper_runtime_resolved` — max_turns_per_call_min / _max bounds

No sibling -> parent cycle.

## Local build status
- `dune build @check`: only pre-existing main breakage remains (`Timeout_floor` unbound, `Worker_runtime` dep cycle, `evidence_role`, `violation_detail`) — unrelated
- godfile lint: clean (absolute_cap=3350, new_file_cap=600)

## RFC-WAIVED
Extract-only sibling refactor with verbatim moves.

Co-Authored-By: codex <noreply@anthropic.com>
