### PR TITLE
fix(keeper_exec_shared): track line-count truncation in lines_to_json omission marker

### DIFF
--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -488,10 +488,15 @@ let shell_readonly_cat_max_bytes args =
 
 let lines_to_json ?(limit = max_int) ?(max_bytes = 32_000) (text : string) : Yojson.Safe.t
   =
-  let all_lines =
+  let all_nonempty =
     String.split_on_char '\n' text
     |> List.filter (fun line -> line <> "")
-    |> fun rows -> if List.length rows > limit then take limit rows else rows
+  in
+  let total = List.length all_nonempty in
+  let truncated_by_limit, limit_overflow =
+    if total > limit
+    then take limit all_nonempty, total - limit
+    else all_nonempty, 0
   in
   (* Byte-budget: accumulate lines until max_bytes is reached.
      This prevents 200 long lines from producing 500KB+ JSON arrays
@@ -507,7 +512,8 @@ let lines_to_json ?(limit = max_int) ?(max_bytes = 32_000) (text : string) : Yoj
       then List.rev acc, List.length rest + 1
       else collect (`String line :: acc) (bytes_used + line_len) rest
   in
-  let kept, omitted = collect [] 0 all_lines in
+  let kept, byte_overflow = collect [] 0 truncated_by_limit in
+  let omitted = limit_overflow + byte_overflow in
   if omitted > 0
   then
     `List


### PR DESCRIPTION
## Summary

\`lib/keeper/keeper_exec_shared.ml:489\` 의 \`lines_to_json\` 가 두 truncation path 보유:

| Path | Behavior (before) |
|---|---|
| \`~limit:N\` | N 초과 line 을 **silent drop** ❌ |
| \`~max_bytes\` | budget 초과 시 \`...[N more lines omitted — narrow your search pattern...]\` marker emit ✓ |

비대칭 — operator 와 LLM 둘 다 line-count 절단 시 *data was lost* 시그널 없음. PR #18073 의 contract test (\`lines_to_json:3 limit truncates\`) 가 symmetric semantics 어설션 (둘 다 marker 있어야), lib 가 lag.

## Fix

\`\`\`ocaml
let total = List.length all_nonempty in
let truncated_by_limit, limit_overflow =
  if total > limit then take limit all_nonempty, total - limit
  else all_nonempty, 0
in
...
let kept, byte_overflow = collect [] 0 truncated_by_limit in
let omitted = limit_overflow + byte_overflow in
\`\`\`

\`omitted\` 가 두 path drop 수를 합산 → 기존 marker 분기가 line-count truncation 도 cover.

## Verification

PR #18152 (test compile fix) 적용 상태에서:

\`\`\`
dune build --root . lib/                                →  EXIT=0
dune runtest --root . test/test_keeper_shell_ops.exe
  lines_to_json:0,1,2                                   →  PASS (regression check)
  lines_to_json:3  limit truncates                      →  PASS  ← 본 PR 효과
  lines_to_json:4  byte budget truncates                →  still FAIL
    독립 test typo: \`List.length items < 4\` assertion 인데 budget
    이 3 lines + 1 marker = 4 items 허용. 별개 PR 영역.
\`\`\`

본 PR 머지 후 \`lines_to_json:3\` unmask 해소.

## Domain

이번 세션 iter 11 의 compile fix (PR #18152) 가 unmask 했던 5 runtime failures 중 첫 fix. **첫 *real lib behavior fix*** — 이전 11 iter 가 expose / typo / sweep miss 였던 것과 달리, 본 PR 은 *invariant correction*.

## Diff

+9 / -3 LoC.

## Compatibility

8 caller in \`lib/keeper/keeper_shell_ops.ml\` 모두 \`lines_to_json ~limit out\` 형태 — limit-truncation 시 새로 marker append 됨. JSON consumer (dashboard / LLM context) 가 trailing string marker 를 *expected omission signal* 로 인식해야 함 — byte-budget 경로는 이미 그렇게 동작 중이므로 추가 안정성 위험 없음.

WORKAROUND-FREE: invariant 정합. compat shim 없음.

RFC-WAIVED: PR #18073 contract test 와 lib behavior 직접 정합.

🤖 Generated with [Claude Code](https://claude.com/claude-code)