### PR TITLE
refactor(operator_control_snapshot): extract snapshot_cache TTL subsystem sibling

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -669,97 +669,11 @@ let valid_snapshot_view_strings = Operator_control_snapshot_view.valid_snapshot_
 let snapshot_view_of_string_opt = Operator_control_snapshot_view.snapshot_view_of_string_opt
 let parse_snapshot_view = Operator_control_snapshot_view.parse_snapshot_view
 
-(* Snapshot TTL cache with same-key deduplication (singleflight).
-   When multiple fibers hit a cache miss for the same key concurrently,
-   only one computes; the rest wait for its result via Eio.Condition.
-   This prevents memory bursts during keeper autoboot where many
-   concurrent dashboard polls would each build heavy keeper snapshots. *)
-
-type snapshot_slot =
-  | Cached of
-      { value : Yojson.Safe.t
-      ; expires_at : float
-      }
-  | Computing of
-      { cond : Eio.Condition.t
-      ; stale : Yojson.Safe.t option
-      ; started_at : float
-      ; stuck_warned : bool ref
-      }
-
-let _snapshot_table : (string, snapshot_slot) Hashtbl.t = Hashtbl.create 4
-let _snapshot_mu = Eio.Mutex.create ()
-let _snapshot_ttl_s = Env_config.Operator.cache_ttl_sec
-
-(* Maximum snapshot cache entries.  Each entry holds a full JSON snapshot
-   tree which can be several MB.  Unbounded growth caused OOM when the
-   dashboard was connected for extended periods (#4795). *)
-let _snapshot_max_entries = 16
-
-(* Evict one expired or oldest entry when table reaches _snapshot_max_entries.
-   Called inside _snapshot_mu when Eio is ready; pre-Eio callers are
-   single-threaded so no lock is needed. *)
-let _maybe_evict_snapshot () =
-  if Hashtbl.length _snapshot_table >= _snapshot_max_entries
-  then (
-    let now_ts = Time_compat.now () in
-    (* Prefer expired entries *)
-    let victim = ref None in
-    Hashtbl.iter
-      (fun key slot ->
-         match slot, !victim with
-         | Cached { expires_at; _ }, None when now_ts >= expires_at -> victim := Some key
-         | Cached _, None -> ()
-         | Cached _, Some _ -> ()
-         | Computing _, _ -> ())
-      _snapshot_table;
-    match !victim with
-    | Some key -> Hashtbl.remove _snapshot_table key
-    | None ->
-      (* All fresh or computing — evict the entry closest to expiry *)
-      let oldest_cached = ref None in
-      let any_key = ref None in
-      Hashtbl.iter
-        (fun key slot ->
-           match slot with
-           | Cached { expires_at; _ } ->
-             (match !oldest_cached with
-              | None -> oldest_cached := Some (key, expires_at)
-              | Some (_, e) when expires_at < e -> oldest_cached := Some (key, expires_at)
-              | Some _ -> ())
-           | Computing _ -> if !any_key = None then any_key := Some key)
-        _snapshot_table;
-      (match !oldest_cached with
-       | Some (key, _) -> Hashtbl.remove _snapshot_table key
-       | None ->
-         (* Never evict an in-flight compute to enforce the entry cap.  Under
-            64-keeper load, replacing a [Computing] slot starts duplicate
-            dashboard snapshots while the old one is still doing filesystem
-            work.  Temporary cache growth is cheaper than a compute stampede. *)
-         ignore !any_key))
-;;
-
-let invalidate_snapshot_cache () =
-  if Eio_guard.is_ready ()
-  then (
-    let conds =
-      Eio.Mutex.use_rw ~protect:true _snapshot_mu (fun () ->
-        let cs =
-          Hashtbl.fold
-            (fun _key slot acc ->
-               match slot with
-               | Computing { cond; _ } -> cond :: acc
-               | Cached _ -> acc)
-            _snapshot_table
-            []
-        in
-        Hashtbl.clear _snapshot_table;
-        cs)
-    in
-    List.iter Eio.Condition.broadcast conds)
-  else Hashtbl.clear _snapshot_table
-;;
-
+(* Snapshot TTL cache with same-key deduplication (singleflight)
+   extracted to [Operator_control_snapshot_cache] (godfile decomp).
+   The include flows through to [Operator_control] via the existing
+   include chain ([Operator_control_action] -> ...). *)
+include Operator_control_snapshot_cache
 let namespace_scope_cache_segment (_config : Coord_utils.config) = "default"
 
 let snapshot_json

--- a/lib/operator/operator_control_snapshot_cache.ml
+++ b/lib/operator/operator_control_snapshot_cache.ml
@@ -1,0 +1,120 @@
+(** Snapshot TTL cache with same-key deduplication (singleflight),
+    extracted from [operator_control_snapshot.ml] (godfile decomp).
+
+    When multiple fibers hit a cache miss for the same key concurrently,
+    only one computes; the rest wait for its result via Eio.Condition.
+    This prevents memory bursts during keeper autoboot where many
+    concurrent dashboard polls would each build heavy keeper snapshots.
+
+    The cluster forms a self-contained subsystem:
+
+    - [snapshot_slot] — variant distinguishing live cache entries
+      ([Cached { value; expires_at }]) from in-flight computations
+      ([Computing { cond; stale; started_at; stuck_warned }]).
+
+    - [_snapshot_table], [_snapshot_mu], [_snapshot_ttl_s],
+      [_snapshot_max_entries] — module-level mutable state. Underscore
+      prefix marks them as internal-only; consumers go through
+      [invalidate_snapshot_cache] or the [snapshot_json]
+      cache-handling code in the parent.
+
+    - [_maybe_evict_snapshot ()] — bounded eviction (~16 entries max,
+      #4795 OOM prevention). Prefers expired entries; falls back to
+      oldest fresh entry; never evicts an in-flight [Computing] slot
+      (cache growth is cheaper than a compute stampede under 64-keeper
+      load).
+
+    - [invalidate_snapshot_cache ()] — clears the table and
+      broadcasts all in-flight [Computing] conditions so waiting
+      fibers can re-run. Eio-guarded: pre-Eio callers single-threaded
+      and need no mutex.
+
+    Parent uses `include Operator_control_snapshot_cache` so all type
+    + state + helpers flow into [Operator_control_snapshot]'s scope.
+    The include chain propagates through to [Operator_control] via
+    [Operator_control_action]. *)
+
+type snapshot_slot =
+  | Cached of
+      { value : Yojson.Safe.t
+      ; expires_at : float
+      }
+  | Computing of
+      { cond : Eio.Condition.t
+      ; stale : Yojson.Safe.t option
+      ; started_at : float
+      ; stuck_warned : bool ref
+      }
+
+let _snapshot_table : (string, snapshot_slot) Hashtbl.t = Hashtbl.create 4
+let _snapshot_mu = Eio.Mutex.create ()
+let _snapshot_ttl_s = Env_config.Operator.cache_ttl_sec
+
+(* Maximum snapshot cache entries.  Each entry holds a full JSON snapshot
+   tree which can be several MB.  Unbounded growth caused OOM when the
+   dashboard was connected for extended periods (#4795). *)
+let _snapshot_max_entries = 16
+
+(* Evict one expired or oldest entry when table reaches _snapshot_max_entries.
+   Called inside _snapshot_mu when Eio is ready; pre-Eio callers are
+   single-threaded so no lock is needed. *)
+let _maybe_evict_snapshot () =
+  if Hashtbl.length _snapshot_table >= _snapshot_max_entries
+  then (
+    let now_ts = Time_compat.now () in
+    (* Prefer expired entries *)
+    let victim = ref None in
+    Hashtbl.iter
+      (fun key slot ->
+         match slot, !victim with
+         | Cached { expires_at; _ }, None when now_ts >= expires_at -> victim := Some key
+         | Cached _, None -> ()
+         | Cached _, Some _ -> ()
+         | Computing _, _ -> ())
+      _snapshot_table;
+    match !victim with
+    | Some key -> Hashtbl.remove _snapshot_table key
+    | None ->
+      (* All fresh or computing — evict the entry closest to expiry *)
+      let oldest_cached = ref None in
+      let any_key = ref None in
+      Hashtbl.iter
+        (fun key slot ->
+           match slot with
+           | Cached { expires_at; _ } ->
+             (match !oldest_cached with
+              | None -> oldest_cached := Some (key, expires_at)
+              | Some (_, e) when expires_at < e -> oldest_cached := Some (key, expires_at)
+              | Some _ -> ())
+           | Computing _ -> if !any_key = None then any_key := Some key)
+        _snapshot_table;
+      (match !oldest_cached with
+       | Some (key, _) -> Hashtbl.remove _snapshot_table key
+       | None ->
+         (* Never evict an in-flight compute to enforce the entry cap.  Under
+            64-keeper load, replacing a [Computing] slot starts duplicate
+            dashboard snapshots while the old one is still doing filesystem
+            work.  Temporary cache growth is cheaper than a compute stampede. *)
+         ignore !any_key))
+;;
+
+let invalidate_snapshot_cache () =
+  if Eio_guard.is_ready ()
+  then (
+    let conds =
+      Eio.Mutex.use_rw ~protect:true _snapshot_mu (fun () ->
+        let cs =
+          Hashtbl.fold
+            (fun _key slot acc ->
+               match slot with
+               | Computing { cond; _ } -> cond :: acc
+               | Cached _ -> acc)
+            _snapshot_table
+            []
+        in
+        Hashtbl.clear _snapshot_table;
+        cs)
+    in
+    List.iter Eio.Condition.broadcast conds)
+  else Hashtbl.clear _snapshot_table
+;;


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane F
- 6th sibling extracted from `operator_control_snapshot.ml` (after #17329 `identity_fields`, #17368 `snapshot_view`, #17386 `persistent_agents_json`, #17392 `room_json`, #17444 `action_log`).
- **Stateful subsystem extraction** — the cluster owns mutable state (Hashtbl + Eio.Mutex) which moves with the helpers.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/operator/operator_control_snapshot.ml` | 1050 | 964 | **-86** |
| `lib/operator/operator_control_snapshot_cache.ml` | — | 120 | +120 |

## Moved (verbatim, no behavior change)

### 1 variant type
```ocaml
type snapshot_slot =
  | Cached of { value : Yojson.Safe.t; expires_at : float }
  | Computing of
      { cond : Eio.Condition.t
      ; stale : Yojson.Safe.t option
      ; started_at : float
      ; stuck_warned : bool ref
      }
```

### 4 module-level state defs (underscore-prefixed, internal-only)
- `_snapshot_table : (string, snapshot_slot) Hashtbl.t` — created with size hint 4
- `_snapshot_mu : Eio.Mutex.t` — guards writes during Eio-aware code paths
- `_snapshot_ttl_s` — from `Env_config.Operator.cache_ttl_sec`
- `_snapshot_max_entries = 16` — bounded entry cap (#4795 OOM prevention; each entry holds a multi-MB JSON snapshot tree)

### 2 helpers
- `_maybe_evict_snapshot ()`:
  - Triggers when `Hashtbl.length _snapshot_table >= _snapshot_max_entries`
  - First pass: prefer expired entries (any `Cached { expires_at }` where `now_ts >= expires_at`)
  - Fallback pass: find oldest fresh `Cached` entry by `expires_at`
  - **Never evicts an in-flight `Computing` slot** — under 64-keeper load this would start duplicate dashboard snapshots while the old one is still doing filesystem work. Cache growth is cheaper than a compute stampede.

- `invalidate_snapshot_cache ()`:
  - Eio-ready: takes `_snapshot_mu` read-write, folds out all `Computing { cond; _ }` conditions, clears table, broadcasts all conds so waiting fibers re-run
  - Pre-Eio (boot path): just `Hashtbl.clear _snapshot_table` — single-threaded, no mutex needed

## Propagation via `include` chain
Parent uses `include Operator_control_snapshot_cache` so all 1 type + 4 state + 2 helpers flow through:

```
Operator_control_snapshot_cache
  -> [include] Operator_control_snapshot
  -> [include] Operator_control_action
  -> [include] Operator_control
```

So:
- `Operator_control.invalidate_snapshot_cache ()` — 8 test call sites unchanged
- `snapshot_json` (parent line 765, now ~679 post-splice) accesses `_snapshot_table`, `_snapshot_mu`, `_snapshot_ttl_s`, `_maybe_evict_snapshot` directly — all resolve through the include

## External callers (all keep working unchanged via include chain)
- `test/test_operator_control_snapshot.ml:278,450,653,956,1065,1102,1115,1179` — 8 calls to `Operator_control.invalidate_snapshot_cache ()`
- `lib/operator/operator_control_snapshot.mli:83` + `operator_control.mli:16` (implicit re-export via `include Operator_control_action` chain) — surface preserved

## Module-load ordering invariant
The sibling's state initializers (`Hashtbl.create 4`, `Eio.Mutex.create ()`, `Env_config.Operator.cache_ttl_sec`) all run at sibling module-load time. Parent depends on sibling (via `include`), so sibling loads first — state exists before any caller queries it.

## Why bundle the cluster?
The 1 type + 4 state + 2 helpers form a single TTL+singleflight cache concern:
- The state is referenced by all 3 callsites (`_maybe_evict_snapshot`, `invalidate_snapshot_cache`, and the parent's `snapshot_json`)
- Splitting into multiple siblings would either:
  1. Force callback injection of the state (Hashtbl callbacks are ugly)
  2. Force `include` of each part separately (no benefit)
- Single sibling = one canonical owner of the cache subsystem; future maintenance changes (eviction policy, mutex strategy, max entries) all live in one file

## Sibling deps
- `Eio.{Mutex.{create, use_rw, t}, Condition.{t, broadcast}}`
- `Eio_guard.is_ready`
- `Hashtbl.{create, length, iter, fold, remove, clear, add}`
- `Time_compat.now`
- `Env_config.Operator.cache_ttl_sec`
- `Yojson.Safe.t`
- Std: `List.iter`, refs, options

No parent-local helpers; no sibling -> parent cycle.

## Local build status
- `dune build --root . lib/operator/` → clean (exit 0)
- godfile lint: sibling 120 LOC under `new_file_cap=600`; parent 964 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim 1-type + 4-state + 2-function cluster move via `include`-based propagation.

Co-Authored-By: codex <noreply@anthropic.com>
