### PR TITLE
fix(dashboard/alert-strip): drop dead inspect_timeout_budget rewrite branch

### DIFF
--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -141,7 +141,6 @@ function isNextHumanAction(s: string): s is NextHumanAction {
 
 function canonicalNextHumanAction(action: string | null): string | null {
   if (action === 'inspect_turn_timeout') return 'inspect_runtime_blocker'
-  if (action === 'inspect_timeout_budget') return 'inspect_runtime_blocker'
   if (action === 'inspect_cascade_attempts') return 'inspect_runtime_blocker'
   if (action === 'inspect_provider_tool_lane') return 'inspect_runtime_blocker'
   if (action === 'inspect_completion_contract') return 'inspect_runtime_blocker'


### PR DESCRIPTION
## Summary
Remove the dead defensive rewrite branch `'inspect_timeout_budget' -> 'inspect_runtime_blocker'` in `canonicalNextHumanAction` (`dashboard/src/components/keeper-detail-alert-strip.ts:144`). The timeout-budget retirement sweep (#17801~#17828) leaves zero producers anywhere.

## Producer audit
- `rg "inspect_timeout_budget" lib/ dashboard/` -> **1 match** (this site only)
- `rg "inspect_turn_timeout" lib/` -> producer at `Keeper_turn_disposition.next_action`
- `rg "inspect_cascade_attempts" lib/` -> producer at `Keeper_turn_disposition.next_action` + `Keeper_status_bridge`
- The 6 other rewrite branches retain producers; only this one is dead.

## Test-lock audit
Per `feedback_dead_defensive_cleanup_must_check_test_lock` memory:
- `rg "inspect_timeout_budget" dashboard/**/*.test.ts` -> **0 matches**
- Safe to remove without test-fixture conflict.

## Anti-pattern audit
- §1 텔레메트리-as-fix: NO
- §2 string classifier 보강: NO — this REMOVES a classifier branch (the doctrine inverse)
- §3 N-of-M: NO — only producer/site
- §4-§7: NO

## Self-review
- Goal: surgical removal of one dead defensive rewrite branch
- Files: 1 (`keeper-detail-alert-strip.ts`)
- Validation: not run locally; CI verifies (TypeScript should still type-check — string union not narrowed by this)
- Unverified: full lint/test run

## Discovery context
3rd PR in the same anti-pattern-lens sweep started by user's "다 고친거야??" probe:
1. #17831 (merged) — `test_keeper_turn_disposition` byte-compat oracle stale
2. #17833 (merged) — `test_keeper_auto_pause_blocker_persist_12683` deserializer rows stale
3. This PR — `keeper-detail-alert-strip.ts` dead defensive rewrite branch

All three share the signature: timeout-budget retirement PR (#17710/#17805/#17806/...) completed production-side change but left a stale companion site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)