### PR TITLE
scripts: add audit-dead-export.sh to catch 5-PR repeat audit-miss pattern

### DIFF
--- a/scripts/audit-dead-export.sh
+++ b/scripts/audit-dead-export.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# audit-dead-export.sh — Pre-removal audit for OCaml .mli exports.
+#
+# Background: five consecutive "0 callers" dead-export sweep PRs
+# (#17946 Auth_strict_mode.of_string, #17947 set_util.{of_list_with,
+# count_distinct}, #17950 Prompt_defaults.init, #17998
+# Lockfree_atomic.update_with_result, #18009
+# Exec_adaptive_timeout.{stats,stats_to_json}) all merged with a
+# correct "no production callers" reading but missed the test
+# callers — leaving compile breakage that took follow-up PRs to
+# restore or migrate. The shared missing step in every audit body
+# was `rg <name> test/`.
+#
+# This script makes the audit reproducible and categorizes call
+# sites so the sweeper sees facade exposures and test pins before
+# concluding "dead".
+#
+# Usage:
+#   bash scripts/audit-dead-export.sh <Module.name>
+#   bash scripts/audit-dead-export.sh <name>             # unqualified
+#
+# Examples:
+#   bash scripts/audit-dead-export.sh Auth_strict_mode.of_string
+#   bash scripts/audit-dead-export.sh count_distinct
+#
+# Output sections (each header includes a count):
+#   1. Qualified production callers      (lib/* outside the defining module)
+#   2. Test callers                       (test/*)
+#   3. Facade exposures                   (include / module M = Mod / let f = Mod.f)
+#   4. mli docstring mentions             (e.g. {!Mod.name} or [Mod.name])
+#   5. Bare-name callers                  (caller likely has `open Mod`)
+#
+# Exit status:
+#   0   no callers anywhere (genuinely dead — safe to remove)
+#   1   only test callers and/or facade exposures (audit-miss risk;
+#       restore-vs-migrate decision needed — see classification
+#       matrix in any of the iter-1..iter-5 PR bodies referenced
+#       above)
+#   2   production callers exist (do NOT remove)
+#
+# The exit codes intentionally distinguish the "0 production but
+# non-zero test" case so CI gates or pre-commit hooks can require
+# a justification PR body when that bucket is non-empty.
+#
+# See: instructions/software-development.md §"AI 코드 생성 안티패턴"
+# (#3 in the audit-driven removal cluster).
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <Module.name | bare_name>" >&2
+  exit 64
+fi
+
+input="$1"
+
+# Parse Module.name vs bare name.
+if [[ "$input" == *.* ]]; then
+  module="${input%%.*}"
+  name="${input##*.}"
+  qualified="$input"
+else
+  module=""
+  name="$input"
+  qualified=""
+fi
+
+# Word-boundary regex for the bare name.
+name_pattern="\b${name}\b"
+
+# Inferred defining file (best-effort; only used to exclude self-refs).
+defining_ml=""
+if [[ -n "$module" ]]; then
+  # OCaml module Mod_name comes from mod_name.ml.
+  mod_lower=$(echo "$module" | tr '[:upper:]' '[:lower:]')
+  defining_ml="lib/${mod_lower}.ml"
+fi
+
+# Build rg excludes. Always exclude _build and worktrees.
+rg_base=(rg --no-heading -n -g '!_build*' -g '!.worktrees/*')
+
+# ─── 1. Qualified production callers ──────────────────────────────
+echo "=== 1. Qualified production callers (lib/*) ==="
+if [[ -n "$qualified" ]]; then
+  qualified_lib=$("${rg_base[@]}" "${qualified//./\\.}" lib/ 2>/dev/null \
+    | grep -v "^${defining_ml}:" || true)
+else
+  qualified_lib=$("${rg_base[@]}" "\.${name}\b" lib/ 2>/dev/null || true)
+fi
+prod_count=$(printf '%s' "$qualified_lib" | grep -c '^.' || true)
+echo "$qualified_lib"
+echo "(count: $prod_count)"
+echo
+
+# ─── 2. Test callers (the historically missed bucket) ─────────────
+# Tests almost always alias the defining module (`module L = Foo`),
+# so a strictly-qualified search misses real callers. Use a
+# capital-prefix dot-access shape `<Mod>.<name>` so a generic bare
+# name like `init` or `of_string` doesn't drown the signal in
+# unrelated namespaces.
+echo "=== 2. Test callers (test/*) ==="
+test_pat="[A-Z][A-Za-z0-9_]*\.${name}\b"
+test_callers=$("${rg_base[@]}" "$test_pat" test/ 2>/dev/null || true)
+test_count=$(printf '%s' "$test_callers" | grep -c '^.' || true)
+echo "$test_callers"
+echo "(count: $test_count — matched 'X.${name}' shape, any module/alias prefix)"
+echo
+
+# ─── 3. Facade exposures ──────────────────────────────────────────
+# An `include Mod`, `module X = Mod`, or `let f = Mod.f` line means
+# bare-name references downstream may be reaching this export.
+echo "=== 3. Facade exposures (include / alias / re-export) ==="
+if [[ -n "$module" ]]; then
+  facade=$("${rg_base[@]}" -e "^include ${module}$" \
+                            -e "^include ${module} " \
+                            -e "^module [A-Z][A-Za-z_]* = ${module}$" \
+                            -e "^let ${name} = ${module}\.${name}$" \
+                            lib/ 2>/dev/null || true)
+else
+  facade=""
+fi
+facade_count=$(printf '%s' "$facade" | grep -c '^.' || true)
+echo "$facade"
+echo "(count: $facade_count)"
+echo
+
+# ─── 4. mli docstring mentions ────────────────────────────────────
+echo "=== 4. mli docstring mentions ==="
+if [[ -n "$qualified" ]]; then
+  doc_mentions=$("${rg_base[@]}" \
+    -e "\{!${qualified//./\\.}\}" \
+    -e "\[${qualified//./\\.}\]" \
+    "**/*.mli" 2>/dev/null || true)
+else
+  doc_mentions=$("${rg_base[@]}" \
+    -e "\{!${name}\}" \
+    -e "\[${name}\]" \
+    "**/*.mli" 2>/dev/null || true)
+fi
+doc_count=$(printf '%s' "$doc_mentions" | grep -c '^.' || true)
+echo "$doc_mentions"
+echo "(count: $doc_count)"
+echo
+
+# ─── 5. Bare-name callers ─────────────────────────────────────────
+# Only meaningful when a facade exposure exists OR caller opens the
+# defining module; this surfaces both cases.
+echo "=== 5. Bare-name callers (likely via open/include) ==="
+bare=$("${rg_base[@]}" "$name_pattern" --type ml 2>/dev/null \
+  | grep -v "^${defining_ml}:" || true)
+# Filter out the qualified hits we already showed.
+if [[ -n "$qualified" ]]; then
+  bare=$(printf '%s\n' "$bare" | grep -v "${qualified//./\\.}" || true)
+fi
+bare_count=$(printf '%s' "$bare" | grep -c '^.' || true)
+# Truncate output — bare name searches can be very noisy.
+if (( bare_count > 50 )); then
+  printf '%s\n' "$bare" | head -50
+  echo "  ... ($((bare_count - 50)) more lines suppressed; inspect manually)"
+else
+  echo "$bare"
+fi
+echo "(count: $bare_count)"
+echo
+
+# ─── Summary + exit ───────────────────────────────────────────────
+echo "─── Summary ─────────────────────────────────────────────────"
+printf '  production callers:  %d\n' "$prod_count"
+printf '  test callers:        %d  <- most-missed bucket\n' "$test_count"
+printf '  facade exposures:    %d\n' "$facade_count"
+printf '  mli doc mentions:    %d\n' "$doc_count"
+printf '  bare-name callers:   %d  (heuristic; review when facade>0)\n' "$bare_count"
+echo
+
+if (( prod_count > 0 )); then
+  echo "RESULT: production callers exist — do NOT remove. Migrate callers first."
+  exit 2
+fi
+
+if (( test_count > 0 )) || (( facade_count > 0 )); then
+  echo "RESULT: zero production callers, but test/facade exposures exist."
+  echo "  Restore-vs-migrate decision per the loop/surface-ssot classification matrix:"
+  echo "    - mli docstring explicitly justifies the surface (e.g. 'exposed for"
+  echo "      unit tests', 'thin fixture-level entry point') ............... RESTORE"
+  echo "    - generic mli header only; no role differentiation ............ DELETE + migrate tests"
+  echo "    - sibling form (record vs tuple, etc.) absorbs the surface .... MIGRATE callers"
+  exit 1
+fi
+
+echo "RESULT: zero callers anywhere — safe to remove from both .ml and .mli."
+exit 0


### PR DESCRIPTION
## 목적

지난 24시간 동안 다섯번 연속으로 \"0 callers\" audit이 test caller를 놓친 패턴 발견. 본 PR은 surface-ssot loop의 *iter-by-iter* 처리 대신 **root-fix**: pre-removal audit을 자동화하는 스크립트로 패턴을 차단합니다.

## 배경 — 5건 누적

| PR | 제거 대상 | Audit 누락 |
|---|---|---|
| #17946 | \`Auth_strict_mode.of_string\` | 4 test caller |
| #17947 | \`set_util.{of_list_with,count_distinct}\` | 4 test caller |
| #17950 | \`Prompt_defaults.init\` | 7 test caller |
| #17998 | \`Lockfree_atomic.update_with_result\` | 3 test caller |
| #18009 | \`Exec_adaptive_timeout.{stats,stats_to_json}\` | 5 test caller |

각 PR은 production caller 진단은 정확했지만 *\`rg <name> test/\` 한 줄을 건너뜀*. 이후 surface-ssot loop iter 1-5가 각각 follow-up PR (#18118, #18124, #18128, #18133, #18136)으로 복원 or migration. 5건 모두 동일 누락 step.

## 변경

\`scripts/audit-dead-export.sh\` 신설. 기존 \`scripts/audit-*.sh\` 패턴 따름.

### 출력 5 버킷

| 버킷 | 설명 |
|---|---|
| 1 | Qualified production callers (lib/*) — \"이미 잘 잡던\" 영역 |
| 2 | Test callers (test/*) — **누락 빈도 1위**. \`X.<name>\` capital-prefix shape로 alias 호출 (\`module L = Foo; L.bar\`) 포함 |
| 3 | Facade exposures (\`include\` / \`module X = Mod\` / \`let f = Mod.f\`) — invisible re-export 경로 |
| 4 | mli docstring mentions (\`{!Mod.name}\` 또는 \`[Mod.name]\`) — 문서 일관성 |
| 5 | Bare-name callers (heuristic, facade > 0 일 때만 의미) |

### Exit 코드

- \`0\` — 모든 버킷 0, 진짜 dead, 제거 안전
- \`1\` — production 0 이지만 test/facade 1+ — restore-vs-migrate 결정 필수 (CI gate 후보)
- \`2\` — production 1+ — 절대 제거 금지

Exit-1 버킷이 핵심: 미래 sweep PR body는 *0이거나 의도적 1+*를 *명시*하도록 강제할 수 있음.

### 일반 이름 (\`init\`, \`of_string\`) noise 처리

Bare \`\b<name>\b\` 검색은 generic name 에서 1000+ false positive 발생. Test bucket은 \`[A-Z][A-Za-z0-9_]*\.<name>\b\` 로 module/alias prefix가 있는 dot-access만 매칭 — false positive 대폭 감소.

## 검증 (4 historical case)

\`\`\`
$ bash scripts/audit-dead-export.sh Auth_strict_mode.of_string
  → exit 1, test callers = 5 (PR #17946의 miss 재현)

$ bash scripts/audit-dead-export.sh count_distinct
  → exit 1, test callers = 4 (PR #17947의 miss 재현)

$ bash scripts/audit-dead-export.sh Lockfree_atomic.update_with_result
  → exit 1, test callers = 4 (PR #17998의 miss 재현 — alias \`L.\` 호출도 캡처)

$ bash scripts/audit-dead-export.sh Some_module.imaginary_function
  → exit 0, all buckets 0 (negative control — clean removal target)
\`\`\`

## SSOT 효과

- **체계적 절차** 가 *문서가 아닌 실행 가능한 스크립트*로 surface — sweeper가 \`audit-dead-export.sh\` 출력을 PR body에 인용하는 패턴 정착 가능
- 5건의 \"실수 후 follow-up\" cycle을 \"실수 전 catch\" 로 이동
- 분류 매트릭스 (restore / migrate / delete)를 스크립트의 result 메시지로 임베드

## 후속 후보

- CI hook으로 mli 수정 PR에서 \`val\` deletion이 있으면 자동 실행하고 PR body 첨부
- \`software-development.md\` 의 \"AI 코드 생성 안티패턴\" 섹션에 이 스크립트 인용 추가
- 다른 언어 surface (TypeScript export, Python public function)에도 동일 패턴 확장