### PR TITLE
fix(test): scan post_turn_memory after decomposition + qualify Keeper_memory_policy refs

### DIFF
--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -1155,10 +1155,19 @@ let read_repo_file rel =
         really_input_string ic (in_channel_length ic))
 
 let test_keeper_agent_run_wires_memory_llm_summarizer () =
-  let source = read_repo_file "lib/keeper/keeper_agent_run.ml" in
+  (* The memory-LLM summarizer wiring lives in the post-turn memory
+     sub-module after the RFC-0147 keeper_agent_run decomposition.
+     [Keeper_memory_llm_summary.make] is constructed there and threaded
+     into [Keeper_memory_bank.compact_memory_bank_if_needed] via the
+     [?summarizer] labelled argument. *)
+  let source =
+    read_repo_file "lib/keeper/keeper_agent_run_post_turn_memory.ml"
+  in
   let summarizer_pos =
     match Astring.String.find_sub ~sub:"Keeper_memory_llm_summary.make" source with
-    | None -> fail "expected Keeper_memory_llm_summary.make in keeper_agent_run"
+    | None ->
+      fail
+        "expected Keeper_memory_llm_summary.make in keeper_agent_run_post_turn_memory"
     | Some pos -> pos
   in
   let compaction_pos =
@@ -1167,7 +1176,9 @@ let test_keeper_agent_run_wires_memory_llm_summarizer () =
         ~sub:"Keeper_memory_bank.compact_memory_bank_if_needed"
         source
     with
-    | None -> fail "expected compact_memory_bank_if_needed in keeper_agent_run"
+    | None ->
+      fail
+        "expected compact_memory_bank_if_needed in keeper_agent_run_post_turn_memory"
     | Some pos -> pos
   in
   check bool "summarizer constructed before compaction" true
@@ -1806,7 +1817,7 @@ let test_compaction_records_consolidation_metrics () =
     in
     let compaction_source_str =
       Option.value ~default:"none"
-        (Option.map Keeper_memory_policy.compaction_source_to_string compaction.source)
+        (Option.map Masc_mcp.Keeper_memory_policy.compaction_source_to_string compaction.source)
     in
     check bool (Printf.sprintf "compaction ran (%s)" compaction_source_str)
       true compaction.performed;
@@ -1867,8 +1878,12 @@ let test_compaction_runs_on_note_pressure_under_byte_trigger () =
     in
     check bool "compaction ran from note pressure" true compaction.performed;
     check (option string) "compaction source"
-      (Some (Keeper_memory_policy.compaction_source_to_string Keeper_memory_policy.Memory_bank))
-      (Option.map Keeper_memory_policy.compaction_source_to_string compaction.source);
+      (Some
+         (Masc_mcp.Keeper_memory_policy.compaction_source_to_string
+            Masc_mcp.Keeper_memory_policy.Memory_bank))
+      (Option.map
+         Masc_mcp.Keeper_memory_policy.compaction_source_to_string
+         compaction.source);
     check int "before notes" (target_notes + 1) compaction.before_notes;
     check int "after notes capped to target" target_notes compaction.after_notes;
     check int "one note dropped" 1 compaction.dropped_notes)


### PR DESCRIPTION
## Goal

Restore the `test_keeper_memory` suite from 82 / 83 → **83 / 83** passing by fixing two unrelated test-only issues in `test/test_keeper_memory.ml`.

## Change 1 — wiring assertion file path

`test_keeper_agent_run_wires_memory_llm_summarizer` reads a source file and asserts that:

* `Keeper_memory_llm_summary.make` appears
* `Keeper_memory_bank.compact_memory_bank_if_needed` appears
* the summarizer position precedes the compaction position
* `?summarizer:memory_summarizer` is in the same file

After the RFC-0147 decomposition (`feat: keeper_agent_run sub-module split`) all three substrings moved into `lib/keeper/keeper_agent_run_post_turn_memory.ml` (the test confirmed this with `grep`: lines 89, 96, 97).  The test was still reading `lib/keeper/keeper_agent_run.ml`, where none of the substrings exist anymore, so it was failing on `origin/main`.

```diff
-  let source = read_repo_file "lib/keeper/keeper_agent_run.ml" in
+  let source =
+    read_repo_file "lib/keeper/keeper_agent_run_post_turn_memory.ml"
+  in
```

`fail` messages updated to point at the new file.  Ordering check (summarizer before compaction) and wiring infix check (`?summarizer:memory_summarizer`) work on the new source as-is.

## Change 2 — qualified `Keeper_memory_policy` references

Lines 1820 (introduced by #17786), 1881, 1882 used `Keeper_memory_policy.…` without the `Masc_mcp.` prefix that every other usage in this file carries.  The test executable refused to build:

```
File "test/test_keeper_memory.ml", line 1820, characters 20-40:
Error: Unbound module Keeper_memory_policy
```

Each reference gains the `Masc_mcp.` prefix to match the rest of the file.  No semantic change.

## Verification

* `dune build --root . test/test_keeper_memory.exe` → pass.
* `_build/default/test/test_keeper_memory.exe` → **83 / 83 pass** (previously 82 / 83 — this case was the single failure).

## Stack context

Test-only.  Independent of the open RFC-0145 doc PR #17807.

## Anti-pattern self-check

- §1 telemetry-as-fix? No — fixes existing assertions to match current code; no new counter or instrumentation.
- §2 substring classifier? No — but worth noting that this test *is* a substring-based wiring assertion, which is inherently fragile to refactoring (the RFC-0147 decomposition broke it).  A future improvement could replace it with a call-graph or compile-time test, but that is out of scope for this fix.
- §3 N-of-M? Tracked — all three unqualified `Keeper_memory_policy` references in the file migrate together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>