### PR TITLE
refactor(board_comment_rate_limit): remove dead export reset

### DIFF
--- a/lib/board_comment_rate_limit.ml
+++ b/lib/board_comment_rate_limit.ml
@@ -48,8 +48,6 @@ let record ~author ~now =
   ts_ref := now :: !ts_ref
 ;;
 
-let reset () = Hashtbl.clear comment_timestamps
-
 (** [sweep_stale ~now ~window] drops timestamps older than [window]
     seconds from every author's entry, then removes any author whose
     list became empty. Called from [board_core] [sweep] as part of the

--- a/lib/board_comment_rate_limit.mli
+++ b/lib/board_comment_rate_limit.mli
@@ -17,9 +17,6 @@ val check : author:string -> now:float -> float option
     drift across concurrent attempts. *)
 val record : author:string -> now:float -> unit
 
-(** [reset ()] clears the tracker entirely. Test-only. *)
-val reset : unit -> unit
-
 (** [sweep_stale ~now ~window] expires per-author timestamps older
     than [window] seconds from [now] and removes any author whose list
     became empty. Called from the board-core sweep loop. *)


### PR DESCRIPTION
## Summary
Remove dead export `Board_comment_rate_limit.reset`.

## Audit
- 0 external callers (qualified-name grep: `Board_comment_rate_limit.reset`)
- 0 internal callers (within `.ml` file)
- 0 test callers
- 0 facade re-export
- 0 `open` usage

The function was documented as "Test-only" but had no test usage.

## Changes
- `lib/board_comment_rate_limit.mli`: remove `val reset : unit -> unit`
- `lib/board_comment_rate_limit.ml`: remove `let reset () = Hashtbl.clear comment_timestamps`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>