### PR TITLE
fix(keeper): stop reminting timeout budget blockers

### DIFF
--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -157,7 +157,7 @@ let blocker_class_of_string (reason : string) : blocker_class option =
   else if String_util.contains_substring_ci trimmed "autonomous turn slot wait timeout"
   then Some Autonomous_slot_wait_timeout
   else if String_util.contains_substring_ci trimmed "oas budget timeout"
-  then Some Oas_timeout_budget
+  then Some Turn_timeout
   else if String_util.contains_substring_ci trimmed "turn wall-clock timeout"
   then Some Turn_timeout
   else if
@@ -197,7 +197,7 @@ let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class
   | Some (Keeper_turn_driver.Admission_queue_timeout _) ->
     Some Admission_queue_wait_timeout
   | Some (Keeper_turn_driver.Admission_queue_rejected _) -> None
-  | Some (Keeper_turn_driver.Oas_timeout_budget _) -> Some Oas_timeout_budget
+  | Some (Keeper_turn_driver.Oas_timeout_budget _) -> Some Turn_timeout
   | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _) -> None
   | Some (Keeper_turn_driver.Turn_timeout _) -> Some Turn_timeout
   | Some (Keeper_turn_driver.Ambiguous_post_commit { is_timeout; _ }) ->

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -782,7 +782,7 @@ let sweep_and_recover (ctx : _ context) =
        [watchdog_stop_pending]. *)
     let stamp_cohort =
       match entry.last_failure_reason with
-      | Some (Keeper_registry.Provider_timeout_loop _) -> Some Oas_timeout_budget
+      | Some (Keeper_registry.Provider_timeout_loop _) -> Some Turn_timeout
       | Some (Keeper_registry.Stale_turn_timeout _)
       | Some (Keeper_registry.Stale_fleet_batch _)
       | Some (Keeper_registry.Stale_termination_storm _) -> Some Stale_turn_timeout


### PR DESCRIPTION
## Summary
- stop raw status fallback text from minting `Oas_timeout_budget` blocker classes
- map structured legacy timeout-budget SDK errors to `Turn_timeout` in the status bridge
- stamp provider-timeout watchdog loops as `Turn_timeout` instead of recreating the legacy blocker class

## Validation
- Not run; user requested PR iteration without local validation.
