### PR TITLE
fix(test): add image inspect handler to legacy fake Docker scripts

### DIFF
--- a/test/test_keeper_docker_read.ml
+++ b/test/test_keeper_docker_read.ml
@@ -292,6 +292,10 @@ if [ \"$1\" = \"info\" ]; then\n\
   printf '[]\\n'\n\
   exit 0\n\
 fi\n\
+if [ \"$1\" = \"image\" ] && [ \"$2\" = \"inspect\" ] && [ \"$3\" = \"alpine:test\" ]; then\n\
+  printf '[]\\n'\n\
+  exit 0\n\
+fi\n\
 if [ \"$1\" = \"run\" ]; then\n\
   printf 'no matches\\n'\n\
   exit 1\n\
@@ -302,6 +306,10 @@ exit 2\n"
 let fake_docker_echo_command_script =
   "#!/bin/sh\n\
 if [ \"$1\" = \"info\" ]; then\n\
+  printf '[]\\n'\n\
+  exit 0\n\
+fi\n\
+if [ \"$1\" = \"image\" ] && [ \"$2\" = \"inspect\" ] && [ \"$3\" = \"alpine:test\" ]; then\n\
   printf '[]\\n'\n\
   exit 0\n\
 fi\n\
@@ -327,6 +335,10 @@ if [ \"$1\" = \"info\" ]; then\n\
   printf '[]\\n'\n\
   exit 0\n\
 fi\n\
+if [ \"$1\" = \"image\" ] && [ \"$2\" = \"inspect\" ] && [ \"$3\" = \"alpine:test\" ]; then\n\
+  printf '[]\\n'\n\
+  exit 0\n\
+fi\n\
 if [ \"$1\" = \"run\" ]; then\n\
   if [ -n \"$log_file\" ]; then\n\
     printf 'run-started\\n' >> \"$log_file\"\n\
@@ -348,6 +360,14 @@ case \"$1\" in\n\
   info)\n\
     printf '[]\\n'\n\
     exit 0\n\
+    ;;\n\
+  image)\n\
+    if [ \"$2\" = \"inspect\" ] && [ \"$3\" = \"alpine:test\" ]; then\n\
+      printf '[]\\n'\n\
+      exit 0\n\
+    fi\n\
+    printf 'missing image\\n' >&2\n\
+    exit 1\n\
     ;;\n\
   run)\n\
     printf 'runtime-container\\n'\n\


### PR DESCRIPTION
## Summary
- Add `docker image inspect alpine:test` handler to 4 legacy fake Docker scripts in test_keeper_docker_read.ml
- Scripts `fake_docker_exit_1_script`, `fake_docker_echo_command_script`, `fake_docker_slow_run_script`, `fake_docker_turn_runtime_script` now respond to image inspect preflight checks
- Fixes `run_command_in_container` tests 2-5, 8-9 that were failing with "unexpected docker invocation" or "sandbox_image_missing"

## Problem (Closes #16819)
Sandbox image preflight feature added `docker image inspect <image>` calls before `docker run`. Legacy fake Docker scripts only handled `info` and `run` commands, causing the preflight to fail and cascading into test failures.

## Test plan
- [ ] Build: `MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_docker_read.exe`
- [ ] Run: `test/test_keeper_docker_read.exe test --show-errors --color=never run_command_in_container`
- [ ] All `run_command_in_container` test cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)