### PR TITLE
[codex] close report follow-up gates

### DIFF
--- a/lib/cascade/cascade_transport_runtime_policy_provider.mli
+++ b/lib/cascade/cascade_transport_runtime_policy_provider.mli
@@ -1,12 +1,14 @@
-(** Provider-driven runtime MCP policy resolver + CLI JSON merger. *)
+(** Provider-driven runtime MCP policy resolver and CLI JSON merger. *)
 
 val runtime_mcp_policy_for_provider :
-     provider_cfg:Llm_provider.Provider_config.t
-  -> agent_name:string
-  -> Llm_provider.Llm_transport.runtime_mcp_policy option
-  -> Llm_provider.Llm_transport.runtime_mcp_policy option
+  provider_cfg:Llm_provider.Provider_config.t ->
+  agent_name:string ->
+  Llm_provider.Llm_transport.runtime_mcp_policy option ->
+  Llm_provider.Llm_transport.runtime_mcp_policy option
+(** Shape a runtime MCP policy according to provider tool-delivery capability. *)
 
 val cli_runtime_mcp_jsons :
   base:string list ->
   Llm_provider.Llm_transport.runtime_mcp_policy option ->
   string list
+(** Merge base CLI MCP JSON entries with a runtime-policy projection. *)

--- a/lib/cdal_runtime_health.ml
+++ b/lib/cdal_runtime_health.ml
@@ -120,7 +120,7 @@ let all_digits value =
 let cdal_run_id_timestamp run_id =
   match String.split_on_char '-' run_id with
   | "cdal" :: ts :: _ when all_digits ts -> Some ts
-  | _ -> None
+  | _parts -> None
 ;;
 
 let compare_numeric_string left right =

--- a/lib/keeper/keeper_heartbeat_loop_board_events.mli
+++ b/lib/keeper/keeper_heartbeat_loop_board_events.mli
@@ -1,0 +1,8 @@
+(** Pending board-event collection for the keeper heartbeat loop. *)
+
+val collect_keepalive_board_events :
+  ctx:'a Keeper_types.context ->
+  meta_current:Keeper_types.keeper_meta ->
+  proactive_warmup_elapsed:bool ->
+  Keeper_world_observation.pending_board_event list * Keeper_types.keeper_meta
+(** Collect pending board events after proactive warmup has elapsed. *)

--- a/lib/keeper/keeper_heartbeat_loop_dispatch_recurring.mli
+++ b/lib/keeper/keeper_heartbeat_loop_dispatch_recurring.mli
@@ -1,0 +1,9 @@
+(** Recurring-task keepalive dispatch for the keeper heartbeat loop. *)
+
+val dispatch_recurring_keepalive :
+  ctx:'a Keeper_types.context ->
+  meta_after_proactive:Keeper_types.keeper_meta ->
+  now_ts:float ->
+  int
+(** Re-enable due recurring tasks, dispatch due broadcasts, and return the
+    dispatch count. *)

--- a/lib/keeper/keeper_heartbeat_loop_presence.mli
+++ b/lib/keeper/keeper_heartbeat_loop_presence.mli
@@ -1,0 +1,32 @@
+(** Presence and identity sync helpers for the keeper heartbeat loop. *)
+
+val effective_keepalive_meta :
+  base_path:string ->
+  fallback:Keeper_types.keeper_meta ->
+  disk_meta_opt:Keeper_types.keeper_meta option ->
+  Keeper_types.keeper_meta
+(** Pick the freshest keeper meta available for keepalive publication. *)
+
+val repair_identity_drift_for_keepalive :
+  ctx:'a Keeper_types.context ->
+  Keeper_types.keeper_meta ->
+  Keeper_types.keeper_meta option
+(** Repair persisted keeper identity drift before publishing heartbeat state. *)
+
+val keeper_agent_status : Keeper_types.keeper_meta -> Masc_domain.agent_status
+(** Project keeper meta into the public agent status enum. *)
+
+val note_turn_failures_preserved_after_heartbeat :
+  ctx:'a Keeper_types.context -> meta:Keeper_types.keeper_meta -> unit
+(** Log when heartbeat recovery intentionally preserves turn-failure debt. *)
+
+val sync_keeper_presence :
+  ctx:'a Keeper_types.context ->
+  meta_current:Keeper_types.keeper_meta ->
+  t_presence_start:float ->
+  consecutive_failures:int ref ->
+  last_successful_heartbeat_ts:float ref ->
+  work_as_hb:(unit -> bool) ->
+  max_silence:(unit -> float) ->
+  Keeper_types.keeper_meta
+(** Publish keeper heartbeat presence and update failure counters. *)

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.mli
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.mli
@@ -1,0 +1,37 @@
+(** Keepalive scheduling decision for the keeper heartbeat loop. *)
+
+type cascade_backpressure_decision =
+  Keeper_heartbeat_loop_observations.cascade_backpressure_decision =
+  | Cascade_admitted
+  | Cascade_backpressured of {
+      cascade_name : string;
+      reason : string;
+    }
+
+val cascade_backpressure_observation_reasons : reason:string -> string list
+
+val cascade_backpressure_decision :
+  cascade_resilience:Keeper_types.cascade_resilience option ->
+  should_run_turn:bool ->
+  cascade_name:string ->
+  cascade_status:Keeper_health_probe.cascade_status ->
+  cascade_backpressure_decision
+
+type keepalive_scheduling_decision = {
+  turn_decision : Keeper_world_observation.keeper_cycle_decision;
+  requested_should_run_turn : bool;
+  cascade_backpressure : cascade_backpressure_decision;
+  should_run_turn : bool;
+  verdict_reasons : string list;
+  admission_reasons : string list;
+  channel : string;
+}
+
+val decide_keepalive_scheduling :
+  ?cascade_resilience_of_name:(string -> Keeper_types.cascade_resilience) ->
+  ?cascade_status_of_name:
+    (cascade_name:string -> Keeper_health_probe.cascade_status) ->
+  stop:bool Atomic.t ->
+  meta:Keeper_types.keeper_meta ->
+  Keeper_world_observation.world_observation ->
+  keepalive_scheduling_decision

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.mli
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.mli
@@ -11,10 +11,10 @@ type cascade_backpressure_decision =
 val cascade_backpressure_observation_reasons : reason:string -> string list
 
 val cascade_backpressure_decision :
-  cascade_resilience:Keeper_types.cascade_resilience option ->
+  cascade_resilience:Keeper_exec_preflight.cascade_resilience option ->
   should_run_turn:bool ->
   cascade_name:string ->
-  cascade_status:Keeper_health_probe.cascade_status ->
+  cascade_status:Keeper_health_probe.health_status ->
   cascade_backpressure_decision
 
 type keepalive_scheduling_decision = {
@@ -28,9 +28,9 @@ type keepalive_scheduling_decision = {
 }
 
 val decide_keepalive_scheduling :
-  ?cascade_resilience_of_name:(string -> Keeper_types.cascade_resilience) ->
+  ?cascade_resilience_of_name:(string -> Keeper_exec_preflight.cascade_resilience) ->
   ?cascade_status_of_name:
-    (cascade_name:string -> Keeper_health_probe.cascade_status) ->
+    (cascade_name:string -> Keeper_health_probe.health_status) ->
   stop:bool Atomic.t ->
   meta:Keeper_types.keeper_meta ->
   Keeper_world_observation.world_observation ->

--- a/lib/keeper/keeper_heartbeat_loop_snapshot_timing.ml
+++ b/lib/keeper/keeper_heartbeat_loop_snapshot_timing.ml
@@ -72,8 +72,9 @@ let record_keepalive_stage_timing
       ~(t_recurring_end : float)
   : unit
   =
-  let timing =
-    { presence_ms = (t_presence_end -. t_presence_start) *. 1000.0
+  let timing : Keeper_keepalive_signal.stage_timing =
+    { Keeper_keepalive_signal.presence_ms =
+        (t_presence_end -. t_presence_start) *. 1000.0
     ; snapshot_ms = (t_snapshot_end -. t_snapshot_start) *. 1000.0
     ; board_ms = (t_board_end -. t_board_start) *. 1000.0
     ; turn_ms = (t_turn_end -. t_turn_start) *. 1000.0

--- a/lib/keeper/keeper_heartbeat_loop_snapshot_timing.mli
+++ b/lib/keeper/keeper_heartbeat_loop_snapshot_timing.mli
@@ -1,0 +1,31 @@
+(** Heartbeat snapshot persistence and stage-timing ring-buffer helpers. *)
+
+val maybe_write_heartbeat_snapshot :
+  ctx:'a Keeper_types.context ->
+  meta_current:Keeper_types.keeper_meta ->
+  now_ts:float ->
+  consecutive_hb_failures:int ->
+  last_snapshot_ts:float ref ->
+  snapshot_interval_sec:int ->
+  timing_ring:Keeper_keepalive_signal.stage_timing array ->
+  timing_filled:int ->
+  unit
+(** Write the heartbeat snapshot when the snapshot interval has elapsed. *)
+
+val record_keepalive_stage_timing :
+  timing_ring:Keeper_keepalive_signal.stage_timing array ->
+  timing_cursor:int ref ->
+  timing_filled:int ref ->
+  ring_sz:int ->
+  t_presence_start:float ->
+  t_presence_end:float ->
+  t_snapshot_start:float ->
+  t_snapshot_end:float ->
+  t_board_start:float ->
+  t_board_end:float ->
+  t_turn_start:float ->
+  t_turn_end:float ->
+  t_recurring_start:float ->
+  t_recurring_end:float ->
+  unit
+(** Record one keepalive cycle's stage timing in the ring buffer. *)

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -1697,7 +1697,7 @@ let prepare_agent_setup
                   ; tool_choice
                   ; tool_filter_override = Some tool_filter
                   }
-              | _ -> Agent_sdk.Hooks.Continue)
+              | _event -> Agent_sdk.Hooks.Continue)
       }
     in
     let hooks = Agent_sdk.Hooks.compose ~outer:before_turn_hook ~inner:base_hooks in

--- a/lib/keeper/keeper_supervisor_reconcile_keepalive.mli
+++ b/lib/keeper/keeper_supervisor_reconcile_keepalive.mli
@@ -1,0 +1,17 @@
+(** Phase 4 durable keepalive reconciliation for the keeper supervisor. *)
+
+val reconcile_keepalive_keepers :
+  publish_lifecycle:
+    (event:Keeper_lifecycle_events.lifecycle_event ->
+     string ->
+     string ->
+     unit ->
+     unit) ->
+  supervise_keepalive:
+    (proactive_warmup_sec:int ->
+     'a Keeper_types.context ->
+     Keeper_types.keeper_meta ->
+     unit) ->
+  'a Keeper_types.context ->
+  unit
+(** Re-launch durable keepalive keepers not dominated by the supervisor sweep. *)

--- a/lib/keeper/keeper_supervisor_restore_reconcile_gate.mli
+++ b/lib/keeper/keeper_supervisor_restore_reconcile_gate.mli
@@ -1,0 +1,12 @@
+(** Reconcile-gate restore path for the keeper supervisor. *)
+
+val restore_reconcile_continue_gate :
+  supervise_keepalive:
+    (proactive_warmup_sec:int ->
+     'a Keeper_types.context ->
+     Keeper_types.keeper_meta ->
+     unit) ->
+  'a Keeper_types.context ->
+  Keeper_types.keeper_meta ->
+  unit
+(** Rehydrate a persisted reconcile approval gate for a paused keeper. *)

--- a/lib/keeper/keeper_supervisor_resume_reconcile_gate.mli
+++ b/lib/keeper/keeper_supervisor_resume_reconcile_gate.mli
@@ -1,0 +1,12 @@
+(** Reconcile-gate resume path for the keeper supervisor. *)
+
+val resume_keeper_after_reconcile_gate :
+  supervise_keepalive:
+    (proactive_warmup_sec:int ->
+     'a Keeper_types.context ->
+     Keeper_types.keeper_meta ->
+     unit) ->
+  'a Keeper_types.context ->
+  Keeper_types.keeper_meta ->
+  unit
+(** Clear the persisted reconcile blocker and resume or relaunch the keeper. *)

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.mli
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.mli
@@ -1,0 +1,21 @@
+(** Keepalive supervision entry point for the keeper supervisor. *)
+
+val supervise_keepalive :
+  publish_lifecycle:
+    (event:Keeper_lifecycle_events.lifecycle_event ->
+     string ->
+     string ->
+     unit ->
+     unit) ->
+  launch_supervised_fiber:
+    (proactive_warmup_sec:int ->
+     'a Keeper_types.context ->
+     Keeper_types.keeper_meta ->
+     Keeper_registry.registry_entry ->
+     unit) ->
+  proactive_warmup_sec:int ->
+  'a Keeper_types.context ->
+  Keeper_types.keeper_meta ->
+  unit
+(** Register and launch a supervised keepalive fiber when spawn admission
+    allows it. *)

--- a/lib/keeper/keeper_unified_metrics_decision.mli
+++ b/lib/keeper/keeper_unified_metrics_decision.mli
@@ -1,0 +1,20 @@
+(** Decision-record append for unified keeper cycle metrics. *)
+
+val append_decision_record :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  observation:Keeper_world_observation.world_observation ->
+  latency_ms:int ->
+  ?semaphore_wait_ms:int ->
+  outcome:string ->
+  ?degraded_retry_applied:bool ->
+  ?degraded_retry_cascade:string ->
+  ?fallback_reason:string ->
+  ?turn_mode:Keeper_unified_metrics_support.turn_mode ->
+  ?social_state:Keeper_social_model.social_state ->
+  ?deliberation_execution:Keeper_deliberation.execution_result ->
+  ?result:Keeper_agent_run.run_result option ->
+  ?error:string ->
+  ?terminal_reason:Keeper_turn_terminal.t ->
+  unit ->
+  unit

--- a/lib/operator/operator_control_snapshot_identity_fields.mli
+++ b/lib/operator/operator_control_snapshot_identity_fields.mli
@@ -1,7 +1,12 @@
-(** Keeper runtime identity field builders for operator control snapshots. *)
+(** Keeper identity-field builders for operator control snapshots. *)
 
 val non_empty_trimmed_string_opt : string -> string option
-val keeper_runtime_identity_fields : Keeper_types.keeper_meta -> (string * Yojson.Safe.t) list
+(** Trim a string and return [None] when it is empty. *)
+
+val keeper_runtime_identity_fields :
+  Keeper_types.keeper_meta -> (string * Yojson.Safe.t) list
+(** Live identity fields with cascade canonicalization. *)
 
 val degraded_keeper_runtime_identity_fields :
   Keeper_types.keeper_meta -> (string * Yojson.Safe.t) list
+(** Fallback identity fields when live cascade resolution is unavailable. *)

--- a/lib/operator/operator_control_snapshot_persistent_agents.mli
+++ b/lib/operator/operator_control_snapshot_persistent_agents.mli
@@ -1,0 +1,8 @@
+(** Persistent keeper-agent rows for the operator snapshot. *)
+
+val persistent_agents_json :
+  ?keeper_names:string list ->
+  ?keeper_rows:Yojson.Safe.t list ->
+  Coord.config ->
+  Yojson.Safe.t
+(** Build the persistent keeper-agent `{ count; items }` JSON object. *)

--- a/lib/operator/operator_control_snapshot_view.mli
+++ b/lib/operator/operator_control_snapshot_view.mli
@@ -1,0 +1,20 @@
+(** Operator snapshot view selector. *)
+
+type snapshot_view =
+  | Summary
+  | Sessions
+  | Keepers
+  | Messages
+  | Full
+
+val snapshot_view_to_string : snapshot_view -> string
+(** Stable wire label for a snapshot view. *)
+
+val valid_snapshot_view_strings : string list
+(** All accepted wire labels. *)
+
+val snapshot_view_of_string_opt : string -> snapshot_view option
+(** Parse a canonical view string, returning [None] for unknown inputs. *)
+
+val parse_snapshot_view : string option -> snapshot_view
+(** Back-compatible parser that falls back to [Full]. *)

--- a/lib/server/server_dashboard_http_core_digest_refresh.mli
+++ b/lib/server/server_dashboard_http_core_digest_refresh.mli
@@ -1,0 +1,8 @@
+(** Operator-digest proactive refresh loop for dashboard HTTP core. *)
+
+val start_operator_digest_refresh_loop :
+  state:Mcp_server.server_state ->
+  sw:Eio.Switch.t ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  unit
+(** Start the cached operator-digest proactive refresh loop. *)

--- a/lib/server/server_dashboard_http_core_meta_cognition.mli
+++ b/lib/server/server_dashboard_http_core_meta_cognition.mli
@@ -2,8 +2,6 @@
 
 module Mc_cache : module type of Server_dashboard_meta_cognition_cache
 
-module Mc_cache : module type of Server_dashboard_meta_cognition_cache
-
 val meta_cognition_summary_ttl : float
 
 val meta_cognition_summary_stale_for : float

--- a/lib/server/server_dashboard_http_core_meta_cognition.mli
+++ b/lib/server/server_dashboard_http_core_meta_cognition.mli
@@ -2,6 +2,8 @@
 
 module Mc_cache : module type of Server_dashboard_meta_cognition_cache
 
+module Mc_cache : module type of Server_dashboard_meta_cognition_cache
+
 val meta_cognition_summary_ttl : float
 
 val meta_cognition_summary_stale_for : float

--- a/lib/server/server_dashboard_http_core_operator_query.mli
+++ b/lib/server/server_dashboard_http_core_operator_query.mli
@@ -1,0 +1,51 @@
+(** Operator query metadata helpers for dashboard HTTP core. *)
+
+val operator_retention_json :
+  config:Coord.config -> scope:string -> producer:string -> Yojson.Safe.t
+
+val operator_snapshot_query_json :
+  actor:string option ->
+  view:string option ->
+  include_messages:bool ->
+  include_keepers:bool ->
+  lightweight_summary:bool ->
+  default_summary_request:bool ->
+  Yojson.Safe.t
+
+val operator_digest_query_json :
+  actor:string option ->
+  target_type:string option ->
+  target_id:string option ->
+  include_workers:bool option ->
+  effective_target_type:string ->
+  default_namespace_request:bool ->
+  Yojson.Safe.t
+
+val with_operator_surface_metadata :
+  config:Coord.config ->
+  ?cache_key:string ->
+  dashboard_surface:string ->
+  source:string ->
+  scope:string ->
+  producer:string ->
+  query:Yojson.Safe.t ->
+  Yojson.Safe.t ->
+  Yojson.Safe.t
+
+val with_operator_snapshot_metadata :
+  config:Coord.config ->
+  ?cache_key:string ->
+  query:Yojson.Safe.t ->
+  Yojson.Safe.t ->
+  Yojson.Safe.t
+
+val with_operator_digest_metadata :
+  config:Coord.config ->
+  ?cache_key:string ->
+  query:Yojson.Safe.t ->
+  Yojson.Safe.t ->
+  Yojson.Safe.t
+
+val operator_snapshot_default_query : unit -> Yojson.Safe.t
+
+val operator_digest_default_query : unit -> Yojson.Safe.t

--- a/lib/server/server_dashboard_http_core_runtime.mli
+++ b/lib/server/server_dashboard_http_core_runtime.mli
@@ -1,0 +1,31 @@
+(** Dashboard compute-runtime bindings extracted from
+    {!Server_dashboard_http_core}. *)
+
+val runtime_support : Server_dashboard_http_runtime_support.t
+(** Shared runtime-support handle for dashboard compute dispatch. *)
+
+val set_executor_pool : Eio.Executor_pool.t -> unit
+(** Register the dashboard executor pool. *)
+
+val dashboard_runtime :
+  ?net:Eio_context.eio_net ->
+  ?mono_clock:Eio.Time.Mono.ty Eio.Resource.t ->
+  Coord.config ->
+  Server_dashboard_http_runtime_support.runtime option
+(** Build optional dashboard runtime capabilities from server resources. *)
+
+val run_dashboard_compute :
+  ?mode:Server_dashboard_http_runtime_support.dashboard_compute_mode ->
+  ?net:Eio_context.eio_net ->
+  ?mono_clock:Eio.Time.Mono.ty Eio.Resource.t ->
+  sw:Eio.Switch.t ->
+  clock:_ Eio.Time.clock ->
+  config:Coord.config ->
+  (config:Coord.config -> sw:Eio.Switch.t -> 'a) ->
+  'a
+(** Dispatch dashboard compute through the configured runtime support. *)
+
+val state_dashboard_runtime_caps :
+  Mcp_server.server_state ->
+  Eio_context.eio_net option * Eio.Time.Mono.ty Eio.Resource.t option
+(** Extract dashboard runtime capabilities from server state. *)

--- a/lib/server/server_dashboard_http_core_snapshot_refresh.mli
+++ b/lib/server/server_dashboard_http_core_snapshot_refresh.mli
@@ -1,0 +1,8 @@
+(** Operator-snapshot proactive refresh loop for dashboard HTTP core. *)
+
+val start_operator_snapshot_refresh_loop :
+  state:Mcp_server.server_state ->
+  sw:Eio.Switch.t ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  unit
+(** Start the cached operator-snapshot proactive refresh loop. *)

--- a/lib/server/server_routes_http_dashboard_handlers.mli
+++ b/lib/server/server_routes_http_dashboard_handlers.mli
@@ -1,0 +1,17 @@
+(** Dashboard HTTP handler bodies extracted from the dashboard route table. *)
+
+val handle_broadcast :
+  Mcp_server.server_state -> string -> Httpun.Reqd.t -> string -> unit
+(** Handle dashboard broadcast POST bodies. *)
+
+val handle_dashboard_link_previews :
+  Mcp_server.server_state -> Httpun.Request.t -> Httpun.Reqd.t -> string -> unit
+(** Handle dashboard link-preview POST bodies. *)
+
+val handle_dashboard_task_history :
+  Mcp_server.server_state -> Httpun.Request.t -> Httpun.Reqd.t -> unit
+(** Handle dashboard task-history requests. *)
+
+val handle_dashboard_rooms :
+  Mcp_server.server_state -> Httpun.Request.t -> Httpun.Reqd.t -> unit
+(** Handle dashboard rooms requests. *)

--- a/lib/server/server_routes_http_routes_dashboard_cascade_meta.mli
+++ b/lib/server/server_routes_http_routes_dashboard_cascade_meta.mli
@@ -1,0 +1,8 @@
+(** Cascade-name persistence helper for dashboard routes. *)
+
+val sync_keeper_cascade_meta :
+  config:Coord.config ->
+  name:string ->
+  cascade_name:string ->
+  (bool, string) result
+(** Persist a keeper cascade-name update to TOML and the in-memory registry. *)

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -357,6 +357,10 @@ let bootstrap_server_state_blocking (state : Mcp_server.server_state) =
      Keeper autoboot and other bootstrap readers should see the canonical paths
      on their first pass, not rely on a later lazy migration task. *)
   migrate_legacy_keeper_dirs_blocking state;
+  (* [create_server_state] normally resets this after config bootstrap, but
+     direct state constructors used by tests and execute contexts can leave a
+     stale process-global config resolution in place. *)
+  Config_dir_resolver.reset ();
   let (_init_msg : string) = Coord.init state.room_config ~agent_name:None in
   audit_keeper_egress_policies state;
   Mcp_server.set_sse_callback state Sse.broadcast

--- a/scripts/oas-api-surface.json
+++ b/scripts/oas-api-surface.json
@@ -1,6 +1,6 @@
 {
-  "pinned_sha": "609600d896af320868b9578d278e5752f8f28075",
-  "pinned_version": "v0.196.7",
+  "pinned_sha": "8ea10c7b088a61a2168b9ff597da6c1908abc631",
+  "pinned_version": "v0.196.8",
   "surfaces": {
     "event_bus_payload_variants": [
       "AgentCompleted",

--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -1,10 +1,10 @@
 {
   "_comment": "OCaml structural-debt baseline. Regenerate with scripts/ocaml-structure-ratchet.sh --regenerate.",
   "_metrics": "See scripts/ocaml-structure-ratchet.sh METRICS array.",
-  "keeper_mli_missing": 8,
-  "coord_mli_missing": 1,
+  "keeper_mli_missing": 0,
+  "coord_mli_missing": 0,
   "godsplit_count": 0,
-  "lib_dune_lines": 651,
+  "lib_dune_lines": 653,
   "inferred_dump_headers": 0,
-  "lib_other_mli_missing": 6
+  "lib_other_mli_missing": 0
 }

--- a/test/test_keeper_wip_admission.ml
+++ b/test/test_keeper_wip_admission.ml
@@ -76,12 +76,15 @@ let test_rejects_goal_cap () =
 
 let test_rejects_category_cap_across_repos () =
   let active =
-    [ item ~category:Admission.Refactor "repo-a" "one"
-    ; item ~category:Admission.Refactor "repo-b" "two"
-    ; item ~category:Admission.Refactor "repo-c" "three"
+    [ item ~goal_id:"goal-a" ~category:Admission.Refactor "repo-a" "one"
+    ; item ~goal_id:"goal-b" ~category:Admission.Refactor "repo-b" "two"
+    ; item ~goal_id:"goal-c" ~category:Admission.Refactor "repo-c" "three"
     ]
   in
-  match Admission.decide ~caps active ~scope:(scope ~category:Admission.Refactor "repo-d") with
+  match
+    Admission.decide ~caps active
+      ~scope:(scope ~goal_id:"goal-d" ~category:Admission.Refactor "repo-d")
+  with
   | Admission.Admit _ -> fail "expected category cap rejection"
   | Reject rejection ->
     check string "reason" "category_cap"


### PR DESCRIPTION
## Summary
- keep report closeout/OAS pin follow-up aligned with latest main extractions
- add curated interfaces for newly extracted keeper/server/operator/cascade modules
- keep OAS API fingerprint synchronized with pinned v0.196.8 surface

## Local verification
- scripts/dune-local.sh build lib/masc_mcp.cmxa test/test_keeper_error_classify_recoverable.exe test/test_keeper_wip_admission.exe test/test_keeper_failure_policy.exe test/test_oas_error_kind_counter.exe test/test_keeper_blocker_class_completion_contract.exe test/test_server_runtime_bootstrap.exe
- ./_build/default/test/test_keeper_error_classify_recoverable.exe
- ./_build/default/test/test_keeper_wip_admission.exe
- ./_build/default/test/test_keeper_failure_policy.exe
- ./_build/default/test/test_oas_error_kind_counter.exe
- ./_build/default/test/test_keeper_blocker_class_completion_contract.exe
- ./_build/default/test/test_server_runtime_bootstrap.exe test bootstrap 20-24
- scripts/check-oas-pin.sh (passes with upstream drift warning)
- scripts/oas-drift-check.sh
- scripts/ocaml-structure-ratchet.sh
- scripts/code-smell-ratchet.sh
- scripts/ci/check-ignore-without-comment-diff.sh --base origin/main --head HEAD
- git diff --check