### PR TITLE
fix(test): drop dead policy_voice_enabled refs blocking main build (RFC-0164 follow-up)

### DIFF
--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -171,43 +171,13 @@ instructions = "TOML instructions"
       check string "desires" "TOML desires" updated.desires;
       check string "instructions" "TOML instructions" updated.instructions
 
-(** Test: TOML policy fields overwrite stale runtime JSON values. *)
-let test_policy_resync () =
-  with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
-  with_config_dir @@ fun config_dir ->
-  Fs_compat.clear_fs ();
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  let keeper_name = "policy-resync-test" in
-  let keepers_toml_dir = Filename.concat config_dir "keepers" in
-  Unix.mkdir keepers_toml_dir 0o755;
-  write_file
-    (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
-{|[keeper]
-sandbox_profile = "docker"
-goal = "test"
-policy_voice_enabled = false
-|};
-  let config = Coord.default_config room_dir in
-  let initial_meta =
-    match
-      Masc_test_deps.meta_of_json_fixture
-        (`Assoc
-          [
-            ("name", `String keeper_name);
-            ("agent_name", `String keeper_name);
-            ("trace_id", `String "trace-policy-resync");
-            ("policy_voice_enabled", `Bool true);
-          ])
-    with
-    | Ok meta -> meta
-    | Error e -> fail ("meta_of_json failed: " ^ e)
-  in
-  seed_persisted_meta config initial_meta;
-  match Keeper_runtime.ensure_keeper_meta config keeper_name with
-  | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
-  | Ok updated ->
-      check bool "policy_voice_enabled" false updated.policy_voice_enabled
+(* test_policy_resync removed: RFC-0164 deletion roadmap dropped
+   [policy_voice_enabled] from Keeper_types.keeper_meta. The test
+   keyed its TOML-overwrites-stale-JSON assertion on that field
+   exclusively, so once the field went away the test no longer had
+   a policy field to drive the assertion. test_sandbox_policy_resync
+   below preserves the same TOML-resync coverage on the sandbox
+   policy fields, which remain part of keeper_meta. *)
 
 let test_sandbox_policy_resync () =
   with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
@@ -1270,10 +1240,6 @@ let () =
         ] );
       ( "policy",
         [
-          test_case
-            "TOML policy fields overwrite stale runtime JSON"
-            `Quick
-            test_policy_resync;
           test_case
             "TOML sandbox policy fields overwrite stale runtime JSON"
             `Quick

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -453,7 +453,6 @@ proactive_enabled = true
 proactive_idle_sec = 300
 proactive_cooldown_sec = 60
 room_signal_prompt_enabled = true
-policy_voice_enabled = false
 autoboot_enabled = false
 github_identity = "anyang-keepers"
 git_identity_mode = "keeper_alias"
@@ -474,7 +473,6 @@ active_goal_ids = ["goal-runtime", "goal-masc-mcp"]
       check (option bool) "proactive" (Some true) d.proactive_enabled;
       check (option bool) "room signal prompt" (Some true)
         d.room_signal_prompt_enabled;
-      check (option bool) "policy_voice" (Some false) d.policy_voice_enabled;
       check (option bool) "autoboot_enabled" (Some false) d.autoboot_enabled;
       check (option string) "github_identity" (Some "anyang-keepers")
         d.github_identity;


### PR DESCRIPTION
PR #18084 (RFC-0164 deletion roadmap) removed policy_voice_enabled from Keeper_types.keeper_meta and KTP.keeper_profile_defaults but the test cleanup was incomplete.  Two record-field reads survived and now break the main test build (Health / Build and Test jobs fail with Error: There is no field policy_voice_enabled within type ...): test/test_keeper_toml.ml:477 and test/test_keeper_runtime_config_ssot.ml:210.  This is the actual OCaml compile error blocking main.  Surgical removal of the two broken sites only — test_policy_resync (driven exclusively by the deleted field; sibling test_sandbox_policy_resync preserves TOML-resync coverage on sandbox-policy fields) plus two lines in test_keeper_toml.ml (TOML fixture line + matching check).  Incidental policy_voice_enabled references in other test files (helper params / JSON string keys) do not block the build and are queued as a follow-up cleanup PR.  Per draft-auto-merge guard, stays Draft.