### PR TITLE
test(keeper-gh): P9a RFC-0160 S2/S3 contract tests for typed gh contract

### DIFF
--- a/test/test_keeper_gh_parser_contract.ml
+++ b/test/test_keeper_gh_parser_contract.ml
@@ -269,6 +269,119 @@ let test_render_round_trip_simple () =
   Alcotest.check argv_t "render → parse round trip preserves argv"
     original_argv reparsed_argv
 
+(* ---- risk_class (RFC-0160 S3) ----------------------------------- *)
+
+let risk_t = Alcotest.testable Masc_exec.Shell_ir_risk.pp_risk_class ( = )
+
+let test_risk_class_read_only () =
+  let cmd = must_ok_argv "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
+  Alcotest.check risk_t "pr list is R0_Read"
+    Masc_exec.Shell_ir_risk.R0_Read
+    (Gh.gh_simple_command_risk_class cmd)
+
+let test_risk_class_api_get () =
+  let cmd = must_ok_argv "api repos" (Gh.gh_simple_command_of_argv [ "api"; "repos" ]) in
+  Alcotest.check risk_t "api without method is GET -> R0_Read"
+    Masc_exec.Shell_ir_risk.R0_Read
+    (Gh.gh_simple_command_risk_class cmd)
+
+let test_risk_class_reversible_mutation () =
+  let cmd =
+    must_ok_argv "pr create" (Gh.gh_simple_command_of_argv [ "pr"; "create" ])
+  in
+  Alcotest.check risk_t "pr create is R1_Reversible_mutation"
+    Masc_exec.Shell_ir_risk.R1_Reversible_mutation
+    (Gh.gh_simple_command_risk_class cmd)
+
+let test_risk_class_api_post () =
+  let cmd =
+    must_ok_argv "api POST"
+      (Gh.gh_simple_command_of_argv [ "api"; "--method=POST"; "repos" ])
+  in
+  Alcotest.check risk_t "api POST is R1_Reversible_mutation"
+    Masc_exec.Shell_ir_risk.R1_Reversible_mutation
+    (Gh.gh_simple_command_risk_class cmd)
+
+let test_risk_class_api_graphql () =
+  let cmd =
+    must_ok_argv "api graphql"
+      (Gh.gh_simple_command_of_argv [ "api"; "graphql" ])
+  in
+  Alcotest.check risk_t "api graphql is R1_Reversible_mutation"
+    Masc_exec.Shell_ir_risk.R1_Reversible_mutation
+    (Gh.gh_simple_command_risk_class cmd)
+
+let test_risk_class_irreversible () =
+  let cmd =
+    must_ok_argv "repo delete" (Gh.gh_simple_command_of_argv [ "repo"; "delete" ])
+  in
+  Alcotest.check risk_t "repo delete is R2_Irreversible"
+    Masc_exec.Shell_ir_risk.R2_Irreversible
+    (Gh.gh_simple_command_risk_class cmd)
+
+let test_risk_class_api_delete () =
+  let cmd =
+    must_ok_argv "api DELETE"
+      (Gh.gh_simple_command_of_argv [ "api"; "--method=DELETE"; "repos" ])
+  in
+  Alcotest.check risk_t "api DELETE is R2_Irreversible"
+    Masc_exec.Shell_ir_risk.R2_Irreversible
+    (Gh.gh_simple_command_risk_class cmd)
+
+(* ---- gh_simple_command_to_shell_ir (RFC-0160 S2) ---------------- *)
+
+let test_to_shell_ir_bin_is_gh () =
+  let cmd = must_ok_argv "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
+  match Gh.gh_simple_command_to_shell_ir cmd with
+  | Masc_exec.Shell_ir.Simple s ->
+    Alcotest.(check bool) "bin is Gh" true
+      (Masc_exec.Bin.equal s.bin (Masc_exec.Bin.of_known Masc_exec.Bin.Gh))
+  | Masc_exec.Shell_ir.Pipeline _ ->
+    Alcotest.fail "expected Simple, got Pipeline"
+
+let test_to_shell_ir_args_are_lit () =
+  let cmd = must_ok_argv "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
+  match Gh.gh_simple_command_to_shell_ir cmd with
+  | Masc_exec.Shell_ir.Simple s ->
+    let texts =
+      List.map
+        (function
+          | Masc_exec.Shell_ir.Lit (t, _) -> t
+          | _ -> Alcotest.fail "expected Lit arg")
+        s.args
+    in
+    Alcotest.check argv_t "args converted to Lit tokens" [ "pr"; "list" ] texts
+  | Masc_exec.Shell_ir.Pipeline _ ->
+    Alcotest.fail "expected Simple, got Pipeline"
+
+let test_to_shell_ir_sandbox_passthrough () =
+  let cmd = must_ok_argv "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
+  let docker = Masc_exec.Sandbox_target.host () in
+  match Gh.gh_simple_command_to_shell_ir ~sandbox:docker cmd with
+  | Masc_exec.Shell_ir.Simple s ->
+    Alcotest.(check bool) "sandbox passed through" true
+      (Masc_exec.Sandbox_target.equal s.sandbox docker)
+  | Masc_exec.Shell_ir.Pipeline _ ->
+    Alcotest.fail "expected Simple, got Pipeline"
+
+let test_to_shell_ir_cwd_passthrough () =
+  let cmd = must_ok_argv "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
+  match Gh.gh_simple_command_to_shell_ir ~cwd:"/tmp" cmd with
+  | Masc_exec.Shell_ir.Simple s ->
+    (match s.cwd with
+     | None -> Alcotest.fail "expected Some cwd"
+     | Some _ -> ())
+  | Masc_exec.Shell_ir.Pipeline _ ->
+    Alcotest.fail "expected Simple, got Pipeline"
+
+let test_to_shell_ir_env_empty () =
+  let cmd = must_ok_argv "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
+  match Gh.gh_simple_command_to_shell_ir cmd with
+  | Masc_exec.Shell_ir.Simple s ->
+    Alcotest.(check int) "env is empty" 0 (List.length s.env)
+  | Masc_exec.Shell_ir.Pipeline _ ->
+    Alcotest.fail "expected Simple, got Pipeline"
+
 (* ---- Suite registration ----------------------------------------- *)
 
 let () =
@@ -321,5 +434,29 @@ let () =
     ; ( "render"
       , [ Alcotest.test_case "round trip preserves argv" `Quick
             test_render_round_trip_simple
+        ] )
+    ; ( "risk_class"
+      , [ Alcotest.test_case "pr list is R0_Read" `Quick test_risk_class_read_only
+        ; Alcotest.test_case "api default is R0_Read" `Quick
+            test_risk_class_api_get
+        ; Alcotest.test_case "pr create is R1" `Quick
+            test_risk_class_reversible_mutation
+        ; Alcotest.test_case "api POST is R1" `Quick
+            test_risk_class_api_post
+        ; Alcotest.test_case "api graphql is R1" `Quick
+            test_risk_class_api_graphql
+        ; Alcotest.test_case "repo delete is R2" `Quick
+            test_risk_class_irreversible
+        ; Alcotest.test_case "api DELETE is R2" `Quick
+            test_risk_class_api_delete
+        ] )
+    ; ( "gh_simple_command_to_shell_ir"
+      , [ Alcotest.test_case "bin is Gh" `Quick test_to_shell_ir_bin_is_gh
+        ; Alcotest.test_case "args are Lit" `Quick test_to_shell_ir_args_are_lit
+        ; Alcotest.test_case "sandbox passthrough" `Quick
+            test_to_shell_ir_sandbox_passthrough
+        ; Alcotest.test_case "cwd passthrough" `Quick
+            test_to_shell_ir_cwd_passthrough
+        ; Alcotest.test_case "env is empty" `Quick test_to_shell_ir_env_empty
         ] )
     ]


### PR DESCRIPTION
test(keeper-gh): P9a — RFC-0160 S2/S3 contract tests for typed gh contract

## Summary

Completes P9a (typed gh contract tests) of the Shell IR Adjacent Surfaces roadmap.

### P9a — Contract tests (S2 + S3)

Adds 12 Alcotest cases across 2 suites to `test/test_keeper_gh_parser_contract.ml`:

**`risk_class` suite (7 tests):**
- `pr list` → `R0_Read`
- `api repos` (no --method) → `R0_Read`  
- `pr create` → `R1_Reversible_mutation`
- `api --method=POST` → `R1_Reversible_mutation`
- `api graphql` → `R1_Reversible_mutation`
- `repo delete` → `R2_Irreversible`
- `api --method=DELETE` → `R2_Irreversible`

**`gh_simple_command_to_shell_ir` suite (5 tests):**
- Bin resolves to `Bin.Gh`
- All argv tokens become `Shell_ir.Lit`
- Sandbox target passthrough
- Cwd option passthrough
- Env is empty list

### Related RFC

- RFC-0160: Shell IR Adjacent Surfaces (§S2 typed `gh` command, §S3 risk classification)

### RFC-WAIVED

RFC-0008, RFC-0019, RFC-0038, RFC-0074, RFC-0141: This PR adds contract tests only; no behavioral changes to credential, identity, TOML resolution, or sandbox auto-provision surfaces.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>