### PR TITLE
fix(keeper): collapse timeout budget terminal reason

### DIFF
--- a/lib/keeper/keeper_turn_terminal.ml
+++ b/lib/keeper/keeper_turn_terminal.ml
@@ -77,7 +77,9 @@ let of_failure ?(post_commit_ambiguous = false) ?(tool_call_count = 0) ~raw_erro
   else (
     match Keeper_turn_driver.classify_masc_internal_error err with
     | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
-      make ~source:"typed_error" "oas_timeout_budget"
+      of_disposition
+        ~source:"typed_error"
+        Keeper_turn_disposition.Turn_wall_clock_timeout
     | Some (Keeper_turn_driver.Capacity_backpressure _) ->
       make ~source:"typed_error" "capacity_backpressure"
     | Some (Keeper_turn_driver.Cascade_exhausted _) ->

--- a/test/test_keeper_terminal_reason.ml
+++ b/test/test_keeper_terminal_reason.ml
@@ -451,7 +451,7 @@ let test_structured_required_tool_no_tool_call () =
     (terminal_next_action terminal)
 ;;
 
-let test_structured_oas_timeout_budget () =
+let test_structured_oas_timeout_budget_collapses_to_turn_timeout () =
   let err =
     Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
       (Masc_mcp.Keeper_turn_driver.Oas_timeout_budget
@@ -465,12 +465,12 @@ let test_structured_oas_timeout_budget () =
          })
   in
   let terminal = KT.of_failure ~raw_error:(Agent_sdk.Error.to_string err) err in
-  check string "code" "oas_timeout_budget" (terminal_code terminal);
+  check string "code" "turn_wall_clock_timeout" (terminal_code terminal);
   check string "severity" "warn" (KT.severity_to_string (terminal_severity terminal));
   check
     (option string)
     "next action"
-    (Some "inspect_timeout_budget")
+    (Some "inspect_turn_timeout")
     (terminal_next_action terminal)
 ;;
 
@@ -722,7 +722,10 @@ let () =
             "required tool no tool call"
             `Quick
             test_structured_required_tool_no_tool_call
-        ; test_case "oas timeout budget" `Quick test_structured_oas_timeout_budget
+        ; test_case
+            "legacy OAS timeout budget collapses to turn timeout"
+            `Quick
+            test_structured_oas_timeout_budget_collapses_to_turn_timeout
         ; test_case
             "max_tokens ceiling violation"
             `Quick


### PR DESCRIPTION
## Summary
- stop producing `oas_timeout_budget` terminal reason codes from typed keeper failures
- map legacy `Oas_timeout_budget` typed errors to the canonical `turn_wall_clock_timeout` terminal disposition
- update structured terminal-reason tests so timeout-budget remains ingress-only, not a receipt/action code

## Validation
- Not run; user requested PR iteration without local validation.
