### PR TITLE
feat(shell): Phase 5 - parser fills arg_meta.quoted

### DIFF
--- a/lib/exec/parser/bash_lexer.mll
+++ b/lib/exec/parser/bash_lexer.mll
@@ -91,8 +91,8 @@ rule token = parse
   | "/dev/null"    { incr_tokens (); DEV_NULL }
   | '\'' "/dev/null" '\'' { incr_tokens (); DEV_NULL }
   | '"' "/dev/null" '"' { incr_tokens (); DEV_NULL }
-  | (word_prefix as prefix) '\'' (sq_body as s) '\'' { incr_tokens (); WORD (prefix ^ s) }
-  | (word_prefix as prefix) '"' (dq_body as s) '"' { incr_tokens (); WORD (prefix ^ s) }
+  | (word_prefix as prefix) '\'' (sq_body as s) '\'' { incr_tokens (); WORD (prefix ^ s, true) }
+  | (word_prefix as prefix) '"' (dq_body as s) '"' { incr_tokens (); WORD (prefix ^ s, true) }
   | '\'' (sq_body as s) '\'' { incr_tokens (); WORD s }
   | '"' (dq_body as s) '"' { incr_tokens (); WORD s }
   | word as w      { incr_tokens (); WORD w }

--- a/lib/exec/parser/bash_subset.mly
+++ b/lib/exec/parser/bash_subset.mly
@@ -24,7 +24,7 @@ let file_redirect fd target mode =
 
    See RFC v5 (docs/rfc/RFC-0005). */
 
-%token <string> WORD
+%token <string * bool> WORD
 %token DEV_NULL
 %token <int * int> FD_REDIRECT
 %token <int * Masc_exec.Redirect_scope.mode> FILE_REDIRECT_OP
@@ -36,7 +36,7 @@ let file_redirect fd target mode =
 %%
 
 literal_word:
-  | value = WORD { value }
+  | value = WORD { fst value }
   | DEV_NULL { "/dev/null" }
 
 part:


### PR DESCRIPTION
Phase 5 follow-up: parser actually fills arg_meta.quoted flag.

- bash_lexer.mll: WORD token carries (string * bool) for quoted
- bash_subset.mly: %token WORD carries tuple
- bash.ml: Shell_ir.Lit receives quoted flag from parser

Next: glob and escaped detection in lexer.