### PR TITLE
refactor(dashboard): rename timeout_budget to provider_timeout_plan

### DIFF
--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -189,7 +189,7 @@ describe('buildFleetRows runtime labels', () => {
             handoff_new_generation: null,
             prompt_fingerprint: null,
             prompt_metrics: null,
-            timeout_budget: null,
+            provider_timeout_plan: null,
             ctx_composition: null,
             input_tokens: null,
             output_tokens: null,

--- a/dashboard/src/components/keeper-detail-telemetry.test.ts
+++ b/dashboard/src/components/keeper-detail-telemetry.test.ts
@@ -58,7 +58,7 @@ describe('InferenceTelemetryPanel', () => {
         fallback_from: null,
         fallback_to: null,
         fallback_reason: null,
-        timeout_budget: null,
+        provider_timeout_plan: null,
       },
       {
         ts: 2,
@@ -105,7 +105,7 @@ describe('InferenceTelemetryPanel', () => {
         fallback_from: null,
         fallback_to: null,
         fallback_reason: null,
-        timeout_budget: null,
+        provider_timeout_plan: null,
       },
     ] satisfies KeeperMetricPoint[]
     const keeper = { metrics_series: metricsSeries } as Keeper
@@ -159,7 +159,7 @@ describe('InferenceTelemetryPanel', () => {
         fallback_from: null,
         fallback_to: null,
         fallback_reason: null,
-        timeout_budget: null,
+        provider_timeout_plan: null,
       },
       {
         ts: 2,
@@ -198,7 +198,7 @@ describe('InferenceTelemetryPanel', () => {
         fallback_from: null,
         fallback_to: null,
         fallback_reason: null,
-        timeout_budget: null,
+        provider_timeout_plan: null,
       },
     ] satisfies KeeperMetricPoint[]
     const keeper = { metrics_series: metricsSeries } as Keeper

--- a/dashboard/src/components/keeper-detail-telemetry.ts
+++ b/dashboard/src/components/keeper-detail-telemetry.ts
@@ -60,7 +60,7 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
   )
   const latestTotal = latestPrompt?.estimated_total_tokens ?? null
   const latestCacheable = latestPrompt?.estimated_cacheable_tokens ?? null
-  const latestTimeoutBudget = latest?.timeout_budget ?? null
+  const latestProviderTimeoutPlan = latest?.provider_timeout_plan ?? null
   const cacheableRatio =
     latestTotal && latestCacheable != null && latestTotal > 0
       ? latestCacheable / latestTotal
@@ -105,14 +105,14 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
             <span>latest ${latestTotal != null ? formatTokens(latestTotal) : '-'}</span>
             <span>cacheable ${latestCacheable != null ? formatTokens(latestCacheable) : '-'}</span>
             ${cacheableRatio != null ? html`<span>${Math.round(cacheableRatio * 100)}% cacheable</span>` : null}
-            ${latestTimeoutBudget?.oas_timeout_sec != null
-              ? html`<span>OAS ${Math.round(latestTimeoutBudget.oas_timeout_sec)}s</span>`
+            ${latestProviderTimeoutPlan?.oas_timeout_sec != null
+              ? html`<span>OAS ${Math.round(latestProviderTimeoutPlan.oas_timeout_sec)}s</span>`
               : null}
-            ${latestTimeoutBudget?.keeper_turn_timeout_sec != null
-              ? html`<span>keeper cap ${Math.round(latestTimeoutBudget.keeper_turn_timeout_sec)}s</span>`
+            ${latestProviderTimeoutPlan?.keeper_turn_timeout_sec != null
+              ? html`<span>keeper cap ${Math.round(latestProviderTimeoutPlan.keeper_turn_timeout_sec)}s</span>`
               : null}
-            ${latestTimeoutBudget?.source
-              ? html`<span>${latestTimeoutBudget.source}</span>`
+            ${latestProviderTimeoutPlan?.source
+              ? html`<span>${latestProviderTimeoutPlan.source}</span>`
               : null}
             ${latest?.cascade_strategy
               ? html`<span>strategy ${latest.cascade_strategy}</span>`

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -406,17 +406,16 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
             }
           : null
       const rawProviderTimeoutPlan = isRecord(item.provider_timeout_plan) ? item.provider_timeout_plan : null
-      const rawTimeoutBudget = isRecord(item.timeout_budget) ? item.timeout_budget : rawProviderTimeoutPlan
-      const timeout_budget =
-        rawTimeoutBudget != null
+      const provider_timeout_plan =
+        rawProviderTimeoutPlan != null
           ? {
-              oas_timeout_sec: asNumber(rawTimeoutBudget.oas_timeout_sec) ?? null,
-              adaptive_timeout_sec: asNumber(rawTimeoutBudget.adaptive_timeout_sec) ?? null,
-              keeper_turn_timeout_sec: asNumber(rawTimeoutBudget.keeper_turn_timeout_sec) ?? null,
-              remaining_turn_budget_sec: asNumber(rawTimeoutBudget.remaining_turn_budget_sec) ?? null,
-              estimated_input_tokens: asNumber(rawTimeoutBudget.estimated_input_tokens) ?? null,
-              max_turns: asNumber(rawTimeoutBudget.max_turns) ?? null,
-              source: typeof rawTimeoutBudget.source === 'string' ? rawTimeoutBudget.source : null,
+              oas_timeout_sec: asNumber(rawProviderTimeoutPlan.oas_timeout_sec) ?? null,
+              adaptive_timeout_sec: asNumber(rawProviderTimeoutPlan.adaptive_timeout_sec) ?? null,
+              keeper_turn_timeout_sec: asNumber(rawProviderTimeoutPlan.keeper_turn_timeout_sec) ?? null,
+              remaining_turn_budget_sec: asNumber(rawProviderTimeoutPlan.remaining_turn_budget_sec) ?? null,
+              estimated_input_tokens: asNumber(rawProviderTimeoutPlan.estimated_input_tokens) ?? null,
+              max_turns: asNumber(rawProviderTimeoutPlan.max_turns) ?? null,
+              source: typeof rawProviderTimeoutPlan.source === 'string' ? rawProviderTimeoutPlan.source : null,
             }
           : null
       const rawCtxComposition = isRecord(item.ctx_composition) ? item.ctx_composition : null
@@ -481,7 +480,7 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
         handoff_new_generation: handoffNewGeneration,
         prompt_fingerprint: promptFingerprint,
         prompt_metrics,
-        timeout_budget,
+        provider_timeout_plan,
         ctx_composition,
         input_tokens: inputTokens,
         output_tokens: outputTokens,

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -365,7 +365,7 @@ export interface KeeperMetricPoint {
   handoff_new_generation: number | null
   prompt_fingerprint: string | null
   prompt_metrics: PromptTelemetry | null
-  timeout_budget: TimeoutBudgetTelemetry | null
+  provider_timeout_plan: TimeoutBudgetTelemetry | null
   ctx_composition: CtxCompositionTelemetry | null
   input_tokens: number | null
   output_tokens: number | null


### PR DESCRIPTION
## Summary
- Rename `timeout_budget` field to `provider_timeout_plan` across dashboard TypeScript to match backend wire format (renamed in #17815)
- Remove old-key fallback in `keeper-store-normalize.ts` — backend now emits only `provider_timeout_plan`
- 5 files changed: type definition, normalize logic, UI component, 2 test files

## Verification
- `rg "timeout_budget" dashboard/src/` → only legacy `oas_timeout_budget` assertion (intentionally preserved) + comment remain
- `pnpm typecheck` → no new errors
- `vitest run` → 81/81 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)