### PR TITLE
refactor(heuristic_metrics_diagnostics): inline + delete unused make_tuple_key constructor

### DIFF
--- a/lib/heuristic_metrics_diagnostics.ml
+++ b/lib/heuristic_metrics_diagnostics.ml
@@ -6,9 +6,6 @@ type tuple_key = {
   triggered : bool;
 }
 
-let make_tuple_key ~raw_value ~threshold ~triggered =
-  { raw_value; threshold; triggered }
-
 type site_stat = {
   site : site;
   count : int;
@@ -64,7 +61,7 @@ let parse_record (j : Yojson.Safe.t) : parsed option =
   Some
     {
       site;
-      key = make_tuple_key ~raw_value:raw ~threshold:thr ~triggered:trig;
+      key = { raw_value = raw; threshold = thr; triggered = trig };
       timestamp = ts;
     }
 

--- a/lib/heuristic_metrics_diagnostics.mli
+++ b/lib/heuristic_metrics_diagnostics.mli
@@ -26,10 +26,6 @@ type tuple_key = private {
   triggered : bool;
 }
 
-val make_tuple_key : raw_value:float -> threshold:float -> triggered:bool -> tuple_key
-(** Constructor used by tests and callers that want to query
-    [per_site_unique_tuples] directly. *)
-
 type site_stat = {
   site : site;
   count : int;


### PR DESCRIPTION
## Summary

`make_tuple_key` was a 1-line constructor for the private `tuple_key` type, exported for external use but called by nobody. The single internal use (`parse_record` at line 67) is inlined as an anonymous record construction; the function definition + .mli val are removed.

## Audit (iter 76)

6-prong dead-export audit:

| Path | Count |
|---|---|
| `Heuristic_metrics_diagnostics.make_tuple_key` qualified | 0 |
| `D.make_tuple_key` (test alias #1) | 0 |
| `HD.make_tuple_key` (test alias #2) | 0 |
| Parent .ml unqualified (no facade) | 0 |
| Opener-unqualified across all .ml | 0 |
| Test exercise (`rg make_tuple_key test/`) | 0 |

Internal use: 1 site in `parse_record` (board_core_payload pattern — inline-deletable).

4 veto paths:
- Internal LIVE — *almost* (single use) → resolved by inlining
- Facade re-export — none (no `include Heuristic_metrics_diagnostics`)
- RFC scaffolding — none (module is #7718 follow-up, already shipped)
- Defensive witness — none (constructor for read-only private type; deletion does not weaken invariants because private type was already construction-restricted)

## Why this is safe

The `tuple_key` type stays exported as `private`. External callers can still pattern-match `site_stat.key.raw_value` etc. — the API for *reading* is unchanged. The only thing removed is the (unused) construction capability from outside the module.

## Diff

-7 LoC net: 4 LoC `.ml` (function body + blank line) + 4 LoC `.mli` (val + docstring) − 1 LoC inline construction.

## Verification

`dune build lib/` PASS (EXIT=0).

## Related

- Iter 75 PR #17875 — same asymmetric-API-surface pattern (type LIVE, helper DEAD)
- Audit methodology: `[[feedback-dead-export-audit-must-trace-include-facade]]` 5-prong + `[[feedback-defensive-witness-4th-veto-path]]` 4 veto paths
- Cumulative dead-export sweep: -320 LoC, 24 dead surfaces

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>