### PR TITLE
fix(keeper): remove timeout budget turn disposition

### DIFF
--- a/lib/keeper/keeper_passive_loop_detector.ml
+++ b/lib/keeper/keeper_passive_loop_detector.ml
@@ -42,7 +42,7 @@ let progress_class_of_disposition (d : Keeper_turn_disposition.t) =
       Some required_tool_no_call_progress_class
   | Required_tool_use_unsatisfied ->
       Some required_tool_unsatisfied_progress_class
-  | Success | External_cancel | Turn_wall_clock_timeout | Oas_timeout_budget
+  | Success | External_cancel | Turn_wall_clock_timeout
   | Gh_repo_context_missing_worktree | Post_commit_ambiguous
   | Cascade_attempts_exhausted
   | Provider_error _ | Unknown _ ->

--- a/lib/keeper/keeper_turn_disposition.ml
+++ b/lib/keeper/keeper_turn_disposition.ml
@@ -12,7 +12,6 @@ type t =
   | Success
   | External_cancel
   | Turn_wall_clock_timeout
-  | Oas_timeout_budget
   | Cascade_attempts_exhausted
   | Gh_repo_context_missing_worktree
   | Required_tool_use_no_tool_call
@@ -31,7 +30,6 @@ let severity = function
   | Success -> Ok
   | External_cancel
   | Turn_wall_clock_timeout
-  | Oas_timeout_budget
   | Cascade_attempts_exhausted
   | Gh_repo_context_missing_worktree -> Warn
   | Required_tool_use_no_tool_call
@@ -44,7 +42,7 @@ let severity = function
 let summary = function
   | Success -> "turn completed"
   | External_cancel -> "keeper turn was cancelled before completion"
-  | Turn_wall_clock_timeout | Oas_timeout_budget ->
+  | Turn_wall_clock_timeout ->
     "keeper turn hit the wall-clock timeout"
   | Cascade_attempts_exhausted ->
     "cascade attempts exhausted; inspect per-attempt root causes"
@@ -65,7 +63,7 @@ let summary = function
 let next_action = function
   | Success -> None
   | External_cancel -> Some "rerun_if_still_relevant"
-  | Turn_wall_clock_timeout | Oas_timeout_budget -> Some "inspect_turn_timeout"
+  | Turn_wall_clock_timeout -> Some "inspect_turn_timeout"
   | Cascade_attempts_exhausted -> Some "inspect_cascade_attempts"
   | Gh_repo_context_missing_worktree -> Some "create_or_link_worktree"
   | Required_tool_use_no_tool_call ->
@@ -80,7 +78,6 @@ let to_wire = function
   | Success -> "success"
   | External_cancel -> "external_cancel"
   | Turn_wall_clock_timeout -> "turn_wall_clock_timeout"
-  | Oas_timeout_budget -> "turn_wall_clock_timeout"
   | Cascade_attempts_exhausted -> "cascade_attempts_exhausted"
   | Gh_repo_context_missing_worktree -> "gh_repo_context_missing_worktree"
   | Required_tool_use_no_tool_call -> "required_tool_use_no_tool_call"
@@ -143,9 +140,6 @@ let equal a b =
   | Success, Success
   | External_cancel, External_cancel
   | Turn_wall_clock_timeout, Turn_wall_clock_timeout
-  | Turn_wall_clock_timeout, Oas_timeout_budget
-  | Oas_timeout_budget, Turn_wall_clock_timeout
-  | Oas_timeout_budget, Oas_timeout_budget
   | Cascade_attempts_exhausted, Cascade_attempts_exhausted
   | Gh_repo_context_missing_worktree, Gh_repo_context_missing_worktree
   | Required_tool_use_no_tool_call, Required_tool_use_no_tool_call
@@ -156,7 +150,6 @@ let equal a b =
   | Success, _
   | External_cancel, _
   | Turn_wall_clock_timeout, _
-  | Oas_timeout_budget, _
   | Cascade_attempts_exhausted, _
   | Gh_repo_context_missing_worktree, _
   | Required_tool_use_no_tool_call, _

--- a/lib/keeper/keeper_turn_disposition.mli
+++ b/lib/keeper/keeper_turn_disposition.mli
@@ -29,10 +29,6 @@ type t =
   | External_cancel
   (** Turn cancelled before completion (operator stop, switch_keeper, …). *)
   | Turn_wall_clock_timeout (** Turn exceeded its wall-clock budget. *)
-  | Oas_timeout_budget
-  (** Legacy OAS timeout-budget wire value. Operators should inspect
-      owner-specific turn/provider timeout evidence instead of treating this
-      as a distinct root cause. *)
   | Cascade_attempts_exhausted
   (** Cascade aggregate outcome: all candidate attempts were exhausted.
           Operators should inspect per-attempt root causes instead of treating
@@ -97,7 +93,6 @@ val next_action : t -> string option
     - [Success] → ["success"]
     - [External_cancel] → ["external_cancel"]
     - [Turn_wall_clock_timeout] → ["turn_wall_clock_timeout"]
-    - [Oas_timeout_budget] → ["turn_wall_clock_timeout"] (legacy alias)
     - [Cascade_attempts_exhausted] → ["cascade_attempts_exhausted"]
     - [Gh_repo_context_missing_worktree] → ["gh_repo_context_missing_worktree"]
     - [Required_tool_use_no_tool_call] → ["required_tool_use_no_tool_call"]
@@ -113,6 +108,8 @@ val to_wire : t -> string
     [Keeper_turn_terminal_code.of_wire]; if that succeeds, the result
     is wrapped via [of_termination_code] (which may itself collapse to
     a non-Provider_error disposition such as [Required_tool_use_unsatisfied]).
+    Legacy ["oas_timeout_budget"] input parses to [Turn_wall_clock_timeout]
+    and is not represented as a distinct disposition state.
     Otherwise [Unknown { raw_error = wire }] is returned. *)
 val of_wire : string -> t
 

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -203,7 +203,6 @@ let registry_failure_reason_of_terminal_reason
   | Keeper_turn_disposition.Success
   | Keeper_turn_disposition.External_cancel
   | Keeper_turn_disposition.Turn_wall_clock_timeout
-  | Keeper_turn_disposition.Oas_timeout_budget
   | Keeper_turn_disposition.Gh_repo_context_missing_worktree
   | Keeper_turn_disposition.Post_commit_ambiguous
   | Keeper_turn_disposition.Unknown _ -> None

--- a/test/test_keeper_turn_disposition.ml
+++ b/test/test_keeper_turn_disposition.ml
@@ -148,7 +148,7 @@ let round_trippable : (string * D.t) list =
   [ "Success", D.Success
   ; "External_cancel", D.External_cancel
   ; "Turn_wall_clock_timeout", D.Turn_wall_clock_timeout
-  ; "Oas_timeout_budget legacy alias", D.Oas_timeout_budget
+  ; "Oas_timeout_budget legacy alias", D.Turn_wall_clock_timeout
   ; "Gh_repo_context_missing_worktree", D.Gh_repo_context_missing_worktree
   ; "Required_tool_use_no_tool_call", D.Required_tool_use_no_tool_call
   ; "Required_tool_use_unsatisfied", D.Required_tool_use_unsatisfied

--- a/test/test_keeper_turn_disposition.ml
+++ b/test/test_keeper_turn_disposition.ml
@@ -9,7 +9,7 @@
        to the input wire (since PR-2 will keep the same producer-side
        normalisation; this test isolates the *consumer-side*
        invariant). Timeout actions intentionally differ: the legacy
-       [inspect_timeout_budget] action collapsed provider, admission/capacity,
+       [inspect_turn_timeout] action collapsed provider, admission/capacity,
        and turn liveness ownership.
 
     2. Round-trip: [of_wire (to_wire t) = t] for every canonical
@@ -148,7 +148,7 @@ let round_trippable : (string * D.t) list =
   [ "Success", D.Success
   ; "External_cancel", D.External_cancel
   ; "Turn_wall_clock_timeout", D.Turn_wall_clock_timeout
-  ; "Oas_timeout_budget legacy alias", D.Turn_wall_clock_timeout
+  ; "legacy timeout-budget wire alias", D.Turn_wall_clock_timeout
   ; "Gh_repo_context_missing_worktree", D.Gh_repo_context_missing_worktree
   ; "Required_tool_use_no_tool_call", D.Required_tool_use_no_tool_call
   ; "Required_tool_use_unsatisfied", D.Required_tool_use_unsatisfied


### PR DESCRIPTION
## Summary
- remove `Oas_timeout_budget` from the keeper turn disposition closed sum
- keep legacy `oas_timeout_budget` wire input as parse-only compatibility that maps to `Turn_wall_clock_timeout`
- update passive-loop and unified-turn disposition consumers so timeout-budget is no longer carried as a distinct turn disposition

## Validation
- Not run; user requested PR iteration without local validation.
