### PR TITLE
docs(spec): refresh memory horizon fallback anchor

### DIFF
--- a/specs/keeper-state-machine/KeeperMemoryLifecycle.tla
+++ b/specs/keeper-state-machine/KeeperMemoryLifecycle.tla
@@ -36,18 +36,18 @@
 \*
 \* Producer (kind -> tier classification):
 \*   lib/keeper/keeper_memory_policy.ml:memory_horizon_of_kind_opt  (strict)
-\*   lib/keeper/keeper_memory_policy.ml:memory_horizon_of_kind      (back-compat wrapper)
+\*   lib/keeper/keeper_memory_bank.ml:memory_horizon_of_kind_with_fallback  (fallback wrapper)
 \*   lib/keeper/keeper_memory_policy.ml:memory_horizon_of_json_opt  (JSON variant)
 \*
 \* Persistence / promotion sites:
-\*   lib/keeper/keeper_memory_bank.ml:append_memory_notes_from_reply   — writes via memory_horizon_of_kind
+\*   lib/keeper/keeper_memory_bank.ml:append_memory_notes_from_reply   — writes via memory_horizon_of_kind_with_fallback
 \*   lib/keeper/keeper_memory_recall.ml:read_recent_memory_texts       — recall path, same horizon fn
 \*   lib/keeper/keeper_compact_policy.ml    overflow + handoff scheduling
 \*   lib/keeper/keeper_compact_audit.ml     ledger trail (provenance source)
 \*
 \* SCOPE DRIFT (worth knowing, NOT a spec violation):
-\*   memory_horizon_of_kind silently routes unknown kinds to mid_term_horizon
-\*   (lib/keeper/keeper_memory_policy.ml:memory_horizon_of_kind  `| None -> mid_term_horizon`).
+\*   memory_horizon_of_kind_with_fallback silently routes unknown kinds to mid_term_horizon
+\*   (lib/keeper/keeper_memory_bank.ml:memory_horizon_of_kind_with_fallback).
 \*   The spec invariants (ProvenanceRequired, RecoveryBounded, NoSilentLoss)
 \*   hold regardless of WHICH tier a note lands in -- the drift is UPSTREAM
 \*   of the spec vocabulary. A typo'd kind ("goalss") gets the wrong tier


### PR DESCRIPTION
## Summary
- refresh KeeperMemoryLifecycle spec-line anchors to the current memory horizon fallback wrapper
- remove dangling reference to the removed memory_horizon_of_kind symbol

## Verification
- bash scripts/lint/spec-line-refs.sh
- git diff --check