### PR TITLE
fix(keeper): qualify Masc_exec.Path_scope + drop dead git_log argv setup

### DIFF
--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -371,7 +371,7 @@ let handle_keeper_shell
          (* P11: Host git_status via Shell IR pipeline.
             Preserves P16 Bash_history + failure_insight. *)
          let dispatch_sandbox = Masc_exec.Sandbox_target.host () in
-         let cwd_scope = Path_scope.classify ~raw:cwd ~cwd:root in
+         let cwd_scope = Masc_exec.Path_scope.classify ~raw:cwd ~cwd:root in
          let ir =
            Masc_exec.Shell_ir.Simple
              { bin = Masc_exec.Bin.of_known Masc_exec.Bin.Git
@@ -869,15 +869,6 @@ let handle_keeper_shell
               ~cmd:"git -C <cwd> --no-optional-locks log --format=<fmt> -<n>"
               ~docker_cmd ~timeout_sec:Keeper_shell_shared.read_timeout_sec)
        else
-         let base_argv =
-           [ "git"; "-C"; cwd; "--no-optional-locks"; "log";
-             Printf.sprintf "--format=%s" format;
-             Printf.sprintf "-%d" count ]
-         in
-         let base_argv =
-           if grep = "" then base_argv else base_argv @ [ "--grep=" ^ grep ]
-         in
-         let argv = if file_path <> "" then base_argv @ [ "--"; file_path ] else base_argv in
          (match Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd with
           | Some runtime ->
             let argv =
@@ -939,7 +930,7 @@ let handle_keeper_shell
             (* P11: Host git_log via Shell IR pipeline.
                Preserves P16 Bash_history + failure_insight. *)
             let dispatch_sandbox = Masc_exec.Sandbox_target.host () in
-            let cwd_scope = Path_scope.classify ~raw:cwd ~cwd:root in
+            let cwd_scope = Masc_exec.Path_scope.classify ~raw:cwd ~cwd:root in
             let base_args =
               [ Masc_exec.Shell_ir.Lit ("--no-optional-locks", Masc_exec.Shell_ir.default_meta)
               ; Masc_exec.Shell_ir.Lit ("log", Masc_exec.Shell_ir.default_meta)


### PR DESCRIPTION
## Summary

\`keeper_shell_ops.ml\` 가 PR #18070 sweep 이후 \`Path_scope\` 모듈을 unqualified 로 호출 — 컴파일 차단.

자매 파일 2곳 (\`keeper_gh_shared.ml:55\`, \`keeper_tool_bash_input.ml:321\`) 는 *이미 \`Masc_exec.Path_scope\` 정규화 완료*. \`keeper_shell_ops.ml\` 만 drift.

### 1단계: caller normalization (alias 복원 X)

| 사이트 | Before | After |
|---|---|---|
| line 374 | \`Path_scope.classify\` | \`Masc_exec.Path_scope.classify\` |
| line 942 | \`Path_scope.classify\` | \`Masc_exec.Path_scope.classify\` |

PR #18077 \`e19a43420\` 의 \`Path_scope alias\` 복원 대신, 자매 패턴과 일치하는 정규 qualification 사용. compat shim 0줄.

### 2단계: dead-block 제거 (Path_scope fix 가 가린 warning-26)

Path_scope 에러가 컴파일 중단을 풀자 line 880 의 dead \`argv\` 가 노출. f0075c361 (2026-05-17) 이후 latent.

\`\`\`ocaml
(* DEAD since 2026-05-17 *)
let base_argv = [ "git"; "-C"; cwd; ... ] in
let base_argv = if grep = "" then base_argv else base_argv @ ... in
let argv = if file_path <> "" then base_argv @ ... else base_argv in
\`\`\`

이 \`argv\` 를 소비하는 arm 없음:

- \`Some runtime\` arm (line 883+) 은 \`argv\` 를 *재정의*해 container-mapped runtime path 로 재구성 → outer \`argv\` 그림자.
- \`None\` arm (line 938+) 은 \`Masc_exec.Shell_ir.Simple\` IR + \`base_args\` 리스트 사용 → outer \`argv\` 미참조.

11줄 통째로 삭제.

## Diff

+2 / -11. Net -9 LoC. Compat shim 0줄, alias 0줄.

## Verification

\`\`\`
dune build --root . lib/   →   Path_scope 에러 + warning 26 둘 다 해소
\`\`\`

남은 lib 빌드 에러 (record_docker_exec_failure, AT.stats, keeper_agent_run_turn_helpers turn_id mismatch) 는 별개 영역.

## Philosophy

본 PR 은 dead-export sweep 사고의 *recovery* 가 아니라 *진짜 제거* 패턴. 사용자 지시: \"실제 제거에 맞게 같이 개선\". alias-as-compat-shim 은 잘못된 코드를 영구화하는 anti-pattern (\`feedback_radical_improvement_over_diff_size\`). caller migration 이 정답.

## Test plan

- [x] \`dune build --root . lib/\` → Path_scope + warning-26 둘 다 해소
- [ ] CI green (lib/keeper subset)
- [ ] CodeRabbit / 사람 리뷰 코멘트 대응
- [ ] \`gh pr ready\` 전환 (사용자 라벨 부착 후)

WORKAROUND-FREE.

RFC-WAIVED: 2026-05-23 dead-export sweep 회귀 cleanup, RFC 영역 아님.

🤖 Generated with [Claude Code](https://claude.com/claude-code)