### PR TITLE
fix(gh_command_validation): short-circuit graphql destructiveness before Bash.parse_string regression

### DIFF
--- a/lib/gh_command_validation.ml
+++ b/lib/gh_command_validation.ml
@@ -296,6 +296,11 @@ let has_mutating_http_method parts =
       4. top command + subcommand in [gh_reversible_mutations] → R1
       5. anything else → R0 (read-only default) *)
 let classify_gh_reversibility cmd =
+  (* RFC-0160 S1 regression: Bash.parse_string rejects { } in graphql
+     query strings, so extract_gh_command_pair returns (None,_).
+     Short-circuit graphql classification before parser-dependent path. *)
+  if gh_api_graphql_is_destructive cmd then R2_Irreversible
+  else 
   match extract_gh_command_pair cmd with
   | (None, _) -> R0_Read
   | (Some command, subcmd_opt) ->


### PR DESCRIPTION
Short-circuit gh_api_graphql_is_destructive before parser-dependent path so graphql mutations are correctly classified as R2_Irreversible.

Fixes regression from PR #17884 where Bash.parse_string rejects { } in graphql query strings.