### PR TITLE
feat(keeper_config): env override for tool_heavy compaction defaults (PR-C of F3)

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -593,14 +593,75 @@ let default_keep_recent_tool_results = 2
 (** Default message-count floor for the tool-heavy compaction gate.
     Mirrors the prior global constant in [keeper_compact_policy.ml].
     Per-keeper override lives at [compaction_policy.tool_heavy_msg_threshold];
-    wired into [decide_compaction] by PR-B. *)
-let default_tool_heavy_msg_threshold = 40
+    wired into [decide_compaction] by PR-B.
+
+    Operator override (PR-C, this commit): [MASC_KEEPER_TOOL_HEAVY_MSG_THRESHOLD]
+    sets the global default that personas without an explicit value inherit.
+    Valid range [1, 10_000]; out-of-range or unparseable values warn and fall
+    back to the built-in default 40 (parse-correctness, not silent coercion —
+    mirrors [emergency_compact_ratio_threshold] in
+    [Keeper_compact_policy]). Read once at module init; restart required. *)
+let default_tool_heavy_msg_threshold : int =
+  let env_var = "MASC_KEEPER_TOOL_HEAVY_MSG_THRESHOLD" in
+  let default_value = 40 in
+  let min_valid = 1 in
+  let max_valid = 10_000 in
+  match Sys.getenv_opt env_var with
+  | None -> default_value
+  | Some raw ->
+    (match int_of_string_opt (String.trim raw) with
+     | None ->
+       Log.Keeper.warn
+         "[keeper_config] %s=%S is not a parseable int; falling back to default \
+          %d"
+         env_var raw default_value;
+       default_value
+     | Some parsed when parsed < min_valid || parsed > max_valid ->
+       Log.Keeper.warn
+         "[keeper_config] %s=%d out of range [%d, %d]; falling back to default \
+          %d"
+         env_var parsed min_valid max_valid default_value;
+       default_value
+     | Some parsed -> parsed)
 
 (** Default context-ratio floor for the tool-heavy compaction gate.
     Mirrors the prior global constant in [keeper_compact_policy.ml].
     Per-keeper override lives at [compaction_policy.tool_heavy_ratio_floor];
-    wired into [decide_compaction] by PR-B. *)
-let default_tool_heavy_ratio_floor = 0.15
+    wired into [decide_compaction] by PR-B.
+
+    Operator override (PR-C, this commit): [MASC_KEEPER_TOOL_HEAVY_RATIO_FLOOR]
+    sets the global default that personas without an explicit value inherit.
+    Valid range [0.0, 1.0); out-of-range, non-finite, or unparseable values
+    warn and fall back to the built-in default 0.15 (parse-correctness;
+    mirrors [emergency_compact_ratio_threshold]). Read once at module init. *)
+let default_tool_heavy_ratio_floor : float =
+  let env_var = "MASC_KEEPER_TOOL_HEAVY_RATIO_FLOOR" in
+  let default_value = 0.15 in
+  let min_valid = 0.0 in
+  let max_valid = 1.0 in
+  match Sys.getenv_opt env_var with
+  | None -> default_value
+  | Some raw ->
+    (match Float.of_string_opt (String.trim raw) with
+     | None ->
+       Log.Keeper.warn
+         "[keeper_config] %s=%S is not a parseable float; falling back to \
+          default %.2f"
+         env_var raw default_value;
+       default_value
+     | Some parsed when not (Float.is_finite parsed) ->
+       Log.Keeper.warn
+         "[keeper_config] %s=%s parsed to non-finite %f; falling back to \
+          default %.2f"
+         env_var raw parsed default_value;
+       default_value
+     | Some parsed when parsed < min_valid || parsed >= max_valid ->
+       Log.Keeper.warn
+         "[keeper_config] %s=%f out of range [%.2f, %.2f); falling back to \
+          default %.2f"
+         env_var parsed min_valid max_valid default_value;
+       default_value
+     | Some parsed -> parsed)
 
 (** Hard upper bound for operator-supplied [keep_recent_tool_results].
     Values above this likely indicate operator typos (e.g. 5000); we

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -193,13 +193,16 @@ val normalize_continuity_compaction_cooldown_sec : int -> int
 val default_keep_recent_tool_results : int
 
 (** Default message-count floor for the tool-heavy compaction gate.
-    Mirrors the prior global constant in [Keeper_compact_policy].
-    Wired into [decide_compaction] by PR-B. *)
+    Wired into [decide_compaction] by PR-B.  Operator override (PR-C):
+    [MASC_KEEPER_TOOL_HEAVY_MSG_THRESHOLD] (valid range [1, 10_000];
+    out-of-range warns and falls back to 40, mirroring
+    [Keeper_compact_policy.emergency_compact_ratio_threshold]). *)
 val default_tool_heavy_msg_threshold : int
 
 (** Default context-ratio floor for the tool-heavy compaction gate.
-    Mirrors the prior global constant in [Keeper_compact_policy].
-    Wired into [decide_compaction] by PR-B. *)
+    Wired into [decide_compaction] by PR-B.  Operator override (PR-C):
+    [MASC_KEEPER_TOOL_HEAVY_RATIO_FLOOR] (valid range [0.0, 1.0);
+    out-of-range or non-finite values warn and fall back to 0.15). *)
 val default_tool_heavy_ratio_floor : float
 
 (** Hard upper bound for operator-supplied


### PR DESCRIPTION
## Summary

Completes the F3 family (#17484 PR-A data, #17491 PR-B wiring).  Adds
operator-controlled env overrides for the global defaults that personas
without an explicit value inherit:

- `MASC_KEEPER_TOOL_HEAVY_MSG_THRESHOLD` (int, [1, 10_000], default 40).
- `MASC_KEEPER_TOOL_HEAVY_RATIO_FLOOR` (float, [0.0, 1.0), default 0.15).

Both mirror the existing
`MASC_KEEPER_EMERGENCY_COMPACT_RATIO_THRESHOLD` pattern at
`lib/keeper/keeper_compact_policy.ml:31-91` — parse-correctness, not
silent coercion: unparseable values, non-finite floats, and
out-of-range numbers warn via `Log.Keeper.warn` and fall back to the
built-in default.

## Files changed (2)

| File | Change |
|---|---|
| `lib/keeper/keeper_config.ml` | `default_tool_heavy_msg_threshold` / `default_tool_heavy_ratio_floor` switch from bare literals to env-readable initialisers with parse-correctness guards |
| `lib/keeper/keeper_config.mli` | Docstring updated to record the new env var contract |

2 files / +72 / -8.

## Verification

```
dune build lib/keeper test/test_keeper_compact_policy_pure.exe      → exit 0
dune exec test/test_keeper_compact_policy_pure.exe                  → 16/16 OK
MASC_KEEPER_TOOL_HEAVY_MSG_THRESHOLD=80 MASC_KEEPER_TOOL_HEAVY_RATIO_FLOOR=0.25
  dune exec ...                                                     → 16/16 OK (override active)
MASC_KEEPER_TOOL_HEAVY_MSG_THRESHOLD=garbage
  dune exec ...                                                     → 16/16 OK (warn emitted, default applied)
```

## Anti-pattern self-check

- **§1 telemetry-as-fix**: NO — env-controlled tunable, no counter.
- **§2 string classifier**: NO — typed int/float parse with closed
  range guards.
- **§3 N-of-M patch**: NO — completes the F3 env-override surface
  paired with PR-A/B; no new sites added, no half-done migration.
- **Symptom suppression (cap/cooldown/dedup/repair)**: NO — legitimate
  operational tuning surface consistent with the
  `emergency_compact_ratio_threshold` precedent.
- **Test backdoor**: NO — env vars are operator-facing, not test-only.

## Motivation

Heavy-tool keepers observed in `~/.masc/keepers/*.decisions.jsonl`:
executor (17k decisions), nick0cave (18k), ramarama (10k+).  Without
this PR, operators must restart with a code change to alter the global
tool_heavy floor; per-keeper persona JSON override existed (PR-A/B) but
the *fleet-wide default* did not.  PR-C closes that gap.

## RFC discovery

Not touching listed mandatory subsystems (credential / operator
control plane / keeper sandbox / dashboard credential / Claude Code
hooks / workflow docs).  RFC not required.

Iter 39 of /loop 10m masc-mcp keeper audit (cron `b7d5acec`).

Independent of remaining backlog (PR-D telemetry-as-fix sunset in
`keeper_memory_recall.ml:654-678`, identified iter 13).