### PR TITLE
fix(operator): drop timeout budget attention reason

### DIFF
--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -109,7 +109,7 @@ let assoc_string_field key fields =
   | _ -> None
 
 let canonical_keeper_attention_reason = function
-  | Some "timeout_budget_exhausted" -> Some "provider_timeout"
+  | Some "timeout_budget_exhausted" -> None
   | reason -> reason
 
 let keeper_attention_kind reason =


### PR DESCRIPTION
## Summary
- stop remapping legacy timeout_budget_exhausted attention reasons into provider_timeout
- treat the retired reason as absent so operator digest does not revive timeout-budget as a keeper attention kind
- keep provider_timeout as the canonical attention reason for current producers

## Validation
- Not run; user requested PR iteration without local validation.