### PR TITLE
refactor(dashboard): migrate live_keeper_cascade_name callers to Result + drop side-effect counter trigger (RFC-0149 §3.3 PR-5)

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -135,7 +135,14 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
             if last_activity_ts <= 0.0 then 0.0 else now_ts -. last_activity_ts
           in
           let trace_history_count = List.length m.runtime.trace_history in
-          let _effective_cascade_name = live_keeper_cascade_name (Keeper_types.cascade_name_of_meta m) in
+          (* RFC-0149 §3.3 — removed [_effective_cascade_name] zombie
+             binding (commit f0075c3611, "domain-owned counter").  The
+             bound name was unused; the line existed only to trigger
+             [Cascade_metrics.on_resolve_live_fallback] through the
+             silent-fallback path — exactly the workaround RFC-0149
+             §3.3 sunsets.  No replacement needed: unresolved cascades
+             surface on the canonical JSON field via the Result-returning
+             resolver at the other call site below. *)
           let primary_model = "" in
           let primary_model_norm = normalize_model_name primary_model in
           let last_compaction_saved_tokens =
@@ -1138,12 +1145,21 @@ let keeper_config_json (config : Coord.config) (name : string)
         ]
       in
       let cascade_name = Keeper_types.cascade_name_of_meta m in
-      let effective_cascade_name = live_keeper_cascade_name cascade_name in
+      (* RFC-0149 §3.3 — Result-returning resolver: on [Error] the
+         canonical field surfaces as JSON [null] (parse-don't-validate
+         honest signal) instead of the silent [Keeper_turn] rewrite the
+         legacy [live_keeper_cascade_name] would produce. *)
+      let selected_cascade_canonical_json =
+        match live_keeper_cascade_name_result cascade_name with
+        | Ok runtime ->
+          `String (Keeper_cascade_profile.runtime_name_to_string runtime)
+        | Error (`Unresolved _) -> `Null
+      in
       let execution =
         `Assoc [
           ("selected_cascade_name", `String cascade_name);
           ( "selected_cascade_canonical",
-            `String effective_cascade_name );
+            selected_cascade_canonical_json );
           ( "cascade_ref",
             (match m.cascade_ref with
              | Some ref_ -> Cascade_ref.cascade_ref_to_json ref_

--- a/lib/dashboard/dashboard_http_keeper_types.ml
+++ b/lib/dashboard/dashboard_http_keeper_types.ml
@@ -13,6 +13,15 @@ let runtime_warning_ctx_ratio =
 let live_keeper_cascade_name (raw : string) =
   Keeper_cascade_profile.resolve_live raw
 
+(* RFC-0149 §3.3 — Result-returning sibling of {!live_keeper_cascade_name}.
+   New dashboard call sites should consume the typed [Error (`Unresolved _)]
+   and surface it on the canonical JSON field as [`Null] (parse-don't-validate
+   honest signal) instead of letting the silent [Keeper_turn] fallback paper
+   over an unresolved cascade. *)
+let live_keeper_cascade_name_result (raw : string) :
+    (Keeper_cascade_profile.runtime_name, [ `Unresolved of string ]) result =
+  Keeper_cascade_profile.resolve_live_result raw
+
 let compute_health_score
     ~restart_count ~max_restarts ~recent_crash_count
     ~is_dead ~context_ratio =

--- a/lib/dashboard/dashboard_http_keeper_types.mli
+++ b/lib/dashboard/dashboard_http_keeper_types.mli
@@ -16,7 +16,19 @@ val runtime_warning_ctx_ratio : float
     [Env_config_keeper.DashboardHealth]. *)
 
 val live_keeper_cascade_name : string -> string
-(** Resolve a raw cascade name to its live (post-rotation) identifier. *)
+(** Resolve a raw cascade name to its live (post-rotation) identifier.
+
+    {b Note:} silent-fallback path retained for the RFC-0149 §3.3 sunset
+    window.  New callers should prefer {!live_keeper_cascade_name_result}. *)
+
+val live_keeper_cascade_name_result :
+  string -> (Keeper_cascade_profile.runtime_name, [ `Unresolved of string ]) result
+(** Result-returning variant of {!live_keeper_cascade_name}.  On
+    [Error (`Unresolved raw)] the caller is expected to surface the
+    unresolved input directly (e.g. as JSON [null] on the canonical
+    field) rather than fall back to the silent [Keeper_turn] default.
+
+    @since RFC-0149 Phase 1 *)
 
 val compute_health_score :
   restart_count:int ->


### PR DESCRIPTION
# refactor(dashboard): migrate live_keeper_cascade_name callers to Result + drop side-effect counter trigger (RFC-0149 §3.3 PR-5)

## 배경

RFC-0149 §3.3 prod caller migration sprint 의 마지막 PR. PR-3 (#17650 operator identity) + PR-4 (#17659 dashboard canonical) 후 남은 caller 2개 (모두 `dashboard_http_keeper.ml`) 를 본 PR 에서 마무리.

## 변경 범위

```
lib/dashboard/dashboard_http_keeper_types.ml  | +9
lib/dashboard/dashboard_http_keeper_types.mli | +14 -1
lib/dashboard/dashboard_http_keeper.ml        | +22 -3
```

## 두 caller 의 *서로 다른* 처리

### caller 1: L138 — zombie binding 삭제

```ocaml
let _effective_cascade_name = live_keeper_cascade_name (Keeper_types.cascade_name_of_meta m) in
```

git blame: commit f0075c3611 (2026-05-17, "domain-owned counter for load_and_apply failures"). `_` prefix + bound 값 *완전 미사용*. 라인 추가의 *유일한 목적* = `Cascade_metrics.on_resolve_live_fallback ()` side-effect 트리거.

**이게 정확히 RFC-0149 §3.3 sunset 대상 워크어라운드** (`feedback_telemetry_as_fix_self_recurrence` + `feedback_dead_defensive_cleanup_must_check_test_lock` 두 패턴 동시 매치):

- 텔레메트리-as-fix (§1): bound 값을 사용하지 않으면서 counter 만 트리거 — 즉 *side-effect 의존*
- dead defensive cleanup: 미사용 바인딩이 telemetry 만 위해 살아남음

해결 = 라인 자체 삭제. 대체 없음 — counter 가 *워크어라운드* 자체이므로 sunset 의 핵심.

### caller 2: L1141 — Result migration (PR-4 패턴)

```ocaml
let effective_cascade_name = live_keeper_cascade_name cascade_name in
...
("selected_cascade_canonical", `String effective_cascade_name);
```

이 caller 는 result 를 *실제 사용* — `selected_cascade_canonical` HTTP JSON 필드. PR-4 와 동일 패턴:

```ocaml
let selected_cascade_canonical_json =
  match live_keeper_cascade_name_result cascade_name with
  | Ok runtime -> `String (Keeper_cascade_profile.runtime_name_to_string runtime)
  | Error (`Unresolved _) -> `Null
in
```

`Error → Null` parse-don't-validate.

### dashboard_http_keeper_types.mli/ml

`live_keeper_cascade_name_result` helper 추가 — `Keeper_cascade_profile.resolve_live_result` 의 thin re-export. 기존 `live_keeper_cascade_name` (legacy) 도 그대로 유지 (PR-closeout 에서 삭제 예정).

## RFC §3.3 sunset readiness

본 PR 머지 후 `resolve_live` / `live_keeper_cascade_name` *모든 prod caller* 가 (a) Result-explicit 또는 (b) 삭제됨. PR-closeout (RFC-0149 §3.3 마지막 단계) 에서 안전 삭제 가능:

| 삭제 대상 | 위치 |
|---|---|
| `resolve_live ?config_path raw` (silent fallback) | `keeper_cascade_profile.ml` |
| `resolve_live_with_catalog` (silent fallback Error arm) | 동일 |
| `Cascade_metrics.on_resolve_live_fallback` counter | `cascade_metrics.ml` |
| `logged_unresolved_raw` Hashtbl | `keeper_cascade_profile.ml` |
| `live_keeper_cascade_name` (legacy facade) | `dashboard_http_keeper_types.ml` |

남는 caller = 2 test sites (`test_keeper_toml_config_validation.ml:626/629`) 는 test fixture 라 별개 migration. 또는 같은 closeout PR 에 포함.

## Workaround Rejection Bar self-check

- §1 텔레메트리-as-fix: **본 PR 이 정확히 §1 패턴을 제거** — 워크어라운드 carrier (zombie counter trigger) 를 삭제. 추가 counter 0.
- §2 substring 분류기: 0
- §3 N-of-M 패치: PR-1~PR-5 가 RFC-0149 §3.3 의 정의된 5-PR sprint. 본 PR 이 caller migration 의 마지막 — 다음 closeout 만 남음.
- catch-all 추가 0, cap/cooldown/dedup/repair 0

## 정량 완료 기준

- `dune build --root . lib/`: pass (확인됨)
- prod caller 3/3 migration 완료: identity (#17650), canonical (#17659), HTTP types (this PR)
- `live_keeper_cascade_name` legacy 호출처 = test 2개만 남음 (closeout 에서 처리)

## 후속

- **PR-closeout (PR-6)**: 위 §"RFC §3.3 sunset readiness" 표의 5 항목 삭제. test 2 caller 도 `_result` 로 migrate 또는 fixture 갱신.
- RFC-0149 frontmatter `implementation_prs` 갱신 (author 영역).

RFC-WAIVED: 본 PR 은 RFC-0149 §3.3 sunset implementation 의 prod caller migration 마지막 단계. lib/dashboard 영역의 다른 RFC 들의 SSOT (credential, sandbox 등) 를 건드리지 않음 — 단일 함수 호출 변경 + 1 zombie 라인 삭제. RFC-0149 frontmatter status: Active.

## Co-Authored-By

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
