### PR TITLE
fix(dashboard): mark timeout budget as legacy copy

### DIFF
--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -849,7 +849,7 @@ export function FleetTelemetryPanel() {
           value=${counts.blocked.toString()}
           detail=${counts.blocked > 0
             ? '런타임은 살아있지만 typed blocker_class를 가진 키퍼 — 행 필터에서 blocker 클래스 이름으로 검색해 원인 확인.'
-            : '활성 차단 사유가 보고된 키퍼가 없습니다 (semaphore_wait_timeout, oas_timeout_budget 등).'}
+            : '활성 차단 사유가 보고된 키퍼가 없습니다 (admission_queue_wait_timeout, provider_runtime_error 등).'}
           tone=${counts.blocked > 0 ? 'warn' : 'ok'}
         />
         <${SummaryCard}

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -738,8 +738,9 @@ export function summaryCounts(rows: FleetRow[]): FleetSummaryCounts {
     && row.last_activity_ago_s >= STALE_ACTIVITY_SEC,
   ).length
   // 2026-05-05 fleet-stuck visibility: count keepers carrying a typed
-  // [runtime_blocker_class] (semaphore_wait_timeout, oas_timeout_budget,
-  // contract_violation, …).  These are alive-but-blocked keepers that
+  // [runtime_blocker_class] (admission_queue_wait_timeout,
+  // provider_tool_capability_missing, completion_contract_violation, …).
+  // These are alive-but-blocked keepers that
   // the live/stale gauges miss — fiber is up, but the next turn cannot
   // start.  Pairs with the `Semaphore_wait_timeout` typing fix
   // (#12855) and the cascade fallback-cycle detector (#12866) so

--- a/dashboard/src/lib/runtime-blocker-class.ts
+++ b/dashboard/src/lib/runtime-blocker-class.ts
@@ -25,9 +25,13 @@ export function asKeeperRuntimeBlockerClass(
 // Source of truth: `lib/keeper/keeper_meta_contract.ml:91 type blocker_class`
 //   + `blocker_class_to_string` (`lib/keeper/keeper_meta_contract.ml:137–164`).
 //
-// Backend emits exactly these 24 lowercase wire strings (verified by
+// Backend can still decode these 24 lowercase wire strings (verified by
 // `Keeper_synthetic_marker` audit, 2026-05-19). The list below is the
 // *frozen* mirror — keep it 1:1 with `keeper_meta_contract.ml`.
+// Some entries are legacy compatibility surfaces rather than desired
+// new root-cause emissions; for example, `oas_timeout_budget` should be
+// projected to owner-specific timeout/admission/capacity causes before it
+// reaches operator copy.
 //
 // Status bridge (`lib/keeper/keeper_status_bridge.ml`) emits two
 // additional dashboard-only synthetic classes (`synthetic_stall`,
@@ -55,7 +59,7 @@ const BACKEND_KEEPER_META_BLOCKER_CLASSES = [
   'autonomous_slot_wait_timeout',
   'admission_queue_wait_timeout',
   'turn_timeout_after_queue_wait',
-  'oas_timeout_budget',
+  'oas_timeout_budget', // legacy decode/compat only; do not present as a new root cause
   'turn_timeout',
   'turn_livelock_blocked',
   'completion_contract_violation',


### PR DESCRIPTION
## Summary
- stop dashboard copy from presenting `oas_timeout_budget` as an active first-class blocker example
- mark `oas_timeout_budget` in runtime-blocker coverage comments as legacy decode/compat only
- replace empty-state/examples with owner-specific blocker examples

## Why
`oas_timeout_budget` is being retired as a synthetic root cause. Keeping it in dashboard examples makes operators treat it as a current blocker class instead of looking for owner-specific timeout/admission/capacity causes.

## Validation
Not run; iterative PR slice and local validation was not requested in this turn.
