### PR TITLE
Run small test process helpers with argv

### DIFF
--- a/test/test_bounded_proc.ml
+++ b/test/test_bounded_proc.ml
@@ -22,13 +22,18 @@ let with_env f =
    and kernel cleanup by sleeping briefly before probing. *)
 let process_exists argv_substring =
   Unix.sleepf 0.2;
-  let cmd =
-    Printf.sprintf "pgrep -f %s > /dev/null 2>&1"
-      (Filename.quote argv_substring)
-  in
-  match Unix.system cmd with
-  | Unix.WEXITED 0 -> true
-  | _ -> false
+  let dev_null = Unix.openfile Filename.null [ Unix.O_WRONLY ] 0o600 in
+  Fun.protect
+    ~finally:(fun () -> Unix.close dev_null)
+    (fun () ->
+      let argv = [| "pgrep"; "-f"; argv_substring |] in
+      let pid =
+        Unix.create_process_env "pgrep" argv (Unix.environment ()) Unix.stdin
+          dev_null dev_null
+      in
+      match snd (Unix.waitpid [] pid) with
+      | Unix.WEXITED 0 -> true
+      | _ -> false)
 
 let test_done_within_timeout () =
   with_env @@ fun ~clock ~process_mgr ~cwd ->

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -55,10 +55,30 @@ let read_text_file path =
     ~finally:(fun () -> close_in_noerr ic)
     (fun () -> Stdlib.really_input_string ic (in_channel_length ic))
 
-let run_shell_ok ~cwd cmd =
-  let quoted_cwd = Filename.quote cwd in
-  let rc = Sys.command (Printf.sprintf "cd %s && %s" quoted_cwd cmd) in
-  Alcotest.(check int) ("shell command: " ^ cmd) 0 rc
+let process_exit_code = function
+  | Unix.WEXITED code -> code
+  | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> 255
+
+let run_process_ok ~cwd prog argv =
+  let original_cwd = Sys.getcwd () in
+  let dev_null = Unix.openfile Filename.null [ Unix.O_WRONLY ] 0o600 in
+  Fun.protect
+    ~finally:(fun () ->
+      Unix.close dev_null;
+      Sys.chdir original_cwd)
+    (fun () ->
+      Sys.chdir cwd;
+      let pid =
+        Unix.create_process_env prog argv (Unix.environment ()) Unix.stdin
+          dev_null dev_null
+      in
+      let _, status = Unix.waitpid [] pid in
+      Alcotest.(check int)
+        ("process command: " ^ String.concat " " (Array.to_list argv))
+        0 (process_exit_code status))
+
+let git_ok ~cwd args =
+  run_process_ok ~cwd "git" (Array.of_list ("git" :: args))
 
 let run_with_fs f =
   Eio_main.run @@ fun env ->
@@ -630,7 +650,7 @@ let test_read_only_preflight_accepts_sandbox_relative_repo_path () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
-      run_shell_ok ~cwd:dir "git init --quiet";
+      git_ok ~cwd:dir [ "init"; "--quiet" ];
       let file_path =
         Filename.concat dir
           ".masc/playground/docker/masc-improver/repos/masc-mcp/lib/thompson_sampling.ml"
@@ -683,7 +703,7 @@ let test_write_preflight_accepts_docker_container_repo_path () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
-      run_shell_ok ~cwd:dir "git init --quiet";
+      git_ok ~cwd:dir [ "init"; "--quiet" ];
       let keeper_toml =
         Filename.concat dir ".masc/config/keepers/sangsu.toml"
       in
@@ -748,7 +768,7 @@ let test_write_preflight_accepts_sandbox_relative_repo_path () =
       Masc_mcp.Keeper_registry.unregister ~base_path:dir keeper_name;
       cleanup_dir dir)
     (fun () ->
-      run_shell_ok ~cwd:dir "git init --quiet";
+      git_ok ~cwd:dir [ "init"; "--quiet" ];
       let rel_path =
         "repos/masc-mcp/.worktrees/keeper-nick0cave-agent-task-240/lib/foo.ml"
       in

--- a/test/test_sandbox_clone_conflict.ml
+++ b/test/test_sandbox_clone_conflict.ml
@@ -30,19 +30,41 @@ let cleanup_dir path =
   in
   if Sys.file_exists path then rm path
 
-let run_ok ~cwd cmd =
-  let status = Sys.command (Printf.sprintf "cd %s && %s" (Filename.quote cwd) cmd) in
-  if status <> 0 then failwith (Printf.sprintf "Command failed: %s" cmd)
+let process_exit_code = function
+  | Unix.WEXITED code -> code
+  | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> 255
+
+let run_process_ok ~cwd prog argv =
+  let original_cwd = Sys.getcwd () in
+  let dev_null = Unix.openfile Filename.null [ Unix.O_WRONLY ] 0o600 in
+  Fun.protect
+    ~finally:(fun () ->
+      Unix.close dev_null;
+      Sys.chdir original_cwd)
+    (fun () ->
+      Sys.chdir cwd;
+      let pid =
+        Unix.create_process_env prog argv (Unix.environment ()) Unix.stdin
+          dev_null dev_null
+      in
+      let _, status = Unix.waitpid [] pid in
+      let code = process_exit_code status in
+      if code <> 0 then
+        failwith
+          (Printf.sprintf "Command failed (%d): %s" code
+             (String.concat " " (Array.to_list argv))))
+
+let git_ok ~cwd args =
+  run_process_ok ~cwd "git" (Array.of_list ("git" :: args))
 
 let test_auto_provision_rejects_plain_dir_clone_conflict () =
   let base_path = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base_path) @@ fun () ->
   mkdir_p base_path;
-  run_ok ~cwd:base_path "git init -q -b main";
+  git_ok ~cwd:base_path [ "init"; "-q"; "-b"; "main" ];
   let source_repo = Filename.concat base_path "workspace/yousleepwhen/masc-mcp" in
   mkdir_p (Filename.dirname source_repo);
-  run_ok ~cwd:base_path
-    (Printf.sprintf "git init -q -b main %s" (Filename.quote source_repo));
+  git_ok ~cwd:base_path [ "init"; "-q"; "-b"; "main"; source_repo ];
   let repos_dir = Filename.concat base_path ".masc/playground/test-agent/repos" in
   mkdir_p repos_dir;
   let conflict_path = Filename.concat repos_dir "masc-mcp" in

--- a/test/test_tool_code_coverage.ml
+++ b/test/test_tool_code_coverage.ml
@@ -42,10 +42,30 @@ let write_text_file path content =
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc content)
 
-let run_shell_ok ~cwd cmd =
-  let quoted_cwd = Filename.quote cwd in
-  let rc = Sys.command (Printf.sprintf "cd %s && %s" quoted_cwd cmd) in
-  Alcotest.(check int) ("shell command: " ^ cmd) 0 rc
+let process_exit_code = function
+  | Unix.WEXITED code -> code
+  | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> 255
+
+let run_process_ok ~cwd prog argv =
+  let original_cwd = Sys.getcwd () in
+  let dev_null = Unix.openfile Filename.null [ Unix.O_WRONLY ] 0o600 in
+  Fun.protect
+    ~finally:(fun () ->
+      Unix.close dev_null;
+      Sys.chdir original_cwd)
+    (fun () ->
+      Sys.chdir cwd;
+      let pid =
+        Unix.create_process_env prog argv (Unix.environment ()) Unix.stdin
+          dev_null dev_null
+      in
+      let _, status = Unix.waitpid [] pid in
+      Alcotest.(check int)
+        ("process command: " ^ String.concat " " (Array.to_list argv))
+        0 (process_exit_code status))
+
+let git_ok ~cwd args =
+  run_process_ok ~cwd "git" (Array.of_list ("git" :: args))
 
 let make_ctx_in_dir base_dir =
   Eio_main.run @@ fun env ->
@@ -130,9 +150,9 @@ let test_code_search_with_file_pattern_finds_matches () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      run_shell_ok ~cwd:base_dir "git init -q -b main";
-      run_shell_ok ~cwd:base_dir "git config user.email test@example.com";
-      run_shell_ok ~cwd:base_dir "git config user.name test";
+      git_ok ~cwd:base_dir [ "init"; "-q"; "-b"; "main" ];
+      git_ok ~cwd:base_dir [ "config"; "user.email"; "test@example.com" ];
+      git_ok ~cwd:base_dir [ "config"; "user.name"; "test" ];
       write_text_file (Filename.concat base_dir "match.ml")
         "let mascot_needle = 1\n";
       write_text_file (Filename.concat base_dir "ignore.md")
@@ -161,9 +181,9 @@ let test_code_search_treats_dash_prefixed_query_as_literal () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      run_shell_ok ~cwd:base_dir "git init -q -b main";
-      run_shell_ok ~cwd:base_dir "git config user.email test@example.com";
-      run_shell_ok ~cwd:base_dir "git config user.name test";
+      git_ok ~cwd:base_dir [ "init"; "-q"; "-b"; "main" ];
+      git_ok ~cwd:base_dir [ "config"; "user.email"; "test@example.com" ];
+      git_ok ~cwd:base_dir [ "config"; "user.name"; "test" ];
       write_text_file (Filename.concat base_dir "sample.txt")
         "--help should be searched literally\n";
       let ctx = make_ctx_in_dir base_dir in


### PR DESCRIPTION
## Summary
- replace small test Sys.command/Unix.system helpers with argv-based process spawning
- run git fixture setup via git_ok in keeper bridge, tool code, and sandbox clone tests
- probe pgrep directly in bounded proc tests instead of a shell command string

## Verification
- ocamlformat --check test/test_keeper_masc_bridge.ml test/test_tool_code_coverage.ml test/test_sandbox_clone_conflict.ml test/test_bounded_proc.ml
- git diff --check origin/main...HEAD
- rg -n 'run_shell_ok|run_ok|Sys\.command|Unix\.system|Filename\.quote|cd %s|wrapped|env_prefix|sh -c|bash -c' test/test_keeper_masc_bridge.ml test/test_tool_code_coverage.ml test/test_sandbox_clone_conflict.ml test/test_bounded_proc.ml (no matches)
- scripts/dune-local.sh build test/test_keeper_masc_bridge.exe test/test_tool_code_coverage.exe test/test_sandbox_clone_conflict.exe test/test_bounded_proc.exe (not completed: local Dune lock held by another dune-local build; waiting process was stopped)