### PR TITLE
test(logs): use provider timeout structured fixtures

### DIFF
--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -102,17 +102,17 @@ describe('log diagnostics', () => {
         seq: 3,
         level: 'ERROR',
         module: 'Keeper',
-        message: 'keeper_llm_bridge timeout',
+        message: 'keeper provider timeout',
         details: {
           failure_envelope: {
             surface: 'keeper_oas_bridge',
             entity_kind: 'oas_execution',
             entity_id: null,
-            cause_code: 'oas_timeout_budget',
+            cause_code: 'provider_timeout',
             severity: 'bad',
-            summary: 'OAS execution exceeded budget',
+            summary: 'Provider execution timed out',
             recoverability: 'operator_action_required',
-            operator_action: 'inspect_timeout_budget',
+            operator_action: 'inspect_provider_stream',
             evidence_ref: { timeout_sec: 300 },
           },
         },
@@ -135,7 +135,7 @@ describe('log diagnostics', () => {
     expect(summary.errors).toBe(1)
     expect(summary.warnings).toBe(1)
     expect(summary.failureEnvelopes).toBe(1)
-    expect(summary.topCauses).toContainEqual({ cause: 'oas_timeout_budget', count: 1 })
+    expect(summary.topCauses).toContainEqual({ cause: 'provider_timeout', count: 1 })
     expect(summary.topCauses).toHaveLength(1)
     expect(summary.topModules[0]).toEqual({ module: 'Keeper', count: 2 })
   })

--- a/test/test_cap_blocker_structured_error.ml
+++ b/test/test_cap_blocker_structured_error.ml
@@ -3,7 +3,7 @@
    #9933: blocker field must preserve structured masc_oas_error
    JSON payloads. The pre-fix behaviour truncated at 200 chars,
    slicing payloads like
-   "Internal error: [masc_oas_error] {\"kind\":\"oas_timeout_budget\",\
+   "Internal error: [masc_oas_error] {\"kind\":\"provider_timeout\",\
    \"budget_sec\":30.0,...}" mid-key and leaving operators with
    "budget_" as the trailing evidence.
 
@@ -20,7 +20,7 @@
 module T = Masc_mcp.Keeper_social_model_types
 
 let oas_error_payload_small =
-  "[masc_oas_error] {\"kind\":\"oas_timeout_budget\",\
+  "[masc_oas_error] {\"kind\":\"provider_timeout\",\
    \"budget_sec\":30.0,\"keeper_turn_timeout_sec\":120.0,\
    \"estimated_input_tokens\":45000,\"source\":\"tool_list_build\"}"
 
@@ -28,7 +28,7 @@ let wrapped_oas_error_payload_small = "Internal error: " ^ oas_error_payload_sma
 
 let oas_error_payload_huge =
   let buf = Buffer.create 2500 in
-  Buffer.add_string buf "[masc_oas_error] {\"kind\":\"oas_timeout_budget\",\"extra\":\"";
+  Buffer.add_string buf "[masc_oas_error] {\"kind\":\"provider_timeout\",\"extra\":\"";
   for _ = 1 to 2500 do Buffer.add_char buf 'x' done;
   Buffer.add_string buf "\"}";
   Buffer.contents buf


### PR DESCRIPTION
## Summary
- replace dashboard log-summary fixture cause code from `oas_timeout_budget` to `provider_timeout`
- replace the fixture operator action from `inspect_timeout_budget` to provider-stream inspection
- keep cap-blocker structured JSON preservation tests but use provider-timeout payloads instead of timeout-budget payloads

## Validation
- Not run; user requested PR iteration without local validation.
