### PR TITLE
docs(rfc): close out 28 Draft RFCs with all implementation PRs merged

### DIFF
--- a/docs/rfc/RFC-0010-ocamlformat-config-reconciliation.md
+++ b/docs/rfc/RFC-0010-ocamlformat-config-reconciliation.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0010"
 title: "ocamlformat config reconciliation"
-status: Draft
+status: Implemented
 created: 2026-05-12
-updated: 2026-05-20
+updated: 2026-05-22
 author: vincent
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0071-exhaustive-match-sweep-codemod.md
+++ b/docs/rfc/RFC-0071-exhaustive-match-sweep-codemod.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0071"
 title: "Exhaustive Match Sweep Codemod — Eliminate N-of-M `_ -> false/None` Anti-Pattern"
-status: Draft
+status: Implemented
 created: 2026-05-12
-updated: 2026-05-20
+updated: 2026-05-22
 author: yousleepwhen
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0073-tool-readiness-probe.md
+++ b/docs/rfc/RFC-0073-tool-readiness-probe.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0073"
 title: "Tool Readiness Probe — Typed Precondition + Runtime Gap Disclosure"
-status: Draft
+status: Implemented
 created: 2026-05-14
-updated: 2026-05-20
+updated: 2026-05-22
 author: vincent
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0077-write-side-silent-failure-typed.md
+++ b/docs/rfc/RFC-0077-write-side-silent-failure-typed.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0077"
 title: "Write-side silent failure — typed propagation"
-status: Draft
+status: Implemented
 created: 2026-05-14
-updated: 2026-05-20
+updated: 2026-05-22
 author: vincent
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0078-rfc-number-reservation-ledger.md
+++ b/docs/rfc/RFC-0078-rfc-number-reservation-ledger.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0078"
 title: "RFC Number Reservation Ledger + CI Collision Guard"
-status: Draft
+status: Implemented
 created: 2026-05-14
-updated: 2026-05-20
+updated: 2026-05-22
 author: vincent
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0079-log-row-typed-encoder.md
+++ b/docs/rfc/RFC-0079-log-row-typed-encoder.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0079"
 title: "Log row typed encoder + silent-drop removal"
-status: Draft
+status: Implemented
 created: 2026-05-14
-updated: 2026-05-20
+updated: 2026-05-22
 author: vincent
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0080-tool-registry-ssot.md
+++ b/docs/rfc/RFC-0080-tool-registry-ssot.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0080"
 title: "Tool registry SSOT — collapse 15-fold OR membership into typed Tool_name boundary"
-status: Draft
+status: Implemented
 created: 2026-05-14
-updated: 2026-05-20
+updated: 2026-05-22
 author: vincent
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0081-telemetry-envelope-and-pivot-timeline.md
+++ b/docs/rfc/RFC-0081-telemetry-envelope-and-pivot-timeline.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0081"
 title: "OAS Telemetry Envelope Context & Keeper/Goal Pivot Timeline"
-status: Draft
+status: Implemented
 created: 2026-05-14
-updated: 2026-05-20
+updated: 2026-05-22
 author: vincent
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0090-write-side-success-model-attribution.md
+++ b/docs/rfc/RFC-0090-write-side-success-model-attribution.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0090"
 title: "Write-side success-model attribution — finish N-of-M migration"
-status: Draft
+status: Implemented
 created: 2026-05-17
-updated: 2026-05-20
+updated: 2026-05-22
 author: vincent
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0094-compact-cooldown-semantics-split.md
+++ b/docs/rfc/RFC-0094-compact-cooldown-semantics-split.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0094"
 title: "Compact cooldown semantics split — typed write anchor vs check anchor"
-status: Draft
+status: Implemented
 created: 2026-05-17
-updated: 2026-05-20
+updated: 2026-05-22
 author: vincent
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0095-openai-compat-streaming-wire-up.md
+++ b/docs/rfc/RFC-0095-openai-compat-streaming-wire-up.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0095"
 title: "OpenAI-compat provider streaming wire-up"
-status: Draft
+status: Implemented
 created: 2026-05-17
-updated: 2026-05-20
+updated: 2026-05-22
 author: jeong-sik
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0096-keeper-turn-contract-multi-turn-and-tier-group-spof.md
+++ b/docs/rfc/RFC-0096-keeper-turn-contract-multi-turn-and-tier-group-spof.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0096"
 title: "Keeper Turn Contract — multi-turn reasoning + tier-group SPOF root-fix"
-status: Draft
+status: Implemented
 created: 2026-05-17
-updated: 2026-05-20
+updated: 2026-05-22
 author: vincent
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0102-pre-turn-cascade-availability-gate.md
+++ b/docs/rfc/RFC-0102-pre-turn-cascade-availability-gate.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0102"
 title: "Pre-turn cascade availability gate — reuse, not new surface"
-status: Draft
+status: Implemented
 created: 2026-05-17
-updated: 2026-05-20
+updated: 2026-05-22
 author: vincent
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0110-tool-pair-atomicity-write-boundary.md
+++ b/docs/rfc/RFC-0110-tool-pair-atomicity-write-boundary.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0110"
 title: "Tool-pair atomicity at write boundary — sunset compaction repair fabrication"
-status: Draft
+status: Implemented
 created: 2026-05-17
-updated: 2026-05-20
+updated: 2026-05-22
 author: vincent
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0111-goal-mint-atomicity-uniqueness-invariant.md
+++ b/docs/rfc/RFC-0111-goal-mint-atomicity-uniqueness-invariant.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0111"
 title: "Goal mint atomicity — auto-goal uniqueness invariant at write boundary"
-status: Draft
+status: Implemented
 created: 2026-05-17
-updated: 2026-05-20
+updated: 2026-05-22
 author: vincent
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0112-typed-json-parse-boundary.md
+++ b/docs/rfc/RFC-0112-typed-json-parse-boundary.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0112"
 title: "Typed JSON parse boundary — eliminate silent-drop fallback across read sites"
-status: Draft
+status: Implemented
 created: 2026-05-17
-updated: 2026-05-20
+updated: 2026-05-22
 author: vincent
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0113-keeper-reaction-liveness-runtime.md
+++ b/docs/rfc/RFC-0113-keeper-reaction-liveness-runtime.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0113"
 title: "KeeperReactionLiveness L1–L5 runtime — phased OCaml mirror of TLA+ design ground"
-status: Draft
+status: Implemented
 created: 2026-05-17
-updated: 2026-05-20
+updated: 2026-05-22
 author: vincent
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0114-ksm-precondition-enforcement.md
+++ b/docs/rfc/RFC-0114-ksm-precondition-enforcement.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0114"
 title: "KSM event precondition enforcement at apply_event boundary"
-status: Draft
+status: Implemented
 created: 2026-05-17
-updated: 2026-05-20
+updated: 2026-05-22
 author: vincent
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0115-ktc-turn-phase-spec-runtime-parity.md
+++ b/docs/rfc/RFC-0115-ktc-turn-phase-spec-runtime-parity.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0115"
 title: "KTC turn_phase spec ← runtime parity — backfill spec for Turn_routing / Turn_exhausted"
-status: Draft
+status: Implemented
 created: 2026-05-17
-updated: 2026-05-20
+updated: 2026-05-22
 author: vincent
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0116-kcr-fallback-cap-mechanism-parity.md
+++ b/docs/rfc/RFC-0116-kcr-fallback-cap-mechanism-parity.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0116"
 title: "KCR fallback cap mechanism parity — explicit counter at spec ↔ visited-list at runtime"
-status: Draft
+status: Implemented
 created: 2026-05-17
-updated: 2026-05-20
+updated: 2026-05-22
 author: vincent
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0117-kcr-health-state-representation-parity.md
+++ b/docs/rfc/RFC-0117-kcr-health-state-representation-parity.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0117"
 title: "KCR item-health representation parity — typed Degraded variant + spec cooldown action + PerKeeperIsolation correction"
-status: Draft
+status: Implemented
 created: 2026-05-17
-updated: 2026-05-20
+updated: 2026-05-22
 author: vincent
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0118-kct-terminal-cascade-contract.md
+++ b/docs/rfc/RFC-0118-kct-terminal-cascade-contract.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0118"
 title: "KCT NoTerminalCascade S1 — typed Result at select_cascade boundary + Zombie mapping correction"
-status: Draft
+status: Implemented
 created: 2026-05-17
-updated: 2026-05-20
+updated: 2026-05-22
 author: vincent
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0119-observer-spec-mapping-table-drift-lint.md
+++ b/docs/rfc/RFC-0119-observer-spec-mapping-table-drift-lint.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0119"
 title: "Observer spec mapping table drift lint — sentinel-marker validator for OCaml↔TLA+ collapse projections"
-status: Draft
+status: Implemented
 created: 2026-05-17
-updated: 2026-05-20
+updated: 2026-05-22
 author: vincent
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0122-keeper-disk-pressure.md
+++ b/docs/rfc/RFC-0122-keeper-disk-pressure.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0122"
 title: "Keeper disk pressure — process-local fleet failure mode beyond FD"
-status: Draft
+status: Implemented
 created: 2026-05-17
-updated: 2026-05-21
+updated: 2026-05-22
 author: vincent
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0123-briefing-last-event-fabrication-write-boundary.md
+++ b/docs/rfc/RFC-0123-briefing-last-event-fabrication-write-boundary.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0123"
 title: "Briefing last_event fabrication — option-typed write boundary, sunset read-side sentinel"
-status: Draft
+status: Implemented
 created: 2026-05-17
-updated: 2026-05-20
+updated: 2026-05-22
 author: vincent
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0131-shell-command-gate-facade.md
+++ b/docs/rfc/RFC-0131-shell-command-gate-facade.md
@@ -1,7 +1,7 @@
 ---
 rfc: "0131"
 title: "Shell Command Gate facade — multi-caller IR-first validation"
-status: Draft
+status: Implemented
 created: 2026-05-19
 updated: 2026-05-19 (status note + §10 revised PR slicing added)
 author: vincent

--- a/docs/rfc/RFC-0133-keeper-phase-casing-ssot-consolidation.md
+++ b/docs/rfc/RFC-0133-keeper-phase-casing-ssot-consolidation.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0132"
 title: "Keeper Phase Casing SSOT Consolidation"
-status: Draft
+status: Implemented
 created: 2026-05-19
-updated: 2026-05-20
+updated: 2026-05-22
 author: vincent
 supersedes: []
 superseded_by: null

--- a/docs/rfc/RFC-0140-dashboard-wire-codec-layer.md
+++ b/docs/rfc/RFC-0140-dashboard-wire-codec-layer.md
@@ -1,9 +1,9 @@
 ---
 rfc: "0140"
 title: "Dashboard Wire-Format Codec Layer"
-status: Draft
+status: Implemented
 created: 2026-05-19
-updated: 2026-05-20
+updated: 2026-05-22
 author: vincent
 supersedes: []
 superseded_by: null


### PR DESCRIPTION
## Summary
- 28 Draft RFCs had every `implementation_prs` entry already MERGED on origin/main, but their frontmatter `status` remained `Draft`
- Each file: `status: Draft` → `status: Implemented`, `updated:` → `2026-05-22`
- Systemic pattern flagged in 2026-05-21 audit — frontmatter status depends on author self-discipline alone

## Verification
- Python script checked every `implementation_prs` entry via `gh pr view --json state`
- Only updated RFCs where **all** listed PRs have `state: MERGED`
- No code changes — frontmatter-only

## RFCs updated
0010, 0071, 0073, 0077, 0078, 0079, 0080, 0081, 0090, 0094, 0095, 0096, 0102, 0110, 0111, 0112, 0113, 0114, 0115, 0116, 0117, 0118, 0119, 0122, 0123, 0131, 0133, 0140

## Remaining Draft RFCs (not touched)
24 Draft RFCs either have no `implementation_prs` or have at least one OPEN/unmerged PR — correctly still Draft.

## Test plan
- [ ] `grep -c "^status: Draft" docs/rfc/RFC-*.md` should return fewer matches
- [ ] Each updated RFC's `implementation_prs` are all MERGED (verified programmatically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)