### PR TITLE
Preserve ci-run login shell with stdin execution

### DIFF
--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -327,7 +327,7 @@ run_with_timeout() {
   tail -n 0 -f "${TEST_LOG_FILE}" &
   ACTIVE_LOG_TAIL_PID=$!
 
-  bash -s <<< "${cmd}" >> "${TEST_LOG_FILE}" 2>&1 &
+  bash -l -s <<< "${cmd}" >> "${TEST_LOG_FILE}" 2>&1 &
   ACTIVE_CMD_PID=$!
   ACTIVE_CMD_PGID="$(
     ps -o pgid= -p "${ACTIVE_CMD_PID}" 2>/dev/null \


### PR DESCRIPTION
## Summary
- keep ci-run-tests using a login bash shell while still passing the command body over stdin
- preserves the old bash -l behavior without putting the command in argv

## Verification
- bash -n scripts/ci-run-tests.sh
- git diff --check
- rg -n 'bash -lc|sh -lc' scripts/ci-run-tests.sh
- env CI_TEST_TIMEOUT_SEC=10 CI_TEST_HEARTBEAT_SEC=1 scripts/ci-run-tests.sh 'printf "ci-run-login-stdin-ok\\n"'
- bash scripts/lint/shell-legacy-purge-ratchet.sh