### PR TITLE
Remove anti-rationalization verdict wrapper

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -860,28 +860,6 @@ let review
                   }))))
 ;;
 
-(** Backward-compatible wrapper that returns only the verdict.
-    Use [review] directly for structured results with audit metadata. *)
-let review_verdict
-      ?evaluator_cascade
-      ?generator_cascade
-      ?completion_contract
-      ?on_verdict
-      ?few_shot_block
-      ?sw
-      req
-  =
-  (review
-     ?evaluator_cascade
-     ?generator_cascade
-     ?completion_contract
-     ?on_verdict
-     ?few_shot_block
-     ?sw
-     req)
-    .verdict
-;;
-
 let review_result_to_json (r : review_result) : Yojson.Safe.t =
   let base =
     [ ( "verdict"

--- a/lib/anti_rationalization.mli
+++ b/lib/anti_rationalization.mli
@@ -75,16 +75,6 @@ val review :
   ?sw:Eio.Switch.t ->
   review_request -> review_result
 
-(** Backward-compatible wrapper returning only the verdict. *)
-val review_verdict :
-  ?evaluator_cascade:string ->
-  ?generator_cascade:string ->
-  ?completion_contract:string list ->
-  ?on_verdict:(review_result -> unit) ->
-  ?few_shot_block:string ->
-  ?sw:Eio.Switch.t ->
-  review_request -> verdict
-
 (** Check completion notes against a contract. Returns unmet items.
     Used internally by Gate 2.5; exposed for testing. *)
 val check_contract : notes:string -> contract:string list -> string list


### PR DESCRIPTION
## Summary
- remove the unused Anti_rationalization.review_verdict compatibility wrapper
- keep callers on the structured Anti_rationalization.review result surface

## Verification
- rg -n "val review_verdict|let review_verdict|Backward-compatible wrapper returning only the verdict|returns only the verdict" lib/anti_rationalization.ml lib/anti_rationalization.mli test -S (no matches)
- git diff --check
- ocamlformat --check lib/anti_rationalization.ml lib/anti_rationalization.mli
- scripts/dune-local.sh build lib/masc_mcp.cma test/test_anti_rationalization_coverage.exe test/test_anti_rationalization_fail_mode.exe (blocked by existing bare Dune processes / machine-wide dune-local lock; not forced to avoid adding contention)