### PR TITLE
refactor(keeper): remove dead export preset_of_defaults from Keeper_turn_up_create

### DIFF
--- a/lib/keeper/keeper_turn_up_create.mli
+++ b/lib/keeper/keeper_turn_up_create.mli
@@ -6,13 +6,6 @@
 
 open Keeper_types
 
-(** Resolve the tool_preset from [profile_defaults.tool_preset]
-    via [Keeper_preset_defaults.preset_of_defaults_warn] with
-    [call_site:"keeper_turn_up_create"]. Returns [None] when the
-    defaults field is unset or names an unknown preset. *)
-val preset_of_defaults :
-  keeper_profile_defaults -> tool_preset option
-
 (** Persist a freshly-built keeper_meta with field-merging CAS
     retry — preserves heartbeat-owned cursors when bootstrap races
     a supervisor write (#9749). *)


### PR DESCRIPTION
## Summary
Remove dead export `val preset_of_defaults` from `Keeper_turn_up_create.mli`.

## Audit
- Qualified callers (`Keeper_turn_up_create.preset_of_defaults`): 0 across lib/ + test/
- Test callers: 0
- Internal .ml caller: `create_keeper` calls it → preserved in .ml
- Re-export (`include`): None
- `open` usage: None

## Why
`preset_of_defaults` is only used internally within `create_keeper` to resolve the tool preset from profile defaults. No external module or test references it directly. Removing from the interface reduces surface area without changing behavior.

## Verification
- [x] 5-prong dead-export audit completed
- [x] Internal .ml caller confirmed (preserved)
- [x] No facade re-export
- [x] No RFC scaffolding dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)