### PR TITLE
refactor(governance_anomaly): drop ref-accumulator in detect_deviations

### DIFF
--- a/lib/governance_anomaly.ml
+++ b/lib/governance_anomaly.ml
@@ -377,21 +377,22 @@ let detect_deviations ~profile ~entries ~threshold =
     let observed_diversity = tool_diversity_of_batch entries in
     let observed_token = token_volume_of_batch entries in
     let observed_failure = failure_rate_of_batch entries in
-    let deviations = ref [] in
-    let add dimension observed expected stat =
+    let check dimension observed stat =
       let z = z_score ~observed ~mean:stat.mean ~stddev:stat.stddev in
       if abs_float z >= threshold then
-        deviations :=
-          { dimension; observed; expected = stat.mean; z_score = z; severity = severity_of_z z }
-          :: !deviations
+        Some
+          { dimension; observed; expected = stat.mean
+          ; z_score = z; severity = severity_of_z z }
+      else None
     in
-    add "activity_volume" observed_activity profile.activity_volume.mean profile.activity_volume;
-    add "tool_diversity" observed_diversity profile.tool_diversity.mean profile.tool_diversity;
-    (match (observed_token, profile.token_volume) with
-    | Some obs, Some stat -> add "token_volume" obs stat.mean stat
-    | _ -> ());
-    add "failure_rate" observed_failure profile.failure_rate.mean profile.failure_rate;
-    List.rev !deviations
+    List.filter_map Fun.id
+      [ check "activity_volume" observed_activity profile.activity_volume
+      ; check "tool_diversity" observed_diversity profile.tool_diversity
+      ; (match (observed_token, profile.token_volume) with
+         | Some obs, Some stat -> check "token_volume" obs stat
+         | None, _ | _, None -> None)
+      ; check "failure_rate" observed_failure profile.failure_rate
+      ]
 
 (* ── Top-level convenience ────────────────────────────────── *)
 


### PR DESCRIPTION
## 목표

`lib/governance_anomaly.ml`의 `detect_deviations` 함수에서 `let deviations = ref []` + `let add ...` closure (4회 호출) 패턴을 제거하고, 4개 `deviation option` + `List.filter_map Fun.id`로 변환.

## 왜

- 4번째 same-pattern. iter #1 #18106 (server_state_product), iter #2 #18109 (chronicle_validate), iter #3 #18119 (tool_control), iter #4 (this). 모두 동일한 ref-as-accumulator anti-pattern.
- 부산물: helper `add`의 dead 4번째 인자 (`expected = profile.X.mean`이 caller에서 전달되지만 함수 안에서 사용 안 함, `stat.mean`이 곧 그 값) 제거. `add` 4-arg → `check` 3-arg로 시그니처 단순화.

## Behavior parity

| 측면 | 원본 | 새 코드 |
|---|---|---|
| Emission 순서 | activity → diversity → token(opt) → failure (prepend + List.rev) | 동일 (list literal 위치) |
| Threshold | `abs_float z >= threshold` | 동일 |
| Record fields | `dimension; observed; expected = stat.mean; z_score; severity` | 동일 |
| Empty entries | early return `[]` | 동일 |
| token_volume None case | `\| _ -> ()` skip | `\| None, _ \| _, None -> None` 명시 분해 (semantically identical) |

## 변경 파일

- `lib/governance_anomaly.ml` (+13 / −12)

## 로컬 검증

```
$ dune build --root . lib/                                  # PASS
$ dune exec --root . test/test_governance_anomaly.exe
...
Test Successful in 0.025s. 11 tests run.
```

3 detect_deviations 테스트 직접 cover:
- detect_deviations flags burst activity
- detect_deviations empty entries
- detect_deviations skips token_volume when None

## 누적 (4 iter)

| Iter | PR | 함수 | 상태 |
|---|---|---|---|
| #1 | #18106 | server_state_product.check_invariants | MERGED |
| #2 | #18109 | chronicle_validate.validate_epoch | MERGED |
| #3 | #18119 | tool_control.keeper_pause_status_json | Draft |
| #4 | (this) | governance_anomaly.detect_deviations | Draft |

## 분류 기준 (4 iter 누적)

- **변환 대상**: 함수 내 `ref []` + closure / List.iter / sequential prepend → fold 또는 filter_map
- **변환 거부**: bounded sample list with counter (cdal_runtime_health), streaming-fold docstring witness (activity_graph_reducer), module-level register state (gh_exit_class.overrides), Eio.Mutex-protected fiber-shared (relay.checkpoints)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>