### PR TITLE
refactor(env_config_keeper): extract KeeperRetryBackoff to sibling module

### DIFF
--- a/lib/config/dune
+++ b/lib/config/dune
@@ -10,6 +10,7 @@
    env_config_exec_timeout
    env_config_governance
    env_config_keeper
+   env_config_keeper_retry_backoff
    env_config_keeper_supervisor
    env_config_oas_bridge
    env_config_runtime

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -903,65 +903,7 @@ end
     backoff between re-attempts when all OAS providers fail transiently
     (e.g. TCP keepalive expiry).  They do NOT affect OAS internal
     per-provider retry (3 attempts with its own backoff). *)
-module KeeperRetryBackoff = struct
-  (** Maximum outer-loop retries after the initial attempt.
-      Total attempts = 1 initial + max_transient_retries.
-      Env: [MASC_KEEPER_MAX_TRANSIENT_RETRIES].  Default: 2. *)
-  let max_transient_retries () = get_int ~default:2 "MASC_KEEPER_MAX_TRANSIENT_RETRIES"
-
-  (** Base delay (seconds) for exponential backoff.
-      Delay at attempt [n] is [base * 2^(n-1)].
-      Env: [MASC_KEEPER_TRANSIENT_BACKOFF_BASE_SEC].  Default: 1.0. *)
-  let transient_backoff_base_sec () =
-    get_float ~default:1.0 "MASC_KEEPER_TRANSIENT_BACKOFF_BASE_SEC"
-  ;;
-
-  (** Hard cap on backoff delay (seconds).
-      Env: [MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC].  Default: 4.0. *)
-  let transient_backoff_cap_sec () =
-    get_float ~default:4.0 "MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC"
-  ;;
-
-  (** Exponential backoff delay for transient retry [attempt] (1-indexed).
-      Env: [MASC_KEEPER_TRANSIENT_BACKOFF_BASE_SEC] and
-      [MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC]. *)
-  let transient_backoff_sec (attempt : int) : float =
-    let base = transient_backoff_base_sec () in
-    let cap = transient_backoff_cap_sec () in
-    Float.min cap (base *. Float.of_int (1 lsl (attempt - 1)))
-  ;;
-
-  (** Productive slot-phase budget (seconds).  PR #13120: when a
-      cascade returns a recoverable error after the keeper has
-      already burned this many seconds inside the outer turn slot,
-      degraded retry rotation is rejected (the rotation evidence is
-      still recorded in [cascade_rotation_attempts] for audit).  The
-      keeper releases the outer slot instead of holding it for a
-      retry that may itself stall.  OAS timeout-budget failures may
-      still rotate to the next degraded cascade when retry budget remains,
-      because the first attempt already consumed its bounded provider
-      budget.  Floor 5s prevents accidental always-reject configs.
-
-      Declared here (not in keeper_turn_cascade_budget.ml) so the
-      env knob catalog generator at bin/env_knob_catalog.ml picks
-      it up — the catalog only scans lib/config/env_config_*.ml.
-
-      Env: [MASC_KEEPER_DEGRADED_RETRY_SLOT_PHASE_BUDGET_SEC].
-      Default: 180.0.
-      @category Timeouts
-      @ops_class operator
-
-      Calibrated to the attempt-liveness bootstrap floor so that
-      slow-but-honest streams are not denied a degraded retry solely
-      because their first-token latency exceeds the old 60 s floor.
-      Providers with successful history can learn a wider candidate
-      budget without hard-coding provider or model-size classes. *)
-  let degraded_retry_slot_phase_budget_sec =
-    Float.max
-      5.0
-      (get_float ~default:180.0 "MASC_KEEPER_DEGRADED_RETRY_SLOT_PHASE_BUDGET_SEC")
-  ;;
-end
+module KeeperRetryBackoff = Env_config_keeper_retry_backoff
 
 (** RFC-0022 §9 rollout flag for the in-attempt streaming liveness gate.
 

--- a/lib/config/env_config_keeper_retry_backoff.ml
+++ b/lib/config/env_config_keeper_retry_backoff.ml
@@ -1,0 +1,72 @@
+(** Keeper transient-retry backoff configuration.
+
+    Exponential backoff knobs for the keeper outer-loop transient
+    retry path plus the productive slot-phase budget gate used by
+    [Keeper_turn_cascade_budget] when deciding whether a degraded
+    retry rotation may proceed.
+
+    Verbatim extract from [Env_config_keeper.KeeperRetryBackoff];
+    the parent now does
+    [module KeeperRetryBackoff = Env_config_keeper_retry_backoff]
+    and existing call sites resolve through the parent module alias
+    unchanged. *)
+
+open Env_config_core
+
+(** Maximum outer-loop retries after the initial attempt.
+    Total attempts = 1 initial + max_transient_retries.
+    Env: [MASC_KEEPER_MAX_TRANSIENT_RETRIES].  Default: 2. *)
+let max_transient_retries () = get_int ~default:2 "MASC_KEEPER_MAX_TRANSIENT_RETRIES"
+
+(** Base delay (seconds) for exponential backoff.
+    Delay at attempt [n] is [base * 2^(n-1)].
+    Env: [MASC_KEEPER_TRANSIENT_BACKOFF_BASE_SEC].  Default: 1.0. *)
+let transient_backoff_base_sec () =
+  get_float ~default:1.0 "MASC_KEEPER_TRANSIENT_BACKOFF_BASE_SEC"
+;;
+
+(** Hard cap on backoff delay (seconds).
+    Env: [MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC].  Default: 4.0. *)
+let transient_backoff_cap_sec () =
+  get_float ~default:4.0 "MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC"
+;;
+
+(** Exponential backoff delay for transient retry [attempt] (1-indexed).
+    Env: [MASC_KEEPER_TRANSIENT_BACKOFF_BASE_SEC] and
+    [MASC_KEEPER_TRANSIENT_BACKOFF_CAP_SEC]. *)
+let transient_backoff_sec (attempt : int) : float =
+  let base = transient_backoff_base_sec () in
+  let cap = transient_backoff_cap_sec () in
+  Float.min cap (base *. Float.of_int (1 lsl (attempt - 1)))
+;;
+
+(** Productive slot-phase budget (seconds).  PR #13120: when a
+    cascade returns a recoverable error after the keeper has
+    already burned this many seconds inside the outer turn slot,
+    degraded retry rotation is rejected (the rotation evidence is
+    still recorded in [cascade_rotation_attempts] for audit).  The
+    keeper releases the outer slot instead of holding it for a
+    retry that may itself stall.  OAS timeout-budget failures may
+    still rotate to the next degraded cascade when retry budget remains,
+    because the first attempt already consumed its bounded provider
+    budget.  Floor 5s prevents accidental always-reject configs.
+
+    Declared here (not in keeper_turn_cascade_budget.ml) so the
+    env knob catalog generator at bin/env_knob_catalog.ml picks
+    it up — the catalog only scans lib/config/env_config_*.ml.
+
+    Env: [MASC_KEEPER_DEGRADED_RETRY_SLOT_PHASE_BUDGET_SEC].
+    Default: 180.0.
+    @category Timeouts
+    @ops_class operator
+
+    Calibrated to the attempt-liveness bootstrap floor so that
+    slow-but-honest streams are not denied a degraded retry solely
+    because their first-token latency exceeds the old 60 s floor.
+    Providers with successful history can learn a wider candidate
+    budget without hard-coding provider or model-size classes. *)
+let degraded_retry_slot_phase_budget_sec =
+  Float.max
+    5.0
+    (get_float ~default:180.0 "MASC_KEEPER_DEGRADED_RETRY_SLOT_PHASE_BUDGET_SEC")
+;;

--- a/lib/config/env_config_keeper_retry_backoff.mli
+++ b/lib/config/env_config_keeper_retry_backoff.mli
@@ -1,0 +1,7 @@
+(** Keeper transient-retry backoff configuration. *)
+
+val max_transient_retries : unit -> int
+val transient_backoff_base_sec : unit -> float
+val transient_backoff_cap_sec : unit -> float
+val transient_backoff_sec : int -> float
+val degraded_retry_slot_phase_budget_sec : float


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/config/env_config_keeper.ml` (1006 → 948 LOC, **-58**). First touch on this godfile — audited by the 2026-05-18 godfile-decomposition build plan.

**Crosses the 1000-LOC threshold.** The parent is no longer a godfile by the audit's definition.

New sibling `lib/config/env_config_keeper_retry_backoff.ml` (72 LOC) hosts the `KeeperRetryBackoff` env-config namespace:

- `max_transient_retries ()` — `int`, env `MASC_KEEPER_MAX_TRANSIENT_RETRIES`, default 2
- `transient_backoff_base_sec ()` — `float`, env `*_BASE_SEC`, default 1.0
- `transient_backoff_cap_sec ()` — `float`, env `*_CAP_SEC`, default 4.0
- `transient_backoff_sec attempt` — derived: `min cap (base * 2^(n-1))`
- `degraded_retry_slot_phase_budget_sec` (PR #13120) — `float` with 5.0s floor + 180.0s default; gates degraded retry rotation when the keeper has already burned this many seconds inside the outer turn slot

## Parent surface preservation

```ocaml
module KeeperRetryBackoff = Env_config_keeper_retry_backoff
```

Whole-module alias, same pattern as the pre-existing `Env_config_keeper_supervisor` sibling at line 139.

## Dune wiring

```
   env_config_keeper
+  env_config_keeper_retry_backoff
   env_config_keeper_supervisor
```

`lib/config/dune (modules ...)` list adds the new sibling alongside the existing `env_config_keeper_supervisor` entry. Sub-library `masc_config` has `include_subdirs:no` with explicit modules listing.

## Env knob catalog

`bin/env_knob_catalog.ml` scans `lib/config/env_config_*.ml` — the new sibling matches the glob so `MASC_KEEPER_MAX_TRANSIENT_RETRIES` and the 4 other env vars continue to appear in the generated catalog. This is the explicit reason the original docstring kept these in `lib/config/env_config_*.ml` rather than co-located with `keeper_turn_cascade_budget.ml`.

## Test plan

- [x] `dune build --root . lib/` clean
- [x] `dune` modules list updated (new sibling registered next to supervisor sibling)
- [x] `open Env_config_core` brings `get_int` / `get_float` into scope — same pattern as parent
- [x] External callers via `Env_config.KeeperRetryBackoff.*` resolve through parent module alias
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
