### PR TITLE
refactor(coord_utils_backend_setup): drop fake `create_backend_eio` wrapper (sw discarded)

### DIFF
--- a/lib/coord/coord_utils_backend_setup.ml
+++ b/lib/coord/coord_utils_backend_setup.ml
@@ -337,11 +337,6 @@ let create_backend cfg =
               Fall back to shared Memory backend for the same base path. *)
            filesystem_fallback
              "No Eio fs context for FileSystem backend;")
-(** Create backend with Eio context. *)
-let create_backend_eio ~sw cfg =
-  let _ = sw in
-  create_backend cfg
-
 (* #10919: per-call Backend init was producing 1745 inits / 2 days
    (~83 inits per server lifetime against an expected 1) plus 3490
    INFO log lines.  Hot callers — [Coord.default_config] from every
@@ -435,6 +430,7 @@ let default_config base_path =
     [on_backend_ready] is called after backend creation, allowing callers
     to initialize dependent systems (e.g., Board) without Coord depending on them. *)
 let default_config_eio ~sw ?(on_backend_ready = fun _backend -> ()) base_path =
+  let _ = sw in
   let resolved_path = resolve_masc_base_path base_path in
   sync_test_base_path_env resolved_path;
   let backend_config = backend_config_for resolved_path in
@@ -443,7 +439,7 @@ let default_config_eio ~sw ?(on_backend_ready = fun _backend -> ()) base_path =
   Log.Backend.debug "MASC Backend: type=%s"
     (Backend_types.show_backend_type backend_config.backend_type);
   let backend =
-    match create_backend_eio ~sw backend_config with
+    match create_backend backend_config with
     | Ok backend ->
         Log.Backend.debug "Backend initialized: %s"
           (match backend with

--- a/lib/coord/coord_utils_backend_setup.mli
+++ b/lib/coord/coord_utils_backend_setup.mli
@@ -36,7 +36,6 @@ val storage_type_from_env : unit -> string
 val sanitize_namespace_segment : string -> string
 val backend_config_for : string -> Backend_types.config
 val create_backend : Backend_types.config -> (storage_backend, Backend_types.error) result
-val create_backend_eio : sw:Eio.Switch.t -> Backend_types.config -> (storage_backend, Backend_types.error) result
 val reset_default_config_cache : unit -> unit
 val build_default_config : string -> config
 val default_config : string -> config


### PR DESCRIPTION
## 목표

`create_backend_eio ~sw cfg = let _ = sw in create_backend cfg` 가 *fake parameter wrapper*:
- `~sw : Eio.Switch.t` 를 명시적으로 `let _ = sw in` 으로 버림
- body 는 단순히 non-eio `create_backend cfg` 호출
- `~sw` 가 *유일한* 차이점인데 무시되므로 두 함수가 동작 동일

## 자가 증거

pre-PR (`lib/coord/coord_utils_backend_setup.ml:341-343`):
```ocaml
(** Create backend with Eio context. *)
let create_backend_eio ~sw cfg =
  let _ = sw in
  create_backend cfg
```

docstring "Create backend with Eio context" 가 lying — Eio context 를 *사용하지 않음*.

## 변경

`lib/coord/coord_utils_backend_setup.ml`:
- `let create_backend_eio ~sw cfg = let _ = sw in create_backend cfg` + docstring 제거
- `default_config_eio` body 내 `create_backend_eio ~sw backend_config` → `create_backend backend_config`
- `default_config_eio ~sw` API surface 보존 (외부 caller 영향 회피), 내부에서 `let _ = sw in` 으로 binding 유지

`lib/coord/coord_utils_backend_setup.mli`:
- `val create_backend_eio` 제거

## 변경 파일 (2 파일, +2 / −7, **net −5 LoC**)

## 5-prong dead-export audit

`create_backend_eio`:

| Path | Result |
|------|--------|
| 1. Direct `Coord_utils_backend_setup.create_backend_eio` / `Coord_utils.create_backend_eio` qualified | 0 hit |
| 2. Module alias | 0 hit |
| 3. Re-export `let create_backend_eio = ...` (다른 ml) | 0 hit |
| 4. `include Coord_utils_backend_setup` (in `coord_utils.ml`/`coord_utils.mli`) | facade *존재* |
| 5. Facade-경유 `Coord_utils.create_backend_eio` | 0 hit |
| 6. `open Coord_utils_backend_setup` | 0 hit |
| 7. bare 'create_backend_eio' catch-all | def + mli + 1 internal callsite 외 0 |

Defensive witness check: docstring 이 "Create backend with Eio context" 만 진술, compile-time invariant maintenance 선언 없음 → 안전.

## Behavior parity

| Call | Before | After |
|------|--------|-------|
| `create_backend_eio ~sw cfg` | `let _ = sw in create_backend cfg` (sw 무시) | (제거됨, callsite 가 `create_backend cfg` 직접 호출) |
| `default_config_eio ~sw` | sw 를 `create_backend_eio` 에 forward | `let _ = sw in ...` (sw 어차피 unused) |
| `default_config_eio ~sw` 외부 API | `sw:Eio.Switch.t -> ... -> config` | 동일 (mcp_server.ml 영향 0) |

## 로컬 검증

```
$ dune build --root . lib/  # clean
$ dune exec --root . test/test_coord_bootstrap.exe
test_coord_bootstrap: all assertions passed
$ rg "create_backend_eio" lib/ test/
(empty — 완전 제거)
```

## 관련

- 같은 spirit 의 이전 loop iter PR 들 (8 anti-pattern 카탈로그):
  - #18122 — 함수 이름이 인자에 거짓말 (`oas_timeout_for_estimated_input_tokens`)
  - #18125 — body 가 `()` no-op (`observe_legacy_release`)
  - #18130 — placeholder type chain (`t/create/default`)
  - #18135 — mli-exposed dead no-op (`init` outlier)
  - #18139 — always-false body (`is_pg_backend`)
  - #18144 — literal-wrapper (`default_keeper_model_label` → `"runtime"`)
  - #18155 — always-None + cascade (`resolved_context_budget_of_meta`)
  - 본 PR — fake-parameter wrapper (sw passed-and-discarded)
- 작업 출처: `/loop 10m 가짜 구현이나 억지로 되게끔만 만든 구현 숙청, 및 레거시 개념 제거`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>