### PR TITLE
fix(keeper_recording_error_state): classify oas_timeout_budget_loop as Provider_timeout

### DIFF
--- a/lib/keeper_recording_error_state/keeper_recording_error_state.ml
+++ b/lib/keeper_recording_error_state/keeper_recording_error_state.ml
@@ -104,6 +104,8 @@ let classify_error (err : string) : error_kind =
   then Stale_turn_timeout
   else if contains "fiber_unresolved"
   then Fiber_unresolved
+  else if contains "oas_timeout_budget_loop"
+  then Provider_timeout
   else if contains "provider_timeout"
   then Provider_timeout
   else if contains "state machine guard" || contains "guard violation"


### PR DESCRIPTION
## Summary
`classify_error` did not match the `\"oas_timeout_budget_loop(...)\"` error marker, causing it to land in `[Other]`. It is part of the provider timeout family and should map to `Provider_timeout`.

## Test plan
- [x] `dune exec test/keeper_recording_error_state/test_keeper_recording_error_state.exe` — 17/17 pass.

## Scope
- Single-line fix in `lib/keeper_recording_error_state/keeper_recording_error_state.ml`.
- No public schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)