### PR TITLE
docs(dashboard): mark timeout budget blocker as legacy

### DIFF
--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -326,6 +326,10 @@ export interface PromptTelemetry {
   segments: Record<string, PromptSegmentTelemetry>
 }
 
+// Compatibility telemetry for historical OAS timeout-budget payloads.
+// New keeper surfaces must keep the immutable root cause owner-specific
+// (provider timeout, admission/capacity pressure, or turn deadline) instead of
+// reclassifying those causes back into a timeout-budget state.
 export interface TimeoutBudgetTelemetry {
   oas_timeout_sec: number | null
   adaptive_timeout_sec: number | null
@@ -396,6 +400,9 @@ export const KEEPER_RUNTIME_BLOCKER_CLASSES = [
   'autonomous_slot_wait_timeout',
   'admission_queue_wait_timeout',
   'turn_timeout_after_queue_wait',
+  // Legacy wire compatibility only. Do not use this as a current runtime root
+  // cause or dashboard wakeup/action predicate; owner-specific timeout,
+  // admission, or capacity blockers must be emitted instead.
   'oas_timeout_budget',
   'turn_timeout',
   // Emitted by `lib/keeper/keeper_meta_contract.ml:101` (Turn_livelock_blocked)


### PR DESCRIPTION
## Summary
- mark dashboard timeout-budget telemetry as historical compatibility data
- document `oas_timeout_budget` runtime blocker as legacy wire decode only
- keep current root-cause ownership on provider timeout, admission/capacity pressure, or turn deadline

## Validation
- Not run; user requested PR iteration without local validation.
