### PR TITLE
refactor(server_routes_dashboard): extract 4 dashboard handlers sibling (-73 LOC)

### DIFF
--- a/lib/server/server_routes_http_dashboard_handlers.ml
+++ b/lib/server/server_routes_http_dashboard_handlers.ml
@@ -1,0 +1,95 @@
+(** Dashboard HTTP handler bodies, extracted from
+    [server_routes_http_routes_dashboard.ml]. Holds the four
+    request-handler bodies wired into the route table: agent broadcast,
+    link previews, task history, and rooms listing. *)
+
+module Http = Http_server_eio
+
+(* Duplicated locally to avoid sibling -> parent cycle. The parent file
+   keeps its own copy because three sites there call it; both copies
+   are identical 4-line helpers. *)
+let trimmed_query_param req key =
+  match Server_utils.query_param req key |> Option.map String.trim with
+  | Some value when value <> "" -> Some value
+  | _ -> None
+;;
+
+let handle_broadcast state agent_name reqd body_str =
+  let reply ok error_opt =
+    let fields = [ ("ok", `Bool ok) ] in
+    let fields = match error_opt with
+      | Some msg -> fields @ [ ("error", `String msg) ]
+      | None -> fields
+    in
+    Http.Response.json (Yojson.Safe.to_string (`Assoc fields)) reqd
+  in
+  try
+    let json = Yojson.Safe.from_string body_str in
+    match Yojson.Safe.Util.member "message" json with
+    | `String message ->
+        let config = state.Mcp_server.room_config in
+        let _ = Coord.broadcast config ~from_agent:agent_name ~content:message in
+        reply true None
+    | `Null -> reply false (Some "missing required field: message")
+    | _ -> reply false (Some "field 'message' must be a string")
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | Yojson.Json_error msg -> reply false (Some ("invalid JSON: " ^ msg))
+  | e -> reply false (Some (Printexc.to_string e))
+
+let handle_dashboard_link_previews state req reqd body_str =
+  let respond_error message =
+    Http.Response.json ~status:`Bad_request ~request:req
+      (Yojson.Safe.to_string
+         (`Assoc
+           [
+             ("ok", `Bool false);
+             ("error", `String message);
+           ]))
+      reqd
+  in
+  try
+    let args = Yojson.Safe.from_string body_str in
+    match
+      Server_dashboard_http_link_preview.dashboard_link_previews_http_json
+        ~state ~args
+    with
+    | Ok json ->
+        Http.Response.json ~compress:true ~request:req
+          (Yojson.Safe.to_string json) reqd
+    | Error message -> respond_error message
+  with Yojson.Json_error message ->
+    respond_error ("invalid json: " ^ message)
+
+let handle_dashboard_task_history state req reqd =
+  let task_id =
+    match Server_utils.query_param req "task_id" with
+    | Some value -> String.trim value
+    | None -> ""
+  in
+  if task_id = "" then
+    Http.Response.json ~status:`Bad_request ~request:req
+      {|{"error":"task_id is required"}|} reqd
+  else
+    let limit =
+      Server_utils.int_query_param req "limit" ~default:50
+      |> Server_utils.clamp ~min_v:1 ~max_v:200
+    in
+    let json =
+      Tool_task.task_history_events_json state.Mcp_server.room_config ~task_id ~limit
+    in
+    Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+
+let handle_dashboard_rooms state req reqd =
+  let limit =
+    Server_utils.int_query_param req "limit" ~default:50
+    |> Server_utils.clamp ~min_v:1 ~max_v:200
+  in
+  let me =
+    match trimmed_query_param req "me" with
+    | Some _ as value -> value
+    | None -> trimmed_query_param req "agent"
+  in
+  let json = Dashboard_rooms.json ~config:state.Mcp_server.room_config ?me ~limit () in
+  Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -133,85 +133,12 @@ let ensure_dashboard_dev_token = Server_routes_http_dashboard_dev_token.ensure_d
 (** Broadcast handler: parse JSON body, extract "message" string field, and
     relay via Coord.broadcast.  Error responses are encoded through Yojson so
     exception messages cannot break JSON framing via embedded quotes. *)
-let handle_broadcast state agent_name reqd body_str =
-  let reply ok error_opt =
-    let fields = [ ("ok", `Bool ok) ] in
-    let fields = match error_opt with
-      | Some msg -> fields @ [ ("error", `String msg) ]
-      | None -> fields
-    in
-    Http.Response.json (Yojson.Safe.to_string (`Assoc fields)) reqd
-  in
-  try
-    let json = Yojson.Safe.from_string body_str in
-    match Yojson.Safe.Util.member "message" json with
-    | `String message ->
-        let config = state.Mcp_server.room_config in
-        let _ = Coord.broadcast config ~from_agent:agent_name ~content:message in
-        reply true None
-    | `Null -> reply false (Some "missing required field: message")
-    | _ -> reply false (Some "field 'message' must be a string")
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | Yojson.Json_error msg -> reply false (Some ("invalid JSON: " ^ msg))
-  | e -> reply false (Some (Printexc.to_string e))
-
-let handle_dashboard_link_previews state req reqd body_str =
-  let respond_error message =
-    Http.Response.json ~status:`Bad_request ~request:req
-      (Yojson.Safe.to_string
-         (`Assoc
-           [
-             ("ok", `Bool false);
-             ("error", `String message);
-           ]))
-      reqd
-  in
-  try
-    let args = Yojson.Safe.from_string body_str in
-    match
-      Server_dashboard_http_link_preview.dashboard_link_previews_http_json
-        ~state ~args
-    with
-    | Ok json ->
-        Http.Response.json ~compress:true ~request:req
-          (Yojson.Safe.to_string json) reqd
-    | Error message -> respond_error message
-  with Yojson.Json_error message ->
-    respond_error ("invalid json: " ^ message)
-
-let handle_dashboard_task_history state req reqd =
-  let task_id =
-    match Server_utils.query_param req "task_id" with
-    | Some value -> String.trim value
-    | None -> ""
-  in
-  if task_id = "" then
-    Http.Response.json ~status:`Bad_request ~request:req
-      {|{"error":"task_id is required"}|} reqd
-  else
-    let limit =
-      Server_utils.int_query_param req "limit" ~default:50
-      |> Server_utils.clamp ~min_v:1 ~max_v:200
-    in
-    let json =
-      Tool_task.task_history_events_json state.Mcp_server.room_config ~task_id ~limit
-    in
-    Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
-
-let handle_dashboard_rooms state req reqd =
-  let limit =
-    Server_utils.int_query_param req "limit" ~default:50
-    |> Server_utils.clamp ~min_v:1 ~max_v:200
-  in
-  let me =
-    match trimmed_query_param req "me" with
-    | Some _ as value -> value
-    | None -> trimmed_query_param req "agent"
-  in
-  let json = Dashboard_rooms.json ~config:state.Mcp_server.room_config ?me ~limit () in
-  Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
-
+(* Dashboard request handlers extracted to
+   [Server_routes_http_dashboard_handlers] (godfile decomp). *)
+let handle_broadcast = Server_routes_http_dashboard_handlers.handle_broadcast
+let handle_dashboard_link_previews = Server_routes_http_dashboard_handlers.handle_dashboard_link_previews
+let handle_dashboard_task_history = Server_routes_http_dashboard_handlers.handle_dashboard_task_history
+let handle_dashboard_rooms = Server_routes_http_dashboard_handlers.handle_dashboard_rooms
 let rec add_routes ~sw ~clock router =
   router
   |> Http.Router.post "/api/v1/broadcast" (fun request reqd ->


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane C
- 2nd sibling extracted from `server_routes_http_routes_dashboard.ml` (after #17282 dev-token cluster).

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/server/server_routes_http_routes_dashboard.ml` | 1511 | 1438 | **-73** |
| `lib/server/server_routes_http_dashboard_handlers.ml` | — | 95 | +95 |

## Moved (verbatim, no behavior change)
- `handle_broadcast` — POST `/api/v1/broadcast` (parse JSON body, extract message, relay via Coord.broadcast)
- `handle_dashboard_link_previews` — POST `/api/v1/dashboard/link-previews` (compressed JSON response)
- `handle_dashboard_task_history` — GET `/api/v1/dashboard/tasks/history` (task_id required + clamped limit)
- `handle_dashboard_rooms` — GET `/api/v1/dashboard/rooms` (me/agent param + clamped limit)

4 single-line aliases in parent.

## Cycle-avoidance pattern
`trimmed_query_param` is a 4-line local helper called from 3 sites in parent
(`oas_telemetry_provider_param`, `add_routes`) AND from `handle_dashboard_rooms`.
Sibling duplicates the helper rather than reaching back into parent. Both copies are byte-identical (`Server_utils.query_param ... |> Option.map String.trim` pattern).

## Sibling deps
- `Http_server_eio` (aliased `Http`)
- `Yojson` — std
- `Coord.broadcast`
- `Mcp_server` (server_state)
- `Server_dashboard_http_link_preview.dashboard_link_previews_http_json` (already a sibling)
- `Server_utils` — query_param / int_query_param / clamp
- `Tool_task.task_history_events_json`
- `Dashboard_rooms.json`
- `Eio.Cancel`, `Printexc`

No sibling -> parent cycle.

## Local build status
- `dune build @check`: only pre-existing main breakage remains (`Timeout_origin`, `Timeout_floor`, `Worker_runtime` dep cycle, etc.) — unrelated
- godfile lint: clean (absolute_cap=3350, new_file_cap=600)

## RFC-WAIVED
Extract-only sibling refactor with documented helper duplication.

Co-Authored-By: codex <noreply@anthropic.com>
