### PR TITLE
test(keeper): direct unit tests for read_file_tail_lines_result (RFC-0149 §3.1 PR-1.5)

### DIFF
--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -13,84 +13,98 @@ let re_weather_en = Re.str "weather" |> Re.compile
 let re_first_ko = Re.str "첫" |> Re.compile
 let re_first_en = Re.str "first" |> Re.compile
 
-let read_file_tail_lines path ~max_bytes ~max_lines : string list =
-  if max_lines <= 0 then []
-  else if not (Fs_compat.file_exists path) then []
+(* RFC-0149 §3.1 — typed Result entry point.  Distinguishes "no memory"
+   ([Ok []] for missing file or zero-line request) from "IO/parse fault"
+   ([Error class]).  The catch-all classifies the exception through the
+   closed sum {!Keeper_memory_recall_exn_class.t} so the caller can
+   branch on a bounded label instead of a free-form string. *)
+let read_file_tail_lines_result path ~max_bytes ~max_lines :
+    (string list, Keeper_memory_recall_exn_class.t) result =
+  if max_lines <= 0 then Ok []
+  else if not (Fs_compat.file_exists path) then Ok []
   else
-    (* The catch-all below preserves prior behavior (return [[]] on
-       IO failure), but read errors used to be indistinguishable from
-       "no recorded memory" — both paths returned the empty list.
-       Emit a counter + WARN so corrupt / missing memory bank files
-       become visible in operator dashboards. Label cardinality is
-       bounded by reusing [Keeper_memory_recall_exn_class] (a 4-value
-       closed sum); the full error string still goes to the log body. *)
     try
       let fd = Unix.openfile path [ Unix.O_RDONLY ] 0 in
-      Fun.protect
-        ~finally:(fun () -> try Unix.close fd with Unix.Unix_error _ -> ())
-        (fun () ->
-          let file_len = (Unix.LargeFile.fstat fd).Unix.LargeFile.st_size in
-          let min_start =
-            if max_bytes <= 0
-            then 0L
-            else Int64.max 0L (Int64.sub file_len (Int64.of_int max_bytes))
-          in
-          let chunk_size = 64 * 1024 in
-          let pos = ref file_len in
-          let chunks = ref [] in
-          let newline_count = ref 0 in
-          let count_newlines s =
-            String.iter (fun ch -> if ch = '\n' then incr newline_count) s
-          in
-          while Int64.compare !pos min_start > 0 && !newline_count <= max_lines do
-            let available = Int64.sub !pos min_start in
-            let read_len =
-              Int64.to_int (Int64.min (Int64.of_int chunk_size) available)
-            in
-            let start = Int64.sub !pos (Int64.of_int read_len) in
-            ignore (Unix.LargeFile.lseek fd start Unix.SEEK_SET);
-            let buf = Bytes.create read_len in
-            let rec read_exact offset remaining =
-              if remaining <= 0 then offset
-              else
-                let n = Unix.read fd buf offset remaining in
-                if n = 0 then offset else read_exact (offset + n) (remaining - n)
-            in
-            let bytes_read = read_exact 0 read_len in
-            let chunk = Bytes.sub_string buf 0 bytes_read in
-            count_newlines chunk;
-            chunks := chunk :: !chunks;
-            pos := start
-          done;
-          let content = String.concat "" !chunks in
-          let lines =
-            content
-            |> String.split_on_char '\n'
-            |> List.filter (fun s -> String.trim s <> "")
-          in
-          let lines =
-            if Int64.compare !pos 0L > 0
-            then (match lines with _ :: rest -> rest | [] -> [])
-            else lines
-          in
-          let n = List.length lines in
-          if n <= max_lines then lines
-          else
-            let drop = n - max_lines in
-            List.filteri (fun i _ -> i >= drop) lines)
+      Ok
+        (Fun.protect
+           ~finally:(fun () -> try Unix.close fd with Unix.Unix_error _ -> ())
+           (fun () ->
+             let file_len = (Unix.LargeFile.fstat fd).Unix.LargeFile.st_size in
+             let min_start =
+               if max_bytes <= 0
+               then 0L
+               else Int64.max 0L (Int64.sub file_len (Int64.of_int max_bytes))
+             in
+             let chunk_size = 64 * 1024 in
+             let pos = ref file_len in
+             let chunks = ref [] in
+             let newline_count = ref 0 in
+             let count_newlines s =
+               String.iter (fun ch -> if ch = '\n' then incr newline_count) s
+             in
+             while Int64.compare !pos min_start > 0 && !newline_count <= max_lines do
+               let available = Int64.sub !pos min_start in
+               let read_len =
+                 Int64.to_int (Int64.min (Int64.of_int chunk_size) available)
+               in
+               let start = Int64.sub !pos (Int64.of_int read_len) in
+               ignore (Unix.LargeFile.lseek fd start Unix.SEEK_SET);
+               let buf = Bytes.create read_len in
+               let rec read_exact offset remaining =
+                 if remaining <= 0 then offset
+                 else
+                   let n = Unix.read fd buf offset remaining in
+                   if n = 0 then offset else read_exact (offset + n) (remaining - n)
+               in
+               let bytes_read = read_exact 0 read_len in
+               let chunk = Bytes.sub_string buf 0 bytes_read in
+               count_newlines chunk;
+               chunks := chunk :: !chunks;
+               pos := start
+             done;
+             let content = String.concat "" !chunks in
+             let lines =
+               content
+               |> String.split_on_char '\n'
+               |> List.filter (fun s -> String.trim s <> "")
+             in
+             let lines =
+               if Int64.compare !pos 0L > 0
+               then (match lines with _ :: rest -> rest | [] -> [])
+               else lines
+             in
+             let n = List.length lines in
+             if n <= max_lines then lines
+             else
+               let drop = n - max_lines in
+               List.filteri (fun i _ -> i >= drop) lines))
     with
     | (Sys_error _ | Unix.Unix_error _ | End_of_file) as exn ->
-        let exn_label =
-          Keeper_memory_recall_exn_class.(to_label (classify exn))
-        in
-        Log.Keeper.warn
-          "read_file_tail_lines: dropping read of %s: %s"
-          path (Printexc.to_string exn);
-        Prometheus.inc_counter
-          Keeper_metrics.metric_keeper_memory_recall_read_errors
-          ~labels:[ ("exception_class", exn_label) ]
-          ();
-        []
+        Error (Keeper_memory_recall_exn_class.classify exn)
+
+let read_file_tail_lines path ~max_bytes ~max_lines : string list =
+  match read_file_tail_lines_result path ~max_bytes ~max_lines with
+  | Ok lines -> lines
+  | Error exn_class ->
+    (* WORKAROUND: RFC-0149 §3.1 sunset target.  Counter + WARN remain
+       in this legacy entry point only; the Result-returning helper
+       above surfaces the typed exception class so the caller can
+       branch on [Error] directly.
+
+       Removal: once every caller migrates to
+       [read_file_tail_lines_result], delete this Error arm together
+       with the counter/WARN per RFC-0149 §3.1 sunset criterion.  The
+       counter itself can be retained for long-tail trend analysis
+       (cardinality already bounded by [exn_class]). *)
+    let exn_label = Keeper_memory_recall_exn_class.to_label exn_class in
+    Log.Keeper.warn
+      "read_file_tail_lines: dropping read of %s: <error class=%s>"
+      path exn_label;
+    Prometheus.inc_counter
+      Keeper_metrics.metric_keeper_memory_recall_read_errors
+      ~labels:[ ("exception_class", exn_label) ]
+      ();
+    []
 
 let read_keeper_memory_summary
     (config : Coord.config)

--- a/lib/keeper/keeper_memory_recall.mli
+++ b/lib/keeper/keeper_memory_recall.mli
@@ -11,7 +11,31 @@ include module type of Keeper_memory_bank
 
 (** {1 File Reading} *)
 
+val read_file_tail_lines_result :
+  string -> max_bytes:int -> max_lines:int
+  -> (string list, Keeper_memory_recall_exn_class.t) result
+(** Result-returning tail reader.  [Ok []] covers both "no recorded
+    memory" (file missing, or [max_lines <= 0]) and "empty file"; the
+    caller cannot disambiguate at this entry point and should not try.
+    [Error class] surfaces an IO/parse failure classified through the
+    bounded {!Keeper_memory_recall_exn_class.t} closed sum so callers
+    can branch on a typed value instead of inspecting a stringified
+    exception (RFC-0149 §3.1).
+
+    Use this entry point when the caller can produce a meaningful
+    operator-visible signal on [Error] (e.g. propagate
+    {b Memory_unavailable} up the chain instead of silently rendering
+    an empty summary).
+
+    @since RFC-0149 Phase 1 *)
+
 val read_file_tail_lines : string -> max_bytes:int -> max_lines:int -> string list
+(** Silent-fallback tail reader: classifies IO/parse failures, emits
+    the [keeper_memory_recall_read_errors] counter + a WARN-once log
+    line, and returns [[]] on any [Error] class.  Retained as a facade
+    over {!read_file_tail_lines_result} during the RFC-0149 §3.1
+    sunset window; new callers should prefer the Result-returning
+    helper. *)
 
 val read_keeper_memory_summary :
   Coord.config ->

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -4,6 +4,7 @@ module Mention = Mention
 module Keeper_execution = Masc_mcp.Keeper_execution
 module Keeper_memory = Masc_mcp.Keeper_memory
 module Keeper_memory_recall = Masc_mcp.Keeper_memory_recall
+module Keeper_memory_recall_exn_class = Masc_mcp.Keeper_memory_recall_exn_class
 module Keeper_world_observation = Masc_mcp.Keeper_world_observation
 module Meas = Masc_mcp.Keeper_measurement
 module Keeper_types = Masc_mcp.Keeper_types
@@ -397,6 +398,62 @@ let test_read_file_tail_lines_drops_partial_byte_cap_line () =
       Keeper_memory_recall.read_file_tail_lines path ~max_bytes:8 ~max_lines:3
     in
     check (list string) "partial first capped line dropped" [ "third" ] lines)
+
+(* RFC-0149 §3.1 — direct unit tests for the Result-returning helper.
+   The legacy facade tests above exercise the [Ok] path indirectly;
+   these cases pin the [Ok] / [Ok []] / [Error _] tri-state contract
+   so a caller migration cannot silently regress the typed boundary. *)
+
+let exn_class_testable =
+  let module E = Keeper_memory_recall_exn_class in
+  Alcotest.testable
+    (fun ppf c -> Format.pp_print_string ppf (E.to_label c))
+    (fun a b -> E.to_label a = E.to_label b)
+
+let test_read_file_tail_lines_result_ok_on_normal_read () =
+  let dir = test_tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
+    let path = Filename.concat dir "history.jsonl" in
+    let oc = open_out path in
+    output_string oc "alpha\nbeta\ngamma\n";
+    close_out oc;
+    match
+      Keeper_memory_recall.read_file_tail_lines_result path
+        ~max_bytes:0 ~max_lines:3
+    with
+    | Ok lines ->
+        check (list string) "all three lines on ok"
+          [ "alpha"; "beta"; "gamma" ] lines
+    | Error _ -> fail "expected Ok on a readable file, got Error")
+
+let test_read_file_tail_lines_result_ok_empty_on_missing_file () =
+  let dir = test_tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
+    let path = Filename.concat dir "does-not-exist.jsonl" in
+    match
+      Keeper_memory_recall.read_file_tail_lines_result path
+        ~max_bytes:0 ~max_lines:3
+    with
+    | Ok lines ->
+        check (list string) "missing file maps to Ok []" [] lines
+    | Error _ ->
+        fail "missing file must surface as Ok [] (no recorded memory)")
+
+let test_read_file_tail_lines_result_error_on_directory_path () =
+  let dir = test_tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
+    (* Use the test tmpdir itself as the "file" path: [Unix.openfile]
+       on a directory raises [Unix.Unix_error (EISDIR, ...)] on macOS /
+       Linux, which the Result helper classifies as [Io_error]. *)
+    match
+      Keeper_memory_recall.read_file_tail_lines_result dir
+        ~max_bytes:0 ~max_lines:3
+    with
+    | Ok _ ->
+        fail "directory-as-path must surface as Error, not Ok"
+    | Error c ->
+        check exn_class_testable "io_error classification"
+          Keeper_memory_recall_exn_class.Io_error c)
 
 let test_recall_candidates_with_history_dedup () =
   let dir = test_tmpdir () in
@@ -1794,6 +1851,12 @@ let () =
             test_read_file_tail_lines_reads_tail_without_byte_cap;
           test_case "read_file_tail_lines drops partial byte-cap line" `Quick
             test_read_file_tail_lines_drops_partial_byte_cap_line;
+          test_case "read_file_tail_lines_result Ok on normal read" `Quick
+            test_read_file_tail_lines_result_ok_on_normal_read;
+          test_case "read_file_tail_lines_result Ok [] on missing file" `Quick
+            test_read_file_tail_lines_result_ok_empty_on_missing_file;
+          test_case "read_file_tail_lines_result Error on directory path" `Quick
+            test_read_file_tail_lines_result_error_on_directory_path;
           test_case "recall_candidates_with_history deduplicates" `Quick
             test_recall_candidates_with_history_dedup;
           test_case "recall_candidates_with_history appends history" `Quick


### PR DESCRIPTION
# test(keeper): direct unit tests for read_file_tail_lines_result (RFC-0149 §3.1 PR-1.5)

## 배경

PR-1 (#17670) 이 `read_file_tail_lines_result` Result helper 를 추가. 본 PR 은 그 새 entry point 의 `Ok` / `Ok []` / `Error _` tri-state contract 를 직접 unit test 로 pin.

**Stacked on**: PR #17670 (RFC-0149 §3.1 PR-1).

## 변경 범위

```
test/test_keeper_memory.ml | +63
```

3 새 Alcotest case:

| 케이스 | 의도 |
|--------|------|
| `Ok on normal read` | 정상 파일 → `Ok ["alpha"; "beta"; "gamma"]` |
| `Ok [] on missing file` | 부재 파일 → `Ok []` (= "no recorded memory") |
| `Error on directory path` | dir 경로 → `Error Io_error` (Unix EISDIR) |

세 번째 케이스는 `Keeper_memory_recall_exn_class.t` 의 `to_label` equality 로 비교 — bounded label 변경 시 자동 fail (cardinality drift 감지).

## 정량 완료 기준

- `dune build test/test_keeper_memory.exe`: pass
- 3 새 test 모두 OK (기존 `read_file_tail_lines reads/drops` 와 함께)

## 후속

본 test stack 머지 후, RFC-0149 §3.1 PR-2 (caller migration of `read_keeper_memory_summary` 등) 진행 시 `Error` 분기 안전 검증의 baseline.

RFC-WAIVED: 본 PR 은 test 추가만 — production code 0 변경. RFC-0149 §3.1 spec 의 typed boundary 검증.

## Co-Authored-By

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>