### PR TITLE
Link fs_compat for keeper meta cleanup test

### DIFF
--- a/test/stanzas/test_keeper_meta_unknown_keys_warn.inc
+++ b/test/stanzas/test_keeper_meta_unknown_keys_warn.inc
@@ -1,4 +1,4 @@
 (test
  (name test_keeper_meta_unknown_keys_warn)
  (modules test_keeper_meta_unknown_keys_warn)
- (libraries masc_mcp alcotest))
+ (libraries masc_mcp fs_compat alcotest))


### PR DESCRIPTION
## Summary

- add `fs_compat` to `test_keeper_meta_unknown_keys_warn`'s dune stanza

## Why

PR #17400 changed `test/test_keeper_meta_unknown_keys_warn.ml` to call `Fs_compat.remove_tree`, but the test stanza still linked only `masc_mcp` and `alcotest`. A plain `dune build` on main fails with:

```text
File "test/test_keeper_meta_unknown_keys_warn.ml", line 67, characters 2-11:
67 |   Fs_compat.remove_tree path
       ^^^^^^^^^
Error: Unbound module Fs_compat
```

## Verification

- `git diff --check HEAD~1 HEAD`

Blocked locally:

- `scripts/dune-local.sh build test/test_keeper_meta_unknown_keys_warn.exe` exited 75 because multiple live bare `dune build` processes were already running across sibling worktrees, so the wrapper refused to start another build.