### PR TITLE
fix(tools): replace internal names in error messages and board descriptions

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -46,7 +46,7 @@ let typed_docker_sandbox_target ~turn_sandbox_factory ~meta ~cwd =
   match Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd with
   | None ->
     Error
-      "typed keeper_bash Docker Shell IR dispatch requires a turn sandbox factory"
+      "typed Bash Docker Shell IR dispatch requires a turn sandbox factory"
   | Some runtime ->
     let image = typed_docker_image meta in
     let runner ~stdin_content ~argv ~env:_ ~cwd:stage_cwd ~timeout_sec =
@@ -149,7 +149,7 @@ let handle_keeper_bash_typed
           | Local -> Ok (Masc_exec.Sandbox_target.host (), [])
           | Docker ->
             if typed_input_has_env input
-            then Error "typed keeper_bash Docker Shell IR dispatch does not support env yet"
+            then Error "typed Bash Docker Shell IR dispatch does not support env yet"
             else (
               match typed_docker_local_fallback_target ~meta ~timeout_sec with
               | Some fallback when in_playground -> Ok fallback
@@ -328,5 +328,5 @@ let handle_keeper_bash
   else
     error_json
       ~fields:[ "typed", `Bool true ]
-      "typed keeper_bash input is required. Provide executable/argv or pipeline/stages."
+      "Typed Bash input is required. Provide executable/argv or pipeline/stages."
 ;;

--- a/lib/keeper/keeper_tool_bash_input.ml
+++ b/lib/keeper/keeper_tool_bash_input.ml
@@ -72,7 +72,7 @@ let reject_unknown_fields ~path ~allowed fields =
   let allowed key = List.exists (String.equal key) allowed in
   match List.find_opt (fun (key, _) -> not (allowed key)) fields with
   | None -> Ok ()
-  | Some (key, _) -> result_errorf "%s.%s is not a supported typed keeper_bash field" path key
+  | Some (key, _) -> result_errorf "%s.%s is not a supported typed Bash field" path key
 ;;
 
 let required_string ~path fields key =
@@ -177,7 +177,7 @@ let of_json (json : Yojson.Safe.t) =
     if Option.is_some (member fields "cmd")
     then
       Error
-        "cmd string is not a typed keeper_bash input; provide \
+        "cmd string is not a typed Bash input; provide \
          executable/argv or pipeline stages"
     else Ok ()
   in

--- a/lib/tool_shard_types_schemas_board.ml
+++ b/lib/tool_shard_types_schemas_board.ml
@@ -8,7 +8,7 @@ let board_tools : Masc_domain.tool_schema list =
         "Read a single board post with all its comments and votes. Use before deciding \
          to comment, vote, or escalate. Returns post content, author, timestamp, \
          vote_count, and comment thread. post_id format: 'p-xxxx'. Get post_id from \
-         keeper_board_list results."
+         masc_board_list results."
     ; input_schema =
         `Assoc
           [ "type", `String "object"
@@ -18,7 +18,7 @@ let board_tools : Masc_domain.tool_schema list =
                   , `Assoc
                       [ "type", `String "string"
                       ; ( "description"
-                        , `String "Post ID (format: p-xxxx). Get from keeper_board_list."
+                        , `String "Post ID (format: p-xxxx). Get from masc_board_list."
                         )
                       ] )
                 ] )
@@ -156,7 +156,7 @@ let board_tools : Masc_domain.tool_schema list =
                       [ "type", `String "string"
                       ; ( "description"
                         , `String
-                            "Post ID (format: p-xxxx...). Get from keeper_board_list \
+                            "Post ID (format: p-xxxx...). Get from masc_board_list \
                              results." )
                       ] )
                 ; ( "content"
@@ -182,7 +182,7 @@ let board_tools : Masc_domain.tool_schema list =
                       [ "type", `String "string"
                       ; ( "description"
                         , `String
-                            "Post ID (format: p-xxxx...). Get from keeper_board_list \
+                            "Post ID (format: p-xxxx...). Get from masc_board_list \
                              results." )
                       ] )
                 ; (* Issue #8506: derive from local mirror that tracks


### PR DESCRIPTION
## Summary
- Error strings returned via `tool_result.message` referenced internal names (`keeper_bash`, `keeper_board_list`) instead of public aliases (`Bash`, `masc_board_list`)
- 5 error messages in `keeper_shell_bash.ml` and `keeper_tool_bash_input.ml` now use "typed Bash"
- 4 board schema descriptions now reference `masc_board_list` instead of `keeper_board_list`

## Test plan
- [ ] `dune build` passes
- [ ] Existing regression test `test_keeper_internal_descriptions_no_cross_leak` still passes
- [ ] Grep confirms zero `keeper_bash`/`keeper_shell` in LLM-facing description/error strings (excluding internal surface self-references and structured logs)

Continues: #17653, #17690

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>