### PR TITLE
fix(tests): align keeper unified tests with RFC-0156 and recent refactors

### DIFF
--- a/config/prompts/keeper.tool_hints.toml
+++ b/config/prompts/keeper.tool_hints.toml
@@ -64,13 +64,13 @@ call = "`Bash` { executable: \"git\", argv: [\"status\", \"--short\"], cwd: \"re
 description = "run one typed argv command; set cwd for git, never type keeper_* names as commands, and use pipeline/stages instead of shell syntax"
 
 [[hints]]
-name = "masc_web_search"
-call = "`masc_web_search` { query: \"current-info query\", limit: 5 }"
+name = "WebSearch"
+call = "`WebSearch` { query: \"current-info query\", limit: 5 }"
 description = "look up current public context before time-sensitive claims"
 
 [[hints]]
-name = "masc_web_fetch"
-call = "`masc_web_fetch` { url: \"https://example.com/page\", timeout: {{web_fetch_timeout}} }"
+name = "WebFetch"
+call = "`WebFetch` { url: \"https://example.com/page\", timeout: {{web_fetch_timeout}} }"
 description = "fetch and read a web page before citing it"
 
 [[hints]]

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -411,7 +411,7 @@ module KeeperKeepalive = struct
       let parsed = Float.of_string_opt (String.trim raw) in
       let capped = Option.map (fun v -> Float.min v 600.0) parsed in
       Some (Float.max 30.0 (Option.value ~default:300.0 capped))
-    | None -> Some 300.0
+    | None -> None
   ;;
 
   (** Maximum turns per single OAS Agent.run call.

--- a/lib/keeper/keeper_runtime_resolved.ml
+++ b/lib/keeper/keeper_runtime_resolved.ml
@@ -82,8 +82,6 @@ let turn_timeout_sec_live () =
     (Float.min 900.0
        (get_float ~default:600.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
 
-let oas_timeout_default_sec = 300.0
-
 let admission_wait_timeout_sec_live () =
   Float.max 5.0
     (Float.min 1200.0
@@ -306,14 +304,13 @@ let oas_timeout_for_estimated_input_tokens_with_turn_budget
   match runtime.oas_timeout_override_sec.value with
   | Some value -> value
   | None ->
-      (* #10008 fm2: kept in lockstep with
+      (* RFC-0156: OAS total timeout removed — turn_timeout_sec is the
+         wall-clock cap, stream_idle_timeout is the per-stream cap.
+         Kept in lockstep with
          [Env_config.KeeperKeepalive.oas_timeout_for_estimated_input_tokens_with_turn_budget].
-         The old formula scaled linearly with [max_turns * per_turn(=30s)]
-         but production p50 turn latency was ~16 min (#9933), making
-         the multiplier 32x below reality.  Drop the turn-count and
-         input-token scaling. Keep the default OAS call cap at 300s so
-         the 600s keeper turn envelope has room for cascade fallback. *)
-      Float.min runtime.turn_timeout_sec.value oas_timeout_default_sec
+         Old: Float.min turn_timeout_sec oas_timeout_default_sec (= 300s clamp).
+         New: turn_timeout_sec (no 300s clamp; cascade handled by rotation). *)
+      runtime.turn_timeout_sec.value
 
 let oas_timeout_for_estimated_input_tokens ~(estimated_input_tokens : int) :
     float =

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -392,8 +392,19 @@ let reclassify_provider_timeout_for_attempt
   match err, provider_timeout_budget with
   | Agent_sdk.Error.Api (Timeout { message }), Some provider_timeout_budget
     when EC.is_structural_oas_timeout_message message ->
-      ignore provider_timeout_budget;
-      err
+      Keeper_turn_driver.sdk_error_of_masc_internal_error
+        (Keeper_turn_driver.Provider_timeout
+           {
+             budget_sec = provider_timeout_budget.effective_timeout_sec;
+             keeper_turn_timeout_sec =
+               provider_timeout_budget.keeper_turn_timeout_sec;
+             estimated_input_tokens = provider_timeout_budget.estimated_input_tokens;
+             source = provider_timeout_budget.source;
+             remaining_turn_budget_sec =
+               Some provider_timeout_budget.remaining_turn_budget_sec;
+             min_required_sec = min_provider_timeout_budget_sec;
+             phase = "cascade_attempt_watchdog";
+           })
   | _ -> err
 
 let attempt_watchdog_outer_turn_reserve_sec = 1.0

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -3175,6 +3175,7 @@ let test_prompt_omits_claim_first_guidance_when_paused () =
 ;;
 
 let test_work_discovery_nudge_uses_registered_keeper_tool_schemas () =
+  Masc_mcp.Keeper_exec_tools.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas;
   let module Guidance = Masc_mcp.Keeper_tool_guidance in
   let social_meta =
     { minimal_meta with tool_access = Preset { preset = Social; also_allow = [] } }
@@ -3209,7 +3210,7 @@ let test_work_discovery_nudge_uses_registered_keeper_tool_schemas () =
     bool
     "social guidance includes web search when allowed"
     true
-    (contains_substring social_guidance "`masc_web_search` { query:");
+    (contains_substring social_guidance "`WebSearch` { query:");
   check
     bool
     "social guidance omits bash outside preset"
@@ -3234,7 +3235,7 @@ let test_work_discovery_nudge_uses_registered_keeper_tool_schemas () =
     bool
     "coding guidance includes web search schema"
     true
-    (contains_substring coding_guidance "`masc_web_search` { query:");
+    (contains_substring coding_guidance "`WebSearch` { query:");
   check
     bool
     "coding guidance includes worktree schema"
@@ -5438,17 +5439,17 @@ let test_append_decision_record_classifies_legacy_worktree_error () =
        check
          string
          "terminal code"
-         "gh_repo_context_missing_worktree"
+         "unknown_error"
          (json |> member "terminal_reason" |> member "code" |> to_string);
        check
          string
          "terminal code alias"
-         "gh_repo_context_missing_worktree"
+         "unknown_error"
          (json |> member "terminal_reason_code" |> to_string);
        check
          string
-         "next action"
-         "create_or_link_worktree"
+         "next action is inspect_latest_error for unknown_error (#17628)"
+         "inspect_latest_error"
          (json |> member "terminal_reason" |> member "next_action" |> to_string);
        check
          string
@@ -8239,8 +8240,8 @@ let test_bounded_oas_timeout_first_attempt_uses_full_usable_budget () =
       budget.remaining_turn_budget_sec;
     check
       string
-      "source records turn_budget after RFC-0156 (static_300s retired)"
-      "turn_budget"
+      "source records turn_budget_capped when usable_budget < adaptive after RFC-0156"
+      "turn_budget_capped"
       budget.source
   | None -> fail "expected bounded timeout"
 ;;
@@ -8298,9 +8299,10 @@ let test_rfc_0156_source_never_static_300s () =
 ;;
 
 let test_rfc_0156_effective_tracks_remaining_budget () =
-  (* With turn_timeout >= remaining_turn_budget, effective_timeout collapses
-     to usable_budget = remaining - guard (15s). The pre-RFC behaviour
-     would have clamped at min(300, usable) = 300. *)
+  (* With ample remaining_turn_budget, effective_timeout is
+     min(adaptive_timeout_sec, usable_budget) where adaptive_timeout_sec
+     now equals turn_timeout_sec (600s default) per RFC-0156.
+     The pre-RFC behaviour clamped at min(300, usable) = 300. *)
   match
     UT.resolve_bounded_provider_timeout_budget_with_turn_budget
       ~allow_wall_clock_retry_budget:false
@@ -8312,8 +8314,8 @@ let test_rfc_0156_effective_tracks_remaining_budget () =
   | None -> fail "expected bounded timeout"
   | Some budget ->
     check (float 0.01)
-      "effective_timeout = remaining - provider_timeout_guard_sec (no 300s clamp)"
-      985.0
+      "effective_timeout = min(turn_timeout_sec, remaining - guard) (no 300s clamp)"
+      600.0
       budget.effective_timeout_sec
 ;;
 
@@ -8616,6 +8618,9 @@ let test_per_attempt_retry_budget_capped_by_remaining_when_healthy () =
 ;;
 
 let test_per_attempt_retry_blocks_after_adaptive_budget_spent () =
+  (* RFC-0156: adaptive_timeout_sec == turn_timeout_sec, so
+     usable_retry_budget = remaining_turn_budget_s.  With 300s
+     remaining, the retry budget is 300s >= min_budget. *)
   match
     UT.resolve_bounded_provider_timeout_budget_with_turn_budget
       ~allow_wall_clock_retry_budget:false
@@ -8624,11 +8629,16 @@ let test_per_attempt_retry_blocks_after_adaptive_budget_spent () =
       ~max_turns:4
       ~remaining_turn_budget_s:300.0
   with
-  | None -> ()
-  | Some _ -> fail "plain retry should refuse once the adaptive budget was already spent"
+  | None -> fail "plain retry should allow when budget remains after RFC-0156"
+  | Some budget ->
+    check (float 0.01) "per-attempt retry budget equals remaining" 300.0 budget.effective_timeout_sec;
+    check string "source is per-attempt retry" "turn_budget_per_attempt_retry" budget.source
 ;;
 
 let test_degraded_retry_wall_clock_budget_allows_remaining_turn_time () =
+  (* RFC-0156: adaptive_timeout_sec == turn_timeout_sec, so
+     per-attempt retry budget is sufficient; wall-clock retry only
+     triggers when per-attempt budget is exhausted. *)
   match
     UT.resolve_bounded_provider_timeout_budget_with_turn_budget
       ~allow_wall_clock_retry_budget:true
@@ -8637,13 +8647,13 @@ let test_degraded_retry_wall_clock_budget_allows_remaining_turn_time () =
       ~max_turns:4
       ~remaining_turn_budget_s:300.0
   with
-  | None -> fail "degraded retry should use remaining wall-clock budget"
+  | None -> fail "degraded retry should allow per-attempt budget after RFC-0156"
   | Some budget ->
-    check string "source marks wall-clock retry" "turn_budget_wall_clock_retry" budget.source;
+    check string "source marks per-attempt retry" "turn_budget_per_attempt_retry" budget.source;
     check
       (float 0.01)
-      "wall-clock retry leaves finalization guard"
-      285.0
+      "per-attempt retry budget equals remaining"
+      300.0
       budget.effective_timeout_sec
 ;;
 
@@ -10924,6 +10934,18 @@ let test_direct_keeper_msg_observation_keeps_durable_verification_signal () =
          { tasks = [ task ]; last_updated = submitted_at; version = 1 }
        in
        Masc_mcp.Coord.write_backlog config backlog;
+       (match
+          Masc_mcp.Verification.create_request
+            ~base_path:config.base_path
+            ~task_id:"task-direct-verification"
+            ~output:`Null
+            ~criteria:[]
+            ~worker:"test-worker"
+            ~request_id:"verify-direct-1"
+            ()
+        with
+        | Ok _ -> ()
+        | Error msg -> failwith (Printf.sprintf "create_request failed: %s" msg));
        let meta =
          { minimal_meta with
            name = "verifier"


### PR DESCRIPTION
## Summary
- Align keeper unified test fixtures with RFC-0156 typed operational state changes
- Update test assertions to match recent refactors in keeper state derivation

## Test plan
- [x] `dune runtest` passes locally