### PR TITLE
docs(timeout): drop timeout budget doc remnants

### DIFF
--- a/lib/cascade/cascade_internal_error.ml
+++ b/lib/cascade/cascade_internal_error.ml
@@ -380,9 +380,8 @@ let summary_of_masc_internal_error = function
    dashboards and Grafana alerts can watch the fleet-wide rate per
    error class (cascade_exhausted vs provider_timeout vs
    ambiguous_post_commit, etc.) rather than reading the free-form
-   BDI blocker string.  Historical [oas_timeout_budget] events accumulated
-   across 9 keepers in 24h without an aggregate signal — this
-   counter is the per-kind surface.
+   BDI blocker string.  Historical provider-timeout events accumulated across 9 keepers in 24h
+   without an aggregate signal — this counter is the per-kind surface.
 
    Emit point is this constructor so all 14 call sites of
    [sdk_error_of_masc_internal_error] are covered automatically,

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -131,7 +131,7 @@ val record_provider_timeout_observation :
 
 val provider_timeout_policy_decision :
   strikes:int -> Agent_sdk.Error.sdk_error -> Keeper_failure_policy.decision option
-(** Return the policy decision for a structured [Oas_timeout_budget] error.
+(** Return the policy decision for a structured provider-timeout error.
     This heartbeat-loop path is reached after the keeper turn returned, so
     timeout evidence is not liveness loss by itself. *)
 


### PR DESCRIPTION
## Summary
- remove the stale Oas_timeout_budget reference from provider timeout heartbeat-loop docs
- update historical cascade metric commentary to use provider-timeout terminology
- avoid leaving documentation breadcrumbs that can revive retired timeout-budget state names

## Validation
- Not run; user requested PR iteration without local validation.