### PR TITLE
[codex] Make docker oneshot run use typed argv

### DIFF
--- a/lib/keeper/keeper_docker_client_real.ml
+++ b/lib/keeper/keeper_docker_client_real.ml
@@ -258,18 +258,16 @@ let run plan =
     Keeper_container_name.to_string (Keeper_sandbox_oneshot_plan.container_name plan)
   in
   let image = Keeper_sandbox_oneshot_plan.image plan in
-  let command = Keeper_sandbox_oneshot_plan.command plan in
+  let command_argv = Keeper_sandbox_oneshot_plan.command_argv plan in
   let timeout_sec = Keeper_sandbox_oneshot_plan.timeout_budget_sec plan in
-  (* [docker run --rm --name <name> <image> sh -lc <cmd>].
+  (* [docker run --rm --name <name> <image> <command_argv>].
      [--rm] removes the container after exit (Phase 3b-iii default
      cleanup strategy — RFC §3.1's spec deferred a typed cleanup
-     policy to a follow-up RFC). [sh -lc] mirrors [exec]'s wrapping
-     so caller-passed [cmd] strings work identically across both
-     functions. *)
+     policy to a follow-up RFC). *)
   let argv =
     [ "docker"; "run"; "--rm"; "--name"; container_name ]
     @ Keeper_sandbox_runtime.docker_run_pull_never_args ()
-    @ [ image; "sh"; "-lc"; command ]
+    @ (image :: command_argv)
   in
   map_status_to_exec_result
     (gated_argv_with_status_split ~timeout_sec ~summary:"keeper docker run (oneshot)" argv)

--- a/lib/keeper/keeper_docker_client_real.mli
+++ b/lib/keeper/keeper_docker_client_real.mli
@@ -37,7 +37,7 @@
       All other [WEXITED n] values surface as
       [Ok { exit_code = n; stdout; stderr }].
     - [run] — wired: spawns
-      [docker run --rm --name <name> <image> sh -lc <cmd>] via
+      [docker run --rm --name <name> <image> <command_argv>] via
       [Process_eio.run_argv_with_status_split], passing
       [Keeper_sandbox_oneshot_plan.timeout_budget_sec] as the
       [?timeout_sec] parameter. Status mapping is the same as [exec]

--- a/lib/keeper/keeper_sandbox_oneshot_plan.ml
+++ b/lib/keeper/keeper_sandbox_oneshot_plan.ml
@@ -2,7 +2,7 @@
 
 type plan_error =
   | Invalid_meta of string
-  | Invalid_command of string
+  | Invalid_command of string list
 
 (* Phase 3b-iii defaults — Phase 3b-iv replaces with caller-provided
    values. Kept as named constants (CLAUDE.md §Magic Number 금지). *)
@@ -13,15 +13,15 @@ let default_hash_algo = Keeper_hash_algo.SHA_256
 type t =
   { container_name : Keeper_container_name.t
   ; image : string
-  ; command : string
+  ; command_argv : string list
   ; timeout_budget_sec : float
   }
 
-let of_request ~turn_id ~attempt ~meta_name ~cmd =
+let of_request ~turn_id ~attempt ~meta_name ~command_argv =
   (* Error payload = offending value (per .mli contract). Empty-string
-     callers see [Invalid_meta ""] / [Invalid_command ""]. *)
+     callers see [Invalid_meta ""] / [Invalid_command []]. *)
   if String.equal meta_name "" then Error (Invalid_meta meta_name)
-  else if String.equal cmd "" then Error (Invalid_command cmd)
+  else if List.is_empty command_argv then Error (Invalid_command command_argv)
   else
     let container_name =
       Keeper_container_name.derive
@@ -33,23 +33,26 @@ let of_request ~turn_id ~attempt ~meta_name ~cmd =
     Ok
       { container_name
       ; image = default_image
-      ; command = cmd
+      ; command_argv
       ; timeout_budget_sec = default_timeout_budget_sec
       }
 
 let container_name t = t.container_name
 let image t = t.image
-let command t = t.command
+let command_argv t = t.command_argv
 let timeout_budget_sec t = t.timeout_budget_sec
 
 let equal a b =
   Keeper_container_name.equal a.container_name b.container_name
   && String.equal a.image b.image
-  && String.equal a.command b.command
+  && List.equal String.equal a.command_argv b.command_argv
   && Float.equal a.timeout_budget_sec b.timeout_budget_sec
 
 let pp ppf t =
   Format.fprintf ppf
-    "@[<v 2>Sandbox_plan {@,container_name = %a;@,image = %S;@,command = %S;@,timeout_budget_sec = %g@]@,}"
+    "@[<v 2>Sandbox_plan {@,container_name = %a;@,image = %S;@,command_argv = \
+     [%s];@,timeout_budget_sec = %g@]@,}"
     Keeper_container_name.pp t.container_name
-    t.image t.command t.timeout_budget_sec
+    t.image
+    (String.concat "; " (List.map Filename.quote t.command_argv))
+    t.timeout_budget_sec

--- a/lib/keeper/keeper_sandbox_oneshot_plan.mli
+++ b/lib/keeper/keeper_sandbox_oneshot_plan.mli
@@ -7,11 +7,11 @@
 
     Reference: docs/rfc/RFC-0070-keeper-sandbox-pure-edge-separation.md §3.1
 
-    Determinism contract: same [(turn_id, attempt, meta_name, cmd)] ⇒
+    Determinism contract: same [(turn_id, attempt, meta_name, command_argv)] ⇒
     identical {!t}. No wall-clock, no Random, no global state.
 
     Scope of Phase 3b-iii: the record exposes the four most-needed
-    fields ([container_name], [image], [command], [timeout_budget_sec]).
+    fields ([container_name], [image], [command_argv], [timeout_budget_sec]).
     Mount, ulimit, and network_mode are deferred to Phase 3b-iv where
     they arrive as typed records together with the [Real]
     [Keeper_docker_client] implementation. *)
@@ -29,7 +29,8 @@
     stay stable and grep-able. *)
 type plan_error =
   | Invalid_meta of string  (** payload = the offending [meta_name] (often [""]) *)
-  | Invalid_command of string  (** payload = the offending [cmd] (often [""]) *)
+  | Invalid_command of string list
+  (** payload = the offending [command_argv] (often [[]]) *)
 
 (** {1 Plan} *)
 
@@ -40,19 +41,20 @@ type t
 
 (** {1 Constructor} *)
 
-(** [of_request ~turn_id ~attempt ~meta_name ~cmd] derives a plan from
+(** [of_request ~turn_id ~attempt ~meta_name ~command_argv] derives a plan from
     its declared inputs alone. Pure: no I/O, no clock, no random.
 
     Validation:
     - [meta_name] must be non-empty (returns [Invalid_meta meta_name]
       otherwise — the offending value is the payload).
-    - [cmd] must be non-empty (returns [Invalid_command cmd] otherwise).
+    - [command_argv] must be non-empty (returns [Invalid_command command_argv]
+      otherwise).
 
     Fields populated:
     - [container_name = Keeper_container_name.derive ~algo:SHA_256
       ~turn_id ~attempt ~suffix:meta_name]
     - [image = default_image] (Phase 3b-iv: caller-provided)
-    - [command = cmd]
+    - [command_argv = command_argv]
     - [timeout_budget_sec = default_timeout_budget_sec] (Phase 3b-iv:
       caller-provided)
 
@@ -63,7 +65,7 @@ val of_request
   :  turn_id:int
   -> attempt:int
   -> meta_name:string
-  -> cmd:string
+  -> command_argv:string list
   -> (t, plan_error) result
 
 (** {1 Accessors} *)
@@ -72,7 +74,7 @@ val container_name : t -> Keeper_container_name.t
 
 val image : t -> string
 
-val command : t -> string
+val command_argv : t -> string list
 
 (** Timeout budget in seconds. Phase 3b-iv replaces with [Eio.Time.span]
     once Eio is wired into the plan layer. *)

--- a/test/test_docker_client_mock.ml
+++ b/test/test_docker_client_mock.ml
@@ -18,7 +18,7 @@ let sample_plan () =
       ~turn_id:1
       ~attempt:0
       ~meta_name:"alice"
-      ~cmd:"echo hi"
+      ~command_argv:[ "echo"; "hi" ]
   with
   | Ok p -> p
   | Error _ -> failwith "test fixture"
@@ -83,7 +83,10 @@ let test_run_unmatched_plan_returns_daemon_unreachable () =
   let p2 =
     match
       Keeper_sandbox_oneshot_plan.of_request
-        ~turn_id:99 ~attempt:0 ~meta_name:"bob" ~cmd:"x"
+        ~turn_id:99
+        ~attempt:0
+        ~meta_name:"bob"
+        ~command_argv:[ "x" ]
     with
     | Ok p -> p
     | Error _ -> failwith "fix"
@@ -103,7 +106,10 @@ let test_run_fifo_order () =
   let p2 =
     match
       Keeper_sandbox_oneshot_plan.of_request
-        ~turn_id:2 ~attempt:0 ~meta_name:"bob" ~cmd:"y"
+        ~turn_id:2
+        ~attempt:0
+        ~meta_name:"bob"
+        ~command_argv:[ "y" ]
     with
     | Ok p -> p
     | Error _ -> failwith "fix"

--- a/test/test_docker_client_real.ml
+++ b/test/test_docker_client_real.ml
@@ -25,7 +25,11 @@ let eio_test_case name speed f =
 
 let sample_plan () =
   match
-    Keeper_sandbox_oneshot_plan.of_request ~turn_id:1 ~attempt:0 ~meta_name:"alice" ~cmd:"echo hi"
+    Keeper_sandbox_oneshot_plan.of_request
+      ~turn_id:1
+      ~attempt:0
+      ~meta_name:"alice"
+      ~command_argv:[ "echo"; "hi" ]
   with
   | Ok p -> p
   | Error _ -> failwith "test fixture"
@@ -75,7 +79,7 @@ let sample_session_plan () =
 (* ── Each S function returns the typed placeholder ──────────── *)
 
 (* Phase 3b-iv.2.3 — run is no longer a placeholder. It spawns
-   [docker run --rm --name <name> <image> sh -lc <cmd>]. Same typed
+   [docker run --rm --name <name> <image> <command_argv>]. Same typed
    contract as [exec]: either [Ok exec_result] (daemon present) or
    [Error Daemon_unreachable] (daemon / CLI missing). No other
    [sandbox_error] variant is semantically valid for [run]. *)

--- a/test/test_keeper_sandbox_oneshot_plan.ml
+++ b/test/test_keeper_sandbox_oneshot_plan.ml
@@ -9,14 +9,15 @@ open Masc_mcp
 
 let plan_error_pp ppf = function
   | Keeper_sandbox_oneshot_plan.Invalid_meta s -> Format.fprintf ppf "Invalid_meta %S" s
-  | Keeper_sandbox_oneshot_plan.Invalid_command s -> Format.fprintf ppf "Invalid_command %S" s
+  | Keeper_sandbox_oneshot_plan.Invalid_command argv ->
+    Format.fprintf ppf "Invalid_command [%s]" (String.concat "; " argv)
 
 let plan_error_eq a b =
   match a, b with
   | Keeper_sandbox_oneshot_plan.Invalid_meta x, Keeper_sandbox_oneshot_plan.Invalid_meta y ->
       String.equal x y
   | Keeper_sandbox_oneshot_plan.Invalid_command x, Keeper_sandbox_oneshot_plan.Invalid_command y ->
-      String.equal x y
+    List.equal String.equal x y
   | _ -> false
 
 let plan_t = testable Keeper_sandbox_oneshot_plan.pp Keeper_sandbox_oneshot_plan.equal
@@ -26,7 +27,11 @@ let plan_error_t = testable plan_error_pp plan_error_eq
 
 let test_empty_meta_rejected () =
   let res =
-    Keeper_sandbox_oneshot_plan.of_request ~turn_id:1 ~attempt:0 ~meta_name:"" ~cmd:"ls"
+    Keeper_sandbox_oneshot_plan.of_request
+      ~turn_id:1
+      ~attempt:0
+      ~meta_name:""
+      ~command_argv:[ "ls" ]
   in
   check
     (result plan_t plan_error_t)
@@ -36,19 +41,27 @@ let test_empty_meta_rejected () =
 
 let test_empty_cmd_rejected () =
   let res =
-    Keeper_sandbox_oneshot_plan.of_request ~turn_id:1 ~attempt:0 ~meta_name:"k" ~cmd:""
+    Keeper_sandbox_oneshot_plan.of_request
+      ~turn_id:1
+      ~attempt:0
+      ~meta_name:"k"
+      ~command_argv:[]
   in
   check
     (result plan_t plan_error_t)
     "empty cmd → Invalid_command"
-    (Error (Keeper_sandbox_oneshot_plan.Invalid_command ""))
+    (Error (Keeper_sandbox_oneshot_plan.Invalid_command []))
     res
 
 (* ── Payload semantics: error carries offending value (Phase 3b-iii contract) ── *)
 
 let test_invalid_meta_payload_is_offending () =
   let res =
-    Keeper_sandbox_oneshot_plan.of_request ~turn_id:1 ~attempt:0 ~meta_name:"" ~cmd:"x"
+    Keeper_sandbox_oneshot_plan.of_request
+      ~turn_id:1
+      ~attempt:0
+      ~meta_name:""
+      ~command_argv:[ "x" ]
   in
   match res with
   | Error (Keeper_sandbox_oneshot_plan.Invalid_meta payload) ->
@@ -57,18 +70,26 @@ let test_invalid_meta_payload_is_offending () =
 
 let test_invalid_command_payload_is_offending () =
   let res =
-    Keeper_sandbox_oneshot_plan.of_request ~turn_id:1 ~attempt:0 ~meta_name:"k" ~cmd:""
+    Keeper_sandbox_oneshot_plan.of_request
+      ~turn_id:1
+      ~attempt:0
+      ~meta_name:"k"
+      ~command_argv:[]
   in
   match res with
   | Error (Keeper_sandbox_oneshot_plan.Invalid_command payload) ->
-      check string "Invalid_command payload = offending cmd (\"\")" "" payload
+    check (list string) "Invalid_command payload = offending argv ([])" [] payload
   | _ -> fail "expected Invalid_command"
 
 (* ── Happy path: returns Ok with populated fields ─────────────── *)
 
 let test_happy_returns_ok () =
   let res =
-    Keeper_sandbox_oneshot_plan.of_request ~turn_id:5 ~attempt:0 ~meta_name:"alice" ~cmd:"echo hi"
+    Keeper_sandbox_oneshot_plan.of_request
+      ~turn_id:5
+      ~attempt:0
+      ~meta_name:"alice"
+      ~command_argv:[ "echo"; "hi" ]
   in
   match res with
   | Ok _ -> ()
@@ -76,7 +97,11 @@ let test_happy_returns_ok () =
 
 let happy_plan () =
   match
-    Keeper_sandbox_oneshot_plan.of_request ~turn_id:5 ~attempt:0 ~meta_name:"alice" ~cmd:"echo hi"
+    Keeper_sandbox_oneshot_plan.of_request
+      ~turn_id:5
+      ~attempt:0
+      ~meta_name:"alice"
+      ~command_argv:[ "echo"; "hi" ]
   with
   | Ok p -> p
   | Error _ -> failwith "test fixture: of_request returned Error"
@@ -86,9 +111,10 @@ let test_image_is_default () =
     Keeper_sandbox_oneshot_plan.default_image
     (Keeper_sandbox_oneshot_plan.image (happy_plan ()))
 
-let test_command_round_trip () =
-  check string "command = cmd arg" "echo hi"
-    (Keeper_sandbox_oneshot_plan.command (happy_plan ()))
+let test_command_argv_round_trip () =
+  check (list string) "command_argv = command_argv arg"
+    [ "echo"; "hi" ]
+    (Keeper_sandbox_oneshot_plan.command_argv (happy_plan ()))
 
 let test_timeout_default () =
   check (float 0.0) "timeout_budget_sec = default"
@@ -107,7 +133,11 @@ let test_determinism () =
 let test_container_name_matches_derive () =
   let plan =
     match
-      Keeper_sandbox_oneshot_plan.of_request ~turn_id:7 ~attempt:3 ~meta_name:"persona" ~cmd:"x"
+      Keeper_sandbox_oneshot_plan.of_request
+        ~turn_id:7
+        ~attempt:3
+        ~meta_name:"persona"
+        ~command_argv:[ "x" ]
     with
     | Ok p -> p
     | Error _ -> failwith "test fixture"
@@ -128,14 +158,22 @@ let test_container_name_matches_derive () =
 let test_distinct_turn () =
   let a =
     match
-      Keeper_sandbox_oneshot_plan.of_request ~turn_id:1 ~attempt:0 ~meta_name:"k" ~cmd:"x"
+      Keeper_sandbox_oneshot_plan.of_request
+        ~turn_id:1
+        ~attempt:0
+        ~meta_name:"k"
+        ~command_argv:[ "x" ]
     with
     | Ok p -> p
     | Error _ -> failwith "fix"
   in
   let b =
     match
-      Keeper_sandbox_oneshot_plan.of_request ~turn_id:2 ~attempt:0 ~meta_name:"k" ~cmd:"x"
+      Keeper_sandbox_oneshot_plan.of_request
+        ~turn_id:2
+        ~attempt:0
+        ~meta_name:"k"
+        ~command_argv:[ "x" ]
     with
     | Ok p -> p
     | Error _ -> failwith "fix"
@@ -148,11 +186,11 @@ let () =
       ( "validation",
         [
           test_case "empty meta rejected" `Quick test_empty_meta_rejected;
-          test_case "empty cmd rejected" `Quick test_empty_cmd_rejected;
+          test_case "empty command_argv rejected" `Quick test_empty_cmd_rejected;
           test_case "Invalid_meta payload = offending meta_name"
             `Quick
             test_invalid_meta_payload_is_offending;
-          test_case "Invalid_command payload = offending cmd"
+          test_case "Invalid_command payload = offending command_argv"
             `Quick
             test_invalid_command_payload_is_offending;
         ] );
@@ -160,7 +198,7 @@ let () =
         [
           test_case "of_request returns Ok" `Quick test_happy_returns_ok;
           test_case "image = default" `Quick test_image_is_default;
-          test_case "command round-trip" `Quick test_command_round_trip;
+          test_case "command_argv round-trip" `Quick test_command_argv_round_trip;
           test_case "timeout = default" `Quick test_timeout_default;
         ] );
       ("determinism", [ test_case "same inputs → same plan" `Quick test_determinism ]);

--- a/test/test_sandbox_executor.ml
+++ b/test/test_sandbox_executor.ml
@@ -18,7 +18,7 @@ let sample_plan ?(turn_id = 1) ?(meta_name = "alice") () =
       ~turn_id
       ~attempt:0
       ~meta_name
-      ~cmd:"echo hi"
+      ~command_argv:[ "echo"; "hi" ]
   with
   | Ok p -> p
   | Error _ -> failwith "test fixture"


### PR DESCRIPTION
## Summary
- change Keeper_sandbox_oneshot_plan from cmd:string to command_argv:string list
- remove the docker run sh -lc wrapper from Keeper_docker_client_real.run
- update oneshot plan, mock, real-client, and executor tests for argv-shaped commands

## Verification
- rebased onto current origin/main before push
- `opam exec -- ocamlformat --check lib/keeper/keeper_sandbox_oneshot_plan.mli lib/keeper/keeper_sandbox_oneshot_plan.ml lib/keeper/keeper_docker_client_real.ml lib/keeper/keeper_docker_client_real.mli test/test_keeper_sandbox_oneshot_plan.ml test/test_docker_client_real.ml test/test_docker_client_mock.ml test/test_sandbox_executor.ml`
- `git diff --check`
- `bash scripts/lint/shell-legacy-purge-ratchet.sh`
- `scripts/lint-spawn-bounded.sh`
- source guard: no oneshot of_request ~cmd / oneshot command accessor / docker run sh -lc remnants in touched surfaces

Focused Dune target check was attempted with `scripts/dune-local.sh build test/test_keeper_sandbox_oneshot_plan.exe test/test_docker_client_real.exe test/test_docker_client_mock.exe test/test_sandbox_executor.exe`, but the wrapper refused to start because other live bare `dune build` processes are bypassing the machine-wide Dune lock.