### PR TITLE
fix(dashboard_yjs): restore frame_update mli export (false-dead from #17967)

### DIFF
--- a/lib/dashboard/dashboard_yjs.mli
+++ b/lib/dashboard/dashboard_yjs.mli
@@ -1,6 +1,13 @@
 (** Dashboard_yjs — Yjs WebSocket Projection Layer for Live Telemetry
     @since Project World Building (Big Bang) *)
 
+val frame_update : string -> string
+(** [frame_update payload] wraps [payload] in the binary Yjs
+    update-message envelope: a 2-byte type header followed by a
+    varint-encoded length prefix and the raw payload bytes. Exposed
+    for [test_dashboard_yjs], which round-trips the frame encoding
+    independently of the broadcast pipeline. *)
+
 (** [broadcast_keeper_telemetry ~keeper_name ~trace_id ~turn_index ~model_id]
     publishes a keeper Yjs telemetry update to dashboard observer sessions.
     [model_id] is accepted for legacy call sites but redacted to the neutral


### PR DESCRIPTION
PR #17967 removed four values from dashboard_yjs.mli as 'dead exports'. Three (encode_uint, broadcast_update, broadcast_trace_telemetry) had zero external callers and remain hidden — legitimately dead. One, frame_update, is used by test/test_dashboard_yjs.ml:7 to round-trip the binary Yjs envelope encoding independently of the broadcast pipeline. The dead-export audit missed the paired-test-file prong of the 5-prong audit pattern. Restore the .mli export with a docstring documenting why the symbol is public (test surface). Cluster A of the broader RFC-0164 + dead-export-sweep main breakage — one of ~20 unique OCaml compile errors currently blocking the main Health/Build job. Per draft-auto-merge guard, stays Draft.