### PR TITLE
fix(keeper): restore parse_prefix/message_prefix mli after PR #17973

### DIFF
--- a/lib/keeper/keeper_path_check_error.mli
+++ b/lib/keeper/keeper_path_check_error.mli
@@ -40,3 +40,13 @@ val to_message : t -> string
     so downstream tools that match on these messages keep their
     contract. *)
 
+val message_prefix : t -> string
+(** Stable lowercase prefix token used by downstream classifiers
+    (e.g. dashboard tool-quality). Always a strict prefix of the
+    lowercase form of [to_message]. *)
+
+val parse_prefix : string -> t option
+(** Inverse of [to_message] for the variant tag only — payload fields
+    are left empty / [None] since the typed module is intended for
+    classification, not full message reconstruction. *)
+


### PR DESCRIPTION
## 증상

\`\`\`
File \"lib/keeper/keeper_failure_circuit_breaker.ml\", line 57, characters 8-37:
57 |   match Path_check_error.parse_prefix error_msg with
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: Unbound value Path_check_error.parse_prefix
\`\`\`

## 원인

PR #17973 (\`refactor(keeper): remove dead exports from Keeper_path_check_error.mli\`)이 \`val parse_prefix\`와 \`val message_prefix\`를 \"0 external callers\" 라고 주장하며 .mli에서 제거했지만, live caller가 한 곳 있었습니다:

\`\`\`
lib/keeper/keeper_failure_circuit_breaker.ml:55: module Path_check_error = Keeper_path_check_error
lib/keeper/keeper_failure_circuit_breaker.ml:57:   match Path_check_error.parse_prefix error_msg with
\`\`\`

이 호출은 \`module Path_check_error = Keeper_path_check_error\` 로컬 alias를 경유하는데, dead-export audit이 qualified callers(\`Keeper_path_check_error.parse_prefix\`)와 \`include Module\` facade는 추적했지만 \`module X = Y\` alias는 누락. .ml 파일은 두 함수 본체가 그대로 남아있고 .mli surface만 제거되어 implementation/interface mismatch가 발생.

## 수정

\`Keeper_path_check_error.mli\`에 \`val message_prefix\`, \`val parse_prefix\` 두 선언 복구. 동작 변경 없음, surface만 복구.

## 검증

- \`dune build --root .\` 출력에서 \`Path_check_error.parse_prefix\` unbound 에러 사라짐
- 잔존 빌드 에러는 본 PR과 무관 (특히 keeper_shell_ops.ml syntax error는 PR #18070 회귀로 보임)

## 학습 포인트

\`feedback_dead_export_audit_must_trace_include_facade.md\` (2026-05-22 메모리) 패턴 재현: include/alias facade는 dead 선언 전에 반드시 추적 필요. dead-export 도구가 \`module X = Y\` alias를 아직 분석하지 않는다는 점이 root cause.

## RFC

RFC-WAIVED: 10-line .mli surface restoration. 동작 변경 없음, PR #17973 over-aggressive deletion 부분 복구.