### PR TITLE
fix(exec): bound buffered shell ir pipeline timeout

### DIFF
--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -1,8 +1,8 @@
 (* P7: Pipeline-Native Dispatch
    Execute Shell_ir.t directly via Exec_gate without going through
-   /bin/bash.  Simple commands use argv-based spawn; pipelines chain
-   stdout->stdin across stages.  Pipeline support is limited to
-   stdout->stdin chaining. *)
+   /bin/bash. Simple commands use argv-based spawn. Redirect-free host
+   and Docker pipelines use streaming process pipes; unsupported shapes
+   fall back to deterministic stdout->stdin chaining. *)
 
 type dispatch_result = {
   status : Unix.process_status;
@@ -88,6 +88,10 @@ let unsupported_redirect_result message =
 
 let status_is_success = function
   | Unix.WEXITED 0 -> true
+  | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> false
+
+let status_is_timeout = function
+  | Unix.WEXITED 124 -> true
   | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> false
 
 let pipeline_status current stage_status =
@@ -204,6 +208,22 @@ let dispatch_simple ?timeout_sec ?stdin_content (s : Shell_ir.simple) =
 
 let invalid_pipeline stderr = { status = Unix.WEXITED 1; stdout = ""; stderr }
 
+let pipeline_timeout_result ~timeout_sec =
+  { status = Unix.WEXITED 124
+  ; stdout = ""
+  ; stderr = Printf.sprintf "pipeline timed out after %.3fs" timeout_sec
+  }
+
+let dispatch_simple_before_deadline ?stdin_content ~deadline ~pipeline_timeout_sec s =
+  let remaining_timeout_sec = deadline -. Unix.gettimeofday () in
+  if remaining_timeout_sec <= 0.0
+  then pipeline_timeout_result ~timeout_sec:pipeline_timeout_sec
+  else
+    dispatch_simple
+      ~timeout_sec:remaining_timeout_sec
+      ?stdin_content
+      s
+
 let host_pipeline_specs stages =
   let rec loop acc = function
     | [] -> Some (List.rev acc)
@@ -222,22 +242,32 @@ let host_pipeline_specs stages =
   loop [] stages
 
 let docker_pipeline_specs stages =
-  let rec loop pipeline_runner acc = function
+  let rec loop pipeline_runner sandbox_target acc = function
     | [] -> Option.map (fun runner -> runner, List.rev acc) pipeline_runner
     | Shell_ir.Simple simple :: rest ->
+        let same_sandbox_target =
+          match sandbox_target with
+          | None -> true
+          | Some first_target -> simple.sandbox == first_target
+        in
         (match simple.sandbox with
-         | Docker { pipeline_runner = Some runner; _ } when simple.redirects = [] ->
+         | Docker { pipeline_runner = Some runner; _ }
+           when simple.redirects = [] && same_sandbox_target ->
              let argv, env, cwd = process_spec_of_simple simple in
              let stage : Sandbox_target.pipeline_stage = { argv; env; cwd } in
              let pipeline_runner = Option.value pipeline_runner ~default:runner in
-             loop (Some pipeline_runner) (stage :: acc) rest
+             let sandbox_target =
+               Option.value sandbox_target ~default:simple.sandbox
+             in
+             loop (Some pipeline_runner) (Some sandbox_target) (stage :: acc) rest
          | _ -> None)
         [@warning "-4"]
     | Shell_ir.Pipeline _ :: _ -> None
   in
-  loop None [] stages
+  loop None None [] stages
 
 let rec dispatch_pipeline ?timeout_sec stages =
+  let pipeline_timeout_sec = dispatch_timeout_sec timeout_sec in
   match stages with
   | [] ->
       invalid_pipeline "empty pipeline not supported in native dispatch"
@@ -256,7 +286,7 @@ let rec dispatch_pipeline ?timeout_sec stages =
                ~actor:`Tool_local_runtime
                ~raw_source
                ~summary:"exec dispatch pipeline"
-               ~timeout_sec:(dispatch_timeout_sec timeout_sec)
+               ~timeout_sec:pipeline_timeout_sec
                specs
            in
            { status; stdout; stderr }
@@ -264,23 +294,31 @@ let rec dispatch_pipeline ?timeout_sec stages =
            match docker_pipeline_specs stages with
            | Some (runner, specs) ->
                let status, stdout, stderr =
-                 runner ~stages:specs ~timeout_sec:(dispatch_timeout_sec timeout_sec)
+                 runner ~stages:specs ~timeout_sec:pipeline_timeout_sec
                in
                { status; stdout; stderr }
            | None ->
+               let deadline = Unix.gettimeofday () +. pipeline_timeout_sec in
                let rec chain ~prev_stdout ~status ~stderr = function
                  | [] -> { status; stdout = prev_stdout; stderr }
                  | Shell_ir.Simple s :: rest ->
                      let stage_result =
-                       dispatch_simple ?timeout_sec ~stdin_content:prev_stdout s
+                       dispatch_simple_before_deadline
+                         ~stdin_content:prev_stdout
+                         ~deadline
+                         ~pipeline_timeout_sec
+                         s
                      in
                      let status = pipeline_status status stage_result.status in
                      let stderr = stderr ^ stage_result.stderr in
-                     chain
-                       ~prev_stdout:stage_result.stdout
-                       ~status
-                       ~stderr
-                       rest
+                     if status_is_timeout stage_result.status
+                     then { status; stdout = stage_result.stdout; stderr }
+                     else
+                       chain
+                         ~prev_stdout:stage_result.stdout
+                         ~status
+                         ~stderr
+                         rest
                  | Pipeline _ :: _ ->
                      { status = Unix.WEXITED 1
                      ; stdout = ""
@@ -294,15 +332,27 @@ let rec dispatch_pipeline ?timeout_sec stages =
                 | first :: rest -> (
                   match first with
                   | Shell_ir.Simple s ->
-                      let first_result = dispatch_simple ?timeout_sec s in
+                      let first_result =
+                        dispatch_simple_before_deadline
+                          ~deadline
+                          ~pipeline_timeout_sec
+                          s
+                      in
                       let status =
                         pipeline_status (Unix.WEXITED 0) first_result.status
                       in
-                      chain
-                        ~prev_stdout:first_result.stdout
-                        ~status
-                        ~stderr:first_result.stderr
-                        rest
+                      if status_is_timeout first_result.status
+                      then
+                        { status
+                        ; stdout = first_result.stdout
+                        ; stderr = first_result.stderr
+                        }
+                      else
+                        chain
+                          ~prev_stdout:first_result.stdout
+                          ~status
+                          ~stderr:first_result.stderr
+                          rest
                   | Pipeline _ ->
                       invalid_pipeline
                         "nested pipeline not supported in native dispatch" ))))

--- a/lib/exec/exec_dispatch.mli
+++ b/lib/exec/exec_dispatch.mli
@@ -10,8 +10,10 @@ val resolve_arg : Shell_ir.arg -> string
 val dispatch : ?timeout_sec:float -> Shell_ir.t -> dispatch_result
 (** Execute a [Shell_ir.t] AST directly via Exec_gate without
     going through /bin/bash.  Simple commands use argv-based spawn;
-    pipelines chain stdout to stdin across stages.  [?timeout_sec]
-    overrides the dispatch default for every spawned stage. *)
+    redirect-free host and Docker pipelines use streaming process pipes;
+    unsupported pipeline shapes fall back to stdout-to-stdin chaining.
+    [?timeout_sec] is the whole pipeline budget for both streaming and
+    fallback pipeline paths. *)
 
 val dispatch_simple :
   ?timeout_sec:float -> ?stdin_content:string -> Shell_ir.simple -> dispatch_result

--- a/test/test_exec_dispatch.ml
+++ b/test/test_exec_dispatch.ml
@@ -490,6 +490,51 @@ let () =
 	      assert (second_cwd = "/tmp/pipeline")
 	  | _ -> assert false
 
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let slow_bin = Masc_exec.Bin.of_string "slow" |> Result.get_ok in
+  let next_bin = Masc_exec.Bin.of_string "next" |> Result.get_ok in
+  let runner_calls = ref [] in
+  let mock_runner ~stdin_content ~argv ~env:_ ~cwd:_ ~timeout_sec =
+    runner_calls := (argv, stdin_content, timeout_sec) :: !runner_calls;
+    match argv, stdin_content with
+    | [ "slow" ], None ->
+        Unix.sleepf 0.12;
+        Unix.WEXITED 0, "typed", ""
+    | [ "next" ], Some "typed" ->
+        Unix.WEXITED 0, "ok", ""
+    | _ -> Unix.WEXITED 2, "", "unexpected mock runner call"
+  in
+  let docker_sandbox =
+    Masc_exec.Sandbox_target.docker ~image:"pipeline-image" ~runner:mock_runner ()
+  in
+  let stage bin =
+    Simple
+      {
+        bin;
+        args = [];
+        env = [];
+        cwd = None;
+        redirects = [];
+        sandbox = docker_sandbox;
+      }
+  in
+  let result =
+    Masc_exec.Exec_dispatch.dispatch
+      ~timeout_sec:0.5
+      (Pipeline [ stage slow_bin; stage next_bin ])
+  in
+  assert (result.status = Unix.WEXITED 0);
+  assert (result.stdout = "ok");
+  match List.rev !runner_calls with
+  | [ ([ "slow" ], None, first_timeout); ([ "next" ], Some "typed", second_timeout) ] ->
+      assert (first_timeout <= 0.5);
+      assert (first_timeout > 0.45);
+      assert (second_timeout < first_timeout);
+      assert (second_timeout < 0.45)
+  | _ -> assert false
+
 (* --- dispatch_pipeline prefers Docker streaming pipeline runner --- *)
 
 let () =
@@ -552,6 +597,79 @@ let () =
       assert (first.cwd = Some "/tmp/pipeline");
       assert (second.cwd = Some "/tmp/pipeline")
   | _ -> assert false
+
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let printf_bin = Masc_exec.Bin.of_string "printf" |> Result.get_ok in
+  let wc_bin = Masc_exec.Bin.of_string "wc" |> Result.get_ok in
+  let first_simple_calls = ref [] in
+  let second_simple_calls = ref [] in
+  let first_pipeline_called = ref false in
+  let second_pipeline_called = ref false in
+  let first_simple_runner ~stdin_content ~argv ~env:_ ~cwd:_ ~timeout_sec:_ =
+    first_simple_calls := (argv, stdin_content) :: !first_simple_calls;
+    match argv, stdin_content with
+    | [ "printf"; "typed" ], None -> Unix.WEXITED 0, "typed", ""
+    | _ -> Unix.WEXITED 2, "", "unexpected first runner call"
+  in
+  let second_simple_runner ~stdin_content ~argv ~env:_ ~cwd:_ ~timeout_sec:_ =
+    second_simple_calls := (argv, stdin_content) :: !second_simple_calls;
+    match argv, stdin_content with
+    | [ "wc"; "-c" ], Some "typed" -> Unix.WEXITED 0, "5\n", ""
+    | _ -> Unix.WEXITED 2, "", "unexpected second runner call"
+  in
+  let first_pipeline_runner ~stages:_ ~timeout_sec:_ =
+    first_pipeline_called := true;
+    Unix.WEXITED 3, "", "first pipeline runner should not be used"
+  in
+  let second_pipeline_runner ~stages:_ ~timeout_sec:_ =
+    second_pipeline_called := true;
+    Unix.WEXITED 3, "", "second pipeline runner should not be used"
+  in
+  let first_docker_sandbox =
+    Masc_exec.Sandbox_target.docker
+      ~image:"pipeline-image"
+      ~runner:first_simple_runner
+      ~pipeline_runner:first_pipeline_runner
+      ()
+  in
+  let second_docker_sandbox =
+    Masc_exec.Sandbox_target.docker
+      ~image:"pipeline-image"
+      ~runner:second_simple_runner
+      ~pipeline_runner:second_pipeline_runner
+      ()
+  in
+  let stages =
+    [
+      Simple
+        {
+          bin = printf_bin;
+          args = [ Lit "typed" ];
+          env = [];
+          cwd = None;
+          redirects = [];
+          sandbox = first_docker_sandbox;
+        };
+      Simple
+        {
+          bin = wc_bin;
+          args = [ Lit "-c" ];
+          env = [];
+          cwd = None;
+          redirects = [];
+          sandbox = second_docker_sandbox;
+        };
+    ]
+  in
+  let result = Masc_exec.Exec_dispatch.dispatch (Pipeline stages) in
+  assert (not !first_pipeline_called);
+  assert (not !second_pipeline_called);
+  assert (result.status = Unix.WEXITED 0);
+  assert (String.trim result.stdout = "5");
+  assert (!first_simple_calls = [ [ "printf"; "typed" ], None ]);
+  assert (!second_simple_calls = [ [ "wc"; "-c" ], Some "typed" ])
 
 let () =
   with_eio @@ fun () ->


### PR DESCRIPTION
## Summary
- treat dispatch pipeline timeout as a whole-pipeline budget for buffered fallback paths
- pass only the remaining deadline budget to each sequential fallback stage
- stop immediately on timeout status instead of continuing later stages after the pipeline budget is exhausted
- require Docker streaming pipelines to use the same Docker sandbox target instance; different Docker targets, even with pipeline runners, stay on buffered fallback
- refresh Exec_dispatch docs to distinguish streaming host/Docker paths from buffered fallback

## Validation
- ocamlformat --check lib/exec/exec_dispatch.ml lib/exec/exec_dispatch.mli test/test_exec_dispatch.ml
- git diff --check HEAD~1..HEAD
- env DUNE_CACHE=disabled DUNE_LOCAL_JOBS=1 MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build lib/exec/masc_exec.cma test/test_exec_dispatch.exe
- _build/default/test/test_exec_dispatch.exe

Refs #17402