### PR TITLE
feat(keeper): capacity health — cascade routing + isolation + capability filtering

### DIFF
--- a/dune-workspace
+++ b/dune-workspace
@@ -1,1 +1,3 @@
 (lang dune 3.22)
+
+(context default)

--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -49,6 +49,16 @@ let provider_capacity_scope_to_http =
 let provider_error_to_http_error =
   Cascade_attempt_fsm_http_error.provider_error_to_http_error
 
+let capacity_backpressure_source_to_failure_scope = function
+  | Cascade_error_classify.Provider_capacity ->
+    Llm_provider.Http_client.Failure_scope_provider
+  | Cascade_error_classify.Client_capacity ->
+    Llm_provider.Http_client.Failure_scope_account
+  | Cascade_error_classify.Tier_admission ->
+    Llm_provider.Http_client.Failure_scope_model
+  | Cascade_error_classify.Cascade_slot ->
+    Llm_provider.Http_client.Failure_scope_unknown
+
 (** Convert an OAS sdk_error into a Cascade_fsm provider_outcome.
     API-level errors and model-capability-dependent agent errors are
     cascadeable (a different provider may succeed).  Structural agent
@@ -64,8 +74,19 @@ let sdk_error_to_cascade_outcome (err : Agent_sdk.Error.sdk_error)
   (* All other MASC-internal classifications (and unclassified errors) fall
      through to the structured [match err with] below to derive the cascade
      outcome from the raw [sdk_error] payload. *)
+  | Some (Cascade_error_classify.Capacity_backpressure { detail; retry_after_sec; source; _ }) ->
+    Some
+      (Cascade_fsm.Call_err
+         (Llm_provider.Http_client.ProviderFailure
+            { kind =
+                Llm_provider.Http_client.Capacity_exhausted
+                  { scope = capacity_backpressure_source_to_failure_scope source
+                  ; retry_after = retry_after_sec
+                  ; model = None
+                  }
+            ; message = detail
+            }))
   | Some (Cascade_error_classify.Cascade_exhausted _)
-  | Some (Cascade_error_classify.Capacity_backpressure _)
   | Some (Cascade_error_classify.No_tool_capable_provider _)
   | Some (Cascade_error_classify.Accept_rejected _)
   | Some (Cascade_error_classify.Admission_queue_timeout _)

--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -591,6 +591,17 @@ let resolve_live_result ?config_path raw :
   resolve_live_with_catalog_result
     ~catalog:(catalog_lookup_names ?config_path ()) raw
 
+let required_capability_profile_of_cascade_name name =
+  Cascade_catalog_runtime_cache.with_cache_lock (fun () ->
+    match !Cascade_catalog_runtime_cache.cache.active_snapshot with
+    | None -> None
+    | Some snapshot -> (
+      match
+        Cascade_catalog_runtime_cache.profile_lookup snapshot.profiles name
+      with
+      | None -> None
+      | Some profile -> profile.required_capability_profile))
+
 let canonicalize (raw : string) : string =
   canonicalize_with_catalog ~catalog:(catalog_names ()) raw
 

--- a/lib/keeper/keeper_cascade_profile.mli
+++ b/lib/keeper/keeper_cascade_profile.mli
@@ -94,6 +94,14 @@ val keeper_catalog_names : ?config_path:string -> unit -> string list
 val system_catalog_names : ?config_path:string -> unit -> string list
 (** Live system-only profile names present in [cascade.toml]. *)
 
+val required_capability_profile_of_cascade_name : string -> string option
+(** [required_capability_profile_of_cascade_name name] returns the
+    [required_capability_profile] declared for cascade [name] in the
+    live catalog snapshot, or [None] when the snapshot is missing or
+    the cascade is not found.  Used by pre-dispatch capability-aware
+    rotation filtering so [Tool_required] turns do not rotate into
+    cascades whose providers cannot satisfy forced [tool_choice]. *)
+
 val fallback_cascade_for : ?config_path:string -> string -> string option
 (** Declarative escalation hint for [name].
 

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -136,7 +136,8 @@ let failure_count_jump_to counts key ~target =
 ;;
 
 type workflow_rejection_info =
-  { rule_id : string option
+  { task_id : string option
+  ; rule_id : string option
   ; tool_suggestion : string option
   ; hint : string option
   }
@@ -153,6 +154,7 @@ let workflow_rejection_info_of_raw raw =
     match json_or_detail_string_opt "failure_class" json with
     | Some "workflow_rejection" ->
       let diagnosis = diagnosis_json_opt json in
+      let task_id = json_nonempty_string_opt "task_id" json in
       let rule_id =
         match diagnosis with
         | Some diagnosis -> json_assoc_string_opt "rule_id" diagnosis
@@ -164,7 +166,8 @@ let workflow_rejection_info_of_raw raw =
         | None -> None
       in
       Some
-        { rule_id
+        { task_id
+        ; rule_id
         ; tool_suggestion
         ; hint = json_or_detail_string_opt "hint" json
         }
@@ -177,7 +180,8 @@ let workflow_rejection_info_of_raw raw =
 
 let workflow_rejection_family_key ~tool_name info =
   Printf.sprintf
-    "%s:%s:%s"
+    "%s:%s:%s:%s"
+    (Option.value ~default:"unknown_task" info.task_id)
     tool_name
     (Option.value ~default:"unknown_rule" info.rule_id)
     (Option.value ~default:"unknown_tool" info.tool_suggestion)

--- a/lib/keeper/keeper_turn_cascade_budget_routing.ml
+++ b/lib/keeper/keeper_turn_cascade_budget_routing.ml
@@ -109,7 +109,26 @@ let next_fail_open_cascade_for_turn
   let rotation_cascades =
     match tool_requirement, rotation_cascades with
     | Keeper_agent_tool_surface.Required, Some _ ->
-      Some (dedupe_keep_order [ base_cascade; tool_required_rotation_cascade_name () ])
+      let tr_cascade = tool_required_rotation_cascade_name () in
+      let tr_has_required_tool_choice =
+        match
+          Keeper_cascade_profile.required_capability_profile_of_cascade_name
+            tr_cascade
+        with
+        | None -> true
+        | Some profile_name -> (
+          match
+            Cascade_capability_profile.resolve_required_capabilities
+              profile_name
+          with
+          | None -> true
+          | Some reqs ->
+            reqs.inline_tool_choice = Cascade_capability_profile.Required)
+      in
+      if tr_has_required_tool_choice then
+        Some (dedupe_keep_order [ base_cascade; tr_cascade ])
+      else
+        Some (dedupe_keep_order [ base_cascade ])
     | _ -> rotation_cascades
   in
   EC.degraded_rotation_after_recoverable_error

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -862,7 +862,40 @@ let cdal_health_json () =
           ("error", `String (Printexc.to_string exn));
         ]
 
-let make_health_json ?(listener = "http/1.1") request =
+let full_health_component_placeholder ?error ?(component_timed_out = false) ~status
+    component =
+  let error_fields =
+    match error with
+    | Some error -> [("error", `String error)]
+    | None -> []
+  in
+  `Assoc
+    ([
+       ("component", `String component);
+       ("status", `String status);
+       ("component_timed_out", `Bool component_timed_out);
+     ]
+     @ error_fields)
+
+let compute_section ~name ?section_timings_ref f =
+  let started = Unix.gettimeofday () in
+  try
+    let result = f () in
+    let elapsed_ms = max 0 (int_of_float ((Unix.gettimeofday () -. started) *. 1000.)) in
+    (match section_timings_ref with
+     | Some ref -> ref := (name, elapsed_ms) :: !ref
+     | None -> ());
+    result
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+      let elapsed_ms = max 0 (int_of_float ((Unix.gettimeofday () -. started) *. 1000.)) in
+      (match section_timings_ref with
+       | Some ref -> ref := (name, elapsed_ms) :: !ref
+       | None -> ());
+      full_health_component_placeholder ~error:(Printexc.to_string exn) ~status:"error" name
+
+let make_health_json ?(listener = "http/1.1") ?section_timings_ref request =
   let uptime_secs = health_uptime_secs () in
   let build = Build_identity.current () in
   let keeper_config_parse_errors =
@@ -911,9 +944,23 @@ let make_health_json ?(listener = "http/1.1") request =
   let base_path = current_room_base_path_opt () in
   let phase_counts = keeper_phase_counts ?base_path () in
   let keeper_fibers = phase_counts.running in
-  let paused_keepers_json = paused_keepers_health_json () in
-  let reaction_ledger_json = keeper_reaction_ledger_health_json () in
-  let fd_accountant_json = fd_accountant_snapshot_json () in
+  let paused_keepers_json =
+    compute_section ~name:"paused_keepers" ?section_timings_ref paused_keepers_health_json
+  in
+  let reaction_ledger_json =
+    compute_section ~name:"keeper_reaction_ledger" ?section_timings_ref
+      keeper_reaction_ledger_health_json
+  in
+  let fd_accountant_json =
+    compute_section ~name:"fd_accountant" ?section_timings_ref fd_accountant_snapshot_json
+  in
+  let keeper_fleet_safety =
+    compute_section ~name:"keeper_fleet_safety" ?section_timings_ref
+      (fun () -> keeper_fleet_safety_health_json ~phase_counts ~paused_keepers_json ())
+  in
+  let cdal_health_json =
+    compute_section ~name:"cdal" ?section_timings_ref cdal_health_json
+  in
   Tool_args.ok_assoc [
     ("server", `String "masc-mcp");
     ("version", `String build.release_version);
@@ -944,9 +991,7 @@ let make_health_json ?(listener = "http/1.1") request =
     , Keeper_fd_pressure.runtime_state_json ~active_keepers:keeper_fibers
         ~starting_keepers:0 ~requested_keepers:24 () );
     ("fd_accountant", fd_accountant_json);
-    ( "keeper_fleet_safety"
-    , keeper_fleet_safety_health_json ~phase_counts
-        ~paused_keepers_json () );
+    ("keeper_fleet_safety", keeper_fleet_safety);
     ("keeper_reaction_ledger", reaction_ledger_json);
     (* Paused-keeper visibility: a keeper with [meta.paused = true] does not
        run turns, and auto-paused keepers may no longer have a live registry
@@ -955,7 +1000,7 @@ let make_health_json ?(listener = "http/1.1") request =
        so an operator can correlate with the cause encoded in their
        last_blocker_class. *)
     (key_paused_keepers, paused_keepers_json);
-    ("cdal", cdal_health_json ());
+    ("cdal", cdal_health_json);
     ("keeper_config_parse_error_count",
      `Int keeper_config_parse_error_count);
     ( "keeper_config_parse_errors",
@@ -1004,6 +1049,7 @@ type full_health_snapshot = {
   error : string option;
   stale_since_ts : float option;
   last_good_available : bool;
+  section_timings : (string * int) list;
 }
 
 let full_health_snapshot_mu = Stdlib.Mutex.create ()
@@ -1064,21 +1110,6 @@ let full_health_cached_field_names =
 let full_health_field_is_cached name =
   List.exists (String.equal name) full_health_cached_field_names
 
-let full_health_component_placeholder ?error ?(component_timed_out = false) ~status
-    component =
-  let error_fields =
-    match error with
-    | Some error -> [ ("error", `String error) ]
-    | None -> []
-  in
-  `Assoc
-    ([
-       ("component", `String component);
-       ("status", `String status);
-       ("component_timed_out", `Bool component_timed_out);
-     ]
-     @ error_fields)
-
 let full_health_placeholder_fields ?error ?(component_timed_out = false)
     ?(status = "warming") () =
   [
@@ -1137,8 +1168,11 @@ let duration_ms ~started_at ~finished_at =
 
 let compute_full_health_snapshot ?(listener = "http/1.1") request =
   let started_at = Unix.gettimeofday () in
+  let section_timings_ref = ref [] in
   try
-    let fields = cached_full_health_fields (make_health_json ~listener request) in
+    let fields =
+      cached_full_health_fields (make_health_json ~listener ~section_timings_ref request)
+    in
     let finished_at = Unix.gettimeofday () in
     {
       fields;
@@ -1147,6 +1181,7 @@ let compute_full_health_snapshot ?(listener = "http/1.1") request =
       error = None;
       stale_since_ts = None;
       last_good_available = true;
+      section_timings = List.rev !section_timings_ref;
     }
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -1160,6 +1195,7 @@ let compute_full_health_snapshot ?(listener = "http/1.1") request =
         error = Some error;
         stale_since_ts = Some finished_at;
         last_good_available = false;
+        section_timings = List.rev !section_timings_ref;
       }
 
 let store_full_health_snapshot snapshot =
@@ -1191,14 +1227,15 @@ let mark_full_health_snapshot_error exn =
          no prior snapshot (warm path on cold boot), fall back to the
          all-error placeholder so the field set stays well-typed. *)
       let preserved_fields, preserved_computed_at, preserved_duration_ms,
-          prior_stale_since, last_good_available =
+          prior_stale_since, last_good_available, preserved_section_timings =
         match !full_health_snapshot with
         | Some s when s.last_good_available ->
             (* A last-good payload exists — keep its component fields
                and preserve [computed_at] so [snapshot_age_ms]
                remains the age of the payload rather than the age of
                the failed refresh attempt. *)
-            (s.fields, s.computed_at, s.duration_ms, s.stale_since_ts, true)
+            (s.fields, s.computed_at, s.duration_ms, s.stale_since_ts, true,
+             s.section_timings)
         | Some s ->
             (* Previous snapshot was already an error placeholder —
                keep whatever [fields] it had (which may itself be
@@ -1210,7 +1247,8 @@ let mark_full_health_snapshot_error exn =
               s.computed_at,
               s.duration_ms,
               s.stale_since_ts,
-              s.last_good_available )
+              s.last_good_available,
+              s.section_timings )
         | None ->
             (* Cold boot — no prior snapshot.  Fall back to the
                original placeholder shape, but classify refresh
@@ -1223,7 +1261,8 @@ let mark_full_health_snapshot_error exn =
               now,
               0,
               None,
-              false )
+              false,
+              [] )
       in
       let stale_since_ts =
         match prior_stale_since with
@@ -1239,6 +1278,7 @@ let mark_full_health_snapshot_error exn =
             error = Some error;
             stale_since_ts;
             last_good_available;
+            section_timings = preserved_section_timings;
           };
       full_health_refresh_in_flight := false;
       full_health_refresh_started_at := None;
@@ -1345,6 +1385,16 @@ let full_health_snapshot_metadata ~now ~refresh_in_flight ~refresh_started_at
     | None -> `Null
   in
   let stale_age_ms = full_health_snapshot_stale_age_ms ~now snapshot in
+  let section_timings_json =
+    match snapshot with
+    | Some s ->
+        `List
+          (List.map
+             (fun (name, ms) ->
+               `Assoc [ ("name", `String name); ("ms", `Int ms) ])
+             s.section_timings)
+    | None -> `List []
+  in
   `Assoc
     [
       ("status", `String status);
@@ -1365,6 +1415,7 @@ let full_health_snapshot_metadata ~now ~refresh_in_flight ~refresh_started_at
       ("component_timed_out", `Bool component_timed_out);
       ("error", error);
       ("last_good_available", `Bool (Option.fold ~none:false ~some:(fun s -> s.last_good_available) snapshot));
+      ("section_timings", section_timings_json);
       (* [stale_since_ts] is the wall-clock of the FIRST failure of
          the current outage; null when the snapshot is fresh.
          Consumers should prefer this over [computed_at_unix] for

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -112,7 +112,7 @@ val health_path_diagnostics :
     default base path computed from env. *)
 
 val make_health_json :
-  ?listener:string -> Httpun.Request.t -> Yojson.Safe.t
+  ?listener:string -> ?section_timings_ref:(string * int) list ref -> Httpun.Request.t -> Yojson.Safe.t
 (** [make_health_json ?listener request] builds the full health diagnostics
     JSON body.  [listener] defaults to ["http/1.1"] and is overridden to
     ["h2"] by the H2 gateway.  This is the force-compute diagnostic builder


### PR DESCRIPTION
## Summary
- Capacity_backpressure → cascadeable Call_err mapping
- Per-section exception isolation and timing for health snapshot
- task_id in workflow_rejection_family_key (false dedup 방지)
- Capability-aware Tool_required rotation filtering

## Test plan
- [x] `dune build` passes
- [ ] Keeper cascade backpressure 로그에서 task_id 확인