### PR TITLE
Remove legacy voice MCP env fallback

### DIFF
--- a/docs/BOOT-ENV-STATE-INVENTORY.md
+++ b/docs/BOOT-ENV-STATE-INVENTORY.md
@@ -361,7 +361,6 @@ Notes:
   Discord bot. When the bot uses relative paths, resolve them against the same
   `MASC_BASE_PATH` as the server. Operational setup and verification steps live
   in `sidecars/discord-bot/README.md`.
-- `VOICE_MCP_HOST` and `VOICE_MCP_PORT` remain legacy environment fallbacks.
 - All voice paths resolve relative to `MASC_BASE_PATH/.masc/`.
   `voice_config.json` is discovered at `<runtime_root>/voice_config.json`
   where `<runtime_root>` = `MASC_BASE_PATH/.masc/`.
@@ -595,8 +594,6 @@ MASC_ZOMBIE_CLEANUP_INTERVAL_SEC
 MASC_ZOMBIE_THRESHOLD_SEC
 OLLAMA_DEFAULT_MODEL
 OLLAMA_SERVER_URL
-VOICE_MCP_HOST
-VOICE_MCP_PORT
 ZAI_BASE_URL
 ```
 
@@ -731,5 +728,5 @@ To regenerate the inventories:
 ```bash
 rg -oN '"MASC_[A-Z0-9_]+"' lib/config/env_config_core.ml lib/config/env_config_runtime.ml lib/config/env_config_governance.ml lib/config/env_config_keeper.ml | tr -d '"' | sort -u
 rg -oN '"MASC_[A-Z0-9_]+"' lib bin | tr -d '"' | sort -u
-rg -oN '"(LLAMA_[A-Z0-9_]+|OLLAMA_[A-Z0-9_]+|VOICE_MCP_[A-Z0-9_]+|HOME|DUNE_SOURCEROOT)"' lib bin | tr -d '"' | sort -u
+rg -oN '"(LLAMA_[A-Z0-9_]+|OLLAMA_[A-Z0-9_]+|HOME|DUNE_SOURCEROOT)"' lib bin | tr -d '"' | sort -u
 ```

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -101,9 +101,6 @@ resolved config root는 별도 탐색 규칙을 가진다: `MASC_CONFIG_DIR` -> 
 | `NEO4J_HTTP_URI` | string | `""` | Neo4j HTTP API URI |
 | `NEO4J_USER` | string | `"neo4j"` | Neo4j 사용자 |
 | `NEO4J_PASSWORD` | string | (필수) | Neo4j 비밀번호 |
-| `VOICE_MCP_HOST` | string | `"127.0.0.1"` | Legacy voice session fallback host. Prefer `MASC_BASE_PATH/.masc/voice_config.json` `session.endpoints`. |
-| `VOICE_MCP_PORT` | int | 8936 | Legacy voice session fallback port. Prefer `MASC_BASE_PATH/.masc/voice_config.json` `session.endpoints`. |
-
 **Voice Configuration** (`MASC_BASE_PATH/.masc/voice_config.json`):
 
 All voice paths resolve relative to `MASC_BASE_PATH/.masc/`. The config file

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -188,13 +188,10 @@ end
 
 module Voice = struct
   (** Default Voice MCP server host *)
-  let default_host =
-    get_string ~default:Masc_network_defaults.masc_http_default_host
-      "VOICE_MCP_HOST"
+  let default_host = Masc_network_defaults.masc_http_default_host
 
   (** Default Voice MCP server port *)
-  let default_port =
-    get_int ~default:8936 "VOICE_MCP_PORT"
+  let default_port = 8936
 
   (** Voice MCP HTTP request budget (seconds).
 

--- a/lib/voice/voice_bridge_core.ml
+++ b/lib/voice/voice_bridge_core.ml
@@ -8,7 +8,7 @@
     TTS Strategy (priority order):
     1. ElevenLabs API direct (ELEVENLABS_API_KEY)
     2. Railway proxy (ELEVENLABS_PROXY_URL)
-    3. Voice MCP session endpoint (HTTP /mcp, legacy VOICE_MCP_* fallback)
+    3. Voice MCP session endpoint (HTTP /mcp)
     4. text_fallback (silent)
 
     Eio Migration Notes:

--- a/lib/voice/voice_runtime_overlay.ml
+++ b/lib/voice/voice_runtime_overlay.ml
@@ -171,31 +171,6 @@ let normalize_base_url value =
   else trimmed
 ;;
 
-let legacy_voice_env_warning_emitted = Atomic.make false
-
-let warn_legacy_voice_env_once () =
-  if not (Atomic.get legacy_voice_env_warning_emitted)
-  then (
-    Atomic.set legacy_voice_env_warning_emitted true;
-    Log.Misc.warn
-      "VOICE_MCP_HOST/PORT fallback is deprecated; prefer .masc/voice_config.json \
-       session.endpoints or MASC_HTTP_* listener settings.")
-;;
-
-let legacy_voice_base_url_opt () =
-  let host_opt = Sys.getenv_opt "VOICE_MCP_HOST" |> trim_opt in
-  let port_opt = Sys.getenv_opt "VOICE_MCP_PORT" |> trim_opt in
-  match host_opt, port_opt with
-  | None, None -> None
-  | _ ->
-    warn_legacy_voice_env_once ();
-    let host = Option.value host_opt ~default:Env_config.Voice.default_host in
-    let port =
-      Option.value port_opt ~default:(string_of_int Env_config.Voice.default_port)
-    in
-    Some (Printf.sprintf "http://%s:%s" host port)
-;;
-
 let http_listener_env_explicit () =
   Option.is_some (Sys.getenv_opt Env_config_core.http_base_url_env_key |> trim_opt)
   || Option.is_some (Sys.getenv_opt Env_config_core.host_env_key |> trim_opt)
@@ -212,14 +187,11 @@ let default_session_base_url () =
         "http://%s:%s"
         (Env_config_core.masc_host ())
         (Env_config_core.masc_http_port ())
-    else (
-      match legacy_voice_base_url_opt () with
-      | Some legacy_base_url -> normalize_base_url legacy_base_url
-      | None ->
-        Printf.sprintf
-          "http://%s:%s"
-          (Env_config_core.masc_host ())
-          (Env_config_core.masc_http_port ()))
+    else
+      Printf.sprintf
+        "http://%s:%s"
+        (Env_config_core.masc_host ())
+        (Env_config_core.masc_http_port ())
 ;;
 
 let compose_endpoint_url ~base_url ~path =

--- a/test/test_voice_runtime_overlay.ml
+++ b/test/test_voice_runtime_overlay.ml
@@ -51,6 +51,19 @@ let test_default_agent_voices_preserve_runtime_defaults () =
     (Voice.default_agent_voices ())
 ;;
 
+let test_voice_mcp_env_no_longer_overrides_default_session_url () =
+  with_env "MASC_HTTP_BASE_URL" None (fun () ->
+    with_env "MASC_HOST" None (fun () ->
+      with_env "MASC_HTTP_PORT" None (fun () ->
+        with_env "VOICE_MCP_HOST" (Some "voice.example.test") (fun () ->
+          with_env "VOICE_MCP_PORT" (Some "9999") (fun () ->
+            check
+              string
+              "voice env ignored"
+              "http://127.0.0.1:8935/mcp"
+              (Voice.default_session_url ~path:"/mcp"))))))
+;;
+
 let test_stt_request_elevenlabs_direct () =
   let endpoint : Masc_mcp.Voice_config.endpoint =
     { id = "test-stt"
@@ -159,6 +172,10 @@ let () =
             "default agent voices preserve runtime defaults"
             `Quick
             test_default_agent_voices_preserve_runtime_defaults
+        ; test_case
+            "voice mcp env no longer overrides default session url"
+            `Quick
+            test_voice_mcp_env_no_longer_overrides_default_session_url
         ] )
     ; ( "stt"
       , [ test_case


### PR DESCRIPTION
## Summary
- stop reading VOICE_MCP_HOST / VOICE_MCP_PORT for voice session fallback URLs
- keep voice session defaults on the canonical MASC HTTP listener defaults unless MASC_HTTP_* is explicit
- update voice env docs and add a regression test that VOICE_MCP_* no longer changes the default session URL

## Verification
- opam exec -- ocamlformat --check lib/voice/voice_runtime_overlay.ml lib/config/env_config_runtime.ml lib/voice/voice_bridge_core.ml test/test_voice_runtime_overlay.ml
- git diff --check
- bash scripts/lint/no-inline-error-envelope.sh
- bash scripts/lint-spawn-bounded.sh

Note: scripts/dune-local.sh build test/test_voice_runtime_overlay.exe was blocked by concurrent bare Dune processes; an isolated Dune build also stayed silent for over a minute and was stopped to avoid adding more host contention. This is draft for CI verification.