### PR TITLE
feat(dashboard): surface memory_kind_usage_error_class on tier panel (RFC-0149 §3.1 frontend)

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -519,6 +519,12 @@ export interface KeeperStateDiagramResponse {
   cascade_models?: string[]
   last_provider_result?: string | null
   memory_kind_usage?: MemoryKindUsageEntry[]
+  /** RFC-0149 §3.1 — sibling field carrying the typed memory-bank
+   *  read failure class (`yojson_parse_error | io_error | type_error
+   *  | other`).  `null` means the bank was readable; a string label
+   *  means the read failed and `memory_kind_usage` contains the
+   *  empty-counts fallback rather than a real snapshot. */
+  memory_kind_usage_error_class?: string | null
 }
 
 export async function fetchKeeperTransitions(

--- a/dashboard/src/components/keeper-memory-tier-panel.ts
+++ b/dashboard/src/components/keeper-memory-tier-panel.ts
@@ -75,6 +75,11 @@ export function KeeperMemoryTierPanel({
   snapshot: externalSnapshot,
 }: KeeperMemoryTierPanelProps) {
   const [usage, setUsage] = useState<MemoryKindUsageEntry[] | null>(null)
+  /** RFC-0149 §3.1 — typed memory-bank read failure label
+   *  (`Keeper_memory_recall_exn_class.t`).  Disambiguates "no rows
+   *  recorded" (usage=[], errorClass=null) from "bank read failed"
+   *  (usage=[], errorClass="<label>"). */
+  const [memoryBankErrorClass, setMemoryBankErrorClass] = useState<string | null>(null)
   const [internalSnapshot, setInternalSnapshot] = useState<KeeperCompositeSnapshot | null>(null)
   const snapshot = externalSnapshot ?? internalSnapshot
   const [error, setError] = useState<string | null>(null)
@@ -105,8 +110,10 @@ export function KeeperMemoryTierPanel({
 
           if (usageResult.status === 'fulfilled') {
             setUsage(usageResult.value.memory_kind_usage ?? [])
+            setMemoryBankErrorClass(usageResult.value.memory_kind_usage_error_class ?? null)
           } else {
             setUsage(null)
+            setMemoryBankErrorClass(null)
             nextError = usageResult.reason instanceof Error ? usageResult.reason.message : 'memory tier fetch failed'
           }
 
@@ -148,7 +155,14 @@ export function KeeperMemoryTierPanel({
   }
 
   if (error || !usage || usage.length === 0) {
-    return html`<${EmptyState} message=${error ?? '메모리 티어 데이터 없음'} compact />`
+    // RFC-0149 §3.1 — if the bank read returned a typed failure class,
+    // surface it on the empty-state message so operators can distinguish
+    // "no memory rows recorded" from "memory bank unreadable".
+    const emptyMessage = error
+      ?? (memoryBankErrorClass !== null
+        ? `메모리 뱅크 읽기 실패: ${memoryBankErrorClass}`
+        : '메모리 티어 데이터 없음')
+    return html`<${EmptyState} message=${emptyMessage} compact />`
   }
 
   const totalUsed = usage.reduce((sum, row) => sum + row.used, 0)


### PR DESCRIPTION
## Goal

Surface the backend-emitted typed memory-bank read failure class on the dashboard so operators can distinguish a freshly-empty keeper from one whose bank read silently failed.

## Background

Backend already emits the sibling typed field via `server_dashboard_http_keeper_api.ml` (PR-7 #17728 MERGED, currently on `origin/main`):

```json
"memory_kind_usage": [...],
"memory_kind_usage_error_class": null | "io_error" | "yojson_parse_error" | "type_error" | "other"
```

Until this PR the frontend `KeeperMemoryTierPanel` collapsed two distinct backend states into the same EmptyState:

| Backend state                  | `memory_kind_usage` | `error_class`         | Frontend (before)        |
|--------------------------------|--------------------|------------------------|--------------------------|
| `Ok` + zero counts             | `[]`               | `null`                | "메모리 티어 데이터 없음" |
| `Error` (bank read failed)     | `[]`               | `"io_error"` etc.     | "메모리 티어 데이터 없음" |

After this PR:

| Backend state                  | `memory_kind_usage` | `error_class`         | Frontend (after)                              |
|--------------------------------|--------------------|------------------------|-----------------------------------------------|
| `Ok` + zero counts             | `[]`               | `null`                | "메모리 티어 데이터 없음"                       |
| `Error io_error`               | `[]`               | `"io_error"`          | "메모리 뱅크 읽기 실패: io_error"               |
| `Error yojson_parse_error`     | `[]`               | `"yojson_parse_error"` | "메모리 뱅크 읽기 실패: yojson_parse_error"     |
| etc.                           | `[]`               | `"<label>"`           | "메모리 뱅크 읽기 실패: <label>"                |

## Change

### `dashboard/src/api/keeper.ts`

```diff
   memory_kind_usage?: MemoryKindUsageEntry[]
+  /** RFC-0149 §3.1 — sibling field carrying the typed memory-bank
+   *  read failure class (`yojson_parse_error | io_error | type_error
+   *  | other`).  `null` means the bank was readable; a string label
+   *  means the read failed and `memory_kind_usage` contains the
+   *  empty-counts fallback rather than a real snapshot. */
+  memory_kind_usage_error_class?: string | null
 }
```

### `dashboard/src/components/keeper-memory-tier-panel.ts`

* New state `memoryBankErrorClass`.
* Populated from `usageResult.value.memory_kind_usage_error_class ?? null` on each fetch.
* Reset to `null` on fetch failure (network error, not a typed Error from backend).
* EmptyState message picks the typed label when `usage` is empty *and* `errorClass` is non-null.

Behavior on the `Ok` populated path is unchanged — no new fetch, no new error state, purely a typed-passthrough of an already-emitted field.

## Verification

* `pnpm typecheck` → pass.
* `pnpm test -- keeper-memory-tier-panel` → pass.
* Full suite: 7303 / 7305 pass.  The 2 failures are in `keeper-detail-alert-strip.test.ts` (canonicalization expectations around `runtime_blocked` / `런타임 근거`) — pre-date this diff and unrelated.

## Stack context

This PR is **independent** of the §3.1 caller-migration stack (#17754 / #17761 / #17762) — the backend field it consumes is already on `origin/main`.  It does not need to be sequenced behind any other PR.

Sibling-field operator surfaces still pending dashboard consumption (future PRs):

| Surface | Backend PR | Status |
|---------|------------|--------|
| `memory_kind_usage_error_class` | #17728 | **this PR consumes** |
| `memory_bank_error_class` (`keeper_status_detail`) | #17732 | not yet consumed |
| `memory_entries.errors[]` (memory subsystems) | #17724 | not yet consumed |
| `[memory unavailable: ...]` note string (`keeper_status`) | #17711 | already rendered as plain string |

## Anti-pattern self-check

- §1 telemetry-as-fix? No — consumes the typed sibling field that *replaced* the silent fallback, turning operator-visible signal into UI.
- §2 substring classifier? No — frontend renders the backend label as-is; no `if (label.includes(...))` parsing.
- §3 N-of-M? Tracked — three other sibling fields remain unconsumed (see table above); each can land in its own focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>