### PR TITLE
fix: address priority review followups

### DIFF
--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -405,7 +405,8 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
               segments: promptSegments,
             }
           : null
-      const rawTimeoutBudget = isRecord(item.timeout_budget) ? item.timeout_budget : null
+      const rawProviderTimeoutBudget = isRecord(item.provider_timeout_budget) ? item.provider_timeout_budget : null
+      const rawTimeoutBudget = isRecord(item.timeout_budget) ? item.timeout_budget : rawProviderTimeoutBudget
       const timeout_budget =
         rawTimeoutBudget != null
           ? {

--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -724,6 +724,10 @@ let metric_keeper_provider_timeout_loop_paused =
   "masc_keeper_provider_timeout_loop_paused_total"
 ;;
 
+let metric_keeper_oas_timeout_budget_loop_paused =
+  metric_keeper_provider_timeout_loop_paused
+;;
+
 let metric_keeper_cycle_exceptions = "masc_keeper_cycle_exceptions_total"
 let metric_keeper_snapshot_write_failures = "masc_keeper_snapshot_write_failures_total"
 
@@ -938,6 +942,8 @@ let metric_keeper_provider_timeout_strike =
   "masc_keeper_provider_timeout_strike_total"
 ;;
 
+let metric_keeper_oas_timeout_budget_strike = metric_keeper_provider_timeout_strike
+
 let metric_keeper_stale_termination_total = "masc_keeper_stale_termination_total"
 
 let metric_keeper_stale_termination_by_class =
@@ -946,6 +952,10 @@ let metric_keeper_stale_termination_by_class =
 
 let metric_keeper_provider_timeout_watchdog_termination =
   "masc_keeper_provider_timeout_watchdog_termination_total"
+;;
+
+let metric_keeper_oas_timeout_budget_watchdog_termination =
+  metric_keeper_provider_timeout_watchdog_termination
 ;;
 
 let metric_keeper_stale_termination_threshold_breached =

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -413,6 +413,7 @@ val metric_keeper_presence_sync_failures : string
 val metric_keeper_self_preservation_universal : string
 val metric_keeper_stale_storm_paused : string
 val metric_keeper_provider_timeout_loop_paused : string
+val metric_keeper_oas_timeout_budget_loop_paused : string
 val metric_keeper_cycle_exceptions : string
 val metric_keeper_snapshot_write_failures : string
 val metric_keeper_state_snapshot_skipped_no_state : string
@@ -594,9 +595,11 @@ val metric_keeper_required_tool_gate_suppressed_total : string
 val metric_keeper_consecutive_idle : string
 val metric_keeper_last_productive_ts : string
 val metric_keeper_provider_timeout_strike : string
+val metric_keeper_oas_timeout_budget_strike : string
 val metric_keeper_stale_termination_total : string
 val metric_keeper_stale_termination_by_class : string
 val metric_keeper_provider_timeout_watchdog_termination : string
+val metric_keeper_oas_timeout_budget_watchdog_termination : string
 val metric_keeper_stale_termination_threshold_breached : string
 val metric_keeper_stale_termination_batch : string
 val metric_keeper_stale_broadcast_emit_failures : string

--- a/lib/server/server_dashboard_http_memory_subsystems.ml
+++ b/lib/server/server_dashboard_http_memory_subsystems.ml
@@ -55,7 +55,7 @@ let load_memory_subsystems_entries ~(config : Coord_utils.config) =
                        keeper, row)
                      summary.recent_notes
                  in
-                 rows_acc @ rows, errs_acc
+                 List.rev_append rows rows_acc, errs_acc
                | Error exn_class ->
                  let label =
                    Keeper_memory_recall_exn_class.to_label exn_class
@@ -66,6 +66,7 @@ let load_memory_subsystems_entries ~(config : Coord_utils.config) =
       | Eio.Cancel.Cancelled _ as e -> raise e
       | _ -> [], []
     in
+    let rows = List.rev rows in
     let errors = List.rev errors in
     memory_subsystems_entry_cache
     := Some (config.base_path, now, rows, errors);

--- a/lib/tool_shard_types_schemas_board.ml
+++ b/lib/tool_shard_types_schemas_board.ml
@@ -8,7 +8,7 @@ let board_tools : Masc_domain.tool_schema list =
         "Read a single board post with all its comments and votes. Use before deciding \
          to comment, vote, or escalate. Returns post content, author, timestamp, \
          vote_count, and comment thread. post_id format: 'p-xxxx'. Get post_id from \
-         masc_board_list results."
+         keeper_board_list results."
     ; input_schema =
         `Assoc
           [ "type", `String "object"
@@ -18,7 +18,7 @@ let board_tools : Masc_domain.tool_schema list =
                   , `Assoc
                       [ "type", `String "string"
                       ; ( "description"
-                        , `String "Post ID (format: p-xxxx). Get from masc_board_list."
+                        , `String "Post ID (format: p-xxxx). Get from keeper_board_list."
                         )
                       ] )
                 ] )
@@ -156,7 +156,7 @@ let board_tools : Masc_domain.tool_schema list =
                       [ "type", `String "string"
                       ; ( "description"
                         , `String
-                            "Post ID (format: p-xxxx...). Get from masc_board_list \
+                            "Post ID (format: p-xxxx...). Get from keeper_board_list \
                              results." )
                       ] )
                 ; ( "content"
@@ -182,7 +182,7 @@ let board_tools : Masc_domain.tool_schema list =
                       [ "type", `String "string"
                       ; ( "description"
                         , `String
-                            "Post ID (format: p-xxxx...). Get from masc_board_list \
+                            "Post ID (format: p-xxxx...). Get from keeper_board_list \
                              results." )
                       ] )
                 ; (* Issue #8506: derive from local mirror that tracks

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -25,13 +25,11 @@ let test_turn_timeout_blocker_class_roundtrip () =
   | None -> fail "Turn_timeout label did not parse back"
 
 let test_oas_timeout_budget_blocker_class_collapses_to_turn_timeout () =
-  let cls = KT.Turn_timeout in
-  let label = KT.blocker_class_to_string cls in
-  check string "label" "turn_timeout" label;
-  match MC.blocker_class_of_serialized_string label with
+  let legacy_label = "oas_timeout_budget" in
+  match MC.blocker_class_of_serialized_string legacy_label with
   | Some MC.Turn_timeout -> ()
   | Some _ -> fail "legacy timeout-budget label parsed as wrong class"
-  | None -> fail "legacy timeout-budget label did not parse back"
+  | None -> fail "legacy timeout-budget label did not parse"
 
 let test_stale_fleet_batch_blocker_class_roundtrip () =
   let cls = KT.Stale_fleet_batch in
@@ -53,10 +51,18 @@ let test_capacity_backpressure_blocker_class_roundtrip () =
 
 let test_timeout_blocker_class_labels_collapse () =
   let tt = KT.blocker_class_to_string KT.Turn_timeout in
-  let ot = KT.blocker_class_to_string KT.Turn_timeout in
+  let legacy_ot = "oas_timeout_budget" in
   let fb = KT.blocker_class_to_string KT.Stale_fleet_batch in
-  check bool "Turn_timeout = Oas_timeout_budget alias" true (tt = ot);
-  check bool "Stale_fleet_batch distinct" true (fb <> tt && fb <> ot)
+  check string "Turn_timeout label" "turn_timeout" tt;
+  check bool "Stale_fleet_batch distinct" true (fb <> tt && fb <> legacy_ot);
+  match
+    ( MC.blocker_class_of_serialized_string tt,
+      MC.blocker_class_of_serialized_string legacy_ot )
+  with
+  | Some MC.Turn_timeout, Some MC.Turn_timeout -> ()
+  | Some _, Some _ -> fail "timeout labels parsed as different blocker classes"
+  | None, _ -> fail "turn timeout label did not parse"
+  | _, None -> fail "legacy timeout-budget label did not parse"
 
 let test_meta_json_roundtrip_with_auto_pause_blocker () =
   let base_json = `Assoc [


### PR DESCRIPTION
## Summary
- restore dashboard timeout budget normalization for provider_timeout_budget detail payloads
- make legacy oas_timeout_budget blocker tests exercise the legacy wire label directly
- restore legacy metric constant aliases, fix keeper board schema references, and avoid quadratic memory subsystem row accumulation

## Validation
- git diff --check
- scripts/dune-local.sh build test/test_keeper_auto_pause_blocker_persist_12683.exe attempted, but machine-wide Dune lock was held by other builds
- dashboard pnpm typecheck attempted, but this worktree has no dashboard/node_modules