### PR TITLE
refactor(server_dashboard_http_keeper_api): typed directive variant, remove assert false

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -530,7 +530,9 @@ let handle_keeper_directive_post state _agent_name req reqd body_str =
       try
         let json = Yojson.Safe.from_string body_str in
         match Safe_ops.json_string_opt "action" json with
-        | Some a when a = "pause" || a = "resume" || a = "wakeup" -> Ok a
+        | Some "pause" -> Ok `Pause
+        | Some "resume" -> Ok `Resume
+        | Some "wakeup" -> Ok `Wakeup
         | Some a ->
             Error
               (Printf.sprintf
@@ -545,15 +547,13 @@ let handle_keeper_directive_post state _agent_name req reqd body_str =
           (Printf.sprintf {|{"ok":false,"error":%s}|}
              (Yojson.Safe.to_string (`String msg)))
           reqd
-    | Ok action_str ->
+    | Ok directive ->
         let config = state.Mcp_server.room_config in
-        let directive =
-          match action_str with
-          | "pause" -> `Pause
-          | "resume" -> `Resume
-          | "wakeup" -> `Wakeup
-          | _ -> assert false
-                 (* Validated at HTTP boundary above (lines 533-537). *)
+        let action_str =
+          match directive with
+          | `Pause -> "pause"
+          | `Resume -> "resume"
+          | `Wakeup -> "wakeup"
         in
         (* Issue #8391 HIGH #1: split [Ok None] (meta vanished) from [Error _]
            (IO/parse failure). For pause/resume the operator expects state to


### PR DESCRIPTION
## Summary

Replace string-based action parsing with polymorphic variant at the HTTP boundary. The `Ok` case now carries `[> \`Pause | \`Resume | \`Wakeup ]` instead of `string`, eliminating the `_ -> assert false` catch-all (line 555) that relied on out-of-band validation at the HTTP boundary.

## Changes

- **Parse boundary**: string -> variant (exhaustive, compiler-checked)
- **Projection site**: variant -> string for logging/JSON (exhaustive)
- **Behavior unchanged**: `action_str` values are identical downstream

## Verification

- [ ] Local `dune build` pass
- [ ] CI green

## Anti-pattern check

- [x] No catch-all `_ ->` added (removed 1)
- [x] No string/substring classifier added
- [x] No telemetry-as-fix pattern
- [x] No N-of-M patch admission

## Related

- Goal 7 (Code Smell Ratchet): `_ -> assert false` count reduced from 1 to 0 in this file
- SSOT: `memory/masc-oas-remaining-goals-2026-05-23.html`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>