### PR TITLE
fix: repair compile drift after OAS v0.196.10 bump

### DIFF
--- a/lib/cascade/cascade_catalog_runtime_named_providers.ml
+++ b/lib/cascade/cascade_catalog_runtime_named_providers.ml
@@ -109,7 +109,7 @@ let tier_id_for_candidate
     tier_index
     (candidate : candidate_runtime) =
   let health_key =
-    Cascade_config.provider_health_key_of_config candidate.provider_cfg
+    Llm_provider.Complete_cascade.provider_key candidate.provider_cfg
   in
   match Hashtbl.find_opt tier_index health_key with
   | Some queue when not (Queue.is_empty queue) -> Queue.pop queue

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -933,19 +933,17 @@ let run_turn
                          (Contract_helpers.completion_contract_violation_error reason)
                    in
                    let finalize_response_text raw_response_text =
-                     Keeper_agent_run_response_text.finalize
-                       ~keeper_name:meta.name
-                       ~goal:meta.goal
-                       ~actual_keeper_tool_names:!actual_keeper_tool_names_ref
-                       ~fallback_tool_names:actual_keeper_tool_names
-                       ~stop_reason:result.stop_reason
-                       ~raw_response_text
-                   in
-                   let
-                     { Keeper_agent_run_response_text.state_snapshot; response_text }
-                     =
-                     finalize_response_text raw_response_text
-                   in
+                     let
+                       { Keeper_agent_run_response_text.state_snapshot; response_text }
+                       =
+                       Keeper_agent_run_response_text.finalize
+                         ~keeper_name:meta.name
+                         ~goal:meta.goal
+                         ~actual_keeper_tool_names:!actual_keeper_tool_names_ref
+                         ~fallback_tool_names:actual_keeper_tool_names
+                         ~stop_reason:result.stop_reason
+                         ~raw_response_text
+                     in
                     let state_snapshot_source =
                       if
                         Option.is_some

--- a/lib/keeper/keeper_agent_run_contract_helpers.ml
+++ b/lib/keeper/keeper_agent_run_contract_helpers.ml
@@ -67,7 +67,7 @@ let observed_tool_contract_status ~required_tool_names ~missing_visible_required
       ~had_owned_active_task_at_turn_start ~actual_keeper_tool_names
   : Keeper_execution_receipt.tool_contract_result
   =
-  Keeper_agent_tool_surface.tool_contract_result_for_observed_tools
+  Keeper_turn_helpers.tool_contract_result_for_observed_tools
     ~required_tool_names ~missing_visible_required ~had_owned_active_task_at_turn_start
     ~actual_keeper_tool_names
 ;;

--- a/lib/keeper/keeper_turn_cascade_budget_event_bus.mli
+++ b/lib/keeper/keeper_turn_cascade_budget_event_bus.mli
@@ -30,3 +30,5 @@ val merge_turn_event_bus_summary
   :  turn_event_bus_summary
   -> turn_event_bus_summary
   -> turn_event_bus_summary
+
+val add_payload_kind : string list -> string -> string list


### PR DESCRIPTION
Fixes 4 build errors that surfaced after agent_sdk (OAS) pin bump to v0.196.10.

Changes:
- Fix syntax error in keeper_agent_run.ml (cherry-pick 2b6f7883)
- Replace removed Cascade_config.provider_health_key_of_config with Llm_provider.Complete_cascade.provider_key
- Fix unbound Keeper_agent_tool_surface.tool_contract_result_for_observed_tools → use Keeper_turn_helpers.tool_contract_result_for_observed_tools
- Expose add_payload_kind in keeper_turn_cascade_budget_event_bus.mli