### PR TITLE
fix(test): complete RFC-0164 sweep — drop policy_voice_enabled from keeper_toml tests

### DIFF
--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -453,7 +453,6 @@ proactive_enabled = true
 proactive_idle_sec = 300
 proactive_cooldown_sec = 60
 room_signal_prompt_enabled = true
-policy_voice_enabled = false
 autoboot_enabled = false
 github_identity = "anyang-keepers"
 git_identity_mode = "keeper_alias"
@@ -474,7 +473,6 @@ active_goal_ids = ["goal-runtime", "goal-masc-mcp"]
       check (option bool) "proactive" (Some true) d.proactive_enabled;
       check (option bool) "room signal prompt" (Some true)
         d.room_signal_prompt_enabled;
-      check (option bool) "policy_voice" (Some false) d.policy_voice_enabled;
       check (option bool) "autoboot_enabled" (Some false) d.autoboot_enabled;
       check (option string) "github_identity" (Some "anyang-keepers")
         d.github_identity;
@@ -1207,7 +1205,6 @@ let test_persona_resolver_renders_durable_keeper_toml () =
         ("mid_goal", `String "mid");
         ("long_goal", `String "long");
         ("instructions", `String "quote: \"ok\"");
-        ("policy_voice_enabled", `Bool false);
         ("autoboot_enabled", `Bool false);
         ("mention_targets", `List [ `String "probe"; `String "@probe" ]);
         ("proactive_enabled", `Bool true);


### PR DESCRIPTION
## Summary

PR #18088 (RFC-0164 voice tool abstraction integrity, -241 LoC) 가 \`policy_voice_enabled\` + sibling \`voice_*\` 필드를 \`keeper_profile_defaults\` 등 모든 record 에서 삭제. lib/ + bin/ sweep 완료했지만 \`test/test_keeper_toml.ml\` 3 references 누락:

| Line | Reference type |
|---|---|
| 456 | TOML input string \`policy_voice_enabled = false\` |
| 477 | Assertion: \`d.policy_voice_enabled = Some false\` ← compile error site |
| 1210 | JSON resolved fixture \`("policy_voice_enabled", Bool false)\` |

## Self-attribution

본 sweep miss 는 **이 세션 author 의 RFC-0164 작업** (PR #18088) — RFC body, .ml/.mli, voice_config.json 등 12 fields × 8 modules sweep 중 1 test site 누락. \`feedback_dead_export_audit_must_trace_include_facade\` patterns 5-prong audit 에 *.test.ml* 분류 명시 필요.

## Fix

3 references 모두 *삭제* (re-add 아님 — RFC-0164 의도는 deletion).

\`\`\`diff
- room_signal_prompt_enabled = true
- policy_voice_enabled = false
- autoboot_enabled = false
+ room_signal_prompt_enabled = true
+ autoboot_enabled = false

- check (option bool) "policy_voice" (Some false) d.policy_voice_enabled;
- check (option bool) "autoboot_enabled" (Some false) d.autoboot_enabled;
+ check (option bool) "autoboot_enabled" (Some false) d.autoboot_enabled;

- ("instructions", \`String "quote: \\\"ok\\\"");
- ("policy_voice_enabled", \`Bool false);
- ("autoboot_enabled", \`Bool false);
+ ("instructions", \`String "quote: \\\"ok\\\"");
+ ("autoboot_enabled", \`Bool false);
\`\`\`

## Verification

\`\`\`
dune build --root . test/test_keeper_toml.exe  →  EXIT=0
dune runtest                                    →  96/98 PASS
  test_profile_full (line 438, owns line 477)   →  PASS
\`\`\`

## Unmasked pre-existing failures (별개 영역)

본 PR fix 가 노출한 2 *별개* failures (본 PR 도입 아님):

| Test | Failure | Domain |
|---|---|---|
| profile_defaults:9 (line 1979) | \`FAIL invalid cascade_name 'oas-coding_first' (reserved: local_only, local_recovery, tool_use_strict; cascade catalog path is not resolved)\` | Cascade catalog config 해결 |
| file_loading:3 (line 2041) | inherits base defaults | file_loading 영역 |

둘 다 voice 와 무관한 코드 경로. 후속 PR 영역.

## Diff

-3 LoC. Net deletion.

WORKAROUND-FREE: deletion-only. compat shim / alias 없음.

RFC-WAIVED: RFC-0164 sweep 직접 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)