### PR TITLE
fix(pr-review): route host gh calls through typed argv

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -164,6 +164,7 @@
    keeper_host_config_provider
    keeper_in_container_login_provider
    keeper_gh_shared
+   keeper_gh_pr_review_cli
    keeper_tool_github_pr
    keeper_tool_pr_review
    keeper_activation_readiness

--- a/lib/keeper/keeper_tool_pr_review.ml
+++ b/lib/keeper/keeper_tool_pr_review.ml
@@ -5,9 +5,6 @@
 open Keeper_types
 open Keeper_exec_shared
 
-(* RFC-0084 host-config-cleanup-B — zsh binary path migration. *)
-let host_zsh = (Host_config.host ()).host_zsh
-
 (* Issue #8480: Variant SSOT for PR review event. Adding a new
    constructor forces compilation in [pr_review_event_to_string],
    [pr_review_event_of_string_opt], and [pr_review_event_to_gh_flag],
@@ -161,9 +158,6 @@ let effective_repo_slug ~(config : Coord.config) ~(repo : string)
     | Some slug -> Ok slug
     | None -> Error "Could not determine repository. Provide repo parameter."
 
-let repo_flag repo_slug =
-  Printf.sprintf " -R %s" (Filename.quote repo_slug)
-
 let docker_pr_review_cwd ~(config : Coord.config) meta =
   let root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   let cwd = Filename.concat root ".gh-pr-review" in
@@ -216,9 +210,15 @@ let with_pr_review_body_file ~(config : Coord.config) ~(meta : keeper_meta) ~bod
       | Sys_error _ -> ())
     (fun () -> f command_path)
 
-let run_pr_review_shell ~(config : Coord.config) ~(meta : keeper_meta)
-    ~timeout_sec ~cmd =
+let run_pr_review_argv
+      ~(config : Coord.config)
+      ~(meta : keeper_meta)
+      ~timeout_sec
+      ~summary
+      ~argv
+  =
   if meta.sandbox_profile = Docker then
+    let cmd = Keeper_gh_pr_review_cli.quote_argv argv in
     match
       Keeper_shell_shared.run_docker_shell_command_with_status
         ~config ~meta
@@ -239,12 +239,12 @@ let run_pr_review_shell ~(config : Coord.config) ~(meta : keeper_meta)
         }
   else
     let root = Keeper_alerting_path.project_root_of_config config in
-    let argv = [ host_zsh; "-lc"; cmd ] in
     let status, output =
       Masc_exec.Exec_gate.run_argv_with_status
         ~actor:`Keeper_shell
-        ~raw_source:(String.concat " " (List.map Filename.quote argv))
-        ~summary:"keeper tool pr review host"
+        ~raw_source:(Keeper_gh_pr_review_cli.quote_argv argv)
+        ~summary
+        ?env:(Keeper_gh_env.process_env config)
         ~cwd:root
         ~timeout_sec
         argv
@@ -284,14 +284,12 @@ let explicit_repo_unresolved_error ~(config : Coord.config) (meta : keeper_meta)
     ~repo_arg ~repo_slug ?pr_number ?event () =
   if String.trim repo_arg = "" then None
   else
-    let cmd =
-      Printf.sprintf "gh repo view %s --json nameWithOwner 2>&1"
-        repo_slug
-    in
+    let argv = Keeper_gh_pr_review_cli.repo_view_name_with_owner repo_slug in
     let result =
-      run_pr_review_shell ~config ~meta
+      run_pr_review_argv ~config ~meta
         ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Pr_review ())
-        ~cmd
+        ~summary:"keeper pr review repo resolve"
+        ~argv
     in
     if status_ok result.status then None
     else
@@ -387,17 +385,18 @@ let approve_preflight
     ~(meta : keeper_meta)
     ~pr_number
     ~repo_slug
-    ~repo_flag_arg
   =
-  let cmd =
-    Printf.sprintf
-      "gh pr view %d%s --json isDraft,headRefName,labels 2>&1"
-      pr_number repo_flag_arg
+  let argv =
+    Keeper_gh_pr_review_cli.pr_view_json
+      ~repo_slug
+      ~pr_number
+      ~json_fields:"isDraft,headRefName,labels"
   in
   let result =
-    run_pr_review_shell ~config ~meta
+    run_pr_review_argv ~config ~meta
       ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Pr_review ())
-      ~cmd
+      ~summary:"keeper pr review approve preflight"
+      ~argv
   in
   if not (status_ok result.status) then
     Error
@@ -472,32 +471,39 @@ let handle_keeper_pr_review_read
          with
          | Some error -> error
          | None ->
-             let repo_flag_arg = repo_flag repo_slug in
              (* Get PR metadata *)
-             let meta_cmd =
-               Printf.sprintf
-                 "gh pr view %d%s --json title,body,state,files,reviews,comments,additions,deletions 2>&1"
-                 pr_number repo_flag_arg
+             let meta_argv =
+               Keeper_gh_pr_review_cli.pr_view_json
+                 ~repo_slug
+                 ~pr_number
+                 ~json_fields:
+                   "title,body,state,files,reviews,comments,additions,deletions"
              in
              let meta_result =
-               run_pr_review_shell ~config ~meta
+               run_pr_review_argv ~config ~meta
                  ~timeout_sec:
                    (Env_config_exec_timeout.timeout_sec ~caller:Pr_review ())
-                 ~cmd:meta_cmd
+                 ~summary:"keeper pr review read metadata"
+                 ~argv:meta_argv
              in
              (* Get PR diff (truncated) *)
-             let diff_cmd =
-               Printf.sprintf "gh pr diff %d%s 2>&1 | head -c %d" pr_number
-                 repo_flag_arg Common.max_tool_output_bytes
+             let diff_argv =
+               Keeper_gh_pr_review_cli.pr_diff ~repo_slug ~pr_number
              in
              let diff_result =
-               run_pr_review_shell ~config ~meta
+               run_pr_review_argv ~config ~meta
                  ~timeout_sec:
                    (Env_config_exec_timeout.timeout_sec ~caller:Pr_review ())
-                 ~cmd:diff_cmd
+                 ~summary:"keeper pr review read diff"
+                 ~argv:diff_argv
              in
              let diff_truncated =
-               String.length diff_result.output >= Common.max_tool_output_bytes
+               String.length diff_result.output > Common.max_tool_output_bytes
+             in
+             let diff_output =
+               Keeper_gh_pr_review_cli.truncate_max
+                 ~max_bytes:Common.max_tool_output_bytes
+                 diff_result.output
              in
              let meta_ok = status_ok meta_result.status in
              if
@@ -528,7 +534,7 @@ let handle_keeper_pr_review_read
                     ; "repo", `String repo_slug
                     ; "execution_via", `String meta_result.via
                     ; "metadata", `String meta_result.output
-                    ; "diff", `String diff_result.output
+                    ; "diff", `String diff_output
                     ; "diff_truncated", `Bool diff_truncated
                     ; "diff_status", `Bool (status_ok diff_result.status)
                     ]
@@ -580,12 +586,10 @@ let handle_keeper_pr_review_comment
              with
              | Some error -> error
              | None ->
-                 let repo_flag_arg = repo_flag repo_slug in
                  let approve_preflight_result =
                    match event with
                    | Approve ->
-                       approve_preflight
-                         ~config ~meta ~pr_number ~repo_slug ~repo_flag_arg
+                       approve_preflight ~config ~meta ~pr_number ~repo_slug
                        |> Result.map (fun json -> Some json)
                    | Comment | Request_changes -> Ok None
                  in
@@ -613,25 +617,24 @@ let handle_keeper_pr_review_comment
                       @ route_fields ~via:preflight_via meta
                       @ identity_attestation_fields ~config meta))
              | Ok approve_preflight_json ->
-                 (* Use gh pr review to create a review *)
                  let result =
                    with_pr_review_body_file ~config ~meta ~body
                    @@ fun body_file ->
-                   let cmd =
-                     Printf.sprintf
-                       "gh pr review %d%s --body-file %s %s 2>&1"
-                       pr_number
-                       repo_flag_arg
-                       (Filename.quote body_file)
-                       (pr_review_event_to_gh_flag event)
+                   let argv =
+                     Keeper_gh_pr_review_cli.pr_review
+                       ~repo_slug
+                       ~pr_number
+                       ~body_file
+                       ~event_flag:(pr_review_event_to_gh_flag event)
                    in
-                   run_pr_review_shell
+                   run_pr_review_argv
                      ~config
                      ~meta
                      ~timeout_sec:
                        (Env_config_exec_timeout.timeout_sec
                           ~caller:Pr_review_post ())
-                     ~cmd
+                     ~summary:"keeper pr review mutate"
+                     ~argv
                  in
                  Log.Keeper.info
                    "pr_review_comment: pr=%d event=%s keeper=%s ok=%b"
@@ -696,17 +699,19 @@ let handle_keeper_pr_review_reply
                let result =
                  with_pr_review_body_file ~config ~meta ~body
                  @@ fun body_file ->
-                 let cmd =
-                   Printf.sprintf
-                     "gh api repos/%s/pulls/%d/comments/%d/replies -F body=@%s \
-                      2>&1"
-                     owner_repo pr_number comment_id (Filename.quote body_file)
+                 let argv =
+                   Keeper_gh_pr_review_cli.pr_comment_reply
+                     ~owner_repo
+                     ~pr_number
+                     ~comment_id
+                     ~body_file
                  in
-                 run_pr_review_shell ~config ~meta
+                 run_pr_review_argv ~config ~meta
                    ~timeout_sec:
                      (Env_config_exec_timeout.timeout_sec
                         ~caller:Pr_review_post ())
-                   ~cmd
+                   ~summary:"keeper pr review reply"
+                   ~argv
                in
                Log.Keeper.info
                  "pr_review_reply: pr=%d comment=%d keeper=%s ok=%b" pr_number

--- a/lib/keeper_gh_pr_review_cli.ml
+++ b/lib/keeper_gh_pr_review_cli.ml
@@ -1,0 +1,42 @@
+(** Typed argv builders for the keeper PR review GitHub CLI surface.
+
+    This module owns the [gh] command shape for keeper_pr_review. Callers choose
+    the execution target; this module only returns argv. *)
+
+let quote_argv argv = String.concat " " (List.map Filename.quote argv)
+let repo_args repo_slug = [ "-R"; repo_slug ]
+
+let truncate_max ~max_bytes s =
+  if String.length s <= max_bytes then s else String.sub s 0 max_bytes
+;;
+
+let repo_view_name_with_owner repo_slug =
+  [ "gh"; "repo"; "view"; repo_slug; "--json"; "nameWithOwner" ]
+;;
+
+let pr_view_json ~repo_slug ~pr_number ~json_fields =
+  [ "gh"; "pr"; "view"; string_of_int pr_number ]
+  @ repo_args repo_slug
+  @ [ "--json"; json_fields ]
+;;
+
+let pr_diff ~repo_slug ~pr_number =
+  [ "gh"; "pr"; "diff"; string_of_int pr_number ] @ repo_args repo_slug
+;;
+
+let pr_review ~repo_slug ~pr_number ~body_file ~event_flag =
+  [ "gh"; "pr"; "review"; string_of_int pr_number ]
+  @ repo_args repo_slug
+  @ [ "--body-file"; body_file; event_flag ]
+;;
+
+let pr_comment_reply ~owner_repo ~pr_number ~comment_id ~body_file =
+  let endpoint =
+    Printf.sprintf
+      "repos/%s/pulls/%d/comments/%d/replies"
+      owner_repo
+      pr_number
+      comment_id
+  in
+  [ "gh"; "api"; endpoint; "-F"; "body=@" ^ body_file ]
+;;

--- a/test/test_keeper_pr_review.ml
+++ b/test/test_keeper_pr_review.ml
@@ -136,12 +136,53 @@ let ensure_github_identity_bundle ~config github_identity =
     \    oauth_token: ghp_fake_test_token_for_docker_route\n\
     \    user: test-user\n"
 
+let gh_config_dir_for_identity ~config github_identity =
+  let masc_dir = Filename.concat config.Coord.base_path Common.masc_dirname in
+  Filename.concat
+    (Filename.concat
+       (Filename.concat masc_dir "github-identities")
+       github_identity)
+    "gh"
+
+let seed_github_credential_mapping
+      ?(github_identity = Masc_mcp.Keeper_gh_env.root_github_identity)
+      ~config
+      ~keeper_name
+      ()
+  =
+  ensure_github_identity_bundle ~config github_identity;
+  let credential_id = "cred-" ^ keeper_name ^ "-" ^ github_identity in
+  let credential : Repo_manager_types.credential =
+    { id = credential_id
+    ; cred_type = Repo_manager_types.Github
+    ; username = github_identity
+    ; gh_config_dir = Some (gh_config_dir_for_identity ~config github_identity)
+    ; ssh_key_path = None
+    ; gpg_key_id = None
+    ; state = Repo_manager_types.Unmaterialized
+    ; token_sha256_prefix = None
+    }
+  in
+  (match Credential_store.add ~base_path:config.Coord.base_path credential with
+   | Ok _ -> ()
+   | Error msg when contains_substring msg "Credential already exists" -> ()
+   | Error msg -> Alcotest.failf "seed credential mapping: %s" msg);
+  let mapping : Repo_manager_types.keeper_repo_mapping =
+    { keeper_id = keeper_name
+    ; repository_ids = []
+    ; github_credential_id = Some credential_id
+    }
+  in
+  match Keeper_repo_mapping.save_mapping ~base_path:config.Coord.base_path mapping with
+  | Ok () -> ()
+  | Error msg -> Alcotest.failf "seed keeper repo mapping: %s" msg
+
 let with_keeper_identity_toml ~config ~keeper_name ~github_identity f =
   let masc_dir = Filename.concat config.Coord.base_path Common.masc_dirname in
   let config_dir = Filename.concat masc_dir "config" in
   let keepers_dir = Filename.concat config_dir "keepers" in
   ensure_dir keepers_dir;
-  ensure_github_identity_bundle ~config github_identity;
+  seed_github_credential_mapping ~github_identity ~config ~keeper_name ();
   write_file
     (Filename.concat keepers_dir (keeper_name ^ ".toml"))
     (Printf.sprintf
@@ -175,16 +216,20 @@ while [ \"$#\" -gt 0 ]; do\n\
   fi\n\
   shift\n\
 done\n\
-case \"$*\" in\n\
-  *\"gh repo view \"*missing/repo*\"--json nameWithOwner\"*)\n\
+stdin_payload=$(cat)\n\
+if [ -n \"$log_file\" ]; then\n\
+  printf 'stdin:%s\\n' \"$stdin_payload\" >> \"$log_file\"\n\
+fi\n\
+case \"$stdin_payload\" in\n\
+  *missing/repo*nameWithOwner*)\n\
     printf '%s\\n' \"GraphQL: Could not resolve to a Repository with the name 'missing/repo'. (repository)\"\n\
     exit 1\n\
     ;;\n\
-  *\"gh repo view \"*jeong-sik/masc-mcp*\"--json nameWithOwner\"*)\n\
+  *jeong-sik/masc-mcp*nameWithOwner*)\n\
     printf '%s\\n' '{\"nameWithOwner\":\"jeong-sik/masc-mcp\"}'\n\
     exit 0\n\
     ;;\n\
-  *\"--json isDraft,headRefName,labels\"*)\n\
+  *isDraft,headRefName,labels*)\n\
     if [ -n \"$KEEPER_FAKE_PR_VIEW_JSON\" ]; then\n\
       printf '%s\\n' \"$KEEPER_FAKE_PR_VIEW_JSON\"\n\
     else\n\
@@ -193,7 +238,7 @@ case \"$*\" in\n\
     exit 0\n\
     ;;\n\
 esac\n\
-printf 'stdout:%s\\n' \"$*\"\n\
+printf 'stdout:%s\\n' \"$stdin_payload\"\n\
 exit 0\n"
 
 let with_fake_docker f =
@@ -237,8 +282,7 @@ let setup_docker_review f =
     make_meta ~name:"reviewer" ~sandbox:Keeper_types.Docker ()
   in
   ensure_dir (Keeper_sandbox.host_root_abs_of_meta ~config meta);
-  ensure_github_identity_bundle ~config
-    Masc_mcp.Keeper_gh_env.root_github_identity;
+  seed_github_credential_mapping ~config ~keeper_name:meta.name ();
   f ~config ~meta
 
 let setup_local_review f =
@@ -505,9 +549,9 @@ let test_read_routes_docker_and_injects_repo_flag () =
   check bool "read used docker run" true
     (contains_substring log "run --rm");
   check bool "metadata command used gh pr view" true
-    (contains_substring log "gh pr view 13510");
+    (contains_substring log "'gh' 'pr' 'view' '13510'");
   check bool "diff command used gh pr diff" true
-    (contains_substring log "gh pr diff 13510");
+    (contains_substring log "'gh' 'pr' 'diff' '13510'");
   check bool "repo flag injected" true
     (contains_substring log "-R"
      && contains_substring log "jeong-sik/masc-mcp")
@@ -558,7 +602,7 @@ let test_comment_and_approve_route_through_docker () =
      | _ -> false);
   let log = read_file log_path in
   check bool "review comment used gh pr review" true
-    (contains_substring log "gh pr review 13510");
+    (contains_substring log "'gh' 'pr' 'review' '13510'");
   check bool "review comment uses body-file" true
     (contains_substring log "--body-file");
   check bool "review body is not in shell command" false
@@ -568,7 +612,7 @@ let test_comment_and_approve_route_through_docker () =
   check bool "approve event flag passed" true
     (contains_substring log "--approve");
   check bool "approve preflight read PR metadata" true
-    (contains_substring log "--json isDraft,headRefName,labels");
+    (contains_substring log "isDraft,headRefName,labels");
   check bool "repo flag injected for review mutation" true
     (contains_substring log "-R"
      && contains_substring log "jeong-sik/masc-mcp")
@@ -600,7 +644,7 @@ let test_approve_blocks_human_ready_pr_before_review () =
     (parse_nested_string_field raw "preflight" "reason");
   let log = read_file log_path in
   check bool "preflight used gh pr view" true
-    (contains_substring log "gh pr view 13510");
+    (contains_substring log "'gh' 'pr' 'view' '13510'");
   check bool "blocked before gh pr review approve" false
     (contains_substring log "--approve")
 
@@ -645,12 +689,12 @@ let test_comment_rejects_unresolved_explicit_repo_before_review () =
     (parse_string_field raw "output");
   let log = read_file log_path in
   check bool "repo preflight checked explicit target" true
-    (contains_substring log "gh repo view"
+    (contains_substring log "'gh' 'repo' 'view'"
      && contains_substring log "missing/repo");
   check bool "repo preflight blocks approve metadata lookup" false
     (contains_substring log "--json isDraft,headRefName,labels");
   check bool "repo preflight blocks review mutation" false
-    (contains_substring log "gh pr review 13510")
+    (contains_substring log "'gh' 'pr' 'review' '13510'")
 
 let test_reply_routes_through_docker_and_infers_repo () =
   with_fake_docker @@ fun () ->
@@ -684,7 +728,8 @@ let test_reply_routes_through_docker_and_infers_repo () =
     (contains_substring log "run --rm");
   check bool "reply used gh api endpoint with inferred repo" true
     (contains_substring log
-       "gh api repos/jeong-sik/masc-mcp/pulls/13510/comments/3192459689/replies");
+       "'gh' 'api' \
+        'repos/jeong-sik/masc-mcp/pulls/13510/comments/3192459689/replies'");
   check bool "reply body uses gh api file field" true
     (contains_substring log "-F" && contains_substring log "body=@");
   check bool "reply body is not in shell command" false

--- a/test/test_keeper_pr_review.ml
+++ b/test/test_keeper_pr_review.ml
@@ -391,8 +391,71 @@ let test_local_pr_review_host_uses_exec_gate_cwd () =
             process_lines);
        check bool "no cd wrapper in argv tap" false
          (List.exists (fun line -> contains_substring line "cd ") process_lines);
+       check bool "no shell -lc wrapper in argv tap" false
+         (List.exists (fun line -> contains_substring line "\"-lc\"") process_lines);
+       check bool "no shell pipe truncation in argv tap" false
+         (List.exists (fun line -> contains_substring line "head -c") process_lines);
        check bool "repo flag reached gh" true
          (contains_substring (read_file gh_args_log) "-R jeong-sik/masc-mcp"))
+
+let test_local_pr_review_comment_uses_argv_not_shell () =
+  setup_local_review @@ fun ~base ~config ~meta ->
+  let bin_dir = Filename.concat base "bin" in
+  let gh_args_log = Filename.concat base "gh-comment-args.log" in
+  ensure_dir bin_dir;
+  write_file
+    (Filename.concat bin_dir "gh")
+    "#!/bin/sh\n\
+     printf '%s\\n' \"$*\" >> \"$GH_ARGS_LOG\"\n\
+     if [ \"$1\" = \"pr\" ] && [ \"$2\" = \"review\" ]; then\n\
+     \  exit 0\n\
+     fi\n\
+     printf 'unexpected gh: %s\\n' \"$*\" >&2\n\
+     exit 2\n";
+  Unix.chmod (Filename.concat bin_dir "gh") 0o755;
+  let captured = ref [] in
+  Fun.protect
+    ~finally:(fun () -> Exec_tap.disable ())
+    (fun () ->
+       Exec_tap.enable ~writer:(fun line -> captured := line :: !captured);
+       with_env "GH_ARGS_LOG" gh_args_log @@ fun () ->
+       with_env "PATH"
+         (bin_dir ^ ":"
+          ^ Option.value ~default:"/usr/bin:/bin" (Sys.getenv_opt "PATH"))
+       @@ fun () ->
+       let raw =
+         KTPR.handle_keeper_pr_review_comment ~config ~meta
+           ~args:
+             (`Assoc
+               [ ("pr_number", `Int 13510)
+               ; ("body", `String "host comment body with * shell chars")
+               ; ("event", `String "COMMENT")
+               ])
+       in
+       check bool "comment ok" true (parse_field raw "ok" |> Json.to_bool);
+       let process_lines =
+         List.filter
+           (fun line ->
+              contains_substring line
+                "\"kind\":\"Process_eio.run_argv_with_status\"")
+           !captured
+       in
+       check bool "process execution recorded" true (process_lines <> []);
+       check bool "no shell -lc wrapper in mutation tap" false
+         (List.exists
+            (fun line -> contains_substring line "\"-lc\"")
+            process_lines);
+       check bool "comment body not embedded in argv" false
+         (List.exists
+            (fun line -> contains_substring line "host comment body")
+            process_lines);
+       let gh_args = read_file gh_args_log in
+       check bool "review subcommand used" true
+         (contains_substring gh_args "pr review 13510");
+       check bool "body-file used" true
+         (contains_substring gh_args "--body-file");
+       check bool "comment flag used" true
+         (contains_substring gh_args "--comment"))
 
 let test_read_routes_docker_and_injects_repo_flag () =
   with_fake_docker @@ fun () ->
@@ -651,6 +714,8 @@ let () =
     "host_route", [
       test_case "host route uses Exec_gate cwd" `Quick
         test_local_pr_review_host_uses_exec_gate_cwd;
+      test_case "host comment uses argv without shell" `Quick
+        test_local_pr_review_comment_uses_argv_not_shell;
     ];
     "docker_route", [
       test_case "with_env restores cleared variables" `Quick


### PR DESCRIPTION
## Summary
- add a small Keeper_gh_pr_review_cli argv builder for keeper PR review gh operations
- remove host zsh -lc execution from keeper_pr_review and route host calls through Exec_gate argv
- truncate PR diff output in OCaml instead of shelling through head -c
- update PR review tests for host argv execution and the current Docker stdin transport/credential mapping contract

## Validation
- git diff --check origin/main...HEAD
- ocamlformat --check lib/keeper_gh_pr_review_cli.ml lib/keeper/keeper_tool_pr_review.ml test/test_keeper_pr_review.ml
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_pr_review.exe
- ./_build/default/test/test_keeper_pr_review.exe