### PR TITLE
refactor(keeper_agent_run): extract contract retry

### DIFF
--- a/lib/cascade/cascade_transport_cli_overrides.mli
+++ b/lib/cascade/cascade_transport_cli_overrides.mli
@@ -1,0 +1,15 @@
+(** CLI-transport override record extracted from [Cascade_transport]. *)
+
+type cli_transport_overrides =
+  { cwd : string option
+  ; claude_mcp_config : string option
+  ; claude_allowed_tools : string list option
+  ; claude_permission_mode : string option
+  ; claude_max_turns : int option
+  ; gemini_yolo : bool option
+  ; cli_subprocess_idle_sec : float option
+  }
+(** Per-call overrides forwarded to CLI transports. *)
+
+val default_cli_transport_overrides : cli_transport_overrides
+(** No-overrides default used when a transport receives no explicit override. *)

--- a/lib/dune
+++ b/lib/dune
@@ -201,6 +201,7 @@
   keeper_agent_prompt_metrics
   keeper_agent_tool_surface
   keeper_agent_run_phase0_telemetry
+  keeper_agent_run_contract_retry
   keeper_agent_run_contract_helpers
   keeper_agent_run_receipt_append
   keeper_agent_result

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -678,84 +678,14 @@ let run_turn
                     ())
               in
               (match
-                 let first_attempt =
-                   match call_run_named ~initial_messages:history_messages with
-                   | Error
-                       (Agent_sdk.Error.Agent
-                          (Agent_sdk.Error.CompletionContractViolation
-                             { reason = violation_reason; violation_detail; _ }))
-                     when acc.contract_violation_retries < 1 ->
-                     (* Contract violation retry (max 1 per turn): the
-                        model did not call a required tool. Build a
-                        feedback message naming satisfying tools and
-                        re-invoke Agent.run so the model sees why it
-                        was rejected. The context builder in
-                        keeper_run_tools injects additional guidance
-                        because [contract_violation_retries > 0]. *)
-                     acc.contract_violation_retries <-
-                       acc.contract_violation_retries + 1;
-                     let satisfying_tools =
-                       let local_tools =
-                         Keeper_agent_tool_surface
-                         .generic_required_tool_candidate_names
-                           ~has_current_task:
-                             (Option.is_some
-                                (owned_active_task_id_for_meta
-                                   ~config ~meta:acc.meta))
-                           ~turn_affordances
-                           ~allowed_tool_names:
-                             acc.tool_surface.required_tool_candidate_names
-                       in
-                       let oas_tools =
-                         match violation_detail with
-                         | Some detail when detail.satisfying_tools <> [] ->
-                           detail.satisfying_tools
-                         | Some _ | None ->
-                           Keeper_tool_disclosure
-                           .satisfying_tools_from_contract_violation_reason
-                             violation_reason
-                       in
-                       Keeper_types.dedupe_keep_order (oas_tools @ local_tools)
-                     in
-                     let retry_action =
-                       match satisfying_tools with
-                       | [] ->
-                         "No currently visible tool can satisfy this contract; \
-                          emit a concise blocker instead."
-                       | tools ->
-                         Printf.sprintf
-                           "You MUST call one of these tools: %s."
-                           (String.concat ", " tools)
-                     in
-                     let retry_feedback =
-                       Printf.sprintf
-                         "[CONTRACT VIOLATION] Your previous response was \
-                          rejected: %s. %s Do NOT respond with text only."
-                         violation_reason
-                         retry_action
-                     in
-                     (* Append violation feedback as a User message so the
-                        model sees why its response was rejected. *)
-                     let retry_messages =
-                       history_messages
-                       @ [ { Agent_sdk.Types.role = User
-                           ; content =
-                               [ Agent_sdk.Types.Text retry_feedback ]
-                           ; name = None
-                           ; tool_call_id = None
-                           ; metadata = []
-                           }
-                         ]
-                     in
-                     Log.Keeper.info
-                       "keeper:%s contract violation retry #%d (reason: %s)"
-                       meta.name
-                       acc.contract_violation_retries
-                       violation_reason;
-                     call_run_named ~initial_messages:retry_messages
-                   | other -> other
-                 in
-                 first_attempt
+                 Keeper_agent_run_contract_retry.run_with_single_retry
+                   ~keeper_name:meta.name
+                   ~acc
+                   ~has_current_task:
+                     (Option.is_some (owned_active_task_id_for_meta ~config ~meta:acc.meta))
+                   ~turn_affordances
+                   ~history_messages
+                   ~call_run_named
                with
                | Error e -> Error e
                | Ok result ->

--- a/lib/keeper/keeper_agent_run_contract_retry.ml
+++ b/lib/keeper/keeper_agent_run_contract_retry.ml
@@ -1,0 +1,75 @@
+(** Contract-violation retry helper, extracted from [Keeper_agent_run]. *)
+
+let retry_feedback_message text : Agent_sdk.Types.message =
+  { Agent_sdk.Types.role = User
+  ; content = [ Agent_sdk.Types.Text text ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+;;
+
+let satisfying_tools_for_violation ~acc ~has_current_task ~turn_affordances
+    ~violation_reason ~violation_detail =
+  let local_tools =
+    Keeper_agent_tool_surface.generic_required_tool_candidate_names
+      ~has_current_task
+      ~turn_affordances
+      ~allowed_tool_names:acc.Keeper_run_tools.tool_surface.required_tool_candidate_names
+  in
+  let oas_tools =
+    match violation_detail with
+    | Some detail when detail.Agent_sdk.Completion_contract_violation_detail.satisfying_tools <> []
+      ->
+      detail.satisfying_tools
+    | Some _ | None ->
+      Keeper_tool_disclosure.satisfying_tools_from_contract_violation_reason
+        violation_reason
+  in
+  Keeper_types.dedupe_keep_order (oas_tools @ local_tools)
+;;
+
+let retry_action = function
+  | [] ->
+    "No currently visible tool can satisfy this contract; emit a concise blocker instead."
+  | tools -> Printf.sprintf "You MUST call one of these tools: %s." (String.concat ", " tools)
+;;
+
+let retry_feedback ~violation_reason ~satisfying_tools =
+  Printf.sprintf
+    "[CONTRACT VIOLATION] Your previous response was rejected: %s. %s Do NOT respond with text only."
+    violation_reason
+    (retry_action satisfying_tools)
+;;
+
+let run_with_single_retry ~keeper_name ~acc ~has_current_task ~turn_affordances
+    ~history_messages ~call_run_named =
+  match call_run_named ~initial_messages:history_messages with
+  | Error
+      (Agent_sdk.Error.Agent
+         (Agent_sdk.Error.CompletionContractViolation
+            { reason = violation_reason; violation_detail; _ }))
+    when acc.Keeper_run_tools.contract_violation_retries < 1 ->
+    (* Contract violation retry (max 1 per turn): the model did not call a
+       required tool. Re-run with feedback so the model sees why it was
+       rejected. The context builder in [Keeper_run_tools] injects extra
+       guidance because [contract_violation_retries > 0]. *)
+    acc.contract_violation_retries <- acc.contract_violation_retries + 1;
+    let satisfying_tools =
+      satisfying_tools_for_violation
+        ~acc
+        ~has_current_task
+        ~turn_affordances
+        ~violation_reason
+        ~violation_detail
+    in
+    let retry_feedback = retry_feedback ~violation_reason ~satisfying_tools in
+    let retry_messages = history_messages @ [ retry_feedback_message retry_feedback ] in
+    Log.Keeper.info
+      "keeper:%s contract violation retry #%d (reason: %s)"
+      keeper_name
+      acc.contract_violation_retries
+      violation_reason;
+    call_run_named ~initial_messages:retry_messages
+  | other -> other
+;;

--- a/lib/keeper/keeper_agent_run_contract_retry.mli
+++ b/lib/keeper/keeper_agent_run_contract_retry.mli
@@ -1,0 +1,14 @@
+(** One-shot completion-contract retry for [Keeper_agent_run.run_turn]. *)
+
+val run_with_single_retry :
+  keeper_name:string ->
+  acc:Keeper_run_tools.hook_accumulator ->
+  has_current_task:bool ->
+  turn_affordances:string list ->
+  history_messages:Agent_sdk.Types.message list ->
+  call_run_named:
+    (initial_messages:Agent_sdk.Types.message list ->
+     ('a, Agent_sdk.Error.sdk_error) result) ->
+  ('a, Agent_sdk.Error.sdk_error) result
+(** Run the first attempt and, for one completion-contract violation per turn,
+    append structured feedback and retry once. *)


### PR DESCRIPTION
## Summary

- Extract the contract-violation retry path from `Keeper_agent_run.run_turn` into `Keeper_agent_run_contract_retry`.
- Keep retry behavior to one local retry for `CompletionContractViolation`, preserving the existing retry feedback and required-tool candidate merge.
- Add the current-main missing `cascade_transport_cli_overrides.mli` sibling so the structure ratchet remains green.

## Product impact

This keeps keeper run-turn behavior unchanged while making the retry contract path smaller and separately reviewable. It reduces the next `keeper_agent_run.ml` slice size and keeps RFC-0147 decomposition moving without changing external operator behavior.

## Evidence

- `ocamlformat --check lib/keeper/keeper_agent_run.ml lib/keeper/keeper_agent_run_contract_retry.ml lib/keeper/keeper_agent_run_contract_retry.mli lib/cascade/cascade_transport_cli_overrides.mli`
- `scripts/ocaml-structure-ratchet.sh`
- `git diff --check`
- `scripts/check-pr-hygiene.sh --base origin/main --head HEAD`
- `wc -l lib/keeper/keeper_agent_run.ml lib/keeper/keeper_agent_run_contract_retry.ml lib/keeper/keeper_agent_run_contract_retry.mli`

Local focused Dune verification was attempted with `scripts/dune-local.sh build lib/masc_mcp_lib.a`, but the wrapper refused with exit 75 because existing bare Dune processes were already running on the host. I did not bypass the guard.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 4/5
provenance: direct
checks:
  - ocamlformat
  - structure_ratchet
  - diff_check
  - pr_hygiene
blocked:
  - focused_dune_local_existing_bare_dune_processes
```

## Review evidence

- `lib/keeper/keeper_agent_run.ml` drops from 2184 to 2114 LOC on this branch.
- New helper owns only the first-attempt plus single contract retry flow.
- The caller still owns turn state, task ownership check, affordances, and history assembly.

## Linked issue

RFC-0147 keeper godfile decomposition follow-up slice.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/agent-run-contract-retry-20260521` → `main` · 1 commit(s) · synced 2026-05-21T12:56:17Z

| sha | subject | date |
|---|---|---|
| `06ef9cfd7` | refactor(keeper_agent_run): extract contract retry | 2026-05-21 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->