### PR TITLE
refactor(keeper_heartbeat_loop): extract snapshot + stage-timing helpers sibling

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -827,67 +827,8 @@ let run_smart_heartbeat_gate
   cycle_continues_after_wake smart_hb_decision sleep_outcome
 ;;
 
-let maybe_write_heartbeat_snapshot
-      ~(ctx : _ context)
-      ~(meta_current : keeper_meta)
-      ~(now_ts : float)
-      ~(consecutive_hb_failures : int)
-      ~(last_snapshot_ts : float ref)
-      ~(snapshot_interval_sec : int)
-      ~(timing_ring : Keeper_keepalive_signal.stage_timing array)
-      ~(timing_filled : int)
-  : unit
-  =
-  if now_ts -. !last_snapshot_ts >= float_of_int snapshot_interval_sec
-  then (
-    (try
-       Keeper_heartbeat_snapshot.write_heartbeat_snapshot
-         ~ctx
-         ~meta_current
-         ~now_ts
-         ~consecutive_hb_failures
-         ~timing_ring
-         ~timing_filled
-     with
-     | Eio.Cancel.Cancelled _ as e -> raise e
-     | exn ->
-       Prometheus.inc_counter
-         Keeper_metrics.metric_keeper_snapshot_write_failures
-         ~labels:[ "keeper", meta_current.name ]
-         ();
-       Log.Keeper.error "heartbeat snapshot write failed: %s" (Printexc.to_string exn));
-    last_snapshot_ts := now_ts)
-;;
-
-let record_keepalive_stage_timing
-      ~(timing_ring : Keeper_keepalive_signal.stage_timing array)
-      ~(timing_cursor : int ref)
-      ~(timing_filled : int ref)
-      ~(ring_sz : int)
-      ~(t_presence_start : float)
-      ~(t_presence_end : float)
-      ~(t_snapshot_start : float)
-      ~(t_snapshot_end : float)
-      ~(t_board_start : float)
-      ~(t_board_end : float)
-      ~(t_turn_start : float)
-      ~(t_turn_end : float)
-      ~(t_recurring_start : float)
-      ~(t_recurring_end : float)
-  : unit
-  =
-  let timing =
-    { presence_ms = (t_presence_end -. t_presence_start) *. 1000.0
-    ; snapshot_ms = (t_snapshot_end -. t_snapshot_start) *. 1000.0
-    ; board_ms = (t_board_end -. t_board_start) *. 1000.0
-    ; turn_ms = (t_turn_end -. t_turn_start) *. 1000.0
-    ; recurring_ms = (t_recurring_end -. t_recurring_start) *. 1000.0
-    }
-  in
-  timing_ring.(!timing_cursor) <- timing;
-  timing_cursor := (!timing_cursor + 1) mod ring_sz;
-  if !timing_filled < ring_sz then incr timing_filled
-;;
+let maybe_write_heartbeat_snapshot = Keeper_heartbeat_loop_snapshot_timing.maybe_write_heartbeat_snapshot
+let record_keepalive_stage_timing = Keeper_heartbeat_loop_snapshot_timing.record_keepalive_stage_timing
 
 (* Spec navigation (OCaml -> TLA+) — plan §19 Cycle 27 anchor for
    B1 (Heartbeat).  Authoritative spec mirror is

--- a/lib/keeper/keeper_heartbeat_loop_snapshot_timing.ml
+++ b/lib/keeper/keeper_heartbeat_loop_snapshot_timing.ml
@@ -1,0 +1,86 @@
+(** Heartbeat snapshot persistence + stage-timing ring-buffer record,
+    extracted from [keeper_heartbeat_loop.ml] (godfile decomp).
+
+    Two side-effect helpers consumed by [run_heartbeat_loop]:
+
+    - [maybe_write_heartbeat_snapshot] — TTL-gated wrapper around
+      [Keeper_heartbeat_snapshot.write_heartbeat_snapshot]. Writes the
+      snapshot iff the configured [~snapshot_interval_sec] has elapsed
+      since [!last_snapshot_ts]. Write failures degrade gracefully:
+      cancellation re-raises, other [exn] increment
+      [metric_keeper_snapshot_write_failures] and log ERROR.
+      [last_snapshot_ts] is bumped to [now_ts] even on failure to
+      avoid retry storms.
+
+    - [record_keepalive_stage_timing] — populates one ring-buffer slot
+      of stage-timing measurements (presence/snapshot/board/turn/
+      recurring in ms) and advances the cursor. [timing_filled] caps
+      at [ring_sz].
+
+    Pure helpers (no callback injection). All references reach
+    external modules (Keeper_heartbeat_snapshot, Keeper_keepalive_signal,
+    Eio, Prometheus, Keeper_metrics, Log) directly. *)
+
+open Keeper_types
+
+let maybe_write_heartbeat_snapshot
+      ~(ctx : _ context)
+      ~(meta_current : keeper_meta)
+      ~(now_ts : float)
+      ~(consecutive_hb_failures : int)
+      ~(last_snapshot_ts : float ref)
+      ~(snapshot_interval_sec : int)
+      ~(timing_ring : Keeper_keepalive_signal.stage_timing array)
+      ~(timing_filled : int)
+  : unit
+  =
+  if now_ts -. !last_snapshot_ts >= float_of_int snapshot_interval_sec
+  then (
+    (try
+       Keeper_heartbeat_snapshot.write_heartbeat_snapshot
+         ~ctx
+         ~meta_current
+         ~now_ts
+         ~consecutive_hb_failures
+         ~timing_ring
+         ~timing_filled
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+       Prometheus.inc_counter
+         Keeper_metrics.metric_keeper_snapshot_write_failures
+         ~labels:[ "keeper", meta_current.name ]
+         ();
+       Log.Keeper.error "heartbeat snapshot write failed: %s" (Printexc.to_string exn));
+    last_snapshot_ts := now_ts)
+;;
+
+let record_keepalive_stage_timing
+      ~(timing_ring : Keeper_keepalive_signal.stage_timing array)
+      ~(timing_cursor : int ref)
+      ~(timing_filled : int ref)
+      ~(ring_sz : int)
+      ~(t_presence_start : float)
+      ~(t_presence_end : float)
+      ~(t_snapshot_start : float)
+      ~(t_snapshot_end : float)
+      ~(t_board_start : float)
+      ~(t_board_end : float)
+      ~(t_turn_start : float)
+      ~(t_turn_end : float)
+      ~(t_recurring_start : float)
+      ~(t_recurring_end : float)
+  : unit
+  =
+  let timing =
+    { presence_ms = (t_presence_end -. t_presence_start) *. 1000.0
+    ; snapshot_ms = (t_snapshot_end -. t_snapshot_start) *. 1000.0
+    ; board_ms = (t_board_end -. t_board_start) *. 1000.0
+    ; turn_ms = (t_turn_end -. t_turn_start) *. 1000.0
+    ; recurring_ms = (t_recurring_end -. t_recurring_start) *. 1000.0
+    }
+  in
+  timing_ring.(!timing_cursor) <- timing;
+  timing_cursor := (!timing_cursor + 1) mod ring_sz;
+  if !timing_filled < ring_sz then incr timing_filled
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane B
- 5th sibling extracted from `keeper_heartbeat_loop.ml` (after #17296 `keepalive_scheduling`, #17320 `presence`, #17344 `board_events`, #17373 `dispatch_recurring`).
- **Bundle extraction** — 2 cohesive observability helpers shipped together to share imports and module-level documentation.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/keeper/keeper_heartbeat_loop.ml` | 1193 | 1134 | **-59** |
| `lib/keeper/keeper_heartbeat_loop_snapshot_timing.ml` | — | 86 | +86 |

## Moved (verbatim, no behavior change)

### `maybe_write_heartbeat_snapshot`
- Gate: `now_ts -. !last_snapshot_ts >= float_of_int snapshot_interval_sec`
- On gate-pass: invoke `Keeper_heartbeat_snapshot.write_heartbeat_snapshot ~ctx ~meta_current ~now_ts ~consecutive_hb_failures ~timing_ring ~timing_filled`
- Failure handling:
  - `Eio.Cancel.Cancelled` → re-raise (cancellation safety)
  - Other `exn` → `inc_counter metric_keeper_snapshot_write_failures ~labels:[keeper, meta_current.name]` + `Log.Keeper.error` with `Printexc.to_string exn`
- `last_snapshot_ts := now_ts` runs even on failure (avoids retry storms — verbatim policy)

### `record_keepalive_stage_timing`
- Builds a `stage_timing` record from 10 timestamp pairs (presence/snapshot/board/turn/recurring start+end), multiplying each `end -. start` by 1000.0 for ms
- Writes to `timing_ring.(!timing_cursor) <- timing`
- Advances cursor: `timing_cursor := (!timing_cursor + 1) mod ring_sz`
- Increments `timing_filled` until it caps at `ring_sz`

Parent retains 2 single-line aliases preserving the `.mli` surface (both functions are `.mli`-exposed at lines 217 and 228).

## Bundling rationale
Both functions are:
- pure side-effect helpers consumed only by `run_heartbeat_loop`
- observability-shaped (snapshot persistence + timing telemetry)
- self-contained (zero parent-local dependencies)

Shipping them in one sibling shares the file-header doc-comment and the `open Keeper_types` line. Two separate siblings would cost ~12 extra LOC of duplicated headers across both files.

## External callers
None. Both functions are `.mli`-exposed but the only callers live inside the parent's `run_heartbeat_loop`:
- `maybe_write_heartbeat_snapshot` at parent line 1069
- `record_keepalive_stage_timing` at parent line 1165

The `.mli` surface is preserved via the parent aliases for future cross-module use.

## Sibling deps (all external)
- `open Keeper_types` — `'a context`, `keeper_meta`
- `Keeper_heartbeat_snapshot.write_heartbeat_snapshot`
- `Keeper_keepalive_signal.stage_timing` (record type + 5 field labels)
- `Eio.Cancel.Cancelled`
- `Prometheus.inc_counter`
- `Keeper_metrics.metric_keeper_snapshot_write_failures`
- `Log.Keeper.error`
- `Printexc.to_string`

No sibling -> parent cycle.

## Local build status
- `dune build --root . lib/keeper/` → clean (exit 0)
- godfile lint: sibling 86 LOC under `new_file_cap=600`; parent 1134 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim 2-helper bundle move, 2 parent aliases.

Co-Authored-By: codex <noreply@anthropic.com>
