### PR TITLE
refactor(keeper): remove dead export Keeper_state_block_prompt.template_text

### DIFF
--- a/lib/keeper/keeper_state_block_prompt.mli
+++ b/lib/keeper/keeper_state_block_prompt.mli
@@ -1,8 +1,5 @@
 (** Canonical keeper [STATE] block prompt text. *)
 
-val template_text : string
-(** Canonical [STATE] block schema shown to keepers. *)
-
 val instruction_text : string
 (** Scoped instruction that embeds the canonical [STATE] block schema. *)
 


### PR DESCRIPTION
## Summary
Remove dead export [val template_text] from [Keeper_state_block_prompt.mli].

## Audit Evidence
- 5-prong audit: qualified-name grep → 0 callers; facade re-export → none; opener-unqualified → none; local alias → none; parent .ml internal calls → 0.
- Test callers: 0.
- Retained exports: [instruction_text] (production callers), [field_summary] (production callers).

## Verification
- [x] Change is [.mli]-only; [.ml] compilation unaffected.
- [x] No external callers (verified via [rg]).

🤖 Generated with Claude Code