### PR TITLE
purge(shell): remove split_wrapper_words and redirect_allowed legacy remnants

### DIFF
--- a/lib/exec/command_gate/shell_command_gate.ml
+++ b/lib/exec/command_gate/shell_command_gate.ml
@@ -51,7 +51,7 @@ type verdict =
 type allowlist_policy = {
   allowed_commands : string list;
   allow_pipes : bool;
-  redirect_allowed : bool;
+  
 }
 
 type path_policy = {
@@ -365,7 +365,7 @@ let apply_policy ~(allowlist : allowlist_policy) ~(path_policy : path_policy)
          Reject { context; reason; diagnostic }
        | None ->
          (match
-            if allowlist.redirect_allowed then None else first_redirect_stage stages
+            first_redirect_stage stages
           with
           | Some stage ->
             Reject

--- a/lib/exec/command_gate/shell_command_gate.mli
+++ b/lib/exec/command_gate/shell_command_gate.mli
@@ -106,12 +106,12 @@ type verdict =
 
 (** Allowlist policy. [allow_pipes = true] keeps the existing legacy
     behavior; [false] yields {!Pipes_not_allowed} for any pipeline with
-    two or more stages. [redirect_allowed = false] rejects all redirect
+    two or more stages. Redirects are always rejected, including fd-to-fd redirects such as
     syntax, including fd-to-fd redirects such as [2>&1]. *)
 type allowlist_policy = {
   allowed_commands : string list;
   allow_pipes : bool;
-  redirect_allowed : bool;
+  
 }
 
 (** Path policy applied to literal path arguments and file redirect

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -63,7 +63,7 @@ let code_shell_allowlist_policy
       ~(allowed_commands : string list)
       ()
   : Exec_shell_gate.allowlist_policy =
-  { allowed_commands; allow_pipes; redirect_allowed = false }
+  { allowed_commands; allow_pipes }
 ;;
 
 let validate_code_shell_command_block_reason

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -192,12 +192,12 @@ let validate_command_name_with_allowlist ~allowed_commands = function
 ;;
 
 let strict_allowlist_policy ~allowed_commands : Exec_shell_gate.allowlist_policy =
-  { allowed_commands; allow_pipes = false; redirect_allowed = false }
+  { allowed_commands; allow_pipes = false }
 ;;
 
 let coding_allowlist_policy ?(allow_pipes = true) ~allowed_commands ()
   : Exec_shell_gate.allowlist_policy =
-  { allowed_commands; allow_pipes; redirect_allowed = false }
+  { allowed_commands; allow_pipes }
 ;;
 
 let rec shell_ir_literal_text = function

--- a/lib/worker_dev_tools_command_syntax.ml
+++ b/lib/worker_dev_tools_command_syntax.ml
@@ -5,18 +5,12 @@
     path-token normalization helpers plus explicit argv/word helpers for
     transparent wrappers such as [env] and [opam exec]. *)
 
-let split_wrapper_words cmd =
-  match Masc_exec_bash_parser.Bash_words.stages cmd with
-  | Ok [ words ] ->
-    words
-    |> List.map (fun word -> word.Masc_exec_bash_parser.Bash_words.value)
-    |> List.filter (fun token -> token <> "")
-  | Ok (words :: _) ->
-    words
-    |> List.map (fun word -> word.Masc_exec_bash_parser.Bash_words.value)
-    |> List.filter (fun token -> token <> "")
-  | Ok [] | Error _ -> []
+let split_on_space cmd =
+  String.split_on_char ' ' cmd
+  |> List.map String.trim
+  |> List.filter (fun token -> token <> "")
 ;;
+
 let strip_wrapping_quotes token =
   let len = String.length token in
   if len >= 2
@@ -62,7 +56,7 @@ let rec command_after_env_prefix_tokens = function
       match rest with
       | arg :: rest -> (
         match
-          command_after_env_prefix_tokens (split_wrapper_words (strip_wrapping_quotes arg))
+          command_after_env_prefix_tokens (split_on_space (strip_wrapping_quotes arg))
         with
         | Some _ as command -> command
         | None -> command_after_env_prefix_tokens rest)
@@ -73,7 +67,7 @@ let rec command_after_env_prefix_tokens = function
       let arg =
         String.sub token (String.length prefix) (String.length token - String.length prefix)
       in
-      command_after_env_prefix_tokens (split_wrapper_words (strip_wrapping_quotes arg))
+      command_after_env_prefix_tokens (split_on_space (strip_wrapping_quotes arg))
     else if token = "-u" || token = "--unset" || token = "-C" || token = "--chdir"
     then (
       match rest with
@@ -140,8 +134,4 @@ let command_after_env_prefix tokens =
 
 let opam_exec_command_name tokens =
   Option.bind (opam_exec_command_tokens tokens) effective_command_name_from_tokens
-;;
-
-let segment_command_name segment =
-  effective_command_name_from_tokens (split_wrapper_words segment)
 ;;

--- a/lib/worker_dev_tools_command_syntax.mli
+++ b/lib/worker_dev_tools_command_syntax.mli
@@ -10,7 +10,3 @@ val opam_exec_command_name : string list -> string option
 (** Resolve the effective command name for argv words following an [opam]
     executable. [opam exec] targets are resolved recursively; non-exec opam
     subcommands resolve to [Some "opam"]. *)
-
-val segment_command_name : string -> string option
-(** Resolve the effective command name of a shell segment, including transparent
-    [env] and [opam exec] wrappers. *)

--- a/test/test_exec_shell_command_gate.ml
+++ b/test/test_exec_shell_command_gate.ml
@@ -23,7 +23,7 @@ module W = Masc_mcp.Worker_dev_tools
 let allowed = [ "rg"; "sort"; "head"; "wc"; "cat"; "git"; "ls"; "grep" ]
 
 let allowlist : Gate.allowlist_policy =
-  { allowed_commands = allowed; allow_pipes = true; redirect_allowed = false }
+  { allowed_commands = allowed; allow_pipes = true }
 ;;
 
 (* {1 Baseline corpus} *)
@@ -275,7 +275,7 @@ let test_pipeline_segment_rejection_carries_stage_index () =
 
 let test_pipes_disabled () =
   let policy : Gate.allowlist_policy =
-    { allowed_commands = allowed; allow_pipes = false; redirect_allowed = false }
+    { allowed_commands = allowed; allow_pipes = false }
   in
   match
     Gate.gate


### PR DESCRIPTION
Remove shell-string parsing leftovers after the Shell IR migration.

- Replace `split_wrapper_words` (Masc_exec_bash_parser.Bash_words.stages) with `split_on_space` (String.split_on_char). The Bash_words full-parser dependency for simple space splitting is overkill now that pipelines are explicit stages in typed Shell IR.

- Remove `segment_command_name` — no callers remain after IR transition.

- Remove `redirect_allowed` field from `allowlist_policy`. All production sites already set it to false; the gate unconditionally rejects redirects now.

- Update all call sites and tests to drop the removed field.