### PR TITLE
docs: canonicalize provider timeout source wording

### DIFF
--- a/lib/agent_stress.mli
+++ b/lib/agent_stress.mli
@@ -42,7 +42,7 @@ type stress_kind =
   | Turn_failure of turn_failure (** keeper turn ended in an error/partial outcome *)
   | Fallback_approval            (** anti-rat or post-verifier fell back to approve *)
   | Timeout                      (** OAS/LLM call timed out *)
-  | Provider_timeout             (** provider/OAS stream timed out *)
+  | Provider_timeout             (** provider stream timed out *)
   | Capacity_pressure            (** admission, cascade, or provider capacity pressure *)
   | Turn_liveness                (** stale turn, heartbeat, or fiber liveness issue *)
   | Parse_degraded               (** LLM response required fallback parsing *)

--- a/lib/cascade/cascade_event_bridge.ml
+++ b/lib/cascade/cascade_event_bridge.ml
@@ -280,7 +280,7 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
     (* #9935: track imminent→action pairing so an unanswered
          overflow (no compact_started/compacted within grace
          window) is observable via metric + warn log, rather
-         than silently burning out on oas_timeout_budget. *)
+         than silently burning out as provider_timeout. *)
     Prometheus.set_gauge
       Prometheus.metric_oas_context_overflow_ratio
       ~labels:[ "agent_name", agent_name ]

--- a/lib/context_overflow_action_tracker.mli
+++ b/lib/context_overflow_action_tracker.mli
@@ -8,7 +8,7 @@
     Issue #9935 evidence: 45 imminent events per day fleet-wide
     with no observability on whether any reduction action followed.
     The scheduler can continue firing turns on an overflowed
-    keeper, which then burns out on the oas_timeout_budget
+    keeper, which then burns out as provider_timeout
     (#9933). This module closes the loop by tracking per-keeper
     state and emitting metrics when an imminent event goes
     unanswered within a grace window.

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -85,7 +85,7 @@ let disposition_of_runtime_blocker_class
       Keeper_turn_disposition.Required_tool_use_unsatisfied
   | "oas_timeout_budget"
   (* Legacy decode only: do not resurrect the retired synthetic
-     Oas_timeout_budget disposition from dashboard/runtime-trust wire. *)
+     timeout-budget disposition from dashboard/runtime-trust wire. *)
   | "turn_timeout"
   | "turn_timeout_after_queue_wait"
   | "stale_turn_timeout" ->

--- a/lib/keeper/social_model/keeper_social_model_types.ml
+++ b/lib/keeper/social_model/keeper_social_model_types.ml
@@ -171,8 +171,8 @@ let default_option_field_max_chars = 200
    Agent_sdk.Error.to_string's "Internal error: [masc_oas_error]" wrapper)
    must NOT be truncated at the narrative budget, or the JSON body is
    cut mid-key and downstream consumers (dashboard, retry classifier,
-   log search) see a partial kind=oas_timeout_budget record with the
-   budget-underscore value missing, and cannot recover the diagnostic
+   log search) see a partial provider-timeout record with the
+   budget value missing, and cannot recover the diagnostic
    fields. The operator ends up re-filing the same triage ticket
    because the budget value, elapsed time, and source field never
    reach them. *)

--- a/lib/memory_oas_bridge.mli
+++ b/lib/memory_oas_bridge.mli
@@ -236,9 +236,9 @@ val timeout_error_kinds : error_kind list
     {!stress_kind_for_error_kind} mapper treats as
     timeout-class.  Pinned because
     [test/test_agent_stress_timeout_wire_10341.ml] asserts
-    its length to keep the catalogue from drifting.  Legacy
-    [oas_timeout_budget] is intentionally not listed; callers should
-    emit owner-specific timeout kinds such as [provider_timeout]. *)
+    its length to keep the catalogue from drifting. Legacy timeout-budget
+    wire labels are intentionally not listed; callers should emit
+    owner-specific timeout kinds such as [provider_timeout]. *)
 
 val stress_kind_for_error_kind :
   error_kind -> Agent_stress.stress_kind option


### PR DESCRIPTION
## Summary
- replace source-level timeout-budget wording with provider-timeout wording in runtime-trust, cascade-event, memory, and context-overflow comments
- keep legacy wire compatibility described as compatibility input rather than a live root cause
- align agent stress documentation with the provider-timeout canonical name

## Validation
- Not run; user requested PR iteration without local validation.
