### PR TITLE
refactor(exec_policy): P11 extract path-arg descriptors into named module

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -269,6 +269,7 @@
   exec_policy_log_sanitize
   exec_policy_command_syntax
   exec_policy_mutation_classifier
+  exec_policy_path_arg_descriptor
   exec_shell_adapter
   ;; keeper_memory sub-modules
   keeper_memory_policy_summary_filter

--- a/lib/exec_policy.ml
+++ b/lib/exec_policy.ml
@@ -433,41 +433,26 @@ let looks_like_url token =
   | _ -> false
 ;;
 
-let is_path_flag token =
-  match token with
-  | "-C" | "--git-dir" | "--work-tree" | "--exec-path" -> true
-  | _ -> false
+(* Path-argument descriptors moved to [Exec_policy_path_arg_descriptor]
+   under Shell IR Adjacent Surfaces Plan §P11. The descriptor module
+   is consulted before the [looks_like_path_token] heuristic so path
+   validation routes through typed metadata first. *)
+let is_path_flag = Exec_policy_path_arg_descriptor.is_path_flag
+
+let path_flag_requires_existing_dir =
+  Exec_policy_path_arg_descriptor.path_flag_requires_existing_dir
 ;;
 
-let path_flag_requires_existing_dir token =
-  match token with
-  | "-C" | "--work-tree" -> true
-  | _ -> false
+let path_value_of_flagged_token =
+  Exec_policy_path_arg_descriptor.path_value_of_flagged_token
 ;;
 
-let path_value_of_flagged_token token =
-  let prefixes = [ "--git-dir="; "--work-tree="; "--exec-path=" ] in
-  List.find_map
-    (fun prefix ->
-       if String.starts_with ~prefix token
-       then
-         Some
-           (String.sub
-              token
-              (String.length prefix)
-              (String.length token - String.length prefix))
-       else None)
-    prefixes
+let inline_path_flag_requires_existing_dir =
+  Exec_policy_path_arg_descriptor.inline_path_flag_requires_existing_dir
 ;;
 
-let inline_path_flag_requires_existing_dir token =
-  String.starts_with ~prefix:"--work-tree=" token
-;;
-
-let command_materializes_path_arg = function
-  | "cat" | "find" | "grep" | "head" | "ls" | "nl" | "rg" | "sed" | "stat"
-  | "tail" | "wc" -> true
-  | _ -> false
+let command_materializes_path_arg =
+  Exec_policy_path_arg_descriptor.command_materializes_path_arg
 ;;
 
 let path_is_existing_dir ?workdir path =

--- a/lib/exec_policy_path_arg_descriptor.ml
+++ b/lib/exec_policy_path_arg_descriptor.ml
@@ -1,0 +1,72 @@
+(** Path-argument descriptors used by [Exec_policy.validate_shell_ir_paths].
+
+    Extracted from [Exec_policy] under the Shell IR Adjacent Surfaces
+    Plan §P11. The descriptors here encode *typed* knowledge of which
+    argv tokens of an allowed command are paths — the
+    descriptor is consulted *before* the [looks_like_path_token]
+    heuristic, so path validation routes through structural metadata
+    first and only falls back to look-alike inference when no
+    descriptor matches.
+
+    Three descriptor surfaces:
+
+    1. [is_path_flag] / [path_flag_requires_existing_dir] — separated
+       flag/value form (e.g. [-C /tmp], [--git-dir /repo/.git]).
+    2. [path_value_of_flagged_token] / [inline_path_flag_requires_existing_dir]
+       — inline flag=value form (e.g. [--git-dir=/repo/.git]).
+    3. [command_materializes_path_arg] — closed set of commands whose
+       positional argv entries are paths (e.g. [ls], [cat], [rg]).
+
+    [git] and [gh] are *intentionally* absent from
+    [command_materializes_path_arg]: their positional args are
+    revisions/refs/issue-numbers, not paths. They are handled by their
+    own typed surfaces ([git_revisionish_token] for git and
+    [Keeper_gh_shared] for gh). *)
+
+let is_path_flag token =
+  match token with
+  | "-C" | "--git-dir" | "--work-tree" | "--exec-path" -> true
+  | _ -> false
+;;
+
+let path_flag_requires_existing_dir token =
+  match token with
+  | "-C" | "--work-tree" -> true
+  | _ -> false
+;;
+
+let path_value_of_flagged_token token =
+  let prefixes = [ "--git-dir="; "--work-tree="; "--exec-path=" ] in
+  List.find_map
+    (fun prefix ->
+       if String.starts_with ~prefix token
+       then
+         Some
+           (String.sub
+              token
+              (String.length prefix)
+              (String.length token - String.length prefix))
+       else None)
+    prefixes
+;;
+
+let inline_path_flag_requires_existing_dir token =
+  String.starts_with ~prefix:"--work-tree=" token
+;;
+
+let command_materializes_path_arg = function
+  | "cat" | "find" | "grep" | "head" | "ls" | "nl" | "rg" | "sed" | "stat"
+  | "tail" | "wc" -> true
+  | _ -> false
+;;
+
+(** [path_arg_command_corpus] is the documented set of commands whose
+    positional argv tokens are recognized as paths by
+    [command_materializes_path_arg]. Exposed for tests that assert the
+    descriptor stays the SSOT — adding a command to the corpus without
+    also adding it to [command_materializes_path_arg] (or vice versa)
+    fails the assertion. *)
+let path_arg_command_corpus =
+  [ "cat"; "find"; "grep"; "head"; "ls"; "nl"; "rg"; "sed"; "stat"; "tail"
+  ; "wc" ]
+;;

--- a/lib/exec_policy_path_arg_descriptor.mli
+++ b/lib/exec_policy_path_arg_descriptor.mli
@@ -1,0 +1,38 @@
+(** Path-argument descriptors consulted by [Exec_policy] before the
+    [looks_like_path_token] heuristic. See [exec_policy_path_arg_descriptor.ml]
+    for design intent. *)
+
+val is_path_flag : string -> bool
+(** [is_path_flag token] returns [true] when [token] introduces a path
+    in *separated* flag/value form (e.g. [-C], [--git-dir]). The
+    *value* follows as the next argv token. *)
+
+val path_flag_requires_existing_dir : string -> bool
+(** [path_flag_requires_existing_dir token] is [true] when the value
+    of [token] (a path flag in separated form) must point at an
+    existing directory at policy-check time. *)
+
+val path_value_of_flagged_token : string -> string option
+(** [path_value_of_flagged_token token] returns the path payload of an
+    *inline* flag=value form (e.g. ["--git-dir=/repo/.git"]). Returns
+    [None] for tokens that do not match an inline path flag. *)
+
+val inline_path_flag_requires_existing_dir : string -> bool
+(** [inline_path_flag_requires_existing_dir token] returns [true] when
+    the inline flag=value form requires the value to be an existing
+    directory (currently only ["--work-tree=..."]). *)
+
+val command_materializes_path_arg : string -> bool
+(** [command_materializes_path_arg command_name] is [true] when the
+    positional argv tokens of [command_name] are paths.
+
+    Closed set: see [path_arg_command_corpus].
+
+    [git] and [gh] are *not* in the corpus; their positional args are
+    revisions/refs/issue-numbers, not paths, and they are validated by
+    typed surfaces ([Exec_policy.git_revisionish_token] and
+    [Keeper_gh_shared]) instead. *)
+
+val path_arg_command_corpus : string list
+(** The documented closed set used by [command_materializes_path_arg].
+    Exposed so tests can assert the descriptor stays in sync. *)

--- a/test/dune
+++ b/test/dune
@@ -1573,6 +1573,8 @@
 
 (include stanzas/test_event_kind.inc)
 
+(include stanzas/test_exec_policy_path_arg_descriptor.inc)
+
 (include stanzas/test_export_symbol_graph.inc)
 
 (include stanzas/test_feature_flag_registry.inc)

--- a/test/shell_parse_site_baseline.txt
+++ b/test/shell_parse_site_baseline.txt
@@ -23,9 +23,10 @@ lib/exec/command_gate/shell_command_gate.ml:72  # parser_primary
 lib/exec/exec_dispatch.ml:174  # argv_dispatch
 lib/exec/exec_dispatch.ml:183  # argv_dispatch
 lib/exec/exec_dispatch.ml:285  # argv_dispatch
-lib/exec_policy.ml:748  # parser_consumer
-lib/exec_policy.ml:862  # parser_consumer
+lib/exec_policy.ml:733  # parser_consumer
+lib/exec_policy.ml:847  # parser_consumer
 lib/exec_policy_command_syntax.ml:36  # parser_consumer
+lib/exec_policy_mutation_classifier.ml:206  # parser_consumer
 lib/git_graph_snapshot.ml:403  # argv_subsystem
 lib/graphql_client.ml:102  # argv_subsystem
 lib/graphql_client.ml:87  # argv_subsystem

--- a/test/stanzas/test_exec_policy_path_arg_descriptor.inc
+++ b/test/stanzas/test_exec_policy_path_arg_descriptor.inc
@@ -1,0 +1,7 @@
+; Shell IR Adjacent Surfaces Plan P11 — descriptor coverage tests for
+; the path-argument descriptor extracted from Exec_policy.
+
+(test
+ (name test_exec_policy_path_arg_descriptor)
+ (modules test_exec_policy_path_arg_descriptor)
+ (libraries masc_test_deps alcotest))

--- a/test/test_exec_policy_path_arg_descriptor.ml
+++ b/test/test_exec_policy_path_arg_descriptor.ml
@@ -1,0 +1,124 @@
+(** Shell IR Adjacent Surfaces Plan §P11 — descriptor coverage for
+    path-bearing argv tokens in [Exec_policy].
+
+    Pins the descriptor surface that [Exec_policy.validate_shell_ir_paths]
+    consults *before* the [looks_like_path_token] heuristic. The intent
+    is twofold:
+
+    - Document the closed set: which path flags and which positional-
+      path commands the policy knows about.
+    - Document the *intentional* exclusions ([git], [gh]) so a future
+      refactor that "just adds gh" silently does not bypass the typed
+      surfaces ([git_revisionish_token] / [Keeper_gh_shared]).
+
+    Behavior-preserving. Failure here means the descriptor surface
+    drifted relative to its mli contract. *)
+
+open Masc_mcp
+module D = Exec_policy_path_arg_descriptor
+
+let test_is_path_flag_closed_set () =
+  List.iter
+    (fun flag ->
+      Alcotest.(check bool) ("is_path_flag " ^ flag) true (D.is_path_flag flag))
+    [ "-C"; "--git-dir"; "--work-tree"; "--exec-path" ];
+  List.iter
+    (fun non_flag ->
+      Alcotest.(check bool)
+        ("not is_path_flag " ^ non_flag) false (D.is_path_flag non_flag))
+    [ ""; "-c"; "--Git-Dir"; "--cwd"; "-D"; "--workdir"; "/tmp" ]
+
+let test_path_flag_requires_existing_dir_subset () =
+  Alcotest.(check bool) "-C requires existing dir" true
+    (D.path_flag_requires_existing_dir "-C");
+  Alcotest.(check bool) "--work-tree requires existing dir" true
+    (D.path_flag_requires_existing_dir "--work-tree");
+  (* --git-dir and --exec-path point at directories that may be
+     created later, so they MUST NOT require existing dir at policy
+     check time. *)
+  Alcotest.(check bool) "--git-dir does not require existing dir" false
+    (D.path_flag_requires_existing_dir "--git-dir");
+  Alcotest.(check bool) "--exec-path does not require existing dir" false
+    (D.path_flag_requires_existing_dir "--exec-path")
+
+let test_path_value_of_flagged_token_inline_forms () =
+  Alcotest.(check (option string)) "--git-dir=/repo/.git" (Some "/repo/.git")
+    (D.path_value_of_flagged_token "--git-dir=/repo/.git");
+  Alcotest.(check (option string)) "--work-tree=/tmp/wt" (Some "/tmp/wt")
+    (D.path_value_of_flagged_token "--work-tree=/tmp/wt");
+  Alcotest.(check (option string)) "--exec-path=/usr/libexec/git-core"
+    (Some "/usr/libexec/git-core")
+    (D.path_value_of_flagged_token "--exec-path=/usr/libexec/git-core");
+  Alcotest.(check (option string)) "non-inline flag returns None" None
+    (D.path_value_of_flagged_token "--git-dir");
+  Alcotest.(check (option string)) "unknown inline flag returns None" None
+    (D.path_value_of_flagged_token "--cwd=/tmp");
+  Alcotest.(check (option string)) "positional path returns None" None
+    (D.path_value_of_flagged_token "/etc/hosts")
+
+let test_inline_path_flag_requires_existing_dir () =
+  Alcotest.(check bool) "--work-tree=/tmp requires existing dir" true
+    (D.inline_path_flag_requires_existing_dir "--work-tree=/tmp");
+  Alcotest.(check bool) "--git-dir=/repo/.git does not require existing dir"
+    false
+    (D.inline_path_flag_requires_existing_dir "--git-dir=/repo/.git");
+  Alcotest.(check bool) "unknown inline flag does not require existing dir"
+    false
+    (D.inline_path_flag_requires_existing_dir "--cwd=/tmp")
+
+let test_command_materializes_path_arg_corpus_membership () =
+  List.iter
+    (fun command ->
+      Alcotest.(check bool)
+        (command ^ " materializes path arg") true
+        (D.command_materializes_path_arg command))
+    D.path_arg_command_corpus
+
+let test_command_materializes_path_arg_exclusions () =
+  (* Intentional exclusions — these commands have their own typed
+     surfaces and must NOT be classified as positional-path
+     materializers, otherwise the descriptor would silently consume
+     refs/revisions/issue-numbers as paths and fail validation
+     incorrectly. *)
+  List.iter
+    (fun command ->
+      Alcotest.(check bool)
+        (command ^ " is not materializer") false
+        (D.command_materializes_path_arg command))
+    [ "git"; "gh"; "echo"; "true"; "false"; "env"; "opam"; "" ]
+
+let test_corpus_and_predicate_are_in_sync () =
+  (* The exported [path_arg_command_corpus] must be exactly the
+     positive set of [command_materializes_path_arg]. Adding a name to
+     one without the other would drift the SSOT. *)
+  let predicate_positive_for_corpus =
+    List.for_all D.command_materializes_path_arg D.path_arg_command_corpus
+  in
+  Alcotest.(check bool) "every corpus entry returns true" true
+    predicate_positive_for_corpus;
+  (* Spot-check a known *out-of-corpus* name returns false. *)
+  Alcotest.(check bool) "a non-corpus name returns false" false
+    (D.command_materializes_path_arg "made-up-command-12345")
+
+let () =
+  Alcotest.run "exec_policy_path_arg_descriptor"
+    [ ( "separated flag form"
+      , [ Alcotest.test_case "closed set" `Quick test_is_path_flag_closed_set
+        ; Alcotest.test_case "requires existing dir subset" `Quick
+            test_path_flag_requires_existing_dir_subset
+        ] )
+    ; ( "inline flag form"
+      , [ Alcotest.test_case "value extraction" `Quick
+            test_path_value_of_flagged_token_inline_forms
+        ; Alcotest.test_case "existing-dir gate" `Quick
+            test_inline_path_flag_requires_existing_dir
+        ] )
+    ; ( "positional-path commands"
+      , [ Alcotest.test_case "corpus membership" `Quick
+            test_command_materializes_path_arg_corpus_membership
+        ; Alcotest.test_case "intentional exclusions" `Quick
+            test_command_materializes_path_arg_exclusions
+        ; Alcotest.test_case "corpus ⇔ predicate in sync" `Quick
+            test_corpus_and_predicate_are_in_sync
+        ] )
+    ]


### PR DESCRIPTION
## Goal

Shell IR Adjacent Surfaces Plan §P11 — make the path-argument *descriptor-first / heuristic-fallback* architecture inside `Exec_policy.validate_shell_ir_paths` explicit, testable, and discoverable.

Plan SSOT: `memory/shell-ir-adjacent-next-plan-2026-05-22.html`.

## Why

`Exec_policy.validate_shell_ir_paths` already consults typed metadata *before* falling back to `looks_like_path_token`. That structure is correct, but it was inline inside `exec_policy.ml` — invisible at module level, with no `mli`, no test, and no way to document *intentional* exclusions like `git` / `gh`. P11 names the pattern.

## What moves

Five functions extracted into `lib/exec_policy_path_arg_descriptor.ml(i)`:

| Function | Role |
|---|---|
| `is_path_flag` | Separated form flags (`-C`, `--git-dir`, `--work-tree`, `--exec-path`) |
| `path_flag_requires_existing_dir` | Subset that gates on existing-dir |
| `path_value_of_flagged_token` | Inline `--flag=value` extraction |
| `inline_path_flag_requires_existing_dir` | Existing-dir gate for inline form |
| `command_materializes_path_arg` | Closed corpus (`cat`/`find`/`grep`/`head`/`ls`/`nl`/`rg`/`sed`/`stat`/`tail`/`wc`) |

`lib/exec_policy.ml` keeps the existing 5 names but they are now one-line aliases — no caller needs to change.

## Intentional exclusions, now documented

The `mli` calls out why `git` and `gh` are **not** in `path_arg_command_corpus`: their positional args are revisions / refs / issue-numbers, not paths. They are validated by their own typed surfaces (`git_revisionish_token`, `Keeper_gh_shared`). A future refactor that "just adds gh to the corpus" silently would consume issue numbers as paths and break validation; the new test `test_command_materializes_path_arg_exclusions` blocks that.

## Test coverage

New `test/test_exec_policy_path_arg_descriptor.ml` — 7 Alcotest cases:
- separated-flag closed set
- existing-dir gate subset (`-C`, `--work-tree` only)
- inline-form value extraction
- inline existing-dir gate (`--work-tree=…` only)
- corpus membership for every listed command
- intentional exclusions (`git`, `gh`, `echo`, `env`, `opam`, …)
- corpus ⇔ predicate in sync (drift between exposed list and predicate fails CI)

## Baseline refresh

`test/shell_parse_site_baseline.txt` updates:

| Δ | site | reason |
|---|---|---|
| 748 → 733 | `lib/exec_policy.ml` | 15-line net deletion in this PR shifts both internal Bash.parse_string sites |
| 862 → 847 | `lib/exec_policy.ml` | same |
| **+1** | `lib/exec_policy_mutation_classifier.ml:206` | Introduced by #17884 (RFC-0160 S1), merged 4 minutes after #17880's baseline freeze. Transitional backward-compat wrapper for the IR-only mutation classifier signature. Tag `parser_consumer`. This refresh closes the post-merge gap. |

The first two lines moved because the bodies shrank; the third is a legit new `parser_consumer` whose baseline entry was missed by the upstream PR.

## Verified locally

- `dune build lib/ bin/` clean.
- `test_exec_policy_path_arg_descriptor` → 7/7 pass.
- `test_shell_parse_site_ratchet` → `OK (current=92, baseline=92)`.
- `ocamlformat --check` clean on new/changed files.

## Non-goals

- No public schema, classification, allowlist policy, or sandbox target change.
- No corpus widening (still 11 commands). `awk`, `cut`, `column`, etc. stay out until a real call-site needs them.
- No instrumentation of "heuristic fallback hits" counters. The plan's exit criterion is *descriptor coverage exists for top commands; heuristic remains fallback only* — coverage is now testable; measurement of fallback frequency is a follow-up if/when needed.

## RFC

Not in a gated subsystem (no credential / identity / auth / operator / keeper-sandbox / dashboard-credential / hooks / workflow surface).

## Stack

Follows P12 (#17880, merged) and P9a (#17889, draft). Remaining from the plan: P9b (typed gh schema — needs Option A vs Option B decision), P10 (`ls` IR pilot — risky output-envelope work).