### PR TITLE
dashboard: surface telemetry cache freshness

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -16,6 +16,8 @@ import {
   fetchMemorySubsystems,
   fetchRuntimeProviders,
   fetchRuntimeModelMetrics,
+  fetchDashboardCacheStats,
+  fetchTelemetry,
   fetchTelemetrySummary,
   fetchTlcResults,
   fetchToolQuality,
@@ -566,6 +568,102 @@ describe('fetchToolQuality', () => {
 })
 
 describe('fetchTelemetrySummary', () => {
+  it('preserves telemetry envelope metadata', async () => {
+    const rawResponse = {
+      generated_at: '2026-05-14T00:00:00Z',
+      generated_at_iso: '2026-05-14T00:00:00Z',
+      dashboard_surface: '/api/v1/dashboard/telemetry',
+      source: 'telemetry_unified',
+      retention: { window_days: 7 },
+      query: { source: 'tool_metric', n: 100 },
+      count: 1,
+      total_matching_entries: 2,
+      truncated: true,
+      entries: [
+        {
+          source: 'tool_metric',
+          ts_unix: 1_775_709_000,
+          tool_name: 'mcp__masc__masc_status',
+        },
+      ],
+    }
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchTelemetry({ source: 'tool_metric', n: 100 })
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/telemetry?source=tool_metric&n=100')
+    expect(result.dashboard_surface).toBe('/api/v1/dashboard/telemetry')
+    expect(result.source).toBe('telemetry_unified')
+    expect(result.retention).toMatchObject({ window_days: 7 })
+    expect(result.query).toMatchObject({ source: 'tool_metric', n: 100 })
+    expect(result.total_matching_entries).toBe(2)
+    expect(result.truncated).toBe(true)
+  })
+
+  it('decodes dashboard cache stats details', async () => {
+    const rawResponse = {
+      entries: 3,
+      fresh: 1,
+      stale: 1,
+      expired: 0,
+      ready_fresh: 1,
+      ready_stale: 1,
+      computing: 1,
+      max_entries: 500,
+      hits_total: 8,
+      misses_total: 2,
+      hit_ratio: 0.8,
+      timeout_circuit_open: 0,
+      timeout_circuit_tracked: 1,
+      entries_truncated_to: 50,
+      entry_details: [
+        {
+          key: 'telemetry:/Users/dancer/me/.masc:src=tool_metric:n=100',
+          kind: 'fresh',
+          ttl_remaining_ms: 750,
+          stale_remaining_ms: 10_000,
+        },
+        {
+          key: 'health:full',
+          kind: 'computing',
+          computing_for_ms: 12,
+          has_stale_fallback: true,
+        },
+      ],
+    }
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchDashboardCacheStats()
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/cache-stats')
+    expect(result.hit_ratio).toBe(0.8)
+    expect(result.entry_details[0]).toMatchObject({
+      key: 'telemetry:/Users/dancer/me/.masc:src=tool_metric:n=100',
+      kind: 'fresh',
+      ttl_remaining_ms: 750,
+      stale_remaining_ms: 10_000,
+    })
+    expect(result.entry_details[1]).toMatchObject({
+      kind: 'computing',
+      computing_for_ms: 12,
+      has_stale_fallback: true,
+    })
+  })
+
   it('preserves per-source coverage gap rows', async () => {
     const rawResponse = {
       generated_at: '2026-05-14T00:00:00Z',

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2791,10 +2791,42 @@ export type TelemetryEntry = Record<string, unknown> & {
 
 export type TelemetryResponse = {
   generated_at: string
+  generated_at_iso?: string
+  dashboard_surface?: string
+  source?: string
+  retention?: Record<string, unknown>
+  query?: Record<string, unknown>
   count: number
   total_matching_entries?: number
   truncated?: boolean
   entries: TelemetryEntry[]
+}
+
+export type DashboardCacheEntryDetail = {
+  key: string
+  kind: string
+  ttl_remaining_ms?: number
+  stale_remaining_ms?: number
+  computing_for_ms?: number
+  has_stale_fallback?: boolean
+}
+
+export type DashboardCacheStatsResponse = {
+  entries: number
+  fresh: number
+  stale: number
+  expired: number
+  ready_fresh: number
+  ready_stale: number
+  computing: number
+  max_entries: number
+  hits_total: number
+  misses_total: number
+  hit_ratio: number
+  timeout_circuit_open: number
+  timeout_circuit_tracked: number
+  entries_truncated_to: number
+  entry_details: DashboardCacheEntryDetail[]
 }
 
 export type TelemetrySourceSummary = TelemetryFreshnessMetadata & {
@@ -2848,12 +2880,55 @@ function decodeTelemetryResponse(raw: unknown): TelemetryResponse | null {
   if (!generatedAt) return null
   return {
     generated_at: generatedAt,
+    generated_at_iso: asString(raw.generated_at_iso),
+    dashboard_surface: asString(raw.dashboard_surface),
+    source: asString(raw.source),
+    retention: isRecord(raw.retention) ? raw.retention : undefined,
+    query: isRecord(raw.query) ? raw.query : undefined,
     count: asNumber(raw.count, 0),
     total_matching_entries: asNumber(raw.total_matching_entries, asNumber(raw.count, 0)),
     truncated: asBoolean(raw.truncated, false),
     entries: asRecordArray(raw.entries)
       .map(decodeTelemetryEntry)
       .filter((entry): entry is TelemetryEntry => entry !== null),
+  }
+}
+
+function decodeDashboardCacheEntryDetail(raw: unknown): DashboardCacheEntryDetail | null {
+  if (!isRecord(raw)) return null
+  const key = asString(raw.key)
+  const kind = asString(raw.kind)
+  if (!key || !kind) return null
+  return {
+    key,
+    kind,
+    ttl_remaining_ms: asNumber(raw.ttl_remaining_ms),
+    stale_remaining_ms: asNumber(raw.stale_remaining_ms),
+    computing_for_ms: asNumber(raw.computing_for_ms),
+    has_stale_fallback: asBoolean(raw.has_stale_fallback),
+  }
+}
+
+function decodeDashboardCacheStatsResponse(raw: unknown): DashboardCacheStatsResponse | null {
+  if (!isRecord(raw)) return null
+  return {
+    entries: asNumber(raw.entries, 0),
+    fresh: asNumber(raw.fresh, 0),
+    stale: asNumber(raw.stale, 0),
+    expired: asNumber(raw.expired, 0),
+    ready_fresh: asNumber(raw.ready_fresh, 0),
+    ready_stale: asNumber(raw.ready_stale, 0),
+    computing: asNumber(raw.computing, 0),
+    max_entries: asNumber(raw.max_entries, 0),
+    hits_total: asNumber(raw.hits_total, 0),
+    misses_total: asNumber(raw.misses_total, 0),
+    hit_ratio: asNumber(raw.hit_ratio, 0),
+    timeout_circuit_open: asNumber(raw.timeout_circuit_open, 0),
+    timeout_circuit_tracked: asNumber(raw.timeout_circuit_tracked, 0),
+    entries_truncated_to: asNumber(raw.entries_truncated_to, 0),
+    entry_details: asRecordArray(raw.entry_details)
+      .map(decodeDashboardCacheEntryDetail)
+      .filter((entry): entry is DashboardCacheEntryDetail => entry !== null),
   }
 }
 
@@ -2925,6 +3000,15 @@ export function fetchTelemetrySummary(opts?: AbortableRequestOptions): Promise<T
     .then((raw) => {
       const decoded = decodeTelemetrySummaryResponse(raw)
       if (!decoded) throw new Error('유효하지 않은 telemetry summary payload')
+      return decoded
+    })
+}
+
+export function fetchDashboardCacheStats(opts?: AbortableRequestOptions): Promise<DashboardCacheStatsResponse> {
+  return get<Record<string, unknown>>('/api/v1/dashboard/cache-stats', { signal: opts?.signal })
+    .then((raw) => {
+      const decoded = decodeDashboardCacheStatsResponse(raw)
+      if (!decoded) throw new Error('유효하지 않은 dashboard cache stats payload')
       return decoded
     })
 }

--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -2,13 +2,17 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { TelemetryResponse, TelemetrySummaryResponse } from '../api/dashboard'
+import type { DashboardCacheStatsResponse, TelemetryResponse, TelemetrySummaryResponse } from '../api/dashboard'
 
 void vi
 vi.setConfig({ testTimeout: 120_000 })
 
 const baseTelemetry: TelemetryResponse = {
   generated_at: '2026-04-09T05:10:00Z',
+  generated_at_iso: '2026-04-09T05:10:00Z',
+  dashboard_surface: '/api/v1/dashboard/telemetry',
+  source: 'telemetry_unified',
+  query: { source: 'tool_metric', n: 100 },
   count: 1,
   entries: [
     {
@@ -41,6 +45,42 @@ const baseSummary: TelemetrySummaryResponse = {
   total_entries: 1,
 }
 
+const baseCacheStats: DashboardCacheStatsResponse = {
+  entries: 2,
+  fresh: 1,
+  stale: 1,
+  expired: 0,
+  ready_fresh: 1,
+  ready_stale: 1,
+  computing: 0,
+  max_entries: 500,
+  hits_total: 8,
+  misses_total: 2,
+  hit_ratio: 0.8,
+  timeout_circuit_open: 0,
+  timeout_circuit_tracked: 1,
+  entries_truncated_to: 50,
+  entry_details: [
+    {
+      key: 'telemetry:/Users/dancer/me/.masc:src=tool_metric:n=100',
+      kind: 'fresh',
+      ttl_remaining_ms: 750,
+      stale_remaining_ms: 10_000,
+    },
+    {
+      key: 'telemetry:/Users/dancer/me/.masc:all:n=100',
+      kind: 'stale',
+      ttl_remaining_ms: 0,
+      stale_remaining_ms: 4_000,
+    },
+    {
+      key: 'health:full',
+      kind: 'fresh',
+      ttl_remaining_ms: 500,
+    },
+  ],
+}
+
 async function flushUi(): Promise<void> {
   await act(async () => {
     for (let i = 0; i < 4; i += 1) {
@@ -67,6 +107,7 @@ async function loadPanel(
     fetchDashboardShell?: (args?: { light?: boolean; signal?: AbortSignal }) => Promise<unknown>
     fetchDashboardTools?: (args?: { signal?: AbortSignal }) => Promise<unknown>
     fetchDashboardNamespaceTruth?: (args?: { signal?: AbortSignal }) => Promise<unknown>
+    fetchDashboardCacheStats?: (args?: { signal?: AbortSignal }) => Promise<DashboardCacheStatsResponse>
   },
 ) {
   vi.resetModules()
@@ -76,6 +117,7 @@ async function loadPanel(
     fetchDashboardShell: opts?.fetchDashboardShell ?? vi.fn().mockResolvedValue({ counts: { keepers: 2, agents: 0, tasks: 5 }, status: { version: '0.2.0', build: { uptime_seconds: 600 } } }),
     fetchDashboardTools: opts?.fetchDashboardTools ?? vi.fn().mockResolvedValue({ tool_inventory: { count: 10, tools: [], surface_summary: { public_mcp: { count: 5, tools: [] } } }, tool_usage: { total_calls: 100, never_called_count: 0 } }),
     fetchDashboardNamespaceTruth: opts?.fetchDashboardNamespaceTruth ?? vi.fn().mockResolvedValue({ execution: { summary: { active_operations: 3, blocked_operations: 1, continuity_alerts: 0 } } }),
+    fetchDashboardCacheStats: opts?.fetchDashboardCacheStats ?? vi.fn().mockResolvedValue(baseCacheStats),
   }))
   return import('./telemetry-unified')
 }
@@ -213,6 +255,13 @@ describe('TelemetryUnified', () => {
     expect(container.textContent).toContain('Auto-refresh 30s')
     expect(container.textContent).toContain('MASC telemetry store entries')
     expect(container.textContent).toContain('mcp__masc__masc_status')
+    expect(container.textContent).toContain('Query cache')
+    expect(container.textContent).toContain('telemetry keys')
+    expect(container.textContent).toContain('fresh:1')
+    expect(container.textContent).toContain('stale:1')
+    expect(container.textContent).toContain('hit 80%')
+    expect(container.textContent).toContain('/api/v1/dashboard/telemetry')
+    expect(container.textContent).toContain('source=tool_metric')
     expect(container.textContent).toContain('freshness_slo_exceeded')
     expect(container.textContent).toContain('Telemetry_unified.summary_json')
     expect(container.textContent).toContain('.masc/tool_metrics/YYYY-MM/DD.jsonl')
@@ -226,6 +275,25 @@ describe('TelemetryUnified', () => {
     expect(container.textContent).toContain('1 차단 작업')
     expect(container.textContent).not.toContain('활성 세션')
     expect(container.textContent).toContain('5 public')
+  })
+
+  it('keeps telemetry rows when dashboard cache stats are unavailable', async () => {
+    const fetchTelemetry = vi.fn().mockResolvedValue(baseTelemetry)
+    const fetchTelemetrySummary = vi.fn().mockResolvedValue(baseSummary)
+    const fetchDashboardCacheStats = vi.fn().mockRejectedValue(new Error('cache offline'))
+    const { TelemetryUnified } = await loadPanel(fetchTelemetry, fetchTelemetrySummary, {
+      fetchDashboardCacheStats,
+    })
+
+    await act(async () => {
+      render(html`<${TelemetryUnified} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(fetchDashboardCacheStats).toHaveBeenCalled()
+    expect(container.textContent).toContain('mcp__masc__masc_status')
+    expect(container.textContent).toContain('cache stats unavailable: cache offline')
   })
 
   it('renders telemetry summary coverage gap provenance', async () => {

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -7,8 +7,11 @@ import {
   fetchDashboardShell,
   fetchDashboardTools,
   fetchDashboardNamespaceTruth,
+  fetchDashboardCacheStats,
   fetchTelemetry,
+  type DashboardCacheStatsResponse,
   type TelemetryEntry,
+  type TelemetryResponse,
   type TelemetrySource,
   type TelemetrySourceSummary,
 } from '../api/dashboard'
@@ -55,9 +58,12 @@ const EMPTY_STORE: StoreSnapshot = {
 }
 interface TelemetryState {
   entries: TelemetryEntry[]
+  telemetry: TelemetryResponse | null
   summary: TelemetrySourceSummary[]
   totalEntries: number
   store: StoreSnapshot
+  cacheStats: DashboardCacheStatsResponse | null
+  cacheStatsError: string | null
   loading: boolean
   error: string | null
 }
@@ -745,6 +751,110 @@ function telemetrySourceProvenanceRows(src: TelemetrySourceSummary): Array<{ lab
   return rows
 }
 
+function formatMilliseconds(value: number | undefined): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return '-'
+  const abs = Math.abs(value)
+  if (abs >= 1000) return `${(value / 1000).toFixed(1)}s`
+  return `${value}ms`
+}
+
+function shortCacheKey(key: string): string {
+  const withoutPrefix = key.startsWith('telemetry:') ? key.slice('telemetry:'.length) : key
+  return withoutPrefix.length > 90 ? `...${withoutPrefix.slice(-87)}` : withoutPrefix
+}
+
+function TelemetryCachePanel({
+  telemetry,
+  summary,
+  cacheStats,
+  cacheStatsError,
+}: {
+  telemetry: TelemetryResponse | null
+  summary: TelemetrySourceSummary[]
+  cacheStats: DashboardCacheStatsResponse | null
+  cacheStatsError: string | null
+}) {
+  const telemetryCacheEntries = (cacheStats?.entry_details ?? []).filter(entry => entry.key.startsWith('telemetry:'))
+  const cacheKindCounts = telemetryCacheEntries.reduce<Record<string, number>>((acc, entry) => {
+    acc[entry.kind] = (acc[entry.kind] ?? 0) + 1
+    return acc
+  }, {})
+  const unhealthySources = summary.filter(src => {
+    const health = src.health ?? ''
+    return health !== '' && health !== 'ok' && health !== 'healthy' && health !== 'fresh'
+  })
+  const activeQuery = telemetry?.query
+  const queryParts = [
+    activeQuery?.source ? `source=${String(activeQuery.source)}` : null,
+    activeQuery?.keeper ? `keeper=${String(activeQuery.keeper)}` : null,
+    activeQuery?.session_id ? `session=${String(activeQuery.session_id)}` : null,
+    activeQuery?.operation_id ? `operation=${String(activeQuery.operation_id)}` : null,
+    activeQuery?.worker_run_id ? `worker=${String(activeQuery.worker_run_id)}` : null,
+    activeQuery?.n ? `n=${String(activeQuery.n)}` : null,
+  ].filter((part): part is string => Boolean(part))
+  const cacheRows = telemetryCacheEntries.slice(0, 3)
+  return html`
+    <section class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3" aria-label="Telemetry cache freshness">
+      <div class="flex flex-wrap items-start justify-between gap-3">
+        <div class="min-w-0">
+          <div class="text-xs font-semibold uppercase tracking-wider text-[var(--color-fg-muted)]">Query cache</div>
+          <div class="mt-1 text-2xs text-[var(--color-fg-disabled)]">
+            ${telemetry?.generated_at_iso ?? telemetry?.generated_at ?? '-'}
+            ${telemetry?.dashboard_surface ? html`<span class="mx-1">·</span><span class="font-mono">${telemetry.dashboard_surface}</span>` : null}
+          </div>
+        </div>
+        <div class="flex flex-wrap gap-2 text-2xs">
+          <span class="rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] px-2 py-1 text-[var(--color-fg-muted)]">
+            telemetry keys <span class="font-mono text-[var(--color-fg-primary)]">${telemetryCacheEntries.length}</span>
+          </span>
+          <span class="rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] px-2 py-1 text-[var(--color-fg-muted)]">
+            hit <span class="font-mono text-[var(--color-fg-primary)]">${(((cacheStats?.hit_ratio ?? 0) * 100).toFixed(0))}%</span>
+          </span>
+          <span class="rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] px-2 py-1 text-[var(--color-fg-muted)]">
+            source issues <span class=${`font-mono ${unhealthySources.length > 0 ? 'text-[var(--bad-light)]' : 'text-[var(--color-status-ok)]'}`}>${unhealthySources.length}</span>
+          </span>
+        </div>
+      </div>
+      <div class="mt-3 grid gap-3 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)]">
+        <div class="grid gap-2 text-2xs text-[var(--color-fg-muted)]">
+          <div class="flex flex-wrap gap-2">
+            ${Object.entries(cacheKindCounts).length > 0
+              ? Object.entries(cacheKindCounts).map(([kind, count]) => html`
+                <span class="rounded-[var(--r-1)] border border-[var(--color-border-default)] px-2 py-1 font-mono">${kind}:${count}</span>
+              `)
+              : html`<span class="rounded-[var(--r-1)] border border-[var(--color-border-default)] px-2 py-1">no telemetry cache rows</span>`}
+          </div>
+          ${cacheStatsError ? html`
+            <div class="rounded-[var(--r-1)] border border-[var(--bad-muted)] bg-[var(--bad-soft)] px-2 py-1 text-[var(--bad-light)]">
+              cache stats unavailable: ${cacheStatsError}
+            </div>
+          ` : null}
+          ${queryParts.length > 0 ? html`
+            <div class="min-w-0 break-all font-mono text-3xs text-[var(--color-fg-disabled)]">${queryParts.join(' · ')}</div>
+          ` : null}
+        </div>
+        <div class="grid gap-1">
+          ${cacheRows.length > 0 ? cacheRows.map(entry => html`
+            <div class="grid grid-cols-[5.5rem_minmax(0,1fr)_7rem] items-center gap-2 rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] px-2 py-1 text-3xs">
+              <span class="font-mono text-[var(--color-fg-muted)]">${entry.kind}</span>
+              <span class="min-w-0 truncate font-mono text-[var(--color-fg-primary)]" title=${entry.key}>${shortCacheKey(entry.key)}</span>
+              <span class="text-right font-mono text-[var(--color-fg-disabled)]">
+                ${entry.kind === 'computing'
+                  ? formatMilliseconds(entry.computing_for_ms)
+                  : formatMilliseconds(entry.ttl_remaining_ms)}
+              </span>
+            </div>
+          `) : html`
+            <div class="rounded-[var(--r-1)] bg-[var(--color-bg-elevated)] px-2 py-1 text-3xs text-[var(--color-fg-disabled)]">
+              cache detail sample does not include telemetry rows
+            </div>
+          `}
+        </div>
+      </div>
+    </section>
+  `
+}
+
 function SummaryCard({ src }: { src: TelemetrySourceSummary }) {
   const meta = sourceMeta(src.source)
   const hasData = src.entry_count > 0
@@ -1012,9 +1122,12 @@ export function TelemetryUnified() {
   const autoRefreshLoadRef = useRef<() => Promise<void>>(async () => undefined)
   const state = useSignal<TelemetryState>({
     entries: [],
+    telemetry: null,
     summary: [],
     totalEntries: 0,
     store: EMPTY_STORE,
+    cacheStats: null,
+    cacheStatsError: null,
     loading: true,
     error: null,
   })
@@ -1080,7 +1193,16 @@ export function TelemetryUnified() {
           uptime: shell?.status?.build?.uptime_seconds ?? null,
         } satisfies StoreSnapshot
       })
-      const [telemetry, , store] = await Promise.all([
+      const cacheStatsPromise = fetchDashboardCacheStats({ signal: controller.signal })
+        .then(cacheStats => ({ cacheStats, cacheStatsError: null as string | null }))
+        .catch(error => {
+          if (isAbortError(error)) throw error
+          return {
+            cacheStats: null,
+            cacheStatsError: error instanceof Error ? error.message : String(error),
+          }
+        })
+      const [telemetry, , store, cacheStatsResult] = await Promise.all([
         fetchTelemetry({
           source: sourceFilter.value || undefined,
           keeper: keeperFilter.value || undefined,
@@ -1094,6 +1216,7 @@ export function TelemetryUnified() {
         // does not duplicate this fetch across panels.
         refreshSharedTelemetrySummary({ signal: controller.signal }),
         storePromise,
+        cacheStatsPromise,
       ])
       if (requestId !== latestRequestId.current) return
       // refreshSharedTelemetrySummary records failures on the shared error
@@ -1108,9 +1231,12 @@ export function TelemetryUnified() {
       const summary = sharedTelemetrySummary.value ?? { sources: [], total_entries: 0, generated_at: '' }
       state.value = {
         entries: telemetry.entries,
+        telemetry,
         summary: summary.sources,
         totalEntries: summary.total_entries,
         store,
+        cacheStats: cacheStatsResult.cacheStats,
+        cacheStatsError: cacheStatsResult.cacheStatsError,
         loading: false,
         error: null,
       }
@@ -1160,6 +1286,7 @@ export function TelemetryUnified() {
   }, [])
 
   const { entries, summary, totalEntries, store, loading, error } = state.value
+  const { telemetry, cacheStats, cacheStatsError } = state.value
   const entrySearchQuery = entrySearch.value
   const allDisplayItems = useMemo(() => buildTelemetryDisplayItems(entries), [entries])
   const displayItems = useMemo(
@@ -1200,6 +1327,13 @@ export function TelemetryUnified() {
       </div>
 
       <${OasHealthChip} />
+
+      <${TelemetryCachePanel}
+        telemetry=${telemetry}
+        summary=${summary}
+        cacheStats=${cacheStats}
+        cacheStatsError=${cacheStatsError}
+      />
 
       <${TelemetryRouteFocusPanel} focus=${routeFocus} matchCount=${routeFocusedItemKeys.size} />
 


### PR DESCRIPTION
## Summary
- preserve telemetry envelope metadata from /api/v1/dashboard/telemetry
- add dashboard cache-stats decoding and surface telemetry cache freshness in the runtime diagnosis panel
- keep telemetry rows rendering when cache-stats is unavailable

## Validation
- pnpm typecheck
- pnpm vitest run --config vitest.config.ts src/api/dashboard.test.ts src/components/telemetry-unified.test.ts --no-file-parallelism --maxWorkers=1
- pnpm eslint src/api/dashboard.ts src/api/dashboard.test.ts src/components/telemetry-unified.ts src/components/telemetry-unified.test.ts
- pnpm build
- git diff --check
