### PR TITLE
refactor(keeper): remove dead export mechanical_tools from Keeper_turn_intent

### DIFF
--- a/lib/keeper/keeper_turn_intent.mli
+++ b/lib/keeper/keeper_turn_intent.mli
@@ -35,7 +35,3 @@ val classify :
   retry_count:int ->
   t
 
-(** Set of tool names considered "mechanical" for classification.
-    Exposed so tests can assert coverage and keeper operators can audit
-    the list. *)
-val mechanical_tools : string list


### PR DESCRIPTION
## Summary
Remove dead export `val mechanical_tools : string list` from `Keeper_turn_intent.mli`.

## Audit
- Qualified callers (`Keeper_turn_intent.mechanical_tools`): 0 across lib/ + test/
- Test callers: 0
- Internal .ml caller: `mechanical_set` uses it → preserved in .ml
- Re-export (`include`): None
- `open` usage: None

## Why
`mechanical_tools` is only used internally within `keeper_turn_intent.ml` to build `mechanical_set`. No external module or test references it. Removing from the interface reduces surface area without changing behavior.

## Verification
- [x] 5-prong dead-export audit completed
- [x] Internal .ml caller confirmed (preserved)
- [x] No facade re-export
- [x] No RFC scaffolding dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)