### PR TITLE
fix(dashboard): drop timeout budget operational state alias

### DIFF
--- a/dashboard/src/lib/keeper-operational-state.test.ts
+++ b/dashboard/src/lib/keeper-operational-state.test.ts
@@ -199,18 +199,6 @@ describe('deriveKeeperOperationalState — stuck branch (RFC-0135 §1.1 root)', 
     })
   })
 
-  it('legacy timeout-budget blocker collapses to turn_timeout headline reason', () => {
-    const state = deriveKeeperOperationalState({
-      keeper: makeKeeper({ runtime_blocker_class: 'oas_timeout_budget' }),
-      composite: null,
-    })
-    expect(state).toMatchObject({
-      kind: 'stuck',
-      attention: 'clean',
-      reason: 'turn_timeout',
-    })
-  })
-
   it('fiber_alive=false ⇒ stuck reason=fiber_dead even without blocker', () => {
     const composite = makeComposite()
     ;(composite as unknown as { phase_diagnosis: unknown }).phase_diagnosis = {
@@ -233,8 +221,7 @@ describe('deriveKeeperOperationalState — stuck branch (RFC-0135 §1.1 root)', 
         keeper: makeKeeper({ runtime_blocker_class: cls as KeeperRuntimeBlockerClass }),
         composite: null,
       })
-      const expectedReason = cls === 'oas_timeout_budget' ? 'turn_timeout' : cls
-      expect(state.kind === 'stuck' && state.reason === expectedReason).toBe(true)
+      expect(state.kind === 'stuck' && state.reason === cls).toBe(true)
     }
   })
 })
@@ -370,27 +357,6 @@ describe('deriveKeeperOperationalState — priority invariants', () => {
       keeper: makeKeeper({
         phase: 'Running',
         runtime_blocker_class: 'turn_timeout',
-      }),
-      composite: makeComposite({
-        runtime_attention: attention({
-          execution_current: false,
-          stale_execution_receipt: true,
-        }),
-      }),
-    })
-    expect(state).toMatchObject({
-      kind: 'running',
-      attention: 'clean',
-      turnPhase: 'idle',
-      staleBlocker: 'turn_timeout',
-    })
-  })
-
-  it('legacy timeout-budget stale blocker collapses to turn_timeout context', () => {
-    const state = deriveKeeperOperationalState({
-      keeper: makeKeeper({
-        phase: 'Running',
-        runtime_blocker_class: 'oas_timeout_budget',
       }),
       composite: makeComposite({
         runtime_attention: attention({

--- a/dashboard/src/lib/keeper-operational-state.ts
+++ b/dashboard/src/lib/keeper-operational-state.ts
@@ -110,7 +110,7 @@ export interface DeriveInputs {
 function canonicalRuntimeBlockerClass(
   blockerClass: KeeperRuntimeBlockerClass | null,
 ): KeeperRuntimeBlockerClass | null {
-  if (blockerClass === 'oas_timeout_budget') return 'turn_timeout'
+  if (blockerClass === 'oas_timeout_budget') return null
   return blockerClass
 }
 

--- a/dashboard/src/lib/runtime-blocker-class.ts
+++ b/dashboard/src/lib/runtime-blocker-class.ts
@@ -27,12 +27,7 @@ export function asKeeperRuntimeBlockerClass(
 //
 // Backend can still decode these 24 lowercase wire strings (verified by
 // `Keeper_synthetic_marker` audit, 2026-05-19). The list below is the
-// *frozen* mirror — keep it 1:1 with `keeper_meta_contract.ml`.
-// Some entries are legacy compatibility surfaces rather than desired
-// new root-cause emissions; for example, `oas_timeout_budget` should be
-// projected to owner-specific timeout/admission/capacity causes before it
-// reaches operator copy.
-//
+// *frozen* mirror — keep it 1:1 with `keeper_meta_contract.ml`.//
 // Status bridge (`lib/keeper/keeper_status_bridge.ml`) emits two
 // additional dashboard-only synthetic classes (`synthetic_stall`,
 // `self_imposed_idle`) and the runtime trust pipeline emits
@@ -59,7 +54,6 @@ const BACKEND_KEEPER_META_BLOCKER_CLASSES = [
   'autonomous_slot_wait_timeout',
   'admission_queue_wait_timeout',
   'turn_timeout_after_queue_wait',
-  'oas_timeout_budget', // legacy decode/compat only; do not present as a new root cause
   'turn_timeout',
   'turn_livelock_blocked',
   'completion_contract_violation',

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -400,10 +400,6 @@ export const KEEPER_RUNTIME_BLOCKER_CLASSES = [
   'autonomous_slot_wait_timeout',
   'admission_queue_wait_timeout',
   'turn_timeout_after_queue_wait',
-  // Legacy wire compatibility only. Do not use this as a current runtime root
-  // cause or dashboard wakeup/action predicate; owner-specific timeout,
-  // admission, or capacity blockers must be emitted instead.
-  'oas_timeout_budget',
   'turn_timeout',
   // Emitted by `lib/keeper/keeper_meta_contract.ml:101` (Turn_livelock_blocked)
   // serialized via `blocker_class_to_string` → `"turn_livelock_blocked"`.


### PR DESCRIPTION
## Summary
- stop mapping dashboard runtime_blocker_class=oas_timeout_budget into turn_timeout operational state
- remove the legacy timeout-budget blocker from the dashboard runtime blocker class mirror
- drop tests that preserved timeout-budget as a valid dashboard-derived state surface

## Validation
- Not run; user requested PR iteration without local validation.