### PR TITLE
refactor(lib): remove dead export broadcast_trace_telemetry from dashboard_yjs.mli

### DIFF
--- a/lib/dashboard/dashboard_yjs.mli
+++ b/lib/dashboard/dashboard_yjs.mli
@@ -16,7 +16,3 @@ val frame_update : string -> string
 val broadcast_keeper_telemetry :
   keeper_name:string -> trace_id:string -> turn_index:int -> model_id:string -> unit
 
-(** [broadcast_trace_telemetry ~author ~position] publishes a trace Yjs
-    telemetry update to dashboard observer sessions. Ordering follows local
-    caller invocation order; no cross-process ordering is guaranteed. *)
-val broadcast_trace_telemetry : author:string -> position:int -> unit


### PR DESCRIPTION
## Summary
Remove dead export broadcast_trace_telemetry from dashboard_yjs.mli.

## Audit
- broadcast_trace_telemetry: 0 qualified callers, 0 test callers, 0 open/include/alias
- frame_update: retained (test callers in test_dashboard_yjs.ml)
- broadcast_keeper_telemetry: retained (production caller)

## Scope
- lib/dashboard/dashboard_yjs.mli: remove broadcast_trace_telemetry val declaration only
- lib/dashboard/dashboard_yjs.ml: kept (internal definition preserved)