### PR TITLE
fix(keeper): correct provider timeout handoff label

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1644,7 +1644,7 @@ let run_keeper_cycle
                       ~degraded_retry_applied
                       ~degraded_retry_cascade
                       ~fallback_reason
-                      ~last_provider_provider_timeout_budget:!last_provider_timeout_budget
+                      ~last_provider_timeout_budget:!last_provider_timeout_budget
                       ~current_turn_blocker_info:!current_turn_blocker_info
                       ~keeper_turn_id
                       result


### PR DESCRIPTION
## Summary
- fix the accidental last_provider_provider_timeout_budget keyword introduced by the provider-timeout rename wave
- restore the success-path handoff call to the actual last_provider_timeout_budget parameter
- keep this isolated so the timeout-state cleanup PRs do not leave a build-breaking side effect

## Validation
- Not run; user requested PR iteration without local validation.