### PR TITLE
refactor(server): eliminate catch-all arms in keeper directive handler

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -547,6 +547,14 @@ let handle_keeper_directive_post state _agent_name req reqd body_str =
           reqd
     | Ok action_str ->
         let config = state.Mcp_server.room_config in
+        let directive =
+          match action_str with
+          | "pause" -> `Pause
+          | "resume" -> `Resume
+          | "wakeup" -> `Wakeup
+          | _ -> assert false
+                 (* Validated at HTTP boundary above (lines 533-537). *)
+        in
         (* Issue #8391 HIGH #1: split [Ok None] (meta vanished) from [Error _]
            (IO/parse failure). For pause/resume the operator expects state to
            change; silent 200 hides the failure. For wakeup we preserve the
@@ -582,21 +590,10 @@ let handle_keeper_directive_post state _agent_name req reqd body_str =
           | Some _ | None -> ()
         in
         let proceed () =
-          (* #10583: pause was missing from the first match, falling
-             through to the [_] arm and emitting a false
-             "Unknown keeper directive: pause" WARN even though the
-             second match (line 923) handles pause correctly. The
-             persisted paused=true also was not reaching meta.json
-             because persist_paused_state(true) was never called for
-             the pause action. Adding the case here both removes the
-             false WARN and restores meta-side durability so the next
-             server restart preserves the operator's pause decision. *)
-          (match action_str with
-           | "pause" -> persist_paused_state true
-           | "resume" -> persist_paused_state false
-           | "wakeup" -> ()
-           | _ ->
-               Log.Server.warn "Unknown keeper directive: %s" action_str);
+          (match directive with
+           | `Pause -> persist_paused_state true
+           | `Resume -> persist_paused_state false
+           | `Wakeup -> ());
           let resolved_agent_name =
             match Keeper_registry_lookup.find_by_name name with
             | Some entry -> entry.meta.agent_name
@@ -607,20 +604,19 @@ let handle_keeper_directive_post state _agent_name req reqd body_str =
           in
           Keeper_keepalive.process_directive
             ~agent_name:resolved_agent_name action_str;
-          (match action_str with
-           | "pause" -> refresh_keeper_execution_surfaces ~config ~name "paused"
-           | "resume" -> refresh_keeper_execution_surfaces ~config ~name "resumed"
-           | "wakeup" -> invalidate_keeper_execution_surfaces ~config ()
-           | _ -> invalidate_keeper_execution_surfaces ~config ());
+          (match directive with
+           | `Pause -> refresh_keeper_execution_surfaces ~config ~name "paused"
+           | `Resume -> refresh_keeper_execution_surfaces ~config ~name "resumed"
+           | `Wakeup -> invalidate_keeper_execution_surfaces ~config ());
           Http.Response.json ~compress:true ~request:req
             (Printf.sprintf {|{"ok":true,"action":"%s","name":"%s"}|}
                (String.escaped action_str) (String.escaped name))
             reqd
         in
         let needs_meta_for_state_transition =
-          match action_str with
-          | "pause" | "resume" -> true
-          | _ -> false
+          match directive with
+          | `Pause | `Resume -> true
+          | `Wakeup -> false
         in
         (match read_result, needs_meta_for_state_transition with
          | Error err, true ->


### PR DESCRIPTION
## Summary

Replace three `_ ->` catch-all match blocks in `handle_keeper_directive_post` with polymorphic variant exhaustive matching.

## Problem

The HTTP boundary (lines 533-537) already validates that `action_str` can only be `\"pause\"`, `\"resume\"`, or `\"wakeup\"`. Yet three separate internal match blocks used `_ ->` catch-all arms:

1. `persist_paused_state` dispatch (line 594-599) — `_ ->` logged a false WARN
2. `refresh_keeper_execution_surfaces` dispatch (line 610-614) — `_ ->` called invalidate
3. `needs_meta_for_state_transition` (line 621-623) — `_ ->` returned false

This made it possible to add a new directive at the boundary and forget to update one of the internal dispatch sites, with silent runtime failure as the result (see #10583).

## Solution

- Parse `action_str` into ``[`Pause | `Resume | `Wakeup]`` variant once, immediately after the HTTP boundary
- Replace all three match blocks with exhaustive variant matching
- Remove the #10583 workaround comment (the variant makes the bug structurally impossible)

## Verification

- `dune build lib/server/server_dashboard_http_keeper_api.ml` passes
- No behavior change: the `_ ->` arms were unreachable due to boundary validation

## Metrics

- Net: -4 lines
- `_ ->` arms in dispatch path: 3 → 0
- Remaining `_ ->`: 1 `assert false` at the validated parse point (justified by boundary check)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>