### PR TITLE
refactor(keeper): remove dead export transition from Keeper_social_model_bdi_speech_v1

### DIFF
--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.mli
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.mli
@@ -22,11 +22,6 @@ type output = {
   delivery_surface : Keeper_social_model_types.delivery_surface;
 }
 
-val transition :
-  state option ->
-  input ->
-  state * output * Keeper_social_model_types.transition_reason
-
 val apply_to_result :
   meta:keeper_meta ->
   observation:Keeper_world_observation.world_observation ->


### PR DESCRIPTION
## Summary
Remove dead export `val transition` from `Keeper_social_model_bdi_speech_v1.mli`.

## Audit
- Qualified callers (`Keeper_social_model_bdi_speech_v1.transition`): 0 across lib/ + test/
- Test callers: 0
- Internal .ml caller: `apply_to_result` calls it → preserved in .ml
- Re-export (`include`): None
- `open` usage: None

## Why
`transition` is only used internally within `apply_to_result`. No external module or test references it directly. Removing from the interface reduces surface area without changing behavior.

## Verification
- [x] 5-prong dead-export audit completed
- [x] Internal .ml caller confirmed (preserved)
- [x] No facade re-export
- [x] No RFC scaffolding dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)