### PR TITLE
refactor(timeout_policy): remove dead exports remaining, slack, metric

### DIFF
--- a/lib/timeout_policy.mli
+++ b/lib/timeout_policy.mli
@@ -47,17 +47,7 @@ module Deadline : sig
     -> t
 
   val elapsed : t -> now:float -> float
-  val remaining : t -> now:float -> float
 end
-
-val default_overshoot_slack_s : float
-(** Default grace window applied when distinguishing expected cleanup tail
-    from a cooperative-cancel miss. Callers may override per site. *)
-
-val metric_overshoot_total : string
-(** #9662: canonical Prometheus metric name for overshoot events.
-    Labels: [layer, origin].  Internal series name is
-    [masc_timeout_policy_overshoot_total]. *)
 
 val overshoot_warn
   :  ?slack_s:float


### PR DESCRIPTION
## Summary
Dead-export audit (5-prong):
- \`Deadline.remaining\`: 0 external/test callers
- \`default_overshoot_slack_s\`: 0 external callers (internal default only)
- \`metric_overshoot_total\`: 0 external callers (internal counter only)

\`overshoot_warn\` remains LIVE (keeper_llm_bridge + tests).
\`Layer.to_string\`, \`Deadline.make\`, \`Deadline.elapsed\` remain LIVE (tests).

## Verification
- [x] 5-prong audit: qualified-name, facade, opener, alias, internal
- [x] No test callers for removed exports
- [x] No production callers outside defining module

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>