### PR TITLE
fix(exec): reject invalid shell ir pipelines

### DIFF
--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -91,11 +91,14 @@ let dispatch_simple ?timeout_sec ?stdin_content (s : Shell_ir.simple) =
 
 (* --- pipeline + entry point (mutually recursive) --- *)
 
+let invalid_pipeline stderr = { status = Unix.WEXITED 1; stdout = ""; stderr }
+
 let rec dispatch_pipeline ?timeout_sec stages =
   match stages with
   | [] ->
-      { status = Unix.WEXITED 0; stdout = ""; stderr = "" }
-  | [ stage ] -> dispatch ?timeout_sec stage
+      invalid_pipeline "empty pipeline not supported in native dispatch"
+  | [ _ ] ->
+      invalid_pipeline "single-stage pipeline not supported in native dispatch"
   | _ ->
       let rec chain prev_stdout = function
         | [] ->
@@ -115,22 +118,18 @@ let rec dispatch_pipeline ?timeout_sec stages =
             in
             { result with status = final_status }
         | Pipeline _ :: _ ->
-            { status = Unix.WEXITED 1;
-              stdout = "";
-              stderr = "nested pipeline not supported in native dispatch" }
+            invalid_pipeline "nested pipeline not supported in native dispatch"
       in
       (match stages with
-       | [] ->
-           { status = Unix.WEXITED 0; stdout = ""; stderr = "" }
+       | [] | [ _ ] ->
+           invalid_pipeline "invalid pipeline arity in native dispatch"
        | first :: rest -> (
          match first with
          | Shell_ir.Simple s ->
            let result = dispatch_simple ?timeout_sec s in
            chain result.stdout rest
          | Pipeline _ ->
-           { status = Unix.WEXITED 1;
-             stdout = "";
-             stderr = "nested pipeline not supported" }))
+           invalid_pipeline "nested pipeline not supported in native dispatch" ))
 
 and dispatch ?timeout_sec (ir : Shell_ir.t) =
   match ir with

--- a/test/test_exec_dispatch.ml
+++ b/test/test_exec_dispatch.ml
@@ -112,8 +112,65 @@ let () =
 let () =
   with_eio @@ fun () ->
   let result = Masc_exec.Exec_dispatch.dispatch (Masc_exec.Shell_ir.Pipeline []) in
-  assert (result.status = Unix.WEXITED 0);
-  assert (result.stdout = "")
+  assert (result.status = Unix.WEXITED 1);
+  assert (result.stdout = "");
+  assert (result.stderr = "empty pipeline not supported in native dispatch")
+
+(* --- dispatch single-stage pipeline --- *)
+
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let bin = Masc_exec.Bin.of_string "echo" |> Result.get_ok in
+  let stage =
+    Simple
+      { bin
+      ; args = [ Lit "single" ]
+      ; env = []
+      ; cwd = None
+      ; redirects = []
+      ; sandbox = Masc_exec.Sandbox_target.host ()
+      }
+  in
+  let result = Masc_exec.Exec_dispatch.dispatch (Pipeline [ stage ]) in
+  assert (result.status = Unix.WEXITED 1);
+  assert (result.stdout = "");
+  assert (result.stderr = "single-stage pipeline not supported in native dispatch")
+
+(* --- dispatch nested pipeline --- *)
+
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let echo_bin = Masc_exec.Bin.of_string "echo" |> Result.get_ok in
+  let cat_bin = Masc_exec.Bin.of_string "cat" |> Result.get_ok in
+  let host_sandbox = Masc_exec.Sandbox_target.host () in
+  let echo_stage =
+    Simple
+      { bin = echo_bin
+      ; args = [ Lit "nested" ]
+      ; env = []
+      ; cwd = None
+      ; redirects = []
+      ; sandbox = host_sandbox
+      }
+  in
+  let cat_stage =
+    Simple
+      { bin = cat_bin
+      ; args = []
+      ; env = []
+      ; cwd = None
+      ; redirects = []
+      ; sandbox = host_sandbox
+      }
+  in
+  let result =
+    Masc_exec.Exec_dispatch.dispatch (Pipeline [ Pipeline [ echo_stage; cat_stage ]; cat_stage ])
+  in
+  assert (result.status = Unix.WEXITED 1);
+  assert (result.stdout = "");
+  assert (result.stderr = "nested pipeline not supported in native dispatch")
 
 (* --- dispatch_simple propagates sandbox runner (SND-05 regression) --- *)
 


### PR DESCRIPTION
Summary
- Reject empty Pipeline values in Exec_dispatch instead of treating them as success.
- Reject single-stage Pipeline values at the dispatch boundary; gate typed single-stage input already lowers to Simple.
- Normalize nested pipeline native-dispatch errors and cover invalid shapes in test_exec_dispatch.

Validation
- PASS: ocamlformat --check lib/exec/exec_dispatch.ml test/test_exec_dispatch.ml
- PASS: git diff --check HEAD~1..HEAD
- LIMITED: scripts/dune-local.sh build test/test_exec_dispatch.exe and the narrowed lib/exec object + test target were both stopped after long no-output waits while the host had many concurrent Dune builds running; no compiler error was emitted before interruption.