### PR TITLE
fix(test): repair base branch test compile errors

### DIFF
--- a/test/test_exec_shell_command_gate.ml
+++ b/test/test_exec_shell_command_gate.ml
@@ -23,7 +23,7 @@ module W = Masc_mcp.Worker_dev_tools
 let allowed = [ "rg"; "sort"; "head"; "wc"; "cat"; "git"; "ls"; "grep" ]
 
 let allowlist : Gate.allowlist_policy =
-  { allowed_commands = allowed; allow_pipes = true }
+  { redirect_allowed = true; allowed_commands = allowed; allow_pipes = true }
 ;;
 
 (* {1 Baseline corpus} *)
@@ -275,7 +275,7 @@ let test_pipeline_segment_rejection_carries_stage_index () =
 
 let test_pipes_disabled () =
   let policy : Gate.allowlist_policy =
-    { allowed_commands = allowed; allow_pipes = false }
+    { redirect_allowed = true; allowed_commands = allowed; allow_pipes = false }
   in
   match
     Gate.gate

--- a/test/test_keeper_turn_disposition.ml
+++ b/test/test_keeper_turn_disposition.ml
@@ -248,7 +248,7 @@ let test_projection () =
 ;;
 
 let check_cascade_failure_reason raw_error expected_code =
-  let terminal = Legacy.of_legacy_error_text raw_error in
+  let terminal = Legacy.of_code "unknown_error" in
   match Unified_types.registry_failure_reason_of_terminal_reason terminal ~raw_error with
   | Some (Registry.Provider_runtime_error { code; detail }) ->
     Alcotest.(check string) "provider runtime code" expected_code code;

--- a/test/test_keeper_turn_terminal_disposition_field.ml
+++ b/test/test_keeper_turn_terminal_disposition_field.ml
@@ -34,14 +34,14 @@ let constructor_cases : (string * T.t) list =
   ; ( "of_code/sdk_error/agent_error_max_turns"
     , T.of_code "agent_error_max_turns_exceeded:turns=10,limit=10" )
   ; "of_code/unknown", T.of_code "totally_unmapped"
-  ; "of_legacy_error_text/empty", T.of_legacy_error_text ""
-  ; ( "of_legacy_error_text/gh_repo"
-    , T.of_legacy_error_text "gh_repo_context_missing_worktree" )
-  ; "of_legacy_error_text/oas_timeout", T.of_legacy_error_text "oas_timeout_budget"
-  ; ( "of_legacy_error_text/turn_wall_clock"
-    , T.of_legacy_error_text "Turn wall-clock timeout fired" )
-  ; ( "of_legacy_error_text/require_tool_use"
-    , T.of_legacy_error_text "called no keeper tools and require_tool_use was set" )
+  ; "of_code/legacy_empty", T.of_code "unknown_error"
+  ; ( "of_code/gh_repo"
+    , T.of_code "gh_repo_context_missing_worktree" )
+  ; "of_code/oas_timeout", T.of_code "oas_timeout_budget"
+  ; ( "of_code/turn_wall_clock"
+    , T.of_code "turn_wall_clock_timeout" )
+  ; ( "of_code/require_tool_use"
+    , T.of_code "required_tool_use_no_tool_call" )
   ]
 ;;
 


### PR DESCRIPTION
## Summary

Repair three test files broken by recent library changes on origin/main.

### Changes

- **test/test_keeper_turn_disposition.ml**: Replace removed `Keeper_turn_terminal.of_legacy_error_text` with `of_code "unknown_error"`.
- **test/test_keeper_turn_terminal_disposition_field.ml**: Replace all `of_legacy_error_text` cases with `of_code` equivalents (legacy text classifier removed in #17628).
- **test/test_exec_shell_command_gate.ml**: Add missing `redirect_allowed` field to `allowlist_policy` record literals.

### Verification

Local `dune build` of all three test exes passes (exit 0, no compile errors).

### Related

- #17628 removed `of_legacy_error_text` but missed these test updates.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>