### PR TITLE
refactor(goal): require structured task goal links

### DIFF
--- a/lib/coord/coord_task_capacity.ml
+++ b/lib/coord/coord_task_capacity.ml
@@ -13,34 +13,10 @@ type capacity_error = {
 
 let default_goal_open_limit = 3
 
-(* [task_matches_goal] is duplicated from [lib/goal/convergence.ml] because
-   that module is part of the [masc_mcp] library, which depends on
-   [masc_coord] — we cannot pull it in here without a dependency cycle.
-   The logic is pure (no external state) and trivially mirrors the
-   upstream definition: structured [goal_id] match, falling back to the
-   legacy [[goal:<id>]] title marker. Keep both in sync. *)
-let goal_title_marker goal_id = Printf.sprintf "[goal:%s]" goal_id
-
-let title_has_goal_marker ~goal_id title =
-  let tag = goal_title_marker goal_id in
-  let title_lower = String.lowercase_ascii title in
-  let tag_lower = String.lowercase_ascii tag in
-  let tag_len = String.length tag_lower in
-  let title_len = String.length title_lower in
-  if tag_len > title_len then false
-  else
-    let found = ref false in
-    for i = 0 to title_len - tag_len do
-      if not !found && String.sub title_lower i tag_len = tag_lower
-      then found := true
-    done;
-    !found
-;;
-
 let task_matches_goal ~goal_id (task : Masc_domain.task) =
   match task.goal_id with
   | Some linked_goal_id -> String.equal linked_goal_id goal_id
-  | None -> title_has_goal_marker ~goal_id task.title
+  | None -> false
 ;;
 
 let open_task_count_for_goal (backlog : Masc_domain.backlog) ~goal_id =

--- a/lib/coord_goals.ml
+++ b/lib/coord_goals.ml
@@ -428,7 +428,6 @@ let handle_goal_upsert ~tool_name ~start_time (ctx : context) args : Tool_result
             | `created -> "created"
             | `updated -> "updated"
           in
-          let task_marker = Printf.sprintf "[goal:%s]" goal.id in
           ok_result
             ~tool_name
             ~start_time
@@ -442,10 +441,9 @@ let handle_goal_upsert ~tool_name ~start_time (ctx : context) args : Tool_result
                      goal.title
                      goal.id) )
             ; "task_link_field", `String "goal_id"
-            ; "task_link_mode", `String "structured_with_legacy_title_marker"
-            ; "task_title_marker", `String task_marker
+            ; "task_link_mode", `String "structured_goal_id"
             ; ( "linked_task_title_example"
-              , `String (Printf.sprintf "%s[child] %s" task_marker goal.title) )
+              , `String (Printf.sprintf "[child] %s" goal.title) )
             ]))
 ;;
 

--- a/lib/dashboard/dashboard_goals_types_accessor.ml
+++ b/lib/dashboard/dashboard_goals_types_accessor.ml
@@ -51,9 +51,7 @@ let task_is_linked_to_goal (task : Masc_domain.task) goal_id =
 let task_linkage_source_opt (task : Masc_domain.task) goal_id =
   match task.goal_id with
   | Some task_goal_id when String.equal task_goal_id goal_id -> Some "explicit"
-  | Some _ -> None
-  | None ->
-      if task_is_linked_to_goal task goal_id then Some "title_tag" else None
+  | Some _ | None -> None
 
 let task_assignee (task : Masc_domain.task) : string option =
   Masc_domain.task_assignee_of_status task.task_status

--- a/lib/goal/convergence.ml
+++ b/lib/goal/convergence.ml
@@ -32,36 +32,13 @@ let convergence_signal_to_yojson = function
           ("iterations_without_progress", `Int iterations_without_progress);
         ]
 
-let goal_title_marker goal_id =
-  Printf.sprintf "[goal:%s]" goal_id
-
-let title_has_goal_marker ~goal_id title =
-  let tag = goal_title_marker goal_id in
-  let title_lower = String.lowercase_ascii title in
-  let tag_lower = String.lowercase_ascii tag in
-  (* Simple substring search *)
-  let tag_len = String.length tag_lower in
-  let title_len = String.length title_lower in
-  if tag_len > title_len then false
-  else
-    let found = ref false in
-    for i = 0 to title_len - tag_len do
-      if not !found then
-        if String.sub title_lower i tag_len = tag_lower then found := true
-    done;
-    !found
-
 let task_has_goal_id ~goal_id (task : Masc_domain.task) =
   match task.goal_id with
   | Some linked_goal_id -> String.equal linked_goal_id goal_id
   | None -> false
 
-(** A task belongs to a goal when its structured goal_id matches or its title
-    carries the legacy [goal:<id>] marker. *)
 let task_matches_goal ~goal_id (task : Masc_domain.task) =
-  match task.goal_id with
-  | Some _ -> task_has_goal_id ~goal_id task
-  | None -> title_has_goal_marker ~goal_id task.title
+  task_has_goal_id ~goal_id task
 
 let is_terminal (task : Masc_domain.task) =
   Masc_domain.task_status_is_terminal task.task_status

--- a/lib/goal/convergence.mli
+++ b/lib/goal/convergence.mli
@@ -12,17 +12,11 @@ type convergence_signal =
 (** Serialize a convergence signal to JSON. *)
 val convergence_signal_to_yojson : convergence_signal -> Yojson.Safe.t
 
-(** Legacy title marker retained for backward compatibility. *)
-val goal_title_marker : string -> string
-
-(** True when the task is structurally linked to the goal or carries the
-    legacy [[goal:<id>]] title marker. *)
+(** True when the task's structured [goal_id] field matches. *)
 val task_matches_goal : goal_id:string -> Masc_domain.task -> bool
 
-(** True only when the task's structured [goal_id] field matches.
-
-    New read models should prefer this over {!task_matches_goal}; the latter is
-    retained for legacy convergence compatibility with old title-marker tasks. *)
+(** Alias for {!task_matches_goal}; retained for call sites that need the
+    predicate name to be explicit about structured linkage. *)
 val task_has_goal_id : goal_id:string -> Masc_domain.task -> bool
 
 (** Check whether a goal's tasks have converged.
@@ -31,9 +25,8 @@ val task_has_goal_id : goal_id:string -> Masc_domain.task -> bool
     [None] when work is still in progress.
 
     @param goal_id  The goal whose tasks to evaluate.
-    @param tasks    All tasks in the room (filtered internally by explicit
-                    [task.goal_id], with legacy title-tag fallback when
-                    [goal_id] is absent).
+    @param tasks    All tasks in the room, filtered internally by explicit
+                    [task.goal_id].
     @param stagnation_threshold  Number of iterations without progress before
                                  emitting [StagnationDetected]. Defaults to [5].
     @param iterations_without_progress  Current count of iterations with no task

--- a/lib/goal/goal_janitor.ml
+++ b/lib/goal/goal_janitor.ml
@@ -114,10 +114,7 @@ let task_age_seconds ?(now = Unix.gettimeofday ()) (task : Masc_domain.task) =
 let task_has_current_goal_link ~valid_goal_ids (task : Masc_domain.task) =
   match task.goal_id with
   | Some goal_id -> List.mem goal_id valid_goal_ids
-  | None ->
-      List.exists
-        (fun goal_id -> Convergence.task_matches_goal ~goal_id task)
-        valid_goal_ids
+  | None -> false
 
 let audit_unclaimed_goal_orphan_tasks ?(now = Unix.gettimeofday ())
     ~valid_goal_ids ~min_age_seconds (tasks : Masc_domain.task list) =

--- a/lib/goal/goal_janitor.mli
+++ b/lib/goal/goal_janitor.mli
@@ -70,7 +70,7 @@ val prune_active_goal_ids :
 
 (** [audit_unclaimed_goal_orphan_tasks ~valid_goal_ids
     ~min_age_seconds tasks] returns stale [Todo] tasks with no structured
-    [goal_id] and no current legacy title-tag linkage. *)
+    [goal_id] linkage. *)
 val audit_unclaimed_goal_orphan_tasks :
   ?now:float ->
   valid_goal_ids:string list ->

--- a/lib/tool_schemas/tool_schemas_coord_extra.ml
+++ b/lib/tool_schemas/tool_schemas_coord_extra.ml
@@ -79,7 +79,7 @@ let schemas : tool_schema list =
       description =
         "List shared planning goals from the Goal Store, optionally filtered by horizon, explicit phase, or legacy status. \
 Use when a PM/planner agent needs current long/mid/short goals before creating tasks or reviews. \
-The dashboard Goal Tree reads the same store. Linked tasks prefer structured task.goal_id; title tags like [goal:<id>] remain a legacy fallback. \
+The dashboard Goal Tree reads the same store. Linked tasks require structured task.goal_id. \
 The response includes each goal's explicit lifecycle phase and verification policy.";
       input_schema =
         `Assoc
@@ -100,7 +100,7 @@ The response includes each goal's explicit lifecycle phase and verification poli
       description =
         "Create or update a shared Goal Store entry used by Planning > Goal Tree. \
 For new goals, provide at least title; omitted horizon defaults to short. \
-After creation, link tasks into the tree with task.goal_id=<goal_id>; legacy [goal:<id>] title markers remain supported for compatibility. \
+After creation, link tasks into the tree with task.goal_id=<goal_id>. \
 Use this tool for goal metadata, parent linkage, and verifier-policy configuration. \
 Lifecycle status/phase fields are intentionally omitted here; use masc_goal_transition / masc_goal_verify for lifecycle moves.";
       input_schema =

--- a/lib/tool_shard_types_schemas_taskboard.ml
+++ b/lib/tool_shard_types_schemas_taskboard.ml
@@ -251,8 +251,7 @@ let taskboard_tools : Masc_domain.tool_schema list =
                       [ "type", `String "string"
                       ; ( "description"
                         , `String
-                            "Optional structured goal linkage. Preferred over relying \
-                             only on [goal:<id>] in the title." )
+                            "Optional structured goal linkage." )
                       ] )
                 ; ( "contract"
                   , `Assoc

--- a/test/test_coordination_product.ml
+++ b/test/test_coordination_product.ml
@@ -215,17 +215,17 @@ let test_duplicate_active_claim_violation () =
   check_has_code "duplicate_active_claim_owners" violations
 ;;
 
-let test_goal_linkage_prefers_structured_goal_id () =
+let test_goal_linkage_requires_structured_goal_id () =
   let explicit =
     task ~id:"task-1" ~title:"Implement product FSM" ~goal_id:"goal-1" ()
   in
-  let legacy =
-    task ~id:"task-2" ~title:"[goal:goal-1] legacy marker" ()
+  let title_marker_only =
+    task ~id:"task-2" ~title:"[goal:goal-1] title marker" ()
   in
   let explicit_other_with_legacy_marker =
     task
       ~id:"task-3"
-      ~title:"[goal:goal-1] stale legacy marker"
+      ~title:"[goal:goal-1] stale title marker"
       ~goal_id:"goal-2"
       ()
   in
@@ -234,15 +234,15 @@ let test_goal_linkage_prefers_structured_goal_id () =
     true
     (Convergence.task_has_goal_id ~goal_id:"goal-1" explicit);
   Alcotest.(check bool)
-    "legacy marker does not satisfy structured matcher"
+    "title marker does not satisfy structured matcher"
     false
-    (Convergence.task_has_goal_id ~goal_id:"goal-1" legacy);
+    (Convergence.task_has_goal_id ~goal_id:"goal-1" title_marker_only);
   Alcotest.(check bool)
-    "legacy matcher remains backward compatible"
-    true
-    (Convergence.task_matches_goal ~goal_id:"goal-1" legacy);
+    "title marker does not satisfy goal matcher"
+    false
+    (Convergence.task_matches_goal ~goal_id:"goal-1" title_marker_only);
   Alcotest.(check bool)
-    "structured goal_id wins over stale title marker"
+    "structured goal_id ignores stale title marker"
     false
     (Convergence.task_matches_goal ~goal_id:"goal-1" explicit_other_with_legacy_marker)
 ;;
@@ -458,7 +458,7 @@ let () =
       , [ Alcotest.test_case
             "structured goal_id matcher"
             `Quick
-            test_goal_linkage_prefers_structured_goal_id
+            test_goal_linkage_requires_structured_goal_id
         ] )
     ; ( "invariants"
       , [ Alcotest.test_case

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -370,26 +370,21 @@ let test_cancelled_only_goal_is_at_risk () =
   check int "linkage warning count" 1
     (node |> member "linkage_warning_count" |> to_int)
 
-let test_title_marker_links_legacy_task () =
+let test_title_marker_does_not_link_task () =
   with_room @@ fun config ->
   let goal, _kind =
-    match Goal_store.upsert_goal config ~title:"Legacy marker goal" () with
+    match Goal_store.upsert_goal config ~title:"Title marker goal" () with
     | Ok payload -> payload
     | Error msg -> fail msg
   in
   ignore
     (Coord_task.add_task config
-       ~title:(Printf.sprintf "[goal:%s] Legacy task" goal.id)
-       ~priority:3 ~description:"legacy title marker");
+       ~title:(Printf.sprintf "[goal:%s] Title marker task" goal.id)
+       ~priority:3 ~description:"title marker only");
   let node = Dashboard_goals.dashboard_goals_tree_json ~config |> root_node in
-  let task =
-    match node |> member "tasks" |> to_list with
-    | task :: _ -> task
-    | [] -> fail "expected linked title-marker task"
-  in
-  check string "legacy linkage source" "title_tag"
-    (task |> member "linkage_source" |> to_string);
-  check string "node linkage source" "title_tag"
+  check int "title marker task not linked" 0
+    (node |> member "tasks" |> to_list |> List.length);
+  check string "node linkage source" "none"
     (node |> member "linkage_source" |> to_string)
 
 let test_goal_attainment_projects_percent_target () =
@@ -1125,8 +1120,8 @@ let () =
             test_open_task_without_keeper_is_at_risk;
           test_case "cancelled-only goal is at risk" `Quick
             test_cancelled_only_goal_is_at_risk;
-          test_case "title marker links legacy task" `Quick
-            test_title_marker_links_legacy_task;
+          test_case "title marker does not link task" `Quick
+            test_title_marker_does_not_link_task;
           test_case "goal attainment projects percent targets" `Quick
             test_goal_attainment_projects_percent_target;
           test_case "goal attainment exports prometheus metric" `Quick

--- a/test/test_goal_janitor.ml
+++ b/test/test_goal_janitor.ml
@@ -168,22 +168,22 @@ let test_escalate_stale_unclaimed_tasks_without_goal_linkage () =
             ~description:"missing goal linkage");
   ignore (Coord.add_task config ~title:"Fresh unlinked task" ~priority:2
             ~description:"fresh enough to avoid escalation");
-  ignore (Coord.add_task config ~title:"Legacy linked [goal:g1]" ~priority:3
-            ~description:"title tag keeps legacy linkage visible");
+  ignore (Coord.add_task config ~title:"Title marker only [goal:g1]" ~priority:3
+            ~description:"title tag does not create linkage");
   ignore (Coord.add_task ~goal_id:"g1" config ~title:"Explicit linked task"
             ~priority:4 ~description:"structured linkage");
   let stale = iso_seconds_ago (31 * 60) in
   set_task_created_at config ~title:"Stale unlinked task" ~created_at:stale;
-  set_task_created_at config ~title:"Legacy linked [goal:g1]" ~created_at:stale;
+  set_task_created_at config ~title:"Title marker only [goal:g1]" ~created_at:stale;
   set_task_created_at config ~title:"Explicit linked task" ~created_at:stale;
   let result = Goal_janitor.run config in
-  check int "one stale unlinked task escalated" 1 result.orphan_tasks;
+  check int "two stale unlinked tasks escalated" 2 result.orphan_tasks;
   let events = event_lines_containing config "goal_orphan_task_escalation" in
   check bool "escalation event emitted" true
     (not (String.equal events ""));
   check bool "stale unlinked task id included" true
     (contains_substring events "task-001");
-  check bool "legacy title-tag task not escalated" false
+  check bool "title-marker-only task escalated" true
     (contains_substring events "task-003")
 
 let test_prune_orphaned_ids () =

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -143,22 +143,17 @@ let test_goal_upsert_and_list () =
     | `String id when id <> "" -> id
     | _ -> fail "goal_id missing from upsert response"
   in
-  let task_marker =
-    match Yojson.Safe.Util.member "task_title_marker" created_json with
-    | `String marker -> marker
-    | _ -> fail "task_title_marker missing from upsert response"
-  in
-  check
-    bool
-    "task marker embeds goal id"
-    true
-    (String.equal task_marker (Printf.sprintf "[goal:%s]" goal_id));
   let task_link_field =
     match Yojson.Safe.Util.member "task_link_field" created_json with
     | `String field -> field
     | _ -> fail "task_link_field missing from upsert response"
   in
   check string "structured link field" "goal_id" task_link_field;
+  check string "structured link mode" "structured_goal_id"
+    (Yojson.Safe.Util.member "task_link_mode" created_json
+     |> Yojson.Safe.Util.to_string);
+  check bool "title marker omitted" true
+    (Yojson.Safe.Util.member "task_title_marker" created_json = `Null);
   let listed =
     Tool_coord.dispatch
       (coord_ctx config)


### PR DESCRIPTION
## Summary
- remove `[goal:<id>]` title-marker fallback from goal convergence, dashboard goal linkage, janitor orphan detection, and goal task capacity checks
- keep goal/task linkage strictly on structured `task.goal_id`
- stop returning title-marker examples from `masc_goal_upsert` and update tool schema guidance/tests

## Validation
- `ocamlformat --check lib/goal/convergence.ml lib/goal/convergence.mli lib/coord/coord_task_capacity.ml lib/dashboard/dashboard_goals_types_accessor.ml lib/goal/goal_janitor.ml lib/goal/goal_janitor.mli lib/coord_goals.ml lib/tool_schemas/tool_schemas_coord_extra.ml lib/tool_shard_types_schemas_taskboard.ml test/test_coordination_product.ml test/test_dashboard_goals.ml test/test_goal_janitor.ml test/test_goal_tools.ml`
- `git diff --check origin/main..HEAD`
- `scripts/ocaml-structure-ratchet.sh`
- attempted focused `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_goal_tools.exe test/test_coordination_product.exe test/test_dashboard_goals.exe test/test_goal_janitor.exe`; first run reached existing parser dependency error `lib/exec/parser/bash_subset.mly:28: Unbound module Shell_ir`; after rebase, retry exited `130` without diagnostics after lock cleanup
