### PR TITLE
fix(shell): align parser metadata tuple types

### DIFF
--- a/lib/exec/parser/bash.ml
+++ b/lib/exec/parser/bash.ml
@@ -16,9 +16,7 @@ let is_env_name_char = function
   | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '_' -> true
   | _other -> false
 
-let meta ~quoted = { Shell_ir.default_meta with quoted }
-
-let parse_env_assignment (word, quoted) =
+let parse_env_assignment (word_str, meta) =
   match String.index_opt word_str '=' with
   | None -> None
   | Some 0 -> None
@@ -30,14 +28,14 @@ let parse_env_assignment (word, quoted) =
       let value =
         String.sub word_str (idx + 1) (String.length word_str - idx - 1)
       in
-      Some (name, Shell_ir.Lit (value, meta ~quoted))
+      Some (name, Shell_ir.Lit (value, meta))
     else None
 
 let split_env_prefix words =
   let rec loop env = function
     | [] -> Error { Parsed.pos = Lexing.dummy_pos; token = ""; expected = [ "command" ] }
     | word :: rest ->
-      (match parse_env_assignment (fst word) with
+      (match parse_env_assignment word with
        | Some binding -> loop (binding :: env) rest
        | None -> Ok (List.rev env, word, rest))
   in
@@ -56,9 +54,7 @@ let raw_to_simple (bin_word, args_words, redirects)
     Error { Parsed.pos = Lexing.dummy_pos; token = bin_str; expected = [] }
   | Ok bin ->
     let args =
-      List.map
-        (fun (s, quoted) -> Shell_ir.Lit (s, meta ~quoted))
-        args_words
+      List.map (fun (s, meta) -> Shell_ir.Lit (s, meta)) args_words
     in
     Ok
       { Shell_ir.bin
@@ -80,7 +76,11 @@ let rec map_stages = function
         | Ok tail -> Ok (simple :: tail)))
 
 let to_shell_ir
-      (stages : (string * string list * Redirect_scope.t list) list)
+      (stages :
+        ( (string * Shell_ir.arg_meta)
+        * (string * Shell_ir.arg_meta) list
+        * Redirect_scope.t list )
+        list)
     : Shell_ir.t Parsed.t =
   match map_stages stages with
   | Error e -> Parsed.Parse_error e

--- a/lib/exec/parser/bash_lexer.mll
+++ b/lib/exec/parser/bash_lexer.mll
@@ -7,6 +7,7 @@
 
 {
   open Bash_subset
+  open Masc_exec
 
   (* Token budget — each lexeme increments a counter.  The 50k ceiling
      is enforced in the lexer so large inputs abort before Menhir builds

--- a/lib/exec/parser/bash_subset.mly
+++ b/lib/exec/parser/bash_subset.mly
@@ -1,9 +1,8 @@
 %{
 open Masc_exec
-open Shell_ir
 
 type stage_part =
-  | Arg of (string * bool)
+  | Arg of (string * Masc_exec.Shell_ir.arg_meta)
   | Redirect of Redirect_scope.t
 
 let file_redirect fd target mode =
@@ -25,20 +24,20 @@ let file_redirect fd target mode =
 
    See RFC v5 (docs/rfc/RFC-0005). */
 
-%token <string * Shell_ir.arg_meta> WORD
+%token <string * Masc_exec.Shell_ir.arg_meta> WORD
 %token DEV_NULL
 %token <int * int> FD_REDIRECT
 %token <int * Masc_exec.Redirect_scope.mode> FILE_REDIRECT_OP
 %token PIPE
 %token EOF
 
-%start <((string * bool) * (string * bool) list * Masc_exec.Redirect_scope.t list) list> command
+%start <((string * Masc_exec.Shell_ir.arg_meta) * (string * Masc_exec.Shell_ir.arg_meta) list * Masc_exec.Redirect_scope.t list) list> command
 
 %%
 
 literal_word:
   | value = WORD { value }
-  | DEV_NULL { "/dev/null", false }
+  | DEV_NULL { "/dev/null", Masc_exec.Shell_ir.default_meta }
 
 part:
   | arg = literal_word { Arg arg }


### PR DESCRIPTION
## Summary
- keep bash parser WORD tuples as Shell_ir.arg_meta through Menhir output
- preserve lexer metadata for env prefix values and argv literals
- fully qualify parser token types so generated parser builds in CI

## Verification
- ocamlformat --check lib/exec/parser/bash.ml lib/exec/parser/bash_subset.mly lib/exec/parser/bash_lexer.mll
- git diff --check
- local scripts/dune-local.sh build @check was attempted on the previous branch but blocked by the shared /tmp/me-dune-local.lock; CI is the active build verification for this follow-up