### PR TITLE
refactor(bash): remove stages alias from keeper_bash schema

### DIFF
--- a/lib/tool_shard_types_schemas_bash.ml
+++ b/lib/tool_shard_types_schemas_bash.ml
@@ -2,9 +2,10 @@
     schema.
 
     The public descriptor exposes only the typed argv / pipeline forms:
-    [executable]/[argv] for a single process and [pipeline]/[stages] for
+    [executable]/[argv] for a single process and [pipeline] for
     explicit Shell IR pipelines. Raw [cmd] strings are intentionally absent
-    from the schema. *)
+    from the schema. The handler still accepts [stages] as a backward-compatible
+    alias for [pipeline], but the schema no longer advertises it. *)
 
 let keeper_bash_exec_stage_schema =
   `Assoc
@@ -24,7 +25,7 @@ let keeper_bash_exec_stage_schema =
                 ; ( "description"
                   , `String
                       "Arguments passed verbatim to executable. Shell metacharacters \
-                       are data; use pipeline/stages for pipes." )
+                       are data; use pipeline for multi-stage execution." )
                 ] )
           ] )
     ; "required", `List [ `String "executable" ]
@@ -113,7 +114,7 @@ let keeper_bash_timeout_sec_field =
 
 let keeper_bash_description =
   "Execute one command through the typed execution gates via typed argv. Use \
-   executable/argv for one process, or pipeline/stages for explicit Shell IR \
+   executable/argv for one process, or pipeline for explicit Shell IR \
    pipelines. The legacy 'cmd' string field is no longer accepted. Shell \
    metacharacters in argv are data, not syntax. Good: executable='git' \
    argv=['status','--short'], pipeline=[{executable='git',...}, \
@@ -134,7 +135,6 @@ let keeper_bash_schema : Masc_domain.tool_schema =
     [ keeper_bash_executable_field
     ; keeper_bash_argv_field
     ; keeper_bash_pipeline_field
-    ; keeper_bash_stages_field
     ; keeper_bash_env_field
     ; keeper_bash_cwd_field
     ; keeper_bash_timeout_sec_field
@@ -143,7 +143,6 @@ let keeper_bash_schema : Masc_domain.tool_schema =
   let one_of_branches =
     [ `Assoc [ "required", `List [ `String "executable" ] ]
     ; `Assoc [ "required", `List [ `String "pipeline" ] ]
-    ; `Assoc [ "required", `List [ `String "stages" ] ]
     ]
   in
   { name = "keeper_bash"

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -565,8 +565,10 @@ let test_keeper_bash_schema_exposes_typed_boundary () =
   check_param_type "executable" "string" params;
   check_param_type "argv" "array" params;
   check_param_type "pipeline" "array" params;
-  check_param_type "stages" "array" params;
   check_param_type "env" "object" params;
+  Alcotest.(check bool)
+    "stages alias not exposed in schema" true
+    (Option.is_none (param_by_name "stages" params));
   Alcotest.(check bool)
     "legacy background flag not exposed"
     true
@@ -1037,7 +1039,10 @@ let test_validate_args_keeper_bash_oneof_empty_pipeline () =
       "expected keeper_bash with executable + empty pipeline to pass, got %s"
       (Yojson.Safe.to_string result.Tool_result.data)
 
-let test_validate_args_keeper_bash_oneof_null_stages () =
+(** stages was removed from the schema (backward-compat alias only in handler).
+    Sending stages in args now triggers additionalProperties rejection since
+    the schema declares additionalProperties: false. *)
+let test_validate_args_keeper_bash_oneof_stages_rejected_by_schema () =
   let args =
     `Assoc
       [ "executable", `String "ls"
@@ -1051,20 +1056,17 @@ let test_validate_args_keeper_bash_oneof_null_stages () =
       ~args
       ()
   with
-  | Ok forwarded ->
-    Alcotest.(check string) "executable preserved" "ls"
-      (assoc_string "executable" forwarded)
   | Error result ->
-    Alcotest.failf
-      "expected keeper_bash with executable + null stages to pass, got %s"
-      (Yojson.Safe.to_string result.Tool_result.data)
+    let msg = Yojson.Safe.to_string result.Tool_result.data in
+    Alcotest.(check bool) "mentions stages" true (string_contains msg "stages")
+  | Ok _ ->
+    Alcotest.fail "expected rejection: stages is no longer a schema-advertised field"
 
-let test_validate_args_keeper_bash_oneof_all_empty () =
+let test_validate_args_keeper_bash_oneof_exec_with_empty_pipeline () =
   let args =
     `Assoc
       [ "executable", `String "echo"
       ; "pipeline", `List []
-      ; "stages", `Null
       ]
   in
   match
@@ -1079,7 +1081,7 @@ let test_validate_args_keeper_bash_oneof_all_empty () =
       (assoc_string "executable" forwarded)
   | Error result ->
     Alcotest.failf
-      "expected keeper_bash with executable + empty others to pass, got %s"
+      "expected keeper_bash with executable + empty pipeline to pass, got %s"
       (Yojson.Safe.to_string result.Tool_result.data)
 
 let test_validate_args_keeper_bash_oneof_real_pipeline_rejects_empty_exec () =
@@ -1180,10 +1182,10 @@ let () =
         test_validate_args_keeper_bash_rejects_bad_argv_type;
       Alcotest.test_case "keeper_bash oneOf: executable + empty pipeline" `Quick
         test_validate_args_keeper_bash_oneof_empty_pipeline;
-      Alcotest.test_case "keeper_bash oneOf: executable + null stages" `Quick
-        test_validate_args_keeper_bash_oneof_null_stages;
-      Alcotest.test_case "keeper_bash oneOf: executable + all empty" `Quick
-        test_validate_args_keeper_bash_oneof_all_empty;
+      Alcotest.test_case "keeper_bash oneOf: stages rejected by schema" `Quick
+        test_validate_args_keeper_bash_oneof_stages_rejected_by_schema;
+      Alcotest.test_case "keeper_bash oneOf: exec with empty pipeline" `Quick
+        test_validate_args_keeper_bash_oneof_exec_with_empty_pipeline;
       Alcotest.test_case "keeper_bash oneOf: pipeline + null exec" `Quick
         test_validate_args_keeper_bash_oneof_real_pipeline_rejects_empty_exec;
       Alcotest.test_case "direct validation uses explicit schema" `Quick


### PR DESCRIPTION
## Summary
- Remove `stages` field from keeper_bash schema properties and oneOf branches (3 -> 2)
- `stages` was an exact duplicate of `pipeline` with identical schema shape and no distinct handler behavior
- The 3-way oneOf ambiguity was the structural root of the #18038 regression

## Detail
- Schema now exposes only `executable` and `pipeline` as oneOf discriminator branches
- Handler (`keeper_tool_bash_input.ml`) still accepts `stages` as backward-compatible alias — no handler change
- `keeper_bash_stages_field` definition retained in source (unused by schema, available if needed)
- Descriptions updated to reference `pipeline` only

## Test plan
- [x] Updated `test_keeper_bash_schema_exposes_typed_boundary` — asserts stages is NOT in schema
- [x] Updated oneOf regression tests — stages input now rejected by additionalProperties: false
- [x] Compiles clean (0 errors in changed files)
- [ ] Full test suite (blocked by pre-existing unrelated build errors on main)

Follows #18038 (pragmatic has_present fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)