### PR TITLE
docker(spawn_throttle): remove dead exports effective_concurrency, configured_max

### DIFF
--- a/lib/docker_spawn_throttle.mli
+++ b/lib/docker_spawn_throttle.mli
@@ -33,12 +33,3 @@ val with_slot : (unit -> 'a) -> 'a
 
     Exceptions from [f] propagate; the slot is always released. *)
 
-val effective_concurrency : unit -> int
-(** [effective_concurrency ()] reports the current cap.
-    Returns [1] while [Keeper_fd_pressure.active ()] is true (degraded
-    serialization), the configured maximum otherwise. Observability
-    only — not a synchronization primitive. *)
-
-val configured_max : unit -> int
-(** [configured_max ()] reports the configured upper bound (post-env
-    resolution), independent of degraded state. *)


### PR DESCRIPTION
## Summary

Remove `val effective_concurrency` and `val configured_max` from `lib/docker_spawn_throttle.mli` — zero external callers each.

### Audit
- `effective_concurrency`: 0 qualified callers, 0 unqualified (no `open` / `include`)
- `configured_max`: 0 qualified callers, 0 unqualified
- Retained: `with_slot` (17 callers)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>