### PR TITLE
Remove shell-string With_process helper

### DIFF
--- a/lib/process/with_process.ml
+++ b/lib/process/with_process.ml
@@ -1,6 +1,6 @@
 (** Exception-safe subprocess stdout capture.
 
-    SSOT for the [Unix.open_process_*] + drain + close pattern.  Extracted
+    SSOT for the argv subprocess + drain + close pattern.  Extracted
     in the post-#8543 hardening (#8538) so every call site uses the same
     error-path close semantics.
 
@@ -24,17 +24,6 @@ let with_process_guard f = (Atomic.get process_guard).run f
 let close_best_effort ic =
   try let _ = (Unix.close_process_in ic : Unix.process_status) in ()
   with Unix.Unix_error _ | Sys_error _ | Failure _ -> ()
-
-let with_process_in cmd f =
-  with_process_guard (fun () ->
-      let ic = Unix.open_process_in cmd in
-      match f ic with
-      | result ->
-          let status = Unix.close_process_in ic in
-          (result, status)
-      | exception exn ->
-          close_best_effort ic;
-          raise exn)
 
 let with_process_args_in prog argv f =
   with_process_guard (fun () ->

--- a/lib/process/with_process.mli
+++ b/lib/process/with_process.mli
@@ -11,31 +11,29 @@ val set_process_guard : process_guard -> unit
 val reset_process_guard_for_testing : unit -> unit
 (** Restore the default direct guard. Intended for focused tests. *)
 
-val with_process_in :
-  string -> (in_channel -> 'a) -> 'a * Unix.process_status
-(** [with_process_in cmd f] opens [cmd] via [Unix.open_process_in], passes
-    the stdout channel to [f], and guarantees [Unix.close_process_in] runs
-    on every exit path.  Returns [f]'s result paired with the subprocess
-    exit status.
+val with_process_args_in :
+  string -> string array -> (in_channel -> 'a) -> 'a * Unix.process_status
+(** [with_process_args_in prog argv f] opens [prog] with exact argv control,
+    passes the stdout channel to [f], and guarantees
+    [Unix.close_process_in] runs on every exit path. Returns [f]'s result
+    paired with the subprocess exit status.
 
-    - If [f] raises, the channel is closed (best-effort) and the
-      exception is re-raised.
+    - If [f] raises, the channel is closed (best-effort) and the exception is
+      re-raised.
     - [Eio.Cancel.Cancelled] is re-raised after close so Eio's structured
       cancellation is preserved.
     - Close errors ([Unix.Unix_error], [Sys_error],
-      [Failure "equal: abstract value"] per ocaml/ocaml#2447) are
-      swallowed on the error path; the primary contract is fd reclaim. *)
+      [Failure "equal: abstract value"] per ocaml/ocaml#2447) are swallowed on
+      the error path; the primary contract is fd reclaim.
 
-val with_process_args_in :
-  string -> string array -> (in_channel -> 'a) -> 'a * Unix.process_status
-(** As [with_process_in] but uses [Unix.open_process_args_in] for exact
-    argv control. *)
+    This helper intentionally avoids shell-string process APIs so callers
+    cannot accidentally route command strings through a shell interpreter. *)
 
 val drain_to_buffer : ?chunk:int -> in_channel -> Buffer.t
 (** Read [ic] to EOF into a fresh buffer using [Buffer.add_channel].
     Default chunk size 4096.  Raises anything other than [End_of_file]
     (e.g. [Sys_error], [Unix.Unix_error]) to the caller — combine with
-    [with_process_in] to close on such faults. *)
+    [with_process_args_in] to close on such faults. *)
 
 val drain_lines : in_channel -> string list
 (** Read [ic] to EOF with [input_line], returning lines in source order. *)

--- a/test/test_with_process_coverage.ml
+++ b/test/test_with_process_coverage.ml
@@ -8,11 +8,14 @@ module WP = With_process
     so that leaks in the helper surface as baseline drift, not silent. *)
 let count_open_fds () =
   let pid = Unix.getpid () in
-  let cmd = Printf.sprintf "lsof -p %d 2>/dev/null | wc -l" pid in
-  let lines, _ = WP.with_process_in cmd WP.drain_lines in
-  match lines with
-  | [] -> 0
-  | line :: _ -> (try int_of_string (String.trim line) with _ -> 0)
+  let lines, status =
+    WP.with_process_args_in "lsof"
+      [| "lsof"; "-p"; string_of_int pid |]
+      WP.drain_lines
+  in
+  match status with
+  | Unix.WEXITED 0 -> List.length lines
+  | _ -> 0
 
 (* ----- tests ----------------------------------------------------------- *)
 
@@ -109,8 +112,11 @@ let test_process_guard_wraps_helpers () =
           WP.drain_lines
       in
       check (list string) "guarded stdout" [ "guard" ] lines;
-      let lines, _ = WP.with_process_in "printf guard2" WP.drain_lines in
-      check (list string) "guarded shell stdout" [ "guard2" ] lines;
+      let lines, _ =
+        WP.with_process_args_in "/bin/echo" [| "/bin/echo"; "guard2" |]
+          WP.drain_lines
+      in
+      check (list string) "guarded argv stdout" [ "guard2" ] lines;
       check int "guard high-water" 1 (Atomic.get high_water);
       check int "guard released" 0 (Atomic.get depth))
 


### PR DESCRIPTION
## Summary
- remove With_process.with_process_in, the shell-string process helper
- keep only argv-based with_process_args_in for guarded subprocess stdout capture
- update with_process coverage tests to avoid shell-string command execution

## Verification
- ocamlformat --check lib/process/with_process.ml lib/process/with_process.mli test/test_with_process_coverage.ml
- git diff --check
- rg -n 'with_process_in|Unix[.]open_process_in' lib/process test/test_with_process_coverage.ml
- rg -n 'Unix[.]open_process_in|Sys[.]command|Unix[.]system|sh -c|bash -c|bash -lc|sh -lc' lib/process/with_process.ml lib/process/with_process.mli test/test_with_process_coverage.ml

## Not run
- scripts/dune-local.sh build test/test_with_process_coverage.exe: blocked by live bare Dune processes outside scripts/dune-local.sh