### PR TITLE
fix(test): wire Cascade_name re_export + drop stale Masc_mcp. prefix

### DIFF
--- a/test/deps/dune
+++ b/test/deps/dune
@@ -95,6 +95,9 @@
    ;; RFC-0086 PR-2F — Cascade_ref leaf extracted to lib/cascade_ref/.
    ;; Re-export so test code using bare `Cascade_ref.X` resolves.
    (re_export masc_mcp.cascade_ref)
+   ;; RFC-0163 Phase D1 — Cascade_name leaf extracted to lib/cascade_name/.
+   ;; Re-export so test code using bare `Cascade_name.X` resolves.
+   (re_export masc_mcp.cascade_name)
    ;; RFC-0086 PR-2H — Tool_args + Tool_result shared types extracted to
    ;; lib/tool_types/. Re-export so test code using bare
    ;; `Tool_args.X` / `Tool_result.X` resolves.

--- a/test/test_cascade_name.ml
+++ b/test/test_cascade_name.ml
@@ -5,7 +5,7 @@
 
 open Alcotest
 
-module CN = Masc_mcp.Cascade_name
+module CN = Cascade_name
 
 (* ── Valid parse tests ─────────────────────────────────────────── *)
 


### PR DESCRIPTION
## Summary

PR #18076 (RFC-0163 Phase D1) 가 \`Cascade_name\` 를 \`lib/cascade/\` 에서 leaf sub-library \`lib/cascade_name/\` 로 extract (\`masc_mcp.cascade_name\`, \`wrapped:false\`). 이는 \`masc_mcp ↔ cascade_ref\` 타입 cycle 깨기 위함.

| 변경 누락 | 영향 |
|---|---|
| \`test/deps/dune\` 에 \`re_export masc_mcp.cascade_name\` 추가 안 함 | test 가 \`Cascade_name\` 모듈에 접근 불가 |
| \`test/test_cascade_name.ml\` 의 \`Masc_mcp.Cascade_name\` 미수정 | extract 후 wrapped:false 라 \`Cascade_name\` 직접 참조해야 함 |

\`lib/\` 코드는 이미 0 사이트에서 bare \`Cascade_name\` 사용 중 — test 만 stale.

## Fix

1. \`test/deps/dune\` 에 sister extraction (\`cascade_ref\`) 옆에 \`(re_export masc_mcp.cascade_name)\` 추가.

2. \`test/test_cascade_name.ml\` 의 alias 정정:

\`\`\`ocaml
- module CN = Masc_mcp.Cascade_name
+ module CN = Cascade_name
\`\`\`

## Verification

\`\`\`
dune build --root . test/test_cascade_name.exe   →  EXIT=0
dune runtest                                      →  10/10 PASS

  [OK]  valid                    0   tier-group prefix
  [OK]  valid                    1   tier prefix
  [OK]  valid                    2   route prefix
  [OK]  valid                    3   whitespace trimmed
  [OK]  invalid                  0   bare short form
  [OK]  invalid                  1   empty string
  [OK]  invalid                  2   whitespace only
  [OK]  invalid                  3   unknown prefix
  [OK]  exn_and_helpers          0   of_string_exn ok
  [OK]  exn_and_helpers          1   is_canonical_prefix
\`\`\`

남은 test/ 회귀 (timeout_policy 별도 PR #18113, auth_strict_mode, dashboard_yjs, etc.) 는 각 sub-library 의 독립 re_export 또는 caller migration 영역.

## Philosophy

"실제 제거에 맞게 같이 개선" — \`feedback_partial_module_orphan_check_all_exports\` 의 sister 패턴. extract 시 *모든 caller surface* 를 grep 해야 하는데 (lib + test + dashboard + bin), 본 PR #18076 가 test 영역 update miss. compat shim 대신 cleanly migrate.

WORKAROUND-FREE.

RFC-WAIVED: PR #18076 직접 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)