### PR TITLE
fix(dashboard): post-spawn refresh + offline-task label + hint label clarity

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -181,7 +181,7 @@ describe('rosterStateNote — RFC-0135 §1.1 typed-state conditioning', () => {
       null,
       '관찰 메모',
     )
-    expect(note).toEqual({ label: '상태 메모', text: '관찰 메모' })
+    expect(note).toEqual({ label: '참고', text: '관찰 메모' })
   })
 
   it('paused keeper produces no state note (signaled by badge elsewhere)', () => {
@@ -200,6 +200,15 @@ describe('rosterStateNote — RFC-0135 §1.1 typed-state conditioning', () => {
       null,
     )
     expect(note).toBeNull()
+  })
+
+  it('offline keeper with assigned task shows interrupted work label', () => {
+    const note = rosterStateNote(
+      k({ phase: 'Crashed', status: 'offline', agent: { current_task: 'task-001', exists: true } }),
+      null,
+      null,
+    )
+    expect(note).toEqual({ label: '작업 중단', text: '할당된 작업이 있으나 keeper가 crashed 상태입니다' })
   })
 
   it('null keeper returns null', () => {

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -143,11 +143,15 @@ export function rosterStateNote(
     }
   }
 
+  if (state.kind === 'offline' && keeper.agent?.current_task) {
+    return { label: '작업 중단', text: `할당된 작업이 있으나 keeper가 ${state.cause} 상태입니다` }
+  }
+
   const diagnosticError = keeper.diagnostic?.last_error?.trim()
   if (diagnosticError) return { label: '최근 오류', text: diagnosticError }
 
   const hint = monitoringHint?.trim()
-  if (hint) return { label: '상태 메모', text: hint }
+  if (hint) return { label: '참고', text: hint }
   return null
 }
 

--- a/dashboard/src/components/keeper-spawn/keeper-spawn-state.ts
+++ b/dashboard/src/components/keeper-spawn/keeper-spawn-state.ts
@@ -3,7 +3,7 @@ import { callMcpTool } from '../../api/mcp'
 import { asBoolean, asString, asStringArray, extractArray, isRecord } from '../common/normalize'
 import { showToast } from '../common/toast'
 import { createAsyncResource, getData } from '../../lib/async-state'
-import { shellAuthSummary } from '../../store'
+import { refreshExecution, shellAuthSummary } from '../../store'
 import { dashboardAuthAccess } from '../../lib/dashboard-auth-access'
 
 export interface PersonaSummary {
@@ -217,7 +217,10 @@ export async function spawnKeeperFromPersona(personaName: string, opts?: { dryRu
     if (opts?.dryRun) args.dry_run = true
     const result = await callMcpTool('masc_keeper_create_from_persona', args)
     spawnResult.value = { success: true, message: result }
-    if (!opts?.dryRun) showToast(`${personaName} 키퍼 생성 완료`, 'success')
+    if (!opts?.dryRun) {
+      showToast(`${personaName} 키퍼 생성 완료`, 'success')
+      void refreshExecution({ force: true })
+    }
   } catch (err) {
     const message = formatKeeperSpawnError(err instanceof Error ? err.message : String(err))
     spawnResult.value = { success: false, message }


### PR DESCRIPTION
## Summary
- 키퍼 생성 성공 후 목록 갱신 누락 수정 (Q6) — `refreshExecution({ force: true })` 추가
- offline keeper에 할당된 작업이 있으면 "작업 중단" 라벨 표시 (Q1) — `keeper.agent?.current_task` 기반
- informational hint 라벨 "상태 메모" → "참고" 변경 (Q5) — 차단 근거 컬럼에서 오인 방지

## Test plan
- [x] `agent-roster.test.ts` 20/20 pass (기존 테스트 정정 + 신규 테스트 1건)
- [x] `tsc --noEmit` — 우리 변경으로 인한 타입 에러 없음 (기존 에러 1건은 `keeper-detail-alert-strip.ts`)
- [ ] 수동: 대시보드에서 키퍼 생성 → 목록에 즉시 나타나는지 확인
- [ ] 수동: offline+task keeper 카드에서 "작업 중단" 라벨 확인
- [ ] 수동: non-blocker hint 카드에서 "참고" 라벨 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)