### PR TITLE
refactor(tool_control): drop triple ref-accumulator in keeper_pause_status_json

### DIFF
--- a/lib/tool_control.ml
+++ b/lib/tool_control.ml
@@ -31,21 +31,29 @@ type context = {
 
 let keeper_pause_status_json ctx =
   let names = Keeper_types.keeper_names ctx.config in
-  let read_errors = ref [] in
-  let paused_by_meta = ref [] in
-  let paused_by_phase = ref [] in
-  List.iter
-    (fun name ->
-      (match Keeper_types.read_meta ctx.config name with
-       | Ok (Some meta) when meta.paused -> paused_by_meta := meta.name :: !paused_by_meta
-       | Ok _ -> ()
-       | Error err -> read_errors := (name, err) :: !read_errors);
-      match Keeper_registry.get_phase ~base_path:ctx.config.base_path name with
-      | Some Keeper_state_machine.Paused -> paused_by_phase := name :: !paused_by_phase
-      | _ -> ())
-    names;
-  let meta_paused_names = List.rev !paused_by_meta in
-  let phase_paused_names = List.rev !paused_by_phase in
+  (* Triple accumulator folded over [names].  All three lists are kept in
+     reverse-prepend order during the fold; downstream consumers
+     ([List.rev], [List.rev_map]) restore the natural order. *)
+  let read_errors_rev, paused_by_meta_rev, paused_by_phase_rev =
+    List.fold_left
+      (fun (errs, by_meta, by_phase) name ->
+        let by_meta, errs =
+          match Keeper_types.read_meta ctx.config name with
+          | Ok (Some meta) when meta.paused -> (meta.name :: by_meta, errs)
+          | Ok _ -> (by_meta, errs)
+          | Error err -> (by_meta, (name, err) :: errs)
+        in
+        let by_phase =
+          match Keeper_registry.get_phase ~base_path:ctx.config.base_path name with
+          | Some Keeper_state_machine.Paused -> name :: by_phase
+          | Some _ | None -> by_phase
+        in
+        (errs, by_meta, by_phase))
+      ([], [], [])
+      names
+  in
+  let meta_paused_names = List.rev paused_by_meta_rev in
+  let phase_paused_names = List.rev paused_by_phase_rev in
   let paused_names =
     Keeper_types.dedupe_keep_order (meta_paused_names @ phase_paused_names)
   in
@@ -61,7 +69,7 @@ let keeper_pause_status_json ctx =
           (List.rev_map
              (fun (name, error) ->
                `Assoc [ ("name", `String name); ("error", `String error) ])
-             !read_errors) );
+             read_errors_rev) );
     ]
 
 let handle_pause ~tool_name ~start_time ctx args =


### PR DESCRIPTION
## 목표

`lib/tool_control.ml`의 `keeper_pause_status_json` 함수에서 세 개의 `let .. = ref []` (read_errors, paused_by_meta, paused_by_phase) + single `List.iter` + 4회 mutation 패턴을 제거하고, 단일 `List.fold_left`로 `(errs, by_meta, by_phase)` 3-tuple을 누적하는 함수형 형태로 변환.

## 왜

- counter가 아닌 *list accumulator* 3개 → fold-with-tuple로 1:1 변환 net positive (3개 변수의 lifecycle이 fold body 안으로 닫힘).
- `cdal_runtime_health.ml`(6 counter + 2 bounded sample) 와 대비: 그 케이스는 counter가 정당화 가능 + tuple 도입이 net loss라 reject. 이 케이스는 정반대.
- 사용자 메모리 `feedback_dual_path_normalize_vs_raw_wire_format` / `feedback_radical_improvement_over_diff_size`와 정합 — 작은 single-function refactor.

## Behavior parity

| 측면 | 원본 | 새 코드 |
|---|---|---|
| 누적 순서 | reverse-prepend during loop | fold body에서 동일하게 prepend |
| `paused_by_meta` 정렬 | 최종 `List.rev` 후 사용 | 동일 |
| `paused_by_phase` 정렬 | 최종 `List.rev` 후 사용 | 동일 |
| `read_errors` JSON emit | `List.rev_map ... !read_errors` | `List.rev_map ... read_errors_rev` (변수명 변경 only) |
| `Ok _ -> ()` catch-all | 유지 → `(by_meta, errs)` no-op | 동일 (catch-all 수 변동 없음) |
| `\| _ -> ()` (get_phase) catch-all | 유지 → `by_phase` no-op | `Some _ \| None -> by_phase` 명시 분해 (semantically identical) |

## 변경 파일

- `lib/tool_control.ml` (+24 / −16, net +8 due to fold-body indentation + 2-line docstring comment)

## 로컬 검증

```
$ dune build --root . lib/                                          # PASS
$ dune exec --root . test/test_tool_control_coverage.exe
...
Test Successful in 0.114s. 11 tests run.
```

특히 4개의 `dispatch_pause_status_*` 테스트(running / surfaces_keeper_paused / ignores_legacy / uninitialized_root)가 이 함수를 end-to-end로 cover.

## 미검증

- caller가 단일(`handle_pause_status` line 93). dynamic dispatch / serialize 경로는 정적 grep으로 추적 불가.
- CI full suite 결과 대기.

## 관련 (이전 iter 머지 완료)

- iter #1: #18106 server_state_product (MERGED)
- iter #2: #18109 chronicle_validate (MERGED)
- iter #3 (this): tool_control

다음 iter 후보:
- `coord_agent.ml` (Array.iter + safe_yield side effect — fold 가능하지만 careful)
- `board_comment_rate_limit.sweep_stale` (Hashtbl.iter + ref [])

reject 사례:
- `activity_graph_reducer.ml` (mli docstring witness — streaming-fold 의도)
- `cdal_runtime_health.ml` (6 counter + 2 bounded sample — tuple 도입 net loss)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>