### PR TITLE
refactor: remove dead export update_with_result from Lockfree_atomic

### DIFF
--- a/lib/lockfree_atomic.ml
+++ b/lib/lockfree_atomic.ml
@@ -4,12 +4,6 @@ let rec update atomic f =
   if Atomic.compare_and_set atomic old_val new_val then ()
   else update atomic f
 
-let rec update_with_result atomic f =
-  let old_val = Atomic.get atomic in
-  let new_val, result = f old_val in
-  if Atomic.compare_and_set atomic old_val new_val then result
-  else update_with_result atomic f
-
 type ('state, 'result) commit = {
   next_state : 'state;
   result : 'result;

--- a/lib/lockfree_atomic.mli
+++ b/lib/lockfree_atomic.mli
@@ -13,17 +13,8 @@
     commits the result via CAS, retrying on contention. *)
 val update : 'a Atomic.t -> ('a -> 'a) -> unit
 
-(** [update_with_result atomic f] is [update] but [f] returns both the new
-    state and a derived value; the derived value of the committed attempt
-    is returned.
-
-    Important: [f] may be invoked multiple times under contention. It must
-    be pure with respect to observable effects, or tolerate repeated calls. *)
-val update_with_result : 'a Atomic.t -> ('a -> 'a * 'b) -> 'b
-
 (** Record-labelled commit describing the next state and a derived value.
-    Equivalent to the tuple form used by [update_with_result]; provided for
-    call sites where positional tuples hurt readability. *)
+    Provided for call sites where positional tuples hurt readability. *)
 type ('state, 'result) commit = {
   next_state : 'state;
   result : 'result;


### PR DESCRIPTION
## Summary
Remove dead export `update_with_result` from `Lockfree_atomic` (both .mli and .ml).

## Audit
- Qualified callers (`Lockfree_atomic.update_with_result`): 0 across lib/ + test/
- Test callers: 0
- Internal .ml callers: 0 (only recursive self-reference in its own definition)
- `update_with_commit` (live) provides equivalent functionality with labelled record syntax.

## Why
`update_with_result` has zero consumers. `update_with_commit` (added later) supersedes it with better readability. All existing callers use `update` or `update_with_commit`. Removing reduces API surface.

## Verification
- [x] 5-prong dead-export audit completed
- [x] Internal .ml caller confirmed (none — safe to remove from .ml)
- [x] No facade re-export
- [x] No RFC scaffolding dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)