### PR TITLE
refactor(fs_compat): remove dead Storage Backend Abstraction (Issue #1442)

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -780,25 +780,3 @@ let append_jsonl (path : string) (json : Yojson.Safe.t) : unit =
     Stdlib.flush oc)
 ;;
 
-(* ================================================================ *)
-(* Storage Backend Abstraction                                      *)
-(* ================================================================ *)
-
-type backend_kind =
-  | Local
-  | Remote of string
-
-type backend =
-  { kind : backend_kind
-  ; base_path : string
-  }
-
-let create_backend ?(kind = Local) ~base_path () = { kind; base_path }
-let backend_base_path (b : backend) = b.base_path
-
-let backend_kind_to_string = function
-  | Local -> "local"
-  | Remote url -> Printf.sprintf "remote(%s)" url
-;;
-
-let default_backend ~base_path = { kind = Local; base_path }

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -157,33 +157,3 @@ val close_all_cached_writers : unit -> unit
 (** Drop and close every cached writer. Test-only — production
     relies on process-lifetime persistence and [at_exit] drain. *)
 val reset_fd_cache_for_testing : unit -> unit
-
-(** {1 Storage Backend Abstraction}
-
-    Types for future migration to composite backends (local + remote).
-    Existing functions continue to operate on the local filesystem.
-    New code can use [backend] to select storage targets.
-
-    @since 2.95.0 — Issue #1442 *)
-
-type backend_kind =
-  | Local (** Local filesystem (Eio or Unix fallback) *)
-  | Remote of string (** Remote endpoint URL *)
-
-type backend =
-  { kind : backend_kind
-  ; base_path : string (** Root directory for this backend *)
-  }
-
-(** Create a backend descriptor.
-    Defaults to [Local] when [kind] is omitted. *)
-val create_backend : ?kind:backend_kind -> base_path:string -> unit -> backend
-
-(** Return the base_path of a backend. *)
-val backend_base_path : backend -> string
-
-(** Serialize backend_kind for logging/diagnostics. *)
-val backend_kind_to_string : backend_kind -> string
-
-(** Convenience: create a [Local] backend with the given base_path. *)
-val default_backend : base_path:string -> backend


### PR DESCRIPTION
## Summary

`Fs_compat`의 `Storage Backend Abstraction` 섹션 (52 줄) 을 삭제. caller 0 dead surface.

- `backend` / `backend_kind` / `create_backend` / `backend_base_path` / `backend_kind_to_string` / `default_backend` / `Local` / `Remote` 모두 호출자 없음
- @since 2.95.0 (Issue #1442) 에 "future migration to composite backends" 약속으로 추가됐으나 1년+ 지나도록 `Remote` 인스턴스 생성된 적 없음
- 기존 local fallback 은 `set_fs` / `with_fs_or_fallback` 직접 경로로 흐름. `backend` 우회 없음

## Evidence

```bash
# qualified
rg -n "Fs_compat\.(backend|create_backend|backend_kind|backend_base_path|default_backend)" --type ocaml -g '!lib/fs_compat/**'
# → 0 results

# unqualified (Backend_types/coord_utils_backend_setup/opentelemetry 의 동명 함수는 별개 모듈, 충돌 0)
rg -n "backend_kind|create_backend|backend_base_path|default_backend" --type ocaml -g '!lib/fs_compat/**'
# → 별개 namespace (Backend_types.config 기반 storage_backend) 만 매칭
```

## Workaround Rejection Bar Self-Check

- §1 telemetry-as-fix? ✗ (dead removal, fix 아님)
- §2 substring classifier? ✗
- §3 N-of-M? ✗ (단일 concern, 단일 PR)
- catch-all 추가? ✗
- cap/cooldown/dedup/repair? ✗
- test backdoor? ✗
- typo fan-out? ✗

PASS.

## Build

\`dune build --root . lib/\` PASS. fs_compat consumer (keeper, jsonl_writer, dated_jsonl, coord) 전부 컴파일 통과.

## Out of Scope

- main HEAD \`b964f49dc2\` 에 별개 \`test/\` baseline 결함 (\`Goal_store.write_state\`, \`A.of_yojson\` Unbound) 존재 — 본 PR 과 무관, 별도 issue 로 보고 예정
- RFC-0162 fs_compat 모듈화 (Wave 5-cluster split: eio_bridge / atomic / jsonl_writer / memo / path_ops) — 본 PR 머지 후 follow-up RFC 로 진행

## Test Plan

- [ ] CI lint/build green
- [ ] fs_compat 변경 면이 \`production caller 0\` 라는 grep 증거 reviewer 가 자체 재현
- [ ] mli/ml 동기 (val 5 + type 2 삭제, 두 파일 sync)

RFC-WAIVED: fs_compat 은 agent_delegation list (credential/keeper/operator/dashboard credential/hooks/workflow) 영역 아님. dead code removal 은 RFC-required 영역 외 surgical change.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>