### PR TITLE
fix(keeper): rename provider timeout reclassify hook

### DIFF
--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -386,13 +386,13 @@ let degraded_retry_bypasses_slot_phase_guard
   | None ->
     false
 
-let reclassify_oas_timeout_for_attempt
-    ~(timeout_budget : provider_timeout_budget option)
+let reclassify_provider_timeout_for_attempt
+    ~(provider_timeout_budget : provider_timeout_budget option)
     (err : Agent_sdk.Error.sdk_error) : Agent_sdk.Error.sdk_error =
-  match err, timeout_budget with
-  | Agent_sdk.Error.Api (Timeout { message }), Some timeout_budget
+  match err, provider_timeout_budget with
+  | Agent_sdk.Error.Api (Timeout { message }), Some provider_timeout_budget
     when EC.is_structural_oas_timeout_message message ->
-      ignore timeout_budget;
+      ignore provider_timeout_budget;
       err
   | _ -> err
 
@@ -400,9 +400,9 @@ let attempt_watchdog_outer_turn_reserve_sec = 1.0
 
 let attempt_watchdog_timeout_sec
     ~(remaining_turn_budget_s : float)
-    (timeout_budget : provider_timeout_budget) : float =
+    (provider_timeout_budget : provider_timeout_budget) : float =
   let desired =
-    timeout_budget.effective_timeout_sec +. provider_timeout_guard_sec
+    provider_timeout_budget.effective_timeout_sec +. provider_timeout_guard_sec
   in
   let cap_before_outer_timeout =
     Float.max 0.001

--- a/lib/keeper/keeper_turn_cascade_budget.mli
+++ b/lib/keeper/keeper_turn_cascade_budget.mli
@@ -160,8 +160,8 @@ val degraded_retry_slot_phase_budget_sec : float
 val degraded_retry_slot_phase_available :
   time_spent_in_turn_s:float -> bool
 
-val reclassify_oas_timeout_for_attempt :
-  timeout_budget:provider_timeout_budget option ->
+val reclassify_provider_timeout_for_attempt :
+  provider_timeout_budget:provider_timeout_budget option ->
   Agent_sdk.Error.sdk_error ->
   Agent_sdk.Error.sdk_error
 (** Preserve upstream structural timeout errors instead of minting a synthetic

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -683,8 +683,8 @@ let run_keeper_cycle
                            Ok result
                          | Error err ->
                            let err =
-                             reclassify_oas_timeout_for_attempt
-                               ~timeout_budget:!attempt_provider_timeout_budget
+                             reclassify_provider_timeout_for_attempt
+                               ~provider_timeout_budget:!attempt_provider_timeout_budget
                                err
                            in
                            let _ = drain_turn_event_bus ~site:"reconcile_pre_check" () in
@@ -1644,7 +1644,7 @@ let run_keeper_cycle
                       ~degraded_retry_applied
                       ~degraded_retry_cascade
                       ~fallback_reason
-                      ~last_provider_timeout_budget:!last_provider_timeout_budget
+                      ~last_provider_provider_timeout_budget:!last_provider_timeout_budget
                       ~current_turn_blocker_info:!current_turn_blocker_info
                       ~keeper_turn_id
                       result

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -58,8 +58,8 @@ val degraded_retry_slot_phase_available : time_spent_in_turn_s:float -> bool
     actually dispatched with an provider timeout budget. This prevents a
     pre-retry turn-budget exhaustion from borrowing a stale previous
     attempt budget and incorrectly rotating cascades. *)
-val reclassify_oas_timeout_for_attempt
-  :  timeout_budget:provider_timeout_budget option
+val reclassify_provider_timeout_for_attempt
+  :  provider_timeout_budget:provider_timeout_budget option
   -> Agent_sdk.Error.sdk_error
   -> Agent_sdk.Error.sdk_error
 

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -8382,18 +8382,18 @@ let test_oas_timeout_reclassifies_only_current_attempt_budget () =
       ~remaining_turn_budget_s:1200.0
   with
   | None -> fail "expected timeout budget"
-  | Some timeout_budget ->
+  | Some provider_timeout_budget ->
     let classified =
-      UT.reclassify_oas_timeout_for_attempt ~timeout_budget:(Some timeout_budget) err
+      UT.reclassify_provider_timeout_for_attempt ~provider_timeout_budget:(Some provider_timeout_budget) err
     in
     (match Masc_mcp.Keeper_turn_driver.classify_masc_internal_error classified with
      | Some (Masc_mcp.Keeper_turn_driver.Provider_timeout budget) ->
        check int "estimated tokens preserved" 2_000 budget.estimated_input_tokens;
-       check string "source preserved" timeout_budget.source budget.source;
+       check string "source preserved" provider_timeout_budget.source budget.source;
        check
          (option (float 0.001))
          "remaining budget preserved"
-         (Some timeout_budget.remaining_turn_budget_sec)
+         (Some provider_timeout_budget.remaining_turn_budget_sec)
          budget.remaining_turn_budget_sec;
        check string "phase" "cascade_attempt_watchdog" budget.phase
      | _ -> fail "expected provider timeout budget classification")
@@ -8405,7 +8405,7 @@ let test_pre_retry_timeout_helper_does_not_reuse_stale_budget () =
       (Timeout
          { message = "Turn wall-clock budget exhausted before retry (remaining=2.0s)" })
   in
-  let classified = UT.reclassify_oas_timeout_for_attempt ~timeout_budget:None err in
+  let classified = UT.reclassify_provider_timeout_for_attempt ~provider_timeout_budget:None err in
   check
     bool
     "plain helper call without budget stays raw timeout"


### PR DESCRIPTION
## Summary
- rename the cascade-budget reclassify hook from oas-timeout to provider-timeout
- rename the hook argument from timeout_budget to provider_timeout_budget across unified-turn callers
- update unified-turn tests to call the provider-timeout hook API

## Validation
- Not run; user requested PR iteration without local validation.