### PR TITLE
fix(docker_spawn_throttle): expose configured_max + effective_concurrency in .mli

### DIFF
--- a/lib/docker_spawn_throttle.mli
+++ b/lib/docker_spawn_throttle.mli
@@ -33,3 +33,15 @@ val with_slot : (unit -> 'a) -> 'a
 
     Exceptions from [f] propagate; the slot is always released. *)
 
+val configured_max : unit -> int
+(** Layer-A concurrency cap as configured by
+    [MASC_DOCKER_SPAWN_CONCURRENCY] (default 8, range 1..64).
+    Stable across calls within a process.  Delegates to
+    [Fd_accountant.configured_concurrency ~kind:Docker_spawn]. *)
+
+val effective_concurrency : unit -> int
+(** Current Layer-A effective concurrency.  Equal to
+    [configured_max ()] under normal conditions; a future change
+    could lower it on sustained FD pressure (Layer B).  Delegates to
+    [Fd_accountant.effective_concurrency ~kind:Docker_spawn]. *)
+


### PR DESCRIPTION
## Summary

\`lib/docker_spawn_throttle.ml\` (RFC-0101 PR-2 thin-delegate to \`Fd_accountant\`) 가 3 helper 정의:

| .ml | .mli | Used by |
|---|---|---|
| \`with_slot\` | ✓ | (production) |
| \`configured_max\` | ❌ | \`test_docker_spawn_throttle\` + \`test_fd_accountant\` |
| \`effective_concurrency\` | ❌ | \`test_docker_spawn_throttle\` |

두 helper 가 \`.mli\` 누락. test 가 *delegate parity invariant* 검증 (legacy alias 가 \`Fd_accountant\` SSOT 와 동일 값 반환) 인데, .mli expose 없으면 외부 접근 불가.

## Test contract (지키려는 것)

\`test_fd_accountant.ml:101-104\`:

\`\`\`ocaml
(* DST.configured_max () must equal
   Fd_accountant.configured_concurrency ~kind:Docker_spawn *)
let via_legacy = DST.configured_max () in
\`\`\`

이는 RFC-0101 sunset 전 *legacy alias 가 silently drift 하지 않는다* 는 contract.

## Fix

\`.mli\` 에 두 \`val ... : unit -> int\` 추가 (docstring 포함). \`.ml\` 변경 없음.

## Verification

\`\`\`
dune build  --root . test/test_docker_spawn_throttle.exe test/test_fd_accountant.exe   →  EXIT=0
dune runtest --root . test/test_docker_spawn_throttle.exe   →  4/4 PASS
dune runtest --root . test/test_fd_accountant.exe           →  20/20 PASS  (including 'delegation: docker delegation cap parity')
\`\`\`

## Diff

+12 LoC, .mli 만.

## Philosophy

iter 2 timeout_policy 와 동일 패턴 — \`.ml\` 정의 + 외부 contract test 사용 + \`.mli\` expose 누락. compat shim 아닌 *원래 의도된 surface 의 빠진 .mli 보강*.

남은 test/ 회귀 (auth_strict_mode, dashboard_yjs, keeper_gh_parser_contract, keeper_shell_ops, keeper_exec_status, keeper_toml, exec_shell_command_gate 등) 는 각자 독립.

WORKAROUND-FREE.

RFC-WAIVED: RFC-0101 PR-2 직접 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)