### PR TITLE
feat(keeper/manifest): F8 turn completeness policy — mandatory clock_refs and lane-level validation

### DIFF
--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -947,3 +947,88 @@ let append_unfinished_provider_attempt_finished_best_effort
       ~decision
       ()
     |> append_best_effort ~site config
+
+(* ═══════════════════════════════════════════════════════════════════════════════
+   F8: Lane-level mandatory event sets and turn completeness policy.
+   ═══════════════════════════════════════════════════════════════════════════════ *)
+
+(** For each event kind, the clock_refs keys that MUST be present for the
+    manifest to be considered structurally complete at that lane. *)
+let mandatory_clock_refs_for_event = function
+  | Turn_started ->
+    [ "edge_id"; "lane" ]
+  | Provider_attempt_started ->
+    [ "edge_id"; "lane"; "provider_attempt_id" ]
+  | Provider_attempt_finished ->
+    [ "edge_id"; "lane"; "provider_attempt_id"; "elapsed_ms" ]
+  | Tool_surface_selected ->
+    [ "edge_id"; "lane"; "tool_batch_id" ]
+  | Provider_lane_resolved ->
+    [ "edge_id"; "lane"; "tool_batch_id" ]
+  | Context_compacted ->
+    [ "edge_id"; "lane"; "compaction_id"; "compaction_source" ]
+  | Checkpoint_saved ->
+    [ "edge_id"; "lane"; "checkpoint_id" ]
+  | Memory_injected | Memory_flushed ->
+    [ "edge_id"; "lane"; "memory_injection_id" ]
+  | Receipt_appended ->
+    [ "edge_id"; "lane" ]
+  | Turn_finished ->
+    [ "edge_id"; "lane" ]
+  | _ ->
+    [ "edge_id"; "lane" ]
+
+let clock_refs_has_keys keys clock_refs_json =
+  match clock_refs_json with
+  | `Assoc fields ->
+    List.for_all
+      (fun key -> List.exists (fun (k, _) -> String.equal k key) fields)
+      keys
+  | _ -> false
+
+let validate_manifest_completeness manifest =
+  let required_keys = mandatory_clock_refs_for_event manifest.event in
+  match manifest.decision with
+  | `Assoc fields ->
+    (match List.assoc_opt "clock_refs" fields with
+    | Some clock_refs ->
+      if clock_refs_has_keys required_keys clock_refs then
+        Ok ()
+      else
+        Error
+          (Printf.sprintf
+             "manifest for %s missing mandatory clock_refs keys: [%s]"
+             (event_kind_to_string manifest.event)
+             (String.concat ", "
+                (List.filter
+                   (fun key -> not (clock_refs_has_keys [ key ] clock_refs))
+                   required_keys)))
+    | None ->
+      Error
+        (Printf.sprintf "manifest for %s missing clock_refs entirely"
+           (event_kind_to_string manifest.event)))
+  | _ ->
+    Error
+      (Printf.sprintf "manifest for %s has non-assoc decision"
+         (event_kind_to_string manifest.event))
+
+(** A turn is "finished" when a [Turn_finished] event exists.
+    A turn is "complete" when it is finished AND has both a receipt link
+    and a checkpoint link, meaning all mandatory lane artifacts are present. *)
+let is_finished_turn manifests =
+  List.exists
+    (fun m -> m.event = Turn_finished)
+    manifests
+
+let is_complete_turn manifests =
+  is_finished_turn manifests
+  && List.exists
+       (fun m ->
+         m.event = Receipt_appended
+         && Option.is_some m.links.receipt_path)
+       manifests
+  && List.exists
+       (fun m ->
+         m.event = Checkpoint_saved
+         && Option.is_some m.links.checkpoint_path)
+       manifests

--- a/lib/keeper/keeper_runtime_manifest.mli
+++ b/lib/keeper/keeper_runtime_manifest.mli
@@ -194,3 +194,19 @@ val append_unfinished_provider_attempt_finished_best_effort :
   ?exception_kind:string ->
   unit ->
   unit
+
+(** {2 F8: Turn completeness policy} *)
+
+(** The clock_refs keys that are mandatory for a structurally complete
+    manifest at this event lane. *)
+val mandatory_clock_refs_for_event : event_kind -> string list
+
+(** Check whether a manifest carries all mandatory clock_refs for its event. *)
+val validate_manifest_completeness : t -> (unit, string) result
+
+(** Whether a list of manifests includes a [Turn_finished] event. *)
+val is_finished_turn : t list -> bool
+
+(** Whether a turn is both [finished] and has all mandatory lane artifacts:
+    receipt link + checkpoint link. *)
+val is_complete_turn : t list -> bool

--- a/test/dune
+++ b/test/dune
@@ -147,6 +147,7 @@
   test_ide_canonical_url_join
   test_ide_migration
   test_keeper_runtime_manifest
+  test_keeper_runtime_manifest_completeness
   test_schema_surface_index
   test_keeper_accountability
   test_reputation_ledger_v2
@@ -464,6 +465,7 @@
   test_ide_canonical_url_join
   test_ide_migration
   test_keeper_runtime_manifest
+  test_keeper_runtime_manifest_completeness
   test_schema_surface_index
   test_keeper_accountability
   test_reputation_ledger_v2

--- a/test/test_keeper_runtime_manifest_completeness.ml
+++ b/test/test_keeper_runtime_manifest_completeness.ml
@@ -1,0 +1,124 @@
+module M = Masc_mcp.Keeper_runtime_manifest
+
+let manifest ~event ~decision ~links =
+  { M.schema_version = 1
+  ; M.ts = "2026-05-22T00:00:00Z"
+  ; M.keeper_name = "test-keeper"
+  ; M.agent_name = None
+  ; M.trace_id = "trace/test"
+  ; M.generation = None
+  ; M.keeper_turn_id = Some 1
+  ; M.oas_turn_count = Some 1
+  ; M.logical_seq = None
+  ; M.event
+  ; M.cascade_name = None
+  ; M.status = "ok"
+  ; M.decision
+  ; M.links
+  }
+
+let links ?receipt_path ?checkpoint_path () =
+  { M.receipt_path; M.checkpoint_path; M.tool_call_log_path = None }
+
+let clock_refs fields = `Assoc ([ ("clock_refs", `Assoc fields) ] |> List.rev)
+
+let test_mandatory_clock_refs () =
+  let keys = M.mandatory_clock_refs_for_event M.Turn_started in
+  Alcotest.(check (list string))
+    "Turn_started mandatory keys" [ "edge_id"; "lane" ] keys;
+  let keys2 =
+    M.mandatory_clock_refs_for_event M.Provider_attempt_finished
+  in
+  Alcotest.(check (list string))
+    "Provider_attempt_finished mandatory keys"
+    [ "edge_id"; "lane"; "provider_attempt_id"; "elapsed_ms" ]
+    keys2
+
+let test_validate_completeness_pass () =
+  let m =
+    manifest ~event:M.Turn_started
+      ~decision:(clock_refs [ ("edge_id", `String "e1"); ("lane", `String "L1") ])
+      ~links:(links ())
+  in
+  Alcotest.(check (result unit string))
+    "valid manifest passes" (Ok ()) (M.validate_manifest_completeness m)
+
+let test_validate_completeness_fail_missing_key () =
+  let m =
+    manifest ~event:M.Provider_attempt_finished
+      ~decision:(clock_refs [ ("edge_id", `String "e1"); ("lane", `String "L1") ])
+      ~links:(links ())
+  in
+  match M.validate_manifest_completeness m with
+  | Ok () -> Alcotest.fail "expected failure for missing provider_attempt_id"
+  | Error msg ->
+    Alcotest.(check string) "error mentions missing keys"
+      "manifest for provider_attempt_finished missing mandatory clock_refs keys: [provider_attempt_id, elapsed_ms]"
+      msg
+
+let test_is_finished_turn () =
+  let manifests =
+    [ manifest ~event:M.Turn_started
+        ~decision:(clock_refs [ ("edge_id", `String "e1"); ("lane", `String "L1") ])
+        ~links:(links ())
+    ; manifest ~event:M.Turn_finished
+        ~decision:(clock_refs [ ("edge_id", `String "e1"); ("lane", `String "L1") ])
+        ~links:(links ())
+    ]
+  in
+  Alcotest.(check bool) "turn with Turn_finished is finished" true
+    (M.is_finished_turn manifests);
+  Alcotest.(check bool) "turn without Turn_finished is not finished" false
+    (M.is_finished_turn [ List.hd manifests ])
+
+let test_is_complete_turn () =
+  let finished_only =
+    [ manifest ~event:M.Turn_finished
+        ~decision:(clock_refs [ ("edge_id", `String "e1"); ("lane", `String "L1") ])
+        ~links:(links ())
+    ]
+  in
+  Alcotest.(check bool)
+    "finished without receipt+checkpoint is not complete" false
+    (M.is_complete_turn finished_only);
+  let with_receipt =
+    [ manifest ~event:M.Turn_finished
+        ~decision:(clock_refs [ ("edge_id", `String "e1"); ("lane", `String "L1") ])
+        ~links:(links ~receipt_path:"/tmp/r.jsonl" ())
+    ; manifest ~event:M.Receipt_appended
+        ~decision:(clock_refs [ ("edge_id", `String "e1"); ("lane", `String "L1") ])
+        ~links:(links ~receipt_path:"/tmp/r.jsonl" ())
+    ]
+  in
+  Alcotest.(check bool)
+    "finished+receipt without checkpoint is not complete" false
+    (M.is_complete_turn with_receipt);
+  let complete =
+    [ manifest ~event:M.Turn_finished
+        ~decision:(clock_refs [ ("edge_id", `String "e1"); ("lane", `String "L1") ])
+        ~links:(links ~receipt_path:"/tmp/r.jsonl" ~checkpoint_path:"/tmp/c.jsonl" ())
+    ; manifest ~event:M.Receipt_appended
+        ~decision:(clock_refs [ ("edge_id", `String "e1"); ("lane", `String "L1") ])
+        ~links:(links ~receipt_path:"/tmp/r.jsonl" ~checkpoint_path:"/tmp/c.jsonl" ())
+    ; manifest ~event:M.Checkpoint_saved
+        ~decision:(clock_refs [ ("edge_id", `String "e1"); ("lane", `String "L1"); ("checkpoint_id", `String "c1") ])
+        ~links:(links ~receipt_path:"/tmp/r.jsonl" ~checkpoint_path:"/tmp/c.jsonl" ())
+    ]
+  in
+  Alcotest.(check bool) "finished+receipt+checkpoint is complete" true
+    (M.is_complete_turn complete)
+
+let () =
+  Alcotest.run "keeper_runtime_manifest_completeness"
+    [ ( "completeness"
+      , [ Alcotest.test_case "mandatory_clock_refs_for_event" `Quick
+            test_mandatory_clock_refs
+        ; Alcotest.test_case "validate_completeness_pass" `Quick
+            test_validate_completeness_pass
+        ; Alcotest.test_case "validate_completeness_fail_missing_key" `Quick
+            test_validate_completeness_fail_missing_key
+        ; Alcotest.test_case "is_finished_turn" `Quick test_is_finished_turn
+        ; Alcotest.test_case "is_complete_turn" `Quick
+            test_is_complete_turn
+        ] )
+    ]


### PR DESCRIPTION
## Summary

Implements F8 from the OAS Agent Runtime Logic hardening matrix (section 9):
lane-level mandatory event sets and turn completeness policy.

### Changes

- `lib/keeper/keeper_runtime_manifest.ml`
  - `mandatory_clock_refs_for_event` — SSOT mapping of required clock_refs keys per event kind
  - `validate_manifest_completeness` — structural validation of a single manifest
  - `is_finished_turn` / `is_complete_turn` — turn-level state predicates

- `lib/keeper/keeper_runtime_manifest.mli` — signatures documented

- `test/test_keeper_runtime_manifest_completeness.ml` — 5 Alcotest cases
  - mandatory keys mapping correctness
  - validation pass
  - validation fail (missing provider_attempt_id + elapsed_ms)
  - finished turn detection
  - complete turn detection (finished + receipt + checkpoint)

- `test/dune` — registers new test in Group 1

### Test plan

- [x] `dune exec test/test_keeper_runtime_manifest_completeness.exe` passes (5/5)
- [ ] CI green

### RFC / Workaround

- No subsystem guard (credential/identity/repo/operator/hooks/workflow) triggered.
- RFC-WAIVED: F8 is a follow-up hardening item from the already-merged OAS #1-#7 sweep (#17830). The functions extend existing manifest infrastructure without touching sensitive subsystems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)