### PR TITLE
refactor(rfc-0160): route pr-metrics through canonical parse_to_ir_opt

### DIFF
--- a/lib/exec/command_gate/shell_command_gate.ml
+++ b/lib/exec/command_gate/shell_command_gate.ml
@@ -506,3 +506,9 @@ let last_stage_bin context =
 ;;
 
 let is_pipeline context = List.length context.stage_bins > 1
+
+let parse_to_ir_opt text =
+  match Masc_exec_bash_parser.Bash.parse_string text with
+  | Masc_exec.Parsed.Parsed ir -> Some ir
+  | _ -> None
+;;

--- a/lib/exec/command_gate/shell_command_gate.mli
+++ b/lib/exec/command_gate/shell_command_gate.mli
@@ -198,3 +198,12 @@ val too_complex_reason_tag : too_complex_reason -> string
 val stage_count : parsed_context -> int
 val last_stage_bin : parsed_context -> string option
 val is_pipeline : parsed_context -> bool
+
+val parse_to_ir_opt : string -> Masc_exec.Shell_ir.t option
+(** Canonical string-to-IR parse entrypoint for callers that need typed
+    IR but no policy verdict (telemetry classifiers, work-action
+    extractors, debug tools). Returns [Some ir] when the bash subset
+    parser succeeds, [None] on any parse failure. This is the single
+    non-gate entry that callers should use instead of reaching into
+    [Masc_exec_bash_parser.Bash.parse_string] directly — prefer {!gate}
+    or {!gate_typed} when a policy verdict is needed. *)

--- a/lib/keeper/keeper_hooks_oas_pr_metrics.ml
+++ b/lib/keeper/keeper_hooks_oas_pr_metrics.ml
@@ -126,10 +126,11 @@ let pr_work_action_of_git_action raw =
   | _ -> None
 
 let pr_work_actions_of_git_segment segment =
-  (* RFC-0160 §S4: route via the gate module's canonical parse entrypoint
-     instead of reaching into [Masc_exec_bash_parser.Bash.parse_string]
-     directly. Behavior is unchanged — the wrapper unwraps the same
-     [Parsed.t] variant the call-site already pattern-matches. *)
+  (* RFC-0160 §S4: route via the gate module's canonical parse entry
+     [Shell_command_gate.parse_to_ir_opt] instead of reaching into the
+     legacy bash parser directly. Behavior is unchanged — the wrapper
+     unwraps the same Parsed variant the call-site already
+     pattern-matches. *)
   match
     Masc_exec_command_gate.Shell_command_gate.parse_to_ir_opt segment
   with

--- a/lib/keeper/keeper_hooks_oas_pr_metrics.ml
+++ b/lib/keeper/keeper_hooks_oas_pr_metrics.ml
@@ -126,8 +126,14 @@ let pr_work_action_of_git_action raw =
   | _ -> None
 
 let pr_work_actions_of_git_segment segment =
-  match Masc_exec_bash_parser.Bash.parse_string segment with
-  | Masc_exec.Parsed.Parsed (Masc_exec.Shell_ir.Simple simple)
+  (* RFC-0160 §S4: route via the gate module's canonical parse entrypoint
+     instead of reaching into [Masc_exec_bash_parser.Bash.parse_string]
+     directly. Behavior is unchanged — the wrapper unwraps the same
+     [Parsed.t] variant the call-site already pattern-matches. *)
+  match
+    Masc_exec_command_gate.Shell_command_gate.parse_to_ir_opt segment
+  with
+  | Some (Masc_exec.Shell_ir.Simple simple)
     when String.equal
            (Masc_exec.Bin.to_string simple.bin |> String.lowercase_ascii)
            "git" ->


### PR DESCRIPTION
RFC-0160 §S4 ("Parser Entry 단일화")이 권고하는 *gate 모듈 SSOT entry* 패턴을 따라, 마지막 직접 `Bash.parse_string` caller였던 `keeper_hooks_oas_pr_metrics.pr_work_actions_of_git_segment`를 canonical entry로 라우팅합니다.

## 변경 사항

- `Shell_command_gate.parse_to_ir_opt : string -> Shell_ir.t option` 신규 추가 (mli + ml). 기존 callers가 직접 unwrap하던 `Parsed.t` variant를 wrapper가 흡수. policy verdict가 필요하면 여전히 `gate` / `gate_typed` 사용.
- `keeper_hooks_oas_pr_metrics.pr_work_actions_of_git_segment` 호출부를 `parse_to_ir_opt`으로 migrate. pattern match가 `Parsed.Parsed (Shell_ir.Simple simple)` → `Some (Shell_ir.Simple simple)`로 단순화. string-prefix fallback arm은 그대로 유지.

Behavior 변화 없음 — underlying parser는 동일, surface API만 gate module namespace로 이동.

## audit metric 변화 (PR #18145 의 정확 baseline 적용 시)

| Goal | Before | After | Target |
|---|---|---|---|
| G1 files | 4 | **3** ✓ | ≤ 3 |
| G1 refs | 10 | 9 | (informative) |

`keeper_hooks_oas_pr_metrics.ml`은 `g1_allowed_files` 화이트리스트에서 제거됩니다. `Shell_command_gate.ml`의 직접 `Bash.parse_string` 호출은 그대로 — §S4가 *유일한 외부 string→IR entry*로 명시한 SSOT call site.

## 컨텍스트

RFC-0160 plan §6 다음 액션 stack의 마지막 단계:

1. PR #18116 — G6 TLA+ spec (Done)
2. PR #18145 — audit accuracy refinement (Done)
3. **본 PR** — G1 target ≤ 3 달성

세 PR 머지 후 plan §6 G1/G6/G7 모두 closed. 남은 항목 (S2 gh op IR lift, S5 universal validator)은 별도 작업.

## 의존성

- 본 PR 단독 머지 가능 (origin/main base).
- PR #18145가 머지되면 audit script가 G1 file count 4→3을 자동 detect → ratchet OK.
- PR #18145 머지 전에 본 PR이 먼저 머지되면 audit script (old grep)가 여전히 keeper_hooks_oas_pr_metrics를 *file 단위로*는 카운트 안 함 (call이 사라졌으니) — 결과는 동일.

RFC-WAIVED: RFC-0160 §S4 직접 구현, RFC body는 이 변경을 이미 명세함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## CI 추적 (iter 8 — 모두 inherited-main-failure 확인)

PR이 `lib/exec/` + `lib/keeper/` 건드려서 다른 PR (#18116, #18145)에서는 SKIP되는 lib-scope CI gate가 trigger됨. 모든 fail 원인은 우리 PR 외부:

| Check | step | 원인 | inherited |
|---|---|---|---|
| G1 + G7 monotone decrease | — | ✅ PASS (8433d1729 comment fix) | — |
| TLA+ Model Checking | — | ✅ PASS (22m17s, parent PR #18116 spec 호환 확인) | — |
| Lint | Check Eio conventions | `lib/keeper/keeper_turn_driver.ml:1244 Unix.sleepf` 위반 (allowed: `file_lock_eio.ml`, `shutdown.ml`, `keeper_turn_slot.ml`) | ✓ main |
| OCaml Structure Ratchet | Run OCaml structure ratchet | `keeper_mli_missing: 3>0`, `lib_dune_lines: 653>643`, `lib_other_mli_missing: 7>0` | ✓ main |
| Meta Guards | Validate spec line refs | `read_recent_memory_texts not found in lib/keeper/keeper_memory_recall.ml` | ✓ main |
| Health | Run health snapshot | TBD (likely similar) | ✓ main (presumed) |
| Godfile size | RFC-0151 ratchet | `godfile_loc_1000plus 45/44`, `catch_all_arms 3282/3269` | ✓ main (RFC-0151 inline-restore loop) |
| Draft Auto-Merge Guard | — | Draft 정책, Ready 전환 시 사용자 라벨 후 통과 | (expected) |

본 PR scope 변경 (3 file, +23/-2 commit 1 + comment fix commit 2 = 4 files):
- `lib/exec/command_gate/shell_command_gate.{ml,mli}` (canonical entrypoint `parse_to_ir_opt` 추가, .mli 페어 포함)
- `lib/keeper/keeper_hooks_oas_pr_metrics.ml` (call site migration + comment rewording)

`lib/**` path filter가 lib-scope ratchet을 trigger한 정상 패턴 (`memory/reference_masc_mcp_ci_build_test_skips.md` documented). RFC-WAIVED 본 PR scope 안 inherited regressions.
