### PR TITLE
fix: re-export Prompt_defaults.init via .mli (PR #17950 follow-up)

### DIFF
--- a/lib/prompt_defaults.mli
+++ b/lib/prompt_defaults.mli
@@ -14,13 +14,26 @@
     Internal helpers (the [existing_dir] predicate, the
     [prompt_markdown_dir_candidates] list, and the
     [bootstrapped_signature] memo ref) are hidden — callers
-    consume only the entry point below. *)
+    consume only the entry points below. *)
 
 val resolve_prompt_markdown_dir :
   workspace_path:string -> base_path:string -> string
 (** Return the first existing prompt markdown directory from the
     candidate list, falling back to {!Config_dir_resolver.prompts_dir}
     when none exist yet. *)
+
+val init : unit -> unit
+(** Lightweight fixture-level setup. Installs the prompt-registry
+    failure observer and, if a markdown directory has been set on
+    {!Prompt_registry} (e.g. via [Prompt_registry.set_markdown_dir]
+    in a test fixture), loads every prompt file from it. No-op when
+    no directory is set.
+
+    Distinct from {!bootstrap_runtime}: this helper does not resolve
+    a directory from the workspace/base-path candidates and does not
+    restore persisted operator overrides from disk — both of which
+    are server-startup concerns. Tests that pin a markdown directory
+    and want to populate the registry use this entry point. *)
 
 val bootstrap_runtime :
   workspace_path:string ->


### PR DESCRIPTION
## 목적

PR #17950이 \`init\` / \`resolve_prompt_markdown_dir\` 둘을 dead-export로 잡아 mli에서 제거. PR #18050이 \`resolve_prompt_markdown_dir\` 만 복원 (test_server_runtime_bootstrap 깨짐). 같은 sweep 누락이었던 \`init\` 도 대칭 복원합니다.

## 진단

이번 loop의 SSOT 위반 계도 관점에서 *vestigial vs 의도적 thin surface*를 구분:

**vestigial 아님 — 의도적 thin surface**

\`\`\`ocaml
let init () =
  install_prompt_registry_observers ();
  match Prompt_registry.get_markdown_dir () with
  | Some dir -> Prompt_registry.load_prompts_from_directory dir
  | None -> ()
\`\`\`

- 실제 동작 함수 (observer install + dir load) — input 무시 패턴 아님
- 5 test fixture (7 call site) 가 사용:
  - \`Prompt_registry.set_markdown_dir test_fixture\` → \`Prompt_defaults.init ()\`
- production은 \`bootstrap_runtime\` 사용 — 같은 부분 + workspace_path 기반 dir resolve + 디스크에서 override restore. Test fixture에 무거움.
- 두 entry point는 *의도적으로* 다른 역할. \`init\` = 가벼운 test fixture surface, \`bootstrap_runtime\` = server startup surface.

\`#18101 의 surface_*_model 같은 \`_arg\` constant-return 함수와 다름\` — 이번 PR은 *복원이 정답인 케이스*. mli docstring을 추가해 두 entry point 역할을 명시화.

## 변경

\`lib/prompt_defaults.mli\` (+14/-1 LoC):
- \`val init : unit -> unit\` 복원
- docstring으로 \`bootstrap_runtime\` 와의 차이 명시 (no workspace dir resolve, no override restore — test fixture 용임)
- 헤더 docstring "entry point**s**" 복수형으로 수정

## 검증

\`\`\`
dune build lib/                                              # green
dune build test/test_keeper_deliberation.exe ...             # green for 4 affected tests
dune exec test/test_keeper_deliberation.exe                  # 83/83 passed
\`\`\`

## 이 PR이 unblock 하는 회귀 (5 file 7 site)

| File | Sites |
|---|---|
| test/test_keeper_deliberation.ml | 1 |
| test/test_keeper_prompt_metrics.ml | 2 |
| test/test_keeper_prompt_external.ml | 1 |
| test/test_keeper_unified.ml | 2 |
| test/test_prompt_registry_defaults.ml | 1 |

## SSOT 일관성

\`bootstrap_runtime\` 와 \`init\` 의 두 surface가 *왜* 별도인지 mli docstring으로 영구 기록됨. 미래 sweep audit이 \`init\` 을 다시 dead로 분류하려 할 때 docstring이 의도를 설명합니다.