### PR TITLE
refactor(keeper): share top-level shell segment parsing

### DIFF
--- a/lib/exec/parser/bash_words.mli
+++ b/lib/exec/parser/bash_words.mli
@@ -24,3 +24,9 @@ val stages : string -> (word list list, error) result
     Empty stages are omitted so callers can remain fail-closed at their own
     command-shape layer while still reusing successfully recovered words for
     diagnostics and path policy. *)
+
+val top_level_command_segments : string -> (bool * string) list
+(** Split [source] on unquoted top-level [&&], [||], [;], and newlines.
+    The boolean marks whether the segment is unconditionally reached from the
+    left.  Single [|] is intentionally not a separator here; pipeline-aware
+    callers should continue using {!stages}. *)

--- a/lib/exec/test/test_bash_parser.ml
+++ b/lib/exec/test/test_bash_parser.ml
@@ -442,6 +442,19 @@ let test_word_metadata_marks_globbed_path () =
     assert (not path.quoted)
   | _ -> assert false
 
+let test_top_level_command_segments_preserve_quote_boundaries () =
+  let segments =
+    Bash_words.top_level_command_segments
+      {|git commit -m "do not gh pr create" && gh pr create --draft; git push origin feat|}
+  in
+  match segments with
+  | [
+      (true, {|git commit -m "do not gh pr create"|});
+      (false, "gh pr create --draft");
+      (true, "git push origin feat");
+    ] -> ()
+  | _ -> assert false
+
 let test_double_quote_with_dollar_rejected () =
   (* Variable expansion is subset-excluded at the A1 layer — any '$'
      inside "..." breaks the lex so Parse_error surfaces rather than
@@ -528,6 +541,7 @@ let () =
   test_word_with_double_quoted_suffix ();
   test_word_metadata_preserves_quoted_path_and_pipeline ();
   test_word_metadata_marks_globbed_path ();
+  test_top_level_command_segments_preserve_quote_boundaries ();
   test_double_quote_with_dollar_rejected ();
   test_double_quote_with_backslash_rejected ();
   test_double_quote_with_backtick_rejected ();

--- a/lib/exec/words/shell_words.ml
+++ b/lib/exec/words/shell_words.ml
@@ -102,3 +102,36 @@ let stages source =
   in
   scan No_quote 0
 ;;
+
+let top_level_command_segments command =
+  let len = String.length command in
+  let push_segment unconditional start stop acc =
+    let segment = String.sub command start (stop - start) |> String.trim in
+    if String.equal segment "" then acc else (unconditional, segment) :: acc
+  in
+  let rec loop acc unconditional start i quote escaped =
+    if i >= len
+    then List.rev (push_segment unconditional start len acc)
+    else if escaped
+    then loop acc unconditional start (i + 1) quote false
+    else (
+      match quote, command.[i] with
+      | (No_quote | Double_quote), '\\' ->
+        loop acc unconditional start (i + 1) quote true
+      | No_quote, '\'' -> loop acc unconditional start (i + 1) Single_quote false
+      | No_quote, '"' -> loop acc unconditional start (i + 1) Double_quote false
+      | Single_quote, '\'' -> loop acc unconditional start (i + 1) No_quote false
+      | Double_quote, '"' -> loop acc unconditional start (i + 1) No_quote false
+      | No_quote, '&' when i + 1 < len && command.[i + 1] = '&' ->
+        let acc = push_segment unconditional start i acc in
+        loop acc false (i + 2) (i + 2) No_quote false
+      | No_quote, '|' when i + 1 < len && command.[i + 1] = '|' ->
+        let acc = push_segment unconditional start i acc in
+        loop acc false (i + 2) (i + 2) No_quote false
+      | No_quote, ('\n' | ';') ->
+        let acc = push_segment unconditional start i acc in
+        loop acc true (i + 1) (i + 1) No_quote false
+      | _ -> loop acc unconditional start (i + 1) quote false)
+  in
+  loop [] true 0 0 No_quote false
+;;

--- a/lib/exec/words/shell_words.mli
+++ b/lib/exec/words/shell_words.mli
@@ -24,3 +24,9 @@ val stages : string -> (word list list, error) result
     Empty stages are omitted so callers can remain fail-closed at their own
     command-shape layer while still reusing successfully recovered words for
     diagnostics and path policy. *)
+
+val top_level_command_segments : string -> (bool * string) list
+(** Split [source] on unquoted top-level [&&], [||], [;], and newlines.
+    The boolean marks whether the segment is unconditionally reached from the
+    left.  Single [|] is intentionally not a separator here; pipeline-aware
+    callers should continue using {!stages}. *)

--- a/lib/keeper/keeper_hooks_oas_pr_metrics.ml
+++ b/lib/keeper/keeper_hooks_oas_pr_metrics.ml
@@ -107,44 +107,6 @@ let pr_review_action_metric_event_of_tool_io
            })
   | _ -> None
 
-let split_top_level_command_segments command =
-  let len = String.length command in
-  let push_segment unconditional start stop acc =
-    let segment = String.sub command start (stop - start) |> String.trim in
-    if segment = "" then acc else (unconditional, segment) :: acc
-  in
-  let rec loop acc unconditional start i in_single in_double escaped =
-    if i >= len then List.rev (push_segment unconditional start len acc)
-    else
-      let c = command.[i] in
-      if escaped then loop acc unconditional start (i + 1) in_single in_double false
-      else
-        match c with
-        | '\\' when not in_single ->
-            loop acc unconditional start (i + 1) in_single in_double true
-        | '\'' when not in_double ->
-            loop acc unconditional start (i + 1) (not in_single) in_double false
-        | '"' when not in_single ->
-            loop acc unconditional start (i + 1) in_single (not in_double) false
-        | '&' when (not in_single) && (not in_double) && i + 1 < len
-                   && command.[i + 1] = '&' ->
-            let acc = push_segment unconditional start i acc in
-            loop acc false (i + 2) (i + 2) in_single in_double false
-        | '|' when (not in_single) && (not in_double) && i + 1 < len
-                   && command.[i + 1] = '|' ->
-            let acc = push_segment unconditional start i acc in
-            loop acc false (i + 2) (i + 2) in_single in_double false
-        | '\n' when (not in_single) && not in_double ->
-            let acc = push_segment unconditional start i acc in
-            loop acc true (i + 1) (i + 1) in_single in_double false
-        | ';' when (not in_single) && not in_double ->
-            let acc = push_segment unconditional start i acc in
-            loop acc true (i + 1) (i + 1) in_single in_double false
-        | _ ->
-            loop acc unconditional start (i + 1) in_single in_double false
-  in
-  loop [] true 0 0 false false false
-
 let pr_work_action_of_git_action raw =
   match String.trim raw |> String.lowercase_ascii with
   | "add" -> Some "GIT_ADD"
@@ -183,7 +145,7 @@ let pr_work_actions_of_gh_segment segment =
   | _ -> []
 
 let pr_work_actions_of_command command =
-  split_top_level_command_segments command
+  Masc_exec_bash_parser.Bash_words.top_level_command_segments command
   |> List.concat_map (fun (unconditional, segment) ->
        (* Shell conditionals can skip later segments at runtime.  Without
           per-segment exit data, count only top-level segments that are


### PR DESCRIPTION
## Summary
- move quote-aware top-level shell segment splitting into shared Bash_words / Shell_words
- remove keeper_hooks_oas_pr_metrics private quote-state command segment scanner
- add parser coverage for quoted command text plus && / ; top-level segmentation

## Verification
- ocamlformat --check lib/exec/words/shell_words.ml lib/exec/words/shell_words.mli lib/exec/parser/bash_words.mli lib/keeper/keeper_hooks_oas_pr_metrics.ml lib/exec/test/test_bash_parser.ml
- git diff --check
- bash scripts/lint/shell-legacy-purge-ratchet.sh
- env MASC_DUNE_ALLOW_BARE_DUNE=1 dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/nested-runtime-typed-parser-20260522 lib/exec/test/test_bash_parser.exe
- ./_build/default/lib/exec/test/test_bash_parser.exe

## Blocked / separated
- On current origin/main, building test/test_keeper_hooks_oas_telemetry.exe is blocked before this change by lib/keeper/keeper_agent_run.ml syntax error at line 1567 and keeper_turn_cascade_budget_event_bus interface drift.
- The same telemetry executable passed before rebasing this patch onto the newer main snapshot.