### PR TITLE
fix(build): restore close parens lost in run_docker_bash (#18044 follow-up)

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -948,7 +948,7 @@ let run_docker_bash
                      , `String (Exec_core.string_of_semantic_status semantic_status)
                    ; "output", `String out
                    ]
-                   @ gh_exit_class_field ~cmd ~status:st ~output:out ~cmd_stages ()))
+                   @ gh_exit_class_field ~cmd ~status:st ~output:out ~cmd_stages ())))
        | _ ->
          (match turn_sandbox_runtime with
           | Some _ ->
@@ -1011,5 +1011,5 @@ let run_docker_bash
                           ~status:result.status
                           ~output:result.output
                           ~cmd_stages
-                          ()))))))
+                          ())))))))
 ;;


### PR DESCRIPTION
## 증상

`dune build` 시작 부분에서 syntax error로 전체 빌드가 차단됩니다:

\`\`\`
File \"lib/keeper/keeper_shell_docker.ml\", line 1015, characters 0-2:
1015 | ;;
       ^^
Error: Syntax error: ) expected
File \"lib/keeper/keeper_shell_docker.ml\", line 899, characters 6-7:
899 |       (match path_validation with
            ^
  This ( might be unmatched
\`\`\`

이후 발견되는 모든 downstream 타입/모듈 에러는 별개 이슈.

## 원인

PR #18044 (\`f741edb4d6\` refactor(shell-ir): S4 G1 consolidate Bash.parse_string callers)이 \`gh_exit_class_field\`의 시그니처를 변경했습니다:

\`\`\`ocaml
- gh_exit_class_field ~cmd ~status ~output : (string * Yojson.Safe.t) list
+ gh_exit_class_field ~cmd ~status ~output ~cmd_stages () : (string * Yojson.Safe.t) list
\`\`\`

두 호출 사이트의 종결부에 \`()\`(unit)를 추가하면서, 각각 닫는 paren 1개를 함께 제거해 net -1 close가 발생했습니다. \`run_docker_bash\`는 호출 사이트가 두 개라 -2.

자매 함수 \`run_docker_credentialed_bash\`는 호출 사이트가 한 개라도 nested match 한 단계가 적어서 결과적으로 balance가 유지됐습니다.

## 수정

두 호출 사이트(\`Network_none\` arm 라인 949, fallback \`_\` arm 라인 1014)의 unit 뒤 paren 시퀀스에 \`)\` 한 개씩 추가.

## 검증

- raw paren count: \`run_docker_bash\` open=40 close=40, \`run_docker_credentialed_bash\` open=24 close=24 (둘 다 delta=0)
- \`dune build lib/keeper/\` 통과 (exit 0)
- syntax error 사라짐 — 후속 unbound value/module 에러는 본 PR과 무관한 origin/main 상태

## RFC

RFC-WAIVED: 2자(paren 2개) 빌드 복구 hotfix. credential/identity/sandbox 의미 변경 없음, 동작 보존 fix. RFC-0142 등 keeper_shell 영역 RFC와 직교.