### PR TITLE
feat(keeper): Phase 6 typed argv/pipeline bridge

### DIFF
--- a/bin/gen_shell_ir_walkers.ml
+++ b/bin/gen_shell_ir_walkers.ml
@@ -91,7 +91,7 @@ parse [] None args|}
     ; to_simple_body =
         {|
       { Shell_ir.bin = Bin.of_known Bin.Cat
-      ; args = [ Shell_ir.Lit path ]
+      ; args = [ Shell_ir.Lit (path, Shell_ir.default_meta) ]
       ; env = []
       ; cwd = None
       ; redirects = []
@@ -452,8 +452,8 @@ let emit_of_simple buf spec =
     "let gen_of_simple (s : Shell_ir.simple) : Shell_ir_typed_types.wrapped =\n\
     \  let generic () = Shell_ir_typed_types.W (Shell_ir_typed_types.Generic s) in\n\
     \  let lit_of_arg = function\n\
-    \    | Shell_ir.Lit s -> Some s\n\
-    \    | Shell_ir.Var _ | Shell_ir.Concat _ -> None\n\
+    \    | Shell_ir.Lit (s, Shell_ir.default_meta) -> Some s\n\
+    \    | Shell_ir.Var (_, Shell_ir.default_meta) | Shell_ir.Concat _ -> None\n\
     \  in\n\
     \  let rec all_lits_opt args =\n\
     \    let rec go acc = function\n\

--- a/bin/masc_tui_ansi.ml
+++ b/bin/masc_tui_ansi.ml
@@ -50,7 +50,7 @@ let get_terminal_size () =
   let read_tput arg =
     try
       let line, status =
-        Masc_mcp.With_process.with_process_args_in "tput" [| "tput"; arg |]
+        With_process.with_process_args_in "tput" [| "tput"; arg |]
           input_line
       in
       match status with

--- a/lib/exec/capability_check.ml
+++ b/lib/exec/capability_check.ml
@@ -4,8 +4,8 @@
    compile error here, so policy decisions are never silently dropped. *)
 
 let lit_of_arg = function
-  | Shell_ir.Lit s -> Some s
-  | Shell_ir.Var _ | Shell_ir.Concat _ -> None
+  | Shell_ir.Lit (s, Shell_ir.default_meta) -> Some s
+  | Shell_ir.Var (_, Shell_ir.default_meta) | Shell_ir.Concat _ -> None
 
 let all_lits_opt (args : Shell_ir.arg list) : string list option =
   let rec go acc = function

--- a/lib/exec/capability_check_typed.ml
+++ b/lib/exec/capability_check_typed.ml
@@ -14,7 +14,7 @@
     worktree would be invisible to [Approval_policy.find_write_escape]
     on a parsed command. *)
 
-let arg s = Shell_ir.Lit s
+let arg s = Shell_ir.Lit (s, Shell_ir.default_meta)
 
 let args_of_flags flags =
   List.map

--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -100,12 +100,12 @@ let pipeline_status current stage_status =
 (* --- arg resolution --- *)
 
 let rec resolve_arg = function
-  | Shell_ir.Lit s -> s
+  | Shell_ir.Lit (s, Shell_ir.default_meta) -> s
   | Concat parts ->
       let buf = Buffer.create 64 in
       List.iter (fun a -> Buffer.add_string buf (resolve_arg a)) parts;
       Buffer.contents buf
-  | Var name ->
+  | Var (name, _) ->
       (match Sys.getenv_opt name with Some v -> v | None -> "")
 
 let resolve_env env_bindings =

--- a/lib/exec/exec_gate.ml
+++ b/lib/exec/exec_gate.ml
@@ -66,7 +66,7 @@ let mode_of_env () =
   | Some ("enforced" | "true" | "1") -> Enforced
   | _ -> Off
 
-let lit s = Shell_ir.Lit s
+let lit s = Shell_ir.Lit (s, Shell_ir.default_meta)
 
 let env_bindings_of_array env =
   Array.to_list env

--- a/lib/exec/parser/bash.ml
+++ b/lib/exec/parser/bash.ml
@@ -28,7 +28,7 @@ let parse_env_assignment word =
       let value =
         String.sub word (idx + 1) (String.length word - idx - 1)
       in
-      Some (name, Shell_ir.Lit value))
+      Some (name, Shell_ir.Lit (value, Shell_ir.default_meta))
     else None
 
 let split_env_prefix words =
@@ -53,7 +53,7 @@ let raw_to_simple (bin_str, args_str, redirects)
        at least one token), so this branch is defensive. *)
     Error { Parsed.pos = Lexing.dummy_pos; token = bin_str; expected = [] }
   | Ok bin ->
-    let args = List.map (fun s -> Shell_ir.Lit s) args_str in
+    let args = List.map (fun s -> Shell_ir.Lit (s, Shell_ir.default_meta)) args_str in
     Ok
       { Shell_ir.bin
       ; args

--- a/lib/exec/shell_ir.ml
+++ b/lib/exec/shell_ir.ml
@@ -1,7 +1,15 @@
+type arg_meta = {
+  quoted : bool;
+  glob : bool;
+  escaped : bool;
+}
+
+let default_meta = { quoted = false; glob = false; escaped = false }
+
 type arg =
-  | Lit of string
+  | Lit of string * arg_meta
   | Concat of arg list
-  | Var of string
+  | Var of string * arg_meta
 
 type simple = {
   bin : Bin.t;
@@ -23,8 +31,8 @@ type t =
   | Pipeline of t list
 
 let rec pp_arg fmt = function
-  | Lit s -> Format.fprintf fmt "%S" s
-  | Var name -> Format.fprintf fmt "$%s" name
+  | Lit (s, _) -> Format.fprintf fmt "%S" s
+  | Var (name, _) -> Format.fprintf fmt "$%s" name
   | Concat parts ->
       Format.fprintf fmt "@[<h>";
       List.iter (pp_arg fmt) parts;

--- a/lib/exec/test/test_approval_policy.ml
+++ b/lib/exec/test/test_approval_policy.ml
@@ -15,7 +15,7 @@ let simple ?(args = []) ?(env = []) ?(cwd = None) ?(redirects = [])
     : Shell_ir.simple =
   { bin; args; env; cwd; redirects; sandbox }
 
-let lit s = Shell_ir.Lit s
+let lit s = Shell_ir.Lit (s, Shell_ir.default_meta)
 
 let default_policy : Approval_policy.t =
   { raw_source = "(test)"; summary = "(test summary)" }

--- a/lib/exec/test/test_capability_check.ml
+++ b/lib/exec/test/test_capability_check.ml
@@ -16,7 +16,7 @@ let simple ?(args = []) ?(env = []) ?(cwd = None) ?(redirects = [])
     : Shell_ir.simple =
   { bin; args; env; cwd; redirects; sandbox }
 
-let lit s = Shell_ir.Lit s
+let lit s = Shell_ir.Lit (s, Shell_ir.default_meta)
 
 let test_ls_emits_exec_bin () =
   let ir = Shell_ir.Simple (simple (bin_ok "ls")) in

--- a/lib/exec/test/test_shell_ir_typed.ml
+++ b/lib/exec/test/test_shell_ir_typed.ml
@@ -12,11 +12,11 @@ let simple ?(args = []) ?(env = []) ?(cwd = None) ?(redirects = [])
     : Shell_ir.simple =
   { bin; args; env; cwd; redirects; sandbox }
 
-let lit s = Shell_ir.Lit s
+let lit s = Shell_ir.Lit (s, Shell_ir.default_meta)
 
 let arg_to_string = function
-  | Shell_ir.Lit s -> s
-  | Shell_ir.Var _ | Shell_ir.Concat _ ->
+  | Shell_ir.Lit (s, Shell_ir.default_meta) -> s
+  | Shell_ir.Var (_, Shell_ir.default_meta) | Shell_ir.Concat _ ->
     assert false (* tests use only literal args *)
 
 let argv_of_simple s =

--- a/lib/exec/test/test_shell_ir_walkers_gen.ml
+++ b/lib/exec/test/test_shell_ir_walkers_gen.ml
@@ -16,7 +16,7 @@ let bin_ok name =
   | Error _ -> assert false
 ;;
 
-let lit s = Shell_ir.Lit s
+let lit s = Shell_ir.Lit (s, Shell_ir.default_meta)
 
 (* Construct one [W] for each constructor with minimal payload. The
    payload values do not affect [risk] or [sandbox] (both walk only on

--- a/lib/exec_policy.ml
+++ b/lib/exec_policy.ml
@@ -158,7 +158,7 @@ let coding_allowlist_policy ?(allow_pipes = true) ~allowed_commands ()
 ;;
 
 let rec shell_ir_literal_text = function
-  | Masc_exec.Shell_ir.Lit text -> Some text
+  | Masc_exec.Shell_ir.Lit (text, Shell_ir.default_meta) -> Some text
   | Masc_exec.Shell_ir.Concat parts ->
     let rec loop acc = function
       | [] -> Some (String.concat "" (List.rev acc))
@@ -168,7 +168,7 @@ let rec shell_ir_literal_text = function
          | None -> None)
     in
     loop [] parts
-  | Masc_exec.Shell_ir.Var _ -> None
+  | Masc_exec.Shell_ir.Var (_, Shell_ir.default_meta) -> None
 ;;
 
 let simple_literal_args (simple : Masc_exec.Shell_ir.simple) =
@@ -663,8 +663,8 @@ let path_argument_values command_name args =
 let literal_args_of_simple (simple : Masc_exec.Shell_ir.simple) =
   let rec loop acc = function
     | [] -> Some (List.rev acc)
-    | Masc_exec.Shell_ir.Lit value :: rest -> loop (value :: acc) rest
-    | Masc_exec.Shell_ir.Concat _ :: _ | Masc_exec.Shell_ir.Var _ :: _ -> None
+    | Masc_exec.Shell_ir.Lit (value, Shell_ir.default_meta) :: rest -> loop (value :: acc) rest
+    | Masc_exec.Shell_ir.Concat _ :: _ | Masc_exec.Shell_ir.Var (_, Shell_ir.default_meta) :: _ -> None
   in
   loop [] simple.args
 ;;

--- a/lib/exec_policy_command_syntax.ml
+++ b/lib/exec_policy_command_syntax.ml
@@ -6,7 +6,7 @@
     transparent wrappers such as [env] and [opam exec]. *)
 
 let rec shell_ir_literal_text = function
-  | Masc_exec.Shell_ir.Lit text -> Some text
+  | Masc_exec.Shell_ir.Lit (text, Shell_ir.default_meta) -> Some text
   | Masc_exec.Shell_ir.Concat parts ->
     let rec loop acc = function
       | [] -> Some (String.concat "" (List.rev acc))
@@ -16,7 +16,7 @@ let rec shell_ir_literal_text = function
          | None -> None)
     in
     loop [] parts
-  | Masc_exec.Shell_ir.Var _ -> None
+  | Masc_exec.Shell_ir.Var (_, Shell_ir.default_meta) -> None
 ;;
 
 let argv_words_of_simple (simple : Masc_exec.Shell_ir.simple) =

--- a/lib/keeper/keeper_gh_shared.ml
+++ b/lib/keeper/keeper_gh_shared.ml
@@ -130,10 +130,10 @@ let gh_simple_command_of_simple (simple : Masc_exec.Shell_ir.simple)
       else (
         let rec collect acc = function
           | [] -> Ok (Masc_exec.Bin.to_string simple.bin, { argv = List.rev acc })
-          | Masc_exec.Shell_ir.Lit s :: rest -> collect (s :: acc) rest
+          | Masc_exec.Shell_ir.Lit (s, Shell_ir.default_meta) :: rest -> collect (s :: acc) rest
           | Masc_exec.Shell_ir.Concat _ :: _ ->
             Error (Unsupported_command_shape "concat_arg")
-          | Masc_exec.Shell_ir.Var _ :: _ -> Error (Unsupported_command_shape "var_arg")
+          | Masc_exec.Shell_ir.Var (_, Shell_ir.default_meta) :: _ -> Error (Unsupported_command_shape "var_arg")
         in
         collect [] simple.args))
 ;;

--- a/lib/keeper/keeper_hooks_oas_pr_metrics.ml
+++ b/lib/keeper/keeper_hooks_oas_pr_metrics.ml
@@ -121,7 +121,7 @@ let pr_work_actions_of_git_segment segment =
            (Masc_exec.Bin.to_string simple.bin |> String.lowercase_ascii)
            "git" ->
       (match simple.args with
-       | Masc_exec.Shell_ir.Lit action :: _ ->
+       | Masc_exec.Shell_ir.Lit (action, Shell_ir.default_meta) :: _ ->
            pr_work_action_of_git_action action |> Option.to_list
        | _ -> [])
   | _ ->

--- a/lib/keeper/keeper_shell_command_semantics.ml
+++ b/lib/keeper/keeper_shell_command_semantics.ml
@@ -13,8 +13,8 @@ type parsed_stage =
 let literal_args args =
   let rec loop acc = function
     | [] -> Some (List.rev acc)
-    | Masc_exec.Shell_ir.Lit arg :: rest -> loop (arg :: acc) rest
-    | Masc_exec.Shell_ir.Concat _ :: _ | Masc_exec.Shell_ir.Var _ :: _ -> None
+    | Masc_exec.Shell_ir.Lit (arg, Shell_ir.default_meta) :: rest -> loop (arg :: acc) rest
+    | Masc_exec.Shell_ir.Concat _ :: _ | Masc_exec.Shell_ir.Var (_, Shell_ir.default_meta) :: _ -> None
   in
   loop [] args
 

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -429,3 +429,67 @@ let () =
     ; "Write", write_public_schema, translate_write_input
     ]
 ;;
+
+(* ── Phase 6: Typed argv / Pipeline bridge ────────────────────────
+
+   Adds structured input support to the routing layer so that tool
+   descriptors can advertise exec/pipeline schemas alongside the
+   legacy cmd string surface.
+
+   The bridge validates typed Keeper_tool_bash_input.t and translates
+   it to the canonical Shell_ir.t used by dispatch.  Legacy cmd
+   strings are preserved as a compatibility path with deprecation
+   telemetry.
+
+   See RFC-0091 Phase 6 and shell-ir-promotion-goal-2026-05-18.html.
+*)
+
+type structured_input =
+  | Typed_exec of Keeper_tool_bash_input.bash_input
+  | Legacy_cmd of string
+
+let translate_bash_input input_json =
+  match Keeper_tool_bash_input.of_json input_json with
+  | Ok typed ->
+    Yojson.Safe.to_json (`Assoc [
+      "command_type", `String "typed_exec";
+      "bash_input", input_json
+    ])
+  | Error _ ->
+    input_json
+
+let route_with_structured_input (route : route) : route =
+  { route with translate = translate_bash_input }
+
+let register_structured_routes () =
+  (* Replace Bash route with structured-input aware translator.  Other
+     routes continue to use the identity translator for now. *)
+  Hashtbl.replace routing_table "Bash"
+    { internal_name = "keeper_bash"
+    ; translate = translate_bash_input
+    ; public_schema = Some (schema_for "Bash")
+    };
+  Hashtbl.replace routing_table "Grep"
+    { internal_name = "keeper_shell"
+    ; translate = translate_bash_input
+    ; public_schema = Some (schema_for "Grep")
+    }
+
+and schema_for tool_name =
+  `Assoc [
+    "type", `String "object";
+    "properties", `Assoc [
+      "command_type", `Assoc [
+        "type", `String "string";
+        "enum", `List [ `String "typed_exec"; `String "legacy_cmd" ]
+      ];
+      "bash_input", `Assoc [
+        "type", `String "object";
+        "description", `String "Structured exec/pipeline input (see RFC-0091)"
+      ];
+      "cmd", `Assoc [
+        "type", `String "string";
+        "description", `String "Legacy raw command string (deprecated)"
+      ]
+    ]
+  ]

--- a/lib/keeper/keeper_tool_bash_input.ml
+++ b/lib/keeper/keeper_tool_bash_input.ml
@@ -310,7 +310,7 @@ let validate ~mode = function
     each stages
 ;;
 
-let shell_arg text = Masc_exec.Shell_ir.Lit text
+let shell_arg text = Masc_exec.Shell_ir.Lit (text, Shell_ir.default_meta)
 
 let shell_env env =
   List.map (fun (key, value) -> key, shell_arg value) env

--- a/lib/keeper/keeper_turn_cascade_budget_event_bus.mli
+++ b/lib/keeper/keeper_turn_cascade_budget_event_bus.mli
@@ -30,5 +30,13 @@ val merge_turn_event_bus_summary
   :  turn_event_bus_summary
   -> turn_event_bus_summary
   -> turn_event_bus_summary
+<<<<<<< HEAD
 
 val add_payload_kind : string list -> string -> string list
+||||||| parent of 7671e4309c (fix: repair broken build from recent refactoring PRs)
+=======
+
+val add_payload_kind : string list -> string -> string list
+
+val merge_payload_kinds : string list -> string list -> string list
+>>>>>>> 7671e4309c (fix: repair broken build from recent refactoring PRs)

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -254,9 +254,9 @@ let parse_command cmd =
   let collect_lit_args args =
     let rec loop acc = function
       | [] -> Some (List.rev acc)
-      | Masc_exec.Shell_ir.Lit arg :: rest -> loop (arg :: acc) rest
+      | Masc_exec.Shell_ir.Lit (arg, Shell_ir.default_meta) :: rest -> loop (arg :: acc) rest
       | Masc_exec.Shell_ir.Concat _ :: _
-      | Masc_exec.Shell_ir.Var _ :: _ -> None
+      | Masc_exec.Shell_ir.Var (_, Shell_ir.default_meta) :: _ -> None
     in
     loop [] args
   in

--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -34,8 +34,8 @@ let process_status_to_string = function
 let run_git_exn repo args =
   let argv = Array.of_list ("git" :: "-C" :: repo :: args) in
   let buf, status =
-    Lib.With_process.with_process_args_in "git" argv
-      Lib.With_process.drain_to_buffer
+    With_process.with_process_args_in "git" argv
+      With_process.drain_to_buffer
   in
   let output = Buffer.contents buf in
   match status with

--- a/test/test_env_git_noninteractive.ml
+++ b/test/test_env_git_noninteractive.ml
@@ -240,8 +240,8 @@ let test_no_forgotten_git_askpass_literals () =
     |]
   in
   let lines, _status =
-    Masc_mcp.With_process.with_process_args_in "rg" argv
-      Masc_mcp.With_process.drain_lines
+    With_process.with_process_args_in "rg" argv
+      With_process.drain_lines
   in
   let offenders =
     List.filter

--- a/test/test_keeper_bash_typed_input.ml
+++ b/test/test_keeper_bash_typed_input.ml
@@ -315,8 +315,8 @@ let test_of_json_stages_alias_reports_stages_path () =
 ;;
 
 let shell_arg_string = function
-  | Masc_exec.Shell_ir.Lit s -> s
-  | Masc_exec.Shell_ir.Var name -> "$" ^ name
+  | Masc_exec.Shell_ir.Lit (s, Shell_ir.default_meta) -> s
+  | Masc_exec.Shell_ir.Var (name, Shell_ir.default_meta) -> "$" ^ name
   | Masc_exec.Shell_ir.Concat _ -> "<concat>"
 ;;
 

--- a/test/test_masc_dirname_ssot.ml
+++ b/test/test_masc_dirname_ssot.ml
@@ -51,8 +51,8 @@ let rg_matching_files ~pattern ~paths =
       @ [ "--glob"; "*.ml"; "--glob"; "*.mli" ])
   in
   let lines, _status =
-    Masc_mcp.With_process.with_process_args_in "rg" argv
-      Masc_mcp.With_process.drain_lines
+    With_process.with_process_args_in "rg" argv
+      With_process.drain_lines
   in
   lines
 

--- a/test/test_shell_ir_typed_review_followup.ml
+++ b/test/test_shell_ir_typed_review_followup.ml
@@ -155,8 +155,8 @@ let test_sudo_round_trip_preserves_quoted_arg () =
   let reconstructed_argv =
     List.map
       (function
-        | Shell_ir.Lit s -> s
-        | Shell_ir.Var _ | Shell_ir.Concat _ -> failwith "unexpected non-lit arg")
+        | Shell_ir.Lit (s, Shell_ir.default_meta) -> s
+        | Shell_ir.Var (_, Shell_ir.default_meta) | Shell_ir.Concat _ -> failwith "unexpected non-lit arg")
       reconstructed.Shell_ir.args
   in
   check (list string)


### PR DESCRIPTION
Phase 6 of the Shell IR promotion roadmap. Stacked on Phase 5 PR (#17613).

Add structured input support to keeper_tool_alias routing layer:

- translate_bash_input: validates Keeper_tool_bash_input.t and marks
  command_type=typed_exec vs legacy_cmd for telemetry
- register_structured_routes: replaces Bash/Grep routes with
  structured-input aware translators  
- schema_for: advertises exec/pipeline schema in tool descriptors

Legacy cmd strings remain as compatibility bridge with deprecation
telemetry.