### PR TITLE
refactor(server): migrate memory_kind_usage to _result (RFC-0149 §3.1 PR-7)

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1197,24 +1197,32 @@ let handle_keeper_get_subroutes state req request reqd =
       let last_provider = `Null in
       (* Memory tier usage: join kind_caps (policy) with kind_counts (bank
          summary). Each kind reports used / cap so the dashboard tier
-         panel can render saturation without re-reading the memory file. *)
+         panel can render saturation without re-reading the memory file.
+
+         RFC-0149 §3.1: route the bank read through the typed Result
+         resolver.  [memory_kind_usage] keeps its [`List …] shape for
+         existing dashboard consumers
+         (dashboard/src/components/keeper-memory-tier-panel.ts,
+         dashboard/src/components/ide/ide-persistence-panel.ts).  The
+         typed [Keeper_memory_recall_exn_class.t] label rides on the
+         sibling [memory_kind_usage_error_class] field so an IO fault is
+         distinguishable from "memory bank empty / no kinds recorded".  *)
+      let used_by_kind, memory_kind_usage_error_class =
+        match meta with
+        | Ok (Some _) ->
+          (match
+             Keeper_memory.read_keeper_memory_summary_result
+               state.Mcp_server.room_config
+               ~name ~max_bytes:120_000 ~max_lines:200 ~recent_limit:0
+           with
+           | Ok summary ->
+             summary.Keeper_memory.kind_counts, None
+           | Error exn_class ->
+             [], Some (Keeper_memory_recall_exn_class.to_label exn_class))
+        | _ -> [], None
+      in
       let memory_kind_usage : Yojson.Safe.t =
         let caps = Keeper_memory_policy.kind_caps () in
-        let used_by_kind =
-          match meta with
-          | Ok (Some _) ->
-            (try
-              let summary =
-                Keeper_memory.read_keeper_memory_summary
-                  state.Mcp_server.room_config
-                  ~name ~max_bytes:120_000 ~max_lines:200 ~recent_limit:0
-              in
-              summary.Keeper_memory.kind_counts
-            with
-            | Eio.Cancel.Cancelled _ as e -> raise e
-            | _ -> [])
-          | _ -> []
-        in
         let lookup_used k =
           List.assoc_opt k used_by_kind |> Option.value ~default:0
         in
@@ -1225,6 +1233,11 @@ let handle_keeper_get_subroutes state req request reqd =
             "cap", `Int cap;
             "priority", `Int (Keeper_memory_policy.priority_for_kind ~kind);
           ]) caps)
+      in
+      let memory_kind_usage_error_class_json : Yojson.Safe.t =
+        match memory_kind_usage_error_class with
+        | Some label -> `String label
+        | None -> `Null
       in
       (* Compaction sub-FSM: only emit a diagram when the keeper is in
          the [Compacting] phase. The three nodes mirror
@@ -1259,6 +1272,7 @@ let handle_keeper_get_subroutes state req request reqd =
         "cascade_models", `List (List.map (fun s -> `String s) cascade_models);
         "last_provider_result", last_provider;
         "memory_kind_usage", memory_kind_usage;
+        "memory_kind_usage_error_class", memory_kind_usage_error_class_json;
       ] in
       Http.Response.json ~compress:true ~request:req
         (Yojson.Safe.to_string json) reqd


### PR DESCRIPTION
## Goal

Sunset the silent fallback at `lib/server/server_dashboard_http_keeper_api.ml:1208` (RFC-0149 §3.1, PR-7 of the caller-migration sprint).

## Change

Route the per-keeper memory-tier API loader through the Result-returning `read_keeper_memory_summary_result` (#17702).

`memory_kind_usage` **keeps its list shape** for backwards compatibility — 8 dashboard sites consume it as an array:

```
dashboard/src/api/keeper.ts:521
dashboard/src/components/keeper-memory-tier-panel.ts
dashboard/src/components/keeper-memory-tier-panel.test.ts
dashboard/src/components/ide/ide-persistence-panel.ts
dashboard/src/components/ide/ide-persistence-panel.a11y.test.ts
dashboard/src/components/ide/ide-persistence-panel.test.ts (×3 fixtures)
dashboard/src/components/ide/ide-shell.test.ts
```

Typed error class rides on a sibling field:

```diff
   "memory_kind_usage": memory_kind_usage;
+  "memory_kind_usage_error_class", memory_kind_usage_error_class_json;
```

## Operator distinction restored

| State                                  | `memory_kind_usage`           | `memory_kind_usage_error_class` |
|----------------------------------------|-------------------------------|----------------------------------|
| Ok, populated bank                     | kinds with real `used` counts | `null`                           |
| Ok, empty bank                         | all kinds `used: 0`           | `null`                           |
| Error (io / yojson_parse / type / other) | all kinds `used: 0`         | `"<label>"`                      |

Previously the bottom two rows were indistinguishable: the silent `try | _ -> []` collapsed both into the empty-counts state, and the read-side fallback counter (the §1 telemetry-as-fix artefact RFC-0149 sunsets) was the only signal.

## Out of scope

`meta` resolution (`match meta with | Ok (Some _) -> … | _ -> []`) is a separate failure boundary — preserved unchanged.

## Verification

* `dune build --root . @lib/server/all` → pass
* Full `dune build lib/` still red on `origin/main` (`keeper_status.ml:252` unbound — fix in #17723). Once #17723 merges, this PR will be rebased to a green base.

## Stack context

| PR | Status | Scope |
|----|--------|-------|
| #17670 | MERGED | PR-1 — `read_file_tail_lines_result` |
| #17681 | MERGED | PR-1.5 — unit tests |
| #17702 | MERGED | PR-2 — `read_keeper_memory_summary_result` |
| #17708 | MERGED | PR-3 — test sites |
| #17711 | MERGED | PR-4 — `keeper_status.ml` |
| #17717 | MERGED | PR-5 — `dashboard_http_keeper.ml` |
| #17724 | Draft  | PR-6 — `server_dashboard_http_memory_subsystems.ml` |
| **this** | Draft | **PR-7 — `server_dashboard_http_keeper_api.ml`** |
| (next) | — | PR-8 — `keeper_status_detail.ml:375` (record surface) |
| (next) | — | PR-closeout — delete legacy silent fallback + counter+WARN |

## Anti-pattern self-check

- §1 telemetry-as-fix? No — silent `try | _ -> []` is *removed*; sibling typed JSON field replaces the dropped counter signal. RFC-0149 directly targets this swap.
- §2 substring classifier? No — uses `Keeper_memory_recall_exn_class.t` (closed 4-value sum).
- §3 N-of-M? Tracked openly — PR-7 of N in the stack table above; closeout PR sunsets the legacy helper after PR-8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>