### PR TITLE
exec(shell_words): remove dead export top_level_command_segments

### DIFF
--- a/lib/exec/words/shell_words.mli
+++ b/lib/exec/words/shell_words.mli
@@ -24,9 +24,3 @@ val stages : string -> (word list list, error) result
     Empty stages are omitted so callers can remain fail-closed at their own
     command-shape layer while still reusing successfully recovered words for
     diagnostics and path policy. *)
-
-val top_level_command_segments : string -> (bool * string) list
-(** Split [source] on unquoted top-level [&&], [||], [;], and newlines.
-    The boolean marks whether the segment is unconditionally reached from the
-    left.  Single [|] is intentionally not a separator here; pipeline-aware
-    callers should continue using {!stages}. *)


### PR DESCRIPTION
## Summary

Remove `val top_level_command_segments` from `lib/exec/words/shell_words.mli` — zero external callers, zero internal callers.

### Audit
- 5-prong audit (`Shell_words.top_level_command_segments`, `top_level_command_segments`, `include Shell_words`, `open Shell_words`, `.ml` unqualified) — no callers.
- Retained export `stages` has 1 caller (`Shell_words.stages` in policy path).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>