### PR TITLE
feat(keeper): add phantom-typed Token_count module (RFC-0149 §3.2 PR-1)

### DIFF
--- a/lib/keeper/token_count.ml
+++ b/lib/keeper/token_count.ml
@@ -1,0 +1,15 @@
+(** See [token_count.mli] for the rationale (RFC-0149 §3.2). *)
+
+type pre
+type post
+type 'phase t = int
+
+let pre_estimate (n : int) : pre t = max 0 n
+let post_recount (n : int) : post t = max 0 n
+
+let to_int (n : _ t) : int = n
+
+let saved ~(pre : pre t) ~(post : post t) :
+    [ `Saved of int | `Divergent of int ] =
+  if post <= pre then `Saved (pre - post)
+  else `Divergent (post - pre)

--- a/lib/keeper/token_count.mli
+++ b/lib/keeper/token_count.mli
@@ -1,0 +1,50 @@
+(** Phantom-typed pre/post token counts for compaction accounting.
+
+    RFC-0149 §3.2 root-fix.  The legacy
+    [let saved_tokens = max 0 (tok_count - new_tok_count)] in
+    [keeper_compact_policy.ml] silently floored the negative-delta case
+    to zero and routed the divergence detection through the
+    [metric_keeper_compaction_negative_savings] counter — a §1
+    telemetry-as-fix.  The two operands originate from the same
+    estimator ([token_count]) applied to two different contexts, so an
+    *estimate divergence* (post > pre) cannot be statically prevented;
+    it must instead become *representable* in the type system, so
+    callers cannot ignore it.
+
+    Phantom tags discriminate the two roles ([pre] / [post]).  The
+    compiler enforces that pre/post arguments cannot be swapped, and
+    the [saved] result variant ([`Saved of int] vs [`Divergent of int])
+    makes the floor non-bypassable: there is no path that silently
+    coerces a negative delta to zero. *)
+
+(** Phantom tag for pre-compaction estimates. *)
+type pre
+
+(** Phantom tag for post-compaction recounts. *)
+type post
+
+(** A count witnessed under a specific phase tag.  [private int] so the
+    only ways to construct one are the smart constructors below; the
+    representation stays a single boxed int with zero runtime cost. *)
+type 'phase t = private int
+
+(** Construct a pre-compaction estimate.  Negative inputs are clamped
+    to zero (token counts are non-negative by domain). *)
+val pre_estimate : int -> pre t
+
+(** Construct a post-compaction recount.  Negative inputs are clamped
+    to zero (token counts are non-negative by domain). *)
+val post_recount : int -> post t
+
+(** Extract the underlying int.  Kept narrow so renderers and metrics
+    emitters can still read the value, but constructing a new count
+    from an arbitrary int is impossible. *)
+val to_int : _ t -> int
+
+(** The saving computation: [pre - post] when [post <= pre], or
+    [`Divergent (post - pre)] when the post-recount exceeded the
+    pre-estimate.  The variant forces the caller to pattern-match,
+    eliminating the silent floor.  The [`Divergent] payload carries
+    the positive magnitude of the divergence so it can drive metrics
+    or operator alerts. *)
+val saved : pre:pre t -> post:post t -> [ `Saved of int | `Divergent of int ]

--- a/test/dune
+++ b/test/dune
@@ -137,6 +137,7 @@
   test_keeper_wake_telemetry
   test_keeper_timing
   test_keeper_memory
+  test_token_count
   test_memory_jsonl_truncation
   test_keeper_chat_store
   test_keeper_runtime_trust_snapshot
@@ -453,6 +454,7 @@
   test_keeper_wake_telemetry
   test_keeper_timing
   test_keeper_memory
+  test_token_count
   test_memory_jsonl_truncation
   test_keeper_chat_store
   test_keeper_runtime_trust_snapshot

--- a/test/test_token_count.ml
+++ b/test/test_token_count.ml
@@ -1,0 +1,63 @@
+(** Phantom-typed token count tests (RFC-0149 §3.2 PR-1). *)
+
+open Alcotest
+
+module Token_count = Masc_mcp.Token_count
+
+let result_pp ppf = function
+  | `Saved n -> Format.fprintf ppf "`Saved %d" n
+  | `Divergent n -> Format.fprintf ppf "`Divergent %d" n
+
+let result_eq a b =
+  match a, b with
+  | `Saved x, `Saved y -> x = y
+  | `Divergent x, `Divergent y -> x = y
+  | _ -> false
+
+let saved_t = testable result_pp result_eq
+
+let saved_when_post_smaller () =
+  let pre = Token_count.pre_estimate 1000 in
+  let post = Token_count.post_recount 200 in
+  check saved_t "post < pre yields Saved" (`Saved 800)
+    (Token_count.saved ~pre ~post)
+
+let saved_zero_when_equal () =
+  let pre = Token_count.pre_estimate 500 in
+  let post = Token_count.post_recount 500 in
+  check saved_t "post = pre yields Saved 0" (`Saved 0)
+    (Token_count.saved ~pre ~post)
+
+let divergent_when_post_bigger () =
+  let pre = Token_count.pre_estimate 300 in
+  let post = Token_count.post_recount 500 in
+  check saved_t "post > pre yields Divergent" (`Divergent 200)
+    (Token_count.saved ~pre ~post)
+
+let negative_input_clamps_to_zero () =
+  let pre = Token_count.pre_estimate (-100) in
+  let post = Token_count.post_recount (-50) in
+  check int "pre clamped to 0" 0 (Token_count.to_int pre);
+  check int "post clamped to 0" 0 (Token_count.to_int post);
+  check saved_t "0 vs 0 yields Saved 0" (`Saved 0)
+    (Token_count.saved ~pre ~post)
+
+let to_int_preserves_value () =
+  let pre = Token_count.pre_estimate 1234 in
+  check int "to_int round-trips constructor input" 1234
+    (Token_count.to_int pre)
+
+let () =
+  run "token_count"
+    [ ( "saved variant"
+      , [ test_case "post smaller -> Saved" `Quick saved_when_post_smaller
+        ; test_case "post equal -> Saved 0" `Quick saved_zero_when_equal
+        ; test_case "post bigger -> Divergent" `Quick
+            divergent_when_post_bigger
+        ] )
+    ; ( "construction"
+      , [ test_case "negative inputs clamp to zero" `Quick
+            negative_input_clamps_to_zero
+        ; test_case "to_int round-trips" `Quick to_int_preserves_value
+        ] )
+    ]


### PR DESCRIPTION
## Goal

Open the §3.2 sunset for the `max 0 (pre - post)` floor + `metric_keeper_compaction_negative_savings` counter — the §1 telemetry-as-fix artefact RFC-0149 targets in the compaction accounting path.

## Audit correction (gating this work)

Prior session memory claimed §3.2 was *stale* (counter and pattern non-existent in code).  That claim was wrong.  Live state:

* `keeper_compact_policy.ml:326-335` emits `metric_keeper_compaction_negative_savings` with closed `{tokens, messages}` kind label vocab.
* `keeper_compact_policy.ml:336-337` runs the `max 0` floor:
  ```ocaml
  let saved_tokens   = max 0 (tok_count - new_tok_count) in
  let saved_messages = max 0 (msg_count - new_msg_count) in
  ```
* Only the line number in the RFC body is stale (RFC says 312, actual is 326-337).

§3.2 is therefore implementable as written.

## Change

Add `lib/keeper/token_count.ml(i)` — phantom-typed pre/post counts:

```ocaml
type pre
type post
type 'phase t = private int

val pre_estimate : int -> pre t
val post_recount : int -> post t
val to_int       : _ t -> int
val saved        : pre:pre t -> post:post t ->
                   [ `Saved of int | `Divergent of int ]
```

Compiler enforces argument role at the call site (the labels `~pre` / `~post` plus the phantom tags make swapping ill-typed).  `saved` returns `Divergent` with positive overrun magnitude when `post > pre`, so the silent floor becomes unreachable: callers must pattern-match.

## Unit tests

5/5 Alcotest cases PASS (`test/test_token_count.ml`):

| Case                                | Expected            |
|-------------------------------------|---------------------|
| `post < pre`                        | `\`Saved (pre - post)` |
| `post = pre`                        | `\`Saved 0`         |
| `post > pre`                        | `\`Divergent (post - pre)` |
| Negative constructor input          | clamped to 0        |
| `to_int` round-trip                 | preserves value     |

## Out of scope

* `keeper_compact_policy.ml` migration — subsequent PR-2 replaces the two `max 0` arithmetic floors and the conditional `inc_counter` site with a single `match` over `Token_count.saved`.
* `metric_keeper_compaction_negative_savings` counter sunset — happens in PR-2 (the typed `Divergent` arm becomes the sole emission source) or the closeout PR.

## Verification

* `dune build --root . lib/keeper/` → pass
* `dune build --root . test/test_token_count.exe` → pass (requires #17723 hotfix applied locally)
* `_build/default/test/test_token_count.exe` → `Test Successful in 0.002s. 5 tests run.`

Full `dune build lib/` is currently red on `origin/main` (`keeper_status.ml:252` unbound — fix in #17723). Once #17723 merges, this PR rebases to a green base.

## Anti-pattern self-check

- §1 telemetry-as-fix? Inverted — this PR introduces the typed replacement for the upcoming counter sunset.  PR-2 actually removes the counter.
- §2 substring classifier? No — variant payload is a closed sum, not a string label.
- §3 N-of-M? Helper-only; PR-2 finishes the migration in one shot (only 2 sites, both in `keeper_compact_policy.ml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>