### PR TITLE
cleanup(dashboard): drop dead export execution_receipt_dir

### DIFF
--- a/lib/dashboard/dashboard_http_keeper_execution_receipt.mli
+++ b/lib/dashboard/dashboard_http_keeper_execution_receipt.mli
@@ -1,6 +1,5 @@
 (** Execution-receipt path resolution and dashboard diagnostics. *)
 
-val execution_receipt_dir : Coord.config -> string -> string
 val execution_receipt_store_pattern : Coord.config -> string
 val count_execution_receipt_entries : Coord.config -> string list -> int
 val execution_receipt_coverage_gaps : Coord.config -> Yojson.Safe.t list


### PR DESCRIPTION
## Summary

Remove dead export `val execution_receipt_dir` from `dashboard_http_keeper_execution_receipt.mli`.

## Audit Evidence

5-prong dead-export audit confirms **zero external callers**:

| Prong | Result |
|-------|--------|
| Qualified (`Dashboard_http_keeper_execution_receipt.execution_receipt_dir`) | 0 matches |
| Opener (`open Dashboard_http_keeper_execution_receipt`) | 0 matches |
| Alias (`module X = Dashboard_http_keeper_execution_receipt`) | 0 matches |
| Unqualified `execution_receipt_dir` outside self | 0 matches |

The function remains defined in the `.ml` for internal consumption by sibling
functions. Removing it from the `.mli` narrows the public surface without
affecting runtime behavior.

## Verification

- [x] 5-prong audit (all paths zero)
- [ ] CI build / lint (delegated to CI)
- [x] No functional change — signature-only cleanup

## Risk

Minimal. Zero external callers; function stays private in `.ml`.