### PR TITLE
refactor(server_runtime_bootstrap): extract legacy-room inference sibling

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -177,72 +177,14 @@ let migrate_legacy_dirs_with_renames = Server_runtime_bootstrap_legacy_migration
 let migrate_legacy_dirs = Server_runtime_bootstrap_legacy_migration.migrate_legacy_dirs
 let migrate_legacy_keeper_dirs_blocking = Server_runtime_bootstrap_legacy_migration.migrate_legacy_keeper_dirs_blocking
 
-let default_room_for_flat_migration = "focus-room"
-
-let legacy_room_candidates rooms_dir =
-  if not (Sys.file_exists rooms_dir) then
-    []
-  else
-    Safe_ops.protect ~default:[] (fun () ->
-      Sys.readdir rooms_dir
-      |> Array.to_list
-      |> List.filter_map (fun room_id ->
-           let room_path = Filename.concat rooms_dir room_id in
-           if Sys.is_directory room_path then
-             let trimmed_room_id = String.trim room_id in
-             if not (String.equal room_id trimmed_room_id) then begin
-               Log.Misc.warn
-                 "migrate: ignoring invalid legacy room dir %S (must not have leading/trailing whitespace)"
-                 room_id;
-               None
-             end else
-               match Coord.validate_room_id room_id with
-               | Ok valid_room_id -> Some valid_room_id
-               | Error msg ->
-                 Log.Misc.warn
-                   "migrate: ignoring invalid legacy room dir %s (%s)" room_id
-                   msg;
-                   None
-           else
-             None))
-
-let infer_current_room_from_legacy_dirs rooms_dir =
-  match legacy_room_candidates rooms_dir with
-  | [ room_id ] ->
-      Log.Misc.info
-        "migrate: current_room unavailable; using only legacy room %s" room_id;
-      Some room_id
-  | room_ids when List.mem default_room_for_flat_migration room_ids ->
-      Log.Misc.info
-        "migrate: current_room unavailable; using legacy room %s"
-        default_room_for_flat_migration;
-      Some default_room_for_flat_migration
-  | [] -> None
-  | room_ids ->
-      Log.Misc.warn
-        "migrate: current_room unavailable and multiple legacy rooms exist (%s); skipping room flatten"
-        (String.concat ", " room_ids);
-      None
-
-let load_current_room_or_default masc_root rooms_dir =
-  let path = Filename.concat masc_root "current_room" in
-  if not (Sys.file_exists path) then
-    infer_current_room_from_legacy_dirs rooms_dir
-  else
-    match Safe_ops.read_file_safe path with
-    | Error msg ->
-        Log.Misc.warn
-          "migrate: failed to read %s (%s); probing legacy room dirs instead"
-          path msg;
-        infer_current_room_from_legacy_dirs rooms_dir
-    | Ok raw -> (
-        match Coord.validate_room_id (String.trim raw) with
-        | Ok room_id -> Some room_id
-        | Error msg ->
-            Log.Misc.warn
-              "migrate: ignoring invalid current_room in %s (%s); probing legacy room dirs instead"
-              path msg;
-            infer_current_room_from_legacy_dirs rooms_dir)
+let default_room_for_flat_migration =
+  Server_runtime_bootstrap_legacy_room.default_room_for_flat_migration
+let legacy_room_candidates =
+  Server_runtime_bootstrap_legacy_room.legacy_room_candidates
+let infer_current_room_from_legacy_dirs =
+  Server_runtime_bootstrap_legacy_room.infer_current_room_from_legacy_dirs
+let load_current_room_or_default =
+  Server_runtime_bootstrap_legacy_room.load_current_room_or_default
 
 let migrate_room_to_flat (state : Mcp_server.server_state) =
   let masc_root = Coord.masc_root_dir state.room_config in

--- a/lib/server/server_runtime_bootstrap_legacy_room.ml
+++ b/lib/server/server_runtime_bootstrap_legacy_room.ml
@@ -1,0 +1,77 @@
+(** Legacy-room inference for the flat-room migration path.
+
+    Pre-flat-migration, sessions lived under [.masc/rooms/<room_id>/].
+    The new layout puts session files directly under [.masc/]. When
+    we detect a [rooms/] dir but no [current_room] marker, this
+    module decides which legacy room (if any) becomes the root.
+
+    Pure filesystem + Log.Misc + Coord; no parent-local state.
+    Extracted verbatim from [Server_runtime_bootstrap]; all callers
+    are internal to the parent. *)
+
+let default_room_for_flat_migration = "focus-room"
+
+let legacy_room_candidates rooms_dir =
+  if not (Sys.file_exists rooms_dir) then
+    []
+  else
+    Safe_ops.protect ~default:[] (fun () ->
+      Sys.readdir rooms_dir
+      |> Array.to_list
+      |> List.filter_map (fun room_id ->
+           let room_path = Filename.concat rooms_dir room_id in
+           if Sys.is_directory room_path then
+             let trimmed_room_id = String.trim room_id in
+             if not (String.equal room_id trimmed_room_id) then begin
+               Log.Misc.warn
+                 "migrate: ignoring invalid legacy room dir %S (must not have leading/trailing whitespace)"
+                 room_id;
+               None
+             end else
+               match Coord.validate_room_id room_id with
+               | Ok valid_room_id -> Some valid_room_id
+               | Error msg ->
+                 Log.Misc.warn
+                   "migrate: ignoring invalid legacy room dir %s (%s)" room_id
+                   msg;
+                   None
+           else
+             None))
+
+let infer_current_room_from_legacy_dirs rooms_dir =
+  match legacy_room_candidates rooms_dir with
+  | [ room_id ] ->
+      Log.Misc.info
+        "migrate: current_room unavailable; using only legacy room %s" room_id;
+      Some room_id
+  | room_ids when List.mem default_room_for_flat_migration room_ids ->
+      Log.Misc.info
+        "migrate: current_room unavailable; using legacy room %s"
+        default_room_for_flat_migration;
+      Some default_room_for_flat_migration
+  | [] -> None
+  | room_ids ->
+      Log.Misc.warn
+        "migrate: current_room unavailable and multiple legacy rooms exist (%s); skipping room flatten"
+        (String.concat ", " room_ids);
+      None
+
+let load_current_room_or_default masc_root rooms_dir =
+  let path = Filename.concat masc_root "current_room" in
+  if not (Sys.file_exists path) then
+    infer_current_room_from_legacy_dirs rooms_dir
+  else
+    match Safe_ops.read_file_safe path with
+    | Error msg ->
+        Log.Misc.warn
+          "migrate: failed to read %s (%s); probing legacy room dirs instead"
+          path msg;
+        infer_current_room_from_legacy_dirs rooms_dir
+    | Ok raw -> (
+        match Coord.validate_room_id (String.trim raw) with
+        | Ok room_id -> Some room_id
+        | Error msg ->
+            Log.Misc.warn
+              "migrate: ignoring invalid current_room in %s (%s); probing legacy room dirs instead"
+              path msg;
+            infer_current_room_from_legacy_dirs rooms_dir)


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/server/server_runtime_bootstrap.ml` (1443 → 1385 LOC, **-58**). First touch on this godfile — 13th-largest `.ml` in `lib/`, audited by the 2026-05-18 godfile-decomposition build plan.

New sibling `lib/server/server_runtime_bootstrap_legacy_room.ml` (78 LOC) hosts the pre-flat-migration legacy-room inference cluster:

- `default_room_for_flat_migration` = `"focus-room"` (constant)
- `legacy_room_candidates` — scans `rooms/` dir; drops whitespace-framed names and invalid room ids; tolerates `Sys.readdir` failures via `Safe_ops.protect`
- `infer_current_room_from_legacy_dirs` — picks an unambiguous legacy room (single dir) or falls back to `focus-room` when present; refuses to flatten on N-way ambiguity
- `load_current_room_or_default` — reads `.masc/current_room` marker then falls through to the inference path on read or validate errors

Pure helpers — only depend on `Sys` + `Filename` + `Safe_ops` + `Log.Misc` + `Coord` (`validate_room_id`, `masc_root_dir`). No parent-local state, no callback injection. All callers are internal to the parent (verified via grep across `lib/` + `test/`; no `.mli` references).

Parent retains 4 single-line aliases. Subsequent caller `migrate_room_to_flat` (line 247) resolves through the parent alias without edits.

## Context

The parent already had 2 prior decomposed siblings (`Config_root_bootstrap`, `Server_runtime_bootstrap_legacy_migration`) — this PR adds a 3rd and continues the established pattern.

## Test plan

- [x] `dune build --root . lib/` clean
- [x] No `.mli` to update (no surface to maintain for these helpers)
- [x] External caller grep across `lib/` + `test/` — no callers found
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
