### PR TITLE
Pass remaining smoke shell scripts over stdin

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -74,12 +74,12 @@ jobs:
 
       - name: Check shared library resolution
         run: |
-          docker run --rm masc-mcp-railway-smoke sh -lc '
+          docker run --rm -i masc-mcp-railway-smoke sh -s <<'SH'
             set -e
             out="$(ldd /app/masc-mcp)"
             printf "%s\n" "$out"
             ! printf "%s\n" "$out" | grep -q "not found"
-          '
+          SH
 
       - name: Smoke deployment image
         run: |

--- a/scripts/keeper-docker-multikeeper-isolation-smoke.sh
+++ b/scripts/keeper-docker-multikeeper-isolation-smoke.sh
@@ -62,19 +62,19 @@ run_keeper() {
     -e "EXPECTED_PLAYGROUND=$expected_playground" \
     -e "OTHER_KEEPER=$other" \
     "$image_tag" \
-    bash -lc '
-      set -euo pipefail
-      test "$(cat own.txt)" = "$EXPECTED_PLAYGROUND"
-      test ! -e "/workspace/$OTHER_KEEPER"
-      test "$(cat /tmp/keeper-creds/.config/gh/identity.txt)" = "$EXPECTED_IDENTITY"
-      test -e "/tmp/keeper-creds/.config/gh/${EXPECTED_IDENTITY%-gh}.txt"
-      test ! -e "/tmp/keeper-creds/.config/gh/${OTHER_KEEPER}.txt"
-      if (printf probe >/tmp/keeper-creds/.config/gh/write-probe) 2>/dev/null; then
-        printf "credential projection is writable\n" >&2
-        exit 21
-      fi
-      printf "ok\n" > write-ok.txt
-    ' >/dev/null
+    bash -l -s <<'BASH' >/dev/null
+set -euo pipefail
+test "$(cat own.txt)" = "$EXPECTED_PLAYGROUND"
+test ! -e "/workspace/$OTHER_KEEPER"
+test "$(cat /tmp/keeper-creds/.config/gh/identity.txt)" = "$EXPECTED_IDENTITY"
+test -e "/tmp/keeper-creds/.config/gh/${EXPECTED_IDENTITY%-gh}.txt"
+test ! -e "/tmp/keeper-creds/.config/gh/${OTHER_KEEPER}.txt"
+if (printf probe >/tmp/keeper-creds/.config/gh/write-probe) 2>/dev/null; then
+  printf "credential projection is writable\n" >&2
+  exit 21
+fi
+printf "ok\n" > write-ok.txt
+BASH
 
   test "$(cat "$playground/write-ok.txt")" = "ok"
 }


### PR DESCRIPTION
## Summary
- pass the Railway shared-library smoke script to docker over stdin instead of sh -lc argv
- pass the multikeeper docker isolation smoke body over stdin instead of bash -lc argv

## Verification
- bash -n scripts/keeper-docker-multikeeper-isolation-smoke.sh
- git diff --check
- rg -n 'bash -lc|sh -lc' .github/workflows/deploy-railway.yml scripts/keeper-docker-multikeeper-isolation-smoke.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-railway.yml")'
- bash scripts/lint/shell-legacy-purge-ratchet.sh