### PR TITLE
fix(ci): repair main OCaml interfaces

### DIFF
--- a/lib/cascade/cascade_transport.ml
+++ b/lib/cascade/cascade_transport.ml
@@ -1023,6 +1023,54 @@ module Json_stream_cli_transport_local = struct
   ;;
 end
 
+let json_stream_cli_transport_ctor
+      ~(provider_cfg : Llm_provider.Provider_config.t)
+      ~runtime_mcp_policy
+      ~cli_transport_overrides
+  =
+  let cwd =
+    Option.bind cli_transport_overrides (fun overrides ->
+      overrides.Cascade_transport_cli_overrides.cwd)
+  in
+  let stdout_idle_timeout_s =
+    Option.bind cli_transport_overrides (fun overrides ->
+      overrides.Cascade_transport_cli_overrides.cli_subprocess_idle_sec)
+  in
+  let mcp_config_json = cli_runtime_mcp_jsons ~base:[] runtime_mcp_policy in
+  let model = cli_model_for_provider_config provider_cfg in
+  let config_json = cli_runtime_config_json_for_provider provider_cfg in
+  let extra_env = cli_direct_binding_extra_env provider_cfg in
+  let cli_path =
+    cli_command_for_provider_config provider_cfg
+    |> Option.value ~default:Json_stream_cli_transport_local.default_config.cli_path
+  in
+  let process_name = cli_process_name_for_provider_config provider_cfg in
+  let config =
+    { Json_stream_cli_transport_local.default_config with
+      cli_path
+    ; process_name
+    ; model
+    ; cwd
+    ; config_json
+    ; mcp_config_json
+    ; extra_env
+    ; stdout_idle_timeout_s
+    }
+  in
+  match Process_eio.get_proc_mgr () with
+  | Error detail -> Error (invalid_runtime_config "proc_mgr" detail)
+  | Ok mgr ->
+    Ok
+      (Cascade_transport_cli_ctors.make_per_call_switch_transport (fun ~sw ->
+         Json_stream_cli_transport_local.create ~sw ~mgr ~config))
+;;
+
+let () =
+  Cascade_transport_non_http_registry.register_non_http_transport
+    ~kind:Llm_provider.Provider_config.Kimi_cli
+    ~ctor:json_stream_cli_transport_ctor
+;;
+
 (* CLI transport constructors + per-call switch wrapping + ctor
    registration extracted to [Cascade_transport_cli_ctors]
    (godfile decomp). The sibling's top-level [let () = ...]

--- a/lib/cascade/cascade_transport_cli_ctors.ml
+++ b/lib/cascade/cascade_transport_cli_ctors.ml
@@ -45,7 +45,6 @@
 module Cli_overrides = Cascade_transport_cli_overrides
 module Cli_config = Cascade_transport_cli_config
 module Cli_argv_sanitize = Cascade_transport_cli_argv_sanitize
-module Runtime_policy_provider = Cascade_transport_runtime_policy_provider
 module Registry = Cascade_transport_non_http_registry
 module Label_resolution = Cascade_transport_label_resolution
 
@@ -111,42 +110,6 @@ let gemini_cli_transport_ctor
       Llm_provider.Transport_gemini_cli.create ~sw ~mgr ~config))
 ;;
 
-let json_stream_cli_transport_ctor
-      ~(provider_cfg : Llm_provider.Provider_config.t)
-      ~runtime_mcp_policy
-      ~cli_transport_overrides
-  =
-  let cwd = Option.bind cli_transport_overrides (fun overrides -> overrides.Cli_overrides.cwd) in
-  let stdout_idle_timeout_s =
-    Option.bind cli_transport_overrides (fun overrides ->
-      overrides.Cli_overrides.cli_subprocess_idle_sec)
-  in
-  let mcp_config_json = Runtime_policy_provider.cli_runtime_mcp_jsons ~base:[] runtime_mcp_policy in
-  let model = Cli_config.cli_model_for_provider_config provider_cfg in
-  let config_json = Cli_config.cli_runtime_config_json_for_provider provider_cfg in
-  let extra_env = Cli_config.cli_direct_binding_extra_env provider_cfg in
-  let cli_path =
-    Cli_config.cli_command_for_provider_config provider_cfg
-    |> Option.value ~default:Json_stream_cli_transport_local.default_config.cli_path
-  in
-  let process_name = Cli_config.cli_process_name_for_provider_config provider_cfg in
-  let config =
-    { Json_stream_cli_transport_local.default_config with
-      cli_path
-    ; process_name
-    ; model
-    ; cwd
-    ; config_json
-    ; mcp_config_json
-    ; extra_env
-    ; stdout_idle_timeout_s
-    }
-  in
-  with_proc_mgr (fun ~mgr ->
-    make_per_call_switch_transport (fun ~sw ->
-      Json_stream_cli_transport_local.create ~sw ~mgr ~config))
-;;
-
 let codex_cli_transport_ctor
       ~provider_cfg:_
       ~runtime_mcp_policy:_
@@ -169,9 +132,6 @@ let () =
   Registry.register_non_http_transport
     ~kind:Llm_provider.Provider_config.Gemini_cli
     ~ctor:gemini_cli_transport_ctor;
-  Registry.register_non_http_transport
-    ~kind:Llm_provider.Provider_config.Kimi_cli
-    ~ctor:json_stream_cli_transport_ctor;
   Registry.register_non_http_transport
     ~kind:Llm_provider.Provider_config.Codex_cli
     ~ctor:codex_cli_transport_ctor

--- a/lib/cascade/cascade_transport_cli_ctors.mli
+++ b/lib/cascade/cascade_transport_cli_ctors.mli
@@ -1,0 +1,4 @@
+(** CLI transport constructors and registration side effects. *)
+
+val make_per_call_switch_transport :
+  (sw:Eio.Switch.t -> Llm_provider.Llm_transport.t) -> Llm_provider.Llm_transport.t

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -729,7 +729,6 @@ let run_turn
                    tool_observation.observed_tool_names
                  in
                  observed_tool_names_ref := observed_tool_names;
-                 let tool_names = tool_observation.tool_names in
                  (* RFC-0064: canonicalise observed tool names across all three
                     input surfaces (LLM-native public / MCP protocol /
                     already-internal) before the disclosure check. Without

--- a/lib/keeper/keeper_agent_run_tool_observation.mli
+++ b/lib/keeper/keeper_agent_run_tool_observation.mli
@@ -13,5 +13,5 @@ val analyze
   -> requested_tool_names_seen:string list
   -> tool_usage_before:(string * int) list
   -> tool_calls:Keeper_agent_result.tool_call_detail list
-  -> Agent_sdk.Types.content list
+  -> Agent_sdk.Types.content_block list
   -> observed

--- a/lib/keeper/keeper_heartbeat_loop_persist_cursor.mli
+++ b/lib/keeper/keeper_heartbeat_loop_persist_cursor.mli
@@ -3,5 +3,5 @@
 val persist_message_cursor_updates :
   config:Coord.config ->
   Keeper_types.keeper_meta ->
-  Keeper_world_observation.message_cursor_update list ->
+  (string * int) list ->
   Keeper_types.keeper_meta

--- a/lib/operator/operator_control_snapshot_action_log.mli
+++ b/lib/operator/operator_control_snapshot_action_log.mli
@@ -1,0 +1,36 @@
+(** Operator action-log persistence and dashboard projection. *)
+
+type action_result_status =
+  | ActionOk
+  | ActionError
+
+val action_result_status_to_string : action_result_status -> string
+
+type confirmation_state =
+  | Preview
+  | Immediate
+  | Expired
+  | Denied
+  | Confirmed
+
+val confirmation_state_to_string : confirmation_state -> string
+
+type action_log_entry =
+  { trace_id : string
+  ; actor : string
+  ; remote_session_id : string option
+  ; remote_client_type : string
+  ; action_type : string
+  ; target_type : string
+  ; target_id : string option
+  ; delegated_tool : string
+  ; confirmation_state : confirmation_state
+  ; result_status : action_result_status
+  ; latency_ms : int
+  ; created_at : string
+  }
+
+val action_log_path : Coord.config -> string
+val action_log_entry_to_yojson : action_log_entry -> Yojson.Safe.t
+val append_action_log : Coord.config -> action_log_entry -> unit
+val recent_actions_json : Coord.config -> Yojson.Safe.t

--- a/lib/server/server_dashboard_http_core_batch.mli
+++ b/lib/server/server_dashboard_http_core_batch.mli
@@ -1,0 +1,3 @@
+(** Dashboard batch-JSON snapshot for the operator dashboard. *)
+
+val dashboard_batch_json : ?compact:bool -> Coord.config -> Yojson.Safe.t


### PR DESCRIPTION
## Summary
- repair stale SDK/content interface types in keeper agent-run helpers
- add missing sibling interfaces for newly extracted cascade/operator/dashboard modules
- keep Kimi json-stream registration beside the parent nested transport module instead of referencing that nested module from the extracted ctor sibling

## Verification
- ocamlformat --check lib/cascade/cascade_transport.ml lib/cascade/cascade_transport_cli_ctors.ml lib/cascade/cascade_transport_cli_ctors.mli lib/keeper/keeper_agent_run_tool_observation.mli lib/keeper/keeper_heartbeat_loop_persist_cursor.mli lib/keeper/keeper_agent_run.ml lib/server/server_dashboard_http_core_batch.mli lib/operator/operator_control_snapshot_action_log.mli
- scripts/ocaml-structure-ratchet.sh
- git diff --check
- env DUNE_CACHE=disabled MASC_DUNE_THROTTLE=0 MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_OPAM_LOCK=0 MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build lib/masc_mcp.cma