### PR TITLE
refactor(keeper_turn_slot): extract types + wait-timeout exception sibling

### DIFF
--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -9,33 +9,25 @@ open Keeper_types
 (** The three semaphore pools that gate keeper turn admission.
     Closed sum type: adding a new pool requires updating every match site,
     which the compiler enforces exhaustively. *)
-type slot_pool =
+type slot_pool = Keeper_turn_slot_types.slot_pool =
   | Turn_pool
   | Autonomous_pool
   | Reactive_pool
 
-let slot_pool_to_string = function
-  | Turn_pool -> "turn"
-  | Autonomous_pool -> "autonomous"
-  | Reactive_pool -> "reactive"
-;;
+let slot_pool_to_string = Keeper_turn_slot_types.slot_pool_to_string
 
-exception Semaphore_wait_timeout of float
+exception Semaphore_wait_timeout = Keeper_turn_slot_types.Semaphore_wait_timeout
 
-type semaphore_wait_phase =
+type semaphore_wait_phase = Keeper_turn_slot_types.semaphore_wait_phase =
   | Autonomous_queue_head
   | Autonomous_slot
   | Reactive_slot
   | Turn_slot
 
-let semaphore_wait_phase_to_string = function
-  | Autonomous_queue_head -> "autonomous_queue_head"
-  | Autonomous_slot -> "autonomous_slot"
-  | Reactive_slot -> "reactive_slot"
-  | Turn_slot -> "turn_slot"
-;;
+let semaphore_wait_phase_to_string =
+  Keeper_turn_slot_types.semaphore_wait_phase_to_string
 
-type semaphore_wait_timeout =
+type semaphore_wait_timeout = Keeper_turn_slot_types.semaphore_wait_timeout =
   { timeout_wait_sec : float
   ; timeout_phase : semaphore_wait_phase
   ; timeout_autonomous_available : int
@@ -46,17 +38,7 @@ type semaphore_wait_timeout =
   ; timeout_holders : (string * float) list
   }
 
-(* RFC-0085 PR-11 — Dropped the [~deprecated] fallback; the typo legacy
-   env MASC_KEEPER_AUTOBOT_MAX is no longer recognised. Operators
-   must set MASC_KEEPER_AUTOBOOT_MAX. *)
-let int_of_env_default ~primary ~default ~min_v ~max_v =
-  match Sys.getenv_opt primary with
-  | None -> default
-  | Some raw when String.trim raw = "" -> default
-  | Some raw ->
-    let v = Option.value ~default (int_of_string_opt (String.trim raw)) in
-    Keeper_config.clamp_int v ~min_v ~max_v
-;;
+let int_of_env_default = Keeper_turn_slot_types.int_of_env_default
 
 (* Global turn slot cap across autonomous + reactive pools.
 

--- a/lib/keeper/keeper_turn_slot_types.ml
+++ b/lib/keeper/keeper_turn_slot_types.ml
@@ -1,0 +1,60 @@
+(** Slot/pool/phase variants + wait-timeout payload for the keeper
+    turn slot machinery.
+
+    Pure types + small [_to_string] helpers + the [Semaphore_wait_timeout]
+    exception. Verbatim extract from the head of [Keeper_turn_slot].
+
+    The exception is defined here so it has a single identity across
+    the module boundary; the parent re-exports it via
+    [exception Semaphore_wait_timeout = Keeper_turn_slot_types.Semaphore_wait_timeout]
+    so existing [try ... with Semaphore_wait_timeout _ -> ...]
+    patterns continue to match. *)
+
+type slot_pool =
+  | Turn_pool
+  | Autonomous_pool
+  | Reactive_pool
+
+let slot_pool_to_string = function
+  | Turn_pool -> "turn"
+  | Autonomous_pool -> "autonomous"
+  | Reactive_pool -> "reactive"
+;;
+
+exception Semaphore_wait_timeout of float
+
+type semaphore_wait_phase =
+  | Autonomous_queue_head
+  | Autonomous_slot
+  | Reactive_slot
+  | Turn_slot
+
+let semaphore_wait_phase_to_string = function
+  | Autonomous_queue_head -> "autonomous_queue_head"
+  | Autonomous_slot -> "autonomous_slot"
+  | Reactive_slot -> "reactive_slot"
+  | Turn_slot -> "turn_slot"
+;;
+
+type semaphore_wait_timeout =
+  { timeout_wait_sec : float
+  ; timeout_phase : semaphore_wait_phase
+  ; timeout_autonomous_available : int
+  ; timeout_reactive_available : int
+  ; timeout_turn_available : int
+  ; timeout_queue_depth : int
+  ; timeout_queue_ahead : int option
+  ; timeout_holders : (string * float) list
+  }
+
+(* RFC-0085 PR-11 — Dropped the [~deprecated] fallback; the typo legacy
+   env MASC_KEEPER_AUTOBOT_MAX is no longer recognised. Operators
+   must set MASC_KEEPER_AUTOBOOT_MAX. *)
+let int_of_env_default ~primary ~default ~min_v ~max_v =
+  match Sys.getenv_opt primary with
+  | None -> default
+  | Some raw when String.trim raw = "" -> default
+  | Some raw ->
+    let v = Option.value ~default (int_of_string_opt (String.trim raw)) in
+    Keeper_config.clamp_int v ~min_v ~max_v
+;;


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/keeper/keeper_turn_slot.ml` (1381 → 1363 LOC, **-18**). First touch on this godfile — 18th-largest `.ml` in `lib/`, audited by the 2026-05-18 godfile-decomposition build plan.

New sibling `lib/keeper/keeper_turn_slot_types.ml` (60 LOC) hosts the type / variant / exception bundle at the head of the parent:

- `type slot_pool = Turn_pool | Autonomous_pool | Reactive_pool`
- `val slot_pool_to_string`
- `exception Semaphore_wait_timeout of float`
- `type semaphore_wait_phase = Autonomous_queue_head | Autonomous_slot | Reactive_slot | Turn_slot`
- `val semaphore_wait_phase_to_string`
- `type semaphore_wait_timeout` — 8-field record incl. `timeout_phase: semaphore_wait_phase`
- `val int_of_env_default` — env parse + `Keeper_config.clamp_int`

All public on the parent `.mli`; transparent aliasing in parent preserves type identity + concrete-field reachability.

## Parent surface preservation

```ocaml
type slot_pool = Keeper_turn_slot_types.slot_pool =
  | Turn_pool | Autonomous_pool | Reactive_pool

exception Semaphore_wait_timeout =
  Keeper_turn_slot_types.Semaphore_wait_timeout

type semaphore_wait_phase = Keeper_turn_slot_types.semaphore_wait_phase = ...

type semaphore_wait_timeout = Keeper_turn_slot_types.semaphore_wait_timeout =
  { timeout_wait_sec : float
  ; timeout_phase : semaphore_wait_phase
  ; ...
  }
```

**Note the exception-identity rebind via `exception X = Module.X`** — without this, `try ... with Semaphore_wait_timeout _ -> ...` in existing call sites would fail to match (each `exception` declaration creates a fresh identity).

## External callers preserved

- `Keeper_turn_slot.slot_pool` (keeper_keepalive.mli line 122)
- `Semaphore_wait_timeout` / `semaphore_wait_phase` / `semaphore_wait_timeout` — re-declared types in keeper_keepalive.mli

## Scope rationale

Pure types + small `_to_string` helpers; only foreign call is `Keeper_config.clamp_int`. **No parent-local state, no `Atomic` / `Mutex` / `Semaphore`** — those stay in the parent with the runtime singletons (`turn_semaphore`, `holder_table_atomic`, etc.).

## Test plan

- [x] `dune build --root . lib/` clean
- [x] `.mli` surface unchanged (transparent aliases preserve all type identities + concrete fields)
- [x] Exception identity preserved via `exception X = Module.X` rebind
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
