### PR TITLE
refactor(server_dashboard_http): extract JSON/string utility helpers sibling

### DIFF
--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -487,25 +487,12 @@ let dashboard_goals_snapshot_json ~(config : Coord.config) : Yojson.Safe.t =
     ]
 ;;
 
-let compact_preview ~max_chars text =
-  let text = String.trim text in
-  if String.length text <= max_chars
-  then text, false
-  else String.sub text 0 max_chars ^ "...", true
-;;
-
-let json_member key = function
-  | `Assoc fields ->
-    (match List.assoc_opt key fields with
-     | Some v -> v
-     | None -> `Null)
-  | _ -> `Null
-;;
-
-let json_string key json = Json_util.get_string json key
-let json_int key json = Json_util.get_int json key
-let json_float key json = Json_util.get_float json key
-let json_bool key json = Json_util.get_bool json key
+let compact_preview = Server_dashboard_http_json_utils.compact_preview
+let json_member = Server_dashboard_http_json_utils.json_member
+let json_string = Server_dashboard_http_json_utils.json_string
+let json_int = Server_dashboard_http_json_utils.json_int
+let json_float = Server_dashboard_http_json_utils.json_float
+let json_bool = Server_dashboard_http_json_utils.json_bool
 
 (* Compact-receipt JSON builders extracted to
    [Server_dashboard_compact_receipt_json] (godfile decomp). *)
@@ -516,29 +503,9 @@ let compact_receipt_tool_surface_json =
   Server_dashboard_compact_receipt_json.compact_receipt_tool_surface_json
 ;;
 
-(* RFC-0142 PR-5: lift the silent [| _ -> None] catch-all through
-   [Json_field.{float,assoc} |> to_option] so Wrong_shape becomes
-   structurally distinct from Field_absent. Caller semantics
-   unchanged: both legacy and new shapes return [None] on missing
-   key or mismatched JSON variant. [Json_field.float] accepts both
-   [`Float] and [`Int] (returning [float_of_int i]), matching the
-   legacy 2-arm match. *)
-
-let json_number key json =
-  Json_field.float json key |> Json_field.to_option
-;;
-
-let json_assoc key json =
-  Json_field.assoc json key
-  |> Json_field.to_option
-  |> Option.map (fun fields -> `Assoc fields)
-;;
-
-let string_has_prefix ~prefix value =
-  let prefix_len = String.length prefix in
-  String.length value >= prefix_len
-  && String.equal (String.sub value 0 prefix_len) prefix
-;;
+let json_number = Server_dashboard_http_json_utils.json_number
+let json_assoc = Server_dashboard_http_json_utils.json_assoc
+let string_has_prefix = Server_dashboard_http_json_utils.string_has_prefix
 
 let tool_call_output_text json =
   match json_member "output" json with

--- a/lib/server/server_dashboard_http_json_utils.ml
+++ b/lib/server/server_dashboard_http_json_utils.ml
@@ -1,0 +1,59 @@
+(** Small JSON / string utility helpers for the dashboard HTTP
+    surface.
+
+    Nine pure helpers used throughout [Server_dashboard_http]:
+
+    [compact_preview ~max_chars text] — trims, then truncates with
+    a [...] suffix iff over the budget. Returns (preview, truncated).
+
+    JSON readers:
+    - [json_member key json] — `Assoc field-by-key with [`Null] on
+      miss / non-Assoc.
+    - [json_string / json_int / json_float / json_bool] — Json_util
+      typed-getter aliases (key, json) order swap.
+    - [json_number] — RFC-0142 PR-5 typed-failure variant via
+      Json_field.float |> to_option (accepts both `Float and `Int).
+    - [json_assoc] — Json_field.assoc adapter wrapping back to
+      [`Assoc fields] option.
+
+    [string_has_prefix ~prefix value] — explicit-length prefix
+    equality without throwing on short input.
+
+    Verbatim extract from [Server_dashboard_http]; the parent
+    retains 9 single-line value aliases. *)
+
+let compact_preview ~max_chars text =
+  let text = String.trim text in
+  if String.length text <= max_chars
+  then text, false
+  else String.sub text 0 max_chars ^ "...", true
+;;
+
+let json_member key = function
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some v -> v
+     | None -> `Null)
+  | _ -> `Null
+;;
+
+let json_string key json = Json_util.get_string json key
+let json_int key json = Json_util.get_int json key
+let json_float key json = Json_util.get_float json key
+let json_bool key json = Json_util.get_bool json key
+
+let json_number key json =
+  Json_field.float json key |> Json_field.to_option
+;;
+
+let json_assoc key json =
+  Json_field.assoc json key
+  |> Json_field.to_option
+  |> Option.map (fun fields -> `Assoc fields)
+;;
+
+let string_has_prefix ~prefix value =
+  let prefix_len = String.length prefix in
+  String.length value >= prefix_len
+  && String.equal (String.sub value 0 prefix_len) prefix
+;;

--- a/lib/server/server_dashboard_http_json_utils.mli
+++ b/lib/server/server_dashboard_http_json_utils.mli
@@ -1,0 +1,30 @@
+(** Small JSON / string utility helpers for the dashboard HTTP surface. *)
+
+(** Trim [text], then truncate to [max_chars] characters with a
+    trailing ["..."] suffix when over budget. Returns
+    [(preview, truncated)]. *)
+val compact_preview : max_chars:int -> string -> string * bool
+
+(** [`Assoc] field-by-key with [`Null] fallback on miss or
+    non-Assoc input. *)
+val json_member : string -> Yojson.Safe.t -> Yojson.Safe.t
+
+(** Typed-getter aliases for [Json_util.get_*] with [(key, json)]
+    argument order. *)
+val json_string : string -> Yojson.Safe.t -> string option
+val json_int : string -> Yojson.Safe.t -> int option
+val json_float : string -> Yojson.Safe.t -> float option
+val json_bool : string -> Yojson.Safe.t -> bool option
+
+(** RFC-0142 PR-5 typed-failure variant: accepts both [`Float] and
+    [`Int]; collapses Wrong_shape / Field_absent to [None] at the
+    boundary. *)
+val json_number : string -> Yojson.Safe.t -> float option
+
+(** [Json_field.assoc] adapter wrapping back to [`Assoc fields]
+    option. *)
+val json_assoc : string -> Yojson.Safe.t -> Yojson.Safe.t option
+
+(** Explicit-length prefix equality without throwing on short
+    input. *)
+val string_has_prefix : prefix:string -> string -> bool


### PR DESCRIPTION
## Summary

Sibling carve-out from `lib/server/server_dashboard_http.ml` (1341 → 1308 LOC, **-33**). First touch on this godfile — audited by the 2026-05-18 godfile-decomposition build plan.

The parent remains a godfile but a small lane is now open for follow-up extracts (`compact_receipt_*` helpers, `composite_*` JSON builders, the `approval_resolve_http_error` cluster).

New sibling `lib/server/server_dashboard_http_json_utils.ml` (59 LOC) hosts 9 pure JSON/string utility helpers:

- `compact_preview ~max_chars text` — trim + truncate-with-`...` suffix when over budget; returns `(preview, truncated)` pair
- `json_member key json` — `` `Assoc `` field-by-key with `` `Null `` on miss / non-Assoc
- `json_string` / `json_int` / `json_float` / `json_bool` — `Json_util` typed-getter aliases with `(key, json)` order swap
- `json_number` — RFC-0142 PR-5 typed-failure variant via `Json_field.float |> to_option` (accepts both `` `Float `` and `` `Int ``)
- `json_assoc` — `Json_field.assoc` adapter wrapping back to `` `Assoc fields option ``
- `string_has_prefix ~prefix value` — explicit-length prefix equality without throwing on short input

## Parent surface preservation

9 single-line value aliases. No `.mli` on `server_dashboard_http` (internal-only helpers), so the implicit signature absorbs the move.

## External callers

**None** under qualified name `Server_dashboard_http.*` (verified via grep across `lib/` + `test/`). All callers internal to the parent's `composite_*`, `dashboard_*`, and `handle_*` functions.

## Anti-pattern note

`json_number` and `json_assoc` preserve the **RFC-0142 PR-5 typed-failure pattern** via `Json_field.to_option` — `Wrong_shape` becomes structurally distinct from `Field_absent` at the producer boundary, even though both still surface as `None` to the caller. **Verbatim move preserves both the call shape and the PR-5 rationale.**

## Test plan

- [x] `dune build --root . lib/` clean
- [x] No `.mli` to update (internal helpers)
- [x] External caller grep across `lib/` + `test/` — no qualified callers
- [x] No sub-library dune edit needed (`lib/server/` in main `masc_mcp` library)
- [ ] CI green

RFC-WAIVED: extract-only refactor (no behavior change, no surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
