### PR TITLE
refactor(server_dashboard_http_core): extract shell bootstrap + paths JSON sibling

### DIFF
--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -334,46 +334,8 @@ let clear_meta_cognition_warm_flag = Server_dashboard_http_core_meta_cognition.c
 let schedule_meta_cognition_summary_warm = Server_dashboard_http_core_meta_cognition.schedule_meta_cognition_summary_warm
 let meta_cognition_summary_cached = Server_dashboard_http_core_meta_cognition.meta_cognition_summary_cached
 
-let dashboard_shell_paths_json (config : Coord.config) : Yojson.Safe.t =
-  Server_base_path_diagnostics.detect
-    ?input_base_path:((Host_config.from_env ()).base_path_raw)
-    ?env_masc_base_path:((Host_config.from_env ()).base_path_raw)
-    ~effective_base_path:config.base_path
-    ~effective_masc_root:(Coord.masc_root_dir config)
-    ()
-  |> Server_base_path_diagnostics.to_yojson
-;;
-
-let dashboard_shell_bootstrap_json (config : Coord.config) : Yojson.Safe.t =
-  let generated_at = Masc_domain.now_iso () in
-  let started_at = Unix.gettimeofday () in
-  `Assoc
-    [ "generated_at", `String generated_at
-    ; ( "status"
-      , `Assoc [ "project", `String "initializing"; "generated_at", `String generated_at ]
-      )
-    ; "paths", dashboard_shell_paths_json config
-    ; ( "counts"
-      , `Assoc
-          [ "agents", `Int 0
-          ; "tasks", `Int 0
-          ; "keepers", `Int 0
-          ; "total_runtimes", `Int 0
-          ] )
-    ; "configured_keepers", `Int 0
-    ; "providers", `Assoc []
-    ; "meta_cognition", `Null
-    ; "config_resolution", `Null
-    ; "runtime_resolution", `Null
-    ]
-  |> with_projection_diagnostics
-       ~surface:"shell"
-       ~started_at
-       ~extra:
-         [ "cache_state", `String "initializing"
-         ; "bootstrap_source", `String "shell_prewarm"
-         ]
-;;
+let dashboard_shell_paths_json = Server_dashboard_http_core_shell_bootstrap.dashboard_shell_paths_json
+let dashboard_shell_bootstrap_json = Server_dashboard_http_core_shell_bootstrap.dashboard_shell_bootstrap_json
 
 let dashboard_shell_last_good_with_source ~light () =
   let full_last_good () =

--- a/lib/server/server_dashboard_http_core_shell_bootstrap.ml
+++ b/lib/server/server_dashboard_http_core_shell_bootstrap.ml
@@ -1,0 +1,63 @@
+(** Dashboard shell bootstrap + paths JSON helpers, extracted from
+    [server_dashboard_http_core.ml] (godfile decomp).
+
+    Two helpers shipped as a bundle because [dashboard_shell_bootstrap_json]
+    embeds the [dashboard_shell_paths_json] result, and both are the
+    pre-warm path for the operator dashboard's shell surface:
+
+    - [dashboard_shell_paths_json config] — discovers the resolution of
+      the operator's base path through
+      [Server_base_path_diagnostics.detect], threading both the
+      env-resolved [Host_config.from_env ()] inputs and the
+      effective config-derived paths. Returns the canonical
+      diagnostics record as JSON.
+
+    - [dashboard_shell_bootstrap_json config] — the "initializing"
+      payload returned by the shell surface before any keeper data
+      is available. Pins `project="initializing"`, zero counts for
+      agents/tasks/keepers/total_runtimes, empty providers map, and
+      null meta_cognition/config_resolution/runtime_resolution. The
+      caller wraps via [with_projection_diagnostics] tagged
+      `surface="shell"` with `cache_state="initializing"` and
+      `bootstrap_source="shell_prewarm"`. *)
+
+let dashboard_shell_paths_json (config : Coord.config) : Yojson.Safe.t =
+  Server_base_path_diagnostics.detect
+    ?input_base_path:((Host_config.from_env ()).base_path_raw)
+    ?env_masc_base_path:((Host_config.from_env ()).base_path_raw)
+    ~effective_base_path:config.base_path
+    ~effective_masc_root:(Coord.masc_root_dir config)
+    ()
+  |> Server_base_path_diagnostics.to_yojson
+;;
+
+let dashboard_shell_bootstrap_json (config : Coord.config) : Yojson.Safe.t =
+  let generated_at = Masc_domain.now_iso () in
+  let started_at = Unix.gettimeofday () in
+  `Assoc
+    [ "generated_at", `String generated_at
+    ; ( "status"
+      , `Assoc [ "project", `String "initializing"; "generated_at", `String generated_at ]
+      )
+    ; "paths", dashboard_shell_paths_json config
+    ; ( "counts"
+      , `Assoc
+          [ "agents", `Int 0
+          ; "tasks", `Int 0
+          ; "keepers", `Int 0
+          ; "total_runtimes", `Int 0
+          ] )
+    ; "configured_keepers", `Int 0
+    ; "providers", `Assoc []
+    ; "meta_cognition", `Null
+    ; "config_resolution", `Null
+    ; "runtime_resolution", `Null
+    ]
+  |> Server_dashboard_http_core_cache.with_projection_diagnostics
+       ~surface:"shell"
+       ~started_at
+       ~extra:
+         [ "cache_state", `String "initializing"
+         ; "bootstrap_source", `String "shell_prewarm"
+         ]
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane C
- 7th sibling extracted from `server_dashboard_http_core.ml` (after #17337, #17358, #17384, #17389, #17422, #17451).
- **Bundle extraction** — two pre-warm helpers shipped together because they form a single concern (operator dashboard "initializing" payload + base-path diagnostics).

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/server/server_dashboard_http_core.ml` | 867 | 829 | **-38** |
| `lib/server/server_dashboard_http_core_shell_bootstrap.ml` | — | 63 | +63 |

## Moved (verbatim, no behavior change)

### `dashboard_shell_paths_json config`
- Calls `Server_base_path_diagnostics.detect` threading:
  - `?input_base_path:((Host_config.from_env ()).base_path_raw)`
  - `?env_masc_base_path:((Host_config.from_env ()).base_path_raw)`
  - `~effective_base_path:config.base_path`
  - `~effective_masc_root:(Coord.masc_root_dir config)`
- Pipes through `Server_base_path_diagnostics.to_yojson`

### `dashboard_shell_bootstrap_json config`
- Emits the "initializing" payload returned by the shell surface before any keeper data is available
- Pins fields:
  - `generated_at`, `status.project="initializing"`, `status.generated_at`
  - `paths` ← inline `dashboard_shell_paths_json config`
  - `counts.{agents,tasks,keepers,total_runtimes} = 0`
  - `configured_keepers = 0`
  - `providers = {}`, `meta_cognition = null`, `config_resolution = null`, `runtime_resolution = null`
- Wraps via `Server_dashboard_http_core_cache.with_projection_diagnostics`:
  - `surface = "shell"`
  - `extra = [cache_state="initializing"; bootstrap_source="shell_prewarm"]`

Parent retains 2 single-line aliases.

## Bundling rationale
The two helpers form a single concern (shell pre-warm) and `bootstrap_json` embeds `paths_json`'s result inline. Splitting into two siblings would duplicate the dependency surface (same `Coord.config` parameter, same surface tag) without semantic benefit.

## Internal callers (all keep working unchanged via parent aliases)
- `dashboard_shell_payload_json` at parent line 577 → `paths_json`
- `dashboard_shell_http_json` at parent line 797 → `bootstrap_json`

## External callers
None. Neither helper is `.mli`-exposed; both are internal helpers. The parent aliases preserve the surface for any future cross-module use.

## Sibling deps
- `Server_base_path_diagnostics.{detect, to_yojson}`
- `Host_config.from_env`
- `Coord.{config, masc_root_dir}`
- `Server_dashboard_http_core_cache.with_projection_diagnostics` — qualified (1 name used; qualified-vs-include policy)
- `Masc_domain.now_iso`
- Std: `Unix.gettimeofday`

No parent-local helpers; no sibling -> parent cycle.

## CI hardening verification
Neither `dashboard_shell_paths_json` nor `dashboard_shell_bootstrap_json` is pinned by any `file_contains_pattern` assertion in `test/test_ci_hardening_source.ml`. The CI-pinned items in this parent (mission refresh trio: `let start_mission_refresh_loop` + `Dashboard_mission.json ~config ~sw ~clock ~proc_mgr ()` + `let dashboard_mission_http_json` + `let compute ?actor () =`; and `let dashboard_shell_http_json ?clock`) remain untouched.

## Local build status
- `dune build --root . lib/server/` → clean (exit 0)
- godfile lint: sibling 63 LOC under `new_file_cap=600`; parent 829 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim 2-helper bundle move via 2 parent aliases.

Co-Authored-By: codex <noreply@anthropic.com>
