### PR TITLE
refactor(cascade_decl): narrow 2 Otoml wildcards in parse_headers (RFC-0145 sweep)

### DIFF
--- a/lib/cascade_decl/cascade_declarative_parser.ml
+++ b/lib/cascade_decl/cascade_declarative_parser.ml
@@ -246,7 +246,9 @@ let parse_provider_healthcheck ~(path : string) (tbl : Otoml.t)
     dropped. The result is sorted by key for deterministic show/eq. *)
 let parse_headers (tbl : Otoml.t) (path : string) : (string * string) list =
   match Otoml.get_table tbl with
-  | exception _ ->
+  (* RFC-0145 — narrow to the only exception [Otoml.get_table] raises
+     on a non-table value.  Unrelated runtime exceptions propagate. *)
+  | exception Otoml.Type_error _ ->
     Logs.warn (fun m ->
       m
         "cascade_declarative_parser: %s — expected TOML table, got non-table value; \
@@ -259,7 +261,9 @@ let parse_headers (tbl : Otoml.t) (path : string) : (string * string) list =
         (fun (k, v) ->
            match Otoml.get_string v with
            | s -> Some (k, s)
-           | exception _ ->
+           (* RFC-0145 — narrow to the only exception [Otoml.get_string]
+              raises on a non-string value. *)
+           | exception Otoml.Type_error _ ->
              Logs.warn (fun m ->
                m
                  "cascade_declarative_parser: %s.%s — non-string header value, ignoring"


### PR DESCRIPTION
## Goal

Eliminate two more Cluster A wildcards in `cascade_declarative_parser.parse_headers` — companion to #17795 which covered 2 sibling sites in the same file.

## Change

```diff
 let parse_headers (tbl : Otoml.t) (path : string) =
   match Otoml.get_table tbl with
-  | exception _ ->
+  (* RFC-0145 — narrow to the only exception [Otoml.get_table] raises
+     on a non-table value.  Unrelated runtime exceptions propagate. *)
+  | exception Otoml.Type_error _ ->
     Logs.warn ...;
     []
   | entries -> ...
     List.filter_map (fun (k, v) ->
        match Otoml.get_string v with
        | s -> Some (k, s)
-       | exception _ ->
+       (* RFC-0145 — narrow to the only exception [Otoml.get_string]
+          raises on a non-string value. *)
+       | exception Otoml.Type_error _ ->
          Logs.warn ...; None)
```

## Behaviour

WARN + graceful-degradation semantics unchanged; only the unbounded catch narrows.  Unrelated runtime exceptions (`Out_of_memory`, async failure, …) now propagate instead of being silently swallowed.

## Stack context

Companion to #17795 (same file, sibling sites).  After both merge, this file has zero remaining wildcard exception arms.

## Verification

* `dune build --root . lib/` → pass.

## Anti-pattern self-check

- §1 telemetry-as-fix? No — WARN already in place pre-RFC; this diff only narrows the catch.
- §2 substring classifier? No — typed `Otoml.Type_error _`.
- §3 N-of-M? Tracked openly — last 2 wildcards in this file, finishing the local sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>