### PR TITLE
fix(keeper): restore memory_bank_summary binding after RFC-0149 §3.1 PR-4 (P0 main breakage)

### DIFF
--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -86,12 +86,14 @@ let handle_keeper_list ctx args : tool_result =
             in
             find_latest (List.rev metrics_window_lines)
           in
-          (* RFC-0149 §3.1 — route through the Result-returning resolver
-             so a memory-bank IO fault surfaces on the operator-visible
-             [memory_recent_note] field as a typed unavailable marker
-             instead of being indistinguishable from "no recorded notes".
-             [None] stays reserved for "Ok summary with empty recent_notes". *)
-          let memory_recent_note =
+          (* RFC-0149 §3.1 — single typed read drives both the structured
+             [memory_bank_summary] (consumed by [memory_bank] / counts
+             elsewhere in this object) and the operator-visible
+             [memory_recent_note] string field.  An IO fault surfaces a
+             typed unavailable marker on the note, and the empty-shaped
+             summary preserves the legacy aggregate semantics (zero notes,
+             no kinds) so downstream JSON keys stay populated. *)
+          let memory_bank_summary, memory_recent_note =
             match
               read_keeper_memory_summary_result
                 ctx.config
@@ -101,13 +103,27 @@ let handle_keeper_list ctx args : tool_result =
                 ~recent_limit:3
             with
             | Ok summary ->
-              (match summary.recent_notes with
-               | row :: _ -> Some row.text
-               | [] -> None)
+              let note =
+                match summary.recent_notes with
+                | row :: _ -> Some row.text
+                | [] -> None
+              in
+              summary, note
             | Error exn_class ->
-              Some
-                (Printf.sprintf "[memory unavailable: %s]"
-                   (Keeper_memory_recall_exn_class.to_label exn_class))
+              let empty : Keeper_memory_policy.keeper_memory_summary =
+                { total_notes = 0
+                ; last_ts_unix = 0.0
+                ; top_kind = None
+                ; kind_counts = []
+                ; recent_notes = []
+                }
+              in
+              let note =
+                Some
+                  (Printf.sprintf "[memory unavailable: %s]"
+                     (Keeper_memory_recall_exn_class.to_label exn_class))
+              in
+              empty, note
           in
             let continuity_reflection_hold_s =
               let cooldown = Float.of_int m.compaction.cooldown_sec in


### PR DESCRIPTION
## P0 — main build broken

PR #17711 (`d205270926`, RFC-0149 §3.1 PR-4) migrated `memory_recent_note` to the Result-returning resolver but **deleted the companion** `let memory_bank_summary = …` binding. Lines 252/254/260 still reference it:

    File "lib/keeper/keeper_status.ml", line 252, characters 41-60:
    252 |               ("memory_note_count", `Int memory_bank_summary.total_notes);
                                                   ^^^^^^^^^^^^^^^^^^^
    Error: Unbound value memory_bank_summary

`origin/main` does not build under `dune build --root . lib/` since #17711 was squash-merged. The miss escaped CI for the same class of sandbox-path-filter reasons captured in `memory/feedback_ci_sandbox_path_filter_masks_syntax_bugs.md`.

## Fix

Drive **both bindings** off a single typed `_result`:

```ocaml
let memory_bank_summary, memory_recent_note =
  match read_keeper_memory_summary_result … with
  | Ok summary ->
    let note = match summary.recent_notes with row::_ -> Some row.text | [] -> None in
    summary, note
  | Error exn_class ->
    let empty : Keeper_memory_policy.keeper_memory_summary =
      { total_notes = 0; last_ts_unix = 0.0; top_kind = None
      ; kind_counts = []; recent_notes = [] }
    in
    let note = Some (Printf.sprintf "[memory unavailable: %s]"
                       (Keeper_memory_recall_exn_class.to_label exn_class)) in
    empty, note
in
```

The empty record shape matches legacy `summarize_memory_bank_lines [] ~recent_limit`, so downstream JSON keys (`memory_note_count`, `memory_top_kind`, `memory_bank`) stay populated on read failure — preserving PR-4's typed operator-visible note signal while restoring the missing aggregate binding.

## Verification

- `dune build --root . lib/` → pass (was failing on `origin/main`)
- No behavior change on `Ok` path
- Error path: aggregate counts already showed zeros under the prior silent fallback; only the note string gains the typed `[memory unavailable: <label>]` marker (unchanged from PR-4)

## Scope

Single file, single binding restoration. Not a behavior change. Stack-PR retrospective in the parent /loop session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>