### PR TITLE
fix(keeper): floor load-bearing native bash timeouts

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -229,7 +229,7 @@ let handle_keeper_bash
   =
   let timeout_sec =
     Keeper_shell_shared.clamp_shell_timeout
-      ~min_sec:Keeper_shell_shared.keeper_bash_native_min_timeout_sec
+      ~min_sec:(Keeper_shell_shared.keeper_bash_min_timeout_sec_for_args args)
       ~default:Keeper_shell_shared.io_timeout_sec
       args
   in

--- a/lib/keeper/keeper_shell_shared.ml
+++ b/lib/keeper/keeper_shell_shared.ml
@@ -93,6 +93,65 @@ let keeper_bash_native_min_timeout_sec =
   Timeout_floor.default_sec Timeout_floor.Native_shell
 ;;
 
+let string_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`String value) -> Some value
+  | _ -> None
+;;
+
+let string_list_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`List values) ->
+    List.filter_map
+      (function
+        | `String value -> Some value
+        | _ -> None)
+      values
+  | _ -> []
+;;
+
+let arg_has_recursive_flag arg =
+  String.length arg >= 2
+  && arg.[0] = '-'
+  && (String.contains arg 'r' || String.contains arg 'R')
+;;
+
+let executable_is_dune_local executable =
+  String.equal executable "dune-local.sh"
+  || String.equal executable "scripts/dune-local.sh"
+  || String.ends_with ~suffix:"/scripts/dune-local.sh" executable
+;;
+
+let typed_stage_needs_tool_dispatch_floor fields =
+  match string_field "executable" fields with
+  | None -> false
+  | Some executable ->
+    let argv = string_list_field "argv" fields in
+    String.equal executable "git"
+    || String.equal executable "rg"
+    || String.equal executable "find"
+    || executable_is_dune_local executable
+    || (String.equal executable "grep" && List.exists arg_has_recursive_flag argv)
+;;
+
+let rec keeper_bash_args_need_tool_dispatch_floor = function
+  | `Assoc fields ->
+    typed_stage_needs_tool_dispatch_floor fields
+    ||
+    (match List.assoc_opt "pipeline" fields, List.assoc_opt "stages" fields with
+     | Some (`List stages), _
+     | _, Some (`List stages) ->
+       List.exists keeper_bash_args_need_tool_dispatch_floor stages
+     | _ -> false)
+  | _ -> false
+;;
+
+let keeper_bash_min_timeout_sec_for_args args =
+  if keeper_bash_args_need_tool_dispatch_floor args
+  then Timeout_floor.default_sec Timeout_floor.Tool_dispatch
+  else keeper_bash_native_min_timeout_sec
+;;
+
 let clamp_shell_timeout
       ?(min_sec = Timeout_floor.default_sec Timeout_floor.Native_shell)
       ~default

--- a/lib/keeper/keeper_shell_shared.mli
+++ b/lib/keeper/keeper_shell_shared.mli
@@ -85,6 +85,12 @@ val keeper_bash_native_min_timeout_sec : float
     issue #5, 2026-05-20).  Keeping a separate native floor avoids
     penalising the host-side fast path for the Docker path's overhead. *)
 
+val keeper_bash_min_timeout_sec_for_args : Yojson.Safe.t -> float
+(** Minimum timeout_sec floor for a typed keeper_bash invocation.
+    Trivial native commands keep {!keeper_bash_native_min_timeout_sec}; git,
+    recursive scans, and local Dune wrapper invocations use the shared
+    Tool_dispatch floor. *)
+
 val git_meta_timeout_sec : float
 (** Ceiling for lightweight git metadata commands (rev-parse,
     log --oneline).  Default 5s, env:

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -327,6 +327,43 @@ let test_keeper_bash_timeout_floor_is_not_sub_io_latency () =
        ~default:Masc_mcp.Keeper_shell_shared.io_timeout_sec
        args)
 
+let test_keeper_bash_load_bearing_timeout_floor () =
+  let check name args expected =
+    Alcotest.(check (float 0.001))
+      name
+      expected
+      (Masc_mcp.Keeper_shell_shared.keeper_bash_min_timeout_sec_for_args args)
+  in
+  check
+    "trivial command keeps native floor"
+    (`Assoc [ "executable", `String "echo"; "argv", `List [ `String "ok" ] ])
+    Keeper_exec_shell.keeper_bash_native_min_timeout_sec;
+  check
+    "git command uses tool dispatch floor"
+    (`Assoc
+       [ "executable", `String "git"
+       ; "argv", `List [ `String "log"; `String "--oneline"; `String "-5" ]
+       ])
+    Masc_mcp.Keeper_shell_shared.gh_min_timeout_sec;
+  check
+    "recursive grep uses tool dispatch floor"
+    (`Assoc
+       [ "executable", `String "grep"
+       ; "argv", `List [ `String "-rn"; `String "Yojson"; `String "." ]
+       ])
+    Masc_mcp.Keeper_shell_shared.gh_min_timeout_sec;
+  check
+    "pipeline inherits load-bearing floor"
+    (`Assoc
+       [ ( "pipeline"
+         , `List
+             [ `Assoc [ "executable", `String "rg"; "argv", `List [ `String "x" ] ]
+             ; `Assoc [ "executable", `String "head"; "argv", `List [ `String "-5" ] ]
+             ] )
+       ])
+    Masc_mcp.Keeper_shell_shared.gh_min_timeout_sec
+;;
+
 let test_nested_runtime_detector_ignores_git_commit_message () =
   Alcotest.(check bool)
     "quoted docker in git commit message is not a nested runtime"
@@ -895,6 +932,10 @@ let () =
             "keeper_bash timeout floor avoids 1s I/O failures"
             `Quick
             test_keeper_bash_timeout_floor_is_not_sub_io_latency
+        ; Alcotest.test_case
+            "keeper_bash load-bearing timeout floor"
+            `Quick
+            test_keeper_bash_load_bearing_timeout_floor
         ; Alcotest.test_case
             "nested runtime detector ignores commit messages"
             `Quick


### PR DESCRIPTION
## Summary
- raise native keeper_bash timeout floor to 15s for typed load-bearing repo scans: git, rg, find, recursive grep, and dune-local.sh
- keep trivial native keeper_bash commands on the existing 5s floor
- add regression coverage for git log, recursive grep, and rg pipelines

## Evidence
- #17349 was reopened after the deployed worker shell_exec fix still produced new post-deploy native Process_eio 5s timeout samples: git log --oneline -5, git log --oneline --all, grep -rn Yojson .
- ocamlformat --check lib/keeper/keeper_shell_shared.ml lib/keeper/keeper_shell_shared.mli lib/keeper/keeper_shell_bash.ml test/test_keeper_bash_safety.ml
- git diff --check origin/main..HEAD
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_bash_safety.exe
- ./_build/default/test/test_keeper_bash_safety.exe: 36 tests, Test Successful

Fixes #17349