### PR TITLE
fix(keeper): split watchdog blocker actions

### DIFF
--- a/dashboard/src/components/keeper-detail-alert-strip.test.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.test.ts
@@ -78,6 +78,22 @@ describe('KeeperRuntimeAlertStrip', () => {
     expect(text).not.toContain('증명')
   })
 
+  it('canonicalizes runtime attention tokens before rendering operator copy', () => {
+    const { container } = render(h(KeeperRuntimeAlertStrip, {
+      keeper: keeper({
+        needs_attention: true,
+        attention_reason: 'watchdog_stale_turn',
+        next_human_action: 'inspect_watchdog_root_cause',
+      }),
+    }))
+
+    const text = container.textContent ?? ''
+    expect(text).toContain('runtime_blocked')
+    expect(text).toContain('런타임 근거 확인')
+    expect(text).not.toContain('watchdog_stale_turn')
+    expect(text).not.toContain('inspect_watchdog_root_cause')
+  })
+
   it('closes 모순 #3: per-attempt completed outcome is hidden when per-turn stop cause is terminal failure', () => {
     const { container } = render(h(KeeperRuntimeAlertStrip, {
       keeper: keeper({

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -86,6 +86,11 @@ const ATTENTION_REASON_LABELS: Record<AttentionReason, string> = {
 
 function canonicalAttentionReason(reason: string | null): string | null {
   if (reason === 'timeout_budget_exhausted') return 'runtime_blocked'
+  if (reason === 'cascade_attempts_exhausted') return 'runtime_blocked'
+  if (reason === 'provider_tool_capability_missing') return 'runtime_blocked'
+  if (reason === 'completion_contract_violation') return 'runtime_blocked'
+  if (reason === 'watchdog_stale_turn') return 'runtime_blocked'
+  if (reason === 'fiber_unresolved') return 'runtime_blocked'
   return reason
 }
 
@@ -136,6 +141,11 @@ function isNextHumanAction(s: string): s is NextHumanAction {
 
 function canonicalNextHumanAction(action: string | null): string | null {
   if (action === 'inspect_timeout_budget') return 'inspect_runtime_blocker'
+  if (action === 'inspect_cascade_attempts') return 'inspect_runtime_blocker'
+  if (action === 'inspect_provider_tool_lane') return 'inspect_runtime_blocker'
+  if (action === 'inspect_completion_contract') return 'inspect_runtime_blocker'
+  if (action === 'inspect_watchdog_root_cause') return 'inspect_runtime_blocker'
+  if (action === 'inspect_turn_finalization') return 'inspect_runtime_blocker'
   return action
 }
 

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -276,6 +276,15 @@ let is_provider_runtime_blocker_class blocker_class =
   String.equal blocker_class "provider_runtime_error"
 ;;
 
+let is_stale_watchdog_blocker_class blocker_class =
+  String.equal blocker_class (blocker_class_to_string Stale_turn_timeout)
+;;
+
+let is_fiber_unresolved_blocker_class blocker_class =
+  String.equal blocker_class (blocker_class_to_string Fiber_unresolved)
+;;
+
+
 
 let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
   : runtime_blocker_surface
@@ -311,6 +320,16 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
       if summary = ""
       then "Keeper turn livelock guard blocked repeated dispatch of the same turn."
       else summary
+    | Fiber_unresolved ->
+      if summary = ""
+      then
+        "Keeper turn fiber ended without completion bookkeeping; inspect liveness/finalization wrapper and preserve the original root cause."
+      else summary
+    | Stale_turn_timeout ->
+      if summary = ""
+      then
+        "Watchdog marked the turn stale; inspect watchdog timing and the underlying root cause separately."
+      else summary
     | No_tool_capable_provider ->
       (match
          Keeper_turn_driver.classify_masc_internal_error
@@ -343,8 +362,6 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
     | Turn_timeout_after_queue_wait
     | Turn_timeout
     | Stay_silent_loop
-    | Fiber_unresolved
-    | Stale_turn_timeout
     | Stale_fleet_batch
     | Sdk_max_turns_exceeded
     | Sdk_token_budget_exceeded
@@ -776,6 +793,10 @@ let attention_fields_json (config : Coord_utils.config) (meta : keeper_meta) =
         true, Some "completion_contract_violation", Some "inspect_completion_contract"
       | Some blocker when is_provider_runtime_blocker_class blocker.blocker_class ->
         true, Some "provider_runtime_error", Some "inspect_provider_runtime_cause"
+      | Some blocker when is_stale_watchdog_blocker_class blocker.blocker_class ->
+        true, Some "watchdog_stale_turn", Some "inspect_watchdog_root_cause"
+      | Some blocker when is_fiber_unresolved_blocker_class blocker.blocker_class ->
+        true, Some "fiber_unresolved", Some "inspect_turn_finalization"
       | Some _ -> true, Some "runtime_blocked", Some "inspect_runtime_blocker"
       | None when meta.paused -> true, Some "paused", Some "resume_or_review"
       | None when not social_model_recognized ->


### PR DESCRIPTION
## Summary
- split stale watchdog and unresolved-fiber blockers from generic `runtime_blocked`
- map `stale_turn_timeout` to `watchdog_stale_turn` / `inspect_watchdog_root_cause`
- map `fiber_unresolved` to `fiber_unresolved` / `inspect_turn_finalization`
- update default summaries to say these are wrapper/liveness observations, not root causes

## Why
Watchdog and liveness states are derived observations. Treating them as generic root-cause blockers makes the dashboard hide the underlying provider/capability/admission failure that caused the turn to stall.

## Validation
Not run; iterative PR slice and local validation was not requested in this turn.
