### PR TITLE
refactor(cascade_transport): extract CLI transport ctors + registration sibling

### DIFF
--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -1023,27 +1023,12 @@ module Json_stream_cli_transport_local = struct
   ;;
 end
 
-(** Wrap CLI transports in a per-call sub-switch.
-
-    agent_sdk's CLI subprocess helper binds stdout/stderr pipes to the
-    switch passed at transport construction time. Reusing a long-lived
-    keeper/server switch across many calls can therefore retain those pipe
-    resources until the outer switch exits. By instantiating the real CLI
-    transport inside a fresh sub-switch for each completion call, any
-    leftover pipe resources are deterministically released at the end of the
-    call even when the outer keeper lifetime is long-lived. *)
-let make_per_call_switch_transport
-      (factory : sw:Eio.Switch.t -> Llm_provider.Llm_transport.t)
-  : Llm_provider.Llm_transport.t
-  =
-  let with_call_switch f = Eio.Switch.run (fun sw -> f (factory ~sw)) in
-  { complete_sync =
-      (fun req -> with_call_switch (fun transport -> transport.complete_sync req))
-  ; complete_stream =
-      (fun ?on_telemetry:_ ~on_event req ->
-        with_call_switch (fun transport -> transport.complete_stream ~on_event req))
-  }
-;;
+(* CLI transport constructors + per-call switch wrapping + ctor
+   registration extracted to [Cascade_transport_cli_ctors]
+   (godfile decomp). The sibling's top-level [let () = ...]
+   block registers the 4 ctors into
+   [Cascade_transport_non_http_registry] at module-load time. *)
+let make_per_call_switch_transport = Cascade_transport_cli_ctors.make_per_call_switch_transport
 
 (* CLI argv UTF-8 sanitization extracted to
    [Cascade_transport_cli_argv_sanitize] (godfile decomp). *)
@@ -1058,130 +1043,4 @@ let sanitize_runtime_mcp_policy_for_cli =
 let sanitize_cli_completion_request_for_argv =
   Cascade_transport_cli_argv_sanitize.sanitize_cli_completion_request_for_argv
 ;;
-
-let make_cli_argv_sanitizing_transport =
-  Cascade_transport_cli_argv_sanitize.make_cli_argv_sanitizing_transport
-;;
-
-(* Non-HTTP transport registry + dispatcher extracted to
-   [Cascade_transport_non_http_registry] (godfile decomp). *)
-let register_non_http_transport = Cascade_transport_non_http_registry.register_non_http_transport
-
-let default_cli_transport_overrides = Cascade_transport_cli_overrides.default_cli_transport_overrides
-
-let with_proc_mgr (f : mgr:_ -> Llm_provider.Llm_transport.t) =
-  match Process_eio.get_proc_mgr () with
-  | Error detail -> Error (invalid_runtime_config "proc_mgr" detail)
-  | Ok mgr -> Ok (f ~mgr)
-;;
-
-let claude_code_transport_ctor
-      ~(provider_cfg : Llm_provider.Provider_config.t)
-      ~runtime_mcp_policy:_
-      ~cli_transport_overrides
-  =
-  let overrides =
-    Option.value ~default:default_cli_transport_overrides cli_transport_overrides
-  in
-  let config =
-    { Llm_provider.Transport_claude_code.default_config with
-      model = cli_model_override provider_cfg.model_id
-    ; cwd = overrides.cwd
-    ; mcp_config = overrides.claude_mcp_config
-    ; allowed_tools = Option.value ~default:[] overrides.claude_allowed_tools
-    ; permission_mode = overrides.claude_permission_mode
-    ; max_turns = overrides.claude_max_turns
-    }
-  in
-  with_proc_mgr (fun ~mgr ->
-    make_per_call_switch_transport (fun ~sw ->
-      Llm_provider.Transport_claude_code.create ~sw ~mgr ~config))
-;;
-
-let gemini_cli_transport_ctor
-      ~(provider_cfg : Llm_provider.Provider_config.t)
-      ~runtime_mcp_policy:_
-      ~cli_transport_overrides
-  =
-  let overrides =
-    Option.value ~default:default_cli_transport_overrides cli_transport_overrides
-  in
-  let config =
-    { Llm_provider.Transport_gemini_cli.default_config with
-      model = cli_model_override provider_cfg.model_id
-    ; cwd = overrides.cwd
-    ; yolo = Option.value ~default:true overrides.gemini_yolo
-    }
-  in
-  with_proc_mgr (fun ~mgr ->
-    make_per_call_switch_transport (fun ~sw ->
-      Llm_provider.Transport_gemini_cli.create ~sw ~mgr ~config))
-;;
-
-let json_stream_cli_transport_ctor
-      ~(provider_cfg : Llm_provider.Provider_config.t)
-      ~runtime_mcp_policy
-      ~cli_transport_overrides
-  =
-  let cwd = Option.bind cli_transport_overrides (fun overrides -> overrides.cwd) in
-  let stdout_idle_timeout_s =
-    Option.bind cli_transport_overrides (fun overrides ->
-      overrides.cli_subprocess_idle_sec)
-  in
-  let mcp_config_json = cli_runtime_mcp_jsons ~base:[] runtime_mcp_policy in
-  let model = cli_model_for_provider_config provider_cfg in
-  let config_json = cli_runtime_config_json_for_provider provider_cfg in
-  let extra_env = cli_direct_binding_extra_env provider_cfg in
-  let cli_path =
-    cli_command_for_provider_config provider_cfg
-    |> Option.value ~default:Json_stream_cli_transport_local.default_config.cli_path
-  in
-  let process_name = cli_process_name_for_provider_config provider_cfg in
-  let config =
-    { Json_stream_cli_transport_local.default_config with
-      cli_path
-    ; process_name
-    ; model
-    ; cwd
-    ; config_json
-    ; mcp_config_json
-    ; extra_env
-    ; stdout_idle_timeout_s
-    }
-  in
-  with_proc_mgr (fun ~mgr ->
-    make_per_call_switch_transport (fun ~sw ->
-      Json_stream_cli_transport_local.create ~sw ~mgr ~config))
-;;
-
-let codex_cli_transport_ctor
-      ~provider_cfg:_
-      ~runtime_mcp_policy:_
-      ~cli_transport_overrides
-  =
-  let cwd = Option.bind cli_transport_overrides (fun overrides -> overrides.cwd) in
-  with_proc_mgr (fun ~mgr ->
-    make_cli_argv_sanitizing_transport
-      (make_per_call_switch_transport (fun ~sw ->
-         Llm_provider.Transport_codex_cli.create
-           ~sw
-           ~mgr
-           ~config:{ Llm_provider.Transport_codex_cli.default_config with cwd })))
-;;
-
-let () =
-  register_non_http_transport
-    ~kind:Llm_provider.Provider_config.Claude_code
-    ~ctor:claude_code_transport_ctor;
-  register_non_http_transport
-    ~kind:Llm_provider.Provider_config.Gemini_cli
-    ~ctor:gemini_cli_transport_ctor;
-  register_non_http_transport
-    ~kind:Llm_provider.Provider_config.Kimi_cli
-    ~ctor:json_stream_cli_transport_ctor;
-  register_non_http_transport
-    ~kind:Llm_provider.Provider_config.Codex_cli
-    ~ctor:codex_cli_transport_ctor
-;;
-
 let non_http_transport_of_provider = Cascade_transport_non_http_registry.non_http_transport_of_provider

--- a/lib/cascade/cascade_transport_cli_ctors.ml
+++ b/lib/cascade/cascade_transport_cli_ctors.ml
@@ -1,0 +1,178 @@
+(** CLI transport constructors + registration, extracted from
+    [cascade_transport.ml] (godfile decomp).
+
+    Builds on prior cascade extractions:
+    - [Cascade_transport_cli_overrides] (#17393): cli_transport_overrides
+      type + default
+    - [Cascade_transport_non_http_registry] (#17428): registry +
+      register_non_http_transport
+    - [Cascade_transport_cli_config]: provider config readers
+    - [Cascade_transport_cli_argv_sanitize]: make_cli_argv_sanitizing_transport
+    - [Cascade_transport_runtime_policy_provider]: cli_runtime_mcp_jsons
+
+    Contents:
+
+    - [make_per_call_switch_transport factory] — wraps each
+      transport call in its own [Eio.Switch] so leftover pipe/process
+      resources release deterministically at call-end, even for
+      long-lived keepers.
+
+    - [with_proc_mgr f] — pulls [Process_eio.get_proc_mgr ()] and
+      threads it as a [~mgr] arg, surfacing the
+      [invalid_runtime_config "proc_mgr" detail] error if the
+      process manager isn't initialized.
+
+    - 4 transport constructors: [claude_code_transport_ctor],
+      [gemini_cli_transport_ctor], [json_stream_cli_transport_ctor]
+      (used by Kimi CLI), [codex_cli_transport_ctor]. Each reads
+      [cli_transport_overrides] from the caller (falling back to
+      defaults), builds the provider's transport-specific config,
+      and returns a per-call switched transport wrapped in
+      [Process_eio.get_proc_mgr]. The codex ctor additionally
+      wraps in [make_cli_argv_sanitizing_transport] for UTF-8 argv
+      hygiene.
+
+    - Top-level [let () = ...] registration block that wires the 4
+      ctors into [Cascade_transport_non_http_registry] at module
+      load time, keyed by [Llm_provider.Provider_config.Claude_code],
+      [.Gemini_cli], [.Kimi_cli], [.Codex_cli]. The sibling's
+      ordering invariant: this block fires *after* the registry's
+      Hashtbl is created (sibling depends on
+      [Cascade_transport_non_http_registry]), so by the time any
+      caller invokes [non_http_transport_of_provider] at runtime,
+      the registry is populated. *)
+
+module Cli_overrides = Cascade_transport_cli_overrides
+module Cli_config = Cascade_transport_cli_config
+module Cli_argv_sanitize = Cascade_transport_cli_argv_sanitize
+module Runtime_policy_provider = Cascade_transport_runtime_policy_provider
+module Registry = Cascade_transport_non_http_registry
+module Label_resolution = Cascade_transport_label_resolution
+
+let make_per_call_switch_transport
+      (factory : sw:Eio.Switch.t -> Llm_provider.Llm_transport.t)
+  : Llm_provider.Llm_transport.t
+  =
+  let with_call_switch f = Eio.Switch.run (fun sw -> f (factory ~sw)) in
+  { complete_sync =
+      (fun req -> with_call_switch (fun transport -> transport.complete_sync req))
+  ; complete_stream =
+      (fun ?on_telemetry:_ ~on_event req ->
+        with_call_switch (fun transport -> transport.complete_stream ~on_event req))
+  }
+;;
+
+let with_proc_mgr (f : mgr:_ -> Llm_provider.Llm_transport.t) =
+  match Process_eio.get_proc_mgr () with
+  | Error detail -> Error (Label_resolution.invalid_runtime_config "proc_mgr" detail)
+  | Ok mgr -> Ok (f ~mgr)
+;;
+
+let claude_code_transport_ctor
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+      ~runtime_mcp_policy:_
+      ~cli_transport_overrides
+  =
+  let overrides =
+    Option.value ~default:Cli_overrides.default_cli_transport_overrides cli_transport_overrides
+  in
+  let config =
+    { Llm_provider.Transport_claude_code.default_config with
+      model = Cli_config.cli_model_override provider_cfg.model_id
+    ; cwd = overrides.cwd
+    ; mcp_config = overrides.claude_mcp_config
+    ; allowed_tools = Option.value ~default:[] overrides.claude_allowed_tools
+    ; permission_mode = overrides.claude_permission_mode
+    ; max_turns = overrides.claude_max_turns
+    }
+  in
+  with_proc_mgr (fun ~mgr ->
+    make_per_call_switch_transport (fun ~sw ->
+      Llm_provider.Transport_claude_code.create ~sw ~mgr ~config))
+;;
+
+let gemini_cli_transport_ctor
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+      ~runtime_mcp_policy:_
+      ~cli_transport_overrides
+  =
+  let overrides =
+    Option.value ~default:Cli_overrides.default_cli_transport_overrides cli_transport_overrides
+  in
+  let config =
+    { Llm_provider.Transport_gemini_cli.default_config with
+      model = Cli_config.cli_model_override provider_cfg.model_id
+    ; cwd = overrides.cwd
+    ; yolo = Option.value ~default:true overrides.gemini_yolo
+    }
+  in
+  with_proc_mgr (fun ~mgr ->
+    make_per_call_switch_transport (fun ~sw ->
+      Llm_provider.Transport_gemini_cli.create ~sw ~mgr ~config))
+;;
+
+let json_stream_cli_transport_ctor
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+      ~runtime_mcp_policy
+      ~cli_transport_overrides
+  =
+  let cwd = Option.bind cli_transport_overrides (fun overrides -> overrides.Cli_overrides.cwd) in
+  let stdout_idle_timeout_s =
+    Option.bind cli_transport_overrides (fun overrides ->
+      overrides.Cli_overrides.cli_subprocess_idle_sec)
+  in
+  let mcp_config_json = Runtime_policy_provider.cli_runtime_mcp_jsons ~base:[] runtime_mcp_policy in
+  let model = Cli_config.cli_model_for_provider_config provider_cfg in
+  let config_json = Cli_config.cli_runtime_config_json_for_provider provider_cfg in
+  let extra_env = Cli_config.cli_direct_binding_extra_env provider_cfg in
+  let cli_path =
+    Cli_config.cli_command_for_provider_config provider_cfg
+    |> Option.value ~default:Json_stream_cli_transport_local.default_config.cli_path
+  in
+  let process_name = Cli_config.cli_process_name_for_provider_config provider_cfg in
+  let config =
+    { Json_stream_cli_transport_local.default_config with
+      cli_path
+    ; process_name
+    ; model
+    ; cwd
+    ; config_json
+    ; mcp_config_json
+    ; extra_env
+    ; stdout_idle_timeout_s
+    }
+  in
+  with_proc_mgr (fun ~mgr ->
+    make_per_call_switch_transport (fun ~sw ->
+      Json_stream_cli_transport_local.create ~sw ~mgr ~config))
+;;
+
+let codex_cli_transport_ctor
+      ~provider_cfg:_
+      ~runtime_mcp_policy:_
+      ~cli_transport_overrides
+  =
+  let cwd = Option.bind cli_transport_overrides (fun overrides -> overrides.Cli_overrides.cwd) in
+  with_proc_mgr (fun ~mgr ->
+    Cli_argv_sanitize.make_cli_argv_sanitizing_transport
+      (make_per_call_switch_transport (fun ~sw ->
+         Llm_provider.Transport_codex_cli.create
+           ~sw
+           ~mgr
+           ~config:{ Llm_provider.Transport_codex_cli.default_config with cwd })))
+;;
+
+let () =
+  Registry.register_non_http_transport
+    ~kind:Llm_provider.Provider_config.Claude_code
+    ~ctor:claude_code_transport_ctor;
+  Registry.register_non_http_transport
+    ~kind:Llm_provider.Provider_config.Gemini_cli
+    ~ctor:gemini_cli_transport_ctor;
+  Registry.register_non_http_transport
+    ~kind:Llm_provider.Provider_config.Kimi_cli
+    ~ctor:json_stream_cli_transport_ctor;
+  Registry.register_non_http_transport
+    ~kind:Llm_provider.Provider_config.Codex_cli
+    ~ctor:codex_cli_transport_ctor
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane D
- 7th sibling extracted from `cascade_transport.ml` (after #17303, #17333, #17347, #17366, #17393, #17428).
- **Closes the 3-PR chain**: #17393 (cli_overrides) → #17428 (registry+dispatcher) → this PR (ctors+registration).

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/cascade/cascade_transport.ml` | 1187 | 1046 | **-141** |
| `lib/cascade/cascade_transport_cli_ctors.ml` | — | 178 | +178 |

## Moved (verbatim, no behavior change)

### Infrastructure helpers (2)
- `make_per_call_switch_transport factory` — wraps each transport call in a fresh `Eio.Switch.run` so subprocess pipes release at call-end (addresses long-lived keeper resource accumulation). Used by all 4 ctors.
- `with_proc_mgr f` — pulls `Process_eio.get_proc_mgr ()` and threads `~mgr`; surfaces `invalid_runtime_config "proc_mgr" detail` on init failure.

### 4 transport constructors
- `claude_code_transport_ctor` — `Llm_provider.Transport_claude_code` with model + cwd + mcp_config + allowed_tools (default []) + permission_mode + max_turns
- `gemini_cli_transport_ctor` — `Llm_provider.Transport_gemini_cli` with model + cwd + yolo (default true)
- `json_stream_cli_transport_ctor` — `Json_stream_cli_transport_local` (Kimi CLI). Threads `cli_runtime_mcp_jsons` (from `Runtime_policy_provider`), `cli_model_for_provider_config`, `cli_runtime_config_json_for_provider`, `cli_direct_binding_extra_env`, `cli_command_for_provider_config`, `cli_process_name_for_provider_config` (all from `Cli_config`).
- `codex_cli_transport_ctor` — `Llm_provider.Transport_codex_cli` wrapped in `make_cli_argv_sanitizing_transport` (from `Cli_argv_sanitize`) for UTF-8 argv hygiene.

### Registration block
```ocaml
let () =
  Registry.register_non_http_transport ~kind:Claude_code ~ctor:claude_code_transport_ctor;
  Registry.register_non_http_transport ~kind:Gemini_cli  ~ctor:gemini_cli_transport_ctor;
  Registry.register_non_http_transport ~kind:Kimi_cli    ~ctor:json_stream_cli_transport_ctor;
  Registry.register_non_http_transport ~kind:Codex_cli   ~ctor:codex_cli_transport_ctor
;;
```

Fires at sibling module-load time. Module-load ordering invariant: the sibling depends on `Cascade_transport_non_http_registry`, so the Hashtbl is created before this `let () = ...` block executes — registry is populated before any caller invokes `non_http_transport_of_provider` at runtime.

## Parent retains
- `let make_per_call_switch_transport = Cascade_transport_cli_ctors.make_per_call_switch_transport` — preserves `.mli` surface used by `Cascade_runner.ml:206`
- 3 sanitize aliases (verbatim, no behavioral change to these):
  - `sanitize_runtime_mcp_server_for_cli`
  - `sanitize_runtime_mcp_policy_for_cli`
  - `sanitize_cli_completion_request_for_argv` — `.mli`-exposed, used by `test_oas_worker.ml:4660`

## Removed (no external references, only used by the moved cluster)
- `make_cli_argv_sanitizing_transport` alias — sibling calls `Cli_argv_sanitize.*` directly
- `register_non_http_transport` alias — no external callers; only the moved `let () = ...` block used it
- `default_cli_transport_overrides` alias — only used by the moved ctors; sibling references `Cli_overrides.*` directly
- `with_proc_mgr` — now sibling-internal

## Closes the 3-PR chain
| PR | What it extracted | Why it mattered |
|---|---|---|
| #17393 | `cli_transport_overrides` type + `default` | Enabling step — unblocked the `non_http_transport_ctor` type reference |
| #17428 | `non_http_transport` registry + `register` + `dispatcher` | Enabling step — sibling-owned Hashtbl + registration API |
| **#this** | 4 ctors + 2 infra helpers + `let () = ...` block | Final piece — the cluster that referenced both prior siblings |

Combined chain savings: -15 (#17393) + -57 (#17428) + -141 (this) = **-213 LOC across 3 PRs**.

## Sibling deps
- `module Cli_overrides = Cascade_transport_cli_overrides` — `cli_transport_overrides`, `default_cli_transport_overrides`
- `module Cli_config = Cascade_transport_cli_config` — `cli_model_override`, `cli_model_for_provider_config`, `cli_command_for_provider_config`, `cli_process_name_for_provider_config`, `cli_runtime_config_json_for_provider`, `cli_direct_binding_extra_env`
- `module Cli_argv_sanitize = Cascade_transport_cli_argv_sanitize` — `make_cli_argv_sanitizing_transport`
- `module Runtime_policy_provider = Cascade_transport_runtime_policy_provider` — `cli_runtime_mcp_jsons`
- `module Registry = Cascade_transport_non_http_registry` — `register_non_http_transport`
- `module Label_resolution = Cascade_transport_label_resolution` — `invalid_runtime_config`
- `Llm_provider.{Provider_config, Transport_{claude_code,gemini_cli,codex_cli}, Llm_transport}` — extensively
- `Json_stream_cli_transport_local`
- `Process_eio.get_proc_mgr`
- `Eio.Switch.{run, t}`
- Std: `Option.value`, `Option.bind`

No parent-local helpers; no sibling -> parent cycle.

## Record-field qualification note
The sibling's 4 ctors access fields of `cli_transport_overrides` (e.g., `overrides.cwd`, `overrides.cli_subprocess_idle_sec`). In `json_stream_cli_transport_ctor` and `codex_cli_transport_ctor`, where the variable is bound via `Option.bind`, I added explicit `overrides.Cli_overrides.cwd` qualification to disambiguate against any other record with a `cwd` field that might be in scope. The other two ctors (`claude_code`, `gemini_cli`) destructure within an `Option.value ~default:...` context where the type is already determined.

## Local build status
- `dune build --root . lib/cascade/` → clean (exit 0)
- godfile lint: sibling 178 LOC under `new_file_cap=600`; parent 1046 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim 6-function + 1 let-block cluster move via 1 parent alias.

Co-Authored-By: codex <noreply@anthropic.com>
