### PR TITLE
fix(keeper): remove internal tool name leaks from keeper_bash description

### DIFF
--- a/lib/tool_shard_types_schemas_bash.ml
+++ b/lib/tool_shard_types_schemas_bash.ml
@@ -112,7 +112,7 @@ let keeper_bash_timeout_sec_field =
 ;;
 
 let keeper_bash_description =
-  "Execute one command through the keeper_bash safety gates via typed argv. Use \
+  "Execute one command through the typed execution gates via typed argv. Use \
    executable/argv for one process, or pipeline/stages for explicit Shell IR \
    pipelines. The legacy 'cmd' string field is no longer accepted. Shell \
    metacharacters in argv are data, not syntax. Good: executable='git' \
@@ -123,9 +123,9 @@ let keeper_bash_description =
    'repos/X' instead. Sandbox root is NOT a git repository: git/gh calls require \
    cwd='repos/<REPO_NAME>' (or the worktree path under it). 'not a git repository' \
    or 'path_outside_sandbox' from the sandbox root means you forgot the cwd. For \
-   read-only search/listing use keeper_shell or Grep when visible; for file edits use \
-   keeper_fs_edit. Long-running commands must be split or run through a \
-   dedicated structured workflow; keeper_bash no longer exposes background task \
+   read-only search/listing use Grep when visible; for file edits use Edit. \
+   Long-running commands must be split or run through a \
+   dedicated structured workflow; this tool no longer exposes background task \
    lifecycle tools."
 ;;
 

--- a/test/test_tool_surface_ssot.ml
+++ b/test/test_tool_surface_ssot.ml
@@ -345,6 +345,63 @@ let test_system_internal_not_visible () =
       (String.concat ", " visible);
   Alcotest.(check bool) "all system_internal hidden" true (visible = [])
 
+let test_keeper_internal_descriptions_no_cross_leak () =
+  (* Keeper-internal tool descriptions should not reference other internal
+     tool names.  The LLM sees these descriptions and will attempt to call
+     whatever name it finds — referencing [keeper_shell] in the [keeper_bash]
+     description causes the LLM to emit [keeper_shell] calls that bypass
+     the alias routing layer (Keeper_tool_alias only routes public names
+     like [Bash], [Grep], etc.). *)
+  let contains_substring haystack needle =
+    let hlen = String.length haystack in
+    let nlen = String.length needle in
+    if nlen = 0 then true
+    else if nlen > hlen then false
+    else
+      let rec loop i =
+        i + nlen <= hlen
+        && (String.sub haystack i nlen = needle || loop (i + 1))
+      in
+      loop 0
+  in
+  let internal_names_to_check =
+    [ "keeper_bash"; "keeper_shell"; "keeper_fs_edit"; "keeper_fs_read"
+    ; "keeper_memory_search"; "keeper_memory_write"; "keeper_board_post"
+    ; "keeper_board_list"; "keeper_pr_create"; "keeper_pr_review_comment"
+    ; "masc_code_shell"; "shell_exec"; "worker_dev_tools"
+    ]
+  in
+  let internal_schemas =
+    Tool_shard.all_keeper_tool_schemas
+    |> List.filter (fun (s : Masc_domain.tool_schema) ->
+           Tool_catalog.is_on_surface Tool_catalog.Keeper_internal s.name)
+  in
+  let violations = ref [] in
+  List.iter (fun (schema : Masc_domain.tool_schema) ->
+    List.iter (fun leaked_name ->
+      if String.length leaked_name > 0
+         && String.equal schema.name leaked_name = false
+         && contains_substring schema.description leaked_name
+      then
+        violations :=
+          (schema.name, leaked_name) :: !violations
+    ) internal_names_to_check
+  ) internal_schemas;
+  if !violations <> [] then begin
+    let msg =
+      !violations
+      |> List.map (fun (host, leak) ->
+             Printf.sprintf "  %s.description contains \"%s\"" host leak)
+      |> String.concat "\n"
+    in
+    Alcotest.failf
+      "Keeper-internal description cross-leak:\n%s\n\
+       Internal names should not appear in descriptions; use public-facing \
+       terms (Bash, Grep, Edit, Write, Read) instead." msg
+  end
+  else
+    Alcotest.(check bool) "no cross-leak" true (!violations = [])
+
 let test_system_internal_callable () =
   (* System_internal tools must be callable via tools/call. *)
   let system_tools = Tool_catalog.tools_for_surface Tool_catalog.System_internal in
@@ -461,6 +518,8 @@ let () =
             test_active_surfaced_tools_are_routable_and_permissioned;
           Alcotest.test_case "Public_mcp count cap <= 80" `Quick
             test_public_mcp_count_cap;
+          Alcotest.test_case "Keeper_internal descriptions no cross-leak" `Quick
+            test_keeper_internal_descriptions_no_cross_leak;
           Alcotest.test_case "System_internal not visible" `Quick
             test_system_internal_not_visible;
           Alcotest.test_case "System_internal callable" `Quick


### PR DESCRIPTION
## Summary

- Remove 4 internal tool name references from `keeper_bash` schema description that LLMs could copy into tool calls, bypassing the `Keeper_tool_alias` routing layer
- Add regression test `test_keeper_internal_descriptions_no_cross_leak` checking all Keeper_internal schema descriptions against 13 internal names

## Changes

### `lib/tool_shard_types_schemas_bash.ml`
| Before | After | Why |
|--------|-------|-----|
| `keeper_bash safety gates` | `typed execution gates` | Self-reference leak |
| `keeper_shell or Grep` | `Grep` | Internal name leak |
| `keeper_fs_edit` | `Edit` | Internal name leak |
| `keeper_bash no longer exposes` | `this tool no longer exposes` | Self-reference leak |

### `test/test_tool_surface_ssot.ml`
New test: `test_keeper_internal_descriptions_no_cross_leak`
- Scans all `Keeper_internal` schema descriptions
- Checks against 13 internal tool names (`keeper_bash`, `keeper_shell`, `keeper_fs_edit`, etc.)
- Self-references excluded (a schema can contain its own name)
- Fails with specific violation listing if any cross-leak found

## Context

Tool Surface Integration Plan PR-1 (surface audit + guard tests).
The `tool_json_for_profile` function exposes `schema.description` verbatim to LLMs via `tools/list`. Internal names in descriptions cause LLMs to emit raw `keeper_*` calls that bypass the alias routing layer (`Bash→keeper_bash`, `Grep→keeper_shell`, etc.).

## Test plan

- [x] Regression test added (`test_keeper_internal_descriptions_no_cross_leak`)
- [ ] Full build passes (main branch currently has pre-existing build breaks from Shell IR Phase 5/6 transition — not caused by this PR)
- [ ] CI green once main branch builds are restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)