### PR TITLE
fix(keeper): wrap provider-timeout if-then-else and restore is_receipt_lost_error mli val

### DIFF
--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -173,3 +173,9 @@ val is_provider_timeout_error : Agent_sdk.Error.sdk_error -> bool
 (** True when [err] is a provider-timeout class failure (deadline,
     cascade timeout, budget retry). Live caller:
     [keeper_unified_turn.ml] degraded-retry classification. *)
+
+val is_receipt_lost_error : Agent_sdk.Error.sdk_error -> bool
+(** True when [err] indicates a receipt-lost failure (the provider
+    confirmed completion but the response payload was lost in transit).
+    Live caller: [keeper_unified_turn.ml] failure-reason classification
+    via the [EC] alias. *)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1421,33 +1421,33 @@ let run_keeper_cycle
                     Keeper_metrics.metric_keeper_turns
                     ~labels:[ "keeper_name", meta.name; "outcome", "failure" ]
                     ();
-                  if EC.is_provider_timeout_error err
-                  then
-                    Keeper_turn_fsm.emit_transition
-                      ~keeper_name:meta.name
-                      ~turn_id:keeper_turn_id
-                      ~prev:Keeper_turn_fsm.Streaming
-                      (Keeper_turn_fsm.Cancelled
-                         Keeper_turn_fsm.Cancelled_provider_timeout)
-                  else
-                    let fsm_failure_reason =
-                      if EC.is_required_tool_contract_violation err
-                      then
-                        Keeper_turn_fsm.Failure_tool_contract_violation
-                          { reason_code = "require_tool_use" }
-                      else if EC.is_receipt_lost_error err
-                      then
-                        Keeper_turn_fsm.Failure_receipt_lost
-                          { primary_error = e_str; fallback_path = None }
-                      else
-                        Keeper_turn_fsm.Failure_provider_error
-                          { kind = sdk_error_kind err; detail = short_preview e_str }
-                    in
-                    Keeper_turn_fsm.emit_transition
-                      ~keeper_name:meta.name
-                      ~turn_id:keeper_turn_id
-                      ~prev:Keeper_turn_fsm.Streaming
-                      (Keeper_turn_fsm.Failed fsm_failure_reason);
+                  (if EC.is_provider_timeout_error err
+                   then
+                     Keeper_turn_fsm.emit_transition
+                       ~keeper_name:meta.name
+                       ~turn_id:keeper_turn_id
+                       ~prev:Keeper_turn_fsm.Streaming
+                       (Keeper_turn_fsm.Cancelled
+                          Keeper_turn_fsm.Cancelled_provider_timeout)
+                   else
+                     let fsm_failure_reason =
+                       if EC.is_required_tool_contract_violation err
+                       then
+                         Keeper_turn_fsm.Failure_tool_contract_violation
+                           { reason_code = "require_tool_use" }
+                       else if EC.is_receipt_lost_error err
+                       then
+                         Keeper_turn_fsm.Failure_receipt_lost
+                           { primary_error = e_str; fallback_path = None }
+                       else
+                         Keeper_turn_fsm.Failure_provider_error
+                           { kind = sdk_error_kind err; detail = short_preview e_str }
+                     in
+                     Keeper_turn_fsm.emit_transition
+                       ~keeper_name:meta.name
+                       ~turn_id:keeper_turn_id
+                       ~prev:Keeper_turn_fsm.Streaming
+                       (Keeper_turn_fsm.Failed fsm_failure_reason));
                   let log_keeper_cycle_failed =
                     if EC.should_warn_keeper_cycle_failed err
                     then Log.Keeper.warn


### PR DESCRIPTION
## Motivation

2026-05-23 dead-export sweep follow-up. `keeper_unified_turn.ml` 의 `run_keeper_cycle` failure-classification 블록에 두 개의 coupled regression이 동시에 들어왔는데, 한쪽이 다른 쪽을 mask하면서 둘 다 main에 그대로 머지됐습니다.

## 두 개의 fix

### 1. `lib/keeper/keeper_unified_turn.ml` — if-then-else scope (PR #18036 follow-up)

PR #18036에서 `emit_transition (Failed ...)` 호출을 `if EC.is_provider_timeout_error err then ... else ...` 로 감쌌는데, trailing `;` 가 **else 브랜치 안쪽**에 들어갔습니다.

```ocaml
if A then E1
else
  let r = ... in
  emit_transition (Failed r);    (* <- 이 세미콜론이 else 안에 들어감 *)
let log_keeper_cycle_failed = ...
```

OCaml은 이걸 `if A then E1 else (E2; rest_of_function)` 로 파싱합니다. 결과적으로:
- `then` 브랜치는 `emit_transition (...)` 만 — 반환 `unit`
- `else` 브랜치는 `(emit_transition (Failed r); log_keeper_cycle_failed ...; metrics ...; result_expr)` — 마지막 result 반환

두 브랜치 타입 mismatch (`unit` vs `result`). 정상 type-checker라면 잡았어야 함.

수정: 전체 if-then-else를 `(...)` 로 감싸고 `;` 를 close paren 뒤로 이동. 두 브랜치 모두 trailing failure-logging + result 생성 path를 공유.

### 2. `lib/keeper/keeper_error_classify.mli` — restore `is_receipt_lost_error`

위 1번이 머지된 게 왜 안 잡혔는가 → `is_receipt_lost_error` mli val이 dead-export sweep으로 stripped. 함수 본체는 `keeper_error_classify.ml:183` 에 살아있고 caller는 `keeper_unified_turn.ml:1438` (`EC = Keeper_error_classify` alias 경유). val이 없으니 else 브랜치 전체가 unbound → 표현식 자체가 type-check 단계에 도달 못함 → branch type mismatch도 노출 안 됨.

`is_provider_timeout_error` 와 정확히 같은 alias-hidden caller pattern. 7번째 발생. PR #18090에서 `is_provider_timeout_error` 만 복구했는데, 이번에 `is_receipt_lost_error` 도 같은 mli 위치에 복구.

## 검증

```
$ dune build --root . lib/
# keeper_unified_turn.ml + keeper_error_classify.* 에러 없음
# 잔존 lib 에러 (_snapshot_table, Turn_helpers.turn_progress_callbacks 등) 는 본 PR 무관 — chain item #2,#3에서 처리
```

## RFC

RFC-WAIVED: 33-line addition / 27-line deletion. `lib/keeper/` 만. credential/identity/sandbox/dashboard credential/Claude hooks/workflow 변경 없음. 코드 동작 의도는 PR #18036 머지 당시 그대로.