### PR TITLE
feat(keeper): explicit LivelockBlocked FSM transition action

### DIFF
--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -134,6 +134,7 @@ type transition_action =
   | ContractOk
   | ContractViolation
   | ReceiptLost
+  | LivelockBlocked
   | GenericFail
   | SupervisorRequestsStop
   | HonorStopSignal
@@ -153,6 +154,7 @@ let transition_action_label = function
   | ContractOk -> "ContractOk"
   | ContractViolation -> "ContractViolation"
   | ReceiptLost -> "ReceiptLost"
+  | LivelockBlocked -> "LivelockBlocked"
   | GenericFail -> "GenericFail"
   | SupervisorRequestsStop -> "SupervisorRequestsStop"
   | HonorStopSignal -> "HonorStopSignal"
@@ -222,6 +224,9 @@ let classify_transition ?ctx ~(from_state: _ turn_state) ~(to_state: _ turn_stat
   | Any Cascade_routing, Any (Failed (Failure_cascade_unavailable _))
     when not stop_signaled_before ->
       Some CascadeUnavailable
+  | Any Cascade_routing, Any (Failed (Failure_turn_livelock_blocked _))
+    when not stop_signaled_before ->
+      Some LivelockBlocked
   | Any Awaiting_provider, Any Streaming when not stop_signaled_before ->
       Some ProviderResponded
   | Any Awaiting_provider, Any (Cancelled Cancelled_provider_timeout)

--- a/lib/keeper/keeper_turn_fsm.mli
+++ b/lib/keeper/keeper_turn_fsm.mli
@@ -90,6 +90,7 @@ type transition_action =
   | ContractOk
   | ContractViolation
   | ReceiptLost
+  | LivelockBlocked
   | GenericFail
   | SupervisorRequestsStop
   | HonorStopSignal

--- a/test/test_keeper_turn_fsm_emit.ml
+++ b/test/test_keeper_turn_fsm_emit.ml
@@ -89,6 +89,11 @@ let test_transition_actions_cover_tla_next () =
     ~from_state:F.Cascade_routing
     ~to_state:
       (F.Failed (F.Failure_cascade_unavailable { base = "ollama"; resolved = None }));
+  check_action
+    F.LivelockBlocked
+    ~from_state:F.Cascade_routing
+    ~to_state:
+      (F.Failed (F.Failure_turn_livelock_blocked { reason = "cycle_cap" }));
   check_action F.ProviderResponded ~from_state:F.Awaiting_provider ~to_state:F.Streaming;
   check_action
     F.ProviderTimeout


### PR DESCRIPTION
## Summary

`Keeper_turn_fsm`의 `classify_transition`에서 `Cascade_routing → Failed(Failure_turn_livelock_blocked)` 전이를 `GenericFail` catch-all 대신 명시적 `LivelockBlocked` 액션으로 분류합니다.

- **Before**: livelock 차단 시 `action=GenericFail`로 기록됨
- **After**: `action=LivelockBlocked`로 기록되어 PromQL에서 livelock 발생률을 별도로 차트링 가능

## 변경 파일

- `lib/keeper/keeper_turn_fsm.ml` — `LivelockBlocked` variant + classify arm 추가
- `lib/keeper/keeper_turn_fsm.mli` — 동일한 type surface
- `test/test_keeper_turn_fsm_emit.ml` — TLA Next 커버리지 테스트 추가

## 검증

- `dune build lib/keeper/` 통과
- `test_keeper_turn_fsm_emit.ml`의 `test_transition_actions_cover_tla_next`에 livelock 케이스 포함

## 이전 컨텍스트

FSM transition 누락 조사 중 `GenericFail` catch-all이 정상 처리하지만, 운영자가 livelock 발생을 별도로 식별할 수 있도록 명시적 액션을 추가합니다.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>