### PR TITLE
refactor(coord): remove dead export agent_parse_error_snapshot from coord_lifecycle.mli

### DIFF
--- a/lib/coord/coord_lifecycle.mli
+++ b/lib/coord/coord_lifecycle.mli
@@ -6,11 +6,6 @@ open Coord_utils
 open Coord_state
 open Coord_broadcast
 
-(** JSON snapshot used when an agent file fails to parse — surfaces
-    [agent_name], [agent_file], and a short error message. *)
-val agent_parse_error_snapshot :
-  agent_name:string -> agent_file:string -> Yojson.Safe.t
-
 val join :
   Coord_utils_backend_setup.config ->
   agent_name:string ->


### PR DESCRIPTION
## Summary
Remove dead export `val agent_parse_error_snapshot` from `lib/coord/coord_lifecycle.mli`.

## 5-Prong Audit
- **Qualified-name grep**: `Coord_lifecycle.agent_parse_error_snapshot` → 0 hits
- **Open/unqualified**: `open Coord_lifecycle` → 0 files
- **Include/facade**: `include Coord_lifecycle` in `lib/coord.ml`, but `Coord.agent_parse_error_snapshot` → 0 hits
- **Test callers**: 0 hits in `test/`
- **Parent .ml internal use**: 2 internal callers in `coord_lifecycle.ml` (registry parse-error diagnostics)

## Decision
Function is used internally (2 call sites within `coord_lifecycle.ml`) but has **zero external callers**. Removing from `.mli` makes it internal-only with no behavior change.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>