### PR TITLE
feat(runtime-lens): P4 compaction source labels and digest gaps

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -316,6 +316,11 @@ let run_turn
   let estimated_input_tokens = prompt_ctx.Keeper_run_prompt.estimated_input_tokens in
   let ctx_work = prompt_ctx.Keeper_run_prompt.ctx_work in
   let history_messages_digest = digest_message_texts_as_joined history_messages in
+  let context_digest =
+    digest_text
+      (base_system_prompt ^ turn_system_prompt ^ dynamic_context ^ memory_context
+       ^ temporal_context ^ user_message ^ history_messages_digest)
+  in
   append_manifest ~site:"context_injected"
     ~keeper_turn_id:manifest_keeper_turn_id
     ~decision:
@@ -331,6 +336,7 @@ let run_turn
             ("history_message_count", `Int (List.length history_messages));
             ("history_messages_digest", `String history_messages_digest);
             ("estimated_input_tokens", `Int estimated_input_tokens);
+            ("context_digest", `String context_digest);
           ]))
     Keeper_runtime_manifest.Context_injected;
   let actionable_signal =

--- a/lib/memory_hooks.ml
+++ b/lib/memory_hooks.ml
@@ -249,6 +249,8 @@ let make
                      ("memory_context_chars", `Int (String.length mem_text));
                      ( "memory_context_digest",
                        `String (Digest.to_hex (Digest.string mem_text)) );
+                     ("payload_digest",
+                      `String (Digest.to_hex (Digest.string mem_text)) );
                      ("episode_limit", `Int episode_limit);
                      ("procedure_limit", `Int procedure_limit);
                      ( "existing_extra_system_context_present",

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_gaps.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_gaps.ml
@@ -442,13 +442,14 @@ let runtime_lens_gaps ~terminal_event_present ~claim_scope ~config_drift scan =
          match scan.latest_context_compacted_row with
          | Some row ->
            let decision = row.Keeper_runtime_manifest.decision in
-           (match json_string_member_opt "source_phase" decision with
+           let clock_refs = Yojson.Safe.Util.member "clock_refs" decision in
+           (match json_string_member_opt "compaction_source" clock_refs with
             | Some _ -> gaps
             | None ->
               { code = "compaction_source_missing"
               ; severity = "warn"
               ; lane = "memory_context"
-              ; detail = Some "context_compacted row lacks source_phase"
+              ; detail = Some "context_compacted row lacks compaction_source in clock_refs"
               }
               :: gaps)
          | None -> gaps)


### PR DESCRIPTION
## Summary
Implement OAS §9.5 slice P4: Context/memory/compaction lineage normalization.

## Changes
- `lib/server/server_dashboard_http_keeper_runtime_lens_gaps.ml`
  - Fix `compaction_source_missing` gap detection to read from `clock_refs.compaction_source` (existing SSOT field) instead of non-existent `decision.source_phase`.
- `lib/keeper/keeper_agent_run.ml`
  - Add `context_digest` to `Context_injected` decision, derived from all turn context components (system prompt, dynamic context, memory, temporal, user message, history).
- `lib/memory_hooks.ml`
  - Add `payload_digest` to `Memory_injected` decision, mirroring existing `memory_context_digest`.

## Verification
- `dune exec test/test_keeper_runtime_manifest.exe` → 47 tests PASS (1.709s).
- No new catch-all arms or string classifiers introduced.

## OAS hardening
F4 (Context/Memory/Compaction terminology mix) — gap detection now correctly consumes distinct `compaction_source` values already emitted by the manifest schema. No conflation of pre-dispatch / proactive / emergency / memory-bank compaction into a single string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)