### PR TITLE
refactor(keeper_heartbeat_loop): extract persist_message_cursor_updates sibling

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -132,45 +132,7 @@ let oas_timeout_budget_metric_outcome =
   Observations.oas_timeout_budget_metric_outcome
 ;;
 
-let persist_message_cursor_updates ~config (meta : keeper_meta) updates =
-  let updated = Keeper_world_observation.apply_message_cursor_updates meta updates in
-  if updates = []
-  then updated
-  else (
-    let merge ~latest ~caller:_ =
-      Keeper_world_observation.apply_message_cursor_updates latest updates
-    in
-    match write_meta_with_merge ~merge config updated with
-    | Ok () ->
-      (match read_meta config updated.name with
-       | Ok (Some latest) -> latest
-       | Ok None ->
-         Prometheus.inc_counter
-           Keeper_metrics.metric_keeper_meta_read_failures
-           ~labels:[ "keeper", updated.name; "site", "cursor_update_none_after_write" ]
-           ();
-         Log.Keeper.warn
-           "read_meta returned None after message cursor update write for %s"
-           updated.name;
-         { updated with meta_version = updated.meta_version + 1 }
-       | Error e ->
-         Prometheus.inc_counter
-           Keeper_metrics.metric_keeper_meta_read_failures
-           ~labels:[ "keeper", updated.name; "site", "cursor_update_read_after_write" ]
-           ();
-         Log.Keeper.warn
-           "read_meta failed after message cursor update write for %s: %s"
-           updated.name
-           e;
-         { updated with meta_version = updated.meta_version + 1 })
-    | Error e ->
-      Prometheus.inc_counter
-        Keeper_metrics.metric_keeper_write_meta_failures
-        ~labels:[ "keeper", updated.name; "phase", "cursor_update" ]
-        ();
-      Log.Keeper.warn "write_meta failed (message cursor update): %s" e;
-      updated)
-;;
+let persist_message_cursor_updates = Keeper_heartbeat_loop_persist_cursor.persist_message_cursor_updates
 
 (** Run keeper cycle with semaphore slot control. *)
 let run_keeper_cycle_with_slot

--- a/lib/keeper/keeper_heartbeat_loop_persist_cursor.ml
+++ b/lib/keeper/keeper_heartbeat_loop_persist_cursor.ml
@@ -1,0 +1,68 @@
+(** Message cursor persistence for keeper heartbeat, extracted from
+    [keeper_heartbeat_loop.ml] (godfile decomp).
+
+    [persist_message_cursor_updates ~config meta updates] folds the
+    requested message_cursor updates into the keeper meta and writes
+    them back via [write_meta_with_merge]. The merge callback re-
+    applies the same updates against the *latest* on-disk meta to
+    avoid stealing concurrent heartbeat writes (cf. #9733).
+
+    On successful write, re-reads the meta to return the final
+    canonical version (which may have additional concurrent merges).
+    Read failures after a successful write degrade gracefully:
+
+    - [Ok None] (race: meta deleted between write and read) →
+      [metric_keeper_meta_read_failures] (site=[cursor_update_none_after_write])
+      + WARN log + return [{ updated with meta_version = v + 1 }]
+    - [Error e] → same metric (site=[cursor_update_read_after_write])
+      + WARN log + same fallback
+
+    Write failures (CAS race or disk error) tick
+    [metric_keeper_write_meta_failures] (phase=[cursor_update]) +
+    WARN log + return the in-memory [updated] meta without bumping
+    [meta_version].
+
+    Pure helper move (no callback injection). All references reach
+    external modules — no parent-local dependencies. *)
+
+open Keeper_types
+
+let persist_message_cursor_updates ~config (meta : keeper_meta) updates =
+  let updated = Keeper_world_observation.apply_message_cursor_updates meta updates in
+  if updates = []
+  then updated
+  else (
+    let merge ~latest ~caller:_ =
+      Keeper_world_observation.apply_message_cursor_updates latest updates
+    in
+    match write_meta_with_merge ~merge config updated with
+    | Ok () ->
+      (match read_meta config updated.name with
+       | Ok (Some latest) -> latest
+       | Ok None ->
+         Prometheus.inc_counter
+           Keeper_metrics.metric_keeper_meta_read_failures
+           ~labels:[ "keeper", updated.name; "site", "cursor_update_none_after_write" ]
+           ();
+         Log.Keeper.warn
+           "read_meta returned None after message cursor update write for %s"
+           updated.name;
+         { updated with meta_version = updated.meta_version + 1 }
+       | Error e ->
+         Prometheus.inc_counter
+           Keeper_metrics.metric_keeper_meta_read_failures
+           ~labels:[ "keeper", updated.name; "site", "cursor_update_read_after_write" ]
+           ();
+         Log.Keeper.warn
+           "read_meta failed after message cursor update write for %s: %s"
+           updated.name
+           e;
+         { updated with meta_version = updated.meta_version + 1 })
+    | Error e ->
+      Prometheus.inc_counter
+        Keeper_metrics.metric_keeper_write_meta_failures
+        ~labels:[ "keeper", updated.name; "phase", "cursor_update" ]
+        ();
+      Log.Keeper.warn "write_meta failed (message cursor update): %s" e;
+      updated)
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane B
- 6th sibling extracted from `keeper_heartbeat_loop.ml` (after #17296 `keepalive_scheduling`, #17320 `presence`, #17344 `board_events`, #17373 `dispatch_recurring`, #17387 `snapshot_timing`).

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/keeper/keeper_heartbeat_loop.ml` | 1134 | 1096 | **-38** |
| `lib/keeper/keeper_heartbeat_loop_persist_cursor.ml` | — | 68 | +68 |

## Moved (verbatim, no behavior change)
- `persist_message_cursor_updates ~config (meta : keeper_meta) updates`:
  - In-memory fold: `Keeper_world_observation.apply_message_cursor_updates meta updates`
  - Empty-updates fast path: returns the folded meta without disk I/O
  - Non-empty path: builds `merge ~latest ~caller:_` closure that re-applies the same updates against the latest on-disk meta (the #9733 concurrent-heartbeat-write avoidance pattern)
  - `write_meta_with_merge ~merge config updated`:
    - **Ok ()** → `read_meta config updated.name`:
      - `Ok (Some latest)` → return `latest` (canonical version with any concurrent merges)
      - `Ok None` (delete race) → `inc_counter metric_keeper_meta_read_failures ~labels:[keeper, name; site, cursor_update_none_after_write]` + WARN + return `{ updated with meta_version = updated.meta_version + 1 }`
      - `Error e` → same metric with `site=cursor_update_read_after_write` + WARN + same fallback
    - **Error e** → `inc_counter metric_keeper_write_meta_failures ~labels:[keeper, name; phase, cursor_update]` + WARN + return `updated` (no version bump)

Parent retains a 1-line alias preserving the `.mli` surface.

## External callers (all keep working unchanged via parent alias)
- `test/test_keeper_meta_heartbeat_retain_9733.ml:196,234` — the #9733 regression test (concurrent heartbeat + cursor update merge race) directly references `Keeper_heartbeat_loop.persist_message_cursor_updates`. The parent alias preserves this test path.

## Sibling deps (all external)
- `open Keeper_types` — `keeper_meta`, `write_meta_with_merge`, `read_meta`
- `Keeper_world_observation.apply_message_cursor_updates`
- `Prometheus.inc_counter`
- `Keeper_metrics.{metric_keeper_meta_read_failures, metric_keeper_write_meta_failures}`
- `Log.Keeper.warn`

No parent-local helpers; no sibling -> parent cycle.

## #9733 invariant preserved
The merge callback (closure capturing `updates`) re-applies the same cursor delta against whatever the *latest* on-disk meta is when CAS commits. This is the verbatim policy that addressed the heartbeat/cursor race where two fibers writing simultaneously could silently drop one set of updates. The fallback paths after a failed read (`Ok None` or `Error`) bump `meta_version` by 1 to signal that an in-memory mutation occurred but the canonical disk version couldn't be confirmed.

## Local build status
- `dune build --root . lib/keeper/` → clean (exit 0)
- godfile lint: sibling 68 LOC under `new_file_cap=600`; parent 1096 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim single-function move, 1-line parent alias.

Co-Authored-By: codex <noreply@anthropic.com>
