### PR TITLE
refactor(agent_health): delete unused get_all_summaries

### DIFF
--- a/lib/agent_health.ml
+++ b/lib/agent_health.ml
@@ -141,21 +141,6 @@ let get_summary ~agent_name : agent_health_summary =
     cooldown_remaining_sec = cooldown_remaining_of status.open_until;
   }
 
-(** Get health summaries for all known agents. *)
-let get_all_summaries () : agent_health_summary list =
-  let breakers = Circuit_breaker.list_all_breakers (Eio.Lazy.force Circuit_breaker.global) in
-  List.map (fun (s : Circuit_breaker.breaker_status) ->
-    {
-      agent_name = s.agent_id;
-      status =
-        health_status_of_breaker
-          ~state_name:s.state_name
-          ~open_reason:s.open_reason;
-      recent_failures = s.recent_failures;
-      cooldown_remaining_sec = cooldown_remaining_of s.open_until;
-    }
-  ) breakers
-
 (** {1 JSON Serialization} *)
 
 let health_status_to_string = function

--- a/lib/agent_health.mli
+++ b/lib/agent_health.mli
@@ -27,8 +27,7 @@ module Random = Stdlib.Random
     - Pre-action: {!is_healthy} before [decide_agent_action]
     - Post-action: {!record_success} / {!record_failure} after
       [execute_agent_action]
-    - Statistics: {!get_summary} / {!get_all_summaries} for
-      dashboard/monitoring
+    - Statistics: {!get_summary} for dashboard/monitoring
 
     @since 2.75.0 *)
 
@@ -80,8 +79,6 @@ val filter_healthy :
 (** {1 Statistics} *)
 
 val get_summary : agent_name:string -> agent_health_summary
-
-val get_all_summaries : unit -> agent_health_summary list
 
 (** {1 JSON Serialization} *)
 


### PR DESCRIPTION
## Summary

`Agent_health.get_all_summaries` exported (lib/agent_health.mli:84) and defined (lib/agent_health.ml:145) with **zero callers** anywhere across lib/, test/, dashboard/.

## Audit (5-prong, per feedback_dead_export_audit_must_trace_include_facade)

```
rg "Agent_health\.get_all_summaries"      → 0 qualified callers
rg "include Agent_health|module \w+ = Agent_health" → 0 facade re-exporters
rg "open Agent_health"                    → 0 opener files
rg "get_all_summaries" lib/agent_health.ml → only the definition at line 145
                                             (line 110 is a design comment, not a use)
```

The companion function `get_summary` (single-agent variant, called from `keeper_status_bridge.ml` etc.) is **retained**.

## Cleanup details

- `lib/agent_health.ml`: -15 LoC (function body + 1-line docstring above it)
- `lib/agent_health.mli`: -2 LoC (val + blank), -1/+1 LoC (docstring cross-reference at line 30 trimmed to drop `{!get_all_summaries}`)

The module-overview docstring previously listed both `{!get_summary}` and `{!get_all_summaries}` under "Statistics"; updated to mention only the surviving function.

## Rationale

Continuation of dead-export sweep (PRs #17841, #17842, #17846, #17847). First find in the top-level `lib/` namespace after `Operator_*` and `Keeper_agent_*` families saturated. Per `feedback_hardcoding_and_legacy_zero_tolerance`: legacy 박멸 + immediate deletion.

## Diff

`-18 LoC` net (-15 from .ml, -3 net from .mli).

## Risk

None — zero callers across all 5 audit paths. Deletion cannot change runtime behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)