### PR TITLE
refactor(server_dashboard_http_runtime_info): extract JSON+helpers sibling

### DIFF
--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -3,24 +3,9 @@
 
 open Dashboard_http_helpers
 
-let contains_substring ~needle haystack = String_util.contains_substring haystack needle
-
-let take n xs =
-  let rec loop acc remaining xs =
-    if remaining <= 0
-    then List.rev acc
-    else (
-      match xs with
-      | [] -> List.rev acc
-      | x :: tl -> loop (x :: acc) (remaining - 1) tl)
-  in
-  loop [] n xs
-;;
-
-let trim_to_option raw =
-  let trimmed = String.trim raw in
-  if trimmed = "" then None else Some trimmed
-;;
+let contains_substring = Server_dashboard_http_runtime_info_json.contains_substring
+let take = Server_dashboard_http_runtime_info_json.take
+let trim_to_option = Server_dashboard_http_runtime_info_json.trim_to_option
 
 type dashboard_runtime_probe_cache_entry =
   { probe : Yojson.Safe.t
@@ -206,28 +191,13 @@ let git_rev_parse_short path =
           else git_rev_parse_short_cached_any dir |> Option.value ~default:None))
 ;;
 
-let opt_string_json = function
-  | None -> `Null
-  | Some value -> `String value
-;;
-
-let opt_bool_json = function
-  | None -> `Null
-  | Some value -> `Bool value
-;;
-
-let opt_commit_equal left right =
-  match left, right with
-  | Some left, Some right -> Some (String.equal left right)
-  | _ -> None
-;;
-
-let opt_int_json = function
-  | None -> `Null
-  | Some value -> `Int value
-;;
+let opt_string_json = Server_dashboard_http_runtime_info_json.opt_string_json
+let opt_bool_json = Server_dashboard_http_runtime_info_json.opt_bool_json
+let opt_commit_equal = Server_dashboard_http_runtime_info_json.opt_commit_equal
+let opt_int_json = Server_dashboard_http_runtime_info_json.opt_int_json
 
 type git_upstream_status =
+  Server_dashboard_http_runtime_info_json.git_upstream_status =
   { branch : string option
   ; upstream_ref : string option
   ; upstream_head_commit : string option
@@ -236,13 +206,7 @@ type git_upstream_status =
   }
 
 let empty_git_upstream_status =
-  { branch = None
-  ; upstream_ref = None
-  ; upstream_head_commit = None
-  ; ahead_count = None
-  ; behind_count = None
-  }
-;;
+  Server_dashboard_http_runtime_info_json.empty_git_upstream_status
 
 let git_upstream_status_probe_hook_for_tests :
   (string -> git_upstream_status option) option Atomic.t

--- a/lib/server/server_dashboard_http_runtime_info_json.ml
+++ b/lib/server/server_dashboard_http_runtime_info_json.ml
@@ -1,0 +1,74 @@
+(** Option → JSON small builders + git_upstream_status record + 3
+    small utility helpers for the dashboard runtime-info surface.
+
+    Four 3-line option-to-Yojson coercers + the
+    [git_upstream_status] record that captures git branch / upstream
+    / ahead-behind state for a worktree, plus its empty default,
+    plus 3 utility helpers shared by the rest of [Server_dashboard_
+    http_runtime_info]:
+    - [contains_substring ~needle haystack] — String_util wrapper
+      with swapped argument order.
+    - [take n xs] — first n elements of a list (tolerant of short
+      input).
+    - [trim_to_option raw] — empty-after-trim string -> None.
+
+    Pure builders + value records. Verbatim extract from
+    [Server_dashboard_http_runtime_info]; the parent retains
+    transparent record alias + 8 value aliases. *)
+
+let contains_substring ~needle haystack = String_util.contains_substring haystack needle
+
+let take n xs =
+  let rec loop acc remaining xs =
+    if remaining <= 0
+    then List.rev acc
+    else (
+      match xs with
+      | [] -> List.rev acc
+      | x :: tl -> loop (x :: acc) (remaining - 1) tl)
+  in
+  loop [] n xs
+;;
+
+let trim_to_option raw =
+  let trimmed = String.trim raw in
+  if trimmed = "" then None else Some trimmed
+;;
+
+let opt_string_json = function
+  | None -> `Null
+  | Some value -> `String value
+;;
+
+let opt_bool_json = function
+  | None -> `Null
+  | Some value -> `Bool value
+;;
+
+let opt_commit_equal left right =
+  match left, right with
+  | Some left, Some right -> Some (String.equal left right)
+  | _ -> None
+;;
+
+let opt_int_json = function
+  | None -> `Null
+  | Some value -> `Int value
+;;
+
+type git_upstream_status =
+  { branch : string option
+  ; upstream_ref : string option
+  ; upstream_head_commit : string option
+  ; ahead_count : int option
+  ; behind_count : int option
+  }
+
+let empty_git_upstream_status =
+  { branch = None
+  ; upstream_ref = None
+  ; upstream_head_commit = None
+  ; ahead_count = None
+  ; behind_count = None
+  }
+;;

--- a/lib/server/server_dashboard_http_runtime_info_json.mli
+++ b/lib/server/server_dashboard_http_runtime_info_json.mli
@@ -1,0 +1,21 @@
+(** Option → JSON small builders + git_upstream_status record +
+    3 small utility helpers for the dashboard runtime-info surface. *)
+
+val contains_substring : needle:string -> string -> bool
+val take : int -> 'a list -> 'a list
+val trim_to_option : string -> string option
+
+val opt_string_json : string option -> Yojson.Safe.t
+val opt_bool_json : bool option -> Yojson.Safe.t
+val opt_int_json : int option -> Yojson.Safe.t
+val opt_commit_equal : string option -> string option -> bool option
+
+type git_upstream_status =
+  { branch : string option
+  ; upstream_ref : string option
+  ; upstream_head_commit : string option
+  ; ahead_count : int option
+  ; behind_count : int option
+  }
+
+val empty_git_upstream_status : git_upstream_status


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/server/server_dashboard_http_runtime_info.ml` (1024 → 988 LOC, **-36**). First touch on this godfile — audited by the 2026-05-18 godfile-decomposition build plan.

**Crosses the 1000-LOC threshold.** The parent is no longer a godfile by the audit's definition.

New sibling `lib/server/server_dashboard_http_runtime_info_json.ml` (74 LOC) hosts a mixed bundle of small pure helpers + the `git_upstream_status` record:

- `contains_substring ~needle haystack` — `String_util` wrapper with swapped argument order
- `take n xs` — first n elements of a list (tolerant of short input via local recursion)
- `trim_to_option raw` — empty-after-trim string → `None`
- `opt_string_json` / `opt_bool_json` / `opt_int_json` — option → Yojson coercers returning `` `Null `` on `None`
- `opt_commit_equal` — pair-wise commit-string equality with option short-circuit: `Some/Some → Some bool`; otherwise `None`
- `type git_upstream_status` — `{ branch; upstream_ref; upstream_head_commit; ahead_count; behind_count }` (all option-typed) for "git branch + upstream + ahead/behind" status
- `empty_git_upstream_status` — all-`None` default

## Parent surface preservation

```ocaml
type git_upstream_status = ...sibling.git_upstream_status =
  { branch; upstream_ref; upstream_head_commit; ahead_count; behind_count }
```

Transparent record alias preserves the `.mli` concrete-field declaration at line 147. 8 single-line value aliases for the helpers + empty constant.

## Scope rationale

Pure builders — no parent state, no I/O. The `git_upstream_status` *producer* (`git_probe_trimmed` + `parse_ahead_behind` + the fetching functions) stays in the parent because it depends on parent-local timeout constants and probe hooks.

## Test plan

- [x] `dune build --root . lib/` clean
- [x] `.mli` surface unchanged (transparent record alias preserves field-name reachability)
- [x] External callers via `.mli` lines 147+ resolve through parent aliases
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
