### PR TITLE
refactor: batch-narrow 5 wildcard exception arms across 4 files (RFC-0145 sweep)

### DIFF
--- a/lib/exec/bash_history.ml
+++ b/lib/exec/bash_history.ml
@@ -225,7 +225,9 @@ let load_entries path =
           while true do
             let line = input_line ic in
             match Yojson.Safe.from_string line with
-            | exception _ -> ()
+            (* RFC-0145 — narrow to the only exception
+               [Yojson.Safe.from_string] raises on malformed JSON. *)
+            | exception Yojson.Json_error _ -> ()
             | json ->
               (match entry_of_json json with
                | Some e -> entries := e :: !entries

--- a/lib/process/bg_task.ml
+++ b/lib/process/bg_task.ml
@@ -397,7 +397,10 @@ let poll_state st =
 	          | _, s -> mark_process_finished st s
 	          | exception Unix.Unix_error (Unix.ECHILD, _, _) ->
 	              mark_process_finished st (Unix.WEXITED 0)
-	          | exception _ -> ()));
+	          (* RFC-0145 — narrow to the only remaining exception kind
+	             [Unix.waitpid] raises (the [ECHILD] case is handled
+	             above as a domain-meaningful outcome). *)
+	          | exception Unix.Unix_error _ -> ()));
     if st.status = None
        && st.timeout_sec > 0.0
        && Unix.gettimeofday () -. st.handle.started_at > st.timeout_sec
@@ -407,7 +410,9 @@ let poll_state st =
 	      (match Unix.waitpid [ Unix.WNOHANG ] st.handle.pid with
 	       | 0, _ -> ()
 	       | _, s -> mark_process_finished st s
-	       | exception _ -> ())
+	       (* RFC-0145 — narrow to [Unix.Unix_error] (the only exception
+	          [Unix.waitpid] raises). *)
+	       | exception Unix.Unix_error _ -> ())
     end;
 	    if st.status <> None && st.stdout_eof && st.stderr_eof then begin
 		      st.closed <- true;

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -1060,7 +1060,9 @@ let handle_schema _state request reqd =
             reqd
             ~status:`OK
             (`Assoc [ "ok", `Bool true; "id", `String id; "schema", parsed ])
-        | exception _ ->
+        (* RFC-0145 — narrow to the only exception
+           [Yojson.Safe.from_string] raises on malformed JSON. *)
+        | exception Yojson.Json_error _ ->
           respond_json
             request
             reqd

--- a/lib/shutdown_hooks.ml
+++ b/lib/shutdown_hooks.ml
@@ -87,8 +87,10 @@ let run_all () =
       let count_after_budget = ref 0 in
       Eio_guard.protect
         ~finally:(fun () ->
+          (* RFC-0145 — narrow to [Unix.Unix_error] (the only exception
+             [Unix.closedir] raises on a bad fd). *)
           try Unix.closedir dh with
-          | _ -> ())
+          | Unix.Unix_error _ -> ())
         (fun () ->
            while not !stop do
              match Unix.readdir dh with


### PR DESCRIPTION
## Goal

Final RFC-0145 sweep batch.  Five remaining Cluster A wildcards under `lib/`, narrowed to the typed exception(s) the underlying call can actually raise.

## Sites

| File / line | Call | Before | After |
|-------------|------|--------|-------|
| `server_routes_http_routes_sidecar.ml:1063` | `Yojson.Safe.from_string` | `\| exception _` | `\| exception Yojson.Json_error _` |
| `bg_task.ml:400` | `Unix.waitpid` (poll path) | `\| exception _ -> ()` | `\| exception Unix.Unix_error _ -> ()` |
| `bg_task.ml:410` | `Unix.waitpid` (timeout-kill path) | `\| exception _ -> ()` | `\| exception Unix.Unix_error _ -> ()` |
| `bash_history.ml:228` | `Yojson.Safe.from_string` | `\| exception _ -> ()` | `\| exception Yojson.Json_error _ -> ()` |
| `shutdown_hooks.ml:91` | `Unix.closedir` (finally) | `\| _ -> ()` | `\| Unix.Unix_error _ -> ()` |

`bg_task.ml:400` already pattern-matches `Unix.Unix_error (ECHILD, _, _)` as the domain-meaningful "child already reaped" outcome; the new narrowed arm covers the *remaining* `Unix_error` variants.

## Excluded site

`lib/keeper/keeper_turn_driver_admission.ml:65` is intentionally **not** narrowed in this batch:

```ocaml
let release_client_capacity_quietly = function
  | None -> ()
  | Some release ->
      (match release () with
       | () -> ()
       | exception _ -> ())
```

`release ()` is a caller-supplied callback whose exception contract is unbounded by design.  Narrowing would change behaviour (mis-classify a legitimate callback exception) rather than tighten it.  RFC-0145 §3 anti-goals: "Each call site keeps its own domain error type."

## Behaviour

| Input shape                                | Before | After |
|--------------------------------------------|--------|-------|
| Well-formed JSON / known Unix outcome       | unchanged | unchanged |
| Malformed JSON                              | swallowed (wildcard) | swallowed (typed) |
| Known Unix errno                            | swallowed (wildcard) | swallowed (typed) |
| Unrelated runtime exception (`Out_of_memory`, async failure, etc.) | swallowed (silent) | **propagated** |

Only the last row changes.

## Verification

* `dune build --root . lib/` → pass.

## Stack context

This is the final batch for the in-session RFC-0145 sweep.  Cumulative progress:

| PR | Site count | File |
|----|------------|------|
| #17780 | 1 | `keeper_approval_queue` |
| #17783 | 3 | `host_fd_pressure_poller` |
| #17789 | 4 | `coord_worktree_repo_discovery` |
| #17793 | 2 | `ide_region_tracker` |
| #17795 | 2 | `cascade_declarative_parser` (string_list_field + match-prefixes) |
| #17796 | 2 | `cascade_declarative_parser` (parse_headers) |
| **this** | 5 | sidecar + bg_task + bash_history + shutdown_hooks |

After merge, `| exception _ -> …` count under `lib/` drops from 19 → 1 (the intentional `release_client_capacity_quietly` callback site).

## Anti-pattern self-check

- §1 telemetry-as-fix? No.
- §2 substring classifier? No — typed OCaml constructors only.
- §3 N-of-M? Tracked openly — final batch closing the in-session sweep; remaining site is documented and intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>