### PR TITLE
refactor(keeper_agent_run): extract thinking trajectory

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -202,7 +202,7 @@
   keeper_agent_tool_surface
   keeper_agent_run_phase0_telemetry
   keeper_agent_run_contract_retry
-  keeper_agent_run_contract_helpers
+  keeper_agent_run_contract_helpers keeper_agent_run_thinking_trajectory
   keeper_agent_run_receipt_append
   keeper_agent_result
   keeper_agent_error

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -708,74 +708,10 @@ let run_turn
                  receipt_model_used_ref := Some model;
                  receipt_stop_reason_ref := Some result.stop_reason;
                  receipt_cascade_observation_ref := result.cascade_observation;
-                 (* Extract and persist thinking blocks to trajectory JSONL.
-           NOTE: turn = acc.turn stays at 0 in the keeper path because
-           Trajectory.increment_turn is never called here — the keeper
-           uses OAS Agent.run which manages its own internal call count.
-           Consumers should treat turn=0 as "turn not tracked in keeper path". *)
-                 (match trajectory_acc with
-                  | Some acc ->
-                    let now = Time_compat.now () in
-                    let now_iso = Masc_domain.now_iso () in
-                    List.iter
-                      (function
-                        | Agent_sdk.Types.Thinking { content; _ } ->
-                          let entry : Trajectory.thinking_entry =
-                            { ts = now
-                            ; ts_iso = now_iso
-                            ; turn = acc.Trajectory.turn
-                            ; content
-                            ; content_length = String.length content
-                            ; redacted = false
-                            }
-                          in
-                          (try
-                             Trajectory.append_thinking
-                               ~masc_root:acc.Trajectory.masc_root
-                               ~keeper_name:acc.Trajectory.keeper_name
-                               ~trace_id:acc.Trajectory.trace_id
-                               entry
-                           with
-                           | Eio.Cancel.Cancelled _ as e -> raise e
-                           | exn ->
-                             Log.Keeper.error
-                               "keeper:%s thinking persist failed: %s"
-                               meta.name
-                               (Printexc.to_string exn);
-                             Prometheus.inc_counter
-                               Keeper_metrics.metric_keeper_thinking_persist_failures
-                               ~labels:[ "keeper", meta.name ]
-                               ())
-                        | Agent_sdk.Types.RedactedThinking _ ->
-                          let entry : Trajectory.thinking_entry =
-                            { ts = now
-                            ; ts_iso = now_iso
-                            ; turn = acc.Trajectory.turn
-                            ; content = "[redacted]"
-                            ; content_length = 0
-                            ; redacted = true
-                            }
-                          in
-                          (try
-                             Trajectory.append_thinking
-                               ~masc_root:acc.Trajectory.masc_root
-                               ~keeper_name:acc.Trajectory.keeper_name
-                               ~trace_id:acc.Trajectory.trace_id
-                               entry
-                           with
-                           | Eio.Cancel.Cancelled _ as e -> raise e
-                           | exn ->
-                             Log.Keeper.error
-                               "keeper:%s redacted thinking persist failed: %s"
-                               meta.name
-                               (Printexc.to_string exn);
-                             Prometheus.inc_counter
-                               Keeper_metrics.metric_keeper_thinking_persist_failures
-                               ~labels:[ "keeper", meta.name ]
-                               ())
-                        | _ -> ())
-                      result.response.content
-                  | None -> ());
+                 Keeper_agent_run_thinking_trajectory.persist_response_content
+                   ~keeper_name:meta.name
+                   ~trajectory_acc
+                   result.response.content;
                  let reported_tool_names =
                    List.filter_map
                      (function

--- a/lib/keeper/keeper_agent_run_thinking_trajectory.ml
+++ b/lib/keeper/keeper_agent_run_thinking_trajectory.ml
@@ -1,0 +1,54 @@
+let append_entry ~keeper_name ~failure_label (acc : Trajectory.accumulator) entry =
+  try
+    Trajectory.append_thinking
+      ~masc_root:acc.Trajectory.masc_root
+      ~keeper_name:acc.Trajectory.keeper_name
+      ~trace_id:acc.Trajectory.trace_id
+      entry
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Keeper.error
+      "keeper:%s %s persist failed: %s"
+      keeper_name
+      failure_label
+      (Printexc.to_string exn);
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_thinking_persist_failures
+      ~labels:[ "keeper", keeper_name ]
+      ()
+;;
+
+let persist_response_content ~keeper_name ~trajectory_acc content =
+  match trajectory_acc with
+  | None -> ()
+  | Some acc ->
+    let now = Time_compat.now () in
+    let now_iso = Masc_domain.now_iso () in
+    List.iter
+      (function
+        | Agent_sdk.Types.Thinking { content; _ } ->
+          let entry : Trajectory.thinking_entry =
+            { ts = now
+            ; ts_iso = now_iso
+            ; turn = acc.Trajectory.turn
+            ; content
+            ; content_length = String.length content
+            ; redacted = false
+            }
+          in
+          append_entry ~keeper_name ~failure_label:"thinking" acc entry
+        | Agent_sdk.Types.RedactedThinking _ ->
+          let entry : Trajectory.thinking_entry =
+            { ts = now
+            ; ts_iso = now_iso
+            ; turn = acc.Trajectory.turn
+            ; content = "[redacted]"
+            ; content_length = 0
+            ; redacted = true
+            }
+          in
+          append_entry ~keeper_name ~failure_label:"redacted thinking" acc entry
+        | _ -> ())
+      content
+;;

--- a/lib/keeper/keeper_agent_run_thinking_trajectory.mli
+++ b/lib/keeper/keeper_agent_run_thinking_trajectory.mli
@@ -1,0 +1,5 @@
+val persist_response_content
+  :  keeper_name:string
+  -> trajectory_acc:Trajectory.accumulator option
+  -> Agent_sdk.Types.content list
+  -> unit


### PR DESCRIPTION
## Summary

- Extract thinking/redacted-thinking trajectory persistence from `Keeper_agent_run.run_turn` into `Keeper_agent_run_thinking_trajectory`.
- Preserve the existing append behavior, cancellation propagation, metrics counter, and log labels.
- Keep `keeper_agent_run.ml` focused on post-turn orchestration after `Agent.run`.

## Product impact

Behavior-preserving keeper godfile decomposition. Thinking block persistence remains available for trajectory JSONL, while the main turn runner loses another isolated post-turn side-effect block.

## Evidence

- `ocamlformat --check lib/keeper/keeper_agent_run.ml lib/keeper/keeper_agent_run_thinking_trajectory.ml lib/keeper/keeper_agent_run_thinking_trajectory.mli`
- `scripts/ocaml-structure-ratchet.sh`
- `git diff --check`
- `scripts/check-pr-hygiene.sh --base origin/main --head HEAD`
- `wc -l lib/keeper/keeper_agent_run.ml lib/keeper/keeper_agent_run_thinking_trajectory.ml lib/keeper/keeper_agent_run_thinking_trajectory.mli`

Local focused Dune verification was attempted with `scripts/dune-local.sh build lib/masc_mcp_lib.a`, but the wrapper refused with exit 75 because existing bare Dune processes were already running on the host. I did not bypass the guard.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 4/5
provenance: direct
checks:
  - ocamlformat
  - structure_ratchet
  - diff_check
  - pr_hygiene
blocked:
  - focused_dune_local_existing_bare_dune_processes
```

## Review evidence

- `lib/keeper/keeper_agent_run.ml` drops from 2114 to 2050 LOC on this branch.
- New helper owns only response-content thinking persistence.
- Existing cancellation handling still re-raises `Eio.Cancel.Cancelled`.

## Linked issue

RFC-0147 keeper godfile decomposition follow-up slice.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/agent-run-thinking-trajectory-20260521` → `main` · 1 commit(s) · synced 2026-05-21T13:41:41Z

| sha | subject | date |
|---|---|---|
| `046dfbedc` | refactor(keeper_agent_run): extract thinking trajectory | 2026-05-21 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->