### PR TITLE
refactor(keeper_turn_driver): extract named resolution

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -219,7 +219,7 @@
   cascade_metrics_registry
   cascade_transport_cli_config
   keeper_oas_checkpoint
-  keeper_cascade_engine
+  keeper_cascade_engine keeper_turn_driver_named_resolution
   keeper_turn_driver_provider_attempt
   keeper_turn_driver
   keeper_turn_driver_helpers

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -125,36 +125,20 @@ let run_named
     || keeper_internal_tools_require_materialized_runtime_surface
          ~keeper_name tools
   in
-  let ( configured_labels_result,
-        candidate_cfgs_result,
-        tiered_providers_result,
-        secondary_resolver ) =
-    let named_resolution =
-      Cascade_catalog_runtime
-      .resolve_named_providers_strict_with_secondary_resolver
-        ~sw ~net ?provider_filter ~cascade_name ()
-    in
-    let candidate_cfgs_result =
-      match named_resolution with
-      | Ok resolution -> Ok resolution.providers
-      | Error detail -> Error detail
-    in
-    let tiered_providers_result =
-      match named_resolution with
-      | Ok resolution -> Ok resolution.tiered_providers
-      | Error detail -> Error detail
-    in
-    let secondary_resolver =
-      match named_resolution with
-      | Ok resolution -> Some resolution.secondary_resolver
-      | Error _ -> None
-    in
-    ( Cascade_runtime.models_of_cascade_name_result runtime_cascade_name,
-      candidate_cfgs_result,
-      tiered_providers_result,
-      secondary_resolver )
+  let named_resolution =
+    Keeper_turn_driver_named_resolution.resolve
+      ~sw
+      ~net
+      ?provider_filter
+      ~cascade_name
+      ~runtime_cascade_name
+      ()
   in
-  (match configured_labels_result, candidate_cfgs_result, tiered_providers_result with
+  (match
+     ( named_resolution.configured_labels_result,
+       named_resolution.candidate_cfgs_result,
+       named_resolution.tiered_providers_result )
+   with
    | Error detail, _, _ | _, Error detail, _ | _, _, Error detail ->
        Log.Misc.error "cascade %s: %s" cascade_name detail;
        Error (cascade_catalog_error_to_sdk_error detail)
@@ -170,7 +154,7 @@ let run_named
       ~tools
       ~require_tool_choice_support
       ~require_tool_support
-      ?secondary_resolver
+      ?secondary_resolver:named_resolution.secondary_resolver
       ~label:cascade_name
       candidate_cfgs
   in

--- a/lib/keeper/keeper_turn_driver_named_resolution.ml
+++ b/lib/keeper/keeper_turn_driver_named_resolution.ml
@@ -1,0 +1,43 @@
+(** Named cascade resolution setup for keeper turn driver. *)
+
+type secondary_resolver =
+  int ->
+  Llm_provider.Provider_config.t ->
+  Llm_provider.Provider_config.t option
+
+type t = {
+  configured_labels_result : (string list, string) result;
+  candidate_cfgs_result : (Llm_provider.Provider_config.t list, string) result;
+  tiered_providers_result :
+    (Cascade_catalog_runtime_named_providers.tiered_provider list, string) result;
+  secondary_resolver : secondary_resolver option;
+}
+
+let resolve ~sw ~net ?provider_filter ~cascade_name ~runtime_cascade_name () =
+  let named_resolution =
+    Cascade_catalog_runtime
+    .resolve_named_providers_strict_with_secondary_resolver
+      ~sw ~net ?provider_filter ~cascade_name ()
+  in
+  let candidate_cfgs_result =
+    match named_resolution with
+    | Ok resolution -> Ok resolution.providers
+    | Error detail -> Error detail
+  in
+  let tiered_providers_result =
+    match named_resolution with
+    | Ok resolution -> Ok resolution.tiered_providers
+    | Error detail -> Error detail
+  in
+  let secondary_resolver =
+    match named_resolution with
+    | Ok resolution -> Some resolution.secondary_resolver
+    | Error _ -> None
+  in
+  {
+    configured_labels_result =
+      Cascade_runtime.models_of_cascade_name_result runtime_cascade_name;
+    candidate_cfgs_result;
+    tiered_providers_result;
+    secondary_resolver;
+  }

--- a/lib/keeper/keeper_turn_driver_named_resolution.mli
+++ b/lib/keeper/keeper_turn_driver_named_resolution.mli
@@ -1,0 +1,23 @@
+(** Named cascade resolution setup for keeper turn driver. *)
+
+type secondary_resolver =
+  int ->
+  Llm_provider.Provider_config.t ->
+  Llm_provider.Provider_config.t option
+
+type t = {
+  configured_labels_result : (string list, string) result;
+  candidate_cfgs_result : (Llm_provider.Provider_config.t list, string) result;
+  tiered_providers_result :
+    (Cascade_catalog_runtime_named_providers.tiered_provider list, string) result;
+  secondary_resolver : secondary_resolver option;
+}
+
+val resolve :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?provider_filter:string list ->
+  cascade_name:string ->
+  runtime_cascade_name:Keeper_cascade_profile.runtime_name ->
+  unit ->
+  t


### PR DESCRIPTION
## Product impact

- No user-facing behavior change expected.
- Narrows `Keeper_turn_driver.run_named` by moving named cascade resolution setup into a focused helper module.

## Summary

- Extract named cascade resolution setup from `Keeper_turn_driver.run_named`.
- Add `Keeper_turn_driver_named_resolution` with resolved labels, provider candidates, tiered providers, and optional secondary resolver.
- Keep downstream provider filtering/admission behavior unchanged.

## Evidence

- `ocamlformat --check lib/keeper/keeper_turn_driver.ml lib/keeper/keeper_turn_driver_named_resolution.ml lib/keeper/keeper_turn_driver_named_resolution.mli`
- `scripts/ocaml-structure-ratchet.sh`
- `git diff --check`
- `git diff --check origin/main..HEAD`
- `scripts/check-pr-hygiene.sh --base origin/main --head HEAD`

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/0
provenance: n/a
stages: []
```

- `keeper_turn_driver.ml` reduced from 1954 to 1928 lines.
- New helper files:
  - `lib/keeper/keeper_turn_driver_named_resolution.ml`
  - `lib/keeper/keeper_turn_driver_named_resolution.mli`

## GOAL LOOP ACT checklist

- [ ] Observe — N/A: refactor-only extraction, no runtime failure targeted.
- [x] Orient — continued keeper god-file reduction on the next large turn-driver surface.
- [x] Decide — bounded extraction of named cascade resolution setup only.
- [x] Act — helper module added and existing call site rewired.
- [x] Verify — formatter, structure ratchet, diff whitespace, and PR hygiene passed.
- [x] Loop — remaining follow-up continues in the existing decomposition queue.

## Review evidence

- Local review checked that the extracted helper only packages the existing `resolve_named_providers_strict_with_secondary_resolver` outputs and the existing `Cascade_runtime.models_of_cascade_name_result` call.
- Downstream filtering still receives the same candidate configs, tiered providers, configured labels, and secondary resolver.

## Linked issue

- None. Decomposition follow-up in the ongoing keeper god-file reduction queue.

## Variant addition checklist

- [ ] **OCaml** — N/A: no variant added, removed, or renamed.
- [ ] **TypeScript** — N/A: no dashboard union type changed.
- [ ] **TLA+ spec** — N/A: no TLA+ domain literal changed.
- [ ] **Event / JSON schema** — N/A: no event type or JSON schema enum changed.
- [ ] **`make check-variants` passes** — N/A: no variant/schema domain change.

## Dune

- `scripts/dune-local.sh build lib/masc_mcp_lib.a` refused with exit 75 because live bare Dune processes were already running outside `scripts/dune-local.sh`; I did not bypass with `MASC_DUNE_ALLOW_BARE_DUNE=1`.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/turn-driver-named-resolution-20260522` → `main` · 1 commit(s) · synced 2026-05-22T03:34:53Z

| sha | subject | date |
|---|---|---|
| `2c369549e` | refactor(keeper_turn_driver): extract named resolution | 2026-05-22 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->