### PR TITLE
cleanup(cdal_runtime): remove dead export run from conformance.mli

### DIFF
--- a/lib/cdal_runtime/conformance.mli
+++ b/lib/cdal_runtime/conformance.mli
@@ -50,10 +50,3 @@ type report =
 
 (** Generate a conformance report from a proof bundle. *)
 val report : Sessions_types.proof_bundle -> report
-
-(** Run conformance checks from a session on disk. *)
-val run
-  :  ?session_root:string
-  -> session_id:string
-  -> unit
-  -> (report, Error.sdk_error) result


### PR DESCRIPTION
## Summary

Remove dead export `run` from `conformance.mli`.

## Audit Evidence

5-prong dead-export audit:
- Qualified callers: `Conformance.run` → 0
- Facade re-export: 0
- Opener-unqualified: 0
- Local alias: 0
- Internal `.ml` usage: 0 (defined but never called internally)

Sibling export `report` remains LIVE (3 qualified callers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)