### PR TITLE
docs(keeper): drop stale memory recall alias note

### DIFF
--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -865,6 +865,3 @@ let work_kind_of_eval (e : memory_recall_eval) : string =
     | Some "first_question" -> "first_question_answer"
     | Some topic when topic <> "" -> topic
     | _ -> "general_chat"
-
-(* Tool definitions moved to Tool_shard for dynamic composition.
-   This alias maintains backward compatibility. *)


### PR DESCRIPTION
## Summary
- remove the stale memory recall comment claiming a compatibility alias still exists
- leave the module ending at the actual exported helper

## Validation
- rg -n "This alias maintains backward compatibility" lib/keeper/keeper_memory_recall.ml (0 matches)
- ocamlformat --check lib/keeper/keeper_memory_recall.ml
- git diff --check