### PR TITLE
fix(cdal): keep terminal incomplete proof store active

### DIFF
--- a/lib/cdal_runtime_health.ml
+++ b/lib/cdal_runtime_health.ml
@@ -266,6 +266,12 @@ let has_stale_incomplete_runs completeness =
   | None -> false
 ;;
 
+let has_terminal_incomplete_runs completeness =
+  match json_int_field "terminal_incomplete_run_dirs" completeness with
+  | Some count -> count > 0
+  | None -> false
+;;
+
 let proof_store_root_json
       ~now
       ~stale_age_seconds
@@ -288,6 +294,8 @@ let proof_store_root_json
   let status =
     if has_stale_incomplete_runs completeness
     then "stale_incomplete_runs"
+    else if has_terminal_incomplete_runs completeness
+    then "active"
     else status_of_latest ~stale_age_seconds ~exists ~age_seconds
   in
   `Assoc


### PR DESCRIPTION
## Summary
- keep proof stores with terminal incomplete runs classified as active instead of dormant
- preserves stale incomplete run blocking while allowing terminal markers to remain non-blocking

## Verification
- ocamlformat --check lib/cdal_runtime_health.ml
- git diff --check
- env MASC_DUNE_THROTTLE=0 MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_DUNE_ALLOW_LIVE_BUILD_LOCK=1 MASC_SKIP_PIN_CHECK=1 MASC_SKIP_OPAM_LOCK=1 scripts/dune-local.sh build bin/main_eio.exe test/test_cdal_runtime_health_15748.exe
- _build/default/test/test_cdal_runtime_health_15748.exe

## Notes
- MASC_SKIP_PIN_CHECK=1 was used to avoid downgrading the shared local agent_sdk pin during local verification.