### PR TITLE
feat(keeper): gate task claims by WIP admission

### DIFF
--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -294,6 +294,7 @@ let claim_next_r
       ?agent_tool_names
       ?(exclude_task_ids = [])
       ?(task_filter = fun _ -> true)
+      ?(admission_filter = fun ~active_tasks:_ _ -> true)
       ()
   =
   let exception Existing_claim of claim_next_result in
@@ -363,6 +364,14 @@ let claim_next_r
                    })));
         let observe_legacy_release () = () in
         let released_task_id, working_tasks = None, backlog.tasks in
+        let active_admission_tasks =
+          List.filter
+            (fun (task : Masc_domain.task) ->
+               match task.task_status with
+               | Claimed _ | InProgress _ -> true
+               | _ -> false)
+            working_tasks
+        in
         (* Starvation prevention: Calculate effective priority
          Tasks waiting >24h get priority boost (-1 per 24h, min 1) *)
         let now = Time_compat.now () in
@@ -479,6 +488,15 @@ let claim_next_r
           required_tools_allowed_for_agent required_tools
           && not (receipt_blocks_task task)
         in
+        let admission_decisions = Hashtbl.create 16 in
+        let admission_allowed task =
+          match Hashtbl.find_opt admission_decisions task.id with
+          | Some allowed -> allowed
+          | None ->
+            let allowed = admission_filter ~active_tasks:active_admission_tasks task in
+            Hashtbl.replace admission_decisions task.id allowed;
+            allowed
+        in
         let required_tool_excluded =
           List.filter
             (fun (t : task) ->
@@ -501,11 +519,13 @@ let claim_next_r
                 ; "ts", `String (now_iso ())
                 ]);
         let effective_task_filter task =
-          task_filter task && required_tool_claim_allowed task
+          task_filter task && admission_allowed task && required_tool_claim_allowed task
         in
         let task_filter_excluded =
           List.filter
-            (fun (t : task) -> (not (List.mem t.id all_excluded)) && not (task_filter t))
+            (fun (t : task) ->
+               (not (List.mem t.id all_excluded))
+               && ((not (task_filter t)) || not (admission_allowed t)))
             unclaimed
         in
         let eligible_from candidates =

--- a/lib/coord/coord_task_schedule.mli
+++ b/lib/coord/coord_task_schedule.mli
@@ -109,6 +109,8 @@ val claim_next_r
   -> ?agent_tool_names:string list
   -> ?exclude_task_ids:string list
   -> ?task_filter:(Masc_domain.task -> bool)
+  -> ?admission_filter:
+       (active_tasks:Masc_domain.task list -> Masc_domain.task -> bool)
   -> unit
   -> Masc_domain.claim_next_result
 

--- a/lib/dune
+++ b/lib/dune
@@ -649,5 +649,3 @@
    )
  (preprocess (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq ppx_let ppx_tla))
  (instrumentation (backend bisect_ppx)))
- 
-; Core library for MASC MCP

--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -224,6 +224,47 @@ let required_tool_workflow_rejection config ~agent_tool_names claim_goal_scope =
            (String.concat ", " missing)))
 ;;
 
+let wip_admission_default_repo config =
+  Keeper_alerting_path.project_root_of_config config |> Filename.basename
+;;
+
+let wip_admission_rejection_json
+      (task_id, (rejection : Keeper_wip_admission.rejection))
+  =
+  `Assoc
+    [ "task_id", `String task_id
+    ; "reason", `String (Keeper_wip_admission.reject_reason_to_string rejection.reason)
+    ; "current", `Int rejection.current
+    ; "limit", `Int rejection.limit
+    ; "scope_key", `String rejection.scope_key
+    ]
+;;
+
+let wip_admission_rejection_action = function
+  | [] -> None
+  | (task_id, (rejection : Keeper_wip_admission.rejection)) :: _ ->
+    Some
+      (Printf.sprintf
+         "WIP admission rejected task %s: %s current=%d limit=%d scope=%s. ACTION: finish/release existing WIP in this scope before claiming more."
+         task_id
+         (Keeper_wip_admission.reject_reason_to_string rejection.reason)
+         rejection.current
+         rejection.limit
+         rejection.scope_key)
+;;
+
+let wip_admission_result_fields rejections =
+  match rejections with
+  | [] -> []
+  | rejections ->
+    [ ( "wip_admission"
+      , `Assoc
+          [ "rejected_count", `Int (List.length rejections)
+          ; "rejections", `List (List.map wip_admission_rejection_json rejections)
+          ] )
+    ]
+;;
+
 let find_task_goal_id config task_id =
   Coord.get_tasks_raw config
   |> List.find_map (fun (task : Masc_domain.task) ->
@@ -425,10 +466,34 @@ let handle_keeper_task_tool
         ~meta
         ()
     in
+    let wip_default_repo = wip_admission_default_repo config in
+    let wip_rejections = ref [] in
+    let remember_wip_rejection task_id rejection =
+      if not (List.exists (fun (existing_id, _) -> String.equal existing_id task_id) !wip_rejections)
+      then wip_rejections := (task_id, rejection) :: !wip_rejections
+    in
+    let wip_admission_filter ~active_tasks task =
+      let active_items =
+        Keeper_wip_admission.active_items_of_tasks
+          ~default_repo:wip_default_repo
+          active_tasks
+      in
+      let scope =
+        Keeper_wip_admission.scope_of_task ~default_repo:wip_default_repo task
+      in
+      match Keeper_wip_admission.decide active_items ~scope with
+      | Keeper_wip_admission.Admit _ -> true
+      | Keeper_wip_admission.Reject rejection ->
+        remember_wip_rejection task.id rejection;
+        false
+    in
     let result =
       Coord.claim_next_r config ~agent_name:meta.agent_name ~agent_tool_names
-        ~task_filter:claim_goal_scope.task_filter ()
+        ~task_filter:claim_goal_scope.task_filter
+        ~admission_filter:wip_admission_filter
+        ()
     in
+    let wip_rejections = List.rev !wip_rejections in
     let auto_started_ok = ref false in
     (match result with
      | Coord.Claim_next_claimed { task_id; _ } ->
@@ -470,15 +535,18 @@ let handle_keeper_task_tool
           ; _
           } ->
         let action =
-          match
-            required_tool_workflow_rejection
-              config
-              ~agent_tool_names
-              claim_goal_scope
-          with
+          match wip_admission_rejection_action wip_rejections with
           | Some rejection -> rejection
           | None ->
-            no_eligible_action_for_claim_scope claim_goal_scope ~excluded_count
+            (match
+               required_tool_workflow_rejection
+                 config
+                 ~agent_tool_names
+                 claim_goal_scope
+             with
+             | Some rejection -> rejection
+             | None ->
+               no_eligible_action_for_claim_scope claim_goal_scope ~excluded_count)
         in
         Printf.sprintf
           "No eligible tasks%s. %s %s"
@@ -556,6 +624,7 @@ let handle_keeper_task_tool
             ("auto_started", `Bool !auto_started_ok);
           ]
          @ claimed_task_fields
+         @ wip_admission_result_fields wip_rejections
          @
          match accountability_warning with
          | Some warning -> [ ("routing_warning", `String warning) ]

--- a/lib/keeper/keeper_wip_admission.ml
+++ b/lib/keeper/keeper_wip_admission.ml
@@ -35,11 +35,36 @@ let category_of_string value =
   | "" -> Other "other"
   | value -> Other value
 
+let title_category title =
+  let normalized = normalize title in
+  let stop =
+    [ String.index_opt normalized ':'
+    ; String.index_opt normalized '('
+    ; String.index_opt normalized ' '
+    ]
+    |> List.filter_map Fun.id
+    |> function
+    | [] -> String.length normalized
+    | positions -> List.fold_left min max_int positions
+  in
+  if stop <= 0 then Other "other" else String.sub normalized 0 stop |> category_of_string
+
 type scope = {
   repo : string;
   goal_id : string option;
   category : category;
 }
+
+let task_repo ~default_repo (task : Masc_domain.task) =
+  match task.worktree with
+  | Some { repo_name; _ } when normalize repo_name <> "" -> repo_name
+  | _ -> default_repo
+
+let scope_of_task ~default_repo (task : Masc_domain.task) =
+  { repo = task_repo ~default_repo task
+  ; goal_id = task.goal_id
+  ; category = title_category task.title
+  }
 
 type caps = {
   max_global : int option;
@@ -59,6 +84,22 @@ type active_item = {
   id : string;
   scope : scope;
 }
+
+let task_is_active_wip (task : Masc_domain.task) =
+  match task.task_status with
+  | Masc_domain.Claimed _ | Masc_domain.InProgress _ -> true
+  | Masc_domain.Todo
+  | Masc_domain.AwaitingVerification _
+  | Masc_domain.Done _
+  | Masc_domain.Cancelled _ -> false
+
+let active_item_of_task ~default_repo (task : Masc_domain.task) =
+  { id = task.id; scope = scope_of_task ~default_repo task }
+
+let active_items_of_tasks ~default_repo tasks =
+  tasks
+  |> List.filter task_is_active_wip
+  |> List.map (active_item_of_task ~default_repo)
 
 type reject_reason =
   | Global_cap

--- a/lib/keeper/keeper_wip_admission.mli
+++ b/lib/keeper/keeper_wip_admission.mli
@@ -12,12 +12,15 @@ type category =
 
 val category_to_string : category -> string
 val category_of_string : string -> category
+val title_category : string -> category
 
 type scope = {
   repo : string;
   goal_id : string option;
   category : category;
 }
+
+val scope_of_task : default_repo:string -> Masc_domain.task -> scope
 
 type caps = {
   max_global : int option;
@@ -32,6 +35,10 @@ type active_item = {
   id : string;
   scope : scope;
 }
+
+val task_is_active_wip : Masc_domain.task -> bool
+val active_item_of_task : default_repo:string -> Masc_domain.task -> active_item
+val active_items_of_tasks : default_repo:string -> Masc_domain.task list -> active_item list
 
 type reject_reason =
   | Global_cap

--- a/lib/operator/operator_control_snapshot_identity_fields.mli
+++ b/lib/operator/operator_control_snapshot_identity_fields.mli
@@ -1,0 +1,7 @@
+(** Keeper runtime identity field builders for operator control snapshots. *)
+
+val non_empty_trimmed_string_opt : string -> string option
+val keeper_runtime_identity_fields : Keeper_types.keeper_meta -> (string * Yojson.Safe.t) list
+
+val degraded_keeper_runtime_identity_fields :
+  Keeper_types.keeper_meta -> (string * Yojson.Safe.t) list

--- a/lib/operator/operator_control_snapshot_runtime_status.mli
+++ b/lib/operator/operator_control_snapshot_runtime_status.mli
@@ -1,0 +1,15 @@
+(** Runtime-status alignment helpers for operator control snapshots. *)
+
+val runtime_status_from_live_signal : Yojson.Safe.t -> string option
+val health_state_allows_runtime_status_override : Yojson.Safe.t -> bool
+
+val align_keeper_runtime_status :
+     surface_status:string
+  -> diagnostic:Yojson.Safe.t
+  -> agent_status_json:Yojson.Safe.t
+  -> keepalive_running:bool
+  -> string
+
+val remote_client_type_of_context : 'a Operator_pending_confirm.context -> string
+val max_turns_override_source : int option -> string
+val operator_server_profile_json : Yojson.Safe.t

--- a/test/test_claim_post_provision_hook.ml
+++ b/test/test_claim_post_provision_hook.ml
@@ -95,6 +95,34 @@ let test_claim_next_hook_failure_is_observed () =
   | Coord.Claim_next_error msg ->
     failf "claim_next unexpectedly failed: %s" msg
 
+let test_claim_next_admission_filter_blocks_claim () =
+  with_test_env @@ fun config ->
+  let _ = Coord.add_task config ~title:"admission gated" ~priority:1 ~description:"" in
+  let admission_calls = ref 0 in
+  let result =
+    Coord.claim_next_r
+      config
+      ~agent_name:"claude"
+      ~admission_filter:(fun ~active_tasks:_ task ->
+        incr admission_calls;
+        not (String.equal task.Masc_domain.id "task-001"))
+      ()
+  in
+  (match result with
+   | Coord.Claim_next_no_eligible { scope_excluded_count; claim_pool_candidate_count; _ } ->
+     check int "scope/admission excluded" 1 scope_excluded_count;
+     check int "claim pool count" 1 claim_pool_candidate_count
+   | Coord.Claim_next_claimed { task_id; _ } ->
+     failf "admission filter should block claim, got %s" task_id
+   | Coord.Claim_next_no_unclaimed ->
+     fail "expected no_eligible, got no_unclaimed"
+   | Coord.Claim_next_error msg ->
+     failf "claim_next unexpectedly failed: %s" msg);
+  check int "admission filter called once" 1 !admission_calls;
+  match Coord.get_tasks_raw config with
+  | [ { Masc_domain.task_status = Masc_domain.Todo; _ } ] -> ()
+  | _ -> fail "admission-filtered task must remain Todo"
+
 let test_hook_not_invoked_on_already_claimed () =
   with_test_env @@ fun config ->
   let _ = Coord.add_task config ~title:"task-103 t3" ~priority:1 ~description:"" in
@@ -121,6 +149,8 @@ let () =
             test_hook_failure_does_not_block_claim;
           test_case "observes claim_next hook failure" `Quick
             test_claim_next_hook_failure_is_observed;
+          test_case "admission filter blocks claim_next" `Quick
+            test_claim_next_admission_filter_blocks_claim;
           test_case "skips already-claimed repeat" `Quick
             test_hook_not_invoked_on_already_claimed;
         ] );

--- a/test/test_keeper_task_dispatch.ml
+++ b/test/test_keeper_task_dispatch.ml
@@ -526,6 +526,59 @@ let test_claim_returns_observation_fragment () =
         |> to_string))
 ;;
 
+let test_claim_reports_wip_admission_rejection () =
+  with_room (fun config ->
+    let meta = make_test_meta () in
+    let add_active idx =
+      let title = Printf.sprintf "fix: active WIP %d" idx in
+      let _ = Coord.add_task config ~title ~priority:1 ~description:"desc" in
+      set_task_status_by_title
+        config
+        ~title
+        ~task_status:
+          (Masc_domain.Claimed
+             { assignee = Printf.sprintf "other-%d" idx; claimed_at = "now" })
+    in
+    add_active 1;
+    add_active 2;
+    add_active 3;
+    let _ =
+      Coord.add_task
+        config
+        ~title:"fix: blocked by admission"
+        ~priority:1
+        ~description:"desc"
+    in
+    let result = call_tool config meta "keeper_task_claim" (`Assoc []) in
+    let json = parse_json result in
+    check
+      bool
+      "result mentions wip admission"
+      true
+      Yojson.Safe.Util.(
+        json |> member "result" |> to_string
+        |> Astring.String.is_infix ~affix:"WIP admission rejected task");
+    check
+      int
+      "rejected count"
+      1
+      Yojson.Safe.Util.(json |> member "wip_admission" |> member "rejected_count" |> to_int);
+    check
+      string
+      "reason"
+      "goal_cap"
+      Yojson.Safe.Util.(
+        json
+        |> member "wip_admission"
+        |> member "rejections"
+        |> index 0
+        |> member "reason"
+        |> to_string);
+    match task_by_title config "fix: blocked by admission" with
+    | { Masc_domain.task_status = Masc_domain.Todo; _ } -> ()
+    | _ -> fail "admission-rejected task must remain Todo")
+;;
+
 let test_claim_syncs_keeper_current_task_id () =
   with_room (fun config ->
     let meta = make_test_meta () in
@@ -2758,6 +2811,10 @@ let () =
             "claim returns observation fragment"
             `Quick
             test_claim_returns_observation_fragment
+        ; test_case
+            "claim reports WIP admission rejection"
+            `Quick
+            test_claim_reports_wip_admission_rejection
         ; test_case
             "claim syncs keeper current_task_id"
             `Quick

--- a/test/test_keeper_wip_admission.ml
+++ b/test/test_keeper_wip_admission.ml
@@ -8,6 +8,31 @@ let scope ?goal_id ?(category = Admission.Fix) repo =
 let item ?goal_id ?(category = Admission.Fix) repo id =
   { Admission.id; scope = scope ?goal_id ~category repo }
 
+let task ?worktree ?goal_id ?(status = Masc_domain.Todo) ?(title = "fix: task") id =
+  { Masc_domain.id
+  ; title
+  ; description = ""
+  ; task_status = status
+  ; priority = 3
+  ; files = []
+  ; created_at = "2026-05-21T00:00:00Z"
+  ; created_by = None
+  ; worktree
+  ; goal_id
+  ; stage = None
+  ; contract = None
+  ; handoff_context = None
+  ; cycle_count = 0
+  ; do_not_reclaim_reason = None
+  }
+
+let worktree repo_name =
+  { Masc_domain.branch = "branch"
+  ; path = "/tmp/worktree"
+  ; git_root = "/tmp/repo"
+  ; repo_name
+  }
+
 let caps =
   { Admission.max_global = Some 10
   ; max_per_repo = Some 2
@@ -87,6 +112,41 @@ let test_decision_json_rejects_with_scope_key () =
   check string "scope key" "global"
     Yojson.Safe.Util.(json |> member "scope_key" |> to_string)
 
+let test_scope_of_task_uses_repo_goal_and_title_category () =
+  let scope =
+    Admission.scope_of_task
+      ~default_repo:"fallback"
+      (task
+         ~worktree:(worktree "masc-mcp")
+         ~goal_id:"goal-a"
+         ~title:"refactor(keeper): split claim gate"
+         "task-001")
+  in
+  check string "repo" "masc-mcp" scope.repo;
+  check (option string) "goal" (Some "goal-a") scope.goal_id;
+  check string "category" "refactor" (Admission.category_to_string scope.category)
+
+let test_active_items_only_include_claimed_or_in_progress () =
+  let tasks =
+    [ task
+        ~status:(Masc_domain.Claimed { assignee = "a"; claimed_at = "now" })
+        ~goal_id:"goal-a"
+        "task-001"
+    ; task
+        ~status:(Masc_domain.InProgress { assignee = "b"; started_at = "now" })
+        ~title:"docs: update runbook"
+        "task-002"
+    ; task ~title:"fix: still todo" "task-003"
+    ]
+  in
+  let active = Admission.active_items_of_tasks ~default_repo:"fallback" tasks in
+  check (list string) "active ids" [ "task-001"; "task-002" ]
+    (List.map (fun item -> item.Admission.id) active);
+  check (list string) "categories" [ "fix"; "docs" ]
+    (List.map
+       (fun item -> Admission.category_to_string item.Admission.scope.category)
+       active)
+
 let () =
   run "Keeper_wip_admission"
     [ ( "caps"
@@ -100,5 +160,9 @@ let () =
             test_active_counts_surface_all_axes
         ; test_case "decision JSON rejects with scope key" `Quick
             test_decision_json_rejects_with_scope_key
+        ; test_case "task scope uses repo goal and title category" `Quick
+            test_scope_of_task_uses_repo_goal_and_title_category
+        ; test_case "active items include active WIP only" `Quick
+            test_active_items_only_include_claimed_or_in_progress
         ] )
     ]


### PR DESCRIPTION
## Summary

- Thread WIP admission into `claim_next_r` via an optional admission filter over active WIP tasks.
- Wire `keeper_task_claim` through the WIP admission gate and surface structured rejection details.
- Add pure, Coord-level, and keeper-tool regression coverage; restore current OCaml structure ratchet.

## Product impact

- User-visible change: keeper task claiming now refuses over-cap WIP scopes and tells the operator which task/scope hit the cap.

## Evidence

- `git diff --check origin/main...HEAD`
- `ocamlformat --check lib/coord/coord_task_schedule.ml lib/coord/coord_task_schedule.mli lib/keeper/keeper_wip_admission.ml lib/keeper/keeper_wip_admission.mli lib/keeper/keeper_exec_task.ml test/test_keeper_wip_admission.ml test/test_claim_post_provision_hook.ml test/test_keeper_task_dispatch.ml lib/operator/operator_control_snapshot_identity_fields.mli lib/operator/operator_control_snapshot_runtime_status.mli`
- `scripts/ocaml-structure-ratchet.sh`
- `scripts/check-pr-hygiene.sh --base origin/main --head HEAD`

Blocked locally:

- `scripts/dune-local.sh build test/test_keeper_wip_admission.exe test/test_claim_post_provision_hook.exe test/test_keeper_task_dispatch.exe` refused to start because other bare Dune builds were active outside `scripts/dune-local.sh`.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 4/5
provenance: mixed
stages:
  - stage: diff-whitespace
    provenance: operator_proxy
    command: git diff --check origin/main...HEAD
    result: pass
  - stage: format
    provenance: operator_proxy
    command: ocamlformat --check focused OCaml files
    result: pass
  - stage: structure-ratchet
    provenance: operator_proxy
    command: scripts/ocaml-structure-ratchet.sh
    result: pass
  - stage: pr-hygiene
    provenance: operator_proxy
    command: scripts/check-pr-hygiene.sh --base origin/main --head HEAD
    result: pass
  - stage: focused-dune
    provenance: operator_proxy
    command: scripts/dune-local.sh build test/test_keeper_wip_admission.exe test/test_claim_post_provision_hook.exe test/test_keeper_task_dispatch.exe
    result: blocked_by_existing_bare_dune_processes
```

## GOAL LOOP ACT checklist

- [x] Observe — existing pure WIP admission policy was merged but claim-path wiring was absent.
- [x] Orient — this PR maps the policy into the keeper claim path without changing the policy caps.
- [x] Decide — bounded next action is claim admission gating plus rejection evidence.
- [x] Act — code and tests changed in Coord claim scheduling, keeper task execution, and focused tests.
- [x] Verify — local static/format/ratchet/hygiene checks passed; focused Dune is queued for CI because local wrapper refused while bare builds are active.
- [x] Loop — no additional follow-up filed from this slice.

## Review evidence

- Cross-model review not run locally.

## Linked issue

- Closes #
- Relates #17159

## Variant addition checklist

- [ ] **OCaml** — N/A: no variant was added, removed, or renamed.
- [ ] **TypeScript** — N/A: no TypeScript union member changed.
- [ ] **TLA+ spec** — N/A: no TLA+ domain literal changed.
- [ ] **Event / JSON schema** — N/A: no schema enum changed.
- [ ] **`make check-variants` passes** — N/A: no variant/schema enum changed.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/wip-admission-claim-gate-20260521` → `main` · 2 commit(s) · synced 2026-05-21T08:37:08Z

| sha | subject | date |
|---|---|---|
| `c46b95223` | chore(ci): restore ocaml structure ratchet | 2026-05-21 |
| `800b5dcc4` | feat(keeper): gate task claims by WIP admission | 2026-05-21 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->