### PR TITLE
Remove remaining keeper bash command argv shelling

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -449,6 +449,31 @@ let rmdir (path : string) : unit =
     (fun fs -> Eio.Path.rmdir Eio.Path.(fs / path))
 ;;
 
+let remove_tree_unix (path : string) : unit =
+  let rec remove path =
+    match Unix.lstat path with
+    | exception Unix.Unix_error (Unix.ENOENT, _, _) -> ()
+    | exception Unix.Unix_error (Unix.ENOTDIR, _, _) -> ()
+    | stat when stat.Unix.st_kind = Unix.S_DIR ->
+      Sys.readdir path
+      |> Array.iter (fun name -> remove (Filename.concat path name));
+      Unix.rmdir path
+    | _stat -> Sys.remove path
+  in
+  remove path
+;;
+
+let remove_tree (path : string) : unit =
+  let normalized = String.trim path in
+  if String.equal normalized "" || String.equal normalized "/" || String.equal normalized "."
+  then invalid_arg (Printf.sprintf "Fs_compat.remove_tree refuses unsafe path %S" path);
+  test_exec_home_guard ~op:"remove_tree" path;
+  with_fs_or_fallback
+    ~path
+    ~fallback:(fun () -> remove_tree_unix path)
+    (fun _fs -> Eio_unix.run_in_systhread (fun () -> remove_tree_unix path))
+;;
+
 let realpath (path : string) : string =
   with_fs_or_fallback
     ~path

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -78,6 +78,10 @@ val rename : string -> string -> unit
 (** Remove directory. *)
 val rmdir : string -> unit
 
+(** Remove a file, symlink, or directory tree without invoking a shell.
+    Missing paths are ignored.  Symlinks are unlinked, not followed. *)
+val remove_tree : string -> unit
+
 (** Get realpath. *)
 val realpath : string -> string
 

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -186,6 +186,32 @@ let run_argv_with_stdin_and_status_retry_eintr ~timeout_sec ~stdin_content argv 
     loop max_eintr_retries)
 ;;
 
+let run_argv_with_stdin_and_status_split_retry_eintr ~timeout_sec ~stdin_content argv =
+  let max_eintr_retries = 8 in
+  Docker_spawn_throttle.with_slot (fun () ->
+    let rec loop attempts_left =
+      let st, stdout, stderr =
+        Masc_exec.Exec_gate.run_argv_with_stdin_and_status_split
+          ~actor:`System_task_sandbox
+          ~raw_source:(String.concat " " argv)
+          ~summary:"keeper turn sandbox stdin command"
+          ~env:(Unix.environment ())
+          ~cwd:(Sys.getcwd ())
+          ~timeout_sec
+          ~stdin_content
+          argv
+      in
+      let out = output_for_status ~stdout ~stderr in
+      match st with
+      | Unix.WEXITED 127
+        when attempts_left > 0
+             && String_util.contains_substring_ci out "interrupted system call" ->
+        loop (attempts_left - 1)
+      | _ -> st, out
+    in
+    loop max_eintr_retries)
+;;
+
 let start_container (t : t) ~(timeout_sec : float) =
   let image =
     match t.meta.sandbox_image with
@@ -445,17 +471,29 @@ let run_bash_with_status (t : t) ~(cwd : string) ~(cmd : string) ~(timeout_sec :
   let container_cwd = container_cwd_of_host t ~host_cwd:cwd in
   let argv ~container_name =
     Keeper_sandbox_runtime.docker_command_argv ()
-    @ [ "exec"; "--user"; Printf.sprintf "%d:%d" t.uid t.gid; "-w"; container_cwd ]
+    @
+    [ "exec"
+    ; "-i"
+    ; "--user"
+    ; Printf.sprintf "%d:%d" t.uid t.gid
+    ; "-w"
+    ; container_cwd
+    ]
     @ Keeper_sandbox_runtime.docker_sandbox_env_args
         ~base_path:t.config.base_path
         ~container_root:t.container_root
-    @ [ container_name; "bash"; "-lc"; cmd ]
+    @ [ container_name; "bash"; "-l"; "-s" ]
   in
   match ensure_started t ~timeout_sec with
   | Error _ as err -> err
   | Ok container_name ->
     let argv = argv ~container_name in
-    let st, out = run_argv_with_status_split_retry_eintr ~timeout_sec argv in
+    let st, out =
+      run_argv_with_stdin_and_status_split_retry_eintr
+        ~timeout_sec
+        ~stdin_content:cmd
+        argv
+    in
     if container_missing_error out
     then (
       match st with
@@ -465,7 +503,11 @@ let run_bash_with_status (t : t) ~(cwd : string) ~(cmd : string) ~(timeout_sec :
          | Error _ as err -> err
          | Ok container_name ->
            let argv = argv ~container_name in
-           Ok (run_argv_with_status_split_retry_eintr ~timeout_sec argv))
+           Ok
+             (run_argv_with_stdin_and_status_split_retry_eintr
+                ~timeout_sec
+                ~stdin_content:cmd
+                argv))
       | _ -> Ok (st, out))
     else Ok (st, out)
 ;;

--- a/test/test_cdal_friction_projection.ml
+++ b/test/test_cdal_friction_projection.ml
@@ -346,7 +346,7 @@ let test_blocked_tool_counts () =
       (Filename.concat store.root "proofs")
       (Filename.concat run_id "evidence")
   in
-  ignore (Sys.command (Printf.sprintf "mkdir -p %s" dir));
+  mkdirp dir;
   let violations =
     `List
       [ `Assoc
@@ -432,7 +432,7 @@ let test_tripwire_fires () =
       (Filename.concat store.root "proofs")
       (Filename.concat run_id "evidence")
   in
-  ignore (Sys.command (Printf.sprintf "mkdir -p %s" dir));
+  mkdirp dir;
   (* 3 identical violations for "write" — threshold=2 should fire *)
   let v =
     `Assoc
@@ -466,7 +466,7 @@ let test_tripwire_below_threshold () =
       (Filename.concat store.root "proofs")
       (Filename.concat run_id "evidence")
   in
-  ignore (Sys.command (Printf.sprintf "mkdir -p %s" dir));
+  mkdirp dir;
   let v =
     `Assoc
       [ "ts", `Float 1.0

--- a/test/test_cdal_verdict_gate.ml
+++ b/test/test_cdal_verdict_gate.ml
@@ -137,7 +137,7 @@ let test_inconclusive_mixed_gaps_rejects () =
 let with_temp_dir f =
   let dir = Filename.temp_dir "cdal_gate_test" "" in
   Fun.protect ~finally:(fun () ->
-    ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)))
+    Fs_compat.remove_tree dir
   ) (fun () -> f dir)
 
 let write_verdict_jsonl ~base_dir ?task_id (verdict : CT.contract_verdict) =
@@ -145,7 +145,7 @@ let write_verdict_jsonl ~base_dir ?task_id (verdict : CT.contract_verdict) =
   let date_dir = Printf.sprintf "%04d-%02d"
     (today.tm_year + 1900) (today.tm_mon + 1) in
   let dir = Filename.concat base_dir date_dir in
-  ignore (Sys.command (Printf.sprintf "mkdir -p %s" (Filename.quote dir)));
+  Fs_compat.mkdir_p dir;
   let day_file = Printf.sprintf "%02d.jsonl" today.tm_mday in
   let path = Filename.concat dir day_file in
   let json = CT.contract_verdict_to_json verdict in

--- a/test/test_eval_gate.ml
+++ b/test/test_eval_gate.ml
@@ -11,7 +11,7 @@ let with_tmpdir f =
     (Printf.sprintf "test_eval_gate_%d" (Random.int 100000)) in
   (try Unix.mkdir dir 0o755 with _ -> ());
   Fun.protect ~finally:(fun () ->
-    ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)))
+    Fs_compat.remove_tree dir
   ) (fun () -> f dir)
 
 let make_acc dir =

--- a/test/test_failure_learnings_10325.ml
+++ b/test/test_failure_learnings_10325.ml
@@ -23,8 +23,7 @@ let with_tmp_base_dir f =
     Fun.protect
       ~finally:(fun () ->
         try
-          let cmd = Printf.sprintf "rm -rf %s" (Filename.quote base) in
-          ignore (Sys.command cmd)
+          Fs_compat.remove_tree base
         with _ -> ())
       (fun () -> f base)
   in

--- a/test/test_fs_compat.ml
+++ b/test/test_fs_compat.ml
@@ -6,21 +6,11 @@
 
 open Alcotest
 
-let rec rm_rf (path : string) : unit =
-  if Sys.file_exists path
-  then
-    if Sys.is_directory path
-    then (
-      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
-      Unix.rmdir path)
-    else Sys.remove path
-;;
-
 let with_tmp_dir (f : string -> unit) : unit =
   let tmp = Filename.temp_file "masc_fs_compat_" ".tmp" in
   Sys.remove tmp;
   Unix.mkdir tmp 0o755;
-  Fun.protect ~finally:(fun () -> rm_rf tmp) (fun () -> f tmp)
+  Fun.protect ~finally:(fun () -> Fs_compat.remove_tree tmp) (fun () -> f tmp)
 ;;
 
 let test_mkdir_p_creates_nested_dirs () =
@@ -46,6 +36,34 @@ let test_mkdir_p_does_not_shell_inject () =
     "dangerous path exists"
     true
     (Sys.file_exists dangerous && Sys.is_directory dangerous)
+;;
+
+let test_remove_tree_does_not_shell_inject () =
+  Fs_compat.clear_fs ();
+  with_tmp_dir
+  @@ fun base ->
+  let marker = Filename.concat base "pwned" in
+  let dangerous = Filename.concat base ("dir;touch " ^ marker) in
+  Unix.mkdir dangerous 0o755;
+  Fs_compat.remove_tree dangerous;
+  check bool "target removed" false (Sys.file_exists dangerous);
+  (* If remove_tree used a shell (`rm -rf <path>`), this would create marker. *)
+  check bool "no shell side-effect file created" false (Sys.file_exists marker)
+;;
+
+let test_remove_tree_unlinks_symlink_without_following () =
+  Fs_compat.clear_fs ();
+  with_tmp_dir
+  @@ fun base ->
+  let target = Filename.concat base "target" in
+  let link = Filename.concat base "link" in
+  Unix.mkdir target 0o755;
+  Fs_compat.save_file (Filename.concat target "kept.txt") "kept";
+  Unix.symlink target link;
+  Fs_compat.remove_tree link;
+  check bool "symlink removed" false (Sys.file_exists link);
+  check bool "target directory preserved" true (Sys.file_exists target);
+  check string "target content preserved" "kept" (Fs_compat.load_file (Filename.concat target "kept.txt"))
 ;;
 
 let test_save_file_atomic_leaves_no_tmp_on_success () =
@@ -280,6 +298,13 @@ let () =
     [ ( "mkdir_p"
       , [ test_case "creates nested dirs" `Quick test_mkdir_p_creates_nested_dirs
         ; test_case "no shell injection" `Quick test_mkdir_p_does_not_shell_inject
+        ] )
+    ; ( "remove_tree"
+      , [ test_case "no shell injection" `Quick test_remove_tree_does_not_shell_inject
+        ; test_case
+            "unlinks symlink without following"
+            `Quick
+            test_remove_tree_unlinks_symlink_without_following
         ] )
     ; ( "save_file_atomic"
       , [ test_case

--- a/test/test_keeper_github_read_only.ml
+++ b/test/test_keeper_github_read_only.ml
@@ -75,14 +75,15 @@ let rec ensure_dir path =
     Unix.mkdir path 0o755)
 
 let run_argv argv =
-  let command = String.concat " " (List.map Filename.quote argv) in
-  match Unix.system command with
-  | Unix.WEXITED 0 -> ()
-  | _ ->
+  match argv with
+  | [] -> invalid_arg "run_argv: empty argv"
+  | prog :: args ->
+    let pid = Unix.create_process prog (Array.of_list argv) Unix.stdin Unix.stdout Unix.stderr in
+    match Unix.waitpid [] pid with
+    | _, Unix.WEXITED 0 -> ()
+    | _ ->
     Alcotest.fail
-      (Printf.sprintf "command failed: %s\n%s"
-         (String.concat " " argv)
-         command)
+      (Printf.sprintf "command failed: %s" (String.concat " " (prog :: args)))
 
 let with_env key value f =
   let prior = Sys.getenv_opt key in

--- a/test/test_keeper_meta_unknown_keys_warn.ml
+++ b/test/test_keeper_meta_unknown_keys_warn.ml
@@ -64,7 +64,7 @@ let fresh_tmpdir () =
   path
 
 let cleanup_tmpdir path =
-  ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote path)))
+  Fs_compat.remove_tree path
 
 let test_progress_updated_line_failure_is_observable () =
   let dir = fresh_tmpdir () in

--- a/test/test_keeper_shell_containment.ml
+++ b/test/test_keeper_shell_containment.ml
@@ -113,10 +113,18 @@ let parse_bool_field raw field =
   Yojson.Safe.from_string raw |> Json.member field |> Json.to_bool_option
 
 let run_cmd argv =
-  let quoted = String.concat " " (List.map Filename.quote argv) in
-  match Sys.command quoted with
-  | 0 -> ()
-  | code -> Alcotest.failf "command failed (%d): %s" code quoted
+  match argv with
+  | [] -> invalid_arg "run_cmd: empty argv"
+  | prog :: args ->
+    let pid = Unix.create_process prog (Array.of_list argv) Unix.stdin Unix.stdout Unix.stderr in
+    (match Unix.waitpid [] pid with
+     | _, Unix.WEXITED 0 -> ()
+     | _, Unix.WEXITED code ->
+       Alcotest.failf "command failed (%d): %s" code (String.concat " " (prog :: args))
+     | _, Unix.WSIGNALED signal ->
+       Alcotest.failf "command signaled (%d): %s" signal (String.concat " " (prog :: args))
+     | _, Unix.WSTOPPED signal ->
+       Alcotest.failf "command stopped (%d): %s" signal (String.concat " " (prog :: args)))
 
 let write_executable path content =
   ignore (Fs_compat.save_file_atomic path content);

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -28,7 +28,7 @@ let with_tmp_log f =
   Fun.protect
     ~finally:(fun () ->
       Keeper_tool_call_log.reset_for_testing ();
-      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir))))
+      Fs_compat.remove_tree dir)
     (fun () -> f ())
 
 let with_tmp_log_dir f =
@@ -43,7 +43,7 @@ let with_tmp_log_dir f =
   Fun.protect
     ~finally:(fun () ->
       Keeper_tool_call_log.reset_for_testing ();
-      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir))))
+      Fs_compat.remove_tree dir)
     (fun () -> f dir)
 
 let with_tmp_corrupt_tool_call_store f =
@@ -60,7 +60,7 @@ let with_tmp_corrupt_tool_call_store f =
   Fun.protect
     ~finally:(fun () ->
       Keeper_tool_call_log.reset_for_testing ();
-      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir))))
+      Fs_compat.remove_tree dir)
     (fun () -> f ~dir ~masc_root)
 
 (* ── read_recent edge cases ─────────────────────────── *)

--- a/test/test_memory_oas_5tier.ml
+++ b/test/test_memory_oas_5tier.ml
@@ -26,7 +26,7 @@ let setup_tmp_dir () =
 
 let cleanup_tmp_dir dir =
   (* Best-effort cleanup *)
-  ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)))
+  Fs_compat.remove_tree dir
 
 (* ================================================================ *)
 (* oas_procedure_of_masc                                             *)

--- a/test/test_repo_store.ml
+++ b/test/test_repo_store.ml
@@ -243,16 +243,25 @@ let test_load_minimal_toml_defaults () =
       | Ok repos ->
           Alcotest.failf "expected one repo, got %d" (List.length repos))
 
-let git_available () =
-  Sys.command "git --version >/dev/null 2>&1" = 0
+let run_git_quiet args =
+  let devnull = Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0 in
+  Fun.protect
+    ~finally:(fun () -> Unix.close devnull)
+    (fun () ->
+      let argv = Array.of_list ("git" :: args) in
+      try
+        let pid = Unix.create_process "git" argv Unix.stdin devnull devnull in
+        match Unix.waitpid [] pid with
+        | _, Unix.WEXITED code -> code
+        | _, (Unix.WSIGNALED _ | Unix.WSTOPPED _) -> 1
+      with
+      | Unix.Unix_error _ -> 1)
+
+let git_available () = run_git_quiet [ "--version" ] = 0
 
 let init_git_repo dir url =
-  ignore (Sys.command (Printf.sprintf "git init %s >/dev/null 2>&1" (Filename.quote dir)));
-  ignore
-    (Sys.command
-       (Printf.sprintf "git -C %s remote add origin %s >/dev/null 2>&1"
-          (Filename.quote dir)
-          (Filename.quote url)))
+  ignore (run_git_quiet [ "init"; dir ]);
+  ignore (run_git_quiet [ "-C"; dir; "remote"; "add"; "origin"; url ])
 
 let canonical_path path =
   try Unix.realpath path with Unix.Unix_error _ | Sys_error _ -> path

--- a/test/test_task_sandbox.ml
+++ b/test/test_task_sandbox.ml
@@ -35,7 +35,7 @@ let make_temp_dir () =
        (Unix.getpid ()) !temp_counter (Random.int 999999))
   in
   if Sys.file_exists dir then
-    ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)));
+    Fs_compat.remove_tree dir;
   Unix.mkdir dir 0o755;
   dir
 
@@ -47,7 +47,7 @@ let with_non_git_room f =
     (match saved_base with
      | Some v -> Unix.putenv "MASC_BASE_PATH" v
      | None -> Unix.putenv "MASC_BASE_PATH" "");
-    ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)))
+    Fs_compat.remove_tree dir
   ) (fun () ->
     Unix.putenv "MASC_BASE_PATH" dir;
     let config = Coord.default_config dir in
@@ -144,7 +144,7 @@ let test_with_sandbox_fails_without_git () =
 let test_symlink_created_when_masc_exists () =
   let dir = make_temp_dir () in
   Fun.protect ~finally:(fun () ->
-    ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)))
+    Fs_compat.remove_tree dir
   ) (fun () ->
     (* Create a fake .masc directory at "repo root" *)
     let masc_dir = Filename.concat dir Common.masc_dirname in
@@ -202,7 +202,7 @@ let seed_playground_clone ~base_path ~agent_name ~source_repo =
   let clone_path = Filename.concat repos_dir (Filename.basename source_repo) in
   Fs_compat.mkdir_p repos_dir;
   if Sys.file_exists clone_path then
-    ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote clone_path)));
+    Fs_compat.remove_tree clone_path;
   run_cmd (Printf.sprintf "git clone %s %s"
     (Filename.quote source_repo) (Filename.quote clone_path));
   clone_path
@@ -280,14 +280,14 @@ let make_meta_with_current_task ~name ~task_id =
 let with_lazy_worktree_fixture f =
   let base = make_temp_dir () in
   let dir = base in
-  ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)));
+  Fs_compat.remove_tree dir;
   let saved_base = Sys.getenv_opt "MASC_BASE_PATH" in
   Fun.protect
     ~finally:(fun () ->
       (match saved_base with
        | Some v -> Unix.putenv "MASC_BASE_PATH" v
        | None -> Unix.putenv "MASC_BASE_PATH" "");
-      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir))))
+      Fs_compat.remove_tree dir)
     (fun () ->
       Eio_main.run (fun env ->
         Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -378,14 +378,14 @@ let test_full_lifecycle () =
   let dir = base in
   let bare_dir = base ^ "-bare" in
   (* Remove the empty dir first since git clone wants a non-existent target *)
-  ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)));
+  Fs_compat.remove_tree dir;
   let saved_base = Sys.getenv_opt "MASC_BASE_PATH" in
   Fun.protect ~finally:(fun () ->
     (match saved_base with
      | Some v -> Unix.putenv "MASC_BASE_PATH" v
      | None -> Unix.putenv "MASC_BASE_PATH" "");
-    ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)));
-    ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote bare_dir)))
+    Fs_compat.remove_tree dir;
+    Fs_compat.remove_tree bare_dir
   ) (fun () ->
     Eio_main.run (fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -473,14 +473,14 @@ let test_full_lifecycle () =
 let test_create_infers_repo_from_task_file_evidence () =
   let base = make_temp_dir () in
   let dir = base in
-  ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)));
+  Fs_compat.remove_tree dir;
   let saved_base = Sys.getenv_opt "MASC_BASE_PATH" in
   Fun.protect
     ~finally:(fun () ->
       (match saved_base with
        | Some v -> Unix.putenv "MASC_BASE_PATH" v
        | None -> Unix.putenv "MASC_BASE_PATH" "");
-      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir))))
+      Fs_compat.remove_tree dir)
     (fun () ->
       Eio_main.run (fun env ->
         Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -554,14 +554,14 @@ let test_create_infers_repo_from_task_file_evidence () =
 let test_create_resolves_docker_visible_path_to_host_worktree () =
   let base = make_temp_dir () in
   let dir = base in
-  ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)));
+  Fs_compat.remove_tree dir;
   let saved_base = Sys.getenv_opt "MASC_BASE_PATH" in
   Fun.protect
     ~finally:(fun () ->
       (match saved_base with
        | Some v -> Unix.putenv "MASC_BASE_PATH" v
        | None -> Unix.putenv "MASC_BASE_PATH" "");
-      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir))))
+      Fs_compat.remove_tree dir)
     (fun () ->
       Eio_main.run (fun env ->
         Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -636,14 +636,14 @@ let test_create_resolves_docker_visible_path_to_host_worktree () =
 let test_create_fails_ambiguous_multi_repo_without_evidence () =
   let base = make_temp_dir () in
   let dir = base in
-  ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)));
+  Fs_compat.remove_tree dir;
   let saved_base = Sys.getenv_opt "MASC_BASE_PATH" in
   Fun.protect
     ~finally:(fun () ->
       (match saved_base with
        | Some v -> Unix.putenv "MASC_BASE_PATH" v
        | None -> Unix.putenv "MASC_BASE_PATH" "");
-      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir))))
+      Fs_compat.remove_tree dir)
     (fun () ->
       Eio_main.run (fun env ->
         Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -694,14 +694,14 @@ let test_create_fails_ambiguous_multi_repo_without_evidence () =
 let test_create_infers_repo_from_task_repo_mentions () =
   let base = make_temp_dir () in
   let dir = base in
-  ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)));
+  Fs_compat.remove_tree dir;
   let saved_base = Sys.getenv_opt "MASC_BASE_PATH" in
   Fun.protect
     ~finally:(fun () ->
       (match saved_base with
        | Some v -> Unix.putenv "MASC_BASE_PATH" v
        | None -> Unix.putenv "MASC_BASE_PATH" "");
-      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir))))
+      Fs_compat.remove_tree dir)
     (fun () ->
       Eio_main.run (fun env ->
         Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -806,14 +806,14 @@ let test_with_sandbox_lifecycle () =
   let base = make_temp_dir () in
   let dir = base in
   let bare_dir = base ^ "-bare" in
-  ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)));
+  Fs_compat.remove_tree dir;
   let saved_base = Sys.getenv_opt "MASC_BASE_PATH" in
   Fun.protect ~finally:(fun () ->
     (match saved_base with
      | Some v -> Unix.putenv "MASC_BASE_PATH" v
      | None -> Unix.putenv "MASC_BASE_PATH" "");
-    ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)));
-    ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote bare_dir)))
+    Fs_compat.remove_tree dir;
+    Fs_compat.remove_tree bare_dir
   ) (fun () ->
     Eio_main.run (fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -866,14 +866,14 @@ let test_with_sandbox_cleans_up_on_exception () =
   let base = make_temp_dir () in
   let dir = base in
   let bare_dir = base ^ "-bare" in
-  ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)));
+  Fs_compat.remove_tree dir;
   let saved_base = Sys.getenv_opt "MASC_BASE_PATH" in
   Fun.protect ~finally:(fun () ->
     (match saved_base with
      | Some v -> Unix.putenv "MASC_BASE_PATH" v
      | None -> Unix.putenv "MASC_BASE_PATH" "");
-    ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)));
-    ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote bare_dir)))
+    Fs_compat.remove_tree dir;
+    Fs_compat.remove_tree bare_dir
   ) (fun () ->
     Eio_main.run (fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -639,9 +639,16 @@ let fresh_base_path () =
      canonical root. An empty `git init` plus an initial commit
      is sufficient; Coord_git.git_root walks up from base_path. *)
   let run_git args =
-    let cmd = String.concat " "
-      (List.map Filename.quote ("git" :: args) @ [">"; "/dev/null"; "2>&1"]) in
-    ignore (Sys.command cmd)
+    let devnull = Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0 in
+    Fun.protect
+      ~finally:(fun () -> Unix.close devnull)
+      (fun () ->
+        let argv = Array.of_list ("git" :: args) in
+        try
+          let pid = Unix.create_process "git" argv Unix.stdin devnull devnull in
+          ignore (Unix.waitpid [] pid)
+        with
+        | Unix.Unix_error _ -> ())
   in
   run_git [ "init"; "-b"; "main"; dir ];
   run_git [ "-C"; dir; "config"; "user.email"; "iter6@example.test" ];
@@ -687,7 +694,7 @@ let test_code_git_status_marks_docker_keeper_route () =
     Filename.concat base_path ".masc/playground/docker/sangsu/repos"
   in
   mkdir_p cwd;
-  ignore (Sys.command (Printf.sprintf "git -C %s init -q" (Filename.quote cwd)));
+  run_git [ "-C"; cwd; "init"; "-q" ];
   let ctx =
     { Tool_code_write.config;
       agent_name = "keeper-sangsu-agent";

--- a/test/test_tool_deep_review.ml
+++ b/test/test_tool_deep_review.ml
@@ -26,7 +26,7 @@ let with_temp_dir f =
   in
   mkdir_p base;
   Fun.protect
-    ~finally:(fun () -> ignore (Sys.command (Printf.sprintf "rm -rf %s" base)))
+    ~finally:(fun () -> Masc_mcp.Fs_compat.remove_tree base)
     (fun () -> f base)
 
 let write_file path content =

--- a/test/test_tool_metrics_persist.ml
+++ b/test/test_tool_metrics_persist.ml
@@ -24,7 +24,7 @@ let with_tmp_dir f =
   P.reset_for_testing ();
   Fun.protect ~finally:(fun () ->
     P.reset_for_testing ();
-    ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)))
+    Fs_compat.remove_tree dir
   ) (fun () -> f dir)
 
 let test_enqueue_flush_restore () =

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -47,7 +47,7 @@ let with_tmpdir f =
   (try Unix.mkdir dir 0o755 with _ -> ());
   Fun.protect ~finally:(fun () ->
     (* Best effort cleanup *)
-    ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)))
+    Fs_compat.remove_tree dir
   ) (fun () -> f dir)
 
 let test_create_accumulator () =
@@ -450,7 +450,7 @@ let test_read_entries_since () =
     let keeper = "test-keeper" in
     (* Create a trajectory file manually *)
     let traj_dir = Filename.concat masc_root (Printf.sprintf "trajectories/%s" keeper) in
-    ignore (Sys.command (Printf.sprintf "mkdir -p %s" (Filename.quote traj_dir)));
+    Fs_compat.mkdir_p traj_dir;
     let path = Filename.concat traj_dir "trace-100.jsonl" in
     let entry_json ts = Printf.sprintf
       {|{"ts":%.1f,"ts_iso":"2026-04-06T10:00:00Z","turn":1,"round":0,"tool_name":"keeper_bash","args":{},"result":"ok","duration_ms":100,"error":null,"cost_usd":0.001}|}
@@ -473,7 +473,7 @@ let test_read_entries_since_result_parses_gate_summary () =
     let masc_root = dir in
     let keeper = "test-keeper" in
     let traj_dir = Filename.concat masc_root (Printf.sprintf "trajectories/%s" keeper) in
-    ignore (Sys.command (Printf.sprintf "mkdir -p %s" (Filename.quote traj_dir)));
+    Fs_compat.mkdir_p traj_dir;
     let path = Filename.concat traj_dir "trace-101.jsonl" in
     let rows =
       [


### PR DESCRIPTION
## Summary
- add Fs_compat.remove_tree for recursive cleanup without invoking shell rm -rf
- cover shell-injection and symlink-not-followed behavior in fs_compat tests
- replace cleanup-only rm -rf / mkdir -p shell calls across focused OCaml tests with typed filesystem helpers
- switch several test git setup helpers from shell-string execution to Unix.create_process argv execution
- route persistent turn-sandbox docker bash through docker exec -i + bash -l -s with the script on stdin, so user commands no longer appear in docker exec argv

## Verification
- opam exec -- ocamlformat --check lib/fs_compat/fs_compat.ml lib/fs_compat/fs_compat.mli lib/keeper/keeper_turn_sandbox_runtime.ml test/test_fs_compat.ml test/test_tool_metrics_persist.ml test/test_task_sandbox.ml test/test_trajectory.ml test/test_keeper_tool_call_log.ml test/test_eval_gate.ml test/test_cdal_verdict_gate.ml test/test_memory_oas_5tier.ml test/test_keeper_meta_unknown_keys_warn.ml test/test_tool_deep_review.ml test/test_failure_learnings_10325.ml test/test_cdal_friction_projection.ml test/test_keeper_github_read_only.ml test/test_keeper_shell_containment.ml test/test_repo_store.ml test/test_tool_code_write_coverage.ml
- git diff --check
- rg -n '"bash";\s*"-lc"|bash -lc|sh -lc' lib -g '*.ml' -g '*.mli' (no matches)
- bash scripts/lint/shell-legacy-purge-ratchet.sh
- scripts/lint-spawn-bounded.sh

## Not run
- scripts/dune-local.sh build focused test/lib targets: blocked by live bare dune processes outside scripts/dune-local.sh on this host
