### PR TITLE
refactor: remove dead exports from Host_fd_pressure_poller

### DIFF
--- a/lib/server/host_fd_pressure_poller.mli
+++ b/lib/server/host_fd_pressure_poller.mli
@@ -21,12 +21,3 @@ val start : sw:Eio.Switch.t -> clock:_ Eio.Time.clock -> unit
     [Server_bootstrap_loops.start_background_maintenance]. Cancelled
     when [sw] terminates. *)
 
-val state_file_path : unit -> string
-(** [state_file_path ()] returns the configured pressure state path.
-    Default [/tmp/masc-host-pressure.state]; env-overrideable via
-    [MASC_HOST_FD_PRESSURE_STATE_FILE]. Exposed for testing. *)
-
-val poll_interval_sec : unit -> float
-(** [poll_interval_sec ()] returns the poll cadence. Default 1.0s;
-    env-overrideable via [MASC_HOST_FD_PRESSURE_POLL_INTERVAL_SEC],
-    bounded [0.5, 60.0]. *)


### PR DESCRIPTION
## Summary

Remove dead exports [state_file_path] and [poll_interval_sec] from [Host_fd_pressure_poller.mli]. Both functions remain in the .ml as they have internal callers within [start].

## Audit findings

| Function | External callers | Test callers | Internal callers | Action |
|----------|-----------------|--------------|------------------|--------|
| [state_file_path] | 0 | 0 | 1 ([start]) | Removed from .mli only |
| [poll_interval_sec] | 0 | 0 | 1 ([start]) | Removed from .mli only |
| [start] | 1+ | - | - | **Retained** |

## Verification

- No [open Host_fd_pressure_poller] or [include Host_fd_pressure_poller] anywhere
- No qualified refs ([Host_fd_pressure_poller.\<fn\>]) for removed functions
- Test file references to [poll_interval_sec] are labeled arguments to [Server_bootstrap_loops.start], not calls to [Host_fd_pressure_poller.poll_interval_sec]

🤖 Generated with [Claude Code](https://claude.com/claude-code)