### PR TITLE
refactor(server_dashboard_http_core): extract runtime helpers sibling (-31 LOC)

### DIFF
--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -10,44 +10,13 @@ type dashboard_compute_mode =
   | Inline_shared
   | Offloaded_readonly
 
-let runtime_support = Server_dashboard_http_runtime_support.default ()
-
-(** Executor pool for CPU-heavy dashboard compute.
-    Pool reference is shared via [Executor_pool_ref] in masc_core. *)
-let set_executor_pool = Server_dashboard_http_runtime_support.set_executor_pool
-
-let dashboard_runtime ?net ?mono_clock (config : Coord.config)
-  : Server_dashboard_http_runtime_support.runtime option
-  =
-  let _ = config in
-  match net, mono_clock with
-  | Some net, Some mono_clock -> Some { net; mono_clock }
-  | _ -> None
-;;
-
-let run_dashboard_compute
-      ?(mode = Offloaded_readonly)
-      ?net
-      ?mono_clock
-      ~sw
-      ~clock
-      ~(config : Coord.config)
-      compute
-  =
-  let runtime = dashboard_runtime ?net ?mono_clock config in
-  Server_dashboard_http_runtime_support.run_dashboard_compute
-    runtime_support
-    ~mode
-    ?runtime
-    ~sw
-    ~clock
-    ~config
-    compute
-;;
-
-let state_dashboard_runtime_caps (state : Mcp_server.server_state) =
-  state.Mcp_server.net, state.Mcp_server.mono_clock
-;;
+(* Dashboard runtime helpers extracted to
+   [Server_dashboard_http_core_runtime] (godfile decomp). *)
+let runtime_support = Server_dashboard_http_core_runtime.runtime_support
+let set_executor_pool = Server_dashboard_http_core_runtime.set_executor_pool
+let dashboard_runtime = Server_dashboard_http_core_runtime.dashboard_runtime
+let run_dashboard_compute = Server_dashboard_http_core_runtime.run_dashboard_compute
+let state_dashboard_runtime_caps = Server_dashboard_http_core_runtime.state_dashboard_runtime_caps
 
 (* ================================================================ *)
 (* Dashboard Data (Batch API)                                       *)

--- a/lib/server/server_dashboard_http_core_runtime.ml
+++ b/lib/server/server_dashboard_http_core_runtime.ml
@@ -1,0 +1,47 @@
+(** Dashboard HTTP compute-runtime bindings, extracted from
+    [server_dashboard_http_core.ml]. Holds the shared
+    [runtime_support] instance, [set_executor_pool] alias,
+    [dashboard_runtime] constructor, the [run_dashboard_compute]
+    dispatch wrapper, and the [state_dashboard_runtime_caps]
+    state-decomposer. *)
+
+open Server_dashboard_http_runtime_support
+
+let runtime_support = Server_dashboard_http_runtime_support.default ()
+
+(** Executor pool for CPU-heavy dashboard compute.
+    Pool reference is shared via [Executor_pool_ref] in masc_core. *)
+let set_executor_pool = Server_dashboard_http_runtime_support.set_executor_pool
+
+let dashboard_runtime ?net ?mono_clock (config : Coord.config)
+  : Server_dashboard_http_runtime_support.runtime option
+  =
+  let _ = config in
+  match net, mono_clock with
+  | Some net, Some mono_clock -> Some { net; mono_clock }
+  | _ -> None
+;;
+
+let run_dashboard_compute
+      ?(mode = Offloaded_readonly)
+      ?net
+      ?mono_clock
+      ~sw
+      ~clock
+      ~(config : Coord.config)
+      compute
+  =
+  let runtime = dashboard_runtime ?net ?mono_clock config in
+  Server_dashboard_http_runtime_support.run_dashboard_compute
+    runtime_support
+    ~mode
+    ?runtime
+    ~sw
+    ~clock
+    ~config
+    compute
+;;
+
+let state_dashboard_runtime_caps (state : Mcp_server.server_state) =
+  state.Mcp_server.net, state.Mcp_server.mono_clock
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane C
- 3rd sibling extracted from `server_dashboard_http_core.ml` (after #17274 meta_cognition and #17306 operator_query).

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/server/server_dashboard_http_core.ml` | 1453 | 1422 | **-31** |
| `lib/server/server_dashboard_http_core_runtime.ml` | — | 47 | +47 |

## Moved (verbatim, no behavior change)
- `runtime_support` — shared `Server_dashboard_http_runtime_support.default ()` singleton
- `set_executor_pool` — Eio executor-pool setter alias
- `dashboard_runtime` — `?net -> ?mono_clock -> Coord.config -> runtime option`
- `run_dashboard_compute` — `Offloaded_readonly` / `Inline_shared` dispatch wrapper
  around `Server_dashboard_http_runtime_support.run_dashboard_compute`
- `state_dashboard_runtime_caps` — `Mcp_server.server_state -> net * mono_clock`

Five single-line aliases in parent preserving the `.mli` surface
(`set_executor_pool` and `run_dashboard_compute` exposed via `.mli`;
caller: `test/test_dashboard_http_core.ml`).

## Cross-module type plumbing
Sibling does `open Server_dashboard_http_runtime_support` to bring the
`Inline_shared | Offloaded_readonly` constructors into scope (the
parent's transparent type alias `type dashboard_compute_mode = ...`
at line 8 stays in parent; the sibling doesn't see that alias). The
single qualified call `Server_dashboard_http_runtime_support.run_dashboard_compute`
remains qualified (local def with the same name would otherwise shadow).

## Sibling deps (all visible)
- `Server_dashboard_http_runtime_support` (open)
- `Coord.config`
- `Mcp_server.server_state`

No sibling -> parent cycle.

## Local build status
- `dune build @check` on changed area: clean
- Pre-existing main breakages unchanged
- godfile lint: sibling 47 LOC under `new_file_cap=600`; parent 1422 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim 5-binding move.

Co-Authored-By: codex <noreply@anthropic.com>
