### PR TITLE
refactor(server_routes_http_routes_dashboard): extract SSE writers sibling

### DIFF
--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -62,24 +62,11 @@ let oas_telemetry_limit_param req =
 
 let oas_telemetry_provider_param req = trimmed_query_param req "provider"
 
-let observe_worktree_status_sse_write writer event =
-  Telemetry_observe.observe_or_fail
-    ~kind:"dashboard_worktree_status_sse_write" (fun () ->
-      Httpun.Body.Writer.write_string writer event)
-
-let rec observe_worktree_status_sse_write_all writer = function
-  | [] -> Ok ()
-  | event :: rest ->
-      (match observe_worktree_status_sse_write writer event with
-       | Ok () -> observe_worktree_status_sse_write_all writer rest
-       | Error _ as err -> err)
-
-let observe_worktree_status_sse_close writer =
-  Telemetry_observe.observe_or_default
-    ~kind:"dashboard_worktree_status_sse_close"
-    ~default:() (fun () ->
-      Httpun.Body.Writer.close writer)
-
+(* worktree-status SSE writers extracted to
+   [Server_routes_http_routes_dashboard_sse_writers] (godfile decomp). *)
+let observe_worktree_status_sse_write = Server_routes_http_routes_dashboard_sse_writers.observe_worktree_status_sse_write
+let observe_worktree_status_sse_write_all = Server_routes_http_routes_dashboard_sse_writers.observe_worktree_status_sse_write_all
+let observe_worktree_status_sse_close = Server_routes_http_routes_dashboard_sse_writers.observe_worktree_status_sse_close
 (* sync_keeper_cascade_meta extracted to
    [Server_routes_http_routes_dashboard_cascade_meta] (godfile decomp). *)
 let sync_keeper_cascade_meta = Server_routes_http_routes_dashboard_cascade_meta.sync_keeper_cascade_meta

--- a/lib/server/server_routes_http_routes_dashboard_sse_writers.ml
+++ b/lib/server/server_routes_http_routes_dashboard_sse_writers.ml
@@ -1,0 +1,42 @@
+(** Worktree-status SSE writer helpers, extracted from
+    [server_routes_http_routes_dashboard.ml] (godfile decomp).
+
+    Three telemetry-instrumented wrappers around [Httpun.Body.Writer]
+    for the worktree-status SSE stream:
+
+    - [observe_worktree_status_sse_write writer event] — single-event
+      write. Returns `Result.t`; `observe_or_fail` surfaces I/O errors
+      to the caller so the stream can abort cleanly.
+
+    - [observe_worktree_status_sse_write_all writer events] — recursive
+      sequence write. Short-circuits on first `Error`. Returns
+      `Ok ()` on full success.
+
+    - [observe_worktree_status_sse_close writer] — closes the body
+      writer via `Telemetry_observe.observe_or_default ~default:()`
+      so close-time I/O errors degrade silently (the connection is
+      already terminating).
+
+    All three thread `Telemetry_observe.*` kind labels
+    `dashboard_worktree_status_sse_write` and
+    `dashboard_worktree_status_sse_close` so the SSE stream's
+    error/latency profile is observable in the operator dashboard's
+    telemetry view. *)
+
+let observe_worktree_status_sse_write writer event =
+  Telemetry_observe.observe_or_fail
+    ~kind:"dashboard_worktree_status_sse_write" (fun () ->
+      Httpun.Body.Writer.write_string writer event)
+
+let rec observe_worktree_status_sse_write_all writer = function
+  | [] -> Ok ()
+  | event :: rest ->
+      (match observe_worktree_status_sse_write writer event with
+       | Ok () -> observe_worktree_status_sse_write_all writer rest
+       | Error _ as err -> err)
+
+let observe_worktree_status_sse_close writer =
+  Telemetry_observe.observe_or_default
+    ~kind:"dashboard_worktree_status_sse_close"
+    ~default:() (fun () ->
+      Httpun.Body.Writer.close writer)


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html` Lane E
- First sibling from `server_routes_http_routes_dashboard.ml` by me (prior extractions in this file were `dashboard_cascade_meta` + `dashboard_dev_token` + `dashboard_handlers` from earlier contributors).
- **Modest yield** (-13 LOC) but clean, focused single-concern extraction.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/server/server_routes_http_routes_dashboard.ml` | 1233 | 1220 | **-13** |
| `lib/server/server_routes_http_routes_dashboard_sse_writers.ml` | — | 42 | +42 |

## Moved (verbatim, no behavior change)
- `observe_worktree_status_sse_write writer event` — single-event SSE write:
  ```ocaml
  Telemetry_observe.observe_or_fail
    ~kind:"dashboard_worktree_status_sse_write" (fun () ->
      Httpun.Body.Writer.write_string writer event)
  ```
- `observe_worktree_status_sse_write_all writer events` — recursive sequence write, short-circuits on first `Error`. Returns `Ok ()` on full success.
- `observe_worktree_status_sse_close writer` — closes the body writer:
  ```ocaml
  Telemetry_observe.observe_or_default
    ~kind:"dashboard_worktree_status_sse_close"
    ~default:() (fun () ->
      Httpun.Body.Writer.close writer)
  ```

All three thread `Telemetry_observe.*` kind labels so SSE stream error/latency is observable in the operator dashboard's telemetry view. The `observe_or_default` choice for close (vs `observe_or_fail` for write) is intentional: close-time I/O errors degrade silently because the connection is already terminating; mid-stream write errors should abort the stream cleanly so the client knows the SSE feed is broken.

Parent retains 3 single-line aliases.

## Internal caller (preserved via parent aliases)
- `add_routes` (parent line 816-817):
  ```ocaml
  ignore (observe_worktree_status_sse_write_all writer events);
  observe_worktree_status_sse_close writer
  ```

## External callers / `.mli`
None. The `.mli` exposes only `add_routes` + cascade profile gate accessors + dashboard dev token helpers. The SSE writers are internal-only helpers consumed exclusively by `add_routes`.

## Sibling deps
- `Telemetry_observe.{observe_or_fail, observe_or_default}` — external
- `Httpun.Body.Writer.{write_string, close}` — external

No parent-local helpers; no sibling -> parent cycle.

## Why a modest yield is worth it
The parent file is dominated by `add_routes` (RFC-scale ~1100 LOC HTTP dispatch table that wires every operator dashboard route). Without an RFC, that function can't be carved up — its closure captures `~sw ~clock`, `router`, and many route-handler call sites. The only safe extractions in this parent are the small internal helpers OUTSIDE `add_routes`:
- `option_int_json` (4 LOC, unused) — dead code, don't touch
- `option_string_json` (6 LOC, unused) — dead code, don't touch
- `trimmed_query_param` + `oas_telemetry_*` (5-line cluster) — extractable but separate concern
- **SSE writers (this PR)** — one cohesive concern, 3 functions

Each Lane E extraction is small but the cumulative effect is a parent file that's only `add_routes` + thin entry helpers.

## Local build status
- `dune build --root . lib/server/` → clean (exit 0)
- godfile lint: sibling 42 LOC under `new_file_cap=600`; parent 1220 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim 3-helper bundle move via 3 parent aliases.

Co-Authored-By: codex <noreply@anthropic.com>
