### PR TITLE
feat(runtime-lens): context/memory/compaction lineage P4

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -773,6 +773,12 @@ export interface KeeperRuntimeLensContextAxis {
   state_snapshot_sidecar_saved_count: number
   active_open_loop_count: number
   last_compaction: unknown
+  source_phase: string | null
+  payload_role: string | null
+  final_payload_digest: string | null
+  compaction_source: string | null
+  memory_injection_id: string | null
+  memory_flush_id: string | null
 }
 
 export interface KeeperRuntimeLensMemoryAxis extends KeeperRuntimeTraceMemorySummary {}
@@ -1132,6 +1138,12 @@ function parseRuntimeLensContextAxis(raw: unknown): KeeperRuntimeLensContextAxis
     state_snapshot_sidecar_saved_count: numberField(obj, 'state_snapshot_sidecar_saved_count'),
     active_open_loop_count: numberField(obj, 'active_open_loop_count'),
     last_compaction: obj.last_compaction ?? null,
+    source_phase: nullableStringField(obj, 'source_phase'),
+    payload_role: nullableStringField(obj, 'payload_role'),
+    final_payload_digest: nullableStringField(obj, 'final_payload_digest'),
+    compaction_source: nullableStringField(obj, 'compaction_source'),
+    memory_injection_id: nullableStringField(obj, 'memory_injection_id'),
+    memory_flush_id: nullableStringField(obj, 'memory_flush_id'),
   }
 }
 

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -968,8 +968,14 @@ export function RuntimeLensSection({
         <${SignalRow} label="proof tools" value=${formatLensList(proof.tools)} />
         <${SignalRow} label="network proof" value=${formatLensList(proof.network_modes)} />
         <${SignalRow} label="context compaction" value=${formatRatioPair({ numerator: context.context_compacted_count, denominator: context.context_compact_started_count })} />
+        <${SignalRow} label="context source phase" value=${context.source_phase ?? '-'} />
+        <${SignalRow} label="context payload role" value=${context.payload_role ?? '-'} />
+        <${SignalRow} label="context digest" value=${compactToken(context.final_payload_digest ?? '-')} />
+        <${SignalRow} label="compaction source" value=${context.compaction_source ?? '-'} />
         <${SignalRow} label="working loops" value=${context.active_open_loop_count} />
         <${SignalRow} label="memory flush" value=${formatIndependentCounters({ leftLabel: 'success', leftValue: memory.memory_flush_success_count, rightLabel: 'error', rightValue: memory.memory_flush_error_count })} />
+        <${SignalRow} label="memory injection id" value=${compactToken(context.memory_injection_id ?? '-')} />
+        <${SignalRow} label="memory flush id" value=${compactToken(context.memory_flush_id ?? '-')} />
         <${SignalRow} label="trace id" value=${compactToken(trace.trace_id)} />
         <${SignalRow}
           label="manifest file"

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -262,6 +262,7 @@ let run_turn
             | None -> `Null
             | Some err -> `String (Agent_sdk.Error.to_string err) );
           ("checkpoint_path", `String checkpoint_path);
+          ("compaction_source", `String "pre_dispatch_hygiene");
         ])
     Keeper_runtime_manifest.Context_compacted;
   (* Steps 5-6: turn prompt, memory/temporal context, prompt metrics,
@@ -286,6 +287,17 @@ let run_turn
   let estimated_input_tokens = prompt_ctx.Keeper_run_prompt.estimated_input_tokens in
   let ctx_work = prompt_ctx.Keeper_run_prompt.ctx_work in
   let history_messages_digest = digest_message_texts_as_joined history_messages in
+  let final_payload_text =
+    String.concat "\n\n"
+      [
+        base_system_prompt;
+        turn_system_prompt;
+        dynamic_context;
+        memory_context;
+        temporal_context;
+        user_message;
+      ]
+  in
   append_manifest ~site:"context_injected"
     ~keeper_turn_id:manifest_keeper_turn_id
     ~decision:
@@ -300,6 +312,9 @@ let run_turn
           ("history_message_count", `Int (List.length history_messages));
           ("history_messages_digest", `String history_messages_digest);
           ("estimated_input_tokens", `Int estimated_input_tokens);
+          ("source_phase", `String "turn_dispatch");
+          ("payload_role", `String "model_input");
+          ("final_payload_digest", `String (digest_text final_payload_text));
         ])
     Keeper_runtime_manifest.Context_injected;
   let actionable_signal =

--- a/lib/memory_hooks.ml
+++ b/lib/memory_hooks.ml
@@ -178,6 +178,9 @@ let make
         in
         (match memory_ctx with
          | None ->
+           let memory_injection_id =
+             agent_name ^ ":" ^ string_of_int turn ^ ":skipped"
+           in
            append_runtime_manifest
              ?runtime_manifest_context
              ?runtime_manifest_append
@@ -186,6 +189,7 @@ let make
              ~decision:
                (`Assoc
                  [
+                   ("memory_injection_id", `String memory_injection_id);
                    ("memory_context_present", `Bool false);
                    ("episode_limit", `Int episode_limit);
                    ("procedure_limit", `Int procedure_limit);
@@ -205,6 +209,9 @@ let make
              | None -> Some mem_text
              | Some existing -> Some (existing ^ "\n\n" ^ mem_text)
            in
+           let memory_injection_id =
+             agent_name ^ ":" ^ string_of_int turn ^ ":injected"
+           in
            append_runtime_manifest
              ?runtime_manifest_context
              ?runtime_manifest_append
@@ -213,6 +220,7 @@ let make
              ~decision:
                (`Assoc
                  [
+                   ("memory_injection_id", `String memory_injection_id);
                    ("memory_context_present", `Bool true);
                    ("memory_context_chars", `Int (String.length mem_text));
                    ( "memory_context_digest",
@@ -227,6 +235,11 @@ let make
                         | None -> 0
                         | Some text -> String.length text) );
                    ( "extra_system_context_chars_after",
+                     `Int
+                       (match extra with
+                        | None -> 0
+                        | Some text -> String.length text) );
+                   ( "extra_system_context_size",
                      `Int
                        (match extra with
                         | None -> 0
@@ -254,6 +267,9 @@ let make
              Log.Keeper.debug
                "memory_hooks: flush_incremental agent=%s episodes=%d procedures=%d"
                agent_name ep pr;
+           let memory_flush_id =
+             agent_name ^ ":" ^ string_of_int turn ^ ":flushed"
+           in
            append_runtime_manifest
              ?runtime_manifest_context
              ?runtime_manifest_append
@@ -262,6 +278,7 @@ let make
              ~decision:
                (`Assoc
                  [
+                   ("memory_flush_id", `String memory_flush_id);
                    ("episodes_flushed", `Int ep);
                    ("procedures_flushed", `Int pr);
                    ("duration_s", `Float duration_s);
@@ -283,6 +300,9 @@ let make
                ~duration_s
                ~episodes:0
                ~procedures:0;
+             let memory_flush_id =
+               agent_name ^ ":" ^ string_of_int turn ^ ":flushed:error"
+             in
              append_runtime_manifest
                ?runtime_manifest_context
                ?runtime_manifest_append
@@ -291,6 +311,7 @@ let make
                ~decision:
                  (`Assoc
                    [
+                     ("memory_flush_id", `String memory_flush_id);
                      ("episodes_flushed", `Int 0);
                      ("procedures_flushed", `Int 0);
                      ("duration_s", `Float duration_s);

--- a/lib/server/server_dashboard_http_keeper_api_runtime_lens.ml
+++ b/lib/server/server_dashboard_http_keeper_api_runtime_lens.ml
@@ -214,6 +214,30 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
                     `Int scan.context_compact_started_count );
                   ( "context_compacted_count",
                     `Int scan.context_compacted_count );
+                  ( "source_phase",
+                    match scan.context_source_phase with
+                    | Some value -> `String value
+                    | None -> `Null );
+                  ( "payload_role",
+                    match scan.context_payload_role with
+                    | Some value -> `String value
+                    | None -> `Null );
+                  ( "final_payload_digest",
+                    match scan.context_final_payload_digest with
+                    | Some value -> `String value
+                    | None -> `Null );
+                  ( "compaction_source",
+                    match scan.context_compaction_source with
+                    | Some value -> `String value
+                    | None -> `Null );
+                  ( "memory_injection_id",
+                    match scan.memory_injection_id with
+                    | Some value -> `String value
+                    | None -> `Null );
+                  ( "memory_flush_id",
+                    match scan.memory_flush_id with
+                    | Some value -> `String value
+                    | None -> `Null );
                   ( "checkpoint_loaded_count",
                     `Int
                       (runtime_lens_event_count scan

--- a/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
@@ -35,6 +35,12 @@ type runtime_manifest_scan =
   ; mutable latest_pre_dispatch_blocked_row : Keeper_runtime_manifest.t option
   ; mutable context_injected_count : int
   ; mutable context_compacted_event_count : int
+  ; mutable context_source_phase : string option
+  ; mutable context_payload_role : string option
+  ; mutable context_final_payload_digest : string option
+  ; mutable context_compaction_source : string option
+  ; mutable memory_injection_id : string option
+  ; mutable memory_flush_id : string option
   ; mutable active_open_loop_count : int option
   ; mutable provider_started_count : int
   ; mutable provider_finished_count : int
@@ -71,6 +77,12 @@ let make_runtime_manifest_scan ~path ~limit =
   ; latest_pre_dispatch_blocked_row = None
   ; context_injected_count = 0
   ; context_compacted_event_count = 0
+  ; context_source_phase = None
+  ; context_payload_role = None
+  ; context_final_payload_digest = None
+  ; context_compaction_source = None
+  ; memory_injection_id = None
+  ; memory_flush_id = None
   ; active_open_loop_count = None
   ; provider_started_count = 0
   ; provider_finished_count = 0
@@ -126,9 +138,23 @@ let update_runtime_manifest_scan scan row =
    | Keeper_runtime_manifest.Pre_dispatch_blocked ->
      scan.latest_pre_dispatch_blocked_row <- Some row
    | Keeper_runtime_manifest.Context_injected ->
-     scan.context_injected_count <- scan.context_injected_count + 1
+     scan.context_injected_count <- scan.context_injected_count + 1;
+     let decision = row.Keeper_runtime_manifest.decision in
+     (match json_string_member_opt "source_phase" decision with
+      | Some value -> scan.context_source_phase <- Some value
+      | None -> ());
+     (match json_string_member_opt "payload_role" decision with
+      | Some value -> scan.context_payload_role <- Some value
+      | None -> ());
+     (match json_string_member_opt "final_payload_digest" decision with
+      | Some value -> scan.context_final_payload_digest <- Some value
+      | None -> ());
    | Keeper_runtime_manifest.Context_compacted ->
-     scan.context_compacted_event_count <- scan.context_compacted_event_count + 1
+     scan.context_compacted_event_count <- scan.context_compacted_event_count + 1;
+     let decision = row.Keeper_runtime_manifest.decision in
+     (match json_string_member_opt "compaction_source" decision with
+      | Some value -> scan.context_compaction_source <- Some value
+      | None -> ())
    | Keeper_runtime_manifest.State_snapshot_sidecar_saved ->
      scan.active_open_loop_count <-
        json_int_member_opt "active_open_loop_count"
@@ -161,7 +187,11 @@ let update_runtime_manifest_scan scan row =
    | Keeper_runtime_manifest.Memory_injected ->
      scan.memory_injected_count <- scan.memory_injected_count + 1;
      if String.equal row.Keeper_runtime_manifest.status "injected"
-     then scan.memory_injected_present_count <- scan.memory_injected_present_count + 1
+     then scan.memory_injected_present_count <- scan.memory_injected_present_count + 1;
+     let decision = row.Keeper_runtime_manifest.decision in
+     (match json_string_member_opt "memory_injection_id" decision with
+      | Some value -> scan.memory_injection_id <- Some value
+      | None -> ())
    | Keeper_runtime_manifest.Memory_flushed ->
      let decision = row.Keeper_runtime_manifest.decision in
      scan.memory_flushed_count <- scan.memory_flushed_count + 1;
@@ -169,6 +199,9 @@ let update_runtime_manifest_scan scan row =
      then scan.memory_flush_success_count <- scan.memory_flush_success_count + 1;
      if String.equal row.Keeper_runtime_manifest.status "error"
      then scan.memory_flush_error_count <- scan.memory_flush_error_count + 1;
+     (match json_string_member_opt "memory_flush_id" decision with
+      | Some value -> scan.memory_flush_id <- Some value
+      | None -> ());
      scan.episodes_flushed <-
        scan.episodes_flushed
        + Option.value (json_int_member_opt "episodes_flushed" decision) ~default:0;


### PR DESCRIPTION
## Summary
Context/memory/compaction lineage enrichment for the runtime lens (OAS Analysis P4 slice).

### Backend emit enrichment
- `keeper_agent_run.ml`: `compaction_source` field on `Context_compacted` decision
- `memory_hooks.ml`: `memory_injection_id` on `Memory_injected`, `memory_flush_id` on `Memory_flushed`

### Lens scan + API
- `server_dashboard_http_keeper_runtime_manifest_scan.ml`: extract 6 new fields into scan state
- `server_dashboard_http_keeper_api_runtime_lens.ml`: surface fields in `context` axis JSON

### Dashboard
- `keeper.ts`: add 6 fields to `KeeperRuntimeLensContextAxis` + parser
- `keeper-detail-runtime.ts`: render new signal rows (source_phase, payload_role, digest, compaction_source, injection_id, flush_id)

### Verification
- `dune build lib/server/` passes
- `vite build` passes

**Size:** +114 / -3 LoC across 6 files.