### PR TITLE
fix(keeper): align workflow_rejection records after PR #18024 split

### DIFF
--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -159,12 +159,12 @@ let workflow_rejection_scope_block_record counts key (info : Keeper_tools_oas_wo
       | Some block -> block.Keeper_tools_oas_workflow.count
       | None -> 0
     in
-    let block =
-      { Keeper_tools_oas_workflow.count = previous_count + 1
-      ; task_id = info.Keeper_tools_oas_workflow.task_id
-      ; rule_id = info.Keeper_tools_oas_workflow.rule_id
-      ; tool_suggestion = info.Keeper_tools_oas_workflow.tool_suggestion
-      ; hint = info.Keeper_tools_oas_workflow.hint
+    let block : Keeper_tools_oas_workflow.workflow_rejection_block =
+      { count = previous_count + 1
+      ; task_id = info.task_id
+      ; rule_id = info.rule_id
+      ; tool_suggestion = info.tool_suggestion
+      ; hint = info.hint
       }
     in
     Hashtbl.replace counts.workflow_block_table key block;

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -161,7 +161,6 @@ let workflow_rejection_scope_block_record counts key (info : Keeper_tools_oas_wo
     in
     let block : Keeper_tools_oas_workflow.workflow_rejection_block =
       { count = previous_count + 1
-      ; task_id = info.task_id
       ; rule_id = info.rule_id
       ; tool_suggestion = info.tool_suggestion
       ; hint = info.hint

--- a/lib/keeper/keeper_tools_oas_workflow.ml
+++ b/lib/keeper/keeper_tools_oas_workflow.ml
@@ -14,7 +14,6 @@ type workflow_rejection_info =
 
 type workflow_rejection_block =
   { count : int
-  ; task_id : string option
   ; rule_id : string option
   ; tool_suggestion : string option
   ; hint : string option

--- a/lib/keeper/keeper_tools_oas_workflow.ml
+++ b/lib/keeper/keeper_tools_oas_workflow.ml
@@ -64,7 +64,7 @@ let workflow_rejection_info_of_raw raw =
   | Yojson.Json_error _ -> None
 ;;
 
-let workflow_rejection_family_key ~tool_name info =
+let workflow_rejection_family_key ~tool_name (info : workflow_rejection_info) =
   Printf.sprintf
     "%s:%s:%s:%s"
     (Option.value ~default:"unknown_task" info.task_id)


### PR DESCRIPTION
## 증상

\`\`\`
File \"lib/keeper/keeper_tools_oas_workflow.ml\", line 1:
Error: The implementation lib/keeper/keeper_tools_oas_workflow.pp.ml
       does not match the interface lib/keeper/keeper_tools_oas_workflow.pp.mli:
        Values do not match:
          val workflow_rejection_family_key :
            tool_name:string -> workflow_rejection_block -> string
        is not included in
          val workflow_rejection_family_key :
            tool_name:string -> workflow_rejection_info -> string

File \"lib/keeper/keeper_tools_oas.ml\", line 164, characters 8-15:
164 |       ; task_id = info.Keeper_tools_oas_workflow.task_id
              ^^^^^^^
Error: The record field task_id belongs to the type workflow_rejection_info
       but is mixed here with fields of type workflow_rejection_block
\`\`\`

## 원인

PR #18024 (\`refactor(keeper): split keeper_tools_oas into focused modules\`)이 동일 모듈 내에 4개 field가 겹치는 두 record를 정의했습니다:

\`\`\`ocaml
type workflow_rejection_info  = { task_id; rule_id; tool_suggestion; hint }
type workflow_rejection_block = { count; task_id; rule_id; tool_suggestion; hint }
\`\`\`

OCaml의 field-disambiguation은 같은 이름 field를 *마지막 정의된* record 타입으로 해석합니다. 그래서:

1. \`workflow_rejection_family_key ~tool_name info\`의 \`info\` 파라미터가 \`info.task_id\` 접근을 통해 \`workflow_rejection_block\`으로 추론되어 .mli signature와 어긋남.
2. \`keeper_tools_oas.ml:163\`의 record literal이 두 타입의 qualified field name을 한 record context에 섞음.

추가로, mli/ml 사이 drift가 잠재해 있었습니다:
- mli: \`workflow_rejection_block = { count; rule_id; tool_suggestion; hint }\`
- ml : \`workflow_rejection_block = { count; task_id; rule_id; tool_suggestion; hint }\` (task_id 잉여)

타입 annotation이 strict checking을 강제하기 전까지는 잠복.

## 수정

2 commits:

**1. \`fix(keeper): disambiguate workflow_rejection records\`**
- \`workflow_rejection_family_key\`의 \`info\` 파라미터에 \`workflow_rejection_info\` 타입 annotation 추가 (기존 컨벤션 매칭)
- record literal에서 qualified field syntax 정리

**2. \`fix(keeper): align workflow_rejection_block ml to mli\`**
- ml에서 \`task_id\` field 제거 (mli 의도된 shape 따름)
- \`keeper_tools_oas.ml\`의 literal에서도 \`task_id\` 제거
- 근거: \`task_id\`는 input인 \`workflow_rejection_info\`에 속하지 그 dedup count holder인 \`workflow_rejection_block\`에 속하지 않음. dedup key는 이미 \`workflow_rejection_family_key\`를 통해 task_id 임베드.

## 검증

- \`dune build --root .\` 출력에서 두 workflow_rejection 관련 에러 사라짐
- 잔존 에러 (\`Keeper_context_core_pair_repair_stats\`, \`docker_exec_status_label\` 등)는 본 PR과 무관

## RFC

RFC-WAIVED: PR #18024 module split의 latent type drift 정리. 새 동작 없음 — mli가 명시한 record shape에 ml을 정렬.