### PR TITLE
fix(dashboard): normalize provider timeout plan payload

### DIFF
--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -405,8 +405,8 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
               segments: promptSegments,
             }
           : null
-      const rawProviderTimeoutBudget = isRecord(item.provider_timeout_budget) ? item.provider_timeout_budget : null
-      const rawTimeoutBudget = isRecord(item.timeout_budget) ? item.timeout_budget : rawProviderTimeoutBudget
+      const rawProviderTimeoutPlan = isRecord(item.provider_timeout_plan) ? item.provider_timeout_plan : null
+      const rawTimeoutBudget = isRecord(item.timeout_budget) ? item.timeout_budget : rawProviderTimeoutPlan
       const timeout_budget =
         rawTimeoutBudget != null
           ? {


### PR DESCRIPTION
## Summary
- read provider_timeout_plan from dashboard store normalization instead of the retired provider_timeout_budget payload key
- keep normalized timeout budget details sourced from the canonical provider-timeout plan payload
- remove the stale public JSON key from dashboard normalization

## Validation
- Not run; user requested PR iteration without local validation.