### PR TITLE
fix(keeper): restore meta_json_scrub + context_core_pair_repair_stats after PRs #18021/#18019

### DIFF
--- a/lib/keeper/keeper_context_core_pair_repair_stats.ml
+++ b/lib/keeper/keeper_context_core_pair_repair_stats.ml
@@ -1,0 +1,54 @@
+(** Tool-pair repair stats and metadata helpers.
+
+    Counters and message-metadata bookkeeping for the
+    [repair_*_tool_*] family in [Keeper_context_core]. The repair
+    bodies themselves stay in the parent (they depend on the
+    parent's [tool_result_text_of_block] specialization, which
+    closes over the parent's
+    [default_max_checkpoint_tool_result_chars] constant).
+
+    Pure record / metadata helpers — no parent-local state, no I/O,
+    no callback injection. *)
+
+type tool_pair_repair_stats =
+  { downgraded_tool_uses : int
+  ; downgraded_tool_results : int
+  }
+
+let empty_tool_pair_repair_stats =
+  { downgraded_tool_uses = 0; downgraded_tool_results = 0 }
+
+let add_tool_pair_repair_stats left right =
+  { downgraded_tool_uses =
+      left.downgraded_tool_uses + right.downgraded_tool_uses
+  ; downgraded_tool_results =
+      left.downgraded_tool_results + right.downgraded_tool_results
+  }
+
+let tool_pair_repair_stats_changed stats =
+  stats.downgraded_tool_uses > 0 || stats.downgraded_tool_results > 0
+
+let pair_repair_metadata_key = "masc.tool_pair_repair"
+
+let pair_repair_metadata_keys =
+  [ "was_fabricated"; "fabrication_source"; pair_repair_metadata_key ]
+
+let with_pair_repair_metadata ~kind ~count (msg : Agent_sdk.Types.message) =
+  let metadata =
+    List.filter
+      (fun (key, _) -> not (List.mem key pair_repair_metadata_keys))
+      msg.metadata
+  in
+  { msg with
+    metadata =
+      [ "was_fabricated", `Bool true
+      ; "fabrication_source", `String "tool_pair_repair"
+      ; ( pair_repair_metadata_key
+        , `Assoc
+            [ "version", `Int 1
+            ; "kind", `String kind
+            ; "count", `Int count
+            ] )
+      ]
+      @ metadata
+  }

--- a/lib/keeper/keeper_context_core_pair_repair_stats.mli
+++ b/lib/keeper/keeper_context_core_pair_repair_stats.mli
@@ -1,0 +1,18 @@
+(** Tool-pair repair stats and metadata helpers for [Keeper_context_core]. *)
+
+type tool_pair_repair_stats =
+  { downgraded_tool_uses : int
+  ; downgraded_tool_results : int
+  }
+
+val empty_tool_pair_repair_stats : tool_pair_repair_stats
+
+val add_tool_pair_repair_stats :
+  tool_pair_repair_stats -> tool_pair_repair_stats -> tool_pair_repair_stats
+
+val tool_pair_repair_stats_changed : tool_pair_repair_stats -> bool
+val pair_repair_metadata_key : string
+val pair_repair_metadata_keys : string list
+
+val with_pair_repair_metadata :
+  kind:string -> count:int -> Agent_sdk.Types.message -> Agent_sdk.Types.message

--- a/lib/keeper/keeper_meta_json_scrub.ml
+++ b/lib/keeper/keeper_meta_json_scrub.ml
@@ -1,0 +1,93 @@
+(** Keeper meta JSON removed-field scrub helpers.
+
+    Kept below the codec/parser facade so persisted runtime JSON can be
+    normalized before strict [keeper_meta] decoding. *)
+
+open Keeper_types_profile
+open Keeper_meta_contract
+
+let drop_assoc_keys (keys : string list) (json : Yojson.Safe.t) : Yojson.Safe.t =
+  match json with
+  | `Assoc fields -> `Assoc (List.filter (fun (key, _) -> not (List.mem key keys)) fields)
+  | _ -> json
+;;
+
+let reject_removed_keeper_meta_fields (json : Yojson.Safe.t) =
+  let present = present_json_keys removed_keeper_meta_key_names json in
+  match present with
+  | [] -> Ok ()
+  | fields ->
+    Error (Printf.sprintf "removed keeper meta fields: %s" (String.concat ", " fields))
+;;
+
+let legacy_keeper_meta_tool_policy_key_names =
+  [ "tool_preset"; "tool_also_allow"; "tool_custom_allowlist"; "tool_allowlist" ]
+;;
+
+let legacy_keeper_meta_key_names =
+  "allowed_providers" :: legacy_keeper_meta_tool_policy_key_names
+;;
+
+let reject_legacy_keeper_meta_fields (json : Yojson.Safe.t) =
+  let present = present_json_keys legacy_keeper_meta_key_names json in
+  match present with
+  | [] -> Ok ()
+  | fields ->
+    Error
+      (Printf.sprintf
+         "legacy keeper meta fields are no longer supported: %s"
+         (String.concat ", " fields))
+;;
+
+let scrub_persisted_keeper_meta_json ~path (json : Yojson.Safe.t) : Yojson.Safe.t * bool =
+  match json with
+  | `Assoc fields ->
+    let removed_present =
+      fields
+      |> List.filter_map (fun (key, _) ->
+        if List.mem key removed_keeper_meta_key_names then Some key else None)
+    in
+    let removed_to_scrub =
+      removed_present
+      |> List.filter (fun key -> not (List.mem key legacy_keeper_meta_key_names))
+    in
+    if removed_to_scrub = []
+    then json, false
+    else (
+      let migrate_legacy_disabled_keepalive =
+        (match List.assoc_opt "presence_keepalive" fields with
+         | Some (`Bool false) -> true
+         | _ -> false)
+        && not (List.mem_assoc "paused" fields)
+      in
+      let scrubbed =
+        let base = drop_assoc_keys removed_to_scrub json in
+        match base with
+        | `Assoc base_fields when migrate_legacy_disabled_keepalive ->
+          `Assoc (("paused", `Bool true) :: List.remove_assoc "paused" base_fields)
+        | _ -> base
+      in
+      let content = Yojson.Safe.pretty_to_string scrubbed in
+      (try
+         Fs_compat.save_file path content;
+         Log.Keeper.info
+           "scrubbed legacy keeper meta fields for %s: %s%s"
+           path
+           (String.concat ", " removed_to_scrub)
+           (if migrate_legacy_disabled_keepalive
+            then " (migrated presence_keepalive=false to paused=true)"
+            else "")
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+         Prometheus.inc_counter
+           Keeper_metrics.metric_keeper_meta_json_failures
+           ~labels:[("site", "scrub")]
+           ();
+         Log.Keeper.warn
+           "failed to scrub removed keeper meta fields for %s: %s"
+           path
+           (Printexc.to_string exn));
+      scrubbed, true)
+  | _ -> json, false
+;;

--- a/lib/keeper/keeper_meta_json_scrub.mli
+++ b/lib/keeper/keeper_meta_json_scrub.mli
@@ -1,0 +1,34 @@
+(** Keeper meta JSON removed-field scrub helpers.
+
+    Lives below the codec/parser facade so persisted runtime JSON can
+    be normalized before strict [keeper_meta] decoding. *)
+
+(** Drop the named keys from a top-level JSON object; passes through
+    non-objects unchanged. *)
+val drop_assoc_keys : string list -> Yojson.Safe.t -> Yojson.Safe.t
+
+(** Returns [Error msg] if any [removed_keeper_meta_key_names] is
+    present at the top level (these have been deleted from the schema
+    and must not appear). *)
+val reject_removed_keeper_meta_fields :
+  Yojson.Safe.t -> (unit, string) result
+
+(** Legacy tool-policy keys that are no longer supported. *)
+val legacy_keeper_meta_tool_policy_key_names : string list
+
+(** Combined legacy key names (allowed_providers + tool-policy keys). *)
+val legacy_keeper_meta_key_names : string list
+
+(** Returns [Error msg] if any legacy key is present. *)
+val reject_legacy_keeper_meta_fields :
+  Yojson.Safe.t -> (unit, string) result
+
+(** [scrub_persisted_keeper_meta_json ~path json] migrates persisted
+    keeper meta to the current schema for removed non-tool fields
+    (including presence_keepalive=false→paused=true) and writes the
+    scrubbed content back to [path] when changes were needed. Legacy
+    tool policy fields are intentionally not rewritten. Returns the
+    scrubbed JSON and a [bool] indicating whether the file was
+    rewritten. *)
+val scrub_persisted_keeper_meta_json :
+  path:string -> Yojson.Safe.t -> Yojson.Safe.t * bool


### PR DESCRIPTION
## 증상

```
File "lib/keeper/keeper_meta_json.mli", line 7, characters 23-45:
7 | include module type of Keeper_meta_json_scrub
                           ^^^^^^^^^^^^^^^^^^^^^^
Error: Unbound module Keeper_meta_json_scrub

File "lib/keeper/keeper_context_core.ml", line 234, characters 30-90:
234 | type tool_pair_repair_stats = Keeper_context_core_pair_repair_stats.tool_pair_repair_stats =
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: Unbound module Keeper_context_core_pair_repair_stats
```

## 원인

`include`-facade dead-export anti-pattern (5번째 발생):

**PR #18021** (`remove(lib): delete dead module keeper_meta_json_scrub`)이 scrub 모듈을 제거했지만 부모 facade `keeper_meta_json`이 module type 전체를 `include`로 재노출하고 있었습니다:

```ocaml
lib/keeper/keeper_meta_json.ml:9:  include Keeper_meta_json_scrub
lib/keeper/keeper_meta_json.mli:7: include module type of Keeper_meta_json_scrub
lib/keeper/keeper_meta_json_parse.ml:9: open Keeper_meta_json_scrub
```

`reject_removed_keeper_meta_fields` 같은 함수가 `keeper_types.mli` public surface에까지 chain되어 있는데, dead-export audit이 `include`/`open` 경유 caller를 추적 못함.

**PR #18019** (`remove(lib): delete dead module keeper_context_core_pair_repair_stats`)이 별개의 stats 모듈을 제거했지만, **6개의 distinct caller** 사용 중:
- `keeper_context_core` (type re-export + impl)
- `keeper_compact_policy`
- `keeper_metrics.mli`
- `prometheus_builtin_metrics_part1`
- `test_pbt_context_overflow`

이건 진짜로 multi-consumer 공유 모듈이라 dead-export 판정 자체가 잘못.

## 수정

두 모듈 verbatim 복구. 합 199 lines (scrub 127, pair_repair_stats 72). 동작 변경 없음.

## 왜 radical inline이 아닌 conservative restore인가

가이드라인은 single-consumer면 inline이 더 정직하지만:

- **`keeper_meta_json_scrub`**: caller가 3개(`.ml include`, `.mli include module type of`, `.ml open`) 모두 keeper_meta_json 패밀리에 있어 1-소비자처럼 보이지만, `keeper_meta_json_parse.ml`이 `open`을 통해 scrub의 unqualified name을 사용함. scrub을 keeper_meta_json.ml로 inline하면 parse.ml이 부모 모듈을 reference해야 하는데, 부모 mli가 `include module type of Keeper_meta_json_parse`도 갖고 있어 circular module signature 우려. 안전한 radical 리팩터는 `scrub + parse + facade`를 하나의 keeper_meta_json.ml로 통합 — 별도 PR 단위로 더 큰 작업.

- **`keeper_context_core_pair_repair_stats`**: 6개 distinct module이 실제로 공유 — legitimate shared module. inline 대상 아님.

## 후속 TODO

`keeper_meta_json` facade architecture의 radical 통합 (`scrub + parse + facade` → 단일 모듈)을 별도 PR로 추적. dead-export audit이 `include`/`open` facade를 추적하도록 도구 자체 수정도 후보.

## 검증

- `dune build --root .` 출력에서 두 unbound module 에러 사라짐
- 잔존 build 에러 (`Keeper_context_core_history` Multiple definition `Message_json` 등)는 본 PR과 무관

## RFC

RFC-WAIVED: 199-line module 복구 (deletion-only PRs #18021, #18019의 부분 reversal). 새 동작 없음. 단, 본 PR은 facade architecture의 근본 정리는 미루는 conservative fix임을 명시 — radical 통합은 후속 PR.
