### PR TITLE
refactor(keeper): RFC-0164 voice tool surface deletion (-241 LoC)

### DIFF
--- a/lib/keeper/keeper_exec_persona.ml
+++ b/lib/keeper/keeper_exec_persona.ml
@@ -35,7 +35,7 @@ let find_jsonl_row_by_action_id rows action_id =
 
 let resolved_keeper_args_to_json
     ~name ~persona_name ~goal ~short_goal ~mid_goal ~long_goal
-    ~instructions ~will ~needs ~desires ~policy_voice_enabled
+    ~instructions ~will ~needs ~desires
     ~mention_targets
     ~allowed_paths_opt
     ~autoboot_enabled_opt
@@ -55,7 +55,6 @@ let resolved_keeper_args_to_json
       ("will", `String will);
       ("needs", `String needs);
       ("desires", `String desires);
-      ("policy_voice_enabled", `Bool policy_voice_enabled);
       ("mention_targets", string_list_to_json mention_targets);
       ("tool_denylist", string_list_to_json tool_denylist);
       ("proactive_enabled", `Bool proactive_enabled);
@@ -95,9 +94,6 @@ let validate_resolved_keeper_create_json (json : Yojson.Safe.t) : string list =
   let errors = ref [] in
   let name = Safe_ops.json_string ~default:"" "name" json in
   let goal = Safe_ops.json_string ~default:"" "goal" json |> String.trim in
-  let _policy_voice_enabled =
-    Safe_ops.json_bool ~default:false "policy_voice_enabled" json
-  in
   let mention_targets = Safe_ops.json_string_list "mention_targets" json in
   if not (validate_name name) then
     errors :=
@@ -227,9 +223,6 @@ let render_keeper_toml_from_resolved_args (json : Yojson.Safe.t) :
               let fields = append_optional_string_field fields "needs" json in
               let fields = append_optional_string_field fields "desires" json in
               let fields = append_optional_string_field fields "instructions" json in
-              let fields =
-                append_optional_bool_field fields "policy_voice_enabled" json
-              in
               let fields =
                 append_optional_bool_field fields "autoboot_enabled" json
               in
@@ -403,12 +396,6 @@ let resolved_keeper_args_from_persona args :
           |> first_some defaults.desires
           |> Option.value ~default:(Env_config_core.keeper_desires ())
         in
-            let policy_voice_enabled =
-              first_some
-                (get_bool_opt args "policy_voice_enabled")
-              defaults.policy_voice_enabled
-              |> Option.value ~default:false
-            in
             let mention_targets =
               let explicit = get_string_list args "mention_targets" in
               let raw =
@@ -484,7 +471,6 @@ let resolved_keeper_args_from_persona args :
                      ~persona_name
                      ~goal ~short_goal ~mid_goal ~long_goal
                      ~instructions  ~will ~needs ~desires
-                     ~policy_voice_enabled
                      ~mention_targets
                      ~allowed_paths_opt:allowed_paths
                      ~autoboot_enabled_opt:autoboot_enabled

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -499,8 +499,7 @@ type keeper_meta =
   ; desires : string
   ; instructions : string
   ; (* -- Policy -- *)
-    policy_voice_enabled : bool
-  ; sandbox_profile : sandbox_profile
+    sandbox_profile : sandbox_profile
   ; sandbox_image : string option
   ; network_mode : network_mode
   ; allowed_paths : string list
@@ -516,10 +515,6 @@ type keeper_meta =
   ; auto_handoff : bool
   ; handoff_threshold : float
   ; handoff_cooldown_sec : int
-  ; (* -- Voice -- *)
-    voice_enabled : bool
-  ; voice_channel : string
-  ; voice_agent_id : string
   ; (* -- Lifecycle -- *)
     created_at : string
   ; updated_at : string

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -333,7 +333,6 @@ type keeper_meta = {
   desires : string;
   instructions : string;
   (* Policy *)
-  policy_voice_enabled : bool;
   sandbox_profile : Keeper_types_profile.sandbox_profile;
   sandbox_image : string option;
   network_mode : Keeper_types_profile.network_mode;
@@ -350,10 +349,6 @@ type keeper_meta = {
   auto_handoff : bool;
   handoff_threshold : float;
   handoff_cooldown_sec : int;
-  (* Voice *)
-  voice_enabled : bool;
-  voice_channel : string;
-  voice_agent_id : string;
   (* Lifecycle *)
   created_at : string;
   updated_at : string;

--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -44,8 +44,7 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
      ]
      @ personality_pairs
      @ [
-      "policy_voice_enabled", `Bool m.policy_voice_enabled
-    ; "sandbox_profile", `String (sandbox_profile_to_string m.sandbox_profile)
+      "sandbox_profile", `String (sandbox_profile_to_string m.sandbox_profile)
     ; "sandbox_image", Json_util.string_opt_to_json m.sandbox_image
     ; "network_mode", `String (network_mode_to_string m.network_mode)
     ; "allowed_paths", `List (List.map (fun s -> `String s) m.allowed_paths)
@@ -70,9 +69,6 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; "auto_handoff", `Bool m.auto_handoff
     ; "handoff_threshold", `Float m.handoff_threshold
     ; "handoff_cooldown_sec", `Int m.handoff_cooldown_sec
-    ; "voice_enabled", `Bool m.voice_enabled
-    ; "voice_channel", `String m.voice_channel
-    ; "voice_agent_id", `String m.voice_agent_id
     ; "last_handoff_ts", `Float rt.last_handoff_ts
     ; "created_at", `String m.created_at
     ; "updated_at", `String m.updated_at
@@ -178,7 +174,6 @@ let fallback_canonical_keeper_meta_key_names =
   ; "needs"
   ; "desires"
   ; "instructions"
-  ; "policy_voice_enabled"
   ; "allowed_paths"
   ; "tool_access"
   ; "tool_denylist"
@@ -198,9 +193,6 @@ let fallback_canonical_keeper_meta_key_names =
   ; "auto_handoff"
   ; "handoff_threshold"
   ; "handoff_cooldown_sec"
-  ; "voice_enabled"
-  ; "voice_channel"
-  ; "voice_agent_id"
   ; "last_handoff_ts"
   ; "created_at"
   ; "updated_at"

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -27,8 +27,7 @@ type parsed_keeper_identity =
   }
 
 type parsed_keeper_policy =
-  { pp_policy_voice_enabled : bool
-  ; pp_sandbox_profile : sandbox_profile
+  { pp_sandbox_profile : sandbox_profile
   ; pp_sandbox_image : string option
   ; pp_network_mode : network_mode
   ; pp_allowed_paths : string list
@@ -43,9 +42,6 @@ type parsed_keeper_policy =
   ; pp_auto_handoff : bool
   ; pp_handoff_threshold : float
   ; pp_handoff_cooldown_sec : int
-  ; pp_voice_enabled : bool
-  ; pp_voice_channel : string
-  ; pp_voice_agent_id : string
   ; pp_per_provider_timeout_s : float option
   ; pp_always_approve : bool option
   }
@@ -215,16 +211,12 @@ let parse_sandbox_policy_fields (json : Yojson.Safe.t)
 let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
   : (parsed_keeper_policy, string) result
   =
-  let voice_enabled_default = default_voice_enabled_for keeper_name in
   match tool_access_of_meta_json json with
   | Error msg -> Error ("meta parse error: " ^ msg)
   | Ok pp_tool_access ->
     (match parse_sandbox_policy_fields json with
      | Error msg -> Error ("meta parse error: " ^ msg)
      | Ok (pp_sandbox_profile, pp_sandbox_image, pp_network_mode) ->
-    let pp_policy_voice_enabled =
-      Safe_ops.json_bool ~default:voice_enabled_default "policy_voice_enabled" json
-    in
     let pp_allowed_paths = Safe_ops.json_string_list "allowed_paths" json in
     let pp_tool_denylist = Safe_ops.json_string_list "tool_denylist" json in
     let pp_mention_targets =
@@ -292,22 +284,6 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
     let pp_handoff_cooldown_sec =
       Safe_ops.json_int ~default:300 "handoff_cooldown_sec" json
     in
-    let pp_voice_enabled =
-      Safe_ops.json_bool ~default:voice_enabled_default "voice_enabled" json
-    in
-    let pp_voice_channel =
-      Safe_ops.json_string
-        ~default:(default_voice_channel_for keeper_name)
-        "voice_channel"
-        json
-      |> canonical_voice_channel
-    in
-    let pp_voice_agent_id =
-      Safe_ops.json_string
-        ~default:(default_voice_agent_id_for keeper_name)
-        "voice_agent_id"
-        json
-    in
     let pp_per_provider_timeout_s =
       normalize_per_provider_timeout_json_field
         ~source:(Printf.sprintf "keeper meta %s" keeper_name)
@@ -316,8 +292,7 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
     in
     let pp_always_approve = Safe_ops.json_bool_opt "always_approve" json in
     Ok
-      { pp_policy_voice_enabled
-      ; pp_sandbox_profile
+      { pp_sandbox_profile
       ; pp_sandbox_image
       ; pp_network_mode
       ; pp_allowed_paths
@@ -361,9 +336,6 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
       ; pp_auto_handoff
       ; pp_handoff_threshold
       ; pp_handoff_cooldown_sec
-      ; pp_voice_enabled
-      ; pp_voice_channel
-      ; pp_voice_agent_id
       ; pp_per_provider_timeout_s
       ; pp_always_approve
       })
@@ -656,7 +628,6 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
                    ; needs = identity.pk_needs
                    ; desires = identity.pk_desires
                    ; instructions = identity.pk_instructions
-                   ; policy_voice_enabled = policy.pp_policy_voice_enabled
                    ; sandbox_profile = policy.pp_sandbox_profile
                    ; sandbox_image = policy.pp_sandbox_image
                    ; network_mode = policy.pp_network_mode
@@ -674,9 +645,6 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
                    ; auto_handoff = policy.pp_auto_handoff
                    ; handoff_threshold = policy.pp_handoff_threshold
                    ; handoff_cooldown_sec = policy.pp_handoff_cooldown_sec
-                   ; voice_enabled = policy.pp_voice_enabled
-                   ; voice_channel = policy.pp_voice_channel
-                   ; voice_agent_id = policy.pp_voice_agent_id
                    ; per_provider_timeout_s = policy.pp_per_provider_timeout_s
                    ; always_approve = policy.pp_always_approve
                    ; created_at =

--- a/lib/keeper/keeper_meta_json_parse.mli
+++ b/lib/keeper/keeper_meta_json_parse.mli
@@ -28,8 +28,7 @@ type parsed_keeper_identity =
 
 (** Parsed policy slice of a persisted keeper meta. *)
 type parsed_keeper_policy =
-  { pp_policy_voice_enabled : bool
-  ; pp_sandbox_profile : sandbox_profile
+  { pp_sandbox_profile : sandbox_profile
   ; pp_sandbox_image : string option
   ; pp_network_mode : network_mode
   ; pp_allowed_paths : string list
@@ -44,9 +43,6 @@ type parsed_keeper_policy =
   ; pp_auto_handoff : bool
   ; pp_handoff_threshold : float
   ; pp_handoff_cooldown_sec : int
-  ; pp_voice_enabled : bool
-  ; pp_voice_channel : string
-  ; pp_voice_agent_id : string
   ; pp_per_provider_timeout_s : float option
   ; pp_always_approve : bool option
   }

--- a/lib/keeper/keeper_persona_authoring.ml
+++ b/lib/keeper/keeper_persona_authoring.ml
@@ -161,11 +161,6 @@ let field_catalog_entries =
         "Self-model desires statement. Overrides the keeper environment default."
       ()
   ; field_catalog_entry
-      ~path:"keeper.policy_voice_enabled"
-      ~typ:"boolean"
-      ~field_effect:"Whether persona-created keepers should surface voice tools."
-      ()
-  ; field_catalog_entry
       ~path:"keeper.mention_targets"
       ~typ:"string[]"
       ~default:(`String "[<handle>]")
@@ -514,8 +509,7 @@ let normalize_keeper_json ~handle keeper_json =
                         fields
                  in
                  let fields =
-                   [ "policy_voice_enabled"
-                   ; "room_signal_prompt_enabled"
+                   [ "room_signal_prompt_enabled"
                    ; "work_discovery_enabled"
                    ; "telemetry_feedback_enabled"
                    ; "always_approve"

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -253,8 +253,6 @@ let ensure_keeper_meta config name =
     let target_instructions = apply_default defaults.instructions meta.instructions in
 
     (* --- Policy --- *)
-    let target_policy_voice_enabled =
-      apply_default defaults.policy_voice_enabled meta.policy_voice_enabled in
     let target_autoboot_enabled =
       apply_default defaults.autoboot_enabled meta.autoboot_enabled in
     let target_mention_targets =
@@ -392,8 +390,7 @@ let ensure_keeper_meta config name =
     in
     let personality_changed = personality_diff_entries <> [] in
     let policy_changed =
-      meta.policy_voice_enabled <> target_policy_voice_enabled
-      || meta.autoboot_enabled <> target_autoboot_enabled
+      meta.autoboot_enabled <> target_autoboot_enabled
       || meta.mention_targets <> target_mention_targets
       || meta.active_goal_ids <> target_active_goal_ids
       || meta.tool_access <> target_tool_access
@@ -503,7 +500,6 @@ let ensure_keeper_meta config name =
         needs = target_needs;
         desires = target_desires;
         instructions = target_instructions;
-        policy_voice_enabled = target_policy_voice_enabled;
         autoboot_enabled = target_autoboot_enabled;
         mention_targets = target_mention_targets;
         active_goal_ids = target_active_goal_ids;

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -353,22 +353,6 @@ let keeper_schemas : tool_schema list = [
           ("type", `String "boolean");
           ("description", `String "If true, keeper can send proactive check-ins after idle periods. Defaults to false unless explicitly enabled.");
         ]);
-        ("policy_voice_enabled", `Assoc [
-          ("type", `String "boolean");
-          ("description", `String "Master switch for voice-bridge tool access. When false, the keeper cannot interact with the voice bridge regardless of the other voice_* fields. Defaults to keeper-profile setting.");
-        ]);
-        ("voice_enabled", `Assoc [
-          ("type", `String "boolean");
-          ("description", `String "Per-keeper runtime voice-bridge participation. Requires policy_voice_enabled=true to take effect. Defaults to keeper-profile setting.");
-        ]);
-        ("voice_channel", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Optional: voice-bridge channel handle the keeper joins when voice_enabled is true. Defaults to the keeper-profile channel.");
-        ]);
-        ("voice_agent_id", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Optional: voice-bridge agent identifier presented on the channel. Defaults to the keeper name.");
-        ]);
         ("proactive_idle_sec", `Assoc [
           ("type", `String "integer");
           ("description", `String "Idle seconds before proactive check-in is allowed (default: 900).");

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -338,21 +338,6 @@ let resolve_policy_group ~(fallback : string list) (group_name : string) : strin
           group_name (List.length fallback);
         fallback)
 
-let keeper_voice_tool_names () =
-  resolve_policy_group
-    ~fallback:
-      [ "keeper_voice_speak"
-      ; "keeper_voice_listen"
-      ; "keeper_voice_agent"
-      ; "keeper_voice_sessions"
-      ; "keeper_voice_session_start"
-      ; "keeper_voice_session_end"
-      ]
-    "voice"
-
-let voice_tools_allowed_by_policy (meta : keeper_meta) =
-  if meta.policy_voice_enabled then keeper_voice_tool_names () else []
-
 (** Optional tools that require explicit opt-in via also_allow.
     Reads [groups.optional] from tool_policy.toml; falls back to
     hardcoded list when config is absent. *)
@@ -409,25 +394,17 @@ let preset_allowlist preset =
         [])
 
 let tool_policy_of_meta (meta : keeper_meta) =
-  let voice_tools = keeper_voice_tool_names () in
-  let policy_voice_allow =
-    if meta.policy_voice_enabled then voice_tools else []
-  in
-  let policy_voice_deny =
-    if meta.policy_voice_enabled then [] else voice_tools
-  in
   let allow =
     match meta.tool_access with
     | Preset { preset; also_allow } ->
         Tool_access_policy.Names
-          (preset_allowlist preset @ keeper_safe_inline_tools @ also_allow
-           @ policy_voice_allow)
+          (preset_allowlist preset @ keeper_safe_inline_tools @ also_allow)
     | Custom allowlist ->
-        Tool_access_policy.Names (allowlist @ policy_voice_allow)
+        Tool_access_policy.Names allowlist
   in
   {
     Tool_access_policy.allow;
-    deny = Tool_access_policy.Names (meta.tool_denylist @ policy_voice_deny);
+    deny = Tool_access_policy.Names meta.tool_denylist;
   }
 
 module StringSet = Set.Make (String)
@@ -445,23 +422,13 @@ let tool_name_set names =
   List.fold_left (fun acc name -> StringSet.add name acc) StringSet.empty names
 
 let tool_access_lookup_of_meta (meta : keeper_meta) =
-  (* keeper_base_candidate_tool_names already pulls [groups.voice] from
-     tool_policy.toml via all_group_tools, so disabling
-     policy_voice_enabled must subtract voice tools here — otherwise they
-     remain in candidate_set and stay discoverable via filter_by_universe
-     even though they are dropped from allow_set. *)
+  (* keeper_base_candidate_tool_names pulls [groups.voice] from
+     tool_policy.toml via all_group_tools — voice tools are present iff
+     the keeper's preset includes the voice group. No per-keeper gate. *)
   let base = keeper_base_candidate_tool_names () in
-  let base_after_voice_policy =
-    if meta.policy_voice_enabled then base
-    else
-      let voice_set = tool_name_set (keeper_voice_tool_names ()) in
-      List.filter (fun name -> not (StringSet.mem name voice_set)) base
-  in
   let candidate_names =
     dedupe_tool_names
-      (base_after_voice_policy
-       @ explicit_optional_candidate_tool_names meta
-       @ voice_tools_allowed_by_policy meta)
+      (base @ explicit_optional_candidate_tool_names meta)
   in
   let candidate_set = tool_name_set candidate_names in
   let allow_names =

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -15,14 +15,10 @@ type parsed_args = {
   mid_goal_opt : string option;
   long_goal_opt : string option;
   cascade_name_opt : string option;
-  policy_voice_enabled_opt : bool option;
   allowed_paths_opt : string list option;
   autoboot_enabled_opt : bool option;
   sandbox_profile_opt : sandbox_profile option;
   network_mode_opt : network_mode option;
-  voice_enabled_opt : bool option;
-  voice_channel_opt : string option;
-  voice_agent_id_opt : string option;
   mention_targets_in : string list;
   active_goal_ids_opt : string list option;
   max_context_override_opt : int option;
@@ -240,11 +236,7 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     let mid_goal_opt = parse_goal_horizon_opt args "mid_goal" in
     let long_goal_opt = parse_goal_horizon_opt args "long_goal" in
     let cascade_name_opt_res = parse_cascade_name_opt args in
-    let policy_voice_enabled_opt = get_bool_opt args "policy_voice_enabled" in
     let autoboot_enabled_opt = get_bool_opt args "autoboot_enabled" in
-    let voice_enabled_opt = get_bool_opt args "voice_enabled" in
-    let voice_channel_opt = get_string_opt args "voice_channel" in
-    let voice_agent_id_opt = get_string_opt args "voice_agent_id" in
     let mention_targets_in = get_string_list args "mention_targets" in
     let max_context_override_opt =
       let min_keeper_context = Keeper_config.min_keeper_context_tokens in
@@ -307,15 +299,11 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
       mid_goal_opt;
       long_goal_opt;
       cascade_name_opt;
-      policy_voice_enabled_opt;
       allowed_paths_opt;
       active_goal_ids_opt;
       autoboot_enabled_opt;
       sandbox_profile_opt;
       network_mode_opt;
-      voice_enabled_opt;
-      voice_channel_opt;
-      voice_agent_id_opt;
       mention_targets_in;
       max_context_override_opt;
       proactive_enabled_opt;

--- a/lib/keeper/keeper_turn_up_args.mli
+++ b/lib/keeper/keeper_turn_up_args.mli
@@ -17,14 +17,10 @@ type parsed_args =
   ; mid_goal_opt : string option
   ; long_goal_opt : string option
   ; cascade_name_opt : string option
-  ; policy_voice_enabled_opt : bool option
   ; allowed_paths_opt : string list option
   ; autoboot_enabled_opt : bool option
   ; sandbox_profile_opt : sandbox_profile option
   ; network_mode_opt : network_mode option
-  ; voice_enabled_opt : bool option
-  ; voice_channel_opt : string option
-  ; voice_agent_id_opt : string option
   ; mention_targets_in : string list
   ; active_goal_ids_opt : string list option
   ; max_context_override_opt : int option

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -43,12 +43,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
     first_some p.autoboot_enabled_opt p.profile_defaults.autoboot_enabled
     |> Option.value ~default:true
   in
-  let policy_voice_enabled =
-    first_some
-      p.policy_voice_enabled_opt
-      p.profile_defaults.policy_voice_enabled
-    |> Option.value ~default:false
-  in
   let allowed_paths =
     match p.allowed_paths_opt with
     | Some paths -> paths
@@ -90,17 +84,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
       ~sandbox_profile
       ~preferred:p.network_mode_opt
       ~fallback:p.profile_defaults.network_mode
-  in
-  let voice_enabled =
-    Option.value ~default:(default_voice_enabled_for p.name) p.voice_enabled_opt
-  in
-  let voice_channel =
-    p.voice_channel_opt
-    |> Option.map canonical_voice_channel
-    |> Option.value ~default:(default_voice_channel_for p.name)
-  in
-  let voice_agent_id =
-    Option.value ~default:(default_voice_agent_id_for p.name) p.voice_agent_id_opt
   in
   let mention_targets =
     resolve_mention_targets
@@ -469,7 +452,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         needs;
         desires;
         instructions;
-        policy_voice_enabled;
         sandbox_profile;
         sandbox_image = None;
         network_mode;
@@ -477,9 +459,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         tool_access;
         tool_preset_source = p.profile_defaults.tool_preset_source;
         tool_denylist;
-        voice_enabled;
-        voice_channel;
-        voice_agent_id;
         mention_targets;
         room_signal_prompt_enabled;
         joined_room_ids = [];
@@ -666,9 +645,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           ("desires", `String meta.desires);
           ("instructions", `String meta.instructions);
           ("cascade_name", `String (cascade_name_of_meta meta));
-          ("voice_enabled", `Bool meta.voice_enabled);
-          ("voice_channel", `String meta.voice_channel);
-          ("voice_agent_id", `String meta.voice_agent_id);
           ("social_model", `String meta.social_model);
           ("tool_access", tool_access_to_json meta.tool_access);
           ("tool_denylist",

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -84,12 +84,6 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
       p.long_goal_opt
     |> normalize_goal_horizon_text
   in
-  let policy_voice_enabled =
-    first_some
-      p.policy_voice_enabled_opt
-      (first_some (Some old.policy_voice_enabled) p.profile_defaults.policy_voice_enabled)
-    |> Option.value ~default:false
-  in
   let allowed_paths =
     Option.value ~default:old.allowed_paths p.allowed_paths_opt
   in
@@ -298,7 +292,6 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
           (if String.trim old.instructions <> "" then old.instructions
            else Option.value ~default:"" p.profile_defaults.instructions)
         p.instructions_opt;
-    policy_voice_enabled;
     allowed_paths;
     sandbox_profile;
     network_mode;
@@ -317,14 +310,6 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
            last_blocker = None;
          }
        else old.runtime);
-    voice_enabled =
-      Option.value ~default:old.voice_enabled p.voice_enabled_opt;
-    voice_channel =
-      (p.voice_channel_opt
-      |> Option.map canonical_voice_channel
-      |> Option.value ~default:old.voice_channel);
-    voice_agent_id =
-      Option.value ~default:old.voice_agent_id p.voice_agent_id_opt;
     mention_targets;
     room_signal_prompt_enabled;
     work_discovery_enabled =

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -286,7 +286,6 @@ type keeper_meta = {
   needs: string;
   desires: string;
   instructions: string;
-  policy_voice_enabled: bool;
   sandbox_profile: sandbox_profile;
   sandbox_image: string option;
   network_mode: network_mode;
@@ -303,9 +302,6 @@ type keeper_meta = {
   auto_handoff: bool;
   handoff_threshold: float;
   handoff_cooldown_sec: int;
-  voice_enabled: bool;
-  voice_channel: string;
-  voice_agent_id: string;
   created_at: string;
   updated_at: string;
   max_context_override: int option;

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -99,30 +99,6 @@ let normalize_tool_preset_raw raw =
 
 let first_some = Dashboard_utils.first_some
 
-let canonical_voice_channel = function
-  | "voice_only" -> "voice_only"
-  | "text_only" -> "text_only"
-  | _ -> "voice_text"
-
-let default_voice_enabled_for _name =
-  (* Pure tests may parse keeper metadata without an Eio context. In that
-     case, treat voice as disabled rather than failing metadata decoding. *)
-  try
-    match Voice_config.load () with
-    | Ok _ -> true
-    | Error _ -> false
-  with
-  | Effect.Unhandled _ -> false
-  | Sys_error _ -> false
-  | Unix.Unix_error _ -> false
-  | _ -> false
-
-let default_voice_channel_for name =
-  if default_voice_enabled_for name then "voice_text" else "text_only"
-
-let default_voice_agent_id_for name =
-  if default_voice_enabled_for name then name else ""
-
 let room_seq_map_to_json (items : (string * int) list) : Yojson.Safe.t =
   `Assoc (List.map (fun (room_id, seq) -> (room_id, `Int seq)) items)
 
@@ -441,7 +417,6 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         needs = str "needs";
         desires = str "desires";
         instructions = str "instructions";
-        policy_voice_enabled = bool_ "policy_voice_enabled";
         autoboot_enabled = bool_ "autoboot_enabled";
         mention_targets = strs "mention_targets";
         proactive_enabled = bool_ "proactive_enabled";
@@ -508,7 +483,6 @@ let parsed_field_key_names =
   ; "needs"
   ; "desires"
   ; "instructions"
-  ; "policy_voice_enabled"
   ; "autoboot_enabled"
   ; "mention_targets"
   ; "proactive_enabled"
@@ -562,7 +536,6 @@ let canonical_keeper_toml_key_names =
   ; "needs"
   ; "desires"
   ; "instructions"
-  ; "policy_voice_enabled"
   ; "autoboot_enabled"
   ; "mention_targets"
   ; "proactive_enabled"
@@ -708,8 +681,6 @@ let merge_keeper_profile_defaults
     needs = prefer overlay.needs base.needs;
     desires = prefer overlay.desires base.desires;
     instructions = prefer overlay.instructions base.instructions;
-    policy_voice_enabled =
-      prefer overlay.policy_voice_enabled base.policy_voice_enabled;
     autoboot_enabled = prefer overlay.autoboot_enabled base.autoboot_enabled;
     mention_targets =
       merge_string_list ~base:base.mention_targets overlay.mention_targets;
@@ -913,10 +884,6 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                 needs = Safe_ops.json_string_opt "needs" keeper_json;
                 desires = Safe_ops.json_string_opt "desires" keeper_json;
                 instructions = Safe_ops.json_string_opt "instructions" keeper_json;
-                policy_voice_enabled =
-                  (match Yojson.Safe.Util.member "policy_voice_enabled" keeper_json with
-                  | `Bool flag -> Some flag
-                  | _ -> None);
                 autoboot_enabled = None;
                 mention_targets = Safe_ops.json_string_list "mention_targets" keeper_json;
                 proactive_enabled = Safe_ops.json_bool_opt "proactive_enabled" keeper_json;

--- a/lib/keeper/keeper_types_profile.mli
+++ b/lib/keeper/keeper_types_profile.mli
@@ -31,10 +31,6 @@ val lower_string_list_opt : string list -> string list option
 val valid_tool_preset_raw_strings : string list
 val normalize_tool_preset_raw : string -> string option
 val first_some : 'a option -> 'a option -> 'a option
-val canonical_voice_channel : string -> string
-val default_voice_enabled_for : string -> bool
-val default_voice_channel_for : string -> string
-val default_voice_agent_id_for : string -> string
 val room_seq_map_to_json : (string * int) list -> Yojson.Safe.t
 val room_seq_map_of_json : Yojson.Safe.t -> (string * int) list
 

--- a/lib/keeper/keeper_types_profile_defaults.ml
+++ b/lib/keeper/keeper_types_profile_defaults.ml
@@ -15,7 +15,6 @@ type keeper_profile_defaults = {
   needs : string option;
   desires : string option;
   instructions : string option;
-  policy_voice_enabled : bool option;
   autoboot_enabled : bool option;
   mention_targets : string list;
   proactive_enabled : bool option;
@@ -82,7 +81,6 @@ let empty_keeper_profile_defaults =
     needs = None;
     desires = None;
     instructions = None;
-    policy_voice_enabled = None;
     autoboot_enabled = None;
     mention_targets = [];
     proactive_enabled = None;

--- a/lib/keeper/keeper_types_profile_defaults.mli
+++ b/lib/keeper/keeper_types_profile_defaults.mli
@@ -17,7 +17,6 @@ type keeper_profile_defaults = {
   needs : string option;
   desires : string option;
   instructions : string option;
-  policy_voice_enabled : bool option;
   autoboot_enabled : bool option;
   mention_targets : string list;
   proactive_enabled : bool option;


### PR DESCRIPTION
## Summary

Implementation of RFC-0164 (merged in #18084). Deletes the redundant keeper-side voice gate that duplicated `tool_policy.toml [groups.voice]` and miscategorized client-intercepted voice tools as provider-required.

**Net diff: -241 / +15 lines across 19 files.**

## What changes

### Fields removed from `keeper_meta`

- `voice_enabled : bool`
- `voice_channel : string` (sentinel `"text_only"`/`"voice_text"`)
- `voice_agent_id : string`
- `policy_voice_enabled : bool`

### Helpers removed from `keeper_types_profile`

- `canonical_voice_channel`
- `default_voice_enabled_for`
- `default_voice_channel_for`
- `default_voice_agent_id_for`

### Gate logic removed from `keeper_tool_policy`

- `voice_tools_allowed_by_policy` (the flag-gated wrapper)
- Conditional voice tool inclusion/exclusion in `tool_policy_of_meta`
- Conditional voice tool filtering in `tool_access_lookup_of_meta`
- Hardcoded fallback list in `keeper_voice_tool_names` (tool_policy.toml is now sole SSOT)

### MCP surface

`masc_keeper_up` tool schema: `voice_enabled` / `policy_voice_enabled` / `voice_channel` / `voice_agent_id` parameters removed (keeper_schema.ml).

### Persistence

JSON read path silently ignores unknown fields (existing behavior). Persisted keeper records on disk with the old fields parse unchanged.

### Runtime config (separate from this repo)

`~/me/.masc/voice_config.json` cleaned: `local_playback` and `session.endpoints` blocks removed (done as part of RFC §3 deletion).

## Invariants verified (RFC §5)

- ✅ `rg "voice_enabled|voice_channel|voice_agent_id|policy_voice_enabled|default_voice_enabled_for|canonical_voice_channel" lib/ bin/` → **0 hits**
- ✅ `dune build --root . lib/keeper/` clean
- ⚠️ Full `dune build` has pre-existing main-branch errors unrelated to this PR (`Keeper_meta_json_scrub`, `Pr.empty`, `Path_scope`, etc.); none are introduced by this change

## Files changed (19)

```
lib/keeper/keeper_exec_persona.ml            | 16 +---------
lib/keeper/keeper_meta_contract.ml           |  7 +----
lib/keeper/keeper_meta_contract.mli          |  5 ---
lib/keeper/keeper_meta_json.ml               | 10 +-----
lib/keeper/keeper_meta_json_parse.ml         | 36 ++-------------------
lib/keeper/keeper_meta_json_parse.mli        |  6 +---
lib/keeper/keeper_persona_authoring.ml       |  8 +----
lib/keeper/keeper_runtime.ml                 |  6 +---
lib/keeper/keeper_schema.ml                  | 16 ----------
lib/keeper/keeper_tool_policy.ml             | 47 +++++-----------------------
lib/keeper/keeper_turn_up_args.ml            | 12 -------
lib/keeper/keeper_turn_up_args.mli           |  4 ---
lib/keeper/keeper_turn_up_create.ml          | 24 --------------
lib/keeper/keeper_turn_up_update.ml          | 15 ---------
lib/keeper/keeper_types.mli                  |  4 ---
lib/keeper/keeper_types_profile.ml           | 33 -------------------
lib/keeper/keeper_types_profile.mli          |  4 ---
lib/keeper/keeper_types_profile_defaults.ml  |  2 --
lib/keeper/keeper_types_profile_defaults.mli |  1 -
```

## Test plan

- [ ] `dune build` (subject to pre-existing main-branch errors being resolved upstream)
- [ ] `dune build @runtest`
- [ ] E2E (RFC §6.2): sangsu emits `keeper_voice_speak` during a normal turn, ElevenLabs char counter advances, audible output via afplay
- [ ] Non-voice keepers (albini, rondo, garnet, echo) unaffected

## Related

- RFC-0164 (merged: #18084)
- RFC-0080 (Tool registry SSOT, Implemented)
- RFC-0088 (Counter-as-Fix umbrella)
- RFC-0157 (Cascade pre-turn required-tool filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)