### PR TITLE
refactor(keeper_heartbeat_loop): extract refresh_work_as_heartbeat sibling

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -569,39 +569,7 @@ let run_keepalive_unified_turn
       meta_after_triage)
 ;;
 
-let refresh_work_as_heartbeat
-      ~(ctx : _ context)
-      ~(meta_after_proactive : keeper_meta)
-      ~(proactive_warmup_elapsed : bool)
-      ~(work_as_hb : unit -> bool)
-      ~(last_successful_heartbeat_ts : float ref)
-      ~(consecutive_failures : int ref)
-  : unit
-  =
-  if work_as_hb () && proactive_warmup_elapsed
-  then (
-    let hb_ok =
-      List.exists
-        (fun _room_id ->
-           try
-             ignore
-               (Coord.heartbeat ctx.config ~agent_name:meta_after_proactive.agent_name);
-             true
-           with
-           | Eio.Cancel.Cancelled _ as e -> raise e
-           | exn ->
-             Log.Keeper.debug
-               "heartbeat failed for %s: %s"
-               meta_after_proactive.name
-               (Printexc.to_string exn);
-             false)
-        meta_after_proactive.joined_room_ids
-    in
-    if hb_ok
-    then (
-      last_successful_heartbeat_ts := Time_compat.now ();
-      consecutive_failures := 0))
-;;
+let refresh_work_as_heartbeat = Keeper_heartbeat_loop_refresh_work.refresh_work_as_heartbeat
 
 let dispatch_recurring_keepalive = Keeper_heartbeat_loop_dispatch_recurring.dispatch_recurring_keepalive
 

--- a/lib/keeper/keeper_heartbeat_loop_refresh_work.ml
+++ b/lib/keeper/keeper_heartbeat_loop_refresh_work.ml
@@ -1,0 +1,56 @@
+(** Work-as-heartbeat refresher, extracted from
+    [keeper_heartbeat_loop.ml] (godfile decomp).
+
+    [refresh_work_as_heartbeat] is the keepalive cycle's
+    "implicit heartbeat" path: when the keeper just finished a
+    productive turn (`work_as_hb () = true`) and the proactive warmup
+    has elapsed, we count any successful Coord.heartbeat against any
+    joined room as evidence that the keeper is alive — and reset the
+    consecutive-failure counter accordingly.
+
+    Per-room failure logging is at DEBUG (not WARN) because the
+    *any-success* aggregation policy means a single live room is
+    sufficient; transient per-room misses are expected during room
+    rebalance and shouldn't pollute the WARN stream.
+
+    Cancellation re-raises (preserves Eio cancellation semantics).
+    All other exceptions degrade to a per-room `false` result.
+
+    Pure helper move — no callback injection, no parent-local
+    dependencies. *)
+
+open Keeper_types
+
+let refresh_work_as_heartbeat
+      ~(ctx : _ context)
+      ~(meta_after_proactive : keeper_meta)
+      ~(proactive_warmup_elapsed : bool)
+      ~(work_as_hb : unit -> bool)
+      ~(last_successful_heartbeat_ts : float ref)
+      ~(consecutive_failures : int ref)
+  : unit
+  =
+  if work_as_hb () && proactive_warmup_elapsed
+  then (
+    let hb_ok =
+      List.exists
+        (fun _room_id ->
+           try
+             ignore
+               (Coord.heartbeat ctx.config ~agent_name:meta_after_proactive.agent_name);
+             true
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn ->
+             Log.Keeper.debug
+               "heartbeat failed for %s: %s"
+               meta_after_proactive.name
+               (Printexc.to_string exn);
+             false)
+        meta_after_proactive.joined_room_ids
+    in
+    if hb_ok
+    then (
+      last_successful_heartbeat_ts := Time_compat.now ();
+      consecutive_failures := 0))
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane B
- 7th sibling extracted from `keeper_heartbeat_loop.ml` (after #17296, #17320, #17344, #17373, #17387, #17435).

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/keeper/keeper_heartbeat_loop.ml` | 1096 | 1064 | **-32** |
| `lib/keeper/keeper_heartbeat_loop_refresh_work.ml` | — | 56 | +56 |

## Moved (verbatim, no behavior change)
- `refresh_work_as_heartbeat ~ctx ~meta_after_proactive ~proactive_warmup_elapsed ~work_as_hb ~last_successful_heartbeat_ts ~consecutive_failures` — work-as-heartbeat refresher:
  - **Entry gate**: `work_as_hb () && proactive_warmup_elapsed`. Skips entirely if either is false.
  - **Any-success aggregation**: `List.exists` over `meta_after_proactive.joined_room_ids`, calling `Coord.heartbeat ctx.config ~agent_name:meta.agent_name` for each. A single non-exception result → `hb_ok = true`.
  - **Failure logging**: `Log.Keeper.debug` (not WARN) for per-room failures. Rationale: any-success aggregation makes per-room misses expected during room rebalance; WARN would pollute the stream.
  - **Cancellation safety**: `Eio.Cancel.Cancelled _ as e -> raise e` re-raises.
  - **On hb_ok**: `last_successful_heartbeat_ts := Time_compat.now ()` and `consecutive_failures := 0`.

Parent retains a 1-line alias preserving the `.mli` surface.

## External callers
None. The `.mli` exposes `refresh_work_as_heartbeat` at line 153, but the only caller is the parent's own `run_keepalive_unified_turn` at parent line 1045 (now ~1013 post-splice). The alias preserves the surface for future cross-module use.

## Sibling deps (all external)
- `open Keeper_types` — `'a context`, `keeper_meta`
- `Coord.heartbeat`
- `Eio.Cancel.Cancelled`
- `Log.Keeper.debug`
- `Time_compat.now`
- `Printexc.to_string`
- Std: `List.exists`, `String.equal`

No parent-local helpers; no sibling -> parent cycle.

## Heartbeat-loop trend after 7 extractions
- Pre-sprint baseline: 1465 LOC
- After this PR: 1064 LOC
- **Reduction: -27%** (401 LOC removed)

Cumulative siblings extracted from this file (Lane B): `keepalive_scheduling`, `presence`, `board_events`, `dispatch_recurring_keepalive`, `snapshot_timing` (bundle of 2), `persist_message_cursor_updates`, `refresh_work_as_heartbeat` — 7 siblings.

Remaining bulk: `run_keepalive_unified_turn` (276 LOC), `run_smart_heartbeat_gate` (~196 LOC), `run_keeper_cycle_with_slot` (~147 LOC), `run_heartbeat_loop` (entry point). All are RFC-scale — they orchestrate the keepalive cycle phases with deeply nested closures over local mutable state.

## Local build status
- `dune build --root . lib/keeper/` → clean (exit 0)
- godfile lint: sibling 56 LOC under `new_file_cap=600`; parent 1064 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim single-function move, 1-line parent alias.

Co-Authored-By: codex <noreply@anthropic.com>
