### PR TITLE
refactor(keeper_tools_oas): extract JSON-extract helpers sibling

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -141,43 +141,11 @@ type workflow_rejection_info =
   ; hint : string option
   }
 
-let json_assoc_field_opt key = function
-  | `Assoc fields -> List.assoc_opt key fields
-  | _ -> None
-;;
-
-let json_assoc_string_opt key json =
-  match json_assoc_field_opt key json with
-  | Some (`String value) -> Some value
-  | _ -> None
-;;
-
-let detail_json_opt json =
-  match json_assoc_field_opt "detail" json with
-  | Some (`Assoc _ as detail) -> Some detail
-  | _ -> None
-;;
-
-let json_or_detail_string_opt key json =
-  match json_assoc_string_opt key json with
-  | Some _ as value -> value
-  | None ->
-    (match detail_json_opt json with
-     | Some detail -> json_assoc_string_opt key detail
-     | None -> None)
-;;
-
-let diagnosis_json_opt json =
-  match json_assoc_field_opt "diagnosis" json with
-  | Some (`Assoc _ as diagnosis) -> Some diagnosis
-  | _ ->
-    (match detail_json_opt json with
-     | Some detail ->
-       (match json_assoc_field_opt "diagnosis" detail with
-        | Some (`Assoc _ as diagnosis) -> Some diagnosis
-        | _ -> None)
-     | None -> None)
-;;
+let json_assoc_field_opt = Keeper_tools_oas_json.json_assoc_field_opt
+let json_assoc_string_opt = Keeper_tools_oas_json.json_assoc_string_opt
+let detail_json_opt = Keeper_tools_oas_json.detail_json_opt
+let json_or_detail_string_opt = Keeper_tools_oas_json.json_or_detail_string_opt
+let diagnosis_json_opt = Keeper_tools_oas_json.diagnosis_json_opt
 
 let workflow_rejection_info_of_raw raw =
   try

--- a/lib/keeper/keeper_tools_oas_json.ml
+++ b/lib/keeper/keeper_tools_oas_json.ml
@@ -1,0 +1,44 @@
+(** JSON-extract helpers for keeper_tools_oas.
+
+    Pure Yojson helpers used by workflow-rejection / failure-class
+    inspection in [Keeper_tools_oas]. All callers are inside
+    [Keeper_tools_oas]; not in .mli. Extracted as a sibling for
+    cohesion. *)
+
+let json_assoc_field_opt key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+;;
+
+let json_assoc_string_opt key json =
+  match json_assoc_field_opt key json with
+  | Some (`String value) -> Some value
+  | _ -> None
+;;
+
+let detail_json_opt json =
+  match json_assoc_field_opt "detail" json with
+  | Some (`Assoc _ as detail) -> Some detail
+  | _ -> None
+;;
+
+let json_or_detail_string_opt key json =
+  match json_assoc_string_opt key json with
+  | Some _ as value -> value
+  | None ->
+    (match detail_json_opt json with
+     | Some detail -> json_assoc_string_opt key detail
+     | None -> None)
+;;
+
+let diagnosis_json_opt json =
+  match json_assoc_field_opt "diagnosis" json with
+  | Some (`Assoc _ as diagnosis) -> Some diagnosis
+  | _ ->
+    (match detail_json_opt json with
+     | Some detail ->
+       (match json_assoc_field_opt "diagnosis" detail with
+        | Some (`Assoc _ as diagnosis) -> Some diagnosis
+        | _ -> None)
+     | None -> None)
+;;


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/keeper/keeper_tools_oas.ml` (1555 → 1523 LOC, **-32**). First touch on this godfile — 7th-largest .ml in `lib/`, audited by the 2026-05-18 godfile-decomposition build plan.

New sibling `lib/keeper/keeper_tools_oas_json.ml` (44 LOC) hosts 5 pure Yojson extract helpers used by workflow-rejection / failure-class inspection:

- `json_assoc_field_opt` — `` `Assoc fields `` → field-by-key (option)
- `json_assoc_string_opt` — typed `` `String value `` over the above
- `detail_json_opt` — narrows to nested `detail` Assoc
- `json_or_detail_string_opt` — string at top-level OR under detail
- `diagnosis_json_opt` — `diagnosis` Assoc at top-level OR under detail

Pure helpers — no parent-local state, no callback injection. External callers: **none** (verified via `grep` across `lib/` + `test/`). These helpers are internal to `keeper_tools_oas.ml` (not in `.mli`).

## Parent surface

5 single-line aliases preserve the qualified in-module names:

```ocaml
let json_assoc_field_opt = Keeper_tools_oas_json.json_assoc_field_opt
let json_assoc_string_opt = Keeper_tools_oas_json.json_assoc_string_opt
let detail_json_opt = Keeper_tools_oas_json.detail_json_opt
let json_or_detail_string_opt = Keeper_tools_oas_json.json_or_detail_string_opt
let diagnosis_json_opt = Keeper_tools_oas_json.diagnosis_json_opt
```

Type identity is preserved because the helpers return only `Yojson.Safe.t` and `string option` — both transparent across module boundaries; no abstract types to alias.

## Test plan

- [x] `dune build --root . lib/` clean
- [x] Parent `.mli` surface unchanged (json helpers were not in `.mli`)
- [x] External caller grep across `lib/` + `test/` — no callers found
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
