### PR TITLE
feat(keeper): add 3 _result companions for memory recall readers (RFC-0149 §3.1 PR-9)

### DIFF
--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -142,17 +142,11 @@ let read_keeper_memory_summary
   in
   summarize_memory_bank_lines lines ~recent_limit
 
-let read_memory_horizon_counts
-    (config : Coord.config)
-    ~(name : string)
-    ~(max_bytes : int)
-    ~(max_lines : int) : (string * int) list =
-  let lines =
-    read_file_tail_lines
-      (keeper_memory_bank_path config name)
-      ~max_bytes
-      ~max_lines
-  in
+(* RFC-0149 §3.1: pure list -> list reducer extracted so the legacy
+   silent-fallback path and the [_result] variant share the same
+   business logic. *)
+let memory_horizon_counts_from_lines (lines : string list) :
+    (string * int) list =
   let counts : (string, int) Hashtbl.t = Hashtbl.create 8 in
   List.iter
     (fun line ->
@@ -172,19 +166,43 @@ let read_memory_horizon_counts
          let c = compare vb va in
          if c <> 0 then c else String.compare ka kb)
 
-let read_recent_memory_texts
+(* RFC-0149 §3.1: typed Result variant.  Distinguishes [Ok []] ("no
+   horizon rows recorded") from [Error class] ("bank read failed"). *)
+let read_memory_horizon_counts_result
     (config : Coord.config)
     ~(name : string)
-    ~(horizon : string)
     ~(max_bytes : int)
-    ~(max_lines : int)
-    ~(limit : int) : string list =
+    ~(max_lines : int) :
+    ((string * int) list, Keeper_memory_recall_exn_class.t) result =
+  match
+    read_file_tail_lines_result
+      (keeper_memory_bank_path config name)
+      ~max_bytes
+      ~max_lines
+  with
+  | Ok lines -> Ok (memory_horizon_counts_from_lines lines)
+  | Error exn_class -> Error exn_class
+
+let read_memory_horizon_counts
+    (config : Coord.config)
+    ~(name : string)
+    ~(max_bytes : int)
+    ~(max_lines : int) : (string * int) list =
   let lines =
     read_file_tail_lines
       (keeper_memory_bank_path config name)
       ~max_bytes
       ~max_lines
   in
+  memory_horizon_counts_from_lines lines
+
+(* RFC-0149 §3.1: pure list -> list filter extracted as a horizon-aware
+   memory text projector.  Shared between the legacy facade and the
+   [_result] variant. *)
+let recent_memory_texts_from_lines
+    ~(horizon : string)
+    ~(limit : int)
+    (lines : string list) : string list =
   lines
   |> List.filter_map parse_memory_bank_row
   |> List.filter (fun row ->
@@ -206,6 +224,41 @@ let read_recent_memory_texts
   |> dedup_by_key (fun row -> normalize_memory_text_key row.text)
   |> take (max 0 limit)
   |> List.map (fun row -> row.text)
+
+(* RFC-0149 §3.1: typed Result variant.  Distinguishes [Ok []] ("no
+   recent texts for this horizon") from [Error class] ("bank read
+   failed"). *)
+let read_recent_memory_texts_result
+    (config : Coord.config)
+    ~(name : string)
+    ~(horizon : string)
+    ~(max_bytes : int)
+    ~(max_lines : int)
+    ~(limit : int) :
+    (string list, Keeper_memory_recall_exn_class.t) result =
+  match
+    read_file_tail_lines_result
+      (keeper_memory_bank_path config name)
+      ~max_bytes
+      ~max_lines
+  with
+  | Ok lines -> Ok (recent_memory_texts_from_lines ~horizon ~limit lines)
+  | Error exn_class -> Error exn_class
+
+let read_recent_memory_texts
+    (config : Coord.config)
+    ~(name : string)
+    ~(horizon : string)
+    ~(max_bytes : int)
+    ~(max_lines : int)
+    ~(limit : int) : string list =
+  let lines =
+    read_file_tail_lines
+      (keeper_memory_bank_path config name)
+      ~max_bytes
+      ~max_lines
+  in
+  recent_memory_texts_from_lines ~horizon ~limit lines
 
 (** Detect whether a query is asking about past conversation memory.
 
@@ -666,11 +719,15 @@ let recent_user_messages (msgs : Agent_sdk.Types.message list) ~(max_n : int) : 
        else None)
   |> take max_n
 
-(** Load user messages from a history.jsonl file (persisted across generations).
-    Each line is a JSON object with "role" and "content" fields.
-    Returns up to [max_n] user messages from the tail of the file. *)
-let load_history_user_messages ~(path : string) ~(max_n : int) : string list =
-  let lines = read_file_tail_lines path ~max_bytes:0 ~max_lines:(max_n * 3) in
+(* RFC-0149 §3.1: pure list -> list filter extracted so the legacy
+   silent-fallback path and the [_result] variant share the same
+   per-line parsing logic.  The per-line [try ... with exn -> log +
+   counter + None] is preserved here — that is a separate boundary
+   (JSONL corruption) from the file-read IO fault. *)
+let history_user_messages_from_lines
+    ~(path : string)
+    ~(max_n : int)
+    (lines : string list) : string list =
   lines
   |> List.filter_map (fun line ->
        try
@@ -719,6 +776,32 @@ let load_history_user_messages ~(path : string) ~(max_n : int) : string list =
              ();
            None)
   |> take max_n
+
+(* RFC-0149 §3.1: typed Result variant.  Distinguishes [Ok []] ("no
+   user messages found in the history file") from [Error class] ("the
+   history file read failed"). *)
+let load_history_user_messages_result
+    ~(path : string)
+    ~(max_n : int) :
+    (string list, Keeper_memory_recall_exn_class.t) result =
+  match
+    read_file_tail_lines_result
+      path
+      ~max_bytes:0
+      ~max_lines:(max_n * 3)
+  with
+  | Ok lines ->
+    Ok (history_user_messages_from_lines ~path ~max_n lines)
+  | Error exn_class -> Error exn_class
+
+(** Load user messages from a history.jsonl file (persisted across generations).
+    Each line is a JSON object with "role" and "content" fields.
+    Returns up to [max_n] user messages from the tail of the file. *)
+let load_history_user_messages ~(path : string) ~(max_n : int) : string list =
+  let lines =
+    read_file_tail_lines path ~max_bytes:0 ~max_lines:(max_n * 3)
+  in
+  history_user_messages_from_lines ~path ~max_n lines
 
 (** Build recall candidates by merging checkpoint messages with history.jsonl.
     Checkpoint messages are prioritized (recent context), history.jsonl

--- a/lib/keeper/keeper_memory_recall.mli
+++ b/lib/keeper/keeper_memory_recall.mli
@@ -64,12 +64,42 @@ val read_keeper_memory_summary :
     window; new callers should prefer
     {!read_keeper_memory_summary_result}. *)
 
+val read_memory_horizon_counts_result :
+  Coord.config ->
+  name:string ->
+  max_bytes:int ->
+  max_lines:int ->
+  ((string * int) list, Keeper_memory_recall_exn_class.t) result
+(** Result-returning variant of {!read_memory_horizon_counts}.  On
+    [Error class] the caller can distinguish "no horizon counts because
+    the bank is empty" ([Ok []]) from "the bank read failed"
+    ([Error class]).
+
+    @since RFC-0149 §3.1 *)
+
 val read_memory_horizon_counts :
   Coord.config ->
   name:string ->
   max_bytes:int ->
   max_lines:int ->
   (string * int) list
+(** Silent-fallback variant: returns [[]] on any IO failure.  Retained
+    as a facade during the RFC-0149 §3.1 sunset window; new callers
+    should prefer {!read_memory_horizon_counts_result}. *)
+
+val read_recent_memory_texts_result :
+  Coord.config ->
+  name:string ->
+  horizon:string ->
+  max_bytes:int ->
+  max_lines:int ->
+  limit:int ->
+  (string list, Keeper_memory_recall_exn_class.t) result
+(** Result-returning variant of {!read_recent_memory_texts}.  On
+    [Error class] the caller can distinguish "no recent texts in this
+    horizon" ([Ok []]) from "the bank read failed" ([Error class]).
+
+    @since RFC-0149 §3.1 *)
 
 val read_recent_memory_texts :
   Coord.config ->
@@ -79,6 +109,9 @@ val read_recent_memory_texts :
   max_lines:int ->
   limit:int ->
   string list
+(** Silent-fallback variant: returns [[]] on any IO failure.  Retained
+    as a facade during the RFC-0149 §3.1 sunset window; new callers
+    should prefer {!read_recent_memory_texts_result}. *)
 
 (** {1 Query Detection} *)
 
@@ -192,8 +225,22 @@ val learned_policy_auto_rules :
 val recent_user_messages :
   Agent_sdk.Types.message list -> max_n:int -> string list
 
+val load_history_user_messages_result :
+  path:string ->
+  max_n:int ->
+  (string list, Keeper_memory_recall_exn_class.t) result
+(** Result-returning variant of {!load_history_user_messages}.  On
+    [Error class] the caller can distinguish "no user messages in the
+    history file" ([Ok []]) from "the history file read failed"
+    ([Error class]).
+
+    @since RFC-0149 §3.1 *)
+
 val load_history_user_messages :
   path:string -> max_n:int -> string list
+(** Silent-fallback variant: returns [[]] on any IO failure.  Retained
+    as a facade during the RFC-0149 §3.1 sunset window; new callers
+    should prefer {!load_history_user_messages_result}. *)
 
 val recall_candidates_with_history :
   checkpoint_messages:Agent_sdk.Types.message list ->


### PR DESCRIPTION
## Goal

Add Result-returning variants for the three remaining direct callers of `read_file_tail_lines` inside `keeper_memory_recall.ml` — the second arm of RFC-0149 §3.1.  Helper-only; unblocks the §3.1 closeout (counter+WARN reclassification per the RFC sunset criterion).

## Surface scope

Per RFC-0149 §3.1, the caller fan-out inside the memory recall module is:

| Function | Existing | New |
|----------|----------|-----|
| `read_keeper_memory_summary` | facade | `read_keeper_memory_summary_result` (PR-2 #17702) ✅ |
| `read_memory_horizon_counts` | facade | **`read_memory_horizon_counts_result`** (this PR) |
| `read_recent_memory_texts` | facade | **`read_recent_memory_texts_result`** (this PR) |
| `load_history_user_messages` | facade | **`load_history_user_messages_result`** (this PR) |

The 15+ direct call sites of `read_file_tail_lines` outside `keeper_memory_recall.ml` (dashboard / operator / tool surfaces consuming metrics, alerts, history paths) are **out of §3.1 scope** — they read non-memory-bank files where the silent-empty contract is intended.

## Refactor pattern

Each function pair shares a pure `*_from_lines` reducer that holds the original list -> list business logic (parse + filter + sort + dedup).  The legacy facade and the `_result` variant compose IO + reducer so the two paths cannot drift apart.

```ocaml
let memory_horizon_counts_from_lines lines = …  (* pure *)

let read_memory_horizon_counts_result config ~name ~max_bytes ~max_lines =
  match read_file_tail_lines_result (keeper_memory_bank_path config name)
          ~max_bytes ~max_lines with
  | Ok lines -> Ok (memory_horizon_counts_from_lines lines)
  | Error exn_class -> Error exn_class

let read_memory_horizon_counts config ~name ~max_bytes ~max_lines =
  let lines =
    read_file_tail_lines (keeper_memory_bank_path config name)
      ~max_bytes ~max_lines
  in
  memory_horizon_counts_from_lines lines
```

Same shape for the other two pairs.

## States

For each `_result` variant:

| Underlying | `_result` | Legacy facade |
|------------|-----------|---------------|
| Bank file empty / no matching rows | `Ok []` | `[]` |
| Bank file IO fault | `Error exn_class` | `[]` (silent) |
| Bank file fully read | `Ok rows` | `rows` |

The first two rows were previously indistinguishable at the legacy boundary — that is exactly the §3.1 telemetry-as-fix collapse the typed variant unwinds.

## Out of scope

- Downstream caller migration: `keeper_exec_memory.ml:455`, `keeper_turn.ml:353`, plus tests will move to `_result` in subsequent PRs.
- Per-line JSONL exception handling inside `history_user_messages_from_lines` is left in place — that is a separate failure boundary (corrupt line) from the file-read IO fault and not a §3.1 target.

## Verification

- `dune build --root . lib/keeper/` (filtered to my files) → my diff compiles.
- Full `dune build lib/` currently fails on `origin/main` due to **unrelated** pre-existing breakage:
  - `Keeper_turn_driver.Oas_timeout_budget` unbound
  - `Keeper_turn_disposition.Provider_timeout` unbound
  - Sites: `keeper_unified_turn.ml`, `keeper_turn_cascade_budget.ml`, `keeper_status_bridge.ml`, `keeper_unified_metrics_failure.ml`, `keeper_unified_turn_types.ml`, `keeper_error_classify.ml`
  
  These belong to the recent codex cascade-timeout PR family (#17721 / #17722 / #17725) and are independent of `keeper_memory_recall.ml`.

## Stack context

| PR | Status | Scope |
|----|--------|-------|
| #17670 | MERGED | §3.1 PR-1 — `read_file_tail_lines_result` |
| #17681 | MERGED | §3.1 PR-1.5 — unit tests |
| #17702 | MERGED | §3.1 PR-2 — `read_keeper_memory_summary_result` |
| #17708 | MERGED | §3.1 PR-3 — test sites |
| #17711 / #17717 / #17724 / #17728 / #17732 | MERGED | §3.1 PR-4..PR-8 — 5 production callers |
| #17739 / #17746 | MERGED | §3.2 PR-1+2 — phantom `Token_count` + caller migration + counter sunset |
| **this** | Draft | **§3.1 PR-9 — 3 _result companions in keeper_memory_recall** |
| (next) | — | §3.1 PR-10 — migrate `keeper_exec_memory` + `keeper_turn` callers |
| (next) | — | §3.1 closeout — reclassify counter to informational, drop WARN-once |

## Anti-pattern self-check

- §1 telemetry-as-fix? No — adds the typed boundary that the closeout will use to demote the existing counter+WARN to informational.
- §2 substring classifier? No — reuses the existing closed 4-value `Keeper_memory_recall_exn_class.t` sum.
- §3 N-of-M? Tracked openly — 3 helpers migrated together inside `keeper_memory_recall.ml`; downstream callers tracked in the stack table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>