### PR TITLE
feat(health): expose runtime truth summary

### DIFF
--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -398,6 +398,33 @@ function KeeperRuntimePanel({ runtime }: { runtime: KeeperRuntimeResolved | null
   `
 }
 
+function RuntimeTruthPanel({ runtimeResolution }: { runtimeResolution: DashboardRuntimeResolution }) {
+  const fd = runtimeResolution.fd_accountant
+  const fleet = runtimeResolution.fleet_safety
+  const fdValue = fd
+    ? `${fd.fd_open ?? '--'} / ${fd.fd_limit ?? '--'}`
+    : '--'
+  const fdTone = fd?.pressure_active ? 'bad' : 'neutral'
+
+  return html`
+    <${ConfigCard} class="mb-4 px-4 py-4">
+      <div class="mb-3 flex flex-wrap items-center gap-2">
+        <div class="text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">live runtime truth</div>
+        <${StatusChip} tone=${toneClass(runtimeResolution.status)}>${runtimeResolution.status}<//>
+        <${StatusChip} tone=${fdTone} uppercase=${false}>fd ${fdValue}<//>
+      </div>
+      <div class="grid gap-3 md:grid-cols-2">
+        <${RuntimeMetaRow} label="effective base" value=${runtimeResolution.resolved_base_path.path ?? '--'} />
+        <${RuntimeMetaRow} label="effective .masc" value=${runtimeResolution.data_root.path ?? '--'} />
+        <${RuntimeMetaRow} label="server repo" value=${runtimeResolution.server_repo_path?.path ?? '--'} />
+        <${RuntimeMetaRow} label="executable commit" value=${runtimeResolution.build.commit ?? '--'} />
+        <${RuntimeMetaRow} label="keeper fibers" value=${String(fleet?.keeper_fibers ?? '--')} />
+        <${RuntimeMetaRow} label="fd pressure" value=${fd?.pressure_active == null ? '--' : fd.pressure_active ? 'active' : 'clear'} />
+      </div>
+    <//>
+  `
+}
+
 function RuntimeProbePanel() {
   const state = useSignal<{
     data: DashboardRuntimeProbeResponse | null
@@ -635,6 +662,8 @@ export function ConfigResolutionPanel({
               <div class="mb-4">
                 <${WarningBlock} title="runtime warnings" warnings=${runtimeResolution.warnings} />
               </div>
+
+              <${RuntimeTruthPanel} runtimeResolution=${runtimeResolution} />
 
               <div class="grid gap-3 md:grid-cols-2">
                 <${ConfigRow} label="base path" item=${runtimeResolution.base_path} />

--- a/dashboard/src/store-normalizers.test.ts
+++ b/dashboard/src/store-normalizers.test.ts
@@ -151,6 +151,23 @@ describe('normalizeDashboardRuntimeResolution fleet safety', () => {
     const result = normalizeDashboardRuntimeResolution(runtimeResolutionRaw())
 
     expect(result?.fleet_safety).toBeNull()
+    expect(result?.fd_accountant).toBeNull()
+  })
+
+  it('parses FD accountant facts for the runtime truth panel', () => {
+    const result = normalizeDashboardRuntimeResolution(runtimeResolutionRaw({
+      fd_accountant: {
+        fd_open: 42,
+        fd_limit: 1024,
+        pressure_active: false,
+      },
+    }))
+
+    expect(result?.fd_accountant).toEqual({
+      fd_open: 42,
+      fd_limit: 1024,
+      pressure_active: false,
+    })
   })
 
   it('parses optional health fleet-safety fields type-safely', () => {

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -605,7 +605,21 @@ export function normalizeDashboardRuntimeResolution(
     build,
     keeper_runtime: normalizeKeeperRuntimeResolved(raw.keeper_runtime),
     fleet_safety: normalizeDashboardFleetSafetyHealth(raw),
+    fd_accountant: normalizeDashboardFdAccountant(raw.fd_accountant),
     cdal: normalizeDashboardCdalHealth(raw.cdal),
+  }
+}
+
+function normalizeDashboardFdAccountant(raw: unknown): DashboardRuntimeResolution['fd_accountant'] {
+  if (!isRecord(raw)) return null
+  const fdOpen = asNumber(raw.fd_open)
+  const fdLimit = asNumber(raw.fd_limit)
+  const pressureActive = asBoolean(raw.pressure_active)
+  if (fdOpen == null && fdLimit == null && pressureActive == null) return null
+  return {
+    fd_open: fdOpen ?? null,
+    fd_limit: fdLimit ?? null,
+    pressure_active: pressureActive ?? null,
   }
 }
 

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -117,7 +117,14 @@ export interface DashboardRuntimeResolution {
   build: ServerBuildIdentity
   keeper_runtime: KeeperRuntimeResolved | null
   fleet_safety: DashboardFleetSafetyHealth | null
+  fd_accountant: DashboardFdAccountant | null
   cdal: DashboardCdalHealth | null
+}
+
+export interface DashboardFdAccountant {
+  fd_open: number | null
+  fd_limit: number | null
+  pressure_active: boolean | null
 }
 
 export interface DashboardFleetSafetyHealth {

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -845,6 +845,35 @@ let fd_accountant_snapshot_json () =
     ]
 ;;
 
+let runtime_truth_json ~build ~path_diagnostics ~keeper_fibers ~fd_accountant =
+  `Assoc
+    [ "schema", `String "masc.runtime_truth.v1"
+    ; "source", `String "running_process"
+    ; "effective_base_path", `String path_diagnostics.Server_base_path_diagnostics.effective_base_path
+    ; "effective_masc_root", `String path_diagnostics.effective_masc_root
+    ; "process_cwd", `String path_diagnostics.process_cwd
+    ; ( "input_base_path"
+      , Option.fold ~none:`Null ~some:(fun value -> `String value) path_diagnostics.input_base_path
+      )
+    ; ( "env_masc_base_path"
+      , Option.fold ~none:`Null ~some:(fun value -> `String value) path_diagnostics.env_masc_base_path
+      )
+    ; "runtime_repo_root", Option.fold ~none:`Null ~some:(fun value -> `String value) build.Build_identity.repo_root
+    ; "executable_path", `String build.executable_path
+    ; "executable_dir", `String build.executable_dir
+    ; "runtime_commit", Option.fold ~none:`Null ~some:(fun value -> `String value) build.commit
+    ; "runtime_commit_source", Option.fold ~none:`Null ~some:(fun value -> `String value) build.commit_source
+    ; "binary_commit", Option.fold ~none:`Null ~some:(fun value -> `String value) build.binary_commit
+    ; "binary_commit_source", Option.fold ~none:`Null ~some:(fun value -> `String value) build.binary_commit_source
+    ; "repo_head_commit", Option.fold ~none:`Null ~some:(fun value -> `String value) build.repo_head_commit
+    ; "repo_head_commit_source", Option.fold ~none:`Null ~some:(fun value -> `String value) build.repo_head_commit_source
+    ; "keeper_fibers", `Int keeper_fibers
+    ; "fd_open", fd_accountant |> Yojson.Safe.Util.member "fd_open"
+    ; "fd_limit", fd_accountant |> Yojson.Safe.Util.member "fd_limit"
+    ; "fd_pressure_active", fd_accountant |> Yojson.Safe.Util.member "pressure_active"
+    ]
+;;
+
 let keeper_fleet_runtime_resolution_fields () =
   keeper_fleet_runtime_resolution_base_fields ()
   @ [ "fd_accountant", fd_accountant_snapshot_json () ]
@@ -922,11 +951,13 @@ let make_health_json ?(listener = "http/1.1") request =
     else "none"
   in
   let key_paused_keepers = "paused_keepers" in
+  let path_diagnostics = health_path_diagnostics () in
   let base_path = current_room_base_path_opt () in
   let phase_counts = keeper_phase_counts ?base_path () in
   let keeper_fibers = phase_counts.running in
   let paused_keepers_json = paused_keepers_health_json () in
   let reaction_ledger_json = keeper_reaction_ledger_health_json () in
+  let fd_accountant_json = fd_accountant_snapshot_json () in
   Tool_args.ok_assoc [
     ("server", `String "masc-mcp");
     ("version", `String build.release_version);
@@ -936,7 +967,10 @@ let make_health_json ?(listener = "http/1.1") request =
     ("protocol", protocol_json ~listener);
     ("transport", transport_json request);
     ("http_listener", Transport_metrics.http_listener_json ());
-    ("paths", Server_base_path_diagnostics.to_yojson (health_path_diagnostics ()));
+    ("paths", Server_base_path_diagnostics.to_yojson path_diagnostics);
+    ( "runtime_truth"
+    , runtime_truth_json ~build ~path_diagnostics ~keeper_fibers
+        ~fd_accountant:fd_accountant_json );
     ("uptime", `String (health_uptime_string uptime_secs));
     ("sse_clients", `Int (Sse.client_count ()));
     ("startup", Server_startup_state.to_yojson ());
@@ -953,7 +987,7 @@ let make_health_json ?(listener = "http/1.1") request =
     ( "keeper_fd_pressure"
     , Keeper_fd_pressure.runtime_state_json ~active_keepers:keeper_fibers
         ~starting_keepers:0 ~requested_keepers:24 () );
-    ("fd_accountant", fd_accountant_snapshot_json ());
+    ("fd_accountant", fd_accountant_json);
     ( "keeper_fleet_safety"
     , keeper_fleet_safety_health_json ~phase_counts
         ~paused_keepers_json () );

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1005,6 +1005,7 @@ let test_health_json_surfaces_durable_paused_keepers () =
           let paused = json |> member "paused_keepers" in
           let fd_pressure = json |> member "keeper_fd_pressure" in
           let fd_accountant = json |> member "fd_accountant" in
+          let runtime_truth = json |> member "runtime_truth" in
           let fleet_safety = json |> member "keeper_fleet_safety" in
           let reaction_ledger = json |> member "keeper_reaction_ledger" in
           let durable_names =
@@ -1054,6 +1055,25 @@ let test_health_json_surfaces_durable_paused_keepers () =
           ignore (fd_accountant |> member "fd_open" |> to_int);
           ignore (fd_accountant |> member "fd_limit" |> to_int);
           ignore (fd_accountant |> member "pressure_active" |> to_bool);
+          Alcotest.(check string) "runtime truth schema"
+            "masc.runtime_truth.v1"
+            (runtime_truth |> member "schema" |> to_string);
+          Alcotest.(check string) "runtime truth source"
+            "running_process"
+            (runtime_truth |> member "source" |> to_string);
+          Alcotest.(check string) "runtime truth effective base path"
+            dir
+            (runtime_truth |> member "effective_base_path" |> to_string);
+          Alcotest.(check string) "runtime truth effective masc root"
+            (Filename.concat dir ".masc")
+            (runtime_truth |> member "effective_masc_root" |> to_string);
+          ignore (runtime_truth |> member "process_cwd" |> to_string);
+          ignore (runtime_truth |> member "executable_path" |> to_string);
+          ignore (runtime_truth |> member "executable_dir" |> to_string);
+          ignore (runtime_truth |> member "keeper_fibers" |> to_int);
+          ignore (runtime_truth |> member "fd_open" |> to_int);
+          ignore (runtime_truth |> member "fd_limit" |> to_int);
+          ignore (runtime_truth |> member "fd_pressure_active" |> to_bool);
           let fd_accountant_per_kind =
             fd_accountant |> member "per_kind" |> to_list
           in


### PR DESCRIPTION
## Summary
- add a /health full payload runtime_truth summary for the running process
- group effective base path, .masc root, executable/build commit identity, keeper fiber count, and FD pressure facts in one operator-facing object
- surface live runtime truth in the dashboard config/runtime panel by preserving fd_accountant in the frontend normalizer
- pin the server health field and dashboard normalizer behavior with regression tests

## Verification
- git diff --check origin/main...HEAD
- ocamlformat --check lib/server/server_routes_http_runtime.ml test/test_server_runtime_bootstrap.ml
- scripts/ocaml-structure-ratchet.sh
- scripts/check-pr-hygiene.sh --base origin/main --head HEAD
- pnpm exec tsc --noEmit --pretty false
- pnpm exec vitest run src/store-normalizers.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1

## Notes
- pnpm install --offline --frozen-lockfile was used in this worktree because dashboard/node_modules was absent.
- pnpm exec eslint src/store-normalizers.ts src/store-normalizers.test.ts src/components/tools/config-resolution-panel.ts src/types/dashboard-execution.ts exited 0, but repo ESLint reported three non-component files as ignored by config.

## Not run
- scripts/dune-local.sh build test/test_server_runtime_bootstrap.exe (refused because other worktrees have bare Dune processes holding the machine-wide build lock)

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/runtime-truth-panel-20260521` → `main` · 1 commit(s) · synced 2026-05-21T09:13:00Z

| sha | subject | date |
|---|---|---|
| `bb556aaa7` | feat(health): expose runtime truth summary | 2026-05-21 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->