### PR TITLE
fix(keeper): restore Keeper_hooks_oas_gate_attempt module after PR #18010

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -227,7 +227,7 @@ let make_hooks
   let streak_state = Keeper_guards.make_streak_state () in
   let streak_threshold = 5 in
   let record_gate_decision event =
-    record_pre_tool_gate_attempt
+    Keeper_hooks_oas_gate_attempt.record_pre_tool_gate_attempt
       ~meta_ref
       ~tool_call_count_ref
       ?trajectory_acc
@@ -674,7 +674,7 @@ let make_hooks
                args_json = Yojson.Safe.to_string safe_input;
                gate_decision = Trajectory.Pass;
                result = Some safe_output;
-               duration_ms = trajectory_duration_ms duration_ms;
+               duration_ms = Keeper_hooks_oas_gate_attempt.trajectory_duration_ms duration_ms;
                error = (if outcome = "ok" then None else Some safe_output);
                cost_usd = Trajectory.tool_cost_estimate tool_name;
              }

--- a/lib/keeper/keeper_hooks_oas_gate_attempt.ml
+++ b/lib/keeper/keeper_hooks_oas_gate_attempt.ml
@@ -1,0 +1,157 @@
+open Keeper_hooks_oas_types
+
+let render_pre_tool_gate_source_hint
+    (event : Keeper_guards.gate_decision_event) =
+  match event.source_path, event.source_line with
+  | None, None -> ""
+  | Some path, None ->
+      Printf.sprintf " source_path=%s" (Keeper_guards.escape_field path)
+  | None, Some line -> Printf.sprintf " source_line=%d" line
+  | Some path, Some line ->
+      Printf.sprintf " source_path=%s source_line=%d"
+        (Keeper_guards.escape_field path) line
+
+let tool_approval_required_tag = "[tool_approval_required]"
+
+let render_pre_tool_gate_output (event : Keeper_guards.gate_decision_event) =
+  if event.decision = Keeper_guards.Gate_approval_required then
+    Printf.sprintf
+      "%s tool=%s source=keeper_hook code=%s reason=%s%s"
+      tool_approval_required_tag
+      (Keeper_guards.escape_field event.tool_name)
+      (Keeper_guards.escape_field event.reason_code)
+      (Keeper_guards.escape_field event.reason_text)
+      (render_pre_tool_gate_source_hint event)
+  else
+    match event.source_path, event.source_line with
+    | Some source_path, Some source_line ->
+        Keeper_guards.render_inline_skip_reason_with_source
+          ~source_path
+          ~source_line
+          ~tool_name:event.tool_name
+          ~reason_code:event.reason_code
+          ~reason_text:event.reason_text
+    | _ ->
+        Keeper_guards.render_inline_skip_reason
+          ~tool_name:event.tool_name
+          ~reason_code:event.reason_code
+          ~reason_text:event.reason_text
+
+let pre_tool_gate_error (event : Keeper_guards.gate_decision_event) =
+  let decision = Keeper_guards.gate_decision_to_string event.decision in
+  Printf.sprintf "%s:%s: %s" decision event.reason_code event.reason_text
+
+let min_duration_ms = 0.0
+
+let trajectory_duration_ms duration_ms =
+  if
+    (not (Float.is_finite duration_ms))
+    || Float.compare duration_ms min_duration_ms <= 0
+  then 0
+  else max 1 (int_of_float (Float.round duration_ms))
+
+let record_pre_tool_gate_attempt
+    ~(meta_ref : Keeper_types.keeper_meta ref)
+    ~(tool_call_count_ref : int ref)
+    ?(trajectory_acc : Trajectory.accumulator option)
+    (event : Keeper_guards.gate_decision_event) =
+  incr tool_call_count_ref;
+  let meta = !meta_ref in
+  let keeper_name = meta.name in
+  let model = current_keeper_model meta in
+  let safe_input = Observability_redact.redact_json_value event.input in
+  let output_text = render_pre_tool_gate_output event in
+  let error = pre_tool_gate_error event in
+  let duration_ms = Float.max 0.0 event.stage_latency_ms in
+  (try
+     Keeper_tool_call_log.log_call
+       ~keeper_name
+       ~tool_name:event.tool_name
+       ~input:safe_input
+       ~output_text
+       ~success:false
+       ~duration_ms
+       ~model
+       ~result_bytes:(String.length output_text)
+       ()
+   with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
+       let callback_label_gate_tool_call_log = "gate_tool_call_log" in
+       Prometheus.inc_counter
+         Keeper_metrics.metric_keeper_lifecycle_callback_failures
+         ~labels:
+           [
+             (label_keeper, keeper_name);
+             (label_callback, callback_label_gate_tool_call_log);
+           ]
+         ();
+       Log.Keeper.warn
+         "keeper:%s pre_tool_use gate tool_call log failed tool=%s err=%s"
+         keeper_name event.tool_name (Printexc.to_string exn));
+  match trajectory_acc with
+  | None -> ()
+  | Some acc ->
+      let trace_id = acc.Trajectory.trace_id in
+      let runtime_contract =
+        Keeper_tool_call_log.runtime_contract_json_for_call
+          ~keeper_name
+          ~model
+          ()
+      in
+      let action_radius =
+        Keeper_tool_call_log.action_radius_json_for_call
+          ~keeper_name
+          ~tool_name:event.tool_name
+          ~input:safe_input
+          ~success:false
+          ~duration_ms
+          ~error
+          ()
+      in
+      let now = Time_compat.now () in
+      let turn = if event.turn > 0 then event.turn else acc.Trajectory.turn in
+      let round =
+        acc.Trajectory.entries
+        |> List.filter (fun (e : Trajectory.tool_call_entry) -> e.turn = turn)
+        |> List.length
+        |> ( + ) 1
+      in
+      let entry : Trajectory.tool_call_entry =
+        {
+          ts = now;
+          ts_iso = Masc_domain.iso8601_of_unix_seconds now;
+          turn;
+          round;
+          tool_name = event.tool_name;
+          args_json = Yojson.Safe.to_string safe_input;
+          gate_decision = Trajectory.Reject error;
+          result = Some output_text;
+          duration_ms = trajectory_duration_ms duration_ms;
+          error = Some error;
+          cost_usd = 0.0;
+        }
+      in
+      Trajectory.record_entry
+        ~runtime_contract
+        ~action_radius
+        ~on_persist_error:(fun exn ->
+          let dashboard_surface_tool_stats = "/api/v1/keepers/:name/tool-stats" in
+          let stale_reason_trajectory_append = "trajectory_append_failed" in
+          let telemetry_source_trajectory = "trajectory_tool_call" in
+          let telemetry_producer_pre_tool = "keeper_hooks_oas.pre_tool_use" in
+          Telemetry_coverage_gap.record
+            ~masc_root:acc.Trajectory.masc_root
+            ~source:telemetry_source_trajectory
+            ~producer:telemetry_producer_pre_tool
+            ~durable_store:
+              (Trajectory.trajectory_path acc.Trajectory.masc_root
+                 acc.Trajectory.keeper_name trace_id)
+            ~dashboard_surface:dashboard_surface_tool_stats
+            ~stale_reason:stale_reason_trajectory_append
+            ~keeper_name
+            ~trace_id
+            ~exn
+            ())
+        acc
+        entry

--- a/lib/keeper/keeper_hooks_oas_gate_attempt.mli
+++ b/lib/keeper/keeper_hooks_oas_gate_attempt.mli
@@ -1,0 +1,16 @@
+(** Pre-tool gate attempt rendering and telemetry for OAS keeper hooks. *)
+
+val render_pre_tool_gate_output :
+  Keeper_guards.gate_decision_event -> string
+
+val pre_tool_gate_error :
+  Keeper_guards.gate_decision_event -> string
+
+val trajectory_duration_ms : float -> int
+
+val record_pre_tool_gate_attempt :
+  meta_ref:Keeper_types.keeper_meta ref ->
+  tool_call_count_ref:int ref ->
+  ?trajectory_acc:Trajectory.accumulator ->
+  Keeper_guards.gate_decision_event ->
+  unit


### PR DESCRIPTION
## 증상

\`\`\`
File \"lib/keeper/keeper_hooks_oas.ml\", line 230, characters 4-32:
230 |     record_pre_tool_gate_attempt
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: Unbound value record_pre_tool_gate_attempt
\`\`\`

추가로 line 677: \`trajectory_duration_ms\`도 unbound.

## 원인

PR #18010 (\`refactor(keeper): remove dead Keeper_hooks_oas_gate_attempt module\`)이 모듈 전체와 re-export alias들을 삭제하면서 \"5-prong audit: 0 callers (qualified, facade, opener-unqualified, local alias, parent .ml internal)\" 라고 주장했지만, 부모 모듈 \`keeper_hooks_oas.ml\`에 2개의 live caller가 있었습니다 — 2026-05-17 (commit f0075c3611) 이후로 unqualified name으로 re-export alias를 호출:

- line 230: \`record_pre_tool_gate_attempt\` (gate-decision recorder)
- line 677: \`trajectory_duration_ms\`       (duration formatter)

## 원인 패턴 (4th occurrence)

PR body의 \"audit passed N/N\" 주장이 실제 code state와 어긋난 경우. \`feedback_subagent_pr_body_self_justification_must_be_traced.md\` (2026-05-20) 메모리가 정확히 이 패턴을 명시합니다 — PR self-claim audit은 trace-verify 의무.

## 수정

- \`Keeper_hooks_oas_gate_attempt.ml\` + \`.mli\` 복구 (173 lines). 4개 typed exports 보존: \`render_pre_tool_gate_output\`, \`pre_tool_gate_error\`, \`trajectory_duration_ms\`, \`record_pre_tool_gate_attempt\`.
- 2 caller를 unqualified alias 부활 대신 qualified module name으로 마이그레이션 → PR #18010의 \"less indirection\" 정신은 유지하면서, dead-export audit이 추적하지 못하는 unqualified name 부활 회피.

## 검증

- \`dune build --root .\` 출력에서 두 unbound caller 에러 사라짐
- 잔존 build 에러 (\`Keeper_context_core_pair_repair_stats\` 등)는 본 PR과 무관
- 테스트의 \`Hooks.trajectory_duration_ms\` unbound는 별개 (test sweep 후속 PR로)

## RFC

RFC-WAIVED: 175-line 모듈 surface 복구. PR #18010 over-deletion 부분 reversal. caller는 qualified로 마이그레이션해 surface 노이즈 최소화.