### PR TITLE
refactor(keeper_agent_run): extract tool surface violation

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -202,7 +202,7 @@
   keeper_agent_tool_surface
   keeper_agent_run_phase0_telemetry keeper_agent_run_contract_retry
   keeper_agent_run_contract_helpers keeper_agent_run_thinking_trajectory
-  keeper_agent_run_tool_observation keeper_agent_run_receipt_append
+  keeper_agent_run_tool_observation keeper_agent_run_tool_surface_violation keeper_agent_run_receipt_append
   keeper_agent_result
   keeper_agent_error
   keeper_agent_memory_episode

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -767,42 +767,14 @@ let run_turn
                  if valid_tool_calls_present then acc.keeper_surface_tool_used <- true;
                  if unexpected_tool_names <> [] && not valid_tool_calls_present
                  then (
-                   let requested_preview =
-                     acc.requested_tool_names_seen
-                     |> List.filteri (fun i _ -> i < 8)
-                     |> String.concat ", "
-                   in
-                   let omitted =
-                     List.length acc.requested_tool_names_seen
-                     - min 8 (List.length acc.requested_tool_names_seen)
-                   in
-                   let requested_suffix =
-                     if omitted > 0 then Printf.sprintf " (+%d more)" omitted else ""
-                   in
-                   let reason =
-                     Printf.sprintf
-                       "keeper turn reported tool names outside selected turn surface: \
-                        unexpected=[%s] requested=[%s%s]"
-                       (String.concat ", " unexpected_tool_names)
-                       requested_preview
-                       requested_suffix
-                   in
                    acc.receipt_tool_contract_result <-
                      Keeper_execution_receipt.Contract_violated;
-                   Prometheus.inc_counter
-                     Keeper_metrics.metric_keeper_contract_violations
-                     ~labels:
-                       [ "keeper_name", meta.name
-                       ; "kind", "tool_surface_violation"
-                       ; "signal", "unexpected_tool_names"
-                       ]
-                     ();
-                   Log.Keeper.error
-                     "keeper:%s cascade=%s %s"
-                     meta.name
-                     (Keeper_types.cascade_name_of_meta meta)
-                     reason;
-                   Error (Agent_sdk.Error.Internal reason))
+                   Error
+                     (Keeper_agent_run_tool_surface_violation.to_sdk_error
+                        ~keeper_name:meta.name
+                        ~cascade_name:(Keeper_types.cascade_name_of_meta meta)
+                        ~requested_tool_names_seen:acc.requested_tool_names_seen
+                        ~unexpected_tool_names))
                  else (
                    let should_log_unexpected_tool_partial =
                      unexpected_tool_names <> []

--- a/lib/keeper/keeper_agent_run_tool_surface_violation.ml
+++ b/lib/keeper/keeper_agent_run_tool_surface_violation.ml
@@ -1,0 +1,41 @@
+let to_sdk_error
+      ~keeper_name
+      ~cascade_name
+      ~requested_tool_names_seen
+      ~unexpected_tool_names
+  =
+  let requested_preview =
+    requested_tool_names_seen
+    |> List.filteri (fun i _ -> i < 8)
+    |> String.concat ", "
+  in
+  let omitted =
+    List.length requested_tool_names_seen
+    - min 8 (List.length requested_tool_names_seen)
+  in
+  let requested_suffix =
+    if omitted > 0 then Printf.sprintf " (+%d more)" omitted else ""
+  in
+  let reason =
+    Printf.sprintf
+      "keeper turn reported tool names outside selected turn surface: \
+       unexpected=[%s] requested=[%s%s]"
+      (String.concat ", " unexpected_tool_names)
+      requested_preview
+      requested_suffix
+  in
+  Prometheus.inc_counter
+    Keeper_metrics.metric_keeper_contract_violations
+    ~labels:
+      [ "keeper_name", keeper_name
+      ; "kind", "tool_surface_violation"
+      ; "signal", "unexpected_tool_names"
+      ]
+    ();
+  Log.Keeper.error
+    "keeper:%s cascade=%s %s"
+    keeper_name
+    cascade_name
+    reason;
+  Agent_sdk.Error.Internal reason
+;;

--- a/lib/keeper/keeper_agent_run_tool_surface_violation.mli
+++ b/lib/keeper/keeper_agent_run_tool_surface_violation.mli
@@ -1,0 +1,6 @@
+val to_sdk_error
+  :  keeper_name:string
+  -> cascade_name:string
+  -> requested_tool_names_seen:string list
+  -> unexpected_tool_names:string list
+  -> Agent_sdk.Error.sdk_error

--- a/lib/keeper/keeper_heartbeat_loop_persist_cursor.mli
+++ b/lib/keeper/keeper_heartbeat_loop_persist_cursor.mli
@@ -1,0 +1,7 @@
+(** Message cursor persistence for keeper heartbeat. *)
+
+val persist_message_cursor_updates :
+  config:Coord.config ->
+  Keeper_types.keeper_meta ->
+  Keeper_world_observation.message_cursor_update list ->
+  Keeper_types.keeper_meta


### PR DESCRIPTION
## Summary

- Extract the invalid tool-surface violation error/log/metric construction from `Keeper_agent_run.run_turn` into `Keeper_agent_run_tool_surface_violation`.
- Keep the parent runner responsible for setting `receipt_tool_contract_result`.
- Add the current-main missing `keeper_heartbeat_loop_persist_cursor.mli` sibling so the structure ratchet remains green.

## Product impact

Behavior-preserving keeper godfile decomposition. The no-valid-tool-call hard-fail path still emits the same metric, log shape, and internal error reason, while `keeper_agent_run.ml` loses another isolated contract-violation block.

## Evidence

- `ocamlformat --check lib/keeper/keeper_agent_run.ml lib/keeper/keeper_agent_run_tool_surface_violation.ml lib/keeper/keeper_agent_run_tool_surface_violation.mli lib/keeper/keeper_heartbeat_loop_persist_cursor.mli`
- `scripts/ocaml-structure-ratchet.sh`
- `git diff --check`
- `scripts/check-pr-hygiene.sh --base origin/main --head HEAD`
- `wc -l lib/keeper/keeper_agent_run.ml lib/keeper/keeper_agent_run_tool_surface_violation.ml lib/keeper/keeper_agent_run_tool_surface_violation.mli`

Local focused Dune verification was attempted with `scripts/dune-local.sh build lib/masc_mcp_lib.a`, but the wrapper refused with exit 75 because existing bare Dune processes were already running on the host. I did not bypass the guard.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 4/5
provenance: direct
checks:
  - ocamlformat
  - structure_ratchet
  - diff_check
  - pr_hygiene
blocked:
  - focused_dune_local_existing_bare_dune_processes
```

## Review evidence

- `lib/keeper/keeper_agent_run.ml` drops from 2030 to 2002 LOC on this branch.
- The helper owns only reason construction, logging, and metric emission.
- Receipt contract mutation remains in the parent runner.

## Linked issue

RFC-0147 keeper godfile decomposition follow-up slice.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/agent-run-tool-surface-violation-20260521` → `main` · 1 commit(s) · synced 2026-05-21T14:18:50Z

| sha | subject | date |
|---|---|---|
| `367191d5f` | refactor(keeper_agent_run): extract tool surface violation | 2026-05-21 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->