### PR TITLE
test(keeper_shell_docker_route): add missing module alias

### DIFF
--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -18,6 +18,7 @@ module Keeper_sandbox_runtime = Masc_mcp.Keeper_sandbox_runtime
 module Keeper_turn_sandbox_runtime = Masc_mcp.Keeper_turn_sandbox_runtime
 module Keeper_shell_command_semantics = Masc_mcp.Keeper_shell_command_semantics
 module Keeper_shell_docker = Masc_mcp.Keeper_shell_docker
+module Keeper_shell_docker_exec_failure = Masc_mcp.Keeper_shell_docker_exec_failure
 module Keeper_types = Masc_mcp.Keeper_types
 module Keeper_alerting_path = Masc_mcp.Keeper_alerting_path
 module Tool_code_write = Masc_mcp.Tool_code_write


### PR DESCRIPTION
## 목적

\`test/test_keeper_shell_docker_route.ml:2056\` 이 \`Keeper_shell_docker_exec_failure.docker_exec_failure_message\` 를 호출하지만 모듈 alias 누락 — \"Unbound module Keeper_shell_docker_exec_failure\" 컴파일 에러. 1줄 alias 추가.

## 진단

모듈 자체는 살아있음:
- \`lib/keeper/keeper_shell_docker_exec_failure.ml\` 존재 (godfile decomp 캠페인에서 \`keeper_shell_docker.ml\` 에서 분리)
- \`docker_exec_failure_message\`, \`docker_exec_failure_message_internal\`, \`docker_exec_failure_message_with_context\`, \`record_docker_exec_failure\` 모두 export

테스트 파일의 모듈 alias 패턴 (\`module X = Masc_mcp.X\` 라인 11-23) 중 이 모듈만 누락. 테스트가 신모듈 호출 추가했을 때 alias 라인이 함께 안 들어갔음.

## 변경

\`test/test_keeper_shell_docker_route.ml\` 20-21번 라인 사이에 한 줄 추가:

\`\`\`ocaml
module Keeper_shell_docker = Masc_mcp.Keeper_shell_docker
+ module Keeper_shell_docker_exec_failure = Masc_mcp.Keeper_shell_docker_exec_failure
module Keeper_types = Masc_mcp.Keeper_types
\`\`\`

## 검증

\`\`\`
dune build test/test_keeper_shell_docker_route.exe → exit 0
\`\`\`

## 도구 한계 메타-기록

\`audit-dead-export.sh\` (PR #18142 v1 + #18151 v2) 가 이 모듈을 \"defining_count = 0\" 으로 분류 — false negative. 이유: 도구가 \`^(let|and|val|type|module|exception)\\s+...\` 컨텐츠 기반으로 정의 사이트 검색하지만, OCaml은 **filename-based module convention** (no explicit \`module Foo = struct\` declaration) 도 사용. \`lib/keeper/keeper_shell_docker_exec_failure.ml\` 파일 *존재 자체가* 모듈 정의.

→ v3 enhancement 후보: filename-based module discovery 추가. \`find lib -name '<lowercase_name>.ml'\` 보조 패턴.

본 PR 은 그 enhancement와 독립적인 1줄 test alias fix.