### PR TITLE
fix(exec): honor Shell IR redirects in native dispatch

### DIFF
--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -190,7 +190,7 @@ let host_pipeline_specs stages =
     | [] -> Some (List.rev acc)
     | Shell_ir.Simple simple :: rest ->
         (match simple.sandbox with
-         | Host ->
+         | Host when simple.redirects = [] ->
              let argv, env, cwd = process_spec_of_simple simple in
              let stage : Process_eio.pipeline_stage =
                { argv; env = Some env; cwd }

--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -86,6 +86,13 @@ let apply_redirect_plan plan result =
 let unsupported_redirect_result message =
   { status = Unix.WEXITED 1; stdout = ""; stderr = message }
 
+let status_is_success = function
+  | Unix.WEXITED 0 -> true
+  | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> false
+
+let pipeline_status current stage_status =
+  if status_is_success stage_status then current else stage_status
+
 (* --- arg resolution --- *)
 
 let rec resolve_arg = function
@@ -219,37 +226,36 @@ let rec dispatch_pipeline ?timeout_sec stages =
            in
            { status; stdout; stderr }
        | None ->
-      let rec chain prev_stdout = function
-        | [] ->
-            { status = Unix.WEXITED 0; stdout = prev_stdout; stderr = "" }
-        | [ Shell_ir.Simple s ] ->
-            dispatch_simple ?timeout_sec ~stdin_content:prev_stdout s
-        | Shell_ir.Simple s :: rest ->
-            let stage_result =
-              dispatch_simple ?timeout_sec ~stdin_content:prev_stdout s
-            in
-            let result = chain stage_result.stdout rest in
-            let final_status =
-              match stage_result.status with
-              | Unix.WEXITED 0 -> result.status
-              | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ ->
-                  stage_result.status
-            in
-            { result with status = final_status }
-        | Pipeline _ :: _ ->
-            invalid_pipeline "nested pipeline not supported in native dispatch"
-      in
-      (match stages with
-       | [] | [ _ ] ->
-           invalid_pipeline "invalid pipeline arity in native dispatch"
-       | first :: rest -> (
-         match first with
-         | Shell_ir.Simple s ->
-           let result = dispatch_simple ?timeout_sec s in
-           chain result.stdout rest
-         | Pipeline _ ->
-           invalid_pipeline "nested pipeline not supported in native dispatch" ))
-      )
+         let rec chain ~prev_stdout ~status ~stderr = function
+           | [] -> { status; stdout = prev_stdout; stderr }
+           | Shell_ir.Simple s :: rest ->
+               let stage_result =
+                 dispatch_simple ?timeout_sec ~stdin_content:prev_stdout s
+               in
+               let status = pipeline_status status stage_result.status in
+               let stderr = stderr ^ stage_result.stderr in
+               chain ~prev_stdout:stage_result.stdout ~status ~stderr rest
+           | Pipeline _ :: _ ->
+               { status = Unix.WEXITED 1
+               ; stdout = ""
+               ; stderr = stderr ^ "nested pipeline not supported in native dispatch"
+               }
+         in
+         match stages with
+         | [] | [ _ ] ->
+             invalid_pipeline "invalid pipeline arity in native dispatch"
+         | first :: rest -> (
+           match first with
+           | Shell_ir.Simple s ->
+               let first_result = dispatch_simple ?timeout_sec s in
+               let status = pipeline_status (Unix.WEXITED 0) first_result.status in
+               chain
+                 ~prev_stdout:first_result.stdout
+                 ~status
+                 ~stderr:first_result.stderr
+                 rest
+           | Pipeline _ ->
+               invalid_pipeline "nested pipeline not supported in native dispatch" ))
 
 and dispatch ?timeout_sec (ir : Shell_ir.t) =
   match ir with

--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -10,6 +10,82 @@ type dispatch_result = {
   stderr : string;
 }
 
+let ( let* ) = Result.bind
+
+type redirect_target =
+  | Capture_stdout
+  | Capture_stderr
+  | Drop
+
+type redirect_plan = {
+  stdout_target : redirect_target;
+  stderr_target : redirect_target;
+}
+
+let default_redirect_plan =
+  { stdout_target = Capture_stdout; stderr_target = Capture_stderr }
+
+let redirect_target_of_fd plan = function
+  | 1 -> Ok plan.stdout_target
+  | 2 -> Ok plan.stderr_target
+  | fd -> Error (Printf.sprintf "unsupported redirect fd: %d" fd)
+
+let set_redirect_target plan fd target =
+  match fd with
+  | 1 -> Ok { plan with stdout_target = target }
+  | 2 -> Ok { plan with stderr_target = target }
+  | fd -> Error (Printf.sprintf "unsupported redirect fd: %d" fd)
+
+let is_dev_null target = String.equal (Path_scope.raw target) "/dev/null"
+
+let redirect_plan_of_redirects redirects =
+  let step plan = function
+    | Redirect_scope.Fd_to_fd { src; dst } ->
+        let* target = redirect_target_of_fd plan dst in
+        set_redirect_target plan src target
+    | Redirect_scope.File
+        { fd; target; mode = (Redirect_scope.Write | Redirect_scope.Append) }
+      when is_dev_null target ->
+        set_redirect_target plan fd Drop
+    | Redirect_scope.File { fd; target; mode = Redirect_scope.Read } ->
+        Error
+          (Printf.sprintf
+             "unsupported redirect in native dispatch: fd %d read from %s"
+             fd
+             (Path_scope.raw target))
+    | Redirect_scope.File
+        { fd; target; mode = (Redirect_scope.Write | Redirect_scope.Append) } ->
+        Error
+          (Printf.sprintf
+             "unsupported redirect in native dispatch: fd %d write to %s"
+             fd
+             (Path_scope.raw target))
+  in
+  List.fold_left
+    (fun acc redirect -> Result.bind acc (fun plan -> step plan redirect))
+    (Ok default_redirect_plan)
+    redirects
+
+let add_redirected_output target text (stdout, stderr) =
+  match target with
+  | Capture_stdout -> stdout ^ text, stderr
+  | Capture_stderr -> stdout, stderr ^ text
+  | Drop -> stdout, stderr
+
+let apply_redirect_plan plan result =
+  (* Captured stdout/stderr are already split by the lower process layer, so
+     fd-to-fd redirection is deterministic but cannot preserve temporal
+     interleaving between the two original streams. *)
+  let stdout, stderr =
+    ("", "")
+    |> add_redirected_output plan.stdout_target result.stdout
+    |> add_redirected_output plan.stderr_target result.stderr
+  in
+  { result with stdout; stderr }
+
+let unsupported_redirect_result message =
+  { status = Unix.WEXITED 1; stdout = ""; stderr = message }
+
 (* --- arg resolution --- *)
 
 let rec resolve_arg = function
@@ -56,8 +132,11 @@ let process_spec_of_simple (s : Shell_ir.simple) =
 let dispatch_simple ?timeout_sec ?stdin_content (s : Shell_ir.simple) =
   let argv, env, cwd = process_spec_of_simple s in
   let timeout_sec = dispatch_timeout_sec timeout_sec in
-  match s.sandbox with
-  | Host ->
+  match redirect_plan_of_redirects s.redirects with
+  | Error message -> unsupported_redirect_result message
+  | Ok redirect_plan -> (
+    match s.sandbox with
+    | Host ->
       let raw_source = String.concat " " argv in
       let run () =
         match stdin_content with
@@ -85,13 +164,15 @@ let dispatch_simple ?timeout_sec ?stdin_content (s : Shell_ir.simple) =
        | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
        | exception exn ->
          { status = Unix.WEXITED 1; stdout = ""; stderr = Printexc.to_string exn }
-       | status, stdout, stderr -> { status; stdout; stderr })
-  | Docker { runner; _ } ->
+       | status, stdout, stderr ->
+         apply_redirect_plan redirect_plan { status; stdout; stderr })
+    | Docker { runner; _ } ->
     (match runner ~stdin_content ~argv ~env ~cwd ~timeout_sec with
      | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
-	     | exception exn ->
-	       { status = Unix.WEXITED 1; stdout = ""; stderr = Printexc.to_string exn }
-	     | status, stdout, stderr -> { status; stdout; stderr })
+     | exception exn ->
+       { status = Unix.WEXITED 1; stdout = ""; stderr = Printexc.to_string exn }
+     | status, stdout, stderr ->
+       apply_redirect_plan redirect_plan { status; stdout; stderr }))
 
 (* --- pipeline + entry point (mutually recursive) --- *)
 

--- a/lib/exec/parser/bash.ml
+++ b/lib/exec/parser/bash.ml
@@ -97,5 +97,6 @@ let parse_string (source : string) : Shell_ir.t Parsed.t =
     let raw = Bash_subset.command Bash_lexer.token lexbuf in
     to_shell_ir raw
   with
+  | Bash_lexer.Token_limit_exceeded -> Parsed.Parse_aborted `Token_limit_50k
   | Bash_subset.Error -> map_error_or_classify source lexbuf
   | Failure _ -> map_error_or_classify source lexbuf

--- a/lib/exec/parser/bash_lexer.mll
+++ b/lib/exec/parser/bash_lexer.mll
@@ -8,12 +8,17 @@
 {
   open Bash_subset
 
-  (* Token budget — each lexeme increments a counter the parser
-     consults.  50k ceiling per RFC v5 plan; enforced at parse_string
-     level, not here (lexer only counts). *)
+  (* Token budget — each lexeme increments a counter.  The 50k ceiling
+     is enforced in the lexer so large inputs abort before Menhir builds
+     an oversized stage list. *)
   let token_count = ref 0
+  let token_limit = 50_000
+  exception Token_limit_exceeded
   let reset_tokens () = token_count := 0
-  let incr_tokens () = incr token_count
+  let incr_tokens () =
+    incr token_count;
+    if !token_count > token_limit then raise Token_limit_exceeded
+  ;;
   let get_tokens () = !token_count
 }
 

--- a/lib/exec/test/test_bash_parser.ml
+++ b/lib/exec/test/test_bash_parser.ml
@@ -400,6 +400,12 @@ let test_unterminated_double_quote_rejected () =
   | Parsed.Parse_error _ -> ()
   | _ -> assert false
 
+let test_token_limit_aborts () =
+  let many_words = List.init 50_001 (fun _ -> "x") in
+  match Bash.parse_string (String.concat " " many_words) with
+  | Parsed.Parse_aborted `Token_limit_50k -> ()
+  | _ -> assert false
+
 let () =
   test_ls_single_command ();
   test_ls_with_args ();
@@ -445,4 +451,5 @@ let () =
   test_double_quote_with_backslash_rejected ();
   test_double_quote_with_backtick_rejected ();
   test_unterminated_double_quote_rejected ();
+  test_token_limit_aborts ();
   print_endline "[test_bash_parser] all tests passed"

--- a/test/test_exec_dispatch.ml
+++ b/test/test_exec_dispatch.ml
@@ -234,6 +234,117 @@ let () =
    | Masc_exec.Sandbox_target.Docker { image; _ } ->
        assert (image = "test-image"))
 
+(* --- dispatch_simple applies supported redirects deterministically --- *)
+
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let bin = Masc_exec.Bin.of_string "echo" |> Result.get_ok in
+  let dev_null =
+    Masc_exec.Path_scope.classify ~raw:"/dev/null" ~cwd:"/tmp"
+  in
+  let mock_runner ~stdin_content:_ ~argv:_ ~env:_ ~cwd:_ ~timeout_sec:_ =
+    Unix.WEXITED 0, "stdout", "stderr"
+  in
+  let docker_sandbox =
+    Masc_exec.Sandbox_target.docker ~image:"redirect-image" ~runner:mock_runner
+  in
+  let ir =
+    Simple
+      {
+        bin;
+        args = [];
+        env = [];
+        cwd = None;
+        redirects =
+          [
+            Masc_exec.Redirect_scope.Fd_to_fd { src = 2; dst = 1 };
+            Masc_exec.Redirect_scope.File
+              { fd = 1; target = dev_null; mode = Masc_exec.Redirect_scope.Write };
+          ];
+        sandbox = docker_sandbox;
+      }
+  in
+  let result = Masc_exec.Exec_dispatch.dispatch ir in
+  assert (result.status = Unix.WEXITED 0);
+  assert (result.stdout = "stderr");
+  assert (result.stderr = "")
+
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let bin = Masc_exec.Bin.of_string "echo" |> Result.get_ok in
+  let dev_null =
+    Masc_exec.Path_scope.classify ~raw:"/dev/null" ~cwd:"/tmp"
+  in
+  let mock_runner ~stdin_content:_ ~argv:_ ~env:_ ~cwd:_ ~timeout_sec:_ =
+    Unix.WEXITED 0, "stdout", "stderr"
+  in
+  let docker_sandbox =
+    Masc_exec.Sandbox_target.docker ~image:"redirect-image" ~runner:mock_runner
+  in
+  let ir =
+    Simple
+      {
+        bin;
+        args = [];
+        env = [];
+        cwd = None;
+        redirects =
+          [
+            Masc_exec.Redirect_scope.File
+              { fd = 2; target = dev_null; mode = Masc_exec.Redirect_scope.Write };
+          ];
+        sandbox = docker_sandbox;
+      }
+  in
+  let result = Masc_exec.Exec_dispatch.dispatch ir in
+  assert (result.status = Unix.WEXITED 0);
+  assert (result.stdout = "stdout");
+  assert (result.stderr = "")
+
+(* --- dispatch_simple rejects unsupported redirects before spawning --- *)
+
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let bin = Masc_exec.Bin.of_string "echo" |> Result.get_ok in
+  let runner_called = ref false in
+  let unsupported_target =
+    Masc_exec.Path_scope.classify ~raw:"/tmp/exec-dispatch-out" ~cwd:"/tmp"
+  in
+  let mock_runner ~stdin_content:_ ~argv:_ ~env:_ ~cwd:_ ~timeout_sec:_ =
+    runner_called := true;
+    Unix.WEXITED 0, "stdout", "stderr"
+  in
+  let docker_sandbox =
+    Masc_exec.Sandbox_target.docker ~image:"redirect-image" ~runner:mock_runner
+  in
+  let ir =
+    Simple
+      {
+        bin;
+        args = [];
+        env = [];
+        cwd = None;
+        redirects =
+          [
+            Masc_exec.Redirect_scope.File
+              {
+                fd = 1;
+                target = unsupported_target;
+                mode = Masc_exec.Redirect_scope.Write;
+              };
+          ];
+        sandbox = docker_sandbox;
+      }
+  in
+  let result = Masc_exec.Exec_dispatch.dispatch ir in
+  assert (not !runner_called);
+  assert (result.status = Unix.WEXITED 1);
+  assert (result.stdout = "");
+  assert (String.length result.stderr > 0)
+
 (* --- dispatch_pipeline propagates stdin and sandbox runner --- *)
 
 let () =

--- a/test/test_exec_dispatch.ml
+++ b/test/test_exec_dispatch.ml
@@ -125,6 +125,73 @@ let () =
   let result = Masc_exec.Exec_dispatch.dispatch (Pipeline stages) in
   assert (result.status = Unix.WEXITED 1)
 
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let false_bin = Masc_exec.Bin.of_string "false" |> Result.get_ok in
+  let echo_bin = Masc_exec.Bin.of_string "echo" |> Result.get_ok in
+  let host_sandbox = Masc_exec.Sandbox_target.host () in
+  let stages =
+    [
+      Simple
+        {
+          bin = false_bin;
+          args = [];
+          env = [];
+          cwd = None;
+          redirects = [];
+          sandbox = host_sandbox;
+        };
+      Simple
+        {
+          bin = echo_bin;
+          args = [ Lit "recovered" ];
+          env = [];
+          cwd = None;
+          redirects = [];
+          sandbox = host_sandbox;
+        };
+    ]
+  in
+  let result = Masc_exec.Exec_dispatch.dispatch (Pipeline stages) in
+  assert (result.status = Unix.WEXITED 1);
+  assert (String.trim result.stdout = "recovered")
+
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let a_bin = Masc_exec.Bin.of_string "a" |> Result.get_ok in
+  let b_bin = Masc_exec.Bin.of_string "b" |> Result.get_ok in
+  let c_bin = Masc_exec.Bin.of_string "c" |> Result.get_ok in
+  let mock_runner ~stdin_content ~argv ~env:_ ~cwd:_ ~timeout_sec:_ =
+    match argv, stdin_content with
+    | [ "a" ], None -> Unix.WEXITED 7, "a-out", "a-err;"
+    | [ "b" ], Some "a-out" -> Unix.WEXITED 0, "b-out", "b-err;"
+    | [ "c" ], Some "b-out" -> Unix.WEXITED 3, "c-out", "c-err;"
+    | _ -> Unix.WEXITED 99, "", "unexpected;"
+  in
+  let docker_sandbox =
+    Masc_exec.Sandbox_target.docker ~image:"pipeline-status" ~runner:mock_runner
+  in
+  let simple bin =
+    Simple
+      {
+        bin;
+        args = [];
+        env = [];
+        cwd = None;
+        redirects = [];
+        sandbox = docker_sandbox;
+      }
+  in
+  let result =
+    Masc_exec.Exec_dispatch.dispatch
+      (Pipeline [ simple a_bin; simple b_bin; simple c_bin ])
+  in
+  assert (result.status = Unix.WEXITED 3);
+  assert (result.stdout = "c-out");
+  assert (result.stderr = "a-err;b-err;c-err;")
+
 (* --- dispatch empty pipeline --- *)
 
 let () =


### PR DESCRIPTION
## Summary
- apply Shell IR redirect semantics inside native dispatch for supported fd-to-fd and /dev/null redirects
- reject unsupported file redirects before spawning native dispatch
- preserve pipeline failure status and stderr evidence across native pipeline stages
- keep docker bash argv builder naming aligned with the CI catchup fix

## Validation
- ocamlformat --check lib/exec/exec_dispatch.ml test/test_exec_dispatch.ml lib/keeper/keeper_turn_sandbox_runtime.ml
- git diff --check origin/main...HEAD
- bash scripts/lint/shell-legacy-purge-ratchet.sh
- _build/default/test/test_exec_dispatch.exe

## Notes
- OCaml structure ratchet currently depends on #17408 because main has a separate missing cascade CLI override .mli blocker.