### PR TITLE
fix(keeper): drop timeout budget metric API aliases

### DIFF
--- a/lib/keeper/keeper_metrics.ml
+++ b/lib/keeper/keeper_metrics.ml
@@ -724,10 +724,6 @@ let metric_keeper_provider_timeout_loop_paused =
   "masc_keeper_provider_timeout_loop_paused_total"
 ;;
 
-let metric_keeper_oas_timeout_budget_loop_paused =
-  metric_keeper_provider_timeout_loop_paused
-;;
-
 let metric_keeper_cycle_exceptions = "masc_keeper_cycle_exceptions_total"
 let metric_keeper_snapshot_write_failures = "masc_keeper_snapshot_write_failures_total"
 
@@ -942,8 +938,6 @@ let metric_keeper_provider_timeout_strike =
   "masc_keeper_provider_timeout_strike_total"
 ;;
 
-let metric_keeper_oas_timeout_budget_strike = metric_keeper_provider_timeout_strike
-
 let metric_keeper_stale_termination_total = "masc_keeper_stale_termination_total"
 
 let metric_keeper_stale_termination_by_class =
@@ -952,10 +946,6 @@ let metric_keeper_stale_termination_by_class =
 
 let metric_keeper_provider_timeout_watchdog_termination =
   "masc_keeper_provider_timeout_watchdog_termination_total"
-;;
-
-let metric_keeper_oas_timeout_budget_watchdog_termination =
-  metric_keeper_provider_timeout_watchdog_termination
 ;;
 
 let metric_keeper_stale_termination_threshold_breached =

--- a/lib/keeper/keeper_metrics.mli
+++ b/lib/keeper/keeper_metrics.mli
@@ -413,7 +413,6 @@ val metric_keeper_presence_sync_failures : string
 val metric_keeper_self_preservation_universal : string
 val metric_keeper_stale_storm_paused : string
 val metric_keeper_provider_timeout_loop_paused : string
-val metric_keeper_oas_timeout_budget_loop_paused : string
 val metric_keeper_cycle_exceptions : string
 val metric_keeper_snapshot_write_failures : string
 val metric_keeper_state_snapshot_skipped_no_state : string
@@ -595,11 +594,9 @@ val metric_keeper_required_tool_gate_suppressed_total : string
 val metric_keeper_consecutive_idle : string
 val metric_keeper_last_productive_ts : string
 val metric_keeper_provider_timeout_strike : string
-val metric_keeper_oas_timeout_budget_strike : string
 val metric_keeper_stale_termination_total : string
 val metric_keeper_stale_termination_by_class : string
 val metric_keeper_provider_timeout_watchdog_termination : string
-val metric_keeper_oas_timeout_budget_watchdog_termination : string
 val metric_keeper_stale_termination_threshold_breached : string
 val metric_keeper_stale_termination_batch : string
 val metric_keeper_stale_broadcast_emit_failures : string


### PR DESCRIPTION
## Summary
- remove exported oas_timeout_budget metric symbols that aliased provider-timeout metrics
- keep provider-timeout metrics available under canonical provider_timeout names only
- prevent retired timeout-budget metric API names from preserving a phantom state surface

## Validation
- Not run; user requested PR iteration without local validation.