### PR TITLE
refactor(coord_utils_paths_backend): drop dead always-false `is_pg_backend` stub

### DIFF
--- a/lib/coord/coord_utils_paths_backend.ml
+++ b/lib/coord/coord_utils_paths_backend.ml
@@ -47,14 +47,6 @@ let state_path config = Filename.concat (masc_dir config) "state.json"
 let backlog_path config = Filename.concat (tasks_dir config) "backlog.json"
 let archive_path config = Filename.concat (masc_dir config) "tasks-archive.json"
 
-(* ============================================ *)
-(* Backend dispatch functions                   *)
-(* ============================================ *)
-
-let is_pg_backend config =
-  let _ = config in
-  false
-
 (** Shared in-memory pubsub for FileSystem and Memory backends.
     All supported backends now share the same in-memory pubsub. *)
 let shared_pubsub = Backend_types.Pubsub_mem.create ()

--- a/lib/coord/coord_utils_paths_backend.mli
+++ b/lib/coord/coord_utils_paths_backend.mli
@@ -48,9 +48,6 @@ val project_prefix : config -> string
 
 (** {1 Backend dispatch} *)
 
-(** Always [false] — postgres backend was removed. *)
-val is_pg_backend : config -> bool
-
 val backend_get :
   config -> key:string -> (string option, Backend_types.error) result
 


### PR DESCRIPTION
## 목표

`is_pg_backend config` 가 *trifecta* anti-pattern:
- body 가 인자 `config` 를 `let _ = config in` 으로 버림
- 항상 `false` 반환 (hardcoded literal)
- 0 caller (5-prong audit pass)

## 자가 증거

`lib/coord/coord_utils_paths_backend.mli` (pre-PR line 51):
```ocaml
(** Always [false] — postgres backend was removed. *)
val is_pg_backend : config -> bool
```

작가가 *알면서도* stub 잔재. 두 가지 anti-pattern 정면 위반:
- `software-development.md` "Don't design for hypothetical future requirements"
- AI 코드 생성 안티패턴 §2 (Unknown→Permissive Default 변형: dead-yet-callable shim)

## 5-prong dead-export audit

(`~/me/memory/feedback_dead_export_audit_must_trace_include_facade.md` 강제)

| Path | Result |
|------|--------|
| 1. Direct `Coord_utils_paths_backend.is_pg_backend` qualified | 0 hit |
| 2. Module alias (`module X = Coord_utils_paths_backend`) | 0 hit |
| 3. Re-export `let is_pg_backend = ...` | 0 hit (def 외) |
| 4. `include Coord_utils_paths_backend` (in coord_utils.ml/mli) | facade *존재* |
| 5. Facade 경유 `Coord_utils.is_pg_backend` | **0 hit** |
| 6. `open Coord_utils_paths_backend` (in coord_utils_ops.ml) | opener 존재 |
| 7. opener-내 bare `is_pg_backend` | **0 hit** |

Catch-all bare-name grep 결과: def + mli 외 0 hit.

Defensive witness check (`~/me/memory/feedback_defensive_witness_4th_veto_path.md`): docstring 이 *현재 행위* ("always false — postgres backend was removed") 만 진술, compile-time invariant maintenance 선언 없음.

## 변경

`lib/coord/coord_utils_paths_backend.ml`:
- `(* Backend dispatch functions *)` 헤더 + `let is_pg_backend config = ...` 제거

`lib/coord/coord_utils_paths_backend.mli`:
- `(** Always [false] — ... *) val is_pg_backend : config -> bool` 제거
- `(** {1 Backend dispatch} *)` 섹션 헤딩 유지 (이후 `backend_get`/`backend_set` 이 같은 섹션)

## 변경 파일 (2 파일, +0 / −11, **net −11 LoC**)

## 로컬 검증

```
$ dune build --root . lib/  # clean
$ dune exec --root . test/test_coord_bootstrap.exe
test_coord_bootstrap: all assertions passed
$ rg "is_pg_backend" lib/ test/
(empty — 완전 제거)
```

## 관련

- `~/me/memory/feedback_dead_export_audit_must_trace_include_facade.md`: facade `include Coord_utils_paths_backend` 경유 callers 까지 audit 했음 (5-prong + 추가 2 path)
- `software-development.md` "Don't design for hypothetical future requirements"
- 같은 spirit 의 이전 loop iter PR 들 (5 anti-pattern, 1 PR씩):
  - #18122 — 함수 이름 거짓 (function-name-lying)
  - #18125 — body 가 `()` no-op
  - #18130 — type 자체가 fake (placeholder chain)
  - #18135 — mli-exposed dead no-op (convention outlier)
  - 본 PR — always-false body + arg discard + dead-yet-exposed
- 작업 출처: `/loop 10m 가짜 구현이나 억지로 되게끔만 만든 구현 숙청, 및 레거시 개념 제거`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>