### PR TITLE
refactor(tool_code_write): extract shell allowlist/validate sibling

### DIFF
--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -51,42 +51,20 @@ let first_nonempty_line output =
 let add_unique acc item =
   if List.exists (String.equal item) acc then acc else acc @ [ item ]
 
-(* Shell command allowlist.  Keep this aligned with keeper_bash/dev shell so
-   safe coding probes do not fail only because they entered through
-   masc_code_shell.  Tool-specific extras are kept here. *)
-let allowed_shell_commands =
-  List.fold_left add_unique Dev_exec_allowlist.dev
-    [ "diff"; "patch"; "mkdir"; "ocamlfind"; "tsc" ]
-
-let code_shell_command_context command =
-  Worker_dev_tools.command_context_coding_with_allowlist
-    ~caller:Exec_shell_gate.Tool_code_write
-    ~allow_pipes:true
-    ~allowed_commands:allowed_shell_commands
-    command
-;;
-
-let validate_code_shell_command (command : string) : (unit, string) Result.t =
-  code_shell_command_context command
-  |> Result.map_error
-       (Worker_dev_tools.block_reason_to_string_with_allowlist
-          ~allowed_commands:allowed_shell_commands)
-  |> Result.map (fun _ -> ())
+let allowed_shell_commands = Tool_code_write_shell_validate.allowed_shell_commands
+let code_shell_command_context =
+  Tool_code_write_shell_validate.code_shell_command_context
+let validate_code_shell_command =
+  Tool_code_write_shell_validate.validate_code_shell_command
 
 type code_shell_exit_status =
+  Tool_code_write_shell_validate.code_shell_exit_status =
   | Shell_ok
   | Shell_ok_expected_nonzero of string
   | Shell_error
 
-let classify_code_shell_exit ~last_stage_bin code =
-  match code with
-  | 0 -> Shell_ok
-  | 1 -> (
-      match last_stage_bin with
-      | Some ("rg" | "grep") -> Shell_ok_expected_nonzero "no_matches"
-      | Some "diff" -> Shell_ok_expected_nonzero "differences"
-      | Some _ | None -> Shell_error)
-  | _ -> Shell_error
+let classify_code_shell_exit =
+  Tool_code_write_shell_validate.classify_code_shell_exit
 
 let shell_ir_with_default_cwd cwd ir =
   match cwd with

--- a/lib/tool_code_write_shell_validate.ml
+++ b/lib/tool_code_write_shell_validate.ml
@@ -1,0 +1,55 @@
+(** Shell command allowlist + validation + exit-status classifier for
+    the [masc_code_shell] tool surface.
+
+    Pure helpers — verbatim extract from [Tool_code_write]. Delegates
+    to [Worker_dev_tools.command_context_coding_with_allowlist] for
+    the heavy parsing; this module owns the tool-specific
+    [allowed_shell_commands] table (which extends [Dev_exec_allowlist.dev]
+    with [diff/patch/mkdir/ocamlfind/tsc]) and the
+    [classify_code_shell_exit] disposition over [code × last_stage_bin].
+
+    The [add_unique] helper that builds the allowlist also stays in
+    the parent (line 51) — duplicated here as a 2-line local because
+    it's used by exactly one site. *)
+
+module Exec_shell_gate = Masc_exec_command_gate.Shell_command_gate
+
+let add_unique acc item =
+  if List.exists (String.equal item) acc then acc else acc @ [ item ]
+
+(* Shell command allowlist.  Keep this aligned with keeper_bash/dev shell so
+   safe coding probes do not fail only because they entered through
+   masc_code_shell.  Tool-specific extras are kept here. *)
+let allowed_shell_commands =
+  List.fold_left add_unique Dev_exec_allowlist.dev
+    [ "diff"; "patch"; "mkdir"; "ocamlfind"; "tsc" ]
+
+let code_shell_command_context command =
+  Worker_dev_tools.command_context_coding_with_allowlist
+    ~caller:Exec_shell_gate.Tool_code_write
+    ~allow_pipes:true
+    ~allowed_commands:allowed_shell_commands
+    command
+;;
+
+let validate_code_shell_command (command : string) : (unit, string) Result.t =
+  code_shell_command_context command
+  |> Result.map_error
+       (Worker_dev_tools.block_reason_to_string_with_allowlist
+          ~allowed_commands:allowed_shell_commands)
+  |> Result.map (fun _ -> ())
+
+type code_shell_exit_status =
+  | Shell_ok
+  | Shell_ok_expected_nonzero of string
+  | Shell_error
+
+let classify_code_shell_exit ~last_stage_bin code =
+  match code with
+  | 0 -> Shell_ok
+  | 1 -> (
+      match last_stage_bin with
+      | Some ("rg" | "grep") -> Shell_ok_expected_nonzero "no_matches"
+      | Some "diff" -> Shell_ok_expected_nonzero "differences"
+      | Some _ | None -> Shell_error)
+  | _ -> Shell_error

--- a/lib/tool_code_write_shell_validate.mli
+++ b/lib/tool_code_write_shell_validate.mli
@@ -1,0 +1,22 @@
+(** Shell command allowlist + validation + exit-status classifier for
+    the [masc_code_shell] tool surface. *)
+
+val allowed_shell_commands : string list
+
+val code_shell_command_context
+  :  string
+  -> (Masc_exec_command_gate.Shell_command_gate.parsed_context,
+      Worker_dev_tools.block_reason)
+     result
+
+val validate_code_shell_command : string -> (unit, string) result
+
+type code_shell_exit_status =
+  | Shell_ok
+  | Shell_ok_expected_nonzero of string
+  | Shell_error
+
+val classify_code_shell_exit
+  :  last_stage_bin:string option
+  -> int
+  -> code_shell_exit_status


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/tool_code_write.ml` (1153 → 1131 LOC, **-22**). First touch on this godfile — audited by the 2026-05-18 godfile-decomposition build plan.

New sibling `lib/tool_code_write_shell_validate.ml` (55 LOC) hosts the `masc_code_shell` command allowlist + validation + exit-status classifier cluster:

- `allowed_shell_commands` — `Dev_exec_allowlist.dev` extended with `[diff; patch; mkdir; ocamlfind; tsc]` (tool-specific)
- `code_shell_command_context` — delegates to `Worker_dev_tools.command_context_coding_with_allowlist` with `caller=Tool_code_write`, `allow_pipes=true`
- `validate_code_shell_command` — surface that yields `(unit, string) Result.t` for the `.mli`-exposed validator
- `type code_shell_exit_status = Shell_ok | Shell_ok_expected_nonzero of string | Shell_error`
- `classify_code_shell_exit ~last_stage_bin code` — maps `(exit_code, last_stage_bin)` to a typed disposition. Code 0 → `Shell_ok`; code 1 + rg/grep/diff → `Shell_ok_expected_nonzero` with reason (`"no_matches"` or `"differences"`); everything else → `Shell_error`

The `add_unique` helper used to build the allowlist is duplicated in the sibling (2 lines) rather than imported — exactly one use site there.

## Parent surface preservation

- 4 single-line value aliases for the helpers
- `type code_shell_exit_status` — transparent variant alias with full constructor re-declaration so `match status with Shell_ok -> ...` continues to type-check against `Tool_code_write.code_shell_exit_status` at internal call sites

## External callers preserved

- `test/test_tool_code_write_coverage.ml` uses `Tool_code_write.validate_code_shell_command` at 5 sites
- All other helpers are internal to the parent

## Anti-pattern note

`classify_code_shell_exit` uses `Some _ | None -> Shell_error` catch-all on the rg/grep/diff special-cases. This is a *typed disposition* (the result variant has 3 cases), **not** the §2 substring-classifier shape — the input is `(int * string option)`, the output is a closed sum. **Verbatim move.**

## Test plan

- [x] `dune build --root . lib/` clean
- [x] `.mli` surface unchanged (transparent variant alias preserves all 3 constructors)
- [x] External tests resolve through parent alias
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
