### PR TITLE
Remove keeper OAS timeout compat accessor

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -475,13 +475,6 @@ module KeeperKeepalive = struct
       ~max_turns:oas_max_turns_per_call
   ;;
 
-  (** Backward-compatible accessor: returns the env override or 300s default.
-      Prefer {!oas_timeout_for_estimated_input_tokens} when a live prompt
-      estimate is available. *)
-  let oas_timeout_sec =
-    Option.value ~default:oas_timeout_default_sec oas_timeout_sec_override
-  ;;
-
   (** Idle-gap timeout for streaming OAS provider responses.
       This bounds time between streamed lines, not total turn duration.
       Env: [MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC]. Default: 120. Range: [5, 600]. *)
@@ -500,10 +493,9 @@ module KeeperKeepalive = struct
       producing line breaks.
 
       Opt-in: unset env leaves [None] so {!Cascade_agent_context} skips
-      the builder wiring. Set to a value strictly less than the per-call
-      turn cap (e.g. 240–540s when [oas_timeout_sec] is 300–600s) for
-      attempt-level fall-forward; set [<= stream_idle_timeout_sec] for a
-      strict overall cap.
+      the builder wiring. Set to a value strictly less than the effective
+      OAS attempt cap for attempt-level fall-forward; set
+      [<= stream_idle_timeout_sec] for a strict overall cap.
 
       Env: [MASC_KEEPER_BODY_TIMEOUT_SEC]. Default: unset → [None].
       Range when set: [10, 600]. *)

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -183,7 +183,6 @@ module KeeperKeepalive : sig
     -> float
 
   val oas_timeout_for_estimated_input_tokens : estimated_input_tokens:int -> float
-  val oas_timeout_sec : float
   val stream_idle_timeout_sec : float
 
   val body_timeout_sec_override : float option

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -79,8 +79,7 @@ let adaptive = Cfg.KeeperKeepalive.oas_timeout_for_estimated_input_tokens
    turn envelope. Input-token size and max_turns no longer affect the computed
    budget; explicit env override remains the only way to change it. *)
 
-let turn_cap = Cfg.KeeperKeepalive.turn_timeout_sec
-let oas_cap = Cfg.KeeperKeepalive.oas_timeout_sec
+let oas_cap = 300.0
 
 let test_oas_timeout_32k_uses_oas_cap () =
   let v = adaptive ~estimated_input_tokens:32_000 in
@@ -122,7 +121,7 @@ let test_oas_timeout_is_token_independent () =
   let v3 = adaptive ~estimated_input_tokens:262_144 in
   check (float 0.1) "32K == 128K (both at OAS cap)" v1 v2;
   check (float 0.1) "128K == 262K (both at OAS cap)" v2 v3;
-  check (float 0.1) "all equal to oas_timeout_sec" oas_cap v1
+  check (float 0.1) "all equal to OAS cap" oas_cap v1
 
 let test_oas_timeout_cap () =
   let v = adaptive ~estimated_input_tokens:1_000_000 in
@@ -152,11 +151,6 @@ let test_scheduled_autonomous_max_turns_range () =
   check bool "scheduled autonomous max_turns >= 1" true (v >= 1);
   check bool "scheduled autonomous max_turns <= global" true
     (v <= Cfg.KeeperKeepalive.oas_max_turns_per_call)
-
-let test_oas_timeout_sec_compat () =
-  (* Without env override, oas_timeout_sec returns 300.0 default *)
-  let v = Cfg.KeeperKeepalive.oas_timeout_sec in
-  check (float 1.0) "backward compat default 300s" 300.0 v
 
 (* ── Semaphore wait timeout (defense against peer slot hoarding) ── *)
 
@@ -389,7 +383,6 @@ let () =
       test_case "max_turns range" `Quick test_max_turns_range;
       test_case "scheduled autonomous max_turns range" `Quick
         test_scheduled_autonomous_max_turns_range;
-      test_case "oas_timeout_sec backward compat" `Quick test_oas_timeout_sec_compat;
     ];
     "semaphore_wait_timeout", [
       test_case "default 60s" `Quick test_semaphore_wait_timeout_default;


### PR DESCRIPTION
## Summary
- remove the unused KeeperKeepalive.oas_timeout_sec compatibility accessor
- keep OAS timeout callers on the adaptive / turn-budget timeout APIs
- drop the compat-only test case and assert the documented 300s default cap directly

## Verification
- rg -n "Cfg\.KeeperKeepalive\.oas_timeout_sec|val oas_timeout_sec|let oas_timeout_sec|oas_timeout_sec backward compat|all equal to oas_timeout_sec|\[oas_timeout_sec\]" lib test -S (no accessor refs; only oas_timeout_sec_override remains)
- git diff --check
- ocamlformat --check lib/config/env_config_keeper.ml lib/config/env_config_keeper.mli test/test_work_as_heartbeat.ml
- scripts/dune-local.sh build test/test_work_as_heartbeat.exe (blocked by existing bare Dune processes; not forced to avoid adding contention)