### PR TITLE
docs: remove autoresearch retired-name criteria

### DIFF
--- a/docs/spec/02-types-and-invariants.md
+++ b/docs/spec/02-types-and-invariants.md
@@ -396,7 +396,7 @@ type module_tag =
   | Mod_shard
 ```
 
-19개 variant (SSOT: `lib/tool_dispatch.mli`). 도구 이름으로 O(1) tag lookup 후, tag별로 적합한 모듈 컨텍스트를 지연 생성한다. Retired 모듈들(command_plane, team_session, voice, mdal, goals, heartbeat, encryption, auth, hat, audit, rate_limit, cost, social, vote, council, handover, relay, cache, tempo, portal, code_swarm, notifications, research, autoresearch, model_catalog, fire_task)은 tag 목록에서 제거됐다.
+19개 variant (SSOT: `lib/tool_dispatch.mli`). 도구 이름으로 O(1) tag lookup 후, tag별로 적합한 모듈 컨텍스트를 지연 생성한다. 제거된 모듈 이름은 tag 목록이나 운영 문서의 기준 목록으로 보존하지 않는다.
 
 ### 4.4 Tool_result.t (structured)
 

--- a/lib/cdal_runtime/autonomy_exec.mli
+++ b/lib/cdal_runtime/autonomy_exec.mli
@@ -1,6 +1,5 @@
 (** Autonomy_exec — external execution primitive for autonomy loops.
 
-    This module intentionally stays below any AutoResearch-specific policy.
     It provides argv-only process execution with timeout, bounded capture,
     env allowlisting, and optional wrapper prefixes for container/sandbox
     launchers such as Docker or Bubblewrap.


### PR DESCRIPTION
## Summary
- remove the AutoResearch-specific policy criterion from autonomy exec docs
- stop preserving retired module names as a spec-side criteria list
- keep current dispatch invariant focused on active tags only

## Verification
- opam exec -- ocamlformat --check lib/cdal_runtime/autonomy_exec.mli
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- rg active-surface autoresearch/archive_runs/cleanup markers: 0 matches

Dune focused build was blocked locally by existing bare Dune processes via scripts/dune-local.sh exit 75.