### PR TITLE
[codex] fix build gates after Shell IR dispatch

### DIFF
--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -369,7 +369,7 @@ let claim_next_r
             (fun (task : Masc_domain.task) ->
                match task.task_status with
                | Claimed _ | InProgress _ -> true
-               | _ -> false)
+               | Todo | AwaitingVerification _ | Done _ | Cancelled _ -> false)
             working_tasks
         in
         (* Starvation prevention: Calculate effective priority
@@ -489,7 +489,7 @@ let claim_next_r
           && not (receipt_blocks_task task)
         in
         let admission_decisions = Hashtbl.create 16 in
-        let admission_allowed task =
+        let admission_allowed (task : task) =
           match Hashtbl.find_opt admission_decisions task.id with
           | Some allowed -> allowed
           | None ->

--- a/lib/keeper/keeper_exec_masc.ml
+++ b/lib/keeper/keeper_exec_masc.ml
@@ -1,4 +1,5 @@
 open Keeper_exec_shared
+open Keeper_types
 
 (* Read-only masc_code_* tools (search, read, symbols) are path-bearing but
    should NOT go through the strict write resolver. The write resolver

--- a/lib/operator/operator_control_snapshot_runtime_status.mli
+++ b/lib/operator/operator_control_snapshot_runtime_status.mli
@@ -1,5 +1,6 @@
 (** Runtime-status alignment helpers for operator control snapshots. *)
 
+val remote_confirm_ttl_seconds : float
 val runtime_status_from_live_signal : Yojson.Safe.t -> string option
 val health_state_allows_runtime_status_override : Yojson.Safe.t -> bool
 

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -334,7 +334,7 @@ let command_context_with_allowlist ?caller ~allowed_commands cmd =
     | Allow context ->
       if context.Exec_shell_gate.direct_dune_seen
       then Error Direct_dune_invocation
-      else Ok ()
+      else Ok context
     | Reject { context; reason; _ } ->
       if context.Exec_shell_gate.direct_dune_seen
       then Error Direct_dune_invocation


### PR DESCRIPTION
## Summary
- preserve the parsed Shell IR context from worker shell_exec validation so dispatch can use context.ast
- close warning-as-error/type gaps in current main build gates for task scheduling, keeper masc execution, cascade retry hints, and operator snapshot runtime status

## Validation
- ocamlformat --check lib/coord/coord_task_schedule.ml lib/keeper/keeper_exec_masc.ml lib/operator/operator_control_snapshot_runtime_status.mli lib/worker_dev_tools.ml
- git diff --check origin/main...HEAD
- bash scripts/lint-spawn-bounded.sh
- bash scripts/lint/shell-legacy-purge-ratchet.sh
- focused Dune passed before final rebase: env MASC_DUNE_THROTTLE=0 MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_OPAM_LOCK=0 MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_timeout_origin.exe test/test_process_timeout_counter.exe test/test_process_eio_coverage.exe test/test_worker_dev_tools.exe test/test_exec_dispatch.exe

Note: the same focused Dune command was retried after the final rebase, but host-local Dune stalled in unrelated server_auth compilation and was interrupted; PR CI should provide the final full build signal.