### PR TITLE
fix(dashboard_yjs): expose frame_update encoder in .mli

### DIFF
--- a/lib/dashboard/dashboard_yjs.mli
+++ b/lib/dashboard/dashboard_yjs.mli
@@ -1,6 +1,13 @@
 (** Dashboard_yjs — Yjs WebSocket Projection Layer for Live Telemetry
     @since Project World Building (Big Bang) *)
 
+val frame_update : string -> string
+(** [frame_update payload] wraps [payload] in the Yjs sync frame envelope
+    used by browser-side Y.applyUpdate consumers: two leading control
+    bytes [\x00\x02] followed by the payload length encoded as a Yjs
+    varint, followed by the payload itself.  Pure function — the byte
+    layout is the wire contract pinned by [test_dashboard_yjs]. *)
+
 (** [broadcast_keeper_telemetry ~keeper_name ~trace_id ~turn_index ~model_id]
     publishes a keeper Yjs telemetry update to dashboard observer sessions.
     [model_id] is accepted for legacy call sites but redacted to the neutral


### PR DESCRIPTION
## Summary

\`lib/dashboard/dashboard_yjs.ml:17\` 의 \`frame_update : string -> string\` (pure encoder, Yjs sync-protocol 프레임 포장) 가 \`.mli\` 노출 누락. \`.mli\` 는 \`broadcast_keeper_telemetry\` 만 expose.

## Why it matters

\`test/test_dashboard_yjs.ml\` 가 wire-format byte layout 3 케이스 pin:

| Payload | Expected frame bytes |
|---|---|
| empty | \`[0; 2; 0]\` |
| 3-byte | \`[0; 2; 3] ++ bytes\` |
| 130-byte | \`[0; 2; 0x82; 0x01] ++ bytes\` (varint encoding) |

이는 browser-side \`Y.applyUpdate\` 가 의존하는 binary contract — \`encode_uint\` 또는 leading 바이트의 silent change 가 양쪽 호환성 깸. .mli omission 이 contract test 차단.

## Fix

\`.mli\` 에 \`val frame_update : string -> string\` 추가 (docstring 으로 byte layout 명시).

## Verification

\`\`\`
dune build --root . test/test_dashboard_yjs.exe  →  EXIT=0
dune runtest                                      →  3/3 PASS
  frame_update 0  empty payload
  frame_update 1  small payload
  frame_update 2  multi-byte varint payload
\`\`\`

## Diff

+7 LoC, .mli 만.

## Pattern (5번째 동일 root cause)

이번 세션 \`.mli expose missing\` 패턴 누적:

| iter | 모듈 | 노출 누락 | PR |
|---|---|---|---|
| 1 | \`Keeper_agent_run_turn_helpers\` | turn_id | #18104 ✓ |
| 2 | \`Timeout_policy\` | Deadline.remaining + metric_overshoot_total | #18113 ✓ |
| 4 | \`Docker_spawn_throttle\` | configured_max + effective_concurrency | #18117 ⏳ |
| 5 | \`Auth_strict_mode\` | of_string | #18123 ⏳ |
| 7 | \`Dashboard_yjs\` | frame_update | 본 PR |

System-level lint 후보: \`.ml\` 의 \`let X\` toplevel 정의 → \`.mli\` 동일 line expose 확인.

WORKAROUND-FREE.

RFC-WAIVED: pre-existing .mli expose 누락 보강.

🤖 Generated with [Claude Code](https://claude.com/claude-code)