### PR TITLE
refactor(keeper_supervisor): extract supervise_keepalive sibling

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -538,77 +538,12 @@ let persona_profile_path_for_drift_check =
 let log_persona_drift_if_missing = Startup_helpers.log_persona_drift_if_missing
 
 let supervise_keepalive ~proactive_warmup_sec (ctx : _ context) (meta : keeper_meta) =
-  if Keeper_registry.is_registered ~base_path:ctx.config.base_path meta.name
-  then ()
-  else
-    match Keeper_registry.spawn_slots_decision ~base_path:ctx.config.base_path () with
-    | Error reason ->
-      Keeper_registry.record_spawn_slot_denied ~keeper_name:meta.name ~surface:"supervisor" reason;
-      publish_lifecycle
-        ~event:
-          (Keeper_lifecycle_events.Custom_event
-             { verb = Keeper_lifecycle_events.Admission_denied
-             ; phase = Some Keeper_state_machine.Offline
-             })
-        meta.name
-        (Keeper_registry.spawn_slot_denial_reason_to_detail reason)
-        ()
-    | Ok () -> (
-    log_persona_drift_if_missing ~base_path:ctx.config.base_path meta;
-    (* Register in Keeper_registry — single source of truth. *)
-    let reg =
-      Keeper_registry.register_offline ~base_path:ctx.config.base_path meta.name meta
-    in
-    (* Coord initialization *)
-    (try
-       if not (Coord_utils.is_initialized ctx.config)
-       then (
-         let (_init_msg : string) = Coord.init ctx.config ~agent_name:None in
-         ())
-     with
-     | Eio.Cancel.Cancelled _ as e -> raise e
-     | exn ->
-       Prometheus.inc_counter
-         Keeper_metrics.metric_keeper_room_init_failures
-         ~labels:[ "keeper", meta.name ]
-         ();
-       Log.Keeper.error "supervisor room init failed: %s" (Printexc.to_string exn));
-    let live_meta =
-      try
-        let synced = ensure_keeper_room_presence ctx.config meta in
-        (match write_meta ctx.config synced with
-         | Ok () -> ()
-         | Error msg ->
-           Prometheus.inc_counter
-             Keeper_metrics.metric_keeper_write_meta_failures
-             ~labels:[ "keeper", meta.name; "phase", "presence_sync" ]
-             ();
-           Log.Keeper.warn
-             "supervisor presence sync: write_meta failed for %s: %s"
-             meta.name
-             msg);
-        synced
-      with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn ->
-        Prometheus.inc_counter
-          Keeper_metrics.metric_keeper_presence_sync_failures
-          ~labels:[ "keeper", meta.name ]
-          ();
-        Log.Keeper.error "supervisor presence sync failed: %s" (Printexc.to_string exn);
-        meta
-    in
-    Keeper_registry.update_meta ~base_path:ctx.config.base_path meta.name live_meta;
-    launch_supervised_fiber ~proactive_warmup_sec ctx live_meta reg;
-    publish_lifecycle
-      ~event:
-        (Keeper_lifecycle_events.Custom_event
-           { verb = Keeper_lifecycle_events.Started
-           ; phase = Some Keeper_state_machine.Running
-           })
-      meta.name
-      "supervised"
-      ())
+  Keeper_supervisor_supervise_keepalive.supervise_keepalive
+    ~publish_lifecycle
+    ~launch_supervised_fiber
+    ~proactive_warmup_sec
+    ctx
+    meta
 ;;
 
 let resume_keeper_after_reconcile_gate (ctx : _ context) (meta : keeper_meta) =

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.ml
@@ -1,0 +1,118 @@
+(** Keepalive supervision entry-point, extracted from
+    [keeper_supervisor.ml] (godfile decomp).
+
+    [supervise_keepalive] is the gate that decides whether to spawn a
+    supervised keepalive fiber for [meta]. Idempotent on already-
+    registered keepers (no-op). On a fresh registration:
+
+    1. Asks [Keeper_registry] for a spawn-slot decision. On [Error
+       reason], records the denial and publishes an [Admission_denied]
+       lifecycle event in [Offline] phase; the keeper does not spawn.
+    2. On [Ok ()]:
+       - logs persona drift if missing
+       - registers offline in [Keeper_registry]
+       - lazily initializes the coordination room (Coord.init)
+       - syncs keeper room presence + writes meta (failures degrade
+         to original meta but tick failure counters)
+       - calls the injected [~launch_supervised_fiber] to actually
+         spawn the supervised fiber
+       - publishes a [Started] / [Running]-phase lifecycle event
+
+    Two parent-local callbacks are injected to avoid sibling -> parent
+    cycles:
+
+    - [~publish_lifecycle] — emits structured lifecycle events
+    - [~launch_supervised_fiber] — the large parent-local fiber
+      spawner (the body of which itself does not move; this sibling
+      just forwards) *)
+
+open Keeper_types
+open Keeper_execution
+module Startup_helpers = Keeper_supervisor_startup_helpers
+
+let supervise_keepalive
+      ~(publish_lifecycle :
+         event:Keeper_lifecycle_events.lifecycle_event ->
+         string -> string -> unit -> unit)
+      ~(launch_supervised_fiber :
+         proactive_warmup_sec:int ->
+         _ context ->
+         keeper_meta ->
+         Keeper_registry.registry_entry ->
+         unit)
+      ~proactive_warmup_sec
+      (ctx : _ context)
+      (meta : keeper_meta)
+  =
+  if Keeper_registry.is_registered ~base_path:ctx.config.base_path meta.name
+  then ()
+  else
+    match Keeper_registry.spawn_slots_decision ~base_path:ctx.config.base_path () with
+    | Error reason ->
+      Keeper_registry.record_spawn_slot_denied ~keeper_name:meta.name ~surface:"supervisor" reason;
+      publish_lifecycle
+        ~event:
+          (Keeper_lifecycle_events.Custom_event
+             { verb = Keeper_lifecycle_events.Admission_denied
+             ; phase = Some Keeper_state_machine.Offline
+             })
+        meta.name
+        (Keeper_registry.spawn_slot_denial_reason_to_detail reason)
+        ()
+    | Ok () -> (
+    Startup_helpers.log_persona_drift_if_missing ~base_path:ctx.config.base_path meta;
+    (* Register in Keeper_registry — single source of truth. *)
+    let reg =
+      Keeper_registry.register_offline ~base_path:ctx.config.base_path meta.name meta
+    in
+    (* Coord initialization *)
+    (try
+       if not (Coord_utils.is_initialized ctx.config)
+       then (
+         let (_init_msg : string) = Coord.init ctx.config ~agent_name:None in
+         ())
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+       Prometheus.inc_counter
+         Keeper_metrics.metric_keeper_room_init_failures
+         ~labels:[ "keeper", meta.name ]
+         ();
+       Log.Keeper.error "supervisor room init failed: %s" (Printexc.to_string exn));
+    let live_meta =
+      try
+        let synced = ensure_keeper_room_presence ctx.config meta in
+        (match write_meta ctx.config synced with
+         | Ok () -> ()
+         | Error msg ->
+           Prometheus.inc_counter
+             Keeper_metrics.metric_keeper_write_meta_failures
+             ~labels:[ "keeper", meta.name; "phase", "presence_sync" ]
+             ();
+           Log.Keeper.warn
+             "supervisor presence sync: write_meta failed for %s: %s"
+             meta.name
+             msg);
+        synced
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+        Prometheus.inc_counter
+          Keeper_metrics.metric_keeper_presence_sync_failures
+          ~labels:[ "keeper", meta.name ]
+          ();
+        Log.Keeper.error "supervisor presence sync failed: %s" (Printexc.to_string exn);
+        meta
+    in
+    Keeper_registry.update_meta ~base_path:ctx.config.base_path meta.name live_meta;
+    launch_supervised_fiber ~proactive_warmup_sec ctx live_meta reg;
+    publish_lifecycle
+      ~event:
+        (Keeper_lifecycle_events.Custom_event
+           { verb = Keeper_lifecycle_events.Started
+           ; phase = Some Keeper_state_machine.Running
+           })
+      meta.name
+      "supervised"
+      ())
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane B
- 5th sibling extracted from `keeper_supervisor.ml` (after #17291 `cleanup_dead_tombstone`, #17342 `reconcile_keepalive_keepers`, #17350 `resume_keeper_after_reconcile_gate`, #17362 `restore_reconcile_continue_gate`).
- **Foundational extraction** — `supervise_keepalive` is the function that the other 3 reconcile-gate siblings inject as a callback. After this PR the entry-point itself is also a sibling.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/keeper/keeper_supervisor.ml` | 1362 | 1297 | **-65** |
| `lib/keeper/keeper_supervisor_supervise_keepalive.ml` | — | 118 | +118 |

## Moved (verbatim, no behavior change)
- `supervise_keepalive ~proactive_warmup_sec ctx meta` — keepalive supervision entry-point:
  - **Idempotency check**: `Keeper_registry.is_registered ~base_path meta.name` → no-op return
  - **Spawn admission gate**: `Keeper_registry.spawn_slots_decision ~base_path ()`
    - `Error reason` → `Keeper_registry.record_spawn_slot_denied ~surface:"supervisor" reason`
      + `publish_lifecycle (Custom_event { verb=Admission_denied; phase=Some Offline })`
      with `spawn_slot_denial_reason_to_detail reason`
    - `Ok ()` continues below
  - **Persona drift check**: `Startup_helpers.log_persona_drift_if_missing ~base_path meta`
  - **Offline registration**: `Keeper_registry.register_offline ~base_path meta.name meta`
  - **Lazy Coord init**: `Coord_utils.is_initialized` guard + `Coord.init ~agent_name:None`
    - on `Eio.Cancel.Cancelled` → re-raise; on `exn` → `inc_counter metric_keeper_room_init_failures` + ERROR
  - **Presence sync**: `ensure_keeper_room_presence` + `write_meta`
    - meta write `Error msg` → `inc_counter metric_keeper_write_meta_failures phase=presence_sync` + WARN
    - outer `exn` → `inc_counter metric_keeper_presence_sync_failures` + ERROR, fall back to original `meta`
  - **Update registry**: `Keeper_registry.update_meta ~base_path meta.name live_meta`
  - **Spawn fiber**: invoke `~launch_supervised_fiber ~proactive_warmup_sec ctx live_meta reg`
  - **Started event**: `publish_lifecycle (Custom_event { verb=Started; phase=Some Running })` "supervised"

Parent retains an 8-line wrapper that binds both local callbacks.

## Callback-injection pattern (mirror of #17342)
Sibling signature:
```ocaml
val supervise_keepalive :
  publish_lifecycle:(event:Keeper_lifecycle_events.lifecycle_event ->
                     string -> string -> unit -> unit) ->
  launch_supervised_fiber:(proactive_warmup_sec:int ->
                           _ context -> keeper_meta ->
                           Keeper_registry.registry_entry -> unit) ->
  proactive_warmup_sec:int -> _ context -> keeper_meta -> unit
```

Parent adapter:
```ocaml
let supervise_keepalive ~proactive_warmup_sec (ctx : _ context) (meta : keeper_meta) =
  Keeper_supervisor_supervise_keepalive.supervise_keepalive
    ~publish_lifecycle
    ~launch_supervised_fiber
    ~proactive_warmup_sec
    ctx
    meta
;;
```

The other 3 reconcile-gate siblings (#17342/#17350/#17362) continue
receiving `~supervise_keepalive` as a callback — they now reach the
parent's *wrapper* version, which in turn forwards to this sibling.
No chain disruption.

## External callers (all unchanged via parent wrapper)
- `test/test_keeper_registry.ml:1405` — `Sup.supervise_keepalive ~proactive_warmup_sec:0 ctx (make_meta denied_name)`
- `test/test_keeper_supervisor.ml:515` — `Sup.supervise_keepalive ~proactive_warmup_sec:0 ctx meta`
- `lib/keeper/keeper_runtime.ml:715` — `Keeper_supervisor.supervise_keepalive`

## Sibling deps (all visible)
- `open Keeper_types` — `'a context`, `keeper_meta`, `write_meta`
- `open Keeper_execution` — `ensure_keeper_room_presence`
- `module Startup_helpers = Keeper_supervisor_startup_helpers` — `log_persona_drift_if_missing`
- `Keeper_registry.{is_registered, spawn_slots_decision, record_spawn_slot_denied,
   spawn_slot_denial_reason_to_detail, register_offline, update_meta, registry_entry}`
- `Keeper_lifecycle_events.{Custom_event, Admission_denied, Started, lifecycle_event}`
- `Keeper_state_machine.{Offline, Running}`
- `Coord_utils.is_initialized`, `Coord.init`
- `Eio.Cancel.Cancelled`
- `Prometheus.inc_counter`
- `Keeper_metrics.{metric_keeper_room_init_failures, metric_keeper_write_meta_failures, metric_keeper_presence_sync_failures}`
- `Log.Keeper.{warn, error}`
- `Printexc.to_string`

No sibling -> parent cycle (both parent-local helpers are passed as labeled args).

## Local build status
- `dune build --root . lib/keeper/` → clean (exit 0)
- godfile lint: sibling 118 LOC under `new_file_cap=600`; parent 1297 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim body move + 2-callback injection.

Co-Authored-By: codex <noreply@anthropic.com>
