### PR TITLE
fix(worker): floor load-bearing shell exec timeouts

### DIFF
--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -334,7 +334,7 @@ let command_context_with_allowlist ?caller ~allowed_commands cmd =
     | Allow context ->
       if context.Exec_shell_gate.direct_dune_seen
       then Error Direct_dune_invocation
-      else Ok ()
+      else Ok context
     | Reject { context; reason; _ } ->
       if context.Exec_shell_gate.direct_dune_seen
       then Error Direct_dune_invocation
@@ -1140,6 +1140,65 @@ let output_for_dispatch_status ~(status : Unix.process_status) ~stdout ~stderr =
     | out, err -> out ^ "\n" ^ err)
 ;;
 
+let simple_literal_argv (simple : Masc_exec.Shell_ir.simple) =
+  match simple_literal_args simple with
+  | None -> None
+  | Some args -> Some (Masc_exec.Bin.to_string simple.Masc_exec.Shell_ir.bin :: args)
+;;
+
+let has_flag_prefix ~prefix args =
+  List.exists (fun arg -> String.length arg >= String.length prefix
+                          && String.sub arg 0 (String.length prefix) = prefix)
+    args
+;;
+
+let is_recursive_scan_command bin args =
+  match bin with
+  | "find" -> true
+  | "rg" -> true
+  | "grep" ->
+    List.exists
+      (fun arg ->
+         String.length arg >= 2
+         && arg.[0] = '-'
+         && (String.contains arg 'r' || String.contains arg 'R'))
+      args
+  | _ -> false
+;;
+
+let shell_exec_simple_timeout_floor (simple : Masc_exec.Shell_ir.simple) =
+  let bin = Masc_exec.Bin.to_string simple.Masc_exec.Shell_ir.bin in
+  match simple_literal_argv simple with
+  | None -> None
+  | Some (_ :: args) ->
+    if String.equal bin "git"
+       || String.equal bin "dune-local.sh"
+       || has_flag_prefix ~prefix:"scripts/dune-local.sh" (bin :: args)
+       || is_recursive_scan_command bin args
+    then Some Timeout_floor.Tool_dispatch
+    else None
+  | Some [] -> None
+;;
+
+let rec shell_exec_timeout_floor = function
+  | Masc_exec.Shell_ir.Simple simple -> shell_exec_simple_timeout_floor simple
+  | Masc_exec.Shell_ir.Pipeline stages ->
+    List.find_map shell_exec_timeout_floor stages
+;;
+
+let effective_shell_exec_timeout_sec_for_context ~requested context =
+  match shell_exec_timeout_floor context.Exec_shell_gate.ast with
+  | None -> requested
+  | Some floor -> Timeout_floor.clamp floor requested
+;;
+
+let effective_shell_exec_timeout_sec ~command ~requested =
+  let requested = Float.min 120.0 requested in
+  match command_context_with_allowlist ~allowed_commands:dev_allowed_commands command with
+  | Error _ -> requested
+  | Ok context -> effective_shell_exec_timeout_sec_for_context ~requested context
+;;
+
 let make_shell_exec_with_allowlist
       ~workdir
       ~on_exec
@@ -1217,6 +1276,8 @@ let make_shell_exec_with_allowlist
                  |> Option.value ~default:30.0
                     (* DET-OK: fixed policy default for absent shell timeout. *)
                  |> Float.min 120.0
+                 |> fun requested ->
+                 effective_shell_exec_timeout_sec_for_context ~requested context
                in
                (try
                   let started = Time_compat.now () in

--- a/lib/worker_dev_tools.mli
+++ b/lib/worker_dev_tools.mli
@@ -160,6 +160,12 @@ val truncate_for_log : ?max_len:int -> string -> string
     operator-visible error string. *)
 val attribution_of_validation : cmd:string -> (unit, block_reason) result -> Attribution.t
 
+(** Effective [shell_exec] timeout after applying load-bearing timeout floors.
+    Caller-supplied short timeouts are preserved for trivial commands, but
+    git, recursive scans, and local Dune wrapper invocations are floored at the
+    shared [Tool_dispatch] timeout floor. *)
+val effective_shell_exec_timeout_sec : command:string -> requested:float -> float
+
 (** {1 OAS tool factories} *)
 
 (** Closed sum classifying the producer error categories emitted by the

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -396,6 +396,22 @@ let test_shell_exec_uses_shell_ir_dispatch_cwd () =
               (contains_substring line "\"-c\"");
             Alcotest.(check bool) "no cd wrapper" false (contains_substring line "cd ")))
 
+let test_shell_exec_timeout_floor_for_load_bearing_commands () =
+  let check command requested expected =
+    Alcotest.(check (float 0.001))
+      command
+      expected
+      (Worker_dev_tools.effective_shell_exec_timeout_sec ~command ~requested)
+  in
+  check "git status -sb" 5.0 15.0;
+  check "git branch -a" 5.0 15.0;
+  check "grep -rn \"timeout\" lib" 5.0 15.0;
+  check "find lib -name \"*.ml\" -type f" 5.0 15.0;
+  check "scripts/dune-local.sh build lib/cascade" 5.0 15.0;
+  check "echo hello" 5.0 5.0;
+  check "git status -sb" 30.0 30.0
+;;
+
 let test_shell_exec_blocked_command () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -693,6 +709,8 @@ let () =
       Alcotest.test_case "echo hello" `Quick test_shell_exec_echo;
       Alcotest.test_case "uses Shell IR dispatch cwd" `Quick
         test_shell_exec_uses_shell_ir_dispatch_cwd;
+      Alcotest.test_case "timeout floor for load-bearing commands" `Quick
+        test_shell_exec_timeout_floor_for_load_bearing_commands;
       Alcotest.test_case "blocked command" `Quick test_shell_exec_blocked_command;
       Alcotest.test_case "env wrapper blocked command" `Quick
         test_shell_exec_blocks_env_wrapped_disallowed_command;


### PR DESCRIPTION
## Summary
- applies the shared Tool_dispatch 15s timeout floor to shell_exec git commands, recursive scans, and scripts/dune-local.sh invocations
- keeps caller-provided short timeouts for trivial commands like echo/pwd
- adds a regression helper/test covering the #17349 5s timeout bucket

Fixes #17349

## Verification
- PASS: ocamlformat --check lib/worker_dev_tools.ml lib/worker_dev_tools.mli test/test_worker_dev_tools.ml
- PASS: git diff --check
- BLOCKED: scripts/dune-local.sh build ./test/test_worker_dev_tools.exe refused because three existing bare dune build processes were already running outside scripts/dune-local.sh