### PR TITLE
test(dune): include timeout floor module

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -450,6 +450,7 @@
   test_fsm_drift_counter
   test_gc_sampler
   test_process_timeout_counter
+  test_timeout_floor
   test_git_fetch_timeout_9587
   test_inference_utils
   test_auth_ambiguous_lookup_9786


### PR DESCRIPTION
## Summary

- Add `test_timeout_floor` to the shared `test/dune` `modules` list.

## Product impact

Restores focused Dune build parsing for the shared test stanza after `test_timeout_floor` was present in `names` but absent from `modules`.

## Evidence

- `git diff --check origin/main...HEAD`
- `scripts/check-pr-hygiene.sh --base origin/main --head HEAD --duplicate-policy fail`
- Blocked: `scripts/dune-local.sh build test/test_timeout_floor.exe` was unable to complete because the machine-wide Dune lock was held by other long-running sessions.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 2/3
provenance: direct
stages:
  - name: whitespace
    command: git diff --check origin/main...HEAD
    result: pass
  - name: hygiene
    command: scripts/check-pr-hygiene.sh --base origin/main --head HEAD --duplicate-policy fail
    result: pass
  - name: focused_dune
    command: scripts/dune-local.sh build test/test_timeout_floor.exe
    result: blocked_by_machine_wide_dune_lock_contention
```

## Review evidence

- `test/test_timeout_floor.ml` exists.
- The same `tests` stanza already listed `test_timeout_floor` in `names`; this patch only aligns `modules`.

## Linked issue

N/A - local validation blocker found while processing the uncovered HTML queue.
