### PR TITLE
refactor(server_routes_http_runtime): extract /health probe helpers sibling

### DIFF
--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -46,7 +46,8 @@ let is_http_error_response = function
   | _ -> false
 
 (** Server start time for uptime calculation *)
-let server_start_time = Unix.gettimeofday ()
+(* server_start_time moved to [Server_routes_http_runtime_health_helpers]
+   (godfile decomp). *)
 
 let configured_http_port () =
   Env_config_core.masc_http_port_int ()
@@ -129,58 +130,14 @@ let agent_card_json request =
           ] );
     ]
 
-let health_path_diagnostics () =
-  match current_server_state_opt () with
-  | Some state ->
-      Server_base_path_diagnostics.detect
-        ?input_base_path:((Host_config.from_env ()).base_path_raw)
-        ?env_masc_base_path:((Host_config.from_env ()).base_path_raw)
-        ~effective_base_path:state.room_config.base_path
-        ~effective_masc_root:(Coord.masc_root_dir state.room_config)
-        ()
-  | None ->
-      let effective_base_path = default_base_path () in
-      let effective_masc_root = Common.masc_dir_from_base_path ~base_path:effective_base_path in
-      Server_base_path_diagnostics.detect
-        ?input_base_path:((Host_config.from_env ()).base_path_raw)
-        ?env_masc_base_path:((Host_config.from_env ()).base_path_raw)
-        ~effective_base_path ~effective_masc_root ()
-
-let health_uptime_secs () =
-  (* NDT-OK: /health exposes wall-clock process uptime for operators; no
-     persisted state transition or scheduler decision depends on this value. *)
-  int_of_float (Unix.gettimeofday () -. server_start_time)
-
-let health_uptime_string uptime_secs =
-  if uptime_secs < 60 then Printf.sprintf "%ds" uptime_secs
-  else if uptime_secs < 3600 then
-    Printf.sprintf "%dm %ds" (uptime_secs / 60) (uptime_secs mod 60)
-  else Printf.sprintf "%dh %dm" (uptime_secs / 3600) ((uptime_secs mod 3600) / 60)
-
-let protocol_json ~listener =
-  `Assoc
-    [
-      ("default", `String mcp_protocol_version_default);
-      ("listener", `String listener);
-      ( "supported",
-        `List (List.map (fun v -> `String v) mcp_protocol_versions) );
-    ]
-
-let quick_gc_json () =
-  (* Keep health probes cheap under live keeper load. [Gc.stat] can force a
-     full major-cycle sync across domains; [Gc.quick_stat] exposes the same
-     operator-facing counters without walking the heap. *)
-  let s = Gc.quick_stat () in
-  `Assoc
-    [
-      ("minor_collections", `Int s.minor_collections);
-      ("major_collections", `Int s.major_collections);
-      ("compactions", `Int s.compactions);
-      ("heap_words", `Int s.heap_words);
-      ("live_words", `Int s.live_words);
-      ("minor_heap_size", `Int (let c = Gc.get () in c.minor_heap_size));
-    ]
-
+(* /health probe building blocks (path diagnostics, uptime, protocol
+   negotiation, GC counters) extracted to
+   [Server_routes_http_runtime_health_helpers] (godfile decomp). *)
+let health_path_diagnostics = Server_routes_http_runtime_health_helpers.health_path_diagnostics
+let health_uptime_secs = Server_routes_http_runtime_health_helpers.health_uptime_secs
+let health_uptime_string = Server_routes_http_runtime_health_helpers.health_uptime_string
+let protocol_json = Server_routes_http_runtime_health_helpers.protocol_json
+let quick_gc_json = Server_routes_http_runtime_health_helpers.quick_gc_json
 let make_health_probe_fields ?(listener = "http/1.1") ?full_health_url
     ?(health_detail = "probe") request =
   let uptime_secs = health_uptime_secs () in

--- a/lib/server/server_routes_http_runtime_health_helpers.ml
+++ b/lib/server/server_routes_http_runtime_health_helpers.ml
@@ -1,0 +1,78 @@
+(** /health probe building blocks, extracted from
+    [server_routes_http_runtime.ml] (godfile decomp).
+
+    Small self-contained JSON+diagnostics helpers used by the
+    [/health] probe response builder:
+
+    - [server_start_time] — captured at sibling module init via
+      [Unix.gettimeofday]. Operators see process uptime against
+      this constant (NDT-OK: no scheduler decision depends on it).
+    - [health_path_diagnostics] — resolves base-path inputs
+      ([Host_config.from_env]) against effective config to surface
+      mis-mapping in operator output. Falls back to
+      [Common.masc_dir_from_base_path] when no server state is
+      live (boot path).
+    - [health_uptime_secs] — process uptime in seconds (int).
+    - [health_uptime_string] — pretty-prints uptime as `<sec>s`,
+      `<min>m <sec>s`, or `<hour>h <min>m`.
+    - [protocol_json ~listener] — MCP protocol version negotiation
+      summary keyed by listener.
+    - [quick_gc_json] — operator-facing GC counter summary. Uses
+      [Gc.quick_stat] (not [Gc.stat]) so health probes don't trigger
+      a full major-cycle sync under live keeper load. *)
+
+open Server_routes_http_common
+
+let server_start_time = Unix.gettimeofday ()
+
+let health_path_diagnostics () =
+  match current_server_state_opt () with
+  | Some state ->
+      Server_base_path_diagnostics.detect
+        ?input_base_path:((Host_config.from_env ()).base_path_raw)
+        ?env_masc_base_path:((Host_config.from_env ()).base_path_raw)
+        ~effective_base_path:state.room_config.base_path
+        ~effective_masc_root:(Coord.masc_root_dir state.room_config)
+        ()
+  | None ->
+      let effective_base_path = default_base_path () in
+      let effective_masc_root = Common.masc_dir_from_base_path ~base_path:effective_base_path in
+      Server_base_path_diagnostics.detect
+        ?input_base_path:((Host_config.from_env ()).base_path_raw)
+        ?env_masc_base_path:((Host_config.from_env ()).base_path_raw)
+        ~effective_base_path ~effective_masc_root ()
+
+let health_uptime_secs () =
+  (* NDT-OK: /health exposes wall-clock process uptime for operators; no
+     persisted state transition or scheduler decision depends on this value. *)
+  int_of_float (Unix.gettimeofday () -. server_start_time)
+
+let health_uptime_string uptime_secs =
+  if uptime_secs < 60 then Printf.sprintf "%ds" uptime_secs
+  else if uptime_secs < 3600 then
+    Printf.sprintf "%dm %ds" (uptime_secs / 60) (uptime_secs mod 60)
+  else Printf.sprintf "%dh %dm" (uptime_secs / 3600) ((uptime_secs mod 3600) / 60)
+
+let protocol_json ~listener =
+  `Assoc
+    [
+      ("default", `String mcp_protocol_version_default);
+      ("listener", `String listener);
+      ( "supported",
+        `List (List.map (fun v -> `String v) mcp_protocol_versions) );
+    ]
+
+let quick_gc_json () =
+  (* Keep health probes cheap under live keeper load. [Gc.stat] can force a
+     full major-cycle sync across domains; [Gc.quick_stat] exposes the same
+     operator-facing counters without walking the heap. *)
+  let s = Gc.quick_stat () in
+  `Assoc
+    [
+      ("minor_collections", `Int s.minor_collections);
+      ("major_collections", `Int s.major_collections);
+      ("compactions", `Int s.compactions);
+      ("heap_words", `Int s.heap_words);
+      ("live_words", `Int s.live_words);
+      ("minor_heap_size", `Int (let c = Gc.get () in c.minor_heap_size));
+    ]


### PR DESCRIPTION
## Plan
- Source: `docs/audit/2026-05-18-godfile-decomposition-build-plan.html`
- **New-lane extraction**: `server_routes_http_runtime.ml` (1611 LOC, 6th-largest .ml in lib/) was untouched by my prior cycles. First sibling carve-out from this godfile.
- 5 of my 6 prior PRs (#17462, #17464, #17465, #17466, #17467) merged in the last cycle, so I pivoted to a fresh godfile rather than chase smaller residuals in the just-touched parents.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/server/server_routes_http_runtime.ml` | 1611 | 1568 | **-43** |
| `lib/server/server_routes_http_runtime_health_helpers.ml` | — | 78 | +78 |

## Moved (verbatim, no behavior change)
- `server_start_time = Unix.gettimeofday ()` — captured at sibling module init
- `health_path_diagnostics` — resolves base-path inputs ([Host_config.from_env].base_path_raw) against effective config via [Server_base_path_diagnostics.detect]; falls back to [Common.masc_dir_from_base_path] when no live server state (boot path)
- `health_uptime_secs` — `int_of_float (Unix.gettimeofday () -. server_start_time)`
- `health_uptime_string uptime_secs` — pretty-prints `<sec>s` / `<min>m <sec>s` / `<hour>h <min>m`
- `protocol_json ~listener` — MCP protocol version negotiation summary (default + listener + supported list)
- `quick_gc_json` — operator-facing GC summary using `Gc.quick_stat` (not `Gc.stat`) to avoid major-cycle sync under live keeper load

Parent retains 5 single-line aliases. `server_start_time` is sibling-internal (only `health_uptime_secs` uses it).

## Internal callers preserved via aliases
- `health_path_diagnostics`: 4 reference sites (`make_health_probe_fields` + 3 other JSON builders at parent lines 386/599/726)
- `health_uptime_secs`, `health_uptime_string`, `protocol_json`, `quick_gc_json`: each used by `make_health_probe_fields` (parent line ~184)

## Sibling deps
- `open Server_routes_http_common` — for `current_server_state_opt`, `default_base_path` (mirrors parent's `open`)
- `Server_base_path_diagnostics.{detect, to_yojson}`
- `Host_config.from_env`
- `Coord.masc_root_dir`
- `Common.masc_dir_from_base_path`
- `Env_config_core.{mcp_protocol_version_default, mcp_protocol_versions}` (via `Server_routes_http_common` chain)
- Std: `Unix.gettimeofday`, `Gc.{quick_stat, get}`, `Printf`, `List.map`

No parent-local helpers; no sibling -> parent cycle.

## Module-load timing
`server_start_time` captures `Unix.gettimeofday ()` at SIBLING module init. Both parent and sibling load at lib init time (sibling first because parent depends on it), so the captured value is operationally equivalent to the previous parent-init value (microseconds within).

## Local build status
- `dune build --root . lib/server/` → clean (exit 0)
- godfile lint: sibling 78 LOC under `new_file_cap=600`; parent 1568 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor. Verbatim 6-helper bundle move via 5 parent aliases.

Co-Authored-By: codex <noreply@anthropic.com>
