### PR TITLE
feat(health): expose autoboot throttle limit and source (#17192)

### DIFF
--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -667,6 +667,10 @@ let keeper_fleet_safety_health_json
            || no_running_fibers
            || low_running_fiber_margin
            || reaction_capacity_below_target) )
+    ; "autoboot_throttle_limit"
+    , `Int Keeper_keepalive.keeper_turn_throttle_limit
+    ; ( "autoboot_throttle_source"
+      , `String (Config_boot_overrides.source "MASC_KEEPER_AUTOBOOT_MAX") )
     ]
 
 let take limit values =

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1115,6 +1115,10 @@ let test_health_json_surfaces_durable_paused_keepers () =
             (fleet_safety |> member "reaction_capacity_shortfall_count" |> to_int);
           Alcotest.(check bool) "health fleet asks for operator action" true
             (fleet_safety |> member "operator_action_required" |> to_bool);
+          Alcotest.(check int) "health exposes autoboot throttle limit" 32
+            (fleet_safety |> member "autoboot_throttle_limit" |> to_int);
+          Alcotest.(check string) "health exposes autoboot throttle source" "default"
+            (fleet_safety |> member "autoboot_throttle_source" |> to_string);
           Alcotest.(check string) "health reaction ledger degraded"
             "degraded"
             (reaction_ledger |> member "status" |> to_string);


### PR DESCRIPTION
## Summary
- Adds `autoboot_throttle_limit` (int) and `autoboot_throttle_source` (string) to `keeper_fleet_safety` health JSON
- Source is `"env"` | `"toml"` (boot_override) | `"default"`, determined by `Config_boot_overrides.source`
- Test assertion: default scenario returns `32` with source `"default"`

## Why
During the 2026-05-21 incident, an env var override (`MASC_KEEPER_AUTOBOOT_MAX=24`) silently defeated a TOML `autoboot_max=3` setting, and the health endpoint provided no visibility into which source was active.

## Test plan
- [x] `server_routes_http_runtime.ml` compiles (dune build passes for the modified module)
- [x] Test assertion added in `test_server_runtime_bootstrap.ml`
- [ ] Full CI build blocked by pre-existing `Masc_exec.Exec_shell_adapter` path mismatch on main (unrelated)
- [ ] Manual: start server with TOML-only → verify `"source": "toml"` in `/health?full=1`
- [ ] Manual: start server with env override → verify `"source": "env"` and effective limit matches env value

Closes #17192

🤖 Generated with [Claude Code](https://claude.com/claude-code)