### PR TITLE
refactor(keeper_supervisor): extract publish_lifecycle helpers sibling

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -37,34 +37,8 @@ let committed_tools_of_ambiguous_blocker =
    either Custom_event (with optional phase context) or Phase_event,
    eliminating the [~phase:Stopped ~event:"crashed"] typo class
    originally addressed at runtime by #8572 / #8575. *)
-let publish_lifecycle
-      ~(event : Keeper_lifecycle_events.lifecycle_event)
-      keeper_name
-      detail
-      ()
-  =
-  let event_name = Keeper_lifecycle_events.lifecycle_event_to_string event in
-  let phase =
-    Option.map
-      Keeper_state_machine.phase_to_string
-      (Keeper_lifecycle_events.lifecycle_event_phase event)
-  in
-  (* #12798: record in the per-keeper lifecycle audit ring for dashboard. *)
-  Keeper_lifecycle_audit.record ~keeper_name ~event_name ~phase ~detail;
-  match Keeper_keepalive.get_bus () with
-  | Some bus -> Cascade_events.publish_keeper_lifecycle bus ~event ~keeper_name ~detail ()
-  | None -> ()
-;;
-
-(** Phase-event helper: the wire event name IS the phase name. *)
-let publish_phase_lifecycle ~phase keeper_name detail () =
-  publish_lifecycle
-    ~event:(Keeper_lifecycle_events.Phase_event phase)
-    keeper_name
-    detail
-    ()
-;;
-
+let publish_lifecycle = Keeper_supervisor_publish_lifecycle.publish_lifecycle
+let publish_phase_lifecycle = Keeper_supervisor_publish_lifecycle.publish_phase_lifecycle
 let fork_stale_watchdog = Keeper_stale_watchdog.fork_stale_watchdog
 
 (* ── Supervised fiber launch ─────────────────────────────── *)

--- a/lib/keeper/keeper_supervisor_publish_lifecycle.ml
+++ b/lib/keeper/keeper_supervisor_publish_lifecycle.ml
@@ -1,0 +1,48 @@
+(** Lifecycle event publisher, extracted from [keeper_supervisor.ml]
+    (godfile decomp).
+
+    [publish_lifecycle] is the supervisor's single event-emission
+    helper.  It (a) records the event into the per-keeper lifecycle
+    audit ring for the dashboard (#12798), and (b) republishes onto
+    the cascade event bus iff [Keeper_keepalive.get_bus ()] resolves —
+    pre-bus callers no-op gracefully.
+
+    [publish_phase_lifecycle ~phase] is a thin convenience that
+    constructs a [Keeper_lifecycle_events.Phase_event phase] and
+    forwards.  The phase IS the wire event name.
+
+    Background — the legacy [publish_lifecycle ?phase event_name]
+    (string event_name) and [publish_phase_lifecycle ~phase] surfaces
+    were folded into [publish_lifecycle ~event] (#8856 / #8605
+    family) so the compiler enforces that every call site picks
+    either [Custom_event] (with optional phase context) or
+    [Phase_event], eliminating the [~phase:Stopped ~event:"crashed"]
+    typo class addressed at runtime by #8572 / #8575. *)
+
+let publish_lifecycle
+      ~(event : Keeper_lifecycle_events.lifecycle_event)
+      keeper_name
+      detail
+      ()
+  =
+  let event_name = Keeper_lifecycle_events.lifecycle_event_to_string event in
+  let phase =
+    Option.map
+      Keeper_state_machine.phase_to_string
+      (Keeper_lifecycle_events.lifecycle_event_phase event)
+  in
+  (* #12798: record in the per-keeper lifecycle audit ring for dashboard. *)
+  Keeper_lifecycle_audit.record ~keeper_name ~event_name ~phase ~detail;
+  match Keeper_keepalive.get_bus () with
+  | Some bus -> Cascade_events.publish_keeper_lifecycle bus ~event ~keeper_name ~detail ()
+  | None -> ()
+;;
+
+(** Phase-event helper: the wire event name IS the phase name. *)
+let publish_phase_lifecycle ~phase keeper_name detail () =
+  publish_lifecycle
+    ~event:(Keeper_lifecycle_events.Phase_event phase)
+    keeper_name
+    detail
+    ()
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane B
- 6th sibling extracted from `keeper_supervisor.ml` (after #17291 `cleanup_dead_tombstone`, #17342 `reconcile_keepalive_keepers`, #17350 `resume_keeper_after_reconcile_gate`, #17362 `restore_reconcile_continue_gate`, #17379 `supervise_keepalive`).
- **Callback-target extraction** — `publish_lifecycle` is the callback injected into 4 of the previous siblings; this PR moves the definition into its own sibling without touching the injection chain.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/keeper/keeper_supervisor.ml` | 1297 | 1271 | **-26** |
| `lib/keeper/keeper_supervisor_publish_lifecycle.ml` | — | 48 | +48 |

## Moved (verbatim, no behavior change)

### `publish_lifecycle ~event keeper_name detail ()`
- Extracts `event_name` via `Keeper_lifecycle_events.lifecycle_event_to_string`
- Extracts optional `phase` via `Option.map Keeper_state_machine.phase_to_string (Keeper_lifecycle_events.lifecycle_event_phase event)`
- Records into `Keeper_lifecycle_audit.record ~keeper_name ~event_name ~phase ~detail` (#12798 — dashboard ring)
- Republishes onto the cascade event bus iff `Keeper_keepalive.get_bus ()` resolves; `None` (pre-bus startup) no-ops gracefully

### `publish_phase_lifecycle ~phase keeper_name detail ()`
- Thin forwarder: constructs `Keeper_lifecycle_events.Phase_event phase` and calls `publish_lifecycle ~event`

Parent retains 2 single-line aliases.

## Callback chain (unchanged)
`publish_lifecycle` is injected as `~publish_lifecycle` into 4 prior sibling extractions:
- #17342 `Keeper_supervisor_reconcile_keepalive.reconcile_keepalive_keepers`
- #17350 `Keeper_supervisor_resume_reconcile_gate.resume_keeper_after_reconcile_gate`
- #17362 `Keeper_supervisor_restore_reconcile_gate.restore_reconcile_continue_gate`
- #17379 `Keeper_supervisor_supervise_keepalive.supervise_keepalive`

Each captures the identifier `publish_lifecycle` from the parent's scope. After this extraction, the parent's `let publish_lifecycle = Keeper_supervisor_publish_lifecycle.publish_lifecycle` binds the identifier to the sibling value — callback semantics identical.

## Internal in-parent callers (also unchanged via aliases)
- `launch_supervised_fiber` (lines 260, 299, 361, 475) — `publish_phase_lifecycle ...` calls
- `apply_self_preservation` wrapper (line 631) — passes `~publish_lifecycle`
- `cleanup_dead_tombstone` wrapper (line 585) — passes `~publish_lifecycle`
- pause-policy wrappers (lines 658, 662, 666) — pass `~publish_phase_lifecycle`

## Sibling deps (all external)
- `Keeper_lifecycle_events.{lifecycle_event_to_string, lifecycle_event_phase, lifecycle_event, Phase_event}`
- `Keeper_state_machine.phase_to_string`
- `Keeper_lifecycle_audit.record`
- `Keeper_keepalive.get_bus`
- `Cascade_events.publish_keeper_lifecycle`
- Std: `Option.map`

No parent-local dependencies; no sibling -> parent cycle.

## External callers / `.mli`
None. Both functions are local-only (not in `.mli`, no external references). The parent aliases preserve future cross-module use.

## Local build status
- `dune build --root . lib/keeper/` → clean (exit 0)
- godfile lint: sibling 48 LOC under `new_file_cap=600`; parent 1271 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim 2-helper cluster move, 2 parent aliases.

Co-Authored-By: codex <noreply@anthropic.com>
