### PR TITLE
fix(alias): remove keeper_fs_read from Read public schema description

### DIFF
--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -200,7 +200,7 @@ let read_public_schema =
     ; property
         "limit"
         "integer"
-        "Approximate maximum bytes to return (mapped to keeper_fs_read max_bytes; \
+        "Approximate maximum bytes to return (byte-based limit; \
          line-based limit is not supported)."
     ; property
         "offset"


### PR DESCRIPTION
## Summary
- Remove internal name `keeper_fs_read` from `read_public_schema`'s `limit` property description
- The description now says "byte-based limit" instead of "mapped to keeper_fs_read max_bytes"
- `public_input_schema` is currently dead code (zero consumers), but this prevents a leak if activated

## Test plan
- [ ] Existing `test_keeper_internal_descriptions_no_cross_leak` regression test passes (scans for internal name leaks)
- [ ] `dune build` passes (description-only change, no logic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)