### PR TITLE
Fix variant checker phase SSOT

### DIFF
--- a/scripts/check-variants.sh
+++ b/scripts/check-variants.sh
@@ -131,7 +131,7 @@ check_pair() {
 
 echo "=== Check 1: KeeperStateMachine.phase (OCaml) vs KeeperPhase (TypeScript) ==="
 
-KSM_ML="lib/keeper/keeper_state_machine.ml"
+KSM_ML="lib/keeper/keeper_state_machine_phase.ml"
 KP_TS="dashboard/src/types/core.ts"
 
 if [ -f "$KSM_ML" ] && [ -f "$KP_TS" ]; then


### PR DESCRIPTION
## Summary
- point check-variants at the extracted Keeper state-machine phase SSOT
- stop the checker from scanning the parent alias module and mixing unrelated constructors into the phase set

## Verification
- scripts/check-variants.sh
- git diff --check