### PR TITLE
fix(dashboard): remove legacy timeout from wakeup blockers

### DIFF
--- a/dashboard/src/lib/keeper-predicates.ts
+++ b/dashboard/src/lib/keeper-predicates.ts
@@ -116,10 +116,13 @@ export function isKeeperOffline(keeper: KeeperOfflineInput): boolean {
 /** Closed set of blocker classes that the wakeup action is intended
  *  to recover. These three are the classes pre-RFC `canWake` checked
  *  inline in keeper-action-panel.ts; widening this set requires
- *  matching backend wakeup-recovery handling. */
+ *  matching backend wakeup-recovery handling.
+ *
+ *  Do not include legacy `oas_timeout_budget`: it is a compatibility
+ *  surface, not an owner-specific recoverable blocker. Wakeup should be
+ *  driven by the owning timeout/admission/capacity cause instead. */
 const WAKEUP_RECOVERABLE_BLOCKERS = new Set<string>([
   'cascade_exhausted',
-  'oas_timeout_budget',
   'turn_timeout',
 ])
 


### PR DESCRIPTION
## Summary
- remove legacy `oas_timeout_budget` from dashboard wakeup-recoverable blocker predicates
- keep `cascade_exhausted` and `turn_timeout` as explicit wakeup candidates
- document that timeout-budget is compatibility-only and wakeup should follow owner-specific timeout/admission/capacity causes

## Why
The dashboard predicate still treated `oas_timeout_budget` as an active recoverable blocker. That keeps the synthetic timeout-budget state alive in operator behavior even after backend root-cause cleanup.

## Validation
Not run; iterative PR slice and local validation was not requested in this turn.
