### PR TITLE
refactor(lib): remove dead exports from agent_sdk_log_bridge.mli

### DIFF
--- a/lib/agent_sdk_log_bridge.mli
+++ b/lib/agent_sdk_log_bridge.mli
@@ -9,18 +9,6 @@
 
     Should be called exactly once during server bootstrap. *)
 
-val render_record_message : Agent_sdk.Log.record -> string
-(** Render an OAS log record into the human-readable message string that
-    masc-mcp writes to stderr / the structured ring. This interpolates
-    printf-style templates and normalizes known structured OAS messages
-    into an operator-friendly form. *)
-
-val effective_level : Agent_sdk.Log.record -> Log.level
-(** Normalize the OAS record severity before forwarding it into masc-mcp.
-    This preserves upstream levels by default, but promotes specific
-    operator-actionable warn-level failures on the keeper main path to
-    [Error]. *)
-
 val install : unit -> unit
 (** Register the OAS → masc-mcp log sink as a global OAS sink.  Call
     once before any keeper turn fires an LLM call.  Idempotent via an


### PR DESCRIPTION
## Summary
Remove dead exports from `lib/agent_sdk_log_bridge.mli`.

## Audit
- `render_record_message`: 0 qualified callers, 0 open/include/alias
- `effective_level`: 0 qualified callers, 0 open/include/alias

## Retained
- `install`: 1 caller

## Verification
- `dune build` clean
- No callers in `lib/` or `test/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)