### PR TITLE
fix(shell): make shell dispatch fully Shell IR native

### DIFF
--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -293,8 +293,10 @@ let claim_next_r
       ~agent_name
       ?agent_tool_names
       ?(exclude_task_ids = [])
-      ?(task_filter = fun _ -> true)
-      ?(admission_filter = fun ~active_tasks:_ _ -> true)
+      ?(task_filter : Masc_domain.task -> bool = fun _ -> true)
+      ?(admission_filter :
+         active_tasks:Masc_domain.task list -> Masc_domain.task -> bool =
+        fun ~active_tasks:_ _ -> true)
       ()
   =
   let exception Existing_claim of claim_next_result in

--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -1,14 +1,8 @@
 (* P7: Pipeline-Native Dispatch
    Execute Shell_ir.t directly via Exec_gate without going through
    /bin/bash.  Simple commands use argv-based spawn; pipelines chain
-   stdout->stdin across stages.
-
-   Controlled by [MASC_BASH_NATIVE_DISPATCH] env var:
-   - "1" (default): native dispatch for Simple, bash fallback for Pipeline
-   - "0": always fall back to bash
-
-   This module is the first step toward eliminating shell injection
-   entirely.  Pipeline support is limited to stdout->stdin chaining. *)
+   stdout->stdin across stages.  Pipeline support is limited to
+   stdout->stdin chaining. *)
 
 type dispatch_result = {
   status : Unix.process_status;
@@ -142,9 +136,3 @@ and dispatch ?timeout_sec (ir : Shell_ir.t) =
   match ir with
   | Shell_ir.Simple s -> dispatch_simple ?timeout_sec s
   | Pipeline stages -> dispatch_pipeline ?timeout_sec stages
-
-let native_dispatch_enabled () =
-  match Unix.getenv "MASC_BASH_NATIVE_DISPATCH" with
-  | exception Not_found -> true
-  | "0" -> false
-  | _ -> true

--- a/lib/exec/exec_dispatch.mli
+++ b/lib/exec/exec_dispatch.mli
@@ -19,8 +19,3 @@ val dispatch_simple :
     used by pipeline dispatch when a previous stage's stdout must be
     forwarded without dropping the stage's sandbox target.  [?timeout_sec]
     overrides the dispatch default. *)
-
-val native_dispatch_enabled : unit -> bool
-(** Check [MASC_BASH_NATIVE_DISPATCH] env var.
-    - [Some "0"] -> false (always bash fallback)
-    - unset or any other value -> true *)

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -166,11 +166,11 @@ let handle_keeper_bash_typed
               with
               | Error e -> Error e
               | Ok () ->
-                Worker_dev_tools.validate_command_paths
+                Worker_dev_tools.validate_shell_ir_paths
                   ~keeper_id:meta.name
                   ~base_path:root
                   ~workdir:cwd
-                  cmd
+                  ir
             in
             (match path_validation with
              | Error e -> error_json ~fields:[ "blocked_cmd", `String cmd_for_log ] e

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -58,80 +58,64 @@ let allowed_shell_commands =
   List.fold_left add_unique Dev_exec_allowlist.dev
     [ "diff"; "patch"; "mkdir"; "ocamlfind"; "tsc" ]
 
-let code_shell_allowlist_policy
-      ?(allow_pipes = true)
-      ~(allowed_commands : string list)
-      ()
-  : Exec_shell_gate.allowlist_policy =
-  { allowed_commands; allow_pipes }
-;;
-
-let validate_code_shell_command_block_reason
-      ?(allow_pipes = true)
-      ~(allowed_commands : string list)
-      command
-  =
-  Worker_dev_tools.validate_command_coding_with_allowlist
+let code_shell_command_context command =
+  Worker_dev_tools.command_context_coding_with_allowlist
     ~caller:Exec_shell_gate.Tool_code_write
-    ~allow_pipes
-    ~allowed_commands
+    ~allow_pipes:true
+    ~allowed_commands:allowed_shell_commands
     command
 ;;
 
 let validate_code_shell_command (command : string) : (unit, string) Result.t =
-  validate_code_shell_command_block_reason
-    ~allow_pipes:true
-    ~allowed_commands:allowed_shell_commands
-    command
+  code_shell_command_context command
   |> Result.map_error
        (Worker_dev_tools.block_reason_to_string_with_allowlist
           ~allowed_commands:allowed_shell_commands)
+  |> Result.map (fun _ -> ())
 
 type code_shell_exit_status =
   | Shell_ok
   | Shell_ok_expected_nonzero of string
   | Shell_error
 
-(* RFC-0131 Phase 2 (Shell IR Promotion Goal, 2026-05-18) — the local
-   string-splitter fallback ([first_token_basename] +
-   [last_pipeline_segment]) was the last in-module shell splitter in
-   [tool_code_write].  It existed to keep exit classification working
-   when the Shell gate could not produce a typed AST.
-
-   Phase 2 explicitly removes that fallback: the exec facade is the only
-   parse path.  When the parser cannot lift the command, the last-stage
-   binary name is genuinely unknown — we conservatively fall through to
-   [Shell_error] instead of silently re-deriving a name from a different
-   splitter.  This matches Phase 2's rule "이 PR 이후
-   lib/tool_code_write.ml 에는 shell splitter가 없어야 한다" and the
-   Plan's separation of parse / validation / exec / classify error
-   classes. *)
-let exit_status_command_name command =
-  match
-    Exec_shell_gate.gate
-      ~caller:Exec_shell_gate.Tool_code_write
-      ~raw:command
-      ~allowlist:
-        (code_shell_allowlist_policy
-           ~allow_pipes:true
-           ~allowed_commands:allowed_shell_commands
-           ())
-      ~path_policy:Exec_shell_gate.allow_all_paths
-      ~sandbox:Exec_shell_gate.host_sandbox
-      ()
-  with
-  | Allow context -> Exec_shell_gate.last_stage_bin context
-  | Reject _ | Cannot_parse _ | Too_complex _ -> None
-
-let classify_code_shell_exit ~command code =
+let classify_code_shell_exit ~last_stage_bin code =
   match code with
   | 0 -> Shell_ok
   | 1 -> (
-      match exit_status_command_name command with
+      match last_stage_bin with
       | Some ("rg" | "grep") -> Shell_ok_expected_nonzero "no_matches"
       | Some "diff" -> Shell_ok_expected_nonzero "differences"
       | Some _ | None -> Shell_error)
   | _ -> Shell_error
+
+let shell_ir_with_default_cwd cwd ir =
+  match cwd with
+  | None -> ir
+  | Some dir ->
+    let default_cwd = Masc_exec.Path_scope.classify ~raw:dir ~cwd:dir in
+    let rec map_ir = function
+      | Masc_exec.Shell_ir.Simple simple ->
+        let simple =
+          match simple.cwd with
+          | Some _ -> simple
+          | None -> { simple with cwd = Some default_cwd }
+        in
+        Masc_exec.Shell_ir.Simple simple
+      | Masc_exec.Shell_ir.Pipeline stages ->
+        Masc_exec.Shell_ir.Pipeline (List.map map_ir stages)
+    in
+    map_ir ir
+;;
+
+let output_for_dispatch_status ~(status : Unix.process_status) ~stdout ~stderr =
+  match status with
+  | Unix.WEXITED 0 -> stdout
+  | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> (
+    match stdout, stderr with
+    | "", err -> err
+    | out, "" -> out
+    | out, err -> out ^ "\n" ^ err)
+;;
 
 let git_common_root path =
   try
@@ -731,12 +715,14 @@ let handle_code_shell ~tool_name ~start_time ctx args =
 
   if String.equal command "" then Tool_result.error ~tool_name ~start_time "command parameter required"
   else
-    match validate_code_shell_command command with
+    match code_shell_command_context command with
     | Error reason ->
         Tool_result.error ~tool_name ~start_time
           ~failure_class:(Some Tool_result.Workflow_rejection)
-          reason
-    | Ok () ->
+          (Worker_dev_tools.block_reason_to_string_with_allowlist
+             ~allowed_commands:allowed_shell_commands
+             reason)
+    | Ok command_context ->
         (* Validate cwd if provided *)
         let cwd_result =
           if String.equal cwd "" then Ok None
@@ -758,27 +744,39 @@ let handle_code_shell ~tool_name ~start_time ctx args =
                | Some dir -> dir
                | None -> Sys.getcwd ()
              in
-             match Worker_dev_tools.validate_command_paths ~workdir:path_workdir command with
-             | Error reason ->
-                 Tool_result.error ~tool_name ~start_time
-                   ~failure_class:(Some Tool_result.Policy_rejection)
-                   reason
-             | Ok () ->
-                 let full_cmd = [(Host_config.host ()).host_sh; "-c"; command] in
-                 match
-                   Masc_exec.Exec_gate.run_argv_with_status
-                     ~actor:`Tool_local_runtime
-                     ~raw_source:(String.concat " " full_cmd)
-                     ~summary:"shell command execution"
-                     ~timeout_sec:safe_timeout
-                     ?cwd:cwd_opt
-                     full_cmd
-                 with
-                 | Unix.WEXITED code, output ->
-                     let exit_status = classify_code_shell_exit ~command code in
-                     let response_fields =
-                       [
-                         ( "status",
+	             match
+	               Worker_dev_tools.validate_shell_ir_paths
+	                 ~workdir:path_workdir
+	                 command_context.Exec_shell_gate.ast
+	             with
+	             | Error reason ->
+	                 Tool_result.error ~tool_name ~start_time
+	                   ~failure_class:(Some Tool_result.Policy_rejection)
+	                   reason
+	             | Ok () ->
+	                 match
+	                   Masc_exec.Exec_dispatch.dispatch
+	                     ~timeout_sec:safe_timeout
+	                     (shell_ir_with_default_cwd
+	                        cwd_opt
+	                        command_context.Exec_shell_gate.ast)
+	                 with
+	                 | { status = Unix.WEXITED code; stdout; stderr } ->
+	                     let output =
+	                       output_for_dispatch_status
+	                         ~status:(Unix.WEXITED code)
+	                         ~stdout
+	                         ~stderr
+	                     in
+	                     let exit_status =
+	                       classify_code_shell_exit
+	                         ~last_stage_bin:
+	                           (Exec_shell_gate.last_stage_bin command_context)
+	                         code
+	                     in
+	                     let response_fields =
+	                       [
+	                         ( "status",
                            `String (match exit_status with Shell_error -> "error" | _ -> "ok") );
                          ("exit_code", `Int code);
                          ("output", `String (truncate_output output));
@@ -795,12 +793,33 @@ let handle_code_shell ~tool_name ~start_time ctx args =
                      (match exit_status with
                       | Shell_ok | Shell_ok_expected_nonzero _ ->
                           fun msg -> Tool_result.ok ~tool_name ~start_time msg
-                      | Shell_error ->
-                          fun msg -> Tool_result.error ~tool_name ~start_time msg)
-                       (Yojson.Safe.pretty_to_string response)
-                 | _, output ->
-                     Tool_result.error ~tool_name ~start_time
-                       (Printf.sprintf "Command failed: %s" (truncate_output output)))
+	                       | Shell_error ->
+	                           fun msg -> Tool_result.error ~tool_name ~start_time msg)
+	                       (Yojson.Safe.pretty_to_string response)
+	                 | { status = Unix.WSIGNALED sig_num; stdout; stderr } ->
+	                     let output =
+	                       output_for_dispatch_status
+	                         ~status:(Unix.WSIGNALED sig_num)
+	                         ~stdout
+	                         ~stderr
+	                     in
+	                     Tool_result.error ~tool_name ~start_time
+	                       (Printf.sprintf
+	                          "Killed by signal %d: %s"
+	                          sig_num
+	                          (truncate_output output))
+	                 | { status = Unix.WSTOPPED sig_num; stdout; stderr } ->
+	                     let output =
+	                       output_for_dispatch_status
+	                         ~status:(Unix.WSTOPPED sig_num)
+	                         ~stdout
+	                         ~stderr
+	                     in
+	                     Tool_result.error ~tool_name ~start_time
+	                       (Printf.sprintf
+	                          "Stopped by signal %d: %s"
+	                          sig_num
+	                          (truncate_output output)))
 
 (* Handler: masc_code_git — Git operations *)
 let code_git_route_fields (ctx : context) =

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -374,7 +374,7 @@ let record_exec_shell_gate ?caller verdict =
       ~verdict:(legendary_verdict_of_exec verdict)
 ;;
 
-let validate_command_coding_with_allowlist
+let command_context_coding_with_allowlist
       ?caller
       ?(allow_pipes = true)
       ~(allowed_commands : string list)
@@ -398,7 +398,10 @@ let validate_command_coding_with_allowlist
     | Allow context ->
       if context.Exec_shell_gate.direct_dune_seen
       then Error Direct_dune_invocation
-      else validate_wrapped_stages ~allowed_commands context.Exec_shell_gate.ast
+      else (
+        match validate_wrapped_stages ~allowed_commands context.Exec_shell_gate.ast with
+        | Ok () -> Ok context
+        | Error _ as err -> err)
     | Reject { context; reason; _ } ->
       (match reason with
        | Pipes_not_allowed _ -> Error Pipes_not_allowed
@@ -407,6 +410,15 @@ let validate_command_coding_with_allowlist
        | _ -> Error (block_reason_of_exec_reject reason))
     | Cannot_parse _ -> Error Injection
     | Too_complex { reason } -> Error (block_reason_of_exec_too_complex reason))
+;;
+
+let validate_command_coding_with_allowlist ?caller ?allow_pipes ~allowed_commands cmd =
+  command_context_coding_with_allowlist
+    ?caller
+    ?allow_pipes
+    ~allowed_commands
+    cmd
+  |> Result.map (fun _ -> ())
 ;;
 
 (** Relaxed command validation for Coding/Full preset keepers.
@@ -752,7 +764,7 @@ let existing_dir_path_values cmd =
   | Masc_exec.Parsed.Too_complex _ -> []
 ;;
 
-let validate_command_paths ?keeper_id ?base_path ?workdir cmd =
+let validate_shell_ir_paths ?keeper_id ?base_path ?workdir shell_ir =
   match workdir with
   | None -> Ok ()
   | Some _ ->
@@ -842,11 +854,16 @@ let validate_command_paths ?keeper_id ?base_path ?workdir cmd =
           in
           loop stages
       in
-      (match Masc_exec_bash_parser.Bash.parse_string cmd with
-       | Masc_exec.Parsed.Parsed shell_ir -> validate_parsed_shell_ir shell_ir
-       | Masc_exec.Parsed.Parse_error _
-       | Masc_exec.Parsed.Parse_aborted _
-       | Masc_exec.Parsed.Too_complex _ -> Ok ())
+      validate_parsed_shell_ir shell_ir
+;;
+
+let validate_command_paths ?keeper_id ?base_path ?workdir cmd =
+  match Masc_exec_bash_parser.Bash.parse_string cmd with
+  | Masc_exec.Parsed.Parsed shell_ir ->
+    validate_shell_ir_paths ?keeper_id ?base_path ?workdir shell_ir
+  | Masc_exec.Parsed.Parse_error _
+  | Masc_exec.Parsed.Parse_aborted _
+  | Masc_exec.Parsed.Too_complex _ -> Ok ()
 ;;
 
 (** Check if a command performs write/mutating operations.
@@ -1257,7 +1274,11 @@ let make_shell_exec_with_allowlist
               | Some dir when String.trim dir <> "" -> dir
               | Some _ | None -> Sys.getcwd ()
             in
-            (match validate_command_paths ~workdir:path_workdir command with
+            (match
+               validate_shell_ir_paths
+                 ~workdir:path_workdir
+                 context.Exec_shell_gate.ast
+             with
              | Error message ->
                Option.iter
                  (fun (f : tool_exec_observer) ->

--- a/lib/worker_dev_tools.mli
+++ b/lib/worker_dev_tools.mli
@@ -91,14 +91,33 @@ val validate_command_coding_with_allowlist
   -> string
   -> (unit, block_reason) result
 
-(** When [workdir] is supplied, parse [cmd] through Shell IR and gate every
-    literal path-bearing argv/redirect value against the path allowlist.
+(** Variant of {!validate_command_coding_with_allowlist} for callers that need
+    to keep the authoritative Shell IR context for execution or follow-up
+    validation. *)
+val command_context_coding_with_allowlist
+  :  ?caller:Masc_exec_command_gate.Shell_command_gate.caller
+  -> ?allow_pipes:bool
+  -> allowed_commands:string list
+  -> string
+  -> (Masc_exec_command_gate.Shell_command_gate.parsed_context, block_reason) result
+
+(** When [workdir] is supplied, gate every literal path-bearing argv/redirect
+    value in [shell_ir] against the path allowlist.
     Values may stay under [workdir],
     [/tmp], the owning worktree repo root, or a registered repository path
     allowed by {!Keeper_repo_mapping} when both [keeper_id] and [base_path]
     are supplied. Returns [Error msg] with the rejected value when a path
     escapes the allowlist.
     Returns [Ok ()] unconditionally when [workdir = None]. *)
+val validate_shell_ir_paths
+  :  ?keeper_id:string
+  -> ?base_path:string
+  -> ?workdir:string
+  -> Masc_exec.Shell_ir.t
+  -> (unit, string) result
+
+(** Compatibility wrapper for legacy string call sites. Prefer
+    {!validate_shell_ir_paths} when the caller already has Shell IR. *)
 val validate_command_paths
   :  ?keeper_id:string
   -> ?base_path:string

--- a/test/test_exec_dispatch.ml
+++ b/test/test_exec_dispatch.ml
@@ -34,16 +34,6 @@ let () =
   assert (result = "prefix-world-suffix");
   Unix.putenv "MASC_TEST_P7_VAR" ""
 
-(* --- native_dispatch_enabled --- *)
-
-let () =
-  Unix.putenv "MASC_BASH_NATIVE_DISPATCH" "0";
-  assert (not (Masc_exec.Exec_dispatch.native_dispatch_enabled ()));
-  Unix.putenv "MASC_BASH_NATIVE_DISPATCH" "1";
-  assert (Masc_exec.Exec_dispatch.native_dispatch_enabled ());
-  Unix.putenv "MASC_BASH_NATIVE_DISPATCH" "";
-  assert (Masc_exec.Exec_dispatch.native_dispatch_enabled ())
-
 (* --- dispatch_simple with real process --- *)
 
 let () =

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -1358,6 +1358,25 @@ let () =
       (* The path validator now consumes Shell IR and validates literal
          path-bearing argv/redirect values. Syntax policy lives in the
          command gate; this suite keeps only containment behaviour here. *)
+      Alcotest.test_case "Shell IR outside literal path is blocked"
+        `Quick (fun () ->
+          let open Masc_exec.Shell_ir in
+          let bin = Masc_exec.Bin.of_string "cat" |> Result.get_ok in
+          let ir =
+            Simple
+              { bin
+              ; args = [ Lit "/etc/passwd" ]
+              ; env = []
+              ; cwd = None
+              ; redirects = []
+              ; sandbox = Masc_exec.Sandbox_target.host ()
+              }
+          in
+          match Worker_dev_tools.validate_shell_ir_paths ~workdir:"/tmp" ir with
+          | Error msg ->
+            Alcotest.(check bool) "outside path blocked" true
+              (contains_substring msg "outside allowed directories")
+          | Ok () -> Alcotest.fail "outside Shell IR literal path must be blocked");
       Alcotest.test_case "outside literal path is blocked"
         `Quick (fun () ->
           match Worker_dev_tools.validate_command_paths


### PR DESCRIPTION
## Summary
- route keeper_bash, worker shell_exec, and masc_code_shell path validation through existing Shell IR instead of reparsing command strings
- dispatch masc_code_shell via Exec_dispatch instead of /bin/sh -c
- remove the dead MASC_BASH_NATIVE_DISPATCH/native_dispatch_enabled fallback knob
- add a direct Shell IR path-validation regression test
- repair latest-main claim_next_r type/warning regression that blocked focused builds

## Verification
- ocamlformat --check lib/coord/coord_task_schedule.ml lib/exec/exec_dispatch.ml lib/exec/exec_dispatch.mli lib/worker_dev_tools.ml lib/worker_dev_tools.mli lib/keeper/keeper_shell_bash.ml lib/tool_code_write.ml test/test_worker_dev_tools.ml test/test_exec_dispatch.ml
- git diff --check
- rg -n "MASC_BASH_NATIVE_DISPATCH|native_dispatch_enabled|Host_config.host \\(\\).*host_sh|shell command execution|validate_command_paths ~workdir:path_workdir command|split_pipeline_segments|tokenize_path_args|path_validation_tokens|forbidden_shell_chars|quote_aware_shape_scan_text|raw_keeper_bash_shape_block" lib test  # only unrelated cdal fixture text remains when using broader phrase search

## Local Dune
Attempted focused build:
MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_exec_dispatch.exe test/test_worker_dev_tools.exe test/test_tool_code_write_coverage.exe test/test_keeper_bash_safety.exe test/test_keeper_bash_typed_input.exe

Result: local build could not complete cleanly because this host has several concurrent bare Dune builds and lock contention. A first run exposed a latest-main Timeout_origin wiring error, fixed upstream by #17352 and rebased in. A second run exposed a latest-main coord_task_schedule type/warning regression, repaired in this PR. Subsequent wrapper attempts were blocked by machine-wide Dune contention.