### PR TITLE
fix(build): remove unresolved rebase conflict markers in tool_task_schemas.ml

### DIFF
--- a/lib/tool_task_schemas.ml
+++ b/lib/tool_task_schemas.ml
@@ -21,19 +21,9 @@ module Float = Stdlib.Float
 
     @since God file decomposition — extracted from tool_task.ml *)
 
-<<<<<<< HEAD
 let masc_add_task_name = Tool_name.Masc.to_string Tool_name.Masc.Add_task
 let masc_code_git_name = Tool_name.Operation.to_string Tool_name.Operation.Code_git
 let masc_claim_next_name = Tool_name.Masc.to_string Tool_name.Masc.Claim_next
-||||||| parent of 06b11523ac (feat(cascade): wire declarative capability overrides through runtime pipeline)
-let masc_add_task_name = Tool_name.Operation.to_string Tool_name.Operation.Add_task
-let masc_code_git_name = Tool_name.Operation.to_string Tool_name.Operation.Code_git
-let masc_claim_next_name = Tool_name.Operation.to_string Tool_name.Operation.Claim_next
-=======
-let masc_add_task_name = Tool_name.Masc.to_string Tool_name.Masc.Add_task
-let masc_code_git_name = Tool_name.Masc.to_string Tool_name.Masc.Code_git
-let masc_claim_next_name = Tool_name.Masc.to_string Tool_name.Masc.Claim_next
->>>>>>> 06b11523ac (feat(cascade): wire declarative capability overrides through runtime pipeline)
 
 let schemas : Masc_domain.tool_schema list = [
   {


### PR DESCRIPTION
## Problem
PR #18022 merged with unresolved Git conflict markers in `lib/tool_task_schemas.ml`, causing `dune build` to fail on main with:

```
File \"lib/tool_task_schemas.ml\", line 24, characters 0-7:
Error: Syntax error
```

## Fix
Removes the conflict markers and keeps the HEAD-side resolution (`Operation.Code_git`).

## Verification
- [x] Local `dune build --root .` passes

## Context
This is a main-breaking hotfix. The merge of #18022 (declarative capability cutover) left `<<<<<<< HEAD` markers in place.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>