### PR TITLE
test(runtime-manifest): update F8 lane mandatory event expectations

### DIFF
--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -1300,6 +1300,8 @@ let test_runtime_trace_lens_summarizes_tool_axis () =
       Alcotest.(check (list string))
         "lens gap codes"
         [ "lane_mandatory_event_missing"
+        ; "lane_mandatory_event_missing"
+        ; "lane_mandatory_event_missing"
         ; "required_tool_not_materialized"
         ; "context_delta_missing"
         ]
@@ -1527,8 +1529,8 @@ let test_runtime_trace_lens_groups_context_memory_swimlane () =
         2
         (json_int_member "episodes_flushed" memory_axis);
       Alcotest.(check int)
-        "lens memory has keeper lane gap"
-        1
+        "lens memory has keeper + memory_context lane gaps"
+        2
         (json_list_length "gaps" lens))
 
 let test_runtime_trace_lens_derives_clock_edges () =


### PR DESCRIPTION
## Summary
F8 lane mandatory event checking implementation added new gap detections that were not reflected in test expectations. This PR updates two test cases to match actual gap computation.

## Changes
- `test_runtime_trace_lens_summarizes_tool_axis` (append.007): expects 3 `lane_mandatory_event_missing` gaps (keeper + masc_policy_cascade + oas_agent)
- `test_runtime_trace_lens_groups_context_memory_swimlane` (append.010): expects 2 gaps (keeper + memory_context), updated label

## Verification
- [x] `dune build test/test_keeper_runtime_manifest.exe`
- [x] `./_build/default/test/test_keeper_runtime_manifest.exe` — 46/46 tests pass

## Context
These tests were written before F8 lane mandatory event checking was implemented in `server_dashboard_http_keeper_runtime_lens_gaps.ml`. The gap logic is correct; test expectations were stale.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>