### PR TITLE
refactor(keeper): narrow wildcard exception to Yojson.Type_error in keeper_approval_queue (RFC-0145 sweep)

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -158,9 +158,14 @@ let string_opt_of_json = function
   | _ -> None
 ;;
 
+(* RFC-0145 — narrow the wildcard catch-all to the only exception
+   [Yojson.Safe.Util.member] can raise on non-object inputs.  An
+   unrelated runtime exception (e.g. [Out_of_memory], async failure,
+   unexpected internal contract break) will now propagate to the
+   caller instead of being silently coerced to [None]. *)
 let string_opt_member key json =
   match Yojson.Safe.Util.member key json with
-  | exception _ -> None
+  | exception Yojson.Safe.Util.Type_error _ -> None
   | value -> string_opt_of_json value
 ;;
 


### PR DESCRIPTION
## Goal

Eliminate one Cluster A (Permissive Silent Fallback) site by narrowing a wildcard exception arm to the *only* exception the underlying call can raise.

## Site

```ocaml
let string_opt_member key json =
  match Yojson.Safe.Util.member key json with
  | exception _ -> None              (* ← Cluster A *)
  | value -> string_opt_of_json value
```

`Yojson.Safe.Util.member` raises `Yojson.Safe.Util.Type_error` on non-object inputs and **nothing else** in normal operation.  The bare `_` arm matches every exception — including `Out_of_memory`, async terminations, unexpected internal contract breaks — silently coercing all of them to `None`.  Operators lose any signal that something other than a typed JSON shape problem occurred.

## Change

```diff
+(* RFC-0145 — narrow the wildcard catch-all to the only exception
+   [Yojson.Safe.Util.member] can raise on non-object inputs.  An
+   unrelated runtime exception (e.g. [Out_of_memory], async failure,
+   unexpected internal contract break) will now propagate to the
+   caller instead of being silently coerced to [None]. *)
 let string_opt_member key json =
   match Yojson.Safe.Util.member key json with
-  | exception _ -> None
+  | exception Yojson.Safe.Util.Type_error _ -> None
   | value -> string_opt_of_json value
```

## Behaviour

| Input shape                      | Before | After |
|----------------------------------|--------|-------|
| Object with `key` → string       | `Some v` | `Some v` (unchanged) |
| Object with `key` → non-string   | `None` | `None` (unchanged) |
| Object without `key`             | `None` (via `\`Null`) | `None` (unchanged) |
| Non-object JSON                  | `None` (caught wildcard) | `None` (caught typed) |
| Unrelated runtime exception      | `None` (silently swallowed) | **raised** |

Only the last row changes, and it changes in the correct direction per RFC-0145 §2 "Pattern definition".

## Verification

* `dune build --root . lib/` → pass.

## Anti-pattern self-check

- §1 telemetry-as-fix? No — no counter added; the change removes a swallow rather than instrumenting one.
- §2 substring classifier? No — narrows to a typed OCaml constructor (`Yojson.Safe.Util.Type_error`).
- §3 N-of-M? Tracked openly — this is one of the two remaining `| exception _ -> ...` sites flagged by RFC-0145 (the other is `host_fd_pressure_poller.ml:119`, larger scope; deferred to its own PR).

## Stack context

Independent of any open RFC-0149 follow-up.  Order 1 (cache_ttl_seconds) and Order 3 (drain_fd_to_buf) of the RFC-0145 §5 migration plan are already merged.  Order 2 (load-history per-line) was *better* than the RFC pattern (4-value bounded label) before this sweep; no migration needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>