### PR TITLE
fix(board): restore Board_comment_rate_limit.reset after PR #18004

### DIFF
--- a/lib/board_comment_rate_limit.ml
+++ b/lib/board_comment_rate_limit.ml
@@ -48,6 +48,8 @@ let record ~author ~now =
   ts_ref := now :: !ts_ref
 ;;
 
+let reset () = Hashtbl.clear comment_timestamps
+
 (** [sweep_stale ~now ~window] drops timestamps older than [window]
     seconds from every author's entry, then removes any author whose
     list became empty. Called from [board_core] [sweep] as part of the

--- a/lib/board_comment_rate_limit.mli
+++ b/lib/board_comment_rate_limit.mli
@@ -17,6 +17,11 @@ val check : author:string -> now:float -> float option
     drift across concurrent attempts. *)
 val record : author:string -> now:float -> unit
 
+(** [reset ()] clears the tracker entirely. Re-exported via
+    [Board_core.reset_comment_rate_tracker] for the board-core sweep
+    used by [board_votes]. *)
+val reset : unit -> unit
+
 (** [sweep_stale ~now ~window] expires per-author timestamps older
     than [window] seconds from [now] and removes any author whose list
     became empty. Called from the board-core sweep loop. *)


### PR DESCRIPTION
## 증상

\`\`\`
File \"lib/board_core.ml\", line 63, characters 33-63:
63 | let reset_comment_rate_tracker = Board_comment_rate_limit.reset
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: Unbound value Board_comment_rate_limit.reset
\`\`\`

## 원인

PR #18004 (\`refactor(board_comment_rate_limit): remove dead export reset\`)이 \`val reset\`과 \`let reset\`을 \"0 external callers, 0 internal callers\" 라며 제거했지만, facade re-export 한 곳을 놓쳤습니다:

\`\`\`
lib/board_core.ml:63:    let reset_comment_rate_tracker = Board_comment_rate_limit.reset
lib/board_votes.ml:        reset_comment_rate_tracker ();  (* downstream caller *)
\`\`\`

## 원인 패턴

Dead-export audit이 direct qualified callers는 추적했지만 \`let alias_name = M.f\` re-export pattern은 안 봤습니다. PR #17973 (\`Path_check_error.parse_prefix\`)와 동일한 anti-pattern — \`feedback_dead_export_audit_must_trace_include_facade.md\` (2026-05-22) 메모리가 정확히 하루 전에 이 패턴을 표시했습니다.

## 수정

- \`Board_comment_rate_limit.ml\`: \`let reset () = Hashtbl.clear comment_timestamps\` 복구
- \`Board_comment_rate_limit.mli\`: \`val reset : unit -> unit\` 선언 복구
- docstring에 \`Board_core.reset_comment_rate_tracker\`로 re-export됨을 명시 → future audit이 chain 보게 함

## 검증

- \`dune build --root .\` 출력에서 \`Board_comment_rate_limit.reset\` unbound 에러 사라짐
- 잔존 빌드 에러는 본 PR과 무관

## RFC

RFC-WAIVED: 7-line dead-export 복구. PR #18004 over-aggressive deletion의 부분 reversal. 새 동작 없음.