### PR TITLE
refactor(operator_control_snapshot): extract room_json sibling

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -725,33 +725,7 @@ let _snapshot_recent_completed_limit () =
 
 (* sessions_json removed — team session cleanup. Sessions always return []. *)
 
-let room_json config =
-  let initialized = Coord.is_initialized config in
-  if not initialized
-  then
-    `Assoc
-      [ "initialized", `Bool false
-      ; "project", `String (Filename.basename config.base_path)
-      ]
-  else (
-    let state = Coord.read_state config in
-    let tempo = Tempo.get_tempo config in
-    let tasks = Coord.get_tasks_raw config in
-    let agents = Coord.get_agents_raw config in
-    `Assoc
-      [ "initialized", `Bool true
-      ; "cluster", `String (Env_config_core.cluster_name ())
-      ; "project", `String state.project
-      ; "paused", `Bool state.paused
-      ; "pause_reason", string_option_to_json state.pause_reason
-      ; "paused_by", string_option_to_json state.paused_by
-      ; "paused_at", string_option_to_json state.paused_at
-      ; "tempo_interval_s", `Float tempo.current_interval_s
-      ; "agent_count", `Int (List.length agents)
-      ; "task_count", `Int (List.length tasks)
-      ; "message_seq", `Int state.message_seq
-      ])
-;;
+let room_json = Operator_control_snapshot_room.room_json
 
 (* snapshot_view variant + parser extracted to
    [Operator_control_snapshot_view] (godfile decomp). *)

--- a/lib/operator/operator_control_snapshot_room.ml
+++ b/lib/operator/operator_control_snapshot_room.ml
@@ -1,0 +1,44 @@
+(** Operator dashboard room descriptor, extracted from
+    [operator_control_snapshot.ml] (godfile decomp).
+
+    [room_json config] produces a minimal room-state summary for the
+    operator dashboard:
+
+    - When the room is not yet initialized via [Coord.init], returns
+      `{initialized=false, project=basename(base_path)}` so the
+      dashboard can render a placeholder before any keeper has
+      bootstrapped the coordination root.
+
+    - When initialized, returns the full snapshot: cluster name,
+      project, paused state with reason/by/at, tempo interval,
+      agent/task counts, and the current message_seq.
+
+    Pure helper move — local-only function with no .mli surface. *)
+
+let room_json config =
+  let initialized = Coord.is_initialized config in
+  if not initialized
+  then
+    `Assoc
+      [ "initialized", `Bool false
+      ; "project", `String (Filename.basename config.base_path)
+      ]
+  else (
+    let state = Coord.read_state config in
+    let tempo = Tempo.get_tempo config in
+    let tasks = Coord.get_tasks_raw config in
+    let agents = Coord.get_agents_raw config in
+    `Assoc
+      [ "initialized", `Bool true
+      ; "cluster", `String (Env_config_core.cluster_name ())
+      ; "project", `String state.project
+      ; "paused", `Bool state.paused
+      ; "pause_reason", Operator_pending_confirm.string_option_to_json state.pause_reason
+      ; "paused_by", Operator_pending_confirm.string_option_to_json state.paused_by
+      ; "paused_at", Operator_pending_confirm.string_option_to_json state.paused_at
+      ; "tempo_interval_s", `Float tempo.current_interval_s
+      ; "agent_count", `Int (List.length agents)
+      ; "task_count", `Int (List.length tasks)
+      ; "message_seq", `Int state.message_seq
+      ])
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane F
- 4th sibling extracted from `operator_control_snapshot.ml` (after #17329 `identity_fields`, #17368 `snapshot_view`, #17386 `persistent_agents_json`).
- **Modest yield** (-26 LOC) but clean — local-only function with single internal caller.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/operator/operator_control_snapshot.ml` | 1148 | 1122 | **-26** |
| `lib/operator/operator_control_snapshot_room.ml` | — | 44 | +44 |

## Moved (verbatim, no behavior change)
- `room_json config` — two-branch room descriptor:
  - **Uninitialized branch** (`not (Coord.is_initialized config)`):
    ```json
    { "initialized": false, "project": "<basename(base_path)>" }
    ```
  - **Initialized branch**: reads `Coord.read_state`, `Tempo.get_tempo`,
    `Coord.get_tasks_raw`, `Coord.get_agents_raw` and emits:
    - `initialized`: `true`
    - `cluster`: `Env_config_core.cluster_name ()`
    - `project`: `state.project`
    - `paused`: `state.paused`
    - `pause_reason`, `paused_by`, `paused_at`: nullable strings via `string_option_to_json`
    - `tempo_interval_s`: `tempo.current_interval_s`
    - `agent_count`, `task_count`: list lengths
    - `message_seq`: `state.message_seq`

Parent retains a 1-line alias.

## External callers / `.mli`
None. Not in `.mli`; single internal caller `snapshot_json` at parent line ~1148 (post-splice). The alias preserves the surface for future cross-module use.

## Sibling deps
- `Coord.{is_initialized, read_state, get_tasks_raw, get_agents_raw}`
- `Tempo.get_tempo`
- `Env_config_core.cluster_name`
- `Operator_pending_confirm.string_option_to_json` (used **qualified** — see note)
- Std: `Filename.basename`, `List.length`

**Qualified-vs-include trade-off**: parent uses `include Operator_pending_confirm` to bring `string_option_to_json` into open scope. The sibling could mirror the `include` but I chose to qualify the 3 call sites (`Operator_pending_confirm.string_option_to_json`) explicitly. Both forms resolve identically; the qualified form makes the dependency boundary visible and avoids a redundant `include` for a single helper. This differs from #17386 (which used `include Operator_control_context_snapshot`) where the sibling needed *multiple* identifiers from the included module.

No sibling -> parent cycle.

## Local build status
- `dune build --root . lib/operator/` → clean (exit 0)
- godfile lint: sibling 44 LOC under `new_file_cap=600`; parent 1122 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim single-function move, 1-line parent alias.

Co-Authored-By: codex <noreply@anthropic.com>
