### PR TITLE
test(dashboard/status-class): lock 4 uncovered offline-trigger statuses

### DIFF
--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -404,6 +404,19 @@ describe('statusClass', () => {
     expect(statusClass(makeRow({ status: 'stopped' }))).toContain('var(--bad-light)')
   })
 
+  // Lock the remaining offline-trigger status strings in statusClass.
+  // Mirrors the fleetBand offline-trigger set (5 statuses); the
+  // 'unbooted' arm is defensive (no current OCaml producer) per the
+  // feedback_dead_defensive_cleanup_must_check_test_lock memory pattern.
+  it.each([
+    'offline',
+    'unbooted',
+    'dead',
+    'crashed',
+  ])('returns bad-light for status=%s', (status) => {
+    expect(statusClass(makeRow({ status }))).toContain('var(--bad-light)')
+  })
+
   it('returns warn for runtime blocker', () => {
     expect(statusClass(makeRow({ runtime_blocker_class: 'turn_timeout' }))).toContain('var(--color-status-warn)')
   })


### PR DESCRIPTION
## Summary
Extend `statusClass` test coverage to lock the 4 uncovered offline-trigger status strings (`'offline'`, `'unbooted'`, `'dead'`, `'crashed'`). Sibling to #17839 which did the same for `fleetBand` in the same file.

## Producer audit
| Wire | Producer site |
|---|---|
| `'offline'` (active) | `dashboard_governance_judge.ml:164`, `dashboard_mission_agents.ml:206`, `keeper_exec_status.ml:276/353` |
| `'dead'` (active) | OCaml status enum producers |
| `'crashed'` (active) | OCaml status enum producers |
| `'unbooted'` (defensive) | No current OCaml producer. Defensive arm for non-OCaml or future runtime states. |

Per `feedback_dead_defensive_cleanup_must_check_test_lock` memory, the defensive `'unbooted'` arm is locked in by test.

## Anti-pattern audit
- §1-§7: NO — adding coverage of existing classifier, not modifying classifier

## Self-review
- Goal: prophylactic coverage of statusClass offline-triggers
- Files: 1 (`dashboard/src/components/fleet-telemetry-utils.test.ts`)
- LoC: +13
- Validation: not run locally; CI verifies

## Discovery context
Iter 60 of session-long anti-pattern lens application. Continues phase 2 defensive prophylaxis. Together with #17839, full coverage for offline-trigger classifier branches across both `fleetBand` and `statusClass` in fleet-telemetry-utils.ts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)