### PR TITLE
fix(keeper): RFC-0163 Phase D1 follow-up — pk_cascade_name + runtime construction typing

### DIFF
--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -618,11 +618,13 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
                         | None ->
                             (* RFC-0041: derive cascade_ref from legacy
                                cascade_name string when persisted JSON
-                               predates the field. *)
-                            Some Cascade_ref.{
-                              group = identity.pk_cascade_name;
-                              item = None;
-                            })
+                               predates the field.  RFC-0163 Phase D1
+                               typed [group] as [Cascade_name.t], so we
+                               must parse via [Cascade_name.of_string]
+                               and drop non-canonical names. *)
+                            (match Cascade_name.of_string identity.pk_cascade_name with
+                             | Ok cn -> Some Cascade_ref.{ group = cn; item = None }
+                             | Error _ -> None))
                    ; models = []
                    ; will = identity.pk_will
                    ; needs = identity.pk_needs

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -488,7 +488,7 @@ let ensure_keeper_meta config name =
         cascade_ref =
           if cascade_changed then
             Some Cascade_ref.{
-              group = Cascade_name.to_string resolved_target_cascade_name;
+              group = resolved_target_cascade_name;
               item = None;
             }
           else meta.cascade_ref;


### PR DESCRIPTION
## Summary

PR #18076 (RFC-0163 Phase D1 — \`cascade_ref.group → Cascade_name.t\`) 가 두 construction 사이트를 누락. main 빌드 차단.

| 사이트 | 증상 | Fix |
|---|---|---|
| \`lib/keeper/keeper_meta_json_parse.ml:623\` | \`group = identity.pk_cascade_name\` (string) → expects Cascade_name.t | \`Cascade_name.of_string\` Result 처리, 비정규는 \`None\` |
| \`lib/keeper/keeper_runtime.ml:491\` | \`Cascade_name.to_string resolved_target_cascade_name\` (Cascade_name.t→string) → expects Cascade_name.t | 중복 \`to_string\` 제거 |

다른 모든 construction 사이트(\`keeper_turn_up_create:444\`, \`keeper_turn_up_update:285\`, \`keeper_unified_turn_cascade_resolution:30\`, \`keeper_meta_contract:564\`) 는 이미 typed (\`Cascade_name.of_string_exn\`) — 본 PR이 마지막 잔재 2건 해소.

## Verification

\`\`\`
dune build --root . @lib/keeper/check  →  EXIT=0
\`\`\`

본 PR 적용 후 \`lib/keeper/\`에서 \`pk_cascade_name has type string\` / \`Cascade_name.to_string\` typing 에러 0건.

## 범위

- **건드린 것**: 위 2 사이트만
- **건드리지 않은 것**: \`lib/keeper/keeper_shell_ops.ml\` (Path_scope), \`keeper_shell_docker.ml\` (record_docker_exec_failure), \`server_routes_http_routes_dashboard\` (available_cascade_profiles), \`operator_control_snapshot\` (_snapshot_table), \`keeper_agent_run_turn_helpers\` mli mismatch 등. 이는 2026-05-23 dead-export sweep 회귀이며 PR #18077 영역.

## Test plan

- [x] \`dune build --root . @lib/keeper/check\` → 0 errors
- [ ] CI green (lib/keeper subset)
- [ ] CodeRabbit / 사람 리뷰 코멘트 대응
- [ ] \`gh pr ready\` 전환 (사용자 라벨 부착 후)

WORKAROUND-FREE: 두 fix 모두 typed boundary 정합. catch-all/counter-as-fix/cap-cooldown 워크어라운드 시그니처 없음.

RFC-WAIVED: scope 가 RFC-0163 Phase D1 의 *직접적 follow-up* (캡처 누락 site 보완) 이라 신규 RFC 불필요. 참조 RFC = docs/rfc/RFC-0163-cascade-ref-group-typing.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)