### PR TITLE
cleanup(server): remove dead mli server_runtime_config_root_bootstrap.mli

### DIFF
--- a/lib/server/server_runtime_config_root_bootstrap.mli
+++ b/lib/server/server_runtime_config_root_bootstrap.mli
@@ -1,3 +1,0 @@
-val config_bootstrap_mode : unit -> [> `Auto | `Empty | `Skip ]
-val bootstrap_base_path_config_root : base_path:string -> unit
-val startup_config_resolution : base_path:string -> Config_dir_resolver.resolution


### PR DESCRIPTION
## Summary

Remove redundant `.mli` file `server_runtime_config_root_bootstrap.mli`.

## Audit Evidence

5-prong dead-export audit confirms **zero external callers** for all 3 exports:

| Export | Qualified | Facade | Opener | Alias |
|--------|-----------|--------|--------|-------|
| `config_bootstrap_mode` | 0 | Re-exported via `Server_runtime_bootstrap` | 0 | 0 |
| `bootstrap_base_path_config_root` | 0 | Re-exported via `Server_runtime_bootstrap` | 0 | 0 |
| `startup_config_resolution` | 0 | Re-exported via `Server_runtime_bootstrap` | 0 | 0 |

All three functions are already exposed through `Server_runtime_bootstrap.mli`:
```ocaml
module Config_root_bootstrap = Server_runtime_config_root_bootstrap
let config_bootstrap_mode = Config_root_bootstrap.config_bootstrap_mode
let bootstrap_base_path_config_root = Config_root_bootstrap.bootstrap_base_path_config_root
let startup_config_resolution = Config_root_bootstrap.startup_config_resolution
```

Removing the `.mli` makes the `.ml` infer its signature; helper functions that
were never referenced externally (e.g. `project_root_from_executable`,
`config_root_from_ancestor`, `dedupe_keep_order`) remain effectively private.

## Verification

- [x] 5-prong audit (all paths zero)
- [ ] CI build / lint (delegated to CI)
- [x] No functional change — interface-only cleanup

## Risk

Minimal. All external usage routes through `Server_runtime_bootstrap`.