### PR TITLE
fix(ci): point variant guard at phase ssot

### DIFF
--- a/scripts/check-variants.sh
+++ b/scripts/check-variants.sh
@@ -127,11 +127,11 @@ check_pair() {
   fi
 }
 
-# ── Check 1: Keeper_state_machine.phase (OCaml) vs KeeperPhase (TypeScript) ──
+# ── Check 1: Keeper_state_machine_phase.phase (OCaml) vs KeeperPhase (TypeScript) ──
 
 echo "=== Check 1: KeeperStateMachine.phase (OCaml) vs KeeperPhase (TypeScript) ==="
 
-KSM_ML="lib/keeper/keeper_state_machine.ml"
+KSM_ML="lib/keeper/keeper_state_machine_phase.ml"
 KP_TS="dashboard/src/types/core.ts"
 
 if [ -f "$KSM_ML" ] && [ -f "$KP_TS" ]; then


### PR DESCRIPTION
## Summary
- fix Meta Guards variant check to read the phase list from keeper_state_machine_phase.ml
- keep the existing OCaml KeeperPhase vs TypeScript KeeperPhase comparison intact

Fixes #17548.

## Verification
- bash scripts/check-variants.sh
- git diff --check