### PR TITLE
fix(keeper): normalize recorded timeout budget errors

### DIFF
--- a/lib/keeper_recording_error_state/keeper_recording_error_state.ml
+++ b/lib/keeper_recording_error_state/keeper_recording_error_state.ml
@@ -25,7 +25,7 @@ type error_kind =
   | Sandbox_docker
   | Stale_turn_timeout
   | Fiber_unresolved
-  | Oas_timeout_budget
+  | Provider_timeout
   | State_machine_guard
   | Expected_version_mismatch
   | Cascade_resolution_failure
@@ -37,7 +37,7 @@ let error_kind_to_string = function
   | Sandbox_docker -> "sandbox_docker"
   | Stale_turn_timeout -> "stale_turn_timeout"
   | Fiber_unresolved -> "fiber_unresolved"
-  | Oas_timeout_budget -> "oas_timeout_budget"
+  | Provider_timeout -> "provider_timeout"
   | State_machine_guard -> "state_machine_guard"
   | Expected_version_mismatch -> "expected_version_mismatch"
   | Cascade_resolution_failure -> "cascade_resolution_failure"
@@ -50,7 +50,7 @@ let error_kind_of_string = function
   | "sandbox_docker" -> Some Sandbox_docker
   | "stale_turn_timeout" -> Some Stale_turn_timeout
   | "fiber_unresolved" -> Some Fiber_unresolved
-  | "oas_timeout_budget" -> Some Oas_timeout_budget
+  | "provider_timeout" | "oas_timeout_budget" -> Some Provider_timeout
   | "state_machine_guard" -> Some State_machine_guard
   | "expected_version_mismatch" -> Some Expected_version_mismatch
   | "cascade_resolution_failure" -> Some Cascade_resolution_failure
@@ -64,7 +64,7 @@ let all_error_kinds =
   [ Sandbox_docker
   ; Stale_turn_timeout
   ; Fiber_unresolved
-  ; Oas_timeout_budget
+  ; Provider_timeout
   ; State_machine_guard
   ; Expected_version_mismatch
   ; Cascade_resolution_failure
@@ -99,8 +99,8 @@ let classify_error (err : string) : error_kind =
   then Stale_turn_timeout
   else if contains "fiber_unresolved"
   then Fiber_unresolved
-  else if contains "oas_timeout_budget"
-  then Oas_timeout_budget
+  else if contains "provider_timeout" || contains "oas_timeout_budget"
+  then Provider_timeout
   else if contains "state machine guard" || contains "guard violation"
   then State_machine_guard
   else if contains "expected_version" && contains "mismatch"

--- a/lib/keeper_recording_error_state/keeper_recording_error_state.mli
+++ b/lib/keeper_recording_error_state/keeper_recording_error_state.mli
@@ -52,7 +52,9 @@ type error_kind =
   | Sandbox_docker (** ["sandbox docker exec failed ..."] family. *)
   | Stale_turn_timeout (** ["stale_turn_timeout(...)"] supervisor guard. *)
   | Fiber_unresolved (** ["fiber_unresolved"] sentinel from turn lifecycle. *)
-  | Oas_timeout_budget (** ["oas_timeout_budget_loop(...)"] from OAS bridge. *)
+  | Provider_timeout
+      (** Provider/OAS timeout family. Legacy ["oas_timeout_budget_loop(...)"]
+          text is normalized here instead of becoming its own root cause. *)
   | State_machine_guard
       (** ["state machine guard violation"] / FSM transition rejected. *)
   | Expected_version_mismatch (** CAS expected_version mismatch. *)

--- a/test/keeper_recording_error_state/test_keeper_recording_error_state.ml
+++ b/test/keeper_recording_error_state/test_keeper_recording_error_state.ml
@@ -42,10 +42,10 @@ let test_classify_fiber_unresolved () =
 let test_classify_oas_timeout () =
   check
     bool
-    "oas_timeout_budget_loop(count=1) → Oas_timeout_budget"
+    "oas_timeout_budget_loop(count=1) → Provider_timeout"
     true
     (S.classify_error "oas_timeout_budget_loop(count=1)"
-     = S.Oas_timeout_budget)
+     = S.Provider_timeout)
 ;;
 
 let test_classify_state_machine_guard () =
@@ -219,7 +219,7 @@ let () =
       , [ test_case "sandbox docker" `Quick test_classify_sandbox_docker
         ; test_case "stale_turn_timeout" `Quick test_classify_stale_turn
         ; test_case "fiber_unresolved" `Quick test_classify_fiber_unresolved
-        ; test_case "oas_timeout_budget" `Quick test_classify_oas_timeout
+        ; test_case "legacy timeout-budget provider timeout" `Quick test_classify_oas_timeout
         ; test_case
             "state machine guard"
             `Quick


### PR DESCRIPTION
## Summary
- replace keeper recording-error-state `Oas_timeout_budget` kind with `Provider_timeout`
- normalize legacy `oas_timeout_budget` labels/text into the provider-timeout bucket
- update the classifier test naming and expectation so timeout-budget is not a first-class learned/dedupe family

## Validation
- Not run; user requested PR iteration without local validation.
