### PR TITLE
Remove snapshot view parser wrapper

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -667,7 +667,6 @@ type snapshot_view = Operator_control_snapshot_view.snapshot_view =
 let snapshot_view_to_string = Operator_control_snapshot_view.snapshot_view_to_string
 let valid_snapshot_view_strings = Operator_control_snapshot_view.valid_snapshot_view_strings
 let snapshot_view_of_string_opt = Operator_control_snapshot_view.snapshot_view_of_string_opt
-let parse_snapshot_view = Operator_control_snapshot_view.parse_snapshot_view
 
 (* Snapshot TTL cache with same-key deduplication (singleflight)
    extracted to [Operator_control_snapshot_cache] (godfile decomp).
@@ -818,7 +817,11 @@ let snapshot_json
     ignore (initialized, _snapshot_session_window_seconds (), _snapshot_session_limit ());
     let trace_id = trace_id "ops" in
     let actor_name = normalized_actor ~context_actor:ctx.agent_name actor in
-    let view = parse_snapshot_view view in
+    let view =
+      match Option.bind view snapshot_view_of_string_opt with
+      | Some view -> view
+      | None -> Full
+    in
     let include_keepers =
       include_keepers
       &&

--- a/lib/operator/operator_control_snapshot_view.ml
+++ b/lib/operator/operator_control_snapshot_view.ml
@@ -35,9 +35,8 @@ let all_snapshot_views = [ Summary; Sessions; Keepers; Messages; Full ]
 let valid_snapshot_view_strings = List.map snapshot_view_to_string all_snapshot_views
 
 (* Sound partial parser — Some for canonical strings, None otherwise.
-   [parse_snapshot_view] below intentionally falls back to [Full] for
-   tool/HTTP back-compat; this opt variant exists for callers that
-   want to distinguish unknown input. *)
+   Callers that need tool/HTTP back-compat should make their fallback
+   explicit at the boundary. *)
 let snapshot_view_of_string_opt raw =
   match String.trim raw |> String.lowercase_ascii with
   | "summary" -> Some Summary
@@ -46,12 +45,4 @@ let snapshot_view_of_string_opt raw =
   | "messages" -> Some Messages
   | "full" -> Some Full
   | _ -> None
-;;
-
-let parse_snapshot_view = function
-  | Some raw ->
-    (match snapshot_view_of_string_opt raw with
-     | Some v -> v
-     | None -> Full)
-  | None -> Full
 ;;

--- a/lib/operator/operator_control_snapshot_view.mli
+++ b/lib/operator/operator_control_snapshot_view.mli
@@ -15,6 +15,3 @@ val valid_snapshot_view_strings : string list
 
 val snapshot_view_of_string_opt : string -> snapshot_view option
 (** Parse a canonical view string, returning [None] for unknown inputs. *)
-
-val parse_snapshot_view : string option -> snapshot_view
-(** Back-compatible parser that falls back to [Full]. *)


### PR DESCRIPTION
## Summary
- remove Operator_control_snapshot_view.parse_snapshot_view from the public view parser module
- keep snapshot_view_of_string_opt as the strict parser surface
- make the HTTP/tool boundary fallback to Full explicit inside snapshot_json

## Verification
- rg -n "parse_snapshot_view\b|Back-compatible parser|falls back to \[Full\]" lib/operator test -S
- git diff --check origin/main...HEAD
- ocamlformat --check lib/operator/operator_control_snapshot_view.ml lib/operator/operator_control_snapshot_view.mli lib/operator/operator_control_snapshot.ml
- scripts/dune-local.sh build test/test_types.exe (blocked: live bare Dune processes already running; wrapper refused to start another local build)