### PR TITLE
refactor(dashboard_safe_autonomy): extract level + domain catalog sibling

### DIFF
--- a/lib/dashboard/dashboard_safe_autonomy.ml
+++ b/lib/dashboard/dashboard_safe_autonomy.ml
@@ -1,6 +1,6 @@
 open Keeper_types
 
-type domain_level =
+type domain_level = Dashboard_safe_autonomy_level.domain_level =
   | Pass
   | Warn
   | Fail
@@ -71,38 +71,16 @@ type keeper_snapshot = {
   findings : finding list;
 }
 
-let tool_domain_id = "tool_correctness"
-let sandbox_domain_id = "sandbox_truth"
-let approval_domain_id = "approval_truth"
-let cascade_domain_id = "cascade_fsm_gracefulness"
-let audit_domain_id = "audit_trail_completeness"
-
-let domain_catalog =
-  [
-    (tool_domain_id, "Tool Correctness", 30);
-    (sandbox_domain_id, "Sandbox Truth", 20);
-    (approval_domain_id, "Approval Truth", 20);
-    (cascade_domain_id, "Cascade & FSM Gracefulness", 20);
-    (audit_domain_id, "Audit Trail Completeness", 10);
-  ]
-
-let level_to_string = function
-  | Pass -> "pass"
-  | Warn -> "warn"
-  | Fail -> "fail"
-
-let level_rank = function
-  | Pass -> 0
-  | Warn -> 1
-  | Fail -> 2
-
-let worse_level left right =
-  if level_rank left >= level_rank right then left else right
-
-let worst_level levels =
-  match levels with
-  | [] -> Warn
-  | hd :: tl -> List.fold_left worse_level hd tl
+let tool_domain_id = Dashboard_safe_autonomy_level.tool_domain_id
+let sandbox_domain_id = Dashboard_safe_autonomy_level.sandbox_domain_id
+let approval_domain_id = Dashboard_safe_autonomy_level.approval_domain_id
+let cascade_domain_id = Dashboard_safe_autonomy_level.cascade_domain_id
+let audit_domain_id = Dashboard_safe_autonomy_level.audit_domain_id
+let domain_catalog = Dashboard_safe_autonomy_level.domain_catalog
+let level_to_string = Dashboard_safe_autonomy_level.level_to_string
+let level_rank = Dashboard_safe_autonomy_level.level_rank
+let worse_level = Dashboard_safe_autonomy_level.worse_level
+let worst_level = Dashboard_safe_autonomy_level.worst_level
 
 let non_empty_string_opt value =
   let trimmed = String.trim value in

--- a/lib/dashboard/dashboard_safe_autonomy_level.ml
+++ b/lib/dashboard/dashboard_safe_autonomy_level.ml
@@ -1,0 +1,50 @@
+(** Safe-autonomy domain level + catalog.
+
+    SSOT for the Pass/Warn/Fail status enum, the 5 safe-autonomy
+    domain identifiers (tool_correctness, sandbox_truth,
+    approval_truth, cascade_fsm_gracefulness, audit_trail_completeness),
+    the canonical [domain_catalog] (id, label, weight) tuples used to
+    compose the overall safety score, and the level-merge helpers
+    [worse_level] / [worst_level].
+
+    Pure data + total functions. No parent-local state, no I/O.
+    Extracted verbatim from the head of [Dashboard_safe_autonomy];
+    all callers are internal to the parent (verified via grep). *)
+
+type domain_level =
+  | Pass
+  | Warn
+  | Fail
+
+let tool_domain_id = "tool_correctness"
+let sandbox_domain_id = "sandbox_truth"
+let approval_domain_id = "approval_truth"
+let cascade_domain_id = "cascade_fsm_gracefulness"
+let audit_domain_id = "audit_trail_completeness"
+
+let domain_catalog =
+  [
+    (tool_domain_id, "Tool Correctness", 30);
+    (sandbox_domain_id, "Sandbox Truth", 20);
+    (approval_domain_id, "Approval Truth", 20);
+    (cascade_domain_id, "Cascade & FSM Gracefulness", 20);
+    (audit_domain_id, "Audit Trail Completeness", 10);
+  ]
+
+let level_to_string = function
+  | Pass -> "pass"
+  | Warn -> "warn"
+  | Fail -> "fail"
+
+let level_rank = function
+  | Pass -> 0
+  | Warn -> 1
+  | Fail -> 2
+
+let worse_level left right =
+  if level_rank left >= level_rank right then left else right
+
+let worst_level levels =
+  match levels with
+  | [] -> Warn
+  | hd :: tl -> List.fold_left worse_level hd tl


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/dashboard/dashboard_safe_autonomy.ml` (1302 → 1280 LOC, **-22**). First touch on this godfile — 24th-largest `.ml` in `lib/`, audited by the 2026-05-18 godfile-decomposition build plan.

New sibling `lib/dashboard/dashboard_safe_autonomy_level.ml` (50 LOC) hosts the Pass/Warn/Fail level enum, the 5 safe-autonomy domain identifiers, the canonical `domain_catalog` weighting tuples, and the level-merge helpers:

- `type domain_level = Pass | Warn | Fail`
- 5 domain_id constants: `tool_domain_id`, `sandbox_domain_id`, `approval_domain_id`, `cascade_domain_id`, `audit_domain_id`
- `domain_catalog`: `(id * label * weight) list` — 30/20/20/20/10 weight distribution
- `level_to_string` — total
- `level_rank` — `Pass=0, Warn=1, Fail=2`
- `worse_level` — binary max-by-rank
- `worst_level` — n-ary fold; `[] → Warn` (conservative default)

## Parent surface preservation

```ocaml
type domain_level = Dashboard_safe_autonomy_level.domain_level =
  | Pass | Warn | Fail
```

10 value bindings have single-line aliases. The variant re-declaration after `=` keeps caller patterns like `match level with Pass -> ...` resolving against `Dashboard_safe_autonomy.domain_level`. Downstream record types `finding` and `keeper_domain` (still in parent) continue to reference `domain_level` via the parent alias unchanged.

## External callers

**None** under qualified name `Dashboard_safe_autonomy.*` for any of the moved bindings (verified via grep across `lib/` + `test/`). No `.mli` on `dashboard_safe_autonomy`, so the implicit signature absorbs the move.

## Scope rationale

Pure data + total functions — no parent-local state, no I/O. The record types right after (`evidence_ref`, `finding`, `keeper_domain`, `live_tool_stats`, `approval_stats`, `activity_stats`, `artifact_state`, `keeper_snapshot`) stay in the parent because they're consumed by the classifier bodies that follow and would force a larger transitive move.

## Test plan

- [x] `dune build --root . lib/` clean
- [x] No `.mli` to update (implicit signature)
- [x] External caller grep across `lib/` + `test/` — no qualified callers found
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
