### PR TITLE
refactor(keeper): add read_keeper_memory_summary_result helper (RFC-0149 §3.1 PR-2)

### DIFF
--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -106,6 +106,28 @@ let read_file_tail_lines path ~max_bytes ~max_lines : string list =
       ();
     []
 
+(* RFC-0149 §3.1 — typed Result entry point.  Distinguishes "empty
+   memory bank" ([Ok summary] where [summary] holds zero recent rows)
+   from "memory bank read failed" ([Error class]).  Callers that want
+   to render a [Memory_unavailable] signal up the chain should consume
+   this variant instead of the legacy
+   [read_keeper_memory_summary]/[empty-summary] silent fallback. *)
+let read_keeper_memory_summary_result
+    (config : Coord.config)
+    ~(name : string)
+    ~(max_bytes : int)
+    ~(max_lines : int)
+    ~(recent_limit : int) :
+    (keeper_memory_summary, Keeper_memory_recall_exn_class.t) result =
+  match
+    read_file_tail_lines_result
+      (keeper_memory_bank_path config name)
+      ~max_bytes
+      ~max_lines
+  with
+  | Ok lines -> Ok (summarize_memory_bank_lines lines ~recent_limit)
+  | Error exn_class -> Error exn_class
+
 let read_keeper_memory_summary
     (config : Coord.config)
     ~(name : string)

--- a/lib/keeper/keeper_memory_recall.mli
+++ b/lib/keeper/keeper_memory_recall.mli
@@ -37,6 +37,21 @@ val read_file_tail_lines : string -> max_bytes:int -> max_lines:int -> string li
     sunset window; new callers should prefer the Result-returning
     helper. *)
 
+val read_keeper_memory_summary_result :
+  Coord.config ->
+  name:string ->
+  max_bytes:int ->
+  max_lines:int ->
+  recent_limit:int ->
+  (keeper_memory_summary, Keeper_memory_recall_exn_class.t) result
+(** Result-returning variant of {!read_keeper_memory_summary}.  On
+    [Error class] the caller can render a typed [Memory_unavailable]
+    signal up the chain (boot-time alert, operator-visible degraded
+    status) instead of emitting an empty summary that is
+    indistinguishable from a fresh keeper with no recorded memory.
+
+    @since RFC-0149 Phase 1 *)
+
 val read_keeper_memory_summary :
   Coord.config ->
   name:string ->
@@ -44,6 +59,10 @@ val read_keeper_memory_summary :
   max_lines:int ->
   recent_limit:int ->
   keeper_memory_summary
+(** Silent-fallback summary reader: returns an empty summary on any
+    IO failure.  Retained as a facade during the RFC-0149 §3.1 sunset
+    window; new callers should prefer
+    {!read_keeper_memory_summary_result}. *)
 
 val read_memory_horizon_counts :
   Coord.config ->


### PR DESCRIPTION
# refactor(keeper): add read_keeper_memory_summary_result helper (RFC-0149 §3.1 PR-2)

새 helper `read_keeper_memory_summary_result` 를 추가, `read_file_tail_lines_result` 의 typed Error 를 `Memory_unavailable` 경로로 propagate 가능하게 만듦. 6 caller (5 lib + 2 test) 안 건드림.

PR-1 (#17670) 이 머지된 후 origin/main 기반으로 rebase 됨.

## 변경 범위
```
lib/keeper/keeper_memory_recall.ml  | +22
lib/keeper/keeper_memory_recall.mli | +19
```

새 entry point:
```ocaml
val read_keeper_memory_summary_result :
  Coord.config -> name:string -> max_bytes:int -> max_lines:int ->
  recent_limit:int ->
  (keeper_memory_summary, Keeper_memory_recall_exn_class.t) result
```

## 정량 완료 기준
- `dune build --root . lib/keeper/`: pass
- caller 6 unchanged — compat

## 후속
- PR-3a~3f: 6 caller (server_dashboard_http_keeper_api, server_dashboard_http_memory_subsystems, dashboard_http_keeper, keeper_status_detail, keeper_status, 2 test) 개별 migrate
- PR-closeout: legacy facade + read_file_tail_lines silent fallback 본체 삭제

RFC-WAIVED: RFC-0149 §3.1 sunset implementation helper-only addition. lib/keeper SSOT (credential/identity/auth) 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
