### PR TITLE
fix(cascade): fold timeout budget error metric

### DIFF
--- a/lib/cascade/cascade_internal_error.ml
+++ b/lib/cascade/cascade_internal_error.ml
@@ -378,11 +378,11 @@ let summary_of_masc_internal_error = function
 
 (* #9933: classify emitted [masc_oas_error] payloads by kind so
    dashboards and Grafana alerts can watch the fleet-wide rate per
-   error class (cascade_exhausted vs oas_timeout_budget vs
+   error class (cascade_exhausted vs turn_timeout vs
    ambiguous_post_commit, etc.) rather than reading the free-form
-   BDI blocker string.  125 [oas_timeout_budget] events accumulated
-   across 9 keepers in 24h without an aggregate signal — this
-   counter is the per-kind surface.
+   BDI blocker string.  Historical timeout-budget inputs are folded
+   into the owner-specific turn-timeout metric label; do not mint a
+   first-class [kind=oas_timeout_budget] series.
 
    Emit point is this constructor so all 14 call sites of
    [sdk_error_of_masc_internal_error] are covered automatically,
@@ -401,7 +401,7 @@ let () =
        kind (cascade_exhausted | capacity_backpressure | resumable_cli_session | \
        no_tool_capable_provider | accept_rejected | \
        admission_queue_timeout | admission_queue_rejected | \
-       turn_timeout | oas_timeout_budget | max_tokens_ceiling_violation | \
+       turn_timeout | max_tokens_ceiling_violation | \
        ambiguous_post_commit | internal_unhandled_exception | \
        internal_bridge_exception | internal_contract_rejected), \
        cascade_name (originating cascade or \"unknown\" for \
@@ -417,7 +417,7 @@ let kind_of_masc_internal_error = function
   | Admission_queue_timeout _ -> "admission_queue_timeout"
   | Admission_queue_rejected _ -> "admission_queue_rejected"
   | Turn_timeout _ -> "turn_timeout"
-  | Oas_timeout_budget _ -> "oas_timeout_budget"
+  | Oas_timeout_budget _ -> "turn_timeout"
   | Max_tokens_ceiling_violation _ -> "max_tokens_ceiling_violation"
   | Ambiguous_post_commit _ -> "ambiguous_post_commit"
   | Internal_unhandled_exception _ -> "internal_unhandled_exception"


### PR DESCRIPTION
## Summary
- stop advertising or emitting `masc_oas_error_total{kind="oas_timeout_budget"}`
- fold legacy `Oas_timeout_budget` internal errors into the existing `turn_timeout` metric label
- document that timeout-budget inputs must not mint a first-class metric series

## Validation
- Not run; user requested PR iteration without local validation.
