### PR TITLE
refactor(otel): remove dead export tool_span_attrs

### DIFF
--- a/lib/otel/otel_dispatch_hook.mli
+++ b/lib/otel/otel_dispatch_hook.mli
@@ -16,10 +16,6 @@
 
     @since 2.103.0 *)
 
-val tool_span_attrs : Tool_result.t -> Opentelemetry.key_value list
-(** Build the full tool-span payload used by the post-hook. Exposed so tests can
-    pin the legacy + GenAI dual-emission contract without installing a collector. *)
-
 val with_test_span_emitter :
   enabled:bool ->
   emit_span:(name:string -> attrs:Opentelemetry.key_value list -> unit) ->


### PR DESCRIPTION
## Summary
Dead-export audit: \`tool_span_attrs\` has 0 external callers and 0 test callers.
Internal use by \`on_tool_result\` remains in \`.ml\` (not public surface).

## Verification
- [x] 5-prong audit: qualified-name, facade, opener, alias, internal
- [x] No test callers
- [x] No production callers outside defining module

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>