### PR TITLE
fix(timeout_policy): expose Deadline.remaining + metric_overshoot_total in .mli

### DIFF
--- a/lib/timeout_policy.mli
+++ b/lib/timeout_policy.mli
@@ -47,7 +47,16 @@ module Deadline : sig
     -> t
 
   val elapsed : t -> now:float -> float
+
+  val remaining : t -> now:float -> float
+  (** [remaining t ~now] is [t.wall_cap_s -. elapsed t ~now].
+      Negative values mean the deadline has passed by that many seconds. *)
 end
+
+val metric_overshoot_total : string
+(** Canonical Prometheus counter name (pinned by #9662 contract test):
+    [masc_timeout_policy_overshoot_total].  Incremented by
+    [overshoot_warn] with [layer] and [origin] labels. *)
 
 val overshoot_warn
   :  ?slack_s:float


### PR DESCRIPTION
## Summary

\`lib/timeout_policy.ml\` 두 심볼이 \`.mli\` 노출 누락:

| Symbol | .ml | .mli | 외부 사용 |
|---|---|---|---|
| \`Deadline.remaining\` | line 29 | 없음 | \`test_timeout_policy.ml:51\` |
| \`metric_overshoot_total\` | line 56 | 없음 (docstring 만 \`{!metric_overshoot_total}\` 참조) | \`test_timeout_policy_overshoot_counter.ml:16,27\` (#9662 contract test) |

\`overshoot_warn\` 의 docstring 이 이미 \`{!metric_overshoot_total}\` 로 cross-reference → \`.mli\` omission 은 의도되지 않은 누락.

## Fix

\`.mli\` 에 두 \`val\` 선언 추가 (각각 docstring 포함):

\`\`\`ocaml
val remaining : t -> now:float -> float
(** [remaining t ~now] is [t.wall_cap_s -. elapsed t ~now].
    Negative values mean the deadline has passed by that many seconds. *)

val metric_overshoot_total : string
(** Canonical Prometheus counter name (pinned by #9662 contract test):
    [masc_timeout_policy_overshoot_total]. *)
\`\`\`

\`.ml\` 변경 없음. semantic shift 0.

## Diff

+9 LoC, .mli만.

## Verification

\`\`\`
dune build --root . lib/   →  EXIT=0 (lib green 유지)
dune build --root .        →  2 Timeout_policy 관련 test unbound 해소
\`\`\`

남은 test/ 회귀 (test_dashboard_yjs, test_keeper_gh_parser_contract, test_keeper_shell_ops, test_fd_accountant, test_exec_shell_command_gate, test_docker_spawn_throttle, test_keeper_exec_status, test_keeper_toml, test_auth_strict_mode, test_cascade_name 등) 는 다른 영역 회귀.

## Philosophy

\`feedback_partial_module_orphan_check_all_exports\` 의 패턴 예방 — .ml 정의되어 있지만 .mli 누락은 *bind sites 가 외부에 있을 때* immediate test failure. 본 fix 는 *지워진 surface 복구* 가 아니라 *원래 의도된 surface 의 .mli expose 누락 보강*. compat shim 아님.

WORKAROUND-FREE.

RFC-WAIVED: .mli expose 누락 직접 보강.

🤖 Generated with [Claude Code](https://claude.com/claude-code)