### PR TITLE
refactor(keeper_agent_run): extract contract branch status

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -893,11 +893,10 @@ let run_turn
                      | Ok (), Some reason ->
                        let contract_status
                            : Keeper_execution_receipt.tool_contract_result =
-                         if actual_keeper_tool_names = []
-                         then Contract_missing_required_tool_use
-                         else if progress_keeper_tool_names = []
-                         then Contract_needs_execution_progress
-                         else tool_contract_status ()
+                         Contract_helpers.passive_violation_contract_status
+                           ~actual_keeper_tool_names
+                           ~progress_keeper_tool_names
+                           ~fallback:tool_contract_status
                        in
                        acc.receipt_tool_contract_result <- contract_status;
                        Keeper_agent_run_contract_violation_log.record_passive
@@ -916,9 +915,9 @@ let run_turn
                      | Error reason, _ ->
                        let contract_status
                            : Keeper_execution_receipt.tool_contract_result =
-                         if actual_keeper_tool_names = []
-                         then Contract_missing_required_tool_use
-                         else tool_contract_status ()
+                         Contract_helpers.text_only_violation_contract_status
+                           ~actual_keeper_tool_names
+                           ~fallback:tool_contract_status
                        in
                        acc.receipt_tool_contract_result <- contract_status;
                        Keeper_agent_run_contract_violation_log.record_text_only

--- a/lib/keeper/keeper_agent_run_contract_helpers.ml
+++ b/lib/keeper/keeper_agent_run_contract_helpers.ml
@@ -71,3 +71,22 @@ let observed_tool_contract_status ~required_tool_names ~missing_visible_required
     ~required_tool_names ~missing_visible_required ~had_owned_active_task_at_turn_start
     ~actual_keeper_tool_names
 ;;
+
+let passive_violation_contract_status ~actual_keeper_tool_names
+      ~progress_keeper_tool_names ~fallback
+  : Keeper_execution_receipt.tool_contract_result
+  =
+  if actual_keeper_tool_names = []
+  then Contract_missing_required_tool_use
+  else if progress_keeper_tool_names = []
+  then Contract_needs_execution_progress
+  else fallback ()
+;;
+
+let text_only_violation_contract_status ~actual_keeper_tool_names ~fallback
+  : Keeper_execution_receipt.tool_contract_result
+  =
+  if actual_keeper_tool_names = []
+  then Contract_missing_required_tool_use
+  else fallback ()
+;;

--- a/lib/keeper/keeper_agent_run_contract_helpers.mli
+++ b/lib/keeper/keeper_agent_run_contract_helpers.mli
@@ -28,3 +28,14 @@ val observed_tool_contract_status :
   had_owned_active_task_at_turn_start:bool ->
   actual_keeper_tool_names:string list ->
   Keeper_execution_receipt.tool_contract_result
+
+val passive_violation_contract_status :
+  actual_keeper_tool_names:string list ->
+  progress_keeper_tool_names:string list ->
+  fallback:(unit -> Keeper_execution_receipt.tool_contract_result) ->
+  Keeper_execution_receipt.tool_contract_result
+
+val text_only_violation_contract_status :
+  actual_keeper_tool_names:string list ->
+  fallback:(unit -> Keeper_execution_receipt.tool_contract_result) ->
+  Keeper_execution_receipt.tool_contract_result


### PR DESCRIPTION
## Summary

- extract passive/text-only contract status branch helpers into `Keeper_agent_run_contract_helpers`
- keep `Keeper_agent_run.run_turn` focused on selecting the branch and recording the result
- preserve the existing missing-tool and no-progress status choices

## Product impact

- User-visible change: none expected; refactor-only helper extraction.

## Evidence

- `ocamlformat --check lib/keeper/keeper_agent_run.ml lib/keeper/keeper_agent_run_contract_helpers.ml lib/keeper/keeper_agent_run_contract_helpers.mli`
- `scripts/ocaml-structure-ratchet.sh`
- `git diff --check`
- `git diff --check origin/main..HEAD`
- `scripts/check-pr-hygiene.sh --base origin/main --head HEAD`

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/0
provenance: n/a
stages: []
```

- `keeper_agent_run.ml` reduced from 1948 to 1947 lines on this base.
- Changed files are limited to `keeper_agent_run.ml` and `keeper_agent_run_contract_helpers.{ml,mli}`.

## GOAL LOOP ACT checklist

- [ ] Observe — N/A: refactor-only extraction, no runtime failure targeted.
- [x] Orient — continued keeper god-file reduction in `Keeper_agent_run`.
- [x] Decide — bounded extraction of repeated contract status branches.
- [x] Act — helper functions added and call site rewired.
- [x] Verify — formatter, structure ratchet, diff whitespace, and PR hygiene passed.
- [x] Loop — remaining follow-up continues in the decomposition queue.

## Review evidence

- Local review checked the extracted helpers preserve prior branch behavior:
  - passive violation: missing required tool first, then no execution progress, then fallback observed status
  - text-only violation: missing required tool first, then fallback observed status

## Linked issue

- None. Decomposition follow-up in the ongoing keeper god-file reduction queue.

## Variant addition checklist

- [ ] **OCaml** — N/A: no variant added, removed, or renamed.
- [ ] **TypeScript** — N/A: no dashboard union type changed.
- [ ] **TLA+ spec** — N/A: no TLA+ domain literal changed.
- [ ] **Event / JSON schema** — N/A: no event type or JSON schema enum changed.
- [ ] **`make check-variants` passes** — N/A: no variant/schema domain change.

## Dune

- `scripts/dune-local.sh build lib/masc_mcp_lib.a` refused with exit 75 because live bare Dune processes were already running outside `scripts/dune-local.sh`; I did not bypass with `MASC_DUNE_ALLOW_BARE_DUNE=1`.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/agent-run-contract-branch-status-20260522` → `main` · 1 commit(s) · synced 2026-05-22T03:50:27Z

| sha | subject | date |
|---|---|---|
| `70e1222c7` | refactor(keeper_agent_run): extract contract branch status | 2026-05-22 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->