### PR TITLE
test(exec): drop orphaned stats/stats_to_json test paths

### DIFF
--- a/lib/exec/test/test_exec_adaptive_timeout.ml
+++ b/lib/exec/test/test_exec_adaptive_timeout.ml
@@ -60,68 +60,6 @@ let test_compute_ignores_failures () =
   (* only 3 successes: 100,110,120. p95 idx=2 => p95=120. 120*1.5=180 *)
   Alcotest.(check int) "ignores failures" 180 t
 
-let test_stats_default () =
-  let entries = [ entry ~duration_ms:100 "ls" ] in
-  (match AT.stats AT.default_config entries with
-   | AT.Default { reason; recommended_ms } ->
-     Alcotest.(check bool) "reason is non-empty" true (String.length reason > 0);
-     Alcotest.(check int) "recommended from config default" 120_000 recommended_ms
-   | _ -> Alcotest.fail "should be Default")
-
-let test_stats_adapted () =
-  let config = { AT.default_config with min_ms = 50; multiplier = 1.5 } in
-  let entries = List.init 5 (fun i ->
-    entry ~duration_ms:(100 + i * 50) "build")
-  in
-  (match AT.stats config entries with
-   | AT.Adapted { p95_ms; recommended_ms; sample_count } ->
-     (* sorted: 100,150,200,250,300. p95 idx=4 => 300 *)
-     Alcotest.(check int) "p95" 300 p95_ms;
-     Alcotest.(check int) "recommended" 450 recommended_ms;
-     Alcotest.(check int) "sample_count" 5 sample_count
-   | _ -> Alcotest.fail "should be Adapted")
-
-let test_stats_json_adapted () =
-  let entries = List.init 5 (fun i ->
-    entry ~duration_ms:(100 + i * 50) "build")
-  in
-  let config = { AT.default_config with min_ms = 50; multiplier = 1.5 } in
-  let s = AT.stats config entries in
-  let json = AT.stats_to_json s in
-  (match json with
-   | `Assoc fields ->
-     (match List.assoc_opt "adapted" fields with
-      | Some (`Bool true) -> ()
-      | _ -> Alcotest.fail "adapted should be true");
-     (match List.assoc_opt "p95_ms" fields with
-      | Some (`Int 300) -> ()
-      | _ -> Alcotest.fail "p95_ms should be 300")
-   | _ -> Alcotest.fail "expected assoc")
-
-let test_stats_json_default () =
-  let s = AT.stats AT.default_config [] in
-  let json = AT.stats_to_json s in
-  (match json with
-   | `Assoc fields ->
-     (match List.assoc_opt "adapted" fields with
-      | Some (`Bool false) -> ()
-      | _ -> Alcotest.fail "adapted should be false");
-     (match List.assoc_opt "recommended_ms" fields with
-      | Some (`Int 120_000) -> ()
-      | _ -> Alcotest.fail "should have default recommended_ms")
-   | _ -> Alcotest.fail "expected assoc")
-
-let test_stats_json_default_uses_config_default () =
-  let config = { AT.default_config with default_ms = 45_000 } in
-  let s = AT.stats config [] in
-  let json = AT.stats_to_json s in
-  (match json with
-   | `Assoc fields ->
-     (match List.assoc_opt "recommended_ms" fields with
-      | Some (`Int 45_000) -> ()
-      | _ -> Alcotest.fail "should use configured default_ms")
-   | _ -> Alcotest.fail "expected assoc")
-
 let () =
   test_default_config ();
   test_compute_empty ();
@@ -130,9 +68,4 @@ let () =
   test_compute_min_clamp ();
   test_compute_max_clamp ();
   test_compute_ignores_failures ();
-  test_stats_default ();
-  test_stats_adapted ();
-  test_stats_json_adapted ();
-  test_stats_json_default ();
-  test_stats_json_default_uses_config_default ();
-  print_endline "test_exec_adaptive_timeout: 12/12 passed"
+  print_endline "test_exec_adaptive_timeout: 7/7 passed"


### PR DESCRIPTION
## 목적

PR #18009의 dead-export sweep 후속 회귀를 정리합니다. 테스트 파일에 남은 5개 orphan 테스트 함수를 제거.

## 배경

[PR #18009](https://github.com/jeong-sik/masc-mcp/pull/18009) (\`b4c1a08ac\`) 가 \`Exec_adaptive_timeout.stats\` / \`stats_to_json\` 을 dead로 판정하고 .ml/.mli에서 제거.

- 5-prong audit 결과 production caller 0건 (실제 확인됨)
- PR body: *"Test coverage exists for default_config and compute only"*
- 실제로는 테스트 파일이 5개 함수에서 dead API를 호출 중 → \`Unbound value AT.stats\` 빌드 실패

\`test_exec_adaptive_timeout.ml\` 단독 빌드가 깨진 상태로 origin/main에 남아있음. \`@lib/exec/test/runtest\` 빌드 시 가장 먼저 unbound 에러 발생.

## 변경

5개 orphan 테스트 함수 + 호출 라인 제거:

- \`test_stats_default\`
- \`test_stats_adapted\`
- \`test_stats_json_adapted\`
- \`test_stats_json_default\`
- \`test_stats_json_default_uses_config_default\`

남는 7개 테스트 (\`default_config\` + \`compute\` 경로)가 \`compute\`의 두 분기 (default fallback / adapted p95) 와 세 clamp (min/max/multiplier ignores-failures) 를 모두 커버합니다.

## 검증

\`\`\`
dune build lib/exec/                                      # green
dune exec lib/exec/test/test_exec_adaptive_timeout.exe    # 7/7 passed
\`\`\`

\`@lib/exec/test/runtest\` 전체는 \`test_bash_parser\`에 별개 사전 회귀(line 202 assertion)가 있어 본 PR과 무관하게 실패합니다.

## 방향 선택의 근거

옵션 두 가지:

- **A. \`stats\`/\`stats_to_json\` 복원** — 테스트는 보존되지만 사용자의 의도적 dead-export 정리를 되돌리는 셈
- **B. 테스트 정리 (이 PR)** — caller migration 마무리

PR #18009 audit이 production-side 판정은 정확했음 (caller 진짜로 0건). 잘못된 부분은 *test usage를 못 본 것*뿐. 옳은 fix는 사용자가 의도한 SSOT 축소를 *그대로 두고* test side만 따라가는 것입니다.