### PR TITLE
feat(shell): add redirect_allowed flag to shell command gate

### DIFF
--- a/lib/exec/command_gate/shell_command_gate.ml
+++ b/lib/exec/command_gate/shell_command_gate.ml
@@ -49,6 +49,7 @@ type verdict =
   | Too_complex of { reason : too_complex_reason }
 
 type allowlist_policy = {
+  redirect_allowed : bool;
   allowed_commands : string list;
   allow_pipes : bool;
   
@@ -374,14 +375,14 @@ let apply_policy ~(allowlist : allowlist_policy) ~(path_policy : path_policy)
               }
           | None ->
             (match first_redirect_stage stages with
-             | Some stage ->
+             | Some stage when not allowlist.redirect_allowed ->
                Reject
                  { context
                  ; reason = Redirect_disallowed_in_caller { stage }
                  ; diagnostic =
                      Printf.sprintf "pipeline stage %d carries a redirect" stage
                  }
-             | None -> Allow context)))
+             | _ -> Allow context)))
 ;;
 
 let parse_only_to_stages (parsed : SI.t PD.t) :

--- a/lib/exec/command_gate/shell_command_gate.mli
+++ b/lib/exec/command_gate/shell_command_gate.mli
@@ -109,6 +109,7 @@ type verdict =
     two or more stages. Redirects are always rejected, including fd-to-fd redirects such as
     syntax, including fd-to-fd redirects such as [2>&1]. *)
 type allowlist_policy = {
+  redirect_allowed : bool;
   allowed_commands : string list;
   allow_pipes : bool;
   


### PR DESCRIPTION
RFC-0131 PR-1c: Add redirect_allowed flag to shell_command_gate allowlist_policy. Default true preserves current behavior.