### PR TITLE
refactor(dashboard): migrate dashboard_http_keeper memory surface to _result (RFC-0149 §3.1 PR-5)

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -220,23 +220,43 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
 
           (* In compact mode (used by execution surface), skip heavy memory bank I/O.
              Full memory bank is only needed for individual keeper detail view. *)
+          (* RFC-0149 §3.1 — route through the Result-returning resolver
+             so a memory-bank IO fault surfaces a typed [unavailable]
+             JSON shape that the dashboard frontend can render as a
+             warning state, separate from "Ok summary with empty bank". *)
           let (memory_bank_json, memory_recent_note) =
             if compact then
               (`Assoc [("total_files", `Int 0); ("skipped", `Bool true)], None)
             else
-              let summary =
-                Keeper_memory.read_keeper_memory_summary
+              match
+                Keeper_memory.read_keeper_memory_summary_result
                   config
                   ~name:m.name
                   ~max_bytes:120000
                   ~max_lines:200
                   ~recent_limit:4
-              in
-              let note = match summary.Keeper_memory.recent_notes with
-                | row :: _ -> Some row.Keeper_memory.text
-                | [] -> None
-              in
-              (Keeper_memory.memory_summary_to_json summary, note)
+              with
+              | Ok summary ->
+                let note = match summary.Keeper_memory.recent_notes with
+                  | row :: _ -> Some row.Keeper_memory.text
+                  | [] -> None
+                in
+                (Keeper_memory.memory_summary_to_json summary, note)
+              | Error exn_class ->
+                let label =
+                  Keeper_memory_recall_exn_class.to_label exn_class
+                in
+                let note =
+                  Some (Printf.sprintf "[memory unavailable: %s]" label)
+                in
+                let json =
+                  `Assoc
+                    [ ("total_files", `Int 0)
+                    ; ("unavailable", `Bool true)
+                    ; ("error_class", `String label)
+                    ]
+                in
+                (json, note)
           in
           let history_path =
             Filename.concat


### PR DESCRIPTION
# refactor(dashboard): migrate dashboard_http_keeper memory surface to _result (RFC-0149 §3.1 PR-5)

PR-4 (#17711 머지) 의 [memory unavailable: <class>] 패턴 을 dashboard HTTP keeper-list 엔드포인트의 memory_bank_json + memory_recent_note 두 surface 에 동시 적용.

## 변경 범위

```
lib/dashboard/dashboard_http_keeper.ml | +28 -8
```

## 3-state JSON shape

```jsonc
// Ok + non-empty
{"total_files": N, "kind_counts": {...}, "recent_notes": [...], ...}

// Ok + empty
{"total_files": 0, "kind_counts": {}, "recent_notes": [], ...}

// Error (RFC-0149 §3.1 new path)
{"total_files": 0, "unavailable": true, "error_class": "io_error"}

// compact short-circuit (unchanged)
{"total_files": 0, "skipped": true}
```

`unavailable=true` 와 `skipped=true` 는 *의도적으로 별개 flag* — frontend 가 "operator-intentional skip" vs "memory-bank IO fault" 분리 렌더 가능.

## Workaround Rejection Bar self-check

- §1 텔레메트리-as-fix: silent fallback 제거. counter 추가 0.
- §2 substring 분류기: 0
- §3 N-of-M 패치: 1 caller per PR. `error_class` label 은 `Keeper_memory_recall_exn_class.to_label` (4-value bounded sum) 라 cardinality 안전.
- catch-all 0

## 정량 완료 기준

- `dune build --root . lib/dashboard/`: pass
- caller compat — function signature 변경 0

## 후속

- PR-6: `keeper_status_detail.ml:375` (record-returning context — surface 제약 더 좁음)
- PR-7/8: `server_dashboard_http_keeper_api.ml:1208`, `server_dashboard_http_memory_subsystems.ml:35`
- PR-9: `read_file_tail_lines` 5 lib caller migration
- PR-closeout: legacy 삭제

RFC-WAIVED: RFC-0149 §3.1 sunset prod caller migration 2/4. lib/dashboard 영역의 다른 RFC SSOT 무관.

## Co-Authored-By

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>