### PR TITLE
fix: export additional missing .mli declarations

### DIFF
--- a/lib/cascade/cascade_config_builder.mli
+++ b/lib/cascade/cascade_config_builder.mli
@@ -31,6 +31,24 @@ val config_for_label :
 (** Build a {!Cascade_runner.config} from a model label string.  Resolves
     the provider config and fills in defaults. *)
 
+(** Preflight check result for codex CLI subprocess transport.
+    Reports token/byte limits and whether the prompt exceeds them. *)
+type codex_cli_prompt_preflight = {
+  prompt_bytes : int;
+  prompt_tokens : int;
+  context_window_tokens : int;
+  retry_limit_tokens : int;
+  hits_argv_limit : bool;
+  hits_context_window : bool;
+}
+
+(** Run preflight checks for the codex CLI subprocess transport.
+    Returns [None] when the provider does not require argv-prompt preflight. *)
+val codex_cli_prompt_preflight :
+  config:Cascade_runner.config ->
+  goal:string ->
+  codex_cli_prompt_preflight option
+
 val with_codex_cli_preflight :
   scope:string ->
   config:Cascade_runner.config ->

--- a/lib/core/set_util.mli
+++ b/lib/core/set_util.mli
@@ -10,6 +10,14 @@
     backing representation needs to change, hide it behind an abstract
     type [`'k t`] in this interface first. *)
 
+(** [of_list_with key xs] builds a hash table set from [xs], using [key] to
+    extract the deduplication key from each element. *)
+val of_list_with : ('a -> 'b) -> 'a list -> ('b, unit) Hashtbl.t
+
+(** [count_distinct key xs] counts distinct keys produced by [key] from [xs].
+    Elements for which [key] returns [None] are skipped. *)
+val count_distinct : ('a -> 'b option) -> 'a list -> int
+
 (** [count_difference xs ~present ~absent] counts distinct keys produced by
     [present] that are NOT also produced by [absent]. Implementation: one
     pass over [xs] populates both the [absent_set] and [present_set]

--- a/lib/keeper/keeper_agent_run_turn_helpers.mli
+++ b/lib/keeper/keeper_agent_run_turn_helpers.mli
@@ -79,6 +79,7 @@ val turn_progress_callbacks :
   config:Coord.config ->
   keeper_name:string ->
   downstream:(Agent_sdk.Types.sse_event -> unit) option ->
+  turn_id:int ->
   (string -> unit)
   * bool
   * (unit -> unit) option

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -60,6 +60,11 @@ val is_cascade_exhausted_error : Agent_sdk.Error.sdk_error -> bool
     already been attempted ([List.length attempted_cascades >= 2]; the list is
     seeded with the initial cascade name so length=1 means no rotations yet),
     and no untried fallback cascade remains. *)
+
+(** [true] when the error is a provider-level timeout (not structural OAS
+    wall-clock budget). Matches both [Agent_sdk.Error.Api (Timeout _)] and
+    [Agent_sdk.Error.Provider (Llm_provider.Error.Timeout _)]. *)
+val is_provider_timeout_error : Agent_sdk.Error.sdk_error -> bool
 val should_cap_rotation_for_contract_violation :
   attempted_cascades:string list ->
   fallback_not_yet_tried:bool ->

--- a/lib/prompt_defaults.mli
+++ b/lib/prompt_defaults.mli
@@ -16,6 +16,18 @@
     [bootstrapped_signature] memo ref) are hidden — callers
     consume only the entry point below. *)
 
+val resolve_prompt_markdown_dir :
+  workspace_path:string -> base_path:string -> string
+(** Return the first existing prompt markdown directory from the
+    candidate list, falling back to {!Config_dir_resolver.prompts_dir}
+    when none exist yet. *)
+
+val init : unit -> unit
+(** Scan the current markdown dir (set via {!Prompt_registry.set_markdown_dir})
+    and load all prompts with YAML frontmatter.  Installs the restore-failure
+    Prometheus observer.  Called by [bootstrap_runtime]; also usable in tests
+    after [set_markdown_dir]. *)
+
 val bootstrap_runtime :
   workspace_path:string ->
   base_path:string ->


### PR DESCRIPTION
## Summary
- Follow-up to #18050 which only exported `resolve_prompt_markdown_dir`
- Adds 5 more missing `.mli` exports that were blocking test compilation
- `prompt_defaults.mli`: `init`
- `keeper_error_classify.mli`: `is_provider_timeout_error`
- `keeper_agent_run_turn_helpers.mli`: `turn_id:int` parameter (was `string`)
- `set_util.mli`: `of_list_with`, `count_distinct`
- `cascade_config_builder.mli`: `codex_cli_prompt_preflight` type + val

## Context
Issue #17040. The first PR (#18050) only partially addressed the `.mli` gap.
Several test binaries still failed to compile due to unexported functions
that were added in recent PRs without updating the interface files.

## Test plan
- [x] `dune build @check` passes for modified `.mli` files (0 errors from these modules)
- [ ] Full `dune build @runtest` blocked by unrelated pre-existing `.mli` gaps in other modules
- [ ] `test-blocking-bootstrap-promotes-legacy-keeper-meta-before-autoboot` (blocked by other module gaps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)