### PR TITLE
refactor(keeper): accept typed gh argv contract

### DIFF
--- a/lib/keeper/keeper_gh_shared.ml
+++ b/lib/keeper/keeper_gh_shared.ml
@@ -92,6 +92,19 @@ let render_simple_gh_command cmd =
   cmd.argv |> List.map Filename.quote |> String.concat " "
 ;;
 
+let gh_simple_command_of_argv argv =
+  let rec drop_leading_gh = function
+    | token :: rest when String_util.equals_ci token "gh" -> drop_leading_gh rest
+    | remaining -> remaining
+  in
+  let argv = drop_leading_gh argv in
+  match argv with
+  | [] -> Error Empty_command
+  | _ when List.exists (fun arg -> String.contains arg '\000') argv ->
+    Error (Unsupported_command_shape "nul_arg")
+  | _ -> Ok { argv }
+;;
+
 let too_complex_reason_tag (r : Masc_exec.Parsed.reason_too_complex) =
   match r with
   | `Heredoc -> "heredoc"

--- a/lib/keeper/keeper_gh_shared.mli
+++ b/lib/keeper/keeper_gh_shared.mli
@@ -89,6 +89,12 @@ type gh_simple_command
 val parse_simple_gh_command :
   string -> (gh_simple_command, gh_command_parse_error) result
 
+(** Build a simple gh command from already-tokenized argv. Accepts both
+    [["pr"; "list"]] and [["gh"; "pr"; "list"]] forms, preserving each
+    argument as a literal argv atom. *)
+val gh_simple_command_of_argv :
+  string list -> (gh_simple_command, gh_command_parse_error) result
+
 val gh_simple_command_argv : gh_simple_command -> string list
 
 val render_simple_gh_command : gh_simple_command -> string

--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -44,6 +44,54 @@ let observe_history_append ~root ~keeper_name entry =
         keeper_name root (Printexc.to_string exn)
 ;;
 
+let json_string_list_field name args =
+  match args with
+  | `Assoc fields ->
+    (match List.assoc_opt name fields with
+     | None -> Ok None
+     | Some (`List values) ->
+       let rec collect acc = function
+         | [] -> Ok (Some (List.rev acc))
+         | `String value :: rest -> collect (value :: acc) rest
+         | _ :: _ -> Error (Printf.sprintf "%s must be an array of strings" name)
+       in
+       collect [] values
+     | Some _ -> Error (Printf.sprintf "%s must be an array of strings" name))
+  | _ -> Ok None
+;;
+
+let gh_parse_error_reason = function
+  | Keeper_gh_shared.Empty_command -> "empty_command"
+  | Keeper_gh_shared.Unsupported_shell_construct tag -> tag
+  | Keeper_gh_shared.Unsupported_command_shape tag -> tag
+;;
+
+let gh_command_from_args raw_cmd_str args =
+  match json_string_list_field "argv" args with
+  | Error msg -> Error (`Input msg)
+  | Ok argv_opt ->
+    let has_cmd = String.trim raw_cmd_str <> "" in
+    (match has_cmd, argv_opt with
+     | true, Some _ ->
+       Error
+         (`Input
+           "cmd and argv are mutually exclusive for gh op; use argv for the typed \
+            contract or cmd for the legacy string contract")
+     | false, None ->
+       Error
+         (`Input
+           "argv or legacy cmd is required for gh op. Prefer typed argv, e.g. \
+            argv=[\"pr\",\"list\",\"--state\",\"open\"].")
+     | true, None ->
+       (match Keeper_gh_shared.parse_simple_gh_command raw_cmd_str with
+        | Ok parsed -> Ok parsed
+        | Error parse_error -> Error (`Parse parse_error))
+     | false, Some argv ->
+       (match Keeper_gh_shared.gh_simple_command_of_argv argv with
+        | Ok parsed -> Ok parsed
+        | Error parse_error -> Error (`Parse parse_error)))
+;;
+
 let handle_keeper_shell
       ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
       ~exec_cache:(_exec_cache : Masc_exec.Exec_cache.t option)
@@ -1112,34 +1160,24 @@ let handle_keeper_shell
     let timeout_sec =
       Keeper_shell_shared.clamp_shell_timeout ~min_sec:Keeper_shell_shared.gh_min_timeout_sec ~default:gh_default_timeout args
     in
-    if String.trim raw_cmd_str = "" then
-      error_json ~fields:[ "op", `String op ]
-        "cmd is required for gh op. Good: cmd='pr list --state open'. Bad: cmd=''."
-    else (
-      match Keeper_gh_shared.parse_simple_gh_command raw_cmd_str with
-      | Error parse_error ->
-        let reason =
-          match parse_error with
-          | Keeper_gh_shared.Empty_command -> "empty_command"
-          | Keeper_gh_shared.Unsupported_shell_construct tag -> tag
-          | Keeper_gh_shared.Unsupported_command_shape tag -> tag
-        in
-        Yojson.Safe.to_string
-          (`Assoc
-              [ "ok", `Bool false
-              ; "op", `String op
-              ; "error", `String "gh_command_shape_unsupported"
-              ; "reason", `String reason
-              ; "hint", `String
-                 "GitHub shell bridge only accepts one simple gh command. \
-                   Avoid pipelines, redirects, env prefixes, and shell \
-                   control syntax."
-              ])
-      | Ok parsed_cmd ->
+    (match gh_command_from_args raw_cmd_str args with
+     | Error (`Input msg) -> error_json ~fields:[ "op", `String op ] msg
+     | Error (`Parse parse_error) ->
+       let reason = gh_parse_error_reason parse_error in
+       Yojson.Safe.to_string
+         (`Assoc
+             [ "ok", `Bool false
+             ; "op", `String op
+             ; "error", `String "gh_command_shape_unsupported"
+             ; "reason", `String reason
+             ; "hint", `String
+                "GitHub shell bridge accepts typed argv or one simple gh command. \
+                 Avoid pipelines, redirects, env prefixes, and shell control syntax."
+             ])
+     | Ok parsed_cmd ->
         let allowed_orgs_opt = Keeper_tool_policy.git_clone_allowed_orgs () in
         let canonical_cmd_str =
-          Keeper_gh_shared.gh_simple_command_argv parsed_cmd
-          |> String.concat " "
+          Keeper_gh_shared.render_simple_gh_command parsed_cmd
         in
         (* Reversibility gate (Thariq / Anthropic auto-mode principle):
            - R0 read / R1 reversible mutation: allowed; R1 is audit-logged.

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -262,7 +262,7 @@ let is_gh_api_read_only (cmd_lower : string) : bool =
 ;;
 
 (** Extract the effective gh command string from keeper_shell op=gh input.
-    [keeper_exec_shell] uses the [cmd] field. *)
+    [keeper_exec_shell] accepts typed [argv] and legacy [cmd] fields. *)
 let normalize_gh_command (cmd : string) : string =
   let tokens = shell_word_values cmd in
   let rec drop_leading_gh = function
@@ -272,12 +272,45 @@ let normalize_gh_command (cmd : string) : string =
   String.concat " " (drop_leading_gh tokens)
 ;;
 
+let normalize_gh_argv argv =
+  let rec drop_leading_gh = function
+    | token :: rest when String_util.equals_ci token "gh" -> drop_leading_gh rest
+    | remaining -> remaining
+  in
+  drop_leading_gh argv |> String.concat " "
+;;
+
+let json_string_list = function
+  | `List values ->
+    let rec collect acc = function
+      | [] -> Some (List.rev acc)
+      | `String value :: rest -> collect (value :: acc) rest
+      | _ :: _ -> None
+    in
+    collect [] values
+  | _ -> None
+;;
+
 let gh_effective_cmd (input : Yojson.Safe.t) : string =
   match input with
   | `Assoc fields ->
-    (match List.assoc_opt "cmd" fields with
-     | Some (`String s) -> normalize_gh_command s
-     | _ -> "")
+    let cmd =
+      match List.assoc_opt "cmd" fields with
+      | Some (`String s) when String.trim s <> "" -> Some (normalize_gh_command s)
+      | _ -> None
+    in
+    let has_argv_field = Option.is_some (List.assoc_opt "argv" fields) in
+    let argv =
+      match List.assoc_opt "argv" fields with
+      | Some value -> Option.map normalize_gh_argv (json_string_list value)
+      | None -> None
+    in
+    (match cmd, argv with
+     | Some _, Some _ -> ""
+     | Some _, None when has_argv_field -> ""
+     | Some cmd, None -> cmd
+     | None, Some argv -> argv
+     | None, None -> "")
   | _ -> ""
 ;;
 

--- a/lib/tool_shard_types_schemas_shell.ml
+++ b/lib/tool_shard_types_schemas_shell.ml
@@ -13,8 +13,9 @@ let shell_tools : Masc_domain.tool_schema list =
          explicit allowed directory or cloned repo. find REQUIRES pattern param (e.g. \
          pattern=\"*.ml\"). No generic bash execution: use Bash for command \
          execution. git_clone: clone a repo into your sandbox repos/ lane (url \
-         required). gh op: run a gh CLI subcommand with cmd=\"<subcommand>\" (e.g. \
-         cmd=\"pr list --state open\"). Requires an active claimed task/current_task_id \
+         required). gh op: run a gh CLI subcommand with typed argv (e.g. \
+         argv=[\"pr\",\"list\",\"--state\",\"open\"]; legacy cmd is still accepted). \
+         Requires an active claimed task/current_task_id \
          because repo context is derived from the task worktree. Always run `gh pr list` \
          first before referencing a PR number to avoid hallucinations. Dangerous \
          commands (repo delete, auth logout, secret set/delete) are blocked. If path not \
@@ -42,10 +43,21 @@ let shell_tools : Masc_domain.tool_schema list =
                       [ "type", `String "string"
                       ; ( "description"
                         , `String
-                            "gh subcommand for op=gh, e.g. 'pr list --state open'. \
-                             Requires an active claimed task/current_task_id. The active \
-                             task worktree determines the repo; any --repo flag is \
-                             normalized to that repo." )
+                            "Legacy gh subcommand string for op=gh, e.g. 'pr list \
+                             --state open'. Prefer argv for typed calls. Requires an \
+                             active claimed task/current_task_id. The active task \
+                             worktree determines the repo; any --repo flag is normalized \
+                             to that repo." )
+                      ] )
+                ; ( "argv"
+                  , `Assoc
+                      [ "type", `String "array"
+                      ; "items", `Assoc [ "type", `String "string" ]
+                      ; ( "description"
+                        , `String
+                            "Typed gh argv for op=gh without the leading gh binary, e.g. \
+                             [\"pr\",\"list\",\"--state\",\"open\"]. A leading \"gh\" is \
+                             accepted and stripped. Mutually exclusive with cmd." )
                       ] )
                 ; ( "path"
                   , `Assoc

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -902,7 +902,20 @@ let test_escalation_read_only_keeper_shell_gh_unchanged () =
       ~base_risk:Gp.Low
   in
   Alcotest.(check string) "read-only keeper_shell op=gh stays low"
-    "low" (Gp.risk_level_to_string unchanged)
+    "low" (Gp.risk_level_to_string unchanged);
+  let typed_unchanged =
+    Gp.combinatorial_risk_escalation
+      ~trifecta_active:true
+      ~tool_name:"keeper_shell"
+      ~input:
+        (`Assoc
+          [ ("op", `String "gh")
+          ; ("argv", `List [ `String "pr"; `String "view"; `String "123" ])
+          ])
+      ~base_risk:Gp.Low
+  in
+  Alcotest.(check string) "read-only keeper_shell op=gh argv stays low"
+    "low" (Gp.risk_level_to_string typed_unchanged)
 
 let test_tool_capabilities_known () =
   let caps = Gp.tool_capabilities "keeper_bash" in

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -247,7 +247,19 @@ let test_keeper_shell_gh_read_only_stays_low () =
   in
   check "keeper_shell op=gh pr view → low"
     (GP.risk_level_to_string GP.Low)
-    (GP.risk_level_to_string actual)
+    (GP.risk_level_to_string actual);
+  let typed_actual =
+    GP.assess_risk
+      ~tool_name:"keeper_shell"
+      ~input:
+        (`Assoc
+          [ ("op", `String "gh")
+          ; ("argv", `List [ `String "pr"; `String "view"; `String "123" ])
+          ])
+  in
+  check "keeper_shell op=gh argv pr view → low"
+    (GP.risk_level_to_string GP.Low)
+    (GP.risk_level_to_string typed_actual)
 
 let test_keeper_shell_gh_mutation_escalates_high () =
   let actual =
@@ -257,7 +269,26 @@ let test_keeper_shell_gh_mutation_escalates_high () =
   in
   check "keeper_shell op=gh pr comment → high"
     (GP.risk_level_to_string GP.High)
-    (GP.risk_level_to_string actual)
+    (GP.risk_level_to_string actual);
+  let typed_actual =
+    GP.assess_risk
+      ~tool_name:"keeper_shell"
+      ~input:
+        (`Assoc
+          [ ("op", `String "gh")
+          ; ( "argv"
+            , `List
+                [ `String "pr"
+                ; `String "comment"
+                ; `String "123"
+                ; `String "--body"
+                ; `String "hi"
+                ] )
+          ])
+  in
+  check "keeper_shell op=gh argv pr comment → high"
+    (GP.risk_level_to_string GP.High)
+    (GP.risk_level_to_string typed_actual)
 
 (* ── 2. Threshold decisions ──────────────────────────────── *)
 

--- a/test/test_keeper_github_read_only.ml
+++ b/test/test_keeper_github_read_only.ml
@@ -3,7 +3,7 @@ module Types = Masc_domain
 (** Tests for [Keeper_tool_registry.is_read_only_with_input].
 
     Validates input-aware read-only classification for keeper_shell op=gh:
-    1. Read-only gh subcommands (pr list, issue view, etc.) via cmd
+    1. Read-only gh subcommands (pr list, issue view, etc.) via cmd/argv
     2. Mutating gh subcommands are not classified as read-only
     3. gh api GET (default) is read-only
     4. gh api with -X POST/PUT/DELETE is mutating
@@ -32,14 +32,18 @@ let mk_bash_exec executable argv =
     ; "argv", `List (List.map (fun arg -> `String arg) argv)
     ]
 
-(* Legacy helpers for backward compat with older tests (not exercised;
-   keeper_shell op=gh only accepts cmd, not args). *)
 let mk_args args =
-  `Assoc [ ("op", `String "gh");
-           ("cmd", `String (String.concat " " args)) ]
+  `Assoc
+    [ ("op", `String "gh")
+    ; ("argv", `List (List.map (fun arg -> `String arg) args))
+    ]
 
-let mk_cmd_and_args cmd _args =
-  `Assoc [ ("op", `String "gh"); ("cmd", `String cmd) ]
+let mk_cmd_and_args cmd args =
+  `Assoc
+    [ ("op", `String "gh")
+    ; ("cmd", `String cmd)
+    ; ("argv", `List (List.map (fun arg -> `String arg) args))
+    ]
 
 let mk_action action =
   `Assoc [ ("action", `String action) ]
@@ -79,11 +83,16 @@ let run_argv argv =
   | [] -> invalid_arg "run_argv: empty argv"
   | prog :: args ->
     let pid = Unix.create_process prog (Array.of_list argv) Unix.stdin Unix.stdout Unix.stderr in
-    match Unix.waitpid [] pid with
+    let rec wait () =
+      match Unix.waitpid [] pid with
+      | result -> result
+      | exception Unix.Unix_error (Unix.EINTR, _, _) -> wait ()
+    in
+    match wait () with
     | _, Unix.WEXITED 0 -> ()
     | _ ->
-    Alcotest.fail
-      (Printf.sprintf "command failed: %s" (String.concat " " (prog :: args)))
+      Alcotest.fail
+        (Printf.sprintf "command failed: %s" (String.concat " " (prog :: args)))
 
 let with_env key value f =
   let prior = Sys.getenv_opt key in
@@ -289,6 +298,17 @@ let test_parse_simple_gh_command_rejects_pipeline () =
   | Ok _ -> Alcotest.fail "expected pipeline rejection"
   | Error _ -> Alcotest.fail "expected pipeline rejection tag"
 
+let test_typed_gh_argv_preserves_literal_args () =
+  match
+    Keeper_gh_shared.gh_simple_command_of_argv
+      [ "gh"; "pr"; "comment"; "123"; "--body"; "looks good to me" ]
+  with
+  | Ok cmd ->
+    Alcotest.(check (list string)) "typed argv preserved"
+      [ "pr"; "comment"; "123"; "--body"; "looks good to me" ]
+      (Keeper_gh_shared.gh_simple_command_argv cmd)
+  | Error _ -> Alcotest.fail "expected typed gh argv parse"
+
 let test_repo_flag_injection_prefixes_args () =
   match Keeper_gh_shared.parse_simple_gh_command "--repo old/repo pr view 123" with
   | Ok cmd ->
@@ -302,12 +322,13 @@ let test_repo_flag_injection_prefixes_args () =
   | Error _ -> Alcotest.fail "expected simple gh command parse"
 
 (* ================================================================ *)
-(* Read-only subcommands via args                                    *)
+(* Read-only subcommands via argv                                    *)
 (* ================================================================ *)
 
 let test_read_only_via_args () =
   let read_only_args =
     [ ["pr"; "list"];
+      ["gh"; "pr"; "list"];
       ["pr"; "view"; "123"];
       ["pr"; "diff"; "123"];
       ["issue"; "list"];
@@ -317,19 +338,20 @@ let test_read_only_via_args () =
   in
   List.iter (fun args ->
     Alcotest.(check bool)
-      (Printf.sprintf "read-only args: [%s]" (String.concat "; " args))
+      (Printf.sprintf "read-only argv: [%s]" (String.concat "; " args))
       true
       (is_ro ~tool_name:"keeper_shell" ~input:(mk_args args))
   ) read_only_args
 
-let test_cmd_takes_precedence_over_args () =
-  (* When cmd is present and non-empty, args are ignored *)
-  Alcotest.(check bool) "cmd=mutating overrides read-only args"
+let test_cmd_and_argv_is_not_read_only () =
+  (* Execution rejects ambiguous cmd+argv, so the approval classifier must not
+     auto-approve it as read-only. *)
+  Alcotest.(check bool) "cmd+argv read-only/mutating ambiguity is not read-only"
     false
     (is_ro ~tool_name:"keeper_shell"
        ~input:(mk_cmd_and_args "pr merge 123" ["pr"; "list"]));
-  Alcotest.(check bool) "cmd=read-only overrides mutating args"
-    true
+  Alcotest.(check bool) "cmd+argv mutating/read-only ambiguity is not read-only"
+    false
     (is_ro ~tool_name:"keeper_shell"
        ~input:(mk_cmd_and_args "pr list" ["pr"; "merge"; "123"]))
 
@@ -691,7 +713,13 @@ let test_keeper_shell_gh_without_current_task_uses_sandbox_context () =
           [
             ("op", `String "gh");
             ("cwd", `String "");
-            ("cmd", `String "pr list --repo example/project");
+            ( "argv"
+            , `List
+                [ `String "pr"
+                ; `String "list"
+                ; `String "--repo"
+                ; `String "example/project"
+                ] );
           ])
   in
   let json = Yojson.Safe.from_string raw in
@@ -970,15 +998,17 @@ let () =
             test_parse_simple_gh_command_preserves_quoted_args;
           Alcotest.test_case "simple gh parser rejects pipeline" `Quick
             test_parse_simple_gh_command_rejects_pipeline;
+          Alcotest.test_case "typed gh argv preserves literal args" `Quick
+            test_typed_gh_argv_preserves_literal_args;
           Alcotest.test_case "repo flag injection prefixes args" `Quick
             test_repo_flag_injection_prefixes_args;
         ] );
-      ( "read_only_args",
+      ( "read_only_argv",
         [
-          Alcotest.test_case "read-only via args field" `Quick
+          Alcotest.test_case "read-only via argv field" `Quick
             test_read_only_via_args;
-          Alcotest.test_case "cmd takes precedence over args" `Quick
-            test_cmd_takes_precedence_over_args;
+          Alcotest.test_case "cmd and argv is not read-only" `Quick
+            test_cmd_and_argv_is_not_read_only;
         ] );
       ( "mutating_cmds",
         [


### PR DESCRIPTION
Summary
- Add typed argv support for keeper_shell op=gh while keeping legacy cmd compatibility.
- Reject ambiguous cmd+argv inputs and expose argv in the keeper_shell schema.
- Teach read-only/HITL/governance classifiers about typed gh argv and cover the execution path with tests.

Validation
- ocamlformat --check touched OCaml files: pass
- git diff --check origin/main...HEAD: pass
- scripts/dune-local.sh build test/test_keeper_github_read_only.exe test/test_hitl_approval.exe test/test_governance_pipeline.exe: pass before the final fast-moving-main rebase; the final repeat was blocked by another worktree's Dune lock and canceled.
- ./_build/default/test/test_keeper_github_read_only.exe: pass, 32 tests
- env -u MASC_BASE_PATH ./_build/default/test/test_hitl_approval.exe test risk_classification 3-4: pass
- env -u MASC_BASE_PATH ./_build/default/test/test_governance_pipeline.exe test lethal_trifecta 10: pass

Notes
- Full test_hitl_approval and full test_governance_pipeline still have unrelated existing local failures outside this PR's touched assertions; the relevant filtered cases pass.