### PR TITLE
Remove keeper health string wrapper

### DIFF
--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -46,15 +46,14 @@ let keeper_health_of_string_opt = function
   | "dead" -> Some KH_dead
   | _ -> None
 
-(** Back-compat wrapper for callers not yet migrated to the option form.
-    Logs the unknown string once per call so drift is operator-visible
-    even when callers do not branch on it. *)
-let keeper_health_of_string s =
+let keeper_health_or_offline ~source s =
   match keeper_health_of_string_opt s with
   | Some h -> h
   | None ->
       Log.Keeper.warn
-        "keeper_health_of_string: unknown wire string %S → KH_offline fallback (#8670)" s;
+        "%s: unknown keeper health wire string %S -> KH_offline fallback (#8670)"
+        source
+        s;
       KH_offline
 
 let keeper_continuity_to_string = function
@@ -448,7 +447,7 @@ let augment_keeper_diagnostic_json
   let health_state =
     json_string_opt "health_state" diagnostic
     |> Option.value ~default:"offline"
-    |> keeper_health_of_string
+    |> keeper_health_or_offline ~source:"augment_keeper_diagnostic_json"
   in
   let continuity_state =
     keeper_continuity_state ~meta ~keepalive_running
@@ -484,7 +483,7 @@ let keeper_surface_status
   let health_state =
     json_string_opt "health_state" diagnostic
     |> Option.value ~default:"offline"
-    |> keeper_health_of_string
+    |> keeper_health_or_offline ~source:"keeper_surface_status"
   in
   let agent_runtime_status =
     json_string_opt "status" agent_status |> Option.map String.lowercase_ascii

--- a/lib/keeper/keeper_exec_status.mli
+++ b/lib/keeper/keeper_exec_status.mli
@@ -29,13 +29,10 @@ val augment_keeper_diagnostic_json :
 val keeper_health_to_string : keeper_health -> string
 
 (** Strict parse: returns [None] when the wire string is not one of the
-    seven canonical keeper_health labels. Prefer this over
-    [keeper_health_of_string] for new code so drift is visible. *)
+    seven canonical keeper_health labels so drift is visible at the
+    call site. *)
 val keeper_health_of_string_opt : string -> keeper_health option
 
-(** Back-compat parse: returns [KH_offline] on unknown strings and
-    logs a warning so the typo is operator-visible. Issue #8670. *)
-val keeper_health_of_string : string -> keeper_health
 val keeper_continuity_to_string : keeper_continuity -> string
 
 val keeper_health_state :

--- a/lib/operator/operator_control_snapshot_runtime_status.ml
+++ b/lib/operator/operator_control_snapshot_runtime_status.ml
@@ -26,7 +26,8 @@ let runtime_status_from_live_signal (agent_status_json : Yojson.Safe.t) =
 let health_state_allows_runtime_status_override (diagnostic : Yojson.Safe.t) =
   let kh =
     Safe_ops.json_string ~default:"offline" "health_state" diagnostic
-    |> Keeper_exec_status.keeper_health_of_string
+    |> Keeper_exec_status.keeper_health_of_string_opt
+    |> Option.value ~default:Keeper_types.KH_offline
   in
   match kh with
   | Keeper_types.KH_stale | KH_degraded | KH_zombie | KH_dead -> false


### PR DESCRIPTION
## Summary
- remove the public Keeper_exec_status.keeper_health_of_string compatibility parser
- keep strict keeper_health_of_string_opt as the public parse boundary
- make remaining fallback-to-offline handling explicit at call sites

## Verification
- rg -n "keeper_health_of_string\b" lib/keeper lib/operator test -S (no matches)
- git diff --check
- ocamlformat --check lib/keeper/keeper_exec_status.ml lib/keeper/keeper_exec_status.mli lib/operator/operator_control_snapshot_runtime_status.ml
- scripts/dune-local.sh build lib/keeper/keeper_exec_status.cmi lib/operator/operator_control_snapshot_runtime_status.cmi test/test_keeper_exec_status.exe (blocked by existing bare Dune process; not forced to avoid adding contention)