### PR TITLE
refactor(server_routes_http_routes_sidecar): extract state variants sibling

### DIFF
--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -45,7 +45,7 @@ let start_sidecar_process ~base_path ~script =
   | Error msg -> Error msg
 ;;
 
-type desired_state =
+type desired_state = Server_routes_http_routes_sidecar_state.desired_state =
   | Desired_running
   | Desired_stopped
 
@@ -57,11 +57,11 @@ type desired_record =
   ; updated_at : string
   }
 
-type observed_state =
+type observed_state = Server_routes_http_routes_sidecar_state.observed_state =
   | Observed_available
   | Observed_unavailable
 
-type reconcile_result =
+type reconcile_result = Server_routes_http_routes_sidecar_state.reconcile_result =
   | Reconcile_started
   | Reconcile_noop of string
 
@@ -76,26 +76,14 @@ type attempt_record =
   ; updated_at : string
   }
 
-let desired_state_to_string = function
-  | Desired_running -> "running"
-  | Desired_stopped -> "stopped"
-;;
-
-let desired_state_of_string = function
-  | "running" -> Some Desired_running
-  | "stopped" -> Some Desired_stopped
-  | _ -> None
-;;
-
-let observed_state_to_string = function
-  | Observed_available -> "available"
-  | Observed_unavailable -> "unavailable"
-;;
-
-let reconcile_result_to_string = function
-  | Reconcile_started -> "started"
-  | Reconcile_noop reason -> "noop:" ^ reason
-;;
+let desired_state_to_string =
+  Server_routes_http_routes_sidecar_state.desired_state_to_string
+let desired_state_of_string =
+  Server_routes_http_routes_sidecar_state.desired_state_of_string
+let observed_state_to_string =
+  Server_routes_http_routes_sidecar_state.observed_state_to_string
+let reconcile_result_to_string =
+  Server_routes_http_routes_sidecar_state.reconcile_result_to_string
 
 let attempt_record_json (record : attempt_record) =
   `Assoc

--- a/lib/server/server_routes_http_routes_sidecar_state.ml
+++ b/lib/server/server_routes_http_routes_sidecar_state.ml
@@ -1,0 +1,44 @@
+(** Sidecar reconciliation state variants + bijection helpers.
+
+    [desired_state] — operator-set goal (Running or Stopped).
+    [observed_state] — observed runtime (Available or Unavailable).
+    [reconcile_result] — outcome of a single reconcile attempt
+    (Started, or Noop with an explanation).
+
+    Verbatim extract from [Server_routes_http_routes_sidecar]; the
+    parent retains transparent variant aliases so the .mli concrete
+    declarations and downstream record fields ([desired_record],
+    [attempt_record]) continue to type-check unchanged. *)
+
+type desired_state =
+  | Desired_running
+  | Desired_stopped
+
+type observed_state =
+  | Observed_available
+  | Observed_unavailable
+
+type reconcile_result =
+  | Reconcile_started
+  | Reconcile_noop of string
+
+let desired_state_to_string = function
+  | Desired_running -> "running"
+  | Desired_stopped -> "stopped"
+;;
+
+let desired_state_of_string = function
+  | "running" -> Some Desired_running
+  | "stopped" -> Some Desired_stopped
+  | _ -> None
+;;
+
+let observed_state_to_string = function
+  | Observed_available -> "available"
+  | Observed_unavailable -> "unavailable"
+;;
+
+let reconcile_result_to_string = function
+  | Reconcile_started -> "started"
+  | Reconcile_noop reason -> "noop:" ^ reason
+;;

--- a/lib/server/server_routes_http_routes_sidecar_state.mli
+++ b/lib/server/server_routes_http_routes_sidecar_state.mli
@@ -1,0 +1,18 @@
+(** Sidecar reconciliation state variants + bijection helpers. *)
+
+type desired_state =
+  | Desired_running
+  | Desired_stopped
+
+type observed_state =
+  | Observed_available
+  | Observed_unavailable
+
+type reconcile_result =
+  | Reconcile_started
+  | Reconcile_noop of string
+
+val desired_state_to_string : desired_state -> string
+val desired_state_of_string : string -> desired_state option
+val observed_state_to_string : observed_state -> string
+val reconcile_result_to_string : reconcile_result -> string


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/server/server_routes_http_routes_sidecar.ml` (1198 → 1186 LOC, **-12**). First touch on this godfile — audited by the 2026-05-18 godfile-decomposition build plan.

New sibling `lib/server/server_routes_http_routes_sidecar_state.ml` (44 LOC) hosts the sidecar reconciliation state variants + bijection helpers:

- `type desired_state = Desired_running | Desired_stopped` — operator-set goal
- `type observed_state = Observed_available | Observed_unavailable` — observed runtime
- `type reconcile_result = Reconcile_started | Reconcile_noop of string` — single reconcile attempt outcome
- `val desired_state_to_string` — total
- `val desired_state_of_string` — parse-don't-validate
- `val observed_state_to_string` — total
- `val reconcile_result_to_string` — `Reconcile_noop reason → "noop:" ^ reason`

## Parent surface preservation

3 transparent variant aliases (with constructor re-declaration). Records `desired_record` (5 fields incl. `desired_state`) and `attempt_record` (8 fields) **stay in the parent** — they reference the variants via the parent alias and would add transitive surface change if moved.

```ocaml
type desired_state = ...sidecar_state.desired_state =
  | Desired_running | Desired_stopped
type observed_state = ...sidecar_state.observed_state =
  | Observed_available | Observed_unavailable
type reconcile_result = ...sidecar_state.reconcile_result =
  | Reconcile_started | Reconcile_noop of string
```

## External callers

`.mli` at lines 155, 167, 170, 186-189 unchanged. All callers resolve through parent aliases.

## Anti-pattern note

Pure variants + total `to_string` + parse-don't-validate `of_string`. `reconcile_result_to_string` uses `^ reason` string concat for `Noop` (`"noop:" ^ reason`) — preserved verbatim. **No new arms added.**

## Test plan

- [x] `dune build --root . lib/` clean
- [x] `.mli` surface unchanged (transparent variant aliases preserve all constructors)
- [x] No sub-library dune edit needed (`lib/server/` is in the main `masc_mcp` `include_subdirs unqualified` library)
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
