### PR TITLE
core(set_util): remove dead exports of_list_with, count_distinct

### DIFF
--- a/lib/core/set_util.mli
+++ b/lib/core/set_util.mli
@@ -7,22 +7,8 @@
     (strings, ints, tuples) without a functor instance, and (b) the linear
     O(N) bucket model matches the existing call sites' allocation profile.
 
-    Note: [Hashtbl.t] is exposed concretely in the return type of
-    [of_list_with], so a future swap to [Set.Make] is NOT a single-module
-    edit — it would break callers that hold the table directly. If the
     backing representation needs to change, hide it behind an abstract
     type [`'k t`] in this interface first. *)
-
-(** [of_list_with key xs] builds a membership set keyed by [key x] for each
-    [x] in [xs]. Duplicates collapse via [Hashtbl.replace]. One linear pass.
-    Default capacity 16 (matches existing call sites). *)
-val of_list_with : ('a -> 'b) -> 'a list -> ('b, unit) Hashtbl.t
-
-(** [count_distinct key xs] counts the number of distinct [Some k] values
-    produced by [key] across [xs]. Elements where [key x = None] are
-    ignored. Two-pass equivalent of [List.filter_map key xs |> List.sort_uniq
-    compare |> List.length] but in O(N) time with no intermediate list. *)
-val count_distinct : ('a -> 'b option) -> 'a list -> int
 
 (** [count_difference xs ~present ~absent] counts distinct keys produced by
     [present] that are NOT also produced by [absent]. Implementation: one


### PR DESCRIPTION
## Summary

Remove `val of_list_with` and `val count_distinct` from `lib/core/set_util.mli` — zero external callers each.

### Audit
- `of_list_with`: 0 qualified callers, 0 unqualified (no `open` / `include`)
- `count_distinct`: 0 qualified callers, 0 unqualified
- Retained: `count_difference` (3 callers)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>