### PR TITLE
fix(build): restore live exports deleted by dead-export PRs #18010–#18027

### DIFF
--- a/lib/board_comment_rate_limit.ml
+++ b/lib/board_comment_rate_limit.ml
@@ -62,3 +62,5 @@ let sweep_stale ~now ~window =
     comment_timestamps;
   List.iter (Hashtbl.remove comment_timestamps) !stale_authors
 ;;
+
+let reset () = Hashtbl.clear comment_timestamps

--- a/lib/board_comment_rate_limit.mli
+++ b/lib/board_comment_rate_limit.mli
@@ -21,3 +21,7 @@ val record : author:string -> now:float -> unit
     than [window] seconds from [now] and removes any author whose list
     became empty. Called from the board-core sweep loop. *)
 val sweep_stale : now:float -> window:float -> unit
+
+(** [reset] clears all comment rate-limit tracking state.
+    Used by board_core when reinitializing the store. *)
+val reset : unit -> unit

--- a/lib/dune
+++ b/lib/dune
@@ -277,6 +277,7 @@
   keeper_memory_recall
   keeper_status_bridge
   keeper_runtime_trust_timeline
+  keeper_hooks_oas_gate_attempt
   keeper_hooks_oas_output_json
   keeper_hooks_oas_response_metrics
   keeper_hooks_oas_cost_events

--- a/lib/exec/exec_adaptive_timeout.ml
+++ b/lib/exec/exec_adaptive_timeout.ml
@@ -41,3 +41,39 @@ let compute config entries =
     clamped
   end
 
+type stats_result =
+  | Default of { reason : string; recommended_ms : int }
+  | Adapted of { p95_ms : int; recommended_ms : int; sample_count : int }
+
+let stats config entries =
+  let success_durations =
+    List.filter_map (fun (e : BH.history_entry) ->
+      if e.success then Some e.duration_ms else None
+    ) entries
+  in
+  let n = List.length success_durations in
+  if n < config.min_samples then
+    Default { reason = "insufficient_samples"; recommended_ms = config.default_ms }
+  else
+    let sorted = List.sort Int.compare success_durations in
+    let p95_idx = min (n - 1) (int_of_float (float_of_int n *. 0.95)) in
+    let p95 = List.nth sorted p95_idx in
+    let raw = int_of_float (float_of_int p95 *. config.multiplier) in
+    let clamped = min config.max_ms (max config.min_ms raw) in
+    Adapted { p95_ms = p95; recommended_ms = clamped; sample_count = n }
+
+let stats_to_json = function
+  | Default { reason; recommended_ms } ->
+    `Assoc [
+      ("adapted", `Bool false);
+      ("reason", `String reason);
+      ("recommended_ms", `Int recommended_ms);
+    ]
+  | Adapted { p95_ms; recommended_ms; sample_count } ->
+    `Assoc [
+      ("adapted", `Bool true);
+      ("p95_ms", `Int p95_ms);
+      ("recommended_ms", `Int recommended_ms);
+      ("sample_count", `Int sample_count);
+    ]
+

--- a/lib/exec/exec_adaptive_timeout.mli
+++ b/lib/exec/exec_adaptive_timeout.mli
@@ -23,3 +23,14 @@ val compute :
     Returns [default_ms] when fewer than [min_samples] successful runs
     are available. *)
 
+type stats_result =
+  | Default of { reason : string; recommended_ms : int }
+  | Adapted of { p95_ms : int; recommended_ms : int; sample_count : int }
+
+val stats : timeout_config -> Bash_history.history_entry list -> stats_result
+(** Return detailed statistics for the given entries, indicating whether
+    adaptation was possible or a default was used. *)
+
+val stats_to_json : stats_result -> Yojson.Safe.t
+(** Serialize stats_result to JSON for telemetry and test assertions. *)
+

--- a/lib/exec/words/shell_words.mli
+++ b/lib/exec/words/shell_words.mli
@@ -24,3 +24,8 @@ val stages : string -> (word list list, error) result
     Empty stages are omitted so callers can remain fail-closed at their own
     command-shape layer while still reusing successfully recovered words for
     diagnostics and path policy. *)
+
+val top_level_command_segments : string -> (bool * string) list
+(** Extract top-level command segments from a shell command string.
+    Returns a list of (is_quoted, segment) tuples for each segment.
+    Used by test fixtures and bash parser surfaces. *)

--- a/lib/exec_core.ml
+++ b/lib/exec_core.ml
@@ -375,7 +375,7 @@ let risk_of_command ~write_intent ~is_destructive family =
 let classify_command ~cmd =
   let tokens, write_intent, is_destructive =
     match Masc_exec_bash_parser.Bash.parse_string cmd with
-    | Parsed.Parsed ir ->
+    | Masc_exec.Parsed.Parsed ir ->
       ( Exec_policy_mutation_classifier.flat_stage_words ir,
         Exec_policy.is_write_operation ir,
         Exec_policy.is_destructive_bash_operation ir )

--- a/lib/exec_policy.ml
+++ b/lib/exec_policy.ml
@@ -840,6 +840,7 @@ let is_git_branch_switch = Mutation_classifier.is_git_branch_switch
 let is_destructive_bash_operation = Mutation_classifier.is_destructive_bash_operation
 let flat_stage_words = Mutation_classifier.flat_stage_words
 let stage_words_of_string = Mutation_classifier.stage_words_of_string
+let stage_words_of_string_result = Mutation_classifier.stage_words_of_string_result
 
 let sanitize_command_for_log = Log_sanitize.sanitize_command_for_log
 let truncate_for_log = Log_sanitize.truncate_for_log

--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -36,3 +36,7 @@ type run_result =
   ; pre_dispatch_compaction_after_tokens : int option
   }
 
+val tool_call_detail_to_json : tool_call_detail -> Yojson.Safe.t
+val surface_model_used : run_result -> string
+val surface_resolved_model_id : run_result -> string
+

--- a/lib/keeper/keeper_context_core_history.ml
+++ b/lib/keeper/keeper_context_core_history.ml
@@ -3,7 +3,6 @@
 open Keeper_types
 
 module StringSet = Set.Make (String)
-module Message_json = Keeper_context_core_message_json
 
 type history_migration_stats =
   { moved_lines : int
@@ -62,7 +61,7 @@ let classify_history_jsonl_line (line : string) : history_line_action option =
       | Some raw -> String.trim raw
       | None -> ""
     in
-    let content = String.trim (Message_json.text_of_history_jsonl_json json) in
+    let content = String.trim (Keeper_context_core_message_json.text_of_history_jsonl_json json) in
     Some (classify_history_entry ~source ~content)
   with
   | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None
@@ -216,7 +215,7 @@ let persist_message ?source session msg =
     let path = history_path_for_source ~session_dir:session.session_dir ~source in
     let now_ts = Time_compat.now () in
     let payload =
-      match Message_json.message_to_json msg with
+      match Keeper_context_core_message_json.message_to_json msg with
       | `Assoc fields ->
           let fields =
             match source with

--- a/lib/keeper/keeper_context_core_pair_repair_stats.ml
+++ b/lib/keeper/keeper_context_core_pair_repair_stats.ml
@@ -1,0 +1,54 @@
+(** Tool-pair repair stats and metadata helpers.
+
+    Counters and message-metadata bookkeeping for the
+    [repair_*_tool_*] family in [Keeper_context_core]. The repair
+    bodies themselves stay in the parent (they depend on the
+    parent's [tool_result_text_of_block] specialization, which
+    closes over the parent's
+    [default_max_checkpoint_tool_result_chars] constant).
+
+    Pure record / metadata helpers — no parent-local state, no I/O,
+    no callback injection. *)
+
+type tool_pair_repair_stats =
+  { downgraded_tool_uses : int
+  ; downgraded_tool_results : int
+  }
+
+let empty_tool_pair_repair_stats =
+  { downgraded_tool_uses = 0; downgraded_tool_results = 0 }
+
+let add_tool_pair_repair_stats left right =
+  { downgraded_tool_uses =
+      left.downgraded_tool_uses + right.downgraded_tool_uses
+  ; downgraded_tool_results =
+      left.downgraded_tool_results + right.downgraded_tool_results
+  }
+
+let tool_pair_repair_stats_changed stats =
+  stats.downgraded_tool_uses > 0 || stats.downgraded_tool_results > 0
+
+let pair_repair_metadata_key = "masc.tool_pair_repair"
+
+let pair_repair_metadata_keys =
+  [ "was_fabricated"; "fabrication_source"; pair_repair_metadata_key ]
+
+let with_pair_repair_metadata ~kind ~count (msg : Agent_sdk.Types.message) =
+  let metadata =
+    List.filter
+      (fun (key, _) -> not (List.mem key pair_repair_metadata_keys))
+      msg.metadata
+  in
+  { msg with
+    metadata =
+      [ "was_fabricated", `Bool true
+      ; "fabrication_source", `String "tool_pair_repair"
+      ; ( pair_repair_metadata_key
+        , `Assoc
+            [ "version", `Int 1
+            ; "kind", `String kind
+            ; "count", `Int count
+            ] )
+      ]
+      @ metadata
+  }

--- a/lib/keeper/keeper_context_core_pair_repair_stats.mli
+++ b/lib/keeper/keeper_context_core_pair_repair_stats.mli
@@ -1,0 +1,18 @@
+(** Tool-pair repair stats and metadata helpers for [Keeper_context_core]. *)
+
+type tool_pair_repair_stats =
+  { downgraded_tool_uses : int
+  ; downgraded_tool_results : int
+  }
+
+val empty_tool_pair_repair_stats : tool_pair_repair_stats
+
+val add_tool_pair_repair_stats :
+  tool_pair_repair_stats -> tool_pair_repair_stats -> tool_pair_repair_stats
+
+val tool_pair_repair_stats_changed : tool_pair_repair_stats -> bool
+val pair_repair_metadata_key : string
+val pair_repair_metadata_keys : string list
+
+val with_pair_repair_metadata :
+  kind:string -> count:int -> Agent_sdk.Types.message -> Agent_sdk.Types.message

--- a/lib/keeper/keeper_egress_audit.ml
+++ b/lib/keeper/keeper_egress_audit.ml
@@ -1,0 +1,116 @@
+(** Boot-time audit for keeper egress policy file placement.
+
+    Leak 11 (2026-04-27): keeper "executor" had its [egress.json] at the
+    host-direct path [playground/<name>/egress.json] while the docker
+    keeper code resolved [egress_policy_path] to
+    [playground/docker/<name>/egress.json].  The file at the wrong
+    location was never read; the lookup fail-closed for 24h+ and every
+    URL command surfaced as [egress_blocked, allowed=[]].
+
+    This module does no I/O writes — it inspects the file system and
+    classifies each keeper's policy file state.  Callers (boot hook,
+    CLI verification, tests) decide whether to log, fail, or repair.
+
+    Status taxonomy ─
+
+    [Ok_present] — expected path exists, no follow-up needed.
+
+    [Missing_at_expected] — expected path is absent and there is no
+    drifted copy elsewhere.  Operator should seed the file (egress
+    policy is fail-closed without it).
+
+    [Stale_orphan] — expected path is absent but a host-direct copy
+    exists.  Indicates the same drift class that produced Leak 11:
+    the file was seeded under the wrong sandbox_profile assumption.
+    Operator should move (or copy + delete the orphan).
+
+    Local keepers always treat [playground/<name>/] as the canonical
+    location, so the [Stale_orphan] class only applies to Docker
+    keepers. *)
+
+module Coord = Coord
+module Keeper_types = Keeper_types
+
+type audit_status =
+  | Ok_present
+  | Missing_at_expected of { expected_path : string }
+  | Stale_orphan of { expected_path : string; orphan_path : string }
+
+type result = {
+  agent_name : string;
+  keeper_name : string;
+  sandbox_profile : Keeper_types.sandbox_profile;
+  status : audit_status;
+}
+
+let host_direct_egress_path ~(config : Coord.config)
+    ~(meta : Keeper_types.keeper_meta) =
+  (* The pre-Leak-11 location used by host (Local) keepers and by the
+     external setup script that seeded executor's file at the wrong
+     branch.  We compute it explicitly so the audit can detect a
+     stale orphan even when the docker-path file is absent. *)
+  Filename.concat
+    (Filename.concat config.base_path
+       (Filename.concat ".masc/playground" meta.name))
+    "egress.json"
+
+let audit_one ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta) =
+  let expected = Keeper_shell_docker.egress_policy_path ~config ~meta in
+  let status =
+    match meta.sandbox_profile with
+    | Keeper_types.Local ->
+        if Sys.file_exists expected then Ok_present
+        else Missing_at_expected { expected_path = expected }
+    | Keeper_types.Docker ->
+        if Sys.file_exists expected then Ok_present
+        else
+          let orphan = host_direct_egress_path ~config ~meta in
+          if Sys.file_exists orphan then
+            Stale_orphan { expected_path = expected; orphan_path = orphan }
+          else Missing_at_expected { expected_path = expected }
+  in
+  {
+    agent_name = meta.agent_name;
+    keeper_name = meta.name;
+    sandbox_profile = meta.sandbox_profile;
+    status;
+  }
+
+let audit_all ~(config : Coord.config) ~(metas : Keeper_types.keeper_meta list)
+    =
+  List.map (fun meta -> audit_one ~config ~meta) metas
+
+(** A grep-friendly one-line summary; the boot hook emits this so
+    operators can locate drifted keepers from the system log without
+    reaching for Prometheus. *)
+let format_log_line (r : result) =
+  let profile = Keeper_types.sandbox_profile_to_string r.sandbox_profile in
+  match r.status with
+  | Ok_present ->
+      Printf.sprintf "[egress_audit:ok] keeper=%s profile=%s" r.keeper_name
+        profile
+  | Missing_at_expected { expected_path } ->
+      Printf.sprintf
+        "[egress_audit:missing] keeper=%s profile=%s expected=%s"
+        r.keeper_name profile expected_path
+  | Stale_orphan { expected_path; orphan_path } ->
+      Printf.sprintf
+        "[egress_audit:stale_orphan] keeper=%s profile=%s expected=%s \
+         orphan_at=%s"
+        r.keeper_name profile expected_path orphan_path
+
+let inactive_missing_reason (meta : Keeper_types.keeper_meta) =
+  if meta.paused then Some "paused"
+  else if not meta.autoboot_enabled then Some "autoboot_disabled"
+  else None
+
+(** Partition results by severity.  The boot hook can then route
+    [Ok] at debug level and [missing]/[stale] at warn. *)
+let partition (results : result list) =
+  List.fold_left
+    (fun (oks, missings, orphans) r ->
+      match r.status with
+      | Ok_present -> (r :: oks, missings, orphans)
+      | Missing_at_expected _ -> (oks, r :: missings, orphans)
+      | Stale_orphan _ -> (oks, missings, r :: orphans))
+    ([], [], []) results

--- a/lib/keeper/keeper_egress_audit.ml
+++ b/lib/keeper/keeper_egress_audit.ml
@@ -107,10 +107,13 @@ let inactive_missing_reason (meta : Keeper_types.keeper_meta) =
 (** Partition results by severity.  The boot hook can then route
     [Ok] at debug level and [missing]/[stale] at warn. *)
 let partition (results : result list) =
-  List.fold_left
-    (fun (oks, missings, orphans) r ->
-      match r.status with
-      | Ok_present -> (r :: oks, missings, orphans)
-      | Missing_at_expected _ -> (oks, r :: missings, orphans)
-      | Stale_orphan _ -> (oks, missings, r :: orphans))
-    ([], [], []) results
+  let oks, missings, orphans =
+    List.fold_left
+      (fun (oks, missings, orphans) r ->
+        match r.status with
+        | Ok_present -> (r :: oks, missings, orphans)
+        | Missing_at_expected _ -> (oks, r :: missings, orphans)
+        | Stale_orphan _ -> (oks, missings, r :: orphans))
+      ([], [], []) results
+  in
+  (List.rev oks, List.rev missings, List.rev orphans)

--- a/lib/keeper/keeper_egress_audit.mli
+++ b/lib/keeper/keeper_egress_audit.mli
@@ -1,0 +1,45 @@
+(** Boot-time audit for keeper egress policy file placement (Leak 11).
+
+    Inspects the file system without writes; classifies each keeper's
+    [egress.json] location.  Boot hooks, tests, and ops tooling
+    consume the structured results to decide on logging, alerting,
+    or repair. *)
+
+type audit_status =
+  | Ok_present
+  | Missing_at_expected of { expected_path : string }
+  | Stale_orphan of { expected_path : string; orphan_path : string }
+
+type result = {
+  agent_name : string;
+  keeper_name : string;
+  sandbox_profile : Keeper_types.sandbox_profile;
+  status : audit_status;
+}
+
+val audit_one :
+  config:Coord.config -> meta:Keeper_types.keeper_meta -> result
+(** Audit a single keeper's egress policy file location. *)
+
+val audit_all :
+  config:Coord.config ->
+  metas:Keeper_types.keeper_meta list ->
+  result list
+(** Audit every keeper meta supplied; pure mapping over [audit_one]. *)
+
+val host_direct_egress_path :
+  config:Coord.config -> meta:Keeper_types.keeper_meta -> string
+(** Pre-Leak-11 host-direct location: [playground/<name>/egress.json].
+    Exposed so boot hooks and tests can construct the same path the
+    audit uses for [Stale_orphan] detection. *)
+
+val format_log_line : result -> string
+(** Grep-friendly one-line summary tagged
+    [[egress_audit:ok|missing|stale_orphan]]. *)
+
+val inactive_missing_reason : Keeper_types.keeper_meta -> string option
+(** [Some reason] when a missing egress policy should not page operators
+    because the keeper is intentionally inactive. *)
+
+val partition : result list -> result list * result list * result list
+(** Split into [(ok, missing, stale_orphan)] in input order. *)

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -22,6 +22,13 @@
 include Keeper_hooks_oas_types
 open Keeper_hooks_oas_pr_metrics
 
+module Gate_attempt = Keeper_hooks_oas_gate_attempt
+
+let render_pre_tool_gate_output = Gate_attempt.render_pre_tool_gate_output
+let pre_tool_gate_error = Gate_attempt.pre_tool_gate_error
+let trajectory_duration_ms = Gate_attempt.trajectory_duration_ms
+let record_pre_tool_gate_attempt = Gate_attempt.record_pre_tool_gate_attempt
+
 (** Keeper deny list — derived from Tool_catalog surface SSOT.
     Administrative/destructive operations that should only be invoked
     by operators or through controlled workflows.
@@ -79,13 +86,6 @@ let idle_decision_to_label = function
   | Agent_sdk.Hooks.ApprovalRequired -> "approval_required"
   | Agent_sdk.Hooks.AdjustParams _ -> "adjust_params"
   | Agent_sdk.Hooks.ElicitInput _ -> "elicit_input"
-
-let trajectory_duration_ms duration_ms =
-  if
-    (not (Float.is_finite duration_ms))
-    || Float.compare duration_ms 0.0 <= 0
-  then 0
-  else max 1 (int_of_float (Float.round duration_ms))
 
 let failure_class_of_tool_error_json json =
   let direct = Safe_ops.json_string_opt "failure_class" json in
@@ -234,7 +234,13 @@ let make_hooks
      [make_hooks] closure — one state per keeper. *)
   let streak_state = Keeper_guards.make_streak_state () in
   let streak_threshold = 5 in
-  let record_gate_decision _event = () in
+  let record_gate_decision event =
+    record_pre_tool_gate_attempt
+      ~meta_ref
+      ~tool_call_count_ref
+      ?trajectory_acc
+      event
+  in
   (* Build the pre_tool_use guard chain via Hooks.compose. Each guard
      lives in Keeper_guards and emits its own masc:keeper_gate event
      on override/approval decisions. The observer persists the same

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -20,6 +20,7 @@
     bindings — see classify_usage_trust which calls
     [context_max_of_telemetry]. *)
 include Keeper_hooks_oas_types
+open Keeper_hooks_oas_pr_metrics
 
 (** Keeper deny list — derived from Tool_catalog surface SSOT.
     Administrative/destructive operations that should only be invoked
@@ -78,6 +79,13 @@ let idle_decision_to_label = function
   | Agent_sdk.Hooks.ApprovalRequired -> "approval_required"
   | Agent_sdk.Hooks.AdjustParams _ -> "adjust_params"
   | Agent_sdk.Hooks.ElicitInput _ -> "elicit_input"
+
+let trajectory_duration_ms duration_ms =
+  if
+    (not (Float.is_finite duration_ms))
+    || Float.compare duration_ms 0.0 <= 0
+  then 0
+  else max 1 (int_of_float (Float.round duration_ms))
 
 let failure_class_of_tool_error_json json =
   let direct = Safe_ops.json_string_opt "failure_class" json in
@@ -226,13 +234,7 @@ let make_hooks
      [make_hooks] closure — one state per keeper. *)
   let streak_state = Keeper_guards.make_streak_state () in
   let streak_threshold = 5 in
-  let record_gate_decision event =
-    record_pre_tool_gate_attempt
-      ~meta_ref
-      ~tool_call_count_ref
-      ?trajectory_acc
-      event
-  in
+  let record_gate_decision _event = () in
   (* Build the pre_tool_use guard chain via Hooks.compose. Each guard
      lives in Keeper_guards and emits its own masc:keeper_gate event
      on override/approval decisions. The observer persists the same

--- a/lib/keeper/keeper_hooks_oas_gate_attempt.ml
+++ b/lib/keeper/keeper_hooks_oas_gate_attempt.ml
@@ -1,0 +1,157 @@
+open Keeper_hooks_oas_types
+
+let render_pre_tool_gate_source_hint
+    (event : Keeper_guards.gate_decision_event) =
+  match event.source_path, event.source_line with
+  | None, None -> ""
+  | Some path, None ->
+      Printf.sprintf " source_path=%s" (Keeper_guards.escape_field path)
+  | None, Some line -> Printf.sprintf " source_line=%d" line
+  | Some path, Some line ->
+      Printf.sprintf " source_path=%s source_line=%d"
+        (Keeper_guards.escape_field path) line
+
+let tool_approval_required_tag = "[tool_approval_required]"
+
+let render_pre_tool_gate_output (event : Keeper_guards.gate_decision_event) =
+  if event.decision = Keeper_guards.Gate_approval_required then
+    Printf.sprintf
+      "%s tool=%s source=keeper_hook code=%s reason=%s%s"
+      tool_approval_required_tag
+      (Keeper_guards.escape_field event.tool_name)
+      (Keeper_guards.escape_field event.reason_code)
+      (Keeper_guards.escape_field event.reason_text)
+      (render_pre_tool_gate_source_hint event)
+  else
+    match event.source_path, event.source_line with
+    | Some source_path, Some source_line ->
+        Keeper_guards.render_inline_skip_reason_with_source
+          ~source_path
+          ~source_line
+          ~tool_name:event.tool_name
+          ~reason_code:event.reason_code
+          ~reason_text:event.reason_text
+    | _ ->
+        Keeper_guards.render_inline_skip_reason
+          ~tool_name:event.tool_name
+          ~reason_code:event.reason_code
+          ~reason_text:event.reason_text
+
+let pre_tool_gate_error (event : Keeper_guards.gate_decision_event) =
+  let decision = Keeper_guards.gate_decision_to_string event.decision in
+  Printf.sprintf "%s:%s: %s" decision event.reason_code event.reason_text
+
+let min_duration_ms = 0.0
+
+let trajectory_duration_ms duration_ms =
+  if
+    (not (Float.is_finite duration_ms))
+    || Float.compare duration_ms min_duration_ms <= 0
+  then 0
+  else max 1 (int_of_float (Float.round duration_ms))
+
+let record_pre_tool_gate_attempt
+    ~(meta_ref : Keeper_types.keeper_meta ref)
+    ~(tool_call_count_ref : int ref)
+    ?(trajectory_acc : Trajectory.accumulator option)
+    (event : Keeper_guards.gate_decision_event) =
+  incr tool_call_count_ref;
+  let meta = !meta_ref in
+  let keeper_name = meta.name in
+  let model = current_keeper_model meta in
+  let safe_input = Observability_redact.redact_json_value event.input in
+  let output_text = render_pre_tool_gate_output event in
+  let error = pre_tool_gate_error event in
+  let duration_ms = Float.max 0.0 event.stage_latency_ms in
+  (try
+     Keeper_tool_call_log.log_call
+       ~keeper_name
+       ~tool_name:event.tool_name
+       ~input:safe_input
+       ~output_text
+       ~success:false
+       ~duration_ms
+       ~model
+       ~result_bytes:(String.length output_text)
+       ()
+   with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
+       let callback_label_gate_tool_call_log = "gate_tool_call_log" in
+       Prometheus.inc_counter
+         Keeper_metrics.metric_keeper_lifecycle_callback_failures
+         ~labels:
+           [
+             (label_keeper, keeper_name);
+             (label_callback, callback_label_gate_tool_call_log);
+           ]
+         ();
+       Log.Keeper.warn
+         "keeper:%s pre_tool_use gate tool_call log failed tool=%s err=%s"
+         keeper_name event.tool_name (Printexc.to_string exn));
+  match trajectory_acc with
+  | None -> ()
+  | Some acc ->
+      let trace_id = acc.Trajectory.trace_id in
+      let runtime_contract =
+        Keeper_tool_call_log.runtime_contract_json_for_call
+          ~keeper_name
+          ~model
+          ()
+      in
+      let action_radius =
+        Keeper_tool_call_log.action_radius_json_for_call
+          ~keeper_name
+          ~tool_name:event.tool_name
+          ~input:safe_input
+          ~success:false
+          ~duration_ms
+          ~error
+          ()
+      in
+      let now = Time_compat.now () in
+      let turn = if event.turn > 0 then event.turn else acc.Trajectory.turn in
+      let round =
+        acc.Trajectory.entries
+        |> List.filter (fun (e : Trajectory.tool_call_entry) -> e.turn = turn)
+        |> List.length
+        |> ( + ) 1
+      in
+      let entry : Trajectory.tool_call_entry =
+        {
+          ts = now;
+          ts_iso = Masc_domain.iso8601_of_unix_seconds now;
+          turn;
+          round;
+          tool_name = event.tool_name;
+          args_json = Yojson.Safe.to_string safe_input;
+          gate_decision = Trajectory.Reject error;
+          result = Some output_text;
+          duration_ms = trajectory_duration_ms duration_ms;
+          error = Some error;
+          cost_usd = 0.0;
+        }
+      in
+      Trajectory.record_entry
+        ~runtime_contract
+        ~action_radius
+        ~on_persist_error:(fun exn ->
+          let dashboard_surface_tool_stats = "/api/v1/keepers/:name/tool-stats" in
+          let stale_reason_trajectory_append = "trajectory_append_failed" in
+          let telemetry_source_trajectory = "trajectory_tool_call" in
+          let telemetry_producer_pre_tool = "keeper_hooks_oas.pre_tool_use" in
+          Telemetry_coverage_gap.record
+            ~masc_root:acc.Trajectory.masc_root
+            ~source:telemetry_source_trajectory
+            ~producer:telemetry_producer_pre_tool
+            ~durable_store:
+              (Trajectory.trajectory_path acc.Trajectory.masc_root
+                 acc.Trajectory.keeper_name trace_id)
+            ~dashboard_surface:dashboard_surface_tool_stats
+            ~stale_reason:stale_reason_trajectory_append
+            ~keeper_name
+            ~trace_id
+            ~exn
+            ())
+        acc
+        entry

--- a/lib/keeper/keeper_hooks_oas_gate_attempt.mli
+++ b/lib/keeper/keeper_hooks_oas_gate_attempt.mli
@@ -1,0 +1,16 @@
+(** Pre-tool gate attempt rendering and telemetry for OAS keeper hooks. *)
+
+val render_pre_tool_gate_output :
+  Keeper_guards.gate_decision_event -> string
+
+val pre_tool_gate_error :
+  Keeper_guards.gate_decision_event -> string
+
+val trajectory_duration_ms : float -> int
+
+val record_pre_tool_gate_attempt :
+  meta_ref:Keeper_types.keeper_meta ref ->
+  tool_call_count_ref:int ref ->
+  ?trajectory_acc:Trajectory.accumulator ->
+  Keeper_guards.gate_decision_event ->
+  unit

--- a/lib/keeper/keeper_hooks_oas_pr_metrics.ml
+++ b/lib/keeper/keeper_hooks_oas_pr_metrics.ml
@@ -1,0 +1,370 @@
+(** PR action metric helpers for [Keeper_hooks_oas]. *)
+
+open Keeper_hooks_oas_types
+
+open Keeper_hooks_oas_output_json
+
+let pr_review_action_metric_event_of_tool_io
+    ~route_via_fallback
+    ~(tool_name : string)
+    ~(input : Yojson.Safe.t)
+    ~(output_text : string)
+    ~(transport_success : bool) =
+  match tool_name with
+  | "keeper_pr_review_comment" ->
+      let output_json = output_json_opt ~surface:"pr_review_action" output_text in
+      let route_via =
+        first_some (Option.bind output_json route_via_of_json)
+          route_via_fallback
+      in
+      let action =
+        match output_json with
+        | Some json -> Safe_ops.json_string_opt "event" json
+        | None -> None
+      in
+      let action =
+        match action with
+        | Some value -> Some value
+        | None -> Safe_ops.json_string_opt "event" input
+      in
+      let success =
+        output_success ~transport_success output_json
+      in
+      let credential = Option.bind output_json (assoc_json_opt "credential") in
+      let identity_attestation =
+        Option.bind output_json (assoc_json_opt "identity_attestation")
+      in
+      Option.map
+        (fun action ->
+           {
+             action;
+             pr_number =
+               first_some
+                 (match output_json with
+                  | Some json -> json_int_opt "pr_number" json
+                  | None -> None)
+                 (json_int_opt "pr_number" input);
+             comment_id = None;
+             success;
+             route_via;
+             credential;
+             identity_attestation;
+           })
+        (Option.bind action normalize_pr_review_action)
+  | "keeper_pr_review_reply" ->
+      let output_json = output_json_opt ~surface:"pr_review_action" output_text in
+      let route_via =
+        first_some (Option.bind output_json route_via_of_json)
+          route_via_fallback
+      in
+      let success =
+        output_success ~transport_success output_json
+      in
+      let credential = Option.bind output_json (assoc_json_opt "credential") in
+      let identity_attestation =
+        Option.bind output_json (assoc_json_opt "identity_attestation")
+      in
+      Some
+        {
+          action = "REPLY";
+          pr_number =
+            first_some
+              (match output_json with
+               | Some json -> json_int_opt "pr_number" json
+               | None -> None)
+              (json_int_opt "pr_number" input);
+          comment_id =
+            first_some
+              (match output_json with
+               | Some json -> json_int_opt "comment_id" json
+               | None -> None)
+              (json_int_opt "comment_id" input);
+          success;
+          route_via;
+          credential;
+          identity_attestation;
+        }
+  | "keeper_shell" ->
+      let output_json = output_json_opt ~surface:"pr_review_action" output_text in
+      let route_via =
+        first_some (Option.bind output_json route_via_of_json)
+          route_via_fallback
+      in
+      let success =
+        output_success ~transport_success output_json
+      in
+      command_candidates_of_tool_io ~tool_name ~input ~output_json
+      |> List.find_map gh_pr_review_action_of_command
+      |> Option.map (fun (action, pr_number) ->
+           {
+             action;
+             pr_number;
+             comment_id = None;
+             success;
+             route_via;
+             credential = None;
+             identity_attestation = None;
+           })
+  | _ -> None
+
+let pr_work_action_of_git_action raw =
+  match String.trim raw |> String.lowercase_ascii with
+  | "add" -> Some "GIT_ADD"
+  | "commit" -> Some "GIT_COMMIT"
+  | "push" -> Some "GIT_PUSH"
+  | _ -> None
+
+let pr_work_actions_of_git_segment segment =
+  match Masc_exec_bash_parser.Bash.parse_string segment with
+  | Masc_exec.Parsed.Parsed (Masc_exec.Shell_ir.Simple simple)
+    when String.equal
+           (Masc_exec.Bin.to_string simple.bin |> String.lowercase_ascii)
+           "git" ->
+      (match simple.args with
+       | Masc_exec.Shell_ir.Lit (action, _) :: _ ->
+           pr_work_action_of_git_action action |> Option.to_list
+       | _ -> [])
+  | _ ->
+      let lower = String.trim segment |> String.lowercase_ascii in
+      let starts_with_word prefix =
+        String.equal lower prefix
+        || (String.length lower > String.length prefix
+            && String.starts_with ~prefix:(prefix ^ " ") lower)
+      in
+      if starts_with_word "git push" then [ "GIT_PUSH" ]
+      else if starts_with_word "git commit" then [ "GIT_COMMIT" ]
+      else if starts_with_word "git add" then [ "GIT_ADD" ]
+      else []
+
+let pr_work_actions_of_gh_segment segment =
+  match gh_argv_of_segment segment with
+  | Some (subcommand :: action :: _)
+    when String.equal (String.lowercase_ascii subcommand) "pr"
+         && String.equal (String.lowercase_ascii action) "create" ->
+      [ "PR_CREATE" ]
+  | _ -> []
+
+let pr_work_actions_of_command command =
+  Masc_exec_bash_parser.Bash_words.top_level_command_segments command
+  |> List.concat_map (fun (unconditional, segment) ->
+       (* Shell conditionals can skip later segments at runtime.  Without
+          per-segment exit data, count only top-level segments that are
+          unconditionally reached. *)
+       if not unconditional then []
+       else
+         match pr_work_actions_of_gh_segment segment with
+         | [] -> pr_work_actions_of_git_segment segment
+         | actions -> actions)
+
+let is_pr_work_action_tool_name = function
+  | "masc_code_git"
+  | "keeper_shell"
+  | "keeper_bash"
+  | "masc_code_shell" -> true
+  | _ -> false
+
+let pr_work_action_metric_events_of_tool_io
+    ~route_via_fallback
+    ~(tool_name : string)
+    ~(input : Yojson.Safe.t)
+    ~(output_text : string)
+    ~(transport_success : bool) =
+  if not (is_pr_work_action_tool_name tool_name) then []
+  else
+  let observe_json_failure =
+    match tool_name with
+    | "keeper_shell" | "keeper_bash" | "masc_code_shell" -> false
+    | _ -> true
+  in
+  let output_json =
+    output_json_opt ~observe_failure:observe_json_failure
+      ~surface:"pr_work_action" output_text
+  in
+  let route_via =
+    first_some (Option.bind output_json route_via_of_json)
+      route_via_fallback
+  in
+  let success = output_success ~transport_success output_json in
+  match tool_name with
+  | "masc_code_git" ->
+      let action =
+        match output_json with
+        | Some json -> Safe_ops.json_string_opt "action" json
+        | None -> None
+      in
+      let action =
+        match action with
+        | Some value -> Some value
+        | None -> Safe_ops.json_string_opt "action" input
+      in
+      (match Option.bind action pr_work_action_of_git_action with
+       | None -> []
+       | Some work_action ->
+           [
+             {
+               work_action;
+               work_source = "masc_code_git";
+               work_ref = None;
+               pr_url = None;
+               command = None;
+               success;
+               route_via;
+             };
+           ])
+  | "keeper_shell" | "keeper_bash" | "masc_code_shell" ->
+      command_candidates_of_tool_io ~tool_name ~input ~output_json
+      |> List.concat_map (fun command ->
+           pr_work_actions_of_command command
+           |> List.map (fun work_action ->
+                ( command,
+                  {
+                    work_action;
+                    work_source = tool_name;
+                    work_ref = None;
+                    pr_url = None;
+                    command = Some command;
+                    success;
+                    route_via;
+                  } )))
+      |> List.fold_left
+           (fun (seen, events) (_command, event) ->
+              let key = event.work_action in
+              if List.mem key seen then (seen, events)
+              else (key :: seen, events @ [ event ]))
+           ([], [])
+      |> snd
+  | _ -> []
+
+let append_pr_review_action_metric
+    ~(config : Coord.config)
+    ~(meta : Keeper_types.keeper_meta)
+    ~(generation : int)
+    ~(tool_name : string)
+    ~(input : Yojson.Safe.t)
+    ~(output_text : string)
+    ~(transport_success : bool)
+    ~(duration_ms : float)
+    () =
+  let route_via_fallback =
+    match meta.sandbox_profile, tool_name with
+    | Docker, ("keeper_pr_review_comment" | "keeper_pr_review_reply") ->
+        Some "brokered"
+    | Docker, "keeper_shell" ->
+        Some "docker"
+    | _ -> None
+  in
+  match
+    pr_review_action_metric_event_of_tool_io
+      ~route_via_fallback ~tool_name ~input ~output_text ~transport_success
+  with
+  | None -> ()
+  | Some event ->
+      let now = Time_compat.now () in
+      let store = Keeper_types.keeper_pr_action_metrics_store config meta.name in
+      let route_fields =
+        match event.route_via with
+        | None -> []
+        | Some via -> [(key_via, `String via); (key_route_via, `String via)]
+      in
+      let identity_fields =
+        []
+        |> (fun fields ->
+             match event.credential with
+             | None -> fields
+             | Some credential -> ("credential", credential) :: fields)
+        |> (fun fields ->
+             match event.identity_attestation with
+             | None -> fields
+             | Some attestation -> ("identity_attestation", attestation) :: fields)
+        |> List.rev
+      in
+      let snapshot =
+        `Assoc
+          ([
+             (key_ts, `String (Masc_domain.iso8601_of_unix_seconds now));
+             (key_ts_unix, `Float now);
+             (key_channel, `String "tool_event");
+             (key_metric_event, `String "keeper_pr_review_action");
+             (key_name, `String meta.name);
+             (key_agent_name, `String meta.agent_name);
+             ( "trace_id",
+               `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id) );
+             (key_generation, `Int generation);
+             (key_tool_name, `String tool_name);
+             (key_pr_review_action, `String event.action);
+             (key_pr_review_action_success, `Bool event.success);
+             (key_tool_call_count, `Int 0);
+             (key_tools_used, `List []);
+             ("pr_number", Json_util.int_opt_to_json event.pr_number);
+             ("comment_id", Json_util.int_opt_to_json event.comment_id);
+             (key_duration_ms, `Float duration_ms);
+           ]
+           @ route_fields
+           @ identity_fields)
+      in
+      Dated_jsonl.append store (Inference_utils.sanitize_json_utf8 snapshot)
+
+let append_pr_work_action_metrics
+    ~(config : Coord.config)
+    ~(meta : Keeper_types.keeper_meta)
+    ~(generation : int)
+    ~(tool_name : string)
+    ~(input : Yojson.Safe.t)
+    ~(output_text : string)
+    ~(transport_success : bool)
+    ~(duration_ms : float)
+    () =
+  let route_via_fallback =
+    match meta.sandbox_profile, tool_name with
+    | Docker, "keeper_shell" -> Some "docker"
+    | Docker, ("keeper_bash" | "masc_code_shell" | "masc_code_git") ->
+        Some "docker"
+    | _ -> None
+  in
+  let events =
+    pr_work_action_metric_events_of_tool_io
+      ~route_via_fallback ~tool_name ~input ~output_text ~transport_success
+  in
+  match events with
+  | [] -> ()
+  | _ ->
+      let store = Keeper_types.keeper_pr_action_metrics_store config meta.name in
+      List.iter
+        (fun event ->
+           let now = Time_compat.now () in
+           let route_fields =
+             match event.route_via with
+             | None -> []
+             | Some via -> [(key_via, `String via); (key_route_via, `String via)]
+           in
+           let snapshot =
+             `Assoc
+               ([
+                  (key_ts, `String (Masc_domain.iso8601_of_unix_seconds now));
+                  (key_ts_unix, `Float now);
+                  (key_channel, `String "tool_event");
+                  (key_metric_event, `String "keeper_pr_work_action");
+                  (key_name, `String meta.name);
+                  (key_agent_name, `String meta.agent_name);
+                  ( "trace_id",
+                    `String
+                      (Keeper_id.Trace_id.to_string meta.runtime.trace_id) );
+                  (key_generation, `Int generation);
+                  (key_tool_name, `String tool_name);
+                  (key_pr_work_action, `String event.work_action);
+                  (key_pr_work_action_source, `String event.work_source);
+                  (key_pr_work_action_success, `Bool event.success);
+                  ( "pr_work_ref",
+                    Json_util.string_opt_to_json event.work_ref );
+                  ("pr_url", Json_util.string_opt_to_json event.pr_url);
+                  ( "pr_work_command",
+                    Json_util.string_opt_to_json event.command );
+                  (key_tool_call_count, `Int 0);
+                  (key_tools_used, `List []);
+                  (key_duration_ms, `Float duration_ms);
+                ]
+                @ route_fields)
+           in
+           Dated_jsonl.append store
+             (Inference_utils.sanitize_json_utf8 snapshot))
+        events

--- a/lib/keeper/keeper_hooks_oas_pr_metrics.mli
+++ b/lib/keeper/keeper_hooks_oas_pr_metrics.mli
@@ -1,0 +1,41 @@
+(** PR action metric helpers for [Keeper_hooks_oas]. *)
+
+val pr_review_action_metric_event_of_tool_io
+  :  route_via_fallback:string option
+  -> tool_name:string
+  -> input:Yojson.Safe.t
+  -> output_text:string
+  -> transport_success:bool
+  -> Keeper_hooks_oas_types.pr_review_action_metric_event option
+
+val pr_work_action_metric_events_of_tool_io
+  :  route_via_fallback:string option
+  -> tool_name:string
+  -> input:Yojson.Safe.t
+  -> output_text:string
+  -> transport_success:bool
+  -> Keeper_hooks_oas_types.pr_work_action_metric_event list
+
+val append_pr_review_action_metric
+  :  config:Coord.config
+  -> meta:Keeper_types.keeper_meta
+  -> generation:int
+  -> tool_name:string
+  -> input:Yojson.Safe.t
+  -> output_text:string
+  -> transport_success:bool
+  -> duration_ms:float
+  -> unit
+  -> unit
+
+val append_pr_work_action_metrics
+  :  config:Coord.config
+  -> meta:Keeper_types.keeper_meta
+  -> generation:int
+  -> tool_name:string
+  -> input:Yojson.Safe.t
+  -> output_text:string
+  -> transport_success:bool
+  -> duration_ms:float
+  -> unit
+  -> unit

--- a/lib/keeper/keeper_meta_json_scrub.ml
+++ b/lib/keeper/keeper_meta_json_scrub.ml
@@ -1,0 +1,93 @@
+(** Keeper meta JSON removed-field scrub helpers.
+
+    Kept below the codec/parser facade so persisted runtime JSON can be
+    normalized before strict [keeper_meta] decoding. *)
+
+open Keeper_types_profile
+open Keeper_meta_contract
+
+let drop_assoc_keys (keys : string list) (json : Yojson.Safe.t) : Yojson.Safe.t =
+  match json with
+  | `Assoc fields -> `Assoc (List.filter (fun (key, _) -> not (List.mem key keys)) fields)
+  | _ -> json
+;;
+
+let reject_removed_keeper_meta_fields (json : Yojson.Safe.t) =
+  let present = present_json_keys removed_keeper_meta_key_names json in
+  match present with
+  | [] -> Ok ()
+  | fields ->
+    Error (Printf.sprintf "removed keeper meta fields: %s" (String.concat ", " fields))
+;;
+
+let legacy_keeper_meta_tool_policy_key_names =
+  [ "tool_preset"; "tool_also_allow"; "tool_custom_allowlist"; "tool_allowlist" ]
+;;
+
+let legacy_keeper_meta_key_names =
+  "allowed_providers" :: legacy_keeper_meta_tool_policy_key_names
+;;
+
+let reject_legacy_keeper_meta_fields (json : Yojson.Safe.t) =
+  let present = present_json_keys legacy_keeper_meta_key_names json in
+  match present with
+  | [] -> Ok ()
+  | fields ->
+    Error
+      (Printf.sprintf
+         "legacy keeper meta fields are no longer supported: %s"
+         (String.concat ", " fields))
+;;
+
+let scrub_persisted_keeper_meta_json ~path (json : Yojson.Safe.t) : Yojson.Safe.t * bool =
+  match json with
+  | `Assoc fields ->
+    let removed_present =
+      fields
+      |> List.filter_map (fun (key, _) ->
+        if List.mem key removed_keeper_meta_key_names then Some key else None)
+    in
+    let removed_to_scrub =
+      removed_present
+      |> List.filter (fun key -> not (List.mem key legacy_keeper_meta_key_names))
+    in
+    if removed_to_scrub = []
+    then json, false
+    else (
+      let migrate_legacy_disabled_keepalive =
+        (match List.assoc_opt "presence_keepalive" fields with
+         | Some (`Bool false) -> true
+         | _ -> false)
+        && not (List.mem_assoc "paused" fields)
+      in
+      let scrubbed =
+        let base = drop_assoc_keys removed_to_scrub json in
+        match base with
+        | `Assoc base_fields when migrate_legacy_disabled_keepalive ->
+          `Assoc (("paused", `Bool true) :: List.remove_assoc "paused" base_fields)
+        | _ -> base
+      in
+      let content = Yojson.Safe.pretty_to_string scrubbed in
+      (try
+         Fs_compat.save_file path content;
+         Log.Keeper.info
+           "scrubbed legacy keeper meta fields for %s: %s%s"
+           path
+           (String.concat ", " removed_to_scrub)
+           (if migrate_legacy_disabled_keepalive
+            then " (migrated presence_keepalive=false to paused=true)"
+            else "")
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+         Prometheus.inc_counter
+           Keeper_metrics.metric_keeper_meta_json_failures
+           ~labels:[("site", "scrub")]
+           ();
+         Log.Keeper.warn
+           "failed to scrub removed keeper meta fields for %s: %s"
+           path
+           (Printexc.to_string exn));
+      scrubbed, true)
+  | _ -> json, false
+;;

--- a/lib/keeper/keeper_meta_json_scrub.mli
+++ b/lib/keeper/keeper_meta_json_scrub.mli
@@ -1,0 +1,34 @@
+(** Keeper meta JSON removed-field scrub helpers.
+
+    Lives below the codec/parser facade so persisted runtime JSON can
+    be normalized before strict [keeper_meta] decoding. *)
+
+(** Drop the named keys from a top-level JSON object; passes through
+    non-objects unchanged. *)
+val drop_assoc_keys : string list -> Yojson.Safe.t -> Yojson.Safe.t
+
+(** Returns [Error msg] if any [removed_keeper_meta_key_names] is
+    present at the top level (these have been deleted from the schema
+    and must not appear). *)
+val reject_removed_keeper_meta_fields :
+  Yojson.Safe.t -> (unit, string) result
+
+(** Legacy tool-policy keys that are no longer supported. *)
+val legacy_keeper_meta_tool_policy_key_names : string list
+
+(** Combined legacy key names (allowed_providers + tool-policy keys). *)
+val legacy_keeper_meta_key_names : string list
+
+(** Returns [Error msg] if any legacy key is present. *)
+val reject_legacy_keeper_meta_fields :
+  Yojson.Safe.t -> (unit, string) result
+
+(** [scrub_persisted_keeper_meta_json ~path json] migrates persisted
+    keeper meta to the current schema for removed non-tool fields
+    (including presence_keepalive=false→paused=true) and writes the
+    scrubbed content back to [path] when changes were needed. Legacy
+    tool policy fields are intentionally not rewritten. Returns the
+    scrubbed JSON and a [bool] indicating whether the file was
+    rewritten. *)
+val scrub_persisted_keeper_meta_json :
+  path:string -> Yojson.Safe.t -> Yojson.Safe.t * bool

--- a/lib/keeper/keeper_path_check_error.mli
+++ b/lib/keeper/keeper_path_check_error.mli
@@ -40,3 +40,9 @@ val to_message : t -> string
     so downstream tools that match on these messages keep their
     contract. *)
 
+val parse_prefix : string -> t option
+(** Attempt to classify a raw error message by its prefix.
+    Returns [Some t] if the message matches a known prefix pattern,
+    [None] otherwise. Used by failure-circuit-breaker for typed
+    error classification without substring grepping. *)
+

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -7,6 +7,7 @@
 
 open Keeper_types
 open Keeper_exec_shared
+open Keeper_shell_docker_exec_failure
 
 let path_exists path =
   try Sys.file_exists path with

--- a/lib/keeper/keeper_shell_docker.mli
+++ b/lib/keeper/keeper_shell_docker.mli
@@ -5,19 +5,6 @@
     invocation. Pure infrastructure; generic command-shape policy lives
     in [Keeper_shell_command_semantics]. *)
 
-(** Diagnostic label for a [Unix.process_status]:
-    [exit=N] / [signal=N] / [stopped=N]. *)
-val docker_exec_status_label : Unix.process_status -> string
-
-(** Build a structured failure message used by docker exec
-    diagnostics, emphasising the exit/signal status and (when
-    blank) flagging empty output explicitly. *)
-val docker_exec_failure_message :
-  image:string ->
-  status:Unix.process_status ->
-  output:string ->
-  string
-
 (** Path of the per-keeper egress policy file
     [<sandbox_root>/egress.json]. *)
 val egress_policy_path :

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -161,7 +161,6 @@ let workflow_rejection_scope_block_record counts key (info : Keeper_tools_oas_wo
     in
     let block =
       { Keeper_tools_oas_workflow.count = previous_count + 1
-      ; task_id = info.Keeper_tools_oas_workflow.task_id
       ; rule_id = info.Keeper_tools_oas_workflow.rule_id
       ; tool_suggestion = info.Keeper_tools_oas_workflow.tool_suggestion
       ; hint = info.Keeper_tools_oas_workflow.hint

--- a/lib/keeper/keeper_tools_oas_workflow.ml
+++ b/lib/keeper/keeper_tools_oas_workflow.ml
@@ -14,7 +14,6 @@ type workflow_rejection_info =
 
 type workflow_rejection_block =
   { count : int
-  ; task_id : string option
   ; rule_id : string option
   ; tool_suggestion : string option
   ; hint : string option

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -15,6 +15,7 @@ let degraded_keeper_runtime_identity_fields = Operator_control_snapshot_identity
    include flows through to [Operator_control] via
    [Operator_control_action] in the existing include chain. *)
 include Operator_control_snapshot_action_log
+include Operator_control_snapshot_cache
 
 let json_ok = Tool_args.ok_assoc
 

--- a/lib/operator/operator_control_snapshot_cache.ml
+++ b/lib/operator/operator_control_snapshot_cache.ml
@@ -41,6 +41,55 @@ type snapshot_slot =
 
 let _snapshot_table : (string, snapshot_slot) Hashtbl.t = Hashtbl.create 4
 let _snapshot_mu = Eio.Mutex.create ()
+let _snapshot_ttl_s = Env_config.Operator.cache_ttl_sec
+
+(* Maximum snapshot cache entries.  Each entry holds a full JSON snapshot
+   tree which can be several MB.  Unbounded growth caused OOM when the
+   dashboard was connected for extended periods (#4795). *)
+let _snapshot_max_entries = 16
+
+(* Evict one expired or oldest entry when table reaches _snapshot_max_entries.
+   Called inside _snapshot_mu when Eio is ready; pre-Eio callers are
+   single-threaded so no lock is needed. *)
+let _maybe_evict_snapshot () =
+  if Hashtbl.length _snapshot_table >= _snapshot_max_entries
+  then (
+    let now_ts = Time_compat.now () in
+    (* Prefer expired entries *)
+    let victim = ref None in
+    Hashtbl.iter
+      (fun key slot ->
+         match slot, !victim with
+         | Cached { expires_at; _ }, None when now_ts >= expires_at -> victim := Some key
+         | Cached _, None -> ()
+         | Cached _, Some _ -> ()
+         | Computing _, _ -> ())
+      _snapshot_table;
+    match !victim with
+    | Some key -> Hashtbl.remove _snapshot_table key
+    | None ->
+      (* All fresh or computing — evict the entry closest to expiry *)
+      let oldest_cached = ref None in
+      let any_key = ref None in
+      Hashtbl.iter
+        (fun key slot ->
+           match slot with
+           | Cached { expires_at; _ } ->
+             (match !oldest_cached with
+              | None -> oldest_cached := Some (key, expires_at)
+              | Some (_, e) when expires_at < e -> oldest_cached := Some (key, expires_at)
+              | Some _ -> ())
+           | Computing _ -> if !any_key = None then any_key := Some key)
+        _snapshot_table;
+      (match !oldest_cached with
+       | Some (key, _) -> Hashtbl.remove _snapshot_table key
+       | None ->
+         (* Never evict an in-flight compute to enforce the entry cap.  Under
+            64-keeper load, replacing a [Computing] slot starts duplicate
+            dashboard snapshots while the old one is still doing filesystem
+            work.  Temporary cache growth is cheaper than a compute stampede. *)
+         ignore !any_key))
+;;
 
 let invalidate_snapshot_cache () =
   if Eio_guard.is_ready ()

--- a/lib/operator/operator_control_snapshot_cache.mli
+++ b/lib/operator/operator_control_snapshot_cache.mli
@@ -12,4 +12,9 @@ type snapshot_slot =
       ; stuck_warned : bool ref
       }
 
+val _snapshot_table : (string, snapshot_slot) Hashtbl.t
+val _snapshot_mu : Eio.Mutex.t
+val _snapshot_ttl_s : float
+val _maybe_evict_snapshot : unit -> unit
+
 val invalidate_snapshot_cache : unit -> unit

--- a/lib/server/server_dashboard_cascade_profile_gate.ml
+++ b/lib/server/server_dashboard_cascade_profile_gate.ml
@@ -1,0 +1,123 @@
+(** Dashboard cascade profile gate — determines which cascade profiles
+    are assignable to a keeper, distinguishing
+    {[
+      valid_profiles
+    ]} from
+    {[
+      invalid_profiles
+    ]}
+    and
+    {[
+      invalid_assignments
+    ]}.
+
+    Extracted from [server_routes_http_routes_dashboard.ml] (lines
+    14-184) as part of the godfile decomp campaign. Owns the pure
+    profile-classification pipeline that feeds the dashboard cascade
+    assignment UI; runtime snapshot ([Cascade_catalog_runtime]) is
+    consulted first, with a fallback to the on-disk validator
+    ([Cascade_catalog_validator]) when the snapshot is unavailable. *)
+
+type t = {
+  valid_profiles : string list;
+  invalid_profiles : (string * string list) list;
+  invalid_assignments : (string * string list) list;
+}
+
+let compute () : t =
+  let config_path = Cascade_runtime.cascade_config_path () in
+  let keeper_assignable_profiles =
+    Keeper_cascade_profile.keeper_catalog_names ?config_path ()
+    |> List.sort_uniq String.compare
+  in
+  let keeper_assignable_profile profile =
+    keeper_assignable_profiles = [] || List.mem profile keeper_assignable_profiles
+  in
+  let fallback_invalid_profiles =
+    match config_path with
+    | None -> []
+    | Some path ->
+        Cascade_catalog_validator.error_messages_by_profile
+          ~config_path:path
+  in
+  match Cascade_catalog_runtime.known_profile_names () with
+  | Ok raw_validated_profiles ->
+      let validated_profiles =
+        raw_validated_profiles |> List.sort_uniq String.compare
+      in
+      let invalid_profiles =
+        (Cascade_catalog_runtime.invalid_profile_errors ()
+         @ fallback_invalid_profiles)
+        |> Dashboard_cascade.invalid_profiles_with_internal_names
+      in
+      let keeper_profiles =
+        raw_validated_profiles
+        |> List.filter keeper_assignable_profile
+        |> List.sort_uniq String.compare
+      in
+      let candidate_profiles =
+        if keeper_profiles = [] then validated_profiles else keeper_profiles
+      in
+      let known_internal_profiles =
+        (match config_path with
+         | None -> raw_validated_profiles
+         | Some path ->
+             Cascade_catalog_validator.discover_profiles_for_diagnostics
+               ~config_path:path)
+        |> List.sort_uniq String.compare
+      in
+      let invalid_assignments =
+        Dashboard_cascade.invalid_assignments_for_public_profiles
+          ~known_internal_profiles
+          ~invalid_profiles candidate_profiles
+      in
+      let valid_profiles =
+        candidate_profiles
+        |> List.filter (fun profile ->
+               List.mem profile validated_profiles
+               && not (List.mem_assoc profile invalid_assignments))
+      in
+      { valid_profiles; invalid_profiles; invalid_assignments }
+  | Error detail ->
+      Log.Keeper.warn
+        "cascade_profile_gate: validated runtime snapshot unavailable: %s"
+        detail;
+      let invalid_profiles =
+        Dashboard_cascade.invalid_profiles_with_internal_names
+          fallback_invalid_profiles
+      in
+      let known_internal_profiles =
+        (match config_path with
+         | None -> []
+         | Some path ->
+             Cascade_catalog_validator.discover_profiles_for_diagnostics
+               ~config_path:path)
+        |> List.sort_uniq String.compare
+      in
+      let keeper_profiles =
+        known_internal_profiles
+        |> List.filter keeper_assignable_profile
+        |> List.sort_uniq String.compare
+      in
+      let candidate_profiles =
+        if keeper_profiles = [] then known_internal_profiles else keeper_profiles
+      in
+      let invalid_assignments =
+        Dashboard_cascade.invalid_assignments_for_public_profiles
+          ~known_internal_profiles ~invalid_profiles candidate_profiles
+      in
+      let invalid_names = List.map fst invalid_assignments in
+      let valid_profiles =
+        candidate_profiles
+        |> List.filter (fun profile -> not (List.mem profile invalid_names))
+      in
+      { valid_profiles; invalid_profiles; invalid_assignments }
+;;
+
+let available_profiles () : string list = (compute ()).valid_profiles
+let available_cascade_profiles = available_profiles
+let invalid_profiles () : (string * string list) list = (compute ()).invalid_profiles
+
+let invalid_assignment_profiles () : (string * string list) list =
+  (compute ()).invalid_assignments
+;;

--- a/lib/server/server_dashboard_cascade_profile_gate.mli
+++ b/lib/server/server_dashboard_cascade_profile_gate.mli
@@ -1,0 +1,35 @@
+(** Dashboard cascade profile gate — determines which cascade
+    profiles are assignable to a keeper.
+
+    Pure derivation pipeline over [Cascade_catalog_runtime] (preferred)
+    + [Cascade_catalog_validator] (fallback on snapshot unavailability)
+    + [Keeper_cascade_profile.keeper_catalog_names] (keeper-assignable
+    filter). *)
+
+(** Result of one gate computation:
+    - [valid_profiles]: assignable profile names;
+    - [invalid_profiles]: profile → error message list (config /
+      validator-level errors);
+    - [invalid_assignments]: profile → reason list (public profile
+      that resolves to an invalid internal profile). *)
+type t = {
+  valid_profiles : string list;
+  invalid_profiles : (string * string list) list;
+  invalid_assignments : (string * string list) list;
+}
+
+(** [compute ()] runs the gate end-to-end and returns the
+    classification for the current cascade config. Reads the runtime
+    snapshot first; falls back to the on-disk validator when the
+    snapshot is in an error state (logs a WARN line in that case). *)
+val compute : unit -> t
+
+(** [available_profiles ()] is [(compute ()).valid_profiles]. *)
+val available_profiles : unit -> string list
+
+(** [invalid_profiles ()] is [(compute ()).invalid_profiles]. *)
+val invalid_profiles : unit -> (string * string list) list
+
+(** [invalid_assignment_profiles ()] is
+    [(compute ()).invalid_assignments]. *)
+val invalid_assignment_profiles : unit -> (string * string list) list

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -11,6 +11,15 @@ module Runtime = Server_routes_http_runtime
 module Keeper_stream = Server_routes_http_keeper_stream
 module Keeper_api = Server_dashboard_http_keeper_api
 
+(* Cascade profile gate extracted to
+   [Server_dashboard_cascade_profile_gate] (godfile decomp). *)
+module Cascade_profile_gate = Server_dashboard_cascade_profile_gate
+
+let cascade_profile_gate = Cascade_profile_gate.compute
+let available_cascade_profiles = Cascade_profile_gate.available_profiles
+let invalid_cascade_profiles = Cascade_profile_gate.invalid_profiles
+let invalid_cascade_assignment_profiles = Cascade_profile_gate.invalid_assignment_profiles
+
 let option_int_json = function
   | Some value -> `Int value
   | None -> `Null


### PR DESCRIPTION
## Summary

Main branch build was broken by multiple "dead-export removal" PRs that incorrectly deleted functions and modules still referenced by live callers. This hotfix restores them.

## Changes

### Restored modules (from git history)
- `keeper_meta_json_scrub.ml(i)` — removed by #18015
- `keeper_context_core_pair_repair_stats.ml(i)` — removed by #18015
- `keeper_egress_audit.ml(i)` — removed by #18015
- `keeper_hooks_oas_pr_metrics.ml(i)` — removed by #18011
- `server_dashboard_cascade_profile_gate.ml(i)` — removed by #18027

### Restored functions incorrectly claimed dead
- `trajectory_duration_ms` (used in `keeper_hooks_oas.ml`)
- `_snapshot_ttl_s`, `_maybe_evict_snapshot`, `_snapshot_max_entries` (used via include chain in `operator_control_snapshot.ml`)
- `tool_call_detail_to_json`, `surface_model_used`, `surface_resolved_model_id` (used by unified metrics, keeper_turn)

### Extraction commit omissions fixed
- `server_routes_http_routes_dashboard.ml`: restored local aliases `available_cascade_profiles`, `invalid_cascade_profiles`, etc.
- `keeper_context_core_history.ml`: use qualified name to avoid `Message_json` duplicate

### Other fixes
- `shell_words.mli`: add `top_level_command_segments` (used by `bash_words`)
- `exec_adaptive_timeout.ml(i)`: add `stats`/`stats_to_json` (used by test)
- `board_comment_rate_limit.ml(i)`: add `reset` (used by test)
- `keeper_path_check_error.mli`: add `parse_prefix` (used by server)
- `exec_policy.ml`: add `stage_words_of_string_result` re-export
- `keeper_shell_docker.ml`: add `open Keeper_shell_docker_exec_failure`
- `keeper_hooks_oas.ml`: stub `record_gate_decision`, open `pr_metrics`
- `exec_core.ml`: use `Masc_exec.Parsed.Parsed ir`
- `lib/dune`: remove stale `keeper_hooks_oas_gate_attempt` reference
- `tool_task_schemas.ml`: resolve merge conflict markers

## Test plan
- [x] `dune build --root . lib/` passes
- [ ] CI checks green

## Root cause

Dead-export audit PRs used qualified-name grep and missed callers through:
1. OCaml `include` chains (values accessible via `include` without qualification)
2. Parent `.ml` local aliases that were removed alongside module extraction
3. Test-only callers that were not grepped