### PR TITLE
fix(keeper): normalize legacy timeout terminal code

### DIFF
--- a/lib/keeper/keeper_turn_terminal_code.ml
+++ b/lib/keeper/keeper_turn_terminal_code.ml
@@ -56,7 +56,7 @@ let of_wire = function
     Some Stale_turn_timeout_in_turn
   | "stale_termination_storm" -> Some Stale_termination_storm
   | "stale_fleet_batch" -> Some Stale_fleet_batch
-  | "oas_timeout_budget" -> Some Oas_timeout_budget
+  | "oas_timeout_budget" -> Some (Provider_runtime_error "provider_timeout")
   | "heartbeat_failures" -> Some Heartbeat_failures
   | "turn_failures" -> Some Turn_failures
   | "ambiguous_partial_commit" ->
@@ -86,7 +86,8 @@ let of_failure_reason : Keeper_registry.failure_reason -> t = function
     Stale_turn_timeout_noop
   | Keeper_registry.Stale_termination_storm _ -> Stale_termination_storm
   | Keeper_registry.Stale_fleet_batch _ -> Stale_fleet_batch
-  | Keeper_registry.Oas_timeout_budget_loop _ -> Oas_timeout_budget
+  | Keeper_registry.Oas_timeout_budget_loop _ ->
+    Provider_runtime_error "provider_timeout_loop"
   | Keeper_registry.Provider_runtime_error { code; _ } -> Provider_runtime_error code
   | Keeper_registry.Tool_required_unsatisfied { code; _ } ->
     Tool_required_unsatisfied code

--- a/lib/keeper/keeper_turn_terminal_code.mli
+++ b/lib/keeper/keeper_turn_terminal_code.mli
@@ -39,8 +39,9 @@ type t =
       Current fleet-batch detection is observation-only; fresh watchdog kills
       retain their per-keeper terminal code. *)
   | Oas_timeout_budget
-  (** [Keeper_registry.Oas_timeout_budget_loop]: same keeper
-          exhausted the OAS turn budget on consecutive cycles. *)
+  (** Legacy wire-only timeout-budget code. New registry projections
+      normalize this to provider/turn timeout evidence instead of emitting
+      ["oas_timeout_budget"]. *)
   | Heartbeat_failures (** [Keeper_registry.Heartbeat_consecutive_failures]. *)
   | Turn_failures (** [Keeper_registry.Turn_consecutive_failures]. *)
   | Provider_runtime_error of string


### PR DESCRIPTION
## Summary
- stop decoding legacy `oas_timeout_budget` terminal-code wire into the `Oas_timeout_budget` constructor
- project persisted `Oas_timeout_budget_loop` registry reasons as `provider_timeout_loop`
- leave the old constructor documented as legacy wire-only compatibility

## Validation
- Not run; user requested PR iteration without local validation.
