### PR TITLE
refactor(exec): RFC-0160 S4 G7 — eliminate Bash_words.stages from lib/

### DIFF
--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -122,12 +122,9 @@ Respond in 1-2 sentences. Be helpful and concise.|}
 let cli_argv_of_agent_type (agent_type : string) : string list =
   match Spawn.get_config agent_type with
   | Some config ->
-    (match Masc_exec_bash_parser.Bash_words.stages config.command with
-     | Ok [ words ] ->
-       words
-       |> List.map (fun (word : Masc_exec_bash_parser.Bash_words.word) -> word.value)
-       |> List.filter (fun s -> s <> "")
-     | Ok [] | Ok (_ :: _ :: _) | Error _ ->
+    (match Exec_policy_mutation_classifier.argv_words_of_string config.command with
+     | Some words -> List.filter (fun s -> s <> "") words
+     | None ->
        let command = String.trim config.command in
        if String.equal command "" then [] else [ command ])
   | None -> [agent_type]

--- a/lib/exec/command_gate/shell_command_gate.ml
+++ b/lib/exec/command_gate/shell_command_gate.ml
@@ -152,14 +152,30 @@ let rec command_words_run_dune = function
   | command :: args -> command_runs_dune command args
 
 and split_string_runs_dune text =
-  match Masc_exec_bash_parser.Bash_words.stages text with
-  | Error _ -> false
-  | Ok stages ->
-    List.exists
-      command_words_run_dune
-      (List.map
-         (List.map (fun w -> w.Masc_exec_bash_parser.Bash_words.value))
-         stages)
+  let stage_words_of_ir ir =
+    let rec literal acc = function
+      | [] -> Some (List.rev acc)
+      | SI.Lit (a, _) :: rest -> literal (a :: acc) rest
+      | SI.Concat _ :: _ | SI.Var _ :: _ -> None
+    in
+    let words_of_simple s =
+      match literal [] s.SI.args with
+      | None -> None
+      | Some args -> Some (Masc_exec.Bin.to_string s.SI.bin :: args)
+    in
+    let rec collect acc = function
+      | SI.Simple s ->
+        (match words_of_simple s with
+         | Some ws -> ws :: acc
+         | None -> acc)
+      | SI.Pipeline stages -> List.fold_left collect acc stages
+    in
+    List.rev (collect [] ir)
+  in
+  match Masc_exec_bash_parser.Bash.parse_string text with
+  | Masc_exec.Parsed.Parsed ir ->
+    List.exists command_words_run_dune (stage_words_of_ir ir)
+  | _ -> false
 
 and env_args_run_dune = function
   | [] -> false

--- a/lib/exec_core.ml
+++ b/lib/exec_core.ml
@@ -223,13 +223,7 @@ let artifact_threshold_bytes =
 ;;
 
 let command_word_stages cmd =
-  match Masc_exec_bash_parser.Bash_words.stages cmd with
-  | Ok stages ->
-      List.map
-        (fun words ->
-           List.map (fun (word : Masc_exec_bash_parser.Bash_words.word) -> word.value) words)
-        stages
-  | Error _ -> []
+  Exec_policy_mutation_classifier.stages_words_of_string cmd
 ;;
 
 let first_segment_tokens cmd =

--- a/lib/exec_policy_mutation_classifier.ml
+++ b/lib/exec_policy_mutation_classifier.ml
@@ -241,3 +241,59 @@ let argv_words_of_string text =
 let parsed_of_string text =
   Masc_exec_bash_parser.Bash.parse_string text
 ;;
+
+(** Multi-stage word extractor: returns per-stage word lists, preserving
+    pipeline structure. Replaces [Bash_words.stages] callers that need
+    stage boundaries (e.g. [Exec_core.command_word_stages]).
+    Returns [[]] on parse failure or non-literal-only stages. *)
+let stages_words_of_string (cmd : string) : string list list =
+  let stage_words_of_ir (ir : Shell_ir.t) : string list list =
+    let rec collect acc = function
+      | Shell_ir.Simple s ->
+        (match literal_words_of_simple s with
+         | Some ws -> ws :: acc
+         | None -> acc)
+      | Shell_ir.Pipeline stages ->
+        List.fold_left collect acc stages
+    in
+    List.rev (collect [] ir)
+  in
+  match Masc_exec_bash_parser.Bash.parse_string cmd with
+  | Parsed.Parsed ir -> stage_words_of_ir ir
+  | _ -> []
+;;
+
+type quoted_word = {
+  value : string;
+  quoted : bool;
+}
+
+(** Extract per-stage word lists with quoting metadata.
+    Replaces [Bash_words.stages] callers that depend on [word.quoted]
+    (e.g. guard token extraction). Non-literal args ([Concat], [Var])
+    are skipped. Returns [[]] on parse failure. *)
+let stages_quoted_words_of_string (cmd : string) : quoted_word list list =
+  let words_of_simple (simple : Shell_ir.simple) : quoted_word list option =
+    let rec collect acc = function
+      | [] -> Some (List.rev acc)
+      | Shell_ir.Lit (a, meta) :: rest ->
+        collect ({ value = a; quoted = meta.Shell_ir.quoted } :: acc) rest
+      | Shell_ir.Concat _ :: _ | Shell_ir.Var _ :: _ -> None
+    in
+    match collect [] simple.args with
+    | None -> None
+    | Some args ->
+      Some ({ value = Bin.to_string simple.bin; quoted = false } :: args)
+  in
+  let rec collect acc = function
+    | Shell_ir.Simple s ->
+      (match words_of_simple s with
+       | Some ws -> ws :: acc
+       | None -> acc)
+    | Shell_ir.Pipeline stages ->
+      List.fold_left collect acc stages
+  in
+  match Masc_exec_bash_parser.Bash.parse_string cmd with
+  | Parsed.Parsed ir -> List.rev (collect [] ir)
+  | _ -> []
+;;

--- a/lib/exec_policy_mutation_classifier.mli
+++ b/lib/exec_policy_mutation_classifier.mli
@@ -72,3 +72,19 @@ val argv_words_of_string : string -> string list option
     callers should route through this instead of calling
     [Masc_exec_bash_parser.Bash.parse_string] directly. *)
 val parsed_of_string : string -> Masc_exec.Shell_ir.t Masc_exec.Parsed.t
+
+(** Multi-stage word extractor: per-stage word lists preserving pipeline
+    structure. Replaces [Bash_words.stages] callers that need stage
+    boundaries. Returns [[]] on parse failure. *)
+val stages_words_of_string : string -> string list list
+
+type quoted_word = {
+  value : string;
+  quoted : bool;
+}
+
+(** Per-stage word extraction with quoting metadata.
+    Replaces [Bash_words.stages] callers that depend on [word.quoted].
+    Non-literal args ([Concat], [Var]) are skipped.
+    Returns [[]] on parse failure. *)
+val stages_quoted_words_of_string : string -> quoted_word list list

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -707,9 +707,9 @@ let normalized_input_hash (input : Yojson.Safe.t) =
 ;;
 
 let first_cmd_token (cmd : string) =
-  match Masc_exec_bash_parser.Bash_words.stages cmd with
-  | Ok ((token :: _) :: _) -> Some token.Masc_exec_bash_parser.Bash_words.value
-  | Ok ([] :: _) | Ok [] | Error _ -> None
+  match Exec_policy_mutation_classifier.stage_words_of_string cmd with
+  | token :: _ -> Some token
+  | [] -> None
 ;;
 
 module For_testing = struct

--- a/lib/keeper/keeper_shell_docker_nested_runtime.ml
+++ b/lib/keeper/keeper_shell_docker_nested_runtime.ml
@@ -58,7 +58,7 @@ let split_unquoted_guard_word acc value =
   loop 0 0 acc
 ;;
 
-let guard_tokens_of_word acc (word : Masc_exec_bash_parser.Bash_words.word) =
+let guard_tokens_of_word acc (word : Exec_policy_mutation_classifier.quoted_word) =
   if word.quoted
   then push_guard_word acc ~quoted:true word.value
   else if String.equal word.value "&&"
@@ -69,16 +69,13 @@ let guard_tokens_of_word acc (word : Masc_exec_bash_parser.Bash_words.word) =
 ;;
 
 let shell_guard_tokens cmd =
-  match Masc_exec_bash_parser.Bash_words.stages cmd with
-  | Error _ -> []
-  | Ok stages ->
-    stages
-    |> List.fold_left
-         (fun acc stage ->
-            let acc = List.fold_left guard_tokens_of_word acc stage in
-            Guard_separator :: acc)
-         []
-    |> List.rev
+  Exec_policy_mutation_classifier.stages_quoted_words_of_string cmd
+  |> List.fold_left
+       (fun acc stage ->
+          let acc = List.fold_left guard_tokens_of_word acc stage in
+          Guard_separator :: acc)
+       []
+  |> List.rev
 ;;
 
 let shell_assignment_like word =

--- a/lib/tool_local_runtime_core.ml
+++ b/lib/tool_local_runtime_core.ml
@@ -56,15 +56,11 @@ let parse_int_opt value =
 let unique_preserve_order = Json_util.dedupe_keep_order
 
 let split_ws text =
-  match Masc_exec_bash_parser.Bash_words.stages text with
-  | Ok stages ->
-      stages
-      |> List.concat
-      |> List.map (fun (word : Masc_exec_bash_parser.Bash_words.word) -> word.value)
-      |> List.filter (fun item -> not (String.equal item ""))
-  | Error _ ->
+  match Exec_policy_mutation_classifier.stage_words_of_string text with
+  | [] ->
       let trimmed = String.trim text in
       if String.equal trimmed "" then [] else [ trimmed ]
+  | words -> List.filter (fun item -> not (String.equal item "")) words
 
 let string_contains_substring = String_util.contains_substring
 


### PR DESCRIPTION
## Summary
- **Bridge all 6 `Bash_words.stages` call sites** in lib/ through `Exec_policy_mutation_classifier` bridge functions
- **New bridge**: `stages_quoted_words_of_string` returns `(quoted_word list) list` preserving quoting metadata (`{ value: string; quoted: bool }`)
- **inline IR traversal** for `shell_command_gate.ml` (sub-library cannot depend on main lib without cycle)
- `parallel_parser_total` (G7 KPI) reduced: all `Bash_words.stages` direct calls eliminated from non-test lib/

## Files changed (8)
| File | Change |
|------|--------|
| `exec_policy_mutation_classifier.ml/mli` | +`stages_quoted_words_of_string` bridge with `quoted_word` type |
| `keeper_approval_queue.ml` | `Bash_words.stages` → `stage_words_of_string` |
| `tool_local_runtime_core.ml` | `Bash_words.stages` → `stage_words_of_string` |
| `auto_responder.ml` | `Bash_words.stages` → `argv_words_of_string` |
| `exec_core.ml` | `Bash_words.stages` → `stages_words_of_string` |
| `shell_command_gate.ml` | `Bash_words.stages` → inline IR traversal (cycle-free) |
| `keeper_shell_docker_nested_runtime.ml` | `Bash_words.stages` → `stages_quoted_words_of_string` |

## Verification
- `dune build @install` — no errors in modified files (pre-existing errors in unrelated files)
- `rg "Bash_words.stages" --type ml` — 0 hits in lib/ production code (only tests + comments remain)

## RFC Reference
RFC-0160 §4 G7 (parallel parser reduction)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>