### PR TITLE
fix(keeper): canonicalize runtime trust timeout labels

### DIFF
--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -79,13 +79,14 @@ let terminal_reason_from_receipt receipt =
    The provider-runtime classes preserve their originating blocker
    string in the typed payload instead of collapsing to a single
    "provider_error" literal. *)
-let disposition_of_runtime_blocker_class
-    : string -> Keeper_turn_disposition.t = function
+let canonical_runtime_blocker_class = function
+  | "oas_timeout_budget" -> "turn_timeout"
+  | blocker_class -> blocker_class
+
+let disposition_of_runtime_blocker_class raw_blocker_class =
+  match canonical_runtime_blocker_class raw_blocker_class with
   | "completion_contract_violation" | "tool_required_unsatisfied" ->
       Keeper_turn_disposition.Required_tool_use_unsatisfied
-  | "oas_timeout_budget"
-  (* Legacy decode only: do not resurrect the retired synthetic
-     timeout-budget disposition from dashboard/runtime-trust wire. *)
   | "turn_timeout"
   | "turn_timeout_after_queue_wait"
   | "stale_turn_timeout" ->


### PR DESCRIPTION
## Summary
- canonicalize legacy `oas_timeout_budget` runtime-trust blocker labels to `turn_timeout` before disposition mapping
- remove timeout-budget from the primary runtime-trust disposition match
- keep legacy dashboard/runtime-trust wire compatibility at the decoder boundary

## Validation
- Not run; user requested PR iteration without local validation.
