### PR TITLE
refactor(operator_control_snapshot): extract snapshot_view variant + parser sibling

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -871,51 +871,19 @@ let room_json config =
       ])
 ;;
 
-type snapshot_view =
+(* snapshot_view variant + parser extracted to
+   [Operator_control_snapshot_view] (godfile decomp). *)
+type snapshot_view = Operator_control_snapshot_view.snapshot_view =
   | Summary
   | Sessions
   | Keepers
   | Messages
   | Full
 
-(* Issue #8471: Variant SSOT for [snapshot_view]. Adding a constructor
-   forces [snapshot_view_to_string] exhaustiveness AND extends
-   [valid_snapshot_view_strings]; the schema in [tool_operator.ml]
-   derives its enum from this list, so a new constructor flows
-   through automatically instead of silently dropping (as [Sessions]
-   did before this fix). *)
-let snapshot_view_to_string = function
-  | Summary -> "summary"
-  | Sessions -> "sessions"
-  | Keepers -> "keepers"
-  | Messages -> "messages"
-  | Full -> "full"
-;;
-
-let all_snapshot_views = [ Summary; Sessions; Keepers; Messages; Full ]
-let valid_snapshot_view_strings = List.map snapshot_view_to_string all_snapshot_views
-
-(* Sound partial parser — Some for canonical strings, None otherwise.
-   [parse_snapshot_view] below intentionally falls back to [Full] for
-   tool/HTTP back-compat; this opt variant exists for callers that
-   want to distinguish unknown input. *)
-let snapshot_view_of_string_opt raw =
-  match String.trim raw |> String.lowercase_ascii with
-  | "summary" -> Some Summary
-  | "sessions" -> Some Sessions
-  | "keepers" -> Some Keepers
-  | "messages" -> Some Messages
-  | "full" -> Some Full
-  | _ -> None
-;;
-
-let parse_snapshot_view = function
-  | Some raw ->
-    (match snapshot_view_of_string_opt raw with
-     | Some v -> v
-     | None -> Full)
-  | None -> Full
-;;
+let snapshot_view_to_string = Operator_control_snapshot_view.snapshot_view_to_string
+let valid_snapshot_view_strings = Operator_control_snapshot_view.valid_snapshot_view_strings
+let snapshot_view_of_string_opt = Operator_control_snapshot_view.snapshot_view_of_string_opt
+let parse_snapshot_view = Operator_control_snapshot_view.parse_snapshot_view
 
 (* Snapshot TTL cache with same-key deduplication (singleflight).
    When multiple fibers hit a cache miss for the same key concurrently,

--- a/lib/operator/operator_control_snapshot_view.ml
+++ b/lib/operator/operator_control_snapshot_view.ml
@@ -1,0 +1,57 @@
+(** Operator snapshot view selector, extracted from
+    [operator_control_snapshot.ml] (godfile decomp).
+
+    The variant + parser cluster used to thread the operator
+    dashboard's per-section snapshot selector through the HTTP layer
+    and the [tool_operator] schema. Issue #8471 keeps
+    [snapshot_view_to_string] exhaustive against the variant and
+    derives [valid_snapshot_view_strings] from [all_snapshot_views]
+    so adding a constructor flows through to both the parser and
+    the schema's user-visible catalogue automatically (the previous
+    sparse string-list version silently dropped [Sessions]). *)
+
+type snapshot_view =
+  | Summary
+  | Sessions
+  | Keepers
+  | Messages
+  | Full
+
+(* Issue #8471: Variant SSOT for [snapshot_view]. Adding a constructor
+   forces [snapshot_view_to_string] exhaustiveness AND extends
+   [valid_snapshot_view_strings]; the schema in [tool_operator.ml]
+   derives its enum from this list, so a new constructor flows
+   through automatically instead of silently dropping (as [Sessions]
+   did before this fix). *)
+let snapshot_view_to_string = function
+  | Summary -> "summary"
+  | Sessions -> "sessions"
+  | Keepers -> "keepers"
+  | Messages -> "messages"
+  | Full -> "full"
+;;
+
+let all_snapshot_views = [ Summary; Sessions; Keepers; Messages; Full ]
+let valid_snapshot_view_strings = List.map snapshot_view_to_string all_snapshot_views
+
+(* Sound partial parser — Some for canonical strings, None otherwise.
+   [parse_snapshot_view] below intentionally falls back to [Full] for
+   tool/HTTP back-compat; this opt variant exists for callers that
+   want to distinguish unknown input. *)
+let snapshot_view_of_string_opt raw =
+  match String.trim raw |> String.lowercase_ascii with
+  | "summary" -> Some Summary
+  | "sessions" -> Some Sessions
+  | "keepers" -> Some Keepers
+  | "messages" -> Some Messages
+  | "full" -> Some Full
+  | _ -> None
+;;
+
+let parse_snapshot_view = function
+  | Some raw ->
+    (match snapshot_view_of_string_opt raw with
+     | Some v -> v
+     | None -> Full)
+  | None -> Full
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane F
- 2nd sibling extracted from `operator_control_snapshot.ml` (after #17329 `identity_fields`).
- **First type-extraction cycle in this sprint** — establishes the transparent-alias pattern for moving variant types between siblings.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/operator/operator_control_snapshot.ml` | 1298 | 1266 | **-32** |
| `lib/operator/operator_control_snapshot_view.ml` | — | 57 | +57 |

## Moved (verbatim, no behavior change)
- `type snapshot_view = Summary | Sessions | Keepers | Messages | Full`
- `snapshot_view_to_string` (exhaustive pattern match)
- `all_snapshot_views = [ Summary; Sessions; Keepers; Messages; Full ]`
- `valid_snapshot_view_strings = List.map snapshot_view_to_string all_snapshot_views`
- `snapshot_view_of_string_opt` (partial, returns `None` for unknown input)
- `parse_snapshot_view` (total, falls back to `Full` for HTTP/tool back-compat)

The Issue #8471 SSOT pattern is preserved verbatim:
- variant exhaustiveness forces `snapshot_view_to_string` to cover new constructors
- `valid_snapshot_view_strings` is derived from `all_snapshot_views`, so the
  wire catalogue and the `tool_operator` schema enum auto-update
- the previous sparse string-list version silently dropped `Sessions`;
  this cluster fixed that and that property is preserved

## Type-extraction pattern
Parent re-exports the type via transparent alias:
```ocaml
type snapshot_view = Operator_control_snapshot_view.snapshot_view =
  | Summary
  | Sessions
  | Keepers
  | Messages
  | Full
```

This makes `Operator_control_snapshot.snapshot_view` and
`Operator_control_snapshot_view.snapshot_view` the **same type** (same
identity) — external callers' `Operator_control_snapshot.Summary` /
`.Sessions` / etc. constructor references keep working unchanged.

Parent also retains 4 single-line value aliases:
- 3 `.mli`-exposed: `snapshot_view_to_string`, `valid_snapshot_view_strings`,
  `snapshot_view_of_string_opt`
- 1 internal: `parse_snapshot_view` (used by `snapshot_json` at parent
  line 1155, now line ~1123 post-splice)

`all_snapshot_views` doesn't need an alias because no parent caller
uses it outside this cluster.

## External callers (all keep working unchanged via aliases)
- `lib/tool_operator.ml:81,85` — uses `Operator_control_snapshot.valid_snapshot_view_strings` (schema enum derivation)
- `test/test_types.ml:463,470,473` — uses `valid_snapshot_view_strings` + `snapshot_view_of_string_opt`

## Sibling deps
None beyond `Stdlib` (`String.trim`, `String.lowercase_ascii`, `List.map`).
Truly self-contained cluster.

No sibling -> parent cycle.

## Local build status
- `dune build --root . lib/operator/` → clean (exit 0)
- godfile lint: sibling 57 LOC under `new_file_cap=600`; parent 1266 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim type + 5-function cluster move via transparent alias.

Co-Authored-By: codex <noreply@anthropic.com>
