### PR TITLE
fix(docs): drain R6 SSOT bypass in RFC-0164 (home-anchored .masc paths)

### DIFF
--- a/docs/rfc/RFC-0164-voice-tool-abstraction-integrity.md
+++ b/docs/rfc/RFC-0164-voice-tool-abstraction-integrity.md
@@ -160,7 +160,7 @@ Plus `lib/keeper/keeper_tool_policy.ml:342-346` carries a hardcoded fallback lis
 
 ### 2.5 Config keys to delete
 
-`~/me/.masc/voice_config.json`:
+`<base-path>/.masc/voice_config.json`:
 
 | Key | Reason |
 |---|---|
@@ -228,7 +228,7 @@ Single PR. No PR-1/PR-2 split because the changes are coupled — removing a fie
 
 Reference path proven on 2026-05-23 via direct ElevenLabs probe (HTTP 200, 81KB mp3, afplay playback). After this RFC's deletion:
 
-1. Persona prompt in `~/me/.masc/config/keepers/sangsu.toml`: add one-line guidance — *"가끔 음성으로 한 마디 던져도 된다"* — into `instructions`.
+1. Persona prompt in `<base-path>/.masc/config/keepers/sangsu.toml`: add one-line guidance — *"가끔 음성으로 한 마디 던져도 된다"* — into `instructions`.
 2. Start a normal sangsu turn (no `voice_enabled` flag needed — there is no such flag).
 3. sangsu LLM emits `keeper_voice_speak({message: "..."})` per its persona discretion.
 4. `keeper_exec_voice.ml` intercepts, calls `Voice_bridge.agent_speak`, which calls ElevenLabs HTTP, returns mp3 bytes, `local_playback` plays via `afplay`.


### PR DESCRIPTION
PR #18084 introduced RFC-0164 with two illustrative paths written as `~/me/.masc/...` in §2.5 and §6.2.  `scripts/check-ssot.sh` rule R6-home-masc-root has baseline 0 — runtime state references must resolve from an explicit `<base-path>` rather than a home-anchored literal, since the latter silently bakes in the author's workstation layout and bypasses `MASC_BASE_PATH` / `--base-path` indirection.  Replace both with `<base-path>/.masc/...` per the lint's own remediation hint.  Documentation-only change; semantics preserved.  Local check-ssot.sh: `OK[R6-home-masc-root]: 0 occurrences (baseline 0)`.  This addresses the *other* Lint job failure on main HEAD (the Unix.sleepf D-10 violation is in PR #18129).  Per draft-auto-merge guard, stays Draft.