### PR TITLE
fix(keeper): drop meta contract timeout budget alias

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -191,7 +191,6 @@ let blocker_class_of_serialized_string = function
   | "autonomous_slot_wait_timeout" -> Some Autonomous_slot_wait_timeout
   | "admission_queue_wait_timeout" -> Some Admission_queue_wait_timeout
   | "turn_timeout_after_queue_wait" -> Some Turn_timeout_after_queue_wait
-  | "oas_timeout_budget" -> Some Turn_timeout
   | "turn_timeout" -> Some Turn_timeout
   | "turn_livelock_blocked" -> Some Turn_livelock_blocked
   | "completion_contract_violation" -> Some Completion_contract_violation

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -194,9 +194,7 @@ type blocker_class =
 
 val blocker_class_to_string : blocker_class -> string
 (** Canonical lowercase labels.  Pinned literals — operator
-    dashboards parse these for keeper supervisor alerting. Legacy
-    ["oas_timeout_budget"] input is parse-only compatibility and maps to
-    [Turn_timeout]. *)
+    dashboards parse these for keeper supervisor alerting. *)
 
 val cascade_exhaustion_summary :
   cascade_exhaustion_reason -> string


### PR DESCRIPTION
## Summary
- remove keeper meta-contract parsing compatibility for oas_timeout_budget
- drop public docs that advertised legacy timeout-budget input as Turn_timeout
- keep blocker-class contract limited to canonical timeout ownership labels

## Validation
- Not run; user requested PR iteration without local validation.