### PR TITLE
fix(keeper): drop turn disposition timeout budget alias

### DIFF
--- a/lib/keeper/keeper_turn_disposition.ml
+++ b/lib/keeper/keeper_turn_disposition.ml
@@ -122,7 +122,6 @@ let of_wire = function
   | "success" -> Success
   | "external_cancel" -> External_cancel
   | "turn_wall_clock_timeout" -> Turn_wall_clock_timeout
-  | "oas_timeout_budget" -> Turn_wall_clock_timeout
   | "cascade_attempts_exhausted" -> Cascade_attempts_exhausted
   | "gh_repo_context_missing_worktree" -> Gh_repo_context_missing_worktree
   | "required_tool_use_no_tool_call" -> Required_tool_use_no_tool_call

--- a/lib/keeper/keeper_turn_disposition.mli
+++ b/lib/keeper/keeper_turn_disposition.mli
@@ -108,8 +108,6 @@ val to_wire : t -> string
     [Keeper_turn_terminal_code.of_wire]; if that succeeds, the result
     is wrapped via [of_termination_code] (which may itself collapse to
     a non-Provider_error disposition such as [Required_tool_use_unsatisfied]).
-    Legacy ["oas_timeout_budget"] input parses to [Turn_wall_clock_timeout]
-    and is not represented as a distinct disposition state.
     Otherwise [Unknown { raw_error = wire }] is returned. *)
 val of_wire : string -> t
 


### PR DESCRIPTION
## Summary
- remove turn-disposition wire parsing compatibility for oas_timeout_budget
- drop docs that advertised legacy timeout-budget input as Turn_wall_clock_timeout
- keep disposition parsing aligned to canonical terminal ownership labels only

## Validation
- Not run; user requested PR iteration without local validation.