### PR TITLE
[clock-spine] P3-P7 runtime-lens DAG + synthetic events + completion proof

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api_runtime_lens.ml
+++ b/lib/server/server_dashboard_http_keeper_api_runtime_lens.ml
@@ -77,6 +77,29 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
     then "selected"
     else "empty"
   in
+  let tool_lineage_stage_counts () =
+    match scan.latest_tool_lineage_decision with
+    | None -> []
+    | Some decision ->
+      let stages =
+        [ "searched"
+        ; "visible"
+        ; "materialized"
+        ; "emitted"
+        ; "executed"
+        ; "verified"
+        ]
+      in
+      List.filter_map
+        (fun stage ->
+           match Yojson.Safe.Util.member stage decision with
+           | `Assoc _ as obj -> (
+             match Yojson.Safe.Util.member "count" obj with
+             | `Int count when count > 0 -> Some (stage, count)
+             | _ -> None)
+           | _ -> None)
+        stages
+  in
   `Assoc
     [
       ( "turn_clock",
@@ -286,6 +309,7 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
                   ]
                 ~terminal_status:
                   (runtime_lens_keeper_terminal_status ~terminal_event_present scan)
+                ~synthetic_events:[]
             );
             ( "masc_policy_cascade",
               runtime_lens_swimlane_json swimlane_scan gaps
@@ -299,6 +323,7 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
                   (Option.value provider_lane_status
                      ~default:
                        (if has_provider_lane then "resolved" else "empty"))
+                ~synthetic_events:[]
             );
             ( "oas_agent",
               runtime_lens_swimlane_json swimlane_scan gaps ~lane:"oas_agent"
@@ -321,7 +346,8 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
                        Keeper_runtime_manifest.Checkpoint_loaded
                      > 0
                    then "checkpoint_loaded"
-                   else "empty") );
+                   else "empty")
+                ~synthetic_events:[] );
             ( "provider",
               runtime_lens_swimlane_json swimlane_scan gaps ~lane:"provider"
                 ~label:"Provider"
@@ -331,6 +357,7 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
                     Keeper_runtime_manifest.Provider_attempt_finished;
                   ]
                 ~terminal_status:(runtime_lens_provider_terminal_status scan)
+                ~synthetic_events:[]
             );
             ( "tool_runtime",
               runtime_lens_swimlane_json swimlane_scan gaps ~lane:"tool_runtime"
@@ -340,6 +367,7 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
                     Keeper_runtime_manifest.Tool_surface_selected;
                     Keeper_runtime_manifest.Tool_lineage_recorded;
                   ]
+                ~synthetic_events:(tool_lineage_stage_counts ())
                 ~terminal_status:tool_runtime_status );
             ( "memory_context",
               runtime_lens_swimlane_json swimlane_scan gaps ~lane:"memory_context"
@@ -352,7 +380,8 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
                     Keeper_runtime_manifest.Memory_injected;
                     Keeper_runtime_manifest.Memory_flushed;
                   ]
-                ~terminal_status:(runtime_lens_memory_terminal_status scan) );
+                ~terminal_status:(runtime_lens_memory_terminal_status scan)
+                ~synthetic_events:[] );
           ] );
       ( "clock_edges",
         Server_dashboard_http_keeper_runtime_lens_clock_edges.runtime_lens_clock_edges_json

--- a/lib/server/server_dashboard_http_keeper_api_runtime_lens.ml
+++ b/lib/server/server_dashboard_http_keeper_api_runtime_lens.ml
@@ -371,7 +371,7 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
                 ~terminal_status:tool_runtime_status );
             ( "memory_context",
               runtime_lens_swimlane_json swimlane_scan gaps ~lane:"memory_context"
-                ~label:"Memory/Context"
+                ~label:"Memory/Context/Checkpoint"
                 ~events:
                   [
                     Keeper_runtime_manifest.Context_injected;
@@ -379,6 +379,10 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
                     Keeper_runtime_manifest.Event_bus_correlated;
                     Keeper_runtime_manifest.Memory_injected;
                     Keeper_runtime_manifest.Memory_flushed;
+                    Keeper_runtime_manifest.Checkpoint_loaded;
+                    Keeper_runtime_manifest.Checkpoint_saved;
+                    Keeper_runtime_manifest.State_snapshot_sidecar_saved;
+                    Keeper_runtime_manifest.Working_state_sidecar_saved;
                   ]
                 ~terminal_status:(runtime_lens_memory_terminal_status scan)
                 ~synthetic_events:[] );

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml
@@ -70,19 +70,36 @@ let runtime_lens_memory_terminal_status scan =
   else if scan.memory_flush_success_count > 0 then "flushed"
   else if scan.memory_injected_count > 0 then "injected"
   else if
+    runtime_lens_event_count scan Keeper_runtime_manifest.Checkpoint_saved > 0
+  then "checkpoint_saved"
+  else if
+    runtime_lens_event_count scan Keeper_runtime_manifest.Checkpoint_loaded > 0
+  then "checkpoint_loaded"
+  else if
     scan.context_injected_count > 0
     || scan.context_compacted_event_count > 0
     || scan.event_bus_count > 0
   then "context"
   else "empty"
 
-(** F8: lane mandatory event sets and terminal policy separation.
+(** F8 + P5: lane mandatory event sets, terminal policy, and completion proof.
 
     [finished] = the lane's terminal event is present.
+                 This means "the turn reached a terminal state for this lane",
+                 not "the lane fulfilled its contract".
+
     [complete] = all mandatory events for the lane are present AND
                  the terminal event is present (or the lane has no terminal).
+                 This means "the lane fulfilled its proof policy".
 
-    This distinguishes "the turn ended" from "the lane fulfilled its contract". *)
+    [mandatory_present] = all mandatory events are present but the lane
+                          has not reached its terminal event.
+
+    [incomplete] = some mandatory events are missing.
+
+    Separation of "terminal" from "complete" is required because a turn can
+    finish (Turn_finished) while a lane still lacks mandatory events
+    (e.g., missing checkpoint save, missing memory flush). *)
 
 type lane_policy =
   { lane : string

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml
@@ -249,6 +249,16 @@ let runtime_lens_swimlane_json scan gaps ~lane ~label ~events
     | `List events -> `List (events @ synthetic_events_json)
     | other -> other
   in
+  let dag_edges_json =
+    List.map
+      (fun (parent_event_id, event_id) ->
+         `Assoc
+           [
+             ("parent_event_id", `String parent_event_id);
+             ("event_id", `String event_id);
+           ])
+      scan.dag_edges
+  in
   `Assoc
     [
       ("lane", `String lane);
@@ -262,4 +272,5 @@ let runtime_lens_swimlane_json scan gaps ~lane ~label ~events
         | code :: _ -> `String code
         | [] -> `Null );
       ("events", all_events);
+      ("dag_edges", `List dag_edges_json);
     ]

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml
@@ -205,13 +205,30 @@ let runtime_lens_swimlane_completeness scan lane =
   else if mandatory_present then "mandatory_present"
   else "incomplete"
 
-let runtime_lens_swimlane_json scan gaps ~lane ~label ~events ~terminal_status =
+let runtime_lens_swimlane_json scan gaps ~lane ~label ~events
+    ~terminal_status ~synthetic_events =
   let gap_codes = runtime_lens_gap_codes_for_lane gaps lane in
-  let event_count =
+  let standard_event_count =
     events
     |> List.fold_left
          (fun total event -> total + runtime_lens_event_count scan event)
          0
+  in
+  let synthetic_event_count =
+    List.fold_left (fun total (_, count) -> total + count) 0 synthetic_events
+  in
+  let event_count = standard_event_count + synthetic_event_count in
+  let standard_events_json = runtime_lens_events_json scan events in
+  let synthetic_events_json =
+    List.map
+      (fun (name, count) ->
+         `Assoc [("event", `String name); ("count", `Int count)])
+      synthetic_events
+  in
+  let all_events =
+    match standard_events_json with
+    | `List events -> `List (events @ synthetic_events_json)
+    | other -> other
   in
   `Assoc
     [
@@ -225,5 +242,5 @@ let runtime_lens_swimlane_json scan gaps ~lane ~label ~events ~terminal_status =
         match gap_codes with
         | code :: _ -> `String code
         | [] -> `Null );
-      ("events", runtime_lens_events_json scan events);
+      ("events", all_events);
     ]

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml
@@ -123,6 +123,8 @@ let lane_policies =
   ; { lane = "memory_context"
     ; mandatory_events =
         [ Keeper_runtime_manifest.Context_injected
+        ; Keeper_runtime_manifest.Checkpoint_loaded
+        ; Keeper_runtime_manifest.Checkpoint_saved
         ; Keeper_runtime_manifest.Memory_flushed
         ]
     ; terminal_events = [ Keeper_runtime_manifest.Memory_flushed ]

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.mli
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.mli
@@ -29,6 +29,7 @@ val runtime_lens_swimlane_json :
   label:string ->
   events:Keeper_runtime_manifest.event_kind list ->
   terminal_status:string ->
+  synthetic_events:(string * int) list ->
   Yojson.Safe.t
 
 val runtime_lens_keeper_terminal_status :

--- a/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
@@ -42,6 +42,7 @@ type runtime_manifest_scan =
   ; mutable provider_started_count : int
   ; mutable provider_finished_count : int
   ; mutable provider_terminal_row : Keeper_runtime_manifest.t option
+  ; mutable dag_edges : (string * string) list
   }
 
 let make_runtime_manifest_scan ~path ~limit =
@@ -81,6 +82,7 @@ let make_runtime_manifest_scan ~path ~limit =
   ; provider_started_count = 0
   ; provider_finished_count = 0
   ; provider_terminal_row = None
+  ; dag_edges = []
   }
 
 let push_bounded queue limit value =
@@ -111,6 +113,20 @@ let update_runtime_manifest_scan scan row =
   scan.total_rows <- scan.total_rows + 1;
   push_bounded scan.returned_rows scan.limit row;
   increment_event_count scan row.Keeper_runtime_manifest.event;
+  (match
+     let decision = row.Keeper_runtime_manifest.decision in
+     let clock_refs = Yojson.Safe.Util.member "clock_refs" decision in
+     match clock_refs with
+     | `Assoc _ ->
+       let event_id = json_string_member_opt "event_id" clock_refs in
+       let parent_event_id = json_string_member_opt "parent_event_id" clock_refs in
+       (match event_id, parent_event_id with
+        | Some eid, Some peid -> Some (peid, eid)
+        | _ -> None)
+     | _ -> None
+   with
+   | Some edge -> scan.dag_edges <- edge :: scan.dag_edges
+   | None -> ());
   (match
      Yojson.Safe.Util.member "payload_role" row.Keeper_runtime_manifest.decision
    with

--- a/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.mli
+++ b/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.mli
@@ -40,6 +40,7 @@ type runtime_manifest_scan =
   ; mutable provider_started_count : int
   ; mutable provider_finished_count : int
   ; mutable provider_terminal_row : Keeper_runtime_manifest.t option
+  ; mutable dag_edges : (string * string) list
   }
 
 val make_runtime_manifest_scan :


### PR DESCRIPTION
## Summary

OAS analysis phases P3-P7 + F8 completion proof taxonomy for masc-mcp clock-spine / runtime-lens hardening.

### Implemented phases

- **P3 — Tool lineage stage enrichment**: injects 6-stage synthetic events (`searched`, `visible`, `materialized`, `emitted`, `executed`, `verified`) into the `tool_runtime` swimlane from `Tool_lineage_recorded` decision JSON. No new `event_kind` variants added.
- **P4 — Memory/Context/Checkpoint lane labeling**: `memory_context` lane renamed to "Memory/Context/Checkpoint". Terminal status now prefers `checkpoint_saved` / `checkpoint_loaded` above generic `context`.
- **P5 — Completion proof taxonomy (F8)**: 4-state lane completeness classification: `complete` (mandatory + terminal), `finished` (terminal only), `mandatory_present` (mandatory without terminal), `incomplete` (missing mandatory). Defined via `lane_policies` with per-lane mandatory/terminal event sets.
- **P7 — DAG causality edges**: extracts `parent_event_id` -> `event_id` edges from `clock_refs` in manifest rows and renders them as `dag_edges` in every swimlane JSON output. Enables concurrent-flow visualization without total-order assumptions.

### Changed files

| File | Change |
|------|--------|
| `lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml` | P5 lane policies, completeness taxonomy, P7 dag_edges JSON, synthetic_events parameter |
| `lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.mli` | `runtime_lens_swimlane_completeness` exposure |
| `lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml` | `dag_edges` accumulation from `clock_refs` |
| `lib/server/server_dashboard_http_keeper_runtime_manifest_scan.mli` | `dag_edges` field in record type |
| `lib/server/server_dashboard_http_keeper_api_runtime_lens.ml` | P3 `tool_lineage_stage_counts`, P4 memory label, swimlane wiring |

### OAS analysis reference

Source analysis: `file:///private/tmp/masc-oas-agent-logic-analysis-2026-05-21.html`

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
