### PR TITLE
feat(runtime-lens): P4 compaction source labels + dashboard lens gaps

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -316,6 +316,11 @@ let run_turn
   let estimated_input_tokens = prompt_ctx.Keeper_run_prompt.estimated_input_tokens in
   let ctx_work = prompt_ctx.Keeper_run_prompt.ctx_work in
   let history_messages_digest = digest_message_texts_as_joined history_messages in
+  let context_digest =
+    digest_text
+      (base_system_prompt ^ turn_system_prompt ^ dynamic_context ^ memory_context
+       ^ temporal_context ^ user_message ^ history_messages_digest)
+  in
   append_manifest ~site:"context_injected"
     ~keeper_turn_id:manifest_keeper_turn_id
     ~decision:
@@ -331,6 +336,7 @@ let run_turn
             ("history_message_count", `Int (List.length history_messages));
             ("history_messages_digest", `String history_messages_digest);
             ("estimated_input_tokens", `Int estimated_input_tokens);
+            ("context_digest", `String context_digest);
           ]))
     Keeper_runtime_manifest.Context_injected;
   let actionable_signal =

--- a/lib/memory_hooks.ml
+++ b/lib/memory_hooks.ml
@@ -249,6 +249,8 @@ let make
                      ("memory_context_chars", `Int (String.length mem_text));
                      ( "memory_context_digest",
                        `String (Digest.to_hex (Digest.string mem_text)) );
+                     ("payload_digest",
+                      `String (Digest.to_hex (Digest.string mem_text)) );
                      ("episode_limit", `Int episode_limit);
                      ("procedure_limit", `Int procedure_limit);
                      ( "existing_extra_system_context_present",

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_gaps.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_gaps.ml
@@ -442,13 +442,14 @@ let runtime_lens_gaps ~terminal_event_present ~claim_scope ~config_drift scan =
          match scan.latest_context_compacted_row with
          | Some row ->
            let decision = row.Keeper_runtime_manifest.decision in
-           (match json_string_member_opt "source_phase" decision with
+           let clock_refs = Yojson.Safe.Util.member "clock_refs" decision in
+           (match json_string_member_opt "compaction_source" clock_refs with
             | Some _ -> gaps
             | None ->
               { code = "compaction_source_missing"
               ; severity = "warn"
               ; lane = "memory_context"
-              ; detail = Some "context_compacted row lacks source_phase"
+              ; detail = Some "context_compacted row lacks compaction_source in clock_refs"
               }
               :: gaps)
          | None -> gaps)

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_gaps.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_gaps.ml
@@ -264,6 +264,7 @@ let runtime_lens_gaps ~terminal_event_present ~claim_scope ~config_drift scan =
                 Keeper_runtime_manifest.all_event_kinds
             in
             if not has_any_event_in_lane then acc
+            else if scan.has_terminal then acc
             else
               let missing =
                 List.filter
@@ -321,6 +322,52 @@ let runtime_lens_gaps ~terminal_event_present ~claim_scope ~config_drift scan =
            }
            :: gaps
          | _ -> gaps)
+    |> (fun gaps ->
+         (* P5: terminal vs complete proof separation.
+            Turn_finished exists but a mandatory lane policy is not satisfied. *)
+         if scan.has_terminal
+         then
+           let incomplete_lanes =
+             Server_dashboard_http_keeper_runtime_lens_swimlane.lane_policies
+             |> List.filter_map
+                  (fun policy ->
+                     let lane =
+                       policy.Server_dashboard_http_keeper_runtime_lens_swimlane.lane
+                     in
+                     let missing =
+                       List.filter
+                         (fun event ->
+                            Server_dashboard_http_keeper_runtime_manifest_scan
+                              .runtime_manifest_scan_event_count
+                              scan event
+                            = 0)
+                         policy.mandatory_events
+                     in
+                     match missing with
+                     | [] -> None
+                     | _ ->
+                       let missing_codes =
+                         List.map Keeper_runtime_manifest.event_kind_to_string missing
+                       in
+                       Some (lane, missing_codes))
+           in
+           match incomplete_lanes with
+           | [] -> gaps
+           | _ ->
+             let detail =
+               incomplete_lanes
+               |> List.map
+                    (fun (lane, codes) ->
+                       Printf.sprintf "%s: %s" lane (String.concat ", " codes))
+               |> String.concat "; "
+             in
+             { code = "turn_terminal_incomplete"
+             ; severity = "warn"
+             ; lane = "keeper"
+             ; detail = Some detail
+             }
+             :: gaps
+         else gaps)
     |> (fun gaps ->
          if scan.provider_started_count > 0
             && scan.event_bus_correlation_ids = []

--- a/test/test_keeper_runtime_manifest.ml
+++ b/test/test_keeper_runtime_manifest.ml
@@ -1299,9 +1299,7 @@ let test_runtime_trace_lens_summarizes_tool_axis () =
       in
       Alcotest.(check (list string))
         "lens gap codes"
-        [ "lane_mandatory_event_missing"
-        ; "lane_mandatory_event_missing"
-        ; "lane_mandatory_event_missing"
+        [ "turn_terminal_incomplete"
         ; "required_tool_not_materialized"
         ; "context_delta_missing"
         ]
@@ -1530,7 +1528,7 @@ let test_runtime_trace_lens_groups_context_memory_swimlane () =
         (json_int_member "episodes_flushed" memory_axis);
       Alcotest.(check int)
         "lens memory has keeper + memory_context lane gaps"
-        4
+        3
         (json_list_length "gaps" lens))
 
 let test_runtime_trace_lens_derives_clock_edges () =


### PR DESCRIPTION
## Summary
- P4 compaction source labels and digest gaps in runtime lens
- Add compaction source labels to dashboard runtime lens gaps endpoint
- Align test_keeper_runtime_manifest fixtures

## Test plan
- [x] `dune build` passes
- [ ] Dashboard keeper detail에서 compaction source label 확인