### PR TITLE
fix(server): restore cascade_profile_gate module (PR #18027 follow-up)

### DIFF
--- a/lib/server/server_dashboard_cascade_profile_gate.ml
+++ b/lib/server/server_dashboard_cascade_profile_gate.ml
@@ -1,0 +1,123 @@
+(** Dashboard cascade profile gate — determines which cascade profiles
+    are assignable to a keeper, distinguishing
+    {[
+      valid_profiles
+    ]} from
+    {[
+      invalid_profiles
+    ]}
+    and
+    {[
+      invalid_assignments
+    ]}.
+
+    Extracted from [server_routes_http_routes_dashboard.ml] (lines
+    14-184) as part of the godfile decomp campaign. Owns the pure
+    profile-classification pipeline that feeds the dashboard cascade
+    assignment UI; runtime snapshot ([Cascade_catalog_runtime]) is
+    consulted first, with a fallback to the on-disk validator
+    ([Cascade_catalog_validator]) when the snapshot is unavailable. *)
+
+type t = {
+  valid_profiles : string list;
+  invalid_profiles : (string * string list) list;
+  invalid_assignments : (string * string list) list;
+}
+
+let compute () : t =
+  let config_path = Cascade_runtime.cascade_config_path () in
+  let keeper_assignable_profiles =
+    Keeper_cascade_profile.keeper_catalog_names ?config_path ()
+    |> List.sort_uniq String.compare
+  in
+  let keeper_assignable_profile profile =
+    keeper_assignable_profiles = [] || List.mem profile keeper_assignable_profiles
+  in
+  let fallback_invalid_profiles =
+    match config_path with
+    | None -> []
+    | Some path ->
+        Cascade_catalog_validator.error_messages_by_profile
+          ~config_path:path
+  in
+  match Cascade_catalog_runtime.known_profile_names () with
+  | Ok raw_validated_profiles ->
+      let validated_profiles =
+        raw_validated_profiles |> List.sort_uniq String.compare
+      in
+      let invalid_profiles =
+        (Cascade_catalog_runtime.invalid_profile_errors ()
+         @ fallback_invalid_profiles)
+        |> Dashboard_cascade.invalid_profiles_with_internal_names
+      in
+      let keeper_profiles =
+        raw_validated_profiles
+        |> List.filter keeper_assignable_profile
+        |> List.sort_uniq String.compare
+      in
+      let candidate_profiles =
+        if keeper_profiles = [] then validated_profiles else keeper_profiles
+      in
+      let known_internal_profiles =
+        (match config_path with
+         | None -> raw_validated_profiles
+         | Some path ->
+             Cascade_catalog_validator.discover_profiles_for_diagnostics
+               ~config_path:path)
+        |> List.sort_uniq String.compare
+      in
+      let invalid_assignments =
+        Dashboard_cascade.invalid_assignments_for_public_profiles
+          ~known_internal_profiles
+          ~invalid_profiles candidate_profiles
+      in
+      let valid_profiles =
+        candidate_profiles
+        |> List.filter (fun profile ->
+               List.mem profile validated_profiles
+               && not (List.mem_assoc profile invalid_assignments))
+      in
+      { valid_profiles; invalid_profiles; invalid_assignments }
+  | Error detail ->
+      Log.Keeper.warn
+        "cascade_profile_gate: validated runtime snapshot unavailable: %s"
+        detail;
+      let invalid_profiles =
+        Dashboard_cascade.invalid_profiles_with_internal_names
+          fallback_invalid_profiles
+      in
+      let known_internal_profiles =
+        (match config_path with
+         | None -> []
+         | Some path ->
+             Cascade_catalog_validator.discover_profiles_for_diagnostics
+               ~config_path:path)
+        |> List.sort_uniq String.compare
+      in
+      let keeper_profiles =
+        known_internal_profiles
+        |> List.filter keeper_assignable_profile
+        |> List.sort_uniq String.compare
+      in
+      let candidate_profiles =
+        if keeper_profiles = [] then known_internal_profiles else keeper_profiles
+      in
+      let invalid_assignments =
+        Dashboard_cascade.invalid_assignments_for_public_profiles
+          ~known_internal_profiles ~invalid_profiles candidate_profiles
+      in
+      let invalid_names = List.map fst invalid_assignments in
+      let valid_profiles =
+        candidate_profiles
+        |> List.filter (fun profile -> not (List.mem profile invalid_names))
+      in
+      { valid_profiles; invalid_profiles; invalid_assignments }
+;;
+
+let available_profiles () : string list = (compute ()).valid_profiles
+let available_cascade_profiles = available_profiles
+let invalid_profiles () : (string * string list) list = (compute ()).invalid_profiles
+
+let invalid_assignment_profiles () : (string * string list) list =
+  (compute ()).invalid_assignments
+;;

--- a/lib/server/server_dashboard_cascade_profile_gate.mli
+++ b/lib/server/server_dashboard_cascade_profile_gate.mli
@@ -1,0 +1,35 @@
+(** Dashboard cascade profile gate — determines which cascade
+    profiles are assignable to a keeper.
+
+    Pure derivation pipeline over [Cascade_catalog_runtime] (preferred)
+    + [Cascade_catalog_validator] (fallback on snapshot unavailability)
+    + [Keeper_cascade_profile.keeper_catalog_names] (keeper-assignable
+    filter). *)
+
+(** Result of one gate computation:
+    - [valid_profiles]: assignable profile names;
+    - [invalid_profiles]: profile → error message list (config /
+      validator-level errors);
+    - [invalid_assignments]: profile → reason list (public profile
+      that resolves to an invalid internal profile). *)
+type t = {
+  valid_profiles : string list;
+  invalid_profiles : (string * string list) list;
+  invalid_assignments : (string * string list) list;
+}
+
+(** [compute ()] runs the gate end-to-end and returns the
+    classification for the current cascade config. Reads the runtime
+    snapshot first; falls back to the on-disk validator when the
+    snapshot is in an error state (logs a WARN line in that case). *)
+val compute : unit -> t
+
+(** [available_profiles ()] is [(compute ()).valid_profiles]. *)
+val available_profiles : unit -> string list
+
+(** [invalid_profiles ()] is [(compute ()).invalid_profiles]. *)
+val invalid_profiles : unit -> (string * string list) list
+
+(** [invalid_assignment_profiles ()] is
+    [(compute ()).invalid_assignments]. *)
+val invalid_assignment_profiles : unit -> (string * string list) list

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -10,6 +10,13 @@ module Pages = Server_routes_http_pages
 module Runtime = Server_routes_http_runtime
 module Keeper_stream = Server_routes_http_keeper_stream
 module Keeper_api = Server_dashboard_http_keeper_api
+module Cascade_profile_gate = Server_dashboard_cascade_profile_gate
+
+(* Exposed test surface (see .mli): allows focused tests to lock the
+   runtime catalog contract independently of the route pipeline.
+   Internal callers in this file use [Cascade_profile_gate.X] directly. *)
+let available_cascade_profiles = Cascade_profile_gate.available_profiles
+let invalid_cascade_profiles = Cascade_profile_gate.invalid_profiles
 
 let option_int_json = function
   | Some value -> `Int value
@@ -1170,7 +1177,7 @@ and add_keeper_cascade_routes router =
 
   |> Http.Router.get "/api/v1/keeper/cascades" (fun request reqd ->
        with_public_read (fun _state _req reqd ->
-         let gate = cascade_profile_gate () in
+         let gate = Cascade_profile_gate.compute () in
          Http.Response.json ~request:request
            (Yojson.Safe.to_string (`Assoc [
              ("profiles", `List (List.map (fun s -> `String s) gate.valid_profiles));
@@ -1205,8 +1212,8 @@ and add_keeper_cascade_routes router =
                  {|{"ok":false,"error":"requires {\"keeper\":\"...\",\"cascade_name\":\"...\"}"}|}
                  reqd
              | Some name, Some cascade ->
-               let known = available_cascade_profiles () in
-               let invalid = invalid_cascade_assignment_profiles () in
+               let known = Cascade_profile_gate.available_profiles () in
+               let invalid = Cascade_profile_gate.invalid_assignment_profiles () in
                (match List.assoc_opt cascade invalid with
                 | Some reasons ->
                   Http.Response.json ~status:`Conflict ~request:req


### PR DESCRIPTION
## Motivation

PR #18027 (dead-export sweep) 이 `server_dashboard_cascade_profile_gate.{ml,mli}` 모듈을 통째로 삭제했지만:

- `server_routes_http_routes_dashboard.ml` 의 3개 unqualified call site (line 1173, 1208, 1209) 가 그대로 남음
- 부모 `.mli` 가 `available_cascade_profiles` + `invalid_cascade_profiles` 를 test surface로 노출 중 (line 14, 19) — "focused tests lock the runtime catalog contract independently of the route pipeline" 라는 명시적 계약

기존 dead-export sweep이 sibling 모듈로 호출되는 caller + mli surface 둘 다 못 봄. 7번째+ 같은 alias-hidden 패턴.

## 복원 전략 (recovery snapshot보다 radical)

원본 recovery commit b89390d9d 는 4개 `let alias = Cascade_profile_gate.X` re-export로 unqualified caller를 그대로 살림. 이건 *바로 그 dead-export audit 사각지대*를 다시 만드는 패턴 (cf. `feedback_dead_export_audit_must_trace_include_facade` 2026-05-22).

본 PR은 더 radical하게:

### 1. 모듈 복원 (verbatim)

`server_dashboard_cascade_profile_gate.{ml,mli}` 123 LoC pure derivation pipeline (`Cascade_catalog_runtime` + `Cascade_catalog_validator` + keeper-assignable filter). Coherent + testable surface — 1.3k-line route 파일에 inline하기보다 별도 모듈 유지가 적절.

### 2. Module alias로 호출 (let alias 아님)

```ocaml
module Cascade_profile_gate = Server_dashboard_cascade_profile_gate
```

기존 파일 line 7-12의 `module Runtime = ...`, `module Keeper_stream = ...` 패턴과 일관. **Structural alias라 모든 linter가 추적**. `let alias = X.fn` 의 dead-export trap이 아님.

### 3. Internal caller qualify

```ocaml
- let gate = cascade_profile_gate () in
+ let gate = Cascade_profile_gate.compute () in

- let known = available_cascade_profiles () in
- let invalid = invalid_cascade_assignment_profiles () in
+ let known = Cascade_profile_gate.available_profiles () in
+ let invalid = Cascade_profile_gate.invalid_assignment_profiles () in
```

3 사이트, 다 qualified. 잘못된 unqualified 호출 → 컴파일 에러로 바로 잡힘.

### 4. mli 계약만 satisfying하는 2개 let-alias

```ocaml
let available_cascade_profiles = Cascade_profile_gate.available_profiles
let invalid_cascade_profiles = Cascade_profile_gate.invalid_profiles
```

부모 `.mli` 가 명시적으로 노출하는 test surface 2개만 살림. Recovery snapshot의 `cascade_profile_gate` + `invalid_cascade_assignment_profiles` 2개 let-alias는 mli 미선언 + caller 없음 = pure dead facade → 생략.

## 검증

```
$ dune build --root . lib/
# cascade_profile_gate / server_routes_http_routes_dashboard 에러 없음
```

잔존 lib 에러 (`Turn_helpers.turn_progress_callbacks` arity, `Path_scope` 등) 는 chain item #2/#3 영역, 본 PR 무관.

## RFC

RFC-WAIVED: 168-line addition (이 중 123 LoC는 verbatim restore된 cascade_profile_gate 모듈) / 3-line deletion. `lib/server/` 만. credential/identity/sandbox/dashboard credential/Claude hooks/workflow 변경 없음. 동작은 PR #18027 머지 이전과 동일.