### PR TITLE
fix(build): restore close parens lost in git_status/git_log (PR #18070 follow-up)

### DIFF
--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -474,7 +474,7 @@ let handle_keeper_shell
                        @ insight_extra)
                     ~status:result.status
                     ~output:result.stdout
-                    ())))
+                    ()))))
   | "ls" ->
     (match read_target () with
      | Error e -> path_error e
@@ -1058,7 +1058,7 @@ let handle_keeper_shell
                           @ insight_extra)
                        ~status:result.status
                        ~output:result.stdout
-                       ()))))
+                       ())))))
   | "find" ->
     let name_pattern =
       let pattern = Safe_ops.json_string ~default:"" "pattern" args |> String.trim in


### PR DESCRIPTION
## 증상

\`\`\`
File \"lib/keeper/keeper_shell_ops.ml\", line 1860, characters 0-2:
1860 | ;;
       ^^
Error: Syntax error: ) expected
File \"lib/keeper/keeper_shell_ops.ml\", line 842, characters 4-5:
842 |     (match cwd_target () with
          ^
  This ( might be unmatched
\`\`\`

## 원인

PR #18070 (\`refactor(keeper): P11 — git_status/git_log via Shell IR pipeline\`)이 \`\"git_status\"\`와 \`\"git_log\"\` arm의 else 분기를 typed Shell IR pipeline으로 재작성하면서 3개의 nested 표현을 추가했습니다:
- \`(match gate_verdict with ...)\`
- \`(match path_validation with ...)\`
- \`(Exec_core.process_result_json ...)\`

하지만 각 arm 끝의 닫는 paren 시퀀스가 1개씩 부족합니다. 결과적으로 \`\"git_status\"\` 종료 시 depth +1 (line 477), \`\"git_log\"\` 종료 시 추가 +1 (line 1061)로 누적되어 파일 끝 \`;;\` (line 1860)에서 \"Syntax error: ) expected\"가 발생.

자매 함수 \`run_docker_bash\`도 PR #18044에서 동일한 형태로 회귀했고 #18065에서 같은 패턴으로 수정한 선례가 있습니다.

## 수정

\`\"git_status\"\` arm 끝 (line 477): \`())))\` → \`()))))\` (+1)
\`\"git_log\"\` arm 끝 (line 1061): \`()))))\` → \`())))))\` (+1)

각 arm마다 닫는 paren 1개씩 추가. 동작 변경 없음.

## 검증

- raw paren scan으로 모든 arm 경계와 파일 끝에서 depth=0 확인
- \`dune build --root .\` 출력에서 \`keeper_shell_ops.ml\` syntax error 사라짐
- 잔존 빌드 에러 (\`Pr.empty\`, \`Resilience_runtime\`, ...)는 본 PR과 무관

## RFC

RFC-WAIVED: 2자(paren 2개) 빌드 복구 hotfix. PR #18044 follow-up #18065와 동일한 패턴의 자매 회귀.