### PR TITLE
refactor(keeper): remove dead exports from Keeper_agent_result.mli

### DIFF
--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -10,8 +10,6 @@ type tool_call_detail =
   ; route_evidence : Yojson.Safe.t option
   }
 
-val tool_call_detail_to_json : tool_call_detail -> Yojson.Safe.t
-
 (** Result of a single Agent.run() keeper turn. *)
 type run_result =
   { response_text : string
@@ -34,15 +32,3 @@ type run_result =
   ; tool_surface : Keeper_agent_tool_surface.tool_surface_metrics
   }
 
-(** Legacy MASC-facing model label helper.
-
-    MASC no longer exposes concrete provider/model identity on status,
-    metrics, or dashboard surfaces; OAS owns that resolution. Kept for
-    schema compatibility and returns the neutral runtime lane label. *)
-val surface_model_used : run_result -> string
-
-(** Legacy MASC-facing resolved model helper.
-
-    Kept for schema compatibility and returns the neutral runtime lane label;
-    concrete provider/model identity belongs to OAS telemetry. *)
-val surface_resolved_model_id : run_result -> string


### PR DESCRIPTION
## Summary
Remove 3 dead `.mli` exports with zero external callers.

## Dead Exports
| Export | Callers |
|--------|---------|
| `tool_call_detail_to_json` | 0 |
| `surface_model_used` | 0 |
| `surface_resolved_model_id` | 0 |

## Retained
| Export | Callers |
|--------|---------|
| `tool_call_detail` (type) | used in type annotations |
| `run_result` (type) | used in type annotations |

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>