### PR TITLE
test(keeper_gh_parser_contract): split must_ok_cmd helper for typed risk-class tests

### DIFF
--- a/test/test_keeper_gh_parser_contract.ml
+++ b/test/test_keeper_gh_parser_contract.ml
@@ -55,6 +55,15 @@ let must_ok_argv label = function
   | Error e ->
     Alcotest.failf "%s: expected Ok, got Error %a" label parse_error_pp e
 
+(* Companion to [must_ok_argv]: returns the parsed gh_simple_command
+   directly (not its argv projection) so callers like the risk-class
+   tests can pass it into [gh_simple_command_risk_class] which expects
+   the typed command, not the string list. *)
+let must_ok_cmd label = function
+  | Ok cmd -> cmd
+  | Error e ->
+    Alcotest.failf "%s: expected Ok, got Error %a" label parse_error_pp e
+
 (* ---- parse_simple_gh_command ------------------------------------ *)
 
 let test_parse_empty () =
@@ -274,20 +283,20 @@ let test_render_round_trip_simple () =
 let risk_t = Alcotest.testable Masc_exec.Shell_ir_risk.pp_risk_class ( = )
 
 let test_risk_class_read_only () =
-  let cmd = must_ok_argv "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
+  let cmd = must_ok_cmd "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
   Alcotest.check risk_t "pr list is R0_Read"
     Masc_exec.Shell_ir_risk.R0_Read
     (Gh.gh_simple_command_risk_class cmd)
 
 let test_risk_class_api_get () =
-  let cmd = must_ok_argv "api repos" (Gh.gh_simple_command_of_argv [ "api"; "repos" ]) in
+  let cmd = must_ok_cmd "api repos" (Gh.gh_simple_command_of_argv [ "api"; "repos" ]) in
   Alcotest.check risk_t "api without method is GET -> R0_Read"
     Masc_exec.Shell_ir_risk.R0_Read
     (Gh.gh_simple_command_risk_class cmd)
 
 let test_risk_class_reversible_mutation () =
   let cmd =
-    must_ok_argv "pr create" (Gh.gh_simple_command_of_argv [ "pr"; "create" ])
+    must_ok_cmd"pr create" (Gh.gh_simple_command_of_argv [ "pr"; "create" ])
   in
   Alcotest.check risk_t "pr create is R1_Reversible_mutation"
     Masc_exec.Shell_ir_risk.R1_Reversible_mutation
@@ -295,7 +304,7 @@ let test_risk_class_reversible_mutation () =
 
 let test_risk_class_api_post () =
   let cmd =
-    must_ok_argv "api POST"
+    must_ok_cmd"api POST"
       (Gh.gh_simple_command_of_argv [ "api"; "--method=POST"; "repos" ])
   in
   Alcotest.check risk_t "api POST is R1_Reversible_mutation"
@@ -304,7 +313,7 @@ let test_risk_class_api_post () =
 
 let test_risk_class_api_graphql () =
   let cmd =
-    must_ok_argv "api graphql"
+    must_ok_cmd"api graphql"
       (Gh.gh_simple_command_of_argv [ "api"; "graphql" ])
   in
   Alcotest.check risk_t "api graphql is R1_Reversible_mutation"
@@ -313,7 +322,7 @@ let test_risk_class_api_graphql () =
 
 let test_risk_class_irreversible () =
   let cmd =
-    must_ok_argv "repo delete" (Gh.gh_simple_command_of_argv [ "repo"; "delete" ])
+    must_ok_cmd"repo delete" (Gh.gh_simple_command_of_argv [ "repo"; "delete" ])
   in
   Alcotest.check risk_t "repo delete is R2_Irreversible"
     Masc_exec.Shell_ir_risk.R2_Irreversible
@@ -321,7 +330,7 @@ let test_risk_class_irreversible () =
 
 let test_risk_class_api_delete () =
   let cmd =
-    must_ok_argv "api DELETE"
+    must_ok_cmd"api DELETE"
       (Gh.gh_simple_command_of_argv [ "api"; "--method=DELETE"; "repos" ])
   in
   Alcotest.check risk_t "api DELETE is R2_Irreversible"
@@ -331,7 +340,7 @@ let test_risk_class_api_delete () =
 (* ---- gh_simple_command_to_shell_ir (RFC-0160 S2) ---------------- *)
 
 let test_to_shell_ir_bin_is_gh () =
-  let cmd = must_ok_argv "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
+  let cmd = must_ok_cmd "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
   match Gh.gh_simple_command_to_shell_ir cmd with
   | Masc_exec.Shell_ir.Simple s ->
     Alcotest.(check bool) "bin is Gh" true
@@ -340,7 +349,7 @@ let test_to_shell_ir_bin_is_gh () =
     Alcotest.fail "expected Simple, got Pipeline"
 
 let test_to_shell_ir_args_are_lit () =
-  let cmd = must_ok_argv "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
+  let cmd = must_ok_cmd "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
   match Gh.gh_simple_command_to_shell_ir cmd with
   | Masc_exec.Shell_ir.Simple s ->
     let texts =
@@ -355,17 +364,22 @@ let test_to_shell_ir_args_are_lit () =
     Alcotest.fail "expected Simple, got Pipeline"
 
 let test_to_shell_ir_sandbox_passthrough () =
-  let cmd = must_ok_argv "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
-  let docker = Masc_exec.Sandbox_target.host () in
-  match Gh.gh_simple_command_to_shell_ir ~sandbox:docker cmd with
+  let cmd = must_ok_cmd "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
+  let sandbox = Masc_exec.Sandbox_target.host () in
+  match Gh.gh_simple_command_to_shell_ir ~sandbox cmd with
   | Masc_exec.Shell_ir.Simple s ->
-    Alcotest.(check bool) "sandbox passed through" true
-      (Masc_exec.Sandbox_target.equal s.sandbox docker)
+    (* Sandbox_target.t carries function closures in its Docker variant,
+       so it has no structural [equal]. For the Host case (this test's
+       passthrough fixture) the constructor shape is enough. *)
+    Alcotest.(check bool) "Host sandbox passed through" true
+      (match s.sandbox with
+       | Masc_exec.Sandbox_target.Host -> true
+       | Masc_exec.Sandbox_target.Docker _ -> false)
   | Masc_exec.Shell_ir.Pipeline _ ->
     Alcotest.fail "expected Simple, got Pipeline"
 
 let test_to_shell_ir_cwd_passthrough () =
-  let cmd = must_ok_argv "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
+  let cmd = must_ok_cmd "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
   match Gh.gh_simple_command_to_shell_ir ~cwd:"/tmp" cmd with
   | Masc_exec.Shell_ir.Simple s ->
     (match s.cwd with
@@ -375,7 +389,7 @@ let test_to_shell_ir_cwd_passthrough () =
     Alcotest.fail "expected Simple, got Pipeline"
 
 let test_to_shell_ir_env_empty () =
-  let cmd = must_ok_argv "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
+  let cmd = must_ok_cmd "pr list" (Gh.gh_simple_command_of_argv [ "pr"; "list" ]) in
   match Gh.gh_simple_command_to_shell_ir cmd with
   | Masc_exec.Shell_ir.Simple s ->
     Alcotest.(check int) "env is empty" 0 (List.length s.env)


### PR DESCRIPTION
## 목적

\`test_keeper_gh_parser_contract.ml\` 의 \`must_ok_argv\` 헬퍼가 *argv projection* (string list) 반환 — 7개 risk_class 테스트가 그 결과를 *parsed gh_simple_command* 자리에 전달하면서 type mismatch 발생. 함수 자체는 살아있음 (1 production caller in \`keeper_shell_ops:1482\`).

## 진단 (audit-dead-export.sh v2)

\`\`\`
$ bash scripts/audit-dead-export.sh gh_simple_command_risk_class
  defining sites:      2
  production callers:  1
  test callers:        7
  RESULT: production callers exist — do NOT remove. Migrate callers first.
  exit: 2
\`\`\`

도구가 정확히 \"do NOT remove\" 라고 분류 — 함수는 살아있고, *test side에 fix가 필요*. \`must_ok_argv\` 의 argv projection이 잘못된 helper 선택이었음.

## 변경

### \`must_ok_cmd\` sibling helper 추가

\`\`\`ocaml
(* Companion to [must_ok_argv]: returns the parsed gh_simple_command
   directly (not its argv projection) so callers like the risk-class
   tests can pass it into [gh_simple_command_risk_class] which expects
   the typed command, not the string list. *)
let must_ok_cmd label = function
  | Ok cmd -> cmd
  | Error e -> Alcotest.failf \"%s: expected Ok, got Error %a\" label parse_error_pp e
\`\`\`

기존 \`must_ok_argv\` 는 parse / round-trip 테스트용 (argv 형태 비교) 으로 보존.

### 10 사이트 helper 교체

risk_class + shell_ir_passthrough 테스트의 \`let cmd = must_ok_argv ...\` → \`must_ok_cmd ...\` (single-line 7 + multi-line 3).

### \`Sandbox_target.equal\` orphan 정정

\`test_to_shell_ir_sandbox_passthrough\` 가 \`Sandbox_target.equal\` 호출 — mli에 없음. \`Sandbox_target.t\` 의 \`Docker\` variant에 *function closure* 가 들어있어서 structural equal 불가능 (설계 의도). \`Host\` / \`Docker _\` 생성자 shape match로 교체.

## 검증

\`\`\`
dune exec test/test_keeper_gh_parser_contract.exe → 34/34 pass
\`\`\`

## 분류 매트릭스 — 8번째 row

| 케이스 | mli 역할 | 정의 | Prod | Test | 결정 |
|---|---|---|---|---|---|
| ... 7 existing rows ... | ... | ... | ... | ... | ... |
| **production-fine, test-bug** (iter 11) | (정상) | > 0 | > 0 | mismatch | **test side만 fix, surface 미변경** |

도구가 exit 2 (production callers exist)를 정확히 진단했지만, 결과 메시지가 \"do NOT remove\" 에만 집중. *실제 fix는 caller side에 있는데* test helper 선택 오류 같은 경우 도구 메시지가 명시화하지 않음 — v3 enhancement 후보 (\"exit 2 시 test 통과 실패 여부도 함께 보고\").