### PR TITLE
[codex] Pass docker bash script over stdin

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -708,7 +708,7 @@ let run_docker_shell_command_with_status_internal
                             @ cred_mounts
                             @ cred_envs
                             @ identity_mounts
-                            @ [ image; "bash"; "-lc"; cmd ]
+                            @ [ image; "bash"; "-l"; "-s" ]
                           in
                           (try
                              let status, output =
@@ -718,13 +718,14 @@ let run_docker_shell_command_with_status_internal
                                    restore_gitdirs ())
                                @@ fun () ->
                                Docker_spawn_throttle.with_slot (fun () ->
-                                 Masc_exec.Exec_gate.run_argv_with_status
+                                 Masc_exec.Exec_gate.run_argv_with_stdin_and_status
                                    ~actor:`Keeper_shell
                                    ~raw_source:(String.concat " " argv)
                                    ~summary:"keeper docker command"
                                    ~env:(Unix.environment ())
                                    ~cwd:(Sys.getcwd ())
                                    ~timeout_sec
+                                   ~stdin_content:cmd
                                    argv)
                              in
                              if not (docker_command_semantic_success ~cmd ~status ~output)

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -474,6 +474,10 @@ while [ \"$#\" -gt 0 ]; do\n\
   fi\n\
   shift\n\
 done\n\
+script=$(cat)\n\
+case \"$script\" in\n\
+  *rg*) exit 1 ;;\n\
+esac\n\
 if [ \"$1\" = \"rg\" ]; then\n\
   exit 1\n\
 fi\n\
@@ -506,8 +510,9 @@ while [ \"$#\" -gt 0 ]; do\n\
   fi\n\
   shift\n\
 done\n\
-if [ \"$1\" = \"bash\" ] && [ \"$2\" = \"-lc\" ]; then\n\
-  case \"$3\" in\n\
+if [ \"$1\" = \"bash\" ] && [ \"$2\" = \"-l\" ] && [ \"$3\" = \"-s\" ]; then\n\
+  script=$(cat)\n\
+  case \"$script\" in\n\
     *rg*) exit 1 ;;\n\
   esac\n\
 fi\n\
@@ -656,6 +661,7 @@ while [ \"$#\" -gt 0 ]; do\n\
   fi\n\
   shift\n\
 done\n\
+cat >/dev/null\n\
 printf 'stdout:%s\\n' \"$*\"\n\
 exit 0\n"
 
@@ -934,7 +940,7 @@ let test_bash_git_push_routes_through_git_creds_docker () =
   let log = read_file log_path in
   Alcotest.(check bool) "git push used docker run" true
     (contains_substring log "run --rm");
-  Alcotest.(check bool) "git push command preserved" true
+  Alcotest.(check bool) "git push command is not exposed in docker argv" false
     (contains_substring log "git push origin feature/proof");
   let root_gh_dir =
     Masc_mcp.Keeper_gh_env.root_gh_config_dir config


### PR DESCRIPTION
## Summary
- stop passing keeper bash command text as the docker run argv tail (`bash -lc <cmd>`)
- invoke bash as `bash -l -s` and pipe the command via Exec_gate stdin support
- update fake docker route tests to read stdin and assert sensitive git push text is not exposed in docker argv logs

## Verification
- rebased onto current origin/main before push
- `opam exec -- ocamlformat --check lib/keeper/keeper_shell_docker.ml test/test_keeper_shell_docker_route.ml`
- `git diff --check origin/main..HEAD`
- `bash scripts/lint/shell-legacy-purge-ratchet.sh`
- `scripts/lint-spawn-bounded.sh`
- source guard: no `[ image; "bash"; "-lc"; cmd ]` remains in `keeper_shell_docker.ml`

Focused Dune target check was attempted with `scripts/dune-local.sh build test/test_keeper_shell_docker_route.exe`, but the wrapper refused to start because other live bare `dune build` processes are bypassing the machine-wide Dune lock.