### PR TITLE
test(dashboard/fleet-band): lock 2 uncovered offline-trigger statuses

### DIFF
--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -306,6 +306,21 @@ describe('fleetBand', () => {
     expect(fleetBand(makeRow({ status: 'crashed' }))).toBe('offline')
   })
 
+  // Lock the remaining offline-trigger status strings in fleetBand's
+  // production code. `'offline'` has an active producer
+  // (dashboard_governance_judge.ml:164, dashboard_mission_agents.ml:206,
+  // keeper_exec_status.ml:276/353); `'unbooted'` is defensive (no
+  // current OCaml producer, but the production check is load-bearing
+  // for non-OCaml producers or future runtime states). Per
+  // feedback_dead_defensive_cleanup_must_check_test_lock memory, lock
+  // the defensive arm explicitly rather than treating it as dead.
+  it.each([
+    'offline',
+    'unbooted',
+  ])('classifies offline for status=%s', (status) => {
+    expect(fleetBand(makeRow({ status }))).toBe('offline')
+  })
+
   it('classifies paused', () => {
     expect(fleetBand(makeRow({ status: 'paused' }))).toBe('paused')
   })


### PR DESCRIPTION
## Summary
Extend `fleetBand` test coverage to lock the 2 uncovered offline-trigger status strings (`'offline'`, `'unbooted'`). Third PR in the defensive lens phase (companion to #17837 + #17838).

## Producer audit
| Wire | Producer site |
|---|---|
| `'offline'` (active) | `dashboard_governance_judge.ml:164`, `dashboard_mission_agents.ml:206`, `keeper_exec_status.ml:276/353` |
| `'unbooted'` (defensive) | No current OCaml producer. Defensive arm for non-OCaml producers or future runtime states. |

Per `feedback_dead_defensive_cleanup_must_check_test_lock` memory, the defensive `'unbooted'` arm is locked in by test rather than removed, mirroring the `keeper-predicates.test.ts` `oas_timeout_budget` defensive guard pattern.

## Anti-pattern audit
- §1-§7: NO — adding coverage of existing classifier, not modifying classifier
- The defensive `'unbooted'` arm is explicitly preserved (not removed) per the established team policy

## Self-review
- Goal: prophylactic coverage of offline-trigger statuses
- Files: 1 (`dashboard/src/components/fleet-telemetry-utils.test.ts`)
- LoC: +15
- Validation: not run locally; CI verifies

## Discovery context
Iter 59 of session-long anti-pattern lens application. Phase 2 defensive prophylaxis extended to fleetBand. After #17837 (canonicalNextHumanAction 6/6), #17838 (canonicalAttentionReason 5/5), and this PR, three rewrite/classifier surfaces in the dashboard have full consumer-side regression guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)