### PR TITLE
tool(permission_map): remove dead export declared_permission_for_tool

### DIFF
--- a/lib/tool_permission_map.mli
+++ b/lib/tool_permission_map.mli
@@ -5,9 +5,6 @@
     role-policy derivation so they do not maintain separate hardcoded tool
     lists. *)
 
-val declared_permission_for_tool : string -> Masc_domain.permission option
-(** Tool_catalog-declared permission, when present. *)
-
 val known_tool_names : string list
 (** Tool names covered by either Tool_catalog metadata or the fallback table.
     Useful for policy derivation that must include permission-mapped tools even


### PR DESCRIPTION
## Summary

Remove `val declared_permission_for_tool` from `lib/tool_permission_map.mli` — zero external callers.

### Audit
- `declared_permission_for_tool`: 0 qualified callers, 0 unqualified (no `open` / `include`)
- Retained: `known_tool_names` (3 callers), `permission_for_tool` (6 callers)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>