### PR TITLE
refactor(server_bootstrap_loops): extract fiber/yield helpers sibling

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -111,39 +111,14 @@ module For_testing = struct
   let board_sse_event_params = board_sse_event_params
 end
 
-let fork_logged_fiber ~sw ~on_error run =
-  Eio.Fiber.fork ~sw (fun () ->
-    try run () with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | exn -> on_error exn)
-;;
-
-let log_server_fiber_crash name exn =
-  Log.Server.error "%s fiber crashed: %s" name (Printexc.to_string exn)
-;;
-
-let log_dashboard_fiber_crash name exn =
-  Log.Dashboard.error "%s fiber crashed: %s" name (Printexc.to_string exn)
-;;
-
-let filteri_with_fair_yield f xs =
-  let meter = Eio_guard.create_yield_meter ~interval:1 () in
-  List.filteri
-    (fun idx item ->
-       let keep = f idx item in
-       Eio_guard.yield_step meter;
-       keep)
-    xs
-;;
-
-let iteri_with_fair_yield f xs =
-  let meter = Eio_guard.create_yield_meter ~interval:1 () in
-  List.iteri
-    (fun idx item ->
-       f idx item;
-       Eio_guard.yield_step meter)
-    xs
-;;
+let fork_logged_fiber = Server_bootstrap_loops_fiber.fork_logged_fiber
+let log_server_fiber_crash =
+  Server_bootstrap_loops_fiber.log_server_fiber_crash
+let log_dashboard_fiber_crash =
+  Server_bootstrap_loops_fiber.log_dashboard_fiber_crash
+let filteri_with_fair_yield =
+  Server_bootstrap_loops_fiber.filteri_with_fair_yield
+let iteri_with_fair_yield = Server_bootstrap_loops_fiber.iteri_with_fair_yield
 
 let start_keeper_loops
       ~sw

--- a/lib/server/server_bootstrap_loops_fiber.ml
+++ b/lib/server/server_bootstrap_loops_fiber.ml
@@ -1,0 +1,53 @@
+(** Fiber + fair-yield helpers for the server bootstrap loops.
+
+    [fork_logged_fiber] forks under a switch and routes non-cancel
+    exceptions through an [on_error] handler so a single crashed
+    fiber does not propagate up to the switch and cancel sibling
+    work. [Eio.Cancel.Cancelled] is re-raised unchanged because the
+    switch may need to honor cancellation.
+
+    [log_server_fiber_crash] / [log_dashboard_fiber_crash] are the
+    two standard [on_error] adapters that print a fiber-crash line
+    to the [Log.Server] / [Log.Dashboard] streams.
+
+    [filteri_with_fair_yield] / [iteri_with_fair_yield] iterate a
+    list while inserting [Eio_guard.yield_step] calls every element,
+    so a long-list iteration cannot starve other fibers on the
+    domain.
+
+    Pure (modulo Eio fiber scheduling + Log emit). All callers are
+    internal to [Server_bootstrap_loops]. *)
+
+let fork_logged_fiber ~sw ~on_error run =
+  Eio.Fiber.fork ~sw (fun () ->
+    try run () with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn -> on_error exn)
+;;
+
+let log_server_fiber_crash name exn =
+  Log.Server.error "%s fiber crashed: %s" name (Printexc.to_string exn)
+;;
+
+let log_dashboard_fiber_crash name exn =
+  Log.Dashboard.error "%s fiber crashed: %s" name (Printexc.to_string exn)
+;;
+
+let filteri_with_fair_yield f xs =
+  let meter = Eio_guard.create_yield_meter ~interval:1 () in
+  List.filteri
+    (fun idx item ->
+       let keep = f idx item in
+       Eio_guard.yield_step meter;
+       keep)
+    xs
+;;
+
+let iteri_with_fair_yield f xs =
+  let meter = Eio_guard.create_yield_meter ~interval:1 () in
+  List.iteri
+    (fun idx item ->
+       f idx item;
+       Eio_guard.yield_step meter)
+    xs
+;;

--- a/lib/server/server_bootstrap_loops_fiber.mli
+++ b/lib/server/server_bootstrap_loops_fiber.mli
@@ -1,0 +1,13 @@
+(** Fiber + fair-yield helpers for the server bootstrap loops. *)
+
+val fork_logged_fiber
+  :  sw:Eio.Switch.t
+  -> on_error:(exn -> unit)
+  -> (unit -> unit)
+  -> unit
+
+val log_server_fiber_crash : string -> exn -> unit
+val log_dashboard_fiber_crash : string -> exn -> unit
+
+val filteri_with_fair_yield : (int -> 'a -> bool) -> 'a list -> 'a list
+val iteri_with_fair_yield : (int -> 'a -> unit) -> 'a list -> unit


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/server/server_bootstrap_loops.ml` (1262 → 1237 LOC, **-25**). First touch on this godfile — audited by the 2026-05-18 godfile-decomposition build plan.

New sibling `lib/server/server_bootstrap_loops_fiber.ml` (53 LOC) hosts the Eio fiber fork + crash-log + fair-yield helpers:

- `fork_logged_fiber ~sw ~on_error run` — forks under a switch and routes non-cancel exceptions through `on_error` so one crashed fiber does not propagate up and cancel sibling work. `Eio.Cancel.Cancelled` is re-raised unchanged.
- `log_server_fiber_crash name exn` — `Log.Server.error` adapter for the `on_error` hook
- `log_dashboard_fiber_crash name exn` — `Log.Dashboard.error` adapter for the `on_error` hook
- `filteri_with_fair_yield f xs` — `List.filteri` with `Eio_guard.yield_step` inserted every element so a long-list iteration cannot starve other fibers on the domain
- `iteri_with_fair_yield f xs` — equivalent for `List.iteri`

## Parent surface

5 single-line value aliases. All remaining call sites in `start_keeper_loops` (parent line 148+, ~843 LOC) and `start_background_maintenance` (parent line 992+, ~270 LOC) resolve through the parent's aliased names without edits.

## External callers

**None** under qualified name `Server_bootstrap_loops.*` (verified via grep across `lib/` + `test/`; not in `.mli`). All callers internal to the parent.

## Anti-pattern note

The `try ... with Eio.Cancel.Cancelled _ as e -> raise e | exn -> on_error exn` pattern in `fork_logged_fiber` is exactly the cancellation-safe shape mandated by Anti-pattern § Cancellation: **cancel exceptions must NOT be swallowed by catch-all `exn ->` arms**. Verbatim move preserves this guarantee.

## Test plan

- [x] `dune build --root . lib/` clean
- [x] No `.mli` to update (internal helpers)
- [x] External caller grep across `lib/` + `test/` — no qualified callers
- [x] No sub-library dune edit needed (`lib/server/` in main `masc_mcp` `include_subdirs unqualified` library)
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
