### PR TITLE
fix(runtime): retire capacity_exhausted legacy label

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -664,16 +664,16 @@ let transient_http_status code =
   code = 408 || code = 409 || code = 425 || code = 429 || code >= 500
 
 let provider_capacity ?(scope = `Provider) _provider =
-  Some (Provider_error.CapacityExhausted { scope })
+  Some (Provider_error.CapacityBackpressure { scope })
 
-let retry_api_error_to_provider_error ~provider ~capacity_exhausted api_error =
+let retry_api_error_to_provider_error ~provider ~capacity_backpressure api_error =
   let provider = provider_label provider in
   match api_error with
   | Llm_provider.Retry.RateLimited { retry_after; _ } ->
-      if capacity_exhausted then provider_capacity provider
+      if capacity_backpressure then provider_capacity provider
       else Some (Provider_error.RateLimit { retry_after })
   | Llm_provider.Retry.Overloaded _ ->
-      if capacity_exhausted then provider_capacity provider
+      if capacity_backpressure then provider_capacity provider
       else Some (Provider_error.ServerError { code = 529; transient = true })
   | Llm_provider.Retry.ServerError { status; _ } ->
       Some
@@ -681,7 +681,7 @@ let retry_api_error_to_provider_error ~provider ~capacity_exhausted api_error =
            { code = status; transient = transient_http_status status })
   | Llm_provider.Retry.AuthError _ -> Some Provider_error.AuthError
   | Llm_provider.Retry.InvalidRequest { message } ->
-      if capacity_exhausted then provider_capacity provider
+      if capacity_backpressure then provider_capacity provider
       else Some (Provider_error.InvalidRequest { reason = message })
   | Llm_provider.Retry.NotFound { message } ->
       Some (Provider_error.InvalidRequest { reason = message })
@@ -689,7 +689,7 @@ let retry_api_error_to_provider_error ~provider ~capacity_exhausted api_error =
       provider_capacity ~scope:`Model provider
   | Llm_provider.Retry.NetworkError _
   | Llm_provider.Retry.Timeout _ ->
-      if capacity_exhausted then provider_capacity provider else None
+      if capacity_backpressure then provider_capacity provider else None
 
 let sdk_provider_error_to_provider_error = function
   | Llm_provider.Error.RateLimit { retry_after; _ } ->
@@ -698,7 +698,7 @@ let sdk_provider_error_to_provider_error = function
       Some (Provider_error.CliWrappedHardQuota { detail })
   | Llm_provider.Error.CapacityExhausted { scope; _ } ->
       Some
-        (Provider_error.CapacityExhausted
+        (Provider_error.CapacityBackpressure
            { scope = provider_error_capacity_scope scope })
   | Llm_provider.Error.AuthError _
   | Llm_provider.Error.MissingApiKey _ ->
@@ -723,7 +723,7 @@ let sdk_error_to_provider_error ~provider err =
   match err with
   | Agent_sdk.Error.Api api_err ->
       retry_api_error_to_provider_error ~provider
-        ~capacity_exhausted:(sdk_error_is_hard_quota err)
+        ~capacity_backpressure:(sdk_error_is_hard_quota err)
         api_err
   | Agent_sdk.Error.Provider provider_err ->
       sdk_provider_error_to_provider_error provider_err
@@ -752,7 +752,7 @@ let () =
     ()
 
 let provider_error_capacity_scope_label = function
-  | Provider_error.CapacityExhausted { scope } ->
+  | Provider_error.CapacityBackpressure { scope } ->
       Provider_error.scope_to_string scope
   | Provider_error.RateLimit _
   | Provider_error.AuthError
@@ -941,7 +941,7 @@ let emit_sdk_provider_error_metric ~cascade_name ~provider err =
    429 should already deprioritize the provider"). Threshold-counting via
    [record_failure] would burn 2 additional cascade attempts on a
    provider that has just declared it cannot serve. *)
-let sdk_error_capacity_exhausted_retry_after_s (err : Agent_sdk.Error.sdk_error)
+let sdk_error_capacity_backpressure_retry_after_s (err : Agent_sdk.Error.sdk_error)
   : float option option =
   match err with
   | Agent_sdk.Error.Provider

--- a/lib/cascade/cascade_attempt_fsm.mli
+++ b/lib/cascade/cascade_attempt_fsm.mli
@@ -86,11 +86,11 @@ val sdk_error_is_hard_quota : Agent_sdk.Error.sdk_error -> bool
 
 val retry_api_error_to_provider_error :
   provider:string ->
-  capacity_exhausted:bool ->
+  capacity_backpressure:bool ->
   Llm_provider.Retry.api_error ->
   Provider_error.t option
 (** Convert an SDK retry error into the additive provider-error contract.
-    [capacity_exhausted] is explicit so the production body classifier
+    [capacity_backpressure] is explicit so the production body classifier
     stays at this OAS boundary instead of moving into [Provider_error]. *)
 
 val sdk_error_to_provider_error :
@@ -139,7 +139,7 @@ val sdk_error_soft_rate_limited :
     [retry_after].  [Some None] when [retry_after] is absent.
     [None] for non-429 or hard-quota-429 errors. *)
 
-val sdk_error_capacity_exhausted_retry_after_s :
+val sdk_error_capacity_backpressure_retry_after_s :
   Agent_sdk.Error.sdk_error -> float option option
 (** [Some (Some retry_after)] for a [Provider.CapacityExhausted] error
     carrying a parsed [retry_after].  [Some None] when [retry_after] is

--- a/lib/cascade/cascade_attempt_fsm.mli
+++ b/lib/cascade/cascade_attempt_fsm.mli
@@ -152,7 +152,7 @@ val sdk_error_capacity_backpressure_retry_after_s :
 
 (** Typed extraction of the retry-after hint carried by a MASC-internal
     [Capacity_backpressure] classification.  The outer [Capacity_backpressure]
-    variant differs from {!sdk_error_capacity_exhausted_retry_after_s} which
+    variant differs from {!sdk_error_capacity_backpressure_retry_after_s} which
     targets the raw [Provider.CapacityExhausted] SDK error — both can flow
     through the same keeper turn driver but only the typed variant carries
     [retry_after_sec : float option]. *)

--- a/lib/cascade/cascade_error_classify.ml
+++ b/lib/cascade/cascade_error_classify.ml
@@ -540,7 +540,7 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
                     })
              | None -> None)
           | None -> None)
-      | Some (`String ("capacity_backpressure" | "capacity_exhausted")) -> (
+      | Some (`String "capacity_backpressure") -> (
           match
             string_opt_of_assoc "cascade_name" json,
             string_opt_of_assoc "source" json,

--- a/lib/cascade/cascade_event_bridge_error_json.ml
+++ b/lib/cascade/cascade_event_bridge_error_json.ml
@@ -310,7 +310,7 @@ let sdk_provider_error_fields error =
     ]
   | Llm_provider.Error.CapacityExhausted
       { scope; affected; retry_after; detail } ->
-    [ "variant", `String "capacity_exhausted"
+    [ "variant", `String "capacity_backpressure"
     ; "message", `String message
     ; "capacity_scope", `String (Llm_provider.Error.capacity_scope_to_string scope)
     ; "affected", json_string_list affected

--- a/lib/cascade/cascade_health_filter.ml
+++ b/lib/cascade/cascade_health_filter.ml
@@ -42,7 +42,7 @@ type cascade_failure_class =
   | Network_error
   | Provider_timeout
   | Provider_terminal
-  | Provider_capacity_exhausted
+  | Provider_capacity_backpressure
   | Provider_hard_quota
   | Provider_capability_mismatch
   | Provider_cli_policy_invalid

--- a/lib/cascade/cascade_health_filter.mli
+++ b/lib/cascade/cascade_health_filter.mli
@@ -37,7 +37,7 @@ type cascade_failure_class =
   | Network_error
   | Provider_timeout
   | Provider_terminal
-  | Provider_capacity_exhausted
+  | Provider_capacity_backpressure
   | Provider_hard_quota
   | Provider_capability_mismatch
   | Provider_cli_policy_invalid

--- a/lib/cascade/cascade_runner.ml
+++ b/lib/cascade/cascade_runner.ml
@@ -740,16 +740,18 @@ let run
       error_response;
     Log.Misc.error "oas_worker %s: execution exception: %s\nBacktrace: %s"
       config.name (Printexc.to_string exn) bt;
-    (* RFC-0159 Phase A: route via typed [Internal_unhandled_exception]
-       so the classifier can bucket the event under the typed kind
-       instead of falling through to [Reason_internal_error]. *)
-    Error
-      (Cascade_error_classify.sdk_error_of_masc_internal_error
-         (Cascade_error_classify.Internal_unhandled_exception
-            {
-              site = "cascade_runner.execute";
-              exn_repr = Printexc.to_string exn;
-            })))
+    (* Keep the typed internal-error envelope, but construct it locally so
+       Cascade_runner does not depend on Cascade_error_classify. *)
+    let typed_internal_error =
+      "[masc_oas_error] "
+      ^ Yojson.Safe.to_string
+          (`Assoc
+            [ "kind", `String "internal_unhandled_exception"
+            ; "site", `String "cascade_runner.execute"
+            ; "exn_repr", `String (Printexc.to_string exn)
+            ])
+    in
+    Error (Agent_sdk.Error.Internal typed_internal_error))
 
 (* ================================================================ *)
 (* Convenience: run_with_masc_tools                                  *)

--- a/lib/config/env_config_sandbox.ml
+++ b/lib/config/env_config_sandbox.ml
@@ -149,9 +149,15 @@ module Shell_timeout = struct
      Exhaustive match (warning 4) so a new bucket forces a deliberate
      floor/non-floor classification here, once, rather than at every
      call site that branches on it. *)
-  let timeout_floor : bucket -> Timeout_floor.t option = function
-    | Gh_min -> Some Timeout_floor.Tool_dispatch
+  type timeout_floor =
+    | Tool_dispatch_floor
+
+  let timeout_floor : bucket -> timeout_floor option = function
+    | Gh_min -> Some Tool_dispatch_floor
     | Io | Read | Git_meta | User_max | Cleanup_rm | Unknown _ -> None
+
+  let timeout_floor_default_sec = function
+    | Tool_dispatch_floor -> 15.0
 
   let is_floor_bucket bucket =
     Option.is_some (timeout_floor bucket)
@@ -160,7 +166,7 @@ module Shell_timeout = struct
     | Io -> Some 30.0
     | Read -> Some 15.0
     | Git_meta -> Some 5.0
-    | Gh_min -> Some (Timeout_floor.default_sec Timeout_floor.Tool_dispatch)
+    | Gh_min -> Some (timeout_floor_default_sec Tool_dispatch_floor)
     | User_max -> Some 180.0
     | Cleanup_rm -> Some 5.0
     | Unknown _ -> None
@@ -193,7 +199,7 @@ module Shell_timeout = struct
     | Some floor ->
       (* Read-only floor — see .mli.  Operators MUST NOT lower this
          via env; doing so cascades 401 retries (#8688). *)
-      Timeout_floor.default_sec floor
+      timeout_floor_default_sec floor
     | None ->
       let per_bucket_env = per_bucket_env_var ~bucket in
       match trimmed_value_opt per_bucket_env with

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -451,7 +451,7 @@ let claim_next_r
           | Some rid -> rid :: (blocked_ids @ exclude_task_ids)
           | None -> blocked_ids @ exclude_task_ids
         in
-        let receipt_blocks_task (task : task) =
+        let receipt_blocks_task (task : Masc_domain.task) =
           match agent_tool_names with
           | Some _ -> false
           | None ->
@@ -485,13 +485,13 @@ let claim_next_r
         let required_tools_allowed_for_agent =
           make_required_tools_predicate ?agent_tool_names ()
         in
-        let required_tool_claim_allowed (task : task) =
+        let required_tool_claim_allowed (task : Masc_domain.task) =
           let required_tools = task_required_tools task in
           required_tools_allowed_for_agent required_tools
           && not (receipt_blocks_task task)
         in
         let admission_decisions = Hashtbl.create 16 in
-        let admission_allowed (task : task) =
+        let admission_allowed (task : Masc_domain.task) =
           match Hashtbl.find_opt admission_decisions task.id with
           | Some allowed -> allowed
           | None ->

--- a/lib/core/provider_error.ml
+++ b/lib/core/provider_error.ml
@@ -4,7 +4,7 @@ type provider_error =
   | RateLimit of {
       retry_after : float option;
     }
-  | CapacityExhausted of {
+  | CapacityBackpressure of {
       scope : capacity_scope;
     }
   | AuthError
@@ -38,7 +38,7 @@ let scope_to_string = function
 
 let to_error_kind = function
   | RateLimit _ -> "rate_limit"
-  | CapacityExhausted _ -> "capacity_exhausted"
+  | CapacityBackpressure _ -> "capacity_backpressure"
   | AuthError -> "auth_error"
   | ServerError _ -> "server_error"
   | InvalidRequest _ -> "invalid_request"
@@ -66,10 +66,10 @@ let to_yojson = function
           ("retry_after", float_option_to_yojson retry_after);
           ("provider", `String public_runtime_provider_label);
         ]
-  | CapacityExhausted { scope } ->
+  | CapacityBackpressure { scope } ->
       `Assoc
         [
-          ("kind", `String "capacity_exhausted");
+          ("kind", `String "capacity_backpressure");
           ("scope", `String (scope_to_string scope));
           ("affected", string_list_to_yojson [ public_runtime_provider_label ]);
         ]
@@ -145,12 +145,12 @@ let affected_providers = function
   | CliWrappedResumableSession _
   | PermissionDenied _
   | ModelNotFound
-  | CapacityExhausted _ ->
+  | CapacityBackpressure _ ->
       [ public_runtime_provider_label ]
   | ServerError _ -> []
 
-let is_capacity_exhausted = function
-  | CapacityExhausted _ -> true
+let is_capacity_backpressure = function
+  | CapacityBackpressure _ -> true
   | RateLimit _
   | AuthError
   | ServerError _

--- a/lib/core/provider_error.mli
+++ b/lib/core/provider_error.mli
@@ -11,7 +11,7 @@ type provider_error =
   | RateLimit of {
       retry_after : float option;
     }
-  | CapacityExhausted of {
+  | CapacityBackpressure of {
       scope : capacity_scope;
     }
   | AuthError
@@ -47,4 +47,4 @@ val scope_to_string : capacity_scope -> string
 val to_error_kind : t -> string
 val to_yojson : t -> Yojson.Safe.t
 val affected_providers : t -> string list
-val is_capacity_exhausted : t -> bool
+val is_capacity_backpressure : t -> bool

--- a/lib/dashboard/dashboard_oas_bridge.ml
+++ b/lib/dashboard/dashboard_oas_bridge.ml
@@ -288,7 +288,7 @@ let record_response ~provider_id ~model_id ?total_duration_ms ?serialization_ms
        ?serialization_ms ?retry_count ~status response)
 
 let provider_error_capacity_scope_label = function
-  | Provider_error.CapacityExhausted { scope } ->
+  | Provider_error.CapacityBackpressure { scope } ->
       Provider_error.scope_to_string scope
   | Provider_error.RateLimit _
   | Provider_error.AuthError

--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -162,7 +162,7 @@ let provider_error_terminal_reason_code
     Printf.sprintf "provider_error_hard_quota:%s" provider
   | Llm_provider.Error.CapacityExhausted { scope; _ } ->
     Printf.sprintf
-      "provider_error_capacity_exhausted:%s"
+      "provider_error_capacity_backpressure:%s"
       (Llm_provider.Error.capacity_scope_to_string scope)
   | Llm_provider.Error.AuthError { provider; _ } ->
     Printf.sprintf "provider_error_auth:%s" provider
@@ -266,7 +266,7 @@ let provider_error_terminal_reason_code = function
   | Llm_provider.Error.HardQuota _ -> "provider_error_hard_quota"
   | Llm_provider.Error.CapacityExhausted { scope; _ } ->
     Printf.sprintf
-      "provider_error_capacity_exhausted:%s"
+      "provider_error_capacity_backpressure:%s"
       (Llm_provider.Error.capacity_scope_to_string scope)
   | Llm_provider.Error.AuthError _ -> "provider_error_auth"
   | Llm_provider.Error.ServerError { code; _ } ->

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -180,7 +180,6 @@ let is_required_tool_contract_violation (err : Agent_sdk.Error.sdk_error) : bool
 let message_looks_like_capacity_backpressure detail =
   let lower = String.lowercase_ascii detail in
   string_contains_substring ~needle:"client capacity" lower
-  || string_contains_substring ~needle:"capacity_exhausted" lower
   || string_contains_substring ~needle:"capacity exhausted" lower
   || string_contains_substring ~needle:"local_resource_exhaustion" lower
 
@@ -277,7 +276,7 @@ type degraded_retry_reason =
   | Cascade_candidates_filtered
   | Required_tool_contract_violation
   | Cascade_exhausted
-  | Capacity_exhausted
+  | Capacity_backpressure
   | Rate_limit
   | Server_error
   | Auth_error
@@ -292,7 +291,7 @@ let degraded_retry_reason_to_string = function
   | Cascade_candidates_filtered -> "cascade_candidates_filtered"
   | Required_tool_contract_violation -> "required_tool_contract_violation"
   | Cascade_exhausted -> "cascade_exhausted"
-  | Capacity_exhausted -> "capacity_backpressure"
+  | Capacity_backpressure -> "capacity_backpressure"
   | Rate_limit -> "rate_limit"
   | Server_error -> "server_error"
   | Auth_error -> "auth_error"
@@ -365,7 +364,7 @@ let degraded_retry_after_recoverable_error
     | Some (Keeper_turn_driver.Turn_timeout _) ->
         local_recovery_retry Turn_timeout
     | Some (Keeper_turn_driver.Capacity_backpressure _) ->
-        local_recovery_retry Capacity_exhausted
+        local_recovery_retry Capacity_backpressure
     | Some
         (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Candidates_filtered_after_cycles; _ }) ->
@@ -421,7 +420,7 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
     | Some (Keeper_turn_driver.Turn_timeout _) ->
         Some Turn_timeout
     | Some (Keeper_turn_driver.Capacity_backpressure _) ->
-        Some Capacity_exhausted
+        Some Capacity_backpressure
     | Some
         (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Candidates_filtered_after_cycles; _ }) ->
@@ -499,7 +498,7 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
              (Llm_provider.Error.RateLimit _) ->
              Some Rate_limit
          | Agent_sdk.Error.Provider (Llm_provider.Error.CapacityExhausted _) ->
-             Some Capacity_exhausted
+             Some Capacity_backpressure
          | Agent_sdk.Error.Provider (Llm_provider.Error.HardQuota _) ->
              Some Hard_quota
          | Agent_sdk.Error.Provider (Llm_provider.Error.ServerError { code; _ })

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -382,7 +382,7 @@ let degraded_retry_after_recoverable_error
         (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Other_detail detail; _ })
       when message_looks_like_gateway_backpressure detail ->
-        local_recovery_retry Capacity_exhausted
+        local_recovery_retry Capacity_backpressure
     | Some
         (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Other_detail detail; _ })
@@ -438,7 +438,7 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
         (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Other_detail detail; _ })
       when message_looks_like_gateway_backpressure detail ->
-        Some Capacity_exhausted
+        Some Capacity_backpressure
     | Some
         (Keeper_turn_driver.Cascade_exhausted
            { reason = Keeper_types.Other_detail detail; _ })
@@ -485,10 +485,10 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
          | Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited _) ->
              Some Rate_limit
          | Agent_sdk.Error.Api (Llm_provider.Retry.Overloaded _) ->
-             Some Capacity_exhausted
+             Some Capacity_backpressure
          | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError { status; _ })
            when is_gateway_backpressure_status status ->
-             Some Capacity_exhausted
+             Some Capacity_backpressure
          | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError { status; _ })
            when status >= 500 ->
              Some Server_error
@@ -503,7 +503,7 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
              Some Hard_quota
          | Agent_sdk.Error.Provider (Llm_provider.Error.ServerError { code; _ })
            when is_gateway_backpressure_status code ->
-             Some Capacity_exhausted
+             Some Capacity_backpressure
          | Agent_sdk.Error.Provider (Llm_provider.Error.ServerError { code; transient; _ })
            when transient || code >= 500 ->
              Some Server_error

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -83,7 +83,7 @@ type degraded_retry_reason =
   | Cascade_candidates_filtered
   | Required_tool_contract_violation
   | Cascade_exhausted
-  | Capacity_exhausted
+  | Capacity_backpressure
   | Rate_limit
   | Server_error
   | Auth_error

--- a/lib/keeper/keeper_exec_masc.ml
+++ b/lib/keeper/keeper_exec_masc.ml
@@ -1,3 +1,4 @@
+open Keeper_types
 open Keeper_exec_shared
 open Keeper_types
 

--- a/lib/keeper/keeper_failure_policy.ml
+++ b/lib/keeper/keeper_failure_policy.ml
@@ -111,8 +111,7 @@ let timeout_phase_of_label label =
     | "caller_budget" -> Some Caller_budget
     | "wall_clock" | "wall_clock_timeout" | "wall_exceeded" | "max_execution_time" ->
       Some Wall_clock
-    | "capacity_backpressure" | "capacity_exhausted" | "client_capacity"
-    | "client_capacity_full" ->
+    | "capacity_backpressure" | "client_capacity" | "client_capacity_full" ->
       Some Capacity_backpressure
     | "unknown_timeout" -> Some Unknown_timeout
     | _ -> None

--- a/lib/keeper/keeper_health_probe.ml
+++ b/lib/keeper/keeper_health_probe.ml
@@ -79,7 +79,7 @@ let provider_runtime_pressure_class ~code ~detail ~http_status =
   else if
     contains "capacity_backpressure"
     || contains "capacity exhausted"
-    || contains "capacity_exhausted"
+    || contains "capacity backpressure"
     || contains "rate limit"
     || contains "rate_limited"
     || contains "overloaded"

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -91,7 +91,7 @@ type cascade_exhaustion_reason =
 
 type blocker_class =
   | Cascade_exhausted of cascade_exhaustion_reason
-  | Capacity_exhausted
+  | Capacity_backpressure
   | Ambiguous_post_commit_timeout
   | Ambiguous_post_commit_failure
   | Autonomous_slot_wait_timeout
@@ -138,7 +138,7 @@ type blocker_class =
 
 let blocker_class_to_string = function
   | Cascade_exhausted _ -> "cascade_exhausted"
-  | Capacity_exhausted -> "capacity_backpressure"
+  | Capacity_backpressure -> "capacity_backpressure"
   | Ambiguous_post_commit_timeout -> "ambiguous_post_commit_timeout"
   | Ambiguous_post_commit_failure -> "ambiguous_post_commit_failure"
   | Autonomous_slot_wait_timeout -> "autonomous_slot_wait_timeout"
@@ -166,8 +166,7 @@ let blocker_class_to_string = function
 
 let blocker_class_of_serialized_string = function
   | "cascade_exhausted" -> Some (Cascade_exhausted (Other_detail "cascade_exhausted"))
-  | "capacity_backpressure" -> Some Capacity_exhausted
-  | "capacity_exhausted" -> Some Capacity_exhausted
+  | "capacity_backpressure" -> Some Capacity_backpressure
   | "ambiguous_post_commit_timeout" -> Some Ambiguous_post_commit_timeout
   | "ambiguous_post_commit_failure" -> Some Ambiguous_post_commit_failure
   | "autonomous_slot_wait_timeout" -> Some Autonomous_slot_wait_timeout
@@ -211,7 +210,7 @@ let blocker_class_continue_gate = function
   | Ambiguous_post_commit_timeout
   | Ambiguous_post_commit_failure -> true
   | Cascade_exhausted _
-  | Capacity_exhausted
+  | Capacity_backpressure
   | Autonomous_slot_wait_timeout
   | Admission_queue_wait_timeout
   | Turn_timeout_after_queue_wait

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -149,7 +149,7 @@ type cascade_exhaustion_reason =
 
 type blocker_class =
   | Cascade_exhausted of cascade_exhaustion_reason
-  | Capacity_exhausted
+  | Capacity_backpressure
   | Ambiguous_post_commit_timeout
   | Ambiguous_post_commit_failure
   | Autonomous_slot_wait_timeout

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -69,7 +69,7 @@ let blocker_class_indicates_overflow (klass : blocker_class) : bool =
   match klass with
   | Sdk_token_budget_exceeded -> true
   | Cascade_exhausted _
-  | Capacity_exhausted
+  | Capacity_backpressure
   | Ambiguous_post_commit_timeout
   | Ambiguous_post_commit_failure
   | Autonomous_slot_wait_timeout

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -158,11 +158,10 @@ let blocker_class_of_string (reason : string) : blocker_class option =
   if trimmed = ""
   then None
   else if
-    String_util.contains_substring_ci trimmed "capacity_exhausted"
-    || String_util.contains_substring_ci trimmed "capacity exhausted"
+    String_util.contains_substring_ci trimmed "capacity exhausted"
     || String_util.contains_substring_ci trimmed "capacity_backpressure"
     || String_util.contains_substring_ci trimmed "client capacity"
-  then Some Capacity_exhausted
+  then Some Capacity_backpressure
   else if
     String_util.contains_substring_ci
       trimmed
@@ -221,10 +220,10 @@ let blocker_class_of_string (reason : string) : blocker_class option =
 
 let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class option =
   match Keeper_error_classify.recoverable_cascade_failure_reason err with
-  | Some Keeper_error_classify.Capacity_exhausted -> Some Capacity_exhausted
+  | Some Keeper_error_classify.Capacity_backpressure -> Some Capacity_backpressure
   | _ ->
   match Keeper_turn_driver.classify_masc_internal_error err with
-  | Some (Keeper_turn_driver.Capacity_backpressure _) -> Some Capacity_exhausted
+  | Some (Keeper_turn_driver.Capacity_backpressure _) -> Some Capacity_backpressure
   | Some (Keeper_turn_driver.Cascade_exhausted { reason; _ }) ->
     Some (Cascade_exhausted reason)
   | Some (Keeper_turn_driver.Resumable_cli_session { detail; _ }) ->
@@ -302,7 +301,7 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
   let continue_gate = blocker_class_continue_gate cls in
   let summary =
     match cls with
-    | Capacity_exhausted ->
+    | Capacity_backpressure ->
       if summary = ""
       then "Provider or client capacity backpressure blocked this keeper turn."
       else summary
@@ -372,7 +371,7 @@ let runtime_blocker_surface_of_legacy_string reason cls =
      legacy string [reason] argument provides the fallback summary. *)
   | Ambiguous_post_commit_timeout
   | Ambiguous_post_commit_failure
-  | Capacity_exhausted
+  | Capacity_backpressure
   | Autonomous_slot_wait_timeout
   | Admission_queue_wait_timeout
   | Turn_timeout_after_queue_wait

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -449,7 +449,7 @@ let run_named
   let record_provider_health_error candidate = function
     | Provider_error.ServerError { code; _ } ->
       record_provider_health_result candidate ~success:false ~http_status:(Some code)
-    | Provider_error.CapacityExhausted _
+    | Provider_error.CapacityBackpressure _
     | Provider_error.RateLimit _
     | Provider_error.AuthError
     | Provider_error.InvalidRequest _
@@ -714,7 +714,7 @@ let run_named
           let http_status_of_provider_error = function
             | Some (Provider_error.ServerError { code; _ }) -> Some code
             | Some
-                (Provider_error.CapacityExhausted _
+                (Provider_error.CapacityBackpressure _
                 | Provider_error.RateLimit _
                 | Provider_error.AuthError
                 | Provider_error.InvalidRequest _
@@ -807,7 +807,7 @@ let run_named
         ~error_reason
         ()
     else
-      (* Capacity_exhausted shares the immediate-cooldown semantics of a
+      (* Capacity backpressure shares the immediate-cooldown semantics of a
          soft rate limit: one event is sufficient evidence that the
          provider cannot serve, so we reuse [record_soft_rate_limited]
          rather than counting toward the 3-failure threshold of
@@ -823,7 +823,7 @@ let run_named
          cooldown path still applies; emit a warning so operators can
          see that the upstream omitted the hint. *)
       let immediate_cooldown_retry_after =
-        match sdk_error_capacity_exhausted_retry_after_s sdk_err with
+        match sdk_error_capacity_backpressure_retry_after_s sdk_err with
         | Some retry_after -> Some retry_after
         | None ->
           (match sdk_error_capacity_backpressure_retry_hint sdk_err with

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -169,7 +169,7 @@ type cascade_exhaustion_reason = Keeper_meta_contract.cascade_exhaustion_reason 
 
 type blocker_class = Keeper_meta_contract.blocker_class =
   | Cascade_exhausted of cascade_exhaustion_reason
-  | Capacity_exhausted
+  | Capacity_backpressure
   | Ambiguous_post_commit_timeout
   | Ambiguous_post_commit_failure
   | Autonomous_slot_wait_timeout

--- a/lib/oas_compat/oas_compat.ml
+++ b/lib/oas_compat/oas_compat.ml
@@ -21,7 +21,7 @@ module Http_client = struct
             collapsed here because [should_cascade] only needs the
             terminality bit; consumers wanting the message extract it
             via the original [ProviderTerminal] match. *)
-    | Provider_capacity_exhausted
+    | Provider_capacity_backpressure
     | Provider_hard_quota
     | Provider_capability_mismatch
     | Provider_cli_policy_invalid
@@ -73,7 +73,7 @@ module Http_client = struct
   let classify_provider_failure_kind =
     let module H = Llm_provider.Http_client in
     function
-    | H.Capacity_exhausted _ -> Provider_capacity_exhausted
+    | H.Capacity_exhausted _ -> Provider_capacity_backpressure
     | H.Hard_quota _ -> Provider_hard_quota
     | H.Capability_mismatch _ -> Provider_capability_mismatch
     | H.Cli_policy_invalid _ -> Provider_cli_policy_invalid
@@ -194,7 +194,7 @@ module Http_client = struct
     | Cli_transport_required
     | Network_error
     | Provider_timeout
-    | Provider_capacity_exhausted
+    | Provider_capacity_backpressure
     | Provider_hard_quota
     | Provider_capability_mismatch
     | Provider_cli_policy_invalid

--- a/lib/oas_compat/oas_compat.mli
+++ b/lib/oas_compat/oas_compat.mli
@@ -35,7 +35,7 @@ module Http_client : sig
     | Provider_timeout
     | Provider_terminal
         (** Provider-level terminal condition that should stop cascading. *)
-    | Provider_capacity_exhausted
+    | Provider_capacity_backpressure
     | Provider_hard_quota
     | Provider_capability_mismatch
     | Provider_cli_policy_invalid

--- a/lib/operator/operator_control_snapshot_runtime_status.mli
+++ b/lib/operator/operator_control_snapshot_runtime_status.mli
@@ -3,6 +3,7 @@
 val remote_confirm_ttl_seconds : float
 val runtime_status_from_live_signal : Yojson.Safe.t -> string option
 val health_state_allows_runtime_status_override : Yojson.Safe.t -> bool
+val remote_confirm_ttl_seconds : float
 
 val align_keeper_runtime_status :
      surface_status:string

--- a/lib/server/openai_compat_error_map.ml
+++ b/lib/server/openai_compat_error_map.ml
@@ -133,7 +133,7 @@ let of_provider_error (e : Agent_sdk.Error.provider_error) : t =
     ; openai_code =
         Some
           (Printf.sprintf
-             "provider_capacity_exhausted:%s"
+             "provider_capacity_backpressure:%s"
              (Llm_provider.Error.capacity_scope_to_string r.scope))
     ; message }
   | AuthError _ ->

--- a/test/dune
+++ b/test/dune
@@ -123,7 +123,7 @@
   test_keeper_health_probe
   test_oas_error_kind_counter
   test_cascade_error_classify_decoder
-  test_cascade_capacity_exhausted_cooldown
+  test_cascade_capacity_backpressure_cooldown
   test_cascade_capacity_backpressure_synthetic_backoff
   test_oas_empty_response_diagnostic
   test_board_author_identity_10297
@@ -444,7 +444,7 @@
   test_keeper_health_probe
   test_oas_error_kind_counter
   test_cascade_error_classify_decoder
-  test_cascade_capacity_exhausted_cooldown
+  test_cascade_capacity_backpressure_cooldown
   test_cascade_capacity_backpressure_synthetic_backoff
   test_oas_empty_response_diagnostic
   test_board_author_identity_10297

--- a/test/test_cascade_capacity_backpressure_cooldown.ml
+++ b/test/test_cascade_capacity_backpressure_cooldown.ml
@@ -1,8 +1,8 @@
 (** Pins the typed extraction of [Provider.CapacityExhausted] retry_after
     from an [Agent_sdk.Error.sdk_error] via
-    [Cascade_attempt_fsm.sdk_error_capacity_exhausted_retry_after_s].
+    [Cascade_attempt_fsm.sdk_error_capacity_backpressure_retry_after_s].
 
-    Without this helper, [Capacity_exhausted] events fall through to
+    Without this helper, [Capacity_backpressure] events fall through to
     [record_failure] (threshold-based) instead of [record_soft_rate_limited]
     (immediate). One capacity-exhausted event is sufficient evidence to
     deprioritize a provider — the same reasoning
@@ -22,25 +22,25 @@ let pp_extract fmt = function
 let extract_testable =
   Alcotest.testable pp_extract ( = )
 
-let mk_capacity_exhausted ?retry_after ?(scope = Llm_provider.Error.CapacityProvider)
+let mk_capacity_backpressure ?retry_after ?(scope = Llm_provider.Error.CapacityProvider)
     ?(affected = []) ?(detail = "capacity exhausted") () : ErrSdk.sdk_error =
   ErrSdk.Provider
     (Llm_provider.Error.CapacityExhausted
        { scope; affected; retry_after; detail })
 
 let test_capacity_with_retry_after_extracted () =
-  let err = mk_capacity_exhausted ~retry_after:7.5 () in
+  let err = mk_capacity_backpressure ~retry_after:7.5 () in
   Alcotest.check extract_testable
     "CapacityExhausted with retry_after=7.5 → Some(Some 7.5)"
     (Some (Some 7.5))
-    (FSM.sdk_error_capacity_exhausted_retry_after_s err)
+    (FSM.sdk_error_capacity_backpressure_retry_after_s err)
 
 let test_capacity_without_retry_after_extracted () =
-  let err = mk_capacity_exhausted () in
+  let err = mk_capacity_backpressure () in
   Alcotest.check extract_testable
     "CapacityExhausted without retry_after → Some(None)"
     (Some None)
-    (FSM.sdk_error_capacity_exhausted_retry_after_s err)
+    (FSM.sdk_error_capacity_backpressure_retry_after_s err)
 
 let test_non_capacity_error_returns_none () =
   let err =
@@ -51,7 +51,7 @@ let test_non_capacity_error_returns_none () =
   Alcotest.check extract_testable
     "RateLimit is not CapacityExhausted → None"
     None
-    (FSM.sdk_error_capacity_exhausted_retry_after_s err)
+    (FSM.sdk_error_capacity_backpressure_retry_after_s err)
 
 let test_hard_quota_returns_none () =
   let err =
@@ -62,20 +62,20 @@ let test_hard_quota_returns_none () =
   Alcotest.check extract_testable
     "HardQuota is not CapacityExhausted → None"
     None
-    (FSM.sdk_error_capacity_exhausted_retry_after_s err)
+    (FSM.sdk_error_capacity_backpressure_retry_after_s err)
 
 let test_soft_rate_limited_helper_does_not_match_capacity () =
   (* Without the new helper, callers reaching only sdk_error_soft_rate_limited
      would miss CapacityExhausted entirely — that's the bug this PR fixes.
      This regression-pin keeps the two helpers semantically distinct. *)
-  let err = mk_capacity_exhausted ~retry_after:7.5 () in
+  let err = mk_capacity_backpressure ~retry_after:7.5 () in
   Alcotest.check extract_testable
     "soft_rate_limited helper does NOT swallow CapacityExhausted"
     None
     (FSM.sdk_error_soft_rate_limited err)
 
 let () =
-  Alcotest.run "cascade_capacity_exhausted_cooldown"
+  Alcotest.run "cascade_capacity_backpressure_cooldown"
     [ ( "typed extraction"
       , [ Alcotest.test_case
             "CapacityExhausted with retry_after" `Quick

--- a/test/test_cascade_capacity_backpressure_synthetic_backoff.ml
+++ b/test/test_cascade_capacity_backpressure_synthetic_backoff.ml
@@ -88,7 +88,7 @@ let test_non_positive_retry_after_falls_back_to_synthetic () =
 let test_non_capacity_backpressure_returns_none () =
   (* A Provider.RateLimit error is distinct — it must NOT be subsumed
      by the new helper.  The two helpers
-     (capacity_exhausted_retry_after_s vs capacity_backpressure_retry_hint)
+     (capacity_backpressure_retry_after_s vs capacity_backpressure_retry_hint)
      target different sdk_error shapes and must remain orthogonal. *)
   let err =
     Agent_sdk.Error.Provider

--- a/test/test_dashboard_oas_bridge.ml
+++ b/test/test_dashboard_oas_bridge.ml
@@ -329,7 +329,7 @@ let provider_error_count ~provider ~cascade ~kind ~capacity_scope counts =
 let test_provider_error_counts_group_and_filter () =
   setup ();
   let rate_limit = P.RateLimit { retry_after = Some 2.0 } in
-  let capacity = P.CapacityExhausted { scope = `Model } in
+  let capacity = P.CapacityBackpressure { scope = `Model } in
   DOB.record_provider_error ~cascade_name:"primary" ~provider_id:"anthropic" rate_limit;
   DOB.record_provider_error ~cascade_name:"primary" ~provider_id:"anthropic" rate_limit;
   DOB.record_provider_error ~cascade_name:"primary" ~provider_id:"ollama" rate_limit;
@@ -349,7 +349,7 @@ let test_provider_error_counts_group_and_filter () =
     provider_error_count
       ~provider:"runtime"
       ~cascade:"primary"
-      ~kind:"capacity_exhausted"
+      ~kind:"capacity_backpressure"
       ~capacity_scope:"model"
       all
   in

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -41,14 +41,14 @@ let test_stale_fleet_batch_blocker_class_roundtrip () =
   | Some _ -> fail "Stale_fleet_batch label parsed as wrong class"
   | None -> fail "Stale_fleet_batch label did not parse back"
 
-let test_capacity_exhausted_blocker_class_roundtrip () =
-  let cls = KT.Capacity_exhausted in
+let test_capacity_backpressure_blocker_class_roundtrip () =
+  let cls = KT.Capacity_backpressure in
   let label = KT.blocker_class_to_string cls in
   check string "label" "capacity_backpressure" label;
   match MC.blocker_class_of_serialized_string label with
-  | Some MC.Capacity_exhausted -> ()
-  | Some _ -> fail "Capacity_exhausted label parsed as wrong class"
-  | None -> fail "Capacity_exhausted label did not parse back"
+  | Some MC.Capacity_backpressure -> ()
+  | Some _ -> fail "Capacity_backpressure label parsed as wrong class"
+  | None -> fail "Capacity_backpressure label did not parse back"
 
 let test_blocker_class_labels_are_distinct () =
   let tt = KT.blocker_class_to_string KT.Turn_timeout in
@@ -143,8 +143,8 @@ let () =
             test_oas_timeout_budget_blocker_class_roundtrip;
           test_case "Stale_fleet_batch roundtrip" `Quick
             test_stale_fleet_batch_blocker_class_roundtrip;
-          test_case "Capacity_exhausted roundtrip" `Quick
-            test_capacity_exhausted_blocker_class_roundtrip;
+          test_case "Capacity_backpressure roundtrip" `Quick
+            test_capacity_backpressure_blocker_class_roundtrip;
           test_case "labels are distinct" `Quick
             test_blocker_class_labels_are_distinct;
         ] );

--- a/test/test_keeper_blocker_class_completion_contract.ml
+++ b/test/test_keeper_blocker_class_completion_contract.ml
@@ -27,16 +27,16 @@ let check_completion_contract_class label cls_opt =
 
 let check_capacity_class label cls_opt =
   match cls_opt with
-  | Some KT.Capacity_exhausted -> ()
+  | Some KT.Capacity_backpressure -> ()
   | Some other ->
       let other_str = KT.blocker_class_to_string other in
       fail
         (Printf.sprintf
-           "%s mapped to %s, expected Capacity_exhausted"
+           "%s mapped to %s, expected Capacity_backpressure"
            label
            other_str)
   | None ->
-      fail (Printf.sprintf "%s returned None, expected Capacity_exhausted" label)
+      fail (Printf.sprintf "%s returned None, expected Capacity_backpressure" label)
 
 let check_cascade_class label cls_opt =
   match cls_opt with
@@ -104,7 +104,7 @@ let test_capacity_backpressure_text_maps () =
   check_capacity_class
     "capacity-exhausted text"
     (B.blocker_class_of_string
-       "Internal error: [masc_oas_error] {\"kind\":\"capacity_exhausted\",\
+       "Internal error: [masc_oas_error] {\"kind\":\"capacity_backpressure\",\
         \"detail\":\"client capacity key glm is full\"}")
 
 let test_legacy_cascade_slot_full_text_stays_cascade_exhausted () =

--- a/test/test_keeper_error_classify_recoverable.ml
+++ b/test/test_keeper_error_classify_recoverable.ml
@@ -89,7 +89,7 @@ let test_typed_capacity_backpressure_is_not_cascade_exhausted () =
   | None ->
     fail "typed capacity backpressure should be recoverable as capacity"
 
-let test_provider_capacity_exhausted_is_capacity_backpressure () =
+let test_provider_capacity_backpressure_is_capacity_backpressure () =
   let err =
     Agent_sdk.Error.Provider
       (Llm_provider.Error.CapacityExhausted
@@ -471,7 +471,7 @@ let () =
           test_case "typed capacity backpressure is not cascade exhausted" `Quick
             test_typed_capacity_backpressure_is_not_cascade_exhausted;
           test_case "provider CapacityExhausted is capacity backpressure" `Quick
-            test_provider_capacity_exhausted_is_capacity_backpressure;
+            test_provider_capacity_backpressure_is_capacity_backpressure;
           test_case "All_providers_failed is recoverable" `Quick
             test_all_providers_failed_recoverable;
           test_case "No_providers_available is recoverable" `Quick

--- a/test/test_keeper_failure_policy.ml
+++ b/test/test_keeper_failure_policy.ml
@@ -50,7 +50,7 @@ let test_operational_timeout_phase_aliases () =
       "no_first_token", Policy.First_token;
       "stream_idle", Policy.Stream_idle Policy.Streaming_unknown;
       "max_execution_time", Policy.Wall_clock;
-      "capacity_exhausted", Policy.Capacity_backpressure;
+      "capacity_backpressure", Policy.Capacity_backpressure;
     ]
   in
   List.iter

--- a/test/test_keeper_rollover_gate.ml
+++ b/test/test_keeper_rollover_gate.ml
@@ -41,7 +41,7 @@ let non_overflow_classes_are_not_matched () =
     KT.Cascade_exhausted KT.No_providers_available;
     KT.Cascade_exhausted KT.All_providers_failed;
     KT.Cascade_exhausted KT.Max_turns_exceeded;
-    KT.Capacity_exhausted;
+    KT.Capacity_backpressure;
     KT.Ambiguous_post_commit_timeout;
     KT.Ambiguous_post_commit_failure;
     KT.Autonomous_slot_wait_timeout;

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -1666,8 +1666,8 @@ let test_turn_timeout_blocker_without_resume_policy_not_auto_resumed () =
         baseline_auto_resume after_auto_resume)
 
 (* Regression guard for #17063/#17067: [auto_resume_after_sec = None] is the
-   manual/operator pause contract.  Blockers from old persisted metadata must
-   not be treated as an implicit auto-resume policy. *)
+   manual/operator pause contract.  A [Capacity_backpressure] blocker from old
+   persisted metadata must not be treated as an implicit auto-resume policy. *)
 let test_capacity_blocker_without_resume_policy_not_auto_resumed () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -1701,7 +1701,7 @@ let test_capacity_blocker_without_resume_policy_not_auto_resumed () =
                 Some
                   (KT.blocker_info_of_class
                      ~detail:"capacity exhausted before explicit resume policy"
-                     KT.Capacity_exhausted);
+                     KT.Capacity_backpressure);
             };
         }
       in
@@ -1737,7 +1737,7 @@ let test_capacity_blocker_without_resume_policy_not_auto_resumed () =
            check bool "capacity blocker stays recorded for operator inspection"
              true
              (match m.runtime.last_blocker with
-              | Some info -> info.klass = KT.Capacity_exhausted
+              | Some info -> info.klass = KT.Capacity_backpressure
               | None -> false)
        | Ok None -> fail "meta missing"
        | Error err -> fail ("read_meta failed: " ^ err));

--- a/test/test_oas_compat_cascade_fallback.ml
+++ b/test/test_oas_compat_cascade_fallback.ml
@@ -227,14 +227,14 @@ let test_provider_failure_capacity_cascades () =
       }
   in
   Alcotest.(check bool)
-    "ProviderFailure Capacity_exhausted must cascade"
+    "ProviderFailure Capacity_backpressure must cascade"
     true
     (Oas_compat.Http_client.should_cascade err);
   match Oas_compat.Http_client.classify err with
-  | Provider_capacity_exhausted -> ()
+  | Provider_capacity_backpressure -> ()
   | _ ->
       Alcotest.fail
-        "Capacity_exhausted must classify as Provider_capacity_exhausted"
+        "Capacity_backpressure must classify as Provider_capacity_backpressure"
 
 let test_provider_failure_hard_quota_cascades () =
   let err =
@@ -455,7 +455,7 @@ let () =
         ] );
       ( "ProviderFailure — typed provider-local skips cascade",
         [
-          Alcotest.test_case "Capacity_exhausted classify + cascade"
+          Alcotest.test_case "Capacity_backpressure classify + cascade"
             `Quick test_provider_failure_capacity_cascades;
           Alcotest.test_case "Hard_quota classify + cascade + message"
             `Quick test_provider_failure_hard_quota_cascades;

--- a/test/test_provider_error.ml
+++ b/test/test_provider_error.ml
@@ -56,11 +56,11 @@ let legacy_health_decision err =
 let typed_health_decision err =
   let error = OWN.sdk_error_to_provider_error ~provider:"anthropic" err in
   match error with
-  | Some (P.CapacityExhausted { scope = `Provider }) -> Hard_quota
+  | Some (P.CapacityBackpressure { scope = `Provider }) -> Hard_quota
   | Some (P.CliWrappedHardQuota _) -> Hard_quota
   | Some (P.RateLimit _) -> Soft_rate_limited
   | Some
-      ( P.CapacityExhausted { scope = `Model }
+      ( P.CapacityBackpressure { scope = `Model }
       | P.AuthError
       | P.ServerError _
       | P.InvalidRequest _
@@ -76,7 +76,7 @@ let test_rate_limit_maps_retry_after () =
     Retry.RateLimited { retry_after = Some 1.5; message = "too many requests" }
     |> OWN.retry_api_error_to_provider_error
          ~provider:" anthropic "
-         ~capacity_exhausted:false
+         ~capacity_backpressure:false
     |> expect_some
   in
   match error with
@@ -91,23 +91,23 @@ let test_rate_limit_maps_retry_after () =
   | _ -> fail "expected RateLimit"
 ;;
 
-let test_rate_limit_can_be_capacity_exhausted () =
+let test_rate_limit_can_be_capacity_backpressure () =
   let error =
     Retry.RateLimited { retry_after = None; message = "resource exhausted" }
     |> OWN.retry_api_error_to_provider_error
          ~provider:"claude_code:auto"
-         ~capacity_exhausted:true
+         ~capacity_backpressure:true
     |> expect_some
   in
   match error with
-  | P.CapacityExhausted { scope = `Provider } ->
+  | P.CapacityBackpressure { scope = `Provider } ->
     check (list string) "affected runtime lane" [ public_provider ] (P.affected_providers error);
-    check bool "capacity" true (P.is_capacity_exhausted error);
+    check bool "capacity" true (P.is_capacity_backpressure error);
     check_json
       "json"
-      {|{"kind":"capacity_exhausted","scope":"provider","affected":["runtime"]}|}
+      {|{"kind":"capacity_backpressure","scope":"provider","affected":["runtime"]}|}
       error
-  | _ -> fail "expected provider CapacityExhausted"
+  | _ -> fail "expected provider CapacityBackpressure"
 ;;
 
 let test_anthropic_invalid_request_specified_limit_body_pins_capacity () =
@@ -126,7 +126,7 @@ let test_anthropic_invalid_request_specified_limit_body_pins_capacity () =
     OWN.sdk_error_to_provider_error ~provider:"anthropic" sdk_error |> expect_some
   in
   match error with
-  | P.CapacityExhausted { scope = `Provider } ->
+  | P.CapacityBackpressure { scope = `Provider } ->
     check (list string) "affected runtime lane" [ public_provider ] (P.affected_providers error)
   | _ -> fail "expected specified-limit InvalidRequest to become capacity"
 ;;
@@ -144,21 +144,21 @@ let test_cli_hard_quota_wrapper_emits_capacity_variant () =
   in
   check bool "existing wrapper classifier" true (OWN.sdk_error_is_hard_quota sdk_error);
   match OWN.sdk_error_to_provider_error ~provider:"claude_code:auto" sdk_error with
-  | Some (P.CapacityExhausted { scope = `Provider } as error) ->
+  | Some (P.CapacityBackpressure { scope = `Provider } as error) ->
     check (list string) "affected runtime lane" [ public_provider ] (P.affected_providers error)
-  | Some error -> failf "expected CapacityExhausted, got %s" (P.to_error_kind error)
+  | Some error -> failf "expected CapacityBackpressure, got %s" (P.to_error_kind error)
   | None -> fail "expected provider_error"
 ;;
 
 let test_server_and_auth_errors_are_closed_variants () =
   let server =
     Retry.ServerError { status = 503; message = "overloaded" }
-    |> OWN.retry_api_error_to_provider_error ~provider:"openai" ~capacity_exhausted:false
+    |> OWN.retry_api_error_to_provider_error ~provider:"openai" ~capacity_backpressure:false
     |> expect_some
   in
   let auth =
     Retry.AuthError { message = "invalid key" }
-    |> OWN.retry_api_error_to_provider_error ~provider:"kimi" ~capacity_exhausted:false
+    |> OWN.retry_api_error_to_provider_error ~provider:"kimi" ~capacity_backpressure:false
     |> expect_some
   in
   match server, auth with
@@ -174,14 +174,14 @@ let test_non_capacity_invalid_request_preserves_reason () =
     Retry.InvalidRequest { message = reason }
     |> OWN.retry_api_error_to_provider_error
          ~provider:"anthropic"
-         ~capacity_exhausted:false
+         ~capacity_backpressure:false
     |> expect_some
   in
   match error with
   | P.InvalidRequest { reason = actual } ->
     check (list string) "affected runtime lane" [ public_provider ] (P.affected_providers error);
     check string "reason" reason actual;
-    check bool "not capacity" false (P.is_capacity_exhausted error)
+    check bool "not capacity" false (P.is_capacity_backpressure error)
   | _ -> fail "expected InvalidRequest"
 ;;
 
@@ -284,7 +284,7 @@ let test_emit_sdk_provider_error_metric_rate_limit () =
 let test_emit_sdk_provider_error_metric_capacity_scope () =
   let before =
     counter_for
-      ~kind:"capacity_exhausted"
+      ~kind:"capacity_backpressure"
       ~provider:public_provider
       ~cascade_name:"primary"
       ~capacity_scope:"provider"
@@ -301,13 +301,13 @@ let test_emit_sdk_provider_error_metric_capacity_scope () =
          ~provider:"anthropic"
     |> expect_some
   in
-  check string "emitted kind" "capacity_exhausted" (P.to_error_kind emitted);
+  check string "emitted kind" "capacity_backpressure" (P.to_error_kind emitted);
   check
     (float 0.0001)
     "counter +1"
     (before +. 1.0)
     (counter_for
-       ~kind:"capacity_exhausted"
+       ~kind:"capacity_backpressure"
        ~provider:public_provider
        ~cascade_name:"primary"
        ~capacity_scope:"provider")
@@ -347,7 +347,7 @@ let () =
         ; test_case
             "rate limit can become capacity"
             `Quick
-            test_rate_limit_can_be_capacity_exhausted
+            test_rate_limit_can_be_capacity_backpressure
         ; test_case
             "Anthropic specified-limit body maps to capacity"
             `Quick


### PR DESCRIPTION
## Summary

- Reauthored the closed/unmerged #17164 change on fresh `main`.
- Retires internal/wire lower-case `capacity_exhausted` labels in favor of `capacity_backpressure`.
- Keeps external SDK/OAS constructors such as `CapacityExhausted` / `Capacity_exhausted` intact.
- Avoids projection-time historical receipt rewriting; `normalize_receipt_projection_json` remains removed.
- Includes current-main build repair needed after rebase drift.

## Verification

- `git diff --check origin/main..HEAD`
- `rg -n "capacity_echausted|capacity_exhausted" lib test docs scripts --glob '!_build/**'`
- `rg -n "normalize_receipt_projection_json" lib test --glob '!_build/**'`
- `scripts/dune-local.sh build bin/main_eio.exe test/test_dashboard_oas_bridge.exe test/test_cascade_capacity_backpressure_cooldown.exe test/test_cascade_capacity_backpressure_synthetic_backoff.exe test/test_keeper_error_classify_recoverable.exe test/test_keeper_failure_policy.exe test/test_keeper_runtime_trust_snapshot.exe test/test_keeper_blocker_class_completion_contract.exe test/test_keeper_auto_pause_blocker_persist_12683.exe test/test_keeper_rollover_gate.exe test/test_oas_compat_cascade_fallback.exe test/test_keeper_supervisor.exe`
- Ran all 11 built test executables listed above.
