### PR TITLE
feat(keeper_shell_ops): RFC-0160 S2 gh op routes through Shell IR gate

### DIFF
--- a/lib/keeper/keeper_gh_shared.ml
+++ b/lib/keeper/keeper_gh_shared.ml
@@ -24,6 +24,46 @@ let gh_simple_command_of_argv argv =
   | _ -> Ok { argv }
 ;;
 
+(** RFC-0160 S2: lower a parsed [gh_simple_command] to [Shell_ir.t].
+
+    The gh op handler historically dispatched via direct argv
+    ([Exec_gate.run_argv_with_status]) without routing through
+    {!Masc_exec_command_gate.Shell_command_gate.gate_typed} or
+    {!Exec_policy.validate_shell_ir_paths}. This helper allows the
+    handler to consume the same single gate as the op=bash path.
+
+    Construction is total: [Bin.Gh] is unconditionally available
+    (see lib/exec/bin.ml), so the result has no failure mode. The
+    [sandbox] target is passed by the caller to preserve docker
+    routing when [meta.sandbox_profile = Docker].
+
+    [args] are [Lit] tokens — each argv entry is a literal by
+    construction (the parser sub-grammar rejects shell metachars and
+    operators; see {!parse_simple_gh_command}). *)
+let gh_simple_command_to_shell_ir
+      ?(sandbox = Masc_exec.Sandbox_target.host ())
+      ?cwd
+      (cmd : gh_simple_command)
+  : Masc_exec.Shell_ir.t
+  =
+  let shell_arg text =
+    Masc_exec.Shell_ir.Lit (text, Masc_exec.Shell_ir.default_meta)
+  in
+  let cwd_scope =
+    match cwd with
+    | None -> None
+    | Some path -> Some (Masc_exec.Path_scope.classify ~raw:path ~cwd:path)
+  in
+  Masc_exec.Shell_ir.Simple
+    { bin = Masc_exec.Bin.of_known Masc_exec.Bin.Gh
+    ; args = List.map shell_arg cmd.argv
+    ; env = []
+    ; cwd = cwd_scope
+    ; redirects = []
+    ; sandbox
+    }
+;;
+
 let too_complex_reason_tag (r : Masc_exec.Parsed.reason_too_complex) =
   match r with
   | `Heredoc -> "heredoc"

--- a/lib/keeper/keeper_gh_shared.mli
+++ b/lib/keeper/keeper_gh_shared.mli
@@ -37,6 +37,21 @@ val gh_simple_command_with_repo_flag :
   gh_simple_command ->
   gh_simple_command
 
+(** RFC-0160 S2: lower a parsed [gh_simple_command] to [Shell_ir.t].
+
+    Used by the keeper [op=gh] handler so the gh dispatch path
+    routes through the same single gate
+    ({!Masc_exec_command_gate.Shell_command_gate.gate_typed}) and
+    path validator ({!Exec_policy.validate_shell_ir_paths}) as the
+    [op=bash] path.
+
+    Construction is total: no failure mode at this boundary. *)
+val gh_simple_command_to_shell_ir :
+  ?sandbox:Masc_exec.Sandbox_target.t ->
+  ?cwd:string ->
+  gh_simple_command ->
+  Masc_exec.Shell_ir.t
+
 (* ---- Repo slug + flag utilities ------------------------------- *)
 
 val has_repo_flag : string -> bool

--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -1230,7 +1230,60 @@ let handle_keeper_shell
               @ repo_fields
             | None -> []
           in
+          (* RFC-0160 S2: route gh dispatch through the same Shell IR
+             gate that op=bash uses. Builds [Shell_ir.t] via the
+             [gh_simple_command_to_shell_ir] lift, then runs
+             [gate_typed] + [validate_shell_ir_paths] before the
+             actual dispatch. The dispatch step itself still uses the
+             existing argv path ([run_argv_with_status] /
+             [run_docker_shell_command_with_status]); routing the
+             execution through [Exec_dispatch.dispatch] is deferred
+             (gh requires env / timeout / docker-routing fields that
+             [Exec_dispatch] does not yet thread). *)
+          let gh_sandbox_target =
+            if meta.sandbox_profile = Docker
+            then Masc_exec.Sandbox_target.host ()
+              (* docker routing handled below; gate runs on host-shape IR *)
+            else Masc_exec.Sandbox_target.host ()
+          in
+          let gh_ir =
+            Keeper_gh_shared.gh_simple_command_to_shell_ir
+              ~sandbox:gh_sandbox_target
+              ~cwd
+              parsed_command
+          in
+          let gh_gate_verdict =
+            Masc_exec_command_gate.Shell_command_gate.gate_typed
+              ~caller:Masc_exec_command_gate.Shell_command_gate.Keeper_shell_bash
+              ~ir:gh_ir
+              ~allowlist:
+                { allowed_commands = [ "gh" ]
+                ; allow_pipes = false
+                ; redirect_allowed = false
+                }
+              ~path_policy:Masc_exec_command_gate.Shell_command_gate.allow_all_paths
+              ~sandbox:{ target = gh_sandbox_target }
+              ()
+          in
+          let gh_path_verdict =
+            match gh_gate_verdict with
+            | Masc_exec_command_gate.Shell_command_gate.Allow _ ->
+              Exec_policy.validate_shell_ir_paths
+                ~keeper_id:meta.name
+                ~workdir:cwd
+                gh_ir
+            | _ -> Ok ()
+          in
           let gh_process =
+            match gh_gate_verdict with
+            | Masc_exec_command_gate.Shell_command_gate.Reject { diagnostic; _ } ->
+              Error (Printf.sprintf "gh_gate_reject: %s" diagnostic)
+            | Cannot_parse _ -> Error "gh_gate_cannot_parse"
+            | Too_complex _ -> Error "gh_gate_too_complex"
+            | Allow _ ->
+            match gh_path_verdict with
+            | Error msg -> Error (Printf.sprintf "gh_path_reject: %s" msg)
+            | Ok () ->
             if meta.sandbox_profile = Docker
             then
               match


### PR DESCRIPTION
## RFC-0160 (Shell IR 1급 승격) S2

SSOT: `~/me/memory/shell-ir-first-class-promotion-todo-2026-05-23.html` (PR jeong-sik/me#1164) · RFC body merged #17887.
Prereqs: S0 #17873, S1 #17884 (both merged).

## Why

keeper op=gh 가 직접 argv 디스패치 (`Exec_gate.run_argv_with_status`) 로 `Shell_command_gate.gate_typed` + `Exec_policy.validate_shell_ir_paths` 둘 다 우회 — RFC-0160 §0 "병렬 typed shape" + §0 "Producer 비대칭" drift signal.

## What

- `Keeper_gh_shared.gh_simple_command_to_shell_ir` helper: `gh_simple_command → Shell_ir.t` 총함수 lift. `Bin.Gh` 무조건 가용, args는 Lit 리터럴 (파서 sub-grammar가 shell metachar 거부).
- `keeper_shell_ops.ml:1149+` gh handler: lift → `gate_typed → validate_shell_ir_paths → dispatch`. reject reason은 `gh_gate_reject` / `gh_path_reject` 로 기존 error_json shape 유지.
- 디스패치 단계는 기존 argv 경로 (run_argv_with_status / run_docker_shell_command_with_status) 유지. `Exec_dispatch.dispatch` 완전 wiring은 S5 deferred (gh는 env/timeout/docker-routing 필드를 dispatch가 아직 안 thread).
- `Shell_command_gate.caller = Keeper_shell_bash` 재사용 (telemetry split = S2.5 후보).

## KPI 진척 (scripts/audit-shell-ir-consumption.sh)

| Goal | After S1 | After S2 | Target | Status |
|---|---|---|---|---|
| G2 classifier sig | string=0, IR=2 | string=0, IR=2 | string=0, IR≥2 | ✓ |
| **G3 gate_typed in keeper** | 2 | **5** | ≥ 4 | **✓ hit** |
| G5 validate_paths active | 4 | **5** | ≥ 4 | ✓ (+ 2 docstring noise) |
| G1 parse_string callers | 12 | 12 | ≤ 3 | transitional |
| G7 parallel parser | 24 | 24 | 0 | S6 owns |

## Workaround Rejection Bar self-check

- §1 telemetry-as-fix: NO — *structural unification* of dispatch path
- §2 substring classifier: NO — closed-set allowlist `[\"gh\"]`
- §3 N-of-M: partial — docker branch 가 wraps argv-shape dispatch, gate는 host-shape IR로 양쪽 동일 결정. 완전 IR dispatch는 S5.
- cap/cooldown: NO
- test backdoor: NO

## Verification

- `MASC_DUNE_ALLOW_BARE_DUNE=1 dune build --root . @check`: clean
- `test_keeper_github_read_only`: 27/27 ✓
- `test_worker_dev_tools`: 172/172 ✓

## Related

- RFC-0160 body #17887 (MERGED)
- S0 measurement #17873 (MERGED)
- S1 classifier #17884 (MERGED)