### PR TITLE
fix: repair broken build from recent refactoring PRs

### DIFF
--- a/bin/masc_tui_ansi.ml
+++ b/bin/masc_tui_ansi.ml
@@ -50,7 +50,7 @@ let get_terminal_size () =
   let read_tput arg =
     try
       let line, status =
-        Masc_mcp.With_process.with_process_args_in "tput" [| "tput"; arg |]
+        With_process.with_process_args_in "tput" [| "tput"; arg |]
           input_line
       in
       match status with

--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -34,8 +34,8 @@ let process_status_to_string = function
 let run_git_exn repo args =
   let argv = Array.of_list ("git" :: "-C" :: repo :: args) in
   let buf, status =
-    Lib.With_process.with_process_args_in "git" argv
-      Lib.With_process.drain_to_buffer
+    With_process.with_process_args_in "git" argv
+      With_process.drain_to_buffer
   in
   let output = Buffer.contents buf in
   match status with

--- a/test/test_env_git_noninteractive.ml
+++ b/test/test_env_git_noninteractive.ml
@@ -240,8 +240,8 @@ let test_no_forgotten_git_askpass_literals () =
     |]
   in
   let lines, _status =
-    Masc_mcp.With_process.with_process_args_in "rg" argv
-      Masc_mcp.With_process.drain_lines
+    With_process.with_process_args_in "rg" argv
+      With_process.drain_lines
   in
   let offenders =
     List.filter

--- a/test/test_masc_dirname_ssot.ml
+++ b/test/test_masc_dirname_ssot.ml
@@ -51,8 +51,8 @@ let rg_matching_files ~pattern ~paths =
       @ [ "--glob"; "*.ml"; "--glob"; "*.mli" ])
   in
   let lines, _status =
-    Masc_mcp.With_process.with_process_args_in "rg" argv
-      Masc_mcp.With_process.drain_lines
+    With_process.with_process_args_in "rg" argv
+      With_process.drain_lines
   in
   lines
 


### PR DESCRIPTION
## Summary
- Fix 6 build errors introduced by #17590, #17585, #17580, and #17582
- Cherry-picks codex hotfix `2b6f78834a` for the `finalize_response_text` scope issue
- Fixes 4 `Unbound module/value` errors from `(wrapped false)` and module extraction
- Exposes 2 missing `.mli` entries in `keeper_turn_cascade_budget_event_bus`

## Changes

| File | Error | Fix |
|------|-------|-----|
| `lib/keeper/keeper_agent_run.ml` | Syntax error (scope break) | Cherry-pick 2b6f78834a: keep destructuring inside function body |
| `lib/keeper/keeper_agent_run_contract_helpers.ml` | Unbound value | Update module path to `Keeper_agent_run_turn_helpers` |
| `lib/cascade/cascade_catalog_runtime_named_providers.ml` | Unbound value | Update to `Cascade_config_provider_binding` submodule |
| `lib/keeper/keeper_turn_cascade_budget_event_bus.mli` | Unbound value | Add `add_payload_kind` + `merge_payload_kinds` to interface |
| `bin/masc_tui_ansi.ml` | Unbound module | `Masc_mcp.With_process` → `With_process` (wrapped false) |
| `test/test_masc_dirname_ssot.ml` | Unbound module | Same fix |
| `test/test_env_git_noninteractive.ml` | Unbound module | Same fix |
| `test/test_dashboard_tools.ml` | Unbound module | `Lib.With_process` → `With_process` |

## Test plan
- [x] `dune build --root .` passes with exit code 0
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>