### PR TITLE
fix(keeper): classify timeout budget retries as provider timeout

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -271,7 +271,7 @@ type degraded_retry_reason =
   | Max_turns
   | Resumable_cli_session
   | Admission_queue_timeout
-  | Oas_timeout_budget
+  | Provider_timeout
   | Turn_timeout
   | Cascade_candidates_filtered
   | Required_tool_contract_violation
@@ -286,7 +286,7 @@ let degraded_retry_reason_to_string = function
   | Max_turns -> "max_turns"
   | Resumable_cli_session -> "resumable_cli_session"
   | Admission_queue_timeout -> "admission_queue_timeout"
-  | Oas_timeout_budget -> "oas_timeout_budget"
+  | Provider_timeout -> "provider_timeout"
   | Turn_timeout -> "turn_timeout"
   | Cascade_candidates_filtered -> "cascade_candidates_filtered"
   | Required_tool_contract_violation -> "required_tool_contract_violation"
@@ -360,7 +360,7 @@ let degraded_retry_after_recoverable_error
     | Some (Keeper_turn_driver.Admission_queue_timeout _) ->
         local_recovery_retry Admission_queue_timeout
     | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
-        local_recovery_retry Oas_timeout_budget
+        local_recovery_retry Provider_timeout
     | Some (Keeper_turn_driver.Turn_timeout _) ->
         local_recovery_retry Turn_timeout
     | Some (Keeper_turn_driver.Capacity_backpressure _) ->
@@ -416,7 +416,7 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
     | Some (Keeper_turn_driver.Admission_queue_timeout _) ->
         Some Admission_queue_timeout
     | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
-        Some Oas_timeout_budget
+        Some Provider_timeout
     | Some (Keeper_turn_driver.Turn_timeout _) ->
         Some Turn_timeout
     | Some (Keeper_turn_driver.Capacity_backpressure _) ->

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -78,7 +78,7 @@ type degraded_retry_reason =
   | Max_turns
   | Resumable_cli_session
   | Admission_queue_timeout
-  | Oas_timeout_budget
+  | Provider_timeout
   | Turn_timeout
   | Cascade_candidates_filtered
   | Required_tool_contract_violation

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -6526,7 +6526,7 @@ let test_degraded_retry_after_recoverable_error_includes_turn_timeout () =
     degraded_retry
 ;;
 
-let test_degraded_retry_after_recoverable_error_includes_oas_timeout_budget () =
+let test_degraded_retry_after_recoverable_error_includes_provider_timeout () =
   let degraded_retry =
     EC.degraded_retry_after_recoverable_error
       ~effective_cascade:"underdog"
@@ -6543,9 +6543,9 @@ let test_degraded_retry_after_recoverable_error_includes_oas_timeout_budget () =
             }))
   in
   expect_degraded_retry
-    "oas timeout budget degraded retry"
+    "provider timeout degraded retry"
     KC.local_recovery_cascade_name
-    "oas_timeout_budget"
+    "provider_timeout"
     degraded_retry
 ;;
 
@@ -12070,9 +12070,9 @@ let () =
             `Quick
             test_degraded_retry_after_recoverable_error_includes_turn_timeout
         ; test_case
-            "OAS timeout budget is degraded-retry eligible"
+            "provider timeout is degraded-retry eligible"
             `Quick
-            test_degraded_retry_after_recoverable_error_includes_oas_timeout_budget
+            test_degraded_retry_after_recoverable_error_includes_provider_timeout
         ; test_case
             "max turns is degraded-retry eligible"
             `Quick


### PR DESCRIPTION
## Summary
- replace the degraded-retry `Oas_timeout_budget` reason with `Provider_timeout`
- emit `provider_timeout` from keeper error classification for legacy timeout-budget typed errors
- update retry classification expectations so fallback/recoverable labels no longer teach timeout-budget as a live reason

## Validation
- Not run; user requested PR iteration without local validation.
