### PR TITLE
docs(rfc): normalize 9 RFC frontmatter status fields

### DIFF
--- a/docs/rfc/RFC-0038-phase-2-keeper-identity-canonical.md
+++ b/docs/rfc/RFC-0038-phase-2-keeper-identity-canonical.md
@@ -3,7 +3,7 @@ rfc: RFC-0038 Phase 2
 title: Keeper Identity Canonical Form (alias canonicalization)
 author: jeong-sik
 created: 2026-05-09
-status: Draft (sketch)
+status: Draft
 supersedes: -
 related:
   - RFC-0038 Phase 1 (opaque identifier types — Provider_id, Cascade_name)

--- a/docs/rfc/RFC-0052-boot-time-required-invariants.md
+++ b/docs/rfc/RFC-0052-boot-time-required-invariants.md
@@ -3,7 +3,7 @@ rfc: RFC-0052
 title: Boot-time Required Invariants (typed)
 author: jeong-sik
 created: 2026-05-09
-status: Draft (sketch)
+status: Draft
 supersedes: -
 related:
   - RFC-0001 (det/nondet boundary harness — Eio env initialization)

--- a/docs/rfc/RFC-0053-tool-dispatch-session-local-handles.md
+++ b/docs/rfc/RFC-0053-tool-dispatch-session-local-handles.md
@@ -3,7 +3,7 @@ rfc: RFC-0053
 title: Tool Dispatch Session-Local Handles
 author: jeong-sik
 created: 2026-05-09
-status: Draft (sketch)
+status: Draft
 supersedes: -
 related:
   - RFC-0035 (cognitive IDE — tool surface context)

--- a/docs/rfc/RFC-0082-keeper-last-blocker-autoclear-and-recovery-escalation.md
+++ b/docs/rfc/RFC-0082-keeper-last-blocker-autoclear-and-recovery-escalation.md
@@ -4,7 +4,7 @@ title: Keeper `last_blocker` auto-clear + cascade recovery escalation
 author: jeong-sik (with Claude Opus 4.7)
 created: 2026-05-14
 corrected: 2026-05-15
-status: Draft (corrected — see §12)
+status: Draft
 supersedes: —
 related:
   - RFC-0038 §4 problem 3 (operator_disposition ↔ paused desync — noted but unresolved)

--- a/docs/rfc/RFC-0084-keeper-tool-dispatch-unification.md
+++ b/docs/rfc/RFC-0084-keeper-tool-dispatch-unification.md
@@ -1,7 +1,7 @@
 ---
 rfc: "0084"
 title: "Keeper→Tool Dispatch Unification + 100% Trace/Telemetry"
-status: Implementation Complete (sprint closeout PR-14)
+status: Implemented
 created: 2026-05-15
 updated: 2026-05-15
 author: vincent

--- a/docs/rfc/RFC-0097-keeper-sandbox-container-reuse.md
+++ b/docs/rfc/RFC-0097-keeper-sandbox-container-reuse.md
@@ -1,7 +1,7 @@
 ---
 rfc: "0097"
 title: "Keeper sandbox container reuse (long-running sandbox per keeper)"
-status: In-progress
+status: Active
 created: 2026-05-17
 updated: 2026-05-20
 author: vincent

--- a/docs/rfc/RFC-0145-permissive-silent-fallback-elimination.md
+++ b/docs/rfc/RFC-0145-permissive-silent-fallback-elimination.md
@@ -1,7 +1,7 @@
 ---
 rfc: "0145"
 title: "Permissive-Silent-Fallback Elimination"
-status: Draft
+status: Active
 created: 2026-05-20
 updated: 2026-05-20
 author: vincent

--- a/docs/rfc/RFC-0155-system-log-category-typed-ssot.md
+++ b/docs/rfc/RFC-0155-system-log-category-typed-ssot.md
@@ -1,7 +1,7 @@
 ---
 rfc: "0155"
 title: "System_log_category Typed SSOT — emit-side closed sum for ops log taxonomy"
-status: Draft
+status: Active
 created: 2026-05-21
 updated: 2026-05-21
 author: vincent

--- a/docs/rfc/RFC-0157-cascade-pre-turn-required-tool-filter.md
+++ b/docs/rfc/RFC-0157-cascade-pre-turn-required-tool-filter.md
@@ -1,7 +1,7 @@
 ---
 rfc: "0157"
 title: "Cascade pre-turn required-tool filter — provider capability boundary"
-status: Draft
+status: Active
 created: 2026-05-21
 updated: 2026-05-21
 author: claude-opus


### PR DESCRIPTION
## Summary

Normalize 9 RFC frontmatter `status` fields to canonical values defined in `docs/rfc/README.md`.

### Changes

| RFC | Old Status | New Status | Rationale |
|-----|-----------|------------|-----------|
| RFC-0145 | Draft | Active | 16 merged commits (sweep PRs #17780~#17807), implementation ongoing |
| RFC-0155 | Draft | Active | PR-1 #17168 merged, implementation started |
| RFC-0157 | Draft | Active | PR-1 #17534 merged, implementation started |
| RFC-0097 | In-progress | Active | Standardize to canonical set |
| RFC-0084 | Implementation Complete (sprint closeout PR-14) | Implemented | Standardize to canonical set |
| RFC-0038 | Draft (sketch) | Draft | Normalize parenthetical |
| RFC-0052 | Draft (sketch) | Draft | Normalize parenthetical |
| RFC-0053 | Draft (sketch) | Draft | Normalize parenthetical |
| RFC-0082 | Draft (corrected — see §12) | Draft | Normalize parenthetical |

### Canonical Status Set

Per `docs/rfc/README.md`: `Draft | Active | Implemented | Superseded | Withdrawn`

### Verification

- [x] All 9 files changed, 1 line each (status field only)
- [x] No code changes
- [x] No RFC body content modified

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>