### PR TITLE
feat(keeper_runtime_manifest): F5 logical clock + F6 provenance redaction guard

### DIFF
--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -3977,6 +3977,10 @@ let () =
             "public projection filters all provenance fields"
             `Quick
             test_public_projection_filters_all_provenance_fields;
+          Alcotest.test_case "public projection keeps elapsed_ms" `Quick
+            test_public_projection_elapsed_ms_allowlist;
+          Alcotest.test_case "public projection keeps logical_seq" `Quick
+            test_public_projection_logical_seq_allowlist;
           Alcotest.test_case
             "runtime manifest contract omits provider/model fields"
             `Quick

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -3413,6 +3413,55 @@ let test_public_to_json_redacts_decision () =
   Alcotest.(check bool) "public_to_json drops provider_secret" true
     (Yojson.Safe.Util.member "provider_secret" decision = `Null)
 
+(** F6: provider/model provenance taxonomy regression guard.
+    All fields emitted by [provider_attempt_provenance_fields] must be
+    redacted in public projection. If a new provenance field is added
+    there without updating the allowlist, this test catches the leak. *)
+let test_public_projection_filters_all_provenance_fields () =
+  let manifest =
+    M.make ~keeper_name:"k" ~trace_id:"t" ~event:M.Provider_attempt_started
+      ~decision:
+        (`Assoc
+           [ ("edge_id", `String "e1")
+           ; ("model_source", `String "named_cascade")
+           ; ("resolved_model_source", `String "cascade_catalog_binding")
+           ; ("capability_source", `String "provider_config_from_cascade_catalog")
+           ; ("fallback_authority", `String "declared_cascade")
+           ; ("provider_source_cascade", `String "ollama-local")
+           ; ("provider_secret", `String "shh")
+           ; ("latency_ms", `Int 42)
+           ])
+      ()
+  in
+  let private_json = M.to_json manifest in
+  let private_decision = Yojson.Safe.Util.member "decision" private_json in
+  Alcotest.(check bool) "private keeps model_source" true
+    (Yojson.Safe.Util.member "model_source" private_decision <> `Null);
+  Alcotest.(check bool) "private keeps resolved_model_source" true
+    (Yojson.Safe.Util.member "resolved_model_source" private_decision <> `Null);
+  Alcotest.(check bool) "private keeps capability_source" true
+    (Yojson.Safe.Util.member "capability_source" private_decision <> `Null);
+  Alcotest.(check bool) "private keeps fallback_authority" true
+    (Yojson.Safe.Util.member "fallback_authority" private_decision <> `Null);
+  Alcotest.(check bool) "private keeps provider_source_cascade" true
+    (Yojson.Safe.Util.member "provider_source_cascade" private_decision <> `Null);
+  let public_json = M.public_to_json manifest in
+  let public_decision = Yojson.Safe.Util.member "decision" public_json in
+  Alcotest.(check bool) "public drops model_source" true
+    (Yojson.Safe.Util.member "model_source" public_decision = `Null);
+  Alcotest.(check bool) "public drops resolved_model_source" true
+    (Yojson.Safe.Util.member "resolved_model_source" public_decision = `Null);
+  Alcotest.(check bool) "public drops capability_source" true
+    (Yojson.Safe.Util.member "capability_source" public_decision = `Null);
+  Alcotest.(check bool) "public drops fallback_authority" true
+    (Yojson.Safe.Util.member "fallback_authority" public_decision = `Null);
+  Alcotest.(check bool) "public drops provider_source_cascade" true
+    (Yojson.Safe.Util.member "provider_source_cascade" public_decision = `Null);
+  Alcotest.(check bool) "public drops provider_secret" true
+    (Yojson.Safe.Util.member "provider_secret" public_decision = `Null);
+  Alcotest.(check bool) "public keeps latency_ms" true
+    (Yojson.Safe.Util.member "latency_ms" public_decision <> `Null)
+
 let test_logical_seq_roundtrip () =
   let manifest =
     M.make ~keeper_name:"k" ~trace_id:"t" ~event:M.Turn_started
@@ -3924,6 +3973,10 @@ let () =
             test_to_json_preserves_full_decision;
           Alcotest.test_case "public_to_json redacts decision" `Quick
             test_public_to_json_redacts_decision;
+          Alcotest.test_case
+            "public projection filters all provenance fields"
+            `Quick
+            test_public_projection_filters_all_provenance_fields;
           Alcotest.test_case
             "runtime manifest contract omits provider/model fields"
             `Quick


### PR DESCRIPTION
## Summary
OAS §9.2 clock-spine hardening: F5 (logical clock separation) + F6 (provenance redaction regression guard).

## F5: Logical clock separation
- `logical_seq : int option` 추가: trace-scope monotonic sequence number로 causal ordering 보장 (wall-clock `ts`와 독립)
- `elapsed_ms : int option` 추가: `clock_refs` 내 same-source elapsed time 측정
- 두 필드 모두 `int option`으로 deserialization에서 backward compatible
- Allowlist-based public projection preserves both fields
- 5개 신규 테스트: roundtrip, backward compat, clock_refs, public projection

## F6: Provenance redaction regression guard
- provider_attempt_provenance_fields가 emit하는 5개 provenance 필드
  (model_source, resolved_model_source, capability_source, fallback_authority,
  provider_source_cascade)가 public projection에서 redaction되는 regression test
- 새 필드 추가 시 allowlist 미갱신 누수를 잡는 guard

## Notes
- Pre-existing test failures 2개 (`runtime trace lens summarizes tool axis`,
  `runtime trace lens groups context and memory`)는 origin/main에서도 동일하게
  발생하여 본 PR과 무관

## Test Plan
- [x] `dune build @check` pass
- [x] F5 신규 5개 schema test pass
- [x] F6 provenance redaction test pass
- [ ] CI Build and Test (expected: same 2 pre-existing failures)

## RFC
F5는 RFC-0004 Phase A0.1의 후속 hardening. 별도 RFC 불필요 (additive only, backward compatible).
F6은 테스트-only regression guard. 별도 RFC 불필요.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>