### PR TITLE
fix(test): mark goal_id unused in goal_upsert structured-link test

### DIFF
--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -138,7 +138,7 @@ let test_goal_upsert_and_list () =
     | Some result -> parse_json_result result
     | None -> fail "masc_goal_upsert not handled"
   in
-  let goal_id =
+  let _goal_id =
     match Yojson.Safe.Util.member "goal_id" created_json with
     | `String id when id <> "" -> id
     | _ -> fail "goal_id missing from upsert response"


### PR DESCRIPTION
## Summary
- prefix [goal_id] with [_] in the masc_goal_upsert structured-link assertion (test/test_goal_tools.ml:141)
- keeps the missing/empty fail-check arm intact

## Why
[refactor(goal): require structured task goal links (#17627)] introduced [let goal_id = ...] without a later reference. Build uses [-warn-error +a], so warning 26 (unused-var) is promoted to error and breaks [dune build @check] on every PR rebased onto main after #17627. Observed in 11/21 open PR Health checks this morning (PR #17648 health job 77341789534 — exit 1 at line 141).

## Verification
- ocamlformat --check test/test_goal_tools.ml → exit 0
- other [goal_id] references in the file (line 86 parameter, line 272 / 298 separate test blocks) inspected and unchanged

## Affected open PRs (Health unblock)
#17645 #17649 #17650 #17651 #17653 #17654 #17655 #17656 #17657 plus newer cascades

🤖 Generated with [Claude Code](https://claude.com/claude-code)