### PR TITLE
refactor(operator): drop root target aliases

### DIFF
--- a/lib/dashboard/dashboard_mission.ml
+++ b/lib/dashboard/dashboard_mission.ml
@@ -235,15 +235,12 @@ let rec evidence_preview_strings json =
       fields |> List.map snd |> List.concat_map evidence_preview_strings |> dedup_strings |> take 4
   | _ -> []
 
-(* Issue #8395: [Operator_digest] canonicalizes root-level attention to
-   [target_type="root"] but also accepts the aliases "namespace" and
-   "room" via [Operator_digest_types.is_root_alias]. This predicate
-   previously compared only to the literal "room", so root-level
-   incidents (the canonical form) fell through to the public queue.
-   Delegate to the shared alias check so every root variant is treated
-   as internal attention — identical to [Dashboard_mission_assembly]. *)
+(* Issue #8395: root-level attention uses [target_type="root"].  This
+   predicate previously compared only to the literal "room", so the
+   canonical form fell through to the public queue.  Delegate to the
+   shared canonical target check used by [Dashboard_mission_assembly]. *)
 let is_internal_attention incident =
-  Operator_digest_types.is_root_alias (string_field "target_type" incident)
+  Operator_digest_types.is_root_target_type (string_field "target_type" incident)
 
 let related_sessions_for_attention incident sessions =
   let direct_session =

--- a/lib/dashboard/dashboard_mission_assembly.ml
+++ b/lib/dashboard/dashboard_mission_assembly.ml
@@ -127,10 +127,10 @@ let identity_digest prefix identity =
   Printf.sprintf "%s:%s" prefix (Digest.to_hex (Digest.string identity))
 
 let is_internal_attention incident =
-  Operator_digest_types.is_root_alias (string_field "target_type" incident)
+  Operator_digest_types.is_root_target_type (string_field "target_type" incident)
 
 let is_internal_action action =
-  Operator_digest_types.is_root_alias (string_field "target_type" action)
+  Operator_digest_types.is_root_target_type (string_field "target_type" action)
 
 let incident_action_types kind =
   match kind with

--- a/lib/keeper/keeper_heartbeat_loop_refresh_work.mli
+++ b/lib/keeper/keeper_heartbeat_loop_refresh_work.mli
@@ -1,0 +1,12 @@
+(** Work-as-heartbeat refresher for keeper heartbeat loop state. *)
+
+val refresh_work_as_heartbeat :
+  ctx:_ Keeper_types.context ->
+  meta_after_proactive:Keeper_types.keeper_meta ->
+  proactive_warmup_elapsed:bool ->
+  work_as_hb:(unit -> bool) ->
+  last_successful_heartbeat_ts:float ref ->
+  consecutive_failures:int ref ->
+  unit
+(** Treat recent productive work as heartbeat evidence when a regular
+    heartbeat succeeds for any joined room. *)

--- a/lib/operator/operator_control_action.ml
+++ b/lib/operator/operator_control_action.ml
@@ -15,7 +15,7 @@ let normalize_judgment_surface value =
 
 let normalize_judgment_target_type value =
   let normalized = String.trim value |> String.lowercase_ascii in
-  if Operator_digest_types.is_root_alias normalized then
+  if Operator_digest_types.is_root_target_type normalized then
     Ok ("root", Operator_judgment.Coord)
   else Error "target_type must be root"
 
@@ -114,7 +114,7 @@ let canonical_action_type action_type = action_type
 
 let normalize_action_target_type target_type =
   let normalized = String.trim target_type |> String.lowercase_ascii in
-  if Operator_digest_types.is_root_alias normalized then Ok "root"
+  if Operator_digest_types.is_root_target_type normalized then Ok "root"
   else match normalized with
   | "keeper" as value -> Ok value
   | "" -> Ok ""

--- a/lib/operator/operator_control_action.mli
+++ b/lib/operator/operator_control_action.mli
@@ -29,8 +29,7 @@ val judgment_write_json :
     {!Operator_judgment} entry parsed from [args].  Required fields:
 
     - [surface]: ["command.namespace"] or ["intervene"].
-    - [target_type]: any root alias (see
-      {!Operator_digest_types.is_root_alias}).
+    - [target_type]: ["root"].
     - [summary] (non-empty after trim).
 
     Optional: [target_id], [fresh_ttl_sec] (default 60s for

--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -305,5 +305,3 @@ let digest_json ?actor ?target_type ?target_id:_target_id ?include_workers:_incl
             @ [ ("recent_reviews", recent_reviews) ]
             @ active_guidance))
     | _ -> Error "unsupported target_type"
-(* Note: normalize_digest_target_type accepts "root"/"namespace"/"room" and
-   returns canonical "root" — the match above only needs the canonical case. *)

--- a/lib/operator/operator_digest_guidance.ml
+++ b/lib/operator/operator_digest_guidance.ml
@@ -10,7 +10,7 @@ let normalize_target_type value =
   String.trim value |> String.lowercase_ascii
 
 let judgment_surface_for_target_type target_type =
-  if Operator_digest_types.is_root_alias target_type then Some "command.namespace"
+  if Operator_digest_types.is_root_target_type target_type then Some "command.namespace"
   else None
 
 let fresh_operator_judgment config ~target_type ~target_id =

--- a/lib/operator/operator_digest_types.ml
+++ b/lib/operator/operator_digest_types.ml
@@ -175,18 +175,13 @@ let summary_of_recommendations ~actor (items : recommended_action list) =
       ("authoritative", `Bool false);
     ]
 
-(** [is_root_alias v] is true when [v] matches the canonical "root" target
-    type or its backward-compat aliases "namespace"/"room". *)
-let is_root_alias value =
-  String.equal value "root"
-  || String.equal value "namespace"
-  || String.equal value "room"
+(** [is_root_target_type v] is true when [v] matches the canonical "root" target type. *)
+let is_root_target_type value = String.equal value "root"
 
 let normalize_digest_target_type value =
   match value with
   | Some raw ->
       let normalized = String.trim raw |> String.lowercase_ascii in
-      if is_root_alias normalized then Ok "root"
+      if is_root_target_type normalized then Ok "root"
       else Error "target_type must be root"
   | None -> Ok "root"
-

--- a/lib/operator/operator_digest_types.mli
+++ b/lib/operator/operator_digest_types.mli
@@ -84,10 +84,9 @@ val summary_of_recommendations :
 
 (** {1 Target type normalisation} *)
 
-(** [true] for canonical ["root"] and its backward-compat aliases
-    ["namespace"] and ["room"]. *)
-val is_root_alias : string -> bool
+(** [true] for the canonical ["root"] target type. *)
+val is_root_target_type : string -> bool
 
 (** Accepts [None] → [Ok "root"]; [Some raw] is trimmed + lowercased, then
-    checked via {!is_root_alias}. Otherwise [Error "target_type must be root"]. *)
+    checked via {!is_root_target_type}. Otherwise [Error "target_type must be root"]. *)
 val normalize_digest_target_type : string option -> (string, string) result

--- a/lib/operator/operator_judgment.ml
+++ b/lib/operator/operator_judgment.ml
@@ -31,7 +31,7 @@ let target_type_to_string = function
   | Coord -> "root"
 
 let target_type_of_string = function
-  | "root" | "room" | "namespace" -> Some Coord
+  | "root" -> Some Coord
   | _ -> None
 
 let option_to_yojson = Json_util.option_to_yojson

--- a/lib/operator/operator_judgment.mli
+++ b/lib/operator/operator_judgment.mli
@@ -51,18 +51,12 @@ type record = {
 (** {1 target_type codec} *)
 
 val target_type_to_string : target_type -> string
-(** [Coord -> "root"].  Pinned literal — JSONL files persisted
-    under earlier process versions must continue to parse. *)
+(** [Coord -> "root"].  Pinned literal for the on-disk JSONL format. *)
 
 val target_type_of_string : string -> target_type option
-(** Accepts three legacy aliases for [Coord]:
-    [["root"]] / [["room"]] / [["namespace"]].  All three
-    decay to the same target type because the operator
-    judgment surface unified its naming over the
-    [namespace -> room -> root] migration arc.  A future
-    "drop legacy aliases" PR must touch this contract — the
-    aliases are part of the persisted-data backward-compat
-    seam. *)
+(** Accepts only the canonical [["root"]] target type for [Coord].
+    Historical [["room"]] / [["namespace"]] aliases are rejected at
+    the parse boundary. *)
 
 (** {1 JSON codec} *)
 

--- a/lib/server/server_dashboard_http_core_operator_digest_http.ml
+++ b/lib/server/server_dashboard_http_core_operator_digest_http.ml
@@ -4,9 +4,8 @@
     [operator_digest_http_json] is the GET handler backing the
     operator dashboard's digest surface. Two paths:
 
-    1. **Default namespace request** (no actor, no target_id, no
-       include_workers override, target_type omitted or one of
-       root/namespace/room) — serves the cached
+    1. **Default root request** (no actor, no target_id, no
+       include_workers override, target_type omitted or [root]) — serves the cached
        [operator_digest_cache] surface immediately (0ms), decorated
        with the default query metadata.
 
@@ -54,10 +53,10 @@ let operator_digest_http_json ~state ~sw ~clock request =
     | Some ("1" | "true" | "yes") -> Some true
     | _ -> None
   in
-  let namespace_target_type value =
+  let root_target_type value =
     match Option.map (fun raw -> String.lowercase_ascii (String.trim raw)) value with
     | None -> true
-    | Some "root" | Some "namespace" | Some "room" -> true
+    | Some "root" -> true
     | Some _ -> false
   in
   let effective_target_type = Option.value ~default:"root" target_type in
@@ -65,7 +64,7 @@ let operator_digest_http_json ~state ~sw ~clock request =
     actor = None
     && target_id = None
     && include_workers = None
-    && namespace_target_type target_type
+    && root_target_type target_type
   in
   let query =
     Core_operator_query.operator_digest_query_json

--- a/lib/tool_operator.ml
+++ b/lib/tool_operator.ml
@@ -89,7 +89,7 @@ let snapshot_schema ~remote =
         ];
   }
 
-let digest_target_type_enums = [ `String "root"; `String "namespace" ]
+let digest_target_type_enums = [ `String "root" ]
 let judgment_surface_enums =
   [
     `String "command.namespace";

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -106,12 +106,16 @@ let () =
             `Quick
             Test_operator_control_judgment
             .test_operator_judgment_write_and_latest_roundtrip;
+          Alcotest.test_case
+            "operator judgment rejects retired target type aliases" `Quick
+            Test_operator_control_judgment
+            .test_operator_judgment_rejects_retired_target_type_aliases;
           Alcotest.test_case "task inject immediate flow" `Quick
             Test_operator_control_actions
             .test_task_inject_executes_immediately;
-          Alcotest.test_case "digest defaults to namespace target" `Quick
+          Alcotest.test_case "digest defaults to root target" `Quick
             Test_operator_control_actions
-            .test_digest_defaults_to_namespace_target;
+            .test_digest_defaults_to_root_target;
           Alcotest.test_case "operator action rejects legacy aliases" `Quick
             Test_operator_control_actions
             .test_operator_action_rejects_legacy_action_aliases;

--- a/test/test_operator_control_actions.ml
+++ b/test/test_operator_control_actions.ml
@@ -70,7 +70,7 @@ let test_task_inject_executes_immediately () =
             [
               ("actor", `String "operator");
               ("action_type", `String "task_inject");
-              ("target_type", `String "namespace");
+              ("target_type", `String "root");
               ( "payload",
                 `Assoc
                   [
@@ -100,7 +100,7 @@ let test_task_inject_executes_immediately () =
       let tasks = Coord.get_tasks_raw config in
       Alcotest.(check int) "task injected" 1 (List.length tasks))
 
-let test_digest_defaults_to_namespace_target () =
+let test_digest_defaults_to_root_target () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
   Eio.Switch.run @@ fun sw ->

--- a/test/test_operator_control_confirm.ml
+++ b/test/test_operator_control_confirm.ml
@@ -28,7 +28,7 @@ let test_confirm_rejects_expired_token () =
                        ("trace_id", `String "ops_expired");
                        ("actor", `String "operator");
                        ("action_type", `String "namespace_pause");
-                       ("target_type", `String "namespace");
+                       ("target_type", `String "root");
                        ("target_id", `Null);
                        ("payload", `Assoc []);
                        ("delegated_tool", `String "masc_pause");

--- a/test/test_operator_control_judgment.ml
+++ b/test/test_operator_control_judgment.ml
@@ -22,7 +22,7 @@ let test_digest_room_prefers_fresh_operator_judgment () =
             [
               ("action_kind", `String "pause_room");
               ("resolved_tool", `String "masc_operator_confirm");
-              ("target_type", `String "namespace");
+              ("target_type", `String "root");
               ("target_id", `Null);
               ("reason", `String "operator judge requires manual gate");
               ("payload_preview", `Assoc [ ("reason", `String "manual review") ]);
@@ -136,7 +136,7 @@ let test_operator_judgment_write_and_latest_roundtrip () =
             (`Assoc
               [
                 ("surface", `String "command.namespace");
-                ("target_type", `String "namespace");
+                ("target_type", `String "root");
                 ("summary", `String "Operator judge requests a human checkpoint.");
                 ("confidence", `Float 0.88);
                 ("fresh_ttl_sec", `Int 90);
@@ -151,7 +151,7 @@ let test_operator_judgment_write_and_latest_roundtrip () =
       let latest =
         match
           Operator_control.judgment_latest_json ctx
-            (`Assoc [ ("surface", `String "command.namespace"); ("target_type", `String "namespace") ])
+            (`Assoc [ ("surface", `String "command.namespace"); ("target_type", `String "root") ])
         with
         | Ok json -> json
         | Error err -> Alcotest.fail err
@@ -161,6 +161,44 @@ let test_operator_judgment_write_and_latest_roundtrip () =
       Alcotest.(check string) "latest summary"
         "Operator judge requests a human checkpoint."
         Yojson.Safe.Util.(latest |> member "judgment" |> member "summary" |> to_string))
+
+let test_operator_judgment_rejects_retired_target_type_aliases () =
+  Alcotest.(check bool)
+    "namespace no longer parses"
+    true
+    (Option.is_none (Operator_judgment.target_type_of_string "namespace"));
+  Alcotest.(check bool)
+    "room no longer parses"
+    true
+    (Option.is_none (Operator_judgment.target_type_of_string "room"));
+  Alcotest.(check (result string string))
+    "digest rejects namespace"
+    (Error "target_type must be root")
+    (Operator_digest_types.normalize_digest_target_type (Some "namespace"));
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator-judge"));
+      let ctx = operator_ctx env sw config "operator-judge" in
+      match
+        Operator_control.judgment_write_json ctx
+          (`Assoc
+            [
+              ("surface", `String "command.namespace");
+              ("target_type", `String "namespace");
+              ("summary", `String "Retired alias must be rejected.");
+            ])
+      with
+      | Ok _ -> Alcotest.fail "namespace target_type should be rejected"
+      | Error err ->
+          Alcotest.(check string)
+            "write rejects namespace"
+            "target_type must be root" err)
 
 let test_confirm_keeps_pending_token_when_delegated_action_fails () =
   Eio_main.run @@ fun env ->
@@ -183,7 +221,7 @@ let test_confirm_keeps_pending_token_when_delegated_action_fails () =
             ("trace_id", `String "trace-retry");
             ("actor", `String "operator");
             ("action_type", `String "missing_action_type");
-            ("target_type", `String "namespace");
+            ("target_type", `String "root");
             ("target_id", `Null);
             ("payload", `Assoc []);
             ("delegated_tool", `String "missing_operator_tool");

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -747,7 +747,7 @@ let test_snapshot_pending_confirm_summary_tracks_actor_scope () =
               [
                 ("actor", `String actor);
                 ("action_type", `String "namespace_pause");
-                ("target_type", `String "namespace");
+                ("target_type", `String "root");
               ])
         with
         | Ok _ -> ()
@@ -1241,7 +1241,7 @@ let test_digest_room_exposes_pending_confirm_attention () =
             [
               ("actor", `String "operator");
                ("action_type", `String "namespace_pause");
-               ("target_type", `String "namespace");
+               ("target_type", `String "root");
             ])
       in
       (match action_json with Ok _ -> () | Error err -> Alcotest.fail err);

--- a/test/test_transport_coverage.ml
+++ b/test/test_transport_coverage.ml
@@ -539,7 +539,7 @@ let test_rest_parse_request_operator_digest () =
   let req =
     Transport.Rest.parse_request ~http_method:"GET"
       ~path:"/api/v1/operator/digest"
-      ~query_params:[ ("target_type", `String "namespace") ] ~body:""
+      ~query_params:[ ("target_type", `String "root") ] ~body:""
   in
   check string "method_name" "masc_operator_digest" req.method_name
 


### PR DESCRIPTION
## Summary
- remove operator judgment/digest target_type aliases for namespace/room; only root is accepted now
- remove namespace from operator digest/judgment tool schema enums and default digest HTTP cache eligibility
- add regression coverage that retired target_type aliases are rejected
- include current keeper heartbeat helper .mli catchup required by the structure ratchet

## Verification
- opam exec -- ocamlformat --check lib/dashboard/dashboard_mission.ml lib/dashboard/dashboard_mission_assembly.ml lib/operator/operator_judgment.ml lib/operator/operator_judgment.mli lib/operator/operator_digest_types.ml lib/operator/operator_digest_types.mli lib/operator/operator_digest_guidance.ml lib/operator/operator_control_action.ml lib/operator/operator_control_action.mli lib/operator/operator_digest.ml lib/tool_operator.ml lib/server/server_dashboard_http_core_operator_digest_http.ml test/test_operator_control.ml test/test_operator_control_actions.ml test/test_operator_control_confirm.ml test/test_operator_control_judgment.ml test/test_operator_control_snapshot.ml test/test_transport_coverage.ml
- scripts/ocaml-structure-ratchet.sh
- git diff --check
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_operator_control.exe test/test_transport_coverage.exe
- ./_build/default/test/test_operator_control.exe test --color=never --show-errors operator 25-29
- ./_build/default/test/test_transport_coverage.exe test --color=never --show-errors 'rest.parse_request' 4