### PR TITLE
fix(keeper): remove timeout budget terminal code

### DIFF
--- a/lib/keeper/keeper_turn_disposition.ml
+++ b/lib/keeper/keeper_turn_disposition.ml
@@ -108,7 +108,6 @@ let of_termination_code (c : Code.t) : t =
   | Code.Stale_turn_timeout_in_turn
   | Code.Stale_turn_timeout_no_progress
   | Code.Stale_turn_timeout_noop -> Turn_wall_clock_timeout
-  | Code.Oas_timeout_budget -> Turn_wall_clock_timeout
   | Code.Tool_required_unsatisfied _ -> Required_tool_use_unsatisfied
   | Code.Ambiguous_partial_commit_post_commit_timeout
   | Code.Ambiguous_partial_commit_post_commit_failure -> Post_commit_ambiguous

--- a/lib/keeper/keeper_turn_terminal_code.ml
+++ b/lib/keeper/keeper_turn_terminal_code.ml
@@ -12,7 +12,6 @@ type t =
   | Stale_turn_timeout_noop
   | Stale_termination_storm
   | Stale_fleet_batch
-  | Oas_timeout_budget
   | Heartbeat_failures
   | Turn_failures
   | Provider_runtime_error of string
@@ -35,7 +34,6 @@ let to_wire = function
     "stale_turn_timeout"
   | Stale_termination_storm -> "stale_termination_storm"
   | Stale_fleet_batch -> "stale_fleet_batch"
-  | Oas_timeout_budget -> "provider_timeout"
   | Heartbeat_failures -> "heartbeat_failures"
   | Turn_failures -> "turn_failures"
   | Provider_runtime_error code -> code

--- a/lib/keeper/keeper_turn_terminal_code.mli
+++ b/lib/keeper/keeper_turn_terminal_code.mli
@@ -38,11 +38,6 @@ type t =
   (** [Keeper_registry.Stale_fleet_batch]: legacy fleet-batch wire value.
       Current fleet-batch detection is observation-only; fresh watchdog kills
       retain their per-keeper terminal code. *)
-  | Oas_timeout_budget
-  (** Legacy wire-only timeout-budget code. New registry projections
-      normalize this to provider/turn timeout evidence. Serialisation emits
-      ["provider_timeout"]; ["oas_timeout_budget"] remains parse-only
-      compatibility in the implementation. *)
   | Heartbeat_failures (** [Keeper_registry.Heartbeat_consecutive_failures]. *)
   | Turn_failures (** [Keeper_registry.Turn_consecutive_failures]. *)
   | Provider_runtime_error of string

--- a/test/test_keeper_turn_disposition.ml
+++ b/test/test_keeper_turn_disposition.ml
@@ -216,7 +216,6 @@ let runtime_codes_to_projection : (string * Code.t * D.t) list =
     , Code.Stale_turn_timeout_no_progress
     , D.Turn_wall_clock_timeout )
   ; "Stale_turn_timeout/noop", Code.Stale_turn_timeout_noop, D.Turn_wall_clock_timeout
-  ; "Oas_timeout_budget", Code.Oas_timeout_budget, D.Turn_wall_clock_timeout
   ; ( "Tool_required_unsatisfied"
     , Code.Tool_required_unsatisfied "x"
     , D.Required_tool_use_unsatisfied )


### PR DESCRIPTION
## Summary
- remove `Oas_timeout_budget` from the keeper terminal-code closed sum
- keep legacy `oas_timeout_budget` wire parsing as compatibility via `Provider_runtime_error "provider_timeout"`
- update disposition projection tests so timeout-budget no longer exists as a typed terminal code

## Validation
- Not run; user requested PR iteration without local validation.
