### PR TITLE
fix(keeper): normalize timeout budget policy reasons

### DIFF
--- a/lib/keeper/keeper_failure_policy.ml
+++ b/lib/keeper/keeper_failure_policy.ml
@@ -256,7 +256,7 @@ let liveness_is_lost = function
   | Recent_heartbeat | In_turn_progress | Unknown_liveness -> false
 ;;
 
-let oas_budget_loop_effect ~phase ~strikes ~liveness =
+let provider_timeout_policy_effect ~phase ~strikes ~liveness =
   match phase, strikes with
   | _, Some n when n >= 3 && liveness_is_lost liveness ->
     ( Pause_keeper
@@ -266,7 +266,7 @@ let oas_budget_loop_effect ~phase ~strikes ~liveness =
   | _, Some n when n >= 3 ->
     Pause_current_work, Provider_cooldown, Reroute_or_tune_provider, "provider_timeout_loop"
   | Some Capacity_backpressure, _ ->
-    Soft_fail_turn, Provider_cooldown, Reroute_or_tune_provider, "provider_timeout:capacity_backpressure"
+    Soft_fail_turn, Provider_cooldown, Reroute_or_tune_provider, "provider_timeout"
   | _ -> Soft_fail_turn, Provider_cooldown, Inspect_provider_stream, "provider_timeout"
 ;;
 
@@ -319,7 +319,7 @@ let decide = function
       ~reason
   | Oas_timeout_budget { phase; strikes; liveness } ->
     let lifecycle_effect, circuit_effect, operator_action, reason =
-      oas_budget_loop_effect ~phase ~strikes ~liveness
+      provider_timeout_policy_effect ~phase ~strikes ~liveness
     in
     let reason =
       match phase with

--- a/lib/keeper/keeper_failure_policy.mli
+++ b/lib/keeper/keeper_failure_policy.mli
@@ -53,6 +53,9 @@ type failure =
       { phase : timeout_phase option
       ; liveness : liveness_evidence
       }
+  (** Legacy OAS timeout-budget ingress. Decisions normalize this to
+      provider-timeout or keeper-liveness ownership; callers must not
+      project it back as a distinct operator-facing root cause. *)
   | Oas_timeout_budget of
       { phase : timeout_phase option
       ; strikes : int option

--- a/test/test_keeper_failure_policy.ml
+++ b/test/test_keeper_failure_policy.ml
@@ -97,7 +97,7 @@ let test_provider_capacity_backpressure_reroutes_provider () =
   check string "reason" "provider_timeout:capacity_backpressure" decision.reason
 ;;
 
-let test_oas_capacity_backpressure_reroutes_before_loop_threshold () =
+let test_legacy_timeout_budget_capacity_backpressure_reroutes_provider () =
   let decision =
     Policy.decide
       (Policy.Oas_timeout_budget
@@ -111,7 +111,7 @@ let test_oas_capacity_backpressure_reroutes_before_loop_threshold () =
   check_lifecycle "lifecycle" "soft_fail_turn" decision.lifecycle_effect;
   check_circuit "circuit" "provider_cooldown" decision.circuit_effect;
   check_action "action" "reroute_or_tune_provider" decision.operator_action;
-  check string "reason" "oas_timeout_budget:capacity_backpressure" decision.reason
+  check string "reason" "provider_timeout:capacity_backpressure" decision.reason
 ;;
 
 let test_oas_budget_loop_with_live_keeper_pauses_work_not_keeper () =
@@ -204,8 +204,8 @@ let () =
             test_provider_streaming_thinking_timeout_does_not_kill_keeper;
           test_case "provider capacity backpressure reroutes provider" `Quick
             test_provider_capacity_backpressure_reroutes_provider;
-          test_case "OAS capacity backpressure reroutes before loop threshold" `Quick
-            test_oas_capacity_backpressure_reroutes_before_loop_threshold;
+          test_case "legacy timeout-budget capacity backpressure reroutes provider" `Quick
+            test_legacy_timeout_budget_capacity_backpressure_reroutes_provider;
           test_case "live OAS budget loop pauses work, not keeper" `Quick
             test_oas_budget_loop_with_live_keeper_pauses_work_not_keeper;
           test_case "lost-liveness OAS budget loop pauses keeper without death" `Quick

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -104,7 +104,7 @@ let test_strike_limit_routes_through_policy_without_keeper_death () =
       (KFP.circuit_effect_to_label decision.circuit_effect);
     Alcotest.(check string)
       "reason preserves streaming thinking"
-      "oas_timeout_budget_loop:stream_idle:streaming_thinking"
+      "provider_timeout_loop:stream_idle:streaming_thinking"
       decision.reason
 
 let test_capacity_phase_routes_to_provider_tuning () =
@@ -127,7 +127,7 @@ let test_capacity_phase_routes_to_provider_tuning () =
       (KFP.operator_action_to_label decision.operator_action);
     Alcotest.(check string)
       "reason preserves capacity phase"
-      "oas_timeout_budget:capacity_backpressure"
+      "provider_timeout:capacity_backpressure"
       decision.reason
 
 let test_concurrent_bumps_do_not_lose_updates () =


### PR DESCRIPTION
## Summary
- keep `Oas_timeout_budget` as legacy failure-policy ingress only
- normalize timeout-budget policy decisions to `provider_timeout` / `provider_timeout_loop` reason families
- update strike/failure-policy expectations so policy no longer teaches timeout-budget as an operator-facing root cause

## Validation
- Not run; user requested PR iteration without local validation.
