### PR TITLE
refactor(dashboard): dedup fsm-hub-invariant-analysis phase conjunctions to SSOT helpers

### DIFF
--- a/dashboard/src/components/fsm-hub-invariant-analysis.ts
+++ b/dashboard/src/components/fsm-hub-invariant-analysis.ts
@@ -11,6 +11,10 @@ import {
   fmtDuration,
 } from './fsm-hub-types'
 import { deriveObservedLaneSummaries } from './fsm-hub-lane-analysis'
+import {
+  isFailingAfterCascadeExhausted,
+  isCompactionActive,
+} from '../lib/keeper-operational-state'
 
 function brokenInvariantKey(
   invariants: KeeperCompositeInvariants,
@@ -71,13 +75,13 @@ function nextExpectedStep(snapshot: KeeperCompositeSnapshot): string {
   if (snapshot.collapsed_from) {
     return `lifecycle 가 raw phase ${snapshot.collapsed_from} 에서 carrier phase 로 collapse 됨; 다음 meaningful edge 가 turn activity 재개 전에 그 underlying condition 을 clear 해야 함.`
   }
-  if (snapshot.phase === 'failing' && snapshot.cascade.state === 'exhausted') {
+  if (isFailingAfterCascadeExhausted(snapshot)) {
     return '정상 provider path 또는 명시적 recovery clearance 가 failing 을 해제해야 running 재개 가능.'
   }
   if (snapshot.phase === 'overflowed') {
     return 'context overflow 은 compaction 또는 명시적 operator clearance 로 해소되어야 lifecycle 이 정착 가능.'
   }
-  if (snapshot.phase === 'compacting' || snapshot.compaction.stage === 'compacting') {
+  if (isCompactionActive(snapshot)) {
     return 'KMC 가 done 에 도달한 뒤 KSM 이 running 으로 control 을 반환해야 함.'
   }
   if (snapshot.phase === 'handing_off') {
@@ -133,7 +137,7 @@ export function deriveOperationalInsight(
 
   const lanes = precomputedLanes ?? deriveObservedLaneSummaries(snapshot, observations, now)
   const stalledLane = lanes.find(lane => lane.stalled)
-  if (snapshot.phase === 'failing' && snapshot.cascade.state === 'exhausted') {
+  if (isFailingAfterCascadeExhausted(snapshot)) {
     return {
       tone: 'error',
       headline: 'cascade exhaustion 후 실패',
@@ -171,7 +175,7 @@ export function deriveOperationalInsight(
       ],
     }
   }
-  if (snapshot.phase === 'compacting' || snapshot.compaction.stage === 'compacting') {
+  if (isCompactionActive(snapshot)) {
     return {
       tone: 'info',
       headline: 'Compaction 가 현재 턴 소유',

--- a/dashboard/src/lib/keeper-operational-state.ts
+++ b/dashboard/src/lib/keeper-operational-state.ts
@@ -319,6 +319,31 @@ export function compositeIsTurnIdle(snapshot: { turn_phase: string }): boolean {
   return snapshot.turn_phase === 'idle'
 }
 
+/** Composite snapshot has entered the post-cascade-exhaustion failure
+ *  mode: KSM has folded to `failing` AND the cascade lane reports
+ *  `exhausted` (no provider path left). Two sites in
+ *  `fsm-hub-invariant-analysis` (`nextExpectedStep` /
+ *  `deriveOperationalInsight`) need this exact conjunction; an SSOT
+ *  prevents the predicate from drifting when either enum evolves.
+ *  Phase wire format stays lowercase per the open-string composite
+ *  schema. */
+export function isFailingAfterCascadeExhausted(
+  snapshot: { phase: string; cascade: { state: string } },
+): boolean {
+  return snapshot.phase === 'failing' && snapshot.cascade.state === 'exhausted'
+}
+
+/** Composite compaction is owning the current turn — either the KSM
+ *  phase has folded to `compacting` or the KMC lane stage is active.
+ *  Two sites in `fsm-hub-invariant-analysis` need the same disjunction;
+ *  SSOT here so the cross-axis OR stays consistent. Phase wire format
+ *  stays lowercase per the open-string composite schema. */
+export function isCompactionActive(
+  snapshot: { phase: string; compaction: { stage: string } },
+): boolean {
+  return snapshot.phase === 'compacting' || snapshot.compaction.stage === 'compacting'
+}
+
 // RFC-0135 PR-14c — display reason SSOT (Goal-2c typed-state expansion).
 //
 // `keeper-detail-runtime.ts:257-264` inlined a 3-way fallback for the


### PR DESCRIPTION
# refactor(dashboard): dedup fsm-hub-invariant-analysis 2-pair phase conjunctions to SSOT helpers

## 배경

Plan 5 (`memory/masc-consolidated-state-and-roadmap-2026-05-20.html` §6) 가 dashboard literal phase compare 잔존 3 파일을 지목했고, 그 중 2개 (`keeper-memory-tier-panel:164`, `keeper-reactivity-monitor:227`) 는 이미 SSOT (`toKeeperPhase`, `isKeeperCrashed`) 적용 완료. 3번째 `fsm-hub-invariant-analysis.ts` 만 8 site live 였음 (line 74/77/80/83/86/136/174/186).

## 변경 범위 + 의도적 비변경

```
dashboard/src/lib/keeper-operational-state.ts          | +25 (2 new helpers)
dashboard/src/components/fsm-hub-invariant-analysis.ts |  -8 +12 (imports + 4 site swap)
```

8 site 중 **2-pair duplication (line 74↔136, line 80↔174) 만 SSOT helper 로 dedup**:

- `isFailingAfterCascadeExhausted(snapshot)` — `phase === 'failing' && cascade.state === 'exhausted'`
- `isCompactionActive(snapshot)` — `phase === 'compacting' || compaction.stage === 'compacting'`

**4 single-occurrence site (line 77/83/86/186) 는 의도적으로 그대로**. 이유:

`dashboard/src/api/schemas/keeper-composite.ts:39-41` 에 명시된 schema-boundary 디자인 결정:

> "FSM state fields stay open strings. The backend can ship new variants ahead of the dashboard, and coercing an unknown state to Stable/idle/clean hides the exact operator signal we need during a drift event."

즉 `KeeperCompositePhase = string()` 은 **의도적 open-string**. typed enum (`KeeperKsmPhase`) 으로 narrow 하는 wholesale migration 은 이 디자인과 충돌. single-occurrence 비교는 그대로 두는 것이 message-switching 명료성과 schema-boundary 둘 다 보전.

## Workaround Rejection Bar self-check

- §1 텔레메트리-as-fix: counter/WARN 추가 0
- §2 substring/literal 분류기 보강: literal 8 → 4 (감소), 0 추가
- §3 N-of-M 패치: 같은 PR 에서 모든 2-pair duplication 정리 (다음 PR 으로 분할 안 함)
- catch-all `_ ->` 추가 0
- cap/cooldown/dedup/repair 0
- test backdoor 0

전 7 항목 통과.

## 정량 완료 기준 (Goal-Driven)

- `rg "snapshot\.phase === '" dashboard/src/components/fsm-hub-invariant-analysis.ts | wc -l`: **8 → 4** (single-occurrence 유지가 의도)
- 2-pair dedup: `isFailingAfterCascadeExhausted` 2 site, `isCompactionActive` 2 site
- `pnpm typecheck`: pass
- `pnpm lint`: pass
- `pnpm test src/components/fsm-hub`: (pending — CI 확정)

## 후속

본 PR 은 plan 5 의 dashboard literal-classifier 잔업 **C** 만 닫음. Plan 5 의 다른 두 잔업 (A: `keeper-memory-tier-panel:164`, B: `keeper-reactivity-monitor:227`) 는 audit 결과 **이미 closed** (RFC-0135 PR-2 normalization + `isKeeperCrashed` SSOT 가 선행 머지됨). plan 본문 자체가 frozen-in-time 메모리였음 — RFC closeout-lag 패턴 (`feedback_rfc_closeout_lag_systemic_pattern_2026_05_21`).

다음 후속:

1. plan 5 본문 (`memory/masc-consolidated-state-and-roadmap-2026-05-20.html` §6) 에서 A/B/C 처리됨 표기 (별도 ~/me PR)
2. RFC-0142 Phase 2 PR-1: `cascade_internal_error.ml` 추출 (godfile 873 LoC 분해 시작)

## Co-Authored-By

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
