### PR TITLE
refactor(keeper): re-extract Keeper_hooks_oas_gate_attempt sibling module (RFC-0151 Step B)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -280,6 +280,7 @@
   keeper_hooks_oas_output_json
   keeper_hooks_oas_response_metrics
   keeper_hooks_oas_cost_events
+  keeper_hooks_oas_gate_attempt
   keeper_hooks_oas_idle
   keeper_hooks_oas_introspection
   keeper_hooks_oas_pr_metrics

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -189,167 +189,20 @@ include Keeper_hooks_oas_cost_events
 
 include Keeper_hooks_oas_idle
 
-(* Pre-tool gate attempt rendering and telemetry. Inlined from former
-   [Keeper_hooks_oas_gate_attempt] (deleted) — keeper_hooks_oas.ml is the
-   only production consumer and tests reach these through the parent
-   module surface, so the standalone submodule added indirection without
-   value. *)
+(* Pre-tool gate attempt helpers — see [Keeper_hooks_oas_gate_attempt].
+   Re-exported here so existing parent-surface callers (incl. tests)
+   keep working unchanged. *)
+let render_pre_tool_gate_output =
+  Keeper_hooks_oas_gate_attempt.render_pre_tool_gate_output
 
-let render_pre_tool_gate_source_hint
-    (event : Keeper_guards.gate_decision_event) =
-  match event.source_path, event.source_line with
-  | None, None -> ""
-  | Some path, None ->
-      Printf.sprintf " source_path=%s" (Keeper_guards.escape_field path)
-  | None, Some line -> Printf.sprintf " source_line=%d" line
-  | Some path, Some line ->
-      Printf.sprintf " source_path=%s source_line=%d"
-        (Keeper_guards.escape_field path) line
+let pre_tool_gate_error =
+  Keeper_hooks_oas_gate_attempt.pre_tool_gate_error
 
-let tool_approval_required_tag = "[tool_approval_required]"
+let trajectory_duration_ms =
+  Keeper_hooks_oas_gate_attempt.trajectory_duration_ms
 
-let render_pre_tool_gate_output (event : Keeper_guards.gate_decision_event) =
-  if event.decision = Keeper_guards.Gate_approval_required then
-    Printf.sprintf
-      "%s tool=%s source=keeper_hook code=%s reason=%s%s"
-      tool_approval_required_tag
-      (Keeper_guards.escape_field event.tool_name)
-      (Keeper_guards.escape_field event.reason_code)
-      (Keeper_guards.escape_field event.reason_text)
-      (render_pre_tool_gate_source_hint event)
-  else
-    match event.source_path, event.source_line with
-    | Some source_path, Some source_line ->
-        Keeper_guards.render_inline_skip_reason_with_source
-          ~source_path
-          ~source_line
-          ~tool_name:event.tool_name
-          ~reason_code:event.reason_code
-          ~reason_text:event.reason_text
-    | _ ->
-        Keeper_guards.render_inline_skip_reason
-          ~tool_name:event.tool_name
-          ~reason_code:event.reason_code
-          ~reason_text:event.reason_text
-
-let pre_tool_gate_error (event : Keeper_guards.gate_decision_event) =
-  let decision = Keeper_guards.gate_decision_to_string event.decision in
-  Printf.sprintf "%s:%s: %s" decision event.reason_code event.reason_text
-
-let min_duration_ms = 0.0
-
-let trajectory_duration_ms duration_ms =
-  if
-    (not (Float.is_finite duration_ms))
-    || Float.compare duration_ms min_duration_ms <= 0
-  then 0
-  else max 1 (int_of_float (Float.round duration_ms))
-
-let record_pre_tool_gate_attempt
-    ~(meta_ref : Keeper_types.keeper_meta ref)
-    ~(tool_call_count_ref : int ref)
-    ?(trajectory_acc : Trajectory.accumulator option)
-    (event : Keeper_guards.gate_decision_event) =
-  incr tool_call_count_ref;
-  let meta = !meta_ref in
-  let keeper_name = meta.name in
-  let model = current_keeper_model meta in
-  let safe_input = Observability_redact.redact_json_value event.input in
-  let output_text = render_pre_tool_gate_output event in
-  let error = pre_tool_gate_error event in
-  let duration_ms = Float.max 0.0 event.stage_latency_ms in
-  (try
-     Keeper_tool_call_log.log_call
-       ~keeper_name
-       ~tool_name:event.tool_name
-       ~input:safe_input
-       ~output_text
-       ~success:false
-       ~duration_ms
-       ~model
-       ~result_bytes:(String.length output_text)
-       ()
-   with
-   | Eio.Cancel.Cancelled _ as e -> raise e
-   | exn ->
-       let callback_label_gate_tool_call_log = "gate_tool_call_log" in
-       Prometheus.inc_counter
-         Keeper_metrics.metric_keeper_lifecycle_callback_failures
-         ~labels:
-           [
-             (label_keeper, keeper_name);
-             (label_callback, callback_label_gate_tool_call_log);
-           ]
-         ();
-       Log.Keeper.warn
-         "keeper:%s pre_tool_use gate tool_call log failed tool=%s err=%s"
-         keeper_name event.tool_name (Printexc.to_string exn));
-  match trajectory_acc with
-  | None -> ()
-  | Some acc ->
-      let trace_id = acc.Trajectory.trace_id in
-      let runtime_contract =
-        Keeper_tool_call_log.runtime_contract_json_for_call
-          ~keeper_name
-          ~model
-          ()
-      in
-      let action_radius =
-        Keeper_tool_call_log.action_radius_json_for_call
-          ~keeper_name
-          ~tool_name:event.tool_name
-          ~input:safe_input
-          ~success:false
-          ~duration_ms
-          ~error
-          ()
-      in
-      let now = Time_compat.now () in
-      let turn = if event.turn > 0 then event.turn else acc.Trajectory.turn in
-      let round =
-        acc.Trajectory.entries
-        |> List.filter (fun (e : Trajectory.tool_call_entry) -> e.turn = turn)
-        |> List.length
-        |> ( + ) 1
-      in
-      let entry : Trajectory.tool_call_entry =
-        {
-          ts = now;
-          ts_iso = Masc_domain.iso8601_of_unix_seconds now;
-          turn;
-          round;
-          tool_name = event.tool_name;
-          args_json = Yojson.Safe.to_string safe_input;
-          gate_decision = Trajectory.Reject error;
-          result = Some output_text;
-          duration_ms = trajectory_duration_ms duration_ms;
-          error = Some error;
-          cost_usd = 0.0;
-        }
-      in
-      Trajectory.record_entry
-        ~runtime_contract
-        ~action_radius
-        ~on_persist_error:(fun exn ->
-          let dashboard_surface_tool_stats = "/api/v1/keepers/:name/tool-stats" in
-          let stale_reason_trajectory_append = "trajectory_append_failed" in
-          let telemetry_source_trajectory = "trajectory_tool_call" in
-          let telemetry_producer_pre_tool = "keeper_hooks_oas.pre_tool_use" in
-          Telemetry_coverage_gap.record
-            ~masc_root:acc.Trajectory.masc_root
-            ~source:telemetry_source_trajectory
-            ~producer:telemetry_producer_pre_tool
-            ~durable_store:
-              (Trajectory.trajectory_path acc.Trajectory.masc_root
-                 acc.Trajectory.keeper_name trace_id)
-            ~dashboard_surface:dashboard_surface_tool_stats
-            ~stale_reason:stale_reason_trajectory_append
-            ~keeper_name
-            ~trace_id
-            ~exn
-            ())
-        acc
-        entry
+let record_pre_tool_gate_attempt =
+  Keeper_hooks_oas_gate_attempt.record_pre_tool_gate_attempt
 
 
 let make_hooks

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -172,9 +172,10 @@ val recent_tool_streak_count :
 
 (** {1 Pre-tool gate attempt rendering and telemetry}
 
-    Inlined from former [Keeper_hooks_oas_gate_attempt] (deleted) —
-    this module is the only production consumer and tests reach these
-    through the parent module surface. *)
+    Implementation lives in [Keeper_hooks_oas_gate_attempt]; the values
+    here are re-exports so existing parent-surface callers (including
+    [test_keeper_guards] and [test_keeper_hooks_oas_telemetry]) keep
+    working unchanged. *)
 
 val render_pre_tool_gate_output :
   Keeper_guards.gate_decision_event -> string

--- a/lib/keeper/keeper_hooks_oas_gate_attempt.ml
+++ b/lib/keeper/keeper_hooks_oas_gate_attempt.ml
@@ -1,0 +1,172 @@
+(** Keeper_hooks_oas_gate_attempt — pre-tool gate attempt rendering and
+    telemetry.
+
+    Extracted from [Keeper_hooks_oas] (2026-05-23, Step B of RFC-0151
+    godfile decomposition) to drop [keeper_hooks_oas.ml] below the
+    1000-LoC ratchet threshold.
+
+    Historical note: this code existed as a sibling module restored by
+    PR #18083, then inlined into [Keeper_hooks_oas] by PR #18086 with
+    a "one-consumer submodule" justification. That justification
+    optimized for local elegance but ignored the RFC-0151 godfile
+    policy — the parent file crossed 1000 LoC. This module restores
+    the original sibling decomposition. *)
+
+open Keeper_hooks_oas_types
+
+let render_pre_tool_gate_source_hint
+    (event : Keeper_guards.gate_decision_event) =
+  match event.source_path, event.source_line with
+  | None, None -> ""
+  | Some path, None ->
+      Printf.sprintf " source_path=%s" (Keeper_guards.escape_field path)
+  | None, Some line -> Printf.sprintf " source_line=%d" line
+  | Some path, Some line ->
+      Printf.sprintf " source_path=%s source_line=%d"
+        (Keeper_guards.escape_field path) line
+
+let tool_approval_required_tag = "[tool_approval_required]"
+
+let render_pre_tool_gate_output (event : Keeper_guards.gate_decision_event) =
+  if event.decision = Keeper_guards.Gate_approval_required then
+    Printf.sprintf
+      "%s tool=%s source=keeper_hook code=%s reason=%s%s"
+      tool_approval_required_tag
+      (Keeper_guards.escape_field event.tool_name)
+      (Keeper_guards.escape_field event.reason_code)
+      (Keeper_guards.escape_field event.reason_text)
+      (render_pre_tool_gate_source_hint event)
+  else
+    match event.source_path, event.source_line with
+    | Some source_path, Some source_line ->
+        Keeper_guards.render_inline_skip_reason_with_source
+          ~source_path
+          ~source_line
+          ~tool_name:event.tool_name
+          ~reason_code:event.reason_code
+          ~reason_text:event.reason_text
+    | _ ->
+        Keeper_guards.render_inline_skip_reason
+          ~tool_name:event.tool_name
+          ~reason_code:event.reason_code
+          ~reason_text:event.reason_text
+
+let pre_tool_gate_error (event : Keeper_guards.gate_decision_event) =
+  let decision = Keeper_guards.gate_decision_to_string event.decision in
+  Printf.sprintf "%s:%s: %s" decision event.reason_code event.reason_text
+
+let min_duration_ms = 0.0
+
+let trajectory_duration_ms duration_ms =
+  if
+    (not (Float.is_finite duration_ms))
+    || Float.compare duration_ms min_duration_ms <= 0
+  then 0
+  else max 1 (int_of_float (Float.round duration_ms))
+
+let record_pre_tool_gate_attempt
+    ~(meta_ref : Keeper_types.keeper_meta ref)
+    ~(tool_call_count_ref : int ref)
+    ?(trajectory_acc : Trajectory.accumulator option)
+    (event : Keeper_guards.gate_decision_event) =
+  incr tool_call_count_ref;
+  let meta = !meta_ref in
+  let keeper_name = meta.name in
+  let model = current_keeper_model meta in
+  let safe_input = Observability_redact.redact_json_value event.input in
+  let output_text = render_pre_tool_gate_output event in
+  let error = pre_tool_gate_error event in
+  let duration_ms = Float.max 0.0 event.stage_latency_ms in
+  (try
+     Keeper_tool_call_log.log_call
+       ~keeper_name
+       ~tool_name:event.tool_name
+       ~input:safe_input
+       ~output_text
+       ~success:false
+       ~duration_ms
+       ~model
+       ~result_bytes:(String.length output_text)
+       ()
+   with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
+       let callback_label_gate_tool_call_log = "gate_tool_call_log" in
+       Prometheus.inc_counter
+         Keeper_metrics.metric_keeper_lifecycle_callback_failures
+         ~labels:
+           [
+             (label_keeper, keeper_name);
+             (label_callback, callback_label_gate_tool_call_log);
+           ]
+         ();
+       Log.Keeper.warn
+         "keeper:%s pre_tool_use gate tool_call log failed tool=%s err=%s"
+         keeper_name event.tool_name (Printexc.to_string exn));
+  match trajectory_acc with
+  | None -> ()
+  | Some acc ->
+      let trace_id = acc.Trajectory.trace_id in
+      let runtime_contract =
+        Keeper_tool_call_log.runtime_contract_json_for_call
+          ~keeper_name
+          ~model
+          ()
+      in
+      let action_radius =
+        Keeper_tool_call_log.action_radius_json_for_call
+          ~keeper_name
+          ~tool_name:event.tool_name
+          ~input:safe_input
+          ~success:false
+          ~duration_ms
+          ~error
+          ()
+      in
+      let now = Time_compat.now () in
+      let turn = if event.turn > 0 then event.turn else acc.Trajectory.turn in
+      let round =
+        acc.Trajectory.entries
+        |> List.filter (fun (e : Trajectory.tool_call_entry) -> e.turn = turn)
+        |> List.length
+        |> ( + ) 1
+      in
+      let entry : Trajectory.tool_call_entry =
+        {
+          ts = now;
+          ts_iso = Masc_domain.iso8601_of_unix_seconds now;
+          turn;
+          round;
+          tool_name = event.tool_name;
+          args_json = Yojson.Safe.to_string safe_input;
+          gate_decision = Trajectory.Reject error;
+          result = Some output_text;
+          duration_ms = trajectory_duration_ms duration_ms;
+          error = Some error;
+          cost_usd = 0.0;
+        }
+      in
+      Trajectory.record_entry
+        ~runtime_contract
+        ~action_radius
+        ~on_persist_error:(fun exn ->
+          let dashboard_surface_tool_stats = "/api/v1/keepers/:name/tool-stats" in
+          let stale_reason_trajectory_append = "trajectory_append_failed" in
+          let telemetry_source_trajectory = "trajectory_tool_call" in
+          let telemetry_producer_pre_tool = "keeper_hooks_oas.pre_tool_use" in
+          Telemetry_coverage_gap.record
+            ~masc_root:acc.Trajectory.masc_root
+            ~source:telemetry_source_trajectory
+            ~producer:telemetry_producer_pre_tool
+            ~durable_store:
+              (Trajectory.trajectory_path acc.Trajectory.masc_root
+                 acc.Trajectory.keeper_name trace_id)
+            ~dashboard_surface:dashboard_surface_tool_stats
+            ~stale_reason:stale_reason_trajectory_append
+            ~keeper_name
+            ~trace_id
+            ~exn
+            ())
+        acc
+        entry
+

--- a/lib/keeper/keeper_hooks_oas_gate_attempt.mli
+++ b/lib/keeper/keeper_hooks_oas_gate_attempt.mli
@@ -1,0 +1,33 @@
+(** Keeper_hooks_oas_gate_attempt — pre-tool gate attempt rendering and
+    telemetry. Sibling module of [Keeper_hooks_oas]; see the .ml header
+    for the decomposition history. *)
+
+val render_pre_tool_gate_output :
+  Keeper_guards.gate_decision_event -> string
+(** Render the user-visible output text for a pre-tool gate decision.
+    Approval-required decisions get a [tool_approval_required] tag and
+    keep source-path hints; rejection decisions defer to
+    {!Keeper_guards.render_inline_skip_reason} (with source when known). *)
+
+val pre_tool_gate_error :
+  Keeper_guards.gate_decision_event -> string
+(** Format a [decision:reason_code: reason_text] string for trajectory
+    [error] fields and log entries. *)
+
+val trajectory_duration_ms : float -> int
+(** Round and clamp a sub-millisecond float duration to the integer ms
+    used in trajectory entries. Non-finite and non-positive inputs
+    collapse to [0]; positive values round to the nearest ms with a
+    floor of [1] so genuinely sub-ms positives are not lost. *)
+
+val record_pre_tool_gate_attempt :
+  meta_ref:Keeper_types.keeper_meta ref ->
+  tool_call_count_ref:int ref ->
+  ?trajectory_acc:Trajectory.accumulator ->
+  Keeper_guards.gate_decision_event ->
+  unit
+(** Record a rejected/blocked pre-tool gate attempt: increments the
+    per-turn tool-call counter, logs the gate decision to the tool-call
+    log (with redaction), and appends a trajectory entry when
+    [trajectory_acc] is provided. Lifecycle callback failures are caught
+    and counted via [Keeper_metrics] rather than propagated. *)


### PR DESCRIPTION
## Goal

Restore `Keeper_hooks_oas_gate_attempt` as a sibling module — reverting the inline portion of PR #18086 — so the parent `keeper_hooks_oas.ml` falls below the RFC-0151 `godfile_loc_1000plus` threshold.

Stacks on top of Step A (PR #18112, **merged**).

## Measured ratchet impact

| Metric | Baseline | Before Step A | After Step A | **After this PR** | Notes |
|---|---|---|---|---|---|
| `godfile_loc_1000plus` | 44 | 45 | 45 | **44 ✅** | `keeper_hooks_oas.ml` 1409 → 1038 → 891 LoC; ratchet passes. |
| `catch_all_arms` | 3269 | 3282 | 3282 | 3282 | Arms relocated; Step C/D will retire ≥13 via typed-match conversion. |
| RFC-0160 G1 parse_string callers | 9 (whitelist) | 10 | 10 | 10 | Step E will replace `parse_string` + string-fallback with typed Shell IR. |

This PR alone closes the RFC-0151 godfile gate; catch-all and parse_string need their own structural changes (queued).

## What changed

- `lib/keeper/keeper_hooks_oas_gate_attempt.{ml,mli}` re-created (was deleted by PR #18086).
- `lib/keeper/keeper_hooks_oas.ml`: inline block (lines 192-353 on prior HEAD) replaced by 4 one-line re-exports so parent-surface callers (incl. tests) keep working unchanged.
- `lib/keeper/keeper_hooks_oas.mli`: doc updated — "Inlined from former... deleted" → "Implementation lives in [Keeper_hooks_oas_gate_attempt]".
- `lib/dune`: `keeper_hooks_oas_gate_attempt` added to `private_modules` (alphabetically next to siblings).

No behaviour change; no catch-all expansion; no test edits required.

## 5-prong audit

- Direct grep `Keeper_hooks_oas.<gate_*>`: 0 hits outside this file.
- Module alias / re-export / include: not present.
- Parent-internal call (within `keeper_hooks_oas.ml`): 2 sites in `make_hooks` (former line 393 / 840) — both resolve through the re-export layer.
- Paired test files: `test/test_keeper_guards.ml` uses `HK.render_pre_tool_gate_output`; `test/test_keeper_hooks_oas_telemetry.ml` uses `Hooks.trajectory_duration_ms`. Both routes preserved via the re-export.

## Anti-pattern chain context (per CLAUDE.md Workaround Rejection Bar §3)

| PR | Action |
|---|---|
| #18011 | Deleted `Keeper_hooks_oas_pr_metrics` as 'dead' (false-dead — parent-internal call missed by bare-name grep) |
| #18083 | Restored `Keeper_hooks_oas_gate_attempt` as a sibling (the correct shape) |
| #18086 | Inlined `gate_attempt` back into the godfile with a "one-consumer submodule" justification — optimized for local elegance, ignored the RFC-0151 godfile policy |
| #18089 | Inline-restored `pr_metrics`, pushing the godfile past 1000 LoC and adding 9 catch-all arms |
| #18112 | Step A — re-extracted `pr_metrics` |
| **This PR** | Step B — re-extracts `gate_attempt` |

## Multi-step plan

| Step | PR | Status |
|---|---|---|
| A | #18112 | **Merged** (`d480df3f4`) |
| B | This PR | Draft |
| C | re-extract `pre_tool_gate` helpers (remaining #18086 inline portion) | queued |
| D | typed-match conversion to retire +13 catch-all delta | queued (multiple PRs) |
| E | replace `Bash.parse_string` + string-fallback in `pr_work_action_of_git_segment` with typed Shell IR | queued |
| F | baselines refresh downward | last |

## Verification

- Metric script run locally on the modified tree: `godfile_loc_1000plus` = 44 (= baseline).
- Local dune build deferred to CI due to machine-wide Dune lock contention (multiple bare `dune` processes from sibling worktrees hold the lock — see `memory/reference_masc_mcp_dune_local_lock_contention.md`).
- 5-prong audit clear (above).

## Draft policy

Per `memory/reference_masc_mcp_draft_auto_merge_guard.md`, stays Draft. Agent does not call `gh pr ready`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)