### PR TITLE
refactor(keeper_memory_bank): extract env-var parsing sibling

### DIFF
--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -188,40 +188,10 @@ let consensus_default_re = Re.Pcre.re {|\d{6,}ep\+?|} |> Re.compile
 let consensus_re_mu = Stdlib.Mutex.create ()
 let consensus_re_cached : (string * Re.re) option ref = ref None
 
-let memory_env_opt name =
-  match Env_config_core.raw_value_opt name with
-  | None -> None
-  | Some raw ->
-      let s = String.trim raw in
-      if s = "" then None else Some s
-
-let memory_env_int_logged name ~default =
-  match memory_env_opt name with
-  | None -> default
-  | Some raw ->
-      (match int_of_string_opt raw with
-       | Some n -> n
-       | None ->
-           Log.Keeper.warn
-             "invalid %s=%S; using default %d"
-             name raw default;
-           default)
-
-let memory_env_bool_logged name ~default =
-  match memory_env_opt name with
-  | None -> default
-  | Some raw ->
-      match String.lowercase_ascii raw with
-      | "1" | "true" | "yes" | "on" | "enabled" -> true
-      | "0" | "false" | "no" | "off" | "disabled" -> false
-      | _ ->
-          Log.Keeper.warn
-            "invalid %s=%S; using default %b"
-            name raw default;
-          default
-
-let memory_llm_summary_enabled () =
-  memory_env_bool_logged "MASC_KEEPER_MEMORY_LLM_SUMMARY" ~default:false
+let memory_env_opt = Keeper_memory_bank_env.memory_env_opt
+let memory_env_int_logged = Keeper_memory_bank_env.memory_env_int_logged
+let memory_env_bool_logged = Keeper_memory_bank_env.memory_env_bool_logged
+let memory_llm_summary_enabled = Keeper_memory_bank_env.memory_llm_summary_enabled
 
 let consensus_pattern_key () =
   match memory_env_opt "MASC_KEEPER_MEMORY_CONSENSUS_PATTERN" with
@@ -281,13 +251,7 @@ let memory_placeholders () =
       in
       base @ extra
 
-let max_memory_text_length () =
-  match memory_env_opt "MASC_KEEPER_MEMORY_MAX_LENGTH" with
-  | None -> 4096
-  | Some raw ->
-      (match int_of_string_opt raw with
-       | Some n when n > 0 -> n
-       | _ -> 4096)
+let max_memory_text_length = Keeper_memory_bank_env.max_memory_text_length
 
 let is_meaningful_memory_text (s : string) : bool =
   let key = normalize_memory_text_key s in

--- a/lib/keeper/keeper_memory_bank_env.ml
+++ b/lib/keeper/keeper_memory_bank_env.ml
@@ -1,0 +1,54 @@
+(** Env-var parsing helpers for the keeper memory bank.
+
+    Three primitives — [memory_env_opt] strips empty/whitespace,
+    [memory_env_int_logged] adds int parsing with WARN-on-invalid,
+    [memory_env_bool_logged] adds bool parsing with the same shape —
+    plus the two .mli-exposed consumers [memory_llm_summary_enabled]
+    and [max_memory_text_length] that use them.
+
+    Pure helpers (modulo [Log.Keeper.warn] on bad input). All callers
+    are internal to [Keeper_memory_bank]; verbatim extract preserves
+    the qualified in-module names via 5 parent aliases. *)
+
+let memory_env_opt name =
+  match Env_config_core.raw_value_opt name with
+  | None -> None
+  | Some raw ->
+      let s = String.trim raw in
+      if s = "" then None else Some s
+
+let memory_env_int_logged name ~default =
+  match memory_env_opt name with
+  | None -> default
+  | Some raw ->
+      (match int_of_string_opt raw with
+       | Some n -> n
+       | None ->
+           Log.Keeper.warn
+             "invalid %s=%S; using default %d"
+             name raw default;
+           default)
+
+let memory_env_bool_logged name ~default =
+  match memory_env_opt name with
+  | None -> default
+  | Some raw ->
+      match String.lowercase_ascii raw with
+      | "1" | "true" | "yes" | "on" | "enabled" -> true
+      | "0" | "false" | "no" | "off" | "disabled" -> false
+      | _ ->
+          Log.Keeper.warn
+            "invalid %s=%S; using default %b"
+            name raw default;
+          default
+
+let memory_llm_summary_enabled () =
+  memory_env_bool_logged "MASC_KEEPER_MEMORY_LLM_SUMMARY" ~default:false
+
+let max_memory_text_length () =
+  match memory_env_opt "MASC_KEEPER_MEMORY_MAX_LENGTH" with
+  | None -> 4096
+  | Some raw ->
+      (match int_of_string_opt raw with
+       | Some n when n > 0 -> n
+       | _ -> 4096)

--- a/lib/keeper/keeper_memory_bank_env.mli
+++ b/lib/keeper/keeper_memory_bank_env.mli
@@ -1,0 +1,7 @@
+(** Env-var parsing helpers for the keeper memory bank. *)
+
+val memory_env_opt : string -> string option
+val memory_env_int_logged : string -> default:int -> int
+val memory_env_bool_logged : string -> default:bool -> bool
+val memory_llm_summary_enabled : unit -> bool
+val max_memory_text_length : unit -> int


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/keeper/keeper_memory_bank.ml` (1204 → 1168 LOC, **-36**). First touch on this godfile — audited by the 2026-05-18 godfile-decomposition build plan.

New sibling `lib/keeper/keeper_memory_bank_env.ml` (54 LOC) hosts the env-var parsing helpers + their two .mli-exposed consumers:

**Primitives (internal):**
- `memory_env_opt name` — reads via `Env_config_core.raw_value_opt`, strips whitespace, treats `""` as `None`
- `memory_env_int_logged ~default` — int parsing with `Log.Keeper.warn` on invalid integer, fallback to default
- `memory_env_bool_logged ~default` — bool parsing accepting `1/true/yes/on/enabled` and `0/false/no/off/disabled` (case-insensitive), `Log.Keeper.warn` on invalid, fallback to default

**`.mli`-exposed consumers:**
- `memory_llm_summary_enabled ()` — reads `MASC_KEEPER_MEMORY_LLM_SUMMARY` (default `false`)
- `max_memory_text_length ()` — reads `MASC_KEEPER_MEMORY_MAX_LENGTH` (default `4096`, positive-int gate via local `int_of_string_opt` match — does not use `memory_env_int_logged` because of the `>0` guard)

## Parent surface

Pure helpers (modulo `Log.Keeper.warn` on bad input). External callers preserved via 5 parent aliases — the three primitives have zero external callers but are aliased in the parent so the rest of `Keeper_memory_bank` (`consensus_pattern_key`, `memory_compaction_target_notes`, etc., still in the parent) keeps using the qualified in-module names without edits.

## Anti-pattern note

This is the same typed-failure pattern that `per_provider_timeout_state` (PR #17499) demonstrates — bad env input is reported via `Log.Keeper.warn` but does **not** silently poison the result; the default is the explicit fallback. The `_ -> default` arms here are intentional config-default behavior on bad input, **not** silent classifier fallbacks (§2 inapplicable — the helpers' return types are `int` / `bool` / `string option`, not a discriminated union, and operators are expected to set valid values).

## Test plan

- [x] `dune build --root . lib/` clean
- [x] `.mli` surface unchanged (consumers stay exposed via parent aliases)
- [x] External caller grep across `lib/` + `test/` — no qualified callers of the primitives
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
