### PR TITLE
chore(server): remove OAS cascade timeout bootstrap

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -28,17 +28,6 @@ let note_storage_enforcement_fallback ~requested ~effective =
   | Some reason -> Server_startup_state.note_fallback reason
   | None -> ()
 
-let ensure_default_oas_cascade_timeout_env () =
-  match Sys.getenv_opt "OAS_CASCADE_MODEL_TIMEOUT_SEC" |> Env_config_core.trim_opt with
-  | Some _ -> ()
-  | None ->
-      let keeper_oas_timeout_s = Env_config_keeper.KeeperKeepalive.oas_timeout_sec in
-      let derived_timeout_s =
-        Float.max 30.0 (Float.min 120.0 (keeper_oas_timeout_s /. 5.0))
-      in
-      Unix.putenv "OAS_CASCADE_MODEL_TIMEOUT_SEC"
-        (Printf.sprintf "%.0f" derived_timeout_s)
-
 let config_bootstrap_mode = Config_root_bootstrap.config_bootstrap_mode
 let bootstrap_base_path_config_root = Config_root_bootstrap.bootstrap_base_path_config_root
 let startup_config_resolution = Config_root_bootstrap.startup_config_resolution
@@ -103,7 +92,6 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
      stub (request returns Error). *)
   Option.iter Eio_context.set_env env;
   force_jsonl_fallback_env ();
-  ensure_default_oas_cascade_timeout_env ();
   Process_eio.init ~cwd_default:Eio.Path.(fs / base_path) ~proc_mgr ~clock;
   Exec_tap.install_from_env ();
   Unix.putenv

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -12,7 +12,6 @@ val storage_enforcement_fallback_reason :
   requested:string -> effective:string -> string option
 val note_storage_enforcement_fallback :
   requested:string -> effective:string -> unit
-val ensure_default_oas_cascade_timeout_env : unit -> unit
 val config_bootstrap_mode : unit -> [> `Auto | `Empty | `Skip ]
 val bootstrap_base_path_config_root : base_path:string -> unit
 val startup_config_resolution : base_path:string -> Config_dir_resolver.resolution

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -587,20 +587,6 @@ let test_storage_enforcement_fallback_reason () =
     "MASC_STORAGE_TYPE=memory requested; filesystem-only bootstrap enforced as filesystem"
     (Yojson.Safe.Util.(json |> member "fallback_reason" |> to_string))
 
-let test_default_oas_cascade_timeout_tracks_keeper_timeout () =
-  with_env "OAS_CASCADE_MODEL_TIMEOUT_SEC" None @@ fun () ->
-  with_env "MASC_KEEPER_OAS_TIMEOUT_SEC" (Some "300") @@ fun () ->
-  Server_runtime_bootstrap.ensure_default_oas_cascade_timeout_env ();
-  Alcotest.(check string) "derived timeout reserves room for fallbacks" "60"
-    (Sys.getenv "OAS_CASCADE_MODEL_TIMEOUT_SEC")
-
-let test_default_oas_cascade_timeout_keeps_explicit_override () =
-  with_env "OAS_CASCADE_MODEL_TIMEOUT_SEC" (Some "45") @@ fun () ->
-  with_env "MASC_KEEPER_OAS_TIMEOUT_SEC" (Some "300") @@ fun () ->
-  Server_runtime_bootstrap.ensure_default_oas_cascade_timeout_env ();
-  Alcotest.(check string) "explicit override wins" "45"
-    (Sys.getenv "OAS_CASCADE_MODEL_TIMEOUT_SEC")
-
 let test_bootstrap_base_path_config_root_copies_shared_seed_but_not_keepers () =
   with_temp_dir "startup-config-bootstrap" (fun dir ->
       let repo = Filename.concat dir "repo" in
@@ -2933,12 +2919,6 @@ let () =
           Alcotest.test_case
             "storage enforcement fallback reason is visible"
             `Quick test_storage_enforcement_fallback_reason;
-          Alcotest.test_case
-            "default OAS cascade timeout tracks keeper timeout"
-            `Quick test_default_oas_cascade_timeout_tracks_keeper_timeout;
-          Alcotest.test_case
-            "default OAS cascade timeout keeps explicit override"
-            `Quick test_default_oas_cascade_timeout_keeps_explicit_override;
           Alcotest.test_case
             "bootstrap base-path config copies shared seed only"
             `Quick


### PR DESCRIPTION
Summary:
- Remove the server bootstrap helper that synthesized OAS_CASCADE_MODEL_TIMEOUT_SEC.
- Remove its public mli surface and the two tests that preserved the OAS-prefixed bootstrap behavior.

Evidence:
- rg OAS_CASCADE_MODEL_TIMEOUT_SEC/MASC_CASCADE_MODEL_TIMEOUT_SEC/ensure_default_oas_cascade_timeout_env across local masc-mcp + oas showed only this setter and its tests.

Validation:
- opam exec -- ocamlformat --check lib/server/server_runtime_bootstrap.ml lib/server/server_runtime_bootstrap.mli test/test_server_runtime_bootstrap.ml
- git diff --check
- rg OAS_CASCADE_MODEL_TIMEOUT_SEC/ensure_default_oas_cascade_timeout_env/oas_cascade_timeout lib test docs scripts config returned no matches
- scripts/dune-local.sh build test/test_server_runtime_bootstrap.exe was blocked by an existing bare Dune build outside scripts/dune-local.sh