### PR TITLE
refactor(gate): require reply field in keeper response

### DIFF
--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -22,10 +22,7 @@ let extract_reply_text (body : string) : string =
     let open Yojson.Safe.Util in
     match json |> member "reply" |> to_string_option with
     | Some r -> r
-    | None ->
-        (match json |> member "text" |> to_string_option with
-         | Some t -> t
-         | None -> body))
+    | None -> body)
 
 let extract_structured (body : string) : Yojson.Safe.t option =
   Safe_ops.protect ~default:None (fun () ->

--- a/lib/gate_keeper_backend.mli
+++ b/lib/gate_keeper_backend.mli
@@ -54,7 +54,8 @@ val filesystem_safe_or_unknown : string -> string
 
 val extract_reply_text : string -> string
 (** Parse the reply text from a keeper response JSON body.
-    Tries ["reply"] field first, then ["text"], then returns raw body. *)
+    Reads the ["reply"] field for JSON responses; non-JSON or missing-reply
+    bodies are returned verbatim. *)
 
 val extract_turn_stats : string -> Gate_protocol.turn_stats option
 (** Extract model usage statistics from a keeper response JSON body.

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -191,10 +191,10 @@ let test_extract_reply_from_reply_field () =
   let result = Gate_keeper_backend.extract_reply_text body in
   check string "reply field extracted" "hello world" result
 
-let test_extract_reply_fallback_to_text_field () =
+let test_extract_reply_does_not_fallback_to_text_field () =
   let body = {|{"text":"fallback content"}|} in
   let result = Gate_keeper_backend.extract_reply_text body in
-  check string "text field fallback" "fallback content" result
+  check string "text field is not reply" body result
 
 let test_extract_reply_raw_on_non_json () =
   let body = "not json at all" in
@@ -274,7 +274,8 @@ let () =
       ( "response_parsing",
         [
           test_case "reply field extracted" `Quick test_extract_reply_from_reply_field;
-          test_case "text field fallback" `Quick test_extract_reply_fallback_to_text_field;
+          test_case "text field is not reply" `Quick
+            test_extract_reply_does_not_fallback_to_text_field;
           test_case "raw body on non-json" `Quick test_extract_reply_raw_on_non_json;
           test_case "turn stats present" `Quick test_extract_turn_stats_present;
           test_case "turn stats ignore model-only payload" `Quick


### PR DESCRIPTION
## Summary
- remove `text` fallback from `Gate_keeper_backend.extract_reply_text`
- keep non-JSON/missing-reply bodies returned verbatim for transport/debug visibility
- update the response parsing test to pin that `text` is not a keeper reply field

## Validation
- `ocamlformat --check lib/gate_keeper_backend.ml lib/gate_keeper_backend.mli test/test_gate_keeper_backend.ml`
- `git diff --check`
- `scripts/ocaml-structure-ratchet.sh`
- attempted `env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=_build_gate_reply_fresh scripts/dune-local.sh build test/test_gate_keeper_backend.exe`; blocked before compile by another worktree holding the Dune lock for `test/test_keeper_unified.exe`
