### PR TITLE
refactor(keeper_agent_run): move contract status helpers

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -866,17 +866,9 @@ let run_turn
                    let actionable_tool_contract_violation_reason =
                      actionable_contract.violation_reason
                    in
-                   let contract_violation_error reason =
-                     Agent_sdk.Error.Agent
-                       (Agent_sdk.Error.CompletionContractViolation
-                          { contract = Agent_sdk.Completion_contract_id.Require_tool_use
-                          ; reason
-                          ; violation_detail = None
-                          })
-                   in
                    let tool_contract_status ()
                        : Keeper_execution_receipt.tool_contract_result =
-                     tool_contract_result_for_observed_tools
+                     Contract_helpers.observed_tool_contract_status
                        ~required_tool_names:acc.tool_surface.required_tool_names
                        ~missing_visible_required:
                          acc.tool_surface.missing_required_tool_names
@@ -916,7 +908,8 @@ let run_turn
                          ~turns:result.turns
                          ~actual_keeper_tool_names
                          ~reason;
-                       Error (contract_violation_error reason)
+                       Error
+                         (Contract_helpers.completion_contract_violation_error reason)
                      | Ok (), None ->
                        acc.receipt_tool_contract_result <- tool_contract_status ();
                        Ok (`Provider_text text)
@@ -937,7 +930,8 @@ let run_turn
                          ~turns:result.turns
                          ~actual_keeper_tool_names
                          ~reason;
-                       Error (contract_violation_error reason)
+                       Error
+                         (Contract_helpers.completion_contract_violation_error reason)
                    in
                    let finalize_response_text raw_response_text =
                      let stop_reason_str =

--- a/lib/keeper/keeper_agent_run_contract_helpers.ml
+++ b/lib/keeper/keeper_agent_run_contract_helpers.ml
@@ -53,3 +53,21 @@ let no_progress_success_tool_names_for_contract
   =
   keeper_tool_names_for_outcome ~allowed_tool_names ~tool_calls ~outcome:"ok_no_progress"
 ;;
+
+let completion_contract_violation_error reason =
+  Agent_sdk.Error.Agent
+    (Agent_sdk.Error.CompletionContractViolation
+       { contract = Agent_sdk.Completion_contract_id.Require_tool_use
+       ; reason
+       ; violation_detail = None
+       })
+;;
+
+let observed_tool_contract_status ~required_tool_names ~missing_visible_required
+      ~had_owned_active_task_at_turn_start ~actual_keeper_tool_names
+  : Keeper_execution_receipt.tool_contract_result
+  =
+  Keeper_agent_tool_surface.tool_contract_result_for_observed_tools
+    ~required_tool_names ~missing_visible_required ~had_owned_active_task_at_turn_start
+    ~actual_keeper_tool_names
+;;

--- a/lib/keeper/keeper_agent_run_contract_helpers.mli
+++ b/lib/keeper/keeper_agent_run_contract_helpers.mli
@@ -18,3 +18,13 @@ val no_progress_success_tool_names_for_contract :
   allowed_tool_names:string list ->
   tool_calls:Keeper_agent_result.tool_call_detail list ->
   string list
+
+val completion_contract_violation_error :
+  string -> Agent_sdk.Error.sdk_error
+
+val observed_tool_contract_status :
+  required_tool_names:string list ->
+  missing_visible_required:string list ->
+  had_owned_active_task_at_turn_start:bool ->
+  actual_keeper_tool_names:string list ->
+  Keeper_execution_receipt.tool_contract_result


### PR DESCRIPTION
## Summary

- move completion-contract violation error construction into `Keeper_agent_run_contract_helpers`
- move observed tool contract status calculation into `Keeper_agent_run_contract_helpers`
- keep `Keeper_agent_run.run_turn` focused on turn flow instead of local helper definitions

## Product impact

- User-visible change: none expected; refactor-only helper extraction.

## Evidence

- `ocamlformat --check lib/keeper/keeper_agent_run.ml lib/keeper/keeper_agent_run_contract_helpers.ml lib/keeper/keeper_agent_run_contract_helpers.mli`
- `scripts/ocaml-structure-ratchet.sh`
- `git diff --check`
- `git diff --check origin/main..HEAD`
- `scripts/check-pr-hygiene.sh --base origin/main --head HEAD`

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/0
provenance: n/a
stages: []
```

- `keeper_agent_run.ml` reduced from 1954 to 1948 lines on this base.
- Changed files are limited to `keeper_agent_run.ml` and `keeper_agent_run_contract_helpers.{ml,mli}`.

## GOAL LOOP ACT checklist

- [ ] Observe — N/A: refactor-only extraction, no runtime failure targeted.
- [x] Orient — continued keeper god-file reduction in `Keeper_agent_run`.
- [x] Decide — bounded extraction of two local contract helpers.
- [x] Act — helper functions added and call site rewired.
- [x] Verify — formatter, structure ratchet, diff whitespace, and PR hygiene passed.
- [x] Loop — remaining follow-up continues in the decomposition queue.

## Review evidence

- Local review checked that the extracted functions preserve the same `CompletionContractViolation` payload and still delegate status calculation to `tool_contract_result_for_observed_tools`.

## Linked issue

- None. Decomposition follow-up in the ongoing keeper god-file reduction queue.

## Variant addition checklist

- [ ] **OCaml** — N/A: no variant added, removed, or renamed.
- [ ] **TypeScript** — N/A: no dashboard union type changed.
- [ ] **TLA+ spec** — N/A: no TLA+ domain literal changed.
- [ ] **Event / JSON schema** — N/A: no event type or JSON schema enum changed.
- [ ] **`make check-variants` passes** — N/A: no variant/schema domain change.

## Dune

- `scripts/dune-local.sh build lib/masc_mcp_lib.a` refused with exit 75 because live bare Dune processes were already running outside `scripts/dune-local.sh`; I did not bypass with `MASC_DUNE_ALLOW_BARE_DUNE=1`.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/agent-run-contract-status-helper-20260522` → `main` · 1 commit(s) · synced 2026-05-22T03:40:41Z

| sha | subject | date |
|---|---|---|
| `3e7d4008d` | refactor(keeper_agent_run): move contract status helpers | 2026-05-22 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->