### PR TITLE
refactor(tool_keeper): inline `"runtime"` literal for `default_keeper_model_label`

### DIFF
--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -556,10 +556,6 @@ let resolve_keeper_meta ctx args =
   | Ok None -> Error (Printf.sprintf "keeper not found: %s" name)
   | Error err -> Error (Printf.sprintf "%s" err)
 
-let default_keeper_model_label (meta : keeper_meta) =
-  let _ = meta in
-  "runtime"
-
 let annotate_keeper_repair_json ?identity_reseed ~(keeper_name : string) body =
   let parsed =
     try Some (Yojson.Safe.from_string body) with Yojson.Json_error _ -> None
@@ -641,9 +637,7 @@ let handle_keeper_repair ctx args : tool_result =
                         ("working_dir", `String working_dir);
                         ("validator_profile", `String validator_profile);
                         ( "model_label",
-                          `String
-                            (get_string args "model_label"
-                               (default_keeper_model_label meta)) );
+                          `String (get_string args "model_label" "runtime") );
                         ("max_attempts", `Int max_attempts);
                         ( "artifact_session_id",
                           `String


### PR DESCRIPTION
## 목표

`default_keeper_model_label (meta : keeper_meta)` 가 function-name-lying:
- 이름이 *keeper-meta-dependent label* 시사
- body 가 `meta` 를 `let _ = meta in` 으로 명시적으로 버림
- 항상 literal `"runtime"` 반환

## 자가 증거

pre-PR (`lib/tool_keeper.ml:559-561`):
```ocaml
let default_keeper_model_label (meta : keeper_meta) =
  let _ = meta in
  "runtime"
```

`~/me/memory/audit-deep-dive-2026-05-22.html` 에서 `"runtime"` literal 잠금 패턴으로 이미 분류된 사이트.

## 변경

내부 함수 (mli 비노출) + 단일 caller (line 642) → 함수 삭제 + callsite 에 `"runtime"` literal 직접 사용:

```ocaml
(* Before *)
( "model_label",
  `String
    (get_string args "model_label"
       (default_keeper_model_label meta)) );

(* After *)
( "model_label",
  `String (get_string args "model_label" "runtime") );
```

## 변경 파일 (1 파일, +1 / −7, **net −6 LoC**)

## Audit

- `default_keeper_model_label` 은 `lib/tool_keeper.mli` 에 노출 안 됨 → 내부 only
- `module Tool_keeper = Tool_keeper` alias (`server_routes_http_common.ml/mli`) 는 alias 일 뿐 mli 를 우회하지 않음 → alias 경유로도 접근 0
- bare-name catch-all grep: def + 1 callsite 외 0 hit

## Behavior parity

- Type: `keeper_meta -> string` → callsite 자리에 `string` 직접
- Value: `"runtime"` ↔ `"runtime"` byte-identical
- `meta` 변수는 callsite 의 다른 곳 (line 651 `meta.runtime.trace_id`, line 644 `Keeper_id.Trace_id.to_string meta.runtime.trace_id` 등) 에서 여전히 사용 — binding 보존

## 로컬 검증

```
$ dune build --root . lib/  # clean
$ rg "default_keeper_model_label" lib/ test/
(empty — 완전 제거)
```

## 관련

- `~/me/memory/function-name-lying-fix-plan-2026-05-22.html` (사이트 분류)
- `~/me/memory/audit-deep-dive-2026-05-22.html` (`"runtime"` literal 잠금 패턴)
- 같은 spirit 의 이전 loop iter PR 들 (6 anti-pattern, 1 PR씩):
  - #18122 — 함수 이름이 인자에 거짓말 (function-name-lying)
  - #18125 — body 가 `()` no-op
  - #18130 — type 자체가 fake (placeholder chain)
  - #18135 — mli-exposed dead no-op (convention outlier)
  - #18139 — always-false hardcoded + ignored arg
  - 본 PR — always-`"runtime"` literal + ignored arg + internal-only
- 작업 출처: `/loop 10m 가짜 구현이나 억지로 되게끔만 만든 구현 숙청, 및 레거시 개념 제거`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>