### PR TITLE
fix(metrics): retire timeout budget metric names

### DIFF
--- a/dashboard/src/components/keeper-reactivity-monitor.test.ts
+++ b/dashboard/src/components/keeper-reactivity-monitor.test.ts
@@ -69,9 +69,9 @@ describe('extractKeeperStopSummaries', () => {
     expect(gamma.storm_pauses).toBe(7)
   })
 
-  it('aggregates budget_loop_pauses from masc_keeper_oas_timeout_budget_loop_paused_total', () => {
+  it('aggregates budget_loop_pauses from masc_keeper_provider_timeout_loop_paused_total', () => {
     const metrics: ParsedMetric[] = [
-      makeMetric('masc_keeper_oas_timeout_budget_loop_paused_total', [
+      makeMetric('masc_keeper_provider_timeout_loop_paused_total', [
         { labels: { keeper: 'delta' }, value: 4 },
       ]),
     ]
@@ -80,9 +80,9 @@ describe('extractKeeperStopSummaries', () => {
     expect(delta.budget_loop_pauses).toBe(4)
   })
 
-  it('aggregates budget_strikes from masc_keeper_oas_timeout_budget_strike', () => {
+  it('aggregates budget_strikes from masc_keeper_provider_timeout_strike_total', () => {
     const metrics: ParsedMetric[] = [
-      makeMetric('masc_keeper_oas_timeout_budget_strike', [
+      makeMetric('masc_keeper_provider_timeout_strike_total', [
         { labels: { keeper: 'epsilon' }, value: 2 },
       ]),
     ]

--- a/dashboard/src/components/keeper-reactivity-monitor.ts
+++ b/dashboard/src/components/keeper-reactivity-monitor.ts
@@ -100,6 +100,7 @@ export function extractKeeperStopSummaries(
       // Legacy compatibility metrics. New keeper policy should surface
       // owner-specific timeout/admission/capacity causes instead of treating
       // timeout-legacy budget strikes as a first-class root cause.
+      m.name === 'masc_keeper_provider_timeout_strike_total' ||
       m.name === 'masc_keeper_oas_timeout_budget_strike' ||
       m.name === 'masc_keeper_oas_timeout_budget_strike_total'
     ) {
@@ -110,7 +111,10 @@ export function extractKeeperStopSummaries(
       for (const s of m.samples) {
         if (s.labels.keeper) entry(s.labels.keeper).storm_pauses += s.value
       }
-    } else if (m.name === 'masc_keeper_oas_timeout_budget_loop_paused_total') {
+    } else if (
+      m.name === 'masc_keeper_provider_timeout_loop_paused_total' ||
+      m.name === 'masc_keeper_oas_timeout_budget_loop_paused_total'
+    ) {
       for (const s of m.samples) {
         if (s.labels.keeper) entry(s.labels.keeper).budget_loop_pauses += s.value
       }

--- a/lib/keeper/keeper_heartbeat_loop_cycle_with_slot.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle_with_slot.ml
@@ -13,7 +13,7 @@
       Exception] + raises [Keeper_registry.Keeper_fiber_crash] for
       the supervisor to handle.
 
-    - OAS timeout budget errors → strike-counter bump (seeded from
+    - Legacy timeout-budget errors → provider-timeout strike-counter bump (seeded from
       [prior_oas_timeout_budget_strikes]) + persistent failure
       reason + observation recording + [Keeper_failure_policy.decide]
       kill/keep decision + [metric_keeper_oas_timeout_budget_strike]

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -336,7 +336,7 @@ let to_string = function
   | PresenceSyncFailures -> "masc_keeper_presence_sync_failures_total"
   | SelfPreservationUniversal -> "masc_keeper_self_preservation_universal_total"
   | StaleStormPaused -> "masc_keeper_stale_storm_paused_total"
-  | OasTimeoutBudgetLoopPaused -> "masc_keeper_oas_timeout_budget_loop_paused_total"
+  | OasTimeoutBudgetLoopPaused -> "masc_keeper_provider_timeout_loop_paused_total"
   | CycleExceptions -> "masc_keeper_cycle_exceptions_total"
   | SnapshotWriteFailures -> "masc_keeper_snapshot_write_failures_total"
   | ProgressUpdatedLineFailures -> "masc_keeper_progress_updated_line_failures_total"
@@ -397,11 +397,11 @@ let to_string = function
   | RequiredToolGateSuppressedTotal -> "masc_keeper_required_tool_gate_suppressed_total"
   | ConsecutiveIdle -> "masc_keeper_consecutive_idle"
   | LastProductiveTs -> "masc_keeper_last_productive_ts"
-  | OasTimeoutBudgetStrike -> "masc_keeper_oas_timeout_budget_strike_total"
+  | OasTimeoutBudgetStrike -> "masc_keeper_provider_timeout_strike_total"
   | StaleTerminationTotal -> "masc_keeper_stale_termination_total"
   | StaleTerminationByClass -> "masc_keeper_stale_termination_by_class_total"
   | OasTimeoutBudgetWatchdogTermination ->
-    "masc_keeper_oas_timeout_budget_watchdog_termination_total"
+    "masc_keeper_stale_watchdog_timeout_termination_total"
   | StaleTerminationThresholdBreached ->
     "masc_keeper_stale_termination_threshold_breached_total"
   | StaleTerminationBatch -> "masc_keeper_stale_termination_batch_total"
@@ -724,7 +724,7 @@ let metric_keeper_self_preservation_universal =
 let metric_keeper_stale_storm_paused = "masc_keeper_stale_storm_paused_total"
 
 let metric_keeper_oas_timeout_budget_loop_paused =
-  "masc_keeper_oas_timeout_budget_loop_paused_total"
+  "masc_keeper_provider_timeout_loop_paused_total"
 ;;
 
 let metric_keeper_cycle_exceptions = "masc_keeper_cycle_exceptions_total"
@@ -938,7 +938,7 @@ let metric_keeper_consecutive_idle = "masc_keeper_consecutive_idle"
 let metric_keeper_last_productive_ts = "masc_keeper_last_productive_ts"
 
 let metric_keeper_oas_timeout_budget_strike =
-  "masc_keeper_oas_timeout_budget_strike_total"
+  "masc_keeper_provider_timeout_strike_total"
 ;;
 
 let metric_keeper_stale_termination_total = "masc_keeper_stale_termination_total"
@@ -948,7 +948,7 @@ let metric_keeper_stale_termination_by_class =
 ;;
 
 let metric_keeper_oas_timeout_budget_watchdog_termination =
-  "masc_keeper_oas_timeout_budget_watchdog_termination_total"
+  "masc_keeper_stale_watchdog_timeout_termination_total"
 ;;
 
 let metric_keeper_stale_termination_threshold_breached =

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -307,8 +307,8 @@ let () =
     ~name:Keeper_metrics.metric_keeper_oas_timeout_budget_watchdog_termination
     ~help:
       "Total watchdog terminations that preserved an unresolved \
-       oas_timeout_budget failure reason instead of reclassifying the \
-       keeper as an idle stale stall. Labels: keeper."
+       timeout failure evidence instead of reclassifying the keeper as \
+       an idle stale stall. Labels: keeper."
     ()
 
 (* #10765 phase 2: fleet-wide batch termination detection.

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -852,7 +852,7 @@ let sweep_and_recover (ctx : _ context) =
        [keeper-level max-turn watchdog] (PR #15964) which cancels the
        keepalive fiber at a typed wall-clock boundary BEFORE the slot
        leaks. Removal target: 30-day soak on
-       [metric_keeper_oas_timeout_budget_watchdog_termination] reaching
+       stale-watchdog timeout termination metric reaching
        zero with [MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC] enabled
        fleet-wide. Do not add new callers. *)
     (match Keeper_turn_slot.force_release_holder_for ~keeper_name:entry.name with

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -157,7 +157,7 @@ val fairness_delay_sec_at : now:float -> keeper_name:string -> float
     (PR #15964), which cancels the keepalive fiber at a typed wall-clock
     boundary BEFORE the slot is leaked, so this rescue path stops being
     reached. Removal target: 30-day soak on
-    [metric_keeper_oas_timeout_budget_watchdog_termination] reaching
+    stale-watchdog timeout termination metric reaching
     zero after `MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC` is enabled
     fleet-wide. Do not invoke from new call sites. Existing legitimate
     callers (slated to be unwound under removal target above):

--- a/lib/prometheus_builtin_metrics_part3.ml
+++ b/lib/prometheus_builtin_metrics_part3.ml
@@ -212,8 +212,7 @@ let register
     `Counter;
   add
     Keeper_metrics.metric_keeper_oas_timeout_budget_loop_paused
-    "Total keepers auto-paused due to repeated OAS timeout budget exhaustion. Labeled by \
-     keeper."
+    "Total keepers auto-paused due to repeated provider timeout loops. Labeled by keeper."
     `Counter;
   add
     Keeper_metrics.metric_keeper_cycle_exceptions

--- a/lib/prometheus_builtin_metrics_part5.ml
+++ b/lib/prometheus_builtin_metrics_part5.ml
@@ -39,8 +39,8 @@ let register
     `Counter;
   add
     Keeper_metrics.metric_keeper_oas_timeout_budget_watchdog_termination
-    "Total watchdog terminations preserving unresolved oas_timeout_budget      failure \
-     reason. Labels: keeper."
+    "Total watchdog terminations preserving unresolved timeout failure evidence. Labels: \
+     keeper."
     `Counter;
   add
     Keeper_metrics.metric_keeper_stale_termination_threshold_breached
@@ -163,7 +163,7 @@ let register
     `Counter;
   add
     Keeper_metrics.metric_keeper_oas_timeout_budget_strike
-    "OAS timeout budget strikes (consecutive timeouts before escalation). Labels: keeper."
+    "Provider timeout strikes (consecutive timeouts before escalation). Labels: keeper."
     `Counter;
   add
     Keeper_metrics.metric_keeper_path_rejection

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -1171,7 +1171,7 @@ let test_oas_timeout_budget_loop_pause_skips_restart () =
         (Some (Reg.Oas_timeout_budget_loop { count = 3 }));
       let baseline_pause =
         Masc_mcp.Prometheus.metric_total
-          "masc_keeper_oas_timeout_budget_loop_paused_total"
+          "masc_keeper_provider_timeout_loop_paused_total"
       in
       let baseline_dead =
         Masc_mcp.Prometheus.metric_total
@@ -1190,7 +1190,7 @@ let test_oas_timeout_budget_loop_pause_skips_restart () =
       Sup.sweep_and_recover ctx;
       let after_pause =
         Masc_mcp.Prometheus.metric_total
-          "masc_keeper_oas_timeout_budget_loop_paused_total"
+          "masc_keeper_provider_timeout_loop_paused_total"
       in
       let after_dead =
         Masc_mcp.Prometheus.metric_total


### PR DESCRIPTION
## Summary
- rename emitted keeper timeout-budget Prometheus series to provider-timeout or stale-watchdog owner names
- update metric help text and supervisor test literals for the new series names
- keep dashboard reactivity parsing the new series while accepting old timeout-budget names as legacy aliases
- leave OCaml public constant identifiers in place for source compatibility while retiring the metric names they return

## Validation
- Not run; user requested PR iteration without local validation.
