### PR TITLE
fix(keeper): add cascade exhausted disposition

### DIFF
--- a/lib/keeper/keeper_turn_disposition.ml
+++ b/lib/keeper/keeper_turn_disposition.ml
@@ -13,6 +13,7 @@ type t =
   | External_cancel
   | Turn_wall_clock_timeout
   | Oas_timeout_budget
+  | Cascade_attempts_exhausted
   | Gh_repo_context_missing_worktree
   | Required_tool_use_no_tool_call
   | Required_tool_use_unsatisfied
@@ -31,6 +32,7 @@ let severity = function
   | External_cancel
   | Turn_wall_clock_timeout
   | Oas_timeout_budget
+  | Cascade_attempts_exhausted
   | Gh_repo_context_missing_worktree -> Warn
   | Required_tool_use_no_tool_call
   | Required_tool_use_unsatisfied
@@ -45,6 +47,8 @@ let summary = function
   | Turn_wall_clock_timeout -> "keeper turn hit the wall-clock timeout"
   | Oas_timeout_budget ->
     "OAS call was skipped or failed because the turn timeout budget was exhausted"
+  | Cascade_attempts_exhausted ->
+    "cascade attempts exhausted; inspect per-attempt root causes"
   | Gh_repo_context_missing_worktree ->
     "GitHub command blocked because the active task has no linked worktree"
   | Required_tool_use_no_tool_call ->
@@ -63,6 +67,7 @@ let next_action = function
   | Success -> None
   | External_cancel -> Some "rerun_if_still_relevant"
   | Turn_wall_clock_timeout | Oas_timeout_budget -> Some "inspect_timeout_budget"
+  | Cascade_attempts_exhausted -> Some "inspect_cascade_attempts"
   | Gh_repo_context_missing_worktree -> Some "create_or_link_worktree"
   | Required_tool_use_no_tool_call | Required_tool_use_unsatisfied ->
     Some "inspect_provider_tool_contract"
@@ -75,6 +80,7 @@ let to_wire = function
   | External_cancel -> "external_cancel"
   | Turn_wall_clock_timeout -> "turn_wall_clock_timeout"
   | Oas_timeout_budget -> "oas_timeout_budget"
+  | Cascade_attempts_exhausted -> "cascade_attempts_exhausted"
   | Gh_repo_context_missing_worktree -> "gh_repo_context_missing_worktree"
   | Required_tool_use_no_tool_call -> "required_tool_use_no_tool_call"
   | Required_tool_use_unsatisfied -> "required_tool_use_unsatisfied"
@@ -120,6 +126,7 @@ let of_wire = function
   | "external_cancel" -> External_cancel
   | "turn_wall_clock_timeout" -> Turn_wall_clock_timeout
   | "oas_timeout_budget" -> Oas_timeout_budget
+  | "cascade_attempts_exhausted" -> Cascade_attempts_exhausted
   | "gh_repo_context_missing_worktree" -> Gh_repo_context_missing_worktree
   | "required_tool_use_no_tool_call" -> Required_tool_use_no_tool_call
   | "required_tool_use_unsatisfied" -> Required_tool_use_unsatisfied
@@ -137,6 +144,7 @@ let equal a b =
   | External_cancel, External_cancel
   | Turn_wall_clock_timeout, Turn_wall_clock_timeout
   | Oas_timeout_budget, Oas_timeout_budget
+  | Cascade_attempts_exhausted, Cascade_attempts_exhausted
   | Gh_repo_context_missing_worktree, Gh_repo_context_missing_worktree
   | Required_tool_use_no_tool_call, Required_tool_use_no_tool_call
   | Required_tool_use_unsatisfied, Required_tool_use_unsatisfied
@@ -147,6 +155,7 @@ let equal a b =
   | External_cancel, _
   | Turn_wall_clock_timeout, _
   | Oas_timeout_budget, _
+  | Cascade_attempts_exhausted, _
   | Gh_repo_context_missing_worktree, _
   | Required_tool_use_no_tool_call, _
   | Required_tool_use_unsatisfied, _

--- a/lib/keeper/keeper_turn_disposition.mli
+++ b/lib/keeper/keeper_turn_disposition.mli
@@ -30,6 +30,10 @@ type t =
   (** Turn cancelled before completion (operator stop, switch_keeper, …). *)
   | Turn_wall_clock_timeout (** Turn exceeded its wall-clock budget. *)
   | Oas_timeout_budget (** OAS turn-budget cooldown / cap rejection. *)
+  | Cascade_attempts_exhausted
+  (** Cascade aggregate outcome: all candidate attempts were exhausted.
+          Operators should inspect per-attempt root causes instead of treating
+          this as the root cause. *)
   | Gh_repo_context_missing_worktree
   (** GitHub command blocked because the active task has no linked
           worktree. *)
@@ -91,6 +95,7 @@ val next_action : t -> string option
     - [External_cancel] → ["external_cancel"]
     - [Turn_wall_clock_timeout] → ["turn_wall_clock_timeout"]
     - [Oas_timeout_budget] → ["oas_timeout_budget"]
+    - [Cascade_attempts_exhausted] → ["cascade_attempts_exhausted"]
     - [Gh_repo_context_missing_worktree] → ["gh_repo_context_missing_worktree"]
     - [Required_tool_use_no_tool_call] → ["required_tool_use_no_tool_call"]
     - [Required_tool_use_unsatisfied] → ["required_tool_use_unsatisfied"]

--- a/lib/keeper/keeper_turn_terminal.ml
+++ b/lib/keeper/keeper_turn_terminal.ml
@@ -80,6 +80,10 @@ let of_failure ?(post_commit_ambiguous = false) ?(tool_call_count = 0) ~raw_erro
       make ~source:"typed_error" "oas_timeout_budget"
     | Some (Keeper_turn_driver.Capacity_backpressure _) ->
       make ~source:"typed_error" "capacity_backpressure"
+    | Some (Keeper_turn_driver.Cascade_exhausted _) ->
+      of_disposition
+        ~source:"typed_error"
+        Keeper_turn_disposition.Cascade_attempts_exhausted
     | Some (Keeper_turn_driver.Turn_timeout _) ->
       make ~source:"typed_error" "turn_wall_clock_timeout"
     | _ ->


### PR DESCRIPTION
## Summary
- add a dedicated `Cascade_attempts_exhausted` keeper turn disposition
- map typed `Cascade_exhausted` terminal errors to the aggregate disposition instead of generic provider error
- set the operator action to `inspect_cascade_attempts`

## Why
`cascade_exhausted` is an aggregate outcome, not the immutable root cause. Without a dedicated disposition, terminal reporting can make cascade exhaustion look like a generic provider/root failure. This PR keeps the root cause model clearer by making the operator projection explicitly aggregate-oriented.

## Validation
Not run; iterative PR slice and local validation was not requested in this turn.
