### PR TITLE
fix(dashboard): drop timeout budget wakeup test alias

### DIFF
--- a/dashboard/src/lib/keeper-predicates.test.ts
+++ b/dashboard/src/lib/keeper-predicates.test.ts
@@ -102,7 +102,7 @@ describe('isCrashedPhase — SSE-safe casing checker', () => {
 
 describe('keeperIsStuckOnRecoverableBlocker', () => {
   it.each([
-    ['cascade_exhausted'], ['oas_timeout_budget'], ['turn_timeout'],
+    ['cascade_exhausted'], ['turn_timeout'],
   ])('blocker_class=%s ⇒ stuck-recoverable', (cls) => {
     expect(keeperIsStuckOnRecoverableBlocker(k({ runtime_blocker_class: cls as Keeper['runtime_blocker_class'] }))).toBe(true)
   })
@@ -115,8 +115,11 @@ describe('keeperIsStuckOnRecoverableBlocker', () => {
 })
 
 describe('keeperCanWakeup', () => {
-  it('stuck on recoverable blocker ⇒ can wake', () => {
-    expect(keeperCanWakeup(k({ runtime_blocker_class: 'oas_timeout_budget' }))).toBe(true)
+  it('stuck on canonical recoverable blocker ⇒ can wake', () => {
+    expect(keeperCanWakeup(k({ runtime_blocker_class: 'turn_timeout' }))).toBe(true)
+  })
+  it('legacy timeout-budget blocker ⇒ cannot wake', () => {
+    expect(keeperCanWakeup(k({ runtime_blocker_class: 'oas_timeout_budget' as Keeper['runtime_blocker_class'] }))).toBe(false)
   })
   it('plain running keeper ⇒ can wake (kick next turn)', () => {
     expect(keeperCanWakeup(k({ phase: 'Running' }))).toBe(true)


### PR DESCRIPTION
## Summary
- remove the dashboard predicate test expectation that oas_timeout_budget is a wakeup-recoverable blocker
- keep wakeup recovery tests focused on canonical cascade_exhausted and turn_timeout blockers
- add explicit coverage that retired timeout-budget blocker input does not authorize wakeup

## Validation
- Not run; user requested PR iteration without local validation.