### PR TITLE
fix(worker): validate Shell IR structural paths independently

### DIFF
--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -823,19 +823,29 @@ let validate_shell_ir_paths ?keeper_id ?base_path ?workdir shell_ir =
            | Error _ as err -> err)
         | Masc_exec.Redirect_scope.Fd_to_fd _ :: rest -> validate_redirects rest
       in
+      let validate_cwd = function
+        | None -> Ok ()
+        | Some cwd ->
+          Masc_exec.Path_scope.raw cwd
+          |> validate_path_value ~requires_existing_dir:true
+      in
       let validate_simple (simple : Masc_exec.Shell_ir.simple) =
         let command_name = Masc_exec.Bin.to_string simple.bin |> Filename.basename in
-        match literal_args_of_simple simple with
-        | None -> Ok ()
-        | Some args ->
-          (match
-             path_argument_values command_name args
-             |> validate_path_values ~command_name false
-           with
-           | Ok () -> validate_redirects simple.redirects
-           | Error _ as err -> err)
+        let argv_result =
+          match literal_args_of_simple simple with
+          | None -> Ok ()
+          | Some args ->
+            path_argument_values command_name args
+            |> validate_path_values ~command_name false
+        in
+        match validate_cwd simple.cwd with
+        | Error _ as err -> err
+        | Ok () ->
+        (match argv_result with
+        | Error _ as err -> err
+        | Ok () -> validate_redirects simple.redirects)
       in
-      let validate_parsed_shell_ir = function
+      let rec validate_parsed_shell_ir = function
         | Masc_exec.Shell_ir.Simple simple -> validate_simple simple
         | Masc_exec.Shell_ir.Pipeline stages ->
           let rec loop = function
@@ -844,7 +854,10 @@ let validate_shell_ir_paths ?keeper_id ?base_path ?workdir shell_ir =
               (match validate_simple simple with
                | Ok () -> loop rest
                | Error _ as err -> err)
-            | Masc_exec.Shell_ir.Pipeline _ :: _ -> Ok ()
+            | Masc_exec.Shell_ir.Pipeline nested :: rest ->
+              (match validate_parsed_shell_ir (Masc_exec.Shell_ir.Pipeline nested) with
+               | Ok () -> loop rest
+               | Error _ as err -> err)
           in
           loop stages
       in

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -1377,6 +1377,84 @@ let () =
             Alcotest.(check bool) "outside path blocked" true
               (contains_substring msg "outside allowed directories")
           | Ok () -> Alcotest.fail "outside Shell IR literal path must be blocked");
+      Alcotest.test_case
+        "Shell IR redirect target is checked even with dynamic argv"
+        `Quick
+        (fun () ->
+          let open Masc_exec.Shell_ir in
+          let bin = Masc_exec.Bin.of_string "cat" |> Result.get_ok in
+          let target =
+            Masc_exec.Path_scope.classify ~raw:"/etc/owned" ~cwd:"/tmp"
+          in
+          let ir =
+            Simple
+              { bin
+              ; args = [ Var "DYNAMIC_INPUT" ]
+              ; env = []
+              ; cwd = None
+              ; redirects =
+                  [ Masc_exec.Redirect_scope.File
+                      { fd = 1; target; mode = Masc_exec.Redirect_scope.Write }
+                  ]
+              ; sandbox = Masc_exec.Sandbox_target.host ()
+              }
+          in
+          match Worker_dev_tools.validate_shell_ir_paths ~workdir:"/tmp" ir with
+          | Error msg ->
+            Alcotest.(check bool) "outside redirect target blocked" true
+              (contains_substring msg "outside allowed directories")
+          | Ok () ->
+            Alcotest.fail
+              "outside Shell IR redirect target must be blocked even when argv is dynamic");
+      Alcotest.test_case "Shell IR cwd outside workdir is blocked"
+        `Quick
+        (fun () ->
+          let open Masc_exec.Shell_ir in
+          let bin = Masc_exec.Bin.of_string "pwd" |> Result.get_ok in
+          let cwd = Masc_exec.Path_scope.classify ~raw:"/etc" ~cwd:"/tmp" in
+          let ir =
+            Simple
+              { bin
+              ; args = []
+              ; env = []
+              ; cwd = Some cwd
+              ; redirects = []
+              ; sandbox = Masc_exec.Sandbox_target.host ()
+              }
+          in
+          match Worker_dev_tools.validate_shell_ir_paths ~workdir:"/tmp" ir with
+          | Error msg ->
+            Alcotest.(check bool) "outside cwd blocked" true
+              (contains_substring msg "outside allowed directories")
+          | Ok () -> Alcotest.fail "outside Shell IR cwd must be blocked");
+      Alcotest.test_case "nested Shell IR pipeline paths are checked"
+        `Quick
+        (fun () ->
+          let open Masc_exec.Shell_ir in
+          let cat = Masc_exec.Bin.of_string "cat" |> Result.get_ok in
+          let head = Masc_exec.Bin.of_string "head" |> Result.get_ok in
+          let simple bin args =
+            Simple
+              { bin
+              ; args = List.map (fun arg -> Lit arg) args
+              ; env = []
+              ; cwd = None
+              ; redirects = []
+              ; sandbox = Masc_exec.Sandbox_target.host ()
+              }
+          in
+          let ir =
+            Pipeline
+              [ Pipeline [ simple cat [ "/etc/passwd" ]; simple head [ "-1" ] ]
+              ; simple head [ "-1" ]
+              ]
+          in
+          match Worker_dev_tools.validate_shell_ir_paths ~workdir:"/tmp" ir with
+          | Error msg ->
+            Alcotest.(check bool) "nested outside path blocked" true
+              (contains_substring msg "outside allowed directories")
+          | Ok () ->
+            Alcotest.fail "nested Shell IR path must not bypass validation");
       Alcotest.test_case "outside literal path is blocked"
         `Quick (fun () ->
           match Worker_dev_tools.validate_command_paths


### PR DESCRIPTION
## Summary
- keep Shell IR redirect targets under path policy even when argv contains dynamic terms
- validate Shell IR cwd as an independent structural path surface before argv/redirect checks
- recurse through nested Shell IR pipelines so nested path-bearing terms cannot bypass policy
- add focused regressions for dynamic-argv redirect targets, outside cwd rejection, and nested pipeline path validation

## Verification
- ocamlformat --check lib/worker_dev_tools.ml test/test_worker_dev_tools.ml
- git diff --check
- bash scripts/lint-spawn-bounded.sh
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_worker_dev_tools.exe
- _build/default/test/test_worker_dev_tools.exe test validate_command_paths_redirect