### PR TITLE
fix(operator): drop timeout budget attention suppressor

### DIFF
--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -108,12 +108,8 @@ let assoc_string_field key fields =
       if String.equal value "" then None else Some value
   | _ -> None
 
-let canonical_keeper_attention_reason = function
-  | Some "timeout_budget_exhausted" -> None
-  | reason -> reason
-
 let keeper_attention_kind reason =
-  match canonical_keeper_attention_reason reason with
+  match reason with
   | Some reason -> "keeper_" ^ reason
   | None -> "keeper_attention"
 


### PR DESCRIPTION
## Summary
- remove the operator digest suppressor for timeout_budget_exhausted attention reasons
- stop collapsing retired timeout-budget reasons into generic keeper_attention
- keep attention kind derivation transparent to the canonical reason supplied upstream

## Validation
- Not run; user requested PR iteration without local validation.