### PR TITLE
refactor(keeper): remove legacy terminal text classifier

### DIFF
--- a/lib/keeper/keeper_turn_disposition.mli
+++ b/lib/keeper/keeper_turn_disposition.mli
@@ -50,10 +50,9 @@ type t =
           [String.starts_with ~prefix:"api_error_"]. *)
   | Unknown of { raw_error : string }
   (** Last-resort escape hatch for un-classified producer paths
-          (mainly [Keeper_turn_terminal.of_legacy_error_text] until
-          PR-3). [to_wire] returns ["unknown_error"] when [raw_error]
-          is empty, else [raw_error] verbatim — matches the legacy
-          [of_legacy_error_text "" → "unknown_error"] behaviour.
+          that have not yet been promoted to a closed constructor.
+          [to_wire] returns ["unknown_error"] when [raw_error] is empty,
+          else [raw_error] verbatim.
 
           PR-3 lint
           [scripts/lint/no-free-unknown-disposition.sh] will block

--- a/lib/keeper/keeper_turn_terminal.ml
+++ b/lib/keeper/keeper_turn_terminal.ml
@@ -71,56 +71,6 @@ let contract_code_from_error_text raw_error =
   else "required_tool_use_unsatisfied"
 ;;
 
-let of_legacy_error_text raw_error =
-  let trimmed = String.trim raw_error in
-  if trimmed = ""
-  then make ~source:"legacy_error_text" "unknown_error"
-  else if contains_ci trimmed "gh_repo_context_missing_worktree"
-  then make ~source:"legacy_error_text" "gh_repo_context_missing_worktree"
-  else if contains_ci trimmed "oas_timeout_budget"
-  then make ~source:"legacy_error_text" "oas_timeout_budget"
-  else if contains_ci trimmed "Turn wall-clock timeout"
-  then make ~source:"legacy_error_text" "turn_wall_clock_timeout"
-  else if contains_ci trimmed "require_tool_use"
-  then make ~source:"legacy_error_text" (contract_code_from_error_text trimmed)
-  else make ~source:"legacy_error_text" "unknown_error"
-;;
-
-(* The fallback was previously detected via [String.equal fallback.code
-   "unknown_error"]. Now we match on the typed disposition: only the
-   empty-raw [Unknown { raw_error = "" }] case (produced by
-   [of_legacy_error_text ""]) opts into the SDK-error-derived code. Any
-   other [of_legacy_error_text] result has classified the error and
-   should be returned as-is. *)
-let is_unknown_empty (reason : t) =
-  (* Enumerate every [Keeper_turn_disposition.t] variant so the
-     compiler flags any new disposition added. Only the empty-raw
-     [Unknown { raw_error = "" }] case opts into the SDK-error-derived
-     code; all other dispositions (Success, External_cancel,
-     Turn_wall_clock_timeout, Oas_timeout_budget,
-     Gh_repo_context_missing_worktree, Required_tool_use_no_tool_call,
-     Required_tool_use_unsatisfied, Post_commit_ambiguous,
-     Provider_error, and Unknown with non-empty raw_error) must yield
-     [false]. A future disposition variant added to
-     [Keeper_turn_disposition.t] would silently inherit [false] under
-     the previous [_ -> false] catch-all without a review point on
-     whether the new variant should opt into the unknown-empty
-     pathway. Same FSM Sparse Match anti-pattern as PRs #14716,
-     #14790, #14806, #14810, #14816, #14823. *)
-  match reason.disposition with
-  | Keeper_turn_disposition.Unknown { raw_error = "" } -> true
-  | Keeper_turn_disposition.Unknown { raw_error = _ }
-  | Keeper_turn_disposition.Success
-  | Keeper_turn_disposition.External_cancel
-  | Keeper_turn_disposition.Turn_wall_clock_timeout
-  | Keeper_turn_disposition.Oas_timeout_budget
-  | Keeper_turn_disposition.Gh_repo_context_missing_worktree
-  | Keeper_turn_disposition.Required_tool_use_no_tool_call
-  | Keeper_turn_disposition.Required_tool_use_unsatisfied
-  | Keeper_turn_disposition.Post_commit_ambiguous
-  | Keeper_turn_disposition.Provider_error _ -> false
-;;
-
 let of_failure ?(post_commit_ambiguous = false) ?(tool_call_count = 0) ~raw_error err =
   if post_commit_ambiguous
   then make ~source:"typed_error" "post_commit_ambiguous"
@@ -144,21 +94,17 @@ let of_failure ?(post_commit_ambiguous = false) ?(tool_call_count = 0) ~raw_erro
          in
          make ~source:"typed_error" code
        | _ ->
-         let fallback = of_legacy_error_text raw_error in
-         if is_unknown_empty fallback
-         then
-           (* RFC-0047 follow-up: emit typed [Provider_error] directly via
-              [Keeper_agent_error.terminal_reason_code_of_sdk_error_typed]
-              so [registry_failure_reason_of_terminal_reason] can match
-              exhaustively on disposition without a substring guard for
-              "api_error_*" wires. The typed bridge encapsulates the
-              [Sdk_error _] wrapping; the consumer no longer touches a
-              raw wire string. *)
-           of_disposition
-             ~source:"typed_error"
-             (Keeper_turn_disposition.Provider_error
-                (Keeper_agent_error.terminal_reason_code_of_sdk_error_typed err))
-         else fallback))
+         (* RFC-0047 follow-up: emit typed [Provider_error] directly via
+            [Keeper_agent_error.terminal_reason_code_of_sdk_error_typed]
+            so [registry_failure_reason_of_terminal_reason] can match
+            exhaustively on disposition without a substring guard for
+            "api_error_*" wires. The typed bridge encapsulates the
+            [Sdk_error _] wrapping; the consumer no longer touches a
+            raw wire string. *)
+         of_disposition
+           ~source:"typed_error"
+           (Keeper_turn_disposition.Provider_error
+              (Keeper_agent_error.terminal_reason_code_of_sdk_error_typed err))))
 ;;
 
 let of_code ?source ?summary ?next_action code =

--- a/lib/keeper/keeper_turn_terminal.mli
+++ b/lib/keeper/keeper_turn_terminal.mli
@@ -59,6 +59,5 @@ val of_failure
   -> Agent_sdk.Error.sdk_error
   -> t
 
-val of_legacy_error_text : string -> t
 val to_json : t -> Yojson.Safe.t
 val of_json : Yojson.Safe.t -> t option

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -135,7 +135,7 @@ let append_decision_record
     | None -> (
         match outcome, error with
         | "success", _ -> Keeper_turn_terminal.success ()
-        | _, Some err -> Keeper_turn_terminal.of_legacy_error_text err
+        | _, Some _ -> Keeper_turn_terminal.of_code ~source:"decision_error" "unknown_error"
         | _ -> Keeper_turn_terminal.of_code "unknown_error")
   in
   let terminal_reason_code = Keeper_turn_terminal.code terminal_reason in

--- a/test/test_keeper_terminal_reason.ml
+++ b/test/test_keeper_terminal_reason.ml
@@ -520,20 +520,6 @@ let test_structured_no_tool_capable_provider () =
   check string "code" "no_tool_capable_provider" (terminal_code terminal)
 ;;
 
-let test_legacy_gh_worktree_text () =
-  let terminal =
-    KT.of_legacy_error_text
-      "keeper_shell failed: gh_repo_context_missing_worktree: active task has no linked \
-       worktree"
-  in
-  check string "code" "gh_repo_context_missing_worktree" (terminal_code terminal);
-  check
-    (option string)
-    "next action"
-    (Some "create_or_link_worktree")
-    (terminal_next_action terminal)
-;;
-
 (* Contract violation encoding/decoding tests *)
 
 module KER = Masc_mcp.Keeper_execution_receipt
@@ -749,7 +735,6 @@ let () =
             "no tool-capable provider"
             `Quick
             test_structured_no_tool_capable_provider
-        ; test_case "legacy gh missing worktree text" `Quick test_legacy_gh_worktree_text
         ] )
     ; ( "contract violation encoding"
       , [ test_case "encode_tool_list" `Quick test_encode_tool_list

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2203,7 +2203,7 @@ let test_runtime_trust_snapshot_surfaces_terminal_reason () =
              ; ( "terminal_reason"
                , `Assoc
                    [ "code", `String "gh_repo_context_missing_worktree"
-                   ; "source", `String "legacy_error_text"
+                   ; "source", `String "typed_error"
                    ; "severity", `String "warn"
                    ; ( "summary"
                      , `String


### PR DESCRIPTION
## Summary
- remove the public `Keeper_turn_terminal.of_legacy_error_text` substring classifier
- route non-contract SDK failures through typed `Provider_error` disposition instead of raw text fallback classification
- make decision-log error fallback fail closed to `unknown_error` when no structured terminal reason is provided

## Validation
- `ocamlformat --check lib/keeper/keeper_turn_terminal.ml lib/keeper/keeper_turn_terminal.mli lib/keeper/keeper_unified_metrics_decision.ml lib/keeper/keeper_turn_disposition.mli test/test_keeper_terminal_reason.ml test/test_keeper_unified.ml`
- `git diff --check`
- `scripts/ocaml-structure-ratchet.sh`
- attempted `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_terminal_reason.exe test/test_keeper_unified.exe`; local Dune process exited `-1` without diagnostics after lock wait
- attempted narrower `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_terminal_reason.exe`; local Dune again exited `-1` without diagnostics after stale lock cleanup
