### PR TITLE
fix(dashboard): error recency label, phase dedup, synthetic description

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -158,7 +158,7 @@ describe('rosterStateNote — RFC-0135 §1.1 typed-state conditioning', () => {
     })
   })
 
-  it('falls through to diagnostic error when no blocker and no stale blocker', () => {
+  it('running keeper with diagnostic error shows "이전 오류" (not current)', () => {
     const note = rosterStateNote(
       k({
         phase: 'Running',
@@ -172,7 +172,25 @@ describe('rosterStateNote — RFC-0135 §1.1 typed-state conditioning', () => {
       compositeWith(attention({ execution_current: true })),
       null,
     )
-    expect(note).toEqual({ label: '최근 오류', text: 'tool call failed' })
+    expect(note).toEqual({ label: '이전 오류', text: 'tool call failed' })
+  })
+
+  it('offline keeper with diagnostic error shows "최근 오류"', () => {
+    const note = rosterStateNote(
+      k({
+        phase: 'Crashed',
+        status: 'offline',
+        diagnostic: {
+          last_error: 'fiber died',
+          health_state: 'degraded',
+          next_action_path: 'recover',
+          last_reply_status: 'error',
+        },
+      }),
+      null,
+      null,
+    )
+    expect(note).toEqual({ label: '최근 오류', text: 'fiber died' })
   })
 
   it('falls through to monitoring hint when nothing else applies', () => {

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -148,7 +148,9 @@ export function rosterStateNote(
   }
 
   const diagnosticError = keeper.diagnostic?.last_error?.trim()
-  if (diagnosticError) return { label: '최근 오류', text: diagnosticError }
+  if (diagnosticError) {
+    return { label: state.kind === 'running' ? '이전 오류' : '최근 오류', text: diagnosticError }
+  }
 
   const hint = monitoringHint?.trim()
   if (hint) return { label: '참고', text: hint }
@@ -879,7 +881,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             <span><strong class="text-[var(--color-fg-secondary)]">현재 단계</strong>는 FSM/monitor phase입니다.</span>
             <span><strong class="text-[var(--color-fg-secondary)]">차단 근거</strong>는 live/stale blocker 증거입니다.</span>
             <span><strong class="text-[var(--color-fg-secondary)]">점</strong>은 활동/presence입니다. 흔들리면 방금 움직였습니다.</span>
-            <span><strong class="text-[var(--color-fg-secondary)]">파생</strong>은 keeper 런타임에서 만든 synthetic row입니다.</span>
+            <span><strong class="text-[var(--color-fg-secondary)]">파생</strong>은 keeper가 자동 생성한 sub-op alias입니다. 카운트에서 중복 제외됩니다.</span>
           </div>
           <div class="grid grid-cols-[minmax(180px,1.35fr)_minmax(90px,0.55fr)_minmax(150px,1fr)_minmax(150px,1fr)_minmax(120px,0.7fr)] gap-3 border-b border-[var(--color-border-divider)] px-4 py-2.5 text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)] max-lg:hidden">
             <span>Keeper</span>
@@ -896,7 +898,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
               const nowLabel =
                 row.fsmStageText
                 ?? row.monitoringEvidence?.phase?.label
-                ?? row.band.label
+                ?? (row.monitoringEvidence?.stage?.label ?? '-')
               const latestTool = row.recentTools[0] ?? (row.toolCallCount != null && row.toolCallCount > 0 ? `${row.toolCallCount} calls` : '-')
 
               return html`


### PR DESCRIPTION
## Summary
- **Q2**: Running keeper diagnostic errors now labeled "이전 오류" (not "최근 오류") to avoid implying a current error when the keeper has already recovered
- **Q3**: "현재 단계" column no longer falls back to band label ("가동중"), eliminating the "가동중이면서 가동중" duplication. Shows monitoring stage or "-" instead
- **Q4**: "파생" explanation improved to clarify these are auto-generated sub-op aliases excluded from runtime counts

## Test plan
- [x] `tsc --noEmit` passes (1 pre-existing unused var in unrelated file)
- [x] `vitest run src/components/agent-roster.test.ts` — 21/21 pass (2 new tests for Q2)
- [ ] Manual: verify running keeper with diagnostic error shows "이전 오류" in blocker column
- [ ] Manual: verify active keeper "현재 단계" shows "-" or stage label, not "가동중"

Continues #17849 (Q1/Q5/Q6). Closes remaining Q2-Q4 from the 6-issue dashboard UX sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)