### PR TITLE
cleanup(config): remove dead exports print_summary and to_json from env_config.mli

### DIFF
--- a/lib/config/env_config.mli
+++ b/lib/config/env_config.mli
@@ -20,9 +20,3 @@ include module type of Env_config_runtime
 include module type of Env_config_governance
 include module type of Env_config_keeper
 
-val print_summary : unit -> unit
-(** Log a multi-line summary of every nested config category at boot
-    time. Side-effects logging only. *)
-
-val to_json : unit -> Yojson.Safe.t
-(** Compatibility wrapper around {!Env_config_snapshot.to_json}. *)


### PR DESCRIPTION
## Summary

Remove two dead exports from `env_config.mli`.

## Audit Evidence

5-prong dead-export audit:
- Qualified callers: `Env_config.print_summary` / `.to_json` → 0
- Facade re-export (`include` / `let alias`): 0
- Opener-unqualified: 0
- Local alias: 0
- Unqualified usage: 0

The `.ml` implementation remains intact; removing from `.mli` makes
both functions private to the module.

## Verification

- [x] `rg 'Env_config\.(print_summary|to_json)\b' lib/ test/ dashboard/src/` → 0
- [x] `rg '\bprint_summary\b' lib/ test/ dashboard/src/` (unqualified) → 0
- [x] `rg '\bto_json\b' lib/ test/ dashboard/src/` (unqualified) → 0 (matches are other modules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)