### PR TITLE
refactor(cascade): drop ignored event bus args

### DIFF
--- a/lib/cascade/cascade_events.ml
+++ b/lib/cascade/cascade_events.ml
@@ -6,11 +6,9 @@
     Custom-name convention: [masc.broadcast], [masc.heartbeat],
     [masc.keeper.lifecycle], ...
 
-    The [bus] argument is accepted for backward compatibility but
-    ignored: every publish routes to [Masc_event_bus.get ()] so the
-    OAS/MASC layer boundary is preserved regardless of the caller's
-    bus reference. OAS's [event_bus.mli:103-107] explicitly warns
-    against publishing domain events onto OAS's bus.
+    Every publish routes to [Masc_event_bus.get ()] so the OAS/MASC
+    layer boundary is preserved. OAS's [event_bus.mli:103-107]
+    explicitly warns against publishing domain events onto OAS's bus.
 
     Wire format on SSE output keeps colon separators ("masc.broadcast")
     for dashboard compatibility — the translation is done by the SSE
@@ -18,16 +16,16 @@
 
     @since 2.90.0 (bus-separated since 2.353.0) *)
 
-(* Route every publish to the MASC-owned bus. Caller-passed [bus] is
-   ignored — this closes the OAS boundary violation where MASC was
-   publishing Custom("masc:...") onto OAS's shared bus. *)
+(* Route every publish to the MASC-owned bus. This closes the OAS boundary
+   violation where MASC was publishing Custom("masc:...") onto OAS's shared
+   bus. *)
 let masc_publish event =
   match Masc_event_bus.get () with
   | Some mb -> Agent_sdk_metrics_bridge.publish mb event
   | None -> ()
 
 (** Publish a broadcast event to the shared Event_bus. *)
-let publish_broadcast (_bus : Agent_sdk.Event_bus.t) ~agent_name ~content =
+let publish_broadcast ~agent_name ~content =
   let payload = `Assoc [
     ("agent_name", `String agent_name);
     ("content", `String content);
@@ -36,7 +34,7 @@ let publish_broadcast (_bus : Agent_sdk.Event_bus.t) ~agent_name ~content =
   masc_publish (Agent_sdk.Event_bus.mk_event (Custom ("masc.broadcast", payload)))
 
 (** Publish a heartbeat event to the shared Event_bus. *)
-let publish_heartbeat (_bus : Agent_sdk.Event_bus.t) ~agent_name ~turn ~context_pct =
+let publish_heartbeat ~agent_name ~turn ~context_pct =
   let payload = `Assoc [
     ("agent_name", `String agent_name);
     ("turn", `Int turn);
@@ -51,7 +49,7 @@ let publish_heartbeat (_bus : Agent_sdk.Event_bus.t) ~agent_name ~turn ~context_
     ("claim" / "start" / "done" / ...) is preserved via
     [Masc_domain.task_action_to_string]. Sibling refactor of #8846 (the
     Coord-side hook for the same transition vocabulary). *)
-let publish_task_transition (_bus : Agent_sdk.Event_bus.t) ~agent_name ~task_id
+let publish_task_transition ~agent_name ~task_id
     ~(transition : Masc_domain.task_action) =
   let payload = `Assoc [
     ("agent_name", `String agent_name);
@@ -65,7 +63,7 @@ let publish_task_transition (_bus : Agent_sdk.Event_bus.t) ~agent_name ~task_id
 
 (** Publish a keeper snapshot event to the OAS Event_bus.
     Emitted alongside SSE broadcast in keeper_keepalive. *)
-let publish_keeper_snapshot (_bus : Agent_sdk.Event_bus.t) ~keeper_name
+let publish_keeper_snapshot ~keeper_name
     ~generation ~context_ratio ~message_count =
   let payload = `Assoc [
     ("keeper_name", `String keeper_name);
@@ -106,7 +104,7 @@ let publish_keeper_snapshot (_bus : Agent_sdk.Event_bus.t) ~keeper_name
      - Custom_event { verb; phase = Some p } -> event=verb, phase=p
      - Phase_event p                          -> event=p, phase=p
    The legacy ?phase optional argument is folded into the variant. *)
-let publish_keeper_lifecycle (_bus : Agent_sdk.Event_bus.t)
+let publish_keeper_lifecycle
     ~(event : Keeper_lifecycle_events.lifecycle_event)
     ~keeper_name ~detail () =
   let phase_json =
@@ -134,7 +132,7 @@ let publish_keeper_lifecycle (_bus : Agent_sdk.Event_bus.t)
     the [event="dead"] entry on [masc.keeper.lifecycle] (which is unstructured
     free-form [detail]) so subscribers can filter on a stable topic and pull
     the structured fields directly. Topic: [masc.keeper.dead]. *)
-let publish_keeper_dead (_bus : Agent_sdk.Event_bus.t)
+let publish_keeper_dead
     ~keeper_name ~reason ~restart_count ~last_failure_reason () =
   let last_failure_json =
     match last_failure_reason with

--- a/lib/cascade/cascade_events.mli
+++ b/lib/cascade/cascade_events.mli
@@ -7,12 +7,9 @@
     [masc.broadcast], [masc.heartbeat], [masc.keeper.lifecycle],
     ...
 
-    The [bus] argument is accepted for backward compatibility
-    but ignored — every publish routes to
-    {!Masc_event_bus.get} so the OAS/MASC layer boundary is
-    preserved regardless of the caller's bus reference.  OAS's
-    [event_bus.mli:103-107] explicitly warns against publishing
-    domain events onto OAS's bus.
+    Every publish routes to {!Masc_event_bus.get} so the OAS/MASC
+    layer boundary is preserved.  OAS's [event_bus.mli:103-107]
+    explicitly warns against publishing domain events onto OAS's bus.
 
     Wire format on SSE output keeps colon separators
     ([masc.broadcast]) for dashboard compatibility — translation
@@ -23,12 +20,11 @@
 (** {1 Active publishers} *)
 
 val publish_broadcast :
-  Agent_sdk.Event_bus.t -> agent_name:string -> content:string -> unit
+  agent_name:string -> content:string -> unit
 (** Publishes [masc.broadcast] with payload
     [{agent_name, content, timestamp}]. *)
 
 val publish_heartbeat :
-  Agent_sdk.Event_bus.t ->
   agent_name:string ->
   turn:int ->
   context_pct:float ->
@@ -37,7 +33,6 @@ val publish_heartbeat :
     [{agent_name, turn, context_pct, timestamp}]. *)
 
 val publish_task_transition :
-  Agent_sdk.Event_bus.t ->
   agent_name:string ->
   task_id:string ->
   transition:Masc_domain.task_action ->
@@ -55,7 +50,6 @@ val publish_task_transition :
 (** {1 Keeper snapshot + lifecycle} *)
 
 val publish_keeper_snapshot :
-  Agent_sdk.Event_bus.t ->
   keeper_name:string ->
   generation:int ->
   context_ratio:float ->
@@ -66,7 +60,6 @@ val publish_keeper_snapshot :
     Emitted alongside SSE broadcast in [keeper_keepalive]. *)
 
 val publish_keeper_lifecycle :
-  Agent_sdk.Event_bus.t ->
   event:Keeper_lifecycle_events.lifecycle_event ->
   keeper_name:string ->
   detail:string ->
@@ -97,7 +90,6 @@ val publish_keeper_lifecycle :
     where observability matters most. *)
 
 val publish_keeper_dead :
-  Agent_sdk.Event_bus.t ->
   keeper_name:string ->
   reason:string ->
   restart_count:int ->

--- a/lib/dashboard/dashboard_safe_autonomy_level.mli
+++ b/lib/dashboard/dashboard_safe_autonomy_level.mli
@@ -1,0 +1,17 @@
+(** Safe-autonomy domain level + catalog. *)
+
+type domain_level =
+  | Pass
+  | Warn
+  | Fail
+
+val tool_domain_id : string
+val sandbox_domain_id : string
+val approval_domain_id : string
+val cascade_domain_id : string
+val audit_domain_id : string
+val domain_catalog : (string * string * int) list
+val level_to_string : domain_level -> string
+val level_rank : domain_level -> int
+val worse_level : domain_level -> domain_level -> domain_level
+val worst_level : domain_level list -> domain_level

--- a/lib/keeper/keeper_context_core_pair_repair_stats.mli
+++ b/lib/keeper/keeper_context_core_pair_repair_stats.mli
@@ -1,0 +1,18 @@
+(** Tool-pair repair stats and metadata helpers for [Keeper_context_core]. *)
+
+type tool_pair_repair_stats =
+  { downgraded_tool_uses : int
+  ; downgraded_tool_results : int
+  }
+
+val empty_tool_pair_repair_stats : tool_pair_repair_stats
+
+val add_tool_pair_repair_stats :
+  tool_pair_repair_stats -> tool_pair_repair_stats -> tool_pair_repair_stats
+
+val tool_pair_repair_stats_changed : tool_pair_repair_stats -> bool
+val pair_repair_metadata_key : string
+val pair_repair_metadata_keys : string list
+
+val with_pair_repair_metadata :
+  kind:string -> count:int -> Agent_sdk.Types.message -> Agent_sdk.Types.message

--- a/lib/keeper/keeper_execution_receipt_outcome_kind.mli
+++ b/lib/keeper/keeper_execution_receipt_outcome_kind.mli
@@ -1,0 +1,14 @@
+(** Outcome-kind polymorphic variant + bijection helpers for keeper execution
+    receipts. *)
+
+type outcome_kind =
+  [ `Ok
+  | `Skipped
+  | `Error
+  | `Cancelled
+  ]
+
+val outcome_kind_to_string : outcome_kind -> string
+val outcome_kind_to_tla_receipt : outcome_kind -> string
+val outcome_kind_of_string : string -> outcome_kind option
+val outcome_kind_is_terminal_success : outcome_kind -> bool

--- a/lib/keeper/keeper_heartbeat_snapshot.ml
+++ b/lib/keeper/keeper_heartbeat_snapshot.ml
@@ -467,15 +467,11 @@ let write_heartbeat_snapshot
          ~labels:[("keeper", meta_current.name)]
          ();
        Log.Keeper.error "heartbeat SSE broadcast failed: %s" (Printexc.to_string exn));
-    (match Keeper_event_bus.get () with
-     | Some bus ->
-       Cascade_events.publish_keeper_snapshot
-         bus
-         ~keeper_name:meta_current.name
-         ~generation:meta_current.runtime.generation
-         ~context_ratio:context_ratio_v
-         ~message_count:message_count_v
-     | None -> ());
+    Cascade_events.publish_keeper_snapshot
+      ~keeper_name:meta_current.name
+      ~generation:meta_current.runtime.generation
+      ~context_ratio:context_ratio_v
+      ~message_count:message_count_v;
     (try
        Keeper_registry_tool_usage_persistence.flush ~base_path:ctx.config.base_path meta_current.name
      with

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -532,9 +532,7 @@ let publish_keeper_lifecycle
       ()
   : unit
   =
-  match get_bus () with
-  | Some bus -> Cascade_events.publish_keeper_lifecycle bus ~event ~keeper_name ~detail ()
-  | None -> ()
+  Cascade_events.publish_keeper_lifecycle ~event ~keeper_name ~detail ()
 ;;
 
 (** Phase-event helper: the wire event name IS the phase name. *)

--- a/lib/keeper/keeper_state_machine_phase.mli
+++ b/lib/keeper/keeper_state_machine_phase.mli
@@ -1,0 +1,20 @@
+(** Keeper lifecycle phase variant + bijection helpers. *)
+
+type phase =
+  | Offline
+  | Running
+  | Failing
+  | Overflowed
+  | Compacting
+  | HandingOff
+  | Draining
+  | Paused
+  | Stopped
+  | Crashed
+  | Restarting
+  | Dead
+  | Zombie
+
+val phase_to_string : phase -> string
+val phase_of_string : string -> phase option
+val all_phases : phase list

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -964,16 +964,12 @@ let sweep_and_recover (ctx : _ context) =
        let last_fr_str =
          Option.map Keeper_registry.failure_reason_to_string entry.last_failure_reason
        in
-       (match Keeper_keepalive.get_bus () with
-        | Some bus ->
-          Cascade_events.publish_keeper_dead
-            bus
-            ~keeper_name:entry.name
-            ~reason:msg
-            ~restart_count:entry.restart_count
-            ~last_failure_reason:last_fr_str
-            ()
-        | None -> ());
+       Cascade_events.publish_keeper_dead
+         ~keeper_name:entry.name
+         ~reason:msg
+         ~restart_count:entry.restart_count
+         ~last_failure_reason:last_fr_str
+         ();
        Prometheus.inc_counter
          Keeper_metrics.metric_keeper_dead_total
          ~labels:

--- a/lib/keeper/keeper_supervisor_publish_lifecycle.ml
+++ b/lib/keeper/keeper_supervisor_publish_lifecycle.ml
@@ -4,8 +4,7 @@
     [publish_lifecycle] is the supervisor's single event-emission
     helper.  It (a) records the event into the per-keeper lifecycle
     audit ring for the dashboard (#12798), and (b) republishes onto
-    the cascade event bus iff [Keeper_keepalive.get_bus ()] resolves —
-    pre-bus callers no-op gracefully.
+    the cascade event bus when the process-wide MASC event bus is set.
 
     [publish_phase_lifecycle ~phase] is a thin convenience that
     constructs a [Keeper_lifecycle_events.Phase_event phase] and
@@ -33,9 +32,7 @@ let publish_lifecycle
   in
   (* #12798: record in the per-keeper lifecycle audit ring for dashboard. *)
   Keeper_lifecycle_audit.record ~keeper_name ~event_name ~phase ~detail;
-  match Keeper_keepalive.get_bus () with
-  | Some bus -> Cascade_events.publish_keeper_lifecycle bus ~event ~keeper_name ~detail ()
-  | None -> ()
+  Cascade_events.publish_keeper_lifecycle ~event ~keeper_name ~detail ()
 ;;
 
 (** Phase-event helper: the wire event name IS the phase name. *)

--- a/lib/keeper/keeper_turn_slot_types.mli
+++ b/lib/keeper/keeper_turn_slot_types.mli
@@ -1,0 +1,32 @@
+(** Slot/pool/phase variants + wait-timeout payload for keeper turn slots. *)
+
+type slot_pool =
+  | Turn_pool
+  | Autonomous_pool
+  | Reactive_pool
+
+val slot_pool_to_string : slot_pool -> string
+
+exception Semaphore_wait_timeout of float
+
+type semaphore_wait_phase =
+  | Autonomous_queue_head
+  | Autonomous_slot
+  | Reactive_slot
+  | Turn_slot
+
+val semaphore_wait_phase_to_string : semaphore_wait_phase -> string
+
+type semaphore_wait_timeout =
+  { timeout_wait_sec : float
+  ; timeout_phase : semaphore_wait_phase
+  ; timeout_autonomous_available : int
+  ; timeout_reactive_available : int
+  ; timeout_turn_available : int
+  ; timeout_queue_depth : int
+  ; timeout_queue_ahead : int option
+  ; timeout_holders : (string * float) list
+  }
+
+val int_of_env_default :
+  primary:string -> default:int -> min_v:int -> max_v:int -> int

--- a/lib/server/server_runtime_bootstrap_legacy_room.mli
+++ b/lib/server/server_runtime_bootstrap_legacy_room.mli
@@ -1,0 +1,6 @@
+(** Legacy-room inference for the flat-room migration path. *)
+
+val default_room_for_flat_migration : string
+val legacy_room_candidates : string -> string list
+val infer_current_room_from_legacy_dirs : string -> string option
+val load_current_room_or_default : string -> string -> string option

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -102,7 +102,7 @@ let test_event_bus_broadcast () =
   let bus = Event_bus.create () in
   Masc_event_bus.set bus;
   let sub = Event_bus.subscribe bus in
-  Cascade_events.publish_broadcast bus ~agent_name:"test-agent" ~content:"hello";
+  Cascade_events.publish_broadcast ~agent_name:"test-agent" ~content:"hello";
   let events = Event_bus.drain sub in
   Alcotest.(check int) "one event" 1 (List.length events);
   match (List.hd events : Event_bus.event).payload with
@@ -117,7 +117,7 @@ let test_event_bus_heartbeat () =
   let bus = Event_bus.create () in
   Masc_event_bus.set bus;
   let sub = Event_bus.subscribe bus in
-  Cascade_events.publish_heartbeat bus ~agent_name:"keeper-runtime" ~turn:5 ~context_pct:0.42;
+  Cascade_events.publish_heartbeat ~agent_name:"keeper-runtime" ~turn:5 ~context_pct:0.42;
   let events = Event_bus.drain sub in
   Alcotest.(check int) "one event" 1 (List.length events);
   match (List.hd events : Event_bus.event).payload with
@@ -203,7 +203,7 @@ let test_event_bus_task_transition () =
   let bus = Event_bus.create () in
   Masc_event_bus.set bus;
   let sub = Event_bus.subscribe bus in
-  Cascade_events.publish_task_transition bus ~agent_name:"worker"
+  Cascade_events.publish_task_transition ~agent_name:"worker"
     ~task_id:"task-1" ~transition:Types_core.Done_action;
   let events = Event_bus.drain sub in
   Alcotest.(check int) "one event" 1 (List.length events);
@@ -219,7 +219,7 @@ let test_event_bus_keeper_lifecycle_includes_phase () =
   let bus = Event_bus.create () in
   Masc_event_bus.set bus;
   let sub = Event_bus.subscribe bus in
-  Cascade_events.publish_keeper_lifecycle bus
+  Cascade_events.publish_keeper_lifecycle
     ~event:(Masc_mcp.Keeper_lifecycle_events.Custom_event
               { verb = Masc_mcp.Keeper_lifecycle_events.Started;
                 phase = Some Masc_mcp.Keeper_state_machine.Running })
@@ -247,7 +247,7 @@ let test_keeper_snapshot_envelope_agent_name () =
   let bus = Event_bus.create () in
   Masc_event_bus.set bus;
   let sub = Event_bus.subscribe bus in
-  Cascade_events.publish_keeper_snapshot bus
+  Cascade_events.publish_keeper_snapshot
     ~keeper_name:"sojin"
     ~generation:4
     ~context_ratio:0.25
@@ -276,7 +276,7 @@ let test_keeper_lifecycle_envelope_agent_name () =
   let bus = Event_bus.create () in
   Masc_event_bus.set bus;
   let sub = Event_bus.subscribe bus in
-  Cascade_events.publish_keeper_lifecycle bus
+  Cascade_events.publish_keeper_lifecycle
     ~event:(Masc_mcp.Keeper_lifecycle_events.Custom_event
               { verb = Masc_mcp.Keeper_lifecycle_events.Started;
                 phase = Some Masc_mcp.Keeper_state_machine.Running })
@@ -367,7 +367,7 @@ let test_oas_event_bridge_broadcasts_lifecycle_to_observers () =
                       "coordinator-lifecycle" ~last_event_id:0);
             Cascade_event_bridge.start_with_interval ~drain_interval_s:0.1
               ~sw ~clock:(Eio.Stdenv.clock env) ~config ~bus;
-            Cascade_events.publish_keeper_lifecycle bus
+            Cascade_events.publish_keeper_lifecycle
               ~event:(Masc_mcp.Keeper_lifecycle_events.Custom_event
                         { verb = Masc_mcp.Keeper_lifecycle_events.Started;
                           phase = Some Masc_mcp.Keeper_state_machine.Running })


### PR DESCRIPTION
## Summary
- remove the ignored Event_bus argument from Cascade_events publisher APIs
- update keeper/cascade call sites to publish through the process-wide Masc_event_bus directly
- add missing interfaces for recently extracted modules so the OCaml structure ratchet remains at baseline

## Validation
- ocamlformat --check lib/cascade/cascade_events.mli lib/cascade/cascade_events.ml lib/keeper/keeper_supervisor_publish_lifecycle.ml lib/keeper/keeper_keepalive.ml lib/keeper/keeper_heartbeat_snapshot.ml lib/keeper/keeper_supervisor.ml test/test_oas_integration.ml lib/keeper/keeper_execution_receipt_outcome_kind.mli lib/keeper/keeper_context_core_pair_repair_stats.mli lib/keeper/keeper_state_machine_phase.mli lib/keeper/keeper_turn_slot_types.mli lib/server/server_runtime_bootstrap_legacy_room.mli lib/dashboard/dashboard_safe_autonomy_level.mli
- git diff --check
- scripts/ocaml-structure-ratchet.sh

## Note
- Focused dune build was attempted with scripts/dune-local.sh, but the local machine-wide Dune lock stayed held by another session, so compile validation is deferred to CI.