### PR TITLE
Remove agent archetype fallback getter

### DIFF
--- a/lib/agent_identity.ml
+++ b/lib/agent_identity.ml
@@ -402,19 +402,6 @@ let archetype_emoji = function
   | Athena -> "🧠"
   | Generalist -> "🌐"
 
-(** Get archetype from identity metadata *)
-let get_archetype identity =
-  match List.assoc_opt "archetype" identity.metadata with
-  | None -> Generalist
-  | Some s -> (
-      match archetype_of_string_opt s with
-      | Some archetype -> archetype
-      | None ->
-          Log.Misc.warn
-            "get_archetype: unknown archetype metadata %S → Generalist fallback (#8691)"
-            s;
-          Generalist)
-
 (** Set archetype in identity metadata *)
 let set_archetype identity archetype =
   let filtered = List.filter (fun (k, _) -> not (String.equal k "archetype")) identity.metadata in  { identity with metadata = ("archetype", archetype_to_string archetype) :: filtered }

--- a/lib/agent_identity.mli
+++ b/lib/agent_identity.mli
@@ -101,7 +101,6 @@ val archetype_of_string_opt : string -> archetype option
 
 val archetype_emoji : archetype -> string
 
-val get_archetype : t -> archetype
 val set_archetype : t -> archetype -> t
 
 val archetype_weight : archetype -> string -> float

--- a/test/test_agent_identity.ml
+++ b/test/test_agent_identity.ml
@@ -149,17 +149,6 @@ let test_archetype_parser_strict () =
   check (option archetype) "unknown is drift" None
     (Agent_identity.archetype_of_string_opt "planner-ish")
 
-let test_get_archetype_fallback_is_boundary_local () =
-  let base = Agent_identity.from_agent_name "archetype-agent" in
-  check archetype "known metadata" Agent_identity.Melchior
-    (Agent_identity.get_archetype
-       { base with Agent_identity.metadata = [ ("archetype", "tech") ] });
-  check archetype "unknown metadata fallback" Agent_identity.Generalist
-    (Agent_identity.get_archetype
-       { base with Agent_identity.metadata = [ ("archetype", "planner-ish") ] });
-  check archetype "missing metadata fallback" Agent_identity.Generalist
-    (Agent_identity.get_archetype base)
-
 let test_same_agent () =
   let id1 = Agent_identity.from_agent_name "agent-a" in
   let id2 = { id1 with Agent_identity.last_seen = Unix.gettimeofday () +. 100.0 } in
@@ -298,8 +287,6 @@ let () =
       test_case "channel_yojson_backward_compat" `Quick
         test_channel_yojson_backward_compat;
       test_case "archetype_parser_strict" `Quick test_archetype_parser_strict;
-      test_case "get_archetype_fallback_is_boundary_local" `Quick
-        test_get_archetype_fallback_is_boundary_local;
       test_case "same_agent" `Quick test_same_agent;
       test_case "to_display_string" `Quick test_to_display_string;
       test_case "to_display_string_empty_session_key" `Quick test_to_display_string_empty_session_key;


### PR DESCRIPTION
## Summary
- remove unused public Agent_identity.get_archetype fallback getter
- keep archetype_of_string_opt as the strict archetype parse surface
- drop the fallback-only get_archetype test case

## Verification
- rg -n "get_archetype\b|Generalist fallback|unknown metadata fallback" lib test -S
- git diff --check origin/main...HEAD
- ocamlformat --check lib/agent_identity.ml lib/agent_identity.mli test/test_agent_identity.ml
- scripts/dune-local.sh build test/test_agent_identity.exe (blocked: live bare Dune processes already running; wrapper refused to start another local build)