### PR TITLE
fix(exec): parse Shell IR env prefixes

### DIFF
--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -110,6 +110,24 @@ let resolve_env env_bindings =
     env_bindings
   |> Array.of_list
 
+let env_key entry =
+  match String.index_opt entry '=' with
+  | None -> entry
+  | Some idx -> String.sub entry 0 idx
+
+let resolve_host_env = function
+  | [] -> None
+  | env_bindings ->
+      let overrides = resolve_env env_bindings |> Array.to_list in
+      let override_keys = List.map env_key overrides in
+      let inherited =
+        Unix.environment ()
+        |> Array.to_list
+        |> List.filter (fun entry ->
+          not (List.mem (env_key entry) override_keys))
+      in
+      Some (Array.of_list (inherited @ overrides))
+
 (* --- simple command execution --- *)
 
 (* Dispatch a simple command via the IR-carried Sandbox_target.
@@ -145,6 +163,7 @@ let dispatch_simple ?timeout_sec ?stdin_content (s : Shell_ir.simple) =
     match s.sandbox with
     | Host ->
       let raw_source = String.concat " " argv in
+      let host_env = resolve_host_env s.env in
       let run () =
         match stdin_content with
         | None ->
@@ -153,7 +172,7 @@ let dispatch_simple ?timeout_sec ?stdin_content (s : Shell_ir.simple) =
             ~raw_source
             ~summary:"exec dispatch simple"
             ~timeout_sec
-            ~env
+            ?env:host_env
             ?cwd
             argv
         | Some stdin_content ->
@@ -162,7 +181,7 @@ let dispatch_simple ?timeout_sec ?stdin_content (s : Shell_ir.simple) =
             ~raw_source
             ~summary:"exec dispatch simple stdin"
             ~timeout_sec
-            ~env
+            ?env:host_env
             ?cwd
             ~stdin_content
             argv
@@ -191,9 +210,9 @@ let host_pipeline_specs stages =
     | Shell_ir.Simple simple :: rest ->
         (match simple.sandbox with
          | Host when simple.redirects = [] ->
-             let argv, env, cwd = process_spec_of_simple simple in
+             let argv, _env, cwd = process_spec_of_simple simple in
              let stage : Process_eio.pipeline_stage =
-               { argv; env = Some env; cwd }
+               { argv; env = resolve_host_env simple.env; cwd }
              in
              loop (stage :: acc) rest
          | _ -> None)

--- a/lib/exec/parser/bash.ml
+++ b/lib/exec/parser/bash.ml
@@ -8,8 +8,44 @@ let make_parse_error (lexbuf : Lexing.lexbuf) : Parsed.parse_error =
   let token = Lexing.lexeme lexbuf in
   { pos; token; expected = [] (* populated in later PR *) }
 
+let is_env_name_start = function
+  | 'A' .. 'Z' | 'a' .. 'z' | '_' -> true
+  | _ -> false
+
+let is_env_name_char = function
+  | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' -> true
+  | _ -> false
+
+let parse_env_assignment word =
+  match String.index_opt word '=' with
+  | None -> None
+  | Some 0 -> None
+  | Some idx ->
+    let name = String.sub word 0 idx in
+    if is_env_name_start name.[0]
+       && String.for_all is_env_name_char name
+    then (
+      let value =
+        String.sub word (idx + 1) (String.length word - idx - 1)
+      in
+      Some (name, Shell_ir.Lit value))
+    else None
+
+let split_env_prefix words =
+  let rec loop env = function
+    | [] -> Error { Parsed.pos = Lexing.dummy_pos; token = ""; expected = [ "command" ] }
+    | word :: rest ->
+      (match parse_env_assignment word with
+       | Some binding -> loop (binding :: env) rest
+       | None -> Ok (List.rev env, word, rest))
+  in
+  loop [] words
+
 let raw_to_simple (bin_str, args_str, redirects)
     : (Shell_ir.simple, Parsed.parse_error) result =
+  match split_env_prefix (bin_str :: args_str) with
+  | Error e -> Error e
+  | Ok (env, bin_str, args_str) -> (
   match Bin.of_string bin_str with
   | Error (`Unknown _) ->
     (* A0 guarantees Bin.of_string only errors on empty input.  That
@@ -21,11 +57,11 @@ let raw_to_simple (bin_str, args_str, redirects)
     Ok
       { Shell_ir.bin
       ; args
-      ; env = []
+      ; env
       ; cwd = None
       ; redirects
       ; sandbox = Sandbox_target.host ()
-      }
+      })
 
 let rec map_stages = function
   | [] -> Ok []

--- a/lib/exec/parser/bash_lexer.mll
+++ b/lib/exec/parser/bash_lexer.mll
@@ -91,6 +91,7 @@ rule token = parse
   | "/dev/null"    { incr_tokens (); DEV_NULL }
   | '\'' "/dev/null" '\'' { incr_tokens (); DEV_NULL }
   | '"' "/dev/null" '"' { incr_tokens (); DEV_NULL }
+  | (word_prefix as prefix) '\'' (sq_body as s) '\'' { incr_tokens (); WORD (prefix ^ s) }
   | (word_prefix as prefix) '"' (dq_body as s) '"' { incr_tokens (); WORD (prefix ^ s) }
   | '\'' (sq_body as s) '\'' { incr_tokens (); WORD s }
   | '"' (dq_body as s) '"' { incr_tokens (); WORD s }

--- a/lib/exec/parser/bash_subset.mly
+++ b/lib/exec/parser/bash_subset.mly
@@ -16,9 +16,9 @@ let file_redirect fd mode =
 
 /* Bash subset grammar — Menhir LR(1).
 
-   Productions now cover simple commands, pipelines, fd-to-fd
-   redirects, and /dev/null file redirects. Subsequent PRs extend to:
-   - env prefix (FOO=bar cmd)
+   Productions now cover simple commands, pipelines, env prefixes
+   (recognized in bash.ml from leading WORD tokens), fd-to-fd redirects,
+   and /dev/null file redirects. Subsequent PRs extend to:
    - general file redirects beyond the explicit /dev/null sink
    - subset guards that mint Parsed.Too_complex rather than matching.
 

--- a/lib/exec/test/test_bash_parser.ml
+++ b/lib/exec/test/test_bash_parser.ml
@@ -163,6 +163,57 @@ let test_pipeline_dev_null_redirect_preserved () =
      | _ -> assert false)
   | _ -> assert false
 
+let test_env_prefix_parsed () =
+  match Bash.parse_string "LC_ALL=C git status" with
+  | Parsed.Parsed (Shell_ir.Simple s) ->
+    assert (Bin.to_string s.bin = "git");
+    assert (s.args = [ Shell_ir.Lit "status" ]);
+    assert (s.env = [ "LC_ALL", Shell_ir.Lit "C" ])
+  | _ -> assert false
+
+let test_multiple_env_prefixes_preserve_order () =
+  match Bash.parse_string "A=1 B='two words' printenv A" with
+  | Parsed.Parsed (Shell_ir.Simple s) ->
+    assert (Bin.to_string s.bin = "printenv");
+    assert (s.args = [ Shell_ir.Lit "A" ]);
+    assert (s.env = [ "A", Shell_ir.Lit "1"; "B", Shell_ir.Lit "two words" ])
+  | _ -> assert false
+
+let test_env_assignment_after_bin_is_arg () =
+  match Bash.parse_string "echo LC_ALL=C" with
+  | Parsed.Parsed (Shell_ir.Simple s) ->
+    assert (Bin.to_string s.bin = "echo");
+    assert (s.args = [ Shell_ir.Lit "LC_ALL=C" ]);
+    assert (s.env = [])
+  | _ -> assert false
+
+let test_env_only_rejected () =
+  match Bash.parse_string "LC_ALL=C" with
+  | Parsed.Parse_error _ -> ()
+  | _ -> assert false
+
+let test_pipeline_env_prefixes_preserved_per_stage () =
+  match Bash.parse_string "LC_ALL=C printf hi | LANG=C wc -c" with
+  | Parsed.Parsed (Shell_ir.Pipeline [ Shell_ir.Simple s1; Shell_ir.Simple s2 ]) ->
+    assert (Bin.to_string s1.bin = "printf");
+    assert (Bin.to_string s2.bin = "wc");
+    assert (s1.env = [ "LC_ALL", Shell_ir.Lit "C" ]);
+    assert (s2.env = [ "LANG", Shell_ir.Lit "C" ]);
+    assert (s1.args = [ Shell_ir.Lit "hi" ]);
+    assert (s2.args = [ Shell_ir.Lit "-c" ])
+  | _ -> assert false
+
+let test_env_prefix_dispatch_overlay () =
+  match
+    Bash.parse_string
+      "MASC_SHELL_IR_ENV_PREFIX_TEST=ok printenv MASC_SHELL_IR_ENV_PREFIX_TEST"
+  with
+  | Parsed.Parsed ir ->
+    let result = Masc_exec.Exec_dispatch.dispatch ir in
+    assert (result.status = Unix.WEXITED 0);
+    assert (String.trim result.stdout = "ok")
+  | _ -> assert false
+
 let test_heredoc_rejected () =
   (* "<<" must out-rank single "<" — order check in classify_too_complex. *)
   match Bash.parse_string "cat <<EOF" with
@@ -425,6 +476,12 @@ let () =
   test_spaced_dev_null_redirect_parsed ();
   test_quoted_dev_null_redirect_parsed ();
   test_pipeline_dev_null_redirect_preserved ();
+  test_env_prefix_parsed ();
+  test_multiple_env_prefixes_preserve_order ();
+  test_env_assignment_after_bin_is_arg ();
+  test_env_only_rejected ();
+  test_pipeline_env_prefixes_preserved_per_stage ();
+  test_env_prefix_dispatch_overlay ();
   test_heredoc_rejected ();
   test_here_string_rejected ();
   test_cmd_subst_paren_rejected ();


### PR DESCRIPTION
## Summary
- parse leading shell env assignments like FOO=bar cmd into Shell_ir.simple.env
- preserve assignment position semantics: env prefixes only before the executable, later FOO=bar stays argv data
- overlay host native dispatch env prefixes onto the inherited environment so PATH and caller env are preserved
- keep Docker runner env contract unchanged by passing only explicit Shell IR env bindings

## Verification
- ocamlformat --check lib/exec/exec_dispatch.ml lib/exec/parser/bash.ml lib/exec/parser/bash_lexer.mll lib/exec/parser/bash_subset.mly lib/exec/test/test_bash_parser.ml
- env DUNE_CACHE=disabled DUNE_LOCAL_JOBS=1 MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build lib/exec/test/test_bash_parser.exe
- _build/default/lib/exec/test/test_bash_parser.exe
- git diff --check origin/main...HEAD

Note: attempted focused build for test/test_exec_dispatch.exe, but Dune repeatedly stalled with a lone Ss dune process and no child build tasks in this worktree; killed only that exact stale Dune PID. The parser test includes a parsed Shell IR -> Exec_dispatch.dispatch env overlay regression.