### PR TITLE
refactor(keeper_supervisor): extract restore_reconcile_continue_gate sibling

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -619,62 +619,10 @@ let resume_keeper_after_reconcile_gate (ctx : _ context) (meta : keeper_meta) =
 ;;
 
 let restore_reconcile_continue_gate (ctx : _ context) (meta : keeper_meta) =
-  let blocker_detail, blocker_klass =
-    match meta.runtime.last_blocker with
-    | Some info -> String.trim info.detail, Some info.klass
-    | None -> "", None
-  in
-  let committed_tools = committed_tools_of_ambiguous_blocker blocker_detail in
-  let failure_reason =
-    match blocker_klass with
-    | Some Ambiguous_post_commit_timeout ->
-      "ambiguous_partial_commit(post_commit_timeout)"
-    | Some Ambiguous_post_commit_failure ->
-      "ambiguous_partial_commit(post_commit_failure)"
-    | Some _ | None -> "ambiguous_partial_commit(post_commit_failure)"
-  in
-  let blocker = blocker_detail in
-  let input =
-    `Assoc
-      [ "kind", `String "reconcile_required"
-      ; "keeper_name", `String meta.name
-      ; "failure_reason", `String failure_reason
-      ; "error_detail", `String blocker
-      ; "committed_tools", `List (List.map (fun tool -> `String tool) committed_tools)
-      ]
-  in
-  let _approval_id =
-    Keeper_approval_queue.submit_pending
-      ~keeper_name:meta.name
-      ~tool_name:"keeper_continue_after_reconcile"
-      ~input
-      ~risk_level:Keeper_approval_queue.Critical
-      ~base_path:ctx.config.base_path
-      ~on_resolution:(fun decision ->
-        match decision with
-        | Agent_sdk.Hooks.Approve | Agent_sdk.Hooks.Edit _ ->
-          resume_keeper_after_reconcile_gate ctx meta;
-          Log.Keeper.info
-            "%s: restored reconcile continue gate approved; keeper resumed"
-            meta.name
-        | Agent_sdk.Hooks.Reject reason ->
-          Log.Keeper.warn
-            "%s: restored reconcile continue gate rejected; keeper remains paused (%s)"
-            meta.name
-            reason;
-          Prometheus.inc_counter
-            Keeper_metrics.metric_keeper_supervisor_cleanup_failures
-            ~labels:
-              [ "keeper", meta.name
-              ; ( "site"
-                , Keeper_supervisor_cleanup_failure_site.(to_label Reconcile_gate_rejected) )
-              ]
-            ())
-      ()
-  in
-  Log.Keeper.warn
-    "%s: restored reconcile continue gate from persisted paused meta"
-    meta.name
+  Keeper_supervisor_restore_reconcile_gate.restore_reconcile_continue_gate
+    ~supervise_keepalive
+    ctx
+    meta
 ;;
 
 (* ── Sweep and recover ───────────────────────────────────── *)

--- a/lib/keeper/keeper_supervisor_restore_reconcile_gate.ml
+++ b/lib/keeper/keeper_supervisor_restore_reconcile_gate.ml
@@ -1,0 +1,86 @@
+(** Reconcile-gate restore path, extracted from
+    [keeper_supervisor.ml] (godfile decomp).
+
+    [restore_reconcile_continue_gate] rehydrates a pending
+    "keeper_continue_after_reconcile" approval entry from the
+    persisted paused meta. On [Approve | Edit], it forwards to
+    [resume_keeper_after_reconcile_gate] (which itself lives in
+    [Keeper_supervisor_resume_reconcile_gate] — we call it directly
+    here, passing the injected [~supervise_keepalive] callback, to
+    avoid bouncing through the parent's wrapper).
+
+    On [Reject], it logs the reason, increments
+    [metric_keeper_supervisor_cleanup_failures] tagged
+    [Reconcile_gate_rejected], and leaves the keeper paused. *)
+
+open Keeper_types
+module Startup_helpers = Keeper_supervisor_startup_helpers
+module Resume_reconcile_gate = Keeper_supervisor_resume_reconcile_gate
+
+let restore_reconcile_continue_gate
+      ~(supervise_keepalive : proactive_warmup_sec:int -> _ context -> keeper_meta -> unit)
+      (ctx : _ context)
+      (meta : keeper_meta)
+  =
+  let blocker_detail, blocker_klass =
+    match meta.runtime.last_blocker with
+    | Some info -> String.trim info.detail, Some info.klass
+    | None -> "", None
+  in
+  let committed_tools =
+    Startup_helpers.committed_tools_of_ambiguous_blocker blocker_detail
+  in
+  let failure_reason =
+    match blocker_klass with
+    | Some Ambiguous_post_commit_timeout ->
+      "ambiguous_partial_commit(post_commit_timeout)"
+    | Some Ambiguous_post_commit_failure ->
+      "ambiguous_partial_commit(post_commit_failure)"
+    | Some _ | None -> "ambiguous_partial_commit(post_commit_failure)"
+  in
+  let blocker = blocker_detail in
+  let input =
+    `Assoc
+      [ "kind", `String "reconcile_required"
+      ; "keeper_name", `String meta.name
+      ; "failure_reason", `String failure_reason
+      ; "error_detail", `String blocker
+      ; "committed_tools", `List (List.map (fun tool -> `String tool) committed_tools)
+      ]
+  in
+  let _approval_id =
+    Keeper_approval_queue.submit_pending
+      ~keeper_name:meta.name
+      ~tool_name:"keeper_continue_after_reconcile"
+      ~input
+      ~risk_level:Keeper_approval_queue.Critical
+      ~base_path:ctx.config.base_path
+      ~on_resolution:(fun decision ->
+        match decision with
+        | Agent_sdk.Hooks.Approve | Agent_sdk.Hooks.Edit _ ->
+          Resume_reconcile_gate.resume_keeper_after_reconcile_gate
+            ~supervise_keepalive
+            ctx
+            meta;
+          Log.Keeper.info
+            "%s: restored reconcile continue gate approved; keeper resumed"
+            meta.name
+        | Agent_sdk.Hooks.Reject reason ->
+          Log.Keeper.warn
+            "%s: restored reconcile continue gate rejected; keeper remains paused (%s)"
+            meta.name
+            reason;
+          Prometheus.inc_counter
+            Keeper_metrics.metric_keeper_supervisor_cleanup_failures
+            ~labels:
+              [ "keeper", meta.name
+              ; ( "site"
+                , Keeper_supervisor_cleanup_failure_site.(to_label Reconcile_gate_rejected) )
+              ]
+            ())
+      ()
+  in
+  Log.Keeper.warn
+    "%s: restored reconcile continue gate from persisted paused meta"
+    meta.name
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane B
- 4th sibling extracted from `keeper_supervisor.ml` (after #17291 `cleanup_dead_tombstone`, #17342 `reconcile_keepalive_keepers`, #17350 `resume_keeper_after_reconcile_gate`).
- Pairs with #17350 to complete the reconcile-gate cluster carve-out.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/keeper/keeper_supervisor.ml` | 1414 | 1362 | **-52** |
| `lib/keeper/keeper_supervisor_restore_reconcile_gate.ml` | — | 86 | +86 |

## Moved (verbatim, no behavior change)
- `restore_reconcile_continue_gate` — restore-side of the
  `keeper_continue_after_reconcile` approval gate:
  - Reads `meta.runtime.last_blocker` → `(blocker_detail, blocker_klass)`
  - Resolves committed tools via
    `Keeper_supervisor_startup_helpers.committed_tools_of_ambiguous_blocker`
  - Maps blocker class to `failure_reason` string:
    - `Ambiguous_post_commit_timeout` → `"ambiguous_partial_commit(post_commit_timeout)"`
    - `Ambiguous_post_commit_failure` (or fallback) → `"ambiguous_partial_commit(post_commit_failure)"`
  - Builds `input` JSON `{kind, keeper_name, failure_reason, error_detail, committed_tools}`
  - Submits Critical-risk pending approval via `Keeper_approval_queue.submit_pending`
  - Resolution callback:
    - `Approve | Edit` → forward to
      `Resume_reconcile_gate.resume_keeper_after_reconcile_gate ~supervise_keepalive`
      (the sibling extracted in #17350) + INFO log
    - `Reject reason` → WARN log + increment
      `metric_keeper_supervisor_cleanup_failures` with
      `site=Reconcile_gate_rejected` label
  - Trailing WARN log on the restore event itself

Parent retains a 6-line wrapper that injects its local
`supervise_keepalive` and forwards ctx/meta. Single internal caller
at line 1238 (was 1250 before the splice) sees an unchanged
interface.

## Callback-injection pattern (mirror of #17342 / #17350)
Sibling signature:
```ocaml
val restore_reconcile_continue_gate :
  supervise_keepalive:(proactive_warmup_sec:int -> _ context ->
                       keeper_meta -> unit) ->
  _ context -> keeper_meta -> unit
```

The sibling reaches the resume sibling directly:
```ocaml
Resume_reconcile_gate.resume_keeper_after_reconcile_gate
  ~supervise_keepalive ctx meta;
```

rather than bouncing through the parent's 6-line wrapper. Avoids an
extra indirection hop.

## Sibling deps (all visible)
- `open Keeper_types` — `'a context`, `keeper_meta`, `Ambiguous_post_commit_{timeout,failure}` variants
- `module Startup_helpers = Keeper_supervisor_startup_helpers` — `committed_tools_of_ambiguous_blocker`
- `module Resume_reconcile_gate = Keeper_supervisor_resume_reconcile_gate` — `resume_keeper_after_reconcile_gate`
- `Keeper_approval_queue.{submit_pending, Critical}`
- `Agent_sdk.Hooks.{Approve, Edit, Reject}`
- `Log.Keeper.{info, warn}`
- `Prometheus.inc_counter`
- `Keeper_metrics.metric_keeper_supervisor_cleanup_failures`
- `Keeper_supervisor_cleanup_failure_site.{to_label, Reconcile_gate_rejected}`

No sibling -> parent cycle.

## Local build status
- `dune build --root . lib/keeper/` → clean (exit 0)
- godfile lint: sibling 86 LOC under `new_file_cap=600`; parent 1362 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim body move + 1-callback injection. Pairs with #17350.

Co-Authored-By: codex <noreply@anthropic.com>
