### PR TITLE
fix(keeper): finish Bash alias cleanup exports

### DIFF
--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -55,7 +55,7 @@ let actionable_path_action_for_class
     match cls with
     | Path_not_found ->
       Printf.sprintf
-        "File does not exist. Use Bash with command='ls %s' first to see available \
+        "File does not exist. Use Bash executable='ls' argv=['%s'] first to see available \
          files, or use a visible file-listing tool if one is present."
         playground
     | Path_not_allowed ->

--- a/lib/keeper/keeper_failure_circuit_breaker.ml
+++ b/lib/keeper/keeper_failure_circuit_breaker.ml
@@ -286,7 +286,7 @@ and corrective_hint cls keeper_name =
     | Path_not_found ->
       Printf.sprintf
         "- The file you are looking for does NOT exist. Do NOT guess paths.\n\
-         - Use Bash with command='ls' on your playground root first to see what actually exists, or use a visible file-listing tool if one is present.\n\
+         - Use Bash executable='ls' argv=['.'] on your playground root first to see what actually exists, or use a visible file-listing tool if one is present.\n\
          - Your playground: .masc/playground/%s/\n\
          - Your repos: .masc/playground/%s/repos/ (clone a repo first if empty)\n\
          - NEVER fabricate file paths like lib/ocaml/... — check with ls first."
@@ -299,7 +299,7 @@ and corrective_hint cls keeper_name =
          - Run `keeper_context_status` to see your allowed paths."
         keeper_name
     | Cwd_not_directory ->
-      "- The cwd you specified is not a directory. Use Bash with command='ls' to find valid directories, or use a visible file-listing tool if one is present.\n\
+      "- The cwd you specified is not a directory. Use Bash executable='ls' argv=['.'] to find valid directories, or use a visible file-listing tool if one is present.\n\
        - Leave the cwd parameter empty to use your default playground root."
     | Shell_exit_nonzero ->
       "- Your shell command is failing repeatedly. Check the command syntax.\n\

--- a/lib/keeper/keeper_repo_readiness.ml
+++ b/lib/keeper/keeper_repo_readiness.ml
@@ -272,7 +272,7 @@ let inspect
       let state, ok, next_action =
         if not status.ok then
           "status_failed", false,
-          "Run Bash with command='git status --short' in this repo; repair git status before starting work."
+          "Run Bash executable='git' argv=['status','--short'] in this repo; repair git status before starting work."
         else if not has_origin then
           "missing_origin", false,
           "Set or reclone origin before worktree creation; latest cannot be verified without origin."

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -1042,7 +1042,6 @@ let prepare_agent_setup
     ; query_text
     }
   in
-  Keeper_tool_alias.register_structured_routes ();
   let initial_tool_surface =
     compute_tool_surface
       ~turn:(start_turn_count + 1)

--- a/lib/keeper/keeper_shell_shared.ml
+++ b/lib/keeper/keeper_shell_shared.ml
@@ -274,8 +274,9 @@ let diagnosis_of_readonly_category category =
                 "git commit/push/checkout modify state; readonly shell only \
                  allows read-only git subcommands (log, diff, status, show)."
             ; rewrite =
-                Some "Use a write-capable Bash surface: Bash \
-                      command='git add lib/foo.ml'. Commit in a second Bash call."
+                Some
+                  "Use a write-capable Bash surface: Bash executable='git' \
+                   argv=['add','lib/foo.ml']. Commit in a second Bash call."
             ; tool_suggestion = None }
   | "package_install" ->
       Some { Exec_core.rule_id = "readonly_package_install_blocked"
@@ -283,8 +284,9 @@ let diagnosis_of_readonly_category category =
                 "opam install / npm install mutate the global environment; \
                  readonly shell forbids package mutations."
             ; rewrite =
-                Some "Use a write-capable Bash surface: Bash \
-                      command='opam install -y eio'."
+                Some
+                  "Use a write-capable Bash surface: Bash executable='opam' \
+                   argv=['install','-y','eio']."
             ; tool_suggestion = None }
   | "destructive" ->
       Some { Exec_core.rule_id = "readonly_destructive_blocked"
@@ -292,8 +294,9 @@ let diagnosis_of_readonly_category category =
                 "rm, curl -o, and similar destructive commands modify or \
                  delete state; readonly shell forbids them."
             ; rewrite =
-                Some "Use a write-capable Bash surface: Bash \
-                      command='rm .tmp/scratch.log'."
+                Some
+                  "Use a write-capable Bash surface: Bash executable='rm' \
+                   argv=['.tmp/scratch.log']."
             ; tool_suggestion = None }
   | _ -> None
 

--- a/lib/keeper/keeper_tool_alias.mli
+++ b/lib/keeper/keeper_tool_alias.mli
@@ -105,5 +105,3 @@ val public_input_schema : string -> Yojson.Safe.t option
 
     For unknown public names this is the identity. *)
 val translate_input : public:string -> Yojson.Safe.t -> Yojson.Safe.t
-
-val register_structured_routes : unit -> unit

--- a/test/test_actionable_path_action.ml
+++ b/test/test_actionable_path_action.ml
@@ -21,8 +21,8 @@ let test_path_not_found () =
   in
   Alcotest.(check bool) "mentions ls hint" true
     (try
-       ignore (Str.search_forward (Str.regexp_string "Bash with command='ls") action 0);
-       true
+       Str.search_forward (Str.regexp_string "Bash executable='ls'") action 0
+       >= 0
      with Not_found -> false);
   Alcotest.(check bool) "mentions playground" true
     (try

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1654,6 +1654,8 @@ let test_tool_failure_classification_contracts () =
   check bool "deterministic tool failures have reason metric" true
     (file_contains_pattern "lib/keeper/keeper_metrics.ml"
        "masc_keeper_tools_oas_deterministic_failures_total"
+     && file_contains_pattern "lib/keeper/keeper_metrics.mli"
+          "val metric_keeper_tools_oas_deterministic_failures : string"
      && file_contains_pattern "lib/keeper/keeper_tools_oas.ml"
           "record_deterministic_tool_failure_metric")
 
@@ -1704,7 +1706,29 @@ let test_public_bash_alias_contracts () =
     (file_not_contains_pattern "lib/keeper/keeper_tool_alias.ml" "Legacy_cmd");
   check bool "public Bash alias has no deferred structured route patcher" true
     (file_not_contains_pattern "lib/keeper/keeper_tool_alias.ml"
-       "register_structured_routes")
+       "register_structured_routes"
+     && file_not_contains_pattern "lib/keeper/keeper_tool_alias.mli"
+          "register_structured_routes"
+     && file_not_contains_pattern "lib/keeper/keeper_run_tools.ml"
+          "register_structured_routes")
+
+let test_public_bash_guidance_contracts () =
+  let raw_command prefix = "command='" ^ prefix in
+  let raw_bash_with_command prefix = "Bash with " ^ raw_command prefix in
+  check bool "readonly diagnoses do not teach raw Bash command field" true
+    (file_not_contains_pattern "lib/keeper/keeper_shell_shared.ml"
+       (raw_command "git add")
+     && file_not_contains_pattern "lib/keeper/keeper_shell_shared.ml"
+          (raw_command "opam install")
+     && file_not_contains_pattern "lib/keeper/keeper_shell_shared.ml"
+          (raw_command "rm .tmp"));
+  check bool "path recovery hints do not teach raw Bash command field" true
+    (file_not_contains_pattern "lib/keeper/keeper_exec_shared.ml"
+       (raw_bash_with_command "ls")
+     && file_not_contains_pattern "lib/keeper/keeper_failure_circuit_breaker.ml"
+          (raw_bash_with_command "ls")
+     && file_not_contains_pattern "lib/keeper/keeper_repo_readiness.ml"
+          (raw_bash_with_command "git status"))
 
 let test_keeper_pr_audit_contracts () =
   check bool "keeper fleet audit has explicit PR-create flag" true
@@ -2729,6 +2753,8 @@ let () =
             test_keeper_github_pr_tool_contracts;
           test_case "public Bash alias contracts" `Quick
             test_public_bash_alias_contracts;
+          test_case "public Bash guidance contracts" `Quick
+            test_public_bash_guidance_contracts;
           test_case "keeper PR audit contracts" `Quick
             test_keeper_pr_audit_contracts;
           test_case "dashboard warm hydration contracts" `Quick

--- a/test/test_circuit_breaker.ml
+++ b/test/test_circuit_breaker.ml
@@ -55,7 +55,8 @@ let test_hint_at_threshold () =
   let r3 = CB.maybe_enrich_error ~keeper_name:"t2" ~error_msg:"path_not_found: /c" in
   check bool "3rd: HAS hint" true (contains r3 "CIRCUIT BREAKER");
   check bool "mentions playground" true (contains r3 "playground");
-  check bool "mentions public Bash ls" true (contains r3 "Bash with command='ls")
+  check bool "mentions typed public Bash ls" true
+    (contains r3 "Bash executable='ls' argv=['.']")
 
 let test_reset_on_success () =
   CB.record_success ~keeper_name:"t3";

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -170,7 +170,11 @@ let test_goal_upsert_and_list () =
     | `Int n -> n
     | _ -> fail "count missing from goal list response"
   in
-  check int "one listed goal" 1 count
+  check int "one listed goal" 1 count;
+  let goals = Yojson.Safe.Util.member "goals" listed_json |> Yojson.Safe.Util.to_list in
+  match goals with
+  | [ goal_json ] -> check string "listed goal id" goal_id (get_string_field goal_json "id")
+  | _ -> fail "expected one listed goal"
 ;;
 
 let test_goal_list_filters_by_phase () =

--- a/test/test_keeper_turn_disposition.ml
+++ b/test/test_keeper_turn_disposition.ml
@@ -248,7 +248,7 @@ let test_projection () =
 ;;
 
 let check_cascade_failure_reason raw_error expected_code =
-  let terminal = Legacy.of_legacy_error_text raw_error in
+  let terminal = Legacy.of_code raw_error in
   match Unified_types.registry_failure_reason_of_terminal_reason terminal ~raw_error with
   | Some (Registry.Provider_runtime_error { code; detail }) ->
     Alcotest.(check string) "provider runtime code" expected_code code;

--- a/test/test_keeper_turn_terminal_disposition_field.ml
+++ b/test/test_keeper_turn_terminal_disposition_field.ml
@@ -34,14 +34,11 @@ let constructor_cases : (string * T.t) list =
   ; ( "of_code/sdk_error/agent_error_max_turns"
     , T.of_code "agent_error_max_turns_exceeded:turns=10,limit=10" )
   ; "of_code/unknown", T.of_code "totally_unmapped"
-  ; "of_legacy_error_text/empty", T.of_legacy_error_text ""
-  ; ( "of_legacy_error_text/gh_repo"
-    , T.of_legacy_error_text "gh_repo_context_missing_worktree" )
-  ; "of_legacy_error_text/oas_timeout", T.of_legacy_error_text "oas_timeout_budget"
-  ; ( "of_legacy_error_text/turn_wall_clock"
-    , T.of_legacy_error_text "Turn wall-clock timeout fired" )
-  ; ( "of_legacy_error_text/require_tool_use"
-    , T.of_legacy_error_text "called no keeper tools and require_tool_use was set" )
+  ; "of_code/empty", T.of_code ""
+  ; "of_code/gh_repo", T.of_code "gh_repo_context_missing_worktree"
+  ; "of_code/oas_timeout", T.of_code "oas_timeout_budget"
+  ; "of_code/turn_wall_clock", T.of_code "turn_wall_clock_timeout"
+  ; "of_code/require_tool_use", T.of_code "required_tool_use_no_tool_call"
   ]
 ;;
 
@@ -66,7 +63,7 @@ let test_to_json_keeps_code_field () =
     let keys = List.map fst fields |> List.sort String.compare in
     Alcotest.(check (list string))
       "JSON fields unchanged"
-      [ "code"; "next_action"; "severity"; "source"; "summary" ]
+      [ "code"; "disposition"; "next_action"; "severity"; "source"; "summary" ]
       keys
   | _ -> Alcotest.fail "expected JSON object"
 ;;


### PR DESCRIPTION
## Summary
- remove the restored dead register_structured_routes patcher, mli export, and runtime call so public Bash schema setup is owned by the module initializer only
- keep deterministic tool failure metric exported through keeper_metrics.mli
- rewrite remaining operator-facing Bash recovery hints from raw command= prose to typed executable/argv examples

## Verification
- ocamlformat --check lib/keeper/keeper_tool_alias.ml lib/keeper/keeper_tool_alias.mli lib/keeper/keeper_run_tools.ml lib/keeper/keeper_metrics.mli lib/keeper/keeper_shell_shared.ml lib/keeper/keeper_repo_readiness.ml lib/keeper/keeper_failure_circuit_breaker.ml lib/keeper/keeper_exec_shared.ml test/test_circuit_breaker.ml test/test_actionable_path_action.ml test/test_ci_hardening_source.ml
- git diff --check origin/main...HEAD
- bash scripts/lint/shell-legacy-purge-ratchet.sh --print
- scripts/dune-local.sh build test/test_circuit_breaker.exe test/test_ci_hardening_source.exe test/test_keeper_readonly_hints.exe test/test_keeper_repo_readiness.exe test/test_keeper_tools_oas.exe test/test_keeper_tool_alias.exe attempted; local Dune lock stayed held by an unrelated @check, so CI is the compile proof
- previously, before the final rebase, focused build exposed the stale mli/call and missing metric export; this PR removes those breakages