### PR TITLE
fix(keeper): stop minting oas timeout before attempts

### DIFF
--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -215,8 +215,8 @@ let oas_retry_budget_available_for_turn
    paths ([adaptive_*_retry] / [static_300s_*_retry]). The current
    caller in [Keeper_unified_turn.ml:589-615] calls
    [resolve_bounded_oas_timeout_budget_with_turn_budget] and, when it
-   returns [None] for a retry, *emits* an [Oas_timeout_budget] error
-   with [source="pre_retry_budget_unavailable"]. That collapses two
+   returns [None] for a retry, emits a turn-owned timeout instead of
+   minting an [Oas_timeout_budget] root cause. That keeps two
    different failure semantics into one wire code:
      (a) the cascade attempt never started because admission budget
          was insufficient, and

--- a/lib/keeper/keeper_turn_cascade_budget.mli
+++ b/lib/keeper/keeper_turn_cascade_budget.mli
@@ -115,7 +115,7 @@ val oas_retry_budget_available_for_turn :
     Distinguishes "admission denied before any provider attempt"
     from "provider attempt ran and OAS server timed out". The
     existing call surface in [Keeper_unified_turn] emits
-    [Oas_timeout_budget] with [source="pre_retry_budget_unavailable"]
+    [Turn_timeout] instead of minting an [Oas_timeout_budget] root cause
     for the former case, which collapses both semantics into one
     metric. This function exposes the typed decision so callers can
     branch on the closed-sum reason. The matching error variant

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -623,24 +623,16 @@ let run_keeper_cycle
                                ~remaining_turn_budget_s:(remaining_turn_budget_s ())
                            with
                            | None ->
+                             let remaining_turn_budget_sec =
+                               remaining_turn_budget_s ()
+                             in
                              Error
                                (Keeper_turn_driver.sdk_error_of_masc_internal_error
-                                  (Keeper_turn_driver.Oas_timeout_budget
-                                     { budget_sec = 0.0
-                                     ; keeper_turn_timeout_sec = timeout_sec
-                                     ; estimated_input_tokens =
-                                         prompt_timeout_estimate_tokens
-                                     ; source =
-                                         (if is_retry
-                                          then "pre_retry_budget_unavailable"
-                                          else "pre_attempt_budget_unavailable")
-                                     ; remaining_turn_budget_sec =
-                                         Some (remaining_turn_budget_s ())
-                                     ; min_required_sec = min_oas_timeout_budget_sec
-                                     ; phase =
-                                         (if is_retry
-                                          then "pre_retry_budget_gate"
-                                          else "pre_attempt_budget_gate")
+                                  (Keeper_turn_driver.Turn_timeout
+                                     {
+                                       elapsed_sec =
+                                         Float.max 0.0
+                                           (timeout_sec -. remaining_turn_budget_sec);
                                      }))
                            | Some timeout_budget ->
                              attempt_timeout_budget := Some timeout_budget;


### PR DESCRIPTION
## Summary
- stop pre-attempt/pre-retry budget gates from minting a synthetic OAS timeout root cause
- classify the gate failure as turn-owned timeout instead
- update timeout-budget comments so the old synthetic emission is not documented as the intended path

## Why
A failed budget gate happens before any OAS/provider attempt. Emitting `Oas_timeout_budget` there makes a derived scheduling fact look like an immutable OAS root cause and feeds the same dashboard confusion as `failure_ratio:oas_timeout_budget`.

## Validation
Not run; iterative PR slice and local validation was not requested in this turn.
