### PR TITLE
fix(logs): drop timeout budget category alias

### DIFF
--- a/lib/masc_log/system_log_category.ml
+++ b/lib/masc_log/system_log_category.ml
@@ -49,12 +49,8 @@ let all =
     Network_error_other;
   ]
 
-let canonical_label = function
-  | "oas_timeout_budget" -> "provider_timeout"
-  | label -> label
-
 let of_string_opt raw =
-  match canonical_label raw with
+  match raw with
   | "task_ownership_ambiguity_current_task_unset" ->
       Some Task_ownership_ambiguity_current_task_unset
   | "state_store_current_task_path_corruption" ->


### PR DESCRIPTION
## Summary
- remove system-log category aliasing from oas_timeout_budget to provider_timeout
- require canonical provider_timeout labels for provider timeout system-log classification
- prevent retired timeout-budget labels from appearing as live provider timeout log categories

## Validation
- Not run; user requested PR iteration without local validation.