### PR TITLE
Purge autoresearch orphan analysis artifacts

### DIFF
--- a/ci/code-smell-baseline.json
+++ b/ci/code-smell-baseline.json
@@ -2757,10 +2757,6 @@
           "value": 1
         },
         {
-          "file": "lib/tool_autoresearch.ml",
-          "value": 12
-        },
-        {
           "file": "lib/tool_board_dispatch.ml",
           "value": 1
         },

--- a/docs/rfc/RFC-0071-inventory.csv
+++ b/docs/rfc/RFC-0071-inventory.csv
@@ -872,12 +872,6 @@ lib/tool_agent.ml,337,None,unclassified
 lib/tool_agent.ml,355,None,unclassified
 lib/tool_assignment_telemetry.ml,113,None,unclassified
 lib/tool_assignment_telemetry.ml,147,None,unclassified
-lib/tool_autoresearch.ml,42,false,unclassified
-lib/tool_autoresearch.ml,290,None,unclassified
-lib/tool_autoresearch.ml,435,false,unclassified
-lib/tool_autoresearch.ml,445,None,unclassified
-lib/tool_autoresearch.ml,602,None,unclassified
-lib/tool_autoresearch.ml,620,None,unclassified
 lib/tool_board.ml,336,None,unclassified
 lib/tool_board.ml,385,None,unclassified
 lib/tool_board.ml,395,None,unclassified

--- a/reports/lib-dependency-graph.json
+++ b/reports/lib-dependency-graph.json
@@ -326,7 +326,6 @@
       "Tool_access_policy",
       "Tool_access_role",
       "Tool_agent_timeline",
-      "Tool_autoresearch",
       "Tool_autoresearch_broadcast",
       "Tool_autoresearch_context",
       "Tool_autoresearch_cycle",
@@ -458,18 +457,16 @@
     },
     {
       "prefix": "tool_autoresearch",
-      "module_count": 6,
+      "module_count": 4,
       "members": [
-        "Tool_autoresearch",
         "Tool_autoresearch_broadcast",
         "Tool_autoresearch_context",
         "Tool_autoresearch_cycle",
-        "Tool_autoresearch_registry",
-        "Tool_autoresearch_schemas"
+        "Tool_autoresearch_registry"
       ],
-      "internal_edges": 6,
-      "external_dep_count": 12,
-      "coupling_ratio": 0.333
+      "internal_edges": 3,
+      "external_dep_count": 5,
+      "coupling_ratio": 0.375
     },
     {
       "prefix": "dashboard_keeper",
@@ -1502,7 +1499,6 @@
       "Capability_registry",
       "Keeper_types",
       "Tool_agent_timeline",
-      "Tool_autoresearch",
       "Tool_board",
       "Tool_catalog",
       "Tool_local_runtime",
@@ -1685,7 +1681,6 @@
     ],
     "Dashboard_http_autoresearch": [
       "Autoresearch",
-      "Tool_autoresearch",
       "Tool_autoresearch_registry"
     ],
     "Dashboard_http_helpers": [
@@ -2500,7 +2495,6 @@
       "Keeper_alerting_path",
       "Keeper_exec_shared",
       "Keeper_types",
-      "Tool_autoresearch",
       "Tool_code",
       "Tool_dispatch",
       "Tool_result"
@@ -3455,7 +3449,6 @@
       "Prometheus",
       "Tool_agent",
       "Tool_agent_timeline",
-      "Tool_autoresearch",
       "Tool_code",
       "Tool_code_write",
       "Tool_control",
@@ -4222,7 +4215,6 @@
       "Session",
       "Tool_agent",
       "Tool_agent_timeline",
-      "Tool_autoresearch",
       "Tool_catalog",
       "Tool_code",
       "Tool_code_write",
@@ -5349,20 +5341,6 @@
     "Tool_assignment_telemetry": [
       "Prometheus"
     ],
-    "Tool_autoresearch": [
-      "Autoresearch",
-      "Autoresearch_knowledge",
-      "Coord",
-      "Provider_adapter",
-      "Tool_args",
-      "Tool_autoresearch_context",
-      "Tool_autoresearch_cycle",
-      "Tool_autoresearch_schemas",
-      "Tool_catalog",
-      "Tool_dispatch",
-      "Tool_result",
-      "Tool_spec"
-    ],
     "Tool_autoresearch_broadcast": [
       "Autoresearch",
       "Sse"
@@ -5384,7 +5362,6 @@
     "Tool_autoresearch_registry": [
       "Autoresearch"
     ],
-    "Tool_autoresearch_schemas": [],
     "Tool_board": [
       "Board",
       "Board_curation",
@@ -5756,7 +5733,6 @@
     "Tool_scope": [],
     "Tool_shard": [
       "Tool_args",
-      "Tool_autoresearch_schemas",
       "Tool_catalog",
       "Tool_code",
       "Tool_dispatch",
@@ -5829,7 +5805,6 @@
     ],
     "Tools": [
       "Keeper_types",
-      "Tool_autoresearch",
       "Tool_code",
       "Tool_code_write",
       "Tool_library",

--- a/scripts/lint/exhaustive-guard.allowlist
+++ b/scripts/lint/exhaustive-guard.allowlist
@@ -877,12 +877,6 @@ lib/tool_agent.ml:337
 lib/tool_agent.ml:355
 lib/tool_assignment_telemetry.ml:113
 lib/tool_assignment_telemetry.ml:147
-lib/tool_autoresearch.ml:42
-lib/tool_autoresearch.ml:290
-lib/tool_autoresearch.ml:435
-lib/tool_autoresearch.ml:445
-lib/tool_autoresearch.ml:602
-lib/tool_autoresearch.ml:620
 lib/tool_board.ml:336
 lib/tool_board.ml:385
 lib/tool_board.ml:395


### PR DESCRIPTION
## Summary
- remove deleted lib/tool_autoresearch.ml entries from RFC-0071 inventory and exhaustive-guard allowlist
- remove deleted Tool_autoresearch and Tool_autoresearch_schemas nodes from dependency graph report
- remove deleted tool_autoresearch code-smell baseline entry

## Verification
- jq empty reports/lib-dependency-graph.json ci/code-smell-baseline.json
- git diff --check origin/main..HEAD
- rg -n '"Tool_autoresearch"|"Tool_autoresearch_schemas"|lib/tool_autoresearch\.ml|lib/tool_autoresearch\.mli|lib/tool_autoresearch_schemas\.ml|lib/tool_autoresearch_schemas\.mli' reports/lib-dependency-graph.json ci/code-smell-baseline.json docs/rfc/RFC-0071-inventory.csv scripts/lint/exhaustive-guard.allowlist
- bash scripts/lint/exhaustive-guard.sh (exit 0; existing RFC-0071 advisory warnings remain)