### PR TITLE
refactor(keeper_state_machine): extract phase variant + bijection sibling

### DIFF
--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -3,7 +3,7 @@
 
 (* ── Phase ─────────────────────────────────────────────── *)
 
-type phase =
+type phase = Keeper_state_machine_phase.phase =
   | Offline
   | Running
   | Failing
@@ -18,55 +18,9 @@ type phase =
   | Dead
   | Zombie
 
-let phase_to_string = function
-  | Offline -> "offline"
-  | Running -> "running"
-  | Failing -> "failing"
-  | Overflowed -> "overflowed"
-  | Compacting -> "compacting"
-  | HandingOff -> "handing_off"
-  | Draining -> "draining"
-  | Paused -> "paused"
-  | Stopped -> "stopped"
-  | Crashed -> "crashed"
-  | Restarting -> "restarting"
-  | Dead -> "dead"
-  | Zombie -> "zombie"
-;;
-
-let phase_of_string = function
-  | "offline" -> Some Offline
-  | "running" -> Some Running
-  | "failing" -> Some Failing
-  | "overflowed" -> Some Overflowed
-  | "compacting" -> Some Compacting
-  | "handing_off" -> Some HandingOff
-  | "draining" -> Some Draining
-  | "paused" -> Some Paused
-  | "stopped" -> Some Stopped
-  | "crashed" -> Some Crashed
-  | "restarting" -> Some Restarting
-  | "dead" -> Some Dead
-  | "zombie" -> Some Zombie
-  | _ -> None
-;;
-
-let all_phases =
-  [ Offline
-  ; Running
-  ; Failing
-  ; Overflowed
-  ; Compacting
-  ; HandingOff
-  ; Draining
-  ; Paused
-  ; Stopped
-  ; Crashed
-  ; Restarting
-  ; Dead
-  ; Zombie
-  ]
-;;
+let phase_to_string = Keeper_state_machine_phase.phase_to_string
+let phase_of_string = Keeper_state_machine_phase.phase_of_string
+let all_phases = Keeper_state_machine_phase.all_phases
 
 (* ── Conditions ────────────────────────────────────────── *)
 

--- a/lib/keeper/keeper_state_machine_phase.ml
+++ b/lib/keeper/keeper_state_machine_phase.ml
@@ -1,0 +1,78 @@
+(** Keeper lifecycle phase variant + bijection helpers.
+
+    SSOT for the 13-state lifecycle phase enum referenced by the
+    [Keeper_state_machine] FSM, dashboard UI, persona audits, and
+    operator-facing keeper status surfaces. Verbatim extract from the
+    head of [Keeper_state_machine]; the parent retains a transparent
+    variant alias so existing exhaustive matches at ~109 call sites
+    continue to type-check unchanged.
+
+    Pure variant + total bijection (modulo unknown-string -> None on
+    parse). No FSM transitions or entry actions live here — those
+    stay in the parent because they depend on [conditions] / [event]
+    types still under iteration. *)
+
+type phase =
+  | Offline
+  | Running
+  | Failing
+  | Overflowed
+  | Compacting
+  | HandingOff
+  | Draining
+  | Paused
+  | Stopped
+  | Crashed
+  | Restarting
+  | Dead
+  | Zombie
+
+let phase_to_string = function
+  | Offline -> "offline"
+  | Running -> "running"
+  | Failing -> "failing"
+  | Overflowed -> "overflowed"
+  | Compacting -> "compacting"
+  | HandingOff -> "handing_off"
+  | Draining -> "draining"
+  | Paused -> "paused"
+  | Stopped -> "stopped"
+  | Crashed -> "crashed"
+  | Restarting -> "restarting"
+  | Dead -> "dead"
+  | Zombie -> "zombie"
+;;
+
+let phase_of_string = function
+  | "offline" -> Some Offline
+  | "running" -> Some Running
+  | "failing" -> Some Failing
+  | "overflowed" -> Some Overflowed
+  | "compacting" -> Some Compacting
+  | "handing_off" -> Some HandingOff
+  | "draining" -> Some Draining
+  | "paused" -> Some Paused
+  | "stopped" -> Some Stopped
+  | "crashed" -> Some Crashed
+  | "restarting" -> Some Restarting
+  | "dead" -> Some Dead
+  | "zombie" -> Some Zombie
+  | _ -> None
+;;
+
+let all_phases =
+  [ Offline
+  ; Running
+  ; Failing
+  ; Overflowed
+  ; Compacting
+  ; HandingOff
+  ; Draining
+  ; Paused
+  ; Stopped
+  ; Crashed
+  ; Restarting
+  ; Dead
+  ; Zombie
+  ]
+;;


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/keeper/keeper_state_machine.ml` (1363 → 1317 LOC, **-46**). First touch on this godfile — 19th-largest `.ml` in `lib/`, audited by the 2026-05-18 godfile-decomposition build plan.

New sibling `lib/keeper/keeper_state_machine_phase.ml` (78 LOC) hosts the canonical keeper lifecycle phase variant + total bijection helpers:

- `type phase = Offline | Running | Failing | Overflowed | Compacting | HandingOff | Draining | Paused | Stopped | Crashed | Restarting | Dead | Zombie` (13 variants)
- `val phase_to_string` — total
- `val phase_of_string` — parse-don't-validate; unknown → `None`
- `val all_phases` — canonical enumeration order

## SSOT scope

This sibling is now the SSOT for the 13-state lifecycle phase enum referenced by:

- `keeper_state_machine` FSM (`can_transition` / `can_execute_turn` / `derive_phase` / `update_conditions` / `entry_actions_for` **stay in the parent** — they depend on `conditions` / `event` types still co-located in the FSM godfile)
- `lib/dashboard.ml` (line 437)
- `lib/tool_keeper.ml` + `lib/tool_keeper_persona_audit.ml`
- **109 total qualified references across `lib/` + `test/`** (grep)

## Parent surface preservation

```ocaml
type phase = Keeper_state_machine_phase.phase =
  | Offline | Running | Failing | Overflowed | Compacting
  | HandingOff | Draining | Paused | Stopped | Crashed
  | Restarting | Dead | Zombie

let phase_to_string = Keeper_state_machine_phase.phase_to_string
let phase_of_string = Keeper_state_machine_phase.phase_of_string
let all_phases = Keeper_state_machine_phase.all_phases
```

The variant re-declaration after `=` is required so caller patterns like `match p with Offline -> ...` (with constructors referenced through `Keeper_state_machine` namespace) continue to match. Without it, the parent's `type phase` would be abstract from callers' point of view despite being transparent in the .ml.

## Scope rationale

Pure variant + total string bijection — no FSM transitions, no entry actions, no condition/event types. Those stay in the FSM godfile under the per-arm exhaustive-match guarantee that the TLA+ spec already validates.

## Anti-pattern note

`phase_of_string` uses `_ -> None` catch-all, which is the *parse-don't-validate* pattern (failure surfaced as `None`), not the §2 classifier pattern. **No new arm added** — verbatim move of the existing parser.

## Test plan

- [x] `dune build --root . lib/` clean
- [x] `.mli` surface unchanged (transparent variant alias preserves all 13 constructors)
- [x] 109 external qualified references continue to resolve via parent alias
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
