### PR TITLE
refactor(policy): consolidate policy ownership and wire structured routes

### DIFF
--- a/lib/exec_policy.ml
+++ b/lib/exec_policy.ml
@@ -830,3 +830,41 @@ let is_destructive_bash_operation = Mutation_classifier.is_destructive_bash_oper
 
 let sanitize_command_for_log = Log_sanitize.sanitize_command_for_log
 let truncate_for_log = Log_sanitize.truncate_for_log
+
+let block_reason_tag = function
+  | Empty_command -> "empty_command"
+  | Chain_or_redirect -> "chain_or_redirect"
+  | Injection -> "injection"
+  | Process_substitution -> "process_substitution"
+  | Unsafe_redirect -> "unsafe_redirect"
+  | Pipes_not_allowed -> "pipes_not_allowed"
+  | Direct_dune_invocation -> "direct_dune_invocation"
+  | Command_not_allowed _ -> "command_not_allowed"
+;;
+
+let attribution_of_validation ~cmd (result : (unit, block_reason) result) : Attribution.t =
+  match result with
+  | Ok () ->
+    let evidence : Yojson.Safe.t = `Assoc [ "cmd", `String cmd ] in
+    Attribution.passed ~origin:Det ~gate:"exec_policy" ~evidence
+  | Error br ->
+    let command_name =
+      match br with
+      | Command_not_allowed name -> Some name
+      | Direct_dune_invocation -> Some "dune"
+      | _ -> None
+    in
+    let evidence : Yojson.Safe.t =
+      `Assoc
+        ([ "cmd", `String cmd; "block_reason", `String (block_reason_tag br) ]
+         @
+         match command_name with
+         | Some n -> [ "command_name", `String n ]
+         | None -> [])
+    in
+    Attribution.policy_failed
+      ~origin:Det
+      ~gate:"exec_policy"
+      ~evidence
+      ~reason:(block_reason_to_string br)
+;;

--- a/lib/exec_policy.mli
+++ b/lib/exec_policy.mli
@@ -82,3 +82,8 @@ val is_destructive_bash_operation : string -> bool
 
 val sanitize_command_for_log : string -> string
 val truncate_for_log : ?max_len:int -> string -> string
+
+val block_reason_tag : block_reason -> string
+
+val attribution_of_validation :
+  cmd:string -> (unit, block_reason) result -> Attribution.t

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -1042,6 +1042,7 @@ let prepare_agent_setup
     ; query_text
     }
   in
+  Keeper_tool_alias.register_structured_routes ();
   let initial_tool_surface =
     compute_tool_surface
       ~turn:(start_turn_count + 1)

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -273,44 +273,6 @@ let make_file_write ?workdir ?on_exec () =
    validation callsite can record the attribution without forward
    referencing. *)
 
-let block_reason_tag = function
-  | Empty_command -> "empty_command"
-  | Chain_or_redirect -> "chain_or_redirect"
-  | Injection -> "injection"
-  | Process_substitution -> "process_substitution"
-  | Unsafe_redirect -> "unsafe_redirect"
-  | Pipes_not_allowed -> "pipes_not_allowed"
-  | Direct_dune_invocation -> "direct_dune_invocation"
-  | Command_not_allowed _ -> "command_not_allowed"
-;;
-
-let attribution_of_validation ~cmd (result : (unit, block_reason) result) : Attribution.t =
-  match result with
-  | Ok () ->
-    let evidence : Yojson.Safe.t = `Assoc [ "cmd", `String cmd ] in
-    Attribution.passed ~origin:Det ~gate:"worker_dev_tools" ~evidence
-  | Error br ->
-    let command_name =
-      match br with
-      | Command_not_allowed name -> Some name
-      | Direct_dune_invocation -> Some "dune"
-      | _ -> None
-    in
-    let evidence : Yojson.Safe.t =
-      `Assoc
-        ([ "cmd", `String cmd; "block_reason", `String (block_reason_tag br) ]
-         @
-         match command_name with
-         | Some n -> [ "command_name", `String n ]
-         | None -> [])
-    in
-    Attribution.policy_failed
-      ~origin:Det
-      ~gate:"worker_dev_tools"
-      ~evidence
-      ~reason:(block_reason_to_string br)
-;;
-
 let shell_ir_with_default_cwd cwd ir =
   match cwd with
   | None -> ir
@@ -431,7 +393,7 @@ let make_shell_exec_with_allowlist
            command_context_with_allowlist ~allowed_commands command
          in
          let validation = Result.map (fun _ -> ()) command_context in
-         Dashboard_attribution.record (attribution_of_validation ~cmd:command validation);
+         Dashboard_attribution.record (Exec_policy.attribution_of_validation ~cmd:command validation);
          (match command_context with
           | Error reason ->
             (* #13078: emit [command_blocked] telemetry so observers


### PR DESCRIPTION
- Move block_reason_tag and attribution_of_validation from worker_dev_tools.ml to Exec_policy.ml\n- Wire Keeper_tool_alias.register_structured_routes in keeper_run_tools.ml