### PR TITLE
fix(keeper): collapse timeout budget turn disposition

### DIFF
--- a/lib/keeper/keeper_turn_disposition.ml
+++ b/lib/keeper/keeper_turn_disposition.ml
@@ -44,9 +44,8 @@ let severity = function
 let summary = function
   | Success -> "turn completed"
   | External_cancel -> "keeper turn was cancelled before completion"
-  | Turn_wall_clock_timeout -> "keeper turn hit the wall-clock timeout"
-  | Oas_timeout_budget ->
-    "OAS call was skipped or failed because the turn timeout budget was exhausted"
+  | Turn_wall_clock_timeout | Oas_timeout_budget ->
+    "keeper turn hit the wall-clock timeout"
   | Cascade_attempts_exhausted ->
     "cascade attempts exhausted; inspect per-attempt root causes"
   | Gh_repo_context_missing_worktree ->
@@ -81,7 +80,7 @@ let to_wire = function
   | Success -> "success"
   | External_cancel -> "external_cancel"
   | Turn_wall_clock_timeout -> "turn_wall_clock_timeout"
-  | Oas_timeout_budget -> "oas_timeout_budget"
+  | Oas_timeout_budget -> "turn_wall_clock_timeout"
   | Cascade_attempts_exhausted -> "cascade_attempts_exhausted"
   | Gh_repo_context_missing_worktree -> "gh_repo_context_missing_worktree"
   | Required_tool_use_no_tool_call -> "required_tool_use_no_tool_call"
@@ -109,7 +108,7 @@ let of_termination_code (c : Code.t) : t =
   | Code.Stale_turn_timeout_in_turn
   | Code.Stale_turn_timeout_no_progress
   | Code.Stale_turn_timeout_noop -> Turn_wall_clock_timeout
-  | Code.Oas_timeout_budget -> Oas_timeout_budget
+  | Code.Oas_timeout_budget -> Turn_wall_clock_timeout
   | Code.Tool_required_unsatisfied _ -> Required_tool_use_unsatisfied
   | Code.Ambiguous_partial_commit_post_commit_timeout
   | Code.Ambiguous_partial_commit_post_commit_failure -> Post_commit_ambiguous
@@ -127,7 +126,7 @@ let of_wire = function
   | "success" -> Success
   | "external_cancel" -> External_cancel
   | "turn_wall_clock_timeout" -> Turn_wall_clock_timeout
-  | "oas_timeout_budget" -> Oas_timeout_budget
+  | "oas_timeout_budget" -> Turn_wall_clock_timeout
   | "cascade_attempts_exhausted" -> Cascade_attempts_exhausted
   | "gh_repo_context_missing_worktree" -> Gh_repo_context_missing_worktree
   | "required_tool_use_no_tool_call" -> Required_tool_use_no_tool_call
@@ -145,6 +144,8 @@ let equal a b =
   | Success, Success
   | External_cancel, External_cancel
   | Turn_wall_clock_timeout, Turn_wall_clock_timeout
+  | Turn_wall_clock_timeout, Oas_timeout_budget
+  | Oas_timeout_budget, Turn_wall_clock_timeout
   | Oas_timeout_budget, Oas_timeout_budget
   | Cascade_attempts_exhausted, Cascade_attempts_exhausted
   | Gh_repo_context_missing_worktree, Gh_repo_context_missing_worktree

--- a/lib/keeper/keeper_turn_disposition.mli
+++ b/lib/keeper/keeper_turn_disposition.mli
@@ -97,7 +97,7 @@ val next_action : t -> string option
     - [Success] → ["success"]
     - [External_cancel] → ["external_cancel"]
     - [Turn_wall_clock_timeout] → ["turn_wall_clock_timeout"]
-    - [Oas_timeout_budget] → ["oas_timeout_budget"]
+    - [Oas_timeout_budget] → ["turn_wall_clock_timeout"] (legacy alias)
     - [Cascade_attempts_exhausted] → ["cascade_attempts_exhausted"]
     - [Gh_repo_context_missing_worktree] → ["gh_repo_context_missing_worktree"]
     - [Required_tool_use_no_tool_call] → ["required_tool_use_no_tool_call"]

--- a/test/test_keeper_turn_disposition.ml
+++ b/test/test_keeper_turn_disposition.ml
@@ -37,7 +37,7 @@ let canonical_app_codes : (string * D.t) list =
   [ "success", D.Success
   ; "external_cancel", D.External_cancel
   ; "turn_wall_clock_timeout", D.Turn_wall_clock_timeout
-  ; "oas_timeout_budget", D.Oas_timeout_budget
+  ; "oas_timeout_budget", D.Turn_wall_clock_timeout
   ; "gh_repo_context_missing_worktree", D.Gh_repo_context_missing_worktree
   ; "required_tool_use_no_tool_call", D.Required_tool_use_no_tool_call
   ; "required_tool_use_unsatisfied", D.Required_tool_use_unsatisfied
@@ -148,7 +148,7 @@ let round_trippable : (string * D.t) list =
   [ "Success", D.Success
   ; "External_cancel", D.External_cancel
   ; "Turn_wall_clock_timeout", D.Turn_wall_clock_timeout
-  ; "Oas_timeout_budget", D.Oas_timeout_budget
+  ; "Oas_timeout_budget legacy alias", D.Oas_timeout_budget
   ; "Gh_repo_context_missing_worktree", D.Gh_repo_context_missing_worktree
   ; "Required_tool_use_no_tool_call", D.Required_tool_use_no_tool_call
   ; "Required_tool_use_unsatisfied", D.Required_tool_use_unsatisfied
@@ -216,7 +216,7 @@ let runtime_codes_to_projection : (string * Code.t * D.t) list =
     , Code.Stale_turn_timeout_no_progress
     , D.Turn_wall_clock_timeout )
   ; "Stale_turn_timeout/noop", Code.Stale_turn_timeout_noop, D.Turn_wall_clock_timeout
-  ; "Oas_timeout_budget", Code.Oas_timeout_budget, D.Oas_timeout_budget
+  ; "Oas_timeout_budget", Code.Oas_timeout_budget, D.Turn_wall_clock_timeout
   ; ( "Tool_required_unsatisfied"
     , Code.Tool_required_unsatisfied "x"
     , D.Required_tool_use_unsatisfied )


### PR DESCRIPTION
## Summary
- treat `Oas_timeout_budget` turn disposition as a legacy alias for `Turn_wall_clock_timeout`
- stop `to_wire` / `of_wire` / terminal-code projection from producing fresh `oas_timeout_budget` disposition wires
- update disposition invariants so legacy timeout-budget inputs collapse to the canonical turn-timeout disposition

## Validation
- Not run; user requested PR iteration without local validation.
