### PR TITLE
feat(keeper): explicit ProviderError FSM transition action

### DIFF
--- a/lib/keeper/keeper_turn_fsm.ml
+++ b/lib/keeper/keeper_turn_fsm.ml
@@ -135,6 +135,7 @@ type transition_action =
   | ContractViolation
   | ReceiptLost
   | LivelockBlocked
+  | ProviderError
   | GenericFail
   | SupervisorRequestsStop
   | HonorStopSignal
@@ -155,6 +156,7 @@ let transition_action_label = function
   | ContractViolation -> "ContractViolation"
   | ReceiptLost -> "ReceiptLost"
   | LivelockBlocked -> "LivelockBlocked"
+  | ProviderError -> "ProviderError"
   | GenericFail -> "GenericFail"
   | SupervisorRequestsStop -> "SupervisorRequestsStop"
   | HonorStopSignal -> "HonorStopSignal"
@@ -227,6 +229,9 @@ let classify_transition ?ctx ~(from_state: _ turn_state) ~(to_state: _ turn_stat
   | Any Cascade_routing, Any (Failed (Failure_turn_livelock_blocked _))
     when not stop_signaled_before ->
       Some LivelockBlocked
+  | Any Cascade_routing, Any (Failed (Failure_provider_error _))
+    when not stop_signaled_before ->
+      Some ProviderError
   | Any Awaiting_provider, Any Streaming when not stop_signaled_before ->
       Some ProviderResponded
   | Any Awaiting_provider, Any (Cancelled Cancelled_provider_timeout)
@@ -244,6 +249,9 @@ let classify_transition ?ctx ~(from_state: _ turn_state) ~(to_state: _ turn_stat
   | Any Streaming, Any (Failed (Failure_receipt_lost _))
     when not stop_signaled_before ->
       Some ReceiptLost
+  | Any Streaming, Any (Failed (Failure_provider_error _))
+    when not stop_signaled_before ->
+      Some ProviderError
   | Any Streaming, Any (Cancelled Cancelled_provider_timeout)
     when not stop_signaled_before ->
       Some ProviderTimeout

--- a/lib/keeper/keeper_turn_fsm.mli
+++ b/lib/keeper/keeper_turn_fsm.mli
@@ -91,6 +91,7 @@ type transition_action =
   | ContractViolation
   | ReceiptLost
   | LivelockBlocked
+  | ProviderError
   | GenericFail
   | SupervisorRequestsStop
   | HonorStopSignal

--- a/test/test_keeper_turn_fsm_emit.ml
+++ b/test/test_keeper_turn_fsm_emit.ml
@@ -94,6 +94,11 @@ let test_transition_actions_cover_tla_next () =
     ~from_state:F.Cascade_routing
     ~to_state:
       (F.Failed (F.Failure_turn_livelock_blocked { reason = "cycle_cap" }));
+  check_action
+    F.ProviderError
+    ~from_state:F.Cascade_routing
+    ~to_state:
+      (F.Failed (F.Failure_provider_error { kind = "openai"; detail = "rate_limit" }));
   check_action F.ProviderResponded ~from_state:F.Awaiting_provider ~to_state:F.Streaming;
   check_action
     F.ProviderTimeout
@@ -112,6 +117,11 @@ let test_transition_actions_cover_tla_next () =
     ~from_state:F.Streaming
     ~to_state:
       (F.Failed (F.Failure_receipt_lost { primary_error = "io"; fallback_path = None }));
+  check_action
+    F.ProviderError
+    ~from_state:F.Streaming
+    ~to_state:
+      (F.Failed (F.Failure_provider_error { kind = "openai"; detail = "rate_limit" }));
   check_action
     F.ProviderTimeout
     ~from_state:F.Streaming


### PR DESCRIPTION
## Summary

`Keeper_turn_fsm`의 `classify_transition`에서 `Failure_provider_error` 전이를
`GenericFail` catch-all 대신 명시적 `ProviderError` 액션으로 분류합니다.

대상 전이:
- `Cascade_routing → Failed(Failure_provider_error)` — cascade 초기화 중 provider 에러
- `Streaming → Failed(Failure_provider_error)` — 스트리밍 중 provider 에러

- **Before**: provider 에러 시 `action=GenericFail`로 기록됨
- **After**: `action=ProviderError`로 기록되어 PromQL에서 provider 에러율을 별도로 차트링 가능

## 변경 파일

- `lib/keeper/keeper_turn_fsm.ml` — `ProviderError` variant + 2 classify arm 추가
- `lib/keeper/keeper_turn_fsm.mli` — 동일한 type surface
- `test/test_keeper_turn_fsm_emit.ml` — TLA Next 커버리지 테스트 2건 추가

## 검증

- `dune build lib/keeper/` 통과
- `test_keeper_turn_fsm_emit.ml`의 `test_transition_actions_cover_tla_next`에 provider error 케이스 포함

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>