### PR TITLE
refactor(keeper_registry_types): extract stale-kill-class sibling

### DIFF
--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -9,17 +9,17 @@ module StringMap = Map.Make (String)
 (** Structured failure reason for cohort detection in self-preservation.
     ADT matching replaces string prefix matching for crash_msg grouping. *)
 type ambiguous_partial_commit_kind =
+  Keeper_registry_types_kill_class.ambiguous_partial_commit_kind =
   | Post_commit_timeout
   | Post_commit_failure
 
 type ambiguous_partial_commit =
+  Keeper_registry_types_kill_class.ambiguous_partial_commit =
   { kind : ambiguous_partial_commit_kind
   ; detail : string
   }
 
-(** Phase B PR-6 (2026-04-28): typed sub-class of stale-watchdog kills.
-    See keeper_registry.mli for rationale. *)
-type stale_kill_class =
+type stale_kill_class = Keeper_registry_types_kill_class.stale_kill_class =
   | Idle_turn of { stall_seconds : float }
   | In_turn_hung of
       { active_seconds : float
@@ -33,33 +33,9 @@ type stale_kill_class =
       }
   | Noop_failure_loop of { noop_count : int }
 
-let progress_kind_label = function
-  | Some kind -> kind
-  | None -> "-"
-;;
-
-let stale_kill_class_to_string = function
-  | Idle_turn { stall_seconds } -> Printf.sprintf "idle_turn(%.0fs)" stall_seconds
-  | In_turn_hung { active_seconds; timeout_threshold } ->
-    Printf.sprintf
-      "in_turn_hung(active=%.0fs threshold=%.0fs)"
-      active_seconds
-      timeout_threshold
-  | Mid_turn_no_progress
-      { active_seconds
-      ; since_progress_seconds
-      ; progress_timeout_threshold
-      ; last_progress_kind
-      } ->
-    Printf.sprintf
-      "mid_turn_no_progress(active=%.0fs since_progress=%.0fs threshold=%.0fs last=%s)"
-      active_seconds
-      since_progress_seconds
-      progress_timeout_threshold
-      (progress_kind_label last_progress_kind)
-  | Noop_failure_loop { noop_count } ->
-    Printf.sprintf "noop_failure_loop(noop=%d)" noop_count
-;;
+let progress_kind_label = Keeper_registry_types_kill_class.progress_kind_label
+let stale_kill_class_to_string =
+  Keeper_registry_types_kill_class.stale_kill_class_to_string
 
 type failure_reason =
   | Heartbeat_consecutive_failures of int
@@ -96,10 +72,8 @@ type failure_reason =
   | Fiber_unresolved
   | Exception of string
 
-let ambiguous_partial_commit_kind_to_string = function
-  | Post_commit_timeout -> "post_commit_timeout"
-  | Post_commit_failure -> "post_commit_failure"
-;;
+let ambiguous_partial_commit_kind_to_string =
+  Keeper_registry_types_kill_class.ambiguous_partial_commit_kind_to_string
 
 let failure_reason_to_string = function
   | Heartbeat_consecutive_failures n ->

--- a/lib/keeper/keeper_registry_types_kill_class.ml
+++ b/lib/keeper/keeper_registry_types_kill_class.ml
@@ -1,0 +1,76 @@
+(** Typed sub-classes for the keeper registry stale-watchdog kill
+    + the [Ambiguous_partial_commit] failure-reason payload.
+
+    [stale_kill_class] is the 4-variant typed kill-class introduced
+    in Phase B PR-6 (2026-04-28) — it distinguishes idle-turn,
+    in-turn-hung, mid-turn-no-progress, and noop-failure-loop kill
+    paths, each carrying the timer/threshold fields the operator
+    dashboard renders.
+
+    [ambiguous_partial_commit] tags a partial-commit failure with
+    the kind (post-commit timeout vs post-commit failure) + the
+    operator-facing detail string.
+
+    Pure variants + records + total [to_string] helpers. Verbatim
+    extract from the head of [Keeper_registry_types]; the parent
+    retains transparent aliases (type + record + variant) so the
+    .mli concrete declarations and the [failure_reason] variants
+    that reference these types continue to type-check unchanged. *)
+
+type ambiguous_partial_commit_kind =
+  | Post_commit_timeout
+  | Post_commit_failure
+
+type ambiguous_partial_commit =
+  { kind : ambiguous_partial_commit_kind
+  ; detail : string
+  }
+
+(** Phase B PR-6 (2026-04-28): typed sub-class of stale-watchdog kills.
+    See keeper_registry.mli for rationale. *)
+type stale_kill_class =
+  | Idle_turn of { stall_seconds : float }
+  | In_turn_hung of
+      { active_seconds : float
+      ; timeout_threshold : float
+      }
+  | Mid_turn_no_progress of
+      { active_seconds : float
+      ; since_progress_seconds : float
+      ; progress_timeout_threshold : float
+      ; last_progress_kind : string option
+      }
+  | Noop_failure_loop of { noop_count : int }
+
+let progress_kind_label = function
+  | Some kind -> kind
+  | None -> "-"
+;;
+
+let stale_kill_class_to_string = function
+  | Idle_turn { stall_seconds } -> Printf.sprintf "idle_turn(%.0fs)" stall_seconds
+  | In_turn_hung { active_seconds; timeout_threshold } ->
+    Printf.sprintf
+      "in_turn_hung(active=%.0fs threshold=%.0fs)"
+      active_seconds
+      timeout_threshold
+  | Mid_turn_no_progress
+      { active_seconds
+      ; since_progress_seconds
+      ; progress_timeout_threshold
+      ; last_progress_kind
+      } ->
+    Printf.sprintf
+      "mid_turn_no_progress(active=%.0fs since_progress=%.0fs threshold=%.0fs last=%s)"
+      active_seconds
+      since_progress_seconds
+      progress_timeout_threshold
+      (progress_kind_label last_progress_kind)
+  | Noop_failure_loop { noop_count } ->
+    Printf.sprintf "noop_failure_loop(noop=%d)" noop_count
+;;
+
+let ambiguous_partial_commit_kind_to_string = function
+  | Post_commit_timeout -> "post_commit_timeout"
+  | Post_commit_failure -> "post_commit_failure"
+;;

--- a/lib/keeper/keeper_registry_types_kill_class.mli
+++ b/lib/keeper/keeper_registry_types_kill_class.mli
@@ -1,0 +1,29 @@
+(** Typed sub-classes for the keeper registry stale-watchdog kill +
+    the [Ambiguous_partial_commit] failure-reason payload. *)
+
+type ambiguous_partial_commit_kind =
+  | Post_commit_timeout
+  | Post_commit_failure
+
+type ambiguous_partial_commit =
+  { kind : ambiguous_partial_commit_kind
+  ; detail : string
+  }
+
+type stale_kill_class =
+  | Idle_turn of { stall_seconds : float }
+  | In_turn_hung of
+      { active_seconds : float
+      ; timeout_threshold : float
+      }
+  | Mid_turn_no_progress of
+      { active_seconds : float
+      ; since_progress_seconds : float
+      ; progress_timeout_threshold : float
+      ; last_progress_kind : string option
+      }
+  | Noop_failure_loop of { noop_count : int }
+
+val progress_kind_label : string option -> string
+val stale_kill_class_to_string : stale_kill_class -> string
+val ambiguous_partial_commit_kind_to_string : ambiguous_partial_commit_kind -> string


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/keeper/keeper_registry_types.ml` (1162 → 1136 LOC, **-26**). First touch on this godfile — audited by the 2026-05-18 godfile-decomposition build plan.

New sibling `lib/keeper/keeper_registry_types_kill_class.ml` (76 LOC) hosts:

- `type ambiguous_partial_commit_kind = Post_commit_timeout | Post_commit_failure`
- `type ambiguous_partial_commit = { kind; detail }`
- `type stale_kill_class` — Phase B PR-6 (2026-04-28) 4-variant typed kill-class with inline records:
  - `Idle_turn { stall_seconds }`
  - `In_turn_hung { active_seconds; timeout_threshold }`
  - `Mid_turn_no_progress { active_seconds; since_progress_seconds; progress_timeout_threshold; last_progress_kind }`
  - `Noop_failure_loop { noop_count }`
- `val progress_kind_label` — option → string with `"-"` default
- `val stale_kill_class_to_string` — per-variant `Printf.sprintf` with all timer/threshold fields rendered
- `val ambiguous_partial_commit_kind_to_string`

## Parent surface preservation

All three types use transparent aliases (with field/variant re-declaration) so the `.mli` concrete declarations at lines 14, 18, 32 remain valid and downstream consumers — particularly the `failure_reason` variant (still in parent, line 64+) which has `Stale_turn_timeout of stale_kill_class` and `Ambiguous_partial_commit of ambiguous_partial_commit` arms — continue to type-check against the parent's aliased types.

```ocaml
type stale_kill_class =
  Keeper_registry_types_kill_class.stale_kill_class =
  | Idle_turn of { stall_seconds : float }
  | In_turn_hung of { active_seconds : float; timeout_threshold : float }
  | Mid_turn_no_progress of { active_seconds; since_progress_seconds; ... }
  | Noop_failure_loop of { noop_count : int }
```

**Inline-record variants** (`Idle_turn of { stall_seconds : float }`) require the same transparent-alias pattern as regular variants — the inline record fields are part of the constructor's payload and must be re-listed for the parent's variant to remain constructor-reachable to callers.

## Scope rationale

Pure types + total `to_string`. No parent-local state, no I/O. The bigger `failure_reason` variant stays in the parent because it composes these types in its arms — separating the dependency target into its own SSOT first is cleaner.

## Test plan

- [x] `dune build --root . lib/` clean
- [x] `.mli` surface unchanged (transparent type + record + variant aliases preserve all declarations)
- [x] External qualified references continue to resolve via parent alias
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
