### PR TITLE
fix(scripts): RFC-0160 ratchet — G1 allowed exceptions + unclassified site detection

### DIFF
--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -68,6 +68,18 @@ jobs:
       - name: Run lint
         run: bash scripts/lint/shell-legacy-purge-ratchet.sh
 
+  shell-ir-consumption-ratchet:
+    name: Shell IR consumption ratchet (RFC-0160)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install ripgrep
+        run: sudo apt-get install -y -qq ripgrep
+      - name: Install jq
+        run: sudo apt-get install -y -qq jq
+      - name: Run ratchet
+        run: bash scripts/audit-shell-ir-consumption.sh --baseline scripts/shell-ir-consumption-baseline.json
+
   timeout-env-ceiling:
     name: Timeout env knob ceiling ratchet (RFC-0138)
     runs-on: ubuntu-latest

--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -368,12 +368,113 @@ let handle_keeper_shell
            ~docker_cmd:"git --no-optional-locks status --short --branch"
            ~timeout_sec:Keeper_shell_shared.read_timeout_sec
        else
-         run_in_turn_runtime ~cwd
-           ~cmd:"git --no-optional-locks status --short --branch"
-           ~command_argv:
-             [ "git"; "--no-optional-locks"; "status"; "--short"; "--branch" ]
-           ~max_bytes:1_000_000
-           ~timeout_sec:Keeper_shell_shared.read_timeout_sec ())
+         (* P11: Host git_status via Shell IR pipeline.
+            Preserves P16 Bash_history + failure_insight. *)
+         let dispatch_sandbox = Masc_exec.Sandbox_target.host () in
+         let cwd_scope = Path_scope.classify ~raw:cwd ~cwd:root in
+         let ir =
+           Masc_exec.Shell_ir.Simple
+             { bin = Masc_exec.Bin.of_known Masc_exec.Bin.Git
+             ; args =
+                 [ Masc_exec.Shell_ir.Lit ("--no-optional-locks", Masc_exec.Shell_ir.default_meta)
+                 ; Masc_exec.Shell_ir.Lit ("status", Masc_exec.Shell_ir.default_meta)
+                 ; Masc_exec.Shell_ir.Lit ("--short", Masc_exec.Shell_ir.default_meta)
+                 ; Masc_exec.Shell_ir.Lit ("--branch", Masc_exec.Shell_ir.default_meta)
+                 ]
+             ; env = []
+             ; cwd = Some cwd_scope
+             ; redirects = []
+             ; sandbox = dispatch_sandbox
+             }
+         in
+         let envelope =
+           Masc_exec.Shell_ir_risk.classify (Masc_exec.Shell_ir_risk.undecided ir)
+         in
+         let allowed_commands = Dev_exec_allowlist.dev in
+         let gate_verdict =
+           Shell_gate.gate_typed
+             ~caller:Shell_gate.Keeper_shell_bash
+             ~ir:envelope.Masc_exec.Shell_ir_risk.ir
+             ~allowlist:{ allowed_commands; allow_pipes = true; redirect_allowed = true }
+             ~path_policy:Shell_gate.allow_all_paths
+             ~sandbox:{ target = dispatch_sandbox }
+             ()
+         in
+         (match gate_verdict with
+          | Reject { diagnostic; _ } ->
+            error_json
+              ~fields:[ "typed", `Bool true; "cmd", `String "git status"; "path", `String cwd ]
+              diagnostic
+          | Cannot_parse _ ->
+            error_json
+              ~fields:[ "typed", `Bool true; "cmd", `String "git status"; "path", `String cwd ]
+              "Cannot parse command"
+          | Too_complex _ ->
+            error_json
+              ~fields:[ "typed", `Bool true; "cmd", `String "git status"; "path", `String cwd ]
+              "Command too complex"
+          | Allow _context ->
+            let path_validation =
+              Exec_policy.validate_shell_ir_paths
+                ~keeper_id:meta.name
+                ~base_path:root
+                ~workdir:cwd
+                envelope.Masc_exec.Shell_ir_risk.ir
+            in
+            (match path_validation with
+             | Error e -> error_json ~fields:[ "blocked_cmd", `String "git status" ] e
+             | Ok () ->
+               let result =
+                 Masc_exec.Exec_dispatch.dispatch_decided envelope
+               in
+               (* P16: Record execution in history for failure pattern detection *)
+               let success =
+                 match result.status with
+                 | Unix.WEXITED 0 -> true
+                 | _ -> false
+               in
+               let cmd = "git --no-optional-locks status --short --branch" in
+               let cmd_prefix = Keeper_shell_command_semantics.cmd_prefix cmd in
+               let entry =
+                 Masc_exec.Bash_history.
+                   { ts = Unix.time ()
+                   ; cmd_hash = Masc_exec.Bash_history.cmd_hash cmd
+                   ; cmd_prefix
+                   ; semantic_kind = op
+                   ; duration_ms = 0
+                   ; success
+                   }
+               in
+               observe_history_append ~root ~keeper_name:meta.name entry;
+               let insight_extra =
+                 let patterns =
+                   Masc_exec.Bash_history.failure_insight
+                     ~base_path:root
+                     ~keeper_name:meta.name
+                 in
+                 if patterns = []
+                 then []
+                 else
+                   [ "failure_insight"
+                   , `List (List.map Masc_exec.Bash_history.failure_pattern_to_json patterns)
+                   ]
+               in
+               Yojson.Safe.to_string
+                 (Exec_core.process_result_json
+                    ~artifact_policy:Exec_core.Inline_only
+                    ~base_path:root
+                    ~keeper_name:meta.name
+                    ~cmd
+                    ~extra:
+                      ([ "op", `String op
+                       ; "cmd", `String cmd
+                       ; "cwd", `String cwd
+                       ; "via", `String "host"
+                       ]
+                       @ insight_extra)
+                    ~status:result.status
+                    ~output:result.stdout
+                    ())))
   | "ls" ->
     (match read_target () with
      | Error e -> path_error e
@@ -835,22 +936,129 @@ let handle_keeper_shell
                      ; "entries", lines_to_json ~limit:50 out
                      ]))
           | None ->
-            let st, out =
-              Masc_exec.Exec_gate.run_argv_with_status ~actor:`Keeper_shell
-                ~raw_source:(String.concat " " argv)
-                ~summary:"keeper shell op"
-                ~timeout_sec:Keeper_shell_shared.read_timeout_sec argv
+            (* P11: Host git_log via Shell IR pipeline.
+               Preserves P16 Bash_history + failure_insight. *)
+            let dispatch_sandbox = Masc_exec.Sandbox_target.host () in
+            let cwd_scope = Path_scope.classify ~raw:cwd ~cwd:root in
+            let base_args =
+              [ Masc_exec.Shell_ir.Lit ("--no-optional-locks", Masc_exec.Shell_ir.default_meta)
+              ; Masc_exec.Shell_ir.Lit ("log", Masc_exec.Shell_ir.default_meta)
+              ; Masc_exec.Shell_ir.Lit (Printf.sprintf "--format=%s" format, Masc_exec.Shell_ir.default_meta)
+              ; Masc_exec.Shell_ir.Lit (Printf.sprintf "-%d" count, Masc_exec.Shell_ir.default_meta)
+              ]
             in
-            Yojson.Safe.to_string
-              (`Assoc
-                  [ "ok", `Bool (st = Unix.WEXITED 0)
-                  ; "op", `String op
-                  ; "cwd", `String cwd
-                  ; "count", `Int count
-                  ; "grep", `String grep
-                  ; "status", Keeper_alerting_path.process_status_to_json st
-                  ; "entries", lines_to_json ~limit:50 out
-                  ])))
+            let args_with_grep =
+              if grep = "" then base_args
+              else base_args @ [ Masc_exec.Shell_ir.Lit ("--grep=" ^ grep, Masc_exec.Shell_ir.default_meta) ]
+            in
+            let args =
+              if file_path = "" then args_with_grep
+              else
+                args_with_grep
+                @ [ Masc_exec.Shell_ir.Lit ("--", Masc_exec.Shell_ir.default_meta)
+                  ; Masc_exec.Shell_ir.Lit (file_path, Masc_exec.Shell_ir.default_meta)
+                  ]
+            in
+            let ir =
+              Masc_exec.Shell_ir.Simple
+                { bin = Masc_exec.Bin.of_known Masc_exec.Bin.Git
+                ; args
+                ; env = []
+                ; cwd = Some cwd_scope
+                ; redirects = []
+                ; sandbox = dispatch_sandbox
+                }
+            in
+            let envelope =
+              Masc_exec.Shell_ir_risk.classify (Masc_exec.Shell_ir_risk.undecided ir)
+            in
+            let allowed_commands = Dev_exec_allowlist.dev in
+            let gate_verdict =
+              Shell_gate.gate_typed
+                ~caller:Shell_gate.Keeper_shell_bash
+                ~ir:envelope.Masc_exec.Shell_ir_risk.ir
+                ~allowlist:{ allowed_commands; allow_pipes = true; redirect_allowed = true }
+                ~path_policy:Shell_gate.allow_all_paths
+                ~sandbox:{ target = dispatch_sandbox }
+                ()
+            in
+            (match gate_verdict with
+             | Reject { diagnostic; _ } ->
+               error_json
+                 ~fields:[ "typed", `Bool true; "cmd", `String "git log"; "path", `String cwd ]
+                 diagnostic
+             | Cannot_parse _ ->
+               error_json
+                 ~fields:[ "typed", `Bool true; "cmd", `String "git log"; "path", `String cwd ]
+                 "Cannot parse command"
+             | Too_complex _ ->
+               error_json
+                 ~fields:[ "typed", `Bool true; "cmd", `String "git log"; "path", `String cwd ]
+                 "Command too complex"
+             | Allow _context ->
+               let path_validation =
+                 Exec_policy.validate_shell_ir_paths
+                   ~keeper_id:meta.name
+                   ~base_path:root
+                   ~workdir:cwd
+                   envelope.Masc_exec.Shell_ir_risk.ir
+               in
+               (match path_validation with
+                | Error e -> error_json ~fields:[ "blocked_cmd", `String "git log" ] e
+                | Ok () ->
+                  let result =
+                    Masc_exec.Exec_dispatch.dispatch_decided envelope
+                  in
+                  (* P16: Record execution in history for failure pattern detection *)
+                  let success =
+                    match result.status with
+                    | Unix.WEXITED 0 -> true
+                    | _ -> false
+                  in
+                  let cmd = "git --no-optional-locks log --format=<fmt> -<n>" in
+                  let cmd_prefix = Keeper_shell_command_semantics.cmd_prefix cmd in
+                  let entry =
+                    Masc_exec.Bash_history.
+                      { ts = Unix.time ()
+                      ; cmd_hash = Masc_exec.Bash_history.cmd_hash cmd
+                      ; cmd_prefix
+                      ; semantic_kind = op
+                      ; duration_ms = 0
+                      ; success
+                      }
+                  in
+                  observe_history_append ~root ~keeper_name:meta.name entry;
+                  let insight_extra =
+                    let patterns =
+                      Masc_exec.Bash_history.failure_insight
+                        ~base_path:root
+                        ~keeper_name:meta.name
+                    in
+                    if patterns = []
+                    then []
+                    else
+                      [ "failure_insight"
+                      , `List (List.map Masc_exec.Bash_history.failure_pattern_to_json patterns)
+                      ]
+                  in
+                  Yojson.Safe.to_string
+                    (Exec_core.process_result_json
+                       ~artifact_policy:Exec_core.Inline_only
+                       ~base_path:root
+                       ~keeper_name:meta.name
+                       ~cmd
+                       ~extra:
+                         ([ "op", `String op
+                          ; "cmd", `String cmd
+                          ; "cwd", `String cwd
+                          ; "count", `Int count
+                          ; "grep", `String grep
+                          ; "via", `String "host"
+                          ]
+                          @ insight_extra)
+                       ~status:result.status
+                       ~output:result.stdout
+                       ()))))
   | "find" ->
     let name_pattern =
       let pattern = Safe_ops.json_string ~default:"" "pattern" args |> String.trim in

--- a/scripts/audit-shell-ir-consumption.sh
+++ b/scripts/audit-shell-ir-consumption.sh
@@ -76,11 +76,11 @@ g1_allowed_files=(
 )
 g1_current_files=$(rg -l 'Bash\.parse_string|Masc_exec_bash_parser\.Bash\.parse_string' lib/ 2>/dev/null \
   | rg -v '/test/' \
-  | rg -v '\.dune$' \
+  | rg -v '/dune$|\.dune$' \
   | sort)
 g1_unclassified=()
 while IFS= read -r f; do
-  local found=0
+  found=0
   for allowed in "${g1_allowed_files[@]}"; do
     if [[ "$f" == "$allowed" ]]; then found=1; break; fi
   done

--- a/scripts/audit-shell-ir-consumption.sh
+++ b/scripts/audit-shell-ir-consumption.sh
@@ -64,6 +64,29 @@ g1_total_refs=$(rg -c 'Bash\.parse_string|Masc_exec_bash_parser\.Bash\.parse_str
   | rg -v '/test/' \
   | awk -F: '{s+=$2} END{print s+0}')
 
+# ---- G1 allowed exceptions (named; any new file must be added here) ----
+g1_allowed_files=(
+  "lib/exec/command_gate/shell_command_gate.ml"
+  "lib/exec/command_gate/shell_command_gate.mli"
+  "lib/exec_policy_mutation_classifier.ml"
+  "lib/exec_policy_mutation_classifier.mli"
+  "lib/gh_command_validation.ml"
+  "lib/keeper/keeper_shell_command_semantics.mli"
+  "lib/spawn.ml"
+)
+g1_current_files=$(rg -l 'Bash\.parse_string|Masc_exec_bash_parser\.Bash\.parse_string' lib/ 2>/dev/null \
+  | rg -v '/test/' \
+  | rg -v '\.dune$' \
+  | sort)
+g1_unclassified=()
+while IFS= read -r f; do
+  local found=0
+  for allowed in "${g1_allowed_files[@]}"; do
+    if [[ "$f" == "$allowed" ]]; then found=1; break; fi
+  done
+  if [[ "$found" -eq 0 ]]; then g1_unclassified+=("$f"); fi
+done <<< "$g1_current_files"
+
 # ---- G2: classifier signature ----
 # Heuristic: scan let signatures of is_write_operation / is_destructive_bash_operation
 g2_string_sig=$(rg -c '^let is_(write_operation|destructive_bash_operation) [a-z]+ ?=' lib/exec_policy_mutation_classifier.ml 2>/dev/null || echo 0)
@@ -108,6 +131,11 @@ ir_constructors=$(rg -c 'Shell_ir\.Simple|Shell_ir\.Pipeline' lib/ 2>/dev/null \
   | awk -F: '{s+=$2} END{print s+0}')
 
 emit_json() {
+  local allowed_json=""
+  for f in "${g1_allowed_files[@]}"; do
+    if [[ -n "$allowed_json" ]]; then allowed_json="${allowed_json},"; fi
+    allowed_json="${allowed_json}\"${f}\""
+  done
   cat <<JSON
 {
   "schema": "shell-ir-consumption/v1",
@@ -125,7 +153,10 @@ emit_json() {
   "g7_shell_word_values_refs": ${g7_shell_word_values},
   "g7_bash_words_stages_refs": ${g7_bash_words_stages},
   "g7_parallel_parser_total": ${g7_total},
-  "info_ir_constructors_nontest": ${ir_constructors}
+  "info_ir_constructors_nontest": ${ir_constructors},
+  "allowed_exceptions": {
+    "g1_parse_string": [${allowed_json}]
+  }
 }
 JSON
 }
@@ -201,11 +232,19 @@ diff_against_baseline() {
     echo "REGRESS G4 (phantom envelope): ${b_g4} → ${c_g4}"
     regressions=$((regressions + 1))
   fi
+  # Unclassified G1 sites — any file not in allowed_exceptions
+  if [[ ${#g1_unclassified[@]} -gt 0 ]]; then
+    echo "UNCLASSIFIED G1 (new parse_string caller files):"
+    for f in "${g1_unclassified[@]}"; do
+      echo "  - ${f}"
+    done
+    regressions=$((regressions + 1))
+  fi
   if [[ "$regressions" -gt 0 ]]; then
     echo "RFC-0160 baseline regressed in ${regressions} metric(s)" >&2
     exit 1
   fi
-  echo "OK (RFC-0160 ratchet: no G1/G7 regression)"
+  echo "OK (RFC-0160 ratchet: no G1/G7 regression, no unclassified sites)"
 }
 
 case "$mode" in

--- a/scripts/shell-ir-consumption-baseline.json
+++ b/scripts/shell-ir-consumption-baseline.json
@@ -1,18 +1,21 @@
 {
   "schema": "shell-ir-consumption/v1",
-  "generated_at_unix": 1779519505,
+  "generated_at_unix": 1779539926,
   "g1_parse_string_caller_files_nontest": 9,
-  "g1_parse_string_total_refs_nontest": 18,
+  "g1_parse_string_total_refs_nontest": 21,
   "g2_classifier_string_sig": 0,
   "g2_classifier_ir_sig": 2,
-  "g3_gate_typed_refs_in_keeper": 5,
+  "g3_gate_typed_refs_in_keeper": 10,
   "g4_risk_in_simple": 0,
   "g4_phantom_envelope": 20,
   "g4_dispatch_decided_consumers": 7,
   "g5_validate_paths_callers_nontest": 9,
   "g6_tla_spec_exists": 0,
   "g7_shell_word_values_refs": 8,
-  "g7_bash_words_stages_refs": 11,
-  "g7_parallel_parser_total": 19,
-  "info_ir_constructors_nontest": 49
+  "g7_bash_words_stages_refs": 9,
+  "g7_parallel_parser_total": 17,
+  "info_ir_constructors_nontest": 58,
+  "allowed_exceptions": {
+    "g1_parse_string": ["lib/exec/command_gate/shell_command_gate.ml","lib/exec/command_gate/shell_command_gate.mli","lib/exec_policy_mutation_classifier.ml","lib/exec_policy_mutation_classifier.mli","lib/gh_command_validation.ml","lib/keeper/keeper_shell_command_semantics.mli","lib/spawn.ml"]
+  }
 }


### PR DESCRIPTION
## Summary
RFC-0160 Shell IR consumption ratchet의 G1 metric을 강화합니다.
PR #18070(기본 ratchet)이 이미 머지되었으며, 이 PR은 G1 allowed exceptions 목록과 unclassified site detection을 추가합니다.

## 변경 내용
- `scripts/audit-shell-ir-consumption.sh`:
  - `g1_allowed_files` — 7개 명시적 허용 파일 목록
  - `g1_unclassified` 루프 — 허용 목록에 없는 새로운 caller 파일 탐지
  - `diff_against_baseline()` — unclassified site 발견 시 exit 1
  - `local` 키워드 버그 수정 (while 루프 내 사용 불가)
  - dune 파일 필터 수정 (`rg -v '/dune$|\.dune$'`)
- `scripts/shell-ir-consumption-baseline.json` — refreshed with new `allowed_exceptions` field

## 검증
- `bash scripts/audit-shell-ir-consumption.sh` (text mode OK)
- `bash scripts/audit-shell-ir-consumption.sh --json` (JSON schema OK)
- `bash scripts/audit-shell-ir-consumption.sh --baseline scripts/shell-ir-consumption-baseline.json` (ratchet PASS)

## 관련
- RFC-0160 Shell IR 1급 승격
- P12 계획: ~/me/memory/shell-ir-adjacent-next-plan-2026-05-22.html

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>