### PR TITLE
refactor(tool_code_write): apply P-S5 Tool Name SSOT to schema descriptions

### DIFF
--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -939,15 +939,29 @@ let dispatch ctx ~name ~args : Tool_result.t option =
   | "masc_code_git" -> Some (handle_code_git ~tool_name:name ~start_time:start ctx args)
   | _ -> None
 
-(* Tool schemas *)
+(* Tool schemas — cross-tool name references resolved through
+   {!Tool_name.Operation} SSOT (RFC: agent-tool-design.md S10 P-S5)
+   so description text stays in sync with the wire-name typed variant. *)
+let masc_code_write_name = Tool_name.Operation.to_string Tool_name.Operation.Code_write
+let masc_code_edit_name = Tool_name.Operation.to_string Tool_name.Operation.Code_edit
+let masc_code_read_name = Tool_name.Operation.to_string Tool_name.Operation.Code_read
+let masc_code_delete_name = Tool_name.Operation.to_string Tool_name.Operation.Code_delete
+let masc_code_shell_name = Tool_name.Operation.to_string Tool_name.Operation.Code_shell
+let masc_code_git_name = Tool_name.Operation.to_string Tool_name.Operation.Code_git
+let masc_worktree_create_name = Tool_name.Operation.to_string Tool_name.Operation.Worktree_create
+let keeper_bash_name = Tool_name.Keeper.to_string Tool_name.Keeper.Bash
+
 let schemas : Masc_domain.tool_schema list = [
   {
-    name = "masc_code_write";
-    description = "Create or overwrite a file in an allowed coding sandbox \
-(.worktrees/ or .masc/playground/). \
-Use to generate new source files, configs, or replace entire file contents. \
-For partial edits (change a function, fix a line), use masc_code_edit instead. \
-Returns bytes_written. Max 1MB. Set up a worktree first with masc_worktree_create.";
+    name = masc_code_write_name;
+    description = Printf.sprintf
+      "Create or overwrite a file in an allowed coding sandbox \
+       (.worktrees/ or .masc/playground/). \
+       Use to generate new source files, configs, or replace entire file contents. \
+       For partial edits (change a function, fix a line), use %s instead. \
+       Returns bytes_written. Max 1MB. Set up a worktree first with %s."
+      masc_code_edit_name
+      masc_worktree_create_name;
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -970,13 +984,16 @@ Returns bytes_written. Max 1MB. Set up a worktree first with masc_worktree_creat
   };
 
   {
-    name = "masc_code_edit";
-    description = "Replace text in a file in an allowed coding sandbox \
-(.worktrees/ or .masc/playground/). \
-Use for surgical edits: fix a bug, update a function, change a config value. \
-old_string must match exactly once (unless replace_all=true). Returns replacement_count. \
-For full file replacement, use masc_code_write. Read the file first with masc_code_read \
-to get the exact text to replace.";
+    name = masc_code_edit_name;
+    description = Printf.sprintf
+      "Replace text in a file in an allowed coding sandbox \
+       (.worktrees/ or .masc/playground/). \
+       Use for surgical edits: fix a bug, update a function, change a config value. \
+       old_string must match exactly once (unless replace_all=true). Returns replacement_count. \
+       For full file replacement, use %s. Read the file first with %s \
+       to get the exact text to replace."
+      masc_code_write_name
+      masc_code_read_name;
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -1003,7 +1020,7 @@ to get the exact text to replace.";
   };
 
   {
-    name = "masc_code_delete";
+    name = masc_code_delete_name;
     description = "Delete a file in an allowed coding sandbox \
 (.worktrees/ or .masc/playground/). Cannot delete directories. \
 Use when removing generated, obsolete, or conflicting files during code work.";
@@ -1020,12 +1037,16 @@ Use when removing generated, obsolete, or conflicting files during code work.";
   };
 
   {
-    name = "masc_code_shell";
-    description = "Run an allowlisted command in an allowed coding sandbox \
-(.worktrees/ or .masc/playground/). \
-Allowed: keeper dev-shell commands plus diff, patch, mkdir, ocamlfind, and tsc. \
-Use for building and testing code in isolated worktrees. For unrestricted shell at project root, use keeper_bash. \
-Returns exit_code and stdout (truncated at " ^ max_output_label ^ ").";
+    name = masc_code_shell_name;
+    description = Printf.sprintf
+      "Run an allowlisted command in an allowed coding sandbox \
+       (.worktrees/ or .masc/playground/). \
+       Allowed: keeper dev-shell commands plus diff, patch, mkdir, ocamlfind, and tsc. \
+       Use for building and testing code in isolated worktrees. \
+       For unrestricted shell at project root, use %s. \
+       Returns exit_code and stdout (truncated at %s)."
+      keeper_bash_name
+      max_output_label;
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -1048,13 +1069,15 @@ Returns exit_code and stdout (truncated at " ^ max_output_label ^ ").";
   };
 
   {
-    name = "masc_code_git";
-    description = "Run git commands in an allowed coding sandbox \
-(.worktrees/ or .masc/playground/). Structured alternative \
-to masc_code_shell for git operations. Supports: add, commit, push, diff, status, \
-log, branch, checkout, stash, fetch, clone. Force push and push to main/master are blocked. \
-Clone is restricted to allowed GitHub orgs (configured in config/tool_policy.toml). \
-Returns git command output.";
+    name = masc_code_git_name;
+    description = Printf.sprintf
+      "Run git commands in an allowed coding sandbox \
+       (.worktrees/ or .masc/playground/). Structured alternative \
+       to %s for git operations. Supports: add, commit, push, diff, status, \
+       log, branch, checkout, stash, fetch, clone. Force push and push to main/master are blocked. \
+       Clone is restricted to allowed GitHub orgs (configured in config/tool_policy.toml). \
+       Returns git command output."
+      masc_code_shell_name;
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [


### PR DESCRIPTION
## Summary

Proof-of-concept PR for **P-S5 (Tool Name SSOT)** — a source-validated principle from Claude Code's leaked source (documented in ~/me PR #1165 `agent-tool-design.md` S10).

Resolves 8 cross-tool name references in `tool_code_write.ml` schema descriptions through `Tool_name.Operation` / `Tool_name.Keeper` typed-variant SSOT instead of hardcoded string literals.

## Background

In Claude Code's source (`~/me/workspace/yousleepwhen/claude-code/src/tools/`), every tool that references another tool's name imports the constant:

```typescript
// BashTool/prompt.ts
import { AGENT_TOOL_NAME } from '../AgentTool/constants.js'
import { FILE_EDIT_TOOL_NAME } from '../FileEditTool/constants.js'
```

This prevents string drift when tool names are renamed. masc-mcp already has the equivalent typed variant in `lib/tool_name.ml` (`Operation.t`, `Keeper.t`) — this PR extends its use from routing/dispatch (where it's already used) to **schema description text**.

## Changes

`lib/tool_code_write.ml` — 5 schema entries refactored:

| Schema | Cross-tool refs (was → now) |
|---|---|
| `masc_code_write` | "masc_code_edit", "masc_worktree_create" → `Tool_name.Operation.Code_edit`, `Worktree_create` |
| `masc_code_edit` | "masc_code_write", "masc_code_read" → `Code_write`, `Code_read` |
| `masc_code_delete` | (no cross-refs, name only) |
| `masc_code_shell` | "keeper_bash" → `Tool_name.Keeper.Bash` |
| `masc_code_git` | "masc_code_shell" → `Operation.Code_shell` |

Pattern:
```ocaml
let masc_code_edit_name = Tool_name.Operation.to_string Tool_name.Operation.Code_edit
(* ... *)
description = Printf.sprintf "... use %s instead ..." masc_code_edit_name;
```

## Verification

- `dune build lib/` PASS (EXIT=0).
- Description text byte-equivalent after Printf.sprintf (OCaml line continuation collapses whitespace to single spaces, same as before).
- No semantic change to schema; wire output identical.

## Why this matters

When `Tool_name.Operation.Code_edit -> "masc_code_edit"` is renamed (e.g., to `"masc_file_edit"`), the *new* PR currently has to grep all `.ml` files for `"masc_code_edit"` string occurrences. After this pattern propagates, the rename in `tool_name.ml` flows through to every description automatically. Compile-time enforcement, zero drift.

## Scope

This PR is the **first of a planned sweep**. Establishes the pattern in one file; follow-ups apply the same refactor to other `lib/tool_*.ml` modules with cross-tool references. Per the **Workaround Rejection Bar**, the alternative (continuing to hardcode strings) would violate P-S5 systematically; this PR begins the migration rather than leaving the gap open.

## Related

- `~/me` PR #1165 — `agent-tool-design.md` S10 introduces P-S5 with Claude Code source citations
- `~/me/knowledge/claude-code-tool-mastery-2026-05-23.md` — full source-level findings
- `lib/tool_name.ml` — existing typed-variant SSOT (already used by routing, dispatch, gating)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>