### PR TITLE
P9a follow-up: equivalence tests + comment cleanup

### DIFF
--- a/lib/exec/test/test_shell_ir_risk.ml
+++ b/lib/exec/test/test_shell_ir_risk.ml
@@ -176,6 +176,35 @@ let test_classify_pipeline_first_stage_destructive () =
   Alcotest.(check bool) "pipeline with destructive first stage"
     true (Risk.is_destructive envelope)
 
+(* --- classify: gh read-only prefix equivalence (P9a) --- *)
+
+let test_classify_gh_read_only_prefixes_equivalence () =
+  let prefixes =
+    [ [ "pr"; "list" ]
+    ; [ "pr"; "view"; "123" ]
+    ; [ "pr"; "diff"; "123" ]
+    ; [ "pr"; "checks"; "123" ]
+    ; [ "pr"; "status" ]
+    ; [ "issue"; "list" ]
+    ; [ "issue"; "view"; "456" ]
+    ; [ "issue"; "status" ]
+    ; [ "repo"; "view" ]
+    ; [ "repo"; "list" ]
+    ; [ "release"; "list" ]
+    ; [ "release"; "view"; "v1.0" ]
+    ; [ "api"; "/repos/o/r" ]
+    ]
+  in
+  List.iter
+    (fun args ->
+       let ir = simple_ir "gh" args in
+       let envelope = Risk.classify (Risk.undecided ir) in
+       Alcotest.(check bool)
+         (Format.asprintf "%a is R0" Risk.pp_risk_class envelope.Risk.risk)
+         true
+         (Risk.is_r0 envelope))
+    prefixes
+
 (* --- classify: unknown commands → R0 --- *)
 
 let test_classify_unknown_read () =
@@ -206,6 +235,7 @@ let () =
   test_classify_gh_api_get_r0 ();
   test_classify_gh_api_graphql_r1 ();
   test_classify_pipeline_first_stage_destructive ();
+  test_classify_gh_read_only_prefixes_equivalence ();
   test_classify_unknown_read ();
   test_trust_decided ();
-  print_endline "test_shell_ir_risk: 15/15 passed"
+  print_endline "test_shell_ir_risk: 16/16 passed"

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -212,8 +212,7 @@ let git_action_of_input (input : Yojson.Safe.t) : string =
 let is_read_only_with_input ~(tool_name : string) ~(input : Yojson.Safe.t) : bool =
   match Tool_name.of_string tool_name with
   | Some (Keeper Shell) when is_shell_gh_op input ->
-    (* RFC-0160 S3: route through Shell_ir_risk.classify_gh instead of
-       string-prefix matching (gh_read_only_prefixes / is_gh_api_read_only).
+    (* RFC-0160 S3: route through Shell_ir_risk.classify_gh.
        Avoids circular dependency through Keeper_gh_shared. *)
     let words =
       match input with


### PR DESCRIPTION
## Summary

Follow-up to PR #18060 (P9a typed gh contract). Adds missing equivalence tests and cleans up stale comment references.

## Changes

- **Add** 13-prefix equivalence test to `test_shell_ir_risk.ml`:
  `pr list/view/diff/checks/status`, `issue list/view/status`,
  `repo view/list`, `release list/view`, `api GET`.
  All classify as `R0_Read` under `Shell_ir_risk.classify_gh`.
  Test runner: **16/16 PASS**.
- **Clean up** RFC-0160 S3 comment in `keeper_tool_registry.ml`:
  remove dead code name references (`gh_read_only_prefixes`,
  `is_gh_api_read_only`) that were removed in the parent PR.

## Verification

- `dune build lib/exec/test/test_shell_ir_risk.exe` → build OK
- `_build/default/lib/exec/test/test_shell_ir_risk.exe` → 16/16 PASS

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>