### PR TITLE
fix(dashboard): drop timeout budget metrics fallback

### DIFF
--- a/lib/dashboard/dashboard_http_keeper_detail.ml
+++ b/lib/dashboard/dashboard_http_keeper_detail.ml
@@ -594,10 +594,7 @@ let compute_metrics_window
 	              ("memory_compaction_invalid_dropped", `Int memory_compaction_invalid_dropped_now);
 	              ("memory_expected_topic", Json_util.string_opt_to_json memory_expected_topic);
               ( "provider_timeout_budget",
-                let provider_timeout_budget = j |> member "provider_timeout_budget" in
-                if provider_timeout_budget <> `Null
-                then provider_timeout_budget
-                else j |> member "timeout_budget" );
+                j |> member "provider_timeout_budget" );
               ( "inference_telemetry",
                 j
                 |> member "inference_telemetry"


### PR DESCRIPTION
## Summary
- stop reading legacy timeout_budget from keeper metrics snapshots in keeper detail output
- trust the canonical provider_timeout_budget field as the dashboard SSOT
- prevent old JSONL timeout-budget evidence from reviving as a dashboard timeout state

## Validation
- Not run; user requested PR iteration without local validation.