### PR TITLE
fix(keeper): replace timeout budget disposition action

### DIFF
--- a/lib/keeper/keeper_turn_disposition.ml
+++ b/lib/keeper/keeper_turn_disposition.ml
@@ -66,7 +66,7 @@ let summary = function
 let next_action = function
   | Success -> None
   | External_cancel -> Some "rerun_if_still_relevant"
-  | Turn_wall_clock_timeout | Oas_timeout_budget -> Some "inspect_timeout_budget"
+  | Turn_wall_clock_timeout | Oas_timeout_budget -> Some "inspect_turn_timeout"
   | Cascade_attempts_exhausted -> Some "inspect_cascade_attempts"
   | Gh_repo_context_missing_worktree -> Some "create_or_link_worktree"
   | Required_tool_use_no_tool_call ->

--- a/lib/keeper/keeper_turn_disposition.mli
+++ b/lib/keeper/keeper_turn_disposition.mli
@@ -29,7 +29,10 @@ type t =
   | External_cancel
   (** Turn cancelled before completion (operator stop, switch_keeper, …). *)
   | Turn_wall_clock_timeout (** Turn exceeded its wall-clock budget. *)
-  | Oas_timeout_budget (** OAS turn-budget cooldown / cap rejection. *)
+  | Oas_timeout_budget
+  (** Legacy OAS timeout-budget wire value. Operators should inspect
+      owner-specific turn/provider timeout evidence instead of treating this
+      as a distinct root cause. *)
   | Cascade_attempts_exhausted
   (** Cascade aggregate outcome: all candidate attempts were exhausted.
           Operators should inspect per-attempt root causes instead of treating

--- a/test/test_keeper_turn_disposition.ml
+++ b/test/test_keeper_turn_disposition.ml
@@ -8,7 +8,9 @@
        next_action — *after* the legacy [normalize_code] is applied
        to the input wire (since PR-2 will keep the same producer-side
        normalisation; this test isolates the *consumer-side*
-       invariant).
+       invariant). Timeout actions intentionally differ: the legacy
+       [inspect_timeout_budget] action collapsed provider, admission/capacity,
+       and turn liveness ownership.
 
     2. Round-trip: [of_wire (to_wire t) = t] for every canonical
        constructor and for [Provider_error] wrapping each runtime
@@ -101,7 +103,9 @@ let test_canonical_next_action_byte_compat () =
     (fun (wire, disp) ->
        let legacy = Legacy.of_code wire in
        let expected =
-         match legacy.next_action with
+         match wire, legacy.next_action with
+         | ("turn_wall_clock_timeout" | "oas_timeout_budget"), _ ->
+           "Some:inspect_turn_timeout"
          | Some s -> "Some:" ^ s
          | None -> "None"
        in


### PR DESCRIPTION
## Summary
- replace terminal-disposition timeout actions from `inspect_timeout_budget` to `inspect_turn_timeout`
- mark `Oas_timeout_budget` disposition as a legacy wire value rather than a distinct operator root cause
- update the disposition byte-compat test oracle to allow the intentional timeout-action split

## Validation
- Not run; user requested PR iteration without local validation.
