### PR TITLE
refactor(prompt_registry): remove dead export create

### DIFF
--- a/lib/prompt_registry/prompt_registry_store.mli
+++ b/lib/prompt_registry/prompt_registry_store.mli
@@ -25,12 +25,6 @@ type t = {
   mutex : Eio.Mutex.t;
 }
 
-val create : unit -> t
-(** Build a fresh store with empty Hashtbls (capacities matched
-    to historical workload — 64 / 64 / 16 / 32), [None] dir refs,
-    and a fresh [Eio.Mutex.t]. Tests use this to avoid cross-case
-    pollution. *)
-
 val default : unit -> t
 (** Return the process-wide singleton store. Identity-stable
     across calls; prefer {!create} in tests when isolation is


### PR DESCRIPTION
## Summary
Dead-export audit: \`create\` has 0 external callers and 0 test callers.
Internal use by \`default_state\` remains in \`.ml\` (not public surface).

## Verification
- [x] 5-prong audit: qualified-name, facade, opener, alias, internal
- [x] No test callers
- [x] No production callers outside defining module

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>