### PR TITLE
feat(memory_hooks): wire computed_size through receipt for final-payload proof (OAS #3)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1501,10 +1501,13 @@ let run_turn
            |> Keeper_turn_terminal_code.to_wire
        in
        let cascade_observation = !receipt_cascade_observation_ref in
-       let extra_system_context_digest, extra_system_context_injected_size =
+       let ( extra_system_context_digest
+             , extra_system_context_computed_size
+             , extra_system_context_injected_size ) =
          match Memory_hooks.get_last_memory_injection meta.agent_name with
-         | Some (digest, size) -> Some digest, Some size
-         | None -> None, None
+         | Some (digest, computed, injected) ->
+           Some digest, Some computed, Some injected
+         | None -> None, None, None
        in
        let receipt =
          { Keeper_execution_receipt.keeper_name = meta.name
@@ -1579,8 +1582,8 @@ let run_turn
          ; started_at = receipt_started_at
          ; ended_at = receipt_ended_at
          ; extra_system_context_digest
+         ; extra_system_context_computed_size
          ; extra_system_context_injected_size
-         ; extra_system_context_computed_size = None
          ; pre_dispatch_compacted = ctx.pre_dispatch_compacted
          ; pre_dispatch_compaction_trigger = ctx.pre_dispatch_compaction_trigger
          ; pre_dispatch_compaction_before_tokens = ctx.pre_dispatch_compaction_before_tokens

--- a/lib/memory_hooks.ml
+++ b/lib/memory_hooks.ml
@@ -20,15 +20,16 @@
     @since v2.266.0 (RFC-MASC-004 Phase 2-3 — legacy functions removed) *)
 
 let last_memory_injection_mu = Stdlib.Mutex.create ()
-let last_memory_injection : (string, string * int) Hashtbl.t = Hashtbl.create 64
+let last_memory_injection : (string, string * int * int) Hashtbl.t =
+  Hashtbl.create 64
 
 let with_last_memory_injection_lock f =
   Stdlib.Mutex.lock last_memory_injection_mu;
   Fun.protect ~finally:(fun () -> Stdlib.Mutex.unlock last_memory_injection_mu) f
 
-let record_last_memory_injection agent_name digest size =
+let record_last_memory_injection agent_name digest computed_size injected_size =
   with_last_memory_injection_lock (fun () ->
-    Hashtbl.replace last_memory_injection agent_name (digest, size))
+    Hashtbl.replace last_memory_injection agent_name (digest, computed_size, injected_size))
 ;;
 
 let get_last_memory_injection agent_name =
@@ -275,6 +276,7 @@ let make
            record_last_memory_injection
              agent_name
              (Digest.to_hex (Digest.string mem_text))
+             (String.length mem_text)
              extra_system_context_chars_after;
            Agent_sdk.Hooks.AdjustParams
              { current_params with extra_system_context = extra })

--- a/lib/memory_hooks.mli
+++ b/lib/memory_hooks.mli
@@ -46,14 +46,17 @@ val make :
   unit ->
   Agent_sdk.Hooks.hooks
 
-val record_last_memory_injection : string -> string -> int -> unit
-(** Record the digest and final size of the last memory injection for an
-    agent. Thread-safe (Stdlib.Mutex). Overwrites any previous entry. *)
+val record_last_memory_injection : string -> string -> int -> int -> unit
+(** [record_last_memory_injection agent_name digest computed_size injected_size]
+    records the digest, computed memory text size, and final injected
+    extra_system_context size of the last memory injection for an agent.
+    Thread-safe (Stdlib.Mutex). Overwrites any previous entry. *)
 
-val get_last_memory_injection : string -> (string * int) option
-(** Retrieve the last recorded memory injection digest and size for an
-    agent. Thread-safe (Stdlib.Mutex). Returns [None] if no injection was
-    recorded since the last [Continue] branch or process start. *)
+val get_last_memory_injection : string -> (string * int * int) option
+(** Retrieve the last recorded memory injection digest, computed size, and
+    injected size for an agent. Thread-safe (Stdlib.Mutex). Returns [None]
+    if no injection was recorded since the last [Continue] branch or process
+    start. *)
 
 val clear_last_memory_injection : string -> unit
 (** Clear the recorded memory injection digest and size for an agent.

--- a/test/test_memory_hooks.ml
+++ b/test/test_memory_hooks.ml
@@ -503,26 +503,37 @@ let test_hook_slots_populated () =
 
 (* ── Memory injection recording tests (OAS checklist #3) ──────── *)
 
+let triple a b c =
+  let pp fmt (x, y, z) =
+    Format.fprintf fmt "(%a, %a, %a)" (Alcotest.pp a) x (Alcotest.pp b) y (Alcotest.pp c) z
+  in
+  let equal (x1, y1, z1) (x2, y2, z2) =
+    Alcotest.equal a x1 x2 && Alcotest.equal b y1 y2 && Alcotest.equal c z1 z2
+  in
+  Alcotest.testable pp equal
+
 let test_record_and_get_last_memory_injection () =
-  Memory_hooks.record_last_memory_injection "agent_a" "digest123" 456;
+  Memory_hooks.record_last_memory_injection "agent_a" "digest123" 400 456;
   let result = Memory_hooks.get_last_memory_injection "agent_a" in
-  check (option (pair string int)) "retrieves recorded injection" (Some ("digest123", 456)) result
+  check (option (triple string int int)) "retrieves recorded injection"
+    (Some ("digest123", 400, 456)) result
 
 let test_get_last_memory_injection_returns_none_when_missing () =
   let result = Memory_hooks.get_last_memory_injection "unknown_agent_xyz" in
-  check (option (pair string int)) "returns None for unknown agent" None result
+  check (option (triple string int int)) "returns None for unknown agent" None result
 
 let test_record_last_memory_injection_overwrites () =
-  Memory_hooks.record_last_memory_injection "agent_b" "first" 100;
-  Memory_hooks.record_last_memory_injection "agent_b" "second" 200;
+  Memory_hooks.record_last_memory_injection "agent_b" "first" 100 150;
+  Memory_hooks.record_last_memory_injection "agent_b" "second" 200 250;
   let result = Memory_hooks.get_last_memory_injection "agent_b" in
-  check (option (pair string int)) "overwrites previous injection" (Some ("second", 200)) result
+  check (option (triple string int int)) "overwrites previous injection"
+    (Some ("second", 200, 250)) result
 
 let test_clear_last_memory_injection () =
-  Memory_hooks.record_last_memory_injection "agent_clear" "digest" 123;
+  Memory_hooks.record_last_memory_injection "agent_clear" "digest" 100 123;
   Memory_hooks.clear_last_memory_injection "agent_clear";
   let result = Memory_hooks.get_last_memory_injection "agent_clear" in
-  check (option (pair string int)) "cleared" None result
+  check (option (triple string int int)) "cleared" None result
 
 let test_memory_injection_cleared_on_continue () =
   let tmp_dir = Filename.temp_dir "masc_test_mh" "" in
@@ -542,7 +553,7 @@ let test_memory_injection_cleared_on_continue () =
   (match decision with
    | Agent_sdk.Hooks.Continue ->
      let result = Memory_hooks.get_last_memory_injection "test_clear" in
-     check (option (pair string int)) "cleared on Continue" None result
+     check (option (triple string int int)) "cleared on Continue" None result
    | Agent_sdk.Hooks.AdjustParams _ ->
      let result = Memory_hooks.get_last_memory_injection "test_clear" in
      check bool "has entry after AdjustParams" true (Option.is_some result);
@@ -554,7 +565,7 @@ let test_memory_injection_cleared_on_continue () =
      (match decision2 with
       | Agent_sdk.Hooks.Continue ->
         let result2 = Memory_hooks.get_last_memory_injection "test_clear" in
-        check (option (pair string int)) "cleared on second Continue" None result2
+        check (option (triple string int int)) "cleared on second Continue" None result2
       | _ -> ())
    | _ -> fail "unexpected decision");
   (try Sys.rmdir tmp_dir with _ -> ())
@@ -615,7 +626,7 @@ let test_execution_receipt_json_includes_memory_fields () =
     ; ended_at = "2024-01-01T00:00:01Z"
     ; extra_system_context_digest = Some "sha256:abc123"
     ; extra_system_context_injected_size = Some 789
-    ; extra_system_context_computed_size = None
+    ; extra_system_context_computed_size = Some 400
     ; pre_dispatch_compacted = false
     ; pre_dispatch_compaction_trigger = None
     ; pre_dispatch_compaction_before_tokens = None
@@ -626,10 +637,13 @@ let test_execution_receipt_json_includes_memory_fields () =
   let json = Keeper_execution_receipt.to_json receipt in
   let digest = Yojson.Safe.Util.(member "extra_system_context_digest" json) in
   let size = Yojson.Safe.Util.(member "extra_system_context_injected_size" json) in
+  let computed = Yojson.Safe.Util.(member "extra_system_context_computed_size" json) in
   check string "extra_system_context_digest in JSON" "sha256:abc123"
     (match digest with `String s -> s | _ -> "");
   check int "extra_system_context_injected_size in JSON" 789
-    (match size with `Int n -> n | `Intlit s -> int_of_string s | _ -> 0)
+    (match size with `Int n -> n | `Intlit s -> int_of_string s | _ -> 0);
+  check int "extra_system_context_computed_size in JSON" 400
+    (match computed with `Int n -> n | `Intlit s -> int_of_string s | _ -> 0)
 
 let test_execution_receipt_json_null_when_missing () =
   let receipt : Keeper_execution_receipt.t =


### PR DESCRIPTION
## Summary
- Hash table value: (string * int) → (string * int * int) for (digest, computed_size, injected_size)
- `record_last_memory_injection` now accepts `computed_size` arg
- `get_last_memory_injection` returns triple option
- `keeper_agent_run.ml`: wire `extra_system_context_computed_size` from Memory_hooks instead of hardcoding `None`
- Tests: update `memory_injection_record` suite for triple type, add `computed_size` JSON assertion in receipt test

## Verification
- [x] `dune exec test/test_memory_hooks.exe --` → 20/20 pass
- [x] Local `dune build` clean

## Related
OAS HTML analysis checklist item #3: Memory final-payload proof