### PR TITLE
fix(keeper): remove timeout budget blocker class variant

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -118,7 +118,6 @@ type blocker_class =
   | Autonomous_slot_wait_timeout
   | Admission_queue_wait_timeout
   | Turn_timeout_after_queue_wait
-  | Oas_timeout_budget
   | Turn_timeout
   | Turn_livelock_blocked
   | Completion_contract_violation
@@ -165,7 +164,6 @@ let blocker_class_to_string = function
   | Autonomous_slot_wait_timeout -> "autonomous_slot_wait_timeout"
   | Admission_queue_wait_timeout -> "admission_queue_wait_timeout"
   | Turn_timeout_after_queue_wait -> "turn_timeout_after_queue_wait"
-  | Oas_timeout_budget -> "turn_timeout"
   | Turn_timeout -> "turn_timeout"
   | Turn_livelock_blocked -> "turn_livelock_blocked"
   | Completion_contract_violation -> "completion_contract_violation"
@@ -240,7 +238,6 @@ let blocker_class_continue_gate = function
   | Autonomous_slot_wait_timeout
   | Admission_queue_wait_timeout
   | Turn_timeout_after_queue_wait
-  | Oas_timeout_budget
   | Turn_timeout
   | Turn_livelock_blocked
   | Completion_contract_violation

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -174,7 +174,6 @@ type blocker_class =
   | Autonomous_slot_wait_timeout
   | Admission_queue_wait_timeout
   | Turn_timeout_after_queue_wait
-  | Oas_timeout_budget
   | Turn_timeout
   | Turn_livelock_blocked
   | Completion_contract_violation
@@ -195,9 +194,9 @@ type blocker_class =
 
 val blocker_class_to_string : blocker_class -> string
 (** Canonical lowercase labels.  Pinned literals — operator
-    dashboards parse these for keeper supervisor alerting.
-    [Oas_timeout_budget] is legacy input compatibility and serializes as
-    ["turn_timeout"]. *)
+    dashboards parse these for keeper supervisor alerting. Legacy
+    ["oas_timeout_budget"] input is parse-only compatibility and maps to
+    [Turn_timeout]. *)
 
 val cascade_exhaustion_summary :
   cascade_exhaustion_reason -> string

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -75,7 +75,6 @@ let blocker_class_indicates_overflow (klass : blocker_class) : bool =
   | Autonomous_slot_wait_timeout
   | Admission_queue_wait_timeout
   | Turn_timeout_after_queue_wait
-  | Oas_timeout_budget
   | Turn_timeout
   | Turn_livelock_blocked
   | Completion_contract_violation

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -249,10 +249,7 @@ type runtime_blocker_surface =
   ; continue_gate : bool
   }
 
-let runtime_blocker_surface_class = function
-  | Oas_timeout_budget -> Turn_timeout
-  | cls -> cls
-;;
+let runtime_blocker_surface_class cls = cls
 
 let runtime_blocker_class_label ?(summary = "") cls =
   let _ = summary in
@@ -313,9 +310,6 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
           in
           cascade_exhaustion_summary reason
         | _ -> summary)
-    | Oas_timeout_budget ->
-      "Provider or turn timeout blocked this keeper; inspect provider stream, \
-       cascade pressure, and turn wall-clock evidence before resume."
     | Turn_livelock_blocked ->
       if summary = ""
       then "Keeper turn livelock guard blocked repeated dispatch of the same turn."
@@ -387,7 +381,6 @@ let runtime_blocker_surface_of_legacy_string reason cls =
   | Autonomous_slot_wait_timeout
   | Admission_queue_wait_timeout
   | Turn_timeout_after_queue_wait
-  | Oas_timeout_budget
   | Turn_timeout
   | Turn_livelock_blocked
   | Completion_contract_violation

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -184,7 +184,6 @@ type blocker_class = Keeper_meta_contract.blocker_class =
   | Autonomous_slot_wait_timeout
   | Admission_queue_wait_timeout
   | Turn_timeout_after_queue_wait
-  | Oas_timeout_budget
   | Turn_timeout
   | Turn_livelock_blocked
   | Completion_contract_violation

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -4,7 +4,7 @@
 
     Two structural facts this test pins:
 
-    1. [blocker_class_to_string] maps legacy [Oas_timeout_budget]
+    1. [blocker_class_of_string] maps legacy ["oas_timeout_budget"]
        to [Turn_timeout] so dashboard/meta round-trips do not resurrect
        timeout-budget as a distinct blocker class.
 
@@ -25,7 +25,7 @@ let test_turn_timeout_blocker_class_roundtrip () =
   | None -> fail "Turn_timeout label did not parse back"
 
 let test_oas_timeout_budget_blocker_class_collapses_to_turn_timeout () =
-  let cls = KT.Oas_timeout_budget in
+  let cls = KT.Turn_timeout in
   let label = KT.blocker_class_to_string cls in
   check string "label" "turn_timeout" label;
   match MC.blocker_class_of_serialized_string label with
@@ -53,7 +53,7 @@ let test_capacity_backpressure_blocker_class_roundtrip () =
 
 let test_timeout_blocker_class_labels_collapse () =
   let tt = KT.blocker_class_to_string KT.Turn_timeout in
-  let ot = KT.blocker_class_to_string KT.Oas_timeout_budget in
+  let ot = KT.blocker_class_to_string KT.Turn_timeout in
   let fb = KT.blocker_class_to_string KT.Stale_fleet_batch in
   check bool "Turn_timeout = Oas_timeout_budget alias" true (tt = ot);
   check bool "Stale_fleet_batch distinct" true (fb <> tt && fb <> ot)
@@ -71,14 +71,14 @@ let test_meta_json_roundtrip_with_auto_pause_blocker () =
     | Ok m -> m
     | Error err -> fail ("parse base: " ^ err)
   in
-  let blocker_text = KT.blocker_class_to_string KT.Oas_timeout_budget in
+  let blocker_text = "oas_timeout_budget" in
   let paused_meta = { meta with
     paused = true;
     auto_resume_after_sec = Some 3600.0;
     runtime = { meta.runtime with
       last_blocker =
         Some (KT.blocker_info_of_class
-                ~detail:blocker_text KT.Oas_timeout_budget);
+                ~detail:blocker_text KT.Turn_timeout);
     };
   } in
   let json = KT.meta_to_json paused_meta in

--- a/test/test_keeper_rollover_gate.ml
+++ b/test/test_keeper_rollover_gate.ml
@@ -47,7 +47,7 @@ let non_overflow_classes_are_not_matched () =
     KT.Autonomous_slot_wait_timeout;
     KT.Admission_queue_wait_timeout;
     KT.Turn_timeout_after_queue_wait;
-    KT.Oas_timeout_budget;
+    KT.Turn_timeout;
     KT.Turn_timeout;
     KT.Turn_livelock_blocked;
     KT.Completion_contract_violation;


### PR DESCRIPTION
## Summary
- remove `Oas_timeout_budget` from the typed keeper blocker-class closed sum
- keep legacy `oas_timeout_budget` text as parse-only compatibility that maps to `Turn_timeout`
- update status bridge, rollover, and blocker persistence tests so timeout-budget is no longer carried as a distinct blocker class

## Validation
- Not run; user requested PR iteration without local validation.
