### PR TITLE
fix(keeper): classify required tool exhaustion

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -1041,10 +1041,25 @@ let run_named
   in
   let rec try_cascade
       ?(on_success = fun ~provider_key:_ -> ())
+      ?(pre_dispatch_required_tool_rejections_rev = [])
       ?resume_checkpoint ?per_provider_timeout_s ?last_capacity_source
       ?last_capacity_backpressure remaining last_err =
     match remaining with
     | [] ->
+      let pre_dispatch_no_tool_capable =
+        match last_err, last_capacity_backpressure with
+        | None, None ->
+          no_tool_capable_provider_of_pre_dispatch_rejections
+            ~cascade_name:error_cascade_name
+            ~configured_labels
+            ~runtime_manifest_required_tool_names
+            ~runtime_mcp_policy
+            ~tools
+            ~required_lane_provider_rejections
+            ~pre_dispatch_provider_rejections:
+              (List.rev pre_dispatch_required_tool_rejections_rev)
+        | Some _, _ | _, Some _ -> None
+      in
       let reason : Keeper_types.cascade_exhaustion_reason = match last_err with
         | Some (Llm_provider.Http_client.NetworkError { message; kind }) ->
             if kind = Llm_provider.Http_client.Connection_refused
@@ -1141,11 +1156,14 @@ let run_named
              sdk_error_of_masc_internal_error capacity_error
            | None ->
              sdk_error_of_masc_internal_error
-               (Cascade_exhausted
-                  {
-                    cascade_name = error_cascade_name;
-                    reason;
-                  }))
+               (match pre_dispatch_no_tool_capable with
+                | Some internal_error -> internal_error
+                | None ->
+                  Cascade_exhausted
+                    {
+                      cascade_name = error_cascade_name;
+                      reason;
+                    }))
       in
       Error
         terminal_error
@@ -1200,6 +1218,11 @@ let run_named
              let skip_reason =
                Cascade_candidate_skip_reason.Required_tool_unsupported { missing }
              in
+             let provider_rejection =
+               provider_rejection_for_required_tool_unsupported
+                 ~provider_label
+                 ~missing_required_tools:missing
+             in
              Log.Misc.info
                "cascade %s: pre-dispatch blocked provider=%s reason=%s \
                 missing=[%s]"
@@ -1221,12 +1244,14 @@ let run_named
                     ; "provider_attempt_started", `Bool false
                     ])
                Keeper_runtime_manifest.Pre_dispatch_blocked;
-             Some ()
+             Some provider_rejection
            | Some true | None -> None)
       in
       match pre_dispatch_blocked with
-      | Some () ->
+      | Some provider_rejection ->
         try_cascade ~on_success ?resume_checkpoint ?per_provider_timeout_s
+          ~pre_dispatch_required_tool_rejections_rev:
+            (provider_rejection :: pre_dispatch_required_tool_rejections_rev)
           ?last_capacity_source ?last_capacity_backpressure rest last_err
       | None ->
       let tier_admission_id = Cascade_runtime_candidate.tier_id candidate in
@@ -1245,9 +1270,11 @@ let run_named
               "cascade %s: skipping %s (provider_key=%s cooldown: %s)"
               cascade_name runtime_candidate_label runtime_candidate_label msg;
             try_cascade ~on_success ?resume_checkpoint ?per_provider_timeout_s
+              ~pre_dispatch_required_tool_rejections_rev
               ?last_capacity_source ?last_capacity_backpressure rest last_err
         | None ->
             try_cascade ~on_success ?resume_checkpoint ?per_provider_timeout_s
+              ~pre_dispatch_required_tool_rejections_rev
               ?last_capacity_source ?last_capacity_backpressure rest last_err)
       else (
       (match health_cooldown with
@@ -1277,6 +1304,7 @@ let run_named
           Printf.sprintf "client capacity key %s is full" capacity_key
         in
         try_cascade ~on_success ?resume_checkpoint ?per_provider_timeout_s
+          ~pre_dispatch_required_tool_rejections_rev
           ~last_capacity_backpressure:
             (Client_capacity, capacity_detail, None)
           rest last_err
@@ -1499,6 +1527,7 @@ let run_named
           Printf.sprintf "tier admission %s is full" tier_admission_id
         in
         try_cascade ~on_success ?resume_checkpoint ?per_provider_timeout_s
+          ~pre_dispatch_required_tool_rejections_rev
           ~last_capacity_backpressure:
             (Tier_admission, capacity_detail, None)
           rest last_err
@@ -1595,7 +1624,11 @@ let run_named
            (* The rejected response is not trusted progress.  Resuming
               from its checkpoint can turn a fallback provider into a
               replay of the rejected empty/schema-invalid turn. *)
-           try_cascade ?resume_checkpoint (filter_provider_health_fail_open rest) new_err
+           try_cascade
+             ~pre_dispatch_required_tool_rejections_rev
+             ?resume_checkpoint
+             (filter_provider_health_fail_open rest)
+             new_err
          | Cascade_fsm.Exhausted _ ->
            record_candidate_health_rejected candidate ~reason;
            let observation =
@@ -1769,6 +1802,7 @@ let run_named
                 Option.bind new_err capacity_backpressure_source_of_http_error
               in
               try_cascade
+                ~pre_dispatch_required_tool_rejections_rev
                 ?resume_checkpoint:retry_resume_checkpoint
                 ?last_capacity_source
                 (filter_provider_health_fail_open rest)

--- a/lib/keeper/keeper_turn_driver_helpers.ml
+++ b/lib/keeper/keeper_turn_driver_helpers.ml
@@ -111,6 +111,39 @@ let required_tool_lane_unavailable_error ~lane ~missing_required_tools
              (String.concat ", " materialized_tools);
        })
 
+let provider_rejection_for_required_tool_unsupported ~provider_label
+    ~missing_required_tools =
+  ({
+     reason =
+       Printf.sprintf
+         "required_tool_unsupported: provider=%s missing_required_tools=[%s]"
+         provider_label
+         (String.concat ", " missing_required_tools);
+   }
+    : Cascade_error_classify.provider_rejection)
+
+let no_tool_capable_provider_of_pre_dispatch_rejections ~cascade_name
+    ~configured_labels ~runtime_manifest_required_tool_names ~runtime_mcp_policy
+    ~tools ~required_lane_provider_rejections ~pre_dispatch_provider_rejections =
+  match runtime_manifest_required_tool_names, pre_dispatch_provider_rejections with
+  | [], _ | _, [] -> None
+  | _ ->
+      let required_tool_names =
+        match required_tool_names_for_no_tool_error ~runtime_mcp_policy ~tools with
+        | [] -> dedupe_keep_order runtime_manifest_required_tool_names
+        | names -> names
+      in
+      Some
+        (Cascade_error_classify.No_tool_capable_provider
+           {
+             cascade_name;
+             configured_labels;
+             required_tool_names;
+             provider_rejections =
+               required_lane_provider_rejections
+               @ pre_dispatch_provider_rejections;
+           })
+
 type empty_candidate_classification =
   | Tool_capability_empty
   | Provider_unavailable

--- a/lib/keeper/keeper_turn_driver_helpers.mli
+++ b/lib/keeper/keeper_turn_driver_helpers.mli
@@ -35,6 +35,21 @@ val required_tool_lane_unavailable_error :
   materialized_tools:string list ->
   Agent_sdk.Error.sdk_error
 
+val provider_rejection_for_required_tool_unsupported :
+  provider_label:string ->
+  missing_required_tools:string list ->
+  Cascade_error_classify.provider_rejection
+
+val no_tool_capable_provider_of_pre_dispatch_rejections :
+  cascade_name:Cascade_error_classify.cascade_name ->
+  configured_labels:string list ->
+  runtime_manifest_required_tool_names:string list ->
+  runtime_mcp_policy:Llm_provider.Llm_transport.runtime_mcp_policy option ->
+  tools:Agent_sdk.Tool.t list ->
+  required_lane_provider_rejections:Cascade_error_classify.provider_rejection list ->
+  pre_dispatch_provider_rejections:Cascade_error_classify.provider_rejection list ->
+  Cascade_error_classify.masc_internal_error option
+
 type empty_candidate_classification =
   | Tool_capability_empty
   | Provider_unavailable

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -3175,6 +3175,57 @@ let test_required_tool_lane_unavailable_is_tool_support_config_error () =
       "expected tool_support InvalidConfig, got %s"
       (Agent_sdk.Error.to_string err)
 
+let test_pre_dispatch_required_tool_exhaustion_is_no_tool_capable () =
+  let module FT = Masc_mcp.Keeper_turn_driver_helpers in
+  let provider_rejection =
+    FT.provider_rejection_for_required_tool_unsupported
+      ~provider_label:"glm-coding"
+      ~missing_required_tools:[ "keeper_bash" ]
+  in
+  match
+    FT.no_tool_capable_provider_of_pre_dispatch_rejections
+      ~cascade_name:
+        (Masc_mcp.Keeper_turn_driver.cascade_name_of_string
+           "strict_tool_candidates")
+      ~configured_labels:[ "glm-coding.glm-5.keeper" ]
+      ~runtime_manifest_required_tool_names:[ "keeper_bash" ]
+      ~runtime_mcp_policy:None
+      ~tools:[]
+      ~required_lane_provider_rejections:[]
+      ~pre_dispatch_provider_rejections:[ provider_rejection ]
+  with
+  | Some
+      (Masc_mcp.Cascade_error_classify.No_tool_capable_provider
+        { required_tool_names; provider_rejections; _ }) ->
+    Alcotest.(check (list string))
+      "required tool names survive empty materialized tool list"
+      [ "keeper_bash" ]
+      required_tool_names;
+    Alcotest.(check int)
+      "provider rejection retained"
+      1
+      (List.length provider_rejections);
+    let rejection_reason =
+      match provider_rejections with
+      | [ rejection ] -> rejection.reason
+      | _ -> ""
+    in
+    Alcotest.(check bool)
+      "rejection records provider"
+      true
+      (contains_substring rejection_reason "provider=glm-coding");
+    Alcotest.(check bool)
+      "rejection records missing tool"
+      true
+      (contains_substring rejection_reason "missing_required_tools=[keeper_bash]")
+  | Some err ->
+    Alcotest.failf
+      "expected No_tool_capable_provider, got %s"
+      (Masc_mcp.Cascade_error_classify.kind_of_masc_internal_error err)
+  | None ->
+    Alcotest.fail
+      "expected pre-dispatch required-tool exhaustion to produce typed error"
+
 let test_empty_candidate_classification_separates_tool_filter_from_availability () =
   let module FT = Masc_mcp.Keeper_turn_driver_helpers in
   let check label expected actual =
@@ -3909,6 +3960,9 @@ let () =
           Alcotest.test_case
             "required tool lane mismatch is cascade-recoverable"
             `Quick test_required_tool_lane_unavailable_is_tool_support_config_error;
+          Alcotest.test_case
+            "pre-dispatch required-tool exhaustion is typed"
+            `Quick test_pre_dispatch_required_tool_exhaustion_is_no_tool_capable;
           Alcotest.test_case
             "empty candidate classification keeps availability separate"
             `Quick


### PR DESCRIPTION
## Summary
- carry pre-dispatch required-tool rejection evidence through keeper cascade exhaustion
- return typed no_tool_capable_provider when required-tool pre-dispatch skips exhaust candidates without provider/capacity errors
- add a focused runtime-manifest helper regression for keeper_bash required-tool exhaustion

## Validation
- scripts/dune-local.sh build test/test_keeper_runtime_manifest.exe
- ./_build/default/test/test_keeper_runtime_manifest.exe test wiring 4
- ocamlformat --check lib/keeper/keeper_turn_driver.ml lib/keeper/keeper_turn_driver_helpers.ml lib/keeper/keeper_turn_driver_helpers.mli test/test_keeper_runtime_manifest.ml
- git diff --check

## Notes
- Full ./_build/default/test/test_keeper_runtime_manifest.exe still has unrelated existing append lens failures: append 7 and append 10.