### PR TITLE
Run local review command from temp script

### DIFF
--- a/scripts/review/local-review.sh
+++ b/scripts/review/local-review.sh
@@ -370,7 +370,12 @@ EOF
 run_reviewer() {
   local prompt="$1"
   if [ -n "$REVIEW_COMMAND" ]; then
-    printf '%s' "$prompt" | bash -lc "$REVIEW_COMMAND"
+    local command_path="$TMP_DIR/review-command.sh"
+    local prompt_path="$TMP_DIR/review-prompt.txt"
+    printf '%s\n' "$REVIEW_COMMAND" > "$command_path"
+    chmod 600 "$command_path"
+    printf '%s' "$prompt" > "$prompt_path"
+    bash -l "$command_path" < "$prompt_path"
     return 0
   fi
   local request_json


### PR DESCRIPTION
## Summary
- run MASC_LOCAL_REVIEW_COMMAND from a chmod 600 temp script instead of bash -lc argv
- keep the review prompt on stdin via a separate temp file

## Verification
- bash -n scripts/review/local-review.sh
- git diff --check
- rg -n 'bash -lc|sh -lc' scripts/review/local-review.sh
- env MASC_LOCAL_REVIEW_COMMAND='cat >/dev/null; printf "No findings.\n"' scripts/review/local-review.sh --no-cache --format text --path scripts/review/local-review.sh
- bash scripts/lint/shell-legacy-purge-ratchet.sh