### PR TITLE
test(keeper_turn_disposition): retire oas_timeout_budget byte-compat after wire alias removal

### DIFF
--- a/test/test_keeper_turn_disposition.ml
+++ b/test/test_keeper_turn_disposition.ml
@@ -37,7 +37,6 @@ let canonical_app_codes : (string * D.t) list =
   [ "success", D.Success
   ; "external_cancel", D.External_cancel
   ; "turn_wall_clock_timeout", D.Turn_wall_clock_timeout
-  ; "oas_timeout_budget", D.Turn_wall_clock_timeout
   ; "gh_repo_context_missing_worktree", D.Gh_repo_context_missing_worktree
   ; "required_tool_use_no_tool_call", D.Required_tool_use_no_tool_call
   ; "required_tool_use_unsatisfied", D.Required_tool_use_unsatisfied
@@ -104,8 +103,7 @@ let test_canonical_next_action_byte_compat () =
        let legacy = Legacy.of_code wire in
        let expected =
          match wire, legacy.next_action with
-         | ("turn_wall_clock_timeout" | "oas_timeout_budget"), _ ->
-           "Some:inspect_turn_timeout"
+         | "turn_wall_clock_timeout", _ -> "Some:inspect_turn_timeout"
          | _, Some s -> "Some:" ^ s
          | _, None -> "None"
        in
@@ -148,7 +146,6 @@ let round_trippable : (string * D.t) list =
   [ "Success", D.Success
   ; "External_cancel", D.External_cancel
   ; "Turn_wall_clock_timeout", D.Turn_wall_clock_timeout
-  ; "legacy timeout-budget wire alias", D.Turn_wall_clock_timeout
   ; "Gh_repo_context_missing_worktree", D.Gh_repo_context_missing_worktree
   ; "Required_tool_use_no_tool_call", D.Required_tool_use_no_tool_call
   ; "Required_tool_use_unsatisfied", D.Required_tool_use_unsatisfied


### PR DESCRIPTION
## Summary
PR #17806 dropped the `"oas_timeout_budget" -> Turn_wall_clock_timeout` arm from `Keeper_turn_disposition.of_wire`, but the test fixture `canonical_app_codes` still claimed byte-compat with the legacy classifier for that wire. Result: 2 stale assertions waiting to fire if the test exe ever ran.

This PR removes the stale rows so the byte-compat oracle reflects the post-retirement contract.

## Root trace
- `Legacy.of_code "oas_timeout_budget"` → `make "oas_timeout_budget"` → `of_wire "oas_timeout_budget"` (no arm after #17806) → `Unknown { raw_error = "oas_timeout_budget" }`
  - severity = `Unknown_bad` → `"bad"`
  - summary  = `"keeper turn ended with oas_timeout_budget"`
- typed `D.Turn_wall_clock_timeout`
  - severity = `Warn` → `"warn"`  ← mismatch
  - summary  = `"keeper turn hit the wall-clock timeout"`  ← mismatch

## Changes
- `canonical_app_codes`: drop `("oas_timeout_budget", D.Turn_wall_clock_timeout)`
- `test_canonical_next_action_byte_compat`: collapse the dead `("turn_wall_clock_timeout" | "oas_timeout_budget")` override into a single-wire arm
- `round_trippable`: drop the misleading `"legacy timeout-budget wire alias"` row (duplicate of the `Turn_wall_clock_timeout` entry — it tested `to_wire`/`of_wire` of `D.Turn_wall_clock_timeout`, not the legacy wire)

## Anti-pattern audit
Per `software-development.md` §Workaround Rejection Bar:
- §1 텔레메트리-as-fix: NO — typed semantics already enforce
- §2 string classifier 보강: NO — removing a legacy wire row, not adding
- §3 N-of-M: NO — #17806 was complete on production code path; the test fixture was the only N-of-M residue
- §4 cap/cooldown/dedup/repair: NO
- §5 test backdoor: NO
- §6 catch-all `_ ->`: NO (no new catch-all)
- §7 same-typo-N-sites: NO (single-site removal)

## Self-review (Best Programmer)
- Goal: align test fixture with post-#17806 retired-wire contract
- Files: `test/test_keeper_turn_disposition.ml` (1 file)
- Validation: not run locally (cron loop convention); CI will verify
- Unverified: full `dune build @runtest` not run before push

## Discovery context
Discovered during `/loop` user honest-check ("다 고친거야??") probing residual byte-compat failures the previous session marked "out of scope". Tracing the legacy classifier through `Legacy.of_code` → `Keeper_turn_disposition.of_wire` revealed the test fixture as the actual stale site (codex partial sweep #6 — #17806 production change, test fixture residue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)