### PR TITLE
fix(doctor): detect keeper internal tool drift

### DIFF
--- a/lib/config_doctor.ml
+++ b/lib/config_doctor.ml
@@ -565,6 +565,81 @@ let provider_forced_tool_rejection_label provider_cfg =
   | Some reason -> Provider_tool_support.rejection_reason_label reason
   | None -> "passes"
 
+let doctor_keeper_agent_name = Keeper_types.keeper_agent_name "config-doctor"
+let required_keeper_internal_tool_name = "keeper_bash"
+
+let required_keeper_internal_tool : Agent_sdk.Tool.t =
+  Agent_sdk.Tool.create
+    ~name:required_keeper_internal_tool_name
+    ~description:"config doctor required keeper internal tool probe"
+    ~parameters:[]
+    (fun _input -> Ok { content = "ok" })
+
+let provider_required_keeper_internal_tool_issue provider_cfg =
+  let resolved =
+    try
+      Cascade_runner.resolve_tool_lane_for_oas_tools
+        ~agent_name:doctor_keeper_agent_name
+        ~tool_requirement:`Required
+        ~provider_cfg
+        ~tools:[ required_keeper_internal_tool ]
+        ()
+    with
+    | Env_config_core.Config_error detail ->
+        Error
+          (Agent_sdk.Error.Config
+             (Agent_sdk.Error.InvalidConfig
+                { field = "runtime_mcp_policy"; detail }))
+  in
+  match resolved with
+  | Error err -> Some (Agent_sdk.Error.to_string err)
+  | Ok (effective_tools, runtime_mcp_policy) ->
+      let materialized_tool_names =
+        Keeper_turn_driver_helpers.materialized_tool_names_after_lane
+          ~effective_tools
+          ~runtime_mcp_policy
+      in
+      let missing_required_tools =
+        Keeper_turn_driver_helpers.missing_required_tool_names_after_lane_by_name
+          ~required_tool_names:[ required_keeper_internal_tool_name ]
+          ~materialized_tool_names
+      in
+      if missing_required_tools = []
+      then None
+      else
+        Some
+          (Printf.sprintf
+             "missing_required_tools=[%s] materialized_tools=[%s]"
+             (String.concat ", " missing_required_tools)
+             (String.concat ", " materialized_tool_names))
+
+let keeper_internal_tool_route_issue route_key target candidates =
+  let rejections =
+    candidates
+    |> List.filter_map (fun provider_cfg ->
+           provider_required_keeper_internal_tool_issue provider_cfg
+           |> Option.map (fun reason ->
+                  Printf.sprintf
+                    "%s:%s"
+                    (Provider_tool_support.provider_debug_label provider_cfg)
+                    reason))
+  in
+  if List.length rejections <> List.length candidates
+  then None
+  else
+    Some
+      (Printf.sprintf
+         "Tool-required cascade route %s targets %s, but none of its %d \
+          provider candidate(s) materialize required keeper internal tool %s \
+          for a keeper agent. rejected=[%s]. Keeper turns that require %s \
+          will fail with no_tool_capable_provider."
+         route_key
+         target
+         (List.length candidates)
+         required_keeper_internal_tool_name
+         (String.concat ", " rejections)
+         required_keeper_internal_tool_name)
+
 let forced_tool_route_issue
     (snapshot : Cascade_catalog_runtime.snapshot)
     (use : Cascade_routes.logical_use)
@@ -608,14 +683,13 @@ let forced_tool_route_issue
                   will fail with no_tool_capable_provider."
                  route_key target)
           else if
-            List.exists
-              (Provider_tool_support.supports_required_tool_use
-                 ~require_tool_choice_support:true
-                 ~require_tool_support:true)
-              candidates
+            not
+              (List.exists
+                 (Provider_tool_support.supports_required_tool_use
+                    ~require_tool_choice_support:true
+                    ~require_tool_support:true)
+                 candidates)
           then
-            None
-          else
             let rejected =
               candidates
               |> List.map (fun provider_cfg ->
@@ -632,7 +706,9 @@ let forced_tool_route_issue
                   (needs inline tool_choice or runtime MCP). rejected=[%s]. \
                   Keeper turns that require tools will fail with \
                   no_tool_capable_provider."
-                 route_key target (List.length candidates) rejected))
+                 route_key target (List.length candidates) rejected)
+          else
+            keeper_internal_tool_route_issue route_key target candidates)
 
 let forced_tool_route_issues live_state_result =
   match live_catalog_snapshot live_state_result with

--- a/test/test_config_doctor.ml
+++ b/test/test_config_doctor.ml
@@ -40,6 +40,13 @@ let write_file path content =
   mkdir_p (Filename.dirname path);
   Out_channel.with_open_bin path (fun oc -> output_string oc content)
 
+let write_per_keeper_token ~base_path ~agent_name ~token =
+  write_file
+    (Filename.concat
+       (Filename.concat base_path ".masc/auth")
+       (agent_name ^ ".token"))
+    token
+
 let minimal_live_cascade_toml =
   {|
 [providers.ollama]
@@ -325,7 +332,14 @@ target = "tier-group.glm-coding-with-spark"
 target = "tier-group.glm-coding-with-spark"
 |}
     config_root;
+  write_per_keeper_token
+    ~base_path
+    ~agent_name:(Keeper_types.keeper_agent_name "config-doctor")
+    ~token:"doctor-test-token";
   with_config_dir config_root @@ fun () ->
+  with_env "MASC_BASE_PATH" base_path @@ fun () ->
+  with_env "MASC_INTERNAL_MCP_TOKEN" "doctor-internal-token" @@ fun () ->
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8931" @@ fun () ->
   with_env "OPENAI_API_KEY" "test" @@ fun () ->
   with_fake_docker fake_docker_missing_image_script @@ fun () ->
   with_env "MASC_CONFIG_DIR" config_root @@ fun () ->
@@ -443,6 +457,81 @@ target = "tier-group.glm-coding-with-spark"
        ~needle:"Route keeper_turn/tool_required to at least one provider"
        report.next_actions)
 
+let test_analyze_live_errors_on_keeper_internal_tool_not_materialized () =
+  with_temp_dir "config-doctor-keeper-internal-tool" @@ fun dir ->
+  let base_path = Filename.concat dir "base" in
+  let config_root = Filename.concat base_path ".masc/config" in
+  initialize_config_root
+    ~cascade_toml:{|[providers.codex_cli]
+display-name = "OpenAI Codex CLI"
+protocol = "openai-http"
+command = "codex"
+is-non-interactive = true
+
+[providers.codex_cli.credentials]
+type = "env"
+key = "OPENAI_API_KEY"
+
+[providers.codex_cli.capabilities]
+requires-per-keeper-bridging-for-bound-actor-tools = true
+identity-runtime-mcp-header-keys = ["x-masc-agent-name", "x-masc-keeper-name"]
+
+[models.codex-spark]
+api-name = "gpt-5.3-codex-spark"
+max-context = 128000
+tools-support = true
+streaming = true
+
+[models.codex-spark.capabilities]
+supports-native-streaming = true
+supports-response-format-json = true
+
+[codex_cli.codex-spark]
+is-default = true
+max-concurrent = 1
+
+[tier.codex-primary]
+members = ["codex_cli.codex-spark"]
+strategy = "failover"
+
+[tier-group.strict_tool_candidates]
+tiers = ["codex-primary"]
+strategy = "priority_tier"
+fallback = false
+
+[routes.keeper_turn]
+target = "tier-group.strict_tool_candidates"
+
+[routes.tool_required]
+target = "tier-group.strict_tool_candidates"
+|}
+    config_root;
+  with_config_dir config_root @@ fun () ->
+  with_env "MASC_BASE_PATH" base_path @@ fun () ->
+  with_env "OPENAI_API_KEY" "test" @@ fun () ->
+  with_env "MASC_KEEPER_SANDBOX_PREFLIGHT_ENABLED" "false" @@ fun () ->
+  with_eio @@ fun ~sw ~net ~clock ~fs ~proc_mgr ->
+  let report =
+    Config_doctor.analyze_live
+      ~sw ~net ~clock ~fs ~proc_mgr
+      ~base_path_input:base_path
+      ~default_base_path:base_path
+      ()
+  in
+  check string "status escalates to error" "error" (status report.status);
+  check bool "keeper internal tool materialization warning present" true
+    (list_contains_substring
+       ~needle:"materialize required keeper internal tool keeper_bash"
+       report.warnings);
+  check bool "no-tool terminal hint present" true
+    (list_contains_substring
+       ~needle:"no_tool_capable_provider"
+       report.warnings);
+  check bool "next action points at tool-capable route" true
+    (list_contains_substring
+       ~needle:"Route keeper_turn/tool_required to at least one provider"
+       report.next_actions)
+
 let () =
   run "config_doctor"
     [
@@ -465,5 +554,8 @@ let () =
            test_case "analyze_live errors on tool-required route without forced tool provider"
              `Quick
              test_analyze_live_errors_on_tool_required_route_without_forced_tool_provider;
+           test_case "analyze_live errors when keeper internal tool is not materialized"
+             `Quick
+             test_analyze_live_errors_on_keeper_internal_tool_not_materialized;
          ]);
     ]


### PR DESCRIPTION
## Summary
- teach `masc-mcp doctor config` to probe tool-required routes for keeper-internal `keeper_bash` materialization
- report `no_tool_capable_provider` when all route candidates pass generic required-tool support but cannot materialize required keeper-internal tools
- add config doctor regression coverage and keep the sandbox preflight fixture isolated with fake auth/runtime URL env

## Validation
- PASS: `ocamlformat --check lib/config_doctor.ml test/test_config_doctor.ml`
- PASS: `git diff --check origin/main..HEAD`
- PASS before current main moved: `scripts/dune-local.sh build test/test_config_doctor.exe`
- PASS before current main moved: `./_build/default/test/test_config_doctor.exe`
- PASS before current main moved: `scripts/dune-local.sh build test/test_keeper_runtime_manifest.exe`
- PASS before current main moved: `./_build/default/test/test_keeper_runtime_manifest.exe test wiring 4`
- BLOCKED on current `origin/main`: `scripts/dune-local.sh build test/test_config_doctor.exe` fails before this patch in `lib/operator/operator_digest.ml` with unbound `canonical_keeper_attention_reason`; that compile unblock is already draft PR #17821.