### PR TITLE
fix(build): align shell ir metadata interface

### DIFF
--- a/bin/gen_shell_ir_walkers.ml
+++ b/bin/gen_shell_ir_walkers.ml
@@ -58,7 +58,7 @@ let shell_ir_typed_spec : ctor list =
         match path with None -> flag_args | Some p -> flag_args @ [ p ]
       in
       { Shell_ir.bin = Bin.of_known Bin.Ls
-      ; args = List.map (fun s -> Shell_ir.Lit s) args
+      ; args = List.map (fun s -> Shell_ir.Lit (s, Shell_ir.default_meta)) args
       ; env = []
       ; cwd = None
       ; redirects = []
@@ -118,7 +118,7 @@ parse [] None args|}
         @ (match path with None -> [] | Some p -> [ p ])
       in
       { Shell_ir.bin = Bin.of_known Bin.Rg
-      ; args = List.map (fun s -> Shell_ir.Lit s) args
+      ; args = List.map (fun s -> Shell_ir.Lit (s, Shell_ir.default_meta)) args
       ; env = []
       ; cwd = None
       ; redirects = []
@@ -156,7 +156,7 @@ parse true None None args|}
         {|
       let args = if short then [ "-s" ] else [] in
       { Shell_ir.bin = Bin.of_known Bin.Git
-      ; args = List.map (fun s -> Shell_ir.Lit s) ("status" :: args)
+      ; args = List.map (fun s -> Shell_ir.Lit (s, Shell_ir.default_meta)) ("status" :: args)
       ; env = []
       ; cwd = None
       ; redirects = []
@@ -187,7 +187,7 @@ parse false args|}
         @ [ repo ]
       in
       { Shell_ir.bin = Bin.of_known Bin.Git
-      ; args = List.map (fun s -> Shell_ir.Lit s) ("clone" :: args)
+      ; args = List.map (fun s -> Shell_ir.Lit (s, Shell_ir.default_meta)) ("clone" :: args)
       ; env = []
       ; cwd = None
       ; redirects = []
@@ -240,7 +240,7 @@ parse 1 None None args|}
       let body_args = match body with None -> [] | Some d -> [ "-d"; d ] in
       let args = method_args @ header_args @ body_args @ [ url ] in
       { Shell_ir.bin = Bin.of_known Bin.Curl
-      ; args = List.map (fun s -> Shell_ir.Lit s) args
+      ; args = List.map (fun s -> Shell_ir.Lit (s, Shell_ir.default_meta)) args
       ; env = []
       ; cwd = None
       ; redirects = []
@@ -306,7 +306,7 @@ parse `GET [] None None args|}
         @ (if force then [ "-f" ] else [])
       in
       { Shell_ir.bin = Bin.of_known Bin.Rm
-      ; args = List.map (fun s -> Shell_ir.Lit s) (flag_args @ paths)
+      ; args = List.map (fun s -> Shell_ir.Lit (s, Shell_ir.default_meta)) (flag_args @ paths)
       ; env = []
       ; cwd = None
       ; redirects = []
@@ -338,7 +338,7 @@ parse false false [] args|}
     ; to_simple_body =
         {|
       { Shell_ir.bin = Bin.of_known Bin.Sudo
-      ; args = List.map (fun s -> Shell_ir.Lit s) target_argv
+      ; args = List.map (fun s -> Shell_ir.Lit (s, Shell_ir.default_meta)) target_argv
       ; env = []
       ; cwd = None
       ; redirects = []
@@ -452,8 +452,8 @@ let emit_of_simple buf spec =
     "let gen_of_simple (s : Shell_ir.simple) : Shell_ir_typed_types.wrapped =\n\
     \  let generic () = Shell_ir_typed_types.W (Shell_ir_typed_types.Generic s) in\n\
     \  let lit_of_arg = function\n\
-    \    | Shell_ir.Lit (s, Shell_ir.default_meta) -> Some s\n\
-    \    | Shell_ir.Var (_, Shell_ir.default_meta) | Shell_ir.Concat _ -> None\n\
+    \    | Shell_ir.Lit (s, _) -> Some s\n\
+    \    | Shell_ir.Var (_, _) | Shell_ir.Concat _ -> None\n\
     \  in\n\
     \  let rec all_lits_opt args =\n\
     \    let rec go acc = function\n\

--- a/lib/exec/capability_check.ml
+++ b/lib/exec/capability_check.ml
@@ -4,8 +4,8 @@
    compile error here, so policy decisions are never silently dropped. *)
 
 let lit_of_arg = function
-  | Shell_ir.Lit (s, Shell_ir.default_meta) -> Some s
-  | Shell_ir.Var (_, Shell_ir.default_meta) | Shell_ir.Concat _ -> None
+  | Shell_ir.Lit (s, _) -> Some s
+  | Shell_ir.Var (_, _) | Shell_ir.Concat _ -> None
 
 let all_lits_opt (args : Shell_ir.arg list) : string list option =
   let rec go acc = function

--- a/lib/exec/command_gate/shell_command_gate.ml
+++ b/lib/exec/command_gate/shell_command_gate.ml
@@ -125,7 +125,7 @@ let ast_of_stages = function
 ;;
 
 let arg_literal = function
-  | SI.Lit s -> Some s
+  | SI.Lit (s, _) -> Some s
   | SI.Var _ | SI.Concat _ -> None
 ;;
 
@@ -275,7 +275,7 @@ let literal_path_surfaces (simple : SI.simple) : string list =
   let argv =
     List.filter_map
       (function
-        | SI.Lit s -> Some s
+        | SI.Lit (s, _) -> Some s
         | SI.Var _ | SI.Concat _ -> None)
       simple.SI.args
   in

--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -100,7 +100,7 @@ let pipeline_status current stage_status =
 (* --- arg resolution --- *)
 
 let rec resolve_arg = function
-  | Shell_ir.Lit (s, Shell_ir.default_meta) -> s
+  | Shell_ir.Lit (s, _) -> s
   | Concat parts ->
       let buf = Buffer.create 64 in
       List.iter (fun a -> Buffer.add_string buf (resolve_arg a)) parts;

--- a/lib/exec/parser/bash.ml
+++ b/lib/exec/parser/bash.ml
@@ -24,7 +24,7 @@ let parse_env_assignment word =
     let name = String.sub word 0 idx in
     if is_env_name_start name.[0]
        && String.for_all is_env_name_char name
-    then (
+    then
       let value =
         String.sub word (idx + 1) (String.length word - idx - 1)
       in

--- a/lib/exec/shell_ir.mli
+++ b/lib/exec/shell_ir.mli
@@ -5,10 +5,18 @@
     glob/brace expansion, backgrounding) is rejected at parse time as
     [Parsed.Too_complex _]. *)
 
+type arg_meta = {
+  quoted : bool;
+  glob : bool;
+  escaped : bool;
+}
+
+val default_meta : arg_meta
+
 type arg =
-  | Lit of string                 (** single- or double-quoted literal *)
+  | Lit of string * arg_meta      (** single- or double-quoted literal *)
   | Concat of arg list            (** adjacent arg pieces: [foo"bar"$X] *)
-  | Var of string                 (** [$HOME], [${VAR}], [${VAR:-default}] *)
+  | Var of string * arg_meta      (** [$HOME], [${VAR}], [${VAR:-default}] *)
 
 type simple = {
   bin : Bin.t;

--- a/lib/exec/test/test_bash_parser.ml
+++ b/lib/exec/test/test_bash_parser.ml
@@ -23,7 +23,7 @@ let test_ls_with_args () =
   | Parsed.Parsed (Shell_ir.Simple s) ->
     assert (Bin.to_string s.bin = "ls");
     (match s.args with
-     | [ Shell_ir.Lit "-la"; Shell_ir.Lit "/tmp" ] -> ()
+     | [ Shell_ir.Lit ("-la", _); Shell_ir.Lit ("/tmp", _) ] -> ()
      (* "args wrong shape" *)
      | _ -> assert false)
   (* "ls -la /tmp must parse" *)
@@ -33,7 +33,7 @@ let test_echo_message () =
   match Bash.parse_string "echo hello" with
   | Parsed.Parsed (Shell_ir.Simple s) ->
     assert (Bin.to_string s.bin = "echo");
-    assert (s.args = [ Shell_ir.Lit "hello" ])
+    assert (s.args = [ Shell_ir.Lit ("hello", Shell_ir.default_meta) ])
   (* "echo hello must parse" *)
   | _ -> assert false
 
@@ -41,7 +41,7 @@ let test_dev_null_as_regular_arg () =
   match Bash.parse_string "cat /dev/null" with
   | Parsed.Parsed (Shell_ir.Simple s) ->
     assert (Bin.to_string s.bin = "cat");
-    assert (s.args = [ Shell_ir.Lit "/dev/null" ]);
+    assert (s.args = [ Shell_ir.Lit ("/dev/null", Shell_ir.default_meta) ]);
     assert (s.redirects = [])
   | _ -> assert false
 
@@ -73,7 +73,7 @@ let test_three_stage_pipeline_with_args () =
        assert (Bin.to_string s1.bin = "ls");
        assert (Bin.to_string s2.bin = "grep");
        assert (Bin.to_string s3.bin = "wc");
-       assert (s2.args = [ Shell_ir.Lit "foo" ])
+       assert (s2.args = [ Shell_ir.Lit ("foo", Shell_ir.default_meta) ])
      (* "3-stage pipeline inner shape wrong" *)
      | _ -> assert false)
   (* "3-stage pipeline must parse" *)
@@ -105,7 +105,7 @@ let test_general_redirect_parsed () =
   match Bash.parse_string "echo hi > /tmp/out" with
   | Parsed.Parsed (Shell_ir.Simple s) ->
     assert (Bin.to_string s.bin = "echo");
-    assert (s.args = [ Shell_ir.Lit "hi" ]);
+    assert (s.args = [ Shell_ir.Lit ("hi", Shell_ir.default_meta) ]);
     (match s.redirects with
      | [ Redirect_scope.File { fd = 1; target; mode = Redirect_scope.Write } ] ->
        assert (Path_scope.raw target = "/tmp/out")
@@ -190,23 +190,23 @@ let test_env_prefix_parsed () =
   match Bash.parse_string "LC_ALL=C git status" with
   | Parsed.Parsed (Shell_ir.Simple s) ->
     assert (Bin.to_string s.bin = "git");
-    assert (s.args = [ Shell_ir.Lit "status" ]);
-    assert (s.env = [ "LC_ALL", Shell_ir.Lit "C" ])
+    assert (s.args = [ Shell_ir.Lit ("status", Shell_ir.default_meta) ]);
+    assert (s.env = [ "LC_ALL", Shell_ir.Lit ("C", Shell_ir.default_meta) ])
   | _ -> assert false
 
 let test_multiple_env_prefixes_preserve_order () =
   match Bash.parse_string "A=1 B='two words' printenv A" with
   | Parsed.Parsed (Shell_ir.Simple s) ->
     assert (Bin.to_string s.bin = "printenv");
-    assert (s.args = [ Shell_ir.Lit "A" ]);
-    assert (s.env = [ "A", Shell_ir.Lit "1"; "B", Shell_ir.Lit "two words" ])
+    assert (s.args = [ Shell_ir.Lit ("A", Shell_ir.default_meta) ]);
+    assert (s.env = [ "A", Shell_ir.Lit ("1", Shell_ir.default_meta); "B", Shell_ir.Lit ("two words", Shell_ir.default_meta) ])
   | _ -> assert false
 
 let test_env_assignment_after_bin_is_arg () =
   match Bash.parse_string "echo LC_ALL=C" with
   | Parsed.Parsed (Shell_ir.Simple s) ->
     assert (Bin.to_string s.bin = "echo");
-    assert (s.args = [ Shell_ir.Lit "LC_ALL=C" ]);
+    assert (s.args = [ Shell_ir.Lit ("LC_ALL=C", Shell_ir.default_meta) ]);
     assert (s.env = [])
   | _ -> assert false
 
@@ -220,10 +220,10 @@ let test_pipeline_env_prefixes_preserved_per_stage () =
   | Parsed.Parsed (Shell_ir.Pipeline [ Shell_ir.Simple s1; Shell_ir.Simple s2 ]) ->
     assert (Bin.to_string s1.bin = "printf");
     assert (Bin.to_string s2.bin = "wc");
-    assert (s1.env = [ "LC_ALL", Shell_ir.Lit "C" ]);
-    assert (s2.env = [ "LANG", Shell_ir.Lit "C" ]);
-    assert (s1.args = [ Shell_ir.Lit "hi" ]);
-    assert (s2.args = [ Shell_ir.Lit "-c" ])
+    assert (s1.env = [ "LC_ALL", Shell_ir.Lit ("C", Shell_ir.default_meta) ]);
+    assert (s2.env = [ "LANG", Shell_ir.Lit ("C", Shell_ir.default_meta) ]);
+    assert (s1.args = [ Shell_ir.Lit ("hi", Shell_ir.default_meta) ]);
+    assert (s2.args = [ Shell_ir.Lit ("-c", Shell_ir.default_meta) ])
   | _ -> assert false
 
 let test_env_prefix_dispatch_overlay () =
@@ -294,7 +294,7 @@ let test_single_quoted_arg () =
   | Parsed.Parsed (Shell_ir.Simple s) ->
     assert (Bin.to_string s.bin = "echo");
     (match s.args with
-     | [ Shell_ir.Lit "hello world" ] -> ()
+     | [ Shell_ir.Lit ("hello world", _) ] -> ()
      (* "single-quoted content must land as one Lit" *)
      | _ -> assert false)
   | _ -> assert false
@@ -304,7 +304,7 @@ let test_single_quoted_empty () =
   | Parsed.Parsed (Shell_ir.Simple s) ->
     assert (Bin.to_string s.bin = "echo");
     (match s.args with
-     | [ Shell_ir.Lit "" ] -> ()
+     | [ Shell_ir.Lit ("", _) ] -> ()
      (* "empty single-quoted string must land as empty Lit" *)
      | _ -> assert false)
   | _ -> assert false
@@ -315,10 +315,10 @@ let test_multiple_single_quoted_args () =
     assert (Bin.to_string s.bin = "git");
     (match s.args with
      | [
-         Shell_ir.Lit "commit";
-         Shell_ir.Lit "-m";
-         Shell_ir.Lit "my message";
-         Shell_ir.Lit "--allow-empty";
+         Shell_ir.Lit ("commit", _);
+         Shell_ir.Lit ("-m", _);
+         Shell_ir.Lit ("my message", _);
+         Shell_ir.Lit ("--allow-empty", _);
        ] -> ()
      (* "commit message must preserve spaces as one Lit" *)
      | _ -> assert false)
@@ -331,7 +331,7 @@ let test_single_quote_with_pipe_metachar () =
   match Bash.parse_string "echo 'foo | bar'" with
   | Parsed.Parsed (Shell_ir.Simple s) ->
     (match s.args with
-     | [ Shell_ir.Lit "foo | bar" ] -> ()
+     | [ Shell_ir.Lit ("foo | bar", _) ] -> ()
      | _ -> assert false)
   | _ -> assert false
 
@@ -351,7 +351,7 @@ let test_double_quoted_arg () =
   | Parsed.Parsed (Shell_ir.Simple s) ->
     assert (Bin.to_string s.bin = "echo");
     (match s.args with
-     | [ Shell_ir.Lit "hello world" ] -> ()
+     | [ Shell_ir.Lit ("hello world", _) ] -> ()
      (* "double-quoted content must land as one Lit" *)
      | _ -> assert false)
   | _ -> assert false
@@ -361,7 +361,7 @@ let test_double_quoted_empty () =
   | Parsed.Parsed (Shell_ir.Simple s) ->
     assert (Bin.to_string s.bin = "echo");
     (match s.args with
-     | [ Shell_ir.Lit "" ] -> ()
+     | [ Shell_ir.Lit ("", _) ] -> ()
      (* "empty double-quoted string must land as empty Lit" *)
      | _ -> assert false)
   | _ -> assert false
@@ -372,7 +372,7 @@ let test_double_quote_with_pipe_metachar () =
   match Bash.parse_string "echo \"foo | bar\"" with
   | Parsed.Parsed (Shell_ir.Simple s) ->
     (match s.args with
-     | [ Shell_ir.Lit "foo | bar" ] -> ()
+     | [ Shell_ir.Lit ("foo | bar", _) ] -> ()
      | _ -> assert false)
   | _ -> assert false
 
@@ -384,7 +384,7 @@ let test_double_quote_rg_pattern () =
   | Parsed.Parsed (Shell_ir.Simple s) ->
     assert (Bin.to_string s.bin = "rg");
     (match s.args with
-     | [ Shell_ir.Lit "error pattern"; Shell_ir.Lit "src/" ] -> ()
+     | [ Shell_ir.Lit ("error pattern", _); Shell_ir.Lit ("src/", _) ] -> ()
      | _ -> assert false)
   | _ -> assert false
 
@@ -397,9 +397,9 @@ let test_double_quote_with_escaped_regex_pipe () =
     assert (Bin.to_string s.bin = "rg");
     (match s.args with
      | [
-         Shell_ir.Lit "-n";
-         Shell_ir.Lit {|ghost\|task|};
-         Shell_ir.Lit "lib/";
+         Shell_ir.Lit ("-n", _);
+         Shell_ir.Lit ({|ghost\|task|}, _);
+         Shell_ir.Lit ("lib/", _);
        ] -> ()
      | _ -> assert false)
   | _ -> assert false
@@ -413,10 +413,10 @@ let test_word_with_double_quoted_suffix () =
     assert (Bin.to_string s.bin = "grep");
     (match s.args with
      | [
-         Shell_ir.Lit "-rn";
-         Shell_ir.Lit "exec_semantic";
-         Shell_ir.Lit "lib/";
-         Shell_ir.Lit "--include=*.ml";
+         Shell_ir.Lit ("-rn", _);
+         Shell_ir.Lit ("exec_semantic", _);
+         Shell_ir.Lit ("lib/", _);
+         Shell_ir.Lit ("--include=*.ml", _);
        ] -> ()
      | _ -> assert false)
   | _ -> assert false

--- a/lib/exec/test/test_capability_check.ml
+++ b/lib/exec/test/test_capability_check.ml
@@ -57,7 +57,7 @@ let test_git_with_var_falls_back_to_exec_bin () =
   (* git ${REMOTE} push — can't classify statically, falls back. *)
   let ir =
     Shell_ir.Simple
-      (simple ~args:[ Shell_ir.Var "REMOTE"; lit "push" ] (bin_ok "git"))
+      (simple ~args:[ Shell_ir.Var ("REMOTE", Shell_ir.default_meta); lit "push" ] (bin_ok "git"))
   in
   match Capability_check.of_ir ir with
   | [ Capability.Exec_bin (b, _) ] ->

--- a/lib/exec/test/test_shell_ir_typed.ml
+++ b/lib/exec/test/test_shell_ir_typed.ml
@@ -15,8 +15,8 @@ let simple ?(args = []) ?(env = []) ?(cwd = None) ?(redirects = [])
 let lit s = Shell_ir.Lit (s, Shell_ir.default_meta)
 
 let arg_to_string = function
-  | Shell_ir.Lit (s, Shell_ir.default_meta) -> s
-  | Shell_ir.Var (_, Shell_ir.default_meta) | Shell_ir.Concat _ ->
+  | Shell_ir.Lit (s, _) -> s
+  | Shell_ir.Var (_, _) | Shell_ir.Concat _ ->
     assert false (* tests use only literal args *)
 
 let argv_of_simple s =

--- a/lib/exec/test/test_shell_ir_walkers_gen.ml
+++ b/lib/exec/test/test_shell_ir_walkers_gen.ml
@@ -196,7 +196,7 @@ let test_of_simple_generic_fallback () =
      | Shell_ir_typed.W (Generic _) -> true
      | _ -> false);
   (* Var arg *)
-  let w_var = Shell_ir_typed.of_simple { base with args = [ Shell_ir.Var "X" ] } in
+  let w_var = Shell_ir_typed.of_simple { base with args = [ Shell_ir.Var ("X", Shell_ir.default_meta) ] } in
   Alcotest.(check bool)
     "var fallback"
     true

--- a/lib/exec_policy.ml
+++ b/lib/exec_policy.ml
@@ -158,7 +158,7 @@ let coding_allowlist_policy ?(allow_pipes = true) ~allowed_commands ()
 ;;
 
 let rec shell_ir_literal_text = function
-  | Masc_exec.Shell_ir.Lit (text, Shell_ir.default_meta) -> Some text
+  | Masc_exec.Shell_ir.Lit (text, _) -> Some text
   | Masc_exec.Shell_ir.Concat parts ->
     let rec loop acc = function
       | [] -> Some (String.concat "" (List.rev acc))
@@ -168,7 +168,7 @@ let rec shell_ir_literal_text = function
          | None -> None)
     in
     loop [] parts
-  | Masc_exec.Shell_ir.Var (_, Shell_ir.default_meta) -> None
+  | Masc_exec.Shell_ir.Var (_, _) -> None
 ;;
 
 let simple_literal_args (simple : Masc_exec.Shell_ir.simple) =
@@ -663,8 +663,8 @@ let path_argument_values command_name args =
 let literal_args_of_simple (simple : Masc_exec.Shell_ir.simple) =
   let rec loop acc = function
     | [] -> Some (List.rev acc)
-    | Masc_exec.Shell_ir.Lit (value, Shell_ir.default_meta) :: rest -> loop (value :: acc) rest
-    | Masc_exec.Shell_ir.Concat _ :: _ | Masc_exec.Shell_ir.Var (_, Shell_ir.default_meta) :: _ -> None
+    | Masc_exec.Shell_ir.Lit (value, _) :: rest -> loop (value :: acc) rest
+    | Masc_exec.Shell_ir.Concat _ :: _ | Masc_exec.Shell_ir.Var (_, _) :: _ -> None
   in
   loop [] simple.args
 ;;

--- a/lib/exec_policy_command_syntax.ml
+++ b/lib/exec_policy_command_syntax.ml
@@ -6,7 +6,7 @@
     transparent wrappers such as [env] and [opam exec]. *)
 
 let rec shell_ir_literal_text = function
-  | Masc_exec.Shell_ir.Lit (text, Shell_ir.default_meta) -> Some text
+  | Masc_exec.Shell_ir.Lit (text, _) -> Some text
   | Masc_exec.Shell_ir.Concat parts ->
     let rec loop acc = function
       | [] -> Some (String.concat "" (List.rev acc))
@@ -16,7 +16,7 @@ let rec shell_ir_literal_text = function
          | None -> None)
     in
     loop [] parts
-  | Masc_exec.Shell_ir.Var (_, Shell_ir.default_meta) -> None
+  | Masc_exec.Shell_ir.Var (_, _) -> None
 ;;
 
 let argv_words_of_simple (simple : Masc_exec.Shell_ir.simple) =

--- a/lib/keeper/keeper_gh_shared.ml
+++ b/lib/keeper/keeper_gh_shared.ml
@@ -130,10 +130,10 @@ let gh_simple_command_of_simple (simple : Masc_exec.Shell_ir.simple)
       else (
         let rec collect acc = function
           | [] -> Ok (Masc_exec.Bin.to_string simple.bin, { argv = List.rev acc })
-          | Masc_exec.Shell_ir.Lit (s, Shell_ir.default_meta) :: rest -> collect (s :: acc) rest
+          | Masc_exec.Shell_ir.Lit (s, _) :: rest -> collect (s :: acc) rest
           | Masc_exec.Shell_ir.Concat _ :: _ ->
             Error (Unsupported_command_shape "concat_arg")
-          | Masc_exec.Shell_ir.Var (_, Shell_ir.default_meta) :: _ -> Error (Unsupported_command_shape "var_arg")
+          | Masc_exec.Shell_ir.Var (_, _) :: _ -> Error (Unsupported_command_shape "var_arg")
         in
         collect [] simple.args))
 ;;

--- a/lib/keeper/keeper_hooks_oas_pr_metrics.ml
+++ b/lib/keeper/keeper_hooks_oas_pr_metrics.ml
@@ -121,7 +121,7 @@ let pr_work_actions_of_git_segment segment =
            (Masc_exec.Bin.to_string simple.bin |> String.lowercase_ascii)
            "git" ->
       (match simple.args with
-       | Masc_exec.Shell_ir.Lit (action, Shell_ir.default_meta) :: _ ->
+       | Masc_exec.Shell_ir.Lit (action, _) :: _ ->
            pr_work_action_of_git_action action |> Option.to_list
        | _ -> [])
   | _ ->

--- a/lib/keeper/keeper_shell_command_semantics.ml
+++ b/lib/keeper/keeper_shell_command_semantics.ml
@@ -13,8 +13,8 @@ type parsed_stage =
 let literal_args args =
   let rec loop acc = function
     | [] -> Some (List.rev acc)
-    | Masc_exec.Shell_ir.Lit (arg, Shell_ir.default_meta) :: rest -> loop (arg :: acc) rest
-    | Masc_exec.Shell_ir.Concat _ :: _ | Masc_exec.Shell_ir.Var (_, Shell_ir.default_meta) :: _ -> None
+    | Masc_exec.Shell_ir.Lit (arg, _) :: rest -> loop (arg :: acc) rest
+    | Masc_exec.Shell_ir.Concat _ :: _ | Masc_exec.Shell_ir.Var (_, _) :: _ -> None
   in
   loop [] args
 

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -450,18 +450,18 @@ type structured_input =
 
 let translate_bash_input input_json =
   match Keeper_tool_bash_input.of_json input_json with
-  | Ok typed ->
-    Yojson.Safe.to_json (`Assoc [
+  | Ok _typed ->
+    `Assoc [
       "command_type", `String "typed_exec";
       "bash_input", input_json
-    ])
+    ]
   | Error _ ->
     input_json
 
 let route_with_structured_input (route : route) : route =
   { route with translate = translate_bash_input }
 
-let register_structured_routes () =
+let rec register_structured_routes () =
   (* Replace Bash route with structured-input aware translator.  Other
      routes continue to use the identity translator for now. *)
   Hashtbl.replace routing_table "Bash"

--- a/lib/keeper/keeper_tool_bash_input.ml
+++ b/lib/keeper/keeper_tool_bash_input.ml
@@ -310,7 +310,7 @@ let validate ~mode = function
     each stages
 ;;
 
-let shell_arg text = Masc_exec.Shell_ir.Lit (text, Shell_ir.default_meta)
+let shell_arg text = Masc_exec.Shell_ir.Lit (text, Masc_exec.Shell_ir.default_meta)
 
 let shell_env env =
   List.map (fun (key, value) -> key, shell_arg value) env

--- a/lib/keeper/keeper_turn_cascade_budget_event_bus.mli
+++ b/lib/keeper/keeper_turn_cascade_budget_event_bus.mli
@@ -30,13 +30,7 @@ val merge_turn_event_bus_summary
   :  turn_event_bus_summary
   -> turn_event_bus_summary
   -> turn_event_bus_summary
-<<<<<<< HEAD
-
-val add_payload_kind : string list -> string -> string list
-||||||| parent of 7671e4309c (fix: repair broken build from recent refactoring PRs)
-=======
 
 val add_payload_kind : string list -> string -> string list
 
 val merge_payload_kinds : string list -> string list -> string list
->>>>>>> 7671e4309c (fix: repair broken build from recent refactoring PRs)

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -254,9 +254,9 @@ let parse_command cmd =
   let collect_lit_args args =
     let rec loop acc = function
       | [] -> Some (List.rev acc)
-      | Masc_exec.Shell_ir.Lit (arg, Shell_ir.default_meta) :: rest -> loop (arg :: acc) rest
+      | Masc_exec.Shell_ir.Lit (arg, _) :: rest -> loop (arg :: acc) rest
       | Masc_exec.Shell_ir.Concat _ :: _
-      | Masc_exec.Shell_ir.Var (_, Shell_ir.default_meta) :: _ -> None
+      | Masc_exec.Shell_ir.Var (_, _) :: _ -> None
     in
     loop [] args
   in

--- a/test/test_exec_dispatch.ml
+++ b/test/test_exec_dispatch.ml
@@ -11,7 +11,7 @@ let with_eio f =
 let () =
   let open Masc_exec.Shell_ir in
   let test_resolve_lit =
-    let result = Masc_exec.Exec_dispatch.(resolve_arg (Lit "hello")) in
+    let result = Masc_exec.Exec_dispatch.(resolve_arg (Lit ("hello", default_meta))) in
     assert (result = "hello")
   in
   test_resolve_lit
@@ -19,18 +19,28 @@ let () =
 let () =
   let open Masc_exec.Shell_ir in
   Unix.putenv "MASC_TEST_P7_VAR" "world";
-  let result = Masc_exec.Exec_dispatch.(resolve_arg (Var "MASC_TEST_P7_VAR")) in
+  let result = Masc_exec.Exec_dispatch.(resolve_arg (Var ("MASC_TEST_P7_VAR", default_meta))) in
   assert (result = "world")
 
 let () =
   let open Masc_exec.Shell_ir in
-  let result = Masc_exec.Exec_dispatch.(resolve_arg (Var "__MASC_NONEXISTENT_P7__")) in
+  let result =
+    Masc_exec.Exec_dispatch.(resolve_arg (Var ("__MASC_NONEXISTENT_P7__", default_meta)))
+  in
   assert (result = "")
 
 let () =
   let open Masc_exec.Shell_ir in
   Unix.putenv "MASC_TEST_P7_VAR" "world";
-  let result = Masc_exec.Exec_dispatch.(resolve_arg (Concat [Lit "prefix-"; Var "MASC_TEST_P7_VAR"; Lit "-suffix"])) in
+  let result =
+    Masc_exec.Exec_dispatch.(
+      resolve_arg
+        (Concat
+           [ Lit ("prefix-", default_meta)
+           ; Var ("MASC_TEST_P7_VAR", default_meta)
+           ; Lit ("-suffix", default_meta)
+           ]))
+  in
   assert (result = "prefix-world-suffix");
   Unix.putenv "MASC_TEST_P7_VAR" ""
 
@@ -43,7 +53,7 @@ let () =
   let ir =
     Simple
       { bin
-      ; args = [ Lit "hello"; Lit "world" ]
+      ; args = [ Lit ("hello", default_meta); Lit ("world", default_meta) ]
       ; env = []
       ; cwd = None
       ; redirects = []
@@ -64,7 +74,7 @@ let () =
   let ir =
     Simple
       { bin
-      ; args = [ Lit "/nonexistent_file_p7_test" ]
+      ; args = [ Lit ("/nonexistent_file_p7_test", default_meta) ]
       ; env = []
       ; cwd = None
       ; redirects = []
@@ -84,8 +94,8 @@ let () =
   let tr_bin = Masc_exec.Bin.of_string "tr" |> Result.get_ok in
   let host_sandbox = Masc_exec.Sandbox_target.host () in
   let stages = [
-    Simple { bin = echo_bin; args = [Lit "hello world"]; env = []; cwd = None; redirects = []; sandbox = host_sandbox };
-    Simple { bin = tr_bin; args = [Lit "a-z"; Lit "A-Z"]; env = []; cwd = None; redirects = []; sandbox = host_sandbox };
+    Simple { bin = echo_bin; args = [Lit ("hello world", default_meta)]; env = []; cwd = None; redirects = []; sandbox = host_sandbox };
+    Simple { bin = tr_bin; args = [Lit ("a-z", default_meta); Lit ("A-Z", default_meta)]; env = []; cwd = None; redirects = []; sandbox = host_sandbox };
   ] in
   let result = Masc_exec.Exec_dispatch.dispatch (Pipeline stages) in
   let stdout = String.trim result.stdout in
@@ -103,7 +113,7 @@ let () =
   let stages =
     [
       Simple { bin = yes_bin; args = []; env = []; cwd = None; redirects = []; sandbox = host_sandbox };
-      Simple { bin = head_bin; args = [Lit "-n"; Lit "1"]; env = []; cwd = None; redirects = []; sandbox = host_sandbox };
+      Simple { bin = head_bin; args = [Lit ("-n", default_meta); Lit ("1", default_meta)]; env = []; cwd = None; redirects = []; sandbox = host_sandbox };
     ]
   in
   let result = Masc_exec.Exec_dispatch.dispatch ~timeout_sec:2.0 (Pipeline stages) in
@@ -119,7 +129,7 @@ let () =
   let false_bin = Masc_exec.Bin.of_string "false" |> Result.get_ok in
   let host_sandbox = Masc_exec.Sandbox_target.host () in
   let stages = [
-    Simple { bin = echo_bin; args = [Lit "ok"]; env = []; cwd = None; redirects = []; sandbox = host_sandbox };
+    Simple { bin = echo_bin; args = [Lit ("ok", default_meta)]; env = []; cwd = None; redirects = []; sandbox = host_sandbox };
     Simple { bin = false_bin; args = []; env = []; cwd = None; redirects = []; sandbox = host_sandbox };
   ] in
   let result = Masc_exec.Exec_dispatch.dispatch (Pipeline stages) in
@@ -145,7 +155,7 @@ let () =
       Simple
         {
           bin = echo_bin;
-          args = [ Lit "recovered" ];
+          args = [ Lit ("recovered", default_meta) ];
           env = [];
           cwd = None;
           redirects = [];
@@ -166,7 +176,7 @@ let () =
     Simple
       {
         bin = sh_bin;
-        args = [ Lit "-c"; Lit script ];
+        args = [ Lit ("-c", default_meta); Lit (script, default_meta) ];
         env = [];
         cwd = None;
         redirects = [];
@@ -237,7 +247,7 @@ let () =
   let stage =
     Simple
       { bin
-      ; args = [ Lit "single" ]
+      ; args = [ Lit ("single", default_meta) ]
       ; env = []
       ; cwd = None
       ; redirects = []
@@ -260,7 +270,7 @@ let () =
   let echo_stage =
     Simple
       { bin = echo_bin
-      ; args = [ Lit "nested" ]
+      ; args = [ Lit ("nested", default_meta) ]
       ; env = []
       ; cwd = None
       ; redirects = []
@@ -307,7 +317,7 @@ let () =
   let ir =
     Simple
       { bin
-      ; args = [ Lit "hello"; Lit "world" ]
+      ; args = [ Lit ("hello", default_meta); Lit ("world", default_meta) ]
       ; env = []
       ; cwd = None
       ; redirects = []
@@ -463,7 +473,7 @@ let () =
       Simple
         {
           bin = printf_bin;
-          args = [ Lit "typed" ];
+          args = [ Lit ("typed", default_meta) ];
           env = [];
           cwd;
           redirects = [];
@@ -472,7 +482,7 @@ let () =
       Simple
         {
           bin = wc_bin;
-          args = [ Lit "-c" ];
+          args = [ Lit ("-c", default_meta) ];
           env = [];
           cwd;
           redirects = [];
@@ -568,7 +578,7 @@ let () =
       Simple
         {
           bin = printf_bin;
-          args = [ Lit "typed" ];
+          args = [ Lit ("typed", default_meta) ];
           env = [];
           cwd;
           redirects = [];
@@ -577,7 +587,7 @@ let () =
       Simple
         {
           bin = wc_bin;
-          args = [ Lit "-c" ];
+          args = [ Lit ("-c", default_meta) ];
           env = [];
           cwd;
           redirects = [];
@@ -646,7 +656,7 @@ let () =
       Simple
         {
           bin = printf_bin;
-          args = [ Lit "typed" ];
+          args = [ Lit ("typed", default_meta) ];
           env = [];
           cwd = None;
           redirects = [];
@@ -655,7 +665,7 @@ let () =
       Simple
         {
           bin = wc_bin;
-          args = [ Lit "-c" ];
+          args = [ Lit ("-c", default_meta) ];
           env = [];
           cwd = None;
           redirects = [];
@@ -704,7 +714,7 @@ let () =
       Simple
         {
           bin = printf_bin;
-          args = [ Lit "typed" ];
+          args = [ Lit ("typed", default_meta) ];
           env = [];
           cwd = None;
           redirects =
@@ -717,7 +727,7 @@ let () =
       Simple
         {
           bin = wc_bin;
-          args = [ Lit "-c" ];
+          args = [ Lit ("-c", default_meta) ];
           env = [];
           cwd = None;
           redirects = [];
@@ -749,7 +759,7 @@ let () =
   let ir =
     Simple
       { bin
-      ; args = [ Lit "x" ]
+      ; args = [ Lit ("x", default_meta) ]
       ; env = []
       ; cwd = None
       ; redirects = []

--- a/test/test_exec_shell_command_gate.ml
+++ b/test/test_exec_shell_command_gate.ml
@@ -300,7 +300,7 @@ let test_lower_typed_single_stage () =
         (match Masc_exec.Bin.of_string "rg" with
          | Ok b -> b
          | Error _ -> Alcotest.fail "Bin.of_string rg failed")
-    ; args = [ Masc_exec.Shell_ir.Lit "foo"; Masc_exec.Shell_ir.Lit "lib" ]
+    ; args = [ Masc_exec.Shell_ir.Lit ("foo", Masc_exec.Shell_ir.default_meta); Masc_exec.Shell_ir.Lit ("lib", Masc_exec.Shell_ir.default_meta) ]
     ; env = []
     ; cwd = None
     ; redirects = []
@@ -327,7 +327,7 @@ let make_stage bin args =
       (match Masc_exec.Bin.of_string bin with
        | Ok b -> b
        | Error _ -> Alcotest.failf "Bin.of_string %s failed" bin)
-  ; args = List.map (fun a -> Masc_exec.Shell_ir.Lit a) args
+  ; args = List.map (fun a -> Masc_exec.Shell_ir.Lit (a, Masc_exec.Shell_ir.default_meta)) args
   ; env = []
   ; cwd = None
   ; redirects = []

--- a/test/test_keeper_bash_typed_input.ml
+++ b/test/test_keeper_bash_typed_input.ml
@@ -315,8 +315,8 @@ let test_of_json_stages_alias_reports_stages_path () =
 ;;
 
 let shell_arg_string = function
-  | Masc_exec.Shell_ir.Lit (s, Shell_ir.default_meta) -> s
-  | Masc_exec.Shell_ir.Var (name, Shell_ir.default_meta) -> "$" ^ name
+  | Masc_exec.Shell_ir.Lit (s, _) -> s
+  | Masc_exec.Shell_ir.Var (name, _) -> "$" ^ name
   | Masc_exec.Shell_ir.Concat _ -> "<concat>"
 ;;
 

--- a/test/test_shell_ir_typed_review_followup.ml
+++ b/test/test_shell_ir_typed_review_followup.ml
@@ -34,7 +34,7 @@ let make_simple
       args
   =
   let bin = Result.get_ok (Bin.of_string bin) in
-  let args = List.map (fun s -> Shell_ir.Lit s) args in
+  let args = List.map (fun s -> Shell_ir.Lit (s, Shell_ir.default_meta)) args in
   {
     Shell_ir.bin;
     args;
@@ -65,7 +65,7 @@ let constructor_label = function
 
 let test_env_forces_generic () =
   let simple =
-    make_simple ~env:[ "PATH", Shell_ir.Lit "/tmp" ] "ls" [ "-l" ]
+    make_simple ~env:[ "PATH", Shell_ir.Lit ("/tmp", Shell_ir.default_meta) ] "ls" [ "-l" ]
   in
   let result = Shell_ir_typed.of_simple simple in
   check bool
@@ -99,7 +99,7 @@ let test_non_literal_arg_falls_through_to_generic () =
   let simple_with_var =
     {
       Shell_ir.bin = Result.get_ok (Bin.of_string "ls");
-      args = [ Shell_ir.Var "HOME" ];
+      args = [ Shell_ir.Var ("HOME", Shell_ir.default_meta) ];
       env = [];
       cwd = None;
       redirects = [];
@@ -155,8 +155,8 @@ let test_sudo_round_trip_preserves_quoted_arg () =
   let reconstructed_argv =
     List.map
       (function
-        | Shell_ir.Lit (s, Shell_ir.default_meta) -> s
-        | Shell_ir.Var (_, Shell_ir.default_meta) | Shell_ir.Concat _ -> failwith "unexpected non-lit arg")
+        | Shell_ir.Lit (s, _) -> s
+        | Shell_ir.Var (_, _) | Shell_ir.Concat _ -> failwith "unexpected non-lit arg")
       reconstructed.Shell_ir.args
   in
   check (list string)

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -1373,7 +1373,7 @@ let () =
           let ir =
             Simple
               { bin
-              ; args = [ Lit "/etc/passwd" ]
+              ; args = [ Lit ("/etc/passwd", default_meta) ]
               ; env = []
               ; cwd = None
               ; redirects = []
@@ -1397,7 +1397,7 @@ let () =
           let ir =
             Simple
               { bin
-              ; args = [ Var "DYNAMIC_INPUT" ]
+              ; args = [ Var ("DYNAMIC_INPUT", default_meta) ]
               ; env = []
               ; cwd = None
               ; redirects =
@@ -1444,7 +1444,7 @@ let () =
           let simple bin args =
             Simple
               { bin
-              ; args = List.map (fun arg -> Lit arg) args
+              ; args = List.map (fun arg -> Lit (arg, default_meta)) args
               ; env = []
               ; cwd = None
               ; redirects = []
@@ -1473,7 +1473,7 @@ let () =
           let simple bin args =
             Simple
               { bin
-              ; args = List.map (fun arg -> Lit arg) args
+              ; args = List.map (fun arg -> Lit (arg, default_meta)) args
               ; env = []
               ; cwd = None
               ; redirects = []


### PR DESCRIPTION
## Summary
- expose Shell_ir arg metadata in the interface to match the implementation
- update literal/variable patterns and tests for the metadata-carrying constructors
- remove leftover merge markers in keeper_turn_cascade_budget_event_bus.mli
- fix adjacent main build errors in structured route JSON/schema wiring

## Verification
- ocamlformat --check on touched OCaml files
- git diff --check
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build @check