### PR TITLE
feat(keeper): wire ReceiptLost, ProviderTimeout, and success-path FSM transitions

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -177,6 +177,22 @@ let is_required_tool_contract_violation (err : Agent_sdk.Error.sdk_error) : bool
   | Agent_sdk.Error.A2a _
   | Agent_sdk.Error.Internal _ -> false
 
+(** Receipt I/O failure: the turn body succeeded but the authoritative
+    receipt could not be persisted.  See
+    [keeper_agent_run.ml::execution_receipt_append_failed]. *)
+let is_receipt_lost_error (err : Agent_sdk.Error.sdk_error) : bool =
+  match err with
+  | Agent_sdk.Error.Internal msg ->
+      string_contains_substring ~needle:"execution_receipt_append_failed" msg
+  | _ -> false
+
+(** Provider-level timeout (not structural OAS wall-clock budget). *)
+let is_provider_timeout_error (err : Agent_sdk.Error.sdk_error) : bool =
+  match err with
+  | Agent_sdk.Error.Api (Timeout _) -> true
+  | Agent_sdk.Error.Provider (Llm_provider.Error.Timeout _) -> true
+  | _ -> false
+
 let message_looks_like_gateway_backpressure detail =
   let lower = String.lowercase_ascii detail in
   string_contains_substring ~needle:"server error 524" lower

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1421,20 +1421,33 @@ let run_keeper_cycle
                     Keeper_metrics.metric_keeper_turns
                     ~labels:[ "keeper_name", meta.name; "outcome", "failure" ]
                     ();
-                  let fsm_failure_reason =
-                    if EC.is_required_tool_contract_violation err
-                    then
-                      Keeper_turn_fsm.Failure_tool_contract_violation
-                        { reason_code = "require_tool_use" }
-                    else
-                      Keeper_turn_fsm.Failure_provider_error
-                        { kind = sdk_error_kind err; detail = short_preview e_str }
-                  in
-                  Keeper_turn_fsm.emit_transition
-                    ~keeper_name:meta.name
-                    ~turn_id:keeper_turn_id
-                    ~prev:Keeper_turn_fsm.Streaming
-                    (Keeper_turn_fsm.Failed fsm_failure_reason);
+                  if EC.is_provider_timeout_error err
+                  then
+                    Keeper_turn_fsm.emit_transition
+                      ~keeper_name:meta.name
+                      ~turn_id:keeper_turn_id
+                      ~prev:Keeper_turn_fsm.Streaming
+                      (Keeper_turn_fsm.Cancelled
+                         Keeper_turn_fsm.Cancelled_provider_timeout)
+                  else
+                    let fsm_failure_reason =
+                      if EC.is_required_tool_contract_violation err
+                      then
+                        Keeper_turn_fsm.Failure_tool_contract_violation
+                          { reason_code = "require_tool_use" }
+                      else if EC.is_receipt_lost_error err
+                      then
+                        Keeper_turn_fsm.Failure_receipt_lost
+                          { primary_error = e_str; fallback_path = None }
+                      else
+                        Keeper_turn_fsm.Failure_provider_error
+                          { kind = sdk_error_kind err; detail = short_preview e_str }
+                    in
+                    Keeper_turn_fsm.emit_transition
+                      ~keeper_name:meta.name
+                      ~turn_id:keeper_turn_id
+                      ~prev:Keeper_turn_fsm.Streaming
+                      (Keeper_turn_fsm.Failed fsm_failure_reason);
                   let log_keeper_cycle_failed =
                     if EC.should_warn_keeper_cycle_failed err
                     then Log.Keeper.warn
@@ -1669,6 +1682,16 @@ let run_keeper_cycle
                   Error err
                 | Ok result ->
                   let final_execution = !last_execution in
+                  Keeper_turn_fsm.emit_transition
+                    ~keeper_name:meta.name
+                    ~turn_id:keeper_turn_id
+                    ~prev:Keeper_turn_fsm.Streaming
+                    Keeper_turn_fsm.Completing;
+                  Keeper_turn_fsm.emit_transition
+                    ~keeper_name:meta.name
+                    ~turn_id:keeper_turn_id
+                    ~prev:Keeper_turn_fsm.Completing
+                    Keeper_turn_fsm.Done;
                   finalize_trajectory_acc
                     ~config
                     ~keeper_name:meta.name


### PR DESCRIPTION
## Summary

Closes 3 of 5 missing FSM transitions identified after PR #18031.

### Changes

**lib/keeper/keeper_error_classify.ml**
- `is_receipt_lost_error`: matches `Agent_sdk.Error.Internal` containing `execution_receipt_append_failed` (the error raised in `keeper_agent_run.ml` when the execution receipt cannot be persisted).
- `is_provider_timeout_error`: matches `Api (Timeout _)` and `Provider (Llm_provider.Error.Timeout _)` variants.

**lib/keeper/keeper_unified_turn.ml**
- **Failure path** (`run_keeper_cycle`): branches on the new predicates before falling back to existing contract/provider error logic.
  - Provider timeout -> `Cancelled Cancelled_provider_timeout`
  - Receipt I/O failure -> `Failed (Failure_receipt_lost { primary_error; fallback_path = None })`
  - Existing contract violation -> `Failed (Failure_tool_contract_violation ...)`
  - Else -> `Failed (Failure_provider_error ...)`
- **Success path**: after `run_turn` returns `Ok`, emits `Streaming -> Completing -> Done`. This closes the observable gap where successful keeper turns produced no `[fsm:transition]` log lines at all.

### Verification

- `dune build lib/keeper/` passes.
- Pre-existing test failures in `test/` (unrelated `Unbound value` errors) are unchanged.

### Remaining work (separate PR)

- `StreamYieldsTool` / `ToolReturned`: requires extending `turn_progress_callbacks` in `keeper_agent_run_turn_helpers.ml` to thread `turn_id` through the `on_yield` / `on_resume` callbacks. The SDK-level slot yield/resume exists; FSM integration needs signature changes.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>