### PR TITLE
fix(keeper): rename provider timeout observation API

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -102,23 +102,23 @@ let record_cascade_backpressure_observation =
   Observations.record_cascade_backpressure_observation
 ;;
 
-let oas_timeout_budget_observation_reasons =
-  Observations.oas_timeout_budget_observation_reasons
+let provider_timeout_observation_reasons =
+  Observations.provider_timeout_observation_reasons
 ;;
 
-let record_oas_timeout_budget_observation =
-  Observations.record_oas_timeout_budget_observation
+let record_provider_timeout_observation =
+  Observations.record_provider_timeout_observation
 ;;
 
-let clear_oas_timeout_budget_failure_reason =
-  Observations.clear_oas_timeout_budget_failure_reason
+let clear_provider_timeout_failure_reason =
+  Observations.clear_provider_timeout_failure_reason
 ;;
 
-let prior_oas_timeout_budget_strikes =
-  Observations.prior_oas_timeout_budget_strikes
+let prior_provider_timeout_strikes =
+  Observations.prior_provider_timeout_strikes
 ;;
 
-let is_oas_timeout_budget_error = Observations.is_oas_timeout_budget_error
+let is_provider_timeout_error = Observations.is_provider_timeout_error
 
 let timeout_phase_of_oas_timeout_budget_phase =
   Observations.timeout_phase_of_oas_timeout_budget_phase

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -124,9 +124,9 @@ val semaphore_wait_timeout_blocker_class :
 val semaphore_wait_timeout_diagnostics :
   cascade_name:string -> Keeper_turn_slot.semaphore_wait_timeout -> string * string
 
-val oas_timeout_budget_observation_reasons : string list
+val provider_timeout_observation_reasons : string list
 
-val record_oas_timeout_budget_observation :
+val record_provider_timeout_observation :
   base_path:string -> keeper_name:string -> unit
 
 val oas_timeout_budget_policy_decision :

--- a/lib/keeper/keeper_heartbeat_loop_cycle_with_slot.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle_with_slot.ml
@@ -13,8 +13,8 @@
       Exception] + raises [Keeper_registry.Keeper_fiber_crash] for
       the supervisor to handle.
 
-    - Legacy timeout-budget errors → provider-timeout strike-counter bump (seeded from
-      [prior_oas_timeout_budget_strikes]) + persistent failure
+    - Provider-timeout errors → provider-timeout strike-counter bump (seeded from
+      [prior_provider_timeout_strikes]) + persistent failure
       reason + observation recording + [Keeper_failure_policy.decide]
       kill/keep decision + [metric_keeper_provider_timeout_strike]
       tick with policy-derived outcome label.
@@ -23,8 +23,8 @@
       [metric_keeper_meta_read_failures] on read failure +
       Site=none_after_failure or error_after_failure label).
 
-    - [Ok updated] → reset budget exhaustion + clear OAS timeout
-      budget failure reason + return updated meta.
+    - [Ok updated] → reset budget exhaustion + clear provider-timeout
+      failure reason + return updated meta.
 
     Pure helper move — no callback injection, all references reach
     external modules (Keeper_unified_turn, Agent_sdk, Log, Prometheus,
@@ -83,12 +83,12 @@ let run_keeper_cycle_with_slot
         (Some
            (Keeper_registry.Exception (Printf.sprintf "fatal environment error: %s" e_str)));
       raise Keeper_registry.Keeper_fiber_crash);
-    if Observations.is_oas_timeout_budget_error err
+    if Observations.is_provider_timeout_error err
     then (
       let keeper_name = meta_after_cursor_persist.name in
       Keeper_turn_slot.reset_budget_exhaustion ~keeper_name;
       Log.Keeper.warn
-        "%s: legacy oas_timeout_budget observed; preserving original turn \
+        "%s: provider_timeout observed; preserving original turn \
          failure without Provider_timeout_loop latch"
         keeper_name);
     (match read_meta ctx.config meta_after_cursor_persist.name with
@@ -116,7 +116,7 @@ let run_keeper_cycle_with_slot
        meta_after_cursor_persist)
   | Ok updated ->
     Keeper_turn_slot.reset_budget_exhaustion ~keeper_name:meta_after_cursor_persist.name;
-    Observations.clear_oas_timeout_budget_failure_reason
+    Observations.clear_provider_timeout_failure_reason
       ~base_path:ctx.config.base_path
       ~keeper_name:meta_after_cursor_persist.name;
     updated

--- a/lib/keeper/keeper_heartbeat_loop_observations.ml
+++ b/lib/keeper/keeper_heartbeat_loop_observations.ml
@@ -148,19 +148,19 @@ let record_cascade_backpressure_observation ~base_path ~keeper_name ~reason =
   Keeper_registry.touch_last_turn_ts ~base_path keeper_name
 ;;
 
-let oas_timeout_budget_observation_reasons =
+let provider_timeout_observation_reasons =
   [ "provider_runtime_error"; "provider_timeout"; "keeper_turn_retry_backoff" ]
 ;;
 
-let record_oas_timeout_budget_observation ~base_path ~keeper_name =
+let record_provider_timeout_observation ~base_path ~keeper_name =
   Keeper_registry.record_skip_reasons
     ~base_path
     keeper_name
-    ~reasons:oas_timeout_budget_observation_reasons;
+    ~reasons:provider_timeout_observation_reasons;
   Keeper_registry.touch_last_turn_ts ~base_path keeper_name
 ;;
 
-let clear_oas_timeout_budget_failure_reason ~base_path ~keeper_name =
+let clear_provider_timeout_failure_reason ~base_path ~keeper_name =
   match Keeper_registry.get ~base_path keeper_name with
   | Some
       { Keeper_registry.last_failure_reason =
@@ -170,7 +170,7 @@ let clear_oas_timeout_budget_failure_reason ~base_path ~keeper_name =
   | _ -> ()
 ;;
 
-let prior_oas_timeout_budget_strikes ~base_path ~keeper_name =
+let prior_provider_timeout_strikes ~base_path ~keeper_name =
   match Keeper_registry.get ~base_path keeper_name with
   | Some
       { Keeper_registry.last_failure_reason =
@@ -180,7 +180,7 @@ let prior_oas_timeout_budget_strikes ~base_path ~keeper_name =
   | _ -> 0
 ;;
 
-let is_oas_timeout_budget_error (err : Agent_sdk.Error.sdk_error) =
+let is_provider_timeout_error (err : Agent_sdk.Error.sdk_error) =
   (* Enumerate every [masc_internal_error] variant + [None] so the
      compiler flags any new constructor here. Mirrors the fix in
      [degraded_retry_bypasses_slot_phase_guard] (PR #14716) and

--- a/lib/keeper/keeper_heartbeat_loop_observations.mli
+++ b/lib/keeper/keeper_heartbeat_loop_observations.mli
@@ -42,24 +42,24 @@ val record_cascade_backpressure_observation
   -> reason:string
   -> unit
 
-val oas_timeout_budget_observation_reasons : string list
+val provider_timeout_observation_reasons : string list
 
-val record_oas_timeout_budget_observation
+val record_provider_timeout_observation
   :  base_path:string
   -> keeper_name:string
   -> unit
 
-val clear_oas_timeout_budget_failure_reason
+val clear_provider_timeout_failure_reason
   :  base_path:string
   -> keeper_name:string
   -> unit
 
-val prior_oas_timeout_budget_strikes
+val prior_provider_timeout_strikes
   :  base_path:string
   -> keeper_name:string
   -> int
 
-val is_oas_timeout_budget_error : Agent_sdk.Error.sdk_error -> bool
+val is_provider_timeout_error : Agent_sdk.Error.sdk_error -> bool
 val timeout_phase_of_oas_timeout_budget_phase : string -> Keeper_failure_policy.timeout_phase option
 
 val oas_timeout_budget_policy_decision

--- a/lib/keeper/keeper_stale_watchdog.ml
+++ b/lib/keeper/keeper_stale_watchdog.ml
@@ -281,7 +281,7 @@ let pending_oas_timeout_budget_count
   let is_timeout_budget_observation_reason reason =
     List.exists
       (String.equal reason)
-      Keeper_heartbeat_loop.oas_timeout_budget_observation_reasons
+      Keeper_heartbeat_loop.provider_timeout_observation_reasons
   in
   let has_timeout_observation =
     match entry.last_skip_observation with

--- a/test/test_keeper_semaphore_wait_counter.ml
+++ b/test/test_keeper_semaphore_wait_counter.ml
@@ -444,7 +444,7 @@ let test_wait_observation_updates_registry_skip_stamp () =
       | Some _ -> Alcotest.fail "last_skip_observation was not stamped"
       | None -> Alcotest.fail "registered keeper missing")
 
-let test_oas_timeout_budget_observation_reason_labels () =
+let test_provider_timeout_observation_reason_labels () =
   Alcotest.(check (list string))
     "provider timeout watchdog reasons"
     [
@@ -452,9 +452,9 @@ let test_oas_timeout_budget_observation_reason_labels () =
       "provider_timeout";
       "keeper_turn_retry_backoff";
     ]
-    Masc_mcp.Keeper_heartbeat_loop.oas_timeout_budget_observation_reasons
+    Masc_mcp.Keeper_heartbeat_loop.provider_timeout_observation_reasons
 
-let test_oas_timeout_budget_observation_updates_registry () =
+let test_provider_timeout_observation_updates_registry () =
   let base_path =
     Filename.concat (Filename.get_temp_dir_name ())
       (Printf.sprintf "masc-oas-timeout-observation-%d" (Unix.getpid ()))
@@ -472,7 +472,7 @@ let test_oas_timeout_budget_observation_updates_registry () =
         | Some entry -> entry.meta.runtime.usage.last_turn_ts
         | None -> Alcotest.fail "registered keeper missing before observation"
       in
-      Masc_mcp.Keeper_heartbeat_loop.record_oas_timeout_budget_observation
+      Masc_mcp.Keeper_heartbeat_loop.record_provider_timeout_observation
         ~base_path
         ~keeper_name:keeper;
       match Masc_mcp.Keeper_registry.get ~base_path keeper with
@@ -480,7 +480,7 @@ let test_oas_timeout_budget_observation_updates_registry () =
                meta = updated_meta; _ } ->
         Alcotest.(check (list string))
           "provider timeout stamped for watchdog routing"
-          Masc_mcp.Keeper_heartbeat_loop.oas_timeout_budget_observation_reasons
+          Masc_mcp.Keeper_heartbeat_loop.provider_timeout_observation_reasons
           reasons;
         Alcotest.(check bool)
           "last_turn_ts touched"
@@ -529,8 +529,8 @@ let () =
       Alcotest.test_case "registry skip stamp is updated" `Quick
         test_wait_observation_updates_registry_skip_stamp;
       Alcotest.test_case "oas timeout labels are stable" `Quick
-        test_oas_timeout_budget_observation_reason_labels;
+        test_provider_timeout_observation_reason_labels;
       Alcotest.test_case "oas timeout registry stamp is updated" `Quick
-        test_oas_timeout_budget_observation_updates_registry;
+        test_provider_timeout_observation_updates_registry;
     ];
   ]


### PR DESCRIPTION
## Summary
- rename heartbeat-loop provider-timeout observation helpers away from `oas_timeout_budget_*`
- update stale-watchdog and keepalive-cycle call sites to use provider-timeout observation names
- keep the existing registry skip reasons unchanged: `provider_runtime_error`, `provider_timeout`, `keeper_turn_retry_backoff`

## Validation
- Not run; user requested PR iteration without local validation.
