### PR TITLE
refactor(cascade_attempt_fsm): extract provider->http error mappers sibling

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -44,81 +44,10 @@ let retry_message_looks_like_model_access_denied (message : string) : bool =
   || String_util.contains_substring_ci message "does not have access to"
   || String_util.contains_substring_ci message "not authorized to access"
 
-let provider_capacity_scope_to_http = function
-  | Llm_provider.Error.CapacityModel -> Llm_provider.Http_client.Failure_scope_model
-  | Llm_provider.Error.CapacityAccount ->
-    Llm_provider.Http_client.Failure_scope_account
-  | Llm_provider.Error.CapacityRegion ->
-    Llm_provider.Http_client.Failure_scope_region
-  | Llm_provider.Error.CapacityProvider ->
-    Llm_provider.Http_client.Failure_scope_provider
-  | Llm_provider.Error.CapacityUnknown ->
-    Llm_provider.Http_client.Failure_scope_unknown
-
-let provider_error_to_http_error (err : Agent_sdk.Error.provider_error)
-  : Llm_provider.Http_client.http_error =
-  let module E = Llm_provider.Error in
-  let message = E.to_string err in
-  match err with
-  | E.MissingApiKey _ | E.InvalidConfig _ ->
-    Llm_provider.Http_client.AcceptRejected { reason = message }
-  | E.ParseError { detail } ->
-    Llm_provider.Http_client.ProviderFailure
-      { kind = Llm_provider.Http_client.Provider_parse_error { parser = None }
-      ; message = detail
-      }
-  | E.UnknownVariant { type_name; value } ->
-    Llm_provider.Http_client.ProviderFailure
-      { kind =
-          Llm_provider.Http_client.Unknown_provider_failure
-            { reason = Some (Printf.sprintf "%s:%s" type_name value) }
-      ; message
-      }
-  | E.ProviderUnavailable { detail; _ } ->
-    Llm_provider.Http_client.HttpError { code = 503; body = detail }
-  | E.RateLimit { detail; _ } ->
-    Llm_provider.Http_client.HttpError { code = 429; body = detail }
-  | E.HardQuota { retry_after; detail; _ } ->
-    Llm_provider.Http_client.ProviderFailure
-      { kind = Llm_provider.Http_client.Hard_quota { retry_after }
-      ; message = detail
-      }
-  | E.CapacityExhausted { scope; affected; retry_after; detail } ->
-    Llm_provider.Http_client.ProviderFailure
-      { kind =
-          Llm_provider.Http_client.Capacity_exhausted
-            { scope = provider_capacity_scope_to_http scope
-            ; retry_after
-            ; model = List.find_opt (fun value -> String.trim value <> "") affected
-            }
-      ; message = detail
-      }
-  | E.AuthError { detail; _ } ->
-    Llm_provider.Http_client.HttpError { code = 401; body = detail }
-  | E.ServerError { code; detail; _ } ->
-    Llm_provider.Http_client.HttpError { code; body = detail }
-  | E.NetworkError { timeout_phase = Some phase; detail; _ } ->
-    Llm_provider.Http_client.TimeoutError { message = detail; phase }
-  | E.NetworkError { kind; timeout_phase = None; detail; _ } ->
-    Llm_provider.Http_client.NetworkError { message = detail; kind }
-  | E.Timeout { timeout_phase; detail; _ } ->
-    let phase =
-      match timeout_phase with
-      | Some phase -> phase
-      | None ->
-        (* DET-OK: OAS provider omitted timeout_phase; Unknown_timeout is an
-           explicit typed sentinel, not a permissive branch heuristic. *)
-        Llm_provider.Http_client.Unknown_timeout
-    in
-    Llm_provider.Http_client.TimeoutError
-      { message = detail; phase }
-  | E.InvalidRequest { reason; _ } ->
-    Llm_provider.Http_client.HttpError { code = 400; body = reason }
-  | E.NotFound { detail; _ } ->
-    Llm_provider.Http_client.HttpError { code = 404; body = detail }
-  | E.ProviderTerminal { reason; detail; _ } ->
-    Llm_provider.Http_client.ProviderTerminal
-      { kind = Llm_provider.Http_client.Other reason; message = detail }
+let provider_capacity_scope_to_http =
+  Cascade_attempt_fsm_http_error.provider_capacity_scope_to_http
+let provider_error_to_http_error =
+  Cascade_attempt_fsm_http_error.provider_error_to_http_error
 
 (** Convert an OAS sdk_error into a Cascade_fsm provider_outcome.
     API-level errors and model-capability-dependent agent errors are

--- a/lib/cascade/cascade_attempt_fsm_http_error.ml
+++ b/lib/cascade/cascade_attempt_fsm_http_error.ml
@@ -1,0 +1,94 @@
+(** Provider-error -> HTTP-error typed mappers for the cascade attempt
+    FSM.
+
+    [provider_capacity_scope_to_http] — closed 5-arm map from
+    [Llm_provider.Error.capacity_scope] to
+    [Llm_provider.Http_client.failure_scope].
+
+    [provider_error_to_http_error] — closed 14-arm map from
+    [Agent_sdk.Error.provider_error] to
+    [Llm_provider.Http_client.http_error]. Each arm converts an OAS-
+    surfaced provider error variant into the dashboard-rendered HTTP
+    failure typed envelope (HttpError + status code, ProviderFailure
+    + structured kind, AcceptRejected, ProviderTerminal,
+    TimeoutError, NetworkError).
+
+    Pure typed-to-typed conversion — no parent state, no I/O. All
+    arms are exhaustive (compiler-enforced). Verbatim extract from
+    [Cascade_attempt_fsm]; all callers are internal to the parent. *)
+
+let provider_capacity_scope_to_http = function
+  | Llm_provider.Error.CapacityModel -> Llm_provider.Http_client.Failure_scope_model
+  | Llm_provider.Error.CapacityAccount ->
+    Llm_provider.Http_client.Failure_scope_account
+  | Llm_provider.Error.CapacityRegion ->
+    Llm_provider.Http_client.Failure_scope_region
+  | Llm_provider.Error.CapacityProvider ->
+    Llm_provider.Http_client.Failure_scope_provider
+  | Llm_provider.Error.CapacityUnknown ->
+    Llm_provider.Http_client.Failure_scope_unknown
+
+let provider_error_to_http_error (err : Agent_sdk.Error.provider_error)
+  : Llm_provider.Http_client.http_error =
+  let module E = Llm_provider.Error in
+  let message = E.to_string err in
+  match err with
+  | E.MissingApiKey _ | E.InvalidConfig _ ->
+    Llm_provider.Http_client.AcceptRejected { reason = message }
+  | E.ParseError { detail } ->
+    Llm_provider.Http_client.ProviderFailure
+      { kind = Llm_provider.Http_client.Provider_parse_error { parser = None }
+      ; message = detail
+      }
+  | E.UnknownVariant { type_name; value } ->
+    Llm_provider.Http_client.ProviderFailure
+      { kind =
+          Llm_provider.Http_client.Unknown_provider_failure
+            { reason = Some (Printf.sprintf "%s:%s" type_name value) }
+      ; message
+      }
+  | E.ProviderUnavailable { detail; _ } ->
+    Llm_provider.Http_client.HttpError { code = 503; body = detail }
+  | E.RateLimit { detail; _ } ->
+    Llm_provider.Http_client.HttpError { code = 429; body = detail }
+  | E.HardQuota { retry_after; detail; _ } ->
+    Llm_provider.Http_client.ProviderFailure
+      { kind = Llm_provider.Http_client.Hard_quota { retry_after }
+      ; message = detail
+      }
+  | E.CapacityExhausted { scope; affected; retry_after; detail } ->
+    Llm_provider.Http_client.ProviderFailure
+      { kind =
+          Llm_provider.Http_client.Capacity_exhausted
+            { scope = provider_capacity_scope_to_http scope
+            ; retry_after
+            ; model = List.find_opt (fun value -> String.trim value <> "") affected
+            }
+      ; message = detail
+      }
+  | E.AuthError { detail; _ } ->
+    Llm_provider.Http_client.HttpError { code = 401; body = detail }
+  | E.ServerError { code; detail; _ } ->
+    Llm_provider.Http_client.HttpError { code; body = detail }
+  | E.NetworkError { timeout_phase = Some phase; detail; _ } ->
+    Llm_provider.Http_client.TimeoutError { message = detail; phase }
+  | E.NetworkError { kind; timeout_phase = None; detail; _ } ->
+    Llm_provider.Http_client.NetworkError { message = detail; kind }
+  | E.Timeout { timeout_phase; detail; _ } ->
+    let phase =
+      match timeout_phase with
+      | Some phase -> phase
+      | None ->
+        (* DET-OK: OAS provider omitted timeout_phase; Unknown_timeout is an
+           explicit typed sentinel, not a permissive branch heuristic. *)
+        Llm_provider.Http_client.Unknown_timeout
+    in
+    Llm_provider.Http_client.TimeoutError
+      { message = detail; phase }
+  | E.InvalidRequest { reason; _ } ->
+    Llm_provider.Http_client.HttpError { code = 400; body = reason }
+  | E.NotFound { detail; _ } ->
+    Llm_provider.Http_client.HttpError { code = 404; body = detail }
+  | E.ProviderTerminal { reason; detail; _ } ->
+    Llm_provider.Http_client.ProviderTerminal
+      { kind = Llm_provider.Http_client.Other reason; message = detail }

--- a/lib/cascade/cascade_attempt_fsm_http_error.mli
+++ b/lib/cascade/cascade_attempt_fsm_http_error.mli
@@ -1,0 +1,10 @@
+(** Provider-error -> HTTP-error typed mappers for the cascade attempt
+    FSM. *)
+
+val provider_capacity_scope_to_http
+  :  Llm_provider.Error.capacity_scope
+  -> Llm_provider.Http_client.provider_failure_scope
+
+val provider_error_to_http_error
+  :  Agent_sdk.Error.provider_error
+  -> Llm_provider.Http_client.http_error


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/cascade/cascade_attempt_fsm.ml` (1070 → 999 LOC, **-71**). First touch on this godfile — audited by the 2026-05-18 godfile-decomposition build plan.

**Crosses the 1000-LOC threshold.** The parent is no longer a godfile by the audit's definition.

New sibling `lib/cascade/cascade_attempt_fsm_http_error.ml` (94 LOC) hosts:

- `provider_capacity_scope_to_http` — closed 5-arm map from `Llm_provider.Error.capacity_scope` to `Llm_provider.Http_client.failure_scope` (Model / Account / Region / Provider / Unknown)
- `provider_error_to_http_error` — closed 14-arm map from `Agent_sdk.Error.provider_error` to `Llm_provider.Http_client.http_error`. Each arm converts an OAS-surfaced provider error variant into the dashboard-rendered HTTP failure typed envelope (`HttpError` + status code, `ProviderFailure` + structured kind, `AcceptRejected`, `ProviderTerminal`, `TimeoutError`, `NetworkError`)

Pure typed-to-typed conversion — no parent state, no I/O. All arms are exhaustive (compiler-enforced; new `Llm_provider.Error.provider_error` variants would force a same-PR converter update via the source module's exhaustive-match check, matching the recurring P0 pattern called out in `failure_reason_cohort_key` elsewhere).

## Parent surface

2 single-line value aliases.

## External callers

**None** under qualified name `Cascade_attempt_fsm.*` (verified via grep across `lib/` + `test/`; not in `.mli`). All callers internal to the parent `sdk_error_to_cascade_outcome` (line 127+) which composes the extracted helpers.

## Anti-pattern note

The `Timeout { timeout_phase = None; _ }` arm includes a `DET-OK` comment marking `Unknown_timeout` as a typed sentinel rather than a permissive branch heuristic. This is the typed-failure pattern §2 wants — the `timeout_phase` absence is explicitly mapped to a distinct typed variant rather than silently substituted with a "common case" default. **Verbatim move preserves both the comment and the typed boundary.**

## Test plan

- [x] `dune build --root . lib/` clean
- [x] No `.mli` to update (internal mappers)
- [x] External caller grep across `lib/` + `test/` — no qualified callers
- [x] `lib/cascade/` has no sub-library dune — uses main `masc_mcp` `include_subdirs unqualified`
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
