### PR TITLE
refactor(keeper): remove 24-keeper nofile legacy

### DIFF
--- a/lib/keeper_fd_pressure.ml
+++ b/lib/keeper_fd_pressure.ml
@@ -12,10 +12,8 @@
     process nofile budget has passed.
 
     Fleet baseline (2026-05-17): default capacity targets 64 active keepers
-    (= 64 * fd_per_active_keeper + fd_headroom). The previous default named
-    [MASC_KEEPER_MIN_NOFILE_FOR_24] (= 4096) capped the fleet at ~41 keepers
-    under macOS launchctl defaults; ramping to 64-keeper baseline closes that
-    gap without changing the admission policy itself. *)
+    (= 64 * fd_per_active_keeper + fd_headroom). The fleet knob is
+    [MASC_KEEPER_MIN_NOFILE_FOR_FLEET]. *)
 
 let cooldown_until = Atomic.make 0.0
 let last_log_at = Atomic.make 0.0
@@ -406,31 +404,17 @@ let system_fd_snapshot ?now () =
           snapshot)
 ;;
 
-(* Fleet baseline (renamed 2026-05-17 from min_nofile_for_24_keepers).
-   Default targets 64 active keepers: 64 * fd_per_active_keeper (96)
-   + fd_headroom (128) ≈ 6272; with 2x margin → 12288. The legacy env name
-   [MASC_KEEPER_MIN_NOFILE_FOR_24] is still honored for operators who set it
-   pre-rename, but FLEET takes precedence and the legacy var only applies
-   when FLEET is absent. *)
+(* Fleet baseline. Default targets 64 active keepers:
+   64 * fd_per_active_keeper (96) + fd_headroom (128) ≈ 6272;
+   with 2x margin → 12288. *)
 let min_nofile_for_fleet () =
   let fleet_default = 12288 in
   let from_fleet =
     Env_config_core.get_int ~default:0 "MASC_KEEPER_MIN_NOFILE_FOR_FLEET"
   in
-  let resolved =
-    if from_fleet > 0
-    then from_fleet
-    else (
-      let legacy =
-        Env_config_core.get_int ~default:0 "MASC_KEEPER_MIN_NOFILE_FOR_24"
-      in
-      if legacy > 0 then legacy else fleet_default)
-  in
+  let resolved = if from_fleet > 0 then from_fleet else fleet_default in
   max 256 resolved
 ;;
-
-(* Compat alias preserved for any out-of-tree callers; do not add new uses. *)
-let min_nofile_for_24_keepers = min_nofile_for_fleet
 
 let fd_headroom () =
   Env_config_core.get_int ~default:128 "MASC_KEEPER_FD_HEADROOM"
@@ -738,7 +722,7 @@ let runtime_state_json ?(soft_limit = process_nofile_soft_limit ())
     ; "host_fd_hotspot_probe_supported", host_fd_hotspot_probe_supported
     ; "headroom", `Int (fd_headroom ())
     ; "fd_per_active_keeper", `Int (fd_per_active_keeper ())
-    ; "min_nofile_for_24_keepers", `Int (min_nofile_for_24_keepers ())
+    ; "min_nofile_for_fleet", `Int (min_nofile_for_fleet ())
     ; "requested_keepers", `Int requested_keepers
     ; "target_keeper_count", `Int target_keeper_count
     ; "active_keepers", `Int active_keepers

--- a/test/test_keeper_fd_pressure_fleet.ml
+++ b/test/test_keeper_fd_pressure_fleet.ml
@@ -2,8 +2,8 @@
     monotonic CAS for [cooldown_until] / [last_log_at], and single-flight
     semantics for [process_nofile_soft_limit].
 
-    Covers the four T1 changes that landed together:
-    - T1-A: [min_nofile_for_fleet] default + [min_nofile_for_24_keepers] alias
+    Covers the fleet FD pressure behavior:
+    - [min_nofile_for_fleet] default
     - T1-C: [cas_monotonic_max] never loses larger writers under race
     - T1-D: [nofile_soft_limit_cache] 3-state variant gives one [Resolved]
             answer regardless of concurrent first-touches *)
@@ -41,14 +41,6 @@ let test_fleet_default_at_or_above_12288 () =
     (Printf.sprintf "min_nofile_for_fleet () = %d >= 12288" v)
     true
     (v >= 12288)
-
-let test_legacy_alias_matches_fleet () =
-  (* [min_nofile_for_24_keepers] is preserved as a compat alias so external
-     readers don't break; it must resolve to the same value. *)
-  Alcotest.(check int)
-    "min_nofile_for_24_keepers = min_nofile_for_fleet"
-    (FD.min_nofile_for_fleet ())
-    (FD.min_nofile_for_24_keepers ())
 
 let test_low_nofile_blocks_synthetic_24_keeper_start () =
   FD.reset_for_tests ();
@@ -251,8 +243,6 @@ let () =
     [ ( "fleet-baseline"
       , [ Alcotest.test_case "default >= 12288" `Quick
             test_fleet_default_at_or_above_12288
-        ; Alcotest.test_case "legacy alias matches fleet" `Quick
-            test_legacy_alias_matches_fleet
         ; Alcotest.test_case "nofile=256 blocks synthetic 24-keeper start" `Quick
             test_low_nofile_blocks_synthetic_24_keeper_start
         ] )


### PR DESCRIPTION
## Summary
- remove the min_nofile_for_24_keepers compatibility alias
- stop honoring the legacy MASC_KEEPER_MIN_NOFILE_FOR_24 env fallback
- replace the runtime JSON field with canonical min_nofile_for_fleet
- drop the compatibility-only alias test

## Validation
- rg -n "MASC_KEEPER_MIN_NOFILE_FOR_24|min_nofile_for_24_keepers" lib test docs dashboard (0 matches)
- ocamlformat --check lib/keeper_fd_pressure.ml test/test_keeper_fd_pressure_fleet.ml
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_fd_pressure_fleet.exe
- _build/default/test/test_keeper_fd_pressure_fleet.exe