### PR TITLE
feat(health): surface full snapshot stale age

### DIFF
--- a/lib/cascade/cascade_transport_runtime_policy_provider.mli
+++ b/lib/cascade/cascade_transport_runtime_policy_provider.mli
@@ -1,0 +1,12 @@
+(** Provider-driven runtime MCP policy resolver + CLI JSON merger. *)
+
+val runtime_mcp_policy_for_provider :
+     provider_cfg:Llm_provider.Provider_config.t
+  -> agent_name:string
+  -> Llm_provider.Llm_transport.runtime_mcp_policy option
+  -> Llm_provider.Llm_transport.runtime_mcp_policy option
+
+val cli_runtime_mcp_jsons :
+  base:string list ->
+  Llm_provider.Llm_transport.runtime_mcp_policy option ->
+  string list

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -1282,6 +1282,38 @@ let refresh_full_health_snapshot_sync ?(listener = "http/1.1") request =
 let snapshot_is_stale ~now snapshot =
   now -. snapshot.computed_at > full_health_snapshot_ttl_sec
 
+let full_health_snapshot_stale_reason ~now snapshot =
+  match snapshot with
+  | None -> None
+  | Some snapshot ->
+      (match snapshot.error with
+       | Some error
+         when snapshot.last_good_available
+              && full_health_refresh_timeout_error error ->
+           Some "last_good_refresh_timeout"
+       | Some _ when snapshot.last_good_available -> Some "last_good_refresh_error"
+       | Some error when full_health_refresh_timeout_error error ->
+           Some "refresh_timeout"
+       | Some _ -> Some "refresh_error"
+       | None when snapshot_is_stale ~now snapshot -> Some "ttl_expired"
+       | None -> None)
+
+let full_health_snapshot_stale_age_ms ~now snapshot =
+  let stale_started_at =
+    match snapshot with
+    | None -> None
+    | Some snapshot ->
+        (match snapshot.stale_since_ts with
+         | Some ts -> Some ts
+         | None when snapshot_is_stale ~now snapshot ->
+             Some (snapshot.computed_at +. full_health_snapshot_ttl_sec)
+         | None -> None)
+  in
+  match stale_started_at with
+  | None -> `Null
+  | Some started_at ->
+      `Int (max 0 (int_of_float ((now -. started_at) *. 1000.)))
+
 let full_health_snapshot_metadata ~now ~refresh_in_flight ~refresh_started_at
     ~refresh_requested snapshot =
   let component_timed_out =
@@ -1317,10 +1349,18 @@ let full_health_snapshot_metadata ~now ~refresh_in_flight ~refresh_started_at
           stale_since_ts_json,
           status )
   in
+  let stale_reason =
+    match full_health_snapshot_stale_reason ~now snapshot with
+    | Some reason -> `String reason
+    | None -> `Null
+  in
+  let stale_age_ms = full_health_snapshot_stale_age_ms ~now snapshot in
   `Assoc
     [
       ("status", `String status);
       ("snapshot_age_ms", snapshot_age_ms);
+      ("stale_reason", stale_reason);
+      ("stale_age_ms", stale_age_ms);
       ("computed_at_unix", computed_at);
       ("duration_ms", duration_ms);
       ("ttl_ms", `Int (int_of_float (full_health_snapshot_ttl_sec *. 1000.)));

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1395,6 +1395,10 @@ let test_health_response_full_query_uses_snapshot_cache () =
   let refreshed = Server_routes_http_runtime.make_health_response_json request in
   Alcotest.(check string) "refreshed snapshot is ready" "ready"
     (refreshed |> member "full_health_snapshot" |> member "status" |> to_string);
+  Alcotest.(check bool) "ready snapshot has no stale reason" true
+    (refreshed |> member "full_health_snapshot" |> member "stale_reason" = `Null);
+  Alcotest.(check bool) "ready snapshot has no stale age" true
+    (refreshed |> member "full_health_snapshot" |> member "stale_age_ms" = `Null);
   Alcotest.(check bool) "refreshed full health keeps reaction ledger" true
     (match refreshed |> member "keeper_reaction_ledger" with
      | `Assoc _ -> true
@@ -1442,6 +1446,12 @@ let test_full_health_refresh_timeout_preserves_last_snapshot () =
      |> to_bool);
   Alcotest.(check string) "timeout error is surfaced" (Printexc.to_string timeout_error)
     (after |> member "full_health_snapshot" |> member "error" |> to_string);
+  Alcotest.(check string) "timeout stale reason" "last_good_refresh_timeout"
+    (after |> member "full_health_snapshot" |> member "stale_reason" |> to_string);
+  Alcotest.(check bool) "timeout stale age is surfaced" true
+    (match after |> member "full_health_snapshot" |> member "stale_age_ms" with
+     | `Int age -> age >= 0
+     | _ -> false);
   Alcotest.(check bool) "timeout records stale-since timestamp" true
     (match after |> member "full_health_snapshot" |> member "stale_since_ts" with
      | `Float _ | `Int _ -> true
@@ -1469,6 +1479,12 @@ let test_full_health_cold_refresh_timeout_is_timeout_not_error () =
   Alcotest.(check bool) "cold timeout has no last good" false
     (after |> member "full_health_snapshot" |> member "last_good_available"
      |> to_bool);
+  Alcotest.(check string) "cold timeout stale reason" "refresh_timeout"
+    (after |> member "full_health_snapshot" |> member "stale_reason" |> to_string);
+  Alcotest.(check bool) "cold timeout stale age is surfaced" true
+    (match after |> member "full_health_snapshot" |> member "stale_age_ms" with
+     | `Int age -> age >= 0
+     | _ -> false);
   Alcotest.(check bool) "cold timeout marks component timeout" true
     (after |> member "cdal" |> member "component_timed_out" |> to_bool)
 


### PR DESCRIPTION
## Summary

- Add `stale_reason` and `stale_age_ms` to `/health?full=1` `full_health_snapshot` metadata.
- Pin ready, last-good timeout, and cold-timeout snapshot UX states in `test_server_runtime_bootstrap`.
- Restore the current cascade `.mli` structure ratchet for the latest main extraction.

## Product impact

- User-visible change: dashboards and operators can display why the full-health snapshot is stale and how long it has been stale without deriving it client-side.

## Evidence

- `git diff --check origin/main...HEAD`
- `ocamlformat --check lib/server/server_routes_http_runtime.ml test/test_server_runtime_bootstrap.ml lib/cascade/cascade_transport_runtime_policy_provider.mli`
- `scripts/ocaml-structure-ratchet.sh`
- `scripts/check-pr-hygiene.sh --base origin/main --head HEAD`

Blocked locally:

- `scripts/dune-local.sh build test/test_server_runtime_bootstrap.exe` refused to start because other bare Dune builds were active outside `scripts/dune-local.sh`.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 4/5
provenance: mixed
stages:
  - stage: diff-whitespace
    provenance: operator_proxy
    command: git diff --check origin/main...HEAD
    result: pass
  - stage: format
    provenance: operator_proxy
    command: ocamlformat --check focused OCaml files
    result: pass
  - stage: structure-ratchet
    provenance: operator_proxy
    command: scripts/ocaml-structure-ratchet.sh
    result: pass
  - stage: pr-hygiene
    provenance: operator_proxy
    command: scripts/check-pr-hygiene.sh --base origin/main --head HEAD
    result: pass
  - stage: focused-dune
    provenance: operator_proxy
    command: scripts/dune-local.sh build test/test_server_runtime_bootstrap.exe
    result: blocked_by_existing_bare_dune_processes
```

## GOAL LOOP ACT checklist

- [x] Observe — Full Health Snapshot v2 already had cache/timeout behavior, but stale display fields were not directly exposed.
- [x] Orient — this closes the consumer-facing stale reason/age signal for `/health?full=1`.
- [x] Decide — bounded next action is metadata and regression tests only.
- [x] Act — added two metadata fields and tests for ready/last-good-timeout/cold-timeout states.
- [x] Verify — local static/format/ratchet/hygiene checks passed; focused Dune is queued for CI because local wrapper refused while bare builds are active.
- [x] Loop — no additional follow-up filed from this slice.

## Review evidence

- Cross-model review not run locally.

## Linked issue

- Closes #
- Relates #

## Variant addition checklist

- [ ] **OCaml** — N/A: no variant was added, removed, or renamed.
- [ ] **TypeScript** — N/A: no TypeScript union member changed.
- [ ] **TLA+ spec** — N/A: no TLA+ domain literal changed.
- [ ] **Event / JSON schema** — N/A: no schema enum changed.
- [ ] **`make check-variants` passes** — N/A: no variant/schema enum changed.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/full-health-stale-ux-20260521` → `main` · 2 commit(s) · synced 2026-05-21T08:45:51Z

| sha | subject | date |
|---|---|---|
| `dae3a0406` | chore(ci): restore cascade mli ratchet | 2026-05-21 |
| `d5494f80e` | feat(health): surface full snapshot stale age | 2026-05-21 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->