### PR TITLE
fix(cascade): capacity backpressure retry_after_sec prevents keeper turn death loop

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,7 +14,7 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 382 unique knobs across 10 modules.
+**Total**: 380 unique knobs across 10 modules.
 
 **Typed getter classification**: 26/235 tagged (`operator`: 26, `algorithm`: 0, `unclassified`: 209).
 
@@ -62,41 +62,41 @@ the categorization roadmap. Newly-added typed getters in
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_ANTI_RATIONALIZATION_FAIL_MODE` | typed:string | unclassified | unclassified | 215 |  |
-| `MASC_ANTI_RATIONALIZATION_GATE2_FAIL_CLOSED` | typed:bool | unclassified | unclassified | 237 |  |
-| `MASC_AUTONOMY_MAX_STARVATION_TICKS` | typed:int | unclassified | unclassified | 87 | {1 Thompson Sampling / Agent Selection Configuration} Primary env vars: MASC_AUTONOMY_*. |
-| `MASC_AUTONOMY_QUIET_END` | typed:int | unclassified | unclassified | 79 | Quiet hours end (0-23). |
-| `MASC_AUTONOMY_QUIET_START` | typed:int | unclassified | unclassified | 75 | Quiet hours start (0-23). Keeper suppresses actions in this window. |
-| `MASC_AUTONOMY_STARVATION_BONUS_COEF` | typed:float | unclassified | unclassified | 90 |  |
-| `MASC_AUTONOMY_THOMPSON_WEIGHT` | typed:float | unclassified | unclassified | 93 |  |
-| `MASC_AUTONOMY_VOTE_DECAY_FACTOR` | typed:float | unclassified | unclassified | 96 |  |
-| `MASC_DASHBOARD_FIXTURE` | string_literal | n/a | n/a | 149 | Dashboard fixture name override. |
-| `MASC_DASHBOARD_FIXTURES_ENABLED` | feature_flag | n/a | n/a | 145 | Whether dashboard fixtures are enabled. Default: false. Re-readable within the process; this does not imply shell-lev... |
-| `MASC_DASHBOARD_GOVERNANCE_JUDGE_ENABLED` | feature_flag | n/a | n/a | 156 | Whether governance judge is enabled. Default: true. |
-| `MASC_DASHBOARD_GOVERNANCE_JUDGE_INTERVAL_SEC` | typed:int | unclassified | unclassified | 153 | Governance judge interval, clamped to >= 15s. Default: 60. |
-| `MASC_DEFAULT_CASCADE` | string_literal | n/a | n/a | 164 | Default cascade label (e.g. "gemini:pro,claude:sonnet"). |
-| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 172 | Default model id. |
-| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 168 | Default provider name. |
-| `MASC_EVENT_BUFFER_SIZE` | typed:int | unclassified | unclassified | 117 | A2A event buffer size per subscription. Caps the in-memory event list to prevent unbounded growth. |
-| `MASC_GOAL_DISPATCH_RUNTIME` | typed:string | unclassified | unclassified | 188 | Goal dispatch runtime. Default: "task". |
-| `MASC_GOAL_MODELS` | string_literal | n/a | n/a | 184 | Goal models (comma-separated). |
-| `MASC_INFERENCE_CACHE_ENABLED` | feature_flag | n/a | n/a | 28 | Enable inference response cache (L1+L2). |
-| `MASC_INFERENCE_CACHE_L1_MAX_ENTRIES` | typed:int | unclassified | unclassified | 46 | L1 in-memory entry cap. BUG-015: Reduced from 2048 to 512 — unbounded growth with 2048 default caused excessive mem... |
-| `MASC_INFERENCE_CACHE_MAX_PROMPT_CHARS` | typed:int | unclassified | unclassified | 36 | Skip caching for oversized prompts (character count). |
-| `MASC_INFERENCE_CACHE_MAX_TEMP` | typed:float | unclassified | unclassified | 40 | Cache only deterministic temperatures (default exact 0.0). |
-| `MASC_INFERENCE_CACHE_TTL_SEC` | typed:int | unclassified | unclassified | 32 | Default TTL for inference response cache (seconds). |
+| `MASC_ANTI_RATIONALIZATION_FAIL_MODE` | typed:string | unclassified | unclassified | 211 |  |
+| `MASC_ANTI_RATIONALIZATION_GATE2_FAIL_CLOSED` | typed:bool | unclassified | unclassified | 233 |  |
+| `MASC_AUTONOMY_MAX_STARVATION_TICKS` | typed:int | unclassified | unclassified | 83 | {1 Thompson Sampling / Agent Selection Configuration} Primary env vars: MASC_AUTONOMY_*. |
+| `MASC_AUTONOMY_QUIET_END` | typed:int | unclassified | unclassified | 75 | Quiet hours end (0-23). |
+| `MASC_AUTONOMY_QUIET_START` | typed:int | unclassified | unclassified | 71 | Quiet hours start (0-23). Keeper suppresses actions in this window. |
+| `MASC_AUTONOMY_STARVATION_BONUS_COEF` | typed:float | unclassified | unclassified | 86 |  |
+| `MASC_AUTONOMY_THOMPSON_WEIGHT` | typed:float | unclassified | unclassified | 89 |  |
+| `MASC_AUTONOMY_VOTE_DECAY_FACTOR` | typed:float | unclassified | unclassified | 92 |  |
+| `MASC_DASHBOARD_FIXTURE` | string_literal | n/a | n/a | 145 | Dashboard fixture name override. |
+| `MASC_DASHBOARD_FIXTURES_ENABLED` | feature_flag | n/a | n/a | 141 | Whether dashboard fixtures are enabled. Default: false. Re-readable within the process; this does not imply shell-lev... |
+| `MASC_DASHBOARD_GOVERNANCE_JUDGE_ENABLED` | feature_flag | n/a | n/a | 152 | Whether governance judge is enabled. Default: true. |
+| `MASC_DASHBOARD_GOVERNANCE_JUDGE_INTERVAL_SEC` | typed:int | unclassified | unclassified | 149 | Governance judge interval, clamped to >= 15s. Default: 60. |
+| `MASC_DEFAULT_CASCADE` | string_literal | n/a | n/a | 160 | Default cascade label (e.g. "gemini:pro,claude:sonnet"). |
+| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 168 | Default model id. |
+| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 164 | Default provider name. |
+| `MASC_EVENT_BUFFER_SIZE` | typed:int | unclassified | unclassified | 113 | A2A event buffer size per subscription. Caps the in-memory event list to prevent unbounded growth. |
+| `MASC_GOAL_DISPATCH_RUNTIME` | typed:string | unclassified | unclassified | 184 | Goal dispatch runtime. Default: "task". |
+| `MASC_GOAL_MODELS` | string_literal | n/a | n/a | 180 | Goal models (comma-separated). |
+| `MASC_INFERENCE_CACHE_ENABLED` | feature_flag | n/a | n/a | 24 | Enable inference response cache (L1+L2). |
+| `MASC_INFERENCE_CACHE_L1_MAX_ENTRIES` | typed:int | unclassified | unclassified | 42 | L1 in-memory entry cap. BUG-015: Reduced from 2048 to 512 — unbounded growth with 2048 default caused excessive mem... |
+| `MASC_INFERENCE_CACHE_MAX_PROMPT_CHARS` | typed:int | unclassified | unclassified | 32 | Skip caching for oversized prompts (character count). |
+| `MASC_INFERENCE_CACHE_MAX_TEMP` | typed:float | unclassified | unclassified | 36 | Cache only deterministic temperatures (default exact 0.0). |
+| `MASC_INFERENCE_CACHE_TTL_SEC` | typed:int | unclassified | unclassified | 28 | Default TTL for inference response cache (seconds). |
 | `MASC_INFERENCE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 8 | Timeout for model API calls (seconds) |
-| `MASC_NEO4J_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 106 | Neo4j / zombie-cleanup interval (seconds). Controls the zero-zombie Pulse rhythm in the orchestrator. Clamped to >= 1... |
-| `MASC_OPERATOR_CACHE_TTL` | typed:float | unclassified | unclassified | 136 | Operator snapshot cache TTL (seconds). Default: 30. |
-| `MASC_OPERATOR_JUDGE_ENABLED` | feature_flag | n/a | n/a | 124 | Whether operator judge background loop is enabled. Default: true. |
-| `MASC_OPERATOR_JUDGE_INTERVAL_SEC` | typed:int | unclassified | unclassified | 127 | Operator judge interval, clamped to >= 15s. Default: 60. |
-| `MASC_OPERATOR_JUDGE_ROOM_TTL_SEC` | typed:int | unclassified | unclassified | 130 | Coord TTL for operator judge cleanup, clamped to >= 15s. Default: 60. |
-| `MASC_OPERATOR_JUDGE_SESSION_TTL_SEC` | typed:int | unclassified | unclassified | 133 | Session TTL for operator judge cleanup, clamped to >= 30s. Default: 300. |
-| `MASC_RATE_LIMIT_CLEANUP_INTERVAL_SEC` | typed:float | unclassified | unclassified | 62 | Cleanup interval for stale rate limit buckets (seconds) |
-| `MASC_RATE_LIMIT_ENTRY_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 66 | Max age for rate limit entries before cleanup (seconds) |
-| `MASC_ROUTING_CASCADE` | string_literal | n/a | n/a | 178 | Routing cascade for team session routing. Defaults to the logical [routes.routing] key; runtime callers normalize it ... |
-| `MASC_SPAWN_CACHE_POLICY` | typed:string | unclassified | unclassified | 52 | Spawn cache policy: - off - safe_only (GLM direct HTTP only, no MCP-tool side effects) |
-| `MASC_SSE_KEEPALIVE_SEC` | typed:float | unclassified | unclassified | 112 | SSE keepalive interval (seconds). Frequency of `: keepalive` frames on command-plane SSE streams. Clamped to >= 1.0 t... |
+| `MASC_NEO4J_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 102 | Neo4j / zombie-cleanup interval (seconds). Controls the zero-zombie Pulse rhythm in the orchestrator. Clamped to >= 1... |
+| `MASC_OPERATOR_CACHE_TTL` | typed:float | unclassified | unclassified | 132 | Operator snapshot cache TTL (seconds). Default: 30. |
+| `MASC_OPERATOR_JUDGE_ENABLED` | feature_flag | n/a | n/a | 120 | Whether operator judge background loop is enabled. Default: true. |
+| `MASC_OPERATOR_JUDGE_INTERVAL_SEC` | typed:int | unclassified | unclassified | 123 | Operator judge interval, clamped to >= 15s. Default: 60. |
+| `MASC_OPERATOR_JUDGE_ROOM_TTL_SEC` | typed:int | unclassified | unclassified | 126 | Coord TTL for operator judge cleanup, clamped to >= 15s. Default: 60. |
+| `MASC_OPERATOR_JUDGE_SESSION_TTL_SEC` | typed:int | unclassified | unclassified | 129 | Session TTL for operator judge cleanup, clamped to >= 30s. Default: 300. |
+| `MASC_RATE_LIMIT_CLEANUP_INTERVAL_SEC` | typed:float | unclassified | unclassified | 58 | Cleanup interval for stale rate limit buckets (seconds) |
+| `MASC_RATE_LIMIT_ENTRY_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 62 | Max age for rate limit entries before cleanup (seconds) |
+| `MASC_ROUTING_CASCADE` | string_literal | n/a | n/a | 174 | Routing cascade for team session routing. Defaults to the logical [routes.routing] key; runtime callers normalize it ... |
+| `MASC_SPAWN_CACHE_POLICY` | typed:string | unclassified | unclassified | 48 | Spawn cache policy: - off - safe_only (GLM direct HTTP only, no MCP-tool side effects) |
+| `MASC_SSE_KEEPALIVE_SEC` | typed:float | unclassified | unclassified | 108 | SSE keepalive interval (seconds). Frequency of `: keepalive` frames on command-plane SSE streams. Clamped to >= 1.0 t... |
 
 ## Env_config_keeper (84 knobs; typed classification 2/71)
 
@@ -226,7 +226,7 @@ the categorization roadmap. Newly-added typed getters in
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC` | string_literal | n/a | n/a | 132 |  |
+| `MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC` | string_literal | n/a | n/a | 114 |  |
 
 ## Env_config_runtime (116 knobs; typed classification 3/93)
 
@@ -375,9 +375,9 @@ the categorization roadmap. Newly-added typed getters in
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALLOW_ANONYMOUS_MUTATIONS` | string_literal | n/a | n/a | 29 |  |
-| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 637 |  |
-| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 641 |  |
-| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 643 |  |
+| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 635 |  |
+| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 639 |  |
+| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 641 |  |
 | `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 221 |  |
 | `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 295 |  |
 | `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 297 |  |
@@ -428,23 +428,23 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 168 |  |
 | `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 167 |  |
 | `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 215 |  |
-| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 735 |  |
-| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 771 |  |
-| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 783 |  |
-| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 683 |  |
-| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 685 |  |
-| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 687 |  |
-| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 689 |  |
-| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 715 |  |
+| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 733 |  |
+| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 769 |  |
+| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 781 |  |
+| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 681 |  |
+| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 683 |  |
+| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 685 |  |
+| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 687 |  |
+| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 713 |  |
 | `MASC_STRUCTURED_STATE` | string_literal | n/a | n/a | 151 |  |
 | `MASC_TELEMETRY_MAX_BYTES` | string_literal | n/a | n/a | 56 |  |
 | `MASC_TELEMETRY_RETENTION_DAYS` | string_literal | n/a | n/a | 53 |  |
-| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 751 |  |
-| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 753 |  |
+| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 749 |  |
+| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 751 |  |
 | `MASC_TLA_TRACE` | string_literal | n/a | n/a | 153 |  |
-| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 815 |  |
-| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 817 |  |
-| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 819 |  |
+| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 813 |  |
+| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 815 |  |
+| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 817 |  |
 | `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 93 |  |
 | `MASC_WS_SLICE_INDEX_ENABLED` | string_literal | n/a | n/a | 96 |  |
 

--- a/lib/cascade/cascade_client_capacity.ml
+++ b/lib/cascade/cascade_client_capacity.ml
@@ -72,9 +72,16 @@ let capacity url =
 
 type release = unit -> unit
 
+type acquire_result =
+  | Acquired of release
+  | Full of { retry_after_s : float option }
+  | Unregistered
+
+let default_retry_after_sec = 5.0
+
 let try_acquire url =
   match lookup url with
-  | None -> None
+  | None -> Unregistered
   | Some e ->
     (* Optimistic CAS on the atomic counter.  Loop to retry when
        another fiber bumps the count between read and CAS. *)
@@ -88,7 +95,7 @@ let try_acquire url =
           kind = Rejected_full;
           active_after = current;
         };
-        None
+        Full { retry_after_s = Some default_retry_after_sec }
       end
       else if Atomic.compare_and_set e.active current (current + 1) then (
         Cascade_client_capacity_history.record {
@@ -111,7 +118,7 @@ let try_acquire url =
             }
           end
         in
-        Some release)
+        Acquired release)
       else attempt ()
     in
     attempt ()

--- a/lib/cascade/cascade_client_capacity.mli
+++ b/lib/cascade/cascade_client_capacity.mli
@@ -12,11 +12,11 @@
 
     The counter is maintained by explicit [try_acquire] / release
     pairs at the cascade call site.  No timeout, no queueing, no
-    blocking — if no permit is free, [try_acquire] returns [None] and
-    the strategy's capacity filter will have already skipped this
+    blocking — if no permit is free, [try_acquire] returns [Full]
+    and the strategy's capacity filter will have already skipped this
     endpoint in its ordering.  Defense-in-depth: both the filter and
     the acquire check the same counter, so a race between filter and
-    acquire simply yields a [None] that the cascade treats as typed
+    acquire simply yields a [Full] that the cascade treats as typed
     capacity backpressure before trying the next candidate.
 
     @since 0.9.6 *)
@@ -106,21 +106,24 @@ type release = unit -> unit
 (** Idempotent release thunk.  Calling it twice is safe; the second
     call is a no-op. *)
 
-val try_acquire : string -> release option
-(** Non-blocking acquire.  Returns [Some release] when a slot was
-    obtained and the caller is now responsible for calling [release]
-    exactly once (via [Fun.protect], [Eio.Switch.on_release], or
-    explicit control flow).  Returns [None] when:
-    - [url] is not registered → unlimited, no counter maintained
-      (caller should treat [None] as "no client cap, go ahead");
-    - [url] is registered and [process_available = 0] → client capacity
-      unavailable; caller should treat [None] as typed backpressure and
-      try another candidate.
+type acquire_result =
+  | Acquired of release
+  | Full of { retry_after_s : float option }
+  | Unregistered
+(** Result of a non-blocking acquire.
 
-    Disambiguate these two [None] cases via {!capacity}: if
-    [capacity url = None] the URL is unregistered; otherwise it is
-    full. *)
+    - [Acquired release] — slot obtained; caller must call [release]
+      exactly once.
+    - [Full { retry_after_s }] — [url] is registered but all slots are
+      in use.  [retry_after_s] hints when the caller should retry.
+    - [Unregistered] — [url] has no declared capacity; caller should
+      treat this as "no client cap, go ahead". *)
+
+val try_acquire : string -> acquire_result
+(** Non-blocking acquire.  See {!acquire_result} for outcome semantics.
+
+    @since 0.9.6 *)
 
 val is_registered : string -> bool
 (** [is_registered url] is [true] iff [url] has a declared capacity.
-    Convenience for the caller's [try_acquire] disambiguation. *)
+    Convenience for disambiguating [Unregistered] from [Full]. *)

--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -1372,21 +1372,6 @@ let handle_keeper_shell
            gh_base ~ok:false ~cwd:"" ~command:(gh_cmd_display parsed_cmd)
              [ "error", `String "gh_irreversible_blocked"
              ; "hint", `String hint ]
-         | Masc_exec.Shell_ir_risk.Destructive_protected ->
-           let hint =
-             "This gh command is classified as destructive-protected. \
-              It requires explicit operator approval before execution."
-           in
-           Prometheus.inc_counter
-             Keeper_metrics.metric_keeper_shell_ops_failures
-             ~labels:[("keeper", meta.name)]
-             ();
-           Log.Keeper.warn
-             "keeper_shell op=gh Destructive_protected blocked: %s (keeper=%s)"
-             canonical_cmd_str meta.name;
-           gh_base ~ok:false ~cwd:"" ~command:(gh_cmd_display parsed_cmd)
-             [ "error", `String "gh_destructive_protected_blocked"
-             ; "hint", `String hint ]
          | Masc_exec.Shell_ir_risk.R0_Read | Masc_exec.Shell_ir_risk.R1_Reversible_mutation ->
            begin
              match allowed_orgs_opt with

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -923,12 +923,12 @@ let run_named
       Cascade_runtime_candidate.capacity_key candidate |> String.trim
     in
     if String.equal capacity_key ""
-       || not (Cascade_client_capacity.is_registered capacity_key)
     then `No_client_capacity
     else
       match Cascade_client_capacity.try_acquire capacity_key with
-      | Some release -> `Acquired (capacity_key, release)
-      | None -> `Full capacity_key
+      | Unregistered -> `No_client_capacity
+      | Acquired release -> `Acquired (capacity_key, release)
+      | Full { retry_after_s } -> `Full (capacity_key, retry_after_s)
   in
   let emit_capacity_blocked_manifest ~capacity_key =
     emit_runtime_manifest
@@ -1333,7 +1333,7 @@ let run_named
       let is_last = rest = [] in
       let attempt_index = max 1 (candidate_count - List.length rest) in
       match acquire_client_capacity_slot candidate with
-      | `Full capacity_key ->
+      | `Full (capacity_key, retry_after_s) ->
         emit_capacity_blocked_manifest ~capacity_key;
         record_cascade_attempt candidate ~outcome:(`Failure "client_capacity_full") ();
         Cascade_legacy_runner.record_fallback_event capture
@@ -1352,7 +1352,7 @@ let run_named
         try_cascade ~on_success ?resume_checkpoint ?per_provider_timeout_s
           ~pre_dispatch_required_tool_rejections_rev
           ~last_capacity_backpressure:
-            (Client_capacity, capacity_detail, None)
+            (Client_capacity, capacity_detail, retry_after_s)
           rest last_err
       | (`No_client_capacity | `Acquired _) as capacity_slot ->
       let capacity_release =

--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -575,6 +575,54 @@ let test_history_try_acquire_records_events () =
           "cli:claude_code" a.key
       | _ -> fail "expected 3 events"))
 
+let test_try_acquire_unregistered_returns_unregistered () =
+  C.unregister_all ();
+  match C.try_acquire "http://never-registered.example/api" with
+  | Unregistered -> ()
+  | Acquired _ -> fail "unregistered URL should not acquire"
+  | Full _ -> fail "unregistered URL should not report Full"
+
+let test_try_acquire_full_returns_retry_after () =
+  C.unregister_all ();
+  C.register ~url:"cli:test_retry" ~max_concurrent:1;
+  let acquired =
+    match C.try_acquire "cli:test_retry" with
+    | Acquired r -> r
+    | Unregistered | Full _ -> fail "first acquire should succeed"
+  in
+  (* Capacity is now saturated. *)
+  (match C.try_acquire "cli:test_retry" with
+   | Full { retry_after_s } ->
+     check (option (float 0.01)) "retry_after_s is Some 5.0"
+       (Some 5.0) retry_after_s
+   | Acquired _ -> fail "second acquire should be Full"
+   | Unregistered -> fail "registered URL should not be Unregistered");
+  acquired ()
+
+let test_try_acquire_full_then_release_then_acquire () =
+  C.unregister_all ();
+  C.register ~url:"cli:test_cycle" ~max_concurrent:1;
+  let release1 =
+    match C.try_acquire "cli:test_cycle" with
+    | Acquired r -> r
+    | Unregistered | Full _ -> fail "first acquire should succeed"
+  in
+  (* Exhaust capacity. *)
+  (match C.try_acquire "cli:test_cycle" with
+   | Full _ -> ()
+   | Acquired _ -> fail "should be Full at cap"
+   | Unregistered -> fail "registered URL should not be Unregistered");
+  (* Release and re-acquire. *)
+  release1 ();
+  (match C.try_acquire "cli:test_cycle" with
+   | Acquired r -> r ()
+   | Unregistered | Full _ -> fail "re-acquire after release should succeed");
+  (* Verify counter is back to zero via snapshot. *)
+  match C.snapshot () with
+  | (url, info) :: _ when url = "cli:test_cycle" ->
+    check int "active after full cycle" 0 info.process_active
+  | _ -> ()
+
 (* ── Prometheus counter coverage (LT-6) ──────────────────
 
    The counter increment runs outside the ring-buffer mutex and uses the
@@ -926,6 +974,12 @@ let () =
         test_history_snapshot_kind_filter;
       test_case "try_acquire records events on registered URL" `Quick
         test_history_try_acquire_records_events;
+      test_case "try_acquire unregistered returns Unregistered" `Quick
+        test_try_acquire_unregistered_returns_unregistered;
+      test_case "try_acquire Full carries retry_after_sec" `Quick
+        test_try_acquire_full_returns_retry_after;
+      test_case "try_acquire release cycle frees slot" `Quick
+        test_try_acquire_full_then_release_then_acquire;
       test_case "record bumps Prometheus counter with label" `Quick
         test_history_prometheus_counter_increments;
       test_case "dashboard JSON exposes provenance" `Quick

--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -230,15 +230,16 @@ let test_client_capacity_acquire_release () =
   C.unregister_all ();
   C.register ~url:"http://x:11434" ~max_concurrent:1;
   match C.try_acquire "http://x:11434" with
-  | None -> fail "first acquire should succeed"
-  | Some release ->
+  | Unregistered | Full _ -> fail "first acquire should succeed"
+  | Acquired release ->
     (match C.capacity "http://x:11434" with
      | Some info -> check int "active = 1 after acquire" 1 info.process_active
      | None -> fail "capacity disappeared");
     (* Second acquire must fail. *)
     (match C.try_acquire "http://x:11434" with
-     | Some _ -> fail "second acquire on 1-slot must fail"
-     | None -> ());
+     | Acquired _ -> fail "second acquire on 1-slot must fail"
+     | Unregistered -> fail "endpoint unregistered unexpectedly"
+     | Full _ -> ());
     release ();
     (match C.capacity "http://x:11434" with
      | Some info ->
@@ -249,8 +250,8 @@ let test_client_capacity_release_idempotent () =
   C.unregister_all ();
   C.register ~url:"http://y:11434" ~max_concurrent:1;
   match C.try_acquire "http://y:11434" with
-  | None -> fail "acquire failed"
-  | Some release ->
+  | Unregistered | Full _ -> fail "acquire failed"
+  | Acquired release ->
     release ();
     release ();  (* second release must be a no-op, not underflow *)
     match C.capacity "http://y:11434" with
@@ -284,8 +285,8 @@ let test_client_capacity_unregistered_url () =
   check (option int) "capacity = None for unregistered URL"
     None (Option.map (fun (i : T.capacity_info) -> i.total)
             (C.capacity "http://nope:9999"));
-  check bool "try_acquire = None for unregistered URL"
-    true (C.try_acquire "http://nope:9999" = None)
+  check bool "try_acquire = Unregistered for unregistered URL"
+    true (C.try_acquire "http://nope:9999" = Unregistered)
 
 let test_client_capacity_clamp_max () =
   C.unregister_all ();
@@ -336,13 +337,17 @@ let test_cli_acquire_blocks_at_cap () =
     ~capacity_keys:["cli:claude_code"]
     ~max_concurrent:1;
   match C.try_acquire "cli:claude_code" with
-  | None -> fail "first acquire should succeed"
-  | Some release ->
-    check bool "second acquire returns None at cap"
-      true (C.try_acquire "cli:claude_code" = None);
+  | Unregistered | Full _ -> fail "first acquire should succeed"
+  | Acquired release ->
+    check bool "second acquire returns Full at cap"
+      true
+      (match C.try_acquire "cli:claude_code" with
+       | Full _ -> true | _ -> false);
     release ();
     check bool "after release: capacity available again"
-      true (C.try_acquire "cli:claude_code" <> None)
+      true
+      (match C.try_acquire "cli:claude_code" with
+       | Acquired _ -> true | _ -> false)
 
 let test_cli_idempotent_registration () =
   C.unregister_all ();
@@ -376,8 +381,8 @@ let test_snapshot_reflects_active_acquires () =
   C.unregister_all ();
   C.register ~url:"cli:codex_cli" ~max_concurrent:2;
   match C.try_acquire "cli:codex_cli" with
-  | None -> fail "first acquire failed"
-  | Some _release ->
+  | Unregistered | Full _ -> fail "first acquire failed"
+  | Acquired _release ->
     let entries = C.snapshot () in
     match List.assoc_opt "cli:codex_cli" entries with
     | None -> fail "snapshot missing entry"
@@ -546,11 +551,13 @@ let test_history_try_acquire_records_events () =
   C.register ~url:"cli:claude_code" ~max_concurrent:1;
   (* First acquire → Acquired recorded *)
   (match C.try_acquire "cli:claude_code" with
-   | None -> fail "first acquire should succeed"
-   | Some release ->
+   | Unregistered | Full _ -> fail "first acquire should succeed"
+   | Acquired release ->
      (* Second acquire → Rejected_full recorded *)
      check bool "second acquire hits cap"
-       true (C.try_acquire "cli:claude_code" = None);
+       true
+       (match C.try_acquire "cli:claude_code" with
+        | Full _ -> true | _ -> false);
      release ();
      let events = CH.snapshot () in
      (* Expected newest-first: Released, Rejected_full, Acquired. *)


### PR DESCRIPTION
## Problem

cascade_client_capacity.try_acquire returned None on capacity full, giving keeper_turn_driver no retry_after information. All cascade candidates were skipped without backoff hints, leading to No_providers_available exhaustion. Without retry_after_sec the keeper immediately retried, creating a system-wide killing loop.

This manifests as fleet drops below target after recoverable capacity failures (#17218).

## Changes

- **lib/cascade/cascade_client_capacity.ml{,i}**: Change try_acquire return from option to 3-variant acquire_result: `Acquired release | Full { retry_after_s } | Unregistered`
- **lib/keeper/keeper_turn_driver.ml**: Pass retry_after_s through last_capacity_backpressure to the cascade strategy's capacity filter
- **lib/keeper/keeper_shell_ops.ml**: Remove dead Destructive_protected match branch (pre-existing warning treated as error)
- **test/test_cascade_strategy.ml**: Add 3 regression tests verifying retry_after_sec semantics

## Test Results

45/45 cascade_strategy tests pass.

Closes #17218

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>