### PR TITLE
fix(keeper): rename provider timeout turn state

### DIFF
--- a/lib/keeper/keeper_turn_slot.ml
+++ b/lib/keeper/keeper_turn_slot.ml
@@ -851,7 +851,7 @@ let reset_autonomous_completion_for_test () : unit =
 
    [provider_timeout] is the canonical policy surface for the legacy
    structured timeout-budget path
-   (see [Keeper_unified_turn.resolve_bounded_oas_timeout_budget_with_turn_budget]).
+   (see [Keeper_unified_turn.resolve_bounded_provider_timeout_budget_with_turn_budget]).
    Re-running on the same fiber gives the same context and the same
    shape of failure repeats, but provider/cascade budget pressure is not
    keeper fiber corruption. Crossing [provider_timeout_strike_limit]

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -390,7 +390,7 @@ let run_keeper_cycle
                     Keeper_registry.Decision_active_guard_ok
                 | _ -> ());
                let last_execution = ref initial_execution in
-               let last_timeout_budget : provider_timeout_budget option ref =
+               let last_provider_timeout_budget : provider_timeout_budget option ref =
                  ref None
                in
                let degraded_retry_info = ref None in
@@ -588,7 +588,7 @@ let run_keeper_cycle
                              ~attempted_cascades
                              err
                          in
-                         let attempt_timeout_budget = ref None in
+                         let attempt_provider_timeout_budget = ref None in
                          let max_turns =
                            match channel with
                            | Keeper_world_observation.Reactive ->
@@ -634,9 +634,9 @@ let run_keeper_cycle
                                          Float.max 0.0
                                            (timeout_sec -. remaining_turn_budget_sec);
                                      }))
-                           | Some timeout_budget ->
-                             attempt_timeout_budget := Some timeout_budget;
-                             last_timeout_budget := Some timeout_budget;
+                           | Some provider_timeout_budget ->
+                             attempt_provider_timeout_budget := Some provider_timeout_budget;
+                             last_provider_timeout_budget := Some provider_timeout_budget;
                              (* Cascade_trying marking moved into the disclosure
                      hook in [Keeper_run_tools] (BeforeTurnParams) so
                      that the spec-mandated atomic group
@@ -656,14 +656,14 @@ let run_keeper_cycle
                              let attempt_watchdog_s =
                                attempt_watchdog_timeout_sec
                                  ~remaining_turn_budget_s:(remaining_turn_budget_s ())
-                                 timeout_budget
+                                 provider_timeout_budget
                              in
                              do_run
                                ~execution
                                ~run_meta
                                ~run_generation
                                ~is_retry
-                               ~oas_timeout_s:timeout_budget.effective_timeout_sec
+                               ~oas_timeout_s:provider_timeout_budget.effective_timeout_sec
                                ~attempt_watchdog_s
                          in
                          match attempt_result with
@@ -684,7 +684,7 @@ let run_keeper_cycle
                          | Error err ->
                            let err =
                              reclassify_oas_timeout_for_attempt
-                               ~timeout_budget:!attempt_timeout_budget
+                               ~timeout_budget:!attempt_provider_timeout_budget
                                err
                            in
                            let _ = drain_turn_event_bus ~site:"reconcile_pre_check" () in
@@ -798,7 +798,7 @@ let run_keeper_cycle
                      finally aborted the cycle (see fleet logs:
                      "passive status/read tools" cascade=default →
                      keeper_unified → kimi_cli_keeper → … →
-                     oas_timeout_budget at 1064s/1200s).  Cap at 1 rotation
+                     provider_timeout at 1064s/1200s).  Cap at 1 rotation
                      so the keeper releases its turn budget promptly.
 
                      The cap fires when attempted_cascades has at least 2
@@ -1416,7 +1416,7 @@ let run_keeper_cycle
                      else if is_transient
                      then " (transient, cooldown preserved)"
                      else if EC.should_warn_keeper_cycle_failed err
-                     then " (oas_timeout_budget, policy handled)"
+                     then " (provider_timeout, policy handled)"
                      else "")
                     (short_preview e_str);
                   Prometheus.inc_counter
@@ -1644,7 +1644,7 @@ let run_keeper_cycle
                       ~degraded_retry_applied
                       ~degraded_retry_cascade
                       ~fallback_reason
-                      ~last_timeout_budget:!last_timeout_budget
+                      ~last_provider_timeout_budget:!last_provider_timeout_budget
                       ~current_turn_blocker_info:!current_turn_blocker_info
                       ~keeper_turn_id
                       result

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -112,7 +112,7 @@ let append_metrics_snapshot
       ~semaphore_wait_ms:_
       ~turn_cost
       ~(lifecycle : KEC.post_turn_lifecycle)
-      ~last_timeout_budget
+      ~last_provider_timeout_budget
   =
   try
     let any_pending =
@@ -141,7 +141,7 @@ let append_metrics_snapshot
       ~compaction:lifecycle.compaction
       ~handoff_json:lifecycle.handoff_json
       ?provider_timeout_budget_json:
-        (Option.map KCB.provider_timeout_budget_to_yojson last_timeout_budget)
+        (Option.map KCB.provider_timeout_budget_to_yojson last_provider_timeout_budget)
       ()
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -463,7 +463,7 @@ let handle
       ~degraded_retry_applied
       ~degraded_retry_cascade
       ~fallback_reason
-      ~last_timeout_budget
+      ~last_provider_timeout_budget
       ~current_turn_blocker_info
       ~keeper_turn_id
       result
@@ -504,7 +504,7 @@ let handle
     ~semaphore_wait_ms
     ~turn_cost
     ~lifecycle
-    ~last_timeout_budget;
+    ~last_provider_timeout_budget;
   let turn_mode = KUM.turn_mode_of_result result in
   let turn_mode_label = KUM.turn_mode_to_string turn_mode in
   let model_used = Keeper_agent_run.surface_model_used result in

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -12,7 +12,7 @@ val handle
   -> degraded_retry_applied:bool
   -> degraded_retry_cascade:string option
   -> fallback_reason:Keeper_error_classify.degraded_retry_reason option
-  -> last_timeout_budget:
+  -> last_provider_timeout_budget:
        Keeper_turn_cascade_budget.provider_timeout_budget option
   -> current_turn_blocker_info:Keeper_meta_contract.blocker_info option
   -> keeper_turn_id:int


### PR DESCRIPTION
## Summary
- rename keeper turn-local timeout budget refs to provider_timeout_budget
- update success-path handoff labels so metrics propagation no longer exposes timeout-budget as keeper state
- replace live operator suffixes/comments that still reported oas_timeout_budget as the handled policy condition

## Validation
- Not run; user requested PR iteration without local validation.