### PR TITLE
fix(keeper): normalize timeout loop status surface

### DIFF
--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -297,8 +297,8 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
     | Oas_timeout_budget ->
       if summary = ""
       then
-        "Legacy OAS timeout-budget blocker; inspect the owner-specific timeout, \
-         admission, or capacity evidence before resume."
+        "Legacy OAS timeout-budget blocker; inspect owner-specific provider, \
+         admission/capacity, or turn-timeout evidence before resume."
       else summary
     | Turn_livelock_blocked ->
       if summary = ""
@@ -457,10 +457,10 @@ let runtime_blocker_surface_of_failure_reason (reason : Keeper_registry.failure_
       (runtime_blocker_surface_of_typed_class
          ~summary:
            (Printf.sprintf
-              "OAS budget timeout repeated %d consecutive cycle(s); keeper was \
+              "Provider timeout repeated %d consecutive cycle(s); keeper was \
                auto-paused before restart loop."
               count)
-         Oas_timeout_budget)
+         Turn_timeout)
   | Keeper_registry.Stale_fleet_batch { distinct_count } ->
     Some
       (runtime_blocker_surface_of_typed_class


### PR DESCRIPTION
## Summary
- project persisted `Oas_timeout_budget_loop` registry reasons as `turn_timeout` runtime blockers
- change the loop summary to provider-timeout ownership instead of OAS timeout-budget ownership
- remove status-bridge special-casing that emitted `timeout_budget_exhausted` / `inspect_timeout_budget`
- keep the legacy `Oas_timeout_budget` blocker summary as compatibility-only guidance

## Validation
- Not run; user requested PR iteration without local validation.
