### PR TITLE
feat(keeper): wire Shell_command_gate.gate_typed in keeper_shell_bash (RFC-0131 PR-2 follow-up)

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -13,6 +13,8 @@ module For_testing = struct
   let elapsed_duration_ms = elapsed_duration_ms
 end
 
+module Shell_gate = Masc_exec_command_gate.Shell_command_gate
+
 let sandbox_profile_label = function
   | Local -> "host"
   | Docker -> "docker"
@@ -189,12 +191,40 @@ let handle_keeper_bash_typed
                ~extra:[ "cmd", `String cmd_for_log; "typed", `Bool true; "execution_time_ms", `Int 0 ]
                ())
         else
-          match Keeper_tool_bash_input.to_shell_ir ~mode ~sandbox:dispatch_sandbox input with
+          match Keeper_tool_bash_input.to_shell_ir_unvalidated ~mode ~sandbox:dispatch_sandbox input with
           | Error e ->
             error_json
               ~fields:[ "typed", `Bool true; "cmd", `String cmd_for_log; "cwd", `String cwd ]
               (typed_validation_error_text e)
           | Ok ir ->
+            let allowed_commands =
+              match mode with
+              | Keeper_tool_bash_input.Dev_full -> Dev_exec_allowlist.dev
+              | Keeper_tool_bash_input.Readonly -> Dev_exec_allowlist.readonly
+            in
+            let gate_verdict =
+              Shell_gate.gate_typed
+                ~caller:Shell_gate.Keeper_shell_bash
+                ~ir
+                ~allowlist:{ allowed_commands; allow_pipes = true; redirect_allowed = true }
+                ~path_policy:Shell_gate.allow_all_paths
+                ~sandbox:{ target = dispatch_sandbox }
+                ()
+            in
+            match gate_verdict with
+            | Reject { diagnostic; _ } ->
+              error_json
+                ~fields:[ "typed", `Bool true; "cmd", `String cmd_for_log; "cwd", `String cwd ]
+                diagnostic
+            | Cannot_parse _ ->
+              error_json
+                ~fields:[ "typed", `Bool true; "cmd", `String cmd_for_log; "cwd", `String cwd ]
+                "Cannot parse command"
+            | Too_complex _ ->
+              error_json
+                ~fields:[ "typed", `Bool true; "cmd", `String cmd_for_log; "cwd", `String cwd ]
+                "Command too complex"
+            | Allow _context ->
             let path_validation =
               match
                 Keeper_task_worktree_lazy.ensure_shell_ir_existing_dirs

--- a/lib/keeper/keeper_tool_bash_input.ml
+++ b/lib/keeper/keeper_tool_bash_input.ml
@@ -342,6 +342,7 @@ let shell_simple ~mode ?(sandbox = Masc_exec.Sandbox_target.host ()) ?cwd ?(env 
 ;;
 
 let to_shell_ir_unvalidated ?(sandbox = Masc_exec.Sandbox_target.host ()) ~mode input =
+  let ( let* ) = Result.bind in
   match input with
   | Exec { executable; argv; cwd; env } ->
     let stage = { executable; argv } in


### PR DESCRIPTION
Follow-up to #17632: actually wire [Shell_command_gate.gate_typed] in [handle_keeper_bash_typed].\n\n- Uses [to_shell_ir_unvalidated] (infra added in #17632)\n- Calls [gate_typed ~caller:Keeper_shell_bash] for allowlist + redirect + path policy\n- Keeps destructive/write-operation gates after facade verdict\n- 172 test_worker_dev_tools tests + 25 test_keeper_bash_typed_input tests pass