### PR TITLE
fix(keeper): inline pr_metrics into hooks_oas, restore egress_audit (PRs #18011/#18020)

### DIFF
--- a/lib/keeper/keeper_egress_audit.ml
+++ b/lib/keeper/keeper_egress_audit.ml
@@ -1,0 +1,116 @@
+(** Boot-time audit for keeper egress policy file placement.
+
+    Leak 11 (2026-04-27): keeper "executor" had its [egress.json] at the
+    host-direct path [playground/<name>/egress.json] while the docker
+    keeper code resolved [egress_policy_path] to
+    [playground/docker/<name>/egress.json].  The file at the wrong
+    location was never read; the lookup fail-closed for 24h+ and every
+    URL command surfaced as [egress_blocked, allowed=[]].
+
+    This module does no I/O writes — it inspects the file system and
+    classifies each keeper's policy file state.  Callers (boot hook,
+    CLI verification, tests) decide whether to log, fail, or repair.
+
+    Status taxonomy ─
+
+    [Ok_present] — expected path exists, no follow-up needed.
+
+    [Missing_at_expected] — expected path is absent and there is no
+    drifted copy elsewhere.  Operator should seed the file (egress
+    policy is fail-closed without it).
+
+    [Stale_orphan] — expected path is absent but a host-direct copy
+    exists.  Indicates the same drift class that produced Leak 11:
+    the file was seeded under the wrong sandbox_profile assumption.
+    Operator should move (or copy + delete the orphan).
+
+    Local keepers always treat [playground/<name>/] as the canonical
+    location, so the [Stale_orphan] class only applies to Docker
+    keepers. *)
+
+module Coord = Coord
+module Keeper_types = Keeper_types
+
+type audit_status =
+  | Ok_present
+  | Missing_at_expected of { expected_path : string }
+  | Stale_orphan of { expected_path : string; orphan_path : string }
+
+type result = {
+  agent_name : string;
+  keeper_name : string;
+  sandbox_profile : Keeper_types.sandbox_profile;
+  status : audit_status;
+}
+
+let host_direct_egress_path ~(config : Coord.config)
+    ~(meta : Keeper_types.keeper_meta) =
+  (* The pre-Leak-11 location used by host (Local) keepers and by the
+     external setup script that seeded executor's file at the wrong
+     branch.  We compute it explicitly so the audit can detect a
+     stale orphan even when the docker-path file is absent. *)
+  Filename.concat
+    (Filename.concat config.base_path
+       (Filename.concat ".masc/playground" meta.name))
+    "egress.json"
+
+let audit_one ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta) =
+  let expected = Keeper_shell_docker.egress_policy_path ~config ~meta in
+  let status =
+    match meta.sandbox_profile with
+    | Keeper_types.Local ->
+        if Sys.file_exists expected then Ok_present
+        else Missing_at_expected { expected_path = expected }
+    | Keeper_types.Docker ->
+        if Sys.file_exists expected then Ok_present
+        else
+          let orphan = host_direct_egress_path ~config ~meta in
+          if Sys.file_exists orphan then
+            Stale_orphan { expected_path = expected; orphan_path = orphan }
+          else Missing_at_expected { expected_path = expected }
+  in
+  {
+    agent_name = meta.agent_name;
+    keeper_name = meta.name;
+    sandbox_profile = meta.sandbox_profile;
+    status;
+  }
+
+let audit_all ~(config : Coord.config) ~(metas : Keeper_types.keeper_meta list)
+    =
+  List.map (fun meta -> audit_one ~config ~meta) metas
+
+(** A grep-friendly one-line summary; the boot hook emits this so
+    operators can locate drifted keepers from the system log without
+    reaching for Prometheus. *)
+let format_log_line (r : result) =
+  let profile = Keeper_types.sandbox_profile_to_string r.sandbox_profile in
+  match r.status with
+  | Ok_present ->
+      Printf.sprintf "[egress_audit:ok] keeper=%s profile=%s" r.keeper_name
+        profile
+  | Missing_at_expected { expected_path } ->
+      Printf.sprintf
+        "[egress_audit:missing] keeper=%s profile=%s expected=%s"
+        r.keeper_name profile expected_path
+  | Stale_orphan { expected_path; orphan_path } ->
+      Printf.sprintf
+        "[egress_audit:stale_orphan] keeper=%s profile=%s expected=%s \
+         orphan_at=%s"
+        r.keeper_name profile expected_path orphan_path
+
+let inactive_missing_reason (meta : Keeper_types.keeper_meta) =
+  if meta.paused then Some "paused"
+  else if not meta.autoboot_enabled then Some "autoboot_disabled"
+  else None
+
+(** Partition results by severity.  The boot hook can then route
+    [Ok] at debug level and [missing]/[stale] at warn. *)
+let partition (results : result list) =
+  List.fold_left
+    (fun (oks, missings, orphans) r ->
+      match r.status with
+      | Ok_present -> (r :: oks, missings, orphans)
+      | Missing_at_expected _ -> (oks, r :: missings, orphans)
+      | Stale_orphan _ -> (oks, missings, r :: orphans))
+    ([], [], []) results

--- a/lib/keeper/keeper_egress_audit.mli
+++ b/lib/keeper/keeper_egress_audit.mli
@@ -1,0 +1,45 @@
+(** Boot-time audit for keeper egress policy file placement (Leak 11).
+
+    Inspects the file system without writes; classifies each keeper's
+    [egress.json] location.  Boot hooks, tests, and ops tooling
+    consume the structured results to decide on logging, alerting,
+    or repair. *)
+
+type audit_status =
+  | Ok_present
+  | Missing_at_expected of { expected_path : string }
+  | Stale_orphan of { expected_path : string; orphan_path : string }
+
+type result = {
+  agent_name : string;
+  keeper_name : string;
+  sandbox_profile : Keeper_types.sandbox_profile;
+  status : audit_status;
+}
+
+val audit_one :
+  config:Coord.config -> meta:Keeper_types.keeper_meta -> result
+(** Audit a single keeper's egress policy file location. *)
+
+val audit_all :
+  config:Coord.config ->
+  metas:Keeper_types.keeper_meta list ->
+  result list
+(** Audit every keeper meta supplied; pure mapping over [audit_one]. *)
+
+val host_direct_egress_path :
+  config:Coord.config -> meta:Keeper_types.keeper_meta -> string
+(** Pre-Leak-11 host-direct location: [playground/<name>/egress.json].
+    Exposed so boot hooks and tests can construct the same path the
+    audit uses for [Stale_orphan] detection. *)
+
+val format_log_line : result -> string
+(** Grep-friendly one-line summary tagged
+    [[egress_audit:ok|missing|stale_orphan]]. *)
+
+val inactive_missing_reason : Keeper_types.keeper_meta -> string option
+(** [Some reason] when a missing egress policy should not page operators
+    because the keeper is intentionally inactive. *)
+
+val partition : result list -> result list * result list * result list
+(** Split into [(ok, missing, stale_orphan)] in input order. *)

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -351,6 +351,378 @@ let record_pre_tool_gate_attempt
         acc
         entry
 
+
+(* PR action metric helpers. Inlined from former [Keeper_hooks_oas_pr_metrics]
+   (deleted) — this is the only production consumer, plus its own tests
+   reach these through the parent module surface. *)
+
+
+open Keeper_hooks_oas_output_json
+
+let pr_review_action_metric_event_of_tool_io
+    ~route_via_fallback
+    ~(tool_name : string)
+    ~(input : Yojson.Safe.t)
+    ~(output_text : string)
+    ~(transport_success : bool) =
+  match tool_name with
+  | "keeper_pr_review_comment" ->
+      let output_json = output_json_opt ~surface:"pr_review_action" output_text in
+      let route_via =
+        first_some (Option.bind output_json route_via_of_json)
+          route_via_fallback
+      in
+      let action =
+        match output_json with
+        | Some json -> Safe_ops.json_string_opt "event" json
+        | None -> None
+      in
+      let action =
+        match action with
+        | Some value -> Some value
+        | None -> Safe_ops.json_string_opt "event" input
+      in
+      let success =
+        output_success ~transport_success output_json
+      in
+      let credential = Option.bind output_json (assoc_json_opt "credential") in
+      let identity_attestation =
+        Option.bind output_json (assoc_json_opt "identity_attestation")
+      in
+      Option.map
+        (fun action ->
+           {
+             action;
+             pr_number =
+               first_some
+                 (match output_json with
+                  | Some json -> json_int_opt "pr_number" json
+                  | None -> None)
+                 (json_int_opt "pr_number" input);
+             comment_id = None;
+             success;
+             route_via;
+             credential;
+             identity_attestation;
+           })
+        (Option.bind action normalize_pr_review_action)
+  | "keeper_pr_review_reply" ->
+      let output_json = output_json_opt ~surface:"pr_review_action" output_text in
+      let route_via =
+        first_some (Option.bind output_json route_via_of_json)
+          route_via_fallback
+      in
+      let success =
+        output_success ~transport_success output_json
+      in
+      let credential = Option.bind output_json (assoc_json_opt "credential") in
+      let identity_attestation =
+        Option.bind output_json (assoc_json_opt "identity_attestation")
+      in
+      Some
+        {
+          action = "REPLY";
+          pr_number =
+            first_some
+              (match output_json with
+               | Some json -> json_int_opt "pr_number" json
+               | None -> None)
+              (json_int_opt "pr_number" input);
+          comment_id =
+            first_some
+              (match output_json with
+               | Some json -> json_int_opt "comment_id" json
+               | None -> None)
+              (json_int_opt "comment_id" input);
+          success;
+          route_via;
+          credential;
+          identity_attestation;
+        }
+  | "keeper_shell" ->
+      let output_json = output_json_opt ~surface:"pr_review_action" output_text in
+      let route_via =
+        first_some (Option.bind output_json route_via_of_json)
+          route_via_fallback
+      in
+      let success =
+        output_success ~transport_success output_json
+      in
+      command_candidates_of_tool_io ~tool_name ~input ~output_json
+      |> List.find_map gh_pr_review_action_of_command
+      |> Option.map (fun (action, pr_number) ->
+           {
+             action;
+             pr_number;
+             comment_id = None;
+             success;
+             route_via;
+             credential = None;
+             identity_attestation = None;
+           })
+  | _ -> None
+
+let pr_work_action_of_git_action raw =
+  match String.trim raw |> String.lowercase_ascii with
+  | "add" -> Some "GIT_ADD"
+  | "commit" -> Some "GIT_COMMIT"
+  | "push" -> Some "GIT_PUSH"
+  | _ -> None
+
+let pr_work_actions_of_git_segment segment =
+  match Masc_exec_bash_parser.Bash.parse_string segment with
+  | Masc_exec.Parsed.Parsed (Masc_exec.Shell_ir.Simple simple)
+    when String.equal
+           (Masc_exec.Bin.to_string simple.bin |> String.lowercase_ascii)
+           "git" ->
+      (match simple.args with
+       | Masc_exec.Shell_ir.Lit (action, _) :: _ ->
+           pr_work_action_of_git_action action |> Option.to_list
+       | _ -> [])
+  | _ ->
+      let lower = String.trim segment |> String.lowercase_ascii in
+      let starts_with_word prefix =
+        String.equal lower prefix
+        || (String.length lower > String.length prefix
+            && String.starts_with ~prefix:(prefix ^ " ") lower)
+      in
+      if starts_with_word "git push" then [ "GIT_PUSH" ]
+      else if starts_with_word "git commit" then [ "GIT_COMMIT" ]
+      else if starts_with_word "git add" then [ "GIT_ADD" ]
+      else []
+
+let pr_work_actions_of_gh_segment segment =
+  match gh_argv_of_segment segment with
+  | Some (subcommand :: action :: _)
+    when String.equal (String.lowercase_ascii subcommand) "pr"
+         && String.equal (String.lowercase_ascii action) "create" ->
+      [ "PR_CREATE" ]
+  | _ -> []
+
+let pr_work_actions_of_command command =
+  Masc_exec_bash_parser.Bash_words.top_level_command_segments command
+  |> List.concat_map (fun (unconditional, segment) ->
+       (* Shell conditionals can skip later segments at runtime.  Without
+          per-segment exit data, count only top-level segments that are
+          unconditionally reached. *)
+       if not unconditional then []
+       else
+         match pr_work_actions_of_gh_segment segment with
+         | [] -> pr_work_actions_of_git_segment segment
+         | actions -> actions)
+
+let is_pr_work_action_tool_name = function
+  | "masc_code_git"
+  | "keeper_shell"
+  | "keeper_bash"
+  | "masc_code_shell" -> true
+  | _ -> false
+
+let pr_work_action_metric_events_of_tool_io
+    ~route_via_fallback
+    ~(tool_name : string)
+    ~(input : Yojson.Safe.t)
+    ~(output_text : string)
+    ~(transport_success : bool) =
+  if not (is_pr_work_action_tool_name tool_name) then []
+  else
+  let observe_json_failure =
+    match tool_name with
+    | "keeper_shell" | "keeper_bash" | "masc_code_shell" -> false
+    | _ -> true
+  in
+  let output_json =
+    output_json_opt ~observe_failure:observe_json_failure
+      ~surface:"pr_work_action" output_text
+  in
+  let route_via =
+    first_some (Option.bind output_json route_via_of_json)
+      route_via_fallback
+  in
+  let success = output_success ~transport_success output_json in
+  match tool_name with
+  | "masc_code_git" ->
+      let action =
+        match output_json with
+        | Some json -> Safe_ops.json_string_opt "action" json
+        | None -> None
+      in
+      let action =
+        match action with
+        | Some value -> Some value
+        | None -> Safe_ops.json_string_opt "action" input
+      in
+      (match Option.bind action pr_work_action_of_git_action with
+       | None -> []
+       | Some work_action ->
+           [
+             {
+               work_action;
+               work_source = "masc_code_git";
+               work_ref = None;
+               pr_url = None;
+               command = None;
+               success;
+               route_via;
+             };
+           ])
+  | "keeper_shell" | "keeper_bash" | "masc_code_shell" ->
+      command_candidates_of_tool_io ~tool_name ~input ~output_json
+      |> List.concat_map (fun command ->
+           pr_work_actions_of_command command
+           |> List.map (fun work_action ->
+                ( command,
+                  {
+                    work_action;
+                    work_source = tool_name;
+                    work_ref = None;
+                    pr_url = None;
+                    command = Some command;
+                    success;
+                    route_via;
+                  } )))
+      |> List.fold_left
+           (fun (seen, events) (_command, event) ->
+              let key = event.work_action in
+              if List.mem key seen then (seen, events)
+              else (key :: seen, events @ [ event ]))
+           ([], [])
+      |> snd
+  | _ -> []
+
+let append_pr_review_action_metric
+    ~(config : Coord.config)
+    ~(meta : Keeper_types.keeper_meta)
+    ~(generation : int)
+    ~(tool_name : string)
+    ~(input : Yojson.Safe.t)
+    ~(output_text : string)
+    ~(transport_success : bool)
+    ~(duration_ms : float)
+    () =
+  let route_via_fallback =
+    match meta.sandbox_profile, tool_name with
+    | Docker, ("keeper_pr_review_comment" | "keeper_pr_review_reply") ->
+        Some "brokered"
+    | Docker, "keeper_shell" ->
+        Some "docker"
+    | _ -> None
+  in
+  match
+    pr_review_action_metric_event_of_tool_io
+      ~route_via_fallback ~tool_name ~input ~output_text ~transport_success
+  with
+  | None -> ()
+  | Some event ->
+      let now = Time_compat.now () in
+      let store = Keeper_types.keeper_pr_action_metrics_store config meta.name in
+      let route_fields =
+        match event.route_via with
+        | None -> []
+        | Some via -> [(key_via, `String via); (key_route_via, `String via)]
+      in
+      let identity_fields =
+        []
+        |> (fun fields ->
+             match event.credential with
+             | None -> fields
+             | Some credential -> ("credential", credential) :: fields)
+        |> (fun fields ->
+             match event.identity_attestation with
+             | None -> fields
+             | Some attestation -> ("identity_attestation", attestation) :: fields)
+        |> List.rev
+      in
+      let snapshot =
+        `Assoc
+          ([
+             (key_ts, `String (Masc_domain.iso8601_of_unix_seconds now));
+             (key_ts_unix, `Float now);
+             (key_channel, `String "tool_event");
+             (key_metric_event, `String "keeper_pr_review_action");
+             (key_name, `String meta.name);
+             (key_agent_name, `String meta.agent_name);
+             ( "trace_id",
+               `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id) );
+             (key_generation, `Int generation);
+             (key_tool_name, `String tool_name);
+             (key_pr_review_action, `String event.action);
+             (key_pr_review_action_success, `Bool event.success);
+             (key_tool_call_count, `Int 0);
+             (key_tools_used, `List []);
+             ("pr_number", Json_util.int_opt_to_json event.pr_number);
+             ("comment_id", Json_util.int_opt_to_json event.comment_id);
+             (key_duration_ms, `Float duration_ms);
+           ]
+           @ route_fields
+           @ identity_fields)
+      in
+      Dated_jsonl.append store (Inference_utils.sanitize_json_utf8 snapshot)
+
+let append_pr_work_action_metrics
+    ~(config : Coord.config)
+    ~(meta : Keeper_types.keeper_meta)
+    ~(generation : int)
+    ~(tool_name : string)
+    ~(input : Yojson.Safe.t)
+    ~(output_text : string)
+    ~(transport_success : bool)
+    ~(duration_ms : float)
+    () =
+  let route_via_fallback =
+    match meta.sandbox_profile, tool_name with
+    | Docker, "keeper_shell" -> Some "docker"
+    | Docker, ("keeper_bash" | "masc_code_shell" | "masc_code_git") ->
+        Some "docker"
+    | _ -> None
+  in
+  let events =
+    pr_work_action_metric_events_of_tool_io
+      ~route_via_fallback ~tool_name ~input ~output_text ~transport_success
+  in
+  match events with
+  | [] -> ()
+  | _ ->
+      let store = Keeper_types.keeper_pr_action_metrics_store config meta.name in
+      List.iter
+        (fun event ->
+           let now = Time_compat.now () in
+           let route_fields =
+             match event.route_via with
+             | None -> []
+             | Some via -> [(key_via, `String via); (key_route_via, `String via)]
+           in
+           let snapshot =
+             `Assoc
+               ([
+                  (key_ts, `String (Masc_domain.iso8601_of_unix_seconds now));
+                  (key_ts_unix, `Float now);
+                  (key_channel, `String "tool_event");
+                  (key_metric_event, `String "keeper_pr_work_action");
+                  (key_name, `String meta.name);
+                  (key_agent_name, `String meta.agent_name);
+                  ( "trace_id",
+                    `String
+                      (Keeper_id.Trace_id.to_string meta.runtime.trace_id) );
+                  (key_generation, `Int generation);
+                  (key_tool_name, `String tool_name);
+                  (key_pr_work_action, `String event.work_action);
+                  (key_pr_work_action_source, `String event.work_source);
+                  (key_pr_work_action_success, `Bool event.success);
+                  ( "pr_work_ref",
+                    Json_util.string_opt_to_json event.work_ref );
+                  ("pr_url", Json_util.string_opt_to_json event.pr_url);
+                  ( "pr_work_command",
+                    Json_util.string_opt_to_json event.command );
+                  (key_tool_call_count, `Int 0);
+                  (key_tools_used, `List []);
+                  (key_duration_ms, `Float duration_ms);
+                ]
+                @ route_fields)
+           in
+           Dated_jsonl.append store
+             (Inference_utils.sanitize_json_utf8 snapshot))
+        events
 let make_hooks
     ~(config : Coord.config)
     ~(meta_ref : Keeper_types.keeper_meta ref)


### PR DESCRIPTION
## Motivation

두 dead-export PR 후속을 묶었습니다. mechanism이 다르고 right answer도 다르지만 `keeper_hooks_oas.ml`/`server_runtime_bootstrap.ml`의 same-chain blocker라 한 PR.

## `Keeper_hooks_oas_pr_metrics` — RADICAL inline

PR #18011이 dead라 주장하며 삭제했지만, 4개의 live caller가 keeper_hooks_oas.ml에 re-export alias로 숨어 있었습니다:

| Line | Caller |
|---|---|
| 588 | `append_pr_review_action_metric` |
| 613 | `append_pr_work_action_metrics` |
| `For_testing.pr_review_action_metric_event_of_tool_io` | testing surface |
| `For_testing.pr_work_action_metric_events_of_tool_io` | testing surface |

Caller 인벤토리: `rg "Keeper_hooks_oas_pr_metrics" lib/ test/` → keeper_hooks_oas.ml + 그 For_testing block만. 모듈 자체 doc도 명시: *"PR action metric helpers for [Keeper_hooks_oas]"*.

gate_attempt 케이스(#18086)와 동일한 single-consumer indirection. submodule 복구는 매번 audit이 놓칠 같은 indirection을 그대로 다시 만듭니다.

### Change
- 4 함수 + private helpers를 `keeper_hooks_oas.ml`로 inline (367 lines), gate_attempt 블록 바로 다음에 배치. caller 옆에 co-locate.
- `open Keeper_hooks_oas_output_json`은 inline site에 추가 (해당 submodule이 쓰던 import; 부모는 별도로 안 쓰므로 site-local이면 충분).
- `keeper_hooks_oas.mli` 변경 없음 — `For_testing`은 이미 *_of_tool_io 2개를 re-export 중이고, append_* 2개는 모두 keeper_hooks_oas.ml 내부 호출이라 mli export 불필요.
- `keeper_hooks_oas_pr_metrics.{ml,mli}` 부활시키지 않음 (PR #18011의 의도 유지, 단 call graph와 이제 정합).

## `Keeper_egress_audit` — CONSERVATIVE restore

PR #18020이 삭제. live caller는:
- `lib/server/server_runtime_bootstrap.ml:210` (production)
- `test/test_keeper_egress_audit.ml` (dedicated test)

call site가 *server* 코드 — keeper 내부가 아님. boot-time audit utility로 module boundary를 넘어 사용되고, 자체 test contract 보유. server_runtime_bootstrap에 inline하면 legitimate boot-time check의 위치가 어색해지고 test contract 손실.

### Change
restore verbatim (116 + 45 lines). 같은 pre-deletion content, 동작 변경 없음.

## 정책 분기

"single-consumer helper는 standalone submodule이면 안 된다" 와 "모든 deleted module을 inline해야 한다"는 다릅니다. 분기 기준은 *어디서 함수에 도달하는가*:

- 모든 caller가 parent keeper module 안 → submodule = 순수 indirection, **inline**.
- distinct architectural boundary 간 caller (server / test / 다른 lib) → legitimate shared module, **restore**.

## 검증

- `dune build --root .` 출력에서 pr_metrics 관련 unbound 4건 + Keeper_egress_audit 관련 1건 모두 사라짐.
- 잔존 빌드 에러(`Path_scope`, `Keeper_context_core_history`의 `Message_json` 중복정의 등)는 본 PR과 무관.

## RFC

RFC-WAIVED: 533-line addition. 372 lines는 single-consumer submodule을 caller 옆으로 inline(behaviour 보존), 161 lines는 multi-consumer boot-time module restore. credential/identity/sandbox surface 변경 없음.

Builds on top of `f9cff38a4` (#18086).
