### PR TITLE
refactor(discovery_cache): delete 3 dead exports — narrow API surface

### DIFF
--- a/lib/discovery_cache.ml
+++ b/lib/discovery_cache.ml
@@ -88,10 +88,6 @@ let cache_age_seconds () =
 
 (* ── Convenience queries ─────────────────────────────────── *)
 
-let any_local_healthy () =
-  let endpoints = get_cached_or_refresh () in
-  List.exists (fun (e : endpoint_info) -> e.healthy) endpoints
-
 let idle_slot_count () =
   let endpoints = get_cached_or_refresh () in
   List.fold_left (fun acc (e : endpoint_info) ->
@@ -109,4 +105,3 @@ let busy_slot_count () =
 (* ── JSON (delegates to OAS) ─────────────────────────────── *)
 
 let endpoint_to_json = Llm_provider.Discovery.endpoint_status_to_json
-let summary_to_json = Llm_provider.Discovery.summary_to_json

--- a/lib/discovery_cache.mli
+++ b/lib/discovery_cache.mli
@@ -64,12 +64,6 @@ val cache_updated_at : float Atomic.t
 
 (** {1 Refresh + read} *)
 
-val refresh_cache : unit -> unit
-(** Run the discovery probe (HTTP, no lock held) and install
-    the result under the cache mutex. Also persists the snapshot
-    to {!Discovery_history} when {!set_base_path} has been called.
-    No-op when {!set_env} has not yet captured the Eio handles. *)
-
 val get_cached_or_refresh : unit -> endpoint_info list
 (** Return the cached endpoint list, refreshing first when:
     - the TTL has elapsed (30 seconds), or
@@ -82,10 +76,6 @@ val cache_age_seconds : unit -> float
 (** Wall-clock seconds since the last successful refresh. *)
 
 (** {1 Convenience queries} *)
-
-val any_local_healthy : unit -> bool
-(** [true] iff at least one cached endpoint reports healthy.
-    Implicitly refreshes via {!get_cached_or_refresh}. *)
 
 val idle_slot_count : unit -> int
 (** Sum of [slot.idle] across cached endpoints; endpoints with
@@ -102,7 +92,3 @@ val busy_slot_count : unit -> int
 val endpoint_to_json : endpoint_info -> Yojson.Safe.t
 (** Re-export of [Llm_provider.Discovery.endpoint_status_to_json]
     so dashboard consumers do not have to spell the path. *)
-
-val summary_to_json : endpoint_info list -> Yojson.Safe.t
-(** Re-export of [Llm_provider.Discovery.summary_to_json] so
-    dashboard consumers do not have to spell the path. *)


### PR DESCRIPTION
## Summary

Three dead exports removed from `Discovery_cache`:

1. **`refresh_cache`** — mli-only deletion (function is internal-LIVE via `get_cached_or_refresh`, no external force-refresh callers)
2. **`any_local_healthy`** — full deletion (val + let), 0 callers
3. **`summary_to_json`** — full deletion of re-export, 0 callers (sibling `endpoint_to_json` re-export stays — 1 caller)

## Audit (iter 79)

5-prong dead-export audit returns 0 for all 3:

| Function | Qualified | Opener-unqual | Internal | Same-name false-positive |
|---|---|---|---|---|
| `refresh_cache` | 0 | 0 | 1 (via `get_cached_or_refresh`) | none |
| `any_local_healthy` | 0 | 0 | 0 | none |
| `summary_to_json` | 0 | 0 | 0 | 5 unrelated modules (`Cdal.Labeling.confusion_summary_to_json`, `Agent_health.summary_to_json`, etc.) — disambiguated by qualified-name grep |

4 veto paths empty for `any_local_healthy` and `summary_to_json`; for `refresh_cache` the internal-LIVE veto applies → kept the let, removed the val.

## Pattern: asymmetric API surface

`refresh_cache` exemplifies a recurring pattern (iter 76 hmd, iter 77 tool_misc_admin): function body is alive via internal use, but the .mli val is dead because the "wrapper that auto-refreshes" (`get_cached_or_refresh`) is what consumers actually call.

## Diff

-19 LoC: -5 .ml, -14 .mli.

## Verification

`dune build lib/discovery_cache.{ml,mli}` PASS (EXIT=0).

## Related

- Iter 76 PR #17878 — `Heuristic_metrics_diagnostics.make_tuple_key` (same mli-only deletion pattern)
- Iter 77 PR #17886 — `Tool_misc_admin.handle_feature_flags` cascade (-101 LoC)
- Cumulative: -465 LoC, 29 dead surfaces across 18 PRs

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>