### PR TITLE
chore(docker): surface cleanup summary in fanout status

### DIFF
--- a/scripts/docker-playground-fd-status.sh
+++ b/scripts/docker-playground-fd-status.sh
@@ -7,6 +7,9 @@ ROOT=""
 LIMIT=20
 FD_WARN="${MASC_DOCKER_PLAYGROUND_FD_WARN:-10000}"
 WORKTREE_WARN="${MASC_DOCKER_PLAYGROUND_WORKTREE_WARN:-100}"
+CLEANUP_SUMMARY=0
+CLEANUP_DAYS=7
+AGGRESSIVE_CLEANUP_DAYS=""
 
 usage() {
   cat <<'EOF'
@@ -25,6 +28,15 @@ Options:
   --worktree-warn N
                 Warn when root contains at least N worktree entries.
                 Default: $MASC_DOCKER_PLAYGROUND_WORKTREE_WARN, then 100.
+  --cleanup-summary
+                Run cleanup dry-runs and print summary counters for root and
+                the largest keeper/repo bucket. No files are removed.
+  --cleanup-days N
+                Days threshold for cleanup dry-run commands and summaries.
+                Default: 7.
+  --aggressive-cleanup-days N
+                Also print a second, more aggressive dry-run summary. This is
+                diagnostic only; use --apply manually after review.
 EOF
 }
 
@@ -34,24 +46,49 @@ while [ $# -gt 0 ]; do
     --limit) LIMIT="${2:-}"; shift 2 ;;
     --fd-warn) FD_WARN="${2:-}"; shift 2 ;;
     --worktree-warn) WORKTREE_WARN="${2:-}"; shift 2 ;;
+    --cleanup-summary) CLEANUP_SUMMARY=1; shift ;;
+    --cleanup-days)
+      CLEANUP_SUMMARY=1
+      CLEANUP_DAYS="${2:-}"
+      if [ -z "$CLEANUP_DAYS" ]; then
+        echo "--cleanup-days requires a value" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    --aggressive-cleanup-days)
+      CLEANUP_SUMMARY=1
+      AGGRESSIVE_CLEANUP_DAYS="${2:-}"
+      if [ -z "$AGGRESSIVE_CLEANUP_DAYS" ]; then
+        echo "--aggressive-cleanup-days requires a value" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
     -h|--help|help) usage; exit 0 ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
 
-for numeric_arg in LIMIT FD_WARN WORKTREE_WARN; do
+for numeric_arg in LIMIT FD_WARN WORKTREE_WARN CLEANUP_DAYS; do
   numeric_value="${!numeric_arg}"
   if ! [[ "$numeric_value" =~ ^[0-9]+$ ]]; then
     case "$numeric_arg" in
       LIMIT) numeric_flag="limit" ;;
       FD_WARN) numeric_flag="fd-warn" ;;
       WORKTREE_WARN) numeric_flag="worktree-warn" ;;
+      CLEANUP_DAYS) numeric_flag="cleanup-days" ;;
       *) numeric_flag="$numeric_arg" ;;
     esac
     echo "--$numeric_flag must be a non-negative integer (got: $numeric_value)" >&2
     exit 2
   fi
 done
+
+if [ -n "$AGGRESSIVE_CLEANUP_DAYS" ] && ! [[ "$AGGRESSIVE_CLEANUP_DAYS" =~ ^[0-9]+$ ]]; then
+  echo "--aggressive-cleanup-days must be a non-negative integer (got: $AGGRESSIVE_CLEANUP_DAYS)" >&2
+  exit 2
+fi
 
 if [ -z "$ROOT" ]; then
   BASE="${MASC_BASE_PATH:-$(pwd)}"
@@ -132,11 +169,98 @@ emit_top_fanout_action() {
   echo "top_fanout_count=$top_fanout_count"
   echo "top_fanout_keeper=$top_fanout_keeper"
   echo "top_fanout_repo=$top_fanout_repo"
-  echo "top_fanout_cleanup_dry_run_command=scripts/cleanup-docker-playground-worktrees.sh --root $quoted_root --keeper $quoted_keeper --repo $quoted_repo --days 7"
-  echo "top_fanout_broken_dry_run_command=scripts/cleanup-docker-playground-worktrees.sh --root $quoted_root --keeper $quoted_keeper --repo $quoted_repo --days 7 --include-broken"
+  echo "top_fanout_cleanup_dry_run_command=scripts/cleanup-docker-playground-worktrees.sh --root $quoted_root --keeper $quoted_keeper --repo $quoted_repo --days $CLEANUP_DAYS"
+  echo "top_fanout_broken_dry_run_command=scripts/cleanup-docker-playground-worktrees.sh --root $quoted_root --keeper $quoted_keeper --repo $quoted_repo --days $CLEANUP_DAYS --include-broken"
 }
 
 emit_top_fanout_action
+
+cleanup_script_path() {
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  printf '%s\n' "$script_dir/cleanup-docker-playground-worktrees.sh"
+}
+
+summary_field() {
+  local summary="$1"
+  local key="$2"
+  printf '%s\n' "$summary" | sed -n "s/.* ${key}=\([0-9][0-9]*\).*/\1/p"
+}
+
+emit_cleanup_summary_fields() {
+  local prefix="$1"
+  local days="$2"
+  local summary="$3"
+  local key value
+  echo "${prefix}_days=$days"
+  for key in scanned candidates removed recent dirty active broken broken_candidates broken_removed failed; do
+    value="$(summary_field "$summary" "$key")"
+    if [ -z "$value" ]; then
+      value="0"
+    fi
+    echo "${prefix}_${key}=$value"
+  done
+}
+
+run_cleanup_summary() {
+  local prefix="$1"
+  local days="$2"
+  local keeper="${3:-}"
+  local repo="${4:-}"
+  local cleanup_script
+  local summary
+  cleanup_script="$(cleanup_script_path)"
+  if [ ! -x "$cleanup_script" ]; then
+    echo "${prefix}_unavailable=cleanup_script_missing"
+    return 0
+  fi
+  if [ -n "$keeper" ] && [ -n "$repo" ]; then
+    summary="$("$cleanup_script" --root "$ROOT" --keeper "$keeper" --repo "$repo" --days "$days" \
+      | awk '/^Summary / { line=$0 } END { print line }')"
+  else
+    summary="$("$cleanup_script" --root "$ROOT" --days "$days" \
+      | awk '/^Summary / { line=$0 } END { print line }')"
+  fi
+  if [ -z "$summary" ]; then
+    echo "${prefix}_unavailable=cleanup_summary_missing"
+    return 0
+  fi
+  emit_cleanup_summary_fields "$prefix" "$days" "$summary"
+}
+
+emit_cleanup_summaries() {
+  [ "$CLEANUP_SUMMARY" -eq 1 ] || return 0
+  echo ""
+  echo "Cleanup dry-run summary:"
+  run_cleanup_summary "cleanup_summary" "$CLEANUP_DAYS"
+  if [ -s "$fanout_tmp" ]; then
+    local top_fanout_line top_fanout_count top_fanout_keeper top_fanout_repo
+    top_fanout_line="$(sort -rn "$fanout_tmp" | head -n 1)"
+    set -- $top_fanout_line
+    top_fanout_count="${1:-0}"
+    top_fanout_keeper="${2:-}"
+    top_fanout_repo="${3:-}"
+    if [ "$top_fanout_count" -gt 0 ] && [ -n "$top_fanout_keeper" ] && [ -n "$top_fanout_repo" ]; then
+      run_cleanup_summary "top_fanout_cleanup_summary" "$CLEANUP_DAYS" \
+        "$top_fanout_keeper" "$top_fanout_repo"
+    fi
+  fi
+  if [ -n "$AGGRESSIVE_CLEANUP_DAYS" ]; then
+    run_cleanup_summary "aggressive_cleanup_summary" "$AGGRESSIVE_CLEANUP_DAYS"
+    if [ -s "$fanout_tmp" ]; then
+      local top_fanout_line top_fanout_count top_fanout_keeper top_fanout_repo
+      top_fanout_line="$(sort -rn "$fanout_tmp" | head -n 1)"
+      set -- $top_fanout_line
+      top_fanout_count="${1:-0}"
+      top_fanout_keeper="${2:-}"
+      top_fanout_repo="${3:-}"
+      if [ "$top_fanout_count" -gt 0 ] && [ -n "$top_fanout_keeper" ] && [ -n "$top_fanout_repo" ]; then
+        run_cleanup_summary "top_fanout_aggressive_cleanup_summary" \
+          "$AGGRESSIVE_CLEANUP_DAYS" "$top_fanout_keeper" "$top_fanout_repo"
+      fi
+    fi
+  fi
+}
 
 emit_hotspot_status() {
   local hotspot_status="ok"
@@ -169,6 +293,7 @@ emit_hotspot_status() {
 if ! command -v lsof >/dev/null 2>&1; then
   echo "fd_holders=unavailable (lsof not found)"
   emit_hotspot_status
+  emit_cleanup_summaries
   exit 0
 fi
 
@@ -205,7 +330,9 @@ if lsof -n -P +c 64 2>/dev/null \
   head -n "$LIMIT" "$holders_tmp"
   echo "top_holder_fd_count=$top_holder_fd_count"
   emit_hotspot_status
+  emit_cleanup_summaries
 else
   echo "fd_holders=unavailable (lsof failed)"
   emit_hotspot_status
+  emit_cleanup_summaries
 fi

--- a/test/test_docker_playground_gc_script.ml
+++ b/test/test_docker_playground_gc_script.ml
@@ -196,6 +196,42 @@ let test_status_warns_on_worktree_hotspot_when_lsof_fails () =
       (contains_substring stdout
          "top_fanout_cleanup_dry_run_command="))
 
+let test_status_cleanup_summary_surfaces_candidate_counts () =
+  with_temp_dir "docker-playground-status-cleanup-summary" (fun dir ->
+    let root = Filename.concat dir ".masc/playground/docker" in
+    let repo_dir = Filename.concat root "keeper-a/repos/masc-mcp" in
+    init_repo repo_dir;
+    mkdir_p (Filename.concat repo_dir ".worktrees");
+    let wt_path = Filename.concat repo_dir ".worktrees/stale-task" in
+    ignore
+      (run_shell_ok ~cwd:repo_dir
+         (Printf.sprintf "git worktree add -q -b stale-task %s" (quote wt_path)));
+    mark_path_old ~cwd:repo_dir wt_path;
+    let fake_bin = Filename.concat dir "bin" in
+    mkdir_p fake_bin;
+    write_executable (Filename.concat fake_bin "lsof") "#!/bin/sh\nexit 1\n";
+    let path =
+      Printf.sprintf "%s:%s" fake_bin
+        (Option.value ~default:"" (Sys.getenv_opt "PATH"))
+    in
+    let stdout, _ =
+      run_shell_ok ~env:[ "PATH", path ] ~cwd:(source_root ())
+        (Printf.sprintf
+           "%s --root %s --limit 5 --worktree-warn 1 --cleanup-summary \
+            --cleanup-days 1 --aggressive-cleanup-days 0"
+           (quote (status_script_path ()))
+           (quote root))
+    in
+    check bool "cleanup summary surfaced" true
+      (contains_substring stdout "Cleanup dry-run summary:");
+    check bool "root candidate count surfaced" true
+      (contains_substring stdout "cleanup_summary_candidates=1");
+    check bool "top fanout candidate count surfaced" true
+      (contains_substring stdout "top_fanout_cleanup_summary_candidates=1");
+    check bool "aggressive summary surfaced" true
+      (contains_substring stdout "aggressive_cleanup_summary_candidates=1");
+    check bool "dry-run does not remove worktree" true (Sys.file_exists wt_path))
+
 let test_dry_run_lists_stale_clean_worktree () =
   with_temp_dir "docker-playground-gc-dry-run" (fun dir ->
     let root = Filename.concat dir ".masc/playground/docker" in
@@ -316,6 +352,8 @@ let () =
             test_status_warns_on_fd_hotspot
         ; test_case "status warns on worktree hotspot when lsof fails" `Quick
             test_status_warns_on_worktree_hotspot_when_lsof_fails
+        ; test_case "status cleanup summary surfaces candidate counts" `Quick
+            test_status_cleanup_summary_surfaces_candidate_counts
         ; test_case "dry-run lists stale clean worktree" `Quick
             test_dry_run_lists_stale_clean_worktree
         ; test_case "recent checkout of old commit is not candidate" `Quick


### PR DESCRIPTION
## Summary
- add optional `--cleanup-summary` output to `docker-playground-fd-status.sh`
- surface conservative root/top-fanout dry-run counters and optional aggressive dry-run counters without applying cleanup
- cover the status summary path in `test_docker_playground_gc_script`

## Evidence
- `bash -n scripts/docker-playground-fd-status.sh scripts/cleanup-docker-playground-worktrees.sh`
- `ocamlformat --check test/test_docker_playground_gc_script.ml`
- `git diff --check origin/main..HEAD`
- live smoke:
  `scripts/docker-playground-fd-status.sh --root /Users/dancer/me/.masc/playground/docker --limit 3 --cleanup-summary --cleanup-days 7 --aggressive-cleanup-days 1`
  showed `top_holder_fd_count=0`, `cleanup_summary_candidates=0`, `top_fanout_cleanup_summary_candidates=0`, `aggressive_cleanup_summary_candidates=50`, and `top_fanout_aggressive_cleanup_summary_candidates=22`

## Notes
- Focused Dune build `scripts/dune-local.sh build ./test/test_docker_playground_gc_script.exe` was attempted but stopped after waiting on `/tmp/me-dune-local.lock`; PR CI is the compile/test gate.
- No cleanup was applied. The aggressive candidate counts are diagnostic only.
