### PR TITLE
refactor(server_routes_dashboard): extract sync_keeper_cascade_meta sibling (-30 LOC)

### DIFF
--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -80,39 +80,9 @@ let observe_worktree_status_sse_close writer =
     ~default:() (fun () ->
       Httpun.Body.Writer.close writer)
 
-let sync_keeper_cascade_meta ~(config : Coord.config) ~(name : string)
-    ~(cascade_name : string) : (bool, string) result =
-  let updated_at = Keeper_types.now_iso () in
-  match Keeper_types.read_meta config name with
-  | Error msg -> Error ("read_meta failed after TOML update: " ^ msg)
-  | Ok (Some meta) ->
-      let updated =
-        { (Keeper_types.set_cascade_name cascade_name meta) with updated_at }
-      in
-      (match Keeper_types.write_meta ~force:true config updated with
-       | Ok () ->
-           let registered =
-             Option.is_some
-               (Keeper_registry.get ~base_path:config.base_path name)
-           in
-           Keeper_registry.update_meta ~base_path:config.base_path name updated;
-           Ok registered
-       | Error msg -> Error ("write_meta failed after TOML update: " ^ msg))
-  | Ok None ->
-      (match Keeper_registry.get ~base_path:config.base_path name with
-       | None -> Ok false
-       | Some entry ->
-           let updated =
-             { (Keeper_types.set_cascade_name cascade_name entry.meta) with updated_at }
-           in
-           (match Keeper_types.write_meta ~force:true config updated with
-            | Ok () ->
-                Keeper_registry.update_meta ~base_path:config.base_path name
-                  updated;
-                Ok true
-            | Error msg ->
-                Error ("write_meta failed after TOML update: " ^ msg)))
-
+(* sync_keeper_cascade_meta extracted to
+   [Server_routes_http_routes_dashboard_cascade_meta] (godfile decomp). *)
+let sync_keeper_cascade_meta = Server_routes_http_routes_dashboard_cascade_meta.sync_keeper_cascade_meta
 (* Dashboard dev-token cluster extracted to
    [Server_routes_http_dashboard_dev_token] (godfile decomp). *)
 

--- a/lib/server/server_routes_http_routes_dashboard_cascade_meta.ml
+++ b/lib/server/server_routes_http_routes_dashboard_cascade_meta.ml
@@ -1,0 +1,38 @@
+(** Cascade-name TOML/registry writer for keeper meta, extracted from
+    [server_routes_http_routes_dashboard.ml]. Single helper that
+    propagates a new [cascade_name] for a keeper into both the on-disk
+    keeper TOML and the in-memory [Keeper_registry] entry, returning
+    whether the keeper was registered before the update. *)
+
+let sync_keeper_cascade_meta ~(config : Coord.config) ~(name : string)
+    ~(cascade_name : string) : (bool, string) result =
+  let updated_at = Keeper_types.now_iso () in
+  match Keeper_types.read_meta config name with
+  | Error msg -> Error ("read_meta failed after TOML update: " ^ msg)
+  | Ok (Some meta) ->
+      let updated =
+        { (Keeper_types.set_cascade_name cascade_name meta) with updated_at }
+      in
+      (match Keeper_types.write_meta ~force:true config updated with
+       | Ok () ->
+           let registered =
+             Option.is_some
+               (Keeper_registry.get ~base_path:config.base_path name)
+           in
+           Keeper_registry.update_meta ~base_path:config.base_path name updated;
+           Ok registered
+       | Error msg -> Error ("write_meta failed after TOML update: " ^ msg))
+  | Ok None ->
+      (match Keeper_registry.get ~base_path:config.base_path name with
+       | None -> Ok false
+       | Some entry ->
+           let updated =
+             { (Keeper_types.set_cascade_name cascade_name entry.meta) with updated_at }
+           in
+           (match Keeper_types.write_meta ~force:true config updated with
+            | Ok () ->
+                Keeper_registry.update_meta ~base_path:config.base_path name
+                  updated;
+                Ok true
+            | Error msg ->
+                Error ("write_meta failed after TOML update: " ^ msg)))


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane C
- 3rd sibling extracted from `server_routes_http_routes_dashboard.ml` (after #17282 dev-token and #17314 handlers).

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/server/server_routes_http_routes_dashboard.ml` | 1438 | 1408 | **-30** |
| `lib/server/server_routes_http_routes_dashboard_cascade_meta.ml` | — | 38 | +38 |

## Moved (verbatim, no behavior change)
- `sync_keeper_cascade_meta` — propagates a new `cascade_name` into both the
  on-disk keeper TOML and the `Keeper_registry` in-memory entry, returning
  `Ok registered` / `Error msg`. Handles three cases:
  1. Disk meta exists -> rewrite + registry update + return registered status
  2. Disk meta absent + registry hit -> derive from registry, rewrite, update
  3. Disk meta absent + registry miss -> `Ok false`

One single-line alias in parent.

## Sibling deps (all visible to parent already)
- `Coord.config` (from open Coord at parent scope — used as type annotation)
- `Keeper_types.now_iso`, `read_meta`, `set_cascade_name`, `write_meta`
- `Keeper_registry.get`, `update_meta`

No `.mli` exposure (function is local to module, only called internally
from `add_routes`). No external callers. No sibling -> parent cycle.

## Local build status
- `dune build @check` on changed area: clean
- Pre-existing main breakages unchanged (`Timeout_origin`/`Timeout_floor`/`Worker_runtime` dep cycle)
- godfile lint: sibling 38 LOC well under `new_file_cap=600`; parent 1408 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim single-function move.

Co-Authored-By: codex <noreply@anthropic.com>
