### PR TITLE
feat(keeper_runtime_manifest): F5 logical clock separation — logical_seq + elapsed_ms

### DIFF
--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -80,6 +80,7 @@ type t = {
   generation : int option;
   keeper_turn_id : int option;
   oas_turn_count : int option;
+  logical_seq : int option;
   event : event_kind;
   cascade_name : string option;
   status : string;
@@ -184,10 +185,15 @@ let string_field_opt key value =
   | Some value when String.trim value <> "" -> Some (key, `String value)
   | Some _ | None -> None
 
+let int_field_opt key value =
+  match value with
+  | Some value -> Some (key, `Int value)
+  | None -> None
+
 let clock_refs ?edge_id ?lane ?source_clock ?observed_at ?started_at
-    ?finished_at ?provider_attempt_id ?tool_batch_id ?checkpoint_id
+    ?finished_at ?elapsed_ms ?provider_attempt_id ?tool_batch_id ?checkpoint_id
     ?compaction_id ?memory_injection_id ?event_bus_correlation_id
-    ?event_bus_run_id ?parent_event_id ?caused_by () =
+    ?event_bus_run_id ?parent_event_id ?caused_by ?logical_seq () =
   `Assoc
     (List.filter_map
        (fun value -> value)
@@ -199,6 +205,7 @@ let clock_refs ?edge_id ?lane ?source_clock ?observed_at ?started_at
          string_field_opt "observed_at" observed_at;
          string_field_opt "started_at" started_at;
          string_field_opt "finished_at" finished_at;
+         int_field_opt "elapsed_ms" elapsed_ms;
          string_field_opt "provider_attempt_id" provider_attempt_id;
          string_field_opt "tool_batch_id" tool_batch_id;
          string_field_opt "checkpoint_id" checkpoint_id;
@@ -208,6 +215,7 @@ let clock_refs ?edge_id ?lane ?source_clock ?observed_at ?started_at
          string_field_opt "event_bus_run_id" event_bus_run_id;
          string_field_opt "parent_event_id" parent_event_id;
          string_field_opt "caused_by" caused_by;
+         int_field_opt "logical_seq" logical_seq;
        ])
 
 let clock_lane_of_event = function
@@ -266,8 +274,9 @@ let context_memory_injection_id ctx ?oas_turn_count () =
   Printf.sprintf "%s:keeper-%s:memory-oas-%s" ctx.manifest_trace_id
     (turn_label ctx) (oas_turn_label oas_turn_count)
 
-let clock_refs_for_context ctx ~event ?oas_turn_count
-    ?event_bus_correlation_id ?event_bus_run_id ?parent_event_id ?caused_by () =
+let clock_refs_for_context ctx ~event ?oas_turn_count ?elapsed_ms
+    ?event_bus_correlation_id ?event_bus_run_id ?parent_event_id ?caused_by
+    ?logical_seq () =
   let tool_batch_id =
     match event with
     | Tool_surface_selected
@@ -308,9 +317,10 @@ let clock_refs_for_context ctx ~event ?oas_turn_count
     | _ -> Wall
   in
   clock_refs ~edge_id:(context_edge_id ctx event)
-    ~lane:(clock_lane_of_event event) ~source_clock ?tool_batch_id
+    ~lane:(clock_lane_of_event event) ~source_clock ?elapsed_ms ?tool_batch_id
     ?checkpoint_id ?compaction_id ?memory_injection_id
-    ?event_bus_correlation_id ?event_bus_run_id ?parent_event_id ?caused_by ()
+    ?event_bus_correlation_id ?event_bus_run_id ?parent_event_id ?caused_by
+    ?logical_seq ()
 
 let assoc_has_key key fields =
   List.exists (fun (field, _) -> String.equal field key) fields
@@ -365,7 +375,7 @@ let tool_lineage ?searched_tool_names ?visible_tool_names
        ])
 
 let make ?(ts = Masc_domain.now_iso ()) ~keeper_name ?agent_name ~trace_id
-    ?generation ?keeper_turn_id ?oas_turn_count ~event ?cascade_name
+    ?generation ?keeper_turn_id ?oas_turn_count ?logical_seq ~event ?cascade_name
     ?(status = "ok") ?(decision = `Assoc []) ?receipt_path ?checkpoint_path
     ?tool_call_log_path () =
   {
@@ -377,6 +387,7 @@ let make ?(ts = Masc_domain.now_iso ()) ~keeper_name ?agent_name ~trace_id
     generation;
     keeper_turn_id;
     oas_turn_count;
+    logical_seq;
     event;
     cascade_name;
     status;
@@ -384,13 +395,13 @@ let make ?(ts = Masc_domain.now_iso ()) ~keeper_name ?agent_name ~trace_id
     links = { receipt_path; checkpoint_path; tool_call_log_path };
   }
 
-let make_for_context ctx ~event ?oas_turn_count ?cascade_name ?status ?decision
-    ?receipt_path ?checkpoint_path ?tool_call_log_path () =
+let make_for_context ctx ~event ?oas_turn_count ?logical_seq ?cascade_name
+    ?status ?decision ?receipt_path ?checkpoint_path ?tool_call_log_path () =
   make ~keeper_name:ctx.manifest_keeper_name
     ?agent_name:ctx.manifest_agent_name ~trace_id:ctx.manifest_trace_id
     ?generation:ctx.manifest_generation
-    ?keeper_turn_id:ctx.manifest_keeper_turn_id ?oas_turn_count ~event
-    ?cascade_name ?status ?decision ?receipt_path ?checkpoint_path
+    ?keeper_turn_id:ctx.manifest_keeper_turn_id ?oas_turn_count ?logical_seq
+    ~event ?cascade_name ?status ?decision ?receipt_path ?checkpoint_path
     ?tool_call_log_path ()
 
 let json_of_string_opt = function
@@ -416,17 +427,18 @@ let links_to_json links =
 let manifest_top_level_allowlist =
   StringSet.of_list
     [ "schema_version"; "ts"; "keeper_name"; "agent_name"; "trace_id"
-    ; "generation"; "keeper_turn_id"; "oas_turn_count"; "event"
+    ; "generation"; "keeper_turn_id"; "oas_turn_count"; "logical_seq"; "event"
     ; "cascade_name"; "status"; "decision"; "links"
     ]
 
 let decision_public_allowlist =
   StringSet.of_list
     [ "edge_id"; "lane"; "source_clock"; "observed_at"; "started_at"; "finished_at"
-    ; "provider_attempt_id"; "tool_batch_id"; "checkpoint_id"; "compaction_id"
-    ; "memory_injection_id"; "event_bus_correlation_id"; "event_bus_run_id"
-    ; "parent_event_id"; "caused_by"; "repair_reason"; "matched_started_ts"
-    ; "matched_started_status"; "error"; "exception_kind"; "latency_ms"
+    ; "elapsed_ms"; "provider_attempt_id"; "tool_batch_id"; "checkpoint_id"
+    ; "compaction_id"; "memory_injection_id"; "event_bus_correlation_id"
+    ; "event_bus_run_id"; "parent_event_id"; "caused_by"; "logical_seq"
+    ; "repair_reason"; "matched_started_ts"; "matched_started_status"
+    ; "error"; "exception_kind"; "latency_ms"
     ; "checkpoint_after_present"; "is_last"; "per_provider_timeout_s"
     ; "attempt_timeout_s"; "attempt_timeout_source"; "attempt_watchdog_source"
     ; "liveness_mode"; "liveness_budget_source"
@@ -439,9 +451,9 @@ let decision_public_allowlist =
 let clock_refs_public_allowlist =
   StringSet.of_list
     [ "edge_id"; "lane"; "source_clock"; "observed_at"; "started_at"; "finished_at"
-    ; "provider_attempt_id"; "tool_batch_id"; "checkpoint_id"; "compaction_id"
-    ; "memory_injection_id"; "event_bus_correlation_id"; "event_bus_run_id"
-    ; "parent_event_id"; "caused_by"
+    ; "elapsed_ms"; "provider_attempt_id"; "tool_batch_id"; "checkpoint_id"
+    ; "compaction_id"; "memory_injection_id"; "event_bus_correlation_id"
+    ; "event_bus_run_id"; "parent_event_id"; "caused_by"; "logical_seq"
     ]
 
 let rec reject_unknown_fields ~allowlist path = function
@@ -538,6 +550,7 @@ let to_json manifest =
       ("generation", json_of_int_opt manifest.generation);
       ("keeper_turn_id", json_of_int_opt manifest.keeper_turn_id);
       ("oas_turn_count", json_of_int_opt manifest.oas_turn_count);
+      ("logical_seq", json_of_int_opt manifest.logical_seq);
       ("event", `String (event_kind_to_string manifest.event));
       ("cascade_name", json_of_string_opt manifest.cascade_name);
       ("status", `String manifest.status);
@@ -556,6 +569,7 @@ let public_to_json manifest =
       ("generation", json_of_int_opt manifest.generation);
       ("keeper_turn_id", json_of_int_opt manifest.keeper_turn_id);
       ("oas_turn_count", json_of_int_opt manifest.oas_turn_count);
+      ("logical_seq", json_of_int_opt manifest.logical_seq);
       ("event", `String (event_kind_to_string manifest.event));
       ("cascade_name", json_of_string_opt manifest.cascade_name);
       ("status", `String manifest.status);
@@ -641,6 +655,7 @@ let of_json = function
             optional_int "generation" fields >>= fun generation ->
             optional_int "keeper_turn_id" fields >>= fun keeper_turn_id ->
             optional_int "oas_turn_count" fields >>= fun oas_turn_count ->
+            optional_int "logical_seq" fields >>= fun logical_seq ->
             required_string "event" fields >>= fun event_string ->
             (match event_kind_of_string event_string with
             | None -> Error (Printf.sprintf "unknown event: %S" event_string)
@@ -661,6 +676,7 @@ let of_json = function
                 generation;
                 keeper_turn_id;
                 oas_turn_count;
+                logical_seq;
                 event;
                 cascade_name;
                 status;

--- a/lib/keeper/keeper_runtime_manifest.mli
+++ b/lib/keeper/keeper_runtime_manifest.mli
@@ -41,6 +41,7 @@ type t = {
   generation : int option;
   keeper_turn_id : int option;
   oas_turn_count : int option;
+  logical_seq : int option;
   event : event_kind;
   cascade_name : string option;
   status : string;
@@ -88,6 +89,7 @@ val clock_refs :
   ?observed_at:string ->
   ?started_at:string ->
   ?finished_at:string ->
+  ?elapsed_ms:int ->
   ?provider_attempt_id:string ->
   ?tool_batch_id:string ->
   ?checkpoint_id:string ->
@@ -97,6 +99,7 @@ val clock_refs :
   ?event_bus_run_id:string ->
   ?parent_event_id:string ->
   ?caused_by:string ->
+  ?logical_seq:int ->
   unit ->
   Yojson.Safe.t
 
@@ -104,10 +107,12 @@ val clock_refs_for_context :
   turn_context ->
   event:event_kind ->
   ?oas_turn_count:int ->
+  ?elapsed_ms:int ->
   ?event_bus_correlation_id:string ->
   ?event_bus_run_id:string ->
   ?parent_event_id:string ->
   ?caused_by:string ->
+  ?logical_seq:int ->
   unit ->
   Yojson.Safe.t
 
@@ -133,6 +138,7 @@ val make :
   ?generation:int ->
   ?keeper_turn_id:int ->
   ?oas_turn_count:int ->
+  ?logical_seq:int ->
   event:event_kind ->
   ?cascade_name:string ->
   ?status:string ->
@@ -147,6 +153,7 @@ val make_for_context :
   turn_context ->
   event:event_kind ->
   ?oas_turn_count:int ->
+  ?logical_seq:int ->
   ?cascade_name:string ->
   ?status:string ->
   ?decision:Yojson.Safe.t ->

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -3413,6 +3413,143 @@ let test_public_to_json_redacts_decision () =
   Alcotest.(check bool) "public_to_json drops provider_secret" true
     (Yojson.Safe.Util.member "provider_secret" decision = `Null)
 
+let test_logical_seq_roundtrip () =
+  let manifest =
+    M.make ~keeper_name:"k" ~trace_id:"t" ~event:M.Turn_started
+      ~logical_seq:42 ()
+  in
+  let json = M.to_json manifest in
+  Alcotest.(check (option int))
+    "to_json preserves logical_seq" (Some 42)
+    (match Yojson.Safe.Util.member "logical_seq" json with
+     | `Int value -> Some value
+     | `Null -> None
+     | other -> Alcotest.fail ("unexpected logical_seq type: " ^ Json_util.kind_name other));
+  let public_json = M.public_to_json manifest in
+  Alcotest.(check (option int))
+    "public_to_json preserves logical_seq" (Some 42)
+    (match Yojson.Safe.Util.member "logical_seq" public_json with
+     | `Int value -> Some value
+     | `Null -> None
+     | other -> Alcotest.fail ("unexpected logical_seq type: " ^ Json_util.kind_name other));
+  match M.of_json json with
+  | Error msg -> Alcotest.fail ("of_json failed: " ^ msg)
+  | Ok parsed ->
+    Alcotest.(check (option int))
+      "of_json recovers logical_seq" (Some 42) parsed.logical_seq
+
+let test_logical_seq_backward_compat () =
+  let json_without_seq =
+    `Assoc
+      [ ("schema_version", `Int 1)
+      ; ("ts", `String "2026-05-22T00:00:00Z")
+      ; ("keeper_name", `String "k")
+      ; ("agent_name", `Null)
+      ; ("trace_id", `String "t")
+      ; ("generation", `Null)
+      ; ("keeper_turn_id", `Null)
+      ; ("oas_turn_count", `Null)
+      ; ("event", `String "turn_started")
+      ; ("cascade_name", `Null)
+      ; ("status", `String "ok")
+      ; ("decision", `Assoc [])
+      ; ("links", `Assoc
+           [ ("receipt_path", `Null)
+           ; ("checkpoint_path", `Null)
+           ; ("tool_call_log_path", `Null)
+           ])
+      ]
+  in
+  match M.of_json json_without_seq with
+  | Error msg -> Alcotest.fail ("of_json failed on legacy row: " ^ msg)
+  | Ok parsed ->
+    Alcotest.(check (option int))
+      "legacy row without logical_seq parses as None" None parsed.logical_seq
+
+let test_clock_refs_elapsed_ms () =
+  let refs = M.clock_refs ~started_at:"2026-05-22T00:00:00Z"
+    ~finished_at:"2026-05-22T00:00:01Z" ~elapsed_ms:1000 ()
+  in
+  match refs with
+  | `Assoc fields ->
+    Alcotest.(check (option int))
+      "clock_refs includes elapsed_ms" (Some 1000)
+      (match List.assoc_opt "elapsed_ms" fields with
+       | Some (`Int value) -> Some value
+       | _ -> None)
+  | other ->
+    Alcotest.fail ("clock_refs must be Assoc, got: " ^ Json_util.kind_name other)
+
+let test_clock_refs_logical_seq () =
+  let refs = M.clock_refs ~edge_id:"e1" ~logical_seq:7 () in
+  match refs with
+  | `Assoc fields ->
+    Alcotest.(check (option int))
+      "clock_refs includes logical_seq" (Some 7)
+      (match List.assoc_opt "logical_seq" fields with
+       | Some (`Int value) -> Some value
+       | _ -> None)
+  | other ->
+    Alcotest.fail ("clock_refs must be Assoc, got: " ^ Json_util.kind_name other)
+
+let test_clock_refs_for_context_logical_seq () =
+  let ctx : M.turn_context =
+    { manifest_keeper_name = "k"
+    ; manifest_agent_name = None
+    ; manifest_trace_id = "t"
+    ; manifest_generation = None
+    ; manifest_keeper_turn_id = Some 1
+    }
+  in
+  let refs = M.clock_refs_for_context ctx ~event:M.Turn_started ~logical_seq:3 () in
+  match refs with
+  | `Assoc fields ->
+    Alcotest.(check (option int))
+      "clock_refs_for_context includes logical_seq" (Some 3)
+      (match List.assoc_opt "logical_seq" fields with
+       | Some (`Int value) -> Some value
+       | _ -> None)
+  | other ->
+    Alcotest.fail ("clock_refs_for_context must be Assoc, got: " ^ Json_util.kind_name other)
+
+let test_public_projection_elapsed_ms_allowlist () =
+  let manifest =
+    M.make ~keeper_name:"k" ~trace_id:"t" ~event:M.Provider_attempt_started
+      ~decision:
+        (M.with_clock_refs
+           ~clock_refs:(M.clock_refs ~elapsed_ms:500 ())
+           (`Assoc []))
+      ()
+  in
+  let public = M.public_to_json manifest in
+  let decision = Yojson.Safe.Util.member "decision" public in
+  let clock_refs = Yojson.Safe.Util.member "clock_refs" decision in
+  Alcotest.(check (option int))
+    "public projection preserves elapsed_ms" (Some 500)
+    (match Yojson.Safe.Util.member "elapsed_ms" clock_refs with
+     | `Int value -> Some value
+     | `Null -> None
+     | other -> Alcotest.fail ("unexpected elapsed_ms type: " ^ Json_util.kind_name other))
+
+let test_public_projection_logical_seq_allowlist () =
+  let manifest =
+    M.make ~keeper_name:"k" ~trace_id:"t" ~event:M.Turn_started
+      ~decision:
+        (M.with_clock_refs
+           ~clock_refs:(M.clock_refs ~logical_seq:9 ())
+           (`Assoc []))
+      ()
+  in
+  let public = M.public_to_json manifest in
+  let decision = Yojson.Safe.Util.member "decision" public in
+  let clock_refs = Yojson.Safe.Util.member "clock_refs" decision in
+  Alcotest.(check (option int))
+    "public projection preserves logical_seq in clock_refs" (Some 9)
+    (match Yojson.Safe.Util.member "logical_seq" clock_refs with
+     | `Int value -> Some value
+     | `Null -> None
+     | other -> Alcotest.fail ("unexpected logical_seq type: " ^ Json_util.kind_name other))
+
 let test_runtime_manifest_contract_omits_provider_model_fields () =
   check_source_omits "lib/keeper/keeper_runtime_manifest.mli" "provider_kind";
   check_source_omits "lib/keeper/keeper_runtime_manifest.mli" "model_id";
@@ -3664,6 +3801,16 @@ let () =
           Alcotest.test_case "safe path segment" `Quick test_safe_segment;
           Alcotest.test_case "source_clock roundtrip" `Quick
             test_source_clock_roundtrip;
+          Alcotest.test_case "logical_seq roundtrip" `Quick
+            test_logical_seq_roundtrip;
+          Alcotest.test_case "logical_seq backward compat" `Quick
+            test_logical_seq_backward_compat;
+          Alcotest.test_case "clock_refs elapsed_ms" `Quick
+            test_clock_refs_elapsed_ms;
+          Alcotest.test_case "clock_refs logical_seq" `Quick
+            test_clock_refs_logical_seq;
+          Alcotest.test_case "clock_refs_for_context logical_seq" `Quick
+            test_clock_refs_for_context_logical_seq;
           Alcotest.test_case "context helper" `Quick test_context_helper;
         ] );
       ( "append",


### PR DESCRIPTION
## Summary
OAS §9.2 F5: wall-clock과 monotonic/logical clock이 혼재되어 negative duration, wall-clock skew, concurrent fiber/timeout/latency 분석에서 partial order misjudgment가 발생.

## Changes
- `logical_seq : int option` 추가: trace-scope monotonic sequence number로 causal ordering 보장 (wall-clock `ts`와 독립)
- `elapsed_ms : int option` 추가: `clock_refs` 내 same-source elapsed time 측정
- 두 필드 모두 `int option`으로 deserialization에서 backward compatible
- `manifest_top_level_allowlist`, `decision_public_allowlist`, `clock_refs_public_allowlist`에 포함하여 public projection 유지
- 5개 신규 테스트: roundtrip, backward compat, clock_refs, public projection

## Notes
- Pre-existing test failures 2개 (`runtime trace lens summarizes tool axis`, `runtime trace lens groups context and memory`)는 origin/main에서도 동일하게 발생하여 본 PR과 무관

## Test Plan
- [x] `dune build @check` pass
- [x] 신규 5개 schema test pass
- [ ] CI Build and Test (expected: same 2 pre-existing failures)

## RFC
F5는 RFC-0004 Phase A0.1의 후속 hardening. 별도 RFC 불필요 (additive only, backward compatible).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>