### PR TITLE
refactor(keeper): add Result-returning resolve_live_result wrapper (RFC-0149 §3.3 PR-2)

### DIFF
--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -627,6 +627,15 @@ let resolve_live_with_catalog ~catalog raw =
 let resolve_live ?config_path raw =
   resolve_live_with_catalog ~catalog:(catalog_lookup_names ?config_path ()) raw
 
+(* RFC-0149 §3.3 — Result-returning wrapper that reads the active catalog
+   from the resolved cascade config path.  Mirrors {!resolve_live} for
+   callers that need to fail loud on unresolved input instead of taking
+   the silent fallback. *)
+let resolve_live_result ?config_path raw :
+    (runtime_name, [ `Unresolved of string ]) result =
+  resolve_live_with_catalog_result
+    ~catalog:(catalog_lookup_names ?config_path ()) raw
+
 let canonicalize (raw : string) : string =
   canonicalize_with_catalog ~catalog:(catalog_names ()) raw
 

--- a/lib/keeper/keeper_cascade_profile.mli
+++ b/lib/keeper/keeper_cascade_profile.mli
@@ -149,6 +149,17 @@ val resolve_live : ?config_path:string -> string -> string
 (** Like {!resolve_live_with_catalog}, but reads the active catalog from the
     resolved cascade config path. *)
 
+val resolve_live_result :
+  ?config_path:string -> string -> (runtime_name, [ `Unresolved of string ]) result
+(** Result-returning variant of {!resolve_live} — wraps
+    {!resolve_live_with_catalog_result} with the active catalog loaded
+    from [config_path].  Callers that should fail loud on unresolved
+    input (boot-time error, operator alert) use this entry point; the
+    legacy {!resolve_live} silently falls back to [Keeper_turn] default
+    (RFC-0149 §3.3 sunset target).
+
+    @since RFC-0149 Phase 1 *)
+
 val canonicalize : string -> string
 (** Catalog-aware normalization: legacy aliases collapse to their canonical
     name through [routes], live catalog names pass through, otherwise


### PR DESCRIPTION
# refactor(keeper): add Result-returning resolve_live_result wrapper (RFC-0149 §3.3 PR-2)

## 배경

PR-1 (#17644) 이 `resolve_live_with_catalog_result` 을 추가했다. `resolve_live_with_catalog` 의 직접 caller 는 internal 1개 (`resolve_live` wrapper) 라 외부 caller migration 은 `resolve_live` 레벨에서 일어난다. 본 PR 은 `resolve_live` 의 Result-returning sibling `resolve_live_result` 을 추가한다 — PR-1 패턴 그대로, caller 안 건드림.

**Stacked on**: PR #17644 (RFC-0149 §3.3 PR-1).

## 변경 범위

```
lib/keeper/keeper_cascade_profile.ml  | +9
lib/keeper/keeper_cascade_profile.mli | +11
```

새 entry point:

```ocaml
val resolve_live_result :
  ?config_path:string -> string -> (runtime_name, [ `Unresolved of string ]) result
```

구현은 PR-1 helper 의 thin wrapper — `catalog:(catalog_lookup_names ?config_path ())` 만 추가:

```ocaml
let resolve_live_result ?config_path raw =
  resolve_live_with_catalog_result
    ~catalog:(catalog_lookup_names ?config_path ()) raw
```

## Scope 정정 (iter 5 task 메모 → iter 7 reality)

iter 5 task 설명에 "28 caller migration" 명시했었으나 grep 패턴이 `resolve_live_with_catalog|cascade_name_for_use` 조인이라 과대. 실제 직접 caller:

| 함수 | 직접 caller 수 |
|------|--------------|
| `resolve_live_with_catalog` | 1 (internal `resolve_live` wrapper) |
| `resolve_live` | 3 prod + 2 test |

3 production callers:
- `lib/operator/operator_control_snapshot_identity_fields.ml:16` — operator identity surface
- `lib/dashboard_cascade_config.ml:235` — dashboard config "canonical" field
- `lib/dashboard/dashboard_http_keeper_types.ml:14` — dashboard HTTP keeper types

Per-caller migration (PR-3/4/5) routes each through `resolve_live_result` + surfaces `Error (`Unresolved _)` on the appropriate operator-visible path (boot-time error, identity-resolution error, dashboard alert).

## Workaround Rejection Bar self-check

- §1 텔레메트리-as-fix: 새 entry point 0 telemetry, legacy fn 의 counter+WARN 그대로 (PR-1 이 isolation 완료)
- §2 substring/literal 분류기 보강: 0
- §3 N-of-M 패치: PR-1 이 catalog-explicit, 본 PR 이 config-reading wrapper — *2개 entry point 모두 단일 PR 단위* (no leftover sites at this abstraction layer)
- catch-all 추가 0, cap/cooldown/dedup/repair 0, test backdoor 0

## 정량 완료 기준

- `dune build --root . lib/keeper/`: pass (확인됨)
- PR-1 + PR-2 누적: 두 entry point (catalog-explicit, config-reading) 모두 Result-returning helper 보유

## 후속

- PR-3: `operator_control_snapshot_identity_fields.ml:16` migration — Error 를 identity resolution error 로 surface
- PR-4: `dashboard_cascade_config.ml:235` migration — Error 를 "unresolved: <raw>" 또는 explicit null 로 surface
- PR-5: `dashboard/dashboard_http_keeper_types.ml:14` migration — Error 를 HTTP 4xx 또는 typed error response 로 surface
- PR-closeout: legacy `resolve_live` + `resolve_live_with_catalog` (silent fallback path) + `Cascade_metrics.on_resolve_live_fallback` + `logged_unresolved_raw` Hashtbl 삭제

## Co-Authored-By

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
