### PR TITLE
fix(tool_input_validation): respect const discriminators in oneOf shape check

### DIFF
--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -172,9 +172,12 @@ let one_of_branch_constraints schema =
                | `Assoc props ->
                  List.filter_map
                    (fun (name, prop_schema) ->
-                      match Yojson.Safe.Util.member "const" prop_schema with
-                      | `Null -> None
-                      | const_value -> Some (name, const_value))
+                      match prop_schema with
+                      | `Assoc prop_fields ->
+                        (match List.assoc_opt "const" prop_fields with
+                         | Some const_value -> Some (name, const_value)
+                         | None -> None)
+                      | _ -> None)
                    props
                | _ -> []
              in
@@ -211,15 +214,15 @@ let one_of_required_shape_error schema = function
         | Some (`List []) -> false
         | Some _ -> true
       in
-      let const_matches name expected =
+      let const_field_matches name expected =
         match List.assoc_opt name fields with
         | Some actual -> Yojson.Safe.equal actual expected
-        | None -> false
+        | None -> true (* const is optional; absence does not disqualify *)
       in
       let branch_matches branch =
         List.for_all has_present branch.required
         && List.for_all
-             (fun (name, expected) -> const_matches name expected)
+             (fun (name, expected) -> const_field_matches name expected)
              branch.consts
       in
       let matching = List.filter branch_matches branches in

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -185,6 +185,19 @@ let one_of_branch_constraints schema =
   | _ -> []
 ;;
 
+let branch_label b =
+  let const_parts =
+    List.map
+      (fun (name, value) ->
+         Printf.sprintf "%s=%s" name (Yojson.Safe.to_string value))
+      b.consts
+  in
+  let req_without_consts =
+    List.filter (fun name -> not (List.mem_assoc name b.consts)) b.required
+  in
+  String.concat "+" (const_parts @ req_without_consts)
+;;
+
 let one_of_required_shape_error schema = function
   | `Assoc fields ->
     let branches = one_of_branch_constraints schema in
@@ -214,16 +227,12 @@ let one_of_required_shape_error schema = function
       | [ _ ] -> None
       | [] ->
         let options =
-          branches
-          |> List.map (fun b -> String.concat "+" b.required)
-          |> String.concat " | "
+          branches |> List.map branch_label |> String.concat " | "
         in
         Some (Printf.sprintf "arguments must include exactly one of: %s" options)
       | _ :: _ :: _ ->
         let options =
-          matching
-          |> List.map (fun b -> String.concat "+" b.required)
-          |> String.concat " | "
+          matching |> List.map branch_label |> String.concat " | "
         in
         Some
           (Printf.sprintf

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -152,24 +152,43 @@ let unsupported_arg_names schema = function
   | _ -> []
 ;;
 
-let simple_one_of_required_groups schema =
+type one_of_branch = {
+  required : string list;
+  consts : (string * Yojson.Safe.t) list;
+}
+
+let one_of_branch_constraints schema =
   match Yojson.Safe.Util.member "oneOf" schema with
   | `List branches ->
-    let groups =
+    let constraints =
       List.filter_map
         (fun branch ->
            let required = required_names branch in
-           if required = [] then None else Some required)
+           if required = []
+           then None
+           else
+             let consts =
+               match Yojson.Safe.Util.member "properties" branch with
+               | `Assoc props ->
+                 List.filter_map
+                   (fun (name, prop_schema) ->
+                      match Yojson.Safe.Util.member "const" prop_schema with
+                      | `Null -> None
+                      | const_value -> Some (name, const_value))
+                   props
+               | _ -> []
+             in
+             Some { required; consts })
         branches
     in
-    if List.length groups = List.length branches then groups else []
+    if List.length constraints = List.length branches then constraints else []
   | _ -> []
 ;;
 
 let one_of_required_shape_error schema = function
   | `Assoc fields ->
-    let groups = simple_one_of_required_groups schema in
-    if groups = []
+    let branches = one_of_branch_constraints schema in
+    if branches = []
     then None
     else (
       let has_present name =
@@ -179,19 +198,32 @@ let one_of_required_shape_error schema = function
         | Some (`List []) -> false
         | Some _ -> true
       in
-      let matching_groups =
-        List.filter (fun required -> List.for_all has_present required) groups
+      let const_matches name expected =
+        match List.assoc_opt name fields with
+        | Some actual -> Yojson.Safe.equal actual expected
+        | None -> false
       in
-      match matching_groups with
+      let branch_matches branch =
+        List.for_all has_present branch.required
+        && List.for_all
+             (fun (name, expected) -> const_matches name expected)
+             branch.consts
+      in
+      let matching = List.filter branch_matches branches in
+      match matching with
       | [ _ ] -> None
       | [] ->
         let options =
-          groups |> List.map (String.concat "+") |> String.concat " | "
+          branches
+          |> List.map (fun b -> String.concat "+" b.required)
+          |> String.concat " | "
         in
         Some (Printf.sprintf "arguments must include exactly one of: %s" options)
       | _ :: _ :: _ ->
         let options =
-          matching_groups |> List.map (String.concat "+") |> String.concat " | "
+          matching
+          |> List.map (fun b -> String.concat "+" b.required)
+          |> String.concat " | "
         in
         Some
           (Printf.sprintf

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -1193,7 +1193,11 @@ let test_oneof_const_discriminator_rejects_unknown_kind () =
   | Error result ->
     let msg = Yojson.Safe.to_string result.Tool_result.data in
     Alcotest.(check bool) "error mentions exact-one-of" true
-      (string_contains msg "exactly one of")
+      (string_contains msg "exactly one of");
+    Alcotest.(check bool) "error mentions preset branch label" true
+      (string_contains msg "\"preset\"");
+    Alcotest.(check bool) "error mentions custom branch label" true
+      (string_contains msg "\"custom\"")
   | Ok _ -> Alcotest.fail "expected rejection for unknown kind value"
 ;;
 

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -1196,6 +1196,54 @@ let test_oneof_const_discriminator_rejects_missing_kind () =
 ;;
 
 (* ================================================================ *)
+(* Production schema regression: Keeper_schema.tool_access_schema   *)
+(* ================================================================ *)
+
+let test_keeper_schema_tool_access_preset () =
+  let schema = Keeper_schema.tool_access_schema "test" in
+  let args = `Assoc [("kind", `String "preset"); ("preset", `String "minimal")] in
+  match Tool_input_validation.validate_args ~schema ~name:"test" ~args () with
+  | Ok _ -> ()
+  | Error result ->
+    Alcotest.failf
+      "expected preset branch to pass: %s"
+      (Yojson.Safe.to_string result.Tool_result.data)
+;;
+
+let test_keeper_schema_tool_access_custom () =
+  let schema = Keeper_schema.tool_access_schema "test" in
+  let args = `Assoc [("kind", `String "custom"); ("tools", `List [`String "rg"])] in
+  match Tool_input_validation.validate_args ~schema ~name:"test" ~args () with
+  | Ok _ -> ()
+  | Error result ->
+    Alcotest.failf
+      "expected custom branch to pass: %s"
+      (Yojson.Safe.to_string result.Tool_result.data)
+;;
+
+let test_keeper_schema_tool_access_rejects_missing_kind () =
+  let schema = Keeper_schema.tool_access_schema "test" in
+  let args = `Assoc [("preset", `String "minimal")] in
+  match Tool_input_validation.validate_args ~schema ~name:"test" ~args () with
+  | Ok _ -> Alcotest.fail "expected missing kind to fail"
+  | Error result ->
+    let msg = result.Tool_result.legacy_message in
+    Alcotest.(check bool) "error mentions branches" true
+      (string_contains msg "exactly one of")
+;;
+
+let test_keeper_schema_tool_access_rejects_unknown_kind () =
+  let schema = Keeper_schema.tool_access_schema "test" in
+  let args = `Assoc [("kind", `String "unknown"); ("preset", `String "minimal")] in
+  match Tool_input_validation.validate_args ~schema ~name:"test" ~args () with
+  | Ok _ -> Alcotest.fail "expected unknown kind to fail"
+  | Error result ->
+    let msg = result.Tool_result.legacy_message in
+    Alcotest.(check bool) "error mentions preset/custom branches" true
+      (string_contains msg "preset" && string_contains msg "custom")
+;;
+
+(* ================================================================ *)
 (* Runner                                                            *)
 (* ================================================================ *)
 
@@ -1300,5 +1348,15 @@ let () =
         test_oneof_const_discriminator_rejects_unknown_kind;
       Alcotest.test_case "missing kind is rejected" `Quick
         test_oneof_const_discriminator_rejects_missing_kind;
+    ]);
+    ("keeper_schema_tool_access", [
+      Alcotest.test_case "preset branch passes" `Quick
+        test_keeper_schema_tool_access_preset;
+      Alcotest.test_case "custom branch passes" `Quick
+        test_keeper_schema_tool_access_custom;
+      Alcotest.test_case "missing kind rejected" `Quick
+        test_keeper_schema_tool_access_rejects_missing_kind;
+      Alcotest.test_case "unknown kind rejected" `Quick
+        test_keeper_schema_tool_access_rejects_unknown_kind;
     ]);
   ]

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -1013,10 +1013,10 @@ let test_registered_hook_required_enum_blank_is_not_stripped () =
 (* Test: oneOf with empty/null values (regression guard)             *)
 (* ================================================================ *)
 
-(** Simulate LLM populating all oneOf branches with empty values.
-    Before fix: List.mem_assoc matched on key presence alone,
-    treating pipeline:[] as a valid group match, causing false
-    "multiple mutually exclusive schemas" rejection. *)
+(** Regression guard: LLM may send both executable and pipeline.
+    Schema no longer advertises oneOf (PR #18110); handler precedence
+    picks executable. Empty pipeline:[] must not trigger any validation
+    error from the pre-hook shape check. *)
 let test_validate_args_keeper_bash_oneof_empty_pipeline () =
   let args =
     `Assoc
@@ -1106,6 +1106,112 @@ let test_validate_args_keeper_bash_oneof_real_pipeline_rejects_empty_exec () =
     Alcotest.failf
       "expected keeper_bash pipeline with null exec to pass shape validation, got %s"
       (Yojson.Safe.to_string result.Tool_result.data)
+
+(* ================================================================ *)
+(* Test: oneOf with const discriminator                              *)
+(* ================================================================ *)
+
+(** Schema where two branches share the same required fields but are
+    distinguished by a const value on the 'kind' field. This exercises
+    the improvement to [one_of_required_shape_error] that respects
+    const discriminators instead of matching purely on required field
+    presence. *)
+let oneof_const_schema =
+  `Assoc
+    [
+      ("type", `String "object");
+      ( "oneOf"
+      , `List
+          [
+            `Assoc
+              [
+                ( "properties"
+                , `Assoc
+                    [
+                      ("kind", `Assoc [("const", `String "preset")])
+                    ; ("value", `Assoc [("type", `String "string")])
+                    ] )
+              ; ("required", `List [`String "kind"; `String "value"])
+              ]
+          ; `Assoc
+              [
+                ( "properties"
+                , `Assoc
+                    [
+                      ("kind", `Assoc [("const", `String "custom")])
+                    ; ("value", `Assoc [("type", `String "string")])
+                    ] )
+              ; ("required", `List [`String "kind"; `String "value"])
+              ]
+          ] )
+    ]
+;;
+
+let test_oneof_const_discriminator_preset_branch () =
+  let args = `Assoc [("kind", `String "preset"); ("value", `String "minimal")] in
+  match
+    Tool_input_validation.validate_args
+      ~schema:oneof_const_schema
+      ~name:"test_oneof_const"
+      ~args
+      ()
+  with
+  | Ok forwarded ->
+    Alcotest.(check bool) "args unchanged" true (Yojson.Safe.equal args forwarded)
+  | Error result ->
+    Alcotest.failf
+      "expected preset branch to match, got %s"
+      (Yojson.Safe.to_string result.Tool_result.data)
+;;
+
+let test_oneof_const_discriminator_custom_branch () =
+  let args = `Assoc [("kind", `String "custom"); ("value", `String "my-tool")] in
+  match
+    Tool_input_validation.validate_args
+      ~schema:oneof_const_schema
+      ~name:"test_oneof_const"
+      ~args
+      ()
+  with
+  | Ok forwarded ->
+    Alcotest.(check bool) "args unchanged" true (Yojson.Safe.equal args forwarded)
+  | Error result ->
+    Alcotest.failf
+      "expected custom branch to match, got %s"
+      (Yojson.Safe.to_string result.Tool_result.data)
+;;
+
+let test_oneof_const_discriminator_rejects_unknown_kind () =
+  let args = `Assoc [("kind", `String "unknown"); ("value", `String "x")] in
+  match
+    Tool_input_validation.validate_args
+      ~schema:oneof_const_schema
+      ~name:"test_oneof_const"
+      ~args
+      ()
+  with
+  | Error result ->
+    let msg = Yojson.Safe.to_string result.Tool_result.data in
+    Alcotest.(check bool) "error mentions exact-one-of" true
+      (string_contains msg "exactly one of")
+  | Ok _ -> Alcotest.fail "expected rejection for unknown kind value"
+;;
+
+let test_oneof_const_discriminator_rejects_missing_kind () =
+  let args = `Assoc [("value", `String "x")] in
+  match
+    Tool_input_validation.validate_args
+      ~schema:oneof_const_schema
+      ~name:"test_oneof_const"
+      ~args
+      ()
+  with
+  | Error result ->
+    let msg = Yojson.Safe.to_string result.Tool_result.data in
+    Alcotest.(check bool) "error mentions exact-one-of" true
+      (string_contains msg "exactly one of")
+  | Ok _ -> Alcotest.fail "expected rejection for missing kind field"
+;;
 
 (* ================================================================ *)
 (* Runner                                                            *)
@@ -1204,5 +1310,15 @@ let () =
         test_registered_hook_goal_list_preserves_invalid_enum_for_handler;
       Alcotest.test_case "required enum blanks are not stripped" `Quick
         test_registered_hook_required_enum_blank_is_not_stripped;
+    ]);
+    ("oneof_const_discriminator", [
+      Alcotest.test_case "preset branch matches via const" `Quick
+        test_oneof_const_discriminator_preset_branch;
+      Alcotest.test_case "custom branch matches via const" `Quick
+        test_oneof_const_discriminator_custom_branch;
+      Alcotest.test_case "unknown kind is rejected" `Quick
+        test_oneof_const_discriminator_rejects_unknown_kind;
+      Alcotest.test_case "missing kind is rejected" `Quick
+        test_oneof_const_discriminator_rejects_missing_kind;
     ]);
   ]

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -1017,7 +1017,7 @@ let test_registered_hook_required_enum_blank_is_not_stripped () =
     Schema no longer advertises oneOf (PR #18110); handler precedence
     picks executable. Empty pipeline:[] must not trigger any validation
     error from the pre-hook shape check. *)
-let test_validate_args_keeper_bash_oneof_empty_pipeline () =
+let test_validate_args_keeper_bash_exec_with_empty_pipeline () =
   let args =
     `Assoc
       [ "executable", `String "pwd"
@@ -1042,7 +1042,7 @@ let test_validate_args_keeper_bash_oneof_empty_pipeline () =
 (** stages was removed from the schema (backward-compat alias only in handler).
     Sending stages in args now triggers additionalProperties rejection since
     the schema declares additionalProperties: false. *)
-let test_validate_args_keeper_bash_oneof_stages_rejected_by_schema () =
+let test_validate_args_keeper_bash_stages_rejected_by_schema () =
   let args =
     `Assoc
       [ "executable", `String "ls"
@@ -1062,7 +1062,7 @@ let test_validate_args_keeper_bash_oneof_stages_rejected_by_schema () =
   | Ok _ ->
     Alcotest.fail "expected rejection: stages is no longer a schema-advertised field"
 
-let test_validate_args_keeper_bash_oneof_exec_with_empty_pipeline () =
+let test_validate_args_keeper_bash_exec_with_empty_pipeline_duplicate () =
   let args =
     `Assoc
       [ "executable", `String "echo"
@@ -1084,7 +1084,7 @@ let test_validate_args_keeper_bash_oneof_exec_with_empty_pipeline () =
       "expected keeper_bash with executable + empty pipeline to pass, got %s"
       (Yojson.Safe.to_string result.Tool_result.data)
 
-let test_validate_args_keeper_bash_oneof_real_pipeline_rejects_empty_exec () =
+let test_validate_args_keeper_bash_pipeline_rejects_null_exec () =
   let args =
     `Assoc
       [ "executable", `Null
@@ -1290,14 +1290,14 @@ let () =
         test_validate_args_keeper_bash_accepts_typed_pipeline;
       Alcotest.test_case "keeper_bash rejects bad typed argv" `Quick
         test_validate_args_keeper_bash_rejects_bad_argv_type;
-      Alcotest.test_case "keeper_bash oneOf: executable + empty pipeline" `Quick
-        test_validate_args_keeper_bash_oneof_empty_pipeline;
-      Alcotest.test_case "keeper_bash oneOf: stages rejected by schema" `Quick
-        test_validate_args_keeper_bash_oneof_stages_rejected_by_schema;
-      Alcotest.test_case "keeper_bash oneOf: exec with empty pipeline" `Quick
-        test_validate_args_keeper_bash_oneof_exec_with_empty_pipeline;
-      Alcotest.test_case "keeper_bash oneOf: pipeline + null exec" `Quick
-        test_validate_args_keeper_bash_oneof_real_pipeline_rejects_empty_exec;
+      Alcotest.test_case "keeper_bash exec + empty pipeline" `Quick
+        test_validate_args_keeper_bash_exec_with_empty_pipeline;
+      Alcotest.test_case "keeper_bash stages rejected by schema" `Quick
+        test_validate_args_keeper_bash_stages_rejected_by_schema;
+      Alcotest.test_case "keeper_bash exec with empty pipeline (dup)" `Quick
+        test_validate_args_keeper_bash_exec_with_empty_pipeline_duplicate;
+      Alcotest.test_case "keeper_bash pipeline + null exec" `Quick
+        test_validate_args_keeper_bash_pipeline_rejects_null_exec;
       Alcotest.test_case "direct validation uses explicit schema" `Quick
         test_validate_args_uses_explicit_schema_without_registry;
       Alcotest.test_case "direct keeper_board_post accepts sources array" `Quick

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -1195,6 +1195,126 @@ let test_oneof_const_discriminator_rejects_missing_kind () =
   | Ok _ -> Alcotest.fail "expected rejection for missing kind field"
 ;;
 
+(** P1 regression: const fields that are not in the branch's required list
+    must be treated as optional.  A schema with disjoint required sets and
+    optional const discriminators should not reject an input that satisfies
+    exactly one branch just because the optional const key is absent. *)
+let oneof_optional_const_schema =
+  `Assoc
+    [
+      ("type", `String "object");
+      ( "oneOf"
+      , `List
+          [
+            `Assoc
+              [
+                ( "properties"
+                , `Assoc
+                    [
+                      ("kind", `Assoc [("const", `String "a")])
+                    ; ("foo", `Assoc [("type", `String "string")])
+                    ] )
+              ; ("required", `List [`String "foo"])
+              ]
+          ; `Assoc
+              [
+                ( "properties"
+                , `Assoc
+                    [
+                      ("kind", `Assoc [("const", `String "b")])
+                    ; ("bar", `Assoc [("type", `String "string")])
+                    ] )
+              ; ("required", `List [`String "bar"])
+              ]
+          ] )
+    ]
+;;
+
+let test_oneof_optional_const_branch_matches_without_const () =
+  let args = `Assoc [("foo", `String "x")] in
+  match
+    Tool_input_validation.validate_args
+      ~schema:oneof_optional_const_schema
+      ~name:"test_oneof_optional_const"
+      ~args
+      ()
+  with
+  | Ok forwarded ->
+    Alcotest.(check bool) "args unchanged" true (Yojson.Safe.equal args forwarded)
+  | Error result ->
+    Alcotest.failf
+      "expected branch A to match without optional const, got %s"
+      (Yojson.Safe.to_string result.Tool_result.data)
+;;
+
+(** P2 regression: "const": null in the schema must be distinguishable from
+    a missing const key.  Two branches with the same required field but
+    distinguished by null vs non-null const should resolve unambiguously. *)
+let oneof_null_const_schema =
+  `Assoc
+    [
+      ("type", `String "object");
+      ( "oneOf"
+      , `List
+          [
+            `Assoc
+              [
+                ( "properties"
+                , `Assoc
+                    [
+                      ("mode", `Assoc [("const", `Null)])
+                    ; ("name", `Assoc [("type", `String "string")])
+                    ] )
+              ; ("required", `List [`String "name"])
+              ]
+          ; `Assoc
+              [
+                ( "properties"
+                , `Assoc
+                    [
+                      ("mode", `Assoc [("const", `String "active")])
+                    ; ("name", `Assoc [("type", `String "string")])
+                    ] )
+              ; ("required", `List [`String "name"])
+              ]
+          ] )
+    ]
+;;
+
+let test_oneof_null_const_matches_null_branch () =
+  let args = `Assoc [("name", `String "x"); ("mode", `Null)] in
+  match
+    Tool_input_validation.validate_args
+      ~schema:oneof_null_const_schema
+      ~name:"test_oneof_null_const"
+      ~args
+      ()
+  with
+  | Ok forwarded ->
+    Alcotest.(check bool) "args unchanged" true (Yojson.Safe.equal args forwarded)
+  | Error result ->
+    Alcotest.failf
+      "expected null-const branch to match, got %s"
+      (Yojson.Safe.to_string result.Tool_result.data)
+;;
+
+let test_oneof_null_const_matches_non_null_branch () =
+  let args = `Assoc [("name", `String "x"); ("mode", `String "active")] in
+  match
+    Tool_input_validation.validate_args
+      ~schema:oneof_null_const_schema
+      ~name:"test_oneof_null_const"
+      ~args
+      ()
+  with
+  | Ok forwarded ->
+    Alcotest.(check bool) "args unchanged" true (Yojson.Safe.equal args forwarded)
+  | Error result ->
+    Alcotest.failf
+      "expected active-const branch to match, got %s"
+      (Yojson.Safe.to_string result.Tool_result.data)
+;;
+
 (* ================================================================ *)
 (* Production schema regression: Keeper_schema.tool_access_schema   *)
 (* ================================================================ *)
@@ -1348,6 +1468,12 @@ let () =
         test_oneof_const_discriminator_rejects_unknown_kind;
       Alcotest.test_case "missing kind is rejected" `Quick
         test_oneof_const_discriminator_rejects_missing_kind;
+      Alcotest.test_case "optional const: branch matches without const key" `Quick
+        test_oneof_optional_const_branch_matches_without_const;
+      Alcotest.test_case "null const: null branch matches" `Quick
+        test_oneof_null_const_matches_null_branch;
+      Alcotest.test_case "null const: non-null branch matches" `Quick
+        test_oneof_null_const_matches_non_null_branch;
     ]);
     ("keeper_schema_tool_access", [
       Alcotest.test_case "preset branch passes" `Quick

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -1062,28 +1062,6 @@ let test_validate_args_keeper_bash_stages_rejected_by_schema () =
   | Ok _ ->
     Alcotest.fail "expected rejection: stages is no longer a schema-advertised field"
 
-let test_validate_args_keeper_bash_exec_with_empty_pipeline_duplicate () =
-  let args =
-    `Assoc
-      [ "executable", `String "echo"
-      ; "pipeline", `List []
-      ]
-  in
-  match
-    Tool_input_validation.validate_args
-      ~schema:keeper_bash_schema
-      ~name:"keeper_bash"
-      ~args
-      ()
-  with
-  | Ok forwarded ->
-    Alcotest.(check string) "executable preserved" "echo"
-      (assoc_string "executable" forwarded)
-  | Error result ->
-    Alcotest.failf
-      "expected keeper_bash with executable + empty pipeline to pass, got %s"
-      (Yojson.Safe.to_string result.Tool_result.data)
-
 let test_validate_args_keeper_bash_pipeline_rejects_null_exec () =
   let args =
     `Assoc
@@ -1294,8 +1272,6 @@ let () =
         test_validate_args_keeper_bash_exec_with_empty_pipeline;
       Alcotest.test_case "keeper_bash stages rejected by schema" `Quick
         test_validate_args_keeper_bash_stages_rejected_by_schema;
-      Alcotest.test_case "keeper_bash exec with empty pipeline (dup)" `Quick
-        test_validate_args_keeper_bash_exec_with_empty_pipeline_duplicate;
       Alcotest.test_case "keeper_bash pipeline + null exec" `Quick
         test_validate_args_keeper_bash_pipeline_rejects_null_exec;
       Alcotest.test_case "direct validation uses explicit schema" `Quick


### PR DESCRIPTION
## Problem

`Tool_input_validation.one_of_required_shape_error` matched `oneOf` branches purely by `required` field presence. It ignored `const` discriminator values declared in `properties`, meaning two branches with identical `required` fields but different `const` values (e.g. `kind: \"preset\"` vs `kind: \"custom\"`) could incorrectly produce:

```
arguments match multiple mutually exclusive schemas: kind+value | kind+value
```

While no current schema in the codebase triggers this (existing `oneOf` schemas have disjoint `required` sets or no `required` at all), adding such a schema in the future would silently break.

## Change

### Core fix (commits 1-2)
1. **Replace `simple_one_of_required_groups` with `one_of_branch_constraints`** — extracts both `required` fields and `(field_name, const_value)` pairs from each `oneOf` branch's `properties`.
2. **Add `const_matches` to `branch_matches`** — after confirming all `required` fields are present, also verify every `const` constraint matches the input value via `Yojson.Safe.equal`.

### UX improvement (commit 3)
3. **Include const values in error messages** — `branch_label` now renders `kind=\"preset\"+preset` instead of `kind+preset`, making it obvious which branch was expected.

### Test hygiene (commits 4-5)
4. **Remove misleading `oneOf` references** from `keeper_bash` tests — PR #18110 removed `oneOf` from the schema; test names still referenced it.
5. **Drop duplicate test** — `exec + empty pipeline` had two nearly identical cases; keep one.

### Production regression tests (commit 6)
6. **Add `Keeper_schema.tool_access_schema` tests** — validates the real-world schema used for `meta.tool_access` in `masc_persona_generate`, which uses `oneOf` + `const` (`kind: "preset"` vs `kind: "custom"`).

## Verification

- Local `ocamlformat` check passes.
- 4 unit tests exercise synthetic `oneOf` + `const` behavior.
- 4 regression tests exercise the production `Keeper_schema.tool_access_schema`.
- Existing `keeper_bash` shape tests remain unchanged in behavior (schema no longer has `oneOf`, so `one_of_branch_constraints` returns `[]` and the check is skipped).

## Backwards Compatibility

No behavior change for existing schemas. The new `const` check is additive: it only narrows matches, never widens them.