### PR TITLE
refactor(keeper): remove dead export Keeper_tool_boundary.dispatch_stream

### DIFF
--- a/lib/keeper/keeper_tool_boundary.mli
+++ b/lib/keeper/keeper_tool_boundary.mli
@@ -23,10 +23,3 @@ val create :
 
 val dispatch :
   _ context -> name:string -> args:Yojson.Safe.t -> Keeper_types.tool_result option
-
-val dispatch_stream :
-  on_text_delta:(string -> unit) ->
-  _ context ->
-  name:string ->
-  args:Yojson.Safe.t ->
-  Keeper_types.tool_result option


### PR DESCRIPTION
## Summary
Remove dead export [val dispatch_stream] from [Keeper_tool_boundary.mli].

## Audit Evidence
- 5-prong audit: qualified-name grep → 0 callers; facade re-export → none; opener-unqualified → none; local alias → none; parent .ml internal calls → 0.
- Test callers: 0.
- Retained exports: [create] (production callers), [dispatch] (production callers).

## Verification
- [x] Change is [.mli]-only; [.ml] compilation unaffected.
- [x] No external callers (verified via [rg]).

🤖 Generated with Claude Code