### PR TITLE
refactor(shell): use shared parser for command argv

### DIFF
--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -122,8 +122,14 @@ Respond in 1-2 sentences. Be helpful and concise.|}
 let cli_argv_of_agent_type (agent_type : string) : string list =
   match Spawn.get_config agent_type with
   | Some config ->
-    String.split_on_char ' ' config.command
-    |> List.filter (fun s -> s <> "")
+    (match Masc_exec_bash_parser.Bash_words.stages config.command with
+     | Ok [ words ] ->
+       words
+       |> List.map (fun (word : Masc_exec_bash_parser.Bash_words.word) -> word.value)
+       |> List.filter (fun s -> s <> "")
+     | Ok [] | Ok (_ :: _ :: _) | Error _ ->
+       let command = String.trim config.command in
+       if String.equal command "" then [] else [ command ])
   | None -> [agent_type]
 
 let run_cli_agent ~agent_type ~prompt =

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -469,7 +469,7 @@ let run_bash_with_status (t : t) ~(cwd : string) ~(cmd : string) ~(timeout_sec :
       cmd
   in
   let container_cwd = container_cwd_of_host t ~host_cwd:cwd in
-  let argv ~container_name =
+  let docker_exec_argv ~container_name =
     Keeper_sandbox_runtime.docker_command_argv ()
     @
     [ "exec"
@@ -487,7 +487,7 @@ let run_bash_with_status (t : t) ~(cwd : string) ~(cmd : string) ~(timeout_sec :
   match ensure_started t ~timeout_sec with
   | Error _ as err -> err
   | Ok container_name ->
-    let argv = argv ~container_name in
+    let argv = docker_exec_argv ~container_name in
     let st, out =
       run_argv_with_stdin_and_status_split_retry_eintr
         ~timeout_sec
@@ -502,7 +502,7 @@ let run_bash_with_status (t : t) ~(cwd : string) ~(cmd : string) ~(timeout_sec :
         (match ensure_started t ~timeout_sec with
          | Error _ as err -> err
          | Ok container_name ->
-           let argv = argv ~container_name in
+           let argv = docker_exec_argv ~container_name in
            Ok
              (run_argv_with_stdin_and_status_split_retry_eintr
                 ~timeout_sec

--- a/lib/tool_local_runtime_core.ml
+++ b/lib/tool_local_runtime_core.ml
@@ -56,10 +56,15 @@ let parse_int_opt value =
 let unique_preserve_order = Json_util.dedupe_keep_order
 
 let split_ws text =
-  text
-  |> String.split_on_char ' '
-  |> List.map String.trim
-  |> List.filter (fun item -> not (String.equal item ""))
+  match Masc_exec_bash_parser.Bash_words.stages text with
+  | Ok stages ->
+      stages
+      |> List.concat
+      |> List.map (fun (word : Masc_exec_bash_parser.Bash_words.word) -> word.value)
+      |> List.filter (fun item -> not (String.equal item ""))
+  | Error _ ->
+      let trimmed = String.trim text in
+      if String.equal trimmed "" then [] else [ trimmed ]
 
 let string_contains_substring = String_util.contains_substring
 

--- a/lib/tool_local_runtime_core.mli
+++ b/lib/tool_local_runtime_core.mli
@@ -83,8 +83,9 @@ val unique_preserve_order : string list -> string list
 (** Alias over {!Json_util.dedupe_keep_order}. *)
 
 val split_ws : string -> string list
-(** [split_ws text] splits on space, trims, and drops empties.
-    Used to tokenise cmdlines into argv-like lists. *)
+(** [split_ws text] returns argv-like literal words using the shared
+    bash-subset word parser, preserving quoted values.  Used to tokenise
+    cmdlines into argv-like lists for process discovery. *)
 
 val string_contains_substring : string -> string -> bool
 (** Alias over {!String_util.contains_substring} — case-

--- a/scripts/lint/shell-legacy-purge-ratchet.baseline
+++ b/scripts/lint/shell-legacy-purge-ratchet.baseline
@@ -28,6 +28,7 @@ Keeper_shell_bash_words 0
 keeper_shell_bash_words 0
 lowercase_shell_words 0
 String.split_on_char ' ' cmd 0
+String.split_on_char ' ' config.command 0
 shell_words_prefix 0
 shell_words_with_boundaries 0
 strip_command_wrappers 0

--- a/scripts/lint/shell-legacy-purge-ratchet.sh
+++ b/scripts/lint/shell-legacy-purge-ratchet.sh
@@ -40,6 +40,7 @@ NEEDLES=(
   "keeper_shell_bash_words"
   "lowercase_shell_words"
   "String.split_on_char ' ' cmd"
+  "String.split_on_char ' ' config.command"
   "shell_words_prefix"
   "shell_words_with_boundaries"
   "strip_command_wrappers"

--- a/test/test_tool_local_runtime_verify.ml
+++ b/test/test_tool_local_runtime_verify.ml
@@ -11,6 +11,14 @@ let test_provider_health_reachable_accepts_json_health () =
     (Masc_mcp.Tool_local_runtime.provider_health_reachable ~status:(Some 503)
        ~body:(Some {|{"status":"error"}|}))
 
+let test_split_ws_preserves_quoted_cmdline_values () =
+  check
+    (list string)
+    "quoted model path remains one argv"
+    [ "/opt/bin/llama-server"; "-m"; "/models/Qwen 3.5.gguf"; "--port"; "8080" ]
+    (Masc_mcp.Tool_local_runtime.split_ws
+       {|/opt/bin/llama-server -m "/models/Qwen 3.5.gguf" --port 8080|})
+
 let test_classify_runtime_blocker_prefers_slot_count_when_health_ok () =
   let blocker, detail =
     Masc_mcp.Tool_local_runtime.classify_runtime_blocker ~provider_reachable:true
@@ -117,6 +125,8 @@ let () =
         [
           test_case "accepts json health payload" `Quick
             test_provider_health_reachable_accepts_json_health;
+          test_case "split_ws preserves quoted cmdline values" `Quick
+            test_split_ws_preserves_quoted_cmdline_values;
         ] );
       ( "runtime_blocker",
         [


### PR DESCRIPTION
## Summary
- replace tool_local_runtime_core's private space split with the shared Bash_words parser so quoted cmdline values stay intact
- replace auto_responder config.command space splitting with the same shared parser
- add regression coverage for quoted llama-server model paths and ratchet the removed config.command split at zero

## Stack note
- This branch is stacked on #17414 because current main has the keeper_turn_sandbox_runtime argv shadowing CI repair pending. Once #17414 lands, this PR should reduce to the command argv parser cleanup commit.

## Verification
- ocamlformat --check lib/tool_local_runtime_core.ml lib/tool_local_runtime_core.mli lib/auto_responder.ml test/test_tool_local_runtime_verify.ml
- git diff --check
- bash scripts/lint/shell-legacy-purge-ratchet.sh
- attempted focused Dune build: env MASC_DUNE_THROTTLE=0 MASC_OPAM_LOCK=0 MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build lib/.masc_mcp.objs/byte/masc_mcp__Tool_local_runtime_core.cmo lib/.masc_mcp.objs/byte/masc_mcp__Auto_responder.cmo test/test_tool_local_runtime_verify.exe; stopped after >10m host-wide Dune compile contention, sample saved at /tmp/dune_command_argv_63591.sample.txt