### PR TITLE
fix(test): repair main build test helpers

### DIFF
--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -619,6 +619,18 @@ let make_config base_path : Masc_mcp.Coord.config =
   Unix.putenv "MASC_BASE_PATH" base_path;
   Masc_mcp.Coord.default_config base_path
 
+let run_git args =
+  let devnull = Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0 in
+  Fun.protect
+    ~finally:(fun () -> Unix.close devnull)
+    (fun () ->
+      let argv = Array.of_list ("git" :: args) in
+      try
+        let pid = Unix.create_process "git" argv Unix.stdin devnull devnull in
+        ignore (Unix.waitpid [] pid)
+      with
+      | Unix.Unix_error _ -> ())
+
 (* Ensure the base path exists as a real git repository so
    Tool_code.validate_path (which requires
    Coord_git.git_root ~base_path) can canonicalise against it.
@@ -638,18 +650,6 @@ let fresh_base_path () =
   (* Initialise a minimal git repository so validate_path has a
      canonical root. An empty `git init` plus an initial commit
      is sufficient; Coord_git.git_root walks up from base_path. *)
-  let run_git args =
-    let devnull = Unix.openfile "/dev/null" [ Unix.O_WRONLY ] 0 in
-    Fun.protect
-      ~finally:(fun () -> Unix.close devnull)
-      (fun () ->
-        let argv = Array.of_list ("git" :: args) in
-        try
-          let pid = Unix.create_process "git" argv Unix.stdin devnull devnull in
-          ignore (Unix.waitpid [] pid)
-        with
-        | Unix.Unix_error _ -> ())
-  in
   run_git [ "init"; "-b"; "main"; dir ];
   run_git [ "-C"; dir; "config"; "user.email"; "iter6@example.test" ];
   run_git [ "-C"; dir; "config"; "user.name"; "Iter6 Test" ];

--- a/test/test_tool_deep_review.ml
+++ b/test/test_tool_deep_review.ml
@@ -26,7 +26,7 @@ let with_temp_dir f =
   in
   mkdir_p base;
   Fun.protect
-    ~finally:(fun () -> Masc_mcp.Fs_compat.remove_tree base)
+    ~finally:(fun () -> Fs_compat.remove_tree base)
     (fun () -> f base)
 
 let write_file path content =


### PR DESCRIPTION
## Summary
- use the direct Fs_compat module in test_tool_deep_review instead of a non-existent Masc_mcp re-export
- lift the git helper in test_tool_code_write_coverage so later tests can use it

## Verification
- git diff --check origin/main..HEAD
- ocamlformat --check test/test_tool_deep_review.ml test/test_tool_code_write_coverage.ml lib/keeper/keeper_agent_run_thinking_trajectory.mli

Note: focused dune target was attempted locally, but dune repeatedly left only the parent scheduler process running with no child compile process in this host session.