### PR TITLE
fix(keeper): repair extracted mli signatures

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -729,7 +729,6 @@ let run_turn
                    tool_observation.observed_tool_names
                  in
                  observed_tool_names_ref := observed_tool_names;
-                 let tool_names = tool_observation.tool_names in
                  (* RFC-0064: canonicalise observed tool names across all three
                     input surfaces (LLM-native public / MCP protocol /
                     already-internal) before the disclosure check. Without

--- a/lib/keeper/keeper_agent_run_tool_observation.mli
+++ b/lib/keeper/keeper_agent_run_tool_observation.mli
@@ -13,5 +13,5 @@ val analyze
   -> requested_tool_names_seen:string list
   -> tool_usage_before:(string * int) list
   -> tool_calls:Keeper_agent_result.tool_call_detail list
-  -> Agent_sdk.Types.content list
+  -> Agent_sdk.Types.content_block list
   -> observed

--- a/lib/keeper/keeper_heartbeat_loop_persist_cursor.mli
+++ b/lib/keeper/keeper_heartbeat_loop_persist_cursor.mli
@@ -3,5 +3,5 @@
 val persist_message_cursor_updates :
   config:Coord.config ->
   Keeper_types.keeper_meta ->
-  Keeper_world_observation.message_cursor_update list ->
+  (string * int) list ->
   Keeper_types.keeper_meta


### PR DESCRIPTION
## Summary
- fix extracted keeper module interfaces to match implementation/public Agent SDK types
- remove an unused local introduced by the tool-observation extraction

## Verification
- ocamlformat --check lib/keeper/keeper_agent_run_tool_observation.mli lib/keeper/keeper_heartbeat_loop_persist_cursor.mli lib/keeper/keeper_agent_run.ml
- git diff --check
- MASC_DUNE_THROTTLE=0 MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_DUNE_ALLOW_LIVE_BUILD_LOCK=1 MASC_SKIP_PIN_CHECK=1 MASC_SKIP_OPAM_LOCK=1 scripts/dune-local.sh build bin/main_eio.exe test/test_cdal_runtime_health_15748.exe
- _build/default/test/test_cdal_runtime_health_15748.exe