### PR TITLE
refactor(cascade_decl): narrow 2 Otoml wildcards in declarative parser (RFC-0145 sweep)

### DIFF
--- a/lib/cascade_decl/cascade_declarative_parser.ml
+++ b/lib/cascade_decl/cascade_declarative_parser.ml
@@ -100,8 +100,11 @@ let parse_capabilities ~(path : string) (tbl : Otoml.t) : cascade_capabilities =
     match Otoml.find_opt tbl Fun.id [ key ] with
     | None -> []
     | Some v ->
+      (* RFC-0145 — narrow to the only exception [Otoml.get_array]
+         raises on a wrong-typed value.  Unrelated runtime exceptions
+         propagate. *)
       (try Otoml.get_array Otoml.get_string v with
-       | _ ->
+       | Otoml.Type_error _ ->
          Logs.warn (fun m ->
            m
              "cascade_declarative_parser: %s.capabilities.%s — expected string array, \
@@ -454,6 +457,9 @@ let parse_model (id : string) (tbl : Otoml.t)
       match Otoml.find_opt tbl Fun.id [ "match-prefixes" ] with
       | None -> []
       | Some v ->
+        (* RFC-0145 — narrow to the only exception [Otoml.get_array]
+           raises on a wrong-typed value.  Unrelated runtime exceptions
+           propagate. *)
         (try
            Otoml.get_array Otoml.get_string v
            |> List.filter_map (fun s ->
@@ -468,7 +474,7 @@ let parse_model (id : string) (tbl : Otoml.t)
                None)
              else Some trimmed)
          with
-         | _ ->
+         | Otoml.Type_error _ ->
            Logs.warn (fun m ->
              m
                "cascade_declarative_parser: %s.match-prefixes — expected string array, \


### PR DESCRIPTION
## Goal

Eliminate two Cluster A (Permissive Silent Fallback) sites in `lib/cascade_decl/cascade_declarative_parser.ml` by narrowing each `| _ -> warn + []` arm to `Otoml.Type_error _`.

## Sites

| Function / block | Before | After |
|------------------|--------|-------|
| `string_list_field` (capabilities array) | `\| _ -> warn + []` | `\| Otoml.Type_error _ -> warn + []` |
| `match-prefixes` parse | `\| _ -> warn + []` | `\| Otoml.Type_error _ -> warn + []` |

## Behaviour

| Config shape                      | Before | After |
|-----------------------------------|--------|-------|
| `capabilities.foo = ["a", "b"]`   | `["a"; "b"]` | unchanged |
| `capabilities.foo = "not array"`  | WARN + `[]` | WARN + `[]` (typed) |
| Unrelated runtime exception       | WARN + `[]` (silent swallow) | **propagated** |

The WARN + empty fallback semantics for ill-typed rows are unchanged — operator visibility is preserved.  Only the unbounded catch-all is removed.

## Verification

* `dune build --root . lib/` → pass.

## Stack context

Independent.  Sibling RFC-0145 sweeps so far this session: #17780, #17783, #17789 (all merged), #17793 (open).

## Anti-pattern self-check

- §1 telemetry-as-fix? No — the WARN was already in place pre-RFC; this diff only narrows the catch.
- §2 substring classifier? No — typed `Otoml.Type_error _`.
- §3 N-of-M? Both wildcards in this file migrate together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>