### PR TITLE
fix(keeper): rename provider timeout plan payload

### DIFF
--- a/lib/dashboard/dashboard_http_keeper_detail.ml
+++ b/lib/dashboard/dashboard_http_keeper_detail.ml
@@ -593,8 +593,8 @@ let compute_metrics_window
 	              ("memory_compaction_dropped_notes", `Int memory_compaction_dropped_notes_now);
 	              ("memory_compaction_invalid_dropped", `Int memory_compaction_invalid_dropped_now);
 	              ("memory_expected_topic", Json_util.string_opt_to_json memory_expected_topic);
-              ( "provider_timeout_budget",
-                j |> member "provider_timeout_budget" );
+              ( "provider_timeout_plan",
+                j |> member "provider_timeout_plan" );
               ( "inference_telemetry",
                 j
                 |> member "inference_telemetry"

--- a/lib/keeper/keeper_unified_metrics.mli
+++ b/lib/keeper/keeper_unified_metrics.mli
@@ -190,7 +190,7 @@ val append_metrics_snapshot :
   message_count:int ->
   compaction:Keeper_exec_context.compaction_event ->
   handoff_json:Yojson.Safe.t option ->
-  ?provider_timeout_budget_json:Yojson.Safe.t ->
+  ?provider_timeout_plan_json:Yojson.Safe.t ->
   ?deliberation_execution:Keeper_deliberation.execution_result ->
   unit ->
   unit

--- a/lib/keeper/keeper_unified_metrics_snapshot.ml
+++ b/lib/keeper/keeper_unified_metrics_snapshot.ml
@@ -21,7 +21,7 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
     ~(message_count : int)
     ~(compaction : Keeper_exec_context.compaction_event)
     ~(handoff_json : Yojson.Safe.t option)
-    ?provider_timeout_budget_json ?deliberation_execution () : unit =
+    ?provider_timeout_plan_json ?deliberation_execution () : unit =
   let now_ts = Time_compat.now () in
   let _observation = observation in
   let turn_mode = turn_mode_of_result result in
@@ -119,8 +119,8 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
         ("resolved_model_id", `Null);
         ("prompt_fingerprint", `String result.prompt_metrics.fingerprint);
         ("prompt", Keeper_agent_run.prompt_metrics_to_json result.prompt_metrics);
-        ( "provider_timeout_budget",
-          match provider_timeout_budget_json with
+        ( "provider_timeout_plan",
+          match provider_timeout_plan_json with
           | Some value -> value
           | None -> `Null );
         ("ctx_composition", Keeper_agent_run.ctx_composition_to_json result.ctx_composition);

--- a/lib/keeper/keeper_unified_metrics_snapshot.mli
+++ b/lib/keeper/keeper_unified_metrics_snapshot.mli
@@ -16,7 +16,7 @@ val append_metrics_snapshot :
   message_count:int ->
   compaction:Keeper_exec_context.compaction_event ->
   handoff_json:Yojson.Safe.t option ->
-  ?provider_timeout_budget_json:Yojson.Safe.t ->
+  ?provider_timeout_plan_json:Yojson.Safe.t ->
   ?deliberation_execution:Keeper_deliberation.execution_result ->
   unit ->
   unit

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -140,7 +140,7 @@ let append_metrics_snapshot
       ~message_count:lifecycle.message_count
       ~compaction:lifecycle.compaction
       ~handoff_json:lifecycle.handoff_json
-      ?provider_timeout_budget_json:
+      ?provider_timeout_plan_json:
         (Option.map KCB.provider_timeout_budget_to_yojson last_provider_timeout_budget)
       ()
   with


### PR DESCRIPTION
## Summary
- rename the public metrics/dashboard payload from provider_timeout_budget to provider_timeout_plan
- keep the internal provider-timeout calculation intact while avoiding budget-as-state vocabulary in operator JSON
- update the unified metrics optional argument name to match the new public payload surface

## Validation
- Not run; user requested PR iteration without local validation.