### PR TITLE
fix(dashboard): mark timeout budget reactivity legacy

### DIFF
--- a/dashboard/src/components/keeper-reactivity-monitor.ts
+++ b/dashboard/src/components/keeper-reactivity-monitor.ts
@@ -97,6 +97,9 @@ export function extractKeeperStopSummaries(
         else if (cls === 'noop_failure_loop') e.noop_failure_loop += s.value
       }
     } else if (
+      // Legacy compatibility metrics. New keeper policy should surface
+      // owner-specific timeout/admission/capacity causes instead of treating
+      // timeout-legacy budget strikes as a first-class root cause.
       m.name === 'masc_keeper_oas_timeout_budget_strike' ||
       m.name === 'masc_keeper_oas_timeout_budget_strike_total'
     ) {
@@ -317,7 +320,7 @@ function AutoPausePanel({
                       ` : null}
                       ${s.budget_loop_pauses > 0 ? html`
                         <span class="rounded bg-[var(--bad-10)] px-1.5 py-0.5 text-[var(--bad-light)]">
-                          budget loop pause ${s.budget_loop_pauses}
+                          legacy budget loop pause ${s.budget_loop_pauses}
                         </span>
                       ` : null}
                       ${s.stale_total > 0 ? html`


### PR DESCRIPTION
## Summary
- mark timeout-budget reactivity metrics as legacy compatibility signals
- keep decoding the old strike/loop metrics for historical dashboards
- change UI copy from active budget-loop cause wording to legacy budget-loop wording

## Why
The keeper no longer treats timeout-budget loops as a first-class root cause. The reactivity monitor should still read historical metrics, but the display must not teach operators that timeout-budget strikes are the current owner of the failure.

## Validation
Not run; iterative PR slice and local validation was not requested in this turn.
