### PR TITLE
refactor(dashboard): retire room truth alias

### DIFF
--- a/lib/server/server_dashboard_http_namespace_truth.mli
+++ b/lib/server/server_dashboard_http_namespace_truth.mli
@@ -28,9 +28,8 @@ val dashboard_namespace_truth_http_json :
 
     All responses, including cold-start, carry top-level
     [dashboard_surface], [dashboard_aliases], [source], [retention],
-    and [generated_at_iso] fields so legacy aliases such as
-    [/dashboard/room-truth] remain visibly tied to the canonical
-    namespace-truth read model.
+    and [generated_at_iso] fields tied to the canonical namespace-truth
+    read model.
 
     Cold-start fast-path: when the proactive
     {!Server_dashboard_http_execution_surfaces.execution_cache} has

--- a/lib/server/server_dashboard_http_namespace_truth_support.ml
+++ b/lib/server/server_dashboard_http_namespace_truth_support.ml
@@ -371,7 +371,6 @@ let namespace_truth_source = "namespace_truth_read_model"
 let namespace_truth_aliases =
   [
     "/api/v1/dashboard/project-snapshot";
-    "/api/v1/dashboard/room-truth";
   ]
 
 let namespace_truth_aliases_json () =

--- a/lib/server/server_dashboard_snapshot_select.mli
+++ b/lib/server/server_dashboard_snapshot_select.mli
@@ -2,7 +2,7 @@
 
     Steps 1+2+3 published a [Dashboard_snapshot]-first read path for
     four projections: [/shell], [/tools], [/telemetry/summary], and
-    [/project-snapshot] (+ aliases [/namespace-truth], [/room-truth]).
+    [/project-snapshot] (+ alias [/namespace-truth]).
     Step 5 of the migration sequence renamed this module from
     [Server_dashboard_shell_snapshot] to [Server_dashboard_snapshot_select]
     and retired [Dashboard_cache] from the cold-start fallback in
@@ -87,7 +87,7 @@ val select_project_snapshot_json :
   Httpun.Request.t ->
   Yojson.Safe.t
 (** RFC-0138 Phase 3 Step 3 — /project-snapshot (+ alias
-    /namespace-truth, /room-truth) read path selector.
+    /namespace-truth) read path selector.
 
     Returns [Dashboard_snapshot.current ()].namespace_truth when the
     refresh fiber has populated it (refresh_loop must be invoked with

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -699,8 +699,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
                       ~extra_headers:cors))
 
       | `GET, "/api/v1/dashboard/project-snapshot"
-      | `GET, "/api/v1/dashboard/namespace-truth"
-      | `GET, "/api/v1/dashboard/room-truth" ->
+      | `GET, "/api/v1/dashboard/namespace-truth" ->
           with_h2_public_read h2_reqd (fun state ->
             let json =
               (* RFC-0138 Phase 3 Step 3 follow-up — route H/2 gateway

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -481,22 +481,6 @@ let rec add_routes ~sw ~clock router =
            ~extra_headers:(Server_timing.extra_header timing)
            (Yojson.Safe.to_string json) reqd
        ) request reqd)
-  |> Http.Router.get "/api/v1/dashboard/room-truth" (fun request reqd ->
-       with_public_read (fun state req reqd ->
-         let timing = Server_timing.create () in
-         (* RFC-0138 Phase 3 Step 3: wait-free read via
-            [Dashboard_snapshot.current ()].namespace_truth when the
-            refresh fiber has populated it.  Cold start (or refresh
-            spawned without ~state) falls through to the synchronous
-            namespace-truth path inside the timing measurement. *)
-         let json =
-           Server_dashboard_snapshot_select.select_project_snapshot_json
-             ~state ~sw ~clock ~timing req
-         in
-         Http.Response.json ~compress:true ~request:req
-           ~extra_headers:(Server_timing.extra_header timing)
-           (Yojson.Safe.to_string json) reqd
-       ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/execution" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json = dashboard_execution_http_json ~state ~sw ~clock request in

--- a/scripts/harness_dashboard_mission_smoke.sh
+++ b/scripts/harness_dashboard_mission_smoke.sh
@@ -304,7 +304,7 @@ async function mcpCall(name, args) {
   });
 
   log('operator digest probe');
-  const missionJsonResult = await mcpCall('masc_operator_digest', { actor: 'mission-smoke', target_type: 'room' });
+  const missionJsonResult = await mcpCall('masc_operator_digest', { actor: 'mission-smoke', target_type: 'root' });
   checks.push({
     name: 'operator digest remains callable during smoke',
     pass: !!missionJsonResult,

--- a/scripts/verify-dashboard.sh
+++ b/scripts/verify-dashboard.sh
@@ -160,13 +160,7 @@ check_json_eventually \
 check_json \
   "namespace-truth exposes provenance" \
   "$BASE/api/v1/dashboard/namespace-truth" \
-  "d.get('dashboard_surface') == '/api/v1/dashboard/namespace-truth' and d.get('source') == 'namespace_truth_read_model' and '/api/v1/dashboard/room-truth' in d.get('dashboard_aliases', []) and d.get('retention', {}).get('scope') == 'dashboard_namespace_truth'" \
-  '^True$'
-check_http "room-truth 200" "$BASE/api/v1/dashboard/room-truth" "200"
-check_json \
-  "room-truth exposes namespace alias provenance" \
-  "$BASE/api/v1/dashboard/room-truth" \
-  "d.get('dashboard_surface') == '/api/v1/dashboard/namespace-truth' and d.get('source') == 'namespace_truth_read_model' and '/api/v1/dashboard/room-truth' in d.get('dashboard_aliases', []) and d.get('retention', {}).get('scope') == 'dashboard_namespace_truth'" \
+  "d.get('dashboard_surface') == '/api/v1/dashboard/namespace-truth' and d.get('source') == 'namespace_truth_read_model' and '/api/v1/dashboard/room-truth' not in d.get('dashboard_aliases', []) and d.get('retention', {}).get('scope') == 'dashboard_namespace_truth'" \
   '^True$'
 check_http "goal-loop status 200" "$BASE/api/v1/dashboard/goal-loop/status" "200"
 check_json "goal-loop status exposes phases" "$BASE/api/v1/dashboard/goal-loop/status" "'overall_status' in d and 'phases' in d" '^True$'

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1780,16 +1780,19 @@ let test_input_validation_contracts () =
        "maybe_evict_expired config")
 
 let test_room_current_validation_contracts () =
-  (* H2 gateway serves canonical namespace routes and keeps temporary room
-     aliases so mixed dashboard/backend deployments do not break during rollout. *)
+  (* H2 gateway serves canonical namespace routes; the dashboard room-truth
+     alias is retired so mixed wording cannot become a second surface. *)
   check bool "h2 gateway serves project-snapshot endpoint" true
     (file_contains_pattern "lib/server/server_h2_gateway.ml"
        {|"/api/v1/dashboard/project-snapshot"|});
   check bool "h2 gateway serves namespace-truth endpoint alias" true
     (file_contains_pattern "lib/server/server_h2_gateway.ml"
        {|"/api/v1/dashboard/namespace-truth"|});
-  check bool "h2 gateway keeps room-truth alias endpoint during rollout" true
-    (file_contains_pattern "lib/server/server_h2_gateway.ml"
+  check bool "h2 gateway does not serve retired room-truth alias" true
+    (file_not_contains_pattern "lib/server/server_h2_gateway.ml"
+       {|"/api/v1/dashboard/room-truth"|});
+  check bool "http router does not serve retired room-truth alias" true
+    (file_not_contains_pattern "lib/server/server_routes_http_routes_dashboard.ml"
        {|"/api/v1/dashboard/room-truth"|});
   check bool "h2 gateway serves namespace current endpoint" true
     (file_contains_pattern "lib/server/server_h2_gateway.ml"

--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -181,11 +181,11 @@ let test_dashboard_namespace_truth_empty_room () =
           (match json |> member "generated_at_iso" with
           | `String value -> String.length value > 0
           | _ -> false);
-        check bool "room-truth alias advertised"
-          true
+        check bool "room-truth alias retired"
+          false
           (json |> member "dashboard_aliases" |> to_list
-          |> List.map to_string
-          |> List.mem "/api/v1/dashboard/room-truth");
+           |> List.map to_string
+           |> List.mem "/api/v1/dashboard/room-truth");
         check bool "readiness status exposed"
           true
           (String.length (json |> member "readiness" |> member "status" |> to_string) > 0);


### PR DESCRIPTION
## Summary
- remove the duplicate /api/v1/dashboard/room-truth read surface from HTTP/1 and HTTP/2 routing
- stop advertising room-truth in namespace-truth dashboard_aliases
- update dashboard verification and mission smoke to use canonical namespace/root surfaces

## Validation
- ocamlformat --check lib/server/server_dashboard_http_namespace_truth_support.ml lib/server/server_routes_http_routes_dashboard.ml lib/server/server_h2_gateway.ml lib/server/server_dashboard_snapshot_select.mli lib/server/server_dashboard_http_namespace_truth.mli test/test_dashboard_namespace_truth.ml test/test_ci_hardening_source.ml
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- bash -n scripts/verify-dashboard.sh scripts/harness_dashboard_mission_smoke.sh

## Note
- Focused dune build for test/test_dashboard_namespace_truth.exe and test/test_ci_hardening_source.exe was attempted, but local machine-wide Dune lock stayed held by another worktree, so compile validation is deferred to CI.