### PR TITLE
[codex] Clarify keeper ops runtime blockers

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -2,7 +2,7 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { AgentRoster, countRuntimeKinds, rosterStateNote } from './agent-roster'
+import { AgentRoster, countRuntimeKinds, rosterBlockerDisplay, rosterStateNote } from './agent-roster'
 import type { Agent, Keeper } from '../types'
 import type { KeeperCompositeSnapshot } from '../api/schemas/keeper-composite'
 import {
@@ -204,6 +204,44 @@ describe('rosterStateNote — RFC-0135 §1.1 typed-state conditioning', () => {
 
   it('null keeper returns null', () => {
     expect(rosterStateNote(null, null, null)).toBeNull()
+  })
+})
+
+describe('rosterBlockerDisplay', () => {
+  it('turns raw blocker code into an operator label and hint', () => {
+    const note = {
+      label: '현재 차단',
+      text: 'fiber_unresolved',
+      kind: 'fiber_unresolved',
+    }
+    const display = rosterBlockerDisplay(note, {
+      name: 'executor',
+      status: 'active',
+      runtime_blocker_class: 'fiber_unresolved',
+      runtime_blocker_summary: 'fiber_unresolved',
+    } as Keeper)
+
+    expect(display.cell).toBe('현재 차단: Fiber 미해결')
+    expect(display.detail).toBe('Keeper fiber가 종료 상태를 확정하지 못해 supervisor 확인이 필요합니다.')
+    expect(display.title).toContain('fiber_unresolved')
+  })
+
+  it('keeps real summary text instead of replacing it with the generic hint', () => {
+    const display = rosterBlockerDisplay(
+      {
+        label: '현재 차단',
+        text: 'cascade list 소진',
+        kind: 'cascade_exhausted',
+      },
+      {
+        name: 'echo',
+        status: 'active',
+        runtime_blocker_class: 'cascade_exhausted',
+      } as Keeper,
+    )
+
+    expect(display.cell).toBe('현재 차단: 캐스케이드 소진')
+    expect(display.detail).toBe('cascade list 소진')
   })
 })
 
@@ -441,6 +479,35 @@ describe('AgentRoster live-only cards', () => {
 
     expect(container.querySelector('aside h3')?.textContent).toContain('beta-agent')
     expect(container.textContent).toContain('상세 열기')
+  })
+
+  it('explains roster axes and renders blocker labels before raw codes', async () => {
+    agents.value = [
+      makeAgent({ name: 'keeper-executor-agent', status: 'active' }),
+    ]
+    keepers.value = [
+      {
+        name: 'executor',
+        agent_name: 'keeper-executor-agent',
+        status: 'active',
+        runtime_blocker_class: 'fiber_unresolved',
+        runtime_blocker_summary: 'fiber_unresolved',
+      } as Keeper,
+    ]
+
+    await act(async () => {
+      render(html`<${AgentRoster} keeperFilter="keeper-only" />`, container)
+    })
+    await flushUi()
+
+    const text = container.textContent ?? ''
+    expect(text).toContain('운영판정')
+    expect(text).toContain('현재 단계')
+    expect(text).toContain('차단 근거')
+    expect(text).toContain('점')
+    expect(text).toContain('파생')
+    expect(text).toContain('현재 차단: Fiber 미해결')
+    expect(text).toContain('Keeper fiber가 종료 상태를 확정하지 못해 supervisor 확인이 필요합니다.')
   })
 
   it('uses heartbeat and full keeper model for cards when action/model fallbacks disagree', async () => {

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -49,6 +49,8 @@ import {
 } from '../runtime-counts'
 import {
   keeperActivityDisplay,
+  keeperRuntimeBlockerHint,
+  keeperRuntimeBlockerLabel,
 } from '../lib/keeper-runtime-display'
 // RFC-0135 PR-4: roster card derives its blocker note through the typed
 // KeeperOperationalState SSOT so the headline (`현재 차단` vs `이전 차단`
@@ -63,6 +65,8 @@ import type { KeeperCompositeSnapshot } from '../api/schemas/keeper-composite'
 import { fleetCompositeSnapshot } from '../composite-signals'
 
 type StatusFilter = 'all' | RuntimeBand
+
+type RosterStateNote = { label: string; text: string; kind?: string }
 
 function stageBadgeClass(stageKey: string): string {
   if (stageKey === 'tool_use') return 'border-[var(--info-border)] bg-[var(--accent-12)] text-[var(--color-accent-fg)]'
@@ -114,7 +118,7 @@ export function rosterStateNote(
   keeper: Keeper | null | undefined,
   composite: KeeperCompositeSnapshot | null,
   monitoringHint?: string | null,
-): { label: string; text: string; kind?: string } | null {
+): RosterStateNote | null {
   if (!keeper) return null
 
   const state = deriveKeeperOperationalState({ keeper, composite })
@@ -145,6 +149,47 @@ export function rosterStateNote(
   const hint = monitoringHint?.trim()
   if (hint) return { label: '상태 메모', text: hint }
   return null
+}
+
+function noteLooksLikeRawKind(note: RosterStateNote): boolean {
+  if (!note.kind) return false
+  return note.text === note.kind || note.text === `차단 종류: ${note.kind} (요약 메시지 없음)`
+}
+
+export function rosterBlockerDisplay(
+  note: RosterStateNote | null,
+  keeper: Keeper | null | undefined,
+): {
+  cell: string
+  detail: string
+  title: string
+  kindLabel: string | null
+  rawKind: string | null
+} {
+  if (!note) {
+    return {
+      cell: '-',
+      detail: '현재 차단 근거 없음',
+      title: '현재 차단 근거 없음',
+      kindLabel: null,
+      rawKind: null,
+    }
+  }
+
+  const kindLabel =
+    note.kind && keeper?.runtime_blocker_class === note.kind
+      ? keeperRuntimeBlockerLabel(keeper.runtime_blocker_class)
+      : null
+  const displayKind = kindLabel ?? note.kind ?? null
+  const cell = displayKind ? `${note.label}: ${displayKind}` : note.label
+  const runtimeHint = noteLooksLikeRawKind(note) ? keeperRuntimeBlockerHint(keeper) : null
+  const detail = runtimeHint ?? note.text
+  const rawKind = note.kind ?? null
+  const title = rawKind && kindLabel
+    ? `${cell} (${rawKind}) · ${detail}`
+    : `${cell} · ${detail}`
+
+  return { cell, detail, title, kindLabel, rawKind }
 }
 
 function registerKeeperLookup<T extends Pick<Keeper, 'keeper_id' | 'name' | 'agent_name'>>(
@@ -759,6 +804,9 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     }
   })
   const selectedRow = rosterRows.find(row => row.key === selectedKey) ?? rosterRows[0] ?? null
+  const selectedBlockerDisplay = selectedRow
+    ? rosterBlockerDisplay(selectedRow.stateNote, selectedRow.keeperRuntime)
+    : null
 
   return html`
     <div class="agent-page flex w-full flex-col gap-5 px-0 py-1">
@@ -822,18 +870,25 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
       <div class="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
         <section class="monitor-surface-card monitor-surface-card-medium overflow-hidden" aria-label="Keeper operations list">
+          <div class="grid gap-2 border-b border-[var(--color-border-divider)] px-4 py-3 text-xs text-[var(--color-fg-muted)] lg:grid-cols-5">
+            <span><strong class="text-[var(--color-fg-secondary)]">운영판정</strong>은 필터용 요약입니다.</span>
+            <span><strong class="text-[var(--color-fg-secondary)]">현재 단계</strong>는 FSM/monitor phase입니다.</span>
+            <span><strong class="text-[var(--color-fg-secondary)]">차단 근거</strong>는 live/stale blocker 증거입니다.</span>
+            <span><strong class="text-[var(--color-fg-secondary)]">점</strong>은 활동/presence입니다. 흔들리면 방금 움직였습니다.</span>
+            <span><strong class="text-[var(--color-fg-secondary)]">파생</strong>은 keeper 런타임에서 만든 synthetic row입니다.</span>
+          </div>
           <div class="grid grid-cols-[minmax(180px,1.35fr)_minmax(90px,0.55fr)_minmax(150px,1fr)_minmax(150px,1fr)_minmax(120px,0.7fr)] gap-3 border-b border-[var(--color-border-divider)] px-4 py-2.5 text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)] max-lg:hidden">
             <span>Keeper</span>
-            <span>State</span>
-            <span>Now</span>
-            <span>Blocker</span>
-            <span>Tool</span>
+            <span>운영판정</span>
+            <span>현재 단계</span>
+            <span>차단 근거</span>
+            <span>최근 도구</span>
           </div>
 
           <div class="divide-y divide-[var(--color-border-divider)]">
             ${rosterRows.map(row => {
               const selected = selectedRow?.key === row.key
-              const blockerLabel = row.stateNote?.kind ?? row.stateNote?.label ?? '-'
+              const blockerDisplay = rosterBlockerDisplay(row.stateNote, row.keeperRuntime)
               const nowLabel =
                 row.fsmStageText
                 ?? row.monitoringEvidence?.phase?.label
@@ -875,17 +930,17 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                   </span>
 
                   <span class="min-w-0 text-xs leading-snug text-[var(--color-fg-primary)]">
-                    <span class="block truncate lg:hidden text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Now</span>
+                    <span class="block truncate lg:hidden text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">현재 단계</span>
                     <span class="block truncate">${nowLabel}</span>
                   </span>
 
                   <span class="min-w-0 text-xs leading-snug text-[var(--color-fg-primary)]">
-                    <span class="block truncate lg:hidden text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Blocker</span>
-                    <span class="block truncate" title=${row.stateNote?.text ?? blockerLabel}>${blockerLabel}</span>
+                    <span class="block truncate lg:hidden text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">차단 근거</span>
+                    <span class="block truncate" title=${blockerDisplay.title}>${blockerDisplay.cell}</span>
                   </span>
 
                   <span class="min-w-0 text-xs leading-snug text-[var(--color-fg-primary)]">
-                    <span class="block truncate lg:hidden text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">Tool</span>
+                    <span class="block truncate lg:hidden text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">최근 도구</span>
                     <span class="block truncate">${latestTool}</span>
                   </span>
                 </button>
@@ -945,11 +1000,14 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                 <div class="rounded-[var(--r-1)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2.5">
                   <div class="flex flex-wrap items-center gap-2">
                     <span class="text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-status-warn)]">${selectedRow.stateNote.label}</span>
-                    ${selectedRow.stateNote.kind
-                      ? html`<span class="rounded-[var(--r-0)] border border-[var(--color-border-divider)] bg-[var(--color-bg-page)] px-2 py-0.5 text-3xs font-mono text-[var(--color-fg-primary)]">${selectedRow.stateNote.kind}</span>`
+                    ${selectedBlockerDisplay?.kindLabel
+                      ? html`<span class="rounded-[var(--r-0)] border border-[var(--color-border-divider)] bg-[var(--color-bg-page)] px-2 py-0.5 text-3xs text-[var(--color-fg-primary)]">${selectedBlockerDisplay.kindLabel}</span>`
+                      : null}
+                    ${selectedBlockerDisplay?.rawKind
+                      ? html`<span class="rounded-[var(--r-0)] border border-[var(--color-border-divider)] bg-[var(--color-bg-page)] px-2 py-0.5 text-3xs font-mono text-[var(--color-fg-muted)]">${selectedBlockerDisplay.rawKind}</span>`
                       : null}
                   </div>
-                  <p class="m-0 mt-1 text-xs leading-relaxed text-[var(--color-fg-primary)]">${selectedRow.stateNote.text}</p>
+                  <p class="m-0 mt-1 text-xs leading-relaxed text-[var(--color-fg-primary)]">${selectedBlockerDisplay?.detail}</p>
                 </div>
               ` : null}
 


### PR DESCRIPTION
## Summary

- Rename Keeper Operations roster axes from generic State/Now/Blocker labels to operator-facing Korean labels.
- Add a compact legend explaining operation verdict, current phase, blocker evidence, presence dots, and synthetic rows.
- Render runtime blocker classes with readable labels and use the existing blocker hint text in the selected detail panel, avoiding repeated raw `fiber_unresolved` text.

## Why

The Keeper Operations table mixed live/runtime projection concepts in ways that made `State`, `Now`, and `Blocker` look like duplicate status fields. Raw blocker codes such as `fiber_unresolved` were also repeated in the selected runtime panel without explaining the operational action.

## Validation

- `pnpm --dir dashboard exec tsc --noEmit --pretty`
- `pnpm --dir dashboard exec vitest run src/components/agent-roster.test.ts`
- `git diff --check`
- Render smoke via Playwright screenshot against `http://127.0.0.1:5174/dashboard/#monitoring?section=agents`