### PR TITLE
refactor(auto_recall): delete unused fetch_context_smart

### DIFF
--- a/lib/auto_recall.ml
+++ b/lib/auto_recall.ml
@@ -404,9 +404,8 @@ let extract_query_hints query =
 
 (* Byte-wise substring search (haystack already lowered, needle lowered
    inline).  Replaces a per-hint [Re.compile] that ran inside a
-   [List.exists]: with K hints and N items in [fetch_context_smart],
-   the old form built K × N regex DFAs even though each pattern was a
-   plain literal. *)
+   [List.exists]: with K hints and N items, the old form built K × N
+   regex DFAs even though each pattern was a plain literal. *)
 let contains_lowered_substring ~haystack_lower needle =
   let nlen = String.length needle in
   let hlen = String.length haystack_lower in
@@ -439,21 +438,3 @@ let content_matches_query content query =
       && contains_lowered_substring ~haystack_lower:content_lower hint
     ) hints
 
-(** Fetch context with query-based relevance boosting *)
-let fetch_context_smart
-    (room_config : Coord_utils.config)
-    ~(config : recall_config)
-    ~(query : string)
-    ()
-    : recall_result =
-  let result = fetch_context room_config ~config ~query () in
-  (* Boost relevance for items matching query *)
-  let boosted_items = List.map (fun item ->
-    if content_matches_query item.content query then
-      { item with relevance = min 1.0 (item.relevance +. 0.3) }
-    else
-      item
-  ) result.items in
-  (* Re-sort after boosting *)
-  let sorted = List.sort (fun a b -> compare b.relevance a.relevance) boosted_items in
-  { result with items = sorted }

--- a/lib/auto_recall.mli
+++ b/lib/auto_recall.mli
@@ -107,21 +107,6 @@ val fetch_context_eio :
   unit ->
   recall_result
 
-(** Fetch context with query-based relevance boosting.
-    Items matching the query get their relevance boosted.
-
-    @param room_config MASC room configuration
-    @param config Recall configuration
-    @param query Query string for matching
-    @return Recall result with boosted relevance
-*)
-val fetch_context_smart :
-  Coord_utils.config ->
-  config:recall_config ->
-  query:string ->
-  unit ->
-  recall_result
-
 (** {1 Formatting} *)
 
 (** Format recall result as grep-like injection-ready text.


### PR DESCRIPTION
## Summary

`Auto_recall.fetch_context_smart` is exported (`auto_recall.mli:118`) and defined (`auto_recall.ml:443`) but has **zero callers** anywhere in lib/, test/, dashboard/. It was a query-boost wrapper over `fetch_context` that never got adopted.

## 5-prong audit

```
rg "Auto_recall\.fetch_context_smart" lib/ test/ dashboard/ → 0
rg "include Auto_recall|module \w+ = Auto_recall"           → 0 facades
rg "open Auto_recall"                                        → 0 opener files
rg "fetch_context_smart" lib/auto_recall.ml                  → only the deleted
                                                              definition + a
                                                              stale comment ref
```

The dangling cross-reference in the `contains_lowered_substring` docstring (which explained the perf rationale "with K hints and N items in `fetch_context_smart`") was edited to drop the specific function name; the K-by-N rationale still applies to the remaining consumer (`content_matches_query` at line 437).

## Companion surface retained

| Function | Status |
|---|---|
| `fetch_context` | LIVE — still used internally by `fetch_context_eio` |
| `fetch_context_eio` | LIVE — 1 external caller |
| `content_matches_query` | LIVE — 1 external caller, also used by historical perf comment |
| `contains_lowered_substring` (private) | LIVE — used by `content_matches_query` |

## Diff

`-36 / +2 = -34 net LoC`:

- `lib/auto_recall.ml`: function body (-19) + cross-reference edit (+2/-3)
- `lib/auto_recall.mli`: val + docstring (-14)

## Risk

None — clean single-function deletion. The shared `fetch_context` core remains intact; the boost logic in `fetch_context_smart` was never used in production, so behavior cannot change. If a future consumer needs query-based relevance boosting, the pattern can be reconstructed from `content_matches_query` (which is still exported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)