### PR TITLE
fix(keeper): rename timeout budget metrics to provider timeout

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop_cycle_with_slot.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle_with_slot.ml
@@ -16,7 +16,7 @@
     - Legacy timeout-budget errors → provider-timeout strike-counter bump (seeded from
       [prior_oas_timeout_budget_strikes]) + persistent failure
       reason + observation recording + [Keeper_failure_policy.decide]
-      kill/keep decision + [metric_keeper_oas_timeout_budget_strike]
+      kill/keep decision + [metric_keeper_provider_timeout_strike]
       tick with policy-derived outcome label.
 
     - Any other [Error err] → DEBUG log + re-read meta (with

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -125,7 +125,7 @@ type t =
   | PresenceSyncFailures
   | SelfPreservationUniversal
   | StaleStormPaused
-  | OasTimeoutBudgetLoopPaused
+  | ProviderTimeoutLoopPaused
   | CycleExceptions
   | SnapshotWriteFailures
   | ProgressUpdatedLineFailures
@@ -185,10 +185,10 @@ type t =
   | RequiredToolGateSuppressedTotal
   | ConsecutiveIdle
   | LastProductiveTs
-  | OasTimeoutBudgetStrike
+  | ProviderTimeoutStrike
   | StaleTerminationTotal
   | StaleTerminationByClass
-  | OasTimeoutBudgetWatchdogTermination
+  | ProviderTimeoutWatchdogTermination
   | StaleTerminationThresholdBreached
   | StaleTerminationBatch
   | StaleBroadcastEmitFailures
@@ -336,7 +336,7 @@ let to_string = function
   | PresenceSyncFailures -> "masc_keeper_presence_sync_failures_total"
   | SelfPreservationUniversal -> "masc_keeper_self_preservation_universal_total"
   | StaleStormPaused -> "masc_keeper_stale_storm_paused_total"
-  | OasTimeoutBudgetLoopPaused -> "masc_keeper_provider_timeout_loop_paused_total"
+  | ProviderTimeoutLoopPaused -> "masc_keeper_provider_timeout_loop_paused_total"
   | CycleExceptions -> "masc_keeper_cycle_exceptions_total"
   | SnapshotWriteFailures -> "masc_keeper_snapshot_write_failures_total"
   | ProgressUpdatedLineFailures -> "masc_keeper_progress_updated_line_failures_total"
@@ -397,11 +397,11 @@ let to_string = function
   | RequiredToolGateSuppressedTotal -> "masc_keeper_required_tool_gate_suppressed_total"
   | ConsecutiveIdle -> "masc_keeper_consecutive_idle"
   | LastProductiveTs -> "masc_keeper_last_productive_ts"
-  | OasTimeoutBudgetStrike -> "masc_keeper_provider_timeout_strike_total"
+  | ProviderTimeoutStrike -> "masc_keeper_provider_timeout_strike_total"
   | StaleTerminationTotal -> "masc_keeper_stale_termination_total"
   | StaleTerminationByClass -> "masc_keeper_stale_termination_by_class_total"
-  | OasTimeoutBudgetWatchdogTermination ->
-    "masc_keeper_stale_watchdog_timeout_termination_total"
+  | ProviderTimeoutWatchdogTermination ->
+    "masc_keeper_provider_timeout_watchdog_termination_total"
   | StaleTerminationThresholdBreached ->
     "masc_keeper_stale_termination_threshold_breached_total"
   | StaleTerminationBatch -> "masc_keeper_stale_termination_batch_total"
@@ -723,7 +723,7 @@ let metric_keeper_self_preservation_universal =
 
 let metric_keeper_stale_storm_paused = "masc_keeper_stale_storm_paused_total"
 
-let metric_keeper_oas_timeout_budget_loop_paused =
+let metric_keeper_provider_timeout_loop_paused =
   "masc_keeper_provider_timeout_loop_paused_total"
 ;;
 
@@ -937,7 +937,7 @@ let metric_keeper_required_tool_gate_suppressed_total =
 let metric_keeper_consecutive_idle = "masc_keeper_consecutive_idle"
 let metric_keeper_last_productive_ts = "masc_keeper_last_productive_ts"
 
-let metric_keeper_oas_timeout_budget_strike =
+let metric_keeper_provider_timeout_strike =
   "masc_keeper_provider_timeout_strike_total"
 ;;
 
@@ -947,8 +947,8 @@ let metric_keeper_stale_termination_by_class =
   "masc_keeper_stale_termination_by_class_total"
 ;;
 
-let metric_keeper_oas_timeout_budget_watchdog_termination =
-  "masc_keeper_stale_watchdog_timeout_termination_total"
+let metric_keeper_provider_timeout_watchdog_termination =
+  "masc_keeper_provider_timeout_watchdog_termination_total"
 ;;
 
 let metric_keeper_stale_termination_threshold_breached =

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -117,7 +117,7 @@ type t =
   | PresenceSyncFailures
   | SelfPreservationUniversal
   | StaleStormPaused
-  | OasTimeoutBudgetLoopPaused
+  | ProviderTimeoutLoopPaused
   | CycleExceptions
   | SnapshotWriteFailures
   | ProgressUpdatedLineFailures
@@ -177,10 +177,10 @@ type t =
   | RequiredToolGateSuppressedTotal
   | ConsecutiveIdle
   | LastProductiveTs
-  | OasTimeoutBudgetStrike
+  | ProviderTimeoutStrike
   | StaleTerminationTotal
   | StaleTerminationByClass
-  | OasTimeoutBudgetWatchdogTermination
+  | ProviderTimeoutWatchdogTermination
   | StaleTerminationThresholdBreached
   | StaleTerminationBatch
   | StaleBroadcastEmitFailures
@@ -413,7 +413,7 @@ val metric_keeper_room_init_failures : string
 val metric_keeper_presence_sync_failures : string
 val metric_keeper_self_preservation_universal : string
 val metric_keeper_stale_storm_paused : string
-val metric_keeper_oas_timeout_budget_loop_paused : string
+val metric_keeper_provider_timeout_loop_paused : string
 val metric_keeper_cycle_exceptions : string
 val metric_keeper_snapshot_write_failures : string
 val metric_keeper_state_snapshot_skipped_no_state : string
@@ -594,10 +594,10 @@ val metric_keeper_zombie_loop_detected_total : string
 val metric_keeper_required_tool_gate_suppressed_total : string
 val metric_keeper_consecutive_idle : string
 val metric_keeper_last_productive_ts : string
-val metric_keeper_oas_timeout_budget_strike : string
+val metric_keeper_provider_timeout_strike : string
 val metric_keeper_stale_termination_total : string
 val metric_keeper_stale_termination_by_class : string
-val metric_keeper_oas_timeout_budget_watchdog_termination : string
+val metric_keeper_provider_timeout_watchdog_termination : string
 val metric_keeper_stale_termination_threshold_breached : string
 val metric_keeper_stale_termination_batch : string
 val metric_keeper_stale_broadcast_emit_failures : string

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -307,7 +307,7 @@ let () =
 
 let () =
   Prometheus.register_counter
-    ~name:Keeper_metrics.metric_keeper_oas_timeout_budget_watchdog_termination
+    ~name:Keeper_metrics.metric_keeper_provider_timeout_watchdog_termination
     ~help:
       "Total watchdog terminations that preserved an unresolved \
        timeout failure evidence instead of reclassifying the keeper as \
@@ -568,7 +568,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                     root cause for supervisor auto-pause. *)
                  request_watchdog_stop ();
                  Prometheus.inc_counter
-                   Keeper_metrics.metric_keeper_oas_timeout_budget_watchdog_termination
+                   Keeper_metrics.metric_keeper_provider_timeout_watchdog_termination
                    ~labels:[ ("keeper", meta.name) ]
                    ();
                  Log.Keeper.error

--- a/lib/keeper/keeper_supervisor_pause_policy.ml
+++ b/lib/keeper/keeper_supervisor_pause_policy.ml
@@ -170,7 +170,7 @@ let handle_oas_timeout_budget_pause
     ctx
     entry
     ~reason_tag:"provider_timeout_loop"
-    ~metric_name:Keeper_metrics.metric_keeper_oas_timeout_budget_loop_paused
+    ~metric_name:Keeper_metrics.metric_keeper_provider_timeout_loop_paused
     ~lifecycle_detail:(Printf.sprintf "provider_timeout_loop count=%d" count)
     ~blocker_class:(Some Turn_timeout)
     ~resume_policy:Auto_resume_with_backoff

--- a/lib/prometheus_builtin_metrics_part3.ml
+++ b/lib/prometheus_builtin_metrics_part3.ml
@@ -211,7 +211,7 @@ let register
     "Total keepers auto-paused due to stale termination storms. Labeled by keeper."
     `Counter;
   add
-    Keeper_metrics.metric_keeper_oas_timeout_budget_loop_paused
+    Keeper_metrics.metric_keeper_provider_timeout_loop_paused
     "Total keepers auto-paused due to repeated provider timeout loops. Labeled by keeper."
     `Counter;
   add

--- a/lib/prometheus_builtin_metrics_part5.ml
+++ b/lib/prometheus_builtin_metrics_part5.ml
@@ -38,7 +38,7 @@ let register
      in_turn_hung | noop_failure_loop). Labels: keeper, class."
     `Counter;
   add
-    Keeper_metrics.metric_keeper_oas_timeout_budget_watchdog_termination
+    Keeper_metrics.metric_keeper_provider_timeout_watchdog_termination
     "Total watchdog terminations preserving unresolved timeout failure evidence. Labels: \
      keeper."
     `Counter;
@@ -162,7 +162,7 @@ let register
      reason."
     `Counter;
   add
-    Keeper_metrics.metric_keeper_oas_timeout_budget_strike
+    Keeper_metrics.metric_keeper_provider_timeout_strike
     "Provider timeout strikes (consecutive timeouts before escalation). Labels: keeper."
     `Counter;
   add


### PR DESCRIPTION
## Summary
- rename keeper metric enum variants and constants from `OasTimeoutBudget*` / `metric_keeper_oas_timeout_budget_*` to provider-timeout names
- keep the emitted metrics in the provider-timeout family, including watchdog termination
- update metric producer call sites so observability no longer preserves timeout-budget as the primary metric identity

## Validation
- Not run; user requested PR iteration without local validation.
