### PR TITLE
fix(keeper): fallback typed bash Docker to local playground

### DIFF
--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -77,6 +77,11 @@ val docker_run_pull_never_args : unit -> string list
 (** Canonical operator action for a missing keeper sandbox image. *)
 val docker_image_missing_next_action : string
 
+(** [docker_image_present ~image ~timeout_sec] checks whether the configured
+    keeper sandbox image can be inspected locally. [Error message] includes
+    daemon/socket access failures as well as missing-image failures. *)
+val docker_image_present : image:string -> timeout_sec:float -> (unit, string) result
+
 (** Docker [--label] argv fragment for containers owned by the keeper
     sandbox runtime. *)
 val docker_label_args

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -86,6 +86,18 @@ let typed_docker_runtime_failure_fields output =
   then [ "failure_class", `String "policy_rejection" ]
   else []
 
+let typed_docker_local_fallback_target ~meta ~timeout_sec =
+  let image = typed_docker_image meta in
+  match Keeper_sandbox_runtime.docker_image_present ~image ~timeout_sec with
+  | Ok () -> None
+  | Error message ->
+    Some
+      ( Masc_exec.Sandbox_target.host ()
+      , [ "requested_sandbox", `String "docker"
+        ; "sandbox_fallback", `String "local_playground"
+        ; "sandbox_fallback_reason", `String (Worker_dev_tools.truncate_for_log message)
+        ] )
+
 let handle_keeper_bash_typed
       ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
       ~(config : Coord.config)
@@ -132,18 +144,23 @@ let handle_keeper_bash_typed
         in
         let dispatch_sandbox =
           match sandbox_profile with
-          | Local -> Ok (Masc_exec.Sandbox_target.host ())
+          | Local -> Ok (Masc_exec.Sandbox_target.host (), [])
           | Docker ->
             if typed_input_has_env input
             then Error "typed keeper_bash Docker Shell IR dispatch does not support env yet"
-            else typed_docker_sandbox_target ~turn_sandbox_factory ~meta ~cwd
+            else (
+              match typed_docker_local_fallback_target ~meta ~timeout_sec with
+              | Some fallback when in_playground -> Ok fallback
+              | Some _ | None ->
+                typed_docker_sandbox_target ~turn_sandbox_factory ~meta ~cwd
+                |> Result.map (fun target -> target, []))
         in
         (match dispatch_sandbox with
          | Error e ->
            error_json
              ~fields:[ "typed", `Bool true; "cmd", `String cmd_for_log; "cwd", `String cwd ]
              e
-         | Ok dispatch_sandbox ->
+         | Ok (dispatch_sandbox, sandbox_extra_fields) ->
         if Worker_dev_tools.is_destructive_bash_operation cmd
         then
           Yojson.Safe.to_string
@@ -227,6 +244,7 @@ let handle_keeper_bash_typed
                     ~cmd
                     ~extra:
                       (runtime_failure_fields
+                       @ sandbox_extra_fields
                        @ [ "cwd", `String cwd
                          ; "typed", `Bool true
                          ; "execution_time_ms", `Int elapsed_ms

--- a/lib/keeper/keeper_turn_cascade_budget_event_bus.mli
+++ b/lib/keeper/keeper_turn_cascade_budget_event_bus.mli
@@ -16,6 +16,8 @@ type turn_event_bus_summary = {
   correlation_id : string option;
   run_id : string option;
   caused_by : string option;
+  event_count : int;
+  payload_kinds : string list;
   overflow_imminent : turn_event_bus_overflow option;
   context_compact_started_count : int;
   context_compacted_count : int;

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -132,6 +132,12 @@ let run_process_ok ~cwd prog argv =
 let git_ok ~cwd args =
   run_process_ok ~cwd "git" (Array.of_list ("git" :: args))
 
+let docker_image_available image =
+  let cmd =
+    Printf.sprintf "docker image inspect %s > /dev/null 2>&1" (Filename.quote image)
+  in
+  Sys.command cmd = 0
+
 let clear_checkout_but_keep_git_dir root =
   Sys.readdir root
   |> Array.iter (fun name ->
@@ -620,6 +626,100 @@ let test_turn_sandbox_file_write_uses_host_bind_mount () =
   Alcotest.(check string) "content written via bind-mounted host path"
     "alpha\nbeta\n"
     (Fs_compat.load_file target)
+
+let keeper_bash_typed_pipeline_args ~cwd =
+  `Assoc
+    [
+      ( "pipeline",
+        `List
+          [
+            `Assoc
+              [
+                ("executable", `String "printf");
+                ("argv", `List [ `String "typed" ]);
+              ];
+            `Assoc
+              [
+                ("executable", `String "wc");
+                ("argv", `List [ `String "-c" ]);
+              ];
+          ] );
+      ("cwd", `String cwd);
+      ("timeout_sec", `Float 5.0);
+    ]
+
+let check_typed_pipeline_response raw =
+  (match parse_bool_field raw "ok" with
+   | Some true -> ()
+   | Some false -> Alcotest.failf "typed pipeline succeeds: got false in %s" raw
+   | None -> Alcotest.failf "typed pipeline succeeds: missing ok in %s" raw);
+  Alcotest.(check (option bool)) "typed response" (Some true)
+    (parse_bool_field raw "typed");
+  Alcotest.(check int) "typed pipeline exit status" 0
+    (parse_status_exit_code raw);
+  Alcotest.(check bool) "pipeline output propagated" true
+    (response_mentions raw "output" "5")
+
+let test_bash_typed_pipeline_falls_back_to_local_playground () =
+  with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "missing:test" @@ fun () ->
+  setup ~sandbox:Keeper_types.Docker
+  @@ fun ~config ~meta ~playground ->
+  let raw =
+    Keeper_exec_shell.handle_keeper_bash
+      ~turn_sandbox_factory:None
+      ~turn_sandbox_factory_git:None
+      ~exec_cache:None
+      ~config
+      ~meta
+      ~args:(keeper_bash_typed_pipeline_args ~cwd:playground)
+      ()
+  in
+  check_typed_pipeline_response raw;
+  Alcotest.(check (option string)) "requested docker" (Some "docker")
+    (parse_string_field raw "requested_sandbox");
+  Alcotest.(check (option string)) "fallback local playground"
+    (Some "local_playground")
+    (parse_string_field raw "sandbox_fallback")
+
+let test_bash_typed_pipeline_uses_local_shell_ir_dispatch () =
+  setup ~sandbox:Keeper_types.Local
+  @@ fun ~config ~meta ~playground ->
+  Keeper_exec_shell.handle_keeper_bash
+    ~turn_sandbox_factory:None
+    ~turn_sandbox_factory_git:None
+    ~exec_cache:None
+    ~config
+    ~meta
+    ~args:(keeper_bash_typed_pipeline_args ~cwd:playground)
+    ()
+  |> check_typed_pipeline_response
+
+let test_bash_typed_pipeline_uses_turn_sandbox_docker_runner () =
+  let image = "masc-keeper-sandbox:local" in
+  if not (docker_image_available image)
+  then Alcotest.skip ()
+  else
+    with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" image
+    @@ fun () ->
+    setup ~sandbox:Keeper_types.Docker
+    @@ fun ~config ~meta ~playground ->
+    let factory = Keeper_sandbox_factory.create ~config ~meta () in
+    Fun.protect
+      ~finally:(fun () -> Keeper_sandbox_factory.cleanup factory)
+    @@ fun () ->
+    let raw =
+      Keeper_exec_shell.handle_keeper_bash
+        ~turn_sandbox_factory:(Some factory)
+        ~turn_sandbox_factory_git:None
+        ~exec_cache:None
+        ~config
+        ~meta
+        ~args:(keeper_bash_typed_pipeline_args ~cwd:playground)
+        ()
+    in
+    check_typed_pipeline_response raw;
+    Alcotest.(check (option string)) "no local fallback when docker works" None
+      (parse_string_field raw "sandbox_fallback")
 
 let test_bash_routes_through_docker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
@@ -1138,7 +1238,7 @@ let test_docker_shell_missing_image_fails_before_run () =
     Alcotest.(check bool) "docker run skipped" false
       (contains_substring log "\nrun ")
 
-let test_bash_missing_image_is_policy_rejection () =
+let test_bash_missing_image_falls_back_to_local_playground () =
   with_fake_docker fake_docker_missing_image_script @@ fun () ->
   setup ~sandbox:Keeper_types.Docker
   @@ fun ~config ~meta ~playground ->
@@ -1156,14 +1256,15 @@ let test_bash_missing_image_is_policy_rejection () =
       ~exec_cache:None
       ~config
       ~meta
-      ~args:(`Assoc [ ("cmd", `String "pwd"); ("cwd", `String playground) ])
+      ~args:(keeper_bash_typed_pipeline_args ~cwd:playground)
       ()
   in
-  Alcotest.(check bool) "error mentions sandbox image" true
-    (response_mentions raw "error" "sandbox_image_missing");
-  Alcotest.(check (option string)) "missing image is operator policy blocker"
-    (Some "policy_rejection")
-    (parse_string_field raw "failure_class");
+  check_typed_pipeline_response raw;
+  Alcotest.(check (option string)) "requested docker" (Some "docker")
+    (parse_string_field raw "requested_sandbox");
+  Alcotest.(check (option string)) "fallback local playground"
+    (Some "local_playground")
+    (parse_string_field raw "sandbox_fallback");
   let log = read_file log_path in
   Alcotest.(check bool) "image inspect attempted" true
     (contains_substring log "image inspect missing:test");
@@ -2048,6 +2149,15 @@ let () =
             "turn sandbox file writes use bind-mounted host path"
             `Quick test_turn_sandbox_file_write_uses_host_bind_mount;
           Alcotest.test_case
+            "keeper_bash typed pipeline uses local shell ir dispatch"
+            `Quick test_bash_typed_pipeline_uses_local_shell_ir_dispatch;
+          Alcotest.test_case
+            "keeper_bash typed pipeline falls back to local playground"
+            `Quick test_bash_typed_pipeline_falls_back_to_local_playground;
+          Alcotest.test_case
+            "keeper_bash typed pipeline uses turn sandbox docker runner"
+            `Quick test_bash_typed_pipeline_uses_turn_sandbox_docker_runner;
+          Alcotest.test_case
             "git-creds skips missing SSH_AUTH_SOCK"
             `Quick test_git_creds_skips_missing_ssh_auth_sock;
           Alcotest.test_case
@@ -2058,8 +2168,8 @@ let () =
             `Quick test_docker_shell_mounts_masc_config_runtime_paths;
           Alcotest.test_case "docker shell missing image fails before run" `Quick
             test_docker_shell_missing_image_fails_before_run;
-          Alcotest.test_case "keeper_bash missing image is policy rejection" `Quick
-            test_bash_missing_image_is_policy_rejection;
+          Alcotest.test_case "keeper_bash missing image falls back locally" `Quick
+            test_bash_missing_image_falls_back_to_local_playground;
           Alcotest.test_case
             "missing playground bind source blocks before docker"
             `Quick test_bash_missing_playground_blocks_before_docker;


### PR DESCRIPTION
## Summary
- fall back typed `keeper_bash` Shell IR execution to the local playground when Docker image/socket preflight fails
- keep Docker execution when the sandbox image is available, and surface `requested_sandbox=docker` plus `sandbox_fallback=local_playground` when falling back
- add public typed pipeline coverage for local dispatch, Docker-unavailable fallback, and gated live Docker turn-sandbox pipeline smoke
- fix latest-main `keeper_turn_cascade_budget_event_bus.mli` drift by exposing `event_count` and `payload_kinds` already present in the implementation

Refs #17402.

## Verification
- `ocamlformat --check lib/keeper/keeper_turn_cascade_budget_event_bus.mli lib/keeper/keeper_shell_bash.ml lib/keeper/keeper_sandbox_runtime.mli test/test_keeper_shell_docker_route.ml`
- `git diff --check HEAD~1..HEAD`
- `env DUNE_CACHE=disabled dune build --root . test/test_keeper_shell_docker_route.exe` (passed before latest-main mli drift fix)
- `_build/default/test/test_keeper_shell_docker_route.exe test --color=never --show-errors --tail-errors=160 docker_route_contract 3,4,5,9,10`
- escalated Docker socket check: `_build/default/test/test_keeper_shell_docker_route.exe test --color=never --show-errors --tail-errors=120 docker_route_contract 5`

Note: after rebasing onto latest `origin/main`, `env DUNE_CACHE=disabled dune build --root . lib/masc_mcp.cma test/test_keeper_shell_docker_route.exe` was interrupted after prolonged host Dune saturation with no new diagnostic beyond the fixed mli mismatch. Focused formatting, diff check, and targeted tests above passed.