### PR TITLE
test(dashboard/alert-strip): lock 3 uncovered canonicalAttentionReason wires

### DIFF
--- a/dashboard/src/components/keeper-detail-alert-strip.test.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.test.ts
@@ -93,6 +93,31 @@ describe('KeeperRuntimeAlertStrip', () => {
     expect(text).not.toContain('inspect_watchdog_root_cause')
   })
 
+  // Lock the remaining producer-side attention reasons that
+  // [canonicalAttentionReason] folds into runtime_blocked. Producers
+  // live at Keeper_status_bridge.ml:782/784/791 (cascade_attempts_exhausted,
+  // provider_tool_capability_missing, fiber_unresolved). The previous
+  // canonicalizes-* it() blocks already cover watchdog_stale_turn and
+  // completion_contract_violation; this parametrises the rest. The
+  // rendered Korean copy "런타임 근거 확인 필요" is the user-visible label
+  // mapped from runtime_blocked in ATTENTION_REASON_LABELS.
+  it.each([
+    'cascade_attempts_exhausted',
+    'provider_tool_capability_missing',
+    'fiber_unresolved',
+  ])('canonicalizes %s into runtime_blocked operator copy', (reason) => {
+    const { container } = render(h(KeeperRuntimeAlertStrip, {
+      keeper: keeper({
+        needs_attention: true,
+        attention_reason: reason,
+      }),
+    }))
+
+    const text = container.textContent ?? ''
+    expect(text).toContain('런타임 근거 확인 필요')
+    expect(text).not.toContain(reason)
+  })
+
   it('canonicalizes turn-disposition timeout actions before rendering operator copy', () => {
     const { container } = render(h(KeeperRuntimeAlertStrip, {
       keeper: keeper({


### PR DESCRIPTION
## Summary
Add parametrised render-time regression tests for the 3 `canonicalAttentionReason` rewrite branches that previously had no consumer-side coverage. Companion to #17837 (canonicalNextHumanAction coverage). Both apply the defensive lens from `feedback_codex_partial_sweep_fan_out_anti_pattern`.

## Producer audit (Keeper_status_bridge.ml)
| Wire | Producer site |
|---|---|
| `cascade_attempts_exhausted` | line 782 |
| `provider_tool_capability_missing` | line 784 |
| `fiber_unresolved` | line 791 (via `is_fiber_unresolved_blocker_class`) |

The 2 already-covered branches (`watchdog_stale_turn`, `completion_contract_violation`) are unchanged.

## Why
If a future "drop X alias" PR removes one of the 3 untested rewrite branches without checking producers, the raw producer wire would leak into operator copy (Korean label `'런타임 근거 확인 필요'` would fall back to the raw `*_exhausted` / `*_missing` / `fiber_unresolved` string).

## Anti-pattern audit
- §1-§7: NO — adding coverage of existing classifier, not modifying classifier

## Self-review
- Goal: prophylactic consumer↔producer alignment guard for attention reasons
- Files: 1 (`dashboard/src/components/keeper-detail-alert-strip.test.ts`)
- LoC: +25
- Validation: not run locally; CI verifies

## Discovery context
Iter 58 of session-long anti-pattern lens application. Phase 2 (defensive prophylaxis) continues — sibling function in the same file as #17837. After this, the file has full producer↔consumer coverage for both `canonicalAttentionReason` (5/5 branches) and `canonicalNextHumanAction` (6/6 branches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)