### PR TITLE
refactor(lib): remove dead export from sandbox_target.mli

### DIFF
--- a/lib/exec/sandbox_target.mli
+++ b/lib/exec/sandbox_target.mli
@@ -46,4 +46,3 @@ val host : unit -> t
     [Keeper_turn_sandbox_runtime] or any other keeper-side construct. *)
 val docker : image:string -> runner:runner -> ?pipeline_runner:pipeline_runner -> unit -> t
 
-val pp : Format.formatter -> t -> unit


### PR DESCRIPTION
## Summary
Remove dead export from `lib/exec/sandbox_target.mli`.

## Audit
- `pp`: 0 qualified callers, 0 open/include/alias

## Retained
- `host`: 21 callers
- `docker`: 1 caller

## Verification
- `dune build` clean
- No external callers for removed export

🤖 Generated with [Claude Code](https://claude.com/claude-code)