### PR TITLE
refactor(server_state_product): drop ref-accumulator in check_invariants

### DIFF
--- a/lib/server_state_product.ml
+++ b/lib/server_state_product.ml
@@ -190,56 +190,56 @@ let initial = {
 (* ── Cross-Dimension Invariants ─────────────────────────── *)
 
 let check_invariants (state : product) : (unit, string) result =
-  let violations = ref [] in
-  let add v = violations := v :: !violations in
-
   (* I1: Ready implies not booting *)
-  (match state.readiness with
-   | Readiness.Ready ->
-     (match state.lifecycle with
-      | Lifecycle.Booting ->
-        add "readiness=Ready but lifecycle=Booting (cannot be ready while booting)"
-      | Lifecycle.Serving | Lifecycle.Draining | Lifecycle.Stopped -> ())
-   | Readiness.NotReady -> ());
-
+  let i1 = match state.readiness with
+    | Readiness.Ready ->
+      (match state.lifecycle with
+       | Lifecycle.Booting ->
+         Some "readiness=Ready but lifecycle=Booting (cannot be ready while booting)"
+       | Lifecycle.Serving | Lifecycle.Draining | Lifecycle.Stopped -> None)
+    | Readiness.NotReady -> None
+  in
   (* I2: Stopped implies not ready *)
-  (match state.lifecycle with
-   | Lifecycle.Stopped ->
-     (match state.readiness with
-      | Readiness.Ready ->
-        add "lifecycle=Stopped but readiness=Ready (stopped server is never ready)"
-      | Readiness.NotReady -> ())
-   | Lifecycle.Booting | Lifecycle.Serving | Lifecycle.Draining -> ());
-
+  let i2 = match state.lifecycle with
+    | Lifecycle.Stopped ->
+      (match state.readiness with
+       | Readiness.Ready ->
+         Some "lifecycle=Stopped but readiness=Ready (stopped server is never ready)"
+       | Readiness.NotReady -> None)
+    | Lifecycle.Booting | Lifecycle.Serving | Lifecycle.Draining -> None
+  in
   (* I3: Pending tasks block stop *)
-  (match state.lazy_tasks with
-   | Lazy_task_queue.Pending _ ->
-     (match state.lifecycle with
-      | Lifecycle.Stopped ->
-        add "lazy_tasks=Pending but lifecycle=Stopped (cannot stop with pending tasks)"
-      | Lifecycle.Booting | Lifecycle.Serving | Lifecycle.Draining -> ())
-   | Lazy_task_queue.Complete -> ());
-
+  let i3 = match state.lazy_tasks with
+    | Lazy_task_queue.Pending _ ->
+      (match state.lifecycle with
+       | Lifecycle.Stopped ->
+         Some "lazy_tasks=Pending but lifecycle=Stopped (cannot stop with pending tasks)"
+       | Lifecycle.Booting | Lifecycle.Serving | Lifecycle.Draining -> None)
+    | Lazy_task_queue.Complete -> None
+  in
   (* I4: Degraded backend => not ready *)
-  (match state.backend with
-   | Backend.Degraded ->
-     (match state.readiness with
-      | Readiness.Ready ->
-        add "backend=Degraded but readiness=Ready (degraded backend must not serve traffic)"
-      | Readiness.NotReady -> ())
-   | Backend.Uninitialized | Backend.Filesystem -> ());
-
-  (* I5: Booting => backend uninitialized *)
-  (match state.lifecycle with
-   | Lifecycle.Booting ->
-     (match state.backend with
-      | Backend.Uninitialized -> ()
-      | _ ->
-        add (Printf.sprintf "lifecycle=Booting but backend=%s (expected Uninitialized)"
-               (Backend.phase_to_string state.backend)))
-   | Lifecycle.Serving | Lifecycle.Draining | Lifecycle.Stopped -> ());
-
-  match List.rev !violations with
+  let i4 = match state.backend with
+    | Backend.Degraded ->
+      (match state.readiness with
+       | Readiness.Ready ->
+         Some "backend=Degraded but readiness=Ready (degraded backend must not serve traffic)"
+       | Readiness.NotReady -> None)
+    | Backend.Uninitialized | Backend.Filesystem -> None
+  in
+  (* I5: Booting => backend uninitialized.
+     Backend.Filesystem | Backend.Degraded are enumerated explicitly so a
+     new Backend variant fails compilation here rather than silently
+     passing this invariant. *)
+  let i5 = match state.lifecycle with
+    | Lifecycle.Booting ->
+      (match state.backend with
+       | Backend.Uninitialized -> None
+       | (Backend.Filesystem | Backend.Degraded) as b ->
+         Some (Printf.sprintf "lifecycle=Booting but backend=%s (expected Uninitialized)"
+                 (Backend.phase_to_string b)))
+    | Lifecycle.Serving | Lifecycle.Draining | Lifecycle.Stopped -> None
+  in
+  match List.filter_map Fun.id [i1; i2; i3; i4; i5] with
   | [] -> Ok ()
   | vs -> Error (String.concat "; " vs)
 


### PR DESCRIPTION
## 목표

`lib/server_state_product.ml`의 `check_invariants` 함수가 in-function `let violations = ref []` + `add` closure 패턴으로 5개 cross-dimension invariant를 누적하던 것을, 각 invariant를 독립적인 `string option`으로 평가하고 `List.filter_map Fun.id`로 합치는 immutable 형태로 변환.

함수 시그니처와 caller (4 internal + test) 전부 unchanged.

## 왜

- `check_invariants`는 정의상 *순수* 함수 (state → result). `ref` 사용은 OCaml 관례상 lifecycle counter / fiber-shared state / Hashtbl accumulator일 때 정당화되지만, 5개 독립 invariant는 어느 카테고리도 아님 → mutable 정당화 부재.
- `let .. = ref [] in ... add` 패턴은 `software-development.md`의 *function-name-lying* + AI 코드 생성 안티패턴 §1(하드코딩 산포) 인접 시그니처. 명시적 5-tuple로 가시화하면 "어떤 invariant들이 평가되는지" 명확해짐.
- 부수 효과로 I5의 `| _ ->` catch-all을 `Backend.Filesystem | Backend.Degraded`로 명시 확장 — 새 `Backend` variant 추가 시 컴파일 타임 detect. 이는 `software-development.md` §워크어라운드 거부 §4(\"catch-all 추가는 제거가 아닌 추가\")의 *역방향*: catch-all 제거 = 안전망 강화.

## Behavior parity

- Emission 순서: 원본은 `add ... | List.rev`로 I1→I5 순서 emit. 새 코드는 list literal `[i1; i2; i3; i4; i5]`로 동일 순서.
- `Ok ()`: 모든 invariant `None`일 때 — 동일.
- `Error reason`: `String.concat "; " vs` — 동일.
- I5 메시지 byte-equality 검증: 원본 `Backend.phase_to_string state.backend` ↔ 새 코드 `Backend.phase_to_string b` (where `b` is the matched variant) — variant payload가 없으므로 결과 동일.

## 변경 파일

- `lib/server_state_product.ml` (+46 / −46, line-symmetric)

## 로컬 검증

```
$ dune build --root . lib/                    # PASS
$ dune exec --root . test/test_server_state_product.exe
...
Test Successful in 0.003s. 25 tests run.
```

5 invariant 테스트 (I1 ready_not_booting / I2 stopped_not_ready / I3 pending_blocks_stop / I4 degraded_not_ready / I5 booting_uninitialized) + 20 surrounding tests 모두 통과.

## 미검증

- 외부 caller (4 internal `apply_*_event` + `test_server_state_product`) 외 다른 진입점 없음을 `rg` 로 확인했지만 dynamic dispatch / Marshal serialize 등 정적 grep으로 보이지 않는 경로는 검증 안 함.
- CI (full test suite) 결과 대기.

## 관련

- 작업 출처: `/loop 20m ... 잘못된 Mutable 구현을 올바른 Immutable 구현으로 바꾸자`
- 후보 발굴 시 reject한 케이스: `activity_graph_reducer.ml`은 mli docstring이 mutable accumulator를 *single seam* 설계로 명시 — defensive witness retention 대상.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>