### PR TITLE
hotfix: resolve main regression from RFC-0160 S3 partial rollout

### DIFF
--- a/lib/exec/exec_dispatch.mli
+++ b/lib/exec/exec_dispatch.mli
@@ -15,6 +15,13 @@ val dispatch_simple :
     forwarded without dropping the stage's sandbox target.  [?timeout_sec]
     overrides the dispatch default. *)
 
+val dispatch :
+  ?timeout_sec:float -> Shell_ir.t -> dispatch_result
+(** General dispatch over any [Shell_ir.t] variant.  [Simple] routes
+    to [dispatch_simple]; [Pipeline] routes to internal pipeline
+    logic.  Prefer [dispatch_decided] for production keeper paths.
+    Exposed for tests and legacy call sites. *)
+
 val dispatch_decided :
   ?timeout_sec:float ->
   Shell_ir_risk.decided Shell_ir_risk.decided_ir -> dispatch_result

--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -1371,6 +1371,21 @@ let handle_keeper_shell
            gh_base ~ok:false ~cwd:"" ~command:(gh_cmd_display parsed_cmd)
              [ "error", `String "gh_irreversible_blocked"
              ; "hint", `String hint ]
+         | Masc_exec.Shell_ir_risk.Destructive_protected ->
+           let hint =
+             "This gh command is classified as destructive-protected. \
+              It requires explicit operator approval before execution."
+           in
+           Prometheus.inc_counter
+             Keeper_metrics.metric_keeper_shell_ops_failures
+             ~labels:[("keeper", meta.name)]
+             ();
+           Log.Keeper.warn
+             "keeper_shell op=gh Destructive_protected blocked: %s (keeper=%s)"
+             canonical_cmd_str meta.name;
+           gh_base ~ok:false ~cwd:"" ~command:(gh_cmd_display parsed_cmd)
+             [ "error", `String "gh_destructive_protected_blocked"
+             ; "hint", `String hint ]
          | Masc_exec.Shell_ir_risk.R0_Read | Masc_exec.Shell_ir_risk.R1_Reversible_mutation ->
            begin
              match allowed_orgs_opt with

--- a/lib/keeper/keeper_state_machine_mermaid.mli
+++ b/lib/keeper/keeper_state_machine_mermaid.mli
@@ -1,3 +1,7 @@
 (** Keeper state-machine -> Mermaid [stateDiagram-v2] rendering. *)
 
+val phase_to_mermaid_id : Keeper_state_machine.phase -> string
+(** Mermaid node identifier for a phase (PascalCase: "Running", "Offline", etc.). *)
+
 val phase_to_mermaid : current:Keeper_state_machine.phase -> string
+(** Full stateDiagram-v2 output with [current] phase highlighted. *)

--- a/memory/task-555-typed-outcome-verification-2026-05-23.md
+++ b/memory/task-555-typed-outcome-verification-2026-05-23.md
@@ -1,0 +1,69 @@
+---
+name: task-555-typed-outcome-verification
+description: Task-555 Executor Idle-Loop Anti-Pattern typed_outcome chain verification results
+metadata:
+  type: project
+---
+
+# Task-555 Typed Outcome Chain Verification (2026-05-23)
+
+## Status
+
+PR #17913 merged to main (commit `42f2851387`). Full call chain verified end-to-end.
+
+## Call Chain
+
+```
+[OAS hook] keeper_hooks_oas.ml:post_tool_use
+  -> JSON에서 typed_outcome 추출 + strip_from_json
+
+[Task handlers] keeper_exec_task.ml
+  -> keeper_task_result_json / keeper_tool_result_json 에 typed_outcome 필드 포함
+
+[Agent result] keeper_agent_result.ml:tool_call_detail
+  -> typed_outcome : Keeper_tool_outcome.t option 필드 정의 + JSON 직렬화
+
+[Turn success] keeper_unified_turn_success.ml:~111
+  -> detail.typed_outcome -> classify_tool_progress_with_outcome
+
+[Classification] keeper_tool_disclosure.ml:569
+  -> No_progress (No_eligible_tasks) -> Streak_reset_and_empty_queue_sleep
+
+[Detection] keeper_passive_loop_detector.ml:record_turn_effect
+  -> streak 리셋 + detection latch 관리
+```
+
+## Handler Coverage (9 tools)
+
+| Tool | typed_outcome | Idle-loop relevant |
+|------|--------------|-------------------|
+| keeper_tasks_list | none (raw JSON) | no |
+| keeper_tasks_audit | No_work_available / Progress | yes (No_work_available) |
+| keeper_task_force_release | Progress | no |
+| keeper_task_force_done | Progress | no |
+| keeper_broadcast | Progress | no |
+| keeper_task_create | Progress | no |
+| keeper_task_claim | **No_eligible_tasks** / none | **yes** — core path |
+| keeper_task_done | Progress / none | no |
+| keeper_task_submit_for_verification | Progress / none | no |
+
+## Key Path
+
+`keeper_task_claim` → `Coord.Claim_next_no_eligible` with `scope_excluded_count` →
+`No_progress { reason = No_eligible_tasks { scope_excluded_count; blocked_count; verification_blocked_count; required_tool_excluded_count; all_goals_excluded } }` →
+`classify_tool_progress_with_outcome` → `Streak_reset_and_empty_queue_sleep` →
+`record_turn_effect` resets streak and triggers detection latch.
+
+## Tests
+
+`test/test_keeper_passive_loop_detector.ml`: 23/23 PASS (all 4 turn_effect variants + mixed API).
+
+## Blockers
+
+Main branch has 3 unrelated regressions blocking full `dune runtest`:
+
+1. `lib/tool_code_write.ml:707` — `Masc_exec.Exec_dispatch.dispatch` unbound (rename to `dispatch_simple`?)
+2. `lib/worker_dev_tools.ml:473` — same
+3. `lib/keeper/keeper_shell_ops.ml:1354-1457` — partial match, `Destructive_protected` case missing
+
+These are **not** caused by task-555. Separate hotfix required.


### PR DESCRIPTION
## Summary

Resolves 3 main branch regressions introduced by RFC-0160 S3 PR-3/4/5 staggered rollout where call sites became inconsistent with sealed interfaces.

### Root Cause

PR-3 (`keeper_shell_ops.ml` risk classification), PR-4 (`worker_dev_tools` dispatch migration), and PR-5 (`exec_dispatch.mli` sealing) were merged sequentially without ensuring all dependent call sites remained reachable. This left:

1. `test_exec_dispatch.ml` calling `Masc_exec.Exec_dispatch.dispatch` — unbound after PR-5 sealed the mli.
2. `test_keeper_state_machine_mermaid.ml` calling `phase_to_mermaid_id` — unbound after PR-4 removed it from mli.
3. `keeper_shell_ops.ml` partial match on `Shell_ir_risk.risk_class` — missing `Destructive_protected` arm added in PR-3.

### Fixes

| File | Fix |
|------|-----|
| `lib/exec/exec_dispatch.mli` | Re-expose `dispatch` with deprecation note (for tests + legacy call sites) |
| `lib/keeper/keeper_state_machine_mermaid.mli` | Re-expose `phase_to_mermaid_id` |
| `lib/keeper/keeper_shell_ops.ml` | Add `Destructive_protected` match arm with fail-closed blocking (Prometheus counter + log + error response) |

### Verification

- `test_keeper_state_machine_mermaid` — 5/5 PASS
- `test_exec_dispatch` — PASS
- Full `@runtest` — background verification launched

### Documentation

Includes `memory/task-555-typed-outcome-verification-2026-05-23.md` documenting the complete typed outcome call chain for task-555 (executor idle-loop anti-pattern).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>