### PR TITLE
refactor(dashboard): migrate keeper_profile_fields canonical to resolve_live_result (RFC-0149 §3.3 PR-4)

### DIFF
--- a/lib/dashboard_cascade_config.ml
+++ b/lib/dashboard_cascade_config.ml
@@ -230,9 +230,25 @@ let profile_json_raw ~config_path ~keeper_assignable_names name =
    Exposed as a pure helper so the contract can be exercised without
    synthesizing a full [Keeper_registry.registry_entry]. *)
 let keeper_profile_fields ~keeper ~cascade_name : (string * Yojson.Safe.t) list =
+  (* RFC-0149 §3.3 — route through the Result-returning resolver so
+     unresolved cascade names surface as JSON [null] on [canonical]
+     instead of the silent [Keeper_turn] default that the legacy
+     [resolve_live] writes.  "Parse, don't validate" — never invent a
+     canonical value that the catalog did not actually resolve.
+
+     UI semantics (per the doc above): when [canonical] = [cascade_name]
+     the table shows "—"; when they differ the table surfaces drift.
+     [null] is a third state that the UI can render as "unresolved" — a
+     stronger drift signal than a silent rewrite to [Keeper_turn]. *)
+  let canonical_json =
+    match Keeper_cascade_profile.resolve_live_result cascade_name with
+    | Ok runtime ->
+      `String (Keeper_cascade_profile.runtime_name_to_string runtime)
+    | Error (`Unresolved _) -> `Null
+  in
   [ "keeper", `String keeper
   ; "cascade_name", `String cascade_name
-  ; "canonical", `String (Keeper_cascade_profile.resolve_live cascade_name)
+  ; "canonical", canonical_json
   ]
 ;;
 


### PR DESCRIPTION
# refactor(dashboard): migrate keeper_profile_fields canonical to resolve_live_result (RFC-0149 §3.3 PR-4)

## 배경

PR-1/2/3 (#17644/#17646/#17650) 가 RFC-0149 §3.3 Result-returning entry point 추가 + 첫 prod caller (operator identity) migration 완료. 본 PR 은 두번째 prod caller (`dashboard_cascade_config.keeper_profile_fields` 의 `canonical` 필드) 를 migrate.

## 변경 범위

```
lib/dashboard_cascade_config.ml | +16 -2
```

`canonical` 필드의 JSON value 결정:

| Before (legacy) | After (this PR) |
|---|---|
| `\`String (Keeper_cascade_profile.resolve_live cascade_name)` | `\`String runtime` on `Ok runtime` |
| (unresolved → silent `Keeper_turn` fallback) | `\`Null` on `Error (\`Unresolved _)` |

UI semantic (함수 doc 기준):
> When the two differ, the UI surfaces that the keeper's declared cascade is not a recognized variant (classic parse-don't-validate drift). When they match, the UI renders "—" in the canonical column.

`Null` 은 *3번째 state* — UI 가 "unresolved" 로 명시 렌더 가능. silent rewrite 보다 강한 drift signal.

## RFC §3.3 spec 일치

> "Parse, don't validate" — never invent a canonical value that the catalog did not actually resolve.

기존 silent `Keeper_turn` fallback 은 *invented value*. 본 PR 후 `Null` = honest "no canonical".

## Workaround Rejection Bar self-check

- §1 텔레메트리-as-fix: legacy 의 `on_resolve_live_fallback` counter 트리거 안 됨 — 진짜 감소
- §2 substring 분류기: 0
- §3 N-of-M 패치: 본 PR 은 single caller; 다른 prod caller (`dashboard_http_keeper_types`) 는 별개 PR-5
- catch-all 추가 0, cap/cooldown/dedup/repair 0

## 정량 완료 기준

- `dune build --root . lib/`: pass (확인됨)
- 직접 test 없음. `Dashboard_cascade_config` 는 `Dashboard_cascade` 에서 `include` 로 re-export — module API surface 변경 없음.
- 함수 시그니처 변경 0 — caller (UI consumer) 는 `canonical` 의 새 `Null` 케이스를 처리해야 함 (UI 측 변경은 별개 frontend PR scope).

## 후속

- PR-5: `dashboard/dashboard_http_keeper_types.ml:14` migration (3 prod caller 중 마지막)
- PR-6 (frontend, 별개 repo): UI 가 `canonical` = `null` 을 "Unresolved" 로 렌더하도록 dashboard frontend 변경
- PR-closeout: legacy `resolve_live` + `resolve_live_with_catalog` (silent fallback) + `Cascade_metrics.on_resolve_live_fallback` + `logged_unresolved_raw` Hashtbl 삭제

RFC-WAIVED: 본 PR 은 RFC-0149 §3.3 sunset implementation 의 prod caller migration. lib/dashboard 영역의 다른 RFC 들 (해당 시) 의 SSOT 영역 (credential, sandbox 등) 를 건드리지 않음 — 단일 JSON field 의 value 결정 로직만 변경. RFC-0149 frontmatter status: Active.

## Co-Authored-By

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
