### PR TITLE
fix(keeper): normalize timeout loop stale cohorts

### DIFF
--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -86,7 +86,7 @@ let failure_reason_to_string = function
   | Stale_fleet_batch { distinct_count } ->
     Printf.sprintf "stale_fleet_batch(distinct_count=%d)" distinct_count
   | Oas_timeout_budget_loop { count } ->
-    Printf.sprintf "oas_timeout_budget_loop(count=%d)" count
+    Printf.sprintf "provider_timeout_loop(count=%d)" count
   | Provider_runtime_error { code; detail; provider_id; http_status } ->
     let prov =
       Option.fold provider_id ~none:""
@@ -123,7 +123,7 @@ let failure_reason_cohort_key = function
   | Some (Stale_turn_timeout _) -> "stale_turn_timeout"
   | Some (Stale_termination_storm _) -> "stale_termination_storm"
   | Some (Stale_fleet_batch _) -> "stale_fleet_batch"
-  | Some (Oas_timeout_budget_loop _) -> "oas_timeout_budget_loop"
+  | Some (Oas_timeout_budget_loop _) -> "provider_timeout_loop"
   | Some (Provider_runtime_error _) -> "provider_runtime_error"
   | Some (Tool_required_unsatisfied _) -> "tool_required_unsatisfied"
   | Some (Ambiguous_partial_commit _) -> "ambiguous_partial_commit"

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -80,10 +80,9 @@ type failure_reason =
           failure reason; if old runtime state still contains it, the
           supervisor treats it like a restartable watchdog crash. *)
   | Oas_timeout_budget_loop of { count : int }
-      (** Latched when the same keeper exhausts the OAS turn budget on
-          consecutive cycles. This is a provider/cascade/runtime throughput
-          failure, so the supervisor pauses instead of restarting into the
-          same slow model and burning another multi-minute budget. *)
+      (** Legacy persisted timeout-loop value. New operator/cohort surfaces
+          normalize it to provider-timeout ownership instead of presenting
+          timeout-budget as a distinct root cause. *)
   | Provider_runtime_error of
       { code : string
       ; detail : string

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -168,6 +168,7 @@ let active_turn_stale_status_for_test = active_turn_stale_status
 
 type batch_root_cause =
   | Cascade_unhealthy
+  | Provider_timeout
   | Provider_auth
   | Fd_exhaustion
   | Mixed
@@ -175,6 +176,7 @@ type batch_root_cause =
 
 let batch_root_cause_to_string = function
   | Cascade_unhealthy -> "cascade_unhealthy"
+  | Provider_timeout -> "provider_timeout"
   | Provider_auth -> "provider_auth"
   | Fd_exhaustion -> "fd_exhaustion"
   | Mixed -> "mixed"
@@ -217,10 +219,11 @@ let failure_reason_batch_root_cause
       Some Provider_auth
   | Exception detail when fd_exhaustion_failure detail ->
       Some Fd_exhaustion
+  | Oas_timeout_budget_loop _ ->
+      Some Provider_timeout
   | Stale_turn_timeout _
   | Stale_termination_storm _
   | Stale_fleet_batch _
-  | Oas_timeout_budget_loop _
   | Provider_runtime_error _ ->
       Some Cascade_unhealthy
   | Heartbeat_consecutive_failures _

--- a/test/test_stale_kill_class.ml
+++ b/test/test_stale_kill_class.ml
@@ -75,8 +75,8 @@ let test_failure_reason_to_string_noop () =
           (Noop_failure_loop { noop_count = 4 })))
 
 let test_failure_reason_to_string_oas_timeout_budget_loop () =
-  r "Oas_timeout_budget_loop includes count"
-    "oas_timeout_budget_loop(count=3)"
+  r "legacy timeout-budget loop normalizes to provider timeout"
+    "provider_timeout_loop(count=3)"
     (failure_reason_to_string (Oas_timeout_budget_loop { count = 3 }))
 
 let test_failure_reason_to_string_stale_fleet_batch () =
@@ -154,7 +154,7 @@ let test_cohort_key_collapses_subclasses () =
        (Some (Stale_turn_timeout (Noop_failure_loop { noop_count = 1 }))))
 
 let test_oas_timeout_budget_loop_cohort_key () =
-  r "Oas_timeout_budget_loop cohort_key" "oas_timeout_budget_loop"
+  r "legacy timeout-budget loop cohort_key" "provider_timeout_loop"
     (failure_reason_cohort_key
        (Some (Oas_timeout_budget_loop { count = 3 })))
 
@@ -282,6 +282,8 @@ let root_cause_label reasons =
 let test_batch_root_cause_labels () =
   r "cascade_unhealthy label" "cascade_unhealthy"
     (SW.batch_root_cause_to_string SW.Cascade_unhealthy);
+  r "provider_timeout label" "provider_timeout"
+    (SW.batch_root_cause_to_string SW.Provider_timeout);
   r "provider_auth label" "provider_auth"
     (SW.batch_root_cause_to_string SW.Provider_auth);
   r "fd_exhaustion label" "fd_exhaustion"
@@ -303,7 +305,7 @@ let test_batch_root_cause_fd_exhaustion () =
     (root_cause_label [ Exception "too many open files (os error 24)" ])
 
 let test_batch_root_cause_cascade_unhealthy () =
-  r "cascade unhealthy" "cascade_unhealthy"
+  r "provider timeout" "provider_timeout"
     (root_cause_label [ Oas_timeout_budget_loop { count = 2 } ])
 
 let test_batch_root_cause_mixed () =


### PR DESCRIPTION
## Summary
- normalize legacy `Oas_timeout_budget_loop` failure strings to `provider_timeout_loop`
- group legacy timeout-budget loops under a provider-timeout cohort instead of a timeout-budget cohort
- add a provider-timeout batch root-cause label for stale-watchdog fleet grouping
- update stale-kill tests to stop treating timeout-budget loop as a first-class cohort

## Validation
- Not run; user requested PR iteration without local validation.
