### PR TITLE
refactor(keeper): remove dead test-only exports from Keeper_fsm_guard_runtime.mli

### DIFF
--- a/lib/keeper/keeper_fsm_guard_runtime.mli
+++ b/lib/keeper/keeper_fsm_guard_runtime.mli
@@ -24,10 +24,3 @@
 
 val wrap_unit : action:string -> stage:string -> (unit -> unit) -> unit
 
-(** Compatibility no-op retained for older tests.  The guard policy no
-    longer reads [MASC_FSM_GUARD_ASSERT]. *)
-val refresh_policy_for_test : unit -> unit
-
-(** Always [true]: guard violations always re-raise after incrementing
-    the violation counter. *)
-val assert_mode_for_test : unit -> bool


### PR DESCRIPTION
## Summary
Remove 2 dead test-only exports (refresh_policy_for_test, assert_mode_for_test).
Retained: wrap_unit (20 callers).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>