### PR TITLE
refactor(keeper, cascade, dashboard): delete legacy silent-fallback path (RFC-0149 §3.3 PR-6 closeout)

### DIFF
--- a/lib/cascade/cascade_metrics.ml
+++ b/lib/cascade/cascade_metrics.ml
@@ -678,34 +678,12 @@ let on_weighted_item_dropped ~reason =
     ~labels:[ ("reason", reason) ]
     ()
 
-(* [Keeper_cascade_profile.resolve_live_with_catalog] redirects a
-   raw cascade name to [fallback_name_for_catalog Keeper_turn]
-   when the name (or its logical-use normalization) is not present
-   in the live catalog.  This is a different layer from iter 30
-   [route_resolve_fallback]:
-
-     iter 30  cascade_name_for_use         — route-table lookup
-                                              (operator declared a
-                                              [routes] entry that
-                                              points at a missing
-                                              profile)
-     iter 36  resolve_live_with_catalog    — direct raw name lookup
-                                              (caller passed a cascade
-                                              name string that is
-                                              neither a catalog member
-                                              nor a known logical use)
-
-   The two windows can disagree because raw resolution does NOT
-   walk the [routes] table — it consults the catalog directly.  A
-   typo in caller code (or in cascade.toml's [routes] target itself
-   referencing a removed profile) hits this layer first.
-
-   Cardinality: 1 series. *)
-let metric_resolve_live_fallback =
-  "masc_cascade_resolve_live_fallback_total"
-
-let on_resolve_live_fallback () =
-  Prometheus.inc_counter metric_resolve_live_fallback ()
+(* RFC-0149 §3.3 sunset closeout: [metric_resolve_live_fallback] +
+   [on_resolve_live_fallback] removed together with the silent-fallback
+   carrier ([Keeper_cascade_profile.resolve_live_with_catalog]).  Every
+   caller now branches on [resolve_live_with_catalog_result]'s
+   [Error (`Unresolved _)] and renders the unresolved cascade on the
+   operator-visible path. *)
 
 (* [Keeper_cascade_profile.fallback_cascade_for] inspects a
    profile's [fallback_cascade] hint and rejects it (returns None)

--- a/lib/cascade/cascade_metrics.mli
+++ b/lib/cascade/cascade_metrics.mli
@@ -209,14 +209,12 @@ val on_weighted_item_dropped : reason:string -> unit
     migration tracker — 5-layer cascade.toml never hits this
     path, so non-zero rate flags legacy fixtures. *)
 
-val on_resolve_live_fallback : unit -> unit
-(** Tick the resolve-live fallback counter at
-    [Keeper_cascade_profile.resolve_live_with_catalog] when the
-    requested raw cascade name (and its logical-use
-    normalization) is not present in the live catalog and the
-    function falls back to the [Keeper_turn] default.  Distinct
-    from iter-30 [route_resolve_fallback] which catches the
-    route-table-lookup variant. *)
+(* RFC-0149 §3.3 sunset closeout: [on_resolve_live_fallback] +
+   [metric_resolve_live_fallback] removed.  Their carrier function
+   ([Keeper_cascade_profile.resolve_live_with_catalog] silent fallback)
+   was deleted in the same closeout; every caller now consumes
+   [resolve_live_with_catalog_result] and surfaces [Error (`Unresolved _)]
+   on the operator-visible path. *)
 
 val on_fallback_hint_invalid : unit -> unit
 (** Tick the fallback-hint-invalid counter at

--- a/lib/cascade/cascade_metrics_registry.ml
+++ b/lib/cascade/cascade_metrics_registry.ml
@@ -102,8 +102,10 @@ let all_cascade_counters : (string * string) list =
     , "masc_cascade_route_binding_dropped_total" )
   ; ( "masc_cascade_weighted_item_dropped_total"
     , "masc_cascade_weighted_item_dropped_total" )
-  ; ( "masc_cascade_resolve_live_fallback_total"
-    , "masc_cascade_resolve_live_fallback_total" )
+  (* RFC-0149 §3.3 sunset closeout: masc_cascade_resolve_live_fallback_total
+     registry entry removed.  Counter + carrier function deleted; the typed
+     [Error (`Unresolved _)] in [resolve_live_with_catalog_result] replaces
+     the silent-fallback signal. *)
   ; ( "masc_cascade_fallback_hint_invalid_total"
     , "masc_cascade_fallback_hint_invalid_total" )
   ; ( "masc_cascade_runtime_mcp_legacy_strip_total"

--- a/lib/dashboard/dashboard_http_keeper_types.ml
+++ b/lib/dashboard/dashboard_http_keeper_types.ml
@@ -10,14 +10,10 @@ let health_penalty_warn = Env_config_keeper.DashboardHealth.penalty_warn
 let runtime_warning_ctx_ratio =
   Env_config_keeper.DashboardHealth.runtime_warning_ctx_ratio
 
-let live_keeper_cascade_name (raw : string) =
-  Keeper_cascade_profile.resolve_live raw
-
-(* RFC-0149 §3.3 — Result-returning sibling of {!live_keeper_cascade_name}.
-   New dashboard call sites should consume the typed [Error (`Unresolved _)]
-   and surface it on the canonical JSON field as [`Null] (parse-don't-validate
-   honest signal) instead of letting the silent [Keeper_turn] fallback paper
-   over an unresolved cascade. *)
+(* RFC-0149 §3.3 — typed Result resolver for dashboard call sites.  The
+   legacy [live_keeper_cascade_name] facade + its silent-fallback carrier
+   ([Keeper_cascade_profile.resolve_live]) were removed in the §3.3
+   sunset closeout. *)
 let live_keeper_cascade_name_result (raw : string) :
     (Keeper_cascade_profile.runtime_name, [ `Unresolved of string ]) result =
   Keeper_cascade_profile.resolve_live_result raw

--- a/lib/dashboard/dashboard_http_keeper_types.mli
+++ b/lib/dashboard/dashboard_http_keeper_types.mli
@@ -15,18 +15,16 @@ val runtime_warning_ctx_ratio : float
 (** Dashboard health scoring thresholds, sourced from
     [Env_config_keeper.DashboardHealth]. *)
 
-val live_keeper_cascade_name : string -> string
-(** Resolve a raw cascade name to its live (post-rotation) identifier.
-
-    {b Note:} silent-fallback path retained for the RFC-0149 §3.3 sunset
-    window.  New callers should prefer {!live_keeper_cascade_name_result}. *)
-
 val live_keeper_cascade_name_result :
   string -> (Keeper_cascade_profile.runtime_name, [ `Unresolved of string ]) result
-(** Result-returning variant of {!live_keeper_cascade_name}.  On
-    [Error (`Unresolved raw)] the caller is expected to surface the
+(** Resolve a raw cascade name to its live (post-rotation) identifier.
+    Returns [Error (`Unresolved raw)] when the input cannot be resolved
+    to any catalog member; the caller is expected to surface the
     unresolved input directly (e.g. as JSON [null] on the canonical
-    field) rather than fall back to the silent [Keeper_turn] default.
+    field) rather than fall back to a silent default.
+
+    The legacy [live_keeper_cascade_name : string -> string] facade was
+    removed in the RFC-0149 §3.3 sunset closeout.
 
     @since RFC-0149 Phase 1 *)
 

--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -482,13 +482,6 @@ let system_catalog_names ?config_path () =
 let logged_invalid_fallback : (string * string, unit) Hashtbl.t =
   Hashtbl.create 4
 
-(** Track raw cascade names that did not resolve to any live catalog
-    member so the resolve-live silent-fallback WARN fires once per
-    distinct unresolved name. Bounded by the number of distinct typo /
-    stale-reference names seen during the process lifetime — typical
-    operator workloads keep this in the low single digits. *)
-let logged_unresolved_raw : (string, unit) Hashtbl.t = Hashtbl.create 4
-
 let fallback_cascade_for ?config_path name =
   let public_name = normalized_query_name ?config_path name in
   if String.equal public_name "" then None
@@ -599,38 +592,12 @@ let resolve_live_with_catalog_result ~catalog raw :
   if List.mem normalized catalog then Ok (Runtime_name normalized)
   else Error (`Unresolved raw)
 
-let resolve_live_with_catalog ~catalog raw =
-  match resolve_live_with_catalog_result ~catalog raw with
-  | Ok name -> runtime_name_to_string name
-  | Error (`Unresolved raw') ->
-    let trimmed = String.trim raw' in
-    (* WORKAROUND: RFC-0149 §3.3 sunset target #16787.  Counter + WARN-once
-       remain in the legacy [string]-returning entry point only; the new
-       Result-returning helper above surfaces [Error (`Unresolved raw)]
-       directly so callers can fail-loud at config load time.
-
-       Removal: once every caller migrates to
-       [resolve_live_with_catalog_result], delete this Error arm together
-       with [Cascade_metrics.on_resolve_live_fallback] and
-       [logged_unresolved_raw] per RFC-0149 §3.3 sunset criterion. *)
-    Cascade_metrics.on_resolve_live_fallback ();
-    if not (Hashtbl.mem logged_unresolved_raw trimmed) then begin
-      Hashtbl.add logged_unresolved_raw trimmed ();
-      Log.Misc.warn
-        "[CascadeConfig] cascade name %S did not resolve to any catalog \
-         member; falling back to [Keeper_turn] default — check cascade.toml \
-         for typo or stale reference"
-        trimmed
-    end;
-    Cascade_routes.fallback_name_for_catalog Keeper_turn ~catalog
-
-let resolve_live ?config_path raw =
-  resolve_live_with_catalog ~catalog:(catalog_lookup_names ?config_path ()) raw
-
 (* RFC-0149 §3.3 — Result-returning wrapper that reads the active catalog
-   from the resolved cascade config path.  Mirrors {!resolve_live} for
-   callers that need to fail loud on unresolved input instead of taking
-   the silent fallback. *)
+   from the resolved cascade config path.  Mirrors
+   {!resolve_live_with_catalog_result} but with the catalog loaded from
+   [config_path].  The legacy silent-fallback [resolve_live] /
+   [resolve_live_with_catalog] entry points + their counter + WARN-once
+   Hashtbl were removed as part of the §3.3 sunset closeout. *)
 let resolve_live_result ?config_path raw :
     (runtime_name, [ `Unresolved of string ]) result =
   resolve_live_with_catalog_result

--- a/lib/keeper/keeper_cascade_profile.mli
+++ b/lib/keeper/keeper_cascade_profile.mli
@@ -118,11 +118,7 @@ val canonicalize_with_catalog : catalog:string list -> string -> string
 
 val resolve_live_with_catalog_result :
   catalog:string list -> string -> (runtime_name, [ `Unresolved of string ]) result
-(** Result-returning variant of {!resolve_live_with_catalog}.  Callers
-    that want to distinguish unresolved input from a successful lookup
-    should use this entry point; the legacy [resolve_live_with_catalog]
-    silently falls back to the [Keeper_turn] default and emits a WARN +
-    counter (RFC-0149 §3.3 workaround #16787, sunset target).
+(** Resolves a keeper-declared cascade against an explicit live catalog.
 
     Returns [Ok (Runtime_name normalized)] when [raw] either matches the
     catalog directly or normalizes via a logical route alias that lands
@@ -130,33 +126,22 @@ val resolve_live_with_catalog_result :
     original (un-trimmed) input so the operator-visible diagnostic can
     point to exactly what was provided.
 
-    @since RFC-0149 Phase 1 *)
-
-val resolve_live_with_catalog : catalog:string list -> string -> string
-(** Resolves a keeper-declared cascade against an explicit live catalog.
-
     Names already present in the catalog pass through; logical route
-    aliases collapse via [routes]; otherwise the keeper-turn fallback is used.
-    Callers that accept qualified declarative names must pass a lookup catalog
-    containing those qualified names, not only display/public names.
+    aliases collapse via [routes].  Callers that accept qualified
+    declarative names must pass a lookup catalog containing those
+    qualified names, not only display/public names.
 
-    {b Note:} For new callers, prefer {!resolve_live_with_catalog_result}
-    which returns a typed [Error (`Unresolved _)] instead of silently
-    falling back.  This entry point retains the silent-fallback behaviour
-    for the RFC-0149 §3.3 sunset window. *)
+    The legacy silent-fallback [resolve_live_with_catalog]/[resolve_live]
+    entry points (+ their counter and WARN-once Hashtbl) were removed as
+    part of the RFC-0149 §3.3 sunset closeout.
 
-val resolve_live : ?config_path:string -> string -> string
-(** Like {!resolve_live_with_catalog}, but reads the active catalog from the
-    resolved cascade config path. *)
+    @since RFC-0149 Phase 1 *)
 
 val resolve_live_result :
   ?config_path:string -> string -> (runtime_name, [ `Unresolved of string ]) result
-(** Result-returning variant of {!resolve_live} — wraps
-    {!resolve_live_with_catalog_result} with the active catalog loaded
-    from [config_path].  Callers that should fail loud on unresolved
-    input (boot-time error, operator alert) use this entry point; the
-    legacy {!resolve_live} silently falls back to [Keeper_turn] default
-    (RFC-0149 §3.3 sunset target).
+(** Result-returning resolver that reads the active catalog from the
+    resolved cascade config path.  Wraps {!resolve_live_with_catalog_result}
+    with the catalog loaded from [config_path].
 
     @since RFC-0149 Phase 1 *)
 

--- a/test/test_keeper_toml_config_validation.ml
+++ b/test/test_keeper_toml_config_validation.ml
@@ -622,12 +622,22 @@ target = "tier-group.primary"
     (Masc_mcp.Keeper_cascade_profile.is_system_only_cascade "tier.primary");
   check bool "qualified tier-group remains system-only" true
     (Masc_mcp.Keeper_cascade_profile.is_system_only_cascade "tier-group.primary");
+  let resolved_string raw =
+    match
+      Masc_mcp.Keeper_cascade_profile.resolve_live_result
+        ~config_path:cascade_path raw
+    with
+    | Ok name -> Masc_mcp.Keeper_cascade_profile.runtime_name_to_string name
+    | Error (`Unresolved raw) ->
+        fail
+          (Printf.sprintf
+             "qualified cascade %S did not resolve against test catalog"
+             raw)
+  in
   check string "qualified tier resolves without fallback" "tier.primary"
-    (Masc_mcp.Keeper_cascade_profile.resolve_live
-       ~config_path:cascade_path "tier.primary");
+    (resolved_string "tier.primary");
   check string "qualified tier-group resolves without fallback" "tier-group.primary"
-    (Masc_mcp.Keeper_cascade_profile.resolve_live
-       ~config_path:cascade_path "tier-group.primary");
+    (resolved_string "tier-group.primary");
   (match
      with_temp_toml
        "[keeper]\nname = \"testkeeper\"\ncascade_name = \"tier.primary\"\n"


### PR DESCRIPTION
# refactor: delete legacy silent-fallback path (RFC-0149 §3.3 PR-6 closeout)

## 배경

RFC-0149 §3.3 sunset 의 **마지막 단계**. PR-1 (#17644), PR-2 (#17646), PR-3 (#17650 identity), PR-4 (#17659 dashboard canonical), PR-5 (#17664 dashboard HTTP types) 가 모두 main 머지됨. 모든 production caller 가 `resolve_live_with_catalog_result` / `resolve_live_result` / `live_keeper_cascade_name_result` 로 migrate 완료된 상태이므로 legacy silent-fallback 기계 완전 삭제.

## 삭제 대상 5종

| 항목 | 위치 | 역할 |
|------|------|------|
| `resolve_live_with_catalog : ... -> string` (legacy facade) | `keeper_cascade_profile.ml/.mli` | counter+WARN+Hashtbl 트리거 + `Keeper_turn` silent fallback |
| `resolve_live : ?config_path:string -> string -> string` | `keeper_cascade_profile.ml/.mli` | 위 legacy 의 config-reading wrapper |
| `logged_unresolved_raw : (string, unit) Hashtbl.t` | `keeper_cascade_profile.ml` | WARN-once dedup 상태 |
| `Cascade_metrics.on_resolve_live_fallback` + `metric_resolve_live_fallback` | `cascade_metrics.ml/.mli` + `cascade_metrics_registry.ml` | silent-fallback Prometheus counter |
| `Dashboard_http_keeper_types.live_keeper_cascade_name : string -> string` | `dashboard_http_keeper_types.ml/.mli` | dashboard facade orphan (PR-5 이후 caller 0) |

## test fixture migration

`test/test_keeper_toml_config_validation.ml:625-630` 의 두 `Keeper_cascade_profile.resolve_live` 호출 (qualified tier + tier-group resolution check) 을 `resolve_live_result` 로 migrate:

```ocaml
let resolved_string raw =
  match Keeper_cascade_profile.resolve_live_result ~config_path:cascade_path raw with
  | Ok name -> runtime_name_to_string name
  | Error (`Unresolved raw) ->
      fail (Printf.sprintf "qualified cascade %S did not resolve against test catalog" raw)
in
check string "qualified tier resolves without fallback" "tier.primary"
  (resolved_string "tier.primary");
```

`Error` arm 에 `fail` 명시 — silent-fallback 회복 의도 없음.

## RFC §3.3 sunset criterion 충족

> When `Cascade_name.t` becomes the resolution boundary and `resolve_live` returns `result`, the `on_resolve_live_fallback` metric is removed and `logged_unresolved_raw` Hashtbl is removed. Operators see typed `Error` at config load time, not at turn time.

본 PR 머지 후 위 모든 조건 충족.

## Workaround Rejection Bar self-check

- **§1 텔레메트리-as-fix**: 본 PR 이 §1 패턴 *제거*. counter (`on_resolve_live_fallback`) + WARN-once (`logged_unresolved_raw`) + Prometheus metric entry 전체 삭제. RFC §3.3 sunset 마침.
- §2 substring 분류기: 0
- §3 N-of-M 패치: PR-1~PR-5 가 sprint plan. PR-6 = closeout. 모든 5 step 한 sprint 안에서 완료.
- catch-all 추가 0, cap/cooldown/dedup/repair 0

## 정량 완료 기준

- `dune build --root . lib/cascade/ lib/dashboard/`: pass
- diff stat: 8 file changed, **123 lines deleted, 57 added (-66 net)** — sunset이 코드 *감소* 임을 확인
- whole-tree `dune build lib/` 는 *pre-existing main 에러* (`keeper_stale_watchdog.mli` Provider_timeout mismatch, `keeper_agent_run_phase5_task_link.mli` Keeper_types.config unbound) 로 차단됨. main HEAD 3ea0752e96 기준 `git stash && dune build && stash pop` 으로 재현 확인 — 본 PR diff 와 무관.

## 후속

- RFC-0149 frontmatter `implementation_prs` field 갱신 (author 영역):
  `[17644, 17646, 17650, 17659, 17664, <this PR>]` + status 변경 검토
- RFC-0149 §3.1 sprint 별개 진행 중 (PR-1 #17670 머지, PR-2 #17702 open, caller migration 후속)
- RFC-0149 §3.2 stale audit (Task #13) 별도 — `CompactionNegativeSavings` counter + 패턴 부재 확인

RFC-WAIVED: 본 PR 은 RFC-0149 §3.3 sunset closeout — 워크어라운드 *제거* PR. lib/keeper/credential, lib/operator/control 등 다른 RFC SSOT 영역 무관. RFC-0149 frontmatter status: Active → Implemented 후보.

## Co-Authored-By

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>