### PR TITLE
refactor(keeper_status_bridge): extract override-field detail sibling

### DIFF
--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -36,57 +36,21 @@ let effective_declarative_cascade_name
 ;;
 
 type override_field_detail =
+  Keeper_status_bridge_override.override_field_detail =
   { field : string
   ; default_value : Yojson.Safe.t
   ; live_value : Yojson.Safe.t
   }
 
-let override_field field ~default_value ~live_value = { field; default_value; live_value }
-
-let maybe_string_override field ?(normalize = fun value -> value) default live acc =
-  let default = Option.map normalize default in
-  match default with
-  | Some value when value <> live ->
-    override_field field ~default_value:(`String value) ~live_value:(`String live) :: acc
-  | _ -> acc
-;;
-
-let maybe_bool_override field default live acc =
-  match default with
-  | Some value when value <> live ->
-    override_field field ~default_value:(`Bool value) ~live_value:(`Bool live) :: acc
-  | _ -> acc
-;;
-
-let maybe_string_list_override field default live acc =
-  match default with
-  | Some authored when authored <> live ->
-    override_field
-      field
-      ~default_value:(string_list_to_json authored)
-      ~live_value:(string_list_to_json live)
-    :: acc
-  | _ -> acc
-;;
-
-let nonempty_string_list_override field default live acc =
-  if default <> [] && default <> live
-  then
-    override_field
-      field
-      ~default_value:(string_list_to_json default)
-      ~live_value:(string_list_to_json live)
-    :: acc
-  else acc
-;;
-
-let maybe_string_option_override field default live acc =
-  match default, live with
-  | Some authored, Some active when authored <> active ->
-    override_field field ~default_value:(`String authored) ~live_value:(`String active)
-    :: acc
-  | _ -> acc
-;;
+let override_field = Keeper_status_bridge_override.override_field
+let maybe_string_override = Keeper_status_bridge_override.maybe_string_override
+let maybe_bool_override = Keeper_status_bridge_override.maybe_bool_override
+let maybe_string_list_override =
+  Keeper_status_bridge_override.maybe_string_list_override
+let nonempty_string_list_override =
+  Keeper_status_bridge_override.nonempty_string_list_override
+let maybe_string_option_override =
+  Keeper_status_bridge_override.maybe_string_option_override
 
 let live_override_details (meta : keeper_meta) (defaults : keeper_profile_defaults)
   : override_field_detail list

--- a/lib/keeper/keeper_status_bridge_override.ml
+++ b/lib/keeper/keeper_status_bridge_override.ml
@@ -1,0 +1,78 @@
+(** Default vs live override-field detail builder + 5 typed
+    matchers for keeper status surfaces.
+
+    Used by [live_override_details] (still in
+    [Keeper_status_bridge]) to compare a keeper's
+    [keeper_profile_defaults] against the live [keeper_meta] field
+    by field, producing a JSON-rendered list of overrides for the
+    operator dashboard.
+
+    Each matcher applies the same shape: take ~field name + default
+    + live, emit a [override_field_detail] iff the two differ.
+    Variants per type: [maybe_string_override] (optional string
+    with an optional normalizer), [maybe_bool_override] (optional
+    bool), [maybe_string_list_override] (optional list),
+    [nonempty_string_list_override] (non-empty list — empty default
+    means no preference, not a difference), [maybe_string_option_
+    override] (both default and live are options).
+
+    Pure builders — no parent state, no I/O. Verbatim extract from
+    [Keeper_status_bridge]; [string_list_to_json] is a 1-line local
+    duplicate because the parent's copy is in flight on a different
+    extract path and this 1-line helper isn't worth a third sibling. *)
+
+let string_list_to_json values = `List (List.map (fun value -> `String value) values)
+
+type override_field_detail =
+  { field : string
+  ; default_value : Yojson.Safe.t
+  ; live_value : Yojson.Safe.t
+  }
+
+let override_field field ~default_value ~live_value =
+  { field; default_value; live_value }
+
+let maybe_string_override field ?(normalize = fun value -> value) default live acc =
+  let default = Option.map normalize default in
+  match default with
+  | Some value when value <> live ->
+    override_field field ~default_value:(`String value) ~live_value:(`String live) :: acc
+  | _ -> acc
+;;
+
+let maybe_bool_override field default live acc =
+  match default with
+  | Some value when value <> live ->
+    override_field field ~default_value:(`Bool value) ~live_value:(`Bool live) :: acc
+  | _ -> acc
+;;
+
+let maybe_string_list_override field default live acc =
+  match default with
+  | Some authored when authored <> live ->
+    override_field
+      field
+      ~default_value:(string_list_to_json authored)
+      ~live_value:(string_list_to_json live)
+    :: acc
+  | _ -> acc
+;;
+
+let nonempty_string_list_override field default live acc =
+  if default <> [] && default <> live
+  then
+    override_field
+      field
+      ~default_value:(string_list_to_json default)
+      ~live_value:(string_list_to_json live)
+    :: acc
+  else acc
+;;
+
+let maybe_string_option_override field default live acc =
+  match default, live with
+  | Some authored, Some active when authored <> active ->
+    override_field field ~default_value:(`String authored) ~live_value:(`String active)
+    :: acc
+  | _ -> acc
+;;

--- a/lib/keeper/keeper_status_bridge_override.mli
+++ b/lib/keeper/keeper_status_bridge_override.mli
@@ -1,0 +1,50 @@
+(** Default vs live override-field detail builder + typed matchers
+    for keeper status surfaces. *)
+
+type override_field_detail =
+  { field : string
+  ; default_value : Yojson.Safe.t
+  ; live_value : Yojson.Safe.t
+  }
+
+val override_field
+  : string
+  -> default_value:Yojson.Safe.t
+  -> live_value:Yojson.Safe.t
+  -> override_field_detail
+
+val maybe_string_override
+  : string
+  -> ?normalize:(string -> string)
+  -> string option
+  -> string
+  -> override_field_detail list
+  -> override_field_detail list
+
+val maybe_bool_override
+  : string
+  -> bool option
+  -> bool
+  -> override_field_detail list
+  -> override_field_detail list
+
+val maybe_string_list_override
+  : string
+  -> string list option
+  -> string list
+  -> override_field_detail list
+  -> override_field_detail list
+
+val nonempty_string_list_override
+  : string
+  -> string list
+  -> string list
+  -> override_field_detail list
+  -> override_field_detail list
+
+val maybe_string_option_override
+  : string
+  -> string option
+  -> string option
+  -> override_field_detail list
+  -> override_field_detail list


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/keeper/keeper_status_bridge.ml` (1016 → 980 LOC, **-36**). First touch on this godfile — audited by the 2026-05-18 godfile-decomposition build plan.

**Crosses the 1000-LOC threshold.** The parent is no longer a godfile by the audit's definition.

New sibling `lib/keeper/keeper_status_bridge_override.ml` (78 LOC) hosts the default-vs-live override-field detail builder + 5 typed matchers used by `live_override_details` (still in parent) to produce the operator-dashboard's "field has been overridden from default" list:

- `type override_field_detail = { field; default_value : Yojson.Safe.t; live_value : Yojson.Safe.t }`
- `override_field` constructor
- `maybe_string_override field ?normalize default live acc` — optional string with an optional normalizer
- `maybe_bool_override field default live acc` — optional bool
- `maybe_string_list_override field default live acc` — optional list (`None` default = no override)
- `nonempty_string_list_override field default live acc` — list with non-empty default (`[]` default = no preference, not a difference)
- `maybe_string_option_override field default live acc` — both default and live are `option` (only `Some/Some` differing pair counts)

## Parent surface preservation

```ocaml
type override_field_detail =
  Keeper_status_bridge_override.override_field_detail =
  { field : string
  ; default_value : Yojson.Safe.t
  ; live_value : Yojson.Safe.t
  }
```

Transparent record alias preserves field-name reachability for `live_override_details` which constructs the record. 6 single-line value aliases for the constructor + 5 matchers.

## Scope rationale

Pure builders — no parent state, no I/O. The 1-line helper `string_list_to_json` is duplicated in the sibling rather than imported (it's used by `maybe_string_list_override` and `nonempty_string_list_override`). Duplication is intentional for the 1-line case.

`live_override_details` (the composer at parent line 91+) stays in the parent because it threads through parent-specific helpers (`effective_declarative_cascade_name`, `normalize_goal_horizon_text`, `cascade_name_of_meta`) and reads `keeper_meta` / `keeper_profile_defaults` fields.

## External callers

**None** under qualified name `Keeper_status_bridge.*` for the moved helpers (verified via grep across `lib/` + `test/`; not in `.mli` — only `live_override_fields` is, which stays in the parent). All callers internal to `live_override_details`.

## Test plan

- [x] `dune build --root . lib/` clean
- [x] `.mli` surface unchanged (`live_override_fields` still resolves through parent)
- [x] Transparent record alias preserves field-name reachability for parent's composer
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
