### PR TITLE
refactor(dashboard_http_runtime_support): drop placeholder `t/create/default/runtime_support` chain

### DIFF
--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -12,7 +12,6 @@ type dashboard_compute_mode =
 
 (* Dashboard runtime helpers extracted to
    [Server_dashboard_http_core_runtime] (godfile decomp). *)
-let runtime_support = Server_dashboard_http_core_runtime.runtime_support
 let set_executor_pool = Server_dashboard_http_core_runtime.set_executor_pool
 let dashboard_runtime = Server_dashboard_http_core_runtime.dashboard_runtime
 let run_dashboard_compute = Server_dashboard_http_core_runtime.run_dashboard_compute

--- a/lib/server/server_dashboard_http_core_runtime.ml
+++ b/lib/server/server_dashboard_http_core_runtime.ml
@@ -1,13 +1,10 @@
 (** Dashboard HTTP compute-runtime bindings, extracted from
-    [server_dashboard_http_core.ml]. Holds the shared
-    [runtime_support] instance, [set_executor_pool] alias,
-    [dashboard_runtime] constructor, the [run_dashboard_compute]
-    dispatch wrapper, and the [state_dashboard_runtime_caps]
-    state-decomposer. *)
+    [server_dashboard_http_core.ml]. Provides the
+    [set_executor_pool] alias, [dashboard_runtime] constructor,
+    the [run_dashboard_compute] dispatch wrapper, and the
+    [state_dashboard_runtime_caps] state-decomposer. *)
 
 open Server_dashboard_http_runtime_support
-
-let runtime_support = Server_dashboard_http_runtime_support.default ()
 
 (** Executor pool for CPU-heavy dashboard compute.
     Pool reference is shared via [Executor_pool_ref] in masc_core. *)
@@ -33,7 +30,6 @@ let run_dashboard_compute
   =
   let runtime = dashboard_runtime ?net ?mono_clock config in
   Server_dashboard_http_runtime_support.run_dashboard_compute
-    runtime_support
     ~mode
     ?runtime
     ~sw

--- a/lib/server/server_dashboard_http_core_runtime.mli
+++ b/lib/server/server_dashboard_http_core_runtime.mli
@@ -1,9 +1,6 @@
 (** Dashboard compute-runtime bindings extracted from
     {!Server_dashboard_http_core}. *)
 
-val runtime_support : Server_dashboard_http_runtime_support.t
-(** Shared runtime-support handle for dashboard compute dispatch. *)
-
 val set_executor_pool : Eio.Executor_pool.t -> unit
 (** Register the dashboard executor pool. *)
 

--- a/lib/server/server_dashboard_http_runtime_support.ml
+++ b/lib/server/server_dashboard_http_runtime_support.ml
@@ -7,19 +7,11 @@ type runtime = {
   mono_clock : Eio.Time.Mono.ty Eio.Resource.t;
 }
 
-type t = unit
-
-let create () = ()
-
-let default_state : t = create ()
-
-let default () = default_state
-
 let set_executor_pool pool = Executor_pool_ref.set pool
 
-let run_dashboard_compute state ?(mode = Offloaded_readonly) ?runtime ~sw ~clock
+let run_dashboard_compute ?(mode = Offloaded_readonly) ?runtime ~sw ~clock
     ~(config : Coord.config) compute =
-  let _ = state, runtime, clock in
+  let _ = runtime, clock in
   let fallback () = compute ~config ~sw in
   let run_in_pool pool_sw =
     `Done (compute ~config ~sw:pool_sw)

--- a/lib/server/server_dashboard_http_runtime_support.mli
+++ b/lib/server/server_dashboard_http_runtime_support.mli
@@ -7,12 +7,7 @@
     starve other dashboard tabs. The pool itself is owned by
     {!Executor_pool_ref} (process-wide single-writer); this
     module is a thin orchestration layer that picks the strategy
-    and falls back to inline compute when no pool is registered.
-
-    Internal helper [create] (currently a [unit -> unit]
-    placeholder) and the [default_state] singleton it produces
-    are hidden — callers consume {!default} for the
-    process-wide handle. *)
+    and falls back to inline compute when no pool is registered. *)
 
 type dashboard_compute_mode =
   | Inline_shared
@@ -31,24 +26,12 @@ type runtime = {
     captured so a future "pool-side network" use-case does not
     have to thread the resource separately. *)
 
-type t
-(** Opaque handle to the runtime-support state. The current
-    implementation has no per-handle state (the executor pool
-    lives in {!Executor_pool_ref}); the type is kept abstract so
-    a future stateful expansion (e.g. per-pool metrics) does not
-    break callers. *)
-
-val default : unit -> t
-(** Return the process-wide handle. Identity-stable across
-    calls. *)
-
 val set_executor_pool : Eio.Executor_pool.t -> unit
 (** Register the executor pool for [Offloaded_readonly] compute.
     Last-writer-wins via {!Executor_pool_ref}.[set]; the slot is
     intended to be filled exactly once at server startup. *)
 
 val run_dashboard_compute :
-  t ->
   ?mode:dashboard_compute_mode ->
   ?runtime:runtime ->
   sw:Eio.Switch.t ->


### PR DESCRIPTION
## 목표

`Server_dashboard_http_runtime_support` 의 `t = unit / create = () / default_state / default / runtime_support` 4단 체인이 모두 fake plumbing. `type t` 는 `unit`, `create` 는 `()` 반환, `run_dashboard_compute` 의 첫 positional 인자 `state` 는 body 의 `let _ = state, ...` 로 즉시 버려짐.

## 자가 증거

원본 mli (lines 12-15) 이 직접 자가 인정:

> "Internal helper [create] (currently a [unit -> unit] placeholder) and the [default_state] singleton it produces are hidden — callers consume {!default} for the process-wide handle."

> "type t ... The current implementation has no per-handle state ...; the type is kept abstract so a future stateful expansion (e.g. per-pool metrics) does not break callers."

후자는 `CLAUDE.md` / `software-development.md` 의 다음 원칙 정면 위반:

> "Don't design for hypothetical future requirements. Three similar lines is better than a premature abstraction. No half-finished implementations either."

미래 expansion 이 실제로 필요해질 때 그 시점에 typed 추가하면 되며, 지금 fake handle 을 통과시킬 이유 0.

## 변경

`lib/server/server_dashboard_http_runtime_support.ml/.mli`:
- `type t = unit` 제거
- `let create () = ()` 제거
- `let default_state : t = create ()` 제거
- `let default () = default_state` 제거
- `run_dashboard_compute` 첫 positional `state` 인자 제거, body `let _ = state, runtime, clock` → `let _ = runtime, clock`
- mli module docstring "Internal helper [create]..." paragraph 제거

`lib/server/server_dashboard_http_core_runtime.ml/.mli`:
- `let runtime_support = Server_dashboard_http_runtime_support.default ()` 제거
- `run_dashboard_compute` body 내 `runtime_support` positional arg 제거
- mli `val runtime_support` 제거
- module docstring 갱신 ("Holds the shared runtime_support instance" 제거)

`lib/server/server_dashboard_http_core.ml`:
- `let runtime_support = Server_dashboard_http_core_runtime.runtime_support` re-export 제거

## 변경 파일 (5 파일, +7 / −40, **net −33 LoC**)

## Behavior parity

- `t = unit`, `default () = ()` → chain 의 값은 단순 `()` 통과
- `run_dashboard_compute` body 가 이미 `let _ = state, runtime, clock` 로 state 명시적으로 버림 → state 제거 후 동작 byte-identical
- `mode/runtime/sw/clock/config/compute` 시그니처 보존

## 로컬 검증

```
$ dune build --root . lib/  # clean
$ rg "Server_dashboard_http_core.runtime_support" lib/ test/
(empty — 외부 caller 0)
```

CI contract 문자열 유지 확인 (`test/test_ci_hardening_source.ml:2058,2061`):
- `let run_dashboard_compute` ✓ (line 14 of support.ml)
- `Eio.Executor_pool.submit_exn` ✓ (line 26 of support.ml)

## 미검증

- CI full suite 결과 대기
- `test/test_keeper_unified.ml` 등 pre-existing main 빌드 에러는 본 PR 과 무관 (`~/me/memory` 의 `main-build-recovery-2026-05-23` worktrees 와 일치)

## 관련

- `CLAUDE.md`: "Don't design for hypothetical future requirements"
- `software-development.md` AI 코드 생성 안티패턴 §1, §2
- 직전 PR #18125 (no-op `observe_legacy_release`) + #18122 (function-name-lying OAS timeout) 와 같은 spirit — fake plumbing 제거
- 작업 출처: `/loop 10m 가짜 구현이나 억지로 되게끔만 만든 구현 숙청, 및 레거시 개념 제거`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>