### PR TITLE
tool(scope): remove dead exports keeper_internal_names, scope_to_string

### DIFF
--- a/lib/tool_scope.mli
+++ b/lib/tool_scope.mli
@@ -25,9 +25,3 @@ val classify : name:string -> scope
 (** [classify ~name] returns the scope for the named tool. Default
     [Surface] unless [name] appears in the keeper-internal list. *)
 
-val keeper_internal_names : unit -> string list
-(** [keeper_internal_names ()] is the explicit list of tool names whose
-    scope is [Keeper_internal]. Returned as a fresh list each call. *)
-
-val scope_to_string : scope -> string
-(** [scope_to_string s] returns ["surface"] or ["keeper_internal"]. *)


### PR DESCRIPTION
## Summary

Remove `val keeper_internal_names` and `val scope_to_string` from `lib/tool_scope.mli` — zero external callers each.

### Audit
- `keeper_internal_names`: 0 qualified callers, 0 unqualified (no `open` / `include`)
- `scope_to_string`: 0 qualified callers, 0 unqualified
- Retained: `classify` (4 callers)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>