### PR TITLE
refactor(cascade_http_probe): drop fake `?now` parameter from `parse_response`

### DIFF
--- a/lib/cascade/cascade_http_probe.ml
+++ b/lib/cascade/cascade_http_probe.ml
@@ -84,8 +84,7 @@ let store_capacity ~url ~capacity ~now =
    [OLLAMA_NUM_PARALLEL=1] (the ollama default).  Users running
    parallel mode can override [total] via the optional argument
    so [process_available] is still meaningful. *)
-let parse_response ?(total = 1) ?now json =
-  let _ = now in
+let parse_response ?(total = 1) json =
   let open Yojson.Safe.Util in
   match json with
   | `Assoc _ ->
@@ -182,7 +181,7 @@ let try_probe ~sw ~net:_ ?clock ?timeout_s ?now url =
     in
     (match parsed with
      | Ok json ->
-       (match parse_response ~now json with
+       (match parse_response json with
         | None -> None
         | Some cap ->
           store_capacity ~url ~capacity:cap ~now;

--- a/lib/cascade/cascade_http_probe.mli
+++ b/lib/cascade/cascade_http_probe.mli
@@ -105,9 +105,9 @@ val refresh_many
 
 (** {1 Pure JSON parser (test surface)} *)
 
-(** [parse_response ?total ?now json] interprets an ollama
-    [/api/ps] response.  Returns [Some info] when [json] is a JSON
-    object containing a [models] field that is a JSON array;
+(** [parse_response ?total json] interprets an ollama [/api/ps]
+    response.  Returns [Some info] when [json] is a JSON object
+    containing a [models] field that is a JSON array;
     [process_active] is set to the array length and
     [process_available] is [total - process_active] (clamped at
     zero).  [total] defaults to [1] (matches [OLLAMA_NUM_PARALLEL=1],
@@ -118,7 +118,6 @@ val refresh_many
     spinning up an HTTP server. *)
 val parse_response
   :  ?total:int
-  -> ?now:float
   -> Yojson.Safe.t
   -> Cascade_throttle.capacity_info option
 


### PR DESCRIPTION
## 목표

`parse_response ?(total = 1) ?now json` 의 `?now` 가 함수 body 첫 줄 `let _ = now in` 으로 명시적으로 버려짐. 1 production caller 가 `~now` 를 전달 하나 동작 영향 0. test suite 의 6 callsite 는 `?now` 전혀 안 씀.

## 자가 증거

pre-PR (`lib/cascade/cascade_http_probe.ml:87-88`):
```ocaml
let parse_response ?(total = 1) ?now json =
  let _ = now in
  let open Yojson.Safe.Util in
  ...
```

원본 작성 의도 추정: future "freshness-aware parsing" placeholder. CLAUDE.md `software-development.md` §"Don't design for hypothetical future requirements" 위반.

## 변경

`lib/cascade/cascade_http_probe.ml`:
- `let parse_response ?(total = 1) ?now json = let _ = now in ...` → `let parse_response ?(total = 1) json = ...`
- 단일 caller (line 185) 의 `parse_response ~now json` → `parse_response json`

`lib/cascade/cascade_http_probe.mli`:
- `val parse_response : ?total:int -> ?now:float -> ...` → `?total:int -> ...` 만
- docstring `parse_response ?total ?now json` → `parse_response ?total json`

## 변경 파일 (2 파일, +1 / −4, **net −3 LoC**)

## Behavior parity

- production caller (line 185 `parse_response ~now json`) 가 `~now` 전달하던 것을 body 가 `let _ = now in` 으로 즉시 버렸으므로 → caller 측 인자 제거 후 byte-identical
- test caller 6개 모두 `?now` 전달 안 함 → 영향 0

## 5-prong audit

- `parse_response` qualified callers: 1 production (`lib/cascade/cascade_http_probe.ml:185`) + 6 test (모두 `?now` 미사용)
- module alias / include / open: 없음 (`Cascade_http_probe.parse_response` 로 사용)
- bare-name catch-all: def + ml caller + mli + test 외 0
- defensive witness: docstring 이 동작만 진술, compile-time invariant 선언 없음

## 로컬 검증

```
$ dune build --root . lib/  # clean
$ dune exec --root . test/test_cascade_http_probe.exe
Test Successful in 0.001s. 12 tests run.
$ rg "parse_response.*~now" lib/ test/
(empty — 완전 제거)
```

## 후속 (별도 PR 후보, 본 PR scope 외)

`try_probe ~sw ~net:_ ?clock ?timeout_s ?now url` (같은 파일 line 127) 도 유사한 fake-parameter 패턴 (`let _ = sw in`). 3 internal callers + cascading `~sw` chain (`refresh_many`, `cached_capacity`) 가 있어 scope 분리. 별도 iter / 후속 PR.

## 관련

- `software-development.md` §"Don't design for hypothetical future requirements"
- 같은 spirit 의 이전 loop iter PR 들 (9 anti-pattern 카탈로그):
  - #18122 — 함수 이름이 인자에 거짓 (function-name-lying)
  - #18125 — body 가 `()` no-op
  - #18130 — placeholder type chain
  - #18135 — dead no-op mli export
  - #18139 — always-false body
  - #18144 — literal-wrapper
  - #18155 — always-None + cascade simplification
  - #18159 — fake-parameter wrapper (`~sw` discarded)
  - 본 PR — fake-**optional**-parameter (`?now` declared then discarded)
- 작업 출처: `/loop 10m 가짜 구현이나 억지로 되게끔만 만든 구현 숙청, 및 레거시 개념 제거`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>