### PR TITLE
refactor(telemetry_unified): extract source variant + bijection sibling

### DIFF
--- a/lib/telemetry_unified.ml
+++ b/lib/telemetry_unified.ml
@@ -18,51 +18,20 @@
     - [<base_path>/data/tool-metrics/]       — Tool duration/success metrics
     @since 2.251.0 *)
 
-type source =
-  | Keeper_metric  (** Per-keeper turn/heartbeat metrics *)
-  | Agent_event    (** Agent lifecycle, task, handoff events *)
-  | Tool_call_io   (** Keeper tool calls with full input/output *)
-  | Trajectory_tool_call  (** Keeper trajectory-backed tool call rows *)
-  | Tool_usage     (** System_internal surface tool invocations *)
-  | Oas_event      (** Durable OAS native/custom event bus relays *)
-  | Execution_receipt  (** Keeper execution receipt rows *)
-  | Goal_event     (** Goal FSM lifecycle and verification events *)
-  | Tool_metric    (** Tool duration and success metrics *)
+type source = Telemetry_unified_source.source =
+  | Keeper_metric
+  | Agent_event
+  | Tool_call_io
+  | Trajectory_tool_call
+  | Tool_usage
+  | Oas_event
+  | Execution_receipt
+  | Goal_event
+  | Tool_metric
 
-let source_to_string = function
-  | Keeper_metric -> "keeper_metric"
-  | Agent_event -> "agent_event"
-  | Tool_call_io -> "tool_call_io"
-  | Trajectory_tool_call -> "trajectory_tool_call"
-  | Tool_usage -> "tool_usage"
-  | Oas_event -> "oas_event"
-  | Execution_receipt -> "execution_receipt"
-  | Goal_event -> "goal_event"
-  | Tool_metric -> "tool_metric"
-
-let source_of_string = function
-  | "keeper_metric" -> Some Keeper_metric
-  | "agent_event" -> Some Agent_event
-  | "tool_call_io" -> Some Tool_call_io
-  | "trajectory_tool_call" -> Some Trajectory_tool_call
-  | "tool_usage" -> Some Tool_usage
-  | "oas_event" -> Some Oas_event
-  | "execution_receipt" -> Some Execution_receipt
-  | "goal_event" -> Some Goal_event
-  | "tool_metric" -> Some Tool_metric
-  | _ -> None
-
-let all_sources =
-  [ Keeper_metric
-  ; Agent_event
-  ; Tool_call_io
-  ; Trajectory_tool_call
-  ; Tool_usage
-  ; Oas_event
-  ; Execution_receipt
-  ; Goal_event
-  ; Tool_metric
-  ]
+let source_to_string = Telemetry_unified_source.source_to_string
+let source_of_string = Telemetry_unified_source.source_of_string
+let all_sources = Telemetry_unified_source.all_sources
 
 let observe_source_read_failure source ~site ~error =
   let source = source_to_string source in

--- a/lib/telemetry_unified_source.ml
+++ b/lib/telemetry_unified_source.ml
@@ -1,0 +1,58 @@
+(** Telemetry unified source variant + total string bijection.
+
+    SSOT for the 9-variant [Telemetry_unified.source] enum that names
+    each durable telemetry stream (keeper_metric, agent_event,
+    tool_call_io, trajectory_tool_call, tool_usage, oas_event,
+    execution_receipt, goal_event, tool_metric).
+
+    Pure variant + total bijection (modulo unknown-string → None on
+    parse). Verbatim extract from the head of [Telemetry_unified];
+    the parent retains a transparent variant alias so existing
+    exhaustive matches at ~20 qualified call sites continue to
+    type-check unchanged. *)
+
+type source =
+  | Keeper_metric  (** Per-keeper turn/heartbeat metrics *)
+  | Agent_event    (** Agent lifecycle, task, handoff events *)
+  | Tool_call_io   (** Keeper tool calls with full input/output *)
+  | Trajectory_tool_call  (** Keeper trajectory-backed tool call rows *)
+  | Tool_usage     (** System_internal surface tool invocations *)
+  | Oas_event      (** Durable OAS native/custom event bus relays *)
+  | Execution_receipt  (** Keeper execution receipt rows *)
+  | Goal_event     (** Goal FSM lifecycle and verification events *)
+  | Tool_metric    (** Tool duration and success metrics *)
+
+let source_to_string = function
+  | Keeper_metric -> "keeper_metric"
+  | Agent_event -> "agent_event"
+  | Tool_call_io -> "tool_call_io"
+  | Trajectory_tool_call -> "trajectory_tool_call"
+  | Tool_usage -> "tool_usage"
+  | Oas_event -> "oas_event"
+  | Execution_receipt -> "execution_receipt"
+  | Goal_event -> "goal_event"
+  | Tool_metric -> "tool_metric"
+
+let source_of_string = function
+  | "keeper_metric" -> Some Keeper_metric
+  | "agent_event" -> Some Agent_event
+  | "tool_call_io" -> Some Tool_call_io
+  | "trajectory_tool_call" -> Some Trajectory_tool_call
+  | "tool_usage" -> Some Tool_usage
+  | "oas_event" -> Some Oas_event
+  | "execution_receipt" -> Some Execution_receipt
+  | "goal_event" -> Some Goal_event
+  | "tool_metric" -> Some Tool_metric
+  | _ -> None
+
+let all_sources =
+  [ Keeper_metric
+  ; Agent_event
+  ; Tool_call_io
+  ; Trajectory_tool_call
+  ; Tool_usage
+  ; Oas_event
+  ; Execution_receipt
+  ; Goal_event
+  ; Tool_metric
+  ]

--- a/lib/telemetry_unified_source.mli
+++ b/lib/telemetry_unified_source.mli
@@ -1,0 +1,16 @@
+(** Telemetry unified source variant + total string bijection. *)
+
+type source =
+  | Keeper_metric
+  | Agent_event
+  | Tool_call_io
+  | Trajectory_tool_call
+  | Tool_usage
+  | Oas_event
+  | Execution_receipt
+  | Goal_event
+  | Tool_metric
+
+val source_to_string : source -> string
+val source_of_string : string -> source option
+val all_sources : source list


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/telemetry_unified.ml` (1204 → 1173 LOC, **-31**). First touch on this godfile — audited by the 2026-05-18 godfile-decomposition build plan.

New sibling `lib/telemetry_unified_source.ml` (58 LOC) hosts the SSOT for the 9-variant telemetry source enum:

- `type source = Keeper_metric | Agent_event | Tool_call_io | Trajectory_tool_call | Tool_usage | Oas_event | Execution_receipt | Goal_event | Tool_metric`
- `val source_to_string` — total
- `val source_of_string` — parse-don't-validate; unknown → `None`
- `val all_sources` — canonical enumeration order

These name each durable telemetry stream the system materializes (per-keeper turn metrics, agent lifecycle events, tool call I/O, trajectory-backed tool call rows, `system_internal` tool invocations, OAS native/custom event relays, execution receipt rows, goal FSM events, tool duration/success metrics).

## Parent surface preservation

```ocaml
type source = Telemetry_unified_source.source =
  | Keeper_metric | Agent_event | Tool_call_io
  | Trajectory_tool_call | Tool_usage | Oas_event
  | Execution_receipt | Goal_event | Tool_metric

let source_to_string = Telemetry_unified_source.source_to_string
let source_of_string = Telemetry_unified_source.source_of_string
let all_sources = Telemetry_unified_source.all_sources
```

The variant re-declaration after `=` keeps caller patterns like `match s with Keeper_metric -> ...` (qualified through the `Telemetry_unified` namespace at ~20 call sites across `lib/` + `test/`) resolving against the parent's `source` type.

## Scope rationale

Pure variant + total string bijection — no parent-local state, no I/O. All downstream helpers (`observe_source_read_failure`, `fixed_store_dir`, `source_freshness_slo_s`, `source_producer`, `source_dashboard_surface`, `source_durable_store`, `source_metadata_fields`, etc.) stay in the parent because they match on `source` AND consume parent-local helpers.

## Anti-pattern note

`source_of_string` uses `_ -> None` catch-all, which is the *parse-don't-validate* pattern (failure surfaced as `None`), not the §2 classifier pattern. **Verbatim move.**

## Test plan

- [x] `dune build --root . lib/` clean
- [x] `.mli` surface unchanged (transparent variant alias preserves all 9 constructors)
- [x] 20 external qualified references continue to resolve via parent alias
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
