### PR TITLE
fix(cascade): increase capacity_backpressure default backoff 5s → 30s (task-536)

### DIFF
--- a/lib/cascade/cascade_health_tracker_config.ml
+++ b/lib/cascade/cascade_health_tracker_config.ml
@@ -139,12 +139,19 @@ let soft_rate_limit_max_clamp_sec =
     ()
 
 (** Synthetic backoff for [Capacity_backpressure] with no [retry_after_sec].
-    See {!Cascade_health_tracker_config.default_capacity_backpressure_backoff_sec}
-    for rationale. *)
+
+    5.0 s was too short — providers rotated back into selection before
+    upstream capacity recovered, causing immediate re-failure and
+    keeper-turn thrashing (task-536).  30.0 s gives a reasonable
+    recovery window while still clamping to
+    [soft_rate_limit_max_clamp_sec] when a real [retry_after] hint is
+    present.
+
+    Override via [MASC_CASCADE_CAPACITY_BACKPRESSURE_DEFAULT_BACKOFF_SEC]. *)
 let default_capacity_backpressure_backoff_sec =
   read_float_setting
     ~primary:"MASC_CASCADE_CAPACITY_BACKPRESSURE_DEFAULT_BACKOFF_SEC"
-    ~default:5.0
+    ~default:30.0
     ()
 
 let read_ring_size env_name =


### PR DESCRIPTION
## Summary

Increases `default_capacity_backpressure_backoff_sec` from 5.0 s to 30.0 s.

## Problem

5.0 s was too short — providers rotated back into cascade selection before upstream capacity recovered, causing immediate re-failure and keeper-turn thrashing (task-536 P0 EMERGENCY).

## Fix

30.0 s gives a reasonable recovery window while still clamping to `soft_rate_limit_max_clamp_sec` when a real `retry_after` hint is present.  Operators can still override via `MASC_CASCADE_CAPACITY_BACKPRESSURE_DEFAULT_BACKOFF_SEC`.

## Test plan

- [ ] dune build passes
- [ ] Unit tests for cascade_health_tracker_config unchanged (default value only)
- [ ] Monitor fleet keeper-restart rate after deploy

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>