### PR TITLE
refactor(cascade_declarative_parser): drop ref-accumulator in parse_toml

### DIFF
--- a/lib/cascade_decl/cascade_declarative_parser.ml
+++ b/lib/cascade_decl/cascade_declarative_parser.ml
@@ -876,25 +876,21 @@ let extract_after_all_errors_guard ~label = function
 ;;
 
 let parse_toml (toml : Otoml.t) : (cascade_config, parse_error list) result =
-  let all_errors = ref [] in
-  let collect = function
-    | Ok _ -> ()
-    | Error errs -> all_errors := !all_errors @ errs
-  in
   let providers_result = parse_providers toml in
   let models_result = parse_models toml in
   let tiers_result = parse_tiers toml in
   let tier_groups_result = parse_tier_groups toml in
-  collect providers_result;
-  collect models_result;
-  collect tiers_result;
-  collect tier_groups_result;
+  let errs = function Ok _ -> [] | Error errs -> errs in
+  let all_errors =
+    errs providers_result @ errs models_result
+    @ errs tiers_result @ errs tier_groups_result
+  in
   let bindings, aliases = parse_bindings_and_aliases toml in
   let routes = parse_routes toml in
   let system_targets = parse_system_targets toml in
   let profiles = parse_profiles toml in
-  if !all_errors <> []
-  then Error !all_errors
+  if all_errors <> []
+  then Error all_errors
   else (
     let providers =
       extract_after_all_errors_guard ~label:"providers" providers_result


### PR DESCRIPTION
## 목표

`lib/cascade_decl/cascade_declarative_parser.ml`의 `parse_toml`에서 `let all_errors = ref []` + `collect` closure (4회 sequential `:= !x @ errs` append) 패턴을 제거. 단일 let-bound polymorphic helper `errs : ('a, parse_error list) result -> parse_error list` + 4번의 `@` chain으로 변환.

## 왜

- 5번째 same-pattern. 이전 4개 PR과 다르게 *append-style* (`:= !x @ errs`) 변형. prepend-style (`:= x :: !x` + List.rev)을 다룬 #18106/#18109/#18119/#18131 family를 보완.
- OCaml let-bound polymorphism이 syntactic function value (`function | Ok _ -> [] | Error errs -> errs`)를 generalize → 4개 `_result`가 *각기 다른 success payload type*을 가지더라도 동일한 helper로 처리 가능. 원본 `collect`가 동일하게 generic하게 작동.

## Behavior parity

| 측면 | 원본 | 새 코드 |
|---|---|---|
| Append 순서 | providers → models → tiers → tier_groups (4 sequential `collect`) | 동일 (`@` chain 순서) |
| Empty errors → Ok | `if !all_errors <> [] then Error else Ok` | `if all_errors <> [] then Error else Ok` (ref dereference 만 제거) |
| `extract_after_all_errors_guard` per-result | 4 calls in success branch | 동일 |
| Cascade_config 필드 9개 | 동일 | 동일 |

## 변경 파일

- `lib/cascade_decl/cascade_declarative_parser.ml` (+7 / −11, net −4)

## 로컬 검증

```
$ dune build --root . lib/                                  # PASS
$ for t in parser hotpath validator adapter; do
    dune exec --root . test/test_cascade_declarative_$t.exe
  done
... 138 tests run (63 + 25 + 29 + 21).  All PASS.
```

## 누적 (5 iter)

| Iter | PR | 함수 | 패턴 | 상태 |
|---|---|---|---|---|
| #1 | #18106 | server_state_product.check_invariants | prepend + List.rev | MERGED |
| #2 | #18109 | chronicle_validate.validate_epoch | prepend + List.rev | MERGED |
| #3 | #18119 | tool_control.keeper_pause_status_json | prepend × 3 + List.rev × 2 | Draft |
| #4 | #18131 | governance_anomaly.detect_deviations | prepend + List.rev | Draft |
| #5 | (this) | cascade_declarative_parser.parse_toml | **append `:= !x @ errs`** | Draft |

## 변환 거부 카테고리 (4종)

1. **Bounded sample with counter** (cdal_runtime_health)
2. **Streaming-fold docstring witness** (activity_graph_reducer)
3. **Module-level register state** (gh_exit_class.overrides)
4. **Eio.Mutex-protected fiber-shared** (relay.checkpoints)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>