### PR TITLE
feat(dashboard): surface memory_entries.errors[] in MemoryEntriesPanel (RFC-0149 §3.1 frontend)

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -3059,6 +3059,15 @@ export interface MemorySubsystemsMemoryEntry {
   ts_unix: number
 }
 
+/** RFC-0149 §3.1 — per-keeper memory bank read failure, surfaced as
+ *  a typed sibling field next to the entry rows.  `error_class` is one
+ *  of the closed 4-value `Keeper_memory_recall_exn_class.t` labels
+ *  (`yojson_parse_error | io_error | type_error | other`). */
+export interface MemorySubsystemsMemoryEntryError {
+  keeper: string
+  error_class: string
+}
+
 export interface MemorySubsystemsResponse {
   generated_at: string
   hebbian: {
@@ -3078,6 +3087,11 @@ export interface MemorySubsystemsResponse {
     shown: number
     limit: number
     items: MemorySubsystemsMemoryEntry[]
+    /** RFC-0149 §3.1 — per-keeper memory bank read failures.  Each
+     *  entry means that keeper's `memory.jsonl` could not be read and
+     *  the corresponding rows are absent from `items`; the rest of
+     *  `items` is still trustworthy. */
+    errors?: MemorySubsystemsMemoryEntryError[]
   }
   filters: {
     keepers: string[]

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -12,6 +12,7 @@ import {
   type MemorySubsystemsSynapse,
   type MemorySubsystemsEpisode,
   type MemorySubsystemsMemoryEntry,
+  type MemorySubsystemsMemoryEntryError,
 } from '../api/dashboard'
 import { formatTimeAgo } from '../lib/format-time'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
@@ -534,6 +535,7 @@ export function MemoryEntriesPanel({
   activeKind,
   onKindChange,
   focused,
+  errors,
 }: {
   readonly entries: readonly MemorySubsystemsMemoryEntry[]
   readonly visibleEntries: readonly MemorySubsystemsMemoryEntry[]
@@ -543,6 +545,10 @@ export function MemoryEntriesPanel({
   readonly activeKind: string
   readonly onKindChange: (kind: string) => void
   readonly focused: boolean
+  /** RFC-0149 §3.1 — per-keeper memory bank read failures.  Each entry
+   *  means that keeper's `memory.jsonl` could not be read; the entry
+   *  rows under `entries` are still trustworthy for the other keepers. */
+  readonly errors?: readonly MemorySubsystemsMemoryEntryError[]
 }) {
   const chips = [
     { key: 'all', label: 'all', count: entries.length },
@@ -575,6 +581,27 @@ export function MemoryEntriesPanel({
         size="sm"
         tone="accent"
       />
+      ${
+        errors && errors.length > 0
+          ? html`<div
+              data-testid="memory-entries-errors"
+              role="alert"
+              class="rounded-[var(--r-1)] border border-[var(--warn-fg)] bg-[var(--warn-bg)] px-3 py-2 text-2xs text-[var(--color-fg-primary)]"
+            >
+              <div class="font-semibold mb-1">
+                ${errors.length} keeper${errors.length > 1 ? 's' : ''} memory unavailable
+              </div>
+              <ul class="flex flex-wrap gap-x-3 gap-y-1 font-mono">
+                ${errors.map(e => html`
+                  <li>
+                    <span class="text-[var(--color-fg-primary)]">${e.keeper}</span>:
+                    <span class="text-[var(--warn-fg)]">${e.error_class}</span>
+                  </li>
+                `)}
+              </ul>
+            </div>`
+          : null
+      }
       ${
         visibleEntries.length === 0
           ? html`<div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] p-4 text-center text-sm text-[var(--color-fg-muted)]">
@@ -754,6 +781,7 @@ export function MemorySubsystems({ focus }: MemorySubsystemsProps = {}) {
                   activeKind=${memoryKindFilter.value}
                   onKindChange=${(kind: string) => { memoryKindFilter.value = kind }}
                   focused=${normalizedFocus === 'entries'}
+                  errors=${data?.memory_entries?.errors ?? []}
                 />
               </div>
             `
@@ -975,6 +1003,7 @@ export function KeeperMemoryPanel({ keeperName }: { readonly keeperName: string 
         activeKind=${memoryKindFilter.value}
         onKindChange=${(kind: string) => { memoryKindFilter.value = kind }}
         focused=${true}
+        errors=${data?.memory_entries?.errors ?? []}
       />
       ${error ? html`<div class="text-xs text-[var(--color-status-warn)]">refresh error: ${error}</div>` : null}
     </div>


### PR DESCRIPTION
## Goal

Surface the per-keeper memory bank read failures that the backend `/api/v1/dashboard/memory-subsystems` endpoint already emits (PR-6 #17724 MERGED).  Until now, when a keeper's `memory.jsonl` could not be read, its entries were silently absent from the panel — operators had no way to distinguish "keeper has not yet recorded any notes" from "this keeper's memory file is unreadable".

## Backend contract (already on `origin/main`)

```jsonc
{
  "memory_entries": {
    "total": N, "filtered": M, "shown": K, "limit": L,
    "items": [ ... rows ... ],
    "errors": [
      { "keeper": "alice", "error_class": "io_error" },
      { "keeper": "bob",   "error_class": "yojson_parse_error" }
    ]
  }
}
```

`error_class` is bounded by the 4-value `Keeper_memory_recall_exn_class.t` closed sum (`yojson_parse_error | io_error | type_error | other`).

## Change

### `dashboard/src/api/dashboard.ts`

New exported interface and optional field:

```diff
+export interface MemorySubsystemsMemoryEntryError {
+  keeper: string
+  error_class: string
+}

 export interface MemorySubsystemsResponse {
   …
   memory_entries?: {
     total: number
     filtered: number
     shown: number
     limit: number
     items: MemorySubsystemsMemoryEntry[]
+    errors?: MemorySubsystemsMemoryEntryError[]
   }
   …
 }
```

### `dashboard/src/components/memory-subsystems.ts`

`MemoryEntriesPanel` gains an `errors` prop.  When non-empty, a `role="alert"` warn-toned banner renders above the entry list:

```
┌─────────────────────────────────────────────────────────┐
│ 2 keepers memory unavailable                            │
│   alice: io_error    bob: yojson_parse_error            │
└─────────────────────────────────────────────────────────┘
```

Banner shape matches existing dashboard warn idioms (`--warn-fg` / `--warn-bg` tokens, font-mono list rows).  Two call sites (`MemorySubsystems` and `MemoryEntriesPanelStandalone`) pass `data?.memory_entries?.errors ?? []` through.

## Operator surface restored

| Backend state                            | `entries` rows | Banner                                   |
|------------------------------------------|----------------|------------------------------------------|
| All keepers `Ok` + populated banks       | full list      | none                                     |
| All keepers `Ok` + empty banks           | `[]`           | none                                     |
| One keeper `Error io_error`              | other keepers  | "1 keeper memory unavailable · alice: io_error" |
| Multiple keepers `Error` (mixed classes) | other keepers  | "N keepers memory unavailable · ..."     |

Previously the third and fourth rows were indistinguishable from the second — the silent drop swallowed both the keepers and the failure class.

## Verification

* `pnpm typecheck` → pass.
* `pnpm install --frozen-lockfile` → clean.

## Stack context

Independent of any open backend PR — the backend field has been on `origin/main` since PR-6 #17724 merged earlier this loop.  Sibling field consume tracking:

| Surface | Backend PR | Frontend |
|---------|------------|----------|
| `memory_kind_usage_error_class` | #17728 | #17766 MERGED |
| `memory_entries.errors[]` | #17724 | **this PR** |
| `memory_bank_error_class` (`keeper_status_detail`) | #17732 | not consumed (no dashboard caller; `include_memory_bank: false` in `keeper-actions.ts`) |

## Anti-pattern self-check

- §1 telemetry-as-fix? No — passthrough rendering of a typed sibling array; no new counter or fetch.
- §2 substring classifier? No — frontend renders the backend label as-is, no `if (label === '...') ...` parsing.
- §3 N-of-M? Tracked — last unconsumed sibling field that has a dashboard caller (`memory_bank_error_class` is intentionally unused by dashboard per backend caller policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>