### PR TITLE
refactor(keeper_supervisor): extract resume_keeper_after_reconcile_gate sibling

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -612,77 +612,10 @@ let supervise_keepalive ~proactive_warmup_sec (ctx : _ context) (meta : keeper_m
 ;;
 
 let resume_keeper_after_reconcile_gate (ctx : _ context) (meta : keeper_meta) =
-  let latest_meta =
-    match read_meta ctx.config meta.name with
-    | Ok (Some latest) -> latest
-    | _ -> meta
-  in
-  let resumed_meta =
-    { latest_meta with
-      paused = false
-    ; updated_at = now_iso ()
-    ; runtime = { latest_meta.runtime with last_blocker = None }
-    }
-  in
-  (* #9733: same race shape as keeper_msg/overflow-pause/sync paths
-     already migrated by #10135 / #10145.  The supervisor reconcile
-     fiber clears [paused] and [runtime.last_blocker] (cycle-owned
-     fields); a heartbeat fiber bumping [joined_room_ids] /
-     [last_seen_seq_by_room] in parallel can still steal the CAS
-     write and silently leave the keeper paused while
-     [Keeper_registry.update_meta] applies the resume in-memory —
-     a registry/disk split that hides the failure. *)
-  (match
-     write_meta_with_merge
-       ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
-       ctx.config
-       resumed_meta
-   with
-   | Ok () -> ()
-   | Error err when is_version_conflict_error err ->
-     Prometheus.inc_counter
-       Keeper_metrics.metric_keeper_write_meta_failures
-       ~labels:[ "keeper", resumed_meta.name; "phase", "reconcile_resume_cas_race" ]
-       ();
-     Log.Keeper.warn
-       "%s: reconcile gate resume write_meta lost CAS race after retries: %s"
-       resumed_meta.name
-       err
-   | Error err ->
-     Prometheus.inc_counter
-       Keeper_metrics.metric_keeper_write_meta_failures
-       ~labels:[ "keeper", resumed_meta.name; "phase", "reconcile_resume" ]
-       ();
-     Log.Keeper.error
-       "%s: reconcile gate resume write_meta failed: %s"
-       resumed_meta.name
-       err);
-  Keeper_registry.update_meta
-    ~base_path:ctx.config.base_path
-    resumed_meta.name
-    resumed_meta;
-  Keeper_registry.set_failure_reason
-    ~base_path:ctx.config.base_path
-    resumed_meta.name
-    None;
-  Keeper_registry.reset_turn_failures ~base_path:ctx.config.base_path resumed_meta.name;
-  Keeper_turn_livelock.reset_keeper_livelock ~keeper:resumed_meta.name;
-  (* ETA-LIVELOCK: keep typed-escalation classifier aligned with the
-     resume path so the resumed keeper's first livelock block emits at
-     ERROR (not silently demoted to DEBUG from a previous lifetime). *)
-  Keeper_livelock_state.reset_for_keeper ~keeper:resumed_meta.name;
-  Keeper_registry.dispatch_event_unit
-    ~base_path:ctx.config.base_path
-    resumed_meta.name
-    Keeper_state_machine.Operator_resume;
-  match Keeper_registry.get ~base_path:ctx.config.base_path resumed_meta.name with
-  | Some entry when Option.is_none (Eio.Promise.peek entry.done_p) ->
-    (* tla-lint: allow-mutation: fiber signal — wake the keeper after operator resume *)
-    Atomic.set entry.fiber_wakeup true
-  | Some _ ->
-    Keeper_registry.unregister ~base_path:ctx.config.base_path resumed_meta.name;
-    supervise_keepalive ~proactive_warmup_sec:0 ctx resumed_meta
-  | None -> supervise_keepalive ~proactive_warmup_sec:0 ctx resumed_meta
+  Keeper_supervisor_resume_reconcile_gate.resume_keeper_after_reconcile_gate
+    ~supervise_keepalive
+    ctx
+    meta
 ;;
 
 let restore_reconcile_continue_gate (ctx : _ context) (meta : keeper_meta) =

--- a/lib/keeper/keeper_supervisor_resume_reconcile_gate.ml
+++ b/lib/keeper/keeper_supervisor_resume_reconcile_gate.ml
@@ -1,0 +1,90 @@
+(** Reconcile-gate resume path, extracted from
+    [keeper_supervisor.ml] (godfile decomp).
+
+    [resume_keeper_after_reconcile_gate] clears the [paused] flag and
+    [runtime.last_blocker] on the latest disk meta, writes back through
+    [Keeper_meta_merge.heartbeat_fields_from_disk] to avoid stealing
+    concurrent heartbeat writes (cf. #9733), resets the keeper's
+    livelock/turn-failure state, dispatches [Operator_resume], and
+    either wakes the existing supervised fiber or re-launches keepalive
+    via the injected [~supervise_keepalive] callback. *)
+
+open Keeper_types
+
+let resume_keeper_after_reconcile_gate
+      ~(supervise_keepalive : proactive_warmup_sec:int -> _ context -> keeper_meta -> unit)
+      (ctx : _ context)
+      (meta : keeper_meta)
+  =
+  let latest_meta =
+    match read_meta ctx.config meta.name with
+    | Ok (Some latest) -> latest
+    | _ -> meta
+  in
+  let resumed_meta =
+    { latest_meta with
+      paused = false
+    ; updated_at = now_iso ()
+    ; runtime = { latest_meta.runtime with last_blocker = None }
+    }
+  in
+  (* #9733: same race shape as keeper_msg/overflow-pause/sync paths
+     already migrated by #10135 / #10145.  The supervisor reconcile
+     fiber clears [paused] and [runtime.last_blocker] (cycle-owned
+     fields); a heartbeat fiber bumping [joined_room_ids] /
+     [last_seen_seq_by_room] in parallel can still steal the CAS
+     write and silently leave the keeper paused while
+     [Keeper_registry.update_meta] applies the resume in-memory —
+     a registry/disk split that hides the failure. *)
+  (match
+     write_meta_with_merge
+       ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+       ctx.config
+       resumed_meta
+   with
+   | Ok () -> ()
+   | Error err when is_version_conflict_error err ->
+     Prometheus.inc_counter
+       Keeper_metrics.metric_keeper_write_meta_failures
+       ~labels:[ "keeper", resumed_meta.name; "phase", "reconcile_resume_cas_race" ]
+       ();
+     Log.Keeper.warn
+       "%s: reconcile gate resume write_meta lost CAS race after retries: %s"
+       resumed_meta.name
+       err
+   | Error err ->
+     Prometheus.inc_counter
+       Keeper_metrics.metric_keeper_write_meta_failures
+       ~labels:[ "keeper", resumed_meta.name; "phase", "reconcile_resume" ]
+       ();
+     Log.Keeper.error
+       "%s: reconcile gate resume write_meta failed: %s"
+       resumed_meta.name
+       err);
+  Keeper_registry.update_meta
+    ~base_path:ctx.config.base_path
+    resumed_meta.name
+    resumed_meta;
+  Keeper_registry.set_failure_reason
+    ~base_path:ctx.config.base_path
+    resumed_meta.name
+    None;
+  Keeper_registry.reset_turn_failures ~base_path:ctx.config.base_path resumed_meta.name;
+  Keeper_turn_livelock.reset_keeper_livelock ~keeper:resumed_meta.name;
+  (* ETA-LIVELOCK: keep typed-escalation classifier aligned with the
+     resume path so the resumed keeper's first livelock block emits at
+     ERROR (not silently demoted to DEBUG from a previous lifetime). *)
+  Keeper_livelock_state.reset_for_keeper ~keeper:resumed_meta.name;
+  Keeper_registry.dispatch_event_unit
+    ~base_path:ctx.config.base_path
+    resumed_meta.name
+    Keeper_state_machine.Operator_resume;
+  match Keeper_registry.get ~base_path:ctx.config.base_path resumed_meta.name with
+  | Some entry when Option.is_none (Eio.Promise.peek entry.done_p) ->
+    (* tla-lint: allow-mutation: fiber signal — wake the keeper after operator resume *)
+    Atomic.set entry.fiber_wakeup true
+  | Some _ ->
+    Keeper_registry.unregister ~base_path:ctx.config.base_path resumed_meta.name;
+    supervise_keepalive ~proactive_warmup_sec:0 ctx resumed_meta
+  | None -> supervise_keepalive ~proactive_warmup_sec:0 ctx resumed_meta
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane B
- 3rd sibling extracted from `keeper_supervisor.ml` (after #17291 `cleanup_dead_tombstone` and #17342 `reconcile_keepalive_keepers`).
- Same callback-injection pattern but with **only one** callback — highest LOC/overhead ratio in this lane so far.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/keeper/keeper_supervisor.ml` | 1481 | 1414 | **-67** |
| `lib/keeper/keeper_supervisor_resume_reconcile_gate.ml` | — | 90 | +90 |

## Moved (verbatim, no behavior change)
- `resume_keeper_after_reconcile_gate` — reconcile-gate resume path:
  - Reads latest meta via `read_meta ctx.config meta.name`; falls back to `meta` on error
  - Clears `paused=false` and `runtime.last_blocker=None`; bumps `updated_at`
  - `write_meta_with_merge` through `Keeper_meta_merge.heartbeat_fields_from_disk`
    to avoid stealing concurrent heartbeat writes (cf. #9733)
  - On CAS-race: `metric_keeper_write_meta_failures` with `phase=reconcile_resume_cas_race` + WARN
  - On other errors: same metric with `phase=reconcile_resume` + ERROR
  - `Keeper_registry.{update_meta, set_failure_reason None, reset_turn_failures}`
  - `Keeper_turn_livelock.reset_keeper_livelock`
  - `Keeper_livelock_state.reset_for_keeper` (ETA-LIVELOCK escalation reset)
  - `Keeper_registry.dispatch_event_unit ... Keeper_state_machine.Operator_resume`
  - 3-branch registry fan-out:
    - Some entry + done_p unresolved → `Atomic.set entry.fiber_wakeup true`
    - Some entry + done_p resolved → unregister + `supervise_keepalive ~proactive_warmup_sec:0`
    - None → `supervise_keepalive ~proactive_warmup_sec:0`

Parent retains a 6-line wrapper that injects its local
`supervise_keepalive`. Single internal caller (line 716 — was 723
before the splice) sees an unchanged interface.

## Callback-injection pattern (mirror of #17291 / #17342, smaller surface)
Sibling signature:
```ocaml
val resume_keeper_after_reconcile_gate :
  supervise_keepalive:(proactive_warmup_sec:int -> _ context ->
                       keeper_meta -> unit) ->
  _ context -> keeper_meta -> unit
```

Parent adapter:
```ocaml
let resume_keeper_after_reconcile_gate (ctx : _ context) (meta : keeper_meta) =
  Keeper_supervisor_resume_reconcile_gate.resume_keeper_after_reconcile_gate
    ~supervise_keepalive
    ctx
    meta
;;
```

One callback × six lines of wrapper = 67 LOC savings on a 73-line
body. Highest yield in the lane so far.

## Sibling deps (all visible)
- `open Keeper_types` — for `read_meta`, `write_meta_with_merge`,
  `is_version_conflict_error`, `now_iso`, `'a context`, `keeper_meta`
- `Keeper_meta_merge.heartbeat_fields_from_disk`
- `Keeper_metrics.metric_keeper_write_meta_failures`
- `Keeper_registry.{update_meta, set_failure_reason, reset_turn_failures,
   dispatch_event_unit, get, unregister}`
- `Keeper_turn_livelock.reset_keeper_livelock`
- `Keeper_livelock_state.reset_for_keeper`
- `Keeper_state_machine.Operator_resume`
- `Log.Keeper.{warn,error}`
- `Prometheus.inc_counter`
- `Eio.Promise.peek`, `Atomic.set`, `Option.is_none`

No sibling -> parent cycle (single parent-local helper is passed as
a labeled arg).

## Local build status
- `dune build --root . lib/keeper/` → clean (exit 0)
- `dune build --root . @check` — pre-existing main breakage in
  `lib/process/process_eio.mli:46` (`Timeout_origin` unbound), unrelated
- godfile lint: sibling 90 LOC under `new_file_cap=600`; parent 1414 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim function body + 1-callback injection.

Co-Authored-By: codex <noreply@anthropic.com>
