### PR TITLE
refactor(anti_rationalization): delete unused review_result_to_json

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -860,22 +860,3 @@ let review
                   }))))
 ;;
 
-let review_result_to_json (r : review_result) : Yojson.Safe.t =
-  let base =
-    [ ( "verdict"
-      , `String
-          (match r.verdict with
-           | Approve -> "approve"
-           | Reject s -> "reject:" ^ s) )
-    ; "evaluator_cascade", `String r.evaluator_cascade
-    ; "generator_cascade", Json_util.string_opt_to_json r.generator_cascade
-    ; "gate", `String (gate_to_string r.gate)
-    ]
-  in
-  let extra =
-    match r.fallback_reason with
-    | Some reason -> [ "fallback_reason", `String reason ]
-    | None -> []
-  in
-  `Assoc (base @ extra)
-;;

--- a/lib/anti_rationalization.mli
+++ b/lib/anti_rationalization.mli
@@ -79,9 +79,6 @@ val review :
     Used internally by Gate 2.5; exposed for testing. *)
 val check_contract : notes:string -> contract:string list -> string list
 
-(** Serialize review result to JSON for logging/calibration. *)
-val review_result_to_json : review_result -> Yojson.Safe.t
-
 (** Load excuse patterns dynamically from config/excuse_patterns.json.
     Returns the default hardcoded list if the file is missing or invalid.
     Exposed for dashboard administration. *)


### PR DESCRIPTION
## Summary

`Anti_rationalization.review_result_to_json` is exported in `.mli:83` and defined in `.ml:863` but has **zero callers** anywhere across lib/, test/, dashboard/. The docstring frames it as "logging/calibration" output, but no log or calibration pipeline ever consumed the projection.

## 5-prong audit

```
rg "Anti_rationalization\.review_result_to_json" lib/ test/ dashboard/ → 0
rg "include Anti_rationalization|module \w+ = Anti_rationalization"   → 0 facades
rg "open Anti_rationalization"                                         → 0 opener files
rg "review_result_to_json" lib/anti_rationalization.ml                 → only the deleted definition
```

## Companion surface retained

| Component | Callers | Status |
|---|---|---|
| `review` (the producer) | 5 | LIVE — kept |
| `review_result` (the record type) | — | LIVE — kept |
| `review_result_to_json` (projection) | **0** | DEAD — this PR |

Consumers of `review_result` read fields directly off the record rather than going through a JSON projection.

## Defensive witness kept

`verdict_constructor_name` (also 0-caller) is **intentionally retained**. Its `.ml:31-38` docstring documents it as a compile-time variant-list sync witness: "Adding a 3rd constructor will fail compilation in `verdict_constructor_name`." The witness pattern provides type-level invariant maintenance even when its own call-graph is zero, so it falls under defensive-design retention rather than dead-export removal — same principle as the `feedback_audit_recommended_variant_must_verify_live_data` lesson but mirrored: defensive structure stays even when usage is zero.

## Diff

`-22 LoC` (19 from .ml, 3 from .mli).

## Risk

None — single-function deletion with no internal use, no facade re-export, no opener-unqualified access. The producer (`review`), record type (`review_result`), and witness function (`verdict_constructor_name`) all stay intact.

## Iter 71 context

Iter 71 first attempted an asymmetric `to_yojson`/`of_yojson` sweep across 5 top-level lib/ modules (Build_identity, Failure_envelope, Board_attachment_meta, Worker_execution_backend, Worker_execution_spec). All 5 turned out to be either internally LIVE (Failure_envelope.of_yojson → find_in_json), PPX convention (Build_identity), or test-only scaffolding (Board_attachment_meta). Pivoted to `anti_rationalization` for this single-function PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)