### PR TITLE
refactor(worker): remove legacy quote stripping from command syntax

### DIFF
--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -433,7 +433,6 @@ let validate_command_coding ?caller cmd =
 ;;
 
 let looks_like_url token =
-  let token = strip_wrapping_quotes token in
   match String.index_opt token ':' with
   | Some idx when idx + 2 < String.length token ->
     token.[idx + 1] = '/' && token.[idx + 2] = '/'
@@ -441,19 +440,18 @@ let looks_like_url token =
 ;;
 
 let is_path_flag token =
-  match strip_wrapping_quotes token with
+  match token with
   | "-C" | "--git-dir" | "--work-tree" | "--exec-path" -> true
   | _ -> false
 ;;
 
 let path_flag_requires_existing_dir token =
-  match strip_wrapping_quotes token with
+  match token with
   | "-C" | "--work-tree" -> true
   | _ -> false
 ;;
 
 let path_value_of_flagged_token token =
-  let token = strip_wrapping_quotes token in
   let prefixes = [ "--git-dir="; "--work-tree="; "--exec-path=" ] in
   List.find_map
     (fun prefix ->
@@ -469,7 +467,6 @@ let path_value_of_flagged_token token =
 ;;
 
 let inline_path_flag_requires_existing_dir token =
-  let token = strip_wrapping_quotes token in
   String.starts_with ~prefix:"--work-tree=" token
 ;;
 
@@ -486,7 +483,6 @@ let path_is_existing_dir ?workdir path =
 ;;
 
 let looks_like_path_token token =
-  let token = strip_wrapping_quotes token in
   token <> ""
   && (not (looks_like_url token))
   && (token = "."
@@ -499,7 +495,6 @@ let looks_like_path_token token =
 ;;
 
 let token_value_is_explicit_path token =
-  let token = strip_wrapping_quotes token in
   token = "."
   || token = ".."
   || String.starts_with ~prefix:"/" token
@@ -510,13 +505,12 @@ let token_value_is_explicit_path token =
 
 let token_has_parent_dir_segment token =
   token
-  |> strip_wrapping_quotes
   |> String.split_on_char '/'
   |> List.exists (String.equal "..")
 ;;
 
 let git_revisionish_token ?workdir token =
-  let token = strip_wrapping_quotes token |> String.trim in
+  let token = String.trim token in
   token <> ""
   && String.contains token '/'
   && (not (token_value_is_explicit_path token))
@@ -769,7 +763,7 @@ let validate_shell_ir_paths ?keeper_id ?base_path ?workdir shell_ir =
   | None -> Ok ()
   | Some _ ->
       let validate_path_value ~requires_existing_dir value =
-        if String.equal (strip_wrapping_quotes value) "/dev/null"
+        if String.equal value "/dev/null"
         then Ok ()
         else if not (validate_path ?keeper_id ?base_path ?workdir value)
         then

--- a/lib/worker_dev_tools_command_syntax.ml
+++ b/lib/worker_dev_tools_command_syntax.ml
@@ -42,22 +42,9 @@ let argv_words_of_split_string text =
   | Masc_exec.Parsed.Too_complex _ -> None
 ;;
 
-let strip_wrapping_quotes token =
-  let len = String.length token in
-  if len >= 2
-  then (
-    let first = token.[0]
-    and last = token.[len - 1] in
-    if (first = '"' && last = '"') || (first = '\'' && last = '\'')
-    then String.sub token 1 (len - 2)
-    else token)
-  else token
-;;
-
-let basename_token token = Filename.basename (strip_wrapping_quotes token)
+let basename_token token = Filename.basename token
 
 let is_env_assignment token =
-  let token = strip_wrapping_quotes token in
   match String.index_opt token '=' with
   | Some idx ->
     idx > 0
@@ -69,14 +56,12 @@ let is_env_assignment token =
 let rec skip_env_assignments_tokens = function
   | [] -> None
   | token :: rest ->
-    let token = strip_wrapping_quotes token in
     if is_env_assignment token then skip_env_assignments_tokens rest else Some (token :: rest)
 ;;
 
 let rec command_after_env_prefix_tokens = function
   | [] -> None
   | token :: rest ->
-    let token = strip_wrapping_quotes token in
     if is_env_assignment token || token = "-" || token = "-i"
        || token = "--ignore-environment" || token = "-0" || token = "--null"
     then command_after_env_prefix_tokens rest
@@ -86,7 +71,7 @@ let rec command_after_env_prefix_tokens = function
     then (
       match rest with
       | arg :: rest -> (
-        match argv_words_of_split_string (strip_wrapping_quotes arg) with
+        match argv_words_of_split_string arg with
         | Some split_tokens -> (
           match command_after_env_prefix_tokens split_tokens with
           | Some _ as command -> command
@@ -100,7 +85,7 @@ let rec command_after_env_prefix_tokens = function
         String.sub token (String.length prefix) (String.length token - String.length prefix)
       in
       Option.bind
-        (argv_words_of_split_string (strip_wrapping_quotes arg))
+        (argv_words_of_split_string arg)
         command_after_env_prefix_tokens
     else if token = "-u" || token = "--unset" || token = "-C" || token = "--chdir"
     then (
@@ -125,7 +110,6 @@ let opam_exec_command_tokens rest =
     let rec find_command_without_sentinel = function
       | [] -> None
       | token :: rest ->
-        let token = strip_wrapping_quotes token in
         if is_env_assignment token
         then find_command_without_sentinel rest
         else if token = "--switch" || token = "--color" || token = "--root" || token = "--cli"

--- a/lib/worker_dev_tools_command_syntax.mli
+++ b/lib/worker_dev_tools_command_syntax.mli
@@ -1,6 +1,4 @@
 (** Shell word helpers for worker path and transparent-wrapper policy. *)
-val strip_wrapping_quotes : string -> string
-
 val command_after_env_prefix : string list -> string option
 (** Resolve the effective command name from argv words following an [env]
     executable. Environment assignments and supported env options are skipped;

--- a/test/test_keeper_bash_typed_input.ml
+++ b/test/test_keeper_bash_typed_input.ml
@@ -176,6 +176,7 @@ let test_wrapper_exec_target_allowlist () =
         ; env = []
         }
     ];
+  expect_not_allowlisted ~target:"'git'" (mk_exec "env" [ "'git'"; "status" ]);
   List.iter
     (fun input ->
       match Bash_input.validate ~mode:Bash_input.Dev_full input with


### PR DESCRIPTION
## Summary
- remove the exported worker command-syntax quote stripper
- rely on Shell IR / Bash parser literal argv normalization for wrapper and path helpers
- add a typed argv regression so literal quote characters are not silently stripped from env wrapper targets

## Verification
- ocamlformat --check lib/worker_dev_tools_command_syntax.ml lib/worker_dev_tools_command_syntax.mli lib/worker_dev_tools.ml test/test_keeper_bash_typed_input.ml
- git diff --check
- bash scripts/lint/shell-legacy-purge-ratchet.sh

## Not run
- scripts/dune-local.sh build test/test_keeper_bash_typed_input.exe test/test_worker_dev_tools.exe: local Dune validation was queued behind another active shared-machine lock holder for several minutes, then stopped to avoid blocking the cleanup queue.