### PR TITLE
fix(specs): re-anchor KeeperMemoryLifecycle ref to read_recent_memory_texts_result

### DIFF
--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-05-21T12:36:26Z (HEAD: e6fc69ecca)
+Generated: 2026-05-23T17:05:01Z (HEAD: 99cd905c9)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -130,7 +130,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperGenerationLineage.tla | KeeperGenerationLineage | manual | 2 | 1 | clean={inv:TypeOK, inv:CurrentTraceIsolation, inv:GenerationMatchesHistory, inv:CurrentTraceNotInHistory, inv:TraceHistoryUnique, inv:TraceIdsAllocated, inv:IdleCheckpointMatchesCommittedLineage, prop:HandoffEventuallyResolves} buggy={inv:TypeOK, inv:GenerationMatchesHistory, inv:CurrentTraceNotInHistory, inv:TraceHistoryUnique, inv:TraceIdsAllocated, inv:IdleCheckpointMatchesCommittedLineage} | bc957a36caf6 |
 | KeeperHeartbeat.tla | KeeperHeartbeat | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | 127b595d597d |
 | KeeperLaunchPending.tla | KeeperLaunchPending | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | b40572292792 |
-| KeeperMemoryLifecycle.tla | KeeperMemoryLifecycle | manual | 2 | 1 | clean={inv:TypeOK ProvenanceRequired NoSilentLoss RecoveryBounded HandoffLeavesNoStaleShort} buggy={inv:TypeOK ProvenanceRequired NoSilentLoss RecoveryBounded HandoffLeavesNoStaleShort} | fcd73975045a |
+| KeeperMemoryLifecycle.tla | KeeperMemoryLifecycle | manual | 2 | 1 | clean={inv:TypeOK ProvenanceRequired NoSilentLoss RecoveryBounded HandoffLeavesNoStaleShort} buggy={inv:TypeOK ProvenanceRequired NoSilentLoss RecoveryBounded HandoffLeavesNoStaleShort} | 366db78c712a |
 | KeeperOASAdvanced.tla | KeeperOASAdvanced | manual | 2 | 1 | clean={inv:NoZombieFibers, inv:CancelledNeverAbsorbed, prop:AtomicCascadeFallback, prop:CommittedSideEffectsRequireContinueGate, prop:StrictStopPreemption, prop:EventualTermination} buggy={inv:NoZombieFibers, inv:CancelledNeverAbsorbed, prop:AtomicCascadeFallback, prop:StrictStopPreemption, prop:EventualTermination} | 010a182b7a8b |
 | KeeperOutcomesConservation.tla | KeeperOutcomesConservation | manual | 2 | 1 | clean={inv:Safety} buggy={inv:ConservationLaw} | 7ac6ec2c5bf3 |
 | KeeperPostTurnOrchestration.tla | KeeperPostTurnOrchestration | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | 16ecb5ba3f0d |
@@ -172,7 +172,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 
 | File | Module | Kind | cfg | buggy | Invariants / Properties | Source Hash |
 |------|--------|------|-----|-------|-------------------------|---------------|
-| MultimodalArtifact.tla | MultimodalArtifact | manual | 2 | 1 | clean={inv:TypeOK, inv:ArtifactIdMatchesKey, inv:DAGRefIntegrity, inv:NoSelfLoops, inv:DAGAcyclic, inv:ProvenanceOriginsLive} buggy={inv:TypeOK, inv:ArtifactIdMatchesKey, inv:DAGRefIntegrity, inv:NoSelfLoops, inv:DAGAcyclic, inv:ProvenanceOriginsLive} | 0b97f690bb47 |
+| MultimodalArtifact.tla | MultimodalArtifact | manual | 2 | 1 | clean={inv:TypeOK, inv:ArtifactIdMatchesKey, inv:DAGRefIntegrity, inv:NoSelfLoops, inv:DAGAcyclic, inv:ProvenanceOriginsLive} buggy={inv:TypeOK, inv:ArtifactIdMatchesKey, inv:DAGRefIntegrity, inv:NoSelfLoops, inv:DAGAcyclic, inv:ProvenanceOriginsLive} | acb9fe58069c |
 | MultimodalHydrator.tla | MultimodalHydrator | manual | 2 | 1 | clean={inv:TypeOK, inv:NoSelfLoop, inv:NoCycleBounded, inv:DedupeIdempotent} buggy={inv:TypeOK, inv:NoSelfLoop, inv:NoCycleBounded, inv:DedupeIdempotent} | 9302762bb85e |
 
 ### specs/resilience (2 specs)

--- a/specs/keeper-state-machine/KeeperMemoryLifecycle.tla
+++ b/specs/keeper-state-machine/KeeperMemoryLifecycle.tla
@@ -41,7 +41,7 @@
 \*
 \* Persistence / promotion sites:
 \*   lib/keeper/keeper_memory_bank.ml:append_memory_notes_from_reply   — writes via memory_horizon_of_kind_with_fallback
-\*   lib/keeper/keeper_memory_recall.ml:read_recent_memory_texts       — recall path, same horizon fn
+\*   lib/keeper/keeper_memory_recall.ml:read_recent_memory_texts_result  — recall path, same horizon fn
 \*   lib/keeper/keeper_compact_policy.ml    overflow + handoff scheduling
 \*   lib/keeper/keeper_compact_audit.ml     ledger trail (provenance source)
 \*


### PR DESCRIPTION
## Goal

Drain the dangling spec-line-refs reference that has been flagging the Meta Guards CI check on main HEAD since PR #17772 merged.

## Root cause

PR #17772 (RFC-0149 §3.1 closeout) deleted the legacy silent facade \`read_recent_memory_texts\` from \`Keeper_memory_recall\`, replacing it with the Result-returning variant \`read_recent_memory_texts_result\`. The TLA+ preamble of \`specs/keeper-state-machine/KeeperMemoryLifecycle.tla\` kept the old symbol name in its 'Persistence / promotion sites' navigation comment.

\`scripts/lint/spec-line-refs.sh\` correctly classified this as a dangling symbol-anchored reference, exiting 2.

## Fix

One-line update inside the spec preamble, re-anchoring the navigation comment to the new symbol name. No code change.

\`\`\`diff
- \*   lib/keeper/keeper_memory_recall.ml:read_recent_memory_texts       — recall path, same horizon fn
+ \*   lib/keeper/keeper_memory_recall.ml:read_recent_memory_texts_result  — recall path, same horizon fn
\`\`\`

## Verification

Local lint run on the modified tree:

\`\`\`
spec-line-refs: 90 refs checked (15 line-anchored ok, 75 symbol-anchored ok, 0 drift, 0 dangling, 0 allowlisted)
\`\`\`

(One previously-dangling reference dropped to 0; one previously line-anchored reference reclassified to symbol-anchored because the new symbol resolves cleanly.)

## Scope

- Orthogonal to the RFC-0151 inline-restore re-extraction work (PR #18112 merged; PR #18114 \`gate_attempt\` Draft).
- Addresses exactly one of the failing CI checks on main: \`Meta Guards\`. The \`Godfile size\` / \`G1 + G7 monotone\` / \`OCaml Structure Ratchet\` / \`Lint\` fails on main HEAD remain — separate root fixes queued.
- Per \`reference_masc_mcp_draft_auto_merge_guard\`, stays Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)