### PR TITLE
scripts(audit-dead-export): add zombie-caller detection (v2)

### DIFF
--- a/scripts/audit-dead-export.sh
+++ b/scripts/audit-dead-export.sh
@@ -24,6 +24,7 @@
 #   bash scripts/audit-dead-export.sh count_distinct
 #
 # Output sections (each header includes a count):
+#   0. Defining sites                     (.ml / .mli — let/and/val/type/module/exception)
 #   1. Qualified production callers      (lib/* outside the defining module)
 #   2. Test callers                       (test/*)
 #   3. Facade exposures                   (include / module M = Mod / let f = Mod.f)
@@ -31,16 +32,22 @@
 #   5. Bare-name callers                  (caller likely has `open Mod`)
 #
 # Exit status:
-#   0   no callers anywhere (genuinely dead — safe to remove)
+#   0   no callers anywhere AND no defining sites either — clean
+#       (or symbol misspelled). Or callers exist but defining sites
+#       confirm the symbol is reachable — see the prod/test breakdown.
 #   1   only test callers and/or facade exposures (audit-miss risk;
-#       restore-vs-migrate decision needed — see classification
-#       matrix in any of the iter-1..iter-5 PR bodies referenced
-#       above)
+#       restore-vs-migrate decision needed)
 #   2   production callers exist (do NOT remove)
+#   3   zombie callers — callers reference a symbol that has zero
+#       defining sites anywhere. The fix is on the caller side
+#       (migrate to a live name), not the defining side (which has
+#       nothing to remove). v2 of this script catches the inverse
+#       case where iter 7's `gate_from_raw_typed` lived: an existing
+#       test references a removed/renamed helper.
 #
-# The exit codes intentionally distinguish the "0 production but
-# non-zero test" case so CI gates or pre-commit hooks can require
-# a justification PR body when that bucket is non-empty.
+# The exit codes intentionally distinguish each bucket so CI gates
+# or pre-commit hooks can require a justification PR body when the
+# audit returns anything other than 0.
 #
 # See: instructions/software-development.md §"AI 코드 생성 안티패턴"
 # (#3 in the audit-driven removal cluster).
@@ -78,6 +85,31 @@ fi
 
 # Build rg excludes. Always exclude _build and worktrees.
 rg_base=(rg --no-heading -n -g '!_build*' -g '!.worktrees/*')
+
+# ─── 0. Defining sites ────────────────────────────────────────────
+# If zero defining sites exist, the symbol is genuinely gone from
+# the codebase — any remaining callers are *zombies*. This case
+# inverts the audit: the fix is on the caller side (migrate to a
+# live name), not the defining side (which has nothing to remove).
+#
+# Match shapes:
+#   let <name>     — top-level definition
+#   and <name>     — let-rec sibling
+#   val <name>     — mli declaration
+#   type <name>    — type / module alias
+#   module <name>  — module definition
+#   exception <name> — exception declaration
+echo "=== 0. Defining sites (.ml + .mli) ==="
+define_pat="^(let|and|val|type|module|exception)[[:space:]]+(rec[[:space:]]+)?${name}\b"
+defining=$("${rg_base[@]}" "$define_pat" --type ml --type ocaml 2>/dev/null || true)
+# Some workspaces don't tag .mli under --type ocaml, so add an
+# explicit *.mli glob fallback.
+defining_mli=$("${rg_base[@]}" "$define_pat" -g '*.mli' 2>/dev/null || true)
+defining_all=$(printf '%s\n%s\n' "$defining" "$defining_mli" | sort -u | grep -v '^$' || true)
+defining_count=$(printf '%s' "$defining_all" | grep -c '^.' || true)
+echo "$defining_all"
+echo "(count: $defining_count)"
+echo
 
 # ─── 1. Qualified production callers ──────────────────────────────
 echo "=== 1. Qualified production callers (lib/*) ==="
@@ -164,13 +196,46 @@ echo "(count: $bare_count)"
 echo
 
 # ─── Summary + exit ───────────────────────────────────────────────
+# For the zombie check below, include bare-name callers — when no
+# defining site exists, even a bare-name hit is a real reference to
+# a missing symbol (e.g. iter 7's `gate_from_raw_typed` was called
+# unqualified in test code; capital-prefix bucket 2 missed it).
+# The bare-name noise concern only applies when defining_count > 0.
+any_callers=$(( prod_count + test_count + facade_count + bare_count ))
+total_callers=$(( prod_count + test_count + facade_count ))
+
 echo "─── Summary ─────────────────────────────────────────────────"
+printf '  defining sites:      %d\n' "$defining_count"
 printf '  production callers:  %d\n' "$prod_count"
 printf '  test callers:        %d  <- most-missed bucket\n' "$test_count"
 printf '  facade exposures:    %d\n' "$facade_count"
 printf '  mli doc mentions:    %d\n' "$doc_count"
 printf '  bare-name callers:   %d  (heuristic; review when facade>0)\n' "$bare_count"
 echo
+
+# Inverse case: zero defining sites + callers exist = zombie callers.
+# The fix lives on the caller side, not the defining side — there is
+# nothing to remove. Surface this before the standard "0 prod / N test"
+# message so the sweeper isn't misled into editing a non-existent
+# defining file.
+if (( defining_count == 0 )) && (( any_callers > 0 )); then
+  echo "RESULT: zombie callers detected — '$name' has no defining site."
+  echo "  Callers reference a symbol that does not exist anywhere in the"
+  echo "  codebase. The fix is on the caller side: migrate to a live name."
+  echo "  Typical causes:"
+  echo "    - API renamed without sweeping callers"
+  echo "    - Helper removed but downstream local wrappers still call it"
+  echo "    - Test references a planned API that was never implemented"
+  exit 3
+fi
+
+# Genuinely dead: zero everywhere, including the defining side.
+# Distinguished from zombie by defining_count == 0 + total_callers == 0.
+if (( defining_count == 0 )) && (( any_callers == 0 )); then
+  echo "RESULT: symbol not present anywhere — nothing to audit."
+  echo "  Either the name is misspelled or it was already fully cleaned up."
+  exit 0
+fi
 
 if (( prod_count > 0 )); then
   echo "RESULT: production callers exist — do NOT remove. Migrate callers first."


### PR DESCRIPTION
## 목적

Iter 7 (\`gate_from_raw_typed\` 케이스)에서 발견한 v1 한계 보완. 정의가 *어디에도 없는* 심볼을 caller가 부르는 *inverse case* (좀비 caller) 를 별도 exit code 3 으로 분류.

기반: PR #18142 (iter 6 v1) 위에 stack.

## v1 의 한계

v1 출력:
\`\`\`
$ bash scripts/audit-dead-export.sh gate_from_raw_typed
  production callers:  0
  test callers:        0
  RESULT: zero callers anywhere — safe to remove from both .ml and .mli.
  → exit 0
\`\`\`

**현실**: 함수 자체가 codebase에 없음. Test가 *존재하지 않는 이름*을 부르는 좀비 패턴. v1은 "safe to remove" 라고 답하지만 *제거할 게 없음* — fix는 caller 쪽.

## v2 변경

### 새 bucket 0 — 정의 사이트

\`\`\`bash
rg '^(let|and|val|type|module|exception)\s+(rec\s+)?<name>\b'
\`\`\`

OCaml이 이름을 도입하는 모든 shape (\`.ml\` + \`.mli\`) 스캔.

### 새 exit code 3 — 좀비

\`defining_count == 0\` 이고 *어떤 caller라도* 존재하면 좀비. 결정 로직:

| defining | callers | exit | meaning |
|---|---|---|---|
| 0 | 0 | 0 | 정말 없음 (clean / misspelled) |
| 0 | > 0 | **3** | **zombie — fix on caller side** |
| > 0 | prod > 0 | 2 | 제거 금지 |
| > 0 | only test/facade | 1 | restore-vs-migrate 결정 |
| > 0 | 0 | 0 | 제거 안전 (audit clean) |

좀비 감지에서는 bare-name bucket도 포함 — 정의가 없는데 bare-name 호출이 있으면 *false positive 아닌 진짜 좀비*. \`gate_from_raw_typed\` 케이스가 정확히 이 shape (test가 unqualified로 부름, capital-prefix bucket 2 미감지).

\`defining > 0\` 일 때는 bare-name은 여전히 heuristic (generic name noise).

## 검증 (3 regression test)

\`\`\`
gate_from_raw_typed   (iter 7 zombie)
  → exit 3, defining=0, bare-name=1, \"zombie detected\"

count_distinct       (iter 4 audit-miss)
  → exit 1, defining=1, test callers=4, restore-vs-migrate 결정 권고

totally_nonexistent_function (misspelling negative control)
  → exit 0, defining=0, all buckets=0, \"not present\"
\`\`\`

## SSOT 효과

분류 매트릭스 6번째 행 추가:

| 케이스 | mli 역할 | 정의 존재 | Prod | Test | 결정 |
|---|---|---|---|---|---|
| ... 5 existing rows | ... | ... | ... | ... | ... |
| **zombie (iter 7)** | N/A | **0** | 0 | 0 | **caller side migration to live SSOT** |

미래 sweeper는 도구 출력만으로 *6가지* 패턴 중 어디에 해당하는지 *수치만으로* 알 수 있음.

## 후속 가능성

- CI hook: PR diff에 \`val\` 추가/삭제가 있으면 자동 실행 + PR body 첨부
- Pre-commit hook: \`val\` 삭제 시 \`audit-dead-export.sh\` exit 0/3 만 허용 (1,2 일 때 commit 차단)
- 다른 언어 (TypeScript, Python) 동일 패턴 확장