### PR TITLE
fix(keeper_turn_driver): drop non-Eio sleep fallback in fleet backoff (D-10)

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -1239,9 +1239,18 @@ let run_named
                cascade_name
                (List.length all_candidates)
                wait_sec;
+             (* Cascade dispatch always runs inside Eio_main; the
+                [None] arm only fires from test setups that exercise
+                this code path without an Eio clock installed.  Skip
+                the backoff in that case rather than block the fiber's
+                thread on a non-Eio sleep primitive (D-10 convention:
+                no non-Eio-clock fallback outside the three allow-listed
+                sites). The test path doesn't depend on the backoff
+                actually elapsing — it only checks dispatch logic — so
+                a no-op skip preserves test semantics. *)
              match Eio_context.get_clock_opt () with
              | Some clock -> Eio.Time.sleep clock wait_sec
-             | None -> Unix.sleepf wait_sec
+             | None -> ()
            ))));
       Eio_guard.fair_yield (); (* P0: keep fast-fail cascades scheduler-fair. *)
       (* RFC-0157 PR-1: pre-dispatch required-tool capability gate.


### PR DESCRIPTION
## Goal

Unblock the **Lint** CI check on main by removing the non-Eio sleep fallback that PR #17909 introduced into the fleet-level backoff loop. The fallback violates the D-10 Eio convention: raw non-Eio sleep primitives are only allowed in three specific files; \`lib/keeper/keeper_turn_driver.ml\` is not one of them.

## Root cause

PR #17909 (\"feat(keeper): fleet-level backoff when all providers in cooldown — task-536\") introduced this branch inside \`Keeper_turn_driver.run_named\`:

\`\`\`ocaml
match Eio_context.get_clock_opt () with
| Some clock -> Eio.Time.sleep clock wait_sec
| None       -> Unix.sleepf wait_sec      (* ← D-10 violation *)
\`\`\`

The \`None\` arm is **unreachable in production**: \`run_named\` is only invoked from \`Keeper_agent_run.run_turn\` and \`Keeper_persona_authoring\`, both deep inside \`Agent.run()\` which always executes inside \`Eio_main\`. The fallback existed only as defensive shim for test setups that drive this code path without an Eio clock installed.

Silently falling back to a blocking thread sleep in the cascade dispatch fiber is exactly the kind of \"silent failure / unknown → permissive default\" anti-pattern the project explicitly flags (\`software-development.md\` §AI Code Generation Antipatterns #2). It also breaks the fiber scheduler invariant — \`Eio_guard.fair_yield ()\` on the next line is followed by a comment \"P0: keep fast-fail cascades scheduler-fair\", which a blocking thread sleep undermines.

## Fix

Replace the fallback with a no-op skip plus an explanatory comment that documents the invariant (\`run_named\` runs inside \`Eio_main\`) and the chosen degradation strategy (skip the backoff in test setups rather than block the thread).

\`\`\`ocaml
match Eio_context.get_clock_opt () with
| Some clock -> Eio.Time.sleep clock wait_sec
| None       -> ()    (* skip backoff outside Eio context *)
\`\`\`

\`failwith\`/\`assert false\` were considered but rejected: a test setup hitting this branch would crash the test run, and the project guidance is to fail safe in defensive paths rather than fail loud in tests that aren't checking the backoff timing.

## What this PR does NOT do

- It does not add \`keeper_turn_driver.ml\" to the lint allow-list. That would be the \"어거지\" workaround the user explicitly forbids — the allow-list documents three files where blocking is the lesser evil (file lock acquisition, shutdown timeout, turn-slot wait), and cascade backoff is not in that category.
- It does not change production behavior. In production the \`Some clock\` arm is always taken; this PR removes dead code from the \`None\` arm.

## Verification

Local lint run on the modified tree:

\`\`\`
$ bash scripts/check-eio-conventions.sh
Eio convention snapshot:
  search tool: rg
  lib/Eio_unix.sleep: 0
  lib/Unix.sleep*: 3                # 4 → 3 (all in allow-listed files)
  lib/Eio.Mutex.create (): 116
  lib/Eio.Fiber.fork: 82
  lib+test/fork_promise: 10
$ echo $?
0
\`\`\`

(Before this PR the script exited 1 with the ERROR \"raw Unix.sleep/Unix.sleepf usage is only allowed in ...\" message.)

## CI Note

\`Build and Test\` currently fails on this PR because origin/main has **pre-existing compilation errors** (missing mli exports: \`Prompt_defaults.init\`, \`Http_protocol_detect.detect_from_fd\`, \`Auth_strict_mode.of_string\`, etc.). These are being fixed in **PR #18183**. Once #18183 merges, this PR\'s Build/Test will pass automatically — the code change in this PR does not introduce any new build errors.

## Scope

This is one of several independent root fixes for main CI fails:
- ✅ Step A (\`pr_metrics\` re-extract) — PR #18112 merged
- 🟡 Step B (\`gate_attempt\` re-extract) — PR #18114 Draft (godfile threshold)
- 🟡 Meta Guards spec re-anchor — PR #18120 Draft
- 🟡 **This PR — Lint D-10 violation**

Remaining main CI fails after this lands (queued):
- OCaml Structure Ratchet (3 missing keeper .mli, 7 missing lib .mli, \`lib_dune_lines\` drift)
- RFC-0151 \`catch_all_arms\` +13 (Step C/D)
- RFC-0160 G1 \`parse_string\` callers +1 (Step E)

Per \`reference_masc_mcp_draft_auto_merge_guard\`, stays Draft.

🤖 Generated with [Claude Code](https://claude.com/code)