### PR TITLE
refactor(set_util): complete #17947 removal — drop dead helper impls + tests

### DIFF
--- a/lib/core/set_util.ml
+++ b/lib/core/set_util.ml
@@ -5,23 +5,6 @@
 
 let default_capacity = 16
 
-let of_list_with (key : 'a -> 'b) (xs : 'a list) : ('b, unit) Hashtbl.t =
-  let tbl = Hashtbl.create default_capacity in
-  List.iter (fun x -> Hashtbl.replace tbl (key x) ()) xs;
-  tbl
-;;
-
-let count_distinct (key : 'a -> 'b option) (xs : 'a list) : int =
-  let seen : ('b, unit) Hashtbl.t = Hashtbl.create default_capacity in
-  List.iter
-    (fun x ->
-       match key x with
-       | Some k -> Hashtbl.replace seen k ()
-       | None -> ())
-    xs;
-  Hashtbl.length seen
-;;
-
 let count_difference
       (xs : 'a list)
       ~(present : 'a -> 'b option)

--- a/lib/core/set_util.mli
+++ b/lib/core/set_util.mli
@@ -2,13 +2,12 @@
     pattern that saturated across perf PRs (telemetry, dedupe, distinct
     counters).
 
-    Each helper is a one-pass [Hashtbl] kernel. We keep [Hashtbl.t] over
-    [Set.Make(Key)] because (a) callers already pass arbitrary key types
-    (strings, ints, tuples) without a functor instance, and (b) the linear
-    O(N) bucket model matches the existing call sites' allocation profile.
-
-    backing representation needs to change, hide it behind an abstract
-    type [`'k t`] in this interface first. *)
+    The one currently exported helper is a one-pass [Hashtbl] kernel.
+    [Hashtbl.t] is used over [Set.Make(Key)] because callers pass arbitrary
+    key types (strings, ints, tuples) without a functor instance, and the
+    linear O(N) bucket model matches existing call sites' allocation
+    profile. If the backing representation needs to change, hide it behind
+    an abstract type [`'k t`] in this interface first. *)
 
 (** [count_difference xs ~present ~absent] counts distinct keys produced by
     [present] that are NOT also produced by [absent]. Implementation: one

--- a/test/test_set_util.ml
+++ b/test/test_set_util.ml
@@ -4,28 +4,6 @@
 open Alcotest
 module S = Set_util
 
-(* ---------- count_distinct ---------- *)
-
-let test_count_distinct_empty () =
-  check int "empty" 0 (S.count_distinct (fun _ -> Some 0) [])
-;;
-
-let test_count_distinct_all_some () =
-  check int "all distinct" 3 (S.count_distinct (fun x -> Some x) [ 1; 2; 3 ])
-;;
-
-let test_count_distinct_duplicates_counted_once () =
-  check int "dup collapsed" 2 (S.count_distinct (fun x -> Some x) [ "a"; "b"; "a"; "a" ])
-;;
-
-let test_count_distinct_none_skipped () =
-  check
-    int
-    "None skipped"
-    2
-    (S.count_distinct (fun x -> if x mod 2 = 0 then Some x else None) [ 1; 2; 3; 4; 5 ])
-;;
-
 (* ---------- count_difference ---------- *)
 
 (* Mini event model isomorphic to telemetry_eio's joined/left flow. *)
@@ -78,16 +56,7 @@ let test_count_difference_present_after_absent () =
 let () =
   run
     "set_util"
-    [ ( "count_distinct"
-      , [ test_case "empty" `Quick test_count_distinct_empty
-        ; test_case "all some" `Quick test_count_distinct_all_some
-        ; test_case
-            "duplicates counted once"
-            `Quick
-            test_count_distinct_duplicates_counted_once
-        ; test_case "None skipped" `Quick test_count_distinct_none_skipped
-        ] )
-    ; ( "count_difference"
+    [ ( "count_difference"
       , [ test_case "empty" `Quick test_count_difference_empty
         ; test_case
             "all present no absent"


### PR DESCRIPTION
## 목적

PR #17947 이 \`of_list_with\` + \`count_distinct\` 를 mli에서 dead로 잡아 제거. 하지만:
1. \`.ml\` 의 구현체가 남음
2. test 4개가 \`count_distinct\` 호출 중
3. mli 헤더 문구에 \`of_list_with\` 잔재 (orphan paragraph fragment)

같은 audit-miss 패턴: PR #17950 (Prompt_defaults.init), #17998 (Lockfree_atomic.update_with_result), #18009 (AT.stats)와 동일 — \`rg <name> test/\` 누락. **4번째 누적 사례**.

## 결정 — restore 아닌 delete

분류 매트릭스 (loop 누적):

| 케이스 | mli 역할 명시 | Production caller | 결정 |
|---|---|---|---|
| Prompt_defaults.init (iter 1) | YES (\"thin surface for test fixtures\") | 0 | 복원 |
| Lockfree_atomic.update_with_result (iter 3) | NO (record form이 SSOT) | 0 | caller migration |
| **set_util.count_distinct / of_list_with (이번)** | NO (mli header만 \"SSOT for membership/difference\" — 일반 표제) | 0 | **delete + test 제거** |

\`count_distinct\` 의 4 test는 *speculative invariant pinning* — production caller 없는 helper의 정확성을 미래 사용 가능성을 위해 보존. YAGNI 위반. \`of_list_with\` 는 test caller 도 0 (전수 dead).

## 변경

| 파일 | 변경 |
|---|---|
| \`lib/core/set_util.ml\` | -17: \`of_list_with\`, \`count_distinct\` 함수 삭제 |
| \`lib/core/set_util.mli\` | header orphan paragraph fragment 정리 (truncated sentence가 \`of_list_with\` 참조) |
| \`test/test_set_util.ml\` | -33: 4 \`count_distinct\` test + runner 그룹 제거 |

Net -49 LoC. mli surface 미변경 (\`count_difference\` 단일 entry point 유지).

## 검증

\`\`\`
dune exec test/test_set_util.exe → 5/5 pass (count_difference 그룹)
\`\`\`

## SSOT

- \`set_util\` surface = \`count_difference\` 1개 entry point
- test runner group = 1개 통합
- \`Hashtbl.t\` exposure (mli §1 노트)는 \`count_difference\` 가 그것에 의존하지 않으므로 미래 \`Set.Make\` swap에도 영향 없음

## Audit 패턴 메타 (누적)

| PR | 제거 대상 | 누락 test caller |
|---|---|---|
| #17947 | of_list_with / count_distinct | 4 |
| #17950 | Prompt_defaults.init | 7 |
| #17998 | Lockfree_atomic.update_with_result | 3 |
| #18009 | AT.stats/stats_to_json | 5 |

**5번째 같은 패턴이 나오기 전에** sweep 표준 의례에 \`rg test/\` 강제 추가 권장. \`scripts/audit-dead-export.sh\` 같은 helper로 자동화 가능.