### PR TITLE
fix(exec): restore string-based Shell_command_gate.gate after PR #18044

### DIFF
--- a/lib/exec/command_gate/shell_command_gate.ml
+++ b/lib/exec/command_gate/shell_command_gate.ml
@@ -427,6 +427,20 @@ let gate_typed ?caller:_ ~ir ~allowlist ~path_policy ~sandbox () : verdict =
   | Ok stages -> apply_policy ~allowlist ~path_policy ~sandbox ~stages
 ;;
 
+let gate ?caller:_ ~raw ~allowlist ~path_policy ~sandbox () : verdict =
+  (* String-based entrypoint retained for callers that have not migrated
+     to the typed Shell_ir surface yet (notably [Exec_policy] via the
+     [Exec_shell_gate] module alias). Parses [raw] once and delegates to
+     the same parse_only_to_stages + apply_policy pipeline as gate_typed,
+     so the typed-variant Too_complex wrapping is shared. The [caller]
+     label is API-shape-only — see the matching note on gate_typed. *)
+  let parsed = Masc_exec_bash_parser.Bash.parse_string raw in
+  match parse_only_to_stages parsed with
+  | Error (`Cannot_parse reason) -> Cannot_parse { reason }
+  | Error (`Too_complex reason) -> Too_complex { reason }
+  | Ok stages -> apply_policy ~allowlist ~path_policy ~sandbox ~stages
+;;
+
 let lower_typed_pipeline ?caller:_ ~stages ~sandbox () : verdict =
   (* See note on [gate] — [caller] is API-shape-only for now. *)
   match stages with

--- a/lib/exec/command_gate/shell_command_gate.mli
+++ b/lib/exec/command_gate/shell_command_gate.mli
@@ -141,6 +141,21 @@ val host_sandbox : sandbox_context
 (** Convenience: the default {!Masc_exec.Sandbox_target.host}
     sandbox. *)
 
+val gate
+  :  ?caller:caller
+  -> raw:string
+  -> allowlist:allowlist_policy
+  -> path_policy:path_policy
+  -> sandbox:sandbox_context
+  -> unit
+  -> verdict
+(** Policy-aware gate for raw shell command strings. Parses [raw] through
+    the Bash parser, then applies the same allowlist, redirect, path
+    policy, sandbox, and nested-pipeline handling as {!gate_typed}.
+    Live caller: [Exec_policy.command_context_with_allowlist] via the
+    [Exec_shell_gate = Masc_exec_command_gate.Shell_command_gate]
+    module alias. *)
+
 val gate_typed
   :  ?caller:caller
   -> ir:Masc_exec.Shell_ir.t


### PR DESCRIPTION
## 증상

\`\`\`
File \"lib/exec_policy.ml\", line 309, characters 6-26:
309 |       Exec_shell_gate.gate
            ^^^^^^^^^^^^^^^^^^^^
Error: Unbound value Exec_shell_gate.gate
\`\`\`

## 원인

PR #18044 (\`refactor(shell-ir): S4 G1 consolidate Bash.parse_string callers to 2 bridge files\`)가 string-based \`gate\` 함수를 \"0 production callers (only tests used it)\" 라며 제거했지만, live caller가 \`lib/exec_policy.ml:309\` (\`command_context_with_allowlist\`)에 module alias로 숨어 있었습니다:

\`\`\`
module Exec_shell_gate = Masc_exec_command_gate.Shell_command_gate
...
Exec_shell_gate.gate ?caller ~raw:trimmed ...
\`\`\`

## 원인 패턴 (3rd occurrence)

Dead-export audit이 qualified callers \`Shell_command_gate.gate\` 만 확인하고 \`module X = Y\` alias는 추적 안 함. PR #17973 (Path_check_error.parse_prefix), PR #18004 (Board_comment_rate_limit.reset)에 이어 세 번째 동일 패턴.

## 수정

- \`Shell_command_gate.ml\`: \`gate\` 함수 복구 (14 lines). \`gate_typed\`와 동일한 \`parse_only_to_stages + apply_policy\` 파이프라인을 사용해 typed Too_complex wrapping (\`Unsupported_construct\`) 공유. \`PD.reason_too_complex\`를 직접 \`Too_complex { reason : too_complex_reason }\`에 넘기는 타입 mismatch 회피.
- \`Shell_command_gate.mli\`: \`val gate\` 선언 복구 (15 lines). docstring에 \`Exec_policy\` alias 경유 live caller 명시 → future audit이 chain 보게 함.

## 검증

- \`dune build --root .\` 출력에서 \`Exec_shell_gate.gate\` unbound 에러 사라짐
- 잔존 build 에러 (\`gate_from_raw_typed\` in test, \`task_id\` record field type mismatch in keeper_tools_oas)는 본 PR과 무관

## RFC

RFC-WAIVED: 29-line surface 복구 (gate function + mli). PR #18044 over-aggressive deletion의 부분 reversal. 새 동작 없음 — gate_typed와 동일 pipeline 공유.