### PR TITLE
fix: restore deleted functions breaking test suite

### DIFF
--- a/lib/attribution.ml
+++ b/lib/attribution.ml
@@ -52,6 +52,76 @@ let to_yojson (t : t) : Yojson.Safe.t =
       ("outcome", outcome_to_yojson t.outcome);
     ]
 
+(* --- Deserialization --- *)
+
+let outcome_of_yojson (json : Yojson.Safe.t) : (outcome, string) result =
+  match json with
+  | `Assoc fields -> (
+      match List.assoc_opt "kind" fields with
+      | Some (`String "passed") -> Ok Passed
+      | Some (`String "policy_failed") -> (
+          match List.assoc_opt "reason" fields with
+          | Some (`String reason) -> Ok (Policy_failed { reason })
+          | _ -> Error "Policy_failed: missing reason")
+      | Some (`String "transition_blocked") -> (
+          match
+            ( List.assoc_opt "from_state" fields,
+              List.assoc_opt "to_state" fields,
+              List.assoc_opt "reason" fields )
+          with
+          | Some (`String from_state), Some (`String to_state), Some (`String reason) ->
+              Ok (Transition_blocked { from_state; to_state; reason })
+          | _ -> Error "Transition_blocked: missing fields")
+      | Some (`String "partial_pass") -> (
+          match
+            (List.assoc_opt "score" fields, List.assoc_opt "rationale" fields)
+          with
+          | Some (`Float score), Some (`String rationale) ->
+              Ok (Partial_pass { score; rationale })
+          | Some (`Int score), Some (`String rationale) ->
+              Ok (Partial_pass { score = float_of_int score; rationale })
+          | _ -> Error "Partial_pass: missing fields")
+      | _ -> Error "outcome: missing or invalid kind")
+  | _ -> Error "outcome: expected object"
+
+let of_yojson (json : Yojson.Safe.t) : (t, string) result =
+  match json with
+  | `Assoc fields -> (
+      match
+        ( List.assoc_opt "origin" fields,
+          List.assoc_opt "gate" fields,
+          List.assoc_opt "evidence" fields,
+          List.assoc_opt "outcome" fields )
+      with
+      | ( Some (`String origin_str),
+          Some (`String gate),
+          Some evidence,
+          Some outcome_json ) -> (
+          match origin_str with
+          | "det" -> (
+              match outcome_of_yojson outcome_json with
+              | Ok outcome -> Ok { origin = Det; gate; evidence; outcome }
+              | Error e -> Error e)
+          | "nondet" -> (
+              match outcome_of_yojson outcome_json with
+              | Ok outcome -> Ok { origin = NonDet; gate; evidence; outcome }
+              | Error e -> Error e)
+          | s -> Error ("invalid origin: " ^ s))
+      | _ -> Error "missing required fields")
+  | _ -> Error "expected JSON object"
+
+(* --- Debug representation --- *)
+
+let show (t : t) : string =
+  Printf.sprintf "Attribution{origin=%s; gate=%s; outcome=%s}"
+    (string_of_origin t.origin)
+    t.gate
+    (match t.outcome with
+     | Passed -> "Passed"
+     | Policy_failed _ -> "Policy_failed{...}"
+     | Transition_blocked _ -> "Transition_blocked{...}"
+     | Partial_pass _ -> "Partial_pass{...}")
+
 (* --- Smart constructors --- *)
 
 let passed ~origin ~gate ~evidence = { origin; gate; evidence; outcome = Passed }

--- a/lib/attribution.mli
+++ b/lib/attribution.mli
@@ -82,6 +82,14 @@ val to_yojson : t -> Yojson.Safe.t
     - [Partial_pass]       → [{"kind":"partial_pass",
                                "score":0.85,"rationale":"..."}] *)
 
+val of_yojson : Yojson.Safe.t -> (t, string) result
+(** Deserialize from JSON. Inverse of {!to_yojson}. *)
+
+val show : t -> string
+(** Concise debug representation. Long fields (evidence, reason,
+    rationale) are elided to […] so the string is safe for logs and
+    test assertions. *)
+
 (** {1 Smart constructors}
 
     Prefer these over the raw record — they enforce the sum invariant

--- a/lib/goal/goal_store.mli
+++ b/lib/goal/goal_store.mli
@@ -173,6 +173,14 @@ val read_state : Coord.config -> state
     are passed through the internal normaliser ([priority]
     clamp + phase/status reconciliation). *)
 
+val write_state : Coord.config -> state -> unit
+(** Direct overwrite of {!goals_path} with the supplied state.
+    Used by tests that need deterministic initial state without
+    the read-modify-write cycle of {!update_state}.
+
+    Does *not* acquire the file lock; callers that need atomicity
+    should use {!update_state} instead. *)
+
 val update_state : Coord.config -> (state -> state) -> state
 (** Atomic read-modify-write under the goals file lock.
     [f] receives the current state and returns the next state.


### PR DESCRIPTION
## Summary

Fixes build failures caused by functions deleted/omitted in recent commits.

### Changes

- `lib/goal/goal_store.mli`: expose `write_state` (used by `test_dashboard_goals.ml`, `test_goal_store.ml`, `test_goal_janitor.ml`)
- `lib/attribution.ml` / `lib/attribution.mli`: restore `of_yojson`, `outcome_of_yojson`, and `show` deleted in #17863; both `test_attribution.ml` and `test_cdal_verdict_gate.ml` reference these values

### Root cause

- #17863 (`refactor(attribution): delete unused of_yojson + show + 6-helper cascade`) removed `of_yojson` and `show` while they were still referenced by test files.
- `Goal_store.write_state` was defined in `.ml` but never exposed in `.mli`, causing 3 test files to fail with `Unbound value`.

## Test plan

- [x] `dune build --root .` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)