### PR TITLE
feat(keeper): wire missing FSM transitions into production code paths

### DIFF
--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -233,6 +233,15 @@ let classify_transition ?ctx ~(from_state: _ turn_state) ~(to_state: _ turn_stat
       Some ToolReturned
   | Any Streaming, Any Completing when not stop_signaled_before ->
       Some StreamComplete
+  | Any Streaming, Any (Failed (Failure_tool_contract_violation _))
+    when not stop_signaled_before ->
+      Some ContractViolation
+  | Any Streaming, Any (Failed (Failure_receipt_lost _))
+    when not stop_signaled_before ->
+      Some ReceiptLost
+  | Any Streaming, Any (Cancelled Cancelled_provider_timeout)
+    when not stop_signaled_before ->
+      Some ProviderTimeout
   | Any Completing, Any Done when not stop_signaled_before ->
       Some ContractOk
   | Any Completing, Any (Failed (Failure_tool_contract_violation _))

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -237,13 +237,22 @@ let run_keeper_cycle
               ~error_message
               ~keeper_turn_id
               ();
+            let failure_reason =
+              if EC.is_cascade_exhausted_error err
+              then
+                Keeper_turn_fsm.Failure_cascade_unavailable
+                  { base = KCP.runtime_name_to_string effective_cascade_runtime_name
+                  ; resolved = None
+                  }
+              else
+                Keeper_turn_fsm.Failure_provider_error
+                  { kind = sdk_error_kind err; detail = error_message }
+            in
             Keeper_turn_fsm.emit_transition
               ~keeper_name:meta.name
               ~turn_id:keeper_turn_id
               ~prev:Keeper_turn_fsm.Cascade_routing
-              (Keeper_turn_fsm.Failed
-                 (Keeper_turn_fsm.Failure_provider_error
-                    { kind = sdk_error_kind err; detail = error_message }));
+              (Keeper_turn_fsm.Failed failure_reason);
             Error err
           | Ok initial_execution ->
             record_pre_dispatch_terminal_observation
@@ -1412,13 +1421,20 @@ let run_keeper_cycle
                     Keeper_metrics.metric_keeper_turns
                     ~labels:[ "keeper_name", meta.name; "outcome", "failure" ]
                     ();
+                  let fsm_failure_reason =
+                    if EC.is_required_tool_contract_violation err
+                    then
+                      Keeper_turn_fsm.Failure_tool_contract_violation
+                        { reason_code = "require_tool_use" }
+                    else
+                      Keeper_turn_fsm.Failure_provider_error
+                        { kind = sdk_error_kind err; detail = short_preview e_str }
+                  in
                   Keeper_turn_fsm.emit_transition
                     ~keeper_name:meta.name
                     ~turn_id:keeper_turn_id
                     ~prev:Keeper_turn_fsm.Streaming
-                    (Keeper_turn_fsm.Failed
-                       (Keeper_turn_fsm.Failure_provider_error
-                          { kind = sdk_error_kind err; detail = short_preview e_str }));
+                    (Keeper_turn_fsm.Failed fsm_failure_reason);
                   let log_keeper_cycle_failed =
                     if EC.should_warn_keeper_cycle_failed err
                     then Log.Keeper.warn

--- a/test/test_keeper_turn_fsm_emit.ml
+++ b/test/test_keeper_turn_fsm_emit.ml
@@ -97,6 +97,20 @@ let test_transition_actions_cover_tla_next () =
   check_action F.StreamYieldsTool ~from_state:F.Streaming ~to_state:F.Awaiting_tool_result;
   check_action F.ToolReturned ~from_state:F.Awaiting_tool_result ~to_state:F.Streaming;
   check_action F.StreamComplete ~from_state:F.Streaming ~to_state:F.Completing;
+  check_action
+    F.ContractViolation
+    ~from_state:F.Streaming
+    ~to_state:
+      (F.Failed (F.Failure_tool_contract_violation { reason_code = "require_tool_use" }));
+  check_action
+    F.ReceiptLost
+    ~from_state:F.Streaming
+    ~to_state:
+      (F.Failed (F.Failure_receipt_lost { primary_error = "io"; fallback_path = None }));
+  check_action
+    F.ProviderTimeout
+    ~from_state:F.Streaming
+    ~to_state:(F.Cancelled F.Cancelled_provider_timeout);
   check_action F.ContractOk ~from_state:F.Completing ~to_state:F.Done;
   check_action
     F.ContractViolation


### PR DESCRIPTION
## Summary

FSM transition audit 결과 7개 missing transition 중 2개를 실제 코드 경로에 연결하고, 나머지 3개의 classifier arm을 추가함.

### Production code path (이전에는 모두 `Failure_provider_error`로 통일됨)

| Transition | From -> To | 조건 | 파일 |
|---|---|---|---|
| `CascadeUnavailable` | `Cascade_routing` -> `Failed` | `is_cascade_exhausted_error` | `keeper_unified_turn.ml` |
| `ContractViolation` | `Streaming` -> `Failed` | `is_required_tool_contract_violation` | `keeper_unified_turn.ml` |

### Classifier only (앞으로의 아키텍처 확장용)

| Transition | From -> To | 비고 |
|---|---|---|
| `ContractViolation` | `Streaming` -> `Failed` | classifier arm 추가 |
| `ReceiptLost` | `Streaming` -> `Failed` | classifier arm 추가 |
| `ProviderTimeout` | `Streaming` -> `Cancelled` | classifier arm 추가 |

### 남은 작업 (후속 PR 예정)

- `ReceiptLost`: receipt I/O 실패 시 typed error로 전환 필요
- `ProviderTimeout` (Streaming): timeout 처리를 `Failed`에서 `Cancelled`로 변경
- `StreamYieldsTool` / `ToolReturned`: `Awaiting_tool_result` 상태를 reachable하게 하는 아키텍처 변경

## Test plan

- [x] `dune build lib/keeper/` compiles
- [x] `test_keeper_turn_fsm_emit.ml` classifier coverage 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)