### PR TITLE
refactor(board_core_payload): delete unused meta_state_block

### DIFF
--- a/lib/board_core_payload.ml
+++ b/lib/board_core_payload.ml
@@ -55,16 +55,6 @@ let extract_state_block (text : string) : string option * string =
     in
     Some state_block, String.trim (before ^ after)
 
-let meta_state_block (meta_json : Yojson.Safe.t option) =
-  match meta_json with
-  | Some (`Assoc fields) -> (
-      match List.assoc_opt "state_block" fields with
-      | Some (`String value) ->
-          let value = String.trim value in
-          if String.equal value "" then None else Some value
-      | _ -> None)
-  | _ -> None
-
 type meta_parse_error = Meta_not_assoc of Yojson.Safe.t
 
 let merge_meta_json ?state_block (meta_json : Yojson.Safe.t option) :

--- a/lib/board_core_payload.mli
+++ b/lib/board_core_payload.mli
@@ -24,13 +24,6 @@ val extract_state_block : string -> string option * string
     text)]. When the opening marker has no matching close, the
     block extends to end-of-text. *)
 
-val meta_state_block : Yojson.Safe.t option -> string option
-(** Read the [state_block] field from a JSON meta object.
-
-    Returns [Some s] when [meta_json] is a JSON object containing
-    a non-empty string [state_block]. Returns [None] for
-    [None] / non-object / non-string / empty-after-trim values. *)
-
 type meta_parse_error = Meta_not_assoc of Yojson.Safe.t
 (** Typed parse failure for [merge_meta_json] / [normalize_post_payload].
 


### PR DESCRIPTION
## Summary

`Board_core_payload.meta_state_block` is exported in `.mli:27` and defined in `.ml:58` but has **zero callers** across all 5 audit paths.

## 5-prong audit

```
rg "Board_core_payload\.meta_state_block" lib/ test/ dashboard/ → 0 direct qualified
rg "Board_core\.meta_state_block"          parent via include   → 0 facade-qualified
rg "BP\.meta_state_block"                   local alias in tests → 0
rg "open Board_core_payload"                                     → 0 opener files
rg "meta_state_block" lib/board_core_payload.ml                  → only the deleted definition
```

Facade chain noted: `lib/board_core.ml:13` does `include Board_core_payload`, so the parent-qualified path was explicitly checked. `lib/board_core.ml:485` is where the unqualified parent-`.ml` use of `normalize_post_payload` lives — it has no analogue for `meta_state_block`.

## Companion peers retained

| Function | Status |
|---|---|
| `extract_state_block` | LIVE — used internally by `normalize_post_payload` |
| `merge_meta_json` | LIVE — `BP.merge_meta_json` in `test_board_core_payload.ml` (5 callsites) |
| `normalize_post_payload` | LIVE — `board_core.ml:485` unqualified via include facade |
| `derive_post_title` | LIVE — test file regression coverage |

`meta_state_block` is the only function that reads the `state_block` field from `meta_json` directly without going through the `extract_state_block` + `merge_meta_json` flow, and no caller ever needed that direct read path.

## Diff

`-17 LoC` (10 from .ml, 7 from .mli).

## Risk

None — zero callers via every audit path. Deletion cannot change runtime behavior. If a future consumer needs a direct `state_block` field reader, the 9-line function is trivially reconstructible from `merge_meta_json`'s parse logic.

## Iter 73 context

This iter:
1. `auto_responder` — 0 candidates, all 10 exports live (saturated).
2. `board_core_payload` — 4 of 5 `0-call` candidates revealed as either internal-LIVE (`extract_state_block`, `merge_meta_json`) or facade-LIVE (`normalize_post_payload` via `board_core.ml:13` include). `meta_state_block` is the only truly dead one.

The facade trap (iter 65 lesson) triggered again — initial qualified-name grep showed 4 candidates as dead; the 5-prong re-audit reduced to 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)