### PR TITLE
refactor(keeper_types_profile): extract per_provider_timeout sibling

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -195,68 +195,16 @@ let persona_operator_todo_placeholder_fields
       ("keeper.work_discovery_guidance", defaults.work_discovery_guidance);
     ]
 
-let normalize_per_provider_timeout_opt ~(source : string)
-    (value : float option) : float option =
-  match value with
-  | Some f when Float.is_finite f && f > 0.0 -> Some f
-  | Some f when not (Float.is_finite f) ->
-      Log.Keeper.warn
-        "%s per_provider_timeout=%s is non-finite; ignoring"
-        source (string_of_float f);
-      None
-  | Some f ->
-      Log.Keeper.warn
-        "%s per_provider_timeout=%s is non-positive; ignoring"
-        source (string_of_float f);
-      None
-  | None -> None
-;;
-
-let per_provider_timeout_of_declared_float_opt ~(source : string)
-    ~(declared : bool)
-    (value : float option)
-    : per_provider_timeout_state * float option =
-  if not declared then
-    Per_provider_timeout_unset, None
-  else
-    match value with
-    | None ->
-        Log.Keeper.warn
-          "%s per_provider_timeout has invalid type; ignoring"
-          source;
-        Per_provider_timeout_invalid, None
-    | Some _ ->
-        (match normalize_per_provider_timeout_opt ~source value with
-         | Some f -> Per_provider_timeout_set, Some f
-         | None -> Per_provider_timeout_invalid, None)
-;;
-
-let per_provider_timeout_of_toml ~(source : string)
-    (doc : Keeper_toml_loader.toml_doc)
-    (key : string)
-    : per_provider_timeout_state * float option =
-  per_provider_timeout_of_declared_float_opt
-    ~source
-    ~declared:(List.mem_assoc key doc)
-    (Keeper_toml_loader.toml_float_opt doc key)
-;;
-
-let per_provider_timeout_of_json_field ~(source : string)
-    ~(field : string)
-    (json : Yojson.Safe.t)
-    : per_provider_timeout_state * float option =
-  per_provider_timeout_of_declared_float_opt
-    ~source
-    ~declared:(Option.is_some (Safe_ops.json_member_opt field json))
-    (Safe_ops.json_float_opt field json)
-;;
-
-let normalize_per_provider_timeout_json_field ~(source : string)
-    ~(field : string)
-    (json : Yojson.Safe.t)
-    : float option =
-  per_provider_timeout_of_json_field ~source ~field json |> snd
-;;
+let normalize_per_provider_timeout_opt =
+  Keeper_types_profile_per_provider_timeout.normalize_per_provider_timeout_opt
+let per_provider_timeout_of_declared_float_opt =
+  Keeper_types_profile_per_provider_timeout.per_provider_timeout_of_declared_float_opt
+let per_provider_timeout_of_toml =
+  Keeper_types_profile_per_provider_timeout.per_provider_timeout_of_toml
+let per_provider_timeout_of_json_field =
+  Keeper_types_profile_per_provider_timeout.per_provider_timeout_of_json_field
+let normalize_per_provider_timeout_json_field =
+  Keeper_types_profile_per_provider_timeout.normalize_per_provider_timeout_json_field
 
 let personas_root_opt = Keeper_types_profile_persona.personas_root_opt
 let persona_profile_path_opt = Keeper_types_profile_persona.persona_profile_path_opt

--- a/lib/keeper/keeper_types_profile_per_provider_timeout.ml
+++ b/lib/keeper/keeper_types_profile_per_provider_timeout.ml
@@ -1,0 +1,76 @@
+(** Per-provider timeout normalization helpers for keeper profile.
+
+    Validates declared [per_provider_timeout] values from TOML / JSON
+    sources, surfacing non-finite / non-positive / wrong-type cases as
+    [Per_provider_timeout_invalid] (typed failure, not silent default).
+
+    Pure helpers (modulo [Log.Keeper.warn] on validation failure).
+    Extracted verbatim from [Keeper_types_profile]. The
+    [per_provider_timeout_state] variant + constructors come from
+    [Keeper_types_profile_defaults] via [include] — same pattern the
+    parent uses at line 145. *)
+
+include Keeper_types_profile_defaults
+
+let normalize_per_provider_timeout_opt ~(source : string)
+    (value : float option) : float option =
+  match value with
+  | Some f when Float.is_finite f && f > 0.0 -> Some f
+  | Some f when not (Float.is_finite f) ->
+      Log.Keeper.warn
+        "%s per_provider_timeout=%s is non-finite; ignoring"
+        source (string_of_float f);
+      None
+  | Some f ->
+      Log.Keeper.warn
+        "%s per_provider_timeout=%s is non-positive; ignoring"
+        source (string_of_float f);
+      None
+  | None -> None
+;;
+
+let per_provider_timeout_of_declared_float_opt ~(source : string)
+    ~(declared : bool)
+    (value : float option)
+    : per_provider_timeout_state * float option =
+  if not declared then
+    Per_provider_timeout_unset, None
+  else
+    match value with
+    | None ->
+        Log.Keeper.warn
+          "%s per_provider_timeout has invalid type; ignoring"
+          source;
+        Per_provider_timeout_invalid, None
+    | Some _ ->
+        (match normalize_per_provider_timeout_opt ~source value with
+         | Some f -> Per_provider_timeout_set, Some f
+         | None -> Per_provider_timeout_invalid, None)
+;;
+
+let per_provider_timeout_of_toml ~(source : string)
+    (doc : Keeper_toml_loader.toml_doc)
+    (key : string)
+    : per_provider_timeout_state * float option =
+  per_provider_timeout_of_declared_float_opt
+    ~source
+    ~declared:(List.mem_assoc key doc)
+    (Keeper_toml_loader.toml_float_opt doc key)
+;;
+
+let per_provider_timeout_of_json_field ~(source : string)
+    ~(field : string)
+    (json : Yojson.Safe.t)
+    : per_provider_timeout_state * float option =
+  per_provider_timeout_of_declared_float_opt
+    ~source
+    ~declared:(Option.is_some (Safe_ops.json_member_opt field json))
+    (Safe_ops.json_float_opt field json)
+;;
+
+let normalize_per_provider_timeout_json_field ~(source : string)
+    ~(field : string)
+    (json : Yojson.Safe.t)
+    : float option =
+  per_provider_timeout_of_json_field ~source ~field json |> snd
+;;

--- a/lib/keeper/keeper_types_profile_per_provider_timeout.mli
+++ b/lib/keeper/keeper_types_profile_per_provider_timeout.mli
@@ -1,0 +1,32 @@
+(** Per-provider timeout normalization helpers for keeper profile. *)
+
+include module type of Keeper_types_profile_defaults
+
+val normalize_per_provider_timeout_opt
+  :  source:string
+  -> float option
+  -> float option
+
+val per_provider_timeout_of_declared_float_opt
+  :  source:string
+  -> declared:bool
+  -> float option
+  -> per_provider_timeout_state * float option
+
+val per_provider_timeout_of_toml
+  :  source:string
+  -> Keeper_toml_loader.toml_doc
+  -> string
+  -> per_provider_timeout_state * float option
+
+val per_provider_timeout_of_json_field
+  :  source:string
+  -> field:string
+  -> Yojson.Safe.t
+  -> per_provider_timeout_state * float option
+
+val normalize_per_provider_timeout_json_field
+  :  source:string
+  -> field:string
+  -> Yojson.Safe.t
+  -> float option


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/keeper/keeper_types_profile.ml` (1335 → 1283 LOC, **-52**). First touch on this godfile — 22nd-largest `.ml` in `lib/`, audited by the 2026-05-18 godfile-decomposition build plan.

New sibling `lib/keeper/keeper_types_profile_per_provider_timeout.ml` (76 LOC) hosts the per_provider_timeout normalization + multi-source loader cluster:

- `normalize_per_provider_timeout_opt ~source` — validates a float option: non-finite → WARN+None, non-positive → WARN+None, finite>0 → Some f
- `per_provider_timeout_of_declared_float_opt ~source ~declared` — surfaces three typed states: `Per_provider_timeout_unset` (not declared in source), `Per_provider_timeout_invalid` (declared but wrong type or out-of-range), `Per_provider_timeout_set` (declared + valid)
- `per_provider_timeout_of_toml ~source doc key` — TOML adapter over the above
- `per_provider_timeout_of_json_field ~source ~field json` — JSON adapter over the above
- `normalize_per_provider_timeout_json_field` — convenience wrapper returning only the float, dropping the state

## Dependency

Sibling depends on the `per_provider_timeout_state` variant (`Per_provider_timeout_unset | Per_provider_timeout_invalid | Per_provider_timeout_set`), which already lives in `Keeper_types_profile_defaults`. Brought in via `include Keeper_types_profile_defaults` — the same pattern the parent already uses at line 145, so the variant identity is preserved and the constructors stay in scope for the matches.

## Parent surface preservation

- All 5 functions are exposed by `.mli` (lines 59, 61, 67, 73, 79)
- 5 single-line parent aliases retain the qualified in-module names for downstream callers including `profile_defaults_of_toml` (line 270), `profile_defaults_of_json` (line 742), and the `keeper.toml` unknown-key validator

## Anti-pattern note

Typed three-state outcome `per_provider_timeout_state` (`Unset | Invalid | Set`) is exactly the typed-failure pattern that Anti-pattern §1 (telemetry-as-fix) and §2 (silent default) push toward — unknown / invalid inputs become a distinct constructor, not a silent fallback to "use the default". **Verbatim move; this PR neither extends nor erodes that boundary.**

## Test plan

- [x] `dune build --root . lib/` clean
- [x] `.mli` surface unchanged
- [x] Variant identity preserved via shared `include Keeper_types_profile_defaults` in both parent and sibling
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
