### PR TITLE
refactor(lib): remove dead export from cascade_event_bridge.mli

### DIFF
--- a/lib/cascade/cascade_event_bridge.mli
+++ b/lib/cascade/cascade_event_bridge.mli
@@ -21,17 +21,6 @@ val start :
   bus:Agent_sdk.Event_bus.t ->
   unit
 
-(** Same as {!start}, but with an explicit drain interval.
-    Exposed so tests can run the bridge without waiting for the
-    production default interval. *)
-val start_with_interval :
-  drain_interval_s:float ->
-  sw:Eio.Switch.t ->
-  clock:_ Eio.Time.clock ->
-  config:Coord.config ->
-  bus:Agent_sdk.Event_bus.t ->
-  unit
-
 (** Serialize a single OAS event to SSE JSON.
     Exposed for unit testing. *)
 val native_event_to_json : Agent_sdk.Event_bus.event -> Yojson.Safe.t option


### PR DESCRIPTION
## Summary
Remove dead export from `lib/cascade/cascade_event_bridge.mli`.

## Audit
- `start_with_interval`: 0 qualified callers, 0 unqualified via `open Cascade_event_bridge`

## Retained
- `start`: 2 qualified callers, 2 files with `open Cascade_event_bridge`
- `native_event_to_json`: 3 qualified callers, 2 files with `open Cascade_event_bridge`

## Verification
- `dune build` clean
- No external callers for removed export

🤖 Generated with [Claude Code](https://claude.com/claude-code)