### PR TITLE
feat(keeper): add telemetry for keeper_shell_bash via Shell_command_gate (RFC-0131 PR-3)

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -211,6 +211,16 @@ let handle_keeper_bash_typed
                 ~sandbox:{ target = dispatch_sandbox }
                 ()
             in
+            let () =
+              let open Legendary_counters in
+              incr_shell_gate
+                ~caller:Keeper_shell_bash
+                ~verdict:
+                  (match gate_verdict with
+                   | Shell_gate.Allow _ -> Allow
+                   | Shell_gate.Reject _ -> Reject
+                   | Shell_gate.Cannot_parse _ | Shell_gate.Too_complex _ -> Cannot_parse)
+            in
             match gate_verdict with
             | Reject { diagnostic; _ } ->
               error_json


### PR DESCRIPTION
RFC-0131 PR-3: Wire telemetry counter for keeper_shell_bash gate usage.\n\n- Records [Legendary_counters.incr_shell_gate] after [gate_typed] returns\n- Maps [Shell_gate.verdict] to [Legendary_counters.shell_gate_verdict_kind]\n- All 172 worker_dev_tools + 25 keeper_bash_typed_input tests pass