### PR TITLE
fix(keeper): surface cascade exhaustion as aggregate

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -220,13 +220,16 @@ let cascade_exhaustion_summary = function
   | Dns_failure ->
     "Cascade exhausted; hostname resolution failed (DNS)."
   | No_providers_available -> "Cascade exhausted; no providers were available."
-  | All_providers_failed -> "Cascade exhausted after all configured providers failed."
-  | Candidates_filtered_after_cycles -> "Cascade exhausted after provider failures."
+  | All_providers_failed ->
+    "Cascade exhausted after all configured providers failed; inspect per-attempt root causes."
+  | Candidates_filtered_after_cycles ->
+    "Cascade exhausted after provider candidates were filtered; inspect candidate filter reasons."
   | Max_turns_exceeded ->
     "Cascade exhausted after a provider hit its per-call turn budget."
   | Structural_attempt_timeout _ ->
     "Cascade exhausted after the per-OAS-call ceiling (max_execution_time_s) fired."
-  | Other_detail _ -> "Cascade exhausted after provider failures."
+  | Other_detail _ ->
+    "Cascade exhausted; inspect cascade attempts for the dominant root cause."
 ;;
 
 let blocker_class_continue_gate = function

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -258,6 +258,12 @@ let is_timeout_budget_blocker_class blocker_class =
   || String.equal blocker_class (blocker_class_to_string Turn_timeout)
 ;;
 
+let is_cascade_exhausted_blocker_class blocker_class =
+  String.equal
+    blocker_class
+    (blocker_class_to_string (Cascade_exhausted (Other_detail "")))
+;;
+
 let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
   : runtime_blocker_surface
   =
@@ -735,6 +741,8 @@ let attention_fields_json (config : Coord_utils.config) (meta : keeper_meta) =
         true, Some "paused", Some "inspect_blocker_before_resume"
       | Some blocker when is_timeout_budget_blocker_class blocker.blocker_class ->
         true, Some "timeout_budget_exhausted", Some "inspect_timeout_budget"
+      | Some blocker when is_cascade_exhausted_blocker_class blocker.blocker_class ->
+        true, Some "cascade_attempts_exhausted", Some "inspect_cascade_attempts"
       | Some _ -> true, Some "runtime_blocked", Some "inspect_runtime_blocker"
       | None when meta.paused -> true, Some "paused", Some "resume_or_review"
       | None when not social_model_recognized ->


### PR DESCRIPTION
## Summary
- stop cascade exhaustion attention from falling through to generic `runtime_blocked`
- surface cascade exhaustion as `cascade_attempts_exhausted` with `inspect_cascade_attempts`
- update cascade exhaustion summaries to point operators at per-attempt root causes instead of implying a single root cause

## Why
`cascade_exhausted` is an aggregate outcome. When the dashboard treats it like a generic runtime blocker, it looks like a root cause and hides the provider/capability/filter/admission cause underneath. This PR keeps the existing class for compatibility but makes the projection explicit: inspect the cascade attempts for the dominant cause.

## Validation
Not run; iterative PR slice and local validation was not requested in this turn.
