### PR TITLE
Drop retired autoresearch tool-policy group

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -72,9 +72,6 @@ tools = ["keeper_pr_review_read", "keeper_pr_review_comment", "keeper_pr_review_
 [groups.coding_shard]
 shard = "coding"
 
-[groups.autoresearch]
-shard = "autoresearch"
-
 # Code-write tools (masc_code_write, masc_code_edit, etc.)
 [groups.coding]
 tools = ["masc_code_write", "masc_code_edit", "masc_code_delete", "masc_code_shell", "masc_code_git"]
@@ -235,13 +232,13 @@ masc_groups = ["essential", "goal", "coding"]
 # still flow through the risk-tiered approval gate in
 # [keeper_routine_allowlist.ml].
 [presets.research]
-groups = ["base", "filesystem", "filesystem_write", "library", "shell", "coordination", "board_core", "autoresearch", "coding_shard", "coding", "github", "github_review"]
+groups = ["base", "filesystem", "filesystem_write", "library", "shell", "coordination", "board_core", "coding_shard", "coding", "github", "github_review"]
 masc_groups = ["essential", "goal", "coordination", "coding"]
 
 # Delivery preset: research + coding for keepers that need to produce code changes.
 # Use for keepers whose goal involves PRs, issues, or code fixes.
 [presets.delivery]
-groups = ["base", "filesystem", "filesystem_write", "library", "shell", "coordination", "board_core", "autoresearch", "coding_shard", "coding", "github", "github_review", "voice"]
+groups = ["base", "filesystem", "filesystem_write", "library", "shell", "coordination", "board_core", "coding_shard", "coding", "github", "github_review", "voice"]
 masc_groups = ["essential", "goal", "coordination", "coding"]
 
 [presets.full]

--- a/test/test_keeper_tool_policy_config.ml
+++ b/test/test_keeper_tool_policy_config.ml
@@ -184,7 +184,7 @@ let test_social_cannot_satisfy_delivery () =
 
 let test_delivery_satisfies_coding () =
   let cfg = load_config () in
-  (* delivery is a superset of coding — includes all coding tools plus autoresearch *)
+  (* delivery is a superset of coding: it includes all coding tools plus voice. *)
   check bool "delivery satisfies coding" true
     (KTPC.preset_can_satisfy cfg ~agent_preset:"delivery" ~required_preset:"coding")
 


### PR DESCRIPTION
## Summary

- remove the stale `groups.autoresearch` entry from `config/tool_policy.toml`
- remove `autoresearch` from research and delivery preset group lists
- update the delivery/coding preset comment so it no longer describes autoresearch as present

## Why

PR #17339 retired the `autoresearch` keeper tool shard from `Tool_shard`, but `config/tool_policy.toml` still referenced it. Runtime keeper preset resolution then repeatedly logged:

```text
tool_policy_config: shard 'autoresearch' not found, returning empty
```

Observed in `/Users/dancer/me/.masc/logs/system_log_2026-05-21.jsonl`, including 317 occurrences in the `2026-05-21T12:45:00Z..12:50:00Z` window.

## Verification

- `rg -n "groups\.autoresearch|\"autoresearch\"" config/tool_policy.toml` exits 1 (no matches)
- `python3 -c 'import tomllib, pathlib; tomllib.loads(pathlib.Path("config/tool_policy.toml").read_text()); print("toml ok")'`
- `opam exec -- ocamlformat --check test/test_keeper_tool_policy_config.ml`
- `git diff --check`

Blocked locally:

- `scripts/dune-local.sh build test/test_keeper_tool_policy_config.exe test/test_tool_shard_coverage.exe` exited 75 because live bare `dune build` processes are already running in sibling worktrees, and the wrapper refused to start another build.