### PR TITLE
fix(keeper): merge timeout budget policy into provider timeout

### DIFF
--- a/lib/keeper/keeper_failure_policy.ml
+++ b/lib/keeper/keeper_failure_policy.ml
@@ -144,10 +144,6 @@ type failure =
   | Workflow_rejection of { rule_id : string option }
   | Provider_timeout of
       { phase : timeout_phase option
-      ; liveness : liveness_evidence
-      }
-  | Oas_timeout_budget of
-      { phase : timeout_phase option
       ; strikes : int option
       ; liveness : liveness_evidence
       }
@@ -284,7 +280,27 @@ let decide = function
       ~operator_action:Fix_invocation
       ~keeper_death_allowed:false
       ~reason
-  | Provider_timeout { phase = Some (Stream_idle state); liveness = _ } ->
+  | Provider_timeout { phase; strikes = (Some _ as strikes); liveness } ->
+    let lifecycle_effect, circuit_effect, operator_action, reason =
+      provider_timeout_policy_effect ~phase ~strikes ~liveness
+    in
+    let reason =
+      match phase with
+      | Some phase -> reason ^ ":" ^ timeout_phase_to_label phase
+      | None -> reason
+    in
+    let failure_scope =
+      if liveness_is_lost liveness then Keeper_liveness_scope else Provider_scope
+    in
+    make_decision
+      ~failure_scope
+      ~lifecycle_effect
+      ~circuit_effect
+      ~operator_action
+      ~keeper_death_allowed:false
+      ~reason
+  | Provider_timeout
+      { phase = Some (Stream_idle state); strikes = None; liveness = _ } ->
     let has_activity = stream_idle_state_is_activity state in
     make_decision
       ~failure_scope:Provider_scope
@@ -296,7 +312,8 @@ let decide = function
         (if has_activity
          then "provider_stream_idle_active:" ^ stream_idle_state_to_label state
          else "provider_stream_idle:" ^ stream_idle_state_to_label state)
-  | Provider_timeout { phase = Some Capacity_backpressure; liveness = _ } ->
+  | Provider_timeout
+      { phase = Some Capacity_backpressure; strikes = None; liveness = _ } ->
     make_decision
       ~failure_scope:Provider_scope
       ~lifecycle_effect:Soft_fail_turn
@@ -304,7 +321,7 @@ let decide = function
       ~operator_action:Reroute_or_tune_provider
       ~keeper_death_allowed:false
       ~reason:"provider_timeout:capacity_backpressure"
-  | Provider_timeout { phase; liveness = _ } ->
+  | Provider_timeout { phase; strikes = None; liveness = _ } ->
     let reason =
       match phase with
       | Some phase -> "provider_timeout:" ^ timeout_phase_to_label phase
@@ -315,22 +332,6 @@ let decide = function
       ~lifecycle_effect:Soft_fail_turn
       ~circuit_effect:Provider_cooldown
       ~operator_action:Inspect_provider_stream
-      ~keeper_death_allowed:false
-      ~reason
-  | Oas_timeout_budget { phase; strikes; liveness } ->
-    let lifecycle_effect, circuit_effect, operator_action, reason =
-      provider_timeout_policy_effect ~phase ~strikes ~liveness
-    in
-    let reason =
-      match phase with
-      | Some phase -> reason ^ ":" ^ timeout_phase_to_label phase
-      | None -> reason
-    in
-    make_decision
-      ~failure_scope:Turn_scope
-      ~lifecycle_effect
-      ~circuit_effect
-      ~operator_action
       ~keeper_death_allowed:false
       ~reason
   | Transient_provider_failure ->

--- a/lib/keeper/keeper_failure_policy.mli
+++ b/lib/keeper/keeper_failure_policy.mli
@@ -51,13 +51,6 @@ type failure =
   | Workflow_rejection of { rule_id : string option }
   | Provider_timeout of
       { phase : timeout_phase option
-      ; liveness : liveness_evidence
-      }
-  (** Legacy OAS timeout-budget ingress. Decisions normalize this to
-      provider-timeout or keeper-liveness ownership; callers must not
-      project it back as a distinct operator-facing root cause. *)
-  | Oas_timeout_budget of
-      { phase : timeout_phase option
       ; strikes : int option
       ; liveness : liveness_evidence
       }

--- a/lib/keeper/keeper_heartbeat_loop_observations.ml
+++ b/lib/keeper/keeper_heartbeat_loop_observations.ml
@@ -227,7 +227,7 @@ let oas_timeout_budget_policy_decision
   | Some (Keeper_turn_driver.Oas_timeout_budget { phase; _ }) ->
     Some
       (Keeper_failure_policy.decide
-         (Keeper_failure_policy.Oas_timeout_budget
+         (Keeper_failure_policy.Provider_timeout
             { phase = timeout_phase_of_oas_timeout_budget_phase phase
             ; strikes = Some strikes
             ; liveness = Keeper_failure_policy.Recent_heartbeat

--- a/lib/keeper/keeper_supervisor_pause_policy.ml
+++ b/lib/keeper/keeper_supervisor_pause_policy.ml
@@ -192,7 +192,7 @@ let failure_reason_policy_decision
   | Some (Keeper_registry.Provider_timeout_loop { count }) ->
     Some
       (Keeper_failure_policy.decide
-         (Keeper_failure_policy.Oas_timeout_budget
+         (Keeper_failure_policy.Provider_timeout
             { phase = None
             ; strikes = Some count
             ; liveness = Keeper_failure_policy.Watchdog_stale

--- a/test/test_keeper_failure_policy.ml
+++ b/test/test_keeper_failure_policy.ml
@@ -87,6 +87,7 @@ let test_provider_capacity_backpressure_reroutes_provider () =
       (Policy.Provider_timeout
          {
            phase = Some Policy.Capacity_backpressure;
+           strikes = None;
            liveness = Policy.Recent_heartbeat;
          })
   in
@@ -97,44 +98,44 @@ let test_provider_capacity_backpressure_reroutes_provider () =
   check string "reason" "provider_timeout:capacity_backpressure" decision.reason
 ;;
 
-let test_legacy_timeout_budget_capacity_backpressure_reroutes_provider () =
+let test_provider_timeout_strike_capacity_backpressure_reroutes_provider () =
   let decision =
     Policy.decide
-      (Policy.Oas_timeout_budget
+      (Policy.Provider_timeout
          {
            phase = Some Policy.Capacity_backpressure;
            strikes = Some 1;
            liveness = Policy.Recent_heartbeat;
          })
   in
-  check_scope "scope" "turn" decision.failure_scope;
+  check_scope "scope" "provider" decision.failure_scope;
   check_lifecycle "lifecycle" "soft_fail_turn" decision.lifecycle_effect;
   check_circuit "circuit" "provider_cooldown" decision.circuit_effect;
   check_action "action" "reroute_or_tune_provider" decision.operator_action;
   check string "reason" "provider_timeout:capacity_backpressure" decision.reason
 ;;
 
-let test_oas_budget_loop_with_live_keeper_pauses_work_not_keeper () =
+let test_provider_timeout_loop_with_live_keeper_pauses_work_not_keeper () =
   let decision =
     Policy.decide
-      (Policy.Oas_timeout_budget
+      (Policy.Provider_timeout
          {
            phase = Some Policy.Caller_budget;
            strikes = Some 6;
            liveness = Policy.Recent_heartbeat;
          })
   in
-  check_scope "scope" "turn" decision.failure_scope;
+  check_scope "scope" "provider" decision.failure_scope;
   check_lifecycle "lifecycle" "pause_current_work" decision.lifecycle_effect;
   check_circuit "circuit" "provider_cooldown" decision.circuit_effect;
   check_action "action" "reroute_or_tune_provider" decision.operator_action;
   check bool "keeper death not allowed" false (Policy.should_kill_keeper decision)
 ;;
 
-let test_oas_budget_loop_with_lost_liveness_pauses_keeper_without_death () =
+let test_provider_timeout_loop_with_lost_liveness_pauses_keeper_without_death () =
   let decision =
     Policy.decide
-      (Policy.Oas_timeout_budget
+      (Policy.Provider_timeout
          {
            phase = Some (Policy.Stream_idle Policy.Awaiting_first_event);
            strikes = Some 3;
@@ -205,11 +206,11 @@ let () =
           test_case "provider capacity backpressure reroutes provider" `Quick
             test_provider_capacity_backpressure_reroutes_provider;
           test_case "legacy timeout-budget capacity backpressure reroutes provider" `Quick
-            test_legacy_timeout_budget_capacity_backpressure_reroutes_provider;
+            test_provider_timeout_strike_capacity_backpressure_reroutes_provider;
           test_case "live OAS budget loop pauses work, not keeper" `Quick
-            test_oas_budget_loop_with_live_keeper_pauses_work_not_keeper;
+            test_provider_timeout_loop_with_live_keeper_pauses_work_not_keeper;
           test_case "lost-liveness OAS budget loop pauses keeper without death" `Quick
-            test_oas_budget_loop_with_lost_liveness_pauses_keeper_without_death;
+            test_provider_timeout_loop_with_lost_liveness_pauses_keeper_without_death;
           test_case "workflow rejection skips keeper circuit" `Quick
             test_workflow_rejection_skips_keeper_circuit;
           test_case "keeper death is liveness-only" `Quick


### PR DESCRIPTION
## Summary
- remove the separate `Keeper_failure_policy.Oas_timeout_budget` failure variant
- carry strike evidence on `Provider_timeout` so timeout-loop decisions derive from the provider-timeout root cause
- update heartbeat/supervisor policy call sites and policy tests to stop treating timeout-budget as a separate policy input

## Validation
- Not run; user requested PR iteration without local validation.
