### PR TITLE
refactor(keeper): remove dead export from Keeper_measurement.mli

### DIFF
--- a/lib/keeper/keeper_measurement.mli
+++ b/lib/keeper/keeper_measurement.mli
@@ -117,5 +117,4 @@ val capture :
 
 (** {1 Serialization} *)
 
-val threshold_params_to_json : threshold_params -> Yojson.Safe.t
 val measurement_snapshot_to_json : measurement_snapshot -> Yojson.Safe.t


### PR DESCRIPTION
## Summary
Remove dead export threshold_params_to_json (0 callers).
Retained: capture (2), measurement_snapshot_to_json (2), types.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>