### PR TITLE
fix(build): re-export stage_words_of_string_result from Exec_policy

### DIFF
--- a/lib/exec_policy.ml
+++ b/lib/exec_policy.ml
@@ -840,6 +840,7 @@ let is_git_branch_switch = Mutation_classifier.is_git_branch_switch
 let is_destructive_bash_operation = Mutation_classifier.is_destructive_bash_operation
 let flat_stage_words = Mutation_classifier.flat_stage_words
 let stage_words_of_string = Mutation_classifier.stage_words_of_string
+let stage_words_of_string_result = Mutation_classifier.stage_words_of_string_result
 
 let sanitize_command_for_log = Log_sanitize.sanitize_command_for_log
 let truncate_for_log = Log_sanitize.truncate_for_log


### PR DESCRIPTION
## 증상

\`\`\`
File \"lib/exec_policy.ml\", line 1:
Error: The implementation lib/exec_policy.pp.ml
       does not match the interface lib/exec_policy.pp.mli:
       The value stage_words_of_string_result is required but not provided
       File \"lib/exec_policy.mli\", line 87, characters 0-71:
         Expected declaration
\`\`\`

## 원인

\`Exec_policy.mli:87\`는 \`stage_words_of_string_result : string -> (string list, unit) result\`를 export로 선언하지만, \`Exec_policy.ml\`이 \`Mutation_classifier\`에서 re-export하는 alias 줄이 빠져 있음.

구현은 \`lib/exec_policy_mutation_classifier.ml:223\`에 동일 시그니처로 이미 존재:
\`\`\`ocaml
let stage_words_of_string_result (cmd : string) : (string list, unit) result =
  match Parsed.parse_string cmd with
  | Parsed.Parsed ir -> Ok (flat_stage_words ir)
  | _ -> Error ()
\`\`\`

## 수정

\`Exec_policy.ml\`의 기존 \`flat_stage_words\`, \`stage_words_of_string\` alias 옆에 한 줄 추가:

\`\`\`ocaml
let stage_words_of_string_result = Mutation_classifier.stage_words_of_string_result
\`\`\`

## 검증

- \`dune build --root .\` 출력에서 exec_policy의 mli mismatch 에러 사라짐
- \`lib/exec_policy.ml\` 잔존 에러(\`Exec_shell_gate.gate\` unbound)는 본 PR과 무관, 별개 이슈

## RFC

RFC-WAIVED: 1-line re-export alias 누락 복구. credential/identity/sandbox 의미 변경 없음.