### PR TITLE
tools(pr): sync commit lineage on open

### DIFF
--- a/scripts/pr-open.sh
+++ b/scripts/pr-open.sh
@@ -178,6 +178,18 @@ arm_agent_draft_guard_status() {
     >/dev/null
 }
 
+sync_commit_lineage() {
+  local pr_number="$1"
+  local sync_script="$script_dir/pr-sync-body.sh"
+
+  if [[ ! -x "$sync_script" ]]; then
+    echo "commit-lineage sync script not executable: $sync_script" >&2
+    exit 1
+  fi
+
+  "$sync_script" "$repo" "$pr_number" >/dev/null
+}
+
 repo=""
 base="main"
 title=""
@@ -201,6 +213,8 @@ done
 require_cmd git
 require_cmd gh
 require_cmd jq
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 load_changed_files() {
   local range="$1"
@@ -297,6 +311,8 @@ fi
 
 arm_agent_draft_guard_status "$pr_number"
 ensure_pr_is_draft "$pr_number" "guard status arming"
+sync_commit_lineage "$pr_number"
+ensure_pr_is_draft "$pr_number" "commit lineage sync"
 
 pr_url="$(gh pr view "$pr_number" --repo "$repo" --json url --jq .url)"
 echo "PR: $pr_url"

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -514,7 +514,10 @@ let test_pr_automation_draft_guard_contracts () =
        "arm_agent_draft_guard_status");
   check bool "pr-open posts Draft Auto-Merge Guard failure status" true
     (file_contains_pattern "scripts/pr-open.sh"
-       {|context="Draft Auto-Merge Guard"|})
+       {|context="Draft Auto-Merge Guard"|});
+  check bool "pr-open syncs commit lineage after push" true
+    (file_contains_pattern "scripts/pr-open.sh"
+       {|sync_commit_lineage "$pr_number"|})
 
 let test_health_and_ci_runner_diagnostics () =
   check bool "health snapshot records baseline source" true

--- a/test/test_pr_open_script.ml
+++ b/test/test_pr_open_script.ml
@@ -113,6 +113,7 @@ log_file="${FAKE_GH_LOG:?}"
 labels_file="${FAKE_GH_LABELS:?}"
 statuses_file="${FAKE_GH_STATUSES:-$labels_file.statuses}"
 draft_file="${FAKE_GH_DRAFT_STATE_FILE:-$labels_file.draft}"
+edit_body_file="${FAKE_GH_EDIT_BODY:-$labels_file.body}"
 cmd1="${1:-}"
 cmd2="${2:-}"
 printf '%s %s\n' "$cmd1" "$cmd2" >>"$log_file"
@@ -132,6 +133,11 @@ case "${cmd1}:${cmd2}" in
     args="$*"
     draft_state="$(cat "$draft_file" 2>/dev/null || printf 'true\n')"
     case "$args" in
+      *"body,commits,headRefName,baseRefName"*)
+        cat <<'JSON'
+{"body":"## Summary\nFake body\n","headRefName":"feature/macos-pr-open","baseRefName":"main","commits":[{"oid":"abcdef1234567890","messageHeadline":"feature commit","committedDate":"2026-05-21T00:00:00Z"}]}
+JSON
+        ;;
       *"state,isDraft,mergeStateStatus,headRefOid,url"*)
         printf 'state=OPEN draft=%s mergeState=CLEAN head=abc123\nurl=https://github.com/example/test/pull/42\n' "$draft_state"
         ;;
@@ -152,6 +158,9 @@ case "${cmd1}:${cmd2}" in
         fi
         ;;
     esac
+    ;;
+  pr:edit)
+    cat >"$edit_body_file"
     ;;
   pr:ready)
     printf 'true\n' >"$draft_file"
@@ -268,6 +277,13 @@ let test_script_runs_under_system_bash_without_watch () =
       check bool "sets draft guard status failure" true
         (contains_substring (read_file (gh_labels ^ ".statuses"))
            "Draft Auto-Merge Guard");
+      check bool "syncs commit lineage" true
+        (contains_substring log "pr edit");
+      let synced_body = read_file (gh_labels ^ ".body") in
+      check bool "writes commit lineage marker" true
+        (contains_substring synced_body "<!-- COMMIT-LINEAGE:START -->");
+      check bool "writes commit lineage commit subject" true
+        (contains_substring synced_body "feature commit");
       let labels = read_file gh_labels in
       check bool "adds enhancement label for code changes" true
         (contains_substring labels "\"enhancement\"");


### PR DESCRIPTION
## Summary

- Make `scripts/pr-open.sh` run `scripts/pr-sync-body.sh` after the draft PR is pushed and guarded.
- Keep the PR in draft state after the lineage sync.
- Extend the fake-`gh` script test so it verifies the managed commit-lineage block is written.

## Product impact

Agent-opened draft PRs now get an automatically synced commit-lineage block, reducing PR body drift after follow-up commits and review-bot complaints about stale descriptions.

## Evidence

- `bash -n scripts/pr-open.sh scripts/pr-sync-body.sh`
- `ocamlformat --check test/test_pr_open_script.ml test/test_ci_hardening_source.ml`
- `git diff --check origin/main...HEAD`
- `scripts/check-pr-hygiene.sh --base origin/main --head HEAD --duplicate-policy fail`
- Blocked: `scripts/dune-local.sh build test/test_pr_open_script.exe test/test_ci_hardening_source.exe` failed before reaching these tests because current `origin/main` has `test_timeout_floor` in `test/dune` names but not in that stanza's `modules` field.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 4/5
provenance: direct
stages:
  - name: shell_syntax
    command: bash -n scripts/pr-open.sh scripts/pr-sync-body.sh
    result: pass
  - name: format
    command: ocamlformat --check test/test_pr_open_script.ml test/test_ci_hardening_source.ml
    result: pass
  - name: whitespace
    command: git diff --check origin/main...HEAD
    result: pass
  - name: hygiene
    command: scripts/check-pr-hygiene.sh --base origin/main --head HEAD --duplicate-policy fail
    result: pass
  - name: focused_dune
    command: scripts/dune-local.sh build test/test_pr_open_script.exe test/test_ci_hardening_source.exe
    result: blocked_by_current_main_test_dune_module_mismatch
```

## Review evidence

- `sync_commit_lineage` calls only the existing `scripts/pr-sync-body.sh`; the managed block semantics stay in one script.
- The sync runs after the hard-stop draft guard status is armed, then rechecks draft state.
- Existing `--no-watch` behavior remains unchanged.

## Linked issue

N/A - follow-up from the PR lifecycle FSM + lineage slice in `masc-oas-uncovered-after-cycle-2026-05-20.html`.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/pr-open-commit-lineage-20260521` → `main` · 1 commit(s) · synced 2026-05-21T07:29:03Z

| sha | subject | date |
|---|---|---|
| `6bf9cdc9d` | tools(pr): sync commit lineage on open | 2026-05-21 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->