### PR TITLE
test(rfc-0160): nested-runtime guard token tests (rescue from #18056)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -248,6 +248,7 @@
   test_keeper_transition_audit
   test_keeper_shell_containment
   test_keeper_shell_docker_route
+  test_keeper_shell_docker_nested_runtime
   test_keeper_shell_via_field
   test_env_git_noninteractive
   test_gh_exit_class
@@ -568,6 +569,7 @@
   test_keeper_transition_audit
   test_keeper_shell_containment
   test_keeper_shell_docker_route
+  test_keeper_shell_docker_nested_runtime
   test_keeper_shell_via_field
   test_env_git_noninteractive
   test_gh_exit_class

--- a/test/test_keeper_shell_docker_nested_runtime.ml
+++ b/test/test_keeper_shell_docker_nested_runtime.ml
@@ -1,0 +1,90 @@
+(* RFC-0160 S6: Verify Shell IR-based guard token extraction preserves
+   the semantics of the old Bash_words-based implementation. *)
+
+open Alcotest
+
+module NRT = Masc_mcp.Keeper_shell_docker_nested_runtime
+
+let guard_words tokens =
+  List.filter_map
+    (function
+      | NRT.Guard_word (w, _) -> Some w
+      | NRT.Guard_separator -> None)
+    tokens
+
+let has_separator tokens =
+  List.exists
+    (function NRT.Guard_separator -> true | _ -> false)
+    tokens
+
+let test_simple_command () =
+  let tokens = NRT.shell_guard_tokens "docker run ubuntu" in
+  let words = guard_words tokens in
+  check int "3 words" 3 (List.length words);
+  check bool "starts with docker" true (List.mem "docker" words);
+  check bool "no separator" false (has_separator tokens)
+
+let test_pipeline_produces_separator () =
+  let tokens = NRT.shell_guard_tokens "echo hello | docker run ubuntu" in
+  let words = guard_words tokens in
+  check bool "has docker" true (List.mem "docker" words);
+  check bool "has separator" true (has_separator tokens)
+
+let test_quoted_separator_preserved () =
+  let tokens = NRT.shell_guard_tokens "echo 'hello;world'" in
+  let words = guard_words tokens in
+  check bool "has hello;world" true (List.mem "hello;world" words)
+
+let test_unquoted_separator_split () =
+  let tokens = NRT.shell_guard_tokens "echo hello; docker ps" in
+  check bool "has separator" true (has_separator tokens)
+
+let test_empty_command () =
+  let tokens = NRT.shell_guard_tokens "" in
+  check int "empty tokens" 0 (List.length tokens)
+
+let test_nested_container_detection () =
+  let is_nested = NRT.command_uses_nested_container_runtime "docker build -t myimage ." in
+  check bool "docker detected" true is_nested;
+  let is_nested2 = NRT.command_uses_nested_container_runtime "podman run alpine" in
+  check bool "podman detected" true is_nested2;
+  let not_nested = NRT.command_uses_nested_container_runtime "ls -la /tmp" in
+  check bool "ls not nested" false not_nested
+
+let test_sudo_docker_chain () =
+  let is_nested = NRT.command_uses_nested_container_runtime "sudo docker ps" in
+  check bool "sudo docker detected" true is_nested
+
+let test_env_docker_chain () =
+  let is_nested = NRT.command_uses_nested_container_runtime "env DOCKER_HOST=xxx docker ps" in
+  check bool "env docker detected" true is_nested
+
+let test_socket_reference () =
+  let is_nested = NRT.command_uses_nested_container_runtime "curl --unix-socket /var/run/docker.sock http://localhost/info" in
+  check bool "socket reference detected" true is_nested
+
+let test_sh_c_docker () =
+  let is_nested = NRT.command_uses_nested_container_runtime "sh -c 'docker ps'" in
+  check bool "sh -c docker detected" true is_nested
+
+let suite =
+  [
+    ( "guard_tokens"
+    , [
+        test_case "simple command" `Quick test_simple_command;
+        test_case "pipeline separator" `Quick test_pipeline_produces_separator;
+        test_case "quoted separator preserved" `Quick test_quoted_separator_preserved;
+        test_case "unquoted separator split" `Quick test_unquoted_separator_split;
+        test_case "empty command" `Quick test_empty_command;
+      ] );
+    ( "nested_container_detection"
+    , [
+        test_case "docker/podman detection" `Quick test_nested_container_detection;
+        test_case "sudo docker chain" `Quick test_sudo_docker_chain;
+        test_case "env docker chain" `Quick test_env_docker_chain;
+        test_case "socket reference" `Quick test_socket_reference;
+        test_case "sh -c docker" `Quick test_sh_c_docker;
+      ] );
+  ]
+
+let () = Alcotest.run "Keeper_shell_docker_nested_runtime" suite


### PR DESCRIPTION
## Summary

Test-only rescue from closed PR #18056. Adds Alcotest coverage for `Keeper_shell_docker_nested_runtime` after #18054 migrated the module to the `Exec_policy_mutation_classifier.quoted_word` bridge.

- `test/test_keeper_shell_docker_nested_runtime.ml` — 10 cases, 90 LoC
- `test/dune` — register test (alcotest_runner + alcotest_runner_strict)

## Why test-only

PR #18056 also re-implemented the 6 G7 lib/ call sites, but #18054 (`9633b1423d`) merged the identical bridge first. The lib/ portion was fully redundant. Only the test additions are unique → split into this focused PR.

## API surface verified against main

Test asserts on the public surface of `lib/keeper/keeper_shell_docker_nested_runtime.ml` as it exists on `origin/main` after #18054:

| Symbol | Source on main |
|--------|----------------|
| `shell_guard_token = Guard_word of string * bool \| Guard_separator` | line 33-35 |
| `shell_guard_tokens : string -> shell_guard_token list` | exported |
| `command_uses_nested_container_runtime : string -> bool` | exported |

No new lib/ changes — pure test addition.

## Test plan

- [x] `git diff --stat` — 2 files, +92/-0
- [ ] `dune build @runtest test/test_keeper_shell_docker_nested_runtime.exe` — blocked by pre-existing main build breakage (Fundamental Check failing on `816ce3bc5e`; see e.g. `keeper_agent_run.ml:480` arity mismatch and `EC.is_provider_timeout_error` unbound). Re-running once main is green.
- [x] Test file lexically/syntactically self-contained against pinned API

## Trace

- Supersedes test portion of #18056 (closed)
- Depends on #18054 (merged)
- RFC-0160 S6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>