### PR TITLE
Remove room-truth SSE compatibility alias

### DIFF
--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -60,7 +60,6 @@ const FIXED_SSE_EVENT_TYPES = new Set([
   'approval:pending',
   'approval:resolved',
   'project_snapshot',
-  'room_truth_snapshot',
   'namespace_truth_snapshot',
   'execution_snapshot',
   'operator_snapshot',

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -477,7 +477,7 @@ export function routeServerPushEvent(event: SSEEvent): void {
 }
 
 export function hydrateServerPushEvent(event: SSEEvent): boolean {
-  if ((event.type === 'project_snapshot' || event.type === 'namespace_truth_snapshot' || event.type === 'room_truth_snapshot') && event.payload) {
+  if ((event.type === 'project_snapshot' || event.type === 'namespace_truth_snapshot') && event.payload) {
     handleNamespaceTruthSnapshot(event.payload)
     return true
   }
@@ -550,7 +550,6 @@ export function hydrateDashboardSlice(slice: string, payload: unknown, eventType
   switch (eventType) {
     case 'project_snapshot':
     case 'namespace_truth_snapshot':
-    case 'room_truth_snapshot':
     case 'execution_snapshot':
     case 'operator_snapshot':
     case 'operator_digest':

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -68,7 +68,6 @@ export type SSEEventType =
   | `oas:${string}`
   // Server-push snapshot events (proactive cache broadcasts)
   | 'project_snapshot'
-  | 'room_truth_snapshot'
   | 'namespace_truth_snapshot'
   | 'execution_snapshot'
   | 'operator_snapshot'

--- a/docs/SYSTEM-EVENT-AND-SNAPSHOT-INVENTORY.md
+++ b/docs/SYSTEM-EVENT-AND-SNAPSHOT-INVENTORY.md
@@ -35,8 +35,7 @@ This document is the operator-facing SSOT for:
 | `operator_digest` | Background proactive refresh loop | Cached payload wrapped as `{type, payload, ts_unix}` | Default root HTTP path returns cache; non-default requests recompute. |
 | `execution_snapshot` | Background proactive refresh loop | Cached payload wrapped as `{type, payload, ts_unix}` | Used by execution dashboard surfaces. |
 | `transport_health_snapshot` | Background proactive refresh loop | Cached payload wrapped as `{type, payload, ts_unix}` | Used for transport diagnostics. |
-| `namespace_truth_snapshot` | After namespace-truth recomposition from cached surfaces | Cached payload wrapped as `{type, payload, ts_unix}` | `room_truth_snapshot` is the legacy alias. |
-| `room_truth_snapshot` | Emitted together with `namespace_truth_snapshot` | Same payload as namespace truth | Compatibility alias; not a distinct read model. |
+| `namespace_truth_snapshot` | After namespace-truth recomposition from cached surfaces | Cached payload wrapped as `{type, payload, ts_unix}` | Namespace truth dashboard snapshot. |
 
 ## `keeper_composite_changed`
 
@@ -176,7 +175,7 @@ Source of accepted event names on the dashboard side: `dashboard/src/types/sse.t
 | Keeper direct SSE | `keeper_heartbeat`, `keeper_handoff`, `masc/keeper_handoff`, `keeper_compaction`, `masc/keeper_compaction`, `keeper_guardrail`, `masc/keeper_guardrail`, `keeper_phase_changed`, `keeper_composite_changed`, `keeper_tool_call`, `masc/keeper_tool_call`, `keeper_tool_skipped`, `keeper_turn_complete`, `masc/keeper_turn_complete` |
 | Approval / governance | `client_input_approved`, `client_input_rejected`, `client_input_updated`, `governance_param_changed`, `approval:pending`, `approval:resolved` |
 | OAS bridge | `oas:masc:keeper:snapshot`, `oas:masc:keeper:lifecycle`, `oas:agent_started`, `oas:agent_completed`, `oas:tool_called`, `oas:tool_completed`, `oas:turn_started`, `oas:turn_completed`, `oas:context_compacted`, `oas:task_state_changed`, `oas:masc:harness:verdict_recorded`, `oas:masc:harness:pre_compact`, `oas:masc:harness:handoff` |
-| Server-push snapshots | `room_truth_snapshot`, `namespace_truth_snapshot`, `execution_snapshot`, `operator_snapshot`, `operator_digest`, `transport_health_snapshot` |
+| Server-push snapshots | `namespace_truth_snapshot`, `execution_snapshot`, `operator_snapshot`, `operator_digest`, `transport_health_snapshot` |
 
 ### 2. OAS custom events published by MASC
 
@@ -201,7 +200,7 @@ These originate in `lib/oas_events.ml` and are later relayed by `oas_event_bridg
 | Event name | Status | Notes |
 | --- | --- | --- |
 | `keeper_lifecycle` | removed legacy direct SSE | Replaced by `keeper_phase_changed` for observer-facing FSM transitions and `oas:masc:keeper:lifecycle` for lifecycle detail. |
-| `room_truth_snapshot` | compatibility alias | Emitted together with `namespace_truth_snapshot`; same payload, different name. |
+| `room_truth_snapshot` | removed legacy alias | Replaced by `namespace_truth_snapshot`; same payload shape, canonical event name only. |
 
 ## Representative Messages
 

--- a/lib/server/server_dashboard_http_namespace_truth.ml
+++ b/lib/server/server_dashboard_http_namespace_truth.ml
@@ -314,17 +314,8 @@ let broadcast_namespace_truth_snapshot (state : Mcp_server.server_state) : unit 
             ("ts_unix", `Float (Time_compat.now ()));
           ]
       in
-      let legacy_sse_json =
-        `Assoc
-          [
-            ("type", `String "room_truth_snapshot");
-            ("payload", snapshot);
-            ("ts_unix", `Float (Time_compat.now ()));
-          ]
-      in
       Sse.broadcast_to Observers namespace_sse_json;
       Sse.broadcast_to Observers namespace_alias_sse_json;
-      Sse.broadcast_to Observers legacy_sse_json;
       (* Snapshot broadcasts are normal dashboard fanout. The cache/update
          failures around this path are logged separately. *)
       Log.Dashboard.routine "project-snapshot pushed via SSE"

--- a/lib/server/server_dashboard_http_namespace_truth.mli
+++ b/lib/server/server_dashboard_http_namespace_truth.mli
@@ -92,14 +92,13 @@ val broadcast_namespace_truth_snapshot :
 (** [broadcast_namespace_truth_snapshot state] dedup-broadcasts the
     current snapshot to all Observer SSE sessions.
 
-    Three SSE channels emitted per broadcast (snapshot payload
+    Two SSE channels emitted per broadcast (snapshot payload
     identical):
 
     | [type] field | Stream alias |
     | --- | --- |
     | ["project_snapshot"] | canonical |
     | ["namespace_truth_snapshot"] | alias for namespace dashboards |
-    | ["room_truth_snapshot"] | legacy compatibility |
 
     Dedup: SHA-256 of the serialized snapshot (with [generated_at]
     stripped recursively before hashing).  When the hash matches the

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -250,7 +250,7 @@ let valid_dashboard_slice = function
   | _ -> false
 
 let dashboard_slice_for_sse_type = function
-  | "project_snapshot" | "namespace_truth_snapshot" | "room_truth_snapshot" ->
+  | "project_snapshot" | "namespace_truth_snapshot" ->
       Some "namespace"
   | "execution_snapshot" ->
       Some "execution"

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -140,14 +140,12 @@ let dashboard_doctor_degraded_json ~self_bin ~exn =
                 ; "kind", `String "config"
                 ; "exit_code", `Int 2
                 ; ( "payload"
-                  , `Assoc
+                  , Tool_args.error_assoc
                       [ "title", `String "Dashboard Doctor Route"
-                      ; "status", `String "error"
                       ; ( "checks"
                         , `List
-                            [ `Assoc
+                            [ Tool_args.error_assoc
                                 [ "name", `String "self-binary"
-                                ; "status", `String "error"
                                 ; "message", `String message
                                 ; "path", `String self_bin
                                 ] ] )

--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -19,17 +19,17 @@
 # lib/bounded_proc/bounded_proc.ml:17  — the canonical helper itself.
 lib/bounded_proc/bounded_proc.ml:17
 
-# lib/process/process_eio.ml:504, 535 — `spawn_and_drain_{stdout,both}`.
+# lib/process/process_eio.ml:459, 490 — `spawn_and_drain_{stdout,both}`.
 # Private functions. Every caller (run_argv*, run_argv_with_status*,
 # run_argv_with_stdin*) wraps in `Eio.Time.with_timeout_exn clk timeout_sec`
 # + `Eio.Switch.run` and the process-wide spawn guard.
-lib/process/process_eio.ml:504
-lib/process/process_eio.ml:535
+lib/process/process_eio.ml:459
+lib/process/process_eio.ml:490
 
-# lib/process/process_eio.ml:942 — native pipeline stage spawn. Wrapped in
+# lib/process/process_eio.ml:897 — native pipeline stage spawn. Wrapped in
 # Eio.Time.with_timeout_exn + fresh Eio.Switch.run inside
 # run_argv_pipeline_with_status_split.
-lib/process/process_eio.ml:942
+lib/process/process_eio.ml:897
 
 # lib/server/lsp_process_manager.ml:178 — LSP child process. Lifetime is
 # bound to the LSP session switch; idle eviction handled by the LSP


### PR DESCRIPTION
## Summary
- stop broadcasting the legacy room_truth_snapshot SSE alias
- remove room_truth_snapshot from dashboard SSE type/schema hydration paths
- update the system event inventory to mark the alias removed

## Verification
- opam exec -- ocamlformat --check lib/server/server_dashboard_http_namespace_truth.ml lib/server/server_dashboard_http_namespace_truth.mli lib/server/server_mcp_transport_ws.ml
- git diff --check
- scripts/dune-local.sh build test/test_dashboard_namespace_truth.exe test/test_ws_transport.exe
- ./_build/default/test/test_dashboard_namespace_truth.exe
- ./_build/default/test/test_ws_transport.exe
- bash scripts/check-doc-truth.sh
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build lib/masc_mcp.cma
- rg -n "room_truth_snapshot|legacy_sse_json" lib dashboard/src test docs scripts

## Notes
- pnpm --dir dashboard typecheck could not run cleanly in this fresh worktree because dashboard/node_modules is absent; even using the root tsc binary fails dependency resolution for vitest/preact/valibot/etc. CI should run with installed dashboard deps.
