### PR TITLE
refactor(cascade_transport): extract runtime_mcp_policy_for_provider sibling (-45 LOC)

### DIFF
--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -135,55 +135,10 @@ let add_masc_authorization_header = Cascade_transport_authorization.add_masc_aut
 let codex_cli_can_auth_keeper_bound_runtime_mcp = Cascade_transport_auth_bridging.codex_cli_can_auth_keeper_bound_runtime_mcp
 let bridged_runtime_mcp_policy_for_agent = Cascade_transport_auth_bridging.bridged_runtime_mcp_policy_for_agent
 
-let runtime_mcp_policy_for_provider
-      ~(provider_cfg : Llm_provider.Provider_config.t)
-      ~(agent_name : string)
-      (policy_opt : Llm_provider.Llm_transport.runtime_mcp_policy option)
-  =
-  let agent_name =
-    let trimmed = String.trim agent_name in
-    if String.equal trimmed "" then None else Some trimmed
-  in
-  (* Dispatch by local tool-delivery policy, not by provider name
-     (RFC-0058 §2.4).  [requires_per_keeper_bridging] gates the
-     strip-and-bridge path. *)
-  let requires_per_keeper_bridging =
-    Provider_tool_support
-    .provider_requires_per_keeper_bridging_for_bound_actor_tools
-      provider_cfg
-  in
-  match policy_opt, requires_per_keeper_bridging, agent_name with
-  | Some policy, true, Some agent_name ->
-    (* Per-request HTTP headers are stripped and only MASC identity headers
-         plus the per-keeper [Authorization] header survive — so runtime MCP
-         tools still authenticate without leaking secrets via argv. *)
-    Some (bridged_runtime_mcp_policy_for_agent ~agent_name policy)
-  | Some policy, true, None ->
-    (* No agent_name to inject — preserve the legacy strip-all behavior.
-       Iter 38: tick a counter so a non-zero rate flags caller paths
-       that should be threading [agent_name] but aren't.  Strip-all
-       means auth-bearing headers (e.g. Authorization: Bearer ...)
-       disappear and runtime MCP tools run unauthenticated. *)
-    Cascade_metrics.on_runtime_mcp_legacy_strip ();
-    Some (runtime_mcp_policy_without_http_headers policy)
-  | Some policy, false, Some agent_name ->
-    Some (runtime_mcp_policy_with_masc_agent_name ~agent_name policy)
-  | Some policy, false, None -> Some policy
-  | None, _, _ -> None
-;;
-
-let cli_runtime_mcp_jsons
-      ~(base : string list)
-      (policy_opt : Llm_provider.Llm_transport.runtime_mcp_policy option)
-  =
-  let request_json =
-    match policy_opt with
-    | Some policy -> Option.to_list (cli_mcp_config_json_of_policy policy)
-    | None -> []
-  in
-  dedupe_preserve_order (base @ request_json)
-;;
-
+(* Provider-driven runtime MCP policy resolver extracted to
+   [Cascade_transport_runtime_policy_provider] (godfile decomp). *)
+let runtime_mcp_policy_for_provider = Cascade_transport_runtime_policy_provider.runtime_mcp_policy_for_provider
+let cli_runtime_mcp_jsons = Cascade_transport_runtime_policy_provider.cli_runtime_mcp_jsons
 let public_mcp_tool_names_of_oas_tools =
   Cascade_transport_mcp_tool_classifier.public_mcp_tool_names_of_oas_tools
 ;;

--- a/lib/cascade/cascade_transport_runtime_policy_provider.ml
+++ b/lib/cascade/cascade_transport_runtime_policy_provider.ml
@@ -1,0 +1,84 @@
+(** Provider-driven runtime MCP policy resolver + CLI JSON merger,
+    extracted from [cascade_transport.ml] (godfile decomp). Two
+    helpers:
+
+    - [runtime_mcp_policy_for_provider] — RFC-0058 §2.4 dispatch by
+      local tool-delivery policy ([requires_per_keeper_bridging]),
+      not by provider name. Resolves the policy through one of four
+      branches based on the (policy, bridging_required, agent_name)
+      triple. Tracks legacy strip-all path via
+      [Cascade_metrics.on_runtime_mcp_legacy_strip].
+
+    - [cli_runtime_mcp_jsons] — merges a [~base] list of MCP JSON
+      strings with the [cli_mcp_config_json_of_policy] projection of
+      a runtime MCP policy, deduping while preserving the original
+      order. *)
+
+module Mcp_policy_helpers = Cascade_transport_mcp_policy_helpers
+module Auth_bridging = Cascade_transport_auth_bridging
+module Cli_mcp_config_json = Cascade_transport_cli_mcp_config_json
+
+(* Duplicated locally to avoid sibling -> parent cycle. The parent
+   keeps its own copy because three other sites there call it; both
+   copies are identical 11-line list-dedup helpers. *)
+let dedupe_preserve_order (items : string list) =
+  let seen = Hashtbl.create (List.length items) in
+  List.filter
+    (fun item ->
+       if Hashtbl.mem seen item
+       then false
+       else (
+         Hashtbl.add seen item ();
+         true))
+    items
+;;
+
+let runtime_mcp_policy_for_provider
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+      ~(agent_name : string)
+      (policy_opt : Llm_provider.Llm_transport.runtime_mcp_policy option)
+  =
+  let agent_name =
+    let trimmed = String.trim agent_name in
+    if String.equal trimmed "" then None else Some trimmed
+  in
+  (* Dispatch by local tool-delivery policy, not by provider name
+     (RFC-0058 §2.4).  [requires_per_keeper_bridging] gates the
+     strip-and-bridge path. *)
+  let requires_per_keeper_bridging =
+    Provider_tool_support
+    .provider_requires_per_keeper_bridging_for_bound_actor_tools
+      provider_cfg
+  in
+  match policy_opt, requires_per_keeper_bridging, agent_name with
+  | Some policy, true, Some agent_name ->
+    (* Per-request HTTP headers are stripped and only MASC identity headers
+         plus the per-keeper [Authorization] header survive — so runtime MCP
+         tools still authenticate without leaking secrets via argv. *)
+    Some (Auth_bridging.bridged_runtime_mcp_policy_for_agent ~agent_name policy)
+  | Some policy, true, None ->
+    (* No agent_name to inject — preserve the legacy strip-all behavior.
+       Iter 38: tick a counter so a non-zero rate flags caller paths
+       that should be threading [agent_name] but aren't.  Strip-all
+       means auth-bearing headers (e.g. Authorization: Bearer ...)
+       disappear and runtime MCP tools run unauthenticated. *)
+    Cascade_metrics.on_runtime_mcp_legacy_strip ();
+    Some (Mcp_policy_helpers.runtime_mcp_policy_without_http_headers policy)
+  | Some policy, false, Some agent_name ->
+    Some (Mcp_policy_helpers.runtime_mcp_policy_with_masc_agent_name ~agent_name policy)
+  | Some policy, false, None -> Some policy
+  | None, _, _ -> None
+;;
+
+let cli_runtime_mcp_jsons
+      ~(base : string list)
+      (policy_opt : Llm_provider.Llm_transport.runtime_mcp_policy option)
+  =
+  let request_json =
+    match policy_opt with
+    | Some policy -> Option.to_list (Cli_mcp_config_json.cli_mcp_config_json_of_policy policy)
+    | None -> []
+  in
+  dedupe_preserve_order (base @ request_json)
+;;
+


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane D
- 3rd sibling extracted from `cascade_transport.ml` (after #17303 `mcp_policy_helpers` and #17333 `auth_bridging`).

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/cascade/cascade_transport.ml` | 1391 | 1346 | **-45** |
| `lib/cascade/cascade_transport_runtime_policy_provider.ml` | — | 83 | +83 |

## Moved (verbatim, no behavior change)
- `runtime_mcp_policy_for_provider` — RFC-0058 §2.4 dispatcher:
  1. trims agent_name to `string option`
  2. asks `Provider_tool_support.provider_requires_per_keeper_bridging_for_bound_actor_tools`
  3. matches `(policy_opt, requires_per_keeper_bridging, agent_name)`:
     - `Some, true, Some` → bridged-and-bound
     - `Some, true, None` → strip-all + tick legacy counter (Iter 38)
     - `Some, false, Some` → masc agent_name injection
     - `Some, false, None` → passthrough
     - `None, _, _` → None
- `cli_runtime_mcp_jsons` — merges `~base` JSON list with policy projection
  via `cli_mcp_config_json_of_policy`, deduping while preserving order

Two single-line aliases in parent preserving `.mli` surface. External
callers (all keep working unchanged via aliases):
- `test/test_oas_worker.ml` → `Cascade_transport.cli_runtime_mcp_jsons`
- `lib/cascade/cascade_runner.ml` → `Cascade_transport.runtime_mcp_policy_for_provider`

## Cycle-avoidance pattern
`dedupe_preserve_order` (11-line helper) is duplicated in the sibling
rather than reaching back into parent. Both copies are byte-identical
`Hashtbl.create` + `List.filter` pattern. The parent keeps its copy
because three other sites there call it (lines 222 / 348 / 408).

## Sibling deps (all already pre-existing siblings)
- `module Mcp_policy_helpers = Cascade_transport_mcp_policy_helpers`
  - `runtime_mcp_policy_without_http_headers`
  - `runtime_mcp_policy_with_masc_agent_name`
- `module Auth_bridging = Cascade_transport_auth_bridging`
  - `bridged_runtime_mcp_policy_for_agent`
- `module Cli_mcp_config_json = Cascade_transport_cli_mcp_config_json`
  - `cli_mcp_config_json_of_policy`
- `Provider_tool_support.provider_requires_per_keeper_bridging_for_bound_actor_tools`
- `Cascade_metrics.on_runtime_mcp_legacy_strip`
- `Llm_provider.Provider_config.t`, `Llm_provider.Llm_transport.runtime_mcp_policy`

No sibling -> parent cycle.

## Local build status
- `dune build @check` on changed area: clean
- Pre-existing main breakages unchanged
- godfile lint: sibling 83 LOC under `new_file_cap=600`; parent 1346 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim 2-helper move + documented helper duplication.

Co-Authored-By: codex <noreply@anthropic.com>
