### PR TITLE
Dashboard typed label helpers: exact-match guard + splitParametric

### DIFF
--- a/dashboard/src/components/fsm-hub-types.test.ts
+++ b/dashboard/src/components/fsm-hub-types.test.ts
@@ -3,6 +3,7 @@ import {
   extractLaneValue,
   displayState,
   fmtDuration,
+  failureReasonLabel,
   STATE_DISPLAY_NAMES,
   LANE_LABELS,
   INVARIANT_LABELS,
@@ -156,6 +157,30 @@ describe('constants', () => {
   it('MAX_OBSERVATIONS and MAX_TRANSITION_HISTORY are positive', () => {
     expect(MAX_OBSERVATIONS).toBeGreaterThan(0)
     expect(MAX_TRANSITION_HISTORY).toBeGreaterThan(0)
+  })
+})
+
+describe('failureReasonLabel', () => {
+  it('maps known bases to Korean', () => {
+    expect(failureReasonLabel('heartbeat_consecutive_failures')).toBe('하트비트 연속 실패')
+    expect(failureReasonLabel('exception')).toBe('런타임 예외')
+  })
+
+  it('preserves parametric detail after the base', () => {
+    expect(failureReasonLabel('heartbeat_consecutive_failures(3)')).toBe('하트비트 연속 실패(3)')
+    expect(failureReasonLabel('tool_required_unsatisfied(code:detail)')).toBe('필수 도구 미충족(code:detail)')
+  })
+
+  it('falls back to raw string for unknown bases', () => {
+    expect(failureReasonLabel('mystery_failure')).toBe('mystery_failure')
+    expect(failureReasonLabel('unknown(42)')).toBe('unknown(42)')
+  })
+
+  it('returns null for empty / null / undefined inputs', () => {
+    expect(failureReasonLabel(null)).toBeNull()
+    expect(failureReasonLabel(undefined)).toBeNull()
+    expect(failureReasonLabel('')).toBeNull()
+    expect(failureReasonLabel('   ')).toBeNull()
   })
 })
 

--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -240,7 +240,7 @@ export function displayState(value: string): string {
  *  the `(detail)` portion verbatim so operators retain the parametric
  *  payload while reading a Korean label. Unknown bases fall back to
  *  the raw string. */
-const FAILURE_REASON_BASE_LABELS: Record<string, string> = {
+const FAILURE_REASON_BASE_LABELS = {
   heartbeat_consecutive_failures: '하트비트 연속 실패',
   turn_consecutive_failures: '턴 연속 실패',
   stale_turn_timeout: 'Stale 턴 시간 초과',
@@ -251,17 +251,33 @@ const FAILURE_REASON_BASE_LABELS: Record<string, string> = {
   ambiguous_partial_commit: '부분 commit 모호',
   fiber_unresolved: 'Fiber 미해결',
   exception: '런타임 예외',
+} as const
+
+type FailureReasonBase = keyof typeof FAILURE_REASON_BASE_LABELS
+
+function isFailureReasonBase(value: string): value is FailureReasonBase {
+  return Object.prototype.hasOwnProperty.call(FAILURE_REASON_BASE_LABELS, value)
+}
+
+/** Split a parametric string `<base>(<detail>)` at the first '('.
+ *  Returns `[base, detail]` where detail includes the '('.
+ *  If no '(' is found, returns `[whole, null]`.
+ *  Mirrors the backend wire format emitted by
+ *  `Keeper_registry_types.failure_reason_to_string`. */
+function splitParametric(value: string): [string, string | null] {
+  const idx = value.indexOf('(')
+  if (idx < 0) return [value, null]
+  return [value.slice(0, idx), value.slice(idx)]
 }
 
 export function failureReasonLabel(value: string | null | undefined): string | null {
   if (!value) return null
   const trimmed = value.trim()
   if (!trimmed) return null
-  const parenIdx = trimmed.indexOf('(')
-  const base = parenIdx >= 0 ? trimmed.slice(0, parenIdx) : trimmed
+  const [base, detail] = splitParametric(trimmed)
+  if (!isFailureReasonBase(base)) return trimmed
   const koreanBase = FAILURE_REASON_BASE_LABELS[base]
-  if (!koreanBase) return trimmed
-  return parenIdx >= 0 ? `${koreanBase}${trimmed.slice(parenIdx)}` : koreanBase
+  return detail ? `${koreanBase}${detail}` : koreanBase
 }
 
 /** Korean labels for `execution.outcome` / `keeper.latest_execution_outcome`.

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -186,7 +186,7 @@ function canonicalTerminalCode(code: string | null): string | null {
   return code
 }
 
-function canonicalTerminalSummary(code: string | null, summary: string | null | undefined): string | null {
+function canonicalTerminalSummary(_code: string | null, summary: string | null | undefined): string | null {
   return summary?.trim() || null
 }
 

--- a/dashboard/src/components/keeper-supervisor-helpers.test.ts
+++ b/dashboard/src/components/keeper-supervisor-helpers.test.ts
@@ -15,6 +15,15 @@ describe('categorizeCrashReason', () => {
     expect(categorizeCrashReason('exception_unhandled')).toBe('exception')
   })
 
+  it('prefers exact match when backend emits category name directly', () => {
+    expect(categorizeCrashReason('heartbeat')).toBe('heartbeat')
+    expect(categorizeCrashReason('turn')).toBe('turn')
+    expect(categorizeCrashReason('fiber')).toBe('fiber')
+    expect(categorizeCrashReason('exception')).toBe('exception')
+    // 'other' is the fallback, not a real category to match
+    expect(categorizeCrashReason('other')).toBe('other')
+  })
+
   it('falls back to other for unknown / empty / nullish reasons', () => {
     expect(categorizeCrashReason('mystery')).toBe('other')
     expect(categorizeCrashReason('')).toBe('other')

--- a/dashboard/src/components/keeper-supervisor-helpers.ts
+++ b/dashboard/src/components/keeper-supervisor-helpers.ts
@@ -28,6 +28,11 @@ const CRASH_PREFIX_MAP: ReadonlyArray<{ readonly prefix: string; readonly catego
 export function categorizeCrashReason(reason: string | null | undefined): CrashCategory {
   if (!reason) return 'other'
   const lower = reason.toLowerCase()
+  // Defensive exact-match: if backend emits the category name directly
+  // (e.g. "heartbeat" instead of "heartbeat_timeout"), prefer that
+  // over prefix heuristic so "heartbeat" does not collide with an
+  // unrelated longer prefix.
+  if (CRASH_CATEGORY_KEYS.includes(lower as CrashCategory)) return lower as CrashCategory
   for (const { prefix, category } of CRASH_PREFIX_MAP) {
     if (lower.startsWith(prefix)) return category
   }


### PR DESCRIPTION
## Summary
Dashboard 문자열 분류기의 typed variant로의 단계적 전환 Phase 0.

### 변경 내용
- `FAILURE_REASON_BASE_LABELS`: `Record<string,string>` → `as const` + `isFailureReasonBase` type guard
- `splitParametric` 헬퍼 추가: wire format `<base>(<detail>)`를 `[base, detail]`로 분리
- `failureReasonLabel` 리팩토링: typed lookup + null detail handling
- `categorizeCrashReason`: prefix heuristic 전 exact-match guard 추가

### 테스트
- `fsm-hub-types.test.ts`: `failureReasonLabel` 4개 케이스 추가
- `keeper-supervisor-helpers.test.ts`: exact-match guard 케이스 추가
- 총 35/35 pass

### 범위 외 (향후 RFC-0089 sister)
- `keeper-composite.ts`의 `string()` 스키마 → discriminated union 전환은 API contract 변경이 필요하여 별도 RFC로 분리
- `STATE_DISPLAY_NAMES`, `TERMINAL_REASON_CODE_LABELS` 등 나머지 `Record<string,string>`는 Phase 1에서 처리

🤖 Generated with [Claude Code](https://claude.com/claude-code)