### PR TITLE
refactor(operator): remove dead exports from Operator_control_snapshot_cache

### DIFF
--- a/lib/operator/operator_control_snapshot_cache.ml
+++ b/lib/operator/operator_control_snapshot_cache.ml
@@ -12,24 +12,17 @@
       ([Cached { value; expires_at }]) from in-flight computations
       ([Computing { cond; stale; started_at; stuck_warned }]).
 
-    - [_snapshot_table], [_snapshot_mu], [_snapshot_ttl_s],
-      [_snapshot_max_entries] — module-level mutable state. Underscore
-      prefix marks them as internal-only; consumers go through
+    - [_snapshot_table], [_snapshot_mu] — module-level mutable state.
+      Underscore prefix marks them as internal-only; consumers go through
       [invalidate_snapshot_cache] or the [snapshot_json]
       cache-handling code in the parent.
-
-    - [_maybe_evict_snapshot ()] — bounded eviction (~16 entries max,
-      #4795 OOM prevention). Prefers expired entries; falls back to
-      oldest fresh entry; never evicts an in-flight [Computing] slot
-      (cache growth is cheaper than a compute stampede under 64-keeper
-      load).
 
     - [invalidate_snapshot_cache ()] — clears the table and
       broadcasts all in-flight [Computing] conditions so waiting
       fibers can re-run. Eio-guarded: pre-Eio callers single-threaded
       and need no mutex.
 
-    Parent uses `include Operator_control_snapshot_cache` so all type
+    Parent uses [include Operator_control_snapshot_cache] so type
     + state + helpers flow into [Operator_control_snapshot]'s scope.
     The include chain propagates through to [Operator_control] via
     [Operator_control_action]. *)
@@ -48,55 +41,6 @@ type snapshot_slot =
 
 let _snapshot_table : (string, snapshot_slot) Hashtbl.t = Hashtbl.create 4
 let _snapshot_mu = Eio.Mutex.create ()
-let _snapshot_ttl_s = Env_config.Operator.cache_ttl_sec
-
-(* Maximum snapshot cache entries.  Each entry holds a full JSON snapshot
-   tree which can be several MB.  Unbounded growth caused OOM when the
-   dashboard was connected for extended periods (#4795). *)
-let _snapshot_max_entries = 16
-
-(* Evict one expired or oldest entry when table reaches _snapshot_max_entries.
-   Called inside _snapshot_mu when Eio is ready; pre-Eio callers are
-   single-threaded so no lock is needed. *)
-let _maybe_evict_snapshot () =
-  if Hashtbl.length _snapshot_table >= _snapshot_max_entries
-  then (
-    let now_ts = Time_compat.now () in
-    (* Prefer expired entries *)
-    let victim = ref None in
-    Hashtbl.iter
-      (fun key slot ->
-         match slot, !victim with
-         | Cached { expires_at; _ }, None when now_ts >= expires_at -> victim := Some key
-         | Cached _, None -> ()
-         | Cached _, Some _ -> ()
-         | Computing _, _ -> ())
-      _snapshot_table;
-    match !victim with
-    | Some key -> Hashtbl.remove _snapshot_table key
-    | None ->
-      (* All fresh or computing — evict the entry closest to expiry *)
-      let oldest_cached = ref None in
-      let any_key = ref None in
-      Hashtbl.iter
-        (fun key slot ->
-           match slot with
-           | Cached { expires_at; _ } ->
-             (match !oldest_cached with
-              | None -> oldest_cached := Some (key, expires_at)
-              | Some (_, e) when expires_at < e -> oldest_cached := Some (key, expires_at)
-              | Some _ -> ())
-           | Computing _ -> if !any_key = None then any_key := Some key)
-        _snapshot_table;
-      (match !oldest_cached with
-       | Some (key, _) -> Hashtbl.remove _snapshot_table key
-       | None ->
-         (* Never evict an in-flight compute to enforce the entry cap.  Under
-            64-keeper load, replacing a [Computing] slot starts duplicate
-            dashboard snapshots while the old one is still doing filesystem
-            work.  Temporary cache growth is cheaper than a compute stampede. *)
-         ignore !any_key))
-;;
 
 let invalidate_snapshot_cache () =
   if Eio_guard.is_ready ()

--- a/lib/operator/operator_control_snapshot_cache.mli
+++ b/lib/operator/operator_control_snapshot_cache.mli
@@ -12,8 +12,4 @@ type snapshot_slot =
       ; stuck_warned : bool ref
       }
 
-val _snapshot_table : (string, snapshot_slot) Hashtbl.t
-val _snapshot_mu : Eio.Mutex.t
-val _snapshot_ttl_s : float
-val _maybe_evict_snapshot : unit -> unit
 val invalidate_snapshot_cache : unit -> unit


### PR DESCRIPTION
## Summary

5-prong dead-export audit on `Operator_control_snapshot_cache`.

### Removed from .mli + .ml (dead code)
- `_snapshot_ttl_s` — defined but never referenced
- `_maybe_evict_snapshot` — defined but never called
- `_snapshot_max_entries` — only referenced by `_maybe_evict_snapshot`

### Removed from .mli only (internal usage preserved)
- `_snapshot_table` — used internally by `invalidate_snapshot_cache`
- `_snapshot_mu` — used internally by `invalidate_snapshot_cache`

### Retained in .mli
- `invalidate_snapshot_cache` — live via `Operator_control_snapshot` facade
  (2 callers in `server_dashboard_http_keeper_api_lifecycle_post.ml`)

### Audit trace
| Export | Prong 1 | Prong 2 (facade) | Prong 3 | Prong 4 | Prong 5 | Verdict |
|--------|--------:|-----------------:|--------:|--------:|--------:|---------|
| _snapshot_table | 0 | 0 | 0 | 0 | 1 | remove from .mli |
| _snapshot_mu | 0 | 0 | 0 | 0 | 1 | remove from .mli |
| _snapshot_ttl_s | 0 | 0 | 0 | 0 | 0 | **DEAD** |
| _maybe_evict_snapshot | 0 | 0 | 0 | 0 | 0 | **DEAD** |
| invalidate_snapshot_cache | 0 | 1 (via Operator_control_snapshot) | 0 | 0 | 0 | RETAIN |

🤖 Generated with [Claude Code](https://claude.com/claude-code)