### PR TITLE
fix(keeper): use provider timeout observation labels

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop_observations.ml
+++ b/lib/keeper/keeper_heartbeat_loop_observations.ml
@@ -149,7 +149,7 @@ let record_cascade_backpressure_observation ~base_path ~keeper_name ~reason =
 ;;
 
 let oas_timeout_budget_observation_reasons =
-  [ "provider_runtime_error"; "oas_timeout_budget"; "keeper_turn_retry_backoff" ]
+  [ "provider_runtime_error"; "provider_timeout"; "keeper_turn_retry_backoff" ]
 ;;
 
 let record_oas_timeout_budget_observation ~base_path ~keeper_name =

--- a/test/test_keeper_semaphore_wait_counter.ml
+++ b/test/test_keeper_semaphore_wait_counter.ml
@@ -479,7 +479,7 @@ let test_oas_timeout_budget_observation_updates_registry () =
       | Some { Masc_mcp.Keeper_registry.last_skip_observation = Some (_, reasons);
                meta = updated_meta; _ } ->
         Alcotest.(check (list string))
-          "timeout budget stamped for watchdog routing"
+          "provider timeout stamped for watchdog routing"
           Masc_mcp.Keeper_heartbeat_loop.oas_timeout_budget_observation_reasons
           reasons;
         Alcotest.(check bool)

--- a/test/test_keeper_semaphore_wait_counter.ml
+++ b/test/test_keeper_semaphore_wait_counter.ml
@@ -446,10 +446,10 @@ let test_wait_observation_updates_registry_skip_stamp () =
 
 let test_oas_timeout_budget_observation_reason_labels () =
   Alcotest.(check (list string))
-    "timeout budget watchdog reasons"
+    "provider timeout watchdog reasons"
     [
       "provider_runtime_error";
-      "oas_timeout_budget";
+      "provider_timeout";
       "keeper_turn_retry_backoff";
     ]
     Masc_mcp.Keeper_heartbeat_loop.oas_timeout_budget_observation_reasons


### PR DESCRIPTION
## Summary
- remove stale timeout-budget wording from heartbeat skip-observation test assertions
- keep the observed heartbeat reason surface aligned with the provider-owned `provider_timeout` label
- avoid re-teaching `oas_timeout_budget` as a live watchdog routing concept in test output

## Validation
- Not run; user requested PR iteration without local validation.
