### PR TITLE
[codex] chore(repo): fail closed without keeper mapping

### DIFF
--- a/docs/repo-migration-guide.md
+++ b/docs/repo-migration-guide.md
@@ -86,10 +86,10 @@ let allowed = Keeper_repo_mapping.is_allowed
   ~base_path
 ```
 
-If no mapping exists for a keeper, access falls back to "allow all" for backward
-compatibility. Once keeper-repository mappings are configured, access is
-restricted to the repositories explicitly listed for that keeper; an explicit
-empty mapping grants access to no repositories.
+If no mapping exists for a keeper, access to registered repositories is denied.
+Use an explicit `repositories = ["*"]` mapping when a keeper should be allowed
+to use every registered repository. An explicit empty mapping grants access to
+no repositories.
 
 ## Rollback
 

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -153,8 +153,8 @@ let filter_repos_by_mapping (mapping : keeper_repo_mapping)
     [credential] records.
 
     Returns [Ok []] when the keeper has no mapping.  Absence remains distinct
-    from load/parse errors so callers can decide their own policy; strict
-    credential-provider dispatch treats this as a missing-mapping error.
+    from load/parse errors so strict credential-provider dispatch can surface a
+    missing-mapping error.
 
     Repository IDs from the mapping are resolved against the loaded
     repositories; unknown repository IDs are ignored by this resolution path.
@@ -215,16 +215,16 @@ let credentials_for_keeper ~base_path ~keeper_id =
 
 let is_allowed ~keeper_id ~repository_id ~base_path =
   match lookup_mapping ~base_path keeper_id with
-  | Mapping_missing _ -> true
+  | Mapping_missing _ -> false
   | Mapping_load_error msg ->
       if not (Hashtbl.mem logged_mapping_errors keeper_id) then begin
         Hashtbl.add logged_mapping_errors keeper_id ();
         Log.Misc.warn
           "[KeeperRepoMapping] is_allowed: mapping load error for keeper %s \
-           — access control bypassed (error: %s)"
+           — access denied fail-closed (error: %s)"
           keeper_id msg
       end;
-      true
+      false
   | Mapping_found mapping ->
       List.exists
         (fun id -> String.equal id repository_id || String.equal id "*")
@@ -268,13 +268,13 @@ let save_mapping ~base_path mapping =
 
 let apply_mapping ~keeper_id ~base_path ~repositories =
   match lookup_mapping ~base_path keeper_id with
-  | Mapping_missing _ -> repositories
+  | Mapping_missing _ -> []
   | Mapping_load_error msg ->
       Log.Misc.warn
         "[KeeperRepoMapping] apply_mapping: mapping load error for \
-         keeper %s — returning unfiltered repositories (error: %s)"
+         keeper %s — returning no repositories fail-closed (error: %s)"
         keeper_id msg;
-      repositories
+      []
   | Mapping_found mapping ->
       filter_repos_by_mapping mapping repositories
 

--- a/lib/repo_manager/keeper_repo_mapping.mli
+++ b/lib/repo_manager/keeper_repo_mapping.mli
@@ -19,8 +19,8 @@ val credentials_for_keeper :
     keeper is allowed to access and looking up each repository's
     [credential_id] in the credential store.
 
-    Returns [Ok []] when the keeper has no mapping (backward-compatibility
-    signal consumed by the RFC-0019 PR-A credential provider bridge).
+    Returns [Ok []] when the keeper has no mapping, preserving a distinct
+    missing-mapping signal for strict credential-provider dispatch.
 
     Repository IDs from the mapping are resolved against the loaded
     repositories; unknown repository IDs are ignored by this resolution.
@@ -46,8 +46,8 @@ val apply_mapping :
   keeper_id:string -> base_path:string -> repositories:repository list -> repository list
 (** [apply_mapping ~keeper_id ~base_path ~repositories] filters the given
     repository list to only those accessible by [keeper_id].
-    When no mapping exists for the keeper, all repositories are returned
-    (backward compatibility). *)
+    When no mapping exists for the keeper, or mapping loading fails, no
+    repositories are returned. *)
 
 val repository_id_of_path :
   base_path:string -> path:string -> repository_id option

--- a/lib/server/server_routes_http_routes_keeper_repos.ml
+++ b/lib/server/server_routes_http_routes_keeper_repos.ml
@@ -115,16 +115,16 @@ let handle_get_mapping state keeper_id req reqd =
             (Yojson.Safe.to_string (mapping_json mapping))
             reqd
       | None ->
-          (* No mapping is intentionally treated as wildcard access for backward
-             compatibility with pre-repository keepers. *)
-          Http.Response.json ~compress:true ~request:req
+          Http.Response.json ~status:`Not_found ~request:req
             (Yojson.Safe.to_string
-               (mapping_json
-                  {
-                    Repo_manager_types.keeper_id;
-                    repository_ids = ["*"];
-                    github_credential_id = None;
-                  }))
+               (`Assoc
+                 [
+                   ("ok", `Bool false);
+                   ( "error",
+                     `String
+                       (Printf.sprintf "No mapping found for keeper: %s"
+                          keeper_id) );
+                 ]))
             reqd)
 
 let credential_type_label = function

--- a/test/test_keeper_repo_mapping.ml
+++ b/test/test_keeper_repo_mapping.ml
@@ -190,8 +190,17 @@ let test_is_allowed_wildcard () =
 let test_is_allowed_no_mapping () =
   with_temp_base_path (fun base_path ->
       Alcotest.(check bool)
-        "no mapping preserves legacy access" true
+        "no mapping denies access" false
         (Keeper_repo_mapping.is_allowed ~keeper_id:"unknown" ~repository_id:"repo-a" ~base_path))
+
+let test_is_allowed_mapping_parse_error () =
+  with_temp_base_path (fun base_path ->
+      write_file
+        (Filename.concat base_path ".masc/config/keeper_repo_mappings.toml")
+        "[mapping.keeper-1]\nrepositories = 42\n";
+      Alcotest.(check bool)
+        "mapping parse error denies access" false
+        (Keeper_repo_mapping.is_allowed ~keeper_id:"keeper-1" ~repository_id:"repo-a" ~base_path))
 
 let test_validate_access_allowed () =
   with_temp_base_path (fun base_path ->
@@ -207,6 +216,15 @@ let test_validate_access_denied () =
       write_mapping base_path "keeper-1" [ "repo-a" ];
       match
         Keeper_repo_mapping.validate_access ~keeper_id:"keeper-1" ~repository_id:"repo-b" ~base_path
+      with
+      | Ok _ -> Alcotest.fail "expected Error"
+      | Error msg ->
+          Alcotest.(check bool) "mentions not allowed" true (contains_substring msg "not allowed"))
+
+let test_validate_access_no_mapping () =
+  with_temp_base_path (fun base_path ->
+      match
+        Keeper_repo_mapping.validate_access ~keeper_id:"unknown" ~repository_id:"repo-a" ~base_path
       with
       | Ok _ -> Alcotest.fail "expected Error"
       | Error msg ->
@@ -668,7 +686,18 @@ let test_apply_mapping_no_mapping () =
       let filtered =
         Keeper_repo_mapping.apply_mapping ~keeper_id:"unknown" ~base_path ~repositories:repos
       in
-      Alcotest.(check int) "no mapping returns all for compatibility" 2 (List.length filtered))
+      Alcotest.(check int) "no mapping returns none" 0 (List.length filtered))
+
+let test_apply_mapping_parse_error () =
+  with_temp_base_path (fun base_path ->
+      write_file
+        (Filename.concat base_path ".masc/config/keeper_repo_mappings.toml")
+        "[mapping.keeper-1]\nrepositories = 42\n";
+      let repos = [ sample_repo "repo-a"; sample_repo "repo-b" ] in
+      let filtered =
+        Keeper_repo_mapping.apply_mapping ~keeper_id:"keeper-1" ~base_path ~repositories:repos
+      in
+      Alcotest.(check int) "mapping parse error returns none" 0 (List.length filtered))
 
 let test_allowed_repositories () =
   with_temp_base_path (fun base_path ->
@@ -912,11 +941,14 @@ let () =
           Alcotest.test_case "explicit list" `Quick test_is_allowed_explicit;
           Alcotest.test_case "wildcard" `Quick test_is_allowed_wildcard;
           Alcotest.test_case "no mapping" `Quick test_is_allowed_no_mapping;
+          Alcotest.test_case "mapping parse error" `Quick
+            test_is_allowed_mapping_parse_error;
         ] );
       ( "validate_access",
         [
           Alcotest.test_case "allowed" `Quick test_validate_access_allowed;
           Alcotest.test_case "denied" `Quick test_validate_access_denied;
+          Alcotest.test_case "no mapping" `Quick test_validate_access_no_mapping;
         ] );
       ( "validate_path_access",
         [
@@ -954,6 +986,8 @@ let () =
           Alcotest.test_case "explicit list" `Quick test_apply_mapping_explicit;
           Alcotest.test_case "wildcard" `Quick test_apply_mapping_wildcard;
           Alcotest.test_case "no mapping" `Quick test_apply_mapping_no_mapping;
+          Alcotest.test_case "mapping parse error" `Quick
+            test_apply_mapping_parse_error;
         ] );
       ( "allowed_repositories",
         [


### PR DESCRIPTION
## Summary
- remove the implicit allow-all behavior when a keeper has no repository mapping
- make mapping load failures fail closed for `is_allowed` and `apply_mapping`
- return 404 for missing `GET /api/v1/keeper-repos/:id` mappings instead of synthesizing `repositories = ["*"]`
- update the migration guide and regression tests for the new fail-closed policy

## Validation
- `opam exec -- ocamlformat --check lib/repo_manager/keeper_repo_mapping.ml lib/repo_manager/keeper_repo_mapping.mli lib/server/server_routes_http_routes_keeper_repos.ml test/test_keeper_repo_mapping.ml`
- `git diff --check HEAD~1..HEAD`
- `rg -n 'no mapping preserves legacy access|no mapping returns all for compatibility|wildcard access for backward|access control bypassed|returning unfiltered repositories|falls back to "allow all"|When no mapping exists for the keeper, all repositories|backward-compatibility signal' lib/repo_manager lib/server test docs/repo-migration-guide.md` returned no matches

## Not Run
- `scripts/dune-local.sh build lib/masc_mcp.cmxa test/test_keeper_repo_mapping.exe` could not complete locally because other worktrees were holding or queueing the shared `/tmp/me-dune-local.lock`; I did not bypass the wrapper lock.