### PR TITLE
fix(build): remove stale keeper_hooks_oas_gate_attempt from lib/dune

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -277,7 +277,6 @@
   keeper_memory_recall
   keeper_status_bridge
   keeper_runtime_trust_timeline
-  keeper_hooks_oas_gate_attempt
   keeper_hooks_oas_output_json
   keeper_hooks_oas_response_metrics
   keeper_hooks_oas_cost_events


### PR DESCRIPTION
## Summary
- PR #18010 deleted `Keeper_hooks_oas_gate_attempt` module but left the reference in `lib/dune`
- Same class of issue as #18028 (stale module reference after module deletion)
- **Note**: Main has 15+ additional build errors from other PR collisions. This PR only fixes the `gate_attempt` stale reference.

## Root Cause
CI `Build and Test` is gated behind `Detect Changed Surfaces`, allowing module-deletion PRs to merge without verifying the dune file is also updated.

## Test plan
- [x] `dune build lib/masc_mcp.a --root .` no longer fails on `gate_attempt`
- [x] Verified module files do not exist: `find lib/ -name "*gate_attempt*"` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)