### PR TITLE
fix(keeper): apply missed review followups

### DIFF
--- a/lib/keeper/keeper_agent_run_phase5_task_link.ml
+++ b/lib/keeper/keeper_agent_run_phase5_task_link.ml
@@ -2,7 +2,9 @@
 
     Extracted from [Keeper_agent_run.run_turn] Step 8 body (RFC-0147 PR-9). *)
 
-let run ~config ~meta ~acc () =
+let run ~config ~(meta : Keeper_types.keeper_meta)
+      ~(acc : Keeper_run_tools.hook_accumulator) ()
+  =
   match acc.meta.current_task_id with
   | None -> ()
   | Some task_id ->

--- a/lib/keeper/keeper_agent_run_phase5_task_link.mli
+++ b/lib/keeper/keeper_agent_run_phase5_task_link.mli
@@ -2,7 +2,7 @@
     Extracted from [Keeper_agent_run.run_turn] Step 8 body (RFC-0147 PR-9). *)
 
 val run :
-  config:Keeper_types.config ->
+  config:Coord_utils.config ->
   meta:Keeper_types.keeper_meta ->
   acc:Keeper_run_tools.hook_accumulator ->
   unit ->

--- a/lib/keeper/keeper_agent_run_post_turn_memory.mli
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.mli
@@ -9,7 +9,7 @@
     counted, never propagated.  [Eio.Cancel.Cancelled] is re-raised. *)
 
 val run :
-  config:Keeper_types.config ->
+  config:Coord_utils.config ->
   meta:Keeper_types.keeper_meta ->
   memory:Agent_sdk.Memory.t ->
   turn:int ->
@@ -18,7 +18,7 @@ val run :
   actual_tools:string list ->
   state_snapshot:Keeper_memory_policy.keeper_state_snapshot ->
   post_turn_t0:float ->
-  ?provider_filter:string ->
+  ?provider_filter:string list ->
   cascade_name:string ->
   inference_telemetry:Agent_sdk.Types.inference_telemetry option ->
   unit ->

--- a/lib/keeper/keeper_context_core_message_json.ml
+++ b/lib/keeper/keeper_context_core_message_json.ml
@@ -32,6 +32,20 @@ let content_blocks_of_json
       if List.length parsed = List.length blocks then Some parsed else None
   | _ -> None
 
+let legacy_content_blocks_of_json
+    (json : Yojson.Safe.t) : Agent_sdk.Types.content_block list option =
+  let open Yojson.Safe.Util in
+  match json |> member "content" with
+  | `String text -> Some [ Agent_sdk.Types.Text text ]
+  | `List blocks ->
+    let parse_legacy_block = function
+      | `String text -> Some (Agent_sdk.Types.Text text)
+      | block -> Agent_sdk.Api.content_block_of_json block
+    in
+    let parsed = List.filter_map parse_legacy_block blocks in
+    if List.length parsed = List.length blocks then Some parsed else None
+  | _ -> None
+
 let string_field_opt key value =
   match value with
   | Some text -> [ (key, `String text) ]
@@ -68,10 +82,8 @@ let message_to_json (m : Agent_sdk.Types.message) : Yojson.Safe.t =
         | Agent_sdk.Types.User
         | Agent_sdk.Types.Assistant -> None)
   in
-  (* SSOT: structured [content_blocks] only. The previous flat [content]
-     field was a duplicate of [text_of_message m] used by retired
-     checkpoint readers; current readers reconstruct text from
-     [content_blocks] via [text_of_history_jsonl_line] (see below). *)
+  (* SSOT for new writes: structured [content_blocks]. Readers below still
+     accept legacy flat [content] rows when [content_blocks] is absent. *)
   let base =
     [
       ("role", `String (role_to_string m.role));
@@ -97,7 +109,7 @@ let message_of_json (json : Yojson.Safe.t) : Agent_sdk.Types.message =
   let content =
     match content_blocks_of_json json with
     | Some blocks -> blocks
-    | None -> []
+    | None -> Option.value (legacy_content_blocks_of_json json) ~default:[]
   in
   Inference_utils.sanitize_message_utf8
     {
@@ -112,13 +124,14 @@ let message_of_json (json : Yojson.Safe.t) : Agent_sdk.Types.message =
       metadata = [];
     }
 
-(** Extract human-readable text from a single history.jsonl line that was
-    produced by [message_to_json].  Reads structured [content_blocks]
-    (current SSOT). Returns [""] when the canonical shape is absent or
-    unparseable. *)
+(** Extract human-readable text from a single history.jsonl line. Reads
+    structured [content_blocks] first and falls back to legacy [content] rows
+    when the canonical shape is absent. *)
 let text_of_history_jsonl_json (json : Yojson.Safe.t) : string =
-  match content_blocks_of_json json with
-  | Some blocks when blocks <> [] ->
+  let text_of_blocks blocks =
+    if blocks = []
+    then ""
+    else
       let msg : Agent_sdk.Types.message =
         {
           Agent_sdk.Types.role = Agent_sdk.Types.User;
@@ -129,4 +142,10 @@ let text_of_history_jsonl_json (json : Yojson.Safe.t) : string =
         }
       in
       Inference_utils.sanitize_text_utf8 (Agent_sdk.Types.text_of_message msg)
-  | _ -> ""
+  in
+  match content_blocks_of_json json with
+  | Some blocks -> text_of_blocks blocks
+  | None ->
+    (match legacy_content_blocks_of_json json with
+     | Some blocks -> text_of_blocks blocks
+     | None -> "")

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -191,7 +191,7 @@ let handle_keeper_bash_typed
                ~extra:[ "cmd", `String cmd_for_log; "typed", `Bool true; "execution_time_ms", `Int 0 ]
                ())
         else
-          match Keeper_tool_bash_input.to_shell_ir_unvalidated ~mode ~sandbox:dispatch_sandbox input with
+          match Keeper_tool_bash_input.to_shell_ir ~mode ~sandbox:dispatch_sandbox input with
           | Error e ->
             error_json
               ~fields:[ "typed", `Bool true; "cmd", `String cmd_for_log; "cwd", `String cwd ]

--- a/lib/keeper/keeper_stale_watchdog.mli
+++ b/lib/keeper/keeper_stale_watchdog.mli
@@ -12,6 +12,7 @@ val slot_holder_age_for_test :
 
 type batch_root_cause =
   | Cascade_unhealthy
+  | Provider_timeout
   | Provider_auth
   | Fd_exhaustion
   | Mixed

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -204,7 +204,6 @@ let registry_failure_reason_of_terminal_reason
   | Keeper_turn_disposition.External_cancel
   | Keeper_turn_disposition.Turn_wall_clock_timeout
   | Keeper_turn_disposition.Oas_timeout_budget
-  | Keeper_turn_disposition.Cascade_attempts_exhausted
   | Keeper_turn_disposition.Gh_repo_context_missing_worktree
   | Keeper_turn_disposition.Post_commit_ambiguous
   | Keeper_turn_disposition.Unknown _ -> None

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -204,6 +204,7 @@ let registry_failure_reason_of_terminal_reason
   | Keeper_turn_disposition.External_cancel
   | Keeper_turn_disposition.Turn_wall_clock_timeout
   | Keeper_turn_disposition.Oas_timeout_budget
+  | Keeper_turn_disposition.Cascade_attempts_exhausted
   | Keeper_turn_disposition.Gh_repo_context_missing_worktree
   | Keeper_turn_disposition.Post_commit_ambiguous
   | Keeper_turn_disposition.Unknown _ -> None

--- a/test/test_keeper_context_core_dedup.ml
+++ b/test/test_keeper_context_core_dedup.ml
@@ -3,9 +3,9 @@
     Pins the contract for three changes shipped together in this PR:
 
     1. [message_to_json] no longer emits the flat ["content"] field;
-       [content_blocks] is the single source of truth.
-    2. [text_of_history_jsonl_json] reads [content_blocks] as the only
-       history text source.
+       [content_blocks] is the write-side source of truth.
+    2. Readers prefer [content_blocks] and keep a legacy read fallback for
+       older flat ["content"] history/checkpoint rows.
     3. [tool_result_text_of_block] caps json-only results at the existing
        [default_max_checkpoint_tool_result_chars] threshold instead of
        inlining the full [Yojson.Safe.to_string] output. *)
@@ -36,7 +36,7 @@ let test_message_to_json_omits_flat_content () =
         (List.mem_assoc "content_blocks" fields)
   | _ -> Alcotest.fail "expected `Assoc"
 
-(* --- message_of_json: canonical content_blocks only --- *)
+(* --- message_of_json: canonical content_blocks first, legacy content fallback --- *)
 
 let test_message_of_json_new_content_blocks_only () =
   (* New checkpoints have only content_blocks — must load as before. *)
@@ -55,12 +55,14 @@ let test_message_of_json_new_content_blocks_only () =
   | [ T.Text s ] -> Alcotest.(check string) "text" "world" s
   | _ -> Alcotest.fail "expected one Text block"
 
-let test_message_of_json_ignores_flat_content () =
+let test_message_of_json_loads_flat_content_fallback () =
   let flat_content : Yojson.Safe.t =
     `Assoc [ ("role", `String "user"); ("content", `String "flat hi") ]
   in
   let msg = C.message_of_json flat_content in
-  Alcotest.(check int) "no canonical blocks" 0 (List.length msg.content)
+  match msg.content with
+  | [ T.Text text ] -> Alcotest.(check string) "flat content text" "flat hi" text
+  | _ -> Alcotest.fail "expected legacy flat content to load as one Text block"
 
 let test_message_of_json_rejects_unknown_role () =
   let json : Yojson.Safe.t =
@@ -87,7 +89,7 @@ let test_history_jsonl_text_uses_blocks_first () =
   let text = C.text_of_history_jsonl_json new_format in
   Alcotest.(check string) "text from blocks" "structured payload" text
 
-let test_history_jsonl_text_ignores_flat_content () =
+let test_history_jsonl_text_loads_flat_content_fallback () =
   let flat_content : Yojson.Safe.t =
     `Assoc
       [
@@ -96,9 +98,9 @@ let test_history_jsonl_text_ignores_flat_content () =
       ]
   in
   let text = C.text_of_history_jsonl_json flat_content in
-  Alcotest.(check string) "flat content ignored" "" text
+  Alcotest.(check string) "flat content fallback" "flat payload" text
 
-let test_history_jsonl_text_ignores_content_array () =
+let test_history_jsonl_text_loads_legacy_content_array () =
   let source : T.message =
     {
       T.role = T.User;
@@ -117,7 +119,7 @@ let test_history_jsonl_text_ignores_content_array () =
     `Assoc [ ("role", `String "user"); ("content", content_blocks) ]
   in
   let text = C.text_of_history_jsonl_json content_array in
-  Alcotest.(check string) "content array ignored" "" text
+  Alcotest.(check string) "content array fallback" "array history payload" text
 
 let test_history_jsonl_text_empty_when_neither () =
   let empty : Yojson.Safe.t = `Assoc [ ("role", `String "user") ] in
@@ -208,8 +210,8 @@ let () =
         [
           Alcotest.test_case "new content_blocks-only loads" `Quick
             test_message_of_json_new_content_blocks_only;
-          Alcotest.test_case "flat content ignored" `Quick
-            test_message_of_json_ignores_flat_content;
+          Alcotest.test_case "flat content fallback loads" `Quick
+            test_message_of_json_loads_flat_content_fallback;
           Alcotest.test_case "unknown role rejected" `Quick
             test_message_of_json_rejects_unknown_role;
           Alcotest.test_case "round-trip text preserved" `Quick
@@ -219,10 +221,10 @@ let () =
         [
           Alcotest.test_case "blocks first" `Quick
             test_history_jsonl_text_uses_blocks_first;
-          Alcotest.test_case "flat content ignored" `Quick
-            test_history_jsonl_text_ignores_flat_content;
-          Alcotest.test_case "content array ignored" `Quick
-            test_history_jsonl_text_ignores_content_array;
+          Alcotest.test_case "flat content fallback loads" `Quick
+            test_history_jsonl_text_loads_flat_content_fallback;
+          Alcotest.test_case "legacy content array fallback loads" `Quick
+            test_history_jsonl_text_loads_legacy_content_array;
           Alcotest.test_case "empty when neither" `Quick
             test_history_jsonl_text_empty_when_neither;
         ] );

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -648,6 +648,31 @@ let keeper_bash_typed_pipeline_args ~cwd =
       ("timeout_sec", `Float 5.0);
     ]
 
+let keeper_bash_typed_single_stage_pipeline_args ~cwd =
+  `Assoc
+    [
+      ( "pipeline",
+        `List
+          [
+            `Assoc
+              [
+                ("executable", `String "printf");
+                ("argv", `List [ `String "typed" ]);
+              ];
+          ] );
+      ("cwd", `String cwd);
+      ("timeout_sec", `Float 5.0);
+    ]
+
+let keeper_bash_typed_env_wrapper_args ~cwd =
+  `Assoc
+    [
+      ("executable", `String "env");
+      ("argv", `List [ `String "id" ]);
+      ("cwd", `String cwd);
+      ("timeout_sec", `Float 5.0);
+    ]
+
 let check_typed_pipeline_response raw =
   (match parse_bool_field raw "ok" with
    | Some true -> ()
@@ -659,6 +684,40 @@ let check_typed_pipeline_response raw =
     (parse_status_exit_code raw);
   Alcotest.(check bool) "pipeline output propagated" true
     (response_mentions raw "output" "5")
+
+let check_typed_validation_error raw needle =
+  Alcotest.(check (option bool)) "typed command rejected" (Some false)
+    (parse_bool_field raw "ok");
+  Alcotest.(check (option bool)) "typed response" (Some true)
+    (parse_bool_field raw "typed");
+  Alcotest.(check bool) "validation error surfaced" true
+    (response_mentions raw "error" needle)
+
+let test_bash_typed_env_wrapper_target_rejected () =
+  setup ~sandbox:Keeper_types.Local
+  @@ fun ~config ~meta ~playground ->
+  Keeper_exec_shell.handle_keeper_bash
+    ~turn_sandbox_factory:None
+    ~turn_sandbox_factory_git:None
+    ~exec_cache:None
+    ~config
+    ~meta
+    ~args:(keeper_bash_typed_env_wrapper_args ~cwd:playground)
+    ()
+  |> check_typed_validation_error "executable \"id\" not in dev_full allowlist"
+
+let test_bash_typed_single_stage_pipeline_rejected () =
+  setup ~sandbox:Keeper_types.Local
+  @@ fun ~config ~meta ~playground ->
+  Keeper_exec_shell.handle_keeper_bash
+    ~turn_sandbox_factory:None
+    ~turn_sandbox_factory_git:None
+    ~exec_cache:None
+    ~config
+    ~meta
+    ~args:(keeper_bash_typed_single_stage_pipeline_args ~cwd:playground)
+    ()
+  |> check_typed_validation_error "Pipeline.stages requires at least two stages"
 
 let test_bash_typed_pipeline_falls_back_to_local_playground () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "missing:test" @@ fun () ->
@@ -2151,6 +2210,12 @@ let () =
           Alcotest.test_case
             "keeper_bash typed pipeline uses local shell ir dispatch"
             `Quick test_bash_typed_pipeline_uses_local_shell_ir_dispatch;
+          Alcotest.test_case
+            "keeper_bash typed env wrapper target is validated"
+            `Quick test_bash_typed_env_wrapper_target_rejected;
+          Alcotest.test_case
+            "keeper_bash typed single-stage pipeline is rejected"
+            `Quick test_bash_typed_single_stage_pipeline_rejected;
           Alcotest.test_case
             "keeper_bash typed pipeline falls back to local playground"
             `Quick test_bash_typed_pipeline_falls_back_to_local_playground;

--- a/test/test_tool_surface_ssot.ml
+++ b/test/test_tool_surface_ssot.ml
@@ -372,7 +372,7 @@ let test_keeper_internal_descriptions_no_cross_leak () =
     ]
   in
   let internal_schemas =
-    Tool_shard.all_keeper_tool_schemas
+    Config.raw_all_tool_schemas
     |> List.filter (fun (s : Masc_domain.tool_schema) ->
            Tool_catalog.is_on_surface Tool_catalog.Keeper_internal s.name)
   in


### PR DESCRIPTION
## Summary
- restore typed keeper_bash validation before Shell gate dispatch
- include standalone keeper internal schemas in cross-surface leak audit
- keep read compatibility for legacy flat content history/checkpoint rows while writing content_blocks only
- cover the current Cascade_attempts_exhausted disposition in exhaustive keeper matches

## Review threads checked
- jeong-sik/masc-mcp#17634 r3286702680 / r3286702686
- jeong-sik/masc-mcp#17635 r3286689105
- jeong-sik/masc-mcp#17615 r3286156783 / r3286156787
- jeong-sik/masc-mcp#17628 was already handled on current main after rebase

## Verification
- ocamlformat on touched files
- git diff --check
- scripts/dune-local.sh build test/test_keeper_shell_docker_route.exe test/test_keeper_context_core_dedup.exe test/test_tool_surface_ssot.exe: blocked after retry by another active Dune lock holder (terminal-code-timeout-legacy worktree)