### PR TITLE
fix(dashboard): warm metrics cache asynchronously

### DIFF
--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -4,6 +4,125 @@ open Server_auth
 
 module Http = Http_server_eio
 
+type dashboard_json_cache_entry =
+  { mutable value : Yojson.Safe.t option
+  ; mutable updated_at : float
+  ; mutable in_flight : bool
+  ; mutable last_error : string option
+  }
+
+let dashboard_metrics_cache_ttl_s = 60.0
+let dashboard_metrics_cache_mu = Stdlib.Mutex.create ()
+let dashboard_model_metrics_cache : (string, dashboard_json_cache_entry) Hashtbl.t = Hashtbl.create 8
+let dashboard_cost_latency_cache : (string, dashboard_json_cache_entry) Hashtbl.t = Hashtbl.create 8
+
+let cache_key parts = String.concat "\x1f" parts
+
+let new_cache_entry () =
+  { value = None; updated_at = 0.0; in_flight = false; last_error = None }
+
+let cache_metadata ~state ~generated_at ?age_s ?error () =
+  let optional_float name = function
+    | None -> []
+    | Some value -> [ name, `Float value ]
+  in
+  let optional_string name = function
+    | None -> []
+    | Some value -> [ name, `String value ]
+  in
+  `Assoc
+    ([ "state", `String state; "generated_at", `Float generated_at ]
+     @ optional_float "age_s" age_s
+     @ optional_string "last_error" error)
+
+let json_with_cache_metadata json metadata =
+  match json with
+  | `Assoc fields -> `Assoc (fields @ [ "cache", metadata ])
+  | other -> `Assoc [ "payload", other; "cache", metadata ]
+
+let cached_dashboard_json ~sw ~cache ~key ~placeholder ~compute =
+  let now = Unix.gettimeofday () in
+  let entry, response, should_refresh =
+    Stdlib.Mutex.lock dashboard_metrics_cache_mu;
+    let entry =
+      match Hashtbl.find_opt cache key with
+      | Some entry -> entry
+      | None ->
+          let entry = new_cache_entry () in
+          Hashtbl.add cache key entry;
+          entry
+    in
+    let age_s = now -. entry.updated_at in
+    let response, should_refresh =
+      match entry.value with
+      | Some json when age_s <= dashboard_metrics_cache_ttl_s ->
+          ( json_with_cache_metadata json
+              (cache_metadata ~state:"fresh" ~generated_at:now ~age_s ()),
+            false )
+      | Some json ->
+          let start_refresh = not entry.in_flight in
+          if start_refresh then entry.in_flight <- true;
+          ( json_with_cache_metadata json
+              (cache_metadata ~state:"stale_refreshing" ~generated_at:now
+                 ~age_s ?error:entry.last_error ()),
+            start_refresh )
+      | None ->
+          let start_refresh = not entry.in_flight in
+          if start_refresh then entry.in_flight <- true;
+          ( json_with_cache_metadata placeholder
+              (cache_metadata ~state:"warming" ~generated_at:now
+                 ?error:entry.last_error ()),
+            start_refresh )
+    in
+    Stdlib.Mutex.unlock dashboard_metrics_cache_mu;
+    entry, response, should_refresh
+  in
+  if should_refresh then
+    Eio.Fiber.fork ~sw (fun () ->
+      let result =
+        try Ok (Eio_guard.run_in_systhread compute) with
+        | exn ->
+            Error (Printexc.to_string exn)
+      in
+      let refreshed_at = Unix.gettimeofday () in
+      Stdlib.Mutex.lock dashboard_metrics_cache_mu;
+      (match result with
+       | Ok json ->
+           entry.value <- Some json;
+           entry.updated_at <- refreshed_at;
+           entry.last_error <- None
+       | Error message ->
+           Log.Misc.warn "dashboard metrics cache refresh failed: %s" message;
+           entry.last_error <- Some message);
+      entry.in_flight <- false;
+      Stdlib.Mutex.unlock dashboard_metrics_cache_mu);
+  response
+
+let empty_model_metrics_json ~window ~bucket_min =
+  let agg =
+    { Model_inference_metrics.window_minutes = window
+    ; bucket_minutes = bucket_min
+    ; models = []
+    ; total_entries = 0
+    ; total_error_entries = 0
+    ; latency_buckets = []
+    }
+  in
+  Model_inference_metrics.to_json agg
+
+let empty_cost_latency_json ~window =
+  `Assoc
+    [ "perAgent", `List []
+    ; ( "matrix"
+      , `Assoc [ "providers", `List []; "models", `List []; "grid", `List [] ] )
+    ; "latencyBuckets", `List []
+    ; "p50", `Null
+    ; "p95", `Null
+    ; "total_cost_usd", `Float 0.0
+    ; "window_minutes", `Int window
+    ; "generated_at", `Float (Unix.gettimeofday ())
+    ]
+
 let dashboard_feed_limit req =
   int_query_param req "limit" ~default:200 |> clamp ~min_v:1 ~max_v:200
 
@@ -88,16 +207,26 @@ let add_routes ~sw router =
          let window = int_query_param req "window" ~default:30 in
          let bucket_min = int_query_param req "bucket_min" ~default:0 in
          let base_path = state.Mcp_server.room_config.base_path in
-         let agg =
-           if bucket_min > 0 then
-             Model_inference_metrics.compute_with_buckets
-               ~base_path ~window_minutes:window ~bucket_minutes:bucket_min
-           else
-             Model_inference_metrics.compute
-               ~base_path ~window_minutes:window
+         let key =
+           cache_key
+             [ base_path; string_of_int window; string_of_int bucket_min ]
+         in
+         let json =
+           cached_dashboard_json ~sw ~cache:dashboard_model_metrics_cache ~key
+             ~placeholder:(empty_model_metrics_json ~window ~bucket_min)
+             ~compute:(fun () ->
+               let agg =
+                 if bucket_min > 0 then
+                   Model_inference_metrics.compute_with_buckets
+                     ~base_path ~window_minutes:window ~bucket_minutes:bucket_min
+                 else
+                   Model_inference_metrics.compute
+                     ~base_path ~window_minutes:window
+               in
+               Model_inference_metrics.to_json agg)
          in
          Http.Response.json ~compress:true ~request:req
-           (Yojson.Safe.to_string (Model_inference_metrics.to_json agg)) reqd
+           (Yojson.Safe.to_string json) reqd
        ) request reqd)
   |> Http.Router.post "/api/v1/agent-runs" (fun request reqd ->
        with_token_permission_auth ~permission:Masc_domain.CanAdmin
@@ -181,8 +310,12 @@ let add_routes ~sw router =
          let window = int_query_param req "window" ~default:1440 in
          let base_path = state.Mcp_server.room_config.base_path in
          let json =
-           Model_inference_metrics.compute_cost_latency_json
-             ~base_path ~window_minutes:window
+           cached_dashboard_json ~sw ~cache:dashboard_cost_latency_cache
+             ~key:(cache_key [ base_path; string_of_int window ])
+             ~placeholder:(empty_cost_latency_json ~window)
+             ~compute:(fun () ->
+               Model_inference_metrics.compute_cost_latency_json
+                 ~base_path ~window_minutes:window)
          in
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd


### PR DESCRIPTION
## Summary
- return verifier-safe warming/stale responses for model metrics and cost-latency dashboard routes
- refresh the expensive JSONL aggregates asynchronously via the server switch
- add explicit cache metadata so degraded first responses are observable

Fixes #17570

## Verification
- ocamlformat --check lib/server/server_routes_http_routes_provider_runs.ml
- git diff --check
- env MASC_DUNE_THROTTLE=0 MASC_OPAM_LOCK=0 MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_LOCAL_JOBS=1 DUNE_CACHE=disabled scripts/dune-local.sh build --cache=disabled lib/.masc_mcp.objs/byte/masc_mcp__Server_routes_http_routes_provider_runs.cmo lib/.masc_mcp.objs/native/masc_mcp__Server_routes_http_routes_provider_runs.cmx

Note: full test binary link was attempted but stopped after local Dune/link contention; focused route module byte/native compile passed.