### PR TITLE
Pass sandbox script commands over stdin

### DIFF
--- a/scripts/coverage_percent.sh
+++ b/scripts/coverage_percent.sh
@@ -27,7 +27,7 @@ require_bisect_reporter() {
     echo "opam is required to run coverage_percent.sh" >&2
     exit 127
   fi
-  if ! opam exec -- bash -lc 'command -v bisect-ppx-report >/dev/null 2>&1'; then
+  if ! opam exec -- bisect-ppx-report --help >/dev/null 2>&1; then
     cat >&2 <<'EOF'
 bisect-ppx-report is not installed in the active opam switch.
 
@@ -81,7 +81,8 @@ if ! $reuse_existing; then
 fi
 
 summary="$(
-  opam exec -- bash -lc "cd '$root_dir' && bisect-ppx-report summary --coverage-path '$coverage_dir'"
+  cd "$root_dir"
+  opam exec -- bisect-ppx-report summary --coverage-path "$coverage_dir"
 )"
 percent="$(
   printf '%s\n' "$summary" \

--- a/scripts/keeper-sandbox-integration-test.sh
+++ b/scripts/keeper-sandbox-integration-test.sh
@@ -53,6 +53,7 @@ run_test() {
   local output
   local status=0
   output=$(
+    printf '%s\n' "$cmd" |
     docker run --rm -i \
       --user "$(id -u):$(id -g)" \
       --read-only \
@@ -66,7 +67,7 @@ run_test() {
       --workdir /workspace \
       "${extra_args[@]}" \
       "$image_tag" \
-      bash -lc "$cmd 2>&1"
+      bash -l -s 2>&1
   ) || status=$?
 
   if [[ "$expect_ok" == "true" && "$status" -eq 0 ]]; then

--- a/scripts/keeper-sandbox-smoke.sh
+++ b/scripts/keeper-sandbox-smoke.sh
@@ -22,7 +22,7 @@ printf 'alpha\nbeta\ngamma\n' > "$playground/demo.txt"
 req_dune_ver="$(grep -E '^\(lang dune\b' "$repo_root/dune-project" \
                 | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1)"
 
-docker run --rm \
+docker run --rm -i \
   --read-only \
   --tmpfs /tmp:rw,nosuid,nodev,noexec,size=64m \
   --cap-drop=ALL \
@@ -32,7 +32,7 @@ docker run --rm \
   -v "$playground:/workspace:rw" \
   --workdir /workspace \
   "$image_tag" \
-  bash -lc '
+  bash -l -s <<'BASH'
     set -euo pipefail
     for cmd in sh bash git gh rg tree jq python3 node npm make opam dune; do
       command -v "$cmd" >/dev/null
@@ -48,7 +48,7 @@ docker run --rm \
     rg beta demo.txt >/dev/null
     printf "delta\n" >> append.txt
     test "$(cat append.txt)" = "delta"
-  '
+BASH
 
 container_name="keeper-sandbox-smoke-$$"
 docker run -d --rm \
@@ -65,9 +65,12 @@ docker run -d --rm \
 
 trap 'docker rm -f "$container_name" >/dev/null 2>&1 || true; rm -rf "$tmpdir"' EXIT
 
-docker exec "$container_name" bash -lc 'cat demo.txt >/tmp/readback && test -s /tmp/readback'
-docker exec "$container_name" bash -lc 'printf "zeta\n" > exec-write.txt'
-docker exec "$container_name" bash -lc 'rg gamma demo.txt >/dev/null'
+printf '%s\n' 'cat demo.txt >/tmp/readback && test -s /tmp/readback' |
+  docker exec -i "$container_name" bash -l -s
+printf '%s\n' 'printf "zeta\n" > exec-write.txt' |
+  docker exec -i "$container_name" bash -l -s
+printf '%s\n' 'rg gamma demo.txt >/dev/null' |
+  docker exec -i "$container_name" bash -l -s
 docker rm -f "$container_name" >/dev/null
 
 test "$(cat "$playground/exec-write.txt")" = "zeta"


### PR DESCRIPTION
## Summary
- remove bash -lc from coverage_percent.sh opam reporter lookup and summary path
- pass keeper sandbox integration test commands to bash -l -s over stdin instead of docker argv
- pass keeper sandbox smoke docker run/exec scripts over stdin instead of bash -lc argv

## Verification
- bash -n scripts/coverage_percent.sh scripts/keeper-sandbox-integration-test.sh scripts/keeper-sandbox-smoke.sh
- git diff --check
- rg -n 'bash -lc|sh -lc' scripts/coverage_percent.sh scripts/keeper-sandbox-integration-test.sh scripts/keeper-sandbox-smoke.sh (no matches)
- bash scripts/lint/shell-legacy-purge-ratchet.sh
- scripts/coverage_percent.sh --help
