### PR TITLE
fix(cascade): apply cooldown on Capacity_backpressure so fleet backoff works

### DIFF
--- a/lib/cascade/cascade_health_tracker.ml
+++ b/lib/cascade/cascade_health_tracker.ml
@@ -432,11 +432,24 @@ let record t ~provider_key ~outcome ?error_kind ?error_reason
       end
     | Capacity_backpressure ->
       (* Capacity exhaustion is transient load, not persistent health
-         degradation.  Do NOT increment consecutive_failures or touch
-         cooldown_until — the event is already recorded in [state.events]
-         above for observability.  The cascade will simply try the next
-         provider and revisit this one on the next turn. *)
-      ()
+         degradation.  Do NOT increment consecutive_failures.
+         Apply cooldown using the upstream retry_after hint when present,
+         or a synthetic default otherwise, so the fleet-level backoff
+         logic can detect all-provider-cooldown and wait for recovery
+         instead of thrashing through every provider every turn. *)
+      let cooldown_dur =
+        match retry_after_s with
+        | Some s when s > 0.0 -> Float.min s soft_rate_limit_max_clamp_sec
+        | _ -> default_capacity_backpressure_backoff_sec
+      in
+      let new_until = now +. cooldown_dur in
+      if new_until > state.cooldown_until then begin
+        state.cooldown_until <- new_until;
+        Cascade_metrics.on_provider_cooldown
+          ~provider:provider_key ~reason:"capacity_backpressure";
+        Prometheus.observe_histogram Keeper_metrics.metric_keeper_provider_block_duration_sec
+          ~labels:[("provider", provider_key)] cooldown_dur
+      end
     | Hard_quota ->
       (* Hard-quota errors (balance depleted, quota exceeded, resource
          exhausted) don't recover on short-window retries — set a long

--- a/test/test_cascade_capacity_backpressure_synthetic_backoff.ml
+++ b/test/test_cascade_capacity_backpressure_synthetic_backoff.ml
@@ -55,19 +55,19 @@ let test_missing_retry_after_uses_synthetic_default () =
     (Some (FSM.Cbr_synthetic_default expected_default))
     (FSM.sdk_error_capacity_backpressure_retry_hint err)
 
-let test_synthetic_default_is_positive_and_below_soft_rl_cooldown () =
+let test_synthetic_default_is_positive_and_within_sane_bounds () =
   (* Sanity bounds: synthetic default should be > 0 (else cascade rotates
-     immediately) and < soft_rate_limit_cooldown_sec (because capacity
-     backpressure recovers faster than 429 in practice). *)
+     immediately) and <= soft_rate_limit_max_clamp_sec (so that the default
+     and any explicit retry_after hint share the same upper bound). *)
   let default = HT.default_capacity_backpressure_backoff_sec in
   Alcotest.(check bool)
     "default_capacity_backpressure_backoff_sec > 0"
     true
     (default > 0.0);
   Alcotest.(check bool)
-    "default_capacity_backpressure_backoff_sec <= soft_rate_limit_cooldown_sec"
+    "default_capacity_backpressure_backoff_sec <= soft_rate_limit_max_clamp_sec"
     true
-    (default <= HT.soft_rate_limit_cooldown_sec)
+    (default <= HT.soft_rate_limit_max_clamp_sec)
 
 let test_non_positive_retry_after_falls_back_to_synthetic () =
   (* retry_after_sec=Some 0.0 or negative is semantically equivalent to
@@ -110,7 +110,7 @@ let () =
           Alcotest.test_case "missing retry_after uses synthetic default" `Quick
             test_missing_retry_after_uses_synthetic_default;
           Alcotest.test_case "synthetic default within sane bounds" `Quick
-            test_synthetic_default_is_positive_and_below_soft_rl_cooldown;
+            test_synthetic_default_is_positive_and_within_sane_bounds;
           Alcotest.test_case "non-positive retry_after falls back" `Quick
             test_non_positive_retry_after_falls_back_to_synthetic;
           Alcotest.test_case "non-Capacity_backpressure → None" `Quick


### PR DESCRIPTION
## Problem

`Capacity_backpressure` previously skipped `cooldown_until` entirely (comment: \"transient load, revisit on next turn\").  This meant the fleet-level backoff gate added in task-536 never triggered — no provider was ever marked as cooled-down, so the condition `all candidates in cooldown` was impossible to reach.

Runtime data from `~/me/.masc` shows the resulting burst pattern: 34% of `no_tool_capable_provider` events occur in just 6 burst turns, suggesting a single upstream quota exhaustion propagates synchronously across all cascades before any backoff takes effect (Umberto, board post `p-bccfb1b2`).

## Fix

Apply cooldown in `Cascade_health_tracker.record` for `Capacity_backpressure` using the same shape as `Soft_rate_limited`:

- `retry_after_sec` present & positive → clamp to `soft_rate_limit_max_clamp_sec`.
- Missing / non-positive → fall back to `default_capacity_backpressure_backoff_sec` (30 s).
- `consecutive_failures` is still NOT incremented, preserving the \"transient load\" semantics.

## Side effect

Fleet-level backoff logic in `keeper_turn_driver.ml:1195-1240` now becomes reachable when every provider simultaneously returns `Capacity_backpressure`.  The cascade waits for the earliest cooldown expiry instead of thrashing through every provider every turn.

## Tests

- `test_cascade_capacity_backpressure_cooldown` — 5/5 PASS (behaviour unchanged).
- `test_cascade_capacity_backpressure_synthetic_backoff` — updated stale assert (`default <= soft_rate_limit_cooldown_sec` was broken by the 5.0 → 30.0 bump in task-536).  5/5 PASS.
- `test_cascade_fsm` — 4/4 PASS.
- `test_cascade_runtime` — 3/3 PASS.

## Checklist

- [x] Local build passes
- [x] Directly affected tests pass
- [ ] Full test suite (pending CI)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>