### PR TITLE
refactor(mcp): remove dead export sdk_prompt_of_local from Mcp_sdk_adapter_masc

### DIFF
--- a/lib/mcp_sdk_adapter_masc.mli
+++ b/lib/mcp_sdk_adapter_masc.mli
@@ -41,16 +41,3 @@ val dispatch_request :
     threaded through for forward compatibility — the current ["ping"]
     dispatcher ignores them.  Polymorphic types intentional: the
     adapter does not own the runtime types. *)
-
-val sdk_prompt_of_local :
-  Mcp_prompt_surface.prompt_def -> Mcp_protocol.Mcp_types.prompt
-(** [sdk_prompt_of_local prompt] converts a MASC-side
-    {!Mcp_prompt_surface.prompt_def} into the SDK-side
-    {!Mcp_protocol.Mcp_types.prompt}.  Each
-    {!Mcp_prompt_surface.prompt_argument} maps to a
-    {!Mcp_protocol.Mcp_types} prompt argument with [description]
-    wrapped in [Some] and [required] wrapped in [Some].
-
-    Exposed because {!Mcp_prompt_surface}'s interface references
-    this conversion in its public contract — keeping the bridge in
-    a single .mli avoids duplication. *)


### PR DESCRIPTION
## Summary
Remove dead export `val sdk_prompt_of_local` from `Mcp_sdk_adapter_masc.mli`.

## Audit
- Qualified callers (`Mcp_sdk_adapter_masc.sdk_prompt_of_local`): 0 across lib/ + test/
- Test callers: 0
- Internal .ml caller: `sdk_prompt_of_local` is used inside the .ml (prompt list projection) → preserved in .ml
- Re-export (`include`): None

## Why
`sdk_prompt_of_local` is only consumed internally within the module. No external module calls it directly. Removing from the interface reduces surface area without changing behavior.

## Verification
- [x] 5-prong dead-export audit completed
- [x] Internal .ml caller confirmed (preserved)
- [x] No facade re-export
- [x] No RFC scaffolding dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)