### PR TITLE
fix(build): restore test_worker_dev_tools.exe green after policy split PRs

### DIFF
--- a/lib/exec_policy.ml
+++ b/lib/exec_policy.ml
@@ -58,8 +58,8 @@ let command_blocked_hint ?allowed_commands name =
     | "curl" | "wget" ->
       " Use masc_web_fetch to fetch page content, or masc_web_search to find sources."
     | "gh" ->
-      " Use keeper_shell op=gh for GitHub CLI work when a keeper task has repo \
-       context. Use git directly for repository/worktree/branch operations."
+      " Use keeper_pr_* tools for GitHub operations (create, merge, comment) or \
+       masc_board_post to escalate. Use git directly for repository/worktree/branch operations."
     | "docker"
     | "podman"
     | "kubectl"
@@ -149,12 +149,12 @@ let validate_command_name_with_allowlist ~allowed_commands = function
 ;;
 
 let strict_allowlist_policy ~allowed_commands : Exec_shell_gate.allowlist_policy =
-  { allowed_commands; allow_pipes = false }
+  { allowed_commands; allow_pipes = false; redirect_allowed = false }
 ;;
 
 let coding_allowlist_policy ?(allow_pipes = true) ~allowed_commands ()
   : Exec_shell_gate.allowlist_policy =
-  { allowed_commands; allow_pipes }
+  { allowed_commands; allow_pipes; redirect_allowed = false }
 ;;
 
 let rec shell_ir_literal_text = function
@@ -288,7 +288,10 @@ let command_context_with_allowlist ?caller ~allowed_commands cmd =
     | Allow context ->
       if context.Exec_shell_gate.direct_dune_seen
       then Error Direct_dune_invocation
-      else Ok context
+      else (
+        match validate_wrapped_stages ~allowed_commands context.Exec_shell_gate.ast with
+        | Ok () -> Ok context
+        | Error _ as err -> err)
     | Reject { context; reason; _ } ->
       if context.Exec_shell_gate.direct_dune_seen
       then Error Direct_dune_invocation
@@ -846,7 +849,7 @@ let attribution_of_validation ~cmd (result : (unit, block_reason) result) : Attr
   match result with
   | Ok () ->
     let evidence : Yojson.Safe.t = `Assoc [ "cmd", `String cmd ] in
-    Attribution.passed ~origin:Det ~gate:"exec_policy" ~evidence
+    Attribution.passed ~origin:Det ~gate:"worker_dev_tools" ~evidence
   | Error br ->
     let command_name =
       match br with
@@ -864,7 +867,7 @@ let attribution_of_validation ~cmd (result : (unit, block_reason) result) : Attr
     in
     Attribution.policy_failed
       ~origin:Det
-      ~gate:"exec_policy"
+      ~gate:"worker_dev_tools"
       ~evidence
       ~reason:(block_reason_to_string br)
 ;;

--- a/lib/keeper/keeper_tool_alias.mli
+++ b/lib/keeper/keeper_tool_alias.mli
@@ -105,3 +105,5 @@ val public_input_schema : string -> Yojson.Safe.t option
 
     For unknown public names this is the identity. *)
 val translate_input : public:string -> Yojson.Safe.t -> Yojson.Safe.t
+
+val register_structured_routes : unit -> unit

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -59,6 +59,10 @@ let is_git_branch_switch = Exec_policy.is_git_branch_switch
 let is_destructive_bash_operation = Exec_policy.is_destructive_bash_operation
 let sanitize_command_for_log = Exec_policy.sanitize_command_for_log
 let truncate_for_log = Exec_policy.truncate_for_log
+let block_reason_tag = Exec_policy.block_reason_tag
+let attribution_of_validation = Exec_policy.attribution_of_validation
+let block_reason_tag = Exec_policy.block_reason_tag
+let attribution_of_validation = Exec_policy.attribution_of_validation
 
 (* --- gh CLI validation (extracted to Gh_command_validation) --- *)
 

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -378,7 +378,7 @@ let test_shell_exec_uses_shell_ir_dispatch_cwd () =
        | Error { Agent_sdk.Types.message = e; _ } ->
          Alcotest.fail (Printf.sprintf "shell_exec failed: %s" e)
        | Ok { Agent_sdk.Types.content = output } ->
-         Alcotest.(check string) "pwd output" (workdir ^ "\n") output;
+         Alcotest.(check string) "pwd output" (Unix.realpath workdir ^ "\n") output;
          let process_line =
            List.find_opt
              (fun line ->


### PR DESCRIPTION
Build-fix PR restoring green CI after #17622, #17623, #17624 landed with interdependent breakage.\n\nFixes:\n- redirect_allowed defaults to false (preserves pre-merge behavior)\n- validate_wrapped_stages wired back into command_context_with_allowlist\n- worker_dev_tools.ml re-exports attribution_of_validation + block_reason_tag\n- keeper_tool_alias.mli exports register_structured_routes\n- macOS pwd test uses Unix.realpath\n- gh hint restored to mention keeper_pr_* alternatives