### PR TITLE
Drop dashboard legacy unscoped-only flag

### DIFF
--- a/dashboard/src/components/fleet-health-panel.test.ts
+++ b/dashboard/src/components/fleet-health-panel.test.ts
@@ -226,7 +226,6 @@ describe('FleetHealthPanel', () => {
           missing_task_scope: false,
           partial_task_scope: false,
           current_writer_missing_task_scope: false,
-          legacy_unscoped_only: false,
         },
       },
     }

--- a/dashboard/src/store-normalizers.test.ts
+++ b/dashboard/src/store-normalizers.test.ts
@@ -344,7 +344,6 @@ describe('normalizeDashboardRuntimeResolution fleet safety', () => {
           missing_task_scope: true,
           partial_task_scope: true,
           current_writer_missing_task_scope: true,
-          legacy_unscoped_only: false,
         },
       },
     }))

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -968,7 +968,6 @@ function normalizeDashboardCdalTaskScopeHealth(raw: unknown): DashboardCdalTaskS
     missing_task_scope: asBoolean(raw.missing_task_scope) ?? null,
     partial_task_scope: asBoolean(raw.partial_task_scope) ?? null,
     current_writer_missing_task_scope: asBoolean(raw.current_writer_missing_task_scope) ?? null,
-    legacy_unscoped_only: asBoolean(raw.legacy_unscoped_only) ?? null,
   }
 }
 

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -208,7 +208,6 @@ export interface DashboardCdalTaskScopeHealth {
   missing_task_scope: boolean | null
   partial_task_scope: boolean | null
   current_writer_missing_task_scope: boolean | null
-  legacy_unscoped_only: boolean | null
 }
 
 export interface DashboardCdalHealth {


### PR DESCRIPTION
## Summary
- remove the frontend-only legacy_unscoped_only field from CDAL task-scope normalization
- drop the matching dashboard type field and test fixture values
- keep legacy_unscoped_rows intact because backend still reports it for runtime classification

## Verification
- pnpm install --offline --frozen-lockfile
- pnpm typecheck
- pnpm exec vitest run --config vitest.config.ts src/store-normalizers.test.ts src/components/fleet-health-panel.test.ts --no-file-parallelism --maxWorkers=1
- git diff --check