### PR TITLE
fix(test/operator): unblock test exe build after codex partial sweeps

### DIFF
--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -114,7 +114,6 @@ let keeper_attention_kind reason =
   | None -> "keeper_attention"
 
 let keeper_attention_severity ~reason ~runtime_blocker_class =
-  let reason = canonical_keeper_attention_reason reason in
   match reason, runtime_blocker_class with
   | Some "runtime_blocked", _
   | Some "provider_timeout", _
@@ -124,7 +123,6 @@ let keeper_attention_severity ~reason ~runtime_blocker_class =
 
 let keeper_attention_summary ~(meta : Keeper_types.keeper_meta) ~reason
     ~runtime_blocker_summary =
-  let reason = canonical_keeper_attention_reason reason in
   match reason, runtime_blocker_summary with
   | Some reason, Some summary ->
       Printf.sprintf "%s needs operator attention: %s (%s)" meta.name reason summary

--- a/test/test_keeper_turn_disposition.ml
+++ b/test/test_keeper_turn_disposition.ml
@@ -106,8 +106,8 @@ let test_canonical_next_action_byte_compat () =
          match wire, legacy.next_action with
          | ("turn_wall_clock_timeout" | "oas_timeout_budget"), _ ->
            "Some:inspect_turn_timeout"
-         | Some s -> "Some:" ^ s
-         | None -> "None"
+         | _, Some s -> "Some:" ^ s
+         | _, None -> "None"
        in
        let actual =
          match D.next_action disp with


### PR DESCRIPTION
## Goal

Restore `dune build test/test_keeper_turn_disposition.exe` (and the rest of `test/`) by fixing two unrelated codex partial-sweep regressions blocking the test executable build on `origin/main`.

## Two fixes in this PR

### 1. `lib/operator/operator_digest.ml`

#17810 ("drop timeout budget attention suppressor") deleted `canonical_keeper_attention_reason` and updated one call site (`keeper_attention_kind`, line 113) to `match reason with`.  Two other call sites at lines 117 and 127 (`keeper_attention_severity` and `keeper_attention_summary`) still ran:

```ocaml
let reason = canonical_keeper_attention_reason reason in
```

which now fails to compile with `Unbound value`.

```diff
 let keeper_attention_severity ~reason ~runtime_blocker_class =
-  let reason = canonical_keeper_attention_reason reason in
   match reason, runtime_blocker_class with
```

The semantic effect of the suppressor (mapping `Some "timeout_budget_exhausted"` to `None`) is what #17810 intentionally dropped per its commit subject.

### 2. `test/test_keeper_turn_disposition.ml`

#17682 ("replace timeout budget disposition action") changed the match scrutinee from `legacy.next_action` to a tuple `(wire, legacy.next_action)` and added a tuple-shaped arm at the top, but left two subsequent arms in single-scrutinee shape (`| Some s -> …` / `| None -> …`), which is a type error against the tuple.

```diff
       let expected =
         match wire, legacy.next_action with
         | ("turn_wall_clock_timeout" | "oas_timeout_budget"), _ ->
           "Some:inspect_turn_timeout"
-        | Some s -> "Some:" ^ s
-        | None -> "None"
+        | _, Some s -> "Some:" ^ s
+        | _, None -> "None"
       in
```

## Out of scope — pre-existing test logic failures

After this PR, `test_keeper_turn_disposition.exe` runs and surfaces **2 pre-existing logic failures**:

```
[FAIL] severity[oas_timeout_budget]   — Expected "bad", Received "warn"
[FAIL] summary[oas_timeout_budget]    — same shape
```

These come from #17710 (`collapse timeout budget turn disposition`) remapping `D.Oas_timeout_budget` to `D.Turn_wall_clock_timeout` without updating the `Legacy` oracle.  The legacy oracle still classifies the `oas_timeout_budget` wire as severity `bad`, while the new disposition collapses to `Turn_wall_clock_timeout` which classifies as `warn`.  Fixing the byte-compat invariant requires deciding whether the legacy oracle should follow the collapse — that's a codex / RFC-level decision and **not in scope for this compile unblock**.

## Verification

* `dune build --root . lib/` → pass.
* `dune build --root . test/test_keeper_turn_disposition.exe` → pass.
* `_build/default/test/test_keeper_turn_disposition.exe` → 7 / 9 pass (was **0 / 9** with the compile failure on `origin/main`; the remaining 2 failures are the documented `oas_timeout_budget` byte-compat regressions).

## Stack context

Independent compile-unblock PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>