### PR TITLE
fix(build): correct mli types for post-turn memory and phase5 task link

### DIFF
--- a/lib/keeper/keeper_agent_run_phase5_task_link.mli
+++ b/lib/keeper/keeper_agent_run_phase5_task_link.mli
@@ -2,7 +2,7 @@
     Extracted from [Keeper_agent_run.run_turn] Step 8 body (RFC-0147 PR-9). *)
 
 val run :
-  config:Coord_utils.config ->
+  config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
   acc:Keeper_run_tools.hook_accumulator ->
   unit ->

--- a/lib/keeper/keeper_agent_run_post_turn_memory.mli
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.mli
@@ -9,7 +9,7 @@
     counted, never propagated.  [Eio.Cancel.Cancelled] is re-raised. *)
 
 val run :
-  config:Coord_utils.config ->
+  config:Coord.config ->
   meta:Keeper_types.keeper_meta ->
   memory:Agent_sdk.Memory.t ->
   turn:int ->


### PR DESCRIPTION
Fixes type mismatches introduced in RFC-0147 PR-4 and PR-9, plus regression from #17711:

- [keeper_agent_run_post_turn_memory.mli] Fix [Coord_utils.config -> Coord.config]
- [keeper_agent_run_phase5_task_link.mli] Fix [Coord_utils.config -> Coord.config]
- [keeper_status.ml] Restore [memory_bank_summary] binding removed in #17711, using [read_keeper_memory_summary_result] with empty fallback on Error

Build verified: [test_worker_dev_tools.exe] 172/172 PASS