### PR TITLE
refactor(keeper): remove dead export Keeper_runtime_trust_snapshot.disposition_fields_json

### DIFF
--- a/lib/keeper/keeper_runtime_trust_snapshot.mli
+++ b/lib/keeper/keeper_runtime_trust_snapshot.mli
@@ -1,6 +1,3 @@
-val disposition_fields_json :
-  config:Coord.config -> meta:Keeper_types.keeper_meta -> Yojson.Safe.t
-
 val snapshot_json :
   config:Coord.config -> meta:Keeper_types.keeper_meta -> Yojson.Safe.t
 


### PR DESCRIPTION
## Summary
Remove dead export [val disposition_fields_json] from [Keeper_runtime_trust_snapshot.mli].

## Audit Evidence
- 5-prong audit: qualified-name grep → 0 callers; facade re-export → none; opener-unqualified → none; local alias → none; parent .ml internal calls → 0.
- Test callers: 0.
- Retained exports: [snapshot_json] (test callers), [summary_json] (production callers).

## Verification
- [x] Change is [.mli]-only; [.ml] compilation unaffected.
- [x] No external callers (verified via [rg]).

🤖 Generated with Claude Code