### PR TITLE
fix(dashboard): mark fsm timeout budget labels legacy

### DIFF
--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -246,7 +246,7 @@ const FAILURE_REASON_BASE_LABELS: Record<string, string> = {
   stale_turn_timeout: 'Stale 턴 시간 초과',
   stale_termination_storm: 'Stale 종료 폭주',
   stale_fleet_batch: 'Fleet stale 배치',
-  oas_timeout_budget_loop: 'OAS 타임아웃 예산 루프',
+  oas_timeout_budget_loop: '레거시 OAS 타임아웃 예산 루프',
   provider_runtime_error: 'Provider 런타임 오류',
   tool_required_unsatisfied: '필수 도구 미충족',
   ambiguous_partial_commit: '부분 commit 모호',
@@ -454,7 +454,7 @@ export function computeKeeperVerdict(input: {
  *  a cascade ladder), while `stop_cause` is emitted per-turn (the
  *  terminal verdict for the whole turn budget). Rendering the
  *  per-attempt success under the generic "런타임 레인" label next to
- *  a per-turn failure such as `oas_timeout_budget` reads as a
+ *  a per-turn failure such as legacy `oas_timeout_budget` reads as a
  *  contradiction.
  *
  *  We tag the observation with an explicit scope (`attempt`) and gate
@@ -481,6 +481,9 @@ export interface CascadeAttemptObservation {
  *  `lib/keeper/keeper_runtime_trust_snapshot.ml`. Unknown codes do
  *  not gate (fail open: operator still sees the attempt outcome). */
 const TURN_TERMINAL_FAILURE_CODES = new Set<string>([
+  // Legacy timeout-budget wires are still terminal failure codes for
+  // compatibility, but new operator copy should prefer owner-specific
+  // timeout/admission/capacity causes.
   'oas_timeout_budget',
   'oas_timeout_budget_loop',
   'turn_timeout',
@@ -625,7 +628,7 @@ const TERMINAL_REASON_CODE_LABELS: Record<string, string> = {
   stale_turn_timeout: '오래된 턴 시간 초과',
   stale_termination_storm: 'Stale 종료 폭주',
   stale_fleet_batch: 'Fleet stale 배치',
-  oas_timeout_budget: 'OAS 타임아웃 예산',
+  oas_timeout_budget: '레거시 OAS 타임아웃 예산',
   heartbeat_failures: '하트비트 실패',
   turn_failures: '턴 실패 반복',
   ambiguous_partial_commit: '부분 commit 모호',


### PR DESCRIPTION
## Summary
- mark FSM hub `oas_timeout_budget` and `oas_timeout_budget_loop` labels as legacy timeout-budget surfaces
- keep the legacy wires in terminal failure classification for compatibility
- update comments so operators are directed toward owner-specific timeout/admission/capacity causes for new behavior

## Why
The FSM hub still rendered timeout-budget wires as current OAS timeout states. That contradicts the root-cause cleanup: timeout-budget wires are compatibility surfaces while new operator guidance should follow owner-specific causes.

## Validation
Not run; iterative PR slice and local validation was not requested in this turn.
