### PR TITLE
test(lockfree_atomic): migrate dropped update_with_result tests to update_with_commit

### DIFF
--- a/test/test_lockfree_atomic.ml
+++ b/test/test_lockfree_atomic.ml
@@ -7,37 +7,20 @@ let test_update_single () =
   L.update a (fun n -> n + 1);
   Alcotest.(check int) "single update increments" 1 (Atomic.get a)
 
-let test_update_with_result_returns_derived_value () =
-  let a = Atomic.make 10 in
-  let prev = L.update_with_result a (fun n -> (n * 2, n)) in
-  Alcotest.(check int) "derived value is pre-update state" 10 prev;
-  Alcotest.(check int) "state is transformed" 20 (Atomic.get a)
-
-let test_update_with_result_on_map () =
-  let module SMap = Map.Make (String) in
-  let a = Atomic.make SMap.empty in
-  let inserted =
-    L.update_with_result a (fun m ->
-        let m' = SMap.add "k" 42 m in
-        (m', SMap.cardinal m'))
-  in
-  Alcotest.(check int) "cardinal after insert" 1 inserted;
-  Alcotest.(check bool) "key present" true (SMap.mem "k" (Atomic.get a))
-
-let test_update_with_result_replays_on_contention () =
+let test_update_with_commit_replays_on_contention () =
   (* Manually stage contention by mutating between read and CAS.
      The helper must retry and eventually converge. *)
   let a = Atomic.make 0 in
   let interference_left = ref 2 in
   let total =
-    L.update_with_result a (fun observed ->
+    L.update_with_commit a (fun observed ->
         (* Simulate another writer bumping [a] between our read and commit
            for the first two invocations. *)
         if !interference_left > 0 then begin
           decr interference_left;
           Atomic.set a (observed + 100)
         end;
-        (observed + 1, observed))
+        { L.next_state = observed + 1; result = observed })
   in
   (* Under contention the observed value changes each attempt, but the final
      commit must see whatever [Atomic.get] returned at that iteration. *)
@@ -80,16 +63,11 @@ let () =
       Alcotest.test_case "single increment" `Quick test_update_single;
       Alcotest.test_case "1k sequential" `Quick test_update_never_loses_work;
     ];
-    "update_with_result", [
-      Alcotest.test_case "derived value" `Quick
-        test_update_with_result_returns_derived_value;
-      Alcotest.test_case "map insert" `Quick test_update_with_result_on_map;
-      Alcotest.test_case "contention replay" `Quick
-        test_update_with_result_replays_on_contention;
-    ];
     "update_with_commit", [
       Alcotest.test_case "derived value" `Quick
         test_update_with_commit_returns_derived_value;
       Alcotest.test_case "map insert" `Quick test_update_with_commit_on_map;
+      Alcotest.test_case "contention replay" `Quick
+        test_update_with_commit_replays_on_contention;
     ];
   ]


### PR DESCRIPTION
## 목적

PR #17998이 \`Lockfree_atomic.update_with_result\` 를 \"0 callers\" audit로 제거했지만 test 파일에 3개 호출 사이트가 남음 — PR #18009 (AT.stats), #17950 (Prompt_defaults.init), #17998 (이번) 세 번째 audit miss. 사용자의 SSOT 축소 의도를 따라 *복원이 아닌 caller migration*으로 완성.

## 진단

\`Lockfree_atomic.mli\` (current SSOT):
\`\`\`
val update_with_commit : 'a Atomic.t -> ('a -> ('a, 'b) commit) -> 'b
\`\`\`

테스트 3개 사이트가 사라진 \`update_with_result\` 호출:
- L10 \`test_update_with_result_returns_derived_value\`
- L16 \`test_update_with_result_on_map\`
- L27 \`test_update_with_result_replays_on_contention\`

**같은 파일에 \`update_with_commit\` 기반 동일 시나리오 테스트가 *이미* 존재**:
- L58 \`test_update_with_commit_returns_derived_value\` ← L10 duplicate
- L66 \`test_update_with_commit_on_map\` ← L16 duplicate

contention replay (L27) 만 unique invariant.

## 변경

- 2 duplicate 테스트 삭제 (L10-25)
- contention replay → \`test_update_with_commit_replays_on_contention\` rename + tuple → record form 변환
- Runner 등록: \"update_with_result\" 그룹 제거, contention replay를 \"update_with_commit\" 그룹에 병합

## SSOT 효과

- \`Lockfree_atomic\` surface: 단일 entry point (\`update_with_commit\`)
- Test runner 그룹: 1개 → 통합
- Net -27 LoC, mli 미변경

## 검증

\`\`\`
dune exec test/test_lockfree_atomic.exe
→ 5/5 pass (update single/1k + commit derived/map/contention)
\`\`\`

## Audit 패턴 메타

세 번째 \"audit이 production만 보고 test miss\" 사례. 패턴 명확:

| PR | 제거 대상 | Audit 누락 |
|---|---|---|
| #17998 | update_with_result | 3 test callers |
| #17950 | Prompt_defaults.init | 7 test callers |
| #18009 | AT.stats/stats_to_json | 5 test callers |

향후 dead-export sweep 시 \`rg ... test/\` 명시 grep 강제가 더 명확해집니다 (memory: feedback_dead_export_audit_must_trace_include_facade.md).