### PR TITLE
test(dashboard): prefer owner-specific timeout fixtures

### DIFF
--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -375,7 +375,7 @@ describe('normalizeKeepers lifecycle metrics', () => {
     })
   })
 
-  it('preserves stopped-reaction fields in trust summary', () => {
+  it('preserves owner-specific stopped-reaction fields in trust summary', () => {
     const [keeper] = normalizeKeepers([
       {
         name: 'blocked-keeper',
@@ -383,17 +383,17 @@ describe('normalizeKeepers lifecycle metrics', () => {
         trust: {
           disposition: 'Alert',
           operator_disposition: 'pause_runtime',
-          operator_disposition_reason: 'timeout_budget_exhausted',
+          operator_disposition_reason: 'turn_timeout',
           needs_attention: true,
-          attention_reason: 'timeout_budget_exhausted',
+          attention_reason: 'turn_timeout',
           latest_terminal_reason: {
-            code: 'timeout_budget_exhausted',
+            code: 'turn_timeout',
             source: 'execution_receipt',
             severity: 'bad',
-            summary: 'Turn budget exhausted after 15 turns',
-            next_action: 'inspect_timeout_budget',
+            summary: 'Turn execution exceeded the keeper turn deadline',
+            next_action: 'inspect_runtime_blocker',
           },
-          latest_next_action: 'inspect_timeout_budget',
+          latest_next_action: 'inspect_runtime_blocker',
         },
       },
     ])
@@ -401,23 +401,23 @@ describe('normalizeKeepers lifecycle metrics', () => {
     expect(keeper?.trust).toMatchObject({
       disposition: 'Alert',
       operator_disposition: 'pause_runtime',
-      operator_disposition_reason: 'timeout_budget_exhausted',
+      operator_disposition_reason: 'turn_timeout',
       needs_attention: true,
-      attention_reason: 'timeout_budget_exhausted',
+      attention_reason: 'turn_timeout',
       latest_terminal_reason: {
-        code: 'timeout_budget_exhausted',
+        code: 'turn_timeout',
         source: 'execution_receipt',
         severity: 'bad',
-        summary: 'Turn budget exhausted after 15 turns',
-        next_action: 'inspect_timeout_budget',
+        summary: 'Turn execution exceeded the keeper turn deadline',
+        next_action: 'inspect_runtime_blocker',
       },
-      latest_next_action: 'inspect_timeout_budget',
+      latest_next_action: 'inspect_runtime_blocker',
     })
     expect(keeper?.stop_cause).toMatchObject({
-      code: 'timeout_budget_exhausted',
+      code: 'turn_timeout',
       source: 'terminal_reason_code',
-      summary: 'Turn budget exhausted after 15 turns',
-      next_action: 'inspect_timeout_budget',
+      summary: 'Turn execution exceeded the keeper turn deadline',
+      next_action: 'inspect_runtime_blocker',
     })
   })
 
@@ -886,18 +886,18 @@ describe('normalizeKeeperTrustTerminalReason — exported helper', () => {
 
   it('returns a full terminal reason when code is present', () => {
     const result = normalizeKeeperTrustTerminalReason({
-      code: 'timeout_budget_exhausted',
+      code: 'turn_timeout',
       source: 'execution_receipt',
       severity: 'bad',
-      summary: 'keeper timed out before completing the turn',
-      next_action: 'adjust_timeout_budget',
+      summary: 'keeper exceeded the turn deadline',
+      next_action: 'inspect_runtime_blocker',
     })
     expect(result).toEqual({
-      code: 'timeout_budget_exhausted',
+      code: 'turn_timeout',
       source: 'execution_receipt',
       severity: 'bad',
-      summary: 'keeper timed out before completing the turn',
-      next_action: 'adjust_timeout_budget',
+      summary: 'keeper exceeded the turn deadline',
+      next_action: 'inspect_runtime_blocker',
     })
   })
 

--- a/dashboard/src/operator-normalizers.test.ts
+++ b/dashboard/src/operator-normalizers.test.ts
@@ -311,29 +311,29 @@ describe('normalizeOperatorSnapshot', () => {
     expect(result.keepers).toEqual([])
   })
 
-  it('preserves keeper runtime_trust and stopped-reaction attention fields', () => {
+  it('preserves keeper runtime_trust and owner-specific stopped-reaction attention fields', () => {
     const result = normalizeOperatorSnapshot({
       keepers: [
         {
           name: 'blocked-keeper',
           status: 'active',
           needs_attention: true,
-          attention_reason: 'timeout_budget_exhausted',
-          next_human_action: 'inspect_timeout_budget',
+          attention_reason: 'turn_timeout',
+          next_human_action: 'inspect_runtime_blocker',
           runtime_trust: {
             disposition: 'Alert',
             operator_disposition: 'pause_runtime',
-            operator_disposition_reason: 'timeout_budget_exhausted',
+            operator_disposition_reason: 'turn_timeout',
             needs_attention: true,
-            attention_reason: 'timeout_budget_exhausted',
+            attention_reason: 'turn_timeout',
             latest_terminal_reason: {
-              code: 'timeout_budget_exhausted',
+              code: 'turn_timeout',
               source: 'execution_receipt',
               severity: 'bad',
-              summary: 'Turn budget exhausted after 15 turns',
-              next_action: 'inspect_timeout_budget',
+              summary: 'Turn execution exceeded the keeper turn deadline',
+              next_action: 'inspect_runtime_blocker',
             },
-            latest_next_action: 'inspect_timeout_budget',
+            latest_next_action: 'inspect_runtime_blocker',
           },
         },
       ],
@@ -341,20 +341,20 @@ describe('normalizeOperatorSnapshot', () => {
     expect(result.keepers).toHaveLength(1)
     const keeper = result.keepers[0]!
     expect(keeper.needs_attention).toBe(true)
-    expect(keeper.attention_reason).toBe('timeout_budget_exhausted')
-    expect(keeper.next_human_action).toBe('inspect_timeout_budget')
+    expect(keeper.attention_reason).toBe('turn_timeout')
+    expect(keeper.next_human_action).toBe('inspect_runtime_blocker')
     expect(keeper.runtime_trust).toMatchObject({
       disposition: 'Alert',
       operator_disposition: 'pause_runtime',
-      operator_disposition_reason: 'timeout_budget_exhausted',
+      operator_disposition_reason: 'turn_timeout',
       needs_attention: true,
       latest_terminal_reason: {
-        code: 'timeout_budget_exhausted',
+        code: 'turn_timeout',
         severity: 'bad',
-        summary: 'Turn budget exhausted after 15 turns',
-        next_action: 'inspect_timeout_budget',
+        summary: 'Turn execution exceeded the keeper turn deadline',
+        next_action: 'inspect_runtime_blocker',
       },
-      latest_next_action: 'inspect_timeout_budget',
+      latest_next_action: 'inspect_runtime_blocker',
     })
   })
 


### PR DESCRIPTION
## Summary
- replace active dashboard normalize fixtures that used timeout-budget exhaustion as the default stopped-reaction reason
- use owner-specific `turn_timeout` and generic runtime-blocker inspection instead of `inspect_timeout_budget`
- keep normalizer behavior unchanged; this only removes legacy timeout-budget as the test baseline

## Validation
- Not run; user requested PR iteration without local validation.
