### PR TITLE
refactor(board_core_classify): delete unused reclassify_report_to_yojson serialiser

### DIFF
--- a/lib/board_core_classify.ml
+++ b/lib/board_core_classify.ml
@@ -290,17 +290,3 @@ type reclassify_report = {
   apply_failures : int;
   changed_post_ids : string list;
 }
-
-let reclassify_report_to_yojson (report : reclassify_report) =
-  `Assoc
-    [
-      ("backend", `String report.backend);
-      ("dry_run", `Bool report.dry_run);
-      ("scanned", `Int report.scanned);
-      ("changed", `Int report.changed);
-      ("unchanged", `Int report.unchanged);
-      ("skipped", `Int report.skipped);
-      ("apply_failures", `Int report.apply_failures);
-      ( "changed_post_ids",
-        `List (List.map (fun id -> `String id) report.changed_post_ids) );
-    ]

--- a/lib/board_core_classify.mli
+++ b/lib/board_core_classify.mli
@@ -181,7 +181,3 @@ type reclassify_report = {
 }
 (** Output of bulk reclassification operations.  Used by both the
     filesystem and PG backends. *)
-
-val reclassify_report_to_yojson : reclassify_report -> Yojson.Safe.t
-(** Hand-written serialiser (no PPX) — kept so the JSON shape stays
-    stable across refactors. *)


### PR DESCRIPTION
## Summary

`reclassify_report_to_yojson` is a hand-written serialiser with zero callers across all 6 audit paths. The `reclassify_report` type itself stays — it remains the return type of `Board_dispatch.reclassify_posts` / `Board.reclassify_posts`.

## Audit (iter 75)

6-prong dead-export audit, all returning 0:

| Path | Count |
|---|---|
| `Board_core_classify.reclassify_report_to_yojson` qualified | 0 |
| `Board_core.*` via `include Board_core_classify` chain | 0 |
| `Board_core_json.*` via `include Board_core_classify` chain | 0 |
| `Board.*` via outer facade chain (`Board → Board_votes → Board_core`) | 0 |
| Internal use within `board_core_classify.ml` | 0 |
| Parent `.ml` unqualified (board_core.ml / board_core_json.ml) | 0 |

4 veto paths all empty:
- Internal LIVE — none
- Facade re-export — none surface this fn under a different name
- RFC scaffolding — none (docstring is generic stability claim)
- Defensive witness — none (not a compile-time invariant guard)

## Pattern: asymmetric read/write

Mirrors iter 70 `Attribution.of_yojson` deletion — but inverted:
- Iter 70: writer LIVE, reader DEAD
- This PR: type LIVE, serialiser DEAD

The docstring "kept so the JSON shape stays stable across refactors" is aspirational — there is no caller exercising it, so the stability claim is unenforced.

## Callers of `reclassify_posts` (return-type LIVE)

Test only — `test/test_board_dispatch.ml:352, 359` calls `Board_dispatch.reclassify_posts` and asserts on record fields directly, never on JSON output.

## Diff

-18 LoC: 1 val from `.mli`, 1 function body from `.ml`.

## Verification

`dune build lib/` PASS (EXIT=0).

## Related

- Iter 70 PR #17863 — same asymmetric read/write pattern (attribution)
- Iter 73 PR #17869, iter 74 PR #17872 — 5-prong audit + 4 veto paths methodology
- Cumulative dead-export sweep: -313 LoC, 23 dead surfaces

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>