### PR TITLE
refactor(fs_compat): extract Fd_cache submodule (RFC-0162 §3.4)

### DIFF
--- a/lib/fs_compat/dune
+++ b/lib/fs_compat/dune
@@ -2,7 +2,7 @@
 (library
  (name fs_compat)
  (public_name masc_mcp.fs_compat)
- (modules fs_compat mkdir_memo)
+ (modules fs_compat mkdir_memo fd_cache)
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags (:standard -w +4))
  (libraries eio eio.unix unix yojson optint))

--- a/lib/fs_compat/fd_cache.ml
+++ b/lib/fs_compat/fd_cache.ml
@@ -1,0 +1,73 @@
+(* RFC-0162 §3.4. See [fd_cache.mli] for the contract. *)
+
+type cached_writer =
+  { oc : out_channel
+  ; mutable last_used : float
+  }
+
+let cached : (string, cached_writer) Hashtbl.t = Hashtbl.create 32
+let mu = Stdlib.Mutex.create ()
+let max_entries = 32
+
+let close_silently w =
+  try Stdlib.close_out w.oc with
+  | _ -> ()
+;;
+
+(* Evict the writer with the smallest [last_used], close its fd.
+   Caller must already hold [mu]. *)
+let evict_lru_locked () =
+  let oldest = ref None in
+  Hashtbl.iter
+    (fun path w ->
+      match !oldest with
+      | None -> oldest := Some (path, w.last_used)
+      | Some (_, ts) when w.last_used < ts -> oldest := Some (path, w.last_used)
+      | _ -> ())
+    cached;
+  match !oldest with
+  | None -> ()
+  | Some (victim_path, _) ->
+    (match Hashtbl.find_opt cached victim_path with
+     | Some w ->
+       close_silently w;
+       Hashtbl.remove cached victim_path
+     | None -> ())
+;;
+
+(* Caller must already hold [mu]. *)
+let get_or_open_locked path =
+  let now = Unix.gettimeofday () in
+  match Hashtbl.find_opt cached path with
+  | Some w ->
+    w.last_used <- now;
+    w.oc
+  | None ->
+    if Hashtbl.length cached >= max_entries then evict_lru_locked ();
+    let oc =
+      Stdlib.open_out_gen
+        [ Stdlib.Open_append; Stdlib.Open_creat; Stdlib.Open_wronly ]
+        0o644
+        path
+    in
+    Hashtbl.add cached path { oc; last_used = now };
+    oc
+;;
+
+let get_writer path =
+  Stdlib.Mutex.protect mu (fun () -> get_or_open_locked path)
+;;
+
+let close_all () =
+  Stdlib.Mutex.protect mu (fun () ->
+    Hashtbl.iter (fun _ w -> close_silently w) cached;
+    Hashtbl.reset cached)
+;;
+
+let reset_for_testing () = close_all ()
+
+(* Best-effort cache drain at process exit. RFC-0108 §6 already
+   states per-record fsync is out of scope, so the [flush] inside
+   the hot path is the durability boundary; this close is just to
+   release the fd handles cleanly. *)
+let () = Stdlib.at_exit close_all

--- a/lib/fs_compat/fd_cache.mli
+++ b/lib/fs_compat/fd_cache.mli
@@ -1,0 +1,33 @@
+(** Per-path bounded LRU [out_channel] cache for the JSONL append
+    write-path. RFC-0162 §3.4.
+
+    Each path keeps one [Stdlib.open_out_gen] writer in
+    [O_APPEND | O_CREAT | O_WRONLY] mode, reused across calls. The
+    cache is bounded by [max_entries=32] with last-used eviction so
+    fd count stays bounded regardless of how many paths the process
+    appends to. A [Stdlib.at_exit] hook closes every cached writer
+    on process exit; production code relies on process-lifetime
+    persistence between exits.
+
+    Boundary: this module owns *only* the bounded LRU [out_channel]
+    cache. It is intentionally unaware of mkdir, write
+    serialization, or test-isolation guards — those stay with the
+    [Fs_compat] append site, which composes them around
+    [get_writer]. *)
+
+(** [get_writer path] returns the cached writer for [path],
+    opening one on the first request and bumping its LRU stamp on
+    every request. Evicts the least-recently-used writer when the
+    bound is exceeded. Internal mutex protects cache state only;
+    {b does not} stay held across the caller's subsequent
+    [output_string]/[flush] on the returned channel. *)
+val get_writer : string -> out_channel
+
+(** Flush and close every cached writer. Safe to call concurrently
+    with active appends; a subsequent [get_writer] re-opens fresh.
+    Registered at [Stdlib.at_exit]. *)
+val close_all : unit -> unit
+
+(** Drop and close every cached writer. Test-only — production
+    relies on process-lifetime persistence and the [at_exit] drain. *)
+val reset_for_testing : unit -> unit

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -679,84 +679,15 @@ let fold_jsonl_lines ~init ~f path =
    - The cache lookup uses a separate, microsecond-scoped mutex
      ([fd_cache_mu]) so two appends to *different* paths never
      contend on a global fd-cache lock. *)
-type cached_writer =
-  { oc : out_channel
-  ; mutable last_used : float
-  }
-
-let cached_writers : (string, cached_writer) Hashtbl.t = Hashtbl.create 32
-let fd_cache_mu = Stdlib.Mutex.create ()
-let fd_cache_max = 32
-
-let close_cached_writer_silently w =
-  try Stdlib.close_out w.oc with
-  | _ -> ()
-;;
-
-(* Evict the cached writer with the smallest [last_used], close its fd.
-   Inside [fd_cache_mu] only. *)
-let evict_lru_locked () =
-  let oldest = ref None in
-  Hashtbl.iter
-    (fun path w ->
-      match !oldest with
-      | None -> oldest := Some (path, w.last_used)
-      | Some (_, ts) when w.last_used < ts -> oldest := Some (path, w.last_used)
-      | _ -> ())
-    cached_writers;
-  match !oldest with
-  | None -> ()
-  | Some (victim_path, _) ->
-    (match Hashtbl.find_opt cached_writers victim_path with
-     | Some w ->
-       close_cached_writer_silently w;
-       Hashtbl.remove cached_writers victim_path
-     | None -> ())
-;;
-
-(* Inside [fd_cache_mu]: return the cached [out_channel] for [path],
-   opening (and possibly LRU-evicting) on first use. *)
-let get_or_open_writer_locked path =
-  let now = Unix.gettimeofday () in
-  match Hashtbl.find_opt cached_writers path with
-  | Some w ->
-    w.last_used <- now;
-    w.oc
-  | None ->
-    if Hashtbl.length cached_writers >= fd_cache_max then evict_lru_locked ();
-    let oc =
-      Stdlib.open_out_gen
-        [ Stdlib.Open_append; Stdlib.Open_creat; Stdlib.Open_wronly ]
-        0o644
-        path
-    in
-    Hashtbl.add cached_writers path { oc; last_used = now };
-    oc
-;;
-
-let close_all_cached_writers () =
-  Stdlib.Mutex.protect fd_cache_mu (fun () ->
-    Hashtbl.iter (fun _ w -> close_cached_writer_silently w) cached_writers;
-    Hashtbl.reset cached_writers)
-;;
-
-let reset_fd_cache_for_testing () = close_all_cached_writers ()
-
-(* Best-effort cache drain at process exit. RFC-0108 §6 already states
-   per-record fsync is out of scope, so the [flush] inside the hot
-   path is the durability boundary; this close is just to release
-   the fd handles cleanly. *)
-let () = Stdlib.at_exit close_all_cached_writers
+let close_all_cached_writers () = Fd_cache.close_all ()
+let reset_fd_cache_for_testing () = Fd_cache.reset_for_testing ()
 
 let append_jsonl (path : string) (json : Yojson.Safe.t) : unit =
   test_exec_home_guard ~op:"append_jsonl" path;
   let dir = Stdlib.Filename.dirname path in
   mkdir_p_memoized dir;
   let line = Yojson.Safe.to_string json ^ "\n" in
-  let oc =
-    Stdlib.Mutex.protect fd_cache_mu (fun () ->
-      get_or_open_writer_locked path)
-  in
+  let oc = Fd_cache.get_writer path in
   let path_mu = get_append_path_mutex path in
   Stdlib.Mutex.protect path_mu (fun () ->
     Stdlib.output_string oc line;


### PR DESCRIPTION
## Summary

\`fs_compat.ml\` 의 per-path bounded LRU \`out_channel\` cache (Phase 2, RFC-0162 §3.4) 를 별도 \`Fd_cache\` submodule 로 추출. **순수 구조 refactor** — RFC-0108 §5.1 의 4 stress case (16-thread multibyte / 8-thread PIPE_BUF-busting / reset-continue / LRU-preserves-data) 가 *test 0 변경* 으로 그대로 4/4 PASS. Record-interleave-0 + partial-write-0 보존 검증.

## Design

\`Fd_cache\` 는 *bounded LRU \`out_channel\` cache 만* 소유:
- state (\`cached\` hashtable, mutex, \`max_entries = 32\`)
- LRU \`evict_lru_locked\`
- \`get_or_open_locked\`
- \`close_all\` / \`reset_for_testing\`
- \`Stdlib.at_exit close_all\` hook

\`mkdir_p_memoized\` / \`test_exec_home_guard\` / \`append_path_mutex_registry\` 의존성 없음 → cycle-free. \`Fs_compat.append_jsonl\` 가 \`Fd_cache.get_writer\` 위에 *이 3가지* 를 직접 composes:

\`\`\`ocaml
let append_jsonl path json =
  test_exec_home_guard ~op:"append_jsonl" path;
  let dir = Stdlib.Filename.dirname path in
  mkdir_p_memoized dir;
  let line = Yojson.Safe.to_string json ^ "\n" in
  let oc = Fd_cache.get_writer path in
  let path_mu = get_append_path_mutex path in
  Stdlib.Mutex.protect path_mu (fun () ->
    Stdlib.output_string oc line;
    Stdlib.flush oc)
\`\`\`

## Two-Mutex Split Preserved

\`get_writer\` 는 *fd-cache mutex 를 caller 의 후속 output 동안 유지하지 않음*. 원본의 *fd-cache mu (lookup/open/LRU)* 와 *path-keyed mu (atomic write)* 분리가 그대로 유지 — 두 append 가 *서로 다른 path* 에 갈 때 global fd-cache lock 으로 contend 하지 않음.

## Diff

| 파일 | 변경 |
|---|---|
| \`lib/fs_compat/dune\` | \`(modules ...)\` += \`fd_cache\` |
| \`lib/fs_compat/fs_compat.ml\` | **-71 LoC** (cache 본체 전체 + at_exit 삭제, 2-line facade + reshaped \`append_jsonl\`) |
| \`lib/fs_compat/fs_compat.mli\` | **0 LoC** (surface 완전 보존) |
| \`lib/fs_compat/fd_cache.ml\` | new, 75 LoC |
| \`lib/fs_compat/fd_cache.mli\` | new, 32 LoC (doc-heavy) |

## Build & Test

- \`dune build --root . lib/fs_compat\` PASS
- \`dune exec test_fs_compat_fd_cache.exe\`: **4/4 PASS** (0.071s)
  - 16-thread × 100 multibyte records (RFC-0108 §5.1 reproduction)
  - 8-thread × 60 PIPE_BUF-busting 5 KB records (4 KB+ interleave guard)
  - reset-then-continue (lifecycle)
  - LRU eviction on 40 paths > \`max_entries=32\` (data preserved on every path)
- \`ocamlformat --check\` on touched files: PASS

## Workaround Rejection Bar Self-Check

| 항목 | 결과 |
|---|---|
| §1 telemetry-as-fix | ✗ |
| §2 substring classifier | ✗ |
| §3 N-of-M | ✗ (single cluster — \`mkdir_memo\`(#17883) + \`fd_cache\` 가 *의도적으로 별개 submodule*, premature abstraction 회피) |
| catch-all 추가 | ✗ |
| cap/cooldown/dedup/repair | ✗ |
| test backdoor | ✗ (\`reset_for_testing\` 은 *기존 surface 이동*) |
| typo fan-out | ✗ |

PASS.

## Out of Scope

- 후속 Wave cluster (\`atomic_write\` / \`eio_bridge\` / \`path_ops\`) — sequential PR
- \`Path_mutex_registry\` submodule extract — *premature abstraction 회피* (2번째 consumer 가 나타날 때까지 보류)

RFC-WAIVED: fs_compat 은 agent_delegation list (credential / keeper / operator / dashboard credential / hooks / workflow) 영역 아님. 순수 구조 refactor, behavior 변경 0.

## Stacking Context

- 머지된 부모: #17874 (Backend dead removal, MERGED \`382bf32d0c\`), #17883 (Mkdir_memo extract, MERGED \`682e67c463\`)
- base=main 위 sequential. 충돌 0 가능성.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>