### PR TITLE
refactor(keeper): remove vestigial surface_*_model helpers, expose runtime_lane_label

### DIFF
--- a/lib/keeper/keeper_agent_result.ml
+++ b/lib/keeper/keeper_agent_result.ml
@@ -69,8 +69,3 @@ type run_result =
 (* RFC-0132 PR-2: agent-result surface label = external boundary; redact via SSOT. *)
 let runtime_lane_label =
   Boundary_redaction.to_string Boundary_redaction.runtime_model_label
-
-let surface_model_used (_result : run_result) : string = runtime_lane_label
-
-let surface_resolved_model_id (_result : run_result) : string =
-  runtime_lane_label

--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -41,15 +41,9 @@ val tool_call_detail_to_json : tool_call_detail -> Yojson.Safe.t
     [include Keeper_agent_result] chain in [Keeper_agent_run], where
     the public surface is exposed under [Keeper_agent_run.mli]. *)
 
-val surface_model_used : run_result -> string
-(** Legacy MASC-facing model label helper. Returns the neutral runtime
-    lane label; OAS owns concrete provider/model identity. Reached via
-    [Keeper_agent_run.surface_model_used] through the include chain;
-    live callers: keeper_unified_metrics_snapshot,
-    keeper_unified_metrics_result, keeper_unified_turn_success. *)
-
-val surface_resolved_model_id : run_result -> string
-(** Legacy MASC-facing resolved model helper. Returns the neutral
-    runtime lane label; OAS owns concrete provider/model identity.
-    Reached via [Keeper_agent_run.surface_resolved_model_id]. *)
+val runtime_lane_label : string
+(** Boundary-redacted label used wherever MASC's keeper metrics surface
+    exposes a model identity field. OAS owns concrete provider/model
+    identity; the keeper-side surface collapses to this single label
+    via [Boundary_redaction]. *)
 

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -169,18 +169,11 @@ val turn_affordances_require_tool_gate_with_allowed
   -> string list
   -> bool
 
-(** Legacy MASC-facing model label helper.
-
-    MASC no longer exposes concrete provider/model identity on status,
-    metrics, or dashboard surfaces; OAS owns that resolution. Kept for
-    schema compatibility and returns the neutral runtime lane label. *)
-val surface_model_used : run_result -> string
-
-(** Legacy MASC-facing resolved model helper.
-
-    Kept for schema compatibility and returns the neutral runtime lane label;
-    concrete provider/model identity belongs to OAS telemetry. *)
-val surface_resolved_model_id : run_result -> string
+(** Boundary-redacted label used wherever MASC's keeper metrics surface
+    exposes a model identity field. OAS owns concrete provider/model
+    identity; the keeper-side surface collapses to this single label
+    via [Boundary_redaction]. *)
+val runtime_lane_label : string
 
 (** {1 Telemetry serialisation} *)
 

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -32,7 +32,7 @@ let resolved_model_id_for_result ~(meta : keeper_meta)
 let turn_cost_for_result ~(meta : keeper_meta)
     (result : Keeper_agent_run.run_result) : float =
   let resolved_model_id = resolved_model_id_for_result ~meta result in
-  let surface_model_used = Keeper_agent_run.surface_model_used result in
+  let surface_model_used = Keeper_agent_run.runtime_lane_label in
   let usage_trust =
     Keeper_unified_metrics.classify_usage_trust
       ~usage_reported:result.usage_reported
@@ -52,7 +52,7 @@ let update_direct_turn_meta (meta : keeper_meta) ~(latency_ms : int)
     (result : Keeper_agent_run.run_result) : keeper_meta =
   let now_ts = Time_compat.now () in
   let turn_cost = turn_cost_for_result ~meta result in
-  let surface_model_used = Keeper_agent_run.surface_model_used result in
+  let surface_model_used = Keeper_agent_run.runtime_lane_label in
   let resolved_model_id = resolved_model_id_for_result ~meta result in
   let usage_trust =
     Keeper_unified_metrics.classify_usage_trust
@@ -708,7 +708,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               Progress.Tracker.complete turn_tracker
                 ~message:(Printf.sprintf "Turn completed: %d tool calls" result.tool_calls_made) ();
               let reply_json =
-                let surface_model_used = Keeper_agent_run.surface_model_used result in
+                let surface_model_used = Keeper_agent_run.runtime_lane_label in
                 let u = result.usage in
                 let cost_field = match u.cost_usd with
                   | Some c -> `Float c

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -262,9 +262,9 @@ let append_decision_record
         ( "telemetry",
           match result with
           | Some r ->
-              let surface_model_used = Keeper_agent_run.surface_model_used r in
+              let surface_model_used = Keeper_agent_run.runtime_lane_label in
               let resolved_model_id =
-                Keeper_agent_run.surface_resolved_model_id r
+                Keeper_agent_run.runtime_lane_label
               in
               let telemetry_reported = telemetry_reported_of_result r in
               let coverage_reason = coverage_reason_of_result r in

--- a/lib/keeper/keeper_unified_metrics_result.ml
+++ b/lib/keeper/keeper_unified_metrics_result.ml
@@ -20,8 +20,8 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
     ?(context_max = 0)
     (result : Keeper_agent_run.run_result) : keeper_meta =
   let now_ts = Time_compat.now () in
-  let surface_model_used = Keeper_agent_run.surface_model_used result in
-  let resolved_model_id = Keeper_agent_run.surface_resolved_model_id result in
+  let surface_model_used = Keeper_agent_run.runtime_lane_label in
+  let resolved_model_id = Keeper_agent_run.runtime_lane_label in
   let usage_trust =
     classify_usage_trust
       ~usage_reported:result.usage_reported

--- a/lib/keeper/keeper_unified_metrics_snapshot.ml
+++ b/lib/keeper/keeper_unified_metrics_snapshot.ml
@@ -25,8 +25,8 @@ let append_metrics_snapshot ~(config : Coord.config) ~(meta : keeper_meta)
   let now_ts = Time_compat.now () in
   let _observation = observation in
   let turn_mode = turn_mode_of_result result in
-  let surface_model_used = Keeper_agent_run.surface_model_used result in
-  let resolved_model_id = Keeper_agent_run.surface_resolved_model_id result in
+  let surface_model_used = Keeper_agent_run.runtime_lane_label in
+  let resolved_model_id = Keeper_agent_run.runtime_lane_label in
   let usage_trust =
     classify_usage_trust
       ~usage_reported:result.usage_reported

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -10,8 +10,8 @@ let runtime_lane_label =
   Boundary_redaction.to_string Boundary_redaction.runtime_model_label
 
 let turn_cost result =
-  let used_model_id = Keeper_agent_run.surface_model_used result in
-  let resolved_model_id = Keeper_agent_run.surface_resolved_model_id result in
+  let used_model_id = Keeper_agent_run.runtime_lane_label in
+  let resolved_model_id = Keeper_agent_run.runtime_lane_label in
   let usage_trust_for_cost =
     KUM.classify_usage_trust
       ~usage_reported:result.Keeper_agent_run.usage_reported
@@ -519,8 +519,8 @@ let handle
     ~last_provider_timeout_budget;
   let turn_mode = KUM.turn_mode_of_result result in
   let turn_mode_label = KUM.turn_mode_to_string turn_mode in
-  let model_used = Keeper_agent_run.surface_model_used result in
-  let resolved_model_id = Keeper_agent_run.surface_resolved_model_id result in
+  let model_used = Keeper_agent_run.runtime_lane_label in
+  let resolved_model_id = Keeper_agent_run.runtime_lane_label in
   let usage_trust =
     KUM.classify_usage_trust
       ~usage_reported:result.Keeper_agent_run.usage_reported

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -3695,88 +3695,12 @@ let test_metrics_surface_model_prefers_successful_cascade_label () =
     string
     "helper redacts surface model"
     "runtime"
-    (KAR.surface_model_used result);
+    (KAR.runtime_lane_label);
   check
     string
     "last_model_used no longer stores concrete surface label"
     ""
     updated.runtime.usage.last_model_used
-;;
-
-(* Provider/model identity is OAS-owned; MASC status/metrics helpers keep the
-   legacy fields but collapse both display and resolved ids to the runtime
-   lane. *)
-let test_metrics_resolved_model_id_prefers_last_attempt_id () =
-  let result =
-    make_run_result
-      ~text:"I checked the board."
-      ~tools:[]
-      ~model:"claude-opus-4-6"
-      ~input_tok:100
-      ~output_tok:50
-      ~cascade_observation:
-        { Masc_mcp.Cascade_legacy_runner.cascade_name =
-            Masc_mcp.Keeper_cascade_profile.Runtime_name
-              Masc_mcp.(Keeper_config.default_cascade_name ())
-        ; strategy = Some "round_robin"
-        ; configured_labels = [ "claude_code:auto" ]
-        ; candidate_models = [ "claude-sonnet-4-6"; "claude-opus-4-6" ]
-        ; primary_model = Some "claude-sonnet-4-6"
-        ; selected_model = Some "claude-opus-4-6"
-        ; selected_model_raw = Some "claude-opus-4-6"
-        ; selected_index = None
-        ; fallback_hops = Some 1
-        ; fallback_applied = true
-        ; attempts =
-            [ { Masc_mcp.Cascade_legacy_runner.attempt_index = 0
-              ; model_id = "claude-sonnet-4-6"
-              ; model_label = Some "claude_code:auto"
-              ; latency_ms = None
-              ; error = Some "HTTP 503"
-              }
-            ; { attempt_index = 1
-              ; model_id = "claude-opus-4-6"
-              ; model_label = Some "claude_code:auto"
-              ; latency_ms = Some 187
-              ; error = None
-              }
-            ]
-        ; fallback_events = []
-        ; attempt_details_available = true
-        ; attempt_details_source = "oas_metrics_callbacks"
-        ; oas_internal_cascade_allowed = false
-        }
-      ()
-  in
-  check
-    string
-    "surface_model_used returns runtime lane"
-    "runtime"
-    (KAR.surface_model_used result);
-  check
-    string
-    "surface_resolved_model_id returns runtime lane"
-    "runtime"
-    (KAR.surface_resolved_model_id result)
-;;
-
-(* Non-cascade keeper turns are redacted the same way: provider-reported
-   model_used remains an OAS bridge detail, not a MASC surface. *)
-let test_metrics_resolved_model_id_fallback_to_model_used () =
-  let result =
-    make_run_result
-      ~text:"ok"
-      ~tools:[]
-      ~model:"claude-opus-4-6"
-      ~input_tok:10
-      ~output_tok:5
-      ()
-  in
-  check
-    string
-    "surface_resolved_model_id redacts provider model"
-    "runtime"
-    (KAR.surface_resolved_model_id result)
 ;;
 
 let test_metrics_tool_response () =
@@ -11409,14 +11333,6 @@ let () =
             "surface model prefers successful cascade label"
             `Quick
             test_metrics_surface_model_prefers_successful_cascade_label
-        ; test_case
-            "resolved_model_id prefers last attempt id (#9953)"
-            `Quick
-            test_metrics_resolved_model_id_prefers_last_attempt_id
-        ; test_case
-            "resolved_model_id falls back to model_used (#9953)"
-            `Quick
-            test_metrics_resolved_model_id_fallback_to_model_used
         ; test_case "tool response" `Quick test_metrics_tool_response
         ; test_case "noop response" `Quick test_metrics_noop_response
         ; test_case


### PR DESCRIPTION
## 목적

PR #18101이 \`surface_model_used\` / \`surface_resolved_model_id\`를 keeper_agent_result.mli에 복원해 빌드를 그린으로 돌렸습니다. 이번 PR은 그 위에서 두 함수의 *근본 vestigial 상태*를 정리합니다.

## 진단

두 함수 구현:

\`\`\`ocaml
let surface_model_used (_result : run_result) : string = runtime_lane_label
let surface_resolved_model_id (_result : run_result) : string = runtime_lane_label
\`\`\`

\`_result\` underscore prefix는 *의도적으로 input을 무시*한다는 OCaml convention. 즉 두 함수는 **\`run_result\`를 받지만 그 값을 보지 않고 항상 같은 상수를 반환**.

### "redaction enforcement" 아님

원래 의도는 "MASC 외부 surface에 provider model ID가 leak되지 않도록 boundary redaction"이었지만:

- 컴파일러가 caller에게 이 함수를 강제하지 않음 (\`~model_used:result.model_used\` 직접 호출 가능)
- 따라서 type-level enforcement가 아닌 *naming convention*에 불과
- 테스트가 검증한다는 "redaction"도 input을 무시하기 때문에 tautology

실질적 redaction guarantee는 *snapshot 쓰기 사이트*의 \`last_model_used = ""\` 같은 invariant에서 검증됩니다 — 그 테스트는 보존.

## 변경

- \`lib/keeper/keeper_agent_result.{ml,mli}\`: 두 함수 삭제. mli에 \`val runtime_lane_label : string\` 추가.
- \`lib/keeper/keeper_agent_run.mli\`: 두 val 재선언 제거. \`runtime_lane_label\` 노출.
- 11 call site (5 lib 파일) caller migration:
  - \`Keeper_agent_run.surface_*_model... result\` → \`Keeper_agent_run.runtime_lane_label\`
  - 파일: keeper_turn, keeper_unified_metrics_{decision,result,snapshot}, keeper_unified_turn_success
- \`test/test_keeper_unified.ml\`: 두 tautology test 삭제 (\`test_metrics_resolved_model_id_prefers_last_attempt_id\`, \`test_metrics_resolved_model_id_fallback_to_model_used\`). 둘은 maigrate 후 \`assert (constant = "runtime")\`로 환원됨. 의미있는 \`last_model_used = ""\` no-leak invariant 검증은 별 test에 보존.

## 검증

\`\`\`
dune build lib/   # green
dune build @check # lib/* clean. test/* 잔여 회귀는 별 영역 (Prompt_defaults.init 등 in-flight #18095 커버)
\`\`\`

## Net diff

\`-102 LoC\` (-126/+24 across 9 files).

## #18101 과의 관계

#18101을 *기반*으로 합니다. #18101 머지가 mandatory prerequisite (이미 머지됨). 본 PR이 머지되면 두 함수는 영구 제거 — RFC-0132 PR-2의 boundary redaction은 \`Boundary_redaction\` SSOT + caller naming + snapshot-site invariant 테스트로 일관됩니다.