### PR TITLE
fix(logs): drop timeout budget system category label

### DIFF
--- a/lib/masc_log/system_log_category.ml
+++ b/lib/masc_log/system_log_category.ml
@@ -49,12 +49,8 @@ let all =
     Network_error_other;
   ]
 
-let canonical_label = function
-  | "oas_timeout_budget" -> "provider_timeout"
-  | label -> label
-
 let of_string_opt raw =
-  match canonical_label raw with
+  match raw with
   | "task_ownership_ambiguity_current_task_unset" ->
       Some Task_ownership_ambiguity_current_task_unset
   | "state_store_current_task_path_corruption" ->


### PR DESCRIPTION
## Summary
- remove system-log category canonicalization for the retired oas_timeout_budget label
- require system-log category parsing to use canonical provider_timeout
- prevent legacy timeout-budget log labels from reviving provider-timeout category state

## Validation
- Not run; user requested PR iteration without local validation.