### PR TITLE
feat(keeper): persist working-state sidecars

### DIFF
--- a/docs/design/keeper-runtime-truth-unification-goal.md
+++ b/docs/design/keeper-runtime-truth-unification-goal.md
@@ -18,7 +18,8 @@ Implemented in this branch:
   `pre_dispatch_blocked`, `tool_surface_selected`,
   `provider_lane_resolved`, `provider_attempt_started`,
   `provider_attempt_finished`, `context_injected`, `context_compacted`,
-  `state_snapshot_sidecar_saved`, `event_bus_correlated`,
+  `state_snapshot_sidecar_saved`, `working_state_sidecar_saved`,
+  `event_bus_correlated`,
   `memory_injected`, `memory_flushed`, `checkpoint_loaded`,
   `checkpoint_saved`, `receipt_appended`, and `turn_finished`.
 - Provider-lane manifest decisions now record requested tools, required tools,
@@ -29,9 +30,13 @@ Implemented in this branch:
 - Successful provider turns now persist structured keeper state snapshots to:
   - `<session_dir>/state-snapshots/turn-000001.json`
   - `<session_dir>/state-snapshot.latest.json`
+- Successful provider turns now persist compact keeper working-state vessels to:
+  - `<session_dir>/working-state/turn-000001.json`
+  - `<session_dir>/working-state.latest.json`
 - Context manifest rows record prompt/context/history digests. A dedicated
   `state_snapshot_sidecar_saved` row links the structured state snapshot
-  sidecars after the provider run.
+  sidecars after the provider run, and `working_state_sidecar_saved` links the
+  compact working-state vessel sidecars.
 - `Keeper_cascade_engine` now encodes the keeper cascade boundary as a typed
   value: MASC owns named-cascade provider iteration and hands OAS a
   single-provider agent run per attempt.
@@ -747,6 +752,7 @@ Suggested event kinds:
 - `context_injected`
 - `context_compacted`
 - `state_snapshot_sidecar_saved`
+- `working_state_sidecar_saved`
 - `checkpoint_loaded`
 - `checkpoint_saved`
 - `receipt_appended`

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1283,6 +1283,14 @@ let run_turn
                     let latest_state_snapshot_sidecar_path =
                       Filename.concat session.session_dir "state-snapshot.latest.json"
                     in
+                    let working_state_sidecar_path =
+                      Filename.concat
+                        (Filename.concat session.session_dir "working-state")
+                        (Printf.sprintf "turn-%06d.json" manifest_keeper_turn_id)
+                    in
+                    let latest_working_state_sidecar_path =
+                      Filename.concat session.session_dir "working-state.latest.json"
+                    in
                     let state_snapshot_ts = Masc_domain.now_iso () in
                     let state_snapshot_updated_at_unix = Time_compat.now () in
                     let working_state =
@@ -1312,6 +1320,23 @@ let run_turn
                           ( "state_snapshot",
                             Keeper_memory_policy.keeper_state_snapshot_to_json
                               state_snapshot );
+                          ( "working_state",
+                            Keeper_working_state.to_json working_state );
+                        ]
+                    in
+                    let working_state_payload =
+                      `Assoc
+                        [
+                          ("schema_version", `Int 1);
+                          ("ts", `String state_snapshot_ts);
+                          ("keeper_name", `String meta.name);
+                          ("agent_name", `String meta.agent_name);
+                          ("trace_id", `String trace_id);
+                          ("generation", `Int generation);
+                          ("keeper_turn_id", `Int manifest_keeper_turn_id);
+                          ("oas_turn_count", `Int result.turns);
+                          ("source", `String state_snapshot_source);
+                          ("active_open_loop_count", `Int active_open_loop_count);
                           ( "working_state",
                             Keeper_working_state.to_json working_state );
                         ]
@@ -1357,6 +1382,45 @@ let run_turn
                           ();
                         false
                     in
+                    let working_state_sidecar_saved =
+                      let sidecar_dir =
+                        Filename.dirname working_state_sidecar_path
+                      in
+                      (try Fs_compat.mkdir_p sidecar_dir with
+                       | exn ->
+                         Log.Keeper.warn
+                           "keeper:%s working state sidecar dir create failed: %s"
+                           meta.name
+                           (Printexc.to_string exn));
+                      match
+                        Fs_compat.save_file_atomic working_state_sidecar_path
+                          (Yojson.Safe.pretty_to_string working_state_payload)
+                      with
+                      | Ok () -> (
+                        match
+                          Fs_compat.save_file_atomic
+                            latest_working_state_sidecar_path
+                            (Yojson.Safe.pretty_to_string working_state_payload)
+                        with
+                        | Ok () -> true
+                        | Error e ->
+                          Log.Keeper.warn
+                            "keeper:%s latest working state sidecar save failed: %s"
+                            meta.name
+                            e;
+                          false)
+                      | Error e ->
+                        Log.Keeper.warn
+                          "keeper:%s working state sidecar save failed: %s"
+                          meta.name
+                          e;
+                        Prometheus.inc_counter
+                          Keeper_metrics.metric_keeper_checkpoint_failures
+                          ~labels:
+                            [ "keeper", meta.name; "site", "working_state_sidecar" ]
+                          ();
+                        false
+                    in
                     append_manifest ~site:"state_snapshot_sidecar"
                       ~keeper_turn_id:manifest_keeper_turn_id
                       ~oas_turn_count:result.turns
@@ -1382,6 +1446,31 @@ let run_turn
                               `String state_snapshot_source );
                           ])
                       Keeper_runtime_manifest.State_snapshot_sidecar_saved;
+                    append_manifest ~site:"working_state_sidecar"
+                      ~keeper_turn_id:manifest_keeper_turn_id
+                      ~oas_turn_count:result.turns
+                      ~status:
+                        (if working_state_sidecar_saved then "saved" else "error")
+                      ~decision:
+                        (`Assoc
+                          [
+                            ( "working_state_sidecar_path",
+                              `String working_state_sidecar_path );
+                            ( "latest_working_state_sidecar_path",
+                              `String latest_working_state_sidecar_path );
+                            ( "working_state_sidecar_saved",
+                              `Bool working_state_sidecar_saved );
+                            ( "active_open_loop_count",
+                              `Int active_open_loop_count );
+                            ( "working_state_prompt_digest_ids",
+                              `List
+                                (List.map
+                                   (fun id -> `String id)
+                                   working_state.prompt_digest_ids) );
+                            ( "source",
+                              `String state_snapshot_source );
+                          ])
+                      Keeper_runtime_manifest.Working_state_sidecar_saved;
                      receipt_response_text_present_ref := true;
                      let assistant_msg =
                        Agent_sdk.Types.make_message

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -12,6 +12,7 @@ type event_kind =
   | Context_injected
   | Context_compacted
   | State_snapshot_sidecar_saved
+  | Working_state_sidecar_saved
   | Event_bus_correlated
   | Memory_injected
   | Memory_flushed
@@ -65,6 +66,7 @@ let all_event_kinds =
     Context_injected;
     Context_compacted;
     State_snapshot_sidecar_saved;
+    Working_state_sidecar_saved;
     Event_bus_correlated;
     Memory_injected;
     Memory_flushed;
@@ -86,6 +88,7 @@ let event_kind_to_string = function
   | Context_injected -> "context_injected"
   | Context_compacted -> "context_compacted"
   | State_snapshot_sidecar_saved -> "state_snapshot_sidecar_saved"
+  | Working_state_sidecar_saved -> "working_state_sidecar_saved"
   | Event_bus_correlated -> "event_bus_correlated"
   | Memory_injected -> "memory_injected"
   | Memory_flushed -> "memory_flushed"
@@ -106,6 +109,7 @@ let event_kind_of_string = function
   | "context_injected" -> Some Context_injected
   | "context_compacted" -> Some Context_compacted
   | "state_snapshot_sidecar_saved" -> Some State_snapshot_sidecar_saved
+  | "working_state_sidecar_saved" -> Some Working_state_sidecar_saved
   | "event_bus_correlated" -> Some Event_bus_correlated
   | "memory_injected" -> Some Memory_injected
   | "memory_flushed" -> Some Memory_flushed

--- a/lib/keeper/keeper_runtime_manifest.mli
+++ b/lib/keeper/keeper_runtime_manifest.mli
@@ -16,6 +16,7 @@ type event_kind =
   | Context_injected
   | Context_compacted
   | State_snapshot_sidecar_saved
+  | Working_state_sidecar_saved
   | Event_bus_correlated
   | Memory_injected
   | Memory_flushed

--- a/lib/server/server_dashboard_http_keeper_api_runtime_lens.ml
+++ b/lib/server/server_dashboard_http_keeper_api_runtime_lens.ml
@@ -227,6 +227,11 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
                       (runtime_lens_event_count scan
                          Keeper_runtime_manifest.State_snapshot_sidecar_saved)
                   );
+                  ( "working_state_sidecar_saved_count",
+                    `Int
+                      (runtime_lens_event_count scan
+                         Keeper_runtime_manifest.Working_state_sidecar_saved)
+                  );
                   ( "active_open_loop_count",
                     `Int
                       (Option.value scan.active_open_loop_count ~default:0) );
@@ -274,6 +279,7 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
                   [
                     Keeper_runtime_manifest.Checkpoint_loaded;
                     Keeper_runtime_manifest.State_snapshot_sidecar_saved;
+                    Keeper_runtime_manifest.Working_state_sidecar_saved;
                     Keeper_runtime_manifest.Checkpoint_saved;
                   ]
                 ~terminal_status:

--- a/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
@@ -133,6 +133,10 @@ let update_runtime_manifest_scan scan row =
      scan.active_open_loop_count <-
        json_int_member_opt "active_open_loop_count"
          row.Keeper_runtime_manifest.decision
+   | Keeper_runtime_manifest.Working_state_sidecar_saved ->
+     scan.active_open_loop_count <-
+       json_int_member_opt "active_open_loop_count"
+         row.Keeper_runtime_manifest.decision
    | Keeper_runtime_manifest.Event_bus_correlated ->
      let decision = row.Keeper_runtime_manifest.decision in
      scan.event_bus_count <- scan.event_bus_count + 1;

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -1723,6 +1723,7 @@ let test_successful_provider_turn_links_runtime_artifacts () =
               M.Provider_attempt_finished;
               M.Checkpoint_saved;
               M.State_snapshot_sidecar_saved;
+              M.Working_state_sidecar_saved;
               M.Receipt_appended;
               M.Turn_finished;
             ];
@@ -1828,6 +1829,52 @@ let test_successful_provider_turn_links_runtime_artifacts () =
             "latest state sidecar exists"
             true
             (Sys.file_exists latest_state_path);
+          let working_row = require_manifest_event M.Working_state_sidecar_saved rows in
+          let working_path =
+            require_some "working state sidecar path"
+              (json_string_member_opt
+                 "working_state_sidecar_path"
+                 working_row.M.decision)
+          in
+          let latest_working_path =
+            require_some "latest working state sidecar path"
+              (json_string_member_opt
+                 "latest_working_state_sidecar_path"
+                 working_row.M.decision)
+          in
+          Alcotest.(check bool)
+            "working state sidecar exists"
+            true
+            (Sys.file_exists working_path);
+          Alcotest.(check string)
+            "working state sidecar uses keeper turn filename"
+            (Printf.sprintf "turn-%06d.json" keeper_turn_id)
+            (Filename.basename working_path);
+          let working_json = Yojson.Safe.from_file working_path in
+          Alcotest.(check int)
+            "working state sidecar keeper turn id"
+            keeper_turn_id
+            (json_int_member "keeper_turn_id" working_json);
+          Alcotest.(check int)
+            "working state sidecar OAS turn count"
+            result.turn_count
+            (json_int_member "oas_turn_count" working_json);
+          Alcotest.(check bool)
+            "latest working state sidecar exists"
+            true
+            (Sys.file_exists latest_working_path);
+          let working_state_json =
+            Yojson.Safe.Util.(working_json |> member "working_state")
+          in
+          Alcotest.(check string)
+            "working state vessel schema"
+            "keeper_working_state.v1"
+            (require_some "working state schema"
+               (json_string_member_opt "schema_version" working_state_json));
+          Alcotest.(check int)
+            "working state active count matches vessel"
+            (json_int_member "active_open_loop_count" working_json)
+            (json_list_length "active_loops" working_state_json);
           let status, api_json =
             Masc_mcp.Server_dashboard_http_keeper_api.keeper_runtime_trace_json
               config meta.name ~trace_id ~turn_id:keeper_turn_id ()
@@ -2246,6 +2293,7 @@ let test_wired_manifest_sites () =
           "Keeper_runtime_manifest.Context_compacted";
           "Keeper_runtime_manifest.Context_injected";
           "Keeper_runtime_manifest.State_snapshot_sidecar_saved";
+          "Keeper_runtime_manifest.Working_state_sidecar_saved";
           "Keeper_runtime_manifest.Checkpoint_loaded";
           "Keeper_runtime_manifest.Tool_surface_selected";
           "Keeper_runtime_manifest.Checkpoint_saved";
@@ -2253,6 +2301,8 @@ let test_wired_manifest_sites () =
           "Keeper_runtime_manifest.Turn_finished";
           "state-snapshots";
           "state-snapshot.latest.json";
+          "working-state";
+          "working-state.latest.json";
         ] );
       ( "lib/keeper/keeper_turn_driver.ml",
         [


### PR DESCRIPTION
## Summary

- Persist the projected keeper working-state vessel as standalone sidecars:
  `<session_dir>/working-state/turn-000001.json` and
  `<session_dir>/working-state.latest.json`.
- Add `working_state_sidecar_saved` to the runtime manifest event schema and
  surface its count in the dashboard runtime lens.
- Extend the runtime manifest integration test to assert the working-state
  sidecar paths, latest pointer, keeper/OAS turn ids, schema, and active-loop
  count.

## Product impact

This completes the durable-storage part of the keeper working-state vessel:
the compact unresolved-work state is no longer only nested in the state snapshot
payload and can be consumed independently by later resume, dashboard, or
compaction-invariant wiring.

## Evidence

- `ocamlformat --check lib/keeper/keeper_agent_run.ml lib/keeper/keeper_runtime_manifest.ml lib/keeper/keeper_runtime_manifest.mli lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml lib/server/server_dashboard_http_keeper_api_runtime_lens.ml test/test_keeper_runtime_manifest.ml`
- `git diff --check origin/main...HEAD`
- `scripts/check-pr-hygiene.sh --base origin/main --head HEAD --duplicate-policy fail`
- Blocked: `scripts/dune-local.sh build test/test_keeper_runtime_manifest.exe` exited 75 because a bare `dune build` process was already running outside `scripts/dune-local.sh`.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 3/4
provenance: direct
stages:
  - name: format
    command: ocamlformat --check touched OCaml files
    result: pass
  - name: whitespace
    command: git diff --check origin/main...HEAD
    result: pass
  - name: hygiene
    command: scripts/check-pr-hygiene.sh --base origin/main --head HEAD --duplicate-policy fail
    result: pass
  - name: focused_dune
    command: scripts/dune-local.sh build test/test_keeper_runtime_manifest.exe
    result: blocked_by_existing_bare_dune_process
```

## Review evidence

- The new sidecar is emitted from the same projected `Keeper_working_state.t`
  already embedded in the state snapshot payload.
- The existing state snapshot sidecar behavior is unchanged.
- Dashboard scan/lens handles both state-snapshot and working-state sidecar
  manifest rows for `active_open_loop_count`.

## Linked issue

N/A - follow-up from `masc-oas-uncovered-after-cycle-2026-05-20.html` H3
keeper working-state vessel slice.
