### PR TITLE
fix(tool_name): add Operation submodule for P-S5 SSOT + fix keeper_tools_oas forward ref

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -148,6 +148,14 @@ let detail_json_opt = Keeper_tools_oas_json.detail_json_opt
 let json_or_detail_string_opt = Keeper_tools_oas_json.json_or_detail_string_opt
 let diagnosis_json_opt = Keeper_tools_oas_json.diagnosis_json_opt
 
+let json_nonempty_string_opt key json =
+  match json_assoc_field_opt key json with
+  | Some (`String value) ->
+    let value = String.trim value in
+    if String.equal value "" then None else Some value
+  | _ -> None
+;;
+
 let workflow_rejection_info_of_raw raw =
   try
     let json = Yojson.Safe.from_string raw in
@@ -274,13 +282,6 @@ let workflow_rejection_recovery_fields ~tool_name ~count raw =
     @ if count >= 2 then [ "workflow_rejection_loop", `Bool true ] else []
 ;;
 
-let json_nonempty_string_opt key json =
-  match json_assoc_field_opt key json with
-  | Some (`String value) ->
-    let value = String.trim value in
-    if String.equal value "" then None else Some value
-  | _ -> None
-;;
 
 let json_has_nonempty_evidence_refs json =
   let nonempty_string = function
@@ -351,7 +352,7 @@ let workflow_rejection_scope_block_fields ~tool_name block =
           (workflow_rejection_recovery_instruction
              ~tool_name
              ~count:(block.count + 1)
-             { rule_id = block.rule_id
+             { task_id = None; rule_id = block.rule_id
              ; tool_suggestion = block.tool_suggestion
              ; hint = block.hint
              })

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -21,6 +21,26 @@ module Float = Stdlib.Float
     Parse boundary: [of_string] at MCP/JSON ingress only.
     Internal code uses [t] directly — typos become compile errors. *)
 
+module Operation = struct
+  type t =
+    | Code_write
+    | Code_edit
+    | Code_read
+    | Code_delete
+    | Code_shell
+    | Code_git
+    | Worktree_create
+
+  let to_string = function
+    | Code_write -> "masc_code_write"
+    | Code_edit -> "masc_code_edit"
+    | Code_read -> "masc_code_read"
+    | Code_delete -> "masc_code_delete"
+    | Code_shell -> "masc_code_shell"
+    | Code_git -> "masc_code_git"
+    | Worktree_create -> "masc_worktree_create"
+end
+
 module Keeper = struct
   type t =
     | Bash

--- a/lib/tool_name.mli
+++ b/lib/tool_name.mli
@@ -3,6 +3,19 @@
     Use [of_string] at MCP/JSON parse boundaries only.
     All internal code passes [t] values directly. *)
 
+module Operation : sig
+  type t =
+    | Code_write
+    | Code_edit
+    | Code_read
+    | Code_delete
+    | Code_shell
+    | Code_git
+    | Worktree_create
+
+  val to_string : t -> string
+end
+
 module Keeper : sig
   type t =
     | Bash


### PR DESCRIPTION
Fixes build breakage from #17908 where Tool_name.Operation references were added without the actual submodule definition.