### PR TITLE
fix(build): remove stale keeper_hooks_oas_pr_metrics from lib/dune

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -282,7 +282,6 @@
   keeper_hooks_oas_response_metrics
   keeper_hooks_oas_cost_events
   keeper_hooks_oas_idle
-  keeper_hooks_oas_pr_metrics
   keeper_hooks_oas_introspection
   keeper_tools_oas_markers
   keeper_tools_oas_workflow


### PR DESCRIPTION
## Summary
- PR #18011 deleted `Keeper_hooks_oas_pr_metrics` module but left the reference in `lib/dune`, breaking main branch build
- Remove the single stale line to restore `dune build` on main

## Root Cause
PR #18011 removed `lib/keeper/keeper_hooks_oas_pr_metrics.ml` and `.mli` files but missed removing the module name from the `private_modules` list in `lib/dune`. This is the same class of issue as #17965 (3-way PR collision leaving stale references).

## Test plan
- [x] `dune build --root .` succeeds (full library build)
- [x] `dune build test/test_keeper_unified.exe --root .` succeeds (310 tests pass)
- [x] No other stale references to `keeper_hooks_oas_pr_metrics` in codebase

## Related
- #17056 (test_keeper_unified failures — verified resolved on current main, closed)
- #17965 (previous main build fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)