### PR TITLE
refactor(keeper): extract Docker helpers from keeper_shell_bash

### DIFF
--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -37,68 +37,11 @@ let normalize_path_for_keeper_bash_containment path =
   Keeper_alerting_path.normalize_path_for_check path
   |> Keeper_alerting_path.strip_trailing_slashes
 
-let typed_docker_image (meta : keeper_meta) =
-  match meta.sandbox_image with
-  | Some img when String.trim img <> "" -> img
-  | _ -> Env_config_keeper.KeeperSandbox.docker_image ()
-
-let typed_docker_sandbox_target ~turn_sandbox_factory ~meta ~cwd =
-  match Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd with
-  | None ->
-    Error
-      "typed Bash Docker Shell IR dispatch requires a turn sandbox factory"
-  | Some runtime ->
-    let image = typed_docker_image meta in
-    let runner ~stdin_content ~argv ~env:_ ~cwd:stage_cwd ~timeout_sec =
-      let cwd = Option.value stage_cwd ~default:cwd in
-      match
-        Keeper_turn_sandbox_runtime.run_exec_with_status
-          ?stdin_content
-          runtime
-          ~timeout_sec
-          ~cwd
-          ~command_argv:argv
-      with
-      | Ok (status, output) -> status, output, ""
-      | Error err -> Unix.WEXITED 1, "", err
-    in
-    let pipeline_runner ~stages ~timeout_sec =
-      let stages =
-        List.map
-          (fun stage ->
-            { Keeper_turn_sandbox_runtime.command_argv = stage.Masc_exec.Sandbox_target.argv
-            ; cwd = stage.cwd
-            })
-          stages
-      in
-      match
-        Keeper_turn_sandbox_runtime.run_exec_pipeline_with_status
-          runtime
-          ~timeout_sec
-          ~cwd
-          ~stages
-      with
-      | Ok result -> result
-      | Error err -> Unix.WEXITED 1, "", err
-    in
-    Ok (Masc_exec.Sandbox_target.docker ~image ~runner ~pipeline_runner ())
-
-let typed_docker_runtime_failure_fields output =
-  if String_util.contains_substring output "sandbox_image_missing"
-  then [ "failure_class", `String "policy_rejection" ]
-  else []
-
-let typed_docker_local_fallback_target ~meta ~timeout_sec =
-  let image = typed_docker_image meta in
-  match Keeper_sandbox_runtime.docker_image_present ~image ~timeout_sec with
-  | Ok () -> None
-  | Error message ->
-    Some
-      ( Masc_exec.Sandbox_target.host ()
-      , [ "requested_sandbox", `String "docker"
-        ; "sandbox_fallback", `String "local_playground"
-        ; "sandbox_fallback_reason", `String (Exec_policy.truncate_for_log message)
-        ] )
+(* Docker helpers extracted to [Keeper_shell_bash_docker] (godfile decomp). *)
+let typed_docker_image = Keeper_shell_bash_docker.typed_docker_image
+let typed_docker_sandbox_target = Keeper_shell_bash_docker.typed_docker_sandbox_target
+let typed_docker_runtime_failure_fields = Keeper_shell_bash_docker.typed_docker_runtime_failure_fields
+let typed_docker_local_fallback_target = Keeper_shell_bash_docker.typed_docker_local_fallback_target
 
 let handle_keeper_bash_typed
       ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)

--- a/lib/keeper/keeper_shell_bash_docker.ml
+++ b/lib/keeper/keeper_shell_bash_docker.ml
@@ -1,0 +1,71 @@
+(* Docker sandbox helpers for typed keeper_bash Shell IR dispatch.
+   Extracted from [Keeper_shell_bash] (godfile decomp). *)
+
+open Keeper_types
+
+let typed_docker_image (meta : keeper_meta) =
+  match meta.sandbox_image with
+  | Some img when String.trim img <> "" -> img
+  | _ -> Env_config_keeper.KeeperSandbox.docker_image ()
+;;
+
+let typed_docker_sandbox_target ~turn_sandbox_factory ~meta ~cwd =
+  match Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd with
+  | None ->
+    Error
+      "typed Bash Docker Shell IR dispatch requires a turn sandbox factory"
+  | Some runtime ->
+    let image = typed_docker_image meta in
+    let runner ~stdin_content ~argv ~env:_ ~cwd:stage_cwd ~timeout_sec =
+      let cwd = Option.value stage_cwd ~default:cwd in
+      match
+        Keeper_turn_sandbox_runtime.run_exec_with_status
+          ?stdin_content
+          runtime
+          ~timeout_sec
+          ~cwd
+          ~command_argv:argv
+      with
+      | Ok (status, output) -> status, output, ""
+      | Error err -> Unix.WEXITED 1, "", err
+    in
+    let pipeline_runner ~stages ~timeout_sec =
+      let stages =
+        List.map
+          (fun stage ->
+            { Keeper_turn_sandbox_runtime.command_argv = stage.Masc_exec.Sandbox_target.argv
+            ; cwd = stage.cwd
+            })
+          stages
+      in
+      match
+        Keeper_turn_sandbox_runtime.run_exec_pipeline_with_status
+          runtime
+          ~timeout_sec
+          ~cwd
+          ~stages
+      with
+      | Ok result -> result
+      | Error err -> Unix.WEXITED 1, "", err
+    in
+    Ok (Masc_exec.Sandbox_target.docker ~image ~runner ~pipeline_runner ())
+;;
+
+let typed_docker_runtime_failure_fields output =
+  if String_util.contains_substring output "sandbox_image_missing"
+  then [ "failure_class", `String "policy_rejection" ]
+  else []
+;;
+
+let typed_docker_local_fallback_target ~meta ~timeout_sec =
+  let image = typed_docker_image meta in
+  match Keeper_sandbox_runtime.docker_image_present ~image ~timeout_sec with
+  | Ok () -> None
+  | Error message ->
+    Some
+      ( Masc_exec.Sandbox_target.host ()
+      , [ "requested_sandbox", `String "docker"
+        ; "sandbox_fallback", `String "local_playground"
+        ; "sandbox_fallback_reason", `String (Exec_policy.truncate_for_log message)
+        ] )
+;;

--- a/lib/keeper/keeper_shell_bash_docker.mli
+++ b/lib/keeper/keeper_shell_bash_docker.mli
@@ -1,0 +1,16 @@
+(** Docker sandbox helpers for typed keeper_bash Shell IR dispatch. *)
+
+val typed_docker_image : Keeper_types.keeper_meta -> string
+
+val typed_docker_sandbox_target
+  :  turn_sandbox_factory:Keeper_sandbox_factory.t option
+  -> meta:Keeper_types.keeper_meta
+  -> cwd:string
+  -> (Masc_exec.Sandbox_target.t, string) result
+
+val typed_docker_runtime_failure_fields : string -> (string * Yojson.Safe.t) list
+
+val typed_docker_local_fallback_target
+  :  meta:Keeper_types.keeper_meta
+  -> timeout_sec:float
+  -> (Masc_exec.Sandbox_target.t * (string * Yojson.Safe.t) list) option


### PR DESCRIPTION
## Summary

Extract 4 Docker-specific functions from \`keeper_shell_bash.ml\` into a new module \`keeper_shell_bash_docker.ml\` to reduce file size below the 300-line decomposition threshold.

### Extracted functions

- \`typed_docker_image\`
- \`typed_docker_sandbox_target\`
- \`typed_docker_runtime_failure_fields\`
- \`typed_docker_local_fallback_target\`

### Changed files

| File | Change |
|------|--------|
| \`lib/keeper/keeper_shell_bash.ml\` | Remove 62 lines of Docker logic, add 4 re-export aliases |
| \`lib/keeper/keeper_shell_bash_docker.ml\` | New module — extracted Docker helpers |
| \`lib/keeper/keeper_shell_bash_docker.mli\` | Interface for extracted module |

### Verification

- \`dune build --root .\` passes
- No behavioral change — original module re-exports via aliases

RFC-WAIVED: Simple godfile decomposition (no functional change to sandbox/containment semantics).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>