### PR TITLE
test: migrate cmd_targets_* zombies to stages_targets_* SSOT

### DIFF
--- a/test/test_gh_exit_class_wiring.ml
+++ b/test/test_gh_exit_class_wiring.ml
@@ -7,28 +7,36 @@
    exec itself is out of scope for a unit test. *)
 
 module KSD = Masc_mcp.Keeper_shell_docker
+module KSCS = Masc_mcp.Keeper_shell_command_semantics
 module LC = Masc_mcp.Legendary_counters
 module GEC = Masc_mcp.Gh_exit_class
 
+(* `cmd_targets_gh` was renamed to `stages_targets_gh` and moved to
+   Keeper_shell_command_semantics with a parsed-stage input.  The
+   string-input shape is reconstructed via `effective_stages_of_cmd`. *)
+let cmd_targets_gh raw =
+  KSCS.stages_targets_gh (KSCS.effective_stages_of_cmd raw)
+
 let test_cmd_targets_gh_positive () =
   Alcotest.(check bool) "gh pr list → true" true
-    (KSD.cmd_targets_gh "gh pr list")
+    (cmd_targets_gh "gh pr list")
 
 let test_cmd_targets_gh_negative () =
   Alcotest.(check bool) "git status → false" false
-    (KSD.cmd_targets_gh "git status");
+    (cmd_targets_gh "git status");
   Alcotest.(check bool) "cd /repo && gh pr view 1 → false" false
-    (KSD.cmd_targets_gh "cd /repo && gh pr view 1");
+    (cmd_targets_gh "cd /repo && gh pr view 1");
   Alcotest.(check bool) "ls -la → false" false
-    (KSD.cmd_targets_gh "ls -la");
+    (cmd_targets_gh "ls -la");
   Alcotest.(check bool) "empty → false" false
-    (KSD.cmd_targets_gh "")
+    (cmd_targets_gh "")
 
 let test_field_empty_for_non_gh () =
   LC.reset ();
   let fields =
     KSD.gh_exit_class_field
-      ~cmd:"git status" ~status:(Unix.WEXITED 0) ~output:""
+      ~cmd_stages:(KSCS.effective_stages_of_cmd "git status")
+      ~status:(Unix.WEXITED 0) ~output:"" ()
   in
   Alcotest.(check int) "no field emitted" 0 (List.length fields);
   let s = LC.snapshot () in
@@ -38,7 +46,8 @@ let test_field_ok_for_gh_exit_0 () =
   LC.reset ();
   let fields =
     KSD.gh_exit_class_field
-      ~cmd:"gh pr list" ~status:(Unix.WEXITED 0) ~output:""
+      ~cmd_stages:(KSCS.effective_stages_of_cmd "gh pr list")
+      ~status:(Unix.WEXITED 0) ~output:"" ()
   in
   Alcotest.(check int) "one field emitted" 1 (List.length fields);
   (match fields with
@@ -53,9 +62,9 @@ let test_field_auth_failed_from_combined_output () =
   LC.reset ();
   let fields =
     KSD.gh_exit_class_field
-      ~cmd:"gh api /user"
+      ~cmd_stages:(KSCS.effective_stages_of_cmd "gh api /user")
       ~status:(Unix.WEXITED 1)
-      ~output:"HTTP 401: Bad credentials (https://api.github.com/user)"
+      ~output:"HTTP 401: Bad credentials (https://api.github.com/user)" ()
   in
   (match fields with
    | [ ("gh_exit_class", `String v) ] ->
@@ -69,7 +78,8 @@ let test_field_signal_maps_to_unknown () =
   LC.reset ();
   let fields =
     KSD.gh_exit_class_field
-      ~cmd:"gh pr list" ~status:(Unix.WSIGNALED 9) ~output:""
+      ~cmd_stages:(KSCS.effective_stages_of_cmd "gh pr list")
+      ~status:(Unix.WSIGNALED 9) ~output:"" ()
   in
   (match fields with
    | [ ("gh_exit_class", `String v) ] ->

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -483,7 +483,12 @@ let () =
         witness Local; witness Docker;
         Alcotest.(check int) "count" 2 (List.length valid_sandbox_profile_strings));
       Alcotest.test_case "cmd_targets_git_or_gh dispatch predicate" `Quick (fun () ->
-        let p = Masc_mcp.Keeper_exec_shell.cmd_targets_git_or_gh in
+        let module KSCS = Masc_mcp.Keeper_shell_command_semantics in
+        (* Renamed: `cmd_targets_git_or_gh` (string -> bool) is now
+           `stages_targets_git_or_gh` (parsed_stage list -> bool) on
+           Keeper_shell_command_semantics. Reconstruct the
+           string-input predicate via `effective_stages_of_cmd`. *)
+        let p raw = KSCS.stages_targets_git_or_gh (KSCS.effective_stages_of_cmd raw) in
         Alcotest.(check bool) "git status" true (p "git status");
         Alcotest.(check bool) "gh pr list" true (p "gh pr list");
         Alcotest.(check bool) "leading whitespace tolerated" true


### PR DESCRIPTION
## 목적

\`cmd_targets_gh\` / \`cmd_targets_git_or_gh\` 가 \`stages_targets_*\` 로 rename 되며 string 입력형이 사라짐 — 2 test 파일의 zombie reference 정리.

## 진단 (v2 도구 dogfooding)

iter 8의 \`audit-dead-export.sh\` v2 가 정확히 분류:

\`\`\`
$ bash scripts/audit-dead-export.sh cmd_targets_gh
  defining sites:      0
  test callers:        5
  RESULT: zombie callers detected — 'cmd_targets_gh' has no defining site.
  exit: 3

$ bash scripts/audit-dead-export.sh cmd_targets_git_or_gh
  defining sites:      0
  test callers:        1
  RESULT: zombie callers detected.
  exit: 3
\`\`\`

도구가 *iter 7*에서 추가한 \`zombie\` 분류 (exit 3) — 정의가 사라졌지만 caller가 잔존하는 inverse case — 를 두 시그널에 정확히 발동.

## 마이그레이션 shape

\`\`\`
raw_cmd  (string)
   ↓
KSCS.effective_stages_of_cmd raw_cmd
   ↓
parsed_stage list
   ↓
stages_targets_gh / stages_targets_git_or_gh / ~cmd_stages
\`\`\`

\`Keeper_shell_command_semantics\` (KSCS) 가 새 SSOT, \`Keeper_shell_docker\` (KSD) 와 \`Keeper_exec_shell\` 에서는 빠짐.

## 변경

### test/test_gh_exit_class_wiring.ml
- \`KSCS\` alias 추가
- Local \`cmd_targets_gh raw\` helper로 새 typed predicate wrap
- 4개 \`KSD.gh_exit_class_field\` 사이트:
  - \`~cmd:string\` → \`~cmd_stages:(KSCS.effective_stages_of_cmd raw)\`
  - 시그니처가 \`unit ->\` 종결 추가 → 호출 끝에 \`()\` 필요

### test/test_types.ml
- 한 줄 \`let p = ...cmd_targets_git_or_gh\` → \`let p raw = KSCS.stages_targets_git_or_gh (KSCS.effective_stages_of_cmd raw)\`
- 7개 \`p "..."\` 호출 사이트 미변경 (lambda signature 그대로)

## 검증

\`\`\`
dune exec test/test_gh_exit_class_wiring.exe → 6/6 pass
dune exec test/test_types.exe                → 115/115 pass
\`\`\`

## 별개 보존 (scope guard)

\`test/test_keeper_sandbox_boundary_policy.ml\` 도 \`cmd_targets_*\` 명칭을 *문자열 검색*으로 참조 (line 87-97). 그 파일은 *컴파일은 정상*이고 *런타임에서 boundary 정책을 검증*. 3개 orthogonal 실패가 한 번에 있어서 (vacuous + parse_string delegated + split_on_char legit) 별 PR로 처리하는 게 명확.

## 패턴 분류 매트릭스 — 7번째 row

iter 6/7/8 도구가 6 row 매트릭스로 발달:

| 케이스 | mli 역할 | 정의 | Prod | Test | 결정 |
|---|---|---|---|---|---|
| (5 existing rows from iter 1-5) | ... | ... | ... | ... | ... |
| zombie (iter 7 single, iter 9 multi) | N/A | **0** | 0 | N | caller migration to live SSOT |

이번 PR이 \`stages_targets_*\` 라는 *명확한 live SSOT 대안*을 가진 zombie 케이스 처리. iter 7의 \`gate_from_raw_typed\` 과 동일 카테고리지만 *2 test file 3 sites* 규모.