### PR TITLE
[codex] Require opt-in for notify execute

### DIFF
--- a/lib/notify.ml
+++ b/lib/notify.ml
@@ -90,6 +90,11 @@ let focus_on_osascript () =
   | Some value -> is_truthy value
   | None -> false
 
+let shell_execute_clicks_enabled () =
+  match getenv_nonempty "MASC_NOTIFY_ALLOW_SHELL_EXECUTE" with
+  | Some value -> is_truthy value
+  | None -> false
+
 let render_focus_template template payload =
   let replace token value acc =
     String_util.replace_substring ~needle:token ~by:value acc
@@ -126,9 +131,12 @@ let escape_shell s =
 
 (** Build click focus command from env config *)
 let build_focus_command payload =
-  match getenv_nonempty "MASC_NOTIFY_FOCUS_CMD" with
-  | Some template -> Some (render_focus_template template payload)
-  | None ->
+  if not (shell_execute_clicks_enabled ()) then
+    None
+  else
+    match getenv_nonempty "MASC_NOTIFY_FOCUS_CMD" with
+    | Some template -> Some (render_focus_template template payload)
+    | None ->
       let focus_app = getenv_nonempty "MASC_NOTIFY_FOCUS_APP" in
       let tmux_session = getenv_nonempty "MASC_TMUX_SESSION" in
       if focus_app = None && tmux_session = None then
@@ -211,9 +219,10 @@ let send_via_terminal_notifier ~title ~subtitle ~message ~sound ~focus_cmd =
      "-message"; message;
      "-group"; "masc"]
     |> fun base -> if sound then base @ ["-sound"; "default"] else base
-    |> fun base -> match focus_cmd with
-      | Some cmd -> base @ ["-execute"; cmd]
-      | None -> base
+    |> fun base ->
+    match focus_cmd with
+    | Some cmd when shell_execute_clicks_enabled () -> base @ ["-execute"; cmd]
+    | Some _ | None -> base
   in
   run_argv_ignore argv
 

--- a/test/test_notify_coverage.ml
+++ b/test/test_notify_coverage.ml
@@ -14,6 +14,27 @@ open Alcotest
 
 module Notify = Masc_mcp.Notify
 
+let source_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root -> root
+  | None -> Sys.getcwd ()
+
+let source_file rel =
+  let path = Filename.concat (source_root ()) rel in
+  let ic = open_in_bin path in
+  Fun.protect ~finally:(fun () -> close_in_noerr ic) @@ fun () ->
+  really_input_string ic (in_channel_length ic)
+
+let contains_substring haystack needle =
+  let len = String.length needle in
+  let n = String.length haystack in
+  let rec loop i =
+    if i + len > n then false
+    else if String.sub haystack i len = needle then true
+    else loop (i + 1)
+  in
+  loop 0
+
 (* ============================================================
    sanitize_token Tests
    ============================================================ *)
@@ -321,6 +342,16 @@ let test_focus_payload_all_none () =
   check (option string) "from" None p.from_agent;
   check (option string) "task" None p.task_id
 
+let test_terminal_notifier_execute_requires_opt_in () =
+  let src = source_file "lib/notify.ml" in
+  check bool "execute opt-in env is present" true
+    (contains_substring src "MASC_NOTIFY_ALLOW_SHELL_EXECUTE");
+  check bool "focus builder defaults to no shell command" true
+    (contains_substring src "if not (shell_execute_clicks_enabled ())");
+  check bool "terminal-notifier execute is guarded" true
+    (contains_substring src
+       "Some cmd when shell_execute_clicks_enabled () -> base @ [\"-execute\"; cmd]")
+
 (* ============================================================
    Test Runners
    ============================================================ *)
@@ -402,5 +433,9 @@ let () =
     "focus_payload", [
       test_case "all some" `Quick test_focus_payload_all_some;
       test_case "all none" `Quick test_focus_payload_all_none;
+    ];
+    "shell_execute_guard", [
+      test_case "terminal-notifier execute requires opt-in" `Quick
+        test_terminal_notifier_execute_requires_opt_in;
     ];
   ]


### PR DESCRIPTION
## Summary
- make terminal-notifier click execution opt-in via MASC_NOTIFY_ALLOW_SHELL_EXECUTE
- default focus command construction to None so notifications do not carry shell snippets by default
- add a notify source guard covering the execute opt-in boundary

## Local checks
- opam exec -- ocamlformat --check lib/notify.ml test/test_notify_coverage.ml
- git diff --check origin/main..HEAD
- scripts/lint-spawn-bounded.sh
- bash scripts/lint/shell-legacy-purge-ratchet.sh

## Not run locally
- scripts/dune-local.sh build test/test_notify_coverage.exe (blocked by /tmp/me-dune-local.lock held by other active worktree builds)
