### PR TITLE
feat(keeper): emit counter for Contract_missing_required_tool_use

### DIFF
--- a/dashboard/src/components/turn-fsm-detail-panel.ts
+++ b/dashboard/src/components/turn-fsm-detail-panel.ts
@@ -98,7 +98,7 @@ export function TurnFsmDetailPanel({ snapshot }: { snapshot: KeeperCompositeSnap
             <${StatusChip} tone=${turnFsmChipTone(terminalTone(execution.outcome))} uppercase=${false} class="font-mono" title=${stopCause.source}>reason ${stopCause.code}</${StatusChip}>
           ` : null}
           ${execution.tool_contract_result ? html`
-            <${StatusChip} tone=${turnFsmChipTone(execution.tool_contract_result === 'violated' ? 'err' : 'neutral')} uppercase=${false} class="font-mono" title=${execution.tool_contract_result}>tool ${toolContractLabel(execution.tool_contract_result)}</${StatusChip}>
+            <${StatusChip} tone=${turnFsmChipTone((execution.tool_contract_result === 'violated' || execution.tool_contract_result === 'missing_required_tool_use') ? 'err' : 'neutral')} uppercase=${false} class="font-mono" title=${execution.tool_contract_result}>tool ${toolContractLabel(execution.tool_contract_result)}</${StatusChip}>
           ` : null}
         </div>
       ` : null}

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -665,7 +665,21 @@ let operator_disposition (receipt : t)
       then Disp_pass_next_model, Reason_tool_route_recoverable_failure
       else Disp_pause_human, Reason_tool_route_recoverable_failure
     else if required_tool_contract_unsatisfied
-    then Disp_pause_human, Reason_tool_required_unsatisfied
+    then (
+      if receipt.tool_contract_result = Contract_missing_required_tool_use
+      then
+        Prometheus.inc_counter
+          Keeper_metrics.metric_keeper_contract_violations
+          ~labels:
+            [ "keeper_name", receipt.keeper_name
+            ; "kind", "missing_required_tool_use"
+            ; "signal"
+            , (if receipt.tools_used = []
+               then "no_tools_used"
+               else "partial_tools_used")
+            ]
+          ();
+      Disp_pause_human, Reason_tool_required_unsatisfied)
     else if
       receipt.degraded_retry_applied || Option.is_some receipt.degraded_retry_cascade
     then Disp_fail_open_next_cascade, Reason_degraded_retry

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -181,8 +181,9 @@ let run_named
                  (String.concat ", " missing_required_tools)
                  (String.concat ", " materialized_tool_names)
              in
-             Log.Misc.info
-               "cascade %s: pre-dispatch skipped provider=%s reason=%s"
+             Log.Keeper.warn
+               "keeper:%s cascade %s: pre-dispatch skipped provider=%s reason=%s"
+               keeper_name
                cascade_name
                provider_label
                reason;

--- a/lib/prometheus_builtin_metrics_part4.ml
+++ b/lib/prometheus_builtin_metrics_part4.ml
@@ -121,7 +121,7 @@ let register
   add
     Keeper_metrics.metric_keeper_contract_violations
     "Keeper turns rejected for required-tool-contract violations (labels: keeper_name, \
-     kind={passive|text_only}). #10530."
+     kind={passive|text_only|missing_required_tool_use}). #10530."
     `Counter;
   add
     Keeper_metrics.metric_keeper_alive_but_stuck


### PR DESCRIPTION
## Summary

Adds observability for keeper turns that fail the required-tool contract.

### Problem

When a keeper turn produces `Contract_missing_required_tool_use`:
1. No Prometheus counter is emitted (unlike `passive`/`text_only` violations)
2. Dashboard renders the chip in neutral/gray tone instead of err/red
3. Pre-filter log uses `Log.Misc.info` without keeper attribution

### Changes

| File | Change |
|------|--------|
| `lib/keeper/keeper_execution_receipt.ml` | Emit `Prometheus.inc_counter` for `Contract_missing_required_tool_use` with `kind="missing_required_tool_use"` and `signal` label (`no_tools_used` / `partial_tools_used`) |
| `lib/keeper/keeper_turn_driver.ml` | Upgrade `Log.Misc.info` to `Log.Keeper.warn` with `keeper_name` prefix |
| `lib/prometheus_builtin_metrics_part4.ml` | Update metric description to include `missing_required_tool_use` in `kind` enum |
| `dashboard/src/components/turn-fsm-detail-panel.ts` | Extend err-tone condition to include `missing_required_tool_use` |

### Verification

- `dune build @install --profile=release` — OCaml 컴파일 성공
- `pnpm run build` (dashboard) — TypeScript 컴파일 성공, `✓ built in 10.01s`

### Risks

| Risk | Mitigation |
|------|------------|
| Double-counting with passive/text_only | Counter emitted from mutually exclusive code path (`operator_disposition` vs `keeper_agent_run.ml` turn rejection) |
| `required_tool_contract_unsatisfied` matches multiple results | Guarded by `if receipt.tool_contract_result = Contract_missing_required_tool_use` |

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>