### PR TITLE
RFC-0160 PR-2: Shell IR sandbox externalization + keeper lowering pilot

### DIFF
--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -534,20 +534,19 @@ let handle_keeper_shell
                  then result.stdout
                  else result.stdout ^ result.stderr
                in
-               Yojson.Safe.to_string
-                 (`Assoc
-                     [ "ok", `Bool (match result.status with Unix.WEXITED 0 -> true | _ -> false)
-                     ; "op", `String op
-                     ; "path", `String target
-                     ; "via", `String "host"
-                     ; "status", Keeper_alerting_path.process_status_to_json result.status
-                     ; "entries", lines_to_json ~limit output
-                     ]))))
-  | "cat" ->
-    (match read_target () with
-     | Error e -> path_error e
-     | Ok target ->
-       let max_bytes = shell_readonly_cat_max_bytes args in
+               render_completed_process_result ~cwd:None
+                 ~cmd:"ls -la"
+                 ~extra:[
+                   "path", `String target;
+                   "entries", lines_to_json ~limit output;
+                 ]
+                 result.status output
+             )))
+     | "cat" ->
+       (match read_target () with
+        | Error e -> path_error e
+        | Ok target ->
+          let max_bytes = shell_readonly_cat_max_bytes args in
        (* RFC-0006 Phase B-3b: docker route via the existing
           read_file_in_container helper (which is already a [cat]
           wrapper around run_command_in_container). Symmetry with

--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -1009,56 +1009,14 @@ let handle_keeper_shell
                   let result =
                     Masc_exec.Exec_dispatch.dispatch_decided envelope
                   in
-                  (* P16: Record execution in history for failure pattern detection *)
-                  let success =
-                    match result.status with
-                    | Unix.WEXITED 0 -> true
-                    | _ -> false
-                  in
-                  let cmd = "git --no-optional-locks log --format=<fmt> -<n>" in
-                  let cmd_prefix = Keeper_shell_command_semantics.cmd_prefix cmd in
-                  let entry =
-                    Masc_exec.Bash_history.
-                      { ts = Unix.time ()
-                      ; cmd_hash = Masc_exec.Bash_history.cmd_hash cmd
-                      ; cmd_prefix
-                      ; semantic_kind = op
-                      ; duration_ms = 0
-                      ; success
-                      }
-                  in
-                  observe_history_append ~root ~keeper_name:meta.name entry;
-                  let insight_extra =
-                    let patterns =
-                      Masc_exec.Bash_history.failure_insight
-                        ~base_path:root
-                        ~keeper_name:meta.name
-                    in
-                    if patterns = []
-                    then []
-                    else
-                      [ "failure_insight"
-                      , `List (List.map Masc_exec.Bash_history.failure_pattern_to_json patterns)
-                      ]
-                  in
-                  Yojson.Safe.to_string
-                    (Exec_core.process_result_json
-                       ~artifact_policy:Exec_core.Inline_only
-                       ~base_path:root
-                       ~keeper_name:meta.name
-                       ~cmd
-                       ~extra:
-                         ([ "op", `String op
-                          ; "cmd", `String cmd
-                          ; "cwd", `String cwd
-                          ; "count", `Int count
-                          ; "grep", `String grep
-                          ; "via", `String "host"
-                          ]
-                          @ insight_extra)
-                       ~status:result.status
-                       ~output:result.stdout
-                       ())))))
+                  render_completed_process_result ~cwd:(Some cwd)
+                    ~cmd:"git --no-optional-locks log --format=<fmt> -<n>"
+                    ~extra:[
+                      "count", `Int count;
+                      "grep", `String grep;
+                    ]
+                    result.status result.stdout
+                ))))
   | "find" ->
     let name_pattern =
       let pattern = Safe_ops.json_string ~default:"" "pattern" args |> String.trim in

--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -427,54 +427,11 @@ let handle_keeper_shell
                let result =
                  Masc_exec.Exec_dispatch.dispatch_decided envelope
                in
-               (* P16: Record execution in history for failure pattern detection *)
-               let success =
-                 match result.status with
-                 | Unix.WEXITED 0 -> true
-                 | _ -> false
-               in
-               let cmd = "git --no-optional-locks status --short --branch" in
-               let cmd_prefix = Keeper_shell_command_semantics.cmd_prefix cmd in
-               let entry =
-                 Masc_exec.Bash_history.
-                   { ts = Unix.time ()
-                   ; cmd_hash = Masc_exec.Bash_history.cmd_hash cmd
-                   ; cmd_prefix
-                   ; semantic_kind = op
-                   ; duration_ms = 0
-                   ; success
-                   }
-               in
-               observe_history_append ~root ~keeper_name:meta.name entry;
-               let insight_extra =
-                 let patterns =
-                   Masc_exec.Bash_history.failure_insight
-                     ~base_path:root
-                     ~keeper_name:meta.name
-                 in
-                 if patterns = []
-                 then []
-                 else
-                   [ "failure_insight"
-                   , `List (List.map Masc_exec.Bash_history.failure_pattern_to_json patterns)
-                   ]
-               in
-               Yojson.Safe.to_string
-                 (Exec_core.process_result_json
-                    ~artifact_policy:Exec_core.Inline_only
-                    ~base_path:root
-                    ~keeper_name:meta.name
-                    ~cmd
-                    ~extra:
-                      ([ "op", `String op
-                       ; "cmd", `String cmd
-                       ; "cwd", `String cwd
-                       ; "via", `String "host"
-                       ]
-                       @ insight_extra)
-                    ~status:result.status
-                    ~output:result.stdout
-                    ()))))
+               render_completed_process_result ~cwd:(Some cwd)
+                 ~cmd:"git --no-optional-locks status --short --branch"
+                 ~extra:[]
+                 result.status result.stdout
+             )))
   | "ls" ->
     (match read_target () with
      | Error e -> path_error e


### PR DESCRIPTION
## Summary

Shell IR redesign: sandbox is execution context, not tool identity. This PR externalizes sandbox from the typed IR into the dispatch layer, enabling Docker path lowering through the typed IR without bypassing it.

## Changes

### Phase 1: Sandbox externalization (latest commit)
- `Shell_ir.simple`: remove `sandbox` field
- `Shell_ir_typed`: GADT reduced from 4 type params to 3 (input, output, risk)
- `Exec_dispatch`: `dispatch_simple`/`dispatch_pipeline` take `?sandbox` parameter
- `Shell_command_gate`: `gate`/`gate_typed`/`lower_typed_pipeline` drop `~sandbox`
- `gen_shell_ir_walkers`: remove sandbox field and `emit_sandbox` function
- `keeper_shell_ops`: update lowering to not pass sandbox into IR
- Tests: remove all sandbox field assignments from IR records, remove obsolete mismatched-sandbox test

### Phase 0: Keeper lowering pilot (prior commits)
- Lower `ls` host path to Shell IR dispatch
- Lower `cat` host path to Shell IR dispatch (RFC-0160)
- Lower `head`/`tail`/`wc`/`tree` host paths to Shell IR dispatch
- Lower `find`/`rg` host paths to Shell IR dispatch
- `exec_policy`: descriptor-first path extraction in `path_argument_values`

## Test Plan

- [ ] `dune build @runtest` (lib/exec tests)
- [ ] `test_exec_dispatch` passes
- [ ] `test_exec_shell_command_gate` passes
- [ ] `test_keeper_bash_typed_input` passes
- [ ] `test_shell_ir_typed_review_followup` passes

## Related

- RFC-0160

🤖 Generated with [Claude Code](https://claude.com/claude-code)