### PR TITLE
refactor(cascade_transport): extract per-keeper auth-bridging sibling (-51 LOC)

### DIFF
--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -130,61 +130,10 @@ let per_keeper_authorization_header = Cascade_transport_authorization.per_keeper
 let runtime_mcp_policy_uses_bound_actor_tools = Cascade_transport_authorization.runtime_mcp_policy_uses_bound_actor_tools
 let add_masc_authorization_header = Cascade_transport_authorization.add_masc_authorization_header
 
-let codex_cli_can_auth_keeper_bound_runtime_mcp ~agent_name policy =
-  runtime_mcp_policy_uses_bound_actor_tools policy
-  && Option.is_some (per_keeper_authorization_header ~agent_name)
-;;
-
-(* RFC-0058 §2.4 capability-driven projection.
-
-   Header lifecycle (in this order, no early exits):
-   1. [runtime_mcp_policy_without_http_headers] strips ALL HTTP headers
-      from every [Http_server] in the policy. This step is
-      unconditional — any inbound [Authorization] is gone before any
-      decision below.
-   2. [runtime_mcp_policy_with_masc_agent_name] re-injects only the
-      non-secret MASC identity headers.
-   3. The [Authorization] header is then sourced from one of two
-      branches:
-        - if [runtime_mcp_policy_uses_bound_actor_tools policy = true],
-          from [Auth.load_raw_token] via
-          [per_keeper_authorization_header ~agent_name];
-        - else, read from the *inbound* policy's [name = "masc"]
-          [Http_server] entry via [authorization_header_from_policy]
-          (which reads [policy.servers], not [stripped.servers], so it
-          recovers the MASC bearer that the caller provided).
-      When either branch yields [None], the returned policy carries no
-      [Authorization] header — there is no fall-through to the inbound
-      policy's non-masc headers, which were removed in step 1.
-
-   Invariant: this function is only reached from the dispatch site when the
-   provider-tool policy says per-keeper bridging is required, i.e. the runtime
-   cannot carry arbitrary per-request HTTP headers.  Body is intentionally
-   identical in semantics to the prior [codex_runtime_mcp_policy_for_agent] —
-   the rename removes the provider-name leak from the dispatch site without
-   altering behavior.
-
-   A future adapter with [requires_per_keeper_bridging = true] but
-   different transport semantics (e.g. native per-keeper header
-   injection) should be handled by an explicit dispatch arm at the
-   call site, not by adding a new flag parameter here — adding such
-   a flag now would introduce a code path no current provider exercises
-   and risks a silent header-preservation regression (see Copilot
-   review of PR #14885). *)
-let bridged_runtime_mcp_policy_for_agent ~agent_name policy =
-  let stripped =
-    runtime_mcp_policy_without_http_headers policy
-    |> runtime_mcp_policy_with_masc_agent_name ~include_internal_token:false ~agent_name
-  in
-  let authorization_header =
-    if runtime_mcp_policy_uses_bound_actor_tools policy
-    then per_keeper_authorization_header ~agent_name
-    else authorization_header_from_policy policy
-  in
-  match authorization_header with
-  | Some header -> add_masc_authorization_header header stripped
-  | None -> stripped
-;;
+(* Per-keeper authorization bridging extracted to
+   [Cascade_transport_auth_bridging] (godfile decomp). *)
+let codex_cli_can_auth_keeper_bound_runtime_mcp = Cascade_transport_auth_bridging.codex_cli_can_auth_keeper_bound_runtime_mcp
+let bridged_runtime_mcp_policy_for_agent = Cascade_transport_auth_bridging.bridged_runtime_mcp_policy_for_agent
 
 let runtime_mcp_policy_for_provider
       ~(provider_cfg : Llm_provider.Provider_config.t)

--- a/lib/cascade/cascade_transport_auth_bridging.ml
+++ b/lib/cascade/cascade_transport_auth_bridging.ml
@@ -1,0 +1,72 @@
+(** Per-keeper authorization bridging for runtime MCP policies.
+    Extracted from [cascade_transport.ml] (godfile decomp). Two
+    helpers:
+
+    - [codex_cli_can_auth_keeper_bound_runtime_mcp] — predicate that
+      decides whether the Codex CLI route can mint a per-keeper
+      Authorization header for a bound-actor MCP policy.
+
+    - [bridged_runtime_mcp_policy_for_agent] — the RFC-0058 §2.4
+      capability-driven projection: strip inbound HTTP headers,
+      re-inject MASC identity headers, and source the Authorization
+      header from the bound-actor branch or the inbound MASC entry. *)
+
+module Authorization = Cascade_transport_authorization
+module Mcp_policy_helpers = Cascade_transport_mcp_policy_helpers
+
+let codex_cli_can_auth_keeper_bound_runtime_mcp ~agent_name policy =
+  Authorization.runtime_mcp_policy_uses_bound_actor_tools policy
+  && Option.is_some (Authorization.per_keeper_authorization_header ~agent_name)
+;;
+
+(* RFC-0058 §2.4 capability-driven projection.
+
+   Header lifecycle (in this order, no early exits):
+   1. [runtime_mcp_policy_without_http_headers] strips ALL HTTP headers
+      from every [Http_server] in the policy. This step is
+      unconditional — any inbound [Authorization] is gone before any
+      decision below.
+   2. [runtime_mcp_policy_with_masc_agent_name] re-injects only the
+      non-secret MASC identity headers.
+   3. The [Authorization] header is then sourced from one of two
+      branches:
+        - if [runtime_mcp_policy_uses_bound_actor_tools policy = true],
+          from [Auth.load_raw_token] via
+          [per_keeper_authorization_header ~agent_name];
+        - else, read from the *inbound* policy's [name = "masc"]
+          [Http_server] entry via [authorization_header_from_policy]
+          (which reads [policy.servers], not [stripped.servers], so it
+          recovers the MASC bearer that the caller provided).
+      When either branch yields [None], the returned policy carries no
+      [Authorization] header — there is no fall-through to the inbound
+      policy's non-masc headers, which were removed in step 1.
+
+   Invariant: this function is only reached from the dispatch site when the
+   provider-tool policy says per-keeper bridging is required, i.e. the runtime
+   cannot carry arbitrary per-request HTTP headers.  Body is intentionally
+   identical in semantics to the prior [codex_runtime_mcp_policy_for_agent] —
+   the rename removes the provider-name leak from the dispatch site without
+   altering behavior.
+
+   A future adapter with [requires_per_keeper_bridging = true] but
+   different transport semantics (e.g. native per-keeper header
+   injection) should be handled by an explicit dispatch arm at the
+   call site, not by adding a new flag parameter here — adding such
+   a flag now would introduce a code path no current provider exercises
+   and risks a silent header-preservation regression (see Copilot
+   review of PR #14885). *)
+let bridged_runtime_mcp_policy_for_agent ~agent_name policy =
+  let stripped =
+    Mcp_policy_helpers.runtime_mcp_policy_without_http_headers policy
+    |> Mcp_policy_helpers.runtime_mcp_policy_with_masc_agent_name
+         ~include_internal_token:false ~agent_name
+  in
+  let authorization_header =
+    if Authorization.runtime_mcp_policy_uses_bound_actor_tools policy
+    then Authorization.per_keeper_authorization_header ~agent_name
+    else Authorization.authorization_header_from_policy policy
+  in
+  match authorization_header with
+  | Some header -> Authorization.add_masc_authorization_header header stripped
+  | None -> stripped
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane D
- 2nd sibling extracted from `cascade_transport.ml` (after #17303 `mcp_policy_helpers`).

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/cascade/cascade_transport.ml` | 1442 | 1391 | **-51** |
| `lib/cascade/cascade_transport_auth_bridging.ml` | — | 75 | +75 |

## Moved (verbatim, no behavior change)
- `codex_cli_can_auth_keeper_bound_runtime_mcp` — predicate gating the
  Codex CLI per-keeper bridging path (`uses_bound_actor_tools` AND
  `per_keeper_authorization_header` exists)
- `bridged_runtime_mcp_policy_for_agent` — RFC-0058 §2.4 capability-driven
  projection: strip all HTTP headers from inbound policy, re-inject MASC
  identity (without internal token), source Authorization from
  bound-actor or inbound MASC entry. 40-line invariant doc-comment
  preserved alongside the body.

Two single-line aliases in parent. `codex_cli_can_auth_keeper_bound_runtime_mcp`
is exposed via `.mli` (caller: `lib/cascade/cascade_runner.ml`);
`bridged_runtime_mcp_policy_for_agent` is local but aliased for symmetry.

## Sibling deps (all already pre-existing siblings)
- `module Authorization = Cascade_transport_authorization`
  - `runtime_mcp_policy_uses_bound_actor_tools`
  - `per_keeper_authorization_header`
  - `authorization_header_from_policy`
  - `add_masc_authorization_header`
- `module Mcp_policy_helpers = Cascade_transport_mcp_policy_helpers`
  - `runtime_mcp_policy_without_http_headers`
  - `runtime_mcp_policy_with_masc_agent_name`

No sibling -> parent cycle (parent had all 6 of these as 1-line aliases
to those same siblings; the new sibling calls those siblings directly).

## Local build status
- `dune build @check` on changed area: clean
- Pre-existing main breakages unchanged
- godfile lint: sibling 75 LOC under `new_file_cap=600`; parent 1391 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim 2-helper move, sibling-deps re-routed.

Co-Authored-By: codex <noreply@anthropic.com>
