### PR TITLE
refactor(approval): parse cmd action keys with shared words

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -695,12 +695,6 @@ let read_recent_audit ?base_path ?keeper_name ?(n = 20) () : Yojson.Safe.t list 
         [])
 ;;
 
-module For_testing = struct
-  let reset_audit_store () =
-    Stdlib.Mutex.protect audit_stores_mu (fun () -> Hashtbl.clear audit_stores)
-  ;;
-end
-
 let generate_id () = make_generated_id "appr"
 
 let normalized_input_hash (input : Yojson.Safe.t) =
@@ -708,13 +702,18 @@ let normalized_input_hash (input : Yojson.Safe.t) =
 ;;
 
 let first_cmd_token (cmd : string) =
-  cmd
-  |> String.trim
-  |> String.split_on_char ' '
-  |> List.find_map (fun token ->
-    let trimmed = String.trim token in
-    if trimmed = "" then None else Some trimmed)
+  match Masc_exec.Command_words.stages cmd with
+  | Ok ((token :: _) :: _) -> Some token.Masc_exec.Command_words.value
+  | Ok ([] :: _) | Ok [] | Error _ -> None
 ;;
+
+module For_testing = struct
+  let reset_audit_store () =
+    Stdlib.Mutex.protect audit_stores_mu (fun () -> Hashtbl.clear audit_stores)
+  ;;
+
+  let first_cmd_token = first_cmd_token
+end
 
 let action_key_of_input ~tool_name ~(input : Yojson.Safe.t) =
   match Safe_ops.json_string_opt "op" input with

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -173,6 +173,7 @@ val read_recent_audit :
 
 module For_testing : sig
   val reset_audit_store : unit -> unit
+  val first_cmd_token : string -> string option
 end
 
 (** {1 Submit & await} *)

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -76,6 +76,16 @@ let audit_event_names ~base_path ~keeper_name =
   |> List.map (fun json ->
          Yojson.Safe.Util.(json |> member "event" |> to_string))
 
+let test_first_cmd_token_uses_shared_words () =
+  Alcotest.(check (option string))
+    "quoted command path preserved"
+    (Some "/tmp/bin/gh cli")
+    (AQ.For_testing.first_cmd_token {|"/tmp/bin/gh cli" pr list|});
+  Alcotest.(check (option string))
+    "malformed quote fails closed"
+    None
+    (AQ.For_testing.first_cmd_token {|"/tmp/bin/gh cli pr list|})
+
 let test_approval_queue_failure_metric_labels_site () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1441,6 +1451,8 @@ let () =
         test_approval_queue_cancel_records_terminal_audit;
       Alcotest.test_case "failure observation labels site" `Quick
         test_approval_queue_failure_metric_labels_site;
+      Alcotest.test_case "first cmd token uses shared words" `Quick
+        test_first_cmd_token_uses_shared_words;
       Alcotest.test_case "background pending callback" `Quick
         test_background_pending_callback_and_keeper_lookup;
       Alcotest.test_case "background pending reuses existing entry" `Quick


### PR DESCRIPTION
## Summary
- replace approval queue action-key first-token parsing with Masc_exec.Command_words
- fail closed on malformed command quoting instead of extracting a partial token
- add a focused regression for quoted command paths and malformed quotes

## Verification
- ocamlformat --check lib/keeper/keeper_approval_queue.ml lib/keeper/keeper_approval_queue.mli test/test_hitl_approval.ml
- git diff --check
- bash scripts/lint/shell-legacy-purge-ratchet.sh
- env MASC_DUNE_THROTTLE=0 MASC_OPAM_LOCK=0 MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_LOCAL_JOBS=1 scripts/dune-local.sh build test/test_hitl_approval.exe
  - blocked by current main compile errors outside this change:
    - lib/keeper/keeper_heartbeat_loop_persist_cursor.mli: unbound Keeper_world_observation.message_cursor_update
    - lib/keeper/keeper_agent_run_tool_observation.mli: unbound Agent_sdk.Types.content
- _build/default/test/test_hitl_approval.exe test approval_queue 10
  - passed before rebasing onto the newer broken main; the test exercises only the added approval-token regression