### PR TITLE
fix(keeper): restore success handler timeout label

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1644,7 +1644,7 @@ let run_keeper_cycle
                       ~degraded_retry_applied
                       ~degraded_retry_cascade
                       ~fallback_reason
-                      ~last_provider_provider_timeout_budget:!last_provider_timeout_budget
+                      ~last_provider_timeout_budget:!last_provider_timeout_budget
                       ~current_turn_blocker_info:!current_turn_blocker_info
                       ~keeper_turn_id
                       result


### PR DESCRIPTION
Follow-up for #17769 review discussion: https://github.com/jeong-sik/masc-mcp/pull/17769#discussion_r3287977465

## Change
- Restore the call-site label to `~last_provider_timeout_budget` so it matches `Keeper_unified_turn_success.handle`.

## Validation
- `ocamlformat --check lib/keeper/keeper_unified_turn.ml`
- `git diff --check`
- `rg -n "last_provider_provider_timeout_budget" lib test` (no matches)
- `scripts/dune-local.sh build lib/keeper/keeper_unified_turn.cmo` blocked locally by existing bare Dune processes outside the wrapper.