### PR TITLE
refactor(mcp): stop treating agent_name as caller identity

### DIFF
--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -687,17 +687,13 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
     | None -> `Null
   in
 
-  (* Resolve agent_name for telemetry.  HTTP auth injects [_agent_name] as
-     the canonical caller; legacy [agent_name] may be a tool-domain target. *)
+  (* Resolve caller identity for telemetry.  HTTP auth injects [_agent_name];
+     tool-domain [agent_name] is not a caller identity. *)
   let agent_name =
     let from_transport =
       Safe_ops.json_string ~default:"" "_agent_name" arguments
     in
-    let from_legacy =
-      Safe_ops.json_string ~default:"" "agent_name" arguments
-    in
     if from_transport <> "" then from_transport
-    else if from_legacy <> "" then from_legacy
     else
       let identity =
         Agent_registry_eio.get_or_create_identity ?mcp_session_id arguments

--- a/lib/mcp_server_eio_caller_identity.ml
+++ b/lib/mcp_server_eio_caller_identity.ml
@@ -26,7 +26,7 @@ let caller_agent_name_from_arguments arguments =
   in
   match nonempty_nonunknown "_agent_name" with
   | Some _ as value -> value
-  | None -> nonempty_nonunknown "agent_name"
+  | None -> None
 
 let direct_call_block_message name =
   if Tool_catalog.is_on_surface Tool_catalog.Keeper_internal name then (

--- a/lib/mcp_server_eio_execute.mli
+++ b/lib/mcp_server_eio_execute.mli
@@ -7,8 +7,8 @@
       [test/test_mcp_server_eio.ml] exercises the join-required
       decisions to keep alias handling consistent across refactors.
     - {!caller_agent_name_from_arguments} — isolates the
-      HTTP [_agent_name] vs legacy [agent_name] precedence
-      contract without running the full dispatcher.
+      HTTP [_agent_name] caller identity contract without running
+      the full dispatcher.
     - {!execute_tool_eio} — invoked by
       [lib/server/server_runtime_bootstrap.ml] and threaded
       through {!Mcp_server_eio_call_tool.handle_call_tool_eio}
@@ -52,10 +52,9 @@ val resolve_join_state :
 
 val caller_agent_name_from_arguments : Yojson.Safe.t -> string option
 (** Returns the explicit caller identity carried in [tools/call]
-    arguments.  The internal HTTP-auth marker [_agent_name] wins
-    over legacy [agent_name]; legacy [agent_name] remains the fallback
-    for direct callers and old MCP clients.  Blank and ["unknown"]
-    values are ignored. *)
+    arguments.  Only the internal HTTP-auth marker [_agent_name] is
+    accepted; tool-domain [agent_name] arguments are not caller
+    identity.  Blank and ["unknown"] values are ignored. *)
 
 (** {1 Test hooks} *)
 

--- a/lib/server/server_mcp_actor_injection.ml
+++ b/lib/server/server_mcp_actor_injection.ml
@@ -4,8 +4,8 @@
     must be overwritten. The legacy argument-scoped [token] is also removed
     when HTTP auth is present so stale MCP bodies cannot override the
     transport token; without HTTP auth, caller identity resolution ignores the
-    argument token. Legacy [agent_name] is left untouched because some tools use
-    it as a domain argument rather than caller identity. *)
+    argument token. Tool-domain [agent_name] is left untouched because some
+    tools use it as a target argument rather than caller identity. *)
 let inject_agent_name_into_body ?(rewrite_existing = false) ?(strip_token = false)
     ~agent_name body_str =
   try
@@ -26,7 +26,7 @@ let inject_agent_name_into_body ?(rewrite_existing = false) ?(strip_token = fals
               else
                 Some trimmed)
         in
-        let existing_legacy_agent =
+        let existing_tool_agent_name =
           Option.bind
             (member "agent_name" args |> to_string_option)
             (fun value ->
@@ -56,7 +56,7 @@ let inject_agent_name_into_body ?(rewrite_existing = false) ?(strip_token = fals
               let should_inject =
                 rewrite_existing
                 || (Option.is_none existing_agent
-                   && Option.is_none existing_legacy_agent)
+                   && Option.is_none existing_tool_agent_name)
               in
               if should_inject then
                 `Assoc (("_agent_name", `String agent_name) :: normalized_fields)

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -2068,10 +2068,10 @@ let test_transport_route_contracts () =
   check bool "frontend exposes ws discovery route" true
     (file_contains_pattern "lib/server/server_routes_http_routes_frontend.ml"
        {|Http.Router.get "/ws" websocket_discovery_handler|});
-  check bool "mcp http agent injection preserves explicit legacy agent_name" true
-    (file_contains_pattern "lib/server/server_mcp_transport_http.ml"
+  check bool "mcp http agent injection preserves tool target agent_name" true
+    (file_contains_pattern "lib/server/server_mcp_actor_injection.ml"
        {|Option.is_none existing_agent
-                    && Option.is_none existing_legacy_agent|});
+                    && Option.is_none existing_tool_agent_name|});
   check bool "h2 mcp post injects canonical http actor" true
     (file_contains_pattern "lib/server/server_h2_gateway.ml"
        "body_with_canonical_http_actor");

--- a/test/test_mcp_post_sse_e2e.ml
+++ b/test/test_mcp_post_sse_e2e.ml
@@ -402,12 +402,12 @@ let rec join_until_ready ~port ~retries_left =
       join_until_ready ~port ~retries_left:(retries - 1)
   | _ -> result
 
-let test_post_tools_call_preserves_explicit_legacy_agent_name () =
+let test_post_tools_call_preserves_explicit_tool_agent_name () =
   with_server @@ fun ~port ->
   let result = join_until_ready ~port ~retries_left:40 in
-  require_http_ok "legacy agent_name preservation tools/call" result;
+  require_http_ok "tool agent_name preservation tools/call" result;
   check int "curl exits cleanly" 0 result.curl_exit;
-  let json = parse_json_body "legacy agent_name preservation tools/call" result in
+  let json = parse_json_body "tool agent_name preservation tools/call" result in
   check bool "json-rpc error absent" true (json |> U.member "error" = `Null);
   check bool "tool succeeded" false
     (json |> U.member "result" |> U.member "isError" |> U.to_bool);
@@ -415,9 +415,9 @@ let test_post_tools_call_preserves_explicit_legacy_agent_name () =
     json |> U.member "result" |> U.member "content" |> U.index 0
     |> U.member "text" |> U.to_string
   in
-  check bool "explicit legacy agent_name preserved" true
+  check bool "explicit tool agent_name preserved" true
     (contains_substr "Type: gemini" text);
-  check bool "header actor not injected over explicit legacy agent_name" false
+  check bool "header actor not used as tool target agent_name" false
     (contains_substr "Type: dashboard-header-actor" text)
 
 let () =
@@ -427,7 +427,7 @@ let () =
         [
           test_case "post tools/call streams sse framing" `Slow
             test_post_tools_call_streams_sse_framing;
-          test_case "post tools/call preserves explicit legacy agent_name"
-            `Slow test_post_tools_call_preserves_explicit_legacy_agent_name;
+          test_case "post tools/call preserves explicit tool agent_name"
+            `Slow test_post_tools_call_preserves_explicit_tool_agent_name;
         ] );
     ]

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1277,13 +1277,13 @@ let test_execute_tool_explicit_agent_name_not_overridden () =
     resolve (`Assoc [ ("agent_name", `String "codex") ])
   in
   Alcotest.(check string)
-    "explicit agent_name wins over stale cache"
-    "codex" codex.agent_name;
+    "tool-domain agent_name does not override cached caller"
+    "cached-stale-nickname" codex.agent_name;
   let gemini =
     resolve (`Assoc [ ("_agent_name", `String "gemini"); ("agent_name", `String "codex") ])
   in
   Alcotest.(check string)
-    "internal _agent_name wins over legacy agent_name"
+    "internal _agent_name is caller over tool-domain agent_name"
     "gemini" gemini.agent_name;
   let cached = resolve (`Assoc []) in
   Alcotest.(check string)
@@ -1346,13 +1346,13 @@ let test_execute_tool_generated_agent_name_uses_token_identity () =
 
   cleanup_dir base_path
 
-let test_execute_tool_internal_agent_name_overrides_legacy_arg () =
+let test_execute_tool_internal_agent_name_is_caller_identity () =
   let resolve args =
     Masc_mcp.Mcp_server_eio_caller_identity.caller_agent_name_from_arguments
       args
   in
   Alcotest.(check (option string))
-    "_agent_name wins over legacy agent_name"
+    "_agent_name is caller over tool-domain agent_name"
     (Some "stable-admin")
     (resolve
        (`Assoc
@@ -1361,12 +1361,12 @@ let test_execute_tool_internal_agent_name_overrides_legacy_arg () =
            ("agent_name", `String "claude");
          ]));
   Alcotest.(check (option string))
-    "legacy agent_name remains fallback"
-    (Some "claude")
+    "agent_name is not caller fallback"
+    None
     (resolve (`Assoc [ ("agent_name", `String "claude") ]));
   Alcotest.(check (option string))
-    "unknown internal marker falls back to legacy"
-    (Some "claude")
+    "unknown internal marker does not fall back to agent_name"
+    None
     (resolve
        (`Assoc
          [
@@ -2784,8 +2784,8 @@ let eio_tests = [
   "explicit alias reuses joined nickname", `Quick, test_execute_tool_explicit_alias_reuses_joined_nickname;
   "generated agent_name uses token identity", `Quick,
     test_execute_tool_generated_agent_name_uses_token_identity;
-  "internal _agent_name overrides legacy agent_name", `Quick,
-    test_execute_tool_internal_agent_name_overrides_legacy_arg;
+  "internal _agent_name is caller identity", `Quick,
+    test_execute_tool_internal_agent_name_is_caller_identity;
   "explicit generated alias claim_next not rewritten by token", `Quick,
     test_execute_tool_explicit_generated_alias_claim_next_not_rewritten_by_token;
   "explicit generated alias transition not rewritten by token", `Quick,

--- a/test/test_mcp_session_coverage.ml
+++ b/test/test_mcp_session_coverage.ml
@@ -178,7 +178,7 @@ let test_inject_agent_name_adds_internal_actor_when_missing () =
   check (option int) "keeps other args" (Some 7)
     (member "days" args |> to_int_option)
 
-let test_inject_agent_name_preserves_legacy_target_by_default () =
+let test_inject_agent_name_preserves_tool_target_by_default () =
   let body =
     {|{"jsonrpc":"2.0","method":"tools/call","params":{"name":"masc_agent_fitness","arguments":{"agent_name":"target-keeper","days":7}},"id":1}|}
   in
@@ -189,7 +189,7 @@ let test_inject_agent_name_preserves_legacy_target_by_default () =
   let open Yojson.Safe.Util in
   check (option string) "does not add _agent_name" None
     (member "_agent_name" args |> to_string_option);
-  check (option string) "keeps legacy agent_name" (Some "target-keeper")
+  check (option string) "keeps tool target agent_name" (Some "target-keeper")
     (member "agent_name" args |> to_string_option)
 
 let test_inject_agent_name_rewrites_internal_actor_only () =
@@ -386,8 +386,8 @@ let () =
     "inject_agent_name", [
       test_case "adds internal actor when missing" `Quick
         test_inject_agent_name_adds_internal_actor_when_missing;
-      test_case "preserves legacy target by default" `Quick
-        test_inject_agent_name_preserves_legacy_target_by_default;
+      test_case "preserves tool target by default" `Quick
+        test_inject_agent_name_preserves_tool_target_by_default;
       test_case "rewrite_existing only rewrites _agent_name" `Quick
         test_inject_agent_name_rewrites_internal_actor_only;
       test_case "reducer skips absent actor" `Quick


### PR DESCRIPTION
## Summary
- stop resolving caller identity from tool-domain `agent_name`; only `_agent_name` is an explicit tools/call caller marker
- keep tool-domain `agent_name` preservation for tools that use it as a target argument
- update telemetry caller resolution and source-level tests away from legacy caller fallback semantics

## Validation
- `ocamlformat --check lib/mcp_server_eio_call_tool.ml lib/mcp_server_eio_caller_identity.ml lib/mcp_server_eio_execute.mli lib/server/server_mcp_actor_injection.ml test/test_ci_hardening_source.ml test/test_mcp_post_sse_e2e.ml test/test_mcp_server_eio.ml test/test_mcp_session_coverage.ml`
- `git diff --check`
- `scripts/ocaml-structure-ratchet.sh`
- attempted `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_mcp_server_eio.exe test/test_mcp_session_coverage.exe test/test_mcp_post_sse_e2e.exe test/test_ci_hardening_source.exe`; blocked before target validation by existing base error: `lib/exec/parser/bash_lexer.mll:96` expected `string * bool` but got `string`
