### PR TITLE
refactor(keeper): remove dead exports from Keeper_path_check_error.mli

### DIFF
--- a/lib/keeper/keeper_path_check_error.mli
+++ b/lib/keeper/keeper_path_check_error.mli
@@ -40,12 +40,3 @@ val to_message : t -> string
     so downstream tools that match on these messages keep their
     contract. *)
 
-val message_prefix : t -> string
-(** Stable lowercase prefix token used by downstream classifiers
-    (e.g. dashboard tool-quality). Always a strict prefix of the
-    lowercase form of [to_message]. *)
-
-val parse_prefix : string -> t option
-(** Inverse of [to_message] for the variant tag only — payload fields
-    are left empty / [None] since the typed module is intended for
-    classification, not full message reconstruction. *)


### PR DESCRIPTION
## Summary
Remove 2 dead .mli exports (message_prefix, parse_prefix) — 0 external callers.
Retained: to_message (4 callers via local open), type t.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>