### PR TITLE
refactor(operator_control_snapshot): extract action_log subsystem sibling

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -9,44 +9,12 @@ include Operator_control_context_snapshot
 let non_empty_trimmed_string_opt = Operator_control_snapshot_identity_fields.non_empty_trimmed_string_opt
 let keeper_runtime_identity_fields = Operator_control_snapshot_identity_fields.keeper_runtime_identity_fields
 let degraded_keeper_runtime_identity_fields = Operator_control_snapshot_identity_fields.degraded_keeper_runtime_identity_fields
-type action_result_status =
-  | ActionOk
-  | ActionError
-
-let action_result_status_to_string = function
-  | ActionOk -> "ok"
-  | ActionError -> "error"
-;;
-
-type confirmation_state =
-  | Preview
-  | Immediate
-  | Expired
-  | Denied
-  | Confirmed
-
-let confirmation_state_to_string = function
-  | Preview -> "preview"
-  | Immediate -> "immediate"
-  | Expired -> "expired"
-  | Denied -> "denied"
-  | Confirmed -> "confirmed"
-;;
-
-type action_log_entry =
-  { trace_id : string
-  ; actor : string
-  ; remote_session_id : string option
-  ; remote_client_type : string
-  ; action_type : string
-  ; target_type : string
-  ; target_id : string option
-  ; delegated_tool : string
-  ; confirmation_state : confirmation_state
-  ; result_status : action_result_status
-  ; latency_ms : int
-  ; created_at : string
-  }
+(* action_result_status + confirmation_state + action_log_entry types,
+   stringifiers, and persistence helpers extracted to
+   [Operator_control_snapshot_action_log] (godfile decomp). The
+   include flows through to [Operator_control] via
+   [Operator_control_action] in the existing include chain. *)
+include Operator_control_snapshot_action_log
 
 let json_ok = Tool_args.ok_assoc
 
@@ -64,7 +32,6 @@ let merge_json_objects left right =
   | _, _ -> `Assoc []
 ;;
 
-let action_log_path config = Filename.concat (operator_dir config) "action_log.jsonl"
 let iso_of_unix = Dashboard_utils.iso_of_unix
 (* remote_confirm_ttl_seconds + runtime-status alignment helpers
    extracted to [Operator_control_snapshot_runtime_status] (godfile decomp). *)
@@ -76,45 +43,6 @@ let remote_client_type_of_context = Operator_control_snapshot_runtime_status.rem
 let max_turns_override_source = Operator_control_snapshot_runtime_status.max_turns_override_source
 let operator_server_profile_json = Operator_control_snapshot_runtime_status.operator_server_profile_json
 
-let action_log_entry_to_yojson (entry : action_log_entry) =
-  `Assoc
-    [ "trace_id", `String entry.trace_id
-    ; "actor", `String entry.actor
-    ; "remote_session_id", string_option_to_json entry.remote_session_id
-    ; "remote_client_type", `String entry.remote_client_type
-    ; "action_type", `String entry.action_type
-    ; "target_type", `String entry.target_type
-    ; "target_id", string_option_to_json entry.target_id
-    ; "delegated_tool", `String entry.delegated_tool
-    ; ( "confirmation_state"
-      , `String (confirmation_state_to_string entry.confirmation_state) )
-    ; "result_status", `String (action_result_status_to_string entry.result_status)
-    ; "latency_ms", `Int entry.latency_ms
-    ; "created_at", `String entry.created_at
-    ]
-;;
-
-let append_action_log config (entry : action_log_entry) =
-  Coord_utils.mkdir_p (operator_dir config);
-  Fs_compat.append_jsonl (action_log_path config) (action_log_entry_to_yojson entry)
-;;
-
-let recent_actions_json config =
-  let path = action_log_path config in
-  if not (Sys.file_exists path)
-  then `List []
-  else (
-    (* Bounded ring — keep the trailing 20 entries via [Queue.t] so the
-       action log JSONL does not need to materialise as a full list. *)
-    let buf : Yojson.Safe.t Queue.t = Queue.create () in
-    Fs_compat.fold_jsonl_lines
-      ~init:()
-      ~f:(fun () ~line_no:_ json ->
-        Queue.add json buf;
-        if Queue.length buf > 20 then ignore (Queue.pop buf))
-      path;
-    `List (List.of_seq (Queue.to_seq buf)))
-;;
 
 let recent_messages_json config =
   Coord.get_messages_raw config ~since_seq:0 ~limit:20

--- a/lib/operator/operator_control_snapshot_action_log.ml
+++ b/lib/operator/operator_control_snapshot_action_log.ml
@@ -1,0 +1,104 @@
+(** Operator action-log subsystem, extracted from
+    [operator_control_snapshot.ml] (godfile decomp).
+
+    Three types + four helpers + one path constant form the audit
+    trail for every operator-initiated action against MASC. The
+    cluster is `include`d into [Operator_control_snapshot] (which is
+    in turn `include`d up the chain into [Operator_control]) so all
+    type identities and value bindings flow through unchanged.
+
+    Wire schema: every operator action (keeper spawn, restart, pause,
+    cascade switch, etc.) is appended as one JSONL line to
+    `<operator_dir>/action_log.jsonl`. The schema covers identity
+    (trace_id, actor, remote session/client), target (type/id), the
+    delegated tool, confirmation state (preview/immediate/expired/
+    denied/confirmed), result (ok/error), latency, and timestamp.
+
+    [recent_actions_json] returns the trailing 20 entries via a
+    bounded ring buffer ([Queue.t]) so the JSONL never materializes
+    as a full in-memory list — the operator dashboard polls this
+    surface frequently and a multi-MB log shouldn't penalize each
+    poll. *)
+
+type action_result_status =
+  | ActionOk
+  | ActionError
+
+let action_result_status_to_string = function
+  | ActionOk -> "ok"
+  | ActionError -> "error"
+;;
+
+type confirmation_state =
+  | Preview
+  | Immediate
+  | Expired
+  | Denied
+  | Confirmed
+
+let confirmation_state_to_string = function
+  | Preview -> "preview"
+  | Immediate -> "immediate"
+  | Expired -> "expired"
+  | Denied -> "denied"
+  | Confirmed -> "confirmed"
+;;
+
+type action_log_entry =
+  { trace_id : string
+  ; actor : string
+  ; remote_session_id : string option
+  ; remote_client_type : string
+  ; action_type : string
+  ; target_type : string
+  ; target_id : string option
+  ; delegated_tool : string
+  ; confirmation_state : confirmation_state
+  ; result_status : action_result_status
+  ; latency_ms : int
+  ; created_at : string
+  }
+
+let action_log_path config =
+  Filename.concat (Operator_pending_confirm.operator_dir config) "action_log.jsonl"
+;;
+
+let action_log_entry_to_yojson (entry : action_log_entry) =
+  `Assoc
+    [ "trace_id", `String entry.trace_id
+    ; "actor", `String entry.actor
+    ; "remote_session_id", Operator_pending_confirm.string_option_to_json entry.remote_session_id
+    ; "remote_client_type", `String entry.remote_client_type
+    ; "action_type", `String entry.action_type
+    ; "target_type", `String entry.target_type
+    ; "target_id", Operator_pending_confirm.string_option_to_json entry.target_id
+    ; "delegated_tool", `String entry.delegated_tool
+    ; ( "confirmation_state"
+      , `String (confirmation_state_to_string entry.confirmation_state) )
+    ; "result_status", `String (action_result_status_to_string entry.result_status)
+    ; "latency_ms", `Int entry.latency_ms
+    ; "created_at", `String entry.created_at
+    ]
+;;
+
+let append_action_log config (entry : action_log_entry) =
+  Coord_utils.mkdir_p (Operator_pending_confirm.operator_dir config);
+  Fs_compat.append_jsonl (action_log_path config) (action_log_entry_to_yojson entry)
+;;
+
+let recent_actions_json config =
+  let path = action_log_path config in
+  if not (Sys.file_exists path)
+  then `List []
+  else (
+    (* Bounded ring — keep the trailing 20 entries via [Queue.t] so the
+       action log JSONL does not need to materialise as a full list. *)
+    let buf : Yojson.Safe.t Queue.t = Queue.create () in
+    Fs_compat.fold_jsonl_lines
+      ~init:()
+      ~f:(fun () ~line_no:_ json ->
+        Queue.add json buf;
+        if Queue.length buf > 20 then ignore (Queue.pop buf))
+      path;
+    `List (List.of_seq (Queue.to_seq buf)))
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane F
- 5th sibling extracted from `operator_control_snapshot.ml` (after #17329 `identity_fields`, #17368 `snapshot_view`, #17386 `persistent_agents_json`, #17392 `room_json`).
- **Subsystem-level bundle extraction** — 3 types + 4 stringifiers/serializers + 3 I/O helpers + 1 path constant shipped together because the cluster forms a single audit-trail concern.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/operator/operator_control_snapshot.ml` | 1122 | 1050 | **-72** |
| `lib/operator/operator_control_snapshot_action_log.ml` | — | 104 | +104 |

## Moved (verbatim, no behavior change)

### Types (3)
- `type action_result_status = ActionOk | ActionError`
- `type confirmation_state = Preview | Immediate | Expired | Denied | Confirmed`
- `type action_log_entry = { trace_id; actor; remote_session_id; remote_client_type; action_type; target_type; target_id; delegated_tool; confirmation_state; result_status; latency_ms; created_at }`

### Stringifiers / Serializers (3)
- `action_result_status_to_string` — exhaustive 2-arm pattern match
- `confirmation_state_to_string` — exhaustive 5-arm pattern match
- `action_log_entry_to_yojson` — 12-field JSON record builder

### I/O helpers (4)
- `action_log_path config` — `Filename.concat (Operator_pending_confirm.operator_dir config) "action_log.jsonl"`
- `append_action_log config entry` — `Coord_utils.mkdir_p` + `Fs_compat.append_jsonl`
- `recent_actions_json config` — bounded-ring read (20-entry `Queue.t`), returns `\`List []` if path doesn't exist

The bounded ring matters: the operator dashboard polls this surface frequently, and a multi-MB action log shouldn't materialize as a full list each poll. The `Queue.t` pattern keeps only the trailing 20 entries.

## Propagation via `include` chain
The parent uses `include Operator_control_snapshot_action_log` so all 3 types + 7 values flow through the existing include chain unchanged:

```
Operator_control_snapshot_action_log
  -> [include] Operator_control_snapshot
  -> [include] Operator_control_action
  -> [include] Operator_control
```

External callers (5+ sites in `operator_control.ml`) reference `Operator_control.{ActionOk, ActionError, append_action_log, action_log_entry, ...}` — all keep working unchanged because the include chain propagates the sibling's type identities and value bindings up the module hierarchy.

## External callers (all keep working unchanged via include chain)
- `lib/operator/operator_control.ml:649,660,677,688,721,732,742` — `append_action_log ctx.config`, `result_status = ActionOk`, `result_status = ActionError`, plus record literals constructing `action_log_entry` values
- `Operator_control.recent_actions_json` re-export at `operator_control.mli:16` preserved
- `.mli` surface at `operator_control_snapshot.mli:164/176/191/192/246` continues to expose types + helpers via the include chain

## Sibling deps
- `Operator_pending_confirm.{operator_dir, string_option_to_json}` — qualified (2 names, qualified-vs-include policy from #17392)
- `Coord_utils.mkdir_p`
- `Fs_compat.{append_jsonl, fold_jsonl_lines}`
- `Coord.config` (via labeled-arg type inference)
- Std: `Filename.concat`, `Sys.file_exists`, `Queue.{create, add, length, pop, to_seq}`, `List.of_seq`, `Yojson.Safe.t`

No parent-local helpers; no sibling -> parent cycle.

## 3 non-contiguous regions consolidated
The action-log subsystem was scattered across 3 regions in the parent file:
- lines 12-49 (38 LOC) — types + stringifiers
- line 67 (1 LOC) — `action_log_path` constant
- lines 79-117 (39 LOC) — `action_log_entry_to_yojson`, `append_action_log`, `recent_actions_json`

All 78 LOC consolidated into one sibling, with the parent retaining just a 6-line documentation comment + 1-line `include` directive.

## Local build status
- `dune build --root . lib/operator/` → clean (exit 0)
- godfile lint: sibling 104 LOC under `new_file_cap=600`; parent 1050 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim 3-type + 7-value cluster move via `include`-based propagation.

Co-Authored-By: codex <noreply@anthropic.com>
