### PR TITLE
fix(validation): treat empty oneOf values as absent in shape check

### DIFF
--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -172,9 +172,15 @@ let one_of_required_shape_error schema = function
     if groups = []
     then None
     else (
-      let has name = List.mem_assoc name fields in
+      let has_present name =
+        match List.assoc_opt name fields with
+        | None -> false
+        | Some `Null -> false
+        | Some (`List []) -> false
+        | Some _ -> true
+      in
       let matching_groups =
-        List.filter (fun required -> List.for_all has required) groups
+        List.filter (fun required -> List.for_all has_present required) groups
       in
       match matching_groups with
       | [ _ ] -> None

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -1008,6 +1008,104 @@ let test_registered_hook_required_enum_blank_is_not_stripped () =
     (assoc_string "mode" forwarded)
 
 (* ================================================================ *)
+(* Test: oneOf with empty/null values (regression guard)             *)
+(* ================================================================ *)
+
+(** Simulate LLM populating all oneOf branches with empty values.
+    Before fix: List.mem_assoc matched on key presence alone,
+    treating pipeline:[] as a valid group match, causing false
+    "multiple mutually exclusive schemas" rejection. *)
+let test_validate_args_keeper_bash_oneof_empty_pipeline () =
+  let args =
+    `Assoc
+      [ "executable", `String "pwd"
+      ; "pipeline", `List []
+      ]
+  in
+  match
+    Tool_input_validation.validate_args
+      ~schema:keeper_bash_schema
+      ~name:"keeper_bash"
+      ~args
+      ()
+  with
+  | Ok forwarded ->
+    Alcotest.(check string) "executable preserved" "pwd"
+      (assoc_string "executable" forwarded)
+  | Error result ->
+    Alcotest.failf
+      "expected keeper_bash with executable + empty pipeline to pass, got %s"
+      (Yojson.Safe.to_string result.Tool_result.data)
+
+let test_validate_args_keeper_bash_oneof_null_stages () =
+  let args =
+    `Assoc
+      [ "executable", `String "ls"
+      ; "stages", `Null
+      ]
+  in
+  match
+    Tool_input_validation.validate_args
+      ~schema:keeper_bash_schema
+      ~name:"keeper_bash"
+      ~args
+      ()
+  with
+  | Ok forwarded ->
+    Alcotest.(check string) "executable preserved" "ls"
+      (assoc_string "executable" forwarded)
+  | Error result ->
+    Alcotest.failf
+      "expected keeper_bash with executable + null stages to pass, got %s"
+      (Yojson.Safe.to_string result.Tool_result.data)
+
+let test_validate_args_keeper_bash_oneof_all_empty () =
+  let args =
+    `Assoc
+      [ "executable", `String "echo"
+      ; "pipeline", `List []
+      ; "stages", `Null
+      ]
+  in
+  match
+    Tool_input_validation.validate_args
+      ~schema:keeper_bash_schema
+      ~name:"keeper_bash"
+      ~args
+      ()
+  with
+  | Ok forwarded ->
+    Alcotest.(check string) "executable preserved" "echo"
+      (assoc_string "executable" forwarded)
+  | Error result ->
+    Alcotest.failf
+      "expected keeper_bash with executable + empty others to pass, got %s"
+      (Yojson.Safe.to_string result.Tool_result.data)
+
+let test_validate_args_keeper_bash_oneof_real_pipeline_rejects_empty_exec () =
+  let args =
+    `Assoc
+      [ "executable", `Null
+      ; "pipeline", `List
+          [ `Assoc [ "executable", `String "echo"; "argv", `List [] ] ]
+      ]
+  in
+  match
+    Tool_input_validation.validate_args
+      ~schema:keeper_bash_schema
+      ~name:"keeper_bash"
+      ~args
+      ()
+  with
+  | Ok forwarded ->
+    Alcotest.(check bool) "executable not in forwarded" true
+      (Yojson.Safe.Util.member "executable" forwarded = `Null)
+  | Error result ->
+    Alcotest.failf
+      "expected keeper_bash pipeline with null exec to pass shape validation, got %s"
+      (Yojson.Safe.to_string result.Tool_result.data)
+
+(* ================================================================ *)
 (* Runner                                                            *)
 (* ================================================================ *)
 
@@ -1080,6 +1178,14 @@ let () =
         test_validate_args_keeper_bash_accepts_typed_pipeline;
       Alcotest.test_case "keeper_bash rejects bad typed argv" `Quick
         test_validate_args_keeper_bash_rejects_bad_argv_type;
+      Alcotest.test_case "keeper_bash oneOf: executable + empty pipeline" `Quick
+        test_validate_args_keeper_bash_oneof_empty_pipeline;
+      Alcotest.test_case "keeper_bash oneOf: executable + null stages" `Quick
+        test_validate_args_keeper_bash_oneof_null_stages;
+      Alcotest.test_case "keeper_bash oneOf: executable + all empty" `Quick
+        test_validate_args_keeper_bash_oneof_all_empty;
+      Alcotest.test_case "keeper_bash oneOf: pipeline + null exec" `Quick
+        test_validate_args_keeper_bash_oneof_real_pipeline_rejects_empty_exec;
       Alcotest.test_case "direct validation uses explicit schema" `Quick
         test_validate_args_uses_explicit_schema_without_registry;
       Alcotest.test_case "direct keeper_board_post accepts sources array" `Quick


### PR DESCRIPTION
## Summary
- `one_of_required_shape_error` used bare `List.mem_assoc` which matched on key presence alone
- When LLMs (especially GLM) populate all declared optional parameters with empty values (`pipeline:[]`, `stages:null`), these triggered false multi-group matches
- All `keeper_bash` calls were rejected with "arguments match multiple mutually exclusive schemas: executable | pipeline | stages"

## Fix
Replace `has name = List.mem_assoc name fields` with `has_present` that treats `Null`, empty list `[]` as "not present", so only fields with meaningful values participate in oneOf discrimination.

## Test plan
- [x] 4 new regression tests covering: executable+empty_pipeline, executable+null_stages, executable+all_empty, pipeline+null_exec
- [x] `tool_input_validation.ml` compiles clean (0 errors in lib/)
- [ ] Existing test suite passes (blocked by pre-existing unrelated build errors on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)