### PR TITLE
fix(memory): stop timeout budget stress wire

### DIFF
--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -421,7 +421,7 @@ let error_kind_to_string (Error_kind value) = value
 
 let timeout_error_kinds =
   List.map error_kind_of_string
-    [ "oas_timeout_budget"; "turn_timeout"; "admission_queue_timeout" ]
+    [ "provider_timeout"; "turn_timeout"; "admission_queue_timeout" ]
 
 let stress_kind_for_error_kind error_kind =
   let trimmed = String.trim (error_kind_to_string error_kind) in

--- a/lib/memory_oas_bridge.mli
+++ b/lib/memory_oas_bridge.mli
@@ -236,7 +236,9 @@ val timeout_error_kinds : error_kind list
     {!stress_kind_for_error_kind} mapper treats as
     timeout-class.  Pinned because
     [test/test_agent_stress_timeout_wire_10341.ml] asserts
-    its length to keep the catalogue from drifting. *)
+    its length to keep the catalogue from drifting.  Legacy
+    [oas_timeout_budget] is intentionally not listed; callers should
+    emit owner-specific timeout kinds such as [provider_timeout]. *)
 
 val stress_kind_for_error_kind :
   error_kind -> Agent_stress.stress_kind option

--- a/test/test_agent_stress_emit_10341.ml
+++ b/test/test_agent_stress_emit_10341.ml
@@ -50,10 +50,10 @@ let classify value =
   Keeper_agent_memory_episode.stress_kind_of_error_kind
     (Memory_oas_bridge.error_kind_of_string value)
 
-let test_oas_timeout_budget_to_timeout () =
-  check opt_kind "oas_timeout_budget -> Timeout"
+let test_provider_timeout_to_timeout () =
+  check opt_kind "provider_timeout -> Timeout"
     (Some Agent_stress.Timeout)
-    (classify "oas_timeout_budget")
+    (classify "provider_timeout")
 
 let test_turn_timeout_to_timeout () =
   check opt_kind "turn_timeout -> Timeout"
@@ -88,8 +88,8 @@ let () =
   run "agent_stress_emit_10341"
     [
       ("classifier", [
-           test_case "oas_timeout_budget maps to Timeout" `Quick
-             test_oas_timeout_budget_to_timeout;
+           test_case "provider_timeout maps to Timeout" `Quick
+             test_provider_timeout_to_timeout;
            test_case "*_timeout suffix maps to Timeout" `Quick
              test_turn_timeout_to_timeout;
            test_case "completion_contract_violation maps to Parse_degraded"

--- a/test/test_agent_stress_timeout_wire_10341.ml
+++ b/test/test_agent_stress_timeout_wire_10341.ml
@@ -9,7 +9,8 @@
     declared [Timeout] but no caller emitted it.
 
     [Memory_oas_bridge.store_failed_turn_episode] now fans out one
-    [Timeout] stress event when the [error_kind] argument names a
+    [Timeout] stress event when the [error_kind] argument names an
+    owner-specific
     timeout-class failure from the OAS internal-error vocabulary.
     These tests pin the classifier — the IO side
     ([Agent_stress.record] -> JSONL) is exercised by
@@ -25,10 +26,10 @@ let kind_to_string = B.error_kind_to_string
 
 (* --- timeout kinds map to [Some Timeout] ------------------------ *)
 
-let test_oas_timeout_budget_maps () =
-  match B.stress_kind_for_error_kind (kind "oas_timeout_budget") with
+let test_provider_timeout_maps () =
+  match B.stress_kind_for_error_kind (kind "provider_timeout") with
   | Some Masc_mcp.Agent_stress.Timeout -> ()
-  | _ -> failf "oas_timeout_budget should map to Timeout"
+  | _ -> failf "provider_timeout should map to Timeout"
 
 let test_turn_timeout_maps () =
   match B.stress_kind_for_error_kind (kind "turn_timeout") with
@@ -43,7 +44,7 @@ let test_admission_queue_timeout_maps () =
 (* --- whitespace tolerance --------------------------------------- *)
 
 let test_trims_whitespace () =
-  match B.stress_kind_for_error_kind (kind "  oas_timeout_budget  ") with
+  match B.stress_kind_for_error_kind (kind "  provider_timeout  ") with
   | Some Masc_mcp.Agent_stress.Timeout -> ()
   | _ -> failf "trimmed timeout kind should still map to Timeout"
 
@@ -107,7 +108,7 @@ let test_timeout_kinds_list_is_three_items () =
     (List.length B.timeout_error_kinds);
   check (list string) "stable order for log diffs"
     [
-      "oas_timeout_budget";
+      "provider_timeout";
       "turn_timeout";
       "admission_queue_timeout";
     ]
@@ -118,8 +119,8 @@ let () =
     [
       ( "timeout-kinds-mapped",
         [
-          test_case "oas_timeout_budget -> Timeout" `Quick
-            test_oas_timeout_budget_maps;
+          test_case "provider_timeout -> Timeout" `Quick
+            test_provider_timeout_maps;
           test_case "turn_timeout -> Timeout" `Quick
             test_turn_timeout_maps;
           test_case "admission_queue_timeout -> Timeout" `Quick


### PR DESCRIPTION
## Summary
- remove `oas_timeout_budget` from `Memory_oas_bridge.timeout_error_kinds`
- use `provider_timeout` as the owner-specific timeout stress wire fixture
- update agent-stress timeout tests so timeout-budget is no longer the pinned stress wire baseline

## Validation
- Not run; user requested PR iteration without local validation.
