### PR TITLE
refactor(keeper): replace max 0 floor with Token_count.saved match (RFC-0149 §3.2 PR-2)

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -317,24 +317,32 @@ let compact_if_needed_typed
     let new_ratio = context_ratio compacted_ctx in
     let new_msg_count = message_count compacted_ctx in
     let new_tok_count = token_count compacted_ctx in
-    (* [max 0 (pre - post)] silently floors the negative-delta case to
-       zero. Surface that case as a counter so operators can detect
-       divergence between the pre/post token (or message) measurement
-       sources — without this signal, [saved_tokens=0] is ambiguous
-       between "no savings" and "post-recount exceeded pre-estimate".
-       The kind label is a closed 2-value vocabulary. *)
-    if tok_count < new_tok_count then
-      Prometheus.inc_counter
-        Keeper_metrics.metric_keeper_compaction_negative_savings
-        ~labels:[ ("keeper", meta.name); ("kind", "tokens") ]
-        ();
-    if msg_count < new_msg_count then
-      Prometheus.inc_counter
-        Keeper_metrics.metric_keeper_compaction_negative_savings
-        ~labels:[ ("keeper", meta.name); ("kind", "messages") ]
-        ();
-    let saved_tokens = max 0 (tok_count - new_tok_count) in
-    let saved_messages = max 0 (msg_count - new_msg_count) in
+    (* RFC-0149 §3.2 PR-2 — the silent [max 0 (pre - post)] floor and
+       the companion [metric_keeper_compaction_negative_savings] counter
+       (a §1 telemetry-as-fix artefact) are replaced by a phantom-typed
+       [Token_count.saved] match.  The [`Divergent] arm carries the
+       overrun magnitude as a typed payload that surfaces on the
+       post-compact JSONL record below ([tokens_divergence] /
+       [messages_divergence]), so operators can detect estimator
+       drift without a free-floating Prometheus counter. *)
+    let saved_tokens, tokens_divergence =
+      match
+        Token_count.saved
+          ~pre:(Token_count.pre_estimate tok_count)
+          ~post:(Token_count.post_recount new_tok_count)
+      with
+      | `Saved n -> n, None
+      | `Divergent n -> 0, Some n
+    in
+    let saved_messages, messages_divergence =
+      match
+        Token_count.saved
+          ~pre:(Token_count.pre_estimate msg_count)
+          ~post:(Token_count.post_recount new_msg_count)
+      with
+      | `Saved n -> n, None
+      | `Divergent n -> 0, Some n
+    in
     Prometheus.inc_counter
       Keeper_metrics.metric_keeper_compactions
       ~labels:[ "keeper", meta.name ]
@@ -384,6 +392,14 @@ let compact_if_needed_typed
             ; "after_tokens", `Int new_tok_count
             ; "saved_messages", `Int saved_messages
             ; "saved_tokens", `Int saved_tokens
+            ; ( "tokens_divergence"
+              , match tokens_divergence with
+                | Some n -> `Int n
+                | None -> `Null )
+            ; ( "messages_divergence"
+              , match messages_divergence with
+                | Some n -> `Int n
+                | None -> `Null )
             ; ( "tool_pair_repair"
               , `Assoc
                   [ ( "downgraded_tool_uses"

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -210,7 +210,6 @@ type t =
   | TurnCleanupFailures
   | MemoryBankLoadHistorySwallowedExceptions
   | MemoryRecallReadErrors
-  | CompactionNegativeSavings
   | CascadeHttpProbeJsonParseFailures
 
 (** String conversion
@@ -426,8 +425,6 @@ let to_string = function
       "masc_keeper_memory_bank_load_history_swallowed_exceptions_total"
   | MemoryRecallReadErrors ->
       "masc_keeper_memory_recall_read_errors_total"
-  | CompactionNegativeSavings ->
-      "masc_keeper_compaction_negative_savings_total"
   | CascadeHttpProbeJsonParseFailures ->
       "masc_cascade_http_probe_json_parse_failures_total"
 ;;
@@ -1015,9 +1012,6 @@ let metric_keeper_memory_recall_read_errors =
   to_string MemoryRecallReadErrors
 ;;
 
-let metric_keeper_compaction_negative_savings =
-  to_string CompactionNegativeSavings
-;;
 let metric_cascade_http_probe_json_parse_failures =
   to_string CascadeHttpProbeJsonParseFailures
 ;;

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -202,7 +202,6 @@ type t =
   | TurnCleanupFailures
   | MemoryBankLoadHistorySwallowedExceptions
   | MemoryRecallReadErrors
-  | CompactionNegativeSavings
   | CascadeHttpProbeJsonParseFailures
 
 val to_string : t -> string
@@ -657,20 +656,6 @@ val metric_keeper_memory_bank_load_history_swallowed_exceptions : string
     as the load-history counter so cardinality is bounded. Behavior is
     unchanged (read still returns [[]] on failure). *)
 val metric_keeper_memory_recall_read_errors : string
-
-(** Counter for compactions where the post-compact recount exceeds the
-    pre-compact estimate, in which case [max 0 (pre - post)] silently
-    floors [saved_tokens] / [saved_messages] to zero. This used to mask
-    a divergence between the two count sources (the token / message
-    counter applied before and after compaction) — operators saw
-    [saved_tokens=0] without any signal that the post-count had grown.
-    The [kind] label is a closed 2-value vocabulary ([tokens] |
-    [messages]); the counter is incremented by one per affected
-    compaction, not by the negative delta, so a single divergent cycle
-    is visible without an unbounded magnitude term. Behavior is
-    unchanged (the floored value still propagates to the existing
-    [saved_tokens] / [saved_messages] gauges and the JSONL audit row). *)
-val metric_keeper_compaction_negative_savings : string
 
 (** Counter for probe responses dropped by the silent JSON parse catch-all
     in [Cascade_http_probe.try_probe]. Before this counter existed the

--- a/lib/keeper/token_count.ml
+++ b/lib/keeper/token_count.ml
@@ -1,0 +1,15 @@
+(** See [token_count.mli] for the rationale (RFC-0149 §3.2). *)
+
+type pre
+type post
+type 'phase t = int
+
+let pre_estimate (n : int) : pre t = max 0 n
+let post_recount (n : int) : post t = max 0 n
+
+let to_int (n : _ t) : int = n
+
+let saved ~(pre : pre t) ~(post : post t) :
+    [ `Saved of int | `Divergent of int ] =
+  if post <= pre then `Saved (pre - post)
+  else `Divergent (post - pre)

--- a/lib/keeper/token_count.mli
+++ b/lib/keeper/token_count.mli
@@ -1,0 +1,50 @@
+(** Phantom-typed pre/post token counts for compaction accounting.
+
+    RFC-0149 §3.2 root-fix.  The legacy
+    [let saved_tokens = max 0 (tok_count - new_tok_count)] in
+    [keeper_compact_policy.ml] silently floored the negative-delta case
+    to zero and routed the divergence detection through the
+    [metric_keeper_compaction_negative_savings] counter — a §1
+    telemetry-as-fix.  The two operands originate from the same
+    estimator ([token_count]) applied to two different contexts, so an
+    *estimate divergence* (post > pre) cannot be statically prevented;
+    it must instead become *representable* in the type system, so
+    callers cannot ignore it.
+
+    Phantom tags discriminate the two roles ([pre] / [post]).  The
+    compiler enforces that pre/post arguments cannot be swapped, and
+    the [saved] result variant ([`Saved of int] vs [`Divergent of int])
+    makes the floor non-bypassable: there is no path that silently
+    coerces a negative delta to zero. *)
+
+(** Phantom tag for pre-compaction estimates. *)
+type pre
+
+(** Phantom tag for post-compaction recounts. *)
+type post
+
+(** A count witnessed under a specific phase tag.  [private int] so the
+    only ways to construct one are the smart constructors below; the
+    representation stays a single boxed int with zero runtime cost. *)
+type 'phase t = private int
+
+(** Construct a pre-compaction estimate.  Negative inputs are clamped
+    to zero (token counts are non-negative by domain). *)
+val pre_estimate : int -> pre t
+
+(** Construct a post-compaction recount.  Negative inputs are clamped
+    to zero (token counts are non-negative by domain). *)
+val post_recount : int -> post t
+
+(** Extract the underlying int.  Kept narrow so renderers and metrics
+    emitters can still read the value, but constructing a new count
+    from an arbitrary int is impossible. *)
+val to_int : _ t -> int
+
+(** The saving computation: [pre - post] when [post <= pre], or
+    [`Divergent (post - pre)] when the post-recount exceeded the
+    pre-estimate.  The variant forces the caller to pattern-match,
+    eliminating the silent floor.  The [`Divergent] payload carries
+    the positive magnitude of the divergence so it can drive metrics
+    or operator alerts. *)
+val saved : pre:pre t -> post:post t -> [ `Saved of int | `Divergent of int ]

--- a/test/dune
+++ b/test/dune
@@ -137,6 +137,7 @@
   test_keeper_wake_telemetry
   test_keeper_timing
   test_keeper_memory
+  test_token_count
   test_memory_jsonl_truncation
   test_keeper_chat_store
   test_keeper_runtime_trust_snapshot
@@ -453,6 +454,7 @@
   test_keeper_wake_telemetry
   test_keeper_timing
   test_keeper_memory
+  test_token_count
   test_memory_jsonl_truncation
   test_keeper_chat_store
   test_keeper_runtime_trust_snapshot

--- a/test/test_token_count.ml
+++ b/test/test_token_count.ml
@@ -1,0 +1,63 @@
+(** Phantom-typed token count tests (RFC-0149 §3.2 PR-1). *)
+
+open Alcotest
+
+module Token_count = Masc_mcp.Token_count
+
+let result_pp ppf = function
+  | `Saved n -> Format.fprintf ppf "`Saved %d" n
+  | `Divergent n -> Format.fprintf ppf "`Divergent %d" n
+
+let result_eq a b =
+  match a, b with
+  | `Saved x, `Saved y -> x = y
+  | `Divergent x, `Divergent y -> x = y
+  | _ -> false
+
+let saved_t = testable result_pp result_eq
+
+let saved_when_post_smaller () =
+  let pre = Token_count.pre_estimate 1000 in
+  let post = Token_count.post_recount 200 in
+  check saved_t "post < pre yields Saved" (`Saved 800)
+    (Token_count.saved ~pre ~post)
+
+let saved_zero_when_equal () =
+  let pre = Token_count.pre_estimate 500 in
+  let post = Token_count.post_recount 500 in
+  check saved_t "post = pre yields Saved 0" (`Saved 0)
+    (Token_count.saved ~pre ~post)
+
+let divergent_when_post_bigger () =
+  let pre = Token_count.pre_estimate 300 in
+  let post = Token_count.post_recount 500 in
+  check saved_t "post > pre yields Divergent" (`Divergent 200)
+    (Token_count.saved ~pre ~post)
+
+let negative_input_clamps_to_zero () =
+  let pre = Token_count.pre_estimate (-100) in
+  let post = Token_count.post_recount (-50) in
+  check int "pre clamped to 0" 0 (Token_count.to_int pre);
+  check int "post clamped to 0" 0 (Token_count.to_int post);
+  check saved_t "0 vs 0 yields Saved 0" (`Saved 0)
+    (Token_count.saved ~pre ~post)
+
+let to_int_preserves_value () =
+  let pre = Token_count.pre_estimate 1234 in
+  check int "to_int round-trips constructor input" 1234
+    (Token_count.to_int pre)
+
+let () =
+  run "token_count"
+    [ ( "saved variant"
+      , [ test_case "post smaller -> Saved" `Quick saved_when_post_smaller
+        ; test_case "post equal -> Saved 0" `Quick saved_zero_when_equal
+        ; test_case "post bigger -> Divergent" `Quick
+            divergent_when_post_bigger
+        ] )
+    ; ( "construction"
+      , [ test_case "negative inputs clamp to zero" `Quick
+            negative_input_clamps_to_zero
+        ; test_case "to_int round-trips" `Quick to_int_preserves_value
+        ] )
+    ]


### PR DESCRIPTION
## Goal

Close §3.2 — replace the silent `max 0 (pre - post)` floor and the §1 telemetry-as-fix counter `metric_keeper_compaction_negative_savings` with a phantom-typed `Token_count.saved` match.

## Change

### `lib/keeper/keeper_compact_policy.ml`

```diff
-    (* [max 0 (pre - post)] silently floors the negative-delta case to
-       zero. Surface that case as a counter so operators can detect ... *)
-    if tok_count < new_tok_count then
-      Prometheus.inc_counter
-        Keeper_metrics.metric_keeper_compaction_negative_savings ...;
-    if msg_count < new_msg_count then
-      Prometheus.inc_counter
-        Keeper_metrics.metric_keeper_compaction_negative_savings ...;
-    let saved_tokens = max 0 (tok_count - new_tok_count) in
-    let saved_messages = max 0 (msg_count - new_msg_count) in
+    let saved_tokens, tokens_divergence =
+      match
+        Token_count.saved
+          ~pre:(Token_count.pre_estimate tok_count)
+          ~post:(Token_count.post_recount new_tok_count)
+      with
+      | `Saved n -> n, None
+      | `Divergent n -> 0, Some n
+    in
+    let saved_messages, messages_divergence = … (same shape for messages)
```

The `Divergent` payload (positive overrun magnitude) propagates to the post-compact JSONL audit row:

```diff
   ; "saved_messages", `Int saved_messages
   ; "saved_tokens", `Int saved_tokens
+  ; ( "tokens_divergence", match tokens_divergence with Some n -> `Int n | None -> `Null )
+  ; ( "messages_divergence", match messages_divergence with Some n -> `Int n | None -> `Null )
```

### Counter sunset (per RFC-0149 §3.2 criterion)

4 sites cleaned in `keeper_metrics.ml(i)`:

* Variant constructor `CompactionNegativeSavings` (decl + .mli)
* `to_string` arm
* Public binding `metric_keeper_compaction_negative_savings`
* Interface doc-comment + `val`

`masc_keeper_compaction_negative_savings_total` is no longer emitted; the `metric_keeper_compactions` / `metric_keeper_compaction_ratio_change` / `metric_keeper_compaction_saved_tokens` instrumentation is unchanged.

## Operator surface

| Pre/post relation | `saved_tokens` (or `_messages`) | `tokens_divergence` | Old behavior |
|-------------------|--------------------------------|---------------------|--------------|
| `post < pre`      | `pre - post` (positive)        | `null`              | same value, no counter |
| `post = pre`      | `0`                            | `null`              | same value, no counter |
| `post > pre`      | `0`                            | `<positive>`        | `0`, opaque counter — magnitude was discarded |

The third row is the §3.2 fix: divergence magnitude is now structurally observable on the JSONL audit row, where it can be correlated with the keeper / trigger / before-after ratios.

## Verification

* `dune build --root . lib/keeper/keeper_compact_policy.ml` → compiles (my diff is consistent).
* Full `dune build lib/` currently fails on `origin/main` due to **unrelated** pre-existing breakage:
  * `Keeper_turn_driver.Oas_timeout_budget` unbound
  * `Keeper_turn_disposition.Provider_timeout` unbound
  * Sites: `keeper_unified_turn_types.ml`, `keeper_unified_metrics_failure.ml`, `keeper_unified_turn.ml`, `keeper_error_classify.ml`
  
  These belong to the recent codex cascade-timeout PR family (#17721 / #17722 / #17725) and are independent of `keeper_compact_policy.ml` / `keeper_metrics.ml`. Once they're restored on `origin/main`, this PR will build clean.

## Stack context

| PR | Status | Scope |
|----|--------|-------|
| #17739 | Draft  | §3.2 PR-1 — `Token_count` module + tests |
| **this** | Draft | **§3.2 PR-2 — caller migration + counter sunset** |

PR-2 stacks on PR-1.  PR-1 must merge first (or be folded together) since this PR consumes `Token_count.saved`.

## Anti-pattern self-check

- §1 telemetry-as-fix? **Sunsetting** one — the conditional `inc_counter` is removed and replaced by a typed `Divergent` payload that propagates to the structured audit row, not a free-floating metric. This is the canonical §1 → typed-boundary trade RFC-0149 prescribes.
- §2 substring classifier? No — `[Saved | Divergent]` is a closed 2-arm sum, no string label.
- §3 N-of-M? No — both `saved_tokens` and `saved_messages` sites migrate in a single PR; both counter-emission sites are removed in the same diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>