### PR TITLE
refactor(keeper): remove dead export Keeper_registry_tool_usage_persistence.tool_usage_path

### DIFF
--- a/lib/keeper/keeper_registry_tool_usage_persistence.mli
+++ b/lib/keeper/keeper_registry_tool_usage_persistence.mli
@@ -1,8 +1,5 @@
 (** Disk persistence for per-keeper tool-usage counters. *)
 
-(** Filesystem path under [<masc>/keepers/tool_usage/<name>.json]. *)
-val tool_usage_path : base_path:string -> string -> string
-
 (** Flush in-memory tool usage stats to disk for persistence across restarts.
     Reads the keeper entry via [Keeper_registry.get]; writes JSON atomically.
     Increments [metric_keeper_tool_usage_flush_failures] on I/O failure. *)


### PR DESCRIPTION
## Summary
Remove dead export [val tool_usage_path] from [Keeper_registry_tool_usage_persistence.mli].

## Audit Evidence
- 5-prong audit: qualified-name grep → 0 callers; facade re-export → none; opener-unqualified → none; local alias → none; parent .ml internal calls → used only internally within [flush] and [restore].
- Test callers: 0.
- Retained exports: [flush] (production callers), [restore] (production callers).

## Verification
- [x] Change is [.mli]-only; [.ml] compilation unaffected.
- [x] No external callers (verified via [rg]).

🤖 Generated with Claude Code