### PR TITLE
refactor(activity_graph_registry): delete unused client_count + dead atomic counter

### DIFF
--- a/lib/activity_graph/activity_graph_registry.ml
+++ b/lib/activity_graph/activity_graph_registry.ml
@@ -12,7 +12,6 @@ type client = {
 
 let clients : (string, client) Hashtbl.t = Hashtbl.create 16
 let registry_mutex = Eio.Mutex.create ()
-let client_count_atomic = Atomic.make 0
 let client_id_counter = Atomic.make 0
 
 let with_registry_rw f =
@@ -45,25 +44,18 @@ let register session_id ~push ~last_seq ?(kind_filters = []) () =
           created_at;
         }
       in
-      let existed = Hashtbl.mem clients session_id in
       Hashtbl.replace clients session_id client;
-      if not existed then Atomic.incr client_count_atomic;
       client_id)
 
 let unregister session_id =
   with_registry_rw (fun () ->
-      if Hashtbl.mem clients session_id then begin
-        Hashtbl.remove clients session_id;
-        Atomic.decr client_count_atomic
-      end)
+      if Hashtbl.mem clients session_id then
+        Hashtbl.remove clients session_id)
 
 let unregister_if_current session_id client_id =
   with_registry_rw (fun () ->
       match Hashtbl.find_opt clients session_id with
       | Some client when client.client_id = client_id ->
-          Hashtbl.remove clients session_id;
-          Atomic.decr client_count_atomic
+          Hashtbl.remove clients session_id
       | Some _ -> ()
       | None -> ())
-
-let client_count () = Atomic.get client_count_atomic

--- a/lib/activity_graph/activity_graph_registry.mli
+++ b/lib/activity_graph/activity_graph_registry.mli
@@ -7,10 +7,10 @@
     fan-out without re-introducing the cycle this split was
     extracted to break.
 
-    Internal storage (the [registry_mutex] handle, the
-    [client_count_atomic] counter, and the [client_id_counter]
-    monotonic id source) is hidden — callers consume only the
-    locked accessors and the lifecycle entry points. *)
+    Internal storage (the [registry_mutex] handle and the
+    [client_id_counter] monotonic id source) is hidden — callers
+    consume only the locked accessors and the lifecycle entry
+    points. *)
 
 open Activity_graph_types
 
@@ -58,9 +58,7 @@ val register :
   unit ->
   int
 (** Register or replace the client for [session_id] and return
-    the freshly-allocated [client_id] (monotonic, never reused).
-    A re-register with the same [session_id] preserves the
-    counter — only new sessions increment {!client_count}. *)
+    the freshly-allocated [client_id] (monotonic, never reused). *)
 
 val unregister : string -> unit
 (** Drop the client for [session_id] unconditionally. No-op when
@@ -71,8 +69,3 @@ val unregister_if_current : string -> int -> unit
     [client_id] equals the given one. Used to avoid a TOCTOU
     where a slow disconnect handler removes a client another
     fiber has already replaced via {!register}. *)
-
-val client_count : unit -> int
-(** Number of distinct [session_id]s currently registered.
-    Backed by an [Atomic.t] so the read does not take the
-    registry lock. *)


### PR DESCRIPTION
## Summary

`Activity_graph_registry.client_count` (also reachable as `Activity_graph.client_count` via the `include` re-export) has **zero callers** anywhere across lib/, test/, dashboard/.

Because removing the read side made `client_count_atomic` write-only, the supporting atomic plus its `Atomic.incr` / `Atomic.decr` call sites in `register` / `unregister` / `unregister_if_current` are deleted in the same change. The Hashtbl (`clients`) already tracks live membership; the atomic was a derived projection that only existed to back the now-dead accessor.

## Same-name disambiguation

The dashboard's SSE channel exposes a separate `Sse.client_count` function for its own client pool. That one is **live** (used by `server_routes_http_runtime`, `server_runtime_bootstrap`, `server_mcp_transport_http`, and three `test_sse_*` files). They are independent functions with the same name in different modules; only the `Activity_graph_registry` one is dead.

## 5-prong audit

```
rg "Activity_graph_registry\.client_count"   → 0 qualified callers
rg "Activity_graph\.client_count"            → 0 facade callers
                                                (matches in lib/sse/test/server
                                                 are the unrelated Sse.client_count)
rg "open Activity_graph_registry"            → 0 opener files
rg "client_count" lib/activity_graph/activity_graph.ml
                                              → 0 unqualified uses in parent
rg "client_count" lib/activity_graph/activity_graph_registry.ml
                                              → only the deleted definition
```

## Diff

`-23 / +8 = -15 net LoC`:

| File | -lines | +lines |
|---|---|---|
| `lib/activity_graph/activity_graph_registry.ml` | -10 | +4 |
| `lib/activity_graph/activity_graph_registry.mli` | -13 | +4 |

Net change includes:
- Drops `client_count_atomic` (1 line) + 3 `Atomic.incr`/`Atomic.decr` lines from the lifecycle functions
- Drops `let client_count () = ...` (1 line)
- Drops `val client_count : ...` + its docstring (5 lines)
- Updates two docstring references that mentioned the dead surface (`client_count_atomic` mention in the module overview, `{!client_count}` cross-reference in `register`)

## Risk

Low — pure dead-code removal. The atomic was a derived counter; the Hashtbl (`clients`) remains authoritative for membership and is what every live caller uses. The same iter-67 caution applied: previous false-positive paths (facade re-export, unqualified parent-module use, local aliases) were all checked.

## Iter 68 context

Iter 68 audited 7 small modules (agent_sdk_log_bridge, agent_sdk_metrics_bridge, activity_graph, activity_graph_registry, activity_graph_reducer, activity_graph_types, ag_ui). `Activity_graph_registry.client_count` is the single truly-dead export; other 0-call candidates (`clients`, `client_matches`, `with_registry_ro`, `with_registry_rw`) are all reachable via the parent `Activity_graph.ml` unqualified-include path and remain live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)