### PR TITLE
fix(cascade): drop timeout budget kind alias

### DIFF
--- a/lib/cascade/cascade_error_from_sdk.ml
+++ b/lib/cascade/cascade_error_from_sdk.ml
@@ -20,11 +20,6 @@
 
 open Cascade_internal_error
 
-let canonical_masc_oas_kind kind =
-  match kind with
-  | "oas_timeout_budget" -> "provider_timeout"
-  | _ -> kind
-
 let parse_masc_internal_error_json (json : Yojson.Safe.t) :
     masc_internal_error option =
   let int_opt_of_assoc key = function
@@ -173,8 +168,7 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
                 Some (Turn_timeout { elapsed_sec = v })
               | _ -> None)
           | _ -> None)
-      | Some (`String kind)
-        when String.equal (canonical_masc_oas_kind kind) "provider_timeout" -> (
+      | Some (`String "provider_timeout") -> (
           match json with
           | `Assoc fields -> (
               match


### PR DESCRIPTION
## Summary
- remove the legacy oas_timeout_budget kind canonicalizer from cascade SDK decode
- require provider-timeout envelopes to use canonical provider_timeout kind
- prevent retired timeout-budget wire kind from reviving provider-timeout internal state

## Validation
- Not run; user requested PR iteration without local validation.