### PR TITLE
refactor(keeper_shell_docker): extract container-naming helpers sibling

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -101,40 +101,12 @@ let check_egress ~(config : Coord.config) ~(meta : keeper_meta) ~cmd =
 
 (* ── Container naming ──────────────────────────────────── *)
 
-let keeper_sandbox_container_name (meta : keeper_meta) =
-  Printf.sprintf
-    "masc-keeper-%s-%d-%d"
-    (Coord_utils.safe_filename meta.name)
-    (Unix.getpid ())
-    (int_of_float (Unix.gettimeofday () *. 1000.0))
-;;
-
-let keeper_private_container_root (meta : keeper_meta) =
-  Keeper_sandbox.container_root meta.name
-;;
-
-let docker_private_workspace_cwd ~(config : Coord.config) ~(meta : keeper_meta) host_cwd =
-  let normalize_path_for_containment path =
-    Keeper_alerting_path.normalize_path_for_check_stripped path
-  in
-  let host_root =
-    Keeper_sandbox.host_root_abs_of_meta ~config meta |> normalize_path_for_containment
-  in
-  let container_root = keeper_private_container_root meta in
-  let host_cwd = normalize_path_for_containment host_cwd in
-  if host_cwd = host_root
-  then container_root
-  else if String.starts_with ~prefix:(host_root ^ "/") host_cwd
-  then (
-    let suffix =
-      String.sub
-        host_cwd
-        (String.length host_root + 1)
-        (String.length host_cwd - String.length host_root - 1)
-    in
-    Filename.concat container_root suffix)
-  else container_root
-;;
+let keeper_sandbox_container_name =
+  Keeper_shell_docker_container_name.keeper_sandbox_container_name
+let keeper_private_container_root =
+  Keeper_shell_docker_container_name.keeper_private_container_root
+let docker_private_workspace_cwd =
+  Keeper_shell_docker_container_name.docker_private_workspace_cwd
 
 let rewrite_docker_command_paths ~(config : Coord.config) ~(meta : keeper_meta) cmd =
   let raw_host_root =

--- a/lib/keeper/keeper_shell_docker_container_name.ml
+++ b/lib/keeper/keeper_shell_docker_container_name.ml
@@ -1,0 +1,59 @@
+(** Docker container naming + host-cwd → container-cwd translation
+    for the keeper sandbox.
+
+    [keeper_sandbox_container_name] — names the per-turn sandbox
+    container using [masc-keeper-<safe_filename>-<pid>-<ms>] so two
+    concurrent keeper turns can never collide on a single container
+    name even within the same process.
+
+    [keeper_private_container_root] — thin alias to
+    [Keeper_sandbox.container_root] returning the fixed
+    per-keeper container-side mount point.
+
+    [docker_private_workspace_cwd] — given a host_cwd absolute
+    path, returns the corresponding container-side path. If
+    host_cwd is *inside* the sandbox host root, the suffix is
+    appended to container_root; otherwise the call falls back to
+    container_root so the keeper still lands inside its sandbox.
+
+    Verbatim extract from [Keeper_shell_docker]; all 3 functions
+    are exposed by the parent .mli at lines 37, 40, 45. *)
+
+let keeper_sandbox_container_name (meta : Keeper_types.keeper_meta) =
+  Printf.sprintf
+    "masc-keeper-%s-%d-%d"
+    (Coord_utils.safe_filename meta.name)
+    (Unix.getpid ())
+    (int_of_float (Unix.gettimeofday () *. 1000.0))
+;;
+
+let keeper_private_container_root (meta : Keeper_types.keeper_meta) =
+  Keeper_sandbox.container_root meta.name
+;;
+
+let docker_private_workspace_cwd
+      ~(config : Coord.config)
+      ~(meta : Keeper_types.keeper_meta)
+      host_cwd
+  =
+  let normalize_path_for_containment path =
+    Keeper_alerting_path.normalize_path_for_check_stripped path
+  in
+  let host_root =
+    Keeper_sandbox.host_root_abs_of_meta ~config meta |> normalize_path_for_containment
+  in
+  let container_root = keeper_private_container_root meta in
+  let host_cwd = normalize_path_for_containment host_cwd in
+  if host_cwd = host_root
+  then container_root
+  else if String.starts_with ~prefix:(host_root ^ "/") host_cwd
+  then (
+    let suffix =
+      String.sub
+        host_cwd
+        (String.length host_root + 1)
+        (String.length host_cwd - String.length host_root - 1)
+    in
+    Filename.concat container_root suffix)
+  else container_root
+;;

--- a/lib/keeper/keeper_shell_docker_container_name.mli
+++ b/lib/keeper/keeper_shell_docker_container_name.mli
@@ -1,0 +1,12 @@
+(** Docker container naming + host-cwd → container-cwd translation
+    for the keeper sandbox. *)
+
+val keeper_sandbox_container_name : Keeper_types.keeper_meta -> string
+
+val keeper_private_container_root : Keeper_types.keeper_meta -> string
+
+val docker_private_workspace_cwd
+  :  config:Coord.config
+  -> meta:Keeper_types.keeper_meta
+  -> string
+  -> string


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/keeper/keeper_shell_docker.ml` (1044 → 1016 LOC, **-28**). First touch on this godfile — audited by the 2026-05-18 godfile-decomposition build plan.

The parent stays just above the 1000-LOC threshold this cycle; this PR opens the lane and a follow-up can pull the `rewrite_docker_command_paths` cluster (~60 LOC) to demote it.

New sibling `lib/keeper/keeper_shell_docker_container_name.ml` (59 LOC) hosts:

- `keeper_sandbox_container_name` — Printf format `masc-keeper-<safe_filename>-<pid>-<ms>` so two concurrent keeper turns can never collide on a single container name even within the same process. Includes `Unix.getpid` + `Unix.gettimeofday` in the name for namespace uniqueness.
- `keeper_private_container_root` — thin alias to `Keeper_sandbox.container_root` returning the fixed per-keeper container-side mount point
- `docker_private_workspace_cwd` — given a `host_cwd` absolute path, returns the corresponding container-side path:
  - `host_cwd == host_root` → `container_root`
  - `host_cwd` is inside `host_root` (prefix match on `host_root + "/"`) → suffix appended to `container_root`
  - Otherwise → falls back to `container_root` so the keeper still lands inside its sandbox

## Parent surface preservation

- 3 single-line value aliases preserve the qualified in-module names. The `.mli` at lines 37, 40, 45 remains unchanged.
- `rewrite_docker_command_paths` (still in parent) continues to call `keeper_private_container_root` via the parent alias.

## Scope rationale

Pure functions (modulo `Unix.getpid` + `Unix.gettimeofday` in the container-name builder). No parent-local state, no I/O beyond the time/pid reads.

## Test plan

- [x] `dune build --root . lib/` clean
- [x] `.mli` surface unchanged (3 single-line value aliases preserve callers)
- [x] No sub-library dune edit needed (`lib/keeper/` in main `masc_mcp` library)
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
