### PR TITLE
fix(tools): replace internal names with public aliases in LLM-facing strings

### DIFF
--- a/lib/coord/coord_git.ml
+++ b/lib/coord/coord_git.ml
@@ -245,7 +245,7 @@ let create ~base_path ~agent_name ~task_id ~base_branch : string masc_result =
               if exit_code = 0 then
                 Ok
                   (Printf.sprintf
-                     "Worktree created:\n  Path: %s\n  Branch: %s%s\n\nNext: cd %s && work. Use git for branch/commit/push and keeper_shell op=gh for GitHub PR work."
+                     "Worktree created:\n  Path: %s\n  Branch: %s%s\n\nNext: cd %s && work. Use git for branch/commit/push and Grep op=gh for GitHub PR work."
                      worktree_path branch_name note worktree_path)
               else Error (System (System_error.IoError (Printf.sprintf "Failed to create worktree from origin/%s." resolved_base))))
 

--- a/lib/coord/coord_worktree_paths.ml
+++ b/lib/coord/coord_worktree_paths.ml
@@ -174,5 +174,5 @@ let keeper_visible_worktree_path ~config ~agent_name ~host_path =
 let worktree_next_step keeper_path =
   Printf.sprintf
     "Next: Bash cwd=%S command=\"git status -sb\"; after edits, git \
-     add/commit/push. Use keeper_shell op=gh for GitHub PR work."
+     add/commit/push. Use Grep op=gh for GitHub PR work."
     keeper_path

--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -200,7 +200,7 @@ let read_public_schema =
     ; property
         "limit"
         "integer"
-        "Approximate maximum bytes to return (mapped to keeper_fs_read max_bytes; \
+        "Approximate maximum bytes to return (byte-based limit; \
          line-based limit is not supported)."
     ; property
         "offset"

--- a/lib/tool_shard_types_schemas_taskboard.ml
+++ b/lib/tool_shard_types_schemas_taskboard.ml
@@ -276,9 +276,9 @@ let taskboard_tools : Masc_domain.tool_schema list =
                                   ; ( "description"
                                     , `String
                                         "Tool names required to claim this task, e.g. \
-                                         Bash or masc_code_git. PR creation tasks \
+                                         Bash, Grep, or masc_code_git. PR creation tasks \
                                          should include keeper_preflight_check, \
-                                         keeper_bash, and keeper_shell so \
+                                         Bash, and Grep so \
                                          claim_next routes them only to shell/GitHub-capable \
                                          presets. PR review mutation tasks should \
                                          include keeper_preflight_check, \


### PR DESCRIPTION
## Summary
- `coord_git.ml` worktree creation response: `keeper_shell op=gh` → `Grep op=gh`
- `coord_worktree_paths.ml` worktree_next_step: same fix
- `taskboard.ml` required_tools description: `keeper_bash/keeper_shell` → `Bash/Grep` examples
- `keeper_tool_alias.ml` read_public_schema: `keeper_fs_read` removed from dead code description

These are LLM-facing strings (public MCP tool responses and descriptions) where internal tool names leaked through instead of public aliases. Operator LLMs see `Grep` and `Bash` in `tools/list`, not `keeper_shell`/`keeper_bash` — so referencing internal names causes confusion or "tool not found" errors.

`canonical_required_tool_name` already maps public→internal, so the `Bash`/`Grep` examples in required_tools work correctly at runtime.

## Test plan
- [ ] `dune build` passes
- [ ] `test_tool_surface_ssot.ml` regression test passes
- [ ] Manual: `masc_worktree_create` response shows `Grep op=gh` (not `keeper_shell op=gh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)