### PR TITLE
fix(keeper): rename provider timeout pause handler

### DIFF
--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -637,8 +637,8 @@ let handle_stale_storm_pause ctx entry =
   Pause_policy.handle_stale_storm_pause ~publish_phase_lifecycle ctx entry
 ;;
 
-let handle_oas_timeout_budget_pause ctx entry =
-  Pause_policy.handle_oas_timeout_budget_pause ~publish_phase_lifecycle ctx entry
+let handle_provider_timeout_pause ctx entry =
+  Pause_policy.handle_provider_timeout_pause ~publish_phase_lifecycle ctx entry
 ;;
 
 let failure_reason_policy_decision = Pause_policy.failure_reason_policy_decision
@@ -718,10 +718,10 @@ let sweep_and_recover (ctx : _ context) =
          handle_stale_storm_pause ctx entry ~count;
          to_unregister := entry :: !to_unregister
        | Some (Keeper_registry.Provider_timeout_loop { count }) ->
-         (* Watchdog-preserved OAS budget loops include liveness evidence,
+         (* Watchdog-preserved provider-timeout loops include liveness evidence,
             so policy allows keeper pause without treating timeout alone as
             keeper death. *)
-         handle_oas_timeout_budget_pause ctx entry ~count;
+         handle_provider_timeout_pause ctx entry ~count;
          to_unregister := entry :: !to_unregister
        | Some
            ( Keeper_registry.Heartbeat_consecutive_failures _

--- a/lib/keeper/keeper_supervisor_pause_policy.ml
+++ b/lib/keeper/keeper_supervisor_pause_policy.ml
@@ -8,7 +8,7 @@
     - the unified entrypoint [handle_crash_auto_pause] used by both
       stale-termination-storm and OAS-timeout-budget-loop pause paths;
     - thin per-cause wrappers [handle_stale_storm_pause] and
-      [handle_oas_timeout_budget_pause] (legacy registry input,
+      [handle_provider_timeout_pause] (legacy registry input,
       surfaced as a provider-timeout loop);
     - the read-side classifier [failure_reason_policy_decision] that
       maps a persisted [Keeper_registry.failure_reason] back to a
@@ -159,7 +159,7 @@ let handle_stale_storm_pause
          count)
 ;;
 
-let handle_oas_timeout_budget_pause
+let handle_provider_timeout_pause
       ~publish_phase_lifecycle
       (ctx : _ context)
       (entry : Keeper_registry.registry_entry)

--- a/lib/keeper/keeper_supervisor_pause_policy.mli
+++ b/lib/keeper/keeper_supervisor_pause_policy.mli
@@ -63,11 +63,11 @@ val handle_stale_storm_pause
   -> count:int
   -> unit
 
-(** [handle_oas_timeout_budget_pause ~publish_phase_lifecycle ctx entry
-      ~count] pauses [entry] because the OAS provider call timed out
+(** [handle_provider_timeout_pause ~publish_phase_lifecycle ctx entry
+      ~count] pauses [entry] because the provider call timed out
     [count] times in a budget window. Auto-resume with exponential
     back-off (see [MASC_KEEPER_AUTO_RESUME_INITIAL_SEC]). *)
-val handle_oas_timeout_budget_pause
+val handle_provider_timeout_pause
   :  publish_phase_lifecycle:
        (phase:Keeper_state_machine.phase -> string -> string -> unit -> unit)
   -> _ context


### PR DESCRIPTION
## Summary
- rename supervisor provider-timeout auto-pause handlers away from `oas_timeout_budget`
- keep provider-timeout loop lifecycle behavior unchanged
- update pause-policy comments and supervisor call sites so timeout-budget is no longer the pause-handler identity

## Validation
- Not run; user requested PR iteration without local validation.
