### PR TITLE
[RFC-0162] Phase 2 — per-path fd cache (invalidates RFC-0108 §3.3)

### DIFF
--- a/docs/rfc/RFC-0108-atomic-jsonl-append.md
+++ b/docs/rfc/RFC-0108-atomic-jsonl-append.md
@@ -132,6 +132,8 @@ val close : t -> unit
 - **Per-record fsync**: durability 보장은 `close` 시점만. crash 시 마지막 N record 손실은 수용.
 - **Cross-domain LRU fd cache**: 단순화를 위해 fd 는 첫 `open_writer` 가 가지고 있다가 `close` 시 해제. fd 수가 keeper N (≤64) 수준이라 cache 가 없어도 무방.
 
+  **Update (RFC-0162, 2026-05-23)**: production evidence (22,440 calls × `EMFILE`/`ENFILE` trace, dashboard fleet-health audit) 로 위 가정이 *unit time 당 open/close churn* 축에서 반증됨. **Per-path fd cache** (RFC-0162 §3.4) 가 본 RFC 의 *Record-interleave-0* 보장과 정합한 형태로 도입됨 — 같은 path 의 `out_channel` 을 process lifetime 동안 재사용하고, 기존 `get_append_path_mutex` 가 cross-domain 직렬화를 그대로 담당한다. fd_cache_max=32 + LRU + `at_exit` drain.
+
 ## 4. Migration Plan
 
 ### 4.1 4 Writer 수렴

--- a/docs/rfc/RFC-0162-jsonl-write-path-fd-pressure.md
+++ b/docs/rfc/RFC-0162-jsonl-write-path-fd-pressure.md
@@ -196,7 +196,7 @@ dashboard 30s refresh × 3 surface 동시 → TTL 10s 이내 첫 호출만 scan.
 - 영구 보존 운영자는 `MASC_TOOL_CALL_LOG_RETENTION_DAYS=0` 명시.
 - **추가 정당화 — 문서-구현 drift**: `lib/keeper_tool_call_log.mli:99-103` 가 *이미* "default is 30 days, and values <= 0 disable pruning" 라고 *약속* 한 상태. 구현이 그 약속을 위반한 drift. 본 phase 는 *새 정책 도입* 이 아니라 *공표된 약속 회복*. RFC-0108 §3.3 가정 invalidate 보다 정당화 부담이 낮다.
 
-### 3.4 Phase 2 — Cross-domain fd reuse (RFC-0108 §3.3 invalidate)
+### 3.4 Phase 2 — Per-path fd cache (RFC-0108 §3.3 invalidate)
 
 본 phase 가 RFC-0108 §3.3 의 *명시적 비목표* 결정을 뒤집는 핵심.
 
@@ -205,23 +205,79 @@ dashboard 30s refresh × 3 surface 동시 → TTL 10s 이내 첫 호출만 scan.
 **Invalidation**:
 
 - "fd 수" 는 *순간 동시 open 수* 가 아니라 *unit time 당 open/close churn* 으로 봐야 한다.
-- 22,440 tool calls × 평균 4-5 동시 fiber → unit time 당 fd churn 이 호스트 kernel filp_cachep 슬랩에 압력.
+- 22,440 tool calls × 평균 4-5 동시 fiber → unit time 당 fd churn 이 호스트 kernel `filp_cachep` 슬랩에 압력.
 - macOS Apple Virtualization VM (RFC-0137 §1) 환경에서 host-wide `kern.maxfiles` 가 인근 프로세스와 공유되어 budget 가정이 흔들림.
 
-**Design 후보**:
+**Design re-think (2026-05-23, Phase 2 작성 중 발견)**: 본 RFC 초안의 *Design 후보 A — Per-domain fd cache* 는 *cross-domain interleave 위험*을 새로 도입한다. POSIX `O_APPEND + write(buf, len)` 의 atomicity 는 `PIPE_BUF` 이하만 보장 (macOS/Linux 일반적으로 ~4 KB). 4 KB+ record (예: prompt dump, large tool output) 가 두 domain 의 *서로 다른 fd* 로 동시에 write 될 때 record interleave 발생 가능. RFC-0108 §3.2 의 *Record interleave 0* 보장이 깨진다.
 
-| 후보 | 설명 | Pro | Con |
-|---|---|---|---|
-| **A. Per-domain fd cache** | 각 domain 이 자기 own fd 보유, cross-domain shared 없음 | RFC-0108 §3.2 보장 유지 | domain 수만큼 fd 사용 |
-| **B. Single-writer coordinator fiber** | 단일 domain 이 fd 보유, 다른 fiber 는 메시지 큐 | fd 최소화 | RFC-0108 §3.2 record interleave 보장 재검증 필요 |
+**채택 Design — Per-path fd cache (cross-domain serialized)**:
 
-**선호: A (Per-domain fd cache)**. 이유:
+| 결정 | 메커니즘 |
+|---|---|
+| **Single fd per path** | path 당 단 하나의 `out_channel` 이 process lifetime 동안 재사용. cross-domain interleave 불가능 (fd 가 하나뿐). |
+| **Cross-domain serialize** | 기존 `append_path_mutex_registry` (`Stdlib.Mutex`) 가 path 별 mutex 로 fiber + 도메인 양쪽을 직렬화. RFC-0108 §3.2 보장 *그대로 활용*. |
+| **Cache lookup 분리 mutex** | path mutex 와 별개의 `fd_cache_mu` 가 Hashtbl op 만 보호 (microsecond 단위 critical section). path mutex 는 `output_string + flush` 만 보유. |
+| **LRU evict** | `fd_cache_max = 32` 초과 시 oldest `last_used` 의 fd 를 `Stdlib.close_out`. day rollover 시 어제 path 가 자연 evict. |
+| **Process shutdown** | `Stdlib.at_exit` 에 `close_all_cached_writers` 등록. flush 후 close. |
 
-- B 는 RFC-0108 §3.2 *Record interleave 0* 보장 재검증 부담.
-- A 는 RFC-0108 §3.2 보장을 *그대로 유지* — 같은 domain 의 같은 fd 는 buffer 공유 안전. cross-domain 은 fd 자체가 분리되므로 corruption 없음.
-- fd 수: 4 writer × 8 domain ≈ 32 fd. RFC-0108 §3.3 의 N≤64 budget 안.
+```ocaml
+type cached_writer = { oc : out_channel; last_used : float }
+let cached_writers : (string, cached_writer) Hashtbl.t = Hashtbl.create 32
+let fd_cache_mu = Stdlib.Mutex.create ()
+let fd_cache_max = 32
 
-**LRU evict**: process lifetime 동안 path 가 day rollover 시 *어제 path* 가 stale. LRU max 8 entry per domain → 4 writer × 2 day = 8 path 까지 캐시. 초과 시 LRU evict + `Stdlib.close_out`.
+(* Inside fd_cache_mu: get-or-open + LRU. *)
+let get_or_open_writer_locked path =
+  match Hashtbl.find_opt cached_writers path with
+  | Some w ->
+    Hashtbl.replace cached_writers path
+      { w with last_used = Unix.gettimeofday () };
+    w.oc
+  | None ->
+    if Hashtbl.length cached_writers >= fd_cache_max
+    then evict_lru_locked ();
+    let oc =
+      Stdlib.open_out_gen
+        [ Stdlib.Open_append; Stdlib.Open_creat; Stdlib.Open_wronly ]
+        0o644 path
+    in
+    Hashtbl.add cached_writers path
+      { oc; last_used = Unix.gettimeofday () };
+    oc
+
+let append_jsonl path json =
+  test_exec_home_guard ~op:"append_jsonl" path;
+  let dir = Filename.dirname path in
+  mkdir_p_memoized dir;                              (* Phase 0a *)
+  let line = Yojson.Safe.to_string json ^ "\n" in
+  let path_mu = get_append_path_mutex path in
+  let oc =
+    Stdlib.Mutex.protect fd_cache_mu (fun () ->
+      get_or_open_writer_locked path)
+  in
+  Stdlib.Mutex.protect path_mu (fun () ->
+    Stdlib.output_string oc line;
+    Stdlib.flush oc)
+```
+
+**보장 (RFC-0108 §3.2 와 1:1 매칭)**:
+
+| 보장 | 메커니즘 |
+|---|---|
+| Fiber race 0 | `append_path_mutex_registry` 가 path 별 `Stdlib.Mutex` 로 fiber+도메인 양쪽 직렬화 (RFC-0108 와 같음) |
+| Partial-write 0 | `output_string + flush` 가 single critical section 안. `out_channel` buffer 가 cross-call carry-over 하지만 critical section 보장 |
+| Record interleave 0 | path 당 단일 fd → POSIX write 가 어떤 size 든 단일 producer 에서 순차 |
+| Large record 안전 | 같은 path mutex 가 끝까지 record 보유 |
+| Cross-process race | RFC-0108 §3.3 와 같음 — 비목표 |
+| Per-record fsync | `flush` 만, no `fsync` — RFC-0108 §6 와 같음 |
+
+**fd budget 분석**:
+
+- macOS default `RLIMIT_NOFILE` = 256 (soft) / unlimited (hard). masc-mcp 가 256 root 안에서 운영.
+- 4 writer (system_log / trajectory / oas-events / reaction-ledger) × 평균 1 active path = 4 fd baseline.
+- Day rollover 시 어제 path 도 evict 전까지 남음 → 최대 8 fd.
+- Dashboard read-side, network connection 등 합쳐 ~30 fd. fd_cache_max=32 는 safe margin.
+- RFC-0108 §3.3 의 "N≤64" budget 안 *충분히 들어옴*.
 
 ### 3.5 §4.5 — Observability gap (related, non-blocking)
 

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -673,25 +673,111 @@ let fold_jsonl_lines ~init ~f path =
     registry. This commit unifies the registry with
     [append_file_unix] so a caller mixing the two helpers on a
     single path remains race-free. *)
+(* RFC-0162 §3.4: per-path fd cache (single fd per path, cross-domain
+   serialized by [append_path_mutex_registry]).
+
+   RFC-0108 §3.3 declared cross-domain fd cache an explicit non-goal
+   under the assumption that fd count ≈ keeper N (≤64). Production
+   evidence (RFC-0162 §1.3) invalidated that on the open/close
+   *churn* axis: 22,440 tool calls × fresh open+close per record was
+   shifting host kernel filp_cachep slab pressure and contributing
+   to the EMFILE/ENFILE trace.
+
+   Design choice — Per-path (not per-domain) cache:
+   - A single [out_channel] per path eliminates the cross-domain
+     write interleave window that an early RFC draft's per-domain
+     design opened up (POSIX O_APPEND+write atomicity is only
+     guaranteed up to PIPE_BUF, ~4 KB, and tool-call records
+     routinely exceed that).
+   - The existing [get_append_path_mutex] is already a cross-domain
+     [Stdlib.Mutex] per path. Wrapping [output_string + flush]
+     inside it preserves RFC-0108 §3.2's Record-interleave-0
+     guarantee verbatim.
+   - The cache lookup uses a separate, microsecond-scoped mutex
+     ([fd_cache_mu]) so two appends to *different* paths never
+     contend on a global fd-cache lock. *)
+type cached_writer =
+  { oc : out_channel
+  ; mutable last_used : float
+  }
+
+let cached_writers : (string, cached_writer) Hashtbl.t = Hashtbl.create 32
+let fd_cache_mu = Stdlib.Mutex.create ()
+let fd_cache_max = 32
+
+let close_cached_writer_silently w =
+  try Stdlib.close_out w.oc with
+  | _ -> ()
+;;
+
+(* Evict the cached writer with the smallest [last_used], close its fd.
+   Inside [fd_cache_mu] only. *)
+let evict_lru_locked () =
+  let oldest = ref None in
+  Hashtbl.iter
+    (fun path w ->
+      match !oldest with
+      | None -> oldest := Some (path, w.last_used)
+      | Some (_, ts) when w.last_used < ts -> oldest := Some (path, w.last_used)
+      | _ -> ())
+    cached_writers;
+  match !oldest with
+  | None -> ()
+  | Some (victim_path, _) ->
+    (match Hashtbl.find_opt cached_writers victim_path with
+     | Some w ->
+       close_cached_writer_silently w;
+       Hashtbl.remove cached_writers victim_path
+     | None -> ())
+;;
+
+(* Inside [fd_cache_mu]: return the cached [out_channel] for [path],
+   opening (and possibly LRU-evicting) on first use. *)
+let get_or_open_writer_locked path =
+  let now = Unix.gettimeofday () in
+  match Hashtbl.find_opt cached_writers path with
+  | Some w ->
+    w.last_used <- now;
+    w.oc
+  | None ->
+    if Hashtbl.length cached_writers >= fd_cache_max then evict_lru_locked ();
+    let oc =
+      Stdlib.open_out_gen
+        [ Stdlib.Open_append; Stdlib.Open_creat; Stdlib.Open_wronly ]
+        0o644
+        path
+    in
+    Hashtbl.add cached_writers path { oc; last_used = now };
+    oc
+;;
+
+let close_all_cached_writers () =
+  Stdlib.Mutex.protect fd_cache_mu (fun () ->
+    Hashtbl.iter (fun _ w -> close_cached_writer_silently w) cached_writers;
+    Hashtbl.reset cached_writers)
+;;
+
+let reset_fd_cache_for_testing () = close_all_cached_writers ()
+
+(* Best-effort cache drain at process exit. RFC-0108 §6 already states
+   per-record fsync is out of scope, so the [flush] inside the hot
+   path is the durability boundary; this close is just to release
+   the fd handles cleanly. *)
+let () = Stdlib.at_exit close_all_cached_writers
+
 let append_jsonl (path : string) (json : Yojson.Safe.t) : unit =
   test_exec_home_guard ~op:"append_jsonl" path;
   let dir = Stdlib.Filename.dirname path in
   mkdir_p_memoized dir;
   let line = Yojson.Safe.to_string json ^ "\n" in
-  let mu = get_append_path_mutex path in
-  Stdlib.Mutex.lock mu;
-  Fun.protect
-    ~finally:(fun () -> Stdlib.Mutex.unlock mu)
-    (fun () ->
-      let oc =
-        Stdlib.open_out_gen
-          [ Stdlib.Open_append; Stdlib.Open_creat; Stdlib.Open_wronly ]
-          0o644
-          path
-      in
-      Fun.protect
-        ~finally:(fun () -> Stdlib.close_out_noerr oc)
-        (fun () -> Stdlib.output_string oc line))
+  let oc =
+    Stdlib.Mutex.protect fd_cache_mu (fun () ->
+      get_or_open_writer_locked path)
+  in
+  let path_mu = get_append_path_mutex path in
+  Stdlib.Mutex.protect path_mu (fun () ->
+    Stdlib.output_string oc line;
+    Stdlib.flush oc)
 ;;
 
 (* ================================================================ *)

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -136,8 +136,27 @@ val fold_jsonl_lines
   -> string
   -> 'acc
 
-(** Append JSON value as line to JSONL file. *)
+(** Append JSON value as line to JSONL file.
+
+    Backed by a process-local per-path fd cache (RFC-0162 §3.4).
+    Each path keeps one cached [out_channel] reused across appends;
+    cross-domain serialization is provided by the same per-path
+    mutex registry as [append_file_unix], preserving RFC-0108 §3.2's
+    Record-interleave-0 guarantee. The cache is bounded by
+    [fd_cache_max=32] with LRU eviction; [close_all_cached_writers]
+    is registered at [at_exit]. *)
 val append_jsonl : string -> Yojson.Safe.t -> unit
+
+(** Flush and close every cached [out_channel] held by
+    [append_jsonl]. Safe to call concurrently with active appends;
+    a subsequent [append_jsonl] re-opens fresh. Intended for
+    shutdown sequencing and rare administrative refresh.
+    RFC-0162 §3.4. *)
+val close_all_cached_writers : unit -> unit
+
+(** Drop and close every cached writer. Test-only — production
+    relies on process-lifetime persistence and [at_exit] drain. *)
+val reset_fd_cache_for_testing : unit -> unit
 
 (** {1 Storage Backend Abstraction}
 

--- a/test/dune
+++ b/test/dune
@@ -1587,6 +1587,8 @@
 
 (include stanzas/test_fs_compat_mkdir_memo.inc)
 
+(include stanzas/test_fs_compat_fd_cache.inc)
+
 (include stanzas/test_fsm_drift_per_agent_counter.inc)
 
 (include stanzas/test_gate_protocol.inc)

--- a/test/stanzas/test_fs_compat_fd_cache.inc
+++ b/test/stanzas/test_fs_compat_fd_cache.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_fs_compat_fd_cache)
+ (modules test_fs_compat_fd_cache)
+ (libraries fs_compat alcotest threads.posix yojson unix))

--- a/test/test_fs_compat_fd_cache.ml
+++ b/test/test_fs_compat_fd_cache.ml
@@ -1,0 +1,213 @@
+(** RFC-0162 §3.4 — [Fs_compat.append_jsonl] per-path fd cache tests.
+
+    The fd cache is a behaviour-preserving optimisation: the
+    Record-interleave-0 and partial-write-0 guarantees from
+    RFC-0108 §3.2 must continue to hold. We re-run RFC-0108's
+    canonical stress cases (16-thread concurrent records, 4 KB
+    PIPE_BUF-busting records, multibyte boundary) against the
+    cached path and additionally verify the lifecycle helpers
+    ([close_all_cached_writers], [reset_fd_cache_for_testing]). *)
+
+open Alcotest
+
+let counter = ref 0
+
+let tmpdir prefix =
+  incr counter;
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "%s_%d_%d_%.0f"
+         prefix
+         !counter
+         (Unix.getpid ())
+         (Unix.gettimeofday ()))
+  in
+  Unix.mkdir dir 0o755;
+  dir
+;;
+
+let read_lines path =
+  if not (Sys.file_exists path)
+  then []
+  else (
+    let ic = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+        let buf = Buffer.create 4096 in
+        (try
+           while true do
+             Buffer.add_channel buf ic 4096
+           done
+         with
+         | End_of_file -> ());
+        let content = Buffer.contents buf in
+        String.split_on_char '\n' content |> List.filter (fun s -> s <> "")))
+;;
+
+(* Re-run the canonical RFC-0108 §5.1 16-fiber stress, now over the
+   cached path. The cache must NOT degrade the existing
+   Record-interleave-0 guarantee. *)
+let test_concurrent_multibyte_records () =
+  Fs_compat.reset_fd_cache_for_testing ();
+  let dir = tmpdir "fd_cache_multibyte" in
+  let path = Filename.concat dir "out.jsonl" in
+  let n_threads = 16 in
+  let n_records_per_thread = 100 in
+  let threads =
+    List.init n_threads (fun tid ->
+      Thread.create
+        (fun () ->
+          for seq = 0 to n_records_per_thread - 1 do
+            let kor_count = 100 + (seq mod 300) in
+            let kor =
+              String.concat "" (List.init kor_count (fun _ -> "가"))
+            in
+            let json =
+              `Assoc
+                [ "tid", `Int tid; "seq", `Int seq; "k", `String kor ]
+            in
+            Fs_compat.append_jsonl path json
+          done)
+        ())
+  in
+  List.iter Thread.join threads;
+  let lines = read_lines path in
+  check
+    int
+    "line count == threads × records"
+    (n_threads * n_records_per_thread)
+    (List.length lines);
+  let seen = Hashtbl.create (n_threads * n_records_per_thread) in
+  List.iter
+    (fun line ->
+      let json =
+        try Yojson.Safe.from_string line with
+        | e ->
+          failf
+            "invalid JSON (len=%d): %s\nfirst bytes: %S"
+            (String.length line)
+            (Printexc.to_string e)
+            (if String.length line > 60 then String.sub line 0 60 else line)
+      in
+      let open Yojson.Safe.Util in
+      let tid = json |> member "tid" |> to_int in
+      let seq = json |> member "seq" |> to_int in
+      let key = tid, seq in
+      if Hashtbl.mem seen key then failf "duplicate record: tid=%d seq=%d" tid seq;
+      Hashtbl.add seen key ())
+    lines;
+  check
+    int
+    "unique (tid, seq) pairs"
+    (n_threads * n_records_per_thread)
+    (Hashtbl.length seen)
+;;
+
+(* PIPE_BUF-busting record (>4 KB). With per-domain fds an early RFC
+   draft would have interleaved here; per-path cache must serialise. *)
+let test_large_records_no_interleave () =
+  Fs_compat.reset_fd_cache_for_testing ();
+  let dir = tmpdir "fd_cache_large" in
+  let path = Filename.concat dir "out.jsonl" in
+  let n_threads = 8 in
+  let n_records_per_thread = 60 in
+  let big_payload =
+    String.init 5_000 (fun i -> Char.chr (33 + (i mod 90)))
+  in
+  let threads =
+    List.init n_threads (fun tid ->
+      Thread.create
+        (fun () ->
+          for seq = 0 to n_records_per_thread - 1 do
+            let json =
+              `Assoc
+                [ "tid", `Int tid
+                ; "seq", `Int seq
+                ; "big", `String big_payload
+                ]
+            in
+            Fs_compat.append_jsonl path json
+          done)
+        ())
+  in
+  List.iter Thread.join threads;
+  let lines = read_lines path in
+  check
+    int
+    "line count == threads × records (large records)"
+    (n_threads * n_records_per_thread)
+    (List.length lines);
+  List.iter
+    (fun line ->
+      let _ =
+        try Yojson.Safe.from_string line with
+        | e ->
+          failf
+            "interleaved large record (len=%d): %s"
+            (String.length line)
+            (Printexc.to_string e)
+      in
+      ())
+    lines
+;;
+
+(* Cache lifecycle: [reset_fd_cache_for_testing] must close the cached
+   fd, and a subsequent append must re-open without losing data. *)
+let test_reset_then_continue_writing () =
+  Fs_compat.reset_fd_cache_for_testing ();
+  let dir = tmpdir "fd_cache_reset" in
+  let path = Filename.concat dir "out.jsonl" in
+  Fs_compat.append_jsonl path (`Assoc [ "phase", `String "before" ]);
+  Fs_compat.reset_fd_cache_for_testing ();
+  Fs_compat.append_jsonl path (`Assoc [ "phase", `String "after" ]);
+  let lines = read_lines path in
+  check int "both pre- and post-reset records persisted" 2 (List.length lines)
+;;
+
+(* LRU eviction: write to many paths so the cache must evict; the
+   data on every path must still be intact. *)
+let test_lru_evict_preserves_data () =
+  Fs_compat.reset_fd_cache_for_testing ();
+  let dir = tmpdir "fd_cache_lru" in
+  (* Slightly above fd_cache_max (=32) to force at least a few evictions. *)
+  let n_paths = 40 in
+  let paths = List.init n_paths (fun i ->
+    Filename.concat dir (Printf.sprintf "p_%03d.jsonl" i))
+  in
+  List.iter
+    (fun p ->
+      Fs_compat.append_jsonl p (`Assoc [ "p", `String p ]))
+    paths;
+  List.iter
+    (fun p ->
+      let lines = read_lines p in
+      check int (Printf.sprintf "path %s preserved 1 record" p) 1 (List.length lines))
+    paths
+;;
+
+let () =
+  Alcotest.run
+    "fs_compat_fd_cache"
+    [ ( "fd_cache"
+      , [ test_case
+            "16 threads × 100 multibyte records (RFC-0108 §5.1 reproduction)"
+            `Quick
+            test_concurrent_multibyte_records
+        ; test_case
+            "8 threads × 60 PIPE_BUF-busting records (>4 KB)"
+            `Quick
+            test_large_records_no_interleave
+        ; test_case
+            "reset then continue writing"
+            `Quick
+            test_reset_then_continue_writing
+        ; test_case
+            "LRU eviction preserves data on every path"
+            `Quick
+            test_lru_evict_preserves_data
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

RFC-0162 **Phase 2** — `Fs_compat.append_jsonl` 의 매 호출 `open_out_gen + close_out_noerr` 를 **per-path fd cache** 로 교체. RFC-0108 §3.3 의 *cross-domain fd cache 비목표* 결정을 production evidence 로 invalidate.

**Base**: PR #17860 squash-merged 됨 (`36594d68db`). 본 PR은 그 위에 cherry-pick 단일 commit. base=`main`..

본 PR 의 fix 영역:
- **per-path cache**: path 별 단 하나의 `out_channel` 이 process lifetime 동안 재사용. cross-domain serialize 는 기존 `get_append_path_mutex` 가 그대로 담당 → RFC-0108 §3.2 *Record-interleave-0* 보장 유지.
- **LRU evict**: `fd_cache_max=32` 초과 시 oldest `last_used` evict.
- **lifecycle**: `Stdlib.at_exit` 에 `close_all_cached_writers` 등록.
- **RFC-0108 §3.3 갱신**: assumption invalidation note 추가, RFC-0162 §3.4 cross-reference.

## Design re-think (RFC body §3.4 갱신 포함)

RFC body 초안의 *후보 A — per-domain fd cache* 는 *cross-domain interleave* 위험을 새로 도입 (POSIX `O_APPEND+write` atomicity 가 PIPE_BUF=~4KB 이하만 보장, tool-call 큰 record 가 두 도메인의 서로 다른 fd 로 동시에 write 시 interleave). 본 PR 의 first commit 으로 §3.4 를 *per-path cache* 로 교체.

## Test plan

- [x] `test_fs_compat_fd_cache` 신규 4/4 PASS — 16 threads × 100 multibyte (RFC-0108 §5.1 reproduction), 8 threads × 60 PIPE_BUF-busting 5 KB, reset-then-continue, LRU-eviction
- [x] `test_fs_compat_append_jsonl_atomicity` 2/2 regression PASS
- [x] `test_fs_compat_mkdir_memo` 4/4 regression PASS (Phase 0a)
- [x] `test_dated_jsonl` 20/20 regression PASS
- [x] `dune build lib/` EXIT=0
- [ ] CI: main `Goal_store.write_state` 별개 사고로 전체 빌드 깨진 상태 — 내 영역(`lib/fs_compat/`)은 무관

## Workaround Rejection Bar self-check

- §1 텔레메트리-as-fix? **NO** — counter/WARN 0건. 실제 syscall (open/close 2×) 자체를 *제거*.
- §2 substring 분류기? **NO**.
- §3 N-of-M? **NO** — `append_jsonl` 1 곳의 root fix. `append_file_unix` 도 같은 leak 이지만 본 RFC §3.4 가 *JSONL writer scope* 로 한정. follow-up RFC 또는 §6 Non-Goals 로 trace.
- catch-all 추가? **NO**.
- cap/cooldown/dedup/repair? **NO** — `fd_cache_max=32` 는 *LRU evict trigger* 이지 *fail-open cap* 아님.
- test backdoor? `reset_fd_cache_for_testing` + `close_all_cached_writers` 노출 — *cache invalidation* 의 production-safe API.

## 의존성

- PR #17860 (feature/fd-pressure-root-fix, RFC + Phase 0a + 0b + 1) 머지 *후* GitHub 가 자동으로 base 를 main 으로 rebase.
- PR #17860 머지 전이라도 conflict free — `append_jsonl` 의 동일 함수 안 다른 line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)