### PR TITLE
fix(keeper): P2 clock_refs emit enrichment for remaining gaps

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1781,6 +1781,11 @@ let run_turn
            | [] -> None
            | _ -> Keeper_tool_call_log.current_log_path ()
          in
+         let clock_refs =
+           Keeper_runtime_manifest.clock_refs_for_context
+             runtime_manifest_context ~event ()
+         in
+         let decision = Keeper_runtime_manifest.with_clock_refs ~clock_refs decision in
          Keeper_runtime_manifest.make ~ts:receipt.ended_at
            ~keeper_name:receipt.keeper_name ~agent_name:receipt.agent_name
            ~trace_id:receipt.trace_id ~generation:receipt.generation

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -917,7 +917,8 @@ let append_unfinished_provider_attempt_finished_best_effort
   | Ok (Some started) ->
     let inherited_fields =
       match started.decision with
-      | `Assoc fields -> fields
+      | `Assoc fields ->
+        List.filter (fun (k, _) -> not (String.equal k "clock_refs")) fields
       | _ -> []
     in
     let terminal_fields =
@@ -934,9 +935,12 @@ let append_unfinished_provider_attempt_finished_best_effort
       | None -> terminal_fields
       | Some kind -> ("exception_kind", `String kind) :: terminal_fields
     in
+    let decision = `Assoc (inherited_fields @ terminal_fields) in
+    let clock_refs = clock_refs_for_context ctx ~event:Provider_attempt_finished () in
+    let decision = with_clock_refs ~clock_refs decision in
     make_for_context ctx ~event:Provider_attempt_finished
       ?cascade_name:started.cascade_name
       ~status
-      ~decision:(`Assoc (inherited_fields @ terminal_fields))
+      ~decision
       ()
     |> append_best_effort ~site config


### PR DESCRIPTION
## Summary

OAS analysis 2026-05-21 Phase P2: completes `decision.clock_refs` enrichment across all manifest emit sites.

### Background

A background agent audit of 5 target files (`keeper_unified_turn.ml`, `keeper_agent_run.ml`, `keeper_turn_driver.ml`, `keeper_turn_driver_try_provider.ml`, `memory_hooks.ml`) found that **all but 2 emit sites** already inject `clock_refs` via `clock_refs_for_context` + `with_clock_refs`. This PR closes the remaining gaps.

### Changes

**`lib/keeper/keeper_runtime_manifest.ml`**
- `append_unfinished_provider_attempt_finished_best_effort`:
  - Generates fresh `clock_refs` for the `Provider_attempt_finished` terminal event
  - Filters stale `"clock_refs"` from inherited started decision to prevent `with_clock_refs` no-op on duplicate key

**`lib/keeper/keeper_agent_run.ml`**
- `append_receipt_manifest` helper:
  - Enriches all receipt-level emits (`receipt_appended`, `tool_lineage_recorded`, `turn_finished`) with `clock_refs`
  - Uses `clock_refs_for_context` with the captured `runtime_manifest_context` from outer scope

### Verification

- No new event_kind variants added (synthetic event policy)
- No substring/catch-all classification
- No telemetry-as-fix pattern
- `with_clock_refs` preserves existing `clock_refs` if present (defensive)

### Related

- OAS analysis: `masc-oas-agent-logic-analysis-2026-05-21.html`
- Prior PR #17638: P3-P7 + F8 implementation (merged)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>