### PR TITLE
test(memory): stop learning timeout budget kind

### DIFF
--- a/test/test_failure_learnings_10325.ml
+++ b/test/test_failure_learnings_10325.ml
@@ -50,7 +50,7 @@ let extract_failure_learnings ~error_kind ~error_message =
 let test_no_generic_boilerplate () =
   let learnings =
     extract_failure_learnings
-      ~error_kind:"oas_timeout_budget"
+      ~error_kind:"provider_timeout"
       ~error_message:"keeper exceeded budget after 12 turns"
   in
   List.iter
@@ -66,12 +66,12 @@ let test_no_generic_boilerplate () =
 let test_kind_and_message_emitted_as_tags () =
   let learnings =
     extract_failure_learnings
-      ~error_kind:"oas_timeout_budget"
+      ~error_kind:"provider_timeout"
       ~error_message:"keeper exceeded budget after 12 turns"
   in
   let has_kind =
     List.exists
-      (fun s -> s = "failure_kind: oas_timeout_budget")
+      (fun s -> s = "failure_kind: provider_timeout")
       learnings
   in
   let has_message_tag =

--- a/test/test_institution_episodes_failure_learnings_10325.ml
+++ b/test/test_institution_episodes_failure_learnings_10325.ml
@@ -43,13 +43,13 @@ let kind value = M.error_kind_of_string value
 
 let test_learnings_carries_error_kind_first () =
   let learnings =
-    M.failure_learnings ~error_kind:(kind "oas_timeout_budget")
+    M.failure_learnings ~error_kind:(kind "provider_timeout")
       ~error_preview:"Adaptive estimated input tokens exceeded budget"
   in
   check (list string)
     "[failure_kind; error_preview] in order"
     [
-      "failure_kind: oas_timeout_budget";
+      "failure_kind: provider_timeout";
       "error_preview: Adaptive estimated input tokens exceeded budget";
     ]
     learnings


### PR DESCRIPTION
## Summary
- replace failure-learning fixture inputs that used `oas_timeout_budget` as the learned failure kind
- assert `failure_kind: provider_timeout` instead, so institution episodes do not encode timeout-budget as a first-class learned cause

## Validation
- Not run; user requested PR iteration without local validation.
