### PR TITLE
refactor(tool_task): extract no_eligible diagnostic helpers sibling

### DIFF
--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -364,44 +364,10 @@ let active_goal_phases_for_agent ctx =
         meta.active_goal_ids
   | Ok None | Error _ -> []
 
-let no_eligible_diagnostics_json
-      ~excluded_count
-      ~blocked_count
-      ~verification_blocked_count
-      ~scope_excluded_count
-      ~required_tool_excluded_count
-      ~explicit_excluded_count
-      ~claim_pool_candidate_count
-      ~receipt_required_tool_blocked
-      ~agent_tool_names_known
-  =
-  `Assoc
-    [ "excluded_count", `Int excluded_count
-    ; "blocked_count", `Int blocked_count
-    ; "verification_blocked_count", `Int verification_blocked_count
-    ; "scope_excluded_count", `Int scope_excluded_count
-    ; "required_tool_excluded_count", `Int required_tool_excluded_count
-    ; "explicit_excluded_count", `Int explicit_excluded_count
-    ; "claim_pool_candidate_count", `Int claim_pool_candidate_count
-    ; "receipt_required_tool_blocked", `Bool receipt_required_tool_blocked
-    ; "agent_tool_names_known", `Bool agent_tool_names_known
-    ]
-;;
-
-let no_eligible_blocker_summary
-      ~blocked_count
-      ~verification_blocked_count
-      ~scope_excluded_count
-      ~required_tool_excluded_count
-  =
-  Printf.sprintf
-    "diagnostics: goal_scope_or_filter=%d, required_tools=%d, verification=%d, \
-     blocked=%d."
-    scope_excluded_count
-    required_tool_excluded_count
-    verification_blocked_count
-    blocked_count
-;;
+let no_eligible_diagnostics_json =
+  Tool_task_no_eligible.no_eligible_diagnostics_json
+let no_eligible_blocker_summary =
+  Tool_task_no_eligible.no_eligible_blocker_summary
 
 let format_no_eligible
       ctx

--- a/lib/tool_task_no_eligible.ml
+++ b/lib/tool_task_no_eligible.ml
@@ -1,0 +1,51 @@
+(** Diagnostic helpers for "no eligible task" responses in
+    [Tool_task.handle_claim_next].
+
+    [no_eligible_diagnostics_json] builds the structured per-bucket
+    exclusion counter object that the operator dashboard renders.
+    [no_eligible_blocker_summary] formats the 4-counter Printf summary
+    that goes into the human-readable response message body.
+
+    Pure builders — no parent-local state, no I/O. Verbatim extract
+    from [Tool_task]; consumed only by the parent's
+    [format_no_eligible] (which still lives in the parent because it
+    also reads [ctx] and calls [active_goal_phases_for_agent]). *)
+
+let no_eligible_diagnostics_json
+      ~excluded_count
+      ~blocked_count
+      ~verification_blocked_count
+      ~scope_excluded_count
+      ~required_tool_excluded_count
+      ~explicit_excluded_count
+      ~claim_pool_candidate_count
+      ~receipt_required_tool_blocked
+      ~agent_tool_names_known
+  =
+  `Assoc
+    [ "excluded_count", `Int excluded_count
+    ; "blocked_count", `Int blocked_count
+    ; "verification_blocked_count", `Int verification_blocked_count
+    ; "scope_excluded_count", `Int scope_excluded_count
+    ; "required_tool_excluded_count", `Int required_tool_excluded_count
+    ; "explicit_excluded_count", `Int explicit_excluded_count
+    ; "claim_pool_candidate_count", `Int claim_pool_candidate_count
+    ; "receipt_required_tool_blocked", `Bool receipt_required_tool_blocked
+    ; "agent_tool_names_known", `Bool agent_tool_names_known
+    ]
+;;
+
+let no_eligible_blocker_summary
+      ~blocked_count
+      ~verification_blocked_count
+      ~scope_excluded_count
+      ~required_tool_excluded_count
+  =
+  Printf.sprintf
+    "diagnostics: goal_scope_or_filter=%d, required_tools=%d, verification=%d, \
+     blocked=%d."
+    scope_excluded_count
+    required_tool_excluded_count
+    verification_blocked_count
+    blocked_count
+;;

--- a/lib/tool_task_no_eligible.mli
+++ b/lib/tool_task_no_eligible.mli
@@ -1,0 +1,20 @@
+(** Diagnostic helpers for "no eligible task" responses. *)
+
+val no_eligible_diagnostics_json
+  :  excluded_count:int
+  -> blocked_count:int
+  -> verification_blocked_count:int
+  -> scope_excluded_count:int
+  -> required_tool_excluded_count:int
+  -> explicit_excluded_count:int
+  -> claim_pool_candidate_count:int
+  -> receipt_required_tool_blocked:bool
+  -> agent_tool_names_known:bool
+  -> Yojson.Safe.t
+
+val no_eligible_blocker_summary
+  :  blocked_count:int
+  -> verification_blocked_count:int
+  -> scope_excluded_count:int
+  -> required_tool_excluded_count:int
+  -> string


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/tool_task.ml` (1234 → 1200 LOC, **-34**). First touch on this godfile — audited by the 2026-05-18 godfile-decomposition build plan.

New sibling `lib/tool_task_no_eligible.ml` (51 LOC) hosts the two pure diagnostic helpers consumed by `Tool_task.format_no_eligible` when `handle_claim_next` has no task to return:

- `no_eligible_diagnostics_json` — 9-field `` `Assoc `` payload with excluded/blocked counts, scope/required-tool/explicit exclusion buckets, `claim_pool_candidate_count`, and the two-flag pair `receipt_required_tool_blocked` + `agent_tool_names_known`. Rendered by the operator dashboard.
- `no_eligible_blocker_summary` — `Printf.sprintf` one-liner summarising 4 counters in `[goal_scope_or_filter / required_tools / verification / blocked]` order for the human-readable response body.

## Scope rationale

Pure builders — no parent-local state, no I/O, no `ctx` reference. Caller `format_no_eligible` stays in the parent (line 406+) because it also reads `ctx` and calls the parent's `active_goal_phases_for_agent`. Three-helper move would require either callback injection for `ctx` or moving the goal-phase helper too — neither is worth the additional surface change for this cycle.

## External callers

- **None** under qualified name `Tool_task.*` (verified via grep across `lib/` + `test/`)
- `Keeper_exec_task` has its own local `no_eligible_blocker_summary` definition — separate function despite the name collision
- Not in `.mli` — internal helpers only

Parent retains 2 single-line aliases preserving the qualified in-module names so `format_no_eligible` resolves without edits.

## Test plan

- [x] `dune build --root . lib/` clean
- [x] No `.mli` to update (internal helpers)
- [x] External caller grep across `lib/` + `test/` — no qualified callers found
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
