### PR TITLE
refactor(keeper_fsm_guard_runtime): drop no-op _for_test compat shims

### DIFF
--- a/lib/keeper/keeper_fsm_guard_runtime.ml
+++ b/lib/keeper/keeper_fsm_guard_runtime.ml
@@ -2,9 +2,6 @@
 
    See keeper_fsm_guard_runtime.mli for the contract. *)
 
-let refresh_policy_for_test () = ()
-let assert_mode_for_test () = true
-
 let bump_counter ~action ~stage =
   Prometheus.inc_counter
     Prometheus.metric_fsm_guard_violation

--- a/test/test_keeper_fsm_guard_actions.ml
+++ b/test/test_keeper_fsm_guard_actions.ml
@@ -43,10 +43,6 @@ let test_honest_thunk_leaves_counter_alone () =
 
 let test_env_zero_still_reraises_and_bumps () =
   Unix.putenv "MASC_FSM_GUARD_ASSERT" "0";
-  G.refresh_policy_for_test ();
-  Alcotest.(check bool)
-    "env zero no longer disables assert mode"
-    true (G.assert_mode_for_test ());
   let action = "TestAction" in
   let stage = "env_zero_assert" in
   let before = read_count ~action ~stage in
@@ -68,10 +64,6 @@ let test_env_zero_still_reraises_and_bumps () =
    (matched in [test_board_vote_quarantine.ml:17] and siblings). *)
 let test_default_is_assert_mode_when_env_cleared () =
   Unix.putenv "MASC_FSM_GUARD_ASSERT" "";
-  G.refresh_policy_for_test ();
-  Alcotest.(check bool)
-    "default with unset env is assert mode"
-    true (G.assert_mode_for_test ());
   let action = "TestAction" in
   let stage = "default_assert" in
   let before = read_count ~action ~stage in
@@ -91,10 +83,6 @@ let test_default_is_assert_mode_when_env_cleared () =
 
 let test_buggy_thunk_reraises () =
   Unix.putenv "MASC_FSM_GUARD_ASSERT" "1";
-  G.refresh_policy_for_test ();
-  Alcotest.(check bool)
-    "policy remains assert mode"
-    true (G.assert_mode_for_test ());
   let action = "TestAction" in
   let stage = "buggy_assert" in
   let before = read_count ~action ~stage in
@@ -112,10 +100,16 @@ let test_buggy_thunk_reraises () =
     "counter is bumped before re-raise"
     (before +. 1.0) after;
   (* Restore default assert mode for any subsequent tests. *)
-  Unix.putenv "MASC_FSM_GUARD_ASSERT" "";
-  G.refresh_policy_for_test ()
+  Unix.putenv "MASC_FSM_GUARD_ASSERT" ""
 
 let test_non_assert_exception_propagates_unchanged () =
+  (* RFC-0072 Phase 5 widened the catch to all exceptions so typed
+     transition violations (Cascade_transition_violation /
+     Turn_phase_transition_violation, which would otherwise create a
+     Keeper_registry → this-module dependency cycle if named) are also
+     captured. That means any exception escaping the thunk bumps the
+     counter and re-raises with the backtrace intact — the no-bump
+     guarantee from the pre-Phase-5 narrow catch no longer holds. *)
   let action = "TestAction" in
   let stage = "non_assert" in
   let before = read_count ~action ~stage in
@@ -130,8 +124,8 @@ let test_non_assert_exception_propagates_unchanged () =
     "Failure propagates without being swallowed"
     true raised;
   Alcotest.(check (float 0.0001))
-    "counter is NOT bumped for non-Assert_failure exceptions"
-    before after
+    "counter bumps for any exception under widened catch"
+    (before +. 1.0) after
 
 let test_distinct_action_label_isolation () =
   let stage = "iso" in


### PR DESCRIPTION
## 목적

\`software-development.md\` 워크어라운드 거부 기준 §6 (\"test backdoor (set_X_for_test / reset_for_test) 노출\")의 *dead state* 정리. RFC-0072 Phase 5가 \`MASC_FSM_GUARD_ASSERT\` soft-mode escape hatch를 제거한 후 남은 no-op compat shim 2개 + 4개 test 호출 사이트 동시 삭제.

## 진단

\`\`\`ocaml
let refresh_policy_for_test () = ()        (* pure no-op *)
let assert_mode_for_test () = true         (* 무조건 true 상수 반환 *)
\`\`\`

조건 5/5 일치:
1. \`_for_test\` 접미사 (워크어라운드 시그니처)
2. 본체 = no-op / 상수 (input 무시)
3. mli 미선언 (이미 internal — \`wrap_unit\` 만 export)
4. 0 production caller (전수 grep 확인)
5. mli docstring 자체가 \"MASC_FSM_GUARD_ASSERT is no longer a runtime soft-mode escape hatch\" 명시 — hatch 사라졌고 shim만 잔존

테스트 4 사이트가 dead surface 호출 중:
\`\`\`ocaml
Unix.putenv \"MASC_FSM_GUARD_ASSERT\" \"0\";
G.refresh_policy_for_test ();              (* no-op *)
Alcotest.(check bool) \"...\" true (G.assert_mode_for_test ())  (* tautology *)
\`\`\`

## 변경

| 파일 | 변경 |
|---|---|
| \`lib/keeper/keeper_fsm_guard_runtime.ml\` | -2 함수 삭제 |
| \`test/test_keeper_fsm_guard_actions.ml\` | -4 no-op 호출, -3 tautology assert, +1 사전 broken test 정정 |

### 사전 broken test 정정

\`test_non_assert_exception_propagates_unchanged\` 가 *예전* 좁은 catch 전제로 \"non-Assert_failure은 counter bump 안 함\" 어설션을 갖고 있었습니다. 컴파일이 dead backdoor 때문에 깨져 *실행이 안 됐고*, migration 후 빌드 그린이 되며 stale expectation 발견.

mli docstring (\"catch widened to all exceptions because Keeper_registry already depends on this module\")에 맞게 어설션을 \`(before +. 1.0) after\`로 정정 + RFC-0072 Phase 5 reasoning 주석 추가.

## 검증

\`\`\`
dune exec test/test_keeper_fsm_guard_actions.exe
→ 7/7 pass
\`\`\`

## SSOT 일관성

- mli surface 미변경 (\`wrap_unit\` 단일 entry point 유지)
- production 행동 미변경 (no-op 삭제 = 영향 0)
- test가 더 정직: 의미있는 contract만 assert, dead shim 호출 제거