### PR TITLE
refactor(keeper_tool_disclosure): extract completion_contract sibling

### DIFF
--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -224,70 +224,20 @@ let has_valid_tool_call ~(unexpected_tool_names : string list) ~(tool_names : st
 ;;
 
 type completion_contract =
+  Keeper_tool_disclosure_completion_contract.completion_contract =
   | Allow_text_or_tool
   | Require_tool_use
 
-let merge_completion_contract
-      ~(previous : completion_contract)
-      ~(current : completion_contract)
-  : completion_contract
-  =
-  match previous, current with
-  | Require_tool_use, _ | _, Require_tool_use -> Require_tool_use
-  | Allow_text_or_tool, Allow_text_or_tool -> Allow_text_or_tool
-;;
-
-(** Issue #8696: exhaustive match against [Agent_sdk.Types.tool_choice].
-    Previous catch-all silently mapped any future SDK constructor to
-    [Allow_text_or_tool]; on an OAS pin bump that adds a constructor
-    (e.g. requiring tool use under new conditions) the keeper would
-    silently degrade. Listing every variant turns SDK drift into a
-    compile error here so it is reviewed at the boundary. *)
-let completion_contract_of_tool_choice (tool_choice : Agent_sdk.Types.tool_choice option)
-  : completion_contract
-  =
-  match tool_choice with
-  | Some (Agent_sdk.Types.Any | Agent_sdk.Types.Tool _) -> Require_tool_use
-  | Some (Agent_sdk.Types.Auto | Agent_sdk.Types.None_) -> Allow_text_or_tool
-  | None -> Allow_text_or_tool
-;;
-
-let run_completion_contract
-      ~(turn_contract : completion_contract)
-      ~(required_tool_use_seen : bool)
-  : completion_contract
-  =
-  if required_tool_use_seen then Require_tool_use else turn_contract
-;;
-
-let validate_completion_contract_presence
-      ~(contract : completion_contract)
-      ~(tool_present : bool)
-  : (unit, string) result
-  =
-  match contract with
-  | Allow_text_or_tool -> Ok ()
-  | Require_tool_use ->
-    if tool_present
-    then Ok ()
-    else
-      Error
-        "keeper turn violated required tool contract: no keeper-surface tools were called"
-;;
-
-let validate_completion_contract
-      ~(contract : completion_contract)
-      ~(tool_names : string list)
-      ()
-  : (unit, string) result
-  =
-  match contract with
-  | Allow_text_or_tool -> Ok ()
-  | Require_tool_use ->
-    (match tool_names with
-     | _ :: _ -> Ok ()
-     | [] -> Error "keeper turn violated required tool contract: no tools were called")
-;;
+let merge_completion_contract =
+  Keeper_tool_disclosure_completion_contract.merge_completion_contract
+let completion_contract_of_tool_choice =
+  Keeper_tool_disclosure_completion_contract.completion_contract_of_tool_choice
+let run_completion_contract =
+  Keeper_tool_disclosure_completion_contract.run_completion_contract
+let validate_completion_contract_presence =
+  Keeper_tool_disclosure_completion_contract.validate_completion_contract_presence
+let validate_completion_contract =
+  Keeper_tool_disclosure_completion_contract.validate_completion_contract
 
 (** Keeper tool progress classes are the shared contract between prompt
     disclosure, required-tool validation, runtime receipts, and liveness

--- a/lib/keeper/keeper_tool_disclosure_completion_contract.ml
+++ b/lib/keeper/keeper_tool_disclosure_completion_contract.ml
@@ -1,0 +1,89 @@
+(** Completion contract — required-tool-use gating for keeper turns.
+
+    Two-state typed contract:
+    [Allow_text_or_tool] (default) — the turn may end with either text
+    or a tool call.
+    [Require_tool_use] — the turn MUST emit at least one tool call;
+    a text-only completion violates the contract and the keeper turn
+    is failed.
+
+    The contract is derived from the [Agent_sdk.Types.tool_choice]
+    option via [completion_contract_of_tool_choice] (exhaustive
+    against the SDK variants per #8696, so future SDK constructors
+    force a compile error rather than silent degradation), then
+    progressively *tightened* across the turn by [merge_completion_
+    contract] (Require dominates) and [run_completion_contract]
+    (observed tool-use latches Require).
+
+    Validation: [validate_completion_contract_presence] checks the
+    boolean flag at observation time; [validate_completion_contract]
+    checks the list of emitted tool names at finalization time.
+
+    Verbatim extract from [Keeper_tool_disclosure]; the parent
+    retains transparent type alias + 5 value aliases. *)
+
+type completion_contract =
+  | Allow_text_or_tool
+  | Require_tool_use
+
+let merge_completion_contract
+      ~(previous : completion_contract)
+      ~(current : completion_contract)
+  : completion_contract
+  =
+  match previous, current with
+  | Require_tool_use, _ | _, Require_tool_use -> Require_tool_use
+  | Allow_text_or_tool, Allow_text_or_tool -> Allow_text_or_tool
+;;
+
+(** Issue #8696: exhaustive match against [Agent_sdk.Types.tool_choice].
+    Previous catch-all silently mapped any future SDK constructor to
+    [Allow_text_or_tool]; on an OAS pin bump that adds a constructor
+    (e.g. requiring tool use under new conditions) the keeper would
+    silently degrade. Listing every variant turns SDK drift into a
+    compile error here so it is reviewed at the boundary. *)
+let completion_contract_of_tool_choice (tool_choice : Agent_sdk.Types.tool_choice option)
+  : completion_contract
+  =
+  match tool_choice with
+  | Some (Agent_sdk.Types.Any | Agent_sdk.Types.Tool _) -> Require_tool_use
+  | Some (Agent_sdk.Types.Auto | Agent_sdk.Types.None_) -> Allow_text_or_tool
+  | None -> Allow_text_or_tool
+;;
+
+let run_completion_contract
+      ~(turn_contract : completion_contract)
+      ~(required_tool_use_seen : bool)
+  : completion_contract
+  =
+  if required_tool_use_seen then Require_tool_use else turn_contract
+;;
+
+let validate_completion_contract_presence
+      ~(contract : completion_contract)
+      ~(tool_present : bool)
+  : (unit, string) result
+  =
+  match contract with
+  | Allow_text_or_tool -> Ok ()
+  | Require_tool_use ->
+    if tool_present
+    then Ok ()
+    else
+      Error
+        "keeper turn violated required tool contract: no keeper-surface tools were called"
+;;
+
+let validate_completion_contract
+      ~(contract : completion_contract)
+      ~(tool_names : string list)
+      ()
+  : (unit, string) result
+  =
+  match contract with
+  | Allow_text_or_tool -> Ok ()
+  | Require_tool_use ->
+    (match tool_names with
+     | _ :: _ -> Ok ()
+     | [] -> Error "keeper turn violated required tool contract: no tools were called")
+;;

--- a/lib/keeper/keeper_tool_disclosure_completion_contract.mli
+++ b/lib/keeper/keeper_tool_disclosure_completion_contract.mli
@@ -1,0 +1,30 @@
+(** Completion contract — required-tool-use gating for keeper turns. *)
+
+type completion_contract =
+  | Allow_text_or_tool
+  | Require_tool_use
+
+val merge_completion_contract
+  :  previous:completion_contract
+  -> current:completion_contract
+  -> completion_contract
+
+val completion_contract_of_tool_choice
+  :  Agent_sdk.Types.tool_choice option
+  -> completion_contract
+
+val run_completion_contract
+  :  turn_contract:completion_contract
+  -> required_tool_use_seen:bool
+  -> completion_contract
+
+val validate_completion_contract_presence
+  :  contract:completion_contract
+  -> tool_present:bool
+  -> (unit, string) result
+
+val validate_completion_contract
+  :  contract:completion_contract
+  -> tool_names:string list
+  -> unit
+  -> (unit, string) result


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/keeper/keeper_tool_disclosure.ml` (1016 → 966 LOC, **-50**). First touch on this godfile — audited by the 2026-05-18 godfile-decomposition build plan.

**Crosses the 1000-LOC threshold.** The parent is no longer a godfile by the audit's definition.

New sibling `lib/keeper/keeper_tool_disclosure_completion_contract.ml` (89 LOC) hosts the two-state typed completion contract + 5 supporting operations:

- `type completion_contract = Allow_text_or_tool | Require_tool_use` — turn may end with text-or-tool / turn MUST emit at least one tool call
- `merge_completion_contract` — Require dominates in a binary join. Used to tighten the contract progressively across a turn.
- `completion_contract_of_tool_choice` — exhaustive against `Agent_sdk.Types.tool_choice option` per **#8696** (`Any`/`Tool` → `Require_tool_use`; `Auto`/`None_`/`None` → `Allow_text_or_tool`). Issue #8696 docstring notes that a catch-all here previously silently degraded on OAS pin bumps; the exhaustive variant listing turns SDK drift into a compile error at the boundary.
- `run_completion_contract` — observed-tool-use latches `Require`
- `validate_completion_contract_presence` — bool-flag validator, emits operator-facing error message on `Require_tool_use + !tool_present`
- `validate_completion_contract` — list-of-tool-names validator at finalization time

## Parent surface preservation

```ocaml
type completion_contract =
  Keeper_tool_disclosure_completion_contract.completion_contract =
  | Allow_text_or_tool | Require_tool_use
```

Transparent variant alias preserves the `.mli` concrete-variant declaration at line 79. 5 single-line value aliases for the helpers.

## External callers preserved

`.mli` lines 79, 85, 93, 100 plus the validators all resolve through the parent module.

## Anti-pattern note

This is exactly the typed-contract pattern §1 and §2 push toward. `completion_contract_of_tool_choice`'s exhaustive match against `Agent_sdk.Types.tool_choice` replaces a catch-all that #8696 already converted; carving it into its own sibling **concentrates the SDK-drift boundary in one short file**. Verbatim move preserves both the exhaustive match and the #8696 docstring rationale.

## Test plan

- [x] `dune build --root . lib/` clean
- [x] `.mli` surface unchanged (transparent variant alias preserves both constructors)
- [x] No sub-library dune edit needed (`lib/keeper/` in main `masc_mcp` library)
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
