### PR TITLE
fix(test): Yojson.Safe.pp + Option.bind argument order typos (PR #18073 follow-up)

### DIFF
--- a/test/test_keeper_shell_ops.ml
+++ b/test/test_keeper_shell_ops.ml
@@ -17,7 +17,7 @@ open Masc_mcp
 
 (* ---- lines_to_json ------------------------------------------------ *)
 
-let yojson_t = Alcotest.testable (Yojson.Safe.pp ~std:false) ( = )
+let yojson_t = Alcotest.testable (Yojson.Safe.pretty_print ~std:false) ( = )
 
 let test_lines_to_json_empty () =
   let json = Keeper_exec_shared.lines_to_json "" in
@@ -49,10 +49,10 @@ let test_lines_to_json_limit_truncates () =
          (String.starts_with ~prefix:"...[2 more lines omitted" s)
      | other ->
        Alcotest.failf "expected omission string, got %a"
-         (Yojson.Safe.pp ~std:false)
+         (Yojson.Safe.pretty_print ~std:false)
          other)
   | other ->
-    Alcotest.failf "expected `List, got %a" (Yojson.Safe.pp ~std:false) other
+    Alcotest.failf "expected `List, got %a" (Yojson.Safe.pretty_print ~std:false) other
 
 let test_lines_to_json_byte_budget () =
   (* 1000-byte max_bytes with long lines should trigger truncation. *)
@@ -70,7 +70,7 @@ let test_lines_to_json_byte_budget () =
          (String.starts_with ~prefix:"...[" s)
      | _ -> Alcotest.fail "expected omission string")
   | other ->
-    Alcotest.failf "expected `List, got %a" (Yojson.Safe.pp ~std:false) other
+    Alcotest.failf "expected `List, got %a" (Yojson.Safe.pretty_print ~std:false) other
 
 (* ---- process_status_to_json --------------------------------------- *)
 
@@ -84,9 +84,9 @@ let test_process_status_exited_zero () =
     Alcotest.(check (option int)) "code = 0"
       (Some 0)
       (List.assoc_opt "code" fields
-       |> Option.bind (function `Int i -> Some i | _ -> None))
+       |> fun opt -> Option.bind opt (function `Int i -> Some i | _ -> None))
   | other ->
-    Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pp ~std:false) other
+    Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pretty_print ~std:false) other
 
 let test_process_status_exited_nonzero () =
   let json = Keeper_alerting_path.process_status_to_json (Unix.WEXITED 2) in
@@ -95,9 +95,9 @@ let test_process_status_exited_nonzero () =
     Alcotest.(check (option int)) "code = 2"
       (Some 2)
       (List.assoc_opt "code" fields
-       |> Option.bind (function `Int i -> Some i | _ -> None))
+       |> fun opt -> Option.bind opt (function `Int i -> Some i | _ -> None))
   | other ->
-    Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pp ~std:false) other
+    Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pretty_print ~std:false) other
 
 let test_process_status_timeout () =
   (* Exit code 124 is the Eio timeout convention. *)
@@ -108,7 +108,7 @@ let test_process_status_timeout () =
       (Some "timeout")
       (List.assoc_opt "kind" fields |> Option.map Yojson.Safe.to_string)
   | other ->
-    Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pp ~std:false) other
+    Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pretty_print ~std:false) other
 
 let test_process_status_signaled () =
   let json = Keeper_alerting_path.process_status_to_json (Unix.WSIGNALED Sys.sigkill) in
@@ -118,7 +118,7 @@ let test_process_status_signaled () =
       (Some "signaled")
       (List.assoc_opt "kind" fields |> Option.map Yojson.Safe.to_string)
   | other ->
-    Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pp ~std:false) other
+    Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pretty_print ~std:false) other
 
 (* ---- JSON envelope shape contract --------------------------------- *)
 
@@ -131,14 +131,14 @@ let yojson_string_field name json =
   match json with
   | `Assoc fields ->
     List.assoc_opt name fields
-    |> Option.bind (function `String s -> Some s | _ -> None)
+    |> fun opt -> Option.bind opt (function `String s -> Some s | _ -> None)
   | _ -> None
 
 let yojson_bool_field name json =
   match json with
   | `Assoc fields ->
     List.assoc_opt name fields
-    |> Option.bind (function `Bool b -> Some b | _ -> None)
+    |> fun opt -> Option.bind opt (function `Bool b -> Some b | _ -> None)
   | _ -> None
 
 let test_p10_host_envelope_shape () =


### PR DESCRIPTION
## Summary

PR #18073 ("test(keeper): P10 output compatibility tests for ls Shell IR lowering", 2026-05-23 22:32) 가 \`test/test_keeper_shell_ops.ml\` 추가 시 두 카테고리 typed-API 에러 도입:

### 1. \`Yojson.Safe.pp ~std:false\` (7 사이트)

\`\`\`
Yojson.Safe.pp : Format.formatter -> t -> unit   (* no ~std label *)
\`\`\`

\`~std:bool\` 라벨은 sibling \`pretty_print\` / \`pretty_to_string\` 등에 있음.

### 2. \`Option.bind\` 인자 순서 (4 사이트)

\`\`\`
val Option.bind : 'a option -> ('a -> 'b option) -> 'b option   (* option 첫째, function 둘째 *)
\`\`\`

\`List.assoc_opt ... |> Option.bind (function ...)\` 는 \`Option.bind (function ...)\` 의 partial application 결과를 option 처럼 취급 → compiler 거부 ("This expression should not be a function").

### CI gap

두 에러 모두 \`Build and Test\` CI job 이 \`Detect Changed Surfaces\` gate 뒤 SKIPPED 되어 main 머지 통과. memory \`reference_masc_mcp_ci_build_test_skips\`. **이번 세션 4번째 동일 CI-skip-masked PR** (iter 6 #18063 cwd typo, iter 10 #18071, iter 11 #18073, plus iter 9 unmask).

## Fix

\`\`\`diff
- (Yojson.Safe.pp ~std:false)
+ (Yojson.Safe.pretty_print ~std:false)
\`\`\`

\`\`\`diff
- ... |> Option.bind (function \`Int i -> Some i | _ -> None)
+ ... |> fun opt -> Option.bind opt (function \`Int i -> Some i | _ -> None)
\`\`\`

minimal sed 둘 다 — 7 + 4 sites.

## Verification

\`\`\`
dune build --root . test/test_keeper_shell_ops.exe  →  EXIT=0
dune runtest                                         →  6/11 PASS
\`\`\`

## Unmasked pre-existing runtime failures (5)

본 PR 의 compile fix 가 PR #18073 의 *runtime spec drift* 노출:

| Test | Failure | Domain |
|---|---|---|
| lines_to_json:3 | Expected \`3\` / Received \`2\` (omission marker) | lib lines_to_json 동작과 어긋남 |
| lines_to_json:4 | byte budget truncates | 동상 |
| process_status_to_json:0 | exited 0 | process_status_to_json shape drift |
| process_status_to_json:2 | timeout (124) | 동상 |
| process_status_to_json:3 | signaled | 동상 |

이 5 는 별개 PR — lib 또는 test 어느쪽이 contract 인지 author 판단 필요.

## Diff

+12 / -12 LoC.

WORKAROUND-FREE: typed-API 정합. compat shim 없음.

RFC-WAIVED: PR #18073 직접 typo fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)