### PR TITLE
Remove legacy messages endpoint

### DIFF
--- a/docs/spec/09-server-transport.md
+++ b/docs/spec/09-server-transport.md
@@ -338,7 +338,6 @@ Sse.subscribe_external ~id:"ws-123"
 | GET | `/mcp/operator` | `handle_get_operator_mcp` | Operator SSE |
 | DELETE | `/mcp/operator` | `handle_delete_mcp ~profile:Operator_remote` | Operator 세션 종료 |
 | GET | `/sse` | `sse_simple_handler` | 단순 SSE (Observer) |
-| POST | `/messages` | `handle_post_messages` | 레거시 MCP 메시지 엔드포인트 |
 | GET | `/ws` | `websocket_discovery_json` | WebSocket discovery JSON (`enabled`, `ws_port`, `ws_url`) |
 | POST | `/webrtc/offer` | `handle_offer_request` | WebRTC offer signaling |
 | POST | `/webrtc/answer` | `handle_answer_request` | WebRTC answer signaling |
@@ -446,7 +445,7 @@ Access-Control-Expose-Headers: Mcp-Session-Id, Mcp-Protocol-Version
 Access-Control-Allow-Credentials: true
 ```
 
-MCP 경로(`/mcp`, `/sse`, `/messages`)에서 Origin 검증을 수행한다. 유효하지 않은 origin은 `403 Forbidden`.
+MCP 경로(`/mcp`, `/sse`)에서 Origin 검증을 수행한다. 유효하지 않은 origin은 `403 Forbidden`.
 
 ---
 

--- a/lib/server/server_bootstrap_http.ml
+++ b/lib/server/server_bootstrap_http.ml
@@ -58,7 +58,6 @@ let print_startup_banner
   Printf.printf "   GET  /api/v1/activity/events → Activity replay API\n%!";
   Printf.printf "   GET  /api/v1/activity/graph → Activity graph snapshot\n%!";
   Printf.printf "   GET  /health → Health check\n%!";
-  Printf.printf "   Compatibility (deprecated): GET /sse, POST /messages → use /mcp\n%!";
   if Masc_grpc_server.is_enabled ()
   then
     Printf.printf

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -513,8 +513,8 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
                                       ("Internal error: "
                                      ^ Printexc.to_string exn))))))))
 
-let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Full)
-    ?(sse_kind = Sse.Coordinator) request reqd =
+let handle_get_mcp ~deps ?(profile = Full) ?(sse_kind = Sse.Coordinator)
+    request reqd =
   if not (deps.is_ready ()) then
     respond_not_ready ~deps request reqd
   else
@@ -532,11 +532,6 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Full)
              deps.verify_mcp_auth ~base_path request)
     | Operator_remote ->
         deps.verify_operator_mcp_auth ~base_path request
-  in
-  let legacy_headers =
-    match legacy_messages_endpoint with
-    | Some _ -> legacy_transport_deprecation_headers
-    | None -> []
   in
   let last_event_id = get_last_event_id request in
   match validate_mcp_session_profile ~profile session_id with
@@ -567,7 +562,7 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Full)
       (match auth_result with
       | Error msg ->
           respond_mcp_error ~code:Mcp_error_code.Auth_error ~deps request reqd ~session_id
-            ~protocol_version ~extra_headers:legacy_headers msg
+            ~protocol_version msg
       | Ok () ->
       remember_mcp_profile session_id profile;
       (match check_sse_connect_guard session_id with
@@ -580,8 +575,7 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Full)
             Transport_metrics.inc_sse_reconnect ();
           let headers =
             Httpun.Headers.of_list
-              (legacy_headers
-              @ sse_stream_headers ~deps session_id protocol_version origin)
+              (sse_stream_headers ~deps session_id protocol_version origin)
           in
           let response = Httpun.Response.create ~headers `OK in
           let writer = Httpun.Reqd.respond_with_streaming reqd response in
@@ -613,15 +607,6 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Full)
           register_sse_conn ~session_id ~info;
           if not (send_raw info (sse_prime_event ())) then
             Log.Server.debug "SSE prime send failed for session %s" info.session_id;
-          (match legacy_messages_endpoint with
-          | None -> ()
-          | Some f ->
-              let endpoint_url = f session_id in
-              if not (send_raw info
-                        (Sse.format_event ~event_type:"endpoint" endpoint_url))
-              then
-                Log.Server.debug "SSE endpoint send failed for session %s"
-                  info.session_id);
           (match last_event_id with
           | Some last_id ->
               let missed = Sse.get_events_after_for_kind sse_kind last_id in
@@ -705,71 +690,6 @@ let handle_get_operator_mcp ~deps request reqd =
         msg
   | Ok () ->
       handle_get_mcp ~deps ~profile:Operator_remote request reqd
-
-let handle_post_messages ~deps request reqd =
-  if not (deps.is_ready ()) then
-    respond_not_ready ~deps request reqd
-  else
-  let origin = deps.get_origin request in
-  let legacy_headers = legacy_transport_deprecation_headers in
-  match get_session_id_any request with
-  | None ->
-      let body = "session_id required" in
-      let headers =
-        Httpun.Headers.of_list
-          (("content-length", string_of_int (String.length body))
-          :: (legacy_headers @ deps.cors_headers origin))
-      in
-      let response = Httpun.Response.create ~headers `Bad_request in
-      safe_respond_with_string reqd response body
-  | Some session_id when not (Mcp_session.is_valid session_id) ->
-      let body = "invalid session_id" in
-      let headers =
-        Httpun.Headers.of_list
-          (("content-length", string_of_int (String.length body))
-          :: (legacy_headers @ deps.cors_headers origin))
-      in
-      let response = Httpun.Response.create ~headers `Bad_request in
-      safe_respond_with_string reqd response body
-  | Some session_id ->
-      let protocol_version = get_protocol_version_for_session ~session_id request in
-      let auth_token = deps.auth_token_from_request request in
-      let base_path = deps.get_base_path () in
-      (match deps.verify_mcp_auth ~base_path request with
-      | Error msg ->
-          respond_mcp_error ~code:Mcp_error_code.Auth_error ~deps request reqd ~session_id
-            ~protocol_version ~extra_headers:legacy_headers msg
-      | Ok () ->
-          Http.Request.read_body_async reqd (fun body_str ->
-              match request_runtime_result deps with
-              | Error msg ->
-                  respond_mcp_error ~code:Mcp_error_code.Internal_error ~extra_headers:legacy_headers
-                    ~deps request reqd ~session_id ~protocol_version msg
-              | Ok runtime ->
-                  let sw = runtime.sw in
-                  Eio.Fiber.fork ~sw (fun () ->
-                  let body_with_agent =
-                    body_with_canonical_http_actor ~base_path ~auth_token
-                      request body_str
-                  in
-                  let internal_keeper_runtime =
-                    Server_auth.is_verified_internal_keeper_request
-                      ~base_path request
-                  in
-                  let response_json =
-                    runtime.handle_request ~mcp_session_id:session_id
-                      ?auth_token ~internal_keeper_runtime body_with_agent
-                  in
-                  (match response_json with
-                  | `Null -> ()
-                  | json -> Sse.send_to session_id json);
-                  let headers =
-                    Httpun.Headers.of_list
-                      (("content-length", "0")
-                      :: (legacy_headers @ mcp_headers session_id protocol_version))
-                  in
-                  let response = Httpun.Response.create ~headers `Accepted in
-                  safe_respond_with_string reqd response "")))
 
 let handle_delete_mcp ~deps ?(profile = Full) request reqd =
   if not (deps.is_ready ()) then

--- a/lib/server/server_mcp_transport_http.mli
+++ b/lib/server/server_mcp_transport_http.mli
@@ -71,7 +71,6 @@ val get_session_id_query : string -> string option
 val get_header_any_case : Httpun.Headers.t -> string -> string option
 val get_cookie_value : Httpun.Request.t -> string -> string option
 val get_session_id_any : Httpun.Request.t -> string option
-val legacy_messages_endpoint_url : Httpun.Request.t -> string -> string
 val get_protocol_version : Httpun.Request.t -> string
 val validate_protocol_version_continuity :
   session_id:string -> Httpun.Request.t -> (unit, string) result
@@ -87,7 +86,6 @@ val should_use_sse_for_body :
   string ->
   Mcp_transport_protocol.Http_negotiation.accept_mode ->
   bool
-val legacy_transport_deprecation_headers : (string * string) list
 val force_json_response : bool
 val get_last_event_id : Httpun.Request.t -> int option
 val mcp_headers : string -> string -> (string * string) list
@@ -107,15 +105,12 @@ val handle_post_mcp :
   unit
 val handle_get_mcp :
   deps:deps ->
-  ?legacy_messages_endpoint:(string -> string) ->
   ?profile:tool_profile ->
   ?sse_kind:Sse.session_kind ->
   Httpun.Request.t ->
   Httpun.Reqd.t ->
   unit
 val handle_get_operator_mcp :
-  deps:deps -> Httpun.Request.t -> Httpun.Reqd.t -> unit
-val handle_post_messages :
   deps:deps -> Httpun.Request.t -> Httpun.Reqd.t -> unit
 val handle_delete_mcp :
   deps:deps ->

--- a/lib/server/server_mcp_transport_http_headers.ml
+++ b/lib/server/server_mcp_transport_http_headers.ml
@@ -86,14 +86,6 @@ let should_use_sse_for_body (request : Httpun.Request.t) body_str accept_mode =
       && Http_negotiation.accepts_sse_header
            (Httpun.Headers.get request.headers "accept")
 
-let legacy_transport_deprecation_headers =
-  [
-    ("deprecation", "true");
-    ( "warning",
-      "299 - \"Legacy SSE endpoints (/sse,/messages) are deprecated; use /mcp\"" );
-    ("link", "</mcp>; rel=\"successor-version\"");
-  ]
-
 let force_json_response =
   env_flag "MASC_FORCE_JSON_RESPONSE" || env_flag "MCP_FORCE_JSON_RESPONSE"
 

--- a/lib/server/server_mcp_transport_http_headers.mli
+++ b/lib/server/server_mcp_transport_http_headers.mli
@@ -131,12 +131,6 @@ val json_headers :
     [deps.cors_headers origin].  The canonical "JSON response"
     builder used by every JSON-bodied response in the transport. *)
 
-val legacy_transport_deprecation_headers : (string * string) list
-(** Static three-header set ([deprecation: true],
-    [warning: 299 - "..."], [link: </mcp>; rel="successor-version"])
-    for the legacy SSE endpoints ([/sse], [/messages]) which are
-    being phased out in favour of the unified [/mcp] path. *)
-
 (** {1 SSE constants} *)
 
 val sse_retry_ms : int

--- a/lib/server/server_mcp_transport_http_protocol.ml
+++ b/lib/server/server_mcp_transport_http_protocol.ml
@@ -86,7 +86,4 @@ let classify_mcp_accept_for_body =
 let should_use_sse_for_body =
   Server_mcp_transport_http_headers.should_use_sse_for_body
 
-let legacy_transport_deprecation_headers =
-  Server_mcp_transport_http_headers.legacy_transport_deprecation_headers
-
 let force_json_response = Server_mcp_transport_http_headers.force_json_response

--- a/lib/server/server_mcp_transport_http_protocol.mli
+++ b/lib/server/server_mcp_transport_http_protocol.mli
@@ -132,10 +132,6 @@ val should_use_sse_for_body :
 (** Re-export of
     {!Server_mcp_transport_http_headers.should_use_sse_for_body}. *)
 
-val legacy_transport_deprecation_headers : (string * string) list
-(** Re-export of
-    {!Server_mcp_transport_http_headers.legacy_transport_deprecation_headers}. *)
-
 val force_json_response : bool
 (** Re-export of
     {!Server_mcp_transport_http_headers.force_json_response}.

--- a/lib/server/server_mcp_transport_http_session.ml
+++ b/lib/server/server_mcp_transport_http_session.ml
@@ -167,23 +167,6 @@ let get_session_id_any (request : Httpun.Request.t) =
       | Some _ as id -> id
       | None -> get_cookie_value request "mcp-session-id")
 
-let legacy_messages_endpoint_url (request : Httpun.Request.t) session_id =
-  match Httpun.Headers.get request.headers "host" with
-  | Some host ->
-      let proto =
-        match Httpun.Headers.get request.headers "x-forwarded-proto" with
-        | Some p -> p
-        | None ->
-            (* Length-mismatched [String.sub host 0 17 = "masc.crying.pict"]
-               (17-char substring vs 16-char literal) was always false, so
-               tunnel hosts silently advertised http://. starts_with also
-               drops a per-request allocation. *)
-            if String.starts_with ~prefix:"masc.crying.pict" host then "https"
-            else "http"
-      in
-      Printf.sprintf "%s://%s/messages?session_id=%s" proto host session_id
-  | None -> Printf.sprintf "/messages?session_id=%s" session_id
-
 let get_protocol_version (request : Httpun.Request.t) =
   match get_header_any_case request.headers "mcp-protocol-version" with
   | Some v -> v

--- a/lib/server/server_mcp_transport_http_session.mli
+++ b/lib/server/server_mcp_transport_http_session.mli
@@ -130,24 +130,6 @@ val get_session_id_any : Httpun.Request.t -> string option
     fallback order is the operator contract — clients that
     drop one channel still authenticate via the next. *)
 
-val legacy_messages_endpoint_url :
-  Httpun.Request.t -> string -> string
-(** [legacy_messages_endpoint_url request session_id] returns
-    the absolute URL for the legacy [/messages?session_id=...]
-    endpoint.
-
-    Protocol resolution:
-    - [X-Forwarded-Proto] header value when present.
-    - Otherwise [https] when [Host:] starts with the literal
-      prefix [["masc.crying.pict"]] (the Cloudflare tunnel
-      hostname); else [http].
-
-    The 16-char tunnel-host prefix is pinned at the contract
-    seam: an earlier version used a length-mismatched
-    [String.sub] (17-char substring vs 16-char literal) which
-    was always false, so tunnel hosts silently advertised
-    [http://].  Pinning prevents drift. *)
-
 (** {1 Protocol version resolution} *)
 
 val get_protocol_version : Httpun.Request.t -> string

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -69,9 +69,6 @@ let get_cookie_value = Server_mcp_transport_http.get_cookie_value
 
 let get_session_id_any = Server_mcp_transport_http.get_session_id_any
 
-let legacy_messages_endpoint_url =
-  Server_mcp_transport_http.legacy_messages_endpoint_url
-
 let get_protocol_version = Server_mcp_transport_http.get_protocol_version
 
 let get_protocol_version_for_session =
@@ -161,9 +158,6 @@ let request_force_json_response =
 
 let classify_mcp_accept = Server_mcp_transport_http.classify_mcp_accept
 
-let legacy_transport_deprecation_headers =
-  Server_mcp_transport_http.legacy_transport_deprecation_headers
-
 let force_json_response = Server_mcp_transport_http.force_json_response
 
 let get_last_event_id = Server_mcp_transport_http.get_last_event_id
@@ -239,18 +233,14 @@ let stop_sse_session = Server_mcp_transport_http.stop_sse_session
 let close_all_sse_connections =
   Server_mcp_transport_http.close_all_sse_connections
 
-let handle_get_mcp ?legacy_messages_endpoint
-    ?(profile = Server_mcp_transport_http.Full) ?sse_kind request reqd =
+let handle_get_mcp ?(profile = Server_mcp_transport_http.Full) ?sse_kind
+    request reqd =
   Server_mcp_transport_http.handle_get_mcp ~deps:(mcp_transport_http_deps ())
-    ?legacy_messages_endpoint ~profile ?sse_kind request reqd
+    ~profile ?sse_kind request reqd
 
 let handle_get_operator_mcp request reqd =
   Server_mcp_transport_http.handle_get_operator_mcp
     ~deps:(mcp_transport_http_deps ()) request reqd
-
-let handle_post_messages request reqd =
-  Server_mcp_transport_http.handle_post_messages ~deps:(mcp_transport_http_deps ())
-    request reqd
 
 let handle_post_mcp ?(profile = Server_mcp_transport_http.Full) request reqd =
   Server_mcp_transport_http.handle_post_mcp ~deps:(mcp_transport_http_deps ())

--- a/lib/server/server_routes_http_common.mli
+++ b/lib/server/server_routes_http_common.mli
@@ -94,8 +94,6 @@ val get_session_id_any : Httpun.Request.t -> string option
 val get_protocol_version : Httpun.Request.t -> string
 val get_protocol_version_for_session :
   ?session_id:string -> Httpun.Request.t -> string
-val legacy_messages_endpoint_url :
-  Httpun.Request.t -> string -> string
 
 (** {1 Server state} *)
 
@@ -123,8 +121,6 @@ val request_force_json_response : Httpun.Request.t -> bool
 val classify_mcp_accept :
   Httpun.Request.t ->
   Mcp_transport_protocol.Http_negotiation.accept_mode
-val legacy_transport_deprecation_headers :
-  (string * string) list
 val force_json_response : bool
 val get_last_event_id : Httpun.Request.t -> int option
 
@@ -145,7 +141,6 @@ val close_all_sse_connections : unit -> unit
 (** {1 MCP HTTP route handlers} *)
 
 val handle_get_mcp :
-  ?legacy_messages_endpoint:(string -> string) ->
   ?profile:Server_mcp_transport_http.tool_profile ->
   ?sse_kind:Sse.session_kind ->
   Httpun.Request.t ->
@@ -153,9 +148,6 @@ val handle_get_mcp :
   unit
 
 val handle_get_operator_mcp :
-  Httpun.Request.t -> Httpun.Reqd.t -> unit
-
-val handle_post_messages :
   Httpun.Request.t -> Httpun.Reqd.t -> unit
 
 val handle_post_mcp :

--- a/lib/server/server_routes_http_routes_frontend.ml
+++ b/lib/server/server_routes_http_routes_frontend.ml
@@ -261,4 +261,3 @@ let add_routes ~port ~host router =
   |> Http.Router.add ~path:"/graphql" ~methods:[`GET; `POST]
        ~handler:(fun request reqd ->
          with_read_auth (fun _state req reqd -> handle_graphql req reqd) request reqd)
-  |> Http.Router.post "/messages" handle_post_messages

--- a/scripts/harness/contract/streamable_http_contract.sh
+++ b/scripts/harness/contract/streamable_http_contract.sh
@@ -156,7 +156,7 @@ header_value() {
   ' "$header_file"
 }
 
-echo "[1/8] json-only Accept is rejected"
+echo "[1/7] json-only Accept is rejected"
 wait_for_mcp_ready
 h1="$tmpdir/json-only-accept.headers"
 b1="$tmpdir/json-only-accept.body"
@@ -176,7 +176,7 @@ if ! grep -qi "Invalid Accept header" "$b1"; then
   exit 1
 fi
 
-echo "[2/8] streamable Accept success"
+echo "[2/7] streamable Accept success"
 h2="$tmpdir/ok.headers"
 b2="$tmpdir/ok.body"
 post_with_accept "application/json, text/event-stream" \
@@ -197,7 +197,7 @@ if [ -z "$SESSION_ID" ] || [ -z "$PROTOCOL_VERSION" ]; then
   exit 1
 fi
 
-echo "[3/8] follow-up POST accepts missing protocol header via session continuity"
+echo "[3/7] follow-up POST accepts missing protocol header via session continuity"
 h3="$tmpdir/missing-protocol.headers"
 b3="$tmpdir/missing-protocol.body"
 post_with_session "$SESSION_ID" "" \
@@ -211,7 +211,7 @@ if [ "$code3" != "200" ]; then
   exit 1
 fi
 
-echo "[4/8] follow-up POST rejects mismatched protocol header"
+echo "[4/7] follow-up POST rejects mismatched protocol header"
 h4="$tmpdir/mismatch-protocol.headers"
 b4="$tmpdir/mismatch-protocol.body"
 post_with_session "$SESSION_ID" "2025-03-26" \
@@ -230,7 +230,7 @@ if ! grep -qi "mismatch" "$b4"; then
   exit 1
 fi
 
-echo "[5/8] follow-up POST succeeds with matching protocol header"
+echo "[5/7] follow-up POST succeeds with matching protocol header"
 h5="$tmpdir/match-protocol.headers"
 b5="$tmpdir/match-protocol.body"
 post_with_session "$SESSION_ID" "$PROTOCOL_VERSION" \
@@ -244,7 +244,7 @@ if [ "$code5" != "200" ]; then
   exit 1
 fi
 
-echo "[6/8] follow-up GET accepts missing protocol header via session continuity"
+echo "[6/7] follow-up GET accepts missing protocol header via session continuity"
 h6="$tmpdir/get-missing-protocol.headers"
 b6="$tmpdir/get-missing-protocol.body"
 get_with_session "$SESSION_ID" "" "$h6" "$b6"
@@ -256,7 +256,7 @@ if [ "$code6" != "200" ]; then
   exit 1
 fi
 
-echo "[7/8] follow-up DELETE accepts missing protocol header via session continuity"
+echo "[7/7] follow-up DELETE accepts missing protocol header via session continuity"
 h7="$tmpdir/delete-missing-protocol.headers"
 b7="$tmpdir/delete-missing-protocol.body"
 delete_with_session "$SESSION_ID" "" "$h7" "$b7"
@@ -267,29 +267,5 @@ if [ "$code7" != "200" ] && [ "$code7" != "204" ]; then
   cat "$b7"
   exit 1
 fi
-
-echo "[8/8] /sse deprecation headers"
-h8="$tmpdir/sse.headers"
-curl -sS -D "$h8" -o /dev/null --max-time 1 \
-  -H 'Accept: text/event-stream' \
-  "$BASE_URL/sse" || true
-require_header_contains "$h8" "Deprecation" "true"
-require_header_contains "$h8" "Link" "</mcp>; rel=\"successor-version\""
-
-echo "[legacy] /messages deprecation headers"
-h9="$tmpdir/messages.headers"
-b9="$tmpdir/messages.body"
-curl -sS -D "$h9" -o "$b9" \
-  -X POST "$BASE_URL/messages" \
-  -H 'Content-Type: application/json' \
-  -d '{"jsonrpc":"2.0","id":9,"method":"ping"}'
-code9="$(status_code "$h9")"
-if [ "$code9" != "400" ]; then
-  echo "FAIL: expected 400 for missing session_id on /messages, got $code9"
-  cat "$h9"
-  cat "$b9"
-  exit 1
-fi
-require_header_contains "$h9" "Deprecation" "true"
 
 echo "PASS: streamable_http contract harness"


### PR DESCRIPTION
## Summary
- remove the deprecated POST /messages MCP compatibility route and handler
- drop legacy endpoint advertisement support from GET /mcp
- remove legacy transport deprecation headers and stale contract/docs references

## Verification
- opam exec -- ocamlformat --check lib/server/server_mcp_transport_http.ml lib/server/server_mcp_transport_http.mli lib/server/server_mcp_transport_http_session.ml lib/server/server_mcp_transport_http_session.mli lib/server/server_mcp_transport_http_headers.ml lib/server/server_mcp_transport_http_headers.mli lib/server/server_mcp_transport_http_protocol.ml lib/server/server_mcp_transport_http_protocol.mli lib/server/server_routes_http_common.ml lib/server/server_routes_http_common.mli lib/server/server_routes_http_routes_frontend.ml lib/server/server_bootstrap_http.ml
- bash -n scripts/harness/contract/streamable_http_contract.sh
- git diff --check
- bash scripts/lint/no-inline-error-envelope.sh
- bash scripts/lint-spawn-bounded.sh

Note: focused Dune build could not complete locally because concurrent bare Dune processes blocked the repo wrapper, and isolated Dune builds stayed silent for multiple minutes; this PR is draft for CI verification.