### PR TITLE
refactor(keeper_heartbeat_loop): extract dispatch_recurring_keepalive sibling

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -641,54 +641,7 @@ let refresh_work_as_heartbeat
       consecutive_failures := 0))
 ;;
 
-let dispatch_recurring_keepalive
-      ~(ctx : _ context)
-      ~(meta_after_proactive : keeper_meta)
-      ~(now_ts : float)
-  : int
-  =
-  (* Recover from transient broadcast failures that previously
-     auto-disabled tasks via [dispatch_due]'s [max_failures] guard.
-     Without this call the keeper's heartbeat broadcasts stay silent
-     for the lifetime of the process, eventually triggering stale-kill
-     cascades.  See lib/keeper/keeper_recurring.ml for the cooldown rule. *)
-  let _reenabled =
-    Keeper_recurring.reenable_due_tasks ~keeper_name:meta_after_proactive.name ~now_ts
-  in
-  try
-    Keeper_recurring.dispatch_due
-      ~keeper_name:meta_after_proactive.name
-      ~now_ts
-      ~dispatch:(fun task action ->
-        match action with
-        | Keeper_recurring.Broadcast msg ->
-          (try
-             let _ =
-               Coord.broadcast
-                 ctx.config
-                 ~from_agent:meta_after_proactive.agent_name
-                 ~content:(Printf.sprintf "[loop:%s] %s" task.label msg)
-             in
-             Log.Keeper.info "[recurring] %s dispatched: %s" task.id task.label;
-             Ok ()
-           with
-           | exn ->
-             Log.Keeper.warn "[recurring] %s failed: %s" task.id (Printexc.to_string exn);
-             Prometheus.inc_counter
-               Keeper_metrics.metric_keeper_recurring_failures
-               ~labels:[ "task", task.id; "phase", "task_execution" ]
-               ();
-             Error (Printexc.to_string exn)))
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn ->
-    Log.Keeper.warn "[recurring] dispatch error: %s" (Printexc.to_string exn);
-    Prometheus.inc_counter
-      Keeper_metrics.metric_keeper_recurring_failures
-      ~labels:[ "task", "dispatch"; "phase", "dispatch_error" ]
-      ();
-    0
-;;
+let dispatch_recurring_keepalive = Keeper_heartbeat_loop_dispatch_recurring.dispatch_recurring_keepalive
 
 (** Whether a smart-heartbeat decision should allow the keepalive
     cycle to continue evaluating turns.

--- a/lib/keeper/keeper_heartbeat_loop_dispatch_recurring.ml
+++ b/lib/keeper/keeper_heartbeat_loop_dispatch_recurring.ml
@@ -1,0 +1,71 @@
+(** Recurring-task keepalive dispatch, extracted from
+    [keeper_heartbeat_loop.ml] (godfile decomp).
+
+    Per heartbeat cycle, attempts to:
+
+    1. Re-enable transiently-broadcast-failed recurring tasks that
+       were previously auto-disabled by [Keeper_recurring.dispatch_due]'s
+       [max_failures] guard (without this re-enable step the keeper
+       falls silent for the lifetime of the process and triggers
+       stale-kill cascades).
+    2. Dispatch all due tasks via [Keeper_recurring.dispatch_due],
+       broadcasting each via [Coord.broadcast] tagged
+       [\[loop:<label>\] <msg>]. Per-task broadcast failures tick
+       [metric_keeper_recurring_failures] with [phase="task_execution"]
+       and surface as [Error] in the inner result. The outer try/with
+       catches dispatch-loop errors and ticks the same metric with
+       [phase="dispatch_error"].
+
+    Returns the count of tasks dispatched (or 0 on dispatch-loop failure).
+    Cancellation re-raises. *)
+
+open Keeper_types
+
+let dispatch_recurring_keepalive
+      ~(ctx : _ context)
+      ~(meta_after_proactive : keeper_meta)
+      ~(now_ts : float)
+  : int
+  =
+  (* Recover from transient broadcast failures that previously
+     auto-disabled tasks via [dispatch_due]'s [max_failures] guard.
+     Without this call the keeper's heartbeat broadcasts stay silent
+     for the lifetime of the process, eventually triggering stale-kill
+     cascades.  See lib/keeper/keeper_recurring.ml for the cooldown rule. *)
+  let _reenabled =
+    Keeper_recurring.reenable_due_tasks ~keeper_name:meta_after_proactive.name ~now_ts
+  in
+  try
+    Keeper_recurring.dispatch_due
+      ~keeper_name:meta_after_proactive.name
+      ~now_ts
+      ~dispatch:(fun task action ->
+        match action with
+        | Keeper_recurring.Broadcast msg ->
+          (try
+             let _ =
+               Coord.broadcast
+                 ctx.config
+                 ~from_agent:meta_after_proactive.agent_name
+                 ~content:(Printf.sprintf "[loop:%s] %s" task.label msg)
+             in
+             Log.Keeper.info "[recurring] %s dispatched: %s" task.id task.label;
+             Ok ()
+           with
+           | exn ->
+             Log.Keeper.warn "[recurring] %s failed: %s" task.id (Printexc.to_string exn);
+             Prometheus.inc_counter
+               Keeper_metrics.metric_keeper_recurring_failures
+               ~labels:[ "task", task.id; "phase", "task_execution" ]
+               ();
+             Error (Printexc.to_string exn)))
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Keeper.warn "[recurring] dispatch error: %s" (Printexc.to_string exn);
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_recurring_failures
+      ~labels:[ "task", "dispatch"; "phase", "dispatch_error" ]
+      ();
+    0
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane B
- 4th sibling extracted from `keeper_heartbeat_loop.ml` (after #17296 `keepalive_scheduling`, #17320 `presence`, #17344 `board_events`).
- **Pure helper move** — no callback injection, no helper duplication.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/keeper/keeper_heartbeat_loop.ml` | 1240 | 1193 | **-47** |
| `lib/keeper/keeper_heartbeat_loop_dispatch_recurring.ml` | — | 71 | +71 |

## Moved (verbatim, no behavior change)
- `dispatch_recurring_keepalive ~ctx ~meta_after_proactive ~now_ts : int`
  - Step 1: `Keeper_recurring.reenable_due_tasks ~keeper_name ~now_ts`
    — recovers tasks auto-disabled by `dispatch_due`'s `max_failures` guard
    (without this re-enable the keeper falls silent for the lifetime of the
    process → stale-kill cascades)
  - Step 2: `Keeper_recurring.dispatch_due ~keeper_name ~now_ts ~dispatch`
    — for each due task whose action is `Broadcast msg`:
      - `Coord.broadcast ctx.config ~from_agent:meta.agent_name ~content:"[loop:<label>] <msg>"`
      - On success: `Log.Keeper.info "[recurring] %s dispatched: %s"`, return `Ok ()`
      - On per-task failure: WARN log, `inc_counter metric_keeper_recurring_failures`
        with `phase="task_execution"`, return `Error <exn-string>`
  - Outer `try/with`:
    - `Eio.Cancel.Cancelled` → re-raise (cancellation safety)
    - Other `exn` → WARN log, `inc_counter` with `phase="dispatch_error"`, return `0`

Parent retains a 1-line alias preserving the `.mli` surface.

## External callers
None. The `.mli` exposes the function at line 162, but the only caller
is the parent's own `run_heartbeat_loop`. The alias preserves the
surface for future cross-module use.

## Sibling deps (all external)
- `open Keeper_types` — `'a context`, `keeper_meta`
- `Keeper_recurring.{reenable_due_tasks, dispatch_due, Broadcast}`
- `Coord.broadcast`
- `Log.Keeper.{info, warn}`
- `Prometheus.inc_counter`
- `Keeper_metrics.metric_keeper_recurring_failures`
- `Eio.Cancel.Cancelled`
- `Printf.sprintf`, `Printexc.to_string`

No parent-local helpers needed; no sibling -> parent cycle.

## Local build status
- `dune build --root . lib/keeper/` → clean (exit 0)
- godfile lint: sibling 71 LOC under `new_file_cap=600`; parent 1193 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim single-function move, 1-line parent alias.

Co-Authored-By: codex <noreply@anthropic.com>
