### PR TITLE
refactor(keeper_agent_run): extract tool observation

### DIFF
--- a/lib/cascade/cascade_transport_non_http_registry.mli
+++ b/lib/cascade/cascade_transport_non_http_registry.mli
@@ -1,0 +1,22 @@
+(** Non-HTTP cascade transport registry and dispatcher. *)
+
+type non_http_transport_ctor =
+  provider_cfg:Llm_provider.Provider_config.t ->
+  runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy option ->
+  cli_transport_overrides:
+    Cascade_transport_cli_overrides.cli_transport_overrides option ->
+  (Llm_provider.Llm_transport.t, Agent_sdk.Error.sdk_error) result
+
+val register_non_http_transport :
+  kind:Llm_provider.Provider_config.provider_kind ->
+  ctor:non_http_transport_ctor ->
+  unit
+
+val non_http_transport_of_provider :
+  sw:Eio.Switch.t ->
+  provider_cfg:Llm_provider.Provider_config.t ->
+  ?runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy ->
+  ?cli_transport_overrides:
+    Cascade_transport_cli_overrides.cli_transport_overrides ->
+  unit ->
+  (Llm_provider.Llm_transport.t option, Agent_sdk.Error.sdk_error) result

--- a/lib/dune
+++ b/lib/dune
@@ -200,10 +200,9 @@
   keeper_turn_telemetry
   keeper_agent_prompt_metrics
   keeper_agent_tool_surface
-  keeper_agent_run_phase0_telemetry
-  keeper_agent_run_contract_retry
+  keeper_agent_run_phase0_telemetry keeper_agent_run_contract_retry
   keeper_agent_run_contract_helpers keeper_agent_run_thinking_trajectory
-  keeper_agent_run_receipt_append
+  keeper_agent_run_tool_observation keeper_agent_run_receipt_append
   keeper_agent_result
   keeper_agent_error
   keeper_agent_memory_episode

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -712,40 +712,24 @@ let run_turn
                    ~keeper_name:meta.name
                    ~trajectory_acc
                    result.response.content;
-                 let reported_tool_names =
-                   List.filter_map
-                     (function
-                       | Agent_sdk.Types.ToolUse { name; _ } -> Some name
-                       | _ -> None)
-                     result.response.content
-                 in
-                 reported_tool_names_ref := reported_tool_names;
-                 let tool_usage_after =
-                   Keeper_tool_disclosure.keeper_tool_usage_snapshot
+                 let tool_observation =
+                   Keeper_agent_run_tool_observation.analyze
                      ~base_path:config.base_path
                      ~keeper_name:meta.name
+                     ~requested_tool_names_seen:acc.requested_tool_names_seen
+                     ~tool_usage_before
+                     ~tool_calls:acc.tool_calls
+                     result.response.content
                  in
-                 let registry_observed_tool_names =
-                   Keeper_tool_disclosure.tool_usage_delta
-                     ~before:tool_usage_before
-                     ~after:tool_usage_after
+                 let reported_tool_names =
+                   tool_observation.reported_tool_names
                  in
-                 let hook_observed_tool_names =
-                   List.rev_map
-                     (fun (detail : tool_call_detail) -> detail.tool_name)
-                     acc.tool_calls
-                 in
+                 reported_tool_names_ref := reported_tool_names;
                  let observed_tool_names =
-                   Keeper_tool_disclosure.merge_observed_tool_names
-                     ~registry_observed_tool_names
-                     ~hook_observed_tool_names
+                   tool_observation.observed_tool_names
                  in
                  observed_tool_names_ref := observed_tool_names;
-                 let tool_names =
-                   Keeper_tool_disclosure.merge_reported_and_observed_tool_names
-                     ~reported_tool_names
-                     ~observed_tool_names
-                 in
+                 let tool_names = tool_observation.tool_names in
                  (* RFC-0064: canonicalise observed tool names across all three
                     input surfaces (LLM-native public / MCP protocol /
                     already-internal) before the disclosure check. Without
@@ -762,13 +746,11 @@ let run_turn
                     single observed call does not produce multiple
                     counter samples (PR #14585 review #3). *)
                  let canonical_tool_names =
-                   List.map Keeper_tool_disclosure.canonical_tool_name_observed tool_names
+                   tool_observation.canonical_tool_names
                  in
                  canonical_tool_names_ref := canonical_tool_names;
                  let unexpected_tool_names =
-                   Keeper_tool_disclosure.unexpected_tool_names
-                     ~allowed_tool_names:acc.requested_tool_names_seen
-                     ~tool_names:canonical_tool_names
+                   tool_observation.unexpected_tool_names
                  in
                  unexpected_tool_names_ref := unexpected_tool_names;
                  (* Partial tolerance (#8471): when a turn mixes valid tool calls
@@ -780,9 +762,7 @@ let run_turn
           turn produced no valid work. See feedback memory
           feedback_tool-error-messages-teach-llm.md. *)
                  let valid_tool_calls_present =
-                   Keeper_tool_disclosure.has_valid_tool_call
-                     ~unexpected_tool_names
-                     ~tool_names:canonical_tool_names
+                   tool_observation.valid_tool_calls_present
                  in
                  if valid_tool_calls_present then acc.keeper_surface_tool_used <- true;
                  if unexpected_tool_names <> [] && not valid_tool_calls_present

--- a/lib/keeper/keeper_agent_run_tool_observation.ml
+++ b/lib/keeper/keeper_agent_run_tool_observation.ml
@@ -1,0 +1,68 @@
+type observed =
+  { reported_tool_names : string list
+  ; observed_tool_names : string list
+  ; tool_names : string list
+  ; canonical_tool_names : string list
+  ; unexpected_tool_names : string list
+  ; valid_tool_calls_present : bool
+  }
+
+let analyze
+      ~base_path
+      ~keeper_name
+      ~requested_tool_names_seen
+      ~tool_usage_before
+      ~tool_calls
+      content
+  =
+  let reported_tool_names =
+    List.filter_map
+      (function
+        | Agent_sdk.Types.ToolUse { name; _ } -> Some name
+        | _ -> None)
+      content
+  in
+  let tool_usage_after =
+    Keeper_tool_disclosure.keeper_tool_usage_snapshot ~base_path ~keeper_name
+  in
+  let registry_observed_tool_names =
+    Keeper_tool_disclosure.tool_usage_delta
+      ~before:tool_usage_before
+      ~after:tool_usage_after
+  in
+  let hook_observed_tool_names =
+    List.rev_map
+      (fun (detail : Keeper_agent_result.tool_call_detail) -> detail.tool_name)
+      tool_calls
+  in
+  let observed_tool_names =
+    Keeper_tool_disclosure.merge_observed_tool_names
+      ~registry_observed_tool_names
+      ~hook_observed_tool_names
+  in
+  let tool_names =
+    Keeper_tool_disclosure.merge_reported_and_observed_tool_names
+      ~reported_tool_names
+      ~observed_tool_names
+  in
+  let canonical_tool_names =
+    List.map Keeper_tool_disclosure.canonical_tool_name_observed tool_names
+  in
+  let unexpected_tool_names =
+    Keeper_tool_disclosure.unexpected_tool_names
+      ~allowed_tool_names:requested_tool_names_seen
+      ~tool_names:canonical_tool_names
+  in
+  let valid_tool_calls_present =
+    Keeper_tool_disclosure.has_valid_tool_call
+      ~unexpected_tool_names
+      ~tool_names:canonical_tool_names
+  in
+  { reported_tool_names
+  ; observed_tool_names
+  ; tool_names
+  ; canonical_tool_names
+  ; unexpected_tool_names
+  ; valid_tool_calls_present
+  }
+;;

--- a/lib/keeper/keeper_agent_run_tool_observation.mli
+++ b/lib/keeper/keeper_agent_run_tool_observation.mli
@@ -1,0 +1,17 @@
+type observed =
+  { reported_tool_names : string list
+  ; observed_tool_names : string list
+  ; tool_names : string list
+  ; canonical_tool_names : string list
+  ; unexpected_tool_names : string list
+  ; valid_tool_calls_present : bool
+  }
+
+val analyze
+  :  base_path:string
+  -> keeper_name:string
+  -> requested_tool_names_seen:string list
+  -> tool_usage_before:(string * int) list
+  -> tool_calls:Keeper_agent_result.tool_call_detail list
+  -> Agent_sdk.Types.content list
+  -> observed


### PR DESCRIPTION
## Summary

- Extract post-turn reported/observed/canonical/unexpected tool-name analysis from `Keeper_agent_run.run_turn` into `Keeper_agent_run_tool_observation`.
- Keep the parent runner responsible for ref updates and contract decisions.
- Add the current-main missing `cascade_transport_non_http_registry.mli` sibling so the structure ratchet remains green.

## Product impact

Behavior-preserving keeper godfile decomposition. The turn runner now delegates tool observation set construction while preserving the existing contract gate inputs and partial-tolerance behavior.

## Evidence

- `ocamlformat --check lib/keeper/keeper_agent_run.ml lib/keeper/keeper_agent_run_tool_observation.ml lib/keeper/keeper_agent_run_tool_observation.mli lib/cascade/cascade_transport_non_http_registry.mli`
- `scripts/ocaml-structure-ratchet.sh`
- `git diff --check origin/main...HEAD`
- `scripts/check-pr-hygiene.sh --base origin/main --head HEAD`
- `wc -l lib/keeper/keeper_agent_run.ml lib/keeper/keeper_agent_run_tool_observation.ml lib/keeper/keeper_agent_run_tool_observation.mli`

Local focused Dune verification was attempted with `scripts/dune-local.sh build lib/masc_mcp_lib.a`, but the wrapper refused with exit 75 because existing bare Dune processes were already running on the host. I did not bypass the guard.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 4/5
provenance: direct
checks:
  - ocamlformat
  - structure_ratchet
  - diff_check
  - pr_hygiene
blocked:
  - focused_dune_local_existing_bare_dune_processes
```

## Review evidence

- `lib/keeper/keeper_agent_run.ml` drops from 2050 to 2030 LOC on this branch.
- The new helper computes only the observation sets; it does not mutate runner refs.
- Existing contract decision branches remain in `Keeper_agent_run.run_turn`.

## Linked issue

RFC-0147 keeper godfile decomposition follow-up slice.
