### PR TITLE
fix(dashboard): drop timeout budget runtime display alias

### DIFF
--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -207,7 +207,6 @@ const runtimeBlockerLabels = {
   autonomous_slot_wait_timeout: '자율 슬롯 대기 만료',
   admission_queue_wait_timeout: '대기열 진입 만료',
   turn_timeout_after_queue_wait: '대기 후 턴 만료',
-  oas_timeout_budget: '턴 응답 만료',
   turn_timeout: '턴 응답 만료',
   turn_livelock_blocked: '턴 livelock 차단',
   completion_contract_violation: '완료 계약 위반',
@@ -243,8 +242,7 @@ export function keeperRuntimeBlockerLabel(
   blockerClass: Keeper['runtime_blocker_class'] | null | undefined,
 ): string | null {
   if (!blockerClass) return null
-  const canonicalBlockerClass = blockerClass === 'oas_timeout_budget' ? 'turn_timeout' : blockerClass
-  return runtimeBlockerLabels[canonicalBlockerClass] ?? null
+  return runtimeBlockerLabels[blockerClass] ?? null
 }
 
 export function keeperRuntimeBlockerHint(keeper: Keeper | null | undefined): string | null {
@@ -252,7 +250,7 @@ export function keeperRuntimeBlockerHint(keeper: Keeper | null | undefined): str
   if (keeper.runtime_blocker_continue_gate) return continueGateHint(keeper)
   const blockerClass = keeper.runtime_blocker_class
   const runtimeBlocker = keeper.runtime_blocker_summary?.trim()
-  if (runtimeBlocker && runtimeBlocker !== blockerClass && blockerClass !== 'oas_timeout_budget') {
+  if (runtimeBlocker && runtimeBlocker !== blockerClass) {
     return runtimeBlocker
   }
   if (blockerClass === 'ambiguous_post_commit_timeout') {
@@ -269,9 +267,6 @@ export function keeperRuntimeBlockerHint(keeper: Keeper | null | undefined): str
   }
   if (blockerClass === 'turn_timeout_after_queue_wait') {
     return '대기 후 실행된 턴이 전체 제한 시간을 초과했습니다.'
-  }
-  if (blockerClass === 'oas_timeout_budget') {
-    return '턴 실행 시간이 제한 시간을 초과했습니다.'
   }
   if (blockerClass === 'turn_timeout') {
     return '턴 실행 시간이 제한 시간을 초과했습니다.'


### PR DESCRIPTION
## Summary
- remove the dashboard runtime-display label for retired oas_timeout_budget blocker values
- stop canonicalizing oas_timeout_budget into turn_timeout before rendering runtime blocker labels
- stop hiding timeout-budget summaries behind the generic turn-timeout hint path

## Validation
- Not run; user requested PR iteration without local validation.