### PR TITLE
refactor(dispatch): seal dispatch behind dispatch_decided (RFC-0160 S3)

### DIFF
--- a/lib/exec/exec_dispatch.mli
+++ b/lib/exec/exec_dispatch.mli
@@ -7,13 +7,6 @@ type dispatch_result = {
 val resolve_arg : Shell_ir.arg -> string
 (** Resolve a Shell_ir.arg to a concrete string value. *)
 
-val dispatch : ?timeout_sec:float -> Shell_ir.t -> dispatch_result
-(** Execute a [Shell_ir.t] AST directly via Exec_gate without
-    going through /bin/bash.  Simple commands use argv-based spawn;
-    redirect-free host and Docker pipelines use streaming process pipes;
-    unsupported pipeline shapes fall back to stdout-to-stdin chaining.
-    [?timeout_sec] is the whole pipeline budget for both streaming and
-    fallback pipeline paths. *)
 
 val dispatch_simple :
   ?timeout_sec:float -> ?stdin_content:string -> Shell_ir.simple -> dispatch_result

--- a/lib/exec/test/test_bash_parser.ml
+++ b/lib/exec/test/test_bash_parser.ml
@@ -133,7 +133,7 @@ let test_input_redirect_parsed () =
 let test_general_redirect_rejected_before_dispatch () =
   match Bash.parse_string "echo hi > /tmp/out" with
   | Parsed.Parsed ir ->
-    let result = Masc_exec.Exec_dispatch.dispatch ir in
+    let result = Masc_exec.Exec_dispatch.dispatch_decided (Shell_ir_risk.classify (Shell_ir_risk.undecided ir)) in
     assert (result.status = Unix.WEXITED 1);
     assert (result.stdout = "");
     assert (String.contains result.stderr 'w');
@@ -232,7 +232,7 @@ let test_env_prefix_dispatch_overlay () =
       "MASC_SHELL_IR_ENV_PREFIX_TEST=ok printenv MASC_SHELL_IR_ENV_PREFIX_TEST"
   with
   | Parsed.Parsed ir ->
-    let result = Masc_exec.Exec_dispatch.dispatch ir in
+    let result = Masc_exec.Exec_dispatch.dispatch_decided (Shell_ir_risk.classify (Shell_ir_risk.undecided ir)) in
     assert (result.status = Unix.WEXITED 0);
     assert (String.trim result.stdout = "ok")
   | _ -> assert false

--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -1237,7 +1237,7 @@ let handle_keeper_shell
              actual dispatch. The dispatch step itself still uses the
              existing argv path ([run_argv_with_status] /
              [run_docker_shell_command_with_status]); routing the
-             execution through [Exec_dispatch.dispatch] is deferred
+             execution through [Exec_dispatch.dispatch_decided] is deferred
              (gh requires env / timeout / docker-routing fields that
              [Exec_dispatch] does not yet thread). *)
           let gh_sandbox_target =


### PR DESCRIPTION
Remove [Exec_dispatch.dispatch] from the public interface and update all call sites to route through [Shell_ir_risk.classify] + [dispatch_decided]. The phantom-type envelope guarantees every dispatched IR has passed risk classification.

Files changed:
- lib/exec/exec_dispatch.mli: drop [dispatch] val
- lib/exec/test/test_bash_parser.ml: wrap IR via [Shell_ir_risk]
- lib/keeper/keeper_shell_bash.ml: wrap IR via [Shell_ir_risk]
- lib/keeper/keeper_shell_ops.ml: update doc comment