### PR TITLE
refactor(coord_task_schedule): drop no-op `observe_legacy_release` helper

### DIFF
--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -364,7 +364,6 @@ let claim_next_r
                    ; released_task_id = None
                    ; message
                    })));
-        let observe_legacy_release () = () in
         let released_task_id, working_tasks = None, backlog.tasks in
         let active_admission_tasks =
           List.filter
@@ -581,8 +580,7 @@ let claim_next_r
                 ; version = backlog.version + 1
                 }
               in
-              write_backlog config new_backlog;
-              observe_legacy_release ()
+              write_backlog config new_backlog
             | None -> ());
            clear_agent_state_after_release ();
            Claim_next_no_unclaimed
@@ -595,8 +593,7 @@ let claim_next_r
                 ; version = backlog.version + 1
                 }
               in
-              write_backlog config new_backlog;
-              observe_legacy_release ()
+              write_backlog config new_backlog
             | None -> ());
            clear_agent_state_after_release ();
            Claim_next_no_eligible
@@ -651,8 +648,7 @@ let claim_next_r
                 ~agent_name
                 ~task_id:rid
                 ~kind:(Event_kind.Task.to_string Event_kind.Task.Released)
-                ~payload:(`Assoc [ "task_id", `String rid ]);
-              observe_legacy_release ()
+                ~payload:(`Assoc [ "task_id", `String rid ])
             | None -> ());
            Coord_task.emit_task_activity
              config


### PR DESCRIPTION
## 목표

`let observe_legacy_release () = ()` — function body 가 `()` 인 literal no-op. 함수 이름이 "observability" (legacy release 관찰) 를 시사하지만 동작 0건. 정의 1개 + 3 call sites 모두 가짜 구현.

## 왜

- 코드 자가 증거 (lib/coord/coord_task_schedule.ml:367, pre-PR):
  ```ocaml
  let observe_legacy_release () = () in
  ```
  이름과 body 의 명백한 불일치 — Manifest 의 "function-name-lying" 인접 패턴.

- 원본 (#15956, 2026-05-17 keeper_runtime_config domain-owned counter for load_and_apply failures) 시점에 counter callsite 였을 가능성 있음. Counter 가 제거되면서 helper 와 callsite 만 잔존 → \`software-development.md\` §1 (Counter-as-Fix umbrella, RFC-0088) 의 read-side 변형.

- 결과: 의도 0 의 noise 4 줄, 다음 작업자가 \"무엇을 관찰하던 자리인가\" 추측 비용 부담.

## 변경

- `let observe_legacy_release () = () in` 정의 삭제 (line 367)
- 3 call sites 삭제 (lines 584, 598, 654) — 각 직전 표현 뒤의 `;` 도 함께 제거

## 변경 파일 (1 파일, +3 / −7, **net −4 LoC**)

- `lib/coord/coord_task_schedule.ml`

## Behavior parity

OCaml semantics: `expr1; () == expr1` (마지막 expression 의 값이 sequence 값). 모든 call site 의 직전 표현은 unit (`write_backlog config new_backlog`, `Coord_task.emit_task_activity ...`) 라 sequence 값도 unit, branch 값도 unit. Byte-identical.

## 로컬 검증

```
$ rg observe_legacy_release lib/ test/
(empty — 완전 제거 확인)

$ dune build --root . lib/
(clean)

$ dune exec --root . test/test_coord_task_lifecycle.exe
test_coord_task_lifecycle: all assertions passed
```

## 미검증

- 외부 dynamic dispatch / Marshal 등 정적 grep 으로 안 보이는 경로는 검증 안 함. no-op 이므로 호출하는 측이 있어도 *동작 변화 없음*.
- CI full suite 결과 대기.

## 관련

- `~/me/memory/feedback_dead_export_sweep_2026_05_23_anti_pattern.md`: 본 PR 은 dead *export* 가 아니라 함수 *body 자체* 가 no-op 인 경우라 5-prong audit 부담 없음 (`let ... in` 으로 함수 내부 정의 — facade re-export / include 경로 0)
- 직전 PR #18122 (function-name-lying OAS timeout) 와 같은 spirit, 더 작은 scope
- 작업 출처: `/loop 10m 가짜 구현이나 억지로 되게끔만 만든 구현 숙청, 및 레거시 개념 제거`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>