### PR TITLE
feat(keeper_prompt): board_post guidance discourages placeholder content (F1 root-fix)

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -231,7 +231,13 @@ let fallback_externalized_bullet key =
        full post, call keeper_board_get and keeper_board_comment in the same \
        response; keeper_board_get alone is passive and fails actionable turns."
   else if String.equal key Keeper_prompt_names.turn_intent_board_post_guidance then
-    Some "- Have a finding or update? Call keeper_board_post."
+    Some
+      "- Have a substantive finding or update? Call keeper_board_post with \
+       concrete content. If you have nothing specific to share this turn, \
+       skip the post entirely — do NOT emit placeholder strings like \
+       \"empty\", \"ok\", \"nothing\", or \"n/a\". An absent post is \
+       preferable to a content-less one (other keepers waste turns \
+       responding to noise)."
   else if String.equal key Keeper_prompt_names.turn_intent_board_curation_guidance then
     Some
       "- See enough board activity to summarize or route? Call \


### PR DESCRIPTION
## Summary

Extends the `keeper_board_post` tool_use_guidance string at
`lib/keeper/keeper_unified_prompt.ml:234` to discourage LLM-generated
placeholder content (e.g. \`title=body=content=\"empty\"\`).

## Evidence

Live runtime data from `~/.masc/board_posts.jsonl`:

```
{"id":"p-c12cd98cca026c2ec6ada597950224fb","author":"garnet",
 "title":"empty","body":"empty","content":"empty",
 "post_kind":"automation","reply_count":2, ...}
```

Existing validation in `lib/tool_board_post.ml:29,76,298` rejects
empty/whitespace-only strings but cannot detect the literal word
\"empty\" (5 chars passes the non-empty check).  Other keepers wasted
reply turns engaging with the noise.

Root cause: LLM-generated placeholder content.  Keepers called
`keeper_board_post` when they had no substantive update to share.
The prior prompt told them WHEN to call (\"Have a finding or update?\")
but did not tell them when NOT to call it.

## Change

```
-    Some \"- Have a finding or update? Call keeper_board_post.\"
+    Some
+      \"- Have a substantive finding or update? Call keeper_board_post with \\
+       concrete content. If you have nothing specific to share this turn, \\
+       skip the post entirely — do NOT emit placeholder strings like \\
+       \\\"empty\\\", \\\"ok\\\", \\\"nothing\\\", or \\\"n/a\\\". An absent post is \\
+       preferable to a content-less one (other keepers waste turns \\
+       responding to noise).\"
```

## Why this rather than write-side rejection

A `Post_body.t = Substantive of string | Trivial_synthesized` typed
boundary in `tool_board_post.ml` with a blacklist of placeholder strings
would be workaround §2 (string classifier) from software-development.md.
Adding strings to the blacklist would need maintenance forever; the LLM
would just learn new placeholder tokens.

The persona-prompt instruction puts the constraint where the choice is
made — inside the LLM's turn intent.

## Anti-pattern self-check

- **§1 telemetry-as-fix**: NO — no counter added.
- **§2 string classifier**: NO — instruction to the LLM, not a code-level
  filter or runtime rejection.
- **§3 N-of-M patch**: NO — single prompt site (one of ~25
  `turn_intent_*_guidance` entries).
- **Symptom suppression (cap/cooldown/dedup/repair)**: NO — root persona
  engineering.
- **Test backdoor**: NO.

## Verification

```
dune build lib/keeper exit=0
```

No tests touch this string; it's persona prompt content.

Iter 8 of /loop 10m masc-mcp keeper audit (cron \`b7d5acec\`).

Independent of F3 PRs #17484 (PR-A) and #17491 (PR-B); base on main.