### PR TITLE
feat(exec_policy): descriptor-first path extraction in path_argument_values (RFC-0160 S4 P11)

### DIFF
--- a/lib/exec_policy.ml
+++ b/lib/exec_policy.ml
@@ -673,12 +673,21 @@ let path_argument_values command_name args =
                    acc
                    rest
                | None ->
-                 loop
-                   ~skip_next_pattern:None
-                   ~redirect_target:false
-                   ~seen_primary_pattern
-                   (token :: acc)
-                   rest)))
+                 if command_materializes_path_arg command_name
+                 then
+                   loop
+                     ~skip_next_pattern:None
+                     ~redirect_target:false
+                     ~seen_primary_pattern
+                     (token :: acc)
+                     rest
+                 else
+                   loop
+                     ~skip_next_pattern:None
+                     ~redirect_target:false
+                     ~seen_primary_pattern
+                     acc
+                     rest)))
   in
   loop
     ~skip_next_pattern:None

--- a/lib/exec_policy_path_arg_descriptor.ml
+++ b/lib/exec_policy_path_arg_descriptor.ml
@@ -56,7 +56,7 @@ let inline_path_flag_requires_existing_dir token =
 
 let command_materializes_path_arg = function
   | "cat" | "find" | "grep" | "head" | "ls" | "nl" | "rg" | "sed" | "stat"
-  | "tail" | "wc" -> true
+  | "tail" | "tree" | "wc" -> true
   | _ -> false
 ;;
 
@@ -68,5 +68,5 @@ let command_materializes_path_arg = function
     fails the assertion. *)
 let path_arg_command_corpus =
   [ "cat"; "find"; "grep"; "head"; "ls"; "nl"; "rg"; "sed"; "stat"; "tail"
-  ; "wc" ]
+  ; "tree"; "wc" ]
 ;;

--- a/test/test_exec_policy_path_arg_descriptor.ml
+++ b/test/test_exec_policy_path_arg_descriptor.ml
@@ -72,7 +72,10 @@ let test_command_materializes_path_arg_corpus_membership () =
       Alcotest.(check bool)
         (command ^ " materializes path arg") true
         (D.command_materializes_path_arg command))
-    D.path_arg_command_corpus
+    D.path_arg_command_corpus;
+  (* tree is a keeper_shell host op — positional arg is always a path. *)
+  Alcotest.(check bool) "tree materializes path arg" true
+    (D.command_materializes_path_arg "tree")
 
 let test_command_materializes_path_arg_exclusions () =
   (* Intentional exclusions — these commands have their own typed


### PR DESCRIPTION
## Summary
P11 마지막 조각. path_argument_values가 descriptor corpus를 먼저 확인하고, corpus 외부 명령은 catch-all heuristic 대신 []를 반환합니다.

## 변경 내용
- lib/exec_policy.ml: path_argument_values가 command_materializes_path_arg를 먼저 확인
- lib/exec_policy_path_arg_descriptor.ml: tree를 closed corpus에 추가
- test/test_exec_policy_path_arg_descriptor.ml: tree corpus membership assertion 추가

## 동작 변화
- corpus 내 명령(cat, find, grep, head, ls, nl, rg, sed, stat, tail, tree, wc): 기존과 동일
- corpus 밖 명령(git, gh, echo, printf 등): positional args는 [] 반환, flag descriptors나 typed surface에서 실제 path-bearing token 추출

## 관련
- P11 계획: ~/me/memory/shell-ir-adjacent-next-plan-2026-05-22.html
- PR #17902 (P11 path-arg descriptors module, 이미 머지)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>