### PR TITLE
feat(keeper_compaction): wire per-keeper tool_heavy into decide_compaction (PR-B of F3, stacked on #17484)

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -90,14 +90,18 @@ let emergency_compact_ratio_threshold : float =
   effective
 ;;
 
-(** Tool-heavy compaction thresholds.
-    When message count exceeds [tool_heavy_msg_threshold] AND context
-    ratio exceeds [tool_heavy_ratio_floor], trigger compaction to
-    stub old tool results. Prevents slow inference on local LLMs
-    when many tool calls accumulate without hitting other gates. *)
-let tool_heavy_msg_threshold = 40
+(* Tool-heavy compaction thresholds.  Per-keeper values live on
+   [meta.compaction.tool_heavy_msg_threshold] and
+   [meta.compaction.tool_heavy_ratio_floor]; defaults at
+   {!Keeper_config.default_tool_heavy_msg_threshold} (40) and
+   {!Keeper_config.default_tool_heavy_ratio_floor} (0.15).
 
-let tool_heavy_ratio_floor = 0.15
+   When message count exceeds the threshold AND context ratio exceeds
+   the floor, [decide_compaction] applies a Tool_heavy trigger that
+   bypasses the continuity-reflection cooldown, the same way the
+   emergency ratio gate does.  PR-A introduced the meta fields with
+   defaults preserving the prior global behavior; PR-B (this commit)
+   wires the meta values into the gate. *)
 
 type compaction_decision =
   | Applied of Compaction_trigger.t
@@ -130,6 +134,8 @@ let decide_compaction
       ~message_gate
       ~token_gate
       ~cooldown_sec
+      ~tool_heavy_msg_threshold
+      ~tool_heavy_ratio_floor
       ~last_continuity_update_ts
       ~last_proactive_ts
       ~now_ts
@@ -196,6 +202,8 @@ let compact_if_needed_typed
       ~message_gate
       ~token_gate
       ~cooldown_sec:meta.compaction.cooldown_sec
+      ~tool_heavy_msg_threshold:meta.compaction.tool_heavy_msg_threshold
+      ~tool_heavy_ratio_floor:meta.compaction.tool_heavy_ratio_floor
       ~last_continuity_update_ts:meta.runtime.last_continuity_update_ts
       ~last_proactive_ts:meta.runtime.proactive_rt.last_ts
       ~now_ts

--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -15,14 +15,6 @@
     {!Keeper_metrics.metric_keeper_emergency_compact_ratio_threshold}. *)
 val emergency_compact_ratio_threshold : float
 
-(** Tool-heavy compaction gate: minimum message count before the
-    [tool_heavy] gate becomes eligible. *)
-val tool_heavy_msg_threshold : int
-
-(** Tool-heavy compaction gate: minimum context ratio before the
-    [tool_heavy] gate becomes eligible. *)
-val tool_heavy_ratio_floor : float
-
 (** Typed result for the compaction policy gate. String rendering is kept
     at telemetry/persistence boundaries via {!compaction_decision_to_string}. *)
 type compaction_decision =
@@ -48,6 +40,8 @@ val decide_compaction
   -> message_gate:int
   -> token_gate:int
   -> cooldown_sec:int
+  -> tool_heavy_msg_threshold:int
+  -> tool_heavy_ratio_floor:float
   -> last_continuity_update_ts:float
   -> last_proactive_ts:float
   -> now_ts:float

--- a/test/test_keeper_compact_policy_pure.ml
+++ b/test/test_keeper_compact_policy_pure.ml
@@ -69,12 +69,16 @@ let test_emergency_threshold_in_range () =
 
 let test_tool_heavy_threshold_positive () =
   Alcotest.(check bool)
-    "tool_heavy_msg_threshold > 0" true (KCP.tool_heavy_msg_threshold > 0)
+    "default_tool_heavy_msg_threshold > 0"
+    true
+    (Keeper_config.default_tool_heavy_msg_threshold > 0)
 
 let test_tool_heavy_floor_in_range () =
-  let v = KCP.tool_heavy_ratio_floor in
-  Alcotest.(check bool) "tool_heavy_ratio_floor is a meaningful ratio [0,1]"
-    true (v >= 0.0 && v <= 1.0)
+  let v = Keeper_config.default_tool_heavy_ratio_floor in
+  Alcotest.(check bool)
+    "default_tool_heavy_ratio_floor is a meaningful ratio [0,1]"
+    true
+    (v >= 0.0 && v <= 1.0)
 
 (* ── pure gate decision ─────────────────────────────────────────────── *)
 
@@ -86,6 +90,10 @@ let decide
     ?(message_gate = 0)
     ?(token_gate = 0)
     ?(cooldown_sec = 60)
+    ?(tool_heavy_msg_threshold =
+      Keeper_config.default_tool_heavy_msg_threshold)
+    ?(tool_heavy_ratio_floor =
+      Keeper_config.default_tool_heavy_ratio_floor)
     ?(last_continuity_update_ts = 0.0)
     ?(last_proactive_ts = 0.0)
     ?(now_ts = 100.0)
@@ -98,6 +106,8 @@ let decide
     ~message_gate
     ~token_gate
     ~cooldown_sec
+    ~tool_heavy_msg_threshold
+    ~tool_heavy_ratio_floor
     ~last_continuity_update_ts
     ~last_proactive_ts
     ~now_ts
@@ -147,8 +157,8 @@ let test_decide_emergency_bypasses_cooldown () =
 let test_decide_tool_heavy_bypasses_cooldown () =
   match
     decide
-      ~ratio:(KCP.tool_heavy_ratio_floor +. 0.01)
-      ~msg_count:(KCP.tool_heavy_msg_threshold + 1)
+      ~ratio:(Keeper_config.default_tool_heavy_ratio_floor +. 0.01)
+      ~msg_count:(Keeper_config.default_tool_heavy_msg_threshold + 1)
       ~ratio_gate:0.99
       ~message_gate:0
       ~token_gate:0


### PR DESCRIPTION
## Summary

Activates the meta fields added by **PR-A (#17484)**.  Replaces the
module-global constants in `keeper_compact_policy.ml:98-100`:
- `let tool_heavy_msg_threshold = 40`
- `let tool_heavy_ratio_floor = 0.15`

with reads from `meta.compaction.tool_heavy_msg_threshold` /
`.tool_heavy_ratio_floor`, threaded via two new params on
`decide_compaction`.

## Files changed (3)

| File | Change |
|---|---|
| `lib/keeper/keeper_compact_policy.ml` | Drop module constants; extend `decide_compaction` sig; `compact_if_needed_typed` pulls from `meta.compaction.*` |
| `lib/keeper/keeper_compact_policy.mli` | Drop `val tool_heavy_msg_threshold` / `val tool_heavy_ratio_floor`; widen `decide_compaction` sig |
| `test/test_keeper_compact_policy_pure.ml` | Reference `Keeper_config.default_tool_heavy_*` instead of removed module constants; helper gains 2 ?-labeled args |

3 files / +33 / -21.

## Behavior preservation

Heavy-tool keepers (executor 17k decisions, nick0cave 18k, ramarama 10k+
— from `~/.masc/keepers/*.decisions.jsonl`) can now tune the tool_heavy
gate via persona JSON without recompile, mirroring the existing
per-keeper `ratio_gate`, `message_gate`, `token_gate`, `cooldown_sec`
knobs.  Defaults preserve prior behavior (40 / 0.15).

## Verification

```
dune build lib/keeper test/test_keeper_compact_policy_pure.exe → exit 0
dune exec test/test_keeper_compact_policy_pure.exe              → 16/16 OK
```

Including `decide_compaction tool-heavy bypasses cooldown` Alcotest.

## Stack

```
main
 └─ #17484 (PR-A): widen compaction_policy with 2 fields (data only)
      └─ this PR  (PR-B): wire fields into decide_compaction
```

Base will rebase to `main` after PR-A merges.  Per
`feedback_stacked_pr_sha_cascade_on_amend.md`, if PR-A is amended
(not just merged), this PR will need force-with-lease=<sha> rebase.

## Anti-pattern self-check

- **§1 telemetry-as-fix**: NO — typed param threading, no counter.
- **§2 string classifier**: NO — typed `int` / `float`.
- **§3 N-of-M patch**: NO — completes per-keeper migration paired with PR-A.
- **Symptom suppression**: NO.
- **Test backdoor**: NO — tests use the *real* `Keeper_config` SSOT defaults.

## Follow-up (optional)

PR-C could add env overrides (`MASC_KEEPER_TOOL_HEAVY_*`) mirroring
the `MASC_KEEPER_EMERGENCY_COMPACT_RATIO_THRESHOLD` pattern at
`keeper_compact_policy.ml:31-91`.  Skipped unless heavy-tool keepers
need runtime override before restart.