### PR TITLE
refactor(keeper_agent_result): delete unused nonempty_trimmed helper

### DIFF
--- a/lib/keeper/keeper_agent_result.ml
+++ b/lib/keeper/keeper_agent_result.ml
@@ -55,10 +55,6 @@ type run_result =
   ; tool_surface : tool_surface_metrics
   }
 
-let nonempty_trimmed raw =
-  let trimmed = String.trim raw in
-  if trimmed = "" then None else Some trimmed
-
 (* RFC-0132 PR-2: agent-result surface label = external boundary; redact via SSOT. *)
 let runtime_lane_label =
   Boundary_redaction.to_string Boundary_redaction.runtime_model_label

--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -33,9 +33,6 @@ type run_result =
   ; tool_surface : Keeper_agent_tool_surface.tool_surface_metrics
   }
 
-(** Trim and return [None] if the result is empty. *)
-val nonempty_trimmed : string -> string option
-
 (** Legacy MASC-facing model label helper.
 
     MASC no longer exposes concrete provider/model identity on status,


### PR DESCRIPTION
## Summary

`Keeper_agent_result.nonempty_trimmed` exported in `.mli` (line 37) and defined in `.ml` (line 58) with **zero callers** through any access path.

## Audit (re-export trap awareness)

This module is consumed through the `Keeper_agent_run` compatibility facade, which does \`include Keeper_agent_result\` (keeper_agent_run.ml:8). So the audit checked **all three callsite paths**:

```
rg Keeper_agent_result.nonempty_trimmed lib/ test/ dashboard/ → 0
rg Keeper_agent_run.nonempty_trimmed    lib/ test/ dashboard/ → 0
rg nonempty_trimmed in opens of either  lib/keeper/keeper_run_tools{,_hook_accumulator}.ml{,i}
                                                              → 0 in opener files
```

The only other `nonempty_trimmed` in the tree is a **separate local definition** at `lib/governance_pipeline.ml:209` — different function, different module.

## Peer helpers stay LIVE

The other three helpers in `Keeper_agent_result` are kept:

| Helper | Caller (via Keeper_agent_run facade) |
|---|---|
| `surface_model_used` | `keeper_unified_metrics_result.ml:23`, `test_keeper_unified.ml:3692/3748` |
| `surface_resolved_model_id` | `keeper_unified_metrics_snapshot.ml:29`, `test_keeper_unified.ml:3753/3772` |
| `tool_call_detail_to_json` | `keeper_unified_metrics_json_support.ml:30`, `keeper_turn.ml:718` |

Only `nonempty_trimmed` has no consumer through any path.

## Rationale

Continuation of dead-export sweep (PRs #17841, #17842, #17846). The re-export chain via `Keeper_agent_run` initially **masked** this as live during a naïve qualified-name grep; tracing the `include` chain revealed it as the single true orphan in the module. Lesson recorded for future audits.

## Diff

`-7 LoC` (4 from `.ml`, 3 from `.mli`).

## Risk

None — function has no callers through any access path; deletion cannot change runtime behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)