### PR TITLE
fix: re-export Auth_strict_mode.of_string via .mli (PR #17946 follow-up)

### DIFF
--- a/lib/auth_strict_mode.mli
+++ b/lib/auth_strict_mode.mli
@@ -26,6 +26,15 @@ val current : unit -> t
     default to [Dry_run] so that operator omissions do not silently disable
     measurement. *)
 
+val of_string : string -> t
+(** Pure parser exposed for unit tests so Phase B PR-2's promotion of
+    [Strict] to a typed reject lands on a parser whose canonical / alias
+    / unknown handling has been pinned at the test boundary. Accepts
+    ["off" | "0" | "false" | "dry_run" | "dry-run" | "strict" | "1" |
+    "true"], case-insensitive and whitespace-trimmed. Any other input
+    returns [Dry_run] (fail-open for telemetry; fail-closed promotion
+    to typed reject happens in Phase B). *)
+
 val to_label : t -> string
 (** [to_label Off = "off"], [Dry_run = "dry_run"], [Strict = "strict"].
     Used as the Prometheus [mode] label so operators can break down


### PR DESCRIPTION
## 목적

PR #17946이 \`Auth_strict_mode.of_string\` 을 \"0 callers\" audit으로 제거했지만 *원본 mli docstring 자체가 \"Pure parser exposed for unit tests\" 라고 명시*했던 의도적 thin-surface helper. 4 test가 canonical / alias / unknown handling 경계 검증 중. 다섯번째 누적 audit-miss.

## 진단

원본 mli docstring (PR #17946이 삭제):
\`\`\`
val of_string : string -> t
(** Pure parser exposed for unit tests.  Accepts [\"off\" | \"0\" | \"false\" |
    \"dry_run\" | \"dry-run\" | \"strict\" | \"1\" | \"true\"], case-insensitive.
    Any other input returns [Dry_run] (fail-open for telemetry, fail-closed
    promotion happens in Phase B). *)
\`\`\`

테스트 파일 자체 헤더 docstring (load-bearing context):
\`\`\`
Phase B PR-2 will branch real behavior on this variant, so a silent
rename or unknown-handling change must fail at the test boundary
rather than in production telemetry.
\`\`\`

→ 의도적 boundary pin surface. **Prompt_defaults.init (iter 1) 와 동일 카테고리** — mli docstring이 thin-surface role을 *명시*.

## 결정

분류 매트릭스 업데이트:

| 케이스 | mli 역할 명시 | Prod caller | 결정 |
|---|---|---|---|
| Prompt_defaults.init (iter 1) | YES | 0 | 복원 |
| Lockfree_atomic.update_with_result (iter 3) | NO | 0 | caller migration |
| set_util.count_distinct (iter 4) | NO | 0 | delete + test 제거 |
| **Auth_strict_mode.of_string (iter 5)** | YES (\"exposed for unit tests\" 명시) | 0 | **복원** |

## 변경

- \`lib/auth_strict_mode.mli\`: \`val of_string : string -> t\` 복원. docstring을 원본 + Phase B PR-2 promotion plan 명시화 (\"future audit이 caller 수 대신 role을 볼 수 있도록\").

## 검증

\`\`\`
dune exec test/test_auth_strict_mode.exe → 6/6 pass
\`\`\`

## Audit-miss 누적 (다섯번째)

| PR | 제거 대상 | 누락 test caller |
|---|---|---|
| #17946 | Auth_strict_mode.of_string | 4 |
| #17947 | set_util.{of_list_with,count_distinct} | 4 |
| #17950 | Prompt_defaults.init | 7 |
| #17998 | Lockfree_atomic.update_with_result | 3 |
| #18009 | AT.stats / stats_to_json | 5 |

5건 연속 동일 누락 step (\`rg <name> test/\`). 다음 iter 후보: \`scripts/audit-dead-export.sh\` 같은 도구로 root-fix.