### PR TITLE
refactor(keeper): remove dead export Keeper_timing.timed

### DIFF
--- a/lib/keeper/keeper_timing.mli
+++ b/lib/keeper/keeper_timing.mli
@@ -3,10 +3,6 @@
 (** Round to 1 decimal place for compact JSON output. *)
 val round1 : float -> float
 
-(** [timed f] runs [f ()], returning its result and elapsed time in ms.
-    Uses [Time_compat.now] as the single timing source. *)
-val timed : (unit -> 'a) -> 'a * float
-
 (** Convert elapsed monotonic timestamps from the same clock, such as
     [Eio.Time.now], to integer milliseconds for telemetry. Positive intervals
     below 1ms are rounded up to 1 so completed calls are not recorded as [0ms].


### PR DESCRIPTION
## Summary
Remove dead export [val timed] from [Keeper_timing.mli].

## Audit Evidence
- 5-prong audit: qualified-name grep → 0 callers; facade re-export → none; opener-unqualified → none; local alias → none; parent .ml internal calls → 0.
- Test callers: 0.
- Retained exports: [round1] (production callers), [elapsed_duration_ms] (test callers).

## Verification
- [x] Change is [.mli]-only; [.ml] compilation unaffected.
- [x] No external callers (verified via [rg]).

🤖 Generated with Claude Code