### PR TITLE
fix(tool_name): correct P-S5 SSOT sweep cross-module references

### DIFF
--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -29,7 +29,7 @@ module Float = Stdlib.Float
 open Masc_domain
 open Tool_args
 
-let masc_code_search_name = Tool_name.Operation.to_string Tool_name.Operation.Code_search
+let masc_code_search_name = Tool_name.Masc.to_string Tool_name.Masc.Code_search
 
 (* Context required by code tools *)
 type context = {

--- a/lib/tool_inline_dispatch_coord.ml
+++ b/lib/tool_inline_dispatch_coord.ml
@@ -23,7 +23,7 @@ module Float = Stdlib.Float
 
 open Tool_inline_dispatch_types
 
-let masc_add_task_name = Tool_name.Operation.to_string Tool_name.Operation.Add_task
+let masc_add_task_name = Tool_name.Masc.to_string Tool_name.Masc.Add_task
 
 (** Argument extraction helpers bound to ctx.arguments. *)
 let arg_get_string ctx key default =

--- a/lib/tool_task_schemas.ml
+++ b/lib/tool_task_schemas.ml
@@ -21,9 +21,9 @@ module Float = Stdlib.Float
 
     @since God file decomposition — extracted from tool_task.ml *)
 
-let masc_add_task_name = Tool_name.Operation.to_string Tool_name.Operation.Add_task
+let masc_add_task_name = Tool_name.Masc.to_string Tool_name.Masc.Add_task
 let masc_code_git_name = Tool_name.Operation.to_string Tool_name.Operation.Code_git
-let masc_claim_next_name = Tool_name.Operation.to_string Tool_name.Operation.Claim_next
+let masc_claim_next_name = Tool_name.Masc.to_string Tool_name.Masc.Claim_next
 
 let schemas : Masc_domain.tool_schema list = [
   {

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -840,7 +840,7 @@ let test_bash_missing_typed_input_field () =
   match parse_error_field raw with
   | Some err ->
       Alcotest.(check bool) "error mentions typed input is required" true
-        (String_util.contains_substring err "typed keeper_bash input is required")
+        (String_util.contains_substring err "Typed Bash input is required")
   | None ->
       Alcotest.fail ("expected error json for missing typed input field, got: " ^ raw)
 


### PR DESCRIPTION
## Summary
- P-S5 SSOT sweep (#17914) migrated 3 callers to `Tool_name.Operation.*` but the referenced constructors (`Add_task`, `Code_search`, `Claim_next`) belong to `Tool_name.Masc`, not `Operation`. Restores correct module paths.
- Fixes pre-existing `negative_path 0` test assertion mismatch (expected `"typed keeper_bash input is required"` but actual is `"Typed Bash input is required"`).

## Impact
- `origin/main` is currently build-breaking due to these 3 unbound constructor errors.
- Fix is 5 line changes across 4 files: 3 production `.ml` + 1 test.

## Test plan
- [x] `dune build` passes (was failing with 3 unbound constructor errors)
- [x] `test_keeper_bash_safety.exe` 36/36 tests pass (was 35/36 with assertion mismatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)