### PR TITLE
feat(exec): stream docker shell ir pipelines

### DIFF
--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -202,6 +202,22 @@ let host_pipeline_specs stages =
   in
   loop [] stages
 
+let docker_pipeline_specs stages =
+  let rec loop pipeline_runner acc = function
+    | [] -> Option.map (fun runner -> runner, List.rev acc) pipeline_runner
+    | Shell_ir.Simple simple :: rest ->
+        (match simple.sandbox with
+         | Docker { pipeline_runner = Some runner; _ } when simple.redirects = [] ->
+             let argv, env, cwd = process_spec_of_simple simple in
+             let stage : Sandbox_target.pipeline_stage = { argv; env; cwd } in
+             let pipeline_runner = Option.value pipeline_runner ~default:runner in
+             loop (Some pipeline_runner) (stage :: acc) rest
+         | _ -> None)
+        [@warning "-4"]
+    | Shell_ir.Pipeline _ :: _ -> None
+  in
+  loop None [] stages
+
 let rec dispatch_pipeline ?timeout_sec stages =
   match stages with
   | [] ->
@@ -225,37 +241,52 @@ let rec dispatch_pipeline ?timeout_sec stages =
                specs
            in
            { status; stdout; stderr }
-       | None ->
-         let rec chain ~prev_stdout ~status ~stderr = function
-           | [] -> { status; stdout = prev_stdout; stderr }
-           | Shell_ir.Simple s :: rest ->
-               let stage_result =
-                 dispatch_simple ?timeout_sec ~stdin_content:prev_stdout s
+       | None -> (
+           match docker_pipeline_specs stages with
+           | Some (runner, specs) ->
+               let status, stdout, stderr =
+                 runner ~stages:specs ~timeout_sec:(dispatch_timeout_sec timeout_sec)
                in
-               let status = pipeline_status status stage_result.status in
-               let stderr = stderr ^ stage_result.stderr in
-               chain ~prev_stdout:stage_result.stdout ~status ~stderr rest
-           | Pipeline _ :: _ ->
-               { status = Unix.WEXITED 1
-               ; stdout = ""
-               ; stderr = stderr ^ "nested pipeline not supported in native dispatch"
-               }
-         in
-         match stages with
-         | [] | [ _ ] ->
-             invalid_pipeline "invalid pipeline arity in native dispatch"
-         | first :: rest -> (
-           match first with
-           | Shell_ir.Simple s ->
-               let first_result = dispatch_simple ?timeout_sec s in
-               let status = pipeline_status (Unix.WEXITED 0) first_result.status in
-               chain
-                 ~prev_stdout:first_result.stdout
-                 ~status
-                 ~stderr:first_result.stderr
-                 rest
-           | Pipeline _ ->
-               invalid_pipeline "nested pipeline not supported in native dispatch" ))
+               { status; stdout; stderr }
+           | None ->
+               let rec chain ~prev_stdout ~status ~stderr = function
+                 | [] -> { status; stdout = prev_stdout; stderr }
+                 | Shell_ir.Simple s :: rest ->
+                     let stage_result =
+                       dispatch_simple ?timeout_sec ~stdin_content:prev_stdout s
+                     in
+                     let status = pipeline_status status stage_result.status in
+                     let stderr = stderr ^ stage_result.stderr in
+                     chain
+                       ~prev_stdout:stage_result.stdout
+                       ~status
+                       ~stderr
+                       rest
+                 | Pipeline _ :: _ ->
+                     { status = Unix.WEXITED 1
+                     ; stdout = ""
+                     ; stderr =
+                         stderr ^ "nested pipeline not supported in native dispatch"
+                     }
+               in
+               (match stages with
+                | [] | [ _ ] ->
+                    invalid_pipeline "invalid pipeline arity in native dispatch"
+                | first :: rest -> (
+                  match first with
+                  | Shell_ir.Simple s ->
+                      let first_result = dispatch_simple ?timeout_sec s in
+                      let status =
+                        pipeline_status (Unix.WEXITED 0) first_result.status
+                      in
+                      chain
+                        ~prev_stdout:first_result.stdout
+                        ~status
+                        ~stderr:first_result.stderr
+                        rest
+                  | Pipeline _ ->
+                      invalid_pipeline
+                        "nested pipeline not supported in native dispatch" ))))
 
 and dispatch ?timeout_sec (ir : Shell_ir.t) =
   match ir with

--- a/lib/exec/sandbox_target.ml
+++ b/lib/exec/sandbox_target.ml
@@ -38,13 +38,24 @@ type runner =
   timeout_sec:float ->
   Unix.process_status * string * string
 
+type pipeline_stage = {
+  argv : string list;
+  env : string array;
+  cwd : string option;
+}
+
+type pipeline_runner =
+  stages:pipeline_stage list ->
+  timeout_sec:float ->
+  Unix.process_status * string * string
+
 type t =
   | Host
-  | Docker of { image : string; runner : runner }
+  | Docker of { image : string; runner : runner; pipeline_runner : pipeline_runner option }
 
 let host () : t = Host
 
-let docker ~image ~runner : t = Docker { image; runner }
+let docker ~image ~runner ?pipeline_runner () : t = Docker { image; runner; pipeline_runner }
 
 let pp fmt = function
   | Host -> Format.pp_print_string fmt "host"

--- a/lib/exec/sandbox_target.mli
+++ b/lib/exec/sandbox_target.mli
@@ -22,9 +22,20 @@ type runner =
   timeout_sec:float ->
   Unix.process_status * string * string
 
+type pipeline_stage = {
+  argv : string list;
+  env : string array;
+  cwd : string option;
+}
+
+type pipeline_runner =
+  stages:pipeline_stage list ->
+  timeout_sec:float ->
+  Unix.process_status * string * string
+
 type t =
   | Host
-  | Docker of { image : string; runner : runner }
+  | Docker of { image : string; runner : runner; pipeline_runner : pipeline_runner option }
 
 (** Default host target.  The dispatch path routes this directly to
     [Exec_gate]; no runner is carried. *)
@@ -33,6 +44,6 @@ val host : unit -> t
 (** Build a Docker target.  The caller (typically [lib/keeper]) supplies
     the runner closure; this keeps [lib/exec] from having to know about
     [Keeper_turn_sandbox_runtime] or any other keeper-side construct. *)
-val docker : image:string -> runner:runner -> t
+val docker : image:string -> runner:runner -> ?pipeline_runner:pipeline_runner -> unit -> t
 
 val pp : Format.formatter -> t -> unit

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -60,7 +60,26 @@ let typed_docker_sandbox_target ~turn_sandbox_factory ~meta ~cwd =
       | Ok (status, output) -> status, output, ""
       | Error err -> Unix.WEXITED 1, "", err
     in
-    Ok (Masc_exec.Sandbox_target.docker ~image ~runner)
+    let pipeline_runner ~stages ~timeout_sec =
+      let stages =
+        List.map
+          (fun stage ->
+            { Keeper_turn_sandbox_runtime.command_argv = stage.Masc_exec.Sandbox_target.argv
+            ; cwd = stage.cwd
+            })
+          stages
+      in
+      match
+        Keeper_turn_sandbox_runtime.run_exec_pipeline_with_status
+          runtime
+          ~timeout_sec
+          ~cwd
+          ~stages
+      with
+      | Ok result -> result
+      | Error err -> Unix.WEXITED 1, "", err
+    in
+    Ok (Masc_exec.Sandbox_target.docker ~image ~runner ~pipeline_runner ())
 
 let typed_docker_runtime_failure_fields output =
   if String_util.contains_substring output "sandbox_image_missing"

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -212,6 +212,32 @@ let run_argv_with_stdin_and_status_split_retry_eintr ~timeout_sec ~stdin_content
     loop max_eintr_retries)
 ;;
 
+let run_argv_pipeline_with_status_split_retry_eintr ~timeout_sec stages =
+  let max_eintr_retries = 8 in
+  Docker_spawn_throttle.with_slot (fun () ->
+    let rec loop attempts_left =
+      let st, stdout, stderr =
+        Masc_exec.Exec_gate.run_argv_pipeline_with_status_split
+          ~actor:`System_task_sandbox
+          ~raw_source:
+            (stages
+             |> List.map (fun stage -> String.concat " " stage.Process_eio.argv)
+             |> String.concat " | ")
+          ~summary:"keeper turn sandbox pipeline command"
+          ~timeout_sec
+          stages
+      in
+      let out = output_for_status ~stdout ~stderr in
+      match st with
+      | Unix.WEXITED 127
+        when attempts_left > 0
+             && String_util.contains_substring_ci out "interrupted system call" ->
+        loop (attempts_left - 1)
+      | _ -> st, stdout, stderr
+    in
+    loop max_eintr_retries)
+;;
+
 let start_container (t : t) ~(timeout_sec : float) =
   let image =
     match t.meta.sandbox_image with
@@ -422,6 +448,72 @@ let run_exec_with_status
   | Ok ((Unix.WEXITED 126 | Unix.WEXITED 127), out) when container_missing_error out ->
     t.state <- Not_started;
     (match run_exec_with_status_once ?stdin_content t ~timeout_sec ~cwd ~command_argv with
+     | Ok _ as ok -> ok
+     | Error _ as err -> err)
+  | Ok other -> Ok other
+;;
+
+type exec_pipeline_stage = {
+  command_argv : string list;
+  cwd : string option;
+}
+
+let rewrite_command_argv (t : t) command_argv =
+  List.map
+    (fun arg ->
+      let rewritten =
+        Keeper_sandbox_runtime.rewrite_host_root_to_container_root
+          ~host_root:t.host_root
+          ~container_root:t.container_root
+          arg
+      in
+      if String.equal t.raw_host_root t.host_root
+      then rewritten
+      else
+        Keeper_sandbox_runtime.rewrite_host_root_to_container_root
+          ~host_root:t.raw_host_root
+          ~container_root:t.container_root
+          rewritten)
+    command_argv
+;;
+
+let docker_exec_pipeline_argv (t : t) ~container_name ~container_cwd command_argv =
+  Keeper_sandbox_runtime.docker_command_argv ()
+  @ [ "exec"; "-i"; "--user"; Printf.sprintf "%d:%d" t.uid t.gid; "-w"; container_cwd ]
+  @ Keeper_sandbox_runtime.docker_sandbox_env_args
+      ~base_path:t.config.base_path
+      ~container_root:t.container_root
+  @ (container_name :: rewrite_command_argv t command_argv)
+;;
+
+let run_exec_pipeline_with_status_once
+      (t : t)
+      ~(timeout_sec : float)
+      ~(cwd : string)
+      ~(stages : exec_pipeline_stage list)
+  =
+  match ensure_started t ~timeout_sec with
+  | Error _ as err -> err
+  | Ok container_name ->
+    let process_stages =
+      List.map
+        (fun { command_argv; cwd = stage_cwd } ->
+          let cwd = Option.value stage_cwd ~default:cwd in
+          let container_cwd = container_cwd_of_host t ~host_cwd:cwd in
+          let argv = docker_exec_pipeline_argv t ~container_name ~container_cwd command_argv in
+          { Process_eio.argv; env = Some (Unix.environment ()); cwd = Some (Sys.getcwd ()) })
+        stages
+    in
+    Ok (run_argv_pipeline_with_status_split_retry_eintr ~timeout_sec process_stages)
+;;
+
+let run_exec_pipeline_with_status t ~timeout_sec ~cwd ~stages =
+  match run_exec_pipeline_with_status_once t ~timeout_sec ~cwd ~stages with
+  | Error _ as err -> err
+  | Ok ((Unix.WEXITED 126 | Unix.WEXITED 127), stdout, stderr)
+    when container_missing_error (output_for_status ~stdout ~stderr) ->
+    t.state <- Not_started;
+    (match run_exec_pipeline_with_status_once t ~timeout_sec ~cwd ~stages with
      | Ok _ as ok -> ok
      | Error _ as err -> err)
   | Ok other -> Ok other

--- a/lib/keeper/keeper_turn_sandbox_runtime.mli
+++ b/lib/keeper/keeper_turn_sandbox_runtime.mli
@@ -47,6 +47,21 @@ val run_exec_with_status :
     process status and merged output without applying success-code policy.
     This is the argv-level entrypoint used by Shell IR dispatch. *)
 
+type exec_pipeline_stage = {
+  command_argv : string list;
+  cwd : string option;
+}
+
+val run_exec_pipeline_with_status :
+  t ->
+  timeout_sec:float ->
+  cwd:string ->
+  stages:exec_pipeline_stage list ->
+  (Unix.process_status * string * string, string) result
+(** Execute [stages] as a streaming argv pipeline inside the turn-scoped
+    container. Each stage is a separate [docker exec -i] process and adjacent
+    stages are connected by host-side process pipes. *)
+
 val run_command :
   ?ok_exit_codes:int list ->
   t ->

--- a/test/test_exec_dispatch.ml
+++ b/test/test_exec_dispatch.ml
@@ -171,7 +171,7 @@ let () =
     | _ -> Unix.WEXITED 99, "", "unexpected;"
   in
   let docker_sandbox =
-    Masc_exec.Sandbox_target.docker ~image:"pipeline-status" ~runner:mock_runner
+    Masc_exec.Sandbox_target.docker ~image:"pipeline-status" ~runner:mock_runner ()
   in
   let simple bin =
     Simple
@@ -275,7 +275,7 @@ let () =
     (Unix.WEXITED 0, "mock_stdout", "mock_stderr")
   in
   let docker_sandbox =
-    Masc_exec.Sandbox_target.docker ~image:"test-image" ~runner:mock_runner
+    Masc_exec.Sandbox_target.docker ~image:"test-image" ~runner:mock_runner ()
   in
   let ir =
     Simple
@@ -314,7 +314,7 @@ let () =
     Unix.WEXITED 0, "stdout", "stderr"
   in
   let docker_sandbox =
-    Masc_exec.Sandbox_target.docker ~image:"redirect-image" ~runner:mock_runner
+    Masc_exec.Sandbox_target.docker ~image:"redirect-image" ~runner:mock_runner ()
   in
   let ir =
     Simple
@@ -348,7 +348,7 @@ let () =
     Unix.WEXITED 0, "stdout", "stderr"
   in
   let docker_sandbox =
-    Masc_exec.Sandbox_target.docker ~image:"redirect-image" ~runner:mock_runner
+    Masc_exec.Sandbox_target.docker ~image:"redirect-image" ~runner:mock_runner ()
   in
   let ir =
     Simple
@@ -385,7 +385,7 @@ let () =
     Unix.WEXITED 0, "stdout", "stderr"
   in
   let docker_sandbox =
-    Masc_exec.Sandbox_target.docker ~image:"redirect-image" ~runner:mock_runner
+    Masc_exec.Sandbox_target.docker ~image:"redirect-image" ~runner:mock_runner ()
   in
   let ir =
     Simple
@@ -428,7 +428,7 @@ let () =
     | _ -> Unix.WEXITED 2, "", "unexpected mock runner call"
   in
   let docker_sandbox =
-    Masc_exec.Sandbox_target.docker ~image:"pipeline-image" ~runner:mock_runner
+    Masc_exec.Sandbox_target.docker ~image:"pipeline-image" ~runner:mock_runner ()
   in
   let cwd = Some (Masc_exec.Path_scope.classify ~raw:"/tmp/pipeline" ~cwd:"/tmp/pipeline") in
   let stages =
@@ -459,8 +459,134 @@ let () =
   match List.rev !runner_calls with
   | [ ([ "printf"; "typed" ], Some first_cwd, None)
     ; ([ "wc"; "-c" ], Some second_cwd, Some "typed") ] ->
-      assert (first_cwd = "/tmp/pipeline");
-      assert (second_cwd = "/tmp/pipeline")
+	      assert (first_cwd = "/tmp/pipeline");
+	      assert (second_cwd = "/tmp/pipeline")
+	  | _ -> assert false
+
+(* --- dispatch_pipeline prefers Docker streaming pipeline runner --- *)
+
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let printf_bin = Masc_exec.Bin.of_string "printf" |> Result.get_ok in
+  let wc_bin = Masc_exec.Bin.of_string "wc" |> Result.get_ok in
+  let simple_runner_called = ref false in
+  let pipeline_runner_calls = ref [] in
+  let simple_runner ~stdin_content:_ ~argv:_ ~env:_ ~cwd:_ ~timeout_sec:_ =
+    simple_runner_called := true;
+    Unix.WEXITED 3, "", "simple runner should not be used"
+  in
+  let pipeline_runner ~stages ~timeout_sec:_ =
+    pipeline_runner_calls := stages :: !pipeline_runner_calls;
+    Unix.WEXITED 0, "5\n", "pipeline-stderr"
+  in
+  let docker_sandbox =
+    Masc_exec.Sandbox_target.docker
+      ~image:"pipeline-image"
+      ~runner:simple_runner
+      ~pipeline_runner
+      ()
+  in
+  let cwd =
+    Some
+      (Masc_exec.Path_scope.classify ~raw:"/tmp/pipeline" ~cwd:"/tmp/pipeline")
+  in
+  let stages =
+    [
+      Simple
+        {
+          bin = printf_bin;
+          args = [ Lit "typed" ];
+          env = [];
+          cwd;
+          redirects = [];
+          sandbox = docker_sandbox;
+        };
+      Simple
+        {
+          bin = wc_bin;
+          args = [ Lit "-c" ];
+          env = [];
+          cwd;
+          redirects = [];
+          sandbox = docker_sandbox;
+        };
+    ]
+  in
+  let result = Masc_exec.Exec_dispatch.dispatch (Pipeline stages) in
+  assert (not !simple_runner_called);
+  assert (result.status = Unix.WEXITED 0);
+  assert (String.trim result.stdout = "5");
+  assert (result.stderr = "pipeline-stderr");
+  match !pipeline_runner_calls with
+  | [ [ first; second ] ] ->
+      assert (first.Masc_exec.Sandbox_target.argv = [ "printf"; "typed" ]);
+      assert (second.Masc_exec.Sandbox_target.argv = [ "wc"; "-c" ]);
+      assert (first.cwd = Some "/tmp/pipeline");
+      assert (second.cwd = Some "/tmp/pipeline")
+  | _ -> assert false
+
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let printf_bin = Masc_exec.Bin.of_string "printf" |> Result.get_ok in
+  let wc_bin = Masc_exec.Bin.of_string "wc" |> Result.get_ok in
+  let dev_null =
+    Masc_exec.Path_scope.classify ~raw:"/dev/null" ~cwd:"/tmp"
+  in
+  let simple_runner_calls = ref [] in
+  let pipeline_runner_called = ref false in
+  let simple_runner ~stdin_content ~argv ~env:_ ~cwd:_ ~timeout_sec:_ =
+    simple_runner_calls := (argv, stdin_content) :: !simple_runner_calls;
+    match argv, stdin_content with
+    | [ "printf"; "typed" ], None -> Unix.WEXITED 0, "typed", "hidden"
+    | [ "wc"; "-c" ], Some "typed" -> Unix.WEXITED 0, "5\n", ""
+    | _ -> Unix.WEXITED 2, "", "unexpected mock runner call"
+  in
+  let pipeline_runner ~stages:_ ~timeout_sec:_ =
+    pipeline_runner_called := true;
+    Unix.WEXITED 3, "", "pipeline runner should not be used for redirects"
+  in
+  let docker_sandbox =
+    Masc_exec.Sandbox_target.docker
+      ~image:"pipeline-image"
+      ~runner:simple_runner
+      ~pipeline_runner
+      ()
+  in
+  let stages =
+    [
+      Simple
+        {
+          bin = printf_bin;
+          args = [ Lit "typed" ];
+          env = [];
+          cwd = None;
+          redirects =
+            [
+              Masc_exec.Redirect_scope.File
+                { fd = 2; target = dev_null; mode = Masc_exec.Redirect_scope.Write };
+            ];
+          sandbox = docker_sandbox;
+        };
+      Simple
+        {
+          bin = wc_bin;
+          args = [ Lit "-c" ];
+          env = [];
+          cwd = None;
+          redirects = [];
+          sandbox = docker_sandbox;
+        };
+    ]
+  in
+  let result = Masc_exec.Exec_dispatch.dispatch (Pipeline stages) in
+  assert (not !pipeline_runner_called);
+  assert (result.status = Unix.WEXITED 0);
+  assert (String.trim result.stdout = "5");
+  assert (result.stderr = "");
+  match List.rev !simple_runner_calls with
+  | [ ([ "printf"; "typed" ], None); ([ "wc"; "-c" ], Some "typed") ] -> ()
   | _ -> assert false
 
 (* --- dispatch_simple exception from runner is caught --- *)
@@ -473,7 +599,7 @@ let () =
     failwith "mock docker failure"
   in
   let docker_sandbox =
-    Masc_exec.Sandbox_target.docker ~image:"fail-image" ~runner:mock_runner
+    Masc_exec.Sandbox_target.docker ~image:"fail-image" ~runner:mock_runner ()
   in
   let ir =
     Simple

--- a/test/test_keeper_bash_typed_input.ml
+++ b/test/test_keeper_bash_typed_input.ml
@@ -373,6 +373,7 @@ let docker_test_sandbox () =
     ~image:"typed-docker"
     ~runner:(fun ~stdin_content:_ ~argv:_ ~env:_ ~cwd:_ ~timeout_sec:_ ->
       Unix.WEXITED 0, "", "")
+    ()
 ;;
 
 let check_docker_sandbox label simple =


### PR DESCRIPTION
## Summary
- add an optional Docker Shell IR pipeline_runner contract alongside the existing simple runner
- route all-Docker redirect-free Shell IR pipelines through a streaming pipeline runner
- wire keeper Docker runtime to run each stage as a separate docker exec connected by Process_eio pipes
- keep mixed host/Docker or redirected pipelines on the existing buffered fallback path

## Validation
- ocamlformat --check lib/exec/sandbox_target.ml lib/exec/sandbox_target.mli lib/exec/exec_dispatch.ml lib/keeper/keeper_turn_sandbox_runtime.ml lib/keeper/keeper_turn_sandbox_runtime.mli lib/keeper/keeper_shell_bash.ml test/test_exec_dispatch.ml test/test_keeper_bash_typed_input.ml
- git diff --check
- env DUNE_CACHE=disabled DUNE_LOCAL_JOBS=1 MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build lib/process/masc_process.cma lib/exec/masc_exec.cma test/test_exec_dispatch.exe test/test_keeper_bash_typed_input.exe
- _build/default/test/test_exec_dispatch.exe
- _build/default/test/test_keeper_bash_typed_input.exe

Refs #17402