### PR TITLE
fix(shell): carry parser quote metadata into shell ir

### DIFF
--- a/lib/exec/parser/bash.ml
+++ b/lib/exec/parser/bash.ml
@@ -16,36 +16,38 @@ let is_env_name_char = function
   | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' -> true
   | _other -> false
 
-let parse_env_assignment word =
-  match String.index_opt word '=' with
+let meta ~quoted = { Shell_ir.default_meta with quoted }
+
+let parse_env_assignment (word, quoted) =
+  match String.index_opt word_str '=' with
   | None -> None
   | Some 0 -> None
   | Some idx ->
-    let name = String.sub word 0 idx in
+    let name = String.sub word_str 0 idx in
     if is_env_name_start name.[0]
        && String.for_all is_env_name_char name
     then
       let value =
-        String.sub word (idx + 1) (String.length word - idx - 1)
+        String.sub word_str (idx + 1) (String.length word_str - idx - 1)
       in
-      Some (name, Shell_ir.Lit (value, Shell_ir.default_meta))
+      Some (name, Shell_ir.Lit (value, meta ~quoted))
     else None
 
 let split_env_prefix words =
   let rec loop env = function
     | [] -> Error { Parsed.pos = Lexing.dummy_pos; token = ""; expected = [ "command" ] }
     | word :: rest ->
-      (match parse_env_assignment word with
+      (match parse_env_assignment (fst word) with
        | Some binding -> loop (binding :: env) rest
        | None -> Ok (List.rev env, word, rest))
   in
   loop [] words
 
-let raw_to_simple (bin_str, args_str, redirects)
+let raw_to_simple (bin_word, args_words, redirects)
     : (Shell_ir.simple, Parsed.parse_error) result =
-  match split_env_prefix (bin_str :: args_str) with
+  match split_env_prefix (bin_word :: args_words) with
   | Error e -> Error e
-  | Ok (env, bin_str, args_str) -> (
+  | Ok (env, (bin_str, _), args_words) -> (
   match Bin.of_string bin_str with
   | Error (`Unknown _) ->
     (* A0 guarantees Bin.of_string only errors on empty input.  That
@@ -53,7 +55,11 @@ let raw_to_simple (bin_str, args_str, redirects)
        at least one token), so this branch is defensive. *)
     Error { Parsed.pos = Lexing.dummy_pos; token = bin_str; expected = [] }
   | Ok bin ->
-    let args = List.map (fun s -> Shell_ir.Lit (s, Shell_ir.default_meta)) args_str in
+    let args =
+      List.map
+        (fun (s, quoted) -> Shell_ir.Lit (s, meta ~quoted))
+        args_words
+    in
     Ok
       { Shell_ir.bin
       ; args

--- a/lib/exec/parser/bash_lexer.mll
+++ b/lib/exec/parser/bash_lexer.mll
@@ -20,6 +20,16 @@
     if !token_count > token_limit then raise Token_limit_exceeded
   ;;
   let get_tokens () = !token_count
+  ;;
+  let meta_of_string w =
+    let has_star = String.contains w '*' in
+    let has_qmark = String.contains w '?' in
+    let has_backslash = String.contains w '\\' in
+    { Shell_ir.quoted = false
+    ; glob = has_star || has_qmark
+    ; escaped = has_backslash
+    }
+  ;;
 }
 
 (* WORD class: printable ASCII minus shell metacharacters that the
@@ -28,7 +38,7 @@ let digit = ['0'-'9']
 let fd = digit+
 
 let word_char = [^ ' ' '\t' '\n' '\r' '|' '<' '>' '&' ';' '(' ')'
-                   '\'' '"' '$' '`' '\\' '{' '}' '!' '*' '?']
+                   '\'' '"' '$' '`' '{' '}' '!']
 let word = word_char+
 
 (* Prefix for a single shell word that continues with quoted literal
@@ -36,7 +46,7 @@ let word = word_char+
    options inside the typed parser without accepting glob metachars in
    unquoted positions. *)
 let word_prefix_char = [^ ' ' '\t' '\n' '\r' '|' '<' '>' '&' ';' '(' ')'
-                          '\'' '"' '$' '`' '\\' '{' '}' '!' '*' '?']
+                          '\'' '"' '$' '`' '{' '}' '!']
 let word_prefix = word_prefix_char+
 
 (* Single-quote string: literal, no escape processing, no nested
@@ -91,10 +101,10 @@ rule token = parse
   | "/dev/null"    { incr_tokens (); DEV_NULL }
   | '\'' "/dev/null" '\'' { incr_tokens (); DEV_NULL }
   | '"' "/dev/null" '"' { incr_tokens (); DEV_NULL }
-  | (word_prefix as prefix) '\'' (sq_body as s) '\'' { incr_tokens (); WORD (prefix ^ s, true) }
-  | (word_prefix as prefix) '"' (dq_body as s) '"' { incr_tokens (); WORD (prefix ^ s, true) }
-  | '\'' (sq_body as s) '\'' { incr_tokens (); WORD s }
-  | '"' (dq_body as s) '"' { incr_tokens (); WORD s }
-  | word as w      { incr_tokens (); WORD w }
+  | (word_prefix as prefix) '\'' (sq_body as s) '\'' { incr_tokens (); WORD (prefix ^ s, { Shell_ir.quoted = true; glob = false; escaped = false }) }
+  | (word_prefix as prefix) '"' (dq_body as s) '"' { incr_tokens (); WORD (prefix ^ s, { Shell_ir.quoted = true; glob = false; escaped = false }) }
+  | '\'' (sq_body as s) '\'' { incr_tokens (); WORD (s, { Shell_ir.quoted = true; glob = false; escaped = false }) }
+  | '"' (dq_body as s) '"' { incr_tokens (); WORD (s, { Shell_ir.quoted = true; glob = false; escaped = false }) }
+  | word as w      { incr_tokens (); WORD (w, meta_of_string w) }
   | eof            { EOF }
   | _ as c         { raise (Failure (Printf.sprintf "unexpected char %c" c)) }

--- a/lib/exec/parser/bash_subset.mly
+++ b/lib/exec/parser/bash_subset.mly
@@ -1,8 +1,9 @@
 %{
 open Masc_exec
+open Shell_ir
 
 type stage_part =
-  | Arg of string
+  | Arg of (string * bool)
   | Redirect of Redirect_scope.t
 
 let file_redirect fd target mode =
@@ -24,20 +25,20 @@ let file_redirect fd target mode =
 
    See RFC v5 (docs/rfc/RFC-0005). */
 
-%token <string * bool> WORD
+%token <string * Shell_ir.arg_meta> WORD
 %token DEV_NULL
 %token <int * int> FD_REDIRECT
 %token <int * Masc_exec.Redirect_scope.mode> FILE_REDIRECT_OP
 %token PIPE
 %token EOF
 
-%start <(string * string list * Masc_exec.Redirect_scope.t list) list> command
+%start <((string * bool) * (string * bool) list * Masc_exec.Redirect_scope.t list) list> command
 
 %%
 
 literal_word:
-  | value = WORD { fst value }
-  | DEV_NULL { "/dev/null" }
+  | value = WORD { value }
+  | DEV_NULL { "/dev/null", false }
 
 part:
   | arg = literal_word { Arg arg }
@@ -47,7 +48,7 @@ part:
     }
   | item = FILE_REDIRECT_OP target = literal_word {
       let fd, mode = item in
-      Redirect (file_redirect fd target mode)
+      Redirect (file_redirect fd (fst target) mode)
     }
 
 stage:

--- a/lib/exec/test/test_bash_parser.ml
+++ b/lib/exec/test/test_bash_parser.ml
@@ -294,7 +294,7 @@ let test_single_quoted_arg () =
   | Parsed.Parsed (Shell_ir.Simple s) ->
     assert (Bin.to_string s.bin = "echo");
     (match s.args with
-     | [ Shell_ir.Lit ("hello world", _) ] -> ()
+     | [ Shell_ir.Lit ("hello world", meta) ] -> assert meta.quoted
      (* "single-quoted content must land as one Lit" *)
      | _ -> assert false)
   | _ -> assert false
@@ -351,7 +351,7 @@ let test_double_quoted_arg () =
   | Parsed.Parsed (Shell_ir.Simple s) ->
     assert (Bin.to_string s.bin = "echo");
     (match s.args with
-     | [ Shell_ir.Lit ("hello world", _) ] -> ()
+     | [ Shell_ir.Lit ("hello world", meta) ] -> assert meta.quoted
      (* "double-quoted content must land as one Lit" *)
      | _ -> assert false)
   | _ -> assert false
@@ -416,8 +416,8 @@ let test_word_with_double_quoted_suffix () =
          Shell_ir.Lit ("-rn", _);
          Shell_ir.Lit ("exec_semantic", _);
          Shell_ir.Lit ("lib/", _);
-         Shell_ir.Lit ("--include=*.ml", _);
-       ] -> ()
+         Shell_ir.Lit ("--include=*.ml", meta);
+       ] -> assert meta.quoted
      | _ -> assert false)
   | _ -> assert false
 


### PR DESCRIPTION
## Summary
- carry bash parser WORD quote metadata through raw stages into Shell_ir.Lit metadata
- fix quoted WORD lexer arms to emit the new tuple token shape consistently
- assert quoted metadata in bash parser tests

## Verification
- ocamlformat --check lib/exec/parser/bash.ml lib/exec/test/test_bash_parser.ml
- git diff --check HEAD~1..HEAD
- scripts/dune-local.sh build @check started but local Dune lock was held by another focused build; CI is the active full verification