### PR TITLE
fix(keeper): keep local capacity out of provider health

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -882,6 +882,26 @@ type capacity_backpressure_retry_hint =
   | Cbr_explicit of float
   | Cbr_synthetic_default of float
 
+let sdk_error_capacity_backpressure_source (err : Agent_sdk.Error.sdk_error)
+  : Cascade_error_classify.capacity_backpressure_source option =
+  match Cascade_error_classify.classify_masc_internal_error err with
+  | Some (Cascade_error_classify.Capacity_backpressure { source; _ }) ->
+    Some source
+  | Some (Cascade_error_classify.Cascade_exhausted _)
+  | Some (Cascade_error_classify.Resumable_cli_session _)
+  | Some (Cascade_error_classify.No_tool_capable_provider _)
+  | Some (Cascade_error_classify.Accept_rejected _)
+  | Some (Cascade_error_classify.Admission_queue_timeout _)
+  | Some (Cascade_error_classify.Admission_queue_rejected _)
+  | Some (Cascade_error_classify.Turn_timeout _)
+  | Some (Cascade_error_classify.Oas_timeout_budget _)
+  | Some (Cascade_error_classify.Max_tokens_ceiling_violation _)
+  | Some (Cascade_error_classify.Ambiguous_post_commit _)
+  | Some (Cascade_error_classify.Internal_unhandled_exception _)
+  | Some (Cascade_error_classify.Internal_bridge_exception _)
+  | Some (Cascade_error_classify.Internal_contract_rejected _)
+  | None -> None
+
 let sdk_error_capacity_backpressure_retry_hint (err : Agent_sdk.Error.sdk_error)
   : capacity_backpressure_retry_hint option =
   match Cascade_error_classify.classify_masc_internal_error err with

--- a/lib/cascade/cascade_attempt_fsm.mli
+++ b/lib/cascade/cascade_attempt_fsm.mli
@@ -164,6 +164,14 @@ type capacity_backpressure_retry_hint =
         injects {!Cascade_health_tracker.default_capacity_backpressure_backoff_sec}
         to prevent immediate cascade re-rotation onto the same provider. *)
 
+val sdk_error_capacity_backpressure_source :
+  Agent_sdk.Error.sdk_error ->
+  Cascade_error_classify.capacity_backpressure_source option
+(** [Some source] when the error classifies as a MASC-internal
+    [Capacity_backpressure].  Callers use this to keep provider-owned
+    capacity failures separate from client/tier/cascade-slot backpressure
+    when projecting provider health. *)
+
 val sdk_error_capacity_backpressure_retry_hint :
   Agent_sdk.Error.sdk_error -> capacity_backpressure_retry_hint option
 (** [Some hint] when the error classifies as

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -865,38 +865,58 @@ let run_named
          within milliseconds.  Inject a typed synthetic backoff so the
          cooldown path still applies; emit a warning so operators can
          see that the upstream omitted the hint. *)
-      let immediate_cooldown_retry_after =
-        match sdk_error_capacity_backpressure_retry_after_s sdk_err with
-        | Some retry_after -> Some retry_after
-        | None ->
-          (match sdk_error_capacity_backpressure_retry_hint sdk_err with
-           | Some (Cbr_explicit s) -> Some (Some s)
-           | Some (Cbr_synthetic_default s) ->
-             Log.Misc.warn
-               "cascade_capacity_backpressure: provider=%s retry_after_sec=null \
-                injecting synthetic backoff=%.1fs (error_kind=%s)"
-               provider_key s
-               (Cascade_health_tracker.error_kind_to_string error_kind);
-             Some (Some s)
-           | None -> sdk_error_soft_rate_limited sdk_err)
+      let capacity_source =
+        sdk_error_capacity_backpressure_source sdk_err
       in
-      match immediate_cooldown_retry_after with
-      | Some retry_after_s ->
-        Cascade_health_tracker.record_capacity_backpressure
-          Cascade_health_tracker.global
-          ~provider_key
-          ?retry_after_s
-          ~error_kind
-          ~error_reason
-          ~now:(Unix.time ())
-          ()
-      | None ->
-        Cascade_health_tracker.record_failure
-          Cascade_health_tracker.global
-          ~provider_key
-          ~error_kind
-          ~error_reason
-          ()
+      let provider_owned_capacity =
+        match capacity_source with
+        | Some Provider_capacity -> true
+        | Some (Client_capacity | Tier_admission | Cascade_slot) -> false
+        | None -> true
+      in
+      if not provider_owned_capacity
+      then
+        Log.Misc.info
+          "cascade_capacity_backpressure: source=%s provider=%s not recorded \
+           as provider health/cooldown (error_kind=%s)"
+          (capacity_source
+           |> Option.map capacity_backpressure_source_to_string
+           |> Option.value ~default:"unknown")
+          provider_key
+          (Cascade_health_tracker.error_kind_to_string error_kind)
+      else
+        let immediate_cooldown_retry_after =
+          match sdk_error_capacity_backpressure_retry_after_s sdk_err with
+          | Some retry_after -> Some retry_after
+          | None ->
+            (match sdk_error_capacity_backpressure_retry_hint sdk_err with
+             | Some (Cbr_explicit s) -> Some (Some s)
+             | Some (Cbr_synthetic_default s) ->
+               Log.Misc.warn
+                 "cascade_capacity_backpressure: provider=%s retry_after_sec=null \
+                  injecting synthetic backoff=%.1fs (error_kind=%s)"
+                 provider_key s
+                 (Cascade_health_tracker.error_kind_to_string error_kind);
+               Some (Some s)
+             | None -> sdk_error_soft_rate_limited sdk_err)
+        in
+        match immediate_cooldown_retry_after with
+        | Some retry_after_s ->
+          Cascade_health_tracker.record_capacity_backpressure
+            Cascade_health_tracker.global
+            ~provider_key
+            ?retry_after_s
+            ~error_kind
+            ~error_reason
+            ~now:(Unix.time ())
+            ()
+        | None ->
+          Cascade_health_tracker.record_failure
+            Cascade_health_tracker.global
+            ~provider_key
+            ~error_kind
+            ~error_reason
+            ()
   in
   let acquire_client_capacity_slot candidate =
     let capacity_key =


### PR DESCRIPTION
## Summary
- keep non-provider capacity backpressure out of provider health/cooldown projection
- expose typed capacity backpressure source extraction from cascade attempt FSM
- preserve provider capacity cooldown behavior for provider-owned capacity errors

## Why
Client capacity, tier admission, and cascade-slot saturation are derived scheduler/admission facts, not provider health facts. Recording them as provider cooldown makes the dashboard show a keeper as running, blocked, unhealthy, and operational at once with a misleading provider root cause.

## Validation
Not run; first PR slice only and local validation was not requested in this turn.