### PR TITLE
Remove approval strict default alias

### DIFF
--- a/lib/exec/approval_config.ml
+++ b/lib/exec/approval_config.ml
@@ -30,8 +30,6 @@ let enforced_all : agent_overlay =
     privileged_trust = Enforced;
   }
 
-let strict_default = enforced_all
-
 let permissive_default : agent_overlay =
   {
     safe_trust = Auto_safe;
@@ -39,7 +37,7 @@ let permissive_default : agent_overlay =
     privileged_trust = Enforced;
   }
 
-let empty : t = { defaults = strict_default; per_agent = [] }
+let empty : t = { defaults = enforced_all; per_agent = [] }
 
 let lookup t ~actor =
   match List.assoc_opt actor t.per_agent with

--- a/lib/exec/approval_config.mli
+++ b/lib/exec/approval_config.mli
@@ -45,15 +45,12 @@ type t = {
 val enforced_all : agent_overlay
 (** All risk classes at [Enforced].  The safest default. *)
 
-val strict_default : agent_overlay
-(** Alias for [enforced_all].  Backward-compatible name. *)
-
 val permissive_default : agent_overlay
 (** [safe_trust = Auto_safe], audited/privileged at [Enforced].
     For well-trusted keeper agents in a dev worktree. *)
 
 val empty : t
-(** [empty] has [defaults = strict_default] and no per-agent entries.
+(** [empty] has [defaults = enforced_all] and no per-agent entries.
     Fail-closed bootstrap for CI and new agents. *)
 
 val lookup : t -> actor:Agent_id.t -> agent_overlay

--- a/lib/exec/exec_gate.ml
+++ b/lib/exec/exec_gate.ml
@@ -35,7 +35,7 @@ let internal_observer_overlay : Approval_config.agent_overlay =
 
 let rollout_config : Approval_config.t =
   {
-    defaults = Approval_config.strict_default;
+    defaults = Approval_config.enforced_all;
     per_agent =
       [
         (`Coord_git, internal_git_admin_overlay);

--- a/lib/exec/test/test_approval_config.ml
+++ b/lib/exec/test/test_approval_config.ml
@@ -2,8 +2,8 @@
 
 open Masc_exec
 
-let test_strict_is_fail_closed () =
-  let o = Approval_config.strict_default in
+let test_enforced_all_is_fail_closed () =
+  let o = Approval_config.enforced_all in
   assert (o.safe_trust = Enforced);
   assert (o.audited_trust = Enforced);
   assert (o.privileged_trust = Enforced)
@@ -14,16 +14,16 @@ let test_permissive_default_auto_safe () =
   assert (o.audited_trust = Enforced);
   assert (o.privileged_trust = Enforced)
 
-let test_empty_uses_strict_defaults () =
+let test_empty_uses_enforced_defaults () =
   let cfg = Approval_config.empty in
   assert (cfg.per_agent = []);
   let o = Approval_config.lookup cfg ~actor:`Other_agent in
-  assert (o = Approval_config.strict_default)
+  assert (o = Approval_config.enforced_all)
 
 let test_lookup_matches_registered_agent () =
   let cfg : Approval_config.t =
     {
-      defaults = Approval_config.strict_default;
+      defaults = Approval_config.enforced_all;
       per_agent = [
         (`Coord_git, Approval_config.permissive_default);
       ];
@@ -32,11 +32,11 @@ let test_lookup_matches_registered_agent () =
   let alpha = Approval_config.lookup cfg ~actor:`Coord_git in
   assert (alpha = Approval_config.permissive_default);
   let other = Approval_config.lookup cfg ~actor:`Other_agent in
-  assert (other = Approval_config.strict_default)
+  assert (other = Approval_config.enforced_all)
 
 let () =
-  test_strict_is_fail_closed ();
+  test_enforced_all_is_fail_closed ();
   test_permissive_default_auto_safe ();
-  test_empty_uses_strict_defaults ();
+  test_empty_uses_enforced_defaults ();
   test_lookup_matches_registered_agent ();
   print_endline "[test_approval_config] all tests passed"

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -20,7 +20,7 @@ let lit s = Shell_ir.Lit s
 let default_policy : Approval_policy.t =
   { raw_source = "(test)"; summary = "(test summary)" }
 
-let strict_overlay = Approval_config.strict_default
+let strict_overlay = Approval_config.enforced_all
 
 let internal_overlay : Approval_config.agent_overlay =
   {


### PR DESCRIPTION
## Summary
- remove the backward-compatible Approval_config.strict_default alias
- use Approval_config.enforced_all directly for empty defaults, rollout config, and approval tests
- update approval config test names/docs to match the phase vocabulary

## Verification
- rg -n "strict_default" lib/exec test lib -S (no matches)
- git diff --check
- scripts/dune-local.sh build lib/exec/test/test_approval_config.exe lib/exec/test/test_approval_policy.exe (blocked by existing machine-wide Dune lock holders; did not force a competing build)