### PR TITLE
fix(lib): drop orphan mli decls and restore live exports (PRs #18015, #18026)

### DIFF
--- a/lib/exec_policy.ml
+++ b/lib/exec_policy.ml
@@ -849,7 +849,6 @@ let is_git_branch_switch = Mutation_classifier.is_git_branch_switch
 let is_destructive_bash_operation = Mutation_classifier.is_destructive_bash_operation
 let flat_stage_words = Mutation_classifier.flat_stage_words
 let stage_words_of_string = Mutation_classifier.stage_words_of_string
-let stage_words_of_string_result = Mutation_classifier.stage_words_of_string_result
 
 let sanitize_command_for_log = Log_sanitize.sanitize_command_for_log
 let truncate_for_log = Log_sanitize.truncate_for_log

--- a/lib/exec_policy.mli
+++ b/lib/exec_policy.mli
@@ -81,11 +81,6 @@ val flat_stage_words : Masc_exec.Shell_ir.t -> string list
     Callers with [Shell_ir.t] should use {!flat_stage_words}. *)
 val stage_words_of_string : string -> string list
 
-(** RFC-0160 S6b: Result-shaped variant preserving parse-failure signal
-    for callers that route on failure (log sanitizer's sensitive-marker
-    fallback). *)
-val stage_words_of_string_result : string -> (string list, unit) result
-
 val sanitize_command_for_log : string -> string
 val truncate_for_log : ?max_len:int -> string -> string
 

--- a/lib/keeper/keeper_context_core_history.ml
+++ b/lib/keeper/keeper_context_core_history.ml
@@ -3,7 +3,11 @@
 open Keeper_types
 
 module StringSet = Set.Make (String)
-module Message_json = Keeper_context_core_message_json
+
+(* Note: this module is `include`d into Keeper_context_core which already
+   exposes `module Message_json = Keeper_context_core_message_json`. Avoid
+   re-declaring the alias here to prevent a duplicate-definition error at
+   the include site; reference the underlying module qualified instead. *)
 
 type history_migration_stats =
   { moved_lines : int
@@ -62,7 +66,7 @@ let classify_history_jsonl_line (line : string) : history_line_action option =
       | Some raw -> String.trim raw
       | None -> ""
     in
-    let content = String.trim (Message_json.text_of_history_jsonl_json json) in
+    let content = String.trim (Keeper_context_core_message_json.text_of_history_jsonl_json json) in
     Some (classify_history_entry ~source ~content)
   with
   | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None
@@ -216,7 +220,7 @@ let persist_message ?source session msg =
     let path = history_path_for_source ~session_dir:session.session_dir ~source in
     let now_ts = Time_compat.now () in
     let payload =
-      match Message_json.message_to_json msg with
+      match Keeper_context_core_message_json.message_to_json msg with
       | `Assoc fields ->
           let fields =
             match source with

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -168,3 +168,8 @@ val summarize_post_commit_failure :
   kind:Keeper_registry.ambiguous_partial_commit_kind ->
   Agent_sdk.Error.sdk_error ->
   string
+
+val is_provider_timeout_error : Agent_sdk.Error.sdk_error -> bool
+(** True when [err] is a provider-timeout class failure (deadline,
+    cascade timeout, budget retry). Live caller:
+    [keeper_unified_turn.ml] degraded-retry classification. *)

--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -313,7 +313,7 @@ let cleanup_oneshot_container ~container_name =
     Log.Keeper.warn
       "docker oneshot cleanup failed for %s (status=%s, output=%s)"
       container_name
-      (docker_exec_status_label status)
+      (Keeper_shell_docker_exec_failure.docker_exec_status_label status)
       (Exec_policy.truncate_for_log output)
 ;;
 

--- a/lib/keeper/keeper_shell_docker.mli
+++ b/lib/keeper/keeper_shell_docker.mli
@@ -5,10 +5,6 @@
     invocation. Pure infrastructure; generic command-shape policy lives
     in [Keeper_shell_command_semantics]. *)
 
-(** Diagnostic label for a [Unix.process_status]:
-    [exit=N] / [signal=N] / [stopped=N]. *)
-val docker_exec_status_label : Unix.process_status -> string
-
 (** Build a structured failure message used by docker exec
     diagnostics, emphasising the exit/signal status and (when
     blank) flagging empty output explicitly. *)


### PR DESCRIPTION
## Motivation

4개의 작은 mli/ml drift cleanup을 묶었습니다. dead-export sweep의 1차 fix가 머지된 후 드러난 잔존 false-negative들. 모두 2026-05-23 sweep의 동일 anti-pattern (audit이 facade/alias를 못 봄)의 가벼운 변형.

## 4 fixes

### 1. `lib/exec_policy.{ml,mli}` — RADICAL (양쪽 모두 삭제)

`val stage_words_of_string_result`와 그 `let` re-export를 둘 다 삭제.

- 외부 caller 0: `lib/exec_policy_log_sanitize.ml:81`이 `Exec_policy_mutation_classifier.stage_words_of_string_result`를 직접 호출. `Exec_policy.stage_words_of_string_result` 사용처 없음.
- PR #18067에서 build 복구용으로 .ml line을 복원했지만, 외부 caller가 없는 indirection을 유지하는 건 RFC-0088 (Counter-as-Fix) 회피 원칙에도 어긋남. 1차 fix는 mli↔ml 대칭을 위해 .ml만 복구했지만, radical은 양쪽 다 삭제.

### 2. `lib/keeper/keeper_shell_docker.{ml,mli}` — qualified caller + drop orphan mli

PR #18015 (`remove dead-export .mli for Keeper_shell_docker_exec_failure`)가 `docker_exec_status_label`을 sibling `keeper_shell_docker_exec_failure` 모듈로 옮겼지만:
- `.mli`에 val 그대로 남아 있음 (orphan)
- line 316 caller가 unqualified로 호출 중

수정: caller를 `Keeper_shell_docker_exec_failure.docker_exec_status_label`로 qualify + .mli orphan val 삭제.

### 3. `lib/keeper/keeper_context_core_history.ml` — duplicate alias drop

`Error: Multiple definition of the module name Message_json` at `keeper_context_core.ml:445` (the `include` site).

`keeper_context_core_history.ml`와 `keeper_context_core.ml` 양쪽이 `module Message_json = Keeper_context_core_message_json` 선언 → `include`가 둘을 같은 scope로 collapse → 충돌.

수정: history.ml에서 중복 alias 제거 + 내부 2 use site를 `Keeper_context_core_message_json.xxx`로 qualify.

### 4. `lib/keeper/keeper_error_classify.mli` — restore live val

`val is_provider_timeout_error` 복구. 

- .ml의 line 190에 함수 본체 그대로 살아있음
- live caller: `keeper_unified_turn.ml:1424` via `module EC = Keeper_error_classify` alias
- 또 다른 alias-hidden caller case — 6번째 발생.

## 검증

- `dune build --root .` 출력에서 4건 unbound/duplicate 에러 모두 사라짐
- 잔존 빌드 에러 (`Path_scope`, ...)는 본 PR과 무관

## RFC

RFC-WAIVED: 13-line addition / 14-line deletion. 모두 mli↔ml drift 정리. 새 동작 없음. credential/identity/sandbox 변경 없음.
