### PR TITLE
Run read and dashboard test helpers with argv

### DIFF
--- a/test/test_dashboard_surface_readiness.ml
+++ b/test/test_dashboard_surface_readiness.ml
@@ -56,20 +56,41 @@ let repo_root () =
 let load_nav_contract_from_script () =
   let root = repo_root () in
   let tmp = Filename.temp_file "dashboard-surface-contract" ".json" in
-  let cmd =
-    Printf.sprintf
-      "cd %s && bash scripts/check-dashboard-surface-parity.sh --print-nav-json > %s"
-      (Filename.quote root)
-      (Filename.quote tmp)
+  let out_fd =
+    Unix.openfile tmp [ Unix.O_WRONLY; Unix.O_TRUNC ] 0o600
   in
-  match Sys.command cmd with
+  let code =
+    Fun.protect
+      ~finally:(fun () -> Unix.close out_fd)
+      (fun () ->
+        let original_cwd = Sys.getcwd () in
+        Fun.protect
+          ~finally:(fun () -> Sys.chdir original_cwd)
+          (fun () ->
+            Sys.chdir root;
+            let argv =
+              [|
+                "bash";
+                "scripts/check-dashboard-surface-parity.sh";
+                "--print-nav-json";
+              |]
+            in
+            let pid =
+              Unix.create_process_env "bash" argv (Unix.environment ())
+                Unix.stdin out_fd Unix.stderr
+            in
+            match snd (Unix.waitpid [] pid) with
+            | Unix.WEXITED code -> code
+            | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> 255))
+  in
+  match code with
   | 0 ->
-      let json = Yojson.Safe.from_file tmp in
-      Sys.remove tmp;
-      load_surface_contracts_from_json json
+    let json = Yojson.Safe.from_file tmp in
+    Sys.remove tmp;
+    load_surface_contracts_from_json json
   | code ->
-      (try Sys.remove tmp with Sys_error _ -> ());
-      fail (Printf.sprintf "surface parity helper failed with exit code %d" code)
+    (try Sys.remove tmp with Sys_error _ -> ());
+    fail (Printf.sprintf "surface parity helper failed with exit code %d" code)
 
 let load_readiness_contract () =
   Dashboard_surface_readiness.json () |> load_surface_contracts_from_json

--- a/test/test_tool_code_read_containment.ml
+++ b/test/test_tool_code_read_containment.ml
@@ -39,19 +39,44 @@ let fresh_base_path ~tag =
   Unix.mkdir raw 0o755;
   try Unix.realpath raw with Unix.Unix_error _ -> raw
 
-let sh cmd =
-  let rc = Sys.command cmd in
-  if rc <> 0 then
-    failwith (Printf.sprintf "shell cmd failed (rc=%d): %s" rc cmd)
+let process_exit_code = function
+  | Unix.WEXITED code -> code
+  | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> 255
+
+let run_process_ok ~cwd prog argv =
+  let original_cwd = Sys.getcwd () in
+  let dev_null = Unix.openfile Filename.null [ Unix.O_WRONLY ] 0o600 in
+  Fun.protect
+    ~finally:(fun () ->
+      Unix.close dev_null;
+      Sys.chdir original_cwd)
+    (fun () ->
+      Sys.chdir cwd;
+      let pid =
+        Unix.create_process_env prog argv (Unix.environment ()) Unix.stdin
+          dev_null dev_null
+      in
+      let _, status = Unix.waitpid [] pid in
+      let code = process_exit_code status in
+      if code <> 0 then
+        failwith
+          (Printf.sprintf "process failed (rc=%d): %s" code
+             (String.concat " " (Array.to_list argv))))
+
+let git_ok ~cwd args =
+  run_process_ok ~cwd "git" (Array.of_list ("git" :: args))
 
 let git_init_base base_path =
   (* [Tool_code.validate_path] requires the tmp dir to be a real git
      repo so [Coord_git.git_root] can resolve it. Initialise + one
      commit so the repo is in a valid state. *)
-  sh (Printf.sprintf "cd %s && git init -q -b main" base_path);
-  sh (Printf.sprintf "cd %s && git config user.email test@example.com" base_path);
-  sh (Printf.sprintf "cd %s && git config user.name test" base_path);
-  sh (Printf.sprintf "cd %s && touch README && git add README && git commit -qm init" base_path)
+  git_ok ~cwd:base_path [ "init"; "-q"; "-b"; "main" ];
+  git_ok ~cwd:base_path [ "config"; "user.email"; "test@example.com" ];
+  git_ok ~cwd:base_path [ "config"; "user.name"; "test" ];
+  let oc = open_out (Filename.concat base_path "README") in
+  close_out oc;
+  git_ok ~cwd:base_path [ "add"; "README" ];
+  git_ok ~cwd:base_path [ "commit"; "-q"; "-m"; "init" ]
 
 let mkdir_p path =
   let rec go acc = function

--- a/test/test_tool_code_read_directory_typed_error.ml
+++ b/test/test_tool_code_read_directory_typed_error.ml
@@ -22,18 +22,41 @@ let fresh_base_path ~tag =
   Unix.mkdir raw 0o755;
   try Unix.realpath raw with Unix.Unix_error _ -> raw
 
-let sh cmd =
-  let rc = Sys.command cmd in
-  if rc <> 0 then failwith (Printf.sprintf "shell cmd failed (rc=%d): %s" rc cmd)
+let process_exit_code = function
+  | Unix.WEXITED code -> code
+  | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> 255
+
+let run_process_ok ~cwd prog argv =
+  let original_cwd = Sys.getcwd () in
+  let dev_null = Unix.openfile Filename.null [ Unix.O_WRONLY ] 0o600 in
+  Fun.protect
+    ~finally:(fun () ->
+      Unix.close dev_null;
+      Sys.chdir original_cwd)
+    (fun () ->
+      Sys.chdir cwd;
+      let pid =
+        Unix.create_process_env prog argv (Unix.environment ()) Unix.stdin
+          dev_null dev_null
+      in
+      let _, status = Unix.waitpid [] pid in
+      let code = process_exit_code status in
+      if code <> 0 then
+        failwith
+          (Printf.sprintf "process failed (rc=%d): %s" code
+             (String.concat " " (Array.to_list argv))))
+
+let git_ok ~cwd args =
+  run_process_ok ~cwd "git" (Array.of_list ("git" :: args))
 
 let git_init_base base_path =
-  sh (Printf.sprintf "cd %s && git init -q -b main" base_path);
-  sh (Printf.sprintf "cd %s && git config user.email test@example.com" base_path);
-  sh (Printf.sprintf "cd %s && git config user.name test" base_path);
-  sh
-    (Printf.sprintf
-       "cd %s && touch README && git add README && git commit -qm init"
-       base_path)
+  git_ok ~cwd:base_path [ "init"; "-q"; "-b"; "main" ];
+  git_ok ~cwd:base_path [ "config"; "user.email"; "test@example.com" ];
+  git_ok ~cwd:base_path [ "config"; "user.name"; "test" ];
+  let oc = open_out (Filename.concat base_path "README") in
+  close_out oc;
+  git_ok ~cwd:base_path [ "add"; "README" ];
+  git_ok ~cwd:base_path [ "commit"; "-q"; "-m"; "init" ]
 
 let write_file path content =
   let oc = open_out path in


### PR DESCRIPTION
## Summary
- replace tool_code_read git setup shell commands with argv-based git helpers
- split README creation from git add/commit instead of using chained shell commands
- run dashboard surface parity script via argv and direct stdout fd capture

## Verification
- ocamlformat --check test/test_tool_code_read_containment.ml test/test_tool_code_read_directory_typed_error.ml test/test_dashboard_surface_readiness.ml
- git diff --check origin/main...HEAD
- rg -n 'Sys\.command|Unix\.system|run_shell|let sh\b|\bsh \(|cd %s|wrapped|env_prefix|sh -c|bash -c' test/test_tool_code_read_containment.ml test/test_tool_code_read_directory_typed_error.ml test/test_dashboard_surface_readiness.ml (no matches)
- scripts/dune-local.sh build test/test_tool_code_read_containment.exe test/test_tool_code_read_directory_typed_error.exe test/test_dashboard_surface_readiness.exe (blocked: live bare dune processes outside scripts/dune-local.sh)