### PR TITLE
refactor(keeper_supervisor): extract reconcile_keepalive_keepers sibling (-54 LOC)

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -751,68 +751,14 @@ let restore_reconcile_continue_gate (ctx : _ context) (meta : keeper_meta) =
     and must NOT be re-launched by reconcile. Stopped entries with
     unresolved fibers (done_p = None) are also skipped — sweep will
     handle them once the fiber terminates. *)
+(* Phase 4 reconciliation extracted to
+   [Keeper_supervisor_reconcile_keepalive] (godfile decomp).
+   publish_lifecycle + supervise_keepalive injected to avoid cycle. *)
 let reconcile_keepalive_keepers (ctx : _ context) =
-  let base_path = ctx.config.base_path in
-  let names = Keeper_types.keepalive_keeper_names ctx.config in
-  Log.Keeper.debug
-    "reconcile_keepalive_keepers: started (candidates=%d)"
-    (List.length names);
-  let t0 = Time_compat.now () in
-  let reconcile_ym = Eio_guard.create_yield_meter () in
-  List.iter
-    (fun name ->
-       (match read_meta ctx.config name with
-        | Ok (Some meta) when not meta.paused ->
-          let dominated_by_sweep =
-            match Keeper_registry.get ~base_path meta.name with
-            | None -> false (* no entry = orphaned, reconcile OK *)
-            | Some e ->
-              (match e.phase with
-               | Keeper_state_machine.Running | Keeper_state_machine.Paused -> true
-               | Keeper_state_machine.Crashed
-               | Keeper_state_machine.Dead
-               | Keeper_state_machine.Zombie -> true
-               | Keeper_state_machine.Failing
-               | Keeper_state_machine.Overflowed
-               | Keeper_state_machine.Compacting
-               | Keeper_state_machine.HandingOff
-               | Keeper_state_machine.Draining
-               | Keeper_state_machine.Restarting -> true
-               | Keeper_state_machine.Offline -> false
-               | Keeper_state_machine.Stopped ->
-                 (* Stopped with unresolved fiber → sweep will clean up *)
-                 Eio.Promise.peek e.done_p = None)
-          in
-          if not dominated_by_sweep
-          then (
-            supervise_keepalive ~proactive_warmup_sec:0 ctx meta;
-            if Keeper_registry.is_running ~base_path meta.name
-            then (
-              publish_lifecycle
-                ~event:
-                  (Keeper_lifecycle_events.Custom_event
-                     { verb = Keeper_lifecycle_events.Reconciled
-                     ; phase = Some Keeper_state_machine.Running
-                     })
-                meta.name
-                "durable keeper"
-                ();
-              Log.Keeper.info "%s: reconciled durable keeper" meta.name))
-        | Ok (Some _meta) -> () (* paused, skip *)
-        | Ok None -> ()
-        | Error err ->
-          Prometheus.inc_counter
-            Keeper_metrics.metric_keeper_observation_query_failures
-            ~labels:
-              [ ("operation", Keeper_observation_query_operation.(to_label Reconcile_read_meta))
-              ]
-            ();
-          Log.Keeper.warn "reconcile: read_meta failed for %s: %s" name err);
-       Eio_guard.yield_step reconcile_ym)
-    names;
-  Log.Keeper.debug
-    "reconcile_keepalive_keepers: completed (elapsed_ms=%d)"
-    (int_of_float ((Time_compat.now () -. t0) *. 1000.0))
+  Keeper_supervisor_reconcile_keepalive.reconcile_keepalive_keepers
+    ~publish_lifecycle
+    ~supervise_keepalive
+    ctx
 ;;
 
 (* Dead-tombstone cleanup extracted to

--- a/lib/keeper/keeper_supervisor_reconcile_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_reconcile_keepalive.ml
@@ -1,0 +1,75 @@
+(** Phase 4 keepalive reconciliation pass for the supervisor.
+    Extracted from [keeper_supervisor.ml] (godfile decomp). The
+    extractor uses callback injection (publish_lifecycle and
+    supervise_keepalive) to avoid sibling -> parent cycles, mirroring
+    the [Keeper_supervisor_cleanup_tombstone] sibling. *)
+
+open Keeper_types
+
+let reconcile_keepalive_keepers
+      ~publish_lifecycle
+      ~supervise_keepalive
+      (ctx : _ context)
+  =
+  let base_path = ctx.config.base_path in
+  let names = Keeper_types.keepalive_keeper_names ctx.config in
+  Log.Keeper.debug
+    "reconcile_keepalive_keepers: started (candidates=%d)"
+    (List.length names);
+  let t0 = Time_compat.now () in
+  let reconcile_ym = Eio_guard.create_yield_meter () in
+  List.iter
+    (fun name ->
+       (match read_meta ctx.config name with
+        | Ok (Some meta) when not meta.paused ->
+          let dominated_by_sweep =
+            match Keeper_registry.get ~base_path meta.name with
+            | None -> false (* no entry = orphaned, reconcile OK *)
+            | Some e ->
+              (match e.phase with
+               | Keeper_state_machine.Running | Keeper_state_machine.Paused -> true
+               | Keeper_state_machine.Crashed
+               | Keeper_state_machine.Dead
+               | Keeper_state_machine.Zombie -> true
+               | Keeper_state_machine.Failing
+               | Keeper_state_machine.Overflowed
+               | Keeper_state_machine.Compacting
+               | Keeper_state_machine.HandingOff
+               | Keeper_state_machine.Draining
+               | Keeper_state_machine.Restarting -> true
+               | Keeper_state_machine.Offline -> false
+               | Keeper_state_machine.Stopped ->
+                 (* Stopped with unresolved fiber → sweep will clean up *)
+                 Eio.Promise.peek e.done_p = None)
+          in
+          if not dominated_by_sweep
+          then (
+            supervise_keepalive ~proactive_warmup_sec:0 ctx meta;
+            if Keeper_registry.is_running ~base_path meta.name
+            then (
+              publish_lifecycle
+                ~event:
+                  (Keeper_lifecycle_events.Custom_event
+                     { verb = Keeper_lifecycle_events.Reconciled
+                     ; phase = Some Keeper_state_machine.Running
+                     })
+                meta.name
+                "durable keeper"
+                ();
+              Log.Keeper.info "%s: reconciled durable keeper" meta.name))
+        | Ok (Some _meta) -> () (* paused, skip *)
+        | Ok None -> ()
+        | Error err ->
+          Prometheus.inc_counter
+            Keeper_metrics.metric_keeper_observation_query_failures
+            ~labels:
+              [ ("operation", Keeper_observation_query_operation.(to_label Reconcile_read_meta))
+              ]
+            ();
+          Log.Keeper.warn "reconcile: read_meta failed for %s: %s" name err);
+       Eio_guard.yield_step reconcile_ym)
+    names;
+  Log.Keeper.debug
+    "reconcile_keepalive_keepers: completed (elapsed_ms=%d)"
+    (int_of_float ((Time_compat.now () -. t0) *. 1000.0))
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane B
- 2nd sibling extracted from `keeper_supervisor.ml` (after #17291 `cleanup_dead_tombstone`).
- Used same callback-injection pattern as #17291 to avoid sibling -> parent cycles.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/keeper/keeper_supervisor.ml` | 1535 | 1481 | **-54** |
| `lib/keeper/keeper_supervisor_reconcile_keepalive.ml` | — | 77 | +77 |

## Moved (verbatim, no behavior change)
- `reconcile_keepalive_keepers` — Phase 4 keepalive reconciliation pass:
  - Walks `Keeper_types.keepalive_keeper_names ctx.config`
  - Reads each keeper meta; skips paused
  - Filters out phases dominated by supervisor sweep (Running/Paused/Crashed/
    Dead/Zombie/Failing/Overflowed/Compacting/HandingOff/Draining/Restarting)
  - For Stopped: checks `Eio.Promise.peek e.done_p = None` to confirm
    unresolved fiber
  - Dispatches `supervise_keepalive ~proactive_warmup_sec:0`
  - Emits `Custom_event { verb = Reconciled; phase = Some Running }` on
    successful registry re-bind
  - Increments `metric_keeper_observation_query_failures` with
    `operation=Reconcile_read_meta` label on `read_meta` errors

Parent retains a 5-line wrapper that injects its local
`publish_lifecycle` and `supervise_keepalive`. Single internal caller
(`sweep_and_recover` at parent line 1513) sees an unchanged interface.

## Callback-injection pattern (mirror of #17291)
Sibling signature:
```ocaml
val reconcile_keepalive_keepers :
  publish_lifecycle:(event:Keeper_lifecycle_events.lifecycle_event ->
                     string -> string -> unit -> unit) ->
  supervise_keepalive:(proactive_warmup_sec:int -> _ context ->
                       keeper_meta -> unit) ->
  _ context -> unit
```

Parent adapter:
```ocaml
let reconcile_keepalive_keepers (ctx : _ context) =
  Keeper_supervisor_reconcile_keepalive.reconcile_keepalive_keepers
    ~publish_lifecycle
    ~supervise_keepalive
    ctx
```

## Sibling deps (all visible)
- `open Keeper_types` — for `read_meta`, `'a context`, `keeper_meta`,
  `keepalive_keeper_names`
- `Keeper_registry.{get,is_running}`
- `Keeper_state_machine` phase variants
- `Keeper_lifecycle_events.{Custom_event,Reconciled}`
- `Keeper_observation_query_operation.{to_label,Reconcile_read_meta}`
- `Keeper_metrics.metric_keeper_observation_query_failures`
- `Log.Keeper.{debug,info,warn}`
- `Time_compat.now`
- `Eio_guard.{create_yield_meter,yield_step}`
- `Eio.Promise.peek`
- `Prometheus.inc_counter`

No sibling -> parent cycle (both parent-local helpers are passed as
labeled args).

## Local build status
- `dune build @check` on changed area: clean
- Pre-existing main breakages unchanged
- godfile lint: sibling 77 LOC under `new_file_cap=600`; parent 1481 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim function body + 2-callback injection.

Co-Authored-By: codex <noreply@anthropic.com>
