### PR TITLE
fix(keeper): rename timeout budget strike policy

### DIFF
--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -196,7 +196,7 @@ val reset_autonomous_completion_for_test : unit -> unit
 val set_after_acquire_flag_hook_for_test :
   (label:string -> keeper_name:string -> unit) option -> unit
 
-(** PR-M (Leak 9): consecutive [oas_timeout_budget] cycle FAILED strikes
+(** PR-M (Leak 9): consecutive [provider_timeout] cycle FAILED strikes
     per keeper. The heartbeat loop routes the count through
     [Keeper_failure_policy] instead of treating the limit as keeper death.
     Reset on any successful turn.
@@ -204,14 +204,14 @@ val set_after_acquire_flag_hook_for_test :
     restart, callers may hydrate the first bump from persisted
     [Provider_timeout_loop] state so multi-process loops still reach
     the policy gate. *)
-val oas_timeout_budget_strike_limit : int
+val provider_timeout_strike_limit : int
 
-type oas_timeout_budget_strike_outcome =
-  | Oas_timeout_budget_warn
-  | Oas_timeout_budget_soft_backoff
+type provider_timeout_strike_outcome =
+  | Provider_timeout_warn
+  | Provider_timeout_soft_backoff
 
-val classify_oas_timeout_budget_strike :
-  strikes:int -> oas_timeout_budget_strike_outcome
+val classify_provider_timeout_strike :
+  strikes:int -> provider_timeout_strike_outcome
 
 val bump_budget_exhaustion_seeded :
   keeper_name:string -> prior_strikes:int -> int

--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -846,14 +846,15 @@ let reset_autonomous_completion_for_test () : unit =
   with_completion_table (fun () -> Hashtbl.reset last_autonomous_completion)
 ;;
 
-(* PR-M (Leak 9): consecutive [oas_timeout_budget] cycle FAILED strikes
+(* PR-M (Leak 9): consecutive [provider_timeout] cycle FAILED strikes
    per keeper.
 
-   [oas_timeout_budget] means the keeper cycle hit its structural budget
+   [provider_timeout] is the canonical policy surface for the legacy
+   structured timeout-budget path
    (see [Keeper_unified_turn.resolve_bounded_oas_timeout_budget_with_turn_budget]).
    Re-running on the same fiber gives the same context and the same
    shape of failure repeats, but provider/cascade budget pressure is not
-   keeper fiber corruption. Crossing [oas_timeout_budget_strike_limit]
+   keeper fiber corruption. Crossing [provider_timeout_strike_limit]
    is therefore routed through [Keeper_failure_policy] before any
    lifecycle effect is applied. Without independent keeper-liveness
    loss, the keeper stays alive while provider cooldown, cascade
@@ -864,16 +865,16 @@ let reset_autonomous_completion_for_test () : unit =
    process restart, callers may seed it from the persisted
    [Provider_timeout_loop] failure reason so restart cannot erase a
    partially observed loop. *)
-let oas_timeout_budget_strike_limit = 3
+let provider_timeout_strike_limit = 3
 
-type oas_timeout_budget_strike_outcome =
-  | Oas_timeout_budget_warn
-  | Oas_timeout_budget_soft_backoff
+type provider_timeout_strike_outcome =
+  | Provider_timeout_warn
+  | Provider_timeout_soft_backoff
 
-let classify_oas_timeout_budget_strike ~strikes =
-  if strikes >= oas_timeout_budget_strike_limit
-  then Oas_timeout_budget_soft_backoff
-  else Oas_timeout_budget_warn
+let classify_provider_timeout_strike ~strikes =
+  if strikes >= provider_timeout_strike_limit
+  then Provider_timeout_soft_backoff
+  else Provider_timeout_warn
 
 module Budget_strike_map = Map.Make (String)
 

--- a/lib/keeper/keeper_turn_slot.mli
+++ b/lib/keeper/keeper_turn_slot.mli
@@ -180,21 +180,21 @@ val reset_autonomous_completion_for_test : unit -> unit
 val set_after_acquire_flag_hook_for_test :
   (label:string -> keeper_name:string -> unit) option -> unit
 
-(** PR-M (Leak 9): consecutive [oas_timeout_budget] cycle FAILED strikes
+(** PR-M (Leak 9): consecutive [provider_timeout] cycle FAILED strikes
     per keeper. The heartbeat loop feeds this count into
     [Keeper_failure_policy] before choosing any lifecycle effect.
 
     Counts are stored in an in-process CAS map and can be seeded from the
     persisted [Provider_timeout_loop] failure reason on the first bump after
     restart or another process update. *)
-val oas_timeout_budget_strike_limit : int
+val provider_timeout_strike_limit : int
 
-type oas_timeout_budget_strike_outcome =
-  | Oas_timeout_budget_warn
-  | Oas_timeout_budget_soft_backoff
+type provider_timeout_strike_outcome =
+  | Provider_timeout_warn
+  | Provider_timeout_soft_backoff
 
-val classify_oas_timeout_budget_strike :
-  strikes:int -> oas_timeout_budget_strike_outcome
+val classify_provider_timeout_strike :
+  strikes:int -> provider_timeout_strike_outcome
 
 val bump_budget_exhaustion_seeded :
   keeper_name:string -> prior_strikes:int -> int

--- a/lib/prometheus.mli
+++ b/lib/prometheus.mli
@@ -170,9 +170,9 @@ include module type of Prometheus_cascade_metric_names
     - [meta_read_failed]: meta read I/O error — recovery skipped
     - [meta_write_failed]: meta write to clear [paused] failed *)
 
-(** PR-M (Leak 9): consecutive [oas_timeout_budget] cycle FAILED strikes.
+(** PR-M (Leak 9): consecutive [provider_timeout] cycle FAILED strikes.
     Labeled by [keeper] and [outcome]:
-    - [outcome=warn]: strike below [oas_timeout_budget_strike_limit];
+    - [outcome=warn]: strike below [provider_timeout_strike_limit];
       cycle continues.
     - [outcome=soft_backoff]: strike at or above limit; keeper fiber
       remains alive while provider/cascade cooldown and retry backoff

--- a/lib/prometheus_builtin_metric_names.mli
+++ b/lib/prometheus_builtin_metric_names.mli
@@ -171,9 +171,9 @@ include module type of Prometheus_cascade_metric_names
     - [meta_read_failed]: meta read I/O error — recovery skipped
     - [meta_write_failed]: meta write to clear [paused] failed *)
 
-(** PR-M (Leak 9): consecutive [oas_timeout_budget] cycle FAILED strikes.
+(** PR-M (Leak 9): consecutive [provider_timeout] cycle FAILED strikes.
     Labeled by [keeper] and [outcome]:
-    - [outcome=warn]: strike below [oas_timeout_budget_strike_limit];
+    - [outcome=warn]: strike below [provider_timeout_strike_limit];
       cycle continues, supervisor not yet involved.
     - [outcome=promote]: strike at or above limit; [Keeper_fiber_crash]
       raised so [Keeper_supervisor.sweep_and_recover] respawns the

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -47,15 +47,15 @@ let test_reset_clears () =
     (KK.peek_budget_exhaustion_for_test ~keeper_name:"reset")
 
 let test_strike_limit_is_soft_backoff () =
-  (match KK.classify_oas_timeout_budget_strike ~strikes:1 with
-   | KK.Oas_timeout_budget_warn -> ()
-   | KK.Oas_timeout_budget_soft_backoff -> failwith "strike 1 should warn");
+  (match KK.classify_provider_timeout_strike ~strikes:1 with
+   | KK.Provider_timeout_warn -> ()
+   | KK.Provider_timeout_soft_backoff -> failwith "strike 1 should warn");
   (match
-     KK.classify_oas_timeout_budget_strike
-       ~strikes:KK.oas_timeout_budget_strike_limit
+     KK.classify_provider_timeout_strike
+       ~strikes:KK.provider_timeout_strike_limit
    with
-   | KK.Oas_timeout_budget_soft_backoff -> ()
-   | KK.Oas_timeout_budget_warn ->
+   | KK.Provider_timeout_soft_backoff -> ()
+   | KK.Provider_timeout_warn ->
      failwith "strike limit should soft-backoff, not crash")
 
 let oas_timeout_budget_error ~phase =
@@ -88,7 +88,7 @@ let test_strike_limit_routes_through_policy_without_keeper_death () =
   let err = oas_timeout_budget_error ~phase:"stream_idle:streaming_thinking" in
   match
     KH.oas_timeout_budget_policy_decision
-      ~strikes:KK.oas_timeout_budget_strike_limit
+      ~strikes:KK.provider_timeout_strike_limit
       err
   with
   | None -> Alcotest.fail "expected OAS timeout budget policy decision"
@@ -148,7 +148,7 @@ let test_concurrent_bumps_do_not_lose_updates () =
       (KK.peek_budget_exhaustion_for_test ~keeper_name:keeper))
 
 let () =
-  Alcotest.run "oas_timeout_budget_strike"
+  Alcotest.run "provider_timeout_strike"
   [
     ( "strike ledger",
       [


### PR DESCRIPTION
## Summary
- rename the keeper timeout-budget strike limit/outcome/classifier to `provider_timeout_strike`
- keep the existing strike/backoff behavior while removing timeout-budget as the policy identity
- update metric comments and strike policy tests to point at the provider-timeout policy surface

## Validation
- Not run; user requested PR iteration without local validation.
