### PR TITLE
refactor(operator_digest_types): delete unused planned_worker_turn_grace_sec and room_digest_session_limit

### DIFF
--- a/lib/operator/operator_digest_types.ml
+++ b/lib/operator/operator_digest_types.ml
@@ -43,8 +43,6 @@ type recommended_action = {
 }
 
 let stalled_session_threshold_sec = Env_config.InternalTimers.stalled_session_threshold_sec
-let planned_worker_turn_grace_sec = 180.0
-let room_digest_session_limit = 10
 
 let severity_rank = function
   | Sev_critical -> 3

--- a/lib/operator/operator_digest_types.mli
+++ b/lib/operator/operator_digest_types.mli
@@ -41,8 +41,6 @@ type recommended_action = {
 (** {1 Thresholds and ranking} *)
 
 val stalled_session_threshold_sec : float
-val planned_worker_turn_grace_sec : float
-val room_digest_session_limit : int
 
 (** [Sev_critical → 3], [Sev_bad → 2], [Sev_warn → 1]. Used for
     descending-severity comparators. *)


### PR DESCRIPTION
## Summary

`Operator_digest_types` exports two threshold constants with **zero callers** anywhere in the repo:

| Constant | Value | Callers |
|---|---|---|
| `planned_worker_turn_grace_sec` | `180.0` | 0 |
| `room_digest_session_limit` | `10` | 0 |

Both are orphan artifacts from the removed `Operator_digest_session` module — see `lib/operator/operator_digest.ml:5` comment `(* Operator_digest_session removed — team session cleanup *)`.

Evidence:

```
rg planned_worker_turn_grace_sec lib/ test/ dashboard/
  → only lib/operator/operator_digest_types.{ml,mli}

rg room_digest_session_limit lib/ test/ dashboard/
  → only lib/operator/operator_digest_types.{ml,mli}
```

`stalled_session_threshold_sec` is **retained** — `lib/config/env_config_runtime.{ml,mli}` references it.

## Rationale

Per `feedback_hardcoding_and_legacy_zero_tolerance` (사용자 절대 원칙): legacy 박멸 + 즉시 삭제. Companion to PR #17841 (`normalize_team_health` deletion) — same cleanup wave from the removed team-session module.

## Diff

`-4 LoC` (2 from `.ml`, 2 from `.mli`).

## Risk

None — exported but unused; deletion cannot change runtime behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)