### PR TITLE
refactor(tool_keeper): extract path validation sibling

### DIFF
--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -581,73 +581,10 @@ let annotate_keeper_repair_json ?identity_reseed ~(keeper_name : string) body =
 
 (* Playground path containment helpers (inlined from deleted Tool_repair_loop). *)
 
-let is_safe_subpath ~parent ~child =
-  if String.equal child parent then true
-  else
-    let parent_with_sep =
-      if Filename.check_suffix parent Stdlib.Filename.dir_sep then parent
-      else parent ^ Filename.dir_sep
-    in
-    let plen = String.length parent_with_sep in
-    String.length child >= plen
-    && String.equal (Stdlib.String.sub child 0 plen) parent_with_sep
-
-let validate_target_file ~working_dir ~target_file =
-  match target_file with
-  | None -> Ok None
-  | Some tf ->
-      if not (Filename.is_relative tf) then
-        Error "target_file must be a relative path"
-      else
-        let candidate = Filename.concat working_dir tf in
-        let resolved =
-          try Unix.realpath candidate with
-          | Unix.Unix_error _ -> candidate
-        in
-        if is_safe_subpath ~parent:working_dir ~child:resolved then
-          Ok (Some tf)
-        else
-          Error "target_file must reside within working_dir"
-
-let resolve_playground_working_dir ~agent_name ~base_path ~working_dir_arg =
-  let playground_rel =
-    Keeper_alerting_path.playground_path_of_keeper agent_name
-  in
-  let playground_abs_raw = Filename.concat base_path playground_rel in
-  match
-    try Ok (Unix.realpath playground_abs_raw) with
-    | Unix.Unix_error _ ->
-        Error
-          (Printf.sprintf
-             "keeper playground directory %S does not exist yet — cannot \
-              validate working_dir containment. Run masc_worktree_create \
-              to provision your playground first. See #6527/#6641."
-             playground_rel)
-  with
-  | Error msg -> Error msg
-  | Ok playground_abs ->
-      let effective_arg =
-        if String.equal (String.trim working_dir_arg) "" then playground_abs
-        else working_dir_arg
-      in
-      let resolved =
-        try Ok (Unix.realpath effective_arg) with
-        | Unix.Unix_error _ ->
-            Error "working_dir does not exist or is not accessible"
-      in
-      (match resolved with
-      | Error msg -> Error msg
-      | Ok working_dir ->
-          if is_safe_subpath ~parent:playground_abs ~child:working_dir then
-            Ok working_dir
-          else
-            Error
-              (Printf.sprintf
-                 "working_dir must be inside your own keeper playground \
-                  (%s). Cross-keeper repair loops are blocked — use \
-                  masc_worktree_create to provision a workspace under your \
-                  playground first. See #6527/#6641."
-                 playground_rel))
+let is_safe_subpath = Tool_keeper_path_validation.is_safe_subpath
+let validate_target_file = Tool_keeper_path_validation.validate_target_file
+let resolve_playground_working_dir =
+  Tool_keeper_path_validation.resolve_playground_working_dir
 
 let handle_keeper_repair ctx args : tool_result =
   match resolve_keeper_meta ctx args with

--- a/lib/tool_keeper_path_validation.ml
+++ b/lib/tool_keeper_path_validation.ml
@@ -1,0 +1,76 @@
+(** Path / working-dir validation helpers for keeper repair flows.
+
+    Verbatim extract from [Tool_keeper]. Used by
+    [handle_keeper_repair] to enforce that target files and working
+    directories stay inside the calling keeper's own playground.
+
+    Pure helpers (modulo [Unix.realpath]); no parent-local state.
+    All callers are internal to [Tool_keeper]. *)
+
+let is_safe_subpath ~parent ~child =
+  if String.equal child parent then true
+  else
+    let parent_with_sep =
+      if Filename.check_suffix parent Stdlib.Filename.dir_sep then parent
+      else parent ^ Filename.dir_sep
+    in
+    let plen = String.length parent_with_sep in
+    String.length child >= plen
+    && String.equal (Stdlib.String.sub child 0 plen) parent_with_sep
+
+let validate_target_file ~working_dir ~target_file =
+  match target_file with
+  | None -> Ok None
+  | Some tf ->
+      if not (Filename.is_relative tf) then
+        Error "target_file must be a relative path"
+      else
+        let candidate = Filename.concat working_dir tf in
+        let resolved =
+          try Unix.realpath candidate with
+          | Unix.Unix_error _ -> candidate
+        in
+        if is_safe_subpath ~parent:working_dir ~child:resolved then
+          Ok (Some tf)
+        else
+          Error "target_file must reside within working_dir"
+
+let resolve_playground_working_dir ~agent_name ~base_path ~working_dir_arg =
+  let playground_rel =
+    Keeper_alerting_path.playground_path_of_keeper agent_name
+  in
+  let playground_abs_raw = Filename.concat base_path playground_rel in
+  match
+    try Ok (Unix.realpath playground_abs_raw) with
+    | Unix.Unix_error _ ->
+        Error
+          (Printf.sprintf
+             "keeper playground directory %S does not exist yet — cannot \
+              validate working_dir containment. Run masc_worktree_create \
+              to provision your playground first. See #6527/#6641."
+             playground_rel)
+  with
+  | Error msg -> Error msg
+  | Ok playground_abs ->
+      let effective_arg =
+        if String.equal (String.trim working_dir_arg) "" then playground_abs
+        else working_dir_arg
+      in
+      let resolved =
+        try Ok (Unix.realpath effective_arg) with
+        | Unix.Unix_error _ ->
+            Error "working_dir does not exist or is not accessible"
+      in
+      (match resolved with
+      | Error msg -> Error msg
+      | Ok working_dir ->
+          if is_safe_subpath ~parent:playground_abs ~child:working_dir then
+            Ok working_dir
+          else
+            Error
+              (Printf.sprintf
+                 "working_dir must be inside your own keeper playground \
+                  (%s). Cross-keeper repair loops are blocked — use \
+                  masc_worktree_create to provision a workspace under your \
+                  playground first. See #6527/#6641."
+                 playground_rel))


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/tool_keeper.ml` (1429 → 1366 LOC, **-63**). First touch on this godfile — 14th-largest `.ml` in `lib/`, audited by the 2026-05-18 godfile-decomposition build plan.

New sibling `lib/tool_keeper_path_validation.ml` (76 LOC) hosts 3 playground containment helpers used by `handle_keeper_repair` to enforce cross-keeper isolation:

- `is_safe_subpath ~parent ~child` — explicit dir-sep aware containment check (separator-terminated prefix match)
- `validate_target_file ~working_dir ~target_file` — requires relative path + `realpath`-resolved containment within `working_dir`
- `resolve_playground_working_dir ~agent_name ~base_path ~working_dir_arg` — resolves the caller's playground absolute path, validates `working_dir` arg lives inside it; returns helpful error messages referencing #6527/#6641

Pure helpers (modulo `Unix.realpath`); no parent-local state. All callers are internal to the parent (verified via grep across `lib/` + `test/`; no `.mli` references; `tool_deep_review` has its own plural `validate_target_files` variant — separate function).

Parent retains 3 single-line aliases. `handle_keeper_repair` (parent line 589) resolves through them without edits.

## Context

The parent already had 2 prior decomposed siblings (`Persona`, `Persona_audit`/`Tool_keeper_persona_audit`) — this PR adds a 3rd and continues the established pattern.

## Test plan

- [x] `dune build --root . lib/` clean
- [x] No `.mli` to update (no surface to maintain for these helpers)
- [x] External caller grep across `lib/` + `test/` — no callers found
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
