### PR TITLE
refactor(tools): P-S5 SSOT sweep — cross-tool name references via Tool_name constants

### DIFF
--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -29,6 +29,8 @@ module Float = Stdlib.Float
 open Masc_domain
 open Tool_args
 
+let masc_code_search_name = Tool_name.Operation.to_string Tool_name.Operation.Code_search
+
 (* Context required by code tools *)
 type context = {
   config: Coord.config;
@@ -536,7 +538,7 @@ let dispatch ctx ~name ~args : Tool_result.t option =
 let schemas : Masc_domain.tool_schema list = [
   (* masc_code_search *)
   {
-    name = "masc_code_search";
+    name = masc_code_search_name;
     description = "Search code using ripgrep. Literal match by default (is_regex=false). \
 Use simple words/phrases as query. Example: query='handle_request', file_pattern='*.ml'. \
 Set is_regex=true only for patterns like 'foo.*bar' or 'class \\w+'.";
@@ -597,9 +599,11 @@ Pair with masc_code_read to then read specific line ranges of interest.";
   (* masc_code_read *)
   {
     name = "masc_code_read";
-    description = "Read a single file with offset/limit pagination. \
+    description = Printf.sprintf
+      "Read a single file with offset/limit pagination. \
 Returns typed error_kind on failure (path_is_directory, file_not_found, binary_file, file_too_large, io_error). \
-For directories use masc_code_search or shell 'ls -la'.";
+For directories use %s or shell 'ls -la'."
+      masc_code_search_name;
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/lib/tool_inline_dispatch_coord.ml
+++ b/lib/tool_inline_dispatch_coord.ml
@@ -23,6 +23,8 @@ module Float = Stdlib.Float
 
 open Tool_inline_dispatch_types
 
+let masc_add_task_name = Tool_name.Operation.to_string Tool_name.Operation.Add_task
+
 (** Argument extraction helpers bound to ctx.arguments. *)
 let arg_get_string ctx key default =
   Safe_ops.json_string ~default key ctx.arguments
@@ -97,8 +99,9 @@ let handle_start ~tool_name ~start_time (ctx : context) : tool_result option =
         Some
           (Tool_result.ok ~tool_name ~start_time
              (Printf.sprintf
-                "masc_start complete (project scope set + joined as %s). No task created — use masc_add_task to create one."
-                agent_name))
+                "masc_start complete (project scope set + joined as %s). No task created — use %s to create one."
+                agent_name
+                masc_add_task_name))
       else begin
         (* RFC-0034.v2: per-goal cap guard. masc_start does not pass a
            [goal_id], so the guard is a no-op for orphan tasks. Wired so

--- a/lib/tool_task_schemas.ml
+++ b/lib/tool_task_schemas.ml
@@ -21,15 +21,21 @@ module Float = Stdlib.Float
 
     @since God file decomposition — extracted from tool_task.ml *)
 
+let masc_add_task_name = Tool_name.Operation.to_string Tool_name.Operation.Add_task
+let masc_code_git_name = Tool_name.Operation.to_string Tool_name.Operation.Code_git
+let masc_claim_next_name = Tool_name.Operation.to_string Tool_name.Operation.Claim_next
+
 let schemas : Masc_domain.tool_schema list = [
   {
-    name = "masc_add_task";
-    description = "Add a new task to the backlog for agents to claim. \
+    name = masc_add_task_name;
+    description = Printf.sprintf
+      "Add a new task to the backlog for agents to claim. \
 Tasks default to an advisory verification contract with completion/evidence requirements. \
 Normal status flow is todo → claimed → awaiting_verification → done/cancelled when verification FSM is enabled. \
 Priority 1=urgent, 5=low (default 3). \
 Returns task-XXX ID for tracking. \
-Example: masc_add_task({title: 'Fix login bug', goal_id: 'g-123', priority: 1, description: 'Users cannot login with SSO'})";
+Example: %s({title: 'Fix login bug', goal_id: 'g-123', priority: 1, description: 'Users cannot login with SSO'})"
+      masc_add_task_name;
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -59,7 +65,7 @@ Example: masc_add_task({title: 'Fix login bug', goal_id: 'g-123', priority: 1, d
             ("required_tools", `Assoc [
               ("type", `String "array");
               ("items", `Assoc [ ("type", `String "string") ]);
-              ("description", `String "Tool names required to claim this task, e.g. Bash or masc_code_git.");
+              ("description", `String (Printf.sprintf "Tool names required to claim this task, e.g. Bash or %s." masc_code_git_name));
             ]);
             ("required_evidence", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
             ("inspect_gate_evidence", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
@@ -79,11 +85,14 @@ Example: masc_add_task({title: 'Fix login bug', goal_id: 'g-123', priority: 1, d
   };
   {
     name = "masc_batch_add_tasks";
-    description = "Add multiple tasks in one call (more efficient than repeated masc_add_task). \
+    description = Printf.sprintf
+      "Add multiple tasks in one call (more efficient than repeated %s). \
 Use when: loading sprint backlog, importing from JIRA, creating related tasks. \
-Tasks default to the same advisory verification contract/evidence requirements as masc_add_task. \
+Tasks default to the same advisory verification contract/evidence requirements as %s. \
 Each task gets unique ID (task-XXX). Atomic: all succeed or all fail. \
-Example: masc_batch_add_tasks({tasks: [{title: 'Task A', goal_id: 'g-123', priority: 2}, {title: 'Task B', goal_id: 'g-124'}]})";
+Example: masc_batch_add_tasks({tasks: [{title: 'Task A', goal_id: 'g-123', priority: 2}, {title: 'Task B', goal_id: 'g-124'}]})"
+      masc_add_task_name
+      masc_add_task_name;
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -118,7 +127,7 @@ Example: masc_batch_add_tasks({tasks: [{title: 'Task A', goal_id: 'g-123', prior
                   ("required_tools", `Assoc [
                     ("type", `String "array");
                     ("items", `Assoc [ ("type", `String "string") ]);
-                    ("description", `String "Tool names required to claim this task, e.g. Bash or masc_code_git.");
+                    ("description", `String (Printf.sprintf "Tool names required to claim this task, e.g. Bash or %s." masc_code_git_name));
                   ]);
                   ("required_evidence", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
                   ("inspect_gate_evidence", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
@@ -216,16 +225,20 @@ Tip: Look for status='todo' tasks to claim.";
   };
   {
     name = "masc_transition";
-    description = "Move a task through its lifecycle: claim, start, done, cancel, release, \
+    description = Printf.sprintf
+      "Move a task through its lifecycle: claim, start, done, cancel, release, \
 submit_for_verification, approve, reject, or submit_pr_evidence. \
 Call when you pick up, finish, or abandon a task. Supports CAS via expected_version. \
-After masc_add_task or masc_claim_next; pair with masc_deliver before action='done'. \
+After %s or %s; pair with masc_deliver before action='done'. \
 Use submit_for_verification to request cross-agent review; approve/reject for verifier actions. \
 Use submit_pr_evidence to submit a merged PR as evidence for a todo task that requires tools \
 unavailable to you — this transitions the task directly to awaiting_verification so a keeper \
 with the required tools can verify and close it. For compatibility, \
 submit_for_verification with evidence on a todo task is treated as submit_pr_evidence. \
-Tasks created through masc_add_task normally route action='done' into awaiting_verification rather than final done.";
+Tasks created through %s normally route action='done' into awaiting_verification rather than final done."
+      masc_add_task_name
+      masc_claim_next_name
+      masc_add_task_name;
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [


### PR DESCRIPTION
## Summary

Expand P-S5 (Tool Name SSOT) pattern from PR #17908 to 3 additional files. Cross-tool references in schema descriptions now route through `Tool_name.Operation.to_string` instead of string literals.

## Files changed

| File | Before | After |
|------|--------|-------|
| `lib/tool_task_schemas.ml` | 8 string literals | 3 constants (`Add_task`, `Code_git`, `Claim_next`) |
| `lib/tool_code.ml` | 2 string literals | 1 constant (`Code_search`) |
| `lib/tool_inline_dispatch_coord.ml` | 1 string literal | 1 constant (`Add_task`) |

## Pattern

```ocaml
let masc_add_task_name = Tool_name.Operation.to_string Tool_name.Operation.Add_task
(* ... *)
description = Printf.sprintf "...use %s to create one." masc_add_task_name
```

## Verification

- [ ] `dune build @check` (pending — lock contention with in-flight builds)
- [x] Diff review: zero functional change, only literal → constant substitution
- [x] No new string literals introduced
- [x] All `Printf.sprintf` substitutions have matching argument count

## Deferred

- `tool_run.ml` has 5 cross-tool refs but `Run_init`/`Run_plan`/`Run_log` variants are missing from `Tool_name.Operation` — separate SSOT-extension PR required.

## Self-check

- [x] No workaround signature (telemetry-as-fix, string classifier, N-of-M)
- [x] No catch-all `_ ->` expansion
- [x] No test backdoor exposure