### PR TITLE
refactor(board): remove truncation bool wrapper

### DIFF
--- a/lib/tool_board.mli
+++ b/lib/tool_board.mli
@@ -14,8 +14,7 @@
       search, comment_vote, reaction, profile, hearth_list,
       curation_read, delete),
     - the {b truncated-markdown detector}
-      ({!detect_truncated_markdown} +
-      {!detect_truncated_markdown_with_reason}) used by
+      ({!detect_truncated_markdown_with_reason}) used by
       the post-create path to flag chat-suffix paste
       accidents,
     - the {b sort-order parser} ({!parse_sort_order})
@@ -65,11 +64,6 @@ val detect_truncated_markdown_with_reason :
     Used by [handle_post_create] to surface a precise
     reason in the response when a paste appears
     truncated. *)
-
-val detect_truncated_markdown : string -> bool
-(** Boolean form — true iff
-    {!detect_truncated_markdown_with_reason} returns a
-    [Some]. *)
 
 (** {1 Sort order} *)
 

--- a/lib/tool_board_format.ml
+++ b/lib/tool_board_format.ml
@@ -369,11 +369,6 @@ let detect_truncated_markdown_with_reason (text : string) : truncation_signal op
     else None)
 ;;
 
-(* Backwards-compatible boolean wrapper. *)
-let detect_truncated_markdown (text : string) : bool =
-  Option.is_some (detect_truncated_markdown_with_reason text)
-;;
-
 (** {1 Sort order}
 
     Issue #8449 PR B: [sort_order] re-exports [Board_dispatch.sort_order]

--- a/test/test_board_truncation_detection.ml
+++ b/test/test_board_truncation_detection.ml
@@ -88,20 +88,6 @@ let test_fence_priority_over_link () =
   check (option signal_t) "fence has higher priority"
     (Some Tool_board.Odd_fence) (detect s)
 
-(* ---- Boolean wrapper agrees with reason API ------------------------ *)
-
-let test_bool_wrapper_agrees () =
-  let cases = [
-    ("complete.", false);
-    ("```\nopen", true);
-    ("trailing `code", true);
-    ("trailing [link](url", true);
-  ] in
-  List.iter (fun (input, expected) ->
-    check bool (Printf.sprintf "case %S" input) expected
-      (Tool_board.detect_truncated_markdown input)
-  ) cases
-
 let () =
   run "board truncation detection (#9777)"
     [
@@ -126,9 +112,5 @@ let () =
       ( "priority",
         [
           test_case "fence wins over link" `Quick test_fence_priority_over_link;
-        ] );
-      ( "compat",
-        [
-          test_case "bool wrapper agrees with reason" `Quick test_bool_wrapper_agrees;
         ] );
     ]


### PR DESCRIPTION
## Summary
- remove the backwards-compatible detect_truncated_markdown boolean wrapper
- keep detect_truncated_markdown_with_reason as the single truncation detection API
- drop the compatibility-only bool wrapper test

## Validation
- rg -n "detect_truncated_markdown\b" lib test docs (0 matches)
- ocamlformat --check lib/tool_board_format.ml lib/tool_board.mli test/test_board_truncation_detection.ml
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_board_truncation_detection.exe (attempted twice; reached compile/link after lock wait, but local tool session exited without a diagnostic and did not produce the exe)