### PR TITLE
refactor(worker_dev_tools): extract token/path classifier sibling

### DIFF
--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -432,114 +432,27 @@ let validate_command_coding ?caller cmd =
     cmd
 ;;
 
-let looks_like_url token =
-  let token = strip_wrapping_quotes token in
-  match String.index_opt token ':' with
-  | Some idx when idx + 2 < String.length token ->
-    token.[idx + 1] = '/' && token.[idx + 2] = '/'
-  | _ -> false
-;;
-
-let is_path_flag token =
-  match strip_wrapping_quotes token with
-  | "-C" | "--git-dir" | "--work-tree" | "--exec-path" -> true
-  | _ -> false
-;;
-
-let path_flag_requires_existing_dir token =
-  match strip_wrapping_quotes token with
-  | "-C" | "--work-tree" -> true
-  | _ -> false
-;;
-
-let path_value_of_flagged_token token =
-  let token = strip_wrapping_quotes token in
-  let prefixes = [ "--git-dir="; "--work-tree="; "--exec-path=" ] in
-  List.find_map
-    (fun prefix ->
-       if String.starts_with ~prefix token
-       then
-         Some
-           (String.sub
-              token
-              (String.length prefix)
-              (String.length token - String.length prefix))
-       else None)
-    prefixes
-;;
-
-let inline_path_flag_requires_existing_dir token =
-  let token = strip_wrapping_quotes token in
-  String.starts_with ~prefix:"--work-tree=" token
-;;
-
-let command_materializes_path_arg = function
-  | "cat" | "find" | "grep" | "head" | "ls" | "nl" | "rg" | "sed" | "stat"
-  | "tail" | "wc" -> true
-  | _ -> false
-;;
-
-let path_is_existing_dir ?workdir path =
-  let resolved = resolve_path ?base_dir:workdir path in
-  try Sys.file_exists resolved && Sys.is_directory resolved with
-  | Sys_error _ -> false
-;;
-
-let looks_like_path_token token =
-  let token = strip_wrapping_quotes token in
-  token <> ""
-  && (not (looks_like_url token))
-  && (token = "."
-      || token = ".."
-      || String.starts_with ~prefix:"/" token
-      || String.starts_with ~prefix:"./" token
-      || String.starts_with ~prefix:"../" token
-      || String.starts_with ~prefix:"~/" token
-      || String.contains token '/')
-;;
-
-let token_value_is_explicit_path token =
-  let token = strip_wrapping_quotes token in
-  token = "."
-  || token = ".."
-  || String.starts_with ~prefix:"/" token
-  || String.starts_with ~prefix:"./" token
-  || String.starts_with ~prefix:"../" token
-  || String.starts_with ~prefix:"~/" token
-;;
-
-let token_has_parent_dir_segment token =
-  token
-  |> strip_wrapping_quotes
-  |> String.split_on_char '/'
-  |> List.exists (String.equal "..")
-;;
-
-let git_revisionish_token ?workdir token =
-  let token = strip_wrapping_quotes token |> String.trim in
-  token <> ""
-  && String.contains token '/'
-  && (not (token_value_is_explicit_path token))
-  && not (token_has_parent_dir_segment token)
-  &&
-  let resolved = resolve_path ?base_dir:workdir token in
-  not (Sys.file_exists resolved)
-;;
-
-let token_value_is_redirect_to_dev_null value =
-  String.equal value ">/dev/null"
-  || String.equal value "2>/dev/null"
-  || String.equal value "1>/dev/null"
-  || String.equal value ">>/dev/null"
-  || String.equal value "2>>/dev/null"
-  || String.equal value "1>>/dev/null"
-;;
-
-let token_value_is_redirect_op value =
-  match value with
-  | ">" | ">>" | "<" | "2>" | "2>>" | "1>" | "1>>" -> true
-  | _ -> false
-;;
+let looks_like_url = Worker_dev_tools_token_classify.looks_like_url
+let is_path_flag = Worker_dev_tools_token_classify.is_path_flag
+let path_flag_requires_existing_dir =
+  Worker_dev_tools_token_classify.path_flag_requires_existing_dir
+let path_value_of_flagged_token =
+  Worker_dev_tools_token_classify.path_value_of_flagged_token
+let inline_path_flag_requires_existing_dir =
+  Worker_dev_tools_token_classify.inline_path_flag_requires_existing_dir
+let command_materializes_path_arg =
+  Worker_dev_tools_token_classify.command_materializes_path_arg
+let path_is_existing_dir = Worker_dev_tools_token_classify.path_is_existing_dir
+let looks_like_path_token = Worker_dev_tools_token_classify.looks_like_path_token
+let token_value_is_explicit_path =
+  Worker_dev_tools_token_classify.token_value_is_explicit_path
+let token_has_parent_dir_segment =
+  Worker_dev_tools_token_classify.token_has_parent_dir_segment
+let git_revisionish_token = Worker_dev_tools_token_classify.git_revisionish_token
+let token_value_is_redirect_to_dev_null =
+  Worker_dev_tools_token_classify.token_value_is_redirect_to_dev_null
+let token_value_is_redirect_op =
+  Worker_dev_tools_token_classify.token_value_is_redirect_op
 
 let command_pattern_arg_flags cmd =
   match cmd with

--- a/lib/worker_dev_tools_token_classify.ml
+++ b/lib/worker_dev_tools_token_classify.ml
@@ -1,0 +1,124 @@
+(** Token / path classifier helpers for the dev-tools worker.
+
+    Pure functions on argv tokens — URL/path/redirect predicates plus
+    a few [Sys.file_exists]-style existence checks. Verbatim extract
+    from [Worker_dev_tools]. All callers are internal to the parent
+    (verified via grep across lib/ + test/).
+
+    Dependencies:
+    - [Worker_dev_tools_command_syntax.strip_wrapping_quotes] —
+      brought in via [open] so the helper bodies remain byte-for-byte
+      identical to the pre-extraction code.
+    - [Worker_dev_tools_paths.resolve_path] — fully-qualified at the
+      two use sites (path_is_existing_dir, git_revisionish_token). *)
+
+open Worker_dev_tools_command_syntax
+
+let looks_like_url token =
+  let token = strip_wrapping_quotes token in
+  match String.index_opt token ':' with
+  | Some idx when idx + 2 < String.length token ->
+    token.[idx + 1] = '/' && token.[idx + 2] = '/'
+  | _ -> false
+;;
+
+let is_path_flag token =
+  match strip_wrapping_quotes token with
+  | "-C" | "--git-dir" | "--work-tree" | "--exec-path" -> true
+  | _ -> false
+;;
+
+let path_flag_requires_existing_dir token =
+  match strip_wrapping_quotes token with
+  | "-C" | "--work-tree" -> true
+  | _ -> false
+;;
+
+let path_value_of_flagged_token token =
+  let token = strip_wrapping_quotes token in
+  let prefixes = [ "--git-dir="; "--work-tree="; "--exec-path=" ] in
+  List.find_map
+    (fun prefix ->
+       if String.starts_with ~prefix token
+       then
+         Some
+           (String.sub
+              token
+              (String.length prefix)
+              (String.length token - String.length prefix))
+       else None)
+    prefixes
+;;
+
+let inline_path_flag_requires_existing_dir token =
+  let token = strip_wrapping_quotes token in
+  String.starts_with ~prefix:"--work-tree=" token
+;;
+
+let command_materializes_path_arg = function
+  | "cat" | "find" | "grep" | "head" | "ls" | "nl" | "rg" | "sed" | "stat"
+  | "tail" | "wc" -> true
+  | _ -> false
+;;
+
+let path_is_existing_dir ?workdir path =
+  let resolved = Worker_dev_tools_paths.resolve_path ?base_dir:workdir path in
+  try Sys.file_exists resolved && Sys.is_directory resolved with
+  | Sys_error _ -> false
+;;
+
+let looks_like_path_token token =
+  let token = strip_wrapping_quotes token in
+  token <> ""
+  && (not (looks_like_url token))
+  && (token = "."
+      || token = ".."
+      || String.starts_with ~prefix:"/" token
+      || String.starts_with ~prefix:"./" token
+      || String.starts_with ~prefix:"../" token
+      || String.starts_with ~prefix:"~/" token
+      || String.contains token '/')
+;;
+
+let token_value_is_explicit_path token =
+  let token = strip_wrapping_quotes token in
+  token = "."
+  || token = ".."
+  || String.starts_with ~prefix:"/" token
+  || String.starts_with ~prefix:"./" token
+  || String.starts_with ~prefix:"../" token
+  || String.starts_with ~prefix:"~/" token
+;;
+
+let token_has_parent_dir_segment token =
+  token
+  |> strip_wrapping_quotes
+  |> String.split_on_char '/'
+  |> List.exists (String.equal "..")
+;;
+
+let git_revisionish_token ?workdir token =
+  let token = strip_wrapping_quotes token |> String.trim in
+  token <> ""
+  && String.contains token '/'
+  && (not (token_value_is_explicit_path token))
+  && not (token_has_parent_dir_segment token)
+  &&
+  let resolved = Worker_dev_tools_paths.resolve_path ?base_dir:workdir token in
+  not (Sys.file_exists resolved)
+;;
+
+let token_value_is_redirect_to_dev_null value =
+  String.equal value ">/dev/null"
+  || String.equal value "2>/dev/null"
+  || String.equal value "1>/dev/null"
+  || String.equal value ">>/dev/null"
+  || String.equal value "2>>/dev/null"
+  || String.equal value "1>>/dev/null"
+;;
+
+let token_value_is_redirect_op value =
+  match value with
+  | ">" | ">>" | "<" | "2>" | "2>>" | "1>" | "1>>" -> true
+  | _ -> false
+;;


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/worker_dev_tools.ml` (1453 → 1366 LOC, **-87**). First touch on this godfile — 12th-largest `.ml` in `lib/`, audited by the 2026-05-18 godfile-decomposition build plan.

New sibling `lib/worker_dev_tools_token_classify.ml` (124 LOC) hosts 13 pure token / path classifier helpers used by the dev-tools exec/path validators:

- `looks_like_url` — `scheme://`-prefix detector
- `is_path_flag` — git path-flag whitelist (`-C`, `--git-dir`, etc.)
- `path_flag_requires_existing_dir` — subset that demands a directory
- `path_value_of_flagged_token` — strips `--flag=VALUE` prefixes
- `inline_path_flag_requires_existing_dir` — `--work-tree=` probe
- `command_materializes_path_arg` — read-only commands that take paths
- `path_is_existing_dir` — `Sys.is_directory` wrapper
- `looks_like_path_token` — explicit-path heuristic
- `token_value_is_explicit_path` — dotted / absolute / `~/` prefix
- `token_has_parent_dir_segment` — `..` segment detector
- `git_revisionish_token` — rev-ish vs path disambiguation
- `token_value_is_redirect_to_dev_null` — 6 redirect forms
- `token_value_is_redirect_op` — bare redirect operator

Pure helpers — no parent-local state, no callback injection. External callers: **none** (verified via grep across `lib/` + `test/`; no `.mli` references either). Internal callers preserved via 13 parent aliases.

## Dependencies

- `open Worker_dev_tools_command_syntax` in the sibling brings `strip_wrapping_quotes` into scope (mirrors parent's `open`).
- `Worker_dev_tools_paths.resolve_path` is fully-qualified at the two use sites (`path_is_existing_dir`, `git_revisionish_token`).

## Context

The parent already had 4 prior decomposed siblings (`Paths`, `Log_sanitize`, `Command_syntax`, `Mutation_classifier`) — this PR adds a 5th and continues the established sibling pattern.

## Test plan

- [x] `dune build --root . lib/` clean
- [x] No `.mli` to update (no surface to maintain for these helpers)
- [x] External caller grep across `lib/` + `test/` — no callers found
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
