### PR TITLE
refactor(board_moderation): delete unused init lifecycle export

### DIFF
--- a/lib/board_moderation.ml
+++ b/lib/board_moderation.ml
@@ -168,11 +168,6 @@ let store () : store =
       global_store := Some s;
       s
 
-let init () : unit =
-  match !global_store with
-  | Some _ -> ()
-  | None   -> global_store := Some (make_store ())
-
 let reset_for_test () : unit =
   global_store := None
 

--- a/lib/board_moderation.mli
+++ b/lib/board_moderation.mli
@@ -108,9 +108,6 @@ type target_summary = {
 
 (** {1 Store lifecycle} *)
 
-val init : unit -> unit
-(** Initialise or re-use the in-memory moderation store.  Idempotent. *)
-
 val reset_for_test : unit -> unit
 (** Drop all in-memory state.  Test-only. *)
 


### PR DESCRIPTION
## Summary

`Board_moderation.init` is a no-op gateway over `make_store` that no caller ever invokes — `get_store` (the internal accessor used by `flag`, `record_action`, etc.) already lazily auto-initializes on first access, so the explicit `init` path is structurally unreachable.

## Audit (iter 74)

5-prong dead-export audit returns 0 callers:

| Path | Count |
|---|---|
| `Board_moderation.init` qualified | 0 |
| `BM.init` local alias (test/) | 0 |
| `open Board_moderation` + unqualified `init` | 0 |
| Parent `.ml` unqualified | 0 (no `include Board_moderation`) |
| Internal use within `board_moderation.ml` | 0 |

4 veto paths all empty:
- Internal LIVE — none (`get_store` is the live initializer)
- Facade re-export — none (`rg "include Board_moderation"` empty)
- RFC scaffolding — none (docstring is generic "Idempotent")
- Defensive witness — none (no compile-time invariant claim)

## Diff

-8 LoC: `init` removed from both `.ml` and `.mli`.

## Verification

`dune build lib/` PASS (EXIT=0).

## Related

- Iter 73 PR #17869 (board_core_payload) — same 5-prong methodology
- Loop dead-export sweep cumulative: -287 LoC, 22 dead surfaces

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>