### PR TITLE
fix(auth_strict_mode): expose pure of_string parser in .mli

### DIFF
--- a/lib/auth_strict_mode.mli
+++ b/lib/auth_strict_mode.mli
@@ -21,6 +21,15 @@
 
 type t = Off | Dry_run | Strict
 
+val of_string : string -> t
+(** Pure parser for [MASC_AUTH_STRICT] values.  Case-insensitive,
+    whitespace-trimmed.  Accepts [off|0|false], [strict|1|true],
+    [dry_run|dry-run|""].  Unknown values fall through to [Dry_run] so
+    operator omissions and typos do not silently disable measurement.
+
+    Exposed so the pre-Phase-B contract (pinned variants, pinned default)
+    is testable in isolation — the runtime [current ()] is not. *)
+
 val current : unit -> t
 (** Read [MASC_AUTH_STRICT] from the environment.  Unknown / missing values
     default to [Dry_run] so that operator omissions do not silently disable


### PR DESCRIPTION
## Summary

\`lib/auth_strict_mode.ml\` 의 pure parser \`of_string\` 가 \`.mli\` 노출 누락. \`current\` 는 환경변수 의존이라 unit-test 불가 → \`of_string\` 가 실제 contract surface (variant set / default-on-unknown / alias handling).

\`test_auth_strict_mode.ml\` 의 file docstring 이 이 의도를 *explicit* 명시:

> The runtime [current ()] reads [MASC_AUTH_STRICT] from the process environment and is therefore not unit-testable in isolation. We pin [of_string] / [to_label] here because Phase B PR-2 will branch real behavior on this variant, so a silent rename or unknown-handling change must fail at the test boundary rather than in production telemetry.

## Fix

\`.mli\` 에 \`val of_string : string -> t\` 추가 (docstring 포함).

## Verification

\`\`\`
dune build --root . test/test_auth_strict_mode.exe   →  EXIT=0
dune runtest                                          →  6/6 PASS
  of_string  0  Off canonical + aliases
  of_string  1  Strict canonical + aliases
  of_string  2  Dry_run canonical + aliases
  of_string  3  unknown -> Dry_run
  to_label   0  canonical labels
  to_label   1  round-trip
\`\`\`

## Diff

+9 LoC, .mli만.

## Pattern

이번 세션 4번째 동일 root cause — \`.ml\` 정의 + 외부 contract test 사용 + \`.mli\` expose 누락:

- iter 1: \`turn_progress_callbacks\` (turn_id mli expose, PR #18104) ✓ MERGED
- iter 2: \`Timeout_policy\` (Deadline.remaining + metric_overshoot_total, PR #18113) ✓ MERGED  
- iter 4: \`Docker_spawn_throttle\` (configured_max + effective_concurrency, PR #18117) ⏳ OPEN
- iter 5: \`Auth_strict_mode.of_string\` ← 이 PR

이는 \`feedback_partial_module_orphan_check_all_exports\` 와 sister 패턴. helper 추가 시 .mli 갱신 빠뜨리는 sweep miss.

WORKAROUND-FREE.

RFC-WAIVED: Phase A F2 직접 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)