### PR TITLE
cleanup(cascade): remove dead export auth_header_authorization from cascade_wire_overlay.mli

### DIFF
--- a/lib/cascade/cascade_wire_overlay.mli
+++ b/lib/cascade/cascade_wire_overlay.mli
@@ -1,7 +1,5 @@
 (** Wire-layer overlays applied after OAS resolves a provider config. *)
 
-val auth_header_authorization : string
-
 val apply :
   provider_cfg:Llm_provider.Provider_config.t ->
   Agent_sdk.Provider.config ->


### PR DESCRIPTION
## Summary

Remove dead export `auth_header_authorization` from `cascade_wire_overlay.mli`.

## Audit Evidence

5-prong dead-export audit:
- Qualified callers: `Cascade_wire_overlay.auth_header_authorization` → 0
- Facade re-export: 0
- Opener-unqualified: 0
- Local alias: 0
- Internal `.ml` usage: used only inside the `apply` function (now private)

Sibling export `apply` remains LIVE (1 qualified caller).

🤖 Generated with [Claude Code](https://claude.com/claude-code)