### PR TITLE
fix(keeper): preserve structural timeout root cause

### DIFF
--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -392,19 +392,8 @@ let reclassify_oas_timeout_for_attempt
   match err, timeout_budget with
   | Agent_sdk.Error.Api (Timeout { message }), Some timeout_budget
     when EC.is_structural_oas_timeout_message message ->
-      Keeper_turn_driver.sdk_error_of_masc_internal_error
-        (Keeper_turn_driver.Oas_timeout_budget
-           {
-             budget_sec = timeout_budget.effective_timeout_sec;
-             keeper_turn_timeout_sec =
-               timeout_budget.keeper_turn_timeout_sec;
-             estimated_input_tokens = timeout_budget.estimated_input_tokens;
-             source = timeout_budget.source;
-             remaining_turn_budget_sec =
-               Some timeout_budget.remaining_turn_budget_sec;
-             min_required_sec = min_oas_timeout_budget_sec;
-             phase = "cascade_attempt_watchdog";
-           })
+      ignore timeout_budget;
+      err
   | _ -> err
 
 let attempt_watchdog_outer_turn_reserve_sec = 1.0

--- a/lib/keeper/keeper_turn_cascade_budget.mli
+++ b/lib/keeper/keeper_turn_cascade_budget.mli
@@ -164,6 +164,9 @@ val reclassify_oas_timeout_for_attempt :
   timeout_budget:oas_timeout_budget_resolution option ->
   Agent_sdk.Error.sdk_error ->
   Agent_sdk.Error.sdk_error
+(** Preserve upstream structural timeout errors instead of minting a synthetic
+    [Oas_timeout_budget] root cause.  Kept as a named hook while the
+    provider-timeout root-cause ADT is introduced in a later PR. *)
 
 val attempt_watchdog_timeout_sec :
   remaining_turn_budget_s:float ->


### PR DESCRIPTION
## Summary
- stop structural OAS timeout reclassification from minting `Oas_timeout_budget`
- preserve the upstream timeout error at the reclassification hook
- update comments to describe the legacy synthetic-budget path as legacy, not intended behavior

## Why
A structural provider/OAS timeout is a provider-attempt fact. Re-emitting it as `Oas_timeout_budget` makes a derived budget projection look like an immutable root cause, which then fans out into keeper blocker class, health probe, dashboard attention reason, and operator action.

## Validation
Not run; iterative PR slice and local validation was not requested in this turn.
