### PR TITLE
refactor(keeper): remove message content fallback

### DIFF
--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -205,7 +205,6 @@ let role_of_string_opt = Message_json.role_of_string_opt
 let role_of_string = Message_json.role_of_string
 let content_blocks_to_json = Message_json.content_blocks_to_json
 let content_blocks_of_json = Message_json.content_blocks_of_json
-let legacy_content_text_of_json = Message_json.legacy_content_text_of_json
 let string_field_opt = Message_json.string_field_opt
 let metadata_of_json = Message_json.metadata_of_json
 let message_to_json = Message_json.message_to_json

--- a/lib/keeper/keeper_context_core_message_json.ml
+++ b/lib/keeper/keeper_context_core_message_json.ml
@@ -39,38 +39,11 @@ let content_blocks_to_json
 let content_blocks_of_json
     (json : Yojson.Safe.t) : Agent_sdk.Types.content_block list option =
   let open Yojson.Safe.Util in
-  let parse_block_list = function
-    | `List blocks ->
-        let parsed = List.filter_map Agent_sdk.Api.content_block_of_json blocks in
-        if List.length parsed = List.length blocks then Some parsed else None
-    | _ -> None
-  in
-  match parse_block_list (json |> member "content_blocks") with
-  | Some _ as blocks -> blocks
-  | None ->
-      (* Some OAS/OpenAI-style checkpoints use a structured [content] array
-         instead of MASC's [content_blocks] field. Treat that as the same
-         block source rather than forcing the legacy flat-string path. *)
-      parse_block_list (json |> member "content")
-
-let legacy_content_text_of_json (json : Yojson.Safe.t) : string =
-  let open Yojson.Safe.Util in
-  match json |> member "content" with
-  | `String value -> Inference_utils.sanitize_text_utf8 value
-  | `Null -> ""
+  match json |> member "content_blocks" with
   | `List blocks ->
       let parsed = List.filter_map Agent_sdk.Api.content_block_of_json blocks in
-      let msg : Agent_sdk.Types.message =
-        {
-          Agent_sdk.Types.role = Agent_sdk.Types.User;
-          content = parsed;
-          name = None;
-          tool_call_id = None;
-          metadata = [];
-        }
-      in
-      Inference_utils.sanitize_text_utf8 (Agent_sdk.Types.text_of_message msg)
-  | _ -> ""
+      if List.length parsed = List.length blocks then Some parsed else None
+  | _ -> None
 
 let string_field_opt key value =
   match value with
@@ -109,11 +82,9 @@ let message_to_json (m : Agent_sdk.Types.message) : Yojson.Safe.t =
         | Agent_sdk.Types.Assistant -> None)
   in
   (* SSOT: structured [content_blocks] only. The previous flat [content]
-     field was a duplicate of [text_of_message m] used by legacy
-     checkpoint readers; new readers reconstruct text from
-     [content_blocks] via [text_of_history_jsonl_line] (see below).
-     Old checkpoints written with both fields still load fine because
-     [message_of_json] keeps the legacy [content] fallback. *)
+     field was a duplicate of [text_of_message m] used by retired
+     checkpoint readers; current readers reconstruct text from
+     [content_blocks] via [text_of_history_jsonl_line] (see below). *)
   let base =
     [
       ("role", `String (role_to_string m.role));
@@ -129,19 +100,10 @@ let message_to_json (m : Agent_sdk.Types.message) : Yojson.Safe.t =
 let message_of_json (json : Yojson.Safe.t) : Agent_sdk.Types.message =
   let open Yojson.Safe.Util in
   let role = json |> member "role" |> to_string |> role_of_string in
-  let text = legacy_content_text_of_json json in
   let content =
     match content_blocks_of_json json with
-    | Some blocks ->
-        if blocks <> [] then blocks
-        else
-          (* Legacy checkpoints stored only flattened text + role. For Tool
-             messages that means the original assistant ToolUse block is gone,
-             so rebuilding a structured ToolResult here creates an invalid
-             orphaned pair on the next Anthropic request. Fall back to plain
-             text so old checkpoints remain readable without breaking turns. *)
-          [ Agent_sdk.Types.Text text ]
-    | None -> [ Agent_sdk.Types.Text text ]
+    | Some blocks -> blocks
+    | None -> []
   in
   Inference_utils.sanitize_message_utf8
     {
@@ -158,9 +120,8 @@ let message_of_json (json : Yojson.Safe.t) : Agent_sdk.Types.message =
 
 (** Extract human-readable text from a single history.jsonl line that was
     produced by [message_to_json].  Reads structured [content_blocks]
-    first (current SSOT), falls back to the legacy flat [content] field
-    for lines written before that field was retired.  Returns [""] when
-    neither shape is parseable. *)
+    (current SSOT). Returns [""] when the canonical shape is absent or
+    unparseable. *)
 let text_of_history_jsonl_json (json : Yojson.Safe.t) : string =
   match content_blocks_of_json json with
   | Some blocks when blocks <> [] ->
@@ -174,4 +135,4 @@ let text_of_history_jsonl_json (json : Yojson.Safe.t) : string =
         }
       in
       Inference_utils.sanitize_text_utf8 (Agent_sdk.Types.text_of_message msg)
-  | _ -> legacy_content_text_of_json json
+  | _ -> ""

--- a/lib/keeper/keeper_context_core_message_json.mli
+++ b/lib/keeper/keeper_context_core_message_json.mli
@@ -8,7 +8,6 @@ val content_blocks_to_json :
 val content_blocks_of_json :
   Yojson.Safe.t -> Agent_sdk.Types.content_block list option
 
-val legacy_content_text_of_json : Yojson.Safe.t -> string
 val string_field_opt : string -> string option -> (string * Yojson.Safe.t) list
 val metadata_of_json : Yojson.Safe.t -> (string * Yojson.Safe.t) list
 val message_to_json : Agent_sdk.Types.message -> Yojson.Safe.t

--- a/test/test_keeper_context_core_dedup.ml
+++ b/test/test_keeper_context_core_dedup.ml
@@ -4,8 +4,8 @@
 
     1. [message_to_json] no longer emits the flat ["content"] field;
        [content_blocks] is the single source of truth.
-    2. [text_of_history_jsonl_json] reads [content_blocks] first and falls
-       back to legacy ["content"] for old history.jsonl lines.
+    2. [text_of_history_jsonl_json] reads [content_blocks] as the only
+       history text source.
     3. [tool_result_text_of_block] caps json-only results at the existing
        [default_max_checkpoint_tool_result_chars] threshold instead of
        inlining the full [Yojson.Safe.to_string] output. *)
@@ -36,19 +36,7 @@ let test_message_to_json_omits_flat_content () =
         (List.mem_assoc "content_blocks" fields)
   | _ -> Alcotest.fail "expected `Assoc"
 
-(* --- message_of_json: legacy checkpoints still load --- *)
-
-let test_message_of_json_legacy_content_only () =
-  (* Pre-PR checkpoints had ONLY a flat content field. They must still
-     load — text becomes a single Text block. *)
-  let legacy : Yojson.Safe.t =
-    `Assoc [ ("role", `String "user"); ("content", `String "legacy hi") ]
-  in
-  let msg = C.message_of_json legacy in
-  Alcotest.(check int) "single block" 1 (List.length msg.content);
-  match msg.content with
-  | [ T.Text s ] -> Alcotest.(check string) "text" "legacy hi" s
-  | _ -> Alcotest.fail "expected one Text block"
+(* --- message_of_json: canonical content_blocks only --- *)
 
 let test_message_of_json_new_content_blocks_only () =
   (* New checkpoints have only content_blocks — must load as before. *)
@@ -67,30 +55,12 @@ let test_message_of_json_new_content_blocks_only () =
   | [ T.Text s ] -> Alcotest.(check string) "text" "world" s
   | _ -> Alcotest.fail "expected one Text block"
 
-let test_message_of_json_legacy_content_array () =
-  (* OAS/OpenAI-style legacy checkpoints may store structured blocks under
-     content instead of content_blocks. This must not raise Type_error. *)
-  let source : T.message =
-    {
-      T.role = T.Assistant;
-      content = [ T.Text "array payload" ];
-      name = None;
-      tool_call_id = None;
-      metadata = [];
-    }
+let test_message_of_json_ignores_flat_content () =
+  let flat_content : Yojson.Safe.t =
+    `Assoc [ ("role", `String "user"); ("content", `String "flat hi") ]
   in
-  let content_blocks =
-    match C.message_to_json source with
-    | `Assoc fields -> List.assoc "content_blocks" fields
-    | _ -> Alcotest.fail "expected object"
-  in
-  let legacy : Yojson.Safe.t =
-    `Assoc [ ("role", `String "assistant"); ("content", content_blocks) ]
-  in
-  let parsed = C.message_of_json legacy in
-  match parsed.content with
-  | [ T.Text s ] -> Alcotest.(check string) "text" "array payload" s
-  | _ -> Alcotest.fail "expected one Text block"
+  let msg = C.message_of_json flat_content in
+  Alcotest.(check int) "no canonical blocks" 0 (List.length msg.content)
 
 (* --- text_of_history_jsonl_json --- *)
 
@@ -108,18 +78,18 @@ let test_history_jsonl_text_uses_blocks_first () =
   let text = C.text_of_history_jsonl_json new_format in
   Alcotest.(check string) "text from blocks" "structured payload" text
 
-let test_history_jsonl_text_legacy_fallback () =
-  let legacy : Yojson.Safe.t =
+let test_history_jsonl_text_ignores_flat_content () =
+  let flat_content : Yojson.Safe.t =
     `Assoc
       [
         ("role", `String "user");
-        ("content", `String "legacy payload");
+        ("content", `String "flat payload");
       ]
   in
-  let text = C.text_of_history_jsonl_json legacy in
-  Alcotest.(check string) "fallback to flat content" "legacy payload" text
+  let text = C.text_of_history_jsonl_json flat_content in
+  Alcotest.(check string) "flat content ignored" "" text
 
-let test_history_jsonl_text_legacy_content_array () =
+let test_history_jsonl_text_ignores_content_array () =
   let source : T.message =
     {
       T.role = T.User;
@@ -134,11 +104,11 @@ let test_history_jsonl_text_legacy_content_array () =
     | `Assoc fields -> List.assoc "content_blocks" fields
     | _ -> Alcotest.fail "expected object"
   in
-  let legacy : Yojson.Safe.t =
+  let content_array : Yojson.Safe.t =
     `Assoc [ ("role", `String "user"); ("content", content_blocks) ]
   in
-  let text = C.text_of_history_jsonl_json legacy in
-  Alcotest.(check string) "text from array content" "array history payload" text
+  let text = C.text_of_history_jsonl_json content_array in
+  Alcotest.(check string) "content array ignored" "" text
 
 let test_history_jsonl_text_empty_when_neither () =
   let empty : Yojson.Safe.t = `Assoc [ ("role", `String "user") ] in
@@ -225,14 +195,12 @@ let () =
           Alcotest.test_case "omits flat content" `Quick
             test_message_to_json_omits_flat_content;
         ] );
-      ( "message_of_json backward compat",
+      ( "message_of_json",
         [
-          Alcotest.test_case "legacy content-only loads" `Quick
-            test_message_of_json_legacy_content_only;
           Alcotest.test_case "new content_blocks-only loads" `Quick
             test_message_of_json_new_content_blocks_only;
-          Alcotest.test_case "legacy content array loads" `Quick
-            test_message_of_json_legacy_content_array;
+          Alcotest.test_case "flat content ignored" `Quick
+            test_message_of_json_ignores_flat_content;
           Alcotest.test_case "round-trip text preserved" `Quick
             test_roundtrip_text_preserved;
         ] );
@@ -240,10 +208,10 @@ let () =
         [
           Alcotest.test_case "blocks first" `Quick
             test_history_jsonl_text_uses_blocks_first;
-          Alcotest.test_case "legacy fallback" `Quick
-            test_history_jsonl_text_legacy_fallback;
-          Alcotest.test_case "legacy content array fallback" `Quick
-            test_history_jsonl_text_legacy_content_array;
+          Alcotest.test_case "flat content ignored" `Quick
+            test_history_jsonl_text_ignores_flat_content;
+          Alcotest.test_case "content array ignored" `Quick
+            test_history_jsonl_text_ignores_content_array;
           Alcotest.test_case "empty when neither" `Quick
             test_history_jsonl_text_empty_when_neither;
         ] );


### PR DESCRIPTION
## Summary
- make keeper message JSON reads use only canonical content_blocks
- remove the flat content / content-array fallback helper and re-export
- update context-core tests to assert non-canonical content is ignored

## Validation
- rg -n "legacy_content_text_of_json|content array fallback|legacy content-only loads|legacy content array loads|fallback to flat content|text from array content|message_of_json backward compat|legacy \[content\]" lib test docs --glob '!docs/audit-responses/**' (0 matches)
- ocamlformat --check lib/keeper/keeper_context_core_message_json.ml lib/keeper/keeper_context_core_message_json.mli lib/keeper/keeper_context_core.ml test/test_keeper_context_core_dedup.ml
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_context_core_dedup.exe (attempted; lock passed but compile/link hung without output for >8 minutes, killed only this worktree's lockf waiter)