### PR TITLE
refactor(keeper_context_core): extract tool-pair-repair stats sibling

### DIFF
--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -233,48 +233,23 @@ let tool_result_text_of_block ~tool_use_id ~content ~json =
 
 let tool_use_text_of_block = Keeper_context_tool_text_block.tool_use_text_of_block
 
-type tool_pair_repair_stats =
+type tool_pair_repair_stats = Keeper_context_core_pair_repair_stats.tool_pair_repair_stats =
   { downgraded_tool_uses : int
   ; downgraded_tool_results : int
   }
 
 let empty_tool_pair_repair_stats =
-  { downgraded_tool_uses = 0; downgraded_tool_results = 0 }
-
-let add_tool_pair_repair_stats left right =
-  { downgraded_tool_uses =
-      left.downgraded_tool_uses + right.downgraded_tool_uses
-  ; downgraded_tool_results =
-      left.downgraded_tool_results + right.downgraded_tool_results
-  }
-
-let tool_pair_repair_stats_changed stats =
-  stats.downgraded_tool_uses > 0 || stats.downgraded_tool_results > 0
-
-let pair_repair_metadata_key = "masc.tool_pair_repair"
-
+  Keeper_context_core_pair_repair_stats.empty_tool_pair_repair_stats
+let add_tool_pair_repair_stats =
+  Keeper_context_core_pair_repair_stats.add_tool_pair_repair_stats
+let tool_pair_repair_stats_changed =
+  Keeper_context_core_pair_repair_stats.tool_pair_repair_stats_changed
+let pair_repair_metadata_key =
+  Keeper_context_core_pair_repair_stats.pair_repair_metadata_key
 let pair_repair_metadata_keys =
-  [ "was_fabricated"; "fabrication_source"; pair_repair_metadata_key ]
-
-let with_pair_repair_metadata ~kind ~count (msg : Agent_sdk.Types.message) =
-  let metadata =
-    List.filter
-      (fun (key, _) -> not (List.mem key pair_repair_metadata_keys))
-      msg.metadata
-  in
-  { msg with
-    metadata =
-      [ "was_fabricated", `Bool true
-      ; "fabrication_source", `String "tool_pair_repair"
-      ; ( pair_repair_metadata_key
-        , `Assoc
-            [ "version", `Int 1
-            ; "kind", `String kind
-            ; "count", `Int count
-            ] )
-      ]
-      @ metadata
-  }
+  Keeper_context_core_pair_repair_stats.pair_repair_metadata_keys
+let with_pair_repair_metadata =
+  Keeper_context_core_pair_repair_stats.with_pair_repair_metadata
 
 let repair_dangling_tool_use_messages_with_stats
     (messages : Agent_sdk.Types.message list)

--- a/lib/keeper/keeper_context_core_pair_repair_stats.ml
+++ b/lib/keeper/keeper_context_core_pair_repair_stats.ml
@@ -1,0 +1,54 @@
+(** Tool-pair repair stats and metadata helpers.
+
+    Counters and message-metadata bookkeeping for the
+    [repair_*_tool_*] family in [Keeper_context_core]. The repair
+    bodies themselves stay in the parent (they depend on the
+    parent's [tool_result_text_of_block] specialization, which
+    closes over the parent's
+    [default_max_checkpoint_tool_result_chars] constant).
+
+    Pure record / metadata helpers — no parent-local state, no I/O,
+    no callback injection. *)
+
+type tool_pair_repair_stats =
+  { downgraded_tool_uses : int
+  ; downgraded_tool_results : int
+  }
+
+let empty_tool_pair_repair_stats =
+  { downgraded_tool_uses = 0; downgraded_tool_results = 0 }
+
+let add_tool_pair_repair_stats left right =
+  { downgraded_tool_uses =
+      left.downgraded_tool_uses + right.downgraded_tool_uses
+  ; downgraded_tool_results =
+      left.downgraded_tool_results + right.downgraded_tool_results
+  }
+
+let tool_pair_repair_stats_changed stats =
+  stats.downgraded_tool_uses > 0 || stats.downgraded_tool_results > 0
+
+let pair_repair_metadata_key = "masc.tool_pair_repair"
+
+let pair_repair_metadata_keys =
+  [ "was_fabricated"; "fabrication_source"; pair_repair_metadata_key ]
+
+let with_pair_repair_metadata ~kind ~count (msg : Agent_sdk.Types.message) =
+  let metadata =
+    List.filter
+      (fun (key, _) -> not (List.mem key pair_repair_metadata_keys))
+      msg.metadata
+  in
+  { msg with
+    metadata =
+      [ "was_fabricated", `Bool true
+      ; "fabrication_source", `String "tool_pair_repair"
+      ; ( pair_repair_metadata_key
+        , `Assoc
+            [ "version", `Int 1
+            ; "kind", `String kind
+            ; "count", `Int count
+            ] )
+      ]
+      @ metadata
+  }


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/keeper/keeper_context_core.ml` (1389 → 1364 LOC, **-25**). First touch on this godfile — 17th-largest `.ml` in `lib/`, audited by the 2026-05-18 godfile-decomposition build plan.

New sibling `lib/keeper/keeper_context_core_pair_repair_stats.ml` (54 LOC) hosts the tool-pair-repair stats / metadata helpers:

- `type tool_pair_repair_stats = { downgraded_tool_uses : int; downgraded_tool_results : int }`
- `empty_tool_pair_repair_stats`
- `add_tool_pair_repair_stats` — combines two stats by field sum
- `tool_pair_repair_stats_changed` — bool predicate
- `pair_repair_metadata_key` = `"masc.tool_pair_repair"`
- `pair_repair_metadata_keys` — 3-entry list incl. `was_fabricated` + `fabrication_source`
- `with_pair_repair_metadata ~kind ~count msg` — stamps message metadata with version=1 / kind / count and replaces any prior pair-repair markers

Pure helpers — no parent-local state, no I/O, no callback injection. Only depend on `Agent_sdk.Types.message` metadata shape.

## Scope rationale

The repair bodies themselves (`repair_dangling_tool_use_messages_*`, `repair_orphan_tool_result_messages_*`, `repair_broken_tool_call_pairs_*`) **stay in the parent** because they close over `tool_result_text_of_block`, which is the parent's specialization of `Keeper_context_tool_text_block.tool_result_text_of_block` with `default_max_checkpoint_tool_result_chars=8000`. Moving the repair bodies would force either a parent→sibling dependency (forbidden — sibling can't reference parent) or callback injection at every call site. Stats type + metadata helpers are the clean cut.

## Parent surface preservation

- `type tool_pair_repair_stats` uses transparent `type X = Sibling.X = { ... }` alias so the `.mli` concrete-field declaration at line 92 stays valid. Field-name resolution and record-update syntax in remaining call sites (lines 305, 320-326, 350, 378-396, 401) still work.
- 6 value bindings have single-line aliases.

## External callers preserved

- `tool_pair_repair_stats_changed` — `test/test_pbt_context_overflow.ml`
- `repair_broken_tool_call_pairs` / `_with_stats` — 5 `lib/` + 1 `test/`
- `pair_repair_metadata_key` — `lib/prometheus_builtin_metrics_part1.ml`, `lib/keeper/keeper_compact_policy.ml`

## Test plan

- [x] `dune build --root . lib/` clean
- [x] `.mli` surface unchanged (transparent type alias preserves concrete field declaration)
- [x] External caller grep across `lib/` + `test/` — surface preserved via parent aliases
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
