### PR TITLE
refactor(keeper): remove message role fallback

### DIFF
--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -202,7 +202,6 @@ let generate_checkpoint_id () =
 
 let role_to_string = Message_json.role_to_string
 let role_of_string_opt = Message_json.role_of_string_opt
-let role_of_string = Message_json.role_of_string
 let content_blocks_to_json = Message_json.content_blocks_to_json
 let content_blocks_of_json = Message_json.content_blocks_of_json
 let string_field_opt = Message_json.string_field_opt

--- a/lib/keeper/keeper_context_core.mli
+++ b/lib/keeper/keeper_context_core.mli
@@ -71,10 +71,6 @@ val role_to_string : Agent_sdk.Types.role -> string
     handle [None] explicitly (#8623). *)
 val role_of_string_opt : string -> Agent_sdk.Types.role option
 
-(** Backwards-compatible wrapper that defaults unknown roles to
-    [Tool] with a warn log (#8623). *)
-val role_of_string : string -> Agent_sdk.Types.role
-
 val message_to_json : Agent_sdk.Types.message -> Yojson.Safe.t
 val message_of_json : Yojson.Safe.t -> Agent_sdk.Types.message
 

--- a/lib/keeper/keeper_context_core_message_json.ml
+++ b/lib/keeper/keeper_context_core_message_json.ml
@@ -19,19 +19,6 @@ let role_of_string_opt = function
   | "tool" -> Some Agent_sdk.Types.Tool
   | _ -> None
 
-(* Backwards-compatible wrapper. [Tool] is the safest fallback for an
-   unrecognised role: tool messages are interpretive context, not
-   instructions, so misclassifying System/Assistant/User as Tool hides
-   the message rather than letting the LLM act on it. The warn log
-   preserves operator visibility. *)
-let role_of_string s =
-  match role_of_string_opt s with
-  | Some role -> role
-  | None ->
-      Log.Misc.warn
-        "keeper_context_core: unknown role %S, defaulting to Tool (#8623)" s;
-      Agent_sdk.Types.Tool
-
 let content_blocks_to_json
     (blocks : Agent_sdk.Types.content_block list) : Yojson.Safe.t =
   `List (List.map Agent_sdk.Api.content_block_to_json blocks)
@@ -99,7 +86,14 @@ let message_to_json (m : Agent_sdk.Types.message) : Yojson.Safe.t =
 
 let message_of_json (json : Yojson.Safe.t) : Agent_sdk.Types.message =
   let open Yojson.Safe.Util in
-  let role = json |> member "role" |> to_string |> role_of_string in
+  let raw_role = json |> member "role" |> to_string in
+  let role =
+    match role_of_string_opt raw_role with
+    | Some role -> role
+    | None ->
+        invalid_arg
+          (Printf.sprintf "keeper_context_core: unknown role %S" raw_role)
+  in
   let content =
     match content_blocks_of_json json with
     | Some blocks -> blocks

--- a/lib/keeper/keeper_context_core_message_json.mli
+++ b/lib/keeper/keeper_context_core_message_json.mli
@@ -1,6 +1,5 @@
 val role_to_string : Agent_sdk.Types.role -> string
 val role_of_string_opt : string -> Agent_sdk.Types.role option
-val role_of_string : string -> Agent_sdk.Types.role
 
 val content_blocks_to_json :
   Agent_sdk.Types.content_block list -> Yojson.Safe.t

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -41,7 +41,6 @@ let append = Keeper_context_core.append
 let append_many = Keeper_context_core.append_many
 let sync_oas_context = Keeper_context_core.sync_oas_context
 let role_to_string = Keeper_context_core.role_to_string
-let role_of_string = Keeper_context_core.role_of_string
 let role_of_string_opt = Keeper_context_core.role_of_string_opt
 let message_to_json = Keeper_context_core.message_to_json
 let message_of_json = Keeper_context_core.message_of_json

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -36,16 +36,12 @@ val append : working_context -> Agent_sdk.Types.message -> working_context
 val append_many : working_context -> Agent_sdk.Types.message list -> working_context
 val sync_oas_context : working_context -> working_context
 
-(** Backwards-compatible: unknown -> [Tool] (safest fallback) + warn log.
-    See {!role_of_string_opt} for the strict version. Issue #8623. *)
 val role_to_string : Agent_sdk.Types.role -> string
 
 (** Strict variant — returns [None] for unrecognised role strings.
     Use this in checkpoint loaders / new code where silently
     misattributing a chat-history message would corrupt the
     LLM-visible conversation. *)
-val role_of_string : string -> Agent_sdk.Types.role
-
 val role_of_string_opt : string -> Agent_sdk.Types.role option
 val message_to_json : Agent_sdk.Types.message -> Yojson.Safe.t
 val message_of_json : Yojson.Safe.t -> Agent_sdk.Types.message

--- a/test/test_keeper_context_core_dedup.ml
+++ b/test/test_keeper_context_core_dedup.ml
@@ -62,6 +62,15 @@ let test_message_of_json_ignores_flat_content () =
   let msg = C.message_of_json flat_content in
   Alcotest.(check int) "no canonical blocks" 0 (List.length msg.content)
 
+let test_message_of_json_rejects_unknown_role () =
+  let json : Yojson.Safe.t =
+    `Assoc [ ("role", `String "operator"); ("content_blocks", `List []) ]
+  in
+  Alcotest.check_raises
+    "unknown role rejected"
+    (Invalid_argument "keeper_context_core: unknown role \"operator\"")
+    (fun () -> C.message_of_json json |> ignore)
+
 (* --- text_of_history_jsonl_json --- *)
 
 let test_history_jsonl_text_uses_blocks_first () =
@@ -201,6 +210,8 @@ let () =
             test_message_of_json_new_content_blocks_only;
           Alcotest.test_case "flat content ignored" `Quick
             test_message_of_json_ignores_flat_content;
+          Alcotest.test_case "unknown role rejected" `Quick
+            test_message_of_json_rejects_unknown_role;
           Alcotest.test_case "round-trip text preserved" `Quick
             test_roundtrip_text_preserved;
         ] );


### PR DESCRIPTION
## Summary
- remove the role_of_string compatibility wrapper that defaulted unknown message roles to Tool
- make message_of_json fail closed on unknown role strings
- drop role_of_string re-exports from keeper context surfaces
- add regression coverage for unknown-role rejection

## Validation
- rg -n "\brole_of_string\b|defaulting to Tool|Backwards-compatible wrapper|unknown -> \[Tool\]" lib/keeper test/test_keeper_context_core_dedup.ml (0 matches)
- ocamlformat --check lib/keeper/keeper_context_core_message_json.ml lib/keeper/keeper_context_core_message_json.mli lib/keeper/keeper_context_core.ml lib/keeper/keeper_context_core.mli lib/keeper/keeper_exec_context.ml lib/keeper/keeper_exec_context.mli test/test_keeper_context_core_dedup.ml
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_context_core_dedup.exe (failed on unrelated latest-main/base break: Shell_ir constructor arity mismatch and conflict marker in lib/keeper/keeper_turn_cascade_budget_event_bus.mli)