### PR TITLE
refactor(tools): share shell adapter helpers

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -759,7 +759,7 @@ let review
                   | Keeper_turn_driver.Admission_queue_timeout _
                   | Keeper_turn_driver.Admission_queue_rejected _
                   | Keeper_turn_driver.Turn_timeout _
-                  | Keeper_turn_driver.Oas_timeout_budget _
+                  | Keeper_turn_driver.Provider_timeout _
                   | Keeper_turn_driver.Max_tokens_ceiling_violation _
                   | Keeper_turn_driver.Ambiguous_post_commit _
                   (* RFC-0159 Phase A: opaque internal failures. *)

--- a/lib/dune
+++ b/lib/dune
@@ -269,6 +269,7 @@
   exec_policy_log_sanitize
   exec_policy_command_syntax
   exec_policy_mutation_classifier
+  exec_shell_adapter
   ;; keeper_memory sub-modules
   keeper_memory_policy_summary_filter
   keeper_memory_policy

--- a/lib/exec_shell_adapter.ml
+++ b/lib/exec_shell_adapter.ml
@@ -1,0 +1,31 @@
+(** Shared helpers for shell-like tool frontends after command policy has
+    already accepted a command and produced Shell IR. *)
+
+let shell_ir_with_default_cwd cwd ir =
+  match cwd with
+  | None -> ir
+  | Some dir ->
+    let default_cwd = Masc_exec.Path_scope.classify ~raw:dir ~cwd:dir in
+    let rec map_ir = function
+      | Masc_exec.Shell_ir.Simple simple ->
+        let simple =
+          match simple.cwd with
+          | Some _ -> simple
+          | None -> { simple with cwd = Some default_cwd }
+        in
+        Masc_exec.Shell_ir.Simple simple
+      | Masc_exec.Shell_ir.Pipeline stages ->
+        Masc_exec.Shell_ir.Pipeline (List.map map_ir stages)
+    in
+    map_ir ir
+;;
+
+let output_for_dispatch_status ~(status : Unix.process_status) ~stdout ~stderr =
+  match status with
+  | Unix.WEXITED 0 -> stdout
+  | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> (
+    match stdout, stderr with
+    | "", err -> err
+    | out, "" -> out
+    | out, err -> out ^ "\n" ^ err)
+;;

--- a/lib/exec_shell_adapter.mli
+++ b/lib/exec_shell_adapter.mli
@@ -1,0 +1,13 @@
+(** Shared helpers for shell-like tool frontends after command policy has
+    already accepted a command and produced Shell IR. *)
+
+val shell_ir_with_default_cwd :
+  string option -> Masc_exec.Shell_ir.t -> Masc_exec.Shell_ir.t
+(** [shell_ir_with_default_cwd cwd ir] fills missing per-stage Shell IR [cwd]
+    values with [cwd]. Existing stage-specific cwd values are preserved. *)
+
+val output_for_dispatch_status :
+  status:Unix.process_status -> stdout:string -> stderr:string -> string
+(** Convert a dispatch status and captured output into the user-visible output
+    string. Successful commands return stdout. Failed, signaled, or stopped
+    commands return stderr, stdout, or both when both are present. *)

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -224,7 +224,7 @@ let is_auto_recoverable_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error
   | Some (Keeper_turn_driver.Admission_queue_rejected _)
   | Some (Keeper_turn_driver.Admission_queue_timeout _)
   | Some (Keeper_turn_driver.Turn_timeout _)
-  | Some (Keeper_turn_driver.Oas_timeout_budget _)
+  | Some (Keeper_turn_driver.Provider_timeout _)
   | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
   | Some (Keeper_turn_driver.Ambiguous_post_commit _)
   (* RFC-0159 Phase A: opaque internal failures. *)
@@ -244,7 +244,7 @@ let is_resumable_cli_session_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Some (Keeper_turn_driver.Admission_queue_timeout _)
   | Some (Keeper_turn_driver.Admission_queue_rejected _)
   | Some (Keeper_turn_driver.Turn_timeout _)
-  | Some (Keeper_turn_driver.Oas_timeout_budget _)
+  | Some (Keeper_turn_driver.Provider_timeout _)
   | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
   | Some (Keeper_turn_driver.Ambiguous_post_commit _)
   (* RFC-0159 Phase A: opaque internal failures. *)
@@ -359,7 +359,7 @@ let degraded_retry_after_recoverable_error
         local_recovery_retry Resumable_cli_session
     | Some (Keeper_turn_driver.Admission_queue_timeout _) ->
         local_recovery_retry Admission_queue_timeout
-    | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
+    | Some (Keeper_turn_driver.Provider_timeout _) ->
         local_recovery_retry Provider_timeout
     | Some (Keeper_turn_driver.Turn_timeout _) ->
         local_recovery_retry Turn_timeout
@@ -415,7 +415,7 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
         Some Resumable_cli_session
     | Some (Keeper_turn_driver.Admission_queue_timeout _) ->
         Some Admission_queue_timeout
-    | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
+    | Some (Keeper_turn_driver.Provider_timeout _) ->
         Some Provider_timeout
     | Some (Keeper_turn_driver.Turn_timeout _) ->
         Some Turn_timeout
@@ -726,7 +726,7 @@ let is_auto_recoverable_turn_error (err : Agent_sdk.Error.sdk_error) : bool =
 
 let should_warn_keeper_cycle_failed (err : Agent_sdk.Error.sdk_error) : bool =
   match Keeper_turn_driver.classify_masc_internal_error err with
-  | Some (Keeper_turn_driver.Oas_timeout_budget _) -> true
+  | Some (Keeper_turn_driver.Provider_timeout _) -> true
   | Some (Keeper_turn_driver.Capacity_backpressure _) -> true
   | Some (Keeper_turn_driver.Cascade_exhausted _)
   | Some (Keeper_turn_driver.Resumable_cli_session _)
@@ -783,7 +783,7 @@ let is_ambiguous_side_effect_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Some (Keeper_turn_driver.Admission_queue_rejected _)
   | Some (Keeper_turn_driver.Admission_queue_timeout _)
   | Some (Keeper_turn_driver.Turn_timeout _)
-  | Some (Keeper_turn_driver.Oas_timeout_budget _)
+  | Some (Keeper_turn_driver.Provider_timeout _)
   | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
   (* RFC-0159 Phase A: opaque internal failures are unambiguous failures. *)
   | Some (Keeper_turn_driver.Internal_unhandled_exception _)
@@ -962,7 +962,7 @@ let is_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Some (Keeper_turn_driver.Capacity_backpressure _)
   | Some (Keeper_turn_driver.Admission_queue_timeout _)
   | Some (Keeper_turn_driver.Admission_queue_rejected _)
-  | Some (Keeper_turn_driver.Oas_timeout_budget _)
+  | Some (Keeper_turn_driver.Provider_timeout _)
   | Some (Keeper_turn_driver.Turn_timeout _)
   | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
   | Some (Keeper_turn_driver.Ambiguous_post_commit _)

--- a/lib/keeper/keeper_heartbeat_loop_observations.ml
+++ b/lib/keeper/keeper_heartbeat_loop_observations.ml
@@ -188,7 +188,7 @@ let is_provider_timeout_error (err : Agent_sdk.Error.sdk_error) =
      both sweeps — the same predicate shape exists in three places
      and only this one still had a catch-all. *)
   match Keeper_turn_driver.classify_masc_internal_error err with
-  | Some (Keeper_turn_driver.Oas_timeout_budget _) -> true
+  | Some (Keeper_turn_driver.Provider_timeout _) -> true
   | Some
       ( Keeper_turn_driver.Cascade_exhausted _
       | Keeper_turn_driver.Capacity_backpressure _
@@ -224,7 +224,7 @@ let oas_timeout_budget_policy_decision
   : Keeper_failure_policy.decision option
   =
   match Keeper_turn_driver.classify_masc_internal_error err with
-  | Some (Keeper_turn_driver.Oas_timeout_budget { phase; _ }) ->
+  | Some (Keeper_turn_driver.Provider_timeout { phase; _ }) ->
     Some
       (Keeper_failure_policy.decide
          (Keeper_failure_policy.Provider_timeout

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -197,7 +197,7 @@ let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class
   | Some (Keeper_turn_driver.Admission_queue_timeout _) ->
     Some Admission_queue_wait_timeout
   | Some (Keeper_turn_driver.Admission_queue_rejected _) -> None
-  | Some (Keeper_turn_driver.Oas_timeout_budget _) -> Some Turn_timeout
+  | Some (Keeper_turn_driver.Provider_timeout _) -> Some Turn_timeout
   | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _) -> None
   | Some (Keeper_turn_driver.Turn_timeout _) -> Some Turn_timeout
   | Some (Keeper_turn_driver.Ambiguous_post_commit { is_timeout; _ }) ->

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -364,7 +364,7 @@ let degraded_retry_bypasses_slot_phase_guard
      was added to Cascade_error_classify, which is exactly the wrong default
      for a guard that decides whether to bypass slot-phase admission. *)
   match Keeper_turn_driver.classify_masc_internal_error err with
-  | Some (Keeper_turn_driver.Oas_timeout_budget _) -> true
+  | Some (Keeper_turn_driver.Provider_timeout _) -> true
   | Some (Keeper_turn_driver.Cascade_exhausted { reason; _ })
     when cascade_reason_is_structural_attempt_timeout reason ->
       true

--- a/lib/keeper/keeper_turn_terminal.ml
+++ b/lib/keeper/keeper_turn_terminal.ml
@@ -76,7 +76,7 @@ let of_failure ?(post_commit_ambiguous = false) ?(tool_call_count = 0) ~raw_erro
   then make ~source:"typed_error" "post_commit_ambiguous"
   else (
     match Keeper_turn_driver.classify_masc_internal_error err with
-    | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
+    | Some (Keeper_turn_driver.Provider_timeout _) ->
       of_disposition
         ~source:"typed_error"
         Keeper_turn_disposition.Turn_wall_clock_timeout

--- a/lib/keeper/keeper_unified_metrics_failure.ml
+++ b/lib/keeper/keeper_unified_metrics_failure.ml
@@ -59,7 +59,7 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
             let trimmed = String.trim detail in
             if trimmed = "" then reason else trimmed
         | Some
-            (Keeper_turn_driver.Oas_timeout_budget
+            (Keeper_turn_driver.Provider_timeout
                {
                  budget_sec;
                  keeper_turn_timeout_sec;
@@ -95,7 +95,7 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
     | Some err -> (
         match Keeper_turn_driver.classify_masc_internal_error err with
         | Some
-            (Keeper_turn_driver.Oas_timeout_budget _
+            (Keeper_turn_driver.Provider_timeout _
             | Keeper_turn_driver.Turn_timeout _
             | Keeper_turn_driver.Admission_queue_timeout _
             | Keeper_turn_driver.Admission_queue_rejected _

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1353,7 +1353,7 @@ let run_keeper_cycle
                   let e_str = Agent_sdk.Error.to_string err in
                   let is_transient = EC.is_transient_network_error err in
                   (match Keeper_turn_driver.classify_masc_internal_error err with
-                   | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
+                   | Some (Keeper_turn_driver.Provider_timeout _) ->
                      Prometheus.inc_counter
                        Keeper_metrics.metric_keeper_oas_timeout_classifications
                        ~labels:[ "classification", "structural_budget" ]

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -203,7 +203,7 @@ let registry_failure_reason_of_terminal_reason
   | Keeper_turn_disposition.Success
   | Keeper_turn_disposition.External_cancel
   | Keeper_turn_disposition.Turn_wall_clock_timeout
-  | Keeper_turn_disposition.Provider_timeout
+  | Keeper_turn_disposition.Oas_timeout_budget
   | Keeper_turn_disposition.Gh_repo_context_missing_worktree
   | Keeper_turn_disposition.Post_commit_ambiguous
   | Keeper_turn_disposition.Unknown _ -> None

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -66,35 +66,6 @@ type code_shell_exit_status =
 let classify_code_shell_exit =
   Tool_code_write_shell_validate.classify_code_shell_exit
 
-let shell_ir_with_default_cwd cwd ir =
-  match cwd with
-  | None -> ir
-  | Some dir ->
-    let default_cwd = Masc_exec.Path_scope.classify ~raw:dir ~cwd:dir in
-    let rec map_ir = function
-      | Masc_exec.Shell_ir.Simple simple ->
-        let simple =
-          match simple.cwd with
-          | Some _ -> simple
-          | None -> { simple with cwd = Some default_cwd }
-        in
-        Masc_exec.Shell_ir.Simple simple
-      | Masc_exec.Shell_ir.Pipeline stages ->
-        Masc_exec.Shell_ir.Pipeline (List.map map_ir stages)
-    in
-    map_ir ir
-;;
-
-let output_for_dispatch_status ~(status : Unix.process_status) ~stdout ~stderr =
-  match status with
-  | Unix.WEXITED 0 -> stdout
-  | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> (
-    match stdout, stderr with
-    | "", err -> err
-    | out, "" -> out
-    | out, err -> out ^ "\n" ^ err)
-;;
-
 let git_common_root path =
   try
     match
@@ -735,13 +706,13 @@ let handle_code_shell ~tool_name ~start_time ctx args =
 	                 match
 	                   Masc_exec.Exec_dispatch.dispatch
 	                     ~timeout_sec:safe_timeout
-	                     (shell_ir_with_default_cwd
+	                     (Exec_shell_adapter.shell_ir_with_default_cwd
 	                        cwd_opt
 	                        command_context.Exec_shell_gate.ast)
 	                 with
 	                 | { status = Unix.WEXITED code; stdout; stderr } ->
 	                     let output =
-	                       output_for_dispatch_status
+	                       Exec_shell_adapter.output_for_dispatch_status
 	                         ~status:(Unix.WEXITED code)
 	                         ~stdout
 	                         ~stderr
@@ -776,7 +747,7 @@ let handle_code_shell ~tool_name ~start_time ctx args =
 	                       (Yojson.Safe.pretty_to_string response)
 	                 | { status = Unix.WSIGNALED sig_num; stdout; stderr } ->
 	                     let output =
-	                       output_for_dispatch_status
+	                       Exec_shell_adapter.output_for_dispatch_status
 	                         ~status:(Unix.WSIGNALED sig_num)
 	                         ~stdout
 	                         ~stderr
@@ -788,7 +759,7 @@ let handle_code_shell ~tool_name ~start_time ctx args =
 	                          (truncate_output output))
 	                 | { status = Unix.WSTOPPED sig_num; stdout; stderr } ->
 	                     let output =
-	                       output_for_dispatch_status
+	                       Exec_shell_adapter.output_for_dispatch_status
 	                         ~status:(Unix.WSTOPPED sig_num)
 	                         ~stdout
 	                         ~stderr

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -277,35 +277,6 @@ let make_file_write ?workdir ?on_exec () =
    validation callsite can record the attribution without forward
    referencing. *)
 
-let shell_ir_with_default_cwd cwd ir =
-  match cwd with
-  | None -> ir
-  | Some dir ->
-    let default_cwd = Masc_exec.Path_scope.classify ~raw:dir ~cwd:dir in
-    let rec map_ir = function
-      | Masc_exec.Shell_ir.Simple simple ->
-        let simple =
-          match simple.cwd with
-          | Some _ -> simple
-          | None -> { simple with cwd = Some default_cwd }
-        in
-        Masc_exec.Shell_ir.Simple simple
-      | Masc_exec.Shell_ir.Pipeline stages ->
-        Masc_exec.Shell_ir.Pipeline (List.map map_ir stages)
-    in
-    map_ir ir
-;;
-
-let output_for_dispatch_status ~(status : Unix.process_status) ~stdout ~stderr =
-  match status with
-  | Unix.WEXITED 0 -> stdout
-  | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> (
-    match stdout, stderr with
-    | "", err -> err
-    | out, "" -> out
-    | out, err -> out ^ "\n" ^ err)
-;;
-
 let simple_literal_argv (simple : Masc_exec.Shell_ir.simple) =
   match simple_literal_args simple with
   | None -> None
@@ -492,7 +463,7 @@ let make_shell_exec_with_allowlist
                            let dispatch_result =
                              Fd_accountant.with_slot ~kind:Sandbox_exec (fun () ->
                                let dispatch_ir =
-                                 shell_ir_with_default_cwd
+                                 Exec_shell_adapter.shell_ir_with_default_cwd
                                    cwd
                                    context.Exec_shell_gate.ast
                                in
@@ -501,7 +472,7 @@ let make_shell_exec_with_allowlist
                                  dispatch_ir)
                            in
                            let output =
-                             output_for_dispatch_status
+                             Exec_shell_adapter.output_for_dispatch_status
                                ~status:dispatch_result.status
                                ~stdout:dispatch_result.stdout
                                ~stderr:dispatch_result.stderr

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -1940,6 +1940,8 @@ let () =
       Alcotest.test_case "worker_dev_tools delegates shared shell policy" `Quick
         (fun () ->
         let worker_source = load_source "lib/worker_dev_tools.ml" in
+        let code_shell_source = load_source "lib/tool_code_write.ml" in
+        let shell_adapter_source = load_source "lib/exec_shell_adapter.ml" in
         let exec_policy_source = load_source "lib/exec_policy.ml" in
         let keeper_bash_source = load_source "lib/keeper/keeper_shell_bash.ml" in
         Alcotest.(check bool) "worker delegates command context" true
@@ -1961,6 +1963,34 @@ let () =
         Alcotest.(check bool) "policy helper names are no longer worker-owned" false
           (contains_substring exec_policy_source "Worker_dev_tools_paths");
         Alcotest.(check bool) "policy uses renamed path helper" true
-          (contains_substring exec_policy_source "module Paths = Exec_policy_paths"));
+          (contains_substring exec_policy_source "module Paths = Exec_policy_paths");
+        Alcotest.(check bool) "shell adapter owns cwd default helper" true
+          (contains_substring shell_adapter_source "let shell_ir_with_default_cwd");
+        Alcotest.(check bool) "worker delegates cwd default helper" true
+          (contains_substring
+             worker_source
+             "Exec_shell_adapter.shell_ir_with_default_cwd");
+        Alcotest.(check bool) "code shell delegates cwd default helper" true
+          (contains_substring
+             code_shell_source
+             "Exec_shell_adapter.shell_ir_with_default_cwd");
+        Alcotest.(check bool) "worker no longer owns cwd default helper" false
+          (contains_substring worker_source "let shell_ir_with_default_cwd");
+        Alcotest.(check bool) "code shell no longer owns cwd default helper" false
+          (contains_substring code_shell_source "let shell_ir_with_default_cwd");
+        Alcotest.(check bool) "shell adapter owns dispatch output helper" true
+          (contains_substring shell_adapter_source "let output_for_dispatch_status");
+        Alcotest.(check bool) "worker delegates dispatch output helper" true
+          (contains_substring
+             worker_source
+             "Exec_shell_adapter.output_for_dispatch_status");
+        Alcotest.(check bool) "code shell delegates dispatch output helper" true
+          (contains_substring
+             code_shell_source
+             "Exec_shell_adapter.output_for_dispatch_status");
+        Alcotest.(check bool) "worker no longer owns dispatch output helper" false
+          (contains_substring worker_source "let output_for_dispatch_status");
+        Alcotest.(check bool) "code shell no longer owns dispatch output helper" false
+          (contains_substring code_shell_source "let output_for_dispatch_status"));
     ];
   ]


### PR DESCRIPTION
Summary:
- Add `Exec_shell_adapter` for shared Shell IR cwd defaulting and dispatch-output shaping.
- Reuse the shared helper from `worker_dev_tools.shell_exec` and `masc_code_shell`.
- Extend the worker source guard so the duplicated helper definitions do not return.

Stacking:
- Temporarily stacked on #17756 because current `main` still has provider-timeout constructor build breakage without that fix.
- After #17756 lands, rebase this branch back onto `main`.

Verification:
- `ocamlformat --check lib/exec_shell_adapter.ml lib/exec_shell_adapter.mli lib/worker_dev_tools.ml lib/tool_code_write.ml test/test_worker_dev_tools.ml`
- `git diff --check codex/build-fix-provider-timeout-constructors-20260522...HEAD`
- `rg -n "let shell_ir_with_default_cwd|let output_for_dispatch_status" lib/worker_dev_tools.ml lib/tool_code_write.ml` exits 1
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_worker_dev_tools.exe test/test_tool_code_write_coverage.exe`
- `./_build/default/test/test_worker_dev_tools.exe` passes: 172 tests

Known local test noise:
- `./_build/default/test/test_tool_code_write_coverage.exe` currently fails 2 pre-existing `masc_code_git` / `masc_code_edit` cases unrelated to this PR; this PR only touches the `masc_code_shell` helper path in `tool_code_write.ml`.
