### PR TITLE
refactor(keeper_agent_run): extract phase0 telemetry

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -200,6 +200,7 @@
   keeper_turn_telemetry
   keeper_agent_prompt_metrics
   keeper_agent_tool_surface
+  keeper_agent_run_phase0_telemetry
   keeper_agent_run_contract_helpers
   keeper_agent_run_receipt_append
   keeper_agent_result

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -567,51 +567,15 @@ let run_turn
             }
             : Cascade_runner.cli_transport_overrides)
        in
-       (* Phase 0: wake-time payload telemetry (Option C baseline).
-       Entire block is dead code when MASC_PAYLOAD_TELEMETRY is unset.
-       Compute logic lives in [Keeper_wake_telemetry] for unit tests;
-       exceptions from the telemetry path never abort the LLM call. *)
-       let () =
-         if Env_config_keeper.KeeperTelemetry.payload_telemetry_enabled ()
-         then (
-           try
-             let sizes =
-               Keeper_wake_telemetry.compute_sizes
-                 ~system_prompt:turn_system_prompt
-                 ~tools
-                 ~history_messages
-                 ~user_message
-             in
-             let model_id =
-               match Keeper_model_labels.configured_model_labels_of_meta meta with
-               | m :: _ -> m
-               | [] -> "auto"
-             in
-             let _event : Dashboard_harness_health.wake_payload_event =
-               Dashboard_harness_health.record_wake_payload
-                 ~keeper_name:meta.name
-                 ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-                 ~turn_index:start_turn_count
-                 ~model_id
-                 ~context_window:max_context
-                 ~approx_body_bytes:sizes.approx_body_bytes
-                 ~system_prompt_bytes:sizes.system_prompt_bytes
-                 ~tool_defs_bytes:sizes.tool_defs_bytes
-                 ~messages_bytes:sizes.messages_bytes
-                 ~message_count:sizes.message_count
-                 ~role_counts:sizes.role_counts
-                 ~tool_count:sizes.tool_count
-                 ~has_compact_happened:pre_dispatch_compacted
-             in
-             ()
-           with
-           | Eio.Cancel.Cancelled _ as e -> raise e
-           | exn ->
-             Log.Harness.warn
-               "[wake_payload] telemetry failed keeper=%s: %s"
-               meta.name
-               (Printexc.to_string exn))
-       in
+       Keeper_agent_run_phase0_telemetry.record_if_enabled
+         ~meta
+         ~turn_system_prompt
+         ~tools
+         ~history_messages
+         ~user_message
+         ~start_turn_count
+         ~max_context
+         ~pre_dispatch_compacted;
        let turn_result =
          match pre_dispatch_checkpoint_error with
          | Some err -> Error err

--- a/lib/keeper/keeper_agent_run_phase0_telemetry.ml
+++ b/lib/keeper/keeper_agent_run_phase0_telemetry.ml
@@ -1,0 +1,52 @@
+(** Phase-0 wake-time payload telemetry, extracted from [Keeper_agent_run]. *)
+
+let record_if_enabled
+    ~(meta : Keeper_types.keeper_meta)
+    ~turn_system_prompt
+    ~tools
+    ~history_messages
+    ~user_message
+    ~start_turn_count
+    ~max_context
+    ~pre_dispatch_compacted
+  =
+  if Env_config_keeper.KeeperTelemetry.payload_telemetry_enabled ()
+  then (
+    try
+      let sizes =
+        Keeper_wake_telemetry.compute_sizes
+          ~system_prompt:turn_system_prompt
+          ~tools
+          ~history_messages
+          ~user_message
+      in
+      let model_id =
+        match Keeper_model_labels.configured_model_labels_of_meta meta with
+        | m :: _ -> m
+        | [] -> "auto"
+      in
+      let _event : Dashboard_harness_health.wake_payload_event =
+        Dashboard_harness_health.record_wake_payload
+          ~keeper_name:meta.name
+          ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+          ~turn_index:start_turn_count
+          ~model_id
+          ~context_window:max_context
+          ~approx_body_bytes:sizes.approx_body_bytes
+          ~system_prompt_bytes:sizes.system_prompt_bytes
+          ~tool_defs_bytes:sizes.tool_defs_bytes
+          ~messages_bytes:sizes.messages_bytes
+          ~message_count:sizes.message_count
+          ~role_counts:sizes.role_counts
+          ~tool_count:sizes.tool_count
+          ~has_compact_happened:pre_dispatch_compacted
+      in
+      ()
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Log.Harness.warn
+        "[wake_payload] telemetry failed keeper=%s: %s"
+        meta.name
+        (Printexc.to_string exn))
+;;

--- a/lib/keeper/keeper_agent_run_phase0_telemetry.mli
+++ b/lib/keeper/keeper_agent_run_phase0_telemetry.mli
@@ -1,0 +1,16 @@
+(** Phase-0 wake payload telemetry for [Keeper_agent_run.run_turn]. *)
+
+val record_if_enabled :
+  meta:Keeper_types.keeper_meta ->
+  turn_system_prompt:string ->
+  tools:Agent_sdk.Tool.t list ->
+  history_messages:Agent_sdk.Types.message list ->
+  user_message:string ->
+  start_turn_count:int ->
+  max_context:int ->
+  pre_dispatch_compacted:bool ->
+  unit
+(** Record wake-time payload sizing when [MASC_PAYLOAD_TELEMETRY] is enabled.
+
+    The telemetry path is best-effort: cancellation is re-raised, while other
+    exceptions are logged and do not abort the LLM call. *)

--- a/lib/keeper/keeper_supervisor_publish_lifecycle.mli
+++ b/lib/keeper/keeper_supervisor_publish_lifecycle.mli
@@ -1,0 +1,17 @@
+(** Lifecycle event publisher extracted from [Keeper_supervisor]. *)
+
+val publish_lifecycle :
+  event:Keeper_lifecycle_events.lifecycle_event ->
+  string ->
+  string ->
+  unit ->
+  unit
+(** Record and publish a keeper lifecycle event. *)
+
+val publish_phase_lifecycle :
+  phase:Keeper_state_machine.phase ->
+  string ->
+  string ->
+  unit ->
+  unit
+(** Publish a lifecycle event whose wire event name is the phase name. *)

--- a/lib/operator/operator_control_snapshot_room.mli
+++ b/lib/operator/operator_control_snapshot_room.mli
@@ -1,0 +1,4 @@
+(** Operator dashboard room descriptor extracted from [Operator_control_snapshot]. *)
+
+val room_json : Coord.config -> Yojson.Safe.t
+(** Return the current room summary JSON for the operator dashboard. *)

--- a/lib/server/server_dashboard_http_core_operator_digest_http.mli
+++ b/lib/server/server_dashboard_http_core_operator_digest_http.mli
@@ -1,0 +1,10 @@
+(** Operator-digest HTTP handler extracted from [Server_dashboard_http_core]. *)
+
+val operator_digest_http_json :
+  state:Mcp_server.server_state ->
+  sw:Eio.Switch.t ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  Httpun.Request.t ->
+  (Yojson.Safe.t, 'a) result
+(** Serve the dashboard operator digest surface, using the cached default
+    namespace digest or a parameterized read-only dashboard compute. *)


### PR DESCRIPTION
## Summary

- Extract `Keeper_agent_run.run_turn` Phase 0 wake payload telemetry into `Keeper_agent_run_phase0_telemetry`.
- Preserve best-effort telemetry semantics: `Cancelled` is re-raised, other telemetry failures warn and do not abort the LLM call.
- Add missing `.mli` files for current-main extracted siblings so the OCaml structure ratchet stays green.

## Product impact

- Starts RFC-0147 PR-1 implementation for `keeper_agent_run` decomposition.
- Reduces `lib/keeper/keeper_agent_run.ml` from 2220 LOC to 2184 LOC.
- Restores structure ratchet on current main by covering three missing sibling interfaces.

## Evidence

- `ocamlformat --check lib/keeper/keeper_agent_run.ml lib/keeper/keeper_agent_run_phase0_telemetry.ml lib/keeper/keeper_agent_run_phase0_telemetry.mli lib/keeper/keeper_supervisor_publish_lifecycle.mli lib/operator/operator_control_snapshot_room.mli lib/server/server_dashboard_http_core_operator_digest_http.mli`
- `git diff --check`
- `scripts/ocaml-structure-ratchet.sh`
- `scripts/check-pr-hygiene.sh --base origin/main --head HEAD`

Local Dune build was not run: `scripts/dune-local.sh build lib/masc_mcp_lib.a` refused because other sessions have live bare `dune build` processes.

## Direct evidence

schema_version: 1
direct_ratio: 4/5
provenance: direct

- Direct: formatting check passed.
- Direct: diff whitespace check passed.
- Direct: OCaml structure ratchet passed.
- Direct: PR hygiene check passed.
- Not direct: local Dune compile, blocked by existing bare Dune processes.

## Review evidence

- Extracted function is called once at the original Phase 0 site.
- The moved block keeps the same inputs, same `Keeper_wake_telemetry.compute_sizes` call, same `Dashboard_harness_health.record_wake_payload` fields, and same exception behavior.

## Linked issue

- RFC-0147 keeper-agent-run decomposition, PR-1 Phase 0 telemetry slice.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/agent-run-phase0-telemetry-20260521` → `main` · 1 commit(s) · synced 2026-05-21T12:47:11Z

| sha | subject | date |
|---|---|---|
| `80c590668` | refactor(keeper_agent_run): extract phase0 telemetry | 2026-05-21 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->