### PR TITLE
fix(cascade): canonicalize provider timeout kind before decode

### DIFF
--- a/lib/cascade/cascade_error_from_sdk.ml
+++ b/lib/cascade/cascade_error_from_sdk.ml
@@ -20,6 +20,11 @@
 
 open Cascade_internal_error
 
+let canonical_masc_oas_kind kind =
+  match kind with
+  | "oas_timeout_budget" -> "provider_timeout"
+  | _ -> kind
+
 let parse_masc_internal_error_json (json : Yojson.Safe.t) :
     masc_internal_error option =
   let int_opt_of_assoc key = function
@@ -169,8 +174,7 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
               | _ -> None)
           | _ -> None)
       | Some (`String kind)
-        when String.equal kind "provider_timeout"
-             || String.equal kind "oas_timeout_budget" -> (
+        when String.equal (canonical_masc_oas_kind kind) "provider_timeout" -> (
           match json with
           | `Assoc fields -> (
               match


### PR DESCRIPTION
## Summary
- add a cascade SDK decoder kind canonicalizer for legacy oas_timeout_budget input
- match the provider-timeout decode branch only on canonical provider_timeout
- keep legacy timeout-budget as wire compatibility input instead of a peer live branch

## Validation
- Not run; user requested PR iteration without local validation.