### PR TITLE
fix(keeper): rename provider timeout budget producer

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -759,7 +759,7 @@ let review
                   | Keeper_turn_driver.Admission_queue_timeout _
                   | Keeper_turn_driver.Admission_queue_rejected _
                   | Keeper_turn_driver.Turn_timeout _
-                  | Keeper_turn_driver.Oas_timeout_budget _
+                  | Keeper_turn_driver.Provider_timeout _
                   | Keeper_turn_driver.Max_tokens_ceiling_violation _
                   | Keeper_turn_driver.Ambiguous_post_commit _
                   (* RFC-0159 Phase A: opaque internal failures. *)

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -224,7 +224,7 @@ let is_auto_recoverable_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error
   | Some (Keeper_turn_driver.Admission_queue_rejected _)
   | Some (Keeper_turn_driver.Admission_queue_timeout _)
   | Some (Keeper_turn_driver.Turn_timeout _)
-  | Some (Keeper_turn_driver.Oas_timeout_budget _)
+  | Some (Keeper_turn_driver.Provider_timeout _)
   | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
   | Some (Keeper_turn_driver.Ambiguous_post_commit _)
   (* RFC-0159 Phase A: opaque internal failures. *)
@@ -244,7 +244,7 @@ let is_resumable_cli_session_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Some (Keeper_turn_driver.Admission_queue_timeout _)
   | Some (Keeper_turn_driver.Admission_queue_rejected _)
   | Some (Keeper_turn_driver.Turn_timeout _)
-  | Some (Keeper_turn_driver.Oas_timeout_budget _)
+  | Some (Keeper_turn_driver.Provider_timeout _)
   | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
   | Some (Keeper_turn_driver.Ambiguous_post_commit _)
   (* RFC-0159 Phase A: opaque internal failures. *)
@@ -359,7 +359,7 @@ let degraded_retry_after_recoverable_error
         local_recovery_retry Resumable_cli_session
     | Some (Keeper_turn_driver.Admission_queue_timeout _) ->
         local_recovery_retry Admission_queue_timeout
-    | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
+    | Some (Keeper_turn_driver.Provider_timeout _) ->
         local_recovery_retry Provider_timeout
     | Some (Keeper_turn_driver.Turn_timeout _) ->
         local_recovery_retry Turn_timeout
@@ -415,7 +415,7 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
         Some Resumable_cli_session
     | Some (Keeper_turn_driver.Admission_queue_timeout _) ->
         Some Admission_queue_timeout
-    | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
+    | Some (Keeper_turn_driver.Provider_timeout _) ->
         Some Provider_timeout
     | Some (Keeper_turn_driver.Turn_timeout _) ->
         Some Turn_timeout
@@ -726,7 +726,7 @@ let is_auto_recoverable_turn_error (err : Agent_sdk.Error.sdk_error) : bool =
 
 let should_warn_keeper_cycle_failed (err : Agent_sdk.Error.sdk_error) : bool =
   match Keeper_turn_driver.classify_masc_internal_error err with
-  | Some (Keeper_turn_driver.Oas_timeout_budget _) -> true
+  | Some (Keeper_turn_driver.Provider_timeout _) -> true
   | Some (Keeper_turn_driver.Capacity_backpressure _) -> true
   | Some (Keeper_turn_driver.Cascade_exhausted _)
   | Some (Keeper_turn_driver.Resumable_cli_session _)
@@ -783,7 +783,7 @@ let is_ambiguous_side_effect_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Some (Keeper_turn_driver.Admission_queue_rejected _)
   | Some (Keeper_turn_driver.Admission_queue_timeout _)
   | Some (Keeper_turn_driver.Turn_timeout _)
-  | Some (Keeper_turn_driver.Oas_timeout_budget _)
+  | Some (Keeper_turn_driver.Provider_timeout _)
   | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
   (* RFC-0159 Phase A: opaque internal failures are unambiguous failures. *)
   | Some (Keeper_turn_driver.Internal_unhandled_exception _)
@@ -962,7 +962,7 @@ let is_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Some (Keeper_turn_driver.Capacity_backpressure _)
   | Some (Keeper_turn_driver.Admission_queue_timeout _)
   | Some (Keeper_turn_driver.Admission_queue_rejected _)
-  | Some (Keeper_turn_driver.Oas_timeout_budget _)
+  | Some (Keeper_turn_driver.Provider_timeout _)
   | Some (Keeper_turn_driver.Turn_timeout _)
   | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
   | Some (Keeper_turn_driver.Ambiguous_post_commit _)

--- a/lib/keeper/keeper_heartbeat_loop_observations.ml
+++ b/lib/keeper/keeper_heartbeat_loop_observations.ml
@@ -188,7 +188,7 @@ let is_provider_timeout_error (err : Agent_sdk.Error.sdk_error) =
      both sweeps — the same predicate shape exists in three places
      and only this one still had a catch-all. *)
   match Keeper_turn_driver.classify_masc_internal_error err with
-  | Some (Keeper_turn_driver.Oas_timeout_budget _) -> true
+  | Some (Keeper_turn_driver.Provider_timeout _) -> true
   | Some
       ( Keeper_turn_driver.Cascade_exhausted _
       | Keeper_turn_driver.Capacity_backpressure _
@@ -224,7 +224,7 @@ let oas_timeout_budget_policy_decision
   : Keeper_failure_policy.decision option
   =
   match Keeper_turn_driver.classify_masc_internal_error err with
-  | Some (Keeper_turn_driver.Oas_timeout_budget { phase; _ }) ->
+  | Some (Keeper_turn_driver.Provider_timeout { phase; _ }) ->
     Some
       (Keeper_failure_policy.decide
          (Keeper_failure_policy.Provider_timeout

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -197,7 +197,7 @@ let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class
   | Some (Keeper_turn_driver.Admission_queue_timeout _) ->
     Some Admission_queue_wait_timeout
   | Some (Keeper_turn_driver.Admission_queue_rejected _) -> None
-  | Some (Keeper_turn_driver.Oas_timeout_budget _) -> Some Turn_timeout
+  | Some (Keeper_turn_driver.Provider_timeout _) -> Some Turn_timeout
   | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _) -> None
   | Some (Keeper_turn_driver.Turn_timeout _) -> Some Turn_timeout
   | Some (Keeper_turn_driver.Ambiguous_post_commit { is_timeout; _ }) ->

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -1,5 +1,5 @@
 (* Keeper_turn_cascade_budget — cascade execution types, fail-open rotation,
-   OAS timeout budget resolution, context overflow observation, keeper pause/resume
+   provider timeout budget resolution, context overflow observation, keeper pause/resume
    sync, partial-commit continue gate, and context budget resolution.
 
    Extracted from keeper_unified_turn.ml (L501-1079) during the god-file split. *)
@@ -53,11 +53,11 @@ let record_turn_failure_stress =
    holds and the halving workaround was killing healthy slow
    streams (14-event 307.5s cluster, 2026-05-17 fleet).
 *)
-let oas_timeout_guard_sec = 15.0
+let provider_timeout_guard_sec = 15.0
 
-let min_oas_timeout_budget_sec = 15.0
+let min_provider_timeout_budget_sec = 15.0
 
-type oas_timeout_budget_resolution = {
+type provider_timeout_budget = {
   effective_timeout_sec : float;
   adaptive_timeout_sec : float;
   keeper_turn_timeout_sec : float;
@@ -67,11 +67,11 @@ type oas_timeout_budget_resolution = {
   source : string;
 }
 
-let oas_timeout_budget_resolution_to_yojson
-    (budget : oas_timeout_budget_resolution) : Yojson.Safe.t =
+let provider_timeout_budget_to_yojson
+    (budget : provider_timeout_budget) : Yojson.Safe.t =
   `Assoc
     [
-      ("oas_timeout_sec", `Float budget.effective_timeout_sec);
+      ("provider_timeout_sec", `Float budget.effective_timeout_sec);
       ("adaptive_timeout_sec", `Float budget.adaptive_timeout_sec);
       ("keeper_turn_timeout_sec", `Float budget.keeper_turn_timeout_sec);
       ("remaining_turn_budget_sec", `Float budget.remaining_turn_budget_sec);
@@ -80,11 +80,11 @@ let oas_timeout_budget_resolution_to_yojson
       ("source", `String budget.source);
     ]
 
-let resolve_bounded_oas_timeout_budget_with_turn_budget
+let resolve_bounded_provider_timeout_budget_with_turn_budget
     ~(allow_wall_clock_retry_budget : bool)
     ~(is_retry : bool)
     ~(estimated_input_tokens : int) ~(max_turns : int)
-    ~(remaining_turn_budget_s : float) : oas_timeout_budget_resolution option =
+    ~(remaining_turn_budget_s : float) : provider_timeout_budget option =
   let runtime = Keeper_runtime_resolved.current () in
   let adaptive_timeout_sec =
     Keeper_runtime_resolved
@@ -98,16 +98,16 @@ let resolve_bounded_oas_timeout_budget_with_turn_budget
     (* Guard: same-cascade retries cannot consume more than 1x per-attempt
        budget per slot acquisition. Degraded cascade rotation can opt into
        wall-clock retry budget so a first cascade that legitimately spent its
-       OAS timeout budget can still fail open inside the remaining turn time. *)
+       provider timeout budget can still fail open inside the remaining turn time. *)
     let wall_clock_retry_budget =
-      let usable_budget = remaining_turn_budget_s -. oas_timeout_guard_sec in
-      if usable_budget < min_oas_timeout_budget_sec
+      let usable_budget = remaining_turn_budget_s -. provider_timeout_guard_sec in
+      if usable_budget < min_provider_timeout_budget_sec
       then None
       else Some (Float.min adaptive_timeout_sec usable_budget)
     in
     let retry_budget =
       if remaining_turn_budget_s <= 0.0 then None
-      else if usable_retry_budget >= min_oas_timeout_budget_sec then
+      else if usable_retry_budget >= min_provider_timeout_budget_sec then
         Some (usable_retry_budget, false)
       else if allow_wall_clock_retry_budget then
         Option.map (fun timeout -> (timeout, true)) wall_clock_retry_budget
@@ -139,8 +139,8 @@ let resolve_bounded_oas_timeout_budget_with_turn_budget
           source;
         }
   end else begin
-    let usable_budget = remaining_turn_budget_s -. oas_timeout_guard_sec in
-    if usable_budget < min_oas_timeout_budget_sec
+    let usable_budget = remaining_turn_budget_s -. provider_timeout_guard_sec in
+    if usable_budget < min_provider_timeout_budget_sec
     then None
     else
       let effective_timeout_sec =
@@ -171,12 +171,12 @@ let resolve_bounded_oas_timeout_budget_with_turn_budget
         }
   end
 
-let bounded_oas_timeout_for_turn_budget_with_turn_budget
+let bounded_provider_timeout_for_turn_budget_with_turn_budget
     ~(estimated_input_tokens : int) ~(max_turns : int)
     ~(remaining_turn_budget_s : float) : float option =
   Option.map
-    (fun (budget : oas_timeout_budget_resolution) -> budget.effective_timeout_sec)
-    (resolve_bounded_oas_timeout_budget_with_turn_budget
+    (fun (budget : provider_timeout_budget) -> budget.effective_timeout_sec)
+    (resolve_bounded_provider_timeout_budget_with_turn_budget
        ~allow_wall_clock_retry_budget:false
        ~is_retry:false
        ~estimated_input_tokens ~max_turns ~remaining_turn_budget_s)
@@ -191,18 +191,18 @@ let allow_wall_clock_retry_budget_for_attempt
   && attempt = 1
   && List.length attempted_cascades > 1
 
-let bounded_oas_timeout_for_turn_budget ~(estimated_input_tokens : int)
+let bounded_provider_timeout_for_turn_budget ~(estimated_input_tokens : int)
     ~(remaining_turn_budget_s : float) : float option =
-  bounded_oas_timeout_for_turn_budget_with_turn_budget ~estimated_input_tokens
+  bounded_provider_timeout_for_turn_budget_with_turn_budget ~estimated_input_tokens
     ~max_turns:(Keeper_runtime_resolved.reactive_max_turns_per_call ())
     ~remaining_turn_budget_s
 
-let oas_retry_budget_available_for_turn
+let provider_retry_budget_available_for_turn
     ~(allow_wall_clock_retry_budget : bool) ~(is_retry : bool)
     ~(estimated_input_tokens : int) ~(max_turns : int)
     ~(remaining_turn_budget_s : float) : bool =
   Option.is_some
-    (resolve_bounded_oas_timeout_budget_with_turn_budget
+    (resolve_bounded_provider_timeout_budget_with_turn_budget
        ~allow_wall_clock_retry_budget
        ~is_retry ~estimated_input_tokens
        ~max_turns ~remaining_turn_budget_s)
@@ -211,17 +211,17 @@ let oas_retry_budget_available_for_turn
    ------------------------------------------------------------------
    Typed admission decision for an upcoming cascade attempt.
 
-   Background: 1077/24h [oas_timeout_budget] events, ~74% from retry
+   Background: 1077/24h [provider_timeout] events, ~74% from retry
    paths ([adaptive_*_retry] / [static_300s_*_retry]). The current
    caller in [Keeper_unified_turn.ml:589-615] calls
-   [resolve_bounded_oas_timeout_budget_with_turn_budget] and, when it
+   [resolve_bounded_provider_timeout_budget_with_turn_budget] and, when it
    returns [None] for a retry, emits a turn-owned timeout instead of
-   minting an [Oas_timeout_budget] root cause. That keeps two
+   minting an [Provider_timeout] root cause. That keeps two
    different failure semantics into one wire code:
      (a) the cascade attempt never started because admission budget
          was insufficient, and
      (b) an actual provider attempt ran and the server timed out.
-   Mixing them inflates the [oas_timeout_budget] signature and hides
+   Mixing them inflates the [provider_timeout] signature and hides
    the retry-admission rate.
 
    This function returns a typed admission decision. It does NOT
@@ -282,10 +282,10 @@ let decide_retry_admission_for_turn
     in
     let usable_retry_budget = adaptive_timeout_sec -. time_spent_in_turn in
     let usable_wall_clock_budget =
-      remaining_turn_budget_s -. oas_timeout_guard_sec
+      remaining_turn_budget_s -. provider_timeout_guard_sec
     in
     let projected_usable_budget_s =
-      if usable_retry_budget >= min_oas_timeout_budget_sec then
+      if usable_retry_budget >= min_provider_timeout_budget_sec then
         usable_retry_budget
       else if allow_wall_clock_retry_budget then usable_wall_clock_budget
       else usable_retry_budget
@@ -295,35 +295,35 @@ let decide_retry_admission_for_turn
         (Retry_budget_below_min
            {
              projected_usable_budget_s;
-             min_required_s = min_oas_timeout_budget_sec;
+             min_required_s = min_provider_timeout_budget_sec;
              remaining_turn_budget_s;
              adaptive_timeout_s = adaptive_timeout_sec;
              allow_wall_clock_retry_budget;
            })
-    else if usable_retry_budget >= min_oas_timeout_budget_sec then Ok ()
+    else if usable_retry_budget >= min_provider_timeout_budget_sec then Ok ()
     else if
       allow_wall_clock_retry_budget
-      && usable_wall_clock_budget >= min_oas_timeout_budget_sec
+      && usable_wall_clock_budget >= min_provider_timeout_budget_sec
     then Ok ()
     else
       Error
         (Retry_budget_below_min
            {
              projected_usable_budget_s;
-             min_required_s = min_oas_timeout_budget_sec;
+             min_required_s = min_provider_timeout_budget_sec;
              remaining_turn_budget_s;
              adaptive_timeout_s = adaptive_timeout_sec;
              allow_wall_clock_retry_budget;
            })
   else
-    let usable_budget = remaining_turn_budget_s -. oas_timeout_guard_sec in
-    if usable_budget >= min_oas_timeout_budget_sec then Ok ()
+    let usable_budget = remaining_turn_budget_s -. provider_timeout_guard_sec in
+    if usable_budget >= min_provider_timeout_budget_sec then Ok ()
     else
       Error
         (First_attempt_budget_below_min
            {
              projected_usable_budget_s = usable_budget;
-             min_required_s = min_oas_timeout_budget_sec;
+             min_required_s = min_provider_timeout_budget_sec;
              remaining_turn_budget_s;
            })
 
@@ -364,7 +364,7 @@ let degraded_retry_bypasses_slot_phase_guard
      was added to Cascade_error_classify, which is exactly the wrong default
      for a guard that decides whether to bypass slot-phase admission. *)
   match Keeper_turn_driver.classify_masc_internal_error err with
-  | Some (Keeper_turn_driver.Oas_timeout_budget _) -> true
+  | Some (Keeper_turn_driver.Provider_timeout _) -> true
   | Some (Keeper_turn_driver.Cascade_exhausted { reason; _ })
     when cascade_reason_is_structural_attempt_timeout reason ->
       true
@@ -387,7 +387,7 @@ let degraded_retry_bypasses_slot_phase_guard
     false
 
 let reclassify_oas_timeout_for_attempt
-    ~(timeout_budget : oas_timeout_budget_resolution option)
+    ~(timeout_budget : provider_timeout_budget option)
     (err : Agent_sdk.Error.sdk_error) : Agent_sdk.Error.sdk_error =
   match err, timeout_budget with
   | Agent_sdk.Error.Api (Timeout { message }), Some timeout_budget
@@ -400,16 +400,16 @@ let attempt_watchdog_outer_turn_reserve_sec = 1.0
 
 let attempt_watchdog_timeout_sec
     ~(remaining_turn_budget_s : float)
-    (timeout_budget : oas_timeout_budget_resolution) : float =
+    (timeout_budget : provider_timeout_budget) : float =
   let desired =
-    timeout_budget.effective_timeout_sec +. oas_timeout_guard_sec
+    timeout_budget.effective_timeout_sec +. provider_timeout_guard_sec
   in
   let cap_before_outer_timeout =
     Float.max 0.001
       (remaining_turn_budget_s -. attempt_watchdog_outer_turn_reserve_sec)
   in
   let floor =
-    Float.min min_oas_timeout_budget_sec cap_before_outer_timeout
+    Float.min min_provider_timeout_budget_sec cap_before_outer_timeout
   in
   Float.max floor (Float.min desired cap_before_outer_timeout)
 
@@ -453,7 +453,7 @@ let next_fail_open_cascade_for_turn_with_budget
         | None -> false
       then Degraded_retry_slot_phase_exhausted retry
       else if
-        oas_retry_budget_available_for_turn
+        provider_retry_budget_available_for_turn
           ~allow_wall_clock_retry_budget:true
           ~is_retry:true ~estimated_input_tokens ~max_turns
           ~remaining_turn_budget_s

--- a/lib/keeper/keeper_turn_cascade_budget.mli
+++ b/lib/keeper/keeper_turn_cascade_budget.mli
@@ -1,5 +1,5 @@
 (* Keeper_turn_cascade_budget — cascade execution types, fail-open rotation,
-   OAS timeout budget resolution, context overflow observation, keeper pause/resume
+   provider timeout budget resolution, context overflow observation, keeper pause/resume
    sync, partial-commit continue gate, and context budget resolution.
 
    Public sub-module included by [Keeper_unified_turn]. *)
@@ -49,15 +49,15 @@ val record_turn_failure_stress :
   err:Agent_sdk.Error.sdk_error ->
   unit
 
-val oas_timeout_guard_sec : float
+val provider_timeout_guard_sec : float
 (** Retry guard floor (seconds). *)
 
-val min_oas_timeout_budget_sec : float
-(** Minimum OAS timeout budget (seconds). *)
+val min_provider_timeout_budget_sec : float
+(** Minimum provider timeout budget (seconds). *)
 
 val sdk_error_kind : Agent_sdk.Error.sdk_error -> string
 
-type oas_timeout_budget_resolution = {
+type provider_timeout_budget = {
   effective_timeout_sec : float;
   adaptive_timeout_sec : float;
   keeper_turn_timeout_sec : float;
@@ -67,16 +67,16 @@ type oas_timeout_budget_resolution = {
   source : string;
 }
 
-val oas_timeout_budget_resolution_to_yojson :
-  oas_timeout_budget_resolution -> Yojson.Safe.t
+val provider_timeout_budget_to_yojson :
+  provider_timeout_budget -> Yojson.Safe.t
 
-val resolve_bounded_oas_timeout_budget_with_turn_budget :
+val resolve_bounded_provider_timeout_budget_with_turn_budget :
   allow_wall_clock_retry_budget:bool ->
   is_retry:bool ->
   estimated_input_tokens:int ->
   max_turns:int ->
   remaining_turn_budget_s:float ->
-  oas_timeout_budget_resolution option
+  provider_timeout_budget option
 (** RFC-0129: the [reserve_degraded_retry_budget] knob was removed
     (2026-05-18). The first-attempt branch now hands the full usable
     budget to [max_execution_time_s]; the keeper turn timeout still
@@ -91,18 +91,18 @@ val allow_wall_clock_retry_budget_for_attempt :
   attempted_cascades:string list ->
   bool
 
-val bounded_oas_timeout_for_turn_budget_with_turn_budget :
+val bounded_provider_timeout_for_turn_budget_with_turn_budget :
   estimated_input_tokens:int ->
   max_turns:int ->
   remaining_turn_budget_s:float ->
   float option
 
-val bounded_oas_timeout_for_turn_budget :
+val bounded_provider_timeout_for_turn_budget :
   estimated_input_tokens:int ->
   remaining_turn_budget_s:float ->
   float option
 
-val oas_retry_budget_available_for_turn :
+val provider_retry_budget_available_for_turn :
   allow_wall_clock_retry_budget:bool ->
   is_retry:bool ->
   estimated_input_tokens:int ->
@@ -115,7 +115,7 @@ val oas_retry_budget_available_for_turn :
     Distinguishes "admission denied before any provider attempt"
     from "provider attempt ran and OAS server timed out". The
     existing call surface in [Keeper_unified_turn] emits
-    [Turn_timeout] instead of minting an [Oas_timeout_budget] root cause
+    [Turn_timeout] instead of minting an [Provider_timeout] root cause
     for the former case, which collapses both semantics into one
     metric. This function exposes the typed decision so callers can
     branch on the closed-sum reason. The matching error variant
@@ -153,7 +153,7 @@ val degraded_retry_slot_phase_budget_sec : float
     suppressed. This is a guardrail for #12888: once the productive
     phase has already consumed this much wall clock, rotation should end
     the cycle instead of holding the same slot for another provider
-    attempt. OAS timeout-budget failures may still rotate to the next
+    attempt. provider-timeout failures may still rotate to the next
     degraded cascade when retry budget remains, because the failed attempt
     already represents the budgeted provider wait. *)
 
@@ -161,23 +161,23 @@ val degraded_retry_slot_phase_available :
   time_spent_in_turn_s:float -> bool
 
 val reclassify_oas_timeout_for_attempt :
-  timeout_budget:oas_timeout_budget_resolution option ->
+  timeout_budget:provider_timeout_budget option ->
   Agent_sdk.Error.sdk_error ->
   Agent_sdk.Error.sdk_error
 (** Preserve upstream structural timeout errors instead of minting a synthetic
-    [Oas_timeout_budget] root cause.  Kept as a named hook while the
+    [Provider_timeout] root cause.  Kept as a named hook while the
     provider-timeout root-cause ADT is introduced in a later PR. *)
 
 val attempt_watchdog_timeout_sec :
   remaining_turn_budget_s:float ->
-  oas_timeout_budget_resolution ->
+  provider_timeout_budget ->
   float
 (** Wall-clock watchdog for a single cascade attempt.
 
     The watchdog fires after the OAS per-attempt budget plus the normal
     finalization guard, while reserving a small outer-turn margin before the
     enclosing keeper turn wall-clock timeout. This keeps a hung provider
-    attempt on the structured [oas_timeout_budget] path, where degraded cascade
+    attempt on the structured [provider_timeout] path, where degraded cascade
     rotation can still run, instead of falling through to terminal
     [turn_timeout]. *)
 

--- a/lib/keeper/keeper_turn_terminal.ml
+++ b/lib/keeper/keeper_turn_terminal.ml
@@ -76,7 +76,7 @@ let of_failure ?(post_commit_ambiguous = false) ?(tool_call_count = 0) ~raw_erro
   then make ~source:"typed_error" "post_commit_ambiguous"
   else (
     match Keeper_turn_driver.classify_masc_internal_error err with
-    | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
+    | Some (Keeper_turn_driver.Provider_timeout _) ->
       of_disposition
         ~source:"typed_error"
         Keeper_turn_disposition.Turn_wall_clock_timeout

--- a/lib/keeper/keeper_unified_metrics_failure.ml
+++ b/lib/keeper/keeper_unified_metrics_failure.ml
@@ -59,7 +59,7 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
             let trimmed = String.trim detail in
             if trimmed = "" then reason else trimmed
         | Some
-            (Keeper_turn_driver.Oas_timeout_budget
+            (Keeper_turn_driver.Provider_timeout
                {
                  budget_sec;
                  keeper_turn_timeout_sec;
@@ -95,7 +95,7 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
     | Some err -> (
         match Keeper_turn_driver.classify_masc_internal_error err with
         | Some
-            (Keeper_turn_driver.Oas_timeout_budget _
+            (Keeper_turn_driver.Provider_timeout _
             | Keeper_turn_driver.Turn_timeout _
             | Keeper_turn_driver.Admission_queue_timeout _
             | Keeper_turn_driver.Admission_queue_rejected _

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -390,7 +390,7 @@ let run_keeper_cycle
                     Keeper_registry.Decision_active_guard_ok
                 | _ -> ());
                let last_execution = ref initial_execution in
-               let last_timeout_budget : oas_timeout_budget_resolution option ref =
+               let last_timeout_budget : provider_timeout_budget option ref =
                  ref None
                in
                let degraded_retry_info = ref None in
@@ -615,7 +615,7 @@ let run_keeper_cycle
                                ~attempted_cascades
                            in
                            match
-                             resolve_bounded_oas_timeout_budget_with_turn_budget
+                             resolve_bounded_provider_timeout_budget_with_turn_budget
                                ~allow_wall_clock_retry_budget
                                ~is_retry
                                ~max_turns
@@ -1353,7 +1353,7 @@ let run_keeper_cycle
                   let e_str = Agent_sdk.Error.to_string err in
                   let is_transient = EC.is_transient_network_error err in
                   (match Keeper_turn_driver.classify_masc_internal_error err with
-                   | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
+                   | Some (Keeper_turn_driver.Provider_timeout _) ->
                      Prometheus.inc_counter
                        Keeper_metrics.metric_keeper_oas_timeout_classifications
                        ~labels:[ "classification", "structural_budget" ]

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -8,7 +8,7 @@
 
     @since Unified Keeper Loop *)
 
-type oas_timeout_budget_resolution =
+type provider_timeout_budget =
   { effective_timeout_sec : float
   ; adaptive_timeout_sec : float
   ; keeper_turn_timeout_sec : float
@@ -18,13 +18,13 @@ type oas_timeout_budget_resolution =
   ; source : string
   }
 
-val resolve_bounded_oas_timeout_budget_with_turn_budget
+val resolve_bounded_provider_timeout_budget_with_turn_budget
   :  allow_wall_clock_retry_budget:bool
   -> is_retry:bool
   -> estimated_input_tokens:int
   -> max_turns:int
   -> remaining_turn_budget_s:float
-  -> oas_timeout_budget_resolution option
+  -> provider_timeout_budget option
 (** RFC-0129: see [Keeper_turn_cascade_budget] for the rationale
     behind removing the [reserve_degraded_retry_budget] knob. *)
 
@@ -33,7 +33,7 @@ val resolve_bounded_oas_timeout_budget_with_turn_budget
     still rotate through the degraded cascade path. *)
 val attempt_watchdog_timeout_sec
   :  remaining_turn_budget_s:float
-  -> oas_timeout_budget_resolution
+  -> provider_timeout_budget
   -> float
 
 val allow_wall_clock_retry_budget_for_attempt
@@ -43,7 +43,7 @@ val allow_wall_clock_retry_budget_for_attempt
   -> attempted_cascades:string list
   -> bool
 
-val oas_retry_budget_available_for_turn
+val provider_retry_budget_available_for_turn
   :  allow_wall_clock_retry_budget:bool
   -> is_retry:bool
   -> estimated_input_tokens:int
@@ -55,11 +55,11 @@ val degraded_retry_slot_phase_budget_sec : float
 val degraded_retry_slot_phase_available : time_spent_in_turn_s:float -> bool
 
 (** Reclassify a structural OAS timeout only when the current attempt
-    actually dispatched with an OAS timeout budget. This prevents a
+    actually dispatched with an provider timeout budget. This prevents a
     pre-retry turn-budget exhaustion from borrowing a stale previous
     attempt budget and incorrectly rotating cascades. *)
 val reclassify_oas_timeout_for_attempt
-  :  timeout_budget:oas_timeout_budget_resolution option
+  :  timeout_budget:provider_timeout_budget option
   -> Agent_sdk.Error.sdk_error
   -> Agent_sdk.Error.sdk_error
 
@@ -296,12 +296,12 @@ val run_keeper_cycle
     @param observation World state snapshot
     @param generation Current generation counter *)
 
-val bounded_oas_timeout_for_turn_budget
+val bounded_provider_timeout_for_turn_budget
   :  estimated_input_tokens:int
   -> remaining_turn_budget_s:float
   -> float option
 
-val bounded_oas_timeout_for_turn_budget_with_turn_budget
+val bounded_provider_timeout_for_turn_budget_with_turn_budget
   :  estimated_input_tokens:int
   -> max_turns:int
   -> remaining_turn_budget_s:float

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -141,7 +141,7 @@ let append_metrics_snapshot
       ~compaction:lifecycle.compaction
       ~handoff_json:lifecycle.handoff_json
       ?timeout_budget_json:
-        (Option.map KCB.oas_timeout_budget_resolution_to_yojson last_timeout_budget)
+        (Option.map KCB.provider_timeout_budget_to_yojson last_timeout_budget)
       ()
   with
   | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -13,7 +13,7 @@ val handle
   -> degraded_retry_cascade:string option
   -> fallback_reason:Keeper_error_classify.degraded_retry_reason option
   -> last_timeout_budget:
-       Keeper_turn_cascade_budget.oas_timeout_budget_resolution option
+       Keeper_turn_cascade_budget.provider_timeout_budget option
   -> current_turn_blocker_info:Keeper_meta_contract.blocker_info option
   -> keeper_turn_id:int
   -> Keeper_agent_run.run_result

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -203,7 +203,7 @@ let registry_failure_reason_of_terminal_reason
   | Keeper_turn_disposition.Success
   | Keeper_turn_disposition.External_cancel
   | Keeper_turn_disposition.Turn_wall_clock_timeout
-  | Keeper_turn_disposition.Provider_timeout
+  | Keeper_turn_disposition.Oas_timeout_budget
   | Keeper_turn_disposition.Gh_repo_context_missing_worktree
   | Keeper_turn_disposition.Post_commit_ambiguous
   | Keeper_turn_disposition.Unknown _ -> None

--- a/test/test_d7_retry_admission_gate.ml
+++ b/test/test_d7_retry_admission_gate.ml
@@ -4,8 +4,8 @@
     [Keeper_turn_cascade_budget.decide_retry_admission_for_turn]
     returns:
       - [Ok ()] when remaining turn budget is well above the
-        per-attempt floor ([oas_timeout_guard_sec +
-        min_oas_timeout_budget_sec] = 30s) for a retry without
+        per-attempt floor ([provider_timeout_guard_sec +
+        min_provider_timeout_budget_sec] = 30s) for a retry without
         wall-clock fallback.
       - [Error (Retry_budget_below_min _)] when the projected
         wall-clock budget falls below the min floor (15s).
@@ -24,7 +24,7 @@ module KCB = Masc_mcp.Keeper_turn_cascade_budget
    [allow_wall_clock_retry_budget]) are enough to drive the
    wall-clock branch deterministically:
      usable_wall_clock_budget = remaining_turn_budget_s - 15.0
-   threshold is min_oas_timeout_budget_sec = 15.0 *)
+   threshold is min_provider_timeout_budget_sec = 15.0 *)
 
 let pp_decision ppf = function
   | Ok () -> Format.fprintf ppf "Ok"

--- a/test/test_keeper_terminal_reason.ml
+++ b/test/test_keeper_terminal_reason.ml
@@ -454,7 +454,7 @@ let test_structured_required_tool_no_tool_call () =
 let test_structured_oas_timeout_budget_collapses_to_turn_timeout () =
   let err =
     Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
-      (Masc_mcp.Keeper_turn_driver.Oas_timeout_budget
+      (Masc_mcp.Keeper_turn_driver.Provider_timeout
          { budget_sec = 90.0
          ; keeper_turn_timeout_sec = 1200.0
          ; estimated_input_tokens = 10_000

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -6532,7 +6532,7 @@ let test_degraded_retry_after_recoverable_error_includes_provider_timeout () =
       ~effective_cascade:"underdog"
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Optional
       (Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
-         (Masc_mcp.Keeper_turn_driver.Oas_timeout_budget
+         (Masc_mcp.Keeper_turn_driver.Provider_timeout
             { budget_sec = 273.0
             ; keeper_turn_timeout_sec = 1200.0
             ; estimated_input_tokens = 2_000
@@ -7125,7 +7125,7 @@ let test_metrics_failure_response () =
 let test_metrics_failure_timeout_increments_proactive_backoff () =
   let sdk_error =
     Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
-      (Masc_mcp.Keeper_turn_driver.Oas_timeout_budget
+      (Masc_mcp.Keeper_turn_driver.Provider_timeout
          { budget_sec = 90.0
          ; keeper_turn_timeout_sec = 90.0
          ; estimated_input_tokens = 42_000
@@ -8135,7 +8135,7 @@ let test_bounded_oas_timeout_uses_adaptive_when_budget_is_large () =
       ~estimated_input_tokens
   in
   match
-    UT.bounded_oas_timeout_for_turn_budget
+    UT.bounded_provider_timeout_for_turn_budget
       ~estimated_input_tokens
       ~remaining_turn_budget_s:1200.0
   with
@@ -8150,17 +8150,17 @@ let test_bounded_oas_timeout_uses_adaptive_when_budget_is_large () =
 ;;
 
 (* #10008 fm2: the budget formula no longer scales with token count,
-   so [bounded_oas_timeout_for_turn_budget] returns the same value
+   so [bounded_provider_timeout_for_turn_budget] returns the same value
    for small and large prompts when the remaining_turn_budget is
    unchanged.  Replaces the prior "smaller prompt gets smaller
    budget" invariant, which was load-bearing on the (removed)
    [per_1k * tokens] term. *)
 let test_bounded_oas_timeout_is_token_independent () =
   match
-    ( UT.bounded_oas_timeout_for_turn_budget
+    ( UT.bounded_provider_timeout_for_turn_budget
         ~estimated_input_tokens:2_000
         ~remaining_turn_budget_s:1200.0
-    , UT.bounded_oas_timeout_for_turn_budget
+    , UT.bounded_provider_timeout_for_turn_budget
         ~estimated_input_tokens:262_144
         ~remaining_turn_budget_s:1200.0 )
   with
@@ -8175,7 +8175,7 @@ let test_bounded_oas_timeout_is_token_independent () =
 
 let test_bounded_oas_timeout_caps_to_remaining_turn_budget () =
   match
-    UT.bounded_oas_timeout_for_turn_budget
+    UT.bounded_provider_timeout_for_turn_budget
       ~estimated_input_tokens:2_000
       ~remaining_turn_budget_s:235.7
   with
@@ -8195,7 +8195,7 @@ let test_bounded_oas_timeout_uses_channel_turn_budget_override () =
       ~max_turns
   in
   match
-    UT.bounded_oas_timeout_for_turn_budget_with_turn_budget
+    UT.bounded_provider_timeout_for_turn_budget_with_turn_budget
       ~max_turns
       ~estimated_input_tokens
       ~remaining_turn_budget_s:1200.0
@@ -8219,7 +8219,7 @@ let test_bounded_oas_timeout_uses_channel_turn_budget_override () =
    still has headroom. *)
 let test_bounded_oas_timeout_first_attempt_uses_full_usable_budget () =
   match
-    UT.resolve_bounded_oas_timeout_budget_with_turn_budget
+    UT.resolve_bounded_provider_timeout_budget_with_turn_budget
       ~allow_wall_clock_retry_budget:false
       ~is_retry:false
       ~estimated_input_tokens:2_000
@@ -8246,15 +8246,15 @@ let test_bounded_oas_timeout_first_attempt_uses_full_usable_budget () =
 ;;
 
 (* RFC-0156 — OAS total timeout removal.
-   Pins the post-removal invariants of [resolve_bounded_oas_timeout_budget_with_turn_budget]:
+   Pins the post-removal invariants of [resolve_bounded_provider_timeout_budget_with_turn_budget]:
      (1) [estimated_input_tokens] is structurally ignored — any token count
          under the same remaining_turn_budget yields the same effective_timeout.
      (2) [source] never carries the retired "static_300s*" labels.
-     (3) effective_timeout tracks [remaining_turn_budget - oas_timeout_guard_sec]
+     (3) effective_timeout tracks [remaining_turn_budget - provider_timeout_guard_sec]
          (no longer capped at 300s when ample turn budget remains). *)
 let test_rfc_0156_token_count_does_not_affect_budget () =
   let resolve estimated_input_tokens =
-    UT.resolve_bounded_oas_timeout_budget_with_turn_budget
+    UT.resolve_bounded_provider_timeout_budget_with_turn_budget
       ~allow_wall_clock_retry_budget:false
       ~is_retry:false
       ~estimated_input_tokens
@@ -8278,7 +8278,7 @@ let test_rfc_0156_token_count_does_not_affect_budget () =
 
 let test_rfc_0156_source_never_static_300s () =
   match
-    UT.resolve_bounded_oas_timeout_budget_with_turn_budget
+    UT.resolve_bounded_provider_timeout_budget_with_turn_budget
       ~allow_wall_clock_retry_budget:false
       ~is_retry:false
       ~estimated_input_tokens:2_000
@@ -8302,7 +8302,7 @@ let test_rfc_0156_effective_tracks_remaining_budget () =
      to usable_budget = remaining - guard (15s). The pre-RFC behaviour
      would have clamped at min(300, usable) = 300. *)
   match
-    UT.resolve_bounded_oas_timeout_budget_with_turn_budget
+    UT.resolve_bounded_provider_timeout_budget_with_turn_budget
       ~allow_wall_clock_retry_budget:false
       ~is_retry:false
       ~estimated_input_tokens:2_000
@@ -8312,7 +8312,7 @@ let test_rfc_0156_effective_tracks_remaining_budget () =
   | None -> fail "expected bounded timeout"
   | Some budget ->
     check (float 0.01)
-      "effective_timeout = remaining - oas_timeout_guard_sec (no 300s clamp)"
+      "effective_timeout = remaining - provider_timeout_guard_sec (no 300s clamp)"
       985.0
       budget.effective_timeout_sec
 ;;
@@ -8324,7 +8324,7 @@ let test_rfc_0156_effective_tracks_remaining_budget () =
    slice. *)
 let test_attempt_watchdog_uses_full_usable_budget () =
   match
-    UT.resolve_bounded_oas_timeout_budget_with_turn_budget
+    UT.resolve_bounded_provider_timeout_budget_with_turn_budget
       ~allow_wall_clock_retry_budget:false
       ~is_retry:false
       ~estimated_input_tokens:2_000
@@ -8364,7 +8364,7 @@ let test_bounded_oas_timeout_refuses_too_little_budget () =
     (option (float 0.01))
     "insufficient budget returns none"
     None
-    (UT.bounded_oas_timeout_for_turn_budget
+    (UT.bounded_provider_timeout_for_turn_budget
        ~estimated_input_tokens:2_000
        ~remaining_turn_budget_s:20.0)
 ;;
@@ -8374,7 +8374,7 @@ let test_oas_timeout_reclassifies_only_current_attempt_budget () =
     Agent_sdk.Error.Api (Timeout { message = "Timeout after 273.0s (budget=273s)" })
   in
   match
-    UT.resolve_bounded_oas_timeout_budget_with_turn_budget
+    UT.resolve_bounded_provider_timeout_budget_with_turn_budget
       ~allow_wall_clock_retry_budget:false
       ~is_retry:false
       ~estimated_input_tokens:2_000
@@ -8387,7 +8387,7 @@ let test_oas_timeout_reclassifies_only_current_attempt_budget () =
       UT.reclassify_oas_timeout_for_attempt ~timeout_budget:(Some timeout_budget) err
     in
     (match Masc_mcp.Keeper_turn_driver.classify_masc_internal_error classified with
-     | Some (Masc_mcp.Keeper_turn_driver.Oas_timeout_budget budget) ->
+     | Some (Masc_mcp.Keeper_turn_driver.Provider_timeout budget) ->
        check int "estimated tokens preserved" 2_000 budget.estimated_input_tokens;
        check string "source preserved" timeout_budget.source budget.source;
        check
@@ -8396,7 +8396,7 @@ let test_oas_timeout_reclassifies_only_current_attempt_budget () =
          (Some timeout_budget.remaining_turn_budget_sec)
          budget.remaining_turn_budget_sec;
        check string "phase" "cascade_attempt_watchdog" budget.phase
-     | _ -> fail "expected OAS timeout budget classification")
+     | _ -> fail "expected provider timeout budget classification")
 ;;
 
 let test_pre_retry_timeout_helper_does_not_reuse_stale_budget () =
@@ -8415,7 +8415,7 @@ let test_pre_retry_timeout_helper_does_not_reuse_stale_budget () =
 
 let oas_timeout_budget_error () =
   Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
-    (Masc_mcp.Keeper_turn_driver.Oas_timeout_budget
+    (Masc_mcp.Keeper_turn_driver.Provider_timeout
        { budget_sec = 273.0
        ; keeper_turn_timeout_sec = 1200.0
        ; estimated_input_tokens = 2_000
@@ -8505,7 +8505,7 @@ let test_degraded_retry_slot_phase_allows_oas_timeout_local_recovery () =
       "oas_timeout_budget"
       (EC.degraded_retry_reason_to_string retry.fallback_reason)
   | UT.Degraded_retry_slot_phase_exhausted _ ->
-    fail "expected OAS timeout budget to bypass slot phase for local recovery"
+    fail "expected provider timeout budget to bypass slot phase for local recovery"
   | UT.Degraded_retry_budget_exhausted _ -> fail "expected retry budget to remain"
   | UT.No_degraded_retry -> fail "expected recoverable retry candidate"
 ;;
@@ -8583,7 +8583,7 @@ let test_degraded_retry_slot_phase_allows_first_contract_rotation () =
    turn timeout (600s). *)
 let test_per_attempt_retry_budget_with_near_zero_remaining () =
   match
-    UT.resolve_bounded_oas_timeout_budget_with_turn_budget
+    UT.resolve_bounded_provider_timeout_budget_with_turn_budget
       ~allow_wall_clock_retry_budget:false
       ~is_retry:true
       ~estimated_input_tokens:2_000
@@ -8599,7 +8599,7 @@ let test_per_attempt_retry_budget_with_near_zero_remaining () =
 
 let test_per_attempt_retry_budget_capped_by_remaining_when_healthy () =
   match
-    UT.resolve_bounded_oas_timeout_budget_with_turn_budget
+    UT.resolve_bounded_provider_timeout_budget_with_turn_budget
       ~allow_wall_clock_retry_budget:false
       ~is_retry:true
       ~estimated_input_tokens:2_000
@@ -8617,7 +8617,7 @@ let test_per_attempt_retry_budget_capped_by_remaining_when_healthy () =
 
 let test_per_attempt_retry_blocks_after_adaptive_budget_spent () =
   match
-    UT.resolve_bounded_oas_timeout_budget_with_turn_budget
+    UT.resolve_bounded_provider_timeout_budget_with_turn_budget
       ~allow_wall_clock_retry_budget:false
       ~is_retry:true
       ~estimated_input_tokens:2_000
@@ -8630,7 +8630,7 @@ let test_per_attempt_retry_blocks_after_adaptive_budget_spent () =
 
 let test_degraded_retry_wall_clock_budget_allows_remaining_turn_time () =
   match
-    UT.resolve_bounded_oas_timeout_budget_with_turn_budget
+    UT.resolve_bounded_provider_timeout_budget_with_turn_budget
       ~allow_wall_clock_retry_budget:true
       ~is_retry:true
       ~estimated_input_tokens:2_000
@@ -8692,7 +8692,7 @@ let test_degraded_retry_wall_clock_budget_gate_is_one_shot () =
 
 let test_non_retry_still_refuses_tiny_budget () =
   match
-    UT.resolve_bounded_oas_timeout_budget_with_turn_budget
+    UT.resolve_bounded_provider_timeout_budget_with_turn_budget
       ~allow_wall_clock_retry_budget:false
       ~is_retry:false
       ~estimated_input_tokens:2_000
@@ -8707,7 +8707,7 @@ let test_per_attempt_retry_refuses_zero_remaining () =
   (* Wall-clock gate: a retry with 0.0s remaining would be immediately
      cancelled by the outer turn timeout — resolver must return None. *)
   match
-    UT.resolve_bounded_oas_timeout_budget_with_turn_budget
+    UT.resolve_bounded_provider_timeout_budget_with_turn_budget
       ~allow_wall_clock_retry_budget:false
       ~is_retry:true
       ~estimated_input_tokens:2_000
@@ -11932,7 +11932,7 @@ let () =
             `Quick
             test_degraded_retry_budget_gate_blocks_exhausted_budget
         ; test_case
-            "OAS timeout budget can still rotate to local recovery after slot phase"
+            "provider timeout budget can still rotate to local recovery after slot phase"
             `Quick
             test_degraded_retry_slot_phase_allows_oas_timeout_local_recovery
         ; test_case


### PR DESCRIPTION
## Summary
- rename the keeper cascade per-attempt budget producer from `oas_timeout_budget_*` to `provider_timeout_budget_*`
- expose `provider_timeout_budget` and `provider_timeout_sec` in the producer/API/JSON surfaces instead of minting timeout-budget terminology
- update unified-turn call sites and budget producer tests to consume the provider-timeout budget API

## Validation
- Not run; user requested PR iteration without local validation.
