### PR TITLE
refactor(agent_sdk_response): delete unused model_used facade method

### DIFF
--- a/lib/agent_sdk_response.ml
+++ b/lib/agent_sdk_response.ml
@@ -8,7 +8,4 @@ type api_response = Agent_sdk.Types.api_response
 let text_of_response (response : api_response) =
   Agent_sdk.Types.text_of_content response.content
 
-let model_used (response : api_response) =
-  response.model
-
 let usage (response : api_response) = response.usage

--- a/lib/agent_sdk_response.mli
+++ b/lib/agent_sdk_response.mli
@@ -8,9 +8,6 @@ type api_response = Agent_sdk.Types.api_response
 val text_of_response : api_response -> string
 (** Extract text content from an API response. *)
 
-val model_used : api_response -> string
-(** Return the model identifier used for the response. *)
-
 val usage : api_response -> Agent_sdk.Types.api_usage option
 (** Return provider-reported usage stats, if present. [None] means the
     provider did not report usage; callers must not treat it as zero. *)


### PR DESCRIPTION
## Summary

`Agent_sdk_response.model_used` is a 1-line accessor returning `response.model`. Exported in `.mli:11` and defined in `.ml:11` but has **zero callers** anywhere in lib/, test/, dashboard/.

## Audit (5-prong)

```
rg "Agent_sdk_response\.model_used"           → 0 qualified callers
rg "include Agent_sdk_response|module \w+ = Agent_sdk_response" → 0 facade re-exporters
rg "open Agent_sdk_response"                   → 0 opener files
rg "model_used" lib/agent_sdk_response.ml      → only the definition (line 11)
```

## Companion accessors retained

| Function | External callers | Status |
|---|---|---|
| `text_of_response` | 8 | LIVE — kept |
| `model_used` | **0** | DEAD — this PR |
| `usage` | 1 | LIVE — kept |

The module docstring positions itself as a *repo-local facade* for SDK response access. `text_of_response` and `usage` fulfill that role with real consumers; `model_used` does not.

## Risk

None. 1-line accessor; can be reintroduced trivially if a future consumer needs it. Removing now keeps the public surface aligned with actual usage.

## Diff

`-6 LoC` (3 from .ml, 3 from .mli).

## Iter 67 context

Iter 67 audited 8 top-level lib/ modules (admission_queue, admission_queue_metrics, agent_economy, agent_identity, agent_name_kind, agent_registry_eio, agent_sdk_response, agent_tool_surfaces). This is the **only truly-dead export** found:

- `Admission_queue.{try_with_permit, set_max_concurrent, max_concurrent, reset_for_test}` — 4 candidates with 0 callers, but **RFC-0026 cascade-layer admission router scaffolding** explicitly referenced in `.mli:8-10`. Deferred per `feedback_audit_recommended_variant_must_verify_live_data` (scaffolding intent vs immediate removal).
- `Agent_tool_surfaces` — 13 candidates with 0 qualified callers, but **all 13 internally LIVE** within `agent_tool_surfaces.ml`. Narrowing candidates (not deletion).
- Other modules — internally LIVE or PPX convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)