### PR TITLE
refactor(streamable-http): drop unreachable batch response

### DIFF
--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -577,19 +577,6 @@ let mcp_post_handler
           let response = Httpun.Response.create ~headers `OK in
           safe_respond_with_string reqd response json_str
 
-      | Streamable_http.Json_batch jsons ->
-          let json_str = Yojson.Safe.to_string (`List jsons) in
-          let extra_headers = match session_opt with
-            | Some s -> Streamable_http.with_session_header s []
-            | None -> []
-          in
-          let headers = Httpun.Headers.of_list ([
-            ("content-type", "application/json");
-            ("content-length", string_of_int (String.length json_str));
-          ] @ extra_headers) in
-          let response = Httpun.Response.create ~headers `OK in
-          safe_respond_with_string reqd response json_str
-
       | Streamable_http.Sse_upgrade ->
           Response.text ~status:`Not_implemented
             "SSE upgrade is not supported on this transport" reqd

--- a/lib/streamable_http.ml
+++ b/lib/streamable_http.ml
@@ -20,7 +20,6 @@ type session = {
 
 type response_mode =
   | Json_response of Yojson.Safe.t
-  | Json_batch of Yojson.Safe.t list
   | Sse_upgrade
   | Error_response of int * string
 

--- a/lib/streamable_http.mli
+++ b/lib/streamable_http.mli
@@ -45,7 +45,6 @@ end
 (** Response modes for /mcp endpoint *)
 type response_mode =
   | Json_response of Yojson.Safe.t       (** Single JSON-RPC response *)
-  | Json_batch of Yojson.Safe.t list     (** Deprecated compatibility constructor; new requests should not use batch *)
   | Sse_upgrade                          (** Upgrade to SSE stream *)
   | Error_response of int * string       (** HTTP error (status, message) *)
 


### PR DESCRIPTION
## Summary
- remove the deprecated Json_batch response_mode constructor
- delete the unreachable HTTP response branch for JSON-RPC batch success responses
- keep existing behavior where JSON-RPC batch payloads are rejected with 400

## Validation
- ocamlformat --check lib/streamable_http.mli lib/streamable_http.ml lib/http_server_eio.ml
- git diff --check
- scripts/ocaml-structure-ratchet.sh

## Note
- Focused dune build for test/test_streamable_http.exe test/test_http_server_eio.exe test/test_mcp_protocol_coverage.exe was attempted, but the local machine-wide Dune lock stayed held by another worktree for over 2 minutes, so compile validation is deferred to CI.