### PR TITLE
fix(lsp): correct ocaml LSP binary name

### DIFF
--- a/lib/server/lsp_process_manager.ml
+++ b/lib/server/lsp_process_manager.ml
@@ -28,7 +28,7 @@ let pp_spawn_error fmt = function
 (** Language → command mapping. Returns [(executable, argv)] or [None]. *)
 let command_for_lang lang_id =
   match lang_id with
-  | "ocaml" -> Some ("ocaml-lsp-server", [ "ocaml-lsp-server" ])
+  | "ocaml" -> Some ("ocamllsp", [ "ocamllsp" ])
   | "typescript" | "javascript" ->
     Some ("typescript-language-server", [ "typescript-language-server"; "--stdio" ])
   | "python" -> Some ("pylsp", [ "pylsp" ])


### PR DESCRIPTION
## Summary
`ocaml-lsp-server` opam package installs `ocamllsp` binary,
not `ocaml-lsp-server`. Fixes LSP proxy spawn failure for OCaml files.

## Test plan
- [ ] `dune build` passes

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>