### PR TITLE
Remove checkpoint compat reader fallback

### DIFF
--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -164,7 +164,7 @@ let load_latest ~(session_dir : string) : Keeper_types.checkpoint option =
        None)
 
 (* ================================================================ *)
-(* OAS Checkpoint Compatibility                                      *)
+(* OAS Checkpoints                                                    *)
 (* ================================================================ *)
 
 let oas_checkpoint_path ~(session_dir : string) ~(session_id : string) =
@@ -388,159 +388,12 @@ let classify_sdk_error (e : Agent_sdk.Error.sdk_error) : checkpoint_load_error =
   | Orchestration _ | A2a _ | Internal _ ->
       Sdk_other_error (Agent_sdk.Error.to_string e)
 
-let result_all items =
-  let rec loop acc = function
-    | [] -> Ok (List.rev acc)
-    | Ok item :: rest -> loop (item :: acc) rest
-    | Error e :: _ -> Error e
-  in
-  loop [] items
-
-let content_block_of_json_strict json =
-  try
-    match Agent_sdk.Api.content_block_of_json json with
-    | Some block -> Ok block
-    | None ->
-        let open Yojson.Safe.Util in
-        let block_type =
-          json |> member "type" |> to_string_option |> Option.value ~default:"<missing>"
-        in
-        Error
-          (Agent_sdk.Error.Serialization
-             (JsonParseError
-                {
-                  detail =
-                    Printf.sprintf "Unknown content block type: %s" block_type;
-                }))
-  with
-  | Yojson.Safe.Util.Type_error (msg, _) ->
-      Error
-        (Agent_sdk.Error.Serialization
-           (JsonParseError
-              { detail = Printf.sprintf "Invalid content block: %s" msg }))
-  | Yojson.Json_error msg ->
-      Error
-        (Agent_sdk.Error.Serialization
-           (JsonParseError
-              { detail = Printf.sprintf "Invalid content block: %s" msg }))
-  | Failure msg ->
-      Error
-        (Agent_sdk.Error.Serialization
-           (JsonParseError
-              { detail = Printf.sprintf "Invalid content block: %s" msg }))
-
-let role_of_string_compat raw =
-  match String.lowercase_ascii (String.trim raw) with
-  | "system" -> Ok Agent_sdk.Types.System
-  | "user" -> Ok Agent_sdk.Types.User
-  | "assistant" -> Ok Agent_sdk.Types.Assistant
-  | "tool" -> Ok Agent_sdk.Types.Tool
-  | other ->
-      Error
-        (Agent_sdk.Error.Serialization
-           (UnknownVariant { type_name = "role"; value = other }))
-
-let message_of_json_compat json =
-  let open Yojson.Safe.Util in
-  try
-    let role = json |> member "role" |> to_string |> role_of_string_compat in
-    let content =
-      json |> member "content" |> to_list
-      |> List.map content_block_of_json_strict
-      |> result_all
-    in
-    match role, content with
-    | Ok role, Ok content ->
-        Ok
-          {
-            Agent_sdk.Types.role;
-            content;
-            name = json |> member "name" |> to_string_option;
-            tool_call_id = json |> member "tool_call_id" |> to_string_option;
-            metadata = [];
-          }
-    | Error e, _ -> Error e
-    | _, Error e -> Error e
-  with
-  | Yojson.Safe.Util.Type_error (msg, _) ->
-      Error
-        (Agent_sdk.Error.Serialization
-           (JsonParseError
-              { detail = Printf.sprintf "Invalid checkpoint message: %s" msg }))
-  | Yojson.Json_error msg ->
-      Error
-        (Agent_sdk.Error.Serialization
-           (JsonParseError
-              { detail = Printf.sprintf "Invalid checkpoint message: %s" msg }))
-
-let normalize_checkpoint_json_for_sdk json =
-  let normalize_message = function
-    | `Assoc fields ->
-        `Assoc
-          (List.map
-             (function
-               | "role", `String ("assistant" | "user" as role) ->
-                   ("role", `String role)
-               | "role", `String _ ->
-                   ("role", `String "assistant")
-               | field -> field)
-             fields)
-    | other -> other
-  in
-  match json with
-  | `Assoc fields ->
-      `Assoc
-        (List.map
-           (function
-             | "messages", `List messages ->
-                 ("messages", `List (List.map normalize_message messages))
-             | field -> field)
-           fields)
-  | other -> other
-
-let checkpoint_of_json_compat json =
-  let open Yojson.Safe.Util in
-  try
-    let messages =
-      json |> member "messages" |> to_list
-      |> List.map message_of_json_compat
-      |> result_all
-    in
-    match messages with
-    | Error e -> Error e
-    | Ok messages -> (
-        match Agent_sdk.Checkpoint.of_json (normalize_checkpoint_json_for_sdk json) with
-        | Ok checkpoint -> Ok { checkpoint with messages }
-        | Error e -> Error e)
-  with
-  | Yojson.Safe.Util.Type_error (msg, _) ->
-      Error
-        (Agent_sdk.Error.Serialization
-           (JsonParseError
-              { detail = Printf.sprintf "Checkpoint.of_json compat: %s" msg }))
-  | Yojson.Json_error msg ->
-      Error
-        (Agent_sdk.Error.Serialization
-           (JsonParseError
-              { detail = Printf.sprintf "Checkpoint.of_json compat: %s" msg }))
-
-let checkpoint_of_string_compat raw =
-  match Agent_sdk.Checkpoint.of_string raw with
-  | Ok checkpoint -> Ok checkpoint
-  | Error _ ->
-      let json =
-        raw
-        |> Inference_utils.sanitize_text_utf8
-        |> Yojson.Safe.from_string
-      in
-      checkpoint_of_json_compat json
-
 let load_oas_history_file ~(session_dir : string) ~(snapshot_id : string) :
     (Agent_sdk.Checkpoint.t, checkpoint_load_error) result =
   let path = oas_history_path ~session_dir ~snapshot_id in
   if Fs_compat.file_exists path then
     try
-      match checkpoint_of_string_compat (Fs_compat.load_file path) with
+      match Agent_sdk.Checkpoint.of_string (Fs_compat.load_file path) with
       | Ok ckpt -> Ok ckpt
       | Error e -> Error (classify_sdk_error e)
     with
@@ -554,7 +407,7 @@ let load_oas ~(session_dir : string) ~(session_id : string) :
     let path = oas_checkpoint_path ~session_dir ~session_id in
     if Fs_compat.file_exists path then
       try
-        match checkpoint_of_string_compat (Fs_compat.load_file path) with
+        match Agent_sdk.Checkpoint.of_string (Fs_compat.load_file path) with
         | Ok ckpt -> Ok ckpt
         | Error e -> Error (classify_sdk_error e)
       with

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -113,40 +113,6 @@ type checkpoint_load_error =
 val classify_sdk_error :
   Agent_sdk.Error.sdk_error -> checkpoint_load_error
 
-(** Sequence a [('a, 'e) result] list into [('a list, 'e) result],
-    short-circuiting on the first [Error]. *)
-val result_all : ('a, 'e) result list -> ('a list, 'e) result
-
-(** Strict content-block parser used for compat OAS checkpoint
-    decode. Errors carry an [Agent_sdk.Error.sdk_error]. *)
-val content_block_of_json_strict :
-  Yojson.Safe.t -> (Agent_sdk.Types.content_block, Agent_sdk.Error.sdk_error) result
-
-(** Compat role parser — accepts trim/case variations and rejects
-    unknown roles via [Agent_sdk.Error.UnknownVariant]. *)
-val role_of_string_compat :
-  string -> (Agent_sdk.Types.role, Agent_sdk.Error.sdk_error) result
-
-(** Compat message-of-json parser. Errors carry an
-    [Agent_sdk.Error.sdk_error]. *)
-val message_of_json_compat :
-  Yojson.Safe.t -> (Agent_sdk.Types.message, Agent_sdk.Error.sdk_error) result
-
-(** Re-shape legacy checkpoint JSON so unknown roles default to
-    [assistant] before handing it to the OAS deserializer. *)
-val normalize_checkpoint_json_for_sdk : Yojson.Safe.t -> Yojson.Safe.t
-
-(** Compat [Agent_sdk.Checkpoint.of_json] that re-parses messages with
-    [message_of_json_compat] when the SDK rejects the raw shape. *)
-val checkpoint_of_json_compat :
-  Yojson.Safe.t -> (Agent_sdk.Checkpoint.t, Agent_sdk.Error.sdk_error) result
-
-(** Compat [Agent_sdk.Checkpoint.of_string]: tries the SDK parser first,
-    then falls back to [checkpoint_of_json_compat] on the
-    UTF-8-sanitized raw JSON. *)
-val checkpoint_of_string_compat :
-  string -> (Agent_sdk.Checkpoint.t, Agent_sdk.Error.sdk_error) result
-
 (** Load a single OAS history archive entry. Returns [Not_found]
     when the file does not exist; classifies SDK errors via
     [classify_sdk_error]. *)


### PR DESCRIPTION
## Summary
- remove the OAS checkpoint compatibility decoder helpers from Keeper_checkpoint_store
- route direct OAS checkpoint/history file reads through Agent_sdk.Checkpoint.of_string only
- keep canonical Agent_sdk.Checkpoint_store load path intact

## Validation
- rg -n "checkpoint_of_string_compat|checkpoint_of_json_compat|message_of_json_compat|role_of_string_compat|normalize_checkpoint_json_for_sdk|content_block_of_json_strict|result_all" lib/keeper/keeper_checkpoint_store.ml lib/keeper/keeper_checkpoint_store.mli test/test_keeper_checkpoint_classify.ml test/test_oas_worker.ml
- ocamlformat --inplace lib/keeper/keeper_checkpoint_store.ml lib/keeper/keeper_checkpoint_store.mli
- ocamlformat --check lib/keeper/keeper_checkpoint_store.ml lib/keeper/keeper_checkpoint_store.mli
- git diff --check
- scripts/ocaml-structure-ratchet.sh

## Not run
- scripts/dune-local.sh build test/test_keeper_checkpoint_classify.exe: blocked by existing bare dune build process (PID 84741: dune build --root .)