### PR TITLE
refactor(keeper): remove dead export Keeper_trace_emit.trace_path

### DIFF
--- a/lib/keeper/keeper_trace_emit.mli
+++ b/lib/keeper/keeper_trace_emit.mli
@@ -18,6 +18,3 @@ val emit_transition :
   unit
 (** [base_path]/keepers/[keeper_name].tla-trace.jsonl 에 JSONL 한 줄 append.
     비활성 시 no-op. *)
-
-val trace_path : base_path:string -> keeper_name:string -> string
-(** Trace 파일 경로 반환. *)


### PR DESCRIPTION
## Summary
Remove dead export [val trace_path] from [Keeper_trace_emit.mli].

## Audit Evidence
- 5-prong audit: qualified-name grep → 0 callers; facade re-export → none; opener-unqualified → none; local alias → none; parent .ml internal calls → used only internally within [emit_transition].
- Test callers: 0.
- Retained exports: [enabled] (production callers), [emit_transition] (production callers).

## Verification
- [x] Change is [.mli]-only; [.ml] compilation unaffected.
- [x] No external callers (verified via [rg]).

🤖 Generated with Claude Code