### PR TITLE
fix(cdal): classify legacy unscoped verdict rows by run age

### DIFF
--- a/lib/cdal_runtime_health.ml
+++ b/lib/cdal_runtime_health.ml
@@ -320,8 +320,28 @@ let assoc_string key = function
 
 let has_task_scope json = Option.is_some (assoc_string "_task_id" json)
 
+let run_id_millis json =
+  match assoc_string "run_id" json with
+  | Some run_id ->
+    (match cdal_run_id_timestamp run_id with
+     | Some ts -> (try Some (Float.of_string ts) with Failure _ -> None)
+     | None -> None)
+  | None -> None
+;;
+
+let latest_scoped_run_millis recent =
+  List.fold_left
+    (fun acc row ->
+       if has_task_scope row
+       then max_float_opt acc (run_id_millis row)
+       else acc)
+    None
+    recent
+;;
+
 let task_scope_counts recent =
   let indexed = List.mapi (fun index row -> index, row) recent in
+  let latest_scoped_run_millis = latest_scoped_run_millis recent in
   let first_task_scoped_index =
     List.fold_left
       (fun acc (index, row) ->
@@ -336,10 +356,14 @@ let task_scope_counts recent =
        if has_task_scope row
        then task_id_rows + 1, legacy_unscoped_rows, current_unscoped_rows
        else (
-         match first_task_scoped_index with
-         | Some scoped_index when index < scoped_index ->
+         match latest_scoped_run_millis, run_id_millis row with
+         | Some latest_scoped, Some row_millis when row_millis <= latest_scoped ->
            task_id_rows, legacy_unscoped_rows + 1, current_unscoped_rows
-         | _ -> task_id_rows, legacy_unscoped_rows, current_unscoped_rows + 1))
+         | _ ->
+           (match first_task_scoped_index with
+            | Some scoped_index when index < scoped_index ->
+              task_id_rows, legacy_unscoped_rows + 1, current_unscoped_rows
+            | _ -> task_id_rows, legacy_unscoped_rows, current_unscoped_rows + 1)))
     (0, 0, 0)
     indexed
 ;;

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -469,7 +469,7 @@ let run_bash_with_status (t : t) ~(cwd : string) ~(cmd : string) ~(timeout_sec :
       cmd
   in
   let container_cwd = container_cwd_of_host t ~host_cwd:cwd in
-  let make_argv ~container_name =
+  let docker_exec_argv ~container_name =
     Keeper_sandbox_runtime.docker_command_argv ()
     @
     [ "exec"
@@ -487,7 +487,7 @@ let run_bash_with_status (t : t) ~(cwd : string) ~(cmd : string) ~(timeout_sec :
   match ensure_started t ~timeout_sec with
   | Error _ as err -> err
   | Ok container_name ->
-    let argv = make_argv ~container_name in
+    let argv = docker_exec_argv ~container_name in
     let st, out =
       run_argv_with_stdin_and_status_split_retry_eintr
         ~timeout_sec
@@ -502,7 +502,7 @@ let run_bash_with_status (t : t) ~(cwd : string) ~(cmd : string) ~(timeout_sec :
         (match ensure_started t ~timeout_sec with
          | Error _ as err -> err
          | Ok container_name ->
-           let argv = make_argv ~container_name in
+           let argv = docker_exec_argv ~container_name in
            Ok
              (run_argv_with_stdin_and_status_split_retry_eintr
                 ~timeout_sec

--- a/test/test_cdal_runtime_health_15748.ml
+++ b/test/test_cdal_runtime_health_15748.ml
@@ -346,6 +346,7 @@ let test_older_cdal_unscoped_rows_do_not_mark_current_writer_partial () =
            [ "_task_id", `String "task-new"
            ; "run_id", `String "cdal-3000-scoped-new"
            ]));
+  (* See: fixture helper returns the proofs dir, but this test only needs it created. *)
   ignore (make_proof_root proof_root);
   let json =
     H.snapshot_json

--- a/test/test_cdal_runtime_health_15748.ml
+++ b/test/test_cdal_runtime_health_15748.ml
@@ -324,6 +324,55 @@ let test_interleaved_unscoped_rows_mark_current_writer_partial () =
     (member_bool "legacy_unscoped_only" task_scope)
 ;;
 
+let test_older_cdal_unscoped_rows_do_not_mark_current_writer_partial () =
+  with_temp_dir @@ fun dir ->
+  let base_dir = Filename.concat dir "cdal_verdicts" in
+  let proof_root = Filename.concat dir ".oas" in
+  ignore
+    (write_ledger_row
+       ~base_dir
+       (`Assoc
+           [ "_task_id", `String "task-old"
+           ; "run_id", `String "cdal-2000-scoped-old"
+           ]));
+  ignore
+    (write_ledger_row
+       ~base_dir
+       (`Assoc [ "run_id", `String "cdal-1000-unscoped-legacy" ]));
+  ignore
+    (write_ledger_row
+       ~base_dir
+       (`Assoc
+           [ "_task_id", `String "task-new"
+           ; "run_id", `String "cdal-3000-scoped-new"
+           ]));
+  ignore (make_proof_root proof_root);
+  let json =
+    H.snapshot_json
+      ~base_dir
+      ~proof_root
+      ~now:(Time_compat.now ())
+      ~stale_age_seconds:60.0
+      ~recent_limit:20
+      ()
+  in
+  Alcotest.(check string) "writer_status" "active" (member_string "writer_status" json);
+  let task_scope = nested "task_scope" json in
+  Alcotest.(check string) "task scope status" "present" (member_string "status" task_scope);
+  Alcotest.(check int)
+    "legacy unscoped rows"
+    1
+    (member_int "legacy_unscoped_rows" task_scope);
+  Alcotest.(check int)
+    "current writer missing task rows"
+    0
+    (member_int "current_writer_missing_task_scope_rows" task_scope);
+  Alcotest.(check bool)
+    "legacy-only marker"
+    true
+    (member_bool "legacy_unscoped_only" task_scope)
+;;
+
 let test_active_writer_status () =
   with_temp_dir @@ fun dir ->
   let base_dir = Filename.concat dir "cdal_verdicts" in
@@ -612,6 +661,10 @@ let () =
             "interleaved unscoped rows mark current writer partial"
             `Quick
             test_interleaved_unscoped_rows_mark_current_writer_partial
+        ; Alcotest.test_case
+            "older cdal unscoped rows do not mark current writer partial"
+            `Quick
+            test_older_cdal_unscoped_rows_do_not_mark_current_writer_partial
         ; Alcotest.test_case "active" `Quick test_active_writer_status
         ; Alcotest.test_case
             "stale incomplete proof store"


### PR DESCRIPTION
## Summary
- classify legacy unscoped CDAL verdict rows using parseable cdal run_id timestamps instead of only list position
- preserve the existing fallback for synthetic/non-cdal run ids
- fix latest-main sandbox compile break from docker exec argv shadowing

## Verification
- ocamlformat --check lib/keeper/keeper_turn_sandbox_runtime.ml lib/cdal_runtime_health.ml test/test_cdal_runtime_health_15748.ml
- git diff --check
- env MASC_DUNE_THROTTLE=0 MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_DUNE_ALLOW_LIVE_BUILD_LOCK=1 MASC_SKIP_PIN_CHECK=1 MASC_SKIP_OPAM_LOCK=1 scripts/dune-local.sh build test/test_cdal_runtime_health_15748.exe bin/main_eio.exe
- _build/default/test/test_cdal_runtime_health_15748.exe

## Notes
- MASC_SKIP_PIN_CHECK=1 was used to avoid downgrading the shared local agent_sdk pin during local verification.