### PR TITLE
fix(keeper_agent_result): restore 3 mli vals reached via include facade (PR #17971 follow-up)

### DIFF
--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -36,3 +36,20 @@ type run_result =
   ; pre_dispatch_compaction_after_tokens : int option
   }
 
+val tool_call_detail_to_json : tool_call_detail -> Yojson.Safe.t
+(** Serialize a tool call detail to JSON. Reached via the
+    [include Keeper_agent_result] chain in [Keeper_agent_run], where
+    the public surface is exposed under [Keeper_agent_run.mli]. *)
+
+val surface_model_used : run_result -> string
+(** Legacy MASC-facing model label helper. Returns the neutral runtime
+    lane label; OAS owns concrete provider/model identity. Reached via
+    [Keeper_agent_run.surface_model_used] through the include chain;
+    live callers: keeper_unified_metrics_snapshot,
+    keeper_unified_metrics_result, keeper_unified_turn_success. *)
+
+val surface_resolved_model_id : run_result -> string
+(** Legacy MASC-facing resolved model helper. Returns the neutral
+    runtime lane label; OAS owns concrete provider/model identity.
+    Reached via [Keeper_agent_run.surface_resolved_model_id]. *)
+


### PR DESCRIPTION
## Motivation

PR #17971 이 `Keeper_agent_result.{tool_call_detail_to_json, surface_model_used, surface_resolved_model_id}` mli vals 를 "0 external callers" 라고 stripped. 그러나 caller가 `include Keeper_agent_result` 패턴을 통해 `Keeper_agent_run.X` 경유로 access 중 → audit이 include facade를 못 봄.

**8번째** 2026-05-23 sweep 동일 anti-pattern.

## Caller 인벤토리 (실측)

### `tool_call_detail_to_json` — 1 lib caller
- `keeper_unified_metrics_json_support.ml:30` → `Keeper_agent_run.tool_call_detail_to_json`
- 같은 모듈의 `include` 체인으로 `keeper_unified_metrics_decision.ml:207`에 재노출

### `surface_model_used` — 5 lib + 2 test callers
- lib:
  - `keeper_unified_metrics_snapshot.ml:28`
  - `keeper_unified_metrics_result.ml:23`
  - `keeper_unified_turn_success.ml:13, 522`
  - `keeper_unified_metrics_decision.ml:265`
- test:
  - `test_keeper_unified.ml:3698, 3755` via `module KAR = Keeper_agent_result`

### `surface_resolved_model_id` — 5 lib + 2 test callers
- 동일한 5 lib site에 paired
- test: `test_keeper_unified.ml:3760, 3779`

모두 함수 본체는 `keeper_agent_result.ml:16, 73, 75` 에 살아있음 — `.mli` val 만 stripped.

## 수정

3 vals 복원 + 각 docstring에 include 체인 명시 (`Reached via [Keeper_agent_run.X] through the include chain`). 향후 audit이 reachability path를 trace 못해도 docstring에서 발견 가능.

## 검증

```
$ dune build --root . lib/
# keeper_agent_result 관련 에러 없음
```

잔존 lib 에러 (`Turn_helpers.turn_progress_callbacks` arity 등) 는 chain 다음 PR 영역.

## RFC

RFC-WAIVED: 17-line addition / 0 deletion. `lib/keeper/` mli 표면만 복원. credential/identity/sandbox/dashboard credential/Claude hooks/workflow 변경 없음. 동작 동일 (함수 본체 미변경, mli surface만).