### PR TITLE
[codex] Make docker exec use typed argv

### DIFF
--- a/lib/keeper/keeper_docker_client.ml
+++ b/lib/keeper/keeper_docker_client.ml
@@ -18,7 +18,7 @@ module type S = sig
     -> ?workdir:string
     -> ?stdin:string
     -> container:Keeper_container_name.t
-    -> cmd:string
+    -> command_argv:string list
     -> unit
     -> (Keeper_docker_response.exec_result, sandbox_error) result
 

--- a/lib/keeper/keeper_docker_client.mli
+++ b/lib/keeper/keeper_docker_client.mli
@@ -48,11 +48,11 @@ module type S = sig
     -> ?workdir:string
     -> ?stdin:string
     -> container:Keeper_container_name.t
-    -> cmd:string
+    -> command_argv:string list
     -> unit
     -> (Keeper_docker_response.exec_result, sandbox_error) result
-  (** [exec ?user ?workdir ?stdin ~container ~cmd ()] runs [cmd]
-      inside an already-running [container] via [docker exec].
+  (** [exec ?user ?workdir ?stdin ~container ~command_argv ()] runs
+      [command_argv] inside an already-running [container] via [docker exec].
 
       - [?user] — [(uid, gid)], emitted as [--user uid:gid]. Omitted
         ⇒ docker uses the container image's [USER].
@@ -63,10 +63,9 @@ module type S = sig
         -i …` reads from the host process's stdin, which the gated
         spawn fills). Omitted ⇒ no [-i] flag and stdin is closed. RFC
         §3.2.1: the keeper-turn `overwrite_file` / `append_file` paths
-        write file content via `sh -lc 'mkdir -p … && cat > …'` with
-        the content piped on stdin; Phase 4.1-h surfaces that as a
-        first-class plan field so the Phase 4.1 caller cutover does
-        not need a parallel stdin-aware code path.
+        pipe content on stdin; Phase 4.1-h surfaces stdin as a
+        first-class plan field so callers do not need a parallel
+        stdin-aware code path.
 
       The trailing [unit] is required so OCaml can erase the leading
       optionals (warning 16) — all parameters are otherwise labeled.

--- a/lib/keeper/keeper_docker_client_mock.ml
+++ b/lib/keeper/keeper_docker_client_mock.ml
@@ -13,7 +13,7 @@ let run_queue
   = Queue.create ()
 
 let exec_queue
-  : ((Keeper_container_name.t * string)
+  : ((Keeper_container_name.t * string list)
      * (Keeper_docker_response.exec_result, Keeper_docker_client.sandbox_error) result)
       Queue.t
   = Queue.create ()
@@ -52,8 +52,8 @@ let run_detached_queue
 
 let inject_run plan response = Queue.add (plan, response) run_queue
 
-let inject_exec ~container ~cmd response =
-  Queue.add ((container, cmd), response) exec_queue
+let inject_exec ~container ~command_argv response =
+  Queue.add ((container, command_argv), response) exec_queue
 ;;
 
 let inject_ps_query ~labels response =
@@ -86,18 +86,18 @@ let run plan =
     response
   | _ -> Error Keeper_docker_client.Daemon_unreachable
 
-let exec ?user:_ ?workdir:_ ?stdin:_ ~container ~cmd () =
+let exec ?user:_ ?workdir:_ ?stdin:_ ~container ~command_argv () =
   (* [?user] / [?workdir] / [?stdin] shape the real [docker exec] argv
      (see {!Keeper_docker_client_real.exec_argv}) but do not affect the mocked
      response, so they are accepted and ignored for matching here —
-     the injection key stays [(container, cmd)]. When a caller (Phase
+     the injection key stays [(container, command_argv)]. When a caller (Phase
      4.1 [keeper_turn_sandbox_runtime] cutover) needs to assert the
      user/workdir/stdin threaded through, widen the injection key
      then; until then a narrower key keeps test setup minimal. *)
   match Queue.peek_opt exec_queue with
-  | Some ((expected_c, expected_cmd), response)
+  | Some ((expected_c, expected_argv), response)
     when Keeper_container_name.equal container expected_c
-         && String.equal cmd expected_cmd ->
+         && List.equal String.equal command_argv expected_argv ->
     (* fire-and-forget: matched FIFO head is intentionally consumed. *)
     ignore (Queue.pop exec_queue);
     response

--- a/lib/keeper/keeper_docker_client_mock.mli
+++ b/lib/keeper/keeper_docker_client_mock.mli
@@ -35,7 +35,7 @@ val inject_run
 
 val inject_exec
   :  container:Keeper_container_name.t
-  -> cmd:string
+  -> command_argv:string list
   -> (Keeper_docker_response.exec_result, Keeper_docker_client.sandbox_error) result
   -> unit
 

--- a/lib/keeper/keeper_docker_client_real.ml
+++ b/lib/keeper/keeper_docker_client_real.ml
@@ -208,7 +208,7 @@ let ps_query ~labels:_ = placeholder
    [?stdin] is a [bool], not the content itself — the *content* is
    never part of the argv (it is piped on stdin by {!exec}), so the
    pure builder only needs to know whether to emit the [-i] flag. *)
-let exec_argv ?user ?workdir ?(stdin = false) ~container ~cmd () =
+let exec_argv ?user ?workdir ?(stdin = false) ~container ~command_argv () =
   let user_args =
     match user with
     | None -> []
@@ -224,12 +224,12 @@ let exec_argv ?user ?workdir ?(stdin = false) ~container ~cmd () =
   @ user_args
   @ workdir_args
   @ stdin_args
-  @ [ Keeper_container_name.to_string container; "sh"; "-lc"; cmd ]
+  @ (Keeper_container_name.to_string container :: command_argv)
 ;;
 
-let exec ?user ?workdir ?stdin ~container ~cmd () =
+let exec ?user ?workdir ?stdin ~container ~command_argv () =
   let argv =
-    exec_argv ?user ?workdir ~stdin:(Option.is_some stdin) ~container ~cmd ()
+    exec_argv ?user ?workdir ~stdin:(Option.is_some stdin) ~container ~command_argv ()
   in
   (* Gated spawn returns [(status, stdout, stderr)]; on spawn failure
      the status is synthesized as [WEXITED 127] (see 3b-iv.2.1 commit

--- a/lib/keeper/keeper_docker_client_real.mli
+++ b/lib/keeper/keeper_docker_client_real.mli
@@ -23,7 +23,7 @@
       caller by design — RFC-0070 requires cancellation to remain
       observable rather than being absorbed into a typed error.
     - [exec] — wired: spawns
-      [docker exec <name> sh -lc <cmd>] via
+      [docker exec <name> <command_argv>] via
       [Process_eio.run_argv_with_status_split]. The semantic
       distinction vs [rm] matters: a non-zero exit *inside the
       container* is the *command's* result, returned as
@@ -59,7 +59,7 @@
 
 include Keeper_docker_client.S
 
-(** [exec_argv ?user ?workdir ?stdin ~container ~cmd ()] is the pure
+(** [exec_argv ?user ?workdir ?stdin ~container ~command_argv ()] is the pure
     [docker exec] argv builder used by {!exec}. Exposed for unit-testing
     the argv shape (option presence, [--user] before [-w] before [-i]
     ordering) without spawning a daemon.
@@ -74,7 +74,7 @@ val exec_argv
   -> ?workdir:string
   -> ?stdin:bool
   -> container:Keeper_container_name.t
-  -> cmd:string
+  -> command_argv:string list
   -> unit
   -> string list
 

--- a/lib/keeper/keeper_sandbox_session_executor.ml
+++ b/lib/keeper/keeper_sandbox_session_executor.ml
@@ -20,12 +20,12 @@ module Make (D : Keeper_docker_client.S) = struct
     | Ok container_name -> Ok { container_name; plan }
     | Error err -> Error err
 
-  let exec t ~cmd =
+  let exec t ~command_argv =
     D.exec
       ?user:(Keeper_sandbox_session_plan.user t.plan)
       ?workdir:(Keeper_sandbox_session_plan.workdir t.plan)
       ~container:t.container_name
-      ~cmd
+      ~command_argv
       ()
 
   let cleanup t = D.rm t.container_name

--- a/lib/keeper/keeper_sandbox_session_executor.mli
+++ b/lib/keeper/keeper_sandbox_session_executor.mli
@@ -47,7 +47,7 @@ module Make : functor (D : Keeper_docker_client.S) -> sig
     :  Keeper_sandbox_session_plan.t
     -> (t, Keeper_docker_client.sandbox_error) result
 
-  (** [exec t ~cmd] runs [cmd] inside the started container via
+  (** [exec t ~command_argv] runs [command_argv] inside the started container via
       [D.exec], threading the originating plan's [user] / [workdir]
       through as [D.exec]'s [?user] / [?workdir] (Phase 3e (b),
       #14947) so the command runs as the same uid:gid / cwd the
@@ -57,7 +57,7 @@ module Make : functor (D : Keeper_docker_client.S) -> sig
       [Error Keeper_docker_client.Daemon_unreachable]. *)
   val exec
     :  t
-    -> cmd:string
+    -> command_argv:string list
     -> (Keeper_docker_response.exec_result, Keeper_docker_client.sandbox_error) result
 
   (** [cleanup t] removes the container via [D.rm]. Calling it on an

--- a/test/test_docker_client_mock.ml
+++ b/test/test_docker_client_mock.ml
@@ -131,30 +131,35 @@ let test_run_fifo_order () =
 let test_exec_matches_injection () =
   setup ();
   let c = sample_container () in
-  Keeper_docker_client_mock.inject_exec ~container:c ~cmd:"ls -la"
+  Keeper_docker_client_mock.inject_exec ~container:c ~command_argv:[ "ls"; "-la" ]
     (Ok sample_exec_result);
-  match Keeper_docker_client_mock.exec ~container:c ~cmd:"ls -la" () with
+  match Keeper_docker_client_mock.exec ~container:c ~command_argv:[ "ls"; "-la" ] () with
   | Ok er -> check string "stdout" "ok" er.stdout
   | Error _ -> fail "expected Ok"
 
 let test_exec_unmatched_cmd () =
   setup ();
   let c = sample_container () in
-  Keeper_docker_client_mock.inject_exec ~container:c ~cmd:"ls -la"
+  Keeper_docker_client_mock.inject_exec ~container:c ~command_argv:[ "ls"; "-la" ]
     (Ok sample_exec_result);
-  match Keeper_docker_client_mock.exec ~container:c ~cmd:"different cmd" () with
+  match Keeper_docker_client_mock.exec ~container:c ~command_argv:[ "different"; "cmd" ] () with
   | Error Keeper_docker_client.Daemon_unreachable -> ()
-  | _ -> fail "expected miss on different cmd"
+  | _ -> fail "expected miss on different command argv"
 
 (* Phase 3e (b) — [exec] now takes [?user] / [?workdir]; the mock
-   ignores them for matching (key stays [(container, cmd)]). Passing
+   ignores them for matching (key stays [(container, command_argv)]). Passing
    them must not change which injection is consumed. *)
 let test_exec_ignores_user_workdir_for_matching () =
   setup ();
   let c = sample_container () in
-  Keeper_docker_client_mock.inject_exec ~container:c ~cmd:"id" (Ok sample_exec_result);
+  Keeper_docker_client_mock.inject_exec ~container:c ~command_argv:[ "id" ] (Ok sample_exec_result);
   match
-    Keeper_docker_client_mock.exec ~user:(1000, 1000) ~workdir:"/work" ~container:c ~cmd:"id" ()
+    Keeper_docker_client_mock.exec
+      ~user:(1000, 1000)
+      ~workdir:"/work"
+      ~container:c
+      ~command_argv:[ "id" ]
+      ()
   with
   | Ok er -> check string "stdout" "ok" er.stdout
   | Error _ -> fail "expected Ok — user/workdir must not affect matching"
@@ -165,12 +170,12 @@ let test_exec_ignores_user_workdir_for_matching () =
 let test_exec_ignores_stdin_for_matching () =
   setup ();
   let c = sample_container () in
-  Keeper_docker_client_mock.inject_exec ~container:c ~cmd:"cat > /tmp/x" (Ok sample_exec_result);
+  Keeper_docker_client_mock.inject_exec ~container:c ~command_argv:[ "cat" ] (Ok sample_exec_result);
   match
     Keeper_docker_client_mock.exec
       ~stdin:"hello world"
       ~container:c
-      ~cmd:"cat > /tmp/x"
+      ~command_argv:[ "cat" ]
       ()
   with
   | Ok er -> check string "stdout" "ok" er.stdout
@@ -180,14 +185,17 @@ let test_exec_ignores_stdin_for_matching () =
 let test_exec_ignores_all_three_optionals_together () =
   setup ();
   let c = sample_container () in
-  Keeper_docker_client_mock.inject_exec ~container:c ~cmd:"tee /tmp/x" (Ok sample_exec_result);
+  Keeper_docker_client_mock.inject_exec
+    ~container:c
+    ~command_argv:[ "tee"; "/tmp/x" ]
+    (Ok sample_exec_result);
   match
     Keeper_docker_client_mock.exec
       ~user:(1000, 1000)
       ~workdir:"/work"
       ~stdin:"payload"
       ~container:c
-      ~cmd:"tee /tmp/x"
+      ~command_argv:[ "tee"; "/tmp/x" ]
       ()
   with
   | Ok _ ->
@@ -306,7 +314,10 @@ let test_reset_clears_all_queues () =
   setup ();
   let c = sample_container () in
   Keeper_docker_client_mock.inject_run (sample_plan ()) (Ok sample_exec_result);
-  Keeper_docker_client_mock.inject_exec ~container:c ~cmd:"x" (Ok sample_exec_result);
+  Keeper_docker_client_mock.inject_exec
+    ~container:c
+    ~command_argv:[ "x" ]
+    (Ok sample_exec_result);
   Keeper_docker_client_mock.inject_ps_query ~labels:[] (Ok []);
   Keeper_docker_client_mock.inject_rm c (Ok ());
   Keeper_docker_client_mock.inject_info_security_options (Ok []);

--- a/test/test_docker_client_real.ml
+++ b/test/test_docker_client_real.ml
@@ -92,14 +92,19 @@ let test_run_returns_typed_result () =
 ;;
 
 (* Phase 3b-iv.2.2 — exec is no longer a placeholder. It spawns
-   [docker exec <container> sh -lc <cmd>]. The test environment may
+   [docker exec <container> <command_argv>]. The test environment may
    or may not have a docker daemon, so we only assert the *typed*
    contract: either [Ok exec_result] (daemon present, command ran
    inside container even if it failed) or [Error Daemon_unreachable]
    (no daemon / CLI missing). Other [sandbox_error] variants are
    semantically out of scope for [exec] and must NOT surface. *)
 let test_exec_returns_typed_result () =
-  match Keeper_docker_client_real.exec ~container:(sample_container ()) ~cmd:"echo hi" () with
+  match
+    Keeper_docker_client_real.exec
+      ~container:(sample_container ())
+      ~command_argv:[ "echo"; "hi" ]
+      ()
+  with
   | Ok _ -> () (* daemon present *)
   | Error Keeper_docker_client.Daemon_unreachable -> () (* daemon / CLI missing *)
   | Error Keeper_docker_client.Cleanup_failed
@@ -120,8 +125,8 @@ let test_exec_argv_plain () =
   check
     (list string)
     "no user, no workdir"
-    [ "docker"; "exec"; Keeper_container_name.to_string c; "sh"; "-lc"; "ls -la" ]
-    (Keeper_docker_client_real.exec_argv ~container:c ~cmd:"ls -la" ())
+    [ "docker"; "exec"; Keeper_container_name.to_string c; "ls"; "-la" ]
+    (Keeper_docker_client_real.exec_argv ~container:c ~command_argv:[ "ls"; "-la" ] ())
 ;;
 
 let test_exec_argv_user_only () =
@@ -134,11 +139,13 @@ let test_exec_argv_user_only () =
     ; "--user"
     ; "1000:1000"
     ; Keeper_container_name.to_string c
-    ; "sh"
-    ; "-lc"
     ; "id"
     ]
-    (Keeper_docker_client_real.exec_argv ~user:(1000, 1000) ~container:c ~cmd:"id" ())
+    (Keeper_docker_client_real.exec_argv
+       ~user:(1000, 1000)
+       ~container:c
+       ~command_argv:[ "id" ]
+       ())
 ;;
 
 let test_exec_argv_workdir_only () =
@@ -146,8 +153,12 @@ let test_exec_argv_workdir_only () =
   check
     (list string)
     "workdir only → -w <dir>"
-    [ "docker"; "exec"; "-w"; "/work"; Keeper_container_name.to_string c; "sh"; "-lc"; "pwd" ]
-    (Keeper_docker_client_real.exec_argv ~workdir:"/work" ~container:c ~cmd:"pwd" ())
+    [ "docker"; "exec"; "-w"; "/work"; Keeper_container_name.to_string c; "pwd" ]
+    (Keeper_docker_client_real.exec_argv
+       ~workdir:"/work"
+       ~container:c
+       ~command_argv:[ "pwd" ]
+       ())
 ;;
 
 let test_exec_argv_user_and_workdir () =
@@ -162,15 +173,13 @@ let test_exec_argv_user_and_workdir () =
     ; "-w"
     ; "/work"
     ; Keeper_container_name.to_string c
-    ; "sh"
-    ; "-lc"
     ; "whoami"
     ]
     (Keeper_docker_client_real.exec_argv
        ~user:(1000, 1000)
        ~workdir:"/work"
        ~container:c
-       ~cmd:"whoami"
+       ~command_argv:[ "whoami" ]
        ())
 ;;
 
@@ -186,23 +195,29 @@ let test_exec_argv_stdin_only_emits_dash_i () =
     ; "exec"
     ; "-i"
     ; Keeper_container_name.to_string c
-    ; "sh"
-    ; "-lc"
-    ; "cat > /tmp/x"
+    ; "cat"
     ]
-    (Keeper_docker_client_real.exec_argv ~stdin:true ~container:c ~cmd:"cat > /tmp/x" ())
+    (Keeper_docker_client_real.exec_argv
+       ~stdin:true
+       ~container:c
+       ~command_argv:[ "cat" ]
+       ())
 ;;
 
 let test_exec_argv_stdin_false_omits_dash_i () =
   let c = sample_container () in
   let argv =
-    Keeper_docker_client_real.exec_argv ~stdin:false ~container:c ~cmd:"echo hi" ()
+    Keeper_docker_client_real.exec_argv
+      ~stdin:false
+      ~container:c
+      ~command_argv:[ "echo"; "hi" ]
+      ()
   in
   check bool "stdin=false ⇒ no -i" false (List.mem "-i" argv);
   check
     (list string)
     "stdin=false matches the plain shape"
-    [ "docker"; "exec"; Keeper_container_name.to_string c; "sh"; "-lc"; "echo hi" ]
+    [ "docker"; "exec"; Keeper_container_name.to_string c; "echo"; "hi" ]
     argv
 ;;
 
@@ -219,16 +234,15 @@ let test_exec_argv_user_workdir_stdin_full_order () =
     ; "/work"
     ; "-i"
     ; Keeper_container_name.to_string c
-    ; "sh"
-    ; "-lc"
-    ; "tee /tmp/x"
+    ; "tee"
+    ; "/tmp/x"
     ]
     (Keeper_docker_client_real.exec_argv
        ~user:(1000, 1000)
        ~workdir:"/work"
        ~stdin:true
        ~container:c
-       ~cmd:"tee /tmp/x"
+       ~command_argv:[ "tee"; "/tmp/x" ]
        ())
 ;;
 
@@ -236,7 +250,9 @@ let test_exec_argv_stdin_default_is_false () =
   (* Omitting [?stdin] altogether is the same as [~stdin:false]: the
      default is "no -i", because most exec calls don't pipe stdin. *)
   let c = sample_container () in
-  let argv = Keeper_docker_client_real.exec_argv ~container:c ~cmd:"echo hi" () in
+  let argv =
+    Keeper_docker_client_real.exec_argv ~container:c ~command_argv:[ "echo"; "hi" ] ()
+  in
   check bool "no ?stdin ⇒ no -i" false (List.mem "-i" argv)
 ;;
 

--- a/test/test_sandbox_session_executor.ml
+++ b/test/test_sandbox_session_executor.ml
@@ -4,7 +4,7 @@
     the start → exec → cleanup lifecycle:
     - [start] returns a handle whose [container_name] is the plan's;
       a [run_detached] error injection surfaces typed from [start];
-    - [exec] forwards to [D.exec] (matched on container + cmd), a
+    - [exec] forwards to [D.exec] (matched on container + command_argv), a
       non-zero container exit stays an [Ok exec_result], a daemon-level
       error surfaces typed;
     - [cleanup] forwards to [D.rm];
@@ -88,9 +88,9 @@ let test_exec_forwards_to_docker_exec () =
   let handle = start_or_fail (sample_plan ()) in
   Keeper_docker_client_mock.inject_exec
     ~container:(Session.container_name handle)
-    ~cmd:"echo hi"
+    ~command_argv:[ "echo"; "hi" ]
     (Ok exec_ok);
-  (match Session.exec handle ~cmd:"echo hi" with
+  (match Session.exec handle ~command_argv:[ "echo"; "hi" ] with
    | Ok er -> check string "stdout threaded through" "out" er.stdout
    | Error _ -> fail "expected Ok exec_result");
   check int "exec injection consumed" 0 (Keeper_docker_client_mock.pending_calls ())
@@ -101,9 +101,9 @@ let test_exec_nonzero_exit_is_ok_result () =
   let handle = start_or_fail (sample_plan ()) in
   Keeper_docker_client_mock.inject_exec
     ~container:(Session.container_name handle)
-    ~cmd:"false"
+    ~command_argv:[ "false" ]
     (Ok Keeper_docker_response.{ exit_code = 1; stdout = ""; stderr = "boom" });
-  match Session.exec handle ~cmd:"false" with
+  match Session.exec handle ~command_argv:[ "false" ] with
   | Ok er ->
     check int "container-command exit code is the result, not an error" 1 er.exit_code
   | Error _ -> fail "non-zero container exit must be Ok, not Error"
@@ -114,9 +114,9 @@ let test_exec_daemon_error_surfaces () =
   let handle = start_or_fail (sample_plan ()) in
   Keeper_docker_client_mock.inject_exec
     ~container:(Session.container_name handle)
-    ~cmd:"echo hi"
+    ~command_argv:[ "echo"; "hi" ]
     (Error Keeper_docker_client.Daemon_unreachable);
-  match Session.exec handle ~cmd:"echo hi" with
+  match Session.exec handle ~command_argv:[ "echo"; "hi" ] with
   | Error Keeper_docker_client.Daemon_unreachable -> ()
   | _ -> fail "daemon-level error must surface typed"
 ;;
@@ -124,7 +124,7 @@ let test_exec_daemon_error_surfaces () =
 let test_exec_no_injection_misses () =
   setup ();
   let handle = start_or_fail (sample_plan ()) in
-  match Session.exec handle ~cmd:"echo hi" with
+  match Session.exec handle ~command_argv:[ "echo"; "hi" ] with
   | Error Keeper_docker_client.Daemon_unreachable -> ()
   | _ -> fail "no exec injection ⇒ Mock's default miss"
 ;;
@@ -158,11 +158,15 @@ let test_lifecycle_start_exec_cleanup () =
   setup ();
   let handle = start_or_fail (sample_plan ()) in
   let c = Session.container_name handle in
-  Keeper_docker_client_mock.inject_exec ~container:c ~cmd:"step 1" (Ok exec_ok);
-  Keeper_docker_client_mock.inject_exec ~container:c ~cmd:"step 2" (Ok exec_ok);
+  Keeper_docker_client_mock.inject_exec ~container:c ~command_argv:[ "step"; "1" ] (Ok exec_ok);
+  Keeper_docker_client_mock.inject_exec ~container:c ~command_argv:[ "step"; "2" ] (Ok exec_ok);
   Keeper_docker_client_mock.inject_rm c (Ok ());
-  (match Session.exec handle ~cmd:"step 1" with Ok _ -> () | Error _ -> fail "step 1");
-  (match Session.exec handle ~cmd:"step 2" with Ok _ -> () | Error _ -> fail "step 2");
+  (match Session.exec handle ~command_argv:[ "step"; "1" ] with
+   | Ok _ -> ()
+   | Error _ -> fail "step 1");
+  (match Session.exec handle ~command_argv:[ "step"; "2" ] with
+   | Ok _ -> ()
+   | Error _ -> fail "step 2");
   (match Session.cleanup handle with Ok () -> () | Error _ -> fail "cleanup");
   check int "all injections drained in order" 0 (Keeper_docker_client_mock.pending_calls ())
 ;;


### PR DESCRIPTION
## Summary
- change Keeper_docker_client.S.exec from shell command strings to command_argv
- remove the docker exec sh -lc wrapper in Keeper_docker_client_real.exec_argv
- update mock/session executor APIs and regression tests to assert direct argv shape

## Verification
- `opam exec -- ocamlformat --check lib/keeper/keeper_docker_client.ml lib/keeper/keeper_docker_client.mli lib/keeper/keeper_docker_client_mock.ml lib/keeper/keeper_docker_client_mock.mli lib/keeper/keeper_docker_client_real.ml lib/keeper/keeper_docker_client_real.mli lib/keeper/keeper_sandbox_session_executor.ml lib/keeper/keeper_sandbox_session_executor.mli test/test_docker_client_mock.ml test/test_docker_client_real.ml test/test_sandbox_session_executor.ml`
- `git diff --check`
- `bash scripts/lint/shell-legacy-purge-ratchet.sh`
- `scripts/lint-spawn-bounded.sh`
- source guard: no docker exec sh -lc / exec_argv ~cmd / Session.exec ~cmd remnants in touched surfaces

Focused Dune target check was attempted with `scripts/dune-local.sh build test/test_docker_client_real.exe test/test_docker_client_mock.exe test/test_sandbox_session_executor.exe`, but the wrapper refused to start because other live bare `dune build` processes are bypassing the machine-wide Dune lock.