### PR TITLE
fix(keeper): materialize typed Shell IR paths directly

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -197,8 +197,8 @@ let handle_keeper_bash_typed
           | Ok ir ->
             let path_validation =
               match
-                Keeper_task_worktree_lazy.ensure_command_existing_dirs
-                  ~config ~meta ~cwd ~cmd
+                Keeper_task_worktree_lazy.ensure_shell_ir_existing_dirs
+                  ~config ~meta ~cwd ~ir
               with
               | Error e -> Error e
               | Ok () ->

--- a/lib/keeper/keeper_task_worktree_lazy.ml
+++ b/lib/keeper/keeper_task_worktree_lazy.ml
@@ -169,8 +169,8 @@ let host_path_of_command_value ~cwd value =
   else value
 ;;
 
-let ensure_command_existing_dirs ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta)
-      ~cwd ~cmd =
+let ensure_existing_dir_values ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta)
+      ~cwd values =
   let rec loop = function
     | [] -> Ok ()
     | value :: rest ->
@@ -179,5 +179,23 @@ let ensure_command_existing_dirs ~(config : Coord.config) ~(meta : Keeper_types.
        | Error _ as err -> err
        | Ok _ -> loop rest)
   in
-  loop (Worker_dev_tools.existing_dir_path_values cmd)
+  loop values
+;;
+
+let ensure_shell_ir_existing_dirs ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta)
+      ~cwd ~ir =
+  ensure_existing_dir_values
+    ~config
+    ~meta
+    ~cwd
+    (Worker_dev_tools.existing_dir_path_values_of_shell_ir ir)
+;;
+
+let ensure_command_existing_dirs ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta)
+      ~cwd ~cmd =
+  ensure_existing_dir_values
+    ~config
+    ~meta
+    ~cwd
+    (Worker_dev_tools.existing_dir_path_values cmd)
 ;;

--- a/lib/keeper/keeper_task_worktree_lazy.mli
+++ b/lib/keeper/keeper_task_worktree_lazy.mli
@@ -32,3 +32,12 @@ val ensure_command_existing_dirs :
 (** Inspect [cmd] for existing-directory path requirements such as
     [git -C <dir>] and lazily repair matching current-task worktrees relative
     to [cwd]. *)
+
+val ensure_shell_ir_existing_dirs :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  cwd:string ->
+  ir:Masc_exec.Shell_ir.t ->
+  (unit, string) result
+(** Inspect typed Shell IR for existing-directory path requirements without
+    reparsing a diagnostic command string. *)

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -741,15 +741,15 @@ let existing_dir_path_values_of_simple (simple : Masc_exec.Shell_ir.simple) =
   | Some args -> loop false [] (path_argument_values command_name args)
 ;;
 
+let rec existing_dir_path_values_of_shell_ir = function
+  | Masc_exec.Shell_ir.Simple simple -> existing_dir_path_values_of_simple simple
+  | Masc_exec.Shell_ir.Pipeline stages ->
+    List.concat_map existing_dir_path_values_of_shell_ir stages
+;;
+
 let existing_dir_path_values cmd =
   match Masc_exec_bash_parser.Bash.parse_string cmd with
-  | Masc_exec.Parsed.Parsed (Masc_exec.Shell_ir.Simple simple) ->
-    existing_dir_path_values_of_simple simple
-  | Masc_exec.Parsed.Parsed (Masc_exec.Shell_ir.Pipeline stages) ->
-    stages
-    |> List.concat_map (function
-      | Masc_exec.Shell_ir.Simple simple -> existing_dir_path_values_of_simple simple
-      | Masc_exec.Shell_ir.Pipeline _ -> [])
+  | Masc_exec.Parsed.Parsed shell_ir -> existing_dir_path_values_of_shell_ir shell_ir
   | Masc_exec.Parsed.Parse_error _
   | Masc_exec.Parsed.Parse_aborted _
   | Masc_exec.Parsed.Too_complex _ -> []

--- a/lib/worker_dev_tools.mli
+++ b/lib/worker_dev_tools.mli
@@ -132,6 +132,11 @@ val validate_command_paths
     and [rg]. Callers may use this to repair an expected sandbox directory
     before delegating to {!validate_command_paths}; the validator remains
     the authority for out-of-sandbox paths. *)
+val existing_dir_path_values_of_shell_ir : Masc_exec.Shell_ir.t -> string list
+
+(** Shell IR authority variant of {!existing_dir_path_values}. Prefer this
+    when the caller already has typed Shell IR so argv tokens are not
+    reconstructed through a diagnostic command string. *)
 val existing_dir_path_values : string -> string list
 
 (** {1 Bash safety classifiers} *)

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -1455,6 +1455,33 @@ let () =
               (contains_substring msg "outside allowed directories")
           | Ok () ->
             Alcotest.fail "nested Shell IR path must not bypass validation");
+      Alcotest.test_case
+        "Shell IR existing-dir materialization keeps typed argv tokens"
+        `Quick
+        (fun () ->
+          let open Masc_exec.Shell_ir in
+          let git = Masc_exec.Bin.of_string "git" |> Result.get_ok in
+          let head = Masc_exec.Bin.of_string "head" |> Result.get_ok in
+          let simple bin args =
+            Simple
+              { bin
+              ; args = List.map (fun arg -> Lit arg) args
+              ; env = []
+              ; cwd = None
+              ; redirects = []
+              ; sandbox = Masc_exec.Sandbox_target.host ()
+              }
+          in
+          let ir =
+            Pipeline
+              [ simple git [ "-C"; "repos/my repo/.worktrees/task"; "status" ]
+              ; Pipeline [ simple head [ "-1" ] ]
+              ]
+          in
+          Alcotest.(check (list string))
+            "existing-dir values"
+            [ "repos/my repo/.worktrees/task" ]
+            (Worker_dev_tools.existing_dir_path_values_of_shell_ir ir));
       Alcotest.test_case "outside literal path is blocked"
         `Quick (fun () ->
           match Worker_dev_tools.validate_command_paths


### PR DESCRIPTION
## Summary
- add a Shell IR authority variant for existing-directory path extraction
- use typed Shell IR directly when keeper_bash lazily repairs task worktree paths
- keep the legacy command-string extractor only as a compatibility wrapper
- cover nested IR traversal and typed argv tokens containing spaces

## Verification
- ocamlformat --check lib/worker_dev_tools.ml lib/worker_dev_tools.mli lib/keeper/keeper_task_worktree_lazy.ml lib/keeper/keeper_task_worktree_lazy.mli lib/keeper/keeper_shell_bash.ml test/test_worker_dev_tools.ml
- git diff --check origin/main...HEAD
- bash scripts/lint-spawn-bounded.sh

## Blocked focused build
- Command: env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_worker_dev_tools.exe
- Blocker: current main fails before this patch on unrelated files:
  - lib/keeper/keeper_agent_run.ml syntax error around line 1567
  - lib/cascade/cascade_catalog_runtime_named_providers.ml unbound Cascade_config.provider_health_key_of_config
- Pin note: normal dune-local also stops on shared agent_sdk floor 0.196.10 while current main still declares branch floor 0.196.8, so the focused compile attempt used MASC_SKIP_PIN_CHECK=1 after the repair script refused a downgrade.