### PR TITLE
[codex] fix(shell): pass pr review host cwd structurally

### DIFF
--- a/lib/keeper/keeper_tool_pr_review.ml
+++ b/lib/keeper/keeper_tool_pr_review.ml
@@ -239,15 +239,13 @@ let run_pr_review_shell ~(config : Coord.config) ~(meta : keeper_meta)
         }
   else
     let root = Keeper_alerting_path.project_root_of_config config in
-    let host_cmd =
-      Printf.sprintf "cd %s && %s" (Filename.quote root) cmd
-    in
-    let argv = [ host_zsh; "-lc"; host_cmd ] in
+    let argv = [ host_zsh; "-lc"; cmd ] in
     let status, output =
       Masc_exec.Exec_gate.run_argv_with_status
         ~actor:`Keeper_shell
-        ~raw_source:(String.concat " " argv)
+        ~raw_source:(String.concat " " (List.map Filename.quote argv))
         ~summary:"keeper tool pr review host"
+        ~cwd:root
         ~timeout_sec
         argv
     in

--- a/test/test_keeper_pr_review.ml
+++ b/test/test_keeper_pr_review.ml
@@ -241,6 +241,18 @@ let setup_docker_review f =
     Masc_mcp.Keeper_gh_env.root_github_identity;
   f ~config ~meta
 
+let setup_local_review f =
+  with_eio_fs @@ fun () ->
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
+  ensure_dir (Filename.concat base Common.masc_dirname);
+  run_ok ~cwd:base "git init -q";
+  run_ok ~cwd:base
+    "git remote add origin https://github.com/jeong-sik/masc-mcp.git";
+  let config = Coord.default_config base in
+  let meta = make_meta ~name:"reviewer" ~sandbox:Keeper_types.Local () in
+  f ~base ~config ~meta
+
 let parse_field raw field =
   Yojson.Safe.from_string raw |> Json.member field
 
@@ -321,6 +333,66 @@ let test_passes_through_unrelated_errors () =
        "HTTP 401: Unauthorized");
   check bool "empty output not flagged" false
     (KTPR.pr_not_found_in_output "")
+
+let test_local_pr_review_host_uses_exec_gate_cwd () =
+  setup_local_review @@ fun ~base ~config ~meta ->
+  let bin_dir = Filename.concat base "bin" in
+  let gh_args_log = Filename.concat base "gh-args.log" in
+  let gh_pwd_log = Filename.concat base "gh-pwd.log" in
+  ensure_dir bin_dir;
+  write_file
+    (Filename.concat bin_dir "gh")
+    "#!/bin/sh\n\
+     printf '%s\\n' \"$PWD\" >> \"$GH_PWD_LOG\"\n\
+     printf '%s\\n' \"$*\" >> \"$GH_ARGS_LOG\"\n\
+     if [ \"$1\" = \"pr\" ] && [ \"$2\" = \"view\" ]; then\n\
+     \  printf '%s\\n' \
+     '{\"title\":\"T\",\"body\":\"B\",\"state\":\"OPEN\",\"files\":[],\"reviews\":[],\"comments\":[],\"additions\":1,\"deletions\":0}'\n\
+     \  exit 0\n\
+     fi\n\
+     if [ \"$1\" = \"pr\" ] && [ \"$2\" = \"diff\" ]; then\n\
+     \  printf '%s\\n' 'diff --git a/README.md b/README.md'\n\
+     \  exit 0\n\
+     fi\n\
+     printf 'unexpected gh: %s\\n' \"$*\" >&2\n\
+     exit 2\n";
+  Unix.chmod (Filename.concat bin_dir "gh") 0o755;
+  let captured = ref [] in
+  Fun.protect
+    ~finally:(fun () -> Exec_tap.disable ())
+    (fun () ->
+       Exec_tap.enable ~writer:(fun line -> captured := line :: !captured);
+       with_env "GH_ARGS_LOG" gh_args_log @@ fun () ->
+       with_env "GH_PWD_LOG" gh_pwd_log @@ fun () ->
+       with_env "PATH" (bin_dir ^ ":" ^ Option.value ~default:"/usr/bin:/bin" (Sys.getenv_opt "PATH")) @@ fun () ->
+       let raw =
+         KTPR.handle_keeper_pr_review_read ~config ~meta
+           ~args:(`Assoc [ ("pr_number", `Int 13510) ])
+       in
+       check (option string) "read via host" (Some "host")
+         (parse_string_field raw "via");
+       check bool "fake gh ran from project root" true
+         (read_file gh_pwd_log
+          |> String.split_on_char '\n'
+          |> List.filter (fun s -> String.trim s <> "")
+          |> List.for_all (fun path ->
+            String.equal (Unix.realpath path) (Unix.realpath base)));
+       let process_lines =
+         List.filter
+           (fun line ->
+              contains_substring line
+                "\"kind\":\"Process_eio.run_argv_with_status\"")
+           !captured
+       in
+       check bool "process execution recorded" true (process_lines <> []);
+       check bool "cwd recorded" true
+         (List.exists
+            (fun line -> contains_substring line ("\"cwd\":\"" ^ base ^ "\""))
+            process_lines);
+       check bool "no cd wrapper in argv tap" false
+         (List.exists (fun line -> contains_substring line "cd ") process_lines);
+       check bool "repo flag reached gh" true
+         (contains_substring (read_file gh_args_log) "-R jeong-sik/masc-mcp"))
 
 let test_read_routes_docker_and_injects_repo_flag () =
   with_fake_docker @@ fun () ->
@@ -575,6 +647,10 @@ let () =
         test_detects_no_pull_requests_found;
       test_case "unrelated errors are not false positives" `Quick
         test_passes_through_unrelated_errors;
+    ];
+    "host_route", [
+      test_case "host route uses Exec_gate cwd" `Quick
+        test_local_pr_review_host_uses_exec_gate_cwd;
     ];
     "docker_route", [
       test_case "with_env restores cleared variables" `Quick


### PR DESCRIPTION
## Summary

Closes #17312 as the next shell hardening slice. The host-side `keeper_pr_review` executor no longer encodes cwd as `cd <root> && <cmd>` inside the shell command.

Changes:
- run the existing `zsh -lc <gh command>` from `Exec_gate.run_argv_with_status ~cwd:root`
- keep the command shell explicit while removing cwd shell syntax from the argv payload
- quote `raw_source` as audit text instead of joining argv unquoted
- add a local host-route regression test that uses fake `gh`, captures Exec_tap, asserts cwd is recorded, and verifies no `cd ` wrapper appears in the process tap

## Validation

Passed locally:
- `opam exec -- ocamlformat --check lib/keeper/keeper_tool_pr_review.ml test/test_keeper_pr_review.ml`
- `git diff --check origin/main...HEAD`
- `scripts/lint-spawn-bounded.sh`
- `bash scripts/lint/shell-legacy-purge-ratchet.sh`
- `scripts/check-oas-pin.sh`

Blocked / base drift:
- `scripts/dune-local.sh build test/test_keeper_pr_review.exe` could not acquire `/tmp/me-dune-local.lock`; other local Dune builds are still active.
- `scripts/ocaml-structure-ratchet.sh` fails on existing `lib_dune_lines` baseline drift, tracked separately by #17239 / #17219. This PR does not touch `lib/dune`.