### PR TITLE
refactor(keeper_cascade_profile): RFC-0143 closeout — delete legacy catalog_metadata_result

### DIFF
--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -370,25 +370,13 @@ let catalog_metadata_of_materialized_json json =
       fallback_hints;
     }
 
-let catalog_metadata_result ?config_path () =
-  let path_opt =
-    match config_path with
-    | Some path -> Some path
-    | None -> Config_dir_resolver.cascade_path_opt ()
-  in
-  match path_opt with
-  | None -> Error "cascade catalog path is not resolved"
-  | Some path -> (
-      match Cascade_config_loader.load_catalog_source_for_diagnostics path with
-      | Error msg -> Error ("declarative cascade catalog invalid: " ^ msg)
-      | Ok json -> catalog_metadata_of_materialized_json json)
-
-(* RFC-0143 Phase 1 bridge.
+(* RFC-0143 typed catalog metadata query.
 
    Distinguishes the three control-flow origins of an unavailable
-   catalog so callers (PR-2..PR-4) can decide what to do about each
-   without grepping the error string. The three branches mirror the
-   three Error sites in [catalog_metadata_result] above. *)
+   catalog so callers can decide what to do about each without
+   grepping an error string.  Replaces the legacy string-error
+   [catalog_metadata_result] which was deleted by the §4 PR-5
+   closeout once all callers consumed this typed variant. *)
 type catalog_unavailable_reason =
   | Catalog_path_not_resolved
       (** The config-dir resolver returned no cascade.toml path.
@@ -415,12 +403,6 @@ let catalog_unavailable_reason_to_string = function
   | Catalog_metadata_invalid _ -> "metadata_invalid"
 ;;
 
-(* Bridge: typed query alongside the legacy string-error
-   [catalog_metadata_result]. PR-1 of RFC-0143 introduces this
-   without migrating any callers. PR-2..PR-4 migrate the six
-   internal call sites (lines 399/408/413/433/494/489 in the
-   pre-migration file) one batch at a time; PR-5 deletes the
-   legacy [catalog_metadata_result] once no callers remain. *)
 let catalog_metadata_query ?config_path () =
   let path_opt =
     match config_path with

--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -459,23 +459,27 @@ let normalized_query_name ?config_path raw =
 let is_system_only_cascade raw =
   let routed = routed_query_target raw |> String.trim in
   let public_name = public_name_of_target routed in
-  match catalog_metadata_result () with
-  | Ok meta ->
+  (* RFC-0143 PR-2 — typed catalog query. *)
+  match catalog_metadata_query () with
+  | Catalog_ok meta ->
       if is_qualified_profile_name routed then
         List.mem routed meta.system_qualified_names
       else
         List.mem public_name meta.system_names
-  | Error _ -> false
+  | Catalog_unavailable _ -> false
 
 let keeper_catalog_names ?config_path () =
-  match catalog_metadata_result ?config_path () with
-  | Ok meta -> meta.keeper_assignable_names
-  | Error _ -> catalog_names ?config_path ()
+  (* RFC-0143 PR-2 — typed catalog query.  On [Catalog_unavailable]
+     fall back to the plain catalog name list. *)
+  match catalog_metadata_query ?config_path () with
+  | Catalog_ok meta -> meta.keeper_assignable_names
+  | Catalog_unavailable _ -> catalog_names ?config_path ()
 
 let system_catalog_names ?config_path () =
-  match catalog_metadata_result ?config_path () with
-  | Ok meta -> meta.system_names
-  | Error _ -> []
+  (* RFC-0143 PR-2 — typed catalog query. *)
+  match catalog_metadata_query ?config_path () with
+  | Catalog_ok meta -> meta.system_names
+  | Catalog_unavailable _ -> []
 
 (** Track which (cascade, target) pairs we have already logged as
     invalid fallback hints so the WARN line fires once per process. *)
@@ -486,9 +490,10 @@ let fallback_cascade_for ?config_path name =
   let public_name = normalized_query_name ?config_path name in
   if String.equal public_name "" then None
   else
-    match catalog_metadata_result ?config_path () with
-    | Error _ -> None
-    | Ok meta -> (
+    (* RFC-0143 PR-2 — typed catalog query. *)
+    match catalog_metadata_query ?config_path () with
+    | Catalog_unavailable _ -> None
+    | Catalog_ok meta -> (
         let qualified_name =
           let routed = routed_query_target ?config_path name |> String.trim in
           if is_qualified_profile_name routed
@@ -547,9 +552,10 @@ let normalize_keeper_runtime_declared_name ?config_path raw =
   let normalized = normalize_declared_name raw in
   let public_name = public_name_of_target normalized in
   let explicitly_keeper_assignable =
-    match catalog_metadata_result ?config_path () with
-    | Ok meta -> List.mem normalized meta.keeper_assignable_names
-    | Error _ -> false
+    (* RFC-0143 PR-2 — typed catalog query. *)
+    match catalog_metadata_query ?config_path () with
+    | Catalog_ok meta -> List.mem normalized meta.keeper_assignable_names
+    | Catalog_unavailable _ -> false
   in
   let keeper_route_targets =
     keeper_runtime_route_uses

--- a/lib/keeper/keeper_cascade_profile.mli
+++ b/lib/keeper/keeper_cascade_profile.mli
@@ -168,21 +168,18 @@ val models_key : string -> string
 val temperature_key : string -> string
 val max_tokens_key : string -> string
 
-(** {1 RFC-0143 Phase 1 — typed catalog query bridge}
+(** {1 RFC-0143 — typed catalog query}
 
     Distinguishes the three control-flow origins of an unavailable
     catalog so callers can decide what to do about each instead of
     collapsing them into [Error _ -> false] / [Error _ -> []].
 
-    The bridge runs alongside the legacy [catalog_metadata_result]
-    (a [('a, string) result]) so call sites can migrate in batches.
-    Per RFC-0143 §4, the legacy API is removed in PR-5 once no
-    callers remain. *)
+    The legacy string-error [catalog_metadata_result] was deleted by
+    the §4 PR-5 closeout once all in-file callers consumed the typed
+    variant. *)
 
-(** Catalog metadata record returned by the bridge. Mirrors the
-    fields the legacy [catalog_metadata_result] already returned;
-    exposed here so the typed query is callable from outside the
-    module. *)
+(** Catalog metadata record returned by the query.  Exposed here so
+    the typed query is callable from outside the module. *)
 type catalog_metadata = {
   qualified_names : string list;
   public_names : string list;
@@ -212,7 +209,7 @@ val catalog_metadata_query
   :  ?config_path:string
   -> unit
   -> catalog_metadata catalog_query_result
-(** Typed alternative to [catalog_metadata_result]. The
-    [Catalog_unavailable] payload carries both the typed [reason]
-    (suitable for routing logic and metric labels) and the original
-    [message] (suitable for operator-facing logs). *)
+(** Typed catalog metadata accessor.  The [Catalog_unavailable]
+    payload carries both the typed [reason] (suitable for routing
+    logic and metric labels) and the original [message] (suitable
+    for operator-facing logs). *)

--- a/test/test_keeper_cascade_profile_bridge.ml
+++ b/test/test_keeper_cascade_profile_bridge.ml
@@ -1,8 +1,9 @@
 (** test_keeper_cascade_profile_bridge — Unit tests for the
-    [catalog_metadata_query] typed bridge.
+    [catalog_metadata_query] typed catalog accessor.
 
-    The bridge has three control-flow origins, mirroring the three
-    [Error] sites in the legacy [catalog_metadata_result]:
+    The query has three control-flow origins (the legacy
+    string-error [catalog_metadata_result] was deleted by the
+    RFC-0143 §4 PR-5 closeout):
 
     {ul
     {- [Catalog_path_not_resolved] — the resolver returned [None].}


### PR DESCRIPTION
## Goal

Close out RFC-0143 by deleting the legacy `catalog_metadata_result` function once PR-2 (#17814) has drained the last in-file caller.

## Verification of "zero callers" precondition

```
$ grep -rn 'catalog_metadata_result\b' lib/ test/ dashboard/src
lib/keeper/keeper_cascade_profile.ml:373:let catalog_metadata_result ...   ← the function being deleted
lib/keeper/keeper_cascade_profile.mli:177:    The bridge runs alongside the legacy [catalog_metadata_result]
lib/keeper/keeper_cascade_profile.mli:183:    fields the legacy [catalog_metadata_result] already returned;
lib/keeper/keeper_cascade_profile.mli:215:(** Typed alternative to [catalog_metadata_result]. The
test/test_keeper_cascade_profile_bridge.ml:5:    [Error] sites in the legacy [catalog_metadata_result]:
```

Only the function's own definition + four doc-comment references remain — no live call sites.

## Change

* `lib/keeper/keeper_cascade_profile.ml`
  * Delete the `catalog_metadata_result` function body.
  * Reword the "Phase 1 bridge" doc-comment block — now the sole catalog accessor.
* `lib/keeper/keeper_cascade_profile.mli`
  * Same wording cleanup on the public-interface doc-comments that referenced the legacy function.
* `test/test_keeper_cascade_profile_bridge.ml`
  * Head-comment wording cleanup.

`catalog_metadata_result` was a private function (never declared in the `.mli`), so the deletion is internal-only and does not affect any external consumer.

## Stack context

| Phase | PR | Status |
|-------|-----|--------|
| PR-1 (bridge) | #16860 | MERGED |
| PR-2 (self-migration) | #17814 | Draft (this PR stacks on) |
| **PR-5 / closeout** (legacy deletion) | **this** | Draft |
| PR-3/4 | (cancelled) | The original RFC body listed 8 external files for PR-3 and 5 for PR-4 — none of them actually call `catalog_metadata_result`.  Verified by `grep -rn` outside `keeper_cascade_profile`.  RFC-0143 §Pending is therefore moot for the legacy function deletion; the remaining work is the ratchet regeneration mentioned in PR-5. |

## Verification

* `dune build --root . lib/` → pass.

Test executable build is currently red on `origin/main` due to **unrelated** breakage that predates this diff:
* `test/test_keeper_memory.ml:1809` — `Keeper_memory_policy` unqualified reference introduced by #17786 (timed compaction_source variant); fix in flight via #17808.
* `test/test_keeper_turn_disposition.ml:109` — `Provider_timeout` constructor drift from the codex cascade-timeout PR family.

Neither file is touched by this diff.

## Anti-pattern self-check

- §1 telemetry-as-fix? No — the typed `Catalog_unavailable` variant is the operator surface; no counter added.
- §2 substring classifier? No — `catalog_unavailable_reason` is a closed 3-arm sum.
- §3 N-of-M? **Closed** — every internal call site migrated by PR-2; the closeout deletes the now-dead function in the canonical single PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>