### PR TITLE
fix(keeper): restore list memory summary binding

### DIFF
--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -91,15 +91,28 @@ let handle_keeper_list ctx args : tool_result =
              [memory_recent_note] field as a typed unavailable marker
              instead of being indistinguishable from "no recorded notes".
              [None] stays reserved for "Ok summary with empty recent_notes". *)
+          let memory_summary_result =
+            read_keeper_memory_summary_result
+              ctx.config
+              ~name:m.name
+              ~max_bytes:120000
+              ~max_lines:180
+              ~recent_limit:3
+          in
+          let memory_bank_summary =
+            match memory_summary_result with
+            | Ok summary -> summary
+            | Error _ ->
+              {
+                total_notes = 0;
+                last_ts_unix = 0.0;
+                top_kind = None;
+                kind_counts = [];
+                recent_notes = [];
+              }
+          in
           let memory_recent_note =
-            match
-              read_keeper_memory_summary_result
-                ctx.config
-                ~name:m.name
-                ~max_bytes:120000
-                ~max_lines:180
-                ~recent_limit:3
-            with
+            match memory_summary_result with
             | Ok summary ->
               (match summary.recent_notes with
                | row :: _ -> Some row.text


### PR DESCRIPTION
## Summary
- restore the missing detailed keeper-list memory summary binding
- reuse the typed memory summary result for both memory_bank JSON and memory_recent_note
- keep read failures represented as an empty summary while preserving the unavailable recent-note marker

## Verification
- ocamlformat --check lib/keeper/keeper_status.ml
- git diff --check
- DUNE_BUILD_DIR=_build_keeper_status_fix dune build --root . --display=quiet lib/keeper/keeper_status.ml
- DUNE_BUILD_DIR=_build_keeper_status_fix dune build --root . --display=quiet test/test_keeper_unified.exe