### PR TITLE
refactor(lib): remove dead export from execution_mode.mli

### DIFF
--- a/lib/cdal_runtime/execution_mode.mli
+++ b/lib/cdal_runtime/execution_mode.mli
@@ -13,7 +13,6 @@ type t =
 [@@deriving yojson, show, eq, ord]
 
 val to_string : t -> string
-val of_string : string -> (t, string) result
 
 (** [can_serve ~requested ~effective] returns [true] iff
     [effective <= requested] in the ordering [Diagnose < Draft < Execute].


### PR DESCRIPTION
## Summary
Remove dead export from `lib/cdal_runtime/execution_mode.mli`.

## Audit
- `of_string`: 0 qualified callers, 0 open/include/alias

## Retained
- `to_string`: 9 callers
- `can_serve`: 1 caller

## Verification
- `dune build` clean
- No external callers for removed export

🤖 Generated with [Claude Code](https://claude.com/claude-code)