### PR TITLE
refactor(keeper_accountability): extract claim_kind/status types sibling

### DIFF
--- a/lib/keeper/keeper_accountability.ml
+++ b/lib/keeper/keeper_accountability.ml
@@ -5,11 +5,11 @@
     explicit completion claims, then derives trust/risk summaries from
     deterministic evidence. *)
 
-type claim_kind =
+type claim_kind = Keeper_accountability_claim_types.claim_kind =
   | Task_commitment
   | Completion_claim
 
-type claim_status =
+type claim_status = Keeper_accountability_claim_types.claim_status =
   | Pending
   | Supported
   | Unsupported
@@ -57,33 +57,10 @@ let completion_claim_expiry_sec = 24.0 *. 3600.0
 let dedupe_window_sec = 3600.0
 let summary_window_days = 14
 
-let claim_kind_to_string = function
-  | Task_commitment -> "task_commitment"
-  | Completion_claim -> "completion_claim"
-;;
-
-let claim_kind_of_string = function
-  | "task_commitment" -> Some Task_commitment
-  | "completion_claim" -> Some Completion_claim
-  | _ -> None
-;;
-
-let claim_status_to_string = function
-  | Pending -> "pending"
-  | Supported -> "supported"
-  | Unsupported -> "unsupported"
-  | Expired -> "expired"
-  | Partial -> "partial"
-;;
-
-let claim_status_of_string = function
-  | "pending" -> Some Pending
-  | "supported" -> Some Supported
-  | "unsupported" -> Some Unsupported
-  | "expired" -> Some Expired
-  | "partial" -> Some Partial
-  | _ -> None
-;;
+let claim_kind_to_string = Keeper_accountability_claim_types.claim_kind_to_string
+let claim_kind_of_string = Keeper_accountability_claim_types.claim_kind_of_string
+let claim_status_to_string = Keeper_accountability_claim_types.claim_status_to_string
+let claim_status_of_string = Keeper_accountability_claim_types.claim_status_of_string
 
 let normalize_refs refs =
   refs

--- a/lib/keeper/keeper_accountability_claim_types.ml
+++ b/lib/keeper/keeper_accountability_claim_types.ml
@@ -1,0 +1,55 @@
+(** Claim kind + status variants for keeper accountability records.
+
+    Two small variants used throughout [Keeper_accountability]:
+    [claim_kind] tags whether an accountability claim is a forward
+    task commitment or a backward completion claim;
+    [claim_status] tracks the lifecycle of resolution (pending,
+    supported by evidence, unsupported, expired, or partial).
+
+    Plus the 4-helper string bijection bundle. Pure types + total
+    [to_string] + parse-don't-validate [of_string] (unknown -> None).
+
+    Verbatim extract from the head of [Keeper_accountability]; the
+    parent retains transparent variant aliases so existing
+    exhaustive matches and external [Keeper_accountability.Pending]
+    / [.Task_commitment] etc. constructor references continue to
+    resolve. *)
+
+type claim_kind =
+  | Task_commitment
+  | Completion_claim
+
+type claim_status =
+  | Pending
+  | Supported
+  | Unsupported
+  | Expired
+  | Partial
+
+let claim_kind_to_string = function
+  | Task_commitment -> "task_commitment"
+  | Completion_claim -> "completion_claim"
+;;
+
+let claim_kind_of_string = function
+  | "task_commitment" -> Some Task_commitment
+  | "completion_claim" -> Some Completion_claim
+  | _ -> None
+;;
+
+let claim_status_to_string = function
+  | Pending -> "pending"
+  | Supported -> "supported"
+  | Unsupported -> "unsupported"
+  | Expired -> "expired"
+  | Partial -> "partial"
+;;
+
+let claim_status_of_string = function
+  | "pending" -> Some Pending
+  | "supported" -> Some Supported
+  | "unsupported" -> Some Unsupported
+  | "expired" -> Some Expired
+  | "partial" -> Some Partial
+  | _ -> None
+;;

--- a/lib/keeper/keeper_accountability_claim_types.mli
+++ b/lib/keeper/keeper_accountability_claim_types.mli
@@ -1,0 +1,17 @@
+(** Claim kind + status variants for keeper accountability records. *)
+
+type claim_kind =
+  | Task_commitment
+  | Completion_claim
+
+type claim_status =
+  | Pending
+  | Supported
+  | Unsupported
+  | Expired
+  | Partial
+
+val claim_kind_to_string : claim_kind -> string
+val claim_kind_of_string : string -> claim_kind option
+val claim_status_to_string : claim_status -> string
+val claim_status_of_string : string -> claim_status option


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/keeper/keeper_accountability.ml` (1161 → 1138 LOC, **-23**). First touch on this godfile — audited by the 2026-05-18 godfile-decomposition build plan.

New sibling `lib/keeper/keeper_accountability_claim_types.ml` (55 LOC) hosts the two small variants + 4-helper string bijection bundle:

- `type claim_kind = Task_commitment | Completion_claim` — forward task commitment vs backward completion claim
- `type claim_status = Pending | Supported | Unsupported | Expired | Partial` — 5-state resolution lifecycle
- `val claim_kind_to_string` — total
- `val claim_kind_of_string` — parse-don't-validate; unknown → `None`
- `val claim_status_to_string` — total
- `val claim_status_of_string` — parse-don't-validate

## Parent surface preservation

```ocaml
type claim_kind = Keeper_accountability_claim_types.claim_kind =
  | Task_commitment | Completion_claim
type claim_status = Keeper_accountability_claim_types.claim_status =
  | Pending | Supported | Unsupported | Expired | Partial

let claim_kind_to_string = ...claim_kind_to_string
let claim_kind_of_string = ...claim_kind_of_string
let claim_status_to_string = ...claim_status_to_string
let claim_status_of_string = ...claim_status_of_string
```

The variant re-declarations after `=` preserve the `.mli`'s concrete-variant declarations at lines 1 + 5 plus all caller exhaustive-match patterns.

## Scope rationale

Records `claim_event`, `resolution_event`, `claim_snapshot` **stay in the parent** because they have many string/option/list fields and moving them would add transitive surface change. The two enum variants + their bijections are the cleanest standalone cut.

## Anti-pattern note

`_ -> None` arms are typed parse failures, not silent classifier fallbacks (§2 inapplicable). Pure variants + total `to_string` + parse-don't-validate `of_string`. **Verbatim move.**

## Test plan

- [x] `dune build --root . lib/` clean
- [x] `.mli` surface unchanged (transparent variant aliases preserve all constructors)
- [x] External qualified references continue to resolve via parent alias
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
