### PR TITLE
refactor(oas-bridge): require run_safe caller

### DIFF
--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -647,8 +647,8 @@ let compute_judgments
     (* build_facts() is moved inside the bridge so a deadlock in
        get_agents_status is bounded by the resolved timeout rather
        than hanging the daemon fiber indefinitely (#8319).
-       #9629: caller migrated from legacy run_safe to run_with_caller
-       so this judge resolves its budget through Env_config_oas_bridge
+       #9629: caller uses run_with_caller so this judge resolves its
+       budget through Env_config_oas_bridge
        and surfaces in the per-caller Prometheus counter. *)
     Masc_oas_bridge.run_with_caller
       ~caller:Env_config_oas_bridge.Governance_judge (fun () ->

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -230,10 +230,9 @@ let compute_judgments
       Keeper_cascade_profile.Operator_judge
   in
   match
-    (* #9629: caller migrated from legacy run_safe (which fell back to
-       the global 30s inference timeout) to run_with_caller so this
-       judge inherits Operator_judge's 300s default and surfaces in the
-       per-caller Prometheus counter. *)
+    (* #9629: caller uses run_with_caller so this judge inherits
+       Operator_judge's 300s default and surfaces in the per-caller
+       Prometheus counter. *)
     Masc_oas_bridge.run_with_caller
       ~caller:Env_config_oas_bridge.Operator_judge (fun () ->
       Keeper_turn_driver_wrappers.run_named_with_masc_tools ~cascade_name

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -363,6 +363,7 @@ val metric_keeper_board_signal_wakeup_capped_total : string
 val metric_keeper_board_signal_no_wake_total : string
 val metric_keeper_meta_json_failures : string
 val metric_keeper_tools_oas_failures : string
+val metric_keeper_tools_oas_deterministic_failures : string
 val metric_keeper_oas_hook_output_parse_failures : string
 val metric_keeper_turn_up_update_failures : string
 val metric_keeper_exec_tools_failures : string

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -1042,7 +1042,6 @@ let prepare_agent_setup
     ; query_text
     }
   in
-  Keeper_tool_alias.register_structured_routes ();
   let initial_tool_surface =
     compute_tool_surface
       ~turn:(start_turn_count + 1)

--- a/lib/keeper/keeper_tool_alias.mli
+++ b/lib/keeper/keeper_tool_alias.mli
@@ -105,5 +105,3 @@ val public_input_schema : string -> Yojson.Safe.t option
 
     For unknown public names this is the identity. *)
 val translate_input : public:string -> Yojson.Safe.t -> Yojson.Safe.t
-
-val register_structured_routes : unit -> unit

--- a/lib/masc_oas_bridge.ml
+++ b/lib/masc_oas_bridge.ml
@@ -10,12 +10,10 @@
     [caller] (#10094) is a free-form identifier ("auto_responder",
     "tool_deep_review", ...) that flows into the timeout label so
     operators can distinguish fantasy budgets from intentional ones
-    when both fire timeouts in the same session.  Defaults to
-    "unknown" so legacy callers still compile; new code should
+    when both fire timeouts in the same session.  Callers must
     pass [~caller] explicitly or use {!run_with_caller}, which
     accepts a typed caller and pulls the configured budget from
     [Env_config_oas_bridge]. *)
-let default_caller = "unknown"
 let min_timeout_s = 0.0
 let routine_cancel_inner_substring = "Eio__core__Fiber.Not_first"
 
@@ -23,7 +21,7 @@ let is_routine_fast_cancel ~bucket ~inner_str =
   String.equal bucket "fast"
   && String_util.contains_substring inner_str routine_cancel_inner_substring
 
-let run_safe ?(caller = default_caller) ~timeout_s fn =
+let run_safe ~caller ~timeout_s fn =
   if not (Float.is_finite timeout_s) || Float.compare timeout_s min_timeout_s <= 0 then
     invalid_arg
       (Printf.sprintf

--- a/lib/masc_oas_bridge.mli
+++ b/lib/masc_oas_bridge.mli
@@ -6,11 +6,10 @@
 (** Safe execution of a generic OAS operation with a mandatory timeout.
     Catches [Eio.Time.Timeout] and [Eio.Cancel.Cancelled] to perform functional rollback.
     [caller] (#10094) labels the Prometheus timeout counter so the
-    operator can attribute timeouts to specific call sites; defaults
-    to ["unknown"] for backwards compatibility with legacy callers.
+    operator can attribute timeouts to specific call sites.
     Raises [Invalid_argument] when [timeout_s] is not positive and finite. *)
 val run_safe
-  :  ?caller:string
+  :  caller:string
   -> timeout_s:float
   -> (unit -> ('a, Agent_sdk.Error.sdk_error) result)
   -> ('a, Agent_sdk.Error.sdk_error) result

--- a/lib/prometheus_builtin_metrics_part2.ml
+++ b/lib/prometheus_builtin_metrics_part2.ml
@@ -222,6 +222,10 @@ let register
      site"
     `Counter;
   add
+    Keeper_metrics.metric_keeper_tools_oas_deterministic_failures
+    "Total keeper OAS deterministic tool failures, labeled by tool and reason"
+    `Counter;
+  add
     Keeper_metrics.metric_keeper_oas_hook_output_parse_failures
     "Total keeper OAS hook tool-output JSON parse failures, labeled by surface"
     `Counter;

--- a/test/test_masc_oas_bridge_timeout_guard.ml
+++ b/test/test_masc_oas_bridge_timeout_guard.ml
@@ -10,7 +10,7 @@ let expected_invalid_timeout timeout_s =
 let check_rejects_timeout ~name timeout_s =
   let called = ref false in
   let run () =
-    Masc_oas_bridge.run_safe ~timeout_s (fun () ->
+    Masc_oas_bridge.run_safe ~caller:"test_timeout_guard" ~timeout_s (fun () ->
       called := true;
       Ok "should-not-run")
     |> ignore
@@ -38,7 +38,7 @@ let test_accepts_positive_timeout_without_eio_env () =
   | None ->
     let called = ref false in
     (match
-       Masc_oas_bridge.run_safe ~timeout_s:0.1 (fun () ->
+       Masc_oas_bridge.run_safe ~caller:"test_timeout_guard" ~timeout_s:0.1 (fun () ->
          called := true;
          Ok "ok")
      with

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -234,7 +234,10 @@ let () = test "masc_oas_bridge_runs_without_eio_env" (fun () ->
     failwith
       "masc_oas_bridge_runs_without_eio_env requires Masc_eio_env.get_opt () = None before calling run_safe"
   | None ->
-    match Masc_oas_bridge.run_safe ~timeout_s:0.1 (fun () -> Ok "ok") with
+    match
+      Masc_oas_bridge.run_safe ~caller:"test_tool_task_coverage" ~timeout_s:0.1 (fun () ->
+        Ok "ok")
+    with
     | Ok "ok" -> ()
     | Ok other -> failwith ("unexpected result: " ^ other)
     | Error err -> failwith (Agent_sdk.Error.to_string err)


### PR DESCRIPTION
## Summary
- require explicit caller labels for Masc_oas_bridge.run_safe instead of defaulting to unknown
- update test callers to pass explicit labels and remove stale run_safe fallback comments
- fix current main build drift from keeper_tool_alias/keeper metrics interface cleanup

## Verification
- ocamlformat --check lib/keeper/keeper_metrics.mli lib/prometheus_builtin_metrics_part2.ml lib/keeper/keeper_tool_alias.mli lib/keeper/keeper_run_tools.ml lib/masc_oas_bridge.ml lib/masc_oas_bridge.mli lib/dashboard/dashboard_operator_judge.ml lib/dashboard/dashboard_governance_judge.ml test/test_masc_oas_bridge_timeout_guard.ml test/test_tool_task_coverage.ml
- git diff --check
- scripts/ocaml-structure-ratchet.sh
- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=_build_oas_bridge_caller2 scripts/dune-local.sh build test/test_masc_oas_bridge_timeout_guard.exe test/test_tool_task_coverage.exe test/test_keeper_tools_oas.exe
- _build_oas_bridge_caller2/default/test/test_masc_oas_bridge_timeout_guard.exe

## Notes
- Direct execution of test_tool_task_coverage.exe and test_keeper_tools_oas.exe without Dune test environment still reports existing fixture failures; the focused Dune build above passes.