### PR TITLE
fix(keeper): update provider timeout constructor consumers

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -759,7 +759,7 @@ let review
                   | Keeper_turn_driver.Admission_queue_timeout _
                   | Keeper_turn_driver.Admission_queue_rejected _
                   | Keeper_turn_driver.Turn_timeout _
-                  | Keeper_turn_driver.Oas_timeout_budget _
+                  | Keeper_turn_driver.Provider_timeout _
                   | Keeper_turn_driver.Max_tokens_ceiling_violation _
                   | Keeper_turn_driver.Ambiguous_post_commit _
                   (* RFC-0159 Phase A: opaque internal failures. *)

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -224,7 +224,7 @@ let is_auto_recoverable_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error
   | Some (Keeper_turn_driver.Admission_queue_rejected _)
   | Some (Keeper_turn_driver.Admission_queue_timeout _)
   | Some (Keeper_turn_driver.Turn_timeout _)
-  | Some (Keeper_turn_driver.Oas_timeout_budget _)
+  | Some (Keeper_turn_driver.Provider_timeout _)
   | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
   | Some (Keeper_turn_driver.Ambiguous_post_commit _)
   (* RFC-0159 Phase A: opaque internal failures. *)
@@ -244,7 +244,7 @@ let is_resumable_cli_session_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Some (Keeper_turn_driver.Admission_queue_timeout _)
   | Some (Keeper_turn_driver.Admission_queue_rejected _)
   | Some (Keeper_turn_driver.Turn_timeout _)
-  | Some (Keeper_turn_driver.Oas_timeout_budget _)
+  | Some (Keeper_turn_driver.Provider_timeout _)
   | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
   | Some (Keeper_turn_driver.Ambiguous_post_commit _)
   (* RFC-0159 Phase A: opaque internal failures. *)
@@ -359,7 +359,7 @@ let degraded_retry_after_recoverable_error
         local_recovery_retry Resumable_cli_session
     | Some (Keeper_turn_driver.Admission_queue_timeout _) ->
         local_recovery_retry Admission_queue_timeout
-    | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
+    | Some (Keeper_turn_driver.Provider_timeout _) ->
         local_recovery_retry Provider_timeout
     | Some (Keeper_turn_driver.Turn_timeout _) ->
         local_recovery_retry Turn_timeout
@@ -415,7 +415,7 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
         Some Resumable_cli_session
     | Some (Keeper_turn_driver.Admission_queue_timeout _) ->
         Some Admission_queue_timeout
-    | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
+    | Some (Keeper_turn_driver.Provider_timeout _) ->
         Some Provider_timeout
     | Some (Keeper_turn_driver.Turn_timeout _) ->
         Some Turn_timeout
@@ -726,7 +726,7 @@ let is_auto_recoverable_turn_error (err : Agent_sdk.Error.sdk_error) : bool =
 
 let should_warn_keeper_cycle_failed (err : Agent_sdk.Error.sdk_error) : bool =
   match Keeper_turn_driver.classify_masc_internal_error err with
-  | Some (Keeper_turn_driver.Oas_timeout_budget _) -> true
+  | Some (Keeper_turn_driver.Provider_timeout _) -> true
   | Some (Keeper_turn_driver.Capacity_backpressure _) -> true
   | Some (Keeper_turn_driver.Cascade_exhausted _)
   | Some (Keeper_turn_driver.Resumable_cli_session _)
@@ -783,7 +783,7 @@ let is_ambiguous_side_effect_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Some (Keeper_turn_driver.Admission_queue_rejected _)
   | Some (Keeper_turn_driver.Admission_queue_timeout _)
   | Some (Keeper_turn_driver.Turn_timeout _)
-  | Some (Keeper_turn_driver.Oas_timeout_budget _)
+  | Some (Keeper_turn_driver.Provider_timeout _)
   | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
   (* RFC-0159 Phase A: opaque internal failures are unambiguous failures. *)
   | Some (Keeper_turn_driver.Internal_unhandled_exception _)
@@ -962,7 +962,7 @@ let is_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Some (Keeper_turn_driver.Capacity_backpressure _)
   | Some (Keeper_turn_driver.Admission_queue_timeout _)
   | Some (Keeper_turn_driver.Admission_queue_rejected _)
-  | Some (Keeper_turn_driver.Oas_timeout_budget _)
+  | Some (Keeper_turn_driver.Provider_timeout _)
   | Some (Keeper_turn_driver.Turn_timeout _)
   | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
   | Some (Keeper_turn_driver.Ambiguous_post_commit _)

--- a/lib/keeper/keeper_heartbeat_loop_observations.ml
+++ b/lib/keeper/keeper_heartbeat_loop_observations.ml
@@ -188,7 +188,7 @@ let is_provider_timeout_error (err : Agent_sdk.Error.sdk_error) =
      both sweeps — the same predicate shape exists in three places
      and only this one still had a catch-all. *)
   match Keeper_turn_driver.classify_masc_internal_error err with
-  | Some (Keeper_turn_driver.Oas_timeout_budget _) -> true
+  | Some (Keeper_turn_driver.Provider_timeout _) -> true
   | Some
       ( Keeper_turn_driver.Cascade_exhausted _
       | Keeper_turn_driver.Capacity_backpressure _
@@ -224,7 +224,7 @@ let oas_timeout_budget_policy_decision
   : Keeper_failure_policy.decision option
   =
   match Keeper_turn_driver.classify_masc_internal_error err with
-  | Some (Keeper_turn_driver.Oas_timeout_budget { phase; _ }) ->
+  | Some (Keeper_turn_driver.Provider_timeout { phase; _ }) ->
     Some
       (Keeper_failure_policy.decide
          (Keeper_failure_policy.Provider_timeout

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -197,7 +197,7 @@ let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class
   | Some (Keeper_turn_driver.Admission_queue_timeout _) ->
     Some Admission_queue_wait_timeout
   | Some (Keeper_turn_driver.Admission_queue_rejected _) -> None
-  | Some (Keeper_turn_driver.Oas_timeout_budget _) -> Some Turn_timeout
+  | Some (Keeper_turn_driver.Provider_timeout _) -> Some Turn_timeout
   | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _) -> None
   | Some (Keeper_turn_driver.Turn_timeout _) -> Some Turn_timeout
   | Some (Keeper_turn_driver.Ambiguous_post_commit { is_timeout; _ }) ->

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -364,7 +364,7 @@ let degraded_retry_bypasses_slot_phase_guard
      was added to Cascade_error_classify, which is exactly the wrong default
      for a guard that decides whether to bypass slot-phase admission. *)
   match Keeper_turn_driver.classify_masc_internal_error err with
-  | Some (Keeper_turn_driver.Oas_timeout_budget _) -> true
+  | Some (Keeper_turn_driver.Provider_timeout _) -> true
   | Some (Keeper_turn_driver.Cascade_exhausted { reason; _ })
     when cascade_reason_is_structural_attempt_timeout reason ->
       true

--- a/lib/keeper/keeper_turn_terminal.ml
+++ b/lib/keeper/keeper_turn_terminal.ml
@@ -76,7 +76,7 @@ let of_failure ?(post_commit_ambiguous = false) ?(tool_call_count = 0) ~raw_erro
   then make ~source:"typed_error" "post_commit_ambiguous"
   else (
     match Keeper_turn_driver.classify_masc_internal_error err with
-    | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
+    | Some (Keeper_turn_driver.Provider_timeout _) ->
       of_disposition
         ~source:"typed_error"
         Keeper_turn_disposition.Turn_wall_clock_timeout

--- a/lib/keeper/keeper_unified_metrics_failure.ml
+++ b/lib/keeper/keeper_unified_metrics_failure.ml
@@ -59,7 +59,7 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
             let trimmed = String.trim detail in
             if trimmed = "" then reason else trimmed
         | Some
-            (Keeper_turn_driver.Oas_timeout_budget
+            (Keeper_turn_driver.Provider_timeout
                {
                  budget_sec;
                  keeper_turn_timeout_sec;
@@ -95,7 +95,7 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
     | Some err -> (
         match Keeper_turn_driver.classify_masc_internal_error err with
         | Some
-            (Keeper_turn_driver.Oas_timeout_budget _
+            (Keeper_turn_driver.Provider_timeout _
             | Keeper_turn_driver.Turn_timeout _
             | Keeper_turn_driver.Admission_queue_timeout _
             | Keeper_turn_driver.Admission_queue_rejected _

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1353,7 +1353,7 @@ let run_keeper_cycle
                   let e_str = Agent_sdk.Error.to_string err in
                   let is_transient = EC.is_transient_network_error err in
                   (match Keeper_turn_driver.classify_masc_internal_error err with
-                   | Some (Keeper_turn_driver.Oas_timeout_budget _) ->
+                   | Some (Keeper_turn_driver.Provider_timeout _) ->
                      Prometheus.inc_counter
                        Keeper_metrics.metric_keeper_oas_timeout_classifications
                        ~labels:[ "classification", "structural_budget" ]

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -203,7 +203,7 @@ let registry_failure_reason_of_terminal_reason
   | Keeper_turn_disposition.Success
   | Keeper_turn_disposition.External_cancel
   | Keeper_turn_disposition.Turn_wall_clock_timeout
-  | Keeper_turn_disposition.Provider_timeout
+  | Keeper_turn_disposition.Oas_timeout_budget
   | Keeper_turn_disposition.Gh_repo_context_missing_worktree
   | Keeper_turn_disposition.Post_commit_ambiguous
   | Keeper_turn_disposition.Unknown _ -> None

--- a/test/test_keeper_terminal_reason.ml
+++ b/test/test_keeper_terminal_reason.ml
@@ -454,7 +454,7 @@ let test_structured_required_tool_no_tool_call () =
 let test_structured_oas_timeout_budget_collapses_to_turn_timeout () =
   let err =
     Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
-      (Masc_mcp.Keeper_turn_driver.Oas_timeout_budget
+      (Masc_mcp.Keeper_turn_driver.Provider_timeout
          { budget_sec = 90.0
          ; keeper_turn_timeout_sec = 1200.0
          ; estimated_input_tokens = 10_000

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -6532,7 +6532,7 @@ let test_degraded_retry_after_recoverable_error_includes_provider_timeout () =
       ~effective_cascade:"underdog"
       ~tool_requirement:Masc_mcp.Keeper_agent_tool_surface.Optional
       (Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
-         (Masc_mcp.Keeper_turn_driver.Oas_timeout_budget
+         (Masc_mcp.Keeper_turn_driver.Provider_timeout
             { budget_sec = 273.0
             ; keeper_turn_timeout_sec = 1200.0
             ; estimated_input_tokens = 2_000
@@ -7125,7 +7125,7 @@ let test_metrics_failure_response () =
 let test_metrics_failure_timeout_increments_proactive_backoff () =
   let sdk_error =
     Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
-      (Masc_mcp.Keeper_turn_driver.Oas_timeout_budget
+      (Masc_mcp.Keeper_turn_driver.Provider_timeout
          { budget_sec = 90.0
          ; keeper_turn_timeout_sec = 90.0
          ; estimated_input_tokens = 42_000
@@ -8387,7 +8387,7 @@ let test_oas_timeout_reclassifies_only_current_attempt_budget () =
       UT.reclassify_oas_timeout_for_attempt ~timeout_budget:(Some timeout_budget) err
     in
     (match Masc_mcp.Keeper_turn_driver.classify_masc_internal_error classified with
-     | Some (Masc_mcp.Keeper_turn_driver.Oas_timeout_budget budget) ->
+     | Some (Masc_mcp.Keeper_turn_driver.Provider_timeout budget) ->
        check int "estimated tokens preserved" 2_000 budget.estimated_input_tokens;
        check string "source preserved" timeout_budget.source budget.source;
        check
@@ -8415,7 +8415,7 @@ let test_pre_retry_timeout_helper_does_not_reuse_stale_budget () =
 
 let oas_timeout_budget_error () =
   Masc_mcp.Keeper_turn_driver.sdk_error_of_masc_internal_error
-    (Masc_mcp.Keeper_turn_driver.Oas_timeout_budget
+    (Masc_mcp.Keeper_turn_driver.Provider_timeout
        { budget_sec = 273.0
        ; keeper_turn_timeout_sec = 1200.0
        ; estimated_input_tokens = 2_000

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -60,7 +60,7 @@ let test_strike_limit_is_soft_backoff () =
 
 let oas_timeout_budget_error ~phase =
   KTD.sdk_error_of_masc_internal_error
-    (KTD.Oas_timeout_budget
+    (KTD.Provider_timeout
        { budget_sec = 90.0
        ; keeper_turn_timeout_sec = 1200.0
        ; estimated_input_tokens = 10_000


### PR DESCRIPTION
## Summary
- update stale Keeper_turn_driver.Oas_timeout_budget consumers to Provider_timeout after the constructor rename
- keep Keeper_turn_disposition legacy Oas_timeout_budget mapping where that type still owns the compatibility alias
- update provider-timeout tests to construct the current Keeper_turn_driver.Provider_timeout variant

## Verification
- ocamlformat --check lib/anti_rationalization.ml lib/keeper/keeper_error_classify.ml lib/keeper/keeper_heartbeat_loop_observations.ml lib/keeper/keeper_status_bridge.ml lib/keeper/keeper_turn_cascade_budget.ml lib/keeper/keeper_turn_terminal.ml lib/keeper/keeper_unified_metrics_failure.ml lib/keeper/keeper_unified_turn.ml lib/keeper/keeper_unified_turn_types.ml test/test_keeper_terminal_reason.ml test/test_keeper_unified.ml test/test_oas_timeout_budget_strike.ml
- git diff --check
- MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=_build_provider_timeout_stale_fix scripts/dune-local.sh build lib/keeper/keeper_status.ml test/test_keeper_unified.exe