### PR TITLE
refactor(keeper_world_observation): extract turn-verdict variants sibling

### DIFF
--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -47,12 +47,13 @@ type world_observation =
   }
 
 type keeper_cycle_channel =
+  Keeper_world_observation_turn_types.keeper_cycle_channel =
   | Reactive
   | Scheduled_autonomous
 
 type unified_turn_channel = keeper_cycle_channel
 
-type turn_reason =
+type turn_reason = Keeper_world_observation_turn_types.turn_reason =
   | Mention_pending
   | Board_event_pending
   | Scope_message_pending
@@ -71,7 +72,7 @@ type turn_reason =
   | Min_interval_elapsed
   | Entropic_oscillation
 
-type skip_reason =
+type skip_reason = Keeper_world_observation_turn_types.skip_reason =
   | Keeper_paused
   | Approval_pending
   | Scheduled_autonomous_disabled
@@ -80,47 +81,19 @@ type skip_reason =
   | Cooldown_pending of { remaining_sec : int }
   | No_signal
 
-type turn_verdict =
+type turn_verdict = Keeper_world_observation_turn_types.turn_verdict =
   | Run of { reasons : turn_reason * turn_reason list }
   | Skip of { reasons : skip_reason * skip_reason list }
 
-let turn_reason_to_string = function
-  | Mention_pending -> "mention_pending"
-  | Board_event_pending -> "board_event_pending"
-  | Scope_message_pending -> "scope_message_pending"
-  | Scheduled_autonomous_turn -> "scheduled_autonomous_turn"
-  | Idle_cooldown_elapsed _ -> "idle_cooldown_elapsed"
-  | Cooldown_elapsed -> "cooldown_elapsed"
-  | Task_backlog _ -> "task_backlog"
-  | Task_reactive_cooldown_elapsed -> "task_reactive_cooldown_elapsed"
-  | Never_started -> "never_started"
-  | Min_interval_elapsed -> "min_interval_elapsed"
-  | Entropic_oscillation -> "entropic_oscillation"
-;;
-
-let skip_reason_to_string = function
-  | Keeper_paused -> "keeper_paused"
-  | Approval_pending -> "approval_pending"
-  | Scheduled_autonomous_disabled -> "scheduled_autonomous_disabled"
-  | Provider_cooldown_pending _ -> "provider_cooldown_pending"
-  | Idle_gate_pending _ -> "idle_gate_pending"
-  | Cooldown_pending _ -> "cooldown_pending"
-  | No_signal -> "no_signal"
-;;
-
-let channel_to_string = function
-  | Reactive -> "reactive"
-  | Scheduled_autonomous -> "scheduled_autonomous"
-;;
-
-let is_autonomous_channel (channel : string) : bool =
-  String.equal channel "scheduled_autonomous" || String.equal channel "proactive"
-;;
-
-let verdict_reasons_to_strings = function
-  | Run { reasons = first, rest } -> List.map turn_reason_to_string (first :: rest)
-  | Skip { reasons = first, rest } -> List.map skip_reason_to_string (first :: rest)
-;;
+let turn_reason_to_string =
+  Keeper_world_observation_turn_types.turn_reason_to_string
+let skip_reason_to_string =
+  Keeper_world_observation_turn_types.skip_reason_to_string
+let channel_to_string = Keeper_world_observation_turn_types.channel_to_string
+let is_autonomous_channel =
+  Keeper_world_observation_turn_types.is_autonomous_channel
+let verdict_reasons_to_strings =
+  Keeper_world_observation_turn_types.verdict_reasons_to_strings
 
 type keeper_cycle_decision =
   { should_run : bool

--- a/lib/keeper/keeper_world_observation_turn_types.ml
+++ b/lib/keeper/keeper_world_observation_turn_types.ml
@@ -1,0 +1,100 @@
+(** Keeper cycle channel + turn-verdict variants + their bijection
+    helpers.
+
+    [keeper_cycle_channel] tags whether a keeper cycle is reactive
+    (driven by mentions/board/messages/tasks) or scheduled-autonomous
+    (proactive turns on a timer). [unified_turn_channel] is an alias
+    retained for legacy callers.
+
+    [turn_reason] carries the 11 reasons a keeper *runs* a turn
+    (mention, board event, scope message, scheduled autonomous, idle
+    cooldown elapsed with timers, etc.). Inline-record variants carry
+    the timing fields the dashboard surfaces.
+
+    [skip_reason] carries the 7 reasons a keeper *skips* a turn
+    (paused, approval pending, autonomous disabled, cooldown
+    pending with remaining_sec, etc.).
+
+    [turn_verdict] is [Run of { reasons }] or [Skip of { reasons }]
+    with non-empty list-of-reasons payload.
+
+    Pure variants + total to_string helpers. Verbatim extract from
+    [Keeper_world_observation]; the parent retains transparent
+    variant aliases so .mli concrete declarations + inline-record
+    payloads stay valid. *)
+
+type keeper_cycle_channel =
+  | Reactive
+  | Scheduled_autonomous
+
+type unified_turn_channel = keeper_cycle_channel
+
+type turn_reason =
+  | Mention_pending
+  | Board_event_pending
+  | Scope_message_pending
+  | Scheduled_autonomous_turn
+  | Idle_cooldown_elapsed of
+      { idle_sec : int
+      ; cooldown : int
+      }
+  | Cooldown_elapsed
+  | Task_backlog of
+      { unclaimed : int
+      ; failed : int
+      }
+  | Task_reactive_cooldown_elapsed
+  | Never_started
+  | Min_interval_elapsed
+  | Entropic_oscillation
+
+type skip_reason =
+  | Keeper_paused
+  | Approval_pending
+  | Scheduled_autonomous_disabled
+  | Provider_cooldown_pending of { remaining_sec : int }
+  | Idle_gate_pending of { remaining_sec : int }
+  | Cooldown_pending of { remaining_sec : int }
+  | No_signal
+
+type turn_verdict =
+  | Run of { reasons : turn_reason * turn_reason list }
+  | Skip of { reasons : skip_reason * skip_reason list }
+
+let turn_reason_to_string = function
+  | Mention_pending -> "mention_pending"
+  | Board_event_pending -> "board_event_pending"
+  | Scope_message_pending -> "scope_message_pending"
+  | Scheduled_autonomous_turn -> "scheduled_autonomous_turn"
+  | Idle_cooldown_elapsed _ -> "idle_cooldown_elapsed"
+  | Cooldown_elapsed -> "cooldown_elapsed"
+  | Task_backlog _ -> "task_backlog"
+  | Task_reactive_cooldown_elapsed -> "task_reactive_cooldown_elapsed"
+  | Never_started -> "never_started"
+  | Min_interval_elapsed -> "min_interval_elapsed"
+  | Entropic_oscillation -> "entropic_oscillation"
+;;
+
+let skip_reason_to_string = function
+  | Keeper_paused -> "keeper_paused"
+  | Approval_pending -> "approval_pending"
+  | Scheduled_autonomous_disabled -> "scheduled_autonomous_disabled"
+  | Provider_cooldown_pending _ -> "provider_cooldown_pending"
+  | Idle_gate_pending _ -> "idle_gate_pending"
+  | Cooldown_pending _ -> "cooldown_pending"
+  | No_signal -> "no_signal"
+;;
+
+let channel_to_string = function
+  | Reactive -> "reactive"
+  | Scheduled_autonomous -> "scheduled_autonomous"
+;;
+
+let is_autonomous_channel (channel : string) : bool =
+  String.equal channel "scheduled_autonomous" || String.equal channel "proactive"
+;;
+
+let verdict_reasons_to_strings = function
+  | Run { reasons = first, rest } -> List.map turn_reason_to_string (first :: rest)
+  | Skip { reasons = first, rest } -> List.map skip_reason_to_string (first :: rest)
+;;

--- a/lib/keeper/keeper_world_observation_turn_types.mli
+++ b/lib/keeper/keeper_world_observation_turn_types.mli
@@ -1,0 +1,45 @@
+(** Keeper cycle channel + turn-verdict variants + bijection helpers. *)
+
+type keeper_cycle_channel =
+  | Reactive
+  | Scheduled_autonomous
+
+type unified_turn_channel = keeper_cycle_channel
+
+type turn_reason =
+  | Mention_pending
+  | Board_event_pending
+  | Scope_message_pending
+  | Scheduled_autonomous_turn
+  | Idle_cooldown_elapsed of
+      { idle_sec : int
+      ; cooldown : int
+      }
+  | Cooldown_elapsed
+  | Task_backlog of
+      { unclaimed : int
+      ; failed : int
+      }
+  | Task_reactive_cooldown_elapsed
+  | Never_started
+  | Min_interval_elapsed
+  | Entropic_oscillation
+
+type skip_reason =
+  | Keeper_paused
+  | Approval_pending
+  | Scheduled_autonomous_disabled
+  | Provider_cooldown_pending of { remaining_sec : int }
+  | Idle_gate_pending of { remaining_sec : int }
+  | Cooldown_pending of { remaining_sec : int }
+  | No_signal
+
+type turn_verdict =
+  | Run of { reasons : turn_reason * turn_reason list }
+  | Skip of { reasons : skip_reason * skip_reason list }
+
+val turn_reason_to_string : turn_reason -> string
+val skip_reason_to_string : skip_reason -> string
+val channel_to_string : keeper_cycle_channel -> string
+val is_autonomous_channel : string -> bool
+val verdict_reasons_to_strings : turn_verdict -> string list


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/keeper/keeper_world_observation.ml` (1047 → 1020 LOC, **-27**). First touch on this godfile — audited by the 2026-05-18 godfile-decomposition build plan.

The parent stays just above the 1000-LOC threshold this cycle; this PR opens the lane.

New sibling `lib/keeper/keeper_world_observation_turn_types.ml` (100 LOC) hosts the keeper-cycle decision variants + bijection helpers:

- `type keeper_cycle_channel = Reactive | Scheduled_autonomous`
- `type unified_turn_channel = keeper_cycle_channel` (legacy alias)
- `type turn_reason` — **11 reasons a keeper runs a turn** (`Mention_pending`, `Board_event_pending`, `Scope_message_pending`, `Scheduled_autonomous_turn`, `Idle_cooldown_elapsed { idle_sec; cooldown }`, `Cooldown_elapsed`, `Task_backlog { unclaimed; failed }`, `Task_reactive_cooldown_elapsed`, `Never_started`, `Min_interval_elapsed`, `Entropic_oscillation`)
- `type skip_reason` — **7 reasons a keeper skips a turn** (`Keeper_paused`, `Approval_pending`, `Scheduled_autonomous_disabled`, `Provider_cooldown_pending { remaining_sec }`, `Idle_gate_pending { remaining_sec }`, `Cooldown_pending { remaining_sec }`, `No_signal`)
- `type turn_verdict = Run of { reasons } | Skip of { reasons }` — non-empty list payload (head + tail)
- `val turn_reason_to_string` — total
- `val skip_reason_to_string` — total
- `val channel_to_string` — total
- `val is_autonomous_channel` — string predicate (accepts canonical `scheduled_autonomous` or legacy `proactive`)
- `val verdict_reasons_to_strings` — lifts a verdict's non-empty list to a string list using the appropriate per-arm helper

## Parent surface preservation

Three transparent variant aliases with full constructor re-declarations (including the inline-record payloads on `Idle_cooldown_elapsed`, `Task_backlog`, `Provider_cooldown_pending`, `Idle_gate_pending`, `Cooldown_pending`) so `.mli` concrete-variant declarations at lines 97, 105, 119, 132 stay valid and downstream consumers (`keeper_cycle_decision` record + many call sites) continue to type-check. 5 single-line value aliases for the to_string helpers.

## Anti-pattern note

`is_autonomous_channel` accepts both `"scheduled_autonomous"` (canonical) and `"proactive"` (legacy) — intentional bi-format input for the operator-facing surface where the rename happened mid-deployment. **Verbatim move; no new arm added.** The catch-all is implicit (any other string → false) and is the typed-failure shape (predicate returns `bool`, not a string fallback).

## Test plan

- [x] `dune build --root . lib/` clean
- [x] `.mli` surface unchanged (transparent variant aliases preserve all 25+ constructors)
- [x] Inline-record payloads re-declared in parent for record-update reachability
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
