### PR TITLE
refactor(keeper_heartbeat_loop): extract collect_keepalive_board_events sibling (-26 LOC)

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -19,35 +19,9 @@ let keeper_agent_status = Keeper_heartbeat_loop_presence.keeper_agent_status
 let note_turn_failures_preserved_after_heartbeat = Keeper_heartbeat_loop_presence.note_turn_failures_preserved_after_heartbeat
 let sync_keeper_presence = Keeper_heartbeat_loop_presence.sync_keeper_presence
 
-let collect_keepalive_board_events
-      ~(ctx : _ context)
-      ~(meta_current : keeper_meta)
-      ~(proactive_warmup_elapsed : bool)
-  =
-  if not proactive_warmup_elapsed
-  then [], meta_current
-  else (
-    let pending_board_events =
-      try
-        let events, _new_count, _mention_count =
-          Keeper_world_observation.collect_board_events
-            ~base_path:ctx.config.base_path
-            ~meta:meta_current
-            ~continuity_summary:meta_current.continuity_summary
-        in
-        events
-      with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn ->
-        Log.Keeper.warn "keepalive: board count query failed: %s" (Printexc.to_string exn);
-        Prometheus.inc_counter
-          Keeper_metrics.metric_keeper_heartbeat_failures
-          ~labels:[ "keeper", meta_current.name; "phase", "board_count_query" ]
-          ();
-        []
-    in
-    pending_board_events, meta_current)
-;;
+(* Pending board-event collection extracted to
+   [Keeper_heartbeat_loop_board_events] (godfile decomp). *)
+let collect_keepalive_board_events = Keeper_heartbeat_loop_board_events.collect_keepalive_board_events
 
 let in_turn_liveness_pulse_interval_sec =
   Keeper_heartbeat_loop_in_turn_pulse.in_turn_liveness_pulse_interval_sec

--- a/lib/keeper/keeper_heartbeat_loop_board_events.ml
+++ b/lib/keeper/keeper_heartbeat_loop_board_events.ml
@@ -1,0 +1,41 @@
+(** Pending board-event collection for the keeper heartbeat loop.
+    Extracted from [keeper_heartbeat_loop.ml] (godfile decomp).
+
+    Single helper that, once the proactive-warmup phase has elapsed,
+    queries [Keeper_world_observation.collect_board_events] for the
+    keeper's pending board events and returns them paired with the
+    current meta. Cancellation is re-raised; any other exception is
+    logged + counted via the heartbeat-failure Prometheus counter
+    (phase="board_count_query") and treated as zero pending events. *)
+
+open Keeper_types
+
+let collect_keepalive_board_events
+      ~(ctx : _ context)
+      ~(meta_current : keeper_meta)
+      ~(proactive_warmup_elapsed : bool)
+  =
+  if not proactive_warmup_elapsed
+  then [], meta_current
+  else (
+    let pending_board_events =
+      try
+        let events, _new_count, _mention_count =
+          Keeper_world_observation.collect_board_events
+            ~base_path:ctx.config.base_path
+            ~meta:meta_current
+            ~continuity_summary:meta_current.continuity_summary
+        in
+        events
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+        Log.Keeper.warn "keepalive: board count query failed: %s" (Printexc.to_string exn);
+        Prometheus.inc_counter
+          Keeper_metrics.metric_keeper_heartbeat_failures
+          ~labels:[ "keeper", meta_current.name; "phase", "board_count_query" ]
+          ();
+        []
+    in
+    pending_board_events, meta_current)
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane B
- 3rd sibling extracted from `keeper_heartbeat_loop.ml` (after #17296 `keepalive_scheduling` and #17320 `presence`).

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/keeper/keeper_heartbeat_loop.ml` | 1266 | 1240 | **-26** |
| `lib/keeper/keeper_heartbeat_loop_board_events.ml` | — | 41 | +41 |

## Moved (verbatim, no behavior change)
- `collect_keepalive_board_events` — proactive-warmup-gated collector:
  - If `proactive_warmup_elapsed = false`, returns `([], meta_current)`
  - Otherwise calls `Keeper_world_observation.collect_board_events`
    with `~base_path` / `~meta` / `~continuity_summary`
  - Returns `(events, meta_current)` discarding new_count/mention_count
  - On `Eio.Cancel.Cancelled _`: re-raises (cancellation safety)
  - On other exceptions: logs WARN + increments
    `metric_keeper_heartbeat_failures` (phase="board_count_query"),
    returns `([], meta_current)`

One single-line alias in parent preserving `.mli` surface (function is
exposed via `.mli`; single internal caller at parent line 1160 sees
unchanged interface).

## Sibling deps (all visible)
- `open Keeper_types` — for `'a context`, `keeper_meta`
- `Keeper_world_observation.collect_board_events`
- `Eio.Cancel.Cancelled`
- `Log.Keeper.warn`
- `Prometheus.inc_counter`
- `Keeper_metrics.metric_keeper_heartbeat_failures`
- `Printexc.to_string`

No sibling -> parent cycle.

## Local build status
- `dune build @check` on changed area: clean
- Pre-existing main breakages unchanged
- godfile lint: sibling 41 LOC under `new_file_cap=600`; parent 1240 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim single-function move.

Co-Authored-By: codex <noreply@anthropic.com>
