### PR TITLE
fix(dashboard): keep shell auth on snapshot reads

### DIFF
--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -1065,6 +1065,15 @@ let dashboard_shell_auth_json ~(request : Httpun.Request.t) (config : Coord.conf
     ]
 ;;
 
+let dashboard_shell_with_request_auth_json ~request (config : Coord.config) payload =
+  match payload with
+  | `Assoc fields ->
+    `Assoc
+      (("auth", dashboard_shell_auth_json ~request config)
+       :: List.remove_assoc "auth" fields)
+  | other -> other
+;;
+
 let dashboard_shell_http_json
       ?clock
       ?request
@@ -1156,11 +1165,5 @@ let dashboard_shell_http_json
   in
   match request with
   | None -> payload
-  | Some request ->
-    (match payload with
-     | `Assoc fields ->
-       `Assoc
-         (("auth", dashboard_shell_auth_json ~request config)
-          :: List.remove_assoc "auth" fields)
-     | other -> other)
+  | Some request -> dashboard_shell_with_request_auth_json ~request config payload
 ;;

--- a/lib/server/server_dashboard_http_core.mli
+++ b/lib/server/server_dashboard_http_core.mli
@@ -70,6 +70,15 @@ val with_projection_diagnostics :
 
 val operator_actor_hint : Httpun.Request.t -> string option
 
+val dashboard_shell_with_request_auth_json :
+  request:Httpun.Request.t ->
+  Coord.config ->
+  Yojson.Safe.t ->
+  Yojson.Safe.t
+(** Inject the request-bound dashboard auth contract into a shell payload.
+    Snapshot shell payloads are process-wide and deliberately omit
+    per-request auth; HTTP handlers must add it back before responding. *)
+
 (** {1 Batch API} *)
 
 val dashboard_batch_json :

--- a/lib/server/server_dashboard_snapshot_select.ml
+++ b/lib/server/server_dashboard_snapshot_select.ml
@@ -16,10 +16,17 @@ let select_shell_json
   else (
     match Dashboard_snapshot.current () with
     | Some snap ->
-      Server_timing.measure
-        timing_obj
-        (Server_timing.Custom "snapshot_read")
-        (fun () -> snap.shell)
+      let shell =
+        Server_timing.measure
+          timing_obj
+          (Server_timing.Custom "snapshot_read")
+          (fun () -> snap.shell)
+      in
+      (match request with
+       | None -> shell
+       | Some request ->
+         Server_dashboard_http_core.dashboard_shell_with_request_auth_json
+           ~request config shell)
     | None ->
       Server_dashboard_http_core.dashboard_shell_http_json
         ?clock ?request ~timing:timing_obj ~light config)

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -733,6 +733,38 @@ let test_dashboard_shell_auth_json_reports_missing_token () =
   check string "missing token code surfaced" "missing_token"
     (auth |> member "auth_error_code" |> to_string)
 
+let test_dashboard_shell_snapshot_selector_injects_auth () =
+  with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  Lib.Dashboard_snapshot.reset_for_test ();
+  Fun.protect
+    ~finally:Lib.Dashboard_snapshot.reset_for_test
+    (fun () ->
+       let snapshot =
+         Lib.Dashboard_snapshot.make_for_test
+           ~shell:
+             (`Assoc
+                [
+                  ("status", `Assoc [ ("project", `String "snapshot") ]);
+                  ("paths", `Assoc []);
+                ])
+           ~tools:`Null
+           ~namespace_truth:`Null
+           ~telemetry_summary:`Null
+       in
+       Lib.Dashboard_snapshot.publish_for_test snapshot;
+       let json =
+         Lib.Server_dashboard_snapshot_select.select_shell_json
+           ~request:(request "/api/v1/dashboard/shell")
+           config
+       in
+       let open Yojson.Safe.Util in
+       check string "snapshot payload preserved" "snapshot"
+         (json |> member "status" |> member "project" |> to_string);
+       check bool "snapshot selector injects auth" true
+         (match json |> member "auth" with
+          | `Assoc _ -> true
+          | _ -> false))
+
 let test_execution_actor_for_request_canonicalizes_token_owner () =
   with_test_env @@ fun ~env:_ ~sw:_ ~config ->
   let cfg =
@@ -1097,6 +1129,8 @@ let () =
             test_dashboard_shell_auth_json_canonicalizes_token_owner;
           test_case "shell auth reports missing token" `Quick
             test_dashboard_shell_auth_json_reports_missing_token;
+          test_case "shell snapshot selector injects auth" `Quick
+            test_dashboard_shell_snapshot_selector_injects_auth;
           test_case "execution actor canonicalizes token owner" `Quick
             test_execution_actor_for_request_canonicalizes_token_owner;
           test_case "verification verifier canonicalizes token owner" `Quick


### PR DESCRIPTION
## Summary
- inject request-bound dashboard auth into shell payloads served from the lock-free snapshot read path
- keep the existing direct shell compute path on the same auth injection helper
- fix a current sandbox retry argv shadowing compile blocker hit by the focused dashboard build

## Evidence
- ocamlformat --check lib/keeper/keeper_turn_sandbox_runtime.ml lib/server/server_dashboard_http_core.ml lib/server/server_dashboard_http_core.mli lib/server/server_dashboard_snapshot_select.ml test/test_dashboard_http_core.ml
- git diff --check origin/main..HEAD
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_dashboard_http_core.exe
- ./_build/default/test/test_dashboard_http_core.exe: 33 tests, Test Successful

Context: this addresses one concrete verifier failure from scripts/verify-dashboard.sh: shell exposes auth contract.