### PR TITLE
http(protocol_detect): remove dead exports detect_from_fd, protocol_to_string

### DIFF
--- a/lib/http_protocol_detect.mli
+++ b/lib/http_protocol_detect.mli
@@ -10,31 +10,12 @@
 
     Internal helpers (the [h2_preface_prefix] string constant
     and the [h2_preface_len] derived integer) are hidden —
-    callers consume only the [protocol] variant, the two
-    detector entry points, and the printable converter. *)
+    callers consume only the [protocol] variant and the
+    detector entry point. *)
 
 type protocol =
   | Http1
   | Http2
-
-val detect_from_fd :
-  Unix.file_descr ->
-  (protocol, string) result
-(** [detect_from_fd fd] peeks the first bytes of [fd] using
-    [MSG_PEEK] and classifies the protocol.
-
-    Returns [Ok Http2] when the peek matches the H2 preface
-    prefix, [Ok Http1] for any other observed bytes (including
-    a partial read shorter than the preface — any valid H2
-    client sends the full preface immediately).
-
-    [Ok Http1] is also returned for [EAGAIN] / [EWOULDBLOCK]
-    on a non-blocking socket — an in-flight HTTP/1.1 request
-    is the most likely cause.
-
-    Returns [Error msg] for [recv = 0] (peer closed before
-    sending) and for any other [Unix.Unix_error]
-    (formatted via [Unix.error_message]). *)
 
 val detect :
   _ Eio.Net.stream_socket ->
@@ -45,7 +26,3 @@ val detect :
 
     Returns [Error "no Unix FD available on this socket"] when
     the flow has no Unix FD (e.g. an in-memory transport). *)
-
-val protocol_to_string : protocol -> string
-(** ["HTTP/1.1"] / ["HTTP/2"] — printable form for log lines and
-    metric labels. *)


### PR DESCRIPTION
## Summary

Remove `val detect_from_fd` and `val protocol_to_string` from `lib/http_protocol_detect.mli` — zero external callers each.

### Audit
- `detect_from_fd`: 0 qualified callers, 0 unqualified (no `open` / `include`)
- `protocol_to_string`: 0 qualified callers, 0 unqualified
- Retained: `detect` (1 caller)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>