### PR TITLE
refactor(chronicle_validate): drop ref-accumulator in validate_epoch

### DIFF
--- a/lib/chronicle_validate.ml
+++ b/lib/chronicle_validate.ml
@@ -141,29 +141,33 @@ let validate_epoch ~workdir epoch =
   let rfc_refs_valid =
     List.map (rfc_file_exists ~workdir) epoch.Chronicle_types.rfc_refs
   in
-  let warnings = ref [] in
-  if not start_ok then
-    warnings :=
-      Printf.sprintf "start_commit %s not found"
-        epoch.Chronicle_types.start_commit
-      :: !warnings;
-  if not end_ok then
-    warnings :=
-      Printf.sprintf "end_commit %s not found"
-        epoch.Chronicle_types.end_commit
-      :: !warnings;
-  if not file_range_check && key_paths <> [] then
-    warnings := "some key_files not in commit range" :: !warnings;
   let rfc_invalid =
     List.filter (fun (_, valid) -> not valid)
       (List.combine epoch.Chronicle_types.rfc_refs rfc_refs_valid)
     |> List.map (fun (r, _) -> r)
   in
-  if rfc_invalid <> [] then
-    warnings :=
-      Printf.sprintf "missing RFC files: %s"
-        (String.concat ", " rfc_invalid)
-      :: !warnings;
+  let warnings =
+    List.filter_map Fun.id
+      [ (if not start_ok then
+           Some
+             (Printf.sprintf "start_commit %s not found"
+                epoch.Chronicle_types.start_commit)
+         else None)
+      ; (if not end_ok then
+           Some
+             (Printf.sprintf "end_commit %s not found"
+                epoch.Chronicle_types.end_commit)
+         else None)
+      ; (if (not file_range_check) && key_paths <> [] then
+           Some "some key_files not in commit range"
+         else None)
+      ; (if rfc_invalid <> [] then
+           Some
+             (Printf.sprintf "missing RFC files: %s"
+                (String.concat ", " rfc_invalid))
+         else None)
+      ]
+  in
   let verification_score =
     compute_score ~sha_check ~file_range_check ~rfc_refs_valid
   in
@@ -174,5 +178,5 @@ let validate_epoch ~workdir epoch =
   ; file_range_check
   ; rfc_refs_valid
   ; verification_score
-  ; warnings = List.rev !warnings
+  ; warnings
   }


### PR DESCRIPTION
## 목표

`lib/chronicle_validate.ml`의 `validate_epoch` 함수에서 `let warnings = ref []` + 4회의 `warnings := ... :: !warnings` 패턴을 제거하고, 4개 conditional warning을 list literal + `List.filter_map Fun.id`로 직접 emit하도록 변환.

## 왜

- `validate_epoch`는 순수 함수 (입력 → \`validation_result\` record). \`ref\` 사용은 OCaml 관례상 lifecycle counter / Hashtbl accumulator / fiber-shared state일 때만 정당화되며, 4개 독립 conditional warning은 어느 카테고리도 아님 → mutable 정당화 부재.
- 원본은 `rfc_invalid` 계산이 *두 `warnings := ` 사이*에 끼어 있어 데이터 의존성이 side-effect 사이에 묻혀 있음. immutable 변환의 부산물로 `rfc_invalid` 계산이 warnings literal *이전*으로 hoist되어 순수 데이터 흐름이 명시됨.
- #18106 (`server_state_product.check_invariants`) follow-up. 같은 ref-accumulator anti-pattern.

## Behavior parity

- emission 순서: 원본은 reverse-append + 최종 `List.rev`로 `start_ok → end_ok → file_range → rfc_invalid` 순서 emit. 새 코드는 list literal 위치로 같은 순서 유지.
- empty case: 모든 4개 \`None\` → `[]` (원본 동일).
- 각 string content는 그대로.

## 변경 파일

- `lib/chronicle_validate.ml` (+23 / −19, net +4 due to list literal formatting)

## 로컬 검증

\`\`\`
\$ dune build --root . lib/                                # PASS
\$ dune exec --root . test/test_chronicle_validate.exe
...
Test Successful in 0.002s. 11 tests run.
\`\`\`

## 미검증

- 단일 module + 단일 caller (`test_chronicle_validate.ml`). 외부 caller 없음 확인 (\`rg -l \"Chronicle_validate\" lib/ test/\`).
- 테스트는 \`List.length warnings\` 만 검사 (순서/내용 lock 없음) → 변환 안전.

## 관련

- \`/loop 20m ... 잘못된 Mutable 구현을 올바른 Immutable 구현으로 바꾸자\` iter #2
- iter #1: #18106 server_state_product (merged)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>