### PR TITLE
fix(test): complete PR #18006 sweep — add provider_label to keeper_exec_status fixture

### DIFF
--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -558,7 +558,7 @@ let test_runtime_surface_names_no_tool_provider_details () =
         required_tool_names = [ "keeper_bash"; "masc_worktree_create" ];
         provider_rejections =
           [
-            { OWN.reason = "codex_keeper_bound_actor_required" };
+            { OWN.provider_label = "codex"; OWN.reason = "codex_keeper_bound_actor_required" };
           ];
       }
   in


### PR DESCRIPTION
## Summary

PR #18006 (2026-05-23, "receipt compaction labels + OAS cascade guard") 가 \`lib/keeper/keeper_turn_driver.mli:21\` 의 \`provider_rejection\` record 에 \`provider_label : string\` 필드 추가하고 sweep 으로 두 test 사이트 migrate:

\`\`\`
test/test_oas_error_kind_counter.ml:157  -- provider_label = "codex"
test/test_oas_error_kind_counter.ml:158  -- provider_label = "kimi"
\`\`\`

\`test/test_keeper_exec_status.ml:561\` 은 sweep 에서 누락 → compile 차단.

\`feedback_codex_partial_sweep_fan_out_anti_pattern\` 정확한 사례 — multi-site 추가 시 일부 누락.

## Fix

| Site | Before | After |
|---|---|---|
| line 561 | \`{ OWN.reason = "codex_keeper_bound_actor_required" }\` | \`{ OWN.provider_label = "codex"; OWN.reason = "codex_keeper_bound_actor_required" }\` |

\`provider_label = "codex"\` 선택 근거:
- line 557 의 \`configured_labels = [ "codex"; "kimi" ]\`
- line 561 의 reason 이 "codex_keeper_..." 시작

Summary builder (\`lib/cascade/cascade_internal_error.ml:317-320\`) 가 \`provider_label\` 미참조 — 본 fix 가 type 만족 + 의미 변화 0.

## Verification

\`\`\`
dune build --root . test/test_keeper_exec_status.exe  →  EXIT=0
dune runtest                                           →  41/43 PASS
  surface_status:10 (touched test)                     →  PASS
\`\`\`

## Unmasked pre-existing failures (별개 영역)

본 PR 의 compile fix 가 **2 별개 pre-existing 회귀** 노출 (본 PR 이 도입한 것 아님):

| Test | Failure |
|---|---|
| surface_status:9 \`runtime surface derives cascade exhausted blocker\` (line 1248) | Expected \`"Cascade exhausted after provider failures; local runtime connection refused."\` / Received \`"Internal error: [masc_oas_error] {...}"\` — summary builder 다른 경로 회귀 |
| surface_status:17 \`runtime surface maps stale watchdog failure reason\` (line 1269) | stale-watchdog reason mapping 별개 회귀 |

이 두 회귀는 본 PR 의 line 561 fixture 와 무관한 코드 경로. 후속 PR 영역 — issue 로 추적 권장.

## Diff

+1 / -1 LoC. Net 0.

WORKAROUND-FREE.

RFC-WAIVED: PR #18006 sweep 직접 보강.

🤖 Generated with [Claude Code](https://claude.com/claude-code)