### PR TITLE
feat(keeper): wire StreamYieldsTool and ToolReturned FSM transitions

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -477,6 +477,7 @@ let run_turn
         ~config
         ~keeper_name:meta.name
         ~downstream:on_event
+        ~turn_id:manifest_keeper_turn_id
     in
     let priority =
       Option.value priority ~default:Llm_provider.Request_priority.Proactive

--- a/lib/keeper/keeper_agent_run_turn_helpers.ml
+++ b/lib/keeper/keeper_agent_run_turn_helpers.ml
@@ -222,7 +222,7 @@ let run_with_setup_cleanup ~cleanup f =
       cleanup ();
       Printexc.raise_with_backtrace e backtrace
 
-let turn_progress_callbacks ~config ~keeper_name ~downstream =
+let turn_progress_callbacks ~config ~keeper_name ~downstream ~turn_id =
   let record_turn_progress event_kind =
     Keeper_registry.record_turn_progress
       ~base_path:config.Coord.base_path
@@ -234,6 +234,11 @@ let turn_progress_callbacks ~config ~keeper_name ~downstream =
     if yield_on_tool then
       Some
         (fun () ->
+          Keeper_turn_fsm.emit_transition
+            ~keeper_name
+            ~turn_id
+            ~prev:Keeper_turn_fsm.Streaming
+            Keeper_turn_fsm.Awaiting_tool_result;
           record_turn_progress "slot_yield";
           Log.Misc.debug "keeper %s: slot yielded (tool execution)" keeper_name)
     else None
@@ -242,6 +247,11 @@ let turn_progress_callbacks ~config ~keeper_name ~downstream =
     if yield_on_tool then
       Some
         (fun () ->
+          Keeper_turn_fsm.emit_transition
+            ~keeper_name
+            ~turn_id
+            ~prev:Keeper_turn_fsm.Awaiting_tool_result
+            Keeper_turn_fsm.Streaming;
           record_turn_progress "slot_resume";
           Log.Misc.debug "keeper %s: slot resumed (next LLM turn)" keeper_name)
     else None


### PR DESCRIPTION
## Summary
Wires the remaining FSM transitions for tool-use turns:
- `StreamYieldsTool`: Streaming → Awaiting_tool_result (when LLM yields a tool call)
- `ToolReturned`: Awaiting_tool_result → Streaming (when tool result resumes LLM stream)

## Changes
- `keeper_agent_run_turn_helpers.ml`: extend `turn_progress_callbacks` with `~turn_id`, emit FSM transitions in `on_yield`/`on_resume` closures
- `keeper_agent_run.ml`: pass `~turn_id:manifest_keeper_turn_id` to `turn_progress_callbacks`

## Verification
- `dune build` passes
- `test_keeper_turn_fsm_emit.ml` already pins these transitions (line 97-98)

**Depends on:** #18036 (merged)
**Part of:** FSM transition completeness sweep

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>