### PR TITLE
refactor(cascade_transport): extract cli_transport_overrides type sibling

### DIFF
--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -4,7 +4,9 @@
     CLI transport construction separate from the build/run orchestration in
     {!Cascade_runner}. *)
 
-type cli_transport_overrides =
+(* cli_transport_overrides type extracted to
+   [Cascade_transport_cli_overrides] (godfile decomp). *)
+type cli_transport_overrides = Cascade_transport_cli_overrides.cli_transport_overrides =
   { cwd : string option
   ; claude_mcp_config : string option
   ; claude_allowed_tools : string list option
@@ -12,14 +14,6 @@ type cli_transport_overrides =
   ; claude_max_turns : int option
   ; gemini_yolo : bool option
   ; cli_subprocess_idle_sec : float option
-    (* When [Some s], the CLI subprocess is aborted via SIGINT if no
-     stdout line arrives within [s] seconds. Currently honoured only
-     by [Json_stream_cli_transport_local], which calls
-     [Cli_common_subprocess.run_stream_lines] directly. The other CLI
-     transports (claude_code, gemini_cli, codex_cli) route through
-     agent_sdk [Transport_*_cli.create] whose configs do not yet
-     expose [stdout_idle_timeout_s]; an OAS upstream change is needed
-     to honour this field there. *)
   }
 
 (* OAS owns provider subprocess hard caps. This constant is a
@@ -1097,16 +1091,7 @@ let register_non_http_transport ~kind ~ctor =
   Hashtbl.replace non_http_transport_registry kind ctor
 ;;
 
-let default_cli_transport_overrides =
-  { cwd = None
-  ; claude_mcp_config = None
-  ; claude_allowed_tools = None
-  ; claude_permission_mode = None
-  ; claude_max_turns = None
-  ; gemini_yolo = None
-  ; cli_subprocess_idle_sec = None
-  }
-;;
+let default_cli_transport_overrides = Cascade_transport_cli_overrides.default_cli_transport_overrides
 
 let with_proc_mgr (f : mgr:_ -> Llm_provider.Llm_transport.t) =
   match Process_eio.get_proc_mgr () with

--- a/lib/cascade/cascade_transport_cli_overrides.ml
+++ b/lib/cascade/cascade_transport_cli_overrides.ml
@@ -1,0 +1,50 @@
+(** CLI-transport override record + default, extracted from
+    [cascade_transport.ml] (godfile decomp).
+
+    [cli_transport_overrides] is the public record of per-keeper
+    overrides honoured by the cascade transport layer when binding a
+    subprocess CLI provider (Claude Code / Gemini CLI / Codex CLI /
+    Kimi CLI). Each field is honoured by exactly one provider kind;
+    missing fields fall back to the transport's [default_config].
+
+    [default_cli_transport_overrides] is the no-overrides record used
+    as the [Option.value ~default] target by the CLI transport ctors
+    when no [?cli_transport_overrides] is supplied.
+
+    This sibling owns the canonical definition; the parent re-exports
+    via a transparent type alias so existing callers
+    ([Cascade_runner.cli_transport_overrides] alias and the keeper
+    layer's record-typed forwarders) keep working unchanged.
+
+    Extracted as an enabling step for follow-up extraction of the
+    [non_http_transport_registry] dispatcher — which references this
+    type via its [non_http_transport_ctor] function-type signature. *)
+
+type cli_transport_overrides =
+  { cwd : string option
+  ; claude_mcp_config : string option
+  ; claude_allowed_tools : string list option
+  ; claude_permission_mode : string option
+  ; claude_max_turns : int option
+  ; gemini_yolo : bool option
+  ; cli_subprocess_idle_sec : float option
+    (* When [Some s], the CLI subprocess is aborted via SIGINT if no
+     stdout line arrives within [s] seconds. Currently honoured only
+     by [Json_stream_cli_transport_local], which calls
+     [Cli_common_subprocess.run_stream_lines] directly. The other CLI
+     transports (claude_code, gemini_cli, codex_cli) route through
+     agent_sdk [Transport_*_cli.create] whose configs do not yet
+     expose [stdout_idle_timeout_s]; an OAS upstream change is needed
+     to honour this field there. *)
+  }
+
+let default_cli_transport_overrides =
+  { cwd = None
+  ; claude_mcp_config = None
+  ; claude_allowed_tools = None
+  ; claude_permission_mode = None
+  ; claude_max_turns = None
+  ; gemini_yolo = None
+  ; cli_subprocess_idle_sec = None
+  }
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane D
- 5th sibling extracted from `cascade_transport.ml` (after #17303 `mcp_policy_helpers`, #17333 `auth_bridging`, #17347 `runtime_policy_provider`, #17366 `runtime_mcp_policy_of_tool_names`).
- **Enabling extraction** — the type was the blocker for extracting `non_http_transport_of_provider` (deferred earlier this sprint because its `non_http_transport_ctor` function-type signature references `cli_transport_overrides`).

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/cascade/cascade_transport.ml` | 1259 | 1244 | **-15** |
| `lib/cascade/cascade_transport_cli_overrides.ml` | — | 50 | +50 |

## Moved (verbatim, no behavior change)
- `type cli_transport_overrides` — 7-field public record:
  - `cwd : string option`
  - `claude_mcp_config : string option`
  - `claude_allowed_tools : string list option`
  - `claude_permission_mode : string option`
  - `claude_max_turns : int option`
  - `gemini_yolo : bool option`
  - `cli_subprocess_idle_sec : float option` (with the multi-line doc-comment about Json_stream_cli_transport_local being the sole honourer)

- `default_cli_transport_overrides` — record literal with all 7 fields = `None`.

Parent retains:
- Transparent type re-export with all 7 fields repeated (required to expose constructor + field labels):
  ```ocaml
  type cli_transport_overrides = Cascade_transport_cli_overrides.cli_transport_overrides =
    { cwd : string option
    ; ...
    }
  ```
- 1-line value alias for `default_cli_transport_overrides`.

## External callers (all unchanged via parent's transparent alias)
- `lib/cascade/cascade_runner.ml:20` + `cascade_runner.mli:48` — defines `Cascade_runner.cli_transport_overrides` as an explicit transparent re-export of `Cascade_transport.cli_transport_overrides`
- `lib/cascade/cascade_agent_context.ml:78` + `.mli:87` — record field typed `Cascade_transport.cli_transport_overrides option`
- `lib/keeper/keeper_turn_driver_try_provider.ml:49` + `.mli:32` — record field typed `Cascade_runner.cli_transport_overrides option`
- `lib/keeper/keeper_turn_driver.mli:248` — labeled arg typed `Cascade_runner.cli_transport_overrides`
- `lib/keeper/keeper_agent_run.ml:568` — explicit type annotation `: Cascade_runner.cli_transport_overrides`

Type identity preserved through the chain: `Cascade_transport_cli_overrides.cli_transport_overrides` = `Cascade_transport.cli_transport_overrides` = `Cascade_runner.cli_transport_overrides`.

## Enabling future extractions
This unblocks the deferred `non_http_transport_of_provider` extraction (~34 LOC, scouted earlier this sprint). That dispatcher's `non_http_transport_ctor` function-type signature is:
```ocaml
type non_http_transport_ctor =
  provider_cfg:Llm_provider.Provider_config.t
  -> runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy option
  -> cli_transport_overrides:cli_transport_overrides option  (* now movable *)
  -> (Llm_provider.Llm_transport.t, Agent_sdk.Error.sdk_error) result
```
With `cli_transport_overrides` now in a sibling, a follow-up PR can extract the dispatcher + registry without forcing the type to move with it.

## Sibling deps
None — `cli_transport_overrides` is a self-contained record of `option` types over `string`, `bool`, `int`, `float`, `string list`. Truly self-contained.

No sibling -> parent cycle.

## Local build status
- `dune build --root . lib/cascade/` → clean (exit 0)
- godfile lint: sibling 50 LOC under `new_file_cap=600`; parent 1244 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim type + value move via transparent alias.

Co-Authored-By: codex <noreply@anthropic.com>
