### PR TITLE
refactor(agent_registry_eio): drop dead no-op `init` export

### DIFF
--- a/lib/agent_registry_eio.ml
+++ b/lib/agent_registry_eio.ml
@@ -70,10 +70,6 @@ let max_session_cache_entries = 1024
 
 (** {1 Initialization} *)
 
-(** Initialize (or re-initialize) the actor state.
-    Idempotent when called more than once – the existing state is kept. *)
-let init () = ()  (* state is created eagerly at module load time *)
-
 (** Reset registry for testing.
     Replaces all state with a fresh empty record. *)
 let reset_for_testing () =

--- a/lib/agent_registry_eio.mli
+++ b/lib/agent_registry_eio.mli
@@ -27,7 +27,6 @@ module Random = Stdlib.Random
 
 (** {1 Initialization} *)
 
-val init : unit -> unit
 val reset_for_testing : unit -> unit
 
 (** {1 Identity Resolution} *)


### PR DESCRIPTION
## 목표

`val init : unit -> unit` 가 mli 로 노출되어 있지만 body 는 `()` no-op 이고 caller 가 0 — *dead export + body no-op* 이중 anti-pattern.

## 자가 증거

`lib/agent_registry_eio.ml` (pre-PR line 75):
```ocaml
let init () = ()  (* state is created eagerly at module load time *)
```

원본 docstring (line 73-74):
> "Initialize (or re-initialize) the actor state. Idempotent when called more than once – the existing state is kept."

이 docstring 은 *호출 효과 0* 을 "idempotent" 로 완곡 표현. 실제로 `make_state ()` 가 module load 시점에 실행되므로 `init ()` 으로 *추가로* 할 일이 없음.

다른 module 의 `init` 함수는 모두 실제 setup 수행:
- `process_eio.init ~cwd_default ~proc_mgr ~clock`
- `prometheus.init`
- `masc_eio_env.init ~sw ~net ?clock`
- `heuristic_metrics.init ~base_path`
- `tool_usage_log.init ?cluster_name ~base_path`
- `coord.init config ~agent_name`
- ... (16개 module의 init 모두 실제 setup)

`agent_registry_eio.init` 만 `() = ()` outlier.

## 5-prong dead-export audit

(`~/me/memory/feedback_dead_export_audit_must_trace_include_facade.md` 강제)

| Path | Result |
|------|--------|
| 1. Direct `Agent_registry_eio.init` qualified call | 0 hit |
| 2. Module alias (`module X = Agent_registry_eio`) | 0 hit |
| 3. Re-export (`let init = Agent_registry_eio.init`) | 0 hit |
| 4. `include Agent_registry_eio` | 0 hit |
| 5. `open Agent_registry_eio` opener + bare `init` | 0 hit (opener 자체가 0) |

Defensive witness check (`~/me/memory/feedback_defensive_witness_4th_veto_path.md`): docstring 은 *observed-behavior* 설명만, compile-time invariant maintenance 선언 없음 → 안전.

## 변경

`lib/agent_registry_eio.mli`:
- `val init : unit -> unit` 제거

`lib/agent_registry_eio.ml`:
- `(** Initialize ... *) let init () = ()` 정의 + docstring 제거

`(** {1 Initialization} *)` 섹션 헤딩은 유지 — `reset_for_testing` 이 여전히 re-initialization 의미.

## 변경 파일 (2 파일, +0 / −5, **net −5 LoC**)

## 로컬 검증

```
$ dune build --root . lib/  # clean
$ dune exec --root . test/test_agent_registry_eio.exe
Test Successful in 0.039s. 11 tests run.
```

Test file 은 `reset_for_testing` / `get_or_create_identity` / `total_count` 만 사용, `init` 안 사용 (5-prong audit step 1 의 grep 으로 확인됨).

## 관련

- `~/me/memory/feedback_dead_export_audit_must_trace_include_facade.md`
- `~/me/memory/feedback_module_name_grep_misses_open_bare_names.md`
- 같은 spirit 의 이전 loop iter PR 들:
  - #18122 (function-name-lying OAS timeout) — name 거짓
  - #18125 (no-op `observe_legacy_release`) — body 가 `()`
  - #18130 (placeholder `t/create/default` chain) — type 자체가 fake
  - 본 PR — mli 에 노출된 dead no-op
- 작업 출처: `/loop 10m 가짜 구현이나 억지로 되게끔만 만든 구현 숙청, 및 레거시 개념 제거`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>