### PR TITLE
refactor(exec): RFC-0160 S6b consolidate shell_word_values SSOT + expose dispatch_pipeline

### DIFF
--- a/lib/exec_policy.mli
+++ b/lib/exec_policy.mli
@@ -90,6 +90,11 @@ val is_destructive_bash_operation_of_string : string -> bool
     replaces 3 duplicated [shell_word_values] private copies). *)
 val stage_words_of_string : string -> string list
 
+(** RFC-0160 S6b: Result-shaped variant preserving parse-failure signal
+    for callers that route on failure (log sanitizer's sensitive-marker
+    fallback). *)
+val stage_words_of_string_result : string -> (string list, unit) result
+
 val sanitize_command_for_log : string -> string
 val truncate_for_log : ?max_len:int -> string -> string
 

--- a/lib/exec_policy_log_sanitize.ml
+++ b/lib/exec_policy_log_sanitize.ml
@@ -8,16 +8,6 @@ let sensitive_assignment_markers =
   [ ":_authToken="; "_authToken="; "token="; "password="; "passwd="; "api-key=" ]
 ;;
 
-let shell_word_values cmd =
-  match Masc_exec_bash_parser.Bash_words.stages cmd with
-  | Error _ -> Error ()
-  | Ok stages ->
-    Ok
-      (stages
-       |> List.concat
-       |> List.map (fun (word : Masc_exec_bash_parser.Bash_words.word) -> word.value))
-;;
-
 let redact_url_credentials token =
   let redact_after_scheme token scheme =
     if String.starts_with ~prefix:scheme token
@@ -88,7 +78,7 @@ let sanitize_parts parts =
 ;;
 
 let sanitize_command_for_log cmd =
-  match shell_word_values cmd with
+  match Exec_policy_mutation_classifier.stage_words_of_string_result cmd with
   | Ok parts -> sanitize_parts parts
   | Error () when command_has_sensitive_marker cmd -> "[REDACTED]"
   | Error () -> cmd |> redact_url_credentials |> redact_inline_secret_assignment

--- a/lib/exec_policy_mutation_classifier.ml
+++ b/lib/exec_policy_mutation_classifier.ml
@@ -224,3 +224,18 @@ let stage_words_of_string (cmd : string) : string list =
   | Parsed.Parsed ir -> flat_stage_words ir
   | _ -> []
 ;;
+
+(** RFC-0160 S6b: Result-shaped variant that preserves the parse-failure
+    signal. [stage_words_of_string] collapses failure to [[]] which suits
+    classifiers (fail-closed = false). [_result] keeps [Error ()] so
+    callers that route on failure (e.g. log sanitizer's sensitive-marker
+    fallback) can branch.
+
+    Single IR producer ([Bash.parse_string]) for both shapes — replaces
+    the legacy [Bash_words.stages]-based [shell_word_values] copy in
+    [exec_policy_log_sanitize]. *)
+let stage_words_of_string_result (cmd : string) : (string list, unit) result =
+  match Masc_exec_bash_parser.Bash.parse_string cmd with
+  | Parsed.Parsed ir -> Ok (flat_stage_words ir)
+  | _ -> Error ()
+;;

--- a/lib/exec_policy_mutation_classifier.mli
+++ b/lib/exec_policy_mutation_classifier.mli
@@ -59,3 +59,14 @@ val is_destructive_bash_operation_of_string : string -> bool
     Transitional surface: prefer {!Masc_exec.Shell_ir.t}-typed callers
     once their upstream entry points migrate (S4). *)
 val stage_words_of_string : string -> string list
+
+(** RFC-0160 S6b: Result-shaped variant for callers that route on parse
+    failure (e.g. log sanitizer's sensitive-marker fallback). The plain
+    [stage_words_of_string] collapses parse failure to [[]] (fail-closed
+    = false suits structural classifiers); this variant preserves
+    [Error ()] so the failure path can branch separately.
+
+    Single IR producer ([Bash.parse_string]) for both shapes — replaces
+    the legacy [Bash_words.stages]-based [shell_word_values] copy in
+    [exec_policy_log_sanitize]. *)
+val stage_words_of_string_result : string -> (string list, unit) result


### PR DESCRIPTION
## Summary

RFC-0160 Shell IR 1급 승격 Phase S6b: 병렬 파서 참조 정리 + dispatch API 노출.

### Changes

1. **exec_policy_log_sanitize.ml**: local `shell_word_values` (Bash_words.stages 기반) 제거. `Exec_policy_mutation_classifier.stage_words_of_string_result`로 단일 SSOT 사용.
   - G7 metric 개선: `Bash_words.stages` 참조 1건 제거.

2. **exec_policy_mutation_classifier.ml/mli**: `stage_words_of_string_result` 추가.
   - `Bash.parse_string`을 단일 IR producer로 사용.
   - `stage_words_of_string`은 parse fail 시 `[]` 반환 (classifier fail-closed).
   - `_result` variant는 `Error ()` 보존 (log sanitizer의 sensitive-marker fallback 분기용).

3. **keeper_shell_ops.ml**: `Destructive_protected` risk class 처리 제거.
   - Risk model 단순화: R0_Read / R1_Reversible_mutation / R2_Irreversible.

4. **exec_dispatch.mli**: `dispatch_pipeline` val 노출 (ml에는 이미 존재).

5. **test_exec_dispatch.ml**: `dispatch_simple` / `dispatch_pipeline` 직접 사용.
   - `Simple` constructor wrapper 제거.

### Metrics

- G7 parallel parser refs: -1 (`shell_word_values` 삭제)
- Files touched: 7 (+65 / -58)

## Test plan

- [ ] `dune build @all` 통과
- [ ] `test_exec_dispatch.ml` 실행 확인
- [ ] Shell IR consumption ratchet (G1 + G7) 통과

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>