### PR TITLE
fix: export resolve_prompt_markdown_dir via .mli (#17040)

### DIFF
--- a/lib/prompt_defaults.mli
+++ b/lib/prompt_defaults.mli
@@ -16,6 +16,12 @@
     [bootstrapped_signature] memo ref) are hidden — callers
     consume only the entry point below. *)
 
+val resolve_prompt_markdown_dir :
+  workspace_path:string -> base_path:string -> string
+(** Return the first existing prompt markdown directory from the
+    candidate list, falling back to {!Config_dir_resolver.prompts_dir}
+    when none exist yet. *)
+
 val bootstrap_runtime :
   workspace_path:string ->
   base_path:string ->


### PR DESCRIPTION
## Summary
- Export `resolve_prompt_markdown_dir` via `lib/prompt_defaults.mli` — the function was only available in the `.ml` implementation but never added to the interface, causing 4 test call sites (lines 2085, 2108, 2128, 2148 in `test_server_runtime_bootstrap.ml`) to fail compilation

## Context
Issue #17040 reported `test_blocking_bootstrap_promotes_legacy_keeper_meta_before_autoboot` failing. Investigation found two problems:

1. **Build-blocking (this PR)**: `resolve_prompt_markdown_dir` not exported via `.mli` — prevents the entire test binary from compiling
2. **Test isolation (already fixed in main)**: The test now sets `MASC_CONFIG_DIR` via `with_env` before bootstrap, which ensures `Config_dir_resolver.keepers_dir()` can find the test's temp directory after `reset()` clears the cache

## Test plan
- [ ] `dune build test/test_server_runtime_bootstrap.exe` compiles (currently blocked by other pre-existing build errors in main — `keeper_agent_run.ml:480`, `keeper_unified_turn.ml:1424`, etc.)
- [ ] `dune exec test/test_server_runtime_bootstrap.exe -- test-blocking-bootstrap-promotes-legacy-keeper-meta-before-autoboot` passes once build errors are resolved
- [ ] `dune exec test/test_server_runtime_bootstrap.exe -- test-prompt-markdown-dir` passes (the 4 tests that were blocked by the missing export)

Closes #17040

🤖 Generated with [Claude Code](https://claude.com/claude-code)