### PR TITLE
[codex] fix keeper timeout build drift

### DIFF
--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -114,7 +114,6 @@ let keeper_attention_kind reason =
   | None -> "keeper_attention"
 
 let keeper_attention_severity ~reason ~runtime_blocker_class =
-  let reason = canonical_keeper_attention_reason reason in
   match reason, runtime_blocker_class with
   | Some "runtime_blocked", _
   | Some "provider_timeout", _
@@ -124,7 +123,6 @@ let keeper_attention_severity ~reason ~runtime_blocker_class =
 
 let keeper_attention_summary ~(meta : Keeper_types.keeper_meta) ~reason
     ~runtime_blocker_summary =
-  let reason = canonical_keeper_attention_reason reason in
   match reason, runtime_blocker_summary with
   | Some reason, Some summary ->
       Printf.sprintf "%s needs operator attention: %s (%s)" meta.name reason summary

--- a/test/test_agent_stress_emit_10341.ml
+++ b/test/test_agent_stress_emit_10341.ml
@@ -39,7 +39,13 @@ let opt_kind = testable
           Fmt.string fmt "Some Fallback_approval"
       | Some Agent_stress.Task_released -> Fmt.string fmt "Some Task_released"
       | Some (Agent_stress.Turn_failure _) ->
-          Fmt.string fmt "Some Turn_failure")
+          Fmt.string fmt "Some Turn_failure"
+      | Some Agent_stress.Provider_timeout ->
+          Fmt.string fmt "Some Provider_timeout"
+      | Some Agent_stress.Capacity_pressure ->
+          Fmt.string fmt "Some Capacity_pressure"
+      | Some Agent_stress.Turn_liveness ->
+          Fmt.string fmt "Some Turn_liveness")
     (fun a b ->
        match (a, b) with
        | None, None -> true

--- a/test/test_keeper_cascade_auto_pause_task074.ml
+++ b/test/test_keeper_cascade_auto_pause_task074.ml
@@ -108,7 +108,7 @@ let mk_required_tool_contract_violation () =
        })
 
 let test_pause_does_not_fire_on_transient () =
-  check bool "Oas_timeout_budget -> no pause" false
+  check bool "Provider_timeout -> no pause" false
     (EC.is_cascade_exhausted_error (mk_oas_timeout_budget ()));
   check bool "Turn_timeout -> no pause" false
     (EC.is_cascade_exhausted_error (mk_turn_timeout ()));

--- a/test/test_keeper_turn_disposition.ml
+++ b/test/test_keeper_turn_disposition.ml
@@ -106,8 +106,8 @@ let test_canonical_next_action_byte_compat () =
          match wire, legacy.next_action with
          | ("turn_wall_clock_timeout" | "oas_timeout_budget"), _ ->
            "Some:inspect_turn_timeout"
-         | Some s -> "Some:" ^ s
-         | None -> "None"
+         | _, Some s -> "Some:" ^ s
+         | _, None -> "None"
        in
        let actual =
          match D.next_action disp with


### PR DESCRIPTION
## Summary
- update keeper timeout-related test expectations for the current timeout/error variants
- complete the agent stress test printer match for new stress kinds
- remove stale operator digest calls to the deleted timeout attention canonicalizer

## Root cause
Recent timeout taxonomy and operator attention changes landed partially across tests and `operator_digest`: tests still referenced retired constructors/record shapes, and `operator_digest` kept calls to a helper removed by the timeout-budget attention cleanup.

## Validation
- `ocamlformat --check lib/operator/operator_digest.ml test/test_dashboard_goals.ml test/test_keeper_cascade_auto_pause_task074.ml test/test_keeper_failure_policy.ml test/test_agent_stress_emit_10341.ml test/test_keeper_turn_disposition.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_dashboard_goals.exe test/test_keeper_cascade_auto_pause_task074.exe test/test_keeper_failure_policy.exe test/test_agent_stress_emit_10341.exe test/test_keeper_turn_disposition.exe`

Note: a post-rebase broad `scripts/dune-local.sh build` attempt was blocked by recurring external bare `dune` processes from another worktree, so the PR records the focused wrapper build that covers the failing surfaces.