### PR TITLE
test(dashboard/alert-strip): lock 4 uncovered canonicalNextHumanAction wires

### DIFF
--- a/dashboard/src/components/keeper-detail-alert-strip.test.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.test.ts
@@ -106,6 +106,32 @@ describe('KeeperRuntimeAlertStrip', () => {
     expect(text).not.toContain('inspect_turn_timeout')
   })
 
+  // Lock the remaining producer-side action wires that
+  // [canonicalNextHumanAction] folds into inspect_runtime_blocker. Each
+  // wire here has a live producer in lib/keeper (see
+  // Keeper_turn_disposition.next_action and Keeper_status_bridge), so
+  // dropping any rewrite branch silently in a future sweep would leak
+  // the raw legacy label into operator copy. The previous
+  // canonicalizes-* it() blocks already cover inspect_watchdog_root_cause
+  // and inspect_turn_timeout.
+  it.each([
+    'inspect_cascade_attempts',
+    'inspect_provider_tool_lane',
+    'inspect_completion_contract',
+    'inspect_turn_finalization',
+  ])('canonicalizes %s into inspect_runtime_blocker operator copy', (action) => {
+    const { container } = render(h(KeeperRuntimeAlertStrip, {
+      keeper: keeper({
+        needs_attention: true,
+        next_human_action: action,
+      }),
+    }))
+
+    const text = container.textContent ?? ''
+    expect(text).toContain('런타임 근거 확인')
+    expect(text).not.toContain(action)
+  })
+
   it('closes 모순 #3: per-attempt completed outcome is hidden when per-turn stop cause is terminal failure', () => {
     const { container } = render(h(KeeperRuntimeAlertStrip, {
       keeper: keeper({


### PR DESCRIPTION
## Summary
Add parametrised render-time regression tests for the 4 `canonicalNextHumanAction` rewrite branches that previously had no consumer-side coverage. Prophylactic application of the codex-partial-sweep anti-pattern lens from #17834.

## Producer audit
| Wire | Producer site |
|---|---|
| `inspect_cascade_attempts` | `Keeper_turn_disposition.next_action Cascade_attempts_exhausted` + `Keeper_status_bridge` cascade_attempts_exhausted |
| `inspect_provider_tool_lane` | `Keeper_status_bridge` provider_tool_capability_missing |
| `inspect_completion_contract` | `Keeper_status_bridge` completion_contract_violation |
| `inspect_turn_finalization` | `Keeper_status_bridge` fiber_unresolved |

The 2 already-covered branches (`inspect_turn_timeout`, `inspect_watchdog_root_cause`) are unchanged.

## Why
After #17834 surgically removed the dead `inspect_timeout_budget` branch, the remaining 6 branches are all load-bearing but only 2 had explicit render-time guards. If a future "drop X alias" PR removes one of the 4 untested branches without checking the producer side, the raw legacy wire would leak into operator copy (`'런타임 근거 확인 필요'` would fall back to the raw `inspect_*` string).

Per `feedback_codex_partial_sweep_fan_out_anti_pattern` memory (new this session): production rewriters defensive branches are one of the 3 categories codex sweeps miss. These tests close the consumer↔producer alignment gap.

## Anti-pattern audit
- §1 텔레메트리-as-fix: NO
- §2 string classifier 보강: NO — adding *test coverage* of existing classifier, not the classifier itself
- §3 N-of-M: NO — locks all 4 uncovered branches in one PR
- §4-§7: NO

## Self-review
- Goal: prophylactic consumer↔producer alignment guard
- Files: 1 (`dashboard/src/components/keeper-detail-alert-strip.test.ts`)
- LoC: +26
- Validation: not run locally; CI verifies
- Unverified: actual vitest run

## Discovery context
Iter 57 of session-long anti-pattern lens application. Pivoted from yield-saturated retirement audit to *prophylactic* coverage extension on a single previously-touched site (#17834). Avoids speculative scope (e.g. F8/F5 Phase 2 wiring) by staying within the consumer file already modified this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)