### PR TITLE
lib(lockfree_atomic): remove dead export update_with_result

### DIFF
--- a/lib/lockfree_atomic.mli
+++ b/lib/lockfree_atomic.mli
@@ -3,23 +3,11 @@
     Consolidates the CAS-loop pattern that has been duplicated across
     lock-free registry refactors (agent_registry_eio, sse, tool_registry...).
 
-    [update_with_result] exists to eliminate the [ref + Option.get] anti-pattern
-    that appears when a caller needs both the new state and a value derived
-    from the transformation.
-
     @since 0.11.x *)
 
 (** [update atomic f] repeatedly runs [f] against the current value and
     commits the result via CAS, retrying on contention. *)
 val update : 'a Atomic.t -> ('a -> 'a) -> unit
-
-(** [update_with_result atomic f] is [update] but [f] returns both the new
-    state and a derived value; the derived value of the committed attempt
-    is returned.
-
-    Important: [f] may be invoked multiple times under contention. It must
-    be pure with respect to observable effects, or tolerate repeated calls. *)
-val update_with_result : 'a Atomic.t -> ('a -> 'a * 'b) -> 'b
 
 (** Record-labelled commit describing the next state and a derived value.
     Equivalent to the tuple form used by [update_with_result]; provided for


### PR DESCRIPTION
## Summary

Remove `val update_with_result` from `lib/lockfree_atomic.mli` — zero external callers.

### Audit
- `update_with_result`: 0 qualified callers, 0 unqualified (no `open` / `include`)
- Retained: `update` (19 callers), `update_with_commit` (14 callers)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>