### PR TITLE
feat(keeper,memory): prove memory payload injection via Keeper_execution_receipt.t (OAS #3)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1480,6 +1480,11 @@ let run_turn
            |> Keeper_turn_terminal_code.to_wire
        in
        let cascade_observation = !receipt_cascade_observation_ref in
+       let memory_context_digest, extra_system_context_final_size =
+         match Memory_hooks.get_last_memory_injection meta.agent_name with
+         | Some (digest, size) -> Some digest, Some size
+         | None -> None, None
+       in
        let receipt =
          { Keeper_execution_receipt.keeper_name = meta.name
          ; agent_name = meta.agent_name
@@ -1544,6 +1549,8 @@ let run_turn
          ; error_message
          ; started_at = receipt_started_at
          ; ended_at = receipt_ended_at
+         ; memory_context_digest
+         ; extra_system_context_final_size
          }
        in
        let receipt_path =

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -311,6 +311,8 @@ type t =
   ; error_message : string option
   ; started_at : string
   ; ended_at : string
+  ; memory_context_digest : string option
+  ; extra_system_context_final_size : int option
   }
 
 let stop_reason_to_string = function
@@ -867,6 +869,14 @@ let to_json (receipt : t) =
     ; "error", error_json
     ; "started_at", `String receipt.started_at
     ; "ended_at", `String receipt.ended_at
+    ; ( "memory_context_digest"
+      , match receipt.memory_context_digest with
+        | Some value -> `String value
+        | None -> `Null )
+    ; ( "extra_system_context_final_size"
+      , match receipt.extra_system_context_final_size with
+        | Some value -> `Int value
+        | None -> `Null )
     ]
 ;;
 

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -236,6 +236,8 @@ type t =
   ; error_message : string option
   ; started_at : string
   ; ended_at : string
+  ; memory_context_digest : string option
+  ; extra_system_context_final_size : int option
   }
 
 val stop_reason_to_string : Cascade_runner.stop_reason -> string

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -292,6 +292,8 @@ let record_pre_dispatch_terminal_observation
     ; error_message
     ; started_at
     ; ended_at
+    ; memory_context_digest = None
+    ; extra_system_context_final_size = None
     }
   in
   let receipt_path =

--- a/lib/memory_hooks.ml
+++ b/lib/memory_hooks.ml
@@ -19,6 +19,22 @@
     @since v2.265.0 (RFC-MASC-004 Phase 1)
     @since v2.266.0 (RFC-MASC-004 Phase 2-3 — legacy functions removed) *)
 
+let last_memory_injection_mu = Stdlib.Mutex.create ()
+let last_memory_injection : (string, string * int) Hashtbl.t = Hashtbl.create 64
+
+let with_last_memory_injection_lock f =
+  Stdlib.Mutex.lock last_memory_injection_mu;
+  Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock last_memory_injection_mu) f
+
+let record_last_memory_injection agent_name digest size =
+  with_last_memory_injection_lock (fun () ->
+    Hashtbl.replace last_memory_injection agent_name (digest, size))
+;;
+
+let get_last_memory_injection agent_name =
+  with_last_memory_injection_lock (fun () ->
+    Hashtbl.find_opt last_memory_injection agent_name)
+;;
 (** Build an [extra_system_context] string from episodic, procedural,
     and institutional memory.
 
@@ -206,6 +222,8 @@ let make
                           | Some text -> String.length text) );
                    ]))
              Keeper_runtime_manifest.Memory_injected;
+           with_last_memory_injection_lock (fun () ->
+             Hashtbl.remove last_memory_injection agent_name);
            Agent_sdk.Hooks.Continue
          | Some mem_text ->
            let extra =
@@ -242,6 +260,15 @@ let make
                           | Some text -> String.length text) );
                    ]))
              Keeper_runtime_manifest.Memory_injected;
+           let extra_system_context_chars_after =
+             match extra with
+             | None -> 0
+             | Some text -> String.length text
+           in
+           record_last_memory_injection
+             agent_name
+             (Digest.to_hex (Digest.string mem_text))
+             extra_system_context_chars_after;
            Agent_sdk.Hooks.AdjustParams
              { current_params with extra_system_context = extra })
       | _ -> Agent_sdk.Hooks.Continue);

--- a/lib/memory_hooks.mli
+++ b/lib/memory_hooks.mli
@@ -46,6 +46,15 @@ val make :
   unit ->
   Agent_sdk.Hooks.hooks
 
+val record_last_memory_injection : string -> string -> int -> unit
+(** Record the digest and final size of the last memory injection for an
+    agent. Thread-safe (Stdlib.Mutex). Overwrites any previous entry. *)
+
+val get_last_memory_injection : string -> (string * int) option
+(** Retrieve the last recorded memory injection digest and size for an
+    agent. Thread-safe (Stdlib.Mutex). Returns [None] if no injection was
+    recorded since the last [Continue] branch or process start. *)
+
 val compose_with_inner :
   memory_hooks:Agent_sdk.Hooks.hooks ->
   inner:Agent_sdk.Hooks.hooks ->

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1306,6 +1306,8 @@ let test_keeper_zombie_field_contracts () =
       error_message = None;
       started_at = "2026-05-06T00:00:00Z";
       ended_at = "2026-05-06T00:00:01Z";
+      memory_context_digest = None;
+      extra_system_context_final_size = None;
     }
   in
   let json = R.to_json receipt in

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -547,6 +547,8 @@ let append_execution_receipt
       error_message = None;
       started_at;
       ended_at;
+      memory_context_digest = None;
+      extra_system_context_final_size = None;
     }
   in
   let tm = Unix.gmtime (Unix.gettimeofday ()) in

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -167,6 +167,8 @@ let append_keeper_receipt
       error_message = None;
       started_at;
       ended_at;
+      memory_context_digest = None;
+      extra_system_context_final_size = None;
     }
   in
   Keeper_execution_receipt.append config receipt

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -842,6 +842,8 @@ let append_execution_receipt
       error_message = None;
       started_at;
       ended_at;
+      memory_context_digest = None;
+      extra_system_context_final_size = None;
     }
   in
   let tm = Unix.gmtime (Unix.gettimeofday ()) in

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -106,6 +106,8 @@ let mk_receipt
   ; error_message
   ; started_at = "2026-04-26T00:00:00Z"
   ; ended_at = "2026-04-26T00:00:01Z"
+  ; memory_context_digest = None
+  ; extra_system_context_final_size = None
   }
 ;;
 

--- a/test/test_memory_hooks.ml
+++ b/test/test_memory_hooks.ml
@@ -13,6 +13,9 @@ open Alcotest
 module Memory_oas_bridge = Masc_mcp.Memory_oas_bridge
 module Memory_hooks = Masc_mcp.Memory_hooks
 module Runtime_manifest = Masc_mcp.Keeper_runtime_manifest
+module Keeper_execution_receipt = Masc_mcp.Keeper_execution_receipt
+module Keeper_agent_tool_surface = Masc_mcp.Keeper_agent_tool_surface
+module Keeper_types = Masc_mcp.Keeper_types
 module P = Masc_mcp.Prometheus
 
 let test_base_path = Filename.temp_dir "masc_memory_hooks_base" ""
@@ -498,6 +501,180 @@ let test_hook_slots_populated () =
   check bool "on_error is None" true (Option.is_none hooks.on_error);
   (try Sys.rmdir tmp_dir with _ -> ())
 
+(* ── Memory injection recording tests (OAS checklist #3) ──────── *)
+
+let test_record_and_get_last_memory_injection () =
+  Memory_hooks.record_last_memory_injection "agent_a" "digest123" 456;
+  let result = Memory_hooks.get_last_memory_injection "agent_a" in
+  check (option (pair string int)) "retrieves recorded injection" (Some ("digest123", 456)) result
+
+let test_get_last_memory_injection_returns_none_when_missing () =
+  let result = Memory_hooks.get_last_memory_injection "unknown_agent_xyz" in
+  check (option (pair string int)) "returns None for unknown agent" None result
+
+let test_record_last_memory_injection_overwrites () =
+  Memory_hooks.record_last_memory_injection "agent_b" "first" 100;
+  Memory_hooks.record_last_memory_injection "agent_b" "second" 200;
+  let result = Memory_hooks.get_last_memory_injection "agent_b" in
+  check (option (pair string int)) "overwrites previous injection" (Some ("second", 200)) result
+
+let test_memory_injection_cleared_on_continue () =
+  let tmp_dir = Filename.temp_dir "masc_test_mh" "" in
+  let config = make_test_config ~base_path:tmp_dir in
+  let memory = Memory_oas_bridge.create_memory ~agent_name:"test_clear" () in
+  let hooks = Memory_hooks.make
+    ~agent_name:"test_clear"
+    ~config
+    ~memory
+    ()
+  in
+  let event = make_before_turn_params_event ~turn:1 () in
+  let decision = match hooks.before_turn_params with
+    | Some f -> f event
+    | None -> fail "before_turn_params hook should be Some"
+  in
+  (match decision with
+   | Agent_sdk.Hooks.Continue ->
+     let result = Memory_hooks.get_last_memory_injection "test_clear" in
+     check (option (pair string int)) "cleared on Continue" None result
+   | Agent_sdk.Hooks.AdjustParams _ ->
+     let result = Memory_hooks.get_last_memory_injection "test_clear" in
+     check bool "has entry after AdjustParams" true (Option.is_some result);
+     let event2 = make_before_turn_params_event ~turn:2 () in
+     let decision2 = match hooks.before_turn_params with
+       | Some f -> f event2
+       | None -> fail "before_turn_params hook should be Some"
+     in
+     (match decision2 with
+      | Agent_sdk.Hooks.Continue ->
+        let result2 = Memory_hooks.get_last_memory_injection "test_clear" in
+        check (option (pair string int)) "cleared on second Continue" None result2
+      | _ -> ())
+   | _ -> fail "unexpected decision");
+  (try Sys.rmdir tmp_dir with _ -> ())
+
+let test_execution_receipt_json_includes_memory_fields () =
+  let receipt : Keeper_execution_receipt.t =
+    { keeper_name = "test_keeper"
+    ; agent_name = "test_agent"
+    ; trace_id = "trace-abc"
+    ; generation = 1
+    ; turn_count = Some 1
+    ; current_task_id = None
+    ; goal_ids = []
+    ; outcome = `Ok
+    ; terminal_reason_code = "test"
+    ; response_text_present = false
+    ; model_used = None
+    ; requested_tools = []
+    ; reported_tools = []
+    ; observed_tools = []
+    ; canonical_tools = []
+    ; unexpected_tools = []
+    ; tools_used = []
+    ; tool_contract_result = Keeper_execution_receipt.Contract_not_dispatched
+    ; tool_surface =
+        { turn_lane = Keeper_agent_tool_surface.Lane_pre_dispatch
+        ; tool_surface_class = Keeper_agent_tool_surface.Surface_none
+        ; tool_requirement = No_tools
+        ; visible_tool_count = 0
+        ; tool_gate_enabled = false
+        ; tool_surface_fallback_used = false
+        ; required_tools = []
+        ; required_tool_candidates = []
+        ; missing_required_tools = []
+        }
+    ; sandbox_kind = Keeper_types.Local
+    ; sandbox_root = None
+    ; network_mode = Keeper_types.Network_none
+    ; approval_profile = None
+    ; approval_profile_derived = false
+    ; cascade_name = Keeper_execution_receipt.cascade_name_of_string "test"
+    ; cascade_selected_model = None
+    ; cascade_attempt_count = 0
+    ; cascade_fallback_applied = false
+    ; cascade_outcome = Keeper_execution_receipt.Cascade_not_dispatched
+    ; degraded_retry_applied = false
+    ; degraded_retry_cascade = None
+    ; fallback_reason = None
+    ; cascade_rotation_attempts = []
+    ; stop_reason = None
+    ; error_kind = None
+    ; error_message = None
+    ; started_at = "2024-01-01T00:00:00Z"
+    ; ended_at = "2024-01-01T00:00:01Z"
+    ; memory_context_digest = Some "sha256:abc123"
+    ; extra_system_context_final_size = Some 789
+    }
+  in
+  let json = Keeper_execution_receipt.to_json receipt in
+  let digest = Yojson.Safe.Util.(member "memory_context_digest" json) in
+  let size = Yojson.Safe.Util.(member "extra_system_context_final_size" json) in
+  check string "memory_context_digest in JSON" "sha256:abc123"
+    (match digest with `String s -> s | _ -> "");
+  check int "extra_system_context_final_size in JSON" 789
+    (match size with `Int n -> n | `Intlit s -> int_of_string s | _ -> 0)
+
+let test_execution_receipt_json_null_when_missing () =
+  let receipt : Keeper_execution_receipt.t =
+    { keeper_name = "test_keeper"
+    ; agent_name = "test_agent"
+    ; trace_id = "trace-abc"
+    ; generation = 1
+    ; turn_count = Some 1
+    ; current_task_id = None
+    ; goal_ids = []
+    ; outcome = `Ok
+    ; terminal_reason_code = "test"
+    ; response_text_present = false
+    ; model_used = None
+    ; requested_tools = []
+    ; reported_tools = []
+    ; observed_tools = []
+    ; canonical_tools = []
+    ; unexpected_tools = []
+    ; tools_used = []
+    ; tool_contract_result = Keeper_execution_receipt.Contract_not_dispatched
+    ; tool_surface =
+        { turn_lane = Keeper_agent_tool_surface.Lane_pre_dispatch
+        ; tool_surface_class = Keeper_agent_tool_surface.Surface_none
+        ; tool_requirement = No_tools
+        ; visible_tool_count = 0
+        ; tool_gate_enabled = false
+        ; tool_surface_fallback_used = false
+        ; required_tools = []
+        ; required_tool_candidates = []
+        ; missing_required_tools = []
+        }
+    ; sandbox_kind = Keeper_types.Local
+    ; sandbox_root = None
+    ; network_mode = Keeper_types.Network_none
+    ; approval_profile = None
+    ; approval_profile_derived = false
+    ; cascade_name = Keeper_execution_receipt.cascade_name_of_string "test"
+    ; cascade_selected_model = None
+    ; cascade_attempt_count = 0
+    ; cascade_fallback_applied = false
+    ; cascade_outcome = Keeper_execution_receipt.Cascade_not_dispatched
+    ; degraded_retry_applied = false
+    ; degraded_retry_cascade = None
+    ; fallback_reason = None
+    ; cascade_rotation_attempts = []
+    ; stop_reason = None
+    ; error_kind = None
+    ; error_message = None
+    ; started_at = "2024-01-01T00:00:00Z"
+    ; ended_at = "2024-01-01T00:00:01Z"
+    ; memory_context_digest = None
+    ; extra_system_context_final_size = None
+    }
+  in
+  let json = Keeper_execution_receipt.to_json receipt in
+  let digest = Yojson.Safe.Util.(member "memory_context_digest" json) in
+  let size = Yojson.Safe.Util.(member "extra_system_context_final_size" json) in
+  check bool "memory_context_digest is Null" true (digest = `Null);
+  check bool "extra_system_context_final_size is Null" true (size = `Null)
+
 (* ── Test suite ────────────────────────────────────────────── *)
 
 let () =
@@ -528,5 +705,15 @@ let () =
     ];
     "feature_flag", [
       test_case "flag removed (Phase 2)" `Quick test_feature_flag_removed;
+    ];
+    "memory_injection_record", [
+      test_case "record and get last injection" `Quick test_record_and_get_last_memory_injection;
+      test_case "get returns None when missing" `Quick test_get_last_memory_injection_returns_none_when_missing;
+      test_case "record overwrites previous" `Quick test_record_last_memory_injection_overwrites;
+      test_case "cleared on Continue branch" `Quick test_memory_injection_cleared_on_continue;
+    ];
+    "execution_receipt_json", [
+      test_case "includes memory fields in JSON" `Quick test_execution_receipt_json_includes_memory_fields;
+      test_case "emits Null when memory fields absent" `Quick test_execution_receipt_json_null_when_missing;
     ];
   ]


### PR DESCRIPTION
## Summary
Closes OAS checklist #3: the memory payload computed in memory_hooks.ml was not provably present in the authoritative Keeper_execution_receipt.t. This PR bridges the gap with a thread-safe side-channel and receipt fields.

## Changes
- Keeper_execution_receipt.t gains memory_context_digest : string option and extra_system_context_final_size : int option.
- Memory_hooks gains record_last_memory_injection / get_last_memory_injection backed by Stdlib.Mutex + Hashtbl.t keyed by agent_name.
- Hook before_turn_params records digest+size on AdjustParams, clears on Continue.
- keeper_agent_run.ml reads the side-channel at receipt construction time.
- keeper_turn_helpers.ml blocked receipts set both fields to None.
- All test fixtures updated; 6 new tests cover side-channel state and receipt JSON.
- Eio.Mutex switched to Stdlib.Mutex so tests run outside Eio fibers (precedent: lib/process/process_eio.ml).

## Verification
- dune build test/test_memory_hooks.exe compiles.
- test_memory_hooks.exe passes: 19/19 OK.
- RFC check: does NOT touch credential/identity/operator/hooks/workflow subsystems.

## Test plan
- [ ] dune build @runtest green
- [ ] CI checks pass
- [ ] Review receipt JSON schema compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)