### PR TITLE
Fix RFC-0132 runtime literal lint on main

### DIFF
--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -216,7 +216,15 @@ let keeper_reply_snapshot_of_history (history_items : Yojson.Safe.t list) =
       (`String "delivered", `Float assistant_ts, `String preview)
 
 let error_keywords =
-  [ "error"; "failed"; "timeout"; "graphql"; "model"; "runtime"; "provider" ]
+  [ "error"
+  ; "failed"
+  ; "timeout"
+  ; "graphql"
+  ; "model"
+  ; (* RFC-0132-EXEMPT: classification list, not boundary redaction *)
+    "runtime"
+  ; "provider"
+  ]
 
 let looks_error_like text =
   List.exists (string_contains_ci text) error_keywords

--- a/scripts/lint/no-runtime-literal-outside-boundary-redaction.sh
+++ b/scripts/lint/no-runtime-literal-outside-boundary-redaction.sh
@@ -11,8 +11,8 @@
 # labels, or internal observability and are out of RFC-0132 scope.
 #
 # Exemption: add `RFC-0132-EXEMPT: <reason>` on the same line or the
-# preceding line. The 2 known-exempt sites listed below are pre-approved
-# (classification list, debug format string).
+# preceding line. The known-exempt site listed below is pre-approved
+# (debug format string).
 #
 # Adding to scope: extend SCAN_FILES when a new subsystem's boundary
 # emit-site is routed through Boundary_redaction. Each addition must
@@ -70,13 +70,11 @@ SCAN_FILES=(
 )
 
 # Pre-approved exemptions from PR-2 audit. Each entry is `path:line:reason`.
-# These two sites carry a `"runtime"` literal that is NOT a redaction
-# target (classification list, debug format string).
+# This site carries a `"runtime"` literal that is NOT a redaction
+# target (debug format string).
 # Drift (line move) makes the entry stale and must be cleaned in the
 # same PR. The runtime check accepts any of the listed lines.
 PREAPPROVED=(
-  # Classification list — enumeration of category names, not a label.
-  "lib/keeper/keeper_exec_status.ml:220"
   # Debug format string inside Printf.sprintf — internal observability
   # (real provider identity, not boundary redaction). The model field
   # above it is already routed via Boundary_redaction.


### PR DESCRIPTION
## Summary
- mark keeper_exec_status runtime keyword as an RFC-0132 classification-list exemption at the literal site
- remove the stale line-number preapproval for that moved classification list

## Verification
- bash scripts/lint/no-runtime-literal-outside-boundary-redaction.sh --fail
- ocamlformat --check lib/keeper/keeper_exec_status.ml
- git diff --check origin/main...HEAD

Focused Dune build was not run because scripts/dune-local.sh refused to start while unrelated bare dune processes were active on the machine.