### PR TITLE
fix(cascade): collapse timeout budget error state

### DIFF
--- a/test/test_keeper_cascade_auto_pause_task074.ml
+++ b/test/test_keeper_cascade_auto_pause_task074.ml
@@ -77,7 +77,7 @@ let test_pause_fires_on_cascade_exhausted_variants () =
 
 let mk_oas_timeout_budget () =
   Owne.sdk_error_of_masc_internal_error
-    (Owne.Oas_timeout_budget
+    (Owne.Provider_timeout
        { budget_sec = 30.0;
          keeper_turn_timeout_sec = 60.0;
          estimated_input_tokens = 1000;


### PR DESCRIPTION
## Summary
- rename the cascade structured timeout-budget ADT from `Oas_timeout_budget` to `Provider_timeout`
- parse both `provider_timeout` and legacy `oas_timeout_budget` envelopes into the canonical provider-timeout variant
- update cascade/keeper/test consumers so timeout-budget is no longer a live typed cascade error constructor

## Validation
- Not run; user requested PR iteration without local validation.
