### PR TITLE
refactor(server): add operator digest http interface

### DIFF
--- a/lib/server/server_dashboard_http_core_operator_digest_http.mli
+++ b/lib/server/server_dashboard_http_core_operator_digest_http.mli
@@ -1,0 +1,10 @@
+(** Operator-digest HTTP handler extracted from [Server_dashboard_http_core]. *)
+
+val operator_digest_http_json :
+  state:Mcp_server.server_state ->
+  sw:Eio.Switch.t ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  Httpun.Request.t ->
+  (Yojson.Safe.t, 'a) result
+(** Serve the dashboard operator digest surface, using the cached default
+    namespace digest or a parameterized read-only dashboard compute. *)


### PR DESCRIPTION
## Summary

- Add the missing interface for `Server_dashboard_http_core_operator_digest_http`.
- Keep the extracted operator digest HTTP handler's public surface explicit and aligned with the parent `Server_dashboard_http_core` re-export.

## Product impact

- Restores the OCaml structure ratchet on current `origin/main`: `lib_other_mli_missing` returns to `0`.
- Keeps the operator digest dashboard handler API documented at the sibling boundary.

## Evidence

- `ocamlformat --check lib/server/server_dashboard_http_core_operator_digest_http.mli`
- `git diff --check`
- `scripts/ocaml-structure-ratchet.sh`
- `scripts/check-pr-hygiene.sh --base origin/main --head HEAD`

Local Dune build was not run: `scripts/dune-local.sh build lib/masc_mcp_lib.a` refused because another session has a live bare `dune build` process.

## Direct evidence

schema_version: 1
direct_ratio: 4/5
provenance: direct

- Direct: interface formatting check passed.
- Direct: diff whitespace check passed.
- Direct: OCaml structure ratchet passed.
- Direct: PR hygiene check passed.
- Not direct: local Dune compile, blocked by existing bare Dune process.

## Review evidence

- The new `.mli` exposes only `operator_digest_http_json`, the single function referenced by `Server_dashboard_http_core`.
- The signature mirrors the parent module's public re-export shape.

## Linked issue

- Follow-up slice from the remaining godfile/structure cleanup queue.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/operator-digest-http-mli-20260521` → `main` · 1 commit(s) · synced 2026-05-21T12:41:50Z

| sha | subject | date |
|---|---|---|
| `ec4dc4b92` | refactor(server): add operator digest http interface | 2026-05-21 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->