### PR TITLE
fix(dashboard): mark detail timeout budget copy legacy

### DIFF
--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -80,7 +80,7 @@ const ATTENTION_REASON_LABELS: Record<AttentionReason, string> = {
   paused: '일시정지',
   paused_blocked: '일시정지 원인 확인 필요',
   runtime_blocked: '런타임 근거 확인 필요',
-  timeout_budget_exhausted: '타임아웃 예산 소진',
+  timeout_budget_exhausted: '레거시 타임아웃 예산 표면',
   social_model_fallback: '소셜 모델 폴백',
   fd_pressure: 'FD 임계치 초과',
   runtime_trust_snapshot_unavailable: '런타임 신뢰 스냅샷 없음',
@@ -120,7 +120,7 @@ const NEXT_HUMAN_ACTION_LABELS: Record<NextHumanAction, string> = {
   approve_or_reject_continue: '계속 진행 승인 또는 거절',
   inspect_blocker_before_resume: '원인 확인 후 재개',
   inspect_runtime_blocker: '런타임 근거 확인',
-  inspect_timeout_budget: '타임아웃 예산 확인',
+  inspect_timeout_budget: '원인별 타임아웃 확인',
   resolve_approval: '승인 요청 처리',
   resume_or_review: '재개 또는 설정 검토',
   review_social_model: '소셜 모델 설정 검토',
@@ -152,6 +152,9 @@ function nextHumanActionLabel(action: string | null): string | null {
 const ATTENTION_PAIR_DUPLICATES: ReadonlyArray<readonly [AttentionReason, NextHumanAction]> = [
   ['runtime_blocked', 'inspect_runtime_blocker'],
   ['paused_blocked', 'inspect_blocker_before_resume'],
+  // Legacy timeout-budget pair is still accepted from older backend wires,
+  // but new operator copy should route to owner-specific timeout/admission/
+  // capacity causes.
   ['timeout_budget_exhausted', 'inspect_timeout_budget'],
   ['runtime_trust_snapshot_unavailable', 'inspect_keeper_runtime_trust'],
 ]
@@ -469,7 +472,7 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
               onClick=${() => handleDirective('pause')}
               title="일시정지: 실행 중인 keeper 를 일시 멈춥니다 (running → paused, 현재 turn 은 정상 종료)"
             >일시정지하기<//>
-            ${(hbStale || runtimeBlockerClass === 'oas_timeout_budget' || runtimeBlockerClass === 'cascade_exhausted' || runtimeBlockerClass === 'turn_timeout')
+            ${(hbStale || runtimeBlockerClass === 'cascade_exhausted' || runtimeBlockerClass === 'turn_timeout')
               ? html`<${ActionButton}
                   variant="warn"
                   size="sm"

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -207,7 +207,7 @@ const runtimeBlockerLabels = {
   autonomous_slot_wait_timeout: '자율 슬롯 대기 만료',
   admission_queue_wait_timeout: '대기열 진입 만료',
   turn_timeout_after_queue_wait: '대기 후 턴 만료',
-  oas_timeout_budget: 'OAS 응답 만료',
+  oas_timeout_budget: '레거시 OAS 타임아웃 표면',
   turn_timeout: '턴 응답 만료',
   turn_livelock_blocked: '턴 livelock 차단',
   completion_contract_violation: '완료 계약 위반',
@@ -268,7 +268,7 @@ export function keeperRuntimeBlockerHint(keeper: Keeper | null | undefined): str
     return '대기 후 실행된 턴이 전체 제한 시간을 초과했습니다.'
   }
   if (blockerClass === 'oas_timeout_budget') {
-    return 'OAS 실행 예산이 먼저 소진되었습니다.'
+    return '레거시 timeout-budget 표면입니다. 실제 owner-specific timeout/admission/capacity 원인을 확인하세요.'
   }
   if (blockerClass === 'turn_timeout') {
     return '턴 실행 시간이 제한 시간을 초과했습니다.'


### PR DESCRIPTION
## Summary
- mark detail alert timeout-budget labels/actions as legacy compatibility surfaces
- route detail hint copy toward owner-specific timeout/admission/capacity causes
- stop rendering wakeup as a special action purely for legacy `oas_timeout_budget` blocker class

## Why
The detail alert strip still made timeout-budget look like the primary operational cause. That conflicts with the root-cause cleanup: timeout-budget is a legacy/synthetic surface and operators should inspect the owning timeout, admission, or capacity cause.

## Validation
Not run; iterative PR slice and local validation was not requested in this turn.
