### PR TITLE
refactor(lib): remove dead export from risk_class.mli

### DIFF
--- a/lib/cdal_runtime/risk_class.mli
+++ b/lib/cdal_runtime/risk_class.mli
@@ -14,7 +14,6 @@ type t =
 [@@deriving yojson, show, eq, ord]
 
 val to_string : t -> string
-val of_string : string -> (t, string) result
 
 (** Maximum allowed execution mode for this risk class.
     [None] means the run should be rejected outright. *)


### PR DESCRIPTION
## Summary
Remove dead export from `lib/cdal_runtime/risk_class.mli`.

## Audit
- `of_string`: 0 qualified callers, 0 open/include/alias

## Retained
- `to_string`: 3 callers
- `max_mode`: 1 caller

## Verification
- `dune build` clean
- No external callers for removed export

🤖 Generated with [Claude Code](https://claude.com/claude-code)