### PR TITLE
refactor(server_state_product): name invariants over i1..i5 positional

### DIFF
--- a/lib/server_state_product.ml
+++ b/lib/server_state_product.ml
@@ -190,8 +190,8 @@ let initial = {
 (* ── Cross-Dimension Invariants ─────────────────────────── *)
 
 let check_invariants (state : product) : (unit, string) result =
-  (* I1: Ready implies not booting *)
-  let i1 = match state.readiness with
+  let ready_implies_not_booting =
+    match state.readiness with
     | Readiness.Ready ->
       (match state.lifecycle with
        | Lifecycle.Booting ->
@@ -199,8 +199,8 @@ let check_invariants (state : product) : (unit, string) result =
        | Lifecycle.Serving | Lifecycle.Draining | Lifecycle.Stopped -> None)
     | Readiness.NotReady -> None
   in
-  (* I2: Stopped implies not ready *)
-  let i2 = match state.lifecycle with
+  let stopped_implies_not_ready =
+    match state.lifecycle with
     | Lifecycle.Stopped ->
       (match state.readiness with
        | Readiness.Ready ->
@@ -208,8 +208,8 @@ let check_invariants (state : product) : (unit, string) result =
        | Readiness.NotReady -> None)
     | Lifecycle.Booting | Lifecycle.Serving | Lifecycle.Draining -> None
   in
-  (* I3: Pending tasks block stop *)
-  let i3 = match state.lazy_tasks with
+  let pending_blocks_stop =
+    match state.lazy_tasks with
     | Lazy_task_queue.Pending _ ->
       (match state.lifecycle with
        | Lifecycle.Stopped ->
@@ -217,8 +217,8 @@ let check_invariants (state : product) : (unit, string) result =
        | Lifecycle.Booting | Lifecycle.Serving | Lifecycle.Draining -> None)
     | Lazy_task_queue.Complete -> None
   in
-  (* I4: Degraded backend => not ready *)
-  let i4 = match state.backend with
+  let degraded_implies_not_ready =
+    match state.backend with
     | Backend.Degraded ->
       (match state.readiness with
        | Readiness.Ready ->
@@ -226,11 +226,10 @@ let check_invariants (state : product) : (unit, string) result =
        | Readiness.NotReady -> None)
     | Backend.Uninitialized | Backend.Filesystem -> None
   in
-  (* I5: Booting => backend uninitialized.
-     Backend.Filesystem | Backend.Degraded are enumerated explicitly so a
-     new Backend variant fails compilation here rather than silently
-     passing this invariant. *)
-  let i5 = match state.lifecycle with
+  (* Backend.Filesystem | Backend.Degraded are enumerated explicitly so a new
+     Backend variant fails compilation here rather than silently passing. *)
+  let booting_implies_uninitialized_backend =
+    match state.lifecycle with
     | Lifecycle.Booting ->
       (match state.backend with
        | Backend.Uninitialized -> None
@@ -239,7 +238,16 @@ let check_invariants (state : product) : (unit, string) result =
                  (Backend.phase_to_string b)))
     | Lifecycle.Serving | Lifecycle.Draining | Lifecycle.Stopped -> None
   in
-  match List.filter_map Fun.id [i1; i2; i3; i4; i5] with
+  let violations =
+    List.filter_map Fun.id
+      [ ready_implies_not_booting
+      ; stopped_implies_not_ready
+      ; pending_blocks_stop
+      ; degraded_implies_not_ready
+      ; booting_implies_uninitialized_backend
+      ]
+  in
+  match violations with
   | [] -> Ok ()
   | vs -> Error (String.concat "; " vs)
 


### PR DESCRIPTION
## 목표

PR #18106의 follow-up. `check_invariants`가 5개의 cross-dimension invariant를 `i1..i5`라는 positional index로 binding하던 것을, 이미 존재하는 테스트 이름(`I1 ready_not_booting` 등)과 정렬된 descriptive name으로 교체.

## 왜

PR #18106이 `let .. = ref [] in ... add` → 5개 sequential `let` immutable 패턴으로 옮기면서, 새로 도입된 binding이 *이름값*을 못 챙겼습니다.

- `i1..i5`는 magic-positional name — `software-development.md` *Magic Number 금지* 의 정신과 충돌. 숫자 리터럴은 아니지만 "의미를 드러내지 않는 식별자"는 같은 안티패턴.
- 원본 (`let violations = ref [] in ... (match ... add ...)`) 은 *공간적*으로 각 블록의 의미를 드러냈지만, refactor 후 binding은 번호만 남았음.
- 정작 `test_server_state_product.ml`은 이미 의미 있는 이름을 사용 (`I1 ready_not_booting`, `I2 stopped_not_ready`, ...). 소스/테스트 간 명명 불일치.

## 변경

| Before | After |
|--------|-------|
| `i1` | `ready_implies_not_booting` |
| `i2` | `stopped_implies_not_ready` |
| `i3` | `pending_blocks_stop` |
| `i4` | `degraded_implies_not_ready` |
| `i5` | `booting_implies_uninitialized_backend` |

이름이 의미를 다 드러내므로 `(* I1: Ready implies not booting *)` 같은 인덱스 주석은 제거 (`software-development.md` "주석은 동작을 기술" 원칙).

Backend variant exhaustiveness 주석 (`Backend.Filesystem | Backend.Degraded are enumerated explicitly...`) 은 `booting_implies_uninitialized_backend` 위로 위치만 조정.

`List.filter_map Fun.id [...]` 의 리스트도 named binding으로 한 줄씩 분리 → 5개 항목이 시각적으로 식별됨.

## Behavior parity

- 함수 시그니처 unchanged: `(product) -> (unit, string) result`
- 평가 순서 unchanged: `ready_implies_not_booting → ... → booting_implies_uninitialized_backend` (= 기존 i1→i5)
- 에러 메시지 byte-identical (5개 모두)
- `Ok ()` / `Error (String.concat "; " vs)` 동일

## 변경 파일

- `lib/server_state_product.ml` (+22 / −14, 이름이 길어서 line-asymmetric — 의도적)

## 로컬 검증

```
$ dune build --root . lib/
$ dune exec --root . test/test_server_state_product.exe
...
Test Successful in 0.004s. 25 tests run.
```

5 invariant + 20 surrounding tests 통과 (PR #18106과 동일 구성).

## 미검증

- 외부 caller (4 internal `apply_*_event` + `test_server_state_product`) 외 진입점 없음을 `rg "check_invariants"`로 재확인. 함수 이름은 바뀌지 않았고 내부 변수만 rename이므로 caller 영향 0.
- CI full suite 결과 대기.

## 관련

- PR #18106 (parent refactor)
- 사용자 리뷰 트리거: "let i4 = match state.backend with i4? i5? i6? 내가 뭔가 오해하는건가" → 시각적 충격의 진짜 원인이 네이밍이라는 합의

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>