### PR TITLE
test(exec_shell_command_gate): wire local helper to live Gate.gate_typed

### DIFF
--- a/test/test_exec_shell_command_gate.ml
+++ b/test/test_exec_shell_command_gate.ml
@@ -26,7 +26,7 @@ let allowed = [ "rg"; "sort"; "head"; "wc"; "cat"; "git"; "ls"; "grep" ]
 let gate_from_raw ?caller ~raw ~allowlist ~path_policy ~sandbox () =
   match Masc_exec_bash_parser.Bash.parse_string raw with
   | PD.Parsed ir ->
-    gate_from_raw_typed ?caller ~ir ~allowlist ~path_policy ~sandbox ()
+    Gate.gate_typed ?caller ~ir ~allowlist ~path_policy ~sandbox ()
   | PD.Parse_error _ ->
     Gate.Cannot_parse { reason = Gate.Parse_error }
   | PD.Parse_aborted reason ->


### PR DESCRIPTION
## 목적

\`test/test_exec_shell_command_gate.ml\` 의 local helper \`gate_from_raw\` 가 사라진 \`gate_from_raw_typed\` 호출 — \`Shell_command_gate.gate_typed\` (live SSOT) 로 단일 라인 마이그레이션.

## 진단 (iter 6 도구 사용)

\`\`\`
$ bash scripts/audit-dead-export.sh gate_from_raw_typed
  production callers:  0
  test callers:        0
  facade exposures:    0
  RESULT: zero callers anywhere — safe to remove.
\`\`\`

도구는 \"0 callers — safe to remove\" 라고 답했지만 *현실은 다름*: 함수 자체가 *어디에도 정의되어 있지 않음*. Test의 local helper가 *exist하지 않는 이름*을 호출 중. 도구의 답은 기술적으로 맞지만 (제거할 게 없음), 실제 fix는 *caller 쪽*에서 발생.

## 시그니처 일치

두 함수는 정확히 동일 시그니처:

\`\`\`ocaml
gate_from_raw_typed  (* 어디에도 정의 없음 *)
  : ?caller:caller -> ir:Shell_ir.t -> allowlist:_ -> path_policy:_
    -> sandbox:_ -> unit -> verdict

Gate.gate_typed       (* lib/exec/command_gate/shell_command_gate.mli *)
  : ?caller:caller -> ir:Shell_ir.t -> allowlist:allowlist_policy
    -> path_policy:path_policy -> sandbox:sandbox_context -> unit -> verdict
\`\`\`

테스트 파일 헤더 docstring 자체가 SSOT를 명시: \"[Masc_exec_command_gate.Shell_command_gate.gate_typed] verdict shape matches what {!test/fixtures/shell_gate/baseline.jsonl} records\".

## 변경

\`test/test_exec_shell_command_gate.ml:29\` 한 줄:
\`\`\`
- gate_from_raw_typed ?caller ~ir ~allowlist ~path_policy ~sandbox ()
+ Gate.gate_typed ?caller ~ir ~allowlist ~path_policy ~sandbox ()
\`\`\`

9개 downstream \`gate_from_raw\` call site 미변경.

## 검증

\`\`\`
dune exec test/test_exec_shell_command_gate.exe → 16/16 pass
\`\`\`

## 메타 — iter 6 도구의 한 가지 가장자리

\`audit-dead-export.sh\` 의 \"exit 0 = safe to remove\" verdict은 *제거 측면*에서만 정확. \"test가 사라진 이름을 호출\" 같은 inverse case는 caller migration 필요. 이 경우의 분류는 도구 출력만으론 안 보이고 *grep/find로 정의 부재 확인* 단계가 추가 필요. 미래 도구 enhancement 후보.