### PR TITLE
refactor(dashboard_cascade_audit_runs): inline `"runtime"` literal for `model_display_of_attempt`

### DIFF
--- a/lib/dashboard_cascade_audit_runs.ml
+++ b/lib/dashboard_cascade_audit_runs.ml
@@ -58,11 +58,6 @@ let stable_audit_run_id json =
   ^ String.sub (Digest.to_hex (Digest.string (Yojson.Safe.to_string json))) 0 16
 ;;
 
-let model_display_of_attempt attempt =
-  let _ = attempt in
-  "runtime"
-;;
-
 let fallback_reason_for_model ~model_id ~model_label fallback_events =
   let _ = model_id, model_label in
   match fallback_events with
@@ -73,7 +68,7 @@ let fallback_reason_for_model ~model_id ~model_label fallback_events =
 let audit_hop_json ~selected_model ~fallback_events attempt =
   let model_id = json_string_opt_member "model_id" attempt in
   let model_label = json_string_opt_member "model_label" attempt in
-  let model = model_display_of_attempt attempt in
+  let model = "runtime" in
   let latency_ms = json_int_member "latency_ms" attempt in
   let error = json_string_opt_member "error" attempt in
   let reason =


### PR DESCRIPTION
## 목표

`model_display_of_attempt attempt = let _ = attempt in "runtime"` 가 직전 PR #18144 (`tool_keeper.default_keeper_model_label`) 와 정확히 동일 패턴:
- 함수 이름이 *attempt-dependent label* 시사
- body 가 `attempt` 를 `let _ = attempt in` 으로 명시적으로 버림
- 항상 literal `"runtime"` 반환

## 자가 증거

pre-PR (`lib/dashboard_cascade_audit_runs.ml:61-64`):
```ocaml
let model_display_of_attempt attempt =
  let _ = attempt in
  "runtime"
;;
```

`~/me/memory/audit-deep-dive-2026-05-22.html` 의 `"runtime"` literal 잠금 사이트 중 하나로 이미 분류됨.

## 변경

`lib/dashboard_cascade_audit_runs.ml`:
- `let model_display_of_attempt attempt = let _ = attempt in "runtime" ;;` 정의 제거
- callsite (line 76) `let model = model_display_of_attempt attempt in` → `let model = "runtime" in`

## 변경 파일 (1 파일, +1 / −6, **net −5 LoC**)

## 5-prong audit

- mli 없음 (purely .ml)
- module facade: `lib/dashboard_cascade.ml:include Dashboard_cascade_audit_runs` 존재 — 그러나 `Dashboard_cascade.model_display_of_attempt` qualified callers 0, facade 경유 bare-name 도 0
- bare-name catch-all `model_display_of_attempt`: def + 1 internal callsite 외 0
- defensive witness: 없음

## Behavior parity

`model_display_of_attempt attempt` 가 항상 `"runtime"` 반환 → callsite 인라인 후 byte-identical. `attempt` 변수는 `audit_hop_json` 의 다른 곳 (line 74-78 `json_*_member` 호출들) 에서 여전히 사용 — binding 보존.

## 로컬 검증

```
$ dune build --root . lib/  # clean
$ rg "model_display_of_attempt" lib/ test/
(empty — 완전 제거)
```

## 미해결 (별도 PR / 후속 후보)

같은 파일 `dashboard_cascade_audit_runs.ml` 에 다른 fake 사이트들:

1. **`fallback_reason_for_model ~model_id ~model_label fallback_events`** (line 67) — `~model_id ~model_label` 둘 다 `let _ = model_id, model_label in` 으로 버림. fake-parameter-pair.

2. **`let selected = let _ = selected_model in false in ...`** (line 85, `audit_hop_json` 내부) — `selected_model` 를 명시적으로 버리고 항상 `false`. `audit-deep-dive-2026-05-22.html` 에서 `selected = (model = selected_model)` 가 정답이라고 식별됨. **이건 behavior bug 가능성** — `status = "success"` 분기가 dead 됨. 별도 RFC / fix PR 후보 (사용자 review 필요).

## 관련

- `~/me/memory/audit-deep-dive-2026-05-22.html` (`"runtime"` literal 잠금 패턴)
- 직전 #18144 (`default_keeper_model_label` → `"runtime"` 인라인, 동일 패턴)
- 누적 10 anti-pattern iter (각각 다른 axis 또는 같은 axis 의 다른 사이트):
  - #18122 — function-name-lying (OAS timeout)
  - #18125 — body `()` no-op (`observe_legacy_release`)
  - #18130 — placeholder type chain (`t/create/default`)
  - #18135 — dead mli no-op (`init` outlier)
  - #18139 — always-false body (`is_pg_backend`)
  - #18144 — literal-wrapper `"runtime"` (`default_keeper_model_label`, tool_keeper)
  - #18155 — always-None + cascade simplification
  - #18159 — fake positional parameter (`~sw` discarded)
  - #18160 — fake optional parameter (`?now` discarded)
  - 본 PR — literal-wrapper `"runtime"` (`model_display_of_attempt`, dashboard, 같은 axis 2nd 사이트)
- 작업 출처: `/loop 10m 가짜 구현이나 억지로 되게끔만 만든 구현 숙청, 및 레거시 개념 제거`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>