### PR TITLE
test(keeper): add Error-path tests for read_memory_horizon_counts_result + read_recent_memory_texts_result

### DIFF
--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -541,6 +541,54 @@ module Coord = Masc_mcp.Coord
 let make_test_room_config dir =
   Coord.default_config dir
 
+(* RFC-0149 §3.1: typed Error path for the horizon-counts reader.
+   A keeper whose memory.jsonl path resolves to a directory (which
+   [read_file_tail_lines] cannot tail) must surface as
+   [Error io_error] rather than collapsing to [Ok []]
+   indistinguishable from "no rows recorded". *)
+let test_read_memory_horizon_counts_result_error_on_directory_path () =
+  let dir = test_tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
+    let config = make_test_room_config dir in
+    let memory_path = Keeper_types.keeper_memory_bank_path config "bad-keeper" in
+    (* Pre-create the parent directory structure, then a *directory*
+       (not a file) at the memory.jsonl path. *)
+    let parent = Filename.dirname memory_path in
+    (try Unix.mkdir parent 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+    Unix.mkdir memory_path 0o755;
+    match
+      Keeper_memory_recall.read_memory_horizon_counts_result config
+        ~name:"bad-keeper" ~max_bytes:100000 ~max_lines:100
+    with
+    | Ok _ ->
+      fail "expected Error io_error when memory.jsonl path is a directory"
+    | Error exn_class ->
+      check string "Error label is io_error"
+        "io_error"
+        (Keeper_memory_recall_exn_class.to_label exn_class))
+
+(* RFC-0149 §3.1: typed Error path for the recent-memory-texts reader. *)
+let test_read_recent_memory_texts_result_error_on_directory_path () =
+  let dir = test_tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
+    let config = make_test_room_config dir in
+    let memory_path = Keeper_types.keeper_memory_bank_path config "bad-keeper" in
+    let parent = Filename.dirname memory_path in
+    (try Unix.mkdir parent 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+    Unix.mkdir memory_path 0o755;
+    match
+      Keeper_memory_recall.read_recent_memory_texts_result config
+        ~name:"bad-keeper"
+        ~horizon:Masc_mcp.Keeper_memory_policy.long_term_horizon
+        ~max_bytes:100000 ~max_lines:100 ~limit:5
+    with
+    | Ok _ ->
+      fail "expected Error io_error when memory.jsonl path is a directory"
+    | Error exn_class ->
+      check string "Error label is io_error"
+        "io_error"
+        (Keeper_memory_recall_exn_class.to_label exn_class))
+
 (** E2E: write memory via append_memory_notes_from_reply, then read back via recall.
     Tests the full pipeline: reply → parse → snapshot → candidates → JSONL → recall.
     This is the test that was missing (RFC #3646 I1). *)
@@ -1915,6 +1963,10 @@ let () =
             test_load_history_user_messages_ignores_internal_prompt_entries;
           test_case "load_history_user_messages_result Error on directory path" `Quick
             test_load_history_user_messages_result_error_on_directory_path;
+          test_case "read_memory_horizon_counts_result Error on directory path" `Quick
+            test_read_memory_horizon_counts_result_error_on_directory_path;
+          test_case "read_recent_memory_texts_result Error on directory path" `Quick
+            test_read_recent_memory_texts_result_error_on_directory_path;
           test_case "read_file_tail_lines reads tail without byte cap" `Quick
             test_read_file_tail_lines_reads_tail_without_byte_cap;
           test_case "read_file_tail_lines drops partial byte-cap line" `Quick


### PR DESCRIPTION
## Goal

Close the symmetry gap in the §3.1 Error-path test coverage.

PR-9 (#17754) added Result-returning variants for **three** memory recall readers:

| Function | Error-path test before this PR |
|----------|--------------------------------|
| `load_history_user_messages_result` | ✅ #17762 / #17808 |
| `read_memory_horizon_counts_result` | ❌ none |
| `read_recent_memory_texts_result` | ❌ none |

This PR adds the two missing tests, both mirroring the directory-path setup used by `test_load_history_user_messages_result_error_on_directory_path`.

## New tests

```ocaml
let test_read_memory_horizon_counts_result_error_on_directory_path () =
  let dir = test_tmpdir () in
  Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
    let config = make_test_room_config dir in
    let memory_path = Keeper_types.keeper_memory_bank_path config "bad-keeper" in
    let parent = Filename.dirname memory_path in
    (try Unix.mkdir parent 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
    Unix.mkdir memory_path 0o755;
    match
      Keeper_memory_recall.read_memory_horizon_counts_result config
        ~name:"bad-keeper" ~max_bytes:100000 ~max_lines:100
    with
    | Ok _ ->
      fail "expected Error io_error when memory.jsonl path is a directory"
    | Error exn_class ->
      check string "Error label is io_error"
        "io_error"
        (Keeper_memory_recall_exn_class.to_label exn_class))
```

Same shape for `read_recent_memory_texts_result_error_on_directory_path` with the additional `~horizon` and `~limit` arguments.

Both tests pin the Error label to `io_error` (cardinality bounded by the closed 4-value `Keeper_memory_recall_exn_class.t` sum).

## Placement

Inserted after `make_test_room_config` (line ~590) so the typed `Coord.config` constructor is in scope.  Test cases registered in the `history_recall` group alongside the existing `load_history_user_messages_result Error on directory path` case.

## Dependency note

The test executable build is currently red on `origin/main` due to the unrelated `canonical_keeper_attention_reason` breakage in `lib/operator/operator_digest.ml` (codex partial sweep fallout from #17810).  The fix is in flight via #17821.  Once #17821 merges, this PR's tests will compile and run cleanly.

## Anti-pattern self-check

- §1 telemetry-as-fix? No — these are unit tests pinning the typed Error path that *replaced* the counter+WARN pair in PR-9.
- §2 substring classifier? No — Error label is the closed 4-value `Keeper_memory_recall_exn_class.t` sum.
- §3 N-of-M? **Closed** — the third Error-path test in the family was the only one missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>