### PR TITLE
refactor(keeper): add Result-returning resolve_live_with_catalog_result (RFC-0149 §3.3 PR-1)

### DIFF
--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -575,7 +575,15 @@ let normalize_keeper_runtime_declared_name ?config_path raw =
   then cascade_name_for_use ?config_path Keeper_turn
   else normalized
 
-let resolve_live_with_catalog ~catalog raw =
+(* RFC-0149 §3.3 — "Parse, don't validate" reverse of the silent-fallback
+   shape.  [resolve_live_with_catalog_result] returns [Ok runtime_name]
+   when the catalog can resolve the input, otherwise [Error (`Unresolved
+   raw)].  The legacy [resolve_live_with_catalog] below keeps the silent
+   fallback + WARN-once + counter for callers that have not yet migrated,
+   but the unresolved branch is now isolated to a single [Error] arm so
+   the sunset path is mechanical. *)
+let resolve_live_with_catalog_result ~catalog raw :
+    (runtime_name, [ `Unresolved of string ]) result =
   let trimmed = String.trim raw in
   let normalized =
     if List.mem trimmed catalog then trimmed
@@ -584,20 +592,27 @@ let resolve_live_with_catalog ~catalog raw =
       | Some use -> Cascade_routes.fallback_name_for_catalog use ~catalog
       | None -> trimmed
   in
-  if List.mem normalized catalog then normalized
-  else begin
-    (* Iter 36: raw cascade name doesn't normalize to a catalog
-       member.  Silently falls back to [Keeper_turn] default —
-       operator's intended cascade is invalidated.  Distinct from
-       iter-30 [route_resolve_fallback] which catches the
-       route-table path; this is the direct-raw-name path.
+  (* [normalized] is already verified to be a catalog member, so it is
+     canonical; bypass [runtime_name_of_string]'s re-canonicalization
+     (also avoids the forward reference — [runtime_name_of_string] is
+     defined further below). *)
+  if List.mem normalized catalog then Ok (Runtime_name normalized)
+  else Error (`Unresolved raw)
 
-       2026-05-20: counter alone was not enough — operators were
-       reading Prometheus but the cascade name that failed to
-       resolve was not in the metric (cardinality bound).  Surface
-       the unresolved name in a WARN line that fires once per
-       distinct raw value so operators can fix the typo / stale
-       cascade.toml entry without grepping the audit JSONL. *)
+let resolve_live_with_catalog ~catalog raw =
+  match resolve_live_with_catalog_result ~catalog raw with
+  | Ok name -> runtime_name_to_string name
+  | Error (`Unresolved raw') ->
+    let trimmed = String.trim raw' in
+    (* WORKAROUND: RFC-0149 §3.3 sunset target #16787.  Counter + WARN-once
+       remain in the legacy [string]-returning entry point only; the new
+       Result-returning helper above surfaces [Error (`Unresolved raw)]
+       directly so callers can fail-loud at config load time.
+
+       Removal: once every caller migrates to
+       [resolve_live_with_catalog_result], delete this Error arm together
+       with [Cascade_metrics.on_resolve_live_fallback] and
+       [logged_unresolved_raw] per RFC-0149 §3.3 sunset criterion. *)
     Cascade_metrics.on_resolve_live_fallback ();
     if not (Hashtbl.mem logged_unresolved_raw trimmed) then begin
       Hashtbl.add logged_unresolved_raw trimmed ();
@@ -608,7 +623,6 @@ let resolve_live_with_catalog ~catalog raw =
         trimmed
     end;
     Cascade_routes.fallback_name_for_catalog Keeper_turn ~catalog
-  end
 
 let resolve_live ?config_path raw =
   resolve_live_with_catalog ~catalog:(catalog_lookup_names ?config_path ()) raw

--- a/lib/keeper/keeper_cascade_profile.mli
+++ b/lib/keeper/keeper_cascade_profile.mli
@@ -116,13 +116,34 @@ val is_system_only_cascade : string -> bool
 val canonicalize_with_catalog : catalog:string list -> string -> string
 (** Resolves dynamic profiles against an explicit live catalog. *)
 
+val resolve_live_with_catalog_result :
+  catalog:string list -> string -> (runtime_name, [ `Unresolved of string ]) result
+(** Result-returning variant of {!resolve_live_with_catalog}.  Callers
+    that want to distinguish unresolved input from a successful lookup
+    should use this entry point; the legacy [resolve_live_with_catalog]
+    silently falls back to the [Keeper_turn] default and emits a WARN +
+    counter (RFC-0149 §3.3 workaround #16787, sunset target).
+
+    Returns [Ok (Runtime_name normalized)] when [raw] either matches the
+    catalog directly or normalizes via a logical route alias that lands
+    on a catalog member; otherwise [Error (`Unresolved raw)] carrying the
+    original (un-trimmed) input so the operator-visible diagnostic can
+    point to exactly what was provided.
+
+    @since RFC-0149 Phase 1 *)
+
 val resolve_live_with_catalog : catalog:string list -> string -> string
 (** Resolves a keeper-declared cascade against an explicit live catalog.
 
     Names already present in the catalog pass through; logical route
     aliases collapse via [routes]; otherwise the keeper-turn fallback is used.
     Callers that accept qualified declarative names must pass a lookup catalog
-    containing those qualified names, not only display/public names. *)
+    containing those qualified names, not only display/public names.
+
+    {b Note:} For new callers, prefer {!resolve_live_with_catalog_result}
+    which returns a typed [Error (`Unresolved _)] instead of silently
+    falling back.  This entry point retains the silent-fallback behaviour
+    for the RFC-0149 §3.3 sunset window. *)
 
 val resolve_live : ?config_path:string -> string -> string
 (** Like {!resolve_live_with_catalog}, but reads the active catalog from the


### PR DESCRIPTION
# refactor(keeper): add Result-returning resolve_live_with_catalog_result (RFC-0149 §3.3 PR-1)

## 배경

RFC-0149 §3.3 ("`resolve_live_with_catalog` — typed `Cascade_name.t` parse, replaces #16787") 은 silent-fallback 워크어라운드 (Cascade_metrics counter + WARN-once Hashtbl + `Cascade_routes.fallback_name_for_catalog Keeper_turn ~catalog` 반환) 를 typed Result.t 로 대체한다.

기존 28 caller 를 한 PR 에서 전부 migrate 하면 N-of-M risk + revert 폭탄. **PR-1 은 새 Result-returning helper 만 추가**하고 legacy fn 은 그 helper 의 facade 로 변환 — caller 안 건드림. 후속 PR-N (per-caller migrate) 후 closeout PR (legacy fn + counter + Hashtbl 삭제).

## 변경 범위

```
lib/keeper/keeper_cascade_profile.ml  | +18 -16 (new helper + facade refactor)
lib/keeper/keeper_cascade_profile.mli | +21 -1  (new val + deprecation note)
```

## 새 entry point

```ocaml
val resolve_live_with_catalog_result :
  catalog:string list -> string -> (runtime_name, [ `Unresolved of string ]) result
```

- `Ok (Runtime_name normalized)` — catalog 또는 logical route alias 로 해소된 경우
- `Error (`Unresolved raw)` — 원본 (un-trimmed) input 보존하여 operator 진단에 유용

legacy `resolve_live_with_catalog : ... -> string` 은 이제 새 helper 를 호출 + Error arm 에서만 silent fallback (counter + WARN + Hashtbl). 추가 변경 없음.

## RFC §3.3 spec 와의 일치

- RFC 가 명세한 `Cascade_name.t` 는 codebase 의 *existing* type `Keeper_cascade_profile.runtime_name` (또는 `Cascade_ref.runtime_name = Runtime_name of string` ) 를 사용 — 새 module wrap 없이 캐논 type 직접 활용
- error variant `` `Unresolved of string `` RFC §3.3 typed signature 와 byte-equal
- 이 PR 은 RFC §3.3 의 caller migration 부분 (cascade_name_for_use, downstream branch on `Ok`/`Error`) 은 *건드리지 않음*. 그건 후속 stack PR.

## Workaround Rejection Bar self-check

- §1 텔레메트리-as-fix: 새 entry point 가 `Error` arm 으로 unresolved 를 *직접 surface* — counter 추가 0, 새 helper 본체에 telemetry 없음. legacy fn 의 기존 counter+WARN+Hashtbl 은 (a) 본 PR 후 *single Error arm 에 isolated*, (b) sunset criterion 명시 + `WORKAROUND:` 주석 추가, (c) closeout PR 에서 제거 예정. CLAUDE.md `워크어라운드 거부 기준 Override` 조건 충족 (deprecated path + RFC reference + removal target).
- §2 substring/literal 분류기 보강: 0
- §3 N-of-M 패치: 새 helper 만 *one entry point* 로 추가 (분할 없음). caller migrate 는 후속 PR 의 별개 책임.
- catch-all 추가 0, cap/cooldown/dedup/repair 0, test backdoor 0

## 정량 완료 기준

- `dune build --root . lib/keeper/`: pass (확인됨)
- `dune build --root .`: pass (전체 lib)
- `dune runtest test/test_keeper_toml_config_validation.ml`: 25/26 pass.
  - 1 fail (`config/keepers 4 verifier hides worker liaison`) 은 **pre-existing main bug** — 같은 test 가 `masc_transition` 을 line 240 keep-list 와 line 250 hide-list 양쪽에 넣어 둠 (test_keeper_toml_config_validation.ml:240/250 contradiction). 본 PR diff 와 무관. main HEAD 195f64ba84 기준으로 미리 깨져 있음.
  - 이 PR 이 손대는 `resolve_live` (line 626-629 tier.primary / tier-group.primary 검증) 두 케이스는 통과 — facade 정합 확인.

## 테스트 보완 (후속)

- `resolve_live_with_catalog_result` 의 `Ok`/`Error` 분기 직접 assert 하는 단위 test 는 PR-2 또는 별개 follow-up. 본 PR 에서는 (a) 빌드 통과 + (b) legacy fn 통과로 캐스트 검증.
- RFC §3.3 "Tests assert that *no path* returns `Cascade_routes.fallback_name_for_catalog Keeper_turn ~catalog` for unresolved input" 은 caller migration PR 들에서 caller-level test 로 확립 — `Error` 분기 받은 caller 가 boot-time error 또는 operator alert 로 propagate 하는지 검증.

## 후속

- PR-2~PR-N: 28 caller (`anti_rationalization.ml`, `keeper_turn_cascade_budget.ml`, dashboard/server, tests) 를 새 entry point 로 점진 migrate. caller 그룹별 stack PR.
- PR-closeout: legacy `resolve_live_with_catalog` + `Cascade_metrics.on_resolve_live_fallback` + `logged_unresolved_raw` Hashtbl 삭제. workaround #16787 sunset 완료.

## Co-Authored-By

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
