### PR TITLE
refactor(docker): remove dead exports effective_concurrency, configured_max from docker_spawn_throttle.mli

### DIFF
--- a/lib/docker_spawn_throttle.mli
+++ b/lib/docker_spawn_throttle.mli
@@ -33,12 +33,3 @@ val with_slot : (unit -> 'a) -> 'a
 
     Exceptions from [f] propagate; the slot is always released. *)
 
-val effective_concurrency : unit -> int
-(** [effective_concurrency ()] reports the current cap.
-    Returns [1] while [Keeper_fd_pressure.active ()] is true (degraded
-    serialization), the configured maximum otherwise. Observability
-    only — not a synchronization primitive. *)
-
-val configured_max : unit -> int
-(** [configured_max ()] reports the configured upper bound (post-env
-    resolution), independent of degraded state. *)


### PR DESCRIPTION
## Summary
Remove two dead exports from `lib/docker_spawn_throttle.mli`.

## Dead Export Audit

| Export | External Callers | Test Callers | Status |
|--------|-----------------|--------------|--------|
| `with_slot` | 15+ (keeper/worker/docker clients) | — | **RETAINED** |
| `effective_concurrency` | 0 | 0 | **REMOVED** |
| `configured_max` | 0 | 0 | **REMOVED** |

## 5-Prong Verification
- **Qualified-name grep**: `Docker_spawn_throttle.effective_concurrency` → 0; `configured_max` → 0
- **Open/unqualified**: `open Docker_spawn_throttle` → 0 files
- **Include/facade**: `include Docker_spawn_throttle` → 0 files
- **Test callers**: 0 hits in `test/`
- **.ml internal use**: functions remain defined in `.ml` for future observability wiring

No behavior change for any consumer.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>