### PR TITLE
RFC-0163 Phase C — Propagate Cascade_name.t through catalog facade

### DIFF
--- a/lib/cascade/cascade_catalog_runtime.ml
+++ b/lib/cascade/cascade_catalog_runtime.ml
@@ -92,7 +92,7 @@ let resolve_declared_name ?sw ?net ?clock ~raw_name () =
   match Cascade_catalog_runtime_resolve.resolve_declared_name ?sw ?net ?clock
           ~raw_name ()
   with
-  | Ok name -> Ok (Cascade_name.to_string name)
+  | Ok name -> Ok name
   | Error _ as e -> e
 let models_of_cascade_name = Cascade_catalog_runtime_resolve.models_of_cascade_name
 

--- a/lib/cascade/cascade_catalog_runtime.mli
+++ b/lib/cascade/cascade_catalog_runtime.mli
@@ -97,7 +97,7 @@ val resolve_declared_name :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   raw_name:string ->
   unit ->
-  (string, string) result
+  (Cascade_name.t, string) result
 
 val models_of_cascade_name :
   ?sw:Eio.Switch.t ->

--- a/lib/cascade/cascade_runtime.ml
+++ b/lib/cascade/cascade_runtime.ml
@@ -612,7 +612,7 @@ let max_output_tokens_ceiling_of_cascade_name cascade_name =
           let raw_name = cascade_name_to_string cascade_name in
           let resolved_name =
             match Cascade_catalog_runtime.resolve_declared_name ~raw_name () with
-            | Ok resolved -> Some resolved
+            | Ok resolved -> Some (Cascade_name.to_string resolved)
             | Error _ -> None
           in
           [ resolved_name; declarative_route_target cfg raw_name; Some raw_name ]

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -14,7 +14,7 @@ open Tool_args
     init time. See issue #14624. *)
 let default_cascade_name () =
   match Cascade_catalog_runtime.resolve_declared_name ~raw_name:"" () with
-  | Ok name -> name
+  | Ok name -> Cascade_name.to_string name
   | Error _ ->
     Keeper_cascade_profile.cascade_name_for_use
       Keeper_cascade_profile.Keeper_turn

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -361,7 +361,7 @@ let ensure_keeper_meta config name =
        register as a semantic change. *)
     let cascade_changed =
       Keeper_cascade_profile.normalize_declared_name (cascade_name_of_meta meta)
-      <> resolved_target_cascade_name
+      <> Cascade_name.to_string resolved_target_cascade_name
     in
     (* #10061: persisted state vs TOML source can differ by a single
        trailing newline when OCaml string literals round-trip through
@@ -491,7 +491,7 @@ let ensure_keeper_meta config name =
         cascade_ref =
           if cascade_changed then
             Some Cascade_ref.{
-              group = resolved_target_cascade_name;
+              group = Cascade_name.to_string resolved_target_cascade_name;
               item = None;
             }
           else meta.cascade_ref;

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -162,14 +162,16 @@ let preflight_keeper_msg ctx args : (unit, string) result =
       | Ok turn_cascade_name ->
         (match
            Keeper_exec_preflight.cascade_resilience_error_message
-             (Keeper_exec_preflight.cascade_resilience_of_name turn_cascade_name)
+             (Keeper_exec_preflight.cascade_resilience_of_name
+                (Cascade_name.to_string turn_cascade_name))
          with
          | Some e -> Error e
          | None ->
         let effective_models =
           if direct_reply then
             Cascade_runtime.models_of_cascade_name
-              (Keeper_cascade_profile.Runtime_name turn_cascade_name)
+              (Keeper_cascade_profile.Runtime_name
+                 (Cascade_name.to_string turn_cascade_name))
           else
             effective_model_labels_for_turn meta
         in
@@ -240,7 +242,8 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
       | Ok turn_cascade_name ->
       (match
          Keeper_exec_preflight.cascade_resilience_error_message
-           (Keeper_exec_preflight.cascade_resilience_of_name turn_cascade_name)
+           (Keeper_exec_preflight.cascade_resilience_of_name
+              (Cascade_name.to_string turn_cascade_name))
        with
        | Some e ->
          Progress.stop_tracking turn_task_id;
@@ -262,7 +265,8 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
       let effective_models =
         if direct_reply then
           Cascade_runtime.models_of_cascade_name
-            (Keeper_cascade_profile.Runtime_name turn_cascade_name)
+            (Keeper_cascade_profile.Runtime_name
+               (Cascade_name.to_string turn_cascade_name))
               else
           effective_model_labels_for_turn meta
       in
@@ -512,7 +516,8 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                     ~build_turn_prompt
                     ~user_message:message
                     ~cascade_name:
-                      (Keeper_cascade_profile.Runtime_name turn_cascade_name)
+                      (Keeper_cascade_profile.Runtime_name
+                         (Cascade_name.to_string turn_cascade_name))
                     ~world_observation
                     ~turn_affordances
                     ~required_tool_names


### PR DESCRIPTION
## Summary

Phase C of RFC-0163 propagates the validated `Cascade_name.t` type through the `cascade_catalog_runtime` facade, making the canonical-prefix guarantee visible to downstream consumers.

## Changes

- **`cascade_catalog_runtime.ml/.mli`**: Facade now preserves `Cascade_name.t` in `resolve_declared_name` return instead of stripping it back to `string`.
- **`cascade_runtime.ml`**: Converts to `string` at the `models_of_cascade_name` boundary where mixed with plain strings.
- **`keeper_config.ml`**: Converts at `default_cascade_name` where the `.mli` declares `unit -> string`.
- **`keeper_runtime.ml`**: Converts at `Cascade_ref.group` assignment and `<>` comparison (OCaml `private string` does not auto-coerce in operator positions).
- **`keeper_turn.ml`**: Converts at 5 call sites: `cascade_resilience_of_name` (2×) and `Runtime_name` constructor (3×).

## Design Decisions

Phase C is intentionally conservative. Deeper types (`Cascade_ref.group`, `Keeper_cascade_profile.Runtime_name`) remain `string`-based to keep blast radius bounded. Converting those is Phase D+ scope.

## Verification

- `dune build` on Phase C files: no type errors in changed modules.
- Full build has unrelated pre-existing errors in `keeper_shell_docker.ml` and other files.

## Blast Radius

6 files, +16/-11 lines. Zero behavior change — all additions are explicit `Cascade_name.to_string` conversions at string-boundary consumers.