### PR TITLE
fix(dashboard): canonicalize timeout blocker operational state

### DIFF
--- a/dashboard/src/lib/keeper-operational-state.test.ts
+++ b/dashboard/src/lib/keeper-operational-state.test.ts
@@ -199,6 +199,18 @@ describe('deriveKeeperOperationalState — stuck branch (RFC-0135 §1.1 root)', 
     })
   })
 
+  it('legacy timeout-budget blocker collapses to turn_timeout headline reason', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({ runtime_blocker_class: 'oas_timeout_budget' }),
+      composite: null,
+    })
+    expect(state).toMatchObject({
+      kind: 'stuck',
+      attention: 'clean',
+      reason: 'turn_timeout',
+    })
+  })
+
   it('fiber_alive=false ⇒ stuck reason=fiber_dead even without blocker', () => {
     const composite = makeComposite()
     ;(composite as unknown as { phase_diagnosis: unknown }).phase_diagnosis = {
@@ -221,7 +233,8 @@ describe('deriveKeeperOperationalState — stuck branch (RFC-0135 §1.1 root)', 
         keeper: makeKeeper({ runtime_blocker_class: cls as KeeperRuntimeBlockerClass }),
         composite: null,
       })
-      expect(state.kind === 'stuck' && state.reason === cls).toBe(true)
+      const expectedReason = cls === 'oas_timeout_budget' ? 'turn_timeout' : cls
+      expect(state.kind === 'stuck' && state.reason === expectedReason).toBe(true)
     }
   })
 })
@@ -357,6 +370,27 @@ describe('deriveKeeperOperationalState — priority invariants', () => {
       keeper: makeKeeper({
         phase: 'Running',
         runtime_blocker_class: 'turn_timeout',
+      }),
+      composite: makeComposite({
+        runtime_attention: attention({
+          execution_current: false,
+          stale_execution_receipt: true,
+        }),
+      }),
+    })
+    expect(state).toMatchObject({
+      kind: 'running',
+      attention: 'clean',
+      turnPhase: 'idle',
+      staleBlocker: 'turn_timeout',
+    })
+  })
+
+  it('legacy timeout-budget stale blocker collapses to turn_timeout context', () => {
+    const state = deriveKeeperOperationalState({
+      keeper: makeKeeper({
+        phase: 'Running',
+        runtime_blocker_class: 'oas_timeout_budget',
       }),
       composite: makeComposite({
         runtime_attention: attention({

--- a/dashboard/src/lib/keeper-operational-state.ts
+++ b/dashboard/src/lib/keeper-operational-state.ts
@@ -107,6 +107,13 @@ export interface DeriveInputs {
   readonly composite: KeeperCompositeSnapshot | null
 }
 
+function canonicalRuntimeBlockerClass(
+  blockerClass: KeeperRuntimeBlockerClass | null,
+): KeeperRuntimeBlockerClass | null {
+  if (blockerClass === 'oas_timeout_budget') return 'turn_timeout'
+  return blockerClass
+}
+
 export function deriveKeeperOperationalState(
   { keeper, composite }: DeriveInputs,
 ): KeeperOperationalState {
@@ -121,7 +128,7 @@ export function deriveKeeperOperationalState(
     return { kind: 'offline', ...axes, cause: deriveOfflineCause(keeper) }
   }
 
-  const blockerClass = keeper.runtime_blocker_class ?? null
+  const blockerClass = canonicalRuntimeBlockerClass(keeper.runtime_blocker_class ?? null)
   const attention = composite?.runtime_attention ?? null
   // An explicit stale marker is required to demote a blocker. The absence
   // of `runtime_attention` (older backend, missing composite) leaves the


### PR DESCRIPTION
## Summary
- canonicalize legacy `oas_timeout_budget` runtime blocker classes inside the operational-state SSOT
- return `turn_timeout` for both stuck headline reasons and stale-blocker context
- update operational-state tests so legacy compatibility tokens cannot become primary state again

## Validation
- Not run; user requested PR iteration without local validation.
