### PR TITLE
fix(keeper): expose turn_id in turn_progress_callbacks .mli (PR #18037 follow-up)

### DIFF
--- a/lib/keeper/keeper_agent_run_turn_helpers.mli
+++ b/lib/keeper/keeper_agent_run_turn_helpers.mli
@@ -79,6 +79,7 @@ val turn_progress_callbacks :
   config:Coord.config ->
   keeper_name:string ->
   downstream:(Agent_sdk.Types.sse_event -> unit) option ->
+  turn_id:int ->
   (string -> unit)
   * bool
   * (unit -> unit) option


### PR DESCRIPTION
## Summary

PR #18037 (StreamYieldsTool + ToolReturned FSM transitions wire) 가 \`turn_progress_callbacks\` 에 \`turn_id:int\` 를 추가:

- \`.ml:225\` — signature 에 \`~turn_id\` 추가 ✓
- \`keeper_agent_run.ml:480\` — caller 에 \`~turn_id:manifest_keeper_turn_id\` 전달 ✓
- \`.mli:78-86\` — **누락** 🔴

OCaml 가 .ml/.mli mismatch 즉시 검출:

\`\`\`
Values do not match:
  val turn_progress_callbacks
    config:... -> keeper_name:... -> downstream:... -> turn_id:int -> ...  (* .ml *)
  is not included in
  val turn_progress_callbacks
    config:... -> keeper_name:... -> downstream:... -> ...                  (* .mli *)
\`\`\`

Caller 에러 (\`function applied to too many arguments\`) 는 downstream cascade.

## turn_id 가 real param 임을 확인

\`.ml:239\`, \`.ml:252\` 에서 \`Keeper_turn_fsm.emit_transition ~turn_id\` 로 실사용 — FSM yield/resume 전이 emission 에 필수. dead 아님, optional 아님.

## Fix

\`.mli\` 시그니처에 \`turn_id:int ->\` 1 line 추가 (downstream 와 결과 튜플 사이).

## Diff

+1 LoC.

## Verification

\`\`\`
dune build --root . lib/   →   0 errors (lib/ fully green this iter)
\`\`\`

이번 PR 머지 후 lib/ 빌드 정상화. 남은 test/ 에러는 별개 회귀 영역 (test_keeper_gh_parser_contract / test_dashboard_yjs / test_keeper_shell_ops / test_timeout_policy 등).

## Test plan

- [x] \`dune build --root . lib/\` → 0 errors
- [ ] CI green
- [ ] CodeRabbit / 사람 리뷰 코멘트 대응
- [ ] \`gh pr ready\` 전환 (사용자 라벨 부착 후)

WORKAROUND-FREE: .mli 정상화. compat shim / alias 없음.

RFC-WAIVED: PR #18037 직접 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)