### PR TITLE
Remove activity graph status wrappers

### DIFF
--- a/lib/activity_graph/activity_graph_types.ml
+++ b/lib/activity_graph/activity_graph_types.ml
@@ -50,19 +50,6 @@ let node_status_of_string_opt = function
   | "" -> Some Unset
   | _ -> None
 
-(** Back-compat wrapper: unknown wire still falls back to [Observed] but a
-    [Log.Misc.warn] is emitted so producer/consumer drift surfaces in
-    operator logs instead of silently misclassifying the node. The previous
-    `_ -> Observed` arm was explicitly documented as "fail-open"; that
-    posture is preserved here, just observable. See #8777. *)
-let node_status_of_string s =
-  match node_status_of_string_opt s with
-  | Some v -> v
-  | None ->
-      Log.Misc.warn
-        "activity_graph: unknown node_status wire %S -> Observed (drift; see #8777)" s;
-      Observed
-
 (** Span status: separate from node_status (different lifecycle).
     @since 7182 *)
 type span_status =
@@ -90,19 +77,6 @@ let span_status_of_string_opt = function
   | "stopped" -> Some Span_stopped
   | "ended" -> Some Span_ended
   | _ -> None
-
-(** Back-compat wrapper: unknown wire still falls back to [Span_ended]
-    (the legacy permissive default), but a [Log.Misc.warn] is emitted so
-    producer/consumer drift surfaces in operator logs instead of silently
-    misclassifying the span as terminal. Same template as
-    [node_status_of_string] (#8779). See #8605. *)
-let span_status_of_string s =
-  match span_status_of_string_opt s with
-  | Some v -> v
-  | None ->
-      Log.Misc.warn
-        "activity_graph: unknown span_status wire %S -> Span_ended (drift; see #8605)" s;
-      Span_ended
 
 type entity_ref = {
   kind : string;

--- a/lib/activity_graph/activity_graph_types.mli
+++ b/lib/activity_graph/activity_graph_types.mli
@@ -30,11 +30,6 @@ val node_status_to_string : node_status -> string
     explicitly (drop / fallback / route). See #8777 / #8605. *)
 val node_status_of_string_opt : string -> node_status option
 
-(** Back-compat wrapper: unknown wire falls back to [Observed] but a
-    [Log.Misc.warn] is emitted so producer/consumer drift surfaces in
-    operator logs. See #8777. *)
-val node_status_of_string : string -> node_status
-
 (** {1 Span status}
 
     Separate lifecycle from {!node_status}.
@@ -49,11 +44,6 @@ val span_status_to_string : span_status -> string
 (** Strict parser: returns [None] on unknown wire so callers can react
     explicitly. Mirror of {!node_status_of_string_opt}. See #8605. *)
 val span_status_of_string_opt : string -> span_status option
-
-(** Back-compat parser: unknown wire still collapses to [Span_ended]
-    but emits a [Log.Misc.warn] so producer/consumer drift surfaces in
-    operator logs instead of silently misclassifying the span. *)
-val span_status_of_string : string -> span_status
 
 (** {1 Graph entities} *)
 

--- a/test/test_activity_graph.ml
+++ b/test/test_activity_graph.ml
@@ -560,16 +560,6 @@ let test_parse_since_ms_supports_minutes () =
   check (option int) "1h still parses" (Some (3600 * 1000))
     (Lib.Server_activity_http.parse_since_ms "1h")
 
-let test_span_status_of_string_handles_ended_round_trip () =
-  check string "ended round-trips explicitly" "ended"
-    (Activity_graph.span_status_of_string "ended"
-     |> Activity_graph.span_status_to_string)
-
-let test_span_status_of_string_keeps_legacy_unknown_fallback () =
-  check string "unknown falls back to ended" "ended"
-    (Activity_graph.span_status_of_string "definitely-not-a-status"
-     |> Activity_graph.span_status_to_string)
-
 let test_span_status_of_string_opt_returns_none_for_unknown () =
   (* #8605 family: strict variant exposes unknown wires explicitly so
      callers can react instead of being silently coerced to Span_ended. *)
@@ -617,10 +607,6 @@ let () =
             test_agent_spans_json_honors_since_ms;
           test_case "parse_since_ms supports minutes" `Quick
             test_parse_since_ms_supports_minutes;
-          test_case "span_status parses ended explicitly" `Quick
-            test_span_status_of_string_handles_ended_round_trip;
-          test_case "span_status keeps unknown fallback" `Quick
-            test_span_status_of_string_keeps_legacy_unknown_fallback;
           test_case "span_status_opt None for unknown" `Quick
             test_span_status_of_string_opt_returns_none_for_unknown;
         ] );


### PR DESCRIPTION
## Summary
- remove the public Activity_graph node_status_of_string and span_status_of_string compat wrappers
- keep the strict *_of_string_opt parsers as the only parse boundary
- drop tests that asserted legacy unknown span fallback behavior

## Verification
- rg -n "node_status_of_string\b|span_status_of_string\b|Back-compat parser|Back-compat wrapper" lib/activity_graph test/test_activity_graph.ml -S
- git diff --check
- ocamlformat --check lib/activity_graph/activity_graph_types.ml lib/activity_graph/activity_graph_types.mli test/test_activity_graph.ml
- scripts/dune-local.sh build test/test_activity_graph.exe (blocked: live bare Dune processes already running; wrapper refused to start another local build)