### PR TITLE
refactor(cascade_transport): extract non_http_transport registry + dispatcher sibling

### DIFF
--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -1063,33 +1063,9 @@ let make_cli_argv_sanitizing_transport =
   Cascade_transport_cli_argv_sanitize.make_cli_argv_sanitizing_transport
 ;;
 
-(** Registry of non-HTTP transport constructors keyed by provider kind.
-    RFC-0058 §2.4: dispatch by registry lookup, not by closed-variant match.
-    Adding a CLI vendor with an existing protocol shape is a single
-    [register_non_http_transport] call (no edit to
-    {!non_http_transport_of_provider} or any match arm). Vendor SDKs themselves
-    remain in [agent_sdk] (Claude Code's leaked `client.ts` follows the same
-    precedent — Bedrock / Vertex / Foundry / firstParty all live behind a
-    dispatch table that selects one SDK package per env-keyed kind).
-
-    Each ctor takes ownership of [Process_eio.get_proc_mgr] so the registry's
-    value type stays a plain function (no row-polymorphic Eio mgr leaks into
-    the Hashtbl). *)
-type non_http_transport_ctor =
-  provider_cfg:Llm_provider.Provider_config.t
-  -> runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy option
-  -> cli_transport_overrides:cli_transport_overrides option
-  -> (Llm_provider.Llm_transport.t, Agent_sdk.Error.sdk_error) result
-
-let non_http_transport_registry
-  : (Llm_provider.Provider_config.provider_kind, non_http_transport_ctor) Hashtbl.t
-  =
-  Hashtbl.create 8
-;;
-
-let register_non_http_transport ~kind ~ctor =
-  Hashtbl.replace non_http_transport_registry kind ctor
-;;
+(* Non-HTTP transport registry + dispatcher extracted to
+   [Cascade_transport_non_http_registry] (godfile decomp). *)
+let register_non_http_transport = Cascade_transport_non_http_registry.register_non_http_transport
 
 let default_cli_transport_overrides = Cascade_transport_cli_overrides.default_cli_transport_overrides
 
@@ -1208,37 +1184,4 @@ let () =
     ~ctor:codex_cli_transport_ctor
 ;;
 
-let non_http_transport_of_provider
-      ~(sw : Eio.Switch.t)
-      ~(provider_cfg : Llm_provider.Provider_config.t)
-      ?runtime_mcp_policy
-      ?cli_transport_overrides
-      ()
-  : (Llm_provider.Llm_transport.t option, Agent_sdk.Error.sdk_error) result
-  =
-  let _ = sw in
-  match Hashtbl.find_opt non_http_transport_registry provider_cfg.kind with
-  | Some ctor ->
-    (match ctor ~provider_cfg ~runtime_mcp_policy ~cli_transport_overrides with
-     | Ok transport -> Ok (Some transport)
-     | Error _ as e -> e)
-  | None ->
-    (* Fail-fast for subprocess CLI kinds that have no registered ctor:
-       falling through to [Ok None] would route the request to the HTTP
-       lane, which cannot serve a CLI provider. HTTP-shaped providers
-       correctly return [Ok None]; they live behind a different transport
-       selector upstream. *)
-    if Llm_provider.Provider_config.is_subprocess_cli provider_cfg.kind
-    then
-      Error
-        (invalid_runtime_config
-           "non_http_transport_registry"
-           (Printf.sprintf
-              "no non-HTTP transport constructor registered for subprocess \
-               CLI kind %s — registry initializer (cascade_transport.ml \
-               top-level [let ()]) is out of sync with the \
-               Llm_provider.Provider_config.provider_kind variant"
-              (Llm_provider.Provider_config.string_of_provider_kind
-                 provider_cfg.kind)))
-    else Ok None
-;;
+let non_http_transport_of_provider = Cascade_transport_non_http_registry.non_http_transport_of_provider

--- a/lib/cascade/cascade_transport_non_http_registry.ml
+++ b/lib/cascade/cascade_transport_non_http_registry.ml
@@ -1,0 +1,88 @@
+(** Non-HTTP transport registry + dispatcher, extracted from
+    [cascade_transport.ml] (godfile decomp).
+
+    Builds on the [Cascade_transport_cli_overrides] type extraction
+    (#17393) — the [non_http_transport_ctor] function-type signature
+    references [cli_transport_overrides] which had to move first.
+
+    Three pieces shipped together:
+
+    - [type non_http_transport_ctor] — function type for a CLI
+      transport constructor. Each ctor takes ownership of
+      [Process_eio.get_proc_mgr] so the registry's value type stays a
+      plain function (no row-polymorphic Eio mgr leaks into the
+      Hashtbl).
+
+    - [non_http_transport_registry] — the per-process Hashtbl that
+      maps each [Llm_provider.Provider_config.provider_kind] to its
+      registered ctor. Populated by the parent's top-level
+      [let () = register_non_http_transport ~kind ... ~ctor:...]
+      block at module load.
+
+    - [register_non_http_transport ~kind ~ctor] — registration entry
+      point invoked by the parent's [let () = ...] block.
+
+    - [non_http_transport_of_provider ~sw ~provider_cfg
+        ?runtime_mcp_policy ?cli_transport_overrides ()] —
+      runtime dispatcher. Looks up [provider_cfg.kind] in the
+      registry, invokes the registered ctor, forwards the result.
+      Fail-fast policy: missing registration for a subprocess CLI
+      kind returns [Error invalid_runtime_config]. Falling through to
+      [Ok None] would route the request to the HTTP lane, which
+      cannot serve a CLI provider. HTTP-shaped providers correctly
+      return [Ok None]; they live behind a different transport
+      selector upstream. *)
+
+module Label_resolution = Cascade_transport_label_resolution
+module Cli_overrides = Cascade_transport_cli_overrides
+
+type non_http_transport_ctor =
+  provider_cfg:Llm_provider.Provider_config.t
+  -> runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy option
+  -> cli_transport_overrides:Cli_overrides.cli_transport_overrides option
+  -> (Llm_provider.Llm_transport.t, Agent_sdk.Error.sdk_error) result
+
+let non_http_transport_registry
+  : (Llm_provider.Provider_config.provider_kind, non_http_transport_ctor) Hashtbl.t
+  =
+  Hashtbl.create 8
+;;
+
+let register_non_http_transport ~kind ~ctor =
+  Hashtbl.replace non_http_transport_registry kind ctor
+;;
+
+let non_http_transport_of_provider
+      ~(sw : Eio.Switch.t)
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+      ?runtime_mcp_policy
+      ?cli_transport_overrides
+      ()
+  : (Llm_provider.Llm_transport.t option, Agent_sdk.Error.sdk_error) result
+  =
+  let _ = sw in
+  match Hashtbl.find_opt non_http_transport_registry provider_cfg.kind with
+  | Some ctor ->
+    (match ctor ~provider_cfg ~runtime_mcp_policy ~cli_transport_overrides with
+     | Ok transport -> Ok (Some transport)
+     | Error _ as e -> e)
+  | None ->
+    (* Fail-fast for subprocess CLI kinds that have no registered ctor:
+       falling through to [Ok None] would route the request to the HTTP
+       lane, which cannot serve a CLI provider. HTTP-shaped providers
+       correctly return [Ok None]; they live behind a different transport
+       selector upstream. *)
+    if Llm_provider.Provider_config.is_subprocess_cli provider_cfg.kind
+    then
+      Error
+        (Label_resolution.invalid_runtime_config
+           "non_http_transport_registry"
+           (Printf.sprintf
+              "no non-HTTP transport constructor registered for subprocess \
+               CLI kind %s — registry initializer (cascade_transport.ml \
+               top-level [let ()]) is out of sync with the \
+               Llm_provider.Provider_config.provider_kind variant"
+              (Llm_provider.Provider_config.string_of_provider_kind
+                 provider_cfg.kind)))
+    else Ok None
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane D
- 6th sibling extracted from `cascade_transport.ml` (after #17303 `mcp_policy_helpers`, #17333 `auth_bridging`, #17347 `runtime_policy_provider`, #17366 `runtime_mcp_policy_of_tool_names`, #17393 `cli_overrides`).
- **Closes the 2-PR chain** with #17393 — `cli_overrides` extraction unblocked this dispatcher extraction.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/cascade/cascade_transport.ml` | 1244 | 1187 | **-57** |
| `lib/cascade/cascade_transport_non_http_registry.ml` | — | 88 | +88 |

## Moved (verbatim, no behavior change)
- `type non_http_transport_ctor` — function type:
  ```ocaml
  provider_cfg:Llm_provider.Provider_config.t
  -> runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy option
  -> cli_transport_overrides:Cli_overrides.cli_transport_overrides option
  -> (Llm_provider.Llm_transport.t, Agent_sdk.Error.sdk_error) result
  ```
- `non_http_transport_registry` — `(Provider_config.provider_kind, non_http_transport_ctor) Hashtbl.t` created with size hint 8
- `register_non_http_transport ~kind ~ctor` — `Hashtbl.replace`
- `non_http_transport_of_provider ~sw ~provider_cfg ?runtime_mcp_policy ?cli_transport_overrides ()`:
  - `Hashtbl.find_opt non_http_transport_registry provider_cfg.kind`
  - `Some ctor` → invoke ctor, forward `Ok transport` → `Ok (Some transport)`, errors pass through
  - `None` branch: if `Llm_provider.Provider_config.is_subprocess_cli provider_cfg.kind`, return `Error invalid_runtime_config` with the original message (preserving the verbatim error string that points back to `cascade_transport.ml top-level [let ()]` — operator-facing diagnostic preserved). HTTP-shaped providers return `Ok None`.

Plus the rich doc-comment above the type (referencing the dispatch-table pattern from `agent_sdk` and the `Process_eio.get_proc_mgr` ownership invariant) — moved with the cluster.

Parent retains 2 single-line aliases:
```ocaml
let register_non_http_transport = Cascade_transport_non_http_registry.register_non_http_transport
let non_http_transport_of_provider = Cascade_transport_non_http_registry.non_http_transport_of_provider
```

## Module-load ordering invariant
The parent's top-level `let () = ...` block (lines ~1185-1188 post-splice) registers 4 ctors:
- `Claude_code` → `claude_code_transport_ctor`
- `Gemini_cli` → `gemini_cli_transport_ctor`
- `Kimi_cli` → `json_stream_cli_transport_ctor`
- `Codex_cli` → `codex_cli_transport_ctor`

This block executes at module-load time AFTER the sibling's `non_http_transport_registry` Hashtbl is created (since the parent depends on the sibling). The `register_non_http_transport` call resolves through the parent's alias to the sibling's function, which mutates the sibling-owned Hashtbl. By the time any caller invokes `non_http_transport_of_provider`, the registry is populated.

## External callers (all unchanged via parent alias)
- `lib/cascade/cascade_runner.ml:295` — `non_http_transport_of_provider ~sw ~provider_cfg ?runtime_mcp_policy ...` (routed via `Cascade_runner.non_http_transport_of_provider` alias at `cascade_runner.ml:208-209`)
- `.mli` exposure at `cascade_transport.mli:240` preserved via parent alias

## Sibling deps
- `module Label_resolution = Cascade_transport_label_resolution` — for `invalid_runtime_config`
- `module Cli_overrides = Cascade_transport_cli_overrides` — for the type referenced in `non_http_transport_ctor`
- `Llm_provider.Provider_config.{provider_kind, t, is_subprocess_cli, string_of_provider_kind}`
- `Llm_provider.Llm_transport.{runtime_mcp_policy, t}`
- `Agent_sdk.Error.sdk_error`
- `Eio.Switch.t`
- `Hashtbl.{create, find_opt, replace}`
- `Printf.sprintf`

No parent-local dependencies; no sibling -> parent cycle.

## Local build status
- `dune build --root . lib/cascade/` → clean (exit 0)
- godfile lint: sibling 88 LOC under `new_file_cap=600`; parent 1187 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim type + 3-function cluster move via 2 parent aliases. Closes the 2-PR chain started in #17393.

Co-Authored-By: codex <noreply@anthropic.com>
