### PR TITLE
docs(exec): update Shell IR parser contract

### DIFF
--- a/lib/exec/parser/bash.mli
+++ b/lib/exec/parser/bash.mli
@@ -2,9 +2,10 @@
 
     [parse_string s] feeds [s] through the Menhir grammar and returns
     a [Shell_ir.t Parsed.t]. The current subset accepts simple
-    commands, literal argv quoting, pipelines, fd-to-fd redirects, and
-    explicit /dev/null file redirects. Unsupported forms — env prefix,
-    general file redirect targets, $(…), heredoc, control flow —
+    commands, literal argv quoting, pipelines, leading environment
+    assignments, fd-to-fd redirects, and file redirects. Unsupported
+    forms — command substitution, process substitution, heredocs,
+    control flow, background jobs, and unsupported shell expansions —
     surface as [Parsed.Parse_error] or [Parsed.Too_complex _].
 
     The parser never raises.  Lexer [Failure], Menhir [Parser.Error],

--- a/test/fixtures/shell_gate/README.md
+++ b/test/fixtures/shell_gate/README.md
@@ -68,7 +68,8 @@ Each line is a single object:
 
 - For `reject`: see `reject_reason_tag` —
   `command_not_in_allowlist` / `pipeline_segment_disallowed` /
-  `pipes_not_allowed` / `path_outside_policy`.
+  `pipes_not_allowed` / `redirect_disallowed_in_caller` /
+  `path_outside_policy`.
 - For `cannot_parse`: see `parse_reason_tag` — `parse_error` /
   `timeout` / `depth_limit` / `token_limit`.
 - For `too_complex`: see `too_complex_reason_tag` —


### PR DESCRIPTION
## Summary
- update the public bash parser contract to match current Shell IR support for env prefixes and general file redirects
- document redirect_disallowed_in_caller in the shell gate corpus README reject tags

## Verification
- ocamlformat --check lib/exec/parser/bash.mli
- git diff --check