### PR TITLE
fix(keeper): rename timeout budget loop registry state

### DIFF
--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -1153,19 +1153,19 @@ let stale_kill_class_label = function
 
 let stale_terminal_reason_code_typed reason =
   match reason with
-  | Some (Keeper_registry.Oas_timeout_budget_loop _) ->
+  | Some (Keeper_registry.Provider_timeout_loop _) ->
     Keeper_turn_terminal_code.Provider_runtime_error "provider_timeout_loop"
   | _ -> Keeper_turn_terminal_code.of_failure_reason_option reason
 ;;
 
 let stale_broadcast_failure_cohort = function
-  | Some (Keeper_registry.Oas_timeout_budget_loop _) -> "provider_timeout_loop"
+  | Some (Keeper_registry.Provider_timeout_loop _) -> "provider_timeout_loop"
   | Some _ as reason -> Keeper_registry.failure_reason_cohort_key reason
   | None -> "stale_turn_timeout"
 ;;
 
 let stale_broadcast_failure_reason_text = function
-  | Some (Keeper_registry.Oas_timeout_budget_loop { count }) ->
+  | Some (Keeper_registry.Provider_timeout_loop { count }) ->
     Some (Printf.sprintf "provider_timeout_loop(count=%d)" count)
   | Some reason -> Some (Keeper_registry.failure_reason_to_string reason)
   | None -> None

--- a/lib/keeper/keeper_health_probe.ml
+++ b/lib/keeper/keeper_health_probe.ml
@@ -103,7 +103,7 @@ let provider_runtime_pressure_class ~code ~detail ~http_status =
 ;;
 
 let runtime_pressure_class_of_failure_reason = function
-  | Some (Keeper_registry.Oas_timeout_budget_loop _) -> Some Provider_timeout
+  | Some (Keeper_registry.Provider_timeout_loop _) -> Some Provider_timeout
   | Some (Keeper_registry.Provider_runtime_error { code; detail; http_status; _ }) ->
     Some (provider_runtime_pressure_class ~code ~detail ~http_status)
   | Some (Keeper_registry.Stale_turn_timeout _) -> Some Turn_stale_timeout

--- a/lib/keeper/keeper_heartbeat_loop_cycle_with_slot.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle_with_slot.ml
@@ -89,7 +89,7 @@ let run_keeper_cycle_with_slot
       Keeper_turn_slot.reset_budget_exhaustion ~keeper_name;
       Log.Keeper.warn
         "%s: legacy oas_timeout_budget observed; preserving original turn \
-         failure without Oas_timeout_budget_loop latch"
+         failure without Provider_timeout_loop latch"
         keeper_name);
     (match read_meta ctx.config meta_after_cursor_persist.name with
      | Ok (Some latest) -> latest

--- a/lib/keeper/keeper_heartbeat_loop_observations.ml
+++ b/lib/keeper/keeper_heartbeat_loop_observations.ml
@@ -164,7 +164,7 @@ let clear_oas_timeout_budget_failure_reason ~base_path ~keeper_name =
   match Keeper_registry.get ~base_path keeper_name with
   | Some
       { Keeper_registry.last_failure_reason =
-          Some (Keeper_registry.Oas_timeout_budget_loop _)
+          Some (Keeper_registry.Provider_timeout_loop _)
       ; _
       } -> Keeper_registry.set_failure_reason ~base_path keeper_name None
   | _ -> ()
@@ -174,7 +174,7 @@ let prior_oas_timeout_budget_strikes ~base_path ~keeper_name =
   match Keeper_registry.get ~base_path keeper_name with
   | Some
       { Keeper_registry.last_failure_reason =
-          Some (Keeper_registry.Oas_timeout_budget_loop { count })
+          Some (Keeper_registry.Provider_timeout_loop { count })
       ; _
       } -> count
   | _ -> 0

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -725,7 +725,7 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
                     (( Keeper_registry.Stale_turn_timeout _
                      | Keeper_registry.Stale_termination_storm _
                      | Keeper_registry.Stale_fleet_batch _
-                     | Keeper_registry.Oas_timeout_budget_loop _ ) as reason)
+                     | Keeper_registry.Provider_timeout_loop _ ) as reason)
               ; _
               } -> record_crash reason
           | _ -> record_stopped "normal exit"

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -202,7 +202,7 @@ val set_after_acquire_flag_hook_for_test :
     Reset on any successful turn.
     The in-process CAS map survives within a server lifetime. After
     restart, callers may hydrate the first bump from persisted
-    [Oas_timeout_budget_loop] state so multi-process loops still reach
+    [Provider_timeout_loop] state so multi-process loops still reach
     the policy gate. *)
 val oas_timeout_budget_strike_limit : int
 

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -53,7 +53,7 @@ type failure_reason =
           fleet-batch detection is observation-only and must not create this
           failure reason; if old runtime state still contains it, the
           supervisor treats it like a restartable watchdog crash. *)
-  | Oas_timeout_budget_loop of { count : int }
+  | Provider_timeout_loop of { count : int }
   (** Latched when the same keeper exhausts the OAS turn budget on
           consecutive cycles. This is a provider/cascade/runtime throughput
           failure, so the supervisor pauses instead of restarting into the
@@ -85,7 +85,7 @@ let failure_reason_to_string = function
     Printf.sprintf "stale_termination_storm(count=%d)" count
   | Stale_fleet_batch { distinct_count } ->
     Printf.sprintf "stale_fleet_batch(distinct_count=%d)" distinct_count
-  | Oas_timeout_budget_loop { count } ->
+  | Provider_timeout_loop { count } ->
     Printf.sprintf "provider_timeout_loop(count=%d)" count
   | Provider_runtime_error { code; detail; provider_id; http_status } ->
     let prov =
@@ -123,7 +123,7 @@ let failure_reason_cohort_key = function
   | Some (Stale_turn_timeout _) -> "stale_turn_timeout"
   | Some (Stale_termination_storm _) -> "stale_termination_storm"
   | Some (Stale_fleet_batch _) -> "stale_fleet_batch"
-  | Some (Oas_timeout_budget_loop _) -> "provider_timeout_loop"
+  | Some (Provider_timeout_loop _) -> "provider_timeout_loop"
   | Some (Provider_runtime_error _) -> "provider_runtime_error"
   | Some (Tool_required_unsatisfied _) -> "tool_required_unsatisfied"
   | Some (Ambiguous_partial_commit _) -> "ambiguous_partial_commit"
@@ -135,7 +135,7 @@ let failure_reason_cohort_key = function
 let stale_watchdog_failure_reason ~prior ~kill_class =
   match prior with
   | Some
-      ( Oas_timeout_budget_loop _
+      ( Provider_timeout_loop _
       | Provider_runtime_error _
       | Tool_required_unsatisfied _
       | Ambiguous_partial_commit _

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -79,7 +79,7 @@ type failure_reason =
           fleet-batch detection is observation-only and must not create this
           failure reason; if old runtime state still contains it, the
           supervisor treats it like a restartable watchdog crash. *)
-  | Oas_timeout_budget_loop of { count : int }
+  | Provider_timeout_loop of { count : int }
       (** Legacy persisted timeout-loop value. New operator/cohort surfaces
           normalize it to provider-timeout ownership instead of presenting
           timeout-budget as a distinct root cause. *)

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -219,7 +219,7 @@ let failure_reason_batch_root_cause
       Some Provider_auth
   | Exception detail when fd_exhaustion_failure detail ->
       Some Fd_exhaustion
-  | Oas_timeout_budget_loop _ ->
+  | Provider_timeout_loop _ ->
       Some Provider_timeout
   | Stale_turn_timeout _
   | Stale_termination_storm _
@@ -290,7 +290,7 @@ let pending_oas_timeout_budget_count
     | None -> false
   in
   match entry.last_failure_reason, has_timeout_observation with
-  | Some (Keeper_registry.Oas_timeout_budget_loop { count }), true -> Some count
+  | Some (Keeper_registry.Provider_timeout_loop { count }), true -> Some count
   | _ -> None
 
 let () =
@@ -559,7 +559,7 @@ let fork_stale_watchdog (ctx : _ context) (meta : keeper_meta)
                | Some count when idle_stale ->
                  let stall_seconds = now -. last_turn in
                  let failure_reason =
-                   Keeper_registry.Oas_timeout_budget_loop { count }
+                   Keeper_registry.Provider_timeout_loop { count }
                  in
                  Keeper_registry.set_failure_reason ~base_path meta.name
                    (Some failure_reason);

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -459,7 +459,7 @@ let runtime_blocker_surface_of_failure_reason (reason : Keeper_registry.failure_
             count
       ; continue_gate = false
       }
-  | Keeper_registry.Oas_timeout_budget_loop { count } ->
+  | Keeper_registry.Provider_timeout_loop { count } ->
     Some
       (runtime_blocker_surface_of_typed_class
          ~summary:

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -185,7 +185,7 @@ let launch_supervised_fiber
                   | Some (Keeper_registry.Stale_turn_timeout _)
                   | Some (Keeper_registry.Stale_termination_storm _)
                   | Some (Keeper_registry.Stale_fleet_batch _)
-                  | Some (Keeper_registry.Oas_timeout_budget_loop _) -> true
+                  | Some (Keeper_registry.Provider_timeout_loop _) -> true
                   (* Other failure reasons are not stale-watchdog signals. *)
                   | Some (Keeper_registry.Heartbeat_consecutive_failures _)
                   | Some (Keeper_registry.Turn_consecutive_failures _)
@@ -717,7 +717,7 @@ let sweep_and_recover (ctx : _ context) =
             increments once per storm. *)
          handle_stale_storm_pause ctx entry ~count;
          to_unregister := entry :: !to_unregister
-       | Some (Keeper_registry.Oas_timeout_budget_loop { count }) ->
+       | Some (Keeper_registry.Provider_timeout_loop { count }) ->
          (* Watchdog-preserved OAS budget loops include liveness evidence,
             so policy allows keeper pause without treating timeout alone as
             keeper death. *)
@@ -754,7 +754,7 @@ let sweep_and_recover (ctx : _ context) =
     | Some (Keeper_registry.Stale_turn_timeout _)
     | Some (Keeper_registry.Stale_termination_storm _)
     | Some (Keeper_registry.Stale_fleet_batch _)
-    | Some (Keeper_registry.Oas_timeout_budget_loop _) -> true
+    | Some (Keeper_registry.Provider_timeout_loop _) -> true
     (* Other failure reasons are not stale-watchdog signals. *)
     | Some (Keeper_registry.Heartbeat_consecutive_failures _)
     | Some (Keeper_registry.Turn_consecutive_failures _)
@@ -782,7 +782,7 @@ let sweep_and_recover (ctx : _ context) =
        [watchdog_stop_pending]. *)
     let stamp_cohort =
       match entry.last_failure_reason with
-      | Some (Keeper_registry.Oas_timeout_budget_loop _) -> Some Oas_timeout_budget
+      | Some (Keeper_registry.Provider_timeout_loop _) -> Some Oas_timeout_budget
       | Some (Keeper_registry.Stale_turn_timeout _)
       | Some (Keeper_registry.Stale_fleet_batch _)
       | Some (Keeper_registry.Stale_termination_storm _) -> Some Stale_turn_timeout

--- a/lib/keeper/keeper_supervisor_alive_but_stuck.ml
+++ b/lib/keeper/keeper_supervisor_alive_but_stuck.ml
@@ -87,7 +87,7 @@ let request_recovery ~base_path ~elapsed (entry : Keeper_registry.registry_entry
     | Some
         ( Keeper_registry.Stale_turn_timeout _
         | Keeper_registry.Stale_termination_storm _
-        | Keeper_registry.Oas_timeout_budget_loop _ ) as kept -> kept
+        | Keeper_registry.Provider_timeout_loop _ ) as kept -> kept
     | Some (Keeper_registry.Heartbeat_consecutive_failures _)
     | Some (Keeper_registry.Turn_consecutive_failures _)
     | Some (Keeper_registry.Provider_runtime_error _)

--- a/lib/keeper/keeper_supervisor_pause_policy.ml
+++ b/lib/keeper/keeper_supervisor_pause_policy.ml
@@ -189,7 +189,7 @@ let failure_reason_policy_decision
   : Keeper_failure_policy.decision option
   =
   match reason with
-  | Some (Keeper_registry.Oas_timeout_budget_loop { count }) ->
+  | Some (Keeper_registry.Provider_timeout_loop { count }) ->
     Some
       (Keeper_failure_policy.decide
          (Keeper_failure_policy.Oas_timeout_budget

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -862,7 +862,7 @@ let reset_autonomous_completion_for_test () : unit =
    Counter is in-memory for the common same-server case and is reset on
    any successful turn (see [Ok updated] branch). On first bump after a
    process restart, callers may seed it from the persisted
-   [Oas_timeout_budget_loop] failure reason so restart cannot erase a
+   [Provider_timeout_loop] failure reason so restart cannot erase a
    partially observed loop. *)
 let oas_timeout_budget_strike_limit = 3
 

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -185,7 +185,7 @@ val set_after_acquire_flag_hook_for_test :
     [Keeper_failure_policy] before choosing any lifecycle effect.
 
     Counts are stored in an in-process CAS map and can be seeded from the
-    persisted [Oas_timeout_budget_loop] failure reason on the first bump after
+    persisted [Provider_timeout_loop] failure reason on the first bump after
     restart or another process update. *)
 val oas_timeout_budget_strike_limit : int
 

--- a/lib/keeper/keeper_turn_terminal_code.ml
+++ b/lib/keeper/keeper_turn_terminal_code.ml
@@ -86,7 +86,7 @@ let of_failure_reason : Keeper_registry.failure_reason -> t = function
     Stale_turn_timeout_noop
   | Keeper_registry.Stale_termination_storm _ -> Stale_termination_storm
   | Keeper_registry.Stale_fleet_batch _ -> Stale_fleet_batch
-  | Keeper_registry.Oas_timeout_budget_loop _ ->
+  | Keeper_registry.Provider_timeout_loop _ ->
     Provider_runtime_error "provider_timeout_loop"
   | Keeper_registry.Provider_runtime_error { code; _ } -> Provider_runtime_error code
   | Keeper_registry.Tool_required_unsatisfied { code; _ } ->

--- a/test/test_keeper_health_probe.ml
+++ b/test/test_keeper_health_probe.ml
@@ -135,7 +135,7 @@ let test_runtime_pressure_classifier () =
     pressure_label_t
     "legacy oas timeout normalizes to provider timeout"
     (Some "provider_timeout")
-    (pressure_label_of_failure_reason (R.Oas_timeout_budget_loop { count = 2 }))
+    (pressure_label_of_failure_reason (R.Provider_timeout_loop { count = 2 }))
 ;;
 
 let test_run_once_records_specific_failure_ratio_reason () =

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -762,7 +762,7 @@ let test_stale_broadcast_payload_preserves_required_tool_failure_reason () =
 ;;
 
 let test_stale_broadcast_payload_preserves_timeout_budget_failure_reason () =
-  let failure_reason = Masc_mcp.Keeper_registry.Oas_timeout_budget_loop { count = 4 } in
+  let failure_reason = Masc_mcp.Keeper_registry.Provider_timeout_loop { count = 4 } in
   let payload =
     R.stale_broadcast_payload
       ~keeper_name:"executor"

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -125,7 +125,7 @@ let test_auto_resume_disabled () =
 
 let test_supervisor_policy_pauses_watchdog_provider_timeout_loop () =
   let decision =
-    policy_decision_exn (Some (Reg.Oas_timeout_budget_loop { count = 3 }))
+    policy_decision_exn (Some (Reg.Provider_timeout_loop { count = 3 }))
   in
   check string "scope" "turn" (KFP.failure_scope_to_label decision.failure_scope);
   check string "lifecycle" "pause_keeper"
@@ -1168,7 +1168,7 @@ let test_provider_timeout_loop_pause_skips_restart () =
       Reg.restore_supervisor_state ~base_path:config.base_path name
         ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
       Reg.set_failure_reason ~base_path:config.base_path name
-        (Some (Reg.Oas_timeout_budget_loop { count = 3 }));
+        (Some (Reg.Provider_timeout_loop { count = 3 }));
       let baseline_pause =
         Masc_mcp.Prometheus.metric_total
           "masc_keeper_provider_timeout_loop_paused_total"
@@ -1232,7 +1232,7 @@ let test_unresolved_watchdog_stopped_budget_loop_is_reaped () =
       Reg.restore_supervisor_state ~base_path:config.base_path name
         ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
       Reg.set_failure_reason ~base_path:config.base_path name
-        (Some (Reg.Oas_timeout_budget_loop { count = 3 }));
+        (Some (Reg.Provider_timeout_loop { count = 3 }));
       let ctx : _ KT.context =
         {
           config;
@@ -1410,7 +1410,7 @@ let test_oas_auto_resume_after_sec_doubles_on_repause () =
       Reg.restore_supervisor_state ~base_path:config.base_path name
         ~restart_count:0 ~last_restart_ts:0.0 ~crash_log:[];
       Reg.set_failure_reason ~base_path:config.base_path name
-        (Some (Reg.Oas_timeout_budget_loop { count = 3 }));
+        (Some (Reg.Provider_timeout_loop { count = 3 }));
       let ctx : _ KT.context =
         {
           config;
@@ -2475,7 +2475,7 @@ let () =
            [Turn_consecutive_failures] / [Exception] / etc., and
            [watchdog_stop_pending] only restarts on
            [Stale_turn_timeout | Stale_termination_storm |
-           Stale_fleet_batch | Oas_timeout_budget_loop].  Recovery would set
+           Stale_fleet_batch | Provider_timeout_loop].  Recovery would set
            [fiber_stop=true] but the supervisor would never convert
            it into a crash/restart.  Pin the post-recovery cohort to
            [stale_turn_timeout] so this regression is caught. *)

--- a/test/test_stale_kill_class.ml
+++ b/test/test_stale_kill_class.ml
@@ -77,7 +77,7 @@ let test_failure_reason_to_string_noop () =
 let test_failure_reason_to_string_oas_timeout_budget_loop () =
   r "legacy timeout-budget loop normalizes to provider timeout"
     "provider_timeout_loop(count=3)"
-    (failure_reason_to_string (Oas_timeout_budget_loop { count = 3 }))
+    (failure_reason_to_string (Provider_timeout_loop { count = 3 }))
 
 let test_failure_reason_to_string_stale_fleet_batch () =
   r "Stale_fleet_batch includes distinct count"
@@ -156,7 +156,7 @@ let test_cohort_key_collapses_subclasses () =
 let test_oas_timeout_budget_loop_cohort_key () =
   r "legacy timeout-budget loop cohort_key" "provider_timeout_loop"
     (failure_reason_cohort_key
-       (Some (Oas_timeout_budget_loop { count = 3 })))
+       (Some (Provider_timeout_loop { count = 3 })))
 
 let test_stale_fleet_batch_cohort_key () =
   r "Stale_fleet_batch cohort_key" "stale_fleet_batch"
@@ -306,7 +306,7 @@ let test_batch_root_cause_fd_exhaustion () =
 
 let test_batch_root_cause_cascade_unhealthy () =
   r "provider timeout" "provider_timeout"
-    (root_cause_label [ Oas_timeout_budget_loop { count = 2 } ])
+    (root_cause_label [ Provider_timeout_loop { count = 2 } ])
 
 let test_batch_root_cause_mixed () =
   r "mixed" "mixed"
@@ -421,7 +421,7 @@ let () =
             test_failure_reason_to_string_mid_turn_no_progress;
           Alcotest.test_case "Stale_turn_timeout(Noop_failure_loop) wraps"
             `Quick test_failure_reason_to_string_noop;
-          Alcotest.test_case "Oas_timeout_budget_loop wraps" `Quick
+          Alcotest.test_case "Provider_timeout_loop wraps" `Quick
             test_failure_reason_to_string_oas_timeout_budget_loop;
           Alcotest.test_case "Stale_fleet_batch wraps" `Quick
             test_failure_reason_to_string_stale_fleet_batch;
@@ -434,7 +434,7 @@ let () =
         [
           Alcotest.test_case "all sub-classes collapse to one cohort"
             `Quick test_cohort_key_collapses_subclasses;
-          Alcotest.test_case "Oas_timeout_budget_loop cohort" `Quick
+          Alcotest.test_case "Provider_timeout_loop cohort" `Quick
             test_oas_timeout_budget_loop_cohort_key;
           Alcotest.test_case "Stale_fleet_batch cohort" `Quick
             test_stale_fleet_batch_cohort_key;


### PR DESCRIPTION
## Summary
- rename the registry failure-reason constructor from `Oas_timeout_budget_loop` to `Provider_timeout_loop`
- update supervisor, stale-watchdog, status, receipt, and test call sites to branch on provider-timeout ownership
- keep projected strings/cohort surfaces in the `provider_timeout_loop` family so persisted legacy meaning is not reintroduced as a root cause

## Validation
- Not run; user requested PR iteration without local validation.
