### PR TITLE
fix(test): String value extraction in process_status_to_json (PR #18073 follow-up)

### DIFF
--- a/test/test_keeper_shell_ops.ml
+++ b/test/test_keeper_shell_ops.ml
@@ -17,7 +17,7 @@ open Masc_mcp
 
 (* ---- lines_to_json ------------------------------------------------ *)
 
-let yojson_t = Alcotest.testable (Yojson.Safe.pp ~std:false) ( = )
+let yojson_t = Alcotest.testable (Yojson.Safe.pretty_print ~std:false) ( = )
 
 let test_lines_to_json_empty () =
   let json = Keeper_exec_shared.lines_to_json "" in
@@ -49,10 +49,10 @@ let test_lines_to_json_limit_truncates () =
          (String.starts_with ~prefix:"...[2 more lines omitted" s)
      | other ->
        Alcotest.failf "expected omission string, got %a"
-         (Yojson.Safe.pp ~std:false)
+         (Yojson.Safe.pretty_print ~std:false)
          other)
   | other ->
-    Alcotest.failf "expected `List, got %a" (Yojson.Safe.pp ~std:false) other
+    Alcotest.failf "expected `List, got %a" (Yojson.Safe.pretty_print ~std:false) other
 
 let test_lines_to_json_byte_budget () =
   (* 1000-byte max_bytes with long lines should trigger truncation. *)
@@ -70,7 +70,7 @@ let test_lines_to_json_byte_budget () =
          (String.starts_with ~prefix:"...[" s)
      | _ -> Alcotest.fail "expected omission string")
   | other ->
-    Alcotest.failf "expected `List, got %a" (Yojson.Safe.pp ~std:false) other
+    Alcotest.failf "expected `List, got %a" (Yojson.Safe.pretty_print ~std:false) other
 
 (* ---- process_status_to_json --------------------------------------- *)
 
@@ -84,9 +84,9 @@ let test_process_status_exited_zero () =
     Alcotest.(check (option int)) "code = 0"
       (Some 0)
       (List.assoc_opt "code" fields
-       |> Option.bind (function `Int i -> Some i | _ -> None))
+       |> fun opt -> Option.bind opt (function `Int i -> Some i | _ -> None))
   | other ->
-    Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pp ~std:false) other
+    Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pretty_print ~std:false) other
 
 let test_process_status_exited_nonzero () =
   let json = Keeper_alerting_path.process_status_to_json (Unix.WEXITED 2) in
@@ -95,9 +95,9 @@ let test_process_status_exited_nonzero () =
     Alcotest.(check (option int)) "code = 2"
       (Some 2)
       (List.assoc_opt "code" fields
-       |> Option.bind (function `Int i -> Some i | _ -> None))
+       |> fun opt -> Option.bind opt (function `Int i -> Some i | _ -> None))
   | other ->
-    Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pp ~std:false) other
+    Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pretty_print ~std:false) other
 
 let test_process_status_timeout () =
   (* Exit code 124 is the Eio timeout convention. *)
@@ -108,7 +108,7 @@ let test_process_status_timeout () =
       (Some "timeout")
       (List.assoc_opt "kind" fields |> Option.map Yojson.Safe.to_string)
   | other ->
-    Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pp ~std:false) other
+    Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pretty_print ~std:false) other
 
 let test_process_status_signaled () =
   let json = Keeper_alerting_path.process_status_to_json (Unix.WSIGNALED Sys.sigkill) in
@@ -118,7 +118,7 @@ let test_process_status_signaled () =
       (Some "signaled")
       (List.assoc_opt "kind" fields |> Option.map Yojson.Safe.to_string)
   | other ->
-    Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pp ~std:false) other
+    Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pretty_print ~std:false) other
 
 (* ---- JSON envelope shape contract --------------------------------- *)
 
@@ -131,14 +131,14 @@ let yojson_string_field name json =
   match json with
   | `Assoc fields ->
     List.assoc_opt name fields
-    |> Option.bind (function `String s -> Some s | _ -> None)
+    |> fun opt -> Option.bind opt (function `String s -> Some s | _ -> None)
   | _ -> None
 
 let yojson_bool_field name json =
   match json with
   | `Assoc fields ->
     List.assoc_opt name fields
-    |> Option.bind (function `Bool b -> Some b | _ -> None)
+    |> fun opt -> Option.bind opt (function `Bool b -> Some b | _ -> None)
   | _ -> None
 
 let test_p10_host_envelope_shape () =

--- a/test/test_keeper_shell_ops.ml
+++ b/test/test_keeper_shell_ops.ml
@@ -80,7 +80,8 @@ let test_process_status_exited_zero () =
   | `Assoc fields ->
     Alcotest.(check (option string)) "kind = exit"
       (Some "exit")
-      (List.assoc_opt "kind" fields |> Option.map Yojson.Safe.to_string);
+      (List.assoc_opt "kind" fields
+       |> fun opt -> Option.bind opt (function `String s -> Some s | _ -> None));
     Alcotest.(check (option int)) "code = 0"
       (Some 0)
       (List.assoc_opt "code" fields
@@ -106,7 +107,8 @@ let test_process_status_timeout () =
   | `Assoc fields ->
     Alcotest.(check (option string)) "kind = timeout"
       (Some "timeout")
-      (List.assoc_opt "kind" fields |> Option.map Yojson.Safe.to_string)
+      (List.assoc_opt "kind" fields
+       |> fun opt -> Option.bind opt (function `String s -> Some s | _ -> None))
   | other ->
     Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pretty_print ~std:false) other
 
@@ -116,7 +118,8 @@ let test_process_status_signaled () =
   | `Assoc fields ->
     Alcotest.(check (option string)) "kind = signaled"
       (Some "signaled")
-      (List.assoc_opt "kind" fields |> Option.map Yojson.Safe.to_string)
+      (List.assoc_opt "kind" fields
+       |> fun opt -> Option.bind opt (function `String s -> Some s | _ -> None))
   | other ->
     Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pretty_print ~std:false) other
 


### PR DESCRIPTION
## Summary

PR #18073 의 \`test_keeper_shell_ops.ml\` 3 사이트가 \`Yojson.Safe.t\` 의 \`String\` 값 추출에 잘못된 API 사용:

\`\`\`ocaml
List.assoc_opt "kind" fields |> Option.map Yojson.Safe.to_string
\`\`\`

\`Yojson.Safe.to_string\` 는 **JSON 직렬화** 형식 반환 — \`\`\`String "exit"\`\`\` 를 받으면 \`"\"exit\""\` (따옴표 포함) 출력. Alcotest assertion \`Some "exit"\` 와 mismatch → 3 fail.

## Sites

| Line | Field | Assertion |
|---|---|---|
| 83 | "kind" | \`Some "exit"\` |
| 109 | "kind" | \`Some "timeout"\` |
| 119 | "kind" | \`Some "signaled"\` |

## Correct pattern

같은 파일 line 137 (\`yojson_string_field\`) 이 이미 정답 패턴 사용:

\`\`\`ocaml
... |> fun opt -> Option.bind opt (function \`String s -> Some s | _ -> None)
\`\`\`

세 사이트도 동일하게 변경 — constructor pattern match로 raw 값 추출.

## Same root cause family

PR #18073 의 typed-API 혼동 4 카테고리:

1. \`Yojson.Safe.pp ~std:false\` → \`pretty_print ~std:false\` (PR #18152)
2. \`Option.bind\` 인자 순서 (PR #18152)
3. \`Option.map Yojson.Safe.to_string\` → \`Option.bind ... (function \`String _)\` ← **본 PR**
4. \`lines_to_json:4\` \`< 4\` count assertion typo (별개)

모두 동일 CI skip masking — \`Build and Test\` job이 \`Detect Changed Surfaces\` gate 뒤 SKIPPED. memory \`reference_masc_mcp_ci_build_test_skips\`.

## Verification

PR #18152 (compile fix) 적용 후 본 PR:

\`\`\`
dune build --root . test/test_keeper_shell_ops.exe  →  EXIT=0
dune runtest                                         →  9/11 PASS
  process_status_to_json:0,1,2,3  →  PASS  (was 3/4 FAIL)
  lines_to_json:3                 →  FAIL  (lib fix in PR #18156)
  lines_to_json:4                 →  FAIL  (test count typo, separate PR)
\`\`\`

## Stack

본 PR base = \`fix/keeper-shell-ops-test-yojson-option-bind\` (PR #18152). PR #18152 머지 후 자동 rebase.

## Diff

+6 / -3 LoC.

WORKAROUND-FREE: typed-API 정합. compat shim 없음.

RFC-WAIVED: PR #18073 직접 typo fix family 의 3번째.

🤖 Generated with [Claude Code](https://claude.com/claude-code)