### PR TITLE
fix(shell): dispatch worker shell exec via Shell IR

### DIFF
--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -44,7 +44,11 @@ let resolve_env env_bindings =
    [Exec_gate] (no behavior change for non-keeper callers); the Docker
    case is wired up by [lib/keeper] using a closure over
    [Keeper_turn_sandbox_runtime]. *)
-let dispatch_simple ?stdin_content (s : Shell_ir.simple) =
+let dispatch_timeout_sec = function
+  | Some timeout_sec -> timeout_sec
+  | None -> Env_config_exec_timeout.timeout_sec ~caller:Dispatch ()
+
+let dispatch_simple ?timeout_sec ?stdin_content (s : Shell_ir.simple) =
   let bin = Bin.to_string s.bin in
   let argv = bin :: List.map resolve_arg s.args in
   let env = resolve_env s.env in
@@ -53,54 +57,61 @@ let dispatch_simple ?stdin_content (s : Shell_ir.simple) =
     | None -> None
     | Some scope -> Some (Path_scope.raw scope)
   in
-  let timeout_sec = Env_config_exec_timeout.timeout_sec ~caller:Dispatch () in
+  let timeout_sec = dispatch_timeout_sec timeout_sec in
   match s.sandbox with
   | Host ->
       let raw_source = String.concat " " argv in
-      (match
-         match stdin_content with
-         | None ->
-           Exec_gate.run_argv_with_status_split
-             ~actor:`Tool_local_runtime
-             ~raw_source
-             ~summary:"exec dispatch simple"
-             ~timeout_sec ~env ?cwd argv
-         | Some stdin_content ->
-           Exec_gate.run_argv_with_stdin_and_status_split
-             ~actor:`Tool_local_runtime
-             ~raw_source
-             ~summary:"exec dispatch simple stdin"
-             ~timeout_sec ~env ?cwd ~stdin_content argv
-       with
+      let run () =
+        match stdin_content with
+        | None ->
+          Exec_gate.run_argv_with_status_split
+            ~actor:`Tool_local_runtime
+            ~raw_source
+            ~summary:"exec dispatch simple"
+            ~timeout_sec
+            ~env
+            ?cwd
+            argv
+        | Some stdin_content ->
+          Exec_gate.run_argv_with_stdin_and_status_split
+            ~actor:`Tool_local_runtime
+            ~raw_source
+            ~summary:"exec dispatch simple stdin"
+            ~timeout_sec
+            ~env
+            ?cwd
+            ~stdin_content
+            argv
+      in
+      (match run () with
+       | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
        | exception exn ->
-           { status = Unix.WEXITED 1;
-             stdout = "";
-             stderr = Printexc.to_string exn }
-       | (status, stdout, stderr) ->
-           { status; stdout; stderr })
+         { status = Unix.WEXITED 1; stdout = ""; stderr = Printexc.to_string exn }
+       | status, stdout, stderr -> { status; stdout; stderr })
   | Docker { runner; _ } ->
-      (match runner ~stdin_content ~argv ~env ~cwd ~timeout_sec with
-       | exception exn ->
-           { status = Unix.WEXITED 1;
-             stdout = "";
-             stderr = Printexc.to_string exn }
-       | (status, stdout, stderr) ->
-           { status; stdout; stderr })
+    (match runner ~stdin_content ~argv ~env ~cwd ~timeout_sec with
+     | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
+     | exception exn ->
+       { status = Unix.WEXITED 1; stdout = ""; stderr = Printexc.to_string exn }
+     | status, stdout, stderr -> { status; stdout; stderr })
 
 (* --- pipeline + entry point (mutually recursive) --- *)
 
-let rec dispatch_pipeline stages =
+let rec dispatch_pipeline ?timeout_sec stages =
   match stages with
   | [] ->
       { status = Unix.WEXITED 0; stdout = ""; stderr = "" }
-  | [ stage ] -> dispatch stage
+  | [ stage ] -> dispatch ?timeout_sec stage
   | _ ->
       let rec chain prev_stdout = function
         | [] ->
             { status = Unix.WEXITED 0; stdout = prev_stdout; stderr = "" }
-        | [ Shell_ir.Simple s ] -> dispatch_simple ~stdin_content:prev_stdout s
+        | [ Shell_ir.Simple s ] ->
+            dispatch_simple ?timeout_sec ~stdin_content:prev_stdout s
         | Shell_ir.Simple s :: rest ->
-            let stage_result = dispatch_simple ~stdin_content:prev_stdout s in
+            let stage_result =
+              dispatch_simple ?timeout_sec ~stdin_content:prev_stdout s
+            in
             let result = chain stage_result.stdout rest in
             let final_status =
               match stage_result.status with
@@ -117,20 +128,20 @@ let rec dispatch_pipeline stages =
       (match stages with
        | [] ->
            { status = Unix.WEXITED 0; stdout = ""; stderr = "" }
-       | first :: rest ->
-           (match first with
-            | Shell_ir.Simple s ->
-                let result = dispatch_simple s in
-                chain result.stdout rest
-            | Pipeline _ ->
-                { status = Unix.WEXITED 1;
-                  stdout = "";
-                  stderr = "nested pipeline not supported" }))
+       | first :: rest -> (
+         match first with
+         | Shell_ir.Simple s ->
+           let result = dispatch_simple ?timeout_sec s in
+           chain result.stdout rest
+         | Pipeline _ ->
+           { status = Unix.WEXITED 1;
+             stdout = "";
+             stderr = "nested pipeline not supported" }))
 
-and dispatch (ir : Shell_ir.t) =
+and dispatch ?timeout_sec (ir : Shell_ir.t) =
   match ir with
-  | Shell_ir.Simple s -> dispatch_simple s
-  | Pipeline stages -> dispatch_pipeline stages
+  | Shell_ir.Simple s -> dispatch_simple ?timeout_sec s
+  | Pipeline stages -> dispatch_pipeline ?timeout_sec stages
 
 let native_dispatch_enabled () =
   match Unix.getenv "MASC_BASH_NATIVE_DISPATCH" with

--- a/lib/exec/exec_dispatch.mli
+++ b/lib/exec/exec_dispatch.mli
@@ -7,16 +7,18 @@ type dispatch_result = {
 val resolve_arg : Shell_ir.arg -> string
 (** Resolve a Shell_ir.arg to a concrete string value. *)
 
-val dispatch : Shell_ir.t -> dispatch_result
+val dispatch : ?timeout_sec:float -> Shell_ir.t -> dispatch_result
 (** Execute a [Shell_ir.t] AST directly via Exec_gate without
     going through /bin/bash.  Simple commands use argv-based spawn;
-    pipelines chain stdout to stdin across stages. *)
+    pipelines chain stdout to stdin across stages.  [?timeout_sec]
+    overrides the dispatch default for every spawned stage. *)
 
 val dispatch_simple :
-  ?stdin_content:string -> Shell_ir.simple -> dispatch_result
+  ?timeout_sec:float -> ?stdin_content:string -> Shell_ir.simple -> dispatch_result
 (** Execute a simple command via argv-based spawn.  [stdin_content] is
     used by pipeline dispatch when a previous stage's stdout must be
-    forwarded without dropping the stage's sandbox target. *)
+    forwarded without dropping the stage's sandbox target.  [?timeout_sec]
+    overrides the dispatch default. *)
 
 val native_dispatch_enabled : unit -> bool
 (** Check [MASC_BASH_NATIVE_DISPATCH] env var.

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -5,8 +5,8 @@
     file modifications).
 
     file_read/file_write use OCaml stdlib (no Eio filesystem capability needed).
-    shell_exec validates commands locally and routes execution through
-    Exec_gate.
+    shell_exec validates commands locally with the Shell IR gate and routes
+    supported commands through Shell IR dispatch.
 
     Safety classification helpers are defined in [Shell_safety_types]
     and re-exported here for backward compat. *)
@@ -316,7 +316,7 @@ let block_reason_of_exec_too_complex
       | `Unknown_construct _ ) -> Injection
 ;;
 
-let validate_command_with_allowlist ?caller ~allowed_commands cmd =
+let command_context_with_allowlist ?caller ~allowed_commands cmd =
   let trimmed = String.trim cmd in
   if trimmed = ""
   then Error Empty_command
@@ -341,6 +341,11 @@ let validate_command_with_allowlist ?caller ~allowed_commands cmd =
       else Error (block_reason_of_exec_reject reason)
     | Cannot_parse _ -> Error Chain_or_redirect
     | Too_complex { reason } -> Error (block_reason_of_exec_too_complex reason))
+;;
+
+let validate_command_with_allowlist ?caller ~allowed_commands cmd =
+  command_context_with_allowlist ?caller ~allowed_commands cmd
+  |> Result.map (fun _ -> ())
 ;;
 
 let validate_command ?caller cmd =
@@ -1106,6 +1111,35 @@ let attribution_of_validation ~cmd (result : (unit, block_reason) result) : Attr
       ~reason:(block_reason_to_string br)
 ;;
 
+let shell_ir_with_default_cwd cwd ir =
+  match cwd with
+  | None -> ir
+  | Some dir ->
+    let default_cwd = Masc_exec.Path_scope.classify ~raw:dir ~cwd:dir in
+    let rec map_ir = function
+      | Masc_exec.Shell_ir.Simple simple ->
+        let simple =
+          match simple.cwd with
+          | Some _ -> simple
+          | None -> { simple with cwd = Some default_cwd }
+        in
+        Masc_exec.Shell_ir.Simple simple
+      | Masc_exec.Shell_ir.Pipeline stages ->
+        Masc_exec.Shell_ir.Pipeline (List.map map_ir stages)
+    in
+    map_ir ir
+;;
+
+let output_for_dispatch_status ~(status : Unix.process_status) ~stdout ~stderr =
+  match status with
+  | Unix.WEXITED 0 -> stdout
+  | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> (
+    match stdout, stderr with
+    | "", err -> err
+    | out, "" -> out
+    | out, err -> out ^ "\n" ^ err)
+;;
+
 let make_shell_exec_with_allowlist
       ~workdir
       ~on_exec
@@ -1134,9 +1168,12 @@ let make_shell_exec_with_allowlist
        match Worker_tool_input.extract_string "command" input with
        | Error e -> tool_error e
        | Ok command ->
-         let validation = validate_command_with_allowlist ~allowed_commands command in
+         let command_context =
+           command_context_with_allowlist ~allowed_commands command
+         in
+         let validation = Result.map (fun _ -> ()) command_context in
          Dashboard_attribution.record (attribution_of_validation ~cmd:command validation);
-         (match validation with
+         (match command_context with
           | Error reason ->
             (* #13078: emit [command_blocked] telemetry so observers
                see validation failures.  Without this, the .mli's
@@ -1155,7 +1192,7 @@ let make_shell_exec_with_allowlist
                    ())
               on_exec;
             tool_error (block_reason_to_string reason)
-          | Ok () ->
+          | Ok context ->
             let path_workdir =
               match workdir with
               | Some dir when String.trim dir <> "" -> dir
@@ -1175,114 +1212,118 @@ let make_shell_exec_with_allowlist
                  on_exec;
                tool_error message
              | Ok () ->
-              let timeout =
-                Worker_tool_input.extract_float "timeout_s" input
-                |> Option.value ~default:30.0
-                   (* DET-OK: fixed policy default for absent shell timeout. *)
-                |> Float.min 120.0
-              in
-              (try
-               let started = Time_compat.now () in
-               let record_result ?error_message result =
-                 let duration_ms =
-                   int_of_float ((Time_compat.now () -. started) *. 1000.0)
-                 in
-                 Option.iter
-                   (fun (f : tool_exec_observer) ->
-                      let success = Result.is_ok result in
-                      if success
-                      then f ~tool_name:"shell_exec" ~success:true ~duration_ms ()
-                      else
-                        f
-                          ~tool_name:"shell_exec"
-                          ~success:false
-                          ~duration_ms
-                          ~error_kind:Shell_error
-                          ?error_message
-                          ())
-                   on_exec;
-                 result
+               let timeout =
+                 Worker_tool_input.extract_float "timeout_s" input
+                 |> Option.value ~default:30.0
+                    (* DET-OK: fixed policy default for absent shell timeout. *)
+                 |> Float.min 120.0
                in
-               Tool_resource_gate.with_permit_raw
-                 ~clock
-                 ~tool_name:"shell_exec"
-                 ~arguments:input
-                 ~is_read_only:false
-                 ~on_reject:(fun message ->
-                   let message = "tool_resource_gate_saturated: " ^ message in
-                   record_result
-                     ~error_message:message
-                     (tool_error ~recoverable:true message))
-                 (fun () ->
-                    let cwd =
-                      match workdir with
-                      | Some dir when String.trim dir <> "" -> Some dir
-                      | Some _ | None -> None
+               (try
+                  let started = Time_compat.now () in
+                  let record_result ?error_message result =
+                    let duration_ms =
+                      int_of_float ((Time_compat.now () -. started) *. 1000.0)
                     in
-                    let argv = [ (Host_config.host ()).host_sh; "-c"; command ] in
-                    let raw_source =
-                      String.concat " " (List.map Filename.quote argv)
-                    in
-                    let result =
-                      try
-                        let status, output =
-                          Fd_accountant.with_slot ~kind:Sandbox_exec (fun () ->
-                            Masc_exec.Exec_gate.run_argv_with_status
-                              ~actor:`Tool_local_runtime
-                              ~raw_source
-                              ~summary:"worker shell_exec command execution"
-                              ~timeout_sec:timeout
-                              ?cwd
-                              argv)
-                        in
-                        match status with
-                        | Unix.WEXITED 0 -> Ok { Agent_sdk.Types.content = output }
-                        | Unix.WEXITED 124 ->
-                          tool_error
-                            ~recoverable:true
-                            (Printf.sprintf
-                               "Timeout after %.0fs: %s\n%s"
-                               timeout
-                               command
-                               output)
-                        | Unix.WEXITED code ->
-                          tool_error (Printf.sprintf "Exit code %d:\n%s" code output)
-                        | Unix.WSIGNALED sig_num ->
-                          tool_error
-                            ~recoverable:(sig_num = Sys.sigterm)
-                            (Printf.sprintf "Killed by signal %d:\n%s" sig_num output)
-                        | Unix.WSTOPPED sig_num ->
-                          tool_error
-                            ~recoverable:true
-                            (Printf.sprintf "Stopped by signal %d:\n%s" sig_num output)
-                      with
-                      | Eio.Time.Timeout ->
-                        tool_error
-                          ~recoverable:true
-                          (Printf.sprintf
-                             "Timeout after %.0fs: %s\n%s"
-                             timeout
-                             command
-                             "")
-                    in
-                    record_result result)
-             with
-             | Eio.Cancel.Cancelled _ as e -> raise e
-             | exn ->
-               let duration_ms = 0 in
-               let exn_msg = Printexc.to_string exn in
-               Option.iter
-                 (fun (f : tool_exec_observer) ->
-                    f
-                      ~tool_name:"shell_exec"
-                      ~success:false
-                      ~duration_ms
-                      ~error_kind:Shell_error
-                      ~error_message:exn_msg
-                      ())
-                 on_exec;
-               tool_error (Printf.sprintf "Command failed: %s" exn_msg))))
-            )
+                    Option.iter
+                      (fun (f : tool_exec_observer) ->
+                         let success = Result.is_ok result in
+                         if success
+                         then f ~tool_name:"shell_exec" ~success:true ~duration_ms ()
+                         else
+                           f
+                             ~tool_name:"shell_exec"
+                             ~success:false
+                             ~duration_ms
+                             ~error_kind:Shell_error
+                             ?error_message
+                             ())
+                      on_exec;
+                    result
+                  in
+                  Tool_resource_gate.with_permit_raw
+                    ~clock
+                    ~tool_name:"shell_exec"
+                    ~arguments:input
+                    ~is_read_only:false
+                    ~on_reject:(fun message ->
+                      let message = "tool_resource_gate_saturated: " ^ message in
+                      record_result
+                        ~error_message:message
+                        (tool_error ~recoverable:true message))
+                    (fun () ->
+                       let cwd =
+                         match workdir with
+                         | Some dir when String.trim dir <> "" -> Some dir
+                         | Some _ | None -> None
+                       in
+                       let result =
+                         try
+                           let dispatch_result =
+                             Fd_accountant.with_slot ~kind:Sandbox_exec (fun () ->
+                               let dispatch_ir =
+                                 shell_ir_with_default_cwd
+                                   cwd
+                                   context.Exec_shell_gate.ast
+                               in
+                               Masc_exec.Exec_dispatch.dispatch
+                                 ~timeout_sec:timeout
+                                 dispatch_ir)
+                           in
+                           let output =
+                             output_for_dispatch_status
+                               ~status:dispatch_result.status
+                               ~stdout:dispatch_result.stdout
+                               ~stderr:dispatch_result.stderr
+                           in
+                           match dispatch_result.status with
+                           | Unix.WEXITED 0 -> Ok { Agent_sdk.Types.content = output }
+                           | Unix.WEXITED 124 ->
+                             tool_error
+                               ~recoverable:true
+                               (Printf.sprintf
+                                  "Timeout after %.0fs: %s\n%s"
+                                  timeout
+                                  command
+                                  output)
+                           | Unix.WEXITED code ->
+                             tool_error (Printf.sprintf "Exit code %d:\n%s" code output)
+                           | Unix.WSIGNALED sig_num ->
+                             tool_error
+                               ~recoverable:(sig_num = Sys.sigterm)
+                               (Printf.sprintf
+                                  "Killed by signal %d:\n%s"
+                                  sig_num
+                                  output)
+                           | Unix.WSTOPPED sig_num ->
+                             tool_error
+                               ~recoverable:true
+                               (Printf.sprintf
+                                  "Stopped by signal %d:\n%s"
+                                  sig_num
+                                  output)
+                         with
+                         | Eio.Time.Timeout ->
+                           tool_error
+                             ~recoverable:true
+                             (Printf.sprintf "Timeout after %.0fs: %s\n%s" timeout command "")
+                       in
+                       record_result result)
+                with
+                | Eio.Cancel.Cancelled _ as e -> raise e
+                | exn ->
+                  let duration_ms = 0 in
+                  let exn_msg = Printexc.to_string exn in
+                  Option.iter
+                    (fun (f : tool_exec_observer) ->
+                       f
+                         ~tool_name:"shell_exec"
+                         ~success:false
+                         ~duration_ms
+                         ~error_kind:Shell_error
+                         ~error_message:exn_msg
+                         ())
+                    on_exec;
+                  tool_error (Printf.sprintf "Command failed: %s" exn_msg)))))
 ;;
 
 let make_shell_exec ~workdir ~on_exec ~proc_mgr ~clock =
@@ -1295,8 +1336,8 @@ let make_shell_exec ~workdir ~on_exec ~proc_mgr ~clock =
     ~description:
       "Execute a shell command and return stdout+stderr. Timeout: 30s default, max 120s. \
        Use for: running tests, git commands, build tools, directory listing. Unlike \
-       file_read (single file), this handles approved CLI operations. Commands run in \
-       /bin/sh but shell control syntax is rejected."
+       file_read (single file), this handles approved CLI operations. Supported commands \
+       run through Shell IR native dispatch; shell control syntax is rejected."
     ()
 ;;
 

--- a/test/dune
+++ b/test/dune
@@ -451,6 +451,7 @@
   test_gc_sampler
   test_process_timeout_counter
   test_timeout_floor
+  test_timeout_origin
   test_git_fetch_timeout_9587
   test_inference_utils
   test_auth_ambiguous_lookup_9786

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -349,7 +349,7 @@ let test_shell_exec_echo () =
    | Error { Agent_sdk.Types.message = e; _ } ->
      Alcotest.fail (Printf.sprintf "expected Ok, got Error: %s" e))
 
-let test_shell_exec_uses_exec_gate_cwd () =
+let test_shell_exec_uses_shell_ir_dispatch_cwd () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let proc_mgr = Eio.Stdenv.process_mgr env in
@@ -382,7 +382,18 @@ let test_shell_exec_uses_exec_gate_cwd () =
          (match process_line with
           | None -> Alcotest.fail "shell_exec did not route through Exec_gate/Process_eio"
           | Some line ->
-            Alcotest.(check bool) "cwd recorded" true (contains_substring line ("\"cwd\":\"" ^ workdir ^ "\""));
+            Alcotest.(check bool)
+              "cwd recorded"
+              true
+              (contains_substring line ("\"cwd\":\"" ^ workdir ^ "\""));
+            Alcotest.(check bool)
+              "direct pwd argv"
+              true
+              (contains_substring line "\"argv\":[\"pwd\"]");
+            Alcotest.(check bool)
+              "no sh -c wrapper"
+              false
+              (contains_substring line "\"-c\"");
             Alcotest.(check bool) "no cd wrapper" false (contains_substring line "cd ")))
 
 let test_shell_exec_blocked_command () =
@@ -680,8 +691,8 @@ let () =
     ];
     "shell_exec", [
       Alcotest.test_case "echo hello" `Quick test_shell_exec_echo;
-      Alcotest.test_case "uses Exec_gate cwd" `Quick
-        test_shell_exec_uses_exec_gate_cwd;
+      Alcotest.test_case "uses Shell IR dispatch cwd" `Quick
+        test_shell_exec_uses_shell_ir_dispatch_cwd;
       Alcotest.test_case "blocked command" `Quick test_shell_exec_blocked_command;
       Alcotest.test_case "env wrapper blocked command" `Quick
         test_shell_exec_blocks_env_wrapped_disallowed_command;


### PR DESCRIPTION
Summary:
- reuse Shell_command_gate parsed context for worker shell_exec execution
- route supported commands through Exec_dispatch with workdir and timeout preservation
- strengthen Exec_tap coverage to prove direct argv and no sh -c wrapper

Validation:
- ocamlformat --check lib/exec/exec_dispatch.ml lib/exec/exec_dispatch.mli lib/worker_dev_tools.ml test/test_worker_dev_tools.ml
- git diff --check origin/main...HEAD
- bash scripts/lint-spawn-bounded.sh
- bash scripts/lint/shell-legacy-purge-ratchet.sh
- focused dune build blocked by current main: Unbound module Timeout_origin in lib/process/process_eio.mli