### PR TITLE
Remove SDK param type wrapper

### DIFF
--- a/lib/sdk_tool_contract.ml
+++ b/lib/sdk_tool_contract.ml
@@ -285,20 +285,6 @@ let param_type_of_schema_opt schema : Agent_sdk.Types.param_type option =
   | "object" -> Some Agent_sdk.Types.Object
   | _ -> None
 
-(* Back-compat wrapper: warns once per unknown JSON Schema type and falls
-   back to [String] (the legacy permissive default mirrored by the
-   upstream Agent_sdk.Mcp.json_schema_type_to_param_type). The warn
-   converts the silent #8605-family fallback into an observable signal
-   without changing the tool-registration result. *)
-let param_type_of_schema schema =
-  match param_type_of_schema_opt schema with
-  | Some t -> t
-  | None ->
-      Log.Misc.warn
-        "param_type_of_schema: unknown JSON Schema type %S -> String (drift; see #8832)"
-        (schema_type schema);
-      Agent_sdk.Types.String
-
 let tool_params_of_input_schema schema =
   let required = required_names schema in
   property_map schema
@@ -311,7 +297,14 @@ let tool_params_of_input_schema schema =
            {
              name;
              description;
-             param_type = param_type_of_schema property_schema;
+             param_type =
+               (match param_type_of_schema_opt property_schema with
+               | Some t -> t
+               | None ->
+                   Log.Misc.warn
+                     "tool_params_of_input_schema: unknown JSON Schema type %S -> String (drift; see #8832)"
+                     (schema_type property_schema);
+                   Agent_sdk.Types.String);
              required = List.mem name required;
            }
          in

--- a/lib/sdk_tool_contract.mli
+++ b/lib/sdk_tool_contract.mli
@@ -13,11 +13,10 @@
     [find_property] / [assoc_members] / [int_member],
     [schema_type] / [label_or_default],
     [validate_json_value] / [validate_input_json],
-    [param_type_of_schema_opt] / [param_type_of_schema] /
-    [tool_params_of_input_schema], and [build_operation_arguments])
-    are hidden — callers consume the typed records, the lookup
-    helpers, the canonical operation list, and the resolver entry
-    points only. *)
+    [param_type_of_schema_opt] / [tool_params_of_input_schema], and
+    [build_operation_arguments]) are hidden — callers consume the
+    typed records, the lookup helpers, the canonical operation list,
+    and the resolver entry points only. *)
 
 (** {1 Typed binding} *)
 
@@ -93,10 +92,6 @@ val param_type_of_schema_opt :
     documented vocabulary ([string] / [integer] / [number] /
     [boolean] / [array] / [object]); [None] for non-vocabulary
     values like [null] / typos / tuple variants (#8832). *)
-
-val param_type_of_schema : Yojson.Safe.t -> Agent_sdk.Types.param_type
-(** Permissive variant of {!param_type_of_schema_opt} that defaults
-    unknown / missing types to [String]. *)
 
 (** {1 Discovery payload} *)
 

--- a/test/test_param_type_classifier.ml
+++ b/test/test_param_type_classifier.ml
@@ -4,9 +4,7 @@
     - the strict [_opt] variant returns [Some] only for documented
       JSON Schema vocabulary,
     - unknown types (e.g. "null", future JSON Schema 2020-12 keywords)
-      return [None] (no silent permissive default),
-    - the back-compat wrapper preserves the legacy [String] fallback so
-      existing tool registrations see no behaviour change. *)
+      return [None] (no silent permissive default). *)
 
 open Alcotest
 
@@ -58,17 +56,6 @@ let test_unknown_types_return_none () =
     None
     (Contract.param_type_of_schema_opt (schema_with_type "tuple"))
 
-let test_wrapper_preserves_legacy_default () =
-  (* Back-compat: unknown type still falls back to String (with a warn
-     line going to the log). *)
-  let open Agent_sdk.Types in
-  check param_type_testable "unknown type -> String legacy"
-    String
-    (Contract.param_type_of_schema (schema_with_type "null"));
-  check param_type_testable "known type unchanged"
-    Integer
-    (Contract.param_type_of_schema (schema_with_type "integer"))
-
 let test_no_type_field_falls_through_schema_type () =
   (* schema_type returns "object" when no "type" field but properties
      exist; "string" otherwise. The strict classifier should still hit
@@ -95,10 +82,5 @@ let () =
             test_unknown_types_return_none;
           test_case "no type field still resolves via schema_type" `Quick
             test_no_type_field_falls_through_schema_type;
-        ] );
-      ( "back-compat wrapper",
-        [
-          test_case "wrapper preserves legacy String default" `Quick
-            test_wrapper_preserves_legacy_default;
         ] );
     ]


### PR DESCRIPTION
## Summary
- remove the public Sdk_tool_contract.param_type_of_schema permissive wrapper
- keep param_type_of_schema_opt as the strict classifier API
- make the remaining tool registration fallback explicit inside tool_params_of_input_schema
- drop wrapper-only tests from test_param_type_classifier

## Verification
- rg -n "param_type_of_schema\b|Back-compat wrapper|back-compat wrapper" lib/sdk_tool_contract.ml lib/sdk_tool_contract.mli test/test_param_type_classifier.ml -S
- git diff --check origin/main...HEAD
- ocamlformat --check lib/sdk_tool_contract.ml lib/sdk_tool_contract.mli test/test_param_type_classifier.ml
- scripts/dune-local.sh build test/test_param_type_classifier.exe (blocked: live bare Dune processes already running; wrapper refused to start another local build)