### PR TITLE
Regenerate lib dependency graph

### DIFF
--- a/reports/lib-dependency-graph.json
+++ b/reports/lib-dependency-graph.json
@@ -1,173 +1,173 @@
 {
   "stats": {
-    "total_modules": 766,
-    "total_edges": 3566,
-    "avg_out_degree": 4.66,
-    "leaf_count": 192,
-    "root_count": 80
+    "total_modules": 1052,
+    "total_edges": 4409,
+    "avg_out_degree": 4.19,
+    "leaf_count": 266,
+    "root_count": 167
   },
   "top_imported": [
     [
       "Prometheus",
-      165
-    ],
-    [
-      "Coord",
-      149
+      227
     ],
     [
       "Keeper_types",
-      142
+      217
+    ],
+    [
+      "Coord",
+      193
     ],
     [
       "Keeper_metrics",
-      91
-    ],
-    [
-      "Tool_result",
-      56
+      148
     ],
     [
       "Keeper_registry",
-      51
+      80
     ],
     [
       "Keeper_id",
-      50
-    ],
-    [
-      "Keeper_cascade_profile",
-      49
-    ],
-    [
-      "Tool_dispatch",
-      47
-    ],
-    [
-      "Tool_args",
-      42
-    ],
-    [
-      "Mcp_server",
-      42
-    ],
-    [
-      "Provider_adapter",
-      40
-    ],
-    [
-      "Server_auth",
-      39
-    ],
-    [
-      "Tool_catalog",
-      37
-    ],
-    [
-      "Keeper_config",
-      36
+      63
     ],
     [
       "Keeper_state_machine",
-      34
+      57
+    ],
+    [
+      "Keeper_cascade_profile",
+      50
+    ],
+    [
+      "Tool_dispatch",
+      48
+    ],
+    [
+      "Mcp_server",
+      48
+    ],
+    [
+      "Keeper_config",
+      42
+    ],
+    [
+      "Server_auth",
+      40
+    ],
+    [
+      "Tool_catalog",
+      39
     ],
     [
       "Server_utils",
+      38
+    ],
+    [
+      "Keeper_exec_context",
+      37
+    ],
+    [
+      "Sse",
       34
+    ],
+    [
+      "Keeper_types_profile",
+      33
     ],
     [
       "Keeper_alerting_path",
       32
     ],
     [
-      "Sse",
-      31
+      "Dashboard",
+      32
     ],
     [
-      "Config_dir_resolver",
-      30
+      "Cascade_runtime",
+      31
     ]
   ],
   "top_importers": [
     [
       "Server_bootstrap_loops",
-      72
+      76
     ],
     [
       "Server_runtime_bootstrap",
-      59
-    ],
-    [
-      "Keeper_unified_turn",
-      56
-    ],
-    [
-      "Dashboard_http_keeper",
-      49
-    ],
-    [
-      "Keeper_run_tools",
-      47
-    ],
-    [
-      "Mcp_server_eio_execute",
-      45
-    ],
-    [
-      "Server_dashboard_http_keeper_api",
-      43
+      58
     ],
     [
       "Keeper_agent_run",
-      42
+      51
     ],
     [
-      "Server_routes_http_routes_dashboard",
-      42
+      "Keeper_run_tools",
+      48
     ],
     [
-      "Keeper_heartbeat_loop",
-      36
+      "Keeper_unified_turn",
+      44
+    ],
+    [
+      "Mcp_server_eio_execute",
+      44
+    ],
+    [
+      "Keeper_supervisor",
+      39
+    ],
+    [
+      "Server_dashboard_http_keeper_api",
+      39
+    ],
+    [
+      "Dashboard_http_keeper",
+      38
     ],
     [
       "Keeper_turn",
       36
     ],
     [
-      "Keeper_supervisor",
-      35
+      "Server_routes_http_routes_dashboard",
+      36
     ],
     [
-      "Keeper_turn_up_create",
-      31
+      "Keeper_heartbeat_loop",
+      33
     ],
     [
       "Mcp_server_eio_call_tool",
-      31
-    ],
-    [
-      "Tool_keeper",
-      31
-    ],
-    [
-      "Keeper_unified_metrics",
-      29
+      33
     ],
     [
       "Server_h2_gateway",
-      29
+      32
+    ],
+    [
+      "Server_routes_http_runtime",
+      31
+    ],
+    [
+      "Keeper_turn_up_create",
+      30
     ],
     [
       "Server_dashboard_http",
-      27
+      30
     ],
     [
-      "Keeper_status_detail",
+      "Keeper_turn_driver",
+      28
+    ],
+    [
+      "Keeper_tools_oas",
       26
     ],
     [
-      "Keeper_world_observation",
-      25
+      "Server_dashboard_http_core",
+      26
     ]
   ],
   "cycles": [
@@ -176,17 +176,22 @@
       "Anti_rationalization",
       "Auth",
       "Auth_resolve",
-      "Autoresearch",
-      "Autoresearch_codegen",
       "Capability_registry",
+      "Cascade_agent_context",
       "Cascade_attempt_fsm",
+      "Cascade_config_builder",
       "Cascade_error_classify",
+      "Cascade_inference",
+      "Cascade_legacy_runner",
       "Cascade_oas_runner",
       "Cascade_runner",
+      "Cascade_runtime_candidate",
       "Cascade_transport",
+      "Cascade_transport_authorization",
+      "Cascade_transport_mcp_policy_helpers",
+      "Cascade_transport_mcp_tool_classifier",
       "Config",
       "Coord",
-      "Credential_provider",
       "Dashboard",
       "Dashboard_attention",
       "Dashboard_governance_metrics",
@@ -205,27 +210,29 @@
       "Governance_pipeline",
       "Governance_pipeline_risk",
       "Governance_registry",
-      "Host_config_provider",
       "Http_server_eio",
       "Keeper_accountability",
+      "Keeper_activation_readiness",
       "Keeper_agent_checkpoint_hygiene",
-      "Keeper_agent_context",
       "Keeper_agent_error",
       "Keeper_agent_memory_episode",
       "Keeper_agent_prompt_metrics",
       "Keeper_agent_result",
       "Keeper_agent_run",
+      "Keeper_agent_run_receipt_append",
       "Keeper_agent_tool_surface",
       "Keeper_alerting",
       "Keeper_alerting_path",
       "Keeper_approval_queue",
-      "Keeper_benchmark_canary",
+      "Keeper_callback_failure",
+      "Keeper_cdal_contract",
       "Keeper_checkpoint_store",
       "Keeper_cli_mcp_config",
       "Keeper_compact_policy",
       "Keeper_config",
       "Keeper_context_core",
       "Keeper_contract_classifier",
+      "Keeper_credential_provider",
       "Keeper_current_task_reconcile",
       "Keeper_cwd_response",
       "Keeper_decision_audit",
@@ -234,6 +241,7 @@
       "Keeper_exec_board",
       "Keeper_exec_context",
       "Keeper_exec_fs",
+      "Keeper_exec_ide",
       "Keeper_exec_masc",
       "Keeper_exec_memory",
       "Keeper_exec_preflight",
@@ -251,7 +259,12 @@
       "Keeper_goal_repair",
       "Keeper_guards",
       "Keeper_hooks_oas",
+      "Keeper_host_config_provider",
       "Keeper_identity",
+      "Keeper_lifecycle_hooks",
+      "Keeper_llm_bridge",
+      "Keeper_memory_bank",
+      "Keeper_memory_llm_summary",
       "Keeper_memory_policy",
       "Keeper_memory_recall",
       "Keeper_meta_contract",
@@ -259,19 +272,32 @@
       "Keeper_personality_io",
       "Keeper_post_turn",
       "Keeper_prompt",
+      "Keeper_reaction_ledger",
       "Keeper_registry",
+      "Keeper_registry_broadcast",
+      "Keeper_registry_cascade_attempt",
+      "Keeper_registry_error_recording",
+      "Keeper_registry_event_validators",
+      "Keeper_registry_fsm_validators",
+      "Keeper_registry_lookup",
+      "Keeper_registry_types",
       "Keeper_repo_readiness",
       "Keeper_rollover",
+      "Keeper_routine_allowlist",
       "Keeper_run_context",
       "Keeper_run_prompt",
       "Keeper_run_tools",
+      "Keeper_run_tools_hook_accumulator",
+      "Keeper_run_tools_work_discovery",
       "Keeper_runtime_contract",
+      "Keeper_runtime_manifest",
       "Keeper_sandbox",
       "Keeper_sandbox_containment",
       "Keeper_sandbox_control",
       "Keeper_sandbox_factory",
       "Keeper_sandbox_runtime",
-      "Keeper_shell_bg_task",
+      "Keeper_shell_bash",
+      "Keeper_shell_command_semantics",
       "Keeper_shell_docker",
       "Keeper_shell_gh_context",
       "Keeper_shell_shared",
@@ -281,8 +307,10 @@
       "Keeper_social_model_registry",
       "Keeper_status_bridge",
       "Keeper_summarizer",
+      "Keeper_task_worktree_lazy",
       "Keeper_text_processing",
       "Keeper_tool_call_log",
+      "Keeper_tool_call_log_context",
       "Keeper_tool_disclosure",
       "Keeper_tool_github_pr",
       "Keeper_tool_guidance",
@@ -290,9 +318,11 @@
       "Keeper_tool_policy_config",
       "Keeper_tool_pr_review",
       "Keeper_tool_registry",
+      "Keeper_tool_resolution",
       "Keeper_tools_oas",
       "Keeper_trace_emit",
       "Keeper_turn_driver",
+      "Keeper_turn_driver_admission",
       "Keeper_turn_driver_helpers",
       "Keeper_turn_driver_try_provider",
       "Keeper_turn_driver_wrappers",
@@ -300,41 +330,47 @@
       "Keeper_turn_telemetry",
       "Keeper_turn_terminal",
       "Keeper_turn_terminal_code",
+      "Keeper_types",
       "Keeper_types_profile",
       "Keeper_types_support",
       "Keeper_unified_metrics",
+      "Keeper_unified_metrics_broadcast",
+      "Keeper_unified_metrics_decision",
+      "Keeper_unified_metrics_failure",
+      "Keeper_unified_metrics_result",
+      "Keeper_unified_metrics_snapshot",
       "Keeper_voice_local",
       "Keeper_world_observation",
+      "Llm_metric_bridge",
       "Masc_grpc_server",
       "Masc_grpc_service",
       "Masc_grpc_transport",
+      "Masc_oas_bridge",
       "Mcp_server",
       "Memory_hooks",
       "Memory_oas_bridge",
+      "Memory_oas_bridge_cache",
       "Operator_judgment",
       "Operator_pending_confirm",
       "Otel_spans",
       "Planning_eio",
       "Procedural_memory",
+      "Provider_health",
       "Runtime_params",
       "Server_mcp_transport_ws",
       "Server_startup_state",
       "Server_webrtc_transport",
       "Server_ws_standalone",
       "Sse",
+      "Task_sandbox",
       "Tempo",
       "Tool_access_policy",
-      "Tool_access_role",
       "Tool_agent_timeline",
-      "Tool_autoresearch_broadcast",
-      "Tool_autoresearch_context",
-      "Tool_autoresearch_cycle",
-      "Tool_autoresearch_registry",
-      "Tool_board",
       "Tool_bridge",
       "Tool_catalog",
       "Tool_code",
       "Tool_code_write",
+      "Tool_code_write_git_policy",
       "Tool_dispatch",
       "Tool_help_registry",
       "Tool_input_validation",
@@ -349,37 +385,59 @@
       "Tool_spec",
       "Tool_suspend",
       "Tool_task",
+      "Tool_telemetry",
       "Tools",
       "Transport",
       "Transport_metrics",
       "Verification_protocol",
       "Voice_bridge",
       "Voice_session_manager",
-      "Worker_dev_tools",
-      "Workflow_guide"
+      "Worktree_live_context"
+    ],
+    [
+      "Autoresearch",
+      "Autoresearch_codegen"
     ]
   ],
   "clusters": [
     {
-      "prefix": "tool_call",
+      "prefix": "model_inference",
+      "module_count": 6,
+      "members": [
+        "Model_inference_metrics",
+        "Model_inference_metrics_aggregate",
+        "Model_inference_metrics_entry",
+        "Model_inference_metrics_json",
+        "Model_inference_metrics_parser",
+        "Model_inference_metrics_reader"
+      ],
+      "internal_edges": 8,
+      "external_dep_count": 1,
+      "coupling_ratio": 0.889
+    },
+    {
+      "prefix": "prometheus_builtin",
       "module_count": 7,
       "members": [
-        "Tool_call_quality_benchmark",
-        "Tool_call_quality_benchmark_loader",
-        "Tool_call_quality_benchmark_render",
-        "Tool_call_quality_benchmark_scoring",
-        "Tool_call_quality_benchmark_summary",
-        "Tool_call_quality_benchmark_types",
-        "Tool_call_replay_harness"
+        "Prometheus_builtin_metric_names",
+        "Prometheus_builtin_metrics",
+        "Prometheus_builtin_metrics_part1",
+        "Prometheus_builtin_metrics_part2",
+        "Prometheus_builtin_metrics_part3",
+        "Prometheus_builtin_metrics_part4",
+        "Prometheus_builtin_metrics_part5"
       ],
-      "internal_edges": 9,
+      "internal_edges": 10,
       "external_dep_count": 2,
-      "coupling_ratio": 0.818
+      "coupling_ratio": 0.833
     },
     {
       "prefix": "server_mcp",
-      "module_count": 10,
+      "module_count": 13,
       "members": [
+        "Server_mcp_actor_injection",
+        "Server_mcp_request_context",
+        "Server_mcp_streaming_tools",
         "Server_mcp_transport_http",
         "Server_mcp_transport_http_agui",
         "Server_mcp_transport_http_conn",
@@ -391,9 +449,68 @@
         "Server_mcp_transport_http_types",
         "Server_mcp_transport_ws"
       ],
-      "internal_edges": 15,
+      "internal_edges": 20,
+      "external_dep_count": 9,
+      "coupling_ratio": 0.69
+    },
+    {
+      "prefix": "keeper_state",
+      "module_count": 4,
+      "members": [
+        "Keeper_state_block_prompt",
+        "Keeper_state_machine",
+        "Keeper_state_machine_json",
+        "Keeper_state_machine_mermaid"
+      ],
+      "internal_edges": 2,
+      "external_dep_count": 1,
+      "coupling_ratio": 0.667
+    },
+    {
+      "prefix": "tool_board",
+      "module_count": 10,
+      "members": [
+        "Tool_board",
+        "Tool_board_cache",
+        "Tool_board_curation",
+        "Tool_board_dispatch",
+        "Tool_board_format",
+        "Tool_board_handlers",
+        "Tool_board_post",
+        "Tool_board_registry",
+        "Tool_board_schemas",
+        "Tool_board_sub_board"
+      ],
+      "internal_edges": 13,
       "external_dep_count": 7,
-      "coupling_ratio": 0.682
+      "coupling_ratio": 0.65
+    },
+    {
+      "prefix": "tool_shard",
+      "module_count": 18,
+      "members": [
+        "Tool_shard",
+        "Tool_shard_limits",
+        "Tool_shard_schemas",
+        "Tool_shard_types",
+        "Tool_shard_types_core",
+        "Tool_shard_types_enum_mirrors",
+        "Tool_shard_types_schemas_base",
+        "Tool_shard_types_schemas_bash",
+        "Tool_shard_types_schemas_board",
+        "Tool_shard_types_schemas_coding_workspace",
+        "Tool_shard_types_schemas_filesystem",
+        "Tool_shard_types_schemas_github_pr",
+        "Tool_shard_types_schemas_library",
+        "Tool_shard_types_schemas_pr_review",
+        "Tool_shard_types_schemas_preflight",
+        "Tool_shard_types_schemas_shell",
+        "Tool_shard_types_schemas_taskboard",
+        "Tool_shard_types_schemas_voice"
+      ],
+      "internal_edges": 7,
+      "external_dep_count": 5,
+      "coupling_ratio": 0.583
     },
     {
       "prefix": "meta_cognition",
@@ -412,18 +529,82 @@
       "coupling_ratio": 0.583
     },
     {
-      "prefix": "keeper_admission",
-      "module_count": 5,
+      "prefix": "cascade_transport",
+      "module_count": 11,
       "members": [
-        "Keeper_admission_glue",
-        "Keeper_admission_policy",
-        "Keeper_admission_registry",
-        "Keeper_admission_router",
-        "Keeper_admission_runtime"
+        "Cascade_transport",
+        "Cascade_transport_auth_bridging",
+        "Cascade_transport_authorization",
+        "Cascade_transport_cli_argv_sanitize",
+        "Cascade_transport_cli_config",
+        "Cascade_transport_cli_mcp_config_json",
+        "Cascade_transport_codex_omission_dedup",
+        "Cascade_transport_label_resolution",
+        "Cascade_transport_mcp_policy_helpers",
+        "Cascade_transport_mcp_tool_classifier",
+        "Cascade_transport_runtime_policy_provider"
       ],
-      "internal_edges": 6,
-      "external_dep_count": 6,
+      "internal_edges": 10,
+      "external_dep_count": 8,
+      "coupling_ratio": 0.556
+    },
+    {
+      "prefix": "cascade_config",
+      "module_count": 9,
+      "members": [
+        "Cascade_config",
+        "Cascade_config_builder",
+        "Cascade_config_loader",
+        "Cascade_config_parser",
+        "Cascade_config_provider_binding",
+        "Cascade_config_provider_filter",
+        "Cascade_config_resolve",
+        "Cascade_config_selection",
+        "Cascade_config_strategy_resolve"
+      ],
+      "internal_edges": 11,
+      "external_dep_count": 11,
       "coupling_ratio": 0.5
+    },
+    {
+      "prefix": "cascade_catalog",
+      "module_count": 8,
+      "members": [
+        "Cascade_catalog_runtime",
+        "Cascade_catalog_runtime_cache",
+        "Cascade_catalog_runtime_json",
+        "Cascade_catalog_runtime_named_providers",
+        "Cascade_catalog_runtime_probe",
+        "Cascade_catalog_runtime_resolve",
+        "Cascade_catalog_runtime_validate",
+        "Cascade_catalog_validator"
+      ],
+      "internal_edges": 11,
+      "external_dep_count": 11,
+      "coupling_ratio": 0.5
+    },
+    {
+      "prefix": "keeper_registry",
+      "module_count": 14,
+      "members": [
+        "Keeper_registry",
+        "Keeper_registry_broadcast",
+        "Keeper_registry_cascade_attempt",
+        "Keeper_registry_entry_action_dispatch",
+        "Keeper_registry_error_recording",
+        "Keeper_registry_error_tracking",
+        "Keeper_registry_event_queue",
+        "Keeper_registry_event_validators",
+        "Keeper_registry_fsm_validators",
+        "Keeper_registry_lookup",
+        "Keeper_registry_orphan_drops",
+        "Keeper_registry_spawn_slots",
+        "Keeper_registry_tool_usage_persistence",
+        "Keeper_registry_types"
+      ],
+      "internal_edges": 16,
+      "external_dep_count": 18,
+      "coupling_ratio": 0.471
     },
     {
       "prefix": "masc_grpc",
@@ -438,6 +619,18 @@
       "internal_edges": 3,
       "external_dep_count": 4,
       "coupling_ratio": 0.429
+    },
+    {
+      "prefix": "voice_bridge",
+      "module_count": 3,
+      "members": [
+        "Voice_bridge",
+        "Voice_bridge_core",
+        "Voice_bridge_transport"
+      ],
+      "internal_edges": 2,
+      "external_dep_count": 3,
+      "coupling_ratio": 0.4
     },
     {
       "prefix": "keeper_social",
@@ -456,17 +649,55 @@
       "coupling_ratio": 0.385
     },
     {
-      "prefix": "tool_autoresearch",
-      "module_count": 4,
+      "prefix": "server_dashboard",
+      "module_count": 42,
       "members": [
-        "Tool_autoresearch_broadcast",
-        "Tool_autoresearch_context",
-        "Tool_autoresearch_cycle",
-        "Tool_autoresearch_registry"
+        "Server_dashboard_cascade_profile_gate",
+        "Server_dashboard_compact_receipt_json",
+        "Server_dashboard_fleet_readiness",
+        "Server_dashboard_http",
+        "Server_dashboard_http_agent_api",
+        "Server_dashboard_http_cache",
+        "Server_dashboard_http_core",
+        "Server_dashboard_http_core_cache",
+        "Server_dashboard_http_core_entities",
+        "Server_dashboard_http_core_json",
+        "Server_dashboard_http_core_meta_cognition",
+        "Server_dashboard_http_core_operator",
+        "Server_dashboard_http_core_operator_query",
+        "Server_dashboard_http_core_runtime",
+        "Server_dashboard_http_core_snapshot_refresh",
+        "Server_dashboard_http_delete_actions",
+        "Server_dashboard_http_execution_surfaces",
+        "Server_dashboard_http_keeper_api",
+        "Server_dashboard_http_keeper_api_checkpoints",
+        "Server_dashboard_http_keeper_api_lifecycle_post",
+        "Server_dashboard_http_keeper_api_runtime_lens",
+        "Server_dashboard_http_keeper_api_scan_summary",
+        "Server_dashboard_http_keeper_api_summary_aggregates",
+        "Server_dashboard_http_keeper_api_trace",
+        "Server_dashboard_http_keeper_api_types",
+        "Server_dashboard_http_keeper_runtime_lens_gaps",
+        "Server_dashboard_http_keeper_runtime_lens_proof",
+        "Server_dashboard_http_keeper_runtime_lens_summaries",
+        "Server_dashboard_http_keeper_runtime_lens_swimlane",
+        "Server_dashboard_http_keeper_runtime_manifest_scan",
+        "Server_dashboard_http_link_preview",
+        "Server_dashboard_http_memory_subsystems",
+        "Server_dashboard_http_namespace_truth",
+        "Server_dashboard_http_namespace_truth_support",
+        "Server_dashboard_http_perf",
+        "Server_dashboard_http_runtime_info",
+        "Server_dashboard_http_runtime_support",
+        "Server_dashboard_logs_json",
+        "Server_dashboard_meta_cognition_cache",
+        "Server_dashboard_shell_projection_trace",
+        "Server_dashboard_snapshot_select",
+        "Server_dashboard_surface"
       ],
-      "internal_edges": 3,
-      "external_dep_count": 5,
-      "coupling_ratio": 0.375
+      "internal_edges": 56,
+      "external_dep_count": 96,
+      "coupling_ratio": 0.368
     },
     {
       "prefix": "dashboard_keeper",
@@ -483,32 +714,75 @@
       "coupling_ratio": 0.333
     },
     {
-      "prefix": "keeper_sandbox",
-      "module_count": 7,
+      "prefix": "tool_autoresearch",
+      "module_count": 4,
       "members": [
-        "Keeper_sandbox",
-        "Keeper_sandbox_containment",
-        "Keeper_sandbox_control",
-        "Keeper_sandbox_factory",
-        "Keeper_sandbox_oneshot_plan",
-        "Keeper_sandbox_runtime",
-        "Keeper_sandbox_session_plan"
+        "Tool_autoresearch_broadcast",
+        "Tool_autoresearch_context",
+        "Tool_autoresearch_cycle",
+        "Tool_autoresearch_registry"
       ],
-      "internal_edges": 5,
-      "external_dep_count": 11,
-      "coupling_ratio": 0.312
+      "internal_edges": 3,
+      "external_dep_count": 6,
+      "coupling_ratio": 0.333
     },
     {
-      "prefix": "docker_client",
-      "module_count": 3,
+      "prefix": "keeper_supervisor",
+      "module_count": 13,
       "members": [
-        "Docker_client",
-        "Docker_client_mock",
-        "Docker_client_real"
+        "Keeper_supervisor",
+        "Keeper_supervisor_alive_but_stuck",
+        "Keeper_supervisor_cleanup_failure_site",
+        "Keeper_supervisor_cleanup_tombstone",
+        "Keeper_supervisor_liveness_recovery",
+        "Keeper_supervisor_pause_policy",
+        "Keeper_supervisor_reconcile_keepalive",
+        "Keeper_supervisor_restart_noop",
+        "Keeper_supervisor_restore_reconcile_gate",
+        "Keeper_supervisor_resume_reconcile_gate",
+        "Keeper_supervisor_self_preservation",
+        "Keeper_supervisor_startup_helpers",
+        "Keeper_supervisor_types"
       ],
-      "internal_edges": 2,
-      "external_dep_count": 5,
-      "coupling_ratio": 0.286
+      "internal_edges": 17,
+      "external_dep_count": 36,
+      "coupling_ratio": 0.321
+    },
+    {
+      "prefix": "dashboard_cascade",
+      "module_count": 10,
+      "members": [
+        "Dashboard_cascade",
+        "Dashboard_cascade_audit_runs",
+        "Dashboard_cascade_capacity",
+        "Dashboard_cascade_config",
+        "Dashboard_cascade_health",
+        "Dashboard_cascade_health_json",
+        "Dashboard_cascade_helpers",
+        "Dashboard_cascade_recommendations",
+        "Dashboard_cascade_slo",
+        "Dashboard_cascade_strategy_trace"
+      ],
+      "internal_edges": 8,
+      "external_dep_count": 17,
+      "coupling_ratio": 0.32
+    },
+    {
+      "prefix": "keeper_hooks",
+      "module_count": 8,
+      "members": [
+        "Keeper_hooks_oas",
+        "Keeper_hooks_oas_cost_events",
+        "Keeper_hooks_oas_gate_attempt",
+        "Keeper_hooks_oas_idle",
+        "Keeper_hooks_oas_output_json",
+        "Keeper_hooks_oas_pr_metrics",
+        "Keeper_hooks_oas_response_metrics",
+        "Keeper_hooks_oas_types"
+      ],
+      "internal_edges": 8,
+      "external_dep_count": 17,
+      "coupling_ratio": 0.32
     },
     {
       "prefix": "keeper_meta",
@@ -523,66 +797,85 @@
         "Keeper_meta_tool_access"
       ],
       "internal_edges": 6,
-      "external_dep_count": 16,
-      "coupling_ratio": 0.273
+      "external_dep_count": 14,
+      "coupling_ratio": 0.3
     },
     {
-      "prefix": "keeper_prompt",
+      "prefix": "dashboard_goals",
+      "module_count": 7,
+      "members": [
+        "Dashboard_goals",
+        "Dashboard_goals_types",
+        "Dashboard_goals_types_accessor",
+        "Dashboard_goals_types_attainment",
+        "Dashboard_goals_types_builder",
+        "Dashboard_goals_types_health",
+        "Dashboard_goals_types_timeline"
+      ],
+      "internal_edges": 5,
+      "external_dep_count": 12,
+      "coupling_ratio": 0.294
+    },
+    {
+      "prefix": "keeper_docker",
+      "module_count": 5,
+      "members": [
+        "Keeper_docker_client",
+        "Keeper_docker_client_mock",
+        "Keeper_docker_client_real",
+        "Keeper_docker_read",
+        "Keeper_docker_response"
+      ],
+      "internal_edges": 5,
+      "external_dep_count": 12,
+      "coupling_ratio": 0.294
+    },
+    {
+      "prefix": "keeper_sandbox",
+      "module_count": 9,
+      "members": [
+        "Keeper_sandbox",
+        "Keeper_sandbox_containment",
+        "Keeper_sandbox_control",
+        "Keeper_sandbox_executor",
+        "Keeper_sandbox_factory",
+        "Keeper_sandbox_oneshot_plan",
+        "Keeper_sandbox_runtime",
+        "Keeper_sandbox_session_executor",
+        "Keeper_sandbox_session_plan"
+      ],
+      "internal_edges": 6,
+      "external_dep_count": 15,
+      "coupling_ratio": 0.286
+    },
+    {
+      "prefix": "keeper_memory",
+      "module_count": 8,
+      "members": [
+        "Keeper_memory",
+        "Keeper_memory_bank",
+        "Keeper_memory_llm_summary",
+        "Keeper_memory_llm_summary_outcome",
+        "Keeper_memory_policy",
+        "Keeper_memory_policy_summary_filter",
+        "Keeper_memory_recall",
+        "Keeper_memory_recall_exn_class"
+      ],
+      "internal_edges": 4,
+      "external_dep_count": 10,
+      "coupling_ratio": 0.286
+    },
+    {
+      "prefix": "keeper_checkpoint",
       "module_count": 3,
       "members": [
-        "Keeper_prompt",
-        "Keeper_prompt_external",
-        "Keeper_prompt_names"
+        "Keeper_checkpoint_failure_operation",
+        "Keeper_checkpoint_store",
+        "Keeper_checkpoint_store_failure_site"
       ],
       "internal_edges": 2,
-      "external_dep_count": 6,
-      "coupling_ratio": 0.25
-    },
-    {
-      "prefix": "operator_digest",
-      "module_count": 3,
-      "members": [
-        "Operator_digest",
-        "Operator_digest_guidance",
-        "Operator_digest_types"
-      ],
-      "internal_edges": 2,
-      "external_dep_count": 6,
-      "coupling_ratio": 0.25
-    },
-    {
-      "prefix": "server_routes",
-      "module_count": 25,
-      "members": [
-        "Server_routes_http",
-        "Server_routes_http_common",
-        "Server_routes_http_keeper_stream",
-        "Server_routes_http_pages",
-        "Server_routes_http_routes_activity",
-        "Server_routes_http_routes_artifacts",
-        "Server_routes_http_routes_attribution",
-        "Server_routes_http_routes_autonomous",
-        "Server_routes_http_routes_cascade",
-        "Server_routes_http_routes_channel_gate",
-        "Server_routes_http_routes_credentials",
-        "Server_routes_http_routes_dashboard",
-        "Server_routes_http_routes_frontend",
-        "Server_routes_http_routes_git_graph",
-        "Server_routes_http_routes_keeper_repos",
-        "Server_routes_http_routes_legendary_bash",
-        "Server_routes_http_routes_multimodal",
-        "Server_routes_http_routes_provider_runs",
-        "Server_routes_http_routes_repositories",
-        "Server_routes_http_routes_resilience",
-        "Server_routes_http_routes_room",
-        "Server_routes_http_routes_sidecar",
-        "Server_routes_http_routes_verification",
-        "Server_routes_http_routes_workspace",
-        "Server_routes_http_runtime"
-      ],
-      "internal_edges": 30,
-      "external_dep_count": 97,
-      "coupling_ratio": 0.236
+      "external_dep_count": 5,
+      "coupling_ratio": 0.286
     },
     {
       "prefix": "tool_local",
@@ -597,8 +890,125 @@
         "Tool_local_runtime_verify"
       ],
       "internal_edges": 4,
-      "external_dep_count": 13,
-      "coupling_ratio": 0.235
+      "external_dep_count": 11,
+      "coupling_ratio": 0.267
+    },
+    {
+      "prefix": "worker_runtime",
+      "module_count": 4,
+      "members": [
+        "Worker_runtime",
+        "Worker_runtime_config",
+        "Worker_runtime_docker",
+        "Worker_runtime_helper_protocol"
+      ],
+      "internal_edges": 2,
+      "external_dep_count": 6,
+      "coupling_ratio": 0.25
+    },
+    {
+      "prefix": "cascade_health",
+      "module_count": 3,
+      "members": [
+        "Cascade_health_filter",
+        "Cascade_health_tracker",
+        "Cascade_health_tracker_config"
+      ],
+      "internal_edges": 1,
+      "external_dep_count": 3,
+      "coupling_ratio": 0.25
+    },
+    {
+      "prefix": "keeper_prompt",
+      "module_count": 3,
+      "members": [
+        "Keeper_prompt",
+        "Keeper_prompt_external",
+        "Keeper_prompt_names"
+      ],
+      "internal_edges": 2,
+      "external_dep_count": 6,
+      "coupling_ratio": 0.25
+    },
+    {
+      "prefix": "memory_oas",
+      "module_count": 3,
+      "members": [
+        "Memory_oas_bridge",
+        "Memory_oas_bridge_cache",
+        "Memory_oas_bridge_op_outcome"
+      ],
+      "internal_edges": 2,
+      "external_dep_count": 6,
+      "coupling_ratio": 0.25
+    },
+    {
+      "prefix": "server_routes",
+      "module_count": 30,
+      "members": [
+        "Server_routes_http",
+        "Server_routes_http_common",
+        "Server_routes_http_dashboard_dev_token",
+        "Server_routes_http_dashboard_handlers",
+        "Server_routes_http_dashboard_provider_logs",
+        "Server_routes_http_keeper_stream",
+        "Server_routes_http_pages",
+        "Server_routes_http_routes_activity",
+        "Server_routes_http_routes_artifacts",
+        "Server_routes_http_routes_attribution",
+        "Server_routes_http_routes_autonomous",
+        "Server_routes_http_routes_cascade",
+        "Server_routes_http_routes_channel_gate",
+        "Server_routes_http_routes_credentials",
+        "Server_routes_http_routes_dashboard",
+        "Server_routes_http_routes_dashboard_cascade_meta",
+        "Server_routes_http_routes_frontend",
+        "Server_routes_http_routes_git_graph",
+        "Server_routes_http_routes_keeper_repos",
+        "Server_routes_http_routes_legendary_bash",
+        "Server_routes_http_routes_multimodal",
+        "Server_routes_http_routes_provider_runs",
+        "Server_routes_http_routes_repositories",
+        "Server_routes_http_routes_resilience",
+        "Server_routes_http_routes_room",
+        "Server_routes_http_routes_sidecar",
+        "Server_routes_http_routes_verification",
+        "Server_routes_http_routes_workspace",
+        "Server_routes_http_runtime",
+        "Server_routes_http_sidecar_paths"
+      ],
+      "internal_edges": 33,
+      "external_dep_count": 102,
+      "coupling_ratio": 0.244
+    },
+    {
+      "prefix": "keeper_tool",
+      "module_count": 20,
+      "members": [
+        "Keeper_tool_affinity",
+        "Keeper_tool_alias",
+        "Keeper_tool_bash_input",
+        "Keeper_tool_boundary",
+        "Keeper_tool_call_log",
+        "Keeper_tool_call_log_context",
+        "Keeper_tool_call_log_route_evidence",
+        "Keeper_tool_deterministic_error",
+        "Keeper_tool_disclosure",
+        "Keeper_tool_diversity",
+        "Keeper_tool_emission_hook",
+        "Keeper_tool_github_pr",
+        "Keeper_tool_guidance",
+        "Keeper_tool_name_projection",
+        "Keeper_tool_policy",
+        "Keeper_tool_policy_config",
+        "Keeper_tool_policy_failure_site",
+        "Keeper_tool_pr_review",
+        "Keeper_tool_registry",
+        "Keeper_tool_resolution"
+      ],
+      "internal_edges": 13,
+      "external_dep_count": 41,
+      "coupling_ratio": 0.241
     },
     {
       "prefix": "keeper_exec",
@@ -620,34 +1030,116 @@
         "Keeper_exec_tools",
         "Keeper_exec_voice"
       ],
-      "internal_edges": 19,
-      "external_dep_count": 66,
-      "coupling_ratio": 0.224
+      "internal_edges": 20,
+      "external_dep_count": 65,
+      "coupling_ratio": 0.235
     },
     {
-      "prefix": "worker_runtime",
-      "module_count": 4,
+      "prefix": "keeper_shell",
+      "module_count": 10,
       "members": [
-        "Worker_runtime",
-        "Worker_runtime_config",
-        "Worker_runtime_docker",
-        "Worker_runtime_helper_protocol"
+        "Keeper_shell_bash",
+        "Keeper_shell_bash_typed_input",
+        "Keeper_shell_command_semantics",
+        "Keeper_shell_docker",
+        "Keeper_shell_docker_exec_failure",
+        "Keeper_shell_docker_nested_runtime",
+        "Keeper_shell_docker_worktree_gitdir",
+        "Keeper_shell_gh_context",
+        "Keeper_shell_ops",
+        "Keeper_shell_shared"
       ],
-      "internal_edges": 2,
-      "external_dep_count": 7,
-      "coupling_ratio": 0.222
+      "internal_edges": 9,
+      "external_dep_count": 30,
+      "coupling_ratio": 0.231
     },
     {
-      "prefix": "tool_shard",
-      "module_count": 3,
+      "prefix": "keeper_unified",
+      "module_count": 24,
       "members": [
-        "Tool_shard",
-        "Tool_shard_limits",
-        "Tool_shard_schemas"
+        "Keeper_unified_metrics",
+        "Keeper_unified_metrics_broadcast",
+        "Keeper_unified_metrics_decision",
+        "Keeper_unified_metrics_failure",
+        "Keeper_unified_metrics_json_support",
+        "Keeper_unified_metrics_result",
+        "Keeper_unified_metrics_snapshot",
+        "Keeper_unified_metrics_support",
+        "Keeper_unified_prompt",
+        "Keeper_unified_turn",
+        "Keeper_unified_turn_attempt_watchdog",
+        "Keeper_unified_turn_cascade_resolution",
+        "Keeper_unified_turn_event_bus",
+        "Keeper_unified_turn_failure",
+        "Keeper_unified_turn_livelock_block",
+        "Keeper_unified_turn_phase_gate",
+        "Keeper_unified_turn_phase_plan",
+        "Keeper_unified_turn_pre_dispatch",
+        "Keeper_unified_turn_retry_setup",
+        "Keeper_unified_turn_rotation_attempt",
+        "Keeper_unified_turn_stay_silent",
+        "Keeper_unified_turn_success",
+        "Keeper_unified_turn_terminal_error",
+        "Keeper_unified_turn_types"
       ],
-      "internal_edges": 2,
-      "external_dep_count": 7,
-      "coupling_ratio": 0.222
+      "internal_edges": 23,
+      "external_dep_count": 80,
+      "coupling_ratio": 0.223
+    },
+    {
+      "prefix": "tool_misc",
+      "module_count": 5,
+      "members": [
+        "Tool_misc",
+        "Tool_misc_admin",
+        "Tool_misc_transport",
+        "Tool_misc_web_fetch",
+        "Tool_misc_web_search"
+      ],
+      "internal_edges": 5,
+      "external_dep_count": 18,
+      "coupling_ratio": 0.217
+    },
+    {
+      "prefix": "mcp_server",
+      "module_count": 12,
+      "members": [
+        "Mcp_server",
+        "Mcp_server_eio",
+        "Mcp_server_eio_call_tool",
+        "Mcp_server_eio_caller_identity",
+        "Mcp_server_eio_execute",
+        "Mcp_server_eio_governance",
+        "Mcp_server_eio_helpers",
+        "Mcp_server_eio_protocol",
+        "Mcp_server_eio_resource",
+        "Mcp_server_eio_tool_profile",
+        "Mcp_server_eio_tool_timeout",
+        "Mcp_server_eio_types"
+      ],
+      "internal_edges": 20,
+      "external_dep_count": 77,
+      "coupling_ratio": 0.206
+    },
+    {
+      "prefix": "keeper_heartbeat",
+      "module_count": 11,
+      "members": [
+        "Keeper_heartbeat_loop",
+        "Keeper_heartbeat_loop_board_events",
+        "Keeper_heartbeat_loop_in_turn_pulse",
+        "Keeper_heartbeat_loop_observations",
+        "Keeper_heartbeat_loop_presence",
+        "Keeper_heartbeat_loop_scheduling",
+        "Keeper_heartbeat_loop_semaphore_timeout",
+        "Keeper_heartbeat_smart",
+        "Keeper_heartbeat_snapshot",
+        "Keeper_heartbeat_stimulus_intake",
+        "Keeper_heartbeat_visibility_gate"
+      ],
+      "internal_edges": 11,
+      "external_dep_count": 44,
+      "coupling_ratio": 0.2
     },
     {
       "prefix": "tool_inline",
@@ -664,65 +1156,79 @@
       "coupling_ratio": 0.2
     },
     {
-      "prefix": "tool_misc",
-      "module_count": 5,
+      "prefix": "operator_digest",
+      "module_count": 3,
       "members": [
-        "Tool_misc",
-        "Tool_misc_admin",
-        "Tool_misc_transport",
-        "Tool_misc_web_fetch",
-        "Tool_misc_web_search"
+        "Operator_digest",
+        "Operator_digest_guidance",
+        "Operator_digest_types"
       ],
-      "internal_edges": 5,
-      "external_dep_count": 20,
+      "internal_edges": 2,
+      "external_dep_count": 8,
       "coupling_ratio": 0.2
     },
     {
-      "prefix": "mcp_server",
-      "module_count": 10,
+      "prefix": "keeper_turn",
+      "module_count": 29,
       "members": [
-        "Mcp_server",
-        "Mcp_server_eio",
-        "Mcp_server_eio_call_tool",
-        "Mcp_server_eio_execute",
-        "Mcp_server_eio_governance",
-        "Mcp_server_eio_helpers",
-        "Mcp_server_eio_protocol",
-        "Mcp_server_eio_resource",
-        "Mcp_server_eio_tool_profile",
-        "Mcp_server_eio_types"
+        "Keeper_turn",
+        "Keeper_turn_cascade_budget",
+        "Keeper_turn_cascade_budget_routing",
+        "Keeper_turn_cleanup_failure_site",
+        "Keeper_turn_disposition",
+        "Keeper_turn_driver",
+        "Keeper_turn_driver_admission",
+        "Keeper_turn_driver_helpers",
+        "Keeper_turn_driver_provider_attempt",
+        "Keeper_turn_driver_try_provider",
+        "Keeper_turn_driver_wrappers",
+        "Keeper_turn_fsm",
+        "Keeper_turn_helpers",
+        "Keeper_turn_intent",
+        "Keeper_turn_lifecycle",
+        "Keeper_turn_livelock",
+        "Keeper_turn_liveness",
+        "Keeper_turn_metrics_snapshot_failure_site",
+        "Keeper_turn_sandbox_runtime",
+        "Keeper_turn_setup",
+        "Keeper_turn_slot",
+        "Keeper_turn_telemetry",
+        "Keeper_turn_terminal",
+        "Keeper_turn_terminal_code",
+        "Keeper_turn_up",
+        "Keeper_turn_up_args",
+        "Keeper_turn_up_create",
+        "Keeper_turn_up_update",
+        "Keeper_turn_up_update_failure_site"
       ],
-      "internal_edges": 18,
-      "external_dep_count": 73,
-      "coupling_ratio": 0.198
+      "internal_edges": 22,
+      "external_dep_count": 98,
+      "coupling_ratio": 0.183
     },
     {
-      "prefix": "cascade_attempt",
-      "module_count": 5,
+      "prefix": "tool_code",
+      "module_count": 4,
       "members": [
-        "Cascade_attempt_fsm",
-        "Cascade_attempt_liveness",
-        "Cascade_attempt_liveness_config",
-        "Cascade_attempt_liveness_observer",
-        "Cascade_attempt_liveness_runtime"
+        "Tool_code",
+        "Tool_code_read_core",
+        "Tool_code_write",
+        "Tool_code_write_git_policy"
+      ],
+      "internal_edges": 3,
+      "external_dep_count": 14,
+      "coupling_ratio": 0.176
+    },
+    {
+      "prefix": "keeper_compact",
+      "module_count": 4,
+      "members": [
+        "Keeper_compact_audit",
+        "Keeper_compact_audit_failure_site",
+        "Keeper_compact_audit_retention_outcome",
+        "Keeper_compact_policy"
       ],
       "internal_edges": 2,
-      "external_dep_count": 9,
-      "coupling_ratio": 0.182
-    },
-    {
-      "prefix": "keeper_shell",
-      "module_count": 6,
-      "members": [
-        "Keeper_shell_bash",
-        "Keeper_shell_bg_task",
-        "Keeper_shell_docker",
-        "Keeper_shell_gh_context",
-        "Keeper_shell_ops",
-        "Keeper_shell_shared"
-      ],
-      "internal_edges": 5,
-      "external_dep_count": 25,
+      "external_dep_count": 10,
       "coupling_ratio": 0.167
     },
     {
@@ -738,36 +1244,75 @@
       "coupling_ratio": 0.167
     },
     {
-      "prefix": "keeper_turn",
-      "module_count": 23,
+      "prefix": "operator_control",
+      "module_count": 9,
       "members": [
-        "Keeper_turn",
-        "Keeper_turn_cascade_budget",
-        "Keeper_turn_disposition",
-        "Keeper_turn_driver",
-        "Keeper_turn_driver_helpers",
-        "Keeper_turn_driver_try_provider",
-        "Keeper_turn_driver_wrappers",
-        "Keeper_turn_fsm",
-        "Keeper_turn_helpers",
-        "Keeper_turn_intent",
-        "Keeper_turn_lifecycle",
-        "Keeper_turn_livelock",
-        "Keeper_turn_liveness",
-        "Keeper_turn_sandbox_runtime",
-        "Keeper_turn_setup",
-        "Keeper_turn_slot",
-        "Keeper_turn_telemetry",
-        "Keeper_turn_terminal",
-        "Keeper_turn_terminal_code",
-        "Keeper_turn_up",
-        "Keeper_turn_up_args",
-        "Keeper_turn_up_create",
-        "Keeper_turn_up_update"
+        "Operator_control",
+        "Operator_control_action",
+        "Operator_control_context_snapshot",
+        "Operator_control_snapshot",
+        "Operator_control_snapshot_identity_fields",
+        "Operator_control_snapshot_runtime_status",
+        "Operator_control_snapshot_tool_audit",
+        "Operator_control_snapshot_tool_names",
+        "Operator_control_snapshot_trust"
       ],
-      "internal_edges": 18,
-      "external_dep_count": 92,
-      "coupling_ratio": 0.164
+      "internal_edges": 6,
+      "external_dep_count": 31,
+      "coupling_ratio": 0.162
+    },
+    {
+      "prefix": "cascade_attempt",
+      "module_count": 5,
+      "members": [
+        "Cascade_attempt_fsm",
+        "Cascade_attempt_liveness",
+        "Cascade_attempt_liveness_config",
+        "Cascade_attempt_liveness_observer",
+        "Cascade_attempt_liveness_runtime"
+      ],
+      "internal_edges": 2,
+      "external_dep_count": 11,
+      "coupling_ratio": 0.154
+    },
+    {
+      "prefix": "keeper_context",
+      "module_count": 5,
+      "members": [
+        "Keeper_context_core",
+        "Keeper_context_core_history",
+        "Keeper_context_core_message_json",
+        "Keeper_context_tool_message_pairs",
+        "Keeper_context_tool_text_block"
+      ],
+      "internal_edges": 2,
+      "external_dep_count": 11,
+      "coupling_ratio": 0.154
+    },
+    {
+      "prefix": "cascade_event",
+      "module_count": 3,
+      "members": [
+        "Cascade_event_bridge",
+        "Cascade_event_bridge_error_json",
+        "Cascade_event_bridge_inference"
+      ],
+      "internal_edges": 2,
+      "external_dep_count": 11,
+      "coupling_ratio": 0.154
+    },
+    {
+      "prefix": "board_core",
+      "module_count": 4,
+      "members": [
+        "Board_core",
+        "Board_core_classify",
+        "Board_core_json",
+        "Board_core_payload"
+      ],
+      "internal_edges": 1,
+      "external_dep_count": 6,
+      "coupling_ratio": 0.143
     },
     {
       "prefix": "dashboard_mission",
@@ -783,55 +1328,108 @@
       "coupling_ratio": 0.143
     },
     {
-      "prefix": "keeper_tool",
-      "module_count": 13,
+      "prefix": "keeper_types",
+      "module_count": 7,
       "members": [
-        "Keeper_tool_affinity",
-        "Keeper_tool_alias",
-        "Keeper_tool_boundary",
-        "Keeper_tool_call_log",
-        "Keeper_tool_disclosure",
-        "Keeper_tool_diversity",
-        "Keeper_tool_emission_hook",
-        "Keeper_tool_github_pr",
-        "Keeper_tool_guidance",
-        "Keeper_tool_policy",
-        "Keeper_tool_policy_config",
-        "Keeper_tool_pr_review",
-        "Keeper_tool_registry"
+        "Keeper_types",
+        "Keeper_types_profile",
+        "Keeper_types_profile_defaults",
+        "Keeper_types_profile_oas_env",
+        "Keeper_types_profile_persona",
+        "Keeper_types_profile_sandbox",
+        "Keeper_types_support"
       ],
-      "internal_edges": 5,
-      "external_dep_count": 34,
-      "coupling_ratio": 0.128
-    },
-    {
-      "prefix": "server_dashboard",
-      "module_count": 12,
-      "members": [
-        "Server_dashboard_http",
-        "Server_dashboard_http_agent_api",
-        "Server_dashboard_http_cache",
-        "Server_dashboard_http_core",
-        "Server_dashboard_http_delete_actions",
-        "Server_dashboard_http_execution_surfaces",
-        "Server_dashboard_http_keeper_api",
-        "Server_dashboard_http_link_preview",
-        "Server_dashboard_http_namespace_truth",
-        "Server_dashboard_http_namespace_truth_support",
-        "Server_dashboard_http_runtime_info",
-        "Server_dashboard_http_runtime_support"
-      ],
-      "internal_edges": 9,
-      "external_dep_count": 88,
-      "coupling_ratio": 0.093
+      "internal_edges": 2,
+      "external_dep_count": 14,
+      "coupling_ratio": 0.125
     },
     {
       "prefix": "keeper_status",
-      "module_count": 3,
+      "module_count": 4,
       "members": [
         "Keeper_status",
         "Keeper_status_bridge",
-        "Keeper_status_detail"
+        "Keeper_status_detail",
+        "Keeper_status_detail_observability"
+      ],
+      "internal_edges": 4,
+      "external_dep_count": 28,
+      "coupling_ratio": 0.125
+    },
+    {
+      "prefix": "keeper_agent",
+      "module_count": 10,
+      "members": [
+        "Keeper_agent_checkpoint_hygiene",
+        "Keeper_agent_error",
+        "Keeper_agent_memory_episode",
+        "Keeper_agent_prompt_metrics",
+        "Keeper_agent_result",
+        "Keeper_agent_run",
+        "Keeper_agent_run_contract_helpers",
+        "Keeper_agent_run_receipt_append",
+        "Keeper_agent_run_turn_helpers",
+        "Keeper_agent_tool_surface"
+      ],
+      "internal_edges": 6,
+      "external_dep_count": 60,
+      "coupling_ratio": 0.091
+    },
+    {
+      "prefix": "dashboard_http",
+      "module_count": 11,
+      "members": [
+        "Dashboard_http_autoresearch",
+        "Dashboard_http_helpers",
+        "Dashboard_http_keeper",
+        "Dashboard_http_keeper_detail",
+        "Dashboard_http_keeper_feeds",
+        "Dashboard_http_keeper_metrics",
+        "Dashboard_http_keeper_outcomes",
+        "Dashboard_http_keeper_trust",
+        "Dashboard_http_keeper_types",
+        "Dashboard_http_monitoring",
+        "Dashboard_http_tool_quality"
+      ],
+      "internal_edges": 6,
+      "external_dep_count": 61,
+      "coupling_ratio": 0.09
+    },
+    {
+      "prefix": "tool_task",
+      "module_count": 6,
+      "members": [
+        "Tool_task",
+        "Tool_task_args",
+        "Tool_task_completion_review",
+        "Tool_task_contract_gate",
+        "Tool_task_payloads",
+        "Tool_task_schemas"
+      ],
+      "internal_edges": 2,
+      "external_dep_count": 24,
+      "coupling_ratio": 0.077
+    },
+    {
+      "prefix": "keeper_persona",
+      "module_count": 4,
+      "members": [
+        "Keeper_persona",
+        "Keeper_persona_authoring",
+        "Keeper_persona_authoring_contract",
+        "Keeper_persona_authoring_slug"
+      ],
+      "internal_edges": 1,
+      "external_dep_count": 12,
+      "coupling_ratio": 0.077
+    },
+    {
+      "prefix": "server_h2",
+      "module_count": 3,
+      "members": [
+        "Server_h2_gateway",
+        "Server_h2_gateway_helpers",
+        "Server_h2_gateway_routes_extra"
       ],
       "internal_edges": 3,
       "external_dep_count": 36,
@@ -839,17 +1437,47 @@
     },
     {
       "prefix": "keeper_runtime",
-      "module_count": 5,
+      "module_count": 7,
       "members": [
         "Keeper_runtime",
         "Keeper_runtime_config",
         "Keeper_runtime_contract",
+        "Keeper_runtime_manifest",
         "Keeper_runtime_resolved",
-        "Keeper_runtime_trust_snapshot"
+        "Keeper_runtime_trust_snapshot",
+        "Keeper_runtime_trust_timeline"
       ],
-      "internal_edges": 2,
-      "external_dep_count": 34,
-      "coupling_ratio": 0.056
+      "internal_edges": 3,
+      "external_dep_count": 37,
+      "coupling_ratio": 0.075
+    },
+    {
+      "prefix": "keeper_run",
+      "module_count": 7,
+      "members": [
+        "Keeper_run_context",
+        "Keeper_run_prompt",
+        "Keeper_run_tools",
+        "Keeper_run_tools_hook_accumulator",
+        "Keeper_run_tools_search",
+        "Keeper_run_tools_task_scope",
+        "Keeper_run_tools_work_discovery"
+      ],
+      "internal_edges": 4,
+      "external_dep_count": 56,
+      "coupling_ratio": 0.067
+    },
+    {
+      "prefix": "keeper_execution",
+      "module_count": 3,
+      "members": [
+        "Keeper_execution",
+        "Keeper_execution_receipt",
+        "Keeper_execution_receipt_failure_site"
+      ],
+      "internal_edges": 1,
+      "external_dep_count": 16,
+      "coupling_ratio": 0.059
     },
     {
       "prefix": "dashboard_governance",
@@ -864,73 +1492,17 @@
       "coupling_ratio": 0.056
     },
     {
-      "prefix": "server_h2",
-      "module_count": 3,
+      "prefix": "server_runtime",
+      "module_count": 4,
       "members": [
-        "Server_h2_gateway",
-        "Server_h2_gateway_helpers",
-        "Server_h2_gateway_routes_extra"
-      ],
-      "internal_edges": 2,
-      "external_dep_count": 34,
-      "coupling_ratio": 0.056
-    },
-    {
-      "prefix": "keeper_agent",
-      "module_count": 8,
-      "members": [
-        "Keeper_agent_checkpoint_hygiene",
-        "Keeper_agent_context",
-        "Keeper_agent_error",
-        "Keeper_agent_memory_episode",
-        "Keeper_agent_prompt_metrics",
-        "Keeper_agent_result",
-        "Keeper_agent_run",
-        "Keeper_agent_tool_surface"
-      ],
-      "internal_edges": 3,
-      "external_dep_count": 52,
-      "coupling_ratio": 0.055
-    },
-    {
-      "prefix": "dashboard_http",
-      "module_count": 7,
-      "members": [
-        "Dashboard_http_autoresearch",
-        "Dashboard_http_helpers",
-        "Dashboard_http_keeper",
-        "Dashboard_http_keeper_detail",
-        "Dashboard_http_keeper_metrics",
-        "Dashboard_http_monitoring",
-        "Dashboard_http_tool_quality"
-      ],
-      "internal_edges": 2,
-      "external_dep_count": 64,
-      "coupling_ratio": 0.03
-    },
-    {
-      "prefix": "keeper_unified",
-      "module_count": 3,
-      "members": [
-        "Keeper_unified_metrics",
-        "Keeper_unified_prompt",
-        "Keeper_unified_turn"
-      ],
-      "internal_edges": 2,
-      "external_dep_count": 73,
-      "coupling_ratio": 0.027
-    },
-    {
-      "prefix": "keeper_run",
-      "module_count": 3,
-      "members": [
-        "Keeper_run_context",
-        "Keeper_run_prompt",
-        "Keeper_run_tools"
+        "Server_runtime_bootstrap",
+        "Server_runtime_bootstrap_legacy_migration",
+        "Server_runtime_codex_mcp_sync",
+        "Server_runtime_config_root_bootstrap"
       ],
       "internal_edges": 1,
-      "external_dep_count": 56,
-      "coupling_ratio": 0.018
+      "external_dep_count": 58,
+      "coupling_ratio": 0.017
     },
     {
       "prefix": "dashboard_execution",
@@ -947,16 +1519,45 @@
       "coupling_ratio": 0.0
     },
     {
-      "prefix": "keeper_memory",
-      "module_count": 4,
+      "prefix": "keeper_cascade",
+      "module_count": 5,
       "members": [
-        "Keeper_memory",
-        "Keeper_memory_bank",
-        "Keeper_memory_policy",
-        "Keeper_memory_recall"
+        "Keeper_cascade_engine",
+        "Keeper_cascade_profile",
+        "Keeper_cascade_routing",
+        "Keeper_cascade_selector",
+        "Keeper_cascade_sync_failure_site"
       ],
       "internal_edges": 0,
-      "external_dep_count": 7,
+      "external_dep_count": 10,
+      "coupling_ratio": 0.0
+    },
+    {
+      "prefix": "keeper_world",
+      "module_count": 5,
+      "members": [
+        "Keeper_world_observation",
+        "Keeper_world_observation_board_signal",
+        "Keeper_world_observation_continuity",
+        "Keeper_world_observation_inputs",
+        "Keeper_world_observation_message_scope"
+      ],
+      "internal_edges": 0,
+      "external_dep_count": 27,
+      "coupling_ratio": 0.0
+    },
+    {
+      "prefix": "worker_dev",
+      "module_count": 5,
+      "members": [
+        "Worker_dev_tools",
+        "Worker_dev_tools_command_syntax",
+        "Worker_dev_tools_log_sanitize",
+        "Worker_dev_tools_mutation_classifier",
+        "Worker_dev_tools_paths"
+      ],
+      "internal_edges": 0,
+      "external_dep_count": 9,
       "coupling_ratio": 0.0
     },
     {
@@ -972,30 +1573,6 @@
       "coupling_ratio": 0.0
     },
     {
-      "prefix": "board_core",
-      "module_count": 3,
-      "members": [
-        "Board_core",
-        "Board_core_classify",
-        "Board_core_payload"
-      ],
-      "internal_edges": 0,
-      "external_dep_count": 3,
-      "coupling_ratio": 0.0
-    },
-    {
-      "prefix": "keeper_cascade",
-      "module_count": 3,
-      "members": [
-        "Keeper_cascade_profile",
-        "Keeper_cascade_routing",
-        "Keeper_cascade_selector"
-      ],
-      "internal_edges": 0,
-      "external_dep_count": 11,
-      "coupling_ratio": 0.0
-    },
-    {
       "prefix": "keeper_lifecycle",
       "module_count": 3,
       "members": [
@@ -1008,30 +1585,6 @@
       "coupling_ratio": 0.0
     },
     {
-      "prefix": "keeper_persona",
-      "module_count": 3,
-      "members": [
-        "Keeper_persona",
-        "Keeper_persona_authoring",
-        "Keeper_persona_authoring_contract"
-      ],
-      "internal_edges": 0,
-      "external_dep_count": 14,
-      "coupling_ratio": 0.0
-    },
-    {
-      "prefix": "keeper_types",
-      "module_count": 3,
-      "members": [
-        "Keeper_types",
-        "Keeper_types_profile",
-        "Keeper_types_support"
-      ],
-      "internal_edges": 0,
-      "external_dep_count": 14,
-      "coupling_ratio": 0.0
-    },
-    {
       "prefix": "worker_container",
       "module_count": 3,
       "members": [
@@ -1040,19 +1593,7 @@
         "Worker_container_types"
       ],
       "internal_edges": 0,
-      "external_dep_count": 12,
-      "coupling_ratio": 0.0
-    },
-    {
-      "prefix": "operator_control",
-      "module_count": 3,
-      "members": [
-        "Operator_control",
-        "Operator_control_action",
-        "Operator_control_snapshot"
-      ],
-      "internal_edges": 0,
-      "external_dep_count": 32,
+      "external_dep_count": 13,
       "coupling_ratio": 0.0
     }
   ],
@@ -1064,7 +1605,8 @@
     "Admission_queue": [
       "Admission_queue_metrics",
       "Keeper_cascade_profile",
-      "Prometheus"
+      "Prometheus",
+      "Tool_resource_gate"
     ],
     "Admission_queue_metrics": [
       "Prometheus"
@@ -1072,6 +1614,7 @@
     "Agent_economy": [],
     "Agent_health": [],
     "Agent_identity": [],
+    "Agent_name_kind": [],
     "Agent_registry_eio": [
       "Agent_identity",
       "Session"
@@ -1095,21 +1638,17 @@
       "Sdk_tool_contract",
       "Tool_board",
       "Tool_catalog",
-      "Tool_catalog_surfaces",
       "Tool_task_schemas"
     ],
     "Alignment_score": [],
     "Anti_rationalization": [
       "Agent_sdk_response",
       "Approval_callbacks",
-      "Cascade_legacy_runner",
-      "Config_dir_resolver",
       "Keeper_cascade_profile",
       "Keeper_turn_driver",
       "Keeper_turn_driver_wrappers",
       "Masc_oas_bridge",
       "Prometheus",
-      "Tool_result",
       "Verification"
     ],
     "Approval_callbacks": [],
@@ -1123,8 +1662,6 @@
     ],
     "Auth": [
       "Prometheus",
-      "Tool_access_policy",
-      "Tool_access_role",
       "Tool_catalog",
       "Tool_permission_map"
     ],
@@ -1133,11 +1670,13 @@
       "Codex_mcp_config_doctor",
       "Server_auth"
     ],
-    "Auth_error_kind": [],
-    "Auth_login": [
-      "Auth",
-      "Tool_args"
+    "Auth_error_kind": [
+      "Silent_dashboard_actor_outcome"
     ],
+    "Auth_login": [
+      "Auth"
+    ],
+    "Auth_nickname": [],
     "Auth_resolve": [
       "Auth",
       "Provider_kind_resolver"
@@ -1156,21 +1695,21 @@
       "Keeper_cascade_profile",
       "Keeper_turn_driver",
       "Masc_oas_bridge",
-      "Provider_adapter",
       "Spawn",
       "Tool_name"
     ],
     "Autoresearch": [
       "Autoresearch_codegen",
-      "Provider_adapter"
+      "Cascade_runtime",
+      "Keeper_cascade_profile"
     ],
     "Autoresearch_codegen": [
       "Agent_sdk_response",
       "Approval_callbacks",
       "Autoresearch",
-      "Cascade_config",
       "Cascade_inference",
       "Cascade_runner",
+      "Cascade_runtime",
       "Keeper_cascade_profile",
       "Keeper_turn_driver",
       "Masc_oas_bridge"
@@ -1189,26 +1728,40 @@
     ],
     "Board": [],
     "Board_attachment_meta": [],
+    "Board_comment_rate_limit": [],
     "Board_core": [
       "Agent_economy",
       "Board",
+      "Board_comment_rate_limit",
+      "Board_core_payload",
+      "Board_paths",
+      "Board_sub_board_json",
       "Prometheus"
     ],
     "Board_core_classify": [
       "Prometheus"
     ],
+    "Board_core_json": [],
     "Board_core_payload": [],
     "Board_curation": [],
     "Board_dispatch": [
       "Board",
-      "Board_curation"
+      "Board_curation",
+      "Prometheus"
     ],
     "Board_moderation": [],
+    "Board_paths": [],
+    "Board_sub_board_json": [],
     "Board_votes": [
       "Agent_economy",
-      "Board_core_classify",
+      "Board_votes_json",
       "Prometheus",
       "Thompson_sampling"
+    ],
+    "Board_votes_json": [
+      "Board_core_classify",
+      "Board_core_payload",
+      "Prometheus"
     ],
     "Bounded": [
       "Spawn"
@@ -1224,16 +1777,22 @@
     "Capability_registry": [
       "Agent_tool_surfaces",
       "Tool_catalog",
-      "Tool_catalog_surfaces",
       "Tool_help_registry",
       "Tool_shard"
+    ],
+    "Cascade_agent_context": [
+      "Cascade_transport",
+      "Cascade_wire_overlay",
+      "Masc_grpc_transport"
     ],
     "Cascade_attempt_fsm": [
       "Cascade_config",
       "Cascade_error_classify",
       "Cascade_fsm",
+      "Cascade_health_tracker",
       "Cascade_oas_runner",
-      "Cascade_runner",
+      "Cascade_saturation_signal",
+      "Cascade_transport",
       "Dashboard_oas_bridge",
       "Keeper_metrics",
       "Keeper_types",
@@ -1249,6 +1808,7 @@
     "Cascade_attempt_liveness_runtime": [
       "Cascade_attempt_liveness"
     ],
+    "Cascade_candidate_skip_reason": [],
     "Cascade_capability_profile": [
       "Cascade_capability_schema",
       "Provider_tool_support"
@@ -1262,6 +1822,42 @@
       "Cascade_throttle"
     ],
     "Cascade_catalog_runtime": [
+      "Cascade_catalog_runtime_cache",
+      "Cascade_catalog_runtime_json",
+      "Cascade_catalog_runtime_named_providers",
+      "Cascade_catalog_runtime_resolve",
+      "Cascade_catalog_runtime_validate",
+      "Cascade_config_loader",
+      "Cascade_strategy"
+    ],
+    "Cascade_catalog_runtime_cache": [
+      "Cascade_config_loader",
+      "Cascade_strategy"
+    ],
+    "Cascade_catalog_runtime_json": [
+      "Cascade_catalog_runtime_cache",
+      "Cascade_strategy"
+    ],
+    "Cascade_catalog_runtime_named_providers": [
+      "Cascade_catalog_runtime_cache",
+      "Cascade_config",
+      "Cascade_config_loader",
+      "Cascade_metrics",
+      "Provider_tool_support"
+    ],
+    "Cascade_catalog_runtime_probe": [
+      "Cascade_catalog_runtime_cache",
+      "Prometheus"
+    ],
+    "Cascade_catalog_runtime_resolve": [
+      "Cascade_catalog_runtime_cache",
+      "Cascade_config",
+      "Cascade_config_loader",
+      "Cascade_metrics",
+      "Cascade_routes"
+    ],
+    "Cascade_catalog_runtime_validate": [
+      "Cascade_catalog_runtime_cache",
       "Cascade_config",
       "Cascade_config_loader",
       "Cascade_declarative_adapter",
@@ -1269,44 +1865,63 @@
       "Cascade_metrics",
       "Cascade_routes",
       "Cascade_strategy",
-      "Cascade_toml_materializer",
-      "Config_dir_resolver",
-      "Masc_eio_env",
-      "Prometheus",
-      "Provider_tool_support"
+      "Cascade_toml_materializer"
     ],
     "Cascade_client_capacity": [
       "Cascade_client_capacity_history",
       "Cascade_throttle"
     ],
     "Cascade_client_capacity_history": [
+      "Cascade_http_probe",
       "Prometheus"
     ],
     "Cascade_config": [
       "Cascade_config_loader",
+      "Cascade_config_parser",
+      "Cascade_config_provider_binding",
+      "Cascade_config_provider_filter",
+      "Cascade_config_resolve",
+      "Cascade_config_selection",
+      "Cascade_config_strategy_resolve",
       "Cascade_health_filter",
-      "Cascade_health_tracker",
-      "Cascade_metrics",
-      "Cascade_model_resolve",
-      "Cascade_routes",
-      "Cascade_state",
-      "Cascade_strategy",
-      "Cascade_throttle",
-      "Provider_adapter",
-      "Provider_kind_resolver"
+      "Cascade_model_resolve"
+    ],
+    "Cascade_config_builder": [
+      "Cascade_runner",
+      "Cascade_runtime"
     ],
     "Cascade_config_loader": [
-      "Cascade_capability_profile",
       "Cascade_metrics",
-      "Cascade_ref",
-      "Cascade_tier",
-      "Cascade_toml_materializer",
-      "Prometheus"
+      "Cascade_toml_materializer"
+    ],
+    "Cascade_config_parser": [
+      "Cascade_config_loader",
+      "Cascade_metrics",
+      "Cascade_model_resolve",
+      "Cascade_state",
+      "Provider_kind_resolver"
+    ],
+    "Cascade_config_provider_binding": [],
+    "Cascade_config_provider_filter": [
+      "Cascade_metrics",
+      "Cascade_model_resolve"
+    ],
+    "Cascade_config_resolve": [
+      "Cascade_config_loader",
+      "Cascade_routes"
+    ],
+    "Cascade_config_selection": [
+      "Cascade_config_loader",
+      "Cascade_health_tracker",
+      "Cascade_metrics"
+    ],
+    "Cascade_config_strategy_resolve": [
+      "Cascade_config_loader",
+      "Cascade_strategy"
     ],
     "Cascade_declarative_adapter": [
       "Cascade_config",
-      "Cascade_strategy",
-      "Provider_adapter"
+      "Cascade_strategy"
     ],
     "Cascade_declarative_hotpath": [
       "Cascade_declarative_adapter",
@@ -1314,23 +1929,30 @@
     ],
     "Cascade_diagnostic_probe": [],
     "Cascade_error_classify": [
-      "Cascade_runner",
-      "Cascade_runtime",
+      "Json_field",
       "Keeper_cascade_profile",
       "Keeper_types",
-      "Prometheus",
-      "Provider_adapter"
+      "Prometheus"
     ],
     "Cascade_event_bridge": [
       "Agent_sdk_metrics_bridge",
+      "Cascade_event_bridge_error_json",
+      "Cascade_event_bridge_inference",
       "Context_overflow_action_tracker",
       "Coord",
       "Inference_utils",
-      "Keeper_agent_error",
-      "Keeper_turn_terminal_code",
+      "Keeper_disk_pressure",
+      "Keeper_fd_pressure",
       "Prometheus",
       "Sse",
       "Transport_metrics"
+    ],
+    "Cascade_event_bridge_error_json": [
+      "Keeper_agent_error",
+      "Keeper_turn_terminal_code"
+    ],
+    "Cascade_event_bridge_inference": [
+      "Prometheus"
     ],
     "Cascade_events": [
       "Agent_sdk_metrics_bridge",
@@ -1344,88 +1966,94 @@
     ],
     "Cascade_health_filter": [],
     "Cascade_health_tracker": [
+      "Cascade_health_tracker_config",
       "Cascade_metrics",
       "Keeper_metrics",
-      "Prometheus",
-      "Provider_adapter"
+      "Prometheus"
     ],
+    "Cascade_health_tracker_config": [],
     "Cascade_http_probe": [
-      "Cascade_throttle"
+      "Cascade_throttle",
+      "Keeper_metrics",
+      "Prometheus"
     ],
-    "Cascade_inventory": [
-      "Cascade_health_tracker",
-      "Cascade_strategy",
-      "Keeper_cascade_profile",
-      "Provider_adapter"
+    "Cascade_http_probe_url": [
+      "Cascade_capacity_probe"
     ],
     "Cascade_legacy_runner": [
       "Cascade_metrics",
       "Keeper_cascade_profile",
-      "Llm_metric_bridge",
-      "Provider_adapter"
+      "Llm_metric_bridge"
     ],
     "Cascade_metrics": [
+      "Cascade_metrics_registry",
       "Prometheus"
     ],
+    "Cascade_metrics_registry": [],
     "Cascade_model_resolve": [
-      "Provider_adapter"
+      "Provider_runtime_projection"
     ],
     "Cascade_oas_runner": [
-      "Cascade_catalog_runtime",
-      "Cascade_health_tracker",
-      "Cascade_inventory",
       "Cascade_runner",
       "Cascade_runtime",
       "Keeper_cascade_profile",
       "Keeper_identity",
       "Keeper_types",
       "Llm_metric_bridge",
-      "Provider_adapter",
       "Provider_tool_support",
       "Tool_catalog"
     ],
     "Cascade_pool": [
       "Cascade_health_tracker"
     ],
-    "Cascade_ref": [],
+    "Cascade_preflight_state": [
+      "Prometheus"
+    ],
     "Cascade_routes": [
       "Cascade_config_loader",
-      "Cascade_metrics",
-      "Cascade_ref",
-      "Config_dir_resolver"
+      "Cascade_metrics"
     ],
     "Cascade_runner": [
+      "Cascade_agent_context",
+      "Cascade_error_classify",
       "Cascade_legacy_runner",
       "Cascade_transport",
       "Dashboard_oas_bridge",
-      "Keeper_agent_context",
+      "Fd_accountant",
       "Keeper_oas_checkpoint",
       "Masc_grpc_transport",
-      "Provider_adapter",
       "Provider_tool_support",
-      "Tool_bridge",
-      "Tool_result"
+      "Tool_bridge"
     ],
     "Cascade_runtime": [
       "Cascade_catalog_runtime",
       "Cascade_config",
       "Cascade_metrics",
-      "Config_dir_resolver",
+      "Cascade_routes",
+      "Cascade_throttle",
       "Keeper_cascade_profile",
-      "Provider_adapter",
+      "Provider_runtime_projection",
       "Provider_tool_support"
     ],
-    "Cascade_state": [
-      "Cascade_metrics",
-      "Lockfree_atomic"
+    "Cascade_runtime_candidate": [
+      "Cascade_attempt_fsm",
+      "Cascade_attempt_liveness",
+      "Cascade_client_capacity",
+      "Cascade_health_tracker",
+      "Cascade_http_probe",
+      "Cascade_http_probe_url",
+      "Cascade_oas_runner",
+      "Cascade_runner",
+      "Cascade_strategy",
+      "Provider_kind_resolver",
+      "Provider_tool_support"
     ],
+    "Cascade_saturation_signal": [],
+    "Cascade_state": [],
     "Cascade_strategy": [
       "Cascade_health_tracker",
       "Cascade_metrics",
-      "Cascade_ref",
-      "Cascade_state",
-      "Cascade_throttle",
-      "Prometheus"
+      "Cascade_throttle"
     ],
     "Cascade_strategy_trace": [
       "Keeper_cascade_profile",
@@ -1438,19 +2066,52 @@
       "Cascade_capability_profile",
       "Cascade_capability_schema"
     ],
-    "Cascade_toml_materializer": [
-      "Config_dir_resolver"
+    "Cascade_tier_admission": [
+      "Cascade_saturation_signal"
     ],
+    "Cascade_toml_materializer": [],
     "Cascade_transport": [
       "Auth",
       "Auth_resolve",
-      "Cascade_config",
-      "Cascade_metrics",
+      "Cascade_transport_auth_bridging",
+      "Cascade_transport_authorization",
+      "Cascade_transport_cli_argv_sanitize",
+      "Cascade_transport_cli_config",
+      "Cascade_transport_cli_mcp_config_json",
+      "Cascade_transport_label_resolution",
+      "Cascade_transport_mcp_policy_helpers",
+      "Cascade_transport_mcp_tool_classifier",
+      "Cascade_transport_runtime_policy_provider",
       "Inference_utils",
-      "Prometheus",
-      "Provider_adapter",
       "Provider_tool_support",
       "Tool_catalog"
+    ],
+    "Cascade_transport_auth_bridging": [],
+    "Cascade_transport_authorization": [
+      "Auth",
+      "Tool_catalog"
+    ],
+    "Cascade_transport_cli_argv_sanitize": [
+      "Inference_utils"
+    ],
+    "Cascade_transport_cli_config": [
+      "Cascade_config"
+    ],
+    "Cascade_transport_cli_mcp_config_json": [],
+    "Cascade_transport_codex_omission_dedup": [
+      "Prometheus"
+    ],
+    "Cascade_transport_label_resolution": [
+      "Cascade_config"
+    ],
+    "Cascade_transport_mcp_policy_helpers": [
+      "Cascade_transport_authorization"
+    ],
+    "Cascade_transport_mcp_tool_classifier": [
+      "Tool_catalog"
+    ],
+    "Cascade_transport_runtime_policy_provider": [
+      "Cascade_metrics"
     ],
     "Cascade_trust": [
       "Cascade_health_tracker"
@@ -1458,32 +2119,45 @@
     "Cascade_trust_persist": [
       "Shutdown"
     ],
+    "Cascade_wire_overlay": [],
+    "Cascade_worker_defaults": [],
+    "Provider_capability": [
+      "Prometheus"
+    ],
+    "Provider_health": [
+      "Coord"
+    ],
     "Cascade_catalog_validator": [
       "Cascade_capability_profile",
       "Cascade_catalog_runtime",
       "Cascade_config",
       "Cascade_config_loader",
-      "Cascade_strategy",
-      "Provider_adapter",
+      "Cascade_declarative_adapter",
+      "Cascade_declarative_hotpath",
       "Provider_tool_support"
     ],
     "Cascade_inference": [
       "Cascade_catalog_runtime",
       "Cascade_config",
+      "Cascade_error_classify",
       "Cascade_metrics",
+      "Cascade_runtime",
       "Keeper_cascade_profile"
+    ],
+    "Cdal_runtime_health": [
+      "Cdal_verdict_gate"
     ],
     "Cdal_verdict_gate": [
       "Attribution",
       "Dashboard_attribution"
     ],
-    "Chronicle_event": [],
     "Chronicle_index": [
       "Chronicle_types"
     ],
-    "Chronicle_ingest": [],
+    "Chronicle_ingest": [
+      "Fd_accountant"
+    ],
     "Chronicle_librarian": [
-      "Chronicle_event",
       "Cognitive_gravity"
     ],
     "Chronicle_memory": [
@@ -1506,12 +2180,12 @@
       "Tool_shard",
       "Tools"
     ],
-    "Config_dir_resolver": [],
     "Config_doctor": [
       "Cascade_catalog_runtime",
       "Cascade_catalog_validator",
-      "Config_dir_resolver",
+      "Cascade_routes",
       "Keeper_sandbox_runtime",
+      "Provider_tool_support",
       "Server_base_path_diagnostics"
     ],
     "Context_compact_oas": [
@@ -1535,17 +2209,21 @@
       "Tool_assignment_telemetry"
     ],
     "Coord_assertions": [
-      "Coord_types",
-      "Tool_result"
+      "Coord_types"
     ],
     "Coord_goals": [
       "Convergence",
+      "Coord_goals_verification",
       "Coord_types",
       "Goal_phase",
       "Goal_store",
-      "Goal_verification",
-      "Tool_args",
-      "Tool_result"
+      "Goal_verification"
+    ],
+    "Coord_goals_verification": [
+      "Coord_types",
+      "Goal_phase",
+      "Goal_store",
+      "Goal_verification"
     ],
     "Coord_status_rendering": [
       "Coord_types"
@@ -1568,16 +2246,9 @@
       "Telemetry_eio"
     ],
     "Credits_dashboard": [],
-    "Briefing_compactors": [
-      "Briefing_json_helpers"
-    ],
-    "Briefing_gaps": [
-      "Briefing_json_helpers"
-    ],
-    "Briefing_json_helpers": [],
+    "Briefing_gaps": [],
     "Briefing_sections": [
-      "Briefing_gaps",
-      "Briefing_json_helpers"
+      "Briefing_gaps"
     ],
     "Dashboard_agent_relations": [
       "Graphql_client"
@@ -1598,12 +2269,12 @@
       "Dashboard",
       "Prometheus"
     ],
-    "Dashboard_eval_feed": [],
     "Dashboard_execution": [
       "Coord",
       "Dashboard",
       "Dashboard_projection_cache",
       "Keeper_exec_status",
+      "Keeper_fd_pressure",
       "Keeper_runtime_trust_snapshot",
       "Keeper_status_bridge",
       "Keeper_turn_disposition",
@@ -1617,11 +2288,10 @@
       "Dashboard"
     ],
     "Dashboard_execution_fixture": [
-      "Provider_adapter",
+      "Cascade_runtime_candidate",
       "Version"
     ],
     "Dashboard_execution_helpers": [
-      "Config_dir_resolver",
       "Dashboard",
       "Graphql_client"
     ],
@@ -1631,18 +2301,49 @@
       "Keeper_types"
     ],
     "Dashboard_goals": [
-      "Convergence",
       "Coord",
       "Goal_phase",
       "Goal_store",
       "Goal_verification",
       "Keeper_approval_queue",
       "Keeper_execution_receipt",
-      "Keeper_id",
       "Keeper_runtime_trust_snapshot",
-      "Keeper_status_bridge",
       "Keeper_types",
       "Prometheus"
+    ],
+    "Dashboard_goals_types": [],
+    "Dashboard_goals_types_accessor": [
+      "Convergence",
+      "Goal_store",
+      "Keeper_types"
+    ],
+    "Dashboard_goals_types_attainment": [
+      "Dashboard_goals_types_accessor",
+      "Goal_phase",
+      "Goal_store"
+    ],
+    "Dashboard_goals_types_builder": [
+      "Dashboard_goals_types_accessor",
+      "Dashboard_goals_types_health",
+      "Goal_phase",
+      "Goal_store",
+      "Goal_verification",
+      "Keeper_id",
+      "Keeper_status_bridge",
+      "Keeper_types"
+    ],
+    "Dashboard_goals_types_health": [
+      "Dashboard_goals_types_accessor",
+      "Goal_phase",
+      "Goal_store",
+      "Keeper_types"
+    ],
+    "Dashboard_goals_types_timeline": [
+      "Dashboard_goals_types_accessor",
+      "Goal_phase",
+      "Goal_store",
+      "Keeper_id",
+      "Keeper_types"
     ],
     "Dashboard_governance": [
       "Dashboard_governance_judge",
@@ -1654,16 +2355,16 @@
     "Dashboard_governance_judge": [
       "Agent_sdk_response",
       "Approval_callbacks",
-      "Cascade_config",
       "Cascade_runner",
+      "Cascade_runtime",
       "Dashboard_http_helpers",
       "Judge_diagnostics",
       "Judge_json_recovery",
       "Keeper_cascade_profile",
+      "Keeper_tool_disclosure",
       "Keeper_turn_driver_wrappers",
       "Masc_oas_bridge",
-      "Prometheus",
-      "Tool_result"
+      "Prometheus"
     ],
     "Dashboard_governance_metrics": [
       "Dashboard",
@@ -1673,39 +2374,29 @@
     ],
     "Dashboard_harness_health": [
       "Cascade_runtime",
-      "Compaction_trigger",
       "Coord",
       "Dashboard_yjs",
       "Eval_calibration",
       "Keeper_types"
     ],
     "Dashboard_http_autoresearch": [
-      "Autoresearch",
-      "Tool_autoresearch_registry"
+      "Autoresearch"
     ],
     "Dashboard_http_helpers": [
-      "Dashboard"
+      "Dashboard",
+      "Json_field"
     ],
     "Dashboard_http_keeper": [
       "Agent_reputation",
       "Agent_stress",
-      "Anti_rationalization",
-      "Cascade_config",
-      "Cascade_ref",
-      "Cascade_runtime",
-      "Cdal_verdict_gate",
       "Coord",
       "Dashboard",
-      "Dashboard_attribution",
-      "Dashboard_eval_feed",
       "Dashboard_goals",
-      "Dashboard_harness_health",
       "Dashboard_http_helpers",
-      "Eval_calibration",
+      "Dashboard_http_keeper_feeds",
       "Goal_store",
       "Governance_registry",
       "Keeper_alerting_path",
-      "Keeper_cascade_profile",
       "Keeper_crash_persistence",
       "Keeper_decision_audit",
       "Keeper_exec_context",
@@ -1713,24 +2404,22 @@
       "Keeper_exec_status_metrics",
       "Keeper_exec_tools",
       "Keeper_execution",
-      "Keeper_execution_receipt",
       "Keeper_hooks_oas",
       "Keeper_id",
       "Keeper_memory",
       "Keeper_prompt",
       "Keeper_prompt_names",
-      "Keeper_provider_health",
       "Keeper_registry",
       "Keeper_runtime_contract",
       "Keeper_runtime_trust_snapshot",
       "Keeper_sandbox",
       "Keeper_sandbox_runtime",
       "Keeper_state_machine",
+      "Keeper_state_machine_json",
+      "Keeper_state_machine_mermaid",
       "Keeper_status_bridge",
-      "Keeper_supervisor",
       "Keeper_tool_call_log",
       "Keeper_tool_policy",
-      "Keeper_transition_audit",
       "Keeper_types",
       "Keeper_types_profile",
       "Runtime_params",
@@ -1738,15 +2427,46 @@
       "Thompson_sampling"
     ],
     "Dashboard_http_keeper_detail": [
+      "Keeper_hooks_oas",
       "Keeper_unified_metrics"
     ],
+    "Dashboard_http_keeper_feeds": [
+      "Coord",
+      "Dashboard_http_helpers",
+      "Dashboard_http_keeper_types",
+      "Keeper_memory",
+      "Keeper_types"
+    ],
     "Dashboard_http_keeper_metrics": [
+      "Cascade_runtime_candidate",
       "Dashboard_execution_helpers",
       "Keeper_context_core",
       "Keeper_execution",
       "Keeper_memory",
-      "Keeper_types",
-      "Provider_adapter"
+      "Keeper_types"
+    ],
+    "Dashboard_http_keeper_outcomes": [
+      "Anti_rationalization",
+      "Cdal_runtime_health",
+      "Cdal_verdict_gate",
+      "Dashboard",
+      "Dashboard_attribution",
+      "Dashboard_harness_health",
+      "Eval_calibration",
+      "Keeper_registry",
+      "Keeper_state_machine",
+      "Keeper_transition_audit"
+    ],
+    "Dashboard_http_keeper_trust": [
+      "Coord",
+      "Dashboard_http_keeper_types",
+      "Keeper_execution_receipt",
+      "Keeper_runtime_trust_snapshot",
+      "Keeper_types"
+    ],
+    "Dashboard_http_keeper_types": [
+      "Keeper_cascade_profile",
+      "Keeper_supervisor"
     ],
     "Dashboard_http_monitoring": [
       "Audit_log",
@@ -1804,13 +2524,13 @@
       "Operator_digest_types"
     ],
     "Dashboard_mission_briefing": [
-      "Briefing_compactors",
       "Briefing_gaps",
-      "Briefing_json_helpers",
       "Briefing_sections",
       "Coord",
       "Dashboard_mission",
-      "Operator_control"
+      "Keeper_metrics",
+      "Operator_control",
+      "Prometheus"
     ],
     "Dashboard_nav_event": [
       "Prometheus"
@@ -1823,18 +2543,18 @@
     "Dashboard_operator_judge": [
       "Agent_sdk_response",
       "Approval_callbacks",
-      "Cascade_config",
       "Cascade_runner",
+      "Cascade_runtime",
       "Coord",
       "Dashboard",
       "Dashboard_http_helpers",
       "Judge_diagnostics",
       "Keeper_cascade_profile",
+      "Keeper_tool_disclosure",
       "Keeper_turn_driver_wrappers",
       "Masc_oas_bridge",
       "Operator_approval",
-      "Operator_judgment",
-      "Tool_result"
+      "Operator_judgment"
     ],
     "Dashboard_operator_nudges": [
       "Coord"
@@ -1855,16 +2575,28 @@
       "Keeper_repo_readiness",
       "Keeper_sandbox",
       "Keeper_sandbox_control",
+      "Keeper_sandbox_runtime",
       "Keeper_status_bridge",
       "Keeper_types",
       "Transport_metrics"
     ],
+    "Dashboard_snapshot": [
+      "Coord",
+      "Dashboard",
+      "Server_dashboard_http_core",
+      "Server_dashboard_http_namespace_truth",
+      "Server_dashboard_http_runtime_info",
+      "Telemetry_unified"
+    ],
     "Dashboard_surface_readiness": [],
-    "Dashboard_verification": [],
+    "Dashboard_verification": [
+      "Keeper_fd_pressure"
+    ],
     "Dashboard_worktree_status": [
       "Dashboard",
       "Keeper_id",
-      "Keeper_registry"
+      "Keeper_registry",
+      "Tool_resource_gate"
     ],
     "Dashboard_yjs": [
       "Dashboard",
@@ -1886,24 +2618,56 @@
       "Runtime_params",
       "Tempo"
     ],
-    "Dashboard_cascade": [
-      "Cascade_catalog_runtime",
-      "Cascade_catalog_validator",
+    "Dashboard_cascade": [],
+    "Dashboard_cascade_audit_runs": [
+      "Dashboard_cascade_helpers"
+    ],
+    "Dashboard_cascade_capacity": [
+      "Cascade_capacity_probe",
       "Cascade_client_capacity",
       "Cascade_client_capacity_history",
+      "Cascade_throttle",
+      "Dashboard_cascade_helpers"
+    ],
+    "Dashboard_cascade_config": [
+      "Cascade_catalog_runtime",
+      "Cascade_catalog_validator",
       "Cascade_config_loader",
       "Cascade_runtime",
-      "Cascade_strategy_trace",
-      "Cascade_throttle",
       "Cascade_toml_materializer",
-      "Cascade_trust",
-      "Config_dir_resolver",
+      "Dashboard_cascade_helpers",
       "Keeper_cascade_profile",
       "Keeper_config",
       "Keeper_registry",
       "Keeper_types",
-      "Keeper_types_profile",
+      "Keeper_types_profile"
+    ],
+    "Dashboard_cascade_health": [
+      "Cascade_trust",
       "Model_inference_metrics"
+    ],
+    "Dashboard_cascade_health_json": [
+      "Cascade_catalog_runtime",
+      "Cascade_runtime",
+      "Dashboard_cascade_health",
+      "Dashboard_cascade_helpers",
+      "Dashboard_cascade_recommendations",
+      "Model_inference_metrics"
+    ],
+    "Dashboard_cascade_helpers": [
+      "Cascade_toml_materializer"
+    ],
+    "Dashboard_cascade_recommendations": [
+      "Cascade_trust"
+    ],
+    "Dashboard_cascade_slo": [
+      "Cascade_strategy_trace",
+      "Dashboard_cascade_helpers"
+    ],
+    "Dashboard_cascade_strategy_trace": [
+      "Cascade_strategy_trace",
+      "Dashboard_cascade_helpers",
+      "Keeper_cascade_profile"
     ],
     "Dashboard_provider_runs": [
       "Cascade_config",
@@ -1912,7 +2676,6 @@
       "Keeper_cascade_profile",
       "Keeper_turn_driver_wrappers",
       "Masc_oas_bridge",
-      "Provider_adapter",
       "Tool_local_runtime_core"
     ],
     "Dashboard_tla_specs": [],
@@ -1932,6 +2695,10 @@
     "Discovery_history": [
       "Prometheus"
     ],
+    "Dispatch_outcome": [],
+    "Docker_spawn_throttle": [
+      "Fd_accountant"
+    ],
     "Doctor_dispatch": [],
     "Drift_guard": [
       "Governance_registry",
@@ -1950,17 +2717,15 @@
       "Anti_rationalization"
     ],
     "Eval_gate": [
+      "Shell_safety_types",
       "Tool_access_policy"
     ],
-    "Eval_harness": [
-      "Trajectory"
-    ],
+    "Eval_harness": [],
     "Exec_core": [
       "Keeper_alerting_path",
       "Worker_dev_tools"
     ],
     "Failure_envelope": [],
-    "Gate_diff_types": [],
     "Gate_keeper_backend": [
       "Tool_keeper"
     ],
@@ -2005,13 +2770,13 @@
       "Governance_pipeline_risk",
       "Governance_pipeline_types",
       "Keeper_approval_queue",
+      "Keeper_model_labels",
       "Keeper_routine_allowlist",
       "Keeper_runtime_contract",
       "Keeper_types",
       "Operator_pending_confirm",
       "Otel_spans",
       "Tool_dispatch",
-      "Tool_result",
       "Tool_shard"
     ],
     "Governance_pipeline_risk": [
@@ -2074,97 +2839,24 @@
       "Level4_config"
     ],
     "Intentional_projection": [],
-    "Alert_persist_kind": [],
-    "Approval_queue_failure_site": [],
-    "Bookkeeping_failure_kind": [],
-    "Cascade_sync_failure_site": [],
-    "Chat_store_operation": [],
-    "Checkpoint_failure_operation": [],
-    "Checkpoint_store_failure_site": [],
-    "Compact_audit_failure_site": [],
-    "Compaction_trigger": [],
-    "Crash_persistence_failure_site": [],
-    "Credential_provider": [
-      "Coord"
-    ],
-    "Docker_client": [
-      "Docker_response",
-      "Keeper_container_name",
-      "Keeper_sandbox_oneshot_plan",
-      "Keeper_sandbox_session_plan"
-    ],
-    "Docker_client_mock": [
-      "Docker_client",
-      "Docker_response",
-      "Keeper_container_name",
-      "Keeper_sandbox_oneshot_plan",
-      "Keeper_sandbox_session_plan"
-    ],
-    "Docker_client_real": [
-      "Docker_client",
-      "Docker_response",
-      "Keeper_container_name",
-      "Keeper_sandbox_oneshot_plan",
-      "Keeper_sandbox_runtime",
-      "Keeper_sandbox_session_plan"
-    ],
-    "Docker_response": [
-      "Keeper_container_name"
-    ],
-    "Event_bus_drain_site": [],
-    "Execution_receipt_failure_site": [],
-    "Fs_failure_site": [],
-    "Generation_lineage_failure_site": [],
-    "Heartbeat_smart": [],
-    "Host_config_provider": [
-      "Coord",
-      "Credential_provider",
-      "Env_git_noninteractive",
-      "Keeper_gh_env",
-      "Keeper_identity",
-      "Keeper_types_profile",
-      "Prometheus"
-    ],
-    "In_container_login_provider": [
-      "Credential_provider"
-    ],
+    "Json_field": [],
+    "Dev_exec_allowlist": [],
     "Keeper_accountability": [
       "Attribution",
       "Keeper_identity",
       "Prometheus"
     ],
-    "Keeper_admission_glue": [
-      "Keeper_admission_policy",
-      "Keeper_admission_router"
-    ],
-    "Keeper_admission_policy": [],
-    "Keeper_admission_registry": [],
-    "Keeper_admission_router": [],
-    "Keeper_admission_runtime": [
-      "Cascade_config_loader",
-      "Config_dir_resolver",
-      "Keeper_admission_glue",
-      "Keeper_admission_policy",
-      "Keeper_admission_registry",
-      "Keeper_admission_router",
-      "Keeper_metrics",
-      "Keeper_provider_token_bucket",
-      "Keeper_wfq_overflow",
-      "Prometheus"
+    "Keeper_activation_readiness": [
+      "Keeper_id",
+      "Keeper_types"
     ],
     "Keeper_agent_checkpoint_hygiene": [
-      "Compaction_trigger",
       "Keeper_compact_policy",
       "Keeper_exec_context",
       "Keeper_types"
     ],
-    "Keeper_agent_context": [
-      "Cascade_legacy_runner",
-      "Cascade_transport",
-      "Masc_grpc_transport",
-      "Provider_adapter"
-    ],
     "Keeper_agent_error": [
+      "Cascade_error_classify",
       "Cascade_legacy_runner",
       "Keeper_execution_receipt",
       "Keeper_turn_terminal_code"
@@ -2189,11 +2881,16 @@
       "Keeper_agent_tool_surface"
     ],
     "Keeper_agent_run": [
+      "Cascade_error_classify",
+      "Cascade_inference",
       "Cascade_runner",
+      "Cascade_runtime",
+      "Cascade_runtime_candidate",
       "Coord",
       "Dashboard_harness_health",
       "Governance_pipeline",
       "Keeper_agent_memory_episode",
+      "Keeper_agent_run_receipt_append",
       "Keeper_alerting_path",
       "Keeper_cascade_profile",
       "Keeper_cdal_contract",
@@ -2204,20 +2901,25 @@
       "Keeper_contract_classifier",
       "Keeper_exec_context",
       "Keeper_execution_receipt",
+      "Keeper_hooks_oas",
       "Keeper_id",
       "Keeper_llm_bridge",
       "Keeper_memory_bank",
+      "Keeper_memory_llm_summary",
       "Keeper_memory_policy",
       "Keeper_memory_recall",
       "Keeper_metrics",
+      "Keeper_model_labels",
       "Keeper_run_context",
       "Keeper_run_prompt",
       "Keeper_run_tools",
+      "Keeper_runtime_manifest",
       "Keeper_runtime_resolved",
       "Keeper_sandbox",
       "Keeper_summarizer",
       "Keeper_text_processing",
       "Keeper_timing",
+      "Keeper_tool_call_log",
       "Keeper_tool_disclosure",
       "Keeper_tool_emission_hook",
       "Keeper_turn_driver",
@@ -2226,26 +2928,50 @@
       "Keeper_types",
       "Keeper_types_support",
       "Keeper_wake_telemetry",
+      "Keeper_working_state",
+      "Keeper_working_state_projector",
       "Memory_oas_bridge",
+      "Prometheus"
+    ],
+    "Keeper_agent_run_contract_helpers": [
+      "Keeper_agent_result",
+      "Keeper_tool_disclosure"
+    ],
+    "Keeper_agent_run_receipt_append": [
+      "Coord",
+      "Keeper_execution_receipt",
+      "Keeper_metrics",
       "Prometheus",
-      "Provider_adapter",
-      "Telemetry_coverage_gap",
-      "Trajectory"
+      "Telemetry_coverage_gap"
+    ],
+    "Keeper_agent_run_turn_helpers": [
+      "Coord",
+      "Keeper_agent_tool_surface",
+      "Keeper_execution_receipt",
+      "Keeper_metrics",
+      "Keeper_registry",
+      "Keeper_run_tools",
+      "Keeper_runtime_manifest",
+      "Keeper_tool_disclosure",
+      "Keeper_types",
+      "Prometheus"
     ],
     "Keeper_agent_tool_surface": [
       "Keeper_current_task_reconcile",
       "Keeper_metrics",
+      "Keeper_tool_alias",
       "Keeper_tool_disclosure",
       "Keeper_types",
       "Prometheus",
       "Tool_catalog",
       "Tool_name"
     ],
+    "Keeper_alert_persist_kind": [],
     "Keeper_alerting": [
-      "Alert_persist_kind",
       "Board",
       "Board_dispatch",
       "Governance_registry",
+      "Keeper_alert_persist_kind",
       "Keeper_config",
       "Keeper_id",
       "Keeper_memory",
@@ -2266,23 +2992,23 @@
       "Prometheus"
     ],
     "Keeper_approval_queue": [
-      "Approval_queue_failure_site",
+      "Keeper_approval_queue_failure_site",
+      "Keeper_fd_pressure",
       "Keeper_metrics",
       "Observability_redact",
       "Prometheus",
       "Sse"
     ],
+    "Keeper_approval_queue_failure_site": [],
     "Keeper_artifact_hydrator": [],
     "Keeper_backoff_policy": [
-      "Docker_client"
+      "Keeper_docker_client"
     ],
     "Keeper_behavioral_regime": [],
     "Keeper_behavioral_regime_observer": [
       "Keeper_types"
     ],
-    "Keeper_bg_task_cleanup": [
-      "Keeper_lifecycle_hooks"
-    ],
+    "Keeper_bookkeeping_failure_kind": [],
     "Keeper_callback_failure": [
       "Keeper_id",
       "Keeper_metrics",
@@ -2290,14 +3016,14 @@
       "Prometheus",
       "Telemetry_coverage_gap"
     ],
+    "Keeper_cascade_engine": [],
     "Keeper_cascade_profile": [
       "Cascade_catalog_runtime",
       "Cascade_config_loader",
+      "Cascade_declarative_adapter",
+      "Cascade_declarative_hotpath",
       "Cascade_metrics",
-      "Cascade_ref",
-      "Cascade_routes",
-      "Cascade_toml_materializer",
-      "Config_dir_resolver"
+      "Cascade_routes"
     ],
     "Keeper_cascade_routing": [
       "Cascade_metrics",
@@ -2306,45 +3032,50 @@
       "Keeper_state_machine"
     ],
     "Keeper_cascade_selector": [
-      "Cascade_ref",
       "Keeper_health_probe"
     ],
+    "Keeper_cascade_sync_failure_site": [],
     "Keeper_cdal_contract": [
+      "Keeper_id",
       "Keeper_types"
     ],
     "Keeper_chat_store": [
-      "Chat_store_operation",
+      "Keeper_chat_store_operation",
       "Keeper_fs",
       "Keeper_metrics",
       "Prometheus"
     ],
+    "Keeper_chat_store_operation": [],
+    "Keeper_checkpoint_failure_operation": [],
     "Keeper_checkpoint_store": [
-      "Checkpoint_failure_operation",
-      "Checkpoint_store_failure_site",
       "Inference_utils",
+      "Keeper_checkpoint_failure_operation",
+      "Keeper_checkpoint_store_failure_site",
       "Keeper_fs",
       "Keeper_metrics",
       "Keeper_types",
       "Prometheus"
     ],
+    "Keeper_checkpoint_store_failure_site": [],
     "Keeper_cli_mcp_config": [
       "Auth"
     ],
     "Keeper_compact_audit": [
       "Agent_sdk_metrics_bridge",
-      "Compact_audit_failure_site",
+      "Keeper_compact_audit_failure_site",
+      "Keeper_compact_audit_retention_outcome",
       "Keeper_metrics",
       "Prometheus"
     ],
+    "Keeper_compact_audit_failure_site": [],
+    "Keeper_compact_audit_retention_outcome": [],
     "Keeper_compact_policy": [
-      "Cascade_config",
-      "Cascade_runtime",
-      "Compaction_trigger",
+      "Cascade_runtime_candidate",
       "Context_compact_oas",
       "Dashboard_harness_health",
-      "Keeper_cascade_profile",
       "Keeper_context_core",
       "Keeper_metrics",
+      "Keeper_model_labels",
       "Keeper_types",
       "Prometheus",
       "Sse"
@@ -2354,30 +3085,47 @@
       "Keeper_metrics",
       "Keeper_registry",
       "Keeper_state_machine",
+      "Keeper_state_machine_json",
       "Prometheus"
     ],
     "Keeper_config": [
       "Cascade_catalog_runtime",
       "Keeper_cascade_profile",
-      "Runtime_params",
-      "Tool_args"
+      "Runtime_params"
     ],
     "Keeper_container_name": [
       "Keeper_hash_algo"
     ],
     "Keeper_context_core": [
-      "Checkpoint_failure_operation",
+      "Cascade_runtime_candidate",
       "Inference_utils",
+      "Keeper_checkpoint_failure_operation",
       "Keeper_checkpoint_store",
+      "Keeper_context_tool_message_pairs",
+      "Keeper_context_tool_text_block",
       "Keeper_fs",
       "Keeper_memory_policy",
       "Keeper_metrics",
       "Keeper_model_labels",
       "Keeper_text_processing",
       "Keeper_types",
-      "Prometheus",
-      "Provider_adapter"
+      "Prometheus"
     ],
+    "Keeper_context_core_history": [
+      "Inference_utils",
+      "Keeper_checkpoint_failure_operation",
+      "Keeper_metrics",
+      "Keeper_types",
+      "Prometheus"
+    ],
+    "Keeper_context_core_message_json": [
+      "Inference_utils"
+    ],
+    "Keeper_context_tool_message_pairs": [],
+    "Keeper_context_tool_text_block": [
+      "Inference_utils"
+    ],
+    "Keeper_continuity_summary_source": [],
     "Keeper_contract_classifier": [
       "Keeper_world_observation"
     ],
@@ -2386,9 +3134,13 @@
       "Keeper_types"
     ],
     "Keeper_crash_persistence": [
-      "Crash_persistence_failure_site",
+      "Keeper_crash_persistence_failure_site",
       "Keeper_metrics",
       "Prometheus"
+    ],
+    "Keeper_crash_persistence_failure_site": [],
+    "Keeper_credential_provider": [
+      "Coord"
     ],
     "Keeper_current_task_reconcile": [
       "Coord",
@@ -2403,8 +3155,8 @@
       "Keeper_sandbox"
     ],
     "Keeper_decision_audit": [
-      "Heartbeat_smart",
       "Keeper_alerting_path",
+      "Keeper_heartbeat_smart",
       "Keeper_measurement",
       "Keeper_metrics",
       "Keeper_state_machine",
@@ -2414,20 +3166,49 @@
     "Keeper_deliberation": [
       "Keeper_prompt_names"
     ],
+    "Keeper_disclosure_strategy": [],
     "Keeper_discovered_tools": [],
+    "Keeper_docker_client": [
+      "Keeper_container_name",
+      "Keeper_docker_response",
+      "Keeper_sandbox_oneshot_plan",
+      "Keeper_sandbox_session_plan"
+    ],
+    "Keeper_docker_client_mock": [
+      "Keeper_container_name",
+      "Keeper_docker_client",
+      "Keeper_docker_response",
+      "Keeper_sandbox_oneshot_plan",
+      "Keeper_sandbox_session_plan"
+    ],
+    "Keeper_docker_client_real": [
+      "Docker_spawn_throttle",
+      "Keeper_container_name",
+      "Keeper_docker_client",
+      "Keeper_docker_response",
+      "Keeper_sandbox_oneshot_plan",
+      "Keeper_sandbox_runtime",
+      "Keeper_sandbox_session_plan"
+    ],
     "Keeper_docker_read": [
+      "Docker_spawn_throttle",
       "Keeper_alerting_path",
       "Keeper_sandbox",
       "Keeper_sandbox_factory",
       "Keeper_sandbox_runtime",
       "Keeper_turn_sandbox_runtime",
       "Keeper_types",
+      "Sandbox_error",
       "Worker_dev_tools"
+    ],
+    "Keeper_docker_response": [
+      "Keeper_container_name"
     ],
     "Keeper_egress_audit": [
       "Keeper_shell_docker"
     ],
     "Keeper_error_classify": [
+      "Cascade_capability_profile",
       "Keeper_agent_tool_surface",
       "Keeper_cascade_profile",
       "Keeper_config",
@@ -2438,7 +3219,7 @@
       "Keeper_types"
     ],
     "Keeper_event_bus": [],
-    "Keeper_event_queue": [],
+    "Keeper_event_bus_drain_site": [],
     "Keeper_exec_board": [
       "Board_core_classify",
       "Keeper_exec_shared",
@@ -2446,13 +3227,11 @@
       "Keeper_types",
       "Prometheus",
       "Tool_board",
-      "Tool_name",
-      "Tool_result"
+      "Tool_name"
     ],
     "Keeper_exec_context": [
-      "Cascade_config",
       "Cascade_runtime",
-      "Compaction_trigger",
+      "Cascade_runtime_candidate",
       "Coord",
       "Keeper_compact_policy",
       "Keeper_config",
@@ -2477,11 +3256,12 @@
       "Keeper_docker_read",
       "Keeper_exec_shared",
       "Keeper_fs",
-      "Keeper_invariant",
+      "Keeper_metrics",
       "Keeper_sandbox_containment",
       "Keeper_sandbox_factory",
       "Keeper_turn_sandbox_runtime",
       "Keeper_types",
+      "Prometheus",
       "Tool_shard_limits"
     ],
     "Keeper_exec_ide": [
@@ -2492,12 +3272,11 @@
     ],
     "Keeper_exec_masc": [
       "Coord",
-      "Keeper_alerting_path",
       "Keeper_exec_shared",
       "Keeper_types",
-      "Tool_code",
+      "Tool_code_read_core",
       "Tool_dispatch",
-      "Tool_result"
+      "Tool_telemetry"
     ],
     "Keeper_exec_memory": [
       "Coord",
@@ -2515,17 +3294,18 @@
       "Prometheus"
     ],
     "Keeper_exec_persona": [
-      "Config_dir_resolver",
       "Keeper_memory",
       "Keeper_preset_defaults",
       "Keeper_turn_up_args",
-      "Keeper_types",
-      "Tool_args"
+      "Keeper_types"
     ],
     "Keeper_exec_preflight": [
+      "Cascade_runtime",
       "Coord",
       "Keeper_accountability",
+      "Keeper_activation_readiness",
       "Keeper_alerting_path",
+      "Keeper_cascade_profile",
       "Keeper_identity",
       "Keeper_repo_readiness",
       "Keeper_tool_policy",
@@ -2538,7 +3318,7 @@
       "Keeper_exec_context",
       "Keeper_failure_circuit_breaker",
       "Keeper_metrics",
-      "Keeper_registry",
+      "Keeper_registry_lookup",
       "Keeper_sandbox",
       "Keeper_tool_policy",
       "Keeper_types",
@@ -2546,19 +3326,16 @@
       "Tool_catalog",
       "Tool_dispatch",
       "Tool_name",
-      "Tool_result",
       "Voice_bridge"
     ],
     "Keeper_exec_shell": [
-      "Keeper_shell_bg_task",
+      "Keeper_shell_bash",
       "Keeper_shell_gh_context"
     ],
     "Keeper_exec_status": [
       "Coord",
-      "Keeper_model_labels",
       "Keeper_state_machine",
-      "Keeper_types",
-      "Provider_adapter"
+      "Keeper_types"
     ],
     "Keeper_exec_status_metrics": [
       "Keeper_accountability",
@@ -2571,6 +3348,7 @@
       "Coord",
       "Goal_store",
       "Keeper_accountability",
+      "Keeper_alerting_path",
       "Keeper_exec_shared",
       "Keeper_id",
       "Keeper_metrics",
@@ -2578,14 +3356,16 @@
       "Keeper_runtime_contract",
       "Keeper_tool_policy",
       "Keeper_types",
+      "Keeper_wip_admission",
       "Prometheus",
-      "Tool_result",
-      "Tool_task"
+      "Tool_task",
+      "Tool_task_completion_review"
     ],
     "Keeper_exec_tools": [
       "Coord",
       "Keeper_exec_board",
       "Keeper_exec_fs",
+      "Keeper_exec_ide",
       "Keeper_exec_masc",
       "Keeper_exec_memory",
       "Keeper_exec_preflight",
@@ -2604,14 +3384,12 @@
       "Tool_help_registry",
       "Tool_library",
       "Tool_name",
-      "Tool_result",
       "Tool_shard"
     ],
     "Keeper_exec_voice": [
       "Keeper_exec_shared",
       "Keeper_types",
       "Keeper_voice_local",
-      "Tool_args",
       "Voice_bridge",
       "Voice_session_manager"
     ],
@@ -2621,43 +3399,52 @@
     "Keeper_execution_receipt": [
       "Cascade_runner",
       "Coord",
-      "Execution_receipt_failure_site",
       "Keeper_agent_tool_surface",
       "Keeper_cascade_profile",
       "Keeper_contract_classifier",
       "Keeper_error_classify",
+      "Keeper_execution_receipt_failure_site",
       "Keeper_metrics",
+      "Keeper_reaction_ledger",
       "Keeper_registry",
       "Keeper_runtime_contract",
+      "Keeper_tool_disclosure",
       "Keeper_turn_terminal_code",
       "Keeper_types",
       "Keeper_types_support",
       "Prometheus"
     ],
+    "Keeper_execution_receipt_failure_site": [],
     "Keeper_extend_turns": [],
     "Keeper_failure_circuit_breaker": [
       "Keeper_metrics",
       "Prometheus"
     ],
+    "Keeper_failure_policy": [],
+    "Keeper_fleet_capacity_supervisor": [],
     "Keeper_fs": [
       "Coord",
-      "Fs_failure_site",
+      "Keeper_disk_pressure",
+      "Keeper_fd_pressure",
+      "Keeper_fs_failure_site",
       "Keeper_metrics",
       "Prometheus"
     ],
+    "Keeper_fs_failure_site": [],
     "Keeper_fsm_guard_runtime": [
       "Prometheus"
     ],
     "Keeper_generation_lineage": [
       "Coord",
       "Drift_guard",
-      "Generation_lineage_failure_site",
       "Keeper_fs",
+      "Keeper_generation_lineage_failure_site",
       "Keeper_id",
       "Keeper_metrics",
       "Keeper_types",
       "Prometheus"
     ],
+    "Keeper_generation_lineage_failure_site": [],
     "Keeper_gh_env": [
       "Coord",
       "Env_git_noninteractive",
@@ -2675,6 +3462,7 @@
     ],
     "Keeper_goal_repair": [
       "Coord",
+      "Goal_phase",
       "Goal_store",
       "Keeper_metrics",
       "Keeper_types",
@@ -2705,43 +3493,94 @@
       "Keeper_types"
     ],
     "Keeper_heartbeat_loop": [
-      "Agent_stress",
-      "Cascade_config_loader",
       "Coord",
       "Governance_registry",
-      "Heartbeat_smart",
-      "Keeper_admission_policy",
-      "Keeper_admission_router",
-      "Keeper_admission_runtime",
       "Keeper_approval_queue",
-      "Keeper_cascade_selector",
       "Keeper_config",
       "Keeper_decision_audit",
-      "Keeper_event_queue",
-      "Keeper_exec_context",
+      "Keeper_disk_pressure",
       "Keeper_execution",
-      "Keeper_health_probe",
+      "Keeper_failure_policy",
+      "Keeper_fd_pressure",
+      "Keeper_heartbeat_loop_board_events",
+      "Keeper_heartbeat_loop_in_turn_pulse",
+      "Keeper_heartbeat_loop_presence",
+      "Keeper_heartbeat_loop_scheduling",
+      "Keeper_heartbeat_loop_semaphore_timeout",
+      "Keeper_heartbeat_smart",
       "Keeper_heartbeat_snapshot",
+      "Keeper_heartbeat_visibility_gate",
       "Keeper_id",
-      "Keeper_identity",
       "Keeper_keepalive_signal",
       "Keeper_memory",
-      "Keeper_meta_contract",
       "Keeper_metrics",
       "Keeper_recurring",
       "Keeper_registry",
+      "Keeper_registry_event_queue",
       "Keeper_state_machine",
       "Keeper_tool_diversity",
       "Keeper_tool_policy",
-      "Keeper_turn_driver",
       "Keeper_turn_slot",
       "Keeper_types",
       "Keeper_unified_turn",
       "Keeper_world_observation",
       "Prometheus",
-      "Runtime_params",
+      "Runtime_params"
+    ],
+    "Keeper_heartbeat_loop_board_events": [
+      "Keeper_metrics",
+      "Keeper_types",
+      "Keeper_world_observation",
+      "Prometheus"
+    ],
+    "Keeper_heartbeat_loop_in_turn_pulse": [
+      "Coord",
+      "Keeper_execution",
+      "Keeper_heartbeat_snapshot",
+      "Keeper_metrics",
+      "Keeper_registry",
+      "Keeper_types",
+      "Prometheus",
       "Sse"
     ],
+    "Keeper_heartbeat_loop_observations": [
+      "Keeper_exec_preflight",
+      "Keeper_failure_policy",
+      "Keeper_health_probe",
+      "Keeper_registry",
+      "Keeper_turn_driver",
+      "Keeper_world_observation"
+    ],
+    "Keeper_heartbeat_loop_presence": [
+      "Agent_stress",
+      "Keeper_exec_context",
+      "Keeper_execution",
+      "Keeper_heartbeat_snapshot",
+      "Keeper_id",
+      "Keeper_identity",
+      "Keeper_keepalive_signal",
+      "Keeper_memory",
+      "Keeper_metrics",
+      "Keeper_registry",
+      "Keeper_state_machine",
+      "Keeper_types",
+      "Prometheus"
+    ],
+    "Keeper_heartbeat_loop_scheduling": [
+      "Keeper_exec_preflight",
+      "Keeper_health_probe",
+      "Keeper_types",
+      "Keeper_world_observation"
+    ],
+    "Keeper_heartbeat_loop_semaphore_timeout": [
+      "Keeper_meta_contract",
+      "Keeper_metrics",
+      "Keeper_turn_slot",
+      "Keeper_types",
+      "Keeper_world_observation",
+      "Prometheus"
+    ],
+    "Keeper_heartbeat_smart": [],
     "Keeper_heartbeat_snapshot": [
       "Cascade_events",
       "Cascade_runtime",
@@ -2761,6 +3600,7 @@
       "Keeper_memory",
       "Keeper_metrics",
       "Keeper_registry",
+      "Keeper_registry_tool_usage_persistence",
       "Keeper_state_machine",
       "Keeper_types",
       "Prometheus",
@@ -2768,30 +3608,94 @@
       "Sse",
       "Thompson_sampling"
     ],
-    "Keeper_hooks_oas": [
-      "Keeper_gh_shared",
-      "Keeper_guards",
+    "Keeper_heartbeat_stimulus_intake": [
+      "Keeper_config",
+      "Keeper_execution",
       "Keeper_metrics",
+      "Keeper_reaction_ledger",
+      "Keeper_registry_event_queue",
+      "Keeper_types",
+      "Keeper_world_observation",
+      "Prometheus"
+    ],
+    "Keeper_heartbeat_visibility_gate": [
+      "Keeper_heartbeat_smart",
+      "Keeper_keepalive_signal",
+      "Sse"
+    ],
+    "Keeper_hooks_oas": [
+      "Coord",
+      "Keeper_guards",
+      "Keeper_memory_policy",
+      "Keeper_metrics",
+      "Keeper_registry",
       "Keeper_tool_call_log",
-      "Keeper_tool_policy",
       "Keeper_types",
       "Keeper_usage_trust",
-      "Metric_emit_dropped_site",
       "Observability_redact",
       "Prometheus",
-      "Provider_adapter",
+      "Sse",
       "Telemetry_coverage_gap",
-      "Tool_catalog",
-      "Tool_dispatch",
-      "Tool_name",
-      "Trajectory"
+      "Tool_catalog"
+    ],
+    "Keeper_hooks_oas_cost_events": [
+      "Keeper_hooks_oas_response_metrics",
+      "Keeper_hooks_oas_types",
+      "Keeper_metric_emit_dropped_site",
+      "Keeper_metrics",
+      "Keeper_usage_trust",
+      "Prometheus"
+    ],
+    "Keeper_hooks_oas_gate_attempt": [
+      "Keeper_guards",
+      "Keeper_hooks_oas_types",
+      "Keeper_metrics",
+      "Keeper_tool_call_log",
+      "Keeper_types",
+      "Observability_redact",
+      "Prometheus",
+      "Telemetry_coverage_gap"
+    ],
+    "Keeper_hooks_oas_idle": [
+      "Keeper_hooks_oas_types",
+      "Keeper_tool_policy",
+      "Tool_name"
+    ],
+    "Keeper_hooks_oas_output_json": [
+      "Keeper_gh_shared",
+      "Keeper_hooks_oas_types",
+      "Keeper_metrics",
+      "Prometheus"
+    ],
+    "Keeper_hooks_oas_pr_metrics": [
+      "Keeper_hooks_oas_output_json",
+      "Keeper_hooks_oas_types"
+    ],
+    "Keeper_hooks_oas_response_metrics": [
+      "Keeper_hooks_oas_types",
+      "Keeper_metrics",
+      "Keeper_usage_trust",
+      "Prometheus"
+    ],
+    "Keeper_hooks_oas_types": [
+      "Tool_name"
+    ],
+    "Keeper_host_config_provider": [
+      "Coord",
+      "Env_git_noninteractive",
+      "Keeper_credential_provider",
+      "Keeper_gh_env",
+      "Keeper_identity",
+      "Keeper_types_profile",
+      "Prometheus"
     ],
     "Keeper_id": [],
     "Keeper_identity": [
-      "Config_dir_resolver",
       "Keeper_config"
     ],
-    "Keeper_invariant": [],
+    "Keeper_in_container_login_provider": [
+      "Keeper_credential_provider"
+    ],
     "Keeper_invariant_check": [],
     "Keeper_keepalive": [
       "Cascade_events",
@@ -2807,8 +3711,13 @@
       "Keeper_memory",
       "Keeper_metrics",
       "Keeper_registry",
+      "Keeper_registry_cascade_attempt",
+      "Keeper_registry_error_recording",
+      "Keeper_registry_lookup",
+      "Keeper_registry_tool_usage_persistence",
       "Keeper_stale_watchdog",
       "Keeper_state_machine",
+      "Keeper_turn_livelock",
       "Keeper_types",
       "Masc_grpc_client",
       "Masc_grpc_transport",
@@ -2820,12 +3729,12 @@
       "Coord",
       "Governance_registry",
       "Keeper_config",
-      "Keeper_event_queue",
       "Keeper_execution",
       "Keeper_id",
       "Keeper_memory",
       "Keeper_metrics",
       "Keeper_registry",
+      "Keeper_registry_event_queue",
       "Keeper_state_machine",
       "Keeper_types",
       "Keeper_world_observation",
@@ -2846,40 +3755,51 @@
       "Telemetry_coverage_gap"
     ],
     "Keeper_llm_bridge": [
+      "Failure_envelope",
+      "Keeper_approval_queue",
       "Keeper_metrics",
       "Masc_eio_env",
       "Prometheus",
       "Timeout_policy"
-    ],
-    "Keeper_mcp_provider_audit": [
-      "Keeper_config"
     ],
     "Keeper_measurement": [],
     "Keeper_memory": [],
     "Keeper_memory_bank": [
       "Keeper_types"
     ],
+    "Keeper_memory_llm_summary": [
+      "Cascade_catalog_runtime",
+      "Keeper_memory_bank",
+      "Keeper_memory_llm_summary_outcome",
+      "Keeper_metrics",
+      "Prometheus"
+    ],
+    "Keeper_memory_llm_summary_outcome": [],
     "Keeper_memory_policy": [
       "Coord",
+      "Keeper_memory_policy_summary_filter",
       "Keeper_synthetic_marker",
       "Keeper_types"
     ],
+    "Keeper_memory_policy_summary_filter": [],
     "Keeper_memory_recall": [
       "Coord",
       "Keeper_context_core",
       "Keeper_guard",
       "Keeper_measurement",
+      "Keeper_memory_recall_exn_class",
+      "Keeper_metrics",
       "Keeper_state_machine",
-      "Keeper_types"
+      "Keeper_types",
+      "Prometheus"
     ],
+    "Keeper_memory_recall_exn_class": [],
     "Keeper_meta_contract": [
-      "Cascade_ref",
       "Keeper_config",
       "Keeper_id",
       "Keeper_types_profile"
     ],
     "Keeper_meta_json": [
-      "Cascade_ref",
       "Keeper_id",
       "Keeper_meta_contract",
       "Keeper_metrics",
@@ -2888,15 +3808,16 @@
       "Prometheus"
     ],
     "Keeper_meta_json_parse": [
-      "Cascade_ref",
       "Keeper_config",
       "Keeper_id",
       "Keeper_identity",
       "Keeper_meta_contract",
       "Keeper_meta_json_scrub",
+      "Keeper_metrics",
       "Keeper_personality_io",
       "Keeper_social_model_types",
-      "Keeper_types_profile"
+      "Keeper_types_profile",
+      "Prometheus"
     ],
     "Keeper_meta_json_scrub": [
       "Keeper_meta_contract",
@@ -2908,7 +3829,6 @@
       "Keeper_types"
     ],
     "Keeper_meta_store": [
-      "Config_dir_resolver",
       "Coord",
       "Keeper_fs",
       "Keeper_id",
@@ -2925,10 +3845,11 @@
       "Tool_catalog",
       "Tool_name"
     ],
+    "Keeper_metric_emit_dropped_site": [],
     "Keeper_metrics": [],
+    "Keeper_metrics_sse_failure_kind": [],
     "Keeper_model_labels": [
       "Cascade_runtime",
-      "Keeper_benchmark_canary",
       "Keeper_cascade_profile",
       "Keeper_types"
     ],
@@ -2940,40 +3861,45 @@
       "Agent_sdk_metrics_bridge",
       "Masc_event_bus"
     ],
+    "Keeper_oas_execution_error_phase": [],
+    "Keeper_observation_query_operation": [],
+    "Keeper_operator_compact_result": [],
     "Keeper_passive_loop_detector": [
       "Keeper_metrics",
       "Keeper_turn_disposition",
       "Prometheus"
     ],
+    "Keeper_path_check_error": [],
+    "Keeper_paused_state_persist_phase": [],
     "Keeper_persona": [
       "Keeper_exec_persona",
       "Keeper_types",
       "Keeper_types_profile",
-      "Tool_args",
       "Tool_shard"
     ],
     "Keeper_persona_authoring": [
       "Agent_sdk_response",
       "Approval_callbacks",
       "Cascade_runner",
-      "Config_dir_resolver",
       "Keeper_cascade_profile",
       "Keeper_config",
       "Keeper_fs",
+      "Keeper_persona_authoring_slug",
       "Keeper_turn_driver",
       "Keeper_types",
       "Keeper_types_profile",
-      "Masc_oas_bridge",
-      "Tool_args"
+      "Masc_oas_bridge"
     ],
     "Keeper_persona_authoring_contract": [
       "Keeper_cascade_profile"
+    ],
+    "Keeper_persona_authoring_slug": [
+      "Keeper_config"
     ],
     "Keeper_personality_io": [
       "Keeper_config"
     ],
     "Keeper_post_turn": [
-      "Compaction_trigger",
       "Keeper_callback_failure",
       "Keeper_checkpoint_store",
       "Keeper_compact_policy",
@@ -2982,30 +3908,33 @@
       "Keeper_memory",
       "Keeper_memory_policy",
       "Keeper_metrics",
+      "Keeper_oas_execution_error_phase",
       "Keeper_rollover",
       "Keeper_tool_emission_hook",
       "Keeper_types",
-      "Oas_execution_error_phase",
       "Prometheus"
     ],
+    "Keeper_post_turn_wirein_failure_site": [],
     "Keeper_preset_defaults": [
       "Keeper_types"
     ],
+    "Keeper_profile_load_failure_site": [],
     "Keeper_prompt": [
       "Keeper_config",
       "Keeper_metrics",
       "Keeper_personality_io",
       "Keeper_prompt_external",
       "Keeper_prompt_names",
+      "Keeper_state_block_prompt",
       "Keeper_types",
       "Prometheus"
     ],
-    "Keeper_prompt_external": [
-      "Config_dir_resolver"
-    ],
+    "Keeper_prompt_external": [],
     "Keeper_prompt_names": [],
-    "Keeper_provider_health": [],
-    "Keeper_provider_token_bucket": [],
+    "Keeper_reaction_ledger": [
+      "Coord"
+    ],
+    "Keeper_reconcile_state": [],
     "Keeper_recurring": [
       "Keeper_metrics",
       "Prometheus"
@@ -3013,11 +3942,13 @@
     "Keeper_registry": [
       "Dashboard_attribution",
       "Governance_registry",
-      "Keeper_event_queue",
       "Keeper_fsm_guard_runtime",
-      "Keeper_id",
+      "Keeper_lifecycle_hooks",
       "Keeper_metrics",
-      "Keeper_runtime_resolved",
+      "Keeper_registry_broadcast",
+      "Keeper_registry_entry_action_dispatch",
+      "Keeper_registry_event_validators",
+      "Keeper_registry_fsm_validators",
       "Keeper_state_machine",
       "Keeper_trace_emit",
       "Keeper_transition_audit",
@@ -3025,6 +3956,75 @@
       "Prometheus",
       "Runtime_params",
       "Sse"
+    ],
+    "Keeper_registry_broadcast": [
+      "Keeper_metrics",
+      "Prometheus",
+      "Sse"
+    ],
+    "Keeper_registry_cascade_attempt": [
+      "Coord",
+      "Keeper_registry",
+      "Keeper_registry_types",
+      "Keeper_types"
+    ],
+    "Keeper_registry_entry_action_dispatch": [
+      "Keeper_metrics",
+      "Keeper_state_machine",
+      "Prometheus"
+    ],
+    "Keeper_registry_error_recording": [
+      "Keeper_fd_pressure",
+      "Keeper_metrics",
+      "Keeper_registry",
+      "Keeper_sandbox_runtime",
+      "Prometheus"
+    ],
+    "Keeper_registry_error_tracking": [
+      "Keeper_metrics",
+      "Keeper_registry_types",
+      "Keeper_state_machine",
+      "Prometheus"
+    ],
+    "Keeper_registry_event_queue": [
+      "Keeper_registry"
+    ],
+    "Keeper_registry_event_validators": [
+      "Keeper_fsm_guard_runtime",
+      "Keeper_registry_types",
+      "Keeper_state_machine"
+    ],
+    "Keeper_registry_fsm_validators": [
+      "Keeper_fsm_guard_runtime",
+      "Keeper_registry_types"
+    ],
+    "Keeper_registry_lookup": [
+      "Keeper_id",
+      "Keeper_registry",
+      "Keeper_registry_types",
+      "Keeper_types"
+    ],
+    "Keeper_registry_orphan_drops": [
+      "Keeper_registry_types"
+    ],
+    "Keeper_registry_spawn_slots": [
+      "Keeper_disk_pressure",
+      "Keeper_fd_pressure",
+      "Keeper_metrics",
+      "Keeper_runtime_resolved",
+      "Prometheus"
+    ],
+    "Keeper_registry_tool_usage_persistence": [
+      "Keeper_metrics",
+      "Keeper_registry",
+      "Keeper_registry_types",
+      "Keeper_types",
+      "Prometheus"
+    ],
+    "Keeper_registry_types": [
+      "Keeper_state_machine",
+      "Keeper_transition_audit",
+      "Keeper_types"
     ],
     "Keeper_relevance_check": [],
     "Keeper_repo_readiness": [
@@ -3045,12 +4045,14 @@
       "Keeper_types",
       "Prometheus"
     ],
-    "Keeper_routine_allowlist": [],
+    "Keeper_routine_allowlist": [
+      "Coord",
+      "Keeper_exec_shared",
+      "Keeper_types"
+    ],
     "Keeper_run_context": [
       "Cascade_inference",
       "Cascade_runtime",
-      "Compaction_trigger",
-      "Config_dir_resolver",
       "Coord",
       "Goal_store",
       "Keeper_agent_checkpoint_hygiene",
@@ -3074,6 +4076,7 @@
       "Keeper_agent_prompt_metrics",
       "Keeper_context_core",
       "Keeper_exec_context",
+      "Keeper_failure_circuit_breaker",
       "Keeper_run_context",
       "Keeper_types",
       "Masc_context_injector",
@@ -3092,7 +4095,6 @@
       "Keeper_agent_tool_surface",
       "Keeper_alerting_path",
       "Keeper_artifact_hydrator",
-      "Keeper_callback_failure",
       "Keeper_cascade_profile",
       "Keeper_config",
       "Keeper_context_core",
@@ -3105,6 +4107,10 @@
       "Keeper_metrics",
       "Keeper_passive_loop_detector",
       "Keeper_registry",
+      "Keeper_run_tools_hook_accumulator",
+      "Keeper_run_tools_task_scope",
+      "Keeper_run_tools_work_discovery",
+      "Keeper_runtime_manifest",
       "Keeper_sandbox",
       "Keeper_timing",
       "Keeper_tool_affinity",
@@ -3112,7 +4118,6 @@
       "Keeper_tool_call_log",
       "Keeper_tool_disclosure",
       "Keeper_tool_emission_hook",
-      "Keeper_tool_guidance",
       "Keeper_tool_policy",
       "Keeper_tool_registry",
       "Keeper_tools_oas",
@@ -3125,13 +4130,30 @@
       "Memory_oas_bridge",
       "Prometheus",
       "Tool_catalog",
-      "Tool_help_registry",
-      "Trajectory"
+      "Tool_help_registry"
+    ],
+    "Keeper_run_tools_hook_accumulator": [
+      "Keeper_agent_result",
+      "Keeper_agent_tool_surface",
+      "Keeper_discovered_tools",
+      "Keeper_execution_receipt",
+      "Keeper_tool_disclosure",
+      "Keeper_types"
+    ],
+    "Keeper_run_tools_search": [
+      "Keeper_tool_alias",
+      "Keeper_types"
+    ],
+    "Keeper_run_tools_task_scope": [],
+    "Keeper_run_tools_work_discovery": [
+      "Coord",
+      "Keeper_callback_failure",
+      "Keeper_tool_guidance",
+      "Keeper_types",
+      "Verification"
     ],
     "Keeper_runtime": [
       "Cascade_catalog_runtime",
-      "Cascade_ref",
-      "Config_dir_resolver",
       "Coord",
       "Governance_registry",
       "Keeper_cascade_profile",
@@ -3139,11 +4161,13 @@
       "Keeper_keepalive",
       "Keeper_metrics",
       "Keeper_personality_io",
+      "Keeper_reconcile_state",
       "Keeper_registry",
       "Keeper_runtime_resolved",
       "Keeper_social_model",
       "Keeper_state_machine",
       "Keeper_supervisor",
+      "Keeper_supervisor_types",
       "Keeper_turn",
       "Keeper_types",
       "Keeper_types_profile",
@@ -3151,8 +4175,8 @@
       "Runtime_params"
     ],
     "Keeper_runtime_config": [
-      "Config_dir_resolver",
-      "Keeper_toml_loader"
+      "Keeper_toml_loader",
+      "Prometheus"
     ],
     "Keeper_runtime_contract": [
       "Convergence",
@@ -3163,16 +4187,25 @@
       "Keeper_id",
       "Keeper_types"
     ],
-    "Keeper_runtime_resolved": [],
+    "Keeper_runtime_manifest": [
+      "Coord",
+      "Keeper_disk_pressure",
+      "Keeper_fd_pressure",
+      "Keeper_types_support",
+      "Telemetry_coverage_gap"
+    ],
+    "Keeper_runtime_resolved": [
+      "Keeper_fd_pressure"
+    ],
     "Keeper_runtime_trust_snapshot": [
       "Coord",
       "Keeper_approval_queue",
-      "Keeper_exec_status",
       "Keeper_execution_receipt",
       "Keeper_id",
       "Keeper_memory",
       "Keeper_registry",
       "Keeper_runtime_contract",
+      "Keeper_runtime_trust_timeline",
       "Keeper_state_machine",
       "Keeper_status_bridge",
       "Keeper_tool_call_log",
@@ -3182,6 +4215,10 @@
       "Keeper_turn_terminal_code",
       "Keeper_types",
       "Prometheus"
+    ],
+    "Keeper_runtime_trust_timeline": [
+      "Keeper_approval_queue",
+      "Keeper_tool_call_log"
     ],
     "Keeper_sandbox": [
       "Coord",
@@ -3195,13 +4232,19 @@
     ],
     "Keeper_sandbox_control": [
       "Coord",
+      "Docker_spawn_throttle",
       "Keeper_alerting_path",
       "Keeper_id",
       "Keeper_registry",
+      "Keeper_registry_error_recording",
       "Keeper_sandbox",
       "Keeper_sandbox_runtime",
       "Keeper_types",
       "Worker_dev_tools"
+    ],
+    "Keeper_sandbox_executor": [
+      "Keeper_backoff_policy",
+      "Keeper_docker_client"
     ],
     "Keeper_sandbox_factory": [
       "Coord",
@@ -3217,8 +4260,14 @@
     ],
     "Keeper_sandbox_runtime": [
       "Config",
+      "Docker_spawn_throttle",
       "Keeper_types",
       "Worker_dev_tools"
+    ],
+    "Keeper_sandbox_session_executor": [
+      "Keeper_container_name",
+      "Keeper_docker_client",
+      "Keeper_sandbox_session_plan"
     ],
     "Keeper_sandbox_session_plan": [
       "Keeper_container_name",
@@ -3232,40 +4281,60 @@
       "Exec_core",
       "Keeper_alerting_path",
       "Keeper_exec_shared",
-      "Keeper_metrics",
       "Keeper_sandbox",
       "Keeper_sandbox_factory",
+      "Keeper_shell_bash_typed_input",
       "Keeper_shell_shared",
+      "Keeper_task_worktree_lazy",
+      "Keeper_tool_bash_input",
       "Keeper_tool_policy",
+      "Keeper_turn_sandbox_runtime",
       "Keeper_types",
-      "Legendary_counters",
-      "Prometheus",
       "Worker_dev_tools"
     ],
-    "Keeper_shell_bg_task": [
+    "Keeper_shell_bash_typed_input": [
+      "Keeper_tool_bash_input"
+    ],
+    "Keeper_shell_command_semantics": [
       "Coord",
       "Keeper_alerting_path",
-      "Keeper_exec_shared",
+      "Keeper_gh_shared",
+      "Keeper_sandbox",
       "Keeper_types"
     ],
     "Keeper_shell_docker": [
       "Coord",
-      "Credential_provider",
+      "Docker_spawn_throttle",
+      "Exec_core",
       "Gh_exit_class",
-      "Host_config_provider",
       "Keeper_alerting_path",
+      "Keeper_credential_provider",
       "Keeper_cwd_response",
       "Keeper_exec_shared",
+      "Keeper_fd_pressure",
+      "Keeper_host_config_provider",
       "Keeper_metrics",
       "Keeper_registry",
+      "Keeper_registry_error_recording",
       "Keeper_sandbox",
       "Keeper_sandbox_runtime",
+      "Keeper_shell_command_semantics",
+      "Keeper_shell_docker_worktree_gitdir",
+      "Keeper_task_worktree_lazy",
       "Keeper_turn_sandbox_runtime",
       "Keeper_types",
       "Legendary_counters",
       "Prometheus",
       "Worker_dev_tools"
     ],
+    "Keeper_shell_docker_exec_failure": [
+      "Coord",
+      "Keeper_registry_error_recording",
+      "Keeper_sandbox_runtime",
+      "Keeper_types"
+    ],
+    "Keeper_shell_docker_nested_runtime": [],
+    "Keeper_shell_docker_worktree_gitdir": [],
     "Keeper_shell_gh_context": [
       "Coord",
       "Keeper_exec_shared",
@@ -3303,11 +4372,12 @@
       "Keeper_exec_shared",
       "Keeper_sandbox",
       "Keeper_sandbox_runtime",
+      "Keeper_shell_command_semantics",
       "Keeper_shell_docker",
+      "Keeper_task_worktree_lazy",
       "Keeper_types",
       "Worker_dev_tools"
     ],
-    "Keeper_skill_routing": [],
     "Keeper_social_model": [
       "Keeper_agent_run",
       "Keeper_social_model_protocol",
@@ -3319,23 +4389,27 @@
     "Keeper_stale_watchdog": [
       "Cascade_catalog_runtime",
       "Cascade_health_filter",
-      "Cascade_health_tracker",
-      "Coord",
+      "Cascade_runtime_candidate",
       "Keeper_execution_receipt",
       "Keeper_heartbeat_loop",
       "Keeper_id",
-      "Keeper_meta_merge",
       "Keeper_metrics",
       "Keeper_registry",
       "Keeper_runtime_resolved",
       "Keeper_state_machine",
       "Keeper_turn_slot",
       "Keeper_types",
-      "Prometheus",
-      "Provider_adapter"
+      "Prometheus"
     ],
+    "Keeper_state_block_prompt": [],
     "Keeper_state_machine": [
       "Attribution"
+    ],
+    "Keeper_state_machine_json": [
+      "Keeper_state_machine"
+    ],
+    "Keeper_state_machine_mermaid": [
+      "Keeper_state_machine"
     ],
     "Keeper_status": [
       "Eval_harness",
@@ -3346,16 +4420,14 @@
       "Keeper_memory",
       "Keeper_status_bridge",
       "Keeper_status_detail",
-      "Keeper_types",
-      "Tool_args",
-      "Trajectory"
+      "Keeper_types"
     ],
     "Keeper_status_bridge": [
       "Cascade_toml_materializer",
-      "Config_dir_resolver",
       "Keeper_approval_queue",
       "Keeper_cascade_profile",
       "Keeper_config",
+      "Keeper_error_classify",
       "Keeper_exec_status",
       "Keeper_memory_policy",
       "Keeper_registry",
@@ -3367,10 +4439,6 @@
       "Keeper_types_profile"
     ],
     "Keeper_status_detail": [
-      "Cascade_config",
-      "Cascade_legacy_runner",
-      "Cascade_runtime",
-      "Discovery_cache",
       "Keeper_alerting",
       "Keeper_alerting_path",
       "Keeper_exec_context",
@@ -3386,13 +4454,14 @@
       "Keeper_runtime_trust_snapshot",
       "Keeper_sandbox",
       "Keeper_sandbox_control",
-      "Keeper_sandbox_runtime",
       "Keeper_social_model",
       "Keeper_status_bridge",
+      "Keeper_status_detail_observability",
       "Keeper_types",
-      "Keeper_types_profile",
-      "Provider_adapter",
-      "Tool_args"
+      "Keeper_types_profile"
+    ],
+    "Keeper_status_detail_observability": [
+      "Keeper_memory"
     ],
     "Keeper_stay_silent_loop_detector": [
       "Keeper_metrics",
@@ -3402,20 +4471,19 @@
       "Keeper_lifecycle_hooks"
     ],
     "Keeper_summarizer": [
-      "Keeper_text_processing"
+      "Keeper_metrics",
+      "Keeper_text_processing",
+      "Prometheus"
     ],
     "Keeper_supervisor": [
-      "Auth",
-      "Cascade_error_classify",
       "Cascade_events",
       "Coord",
       "Governance_registry",
       "Keeper_approval_queue",
       "Keeper_crash_persistence",
-      "Keeper_event_queue",
       "Keeper_execution",
+      "Keeper_failure_policy",
       "Keeper_health_probe",
-      "Keeper_identity",
       "Keeper_invariant_check",
       "Keeper_keepalive",
       "Keeper_lifecycle_audit",
@@ -3423,23 +4491,128 @@
       "Keeper_lifecycle_hooks",
       "Keeper_meta_merge",
       "Keeper_metrics",
-      "Keeper_passive_loop_detector",
-      "Keeper_provider_health",
       "Keeper_registry",
+      "Keeper_registry_cascade_attempt",
+      "Keeper_registry_error_recording",
+      "Keeper_registry_event_queue",
+      "Keeper_registry_types",
       "Keeper_stale_watchdog",
       "Keeper_state_machine",
-      "Keeper_stay_silent_loop_detector",
+      "Keeper_supervisor_alive_but_stuck",
+      "Keeper_supervisor_cleanup_failure_site",
+      "Keeper_supervisor_cleanup_tombstone",
+      "Keeper_supervisor_liveness_recovery",
+      "Keeper_supervisor_reconcile_keepalive",
+      "Keeper_supervisor_restart_noop",
+      "Keeper_supervisor_restore_reconcile_gate",
+      "Keeper_supervisor_resume_reconcile_gate",
+      "Keeper_supervisor_self_preservation",
+      "Keeper_supervisor_types",
       "Keeper_tool_emission_hook",
       "Keeper_turn_livelock",
       "Keeper_turn_slot",
       "Keeper_types",
-      "Keeper_types_profile",
-      "Lockfree_atomic",
-      "Observation_query_operation",
       "Prometheus",
       "Runtime_params",
-      "Shutdown",
-      "Supervisor_cleanup_failure_site"
+      "Shutdown"
+    ],
+    "Keeper_supervisor_alive_but_stuck": [
+      "Keeper_metrics",
+      "Keeper_registry",
+      "Keeper_registry_event_queue",
+      "Keeper_state_machine",
+      "Keeper_supervisor_types",
+      "Keeper_types",
+      "Prometheus"
+    ],
+    "Keeper_supervisor_cleanup_failure_site": [],
+    "Keeper_supervisor_cleanup_tombstone": [
+      "Keeper_execution",
+      "Keeper_lifecycle_events",
+      "Keeper_meta_merge",
+      "Keeper_metrics",
+      "Keeper_registry",
+      "Keeper_supervisor_cleanup_failure_site",
+      "Keeper_tool_emission_hook",
+      "Keeper_types",
+      "Prometheus"
+    ],
+    "Keeper_supervisor_liveness_recovery": [
+      "Auth",
+      "Keeper_execution",
+      "Keeper_lifecycle_events",
+      "Keeper_meta_merge",
+      "Keeper_metrics",
+      "Keeper_passive_loop_detector",
+      "Keeper_registry",
+      "Keeper_state_machine",
+      "Keeper_stay_silent_loop_detector",
+      "Keeper_supervisor_types",
+      "Keeper_tool_emission_hook",
+      "Keeper_types",
+      "Keeper_types_profile",
+      "Prometheus"
+    ],
+    "Keeper_supervisor_pause_policy": [
+      "Keeper_execution",
+      "Keeper_failure_policy",
+      "Keeper_meta_merge",
+      "Keeper_metrics",
+      "Keeper_registry",
+      "Keeper_state_machine",
+      "Keeper_supervisor_types",
+      "Keeper_types",
+      "Prometheus"
+    ],
+    "Keeper_supervisor_reconcile_keepalive": [
+      "Keeper_lifecycle_events",
+      "Keeper_metrics",
+      "Keeper_observation_query_operation",
+      "Keeper_registry",
+      "Keeper_state_machine",
+      "Keeper_types",
+      "Prometheus"
+    ],
+    "Keeper_supervisor_restart_noop": [
+      "Lockfree_atomic"
+    ],
+    "Keeper_supervisor_restore_reconcile_gate": [
+      "Keeper_approval_queue",
+      "Keeper_metrics",
+      "Keeper_supervisor_cleanup_failure_site",
+      "Keeper_types",
+      "Prometheus"
+    ],
+    "Keeper_supervisor_resume_reconcile_gate": [
+      "Keeper_meta_merge",
+      "Keeper_metrics",
+      "Keeper_registry",
+      "Keeper_state_machine",
+      "Keeper_turn_livelock",
+      "Keeper_types",
+      "Prometheus"
+    ],
+    "Keeper_supervisor_self_preservation": [
+      "Keeper_crash_persistence",
+      "Keeper_lifecycle_events",
+      "Keeper_metrics",
+      "Keeper_registry",
+      "Keeper_supervisor_types",
+      "Prometheus"
+    ],
+    "Keeper_supervisor_startup_helpers": [
+      "Cascade_error_classify",
+      "Keeper_metrics",
+      "Keeper_supervisor_types",
+      "Keeper_types",
+      "Keeper_types_profile",
+      "Prometheus"
+    ],
+    "Keeper_supervisor_types": [
+      "Keeper_registry",
+      "Keeper_state_machine",
+      "Keeper_types",
+      "Keeper_types_profile"
     ],
     "Keeper_synthetic_marker": [],
     "Keeper_tag_dispatch": [
@@ -3458,16 +4631,24 @@
       "Tool_local_runtime",
       "Tool_misc",
       "Tool_plan",
-      "Tool_result",
       "Tool_run",
       "Tool_shard",
       "Tool_suspend",
       "Tool_task",
       "Tool_worktree"
     ],
+    "Keeper_task_worktree_lazy": [
+      "Coord",
+      "Keeper_alerting_path",
+      "Keeper_id",
+      "Keeper_metrics",
+      "Keeper_types",
+      "Prometheus",
+      "Task_sandbox",
+      "Worker_dev_tools"
+    ],
     "Keeper_telemetry_consumer": [
       "Agent_sdk_metrics_bridge",
-      "Keeper_provider_health",
       "Prometheus"
     ],
     "Keeper_text_processing": [
@@ -3476,23 +4657,29 @@
     "Keeper_timing": [],
     "Keeper_toml_loader": [],
     "Keeper_tool_affinity": [
-      "Keeper_discovered_tools",
-      "Trajectory"
+      "Keeper_discovered_tools"
     ],
     "Keeper_tool_alias": [
       "Keeper_metrics",
       "Prometheus",
-      "Tool_catalog_surfaces"
+      "Tool_shard_types_schemas_bash"
+    ],
+    "Keeper_tool_bash_input": [
+      "Dev_exec_allowlist",
+      "Worker_dev_tools_command_syntax"
     ],
     "Keeper_tool_boundary": [
       "Coord",
       "Tool_keeper"
     ],
+    "Keeper_tool_deterministic_error": [],
     "Keeper_tool_disclosure": [
+      "Keeper_contract_classifier",
       "Keeper_exec_tools",
       "Keeper_metrics",
       "Keeper_registry",
       "Keeper_tool_alias",
+      "Keeper_tool_resolution",
       "Keeper_types",
       "Prometheus",
       "Tool_catalog",
@@ -3511,15 +4698,26 @@
     ],
     "Keeper_tool_github_pr": [
       "Coord",
+      "Keeper_alerting_path",
       "Keeper_exec_shared",
       "Keeper_gh_env",
+      "Keeper_gh_shared",
+      "Keeper_sandbox",
       "Keeper_shell_docker",
       "Keeper_shell_shared",
       "Keeper_tool_pr_review",
       "Keeper_types"
     ],
     "Keeper_tool_guidance": [
+      "Keeper_metrics",
+      "Keeper_prompt_names",
+      "Keeper_tool_alias",
+      "Keeper_types",
+      "Prometheus",
       "Tool_misc_web_fetch"
+    ],
+    "Keeper_tool_name_projection": [
+      "Keeper_tool_alias"
     ],
     "Keeper_tool_policy": [
       "Keeper_alerting",
@@ -3528,6 +4726,7 @@
       "Keeper_metrics",
       "Keeper_state_machine",
       "Keeper_tool_policy_config",
+      "Keeper_tool_policy_failure_site",
       "Keeper_tool_registry",
       "Keeper_types",
       "Prometheus",
@@ -3536,15 +4735,14 @@
       "Tool_code_write",
       "Tool_dispatch",
       "Tool_name",
-      "Tool_policy_failure_site",
       "Tool_shard"
     ],
     "Keeper_tool_policy_config": [
-      "Config_dir_resolver",
       "Keeper_toml_loader",
-      "Tool_dispatch",
+      "Keeper_tool_resolution",
       "Tool_shard"
     ],
+    "Keeper_tool_policy_failure_site": [],
     "Keeper_tool_pr_review": [
       "Coord",
       "Keeper_alerting_path",
@@ -3565,19 +4763,31 @@
       "Tool_name",
       "Tool_shard"
     ],
+    "Keeper_tool_resolution": [
+      "Keeper_tool_alias",
+      "Keeper_tool_registry",
+      "Tool_dispatch",
+      "Tool_name",
+      "Tool_shard"
+    ],
     "Keeper_tools_oas": [
       "Coord",
+      "Dispatch_outcome",
       "Inference_utils",
       "Keeper_exec_tools",
       "Keeper_metrics",
       "Keeper_registry",
+      "Keeper_registry_lookup",
       "Keeper_sandbox_factory",
       "Keeper_tool_alias",
       "Keeper_tool_call_log",
+      "Keeper_tool_deterministic_error",
       "Keeper_tool_policy",
+      "Keeper_tools_oas_markers",
       "Keeper_types",
       "Keeper_types_support",
       "Prometheus",
+      "Prometheus_hotpath",
       "Sse",
       "Tool_assignment_telemetry",
       "Tool_bridge",
@@ -3585,9 +4795,10 @@
       "Tool_input_validation",
       "Tool_output_validation",
       "Tool_registry",
-      "Tool_result",
+      "Tool_resource_gate",
       "Worktree_live_context"
     ],
+    "Keeper_tools_oas_markers": [],
     "Keeper_trace_emit": [
       "Keeper_metrics",
       "Keeper_types_support",
@@ -3597,13 +4808,13 @@
       "Keeper_measurement",
       "Keeper_metrics",
       "Keeper_state_machine",
+      "Keeper_state_machine_json",
       "Prometheus"
     ],
     "Keeper_turn": [
-      "Agent_economy",
       "Cascade_catalog_runtime",
-      "Cascade_config",
       "Cascade_runtime",
+      "Cascade_runtime_candidate",
       "Coord",
       "Keeper_accountability",
       "Keeper_agent_run",
@@ -3611,6 +4822,7 @@
       "Keeper_cascade_profile",
       "Keeper_event_bus",
       "Keeper_exec_context",
+      "Keeper_exec_preflight",
       "Keeper_execution",
       "Keeper_id",
       "Keeper_keepalive",
@@ -3620,6 +4832,7 @@
       "Keeper_metrics",
       "Keeper_model_labels",
       "Keeper_prompt",
+      "Keeper_registry",
       "Keeper_social_model",
       "Keeper_state_machine",
       "Keeper_turn_cascade_budget",
@@ -3630,94 +4843,125 @@
       "Keeper_types",
       "Keeper_unified_metrics",
       "Keeper_world_observation",
+      "Model_inference_metrics",
       "Progress",
       "Prometheus",
-      "Tool_args",
       "Tool_name",
-      "Trajectory",
       "Worktree_live_context"
     ],
     "Keeper_turn_cascade_budget": [
-      "Agent_stress",
-      "Cascade_sync_failure_site",
       "Coord",
       "Keeper_agent_tool_surface",
       "Keeper_approval_queue",
       "Keeper_cascade_profile",
-      "Keeper_config",
+      "Keeper_cascade_sync_failure_site",
       "Keeper_exec_context",
       "Keeper_meta_merge",
       "Keeper_metrics",
+      "Keeper_oas_execution_error_phase",
       "Keeper_registry",
       "Keeper_runtime_resolved",
       "Keeper_state_machine",
+      "Keeper_supervisor_pause_policy",
+      "Keeper_turn_cascade_budget_routing",
       "Keeper_turn_driver",
       "Keeper_turn_helpers",
       "Keeper_types",
-      "Oas_execution_error_phase",
       "Prometheus"
     ],
+    "Keeper_turn_cascade_budget_routing": [
+      "Agent_stress",
+      "Cascade_routes",
+      "Keeper_agent_tool_surface",
+      "Keeper_cascade_profile",
+      "Keeper_config",
+      "Keeper_exec_context",
+      "Keeper_types"
+    ],
+    "Keeper_turn_cleanup_failure_site": [],
     "Keeper_turn_disposition": [],
     "Keeper_turn_driver": [
       "Admission_queue",
       "Agent_sdk_response",
+      "Cascade_attempt_liveness_config",
       "Cascade_capacity_probe",
       "Cascade_catalog_runtime",
       "Cascade_client_capacity",
+      "Cascade_error_classify",
       "Cascade_fsm",
       "Cascade_health_tracker",
-      "Cascade_http_probe",
       "Cascade_legacy_runner",
       "Cascade_metrics",
+      "Cascade_oas_runner",
+      "Cascade_preflight_state",
       "Cascade_runner",
       "Cascade_runtime",
+      "Cascade_runtime_candidate",
       "Cascade_strategy",
       "Cascade_strategy_trace",
+      "Keeper_cascade_engine",
       "Keeper_cascade_profile",
+      "Keeper_registry_cascade_attempt",
+      "Keeper_runtime_manifest",
+      "Keeper_turn_driver_admission",
       "Keeper_turn_driver_try_provider",
       "Keeper_types",
-      "Llm_metric_bridge",
       "Masc_grpc_transport",
-      "Prometheus",
-      "Provider_adapter",
-      "Provider_tool_support"
+      "Provider_capability",
+      "Provider_health"
+    ],
+    "Keeper_turn_driver_admission": [
+      "Cascade_attempt_fsm",
+      "Cascade_catalog_runtime_named_providers",
+      "Cascade_runtime_candidate",
+      "Cascade_saturation_signal",
+      "Cascade_tier_admission",
+      "Keeper_metrics",
+      "Prometheus"
     ],
     "Keeper_turn_driver_helpers": [
       "Cascade_error_classify",
+      "Cascade_runtime_candidate",
+      "Keeper_tool_alias"
+    ],
+    "Keeper_turn_driver_provider_attempt": [
+      "Cascade_attempt_fsm",
       "Cascade_health_tracker",
-      "Cascade_oas_runner",
-      "Provider_adapter",
-      "Provider_tool_support"
+      "Cascade_runtime_candidate"
     ],
     "Keeper_turn_driver_try_provider": [
-      "Cascade_attempt_fsm",
       "Cascade_attempt_liveness",
       "Cascade_attempt_liveness_config",
       "Cascade_attempt_liveness_observer",
+      "Cascade_config_builder",
       "Cascade_error_classify",
       "Cascade_oas_runner",
       "Cascade_runner",
+      "Cascade_runtime_candidate",
+      "Keeper_approval_queue",
+      "Keeper_cascade_engine",
+      "Keeper_runtime_manifest",
       "Keeper_runtime_resolved",
       "Keeper_turn_driver_helpers",
       "Keeper_types",
       "Masc_eio_env",
-      "Masc_grpc_transport",
-      "Provider_adapter"
+      "Masc_grpc_transport"
     ],
     "Keeper_turn_driver_wrappers": [
       "Admission_queue",
       "Agent_sdk_response",
-      "Cascade_legacy_runner",
+      "Cascade_config_builder",
+      "Cascade_oas_runner",
       "Cascade_runner",
       "Keeper_cascade_profile",
       "Keeper_turn_driver",
       "Masc_grpc_transport",
-      "Tool_bridge",
-      "Tool_result"
+      "Tool_bridge"
     ],
     "Keeper_turn_fsm": [
       "Keeper_fsm_guard_runtime",
       "Keeper_metrics",
+      "Keeper_transition_audit",
       "Prometheus"
     ],
     "Keeper_turn_helpers": [
@@ -3729,12 +4973,14 @@
       "Keeper_id",
       "Keeper_metrics",
       "Keeper_registry",
+      "Keeper_registry_error_recording",
+      "Keeper_runtime_manifest",
       "Keeper_sandbox",
       "Keeper_state_machine",
+      "Keeper_status_detail",
       "Keeper_types",
       "Prometheus",
-      "Telemetry_coverage_gap",
-      "Trajectory"
+      "Telemetry_coverage_gap"
     ],
     "Keeper_turn_intent": [],
     "Keeper_turn_lifecycle": [
@@ -3747,24 +4993,23 @@
       "Keeper_tool_emission_hook",
       "Keeper_types",
       "Operator_pending_confirm",
-      "Prometheus",
-      "Tool_args"
+      "Prometheus"
     ],
     "Keeper_turn_livelock": [
       "Keeper_metrics",
-      "Keeper_provider_health",
       "Prometheus"
     ],
     "Keeper_turn_liveness": [
       "Cascade_capacity_probe",
-      "Cascade_config",
-      "Cascade_throttle",
+      "Cascade_runtime_candidate",
       "Keeper_cascade_profile",
       "Keeper_config",
       "Keeper_types"
     ],
+    "Keeper_turn_metrics_snapshot_failure_site": [],
     "Keeper_turn_sandbox_runtime": [
       "Coord",
+      "Docker_spawn_throttle",
       "Keeper_alerting_path",
       "Keeper_metrics",
       "Keeper_sandbox",
@@ -3777,7 +5022,7 @@
       "Keeper_types"
     ],
     "Keeper_turn_slot": [
-      "Bookkeeping_failure_kind",
+      "Keeper_bookkeeping_failure_kind",
       "Keeper_config",
       "Keeper_metrics",
       "Keeper_types",
@@ -3802,23 +5047,22 @@
       "Keeper_types"
     ],
     "Keeper_turn_up_args": [
+      "Cascade_runtime",
       "Coord",
       "Keeper_alerting_path",
+      "Keeper_cascade_profile",
       "Keeper_config",
-      "Keeper_gh_env",
       "Keeper_sandbox",
-      "Keeper_types",
-      "Tool_args"
+      "Keeper_types"
     ],
     "Keeper_turn_up_create": [
       "Auth",
-      "Cascade_ref",
       "Cascade_runtime",
-      "Checkpoint_failure_operation",
       "Goal_store",
       "Governance_registry",
       "Keeper_alerting_path",
       "Keeper_cascade_profile",
+      "Keeper_checkpoint_failure_operation",
       "Keeper_config",
       "Keeper_context_core",
       "Keeper_exec_context",
@@ -3844,34 +5088,54 @@
       "Tool_shard"
     ],
     "Keeper_turn_up_update": [
-      "Cascade_ref",
       "Goal_store",
       "Keeper_approval_queue",
       "Keeper_config",
       "Keeper_keepalive",
       "Keeper_metrics",
       "Keeper_sandbox_runtime",
+      "Keeper_turn_livelock",
       "Keeper_turn_up_args",
+      "Keeper_turn_up_update_failure_site",
       "Keeper_types",
-      "Prometheus",
-      "Turn_up_update_failure_site"
+      "Prometheus"
     ],
+    "Keeper_turn_up_update_failure_site": [],
     "Keeper_typed": [],
-    "Keeper_types": [],
+    "Keeper_types": [
+      "Keeper_config"
+    ],
     "Keeper_types_profile": [
-      "Config_dir_resolver",
       "Coord",
       "Keeper_cascade_profile",
       "Keeper_fs",
       "Keeper_id",
       "Keeper_metrics",
+      "Keeper_profile_load_failure_site",
       "Keeper_runtime_resolved",
       "Keeper_schema",
       "Keeper_social_model_types",
       "Keeper_toml_loader",
-      "Profile_load_failure_site",
+      "Keeper_types_profile_persona",
       "Prometheus",
       "Voice_config"
+    ],
+    "Keeper_types_profile_defaults": [
+      "Keeper_id",
+      "Keeper_types_profile_sandbox"
+    ],
+    "Keeper_types_profile_oas_env": [
+      "Keeper_metrics",
+      "Keeper_toml_loader",
+      "Prometheus"
+    ],
+    "Keeper_types_profile_persona": [
+      "Keeper_metrics",
+      "Keeper_profile_load_failure_site",
+      "Prometheus"
+    ],
+    "Keeper_types_profile_sandbox": [
+      "Keeper_config"
     ],
     "Keeper_types_support": [
       "Cascade_runtime",
@@ -3879,9 +5143,24 @@
       "Keeper_fs"
     ],
     "Keeper_unified_metrics": [
-      "Cascade_legacy_runner",
+      "Keeper_exec_context",
+      "Keeper_types",
+      "Keeper_unified_metrics_broadcast",
+      "Keeper_unified_metrics_decision",
+      "Keeper_unified_metrics_failure",
+      "Keeper_unified_metrics_result",
+      "Keeper_unified_metrics_snapshot"
+    ],
+    "Keeper_unified_metrics_broadcast": [
+      "Keeper_exec_context",
+      "Keeper_metrics",
+      "Keeper_metrics_sse_failure_kind",
+      "Keeper_types",
+      "Prometheus",
+      "Sse"
+    ],
+    "Keeper_unified_metrics_decision": [
       "Cascade_runner",
-      "Compaction_trigger",
       "Coord",
       "Keeper_agent_run",
       "Keeper_agent_tool_surface",
@@ -3889,143 +5168,341 @@
       "Keeper_cascade_profile",
       "Keeper_deliberation",
       "Keeper_exec_context",
-      "Keeper_hooks_oas",
       "Keeper_id",
-      "Keeper_meta_contract",
       "Keeper_metrics",
-      "Keeper_model_labels",
       "Keeper_runtime_contract",
-      "Keeper_status_bridge",
       "Keeper_tool_call_log",
       "Keeper_tool_disclosure",
-      "Keeper_turn_driver",
       "Keeper_turn_terminal",
+      "Keeper_types",
+      "Keeper_world_observation",
+      "Prometheus"
+    ],
+    "Keeper_unified_metrics_failure": [
+      "Keeper_exec_context",
+      "Keeper_meta_contract",
+      "Keeper_metrics",
+      "Keeper_status_bridge",
+      "Keeper_turn_driver",
+      "Keeper_types",
+      "Keeper_world_observation",
+      "Prometheus"
+    ],
+    "Keeper_unified_metrics_json_support": [
+      "Cascade_legacy_runner",
+      "Keeper_agent_run",
+      "Keeper_agent_tool_surface",
+      "Keeper_cascade_profile",
+      "Keeper_exec_context",
+      "Keeper_id",
+      "Keeper_types"
+    ],
+    "Keeper_unified_metrics_result": [
+      "Keeper_agent_run",
+      "Keeper_exec_context",
+      "Keeper_metrics",
+      "Keeper_types",
+      "Keeper_world_observation",
+      "Prometheus"
+    ],
+    "Keeper_unified_metrics_snapshot": [
+      "Cascade_legacy_runner",
+      "Coord",
+      "Keeper_agent_run",
+      "Keeper_cascade_profile",
+      "Keeper_deliberation",
+      "Keeper_exec_context",
+      "Keeper_hooks_oas",
+      "Keeper_id",
+      "Keeper_metrics",
+      "Keeper_types",
+      "Keeper_world_observation",
+      "Prometheus"
+    ],
+    "Keeper_unified_metrics_support": [
+      "Keeper_agent_run",
+      "Keeper_exec_context",
+      "Keeper_metrics",
+      "Keeper_tool_disclosure",
       "Keeper_types",
       "Keeper_usage_trust",
       "Keeper_world_observation",
-      "Metrics_sse_failure_kind",
       "Prometheus",
-      "Provider_adapter",
-      "Sse",
       "Tool_name"
     ],
     "Keeper_unified_prompt": [
       "Agent_economy",
       "Board",
       "Keeper_memory_policy",
+      "Keeper_metrics",
       "Keeper_prompt_names",
+      "Keeper_state_block_prompt",
       "Keeper_tool_policy",
       "Keeper_types",
-      "Keeper_world_observation"
+      "Keeper_unified_metrics",
+      "Keeper_world_observation",
+      "Prometheus"
     ],
     "Keeper_unified_turn": [
-      "Agent_sdk_metrics_bridge",
-      "Cascade_capacity_probe",
-      "Cascade_inference",
-      "Cascade_ref",
-      "Cascade_runner",
-      "Cascade_sync_failure_site",
       "Coord",
-      "Event_bus_drain_site",
-      "Governance_registry",
-      "Keeper_accountability",
       "Keeper_agent_error",
       "Keeper_agent_run",
-      "Keeper_agent_tool_surface",
-      "Keeper_behavioral_regime",
-      "Keeper_cascade_profile",
-      "Keeper_cascade_routing",
+      "Keeper_cascade_sync_failure_site",
       "Keeper_config",
-      "Keeper_coordination",
       "Keeper_event_bus",
       "Keeper_exec_context",
-      "Keeper_exec_tools",
       "Keeper_execution_receipt",
       "Keeper_health_probe",
       "Keeper_id",
       "Keeper_meta_merge",
       "Keeper_metrics",
-      "Keeper_model_labels",
+      "Keeper_oas_execution_error_phase",
       "Keeper_passive_loop_detector",
+      "Keeper_post_turn_wirein_failure_site",
       "Keeper_registry",
-      "Keeper_runtime_resolved",
+      "Keeper_runtime_manifest",
       "Keeper_state_machine",
-      "Keeper_stay_silent_loop_detector",
-      "Keeper_tool_disclosure",
       "Keeper_tool_registry",
-      "Keeper_turn_disposition",
+      "Keeper_turn_cleanup_failure_site",
       "Keeper_turn_driver",
       "Keeper_turn_fsm",
       "Keeper_turn_livelock",
       "Keeper_turn_slot",
       "Keeper_turn_terminal",
-      "Keeper_turn_terminal_code",
       "Keeper_types",
       "Keeper_types_profile",
       "Keeper_unified_metrics",
       "Keeper_unified_prompt",
+      "Keeper_unified_turn_attempt_watchdog",
+      "Keeper_unified_turn_cascade_resolution",
+      "Keeper_unified_turn_event_bus",
+      "Keeper_unified_turn_failure",
+      "Keeper_unified_turn_livelock_block",
+      "Keeper_unified_turn_phase_gate",
+      "Keeper_unified_turn_pre_dispatch",
+      "Keeper_unified_turn_retry_setup",
+      "Keeper_unified_turn_rotation_attempt",
+      "Keeper_unified_turn_success",
+      "Keeper_unified_turn_terminal_error",
       "Keeper_world_observation",
-      "Metric_emit_dropped_site",
-      "Oas_execution_error_phase",
+      "Keeper_write_meta_cycle_failure_site",
       "Otel_genai",
-      "Post_turn_wirein_failure_site",
+      "Prometheus"
+    ],
+    "Keeper_unified_turn_attempt_watchdog": [],
+    "Keeper_unified_turn_cascade_resolution": [
+      "Keeper_cascade_engine",
+      "Keeper_cascade_routing",
+      "Keeper_exec_context",
+      "Keeper_metrics",
+      "Keeper_model_labels",
+      "Keeper_state_machine",
+      "Keeper_turn_liveness",
+      "Keeper_types",
+      "Prometheus"
+    ],
+    "Keeper_unified_turn_event_bus": [
+      "Agent_sdk_metrics_bridge",
+      "Keeper_event_bus",
+      "Keeper_event_bus_drain_site",
+      "Keeper_metrics",
+      "Keeper_turn_cascade_budget",
+      "Keeper_turn_helpers",
+      "Keeper_unified_turn_types",
+      "Prometheus"
+    ],
+    "Keeper_unified_turn_failure": [
+      "Coord",
+      "Governance_registry",
+      "Keeper_behavioral_regime",
+      "Keeper_id",
+      "Keeper_metrics",
+      "Keeper_oas_execution_error_phase",
+      "Keeper_registry",
+      "Keeper_supervisor_pause_policy",
+      "Keeper_turn_cascade_budget",
+      "Keeper_types",
+      "Keeper_types_profile",
+      "Keeper_unified_turn_types",
       "Prometheus",
-      "Runtime_params",
-      "Trajectory",
-      "Turn_cleanup_failure_site",
-      "Turn_metrics_snapshot_failure_site",
-      "Write_meta_cycle_failure_site"
+      "Runtime_params"
     ],
-    "Keeper_usage_trust": [
-      "Provider_adapter",
-      "Provider_kind_resolver"
+    "Keeper_unified_turn_livelock_block": [
+      "Coord",
+      "Keeper_execution_receipt",
+      "Keeper_metrics",
+      "Keeper_registry",
+      "Keeper_state_machine",
+      "Keeper_supervisor_pause_policy",
+      "Keeper_turn_cascade_budget",
+      "Keeper_turn_fsm",
+      "Keeper_turn_helpers",
+      "Keeper_turn_livelock",
+      "Keeper_types",
+      "Prometheus"
     ],
+    "Keeper_unified_turn_phase_gate": [
+      "Coord",
+      "Keeper_exec_context",
+      "Keeper_execution_receipt",
+      "Keeper_registry",
+      "Keeper_state_machine",
+      "Keeper_turn_fsm",
+      "Keeper_turn_helpers",
+      "Keeper_types",
+      "Keeper_unified_turn_phase_plan"
+    ],
+    "Keeper_unified_turn_phase_plan": [
+      "Keeper_state_machine"
+    ],
+    "Keeper_unified_turn_pre_dispatch": [
+      "Cascade_error_classify",
+      "Cascade_inference",
+      "Cascade_runtime",
+      "Keeper_config",
+      "Keeper_coordination",
+      "Keeper_exec_context",
+      "Keeper_turn_cascade_budget",
+      "Keeper_turn_helpers",
+      "Keeper_types",
+      "Keeper_types_profile"
+    ],
+    "Keeper_unified_turn_retry_setup": [
+      "Keeper_agent_run",
+      "Keeper_agent_tool_surface",
+      "Keeper_runtime_resolved",
+      "Keeper_types_profile",
+      "Keeper_world_observation"
+    ],
+    "Keeper_unified_turn_rotation_attempt": [
+      "Keeper_agent_error",
+      "Keeper_error_classify",
+      "Keeper_execution_receipt"
+    ],
+    "Keeper_unified_turn_stay_silent": [
+      "Coord",
+      "Keeper_meta_contract",
+      "Keeper_reaction_ledger",
+      "Keeper_registry",
+      "Keeper_registry_event_queue",
+      "Keeper_types"
+    ],
+    "Keeper_unified_turn_success": [
+      "Cascade_runner",
+      "Coord",
+      "Keeper_accountability",
+      "Keeper_agent_run",
+      "Keeper_error_classify",
+      "Keeper_id",
+      "Keeper_meta_merge",
+      "Keeper_metric_emit_dropped_site",
+      "Keeper_metrics",
+      "Keeper_passive_loop_detector",
+      "Keeper_registry",
+      "Keeper_state_machine",
+      "Keeper_stay_silent_loop_detector",
+      "Keeper_tool_disclosure",
+      "Keeper_turn_fsm",
+      "Keeper_turn_helpers",
+      "Keeper_turn_metrics_snapshot_failure_site",
+      "Keeper_types",
+      "Keeper_unified_turn_stay_silent",
+      "Keeper_usage_trust",
+      "Keeper_world_observation",
+      "Keeper_write_meta_cycle_failure_site",
+      "Prometheus"
+    ],
+    "Keeper_unified_turn_terminal_error": [
+      "Coord",
+      "Keeper_metrics",
+      "Keeper_oas_execution_error_phase",
+      "Keeper_registry",
+      "Prometheus"
+    ],
+    "Keeper_unified_turn_types": [
+      "Cascade_error_classify",
+      "Coord",
+      "Keeper_behavioral_regime",
+      "Keeper_error_classify",
+      "Keeper_exec_tools",
+      "Keeper_execution_receipt",
+      "Keeper_registry",
+      "Keeper_turn_cascade_budget",
+      "Keeper_turn_disposition",
+      "Keeper_turn_fsm",
+      "Keeper_turn_helpers",
+      "Keeper_turn_slot",
+      "Keeper_turn_terminal",
+      "Keeper_turn_terminal_code",
+      "Keeper_types",
+      "Keeper_types_profile"
+    ],
+    "Keeper_usage_trust": [],
+    "Keeper_user_visible_reply_source": [],
     "Keeper_wake_telemetry": [],
-    "Keeper_wfq_overflow": [],
+    "Keeper_wip_admission": [],
+    "Keeper_working_state": [],
+    "Keeper_working_state_projector": [],
     "Keeper_world_observation": [
       "Agent_economy",
       "Board",
       "Board_dispatch",
-      "Cascade_config",
       "Cascade_health_tracker",
       "Cascade_runtime",
+      "Cascade_runtime_candidate",
       "Coord",
       "Keeper_approval_queue",
       "Keeper_cascade_profile",
-      "Keeper_checkpoint_store",
       "Keeper_config",
-      "Keeper_event_queue",
+      "Keeper_memory",
+      "Keeper_metrics",
+      "Keeper_observation_query_operation",
+      "Keeper_reaction_ledger",
+      "Keeper_registry",
+      "Keeper_types",
+      "Prometheus",
+      "Worktree_live_context"
+    ],
+    "Keeper_world_observation_board_signal": [
+      "Board",
+      "Board_dispatch",
+      "Keeper_types"
+    ],
+    "Keeper_world_observation_continuity": [
+      "Coord",
+      "Keeper_checkpoint_store",
+      "Keeper_continuity_summary_source",
       "Keeper_exec_context",
       "Keeper_id",
-      "Keeper_identity",
       "Keeper_memory",
       "Keeper_memory_policy",
       "Keeper_metrics",
       "Keeper_model_labels",
-      "Keeper_registry",
+      "Keeper_types",
+      "Prometheus"
+    ],
+    "Keeper_world_observation_inputs": [
+      "Coord",
+      "Keeper_exec_context",
+      "Keeper_id",
+      "Keeper_metrics",
+      "Keeper_model_labels",
+      "Keeper_observation_query_operation",
       "Keeper_runtime_contract",
       "Keeper_types",
-      "Observation_query_operation",
       "Prometheus",
-      "Worktree_live_context"
+      "Verification"
     ],
-    "Metric_emit_dropped_site": [],
-    "Metrics_sse_failure_kind": [],
-    "Oas_execution_error_phase": [],
-    "Observation_query_operation": [],
-    "Operator_compact_result": [],
-    "Paused_state_persist_phase": [],
-    "Post_turn_wirein_failure_site": [],
-    "Profile_load_failure_site": [],
-    "Sandbox_executor": [
-      "Docker_client",
-      "Keeper_backoff_policy"
+    "Keeper_world_observation_message_scope": [
+      "Coord",
+      "Keeper_config",
+      "Keeper_exec_context",
+      "Keeper_identity",
+      "Keeper_memory",
+      "Keeper_types"
     ],
-    "Sandbox_session_executor": [
-      "Docker_client",
-      "Keeper_container_name",
-      "Keeper_sandbox_session_plan"
-    ],
+    "Keeper_write_meta_cycle_failure_site": [],
+    "Sandbox_error": [],
     "Keeper_social_model_bdi_speech_v1": [
       "Board",
       "Board_dispatch",
@@ -4053,31 +5530,38 @@
       "Keeper_world_observation"
     ],
     "Keeper_social_model_types": [],
-    "Supervisor_cleanup_failure_site": [],
-    "Tool_policy_failure_site": [],
-    "Turn_cleanup_failure_site": [],
-    "Turn_metrics_snapshot_failure_site": [],
-    "Turn_up_update_failure_site": [],
-    "Write_meta_cycle_failure_site": [],
     "Keeper_benchmark_canary": [
       "Keeper_config",
-      "Keeper_types",
-      "Tool_call_quality_benchmark"
+      "Keeper_types"
     ],
+    "Keeper_disk_pressure": [],
+    "Keeper_fd_pressure": [],
     "Keeper_tool_call_log": [
+      "Inference_utils",
+      "Keeper_disk_pressure",
+      "Keeper_fd_pressure",
       "Keeper_runtime_contract",
-      "Keeper_tool_alias"
+      "Keeper_tool_call_log_context",
+      "Keeper_tool_call_log_route_evidence",
+      "Observability_redact",
+      "Prometheus",
+      "Shutdown",
+      "Telemetry_coverage_gap"
     ],
+    "Keeper_tool_call_log_context": [
+      "Keeper_runtime_contract"
+    ],
+    "Keeper_tool_call_log_route_evidence": [],
     "Keeper_voice_local": [
       "Voice_session_manager"
     ],
     "Legendary_counters": [
-      "Gate_diff_types",
       "Gh_exit_class"
     ],
     "Level2_config": [],
     "Level4_config": [],
     "Llm_metric_bridge": [
+      "Otel_spans",
       "Prometheus"
     ],
     "Local_runtime_pool": [
@@ -4085,7 +5569,7 @@
     ],
     "Worker_container": [
       "Cascade_config",
-      "Cascade_legacy_runner",
+      "Cascade_worker_defaults",
       "Telemetry_eio",
       "Tool_catalog",
       "Worker_dev_tools",
@@ -4101,6 +5585,7 @@
     "Worker_container_types": [
       "Agent_tool_surfaces",
       "Auth",
+      "Keeper_disclosure_strategy",
       "Worker_execution_backend"
     ],
     "Worker_runtime": [],
@@ -4110,7 +5595,11 @@
     "Masc_eio_env": [],
     "Masc_error_recovery": [],
     "Masc_event_bus": [],
+    "Masc_event_bus_policy": [
+      "Prometheus"
+    ],
     "Masc_oas_bridge": [
+      "Cascade_error_classify",
       "Masc_eio_env",
       "Prometheus"
     ],
@@ -4163,6 +5652,8 @@
       "Keeper_alerting_path",
       "Keeper_id",
       "Keeper_registry",
+      "Keeper_registry_lookup",
+      "Keeper_registry_tool_usage_persistence",
       "Keeper_runtime_contract",
       "Keeper_sandbox",
       "Keeper_tool_call_log",
@@ -4171,6 +5662,7 @@
       "Keeper_types_profile",
       "Masc_error_recovery",
       "Mcp_server",
+      "Mcp_server_eio_tool_timeout",
       "Mcp_server_eio_types",
       "Observability_redact",
       "Otel_spans",
@@ -4183,30 +5675,40 @@
       "Tool_catalog",
       "Tool_dispatch",
       "Tool_registry",
-      "Tool_result",
+      "Tool_resource_gate",
       "Tools",
-      "Trajectory",
       "Workflow_guide"
+    ],
+    "Mcp_server_eio_caller_identity": [
+      "Agent_identity",
+      "Agent_name_kind",
+      "Auth",
+      "Auth_error_kind",
+      "Auth_strict_mode",
+      "Coord",
+      "Keeper_id",
+      "Keeper_types",
+      "Prometheus",
+      "Tool_catalog"
     ],
     "Mcp_server_eio_execute": [
       "Agent_identity",
       "Agent_registry_eio",
       "Audit_log",
       "Auth",
-      "Auth_error_kind",
-      "Auth_strict_mode",
       "Coord",
       "Keeper_config",
       "Keeper_exec_context",
       "Keeper_exec_tools",
-      "Keeper_id",
       "Keeper_identity",
       "Keeper_registry",
+      "Keeper_registry_lookup",
       "Keeper_sandbox_factory",
       "Keeper_tool_boundary",
       "Keeper_tool_policy",
       "Keeper_types",
       "Mcp_server",
+      "Mcp_server_eio_caller_identity",
       "Mcp_server_eio_governance",
       "Mcp_server_eio_helpers",
       "Mcp_server_eio_tool_profile",
@@ -4221,17 +5723,18 @@
       "Tool_control",
       "Tool_coord",
       "Tool_dispatch",
+      "Tool_dispatch_emit",
       "Tool_inline_dispatch",
       "Tool_library",
       "Tool_local_runtime",
       "Tool_misc",
       "Tool_operator",
       "Tool_plan",
-      "Tool_result",
       "Tool_run",
       "Tool_shard",
       "Tool_suspend",
       "Tool_task",
+      "Tool_telemetry",
       "Tool_worktree"
     ],
     "Mcp_server_eio_governance": [
@@ -4243,6 +5746,7 @@
     "Mcp_server_eio_protocol": [
       "Config",
       "Coord",
+      "Mcp_error_code",
       "Mcp_prompt_surface",
       "Mcp_sdk_adapter_masc",
       "Mcp_server",
@@ -4278,10 +5782,13 @@
       "Tool_shard",
       "Tools"
     ],
+    "Mcp_server_eio_tool_timeout": [
+      "Tools"
+    ],
     "Mcp_server_eio_types": [],
-    "Memory_jsonl": [],
     "Memory_hooks": [
       "Keeper_metrics",
+      "Keeper_runtime_manifest",
       "Memory_oas_bridge",
       "Prometheus"
     ],
@@ -4289,10 +5796,17 @@
       "Agent_stress",
       "Institution_eio",
       "Keeper_memory_policy",
-      "Memory_jsonl",
+      "Keeper_metrics",
+      "Memory_oas_bridge_cache",
+      "Memory_oas_bridge_op_outcome",
       "Procedural_memory",
       "Prometheus"
     ],
+    "Memory_oas_bridge_cache": [
+      "Institution_eio",
+      "Procedural_memory"
+    ],
+    "Memory_oas_bridge_op_outcome": [],
     "Mention_inbox": [
       "Coord"
     ],
@@ -4322,10 +5836,24 @@
     ],
     "Meta_cognition_types": [],
     "Metrics_store_eio": [],
-    "Model_inference_metrics": [
+    "Model_inference_metrics": [],
+    "Model_inference_metrics_aggregate": [
+      "Model_inference_metrics_entry",
+      "Model_inference_metrics_reader"
+    ],
+    "Model_inference_metrics_entry": [],
+    "Model_inference_metrics_json": [
+      "Model_inference_metrics_aggregate",
+      "Model_inference_metrics_entry",
+      "Model_inference_metrics_reader"
+    ],
+    "Model_inference_metrics_parser": [
       "Keeper_cascade_profile",
-      "Keeper_hooks_oas",
-      "Provider_adapter"
+      "Model_inference_metrics_entry"
+    ],
+    "Model_inference_metrics_reader": [
+      "Model_inference_metrics_entry",
+      "Model_inference_metrics_parser"
     ],
     "Notify": [],
     "Observability_redact": [],
@@ -4342,7 +5870,6 @@
       "Keeper_types",
       "Keeper_types_profile",
       "Operator_pending_confirm",
-      "Tool_args",
       "Tool_keeper"
     ],
     "Operator_control_action": [
@@ -4350,36 +5877,70 @@
       "Operator_approval",
       "Operator_digest_types",
       "Operator_judgment",
-      "Operator_pending_confirm",
-      "Tool_args"
+      "Operator_pending_confirm"
+    ],
+    "Operator_control_context_snapshot": [
+      "Keeper_memory",
+      "Keeper_types",
+      "Operator_pending_confirm"
     ],
     "Operator_control_snapshot": [
       "Admission_queue",
-      "Cascade_runtime",
       "Coord",
       "Dashboard",
       "Dashboard_cache",
       "Dashboard_http_helpers",
-      "Keeper_cascade_profile",
       "Keeper_exec_status",
-      "Keeper_exec_status_metrics",
-      "Keeper_exec_tools",
+      "Keeper_fd_pressure",
       "Keeper_id",
       "Keeper_memory",
       "Keeper_registry",
-      "Keeper_runtime_resolved",
-      "Keeper_runtime_trust_snapshot",
       "Keeper_social_model",
       "Keeper_state_machine",
       "Keeper_status_bridge",
       "Keeper_types",
       "Keeper_types_profile",
-      "Tempo",
-      "Tool_args"
+      "Operator_control_snapshot_identity_fields",
+      "Operator_control_snapshot_runtime_status",
+      "Operator_control_snapshot_tool_audit",
+      "Operator_control_snapshot_tool_names",
+      "Operator_control_snapshot_trust",
+      "Tempo"
+    ],
+    "Operator_control_snapshot_identity_fields": [
+      "Keeper_cascade_profile",
+      "Keeper_types",
+      "Operator_pending_confirm"
+    ],
+    "Operator_control_snapshot_runtime_status": [
+      "Keeper_exec_status",
+      "Keeper_runtime_resolved",
+      "Keeper_types",
+      "Operator_pending_confirm"
+    ],
+    "Operator_control_snapshot_tool_audit": [
+      "Coord",
+      "Dashboard_cache",
+      "Keeper_exec_status_metrics",
+      "Keeper_exec_tools",
+      "Keeper_memory",
+      "Keeper_types",
+      "Operator_control_snapshot_tool_names",
+      "Operator_pending_confirm"
+    ],
+    "Operator_control_snapshot_tool_names": [],
+    "Operator_control_snapshot_trust": [
+      "Coord",
+      "Keeper_fd_pressure",
+      "Keeper_id",
+      "Keeper_runtime_trust_snapshot",
+      "Keeper_types"
     ],
     "Operator_digest": [
       "Coord",
       "Failure_envelope",
+      "Keeper_status_bridge",
+      "Keeper_types",
       "Operator_digest_guidance",
       "Operator_pending_confirm",
       "Operator_review_state"
@@ -4412,11 +5973,11 @@
     ],
     "Otel_config": [],
     "Otel_dispatch_hook": [
+      "Dispatch_outcome",
       "Otel_config",
       "Otel_genai",
       "Prometheus",
-      "Tool_dispatch",
-      "Tool_result"
+      "Tool_dispatch"
     ],
     "Otel_genai": [
       "Keeper_cascade_profile",
@@ -4435,33 +5996,84 @@
     "Planning_eio": [
       "Coord"
     ],
-    "Post_verifier": [
-      "Reward_advice_artifact"
-    ],
     "Procedural_memory": [
       "Config"
     ],
     "Progress": [],
     "Prometheus": [
-      "Keeper_metrics"
+      "Fd_accountant",
+      "Pool_metrics",
+      "Prometheus_builtin_metrics",
+      "Prometheus_process",
+      "Prometheus_render",
+      "Prometheus_store"
     ],
+    "Prometheus_builtin_metric_names": [
+      "Pool_metrics"
+    ],
+    "Prometheus_builtin_metrics": [
+      "Prometheus_builtin_metrics_part1",
+      "Prometheus_builtin_metrics_part2",
+      "Prometheus_builtin_metrics_part3",
+      "Prometheus_builtin_metrics_part4",
+      "Prometheus_builtin_metrics_part5"
+    ],
+    "Prometheus_builtin_metrics_part1": [
+      "Keeper_metrics",
+      "Prometheus_builtin_metric_names"
+    ],
+    "Prometheus_builtin_metrics_part2": [
+      "Keeper_metrics",
+      "Prometheus_builtin_metric_names"
+    ],
+    "Prometheus_builtin_metrics_part3": [
+      "Keeper_metrics",
+      "Prometheus_builtin_metric_names"
+    ],
+    "Prometheus_builtin_metrics_part4": [
+      "Keeper_metrics",
+      "Prometheus_builtin_metric_names"
+    ],
+    "Prometheus_builtin_metrics_part5": [
+      "Keeper_metrics",
+      "Prometheus_builtin_metric_names"
+    ],
+    "Prometheus_cascade_metric_names": [],
+    "Prometheus_core_metric_names": [],
+    "Prometheus_format": [],
+    "Prometheus_hotpath": [
+      "Prometheus"
+    ],
+    "Prometheus_identity_metric_names": [],
+    "Prometheus_key": [],
+    "Prometheus_metric_names": [],
+    "Prometheus_oas_metric_names": [],
+    "Prometheus_policy_metric_names": [],
+    "Prometheus_process": [],
+    "Prometheus_render": [
+      "Prometheus_format",
+      "Prometheus_store",
+      "Prometheus_text"
+    ],
+    "Prometheus_runtime_metric_names": [],
+    "Prometheus_store": [
+      "Prometheus_key"
+    ],
+    "Prometheus_text": [],
+    "Prometheus_transport_metric_names": [],
     "Prompt_composer": [
       "Team_context"
     ],
     "Prompt_defaults": [
-      "Config_dir_resolver",
       "Keeper_metrics",
       "Prometheus"
-    ],
-    "Provider_adapter": [
-      "Voice_config"
     ],
     "Provider_kind_resolver": [
       "Cascade_model_resolve"
     ],
+    "Provider_runtime_projection": [],
     "Provider_tool_support": [
-      "Prometheus",
-      "Provider_adapter"
+      "Prometheus"
     ],
     "Rate_limit": [],
     "Relation_materializer": [
@@ -4478,9 +6090,6 @@
       "Coord"
     ],
     "Retrieval_projection": [],
-    "Reward_advice_artifact": [
-      "Tool_call_quality_benchmark_types"
-    ],
     "Room_protocol": [
       "Coord",
       "Tempo"
@@ -4492,15 +6101,25 @@
     "Runtime_params": [
       "Config"
     ],
+    "Docker_api": [],
     "Sdk_tool_contract": [
       "Tool_schema_dsl"
     ],
     "Atomic_orphan_size_class": [],
+    "Fd_accountant": [
+      "Keeper_fd_pressure"
+    ],
+    "Host_fd_pressure_poller": [
+      "Keeper_fd_pressure"
+    ],
     "Lsp_message_router": [
       "Lsp_process_manager"
     ],
     "Lsp_overlay_provider": [],
     "Lsp_process_manager": [],
+    "Mcp_error_code": [],
+    "Openai_compat_error_map": [],
+    "Pool_metrics": [],
     "Proactive_refresh": [
       "Dashboard"
     ],
@@ -4516,7 +6135,6 @@
       "Rate_limit",
       "Server_health_paths",
       "Server_utils",
-      "Silent_dashboard_actor_outcome",
       "Transport"
     ],
     "Server_bootstrap_http": [
@@ -4532,6 +6150,7 @@
       "Agent_registry_eio",
       "Agent_sdk_metrics_bridge",
       "Agent_tool_surfaces",
+      "Auth",
       "Board",
       "Board_dispatch",
       "Board_votes",
@@ -4542,10 +6161,12 @@
       "Dashboard",
       "Dashboard_governance_judge",
       "Dashboard_operator_judge",
+      "Dashboard_snapshot",
+      "Dispatch_outcome",
       "Goal_janitor",
       "Governance_pipeline",
+      "Host_fd_pressure_poller",
       "Keeper_approval_queue",
-      "Keeper_bg_task_cleanup",
       "Keeper_compact_audit",
       "Keeper_config",
       "Keeper_fs",
@@ -4562,7 +6183,9 @@
       "Keeper_telemetry_consumer",
       "Keeper_tool_call_log",
       "Keeper_types",
+      "Keeper_types_profile",
       "Masc_event_bus",
+      "Masc_event_bus_policy",
       "Mcp_server",
       "Metrics_store_eio",
       "Operator_control",
@@ -4595,12 +6218,26 @@
       "Tool_metrics_persist",
       "Tool_name",
       "Tool_output_validation",
-      "Tool_result",
       "Tool_task",
       "Tool_usage_log",
       "Transport_metrics",
       "Verification",
       "Verification_protocol"
+    ],
+    "Server_dashboard_cascade_profile_gate": [
+      "Cascade_catalog_runtime",
+      "Cascade_catalog_validator",
+      "Cascade_runtime",
+      "Dashboard_cascade",
+      "Keeper_cascade_profile"
+    ],
+    "Server_dashboard_compact_receipt_json": [],
+    "Server_dashboard_fleet_readiness": [
+      "Coord",
+      "Dashboard",
+      "Keeper_activation_readiness",
+      "Keeper_registry",
+      "Keeper_types"
     ],
     "Server_dashboard_http": [
       "Board",
@@ -4612,23 +6249,26 @@
       "Dashboard_goals",
       "Dashboard_governance",
       "Dashboard_governance_metrics",
+      "Dashboard_verification",
       "Goal_store",
-      "Institution_eio",
+      "Json_field",
       "Keeper_approval_queue",
       "Keeper_composite_observer",
       "Keeper_execution_receipt",
-      "Keeper_memory_policy",
-      "Keeper_memory_recall",
       "Keeper_registry",
+      "Keeper_status_bridge",
+      "Keeper_tool_call_log",
       "Keeper_types",
       "Mcp_server",
       "Operator_control",
       "Operator_digest_types",
       "Server_auth",
+      "Server_dashboard_compact_receipt_json",
+      "Server_dashboard_fleet_readiness",
       "Server_dashboard_http_namespace_truth",
       "Server_dashboard_http_namespace_truth_support",
+      "Server_dashboard_snapshot_select",
       "Server_utils",
-      "Tool_args",
       "Verification_protocol"
     ],
     "Server_dashboard_http_agent_api": [
@@ -4645,8 +6285,6 @@
     ],
     "Server_dashboard_http_core": [
       "Auth",
-      "Build_identity",
-      "Config_dir_resolver",
       "Coord",
       "Dashboard",
       "Dashboard_cache",
@@ -4654,22 +6292,72 @@
       "Dashboard_mission",
       "Dashboard_mission_briefing",
       "Mcp_server",
-      "Meta_cognition",
       "Operator_control",
       "Proactive_refresh",
       "Server_auth",
       "Server_base_path_diagnostics",
+      "Server_dashboard_http_core_cache",
+      "Server_dashboard_http_core_entities",
+      "Server_dashboard_http_core_json",
+      "Server_dashboard_http_core_meta_cognition",
+      "Server_dashboard_http_core_operator",
+      "Server_dashboard_http_core_operator_query",
+      "Server_dashboard_http_core_runtime",
+      "Server_dashboard_http_core_snapshot_refresh",
       "Server_dashboard_http_runtime_info",
       "Server_dashboard_http_runtime_support",
       "Server_startup_state",
+      "Server_timing",
       "Server_utils",
       "Tempo"
+    ],
+    "Server_dashboard_http_core_cache": [
+      "Coord",
+      "Dashboard"
+    ],
+    "Server_dashboard_http_core_entities": [
+      "Build_identity",
+      "Coord",
+      "Dashboard_execution_helpers",
+      "Tempo"
+    ],
+    "Server_dashboard_http_core_json": [
+      "Server_dashboard_http_core_cache",
+      "Server_dashboard_http_core_operator"
+    ],
+    "Server_dashboard_http_core_meta_cognition": [
+      "Coord",
+      "Dashboard_cache",
+      "Meta_cognition",
+      "Server_dashboard_http_core_cache"
+    ],
+    "Server_dashboard_http_core_operator": [
+      "Dashboard_http_helpers",
+      "Server_auth",
+      "Server_dashboard_http_cache"
+    ],
+    "Server_dashboard_http_core_operator_query": [
+      "Coord",
+      "Server_dashboard_http_core_cache",
+      "Server_dashboard_http_core_json",
+      "Server_dashboard_http_core_operator"
+    ],
+    "Server_dashboard_http_core_runtime": [
+      "Coord",
+      "Mcp_server",
+      "Server_dashboard_http_runtime_support"
+    ],
+    "Server_dashboard_http_core_snapshot_refresh": [
+      "Dashboard",
+      "Mcp_server",
+      "Operator_control",
+      "Proactive_refresh",
+      "Server_dashboard_http_runtime_support"
     ],
     "Server_dashboard_http_delete_actions": [
       "Auth",
       "Board_dispatch",
       "Board_moderation",
-      "Config_dir_resolver",
       "Coord",
       "Goal_janitor",
       "Goal_store",
@@ -4699,25 +6387,19 @@
       "Prometheus",
       "Server_auth",
       "Server_dashboard_http_core",
+      "Server_dashboard_surface",
       "Server_utils",
       "Sse",
       "Transport_metrics"
     ],
     "Server_dashboard_http_keeper_api": [
-      "Cascade_runtime",
       "Coord",
-      "Dashboard",
-      "Dashboard_cache",
-      "Dashboard_eval_feed",
       "Dashboard_http_keeper",
-      "Dashboard_projection_cache",
       "Keeper_behavioral_regime_observer",
-      "Keeper_cascade_profile",
       "Keeper_cascade_routing",
       "Keeper_chat_store",
       "Keeper_checkpoint_store",
       "Keeper_config",
-      "Keeper_context_core",
       "Keeper_decision_audit",
       "Keeper_exec_tools",
       "Keeper_id",
@@ -4726,8 +6408,12 @@
       "Keeper_memory",
       "Keeper_memory_policy",
       "Keeper_metrics",
+      "Keeper_paused_state_persist_phase",
       "Keeper_registry",
+      "Keeper_registry_lookup",
+      "Keeper_runtime_manifest",
       "Keeper_state_machine",
+      "Keeper_state_machine_mermaid",
       "Keeper_tool_call_log",
       "Keeper_tool_policy",
       "Keeper_transition_audit",
@@ -4736,21 +6422,104 @@
       "Keeper_types",
       "Local_runtime_pool",
       "Mcp_server",
-      "Operator_control_snapshot",
-      "Paused_state_persist_phase",
       "Prometheus",
       "Server_auth",
       "Server_dashboard_http",
-      "Server_dashboard_http_execution_surfaces",
+      "Server_dashboard_http_keeper_api_lifecycle_post",
+      "Server_dashboard_http_keeper_api_runtime_lens",
+      "Server_dashboard_http_keeper_api_summary_aggregates",
       "Server_utils",
       "Telemetry_coverage_gap",
       "Thompson_sampling",
-      "Tool_keeper",
-      "Trajectory"
+      "Tool_keeper"
+    ],
+    "Server_dashboard_http_keeper_api_checkpoints": [
+      "Coord",
+      "Keeper_checkpoint_store",
+      "Keeper_context_core",
+      "Keeper_id",
+      "Keeper_types",
+      "Server_dashboard_http_keeper_api_types"
+    ],
+    "Server_dashboard_http_keeper_api_lifecycle_post": [
+      "Dashboard",
+      "Dashboard_cache",
+      "Dashboard_projection_cache",
+      "Keeper_keepalive",
+      "Keeper_metrics",
+      "Keeper_paused_state_persist_phase",
+      "Keeper_registry",
+      "Keeper_registry_lookup",
+      "Keeper_state_machine",
+      "Keeper_types",
+      "Mcp_server",
+      "Operator_control_snapshot",
+      "Prometheus",
+      "Server_dashboard_http_execution_surfaces",
+      "Server_dashboard_http_keeper_api_types",
+      "Tool_keeper"
+    ],
+    "Server_dashboard_http_keeper_api_runtime_lens": [
+      "Keeper_runtime_manifest",
+      "Server_dashboard_http_keeper_api_types",
+      "Server_dashboard_http_keeper_runtime_lens_gaps",
+      "Server_dashboard_http_keeper_runtime_lens_proof",
+      "Server_dashboard_http_keeper_runtime_lens_summaries",
+      "Server_dashboard_http_keeper_runtime_lens_swimlane",
+      "Server_dashboard_http_keeper_runtime_manifest_scan"
+    ],
+    "Server_dashboard_http_keeper_api_scan_summary": [
+      "Server_dashboard_http_keeper_api_types",
+      "Server_dashboard_http_keeper_runtime_manifest_scan"
+    ],
+    "Server_dashboard_http_keeper_api_summary_aggregates": [
+      "Keeper_runtime_manifest",
+      "Server_dashboard_http_keeper_api_types",
+      "Server_dashboard_http_keeper_runtime_manifest_scan"
+    ],
+    "Server_dashboard_http_keeper_api_trace": [
+      "Coord",
+      "Keeper_types"
+    ],
+    "Server_dashboard_http_keeper_api_types": [
+      "Keeper_memory_policy",
+      "Keeper_runtime_manifest"
+    ],
+    "Server_dashboard_http_keeper_runtime_lens_gaps": [
+      "Keeper_runtime_manifest",
+      "Server_dashboard_http_keeper_api_types",
+      "Server_dashboard_http_keeper_runtime_lens_swimlane",
+      "Server_dashboard_http_keeper_runtime_manifest_scan"
+    ],
+    "Server_dashboard_http_keeper_runtime_lens_proof": [
+      "Keeper_tool_call_log",
+      "Server_dashboard_http_keeper_api_types"
+    ],
+    "Server_dashboard_http_keeper_runtime_lens_summaries": [
+      "Keeper_status_bridge",
+      "Keeper_tool_call_log",
+      "Keeper_types",
+      "Server_dashboard_http_keeper_api_types"
+    ],
+    "Server_dashboard_http_keeper_runtime_lens_swimlane": [
+      "Keeper_runtime_manifest",
+      "Server_dashboard_http_keeper_api_types",
+      "Server_dashboard_http_keeper_runtime_manifest_scan"
+    ],
+    "Server_dashboard_http_keeper_runtime_manifest_scan": [
+      "Keeper_runtime_manifest",
+      "Server_dashboard_http_keeper_api_types"
     ],
     "Server_dashboard_http_link_preview": [
       "Mcp_server",
       "Server_auth"
+    ],
+    "Server_dashboard_http_memory_subsystems": [
+      "Institution_eio",
+      "Keeper_memory_policy",
+      "Keeper_memory_recall",
+      "Keeper_types",
+      "Server_utils"
     ],
     "Server_dashboard_http_namespace_truth": [
       "Coord",
@@ -4768,14 +6537,20 @@
       "Meta_cognition",
       "Operator_control"
     ],
+    "Server_dashboard_http_perf": [
+      "Coord",
+      "Dashboard_http_helpers"
+    ],
     "Server_dashboard_http_runtime_info": [
       "Build_identity",
-      "Config_dir_resolver",
       "Coord",
       "Dashboard",
+      "Dashboard_cache",
       "Dashboard_http_helpers",
       "Keeper_runtime_resolved",
-      "Tool_local_runtime",
+      "Server_dashboard_http_perf",
+      "Server_routes_http_runtime",
+      "Server_timing",
       "Tool_misc",
       "Tool_unified",
       "Tool_usage_log"
@@ -4784,6 +6559,20 @@
       "Coord",
       "Dashboard"
     ],
+    "Server_dashboard_logs_json": [
+      "Coord"
+    ],
+    "Server_dashboard_meta_cognition_cache": [],
+    "Server_dashboard_shell_projection_trace": [],
+    "Server_dashboard_snapshot_select": [
+      "Coord",
+      "Dashboard_snapshot",
+      "Server_dashboard_http_core",
+      "Server_dashboard_http_runtime_info",
+      "Server_timing",
+      "Telemetry_unified"
+    ],
+    "Server_dashboard_surface": [],
     "Server_h2_gateway": [
       "Anti_rationalization",
       "Coord",
@@ -4801,8 +6590,11 @@
       "Rate_limit",
       "Server_auth",
       "Server_dashboard_http",
+      "Server_dashboard_snapshot_select",
+      "Server_h2_gateway_helpers",
       "Server_h2_gateway_routes_extra",
       "Server_health_paths",
+      "Server_mcp_request_context",
       "Server_mcp_transport_http",
       "Server_routes_http",
       "Server_routes_http_routes_provider_runs",
@@ -4846,23 +6638,37 @@
       "Server_auth",
       "Server_utils"
     ],
+    "Server_mcp_actor_injection": [],
+    "Server_mcp_request_context": [
+      "Server_mcp_transport_http_headers",
+      "Server_mcp_transport_http_protocol"
+    ],
+    "Server_mcp_streaming_tools": [],
     "Server_mcp_transport_http": [
+      "Mcp_error_code",
       "Server_auth",
+      "Server_mcp_actor_injection",
+      "Server_mcp_request_context",
+      "Server_mcp_streaming_tools",
       "Server_mcp_transport_http_headers",
       "Server_mcp_transport_http_types",
+      "Session_lifecycle_event",
       "Sse",
       "Transport_metrics"
     ],
     "Server_mcp_transport_http_agui": [
+      "Mcp_error_code",
       "Server_mcp_transport_http_conn",
       "Server_mcp_transport_http_headers",
       "Server_mcp_transport_http_protocol",
       "Server_mcp_transport_http_respond",
+      "Session_lifecycle_event",
       "Sse",
       "Transport",
       "Transport_metrics"
     ],
     "Server_mcp_transport_http_conn": [
+      "Session_lifecycle_event",
       "Sse",
       "Sse_reject_reason"
     ],
@@ -4876,6 +6682,7 @@
       "Server_mcp_transport_http_types"
     ],
     "Server_mcp_transport_http_respond": [
+      "Mcp_error_code",
       "Server_mcp_transport_http_headers",
       "Server_mcp_transport_http_types",
       "Sse_reject_reason",
@@ -4899,12 +6706,12 @@
     "Server_openai_compat": [
       "Agent_sdk_response",
       "Approval_callbacks",
-      "Cascade_legacy_runner",
       "Keeper_cascade_profile",
       "Keeper_turn",
       "Keeper_turn_driver",
       "Keeper_types",
       "Masc_oas_bridge",
+      "Openai_compat_error_map",
       "Transport"
     ],
     "Server_routes_http": [
@@ -4935,13 +6742,28 @@
       "Mcp_server_eio",
       "Server_auth"
     ],
+    "Server_routes_http_dashboard_dev_token": [
+      "Auth"
+    ],
+    "Server_routes_http_dashboard_handlers": [
+      "Coord",
+      "Dashboard_rooms",
+      "Mcp_server",
+      "Server_dashboard_http_link_preview",
+      "Server_utils",
+      "Tool_task"
+    ],
+    "Server_routes_http_dashboard_provider_logs": [
+      "Cascade_runtime",
+      "Server_utils"
+    ],
     "Server_routes_http_keeper_stream": [
       "Audit_log",
       "Gate_keeper_backend",
       "Keeper_chat_store",
       "Keeper_execution",
-      "Keeper_skill_routing",
       "Keeper_timing",
+      "Keeper_types",
       "Mcp_server",
       "Server_auth",
       "Telemetry_eio",
@@ -4961,6 +6783,7 @@
       "Agent_reputation",
       "Audit_log",
       "Board",
+      "Board_curation",
       "Board_dispatch",
       "Governance_registry",
       "Mcp_server",
@@ -4972,8 +6795,7 @@
       "Server_routes_http_runtime",
       "Server_utils",
       "Sse",
-      "Tool_board",
-      "Tool_result"
+      "Tool_board"
     ],
     "Server_routes_http_routes_artifacts": [
       "Server_auth",
@@ -5009,15 +6831,9 @@
     ],
     "Server_routes_http_routes_dashboard": [
       "Anti_rationalization",
-      "Auth",
-      "Cascade_catalog_runtime",
-      "Cascade_catalog_validator",
-      "Cascade_runtime",
-      "Config_dir_resolver",
       "Coord",
       "Dashboard_branches",
       "Dashboard_cache",
-      "Dashboard_eval_feed",
       "Dashboard_feature_health",
       "Dashboard_goal_loop",
       "Dashboard_harness_health",
@@ -5027,29 +6843,34 @@
       "Dashboard_nav_event",
       "Dashboard_oas_bridge",
       "Dashboard_operator_nudges",
-      "Dashboard_rooms",
       "Dashboard_safe_autonomy",
       "Dashboard_surface_readiness",
       "Dashboard_tool_host_events",
       "Dashboard_worktree_status",
       "Env_config_introspect",
-      "Keeper_cascade_profile",
-      "Keeper_registry",
       "Keeper_toml_loader",
-      "Keeper_types",
       "Mcp_server",
       "Server_auth",
       "Server_dashboard_http",
       "Server_dashboard_http_agent_api",
       "Server_dashboard_http_delete_actions",
-      "Server_dashboard_http_link_preview",
+      "Server_dashboard_logs_json",
+      "Server_dashboard_snapshot_select",
       "Server_routes_http_common",
+      "Server_routes_http_dashboard_dev_token",
+      "Server_routes_http_dashboard_handlers",
       "Server_routes_http_keeper_stream",
+      "Server_routes_http_routes_dashboard_cascade_meta",
+      "Server_timing",
       "Server_utils",
       "Telemetry_observe",
       "Telemetry_unified",
-      "Tool_name",
-      "Tool_task"
+      "Tool_name"
+    ],
+    "Server_routes_http_routes_dashboard_cascade_meta": [
+      "Coord",
+      "Keeper_registry",
+      "Keeper_types"
     ],
     "Server_routes_http_routes_frontend": [
       "Credits_dashboard",
@@ -5078,7 +6899,6 @@
       "Server_utils"
     ],
     "Server_routes_http_routes_legendary_bash": [
-      "Keeper_alerting_path",
       "Legendary_counters",
       "Server_auth",
       "Server_utils"
@@ -5121,7 +6941,7 @@
     ],
     "Server_routes_http_routes_sidecar": [
       "Keeper_toml_loader",
-      "Mcp_server",
+      "Prometheus",
       "Server_auth",
       "Server_utils"
     ],
@@ -5146,10 +6966,23 @@
       "Board",
       "Board_dispatch",
       "Build_identity",
+      "Cdal_runtime_health",
       "Coord",
+      "Dashboard",
       "Dashboard_feature_health",
+      "Fd_accountant",
+      "Keeper_fd_pressure",
+      "Keeper_meta_store",
+      "Keeper_reaction_ledger",
       "Keeper_registry",
+      "Keeper_runtime",
+      "Keeper_state_machine",
+      "Keeper_status_bridge",
+      "Keeper_supervisor_types",
+      "Keeper_types",
       "Keeper_types_profile",
+      "Mcp_server",
+      "Proactive_refresh",
       "Prometheus",
       "Server_auth",
       "Server_base_path_diagnostics",
@@ -5158,10 +6991,14 @@
       "Server_utils",
       "Sse",
       "Subsystem_health",
-      "Tool_args",
       "Transport_bridge",
       "Transport_metrics",
       "Transport_read_model"
+    ],
+    "Server_routes_http_sidecar_paths": [
+      "Keeper_toml_loader",
+      "Mcp_server",
+      "Server_utils"
     ],
     "Server_runtime_bootstrap": [
       "Agent_sdk_log_bridge",
@@ -5172,8 +7009,6 @@
       "Board_dispatch",
       "Build_identity",
       "Cascade_catalog_runtime",
-      "Cascade_runtime",
-      "Config_dir_resolver",
       "Coord",
       "Dashboard",
       "Discovery_cache",
@@ -5181,13 +7016,11 @@
       "Gc_sampler",
       "Governance_registry",
       "Heuristic_metrics",
-      "Keeper_cascade_profile",
       "Keeper_context_core",
       "Keeper_crash_persistence",
       "Keeper_egress_audit",
       "Keeper_exec_tools",
       "Keeper_keepalive",
-      "Keeper_mcp_provider_audit",
       "Keeper_runtime",
       "Keeper_runtime_config",
       "Keeper_runtime_resolved",
@@ -5200,8 +7033,10 @@
       "Masc_grpc_service",
       "Masc_grpc_transport",
       "Mcp_server_eio_execute",
+      "Pool_metrics",
       "Prometheus",
       "Prompt_defaults",
+      "Provider_health",
       "Rate_limit",
       "Runtime_params",
       "Server_auth",
@@ -5211,6 +7046,8 @@
       "Server_dashboard_http",
       "Server_mcp_transport_ws",
       "Server_routes_http",
+      "Server_routes_http_runtime",
+      "Server_runtime_bootstrap_legacy_migration",
       "Server_startup_state",
       "Server_webrtc_transport",
       "Server_ws_standalone",
@@ -5220,20 +7057,29 @@
       "Tool_metrics_persist",
       "Tool_registration_check",
       "Tool_registry",
-      "Tool_result",
       "Transport",
       "Transport_bridge"
     ],
+    "Server_runtime_bootstrap_legacy_migration": [
+      "Coord",
+      "Keeper_types",
+      "Mcp_server"
+    ],
+    "Server_runtime_codex_mcp_sync": [
+      "Auth"
+    ],
+    "Server_runtime_config_root_bootstrap": [],
     "Server_startup_takeover": [
       "Server_health_paths"
     ],
+    "Server_timing": [],
     "Server_utils": [
       "Agent_reputation",
       "Board",
       "Board_dispatch",
       "Board_moderation",
       "Keeper_identity",
-      "Keeper_registry"
+      "Keeper_registry_lookup"
     ],
     "Server_voice_config": [
       "Voice_bridge"
@@ -5248,6 +7094,7 @@
       "Transport",
       "Transport_metrics"
     ],
+    "Session_lifecycle_event": [],
     "Silent_dashboard_actor_outcome": [],
     "Sse_reject_reason": [],
     "Server_base_path_diagnostics": [],
@@ -5257,6 +7104,7 @@
     ],
     "Server_state_product": [],
     "Session": [],
+    "Shell_safety_types": [],
     "Shutdown": [],
     "Shutdown_hooks": [
       "Agent_registry_eio",
@@ -5268,12 +7116,15 @@
     ],
     "Spawn": [
       "Agent_tool_surfaces",
-      "Provider_adapter"
+      "Fd_accountant",
+      "Provider_runtime_projection"
     ],
     "Sse": [
       "Lockfree_atomic",
+      "Sse_jsonrpc_filter",
       "Transport_metrics"
     ],
+    "Sse_jsonrpc_filter": [],
     "State_product": [],
     "Streamable_http": [],
     "Subscriptions": [],
@@ -5282,7 +7133,9 @@
     "Task_dispatch": [
       "Coord"
     ],
-    "Task_sandbox": [],
+    "Task_sandbox": [
+      "Coord"
+    ],
     "Team_context": [
       "Prometheus"
     ],
@@ -5296,6 +7149,7 @@
       "Prometheus"
     ],
     "Telemetry_unified": [
+      "Json_field",
       "Prometheus",
       "Telemetry_coverage_gap"
     ],
@@ -5304,7 +7158,6 @@
     ],
     "Thompson_sampling": [
       "Agent_health",
-      "Post_verifier",
       "Prometheus"
     ],
     "Timeout_bucket": [],
@@ -5322,21 +7175,14 @@
       "Coord",
       "Metrics_store_eio",
       "Thompson_sampling",
-      "Tool_args",
       "Tool_dispatch",
-      "Tool_result",
       "Tool_spec"
     ],
     "Tool_agent_timeline": [
       "Coord",
       "Keeper_unified_metrics",
-      "Tool_args",
       "Tool_dispatch",
-      "Tool_result",
       "Tool_spec"
-    ],
-    "Tool_args": [
-      "Tool_result"
     ],
     "Tool_assignment_telemetry": [
       "Prometheus"
@@ -5354,7 +7200,6 @@
       "Autoresearch_lineage",
       "Coord",
       "Memory_oas_bridge",
-      "Tool_args",
       "Tool_autoresearch_broadcast",
       "Tool_autoresearch_context",
       "Tool_autoresearch_registry"
@@ -5362,91 +7207,110 @@
     "Tool_autoresearch_registry": [
       "Autoresearch"
     ],
-    "Tool_board": [
-      "Board",
+    "Tool_board": [],
+    "Tool_board_cache": [],
+    "Tool_board_curation": [
       "Board_curation",
       "Board_dispatch",
-      "Prometheus",
-      "Tool_args",
-      "Tool_board_schemas",
+      "Tool_board_format"
+    ],
+    "Tool_board_dispatch": [
+      "Tool_board_cache",
+      "Tool_board_curation",
+      "Tool_board_format",
+      "Tool_board_handlers",
+      "Tool_board_post",
+      "Tool_board_registry",
+      "Tool_board_sub_board",
       "Tool_dispatch",
-      "Tool_result",
       "Tool_spec"
+    ],
+    "Tool_board_format": [
+      "Board",
+      "Board_dispatch"
+    ],
+    "Tool_board_handlers": [
+      "Board",
+      "Board_dispatch",
+      "Tool_board_format"
+    ],
+    "Tool_board_post": [
+      "Board",
+      "Board_dispatch",
+      "Prometheus",
+      "Tool_board_cache",
+      "Tool_board_format",
+      "Tool_board_handlers"
+    ],
+    "Tool_board_registry": [
+      "Tool_board_schemas"
     ],
     "Tool_board_schemas": [
       "Board",
       "Board_core_classify",
       "Board_dispatch"
     ],
+    "Tool_board_sub_board": [
+      "Board",
+      "Board_dispatch"
+    ],
     "Tool_bridge": [
+      "Prometheus_hotpath",
       "Tool_catalog",
-      "Tool_dispatch",
-      "Tool_result"
+      "Tool_dispatch"
     ],
     "Tool_broadcast_typed": [
       "Tool_dispatch",
       "Tool_input_validation",
       "Typed_tool_masc"
     ],
-    "Tool_call_quality_benchmark": [
-      "Tool_call_quality_benchmark_loader",
-      "Tool_call_quality_benchmark_render",
-      "Tool_call_quality_benchmark_scoring",
-      "Tool_call_quality_benchmark_summary"
-    ],
-    "Tool_call_quality_benchmark_loader": [
-      "Tool_call_quality_benchmark_types"
-    ],
-    "Tool_call_quality_benchmark_render": [
-      "Tool_call_quality_benchmark_types"
-    ],
-    "Tool_call_quality_benchmark_scoring": [
-      "Reward_advice_artifact",
-      "Tool_call_quality_benchmark_types"
-    ],
-    "Tool_call_quality_benchmark_summary": [
-      "Tool_call_quality_benchmark_scoring",
-      "Tool_call_quality_benchmark_types"
-    ],
-    "Tool_call_quality_benchmark_types": [],
-    "Tool_call_replay_harness": [
-      "Provider_adapter"
+    "Tool_call_replay_harness": [],
+    "Tool_capability": [
+      "Tool_dispatch"
     ],
     "Tool_catalog": [
-      "Tool_catalog_surfaces",
-      "Tool_name",
+      "Tool_catalog_inference",
       "Tools"
     ],
-    "Tool_catalog_surfaces": [],
+    "Tool_catalog_inference": [
+      "Tool_name"
+    ],
     "Tool_code": [
       "Coord",
       "Keeper_alerting_path",
-      "Tool_args",
+      "Keeper_sandbox",
       "Tool_catalog",
+      "Tool_code_read_core",
       "Tool_dispatch",
-      "Tool_result",
+      "Tool_error",
       "Tool_spec"
     ],
+    "Tool_code_read_core": [],
     "Tool_code_write": [
       "Coord",
-      "Keeper_alerting_path",
+      "Dev_exec_allowlist",
       "Keeper_identity",
-      "Keeper_metrics",
+      "Keeper_sandbox",
       "Keeper_tool_policy_config",
-      "Prometheus",
-      "Tool_args",
       "Tool_code",
+      "Tool_code_write_git_policy",
       "Tool_dispatch",
-      "Tool_policy_failure_site",
-      "Tool_result",
+      "Tool_error",
       "Tool_spec",
       "Worker_dev_tools"
     ],
+    "Tool_code_write_git_policy": [
+      "Keeper_metrics",
+      "Keeper_tool_policy_config",
+      "Keeper_tool_policy_failure_site",
+      "Prometheus"
+    ],
     "Tool_control": [
       "Coord",
-      "Tool_args",
+      "Keeper_registry",
+      "Keeper_state_machine",
+      "Keeper_types",
       "Tool_dispatch",
-      "Tool_result",
       "Tool_spec"
     ],
     "Tool_coord": [
@@ -5460,10 +7324,8 @@
       "Keeper_identity",
       "Keeper_runtime",
       "Planning_eio",
-      "Tool_args",
       "Tool_catalog",
       "Tool_dispatch",
-      "Tool_result",
       "Tool_spec",
       "Workflow_guide"
     ],
@@ -5473,35 +7335,38 @@
       "Coord",
       "Keeper_cascade_profile",
       "Keeper_turn_driver",
-      "Masc_oas_bridge",
-      "Tool_result"
+      "Masc_oas_bridge"
     ],
     "Tool_dispatch": [
+      "Dispatch_outcome",
       "Tool_name",
-      "Tool_result",
-      "Tool_token",
-      "Tools"
+      "Tool_telemetry",
+      "Tool_token"
     ],
+    "Tool_dispatch_emit": [
+      "Dispatch_outcome",
+      "Tool_dispatch"
+    ],
+    "Tool_error": [],
     "Tool_help_registry": [
       "Tool_catalog",
       "Workflow_guide"
     ],
     "Tool_inline_dispatch": [
       "Cascade_config",
+      "Cascade_runtime",
       "Config",
       "Coord",
       "Keeper_approval_queue",
       "Mcp_server",
       "Mcp_server_eio_governance",
-      "Provider_adapter",
       "Session",
       "Spawn",
-      "Tool_args",
+      "Tool_catalog",
       "Tool_inline_dispatch_comm",
       "Tool_inline_dispatch_coord",
       "Tool_inline_dispatch_extra",
-      "Tool_inline_dispatch_types",
-      "Tool_result"
+      "Tool_inline_dispatch_types"
     ],
     "Tool_inline_dispatch_comm": [
       "Audit_log",
@@ -5512,8 +7377,7 @@
       "Otel_trace_context",
       "Session",
       "Subscriptions",
-      "Tool_inline_dispatch_types",
-      "Tool_result"
+      "Tool_inline_dispatch_types"
     ],
     "Tool_inline_dispatch_coord": [
       "Coord",
@@ -5523,8 +7387,8 @@
       "Planning_eio",
       "Prometheus",
       "Session",
-      "Tool_inline_dispatch_types",
-      "Tool_result"
+      "Tool_error",
+      "Tool_inline_dispatch_types"
     ],
     "Tool_inline_dispatch_extra": [
       "Auto_responder",
@@ -5534,37 +7398,34 @@
       "Notify",
       "Prometheus",
       "Server_utils",
-      "Tool_board",
-      "Tool_result"
+      "Tool_board"
     ],
     "Tool_inline_dispatch_types": [
       "Coord",
       "Mcp_server",
       "Mcp_server_eio_governance",
-      "Session",
-      "Tool_result"
+      "Session"
     ],
     "Tool_input_validation": [
-      "Tool_dispatch",
-      "Tool_result"
+      "Otel_spans",
+      "Prometheus",
+      "Tool_bridge",
+      "Tool_dispatch"
     ],
     "Tool_keeper": [
-      "Cascade_runtime",
-      "Config_dir_resolver",
       "Coord",
       "Keeper_alerting_path",
-      "Keeper_cascade_profile",
       "Keeper_checkpoint_store",
       "Keeper_config",
       "Keeper_exec_context",
       "Keeper_exec_persona",
       "Keeper_exec_status",
-      "Keeper_goal_repair",
       "Keeper_id",
       "Keeper_identity",
       "Keeper_memory",
       "Keeper_metrics",
       "Keeper_msg_async",
+      "Keeper_operator_compact_result",
       "Keeper_registry",
       "Keeper_runtime",
       "Keeper_sandbox_control",
@@ -5574,16 +7435,25 @@
       "Keeper_status_detail",
       "Keeper_types",
       "Lockfree_atomic",
-      "Operator_compact_result",
       "Prometheus",
       "Server_startup_state",
-      "Tool_args",
       "Tool_dispatch",
       "Tool_spec"
     ],
+    "Tool_keeper_persona_audit": [
+      "Coord",
+      "Keeper_exec_status",
+      "Keeper_goal_repair",
+      "Keeper_registry",
+      "Keeper_runtime",
+      "Keeper_runtime_contract",
+      "Keeper_state_machine",
+      "Keeper_status_bridge",
+      "Keeper_types"
+    ],
     "Tool_library": [
       "Tool_dispatch",
-      "Tool_result",
+      "Tool_error",
       "Tool_spec"
     ],
     "Tool_local_runtime": [
@@ -5599,14 +7469,14 @@
       "Cascade_runtime",
       "Inference_utils",
       "Local_runtime_pool",
-      "Masc_eio_env",
-      "Provider_adapter"
+      "Masc_eio_env"
     ],
     "Tool_local_runtime_core": [
-      "Coord",
-      "Tool_args"
+      "Coord"
     ],
-    "Tool_local_runtime_http": [],
+    "Tool_local_runtime_http": [
+      "Fd_accountant"
+    ],
     "Tool_local_runtime_probe": [
       "Prometheus"
     ],
@@ -5615,28 +7485,25 @@
       "Local_runtime_pool"
     ],
     "Tool_local_runtime_verify": [
-      "Cascade_legacy_runner",
       "Discovery_cache",
       "Inference_utils",
       "Local_runtime_pool",
       "Masc_eio_env"
     ],
     "Tool_metrics": [
-      "Tool_dispatch",
-      "Tool_result"
+      "Dispatch_outcome",
+      "Tool_dispatch"
     ],
     "Tool_metrics_persist": [
       "Error_event_type",
       "Prometheus",
       "Shutdown",
-      "Tool_metrics",
-      "Tool_result"
+      "Tool_metrics"
     ],
     "Tool_misc": [
       "Config",
       "Coord",
       "Dashboard",
-      "Tool_args",
       "Tool_deep_review",
       "Tool_dispatch",
       "Tool_help_registry",
@@ -5645,7 +7512,6 @@
       "Tool_misc_web_fetch",
       "Tool_misc_web_search",
       "Tool_registry",
-      "Tool_result",
       "Tool_spec"
     ],
     "Tool_misc_admin": [
@@ -5656,28 +7522,21 @@
       "Enforcement_status",
       "Env_config_introspect",
       "Server_auth",
-      "Tool_args",
       "Tool_catalog",
-      "Tool_help_registry",
-      "Tool_result"
+      "Tool_dispatch",
+      "Tool_help_registry"
     ],
     "Tool_misc_transport": [
       "Server_webrtc_transport",
-      "Tool_args",
-      "Tool_result",
       "Transport_read_model"
     ],
     "Tool_misc_web_fetch": [
-      "Tool_args",
       "Tool_local_runtime_http",
       "Tool_misc_web_search",
-      "Tool_result",
       "Tools"
     ],
     "Tool_misc_web_search": [
-      "Tool_args",
       "Tool_local_runtime_http",
-      "Tool_result",
       "Tools"
     ],
     "Tool_name": [],
@@ -5686,15 +7545,12 @@
       "Dashboard_surface_readiness",
       "Operator_control",
       "Operator_control_snapshot",
-      "Tool_args",
       "Tool_catalog",
       "Tool_dispatch",
-      "Tool_result",
       "Tool_spec"
     ],
     "Tool_output_validation": [
-      "Tool_dispatch",
-      "Tool_result"
+      "Tool_dispatch"
     ],
     "Tool_permission_map": [
       "Tool_catalog"
@@ -5703,9 +7559,7 @@
       "Coord",
       "Plan_action_outcome",
       "Planning_eio",
-      "Tool_args",
       "Tool_dispatch",
-      "Tool_result",
       "Tool_spec"
     ],
     "Tool_prefilter": [],
@@ -5717,35 +7571,58 @@
       "Tool_shard"
     ],
     "Tool_registry": [
-      "Telemetry_eio",
-      "Tool_catalog_surfaces"
+      "Telemetry_eio"
     ],
-    "Tool_result": [],
+    "Tool_resource_gate": [
+      "Tool_name"
+    ],
     "Tool_run": [
       "Coord",
       "Run_eio",
-      "Tool_args",
       "Tool_dispatch",
-      "Tool_result",
       "Tool_spec"
     ],
     "Tool_schema_dsl": [],
     "Tool_scope": [],
     "Tool_shard": [
-      "Tool_args",
-      "Tool_catalog",
       "Tool_code",
       "Tool_dispatch",
-      "Tool_name",
-      "Tool_shard_limits",
       "Tool_shard_schemas",
       "Tool_spec"
     ],
     "Tool_shard_limits": [],
     "Tool_shard_schemas": [],
+    "Tool_shard_types": [],
+    "Tool_shard_types_core": [
+      "Tool_catalog",
+      "Tool_name"
+    ],
+    "Tool_shard_types_enum_mirrors": [],
+    "Tool_shard_types_schemas_base": [
+      "Tool_shard_types_enum_mirrors"
+    ],
+    "Tool_shard_types_schemas_bash": [],
+    "Tool_shard_types_schemas_board": [
+      "Tool_shard_types_enum_mirrors"
+    ],
+    "Tool_shard_types_schemas_coding_workspace": [],
+    "Tool_shard_types_schemas_filesystem": [
+      "Tool_shard_limits",
+      "Tool_shard_types_enum_mirrors"
+    ],
+    "Tool_shard_types_schemas_github_pr": [],
+    "Tool_shard_types_schemas_library": [],
+    "Tool_shard_types_schemas_pr_review": [
+      "Tool_shard_types_enum_mirrors"
+    ],
+    "Tool_shard_types_schemas_preflight": [],
+    "Tool_shard_types_schemas_shell": [
+      "Tool_shard_types_enum_mirrors"
+    ],
+    "Tool_shard_types_schemas_taskboard": [],
+    "Tool_shard_types_schemas_voice": [],
     "Tool_spec": [
       "Tool_catalog",
-      "Tool_catalog_surfaces",
       "Tool_dispatch"
     ],
     "Tool_suspend": [
@@ -5760,27 +7637,42 @@
       "Cdal_verdict_gate",
       "Coord",
       "Eval_calibration",
+      "Goal_phase",
       "Goal_store",
+      "Keeper_config",
       "Keeper_current_task_reconcile",
       "Keeper_identity",
       "Keeper_registry",
       "Keeper_tool_policy",
+      "Keeper_types",
       "Mcp_server",
       "Metrics_store_eio",
       "Planning_eio",
-      "Post_verifier",
       "Prometheus",
       "Sse",
       "Subscriptions",
       "Thompson_sampling",
-      "Tool_args",
       "Tool_dispatch",
-      "Tool_result",
       "Tool_spec",
+      "Tool_task_contract_gate",
       "Verification",
       "Verification_protocol"
     ],
+    "Tool_task_args": [
+      "Tool_task_completion_review"
+    ],
+    "Tool_task_completion_review": [],
+    "Tool_task_contract_gate": [
+      "Cdal_verdict_gate"
+    ],
+    "Tool_task_payloads": [
+      "Anti_rationalization"
+    ],
     "Tool_task_schemas": [],
+    "Tool_telemetry": [
+      "Otel_spans",
+      "Prometheus"
+    ],
     "Tool_token": [],
     "Tool_unified": [
       "Cascade_legacy_runner",
@@ -5791,16 +7683,15 @@
       "Tool_registry"
     ],
     "Tool_usage_log": [
+      "Dispatch_outcome",
+      "Keeper_disk_pressure",
+      "Keeper_fd_pressure",
       "Telemetry_coverage_gap",
-      "Tool_catalog_surfaces",
-      "Tool_dispatch",
-      "Tool_result"
+      "Tool_dispatch"
     ],
     "Tool_worktree": [
       "Coord",
-      "Tool_args",
       "Tool_dispatch",
-      "Tool_result",
       "Tool_spec"
     ],
     "Tools": [
@@ -5814,7 +7705,6 @@
       "Tool_suspend",
       "Tool_task"
     ],
-    "Trajectory": [],
     "Transport": [
       "Config",
       "Masc_grpc_server",
@@ -5849,16 +7739,17 @@
     "Typed_tool_masc": [
       "Tool_catalog",
       "Tool_dispatch",
-      "Tool_result",
       "Tool_spec"
     ],
     "Verification": [
       "Attribution",
+      "Keeper_fd_pressure",
       "Prometheus"
     ],
     "Verification_protocol": [
       "Board",
       "Board_dispatch",
+      "Cdal_verdict_gate",
       "Coord",
       "Dashboard_attribution",
       "Planning_eio",
@@ -5869,26 +7760,29 @@
     "Verifier_oas": [
       "Agent_sdk_response",
       "Approval_callbacks",
-      "Cascade_legacy_runner",
       "Eval_gate",
       "Keeper_cascade_profile",
       "Keeper_turn_driver_wrappers",
-      "Tool_result",
       "Verifier_core"
     ],
     "Version": [],
     "Voice_bridge": [
-      "Provider_adapter",
-      "Tool_args",
       "Transport",
-      "Voice_config"
+      "Voice_bridge_transport",
+      "Voice_config",
+      "Voice_runtime_overlay"
     ],
     "Voice_bridge_core": [
-      "Provider_adapter",
-      "Voice_config"
+      "Voice_config",
+      "Voice_runtime_overlay"
     ],
-    "Voice_config": [
-      "Tool_args"
+    "Voice_bridge_transport": [
+      "Voice_bridge_core",
+      "Voice_runtime_overlay"
+    ],
+    "Voice_config": [],
+    "Voice_runtime_overlay": [
+      "Voice_config"
     ],
     "Voice_session_manager": [
       "Voice_bridge"
@@ -5897,21 +7791,32 @@
     "Worker_dev_tools": [
       "Attribution",
       "Dashboard_attribution",
-      "Eval_gate",
+      "Dev_exec_allowlist",
+      "Fd_accountant",
+      "Keeper_path_check_error",
+      "Legendary_counters",
+      "Tool_resource_gate",
       "Worker_tool_input"
     ],
+    "Worker_dev_tools_command_syntax": [],
+    "Worker_dev_tools_log_sanitize": [],
+    "Worker_dev_tools_mutation_classifier": [
+      "Eval_gate"
+    ],
+    "Worker_dev_tools_paths": [],
     "Worker_execution_backend": [],
     "Worker_execution_spec": [
       "Worker_execution_backend"
     ],
     "Worker_oas": [
       "Approval_callbacks",
-      "Cascade_legacy_runner",
       "Cascade_runner",
+      "Cascade_runtime",
+      "Cascade_worker_defaults",
       "Eval_gate",
+      "Keeper_disclosure_strategy",
       "Masc_context_injector",
       "Orchestrator",
-      "Provider_adapter",
       "Tool_access_policy",
       "Tool_dispatch",
       "Verifier_oas",
@@ -5920,13 +7825,11 @@
       "Worker_execution_backend"
     ],
     "Worker_runtime_config": [
-      "Config_dir_resolver",
       "Worker_execution_backend"
     ],
     "Worker_runtime_docker": [
       "Cascade_config",
-      "Config_dir_resolver",
-      "Provider_adapter",
+      "Docker_spawn_throttle",
       "Worker_container",
       "Worker_container_types",
       "Worker_execution_spec",
@@ -5937,9 +7840,10 @@
       "Worker_container_types"
     ],
     "Worker_tool_input": [],
-    "Workflow_guide": [
-      "Tool_catalog"
-    ],
-    "Worktree_live_context": []
+    "Workflow_guide": [],
+    "Worktree_live_context": [
+      "Coord",
+      "Fd_accountant"
+    ]
   }
 }

--- a/reports/lib-dependency-summary.md
+++ b/reports/lib-dependency-summary.md
@@ -7,62 +7,62 @@
 
 | Metric | Current | Delta |
 | --- | --- | --- |
-| total_modules | 766 | - |
-| total_edges | 3566 | - |
-| avg_out_degree | 4.66 | - |
-| scc_count | 1 | - |
-| largest_scc_size | 186 | - |
+| total_modules | 1052 | - |
+| total_edges | 4409 | - |
+| avg_out_degree | 4.19 | - |
+| scc_count | 2 | - |
+| largest_scc_size | 221 | - |
 
 ## Room/Coordination Dependents
 
 | Module | Dependents | Delta |
 | --- | --- | --- |
-| Coord | 149 | - |
+| Coord | 193 | - |
 
 ## Top Hub Modules
 
 | Rank | Module | Dependents |
 | --- | --- | --- |
-| 1 | Prometheus | 165 |
-| 2 | Coord | 149 |
-| 3 | Keeper_types | 142 |
-| 4 | Keeper_metrics | 91 |
-| 5 | Tool_result | 56 |
-| 6 | Keeper_registry | 51 |
-| 7 | Keeper_id | 50 |
-| 8 | Keeper_cascade_profile | 49 |
-| 9 | Tool_dispatch | 47 |
-| 10 | Tool_args | 42 |
+| 1 | Prometheus | 227 |
+| 2 | Keeper_types | 217 |
+| 3 | Coord | 193 |
+| 4 | Keeper_metrics | 148 |
+| 5 | Keeper_registry | 80 |
+| 6 | Keeper_id | 63 |
+| 7 | Keeper_state_machine | 57 |
+| 8 | Keeper_cascade_profile | 50 |
+| 9 | Tool_dispatch | 48 |
+| 10 | Mcp_server | 48 |
 
 ## Heaviest Importers
 
 | Rank | Module | Dependencies |
 | --- | --- | --- |
-| 1 | Server_bootstrap_loops | 72 |
-| 2 | Server_runtime_bootstrap | 59 |
-| 3 | Keeper_unified_turn | 56 |
-| 4 | Dashboard_http_keeper | 49 |
-| 5 | Keeper_run_tools | 47 |
-| 6 | Mcp_server_eio_execute | 45 |
-| 7 | Server_dashboard_http_keeper_api | 43 |
-| 8 | Keeper_agent_run | 42 |
-| 9 | Server_routes_http_routes_dashboard | 42 |
-| 10 | Keeper_heartbeat_loop | 36 |
+| 1 | Server_bootstrap_loops | 76 |
+| 2 | Server_runtime_bootstrap | 58 |
+| 3 | Keeper_agent_run | 51 |
+| 4 | Keeper_run_tools | 48 |
+| 5 | Keeper_unified_turn | 44 |
+| 6 | Mcp_server_eio_execute | 44 |
+| 7 | Keeper_supervisor | 39 |
+| 8 | Server_dashboard_http_keeper_api | 39 |
+| 9 | Dashboard_http_keeper | 38 |
+| 10 | Keeper_turn | 36 |
 
 ## Batch 2 Extraction Candidates
 
 | Prefix | Modules | Coupling | External Deps | Internal Edges |
 | --- | --- | --- | --- | --- |
-| tool_call | 7 | 0.818 | 2 | 9 |
-| server_mcp | 10 | 0.682 | 7 | 15 |
+| model_inference | 6 | 0.889 | 1 | 8 |
+| prometheus_builtin | 7 | 0.833 | 2 | 10 |
+| server_mcp | 13 | 0.690 | 9 | 20 |
+| keeper_state | 4 | 0.667 | 1 | 2 |
+| tool_board | 10 | 0.650 | 7 | 13 |
+| tool_shard | 18 | 0.583 | 5 | 7 |
 | meta_cognition | 7 | 0.583 | 5 | 7 |
-| keeper_admission | 5 | 0.500 | 6 | 6 |
-| masc_grpc | 5 | 0.429 | 4 | 3 |
-| keeper_social | 7 | 0.385 | 8 | 5 |
-| tool_autoresearch | 6 | 0.333 | 12 | 6 |
-| dashboard_keeper | 5 | 0.333 | 4 | 2 |
-| keeper_sandbox | 7 | 0.312 | 11 | 5 |
-| docker_client | 3 | 0.286 | 5 | 2 |
+| cascade_transport | 11 | 0.556 | 8 | 10 |
+| cascade_config | 9 | 0.500 | 11 | 11 |
+| cascade_catalog | 8 | 0.500 | 11 | 11 |
 
 ## Regeneration
 


### PR DESCRIPTION
## Summary
- regenerate reports/lib-dependency-graph.json from the current tree
- refresh reports/lib-dependency-summary.md from the regenerated graph
- remove stale graph nodes for deleted or moved flat modules such as Provider_adapter, Keeper_provider_health, Tool_result, Cascade_ref, Compaction_trigger, and retired Tool_autoresearch schemas

## Verification
- python3 scripts/analyze_lib_deps.py --json-out reports/lib-dependency-graph.json
- python3 scripts/lib_dep_report.py --graph reports/lib-dependency-graph.json --output reports/lib-dependency-summary.md
- jq empty reports/lib-dependency-graph.json
- rg -n '"Provider_adapter"|"Keeper_provider_health"|"Tool_result"|"Cascade_ref"|"Compaction_trigger"|"Keeper_skill_routing"|"Tool_autoresearch"|"Tool_autoresearch_schemas"' reports/lib-dependency-graph.json reports/lib-dependency-summary.md
- git diff --check origin/main..HEAD