### PR TITLE
ci: add code-smell monotone ratchet

### DIFF
--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -173,10 +173,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Install ripgrep
+        run: sudo apt-get install -y -qq ripgrep
       - name: Run lint
         env:
           BASE: ${{ github.event.pull_request.base.ref && format('origin/{0}', github.event.pull_request.base.ref) || '' }}
         run: bash scripts/lint/godfile-size-regression.sh
+      - name: Run RFC-0151 code-smell ratchet
+        run: bash scripts/code-smell/measure.sh
 
   ignore-without-comment-new:
     name: ignore() justification (new sites)

--- a/ci/code-smell-baseline.json
+++ b/ci/code-smell-baseline.json
@@ -1,0 +1,3386 @@
+{
+  "_comment": "RFC-0151 code-smell monotone ratchet baseline. Regenerate with scripts/code-smell/measure.sh --regenerate.",
+  "_policy": "Current metric values must be <= baseline. Decreases should be committed as baseline updates.",
+  "metrics": {
+    "godfile_loc_1000plus": {
+      "baseline": 53,
+      "scope": "lib/**/*.ml excluding *_intf.ml, *_test.ml, _build; LoC >= 1000",
+      "files": [
+        {
+          "file": "lib/auth.ml",
+          "value": 1459
+        },
+        {
+          "file": "lib/board_core.ml",
+          "value": 1734
+        },
+        {
+          "file": "lib/cascade/cascade_attempt_fsm.ml",
+          "value": 1067
+        },
+        {
+          "file": "lib/cascade/cascade_error_classify.ml",
+          "value": 1002
+        },
+        {
+          "file": "lib/cascade/cascade_transport.ml",
+          "value": 1442
+        },
+        {
+          "file": "lib/config/env_config_keeper.ml",
+          "value": 1006
+        },
+        {
+          "file": "lib/coord/coord_task.ml",
+          "value": 1161
+        },
+        {
+          "file": "lib/dashboard/dashboard_http_keeper.ml",
+          "value": 1447
+        },
+        {
+          "file": "lib/dashboard/dashboard_safe_autonomy.ml",
+          "value": 1302
+        },
+        {
+          "file": "lib/exec_core.ml",
+          "value": 1035
+        },
+        {
+          "file": "lib/keeper/keeper_accountability.ml",
+          "value": 1161
+        },
+        {
+          "file": "lib/keeper/keeper_agent_run.ml",
+          "value": 2131
+        },
+        {
+          "file": "lib/keeper/keeper_approval_queue.ml",
+          "value": 1470
+        },
+        {
+          "file": "lib/keeper/keeper_context_core.ml",
+          "value": 1389
+        },
+        {
+          "file": "lib/keeper/keeper_execution_receipt.ml",
+          "value": 1305
+        },
+        {
+          "file": "lib/keeper/keeper_heartbeat_loop.ml",
+          "value": 1465
+        },
+        {
+          "file": "lib/keeper/keeper_hooks_oas.ml",
+          "value": 1052
+        },
+        {
+          "file": "lib/keeper/keeper_memory_bank.ml",
+          "value": 1204
+        },
+        {
+          "file": "lib/keeper/keeper_metrics.ml",
+          "value": 1019
+        },
+        {
+          "file": "lib/keeper/keeper_registry_types.ml",
+          "value": 1162
+        },
+        {
+          "file": "lib/keeper/keeper_registry.ml",
+          "value": 1579
+        },
+        {
+          "file": "lib/keeper/keeper_run_tools.ml",
+          "value": 1779
+        },
+        {
+          "file": "lib/keeper/keeper_runtime.ml",
+          "value": 1056
+        },
+        {
+          "file": "lib/keeper/keeper_sandbox_runtime.ml",
+          "value": 1509
+        },
+        {
+          "file": "lib/keeper/keeper_shell_docker.ml",
+          "value": 1043
+        },
+        {
+          "file": "lib/keeper/keeper_shell_ops.ml",
+          "value": 1403
+        },
+        {
+          "file": "lib/keeper/keeper_state_machine.ml",
+          "value": 1363
+        },
+        {
+          "file": "lib/keeper/keeper_status_bridge.ml",
+          "value": 1017
+        },
+        {
+          "file": "lib/keeper/keeper_supervisor.ml",
+          "value": 1535
+        },
+        {
+          "file": "lib/keeper/keeper_tool_disclosure.ml",
+          "value": 1016
+        },
+        {
+          "file": "lib/keeper/keeper_tools_oas.ml",
+          "value": 1555
+        },
+        {
+          "file": "lib/keeper/keeper_turn_cascade_budget.ml",
+          "value": 1060
+        },
+        {
+          "file": "lib/keeper/keeper_turn_driver.ml",
+          "value": 1806
+        },
+        {
+          "file": "lib/keeper/keeper_turn_slot.ml",
+          "value": 1381
+        },
+        {
+          "file": "lib/keeper/keeper_types_profile.ml",
+          "value": 1332
+        },
+        {
+          "file": "lib/keeper/keeper_unified_turn.ml",
+          "value": 1642
+        },
+        {
+          "file": "lib/keeper/keeper_world_observation.ml",
+          "value": 1047
+        },
+        {
+          "file": "lib/operator/operator_control_snapshot.ml",
+          "value": 1386
+        },
+        {
+          "file": "lib/server/server_bootstrap_loops.ml",
+          "value": 1242
+        },
+        {
+          "file": "lib/server/server_dashboard_http_core.ml",
+          "value": 1453
+        },
+        {
+          "file": "lib/server/server_dashboard_http_keeper_api.ml",
+          "value": 1349
+        },
+        {
+          "file": "lib/server/server_dashboard_http_runtime_info.ml",
+          "value": 1024
+        },
+        {
+          "file": "lib/server/server_dashboard_http.ml",
+          "value": 1341
+        },
+        {
+          "file": "lib/server/server_h2_gateway.ml",
+          "value": 1024
+        },
+        {
+          "file": "lib/server/server_routes_http_routes_dashboard.ml",
+          "value": 1511
+        },
+        {
+          "file": "lib/server/server_routes_http_routes_sidecar.ml",
+          "value": 1198
+        },
+        {
+          "file": "lib/server/server_routes_http_runtime.ml",
+          "value": 1537
+        },
+        {
+          "file": "lib/server/server_runtime_bootstrap.ml",
+          "value": 1451
+        },
+        {
+          "file": "lib/telemetry_unified.ml",
+          "value": 1204
+        },
+        {
+          "file": "lib/tool_code_write.ml",
+          "value": 1057
+        },
+        {
+          "file": "lib/tool_keeper.ml",
+          "value": 1429
+        },
+        {
+          "file": "lib/tool_task.ml",
+          "value": 1234
+        },
+        {
+          "file": "lib/worker_dev_tools.ml",
+          "value": 1334
+        }
+      ]
+    },
+    "catch_all_arms": {
+      "baseline": 3254,
+      "scope": "line-leading OCaml anonymous match arms: | _ ->",
+      "files": [
+        {
+          "file": "lib/activity_graph/activity_graph_reducer.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/activity_graph/activity_graph_types.ml",
+          "value": 10
+        },
+        {
+          "file": "lib/activity_graph/activity_graph.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/agent_economy.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/agent_identity.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/agent_registry_eio.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/agent_sdk_log_bridge.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/agent_stress.ml",
+          "value": 9
+        },
+        {
+          "file": "lib/attempt_state.ml",
+          "value": 8
+        },
+        {
+          "file": "lib/audit_log.ml",
+          "value": 10
+        },
+        {
+          "file": "lib/auth_doctor.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/auth_error_kind.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/auth_login.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/auth_nickname.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/auth_strict_mode.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/auth.ml",
+          "value": 9
+        },
+        {
+          "file": "lib/auto_recall.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/auto_responder.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/autonomous/autonomous_bridge.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/autonomous/autonomous_executor.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/autonomous/stimulus.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/autonomous/wirein_helpers.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/autoresearch_knowledge.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/autoresearch.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/autoresearch/autoresearch_git.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/autoresearch/autoresearch_metric.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/autoresearch/autoresearch_serde.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/backend/backend_types.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/backend/backend.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/board_attachment_meta.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/board_core_classify.ml",
+          "value": 8
+        },
+        {
+          "file": "lib/board_core_json.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/board_core_payload.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/board_core.ml",
+          "value": 9
+        },
+        {
+          "file": "lib/board_dispatch.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/board_moderation.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/board_sub_board_json.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/board_votes_json.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/board_votes.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/bounded_event_dedupe/bounded_event_dedupe.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/bounded.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/briefing_compactors/briefing_compactors.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/briefing_compactors/briefing_json_helpers.ml",
+          "value": 8
+        },
+        {
+          "file": "lib/build_identity.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/cache_eio.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/cascade_catalog_validator.ml",
+          "value": 9
+        },
+        {
+          "file": "lib/cascade_decl/cascade_declarative_parser.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/cascade_inference.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/cascade_ref/cascade_ref.ml",
+          "value": 16
+        },
+        {
+          "file": "lib/cascade/cascade_attempt_fsm.ml",
+          "value": 11
+        },
+        {
+          "file": "lib/cascade/cascade_attempt_liveness_config.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/cascade/cascade_attempt_liveness_observer.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/cascade/cascade_capability_profile.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/cascade/cascade_catalog_runtime_named_providers.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/cascade/cascade_catalog_runtime_resolve.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/cascade/cascade_config_loader.ml",
+          "value": 12
+        },
+        {
+          "file": "lib/cascade/cascade_config_parser.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/cascade/cascade_config_provider_binding.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/cascade/cascade_config_provider_filter.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/cascade/cascade_config_resolve.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/cascade/cascade_config_selection.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/cascade/cascade_config_strategy_resolve.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/cascade/cascade_declarative_adapter.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/cascade/cascade_declarative_hotpath.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/cascade/cascade_error_classify.ml",
+          "value": 31
+        },
+        {
+          "file": "lib/cascade/cascade_event_bridge_inference.ml",
+          "value": 9
+        },
+        {
+          "file": "lib/cascade/cascade_event_bridge.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/cascade/cascade_fsm.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/cascade/cascade_health_tracker.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/cascade/cascade_http_probe.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/cascade/cascade_legacy_runner.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/cascade/cascade_model_resolve.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/cascade/cascade_oas_runner.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/cascade/cascade_pool.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/cascade/cascade_routes.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/cascade/cascade_runner.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/cascade/cascade_runtime_candidate.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/cascade/cascade_runtime.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/cascade/cascade_saturation_signal.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/cascade/cascade_strategy.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/cascade/cascade_toml_materializer.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/cascade/cascade_transport_cli_config.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/cascade/cascade_transport_mcp_policy_helpers.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/cascade/cascade_transport.ml",
+          "value": 15
+        },
+        {
+          "file": "lib/cascade/cascade_trust_persist.ml",
+          "value": 8
+        },
+        {
+          "file": "lib/cascade/cascade_wire_overlay.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/cascade/provider_capability.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/cascade/provider_health.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/cdal_runtime_health.ml",
+          "value": 12
+        },
+        {
+          "file": "lib/cdal_runtime/autonomy_diff_guard.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/cdal_runtime/autonomy_exec.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/cdal_runtime/conformance.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/cdal_runtime/contract_runner.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/cdal_runtime/direct_evidence.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/cdal_runtime/mode_enforcer.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/cdal_runtime/proof_capture.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/cdal_runtime/runtime_evidence.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/cdal_verdict_gate.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/cdal/adversarial_eval.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/cdal/effect_evidence.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/cdal/labeling.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/chronicle_event/chronicle_event.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/chronicle_ingest.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/chronicle_memory.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/chronicle_validate.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/codex_mcp_config_doctor.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/compaction_trigger/compaction_trigger.ml",
+          "value": 9
+        },
+        {
+          "file": "lib/config_dir_resolver/config_dir_resolver.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/config_doctor.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/config/env_config_core.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/config/env_config_governance.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/config/env_config_keeper.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/config/env_config_runtime.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/config/keeper_sandbox_config.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/config/masc_network_defaults.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/config/playground_paths.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/context_compact_oas.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/context_overflow_action_tracker.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/coord_assertions.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/coord_goals.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/coord_status_rendering.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/coord/coord_broadcast.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/coord/coord_eio.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/coord/coord_resilience.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/coord/coord_state.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/coord/coord_task_classify.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/coord/coord_task_id.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/coord/coord_task_receipts.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/coord/coord_task.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/coord/coord_utils_backend_setup.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/coord/coord_utils_ops.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/coord/coord_verification_store.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/coord/coord_worktree_policy.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/coord/coord_worktree_repo_discovery.ml",
+          "value": 9
+        },
+        {
+          "file": "lib/coord/event_kind.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/coord/mention_dedup.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/coord/nickname.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/coord/playground_repo_cache.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/coordination_product_snapshot.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/coordination_product.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/core/json_util.ml",
+          "value": 10
+        },
+        {
+          "file": "lib/core/safe_ops.ml",
+          "value": 15
+        },
+        {
+          "file": "lib/core/system_error_class.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/dashboard_cascade_audit_runs.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/dashboard_cascade_helpers.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/dashboard_provider_runs.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/dashboard_tla_specs.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/dashboard_tool_host_events.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/dashboard_tool_source_freshness.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/dashboard_utils/dashboard_utils.ml",
+          "value": 11
+        },
+        {
+          "file": "lib/dashboard.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/dashboard/dashboard_branches.ml",
+          "value": 9
+        },
+        {
+          "file": "lib/dashboard/dashboard_cache.ml",
+          "value": 20
+        },
+        {
+          "file": "lib/dashboard/dashboard_execution_builders.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/dashboard/dashboard_execution_helpers.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/dashboard/dashboard_execution_sessions.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/dashboard/dashboard_execution.ml",
+          "value": 12
+        },
+        {
+          "file": "lib/dashboard/dashboard_goal_loop.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/dashboard/dashboard_goals_types_accessor.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/dashboard/dashboard_goals_types_attainment.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/dashboard/dashboard_goals_types_builder.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/dashboard/dashboard_goals_types_timeline.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/dashboard/dashboard_goals.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/dashboard/dashboard_governance_judge.ml",
+          "value": 15
+        },
+        {
+          "file": "lib/dashboard/dashboard_governance_metrics.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/dashboard/dashboard_harness_health.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/dashboard/dashboard_http_autoresearch.ml",
+          "value": 9
+        },
+        {
+          "file": "lib/dashboard/dashboard_http_helpers.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/dashboard/dashboard_http_keeper_detail.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/dashboard/dashboard_http_keeper_feeds.ml",
+          "value": 11
+        },
+        {
+          "file": "lib/dashboard/dashboard_http_keeper_metrics.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/dashboard/dashboard_http_keeper_outcomes.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/dashboard/dashboard_http_keeper_types.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/dashboard/dashboard_http_keeper.ml",
+          "value": 22
+        },
+        {
+          "file": "lib/dashboard/dashboard_http_monitoring.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/dashboard/dashboard_http_tool_quality.ml",
+          "value": 23
+        },
+        {
+          "file": "lib/dashboard/dashboard_keeper_decision_log_proof.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/dashboard/dashboard_keeper_feature_proof.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/dashboard/dashboard_keeper_git_pr_proof.ml",
+          "value": 10
+        },
+        {
+          "file": "lib/dashboard/dashboard_keeper_tool_failure_proof.ml",
+          "value": 15
+        },
+        {
+          "file": "lib/dashboard/dashboard_labels.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/dashboard/dashboard_mission_agents.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/dashboard/dashboard_mission_assembly.ml",
+          "value": 10
+        },
+        {
+          "file": "lib/dashboard/dashboard_mission_briefing.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/dashboard/dashboard_mission.ml",
+          "value": 10
+        },
+        {
+          "file": "lib/dashboard/dashboard_nav_event.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/dashboard/dashboard_oas_bridge.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/dashboard/dashboard_operator_judge.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/dashboard/dashboard_operator_nudges.ml",
+          "value": 11
+        },
+        {
+          "file": "lib/dashboard/dashboard_rooms.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/dashboard/dashboard_safe_autonomy.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/dashboard/dashboard_verification.ml",
+          "value": 11
+        },
+        {
+          "file": "lib/dashboard/dashboard_worktree_status.ml",
+          "value": 10
+        },
+        {
+          "file": "lib/dashboard/judge_json_recovery.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/dated_jsonl/dated_jsonl.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/discovery_history.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/dispatch_outcome.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/doctor_dispatch.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/drift_guard.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/eval_calibration.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/eval_gate.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/eval_harness.ml",
+          "value": 10
+        },
+        {
+          "file": "lib/exec_core.ml",
+          "value": 14
+        },
+        {
+          "file": "lib/exec/agent_id.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/exec/bash_history.ml",
+          "value": 13
+        },
+        {
+          "file": "lib/exec/bin.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/exec/command_gate/shell_command_gate.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/exec/egress_policy.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/exec/exec_dispatch.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/exec/exec_gate.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/exec/exec_semantic.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/exec/exit_code.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/exec/git_op.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/exec/output_parse.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/exec/risk_classifier.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/failure_envelope.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/fs_compat/fs_compat.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/gate_keeper_backend.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/gate/channel_gate_discord_names.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/gate/channel_gate_discord_state.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/gate/channel_gate_imessage_state.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/gate/channel_gate_metrics.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/gate/gate_protocol.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/gh_command_validation.ml",
+          "value": 9
+        },
+        {
+          "file": "lib/git_graph_snapshot.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/goal/goal_janitor.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/goal/goal_phase.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/goal/goal_store.ml",
+          "value": 11
+        },
+        {
+          "file": "lib/goal/goal_verification.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/governance_anomaly.ml",
+          "value": 15
+        },
+        {
+          "file": "lib/governance_cases_snapshot.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/governance_pipeline_risk.ml",
+          "value": 10
+        },
+        {
+          "file": "lib/governance_pipeline.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/graphql_api.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/graphql_endpoint.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/grpc/masc_grpc_service.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/heuristic_metrics_diagnostics.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/heuristic_metrics.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/http_server_eio.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/http_server_h2.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/ide/ide_annotation_types.ml",
+          "value": 13
+        },
+        {
+          "file": "lib/ide/ide_annotations.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/ide/ide_migration.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/ide/ide_paths.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/ide/ide_region_tracker.ml",
+          "value": 12
+        },
+        {
+          "file": "lib/inference_utils.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/institution_eio.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/json/json_field.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper_benchmark_canary.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/keeper_disk_pressure.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/keeper_event_queue/keeper_event_queue.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper_fd_pressure.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/keeper_livelock_state/keeper_livelock_state.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper_recording_error_state/keeper_recording_error_state.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper_skill_routing/keeper_skill_routing.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/keeper_tool_call_log_context.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper_tool_call_log_route_evidence.ml",
+          "value": 8
+        },
+        {
+          "file": "lib/keeper_tool_call_log.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/keeper/keeper_accountability.ml",
+          "value": 16
+        },
+        {
+          "file": "lib/keeper/keeper_activation_readiness.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_agent_prompt_metrics.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_agent_run_contract_helpers.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_agent_run.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/keeper/keeper_agent_tool_surface.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/keeper/keeper_alerting.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/keeper/keeper_approval_queue.ml",
+          "value": 8
+        },
+        {
+          "file": "lib/keeper/keeper_artifact_hydrator.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_behavioral_regime.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_cascade_profile.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/keeper/keeper_cascade_selector.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_checkpoint_store.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_cli_mcp_config.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_compact_audit.ml",
+          "value": 10
+        },
+        {
+          "file": "lib/keeper/keeper_composite_observer.ml",
+          "value": 8
+        },
+        {
+          "file": "lib/keeper/keeper_config.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/keeper/keeper_context_core_history.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/keeper/keeper_context_core_message_json.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/keeper/keeper_context_core.ml",
+          "value": 9
+        },
+        {
+          "file": "lib/keeper/keeper_context_tool_message_pairs.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_decision_audit.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_deliberation.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/keeper/keeper_docker_client_mock.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/keeper/keeper_docker_client_real.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/keeper/keeper_docker_read.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_docker_response.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_exec_board.ml",
+          "value": 11
+        },
+        {
+          "file": "lib/keeper/keeper_exec_context.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_exec_fs.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/keeper/keeper_exec_masc.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_exec_memory.ml",
+          "value": 10
+        },
+        {
+          "file": "lib/keeper/keeper_exec_persona.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/keeper/keeper_exec_preflight.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_exec_status_metrics.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/keeper/keeper_exec_status.ml",
+          "value": 15
+        },
+        {
+          "file": "lib/keeper/keeper_exec_task.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/keeper/keeper_exec_tools.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_exec_voice.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_execution_receipt.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/keeper/keeper_failure_circuit_breaker.ml",
+          "value": 10
+        },
+        {
+          "file": "lib/keeper/keeper_failure_policy.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/keeper/keeper_generation_lineage.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_gh_shared.ml",
+          "value": 15
+        },
+        {
+          "file": "lib/keeper/keeper_goal_repair.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_guards.ml",
+          "value": 11
+        },
+        {
+          "file": "lib/keeper/keeper_hash_algo.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_health_probe.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_heartbeat_loop_in_turn_pulse.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_heartbeat_loop_observations.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/keeper/keeper_heartbeat_loop.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_heartbeat_visibility_gate.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_hooks_oas_cost_events.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_hooks_oas_idle.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_hooks_oas_output_json.ml",
+          "value": 11
+        },
+        {
+          "file": "lib/keeper/keeper_hooks_oas_pr_metrics.ml",
+          "value": 9
+        },
+        {
+          "file": "lib/keeper/keeper_hooks_oas_response_metrics.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/keeper/keeper_hooks_oas_types.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/keeper/keeper_hooks_oas.ml",
+          "value": 16
+        },
+        {
+          "file": "lib/keeper/keeper_host_config_provider.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_id.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_identity.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/keeper/keeper_keepalive_signal.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_keepalive.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/keeper/keeper_lifecycle_hooks.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_llm_bridge.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_memory_bank.ml",
+          "value": 9
+        },
+        {
+          "file": "lib/keeper/keeper_memory_llm_summary.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_memory_policy_summary_filter.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_memory_policy.ml",
+          "value": 17
+        },
+        {
+          "file": "lib/keeper/keeper_memory_recall_exn_class.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_memory_recall.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/keeper/keeper_meta_contract.ml",
+          "value": 20
+        },
+        {
+          "file": "lib/keeper/keeper_meta_json_parse.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/keeper/keeper_meta_json_scrub.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/keeper/keeper_meta_json.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_meta_store.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/keeper/keeper_meta_tool_access.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/keeper/keeper_msg_async.ml",
+          "value": 8
+        },
+        {
+          "file": "lib/keeper/keeper_oas_checkpoint.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_passive_loop_detector.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/keeper/keeper_persona_authoring_slug.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_persona_authoring.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/keeper/keeper_post_turn.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/keeper/keeper_prompt_external.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_reaction_ledger.ml",
+          "value": 14
+        },
+        {
+          "file": "lib/keeper/keeper_registry_cascade_attempt.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_registry_entry_action_dispatch.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_registry_event_validators.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_registry_tool_usage_persistence.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/keeper/keeper_registry_types.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/keeper/keeper_registry.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/keeper/keeper_relevance_check.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_repo_readiness.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/keeper/keeper_routine_allowlist.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/keeper/keeper_run_tools_task_scope.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_run_tools_work_discovery.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/keeper/keeper_run_tools.ml",
+          "value": 8
+        },
+        {
+          "file": "lib/keeper/keeper_runtime_config.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_runtime_contract.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/keeper/keeper_runtime_manifest.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/keeper/keeper_runtime_resolved.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_runtime_trust_snapshot.ml",
+          "value": 12
+        },
+        {
+          "file": "lib/keeper/keeper_runtime_trust_timeline.ml",
+          "value": 23
+        },
+        {
+          "file": "lib/keeper/keeper_sandbox_control.ml",
+          "value": 11
+        },
+        {
+          "file": "lib/keeper/keeper_sandbox_runtime.ml",
+          "value": 8
+        },
+        {
+          "file": "lib/keeper/keeper_sandbox_session_plan.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_shell_bash_typed_input.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_shell_bash.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_shell_command_semantics.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/keeper/keeper_shell_docker_nested_runtime.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/keeper/keeper_shell_docker.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/keeper/keeper_shell_ops.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_shell_shared.ml",
+          "value": 8
+        },
+        {
+          "file": "lib/keeper/keeper_social_model.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_stale_watchdog.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/keeper/keeper_state_machine.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_status_bridge.ml",
+          "value": 11
+        },
+        {
+          "file": "lib/keeper/keeper_status_detail_observability.ml",
+          "value": 13
+        },
+        {
+          "file": "lib/keeper/keeper_status_detail.ml",
+          "value": 9
+        },
+        {
+          "file": "lib/keeper/keeper_status.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_supervisor_self_preservation.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_supervisor_startup_helpers.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_supervisor.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/keeper/keeper_task_worktree_lazy.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_telemetry_consumer.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_text_processing.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_toml_loader.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/keeper/keeper_tool_alias.ml",
+          "value": 12
+        },
+        {
+          "file": "lib/keeper/keeper_tool_bash_input.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/keeper/keeper_tool_deterministic_error.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/keeper/keeper_tool_disclosure.ml",
+          "value": 9
+        },
+        {
+          "file": "lib/keeper/keeper_tool_diversity.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_tool_emission_hook.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_tool_github_pr.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/keeper/keeper_tool_guidance.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_tool_policy_config.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_tool_policy.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/keeper/keeper_tool_pr_review.ml",
+          "value": 9
+        },
+        {
+          "file": "lib/keeper/keeper_tool_registry.ml",
+          "value": 9
+        },
+        {
+          "file": "lib/keeper/keeper_tools_oas_markers.ml",
+          "value": 9
+        },
+        {
+          "file": "lib/keeper/keeper_tools_oas.ml",
+          "value": 15
+        },
+        {
+          "file": "lib/keeper/keeper_trace_emit.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_transition_audit.ml",
+          "value": 10
+        },
+        {
+          "file": "lib/keeper/keeper_turn_cascade_budget_routing.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_turn_cascade_budget.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/keeper/keeper_turn_driver_admission.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_turn_driver_helpers.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_turn_driver_try_provider.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/keeper/keeper_turn_driver.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/keeper/keeper_turn_fsm.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_turn_lifecycle.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_turn_liveness.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_turn_sandbox_runtime.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/keeper/keeper_turn_terminal.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_turn_up_args.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/keeper/keeper_turn_up_update.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_turn.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/keeper/keeper_types_profile_oas_env.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_types_profile_persona.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_types_profile_sandbox.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_types_profile.ml",
+          "value": 13
+        },
+        {
+          "file": "lib/keeper/keeper_types_support.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_types.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_unified_metrics_broadcast.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_unified_metrics_decision.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/keeper/keeper_unified_metrics_failure.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_unified_metrics_snapshot.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_unified_metrics_support.ml",
+          "value": 9
+        },
+        {
+          "file": "lib/keeper/keeper_unified_prompt.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/keeper/keeper_unified_turn_event_bus.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/keeper/keeper_unified_turn_stay_silent.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_unified_turn_types.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_unified_turn.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_wip_admission.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_working_state.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_world_observation_board_signal.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/keeper/keeper_world_observation_inputs.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_world_observation_message_scope.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_world_observation.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/keeper/social_model/keeper_social_model_magentic_ledger_fsm.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/keeper/social_model/keeper_social_model_protocol.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/keeper/social_model/keeper_social_model_types.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/level4_config.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/llm_metric_bridge.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/local/local_runtime_pool.ml",
+          "value": 9
+        },
+        {
+          "file": "lib/local/worker_container_runners.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/local/worker_container_types.ml",
+          "value": 18
+        },
+        {
+          "file": "lib/local/worker_container.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/masc_context_injector.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/masc_http_client/masc_http_client.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/masc_http_client/pool.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/masc_log/log.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/masc_log/system_log_category.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/masc_oas_bridge.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/mcp_prompt_surface.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/mcp_sdk_adapter_masc.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/mcp_server_eio_call_tool.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/mcp_server_eio_caller_identity.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/mcp_server_eio_execute.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/mcp_server_eio_governance.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/mcp_server_eio_helpers.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/mcp_server_eio_protocol.ml",
+          "value": 15
+        },
+        {
+          "file": "lib/mcp_server_eio_resource.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/mcp_server_eio_tool_profile.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/mcp_server_eio_tool_timeout.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/mcp_server.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/mcp_session/mcp_session.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/mcp_transport_protocol/mcp_transport_protocol.ml",
+          "value": 9
+        },
+        {
+          "file": "lib/memory_hooks.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/memory_jsonl/memory_jsonl.ml",
+          "value": 10
+        },
+        {
+          "file": "lib/memory_oas_bridge_cache.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/memory_oas_bridge.ml",
+          "value": 12
+        },
+        {
+          "file": "lib/mention_inbox.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/meta_cognition_digest.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/meta_cognition_interpret.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/meta_cognition_parse.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/meta_cognition_snapshot.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/metrics_store_eio.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/model_inference_metrics_aggregate.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/model_inference_metrics_entry.ml",
+          "value": 11
+        },
+        {
+          "file": "lib/model_inference_metrics_parser.ml",
+          "value": 20
+        },
+        {
+          "file": "lib/model_inference_metrics_reader.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/multimodal/keeper_emitter.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/multimodal/multimodal_hydrator.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/multimodal/multimodal_keeper_bridge.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/multimodal/tool_emission.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/multimodal/wirein_helpers.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/multimodal/workspace_id.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/multimodal/workspace.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/notify.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/observability_redact.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/operator/operator_control_action.ml",
+          "value": 9
+        },
+        {
+          "file": "lib/operator/operator_control_context_snapshot.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/operator/operator_control_snapshot_tool_audit.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/operator/operator_control_snapshot_tool_names.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/operator/operator_control_snapshot.ml",
+          "value": 15
+        },
+        {
+          "file": "lib/operator/operator_control.ml",
+          "value": 11
+        },
+        {
+          "file": "lib/operator/operator_digest_guidance.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/operator/operator_digest_types.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/operator/operator_digest.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/operator/operator_judgment.ml",
+          "value": 8
+        },
+        {
+          "file": "lib/operator/operator_pending_confirm.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/operator/operator_review_state.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/otel/otel_config.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/otel/otel_dispatch_hook.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/otel/otel_trace_context.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/planning_eio.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/procedural_memory.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/process/bg_task.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/process/exec_tap.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/process/process_eio.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/prometheus_hotpath.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/prompt_registry/prompt_registry.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/provider_runtime_projection.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/provider_tool_support.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/rate_limit.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/relay.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/repo_manager/credential_materializer.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/repo_manager/keeper_repo_mapping.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/repo_manager/repo_store.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/repo_synthesis_benchmark.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/reputation_ledger_v2.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/resilience/audit.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/resilience/degradation.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/resilience/keeper_bridge.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/response/response.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/retrieval_projection.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/sdk_tool_contract.ml",
+          "value": 8
+        },
+        {
+          "file": "lib/server_base_path_diagnostics.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/server_startup_state.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/server/fd_accountant.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/server/host_fd_pressure_poller.ml",
+          "value": 10
+        },
+        {
+          "file": "lib/server/lsp_message_router.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/server/lsp_overlay_provider.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/server/lsp_process_manager.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/server/mcp_error_code.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/server/proactive_refresh.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/server/server_activity_http.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/server/server_auth.ml",
+          "value": 8
+        },
+        {
+          "file": "lib/server/server_bootstrap_http.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/server/server_bootstrap_loops.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/server/server_dashboard_compact_receipt_json.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/server/server_dashboard_http_cache.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/server/server_dashboard_http_core_cache.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/server/server_dashboard_http_core_entities.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/server/server_dashboard_http_core_json.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/server/server_dashboard_http_core.ml",
+          "value": 11
+        },
+        {
+          "file": "lib/server/server_dashboard_http_delete_actions.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/server/server_dashboard_http_execution_surfaces.ml",
+          "value": 17
+        },
+        {
+          "file": "lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/server/server_dashboard_http_keeper_api_trace.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/server/server_dashboard_http_keeper_api_types.ml",
+          "value": 12
+        },
+        {
+          "file": "lib/server/server_dashboard_http_keeper_api.ml",
+          "value": 13
+        },
+        {
+          "file": "lib/server/server_dashboard_http_keeper_runtime_lens_gaps.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/server/server_dashboard_http_keeper_runtime_lens_proof.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/server/server_dashboard_http_keeper_runtime_lens_summaries.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/server/server_dashboard_http_link_preview.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/server/server_dashboard_http_memory_subsystems.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/server/server_dashboard_http_namespace_truth_support.ml",
+          "value": 9
+        },
+        {
+          "file": "lib/server/server_dashboard_http_namespace_truth.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/server/server_dashboard_http_perf.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/server/server_dashboard_http_runtime_info.ml",
+          "value": 16
+        },
+        {
+          "file": "lib/server/server_dashboard_http.ml",
+          "value": 21
+        },
+        {
+          "file": "lib/server/server_dashboard_surface.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/server/server_h2_gateway_routes_extra.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/server/server_h2_gateway.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/server/server_ide_http.ml",
+          "value": 16
+        },
+        {
+          "file": "lib/server/server_ide_lsp_proxy.ml",
+          "value": 12
+        },
+        {
+          "file": "lib/server/server_mcp_actor_injection.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/server/server_mcp_transport_http_headers.ml",
+          "value": 9
+        },
+        {
+          "file": "lib/server/server_mcp_transport_http_protocol.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/server/server_mcp_transport_http_respond.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/server/server_mcp_transport_http_session.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/server/server_mcp_transport_http.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/server/server_mcp_transport_ws.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/server/server_routes_http_common.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/server/server_routes_http_dashboard_provider_logs.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/server/server_routes_http_keeper_stream.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/server/server_routes_http_pages.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/server/server_routes_http_routes_activity.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/server/server_routes_http_routes_attribution.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/server/server_routes_http_routes_cascade.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/server/server_routes_http_routes_channel_gate.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/server/server_routes_http_routes_credentials.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/server/server_routes_http_routes_dashboard.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/server/server_routes_http_routes_git_graph.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/server/server_routes_http_routes_keeper_repos.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/server/server_routes_http_routes_multimodal.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/server/server_routes_http_routes_provider_runs.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/server/server_routes_http_routes_repositories.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/server/server_routes_http_routes_sidecar.ml",
+          "value": 17
+        },
+        {
+          "file": "lib/server/server_routes_http_routes_verification.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/server/server_routes_http_routes_workspace.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/server/server_routes_http_runtime.ml",
+          "value": 19
+        },
+        {
+          "file": "lib/server/server_routes_http_sidecar_paths.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/server/server_runtime_bootstrap_legacy_migration.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/server/server_runtime_bootstrap.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/server/server_runtime_codex_mcp_sync.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/server/server_runtime_config_root_bootstrap.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/server/server_startup_takeover.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/server/server_timing.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/server/server_utils.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/server/server_webrtc_transport.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/server/session_lifecycle_event.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/session.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/shared_types/artifact_id.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/shared_types/budget.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/shared_types/confidence.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/shared_types/timestamp.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/shutdown_hooks.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/spawn.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/sse_event/sse_event.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/sse_jsonrpc_filter.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/state_product.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/streamable_http.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/subscriptions.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/supervisor.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/task_dispatch.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/task_transition_state/task_transition_state.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/telemetry_coverage_gap.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/telemetry_eio.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/telemetry_observe.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/telemetry_unified.ml",
+          "value": 23
+        },
+        {
+          "file": "lib/timeout_origin.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/tool_access_policy.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/tool_agent_timeline.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/tool_agent.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/tool_assignment_telemetry.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/tool_autoresearch_cycle.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/tool_autoresearch.ml",
+          "value": 12
+        },
+        {
+          "file": "lib/tool_board_dispatch.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/tool_board_format.ml",
+          "value": 19
+        },
+        {
+          "file": "lib/tool_board_handlers.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/tool_board_post.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/tool_bridge.ml",
+          "value": 14
+        },
+        {
+          "file": "lib/tool_call_quality_benchmark/post_verifier.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/tool_call_quality_benchmark/reward_advice_artifact.ml",
+          "value": 10
+        },
+        {
+          "file": "lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/tool_call_quality_benchmark/tool_call_quality_benchmark_scoring.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/tool_call_replay_harness.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/tool_capability.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/tool_catalog_surfaces/tool_catalog_surfaces.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/tool_catalog.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/tool_code_write_git_policy.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/tool_code_write.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/tool_code.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/tool_control.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/tool_coord.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/tool_deep_review.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/tool_help_registry.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/tool_inline_dispatch_extra.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/tool_inline_dispatch.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/tool_input_validation.ml",
+          "value": 16
+        },
+        {
+          "file": "lib/tool_keeper_persona_audit.ml",
+          "value": 14
+        },
+        {
+          "file": "lib/tool_keeper.ml",
+          "value": 10
+        },
+        {
+          "file": "lib/tool_library.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/tool_local_runtime_bench.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/tool_local_runtime_core.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/tool_local_runtime_http.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/tool_local_runtime_probe.ml",
+          "value": 11
+        },
+        {
+          "file": "lib/tool_local_runtime_status.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/tool_local_runtime_verify.ml",
+          "value": 19
+        },
+        {
+          "file": "lib/tool_local_runtime.ml",
+          "value": 17
+        },
+        {
+          "file": "lib/tool_metrics.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/tool_misc_admin.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/tool_misc_web_fetch.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/tool_misc_web_search.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/tool_misc.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/tool_name.ml",
+          "value": 7
+        },
+        {
+          "file": "lib/tool_operator.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/tool_output_validation.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/tool_plan.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/tool_prefilter.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/tool_resource_gate.ml",
+          "value": 8
+        },
+        {
+          "file": "lib/tool_run.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/tool_shard_types_core.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/tool_shard.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/tool_task_args.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/tool_task_completion_review.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/tool_task_contract_gate.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/tool_task.ml",
+          "value": 21
+        },
+        {
+          "file": "lib/tool_types/tool_result.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/tool_usage_log.ml",
+          "value": 12
+        },
+        {
+          "file": "lib/tool_worktree.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/trajectory/trajectory.ml",
+          "value": 8
+        },
+        {
+          "file": "lib/transport_metrics.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/transport_read_model.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/transport.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/tui_decode.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/types/ids.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/types/masc_error.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/types/types_core.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/verification_protocol.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/verification.ml",
+          "value": 17
+        },
+        {
+          "file": "lib/verifier_core.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/voice/voice_bridge.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/voice/voice_config.ml",
+          "value": 9
+        },
+        {
+          "file": "lib/voice/voice_runtime_overlay.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/voice/voice_session_manager.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/worker_dev_tools_mutation_classifier.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/worker_dev_tools_paths.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/worker_dev_tools.ml",
+          "value": 12
+        },
+        {
+          "file": "lib/worker_execution_backend.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/worker_execution_spec.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/worker_oas.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/worker_runtime_config.ml",
+          "value": 3
+        },
+        {
+          "file": "lib/worker_runtime_docker.ml",
+          "value": 6
+        },
+        {
+          "file": "lib/worker_runtime_helper_protocol.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/worker_tool_input.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/workflow_guide.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/worktree_live_context.ml",
+          "value": 2
+        }
+      ]
+    },
+    "contains_substring_defs": {
+      "baseline": 17,
+      "scope": "let definitions using String/Astring substring/prefix/suffix helpers",
+      "files": [
+        {
+          "file": "lib/backend/backend.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/cascade/cascade_transport.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/cdal_runtime/mode_enforcer.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/grpc/masc_grpc_server.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_alerting_path.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_sandbox_containment.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/social_model/keeper_social_model_magentic_ledger_fsm.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/masc_log/log.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/repo_manager/keeper_repo_mapping.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/server/server_routes_http_common.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/server/server_routes_http_sidecar_paths.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/tool_blob_store/tool_output.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/voice/voice_bridge.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/worker_dev_tools_mutation_classifier.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/worker_runtime_docker.ml",
+          "value": 1
+        }
+      ]
+    },
+    "ignore_no_comment": {
+      "baseline": 75,
+      "scope": "scripts/lint-ignore-without-comment.sh --target lib",
+      "files": [
+        {
+          "file": "lib/auth.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/bounded.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/cascade/provider_health.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/coord/coord_resilience.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/coord/coord_utils_backend_setup.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/dashboard/dashboard_attribution.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/dashboard/dashboard_governance_judge.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/dashboard/dashboard_mission.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/dashboard/dashboard_oas_bridge.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/dashboard/dashboard_snapshot.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/dated_jsonl/dated_jsonl.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_agent_run.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_chat_store.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_checkpoint_store.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_config.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_context_core.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_current_task_reconcile.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_docker_client_mock.ml",
+          "value": 5
+        },
+        {
+          "file": "lib/keeper/keeper_exec_board.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_exec_shared.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_fs.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_generation_lineage.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_heartbeat_snapshot.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_memory_recall.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_meta_store.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_msg_async.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_persona_authoring.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_shell_ops.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_supervisor.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_tool_pr_review.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/keeper/keeper_turn_slot.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_turn_up_create.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_types_support.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/keeper/keeper_unified_turn_event_bus.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/local/worker_container_types.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/mcp_server_eio_call_tool.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/mcp_server_eio_protocol.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/operator/operator_control_snapshot.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/otel/otel_spans.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/process/file_lock_eio.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/process/process_eio.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/server/server_activity_http.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/server/server_bootstrap_http.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/server/server_ide_lsp_proxy.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/server/server_mcp_transport_http.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/server/server_routes_http_keeper_stream.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/server/server_routes_http_routes_channel_gate.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/server/server_routes_http_routes_dashboard.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/server/server_routes_http_routes_room.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/session.ml",
+          "value": 2
+        },
+        {
+          "file": "lib/shutdown.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/tool_autoresearch_cycle.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/tool_inline_dispatch_comm.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/tool_inline_dispatch_extra.ml",
+          "value": 4
+        },
+        {
+          "file": "lib/tool_inline_dispatch.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/tool_keeper.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/tool_registry.ml",
+          "value": 1
+        },
+        {
+          "file": "lib/tool_suspend.ml",
+          "value": 1
+        }
+      ]
+    }
+  }
+}

--- a/scripts/code-smell-ratchet.sh
+++ b/scripts/code-smell-ratchet.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Backward-compatible entrypoint for the RFC-0151 code-smell ratchet.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/code-smell/measure.sh" "$@"

--- a/scripts/code-smell/measure.sh
+++ b/scripts/code-smell/measure.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# RFC-0151 code-smell monotone ratchet.
+#
+# This is a trend gate, not a cleanup codemod: each strict metric must stay at
+# or below the committed baseline in ci/code-smell-baseline.json.
+#
+# Usage:
+#   scripts/code-smell/measure.sh              # print + enforce baseline
+#   scripts/code-smell/measure.sh --print      # print current/baseline only
+#   scripts/code-smell/measure.sh --regenerate # rewrite baseline from current
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BASELINE_FILE="${REPO_ROOT}/ci/code-smell-baseline.json"
+IGNORE_LINT="${REPO_ROOT}/scripts/lint-ignore-without-comment.sh"
+
+for tool in rg python3 awk find wc; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "[code-smell-ratchet] required tool missing: $tool" >&2
+    exit 1
+  }
+done
+
+cd "$REPO_ROOT"
+
+count_godfiles() {
+  find lib -type f -name '*.ml' \
+    -not -name '*_intf.ml' \
+    -not -name '*_test.ml' \
+    -not -path '*/_build/*' 2>/dev/null \
+    | while IFS= read -r file; do
+        lines=$(wc -l < "$file")
+        if [[ "$lines" -ge 1000 ]]; then
+          printf '%s\n' "$file"
+        fi
+      done \
+    | wc -l \
+    | tr -d ' '
+}
+
+count_catch_all_arms() {
+  ( set +o pipefail
+    rg -c '^\s*\| _ -> ' --glob 'lib/**/*.ml' --glob '!lib/**/test/**' lib 2>/dev/null \
+      | awk -F: '{s+=$NF} END {print s+0}'
+  )
+}
+
+count_contains_substring_defs() {
+  ( set +o pipefail
+    rg -nP '^\s*let\s+(rec\s+)?[a-zA-Z0-9_]*\s+[^=]*=\s*.*\b(String\.(starts_with|ends_with|contains)|Astring\.(is_prefix|is_infix|is_suffix)|Astring\.String\.(is_prefix|is_infix|is_suffix))\b' \
+      --glob 'lib/**/*.ml' --glob '!lib/**/test/**' lib 2>/dev/null \
+      | wc -l \
+      | tr -d ' '
+  )
+}
+
+count_ignore_no_comment() {
+  if [[ ! -x "${IGNORE_LINT}" ]]; then
+    echo "[code-smell-ratchet] missing scripts/lint-ignore-without-comment.sh" >&2
+    exit 1
+  fi
+  bash "${IGNORE_LINT}" --target lib 2>/dev/null \
+    | wc -l \
+    | tr -d ' '
+}
+
+metric_file_breakdown() {
+  case "$1" in
+    godfile_loc_1000plus)
+      find lib -type f -name '*.ml' \
+        -not -name '*_intf.ml' \
+        -not -name '*_test.ml' \
+        -not -path '*/_build/*' 2>/dev/null \
+        | while IFS= read -r file; do
+            lines=$(wc -l < "$file")
+            if [[ "$lines" -ge 1000 ]]; then
+              printf '%s\t%s\n' "$file" "$lines"
+            fi
+          done \
+        | sort
+      ;;
+    catch_all_arms)
+      ( set +o pipefail
+        rg -n '^\s*\| _ -> ' --glob 'lib/**/*.ml' --glob '!lib/**/test/**' lib 2>/dev/null \
+          | cut -d: -f1 \
+          | sort \
+          | uniq -c \
+          | awk '{count=$1; $1=""; sub(/^ /, ""); printf "%s\t%s\n", $0, count}'
+      )
+      ;;
+    contains_substring_defs)
+      ( set +o pipefail
+        rg -nP '^\s*let\s+(rec\s+)?[a-zA-Z0-9_]*\s+[^=]*=\s*.*\b(String\.(starts_with|ends_with|contains)|Astring\.(is_prefix|is_infix|is_suffix)|Astring\.String\.(is_prefix|is_infix|is_suffix))\b' \
+          --glob 'lib/**/*.ml' --glob '!lib/**/test/**' lib 2>/dev/null \
+          | cut -d: -f1 \
+          | sort \
+          | uniq -c \
+          | awk '{count=$1; $1=""; sub(/^ /, ""); printf "%s\t%s\n", $0, count}'
+      )
+      ;;
+    ignore_no_comment)
+      bash "${IGNORE_LINT}" --target lib 2>/dev/null \
+        | cut -d: -f1 \
+        | sort \
+        | uniq -c \
+        | awk '{count=$1; $1=""; sub(/^ /, ""); printf "%s\t%s\n", $0, count}'
+      ;;
+    *) echo "unknown metric: $1" >&2; exit 1 ;;
+  esac
+}
+
+current_value() {
+  case "$1" in
+    godfile_loc_1000plus) count_godfiles ;;
+    catch_all_arms) count_catch_all_arms ;;
+    contains_substring_defs) count_contains_substring_defs ;;
+    ignore_no_comment) count_ignore_no_comment ;;
+    *) echo "unknown metric: $1" >&2; exit 1 ;;
+  esac
+}
+
+baseline_value() {
+  local name="$1"
+  if [[ ! -f "$BASELINE_FILE" ]]; then
+    echo "[code-smell-ratchet] missing baseline: $BASELINE_FILE" >&2
+    exit 1
+  fi
+  python3 - "$BASELINE_FILE" "$name" <<'PYEOF'
+import json
+import sys
+
+path, name = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    data = json.load(f)
+metric = data.get("metrics", {}).get(name)
+if metric is None:
+    raise SystemExit(f"missing metric in baseline: {name}")
+print(int(metric["baseline"]))
+PYEOF
+}
+
+metrics=(
+  godfile_loc_1000plus
+  catch_all_arms
+  contains_substring_defs
+  ignore_no_comment
+)
+
+print_counts() {
+  printf "%-30s %9s  %9s\n" "metric" "current" "baseline"
+  echo "--------------------------------------------------------"
+  local name current baseline
+  for name in "${metrics[@]}"; do
+    current=$(current_value "$name")
+    baseline=$(baseline_value "$name")
+    printf "%-30s %9d  %9d\n" "$name" "$current" "$baseline"
+  done
+}
+
+regenerate() {
+  local god catch substr ignore
+  god=$(count_godfiles)
+  catch=$(count_catch_all_arms)
+  substr=$(count_contains_substring_defs)
+  ignore=$(count_ignore_no_comment)
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  metric_file_breakdown godfile_loc_1000plus > "${tmpdir}/godfile_loc_1000plus.tsv"
+  metric_file_breakdown catch_all_arms > "${tmpdir}/catch_all_arms.tsv"
+  metric_file_breakdown contains_substring_defs > "${tmpdir}/contains_substring_defs.tsv"
+  metric_file_breakdown ignore_no_comment > "${tmpdir}/ignore_no_comment.tsv"
+  if ! python3 - "$BASELINE_FILE" "$tmpdir" "$god" "$catch" "$substr" "$ignore" <<'PYEOF'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+tmpdir = Path(sys.argv[2])
+god, catch, substr, ignore = map(int, sys.argv[3:])
+
+def files_for(metric):
+    rows = []
+    tsv = tmpdir / f"{metric}.tsv"
+    if not tsv.exists():
+        return rows
+    for line in tsv.read_text().splitlines():
+        if not line.strip():
+            continue
+        file, value = line.rsplit("\t", 1)
+        rows.append({"file": file, "value": int(value)})
+    return rows
+
+data = {
+    "_comment": "RFC-0151 code-smell monotone ratchet baseline. Regenerate with scripts/code-smell/measure.sh --regenerate.",
+    "_policy": "Current metric values must be <= baseline. Decreases should be committed as baseline updates.",
+    "metrics": {
+        "godfile_loc_1000plus": {
+            "baseline": god,
+            "scope": "lib/**/*.ml excluding *_intf.ml, *_test.ml, _build; LoC >= 1000",
+            "files": files_for("godfile_loc_1000plus"),
+        },
+        "catch_all_arms": {
+            "baseline": catch,
+            "scope": "line-leading OCaml anonymous match arms: | _ ->",
+            "files": files_for("catch_all_arms"),
+        },
+        "contains_substring_defs": {
+            "baseline": substr,
+            "scope": "let definitions using String/Astring substring/prefix/suffix helpers",
+            "files": files_for("contains_substring_defs"),
+        },
+        "ignore_no_comment": {
+            "baseline": ignore,
+            "scope": "scripts/lint-ignore-without-comment.sh --target lib",
+            "files": files_for("ignore_no_comment"),
+        },
+    },
+}
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(json.dumps(data, indent=2) + "\n")
+print(f"[code-smell-ratchet] wrote {path}")
+PYEOF
+  then
+    status=$?
+    rm -rf "$tmpdir"
+    return "$status"
+  fi
+  rm -rf "$tmpdir"
+}
+
+check() {
+  local drift=0
+  local name current baseline
+  for name in "${metrics[@]}"; do
+    current=$(current_value "$name")
+    baseline=$(baseline_value "$name")
+    if (( current > baseline )); then
+      echo "[code-smell-ratchet] DRIFT UP: ${name} current=${current} baseline=${baseline}" >&2
+      drift=1
+    fi
+  done
+  return "$drift"
+}
+
+case "${1:-}" in
+  --print)
+    print_counts
+    ;;
+  --regenerate)
+    regenerate
+    ;;
+  "")
+    print_counts
+    if check; then
+      echo
+      echo "[code-smell-ratchet] OK"
+      exit 0
+    else
+      echo
+      echo "[code-smell-ratchet] FAIL - current exceeds baseline" >&2
+      echo "  If the increase is intentional, cite RFC-0151 and commit the" >&2
+      echo "  paired baseline update with an explicit RATCHET-WAIVED note." >&2
+      exit 2
+    fi
+    ;;
+  *)
+    echo "usage: $0 [--print | --regenerate]" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add RFC-0151 code-smell monotone ratchet measurement at scripts/code-smell/measure.sh
- commit ci/code-smell-baseline.json with per-metric file breakdowns
- run the ratchet from the existing Fundamental Check Godfile size job

## Validation
- scripts/code-smell/measure.sh
- bash -n scripts/code-smell/measure.sh scripts/code-smell-ratchet.sh
- shellcheck scripts/code-smell/measure.sh scripts/code-smell-ratchet.sh
- BASE=origin/main bash scripts/lint/godfile-size-regression.sh
- bash scripts/ci/check-ignore-without-comment-diff.sh --base origin/main --head HEAD
- bash scripts/lint/yaml-syntax.sh
- git diff --check origin/main...HEAD