### PR TITLE
refactor(multimodal): remove dead exports empty, of_json from provenance_stub.mli

### DIFF
--- a/lib/multimodal/provenance_stub.mli
+++ b/lib/multimodal/provenance_stub.mli
@@ -20,11 +20,4 @@ type t = {
   created_at : float;
 }
 
-val empty : created_by:string -> created_at:float -> t
-(** [empty ~created_by ~created_at] constructs a provenance with no
-    origin artifacts. Useful when an artifact is the start of a new
-    creation chain (no predecessors). *)
-
 val to_json : t -> Yojson.Safe.t
-
-val of_json : Yojson.Safe.t -> (t, string) result


### PR DESCRIPTION
## Summary
Remove two dead exports from `lib/multimodal/provenance_stub.mli`.

## Dead Export Audit

| Export | External Callers | Test Callers | Status |
|--------|-----------------|--------------|--------|
| `to_json` | 1 (artifact.ml) | — | **RETAINED** |
| `empty` | 0 | 0 | **REMOVED** |
| `of_json` | 0 | 0 | **REMOVED** |

## 5-Prong Verification
- **Qualified-name grep**: `Provenance_stub.empty` → 0; `Provenance_stub.of_json` → 0
- **Open/unqualified**: `open Provenance_stub` → 0 files
- **Include/facade**: `include Provenance_stub` → 0 files
- **Test callers**: 0 hits in `test/`
- **.ml internal use**: `empty` unused internally; `of_json` unused internally

Callers construct `Provenance_stub.t` records directly or via `Multimodal.create.provenance_of`. No behavior change.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>