### PR TITLE
fix(test): correct gate_from_raw_typed → Gate.gate_typed typo (d09b28c16)

### DIFF
--- a/test/test_exec_shell_command_gate.ml
+++ b/test/test_exec_shell_command_gate.ml
@@ -26,7 +26,7 @@ let allowed = [ "rg"; "sort"; "head"; "wc"; "cat"; "git"; "ls"; "grep" ]
 let gate_from_raw ?caller ~raw ~allowlist ~path_policy ~sandbox () =
   match Masc_exec_bash_parser.Bash.parse_string raw with
   | PD.Parsed ir ->
-    gate_from_raw_typed ?caller ~ir ~allowlist ~path_policy ~sandbox ()
+    Gate.gate_typed ?caller ~ir ~allowlist ~path_policy ~sandbox ()
   | PD.Parse_error _ ->
     Gate.Cannot_parse { reason = Gate.Parse_error }
   | PD.Parse_aborted reason ->


### PR DESCRIPTION
## Summary

PR \`d09b28c16\` (2026-05-23, "refactor(shell-ir): remove dead string-based gate entrypoint") 가 \`Shell_command_gate.gate\` 제거 후 test 에 migration helper 추가했는데, helper 내부에서 *never-existed* 이름 호출:

\`\`\`ocaml
let gate_from_raw ?caller ~raw ~allowlist ~path_policy ~sandbox () =
  match Masc_exec_bash_parser.Bash.parse_string raw with
  | PD.Parsed ir ->
    gate_from_raw_typed ?caller ~ir ~allowlist ~path_policy ~sandbox ()
    ^^^^^^^^^^^^^^^^^^^^^^^ never existed in lib/
\`\`\`

의도된 callee: \`Gate.gate_typed\` (where \`module Gate = Masc_exec_command_gate.Shell_command_gate\`).

| Symbol | Location | Purpose |
|---|---|---|
| \`Gate.gate_typed\` | \`shell_command_gate.ml:420\` + \`.mli:159\` | Canonical typed entrypoint |
| Production callers | \`keeper_shell_ops.ml:395\`, \`keeper_gh_shared\` 등 | Already use \`Gate.gate_typed\` |

CI \`Build and Test\` job 이 \`Detect Changed Surfaces\` gate 뒤에 SKIPPED — surface 검출 패턴이 본 test 를 trigger 안 한 것이 typo 표면화 차단. (memory \`reference_masc_mcp_ci_build_test_skips\`).

## Fix

\`gate_from_raw_typed\` → \`Gate.gate_typed\` (1 char-level rename).

## Verification

\`\`\`
dune build --root . test/test_exec_shell_command_gate.exe  →  EXIT=0
dune runtest                                                →  16/16 PASS
\`\`\`

모든 6 test group (phase_0_corpus, phase_1_shape, phase_1_typed_lower, phase_1_policy, phase_1_telemetry, phase_0_pr_a2) PASS.

## Diff

+1 / -1 LoC. Net 0. 

## Philosophy

본 fix 는 *제거 의도와 정합* — string-based gate 가 사라진 상태 유지 + caller migration 의 typo 만 정정. compat shim / alias / re-add 없음. "실제 제거에 맞게 같이 개선".

WORKAROUND-FREE.

RFC-WAIVED: \`d09b28c16\` 직접 typo fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)