### PR TITLE
fix(test): must_ok_argv→must_ok_cmd typing + Sandbox_target.equal absence (PR #18071 follow-up)

### DIFF
--- a/test/test_keeper_gh_parser_contract.ml
+++ b/test/test_keeper_gh_parser_contract.ml
@@ -55,6 +55,14 @@ let must_ok_argv label = function
   | Error e ->
     Alcotest.failf "%s: expected Ok, got Error %a" label parse_error_pp e
 
+(* RFC-0160 S2/S3 contract tests need the typed [gh_simple_command]
+   value (for risk_class + to_shell_ir).  [must_ok_argv] drops the
+   typed wrapper down to [string list]; this sibling keeps it. *)
+let must_ok_cmd label = function
+  | Ok cmd -> cmd
+  | Error e ->
+    Alcotest.failf "%s: expected Ok, got Error %a" label parse_error_pp e
+
 (* ---- parse_simple_gh_command ------------------------------------ *)
 
 let test_parse_empty () =
@@ -274,20 +282,20 @@ let test_render_round_trip_simple () =
 let risk_t = Alcotest.testable Masc_exec.Shell_ir_risk.pp_risk_class ( = )
 
 let test_risk_class_read_only () =
-  let cmd = must_ok_argv "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
+  let cmd = must_ok_cmd "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
   Alcotest.check risk_t "pr list is R0_Read"
     Masc_exec.Shell_ir_risk.R0_Read
     (Gh.gh_simple_command_risk_class cmd)
 
 let test_risk_class_api_get () =
-  let cmd = must_ok_argv "api repos" (Gh.gh_simple_command_of_argv [ "api"; "repos" ]) in
+  let cmd = must_ok_cmd "api repos" (Gh.gh_simple_command_of_argv [ "api"; "repos" ]) in
   Alcotest.check risk_t "api without method is GET -> R0_Read"
     Masc_exec.Shell_ir_risk.R0_Read
     (Gh.gh_simple_command_risk_class cmd)
 
 let test_risk_class_reversible_mutation () =
   let cmd =
-    must_ok_argv "pr create" (Gh.gh_simple_command_of_argv [ "pr"; "create" ])
+    must_ok_cmd "pr create" (Gh.gh_simple_command_of_argv [ "pr"; "create" ])
   in
   Alcotest.check risk_t "pr create is R1_Reversible_mutation"
     Masc_exec.Shell_ir_risk.R1_Reversible_mutation
@@ -295,7 +303,7 @@ let test_risk_class_reversible_mutation () =
 
 let test_risk_class_api_post () =
   let cmd =
-    must_ok_argv "api POST"
+    must_ok_cmd "api POST"
       (Gh.gh_simple_command_of_argv [ "api"; "--method=POST"; "repos" ])
   in
   Alcotest.check risk_t "api POST is R1_Reversible_mutation"
@@ -304,7 +312,7 @@ let test_risk_class_api_post () =
 
 let test_risk_class_api_graphql () =
   let cmd =
-    must_ok_argv "api graphql"
+    must_ok_cmd "api graphql"
       (Gh.gh_simple_command_of_argv [ "api"; "graphql" ])
   in
   Alcotest.check risk_t "api graphql is R1_Reversible_mutation"
@@ -313,7 +321,7 @@ let test_risk_class_api_graphql () =
 
 let test_risk_class_irreversible () =
   let cmd =
-    must_ok_argv "repo delete" (Gh.gh_simple_command_of_argv [ "repo"; "delete" ])
+    must_ok_cmd "repo delete" (Gh.gh_simple_command_of_argv [ "repo"; "delete" ])
   in
   Alcotest.check risk_t "repo delete is R2_Irreversible"
     Masc_exec.Shell_ir_risk.R2_Irreversible
@@ -321,7 +329,7 @@ let test_risk_class_irreversible () =
 
 let test_risk_class_api_delete () =
   let cmd =
-    must_ok_argv "api DELETE"
+    must_ok_cmd "api DELETE"
       (Gh.gh_simple_command_of_argv [ "api"; "--method=DELETE"; "repos" ])
   in
   Alcotest.check risk_t "api DELETE is R2_Irreversible"
@@ -331,7 +339,7 @@ let test_risk_class_api_delete () =
 (* ---- gh_simple_command_to_shell_ir (RFC-0160 S2) ---------------- *)
 
 let test_to_shell_ir_bin_is_gh () =
-  let cmd = must_ok_argv "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
+  let cmd = must_ok_cmd "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
   match Gh.gh_simple_command_to_shell_ir cmd with
   | Masc_exec.Shell_ir.Simple s ->
     Alcotest.(check bool) "bin is Gh" true
@@ -340,7 +348,7 @@ let test_to_shell_ir_bin_is_gh () =
     Alcotest.fail "expected Simple, got Pipeline"
 
 let test_to_shell_ir_args_are_lit () =
-  let cmd = must_ok_argv "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
+  let cmd = must_ok_cmd "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
   match Gh.gh_simple_command_to_shell_ir cmd with
   | Masc_exec.Shell_ir.Simple s ->
     let texts =
@@ -355,17 +363,23 @@ let test_to_shell_ir_args_are_lit () =
     Alcotest.fail "expected Simple, got Pipeline"
 
 let test_to_shell_ir_sandbox_passthrough () =
-  let cmd = must_ok_argv "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
-  let docker = Masc_exec.Sandbox_target.host () in
-  match Gh.gh_simple_command_to_shell_ir ~sandbox:docker cmd with
+  let cmd = must_ok_cmd "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
+  let host_sandbox = Masc_exec.Sandbox_target.host () in
+  match Gh.gh_simple_command_to_shell_ir ~sandbox:host_sandbox cmd with
   | Masc_exec.Shell_ir.Simple s ->
+    (* [Sandbox_target.t] has a Docker variant with [runner]/[pipeline_runner]
+       function fields, so structural / derived equality is not safe.
+       This test passes Host explicitly, so a constructor-shape check is
+       sufficient and avoids adding an ad-hoc equal helper to lib. *)
     Alcotest.(check bool) "sandbox passed through" true
-      (Masc_exec.Sandbox_target.equal s.sandbox docker)
+      (match s.sandbox with
+       | Masc_exec.Sandbox_target.Host -> true
+       | Masc_exec.Sandbox_target.Docker _ -> false)
   | Masc_exec.Shell_ir.Pipeline _ ->
     Alcotest.fail "expected Simple, got Pipeline"
 
 let test_to_shell_ir_cwd_passthrough () =
-  let cmd = must_ok_argv "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
+  let cmd = must_ok_cmd "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
   match Gh.gh_simple_command_to_shell_ir ~cwd:"/tmp" cmd with
   | Masc_exec.Shell_ir.Simple s ->
     (match s.cwd with
@@ -375,7 +389,7 @@ let test_to_shell_ir_cwd_passthrough () =
     Alcotest.fail "expected Simple, got Pipeline"
 
 let test_to_shell_ir_env_empty () =
-  let cmd = must_ok_argv "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
+  let cmd = must_ok_cmd "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
   match Gh.gh_simple_command_to_shell_ir cmd with
   | Masc_exec.Shell_ir.Simple s ->
     Alcotest.(check int) "env is empty" 0 (List.length s.env)


### PR DESCRIPTION
## Summary

PR #18071 (2026-05-23 22:32, "test(keeper-gh): RFC-0160 S2/S3 contract tests for typed gh contract (P9a)") 가 두 typed-contract test 그룹 추가했지만 컴파일 차단된 상태로 머지:

### 1. \`must_ok_argv\` vs \`must_ok_cmd\` 혼동

\`must_ok_argv\` 는 \`Gh.gh_simple_command_argv cmd\` 로 typed 값을 \`string list\` 로 strip.

S3 risk_class + S2 to_shell_ir test 그룹이 \`let cmd = must_ok_argv ...\` 으로 결과를 받아 \`Gh.gh_simple_command_risk_class cmd\` / \`Gh.gh_simple_command_to_shell_ir cmd\` 에 전달 — typed 입력 필요, 컴파일 에러:

\`\`\`
File "test/test_keeper_gh_parser_contract.ml", line 280, characters 37-40:
Error: The value cmd has type string list
       but an expression was expected of type Gh.gh_simple_command
\`\`\`

### 2. \`Sandbox_target.equal\` never existed

\`test_to_shell_ir_sandbox_passthrough\` 가 \`Masc_exec.Sandbox_target.equal s.sandbox docker\` 호출. \`Sandbox_target.t\` 는 \`Docker of { runner; pipeline_runner }\` 함수 필드 보유 — equal 정의 불가, 어디에도 노출 안 됨.

## CI gap 컨텍스트

본 컴파일 에러들이 main 머지 통과한 이유 — \`Build and Test\` CI job 이 \`Detect Changed Surfaces\` gate 뒤 SKIPPED. (memory \`reference_masc_mcp_ci_build_test_skips\`).

## Fix

### (1) Helper 분리

\`\`\`ocaml
let must_ok_argv label = function
  | Ok cmd -> Gh.gh_simple_command_argv cmd   (* argv 추출 - 기존 동작 *)
  | Error e -> Alcotest.failf ...

(* RFC-0160 S2/S3 contract tests need the typed [gh_simple_command] value *)
let must_ok_cmd label = function
  | Ok cmd -> cmd                              (* typed 유지 *)
  | Error e -> Alcotest.failf ...
\`\`\`

기존 must_ok_argv 는 argv-비교 test 10 사이트 유지 (lines 80, 85, 91, 99, 144, 154, 161, 169, 275).
must_ok_cmd 는 typed-cmd binding test 13 사이트 (lines 285-386).

### (2) Sandbox_target.equal → 패턴 매치

\`docker = Sandbox_target.host ()\` (이름은 docker지만 실제 Host). passthrough test 는 *constructor shape* 만 확인하면 충분:

\`\`\`ocaml
- (Masc_exec.Sandbox_target.equal s.sandbox docker)
+ (match s.sandbox with
+  | Masc_exec.Sandbox_target.Host -> true
+  | Masc_exec.Sandbox_target.Docker _ -> false)
\`\`\`

lib에 단일 test site 위한 \`equal\` API 추가 회피. 변수명도 \`docker\` → \`host_sandbox\` 정정 (misleading 제거).

## Verification

\`\`\`
dune build --root . test/test_keeper_gh_parser_contract.exe  →  EXIT=0
dune runtest                                                  →  34/34 PASS
\`\`\`

## Diff

+29 / -15 LoC.

WORKAROUND-FREE: type 정합 fix + 의도 명료화. compat shim / lib API 추가 없음.

RFC-WAIVED: PR #18071 직접 typo + dead-API fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)