### PR TITLE
refactor(operator): delete unused write_review_decisions and latest_active_json

### DIFF
--- a/lib/operator/operator_judgment.ml
+++ b/lib/operator/operator_judgment.ml
@@ -196,11 +196,6 @@ let latest_active config ~surface ~target_type ~target_id =
   let table = latest_by_key config in
   Hashtbl.find_opt table (key_of ~surface ~target_type ~target_id)
 
-let latest_active_json config ~surface ~target_type ~target_id =
-  match latest_active config ~surface ~target_type ~target_id with
-  | Some value -> Some (to_yojson value)
-  | None -> None
-
 let record config ~surface ~target_type ~target_id ~summary ~confidence
     ?model_name ?runtime_name ?recommended_action ?(evidence_refs = [])
     ?(fallback_used = false) ?(disagreement_with_truth = false) ~generated_at

--- a/lib/operator/operator_judgment.mli
+++ b/lib/operator/operator_judgment.mli
@@ -119,14 +119,6 @@ val latest_active :
     [(surface, target_type, target_id)] key, comparing by
     [generated_at_unix].  None when the key has no records. *)
 
-val latest_active_json :
-  Coord.config ->
-  surface:string ->
-  target_type:target_type ->
-  target_id:string option ->
-  Yojson.Safe.t option
-(** {!latest_active} composed with {!to_yojson}. *)
-
 (** {1 Write} *)
 
 val record :

--- a/lib/operator/operator_review_state.ml
+++ b/lib/operator/operator_review_state.ml
@@ -71,12 +71,6 @@ let raw_review_decisions config =
       |> List.sort compare_review_decision
   | Some _ -> []
 
-let write_review_decisions config entries =
-  entries
-  |> List.sort compare_review_decision
-  |> List.map review_decision_to_yojson
-  |> fun rows -> Coord_utils.write_json config (review_state_path config) (`List rows)
-
 let read_review_decisions config = raw_review_decisions config
 
 let recent_review_decisions ?limit ?target_type ?target_id config =

--- a/lib/operator/operator_review_state.mli
+++ b/lib/operator/operator_review_state.mli
@@ -44,10 +44,6 @@ val compare_review_decision :
 val read_review_decisions :
   Coord_utils.config -> review_decision list
 
-(** Atomically rewrite the full decision log. *)
-val write_review_decisions :
-  Coord_utils.config -> review_decision list -> unit
-
 (** {1 Queries} *)
 
 (** [recent_review_decisions ?limit ?target_type ?target_id config]


### PR DESCRIPTION
## Summary

Two orphan helpers exported in `.mli` and defined in `.ml`, but with **zero callers** anywhere across `lib/`, `test/`, `dashboard/`:

| Function | Module | Callers |
|---|---|---|
| `write_review_decisions` | `Operator_review_state` | 0 |
| `latest_active_json` | `Operator_judgment` | 0 |

Evidence:

```
rg -n write_review_decisions lib/ test/ dashboard/
  → lib/operator/operator_review_state.ml:74  (definition)
  → lib/operator/operator_review_state.mli:48 (export)

rg -n latest_active_json lib/ test/ dashboard/
  → lib/operator/operator_judgment.ml:199  (definition)
  → lib/operator/operator_judgment.mli:122 (export)
```

## Observation (not a fix in this PR)

`write_review_decisions` having zero callers implies `review_state.json` is **never written through this code path**. The read side (`recent_review_decisions_json`, called from `operator_digest.ml`) returns the on-disk decisions, but no production code path writes them. This is either dead by design (review decisions are written by a different mechanism), or a latent gap. **Out of scope for this PR**; flagging for future investigation.

## Rationale

Continuation of the dead-export sweep (PRs #17841, #17842) — `Operator_*` modules have multiple orphan helpers surviving from earlier cleanup waves. Per `feedback_hardcoding_and_legacy_zero_tolerance`: legacy 박멸, immediate deletion.

## Diff

`-23 LoC` total (-5/-8/-6/-4 across the four files).

## Risk

None — exported but never called; deletion cannot change runtime behavior. `latest_active` (the source `record option`) and `to_yojson` both retain other live callers, so dependency chain is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)