### PR TITLE
[codex] fix(shell): avoid shell for keeper command probe

### DIFF
--- a/lib/keeper/keeper_shell_shared.ml
+++ b/lib/keeper/keeper_shell_shared.ml
@@ -387,17 +387,32 @@ let run_argv_with_status_retry_eintr ?cwd ~timeout_sec argv =
   in
   loop max_eintr_retries
 
-let shell_command_available name =
-  let probe =
-    Printf.sprintf "command -v %s >/dev/null 2>&1" (Filename.quote name)
-  in
-  match
-    run_argv_with_status_retry_eintr
-      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Shell_probe ())
-      [ "/bin/sh"; "-c"; probe ]
+let executable_file path =
+  try
+    let st = Unix.stat path in
+    st.Unix.st_kind = Unix.S_REG
+    &&
+    (Unix.access path [ Unix.X_OK ];
+     true)
   with
-  | Unix.WEXITED 0, _ -> true
-  | _ -> false
+  | Unix.Unix_error _ | Sys_error _ -> false
+
+let path_has_executable name =
+  match Sys.getenv_opt "PATH" with
+  | None -> false
+  | Some path ->
+    path
+    |> String.split_on_char ':'
+    |> List.exists (fun dir ->
+      (* Do not mirror the shell's empty-PATH current-directory fallback
+         for keeper probes; only explicit directories are trusted. *)
+      dir <> "" && executable_file (Filename.concat dir name))
+
+let shell_command_available name =
+  let name = String.trim name in
+  if name = "" then false
+  else if String.contains name '/' then executable_file name
+  else path_has_executable name
 
 (** Write playground repo state cache after successful clone/pull.
     Reads git metadata from [repo_path] and upserts into

--- a/lib/keeper/keeper_shell_shared.mli
+++ b/lib/keeper/keeper_shell_shared.mli
@@ -181,9 +181,9 @@ val run_argv_with_status_retry_eintr :
     call" output.  Other statuses are returned unchanged. *)
 
 val shell_command_available : string -> bool
-(** [command -v <name>] probe inside [/bin/sh -c], with
-    {!Env_config_exec_timeout.timeout_sec} budget for the
-    [Shell_probe] caller bucket. *)
+(** PATH executable probe for keeper shell read fallback selection.
+    This intentionally avoids [/bin/sh -c] and does not treat empty
+    PATH entries as the current directory. *)
 
 (** {1 Playground repo cache} *)
 

--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -19,12 +19,12 @@
 # lib/bounded_proc/bounded_proc.ml:17  — the canonical helper itself.
 lib/bounded_proc/bounded_proc.ml:17
 
-# lib/process/process_eio.ml:504, 535 — `spawn_and_drain_{stdout,both}`.
+# lib/process/process_eio.ml:486, 517 — `spawn_and_drain_{stdout,both}`.
 # Private functions. Every caller (run_argv*, run_argv_with_status*,
 # run_argv_with_stdin*) wraps in `Eio.Time.with_timeout_exn clk timeout_sec`
 # + `Eio.Switch.run` and the process-wide spawn guard.
-lib/process/process_eio.ml:504
-lib/process/process_eio.ml:535
+lib/process/process_eio.ml:486
+lib/process/process_eio.ml:517
 
 # lib/server/lsp_process_manager.ml:178 — LSP child process. Lifetime is
 # bound to the LSP session switch; idle eviction handled by the LSP

--- a/test/test_keeper_shell_containment.ml
+++ b/test/test_keeper_shell_containment.ml
@@ -137,6 +137,45 @@ let existing_path () =
   | Some value -> value
   | None -> "/usr/bin:/bin"
 
+let test_shell_command_available_uses_path_without_shell () =
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Exec_tap.disable ();
+      cleanup_dir dir)
+    (fun () ->
+       let tool_name = "probe;not-shell" in
+       write_executable
+         (Filename.concat dir tool_name)
+         "#!/bin/sh\nexit 0\n";
+       let captured = ref [] in
+       Exec_tap.enable ~writer:(fun line -> captured := line :: !captured);
+       with_env "PATH" dir @@ fun () ->
+       Alcotest.(check bool)
+         "probe found on PATH"
+         true
+         (Keeper_shell_shared.shell_command_available tool_name);
+       Alcotest.(check int) "no process execution" 0 (List.length !captured))
+
+let test_shell_command_available_rejects_empty_path_segment_cwd () =
+  let dir = temp_dir () in
+  let cwd = Sys.getcwd () in
+  Fun.protect
+    ~finally:(fun () ->
+      Sys.chdir cwd;
+      cleanup_dir dir)
+    (fun () ->
+       let tool_name = "cwd-only-probe" in
+       write_executable
+         (Filename.concat dir tool_name)
+         "#!/bin/sh\nexit 0\n";
+       Sys.chdir dir;
+       with_env "PATH" ":" @@ fun () ->
+       Alcotest.(check bool)
+         "empty PATH entry not cwd"
+         false
+         (Keeper_shell_shared.shell_command_available tool_name))
+
 let setup_task_with_worktree
       ~base
       ~config
@@ -565,6 +604,10 @@ let () =
     [
       ( "containment",
         [
+          Alcotest.test_case "shell command probe uses PATH without shell"
+            `Quick test_shell_command_available_uses_path_without_shell;
+          Alcotest.test_case "shell command probe skips empty PATH cwd"
+            `Quick test_shell_command_available_rejects_empty_path_segment_cwd;
           Alcotest.test_case "legacy keeper unaffected" `Quick
             test_legacy_keeper_unaffected;
           Alcotest.test_case "docker keeper blocks ls outside" `Quick


### PR DESCRIPTION
## Summary

Small follow-up shell hardening slice. `Keeper_shell_shared.shell_command_available` only needs to answer whether a command name exists on PATH, but it previously did that by constructing `command -v <name>` and executing `/bin/sh -c`.

Changes:
- replace the shell probe with direct `PATH` lookup using `Unix.stat` + `Unix.access X_OK`
- intentionally do not treat empty PATH entries as the current directory
- add regression coverage for shell punctuation in the probed command name and assert no Exec_tap process execution is recorded
- refresh the `process_eio` spawn allowlist line numbers after upstream line drift

## Validation

Passed locally:
- `opam exec -- ocamlformat --check lib/keeper/keeper_shell_shared.ml lib/keeper/keeper_shell_shared.mli test/test_keeper_shell_containment.ml`
- `git diff --check origin/main...HEAD`
- `scripts/lint-spawn-bounded.sh`
- `bash scripts/lint/shell-legacy-purge-ratchet.sh`
- `scripts/check-oas-pin.sh`

Blocked / base drift:
- `scripts/dune-local.sh build test/test_keeper_shell_containment.exe` could not acquire `/tmp/me-dune-local.lock`; other local Dune builds are still active.
- `scripts/ocaml-structure-ratchet.sh` fails on existing `lib_dune_lines` baseline drift, tracked separately by #17239 / #17219. This PR does not touch `lib/dune`.