### PR TITLE
refactor(audit_log): drop ref-accumulator in parse_entries

### DIFF
--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -249,23 +249,29 @@ let get_audit_store (config : config) : Dated_jsonl.t =
 let max_logged_errors = 5
 
 let parse_entries (jsons : Yojson.Safe.t list) : audit_entry list =
-  let ok = ref [] in
-  let err_count = ref 0 in
-  List.iter (fun json ->
-    match entry_of_json_r json with
-    | Ok entry -> ok := entry :: !ok
-    | Error reason ->
-        incr err_count;
-        if !err_count <= max_logged_errors then
-          Log.Misc.error "audit_log: corrupt entry (#%d): %s" !err_count reason
-  ) jsons;
-  if !err_count > 0 then
+  (* Logging side effects (per-entry corrupt-entry ERROR, rate-limited
+     by [max_logged_errors]) are kept inside the fold body — they are
+     observably equivalent to the original [List.iter] order. *)
+  let ok_rev, err_count =
+    List.fold_left
+      (fun (ok, errc) json ->
+        match entry_of_json_r json with
+        | Ok entry -> (entry :: ok, errc)
+        | Error reason ->
+            let errc = errc + 1 in
+            if errc <= max_logged_errors then
+              Log.Misc.error "audit_log: corrupt entry (#%d): %s" errc reason;
+            (ok, errc))
+      ([], 0)
+      jsons
+  in
+  if err_count > 0 then
     Log.Misc.error "audit_log: %d/%d entries failed to parse (possible corruption)%s"
-      !err_count (List.length jsons)
-      (if !err_count > max_logged_errors
-       then Printf.sprintf " (%d more suppressed)" (!err_count - max_logged_errors)
+      err_count (List.length jsons)
+      (if err_count > max_logged_errors
+       then Printf.sprintf " (%d more suppressed)" (err_count - max_logged_errors)
        else "");
-  List.rev !ok
+  List.rev ok_rev
 
 (** Read recent audit entries.
     Tries date-split store first; falls back to legacy single file.


### PR DESCRIPTION
## 목표

`lib/audit_log.ml`의 `parse_entries`에서 `let ok = ref []` + `let err_count = ref 0` + `List.iter` 패턴을 `List.fold_left` over `(ok_rev, err_count)` tuple state로 변환. 두 accumulator(list + counter)가 함께 fold value가 됨.

## 왜

- 7번째 same-pattern conversion. 다만 이번은 *counter + list + logging side effect* mixed variant라 single fold-state로 통합.
- Counter retention 카테고리(`cdal_runtime_health`)와 비교: 거기서는 6 counter + 2 bounded sample이 함께 있어 tuple 도입이 net loss였지만, 여기는 list 1 + counter 1 + logging predicate가 *서로 의존* (logging이 counter 값 사용)이라 tuple 통합이 자연스러움.
- Side effect (`Log.Misc.error`)는 fold body 안에 retain. logging API 자체가 imperative이므로 분리 불가능. *입력 상태 변형*만 immutable이 됨.

## Behavior parity

| 측면 | 원본 | 새 코드 |
|---|---|---|
| `entry_of_json_r` 호출 횟수/순서 | 1 per element (List.iter) | 동일 (List.fold_left) |
| Corrupt-entry ERROR 호출 조건 | `incr err_count; if !err_count <= max_logged_errors then log` | `let errc = errc + 1 in if errc <= ... then log` (semantically identical, post-increment 값 같음) |
| Tail summary message | `%d/%d entries failed to parse ...` | byte-equal |
| Suppression suffix | `if !err_count > max ... " (%d more suppressed)"` | 동일 |
| 반환값 entry 순서 | `List.rev !ok` | `List.rev ok_rev` (동일) |

## 변경 파일

- `lib/audit_log.ml` (+21 / −15, net +6 due to fold body + 3-line docstring comment)

## 로컬 검증

```
$ dune build --root . lib/                  # PASS
$ dune exec --root . test/test_audit_log.exe
...
Test Successful in 0.004s. 2 tests run.
```

test_audit_log는 2 tests로 적지만 lib 전체 compile + 다른 attribution test가 함께 build. parse_entries는 audit_log 내부 caller (`get_recent_entries`, line 278/302) 통해서만 호출되어 외부 surface 변화 없음.

## 누적 (7 iter)

| Iter | PR | 함수 | 변형 | 상태 |
|---|---|---|---|---|
| #1 | #18106 | server_state_product.check_invariants | prepend + List.rev | MERGED |
| #2 | #18109 | chronicle_validate.validate_epoch | prepend + List.rev | MERGED |
| #3 | #18119 | tool_control.keeper_pause_status_json | prepend × 3 + fold | Draft |
| #4 | #18131 | governance_anomaly.detect_deviations | prepend + List.rev | Draft |
| #5 | #18141 | cascade_declarative_parser.parse_toml | append `:= !x @ errs` | Draft |
| #6 | #18150 | cdal_judge.check_execution_mode | prepend + List.rev | Draft |
| #7 | (this) | audit_log.parse_entries | **counter + list + logging mixed** | Draft |

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>