### PR TITLE
fix(server): restore Server_dashboard_cascade_profile_gate after PR #18027

### DIFF
--- a/lib/server/server_dashboard_cascade_profile_gate.ml
+++ b/lib/server/server_dashboard_cascade_profile_gate.ml
@@ -1,0 +1,123 @@
+(** Dashboard cascade profile gate — determines which cascade profiles
+    are assignable to a keeper, distinguishing
+    {[
+      valid_profiles
+    ]} from
+    {[
+      invalid_profiles
+    ]}
+    and
+    {[
+      invalid_assignments
+    ]}.
+
+    Extracted from [server_routes_http_routes_dashboard.ml] (lines
+    14-184) as part of the godfile decomp campaign. Owns the pure
+    profile-classification pipeline that feeds the dashboard cascade
+    assignment UI; runtime snapshot ([Cascade_catalog_runtime]) is
+    consulted first, with a fallback to the on-disk validator
+    ([Cascade_catalog_validator]) when the snapshot is unavailable. *)
+
+type t = {
+  valid_profiles : string list;
+  invalid_profiles : (string * string list) list;
+  invalid_assignments : (string * string list) list;
+}
+
+let compute () : t =
+  let config_path = Cascade_runtime.cascade_config_path () in
+  let keeper_assignable_profiles =
+    Keeper_cascade_profile.keeper_catalog_names ?config_path ()
+    |> List.sort_uniq String.compare
+  in
+  let keeper_assignable_profile profile =
+    keeper_assignable_profiles = [] || List.mem profile keeper_assignable_profiles
+  in
+  let fallback_invalid_profiles =
+    match config_path with
+    | None -> []
+    | Some path ->
+        Cascade_catalog_validator.error_messages_by_profile
+          ~config_path:path
+  in
+  match Cascade_catalog_runtime.known_profile_names () with
+  | Ok raw_validated_profiles ->
+      let validated_profiles =
+        raw_validated_profiles |> List.sort_uniq String.compare
+      in
+      let invalid_profiles =
+        (Cascade_catalog_runtime.invalid_profile_errors ()
+         @ fallback_invalid_profiles)
+        |> Dashboard_cascade.invalid_profiles_with_internal_names
+      in
+      let keeper_profiles =
+        raw_validated_profiles
+        |> List.filter keeper_assignable_profile
+        |> List.sort_uniq String.compare
+      in
+      let candidate_profiles =
+        if keeper_profiles = [] then validated_profiles else keeper_profiles
+      in
+      let known_internal_profiles =
+        (match config_path with
+         | None -> raw_validated_profiles
+         | Some path ->
+             Cascade_catalog_validator.discover_profiles_for_diagnostics
+               ~config_path:path)
+        |> List.sort_uniq String.compare
+      in
+      let invalid_assignments =
+        Dashboard_cascade.invalid_assignments_for_public_profiles
+          ~known_internal_profiles
+          ~invalid_profiles candidate_profiles
+      in
+      let valid_profiles =
+        candidate_profiles
+        |> List.filter (fun profile ->
+               List.mem profile validated_profiles
+               && not (List.mem_assoc profile invalid_assignments))
+      in
+      { valid_profiles; invalid_profiles; invalid_assignments }
+  | Error detail ->
+      Log.Keeper.warn
+        "cascade_profile_gate: validated runtime snapshot unavailable: %s"
+        detail;
+      let invalid_profiles =
+        Dashboard_cascade.invalid_profiles_with_internal_names
+          fallback_invalid_profiles
+      in
+      let known_internal_profiles =
+        (match config_path with
+         | None -> []
+         | Some path ->
+             Cascade_catalog_validator.discover_profiles_for_diagnostics
+               ~config_path:path)
+        |> List.sort_uniq String.compare
+      in
+      let keeper_profiles =
+        known_internal_profiles
+        |> List.filter keeper_assignable_profile
+        |> List.sort_uniq String.compare
+      in
+      let candidate_profiles =
+        if keeper_profiles = [] then known_internal_profiles else keeper_profiles
+      in
+      let invalid_assignments =
+        Dashboard_cascade.invalid_assignments_for_public_profiles
+          ~known_internal_profiles ~invalid_profiles candidate_profiles
+      in
+      let invalid_names = List.map fst invalid_assignments in
+      let valid_profiles =
+        candidate_profiles
+        |> List.filter (fun profile -> not (List.mem profile invalid_names))
+      in
+      { valid_profiles; invalid_profiles; invalid_assignments }
+;;
+
+let available_profiles () : string list = (compute ()).valid_profiles
+let available_cascade_profiles = available_profiles
+let invalid_profiles () : (string * string list) list = (compute ()).invalid_profiles
+
+let invalid_assignment_profiles () : (string * string list) list =
+  (compute ()).invalid_assignments
+;;

--- a/lib/server/server_dashboard_cascade_profile_gate.mli
+++ b/lib/server/server_dashboard_cascade_profile_gate.mli
@@ -1,0 +1,35 @@
+(** Dashboard cascade profile gate — determines which cascade
+    profiles are assignable to a keeper.
+
+    Pure derivation pipeline over [Cascade_catalog_runtime] (preferred)
+    + [Cascade_catalog_validator] (fallback on snapshot unavailability)
+    + [Keeper_cascade_profile.keeper_catalog_names] (keeper-assignable
+    filter). *)
+
+(** Result of one gate computation:
+    - [valid_profiles]: assignable profile names;
+    - [invalid_profiles]: profile → error message list (config /
+      validator-level errors);
+    - [invalid_assignments]: profile → reason list (public profile
+      that resolves to an invalid internal profile). *)
+type t = {
+  valid_profiles : string list;
+  invalid_profiles : (string * string list) list;
+  invalid_assignments : (string * string list) list;
+}
+
+(** [compute ()] runs the gate end-to-end and returns the
+    classification for the current cascade config. Reads the runtime
+    snapshot first; falls back to the on-disk validator when the
+    snapshot is in an error state (logs a WARN line in that case). *)
+val compute : unit -> t
+
+(** [available_profiles ()] is [(compute ()).valid_profiles]. *)
+val available_profiles : unit -> string list
+
+(** [invalid_profiles ()] is [(compute ()).invalid_profiles]. *)
+val invalid_profiles : unit -> (string * string list) list
+
+(** [invalid_assignment_profiles ()] is
+    [(compute ()).invalid_assignments]. *)
+val invalid_assignment_profiles : unit -> (string * string list) list

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -11,6 +11,20 @@ module Runtime = Server_routes_http_runtime
 module Keeper_stream = Server_routes_http_keeper_stream
 module Keeper_api = Server_dashboard_http_keeper_api
 
+(* Cascade profile gate extracted to
+   [Server_dashboard_cascade_profile_gate] (godfile decomp PR #18027).
+   PR #18027 deleted this surface but left 3 unqualified call sites in
+   the parent dashboard route file (lines 1173, 1208, 1209). Restored
+   via module alias + local function aliases that map the old
+   unqualified names to the new [_profile_gate] surface. *)
+module Cascade_profile_gate = Server_dashboard_cascade_profile_gate
+
+let cascade_profile_gate = Cascade_profile_gate.compute
+let available_cascade_profiles = Cascade_profile_gate.available_profiles
+let invalid_cascade_profiles = Cascade_profile_gate.invalid_profiles
+let invalid_cascade_assignment_profiles =
+  Cascade_profile_gate.invalid_assignment_profiles
+
 let option_int_json = function
   | Some value -> `Int value
   | None -> `Null


### PR DESCRIPTION
## Summary

PR #18027 (2026-05-23 godfile decomp dead-export sweep) 가 \`server_dashboard_cascade_profile_gate.{ml,mli}\` 를 \"0 callers\" audit 로 삭제했지만, 부모 dashboard route 파일이 **unqualified 이름** 으로 3 곳에서 호출 — 5 facade 경로 중 4번째 (parent .ml internal call) 누락.

| Call site | Symbol |
|---|---|
| \`server_routes_http_routes_dashboard.ml:1173\` | \`cascade_profile_gate ()\` |
| \`server_routes_http_routes_dashboard.ml:1208\` | \`available_cascade_profiles ()\` |
| \`server_routes_http_routes_dashboard.ml:1209\` | \`invalid_cascade_assignment_profiles ()\` |

## Fix

1. **\`lib/server/server_dashboard_cascade_profile_gate.{ml,mli}\` 복구** — pre-#18027 상태와 동일 (123 LoC .ml + 35 LoC .mli, pure derivation pipeline). 출처: PR #18077 worktree snapshot \`b89390d9d\`.

2. **\`lib/server/server_routes_http_routes_dashboard.ml\` 에 11-line alias section** — 복구된 \`_profile_gate\` 모듈을 legacy unqualified 이름으로 재노출:

\`\`\`ocaml
module Cascade_profile_gate = Server_dashboard_cascade_profile_gate
let cascade_profile_gate = Cascade_profile_gate.compute
let available_cascade_profiles = Cascade_profile_gate.available_profiles
let invalid_cascade_profiles = Cascade_profile_gate.invalid_profiles
let invalid_cascade_assignment_profiles =
  Cascade_profile_gate.invalid_assignment_profiles
\`\`\`

## Attribution

본 fix 의 module restoration 부분은 PR #18077 의 commit \`b89390d9d\` (3-fix combo: snapshot_cache + cascade_profile_gate + FSM if-then-else) 에서 가져왔습니다. snapshot_cache 부분은 이미 PR #18093 으로 cherry-pick 머지. 본 PR 은 cascade_profile_gate 부분만 분리해 머지 가능한 단위로 추출. \`Co-Authored-By\` 로 명시.

## Verification

\`\`\`
dune build --root . lib/
\`\`\`

본 PR 의 영역인 \`available_cascade_profiles\` / \`invalid_cascade_assignment_profiles\` / \`cascade_profile_gate\` 모두 bind clean.

남은 lib/ 빌드 에러 (Path_scope, record_docker_exec_failure, AT.stats, keeper_agent_run_turn_helpers mli mismatch) 는 다른 dead-export sweep 회귀 영역으로, PR #18077 의 다른 commit 들이 다룸.

## Test plan

- [x] \`dune build --root . lib/\` → \`available_cascade_profiles\` 에러 해소 확인
- [ ] CI green (lib/server subset)
- [ ] CodeRabbit / 사람 리뷰 코멘트 대응
- [ ] \`gh pr ready\` 전환 (사용자 라벨 부착 후)

WORKAROUND-FREE: 본 fix 는 root cause (deleted module + unqualified call sites) 를 정확히 복구. catch-all / counter-as-fix / cap-cooldown 시그니처 없음.

RFC-WAIVED: 본 PR 은 2026-05-23 dead-export sweep 회귀 복구 cherry-pick 으로, RFC 영역이 아님 (sweep 자체가 RFC-less 였음). Anti-pattern 정리는 \`~/me/memory/feedback_dead_export_sweep_2026_05_23_anti_pattern.md\` 가 SSOT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)