### PR TITLE
fix: address merged review followups

### DIFF
--- a/dashboard/src/components/keeper-detail-alert-strip.test.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.test.ts
@@ -88,10 +88,22 @@ describe('KeeperRuntimeAlertStrip', () => {
     }))
 
     const text = container.textContent ?? ''
-    expect(text).toContain('runtime_blocked')
-    expect(text).toContain('런타임 근거 확인')
+    expect(text).toContain('런타임 근거 확인 필요')
     expect(text).not.toContain('watchdog_stale_turn')
     expect(text).not.toContain('inspect_watchdog_root_cause')
+  })
+
+  it('canonicalizes turn-disposition timeout actions before rendering operator copy', () => {
+    const { container } = render(h(KeeperRuntimeAlertStrip, {
+      keeper: keeper({
+        needs_attention: true,
+        next_human_action: 'inspect_turn_timeout',
+      }),
+    }))
+
+    const text = container.textContent ?? ''
+    expect(text).toContain('런타임 근거 확인')
+    expect(text).not.toContain('inspect_turn_timeout')
   })
 
   it('closes 모순 #3: per-attempt completed outcome is hidden when per-turn stop cause is terminal failure', () => {

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -110,6 +110,7 @@ function attentionReasonLabel(reason: string | null, paused: boolean): string | 
 // Backend emit sites for `next_human_action` (paired 1:1 with the
 // corresponding `attention_reason`):
 //   - lib/keeper/keeper_status_bridge.ml:727-742 (seven common actions)
+//   - lib/keeper/keeper_turn_disposition.ml:63-70 (runtime-trust latest action)
 //   - lib/keeper_fd_pressure.ml:191 ('restore_fd_headroom')
 //   - lib/dashboard/dashboard_goals.ml:45 ('inspect_keeper_runtime_trust')
 const NEXT_HUMAN_ACTIONS = [
@@ -140,6 +141,7 @@ function isNextHumanAction(s: string): s is NextHumanAction {
 }
 
 function canonicalNextHumanAction(action: string | null): string | null {
+  if (action === 'inspect_turn_timeout') return 'inspect_runtime_blocker'
   if (action === 'inspect_timeout_budget') return 'inspect_runtime_blocker'
   if (action === 'inspect_cascade_attempts') return 'inspect_runtime_blocker'
   if (action === 'inspect_provider_tool_lane') return 'inspect_runtime_blocker'

--- a/dashboard/src/components/keeper-memory-tier-panel.test.ts
+++ b/dashboard/src/components/keeper-memory-tier-panel.test.ts
@@ -86,12 +86,16 @@ describe('filterMemoryKindUsage', () => {
   })
 })
 
-function mockMemoryTierFetches(usage: MemoryKindUsageEntry[]) {
+function mockMemoryTierFetches(
+  usage: MemoryKindUsageEntry[],
+  opts: { memoryKindUsageErrorClass?: string | null } = {},
+) {
   fetchKeeperStateDiagramMock.mockResolvedValue({
     keeper: 'keeper-1',
     current_phase: 'Compacting',
     mermaid: 'graph TD',
     memory_kind_usage: usage,
+    memory_kind_usage_error_class: opts.memoryKindUsageErrorClass ?? null,
   } satisfies KeeperStateDiagramResponse)
   const composite = {
     correlation_id: 'keeper-1:run-1',
@@ -139,5 +143,17 @@ describe('KeeperMemoryTierPanel status chips', () => {
     expect(kmcChip?.getAttribute('data-status-chip-uppercase')).toBe('false')
     expect(compactingChip?.getAttribute('data-status-chip-tone')).toBe('warn')
     expect(compactingChip?.getAttribute('data-status-chip-uppercase')).toBe('false')
+  })
+
+  it('surfaces memory bank read errors even when policy caps provide usage rows', async () => {
+    mockMemoryTierFetches(
+      [{ kind: 'tool_result', used: 0, cap: 10, priority: 1 }],
+      { memoryKindUsageErrorClass: 'io_error' },
+    )
+
+    render(html`<${KeeperMemoryTierPanel} keeperName="keeper-1" />`)
+
+    await waitFor(() => expect(screen.getByText('메모리 뱅크 읽기 실패: io_error')).toBeTruthy())
+    expect(screen.queryByText('tool_result')).toBeNull()
   })
 })

--- a/dashboard/src/components/keeper-memory-tier-panel.ts
+++ b/dashboard/src/components/keeper-memory-tier-panel.ts
@@ -154,7 +154,7 @@ export function KeeperMemoryTierPanel({
     `
   }
 
-  if (error || !usage || usage.length === 0) {
+  if (error || memoryBankErrorClass !== null || !usage || usage.length === 0) {
     // RFC-0149 §3.1 — if the bank read returned a typed failure class,
     // surface it on the empty-state message so operators can distinguish
     // "no memory rows recorded" from "memory bank unreadable".

--- a/lib/coord/coord_git.ml
+++ b/lib/coord/coord_git.ml
@@ -245,7 +245,7 @@ let create ~base_path ~agent_name ~task_id ~base_branch : string masc_result =
               if exit_code = 0 then
                 Ok
                   (Printf.sprintf
-                     "Worktree created:\n  Path: %s\n  Branch: %s%s\n\nNext: cd %s && work. Use git for branch/commit/push and Grep op=gh for GitHub PR work."
+                     "Worktree created:\n  Path: %s\n  Branch: %s%s\n\nNext: cd %s && work. Use git for branch/commit/push and GitHub PR tooling for PR work."
                      worktree_path branch_name note worktree_path)
               else Error (System (System_error.IoError (Printf.sprintf "Failed to create worktree from origin/%s." resolved_base))))
 

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -123,6 +123,7 @@ let run_turn
   =
   let user_message = Keeper_run_prompt.sanitize_user_message user_message in
   Masc_runtime_events.emit_turn_start ();
+  Memory_hooks.clear_last_memory_injection meta.agent_name;
   (* Cancel-safe cleanup (#9747): stdlib [Fun.protect] wraps finally
      exceptions in [Fun.Finally_raised], masking the outer
      [Eio.Cancel.Cancelled] raised by the turn body during fleet-wide
@@ -278,7 +279,8 @@ let run_turn
     Keeper_runtime_manifest.Checkpoint_loaded;
   append_manifest ~site:"context_compacted"
     ~keeper_turn_id:manifest_keeper_turn_id
-    ~compaction_source:(if pre_dispatch_compacted then "pre_dispatch_hygiene" else "skipped")
+    ?compaction_source:
+      (if pre_dispatch_compacted then Some "pre_dispatch_hygiene" else None)
     ~status:(if pre_dispatch_compacted then "compacted" else "skipped")
     ~decision:
       (Keeper_runtime_manifest.with_payload_role ~payload_role:Model_input

--- a/lib/keeper/keeper_exec_memory.ml
+++ b/lib/keeper/keeper_exec_memory.ml
@@ -241,7 +241,7 @@ let search_history
      the others.  The decision to elide is made *here* rather than
      hidden inside a silent facade — failures still surface via the
      [metric_keeper_memory_recall_read_errors] counter emitted by
-     [read_file_tail_lines]. *)
+     [Keeper_memory_recall.load_history_user_messages_result]. *)
   let current_history =
     match
       Keeper_memory_recall.load_history_user_messages_result

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -106,6 +106,17 @@ let read_file_tail_lines path ~max_bytes ~max_lines : string list =
       ();
     []
 
+let record_memory_recall_read_error ~site path exn_class =
+  let exn_label = Keeper_memory_recall_exn_class.to_label exn_class in
+  Log.Keeper.warn
+    "%s: dropping history read of %s: <error class=%s>"
+    site path exn_label;
+  Prometheus.inc_counter
+    Keeper_metrics.metric_keeper_memory_recall_read_errors
+    ~labels:[ ("exception_class", exn_label) ]
+    ()
+;;
+
 (* RFC-0149 §3.1 — typed Result entry point.  Distinguishes "empty
    memory bank" ([Ok summary] where [summary] holds zero recent rows)
    from "memory bank read failed" ([Error class]).  Callers that want
@@ -739,7 +750,8 @@ let history_user_messages_from_lines
 
 (* RFC-0149 §3.1: typed Result variant.  Distinguishes [Ok []] ("no
    user messages found in the history file") from [Error class] ("the
-   history file read failed"). *)
+   history file read failed"). Read failures still increment the bounded
+   recall-read-error metric before returning [Error]. *)
 let load_history_user_messages_result
     ~(path : string)
     ~(max_n : int) :
@@ -752,7 +764,12 @@ let load_history_user_messages_result
   with
   | Ok lines ->
     Ok (history_user_messages_from_lines ~path ~max_n lines)
-  | Error exn_class -> Error exn_class
+  | Error exn_class ->
+    record_memory_recall_read_error
+      ~site:"load_history_user_messages_result"
+      path
+      exn_class;
+    Error exn_class
 
 (** Build recall candidates by merging checkpoint messages with history.jsonl.
     Checkpoint messages are prioritized (recent context), history.jsonl
@@ -766,8 +783,9 @@ let recall_candidates_with_history
   let from_checkpoint = recent_user_messages checkpoint_messages ~max_n:max_checkpoint in
   (* RFC-0149 §3.1 closeout — aggregation site.  History read failure
      is elided to [[]] so the checkpoint matches still surface; the
-     bounded [exn_class] counter on [read_file_tail_lines] is the
-     informational signal for the failure. *)
+     bounded [exn_class] counter emitted by
+     [load_history_user_messages_result] is the informational signal for
+     the failure. *)
   let from_history =
     match
       load_history_user_messages_result ~path:history_path ~max_n:max_history

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -441,8 +441,8 @@ let decision_public_allowlist =
     ; "elapsed_ms"; "provider_attempt_id"; "tool_batch_id"; "checkpoint_id"
     ; "compaction_id"; "memory_injection_id"; "event_bus_correlation_id"
     ; "event_bus_run_id"; "parent_event_id"; "caused_by"; "logical_seq"
-    ; "repair_reason"; "matched_started_ts"; "matched_started_status"
-    ; "error"; "exception_kind"; "latency_ms"
+    ; "compaction_source"; "repair_reason"; "matched_started_ts"
+    ; "matched_started_status"; "error"; "exception_kind"; "latency_ms"
     ; "checkpoint_after_present"; "is_last"; "per_provider_timeout_s"
     ; "attempt_timeout_s"; "attempt_timeout_source"; "attempt_watchdog_source"
     ; "liveness_mode"; "liveness_budget_source"
@@ -456,8 +456,9 @@ let clock_refs_public_allowlist =
   StringSet.of_list
     [ "edge_id"; "lane"; "source_clock"; "observed_at"; "started_at"; "finished_at"
     ; "elapsed_ms"; "provider_attempt_id"; "tool_batch_id"; "checkpoint_id"
-    ; "compaction_id"; "memory_injection_id"; "event_bus_correlation_id"
-    ; "event_bus_run_id"; "parent_event_id"; "caused_by"; "logical_seq"
+    ; "compaction_id"; "compaction_source"; "memory_injection_id"
+    ; "event_bus_correlation_id"; "event_bus_run_id"; "parent_event_id"
+    ; "caused_by"; "logical_seq"
     ]
 
 let rec reject_unknown_fields ~allowlist path = function

--- a/lib/keeper_recording_error_state/keeper_recording_error_state.ml
+++ b/lib/keeper_recording_error_state/keeper_recording_error_state.ml
@@ -98,9 +98,6 @@ let classify_error (err : string) : error_kind =
       in
       go 0)
   in
-  let err =
-    if contains_in err "oas_timeout_budget" then "provider_timeout" else err
-  in
   let contains needle = contains_in err needle in
   if contains "sandbox docker"
   then Sandbox_docker
@@ -108,7 +105,7 @@ let classify_error (err : string) : error_kind =
   then Stale_turn_timeout
   else if contains "fiber_unresolved"
   then Fiber_unresolved
-  else if contains "provider_timeout"
+  else if contains "provider_timeout" || contains "oas_timeout_budget"
   then Provider_timeout
   else if contains "state machine guard" || contains "guard violation"
   then State_machine_guard

--- a/lib/memory_hooks.ml
+++ b/lib/memory_hooks.ml
@@ -35,6 +35,11 @@ let get_last_memory_injection agent_name =
   with_last_memory_injection_lock (fun () ->
     Hashtbl.find_opt last_memory_injection agent_name)
 ;;
+
+let clear_last_memory_injection agent_name =
+  with_last_memory_injection_lock (fun () ->
+    Hashtbl.remove last_memory_injection agent_name)
+;;
 (** Build an [extra_system_context] string from episodic, procedural,
     and institutional memory.
 

--- a/lib/memory_hooks.mli
+++ b/lib/memory_hooks.mli
@@ -55,6 +55,11 @@ val get_last_memory_injection : string -> (string * int) option
     agent. Thread-safe (Stdlib.Mutex). Returns [None] if no injection was
     recorded since the last [Continue] branch or process start. *)
 
+val clear_last_memory_injection : string -> unit
+(** Clear the recorded memory injection digest and size for an agent.
+    Used at the keeper turn boundary so pre-dispatch failures cannot
+    inherit side-channel data from an earlier turn. *)
+
 val compose_with_inner :
   memory_hooks:Agent_sdk.Hooks.hooks ->
   inner:Agent_sdk.Hooks.hooks ->

--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -419,12 +419,26 @@ type error_kind = Error_kind of string
 let error_kind_of_string value = Error_kind value
 let error_kind_to_string (Error_kind value) = value
 
+let canonical_error_kind_label = function
+  | "oas_timeout_budget" -> "provider_timeout"
+  | "oas_timeout_budget_loop" -> "provider_timeout_loop"
+  | value -> value
+
 let timeout_error_kinds =
   List.map error_kind_of_string
-    [ "provider_timeout"; "turn_timeout"; "admission_queue_timeout" ]
+    [
+      "provider_timeout";
+      "provider_timeout_loop";
+      "turn_timeout";
+      "admission_queue_timeout";
+    ]
 
 let stress_kind_for_error_kind error_kind =
-  let trimmed = String.trim (error_kind_to_string error_kind) in
+  let trimmed =
+    error_kind_to_string error_kind
+    |> String.trim
+    |> canonical_error_kind_label
+  in
   if
     List.exists
       (fun kind -> String.equal trimmed (error_kind_to_string kind))
@@ -463,7 +477,11 @@ let () =
     ()
 
 let normalize_error_kind kind =
-  let trimmed = String.trim (error_kind_to_string kind) in
+  let trimmed =
+    error_kind_to_string kind
+    |> String.trim
+    |> canonical_error_kind_label
+  in
   if trimmed = "" then "unspecified" else trimmed
 
 let failure_learnings ~error_kind ~error_preview =
@@ -496,7 +514,7 @@ let store_failed_turn_episode
     String_util.utf8_safe ~max_bytes:4099 ~suffix:"..." error_message
     |> String_util.to_string
   in
-  let error_kind_label = error_kind_to_string error_kind in
+  let error_kind_label = normalize_error_kind error_kind in
   let summary =
     Printf.sprintf "keeper turn %d failed (%s): %s" turn error_kind_label
       error_preview

--- a/lib/server/host_fd_pressure_poller.ml
+++ b/lib/server/host_fd_pressure_poller.ml
@@ -71,8 +71,9 @@ let parse_iso8601_opt s =
      with
      (* RFC-0145 — narrowed from a wildcard catch-all to the only
         exceptions [Scanf.sscanf] / [Unix.mktime] raise on ill-formed
-        ISO8601 input.  Unrelated runtime exceptions now propagate. *)
-     | Scanf.Scan_failure _ | End_of_file | Unix.Unix_error _ -> None)
+        ISO8601 input.  [Failure] covers numeric conversion failures
+        from [Scanf.sscanf] for malformed external timestamps. *)
+     | Scanf.Scan_failure _ | Failure _ | End_of_file | Unix.Unix_error _ -> None)
   | _ -> None
 ;;
 

--- a/test/keeper_recording_error_state/test_keeper_recording_error_state.ml
+++ b/test/keeper_recording_error_state/test_keeper_recording_error_state.ml
@@ -48,6 +48,16 @@ let test_classify_oas_timeout () =
      = S.Provider_timeout)
 ;;
 
+let test_classify_mixed_stale_and_legacy_timeout_keeps_stale () =
+  check
+    bool
+    "stale_turn_timeout wins over legacy timeout-budget marker"
+    true
+    (S.classify_error
+       "stale_turn_timeout(idle_turn(1559s)); prior=oas_timeout_budget"
+     = S.Stale_turn_timeout)
+;;
+
 let test_classify_state_machine_guard () =
   check
     bool
@@ -220,6 +230,10 @@ let () =
         ; test_case "stale_turn_timeout" `Quick test_classify_stale_turn
         ; test_case "fiber_unresolved" `Quick test_classify_fiber_unresolved
         ; test_case "legacy timeout-budget provider timeout" `Quick test_classify_oas_timeout
+        ; test_case
+            "mixed stale and legacy timeout keeps stale"
+            `Quick
+            test_classify_mixed_stale_and_legacy_timeout_keeps_stale
         ; test_case
             "state machine guard"
             `Quick

--- a/test/test_failure_learnings_10325.ml
+++ b/test/test_failure_learnings_10325.ml
@@ -66,7 +66,7 @@ let test_no_generic_boilerplate () =
 let test_kind_and_message_emitted_as_tags () =
   let learnings =
     extract_failure_learnings
-      ~error_kind:"provider_timeout"
+      ~error_kind:"oas_timeout_budget"
       ~error_message:"keeper exceeded budget after 12 turns"
   in
   let has_kind =
@@ -81,6 +81,14 @@ let test_kind_and_message_emitted_as_tags () =
   in
   check bool "failure_kind entry emitted" true has_kind;
   check bool "error_preview entry emitted" true has_message_tag
+
+let test_timeout_budget_loop_kind_canonicalized () =
+  let learnings =
+    extract_failure_learnings
+      ~error_kind:"oas_timeout_budget_loop" ~error_message:""
+  in
+  check (list string) "legacy loop kind canonicalized"
+    [ "failure_kind: provider_timeout_loop" ] learnings
 
 let test_unspecified_kind_when_both_blank () =
   let learnings =
@@ -105,6 +113,8 @@ let () =
              test_no_generic_boilerplate;
            test_case "kind and message become tag entries" `Quick
              test_kind_and_message_emitted_as_tags;
+           test_case "legacy timeout budget loop kind is canonicalized" `Quick
+             test_timeout_budget_loop_kind_canonicalized;
            test_case "unspecified sentinel when both blank" `Quick
              test_unspecified_kind_when_both_blank;
            test_case "only error_kind when message blank" `Quick

--- a/test/test_keeper_failure_policy.ml
+++ b/test/test_keeper_failure_policy.ml
@@ -67,6 +67,7 @@ let test_provider_streaming_thinking_timeout_does_not_kill_keeper () =
       (Policy.Provider_timeout
          {
            phase = Some (Policy.Stream_idle Policy.Streaming_thinking);
+           strikes = None;
            liveness = Policy.In_turn_progress;
          })
   in

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -3343,12 +3343,14 @@ let test_public_projection_allowlist_filters_provider_model () =
       [ ("edge_id", `String "e1")
       ; ("lane", `String "L1")
       ; ("source_clock", `String "wall")
+      ; ("compaction_source", `String "pre_dispatch_hygiene")
       ; ("model_source", `String "gpt-4")
       ; ("provider_attempt_id", `String "pa1")
       ; ( "clock_refs"
         , `Assoc
             [ ("edge_id", `String "ce1")
             ; ("source_clock", `String "monotonic")
+            ; ("compaction_source", `String "pre_dispatch_hygiene")
             ; ("provider_model_hint", `String "should_be_filtered")
             ; ("provider_attempt_id", `String "cpa1")
             ] )
@@ -3371,12 +3373,14 @@ let test_public_projection_allowlist_filters_provider_model () =
   Alcotest.(check bool) "edge_id kept" true (has "edge_id");
   Alcotest.(check bool) "lane kept" true (has "lane");
   Alcotest.(check bool) "source_clock kept" true (has "source_clock");
+  Alcotest.(check bool) "compaction_source kept" true (has "compaction_source");
   Alcotest.(check bool) "provider_attempt_id kept" true (has "provider_attempt_id");
   Alcotest.(check bool) "model_source filtered" false (has "model_source");
   Alcotest.(check bool) "unknown_field filtered" false (has "unknown_field");
   Alcotest.(check bool) "clock_refs kept" true (has "clock_refs");
   Alcotest.(check bool) "clock edge_id kept" true (clock_has "edge_id");
   Alcotest.(check bool) "clock source_clock kept" true (clock_has "source_clock");
+  Alcotest.(check bool) "clock compaction_source kept" true (clock_has "compaction_source");
   Alcotest.(check bool) "clock provider_attempt_id kept" true (clock_has "provider_attempt_id");
   Alcotest.(check bool) "clock provider_model_hint filtered" false (clock_has "provider_model_hint")
 

--- a/test/test_memory_hooks.ml
+++ b/test/test_memory_hooks.ml
@@ -518,6 +518,12 @@ let test_record_last_memory_injection_overwrites () =
   let result = Memory_hooks.get_last_memory_injection "agent_b" in
   check (option (pair string int)) "overwrites previous injection" (Some ("second", 200)) result
 
+let test_clear_last_memory_injection () =
+  Memory_hooks.record_last_memory_injection "agent_clear" "digest" 123;
+  Memory_hooks.clear_last_memory_injection "agent_clear";
+  let result = Memory_hooks.get_last_memory_injection "agent_clear" in
+  check (option (pair string int)) "cleared" None result
+
 let test_memory_injection_cleared_on_continue () =
   let tmp_dir = Filename.temp_dir "masc_test_mh" "" in
   let config = make_test_config ~base_path:tmp_dir in
@@ -710,6 +716,7 @@ let () =
       test_case "record and get last injection" `Quick test_record_and_get_last_memory_injection;
       test_case "get returns None when missing" `Quick test_get_last_memory_injection_returns_none_when_missing;
       test_case "record overwrites previous" `Quick test_record_last_memory_injection_overwrites;
+      test_case "clear last injection" `Quick test_clear_last_memory_injection;
       test_case "cleared on Continue branch" `Quick test_memory_injection_cleared_on_continue;
     ];
     "execution_receipt_json", [


### PR DESCRIPTION
Collects actionable review feedback that landed on already-merged PRs instead of dropping it as stale.

## Follow-ups addressed
- #17786: preserve compaction_source through runtime-manifest public projection.
- #17786: stop emitting compaction_source=skipped on skipped context compaction rows.
- #17783: keep host FD pressure timestamp parse failures soft for Scanf numeric Failure cases.
- #17770: clear memory injection side-channel at keeper turn start so pre-dispatch failures cannot inherit stale digest/size.
- #17772: keep memory recall read failures visible through the bounded read-error metric when Result callers elide failed history reads.
- #17766: surface memory bank read error class even when policy caps produce non-empty usage rows.
- #17743: preserve error-text context while treating legacy oas_timeout_budget as provider_timeout at its normal classifier precedence.
- #17731: add missing strikes=None to the remaining Provider_timeout test constructor.
- #17690: remove invalid Grep op=gh worktree guidance.
- #17689: canonicalize legacy oas_timeout_budget failure learnings and metrics to provider_timeout, with regression fixture restored to legacy input.
- #17682: canonicalize inspect_turn_timeout for dashboard labels and duplicate-pair suppression.
- #17687: ensure provider_timeout_loop strings stay classified through the provider-timeout family instead of other.

Already fixed on current main, tracked separately in comments:
- #17769: success-handler provider timeout label fixed by #17773.
- #17765: dashboard normalizer now reads provider_timeout_budget fallback.
- #17740: timeout blocker compatibility tests now exercise literal oas_timeout_budget input.
- #17697: provider-timeout loop pause metric and blocker-class expectations are aligned on current main.
- #17693: provider_timeout internal-error JSON now reverse-decodes through the canonical mapper.

## Validation
- ocamlformat --check on touched OCaml files
- git diff --check
- rg scan: no compaction_source=skipped emission remains
- dashboard: pnpm install --frozen-lockfile
- dashboard: pnpm typecheck
- dashboard: pnpm exec vitest run src/components/keeper-memory-tier-panel.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- dashboard: pnpm exec vitest run src/components/keeper-detail-alert-strip.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- scripts/dune-local.sh build test/test_failure_learnings_10325.exe
- ./_build/default/test/test_failure_learnings_10325.exe

Thread sweep:
- Open PR review threads: none unresolved in latest scan.
- Recent merged PR review threads: none unresolved in latest scan.