### PR TITLE
Quiet missing dashboard eval-feed directories

### DIFF
--- a/lib/dashboard_eval_feed/dashboard_eval_feed.ml
+++ b/lib/dashboard_eval_feed/dashboard_eval_feed.ml
@@ -108,46 +108,68 @@ let eval_base ~base_path =
 let eval_dir ~base_path ~agent_name =
   Filename.concat (eval_base ~base_path) agent_name
 
-(* Silent [Sys_error _ -> []] previously hid two distinct failure modes
-   behind "no agents have eval data": (1) the eval directory is
-   legitimately empty (expected during fresh boot before any verdict
-   write), (2) the directory is unreadable due to permission denied,
-   missing parent, or filesystem unavailability. Operators staring at
-   an empty Eval Feed pane need to tell these apart. Same pattern as
-   #16712, #16720, #16724, #16725, #16729 (silent-failure series). *)
-let list_agents ~base_path =
-  let dir = eval_base ~base_path in
+let path_kind path =
+  try
+    if Sys.file_exists path then
+      if Sys.is_directory path then `Directory else `Other
+    else `Missing
+  with Sys_error msg -> `Unreadable msg
+
+let warn_unreadable ~op ~path msg =
+  Log.Dashboard.warn "[eval_feed.%s] path unreadable at %s: %s" op path msg
+
+let warn_not_directory ~op ~path =
+  Log.Dashboard.warn "[eval_feed.%s] expected directory at %s" op path
+
+let sorted_json_files dir =
   try
     Sys.readdir dir
     |> Array.to_list
-    |> List.filter (fun name ->
-         Sys.is_directory (Filename.concat dir name))
-    |> List.sort String.compare
-  with
-  | Sys_error msg ->
-    Log.Dashboard.warn
-      "[eval_feed.list_agents] eval directory unreadable at %s: %s"
-      dir
-      msg;
+    |> List.filter (fun f -> Filename.check_suffix f ".json")
+    |> List.sort (fun a b -> String.compare b a)
+  with Sys_error msg ->
+    warn_unreadable ~op:"read_latest" ~path:dir msg;
     []
+
+let list_agents ~base_path =
+  let dir = eval_base ~base_path in
+  match path_kind dir with
+  | `Missing -> []
+  | `Other ->
+      warn_not_directory ~op:"list_agents" ~path:dir;
+      []
+  | `Unreadable msg ->
+      warn_unreadable ~op:"list_agents" ~path:dir msg;
+      []
+  | `Directory -> (
+      try
+        Sys.readdir dir
+        |> Array.to_list
+        |> List.filter (fun name ->
+             match path_kind (Filename.concat dir name) with
+             | `Directory -> true
+             | `Missing | `Other -> false
+             | `Unreadable msg ->
+                 warn_unreadable ~op:"list_agents"
+                   ~path:(Filename.concat dir name) msg;
+                 false)
+        |> List.sort String.compare
+      with Sys_error msg ->
+        warn_unreadable ~op:"list_agents" ~path:dir msg;
+        [])
 
 let read_latest ~base_path ~agent_name ~limit =
   let dir = eval_dir ~base_path ~agent_name in
   let files =
-    try
-      Sys.readdir dir
-      |> Array.to_list
-      |> List.filter (fun f -> Filename.check_suffix f ".json")
-      |> List.sort (fun a b -> String.compare b a)
-    with
-    | Sys_error msg ->
-      Log.Dashboard.warn
-        "[eval_feed.read_latest] per-agent verdict directory unreadable for \
-         %s at %s: %s"
-        agent_name
-        dir
-        msg;
-      []
+    match path_kind dir with
+    | `Missing -> []
+    | `Other ->
+        warn_not_directory ~op:"read_latest" ~path:dir;
+        []
+    | `Unreadable msg ->
+        warn_unreadable ~op:"read_latest" ~path:dir msg;
+        []
+    | `Directory -> sorted_json_files dir
   in
   let rec collect acc remaining = function
     | [] -> List.rev acc

--- a/lib/dashboard_eval_feed/dashboard_eval_feed.mli
+++ b/lib/dashboard_eval_feed/dashboard_eval_feed.mli
@@ -39,7 +39,8 @@ val read_verdict_json : Yojson.Safe.t -> (swiss_verdict_json, string) result
 val list_agents : base_path:string -> string list
 (** Return sorted agent names that have eval data under
     [<base_path>/.oas/eval/].  Returns an empty list when the
-    directory does not exist.  Never raises. *)
+    directory does not exist.  Missing eval data is a normal fresh-boot
+    state and does not log a warning.  Never raises. *)
 
 val read_latest :
   base_path:string -> agent_name:string -> limit:int -> eval_snapshot list
@@ -50,7 +51,8 @@ val read_latest :
     [verdict] field conforming to the swiss-verdict schema.
 
     Returns an empty list when the directory does not exist or contains
-    no parseable files.  Never raises. *)
+    no parseable files.  Missing eval data is a normal fresh-boot state
+    and does not log a warning.  Never raises. *)
 
 val snapshot_to_json : eval_snapshot -> Yojson.Safe.t
 (** Serialize an eval snapshot to JSON for HTTP responses. *)

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -140,14 +140,12 @@ let dashboard_doctor_degraded_json ~self_bin ~exn =
                 ; "kind", `String "config"
                 ; "exit_code", `Int 2
                 ; ( "payload"
-                  , `Assoc
+                  , Tool_args.error_assoc
                       [ "title", `String "Dashboard Doctor Route"
-                      ; "status", `String "error"
                       ; ( "checks"
                         , `List
-                            [ `Assoc
+                            [ Tool_args.error_assoc
                                 [ "name", `String "self-binary"
-                                ; "status", `String "error"
                                 ; "message", `String message
                                 ; "path", `String self_bin
                                 ] ] )

--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -19,17 +19,17 @@
 # lib/bounded_proc/bounded_proc.ml:17  — the canonical helper itself.
 lib/bounded_proc/bounded_proc.ml:17
 
-# lib/process/process_eio.ml:504, 535 — `spawn_and_drain_{stdout,both}`.
+# lib/process/process_eio.ml:459, 490 — `spawn_and_drain_{stdout,both}`.
 # Private functions. Every caller (run_argv*, run_argv_with_status*,
 # run_argv_with_stdin*) wraps in `Eio.Time.with_timeout_exn clk timeout_sec`
 # + `Eio.Switch.run` and the process-wide spawn guard.
-lib/process/process_eio.ml:504
-lib/process/process_eio.ml:535
+lib/process/process_eio.ml:459
+lib/process/process_eio.ml:490
 
-# lib/process/process_eio.ml:942 — native pipeline stage spawn. Wrapped in
+# lib/process/process_eio.ml:897 — native pipeline stage spawn. Wrapped in
 # Eio.Time.with_timeout_exn + fresh Eio.Switch.run inside
 # run_argv_pipeline_with_status_split.
-lib/process/process_eio.ml:942
+lib/process/process_eio.ml:897
 
 # lib/server/lsp_process_manager.ml:178 — LSP child process. Lifetime is
 # bound to the LSP session switch; idle eviction handled by the LSP

--- a/test/test_eval_feed.ml
+++ b/test/test_eval_feed.ml
@@ -162,6 +162,19 @@ let test_parse_layer_missing_name () =
 
 (* ── read_latest tests ───────────────────────────────────────────── *)
 
+let test_list_agents_nonexistent_dir () =
+  let result = Eval_feed.list_agents ~base_path:"/nonexistent/path" in
+  check int "empty result" 0 (List.length result)
+
+let test_list_agents_with_dirs () =
+  let base = tmpdir "eval_agents" in
+  let eval_root = Filename.concat (Filename.concat base ".oas") "eval" in
+  mkdir_p (Filename.concat eval_root "keeper-b");
+  mkdir_p (Filename.concat eval_root "keeper-a");
+  write_file (Filename.concat eval_root "readme.txt") "ignore me";
+  let result = Eval_feed.list_agents ~base_path:base in
+  check (list string) "sorted agent dirs" [ "keeper-a"; "keeper-b" ] result
+
 let test_read_latest_empty_dir () =
   let base = tmpdir "eval_empty" in
   let result = Eval_feed.read_latest ~base_path:base ~agent_name:"keeper-a" ~limit:10 in
@@ -326,6 +339,10 @@ let () =
         ] );
       ( "read_latest",
         [
+          test_case "list_agents nonexistent directory" `Quick
+            test_list_agents_nonexistent_dir;
+          test_case "list_agents with dirs" `Quick
+            test_list_agents_with_dirs;
           test_case "empty directory" `Quick test_read_latest_empty_dir;
           test_case "nonexistent directory" `Quick
             test_read_latest_nonexistent_dir;


### PR DESCRIPTION
## Summary
- treat missing dashboard eval-feed directories as normal empty fresh-boot state
- keep warnings for unreadable paths or non-directory eval-feed paths
- add list_agents coverage for nonexistent and sorted agent directories
- refresh CI ratchets exposed by rebasing onto current main

## Verification
- opam exec -- ocamlformat --check lib/dashboard_eval_feed/dashboard_eval_feed.ml lib/dashboard_eval_feed/dashboard_eval_feed.mli test/test_eval_feed.ml lib/server/server_routes_http_routes_dashboard.ml
- git diff --check
- bash scripts/lint-spawn-bounded.sh
- bash scripts/lint/no-inline-error-envelope.sh
- scripts/dune-local.sh build test/test_eval_feed.exe
- ./_build/default/test/test_eval_feed.exe
- scripts/dune-local.sh build lib/dashboard_eval_feed/masc_mcp_dashboard_eval_feed.cma
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build lib/masc_mcp.cma
- rg -n "per-agent verdict directory unreadable|eval directory unreadable|\.oas/eval|autoresearch" config lib test/test_eval_feed.ml