### PR TITLE
feat(keeper): expose oas_internal_cascade_allowed in receipt and cascade observation

### DIFF
--- a/lib/cascade/cascade_legacy_runner.ml
+++ b/lib/cascade/cascade_legacy_runner.ml
@@ -26,6 +26,7 @@ type cascade_observation = {
   fallback_events : cascade_fallback_event list;
   attempt_details_available : bool;
   attempt_details_source : string;
+  oas_internal_cascade_allowed : bool;
 }
 
 and cascade_attempt = {
@@ -156,6 +157,7 @@ let cascade_observation_of_candidates ~cascade_name ?strategy ~configured_labels
     ?(fallback_events = [])
     ?(attempt_details_available = false)
     ?(attempt_details_source = "opaque_named_cascade")
+    ?(oas_internal_cascade_allowed = false)
     () : cascade_observation =
   let candidate_models =
     List.init (max 0 candidate_count) (fun _ -> public_runtime_model_label)
@@ -193,6 +195,7 @@ let cascade_observation_of_candidates ~cascade_name ?strategy ~configured_labels
     fallback_events;
     attempt_details_available;
     attempt_details_source;
+    oas_internal_cascade_allowed;
   }
 
 (* ================================================================ *)
@@ -403,13 +406,16 @@ let cascade_metrics_for_candidates ~candidate_count:(_ : int) () =
 
 let cascade_observation_with_metrics ~cascade_name ?strategy ~configured_labels
     ~(candidate_count : int)
-    ~(selected_model_raw : string option) ~(capture : cascade_metrics_capture) () =
+    ~(selected_model_raw : string option) ~(capture : cascade_metrics_capture)
+    ?(oas_internal_cascade_allowed = false)
+    () =
   cascade_observation_of_candidates ~cascade_name ?strategy ~configured_labels
     ~candidate_count ~selected_model_raw
     ~attempts:(List.rev capture.attempts_rev)
     ~fallback_events:(List.rev capture.fallback_events_rev)
     ~attempt_details_available:true
     ~attempt_details_source:"oas_metrics_callbacks"
+    ~oas_internal_cascade_allowed
     ()
 
 (* ================================================================ *)
@@ -441,6 +447,7 @@ let cascade_observation_to_json (obs : cascade_observation) : Yojson.Safe.t =
           (List.map cascade_fallback_event_to_json obs.fallback_events) );
       ("attempt_details_available", `Bool obs.attempt_details_available);
       ("attempt_details_source", `String obs.attempt_details_source);
+      ("oas_internal_cascade_allowed", `Bool obs.oas_internal_cascade_allowed);
     ]
 
 let get_cascade_audit_store store_opt =

--- a/lib/cascade/cascade_legacy_runner.mli
+++ b/lib/cascade/cascade_legacy_runner.mli
@@ -73,6 +73,7 @@ type cascade_observation = {
   fallback_events : cascade_fallback_event list;
   attempt_details_available : bool;
   attempt_details_source : string;
+  oas_internal_cascade_allowed : bool;
 }
 (** Per-turn cascade execution snapshot.  [attempts] is
     in chronological order (the internal capture stores
@@ -160,6 +161,7 @@ val cascade_observation_with_metrics :
   candidate_count:int ->
   selected_model_raw:string option ->
   capture:cascade_metrics_capture ->
+  ?oas_internal_cascade_allowed:bool ->
   unit ->
   cascade_observation
 (** Materialises a {!cascade_observation} from a finished

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1562,6 +1562,10 @@ let run_turn
               | Some obs -> obs.fallback_applied
               | None -> false)
          ; cascade_outcome = cascade_outcome_of_observation cascade_observation
+         ; oas_internal_cascade_allowed =
+             (match cascade_observation with
+              | Some obs -> obs.oas_internal_cascade_allowed
+              | None -> false)
          ; degraded_retry_applied
          ; degraded_retry_cascade =
              Option.map

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -306,6 +306,7 @@ type t =
   ; cascade_attempt_count : int
   ; cascade_fallback_applied : bool
   ; cascade_outcome : cascade_outcome
+  ; oas_internal_cascade_allowed : bool
   ; degraded_retry_applied : bool
   ; degraded_retry_cascade : cascade_name option
   ; fallback_reason : Keeper_error_classify.degraded_retry_reason option
@@ -881,6 +882,7 @@ let to_json (receipt : t) =
           ; "attempt_count", `Int receipt.cascade_attempt_count
           ; "fallback_applied", `Bool receipt.cascade_fallback_applied
           ; "outcome", `String (cascade_outcome_to_string receipt.cascade_outcome)
+          ; "oas_internal_cascade_allowed", `Bool receipt.oas_internal_cascade_allowed
           ; "degraded_retry_applied", `Bool receipt.degraded_retry_applied
           ; ( "degraded_retry_cascade"
             , match receipt.degraded_retry_cascade with

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -231,6 +231,7 @@ type t =
   ; cascade_attempt_count : int
   ; cascade_fallback_applied : bool
   ; cascade_outcome : cascade_outcome
+  ; oas_internal_cascade_allowed : bool
   ; degraded_retry_applied : bool
   ; degraded_retry_cascade : cascade_name option
   ; fallback_reason : Keeper_error_classify.degraded_retry_reason option

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -1642,7 +1642,9 @@ let run_named
             ~cascade_name:error_cascade_name
             ?strategy:!cascade_strategy_name_ref ~configured_labels
             ~candidate_count ~selected_model_raw:(success_selected_model_raw candidate)
-            ~capture ()
+            ~capture
+          ~oas_internal_cascade_allowed:(Keeper_cascade_engine.allows_oas_internal_cascade cascade_engine)
+          ()
         in
         let result = { result with cascade_observation = Some observation } in
                 Cascade_legacy_runner.record_cascade ~keeper_name
@@ -1675,7 +1677,9 @@ let run_named
                ~cascade_name:error_cascade_name
                ?strategy:!cascade_strategy_name_ref ~configured_labels
                ~candidate_count ~selected_model_raw:(success_selected_model_raw candidate)
-               ~capture ()
+               ~capture
+          ~oas_internal_cascade_allowed:(Keeper_cascade_engine.allows_oas_internal_cascade cascade_engine)
+          ()
            in
            let result = { result with cascade_observation = Some observation } in
                    Cascade_legacy_runner.record_cascade ~keeper_name
@@ -1707,7 +1711,9 @@ let run_named
                ~cascade_name:error_cascade_name
                ?strategy:!cascade_strategy_name_ref ~configured_labels
                ~candidate_count ~selected_model_raw:error_selected_model_raw
-               ~capture ()
+               ~capture
+          ~oas_internal_cascade_allowed:(Keeper_cascade_engine.allows_oas_internal_cascade cascade_engine)
+          ()
            in
            Cascade_legacy_runner.record_cascade ~keeper_name
              ~cascade_name:error_cascade_name
@@ -1738,7 +1744,9 @@ let run_named
                ~cascade_name:error_cascade_name
                ?strategy:!cascade_strategy_name_ref ~configured_labels
                ~candidate_count ~selected_model_raw:(success_selected_model_raw candidate)
-               ~capture ()
+               ~capture
+          ~oas_internal_cascade_allowed:(Keeper_cascade_engine.allows_oas_internal_cascade cascade_engine)
+          ()
            in
            let result = { result with cascade_observation = Some observation } in
                    Cascade_legacy_runner.record_cascade ~keeper_name

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -303,6 +303,7 @@ let record_pre_dispatch_terminal_observation
     ; pre_dispatch_compaction_trigger = None
     ; pre_dispatch_compaction_before_tokens = None
     ; pre_dispatch_compaction_after_tokens = None
+    ; oas_internal_cascade_allowed = false
     }
   in
   let receipt_path =

--- a/test/test_cascade_catalog_runtime_yojson.ml
+++ b/test/test_cascade_catalog_runtime_yojson.ml
@@ -298,6 +298,7 @@ let mk_observation ?(attempts = []) ?(fallback_events = []) () :
     fallback_events;
     attempt_details_available = true;
     attempt_details_source = "oas_metrics_callbacks";
+    oas_internal_cascade_allowed = false;
   }
 
 let nth_attempt_model_id json idx =

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -1317,6 +1317,7 @@ let test_keeper_zombie_field_contracts () =
       pre_dispatch_compaction_trigger = None;
       pre_dispatch_compaction_before_tokens = None;
       pre_dispatch_compaction_after_tokens = None;
+      oas_internal_cascade_allowed = false;
     }
   in
   let json = R.to_json receipt in

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -558,6 +558,7 @@ let append_execution_receipt
       pre_dispatch_compaction_trigger = None;
       pre_dispatch_compaction_before_tokens = None;
       pre_dispatch_compaction_after_tokens = None;
+      oas_internal_cascade_allowed = false;
     }
   in
   let tm = Unix.gmtime (Unix.gettimeofday ()) in

--- a/test/test_dashboard_goals.ml
+++ b/test/test_dashboard_goals.ml
@@ -178,6 +178,7 @@ let append_keeper_receipt
       pre_dispatch_compaction_trigger = None;
       pre_dispatch_compaction_before_tokens = None;
       pre_dispatch_compaction_after_tokens = None;
+      oas_internal_cascade_allowed = false;
     }
   in
   Keeper_execution_receipt.append config receipt

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -853,6 +853,7 @@ let append_execution_receipt
       pre_dispatch_compaction_trigger = None;
       pre_dispatch_compaction_before_tokens = None;
       pre_dispatch_compaction_after_tokens = None;
+      oas_internal_cascade_allowed = false;
     }
   in
   let tm = Unix.gmtime (Unix.gettimeofday ()) in

--- a/test/test_keeper_pause_broadcast.ml
+++ b/test/test_keeper_pause_broadcast.ml
@@ -118,6 +118,7 @@ let mk_receipt
   ; pre_dispatch_compaction_trigger = None
   ; pre_dispatch_compaction_before_tokens = None
   ; pre_dispatch_compaction_after_tokens = None
+  ; oas_internal_cascade_allowed = false
   }
 ;;
 

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -3680,6 +3680,7 @@ let test_metrics_surface_model_prefers_successful_cascade_label () =
             ]
         ; attempt_details_available = true
         ; attempt_details_source = "oas_metrics_callbacks"
+        ; oas_internal_cascade_allowed = false
         }
       ()
   in
@@ -3743,6 +3744,7 @@ let test_metrics_resolved_model_id_prefers_last_attempt_id () =
         ; fallback_events = []
         ; attempt_details_available = true
         ; attempt_details_source = "oas_metrics_callbacks"
+        ; oas_internal_cascade_allowed = false
         }
       ()
   in
@@ -4408,6 +4410,7 @@ let test_append_metrics_snapshot_includes_cascade_observation () =
                    ]
                ; attempt_details_available = true
                ; attempt_details_source = "oas_metrics_callbacks"
+               ; oas_internal_cascade_allowed = false
                }
          }
        in

--- a/test/test_memory_hooks.ml
+++ b/test/test_memory_hooks.ml
@@ -620,6 +620,7 @@ let test_execution_receipt_json_includes_memory_fields () =
     ; pre_dispatch_compaction_trigger = None
     ; pre_dispatch_compaction_before_tokens = None
     ; pre_dispatch_compaction_after_tokens = None
+    ; oas_internal_cascade_allowed = false
     }
   in
   let json = Keeper_execution_receipt.to_json receipt in
@@ -691,6 +692,7 @@ let test_execution_receipt_json_null_when_missing () =
     ; pre_dispatch_compaction_trigger = None
     ; pre_dispatch_compaction_before_tokens = None
     ; pre_dispatch_compaction_after_tokens = None
+    ; oas_internal_cascade_allowed = false
     }
   in
   let json = Keeper_execution_receipt.to_json receipt in

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -859,6 +859,7 @@ let test_cascade_observation_json_includes_fallback_fields () =
         ]
     ; attempt_details_available = true
     ; attempt_details_source = "oas_metrics_callbacks"
+    ; oas_internal_cascade_allowed = false
     }
   in
   let json = Cascade_legacy_runner.cascade_observation_to_json observation in
@@ -1051,6 +1052,7 @@ let test_cascade_audit_persists_observation () =
              ]
          ; attempt_details_available = true
          ; attempt_details_source = "oas_metrics_callbacks"
+         ; oas_internal_cascade_allowed = false
          }
        in
        Masc_mcp.Cascade_legacy_runner.record_cascade


### PR DESCRIPTION
## Summary
Wires the `oas_internal_cascade_allowed` invariant through the entire cascade → receipt → JSON pipeline.

- Adds `oas_internal_cascade_allowed : bool` to `Cascade_legacy_runner.cascade_observation` (type + JSON encoder)
- Adds the same field to `Keeper_execution_receipt.t` (type + JSON encoder)
- Propagates via `Keeper_cascade_engine.allows_oas_internal_cascade` through all `cascade_observation_with_metrics` call sites in `keeper_turn_driver.ml`
- Updates 8 test files with the new record field

## Motivation
`Keeper_cascade_engine.allows_oas_internal_cascade` is hardcoded `false` in `keeper_managed` mode. Rather than leaving this invariant implicit, this PR makes it observable in execution receipts and downstream manifest, providing a regression guard against accidental multi-provider cascade activation on the keeper hot path.

## Verification
- `dune build --root . @all` passes
- `test_oas_worker.exe` (178 tests) passes
- `test_memory_hooks.exe` (20 tests) passes
- `test_cascade_catalog_runtime_yojson.exe` (10 tests) passes

## Scope
HTML checklist item #5 (OAS internal cascade regression guard).
No RFC-affected subsystem touched (credential, identity, operator, sandbox, dashboard credential, hooks, workflow docs).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>