### PR TITLE
refactor(server_dashboard_http_core): extract operator_digest refresh-loop sibling

### DIFF
--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -219,70 +219,7 @@ let operator_digest_default_query = Server_dashboard_http_core_operator_query.op
 
 let start_operator_snapshot_refresh_loop = Server_dashboard_http_core_snapshot_refresh.start_operator_snapshot_refresh_loop
 
-let start_operator_digest_refresh_loop ~state ~sw ~clock =
-  let config = state.Mcp_server.room_config in
-  let proc_mgr = state.Mcp_server.proc_mgr in
-  let net, mono_clock = state_dashboard_runtime_caps state in
-  let compute () =
-    mark_cached_surface_attempt operator_digest_cache;
-    let started_at = Unix.gettimeofday () in
-    try
-      run_dashboard_compute
-        ~mode:Offloaded_readonly
-        ?net
-        ?mono_clock
-        ~sw
-        ~clock
-        ~config
-        (fun ~config ~sw ->
-           let ctx : _ Operator_control.context =
-             { config
-             ; agent_name = "dashboard"
-             ; sw
-             ; clock
-             ; proc_mgr
-             ; net = None
-             ; mcp_session_id = None
-             }
-           in
-           match
-             Operator_control.digest_json ~actor:"dashboard" ~target_type:"root" ctx
-           with
-           | Ok json ->
-             with_projection_diagnostics
-               ~surface:"operator_digest"
-               ~started_at
-               ~extra:(operator_snapshot_extra ())
-               json
-           | Error err ->
-             invalid_arg ("server_dashboard_http_core: operator digest failed: " ^ err))
-    with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | exn ->
-      mark_cached_surface_error operator_digest_cache exn;
-      raise exn
-  in
-  Proactive_refresh.start
-    ~sw
-    ~clock
-    ~config:
-      { (Proactive_refresh.default_config
-           ~label:"operator_digest"
-           ~interval_s:operator_refresh_interval_s)
-        with
-        timeout_s = operator_refresh_interval_s *. 0.8
-      ; on_error = Some (mark_cached_surface_error operator_digest_cache)
-      ; warm_delay_s = 150.0
-      }
-    ~compute
-    ~on_result:(fun json ->
-      mark_cached_surface_success operator_digest_cache json;
-      !operator_digest_broadcast_ref
-        (cached_surface_json operator_digest_cache
-         |> with_operator_digest_metadata
-              ~config
-              ~query:(operator_digest_default_query ())))
-;;
+let start_operator_digest_refresh_loop = Server_dashboard_http_core_digest_refresh.start_operator_digest_refresh_loop
 
 let operator_snapshot_http_json ~state ~sw ~clock request =
   let config = state.Mcp_server.room_config in

--- a/lib/server/server_dashboard_http_core_digest_refresh.ml
+++ b/lib/server/server_dashboard_http_core_digest_refresh.ml
@@ -1,0 +1,103 @@
+(** Operator-digest proactive refresh loop, extracted from
+    [server_dashboard_http_core.ml] (godfile decomp). Pairs with the
+    snapshot refresh sibling (#17358).
+
+    [start_operator_digest_refresh_loop] wires the cached
+    [operator_digest] surface into [Proactive_refresh.start] with the
+    dashboard runtime's offloaded-readonly compute path. Each cycle
+    invokes [Operator_control.digest_json ~actor:"dashboard"
+    ~target_type:"root"] under a fresh [Operator_control.context],
+    decorates the result with [with_projection_diagnostics] /
+    [with_operator_digest_metadata], and republishes via
+    [!operator_digest_broadcast_ref].
+
+    Pure helper move (no callback injection). All cross-module
+    references reach existing siblings or top-level libraries — no
+    sibling -> parent dependency.
+
+    The digest path differs from the snapshot path in two ways:
+    - [Operator_control.digest_json] returns [Result.t]; an [Error]
+      becomes [invalid_arg ...] inside the compute closure (preserves
+      the original behavior where Proactive_refresh sees an exception).
+    - [warm_delay_s = 150.0] (vs 120.0 for snapshot) — digest is
+      heavier and starts later so it does not race the snapshot's
+      first warm-up. *)
+
+include Server_dashboard_http_cache
+(* Constructors for [dashboard_compute_mode] (Inline_shared,
+   Offloaded_readonly) live in the runtime-support sibling.  Same
+   constructor-scope trap as the snapshot sibling (#17358): even
+   though the parent re-exports the type as a transparent alias, the
+   constructors are scoped to the defining module and need an [open]
+   here. *)
+open Server_dashboard_http_runtime_support
+
+module Core_runtime = Server_dashboard_http_core_runtime
+module Core_cache = Server_dashboard_http_core_cache
+module Core_operator = Server_dashboard_http_core_operator
+module Core_operator_query = Server_dashboard_http_core_operator_query
+
+let start_operator_digest_refresh_loop ~state ~sw ~clock =
+  let config = state.Mcp_server.room_config in
+  let proc_mgr = state.Mcp_server.proc_mgr in
+  let net, mono_clock = Core_runtime.state_dashboard_runtime_caps state in
+  let compute () =
+    mark_cached_surface_attempt Core_operator.operator_digest_cache;
+    let started_at = Unix.gettimeofday () in
+    try
+      Core_runtime.run_dashboard_compute
+        ~mode:Offloaded_readonly
+        ?net
+        ?mono_clock
+        ~sw
+        ~clock
+        ~config
+        (fun ~config ~sw ->
+           let ctx : _ Operator_control.context =
+             { config
+             ; agent_name = "dashboard"
+             ; sw
+             ; clock
+             ; proc_mgr
+             ; net = None
+             ; mcp_session_id = None
+             }
+           in
+           match
+             Operator_control.digest_json ~actor:"dashboard" ~target_type:"root" ctx
+           with
+           | Ok json ->
+             Core_cache.with_projection_diagnostics
+               ~surface:"operator_digest"
+               ~started_at
+               ~extra:(Core_operator.operator_snapshot_extra ())
+               json
+           | Error err ->
+             invalid_arg ("server_dashboard_http_core: operator digest failed: " ^ err))
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      mark_cached_surface_error Core_operator.operator_digest_cache exn;
+      raise exn
+  in
+  Proactive_refresh.start
+    ~sw
+    ~clock
+    ~config:
+      { (Proactive_refresh.default_config
+           ~label:"operator_digest"
+           ~interval_s:Core_operator.operator_refresh_interval_s)
+        with
+        timeout_s = Core_operator.operator_refresh_interval_s *. 0.8
+      ; on_error = Some (mark_cached_surface_error Core_operator.operator_digest_cache)
+      ; warm_delay_s = 150.0
+      }
+    ~compute
+    ~on_result:(fun json ->
+      mark_cached_surface_success Core_operator.operator_digest_cache json;
+      !Core_operator.operator_digest_broadcast_ref
+        (cached_surface_json Core_operator.operator_digest_cache
+         |> Core_operator_query.with_operator_digest_metadata
+              ~config
+              ~query:(Core_operator_query.operator_digest_default_query ())))
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane C
- Sibling extracted from `server_dashboard_http_core.ml` (after #17337 `runtime` cluster, #17358 `snapshot_refresh`).
- **Pairs with #17358** — completes the operator refresh-loop pair (snapshot + digest).

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/server/server_dashboard_http_core.ml` | 1346 | 1283 | **-63** |
| `lib/server/server_dashboard_http_core_digest_refresh.ml` | — | 103 | +103 |

## Moved (verbatim, no behavior change)
- `start_operator_digest_refresh_loop ~state ~sw ~clock` — proactive-refresh loop:
  - Reads `state.Mcp_server.{room_config, proc_mgr}`
  - Resolves `Net`/`mono_clock` caps via `state_dashboard_runtime_caps`
  - Defines a `compute ()` closure that:
    - `mark_cached_surface_attempt operator_digest_cache`
    - `run_dashboard_compute ~mode:Offloaded_readonly ...` with a fresh `Operator_control.context`
    - calls `Operator_control.digest_json ~actor:"dashboard" ~target_type:"root"` (returns `Result.t`)
    - on `Ok json` → decorates with `with_projection_diagnostics ~surface:"operator_digest"`
    - on `Error err` → `invalid_arg ("server_dashboard_http_core: operator digest failed: " ^ err)`
      (preserves the original failure contract — Proactive_refresh sees an exception)
    - on `Eio.Cancel.Cancelled` re-raises; on other `exn` marks error + re-raises
  - Wires to `Proactive_refresh.start` with:
    - `label = "operator_digest"`, `interval_s = operator_refresh_interval_s`
    - `timeout_s = interval_s * 0.8`
    - `on_error = Some (mark_cached_surface_error ...)`
    - `warm_delay_s = 150.0` (vs 120.0 for snapshot — digest is heavier, starts later)
  - `on_result` marks success + re-broadcasts via `!operator_digest_broadcast_ref` decorated with `with_operator_digest_metadata`

Parent retains a 1-line alias preserving the `.mli` surface.

## Parallels with #17358
| Aspect | Snapshot (#17358) | Digest (this PR) |
|---|---|---|
| Function name | `start_operator_snapshot_refresh_loop` | `start_operator_digest_refresh_loop` |
| Surface label | `operator_snapshot` | `operator_digest` |
| Cache cell | `operator_snapshot_cache` | `operator_digest_cache` |
| Broadcast ref | `operator_snapshot_broadcast_ref` | `operator_digest_broadcast_ref` |
| Metadata helper | `with_operator_snapshot_metadata` | `with_operator_digest_metadata` |
| Default query | `operator_snapshot_default_query` | `operator_digest_default_query` |
| Compute fn | `Operator_control.snapshot_json` (returns json) | `Operator_control.digest_json` (returns `Result.t`) |
| `warm_delay_s` | 120.0 | 150.0 |
| Profile log | yes (5s threshold) | no |

## External callers
- `lib/server/server_runtime_bootstrap.ml:1367` — `Server_dashboard_http.start_operator_digest_refresh_loop ~state ~sw ~clock`

## Sibling deps
- `include Server_dashboard_http_cache` — for `mark_cached_surface_{attempt,error,success}`, `cached_surface_json`
- `open Server_dashboard_http_runtime_support` — for `Offloaded_readonly` constructor
- Module aliases:
  - `Core_runtime = Server_dashboard_http_core_runtime` — `state_dashboard_runtime_caps`, `run_dashboard_compute`
  - `Core_cache = Server_dashboard_http_core_cache` — `with_projection_diagnostics`
  - `Core_operator = Server_dashboard_http_core_operator` — `operator_digest_{cache,broadcast_ref}`, `operator_snapshot_extra`, `operator_refresh_interval_s`
  - `Core_operator_query = Server_dashboard_http_core_operator_query` — `with_operator_digest_metadata`, `operator_digest_default_query`
- External: `Operator_control.{digest_json,context}`, `Proactive_refresh.{start,default_config}`, `Mcp_server.{room_config,proc_mgr,server_state}`, `Eio.Cancel.Cancelled`, `Unix.gettimeofday`

No sibling -> parent cycle.

## Local build status
- `dune build --root . lib/server/` → clean (exit 0)
- godfile lint: sibling 103 LOC under `new_file_cap=600`; parent 1283 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim single-function move, 1-line parent alias. Pairs with #17358.

Co-Authored-By: codex <noreply@anthropic.com>
