### PR TITLE
fix(process): use rightmost nonzero pipeline status

### DIFF
--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -555,15 +555,13 @@ let unix_status_of_eio_status = function
   | `Signaled n -> Unix.WSIGNALED n
 
 let pipeline_status statuses =
-  match statuses with
-  | [] -> Unix.WEXITED 0
-  | last :: rest ->
-      List.fold_left
-        (fun acc status ->
-          match acc, status with
-          | Unix.WEXITED 0, _ -> status
-          | (Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _), _ -> acc)
-        last rest
+  List.fold_left
+    (fun acc status ->
+      match status with
+      | Unix.WEXITED 0 -> acc
+      | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> status)
+    (Unix.WEXITED 0)
+    statuses
 
 let run_argv ?(timeout_sec = default_timeout_sec) ?env (argv : string list) : string =
   Exec_tap.record ~kind:Exec_tap.Process_eio_run_argv ~argv ?env ();
@@ -793,33 +791,25 @@ let run_argv_pipeline_with_status_split ?(timeout_sec = default_timeout_sec)
           run_unix_argv_with_stdin_and_status_split_fallback ~timeout_sec ?env
             ?cwd ~stdin_content:prev_stdout argv
       | { argv; env; cwd } :: rest ->
-          let status, stdout, _stderr =
+          let status, stdout, stderr =
             run_unix_argv_with_stdin_and_status_split_fallback ~timeout_sec
               ?env ?cwd ~stdin_content:prev_stdout argv
           in
           let result_status, result_stdout, result_stderr = chain stdout rest in
-          let final_status =
-            match status with
-            | Unix.WEXITED 0 -> result_status
-            | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> status
-          in
-          (final_status, result_stdout, result_stderr)
+          let final_status = pipeline_status [ status; result_status ] in
+          (final_status, result_stdout, stderr ^ result_stderr)
     in
     match stages with
     | [] -> (Unix.WEXITED 0, "", "")
     | [ { argv; env; cwd } ] ->
         run_unix_argv_with_status_split_fallback ~timeout_sec ?env ?cwd argv
     | { argv; env; cwd } :: rest ->
-        let status, stdout, _stderr =
+        let status, stdout, stderr =
           run_unix_argv_with_status_split_fallback ~timeout_sec ?env ?cwd argv
         in
         let result_status, result_stdout, result_stderr = chain stdout rest in
-        let final_status =
-          match status with
-          | Unix.WEXITED 0 -> result_status
-          | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> status
-        in
-        (final_status, result_stdout, result_stderr)
+        let final_status = pipeline_status [ status; result_status ] in
+        (final_status, result_stdout, stderr ^ result_stderr)
   in
   with_spawn_guard (fun () ->
       if not (is_initialized ()) then fallback_buffered ()

--- a/test/test_exec_dispatch.ml
+++ b/test/test_exec_dispatch.ml
@@ -160,6 +160,33 @@ let () =
 let () =
   with_eio @@ fun () ->
   let open Masc_exec.Shell_ir in
+  let sh_bin = Masc_exec.Bin.of_string "sh" |> Result.get_ok in
+  let host_sandbox = Masc_exec.Sandbox_target.host () in
+  let stage script =
+    Simple
+      {
+        bin = sh_bin;
+        args = [ Lit "-c"; Lit script ];
+        env = [];
+        cwd = None;
+        redirects = [];
+        sandbox = host_sandbox;
+      }
+  in
+  let result =
+    Masc_exec.Exec_dispatch.dispatch
+      (Pipeline
+         [
+           stage "echo left >&2; exit 7";
+           stage "echo right >&2; exit 3";
+         ])
+  in
+  assert (result.status = Unix.WEXITED 3);
+  assert (result.stderr = "left\nright\n")
+
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
   let a_bin = Masc_exec.Bin.of_string "a" |> Result.get_ok in
   let b_bin = Masc_exec.Bin.of_string "b" |> Result.get_ok in
   let c_bin = Masc_exec.Bin.of_string "c" |> Result.get_ok in


### PR DESCRIPTION
## Summary
- make Process_eio pipeline status selection match Shell IR fallback semantics: rightmost nonzero wins
- preserve stderr from intermediate stages in the Unix fallback pipeline path
- add host Shell IR regression coverage for two failing stages and stage-ordered stderr

## Verification
- ocamlformat --check lib/process/process_eio.ml test/test_exec_dispatch.ml
- env DUNE_CACHE=disabled DUNE_LOCAL_JOBS=1 MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_exec_dispatch.exe
- _build/default/test/test_exec_dispatch.exe
- git diff --check