### PR TITLE
refactor(otel): remove dead export tool_span_attrs from otel_dispatch_hook.mli

### DIFF
--- a/lib/otel/otel_dispatch_hook.mli
+++ b/lib/otel/otel_dispatch_hook.mli
@@ -16,10 +16,6 @@
 
     @since 2.103.0 *)
 
-val tool_span_attrs : Tool_result.t -> Opentelemetry.key_value list
-(** Build the full tool-span payload used by the post-hook. Exposed so tests can
-    pin the legacy + GenAI dual-emission contract without installing a collector. *)
-
 val with_test_span_emitter :
   enabled:bool ->
   emit_span:(name:string -> attrs:Opentelemetry.key_value list -> unit) ->


### PR DESCRIPTION
## Summary
Remove dead export `val tool_span_attrs` from `lib/otel/otel_dispatch_hook.mli`.

## Dead Export Audit

| Export | External Callers | Test Callers | Status |
|--------|-----------------|--------------|--------|
| `install` | 1 (server_bootstrap_loops.ml) | — | **RETAINED** |
| `with_test_span_emitter` | — | 1 (test_otel_genai.ml) | **RETAINED** |
| `tool_span_attrs` | 0 | 0 | **REMOVED** |

## 5-Prong Verification
- **Qualified-name grep**: `Otel_dispatch_hook.tool_span_attrs` → 0
- **Open/unqualified**: `open Otel_dispatch_hook` → 0 files
- **Include/facade**: `include Otel_dispatch_hook` → 0 files
- **Test callers**: 0 hits in `test/`
- **.ml internal use**: function remains defined in `.ml`; no consumer impact

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>