### PR TITLE
Remove stale messages transport glue

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -100,9 +100,6 @@ let get_cookie_value = Server_mcp_transport_http.get_cookie_value
 
 let get_session_id_any = Server_mcp_transport_http.get_session_id_any
 
-let legacy_messages_endpoint_url =
-  Server_mcp_transport_http.legacy_messages_endpoint_url
-
 let get_protocol_version = Server_mcp_transport_http.get_protocol_version
 
 let get_protocol_version_for_session =
@@ -194,7 +191,6 @@ let is_mcp_like_path path =
   || String.equal path "/mcp/managed"
   || String.equal path "/mcp/operator"
   || String.equal path "/sse"
-  || String.equal path "/messages"
 
 (** Returns true if the request failed origin or protocol-version
     validation and the corresponding error response was sent on [reqd].

--- a/lib/server/server_routes_http_routes_room.mli
+++ b/lib/server/server_routes_http_routes_room.mli
@@ -1,8 +1,8 @@
 (** Server_routes_http_routes_room — Read-only HTTP routes for
     project/room state.
 
-    Registers [GET /api/v1/status], [/tasks], [/agents],
-    [/messages]. All routes require read authentication via
+    Registers [GET /api/v1/status], [/api/v1/tasks], [/api/v1/agents],
+    [/api/v1/messages]. All routes require read authentication via
     {!Server_auth.with_read_auth}. *)
 
 val add_routes :

--- a/test/test_mcp_session_coverage.ml
+++ b/test/test_mcp_session_coverage.ml
@@ -249,7 +249,7 @@ let test_body_with_canonical_http_actor_uses_token_owner () =
             ("x-masc-agent", "dashboard");
           ]
       in
-      let request = Httpun.Request.create ~headers `POST "/messages" in
+      let request = Httpun.Request.create ~headers `POST "/mcp" in
       let body =
         {|{"jsonrpc":"2.0","method":"tools/call","params":{"name":"masc_keeper_status","arguments":{"_agent_name":"dashboard","token":"stale-token","name":"sangsu"}},"id":1}|}
       in


### PR DESCRIPTION
## Summary
- remove the stale main_eio alias to the deleted legacy messages endpoint helper
- stop classifying /messages as an MCP transport path
- move the canonical HTTP actor coverage test onto /mcp and clarify room API docs

## Verification
- opam exec -- ocamlformat --check bin/main_eio.ml test/test_mcp_session_coverage.ml lib/server/server_routes_http_routes_room.mli
- git diff --check
- bash scripts/lint/no-inline-error-envelope.sh
- bash scripts/lint-spawn-bounded.sh

## Not run
- scripts/dune-local.sh build test/test_mcp_session_coverage.exe (blocked by existing bare Dune processes; wrapper refused to start another build)