### PR TITLE
Run pr-open script tests with argv

### DIFF
--- a/test/test_pr_open_script.ml
+++ b/test/test_pr_open_script.ml
@@ -8,8 +8,6 @@ let source_root () =
 let script_path () =
   Filename.concat (source_root ()) "scripts/pr-open.sh"
 
-let quote = Filename.quote
-
 let contains_substring haystack needle =
   let hlen = String.length haystack in
   let nlen = String.length needle in
@@ -70,36 +68,66 @@ let with_temp_dir prefix f =
   Unix.mkdir dir 0o755;
   Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
 
-let run_shell ?(env = []) ~cwd cmd =
-  let env_prefix =
-    env
-    |> List.map (fun (k, v) -> Printf.sprintf "%s=%s" k (quote v))
-    |> String.concat " "
-  in
-  let full =
-    if env_prefix = "" then
-      Printf.sprintf "cd %s && %s" (quote cwd) cmd
-    else
-      Printf.sprintf "cd %s && %s %s" (quote cwd) env_prefix cmd
-  in
+let env_array overrides =
+  let table = Hashtbl.create 64 in
+  Unix.environment ()
+  |> Array.iter (fun entry ->
+         match String.index_opt entry '=' with
+         | None -> ()
+         | Some idx ->
+             let key = String.sub entry 0 idx in
+             let value =
+               String.sub entry (idx + 1) (String.length entry - idx - 1)
+             in
+             Hashtbl.replace table key value);
+  List.iter (fun (key, value) -> Hashtbl.replace table key value) overrides;
+  Hashtbl.fold
+    (fun key value acc -> Printf.sprintf "%s=%s" key value :: acc)
+    table []
+  |> Array.of_list
+
+let run_process ?(env = []) ~cwd prog argv =
   let out = Filename.temp_file "pr-open-out" ".txt" in
   let err = Filename.temp_file "pr-open-err" ".txt" in
-  let wrapped =
-    Printf.sprintf "%s > %s 2> %s" full (quote out) (quote err)
+  let out_fd = Unix.openfile out [ Unix.O_WRONLY; Unix.O_TRUNC ] 0o600 in
+  let err_fd = Unix.openfile err [ Unix.O_WRONLY; Unix.O_TRUNC ] 0o600 in
+  let original_cwd = Sys.getcwd () in
+  let pid =
+    Fun.protect
+      ~finally:(fun () ->
+        Sys.chdir original_cwd;
+        Unix.close out_fd;
+        Unix.close err_fd)
+      (fun () ->
+        Sys.chdir cwd;
+        Unix.create_process_env prog argv (env_array env) Unix.stdin out_fd
+          err_fd)
   in
-  let code = Sys.command wrapped in
+  let _, status = Unix.waitpid [] pid in
+  let code =
+    match status with
+    | Unix.WEXITED code -> code
+    | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> 255
+  in
   let stdout = read_file out in
   let stderr = read_file err in
   Sys.remove out;
   Sys.remove err;
   (code, stdout, stderr)
 
-let run_shell_ok ?(env = []) ~cwd cmd =
-  let code, stdout, stderr = run_shell ~env ~cwd cmd in
+let run_process_ok ?(env = []) ~cwd prog argv =
+  let code, stdout, stderr = run_process ~env ~cwd prog argv in
   if code <> 0 then
-    failf "command failed (%d): %s\nstdout:\n%s\nstderr:\n%s" code cmd stdout
+    failf "command failed (%d): %s\nstdout:\n%s\nstderr:\n%s" code prog stdout
       stderr;
   (stdout, stderr)
+
+let git_ok ~cwd args =
+  ignore (run_process_ok ~cwd "git" (Array.of_list ("git" :: args)))
+
+let run_pr_open ?(env = []) ~cwd args =
+  run_process ~env ~cwd "/bin/bash"
+    (Array.of_list ("/bin/bash" :: script_path () :: args))
 
 let make_fake_gh dir =
   let bin_dir = Filename.concat dir "bin" in
@@ -202,29 +230,25 @@ esac
 
 let init_repo_with_remote dir =
   let remote_dir = Filename.concat dir "remote.git" in
-  ignore (run_shell_ok ~cwd:dir "git init -q");
-  ignore (run_shell_ok ~cwd:dir "git config user.email test@example.com");
-  ignore (run_shell_ok ~cwd:dir "git config user.name tester");
-  ignore (run_shell_ok ~cwd:dir "git checkout -qb main");
+  git_ok ~cwd:dir [ "init"; "-q" ];
+  git_ok ~cwd:dir [ "config"; "user.email"; "test@example.com" ];
+  git_ok ~cwd:dir [ "config"; "user.name"; "tester" ];
+  git_ok ~cwd:dir [ "checkout"; "-qb"; "main" ];
   mkdir_p (Filename.concat dir "docs");
   mkdir_p (Filename.concat dir "lib");
   write_file (Filename.concat dir "README.md") "# temp\n";
-  ignore
-    (run_shell_ok ~cwd:dir
-       "git add README.md && git -c core.hooksPath=/dev/null commit -q -m base");
-  ignore
-    (run_shell_ok ~cwd:dir
-       (Printf.sprintf "git init --bare -q %s" (quote remote_dir)));
-  ignore
-    (run_shell_ok ~cwd:dir
-       (Printf.sprintf "git remote add origin %s" (quote remote_dir)));
-  ignore (run_shell_ok ~cwd:dir "git push -u origin main");
-  ignore (run_shell_ok ~cwd:dir "git checkout -qb feature/macos-pr-open");
+  git_ok ~cwd:dir [ "add"; "README.md" ];
+  git_ok ~cwd:dir
+    [ "-c"; "core.hooksPath=/dev/null"; "commit"; "-q"; "-m"; "base" ];
+  git_ok ~cwd:dir [ "init"; "--bare"; "-q"; remote_dir ];
+  git_ok ~cwd:dir [ "remote"; "add"; "origin"; remote_dir ];
+  git_ok ~cwd:dir [ "push"; "-u"; "origin"; "main" ];
+  git_ok ~cwd:dir [ "checkout"; "-qb"; "feature/macos-pr-open" ];
   write_file (Filename.concat dir "lib/example.ml") "let value = 1\n";
-  ignore
-    (run_shell_ok ~cwd:dir
-       "git add lib/example.ml && git -c core.hooksPath=/dev/null commit -q -m feature");
-  ignore (run_shell_ok ~cwd:dir "git push -u origin feature/macos-pr-open")
+  git_ok ~cwd:dir [ "add"; "lib/example.ml" ];
+  git_ok ~cwd:dir
+    [ "-c"; "core.hooksPath=/dev/null"; "commit"; "-q"; "-m"; "feature" ];
+  git_ok ~cwd:dir [ "push"; "-u"; "origin"; "feature/macos-pr-open" ]
 
 let test_source_avoids_mapfile_only_bash4_features () =
   let content = read_file (script_path ()) in
@@ -254,14 +278,18 @@ let test_script_runs_under_system_bash_without_watch () =
           ("FAKE_GH_LABELS", gh_labels);
         ]
       in
-      let cmd =
-        Printf.sprintf "/bin/bash %s --repo %s --title %s --body-file %s --no-watch"
-          (quote (script_path ()))
-          (quote "example/test")
-          (quote "fix: macOS bash compatibility")
-          (quote body_file)
+      let code, stdout, stderr =
+        run_pr_open ~cwd:dir ~env
+          [
+            "--repo";
+            "example/test";
+            "--title";
+            "fix: macOS bash compatibility";
+            "--body-file";
+            body_file;
+            "--no-watch";
+          ]
       in
-      let code, stdout, stderr = run_shell ~cwd:dir ~env cmd in
       if code <> 0 then
         failf "pr-open failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout stderr;
       check bool "prints PR url" true
@@ -314,14 +342,18 @@ let test_script_restores_draft_when_create_returns_ready () =
           ("FAKE_GH_CREATE_READY", "1");
         ]
       in
-      let cmd =
-        Printf.sprintf "/bin/bash %s --repo %s --title %s --body-file %s --no-watch"
-          (quote (script_path ()))
-          (quote "example/test")
-          (quote "fix: restore ready pr to draft")
-          (quote body_file)
+      let code, stdout, stderr =
+        run_pr_open ~cwd:dir ~env
+          [
+            "--repo";
+            "example/test";
+            "--title";
+            "fix: restore ready pr to draft";
+            "--body-file";
+            body_file;
+            "--no-watch";
+          ]
       in
-      let code, stdout, stderr = run_shell ~cwd:dir ~env cmd in
       if code <> 0 then
         failf "pr-open failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout stderr;
       let log = read_file gh_log in
@@ -355,14 +387,17 @@ let test_script_prints_final_status_after_watch () =
           ("FAKE_GH_ALLOW_CHECKS", "1");
         ]
       in
-      let cmd =
-        Printf.sprintf "/bin/bash %s --repo %s --title %s --body-file %s"
-          (quote (script_path ()))
-          (quote "example/test")
-          (quote "fix: print final status")
-          (quote body_file)
+      let code, stdout, stderr =
+        run_pr_open ~cwd:dir ~env
+          [
+            "--repo";
+            "example/test";
+            "--title";
+            "fix: print final status";
+            "--body-file";
+            body_file;
+          ]
       in
-      let code, stdout, stderr = run_shell ~cwd:dir ~env cmd in
       if code <> 0 then
         failf "pr-open failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout stderr;
       check bool "runs watched checks" true
@@ -393,14 +428,18 @@ let test_script_rejects_body_missing_required_sections () =
           ("FAKE_GH_LABELS", gh_labels);
         ]
       in
-      let cmd =
-        Printf.sprintf "/bin/bash %s --repo %s --title %s --body-file %s --no-watch"
-          (quote (script_path ()))
-          (quote "example/test")
-          (quote "fix: reject incomplete PR body")
-          (quote body_file)
+      let code, stdout, stderr =
+        run_pr_open ~cwd:dir ~env
+          [
+            "--repo";
+            "example/test";
+            "--title";
+            "fix: reject incomplete PR body";
+            "--body-file";
+            body_file;
+            "--no-watch";
+          ]
       in
-      let code, stdout, stderr = run_shell ~cwd:dir ~env cmd in
       check bool "command fails" true (code <> 0);
       check bool "stdout empty" true (String.trim stdout = "");
       check bool "mentions hygiene failure" true
@@ -446,14 +485,18 @@ let test_script_rejects_body_missing_direct_evidence_schema () =
           ("FAKE_GH_LABELS", gh_labels);
         ]
       in
-      let cmd =
-        Printf.sprintf "/bin/bash %s --repo %s --title %s --body-file %s --no-watch"
-          (quote (script_path ()))
-          (quote "example/test")
-          (quote "fix: reject direct evidence drift")
-          (quote body_file)
+      let code, stdout, stderr =
+        run_pr_open ~cwd:dir ~env
+          [
+            "--repo";
+            "example/test";
+            "--title";
+            "fix: reject direct evidence drift";
+            "--body-file";
+            body_file;
+            "--no-watch";
+          ]
       in
-      let code, stdout, stderr = run_shell ~cwd:dir ~env cmd in
       check bool "command fails" true (code <> 0);
       check bool "stdout empty" true (String.trim stdout = "");
       check bool "mentions direct evidence schema failure" true
@@ -473,7 +516,7 @@ let test_script_rejects_staged_changes_before_push () =
       let body_file = Filename.concat dir "body.md" in
       write_file body_file valid_pr_body;
       write_file (Filename.concat dir "lib/staged.ml") "let staged = true\n";
-      ignore (run_shell_ok ~cwd:dir "git add lib/staged.ml");
+      git_ok ~cwd:dir [ "add"; "lib/staged.ml" ];
       let path =
         Printf.sprintf "%s:%s" fake_gh_dir
           (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
@@ -485,14 +528,18 @@ let test_script_rejects_staged_changes_before_push () =
           ("FAKE_GH_LABELS", gh_labels);
         ]
       in
-      let cmd =
-        Printf.sprintf "/bin/bash %s --repo %s --title %s --body-file %s --no-watch"
-          (quote (script_path ()))
-          (quote "example/test")
-          (quote "fix: reject staged changes")
-          (quote body_file)
+      let code, stdout, stderr =
+        run_pr_open ~cwd:dir ~env
+          [
+            "--repo";
+            "example/test";
+            "--title";
+            "fix: reject staged changes";
+            "--body-file";
+            body_file;
+            "--no-watch";
+          ]
       in
-      let code, stdout, stderr = run_shell ~cwd:dir ~env cmd in
       check bool "command fails" true (code <> 0);
       check bool "stdout empty" true (String.trim stdout = "");
       check bool "mentions staged changes" true


### PR DESCRIPTION
## Summary
- replace test_pr_open_script's shell wrapper with argv-based process execution
- split git setup into explicit argv calls
- keep the system-bash compatibility check while invoking /bin/bash with argv instead of a shell command string

## Verification
- ocamlformat --check test/test_pr_open_script.ml
- git diff --check HEAD~1..HEAD
- rg -n 'Sys[.]command|Unix[.]system|Unix[.]open_process_in|with_process_in|bash -lc|sh -lc|sh -c|bash -c|let quote|Filename[.]quote|run_shell|Printf[.]sprintf .*git|Printf[.]sprintf .*/bin/bash' test/test_pr_open_script.ml
- scripts/dune-local.sh build test/test_pr_open_script.exe (blocked: live bare Dune process from another session)