### PR TITLE
refactor(lib): remove dead export pp from sandbox_target.mli

### DIFF
--- a/lib/exec/sandbox_target.mli
+++ b/lib/exec/sandbox_target.mli
@@ -46,4 +46,3 @@ val host : unit -> t
     [Keeper_turn_sandbox_runtime] or any other keeper-side construct. *)
 val docker : image:string -> runner:runner -> ?pipeline_runner:pipeline_runner -> unit -> t
 
-val pp : Format.formatter -> t -> unit


### PR DESCRIPTION
## Summary
Remove dead export pp from sandbox_target.mli.

## Audit
- pp: 0 qualified callers, 0 test callers, 0 open/include/alias
- host: retained (21 production + test callers)
- docker: retained (1 production caller)

## Scope
- lib/exec/sandbox_target.mli: remove pp val declaration only
- lib/exec/sandbox_target.ml: kept (internal definition preserved)