### PR TITLE
refactor(fs_compat): extract Mkdir_memo submodule (RFC-0162 §3.1)

### DIFF
--- a/lib/fs_compat/dune
+++ b/lib/fs_compat/dune
@@ -2,7 +2,7 @@
 (library
  (name fs_compat)
  (public_name masc_mcp.fs_compat)
- (modules fs_compat)
+ (modules fs_compat mkdir_memo)
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags (:standard -w +4))
  (libraries eio eio.unix unix yojson optint))

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -507,25 +507,8 @@ let mkdir_p (path : string) : unit =
 
    Race: two domains may both miss-and-mkdir; the second [mkdir] is a
    harmless EEXIST. The mutex covers the [Hashtbl] op only. *)
-let mkdir_p_done : (string, unit) Hashtbl.t = Hashtbl.create 32
-let mkdir_p_memo_mu = Stdlib.Mutex.create ()
-
-let mkdir_p_memoized (path : string) : unit =
-  let cached =
-    Stdlib.Mutex.protect mkdir_p_memo_mu (fun () ->
-      Hashtbl.mem mkdir_p_done path)
-  in
-  if not cached then begin
-    mkdir_p path;
-    Stdlib.Mutex.protect mkdir_p_memo_mu (fun () ->
-      Hashtbl.replace mkdir_p_done path ())
-  end
-;;
-
-let reset_mkdir_memo_for_testing () =
-  Stdlib.Mutex.protect mkdir_p_memo_mu (fun () ->
-    Hashtbl.reset mkdir_p_done)
-;;
+let mkdir_p_memoized path = Mkdir_memo.mkdir_p_memoized ~mkdir_p path
+let reset_mkdir_memo_for_testing () = Mkdir_memo.reset_for_testing ()
 
 (** Parse pre-read string lines as JSONL.
     Use when lines come from [Keeper_memory.read_file_tail_lines] or

--- a/lib/fs_compat/mkdir_memo.ml
+++ b/lib/fs_compat/mkdir_memo.ml
@@ -1,0 +1,24 @@
+(* RFC-0162 §3.1. See [mkdir_memo.mli] for the contract.
+
+   Race: two domains may both miss-and-mkdir; the second [mkdir_p]
+   call is a harmless EEXIST inside the caller's primitive. The
+   mutex only guards the [Hashtbl] op so the [mkdir_p] callback
+   runs unlocked and can itself acquire fs locks without nesting. *)
+
+let done_ : (string, unit) Hashtbl.t = Hashtbl.create 32
+let mu = Stdlib.Mutex.create ()
+
+let mkdir_p_memoized ~(mkdir_p : string -> unit) (path : string) : unit =
+  let cached =
+    Stdlib.Mutex.protect mu (fun () -> Hashtbl.mem done_ path)
+  in
+  if not cached
+  then begin
+    mkdir_p path;
+    Stdlib.Mutex.protect mu (fun () -> Hashtbl.replace done_ path ())
+  end
+;;
+
+let reset_for_testing () =
+  Stdlib.Mutex.protect mu (fun () -> Hashtbl.reset done_)
+;;

--- a/lib/fs_compat/mkdir_memo.mli
+++ b/lib/fs_compat/mkdir_memo.mli
@@ -1,0 +1,22 @@
+(** Idempotent directory-existence cache.
+
+    Path-keyed memoize wrapper around a caller-supplied [mkdir_p]
+    primitive. The cache stores only the {i fact} that the dir
+    exists; no fd is held. External processes that delete the dir
+    after first call will see silent skip — caller must ensure this
+    is acceptable for their domain (e.g. self-owned [.masc/] trees).
+    RFC-0162 §3.1.
+
+    The [mkdir_p] callback is injected so this module stays free of
+    [Fs_compat]'s Eio bridge, test-isolation guard, and Unix
+    fallback. Cycle-free placement inside [fs_compat]'s wrapped
+    library. *)
+
+(** [mkdir_p_memoized ~mkdir_p path] calls [mkdir_p path] only on
+    the first request for [path] in this process. Subsequent calls
+    skip the stat/mkdir entirely. *)
+val mkdir_p_memoized : mkdir_p:(string -> unit) -> string -> unit
+
+(** Reset the cache. Test-only — production code relies on
+    process-lifetime persistence. *)
+val reset_for_testing : unit -> unit


### PR DESCRIPTION
## Summary

\`fs_compat.ml\` 의 mkdir memoize cache (Phase 0a, line 484-528) 를 별도 \`Mkdir_memo\` submodule 로 추출. *순수 구조 refactor* — 기존 Alcotest 4 case 가 *test 0 변경* 으로 그대로 PASS, 외부 caller 시그니처 보존.

## Design — Callback Injection

\`Mkdir_memo.mkdir_p_memoized\` 가 \`mkdir_p\` 함수를 labelled argument 로 받음. wrapped-library 안에서 sub-module 이 container 모듈을 다시 호출하는 cyclic-dependency 위험을 *callback 주입* 으로 회피.

\`\`\`ocaml
val mkdir_p_memoized : mkdir_p:(string -> unit) -> string -> unit
\`\`\`

\`Fs_compat.mkdir_p_memoized\` 는 한 줄 partial-apply facade:

\`\`\`ocaml
let mkdir_p_memoized path = Mkdir_memo.mkdir_p_memoized ~mkdir_p path
let reset_mkdir_memo_for_testing () = Mkdir_memo.reset_for_testing ()
\`\`\`

→ 외부 caller (현재는 \`test/test_fs_compat_mkdir_memo.ml\` 만) 변경 0.

## Why Submodule, Not Full Library

- single-responsibility (\`mkdir\` cache 만) — 24 LoC implementation + 22 LoC mli
- \`fs_compat\` library 의 \`-w +4\` ratchet (RFC-0071 §3.4 Phase 5) 같은 lint 게이트 그대로 적용
- 같은 wrapped library 안 sub-module 라 외부에서 \`Fs_compat.Mkdir_memo.X\` 자동 노출 (선택적 사용)
- callback 패턴으로 후속 sub-module (Append_writer 등) 에서 같은 cycle-free 패턴 재사용

## Diff

| 파일 | 변경 |
|---|---|
| \`lib/fs_compat/dune\` | \`modules\` 에 \`mkdir_memo\` 추가 |
| \`lib/fs_compat/fs_compat.ml\` | -19 LoC (cache 본체 삭제 + 2-line facade) |
| \`lib/fs_compat/mkdir_memo.ml\` | new, 24 LoC |
| \`lib/fs_compat/mkdir_memo.mli\` | new, 22 LoC (doc-heavy) |

## Build & Test

- \`dune build --root . lib/\` PASS
- \`dune exec test_fs_compat_mkdir_memo.exe\`: **4/4 PASS** (first call / idempotent repeat / external delete contract / concurrent race-safe)
- \`ocamlformat --check\` on touched files: PASS

## Workaround Rejection Bar Self-Check

| 항목 | 결과 |
|---|---|
| §1 telemetry-as-fix | ✗ |
| §2 substring classifier | ✗ |
| §3 N-of-M | ✗ (single extract) |
| catch-all addition | ✗ |
| cap/cooldown/dedup/repair | ✗ |
| test backdoor | ✗ (reset_for_testing 은 *기존 surface 의 이동*, 새 노출 0) |
| typo fan-out | ✗ |

PASS.

## Out of Scope

- **Wave 5-cluster split** — 이 PR 은 첫 cluster (mkdir_memo) 만. 나머지 (path_ops / atomic_write / append_writer / eio_bridge) 는 RFC-0162 production soak 이후 각각 별도 PR
- **CI infrastructure baseline failures** (Godfile size / Workflow YAML / Provider name ratchet) on main HEAD ~2026-05-23 — 자매 refactor PR #17872 / #17869 / #17867 에서 동일 fail, 본 PR 무관

## Test Plan

- [ ] CI infra 회복 시 lint/build/test green
- [ ] mli surface diff 0 reviewer 가 자체 재현 (\`git diff origin/main lib/fs_compat/fs_compat.mli\`)
- [ ] \`Fs_compat.Mkdir_memo\` 의 \`mkdir_p\` callback 시그니처 검토

RFC-WAIVED: fs_compat 은 agent_delegation list (credential / keeper / operator / dashboard credential / hooks / workflow) 영역 아님. 순수 구조 refactor.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>