### PR TITLE
fix(build): restore register_structured_routes and export deterministic_failures metric

### DIFF
--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -363,6 +363,7 @@ val metric_keeper_board_signal_wakeup_capped_total : string
 val metric_keeper_board_signal_no_wake_total : string
 val metric_keeper_meta_json_failures : string
 val metric_keeper_tools_oas_failures : string
+val metric_keeper_tools_oas_deterministic_failures : string
 val metric_keeper_oas_hook_output_parse_failures : string
 val metric_keeper_turn_up_update_failures : string
 val metric_keeper_exec_tools_failures : string

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -410,6 +410,19 @@ let translate_input ~public input =
    because the per-tool helpers above are not yet in scope at table creation
    time. This [register] call patches in the real values. *)
 
+let rec register_structured_routes () =
+  Hashtbl.replace routing_table "Bash"
+    { internal_name = "keeper_bash"
+    ; translate = translate_bash_input
+    ; public_schema = Some (bash_public_schema)
+    };
+  Hashtbl.replace routing_table "Grep"
+    { internal_name = "keeper_shell"
+    ; translate = translate_bash_input
+    ; public_schema = Some (bash_public_schema)
+    }
+;;
+
 let () =
   List.iter
     (fun (pub, schema, translator) ->


### PR DESCRIPTION
Build fix for two compile errors on main:\n\n1.  declared in  but not in \n2.  used in  but not exported in 