### PR TITLE
refactor(lib): remove dead export from executor_pool_ref.mli

### DIFF
--- a/lib/core/executor_pool_ref.mli
+++ b/lib/core/executor_pool_ref.mli
@@ -11,8 +11,3 @@ val get : unit -> Eio.Executor_pool.t option
 val set : Eio.Executor_pool.t -> unit
 (** Install the pool reference. Idempotent overwrite. *)
 
-val submit_or_inline : ?weight:float -> (unit -> 'a) -> 'a
-(** Run [f] on the executor pool when available, else inline in the
-    caller's fiber. [Eio.Cancel.Cancelled] is re-raised so structured
-    concurrency is preserved; other pool-side exceptions trigger
-    inline fallback with a warn log. *)


### PR DESCRIPTION
## Summary
Remove dead export from `lib/core/executor_pool_ref.mli`.

## Audit
- `submit_or_inline`: 0 qualified callers, 0 open/include/alias

## Retained
- `get`: 1 caller
- `set`: 1 caller

## Verification
- `dune build` clean
- No external callers for removed export

🤖 Generated with [Claude Code](https://claude.com/claude-code)