### PR TITLE
fix(keeper): drop timeout budget terminal wire alias

### DIFF
--- a/lib/keeper/keeper_turn_terminal_code.ml
+++ b/lib/keeper/keeper_turn_terminal_code.ml
@@ -54,7 +54,6 @@ let of_wire = function
     Some Stale_turn_timeout_in_turn
   | "stale_termination_storm" -> Some Stale_termination_storm
   | "stale_fleet_batch" -> Some Stale_fleet_batch
-  | "oas_timeout_budget" -> Some (Provider_runtime_error "provider_timeout")
   | "heartbeat_failures" -> Some Heartbeat_failures
   | "turn_failures" -> Some Turn_failures
   | "ambiguous_partial_commit" ->

--- a/test/test_keeper_turn_terminal_disposition_field.ml
+++ b/test/test_keeper_turn_terminal_disposition_field.ml
@@ -36,7 +36,6 @@ let constructor_cases : (string * T.t) list =
   ; "of_code/unknown", T.of_code "totally_unmapped"
   ; "of_code/empty", T.of_code ""
   ; "of_code/gh_repo", T.of_code "gh_repo_context_missing_worktree"
-  ; "of_code/oas_timeout", T.of_code "oas_timeout_budget"
   ; "of_code/turn_wall_clock", T.of_code "turn_wall_clock_timeout"
   ; "of_code/require_tool_use", T.of_code "required_tool_use_no_tool_call"
   ]


### PR DESCRIPTION
## Summary
- remove the legacy oas_timeout_budget terminal-code decoder alias
- stop mapping timeout-budget terminal wire input back into provider_timeout
- remove the terminal disposition invariant case that kept the retired wire code alive

## Validation
- Not run; user requested PR iteration without local validation.