### PR TITLE
Remove memory horizon wrappers

### DIFF
--- a/lib/keeper/keeper_exec_memory.ml
+++ b/lib/keeper/keeper_exec_memory.ml
@@ -54,6 +54,22 @@ type memory_match =
 
 let memory_bank_persistence_surface = "keeper_exec_memory_bank"
 
+let memory_horizon_of_kind_with_fallback kind =
+  match Keeper_memory_policy.memory_horizon_of_kind_opt kind with
+  | Some horizon -> horizon
+  | None ->
+      Log.Memory.warn
+        "keeper_exec_memory: unknown memory kind %S -> mid_term (drift; see #8826)"
+        kind;
+      Keeper_memory_policy.mid_term_horizon
+;;
+
+let memory_horizon_of_json_with_fallback ~kind json =
+  match Keeper_memory_policy.memory_horizon_of_json_opt json with
+  | Some horizon -> horizon
+  | None -> memory_horizon_of_kind_with_fallback kind
+;;
+
 let report_memory_bank_read_drop ~path ~reason ~detail =
   Safe_ops.report_persistence_read_drop
     ~on_drop:(fun () ->
@@ -93,7 +109,7 @@ let search_memory_bank
       | `Assoc _ as j ->
         (try
            let kind = Safe_ops.json_string ~default:"" "kind" j |> String.trim in
-           let horizon = Keeper_memory_policy.memory_horizon_of_json ~kind j in
+           let horizon = memory_horizon_of_json_with_fallback ~kind j in
            let source = Safe_ops.json_string ~default:"" "source" j |> String.trim in
            let text = Safe_ops.json_string ~default:"" "text" j |> String.trim in
            let priority = Safe_ops.json_int ~default:0 "priority" j in

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -20,8 +20,7 @@
    This block is the reverse-direction citation so code search for
    "KeeperMemoryLifecycle" lands in this module too — completing the
    sibling pair with keeper_memory_policy.ml which carries the
-   horizon-tier and producer anchors (memory_horizon_of_kind_opt
-   and memory_horizon_of_kind).
+   horizon-tier and producer anchor (memory_horizon_of_kind_opt).
 
    Sibling division of labor:
      keeper_memory_policy.ml   tier vocabulary, producer,
@@ -45,6 +44,22 @@
 open Keeper_types
 
 include Keeper_memory_policy
+
+let memory_horizon_of_kind_with_fallback kind =
+  match memory_horizon_of_kind_opt kind with
+  | Some horizon -> horizon
+  | None ->
+      Log.Memory.warn
+        "memory_horizon_of_kind_with_fallback: unknown kind %S -> mid_term (drift; see #8826)"
+        kind;
+      mid_term_horizon
+;;
+
+let memory_horizon_of_json_with_fallback ~kind json =
+  match memory_horizon_of_json_opt json with
+  | Some horizon -> horizon
+  | None -> memory_horizon_of_kind_with_fallback kind
+;;
 
 let with_stdlib_mutex mutex f =
   Stdlib.Mutex.lock mutex;
@@ -332,7 +347,7 @@ let parse_memory_bank_row (line : string) : keeper_memory_row_raw option =
       None
     else
     let kind = Safe_ops.json_string ~default:"" "kind" j |> String.trim in
-    let horizon = memory_horizon_of_json ~kind j in
+    let horizon = memory_horizon_of_json_with_fallback ~kind j in
     let source = Safe_ops.json_string ~default:"" "source" j |> String.trim in
     let generation = Safe_ops.json_int ~default:0 "generation" j in
     let text = Safe_ops.json_string ~default:"" "text" j |> String.trim in
@@ -980,7 +995,7 @@ let append_memory_notes_from_reply
     with_memory_bank_lock path (fun () ->
       List.iter
         (fun (kind, text, priority) ->
-           let horizon = memory_horizon_of_kind kind in
+           let horizon = memory_horizon_of_kind_with_fallback kind in
            if not (Hashtbl.mem seen_kinds kind) then begin
              Hashtbl.add seen_kinds kind ();
              kinds_acc := kind :: !kinds_acc

--- a/lib/keeper/keeper_memory_bank.mli
+++ b/lib/keeper/keeper_memory_bank.mli
@@ -122,9 +122,7 @@ val short_term_horizon : string
 val mid_term_horizon : string
 val long_term_horizon : string
 val memory_horizon_of_kind_opt : string -> string option
-val memory_horizon_of_kind : string -> string
 val memory_horizon_of_json_opt : Yojson.Safe.t -> string option
-val memory_horizon_of_json : kind:string -> Yojson.Safe.t -> string
 val trim_nonempty : string -> string option
 val split_state_items : string -> string list
 val strip_prefix_ci : prefix:string -> string -> string option

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -14,10 +14,7 @@
                                          [long_term_horizon].
       provenanced  -> rows with non-empty trace_id / source
                       (lives in keeper_memory_bank, not this file).
-      producer     -> [memory_horizon_of_kind_opt] (strict) and
-                      [memory_horizon_of_kind] (back-compat wrapper that
-                      defaults unknown kinds to mid_term with a warn —
-                      see #8826 drift note).
+      producer     -> [memory_horizon_of_kind_opt] (strict).
 
     This block is the reverse-direction citation so code search for
     "KeeperMemoryLifecycle" lands here.  Citations are by symbol name,
@@ -211,19 +208,6 @@ let memory_horizon_of_kind_opt (kind : string) : string option =
   | "long_term" -> Some long_term_horizon
   | _ -> None
 
-(* Back-compat wrapper: warns once per unknown kind and falls back to
-   [mid_term_horizon] (the legacy permissive default). The explicit warn
-   converts the silent #8605-family fallback into an observable signal
-   without changing the legacy classification result. *)
-let memory_horizon_of_kind (kind : string) : string =
-  match memory_horizon_of_kind_opt kind with
-  | Some h -> h
-  | None ->
-      Log.Memory.warn
-        "memory_horizon_of_kind: unknown kind %S -> mid_term (drift; see #8826)"
-        kind;
-      mid_term_horizon
-
 (* Strict JSON horizon parser: returns [None] for missing or unknown
    horizon strings so callers can decide whether to consult [kind] or
    reject the row. *)
@@ -237,15 +221,6 @@ let memory_horizon_of_json_opt (json : Yojson.Safe.t) : string option =
   | "mid_term" -> Some mid_term_horizon
   | "long_term" -> Some long_term_horizon
   | _ -> None
-
-(* Back-compat wrapper: when the JSON [horizon] is absent or unknown we
-   fall through to [memory_horizon_of_kind kind] (which itself warns on
-   unknown). The cascade is preserved exactly; the new wrapper just
-   exposes a strict variant for new callers. *)
-let memory_horizon_of_json ~(kind : string) (json : Yojson.Safe.t) : string =
-  match memory_horizon_of_json_opt json with
-  | Some h -> h
-  | None -> memory_horizon_of_kind kind
 
 let trim_nonempty (s : string) : string option =
   let t = String.trim s in

--- a/lib/keeper/keeper_memory_policy.mli
+++ b/lib/keeper/keeper_memory_policy.mli
@@ -161,12 +161,7 @@ val memory_horizon_of_kind_opt : string -> string option
 (** Horizon for [kind], or [None] when [kind] is unknown.  Use this in
     silent-default contexts. *)
 
-val memory_horizon_of_kind : string -> string
-(** Horizon for [kind] with a typed fallback to [mid_term_horizon] for
-    unknown kinds. *)
-
 val memory_horizon_of_json_opt : Yojson.Safe.t -> string option
-val memory_horizon_of_json : kind:string -> Yojson.Safe.t -> string
 
 (** {1 [STATE] block parsing} *)
 

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -153,8 +153,14 @@ let read_recent_memory_texts
   |> List.filter_map parse_memory_bank_row
   |> List.filter (fun row ->
          let row_horizon =
-           if String.trim row.horizon = ""
-           then memory_horizon_of_kind row.kind
+           if String.trim row.horizon = "" then
+             match memory_horizon_of_kind_opt row.kind with
+             | Some horizon -> horizon
+             | None ->
+                 Log.Memory.warn
+                   "memory_horizon_recall: unknown kind %S -> mid_term (drift; see #8826)"
+                   row.kind;
+                 mid_term_horizon
            else row.horizon
          in
          String.equal row_horizon horizon)

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -1530,7 +1530,10 @@ let memory_bank_test_row ~kind ~trace_id ~text ~priority ~idx =
        [
          ("schema_version", `Int Keeper_memory_bank.keeper_memory_schema_version);
          ("kind", `String kind);
-         ("horizon", `String (Keeper_memory_bank.memory_horizon_of_kind kind));
+         ( "horizon",
+           `String
+             (Keeper_memory_bank.memory_horizon_of_kind_opt kind
+              |> Option.value ~default:Keeper_memory_bank.mid_term_horizon) );
          ("source", `String "test_seed");
          ("text", `String text);
          ("priority", `Int priority);

--- a/test/test_memory_horizon_classifier.ml
+++ b/test/test_memory_horizon_classifier.ml
@@ -3,9 +3,7 @@
     Verifies that:
     - the strict [_opt] variants return [Some] only for documented
       vocabulary,
-    - unknown wire strings return [None] (no silent permissive default),
-    - the back-compat wrappers preserve the legacy [mid_term_horizon]
-      fallback so existing callers see no behaviour change. *)
+    - unknown wire strings return [None] (no silent permissive default). *)
 
 open Alcotest
 
@@ -56,16 +54,6 @@ let test_case_and_whitespace_normalised () =
     (Some Policy.short_term_horizon)
     (Policy.memory_horizon_of_kind_opt "  next  ")
 
-let test_wrapper_preserves_legacy_default () =
-  (* Back-compat: unknown kind still falls back to mid_term_horizon
-     (with a warn line going to the log). *)
-  check string "unknown kind -> mid_term legacy"
-    Policy.mid_term_horizon
-    (Policy.memory_horizon_of_kind "definitely_not_a_kind");
-  check string "known kind unchanged"
-    Policy.short_term_horizon
-    (Policy.memory_horizon_of_kind "next")
-
 let test_json_strict_classifier () =
   let json_with horizon =
     `Assoc [ ("horizon", `String horizon); ("kind", `String "next") ]
@@ -86,20 +74,6 @@ let test_json_strict_classifier () =
     None
     (Policy.memory_horizon_of_json_opt (`Assoc [ ("kind", `String "next") ]))
 
-let test_json_wrapper_falls_back_to_kind () =
-  let json_unknown =
-    `Assoc [ ("horizon", `String "unknown_horizon"); ("kind", `String "next") ]
-  in
-  check string "JSON unknown horizon falls through to kind classification"
-    Policy.short_term_horizon
-    (Policy.memory_horizon_of_json ~kind:"next" json_unknown);
-  let json_known =
-    `Assoc [ ("horizon", `String "long_term"); ("kind", `String "next") ]
-  in
-  check string "JSON known horizon takes precedence over kind"
-    Policy.long_term_horizon
-    (Policy.memory_horizon_of_json ~kind:"next" json_known)
-
 let () =
   Alcotest.run "memory_horizon_classifier"
     [
@@ -112,12 +86,5 @@ let () =
           test_case "case and whitespace normalised" `Quick
             test_case_and_whitespace_normalised;
           test_case "JSON strict classifier" `Quick test_json_strict_classifier;
-        ] );
-      ( "back-compat wrappers",
-        [
-          test_case "wrapper preserves legacy default" `Quick
-            test_wrapper_preserves_legacy_default;
-          test_case "JSON wrapper falls back to kind" `Quick
-            test_json_wrapper_falls_back_to_kind;
         ] );
     ]


### PR DESCRIPTION
## Summary
- remove public Keeper_memory_policy/Keeper_memory_bank memory_horizon_of_kind and memory_horizon_of_json permissive wrappers
- keep strict memory_horizon_of_kind_opt and memory_horizon_of_json_opt as the public parse/classification APIs
- move legacy mid_term fallback behavior into explicit private call-site helpers for memory bank parsing, append, recall, and exec search
- drop wrapper-only classifier tests

## Verification
- rg -n "memory_horizon_of_kind\b|memory_horizon_of_json\b|Back-compat wrapper|back-compat wrappers" lib/keeper test -S
- git diff --check origin/main...HEAD
- ocamlformat --check lib/keeper/keeper_memory_policy.ml lib/keeper/keeper_memory_policy.mli lib/keeper/keeper_memory_bank.ml lib/keeper/keeper_memory_bank.mli lib/keeper/keeper_memory_recall.ml lib/keeper/keeper_exec_memory.ml test/test_memory_horizon_classifier.ml test/test_keeper_memory.ml
- scripts/dune-local.sh build test/test_memory_horizon_classifier.exe test/test_keeper_memory.exe (blocked: live bare Dune processes already running; wrapper refused to start another local build)