### PR TITLE
Fix thinking trajectory content type

### DIFF
--- a/lib/keeper/keeper_agent_run_thinking_trajectory.mli
+++ b/lib/keeper/keeper_agent_run_thinking_trajectory.mli
@@ -1,5 +1,5 @@
 val persist_response_content
   :  keeper_name:string
   -> trajectory_acc:Trajectory.accumulator option
-  -> Agent_sdk.Types.content list
+  -> Agent_sdk.Types.content_block list
   -> unit


### PR DESCRIPTION
## Summary
- use Agent_sdk.Types.content_block list for thinking trajectory response content persistence

## Verification
- git diff --check
- scripts/dune-local.sh build lib/masc_mcp.cma *(blocked locally: existing machine-wide Dune lock/bare Dune processes; no code error reached)*