### PR TITLE
fix(keeper): remove oas_timeout_budget parse-only canonicalizer arms

### DIFF
--- a/lib/keeper_recording_error_state/keeper_recording_error_state.ml
+++ b/lib/keeper_recording_error_state/keeper_recording_error_state.ml
@@ -47,7 +47,6 @@ let error_kind_to_string = function
 ;;
 
 let canonical_error_kind_label = function
-  | "oas_timeout_budget" -> "provider_timeout"
   | value -> value
 
 let error_kind_of_string raw =
@@ -105,7 +104,7 @@ let classify_error (err : string) : error_kind =
   then Stale_turn_timeout
   else if contains "fiber_unresolved"
   then Fiber_unresolved
-  else if contains "provider_timeout" || contains "oas_timeout_budget"
+  else if contains "provider_timeout"
   then Provider_timeout
   else if contains "state machine guard" || contains "guard violation"
   then State_machine_guard

--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -420,8 +420,6 @@ let error_kind_of_string value = Error_kind value
 let error_kind_to_string (Error_kind value) = value
 
 let canonical_error_kind_label = function
-  | "oas_timeout_budget" -> "provider_timeout"
-  | "oas_timeout_budget_loop" -> "provider_timeout_loop"
   | value -> value
 
 let timeout_error_kinds =


### PR DESCRIPTION
## Summary
- Remove 3 remaining `oas_timeout_budget` parse-only canonicalizer arms from `keeper_recording_error_state.ml` and `memory_oas_bridge.ml`
- These were legacy string-input normalizers that mapped old wire labels to `provider_timeout` — the backend no longer emits `oas_timeout_budget`, making these arms dead code
- ADT variant `Oas_timeout_budget` was already fully removed in the 111-PR timeout state collapse sweep; this cleans up the last string-level remnants

## Verification
- `rg "oas_timeout_budget" lib/ --type ml` → 0 hits
- `dune build --root . @install` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)