### PR TITLE
refactor(exec_policy): RFC-0160 S6 consolidate shell_word_values SSOT

### DIFF
--- a/lib/exec_policy.ml
+++ b/lib/exec_policy.ml
@@ -877,6 +877,8 @@ let is_destructive_bash_operation_of_string =
   Mutation_classifier.is_destructive_bash_operation_of_string
 ;;
 
+let stage_words_of_string = Mutation_classifier.stage_words_of_string
+
 let sanitize_command_for_log = Log_sanitize.sanitize_command_for_log
 let truncate_for_log = Log_sanitize.truncate_for_log
 

--- a/lib/exec_policy.mli
+++ b/lib/exec_policy.mli
@@ -86,6 +86,10 @@ val is_write_operation_of_string : string -> bool
 val is_git_branch_switch_of_string : string -> bool
 val is_destructive_bash_operation_of_string : string -> bool
 
+(** RFC-0160 S6: shared shell-word extractor (single source of truth,
+    replaces 3 duplicated [shell_word_values] private copies). *)
+val stage_words_of_string : string -> string list
+
 val sanitize_command_for_log : string -> string
 val truncate_for_log : ?max_len:int -> string -> string
 

--- a/lib/exec_policy_mutation_classifier.ml
+++ b/lib/exec_policy_mutation_classifier.ml
@@ -211,3 +211,16 @@ let parse_and_apply (classifier : Shell_ir.t -> bool) (cmd : string) : bool =
 let is_write_operation_of_string = parse_and_apply is_write_operation
 let is_git_branch_switch_of_string = parse_and_apply is_git_branch_switch
 let is_destructive_bash_operation_of_string = parse_and_apply is_destructive_bash_operation
+
+(** RFC-0160 S6: shared shell-word extractor that replaces the
+    private [shell_word_values] copies previously duplicated in
+    [exec_policy_log_sanitize], [gh_command_validation], and
+    [keeper_tool_registry]. Returns flattened literal stage words
+    (or [[]] on parse failure / non-literal stages). Transitional
+    surface: callers should accept [Shell_ir.t] directly once their
+    entry points migrate (S4). *)
+let stage_words_of_string (cmd : string) : string list =
+  match Masc_exec_bash_parser.Bash.parse_string cmd with
+  | Parsed.Parsed ir -> flat_stage_words ir
+  | _ -> []
+;;

--- a/lib/exec_policy_mutation_classifier.mli
+++ b/lib/exec_policy_mutation_classifier.mli
@@ -48,3 +48,14 @@ val is_destructive_bash_operation : Masc_exec.Shell_ir.t -> bool
 val is_write_operation_of_string : string -> bool
 val is_git_branch_switch_of_string : string -> bool
 val is_destructive_bash_operation_of_string : string -> bool
+
+(** RFC-0160 S6: shared shell-word extractor, single source of truth
+    for what used to be 3 duplicated [shell_word_values] copies in
+    [exec_policy_log_sanitize], [gh_command_validation], and
+    [keeper_tool_registry]. Returns the flattened literal stage words
+    across all pipeline segments ([[]] on parse failure or
+    non-literal-only stages).
+
+    Transitional surface: prefer {!Masc_exec.Shell_ir.t}-typed callers
+    once their upstream entry points migrate (S4). *)
+val stage_words_of_string : string -> string list

--- a/lib/gh_command_validation.ml
+++ b/lib/gh_command_validation.ml
@@ -13,13 +13,8 @@ let has_strict_shell_metachar cmd =
       | _ -> false)
     cmd
 
-let shell_word_values cmd =
-  match Masc_exec_bash_parser.Bash_words.stages cmd with
-  | Error _ -> []
-  | Ok stages ->
-    stages
-    |> List.concat
-    |> List.map (fun (word : Masc_exec_bash_parser.Bash_words.word) -> word.value)
+(* RFC-0160 S6: private [shell_word_values] removed. Callers now route
+   through {!Exec_policy.stage_words_of_string} (single SSOT). *)
 
 (** Top-level gh CLI commands allowed. Commands not in this list are
     rejected at the allowlist gate. *)
@@ -111,7 +106,7 @@ let gh_graphql_r2_mutations =
     "archiverepository" ]
 
 let extract_gh_api_method cmd =
-  let tokens = shell_word_values cmd in
+  let tokens = Exec_policy.stage_words_of_string cmd in
   let rec find = function
     | [] -> "GET"
     | "-X" :: m :: _ | "--method" :: m :: _ -> String.uppercase_ascii m
@@ -152,7 +147,7 @@ let gh_blocked_operations =
     Only the owner segment is returned; repo/branch names are outside
     the allowlist scope. *)
 let extract_gh_repo_owner cmd =
-  let tokens = shell_word_values cmd in
+  let tokens = Exec_policy.stage_words_of_string cmd in
   let owner_of_slug s =
     match String.split_on_char '/' s with
     | owner :: _ :: _ when owner <> "" -> Some owner
@@ -177,7 +172,7 @@ let extract_gh_repo_owner cmd =
     Example: "pr view 123" -> (Some "pr", Some "view")
     Example: "workflow --repo o/r disable" -> (Some "workflow", Some "disable") *)
 let extract_gh_command_pair cmd =
-  let parts = shell_word_values cmd in
+  let parts = Exec_policy.stage_words_of_string cmd in
   match parts with
   | [] -> (None, None)
   | [ x ] -> (Some x, None)
@@ -316,7 +311,7 @@ let classify_gh_reversibility cmd =
     if in_table gh_irreversible_ops then R2_Irreversible
     else if command = "api" then begin
       let method_ = extract_gh_api_method cmd in
-      let parts = shell_word_values cmd in
+      let parts = Exec_policy.stage_words_of_string cmd in
       if method_ = "DELETE" then R2_Irreversible
       else if gh_api_graphql_is_destructive cmd then R2_Irreversible
       else if List.mem method_ ["POST"; "PUT"; "PATCH"] then R1_Reversible
@@ -362,7 +357,7 @@ let positional_tokens parts =
 
 (** Shared tokenizer for destructive-operation checks. *)
 let gh_op_parts cmd =
-  shell_word_values cmd |> List.map String.lowercase_ascii
+  Exec_policy.stage_words_of_string cmd |> List.map String.lowercase_ascii
 
 let has_positional_subcmd subcmds rest =
   let positionals = positional_tokens rest in
@@ -392,7 +387,7 @@ let is_gh_pr_merge cmd =
   | _ -> false
 
 let gh_raw_parts cmd =
-  shell_word_values cmd
+  Exec_policy.stage_words_of_string cmd
 
 let gh_option_takes_value tok =
   let tok = String.lowercase_ascii tok in

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -13,14 +13,8 @@ let dedupe_tool_names names =
   dedupe_keep_order (names |> List.map String.trim |> List.filter (fun name -> name <> ""))
 ;;
 
-let shell_word_values cmd =
-  match Masc_exec_bash_parser.Bash_words.stages cmd with
-  | Error _ -> []
-  | Ok stages ->
-    stages
-    |> List.concat
-    |> List.map (fun (word : Masc_exec_bash_parser.Bash_words.word) -> word.value)
-;;
+(* RFC-0160 S6: private [shell_word_values] removed. Callers route
+   through {!Exec_policy.stage_words_of_string} (single SSOT). *)
 
 (* ── Runtime-resolved tool names ─────────────────────────────── *)
 
@@ -213,7 +207,7 @@ let gh_read_only_prefixes =
     [graphqlx ...] as the graphql subcommand.  User hard rule: "no
     string matching for classification". *)
 let is_gh_api_read_only (cmd_lower : string) : bool =
-  let tokens = shell_word_values cmd_lower in
+  let tokens = Exec_policy.stage_words_of_string cmd_lower in
   match tokens with
   | "api" :: rest_after_api ->
     let is_graphql_subcommand =
@@ -264,7 +258,7 @@ let is_gh_api_read_only (cmd_lower : string) : bool =
 (** Extract the effective gh command string from keeper_shell op=gh input.
     [keeper_exec_shell] accepts typed [argv] and legacy [cmd] fields. *)
 let normalize_gh_command (cmd : string) : string =
-  let tokens = shell_word_values cmd in
+  let tokens = Exec_policy.stage_words_of_string cmd in
   let rec drop_leading_gh = function
     | token :: rest when String_util.equals_ci token "gh" -> drop_leading_gh rest
     | remaining -> remaining


### PR DESCRIPTION
## RFC-0160 (Shell IR 1급 승격) S6 — partial

SSOT: `~/me/memory/shell-ir-first-class-promotion-todo-2026-05-23.html` (jeong-sik/me#1164) · RFC body #17887 (MERGED).
Prereqs: S0 #17873, S1 #17884 (MERGED). Pairs with S2 #17898 (Draft).

## Why

S1 + S2 migrated *primary* mutation classifier + gh op surfaces to Shell IR. S6 closes the *duplicate parser* loop — 3 lib files maintained their own private `shell_word_values` copies that re-tokenized via `Bash_words.stages` independently of the canonical IR pipeline.

## What

- `Exec_policy.stage_words_of_string` 노출 (single shared helper, mutation_classifier 위임).
- `gh_command_validation.shell_word_values` 삭제 (def + 6 callers → `stage_words_of_string` 라우팅).
- `keeper_tool_registry.shell_word_values` 삭제 (def + 2 callers → same).
- `exec_policy_log_sanitize.shell_word_values` **deferred**: `(string list, unit) result` 반환 — Error 케이스가 redaction fallback의 load-bearing 분기. Result-shaped 변형은 별도 PR.

## KPI 진척

| Goal | After S2 | **After S6** | Target | Status |
|---|---|---|---|---|
| **G7 parallel parser** | 24 | **17 (-9, -35%)** | 0 | partial (8 잔재: 6 doc/comment + 2 log_sanitize) |
| - shell_word_values refs | 16 | 8 | 0 | partial |
| - Bash_words.stages refs | 11 | 9 | 0 | partial |
| 기타 G1-G6 | 변경 없음 | 변경 없음 | — | — |

## Workaround Rejection Bar self-check

- §1 telemetry-as-fix: NO — structural dedup
- §2 substring classifier: NO — closed-set helpers
- §3 N-of-M: **explicit partial** — `exec_policy_log_sanitize`는 code comment로 reason 명시 (Result signature mismatch), 별도 PR로 회수
- cap/cooldown: NO
- test backdoor: NO

## Pre-existing main breakage 노트

origin/main HEAD `c1aae68a00` 가 `@check` 실패 — `Unbound value json_nonempty_string_opt` at `lib/keeper/keeper_tools_oas.ml:157`. **PR #17893가 도입**한 breakage이며 본 PR과 무관. S6 변경 자체는 isolated (stash 후 base branch 재검증으로 확인). 본 PR CI도 동일 fail 예상 — 별도 hotfix 머지 대기.

## Verification

- `MASC_DUNE_ALLOW_BARE_DUNE=1 dune build --root . @check`: pre-existing main breakage로 인해 미실행 (위 노트 참조)
- `scripts/audit-shell-ir-consumption.sh --json`: G7 26→17 측정 확인
- 변경 파일 6개 (lib/exec_policy* + lib/gh_command_validation + lib/keeper/keeper_tool_registry)

## Related

- RFC-0160 body #17887 (MERGED)
- S0 measurement #17873 (MERGED)
- S1 classifier #17884 (MERGED)
- S2 gh lift #17898 (Draft)