### PR TITLE
refactor(operator_digest): delete unused normalize_team_health

### DIFF
--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -15,12 +15,6 @@ let health_from_attention_items (items : attention_item list) =
   else if items <> [] then "warn"
   else "ok"
 
-let normalize_team_health = function
-  | "healthy" -> "ok"
-  | "degraded" -> "warn"
-  | "critical" -> "bad"
-  | other -> other
-
 let tool_host_attention_window_sec = 900.0
 
 let recent_tool_host_failures ~now () =

--- a/lib/operator/operator_digest.mli
+++ b/lib/operator/operator_digest.mli
@@ -37,7 +37,6 @@ val dedup_recommendations : recommended_action list -> recommended_action list
 val summary_of_recommendations : actor:string -> recommended_action list -> Yojson.Safe.t
 
 val health_from_attention_items : attention_item list -> string
-val normalize_team_health : string -> string
 
 val build_room_attention_items : Coord.config -> attention_item list
 


### PR DESCRIPTION
## Summary
`Operator_digest.normalize_team_health` is exported in the `.mli` but has zero callers in `lib/`, `test/`, or `dashboard/`. Delete the unused helper and its export.

## Producer audit
- `rg "normalize_team_health" lib/ test/ dashboard/` → 2 hits: the `.mli` declaration and `.ml` definition. No callers.
- The function maps `healthy`/`degraded`/`critical` → `ok`/`warn`/`bad` with a passthrough default. The conceptually adjacent producer `health_from_attention_items` computes the same output domain directly from typed `attention_item list` (no stringly-typed input), making the legacy normalizer redundant.

## Anti-pattern audit (workaround rejection bar)
- §1-§7: NO — this is a *removal* of dead defensive code, not a new addition
- Aligns with `feedback_hardcoding_and_legacy_zero_tolerance` (legacy 박멸)

## Self-review
- Goal: dead-code removal of `normalize_team_health`
- Files: 2 (`lib/operator/operator_digest.ml`, `lib/operator/operator_digest.mli`)
- LoC: -7
- Validation: not run locally; CI verifies (compile + test)
- Risk: very low — function is exported but never called

## Discovery context
Iter 61 of session-long anti-pattern lens application. Pivoted from defensive coverage extension to dead-code pruning after sweeping `lib/` for `let canonical_*` / `let normalize_*` patterns. Distinct from the timeout-budget retirement sweep — this dead helper predates that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)