### PR TITLE
Fix cascade tier admission identity for strict tool groups

### DIFF
--- a/lib/cascade/cascade_catalog_runtime_named_providers.ml
+++ b/lib/cascade/cascade_catalog_runtime_named_providers.ml
@@ -75,23 +75,62 @@ let direct_candidate_providers_ordered_by_entries
   direct_candidates_ordered_by_entries profile ordered_entries
   |> List.map (fun (candidate : candidate_runtime) -> candidate.provider_cfg)
 
-let tier_id_for_candidate (profile : profile_snapshot) _candidate =
-  profile.name
+let tier_bucket_id (profile : profile_snapshot) tier_index =
+  let tiers = profile.strategy.Cascade_strategy.tiers in
+  if List.length tiers <= 1
+  then profile.name
+  else Printf.sprintf "%s.tier-%d" profile.name tier_index
+
+let tier_id_queues_by_health_key (profile : profile_snapshot) =
+  let tiers = profile.strategy.Cascade_strategy.tiers in
+  let index : (string, string Queue.t) Hashtbl.t = Hashtbl.create 8 in
+  if List.length tiers > 1
+  then
+    List.iteri
+      (fun tier_index health_keys ->
+         let tier_id = tier_bucket_id profile tier_index in
+         List.iter
+           (fun health_key ->
+              let queue =
+                match Hashtbl.find_opt index health_key with
+                | Some queue -> queue
+                | None ->
+                    let queue = Queue.create () in
+                    Hashtbl.add index health_key queue;
+                    queue
+              in
+              Queue.add tier_id queue)
+           health_keys)
+      tiers;
+  index
+
+let tier_id_for_candidate
+    (profile : profile_snapshot)
+    tier_index
+    (candidate : candidate_runtime) =
+  let health_key =
+    Cascade_config.provider_health_key_of_config candidate.provider_cfg
+  in
+  match Hashtbl.find_opt tier_index health_key with
+  | Some queue when not (Queue.is_empty queue) -> Queue.pop queue
+  | _ -> profile.name
 
 let tiered_provider_of_candidate
     profile
+    tier_index
     (candidate : candidate_runtime)
     : tiered_provider =
   {
     provider_cfg = candidate.provider_cfg;
-    tier_id = tier_id_for_candidate profile candidate;
+    tier_id = tier_id_for_candidate profile tier_index candidate;
   }
 
 let tiered_providers_of_ordered_entries ~(profile : profile_snapshot)
     ~cascade_name:_
     (ordered_entries : Cascade_config_loader.weighted_entry list) =
+  let tier_index = tier_id_queues_by_health_key profile in
   direct_candidates_ordered_by_entries profile ordered_entries
-  |> List.map (tiered_provider_of_candidate profile)
+  |> List.map (tiered_provider_of_candidate profile tier_index)
 
 let provider_configs_of_ordered_entries ~(profile : profile_snapshot)
     ~cascade_name:_

--- a/test/test_cascade_declarative_hotpath.ml
+++ b/test/test_cascade_declarative_hotpath.ml
@@ -540,6 +540,78 @@ fallback = false
          "expected one tiered provider, got %d"
          (List.length resolution.tiered_providers))
 
+let test_runtime_resolution_splits_multi_tier_group_admission_ids () =
+  let toml =
+    {|
+[providers.runpod_mtp]
+protocol = "openai-http"
+endpoint = "https://runpod.example.test/v1"
+
+[providers.ollama_cloud]
+protocol = "ollama-http"
+endpoint = "https://ollama.com"
+
+[providers.ollama_cloud.credentials]
+type = "env"
+key = "OLLAMA_CLOUD_API_KEY"
+
+[models.qwen36-mtp]
+api-name = "Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf"
+max-context = 160000
+tools-support = true
+streaming = true
+
+[models.qwen36-mtp.capabilities]
+supports-tool-choice = true
+supports-native-streaming = true
+
+[models.kimi-cloud]
+api-name = "kimi-k2.6"
+max-context = 128000
+tools-support = true
+streaming = true
+
+[models.kimi-cloud.capabilities]
+supports-tool-choice = true
+supports-native-streaming = true
+
+[runpod_mtp.qwen36-mtp]
+
+[ollama_cloud.kimi-cloud]
+
+[tier.runpod_primary]
+members = ["runpod_mtp.qwen36-mtp"]
+strategy = "failover"
+
+[tier.ollama_cloud_stable]
+members = ["ollama_cloud.kimi-cloud"]
+strategy = "failover"
+
+[tier-group.strict_tool_candidates]
+tiers = ["runpod_primary", "ollama_cloud_stable"]
+strategy = "failover"
+fallback = false
+|}
+  in
+  with_env "OLLAMA_CLOUD_API_KEY" "test-token" @@ fun () ->
+  with_temp_cascade_config toml @@ fun () ->
+  match
+    Masc_mcp.Cascade_catalog_runtime.resolve_named_providers_strict_with_secondary_resolver
+      ~cascade_name:"tier-group.strict_tool_candidates"
+      ()
+  with
+  | Error err -> fail err
+  | Ok { tiered_providers = [ runpod; ollama ]; _ } ->
+    check string "runpod admission tier id"
+      "tier-group.strict_tool_candidates.tier-0" runpod.tier_id;
+    check string "ollama cloud admission tier id"
+      "tier-group.strict_tool_candidates.tier-1" ollama.tier_id
+  | Ok resolution ->
+    fail
+      (Printf.sprintf
+         "expected two tiered providers, got %d"
+         (List.length resolution.tiered_providers))
+
 (* --- RFC-0058 Phase 8: partial parse --- *)
 
 (* Reproduces the 2026-05-17 keeper-skip incident: a stale [<ghost>.<m>]
@@ -829,6 +901,10 @@ let () =
           "runtime resolution preserves admission tier id"
           `Quick
           test_runtime_resolution_preserves_tier_id;
+        test_case
+          "runtime resolution splits multi-tier group admission ids"
+          `Quick
+          test_runtime_resolution_splits_multi_tier_group_admission_ids;
       ];
       "phase8_partial_parse",
       [


### PR DESCRIPTION
## Summary
- Split admission bucket IDs for multi-tier strict_tool_candidates groups so candidates from different tiers do not share admission state.
- Add regression test for multi-tier candidate resolution to ensure tier-specific admission IDs.
- This reduces false `tier_admission_full` contention when one tier is saturated while another is available.