### PR TITLE
fix(sandbox): write turn files via bind mount

### DIFF
--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -417,34 +417,30 @@ let write_file_common
       (t : t)
       ~(host_path : string)
       ~(content : string)
-      ~(timeout_sec : float)
+      ~timeout_sec:_
       ~(append : bool)
       ()
   =
   match container_path_of_host t ~host_path with
   | Error _ as err -> err
-  | Ok container_path ->
-    let parent = Filename.dirname container_path in
-    let redirect = if append then ">>" else ">" in
-    let shell_cmd =
-      Printf.sprintf
-        "mkdir -p -- %s && cat %s %s"
-        (Filename.quote parent)
-        redirect
-        (Filename.quote container_path)
-    in
-    (match
-       run_exec_with_status
-         ~stdin_content:content
-         t
-         ~timeout_sec
-         ~cwd:t.host_root
-         ~command_argv:[ "sh"; "-lc"; shell_cmd ]
+  | Ok _container_path ->
+    let host_path = normalize_path host_path in
+    (try
+       Fs_compat.mkdir_p (Filename.dirname host_path);
+       if append
+       then Fs_compat.append_file host_path content
+       else Fs_compat.save_file host_path content;
+       Ok ()
      with
-     | Error _ as err -> err
-     | Ok (Unix.WEXITED 0, _out) -> Ok ()
-     | Ok (st, out) ->
-       Error (format_docker_exec_error ~head_program:"write_file" ~st ~out))
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | Sys_error msg -> Error msg
+     | Unix.Unix_error (err, fn, arg) ->
+       Error
+         (Printf.sprintf
+            "%s%s%s"
+            (Unix.error_message err)
+            (if String.equal fn "" then "" else ": " ^ fn)
+            (if String.equal arg "" then "" else " " ^ arg)))
 ;;
 
 let overwrite_file t ~host_path ~content ~timeout_sec () =

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -568,6 +568,35 @@ let test_git_clone_routes_through_docker () =
     (response_mentions raw "path"
        (Filename.concat playground "repos/masc-mcp"))
 
+let test_turn_sandbox_file_write_uses_host_bind_mount () =
+  setup ~sandbox:Keeper_types.Docker
+  @@ fun ~config ~meta ~playground ->
+  let runtime = Keeper_turn_sandbox_runtime.create ~config ~meta ~turn_id:1 () in
+  let target = Filename.concat playground "nested/result.txt" in
+  (match
+     Keeper_turn_sandbox_runtime.overwrite_file
+       runtime
+       ~host_path:target
+       ~content:"alpha\n"
+       ~timeout_sec:1.0
+       ()
+   with
+   | Error msg -> Alcotest.fail msg
+   | Ok () -> ());
+  (match
+     Keeper_turn_sandbox_runtime.append_file
+       runtime
+       ~host_path:target
+       ~content:"beta\n"
+       ~timeout_sec:1.0
+       ()
+   with
+   | Error msg -> Alcotest.fail msg
+   | Ok () -> ());
+  Alcotest.(check string) "content written via bind-mounted host path"
+    "alpha\nbeta\n"
+    (Fs_compat.load_file target)
+
 let test_bash_routes_through_docker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
   setup ~sandbox:Keeper_types.Docker
@@ -2002,6 +2031,9 @@ let () =
             test_rg_no_match_remains_successful_in_docker_route;
           Alcotest.test_case "git_clone routes through docker" `Quick
             test_git_clone_routes_through_docker;
+          Alcotest.test_case
+            "turn sandbox file writes use bind-mounted host path"
+            `Quick test_turn_sandbox_file_write_uses_host_bind_mount;
           Alcotest.test_case
             "git-creds skips missing SSH_AUTH_SOCK"
             `Quick test_git_creds_skips_missing_ssh_auth_sock;


### PR DESCRIPTION
## Summary
- replace turn sandbox write_file shell redirection with typed host filesystem writes through the existing bind-mounted playground
- keep Docker as the container boundary and avoid sh/python interpreter payloads for file writes
- add a behavior regression for overwrite+append through the turn sandbox runtime

## Validation
- git diff --check
- ocamlformat --check lib/keeper/keeper_turn_sandbox_runtime.ml test/test_keeper_shell_docker_route.ml
- scripts/dune-local.sh build test/test_keeper_shell_docker_route.exe: blocked by existing machine-wide bare Dune processes; not a code failure