### PR TITLE
refactor(server): centralize bootstrap fiber crash handling

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -111,6 +111,21 @@ module For_testing = struct
   let board_sse_event_params = board_sse_event_params
 end
 
+let fork_logged_fiber ~sw ~on_error run =
+  Eio.Fiber.fork ~sw (fun () ->
+    try run () with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn -> on_error exn)
+;;
+
+let log_server_fiber_crash name exn =
+  Log.Server.error "%s fiber crashed: %s" name (Printexc.to_string exn)
+;;
+
+let log_dashboard_fiber_crash name exn =
+  Log.Dashboard.error "%s fiber crashed: %s" name (Printexc.to_string exn)
+;;
+
 let filteri_with_fair_yield f xs =
   let meter = Eio_guard.create_yield_meter ~interval:1 () in
   List.filteri
@@ -217,12 +232,12 @@ let start_keeper_loops
      Subsystem_health tracks liveness at module level (no init timing dependency). *)
   let fork_subsystem name f =
     Subsystem_health.register name;
-    Eio.Fiber.fork ~sw (fun () ->
-      try f () with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn ->
+    fork_logged_fiber
+      ~sw
+      ~on_error:(fun exn ->
         Subsystem_health.mark_dead name;
         Log.Server.error "subsystem %s crashed: %s" name (Printexc.to_string exn))
+      f
   in
   let wait_for_lazy_startup () =
     (* Combines #10843 (per-task elapsed diagnostic, merged via #10854) with
@@ -387,7 +402,10 @@ let start_keeper_loops
     | None -> 200
   in
   Agent_sdk_metrics_bridge.start_sampler ~sw ~clock ~warn_threshold ();
-  Eio.Fiber.fork ~sw (fun () ->
+  fork_logged_fiber
+    ~sw
+    ~on_error:(log_dashboard_fiber_crash "keeper lifecycle listener")
+    (fun () ->
     let rec loop () =
       (try
          let events = Agent_sdk_metrics_bridge.drain keeper_lifecycle_sub in
@@ -974,10 +992,10 @@ let start_keeper_loops
 let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_state) =
   (* Metrics flush fiber: drains write queue every 500ms, batches file appends.
      Replaces the old mutex + synchronous file I/O pattern. *)
-  Eio.Fiber.fork ~sw (fun () ->
-    try Metrics_store_eio.start_flush_fiber ~clock with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | exn -> Log.Server.error "metrics_flush fiber crashed: %s" (Printexc.to_string exn));
+  fork_logged_fiber
+    ~sw
+    ~on_error:(log_server_fiber_crash "metrics_flush")
+    (fun () -> Metrics_store_eio.start_flush_fiber ~clock);
   Shutdown.register ~name:"metrics_flush" ~priority:30 Metrics_store_eio.flush_pending;
   (* RFC-0137 PR-2: host FD pressure poller. Watches sysmon's pressure state
      file at /tmp/masc-host-pressure.state every 1s; bridges WARN/CRIT into
@@ -1053,7 +1071,10 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
   (* Board_listener removed: filesystem-first principle.
      JSONL path emits SSE directly via Board_dispatch.emit_board_sse_event.
      PG path also uses Board_dispatch, making the pg_notify relay redundant. *)
-  Eio.Fiber.fork ~sw (fun () ->
+  fork_logged_fiber
+    ~sw
+    ~on_error:(log_server_fiber_crash "maintenance_cleanup")
+    (fun () ->
     let last_prune = ref (Unix.gettimeofday ()) in
     let rec loop () =
       Eio.Time.sleep clock Env_config_runtime.InternalTimers.janitor_interval_sec;
@@ -1187,7 +1208,10 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
     in
     loop ());
   (* Periodic repository sync: fetch repositories with auto_sync enabled. *)
-  Eio.Fiber.fork ~sw (fun () ->
+  fork_logged_fiber
+    ~sw
+    ~on_error:(log_server_fiber_crash "repo_sync")
+    (fun () ->
     let repo_sync_interval_sec =
       Env_config_runtime.InternalTimers.repo_sync_interval_sec
     in
@@ -1220,8 +1244,10 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
      The interval (2.0s) matches RFC-0138 §6 Q2: frontend polls /shell
      every 3s, so a 2s refresh keeps staleness bounded at 5s (2s + 3s)
      while leaving the compute path fully out of the request fiber. *)
-  Eio.Fiber.fork ~sw (fun () ->
-    try
+  fork_logged_fiber
+    ~sw
+    ~on_error:(log_server_fiber_crash "dashboard_snapshot refresh")
+    (fun () ->
       (* RFC-0138 Phase 3 Step 3: pass [~state] so refresh_loop can
          populate [namespace_truth] from the cached-refs path.
          That moves the 6 MASC_NAMESPACE_TRUTH_*_TIMEOUT_S knobs out
@@ -1229,13 +1255,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
          response (Step 4 retires the env knobs themselves). *)
       Dashboard_snapshot.refresh_loop
         ~sw ~clock ~config:state.room_config ~state
-        ~interval_sec:2.0 ()
-    with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | exn ->
-      Log.Server.error
-        "dashboard_snapshot refresh fiber crashed: %s"
-        (Printexc.to_string exn));
+        ~interval_sec:2.0 ());
   let resolved_base = state.room_config.base_path in
   let masc_dir = Coord.masc_root_dir state.room_config in
   resolved_base, masc_dir

--- a/test/dune
+++ b/test/dune
@@ -2195,6 +2195,15 @@
  (modules test_pr_i_2e_bootstrap_loops_typed)
  (libraries alcotest))
 
+; server_bootstrap_loops fork helper ratchet.
+; Pins raw Eio.Fiber.fork ownership to the cancel-safe helper instead
+; of repeating ad hoc crash wrappers at each background loop site.
+
+(test
+ (name test_server_bootstrap_loop_fork_helper)
+ (modules test_server_bootstrap_loop_fork_helper)
+ (libraries alcotest))
+
 ; RFC-0084 PR-I-3 — legacy post-hook surface removal (final).
 ; Pins 0 references to register_post_hook / run_post_hooks across
 ; all of lib/, 0 declarations of legacy entries in the mli, and

--- a/test/test_server_bootstrap_loop_fork_helper.ml
+++ b/test/test_server_bootstrap_loop_fork_helper.ml
@@ -1,0 +1,75 @@
+open Alcotest
+
+(** Source-level ratchet for server_bootstrap_loops fiber spawning.
+
+    The module used to repeat raw [Eio.Fiber.fork] + cancellation-safe
+    exception handling at each bootstrap/background loop site. The helper keeps
+    cancellation propagation and crash logging in one place while preserving
+    loop-specific iteration error handling. *)
+
+let read_file path =
+  match In_channel.with_open_text path In_channel.input_all with
+  | exception _ -> ""
+  | content -> content
+;;
+
+let count_substring ~haystack ~needle =
+  let rec loop i acc =
+    let next = String.index_from_opt haystack i needle.[0] in
+    match next with
+    | None -> acc
+    | Some j ->
+      let len = String.length needle in
+      if j + len <= String.length haystack
+         && String.sub haystack j len = needle
+      then loop (j + len) (acc + 1)
+      else loop (j + 1) acc
+  in
+  loop 0 0
+;;
+
+let test_raw_fork_is_owned_by_helper () =
+  let content = read_file "lib/server/server_bootstrap_loops.ml" in
+  check int
+    "only fork_logged_fiber owns direct Eio.Fiber.fork in server_bootstrap_loops"
+    1
+    (count_substring ~haystack:content ~needle:"Eio.Fiber.fork ~sw (fun () ->")
+;;
+
+let test_bootstrap_sites_use_logged_helper () =
+  let content = read_file "lib/server/server_bootstrap_loops.ml" in
+  check bool
+    "bootstrap/background fibers route through fork_logged_fiber"
+    true
+    (count_substring ~haystack:content ~needle:"fork_logged_fiber" >= 7)
+;;
+
+let test_crash_log_names_remain_specific () =
+  let content = read_file "lib/server/server_bootstrap_loops.ml" in
+  List.iter
+    (fun needle ->
+       check bool
+         (Printf.sprintf "keeps crash log surface: %s" needle)
+         true
+         (count_substring ~haystack:content ~needle >= 1))
+    [ "subsystem %s crashed: %s"
+    ; "metrics_flush"
+    ; "keeper lifecycle listener"
+    ; "maintenance_cleanup"
+    ; "repo_sync"
+    ; "dashboard_snapshot refresh"
+    ]
+;;
+
+let () =
+  run
+    "server_bootstrap_loops fork helper"
+    [ ( "fork-helper-ratchet"
+      , [ test_case "raw-fork-owned-by-helper" `Quick test_raw_fork_is_owned_by_helper
+        ; test_case "bootstrap-sites-use-helper" `Quick
+            test_bootstrap_sites_use_logged_helper
+        ; test_case "crash-log-names-remain-specific" `Quick
+            test_crash_log_names_remain_specific
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- add a cancel-safe fork_logged_fiber helper in server_bootstrap_loops
- route subsystem, lifecycle, metrics, cleanup, repo_sync, and dashboard snapshot fibers through the helper
- add a source ratchet test so raw Eio.Fiber.fork ownership stays centralized

## Verification
- ocamlformat --check lib/server/server_bootstrap_loops.ml test/test_server_bootstrap_loop_fork_helper.ml
- git diff --check origin/main...HEAD
- rg -c 'Eio\.Fiber\.fork ~sw \(fun \(\) ->' lib/server/server_bootstrap_loops.ml => 1
- rg -c 'fork_logged_fiber' lib/server/server_bootstrap_loops.ml => 7
- scripts/dune-local.sh build test/test_server_bootstrap_loop_fork_helper.exe blocked locally by bare dune process: dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/runtime-main-8935-20260521-0703 bin/main_eio.exe test/test_timeout_floor.exe