### PR TITLE
refactor(process_eio): extract stderr capture + output formatting sibling

### DIFF
--- a/lib/process/dune
+++ b/lib/process/dune
@@ -3,7 +3,7 @@
  (name masc_process)
  (public_name masc_mcp.masc_process)
  (wrapped false)
- (modules process_eio file_lock_eio exec_tap with_process bg_task timeout_origin)
+ (modules process_eio process_eio_stderr file_lock_eio exec_tap with_process bg_task timeout_origin)
  ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 (fragile pattern match) on.
  (flags (:standard -w +4))
  (libraries masc_core masc_log time_compat masc_cancel_safe eio eio.unix unix threads))

--- a/lib/process/process_eio.ml
+++ b/lib/process/process_eio.ml
@@ -149,58 +149,13 @@ let create_process_env ?cwd prog argv env stdin_fd stdout_fd stderr_fd =
           Sys.chdir dir;
           Unix.create_process_env prog (Array.of_list argv) env stdin_fd stdout_fd stderr_fd)
 
-let output_for_status ~(status : Unix.process_status) ~(stdout : string)
-    ~(stderr : string) : string =
-  let succeeded =
-    match status with
-    | Unix.WEXITED 0 -> true
-    | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> false
-  in
-  if succeeded then stdout
-  else
-    match stdout, stderr with
-    | "", err -> err
-    | out, "" -> out
-    | out, err -> out ^ "\n" ^ err
-
-let process_error_output ?(stderr = "") ~label:_ ~reason () =
-  let stderr = String.trim stderr in
-  if stderr = "" then
-    Printf.sprintf "process_eio_error: %s" reason
-  else
-    Printf.sprintf "process_eio_error: %s\nstderr:\n%s" reason stderr
-
-let reason_of_exn_for_output = function
-  | Unix.Unix_error (err, fn, _) ->
-      Printf.sprintf "%s: %s" fn (Unix.error_message err)
-  | exn -> Printexc.to_string exn
-
-(** Create a private stderr capture file for Unix fallback status helpers.
-    Uses [Filename.temp_file] for atomic creation, then opens the file with
-    private permissions and marks the descriptor close-on-exec to avoid
-    descriptor leaks into unrelated child processes. *)
-let create_stderr_tempfile () =
-  let path = Filename.temp_file "masc_process_eio_stderr" ".tmp" in
-  let fd =
-    Unix.openfile path [ Unix.O_WRONLY; Unix.O_TRUNC; Unix.O_CLOEXEC ] 0o600
-  in
-  (path, fd)
-
-let remove_temp_file_quietly path =
-  try Sys.remove path with
-  | Sys_error _ -> ()
-
-let read_stderr_capture path =
-  try In_channel.with_open_bin path In_channel.input_all with
-  | Sys_error msg ->
-      Printf.sprintf
-        "(stderr capture error) %s: %s"
-        (Filename.basename path) msg
-
-let captured_stderr_or_empty path_opt =
-  match path_opt with
-  | Some path -> read_stderr_capture path
-  | None -> ""
+let output_for_status = Process_eio_stderr.output_for_status
+let process_error_output = Process_eio_stderr.process_error_output
+let reason_of_exn_for_output = Process_eio_stderr.reason_of_exn_for_output
+let create_stderr_tempfile = Process_eio_stderr.create_stderr_tempfile
+let remove_temp_file_quietly = Process_eio_stderr.remove_temp_file_quietly
+let read_stderr_capture = Process_eio_stderr.read_stderr_capture
+let captured_stderr_or_empty = Process_eio_stderr.captured_stderr_or_empty
 
 let with_unix_capture ?env ?cwd ?stdin_content ?(capture_stderr = false)
     ?(timeout_sec = default_timeout_sec)

--- a/lib/process/process_eio_stderr.ml
+++ b/lib/process/process_eio_stderr.ml
@@ -1,0 +1,67 @@
+(** stderr-capture + process-output formatting helpers for the Eio
+    process runtime.
+
+    Pure helpers — [output_for_status], [process_error_output], and
+    [reason_of_exn_for_output] are total Printf builders.
+    [create_stderr_tempfile] / [remove_temp_file_quietly] /
+    [read_stderr_capture] / [captured_stderr_or_empty] are the
+    private-tempfile cycle used by the Unix-fallback status helpers
+    in [Process_eio] when the Eio path needs to surface a child
+    process's stderr without leaking descriptors.
+
+    Verbatim extract from [Process_eio]; all callers are internal
+    to the parent (verified via grep across lib/ + test/; not in
+    .mli). *)
+
+let output_for_status ~(status : Unix.process_status) ~(stdout : string)
+    ~(stderr : string) : string =
+  let succeeded =
+    match status with
+    | Unix.WEXITED 0 -> true
+    | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> false
+  in
+  if succeeded then stdout
+  else
+    match stdout, stderr with
+    | "", err -> err
+    | out, "" -> out
+    | out, err -> out ^ "\n" ^ err
+
+let process_error_output ?(stderr = "") ~label:_ ~reason () =
+  let stderr = String.trim stderr in
+  if stderr = "" then
+    Printf.sprintf "process_eio_error: %s" reason
+  else
+    Printf.sprintf "process_eio_error: %s\nstderr:\n%s" reason stderr
+
+let reason_of_exn_for_output = function
+  | Unix.Unix_error (err, fn, _) ->
+      Printf.sprintf "%s: %s" fn (Unix.error_message err)
+  | exn -> Printexc.to_string exn
+
+(** Create a private stderr capture file for Unix fallback status helpers.
+    Uses [Filename.temp_file] for atomic creation, then opens the file with
+    private permissions and marks the descriptor close-on-exec to avoid
+    descriptor leaks into unrelated child processes. *)
+let create_stderr_tempfile () =
+  let path = Filename.temp_file "masc_process_eio_stderr" ".tmp" in
+  let fd =
+    Unix.openfile path [ Unix.O_WRONLY; Unix.O_TRUNC; Unix.O_CLOEXEC ] 0o600
+  in
+  (path, fd)
+
+let remove_temp_file_quietly path =
+  try Sys.remove path with
+  | Sys_error _ -> ()
+
+let read_stderr_capture path =
+  try In_channel.with_open_bin path In_channel.input_all with
+  | Sys_error msg ->
+      Printf.sprintf
+        "(stderr capture error) %s: %s"
+        (Filename.basename path) msg
+
+let captured_stderr_or_empty path_opt =
+  match path_opt with
+  | Some path -> read_stderr_capture path
+  | None -> ""

--- a/lib/process/process_eio_stderr.mli
+++ b/lib/process/process_eio_stderr.mli
@@ -1,0 +1,25 @@
+(** stderr-capture + process-output formatting helpers for the Eio
+    process runtime. *)
+
+val output_for_status
+  :  status:Unix.process_status
+  -> stdout:string
+  -> stderr:string
+  -> string
+
+val process_error_output
+  :  ?stderr:string
+  -> label:string
+  -> reason:string
+  -> unit
+  -> string
+
+val reason_of_exn_for_output : exn -> string
+
+val create_stderr_tempfile : unit -> string * Unix.file_descr
+
+val remove_temp_file_quietly : string -> unit
+
+val read_stderr_capture : string -> string
+
+val captured_stderr_or_empty : string option -> string


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/process/process_eio.ml` (1163 → 1118 LOC, **-45**). First touch on this godfile — audited by the 2026-05-18 godfile-decomposition build plan.

**First sub-library carve-out of the sprint.** `lib/process/` is its own `masc_process` library with `(include_subdirs no)` and an explicit `(modules ...)` list, so the new sibling required a matching `dune` edit (1 line).

New sibling `lib/process/process_eio_stderr.ml` (67 LOC) hosts the stderr-capture + process-output formatting helpers:

- `output_for_status` — `status × stdout × stderr → combined string output` (succeeded → stdout; failed → stderr or `stdout\nstderr` concat)
- `process_error_output` — Printf builder for the standard `process_eio_error: <reason>\nstderr:\n<stderr>` format
- `reason_of_exn_for_output` — `Unix_error → "<fn>: <msg>"`; other exn → `Printexc.to_string`
- `create_stderr_tempfile` — `Filename.temp_file` + atomic `O_TRUNC + O_CLOEXEC + 0o600` mode
- `remove_temp_file_quietly` — `Sys.remove` swallowing `Sys_error`
- `read_stderr_capture` — `In_channel.with_open_bin` + `In_channel.input_all` with `Sys_error` fallback returning capture-error diagnostic string
- `captured_stderr_or_empty` — option dispatch over the above

## Dune wiring

```
- (modules process_eio file_lock_eio exec_tap with_process bg_task timeout_origin)
+ (modules process_eio process_eio_stderr file_lock_eio exec_tap with_process bg_task timeout_origin)
```

## Parent surface

- 7 single-line value aliases in `process_eio.ml`
- External callers: **none** (verified via grep across `lib/` + `test/`; not in `.mli`)

## Anti-pattern note

`remove_temp_file_quietly` swallows `Sys_error` (cleanup path, should not fail the caller); `read_stderr_capture` returns a diagnostic string on `Sys_error` rather than raising — both are deliberate "must not crash the error path" choices, preserved verbatim.

## Test plan

- [x] `dune build --root . lib/` clean
- [x] `dune` modules list updated (added `process_eio_stderr` next to `process_eio`)
- [x] External caller grep across `lib/` + `test/` — no qualified callers
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
