### PR TITLE
test(keeper): migrate test_keeper_memory summary callers to _result (RFC-0149 §3.1 PR-3)

### DIFF
--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -539,10 +539,20 @@ let test_memory_write_then_recall_with_state_block () =
     check bool "at least one note written" true (notes_written > 0);
     check bool "goal kind present" true (List.mem "goal" kinds);
 
-    (* Verify recall reads back what was written *)
+    (* Verify recall reads back what was written.  RFC-0149 §3.1 migration:
+       route through the Result-returning entry point and fail the test on
+       [Error _] so an IO fault cannot masquerade as an empty summary. *)
     let summary =
-      Keeper_memory_recall.read_keeper_memory_summary config
-        ~name:"e2e-keeper" ~max_bytes:100000 ~max_lines:100 ~recent_limit:10
+      match
+        Keeper_memory_recall.read_keeper_memory_summary_result config
+          ~name:"e2e-keeper" ~max_bytes:100000 ~max_lines:100 ~recent_limit:10
+      with
+      | Ok s -> s
+      | Error exn_class ->
+          fail
+            (Printf.sprintf
+               "memory bank read failed: %s"
+               (Keeper_memory_recall_exn_class.to_label exn_class))
     in
     check bool "recall finds notes" true (summary.total_notes > 0);
     check bool "recall has goal kind" true
@@ -567,10 +577,19 @@ let test_memory_write_then_recall_meta_fallback () =
     check bool "fallback wrote notes" true (notes_written > 0);
     check bool "fallback wrote goal kind" true (List.mem "goal" kinds);
 
-    (* Recall should find the note *)
+    (* Recall should find the note.  RFC-0149 §3.1 migration: same
+       Result-pattern as above. *)
     let summary =
-      Keeper_memory_recall.read_keeper_memory_summary config
-        ~name:"fallback-keeper" ~max_bytes:100000 ~max_lines:100 ~recent_limit:10
+      match
+        Keeper_memory_recall.read_keeper_memory_summary_result config
+          ~name:"fallback-keeper" ~max_bytes:100000 ~max_lines:100 ~recent_limit:10
+      with
+      | Ok s -> s
+      | Error exn_class ->
+          fail
+            (Printf.sprintf
+               "memory bank read failed: %s"
+               (Keeper_memory_recall_exn_class.to_label exn_class))
     in
     check bool "recall finds fallback notes" true (summary.total_notes > 0))
 


### PR DESCRIPTION
# test(keeper): migrate test_keeper_memory summary callers to _result (RFC-0149 §3.1 PR-3)

## 배경

PR-2 (#17702 머지됨) 의 `read_keeper_memory_summary_result` 를 첫 caller migration 으로 적용. test fixture 가 가장 isolated 한 시작점 — production code 손대지 않고 typed boundary 가 *적용 가능한지* 검증 + spec 정합 확인.

## 변경 범위

```
test/test_keeper_memory.ml | +25 -6
```

2 call site:
- L544 (`e2e_memory_pipeline → write with [STATE]`)
- L572 (`e2e_memory_pipeline → meta fallback`)

각 site 모두 동일 패턴:

```ocaml
let summary =
  match
    Keeper_memory_recall.read_keeper_memory_summary_result config
      ~name:... ~max_bytes:... ~max_lines:... ~recent_limit:...
  with
  | Ok s -> s
  | Error exn_class ->
      fail (Printf.sprintf "memory bank read failed: %s"
              (Keeper_memory_recall_exn_class.to_label exn_class))
in
```

## RFC §3.1 spec 일치

> branch on [Ok] (compute summary) vs. [Error] (return typed [Memory_unavailable] variant up the chain instead of empty summary).

test context 에서 *Memory_unavailable propagation* 의 등가물 = `Alcotest.fail` — 테스트 명시적 실패. silent empty-summary 회복 의도 없음.

## Workaround Rejection Bar self-check

- §1 텔레메트리-as-fix: 0 counter, 0 WARN
- §2 substring 분류기: 0
- §3 N-of-M 패치: 5 lib caller migration 은 후속 PR (각 prod surface 의 Error 처리가 컨텍스트 별로 다르므로 wholesale uniform 불가)
- catch-all 0, cap/cooldown 0

## 정량 완료 기준

- whole-tree `dune build test/test_keeper_memory.exe` 는 *pre-existing main 에러* (`keeper_stale_watchdog.mli` Provider_timeout mismatch, `keeper_agent_run_post_turn_memory.mli` Keeper_types.config unbound) 로 차단됨. origin/main 2a7202551f 기준 reproduce 됨 — 본 diff 무관.
- 본 PR diff 자체는 typed pattern match 만 추가 — caller compat preserved.

## 후속

- PR-4: `keeper_status.ml:90` migration (단일 read_keeper_memory_summary call → `Error` 시 memory_recent_note = None 또는 explicit signal)
- PR-5: `keeper_status_detail.ml:375` migration
- PR-6/7/8: `dashboard_http_keeper.ml:221`, `server_dashboard_http_keeper_api.ml:1208`, `server_dashboard_http_memory_subsystems.ml:35`
- PR-closeout: legacy `read_keeper_memory_summary` + `read_file_tail_lines` (silent fallback) + counter+WARN 삭제 (RFC §3.1 sunset criterion)

RFC-WAIVED: 본 PR 은 test fixture 변경만 — production code 0 변경. RFC-0149 §3.1 sunset implementation 의 첫 caller migration. lib/keeper subsystem 의 다른 RFC SSOT 영역 무관.

## Co-Authored-By

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>