### PR TITLE
[codex] Remove docker keepalive shell wrappers

### DIFF
--- a/docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md
+++ b/docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md
@@ -144,7 +144,7 @@ Phase 4.1 prep audit (2026-05-12, iter 34 of cron `7493fe21`) enumerated **all 1
 
 | Caller | Site | Pattern | Lifetime | v1 Plan fit |
 |--------|------|---------|----------|-------------|
-| `keeper_turn_sandbox_runtime` | line 184 | `docker run -d --rm --name <n> ... sh -lc "trap : TERM INT; while :; do sleep 3600; done"` + `docker exec <n> <cmd>` × N + `docker rm -f <n>` | **session** (turn-scoped) | ❌ not representable |
+| `keeper_turn_sandbox_runtime` | line 184 | `docker run -d --rm --name <n> ... <image> tail -f /dev/null` + `docker exec <n> <cmd>` × N + `docker rm -f <n>` | **session** (turn-scoped) | ❌ not representable |
 | `keeper_shell_docker` | line 820 | `docker run --rm --name <n> <image> sh -lc <cmd>` | **named one-shot** | ⚠ partial (Plan has `container_name`, but caller treats name as observable identity) |
 | `keeper_sandbox_runtime` | line 838 | `docker run --rm --network none --entrypoint sh <image> -lc <script>` | **anonymous one-shot** | ✅ closest to v1 Plan |
 
@@ -276,7 +276,7 @@ The fields below were measured byte-for-byte against `keeper_turn_sandbox_runtim
 
 | Concern | Lives in | Why |
 |---------|----------|-----|
-| `container_name` (hash of turn_id‖attempt‖suffix), `image`, `startup_command`, `cap_drop_all`, `no_new_privileges`, `seccomp_profile` (the *choice*), `read_only_rootfs`, `tmpfs`, `workdir`, `user`, `network_mode`, `pids_limit`, `memory_limit`, `env_overrides` (4 hardcoded `HOME`/`USER`/`LOGNAME`/`SHELL` + `?extra_env`), `ulimits` | **Plan** (`of_request`, pure) | deterministic given the request inputs. (`pids_limit`/`memory_limit`/`ulimits` are read from `Env_config_keeper.KeeperSandbox.*` — config reads are stable per run, not the wall-clock/PID/random/daemon-I/O non-determinism the split targets.) |
+| `container_name` (hash of turn_id‖attempt‖suffix), `image`, `startup_argv`, `cap_drop_all`, `no_new_privileges`, `seccomp_profile` (the *choice*), `read_only_rootfs`, `tmpfs`, `workdir`, `user`, `network_mode`, `pids_limit`, `memory_limit`, `env_overrides` (4 hardcoded `HOME`/`USER`/`LOGNAME`/`SHELL` + `?extra_env`), `ulimits` | **Plan** (`of_request`, pure) | deterministic given the request inputs. (`pids_limit`/`memory_limit`/`ulimits` are read from `Env_config_keeper.KeeperSandbox.*` — config reads are stable per run, not the wall-clock/PID/random/daemon-I/O non-determinism the split targets.) |
 | `mounts` — the workspace volume (`-v host_root:container_root:rw`) **and** the identity mounts (`-v <host_root>/.docker-identity/passwd:/etc/passwd:ro`, `…/group:/etc/group:ro`) | **Plan** | the mount *args* are deterministic (path concat). Note: the identity mounts only *work* if the files exist — see `identity_files` below. |
 | `identity_files : (string * string) list` — the `(path, content)` pairs the edge must write before the mounts are valid: `(<host_root>/.docker-identity/passwd, "root:x:0:0:…\nkeeper:x:<uid>:<gid>:…\n")` and `(…/group, "root:x:0:\nkeeper:x:<gid>:\n")` | **Plan** | the *content* is deterministic given `uid`/`gid`; only *writing* it is I/O. The Plan describes what must exist; the edge materialises it. |
 | `labels` — the 7 **deterministic** labels: component (static), `base_path_hash` (MD5 of normalised `base_path`), keeper (`sanitize_label_value meta_name`), kind (`sanitize_label_value container_kind`), network (`sanitize_label_value network_label`, where `network_label` is derived from `network_mode`), turn_id, ttl_sec | **Plan** | pure string ops. |
@@ -303,7 +303,7 @@ type t  (** abstract — like Oneshot_plan; accessors below, no exposed record *
      read_only_rootfs : t -> bool
      tmpfs            : t -> string option
      workdir          : t -> string option
-     startup_command  : t -> string                      (* default: trap-and-sleep idle loop *)
+     startup_argv     : t -> string list                  (* default: ["tail"; "-f"; "/dev/null"] *)
      labels           : t -> (string * string) list      (* 7 deterministic labels; edge adds PID + started_at *)
      cap_drop_all     : t -> bool
      no_new_privileges : t -> bool
@@ -327,7 +327,7 @@ val of_request
   -> (t, plan_error) result
 ```
 
-Covers `keeper_turn_sandbox_runtime:184` (persistent session). The startup_command default is the existing trap-and-sleep idiom. The `Plan` represents *one container's lifetime*, NOT a single command — commands are issued via `Session.exec` (§3.2.3) against an already-started container.
+Covers `keeper_turn_sandbox_runtime:184` (persistent session). The startup argv is a direct idle process, not a shell command. The `Plan` represents *one container's lifetime*, NOT a single command — commands are issued via `Session.exec` (§3.2.3) against an already-started container.
 
 #### 3.1.3 Named one-shot — represented via Oneshot_plan extension
 

--- a/lib/keeper/keeper_docker_client_real.ml
+++ b/lib/keeper/keeper_docker_client_real.ml
@@ -409,7 +409,7 @@ let run_detached_argv
   @ List.concat_map (fun v -> [ "-v"; v ]) (P.mounts plan)
   @ workdir_args (P.workdir plan)
   @ network_args
-  @ [ P.image plan; "sh"; "-lc"; P.startup_command plan ]
+  @ (P.image plan :: P.startup_argv plan)
 ;;
 
 let write_identity_files (plan : Keeper_sandbox_session_plan.t) =

--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -202,14 +202,7 @@ let start_managed_container
                       container_root;
                     ]
                     @ network_args
-                    @ [
-                      image;
-                      "sh";
-                      "-lc";
-                      Printf.sprintf
-                        "trap : TERM INT; while :; do sleep %d; done"
-                        (Env_config_sandbox.Cleanup.managed_sleep_sec ());
-                    ]
+                    @ [ image; "tail"; "-f"; "/dev/null" ]
                   in
                   (* Throttle the managed-container [docker run -d] just like
                      the per-call sandbox spawns (PR #15727). RFC-0097 calls

--- a/lib/keeper/keeper_sandbox_session_plan.ml
+++ b/lib/keeper/keeper_sandbox_session_plan.ml
@@ -32,9 +32,8 @@ let identity_group_file = "group"
 let identity_passwd_target = "/etc/passwd"
 let identity_group_target = "/etc/group"
 
-(* MUST match the literal in keeper_turn_sandbox_runtime.start_container's
-   trailing [ image; "sh"; "-lc"; <this> ] argv. *)
-let idle_startup_command = "trap : TERM INT; while :; do sleep 3600; done"
+(* MUST match the idle argv in keeper_turn_sandbox_runtime.start_container. *)
+let idle_startup_argv = [ "tail"; "-f"; "/dev/null" ]
 
 type t =
   { container_name : Keeper_container_name.t
@@ -49,7 +48,7 @@ type t =
   ; read_only_rootfs : bool
   ; tmpfs_mount : string
   ; workdir : string option
-  ; startup_command : string
+  ; startup_argv : string list
   ; labels : (string * string) list
   ; cap_drop_all : bool
   ; no_new_privileges : bool
@@ -158,7 +157,7 @@ let of_request
           Env_config_keeper.KeeperSandbox.read_only_rootfs_args () <> []
       ; tmpfs_mount = Env_config_keeper.KeeperSandbox.tmpfs_mount ()
       ; workdir = Some container_root
-      ; startup_command = idle_startup_command
+      ; startup_argv = idle_startup_argv
       ; labels =
           deterministic_labels
             ~base_path
@@ -186,7 +185,7 @@ let ulimits t = t.ulimits
 let read_only_rootfs t = t.read_only_rootfs
 let tmpfs_mount t = t.tmpfs_mount
 let workdir t = t.workdir
-let startup_command t = t.startup_command
+let startup_argv t = t.startup_argv
 let labels t = t.labels
 let cap_drop_all t = t.cap_drop_all
 let no_new_privileges t = t.no_new_privileges
@@ -223,7 +222,7 @@ let equal a b =
   && Bool.equal a.read_only_rootfs b.read_only_rootfs
   && String.equal a.tmpfs_mount b.tmpfs_mount
   && Option.equal String.equal a.workdir b.workdir
-  && String.equal a.startup_command b.startup_command
+  && List.equal String.equal a.startup_argv b.startup_argv
   && equal_pairs a.labels b.labels
   && Bool.equal a.cap_drop_all b.cap_drop_all
   && Bool.equal a.no_new_privileges b.no_new_privileges

--- a/lib/keeper/keeper_sandbox_session_plan.mli
+++ b/lib/keeper/keeper_sandbox_session_plan.mli
@@ -103,8 +103,8 @@ type t
       [n = Env_config_keeper.KeeperSandbox.nofile_limit ()].
     - [pids_limit], [memory_limit], [tmpfs], [read_only_rootfs] —
       from [Env_config_keeper.KeeperSandbox.*].
-    - [startup_command] — the trap-and-sleep idle loop
-      ([trap : TERM INT; while :; do sleep 3600; done]).
+    - [startup_argv] — the direct idle process argv
+      (["tail"; "-f"; "/dev/null"]).
     - [seccomp_profile = Seccomp_default], [cap_drop_all = true],
       [no_new_privileges = true], [user = Some (uid, gid)],
       [image] / [container_root] / [network_mode] / [workdir = Some container_root]
@@ -148,7 +148,7 @@ val ulimits : t -> ulimit list
 val read_only_rootfs : t -> bool
 val tmpfs_mount : t -> string
 val workdir : t -> string option
-val startup_command : t -> string
+val startup_argv : t -> string list
 
 (** The 7 deterministic [(key, value)] label pairs. The edge appends
     [owner_pid] + [started_at] at spawn time. *)

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -228,7 +228,7 @@ let start_container (t : t) ~(timeout_sec : float) =
                ~container_root:t.container_root
            @ identity_mounts
            @ network_args
-           @ [ image; "sh"; "-lc"; "trap : TERM INT; while :; do sleep 3600; done" ]
+           @ [ image; "tail"; "-f"; "/dev/null" ]
          in
          let st, out = run_argv_with_status_retry_eintr ~timeout_sec argv in
          (match st with

--- a/scripts/keeper-sandbox-smoke.sh
+++ b/scripts/keeper-sandbox-smoke.sh
@@ -61,7 +61,7 @@ docker run -d --rm \
   -v "$playground:/workspace:rw" \
   --workdir /workspace \
   "$image_tag" \
-  sh -lc 'trap : TERM INT; while :; do sleep 3600; done' >/dev/null
+  tail -f /dev/null >/dev/null
 
 trap 'docker rm -f "$container_name" >/dev/null 2>&1 || true; rm -rf "$tmpdir"' EXIT
 

--- a/test/test_docker_client_real.ml
+++ b/test/test_docker_client_real.ml
@@ -419,13 +419,10 @@ let test_run_detached_argv_shape () =
   List.iter
     (fun m -> check bool (Printf.sprintf "mount %S present as -v arg" m) true (List.mem m argv))
     (Keeper_sandbox_session_plan.mounts plan);
-  check bool "ends with [image; sh; -lc; startup_command]" true
+  check bool "ends with [image] + startup_argv" true
     (ends_with
-       [ Keeper_sandbox_session_plan.image plan
-       ; "sh"
-       ; "-lc"
-       ; Keeper_sandbox_session_plan.startup_command plan
-       ]
+       (Keeper_sandbox_session_plan.image plan
+        :: Keeper_sandbox_session_plan.startup_argv plan)
        argv)
 ;;
 

--- a/test/test_keeper_sandbox_session_plan.ml
+++ b/test/test_keeper_sandbox_session_plan.ml
@@ -200,9 +200,9 @@ let test_static_fields () =
     (Some (1234, 5678)) (Keeper_sandbox_session_plan.user p);
   check (option string) "workdir = container_root"
     (Some "/keeper/alice") (Keeper_sandbox_session_plan.workdir p);
-  check string "startup_command = idle loop"
-    "trap : TERM INT; while :; do sleep 3600; done"
-    (Keeper_sandbox_session_plan.startup_command p);
+  check (list string) "startup_argv = direct idle argv"
+    [ "tail"; "-f"; "/dev/null" ]
+    (Keeper_sandbox_session_plan.startup_argv p);
   (match Keeper_sandbox_session_plan.seccomp_profile p with
    | Keeper_sandbox_session_plan.Seccomp_default -> ()
    | _ -> fail "seccomp_profile should default to Seccomp_default");


### PR DESCRIPTION
## Summary
- replace persistent Docker keepalive shell loops with direct `tail -f /dev/null` argv
- change sandbox session plan from `startup_command` string to `startup_argv`
- update tests, RFC notes, and sandbox smoke script to match the direct argv contract

## Verification
- `opam exec -- ocamlformat --check lib/keeper/keeper_sandbox_session_plan.mli lib/keeper/keeper_sandbox_session_plan.ml lib/keeper/keeper_docker_client_real.ml lib/keeper/keeper_sandbox_control.ml lib/keeper/keeper_turn_sandbox_runtime.ml test/test_docker_client_real.ml test/test_keeper_sandbox_session_plan.ml`
- `git diff --check`
- `bash scripts/lint/shell-legacy-purge-ratchet.sh`
- `scripts/lint-spawn-bounded.sh`
- `bash -n scripts/keeper-sandbox-smoke.sh`

Focused Dune target check was attempted with `scripts/dune-local.sh build test/test_docker_client_real.exe test/test_keeper_sandbox_session_plan.exe`, but the wrapper refused to start because other live bare `dune build` processes are bypassing the machine-wide Dune lock.