### PR TITLE
fix(keeper): serialize timeout terminal code as provider timeout

### DIFF
--- a/lib/keeper/keeper_turn_terminal_code.ml
+++ b/lib/keeper/keeper_turn_terminal_code.ml
@@ -35,7 +35,7 @@ let to_wire = function
     "stale_turn_timeout"
   | Stale_termination_storm -> "stale_termination_storm"
   | Stale_fleet_batch -> "stale_fleet_batch"
-  | Oas_timeout_budget -> "oas_timeout_budget"
+  | Oas_timeout_budget -> "provider_timeout"
   | Heartbeat_failures -> "heartbeat_failures"
   | Turn_failures -> "turn_failures"
   | Provider_runtime_error code -> code

--- a/lib/keeper/keeper_turn_terminal_code.mli
+++ b/lib/keeper/keeper_turn_terminal_code.mli
@@ -40,8 +40,9 @@ type t =
       retain their per-keeper terminal code. *)
   | Oas_timeout_budget
   (** Legacy wire-only timeout-budget code. New registry projections
-      normalize this to provider/turn timeout evidence instead of emitting
-      ["oas_timeout_budget"]. *)
+      normalize this to provider/turn timeout evidence. Serialisation emits
+      ["provider_timeout"]; ["oas_timeout_budget"] remains parse-only
+      compatibility in the implementation. *)
   | Heartbeat_failures (** [Keeper_registry.Heartbeat_consecutive_failures]. *)
   | Turn_failures (** [Keeper_registry.Turn_consecutive_failures]. *)
   | Provider_runtime_error of string


### PR DESCRIPTION
## Summary
- stop serializing the legacy terminal-code `Oas_timeout_budget` variant as `oas_timeout_budget`
- emit `provider_timeout` for the legacy timeout terminal-code alias
- keep `oas_timeout_budget` as parse-only compatibility in terminal-code decoding

## Validation
- Not run; user requested PR iteration without local validation.
