### PR TITLE
refactor(keeper_agent_run): extract response finalization

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -198,13 +198,11 @@
   keeper_post_turn
   keeper_tool_disclosure
   keeper_turn_telemetry
-  keeper_agent_prompt_metrics
-  keeper_agent_tool_surface
+  keeper_agent_prompt_metrics keeper_agent_tool_surface
   keeper_agent_run_phase0_telemetry keeper_agent_run_contract_retry keeper_agent_run_actionable_contract
-  keeper_agent_run_contract_violation_log keeper_agent_run_contract_helpers keeper_agent_run_thinking_trajectory
+  keeper_agent_run_contract_violation_log keeper_agent_run_contract_helpers keeper_agent_run_response_text keeper_agent_run_thinking_trajectory
   keeper_agent_run_tool_observation keeper_agent_run_tool_surface_violation keeper_agent_run_receipt_append
-  keeper_agent_result
-  keeper_agent_error
+  keeper_agent_result keeper_agent_error
   keeper_agent_memory_episode
   keeper_run_tools_search
   keeper_run_tools_work_discovery

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -933,53 +933,18 @@ let run_turn
                          (Contract_helpers.completion_contract_violation_error reason)
                    in
                    let finalize_response_text raw_response_text =
-                     let stop_reason_str =
-                       match result.stop_reason with
-                       | Cascade_runner.Completed -> "completed"
-                       | Cascade_runner.TurnBudgetExhausted _ -> "budget_exhausted"
-                       | Cascade_runner.MutationBoundaryReached { tool_name; _ } ->
-                         (match tool_name with
-                          | Some tool -> Printf.sprintf "mutation_boundary(%s)" tool
-                          | None -> "mutation_boundary")
-                     in
-                     let state_snapshot =
-                       match
-                         Keeper_memory_policy.parse_state_snapshot_from_reply
-                           raw_response_text
-                       with
-                       | Some snapshot -> snapshot
-                       | None ->
-                         let final_tool_names =
-                           match !actual_keeper_tool_names_ref with
-                           | [] -> actual_keeper_tool_names
-                           | names -> names
-                         in
-                         let synth =
-                           Keeper_memory_policy.synthesize_state_from_run_result
-                             ~goal:meta.goal
-                             ~tools_used:final_tool_names
-                             ~stop_reason:stop_reason_str
-                             ~response_text:raw_response_text
-                         in
-                         Log.Keeper.info
-                           "keeper:%s [STATE] missing, synthesized from %d tools \
-                            (stop=%s)"
-                           meta.name
-                           (List.length final_tool_names)
-                           stop_reason_str;
-                         synth
-                     in
-                     let response_text =
-                       match
-                         Keeper_text_processing.state_snapshot_reply_fallback
-                           (Some state_snapshot)
-                     with
-                     | Some fallback ->
-                       Keeper_text_processing.user_visible_reply_text
-                         ~fallback
-                         raw_response_text
-                     | None ->
-                       Keeper_text_processing.user_visible_reply_text raw_response_text
+                     Keeper_agent_run_response_text.finalize
+                       ~keeper_name:meta.name
+                       ~goal:meta.goal
+                       ~actual_keeper_tool_names:!actual_keeper_tool_names_ref
+                       ~fallback_tool_names:actual_keeper_tool_names
+                       ~stop_reason:result.stop_reason
+                       ~raw_response_text
+                   in
+                   let
+                     { Keeper_agent_run_response_text.state_snapshot; response_text }
+                     =
+                     finalize_response_text raw_response_text
                    in
                     let state_snapshot_source =
                       if

--- a/lib/keeper/keeper_agent_run_response_text.ml
+++ b/lib/keeper/keeper_agent_run_response_text.ml
@@ -1,0 +1,71 @@
+(** Response text and [STATE] snapshot finalization for keeper agent runs. *)
+
+type finalized = {
+  state_snapshot : Keeper_memory_policy.keeper_state_snapshot;
+  response_text : string;
+}
+
+let stop_reason_label = function
+  | Cascade_runner.Completed -> "completed"
+  | Cascade_runner.TurnBudgetExhausted _ -> "budget_exhausted"
+  | Cascade_runner.MutationBoundaryReached { tool_name; _ } ->
+    (match tool_name with
+     | Some tool -> Printf.sprintf "mutation_boundary(%s)" tool
+     | None -> "mutation_boundary")
+;;
+
+let final_tool_names ~actual_keeper_tool_names ~fallback_tool_names =
+  match actual_keeper_tool_names with
+  | [] -> fallback_tool_names
+  | names -> names
+;;
+
+let state_snapshot ~keeper_name ~goal ~actual_keeper_tool_names ~fallback_tool_names
+      ~stop_reason ~raw_response_text
+  =
+  match Keeper_memory_policy.parse_state_snapshot_from_reply raw_response_text with
+  | Some snapshot -> snapshot
+  | None ->
+    let stop_reason_str = stop_reason_label stop_reason in
+    let final_tool_names =
+      final_tool_names ~actual_keeper_tool_names ~fallback_tool_names
+    in
+    let synth =
+      Keeper_memory_policy.synthesize_state_from_run_result
+        ~goal
+        ~tools_used:final_tool_names
+        ~stop_reason:stop_reason_str
+        ~response_text:raw_response_text
+    in
+    Log.Keeper.info
+      "keeper:%s [STATE] missing, synthesized from %d tools (stop=%s)"
+      keeper_name
+      (List.length final_tool_names)
+      stop_reason_str;
+    synth
+;;
+
+let response_text ~state_snapshot ~raw_response_text =
+  match
+    Keeper_text_processing.state_snapshot_reply_fallback (Some state_snapshot)
+  with
+  | Some fallback ->
+    Keeper_text_processing.user_visible_reply_text ~fallback raw_response_text
+  | None -> Keeper_text_processing.user_visible_reply_text raw_response_text
+;;
+
+let finalize ~keeper_name ~goal ~actual_keeper_tool_names ~fallback_tool_names
+      ~stop_reason ~raw_response_text
+  =
+  let state_snapshot =
+    state_snapshot
+      ~keeper_name
+      ~goal
+      ~actual_keeper_tool_names
+      ~fallback_tool_names
+      ~stop_reason
+      ~raw_response_text
+  in
+  let response_text = response_text ~state_snapshot ~raw_response_text in
+  { state_snapshot; response_text }
+;;

--- a/lib/keeper/keeper_agent_run_response_text.mli
+++ b/lib/keeper/keeper_agent_run_response_text.mli
@@ -1,0 +1,17 @@
+(** Response text and [STATE] snapshot finalization for keeper agent runs. *)
+
+type finalized = {
+  state_snapshot : Keeper_memory_policy.keeper_state_snapshot;
+  response_text : string;
+}
+
+val stop_reason_label : Cascade_runner.stop_reason -> string
+
+val finalize :
+  keeper_name:string ->
+  goal:string ->
+  actual_keeper_tool_names:string list ->
+  fallback_tool_names:string list ->
+  stop_reason:Cascade_runner.stop_reason ->
+  raw_response_text:string ->
+  finalized


### PR DESCRIPTION
## Summary

- extract keeper response text and `[STATE]` snapshot finalization into `Keeper_agent_run_response_text`
- keep `Keeper_agent_run.run_turn` focused on orchestration after contract validation
- preserve synthesized `[STATE]` fallback behavior and user-visible reply fallback behavior

## Product impact

- User-visible change: none expected; refactor-only extraction.

## Evidence

- `ocamlformat --check lib/keeper/keeper_agent_run.ml lib/keeper/keeper_agent_run_response_text.ml lib/keeper/keeper_agent_run_response_text.mli`
- `scripts/ocaml-structure-ratchet.sh`
- `git diff --check`
- `git diff --check origin/main..HEAD`
- `scripts/check-pr-hygiene.sh --base origin/main --head HEAD`

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/0
provenance: n/a
stages: []
```

- `keeper_agent_run.ml` reduced from 1947 to 1912 lines on this base.
- Added `lib/keeper/keeper_agent_run_response_text.{ml,mli}`.
- `lib/dune` line count kept at the ratchet baseline by combining adjacent private module entries.

## GOAL LOOP ACT checklist

- [ ] Observe — N/A: refactor-only extraction, no runtime failure targeted.
- [x] Orient — continued keeper god-file reduction in `Keeper_agent_run`.
- [x] Decide — bounded extraction of response finalization and synthesized state fallback.
- [x] Act — helper module added and call site rewired.
- [x] Verify — formatter, structure ratchet, diff whitespace, and PR hygiene passed.
- [x] Loop — remaining follow-up continues in the decomposition queue.

## Review evidence

- Local review checked the extracted helper preserves:
  - stop reason labels for completed, budget exhausted, and mutation boundary
  - model `[STATE]` parse first, synthesized fallback second
  - `state_snapshot_reply_fallback` user-visible response behavior

## Linked issue

- None. Decomposition follow-up in the ongoing keeper god-file reduction queue.

## Variant addition checklist

- [ ] **OCaml** — N/A: no variant added, removed, or renamed.
- [ ] **TypeScript** — N/A: no dashboard union type changed.
- [ ] **TLA+ spec** — N/A: no TLA+ domain literal changed.
- [ ] **Event / JSON schema** — N/A: no event type or JSON schema enum changed.
- [ ] **`make check-variants` passes** — N/A: no variant/schema domain change.

## Dune

- `scripts/dune-local.sh build lib/masc_mcp_lib.a` refused with exit 75 because live bare Dune processes were already running outside `scripts/dune-local.sh`; I did not bypass with `MASC_DUNE_ALLOW_BARE_DUNE=1`.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`codex/agent-run-response-finalize-20260522` → `main` · 1 commit(s) · synced 2026-05-22T03:57:27Z

| sha | subject | date |
|---|---|---|
| `a5d10f29b` | refactor(keeper_agent_run): extract response finalization | 2026-05-22 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->