### PR TITLE
fix(dashboard): drop timeout budget alert aliases

### DIFF
--- a/dashboard/src/components/keeper-detail-alert-strip.test.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.test.ts
@@ -57,7 +57,7 @@ describe('KeeperRuntimeAlertStrip', () => {
         needs_attention: true,
         trust: {
           disposition: 'Alert',
-          attention_reason: 'timeout_budget_exhausted',
+          attention_reason: 'completion_contract_violation',
           execution_summary: {
             tool_contract_result: 'satisfied_execution',
           },
@@ -69,7 +69,7 @@ describe('KeeperRuntimeAlertStrip', () => {
     // Verdict failure is surfaced under a single "검증" label.
     expect(text).toContain('검증')
     expect(text).toContain('runtime_blocked')
-    expect(text).not.toContain('timeout_budget_exhausted')
+    expect(text).not.toContain('completion_contract_violation')
     // The tool contract success is preserved but tagged as scope
     // evidence ("도구 계약"), not as a sibling "증명" claim that would
     // read as the surface contradicting itself.
@@ -110,10 +110,10 @@ describe('KeeperRuntimeAlertStrip', () => {
     const { container } = render(h(KeeperRuntimeAlertStrip, {
       keeper: keeper({
         stop_cause: {
-          code: 'oas_timeout_budget',
+          code: 'turn_timeout',
           source: 'runtime_blocker_class',
-          label: 'OAS timeout budget',
-          summary: 'budget exhausted before turn completion',
+          label: 'Turn timeout',
+          summary: 'turn wall clock exceeded before completion',
         },
         trust: {
           execution_summary: {
@@ -129,9 +129,9 @@ describe('KeeperRuntimeAlertStrip', () => {
     // Per-turn stop cause is rendered through the canonical terminal code.
     expect(text).toContain('정지 원인')
     expect(text).toContain('turn_timeout')
-    expect(text).not.toContain('oas_timeout_budget')
+    expect(text).toContain('turn_timeout')
     // Per-attempt success is gated out so the strip no longer shows
-    // "런타임 레인 · completed" next to "정지 원인 · oas_timeout_budget".
+    // "런타임 레인 · completed" next to "정지 원인 · turn_timeout".
     expect(text).not.toContain('런타임 레인')
     expect(text).not.toContain('마지막 시도')
   })
@@ -169,8 +169,8 @@ describe('KeeperRuntimeAlertStrip', () => {
         needs_attention: true,
         attention_reason: 'paused',
         next_human_action: 'inspect_blocker_before_resume',
-        runtime_blocker_class: 'oas_timeout_budget',
-        runtime_blocker_summary: 'OAS budget timeout fired before the keeper hard timeout.',
+        runtime_blocker_class: 'turn_timeout',
+        runtime_blocker_summary: 'Turn timeout fired before resume.',
       }),
     }))
 

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -85,7 +85,6 @@ const ATTENTION_REASON_LABELS: Record<AttentionReason, string> = {
 }
 
 function canonicalAttentionReason(reason: string | null): string | null {
-  if (reason === 'timeout_budget_exhausted') return 'runtime_blocked'
   if (reason === 'cascade_attempts_exhausted') return 'runtime_blocked'
   if (reason === 'provider_tool_capability_missing') return 'runtime_blocked'
   if (reason === 'completion_contract_violation') return 'runtime_blocked'
@@ -185,14 +184,10 @@ function isAttentionPairDuplicate(reason: string | null, action: string | null):
 }
 
 function canonicalTerminalCode(code: string | null): string | null {
-  if (code === 'oas_timeout_budget') return 'turn_timeout'
   return code
 }
 
 function canonicalTerminalSummary(code: string | null, summary: string | null | undefined): string | null {
-  if (code === 'oas_timeout_budget') {
-    return '턴 실행 시간이 제한 시간을 초과했습니다.'
-  }
   return summary?.trim() || null
 }
 
@@ -266,10 +261,7 @@ function renderCascadeAttemptObservation(observation: CascadeAttemptObservation)
 }
 
 export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
-  const runtimeBlockerClass =
-    keeper.runtime_blocker_class === 'oas_timeout_budget'
-      ? 'turn_timeout'
-      : keeper.runtime_blocker_class
+  const runtimeBlockerClass = keeper.runtime_blocker_class
   const runtimeBlocker = keeperRuntimeBlockerHint(keeper)
   const continueGate = keeper.runtime_blocker_continue_gate === true
   const socialFallbackActive = keeper.social_model_recognized === false


### PR DESCRIPTION
## Summary
- stop canonicalizing timeout_budget_exhausted attention reasons into runtime_blocked in the alert strip
- stop canonicalizing oas_timeout_budget terminal/runtime blocker values into turn_timeout display state
- update alert-strip tests so they no longer preserve retired timeout-budget tokens as accepted dashboard inputs

## Validation
- Not run; user requested PR iteration without local validation.