### PR TITLE
refactor(exec): remove dead export Shell_ir.pp_arg

### DIFF
--- a/lib/exec/shell_ir.mli
+++ b/lib/exec/shell_ir.mli
@@ -34,5 +34,4 @@ type t =
   | Simple of simple
   | Pipeline of t list            (** length >= 2 — head | middle* | tail *)
 
-val pp_arg : Format.formatter -> arg -> unit
 val pp : Format.formatter -> t -> unit


### PR DESCRIPTION
## Summary

Remove dead `.mli` export `Shell_ir.pp_arg` — zero external callers.

## Audit Evidence

| Prong | Result |
|-------|--------|
| Qualified-name grep (`Shell_ir.pp_arg`) | 0 callers |
| Facade re-export (`include module type of`) | none |
| `open Shell_ir` unqualified | none |
| Local alias (`module X = Shell_ir`) | none |
| Parent `.ml` internal calls | 3 (internal only, not external) |

**Conclusion**: `pp_arg` is defined in `shell_ir.ml` and called only within that same module. No external module references it. Safe to remove from the interface.

## Retained Exports

- `default_meta` — 24+ external callers (LIVE)
- `pp` — 3 external callers (LIVE)

## Verification

- [x] `dune build` passes
- [x] No behavioral change (interface narrowing only)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>