### PR TITLE
feat(keeper): add to_shell_ir_unvalidated for Shell_command_gate adoption (RFC-0131 PR-2 infra)

### DIFF
--- a/lib/keeper/keeper_tool_bash_input.ml
+++ b/lib/keeper/keeper_tool_bash_input.ml
@@ -341,9 +341,7 @@ let shell_simple ~mode ?(sandbox = Masc_exec.Sandbox_target.host ()) ?cwd ?(env 
     }
 ;;
 
-let to_shell_ir ?(sandbox = Masc_exec.Sandbox_target.host ()) ~mode input =
-  let ( let* ) = Result.bind in
-  let* () = validate ~mode input in
+let to_shell_ir_unvalidated ?(sandbox = Masc_exec.Sandbox_target.host ()) ~mode input =
   match input with
   | Exec { executable; argv; cwd; env } ->
     let stage = { executable; argv } in
@@ -360,6 +358,12 @@ let to_shell_ir ?(sandbox = Masc_exec.Sandbox_target.host ()) ~mode input =
       loop [] stages
     in
     Ok (Masc_exec.Shell_ir.Pipeline simples)
+;;
+
+let to_shell_ir ?sandbox ~mode input =
+  let ( let* ) = Result.bind in
+  let* () = validate ~mode input in
+  to_shell_ir_unvalidated ?sandbox ~mode input
 ;;
 
 let pp_mode ppf = function

--- a/lib/keeper/keeper_tool_bash_input.mli
+++ b/lib/keeper/keeper_tool_bash_input.mli
@@ -82,6 +82,16 @@ val validate : mode:allowlist_mode -> bash_input -> (unit, validation_error) res
     success, or the first {!validation_error} encountered.  No side
     effects, no exceptions. *)
 
+val to_shell_ir_unvalidated :
+  ?sandbox:Masc_exec.Sandbox_target.t ->
+  mode:allowlist_mode ->
+  bash_input ->
+  (Masc_exec.Shell_ir.t, validation_error) result
+(** Lower [input] into {!Masc_exec.Shell_ir.t} without allowlist validation.
+    Callers that use the Shell IR facade ([Shell_command_gate.gate_typed])
+    should use this entrypoint so validation runs through the facade rather
+    than duplicating the allowlist check. *)
+
 val to_shell_ir :
   ?sandbox:Masc_exec.Sandbox_target.t ->
   mode:allowlist_mode ->


### PR DESCRIPTION
Adds [to_shell_ir_unvalidated] so that [keeper_shell_bash.ml] can call [Shell_command_gate.gate_typed] directly in the follow-up PR, rather than duplicating the allowlist check inside [Keeper_tool_bash_input.validate].\n\n- [to_shell_ir] behavior is unchanged (still calls [validate] internally)\n- [to_shell_ir_unvalidated] performs only IR lowering without allowlist validation\n- Next PR will wire [gate_typed ~caller:Keeper_shell_bash] in [handle_keeper_bash_typed]