### PR TITLE
fix(ci): cover cascade disposition warnings

### DIFF
--- a/lib/keeper/keeper_passive_loop_detector.ml
+++ b/lib/keeper/keeper_passive_loop_detector.ml
@@ -44,6 +44,7 @@ let progress_class_of_disposition (d : Keeper_turn_disposition.t) =
       Some required_tool_unsatisfied_progress_class
   | Success | External_cancel | Turn_wall_clock_timeout | Oas_timeout_budget
   | Gh_repo_context_missing_worktree | Post_commit_ambiguous
+  | Cascade_attempts_exhausted
   | Provider_error _ | Unknown _ ->
       None
 

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -192,6 +192,14 @@ let registry_failure_reason_of_terminal_reason
          ; provider_id = None
          ; http_status = None
          })
+  | Keeper_turn_disposition.Cascade_attempts_exhausted ->
+    Some
+      (Keeper_registry.Provider_runtime_error
+         { code = "cascade_attempts_exhausted"
+         ; detail
+         ; provider_id = None
+         ; http_status = None
+         })
   | Keeper_turn_disposition.Success
   | Keeper_turn_disposition.External_cancel
   | Keeper_turn_disposition.Turn_wall_clock_timeout

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -138,11 +138,12 @@ let test_goal_upsert_and_list () =
     | Some result -> parse_json_result result
     | None -> fail "masc_goal_upsert not handled"
   in
-  let _goal_id =
+  let goal_id =
     match Yojson.Safe.Util.member "goal_id" created_json with
     | `String id when id <> "" -> id
     | _ -> fail "goal_id missing from upsert response"
   in
+  check bool "goal_id populated" true (String.length goal_id > 0);
   let task_link_field =
     match Yojson.Safe.Util.member "task_link_field" created_json with
     | `String field -> field


### PR DESCRIPTION
## Summary
- cover Cascade_attempts_exhausted in keeper disposition matches
- keep goal_id binding live in goal tool test so warning-as-error builds pass

## Verification
- ocamlformat --check lib/keeper/keeper_passive_loop_detector.ml lib/keeper/keeper_unified_turn_types.ml test/test_goal_tools.ml
- git diff --check
- OCAMLPARAM='_,warn-error=+a' DUNE_BUILD_DIR=_build_ci_failures dune build --root . --display=quiet test/test_goal_tools.exe
- OCAMLPARAM='_,warn-error=+a' DUNE_BUILD_DIR=_build_ci_failures dune build --root . --display=quiet @install test/test_goal_tools.exe