### PR TITLE
fix(operator): restore missing snapshot cache helpers (PR #18017 follow-up)

### DIFF
--- a/lib/operator/operator_control_snapshot_cache.ml
+++ b/lib/operator/operator_control_snapshot_cache.ml
@@ -41,6 +41,55 @@ type snapshot_slot =
 
 let _snapshot_table : (string, snapshot_slot) Hashtbl.t = Hashtbl.create 4
 let _snapshot_mu = Eio.Mutex.create ()
+let _snapshot_ttl_s = Env_config.Operator.cache_ttl_sec
+
+(* Maximum snapshot cache entries.  Each entry holds a full JSON snapshot
+   tree which can be several MB.  Unbounded growth caused OOM when the
+   dashboard was connected for extended periods (#4795). *)
+let _snapshot_max_entries = 16
+
+(* Evict one expired or oldest entry when table reaches _snapshot_max_entries.
+   Called inside _snapshot_mu when Eio is ready; pre-Eio callers are
+   single-threaded so no lock is needed. *)
+let _maybe_evict_snapshot () =
+  if Hashtbl.length _snapshot_table >= _snapshot_max_entries
+  then (
+    let now_ts = Time_compat.now () in
+    (* Prefer expired entries *)
+    let victim = ref None in
+    Hashtbl.iter
+      (fun key slot ->
+         match slot, !victim with
+         | Cached { expires_at; _ }, None when now_ts >= expires_at -> victim := Some key
+         | Cached _, None -> ()
+         | Cached _, Some _ -> ()
+         | Computing _, _ -> ())
+      _snapshot_table;
+    match !victim with
+    | Some key -> Hashtbl.remove _snapshot_table key
+    | None ->
+      (* All fresh or computing — evict the entry closest to expiry *)
+      let oldest_cached = ref None in
+      let any_key = ref None in
+      Hashtbl.iter
+        (fun key slot ->
+           match slot with
+           | Cached { expires_at; _ } ->
+             (match !oldest_cached with
+              | None -> oldest_cached := Some (key, expires_at)
+              | Some (_, e) when expires_at < e -> oldest_cached := Some (key, expires_at)
+              | Some _ -> ())
+           | Computing _ -> if !any_key = None then any_key := Some key)
+        _snapshot_table;
+      (match !oldest_cached with
+       | Some (key, _) -> Hashtbl.remove _snapshot_table key
+       | None ->
+         (* Never evict an in-flight compute to enforce the entry cap.  Under
+            64-keeper load, replacing a [Computing] slot starts duplicate
+            dashboard snapshots while the old one is still doing filesystem
+            work.  Temporary cache growth is cheaper than a compute stampede. *)
+         ignore !any_key))
+;;
 
 let invalidate_snapshot_cache () =
   if Eio_guard.is_ready ()

--- a/lib/operator/operator_control_snapshot_cache.mli
+++ b/lib/operator/operator_control_snapshot_cache.mli
@@ -12,4 +12,9 @@ type snapshot_slot =
       ; stuck_warned : bool ref
       }
 
+val _snapshot_table : (string, snapshot_slot) Hashtbl.t
+val _snapshot_mu : Eio.Mutex.t
+val _snapshot_ttl_s : float
+val _maybe_evict_snapshot : unit -> unit
+
 val invalidate_snapshot_cache : unit -> unit


### PR DESCRIPTION
## Motivation

PR #18017 (godfile decomp) 가 `Operator_control_snapshot_cache` 모듈을 sibling으로 추출했지만 3개 helper가 옮겨지지 않아 18개 call site에서 unbound error 발생.

## 현재 상태

`operator_control_snapshot.ml:675` 에 `include Operator_control_snapshot_cache` 는 이미 main에 머지됨. 그러나:

| 심볼 | cache.ml 상태 | cache.mli 노출 | 결과 |
|------|---------------|-----------------|------|
| `_snapshot_table` | ✓ 정의됨 | ✗ | parent에서 unbound |
| `_snapshot_mu` | ✓ 정의됨 | ✗ | parent에서 unbound |
| `_snapshot_ttl_s` | ✗ 없음 | ✗ | parent에서 unbound |
| `_snapshot_max_entries` | ✗ 없음 | ✗ | (internal use only) |
| `_maybe_evict_snapshot` | ✗ 없음 | ✗ | parent에서 unbound |

`include` 만으로는 부족 — mli가 노출 안 하면 include 통과 안 됨.

## 수정

### `operator_control_snapshot_cache.ml` (+49)

3개 helper 추가:
- `_snapshot_ttl_s = Env_config.Operator.cache_ttl_sec`
- `_snapshot_max_entries = 16` (16-entry cap, dashboard 장시간 세션 OOM 회피, #4795 참조)
- `_maybe_evict_snapshot ()` — expired-first / oldest-cached eviction. **`Computing` slot은 절대 evict하지 않음** (in-flight compute stampede 회피)

### `operator_control_snapshot_cache.mli` (+5)

4개 val 노출:
- `_snapshot_table : (string, snapshot_slot) Hashtbl.t`
- `_snapshot_mu : Eio.Mutex.t`
- `_snapshot_ttl_s : float`
- `_maybe_evict_snapshot : unit -> unit`

`_snapshot_max_entries` 는 `_maybe_evict_snapshot` 내부에서만 사용되므로 mli 비노출.

## 검증

```
$ dune build --root . lib/
# operator_control_snapshot* 에러 없음
```

잔존 빌드 에러 (`Turn_helpers.turn_progress_callbacks` arity, dead-export sweep 후속 test 실패 등) 은 본 PR 무관, chain item #2/#3에서 처리.

## 남은 code smell (별도 PR 후보)

`_*` underscore prefix는 OCaml 관습상 module-private. 이걸 mli로 노출하는 건 godfile decomp의 잔재. 깔끔히 정리하려면:
- helper 이름 normalize (`_snapshot_table` → `snapshot_table`)
- 또는 cache 모듈에 `get_or_compute` 같은 public API 추가하고 parent를 그쪽으로 마이그레이션

본 build-recovery 범위 밖. 별도 issue로 트래킹 가능.

## RFC

RFC-WAIVED: 54-line addition / 0 deletion. `lib/operator/` cache 모듈만. credential/identity/sandbox/dashboard credential/Claude hooks/workflow 변경 없음. 동작은 godfile decomp 이전과 동일.