### PR TITLE
refactor(keeper): remove dead exports from Keeper_heartbeat_loop_scheduling.mli

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop_scheduling.mli
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.mli
@@ -8,15 +8,6 @@ type cascade_backpressure_decision =
       reason : string;
     }
 
-val cascade_backpressure_observation_reasons : reason:string -> string list
-
-val cascade_backpressure_decision :
-  cascade_resilience:Keeper_exec_preflight.cascade_resilience option ->
-  should_run_turn:bool ->
-  cascade_name:string ->
-  cascade_status:Keeper_health_probe.health_status ->
-  cascade_backpressure_decision
-
 type keepalive_scheduling_decision = {
   turn_decision : Keeper_world_observation.keeper_cycle_decision;
   requested_should_run_turn : bool;


### PR DESCRIPTION
## Summary
Remove 2 dead exports (cascade_backpressure_observation_reasons, cascade_backpressure_decision).
Retained: decide_keepalive_scheduling (1 caller), types.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>