### PR TITLE
refactor(keeper_execution_receipt): extract outcome_kind sibling

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -7,39 +7,16 @@
    cancellation. The receipt record still stores the legacy string for
    JSON compatibility; consumers must go through these helpers so that
    Skipped/Cancelled/Error are not silently folded into one another. *)
-type outcome_kind =
-  [ `Ok
-  | `Skipped
-  | `Error
-  | `Cancelled
-  ]
+type outcome_kind = Keeper_execution_receipt_outcome_kind.outcome_kind
 
-let outcome_kind_to_string = function
-  | `Ok -> "ok"
-  | `Skipped -> "skipped"
-  | `Error -> "error"
-  | `Cancelled -> "cancelled"
-;;
-
-let outcome_kind_to_tla_receipt = function
-  | `Ok -> "receipt_done"
-  | `Skipped -> "receipt_skipped"
-  | `Error -> "receipt_failed"
-  | `Cancelled -> "receipt_cancelled"
-;;
-
-let outcome_kind_of_string = function
-  | "ok" | "receipt_done" -> Some `Ok
-  | "skipped" | "receipt_skipped" -> Some `Skipped
-  | "error" | "receipt_failed" -> Some `Error
-  | "cancelled" | "receipt_cancelled" -> Some `Cancelled
-  | _ -> None
-;;
-
-let outcome_kind_is_terminal_success = function
-  | `Ok | `Skipped -> true
-  | `Error | `Cancelled -> false
-;;
+let outcome_kind_to_string =
+  Keeper_execution_receipt_outcome_kind.outcome_kind_to_string
+let outcome_kind_to_tla_receipt =
+  Keeper_execution_receipt_outcome_kind.outcome_kind_to_tla_receipt
+let outcome_kind_of_string =
+  Keeper_execution_receipt_outcome_kind.outcome_kind_of_string
+let outcome_kind_is_terminal_success =
+  Keeper_execution_receipt_outcome_kind.outcome_kind_is_terminal_success
 
 type error_kind = Error_kind of string
 

--- a/lib/keeper/keeper_execution_receipt_outcome_kind.ml
+++ b/lib/keeper/keeper_execution_receipt_outcome_kind.ml
@@ -1,0 +1,45 @@
+(** Outcome-kind polymorphic variant + bijection helpers for
+    keeper execution receipts.
+
+    Verbatim extract from the head of [Keeper_execution_receipt].
+    The variant is polymorphic ([`Ok | `Skipped | `Error | `Cancelled]),
+    so the parent re-export only needs a transparent type alias —
+    polyvariants are structurally typed and constructors auto-share
+    across module boundaries without re-declaration.
+
+    Pure variant + total to/from-string + a small terminal-success
+    predicate. No parent-local state. *)
+
+type outcome_kind =
+  [ `Ok
+  | `Skipped
+  | `Error
+  | `Cancelled
+  ]
+
+let outcome_kind_to_string = function
+  | `Ok -> "ok"
+  | `Skipped -> "skipped"
+  | `Error -> "error"
+  | `Cancelled -> "cancelled"
+;;
+
+let outcome_kind_to_tla_receipt = function
+  | `Ok -> "receipt_done"
+  | `Skipped -> "receipt_skipped"
+  | `Error -> "receipt_failed"
+  | `Cancelled -> "receipt_cancelled"
+;;
+
+let outcome_kind_of_string = function
+  | "ok" | "receipt_done" -> Some `Ok
+  | "skipped" | "receipt_skipped" -> Some `Skipped
+  | "error" | "receipt_failed" -> Some `Error
+  | "cancelled" | "receipt_cancelled" -> Some `Cancelled
+  | _ -> None
+;;
+
+let outcome_kind_is_terminal_success = function
+  | `Ok | `Skipped -> true
+  | `Error | `Cancelled -> false
+;;


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/keeper/keeper_execution_receipt.ml` (1305 → 1282 LOC, **-23**). First touch on this godfile — 23rd-largest `.ml` in `lib/`, audited by the 2026-05-18 godfile-decomposition build plan.

New sibling `lib/keeper/keeper_execution_receipt_outcome_kind.ml` (45 LOC) hosts the outcome-kind polymorphic variant + bijection:

- `type outcome_kind = [ \`Ok | \`Skipped | \`Error | \`Cancelled ]`
- `val outcome_kind_to_string` — total
- `val outcome_kind_to_tla_receipt` — TLA+ wire form (`receipt_done` / `receipt_skipped` / `receipt_failed` / `receipt_cancelled`)
- `val outcome_kind_of_string` — parse-don't-validate; accepts both the lowercase form *and* the TLA wire form per variant, so receipts parsed from either source round-trip
- `val outcome_kind_is_terminal_success` — `Ok | Skipped → true`

## Parent surface preservation

```ocaml
type outcome_kind = Keeper_execution_receipt_outcome_kind.outcome_kind

let outcome_kind_to_string = ...outcome_kind_to_string
let outcome_kind_to_tla_receipt = ...outcome_kind_to_tla_receipt
let outcome_kind_of_string = ...outcome_kind_of_string
let outcome_kind_is_terminal_success = ...outcome_kind_is_terminal_success
```

**Polyvariants are *structurally* typed in OCaml**, so the parent's single-line `type outcome_kind = Sibling.outcome_kind` alias preserves constructor reachability across module boundaries *without* the `= | A | B | ...` re-declaration required for nominal variants (PRs #17488, #17492). `` `Ok `` / `` `Skipped `` / `` `Error `` / `` `Cancelled `` continue to type-check against `Keeper_execution_receipt.outcome_kind` at all caller sites.

## External callers preserved

- `.mli` surfaces `outcome_kind` at line 13 (type), 24, 29, 34, 40 (vals), 85 (`outcome:outcome_kind` arg in `append_receipt`), 208 (`outcome` field of `t` record)
- The 4 functions are used through the parent's qualified name by post-turn flows, the dashboard JSON encoder, and TLA+ trajectory checkpointing

## Anti-pattern note

`outcome_kind_of_string` accepts both lowercase and TLA wire-form (e.g. both `"ok"` and `"receipt_done"` map to `` `Ok ``). This is intentional — the receipt format has two emit sources (operator-facing JSON and TLA model trace) and the parser must accept both. The catch-all is parse-don't-validate (`_ -> None`), not classifier-fallback. **Verbatim move; no new arm added.**

## Test plan

- [x] `dune build --root . lib/` clean
- [x] `.mli` surface unchanged (polyvariant structural typing preserves constructor reachability)
- [x] External qualified references continue to resolve via parent alias
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
