### PR TITLE
[codex] Write turn sandbox files without shell

### DIFF
--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -423,28 +423,27 @@ let write_file_common
   =
   match container_path_of_host t ~host_path with
   | Error _ as err -> err
-  | Ok container_path ->
-    let parent = Filename.dirname container_path in
-    let redirect = if append then ">>" else ">" in
-    let shell_cmd =
-      Printf.sprintf
-        "mkdir -p -- %s && cat %s %s"
-        (Filename.quote parent)
-        redirect
-        (Filename.quote container_path)
-    in
-    (match
-       run_exec_with_status
-         ~stdin_content:content
-         t
-         ~timeout_sec
-         ~cwd:t.host_root
-         ~command_argv:[ "sh"; "-lc"; shell_cmd ]
+  | Ok _ ->
+    ignore timeout_sec;
+    let host_path = normalize_path host_path in
+    (try
+       Fs_compat.mkdir_p (Filename.dirname host_path);
+       if append
+       then Fs_compat.append_file host_path content
+       else (
+         let oc =
+           Stdlib.open_out_gen
+             [ Open_wronly; Open_creat; Open_trunc; Open_binary ]
+             0o644
+             host_path
+         in
+         Fun.protect
+           ~finally:(fun () -> close_out_noerr oc)
+           (fun () -> output_string oc content));
+       Ok ()
      with
-     | Error _ as err -> err
-     | Ok (Unix.WEXITED 0, _out) -> Ok ()
-     | Ok (st, out) ->
-       Error (format_docker_exec_error ~head_program:"write_file" ~st ~out))
+     | Sys_error msg ->
+       Error (Printf.sprintf "write_file_failed: path=%s error=%s" host_path msg))
 ;;
 
 let overwrite_file t ~host_path ~content ~timeout_sec () =

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -2216,6 +2216,23 @@ let test_dashboard_doctor_route_process_contracts () =
     && file_not_contains_pattern "lib/server/server_routes_http_routes_dashboard.ml"
          {|doctor all --json|})
 
+let test_turn_sandbox_write_file_process_contracts () =
+  check bool "turn sandbox file writes use host fs, not shell subprocesses" true
+    (file_contains_pattern "lib/keeper/keeper_turn_sandbox_runtime.ml"
+       "Fs_compat.mkdir_p (Filename.dirname host_path)"
+    && file_contains_pattern "lib/keeper/keeper_turn_sandbox_runtime.ml"
+         "Fs_compat.append_file host_path content"
+    && file_contains_pattern "lib/keeper/keeper_turn_sandbox_runtime.ml"
+         {|[ Open_wronly; Open_creat; Open_trunc; Open_binary ]|}
+    && file_not_contains_pattern "lib/keeper/keeper_turn_sandbox_runtime.ml"
+         {|~command_argv:[ "python3"; "-c"; writer; mode; container_path ]|}
+    && file_not_contains_pattern "lib/keeper/keeper_turn_sandbox_runtime.ml"
+         "path.parent.mkdir(parents=True, exist_ok=True)"
+    && file_not_contains_pattern "lib/keeper/keeper_turn_sandbox_runtime.ml"
+         {|~command_argv:[ "sh"; "-lc"; shell_cmd ]|}
+    && file_not_contains_pattern "lib/keeper/keeper_turn_sandbox_runtime.ml"
+         "mkdir -p -- %s && cat %s %s")
+
 let test_oas_worker_capability_threading_contracts () =
   check bool "oas worker model-by-label accepts threaded sw capability" true
     (file_contains_pattern "lib/oas_worker.mli"
@@ -2711,6 +2728,8 @@ let () =
              test_worktree_list_contracts;
            test_case "dashboard doctor route process contracts" `Quick
              test_dashboard_doctor_route_process_contracts;
+           test_case "turn sandbox write file process contracts" `Quick
+             test_turn_sandbox_write_file_process_contracts;
            test_case "oas worker capability threading contracts" `Quick
              test_oas_worker_capability_threading_contracts;
            test_case "oas capacity restore contracts" `Quick


### PR DESCRIPTION
## Summary
- remove the turn-sandbox file write shell path: sh -lc mkdir-plus-cat
- replace the interim Python subprocess writer with direct OCaml host filesystem writes against the validated bind-mounted host path
- keep a source contract test that blocks both the old shell command and the Python writer fallback

## Validation
- ocamlformat --check lib/keeper/keeper_turn_sandbox_runtime.ml test/test_ci_hardening_source.ml
- git diff --check origin/main...HEAD
- bash scripts/lint/shell-legacy-purge-ratchet.sh
- bash scripts/lint-spawn-bounded.sh
- env MASC_DUNE_THROTTLE=0 MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_OPAM_LOCK=0 MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_ci_hardening_source.exe test/test_keeper_docker_read.exe

Note: the focused Dune command used guard overrides because other sessions had bare Dune processes holding/bypassing the machine-wide wrapper guard.