### PR TITLE
cleanup(cdal_runtime): remove dead export masc_internal_error_prefix from internal_error_substrate.mli

### DIFF
--- a/lib/cdal_runtime/internal_error_substrate.mli
+++ b/lib/cdal_runtime/internal_error_substrate.mli
@@ -18,12 +18,6 @@
 type t =
   | Contract_rejected of { reason : string }
 
-val masc_internal_error_prefix : string
-(** Mirror of [Cascade_error_classify.masc_internal_error_prefix].  A
-    follow-up PR will promote this to a shared sub-library; for Phase A
-    the mirror is acceptable because both ends are tested against the
-    same literal. *)
-
 val sdk_error_of : t -> Error.sdk_error
 (** Encode [t] as an [Error.Internal] payload prefixed with
     [\[masc_oas_error\]] so the masc_mcp classifier routes it to the


### PR DESCRIPTION
## Summary

Remove dead export `masc_internal_error_prefix` from `internal_error_substrate.mli`.

## Audit Evidence

5-prong dead-export audit:
- Qualified callers: `Internal_error_substrate.masc_internal_error_prefix` → 0
- Facade re-export: 0
- Opener-unqualified: 0
- Local alias: 0
- Internal `.ml` usage: used only inside `sdk_error_of` (now private)

Sibling export `sdk_error_of` remains LIVE (2 qualified callers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)