### PR TITLE
Use argv process helpers for test rg scans

### DIFF
--- a/test/test_env_git_noninteractive.ml
+++ b/test/test_env_git_noninteractive.ml
@@ -224,14 +224,22 @@ let test_no_forgotten_git_askpass_literals () =
     | None -> Sys.getcwd ()
   in
   let lib_dir = Filename.concat root "lib" in
-  let cmd =
-    Printf.sprintf
-      "rg --no-messages -l 'GIT_ASKPASS|GIT_TERMINAL_PROMPT' %s \
-       --glob '!env_git_noninteractive.*' \
-       --glob '*.ml' --glob '*.mli' || true"
-      (Filename.quote lib_dir)
+  let argv =
+    [|
+      "rg";
+      "--no-messages";
+      "-l";
+      "GIT_ASKPASS|GIT_TERMINAL_PROMPT";
+      lib_dir;
+      "--glob";
+      "!env_git_noninteractive.*";
+      "--glob";
+      "*.ml";
+      "--glob";
+      "*.mli";
+    |]
   in
-  let ic = Unix.open_process_in cmd in
+  let ic = Unix.open_process_args_in "rg" argv in
   let rec drain acc =
     try drain (input_line ic :: acc)
     with End_of_file -> List.rev acc

--- a/test/test_masc_dirname_ssot.ml
+++ b/test/test_masc_dirname_ssot.ml
@@ -38,15 +38,19 @@ let drain ic =
   loop []
 
 let rg_matching_files ~pattern ~paths =
-  let paths_quoted =
-    String.concat " " (List.map Filename.quote paths)
+  let argv =
+    Array.of_list
+      ([
+         "rg";
+         "--no-messages";
+         "-l";
+         "-e";
+         pattern;
+       ]
+      @ paths
+      @ [ "--glob"; "*.ml"; "--glob"; "*.mli" ])
   in
-  let cmd =
-    Printf.sprintf
-      "rg --no-messages -l -e %s %s --glob '*.ml' --glob '*.mli' || true"
-      (Filename.quote pattern) paths_quoted
-  in
-  let ic = Unix.open_process_in cmd in
+  let ic = Unix.open_process_args_in "rg" argv in
   let lines = drain ic in
   let _ = Unix.close_process_in ic in
   lines


### PR DESCRIPTION
## Summary
- replace test-only Unix.open_process_in rg command strings with Unix.open_process_args_in argv calls
- remove shell quoting from rg-based ratchet helpers

## Verification
- ocamlformat --check test/test_env_git_noninteractive.ml test/test_masc_dirname_ssot.ml
- git diff --check
- targeted rg scan left only test/test_keeper_bash_safety.ml fixture

## Not run
- scripts/dune-local.sh build test/test_env_git_noninteractive.exe test/test_masc_dirname_ssot.exe: blocked by live bare Dune processes outside scripts/dune-local.sh