### PR TITLE
refactor(keeper_run_tools): move task scope parsing

### DIFF
--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -56,45 +56,8 @@ let record_requested_tool_names = Keeper_run_tools_hook_accumulator.record_reque
 let task_scope_tool_names = Keeper_run_tools_task_scope.task_scope_tool_names
 let json_string_opt = Keeper_run_tools_task_scope.json_string_opt
 let task_id_scope_of_tool_input = Keeper_run_tools_task_scope.task_id_scope_of_tool_input
-
-let first_some left right =
-  match left with
-  | Some _ -> left
-  | None -> right
-;;
-
-let current_task_id_of_meta (meta : Keeper_types.keeper_meta) =
-  Option.map Keeper_id.Task_id.to_string meta.current_task_id
-;;
-
-let task_id_scope_of_claim_output ~tool_name output_text =
-  if not (List.mem tool_name [ "keeper_task_claim"; "masc_claim_next" ])
-  then None
-  else (
-    let output_text =
-      match Tool_output.decode_from_oas output_text with
-      | Tool_output.Stored { preview; _ } -> preview
-      | Tool_output.Inline value -> value
-    in
-    try
-      match Yojson.Safe.from_string (Safe_ops.sanitize_text_utf8 output_text) with
-      | `Assoc fields ->
-        (match List.assoc_opt "result" fields with
-         | Some result ->
-           first_some (json_string_opt "task_id" result) (json_string_opt "task_id" (`Assoc fields))
-         | None -> json_string_opt "task_id" (`Assoc fields))
-      | _ -> None
-    with
-    | Yojson.Json_error _ -> None)
-;;
-
-let task_id_scope_of_tool_call ~tool_name ~input ~output_text ~meta =
-  first_some
-    (task_id_scope_of_tool_input ~tool_name input)
-    (first_some
-       (task_id_scope_of_claim_output ~tool_name output_text)
-       (current_task_id_of_meta meta))
-;;
+let task_id_scope_of_claim_output = Keeper_run_tools_task_scope.task_id_scope_of_claim_output
+let task_id_scope_of_tool_call = Keeper_run_tools_task_scope.task_id_scope_of_tool_call
 
 type tool_search_hit_partition = Tool_search.tool_search_hit_partition =
   { visible_core_hits : (string * float) list

--- a/lib/keeper/keeper_run_tools_task_scope.ml
+++ b/lib/keeper/keeper_run_tools_task_scope.ml
@@ -25,3 +25,42 @@ let task_id_scope_of_tool_input ~tool_name input =
   then json_string_opt "task_id" input
   else None
 ;;
+
+let first_some left right =
+  match left with
+  | Some _ -> left
+  | None -> right
+;;
+
+let current_task_id_of_meta (meta : Keeper_types.keeper_meta) =
+  Option.map Keeper_id.Task_id.to_string meta.current_task_id
+;;
+
+let task_id_scope_of_claim_output ~tool_name output_text =
+  if not (List.mem tool_name [ "keeper_task_claim"; "masc_claim_next" ])
+  then None
+  else (
+    let output_text =
+      match Tool_output.decode_from_oas output_text with
+      | Tool_output.Stored { preview; _ } -> preview
+      | Tool_output.Inline value -> value
+    in
+    try
+      match Yojson.Safe.from_string (Safe_ops.sanitize_text_utf8 output_text) with
+      | `Assoc fields ->
+        (match List.assoc_opt "result" fields with
+         | Some result ->
+           first_some (json_string_opt "task_id" result) (json_string_opt "task_id" (`Assoc fields))
+         | None -> json_string_opt "task_id" (`Assoc fields))
+      | _ -> None
+    with
+    | Yojson.Json_error _ -> None)
+;;
+
+let task_id_scope_of_tool_call ~tool_name ~input ~output_text ~meta =
+  first_some
+    (task_id_scope_of_tool_input ~tool_name input)
+    (first_some
+       (task_id_scope_of_claim_output ~tool_name output_text)
+       (current_task_id_of_meta meta))
+;;

--- a/lib/keeper/keeper_run_tools_task_scope.mli
+++ b/lib/keeper/keeper_run_tools_task_scope.mli
@@ -5,3 +5,13 @@ val json_string_opt : string -> Yojson.Safe.t -> string option
 
 val task_id_scope_of_tool_input :
   tool_name:string -> Yojson.Safe.t -> string option
+
+val task_id_scope_of_claim_output :
+  tool_name:string -> string -> string option
+
+val task_id_scope_of_tool_call :
+  tool_name:string ->
+  input:Yojson.Safe.t ->
+  output_text:string ->
+  meta:Keeper_types.keeper_meta ->
+  string option


### PR DESCRIPTION
## Summary

- Move task-scope output parsing helpers from `keeper_run_tools.ml` into `keeper_run_tools_task_scope`.
- Leave `keeper_run_tools.ml` with aliases only, preserving existing call sites.
- Rebase on latest main after #17405 landed, so this PR now carries only the task-scope extraction.

## Product impact

This is a behavior-preserving extraction for the keeper run-tools godfile. Task-id scope parsing now lives with the existing task-scope input helpers, reducing the parent file while keeping the runtime tool-contract path unchanged.

## Evidence

- `ocamlformat --check lib/keeper/keeper_run_tools.ml lib/keeper/keeper_run_tools_task_scope.ml lib/keeper/keeper_run_tools_task_scope.mli`
- `scripts/ocaml-structure-ratchet.sh`
- `git diff --check origin/main...HEAD`
- `scripts/check-pr-hygiene.sh --base origin/main --head HEAD`
- `wc -l lib/keeper/keeper_run_tools.ml lib/keeper/keeper_run_tools_task_scope.ml lib/keeper/keeper_run_tools_task_scope.mli`

Local focused Dune verification was attempted with `scripts/dune-local.sh build lib/masc_mcp_lib.a`, but the wrapper refused with exit 75 because existing bare Dune processes were already running on the host. I did not bypass the guard.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 4/5
provenance: direct
checks:
  - ocamlformat
  - structure_ratchet
  - diff_check
  - pr_hygiene
blocked:
  - focused_dune_local_existing_bare_dune_processes
```

## Review evidence

- `lib/keeper/keeper_run_tools.ml` drops from 1818 to 1781 LOC on this branch.
- New task-scope helpers are pure and reuse the existing input-scope helper module.
- Existing runtime call site continues to call `task_id_scope_of_tool_call` through the parent module alias.

## Linked issue

RFC-0147 keeper godfile decomposition follow-up slice.
