### PR TITLE
refactor(operator_control_snapshot): extract identity-fields helpers sibling (-26 LOC)

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -4,37 +4,11 @@ include Operator_digest
 
 include Operator_control_context_snapshot
 
-let non_empty_trimmed_string_opt value =
-  let trimmed = String.trim value in
-  if trimmed = "" then None else Some trimmed
-;;
-
-let keeper_runtime_identity_fields (meta : Keeper_types.keeper_meta) =
-  let cascade_name = Keeper_types.cascade_name_of_meta meta in
-  let effective_cascade = Keeper_cascade_profile.resolve_live cascade_name in
-  [ "cascade_name", string_option_to_json (non_empty_trimmed_string_opt cascade_name)
-  ; "cascade_canonical", `String effective_cascade
-  ; "selected_cascade_canonical", `String effective_cascade
-  ; "primary_model", `Null
-  ; "active_model", `Null
-  ; "active_model_label", `Null
-  ; "last_model_used_label", `Null
-  ]
-;;
-
-let degraded_keeper_runtime_identity_fields (meta : Keeper_types.keeper_meta) =
-  let cascade_name = non_empty_trimmed_string_opt (Keeper_types.cascade_name_of_meta meta) in
-  let cascade_json = string_option_to_json cascade_name in
-  [ "cascade_name", cascade_json
-  ; "cascade_canonical", cascade_json
-  ; "selected_cascade_canonical", cascade_json
-  ; "primary_model", `Null
-  ; "active_model", `Null
-  ; "active_model_label", `Null
-  ; "last_model_used_label", `Null
-  ]
-;;
-
+(* Keeper runtime identity fields extracted to
+   [Operator_control_snapshot_identity_fields] (godfile decomp). *)
+let non_empty_trimmed_string_opt = Operator_control_snapshot_identity_fields.non_empty_trimmed_string_opt
+let keeper_runtime_identity_fields = Operator_control_snapshot_identity_fields.keeper_runtime_identity_fields
+let degraded_keeper_runtime_identity_fields = Operator_control_snapshot_identity_fields.degraded_keeper_runtime_identity_fields
 type action_result_status =
   | ActionOk
   | ActionError

--- a/lib/operator/operator_control_snapshot_identity_fields.ml
+++ b/lib/operator/operator_control_snapshot_identity_fields.ml
@@ -1,0 +1,39 @@
+(** Keeper runtime identity field builders for the operator control
+    snapshot, extracted from [operator_control_snapshot.ml]. Three
+    helpers: a trimmed-string predicate, the live identity-fields list
+    (with cascade resolution), and the degraded fallback that elides
+    the resolved-cascade lookup. *)
+
+open Operator_pending_confirm
+
+let non_empty_trimmed_string_opt value =
+  let trimmed = String.trim value in
+  if trimmed = "" then None else Some trimmed
+;;
+
+let keeper_runtime_identity_fields (meta : Keeper_types.keeper_meta) =
+  let cascade_name = Keeper_types.cascade_name_of_meta meta in
+  let effective_cascade = Keeper_cascade_profile.resolve_live cascade_name in
+  [ "cascade_name", string_option_to_json (non_empty_trimmed_string_opt cascade_name)
+  ; "cascade_canonical", `String effective_cascade
+  ; "selected_cascade_canonical", `String effective_cascade
+  ; "primary_model", `Null
+  ; "active_model", `Null
+  ; "active_model_label", `Null
+  ; "last_model_used_label", `Null
+  ]
+;;
+
+let degraded_keeper_runtime_identity_fields (meta : Keeper_types.keeper_meta) =
+  let cascade_name = non_empty_trimmed_string_opt (Keeper_types.cascade_name_of_meta meta) in
+  let cascade_json = string_option_to_json cascade_name in
+  [ "cascade_name", cascade_json
+  ; "cascade_canonical", cascade_json
+  ; "selected_cascade_canonical", cascade_json
+  ; "primary_model", `Null
+  ; "active_model", `Null
+  ; "active_model_label", `Null
+  ; "last_model_used_label", `Null
+  ]
+;;
+


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane F
- 2nd sibling extracted from `operator_control_snapshot.ml` (after #17310 `runtime_status` helpers).

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/operator/operator_control_snapshot.ml` | 1324 | 1298 | **-26** |
| `lib/operator/operator_control_snapshot_identity_fields.ml` | — | 39 | +39 |

## Moved (verbatim, no behavior change)
- `non_empty_trimmed_string_opt` — `String.trim` + non-empty predicate (~3 LOC)
- `keeper_runtime_identity_fields` — live identity fields list with
  `Keeper_cascade_profile.resolve_live` cascade resolution (~12 LOC)
- `degraded_keeper_runtime_identity_fields` — fallback field list skipping
  the resolved-cascade lookup (~12 LOC)

Three single-line aliases in parent (defensive: parent has no `.mli`, so
all symbols are exposed; aliases preserve any indirect consumers and
parent's own internal uses at lines 296 and 520).

## Sibling deps (all visible to parent already)
- `open Operator_pending_confirm` — for `string_option_to_json`
  (parent `include Operator_pending_confirm`)
- `Keeper_types.keeper_meta`, `cascade_name_of_meta`
- `Keeper_cascade_profile.resolve_live`

No external qualified callers (verified `rg "Operator_control_snapshot.X"`).
No sibling -> parent cycle.

## Local build status
- `dune build @check` on changed area: clean
- Pre-existing main breakages unchanged
- godfile lint: sibling 39 LOC well under `new_file_cap=600`; parent 1298 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim 3-helper move.

Co-Authored-By: codex <noreply@anthropic.com>
