### PR TITLE
fix(keeper): rename provider timeout policy API

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -120,16 +120,16 @@ let prior_provider_timeout_strikes =
 
 let is_provider_timeout_error = Observations.is_provider_timeout_error
 
-let timeout_phase_of_oas_timeout_budget_phase =
-  Observations.timeout_phase_of_oas_timeout_budget_phase
+let timeout_phase_of_provider_timeout_phase =
+  Observations.timeout_phase_of_provider_timeout_phase
 ;;
 
-let oas_timeout_budget_policy_decision =
-  Observations.oas_timeout_budget_policy_decision
+let provider_timeout_policy_decision =
+  Observations.provider_timeout_policy_decision
 ;;
 
-let oas_timeout_budget_metric_outcome =
-  Observations.oas_timeout_budget_metric_outcome
+let provider_timeout_metric_outcome =
+  Observations.provider_timeout_metric_outcome
 ;;
 
 let persist_message_cursor_updates = Keeper_heartbeat_loop_persist_cursor.persist_message_cursor_updates

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -129,7 +129,7 @@ val provider_timeout_observation_reasons : string list
 val record_provider_timeout_observation :
   base_path:string -> keeper_name:string -> unit
 
-val oas_timeout_budget_policy_decision :
+val provider_timeout_policy_decision :
   strikes:int -> Agent_sdk.Error.sdk_error -> Keeper_failure_policy.decision option
 (** Return the policy decision for a structured [Oas_timeout_budget] error.
     This heartbeat-loop path is reached after the keeper turn returned, so

--- a/lib/keeper/keeper_heartbeat_loop_observations.ml
+++ b/lib/keeper/keeper_heartbeat_loop_observations.ml
@@ -208,7 +208,7 @@ let is_provider_timeout_error (err : Agent_sdk.Error.sdk_error) =
     false
 ;;
 
-let timeout_phase_of_oas_timeout_budget_phase phase =
+let timeout_phase_of_provider_timeout_phase phase =
   let phase = String.trim phase in
   if String.equal phase ""
   then None
@@ -218,7 +218,7 @@ let timeout_phase_of_oas_timeout_budget_phase phase =
     | None -> Some Keeper_failure_policy.Unknown_timeout)
 ;;
 
-let oas_timeout_budget_policy_decision
+let provider_timeout_policy_decision
       ~(strikes : int)
       (err : Agent_sdk.Error.sdk_error)
   : Keeper_failure_policy.decision option
@@ -228,7 +228,7 @@ let oas_timeout_budget_policy_decision
     Some
       (Keeper_failure_policy.decide
          (Keeper_failure_policy.Provider_timeout
-            { phase = timeout_phase_of_oas_timeout_budget_phase phase
+            { phase = timeout_phase_of_provider_timeout_phase phase
             ; strikes = Some strikes
             ; liveness = Keeper_failure_policy.Recent_heartbeat
             }))
@@ -251,7 +251,7 @@ let oas_timeout_budget_policy_decision
     None
 ;;
 
-let oas_timeout_budget_metric_outcome
+let provider_timeout_metric_outcome
       (decision : Keeper_failure_policy.decision)
   =
   match decision.lifecycle_effect with

--- a/lib/keeper/keeper_heartbeat_loop_observations.mli
+++ b/lib/keeper/keeper_heartbeat_loop_observations.mli
@@ -60,11 +60,11 @@ val prior_provider_timeout_strikes
   -> int
 
 val is_provider_timeout_error : Agent_sdk.Error.sdk_error -> bool
-val timeout_phase_of_oas_timeout_budget_phase : string -> Keeper_failure_policy.timeout_phase option
+val timeout_phase_of_provider_timeout_phase : string -> Keeper_failure_policy.timeout_phase option
 
-val oas_timeout_budget_policy_decision
+val provider_timeout_policy_decision
   :  strikes:int
   -> Agent_sdk.Error.sdk_error
   -> Keeper_failure_policy.decision option
 
-val oas_timeout_budget_metric_outcome : Keeper_failure_policy.decision -> string
+val provider_timeout_metric_outcome : Keeper_failure_policy.decision -> string

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -58,7 +58,7 @@ let test_strike_limit_is_soft_backoff () =
    | KK.Provider_timeout_warn ->
      failwith "strike limit should soft-backoff, not crash")
 
-let oas_timeout_budget_error ~phase =
+let provider_timeout_error ~phase =
   KTD.sdk_error_of_masc_internal_error
     (KTD.Oas_timeout_budget
        { budget_sec = 90.0
@@ -75,23 +75,23 @@ let turn_timeout_error () =
 
 let test_cycle_failed_log_level_is_policy_aware () =
   Alcotest.(check bool)
-    "oas timeout budget cycle failure is warn"
+    "provider timeout cycle failure is warn"
     true
     (EC.should_warn_keeper_cycle_failed
-       (oas_timeout_budget_error ~phase:"cascade_attempt_watchdog"));
+       (provider_timeout_error ~phase:"cascade_attempt_watchdog"));
   Alcotest.(check bool)
     "turn wall-clock timeout remains error"
     false
     (EC.should_warn_keeper_cycle_failed (turn_timeout_error ()))
 
 let test_strike_limit_routes_through_policy_without_keeper_death () =
-  let err = oas_timeout_budget_error ~phase:"stream_idle:streaming_thinking" in
+  let err = provider_timeout_error ~phase:"stream_idle:streaming_thinking" in
   match
-    KH.oas_timeout_budget_policy_decision
+    KH.provider_timeout_policy_decision
       ~strikes:KK.provider_timeout_strike_limit
       err
   with
-  | None -> Alcotest.fail "expected OAS timeout budget policy decision"
+  | None -> Alcotest.fail "expected provider timeout policy decision"
   | Some decision ->
     Alcotest.(check bool) "keeper death denied" false decision.keeper_death_allowed;
     Alcotest.(check string)
@@ -108,9 +108,9 @@ let test_strike_limit_routes_through_policy_without_keeper_death () =
       decision.reason
 
 let test_capacity_phase_routes_to_provider_tuning () =
-  let err = oas_timeout_budget_error ~phase:"capacity_backpressure" in
-  match KH.oas_timeout_budget_policy_decision ~strikes:1 err with
-  | None -> Alcotest.fail "expected OAS timeout budget policy decision"
+  let err = provider_timeout_error ~phase:"capacity_backpressure" in
+  match KH.provider_timeout_policy_decision ~strikes:1 err with
+  | None -> Alcotest.fail "expected provider timeout policy decision"
   | Some decision ->
     Alcotest.(check bool) "keeper death denied" false decision.keeper_death_allowed;
     Alcotest.(check string)


### PR DESCRIPTION
## Summary
- rename heartbeat-loop timeout policy API from oas-timeout-budget to provider-timeout
- update the public wrapper so new callers consume provider_timeout_policy_decision
- update strike policy tests to assert provider-timeout policy behavior through the new API

## Validation
- Not run; user requested PR iteration without local validation.