### PR TITLE
ci(shell-ir): RFC-0160 S7 G1+G7 monotone-decrease ratchet

### DIFF
--- a/.github/workflows/shell-ir-consumption-ratchet.yml
+++ b/.github/workflows/shell-ir-consumption-ratchet.yml
@@ -1,0 +1,63 @@
+name: Shell IR Consumption Ratchet (RFC-0160)
+
+# RFC-0160 (Shell IR 1급 승격) §S7: gate PRs against the frozen
+# baseline at scripts/shell-ir-consumption-baseline.json so that
+# G1 (Bash.parse_string callers) and G7 (parallel parser refs) only
+# monotonically decrease toward target.
+#
+# The script exits 1 when either metric regresses; non-G1/G7 changes
+# (G2-G6 / info constructors) are reported but do not fail the gate
+# at this phase — those metrics still trend toward targets via
+# per-phase PRs (S2-S6), not a per-PR ratchet.
+#
+# Update protocol when a Shell IR phase PR legitimately moves a
+# metric: regenerate scripts/shell-ir-consumption-baseline.json via
+#   bash scripts/audit-shell-ir-consumption.sh --json > scripts/shell-ir-consumption-baseline.json
+# and commit alongside the structural change. Reviewer checks the
+# updated baseline against PR-stated KPI movement.
+
+on:
+  pull_request:
+    paths:
+      - 'lib/**'
+      - 'scripts/audit-shell-ir-consumption.sh'
+      - 'scripts/shell-ir-consumption-baseline.json'
+      - '.github/workflows/shell-ir-consumption-ratchet.yml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: shell-ir-ratchet-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ratchet:
+    name: G1 + G7 monotone decrease
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ripgrep + jq
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq ripgrep jq
+
+      - name: Run audit against baseline
+        run: |
+          bash scripts/audit-shell-ir-consumption.sh \
+            --baseline scripts/shell-ir-consumption-baseline.json
+
+      - name: Emit current metrics (for PR diff)
+        if: always()
+        run: |
+          echo '## Shell IR consumption (current)'
+          bash scripts/audit-shell-ir-consumption.sh
+
+      - name: Upload JSON snapshot
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: shell-ir-consumption-current
+          path: scripts/shell-ir-consumption-baseline.json

--- a/scripts/shell-ir-consumption-baseline.json
+++ b/scripts/shell-ir-consumption-baseline.json
@@ -1,17 +1,17 @@
 {
   "schema": "shell-ir-consumption/v1",
-  "generated_at_unix": 1779470159,
-  "g1_parse_string_caller_files_nontest": 10,
-  "g1_parse_string_total_refs_nontest": 15,
-  "g2_classifier_string_sig": 2,
-  "g2_classifier_ir_sig": 0,
-  "g3_gate_typed_refs_in_keeper": 2,
+  "generated_at_unix": 1779473046,
+  "g1_parse_string_caller_files_nontest": 12,
+  "g1_parse_string_total_refs_nontest": 19,
+  "g2_classifier_string_sig": 0,
+  "g2_classifier_ir_sig": 2,
+  "g3_gate_typed_refs_in_keeper": 5,
   "g4_risk_in_simple": 0,
   "g4_phantom_envelope": 0,
-  "g5_validate_paths_callers_nontest": 4,
+  "g5_validate_paths_callers_nontest": 8,
   "g6_tla_spec_exists": 0,
-  "g7_shell_word_values_refs": 16,
-  "g7_bash_words_stages_refs": 10,
-  "g7_parallel_parser_total": 26,
-  "info_ir_constructors_nontest": 45
+  "g7_shell_word_values_refs": 8,
+  "g7_bash_words_stages_refs": 9,
+  "g7_parallel_parser_total": 17,
+  "info_ir_constructors_nontest": 49
 }


### PR DESCRIPTION
## RFC-0160 (Shell IR 1급 승격) S7 — CI ratchet

SSOT: `~/me/memory/shell-ir-first-class-promotion-todo-2026-05-23.html` (jeong-sik/me#1164) · RFC body #17887 (MERGED).
Prereqs: S0 #17873, S1 #17884, S2 #17898, S6 #17903 (all MERGED).

## Why

S1-S6 가 KPI를 측정 가능하게 만들었지만, *non-IR PR이 무심코 새 `Bash.parse_string` caller나 `shell_word_values` literal을 추가*하면 G1/G7이 ratchet 없이 역행 가능. monotone-decrease gate로 회귀 차단.

## What

- `.github/workflows/shell-ir-consumption-ratchet.yml` — `lib/`, audit script, baseline JSON, 본 workflow 변경 PR에서 `audit-shell-ir-consumption.sh --baseline` 실행. G1/G7 증가 시 exit 1.
- `scripts/shell-ir-consumption-baseline.json` 갱신 — S2 + S6 merged 후 측정값으로 동결.

| Goal | Old baseline (b964f49) | **New baseline (frozen, d03d81b)** |
|---|---|---|
| G1 parse_string callers | 10 | **12** (transitional, S4가 회수) |
| G2 classifier sig | string=2, IR=0 | **string=0, IR=2** ✓ |
| G3 gate_typed in keeper | 2 | **5** ✓ (target ≥4) |
| G5 validate_paths callers | 4 | **8** ✓ (target ≥4) |
| **G7 parallel parser** | 26 | **17** (-9, -35%) |
| info Shell_ir constructors | 45 | 49 (+4) |

## Update protocol

Phase PR이 G1/G7를 합법적으로 움직이면 같은 PR에서:

```bash
bash scripts/audit-shell-ir-consumption.sh --json > scripts/shell-ir-consumption-baseline.json
git add scripts/shell-ir-consumption-baseline.json
```

리뷰어가 baseline delta와 PR-stated KPI 움직임을 cross-check.

## Workaround Rejection Bar self-check

- §1 telemetry-as-fix: NO — gate enforces *direction*, not visibility
- §2 substring classifier: NO
- §3 N-of-M: N/A (single ratchet covers all in-flight phases)
- cap/cooldown: NO
- test backdoor: NO

## Verification

- `scripts/audit-shell-ir-consumption.sh --baseline ...`: `OK (RFC-0160 ratchet: no G1/G7 regression)` 확인
- workflow YAML 문법 검증 (apt-get + jq install, action checkout v4, upload-artifact v4)

## Related

- RFC-0160 body #17887 (MERGED)
- S0 measurement #17873 (MERGED, audit script 원본)
- S1 classifier #17884, S2 gh lift #17898, S6 cleanup #17903 (all MERGED)