### PR TITLE
fix(tests): update provider timeout constructors

### DIFF
--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -975,7 +975,7 @@ let test_goal_detail_promotes_newer_runtime_blocker_over_stale_receipt () =
           last_blocker =
             Some (Keeper_types.blocker_info_of_class
                     ~detail:"Internal error: [masc_oas_error] {\"kind\":\"oas_timeout_budget\"}"
-                    Keeper_types.Oas_timeout_budget);
+                    Keeper_types.Turn_timeout);
         };
     }
   in
@@ -1042,7 +1042,7 @@ let test_goal_detail_keeps_decision_terminal_reason_over_newer_blocker () =
           last_blocker =
             Some (Keeper_types.blocker_info_of_class
                     ~detail:"Internal error: [masc_oas_error] {\"kind\":\"oas_timeout_budget\"}"
-                    Keeper_types.Oas_timeout_budget);
+                    Keeper_types.Turn_timeout);
         };
     }
   in


### PR DESCRIPTION
## Summary
- update stale dashboard goal blocker constructors from Oas_timeout_budget to Turn_timeout
- keep the legacy oas_timeout_budget payload string as compatibility input

## Verification
- ocamlformat --check test/test_dashboard_goals.ml
- git diff --check origin/main...HEAD
- rg stale typed constructors in lib/test: no matches
- focused Dune attempted: scripts/dune-local.sh build test/test_dashboard_goals.exe, but stopped while waiting on /tmp/me-dune-local.lock held by another worktree