### PR TITLE
refactor(attribution): delete unused of_yojson + show + 6-helper cascade

### DIFF
--- a/lib/attribution.ml
+++ b/lib/attribution.ml
@@ -4,14 +4,6 @@ type origin = Det | NonDet
 
 let string_of_origin = function Det -> "det" | NonDet -> "nondet"
 
-let origin_of_string = function
-  | "det" -> Ok Det
-  | "nondet" -> Ok NonDet
-  | other ->
-    Error
-      (Printf.sprintf
-         "attribution.origin: expected \"det\" | \"nondet\", got %S" other)
-
 type outcome =
   | Passed
   | Policy_failed of { reason : string }
@@ -59,93 +51,6 @@ let to_yojson (t : t) : Yojson.Safe.t =
       ("evidence", t.evidence);
       ("outcome", outcome_to_yojson t.outcome);
     ]
-
-(* --- Parsing --- *)
-
-open Result.Syntax
-
-let require_field fields key =
-  match List.assoc_opt key fields with
-  | Some v -> Ok v
-  | None -> Error (Printf.sprintf "attribution: missing field %S" key)
-
-let require_string fields key =
-  let* v = require_field fields key in
-  match v with
-  | `String s -> Ok s
-  | other ->
-    Error
-      (Printf.sprintf "attribution.%s: expected string, got %s" key
-         (Yojson.Safe.to_string other))
-
-let require_float fields key =
-  let* v = require_field fields key in
-  match v with
-  | `Float f -> Ok f
-  | `Int i -> Ok (float_of_int i)
-  | other ->
-    Error
-      (Printf.sprintf "attribution.%s: expected number, got %s" key
-         (Yojson.Safe.to_string other))
-
-let outcome_of_yojson : Yojson.Safe.t -> (outcome, string) result = function
-  | `Assoc fields ->
-    let* kind = require_string fields "kind" in
-    (match kind with
-     | "passed" -> Ok Passed
-     | "policy_failed" ->
-       let* reason = require_string fields "reason" in
-       Ok (Policy_failed { reason })
-     | "transition_blocked" ->
-       let* from_state = require_string fields "from_state" in
-       let* to_state = require_string fields "to_state" in
-       let* reason = require_string fields "reason" in
-       Ok (Transition_blocked { from_state; to_state; reason })
-     | "partial_pass" ->
-       let* score = require_float fields "score" in
-       let* rationale = require_string fields "rationale" in
-       Ok (Partial_pass { score; rationale })
-     | other ->
-       Error
-         (Printf.sprintf
-            "attribution.outcome.kind: unknown %S (expected passed | \
-             policy_failed | transition_blocked | partial_pass)"
-            other))
-  | json ->
-    Error
-      (Printf.sprintf "attribution.outcome: expected JSON object, got %s"
-         (Yojson.Safe.to_string json))
-
-let of_yojson = function
-  | `Assoc fields ->
-    let* origin_s = require_string fields "origin" in
-    let* origin = origin_of_string origin_s in
-    let* gate = require_string fields "gate" in
-    let evidence =
-      match List.assoc_opt "evidence" fields with
-      | None | Some `Null -> `Null
-      | Some ev -> ev
-    in
-    let* outcome_j = require_field fields "outcome" in
-    let* outcome = outcome_of_yojson outcome_j in
-    Ok { origin; gate; evidence; outcome }
-  | json ->
-    Error
-      (Printf.sprintf "attribution: expected JSON object, got %s"
-         (Yojson.Safe.to_string json))
-
-(* --- Show --- *)
-
-let string_of_outcome_kind = function
-  | Passed -> "passed"
-  | Policy_failed _ -> "policy_failed"
-  | Transition_blocked _ -> "transition_blocked"
-  | Partial_pass _ -> "partial_pass"
-
-let show (t : t) : string =
-  Printf.sprintf "Attribution{origin=%s; gate=%s; outcome=%s}"
-    (string_of_origin t.origin) t.gate
-    (string_of_outcome_kind t.outcome)
 
 (* --- Smart constructors --- *)
 

--- a/lib/attribution.mli
+++ b/lib/attribution.mli
@@ -82,15 +82,6 @@ val to_yojson : t -> Yojson.Safe.t
     - [Partial_pass]       → [{"kind":"partial_pass",
                                "score":0.85,"rationale":"..."}] *)
 
-val of_yojson : Yojson.Safe.t -> (t, string) result
-(** Parse from JSON. Returns [Error] with a human-readable message on
-    malformed input (missing field, unknown [kind], bad types).
-    Missing [evidence] defaults to [`Null]. *)
-
-val show : t -> string
-(** Single-line representation for debug logs. Elides [evidence] and
-    long string fields to keep logs scannable. *)
-
 (** {1 Smart constructors}
 
     Prefer these over the raw record — they enforce the sum invariant


### PR DESCRIPTION
## Summary

`Attribution.of_yojson` and `Attribution.show` both have **zero callers** anywhere across lib/, test/, dashboard/. Their removal cascade-deletes six private helpers that existed only to support these two entry points.

## Dead-cluster map

| Function | Why dead | LoC |
|---|---|---|
| `of_yojson` | 0 external callers | 17 |
| `show` | 0 external callers | 4 |
| `outcome_of_yojson` | only caller is `of_yojson` (now dead) | 27 |
| `require_field` | only consumers are `require_string` + `require_float` + `of_yojson` (all dead) | 4 |
| `require_string` | only consumers are `outcome_of_yojson` + `of_yojson` (both dead) | 8 |
| `require_float` | only consumer is `outcome_of_yojson` (dead) | 9 |
| `origin_of_string` | only consumer is `of_yojson` (dead) | 7 |
| `string_of_outcome_kind` | only consumer is `show` (dead) | 5 |

`string_of_origin` (line 5) is **retained** — still used by `to_yojson` at line 57.

## Asymmetric read/write surface

Same pattern as the iter-63 finding `Operator_review_state.write_review_decisions` — the **OCaml side writes** Attribution JSON via `to_yojson` (2 callers in `cdal_verdict_gate.ml`, used by `verification.ml` per its `.mli` signatures), but the **OCaml-side reader** (`of_yojson`) is never called. The dashboard-side TypeScript at `dashboard/src/...` consumes the JSON wire format with its own parsers; the OCaml round-trip was never wired up.

## 5-prong audit

```
rg "Attribution\.of_yojson"  lib/ test/ dashboard/ → 0
rg "Attribution\.show"       lib/ test/ dashboard/ → 0
rg "include Attribution|module \w+ = Attribution" → 0 facades
rg "open Attribution"                              → 0 opener files
rg "of_yojson|\bshow\b"      lib/attribution.ml    → only the deleted definitions
```

## Diff

`-104 LoC` total (-95 from .ml, -9 from .mli). The implementation-side cascade dominates because each entry-point removal pulls down 3-4 layers of parser helpers.

## Risk

Low — every removed symbol's caller set was traced to 0. The smart constructors (`passed`, `policy_failed`, `transition_blocked`, `partial_pass`) and `to_yojson` are unchanged, so all current production emitters keep working. If a future PR needs OCaml-side JSON parsing for round-trip tests, `of_yojson` plus its helpers can be reintroduced; the wire format documented in `to_yojson`'s docstring is the canonical reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)