### PR TITLE
fix(keeper_shell_docker): qualify exec_failure callers, drop dead facade and unused cmd arg

### DIFF
--- a/lib/keeper/keeper_shell_docker.ml
+++ b/lib/keeper/keeper_shell_docker.ml
@@ -198,11 +198,11 @@ let ensure_keeper_sandbox_runtime ~timeout_sec =
 ;;
 
 
-(* Emit a ("gh_exit_class", "…") JSON field when [cmd] targets gh,
+(* Emit a ("gh_exit_class", "…") JSON field when [cmd_stages] targets gh,
    AND increment the matching Legendary_counters bucket.  Callers
    append the returned list to their `Assoc payload unconditionally —
    it is empty for non-gh commands, so call sites keep their shape. *)
-let gh_exit_class_field ~cmd ~status ~output
+let gh_exit_class_field ~status ~output
     ~(cmd_stages : Keeper_shell_command_semantics.parsed_stage list)
     () : (string * Yojson.Safe.t) list =
   if not (Keeper_shell_command_semantics.stages_targets_gh cmd_stages)
@@ -687,7 +687,7 @@ let run_docker_shell_command_with_status_internal
                              in
                              if not (docker_command_semantic_success ~cmd ~status ~output)
                              then
-                               record_docker_exec_failure
+                               Keeper_shell_docker_exec_failure.record_docker_exec_failure
                                  ~config
                                  ~meta
                                  ~image
@@ -833,7 +833,6 @@ let run_docker_credentialed_bash
                      ; "output", `String result.output
                      ]
                      @ gh_exit_class_field
-                         ~cmd
                          ~status:result.status
                          ~output:result.output
                         ~cmd_stages
@@ -917,7 +916,7 @@ let run_docker_bash
             in
             if not semantic_ok
             then
-              record_docker_exec_failure
+              Keeper_shell_docker_exec_failure.record_docker_exec_failure
                 ~config
                 ~meta
                 ~image
@@ -948,7 +947,7 @@ let run_docker_bash
                      , `String (Exec_core.string_of_semantic_status semantic_status)
                    ; "output", `String out
                    ]
-                   @ gh_exit_class_field ~cmd ~status:st ~output:out ~cmd_stages ())))
+                   @ gh_exit_class_field ~status:st ~output:out ~cmd_stages ())))
        | _ ->
          (match turn_sandbox_runtime with
           | Some _ ->
@@ -1007,7 +1006,6 @@ let run_docker_bash
                       ; "output", `String result.output
                       ]
                       @ gh_exit_class_field
-                          ~cmd
                           ~status:result.status
                           ~output:result.output
                           ~cmd_stages

--- a/lib/keeper/keeper_shell_docker.mli
+++ b/lib/keeper/keeper_shell_docker.mli
@@ -3,16 +3,11 @@
     Extracted from keeper_exec_shell.ml — Docker container
     lifecycle, sandbox profile resolution, and container
     invocation. Pure infrastructure; generic command-shape policy lives
-    in [Keeper_shell_command_semantics]. *)
+    in [Keeper_shell_command_semantics].
 
-(** Build a structured failure message used by docker exec
-    diagnostics, emphasising the exit/signal status and (when
-    blank) flagging empty output explicitly. *)
-val docker_exec_failure_message :
-  image:string ->
-  status:Unix.process_status ->
-  output:string ->
-  string
+    The failure-message and failure-recording surfaces moved out to
+    [Keeper_shell_docker_exec_failure] during godfile decomp. Call
+    those qualified rather than relying on a re-export here. *)
 
 (** Path of the per-keeper egress policy file
     [<sandbox_root>/egress.json]. *)
@@ -82,15 +77,15 @@ val ensure_keeper_sandbox_runtime :
     Returns [Some (repo_arg, endpoint)] when the misuse pattern is
     detected, [None] otherwise — caller emits a self-correcting
     error pre-exec. *)
-(** Emit a [("gh_exit_class", ...)] JSON field when [cmd] targets
+(** Emit a [("gh_exit_class", ...)] JSON field when [cmd_stages] target
     gh (otherwise []), and bump the matching [Legendary_counters]
     bucket. Caller appends the returned list to its assoc payload
     unconditionally — the empty case keeps callsite shapes stable. *)
 val gh_exit_class_field :
-  cmd:string ->
   status:Unix.process_status ->
   output:string ->
   cmd_stages:Keeper_shell_command_semantics.parsed_stage list ->
+  unit ->
   (string * Yojson.Safe.t) list
 
 (** [-v <host>:<container>:ro] mount list, or [[]] when [host] is

--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -2053,7 +2053,7 @@ let test_docker_mount_failure_message_preserves_path () =
     ^ ": no such file or directory"
   in
   let message =
-    Keeper_shell_docker.docker_exec_failure_message
+    Keeper_shell_docker_exec_failure.docker_exec_failure_message
       ~image:"masc-keeper-sandbox:local"
       ~status:(Unix.WEXITED 125)
       ~output


### PR DESCRIPTION
## Motivation

PR #18015 (`Keeper_shell_docker_exec_failure` 모듈 추출) + 2026-05-23 dead-export sweep 후속. `keeper_shell_docker.{ml,mli}` 에 3가지 coupled issue.

## 3가지 fix

### 1. `record_docker_exec_failure` qualify (lib build break)

PR #18015 가 함수 본체를 sibling 모듈로 옮겼지만 unqualified 호출 2개 그대로:

```ocaml
- record_docker_exec_failure
+ Keeper_shell_docker_exec_failure.record_docker_exec_failure
```

라인 690 (`run_docker_shell_command_with_status_internal`), 920 (`run_docker_bash`). Build break 직접 원인.

### 2. `docker_exec_failure_message` orphan val drop

`keeper_shell_docker.mli:11-15` 가 val 선언, but `.ml` 에 binding 없음. 함수 본체는 `Keeper_shell_docker_exec_failure.docker_exec_failure_message` 에 살아있음 — 즉 mli가 빈 facade contract.

**Recovery snapshot의 접근법** (해당 모듈에 `let docker_exec_failure_message = X.docker_exec_failure_message` re-export 추가) 은 dead-export 도구가 다시 못 보는 facade. **본 PR은 radical**:
- mli 에서 val 삭제
- 단일 test caller (`test/test_keeper_shell_docker_route.ml:2056`) 를 sibling 모듈 직접 호출로 변경

### 3. `gh_exit_class_field` unused `~cmd` param drop + mli sync

mli/ml 시그니처 mismatch:
- `.mli`: 4-labeled args, no `unit ->`
- `.ml`: same 4 labels + final `()` (5번째 unit arg)

원인 분석 후 발견: function body는 `cmd_stages` (이미 parsed) 만 사용, `cmd:string` 은 dead parameter. Stage-parser refactor 이전 흔적.

**Recovery snapshot의 접근법** (`~(cmd : string)` 명시 annotation + `let _ = cmd in` 으로 unused warning 회피) 은 dead-code workaround. **본 PR은 radical**:
- `~cmd:string` 파라미터를 .mli/.ml/3 lib call site 에서 모두 제거
- `unit ->` 를 mli에 추가해서 .ml의 `()` 와 일치
- doc comment를 `[cmd_stages]` 로 업데이트

## Test 영향

`test/test_gh_exit_class_wiring.ml` 은 **본 PR 이전부터 broken**:
- `KSD.cmd_targets_gh` — keeper_shell_docker 에 존재하지 않음 (다른 dead-export PR 이 stripped)
- 4 caller가 `~cmd_stages` 인자 누락 — 호출 자체가 incomplete

본 PR 은 별개 chain item (#3 test surfaces) 에서 처리. 직접 caller인 `test_keeper_shell_docker_route.ml` 만 sibling 호출로 업데이트.

## 검증

```
$ dune build --root . lib/
# keeper_shell_docker.{ml,mli} 에러 없음
```

잔존 lib 에러:
- `Turn_helpers.turn_progress_callbacks` arity / `keeper_agent_run_turn_helpers.pp.ml` mismatch → 별도 PR (chain #2)
- `AT.stats`, `Path_scope` → 별도 PR

## RFC

RFC-WAIVED: 12-line addition / 19-line deletion (net -7). `lib/keeper/` 만 (+test 1 caller). credential/identity/sandbox/dashboard credential/Claude hooks/workflow 변경 없음.