### PR TITLE
Route test git and rg probes through process guard

### DIFF
--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -31,22 +31,14 @@ let process_status_to_string = function
   | Unix.WSIGNALED signal -> Printf.sprintf "signal %d" signal
   | Unix.WSTOPPED signal -> Printf.sprintf "stopped %d" signal
 
-let read_all ic =
-  let buf = Buffer.create 256 in
-  (try
-     while true do
-       Buffer.add_string buf (input_line ic);
-       Buffer.add_char buf '\n'
-     done
-   with
-   | End_of_file -> ());
-  Buffer.contents buf
-
 let run_git_exn repo args =
   let argv = Array.of_list ("git" :: "-C" :: repo :: args) in
-  let ic = Unix.open_process_args_in "git" argv in
-  let output = read_all ic in
-  match Unix.close_process_in ic with
+  let buf, status =
+    Lib.With_process.with_process_args_in "git" argv
+      Lib.With_process.drain_to_buffer
+  in
+  let output = Buffer.contents buf in
+  match status with
   | Unix.WEXITED 0 -> String.trim output
   | status ->
     Alcotest.failf

--- a/test/test_env_git_noninteractive.ml
+++ b/test/test_env_git_noninteractive.ml
@@ -239,13 +239,10 @@ let test_no_forgotten_git_askpass_literals () =
       "*.mli";
     |]
   in
-  let ic = Unix.open_process_args_in "rg" argv in
-  let rec drain acc =
-    try drain (input_line ic :: acc)
-    with End_of_file -> List.rev acc
+  let lines, _status =
+    Masc_mcp.With_process.with_process_args_in "rg" argv
+      Masc_mcp.With_process.drain_lines
   in
-  let lines = drain [] in
-  let _ = Unix.close_process_in ic in
   let offenders =
     List.filter
       (fun line ->

--- a/test/test_masc_dirname_ssot.ml
+++ b/test/test_masc_dirname_ssot.ml
@@ -50,9 +50,10 @@ let rg_matching_files ~pattern ~paths =
       @ paths
       @ [ "--glob"; "*.ml"; "--glob"; "*.mli" ])
   in
-  let ic = Unix.open_process_args_in "rg" argv in
-  let lines = drain ic in
-  let _ = Unix.close_process_in ic in
+  let lines, _status =
+    Masc_mcp.With_process.with_process_args_in "rg" argv
+      Masc_mcp.With_process.drain_lines
+  in
   lines
 
 (* Heuristic: skip occurrences whose line is clearly inside an OCaml


### PR DESCRIPTION
## Summary
- replace direct open_process_args_in use in dashboard/tools and ratchet tests with With_process.with_process_args_in
- preserve argv execution and existing rg status behavior while centralizing close/guard handling

## Verification
- ocamlformat --check test/test_dashboard_tools.ml test/test_env_git_noninteractive.ml test/test_masc_dirname_ssot.ml
- git diff --check origin/main...HEAD
- rg -n 'Unix\.open_process_args_in|Unix\.open_process|close_process_in' test/test_dashboard_tools.ml test/test_env_git_noninteractive.ml test/test_masc_dirname_ssot.ml (no matches)

Focused Dune build was not run because scripts/dune-local.sh refused to start while unrelated bare dune processes were active on the machine.