### PR TITLE
refactor(transport): purge legacy Accept fallback

### DIFF
--- a/lib/mcp_transport_protocol/mcp_transport_protocol.ml
+++ b/lib/mcp_transport_protocol/mcp_transport_protocol.ml
@@ -6,8 +6,7 @@
     JSON-RPC core: request/response types, builders, validators.
     Protocol version: supported versions, validation, normalization.
     HTTP negotiation: delegates parsing to {!Mcp_protocol.Http_negotiation}
-    (SDK); adds [accept_mode] with [Legacy_accepted] for the HTTP
-    notification-only relaxation. *)
+    (SDK) and classifies the Streamable HTTP Accept contract. *)
 
 (* ── JSON-RPC core types ─────────────────────────────────── *)
 
@@ -114,12 +113,9 @@ let jsonrpc_notification ?params method_name =
 
 module Http_negotiation = struct
   (** MASC-specific accept classification.
-      [Legacy_accepted] has no SDK equivalent. It is reserved for the HTTP
-      layer's notification-only relaxation; normal request Accept negotiation
-      never returns it. *)
+      Streamable HTTP requires both JSON and SSE media types. *)
   type accept_mode =
     | Streamable
-    | Legacy_accepted
     | Rejected
 
   (* Re-export SDK constants so callers' [Http_negotiation.sse_content_type]

--- a/lib/mcp_transport_protocol/mcp_transport_protocol.mli
+++ b/lib/mcp_transport_protocol/mcp_transport_protocol.mli
@@ -5,7 +5,7 @@
     builders, validators), {b protocol version} (supported set, validation,
     normalization), and {b HTTP negotiation} (delegates parsing to
     {!Mcp_protocol.Http_negotiation} from the SDK; layers MASC's
-    [accept_mode] with [Legacy_accepted] for the HTTP notification relaxation). *)
+    Streamable HTTP Accept classification). *)
 
 (** {1 JSON-RPC Core Types} *)
 
@@ -74,13 +74,9 @@ module Http_negotiation : sig
       [Streamable] — Accept header advertises both [application/json] and
       [text/event-stream] (the spec-compliant mode).
 
-      [Legacy_accepted] — reserved for the HTTP layer's notification-only
-      relaxation. The pure Accept classifier does not return this variant.
-
       [Rejected] — neither mode applies. *)
   type accept_mode =
     | Streamable
-    | Legacy_accepted
     | Rejected
 
   val sse_content_type : string
@@ -107,8 +103,7 @@ module Http_negotiation : sig
   (** [true] iff the header advertises both JSON and SSE
       (the Streamable HTTP transport requirement). *)
 
-  val classify_mcp_accept :
-    string option -> accept_mode
+  val classify_mcp_accept : string option -> accept_mode
   (** Top-level classification: [Streamable] if both media types are
       advertised, else [Rejected]. *)
 end

--- a/lib/server/server_mcp_request_context.ml
+++ b/lib/server/server_mcp_request_context.ml
@@ -43,8 +43,7 @@ let decide_post_body ~request ~context ~session_is_known body_str =
       | Error msg -> Error (Unknown_session msg)
       | Ok () -> (
           match
-            Server_mcp_transport_http_headers.classify_mcp_accept_for_body request
-              body_str
+            Server_mcp_transport_http_headers.classify_mcp_accept request
           with
           | Mcp_transport_protocol.Http_negotiation.Rejected ->
               Error (Invalid_accept invalid_accept_message)

--- a/lib/server/server_mcp_transport_http.mli
+++ b/lib/server/server_mcp_transport_http.mli
@@ -80,8 +80,6 @@ val get_protocol_version_for_session :
 val request_force_json_response : Httpun.Request.t -> bool
 val classify_mcp_accept :
   Httpun.Request.t -> Mcp_transport_protocol.Http_negotiation.accept_mode
-val classify_mcp_accept_for_body :
-  Httpun.Request.t -> string -> Mcp_transport_protocol.Http_negotiation.accept_mode
 val should_use_sse_for_body :
   Httpun.Request.t ->
   string ->

--- a/lib/server/server_mcp_transport_http_headers.ml
+++ b/lib/server/server_mcp_transport_http_headers.ml
@@ -59,24 +59,7 @@ let body_jsonrpc_method body_str =
     | _ -> None
   with Yojson.Json_error _ -> None
 
-let is_notification_method method_ =
-  let prefix = "notifications/" in
-  String.starts_with method_ ~prefix
-
 let is_initialize_method method_ = String.equal method_ "initialize"
-
-let request_accepts_json (request : Httpun.Request.t) =
-  Http_negotiation.accepts_json
-    (Httpun.Headers.get request.headers "accept")
-
-let classify_mcp_accept_for_body (request : Httpun.Request.t) body_str =
-  match classify_mcp_accept request with
-  | Http_negotiation.Rejected -> (
-      match body_jsonrpc_method body_str with
-      | Some (method_, false) when is_notification_method method_ ->
-          Http_negotiation.Legacy_accepted
-      | _ -> Http_negotiation.Rejected)
-  | accept_mode -> accept_mode
 
 let should_use_sse_for_body (request : Httpun.Request.t) body_str accept_mode =
   match body_jsonrpc_method body_str with

--- a/lib/server/server_mcp_transport_http_headers.mli
+++ b/lib/server/server_mcp_transport_http_headers.mli
@@ -33,11 +33,6 @@ val body_jsonrpc_method : string -> (string * bool) option
     non-object body).  [has_id] reports whether the [id] field is
     present (used to distinguish notifications from requests). *)
 
-val is_notification_method : string -> bool
-(** [is_notification_method m] tests whether [m] starts with the
-    literal prefix [["notifications/"]].  Notifications must have
-    [has_id = false] in the JSON-RPC envelope. *)
-
 val is_initialize_method : string -> bool
 (** [is_initialize_method m] tests whether [m] equals the literal
     [["initialize"]].  The initialize handshake must always go over
@@ -46,7 +41,7 @@ val is_initialize_method : string -> bool
 (** {1 Accept-header classification}
 
     The MCP spec mandates [Accept: application/json, text/event-stream]
-    for streamable transports.  One request-level opt-out remains:
+    for streamable transports.  One opt-out remains:
 
     - The [x-masc-force-json] request header overrides the Accept
       negotiation entirely. *)
@@ -56,17 +51,6 @@ val classify_mcp_accept :
   Mcp_transport_protocol.Http_negotiation.accept_mode
 (** [classify_mcp_accept request] reads the [accept] header and
     returns the negotiation classification. *)
-
-val classify_mcp_accept_for_body :
-  Httpun.Request.t ->
-  string ->
-  Mcp_transport_protocol.Http_negotiation.accept_mode
-(** Same as {!classify_mcp_accept} but with one upgrade path: when
-    the Accept header alone classifies as [Rejected] AND the body
-    is a notification (method starts with [notifications/], no id),
-    promote the classification to [Legacy_accepted] so notifications
-    can land even from clients that omit the streamable Accept set.
-    Notification-only relaxation, never for request-id'd calls. *)
 
 val should_use_sse_for_body :
   Httpun.Request.t ->
@@ -79,10 +63,6 @@ val should_use_sse_for_body :
     handshake (always JSON) OR [accept_mode <> Streamable] OR the
     Accept header does not include [text/event-stream]. *)
 
-val request_accepts_json : Httpun.Request.t -> bool
-(** [request_accepts_json request] returns [true] iff the Accept
-    header advertises [application/json] (or wildcard). *)
-
 val request_force_json_response : Httpun.Request.t -> bool
 (** [request_force_json_response request] returns [true] iff the
     [x-masc-force-json] header is set to a truthy value
@@ -92,8 +72,8 @@ val request_force_json_response : Httpun.Request.t -> bool
 val force_json_response : bool
 (** Module-init cache of [MASC_FORCE_JSON_RESPONSE] OR
     [MCP_FORCE_JSON_RESPONSE] env flags (truthy semantics matching
-    the local env parser).  Either flag forces every response to
-    plain JSON regardless of Accept negotiation. *)
+    {!request_force_json_response}).  Either flag forces every
+    response to plain JSON regardless of Accept negotiation. *)
 
 (** {1 Header builders} *)
 

--- a/lib/server/server_mcp_transport_http_protocol.ml
+++ b/lib/server/server_mcp_transport_http_protocol.ml
@@ -80,9 +80,6 @@ let request_force_json_response =
 
 let classify_mcp_accept = Server_mcp_transport_http_headers.classify_mcp_accept
 
-let classify_mcp_accept_for_body =
-  Server_mcp_transport_http_headers.classify_mcp_accept_for_body
-
 let should_use_sse_for_body =
   Server_mcp_transport_http_headers.should_use_sse_for_body
 

--- a/lib/server/server_mcp_transport_http_protocol.mli
+++ b/lib/server/server_mcp_transport_http_protocol.mli
@@ -117,13 +117,6 @@ val classify_mcp_accept :
 (** Re-export of
     {!Server_mcp_transport_http_headers.classify_mcp_accept}. *)
 
-val classify_mcp_accept_for_body :
-  Httpun.Request.t ->
-  string ->
-  Mcp_transport_protocol.Http_negotiation.accept_mode
-(** Re-export of
-    {!Server_mcp_transport_http_headers.classify_mcp_accept_for_body}. *)
-
 val should_use_sse_for_body :
   Httpun.Request.t ->
   string ->

--- a/test/test_http_negotiation.ml
+++ b/test/test_http_negotiation.ml
@@ -30,7 +30,6 @@ let test_classify_mcp_accept () =
     let same =
       match (expected, actual) with
       | Streamable, Streamable
-      | Legacy_accepted, Legacy_accepted
       | Rejected, Rejected ->
           true
       | _ -> false
@@ -95,17 +94,14 @@ let test_protocol_continuity_rejects_mismatch () =
             (String.length msg > 0
             && String.contains msg ':'))
 
-let test_notification_body_relaxes_accept () =
+let test_notification_json_only_rejected () =
   let module Transport = Masc_mcp.Server_mcp_transport_http in
   let headers = Httpun.Headers.of_list [("accept", "application/json")] in
   let request = Httpun.Request.create ~headers `POST "/mcp" in
-  let body =
-    {|{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}|}
-  in
-  let mode = Transport.classify_mcp_accept_for_body request body in
-  check bool "notification accept relaxation" true
+  let mode = Transport.classify_mcp_accept request in
+  check bool "notification json-only is rejected" true
     (match mode with
-    | Mcp_transport_protocol.Http_negotiation.Legacy_accepted -> true
+    | Mcp_transport_protocol.Http_negotiation.Rejected -> true
     | _ -> false)
 
 let test_request_json_only_accepted () =
@@ -113,10 +109,7 @@ let test_request_json_only_accepted () =
   let module Transport = Masc_mcp.Server_mcp_transport_http in
   let headers = Httpun.Headers.of_list [("accept", "application/json")] in
   let request = Httpun.Request.create ~headers `POST "/mcp" in
-  let body =
-    {|{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}|}
-  in
-  let mode = Transport.classify_mcp_accept_for_body request body in
+  let mode = Transport.classify_mcp_accept request in
   check bool "json-only accept is rejected" true
     (match mode with
     | Mcp_transport_protocol.Http_negotiation.Rejected -> true
@@ -127,10 +120,7 @@ let test_initialize_json_only_accepted () =
   let module Transport = Masc_mcp.Server_mcp_transport_http in
   let headers = Httpun.Headers.of_list [("accept", "application/json")] in
   let request = Httpun.Request.create ~headers `POST "/mcp" in
-  let body =
-    {|{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"0.1"}}}|}
-  in
-  let mode = Transport.classify_mcp_accept_for_body request body in
+  let mode = Transport.classify_mcp_accept request in
   check bool "initialize with json-only is rejected" true
     (match mode with
     | Mcp_transport_protocol.Http_negotiation.Rejected -> true
@@ -141,10 +131,7 @@ let test_no_accept_header_rejected () =
   let module Transport = Masc_mcp.Server_mcp_transport_http in
   let headers = Httpun.Headers.of_list [] in
   let request = Httpun.Request.create ~headers `POST "/mcp" in
-  let body =
-    {|{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}|}
-  in
-  let mode = Transport.classify_mcp_accept_for_body request body in
+  let mode = Transport.classify_mcp_accept request in
   check bool "no accept header is rejected" true
     (match mode with
     | Mcp_transport_protocol.Http_negotiation.Rejected -> true
@@ -219,8 +206,9 @@ let () =
         test_case "remembered session version is reused" `Quick test_protocol_version_for_session_falls_back_to_negotiated_version;
         test_case "mismatch still rejects" `Quick test_protocol_continuity_rejects_mismatch;
       ]);
-      ("body_aware_accept", [
-        test_case "notification relaxes accept" `Quick test_notification_body_relaxes_accept;
+      ("accept_contract", [
+        test_case "notification json-only rejected" `Quick
+          test_notification_json_only_rejected;
         test_case "json-only accept is rejected" `Quick test_request_json_only_accepted;
         test_case "initialize json-only is rejected" `Quick test_initialize_json_only_accepted;
         test_case "no accept header rejected" `Quick test_no_accept_header_rejected;

--- a/test/test_mcp_h1_h2_admission_parity.ml
+++ b/test/test_mcp_h1_h2_admission_parity.ml
@@ -41,7 +41,6 @@ let assert_accept_mode label expected actual =
   let same =
     match (expected, actual) with
     | Negotiation.Streamable, Negotiation.Streamable
-    | Negotiation.Legacy_accepted, Negotiation.Legacy_accepted
     | Negotiation.Rejected, Negotiation.Rejected ->
         true
     | _ -> false
@@ -146,13 +145,12 @@ let test_shared_post_admission_matrix () =
     request ~headers:[ ("accept", "application/json") ] "/mcp"
   in
   assert_accept_mode "streamable Accept remains admitted" Negotiation.Streamable
-    (Headers.classify_mcp_accept_for_body streamable_request (body "tools/call"));
+    (Headers.classify_mcp_accept streamable_request);
   assert_accept_mode "json-only Accept is rejected for requests" Negotiation.Rejected
-    (Headers.classify_mcp_accept_for_body json_only_request (body "tools/call"));
-  assert_accept_mode "json-only notifications remain legacy-compatible"
-    Negotiation.Legacy_accepted
-    (Headers.classify_mcp_accept_for_body json_only_request
-       {|{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}|})
+    (Headers.classify_mcp_accept json_only_request);
+  assert_accept_mode "json-only notifications are rejected"
+    Negotiation.Rejected
+    (Headers.classify_mcp_accept json_only_request)
 
 let test_shared_protocol_and_delete_matrix () =
   let session_id = "h1-h2-parity-protocol-session" in

--- a/test/test_mcp_protocol_coverage.ml
+++ b/test/test_mcp_protocol_coverage.ml
@@ -175,17 +175,13 @@ let test_classify_rejected () =
     (match mode with Http_negotiation.Rejected -> true | _ -> false)
 
 let test_classify_none_rejected () =
-  let mode =
-    Http_negotiation.classify_mcp_accept None
-  in
+  let mode = Http_negotiation.classify_mcp_accept None in
   check bool "none rejected" true
     (match mode with Http_negotiation.Rejected -> true | _ -> false)
 
 let test_classify_wildcard_rejected () =
   (* */* alone: json=true but sse=false, so not Streamable *)
-  let mode =
-    Http_negotiation.classify_mcp_accept (Some "*/*")
-  in
+  let mode = Http_negotiation.classify_mcp_accept (Some "*/*") in
   check bool "wildcard rejected" true
     (match mode with Http_negotiation.Rejected -> true | _ -> false)
 

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -2299,6 +2299,7 @@ let test_main_eio_fresh_bootstrap_and_mcp_handshake () =
               ~headers:
                 [
                   "Content-Type: application/json";
+                  "Accept: application/json, text/event-stream";
                   "Mcp-Session-Id: " ^ session_id;
                   "Mcp-Protocol-Version: " ^ protocol_version;
                 ]
@@ -2318,6 +2319,7 @@ let test_main_eio_fresh_bootstrap_and_mcp_handshake () =
               ~headers:
                 [
                   "Content-Type: application/json";
+                  "Accept: application/json, text/event-stream";
                   "Mcp-Session-Id: " ^ session_id;
                   "Mcp-Protocol-Version: " ^ protocol_version;
                 ]


### PR DESCRIPTION
## Summary
- remove the legacy Accept compatibility mode and MASC_ALLOW_LEGACY_ACCEPT runtime knob
- collapse Streamable HTTP Accept classification to Streamable/Rejected only
- update contract/tests/scripts/docs so JSON-only Accept is rejected instead of warned through

## Validation
- ocamlformat --check touched OCaml files
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- rg legacy Accept fallback surfaces: no matches for Legacy_accepted, MASC_ALLOW_LEGACY_ACCEPT, allow_legacy, legacy_accept_warning, x-masc-legacy-accept, classify_mcp_accept_for_body, is_notification_method, request_accepts_json

## Not run
- focused dune build was attempted twice, but /tmp/me-dune-local.lock was held by another worktree: remove-ide-merge-legacy building test/test_ide_annotations.exe