### PR TITLE
refactor(keeper): migrate keeper_status_detail memory_bank to _result (RFC-0149 §3.1 PR-8)

### DIFF
--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -369,28 +369,45 @@ let handle_keeper_status ctx args : tool_result =
              in
              find_latest (List.rev metrics_window_lines)
          in
-         let memory_bank_summary =
+         (* RFC-0149 §3.1 — typed Result resolver.  The companion
+            [memory_bank_error_class] travels alongside the summary so
+            the dashboard detail surface can distinguish an empty
+            memory bank ([Ok summary], no recent rows) from an IO
+            fault ([Error class]) instead of collapsing both into the
+            same empty-shape record via the legacy silent fallback. *)
+         let empty_memory_bank_summary
+           : Keeper_memory_policy.keeper_memory_summary
+           =
+           { total_notes = 0
+           ; last_ts_unix = 0.0
+           ; top_kind = None
+           ; kind_counts = []
+           ; recent_notes = []
+           }
+         in
+         let memory_bank_summary, memory_bank_error_class =
            if include_memory_bank then
-             let summary =
-               read_keeper_memory_summary
+             match
+               read_keeper_memory_summary_result
                  ctx.config
                  ~name:m.name
                  ~max_bytes:tail_bytes
                  ~max_lines:(max (tail_turns * 10) 400)
                  ~recent_limit:8
-             in
-             {
-               summary with
-               recent_notes = apply_tail_order tail_order summary.recent_notes;
-             }
+             with
+             | Ok summary ->
+               let summary =
+                 { summary with
+                   recent_notes =
+                     apply_tail_order tail_order summary.recent_notes
+                 }
+               in
+               summary, None
+             | Error exn_class ->
+               ( empty_memory_bank_summary
+               , Some (Keeper_memory_recall_exn_class.to_label exn_class) )
            else
-             {
-               total_notes = 0;
-               last_ts_unix = 0.0;
-               top_kind = None;
-               kind_counts = [];
-               recent_notes = [];
-             }
+             empty_memory_bank_summary, None
          in
 
          let history_filter_fragments =
@@ -863,6 +880,10 @@ let handle_keeper_status ctx args : tool_result =
            ("skill_route", Json_util.option_to_yojson Fun.id last_skill_route);
            ("metrics_overview", metrics_summary_to_json metrics_overview);
            ("memory_bank", memory_summary_to_json memory_bank_summary);
+           ("memory_bank_error_class",
+             match memory_bank_error_class with
+             | Some label -> `String label
+             | None -> `Null);
            ("generation_lineage", generation_lineage);
            ("metrics_tail", metrics_tail);
            ("history_tail", history_tail);


### PR DESCRIPTION
## Goal

Sunset the silent-fallback path at `lib/keeper/keeper_status_detail.ml:375` (RFC-0149 §3.1, PR-8 of the caller-migration sprint — the last production caller before closeout).

## Change

Route the detail-surface memory-bank read through the Result-returning `read_keeper_memory_summary_result` (#17702).  The detail JSON object gains a sibling typed-error field:

```diff
   ("memory_bank", memory_summary_to_json memory_bank_summary);
+  ("memory_bank_error_class",
+    match memory_bank_error_class with
+    | Some label -> `String label
+    | None -> `Null);
```

## States

| `include_memory_bank` | Result        | `memory_bank` JSON | `memory_bank_error_class` |
|-----------------------|---------------|--------------------|----------------------------|
| `false`               | (not called)  | empty-shape        | `null`                    |
| `true`                | `Ok summary`  | real summary       | `null`                    |
| `true`                | `Error class` | empty-shape        | `"<label>"`               |

The third row was previously indistinguishable from the second — the silent fallback inside `read_file_tail_lines` collapsed both into the empty-summary state.  Only the read-side fallback counter — the §1 telemetry-as-fix artefact RFC-0149 sunsets — disambiguated them.

`error_class` cardinality is bounded by `Keeper_memory_recall_exn_class.t`: `yojson_parse_error | io_error | type_error | other`.

## Out of scope

`metrics_window_lines`, `history_tail`, and other detail surfaces use their own readers and are not §3.1 targets.

## Verification

* `dune build --root . lib/keeper/` → pass
* Full `dune build lib/` is currently red on `origin/main` (`keeper_status.ml:252` unbound, unrelated to this diff — fix in #17723). Once #17723 merges, this PR will be rebased to a green base.

## Stack context

| PR | Status | Scope |
|----|--------|-------|
| #17670 | MERGED | PR-1 — `read_file_tail_lines_result` |
| #17681 | MERGED | PR-1.5 — unit tests |
| #17702 | MERGED | PR-2 — `read_keeper_memory_summary_result` |
| #17708 | MERGED | PR-3 — test sites |
| #17711 | MERGED | PR-4 — `keeper_status.ml` |
| #17717 | MERGED | PR-5 — `dashboard_http_keeper.ml` |
| #17723 | Draft  | hotfix — `keeper_status.ml` binding restore |
| #17724 | Draft  | PR-6 — `server_dashboard_http_memory_subsystems.ml` |
| #17728 | Draft  | PR-7 — `server_dashboard_http_keeper_api.ml` |
| **this** | Draft | **PR-8 — `keeper_status_detail.ml`** |
| (next) | — | PR-closeout — delete legacy silent fallback + counter+WARN |

PR-8 closes the **production-caller sweep** for the `read_keeper_memory_summary` migration arm of §3.1.  After PR-8 merges, the legacy helper has no live consumers, and the closeout PR can delete it together with the read-side fallback counter/WARN.

## Anti-pattern self-check

- §1 telemetry-as-fix? No — silent fallback is *removed* from the caller path; sibling typed JSON field replaces the dropped counter signal.
- §2 substring classifier? No — uses `Keeper_memory_recall_exn_class.t` (closed 4-value sum).
- §3 N-of-M? Tracked openly — PR-8 of N in the stack table above, with closeout PR-9 next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>