### PR TITLE
fix(keeper): restore lib build after 2026-05-23 sweep follow-ups

### DIFF
--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -36,3 +36,17 @@ type run_result =
   ; pre_dispatch_compaction_after_tokens : int option
   }
 
+val tool_call_detail_to_json : tool_call_detail -> Yojson.Safe.t
+
+(** Legacy MASC-facing model label helper.
+
+    MASC no longer exposes concrete provider/model identity on status,
+    metrics, or dashboard surfaces; OAS owns that resolution. Kept for
+    schema compatibility and returns the neutral runtime lane label. *)
+val surface_model_used : run_result -> string
+
+(** Legacy MASC-facing resolved model helper.
+
+    Kept for schema compatibility and returns the neutral runtime lane label;
+    concrete provider/model identity belongs to OAS telemetry. *)
+val surface_resolved_model_id : run_result -> string

--- a/lib/keeper/keeper_agent_run_turn_helpers.mli
+++ b/lib/keeper/keeper_agent_run_turn_helpers.mli
@@ -79,6 +79,7 @@ val turn_progress_callbacks :
   config:Coord.config ->
   keeper_name:string ->
   downstream:(Agent_sdk.Types.sse_event -> unit) option ->
+  turn_id:int ->
   (string -> unit)
   * bool
   * (unit -> unit) option

--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -427,7 +427,7 @@ let handle_keeper_shell
                let result =
                  Masc_exec.Exec_dispatch.dispatch_decided envelope
                in
-               render_completed_process_result ~cwd:(Some cwd)
+               render_completed_process_result ~cwd
                  ~cmd:"git --no-optional-locks status --short --branch"
                  ~extra:[]
                  result.status result.stdout
@@ -534,7 +534,7 @@ let handle_keeper_shell
                  then result.stdout
                  else result.stdout ^ result.stderr
                in
-               render_completed_process_result ~cwd:None
+               render_completed_process_result
                  ~cmd:"ls -la"
                  ~extra:[
                    "path", `String target;
@@ -956,7 +956,7 @@ let handle_keeper_shell
                   let result =
                     Masc_exec.Exec_dispatch.dispatch_decided envelope
                   in
-                  render_completed_process_result ~cwd:(Some cwd)
+                  render_completed_process_result ~cwd
                     ~cmd:"git --no-optional-locks log --format=<fmt> -<n>"
                     ~extra:[
                       "count", `Int count;


### PR DESCRIPTION
## 목적

어제(2026-05-23) dead-export sweep + sibling refactor에서 누락된 3건의 lib 회귀를 복원합니다. lib 빌드를 그린으로 돌립니다.

## 변경 (3 파일, +18/-3 LoC)

### 1. \`lib/keeper/keeper_agent_run_turn_helpers.mli\`
\`turn_progress_callbacks\` 시그니처에 \`~turn_id:int\` 누락. ml impl + caller (\`keeper_agent_run.ml:480\`) 모두 이미 \`~turn_id:manifest_keeper_turn_id\` 전달 중. mli만 sync 안 됨.

### 2. \`lib/keeper/keeper_shell_ops.ml\` (3 call sites: 430, 537, 959)
\`render_completed_process_result\`는 \`?cwd\` (string option, optional) 선언이지만 3개 call site가 \`~cwd:(Some cwd)\`, \`~cwd:None\` 형태로 \`~cwd:string option\` 처럼 호출 — 타입 오류. Call site 정정:
- \`~cwd:(Some cwd)\` → \`~cwd\` (?cwd가 auto-wrap)
- \`~cwd:None\` → 생략 (default None)

### 3. \`lib/keeper/keeper_agent_result.mli\` — 가장 중요
어제 sweep이 .mli에서 3개 live 함수 export 제거. \`Keeper_agent_run\`가 \`include Keeper_agent_result\` 로 facade re-export하기 때문에 keeper_agent_run.mli 선언들은 *암묵적으로* 만족됐던 것. SSOT(.mli)를 닫으니 한꺼번에 깨짐.

| 함수 | 실제 caller 수 |
|---|---|
| \`tool_call_detail_to_json\` | 4 (keeper_turn, keeper_unified_metrics_{decision,json_support}) |
| \`surface_model_used\` | 4 lib + 2 test |
| \`surface_resolved_model_id\` | 5 lib + 2 test |

dead-export sweep audit 시 \`include\` facade 경유 caller를 못 본 전형적 패턴 (memory: \`feedback_dead_export_audit_must_trace_include_facade.md\`).

## 검증

\`\`\`
dune build --root . @check    # lib/* 전부 그린
\`\`\`

남은 빌드 실패는 \`test/*\`에 국한되며 별도 추적 (일부는 in-flight #18095가 커버, 일부는 후속 PR 후보).

## #18095 와의 관계

이 PR이 건드리는 3 파일 중 \`keeper_agent_run_turn_helpers.mli\`는 #18095 범위에도 포함 — 본 PR이 먼저 머지되면 #18095에서 해당 hunk만 충돌, rebase로 흡수 가능합니다. 나머지 2 파일은 #18095 미커버.