### PR TITLE
fix(dashboard): drop timeout budget operational reject shim

### DIFF
--- a/dashboard/src/lib/keeper-operational-state.ts
+++ b/dashboard/src/lib/keeper-operational-state.ts
@@ -110,7 +110,6 @@ export interface DeriveInputs {
 function canonicalRuntimeBlockerClass(
   blockerClass: KeeperRuntimeBlockerClass | null,
 ): KeeperRuntimeBlockerClass | null {
-  if (blockerClass === 'oas_timeout_budget') return null
   return blockerClass
 }
 


### PR DESCRIPTION
## Summary
- remove the last dashboard operational-state branch that special-cased oas_timeout_budget
- rely on the runtime blocker class mirror to reject retired timeout-budget values before state derivation
- avoid leaving a stale compatibility shim in the operational-state SSOT path

## Validation
- Not run; user requested PR iteration without local validation.