### PR TITLE
refactor(ide): narrow 2 List.nth wildcards in parse_hunk_header (RFC-0145 sweep)

### DIFF
--- a/lib/ide/ide_region_tracker.ml
+++ b/lib/ide/ide_region_tracker.ml
@@ -6,13 +6,16 @@ let parse_hunk_header line =
   if not (String.starts_with ~prefix:"@@" line) then None
   else
     let parts = String.split_on_char ' ' line in
+    (* RFC-0145 — [List.nth] raises [Failure "nth"] on out-of-bounds;
+       narrow the wildcard catch-all to that one exception so unrelated
+       runtime failures propagate to the caller. *)
     let old_part =
       try List.nth parts 1 with
-      | _ -> ""
+      | Failure _ -> ""
     in
     let _new_part =
       try List.nth parts 2 with
-      | _ -> ""
+      | Failure _ -> ""
     in
     let parse_start s =
       let s =


### PR DESCRIPTION
## Goal

Eliminate two Cluster A (Permissive Silent Fallback) sites in `lib/ide/ide_region_tracker.ml` by narrowing each bare `_` exception arm to `Failure _` — the only exception `List.nth` raises.

## Change

```diff
     let parts = String.split_on_char ' ' line in
+    (* RFC-0145 — [List.nth] raises [Failure "nth"] on out-of-bounds;
+       narrow the wildcard catch-all to that one exception so unrelated
+       runtime failures propagate to the caller. *)
     let old_part =
       try List.nth parts 1 with
-      | _ -> ""
+      | Failure _ -> ""
     in
     let _new_part =
       try List.nth parts 2 with
-      | _ -> ""
+      | Failure _ -> ""
     in
```

## Behaviour

| Hunk shape                                | Before | After |
|-------------------------------------------|--------|-------|
| Well-formed `@@ -A,B +C,D @@`             | unchanged | unchanged |
| Only one space token after `@@`           | `""` (wildcard) | `""` (typed `Failure`) |
| Unrelated runtime exception inside `List.nth` (effectively impossible for an immutable list, but still defensively unbounded before) | `""` (silently swallowed) | **propagated to caller** |

## Verification

* `dune build --root . lib/` → pass.

## Stack context

Independent.  Sibling RFC-0145 sweeps: #17780, #17783, #17789 (all merged).

## Anti-pattern self-check

- §1 telemetry-as-fix? No.
- §2 substring classifier? No — typed OCaml constructor (`Failure _`).
- §3 N-of-M? Both wildcards in this function migrate together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>