### PR TITLE
feat(exec): stream host shell ir pipelines

### DIFF
--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -42,7 +42,7 @@ let dispatch_timeout_sec = function
   | Some timeout_sec -> timeout_sec
   | None -> Env_config_exec_timeout.timeout_sec ~caller:Dispatch ()
 
-let dispatch_simple ?timeout_sec ?stdin_content (s : Shell_ir.simple) =
+let process_spec_of_simple (s : Shell_ir.simple) =
   let bin = Bin.to_string s.bin in
   let argv = bin :: List.map resolve_arg s.args in
   let env = resolve_env s.env in
@@ -51,6 +51,10 @@ let dispatch_simple ?timeout_sec ?stdin_content (s : Shell_ir.simple) =
     | None -> None
     | Some scope -> Some (Path_scope.raw scope)
   in
+  (argv, env, cwd)
+
+let dispatch_simple ?timeout_sec ?stdin_content (s : Shell_ir.simple) =
+  let argv, env, cwd = process_spec_of_simple s in
   let timeout_sec = dispatch_timeout_sec timeout_sec in
   match s.sandbox with
   | Host ->
@@ -85,13 +89,30 @@ let dispatch_simple ?timeout_sec ?stdin_content (s : Shell_ir.simple) =
   | Docker { runner; _ } ->
     (match runner ~stdin_content ~argv ~env ~cwd ~timeout_sec with
      | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
-     | exception exn ->
-       { status = Unix.WEXITED 1; stdout = ""; stderr = Printexc.to_string exn }
-     | status, stdout, stderr -> { status; stdout; stderr })
+	     | exception exn ->
+	       { status = Unix.WEXITED 1; stdout = ""; stderr = Printexc.to_string exn }
+	     | status, stdout, stderr -> { status; stdout; stderr })
 
 (* --- pipeline + entry point (mutually recursive) --- *)
 
 let invalid_pipeline stderr = { status = Unix.WEXITED 1; stdout = ""; stderr }
+
+let host_pipeline_specs stages =
+  let rec loop acc = function
+    | [] -> Some (List.rev acc)
+    | Shell_ir.Simple simple :: rest ->
+        (match simple.sandbox with
+         | Host ->
+             let argv, env, cwd = process_spec_of_simple simple in
+             let stage : Process_eio.pipeline_stage =
+               { argv; env = Some env; cwd }
+             in
+             loop (stage :: acc) rest
+         | _ -> None)
+        [@warning "-4"]
+    | Shell_ir.Pipeline _ :: _ -> None
+  in
+  loop [] stages
 
 let rec dispatch_pipeline ?timeout_sec stages =
   match stages with
@@ -100,6 +121,23 @@ let rec dispatch_pipeline ?timeout_sec stages =
   | [ _ ] ->
       invalid_pipeline "single-stage pipeline not supported in native dispatch"
   | _ ->
+      (match host_pipeline_specs stages with
+       | Some specs ->
+           let raw_source =
+             specs
+             |> List.map (fun stage -> String.concat " " stage.Process_eio.argv)
+             |> String.concat " | "
+           in
+           let status, stdout, stderr =
+             Exec_gate.run_argv_pipeline_with_status_split
+               ~actor:`Tool_local_runtime
+               ~raw_source
+               ~summary:"exec dispatch pipeline"
+               ~timeout_sec:(dispatch_timeout_sec timeout_sec)
+               specs
+           in
+           { status; stdout; stderr }
+       | None ->
       let rec chain prev_stdout = function
         | [] ->
             { status = Unix.WEXITED 0; stdout = prev_stdout; stderr = "" }
@@ -130,6 +168,7 @@ let rec dispatch_pipeline ?timeout_sec stages =
            chain result.stdout rest
          | Pipeline _ ->
            invalid_pipeline "nested pipeline not supported in native dispatch" ))
+      )
 
 and dispatch ?timeout_sec (ir : Shell_ir.t) =
   match ir with

--- a/lib/exec/exec_gate.ml
+++ b/lib/exec/exec_gate.ml
@@ -256,3 +256,20 @@ let run_argv_with_stdin_and_status_split ~actor ~raw_source ~summary
         "",
         blocked_output ~summary ~raw_source ~reason ))
     ()
+
+let run_argv_pipeline_with_status_split ~actor ~raw_source ~summary
+    ?(timeout_sec = 60.0) stages =
+  let rec check_stages = function
+    | [] -> Ok ()
+    | ({ Process_eio.argv; env; cwd } : Process_eio.pipeline_stage) :: rest ->
+        with_verdict ~actor ~raw_source ~summary ~argv ?env ?cwd
+          ~on_allow:(fun () -> check_stages rest)
+          ~on_blocked:(fun reason -> Error reason)
+          ()
+  in
+  match check_stages stages with
+  | Ok () -> Process_eio.run_argv_pipeline_with_status_split ~timeout_sec stages
+  | Error reason ->
+      ( Unix.WEXITED 126,
+        "",
+        blocked_output ~summary ~raw_source ~reason )

--- a/lib/exec/exec_gate.mli
+++ b/lib/exec/exec_gate.mli
@@ -82,3 +82,13 @@ val run_argv_with_stdin_and_status_split :
   string list ->
   (Unix.process_status * string * string)
 (** Typed gate in front of [Process_eio.run_argv_with_stdin_and_status_split]. *)
+
+val run_argv_pipeline_with_status_split :
+  actor:Agent_id.t ->
+  raw_source:string ->
+  summary:string ->
+  ?timeout_sec:float ->
+  Process_eio.pipeline_stage list ->
+  (Unix.process_status * string * string)
+(** Typed gate in front of [Process_eio.run_argv_pipeline_with_status_split].
+    Every stage is checked before any process is spawned. *)

--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -540,6 +540,31 @@ let spawn_and_drain_both ?phase_ref ~sw pm ~cwd ?env ?stdin_source argv stdout_b
   | `Exited n -> Unix.WEXITED n
   | `Signaled n -> Unix.WSIGNALED n
 
+type pipeline_stage = {
+  argv : string list;
+  env : string array option;
+  cwd : string option;
+}
+
+let effective_cwd default_cwd = function
+  | None -> default_cwd
+  | Some dir -> Eio.Path.(default_cwd / dir)
+
+let unix_status_of_eio_status = function
+  | `Exited n -> Unix.WEXITED n
+  | `Signaled n -> Unix.WSIGNALED n
+
+let pipeline_status statuses =
+  match statuses with
+  | [] -> Unix.WEXITED 0
+  | last :: rest ->
+      List.fold_left
+        (fun acc status ->
+          match acc, status with
+          | Unix.WEXITED 0, _ -> status
+          | (Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _), _ -> acc)
+        last rest
+
 let run_argv ?(timeout_sec = default_timeout_sec) ?env (argv : string list) : string =
   Exec_tap.record ~kind:Exec_tap.Process_eio_run_argv ~argv ?env ();
   with_spawn_guard (fun () ->
@@ -758,6 +783,177 @@ let run_argv_with_status_split ?(timeout_sec = default_timeout_sec) ?env ?cwd
                     "",
                     process_error_output ~label
                       ~reason:(reason_of_exn_for_output exn) () )))
+
+let run_argv_pipeline_with_status_split ?(timeout_sec = default_timeout_sec)
+    (stages : pipeline_stage list) : Unix.process_status * string * string =
+  let fallback_buffered () =
+    let rec chain prev_stdout = function
+      | [] -> (Unix.WEXITED 0, prev_stdout, "")
+      | [ { argv; env; cwd } ] ->
+          run_unix_argv_with_stdin_and_status_split_fallback ~timeout_sec ?env
+            ?cwd ~stdin_content:prev_stdout argv
+      | { argv; env; cwd } :: rest ->
+          let status, stdout, _stderr =
+            run_unix_argv_with_stdin_and_status_split_fallback ~timeout_sec
+              ?env ?cwd ~stdin_content:prev_stdout argv
+          in
+          let result_status, result_stdout, result_stderr = chain stdout rest in
+          let final_status =
+            match status with
+            | Unix.WEXITED 0 -> result_status
+            | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> status
+          in
+          (final_status, result_stdout, result_stderr)
+    in
+    match stages with
+    | [] -> (Unix.WEXITED 0, "", "")
+    | [ { argv; env; cwd } ] ->
+        run_unix_argv_with_status_split_fallback ~timeout_sec ?env ?cwd argv
+    | { argv; env; cwd } :: rest ->
+        let status, stdout, _stderr =
+          run_unix_argv_with_status_split_fallback ~timeout_sec ?env ?cwd argv
+        in
+        let result_status, result_stdout, result_stderr = chain stdout rest in
+        let final_status =
+          match status with
+          | Unix.WEXITED 0 -> result_status
+          | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> status
+        in
+        (final_status, result_stdout, result_stderr)
+  in
+  with_spawn_guard (fun () ->
+      if not (is_initialized ()) then fallback_buffered ()
+      else
+        match get_proc_mgr (), get_clock (), get_cwd_default () with
+        | Error _, _, _ | _, Error _, _ | _, _, Error _ -> fallback_buffered ()
+        | Ok pm, Ok clk, Ok default_cwd ->
+            let label =
+              stages
+              |> List.map (fun stage ->
+                String.concat " " (List.map Filename.quote stage.argv))
+              |> String.concat " | "
+            in
+            let stdout_buf = Buffer.create default_buffer_size in
+            let phase_ref = ref Timeout_origin.Spawn in
+            let stderr_for_timeout = ref "" in
+            (try
+               Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
+                   Eio.Switch.run (fun sw ->
+                       let final_stdout_r, final_stdout_w =
+                         Eio.Process.pipe ~sw pm
+                       in
+                       let links =
+                         List.init
+                           (max 0 (List.length stages - 1))
+                           (fun _ -> Eio.Process.pipe ~sw pm)
+                       in
+                       let stderr_pairs =
+                         List.map
+                           (fun _ -> Eio.Process.pipe ~sw pm)
+                           stages
+                       in
+                       let stderr_buffers =
+                         List.map
+                           (fun _ -> Buffer.create 256)
+                           stages
+                       in
+                       let procs =
+                         stages
+                         |> List.mapi (fun idx stage ->
+                           Exec_tap.record ~kind:Exec_tap.Process_eio_run_argv_with_status
+                             ~argv:stage.argv ?env:stage.env ?cwd:stage.cwd ();
+                           let stdin =
+                             if idx = 0 then None
+                             else Some (fst (List.nth links (idx - 1)))
+                           in
+                           let stdout =
+                             if idx = List.length stages - 1
+                             then final_stdout_w
+                             else snd (List.nth links idx)
+                           in
+                           let stderr = snd (List.nth stderr_pairs idx) in
+                           let proc =
+                             Eio.Process.spawn
+                               ~sw
+                               pm
+                               ~cwd:(effective_cwd default_cwd stage.cwd)
+                               ?env:stage.env
+                               ?stdin
+                               ~stdout
+                               ~stderr
+                               stage.argv
+                           in
+                           phase_ref := Timeout_origin.Command;
+                           proc)
+                       in
+                       Eio.Flow.close final_stdout_w;
+                       List.iter
+                         (fun (r, w) ->
+                           Eio.Flow.close r;
+                           Eio.Flow.close w)
+                         links;
+                       List.iter
+                         (fun (_r, w) -> Eio.Flow.close w)
+                         stderr_pairs;
+                       let drain_final_stdout () =
+                         Eio.Flow.copy final_stdout_r
+                           (Eio.Flow.buffer_sink stdout_buf);
+                         Eio.Flow.close final_stdout_r
+                       in
+                       let drain_stderr idx (r, _w) =
+                         let buf = List.nth stderr_buffers idx in
+                         Eio.Flow.copy r (Eio.Flow.buffer_sink buf);
+                         Eio.Flow.close r
+                       in
+                       let await_all () =
+                         List.map Eio.Process.await procs
+                         |> List.map unix_status_of_eio_status
+                       in
+                       let drain_all () =
+                         Eio.Fiber.all
+                           (drain_final_stdout
+                            :: List.mapi
+                                 (fun idx pair -> fun () ->
+                                   drain_stderr idx pair)
+                                 stderr_pairs)
+                       in
+                       let statuses, () = Eio.Fiber.pair await_all drain_all in
+                       let stderr =
+                         stderr_buffers
+                         |> List.map Buffer.contents
+                         |> String.concat ""
+                       in
+                       stderr_for_timeout := stderr;
+                       (pipeline_status statuses, Buffer.contents stdout_buf, stderr)))
+             with
+             | Eio.Time.Timeout ->
+                 Log.Misc.warn "[Process_eio] Timeout after %.0fs (%s): %s"
+                   timeout_sec (Timeout_origin.to_label !phase_ref) label;
+                 observe_process_timeout
+                   (match stages with [] -> [] | stage :: _ -> stage.argv)
+                   ~timeout_sec ~origin:!phase_ref;
+                 let stderr =
+                   if String.trim !stderr_for_timeout = "" then
+                     process_error_output ~label
+                       ~reason:(Printf.sprintf "timeout after %.0fs" timeout_sec)
+                       ()
+                   else !stderr_for_timeout
+                 in
+                 (Unix.WEXITED 124, Buffer.contents stdout_buf, stderr)
+             | Eio.Cancel.Cancelled _ as exn -> raise exn
+             | exn ->
+                 if should_retry_unix_fallback exn then (
+                   Log.Misc.warn
+                     "[Process_eio] pipeline bind error, retrying via Unix fallback: %s — %s"
+                     label (Printexc.to_string exn);
+                   fallback_buffered ())
+                 else (
+                   Log.Misc.error "[Process_eio] pipeline error: %s — %s" label
+                     (Printexc.to_string exn);
+                   ( Unix.WEXITED 127,
+                     "",
+                     process_error_output ~label
+                       ~reason:(reason_of_exn_for_output exn) () ))))
 
 let run_argv_with_status ?(timeout_sec = default_timeout_sec) ?env ?cwd
     (argv : string list) : Unix.process_status * string =

--- a/lib/process/process_eio.mli
+++ b/lib/process/process_eio.mli
@@ -137,6 +137,20 @@ val run_argv_with_status_split :
 (** Like [run_argv_with_status], but returns
     [(status, stdout, stderr)] without combining stderr into stdout. *)
 
+type pipeline_stage = {
+  argv : string list;
+  env : string array option;
+  cwd : string option;
+}
+(** One argv-only process stage in a native pipeline. *)
+
+val run_argv_pipeline_with_status_split :
+  ?timeout_sec:float -> pipeline_stage list -> (Unix.process_status * string * string)
+(** Run host stages as a native pipeline. Adjacent stages are connected with
+    process pipes so intermediate stdout is streamed with backpressure rather
+    than buffered into OCaml strings. The returned stdout is the final stage's
+    stdout; stderr is captured from every stage in stage order. *)
+
 (** {1 Detached (background) spawn primitives — P2 foundation} *)
 
 type detached_handle = {

--- a/test/test_exec_dispatch.ml
+++ b/test/test_exec_dispatch.ml
@@ -92,6 +92,24 @@ let () =
   assert (stdout = "HELLO WORLD");
   assert (result.status = Unix.WEXITED 0)
 
+(* --- host pipeline streams between stages --- *)
+
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let yes_bin = Masc_exec.Bin.of_string "yes" |> Result.get_ok in
+  let head_bin = Masc_exec.Bin.of_string "head" |> Result.get_ok in
+  let host_sandbox = Masc_exec.Sandbox_target.host () in
+  let stages =
+    [
+      Simple { bin = yes_bin; args = []; env = []; cwd = None; redirects = []; sandbox = host_sandbox };
+      Simple { bin = head_bin; args = [Lit "-n"; Lit "1"]; env = []; cwd = None; redirects = []; sandbox = host_sandbox };
+    ]
+  in
+  let result = Masc_exec.Exec_dispatch.dispatch ~timeout_sec:2.0 (Pipeline stages) in
+  assert (String.trim result.stdout = "y");
+  assert (result.status <> Unix.WEXITED 124)
+
 (* --- dispatch pipeline exit code: last nonzero wins --- *)
 
 let () =


### PR DESCRIPTION
Summary
- Add Process_eio.run_argv_pipeline_with_status_split for host-native argv pipelines connected by Eio process pipes.
- Add Exec_gate pipeline wrapper so every stage is checked before any process is spawned.
- Route all-host Shell_ir pipelines through the streaming path while keeping Docker/mixed pipelines on the existing runner contract.
- Add a regression test using yes | head -n 1 to prove the pipeline does not wait for an infinite producer to finish before starting the consumer.

Validation
- PASS: ocamlformat --check lib/process/process_eio.ml lib/process/process_eio.mli lib/exec/exec_gate.ml lib/exec/exec_gate.mli lib/exec/exec_dispatch.ml test/test_exec_dispatch.ml
- PASS: git diff --check HEAD~1..HEAD
- PASS: env DUNE_CACHE=disabled DUNE_LOCAL_JOBS=1 MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build lib/process/masc_process.cma lib/exec/masc_exec.cma test/test_exec_dispatch.exe
- PASS: _build/default/test/test_exec_dispatch.exe

Notes
- This addresses the host half of #17402. Docker and mixed host/Docker pipelines still need a streaming-capable runner contract before #17402 can close.