### PR TITLE
feat(keeper): RFC-0142 Phase 4 PR-A — Provider_error_class typed boundary

### DIFF
--- a/docs/rfc/RFC-0142-cascade-error-classify-decomp.md
+++ b/docs/rfc/RFC-0142-cascade-error-classify-decomp.md
@@ -3,11 +3,11 @@ rfc: "0142"
 title: "cascade_error_classify Decomposition + Typed JSON-Extraction Variant"
 status: Active
 created: 2026-05-20
-updated: 2026-05-22
+updated: 2026-05-23
 author: vincent
 supersedes: []
 superseded_by: null
-related: ["0085", "0088", "0148", "0154"]
+related: ["0085", "0088", "0089", "0148", "0154"]
 implementation_prs: [16790, 16806, 16894, 16899, 17474]
 ---
 
@@ -80,6 +80,56 @@ remainder).
 - **RFC-0154** (System_error_class typed SSOT, Implemented 2026-05-21):
   operator-facing closed-sum SSOT. The `Wrong_shape` diagnostic
   affordance here is the same parse-don't-validate discipline.
+
+### Phase 4 — `Provider_error_class` typed boundary (NEW 2026-05-23)
+
+Audit on 2026-05-23 (`memory/keeper-health-probe-hardcoding-audit-2026-05-23.html`)
+identified an adjacent surface untouched by Phases 1-3:
+`lib/keeper/keeper_health_probe.ml:provider_runtime_pressure_class`
+holds the same `contains "<needle>"` + magic HTTP status + 20-alias
+parse soup that this RFC's umbrella exists to eliminate.
+
+Inventory at `origin/main` 2026-05-23:
+
+| Surface | Count | Site |
+|---------|-------|------|
+| `String_util.contains_substring_ci` substring literals | 23 | `keeper_health_probe.ml:66-98` |
+| Magic HTTP status integer literals | 5 (`408`/`429`/`504`/`524`/`529`) | `keeper_health_probe.ml:83, 99` |
+| `runtime_pressure_class_of_label` alias strings | 20 (10 variants × 1-3 aliases) | `keeper_health_probe.ml:37-52` |
+
+The fall-through `| _ -> Provider_error` in
+`provider_runtime_pressure_class` is exactly RFC-0088 §1 *Unknown →
+Permissive Default* — an `Unknown` provider error is silently
+classified into the catch-all bucket, defeating reactor
+specialization.
+
+#### Phase 4 PR plan
+
+| PR | Scope | Acceptance |
+|----|-------|-----------|
+| **PR-A** (this PR) | `lib/keeper/provider_error_class.{ml,mli}` new module — closed-sum `t` + named `Http_status` constants + wire tags + tests. Zero callers, zero behavioural change. | `dune build lib/keeper/provider_error_class.cmi` clean; `test_provider_error_class` Alcotest green; `rg 'contains "' lib/keeper/keeper_health_probe.ml` count *unchanged* (PR-A is additive only). |
+| PR-B-Anthropic | `lib/llm_provider/anthropic_*` adapter emits `Provider_error_class.t` directly from typed error response. | Anthropic adapter test covers 6 named variants; `Unspecified` only on genuinely unknown payloads. |
+| PR-B-Openai_compat | Same for OpenAI-compatible adapter (Kimi, GLM, llamacpp-OpenAI-API). | Adapter test covers 6 variants. |
+| PR-B-Llamacpp_local | Same for local llama.cpp adapter. | Adapter test covers timeout & DNS only (no backpressure surface). |
+| PR-C | Add `classified_as : Provider_error_class.t` field to `Keeper_registry_types.Provider_runtime_error`. Producers set it from PR-B output; consumers may still ignore it. | Field present in `.ml` + `.mli`; `failure_reason_to_string` reads `classified_as |> to_short_tag` for the tag prefix; backwards-compatible serialization. |
+| PR-D | `keeper_health_probe.ml:provider_runtime_pressure_class` rewritten as pure typed `match` on `classified_as`. `runtime_pressure_class_of_label` parse function deleted. | `rg 'contains "' lib/keeper/keeper_health_probe.ml` → **0**; `rg '\b(408\|429\|504\|524\|529)\b' lib/keeper/keeper_health_probe.ml` → **0**; new typed variant in `Provider_error_class.t` triggers exhaustive-match compile error in the consumer. |
+
+#### Acceptance metric for Phase 4 closure
+
+| Metric | Before | After Phase 4 |
+|--------|--------|---------------|
+| Substring literals in `keeper_health_probe.ml` classifier branches | 23 | 0 |
+| Magic HTTP status integers in `keeper_health_probe.ml` | 5 | 0 (named constants in `Provider_error_class.Http_status`) |
+| `runtime_pressure_class_of_label` alias strings | 20 | 0 (function deleted, callers consume typed `Provider_error_class.t` directly) |
+| Classifier surface compiler-checked on new provider error addition | No (substring soup) | Yes (exhaustive `match` on closed sum) |
+
+#### Why Phase 4 belongs in RFC-0142
+
+RFC-0142's umbrella scope is "cascade/provider error classification
+substring-and-catch-all elimination" (cf. RFC-0089 string-classifier
+umbrella).  The originally-listed `cascade_error_classify.ml` was one
+file under that umbrella; `keeper_health_probe.ml` is another.  Phase
+4 closes the keeper-reaction-layer twin.
 
 ---
 

--- a/lib/keeper/provider_error_class.ml
+++ b/lib/keeper/provider_error_class.ml
@@ -1,0 +1,73 @@
+(* RFC-0142 §Phase 2 — PR-A.  SSOT for LLM-provider runtime error
+   classification.  See provider_error_class.mli for the contract.
+
+   This module is intentionally dependency-free (no transitive [String_util],
+   no Eio, no Unix) so the boundary type can land before any adapter or
+   consumer wires it in. *)
+
+type response_timeout_kind =
+  | Connection_timeout
+  | First_token_timeout
+  | Inter_chunk_idle
+  | Wall_clock_timeout
+
+type t =
+  | Client_capacity_exhausted
+  | Tier_admission_exhausted of { capability_profile : string option }
+  | Backpressure of
+      { http_status : int
+      ; retry_after_ms : int option
+      }
+  | Dns_resolution_failure of { host : string option }
+  | Response_timeout of
+      { kind : response_timeout_kind
+      ; elapsed_ms : int option
+      }
+  | Unspecified of
+      { raw_code : string
+      ; raw_detail : string
+      }
+
+module Http_status = struct
+  let too_many_requests = 429
+  let anthropic_overloaded = 529
+  let request_timeout = 408
+  let gateway_timeout = 504
+  let cloudflare_origin_timeout = 524
+end
+
+let backpressure_http_statuses =
+  [ Http_status.too_many_requests; Http_status.anthropic_overloaded ]
+;;
+
+let timeout_http_statuses =
+  [ Http_status.request_timeout
+  ; Http_status.gateway_timeout
+  ; Http_status.cloudflare_origin_timeout
+  ]
+;;
+
+let response_timeout_kind_to_string = function
+  | Connection_timeout -> "connection_timeout"
+  | First_token_timeout -> "first_token_timeout"
+  | Inter_chunk_idle -> "inter_chunk_idle"
+  | Wall_clock_timeout -> "wall_clock_timeout"
+;;
+
+let to_short_tag = function
+  | Client_capacity_exhausted -> "client_capacity_exhausted"
+  | Tier_admission_exhausted _ -> "tier_admission_exhausted"
+  | Backpressure _ -> "backpressure"
+  | Dns_resolution_failure _ -> "dns_resolution_failure"
+  | Response_timeout _ -> "response_timeout"
+  | Unspecified _ -> "unspecified"
+;;
+
+let raw_payload = function
+  | Unspecified { raw_code; raw_detail } -> Some (raw_code, raw_detail)
+  | Client_capacity_exhausted
+  | Tier_admission_exhausted _
+  | Backpressure _
+  | Dns_resolution_failure _
+  | Response_timeout _ -> None
+;;

--- a/lib/keeper/provider_error_class.mli
+++ b/lib/keeper/provider_error_class.mli
@@ -1,0 +1,140 @@
+(** SSOT for LLM-provider runtime error classification surfaced to
+    keeper auto-resume reactors (Provider_capacity backpressure,
+    Tier_admission watchdog, Provider_dns_failure, Provider_timeout).
+
+    RFC-0142 §Phase 2 — PR-A.
+
+    This module is the *boundary* typed variant.  PR-B onward wires it
+    into [Keeper_registry_types.Provider_runtime_error.classified_as],
+    and PR-C replaces the substring-and-magic-HTTP dispatch inside
+    [Keeper_health_probe.provider_runtime_pressure_class] with a pure
+    [match] on this type.
+
+    PR-A scope (this PR): the type, named HTTP status constants, and
+    wire tags.  Zero callers, zero behavioural change.  A
+    [classify_raw] helper is deliberately *not* exposed — adapter-side
+    typed emission (per-provider [Anthropic], [Openai_compat],
+    [Llamacpp_local], …) belongs in PR-B-family so the substring soup
+    moves to its single legitimate residence (the wire boundary), not
+    a relocated copy inside the keeper layer.
+
+    Adding a new named variant requires (a) at least one provider
+    adapter that produces it and (b) a downstream keeper reactor that
+    consumes it — otherwise the original payload is preserved verbatim
+    in [Unspecified], which is a parse-don't-validate escape hatch,
+    not a catch-all. *)
+
+type response_timeout_kind =
+  | Connection_timeout
+      (** Underlying TCP/TLS handshake never completed.  Default kind
+          for HTTP 408 / 504 / 524 status when no streaming-stage
+          evidence is available. *)
+  | First_token_timeout
+      (** Streaming connection opened but no first token arrived
+          before the agreed deadline.  Distinct from
+          [Inter_chunk_idle] because retry strategy differs. *)
+  | Inter_chunk_idle
+      (** Streaming response stalled mid-flight between tokens. *)
+  | Wall_clock_timeout
+      (** Whole-turn wall-clock budget exceeded
+          ([max_execution_time], orchestrator-side deadline). *)
+
+type t =
+  | Client_capacity_exhausted
+      (** Local in-flight admission cap reached; the failure is on
+          our side, not the provider.  RFC-0042 / RFC-0058 territory.
+          Reactor: pause new admission, drain in-flight. *)
+  | Tier_admission_exhausted of { capability_profile : string option }
+      (** Cascade tier-group admission denied because every model in
+          the strict capability profile is saturated or unavailable.
+          [capability_profile] is the canonical profile name (e.g.
+          [Some "strict_tool_candidates"]) when the adapter can
+          attribute the denial to a specific profile, [None]
+          otherwise. *)
+  | Backpressure of
+      { http_status : int
+      ; retry_after_ms : int option
+      }
+      (** Provider explicitly signalled "slow down" — HTTP
+          [too_many_requests] / [anthropic_overloaded], or vendor
+          equivalents detected by the adapter.  [retry_after_ms]
+          mirrors any [Retry-After] header.  Reactor: exponential
+          backoff with jitter. *)
+  | Dns_resolution_failure of { host : string option }
+      (** Hostname could not be resolved.  [host] is the canonical
+          host whose lookup failed when the adapter can name it.
+          Reactor: pause cascade, mark route unhealthy. *)
+  | Response_timeout of
+      { kind : response_timeout_kind
+      ; elapsed_ms : int option
+      }
+      (** Request timed out.  [kind] discriminates connection vs
+          streaming-stage timeouts; [elapsed_ms] is the observed
+          duration when the adapter measured it. *)
+  | Unspecified of
+      { raw_code : string
+      ; raw_detail : string
+      }
+      (** Adapter could not classify the failure into one of the
+          named variants.  [raw_code] / [raw_detail] preserve the
+          original payload verbatim so dashboards and post-mortems
+          retain the message.  Not a catch-all — never use this
+          variant when a typed signal exists. *)
+
+(** {1 Named HTTP status constants}
+
+    These are the magic literals previously inlined in
+    [Keeper_health_probe.provider_runtime_pressure_class].  Holding
+    them in one named module lets adapters reference the same numbers
+    by name, and lets PR-C delete the inline integer literals from the
+    consumer. *)
+
+module Http_status : sig
+  val too_many_requests : int
+  (** [429] — RFC 6585. *)
+
+  val anthropic_overloaded : int
+  (** [529] — Anthropic non-standard overload signal. *)
+
+  val request_timeout : int
+  (** [408] — HTTP/1.1. *)
+
+  val gateway_timeout : int
+  (** [504] — HTTP/1.1. *)
+
+  val cloudflare_origin_timeout : int
+  (** [524] — Cloudflare non-standard origin timeout. *)
+end
+
+val backpressure_http_statuses : int list
+(** Canonical set used by adapters to map raw HTTP statuses to
+    [Backpressure].  Stable list — adding to it requires a paired
+    docstring entry on the named constant.  Reads:
+    [[Http_status.too_many_requests; Http_status.anthropic_overloaded]]. *)
+
+val timeout_http_statuses : int list
+(** Canonical set used by adapters to map raw HTTP statuses to
+    [Response_timeout { kind = Connection_timeout; _ }].  Reads:
+    [[Http_status.request_timeout; Http_status.gateway_timeout;
+      Http_status.cloudflare_origin_timeout]]. *)
+
+(** {1 Wire tags}
+
+    Stable string identifiers for telemetry, dashboards, and
+    [Keeper_health_probe.runtime_pressure_class_of_label] migration. *)
+
+val to_short_tag : t -> string
+(** Returns the stable short tag.  One of:
+    [client_capacity_exhausted], [tier_admission_exhausted],
+    [backpressure], [dns_resolution_failure], [response_timeout],
+    [unspecified]. *)
+
+val response_timeout_kind_to_string : response_timeout_kind -> string
+(** [connection_timeout] / [first_token_timeout] / [inter_chunk_idle] /
+    [wall_clock_timeout]. *)
+
+val raw_payload : t -> (string * string) option
+(** [Some (raw_code, raw_detail)] for [Unspecified], [None]
+    otherwise.  Provided so consumers that must surface a free-form
+    error message (operator UI, post-mortem export) need not
+    re-classify or destructure. *)

--- a/test/dune
+++ b/test/dune
@@ -943,6 +943,7 @@
   test_goal_verification
   test_string_util
   test_system_error_class
+  test_provider_error_class
   test_set_util
   test_board_core_payload
   test_board_attachment_meta
@@ -1168,6 +1169,7 @@
   test_goal_verification
   test_string_util
   test_system_error_class
+  test_provider_error_class
   test_set_util
   test_board_core_payload
   test_board_attachment_meta

--- a/test/test_provider_error_class.ml
+++ b/test/test_provider_error_class.ml
@@ -1,0 +1,157 @@
+(** RFC-0142 §Phase 2 — PR-A.  Unit tests for the typed
+    [Provider_error_class] SSOT.
+
+    Covers (a) wire-tag stability for every constructor,
+    (b) [raw_payload] preserves [Unspecified] verbatim and is [None]
+    elsewhere, (c) HTTP status named-constant values match the
+    numbers previously inlined in [Keeper_health_probe], and
+    (d) [response_timeout_kind] wire tags. *)
+
+open Alcotest
+
+module P = Masc_mcp.Provider_error_class
+
+let tag = testable Fmt.string String.equal
+
+let check_tag label expected actual =
+  check tag label expected (P.to_short_tag actual)
+;;
+
+(* ---- to_short_tag: every constructor pinned ---- *)
+
+let test_short_tag_client_capacity_exhausted () =
+  check_tag "Client_capacity_exhausted" "client_capacity_exhausted"
+    P.Client_capacity_exhausted
+;;
+
+let test_short_tag_tier_admission_exhausted_some () =
+  check_tag "Tier_admission_exhausted Some" "tier_admission_exhausted"
+    (P.Tier_admission_exhausted
+       { capability_profile = Some "strict_tool_candidates" })
+;;
+
+let test_short_tag_tier_admission_exhausted_none () =
+  check_tag "Tier_admission_exhausted None" "tier_admission_exhausted"
+    (P.Tier_admission_exhausted { capability_profile = None })
+;;
+
+let test_short_tag_backpressure () =
+  check_tag "Backpressure" "backpressure"
+    (P.Backpressure
+       { http_status = P.Http_status.too_many_requests
+       ; retry_after_ms = Some 2_500
+       })
+;;
+
+let test_short_tag_dns_resolution_failure () =
+  check_tag "Dns_resolution_failure" "dns_resolution_failure"
+    (P.Dns_resolution_failure { host = Some "api.anthropic.com" })
+;;
+
+let test_short_tag_response_timeout () =
+  check_tag "Response_timeout" "response_timeout"
+    (P.Response_timeout
+       { kind = P.First_token_timeout; elapsed_ms = Some 30_000 })
+;;
+
+let test_short_tag_unspecified () =
+  check_tag "Unspecified" "unspecified"
+    (P.Unspecified { raw_code = "unknown_provider_error"; raw_detail = "" })
+;;
+
+(* ---- raw_payload: Unspecified preserves verbatim, others are None ---- *)
+
+let raw_pair = pair string string
+
+let test_raw_payload_unspecified_preserves () =
+  check (option raw_pair) "verbatim raw_code + raw_detail"
+    (Some ("upstream_5xx", "Bad Gateway (cloudflare proxy)"))
+    (P.raw_payload
+       (P.Unspecified
+          { raw_code = "upstream_5xx"
+          ; raw_detail = "Bad Gateway (cloudflare proxy)"
+          }))
+;;
+
+let test_raw_payload_typed_variants_are_none () =
+  check (option raw_pair) "Client_capacity_exhausted" None
+    (P.raw_payload P.Client_capacity_exhausted);
+  check (option raw_pair) "Tier_admission_exhausted" None
+    (P.raw_payload
+       (P.Tier_admission_exhausted { capability_profile = None }));
+  check (option raw_pair) "Backpressure" None
+    (P.raw_payload
+       (P.Backpressure
+          { http_status = P.Http_status.anthropic_overloaded
+          ; retry_after_ms = None
+          }));
+  check (option raw_pair) "Dns_resolution_failure" None
+    (P.raw_payload (P.Dns_resolution_failure { host = None }));
+  check (option raw_pair) "Response_timeout" None
+    (P.raw_payload
+       (P.Response_timeout
+          { kind = P.Wall_clock_timeout; elapsed_ms = None }))
+;;
+
+(* ---- HTTP status constants pin the magic numbers previously inlined ---- *)
+
+let test_http_status_named_constants () =
+  check int "too_many_requests = 429" 429 P.Http_status.too_many_requests;
+  check int "anthropic_overloaded = 529" 529 P.Http_status.anthropic_overloaded;
+  check int "request_timeout = 408" 408 P.Http_status.request_timeout;
+  check int "gateway_timeout = 504" 504 P.Http_status.gateway_timeout;
+  check int "cloudflare_origin_timeout = 524" 524
+    P.Http_status.cloudflare_origin_timeout
+;;
+
+let test_backpressure_http_statuses_set () =
+  check (list int) "backpressure set"
+    [ 429; 529 ] P.backpressure_http_statuses
+;;
+
+let test_timeout_http_statuses_set () =
+  check (list int) "timeout set" [ 408; 504; 524 ] P.timeout_http_statuses
+;;
+
+(* ---- response_timeout_kind wire tags ---- *)
+
+let test_response_timeout_kind_tags () =
+  let kt = P.response_timeout_kind_to_string in
+  check string "Connection_timeout" "connection_timeout" (kt P.Connection_timeout);
+  check string "First_token_timeout" "first_token_timeout"
+    (kt P.First_token_timeout);
+  check string "Inter_chunk_idle" "inter_chunk_idle" (kt P.Inter_chunk_idle);
+  check string "Wall_clock_timeout" "wall_clock_timeout"
+    (kt P.Wall_clock_timeout)
+;;
+
+let () =
+  run "provider_error_class"
+    [ ( "to_short_tag"
+      , [ test_case "client_capacity_exhausted" `Quick
+            test_short_tag_client_capacity_exhausted
+        ; test_case "tier_admission_exhausted Some" `Quick
+            test_short_tag_tier_admission_exhausted_some
+        ; test_case "tier_admission_exhausted None" `Quick
+            test_short_tag_tier_admission_exhausted_none
+        ; test_case "backpressure" `Quick test_short_tag_backpressure
+        ; test_case "dns_resolution_failure" `Quick
+            test_short_tag_dns_resolution_failure
+        ; test_case "response_timeout" `Quick test_short_tag_response_timeout
+        ; test_case "unspecified" `Quick test_short_tag_unspecified
+        ] )
+    ; ( "raw_payload"
+      , [ test_case "Unspecified preserves verbatim" `Quick
+            test_raw_payload_unspecified_preserves
+        ; test_case "typed variants → None" `Quick
+            test_raw_payload_typed_variants_are_none
+        ] )
+    ; ( "http_status"
+      , [ test_case "named constants" `Quick test_http_status_named_constants
+        ; test_case "backpressure set" `Quick test_backpressure_http_statuses_set
+        ; test_case "timeout set" `Quick test_timeout_http_statuses_set
+        ] )
+    ; ( "response_timeout_kind"
+      , [ test_case "wire tags" `Quick test_response_timeout_kind_tags ] )
+    ]
+;;


### PR DESCRIPTION
RFC-0142 Phase 4 PR-A — `Provider_error_class` typed boundary module.

## Summary

- New module `lib/keeper/provider_error_class.{ml,mli}` — closed-sum `t` (6 variants), named `Http_status` constants (replacing 5 magic integer literals), wire tags.
- Tests `test/test_provider_error_class.ml` — pins every constructor's `to_short_tag`, every named HTTP status value, `raw_payload` `Unspecified` round-trip and typed-variant `None` behaviour.
- `docs/rfc/RFC-0142-cascade-error-classify-decomp.md` — adds **§Phase 4** with full inventory, PR plan (PR-A → PR-D), and acceptance metrics.
- Zero callers wired. Zero behavioural change. PR-A is purely additive — `keeper_health_probe.ml`'s 23-substring classifier is **unchanged** until PR-D.

## Why

2026-05-23 audit ([`memory/keeper-health-probe-hardcoding-audit-2026-05-23.html`](https://github.com/jeong-sik/me/blob/main/.worktrees/report-keeper-health-hardcoding-20260523/memory/keeper-health-probe-hardcoding-audit-2026-05-23.html)) identified that PR #18059 adds a substring (`contains "strict_tool_candidates"`) to `keeper_health_probe.ml` while its own RFC body §3 declared "string classifier elimination" as a goal. The audit also catalogued the wider debt at the same site:

| Surface | `origin/main` count |
|---------|---------------------|
| `contains_substring_ci` substring literals in classifier branches | 23 |
| Magic HTTP status integers (`408`/`429`/`504`/`524`/`529`) | 5 |
| `runtime_pressure_class_of_label` alias strings (10 variants × 1-3 aliases) | 20 |

This is the *same* anti-pattern RFC-0142's umbrella was written to eliminate, just at the keeper-reaction layer instead of the cascade error JSON-extraction layer. Phase 4 (added in this PR) extends RFC-0142's scope to cover it.

## Design

Mirrors RFC-0154's `system_error_class.{ml,mli}` (Implemented 2026-05-21) shape and discipline. Differs in domain (LLM-provider runtime errors vs OS errno).

```ocaml
type response_timeout_kind =
  | Connection_timeout | First_token_timeout
  | Inter_chunk_idle | Wall_clock_timeout

type t =
  | Client_capacity_exhausted
  | Tier_admission_exhausted of { capability_profile : string option }
  | Backpressure of { http_status : int; retry_after_ms : int option }
  | Dns_resolution_failure of { host : string option }
  | Response_timeout of { kind : response_timeout_kind; elapsed_ms : int option }
  | Unspecified of { raw_code : string; raw_detail : string }
```

A `classify_raw` helper is deliberately **not** exposed. Adapter-side typed emission (per-provider `Anthropic`, `Openai_compat`, `Llamacpp_local` in PR-B-* of Phase 4) is the correct residence for substring parsing — exposing `classify_raw` here would just *relocate* the soup from `keeper_health_probe.ml` to `provider_error_class.ml`. `Unspecified { raw_code; raw_detail }` is the parse-don't-validate escape hatch, never a catch-all.

## Test plan

- [x] `ocamlfind ocamlc` pinpoint compile of `.mli` and `.ml` — clean (zero warnings).
- [x] `ocp-indent` parses `test/test_provider_error_class.ml` cleanly (157 lines).
- [ ] **Full `dune build @all` + `dune test test_provider_error_class` cannot run on `origin/main` `079b2c8c14`** due to pre-existing unrelated breakage (`Keeper_meta_json_scrub` unbound, `Path_check_error.parse_prefix` unbound, syntax error in `keeper_shell_docker.ml`). CI "Fundamental Check" reports `failure` on this main HEAD. PR-A's changed surface is fully orthogonal — the "Detect Changed Surfaces" gate (per `memory/reference_masc_mcp_ci_build_test_skips.md`) may therefore SKIP `Build and Test` for this PR. Once main self-heals, the test stanza will run.

## RFC reference

This PR is **RFC-0142 §Phase 4 PR-A**. Phase 4 added in this same PR. Phases 1-3 (separate cascade_error_classify decomposition) are unaffected.

Related RFC:
- RFC-0089 — string-classifier umbrella
- RFC-0148 — typed `tool_error` variant (sibling pattern)
- RFC-0154 — `system_error_class` typed SSOT (closest sibling)

## What this PR does NOT do

- Does **not** touch `keeper_health_probe.ml`. The 23 substring literals remain.
- Does **not** add a `classified_as` field to `Provider_runtime_error`. That is PR-C.
- Does **not** interact with PR #18059 (`shell-ir-s4-parser-consolidation`). PR #18059's substring addition continues to exist on its branch — this PR makes the destination type available so a future PR can replace, not extend, the substring soup.

## Follow-up sequence

| PR | Scope |
|----|-------|
| PR-B-Anthropic | `lib/llm_provider/anthropic_*` emits `Provider_error_class.t` from typed error response. |
| PR-B-Openai_compat | Same for OpenAI-compatible adapters (Kimi, GLM, llamacpp-OAI). |
| PR-B-Llamacpp_local | Same for local llama.cpp adapter (timeout + DNS only). |
| PR-C | Add `classified_as : Provider_error_class.t` to `Keeper_registry_types.Provider_runtime_error`. |
| PR-D | Rewrite `keeper_health_probe.ml:provider_runtime_pressure_class` as pure typed `match`. Delete `runtime_pressure_class_of_label` alias parser. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
