### PR TITLE
[codex] add cascade CLI overrides interface

### DIFF
--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -469,7 +469,7 @@ let run_bash_with_status (t : t) ~(cwd : string) ~(cmd : string) ~(timeout_sec :
       cmd
   in
   let container_cwd = container_cwd_of_host t ~host_cwd:cwd in
-  let argv ~container_name =
+  let make_argv ~container_name =
     Keeper_sandbox_runtime.docker_command_argv ()
     @
     [ "exec"
@@ -487,7 +487,7 @@ let run_bash_with_status (t : t) ~(cwd : string) ~(cmd : string) ~(timeout_sec :
   match ensure_started t ~timeout_sec with
   | Error _ as err -> err
   | Ok container_name ->
-    let argv = argv ~container_name in
+    let argv = make_argv ~container_name in
     let st, out =
       run_argv_with_stdin_and_status_split_retry_eintr
         ~timeout_sec
@@ -502,7 +502,7 @@ let run_bash_with_status (t : t) ~(cwd : string) ~(cmd : string) ~(timeout_sec :
         (match ensure_started t ~timeout_sec with
          | Error _ as err -> err
          | Ok container_name ->
-           let argv = argv ~container_name in
+           let argv = make_argv ~container_name in
            Ok
              (run_argv_with_stdin_and_status_split_retry_eintr
                 ~timeout_sec


### PR DESCRIPTION
## Summary
- add a curated sibling interface for cascade_transport_cli_overrides
- close the latest OCaml structure ratchet regression from the main refactor train

## Verification
- ocamlformat --check lib/cascade/cascade_transport_cli_overrides.mli
- scripts/dune-local.sh build lib/.masc_mcp.objs/byte/masc_mcp__Cascade_transport_cli_overrides.cmi lib/.masc_mcp.objs/native/masc_mcp__Cascade_transport_cli_overrides.cmx
- scripts/ocaml-structure-ratchet.sh
- git diff --check
- scripts/ci/check-ignore-without-comment-diff.sh --base origin/main --head HEAD
- scripts/oas-drift-check.sh
- scripts/check-oas-pin.sh