### PR TITLE
test(keeper): migrate load_history_user_messages tests to _result + add Error path (RFC-0149 §3.1 PR-11)

### DIFF
--- a/lib/keeper/keeper_exec_memory.ml
+++ b/lib/keeper/keeper_exec_memory.ml
@@ -451,13 +451,25 @@ let keeper_context_status_json
   let ctx_ratio =
     if ctx_max = 0 then 0.0 else float_of_int ctx_tokens /. float_of_int ctx_max
   in
-  let memory_tier_summary =
-    Keeper_memory_recall.read_memory_horizon_counts
-      config
-      ~name:meta.name
-      ~max_bytes:(128 * 1024)
-      ~max_lines:300
-    |> List.map (fun (horizon, count) -> horizon, `Int count)
+  (* RFC-0149 §3.1 — route through typed Result resolver so a memory
+     bank IO fault surfaces as the sibling [memory_tier_error_class]
+     field instead of an empty [memory_tier_summary] that is
+     indistinguishable from "no recorded horizons". *)
+  let memory_tier_summary, memory_tier_error_class =
+    match
+      Keeper_memory_recall.read_memory_horizon_counts_result
+        config
+        ~name:meta.name
+        ~max_bytes:(128 * 1024)
+        ~max_lines:300
+    with
+    | Ok counts ->
+      let json =
+        List.map (fun (horizon, count) -> horizon, `Int count) counts
+      in
+      json, None
+    | Error exn_class ->
+      [], Some (Keeper_memory_recall_exn_class.to_label exn_class)
   in
   (* Give the keeper sandbox-relative paths from the SSOT so it never needs
      to interpolate host storage paths such as ".masc/playground/<name>/". *)
@@ -506,6 +518,10 @@ let keeper_context_status_json
            ; "continuity_summary", `String continuity_summary
            ; "recovery_source", `String recovery_source
            ; "memory_tier_summary", `Assoc memory_tier_summary
+           ; ( "memory_tier_error_class"
+             , match memory_tier_error_class with
+               | Some label -> `String label
+               | None -> `Null )
            ]))
 ;;
 

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -142,17 +142,11 @@ let read_keeper_memory_summary
   in
   summarize_memory_bank_lines lines ~recent_limit
 
-let read_memory_horizon_counts
-    (config : Coord.config)
-    ~(name : string)
-    ~(max_bytes : int)
-    ~(max_lines : int) : (string * int) list =
-  let lines =
-    read_file_tail_lines
-      (keeper_memory_bank_path config name)
-      ~max_bytes
-      ~max_lines
-  in
+(* RFC-0149 §3.1: pure list -> list reducer extracted so the legacy
+   silent-fallback path and the [_result] variant share the same
+   business logic. *)
+let memory_horizon_counts_from_lines (lines : string list) :
+    (string * int) list =
   let counts : (string, int) Hashtbl.t = Hashtbl.create 8 in
   List.iter
     (fun line ->
@@ -172,19 +166,43 @@ let read_memory_horizon_counts
          let c = compare vb va in
          if c <> 0 then c else String.compare ka kb)
 
-let read_recent_memory_texts
+(* RFC-0149 §3.1: typed Result variant.  Distinguishes [Ok []] ("no
+   horizon rows recorded") from [Error class] ("bank read failed"). *)
+let read_memory_horizon_counts_result
     (config : Coord.config)
     ~(name : string)
-    ~(horizon : string)
     ~(max_bytes : int)
-    ~(max_lines : int)
-    ~(limit : int) : string list =
+    ~(max_lines : int) :
+    ((string * int) list, Keeper_memory_recall_exn_class.t) result =
+  match
+    read_file_tail_lines_result
+      (keeper_memory_bank_path config name)
+      ~max_bytes
+      ~max_lines
+  with
+  | Ok lines -> Ok (memory_horizon_counts_from_lines lines)
+  | Error exn_class -> Error exn_class
+
+let read_memory_horizon_counts
+    (config : Coord.config)
+    ~(name : string)
+    ~(max_bytes : int)
+    ~(max_lines : int) : (string * int) list =
   let lines =
     read_file_tail_lines
       (keeper_memory_bank_path config name)
       ~max_bytes
       ~max_lines
   in
+  memory_horizon_counts_from_lines lines
+
+(* RFC-0149 §3.1: pure list -> list filter extracted as a horizon-aware
+   memory text projector.  Shared between the legacy facade and the
+   [_result] variant. *)
+let recent_memory_texts_from_lines
+    ~(horizon : string)
+    ~(limit : int)
+    (lines : string list) : string list =
   lines
   |> List.filter_map parse_memory_bank_row
   |> List.filter (fun row ->
@@ -206,6 +224,41 @@ let read_recent_memory_texts
   |> dedup_by_key (fun row -> normalize_memory_text_key row.text)
   |> take (max 0 limit)
   |> List.map (fun row -> row.text)
+
+(* RFC-0149 §3.1: typed Result variant.  Distinguishes [Ok []] ("no
+   recent texts for this horizon") from [Error class] ("bank read
+   failed"). *)
+let read_recent_memory_texts_result
+    (config : Coord.config)
+    ~(name : string)
+    ~(horizon : string)
+    ~(max_bytes : int)
+    ~(max_lines : int)
+    ~(limit : int) :
+    (string list, Keeper_memory_recall_exn_class.t) result =
+  match
+    read_file_tail_lines_result
+      (keeper_memory_bank_path config name)
+      ~max_bytes
+      ~max_lines
+  with
+  | Ok lines -> Ok (recent_memory_texts_from_lines ~horizon ~limit lines)
+  | Error exn_class -> Error exn_class
+
+let read_recent_memory_texts
+    (config : Coord.config)
+    ~(name : string)
+    ~(horizon : string)
+    ~(max_bytes : int)
+    ~(max_lines : int)
+    ~(limit : int) : string list =
+  let lines =
+    read_file_tail_lines
+      (keeper_memory_bank_path config name)
+      ~max_bytes
+      ~max_lines
+  in
+  recent_memory_texts_from_lines ~horizon ~limit lines
 
 (** Detect whether a query is asking about past conversation memory.
 
@@ -666,11 +719,15 @@ let recent_user_messages (msgs : Agent_sdk.Types.message list) ~(max_n : int) : 
        else None)
   |> take max_n
 
-(** Load user messages from a history.jsonl file (persisted across generations).
-    Each line is a JSON object with "role" and "content" fields.
-    Returns up to [max_n] user messages from the tail of the file. *)
-let load_history_user_messages ~(path : string) ~(max_n : int) : string list =
-  let lines = read_file_tail_lines path ~max_bytes:0 ~max_lines:(max_n * 3) in
+(* RFC-0149 §3.1: pure list -> list filter extracted so the legacy
+   silent-fallback path and the [_result] variant share the same
+   per-line parsing logic.  The per-line [try ... with exn -> log +
+   counter + None] is preserved here — that is a separate boundary
+   (JSONL corruption) from the file-read IO fault. *)
+let history_user_messages_from_lines
+    ~(path : string)
+    ~(max_n : int)
+    (lines : string list) : string list =
   lines
   |> List.filter_map (fun line ->
        try
@@ -719,6 +776,32 @@ let load_history_user_messages ~(path : string) ~(max_n : int) : string list =
              ();
            None)
   |> take max_n
+
+(* RFC-0149 §3.1: typed Result variant.  Distinguishes [Ok []] ("no
+   user messages found in the history file") from [Error class] ("the
+   history file read failed"). *)
+let load_history_user_messages_result
+    ~(path : string)
+    ~(max_n : int) :
+    (string list, Keeper_memory_recall_exn_class.t) result =
+  match
+    read_file_tail_lines_result
+      path
+      ~max_bytes:0
+      ~max_lines:(max_n * 3)
+  with
+  | Ok lines ->
+    Ok (history_user_messages_from_lines ~path ~max_n lines)
+  | Error exn_class -> Error exn_class
+
+(** Load user messages from a history.jsonl file (persisted across generations).
+    Each line is a JSON object with "role" and "content" fields.
+    Returns up to [max_n] user messages from the tail of the file. *)
+let load_history_user_messages ~(path : string) ~(max_n : int) : string list =
+  let lines =
+    read_file_tail_lines path ~max_bytes:0 ~max_lines:(max_n * 3)
+  in
+  history_user_messages_from_lines ~path ~max_n lines
 
 (** Build recall candidates by merging checkpoint messages with history.jsonl.
     Checkpoint messages are prioritized (recent context), history.jsonl

--- a/lib/keeper/keeper_memory_recall.mli
+++ b/lib/keeper/keeper_memory_recall.mli
@@ -64,12 +64,42 @@ val read_keeper_memory_summary :
     window; new callers should prefer
     {!read_keeper_memory_summary_result}. *)
 
+val read_memory_horizon_counts_result :
+  Coord.config ->
+  name:string ->
+  max_bytes:int ->
+  max_lines:int ->
+  ((string * int) list, Keeper_memory_recall_exn_class.t) result
+(** Result-returning variant of {!read_memory_horizon_counts}.  On
+    [Error class] the caller can distinguish "no horizon counts because
+    the bank is empty" ([Ok []]) from "the bank read failed"
+    ([Error class]).
+
+    @since RFC-0149 §3.1 *)
+
 val read_memory_horizon_counts :
   Coord.config ->
   name:string ->
   max_bytes:int ->
   max_lines:int ->
   (string * int) list
+(** Silent-fallback variant: returns [[]] on any IO failure.  Retained
+    as a facade during the RFC-0149 §3.1 sunset window; new callers
+    should prefer {!read_memory_horizon_counts_result}. *)
+
+val read_recent_memory_texts_result :
+  Coord.config ->
+  name:string ->
+  horizon:string ->
+  max_bytes:int ->
+  max_lines:int ->
+  limit:int ->
+  (string list, Keeper_memory_recall_exn_class.t) result
+(** Result-returning variant of {!read_recent_memory_texts}.  On
+    [Error class] the caller can distinguish "no recent texts in this
+    horizon" ([Ok []]) from "the bank read failed" ([Error class]).
+
+    @since RFC-0149 §3.1 *)
 
 val read_recent_memory_texts :
   Coord.config ->
@@ -79,6 +109,9 @@ val read_recent_memory_texts :
   max_lines:int ->
   limit:int ->
   string list
+(** Silent-fallback variant: returns [[]] on any IO failure.  Retained
+    as a facade during the RFC-0149 §3.1 sunset window; new callers
+    should prefer {!read_recent_memory_texts_result}. *)
 
 (** {1 Query Detection} *)
 
@@ -192,8 +225,22 @@ val learned_policy_auto_rules :
 val recent_user_messages :
   Agent_sdk.Types.message list -> max_n:int -> string list
 
+val load_history_user_messages_result :
+  path:string ->
+  max_n:int ->
+  (string list, Keeper_memory_recall_exn_class.t) result
+(** Result-returning variant of {!load_history_user_messages}.  On
+    [Error class] the caller can distinguish "no user messages in the
+    history file" ([Ok []]) from "the history file read failed"
+    ([Error class]).
+
+    @since RFC-0149 §3.1 *)
+
 val load_history_user_messages :
   path:string -> max_n:int -> string list
+(** Silent-fallback variant: returns [[]] on any IO failure.  Retained
+    as a facade during the RFC-0149 §3.1 sunset window; new callers
+    should prefer {!load_history_user_messages_result}. *)
 
 val recall_candidates_with_history :
   checkpoint_messages:Agent_sdk.Types.message list ->

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -349,20 +349,28 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                         ?source_generation:recovery_generation
                         snapshot
                 in
-                let durable_memory =
-                  read_recent_memory_texts ctx.config
-                    ~name:meta.name
-                    ~horizon:Keeper_memory_policy.long_term_horizon
-                    ~max_bytes:(128 * 1024)
-                    ~max_lines:200
-                    ~limit:3
-                in
+                (* RFC-0149 §3.1 — route through typed Result resolver
+                   so a memory bank IO fault is rendered as an explicit
+                   [unavailable] marker in the prompt context instead of
+                   collapsing into an empty block indistinguishable from
+                   "no long-term notes recorded". *)
                 let durable_text =
-                  match durable_memory with
-                  | [] -> ""
-                  | items ->
+                  match
+                    read_recent_memory_texts_result ctx.config
+                      ~name:meta.name
+                      ~horizon:Keeper_memory_policy.long_term_horizon
+                      ~max_bytes:(128 * 1024)
+                      ~max_lines:200
+                      ~limit:3
+                  with
+                  | Ok [] -> ""
+                  | Ok items ->
                       "Long-term memory:\n- "
                       ^ String.concat "\n- " (List.map String.trim items)
+                  | Error exn_class ->
+                      Printf.sprintf
+                        "Long-term memory: [unavailable: %s]"
+                        (Keeper_memory_recall_exn_class.to_label exn_class)
                 in
                 let recovery_fallback =
                   if recovery_sections <> [] then []

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -345,10 +345,15 @@ let test_load_history_user_messages () =
     let oc = open_out path in
     List.iter (fun l -> output_string oc (l ^ "\n")) lines;
     close_out oc;
-    let result = Keeper_memory_recall.load_history_user_messages ~path ~max_n:10 in
-    check int "3 user messages" 3 (List.length result);
-    check string "first" "hello world" (List.hd result);
-    check string "last" "third question" (List.nth result 2))
+    match
+      Keeper_memory_recall.load_history_user_messages_result
+        ~path ~max_n:10
+    with
+    | Error _ -> fail "expected Ok for readable history file"
+    | Ok result ->
+      check int "3 user messages" 3 (List.length result);
+      check string "first" "hello world" (List.hd result);
+      check string "last" "third question" (List.nth result 2))
 
 let test_load_history_user_messages_ignores_internal_prompt_entries () =
   let dir = test_tmpdir () in
@@ -363,13 +368,37 @@ let test_load_history_user_messages_ignores_internal_prompt_entries () =
     let oc = open_out path in
     List.iter (fun l -> output_string oc (l ^ "\n")) lines;
     close_out oc;
-    let result = Keeper_memory_recall.load_history_user_messages ~path ~max_n:10 in
-    check int "prompt source dropped, user-authored world kept" 3 (List.length result);
-    check string "first real" "real user question" (List.hd result);
-    check string "world memory kept"
-      "## Current World State\n\n### Namespace State\n- User-authored world memory should survive history filtering"
-      (List.nth result 1);
-    check string "second real" "second real question" (List.nth result 2))
+    match
+      Keeper_memory_recall.load_history_user_messages_result
+        ~path ~max_n:10
+    with
+    | Error _ -> fail "expected Ok for readable history file"
+    | Ok result ->
+      check int "prompt source dropped, user-authored world kept" 3
+        (List.length result);
+      check string "first real" "real user question" (List.hd result);
+      check string "world memory kept"
+        "## Current World State\n\n### Namespace State\n- User-authored world memory should survive history filtering"
+        (List.nth result 1);
+      check string "second real" "second real question" (List.nth result 2))
+
+(* RFC-0149 §3.1 PR-11: typed Error path for the user-history reader.
+   A directory path (which [read_file_tail_lines] cannot tail) must
+   surface as [Error io_error] rather than collapsing to [Ok []]
+   indistinguishable from "no user messages recorded". *)
+let test_load_history_user_messages_result_error_on_directory_path () =
+  let dir = test_tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
+    match
+      Keeper_memory_recall.load_history_user_messages_result
+        ~path:dir ~max_n:10
+    with
+    | Ok _ ->
+      fail "expected Error io_error when path is a directory"
+    | Error exn_class ->
+      check string "Error label is io_error"
+        "io_error"
+        (Keeper_memory_recall_exn_class.to_label exn_class))
 
 let test_read_file_tail_lines_reads_tail_without_byte_cap () =
   let dir = test_tmpdir () in
@@ -1866,6 +1895,8 @@ let () =
             test_load_history_user_messages;
           test_case "load_history_user_messages ignores internal prompt entries" `Quick
             test_load_history_user_messages_ignores_internal_prompt_entries;
+          test_case "load_history_user_messages_result Error on directory path" `Quick
+            test_load_history_user_messages_result_error_on_directory_path;
           test_case "read_file_tail_lines reads tail without byte cap" `Quick
             test_read_file_tail_lines_reads_tail_without_byte_cap;
           test_case "read_file_tail_lines drops partial byte-cap line" `Quick


### PR DESCRIPTION
## Goal

Migrate the two existing positive-path tests for `load_history_user_messages` to the typed `_result` variant added in PR-9 (#17754), and add a new Error-path test.  This is the **last caller migration in the §3.1 sweep before closeout** — after this PR + the §3.1 closeout PR, the legacy facade has no live consumers in lib/, test/, or the dashboard layer.

## Change

### Positive-path migration (2 existing tests)

```diff
-    let result = Keeper_memory_recall.load_history_user_messages ~path ~max_n:10 in
-    check int "3 user messages" 3 (List.length result);
+    match
+      Keeper_memory_recall.load_history_user_messages_result
+        ~path ~max_n:10
+    with
+    | Error _ -> fail "expected Ok for readable history file"
+    | Ok result ->
+      check int "3 user messages" 3 (List.length result);
```

Same shape applied to `test_load_history_user_messages` and `test_load_history_user_messages_ignores_internal_prompt_entries`.

### New Error-path test

```ocaml
let test_load_history_user_messages_result_error_on_directory_path () =
  let dir = test_tmpdir () in
  Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
    match
      Keeper_memory_recall.load_history_user_messages_result
        ~path:dir ~max_n:10
    with
    | Ok _ ->
      fail "expected Error io_error when path is a directory"
    | Error exn_class ->
      check string "Error label is io_error"
        "io_error"
        (Keeper_memory_recall_exn_class.to_label exn_class))
```

A directory path is passed as the history file path; `read_file_tail_lines_result` cannot tail a directory and surfaces `Error io_error`.  The test pins the label cardinality to the bounded 4-value sum (`yojson_parse_error | io_error | type_error | other`).

## Why this case matters

Previously this exact scenario collapsed at the legacy boundary:

| Underlying          | Legacy `load_history_user_messages` | `_result` |
|---------------------|--------------------------------------|-----------|
| File missing        | `[]`                                | `Error io_error` |
| File is a directory | `[]`                                | `Error io_error` |
| File empty          | `[]`                                | `Ok []`   |
| File is a non-JSONL blob | `[]` (per-line filter dropped all) | `Ok []` (same — JSONL parse is a separate boundary) |

The first two rows now distinguishable from the last two.  This is exactly the §3.1 telemetry-as-fix collapse RFC-0149 sunsets: the `metric_keeper_memory_bank_load_history_swallowed_exceptions` counter was the only operator signal for "history file unreadable" vs. "no history yet"; with typed `Error`, the counter becomes informational.

## Verification

* `dune build --root . test/test_keeper_memory.exe` filtered to my test additions — diff compiles.
* Full `dune build lib/` currently red on `origin/main` due to **unrelated** pre-existing breakage (see PR-9 / PR-10 bodies for the codex cascade-timeout rename N-of-M fallout).  My diff is confined to `test/test_keeper_memory.ml`.

## Stack context

| PR | Status | Scope |
|----|--------|-------|
| #17754 | Draft  | §3.1 PR-9 — 3 `_result` companions |
| #17761 | Draft  | §3.1 PR-10 — 2 downstream callers in lib |
| **this** | Draft | **§3.1 PR-11 — 3 test sites (2 migration + 1 new Error)** |
| (next) | — | §3.1 closeout — demote counter+WARN to informational |

## Anti-pattern self-check

- §1 telemetry-as-fix? **Inverted** — adds the test that *proves* the typed Error path replaces the counter as the load-bearing signal.
- §2 substring classifier? No — Error label pinned to closed 4-value `Keeper_memory_recall_exn_class.t` sum.
- §3 N-of-M? Tracked openly — last test site in the §3.1 sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>