### PR TITLE
[codex] Harden dashboard doctor argv

### DIFF
--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -466,12 +466,11 @@ let rec add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/dashboard/doctor" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          let self_bin = Sys.argv.(0) in
-         let cmd =
-           Printf.sprintf "%s doctor all --json" (Filename.quote self_bin)
-         in
          try
            let buf, _status =
-             With_process.with_process_in cmd
+             With_process.with_process_args_in
+               self_bin
+               [| self_bin; "doctor"; "all"; "--json" |]
                (With_process.drain_to_buffer ~chunk:4096)
            in
            Http.Response.json

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -2207,6 +2207,14 @@ let test_worktree_list_contracts () =
      file_not_contains_pattern "lib/tool_worktree.ml"
        {|"masc_worktree_remove"; "masc_worktree_list"|})
 
+let test_dashboard_doctor_route_process_contracts () =
+  check bool "dashboard doctor route uses argv process" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_dashboard.ml"
+       "With_process.with_process_args_in"
+    && file_contains_pattern "lib/server/server_routes_http_routes_dashboard.ml"
+         {|[| self_bin; "doctor"; "all"; "--json" |]|}
+    && file_not_contains_pattern "lib/server/server_routes_http_routes_dashboard.ml"
+         {|doctor all --json|})
 
 let test_oas_worker_capability_threading_contracts () =
   check bool "oas worker model-by-label accepts threaded sw capability" true
@@ -2701,6 +2709,8 @@ let () =
              test_http_cancel_response_contracts;
            test_case "worktree list contracts" `Quick
              test_worktree_list_contracts;
+           test_case "dashboard doctor route process contracts" `Quick
+             test_dashboard_doctor_route_process_contracts;
            test_case "oas worker capability threading contracts" `Quick
              test_oas_worker_capability_threading_contracts;
            test_case "oas capacity restore contracts" `Quick


### PR DESCRIPTION
## Summary

- replace `/api/v1/dashboard/doctor` shell-command execution with `With_process.with_process_args_in`
- pass the self binary and `doctor all --json` as exact argv instead of a quoted command string
- add a source guard so the route stays on argv execution

## Validation

- `opam exec -- ocamlformat --check lib/server/server_routes_http_routes_dashboard.ml test/test_ci_hardening_source.ml`
- `git diff --check origin/main...HEAD`
- `scripts/lint-spawn-bounded.sh`
- `bash scripts/lint/shell-legacy-purge-ratchet.sh`
- `scripts/check-oas-pin.sh`
- `rg -n -- 'doctor all --json|With_process\\.with_process_in cmd|Printf\\.sprintf.*doctor all' lib/server/server_routes_http_routes_dashboard.ml`

Focused Dune build was attempted with `lockf -k -t 5 /tmp/me-dune-local.lock scripts/dune-local.sh build test/test_ci_hardening_source.exe`, but local wrapper refused to start because bare Dune processes were already running outside `scripts/dune-local.sh`.
