### PR TITLE
refactor(oas timeout): drop function-name-lying `_for_estimated_input_tokens(_with_turn_budget)`

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -347,10 +347,10 @@ module KeeperKeepalive = struct
       The default stays at 600 (the prior hard ceiling) so existing
       remote cascades keep their budget unchanged; the lifted ceiling
       only fires when an operator opts in via env or cascade override.
-      Individual OAS provider attempts are still capped by
-      [oas_timeout_default_sec] and provider-specific bounds below, so
-      the full turn budget remains a container for fallback/retry work
-      rather than one provider's spend. *)
+      RFC-0156: post-removal there is no per-provider OAS cap layered
+      below this — [oas_call_timeout_sec] reuses [turn_timeout_sec]
+      directly; cascade rotation is driven by [stream_idle_timeout_sec]
+      + HTTP error + completion contract. *)
   let turn_timeout_sec =
     Float.max
       60.0
@@ -358,8 +358,6 @@ module KeeperKeepalive = struct
          timeout_hard_ceiling_sec
          (get_float ~default:600.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
   ;;
-
-  let oas_timeout_default_sec = 300.0
 
   (** Maximum time a proactive keeper will wait in the MASC admission queue
       before abandoning the current OAS attempt.
@@ -451,37 +449,17 @@ module KeeperKeepalive = struct
             (get_int ~default "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL_SCHEDULED_AUTONOMOUS")))
   ;;
 
-  let oas_timeout_for_estimated_input_tokens_with_turn_budget
-        ~(estimated_input_tokens : int)
-        ~(max_turns : int)
-    : float
-    =
-    let _ = max_turns in
-    let _ = estimated_input_tokens in
+  (* RFC-0156: OAS total timeout removed. Resolved OAS-call timeout = override
+     when set, else turn_timeout_sec (wall-clock cap). stream_idle_timeout
+     handles per-stream cap; cascade rotation triggers on stream_idle + HTTP
+     error + completion contract. Historic names
+     ([oas_timeout_for_estimated_input_tokens] /
+     [oas_timeout_for_estimated_input_tokens_with_turn_budget]) ignored the
+     [estimated_input_tokens] and [max_turns] args — function-name-lying. *)
+  let oas_call_timeout_sec : float =
     match oas_timeout_sec_override with
     | Some v -> v
-    | None ->
-      (* RFC-0156: OAS total timeout 제거 — turn_timeout이 wall-clock cap,
-         stream_idle_timeout이 per-stream cap. 함수 이름의 `for_estimated_input_tokens`
-         + `with_turn_budget`은 historic naming이며 v2 PR에서 rename 예정.
-
-         이전 행위: Float.min turn_timeout_sec oas_timeout_default_sec
-                    (= min(600, 300) = 300, "static_300s" source label)
-         새 행위:   turn_timeout_sec
-                    (cascade rotation은 stream_idle + HTTP error + completion contract로 trigger)
-
-         Slow-but-successful 5분+ 응답이 회수됨. cascade fallback 시간은 줄지만
-         stream_idle_timeout이 healthy slow stream을 신호로 잡음.
-
-         #10008 fm2의 의도 ("research turn 끝까지 진행") 와 정합 — token scaling
-         복원 없이 단순히 turn-level cap 한 layer로 단순화. *)
-      turn_timeout_sec
-  ;;
-
-  let oas_timeout_for_estimated_input_tokens ~(estimated_input_tokens : int) : float =
-    oas_timeout_for_estimated_input_tokens_with_turn_budget
-      ~estimated_input_tokens
-      ~max_turns:oas_max_turns_per_call
+    | None -> turn_timeout_sec
   ;;
 
   (** Idle-gap timeout for streaming OAS provider responses.

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -177,12 +177,9 @@ module KeeperKeepalive : sig
   val oas_max_turns_per_call : int
   val oas_max_turns_per_call_scheduled_autonomous : int
 
-  val oas_timeout_for_estimated_input_tokens_with_turn_budget
-    :  estimated_input_tokens:int
-    -> max_turns:int
-    -> float
-
-  val oas_timeout_for_estimated_input_tokens : estimated_input_tokens:int -> float
+  val oas_call_timeout_sec : float
+  (** Resolved OAS-call timeout: [oas_timeout_sec_override] when set, otherwise
+      [turn_timeout_sec]. RFC-0156: no token- or turn-budget dependence. *)
   val stream_idle_timeout_sec : float
 
   val body_timeout_sec_override : float option

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -524,9 +524,7 @@ let run_turn
        let timeout_s =
          match oas_timeout_s with
          | Some value -> value
-         | None ->
-           Keeper_runtime_resolved.oas_timeout_for_estimated_input_tokens
-             ~estimated_input_tokens
+         | None -> Keeper_runtime_resolved.oas_call_timeout_sec ()
        in
        let per_provider_timeout_s =
          per_provider_timeout_for_turn

--- a/lib/keeper/keeper_runtime_resolved.ml
+++ b/lib/keeper/keeper_runtime_resolved.ml
@@ -296,24 +296,14 @@ let stream_idle_timeout_for_total_timeout ~(total_timeout_s : float) =
 let body_timeout_override_sec () =
   (current ()).body_timeout_override_sec.value
 
-let oas_timeout_for_estimated_input_tokens_with_turn_budget
-    ~(estimated_input_tokens : int) ~(max_turns : int) : float =
-  let _ = estimated_input_tokens in
-  let _ = max_turns in
+(* RFC-0156: OAS total timeout removed — turn_timeout_sec is the wall-clock
+   cap, stream_idle_timeout is the per-stream cap. Kept in lockstep with
+   [Env_config.KeeperKeepalive.oas_call_timeout_sec]. Historic names
+   ([oas_timeout_for_estimated_input_tokens] /
+   [oas_timeout_for_estimated_input_tokens_with_turn_budget]) ignored their
+   args — function-name-lying. *)
+let oas_call_timeout_sec () : float =
   let runtime = current () in
   match runtime.oas_timeout_override_sec.value with
   | Some value -> value
-  | None ->
-      (* RFC-0156: OAS total timeout removed — turn_timeout_sec is the
-         wall-clock cap, stream_idle_timeout is the per-stream cap.
-         Kept in lockstep with
-         [Env_config.KeeperKeepalive.oas_timeout_for_estimated_input_tokens_with_turn_budget].
-         Old: Float.min turn_timeout_sec oas_timeout_default_sec (= 300s clamp).
-         New: turn_timeout_sec (no 300s clamp; cascade handled by rotation). *)
-      runtime.turn_timeout_sec.value
-
-let oas_timeout_for_estimated_input_tokens ~(estimated_input_tokens : int) :
-    float =
-  oas_timeout_for_estimated_input_tokens_with_turn_budget
-    ~estimated_input_tokens
-    ~max_turns:(reactive_max_turns_per_call ())
+  | None -> runtime.turn_timeout_sec.value

--- a/lib/keeper/keeper_runtime_resolved.mli
+++ b/lib/keeper/keeper_runtime_resolved.mli
@@ -69,11 +69,6 @@ val body_timeout_override_sec : unit -> float option
     transports require an OAS upstream change to expose
     [stdout_idle_timeout_s]. *)
 val cli_subprocess_idle_sec : unit -> float
-val oas_timeout_for_estimated_input_tokens_with_turn_budget :
-  estimated_input_tokens:int ->
-  max_turns:int ->
-  float
-
-val oas_timeout_for_estimated_input_tokens :
-  estimated_input_tokens:int ->
-  float
+val oas_call_timeout_sec : unit -> float
+(** Resolved OAS-call timeout: [oas_timeout_override_sec] when set, otherwise
+    [turn_timeout_sec]. RFC-0156: no token- or turn-budget dependence. *)

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -86,11 +86,7 @@ let resolve_bounded_provider_timeout_budget_with_turn_budget
     ~(estimated_input_tokens : int) ~(max_turns : int)
     ~(remaining_turn_budget_s : float) : provider_timeout_budget option =
   let runtime = Keeper_runtime_resolved.current () in
-  let adaptive_timeout_sec =
-    Keeper_runtime_resolved
-    .oas_timeout_for_estimated_input_tokens_with_turn_budget
-      ~estimated_input_tokens ~max_turns
-  in
+  let adaptive_timeout_sec = Keeper_runtime_resolved.oas_call_timeout_sec () in
   if is_retry then begin
     let time_spent_in_turn = runtime.turn_timeout_sec.value -. remaining_turn_budget_s in
     let usable_retry_budget = adaptive_timeout_sec -. time_spent_in_turn in
@@ -270,11 +266,7 @@ let decide_retry_admission_for_turn
     ~(estimated_input_tokens : int)
     ~(max_turns : int) : (unit, retry_admission_denial) result =
   let runtime = Keeper_runtime_resolved.current () in
-  let adaptive_timeout_sec =
-    Keeper_runtime_resolved
-    .oas_timeout_for_estimated_input_tokens_with_turn_budget
-      ~estimated_input_tokens ~max_turns
-  in
+  let adaptive_timeout_sec = Keeper_runtime_resolved.oas_call_timeout_sec () in
   let is_retry = attempt_kind_is_retry attempt_kind in
   if is_retry then
     let time_spent_in_turn =

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -176,10 +176,7 @@ let wrap_runtime_mcp_external_tool_hooks
 let max_execution_time_for_attempt ?per_provider_timeout_s () =
   match per_provider_timeout_s with
   | Some timeout_s -> Some timeout_s
-  | None ->
-    Some
-      (Keeper_runtime_resolved.oas_timeout_for_estimated_input_tokens
-         ~estimated_input_tokens:0)
+  | None -> Some (Keeper_runtime_resolved.oas_call_timeout_sec ())
 
 (** Run a single provider attempt within the cascade.
 

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -8064,10 +8064,7 @@ let test_cascade_exhausted_error_includes_resumable_cli_session_error () =
 
 let test_bounded_oas_timeout_uses_adaptive_when_budget_is_large () =
   let estimated_input_tokens = 2_000 in
-  let expected =
-    Env_config.KeeperKeepalive.oas_timeout_for_estimated_input_tokens
-      ~estimated_input_tokens
-  in
+  let expected = Env_config.KeeperKeepalive.oas_call_timeout_sec in
   match
     UT.bounded_provider_timeout_for_turn_budget
       ~estimated_input_tokens
@@ -8123,11 +8120,7 @@ let test_bounded_oas_timeout_uses_channel_turn_budget_override () =
     Env_config.KeeperKeepalive.oas_max_turns_per_call_scheduled_autonomous
   in
   let estimated_input_tokens = 2_000 in
-  let raw =
-    Env_config.KeeperKeepalive.oas_timeout_for_estimated_input_tokens_with_turn_budget
-      ~estimated_input_tokens
-      ~max_turns
-  in
+  let raw = Env_config.KeeperKeepalive.oas_call_timeout_sec in
   match
     UT.bounded_provider_timeout_for_turn_budget_with_turn_budget
       ~max_turns

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -67,65 +67,18 @@ let test_keepalive_jitter_range () =
   check bool "jitter >= 0.0" true (v >= 0.0);
   check bool "jitter <= 0.5" true (v <= 0.5)
 
-(* ── OAS adaptive timeout tests ───────────────────────── *)
+(* ── OAS call timeout tests ───────────────────────────── *)
 
-let adaptive = Cfg.KeeperKeepalive.oas_timeout_for_estimated_input_tokens
+(* RFC-0156: OAS total timeout removed. [oas_call_timeout_sec] = override when
+   set, else [turn_timeout_sec]. No token/turn-budget dependence — the historic
+   [oas_timeout_for_estimated_input_tokens(_with_turn_budget)] names lied. *)
 
-(* #10008 fm2: the budget formula no longer scales with
-   [max_turns * per_turn(=30s)].  Production p50 turn latency showed that
-   token-count estimates were too small for real research turns.
-
-   The current invariant is a fixed 300s OAS call cap inside the 600s keeper
-   turn envelope. Input-token size and max_turns no longer affect the computed
-   budget; explicit env override remains the only way to change it. *)
-
-let oas_cap = 300.0
-
-let test_oas_timeout_32k_uses_oas_cap () =
-  let v = adaptive ~estimated_input_tokens:32_000 in
+let test_oas_call_timeout_no_override_equals_turn_timeout () =
+  (* No env override in test → resolved value equals turn_timeout_sec. *)
   check (float 1.0)
-    "32K input -> OAS cap" oas_cap v
-
-let test_oas_timeout_128k_uses_oas_cap () =
-  let v = adaptive ~estimated_input_tokens:128_000 in
-  check (float 1.0)
-    "128K input -> OAS cap" oas_cap v
-
-let test_oas_timeout_262k_uses_oas_cap () =
-  let v = adaptive ~estimated_input_tokens:262_144 in
-  check (float 1.0)
-    "262K input -> OAS cap" oas_cap v
-
-let test_oas_timeout_scheduled_autonomous_uses_oas_cap () =
-  (* #10008 fm2 regression guard: max_turns must not pull the
-     budget below the provider-attempt envelope anymore. *)
-  let v =
-    Cfg.KeeperKeepalive.oas_timeout_for_estimated_input_tokens_with_turn_budget
-      ~estimated_input_tokens:262_144
-      ~max_turns:Cfg.KeeperKeepalive.oas_max_turns_per_call_scheduled_autonomous
-  in
-  check (float 1.0)
-    "scheduled_autonomous -> OAS cap"
-    oas_cap v
-
-let test_oas_timeout_zero_uses_oas_cap () =
-  let v = adaptive ~estimated_input_tokens:0 in
-  check (float 1.0) "0 context -> OAS cap" oas_cap v
-
-(* #10008 fm2: the formula no longer varies with token count,
-   so the old "monotonic increase with input size" invariant is replaced by a
-   "constant equal to OAS cap" invariant. *)
-let test_oas_timeout_is_token_independent () =
-  let v1 = adaptive ~estimated_input_tokens:32_000 in
-  let v2 = adaptive ~estimated_input_tokens:128_000 in
-  let v3 = adaptive ~estimated_input_tokens:262_144 in
-  check (float 0.1) "32K == 128K (both at OAS cap)" v1 v2;
-  check (float 0.1) "128K == 262K (both at OAS cap)" v2 v3;
-  check (float 0.1) "all equal to OAS cap" oas_cap v1
-
-let test_oas_timeout_cap () =
-  let v = adaptive ~estimated_input_tokens:1_000_000 in
-  check (float 0.1) "1M estimated input tokens -> capped at OAS cap" oas_cap v
+    "no override -> turn_timeout_sec"
+    Cfg.KeeperKeepalive.turn_timeout_sec
+    Cfg.KeeperKeepalive.oas_call_timeout_sec
 
 let test_turn_timeout_default () =
   check (float 0.1) "default turn timeout 600s" 600.0
@@ -362,21 +315,10 @@ let () =
       test_case "jitter default" `Quick test_keepalive_jitter_default;
       test_case "jitter range" `Quick test_keepalive_jitter_range;
     ];
-    "oas_timeout_adaptive", [
-      test_case "32K context uses OAS cap (#10008 fm2)" `Quick
-        test_oas_timeout_32k_uses_oas_cap;
-      test_case "128K context uses OAS cap (#10008 fm2)" `Quick
-        test_oas_timeout_128k_uses_oas_cap;
-      test_case "262K context uses OAS cap (#10008 fm2)" `Quick
-        test_oas_timeout_262k_uses_oas_cap;
-      test_case "scheduled autonomous uses OAS cap (#10008 fm2)" `Quick
-        test_oas_timeout_scheduled_autonomous_uses_oas_cap;
-      test_case "0 context uses OAS cap (#10008 fm2)" `Quick
-        test_oas_timeout_zero_uses_oas_cap;
-      test_case "budget is token-count independent (#10008 fm2)" `Quick
-        test_oas_timeout_is_token_independent;
+    "oas_call_timeout", [
+      test_case "no override equals turn_timeout_sec (RFC-0156)" `Quick
+        test_oas_call_timeout_no_override_equals_turn_timeout;
       test_case "turn timeout default is 600" `Quick test_turn_timeout_default;
-      test_case "adaptive capped at OAS timeout" `Quick test_oas_timeout_cap;
       test_case "max_turns default is 30" `Quick test_max_turns_default;
       test_case "scheduled autonomous max_turns default is 10" `Quick
         test_scheduled_autonomous_max_turns_default;


### PR DESCRIPTION
## 목표

`oas_timeout_for_estimated_input_tokens` / `oas_timeout_for_estimated_input_tokens_with_turn_budget` 두 함수가 인자 `estimated_input_tokens` / `max_turns` 를 명시적으로 `let _ = ... in` 으로 *버리면서도* 그 인자에 기반한 듯한 이름을 노출하는 function-name-lying 박멸. RFC-0156 (OAS total timeout removed) 이후 두 함수는 단순히 `override-or-turn_timeout` 으로 collapse 됐고, 원본 작성자가 코드 주석에 "v2 PR에서 rename 예정"을 *직접 명시*. 이 PR이 그 v2.

## 왜

- 원본 코드 자가 증거 (lib/config/env_config_keeper.ml:459-460, lib/keeper/keeper_runtime_resolved.ml:301-302):
  ```ocaml
  let _ = max_turns in
  let _ = estimated_input_tokens in
  ```
  인자를 *받은 즉시* 버림. 이름과 시그니처가 거짓말.

- 원본 코드 주석 (env_config_keeper.ml:465-466) 명시:
  > 함수 이름의 `for_estimated_input_tokens` + `with_turn_budget`은 historic naming 이며 v2 PR에서 rename 예정.

- 정렬 메모리:
  - `~/me/memory/function-name-lying-fix-plan-2026-05-22.html` §3 (사이트 A1/A2)
  - `~/me/memory/audit-deep-dive-2026-05-22.html` (분류: "function name이 adaptive 시사, comment 없음, 인자를 진짜로 무시")
  - `software-development.md` §AI 코드 생성 안티패턴 §1 (하드코딩 산포) + Manifest "function-name-lying"

## 변경

| Before | After |
|--------|-------|
| `oas_timeout_for_estimated_input_tokens ~estimated_input_tokens` | `oas_call_timeout_sec` |
| `oas_timeout_for_estimated_input_tokens_with_turn_budget ~estimated_input_tokens ~max_turns` | `oas_call_timeout_sec` |
| env_config: `~estimated_input_tokens -> float` / `~tokens ~turns -> float` | static `float` |
| runtime_resolved: `~tokens ~turns -> float` / `~tokens -> float` | `unit -> float` |

`oas_call_timeout_sec` 의미: override 있으면 override, 없으면 `turn_timeout_sec`. RFC-0156 § "OAS total timeout removed" 와 1:1 정합.

**Sibling cleanup**: `let oas_timeout_default_sec = 300.0` (0 caller, post-RFC-0156 dead literal) 제거. `turn_timeout_sec` 의 docstring 도 stale `[oas_timeout_default_sec]` 참조를 RFC-0156 후속 구조로 갱신.

## 변경 파일 (9 파일, +45/-163, **net -118 LoC**)

- `lib/config/env_config_keeper.ml/.mli`: 두 함수 → `oas_call_timeout_sec` 상수, dead `oas_timeout_default_sec` 제거, stale docstring 갱신
- `lib/keeper/keeper_runtime_resolved.ml/.mli`: 두 wrapper → `oas_call_timeout_sec ()` 하나
- 3 call sites:
  - `lib/keeper/keeper_turn_cascade_budget.ml` (2 sites)
  - `lib/keeper/keeper_turn_driver_try_provider.ml`
  - `lib/keeper/keeper_agent_run.ml`
- 2 test files:
  - `test/test_work_as_heartbeat.ml`: 5 redundant token-input tests + monotonic + cap (모두 *token-independence 를 token-input 시그니처로 동조 검증* — 안티패턴 자가-trap) 을 1 정직한 test (`test_oas_call_timeout_no_override_equals_turn_timeout`) 로 collapse
  - `test/test_keeper_unified.ml`: 2 caller migration

## Behavior parity

함수 의미 byte-identical:
- `override = Some v` → `v` (unchanged)
- `override = None` → `turn_timeout_sec` (unchanged)
- `estimated_input_tokens` / `max_turns` 인자 → already ignored before, now removed from signature

## 로컬 검증

```
$ dune build --root . lib/
$ dune exec --root . test/test_work_as_heartbeat.exe
...
Test Successful in 0.062s. 43 tests run.
```

새 test `test_oas_call_timeout_no_override_equals_turn_timeout` 통과 → 의미적 행위 확인 (override 없을 때 = `turn_timeout_sec`).

## 미검증

- `test/test_keeper_unified.ml` *전체* exe 빌드는 pre-existing main 에러 (`Prompt_defaults.init`, `policy_voice_enabled`, `L.update_with_result`, `Keeper_exec_shell.cmd_targets_git_or_gh` 등) 가 막아 실패. 이 PR과 무관 — `~/me/memory` 의 `main-build-recovery-2026-05-23` worktrees 와 일치. 내가 손댄 두 callsite (line 8067, 8123) 는 단순 rename 으로 surface OK.
- CI full suite 결과 대기.

## 관련

- RFC-0156 (OAS total timeout removal)
- 원본 작성자 주석 "v2 PR에서 rename 예정" (env_config_keeper.ml @ 머지 전 line 466) 의 v2 PR
- `~/me/memory/function-name-lying-fix-plan-2026-05-22.html`
- 작업 출처: `/loop 10m 가짜 구현이나 억지로 되게끔만 만든 구현 숙청, 및 레거시 개념 제거`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>