### PR TITLE
fix(exec): preserve file redirects in Shell IR

### DIFF
--- a/lib/exec/parser/bash_subset.mly
+++ b/lib/exec/parser/bash_subset.mly
@@ -5,12 +5,9 @@ type stage_part =
   | Arg of string
   | Redirect of Redirect_scope.t
 
-let dev_null_path () =
-  Path_scope.classify ~raw:"/dev/null" ~cwd:"."
-;;
-
-let file_redirect fd mode =
-  Redirect_scope.File { fd; target = dev_null_path (); mode }
+let file_redirect fd target mode =
+  Redirect_scope.File
+    { fd; target = Path_scope.classify ~raw:target ~cwd:"."; mode }
 ;;
 %}
 
@@ -18,9 +15,8 @@ let file_redirect fd mode =
 
    Productions now cover simple commands, pipelines, env prefixes
    (recognized in bash.ml from leading WORD tokens), fd-to-fd redirects,
-   and /dev/null file redirects. Subsequent PRs extend to:
-   - general file redirects beyond the explicit /dev/null sink
-   - subset guards that mint Parsed.Too_complex rather than matching.
+   and file redirects. Subsequent PRs extend to subset guards that mint
+   Parsed.Too_complex rather than matching.
 
    The grammar emits a list of raw (bin, args, redirects) triples,
    one per pipeline stage. bash.ml adapts the singleton case to
@@ -49,9 +45,9 @@ part:
       let src, dst = pair in
       Redirect (Redirect_scope.Fd_to_fd { src; dst })
     }
-  | item = FILE_REDIRECT_OP DEV_NULL {
+  | item = FILE_REDIRECT_OP target = literal_word {
       let fd, mode = item in
-      Redirect (file_redirect fd mode)
+      Redirect (file_redirect fd target mode)
     }
 
 stage:

--- a/lib/exec/test/test_bash_parser.ml
+++ b/lib/exec/test/test_bash_parser.ml
@@ -101,20 +101,43 @@ let test_logic_and_rejected () =
   | Parsed.Too_complex `Logic_op -> ()
   | _ -> assert false
 
-let test_general_redirect_rejected () =
+let test_general_redirect_parsed () =
   match Bash.parse_string "echo hi > /tmp/out" with
-  | Parsed.Too_complex `Redirect -> ()
-  (* "> must classify as Redirect" *)
+  | Parsed.Parsed (Shell_ir.Simple s) ->
+    assert (Bin.to_string s.bin = "echo");
+    assert (s.args = [ Shell_ir.Lit "hi" ]);
+    (match s.redirects with
+     | [ Redirect_scope.File { fd = 1; target; mode = Redirect_scope.Write } ] ->
+       assert (Path_scope.raw target = "/tmp/out")
+     | _ -> assert false)
   | _ -> assert false
 
-let test_redirect_append_rejected () =
+let test_redirect_append_parsed () =
   match Bash.parse_string "echo hi >> /tmp/out" with
-  | Parsed.Too_complex `Redirect -> ()
+  | Parsed.Parsed (Shell_ir.Simple s) ->
+    (match s.redirects with
+     | [ Redirect_scope.File { fd = 1; target; mode = Redirect_scope.Append } ] ->
+       assert (Path_scope.raw target = "/tmp/out")
+     | _ -> assert false)
   | _ -> assert false
 
-let test_input_redirect_rejected () =
+let test_input_redirect_parsed () =
   match Bash.parse_string "cat < /etc/hosts" with
-  | Parsed.Too_complex `Redirect -> ()
+  | Parsed.Parsed (Shell_ir.Simple s) ->
+    (match s.redirects with
+     | [ Redirect_scope.File { fd = 0; target; mode = Redirect_scope.Read } ] ->
+       assert (Path_scope.raw target = "/etc/hosts")
+     | _ -> assert false)
+  | _ -> assert false
+
+let test_general_redirect_rejected_before_dispatch () =
+  match Bash.parse_string "echo hi > /tmp/out" with
+  | Parsed.Parsed ir ->
+    let result = Masc_exec.Exec_dispatch.dispatch ir in
+    assert (result.status = Unix.WEXITED 1);
+    assert (result.stdout = "");
+    assert (String.contains result.stderr 'w');
+    assert (String.contains result.stderr '/')
   | _ -> assert false
 
 let test_fd_redirect_parsed () =
@@ -468,9 +491,10 @@ let () =
   test_single_command_is_simple_not_pipeline ();
   test_logic_or_rejected ();
   test_logic_and_rejected ();
-  test_general_redirect_rejected ();
-  test_redirect_append_rejected ();
-  test_input_redirect_rejected ();
+  test_general_redirect_parsed ();
+  test_redirect_append_parsed ();
+  test_input_redirect_parsed ();
+  test_general_redirect_rejected_before_dispatch ();
   test_fd_redirect_parsed ();
   test_dev_null_redirect_parsed ();
   test_spaced_dev_null_redirect_parsed ();


### PR DESCRIPTION
## Summary
- parse general file redirects into Redirect_scope.File instead of collapsing them into Too_complex Redirect
- keep /dev/null behavior unchanged while preserving write/append/read redirect targets for policy and capability analysis
- verify native dispatch still fails closed before spawning for unsupported non-/dev/null redirects

## Verification
- ocamlformat --check lib/exec/parser/bash_subset.mly lib/exec/test/test_bash_parser.ml
- env DUNE_CACHE=disabled DUNE_LOCAL_JOBS=1 MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build lib/exec/test/test_bash_parser.exe
- _build/default/lib/exec/test/test_bash_parser.exe
- git diff --check