### PR TITLE
refactor(keeper_cascade_profile): self-migrate 5 call sites to catalog_metadata_query (RFC-0143 PR-2)

### DIFF
--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -459,23 +459,27 @@ let normalized_query_name ?config_path raw =
 let is_system_only_cascade raw =
   let routed = routed_query_target raw |> String.trim in
   let public_name = public_name_of_target routed in
-  match catalog_metadata_result () with
-  | Ok meta ->
+  (* RFC-0143 PR-2 — typed catalog query. *)
+  match catalog_metadata_query () with
+  | Catalog_ok meta ->
       if is_qualified_profile_name routed then
         List.mem routed meta.system_qualified_names
       else
         List.mem public_name meta.system_names
-  | Error _ -> false
+  | Catalog_unavailable _ -> false
 
 let keeper_catalog_names ?config_path () =
-  match catalog_metadata_result ?config_path () with
-  | Ok meta -> meta.keeper_assignable_names
-  | Error _ -> catalog_names ?config_path ()
+  (* RFC-0143 PR-2 — typed catalog query.  On [Catalog_unavailable]
+     fall back to the plain catalog name list. *)
+  match catalog_metadata_query ?config_path () with
+  | Catalog_ok meta -> meta.keeper_assignable_names
+  | Catalog_unavailable _ -> catalog_names ?config_path ()
 
 let system_catalog_names ?config_path () =
-  match catalog_metadata_result ?config_path () with
-  | Ok meta -> meta.system_names
-  | Error _ -> []
+  (* RFC-0143 PR-2 — typed catalog query. *)
+  match catalog_metadata_query ?config_path () with
+  | Catalog_ok meta -> meta.system_names
+  | Catalog_unavailable _ -> []
 
 (** Track which (cascade, target) pairs we have already logged as
     invalid fallback hints so the WARN line fires once per process. *)
@@ -486,9 +490,10 @@ let fallback_cascade_for ?config_path name =
   let public_name = normalized_query_name ?config_path name in
   if String.equal public_name "" then None
   else
-    match catalog_metadata_result ?config_path () with
-    | Error _ -> None
-    | Ok meta -> (
+    (* RFC-0143 PR-2 — typed catalog query. *)
+    match catalog_metadata_query ?config_path () with
+    | Catalog_unavailable _ -> None
+    | Catalog_ok meta -> (
         let qualified_name =
           let routed = routed_query_target ?config_path name |> String.trim in
           if is_qualified_profile_name routed
@@ -547,9 +552,10 @@ let normalize_keeper_runtime_declared_name ?config_path raw =
   let normalized = normalize_declared_name raw in
   let public_name = public_name_of_target normalized in
   let explicitly_keeper_assignable =
-    match catalog_metadata_result ?config_path () with
-    | Ok meta -> List.mem normalized meta.keeper_assignable_names
-    | Error _ -> false
+    (* RFC-0143 PR-2 — typed catalog query. *)
+    match catalog_metadata_query ?config_path () with
+    | Catalog_ok meta -> List.mem normalized meta.keeper_assignable_names
+    | Catalog_unavailable _ -> false
   in
   let keeper_route_targets =
     keeper_runtime_route_uses


### PR DESCRIPTION
## Goal

Migrate every in-file consumer of the legacy string-error `catalog_metadata_result` in `lib/keeper/keeper_cascade_profile.ml` to the typed `catalog_metadata_query` bridge added by PR-1 (#16860).  Phase B of the RFC-0143 caller migration.

## Sites

| Function | Before | After |
|----------|--------|-------|
| `is_system_only_cascade` | `Ok meta` / `Error _` | `Catalog_ok meta` / `Catalog_unavailable _` |
| `keeper_catalog_names` | same | same |
| `system_catalog_names` | same | same |
| `fallback_cascade_for` | same | same |
| `normalize_keeper_runtime_declared_name` (`explicitly_keeper_assignable` binding) | same | same |

5 call sites migrated.  The RFC §4 "6 sites" count includes the bridge function definition itself, which stays in place — it is the bridge.

## Behaviour

| Path | Before | After |
|------|--------|-------|
| Happy: catalog loads, query hits | unchanged | unchanged |
| Error: catalog unavailable | `Error msg`, message discarded by `_` | `Catalog_unavailable {reason; message}`, both discarded |

The migration is purely a wire-shape conversion — every site discarded the legacy `Error msg` string already, and discards the new typed payload identically.  No new operator surface in this PR; later PRs (PR-3 external callers, PR-4 cross-domain) will expose the typed `reason` field where useful.

## Out of scope

* Legacy `catalog_metadata_result` definition (lines 373 / 391 / 419 / 423 doc-comments + the function body) — retained until PR-5 closeout when external callers across `lib/keeper/`, `lib/cascade/`, `lib/server/`, `dashboard/` have all migrated.

## Verification

* `dune build --root . lib/` → pass.

## Stack context

| Phase | PR | Status |
|-------|-----|--------|
| PR-1 (bridge) | #16860 | MERGED |
| **PR-2** (self-migration) | **this** | Draft |
| PR-3 | (pending) | external `lib/keeper/` callers (~8 files) |
| PR-4 | (pending) | `lib/cascade/` + `lib/server/` + `dashboard/` (~5 files) |
| PR-5 | (pending) | delete `catalog_metadata_result` + regenerate ratchet baseline |

## Anti-pattern self-check

- §1 telemetry-as-fix? No — replaces string-Error path with typed variant; no new counter or instrumentation.
- §2 substring classifier? No — `Catalog_unavailable` reason is a closed sum (`Catalog_path_not_resolved | Catalog_load_failed _ | Catalog_metadata_invalid _`), defined at the bridge.
- §3 N-of-M? Tracked openly — 5 of 5 in-file sites migrate together; external callers tracked in the stack table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>