### PR TITLE
fix(test,ci): CAS race in test_operator_control + CI gate empty-string fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1196,7 +1196,7 @@ jobs:
                   . as $root
                   |
                   (csv(env.PR_EFFECTIVE_LABELS)) as $present_labels
-                  | (csv(env.AGENT_DRAFT_GUARD_BYPASS_LABELS // "human-approved-ready")
+                  | (csv(if (env.AGENT_DRAFT_GUARD_BYPASS_LABELS == null or env.AGENT_DRAFT_GUARD_BYPASS_LABELS == "") then "human-approved-ready" else env.AGENT_DRAFT_GUARD_BYPASS_LABELS end)
                      | map(select(. != "allow-auto-merge"))) as $bypass_labels
                   | any($bypass_labels[]; . as $label |
                       ($present_labels | index($label)) and

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -2892,6 +2892,10 @@ proactive_enabled = true
       Alcotest.(check bool) "unknown active goal rejected" false ok;
       Alcotest.(check bool) "unknown active goal names surfaced" true
         (contains_substring msg "goal-missing");
+      (* Stop keepalive before direct write_meta to prevent CAS conflict.
+         The keepalive fiber bumps meta_version on each tick, racing with
+         the test's read-then-write cycle.  Issue #17231. *)
+      Keeper_keepalive.stop_keepalive keeper_name;
       let meta = read_keeper_meta_exn config keeper_name in
       let mutated =
         {
@@ -2921,7 +2925,6 @@ proactive_enabled = true
       (match Masc_mcp.Keeper_types.write_meta config mutated with
       | Ok () -> ()
       | Error err -> Alcotest.fail ("meta write failed: " ^ err));
-      Keeper_keepalive.stop_keepalive keeper_name;
       let status, json =
         Masc_mcp.Dashboard_http_keeper.keeper_config_json config keeper_name
       in


### PR DESCRIPTION
## Summary
- **#17231**: Move `Keeper_keepalive.stop_keepalive` before `write_meta` in `test_keeper_config_exposes_live_runtime_and_sources` to prevent CAS version conflict. The keepalive fiber races with the test's read-then-write cycle.
- **#16519**: Fix CI gate jq bypass-label resolution: `AGENT_DRAFT_GUARD_BYPASS_LABELS` unset → empty string via `${{ vars.X }}`, but jq `//` does not treat `""` as null. Use explicit null-or-empty check.

## Test plan
- [x] `dune build test/test_operator_control.exe` passes
- [ ] `./_build/default/test/test_operator_control.exe test` — verify case 62 no longer flakes on CAS conflict
- [ ] CI gate behavior: push a PR with `human-approved-ready` label + marker comment, verify gate passes even when `vars.AGENT_DRAFT_GUARD_BYPASS_LABELS` is unset

Closes #17231
Closes #16519

🤖 Generated with [Claude Code](https://claude.com/claude-code)