### PR TITLE
refactor(server): migrate memory subsystems caller to _result (RFC-0149 §3.1 PR-6)

### DIFF
--- a/lib/server/server_dashboard_http_memory_subsystems.ml
+++ b/lib/server/server_dashboard_http_memory_subsystems.ml
@@ -4,8 +4,16 @@ open Server_utils
 
 let memory_subsystems_entry_cache_ttl_sec = 30.0
 
+(* RFC-0149 §3.1: cache holds typed errors alongside successful rows so the
+   dashboard JSON can surface per-keeper Read failure class instead of silently
+   swallowing them. *)
 let memory_subsystems_entry_cache
-  : (string * float * (string * Keeper_memory_policy.keeper_memory_line) list) option ref
+  : (string
+     * float
+     * (string * Keeper_memory_policy.keeper_memory_line) list
+     * (string * string) list)
+      option
+      ref
   =
   ref None
 ;;
@@ -22,35 +30,46 @@ let load_memory_subsystems_entries ~(config : Coord_utils.config) =
   (* NDT-OK: wall-clock read only gates a dashboard cache TTL. *)
   let now = Unix.gettimeofday () in
   match !memory_subsystems_entry_cache with
-  | Some (base_path, cached_at, rows)
+  | Some (base_path, cached_at, rows, errors)
     when String.equal base_path config.base_path
-         && now -. cached_at < memory_subsystems_entry_cache_ttl_sec -> rows
+         && now -. cached_at < memory_subsystems_entry_cache_ttl_sec ->
+    (rows, errors)
   | _ ->
-    let rows =
+    let rows, errors =
       try
         Keeper_types.keeper_names config
-        |> List.concat_map (fun keeper ->
-          try
-            let summary =
-              Keeper_memory_recall.read_keeper_memory_summary
-                config
-                ~name:keeper
-                ~max_bytes:120000
-                ~max_lines:180
-                ~recent_limit:30
-            in
-            List.map
-              (fun (row : Keeper_memory_policy.keeper_memory_line) -> keeper, row)
-              summary.recent_notes
-          with
-          | Eio.Cancel.Cancelled _ as e -> raise e
-          | _ -> [])
+        |> List.fold_left
+             (fun (rows_acc, errs_acc) keeper ->
+               match
+                 Keeper_memory_recall.read_keeper_memory_summary_result
+                   config
+                   ~name:keeper
+                   ~max_bytes:120000
+                   ~max_lines:180
+                   ~recent_limit:30
+               with
+               | Ok summary ->
+                 let rows =
+                   List.map
+                     (fun (row : Keeper_memory_policy.keeper_memory_line) ->
+                       keeper, row)
+                     summary.recent_notes
+                 in
+                 rows_acc @ rows, errs_acc
+               | Error exn_class ->
+                 let label =
+                   Keeper_memory_recall_exn_class.to_label exn_class
+                 in
+                 rows_acc, (keeper, label) :: errs_acc)
+             ([], [])
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
-      | _ -> []
+      | _ -> [], []
     in
-    memory_subsystems_entry_cache := Some (config.base_path, now, rows);
-    rows
+    let errors = List.rev errors in
+    memory_subsystems_entry_cache
+    := Some (config.base_path, now, rows, errors);
+    rows, errors
 ;;
 
 let dashboard_memory_subsystems_http_json
@@ -110,8 +129,10 @@ let dashboard_memory_subsystems_http_json
       ; "ts_unix", `Float row.ts_unix
       ]
   in
-  let all_memory_entries =
-    if include_memory_entries then load_memory_subsystems_entries ~config else []
+  let all_memory_entries, memory_entry_errors =
+    if include_memory_entries
+    then load_memory_subsystems_entries ~config
+    else [], []
   in
   let memory_total = List.length all_memory_entries in
   let memory_filtered =
@@ -211,6 +232,15 @@ let dashboard_memory_subsystems_http_json
                 (List.map
                    (fun (keeper, row) -> memory_entry_to_json keeper row)
                    memory_entries) )
+          ; ( "errors"
+            , `List
+                (List.map
+                   (fun (keeper, error_class) ->
+                     `Assoc
+                       [ "keeper", `String keeper
+                       ; "error_class", `String error_class
+                       ])
+                   memory_entry_errors) )
           ] )
     ; ( "filters"
       , `Assoc


### PR DESCRIPTION
## Goal

Sunset the silent fallback at `lib/server/server_dashboard_http_memory_subsystems.ml:35` (RFC-0149 §3.1, PR-6 of the caller-migration sprint).

## Change

Route the dashboard memory-subsystems entry loader through the Result-returning `read_keeper_memory_summary_result` added in PR-2 (#17702).  Per-keeper Read failures now propagate to the JSON shape under `memory_entries.errors` as a typed `{keeper, error_class}` list rather than being silently swallowed into an empty row set.

Cache shape extended:

```
(base_path, ts, rows)  →  (base_path, ts, rows, errors)
```

TTL / baseline-path eviction policy unchanged.

## JSON contract

```jsonc
{
  "memory_entries": {
    "total": …, "filtered": …, "shown": …, "limit": …,
    "items": [ … ],
    "errors": [ { "keeper": "<name>", "error_class": "<label>" }, … ]  // NEW
  }
}
```

* `error_class` is one of `yojson_parse_error | io_error | type_error | other` (cardinality-bounded by `Keeper_memory_recall_exn_class.t`).
* `items` totals remain unaffected — no synthetic memory rows injected on Error.

## Out of scope

* Outer-scope `try … | _ -> []` covering `Keeper_types.keeper_names` resolution stays intact — different failure boundary, not a §3.1 target.

## Verification

* `dune build --root . lib/server/` → pass
* Full `dune build lib/` is **currently red on `origin/main`** unrelated to this diff (`memory_bank_summary` unbound in `keeper_status.ml:252`). Fix in hotfix #17723. Once #17723 merges, this PR will be rebased to a green base.

## Stack context

| PR | Status | Scope |
|----|--------|-------|
| #17670 | MERGED | PR-1 — `read_file_tail_lines_result` helper |
| #17681 | MERGED | PR-1.5 — unit tests |
| #17702 | MERGED | PR-2 — `read_keeper_memory_summary_result` helper |
| #17708 | MERGED | PR-3 — test sites migration |
| #17711 | MERGED | PR-4 — `keeper_status.ml` |
| #17717 | MERGED | PR-5 — `dashboard_http_keeper.ml` |
| **this** | Draft | **PR-6 — `server_dashboard_http_memory_subsystems.ml`** |
| (next) | — | PR-7 — `server_dashboard_http_keeper_api.ml:1208` |
| (next) | — | PR-8 — `keeper_status_detail.ml:375` (record surface — narrower migration) |
| (next) | — | PR-closeout — delete legacy silent fallback + counter+WARN |

## Anti-pattern self-check (§1 / §2 / §3)

- §1 telemetry-as-fix? No — the silent `try | _ -> []` is *removed*; `errors[]` is the typed propagated boundary, not an alarm sitting next to the swallow.
- §2 substring classifier? No — `error_class` field uses `Keeper_memory_recall_exn_class.t` (closed 4-value sum), not a string match.
- §3 N-of-M? Partial — this is one caller of N in an ongoing sweep, tracked in the stack table above and culminating in the closeout PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>