### PR TITLE
refactor(keeper_sandbox_runtime): extract docker classifier sibling

### DIFF
--- a/lib/keeper/keeper_sandbox_runtime.ml
+++ b/lib/keeper/keeper_sandbox_runtime.ml
@@ -61,68 +61,20 @@ type classified_error =
   ; failure_class : string
   }
 
-let process_status_is_timeout = function
-  | Unix.WEXITED 124 -> true
-  | Unix.WEXITED _
-  | Unix.WSIGNALED _
-  | Unix.WSTOPPED _ ->
-    false
-;;
-
-let lower_contains output needle =
-  String_util.contains_substring (String.lowercase_ascii output) needle
-;;
-
-let output_looks_docker_daemon_unavailable output =
-  lower_contains output "cannot connect to the docker daemon"
-  || lower_contains output "is the docker daemon running"
-  || lower_contains output "docker daemon is not running"
-  || lower_contains output "connection refused"
-;;
-
-let output_looks_image_missing output =
-  lower_contains output "no such image"
-  || lower_contains output "no such object"
-;;
-
-let output_looks_timeout output =
-  lower_contains output "timeout after"
-  || lower_contains output "timed out"
-  || lower_contains output "i/o timeout"
-;;
-
-let docker_output_looks_oci_mount_failure output =
-  lower_contains output "oci runtime create failed"
-  || lower_contains output "error during container init"
-;;
-
-let classify_docker_runtime_failure ~status ~output =
-  if process_status_is_timeout status || output_looks_timeout output
-  then "docker_daemon_timeout"
-  else if output_looks_docker_daemon_unavailable output
-  then "docker_daemon_unavailable"
-  else "docker_runtime_error"
-;;
-
-let classify_image_inspect_failure ~status ~output =
-  if process_status_is_timeout status || output_looks_timeout output
-  then "image_inspect_timeout"
-  else if output_looks_docker_daemon_unavailable output
-  then "docker_daemon_unavailable"
-  else if output_looks_image_missing output
-  then "image_missing"
-  else "image_inspect_error"
-;;
-
-let classify_image_inventory_failure ~status ~output =
-  if process_status_is_timeout status || output_looks_timeout output
-  then "image_inventory_timeout"
-  else if docker_output_looks_oci_mount_failure output
-  then "oci_mount_failure"
-  else if output_looks_docker_daemon_unavailable output
-  then "docker_daemon_unavailable"
-  else "image_inventory_error"
-;;
+let process_status_is_timeout = Keeper_sandbox_runtime_classify.process_status_is_timeout
+let lower_contains = Keeper_sandbox_runtime_classify.lower_contains
+let output_looks_docker_daemon_unavailable =
+  Keeper_sandbox_runtime_classify.output_looks_docker_daemon_unavailable
+let output_looks_image_missing = Keeper_sandbox_runtime_classify.output_looks_image_missing
+let output_looks_timeout = Keeper_sandbox_runtime_classify.output_looks_timeout
+let docker_output_looks_oci_mount_failure =
+  Keeper_sandbox_runtime_classify.docker_output_looks_oci_mount_failure
+let classify_docker_runtime_failure =
+  Keeper_sandbox_runtime_classify.classify_docker_runtime_failure
+let classify_image_inspect_failure =
+  Keeper_sandbox_runtime_classify.classify_image_inspect_failure
+let classify_image_inventory_failure =
+  Keeper_sandbox_runtime_classify.classify_image_inventory_failure
 
 let docker_info_security_options_with_class ~timeout_sec =
   let argv =

--- a/lib/keeper/keeper_sandbox_runtime_classify.ml
+++ b/lib/keeper/keeper_sandbox_runtime_classify.ml
@@ -1,0 +1,74 @@
+(** Docker output / status classifiers for the keeper sandbox runtime.
+
+    Pure functions — verbatim extraction of the substring-based
+    failure-class triage used by [Keeper_sandbox_runtime]. No
+    parent-local state. All callers are internal to the parent
+    (verified via grep across lib/ + test/).
+
+    Note: the [classify_*] functions return string failure-class tokens
+    rather than a typed variant. This is verbatim with the
+    pre-extraction code; a typed conversion is RFC-territory because
+    the strings cross many call sites and the dashboard surface. *)
+
+let process_status_is_timeout = function
+  | Unix.WEXITED 124 -> true
+  | Unix.WEXITED _
+  | Unix.WSIGNALED _
+  | Unix.WSTOPPED _ ->
+    false
+;;
+
+let lower_contains output needle =
+  String_util.contains_substring (String.lowercase_ascii output) needle
+;;
+
+let output_looks_docker_daemon_unavailable output =
+  lower_contains output "cannot connect to the docker daemon"
+  || lower_contains output "is the docker daemon running"
+  || lower_contains output "docker daemon is not running"
+  || lower_contains output "connection refused"
+;;
+
+let output_looks_image_missing output =
+  lower_contains output "no such image"
+  || lower_contains output "no such object"
+;;
+
+let output_looks_timeout output =
+  lower_contains output "timeout after"
+  || lower_contains output "timed out"
+  || lower_contains output "i/o timeout"
+;;
+
+let docker_output_looks_oci_mount_failure output =
+  lower_contains output "oci runtime create failed"
+  || lower_contains output "error during container init"
+;;
+
+let classify_docker_runtime_failure ~status ~output =
+  if process_status_is_timeout status || output_looks_timeout output
+  then "docker_daemon_timeout"
+  else if output_looks_docker_daemon_unavailable output
+  then "docker_daemon_unavailable"
+  else "docker_runtime_error"
+;;
+
+let classify_image_inspect_failure ~status ~output =
+  if process_status_is_timeout status || output_looks_timeout output
+  then "image_inspect_timeout"
+  else if output_looks_docker_daemon_unavailable output
+  then "docker_daemon_unavailable"
+  else if output_looks_image_missing output
+  then "image_missing"
+  else "image_inspect_error"
+;;
+
+let classify_image_inventory_failure ~status ~output =
+  if process_status_is_timeout status || output_looks_timeout output
+  then "image_inventory_timeout"
+  else if docker_output_looks_oci_mount_failure output
+  then "oci_mount_failure"
+  else if output_looks_docker_daemon_unavailable output
+  then "docker_daemon_unavailable"
+  else "image_inventory_error"
+;;


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/keeper/keeper_sandbox_runtime.ml` (1509 → 1461 LOC, **-48**). First touch on this godfile — 9th-largest .ml in `lib/`, audited by the 2026-05-18 godfile-decomposition build plan.

New sibling `lib/keeper/keeper_sandbox_runtime_classify.ml` (74 LOC) hosts 9 substring-based docker output/status classifiers:

- `process_status_is_timeout` — `Unix.WEXITED 124` detector
- `lower_contains` — case-insensitive substring matcher (over `String_util.contains_substring`)
- `output_looks_docker_daemon_unavailable` — 4 known phrases
- `output_looks_image_missing` — 2 phrases
- `output_looks_timeout` — 3 phrases
- `docker_output_looks_oci_mount_failure` — 2 phrases
- `classify_docker_runtime_failure` — `~status ~output → string class`
- `classify_image_inspect_failure` — `~status ~output → string class`
- `classify_image_inventory_failure` — `~status ~output → string class`

Pure helpers — no parent-local state, no callback injection. External callers: **none** for any of these helpers in `keeper_sandbox_runtime`'s surface (verified via grep across `lib/` + `test/`; name collisions in `exec_core` / `keeper_shell_shared` have their own local definitions). No `.mli` on `keeper_sandbox_runtime`, so the implicit signature absorbs the move.

## Parent surface

9 single-line aliases preserve the qualified in-module names:

```ocaml
let process_status_is_timeout = Keeper_sandbox_runtime_classify.process_status_is_timeout
let lower_contains = Keeper_sandbox_runtime_classify.lower_contains
...
```

## Anti-pattern note

The `classify_*` functions return string failure-class tokens (`"docker_daemon_timeout"`, `"image_missing"`, etc.) rather than a typed variant — that is the substring-classifier shape Anti-pattern §2 cautions against *adding* to. This PR is a verbatim *move* of pre-existing code; **no new arm is added and no catch-all is widened**. A typed conversion would be RFC-territory (touches the dashboard surface and many call sites) and is out of scope for an extract-only refactor.

## Test plan

- [x] `dune build --root . lib/` clean
- [x] No `.mli` to update (implicit signature)
- [x] External caller grep across `lib/` + `test/` — no callers of the moved helpers from this parent
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
