### PR TITLE
refactor(operator_control_context_snapshot): drop dead always-`None` `resolved_context_budget_of_meta` + cascade simplification

### DIFF
--- a/lib/operator/operator_control_context_snapshot.ml
+++ b/lib/operator/operator_control_context_snapshot.ml
@@ -1,18 +1,16 @@
 (** Keeper context snapshot helpers for operator control snapshots. *)
 
-let resolved_context_budget_of_meta (meta : Keeper_types.keeper_meta) : int option =
-  let _ = meta in
-  None
-;;
+(* Context budget resolution is intentionally unimplemented: the provider-side
+   max-context number is not threaded through the keeper meta yet. Both
+   [compute_context_ratio] and [context_max] therefore return [None] for all
+   keepers — observed-and-tested behavior (see
+   [test_compute_context_ratio_does_not_infer_provider_budget]). If a future
+   RFC threads the budget through, these call sites become real computations
+   again. *)
 
 let compute_context_ratio (meta : Keeper_types.keeper_meta) : float option =
-  let input_tokens = meta.runtime.usage.last_input_tokens in
-  if input_tokens = 0
-  then None
-  else (
-    match resolved_context_budget_of_meta meta with
-    | Some max_ctx -> Some (float_of_int input_tokens /. float_of_int max_ctx)
-    | None -> None)
+  let _ = meta in
+  None
 ;;
 
 type keeper_context_snapshot =
@@ -79,18 +77,15 @@ let latest_keeper_context_snapshot_from_files config keeper_name =
 ;;
 
 let fallback_keeper_context_snapshot (meta : Keeper_types.keeper_meta) =
+  (* context_max / context_source stay [None] because the provider-side budget
+     is not yet plumbed through meta (see top-of-file note). *)
   { context_ratio = compute_context_ratio meta
   ; context_tokens =
       (match meta.runtime.usage.last_input_tokens with
        | n when n > 0 -> Some n
        | _ -> None)
-  ; context_max = resolved_context_budget_of_meta meta
-  ; context_source =
-      (match
-         meta.runtime.usage.last_input_tokens, resolved_context_budget_of_meta meta
-       with
-       | n, Some _ when n > 0 -> Some "usage_last_input_tokens"
-       | _ -> None)
+  ; context_max = None
+  ; context_source = None
   }
 ;;
 

--- a/lib/operator/operator_control_context_snapshot.mli
+++ b/lib/operator/operator_control_context_snapshot.mli
@@ -1,6 +1,5 @@
 (** Keeper context snapshot helpers for operator control snapshots. *)
 
-val resolved_context_budget_of_meta : Keeper_types.keeper_meta -> int option
 val compute_context_ratio : Keeper_types.keeper_meta -> float option
 
 type keeper_context_snapshot =

--- a/lib/operator/operator_control_snapshot.mli
+++ b/lib/operator/operator_control_snapshot.mli
@@ -29,7 +29,6 @@
     [_snapshot_mu] / [_snapshot_table] / [_snapshot_ttl_s]
     cache state, [Cached] / [Computing] cache states, the
     keeper-context snapshot helpers,
-    [resolved_context_budget_of_meta],
     [compute_context_ratio],
     [keeper_context_snapshot] type +
     [keeper_context_snapshot_is_empty] /


### PR DESCRIPTION
## 목표

`resolved_context_budget_of_meta (meta : keeper_meta) : int option = let _ = meta in None` 가 *항상 None* 반환 + `meta` 무시 + cascade 결과:

- `compute_context_ratio` 의 inner match `| Some max_ctx -> Some (...)` 분기 unreachable
- `fallback_keeper_context_snapshot` 의 `context_max` 항상 None
- `fallback_keeper_context_snapshot.context_source` match 의 `| n, Some _ when n > 0 -> Some "..."` 분기 unreachable

근본 원인: provider-side max-context 가 아직 keeper_meta 에 threaded 되지 않음. 원본 코드는 *"미래 RFC 가 budget threading 을 추가할 때 그 자리"* 로 stub 남김. CLAUDE.md `software-development.md` §"Don't design for hypothetical future requirements" 위반.

## 변경

`lib/operator/operator_control_context_snapshot.ml`:
- `resolved_context_budget_of_meta` 정의 제거
- `compute_context_ratio` body 의 nested match 제거 (always-None 으로 단순화)
- `fallback_keeper_context_snapshot`:
  - `context_max = resolved_context_budget_of_meta meta` → `context_max = None`
  - `context_source` match (2nd arg always None) → `context_source = None`
- 파일 top 에 *왜 None* 인지 명시하는 주석 추가 — `test_compute_context_ratio_does_not_infer_provider_budget` 가 이 행동을 잠근다는 점 + 미래 RFC 가 budget threading 추가 시 real computation 으로 복원 가능 명시

`lib/operator/operator_control_context_snapshot.mli`:
- `val resolved_context_budget_of_meta` 제거

`lib/operator/operator_control_snapshot.mli`:
- docstring (line 32) 의 `[resolved_context_budget_of_meta]` 멘션 제거

## 변경 파일 (3 파일, +10 / −18, **net −8 LoC**)

## Behavior parity (byte-identical)

| Caller / Field | Pre-PR Return | Post-PR Return |
|----------------|---------------|----------------|
| `compute_context_ratio meta` | None (cascade through always-None inner) | None (direct) |
| `fallback.context_max` | None | None |
| `fallback.context_source` | None (`Some _` branch unreachable) | None |
| `fallback.context_ratio` | None (via compute_context_ratio) | None (unchanged) |
| `fallback.context_tokens` | conditional on last_input_tokens | conditional (unchanged) |

`compute_context_ratio` surface (`Keeper_types.keeper_meta -> float option`) 유지 → production caller (`Operator_control_snapshot.compute_context_ratio meta` at `server_routes_http_routes_provider_runs.ml:152`) + test guard 영향 0.

## 5-prong dead-export audit

`resolved_context_budget_of_meta`:

| Path | Result |
|------|--------|
| 1. Direct qualified `Operator_control_context_snapshot.resolved_context_budget_of_meta` (외부) | 0 hit |
| 2. Module alias | 0 hit |
| 3. Re-export `let resolved_context_budget_of_meta = ...` (다른 ml) | 0 hit |
| 4. `include Operator_control_context_snapshot` (`operator_control_snapshot.ml` + `operator_control_snapshot_persistent_agents.ml`) | 존재, but… |
| 5. Facade-경유 노출 (`operator_control_snapshot.mli`) | docstring 멘션만, **`val` declaration 없음** → 외부 비노출 |
| 6. `open` opener (qualified-only) | 0 hit |
| 7. test 파일 catch-all | 0 hit |

Defensive witness check (`feedback_defensive_witness_4th_veto_path.md`): docstring 이 *현재 행위* 만 진술, compile-time invariant maintenance 선언 없음 → 안전.

## 로컬 검증

```
$ dune build --root . lib/  # clean
$ rg "resolved_context_budget_of_meta" lib/ test/
(empty — 완전 제거)
```

`test/test_operator_control.exe` 38 failures 는 pre-existing main 이슈 (`Prompt_defaults.init`, `Keeper_exec_shell.cmd_targets_git_or_gh` 등) — `~/me/memory` 의 `main-build-recovery-2026-05-23-clean` worktrees 진행 중. 본 PR 변경 영역 (`compute_context_ratio` 의 always-None 행동) 은 byte-identical 이라 회귀 가능성 0.

## 관련

- `software-development.md` §"Don't design for hypothetical future requirements"
- 같은 spirit 의 이전 loop iter PR 들 (7 anti-pattern 카탈로그):
  - #18122 — function-name-lying (OAS timeout)
  - #18125 — body `()` no-op (observe_legacy_release)
  - #18130 — placeholder type chain (t/create/default)
  - #18135 — mli-exposed dead no-op (`init` convention outlier)
  - #18139 — always-false hardcoded (`is_pg_backend`)
  - #18144 — literal-wrapper (`default_keeper_model_label` → "runtime")
  - 본 PR — always-None body + ignored arg + facade-hidden + cascade simplification
- 작업 출처: `/loop 10m 가짜 구현이나 억지로 되게끔만 만든 구현 숙청, 및 레거시 개념 제거`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>