### PR TITLE
refactor(keeper): migrate keeper_status memory_recent_note to _result (RFC-0149 §3.1 PR-4)

### DIFF
--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -86,19 +86,29 @@ let handle_keeper_list ctx args : tool_result =
             in
             find_latest (List.rev metrics_window_lines)
           in
-          let memory_bank_summary =
-              read_keeper_memory_summary
+          (* RFC-0149 §3.1 — route through the Result-returning resolver
+             so a memory-bank IO fault surfaces on the operator-visible
+             [memory_recent_note] field as a typed unavailable marker
+             instead of being indistinguishable from "no recorded notes".
+             [None] stays reserved for "Ok summary with empty recent_notes". *)
+          let memory_recent_note =
+            match
+              read_keeper_memory_summary_result
                 ctx.config
                 ~name:m.name
                 ~max_bytes:120000
                 ~max_lines:180
                 ~recent_limit:3
-            in
-            let memory_recent_note =
-              match memory_bank_summary.recent_notes with
-              | row :: _ -> Some row.text
-              | [] -> None
-            in
+            with
+            | Ok summary ->
+              (match summary.recent_notes with
+               | row :: _ -> Some row.text
+               | [] -> None)
+            | Error exn_class ->
+              Some
+                (Printf.sprintf "[memory unavailable: %s]"
+                   (Keeper_memory_recall_exn_class.to_label exn_class))
+          in
             let continuity_reflection_hold_s =
               let cooldown = Float.of_int m.compaction.cooldown_sec in
               let last_reflection_ts =


### PR DESCRIPTION
# refactor(keeper): migrate keeper_status memory_recent_note to _result (RFC-0149 §3.1 PR-4)

PR-2 (#17702) 의 `read_keeper_memory_summary_result` 첫 prod caller migration. operator-visible `memory_recent_note` 가 silent empty-summary 회피 + typed unavailable signal surface.

## 변경 범위

```
lib/keeper/keeper_status.ml | +18 -8
```

## Before / After

| 상태 | Before | After |
|------|--------|-------|
| Ok + non-empty | `Some row.text` | `Some row.text` (unchanged) |
| Ok + empty | `None` | `None` (unchanged) |
| Error (IO fault) | `None` (silent — operator 못 봄) | `Some "[memory unavailable: <class>]"` |

Error label 은 `Keeper_memory_recall_exn_class.to_label` 의 bounded 4-value sum (`yojson_parse_error` / `io_error` / `type_error` / `other`) — cardinality 폭증 회피.

## Workaround Rejection Bar self-check

- §1 텔레메트리-as-fix: silent fallback *제거*. counter 추가 0.
- §2 substring 분류기: 0
- §3 N-of-M 패치: 1 caller per PR — 각 prod surface의 Error rendering이 컨텍스트별로 다르므로 wholesale 불가.
- catch-all 0

## 정량 완료 기준

- `dune build --root . lib/keeper/`: pass
- 함수 외부 시그니처 (handle_keeper_list 등) 변경 0 — UI consumer compat

## 후속

- PR-5: `keeper_status_detail.ml:375`
- PR-6: `dashboard_http_keeper.ml:221`
- PR-7/8: `server_dashboard_http_keeper_api.ml:1208`, `server_dashboard_http_memory_subsystems.ml:35`
- PR-9: `read_file_tail_lines` 다른 5 lib caller (`tool_keeper`, `dashboard_http_keeper_feeds`, `operator_control_context_snapshot`, `dashboard_keeper_decision_log_proof`, `fs_compat/fs_compat`)
- PR-closeout: legacy `read_keeper_memory_summary` + `read_file_tail_lines` (silent fallback 본체) 삭제

RFC-WAIVED: RFC-0149 §3.1 sunset implementation 첫 prod caller migration. lib/keeper subsystem 의 다른 RFC SSOT (credential/identity/auth) 영역 무관.

## Co-Authored-By

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>