### PR TITLE
feat(keeper/manifest): F5 clock separation policy

### DIFF
--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -75,6 +75,12 @@ let source_clock_of_event = function
     Logical
   | _ -> Wall
 
+type logical_ordering = {
+  parent_event_id : string option;
+  caused_by : string option;
+  logical_seq : int option;
+}
+
 module StringSet = Set.Make (String)
 
 type links = {
@@ -230,6 +236,71 @@ let clock_refs ?edge_id ?lane ?source_clock ?observed_at ?started_at
          string_field_opt "caused_by" caused_by;
          int_field_opt "logical_seq" logical_seq;
        ])
+
+let extract_string_field key json =
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+    | Some (`String value) -> Some value
+    | _ -> None)
+  | _ -> None
+
+let extract_int_field key json =
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+    | Some (`Int value) -> Some value
+    | _ -> None)
+  | _ -> None
+
+let extract_clock_refs decision =
+  match decision with
+  | `Assoc fields -> List.assoc_opt "clock_refs" fields
+  | _ -> None
+
+let source_clock_from_manifest manifest =
+  match extract_clock_refs manifest.decision with
+  | Some (`Assoc fields) ->
+    (match List.assoc_opt "source_clock" fields with
+    | Some (`String s) -> source_clock_of_string s
+    | _ -> None)
+  | _ -> None
+
+let logical_ordering manifest =
+  match extract_clock_refs manifest.decision with
+  | Some (`Assoc fields) ->
+    let parent_event_id =
+      match List.assoc_opt "parent_event_id" fields with
+      | Some (`String s) -> Some s
+      | _ -> None
+    in
+    let caused_by =
+      match List.assoc_opt "caused_by" fields with
+      | Some (`String s) -> Some s
+      | _ -> None
+    in
+    let logical_seq =
+      match List.assoc_opt "logical_seq" fields with
+      | Some (`Int i) -> Some i
+      | _ -> None
+    in
+    { parent_event_id; caused_by; logical_seq }
+  | _ -> { parent_event_id = None; caused_by = None; logical_seq = None }
+
+let comparable_for_latency a b =
+  match source_clock_from_manifest a, source_clock_from_manifest b with
+  | Some sc_a, Some sc_b ->
+    if sc_a = sc_b then Ok sc_a
+    else
+      Error
+        (Printf.sprintf
+           "latency comparison invalid: source_clock mismatch (%s vs %s)"
+           (source_clock_to_string sc_a)
+           (source_clock_to_string sc_b))
+  | None, _ ->
+    Error "latency comparison invalid: manifest a has no source_clock"
+  | _, None ->
+    Error "latency comparison invalid: manifest b has no source_clock"
 
 let clock_lane_of_event = function
   | Turn_started

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -1,4 +1,6 @@
-(** Durable per-turn decision manifest for keeper runtime diagnosis. *)
+(** Durable per-turn decision manifest for keeper runtime diagnosis.
+
+    See the corresponding [mli] for the layered SSOT hierarchy. *)
 
 type event_kind =
   | Turn_started

--- a/lib/keeper/keeper_runtime_manifest.mli
+++ b/lib/keeper/keeper_runtime_manifest.mli
@@ -2,7 +2,33 @@
 
     The manifest is intentionally narrower than execution receipts.  Receipts
     describe what happened after a turn; manifest rows record the routing and
-    context decisions that explain why the turn took that path. *)
+    context decisions that explain why the turn took that path.
+
+    {2 Layered SSOT}
+
+    The manifest is structured in five layers.  Each layer has a single
+    authoritative source of truth and a clear boundary:
+
+    - {b Layer 1 — Identity}: [keeper_name], [agent_name], [trace_id],
+      [generation].  Stable across every event in a turn.  SSOT is the
+      keeper registry entry at turn start.
+
+    - {b Layer 2 — Time}: [ts], [source_clock], [clock_refs].  Provides
+      wall / monotonic / logical / provider / event_bus provenance.
+      SSOT is the runtime clock snapshot taken when the event is emitted.
+
+    - {b Layer 3 — Lineage}: [event_kind], [tool_lineage] (6 stages:
+      searched / visible / materialized / emitted / executed / verified).
+      Tracks the tool lifecycle.  SSOT is the tool dispatch pipeline.
+
+    - {b Layer 4 — Payload}: [payload_role] ([Model_input],
+      [Operator_evidence], [Checkpoint], [Memory_store]).  Classifies the
+      semantic role of the decision data.  SSOT is the caller contract
+      at the injection point.
+
+    - {b Layer 5 — Trust}: public projection allowlist.  Redacts sensitive
+      fields based on consumer identity.  SSOT is the consumer capability
+      profile. *)
 
 type event_kind =
   | Turn_started

--- a/lib/keeper/keeper_runtime_manifest.mli
+++ b/lib/keeper/keeper_runtime_manifest.mli
@@ -221,6 +221,30 @@ val append_unfinished_provider_attempt_finished_best_effort :
   unit ->
   unit
 
+(** {2 F5: Clock separation policy}
+
+    Wall-clock ([ts]) is display-only.  Ordering uses logical
+    [parent_event_id]/[caused_by]/[logical_seq].  Latency comparison
+    ([elapsed_ms]) is only valid between events that share the same
+    [source_clock]. *)
+
+type logical_ordering = {
+  parent_event_id : string option;
+  caused_by : string option;
+  logical_seq : int option;
+}
+
+(** Extract the source_clock from a manifest's decision JSON. *)
+val source_clock_from_manifest : t -> source_clock option
+
+(** Extract the logical ordering fields from a manifest's clock_refs. *)
+val logical_ordering : t -> logical_ordering
+
+(** Validate that two manifests share the same source_clock so that
+    their [elapsed_ms] values are comparable.  Returns [Ok source_clock]
+    on match, [Error msg] on mismatch or missing clock. *)
+val comparable_for_latency : t -> t -> (source_clock, string) result
+
 (** {2 F8: Turn completeness policy} *)
 
 (** The clock_refs keys that are mandatory for a structurally complete

--- a/test/dune
+++ b/test/dune
@@ -148,6 +148,7 @@
   test_ide_migration
   test_keeper_runtime_manifest
   test_keeper_runtime_manifest_completeness
+  test_keeper_runtime_manifest_clock_separation
   test_schema_surface_index
   test_keeper_accountability
   test_reputation_ledger_v2
@@ -466,6 +467,7 @@
   test_ide_migration
   test_keeper_runtime_manifest
   test_keeper_runtime_manifest_completeness
+  test_keeper_runtime_manifest_clock_separation
   test_schema_surface_index
   test_keeper_accountability
   test_reputation_ledger_v2

--- a/test/test_keeper_runtime_manifest_clock_separation.ml
+++ b/test/test_keeper_runtime_manifest_clock_separation.ml
@@ -1,0 +1,109 @@
+module M = Masc_mcp.Keeper_runtime_manifest
+
+let manifest ~event ~decision ~links =
+  { M.schema_version = 1
+  ; M.ts = "2026-05-22T00:00:00Z"
+  ; M.keeper_name = "test-keeper"
+  ; M.agent_name = None
+  ; M.trace_id = "trace/test"
+  ; M.generation = None
+  ; M.keeper_turn_id = Some 1
+  ; M.oas_turn_count = Some 1
+  ; M.logical_seq = None
+  ; M.event
+  ; M.cascade_name = None
+  ; M.status = "ok"
+  ; M.decision
+  ; M.links
+  }
+
+let links ?receipt_path ?checkpoint_path () =
+  { M.receipt_path; M.checkpoint_path; M.tool_call_log_path = None }
+
+let clock_refs ?(source_clock = "wall") fields =
+  `Assoc
+    ([ ("clock_refs", `Assoc (fields @ [ ("source_clock", `String source_clock) ])) ]
+    |> List.rev)
+
+let source_clock_testable =
+  let pp fmt sc = Format.fprintf fmt "%s" (M.source_clock_to_string sc) in
+  let equal = ( = ) in
+  Alcotest.testable pp equal
+
+let test_source_clock_from_manifest () =
+  let m =
+    manifest ~event:M.Turn_started
+      ~decision:(clock_refs ~source_clock:"monotonic" [ ("edge_id", `String "e1") ])
+      ~links:(links ())
+  in
+  Alcotest.(check (option source_clock_testable))
+    "extracts monotonic" (Some M.Monotonic) (M.source_clock_from_manifest m);
+  let m2 =
+    manifest ~event:M.Turn_started
+      ~decision:(clock_refs ~source_clock:"provider" [ ("edge_id", `String "e1") ])
+      ~links:(links ())
+  in
+  Alcotest.(check (option source_clock_testable))
+    "extracts provider" (Some M.Provider) (M.source_clock_from_manifest m2)
+
+let test_logical_ordering () =
+  let m =
+    manifest ~event:M.Turn_started
+      ~decision:
+        (clock_refs
+           [ ("edge_id", `String "e1")
+           ; ("parent_event_id", `String "p1")
+           ; ("caused_by", `String "c1")
+           ; ("logical_seq", `Int 7)
+           ])
+      ~links:(links ())
+  in
+  let lo = M.logical_ordering m in
+  Alcotest.(check (option string)) "parent_event_id" (Some "p1") lo.parent_event_id;
+  Alcotest.(check (option string)) "caused_by" (Some "c1") lo.caused_by;
+  Alcotest.(check (option int)) "logical_seq" (Some 7) lo.logical_seq
+
+let test_comparable_for_latency_same_clock () =
+  let a =
+    manifest ~event:M.Provider_attempt_started
+      ~decision:(clock_refs ~source_clock:"provider" [ ("edge_id", `String "e1") ])
+      ~links:(links ())
+  in
+  let b =
+    manifest ~event:M.Provider_attempt_finished
+      ~decision:(clock_refs ~source_clock:"provider" [ ("edge_id", `String "e2") ])
+      ~links:(links ())
+  in
+  Alcotest.(check (result source_clock_testable string))
+    "same provider clock is comparable" (Ok M.Provider)
+    (M.comparable_for_latency a b)
+
+let test_comparable_for_latency_different_clock () =
+  let a =
+    manifest ~event:M.Turn_started
+      ~decision:(clock_refs ~source_clock:"wall" [ ("edge_id", `String "e1") ])
+      ~links:(links ())
+  in
+  let b =
+    manifest ~event:M.Provider_attempt_started
+      ~decision:(clock_refs ~source_clock:"provider" [ ("edge_id", `String "e2") ])
+      ~links:(links ())
+  in
+  match M.comparable_for_latency a b with
+  | Ok _ -> Alcotest.fail "expected failure for different source_clock"
+  | Error msg ->
+    Alcotest.(check bool) "error mentions mismatch" true
+      (String.equal msg "latency comparison invalid: source_clock mismatch (wall vs provider)")
+
+let () =
+  Alcotest.run "keeper_runtime_manifest_clock_separation"
+    [ ( "clock_separation"
+      , [ Alcotest.test_case "source_clock_from_manifest" `Quick
+            test_source_clock_from_manifest
+        ; Alcotest.test_case "logical_ordering" `Quick test_logical_ordering
+        ; Alcotest.test_case "comparable_for_latency_same" `Quick
+            test_comparable_for_latency_same_clock
+        ; Alcotest.test_case "comparable_for_latency_different" `Quick
+            test_comparable_for_latency_different_clock
+        ] )
+    ]


### PR DESCRIPTION
## Summary
Implements OAS F5 (Clock Separation Policy) helpers in `keeper_runtime_manifest`:

- `source_clock_from_manifest` — extracts source_clock from decision JSON
- `logical_ordering` — returns `{parent_event_id; caused_by; logical_seq}` for causal ordering
- `comparable_for_latency` — validates two manifests share the same source_clock before comparing elapsed_ms

## Policy enforced
- Wall-clock (`ts`) is display-only
- Ordering uses logical fields (`parent_event_id`/`caused_by`/`logical_seq`)
- Latency (`elapsed_ms`) only comparable between same `source_clock` events

## Tests
4 Alcotest cases in `test_keeper_runtime_manifest_clock_separation`:
1. source_clock_from_manifest extracts Monotonic / Provider
2. logical_ordering extracts all three fields
3. comparable_for_latency returns Ok when clocks match
4. comparable_for_latency returns Error with descriptive msg when clocks differ

## Verification
- [ ] `dune build @runtest` passes (test_keeper_runtime_manifest_clock_separation)
- [ ] ocamlformat clean

RFC-WAIVED: F5 is documentation+helper addition to existing manifest surface; no RFC required per workflow-pr.md §11 (not credential/identity/operator/repo/hooks/workflow subsystem).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>