### PR TITLE
refactor(operator): migrate identity fields to resolve_live_result (RFC-0149 §3.3 PR-3)

### DIFF
--- a/lib/operator/operator_control_snapshot_identity_fields.ml
+++ b/lib/operator/operator_control_snapshot_identity_fields.ml
@@ -13,10 +13,22 @@ let non_empty_trimmed_string_opt value =
 
 let keeper_runtime_identity_fields (meta : Keeper_types.keeper_meta) =
   let cascade_name = Keeper_types.cascade_name_of_meta meta in
-  let effective_cascade = Keeper_cascade_profile.resolve_live cascade_name in
-  [ "cascade_name", string_option_to_json (non_empty_trimmed_string_opt cascade_name)
-  ; "cascade_canonical", `String effective_cascade
-  ; "selected_cascade_canonical", `String effective_cascade
+  let cascade_name_json =
+    string_option_to_json (non_empty_trimmed_string_opt cascade_name)
+  in
+  (* RFC-0149 §3.3 — use the Result-returning resolver so an unresolved
+     cascade surfaces as the original input on the canonical fields
+     (matching the degraded-fallback shape below) instead of the silent
+     [Keeper_turn] default the legacy [resolve_live] would have written. *)
+  let canonical_json =
+    match Keeper_cascade_profile.resolve_live_result cascade_name with
+    | Ok runtime ->
+      `String (Keeper_cascade_profile.runtime_name_to_string runtime)
+    | Error (`Unresolved _) -> cascade_name_json
+  in
+  [ "cascade_name", cascade_name_json
+  ; "cascade_canonical", canonical_json
+  ; "selected_cascade_canonical", canonical_json
   ; "primary_model", `Null
   ; "active_model", `Null
   ; "active_model_label", `Null


### PR DESCRIPTION
# refactor(operator): migrate identity fields to resolve_live_result (RFC-0149 §3.3 PR-3)

## 배경

PR-1 (#17644) 과 PR-2 (#17646) 가 `resolve_live_with_catalog_result` + `resolve_live_result` 두 Result-returning entry point 를 추가했다. 본 PR 은 3 prod caller 중 첫 migration — `keeper_runtime_identity_fields` 의 cascade 해소를 silent fallback path 에서 typed Error 분기로 전환한다.

## 변경 범위

```
lib/operator/operator_control_snapshot_identity_fields.ml | +16 -4
```

단일 파일, 단일 함수 (`keeper_runtime_identity_fields`).

## Before / After

**Before** — legacy `resolve_live` silent fallback:

```ocaml
let effective_cascade = Keeper_cascade_profile.resolve_live cascade_name in
[ "cascade_name", string_option_to_json (non_empty_trimmed_string_opt cascade_name)
; "cascade_canonical", `String effective_cascade
; "selected_cascade_canonical", `String effective_cascade
; ... ]
```

Unresolved cascade → `effective_cascade = Cascade_routes.fallback_name_for_catalog Keeper_turn ~catalog` (silently). Operator 화면에 *Keeper_turn* 이 표시돼 keeper 가 의도한 cascade 가 무엇이었는지 알 수 없음.

**After** — typed `Error` 분기:

```ocaml
let canonical_json =
  match Keeper_cascade_profile.resolve_live_result cascade_name with
  | Ok runtime -> `String (Keeper_cascade_profile.runtime_name_to_string runtime)
  | Error (`Unresolved _) -> cascade_name_json
in
[ "cascade_name", cascade_name_json
; "cascade_canonical", canonical_json
; "selected_cascade_canonical", canonical_json
; ... ]
```

Unresolved → canonical/selected 가 *원본 cascade_name* 으로 surface. `degraded_keeper_runtime_identity_fields` (이미 존재하는 fallback) 와 동일 shape. Operator 가 실제 unresolved 값을 본다 — typo / stale cascade.toml entry 진단 가능.

## RFC §3.3 spec 와의 일치

> Caller sites: ... branch on [Ok name] (use) vs. [Error (`Unresolved raw)] (boot-time error or operator-visible alert; never default-route).

본 caller 는 *snapshot read* 컨텍스트 (boot 도 turn-time 도 아닌 inspection), boot-time error 는 부적합. Operator-visible alert = "actual input 을 그대로 surface" — 즉 operator 가 dashboard 에서 직접 wrong value 를 봄. RFC §3.3 spec 의 "never default-route" 통과.

## Workaround Rejection Bar self-check

- §1 텔레메트리-as-fix: 0 (counter 안 호출, legacy path 에 있던 `on_resolve_live_fallback` 도 이 caller 에서 더 이상 트리거 안 됨 — 진짜 감소)
- §2 substring 분류기 보강: 0
- §3 N-of-M 패치: 본 PR 단일 caller, 다른 2 caller (dashboard) 는 별개 PR. PR scope 가 명확.
- catch-all 추가 0, cap/cooldown/dedup/repair 0

## 정량 완료 기준

- `dune build --root . lib/operator/`: pass (확인됨)
- `test_operator_control_keeper.ml` runtest: **별개의 pre-existing main error** 로 차단됨 (`Keeper_metrics.metric_keeper_tools_oas_deterministic_failures` unbound in `keeper_tool_alias.pp.ml`). 본 PR diff 와 무관. main HEAD 75d9c1f73a 기준 확인.
- 함수 시그니처 변경 0 — caller (operator snapshot consumer) compat.

## 후속

- PR-4: `dashboard_cascade_config.ml:235` migration (`canonical` field)
- PR-5: `dashboard/dashboard_http_keeper_types.ml:14` migration (HTTP keeper types)
- PR-closeout: legacy `resolve_live` + `resolve_live_with_catalog` (silent fallback) + `Cascade_metrics.on_resolve_live_fallback` + `logged_unresolved_raw` Hashtbl 삭제

## Co-Authored-By

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

---

RFC-WAIVED: 본 PR 은 RFC-0149 §3.3 sunset implementation 의 일부로 single function (`keeper_runtime_identity_fields`) 의 cascade 해소 호출만 변경. lib/operator subsystem 의 credential/identity/auth RFCs (0008/0019/0038/0074) 의 SSOT 영역 (credential, sandbox, auto-provision) 을 건드리지 않음 — caller-side migration 만이며 cascade name typed Error surface 가 추가 effect. RFC-0149 frontmatter status: Active.
