### PR TITLE
fix(keeper): restore timeout metric compatibility aliases

### DIFF
--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -724,6 +724,10 @@ let metric_keeper_provider_timeout_loop_paused =
   "masc_keeper_provider_timeout_loop_paused_total"
 ;;
 
+let metric_keeper_oas_timeout_budget_loop_paused =
+  metric_keeper_provider_timeout_loop_paused
+;;
+
 let metric_keeper_cycle_exceptions = "masc_keeper_cycle_exceptions_total"
 let metric_keeper_snapshot_write_failures = "masc_keeper_snapshot_write_failures_total"
 
@@ -938,6 +942,8 @@ let metric_keeper_provider_timeout_strike =
   "masc_keeper_provider_timeout_strike_total"
 ;;
 
+let metric_keeper_oas_timeout_budget_strike = metric_keeper_provider_timeout_strike
+
 let metric_keeper_stale_termination_total = "masc_keeper_stale_termination_total"
 
 let metric_keeper_stale_termination_by_class =
@@ -946,6 +952,10 @@ let metric_keeper_stale_termination_by_class =
 
 let metric_keeper_provider_timeout_watchdog_termination =
   "masc_keeper_provider_timeout_watchdog_termination_total"
+;;
+
+let metric_keeper_oas_timeout_budget_watchdog_termination =
+  metric_keeper_provider_timeout_watchdog_termination
 ;;
 
 let metric_keeper_stale_termination_threshold_breached =

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -413,6 +413,7 @@ val metric_keeper_presence_sync_failures : string
 val metric_keeper_self_preservation_universal : string
 val metric_keeper_stale_storm_paused : string
 val metric_keeper_provider_timeout_loop_paused : string
+val metric_keeper_oas_timeout_budget_loop_paused : string
 val metric_keeper_cycle_exceptions : string
 val metric_keeper_snapshot_write_failures : string
 val metric_keeper_state_snapshot_skipped_no_state : string
@@ -594,9 +595,11 @@ val metric_keeper_required_tool_gate_suppressed_total : string
 val metric_keeper_consecutive_idle : string
 val metric_keeper_last_productive_ts : string
 val metric_keeper_provider_timeout_strike : string
+val metric_keeper_oas_timeout_budget_strike : string
 val metric_keeper_stale_termination_total : string
 val metric_keeper_stale_termination_by_class : string
 val metric_keeper_provider_timeout_watchdog_termination : string
+val metric_keeper_oas_timeout_budget_watchdog_termination : string
 val metric_keeper_stale_termination_threshold_breached : string
 val metric_keeper_stale_termination_batch : string
 val metric_keeper_stale_broadcast_emit_failures : string


### PR DESCRIPTION
## Summary
- restore legacy metric_keeper_oas_timeout_budget_* OCaml constants as aliases to provider-timeout metrics
- preserve provider-timeout metric names while keeping downstream source compatibility after #17785

## Validation
- git diff --check
- ocamlformat -i lib/keeper/keeper_metrics.ml lib/keeper/keeper_metrics.mli
- scripts/dune-local.sh build lib/keeper/keeper_metrics.cmi attempted, but a bare dune build was already running