### PR TITLE
refactor(activity_graph_types): delete unused node_status_of_string_opt

### DIFF
--- a/lib/activity_graph/activity_graph_types.ml
+++ b/lib/activity_graph/activity_graph_types.ml
@@ -33,23 +33,6 @@ let node_status_to_string = function
   | Stopped -> "stopped" | Finalized -> "finalized"
   | Observed -> "observed" | Coord -> "room" | Unset -> ""
 
-(** Strict parser. Returns [None] on unknown wire so callers can react
-    explicitly (drop / fallback / route). See #8777 / #8605. *)
-let node_status_of_string_opt = function
-  | "active" -> Some Active | "offline" -> Some Offline | "spawned" -> Some Spawned
-  | "retired" -> Some Retired | "compacting" -> Some Compacting | "handoff" -> Some Handoff
-  | "autonomy" -> Some Autonomy | "guardrail" -> Some Guardrail
-  | "todo" -> Some Todo | "claimed" -> Some Claimed | "in_progress" -> Some In_progress
-  | "done" -> Some Done | "cancelled" -> Some Cancelled
-  | "posted" -> Some Posted | "discussed" -> Some Discussed
-  | "open" -> Some Open | "resolved" -> Some Resolved
-  | "approved" -> Some Approved | "denied" -> Some Denied
-  | "running" -> Some Running | "paused" -> Some Paused
-  | "stopped" -> Some Stopped | "finalized" -> Some Finalized
-  | "observed" -> Some Observed | "room" -> Some Coord
-  | "" -> Some Unset
-  | _ -> None
-
 (** Span status: separate from node_status (different lifecycle).
     @since 7182 *)
 type span_status =
@@ -64,8 +47,7 @@ let span_status_to_string = function
   | Span_ended -> "ended"
 
 (** Strict parser. Returns [None] on unknown wire so callers can react
-    explicitly (drop / fallback / route). Mirror of [node_status_of_string_opt]
-    introduced in #8779. See #8605. *)
+    explicitly (drop / fallback / route). See #8605. *)
 let span_status_of_string_opt = function
   | "open" -> Some Span_open
   | "completed" -> Some Span_completed

--- a/lib/activity_graph/activity_graph_types.mli
+++ b/lib/activity_graph/activity_graph_types.mli
@@ -26,10 +26,6 @@ type node_status =
 
 val node_status_to_string : node_status -> string
 
-(** Strict parser. Returns [None] on unknown wire so callers react
-    explicitly (drop / fallback / route). See #8777 / #8605. *)
-val node_status_of_string_opt : string -> node_status option
-
 (** {1 Span status}
 
     Separate lifecycle from {!node_status}.
@@ -42,7 +38,7 @@ type span_status =
 val span_status_to_string : span_status -> string
 
 (** Strict parser: returns [None] on unknown wire so callers can react
-    explicitly. Mirror of {!node_status_of_string_opt}. See #8605. *)
+    explicitly (drop / fallback / route). See #8605. *)
 val span_status_of_string_opt : string -> span_status option
 
 (** {1 Graph entities} *)


### PR DESCRIPTION
## Summary

`Activity_graph_types.node_status_of_string_opt` (also reachable as `Activity_graph.node_status_of_string_opt` via the include facade) has **zero callers** anywhere across lib/, test/, dashboard/.

## Half-migration context

This parser was introduced in #8779 as part of the strict-parser wave (issues #8605, #8777, #8779) intended to add `_of_string_opt` parsers for both `node_status` and `span_status`. The sibling `span_status_of_string_opt` materialized one external caller via the `Activity_graph` facade and is **retained**. The node-side parser stayed unmaterialized.

| Function | External callers | Status |
|---|---|---|
| `node_status_of_string_opt` | **0** | DEAD — this PR |
| `span_status_of_string_opt` | 1 (via `Activity_graph.`) | LIVE — kept |

Half-migration closure aligns with `feedback_hardcoding_and_legacy_zero_tolerance`: an N-of-2 unfinished migration becomes N-of-1 (with the surviving half labelled honestly as the only intended parser, instead of being framed as a "mirror" of a dead sibling).

## 5-prong audit

```
rg "Activity_graph_types\.node_status_of_string_opt" → 0
rg "Activity_graph\.node_status_of_string_opt"       → 0
rg "open Activity_graph_types"                       → 0
rg "node_status_of_string_opt" lib/activity_graph/activity_graph.ml,
                                activity_graph_reducer.ml          → 0 unqualified
rg "node_status_of_string_opt" lib/activity_graph/activity_graph_types.ml
                                                                    → only the deleted definition
```

## Diff

`-24 / +2 = -22 net LoC`:

- `lib/activity_graph/activity_graph_types.ml`: function body + docstring deleted; `span_status_of_string_opt` docstring updated to drop the now-dangling `Mirror of node_status_of_string_opt` cross-reference.
- `lib/activity_graph/activity_graph_types.mli`: corresponding `val` deleted; `span_status_of_string_opt` `.mli` docstring updated to drop the same cross-reference (now points at no symbol).

## Risk

None — 5-prong audit yielded zero callers via every reachable path (qualified, facade-qualified via `Activity_graph`, opener-unqualified, parent-module unqualified, and same-module internal use). Deletion cannot change runtime behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)