### PR TITLE
feat(keeper): fleet-level backoff when all providers in cooldown (task-536)

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -1168,6 +1168,52 @@ let run_named
       Error
         terminal_error
     | candidate :: rest ->
+      (* Fleet-level backoff: when every remaining candidate is under
+         health cooldown, wait until the earliest cooldown expires rather
+         than exhausting the cascade immediately.  This prevents the
+         fail-open -> capacity-backpressure -> restart loop that thrashes
+         keepers when all providers are simultaneously exhausted.
+         (task-536, PR-17885 follow-up). *)
+      (if health_cooldown_fail_open then (
+         let now = Unix.gettimeofday () in
+         let all_candidates = candidate :: rest in
+         let cooldown_expirations =
+           List.filter_map
+             (fun c ->
+                match Cascade_runtime_candidate.first_health_cooldown c with
+                | None -> None
+                | Some (key, _) -> (
+                  match
+                    Cascade_health_tracker.provider_info
+                      Cascade_health_tracker.global ~provider_key:key
+                  with
+                  | None -> None
+                  | Some info -> info.cooldown_expires_at))
+             all_candidates
+         in
+         if List.length cooldown_expirations = List.length all_candidates
+            && cooldown_expirations <> []
+         then (
+           let min_expiry =
+             List.fold_left Float.min Float.infinity cooldown_expirations
+           in
+           let wait_sec =
+             Float.max 0.0
+               (Float.min
+                  (min_expiry -. now)
+                  Cascade_health_tracker_config.default_capacity_backpressure_backoff_sec)
+           in
+           if wait_sec > 0.0 then (
+             Log.Misc.info
+               "cascade %s: fleet-level backoff -- all %d provider(s) in \
+                cooldown, waiting %.1fs for earliest recovery"
+               cascade_name
+               (List.length all_candidates)
+               wait_sec;
+             match Eio_context.get_clock_opt () with
+             | Some clock -> Eio.Time.sleep clock wait_sec
+             | None -> Unix.sleepf wait_sec
+           ))));
       Eio_guard.fair_yield (); (* P0: keep fast-fail cascades scheduler-fair. *)
       (* RFC-0157 PR-1: pre-dispatch required-tool capability gate.
          Resolves the candidate's effective tool surface and checks whether


### PR DESCRIPTION
## Summary

PR #17885 (per-provider 30s cooldown)는 같은 provider의 빠른 retry를 막지만, **모든 provider가 동시에 exhausted**일 때의 fail-open 루프는 막지 못함.

이 PR은 fleet-level backoff를 추가: 모든 remaining candidate가 cooldown 중이면 earliest expiry까지 기다린 후 cascade를 재개.

## Problem (task-536)

1. 모든 provider가 capacity backpressure 반환
2. `fail_open_health_filtered_candidates`가 cooldown 무효화
3. 각 provider를 다시 시도 → 다시 capacity backpressure
4. Cascade exhausted → keeper restart
5. Restart 후 다시 1번부터 반복

## Solution

`try_cascade`의 `candidate :: rest` 케이스에 fleet-level sleep 추가:

- 모든 remaining candidate의 `cooldown_expires_at` 조회
- 모두 active cooldown이면 earliest expiry까지 sleep
- max clamp: `default_capacity_backpressure_backoff_sec` (30s, env override 가능)
- `Eio.Time.sleep` 우선, `Unix.sleepf` fallback

## Trade-offs / Known Limitations

**"영구히 잠드는 건 아닌가?"** — max 30s까지만 기다림. `MASC_CASCADE_CAPACITY_BACKPRESSURE_DEFAULT_BACKOFF_SEC`로 조정 가능.

**"효율적이고 활동성 넘치나?"** — 이 구현은 P0 emergency fix로 fail-open restart loop를 막는 게 목표. 매 turn마다 최대 30s 대기하면 처리량은 저하. 근본 해결은:
1. capacity state를 health cooldown과 분리 (RFC-0153 방향)
2. capacity-aware routing / async queueing

## Checklist

- [x] `dune build` pass
- [ ] `dune test` pass (sandbox env issue 확인 필요)
- [ ] CI green

## Related

- PR #17885 (per-provider cooldown 5s → 30s)
- task-536