### PR TITLE
Run local review script tests with argv

### DIFF
--- a/test/test_local_review_script.ml
+++ b/test/test_local_review_script.ml
@@ -8,8 +8,6 @@ let source_root () =
 let script_path () =
   Filename.concat (source_root ()) "scripts/review/local-review.sh"
 
-let quote = Filename.quote
-
 let read_file path =
   In_channel.with_open_bin path In_channel.input_all
 
@@ -41,48 +39,63 @@ let with_temp_dir prefix f =
   Unix.mkdir dir 0o755;
   Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
 
-let run_shell ?(env = []) ~cwd cmd =
-  let env_prefix =
-    env
-    |> List.map (fun (k, v) -> Printf.sprintf "%s=%s" k (quote v))
-    |> String.concat " "
-  in
-  let full =
-    if env_prefix = "" then
-      Printf.sprintf "cd %s && %s" (quote cwd) cmd
-    else
-      Printf.sprintf "cd %s && %s %s" (quote cwd) env_prefix cmd
-  in
+let env_array overrides =
+  let table = Hashtbl.create 64 in
+  Unix.environment ()
+  |> Array.iter (fun entry ->
+         match String.index_opt entry '=' with
+         | None -> ()
+         | Some idx ->
+             let key = String.sub entry 0 idx in
+             let value =
+               String.sub entry (idx + 1) (String.length entry - idx - 1)
+             in
+             Hashtbl.replace table key value);
+  List.iter (fun (key, value) -> Hashtbl.replace table key value) overrides;
+  Hashtbl.fold
+    (fun key value acc -> Printf.sprintf "%s=%s" key value :: acc)
+    table []
+  |> Array.of_list
+
+let run_process ?(env = []) ~cwd prog argv =
   let out = Filename.temp_file "local-review-out" ".txt" in
   let err = Filename.temp_file "local-review-err" ".txt" in
-  let wrapped =
-    Printf.sprintf "%s > %s 2> %s" full (quote out) (quote err)
+  let out_fd = Unix.openfile out [ Unix.O_WRONLY; Unix.O_TRUNC ] 0o600 in
+  let err_fd = Unix.openfile err [ Unix.O_WRONLY; Unix.O_TRUNC ] 0o600 in
+  let original_cwd = Sys.getcwd () in
+  let pid =
+    Fun.protect
+      ~finally:(fun () ->
+        Sys.chdir original_cwd;
+        Unix.close out_fd;
+        Unix.close err_fd)
+      (fun () ->
+        Sys.chdir cwd;
+        Unix.create_process_env prog argv (env_array env) Unix.stdin out_fd
+          err_fd)
   in
-  let code = Sys.command wrapped in
+  let _, status = Unix.waitpid [] pid in
+  let code =
+    match status with
+    | Unix.WEXITED code -> code
+    | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> 255
+  in
   let stdout = read_file out in
   let stderr = read_file err in
   Sys.remove out;
   Sys.remove err;
   (code, stdout, stderr)
 
-let run_shell_ok ?(env = []) ~cwd cmd =
-  let code, stdout, stderr = run_shell ~env ~cwd cmd in
+let run_process_ok ?(env = []) ~cwd prog argv =
+  let code, stdout, stderr = run_process ~env ~cwd prog argv in
   if code <> 0 then
-    failf "command failed (%d): %s\n%s" code cmd stderr;
+    failf "command failed (%d): %s\n%s" code prog stderr;
   (stdout, stderr)
 
-let spawn_shell ?(env = []) ~cwd cmd =
-  let env_prefix =
-    env
-    |> List.map (fun (k, v) -> Printf.sprintf "%s=%s" k (quote v))
-    |> String.concat " "
-  in
-  let full =
-    if env_prefix = "" then
-      Printf.sprintf "cd %s && %s" (quote cwd) cmd
-    else
-      Printf.sprintf "cd %s && %s %s" (quote cwd) env_prefix cmd
-  in
+let git_ok ~cwd args =
+  ignore (run_process_ok ~cwd "git" (Array.of_list ("git" :: args)))
+
+let spawn_process ?(env = []) ~cwd prog argv =
   let out = Filename.temp_file "local-review-out" ".txt" in
   let err = Filename.temp_file "local-review-err" ".txt" in
   let out_fd =
@@ -91,12 +104,18 @@ let spawn_shell ?(env = []) ~cwd cmd =
   let err_fd =
     Unix.openfile err [ Unix.O_CREAT; Unix.O_TRUNC; Unix.O_WRONLY ] 0o644
   in
+  let original_cwd = Sys.getcwd () in
   let pid =
-    Unix.create_process "/bin/sh" [| "/bin/sh"; "-lc"; full |] Unix.stdin out_fd
-      err_fd
+    Fun.protect
+      ~finally:(fun () ->
+        Sys.chdir original_cwd;
+        Unix.close out_fd;
+        Unix.close err_fd)
+      (fun () ->
+        Sys.chdir cwd;
+        Unix.create_process_env prog argv (env_array env) Unix.stdin out_fd
+          err_fd)
   in
-  Unix.close out_fd;
-  Unix.close err_fd;
   (pid, out, err)
 
 let wait_process (pid, out, err) =
@@ -112,28 +131,32 @@ let wait_process (pid, out, err) =
   Sys.remove err;
   (code, stdout, stderr)
 
-let command_output ~cwd cmd =
-  let stdout, _stderr = run_shell_ok ~cwd cmd in
+let command_output ~cwd prog argv =
+  let stdout, _stderr = run_process_ok ~cwd prog argv in
   String.trim stdout
 
 let init_repo dir =
-  ignore (run_shell_ok ~cwd:dir "git init -q");
-  ignore (run_shell_ok ~cwd:dir "git config user.email test@example.com");
-  ignore (run_shell_ok ~cwd:dir "git config user.name tester");
+  git_ok ~cwd:dir [ "init"; "-q" ];
+  git_ok ~cwd:dir [ "config"; "user.email"; "test@example.com" ];
+  git_ok ~cwd:dir [ "config"; "user.name"; "tester" ];
   write_file (Filename.concat dir "alpha.txt") "alpha base\n";
   write_file (Filename.concat dir "beta.txt") "beta base\n";
-  ignore
-    (run_shell_ok ~cwd:dir
-       "git add alpha.txt beta.txt && git -c core.hooksPath=/dev/null commit -q -m base");
-  let base_sha = command_output ~cwd:dir "git rev-parse HEAD" in
+  git_ok ~cwd:dir [ "add"; "alpha.txt"; "beta.txt" ];
+  git_ok ~cwd:dir
+    [ "-c"; "core.hooksPath=/dev/null"; "commit"; "-q"; "-m"; "base" ];
+  let base_sha =
+    command_output ~cwd:dir "git" [| "git"; "rev-parse"; "HEAD" |]
+  in
   write_file (Filename.concat dir "alpha.txt")
     "alpha changed once\nalpha changed twice\n";
   write_file (Filename.concat dir "beta.txt")
     "beta changed once\nbeta changed twice\n";
-  ignore
-    (run_shell_ok ~cwd:dir
-       "git add alpha.txt beta.txt && git -c core.hooksPath=/dev/null commit -q -m head");
-  let head_sha = command_output ~cwd:dir "git rev-parse HEAD" in
+  git_ok ~cwd:dir [ "add"; "alpha.txt"; "beta.txt" ];
+  git_ok ~cwd:dir
+    [ "-c"; "core.hooksPath=/dev/null"; "commit"; "-q"; "-m"; "head" ];
+  let head_sha =
+    command_output ~cwd:dir "git" [| "git"; "rev-parse"; "HEAD" |]
+  in
   (base_sha, head_sha)
 
 let make_fake_reviewer dir =
@@ -163,17 +186,16 @@ printf '%s\n' "${FAKE_REVIEW_OUTPUT:-No findings.}"
 let parse_json_output stdout =
   Yojson.Safe.from_string stdout
 
-let review_cmd script base_sha head_sha =
-  String.concat " "
-    [
-      quote script;
-      "--base";
-      quote base_sha;
-      "--head";
-      quote head_sha;
-      "--format";
-      "json";
-    ]
+let review_argv script base_sha head_sha =
+  [| script; "--base"; base_sha; "--head"; head_sha; "--format"; "json" |]
+
+let run_review ?(env = []) ~cwd base_sha head_sha =
+  let script = script_path () in
+  run_process ~cwd ~env script (review_argv script base_sha head_sha)
+
+let spawn_review ?(env = []) ~cwd base_sha head_sha =
+  let script = script_path () in
+  spawn_process ~cwd ~env script (review_argv script base_sha head_sha)
 
 let test_cache_hit_and_chunking () =
   with_temp_dir "local-review-cache-test" (fun dir ->
@@ -190,7 +212,7 @@ let test_cache_hit_and_chunking () =
         ]
       in
       let code1, stdout1, stderr1 =
-        run_shell ~cwd:dir ~env (review_cmd (script_path ()) base_sha head_sha)
+        run_review ~cwd:dir ~env base_sha head_sha
       in
       if code1 <> 0 then
         failf "first run failed (%d): %s" code1 stderr1;
@@ -208,7 +230,7 @@ let test_cache_hit_and_chunking () =
         (string_of_int chunk_count) (read_file count_file);
 
       let code2, stdout2, stderr2 =
-        run_shell ~cwd:dir ~env (review_cmd (script_path ()) base_sha head_sha)
+        run_review ~cwd:dir ~env base_sha head_sha
       in
       if code2 <> 0 then
         failf "second run failed (%d): %s" code2 stderr2;
@@ -234,10 +256,9 @@ let test_single_flight_reuses_pending_worker () =
           ("MASC_LOCAL_REVIEW_STALE_SECS", "30");
         ]
       in
-      let cmd = review_cmd (script_path ()) base_sha head_sha in
-      let p1 = spawn_shell ~cwd:dir ~env cmd in
+      let p1 = spawn_review ~cwd:dir ~env base_sha head_sha in
       ignore (Unix.select [] [] [] 0.2);
-      let p2 = spawn_shell ~cwd:dir ~env cmd in
+      let p2 = spawn_review ~cwd:dir ~env base_sha head_sha in
       let code1, stdout1, stderr1 = wait_process p1 in
       let code2, stdout2, stderr2 = wait_process p2 in
       if code1 <> 0 then failf "first process failed (%d): %s" code1 stderr1;
@@ -267,18 +288,18 @@ let test_stale_pending_is_reaped () =
           ("MASC_LOCAL_REVIEW_STALE_SECS", "1");
         ]
       in
-      let key_cmd =
-        String.concat " "
-          [
-            quote (script_path ());
+      let script = script_path () in
+      let cache_key =
+        command_output ~cwd:dir script
+          [|
+            script;
             "--base";
-            quote base_sha;
+            base_sha;
             "--head";
-            quote head_sha;
+            head_sha;
             "--print-cache-key";
-          ]
+          |]
       in
-      let cache_key = command_output ~cwd:dir key_cmd in
       let lock_dir =
         Filename.concat cache_dir (Filename.concat "locks" (cache_key ^ ".lock"))
       in
@@ -293,7 +314,7 @@ let test_stale_pending_is_reaped () =
       write_file pending_file
         {|{"pid":999999,"started_at_epoch":1,"started_at":"1970-01-01T00:00:01Z"}|};
       let code, stdout, stderr =
-        run_shell ~cwd:dir ~env (review_cmd (script_path ()) base_sha head_sha)
+        run_review ~cwd:dir ~env base_sha head_sha
       in
       if code <> 0 then failf "stale reap run failed (%d): %s" code stderr;
       let open Yojson.Safe.Util in
@@ -310,10 +331,8 @@ let test_default_cache_dir_shared_across_worktrees () =
       let fake = make_fake_reviewer dir in
       let count_file = Filename.concat dir "count.txt" in
       let worktree_dir = Filename.concat dir "wt-review" in
-      ignore
-        (run_shell_ok ~cwd:dir
-           (Printf.sprintf "git worktree add -q %s -b review-cache-branch"
-              (quote worktree_dir)));
+      git_ok ~cwd:dir
+        [ "worktree"; "add"; "-q"; worktree_dir; "-b"; "review-cache-branch" ];
       let env =
         [
           ("MASC_LOCAL_REVIEW_COMMAND", fake);
@@ -321,8 +340,9 @@ let test_default_cache_dir_shared_across_worktrees () =
           ("MASC_LOCAL_REVIEW_CHUNK_BYTES", "20");
         ]
       in
-      let cmd = review_cmd (script_path ()) base_sha head_sha in
-      let code1, stdout1, stderr1 = run_shell ~cwd:dir ~env cmd in
+      let code1, stdout1, stderr1 =
+        run_review ~cwd:dir ~env base_sha head_sha
+      in
       if code1 <> 0 then
         failf "root run failed (%d): %s" code1 stderr1;
       let json1 = parse_json_output stdout1 in
@@ -332,7 +352,9 @@ let test_default_cache_dir_shared_across_worktrees () =
         (json1 |> member "cache_hit" |> to_bool);
       check string "root run reviewer calls" (string_of_int chunk_count)
         (read_file count_file);
-      let code2, stdout2, stderr2 = run_shell ~cwd:worktree_dir ~env cmd in
+      let code2, stdout2, stderr2 =
+        run_review ~cwd:worktree_dir ~env base_sha head_sha
+      in
       if code2 <> 0 then
         failf "worktree run failed (%d): %s" code2 stderr2;
       let json2 = parse_json_output stdout2 in


### PR DESCRIPTION
## Summary
- replace test_local_review_script shell wrappers with argv-based process execution
- run git setup and local-review.sh through explicit argv arrays
- preserve the concurrent single-flight test with argv-based spawned processes

## Verification
- ocamlformat --check test/test_local_review_script.ml
- git diff --check
- targeted dangerous-pattern rg on test/test_local_review_script.ml
- scripts/dune-local.sh build test/test_local_review_script.exe blocked by live bare Dune processes from other sessions