### PR TITLE
feat(runtime-lens): OAS §9.7 mandatory proof matrix gap codes (9 new gaps)

### DIFF
--- a/lib/server/server_dashboard_http_keeper_runtime_lens_gaps.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_gaps.ml
@@ -335,6 +335,151 @@ let runtime_lens_gaps ~terminal_event_present ~claim_scope ~config_drift scan =
            }
            :: gaps
          else gaps)
+    |> (fun gaps ->
+         if scan.total_rows > 0
+            && runtime_manifest_scan_event_count scan Keeper_runtime_manifest.Turn_started
+               > 0
+            && runtime_manifest_scan_event_count scan Keeper_runtime_manifest.Phase_gate_decided
+               = 0
+         then
+           { code = "phase_gate_missing"
+           ; severity = "warn"
+           ; lane = "keeper"
+           ; detail = Some "turn started but no phase_gate_decided event recorded"
+           }
+           :: gaps
+         else gaps)
+    |> (fun gaps ->
+         if scan.total_rows > 0
+            && runtime_manifest_scan_event_count scan Keeper_runtime_manifest.Turn_started
+               > 0
+            && runtime_manifest_scan_event_count scan Keeper_runtime_manifest.Cascade_routed
+               = 0
+         then
+           { code = "cascade_decision_missing"
+           ; severity = "warn"
+           ; lane = "masc_policy_cascade"
+           ; detail = Some "turn started but no cascade_routed event recorded"
+           }
+           :: gaps
+         else gaps)
+    |> (fun gaps ->
+         if scan.provider_started_count > scan.provider_finished_count
+         then
+           { code = "provider_attempt_unclosed"
+           ; severity = "bad"
+           ; lane = "provider"
+           ; detail =
+               Some
+                 (Printf.sprintf
+                    "provider attempts started (%d) exceeds finished (%d)"
+                    scan.provider_started_count
+                    scan.provider_finished_count)
+           }
+           :: gaps
+         else gaps)
+    |> (fun gaps ->
+         match scan.provider_terminal_row with
+         | Some row ->
+           let decision = row.Keeper_runtime_manifest.decision in
+           (match json_string_member_opt "terminal_provider_kind" decision with
+            | Some _ -> gaps
+            | None ->
+              { code = "provider_provenance_missing"
+              ; severity = "warn"
+              ; lane = "provider"
+              ; detail = Some "terminal provider row lacks terminal_provider_kind"
+              }
+              :: gaps)
+         | None -> gaps)
+    |> (fun gaps ->
+         match scan.latest_tool_lineage_decision with
+         | Some decision ->
+           let has_emitted =
+             match Yojson.Safe.Util.member "emitted" decision with
+             | `Assoc _ -> true
+             | _ -> false
+           in
+           let has_executed =
+             match Yojson.Safe.Util.member "executed" decision with
+             | `Assoc _ -> true
+             | _ -> false
+           in
+           if has_emitted && not has_executed
+           then
+             { code = "tool_emitted_not_executed"
+             ; severity = "warn"
+             ; lane = "tool_runtime"
+             ; detail = Some "tool lineage shows emitted stage but no executed stage"
+             }
+             :: gaps
+           else gaps
+         | None -> gaps)
+    |> (fun gaps ->
+         match scan.latest_tool_lineage_decision with
+         | Some decision ->
+           let has_executed =
+             match Yojson.Safe.Util.member "executed" decision with
+             | `Assoc _ -> true
+             | _ -> false
+           in
+           let has_verified =
+             match Yojson.Safe.Util.member "verified" decision with
+             | `Assoc _ -> true
+             | _ -> false
+           in
+           if has_executed && not has_verified
+           then
+             { code = "tool_execution_unverified"
+             ; severity = "warn"
+             ; lane = "tool_runtime"
+             ; detail = Some "tool lineage shows executed stage but no verified stage"
+             }
+             :: gaps
+           else gaps
+         | None -> gaps)
+    |> (fun gaps ->
+         match scan.latest_context_compacted_row with
+         | Some row ->
+           let decision = row.Keeper_runtime_manifest.decision in
+           (match json_string_member_opt "source_phase" decision with
+            | Some _ -> gaps
+            | None ->
+              { code = "compaction_source_missing"
+              ; severity = "warn"
+              ; lane = "memory_context"
+              ; detail = Some "context_compacted row lacks source_phase"
+              }
+              :: gaps)
+         | None -> gaps)
+    |> (fun gaps ->
+         match scan.latest_context_injected_row with
+         | Some row ->
+           let decision = row.Keeper_runtime_manifest.decision in
+           (match json_string_member_opt "context_digest" decision with
+            | Some _ -> gaps
+            | None ->
+              { code = "context_digest_missing"
+              ; severity = "warn"
+              ; lane = "memory_context"
+              ; detail = Some "context_injected row lacks context_digest"
+              }
+              :: gaps)
+         | None -> gaps)
+    |> (fun gaps ->
+         match scan.latest_memory_injected_row with
+         | Some row ->
+           let decision = row.Keeper_runtime_manifest.decision in
+           (match json_string_member_opt "payload_digest" decision with
+            | Some _ -> gaps
+            | None ->
+              { code = "memory_payload_digest_missing"
+              ; severity = "warn"
+              ; lane = "memory_context"
+              ; detail = Some "memory_injected row lacks payload_digest"
+              }
+              :: gaps)
+         | None -> gaps)
   in
   gaps
   @ Server_dashboard_http_keeper_runtime_lens_clock_groups.runtime_lens_clock_gaps

--- a/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
@@ -42,6 +42,9 @@ type runtime_manifest_scan =
   ; mutable provider_started_count : int
   ; mutable provider_finished_count : int
   ; mutable provider_terminal_row : Keeper_runtime_manifest.t option
+  ; mutable latest_context_injected_row : Keeper_runtime_manifest.t option
+  ; mutable latest_context_compacted_row : Keeper_runtime_manifest.t option
+  ; mutable latest_memory_injected_row : Keeper_runtime_manifest.t option
   ; mutable dag_edges : (string * string) list
   }
 
@@ -82,6 +85,9 @@ let make_runtime_manifest_scan ~path ~limit =
   ; provider_started_count = 0
   ; provider_finished_count = 0
   ; provider_terminal_row = None
+  ; latest_context_injected_row = None
+  ; latest_context_compacted_row = None
+  ; latest_memory_injected_row = None
   ; dag_edges = []
   }
 
@@ -186,9 +192,11 @@ let update_runtime_manifest_scan scan row =
    | Keeper_runtime_manifest.Tool_lineage_recorded ->
      scan.latest_tool_lineage_decision <- Some row.Keeper_runtime_manifest.decision
    | Keeper_runtime_manifest.Context_injected ->
-     scan.context_injected_count <- scan.context_injected_count + 1
+     scan.context_injected_count <- scan.context_injected_count + 1;
+     scan.latest_context_injected_row <- Some row
    | Keeper_runtime_manifest.Context_compacted ->
-     scan.context_compacted_event_count <- scan.context_compacted_event_count + 1
+     scan.context_compacted_event_count <- scan.context_compacted_event_count + 1;
+     scan.latest_context_compacted_row <- Some row
    | Keeper_runtime_manifest.State_snapshot_sidecar_saved ->
      scan.active_open_loop_count <-
        json_int_member_opt "active_open_loop_count"
@@ -220,6 +228,7 @@ let update_runtime_manifest_scan scan row =
       | _ -> ())
    | Keeper_runtime_manifest.Memory_injected ->
      scan.memory_injected_count <- scan.memory_injected_count + 1;
+     scan.latest_memory_injected_row <- Some row;
      if String.equal row.Keeper_runtime_manifest.status "injected"
      then scan.memory_injected_present_count <- scan.memory_injected_present_count + 1
    | Keeper_runtime_manifest.Memory_flushed ->

--- a/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.mli
+++ b/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.mli
@@ -40,6 +40,9 @@ type runtime_manifest_scan =
   ; mutable provider_started_count : int
   ; mutable provider_finished_count : int
   ; mutable provider_terminal_row : Keeper_runtime_manifest.t option
+  ; mutable latest_context_injected_row : Keeper_runtime_manifest.t option
+  ; mutable latest_context_compacted_row : Keeper_runtime_manifest.t option
+  ; mutable latest_memory_injected_row : Keeper_runtime_manifest.t option
   ; mutable dag_edges : (string * string) list
   }
 

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -1530,7 +1530,7 @@ let test_runtime_trace_lens_groups_context_memory_swimlane () =
         (json_int_member "episodes_flushed" memory_axis);
       Alcotest.(check int)
         "lens memory has keeper + memory_context lane gaps"
-        2
+        4
         (json_list_length "gaps" lens))
 
 let test_runtime_trace_lens_derives_clock_edges () =


### PR DESCRIPTION
## Summary

Implements 9 remaining diagnostic gap codes from OAS §9.7 Mandatory Proof Matrix:

| Gap code | Severity | Lane | Condition |
|----------|----------|------|-----------|
| `phase_gate_missing` | warn | keeper | Turn_started > 0, Phase_gate_decided = 0 |
| `cascade_decision_missing` | warn | masc_policy_cascade | Turn_started > 0, Cascade_routed = 0 |
| `provider_attempt_unclosed` | bad | provider | Provider_started > Provider_finished |
| `provider_provenance_missing` | warn | provider | Terminal row lacks `terminal_provider_kind` |
| `tool_emitted_not_executed` | warn | tool_runtime | Tool lineage emitted stage but no executed stage |
| `tool_execution_unverified` | warn | tool_runtime | Tool lineage executed stage but no verified stage |
| `compaction_source_missing` | warn | memory_context | Context_compacted row lacks `source_phase` |
| `context_digest_missing` | warn | memory_context | Context_injected row lacks `context_digest` |
| `memory_payload_digest_missing` | warn | memory_context | Memory_injected row lacks `payload_digest` |

## Changes

- `lib/server/server_dashboard_http_keeper_runtime_lens_gaps.ml`: +9 gap detectors
- `lib/server/server_dashboard_http_keeper_runtime_manifest_scan.mli/.ml`: +3 scan fields (`latest_context_injected_row`, `latest_context_compacted_row`, `latest_memory_injected_row`)
- `test/test_keeper_runtime_manifest.ml`: expectation update (2→4 gaps for empty-decision fixtures)

## Verification

- `dune build @runtest` (`test_keeper_runtime_manifest.exe`): **47/47 pass**

🤖 Generated with [Claude Code](https://claude.com/code)