### PR TITLE
refactor(coord): narrow 4 wildcard exception arms in worktree repo discovery (RFC-0145 sweep)

### DIFF
--- a/lib/coord/coord_worktree_repo_discovery.ml
+++ b/lib/coord/coord_worktree_repo_discovery.ml
@@ -88,23 +88,27 @@ let repo_exact_alias_variants token =
   |> List.filter (fun s -> s <> "")
   |> List.sort_uniq String.compare
 
+(* RFC-0145 — narrow wildcard fallbacks to [Otoml.Type_error] only.
+   Otoml getters raise exactly that exception on type mismatch; any
+   unrelated runtime exception (allocation failure, async failure)
+   now propagates to the caller. *)
 let toml_table_opt value =
   try Some (Otoml.get_table value) with
-  | _ -> None
+  | Otoml.Type_error _ -> None
 
 let toml_string_opt tbl key =
   match List.assoc_opt key tbl with
   | None -> None
   | Some value -> (
       try Some (Otoml.get_string value) with
-      | _ -> None)
+      | Otoml.Type_error _ -> None)
 
 let toml_string_array_or_empty tbl key =
   match List.assoc_opt key tbl with
   | None -> []
   | Some value -> (
       try Otoml.get_array Otoml.get_string value with
-      | _ -> [])
+      | Otoml.Type_error _ -> [])
 
 let repository_config_path config =
   Filename.concat
@@ -151,8 +155,14 @@ let repository_aliases_for_candidate config ~repo_name =
                      in
                      if List.mem repo_name aliases then aliases else [])
             |> List.sort_uniq String.compare)
+    (* RFC-0145 — narrow to the exceptions [Otoml.Parser.from_file]
+       can raise on malformed / unreadable [repositories.toml].  Inner
+       [Otoml.find_opt] returns an option (does not raise), and the
+       nested [toml_*_opt] helpers already swallow [Otoml.Type_error]
+       at their own boundaries.  Unrelated runtime exceptions now
+       propagate to the caller. *)
     with
-    | _ -> []
+    | Otoml.Parse_error _ | Sys_error _ -> []
 
 (* Route to the SSOT helper rather than allocating String.sub on every
    step.  Keeps semantics aligned across modules (empty needle returns


### PR DESCRIPTION
## Goal

Eliminate four Cluster A (Permissive Silent Fallback) sites in `lib/coord/coord_worktree_repo_discovery.ml` by narrowing each bare `_` exception arm to the typed Otoml exception the corresponding call can actually raise.

## Site map

| Function | Before | After |
|----------|--------|-------|
| `toml_table_opt` | `\| _ -> None` | `\| Otoml.Type_error _ -> None` |
| `toml_string_opt` | `\| _ -> None` | `\| Otoml.Type_error _ -> None` |
| `toml_string_array_or_empty` | `\| _ -> []` | `\| Otoml.Type_error _ -> []` |
| `repository_aliases_for_candidate` outer try | `\| _ -> []` | `\| Otoml.Parse_error _ \| Sys_error _ -> []` |

Otoml getters (`get_table`, `get_string`, `get_array`) only raise `Type_error` on type mismatch.  `Otoml.Parser.from_file` raises `Parse_error` on malformed TOML and `Sys_error` on file open failure.  Internal `Otoml.find_opt` returns an option (does not raise).  No other exception is in the documented contract.

## Behaviour

| Input shape | Before | After |
|-------------|--------|-------|
| Well-formed `repositories.toml` with expected schema | unchanged | unchanged |
| Malformed TOML | `[]` (wildcard) | `[]` (typed `Parse_error`) |
| Missing / unreadable file | `[]` (wildcard) | `[]` (typed `Sys_error`) |
| Wrong-typed value in a getter call | `None` / `[]` (wildcard) | `None` / `[]` (typed `Type_error`) |
| Unrelated runtime exception (`Out_of_memory`, async failure, etc.) | `None` / `[]` (silently swallowed) | **propagated to caller** |

Only the last row changes, in the direction RFC-0145 §2 prescribes.

## Verification

* `dune build --root . lib/` → pass.

## Stack context

Independent of any open PR.  Sibling sweeps:
- #17780 — `keeper_approval_queue.string_opt_member` (MERGED).
- #17783 — `host_fd_pressure_poller` 3-site sweep (MERGED).

After this PR merges, the wildcard count in the `try ... with | _ -> ...` shape under `lib/` continues to drop; remaining matches are typed sums (`Parse_outcome`, `Drain_outcome`) or domain-specific helpers.

## Anti-pattern self-check

- §1 telemetry-as-fix? No — no counter, no log; the diff removes unbounded swallowing.
- §2 substring classifier? No — typed OCaml constructors only.
- §3 N-of-M? Tracked openly — all four wildcards in this file migrate together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>