### PR TITLE
fix(keeper): correct ?cwd label syntax at 3 callers introduced by #18063

### DIFF
--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -427,7 +427,7 @@ let handle_keeper_shell
                let result =
                  Masc_exec.Exec_dispatch.dispatch_decided envelope
                in
-               render_completed_process_result ~cwd:(Some cwd)
+               render_completed_process_result ~cwd
                  ~cmd:"git --no-optional-locks status --short --branch"
                  ~extra:[]
                  result.status result.stdout
@@ -534,7 +534,7 @@ let handle_keeper_shell
                  then result.stdout
                  else result.stdout ^ result.stderr
                in
-               render_completed_process_result ~cwd:None
+               render_completed_process_result
                  ~cmd:"ls -la"
                  ~extra:[
                    "path", `String target;
@@ -956,7 +956,7 @@ let handle_keeper_shell
                   let result =
                     Masc_exec.Exec_dispatch.dispatch_decided envelope
                   in
-                  render_completed_process_result ~cwd:(Some cwd)
+                  render_completed_process_result ~cwd
                     ~cmd:"git --no-optional-locks log --format=<fmt> -<n>"
                     ~extra:[
                       "count", `Int count;


### PR DESCRIPTION
## Summary

PR #18063 (RFC-0160 PR-2 Shell IR sandbox externalization) 가 \`render_completed_process_result\` 의 optional \`?cwd\` 라벨을 3 사이트에서 잘못 사용:

| 사이트 | Before | After |
|---|---|---|
| line 430 | \`~cwd:(Some cwd)\` | \`~cwd\` |
| line 537 | \`~cwd:None\` | (omitted) |
| line 959 | \`~cwd:(Some cwd)\` | \`~cwd\` |

## OCaml optional argument 문법

함수 시그니처 (line 207):

\`\`\`ocaml
let render_completed_process_result ?cwd ~cmd ?(extra = []) st out = ...
(* cwd : string option, auto-wrap on \`~\` calls *)
\`\`\`

- \`~cwd:value\` — \`value : string\`, OCaml auto-wraps to \`Some value\`
- \`?cwd:value\` — \`value : string option\` verbatim

3 callers 가 \`~\` (auto-wrap) 문법 + 이미 wrapped 된 \`string option\` 값 → 컴파일러가 \`Some (Some cwd) : string option option\` 만들려다 type mismatch.

기존 line 305 가 정확한 패턴:

\`\`\`ocaml
render_completed_process_result ~cwd ~cmd ~extra st (map_output out)
\`\`\`

line 537 의 경우 caller (ls -la 케이스) 가 cwd context 가 없으므로 \`~cwd:None\` 줄을 통째로 삭제 — OCaml optional 은 omission = None.

## Diff

+3 / -3. Net 0 LoC. 컴파일 차단 해소.

## Verification

\`\`\`
dune build --root . lib/
\`\`\`

3 cwd-label errors 모두 사라짐. 남은 lib 빌드 에러 (keeper_agent_run_turn_helpers turn_id mli/ml mismatch + dependent keeper_agent_run.ml:476) 는 별개 PR 영역.

WORKAROUND-FREE.

RFC-WAIVED: PR #18063 의 RFC-0160 PR-2 직접 follow-up, 신규 RFC 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)