### PR TITLE
cleanup(keeper): drop dead export phase_to_mermaid_id

### DIFF
--- a/lib/keeper/keeper_state_machine_mermaid.mli
+++ b/lib/keeper/keeper_state_machine_mermaid.mli
@@ -1,4 +1,3 @@
 (** Keeper state-machine -> Mermaid [stateDiagram-v2] rendering. *)
 
-val phase_to_mermaid_id : Keeper_state_machine.phase -> string
 val phase_to_mermaid : current:Keeper_state_machine.phase -> string


### PR DESCRIPTION
## Summary

Remove dead export `val phase_to_mermaid_id` from `keeper_state_machine_mermaid.mli`.

## Audit Evidence

5-prong dead-export audit confirms **zero external callers**:

| Prong | Result |
|-------|--------|
| Qualified (`Keeper_state_machine_mermaid.phase_to_mermaid_id`) | 0 matches |
| Facade re-export (`include` / `let x = Module.x`) | 0 matches |
| Opener-unqualified (`open Keeper_state_machine_mermaid`) | 0 matches |
| Local alias (`module X = Keeper_state_machine_mermaid`) | 0 matches |
| Parent `.ml` internal use | Used only within `phase_to_mermaid` helper |

The function remains defined in the `.ml` file for internal consumption by `phase_to_mermaid`. Removing it from the `.mli` simply narrows the public surface without affecting runtime behavior.

## Verification

- [x] 5-prong audit (all paths zero)
- [ ] CI build / lint (dune lock contention, delegated to CI)
- [ ] No functional change — signature-only cleanup

## Risk

Minimal. Zero callers; function stays private in `.ml`.