### PR TITLE
refactor(dashboard_http_keeper): extract execution_receipt helpers + fix #17471 mli mismatch

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -35,48 +35,11 @@ let keeper_trust_json = Trust.keeper_trust_json
    moved to Dashboard_http_keeper_types (intra-library file split,
    2026-05-16). *)
 
-let execution_receipt_dir config keeper_name =
-  Filename.concat
-    (Filename.concat (Filename.concat (Coord.masc_root_dir config) "keepers")
-       keeper_name)
-    "execution-receipts"
-
-let execution_receipt_store_pattern config =
-  Filename.concat
-    (Filename.concat (Coord.masc_root_dir config) "keepers")
-    "*/execution-receipts"
-
-let count_execution_receipt_entries config keeper_names =
-  keeper_names
-  |> List.fold_left
-       (fun acc keeper_name ->
-         let dir = execution_receipt_dir config keeper_name in
-         if not (Sys.file_exists dir) then acc
-         else
-           acc
-           +
-           (match Dated_jsonl.create ~base_dir:dir () with
-            | store -> Dated_jsonl.count_entries store
-            | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
-            | exception exn ->
-              Log.Dashboard.warn
-                "execution_trust receipt count failed for %s: %s"
-                dir
-                (Printexc.to_string exn);
-              0))
-       0
-
-(* max_ts_opt / latest_receipt_ts_of_keeper_rows / freshness_fields /
-   source_health_fields moved to Dashboard_http_keeper_types
-   (intra-library file split, 2026-05-16). *)
-
-let execution_receipt_coverage_gaps config =
-  Telemetry_coverage_gap.read_recent
-    ~masc_root:(Coord.masc_root_dir config)
-    ~n:50
-  |> List.filter (fun gap ->
-       String.equal execution_trust_source
-         (Safe_ops.json_string ~default:"" "source" gap))
+(* execution_receipt path/diagnostic helpers extracted to
+   [Dashboard_http_keeper_execution_receipt] (godfile decomp). *)
+let execution_receipt_store_pattern = Dashboard_http_keeper_execution_receipt.execution_receipt_store_pattern
+let count_execution_receipt_entries = Dashboard_http_keeper_execution_receipt.count_execution_receipt_entries
+let execution_receipt_coverage_gaps = Dashboard_http_keeper_execution_receipt.execution_receipt_coverage_gaps
 
 let keeper_names (config : Coord.config) =
   Keeper_types.keeper_names config

--- a/lib/dashboard/dashboard_http_keeper_execution_receipt.ml
+++ b/lib/dashboard/dashboard_http_keeper_execution_receipt.ml
@@ -1,0 +1,63 @@
+(** Execution-receipt path resolution + dashboard diagnostics, extracted
+    from [dashboard_http_keeper.ml] (godfile decomp).
+
+    Four helpers around the per-keeper execution-receipt JSONL store
+    layout at `<masc_root>/keepers/<keeper_name>/execution-receipts/`:
+
+    - [execution_receipt_dir config keeper_name] — canonical directory
+      path for a single keeper's receipts.
+    - [execution_receipt_store_pattern config] — glob pattern
+      (`<masc_root>/keepers/*/execution-receipts`) used in dashboard
+      surface metadata.
+    - [count_execution_receipt_entries config keeper_names] — sums
+      [Dated_jsonl.count_entries] across the provided keeper list,
+      tolerating missing dirs (skip) and read failures (WARN log +
+      contribute 0). Cancellation re-raises.
+    - [execution_receipt_coverage_gaps config] — surfaces recent
+      [Telemetry_coverage_gap] entries filtered to the
+      [execution_trust_source] producer (50 most-recent entries).
+
+    Pure helper move — sibling uses `include Dashboard_http_keeper_types`
+    for [execution_trust_source]. All other references reach external
+    modules. *)
+
+include Dashboard_http_keeper_types
+
+let execution_receipt_dir config keeper_name =
+  Filename.concat
+    (Filename.concat (Filename.concat (Coord.masc_root_dir config) "keepers")
+       keeper_name)
+    "execution-receipts"
+
+let execution_receipt_store_pattern config =
+  Filename.concat
+    (Filename.concat (Coord.masc_root_dir config) "keepers")
+    "*/execution-receipts"
+
+let count_execution_receipt_entries config keeper_names =
+  keeper_names
+  |> List.fold_left
+       (fun acc keeper_name ->
+         let dir = execution_receipt_dir config keeper_name in
+         if not (Sys.file_exists dir) then acc
+         else
+           acc
+           +
+           (match Dated_jsonl.create ~base_dir:dir () with
+            | store -> Dated_jsonl.count_entries store
+            | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
+            | exception exn ->
+              Log.Dashboard.warn
+                "execution_trust receipt count failed for %s: %s"
+                dir
+                (Printexc.to_string exn);
+              0))
+       0
+
+let execution_receipt_coverage_gaps config =
+  Telemetry_coverage_gap.read_recent
+    ~masc_root:(Coord.masc_root_dir config)
+    ~n:50
+  |> List.filter (fun gap ->
+       String.equal execution_trust_source
+         (Safe_ops.json_string ~default:"" "source" gap))

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -49,6 +49,7 @@ let is_http_error_response = function
 (* server_start_time moved to [Server_routes_http_runtime_health_helpers]
    (godfile decomp). *)
 
+let server_start_time = Server_routes_http_runtime_health_helpers.server_start_time
 let configured_http_port () =
   Env_config_core.masc_http_port_int ()
 


### PR DESCRIPTION
## Plan
- Two changes bundled in one PR for build-unblocking reasons (see below).
- **Primary**: new-lane extraction from `dashboard_http_keeper.ml` (1447 LOC, untouched godfile).
- **Hotfix**: forward-fix for `server_start_time` .mli mismatch introduced by #17471.

## LOC delta
| File | Before | After | Δ |
|---|---:|---:|---:|
| `lib/dashboard/dashboard_http_keeper.ml` | 1447 | 1410 | **-37** |
| `lib/dashboard/dashboard_http_keeper_execution_receipt.ml` | — | 63 | +63 |
| `lib/server/server_routes_http_runtime.ml` | 1568 | 1569 | +1 (hotfix) |

## Part 1: execution_receipt extraction (Lane: dashboard, new entry)

### Moved (verbatim, no behavior change)
- `execution_receipt_dir config keeper_name` — canonical directory path `<masc_root>/keepers/<keeper>/execution-receipts/`
- `execution_receipt_store_pattern config` — glob pattern `<masc_root>/keepers/*/execution-receipts` (dashboard surface metadata)
- `count_execution_receipt_entries config keeper_names`:
  - Folds `Dated_jsonl.count_entries` across `keeper_names`
  - Missing dirs → skip (contribute 0)
  - `Eio.Cancel.Cancelled` → re-raise
  - Other exceptions → `Log.Dashboard.warn` + contribute 0
- `execution_receipt_coverage_gaps config` — last 50 `Telemetry_coverage_gap.read_recent` entries filtered to `execution_trust_source` producer

### Internal callers (preserved via 3 parent aliases)
- `execution_trust_dashboard_json` at parent lines 897, 899, 905 — all 3 callable helpers (`count_execution_receipt_entries`, `execution_receipt_coverage_gaps`, `execution_receipt_store_pattern`)

`execution_receipt_dir` is sibling-internal (only used by `count_execution_receipt_entries`).

### Sibling deps
- `include Dashboard_http_keeper_types` — for `execution_trust_source` constant
- External: `Filename.concat`, `Coord.masc_root_dir`, `Sys.file_exists`, `Dated_jsonl.{create, count_entries}`, `Eio.Cancel.Cancelled`, `Log.Dashboard.warn`, `Printexc.to_string`, `Telemetry_coverage_gap.read_recent`, `Safe_ops.json_string`, `String.equal`, `List.{fold_left, filter}`

No parent-local helpers; no sibling -> parent cycle.

## Part 2: hotfix for #17471

PR #17471 (`/health probe helpers` extraction) moved `server_start_time` to the sibling but the parent's `.mli` still declares `val server_start_time : float` at line 56. This left an unresolved .mli/.ml mismatch on origin/main that blocked any subsequent build:

```
Error: The value server_start_time is required but not provided
  File "lib/server/server_routes_http_runtime.mli", line 56, characters 0-29:
    Expected declaration
```

Adding the 1-line parent alias `let server_start_time = Server_routes_http_runtime_health_helpers.server_start_time` restores the .mli surface and unblocks the build.

### Why forward-fix in the same PR
The build was broken on origin/main, blocking any other extraction work. Bundling the fix here is faster than a separate hotfix PR + waiting for it to merge. The fix is single-line and orthogonal to the primary extraction.

## Local build status
- `dune build --root . lib/` → clean (exit 0) after both changes applied
- godfile lint: sibling 63 LOC under `new_file_cap=600`; parent `dashboard_http_keeper.ml` 1410 < `absolute_cap=3350`

## RFC-WAIVED
Extract-only sibling refactor + .mli-completing parent alias hotfix. Verbatim 4-helper move via 3 aliases + 1 hotfix alias.

Co-Authored-By: codex <noreply@anthropic.com>
