### PR TITLE
fix(dashboard): collapse legacy timeout blocker surface

### DIFF
--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -249,9 +249,14 @@ type runtime_blocker_surface =
   ; continue_gate : bool
   }
 
+let runtime_blocker_surface_class = function
+  | Oas_timeout_budget -> Turn_timeout
+  | cls -> cls
+;;
+
 let runtime_blocker_class_label ?(summary = "") cls =
-  match cls with
-  | _ -> blocker_class_to_string cls
+  let _ = summary in
+  blocker_class_to_string (runtime_blocker_surface_class cls)
 
 let is_cascade_exhausted_blocker_class blocker_class =
   String.equal
@@ -271,8 +276,9 @@ let is_completion_contract_blocker_class blocker_class =
 let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
   : runtime_blocker_surface
   =
+  let surface_cls = runtime_blocker_surface_class cls in
   let str = runtime_blocker_class_label ~summary cls in
-  let continue_gate = blocker_class_continue_gate cls in
+  let continue_gate = blocker_class_continue_gate surface_cls in
   let summary =
     match cls with
     | Capacity_backpressure ->
@@ -295,11 +301,8 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
           cascade_exhaustion_summary reason
         | _ -> summary)
     | Oas_timeout_budget ->
-      if summary = ""
-      then
-        "Legacy OAS timeout-budget blocker; inspect owner-specific provider, \
-         admission/capacity, or turn-timeout evidence before resume."
-      else summary
+      "Provider or turn timeout blocked this keeper; inspect provider stream, \
+       cascade pressure, and turn wall-clock evidence before resume."
     | Turn_livelock_blocked ->
       if summary = ""
       then "Keeper turn livelock guard blocked repeated dispatch of the same turn."

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -997,14 +997,14 @@ let test_goal_detail_promotes_newer_runtime_blocker_over_stale_receipt () =
       check string "newer blocker drives operator disposition"
         "alert_exhausted"
         (runtime_trust |> member "operator_disposition" |> to_string);
-      check string "timeout blocker keeps attention reason"
-        "timeout_budget_exhausted"
+      check string "legacy timeout blocker collapses to runtime attention"
+        "runtime_blocked"
         (runtime_trust |> member "attention_reason" |> to_string);
       check string "latest terminal reason comes from blocker"
         "runtime_blocker"
         (terminal_reason |> member "source" |> to_string);
-      check string "latest terminal reason is timeout budget"
-        "oas_timeout_budget"
+      check string "latest terminal reason is normalized turn timeout"
+        "turn_timeout"
         (terminal_reason |> member "code" |> to_string);
       check string "latest causal event follows runtime blocker"
         "runtime_blocker"


### PR DESCRIPTION
## Summary
- normalize legacy `Oas_timeout_budget` runtime blocker surfaces to the canonical `turn_timeout` dashboard blocker class
- stop exposing timeout-budget-specific attention/action semantics from goal-detail runtime trust when the input is a legacy blocker
- keep legacy persisted/typed input decodable, but prevent it from becoming the dashboard-facing primary state

## Validation
- Not run; user requested PR iteration without local validation.
