### PR TITLE
refactor(shell): parse history command prefixes

### DIFF
--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -520,7 +520,7 @@ let claim_next_r
                 ; "agent_tool_names_known", `Bool (Option.is_some agent_tool_names)
                 ; "ts", `String (now_iso ())
                 ]);
-        let effective_task_filter task =
+        let effective_task_filter (task : Masc_domain.task) =
           task_filter task && admission_allowed task && required_tool_claim_allowed task
         in
         let task_filter_excluded =

--- a/lib/exec/test/test_history_insight.ml
+++ b/lib/exec/test/test_history_insight.ml
@@ -20,13 +20,11 @@ let teardown () =
   in
   if Sys.file_exists tmp_dir then rm_rf tmp_dir
 
-let make_entry ~cmd ~success ~duration =
+let make_entry ?cmd_prefix ~cmd ~success ~duration () =
+  let cmd_prefix = Option.value cmd_prefix ~default:(String.trim cmd) in
   { BH.ts = Unix.time ();
     BH.cmd_hash = BH.cmd_hash cmd;
-    BH.cmd_prefix =
-      (* take first word as prefix *)
-      (match String.split_on_char ' ' cmd with
-       | [] -> cmd | w :: _ -> w);
+    BH.cmd_prefix = cmd_prefix;
     BH.semantic_kind = "Unknown";
     BH.duration_ms = duration;
     BH.success }
@@ -51,7 +49,7 @@ let test_healthy_history () =
   let dir = setup () in
   let entries =
     List.init 10 (fun i ->
-      make_entry ~cmd:("cmd" ^ string_of_int i) ~success:true ~duration:100)
+      make_entry ~cmd:("cmd" ^ string_of_int i) ~success:true ~duration:100 ())
   in
   append_entries dir "healthy" entries;
   let patterns = BH.failure_insight ~base_path:dir ~keeper_name:"healthy" in
@@ -61,10 +59,10 @@ let test_healthy_history () =
 let test_repeated_failure () =
   let dir = setup () in
   let entries = [
-    make_entry ~cmd:"npm test" ~success:true ~duration:500;
-    make_entry ~cmd:"npm test" ~success:false ~duration:200;
-    make_entry ~cmd:"npm test" ~success:false ~duration:200;
-    make_entry ~cmd:"npm test" ~success:false ~duration:200;
+    make_entry ~cmd:"npm test" ~cmd_prefix:"npm" ~success:true ~duration:500 ();
+    make_entry ~cmd:"npm test" ~cmd_prefix:"npm" ~success:false ~duration:200 ();
+    make_entry ~cmd:"npm test" ~cmd_prefix:"npm" ~success:false ~duration:200 ();
+    make_entry ~cmd:"npm test" ~cmd_prefix:"npm" ~success:false ~duration:200 ();
   ] in
   append_entries dir "stuck" entries;
   let patterns = BH.failure_insight ~base_path:dir ~keeper_name:"stuck" in
@@ -83,14 +81,14 @@ let test_high_failure_rate () =
   let dir = setup () in
   (* 6 failures out of 8 recent = 75% > 60% threshold *)
   let entries = [
-    make_entry ~cmd:"a" ~success:false ~duration:100;
-    make_entry ~cmd:"b" ~success:false ~duration:100;
-    make_entry ~cmd:"c" ~success:true  ~duration:100;
-    make_entry ~cmd:"d" ~success:false ~duration:100;
-    make_entry ~cmd:"e" ~success:false ~duration:100;
-    make_entry ~cmd:"f" ~success:true  ~duration:100;
-    make_entry ~cmd:"g" ~success:false ~duration:100;
-    make_entry ~cmd:"h" ~success:false ~duration:100;
+    make_entry ~cmd:"a" ~success:false ~duration:100 ();
+    make_entry ~cmd:"b" ~success:false ~duration:100 ();
+    make_entry ~cmd:"c" ~success:true  ~duration:100 ();
+    make_entry ~cmd:"d" ~success:false ~duration:100 ();
+    make_entry ~cmd:"e" ~success:false ~duration:100 ();
+    make_entry ~cmd:"f" ~success:true  ~duration:100 ();
+    make_entry ~cmd:"g" ~success:false ~duration:100 ();
+    make_entry ~cmd:"h" ~success:false ~duration:100 ();
   ] in
   append_entries dir "flaky" entries;
   let patterns = BH.failure_insight ~base_path:dir ~keeper_name:"flaky" in
@@ -110,9 +108,9 @@ let test_high_failure_rate () =
 let test_timeout_cluster () =
   let dir = setup () in
   let entries = [
-    make_entry ~cmd:"dune build" ~success:true ~duration:5000;
-    make_entry ~cmd:"dune build" ~success:false ~duration:35000;
-    make_entry ~cmd:"dune build" ~success:false ~duration:32000;
+    make_entry ~cmd:"dune build" ~cmd_prefix:"dune" ~success:true ~duration:5000 ();
+    make_entry ~cmd:"dune build" ~cmd_prefix:"dune" ~success:false ~duration:35000 ();
+    make_entry ~cmd:"dune build" ~cmd_prefix:"dune" ~success:false ~duration:32000 ();
   ] in
   append_entries dir "slow" entries;
   let patterns = BH.failure_insight ~base_path:dir ~keeper_name:"slow" in
@@ -130,9 +128,9 @@ let test_timeout_cluster () =
 let test_json_output () =
   let dir = setup () in
   let entries = [
-    make_entry ~cmd:"cargo test" ~success:false ~duration:100;
-    make_entry ~cmd:"cargo test" ~success:false ~duration:100;
-    make_entry ~cmd:"cargo test" ~success:false ~duration:100;
+    make_entry ~cmd:"cargo test" ~cmd_prefix:"cargo" ~success:false ~duration:100 ();
+    make_entry ~cmd:"cargo test" ~cmd_prefix:"cargo" ~success:false ~duration:100 ();
+    make_entry ~cmd:"cargo test" ~cmd_prefix:"cargo" ~success:false ~duration:100 ();
   ] in
   append_entries dir "json_test" entries;
   let patterns = BH.failure_insight ~base_path:dir ~keeper_name:"json_test" in

--- a/lib/keeper/keeper_exec_masc.ml
+++ b/lib/keeper/keeper_exec_masc.ml
@@ -58,7 +58,7 @@ let keeper_masc_path_blocked
    agent-side handler [Tool_code.handle_code_read]). *)
 let handle_keeper_masc_code_read
       ~(config : Coord.config)
-      ~(meta : keeper_meta)
+      ~(meta : Keeper_types.keeper_meta)
       ~(args : Yojson.Safe.t)
   =
   let path = Safe_ops.json_string ~default:"" "path" args in

--- a/lib/keeper/keeper_shell_command_semantics.ml
+++ b/lib/keeper/keeper_shell_command_semantics.ml
@@ -93,6 +93,11 @@ let cmd_targets_git_or_gh cmd =
 let cmd_targets_gh cmd =
   effective_stages cmd |> List.exists (fun stage -> stage.bin = "gh")
 
+let cmd_prefix cmd =
+  match effective_stages cmd with
+  | stage :: _ -> stage.bin
+  | [] -> String.trim cmd
+
 let repo_flag_value = function
   | "--repo" -> None
   | flag when String.starts_with ~prefix:"--repo=" flag ->

--- a/lib/keeper/keeper_shell_command_semantics.mli
+++ b/lib/keeper/keeper_shell_command_semantics.mli
@@ -13,6 +13,11 @@ val cmd_targets_gh : string -> bool
 (** [true] only when the typed bash subset parser identifies an effective
     command stage whose executable is [gh]. *)
 
+val cmd_prefix : string -> string
+(** Prefix used for shell-history grouping. Uses the same typed bash subset
+    parser and effective-command wrapper handling as command-shape policy.
+    Unsupported command shapes fall back to the trimmed original command. *)
+
 val detect_gh_repo_flag_with_api_misuse : string -> (string * string) option
 (** Detect the invalid [gh --repo <repo> api <endpoint>] shape.  [--repo]
     is a subcommand flag, not a [gh api] global option. *)

--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -111,10 +111,7 @@ let handle_keeper_shell
     in
     (* P16: Record execution in history for failure pattern detection *)
     let success = st = Unix.WEXITED 0 in
-    let cmd_prefix =
-      match String.split_on_char ' ' cmd with
-      | [] -> cmd | w :: _ -> w
-    in
+    let cmd_prefix = Keeper_shell_command_semantics.cmd_prefix cmd in
     let entry = Masc_exec.Bash_history.{
       ts = Unix.time ();
       cmd_hash = Masc_exec.Bash_history.cmd_hash cmd;
@@ -160,10 +157,7 @@ let handle_keeper_shell
   let render_completed_process_result ?cwd ~cmd ?(extra = []) st out =
     (* P16: Record execution in history for failure pattern detection *)
     let success = st = Unix.WEXITED 0 in
-    let cmd_prefix =
-      match String.split_on_char ' ' cmd with
-      | [] -> cmd | w :: _ -> w
-    in
+    let cmd_prefix = Keeper_shell_command_semantics.cmd_prefix cmd in
     let elapsed_ms =
       List.find_map (fun (k, v) ->
         if k = "execution_time_ms" then

--- a/lib/worker_dev_tools_command_syntax.ml
+++ b/lib/worker_dev_tools_command_syntax.ml
@@ -5,10 +5,41 @@
     path-token normalization helpers plus explicit argv/word helpers for
     transparent wrappers such as [env] and [opam exec]. *)
 
-let split_on_space cmd =
-  String.split_on_char ' ' cmd
-  |> List.map String.trim
-  |> List.filter (fun token -> token <> "")
+let rec shell_ir_literal_text = function
+  | Masc_exec.Shell_ir.Lit text -> Some text
+  | Masc_exec.Shell_ir.Concat parts ->
+    let rec loop acc = function
+      | [] -> Some (String.concat "" (List.rev acc))
+      | part :: rest ->
+        (match shell_ir_literal_text part with
+         | Some text -> loop (text :: acc) rest
+         | None -> None)
+    in
+    loop [] parts
+  | Masc_exec.Shell_ir.Var _ -> None
+;;
+
+let argv_words_of_simple (simple : Masc_exec.Shell_ir.simple) =
+  let rec loop acc = function
+    | [] -> Some (List.rev acc)
+    | arg :: rest ->
+      (match shell_ir_literal_text arg with
+       | Some text -> loop (text :: acc) rest
+       | None -> None)
+  in
+  Option.map
+    (fun args -> Masc_exec.Bin.to_string simple.bin :: args)
+    (loop [] simple.Masc_exec.Shell_ir.args)
+;;
+
+let argv_words_of_split_string text =
+  match Masc_exec_bash_parser.Bash.parse_string text with
+  | Masc_exec.Parsed.Parsed (Masc_exec.Shell_ir.Simple simple) ->
+    argv_words_of_simple simple
+  | Masc_exec.Parsed.Parsed (Masc_exec.Shell_ir.Pipeline _)
+  | Masc_exec.Parsed.Parse_error _
+  | Masc_exec.Parsed.Parse_aborted _
+  | Masc_exec.Parsed.Too_complex _ -> None
 ;;
 
 let strip_wrapping_quotes token =
@@ -55,10 +86,11 @@ let rec command_after_env_prefix_tokens = function
     then (
       match rest with
       | arg :: rest -> (
-        match
-          command_after_env_prefix_tokens (split_on_space (strip_wrapping_quotes arg))
-        with
-        | Some _ as command -> command
+        match argv_words_of_split_string (strip_wrapping_quotes arg) with
+        | Some split_tokens -> (
+          match command_after_env_prefix_tokens split_tokens with
+          | Some _ as command -> command
+          | None -> command_after_env_prefix_tokens rest)
         | None -> command_after_env_prefix_tokens rest)
       | [] -> None)
     else if String.starts_with ~prefix:"--split-string=" token
@@ -67,7 +99,9 @@ let rec command_after_env_prefix_tokens = function
       let arg =
         String.sub token (String.length prefix) (String.length token - String.length prefix)
       in
-      command_after_env_prefix_tokens (split_on_space (strip_wrapping_quotes arg))
+      Option.bind
+        (argv_words_of_split_string (strip_wrapping_quotes arg))
+        command_after_env_prefix_tokens
     else if token = "-u" || token = "--unset" || token = "-C" || token = "--chdir"
     then (
       match rest with

--- a/scripts/lint/shell-legacy-purge-ratchet.baseline
+++ b/scripts/lint/shell-legacy-purge-ratchet.baseline
@@ -26,6 +26,7 @@ shell_word_simple_commands 0
 command_has_repo_wide_scan 0
 Keeper_shell_bash_words 0
 keeper_shell_bash_words 0
+String.split_on_char ' ' cmd 0
 shell_words_with_boundaries 0
 strip_command_wrappers 0
 cmd_gh_pr_native_subcommand 0

--- a/scripts/lint/shell-legacy-purge-ratchet.sh
+++ b/scripts/lint/shell-legacy-purge-ratchet.sh
@@ -38,6 +38,7 @@ NEEDLES=(
   "command_has_repo_wide_scan"
   "Keeper_shell_bash_words"
   "keeper_shell_bash_words"
+  "String.split_on_char ' ' cmd"
   "shell_words_with_boundaries"
   "strip_command_wrappers"
   "cmd_gh_pr_native_subcommand"

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -1334,6 +1334,21 @@ let test_sandbox_root_git_cwd_cd_chain_is_not_interpreted () =
     None
     error
 
+let test_cmd_prefix_uses_shell_semantics () =
+  let check label expected cmd =
+    Alcotest.(check string)
+      label
+      expected
+      (Keeper_shell_command_semantics.cmd_prefix cmd)
+  in
+  check "plain command" "git" "git status";
+  check "env wrapper" "gh" "env GH_TOKEN=redacted gh pr list";
+  check "opam wrapper" "dune" "opam exec -- dune runtest";
+  check
+    "unsupported shell shape falls back to original command"
+    "cd repos/masc-mcp && git status"
+    "cd repos/masc-mcp && git status"
+
 let test_gh_repo_api_misuse_uses_shell_semantics () =
   let check label expected cmd =
     Alcotest.(check (option (pair string string)))
@@ -2057,5 +2072,9 @@ let () =
             "gh --repo api misuse uses shell semantics"
             `Quick
             test_gh_repo_api_misuse_uses_shell_semantics;
+          Alcotest.test_case
+            "history cmd_prefix uses shell semantics"
+            `Quick
+            test_cmd_prefix_uses_shell_semantics;
         ] );
     ]


### PR DESCRIPTION
## Summary
- replace private space-splitting of shell history command prefixes with shell parser semantics
- route worker env split-string command detection through Bash parser literal argv extraction
- add ratchet coverage for the removed String.split_on_char command-prefix marker

## Verification
- ocamlformat --check touched OCaml files
- git diff --check origin/main...HEAD
- bash scripts/lint/shell-legacy-purge-ratchet.sh
- env MASC_DUNE_THROTTLE=0 MASC_OPAM_LOCK=0 MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build lib/.masc_mcp.objs/byte/masc_mcp__Worker_dev_tools_command_syntax.cmo
- _build/default/lib/exec/test/test_history_insight.exe

Note: test/test_worker_dev_tools.exe build was attempted, but local Dune scheduler entered condition-wait after compiling under heavy multi-worktree contention; the smaller changed-module cmo target completed.