### PR TITLE
fix(build): qualify cascade contract detail fields

### DIFF
--- a/lib/cascade/cascade_event_bridge_error_json.ml
+++ b/lib/cascade/cascade_event_bridge_error_json.ml
@@ -58,17 +58,21 @@ let json_contract_violation_detail
   =
   match detail with
   | None -> `Null
-  | Some detail ->
+  | Some (detail : Agent_sdk.Completion_contract_violation_detail.t) ->
     `Assoc
-      [ "called_tools", json_string_list detail.called_tools
-      ; "satisfying_tools", json_string_list detail.satisfying_tools
+      [ ( "called_tools"
+        , json_string_list
+            detail.Agent_sdk.Completion_contract_violation_detail.called_tools )
+      ; ( "satisfying_tools"
+        , json_string_list
+            detail.Agent_sdk.Completion_contract_violation_detail.satisfying_tools )
       ; ( "rejection_reasons"
         , `List
             (List.map
                (fun (tool_name, reason) ->
                   `Assoc
                     [ "tool_name", `String tool_name; "reason", `String reason ])
-               detail.rejection_reasons) )
+               detail.Agent_sdk.Completion_contract_violation_detail.rejection_reasons) )
       ]
 ;;
 


### PR DESCRIPTION
## Summary
- Qualify `Agent_sdk.Completion_contract_violation_detail` record fields in cascade bridge JSON decoding.
- Keeps cascade error bridge compatible with the current SDK record-field namespace after recent OAS pin movement.

## Validation
- `git diff --check origin/main...HEAD`
- `ocamlformat --check lib/cascade/cascade_event_bridge_error_json.ml`
- `bash scripts/sync-oas-pin-docs.sh --check`
- `env DUNE_CACHE=disabled DUNE_LOCAL_JOBS=1 MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_cascade_error_classify_decoder.exe test/test_cascade_capacity_backpressure_synthetic_backoff.exe`

## Note
- During this branch, upstream main absorbed the Shell IR worker/timeout hardening and several compile blockers. This PR now carries only the remaining cascade field-qualification fix.