### PR TITLE
fix(test): correct lines_to_json:4 byte-budget item count assertion (PR #18073 family 4/4)

### DIFF
--- a/test/test_keeper_shell_ops.ml
+++ b/test/test_keeper_shell_ops.ml
@@ -17,7 +17,7 @@ open Masc_mcp
 
 (* ---- lines_to_json ------------------------------------------------ *)
 
-let yojson_t = Alcotest.testable (Yojson.Safe.pp ~std:false) ( = )
+let yojson_t = Alcotest.testable (Yojson.Safe.pretty_print ~std:false) ( = )
 
 let test_lines_to_json_empty () =
   let json = Keeper_exec_shared.lines_to_json "" in
@@ -49,10 +49,10 @@ let test_lines_to_json_limit_truncates () =
          (String.starts_with ~prefix:"...[2 more lines omitted" s)
      | other ->
        Alcotest.failf "expected omission string, got %a"
-         (Yojson.Safe.pp ~std:false)
+         (Yojson.Safe.pretty_print ~std:false)
          other)
   | other ->
-    Alcotest.failf "expected `List, got %a" (Yojson.Safe.pp ~std:false) other
+    Alcotest.failf "expected `List, got %a" (Yojson.Safe.pretty_print ~std:false) other
 
 let test_lines_to_json_byte_budget () =
   (* 1000-byte max_bytes with long lines should trigger truncation. *)
@@ -70,7 +70,7 @@ let test_lines_to_json_byte_budget () =
          (String.starts_with ~prefix:"...[" s)
      | _ -> Alcotest.fail "expected omission string")
   | other ->
-    Alcotest.failf "expected `List, got %a" (Yojson.Safe.pp ~std:false) other
+    Alcotest.failf "expected `List, got %a" (Yojson.Safe.pretty_print ~std:false) other
 
 (* ---- process_status_to_json --------------------------------------- *)
 
@@ -84,9 +84,9 @@ let test_process_status_exited_zero () =
     Alcotest.(check (option int)) "code = 0"
       (Some 0)
       (List.assoc_opt "code" fields
-       |> Option.bind (function `Int i -> Some i | _ -> None))
+       |> fun opt -> Option.bind opt (function `Int i -> Some i | _ -> None))
   | other ->
-    Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pp ~std:false) other
+    Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pretty_print ~std:false) other
 
 let test_process_status_exited_nonzero () =
   let json = Keeper_alerting_path.process_status_to_json (Unix.WEXITED 2) in
@@ -95,9 +95,9 @@ let test_process_status_exited_nonzero () =
     Alcotest.(check (option int)) "code = 2"
       (Some 2)
       (List.assoc_opt "code" fields
-       |> Option.bind (function `Int i -> Some i | _ -> None))
+       |> fun opt -> Option.bind opt (function `Int i -> Some i | _ -> None))
   | other ->
-    Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pp ~std:false) other
+    Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pretty_print ~std:false) other
 
 let test_process_status_timeout () =
   (* Exit code 124 is the Eio timeout convention. *)
@@ -108,7 +108,7 @@ let test_process_status_timeout () =
       (Some "timeout")
       (List.assoc_opt "kind" fields |> Option.map Yojson.Safe.to_string)
   | other ->
-    Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pp ~std:false) other
+    Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pretty_print ~std:false) other
 
 let test_process_status_signaled () =
   let json = Keeper_alerting_path.process_status_to_json (Unix.WSIGNALED Sys.sigkill) in
@@ -118,7 +118,7 @@ let test_process_status_signaled () =
       (Some "signaled")
       (List.assoc_opt "kind" fields |> Option.map Yojson.Safe.to_string)
   | other ->
-    Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pp ~std:false) other
+    Alcotest.failf "expected `Assoc, got %a" (Yojson.Safe.pretty_print ~std:false) other
 
 (* ---- JSON envelope shape contract --------------------------------- *)
 
@@ -131,14 +131,14 @@ let yojson_string_field name json =
   match json with
   | `Assoc fields ->
     List.assoc_opt name fields
-    |> Option.bind (function `String s -> Some s | _ -> None)
+    |> fun opt -> Option.bind opt (function `String s -> Some s | _ -> None)
   | _ -> None
 
 let yojson_bool_field name json =
   match json with
   | `Assoc fields ->
     List.assoc_opt name fields
-    |> Option.bind (function `Bool b -> Some b | _ -> None)
+    |> fun opt -> Option.bind opt (function `Bool b -> Some b | _ -> None)
   | _ -> None
 
 let test_p10_host_envelope_shape () =

--- a/test/test_keeper_shell_ops.ml
+++ b/test/test_keeper_shell_ops.ml
@@ -61,9 +61,14 @@ let test_lines_to_json_byte_budget () =
   let json = Keeper_exec_shared.lines_to_json ~max_bytes:1_000 text in
   match json with
   | `List items ->
-    (* At least one line kept, but not all 4 because 4 × (300 + 4) > 1000 *)
-    Alcotest.(check bool) "byte budget truncates" true (List.length items < 4);
-    (* Last element is an omission marker *)
+    (* 3 lines (912 bytes) fit + 1 omission marker = 4 items; the
+       original 4th 304-byte line tips the budget over 1000 and is
+       replaced by the marker.  The truncation invariant is the
+       marker's presence on the tail, not the item count: marker +
+       N kept yields the same length as N+1 kept-without-marker. *)
+    Alcotest.(check bool) "at least one line kept alongside marker" true
+      (List.length items >= 2);
+    (* Last element is an omission marker — the real truncation evidence. *)
     (match List.rev items |> List.hd with
      | `String s ->
        Alcotest.(check bool) "last item is omission marker" true


### PR DESCRIPTION
## Summary

\`test_lines_to_json_byte_budget\` 의 count assertion 이 marker 와 lines 를 혼동:

\`\`\`ocaml
Alcotest.(check bool) "byte budget truncates" true (List.length items < 4);
\`\`\`

max_bytes=1000 + 4 lines × 304 bytes:
- 3 lines × 304 = 912 ≤ 1000 → accepted
- 4번째 line: 912+304=1216 > 1000 → rejected, omitted=1
- Output items: 3 lines + 1 marker = **4 items**
- Assertion \`4 < 4\` → FAIL

작가 의도 ("not all 4 lines kept") 는 정확하지만 count 검사가 *lines* vs *lines+marker* 혼동.

## Fix

count 검사를 \`>= 2\` (at least 1 line + marker) 로 relax. marker presence 검사 (line 67-71) 는 그대로 — 실제 truncation invariant.

\`\`\`diff
- (* At least one line kept, but not all 4 because 4 × (300 + 4) > 1000 *)
- Alcotest.(check bool) "byte budget truncates" true (List.length items < 4);
+ (* 3 lines (912 bytes) fit + 1 omission marker = 4 items; ... *)
+ Alcotest.(check bool) "at least one line kept alongside marker" true
+   (List.length items >= 2);
\`\`\`

## PR #18073 typed-API confusion family — 종결

이번 PR로 PR #18073 의 4 카테고리 typo 모두 해소:

| # | Category | PR |
|---|---|---|
| 1 | \`Yojson.Safe.pp ~std:false\` → \`pretty_print ~std:false\` | #18152 |
| 2 | \`Option.bind\` 인자 순서 | #18152 |
| 3 | \`Option.map Yojson.Safe.to_string\` for String value | #18161 |
| 4 | \`lines_to_json:4\` item-count assertion typo | **본 PR** |

별개: lib bug \`lines_to_json:3\` 도 PR #18156 (lib fix).

## Verification (with PR #18152 base)

\`\`\`
dune build --root . test/test_keeper_shell_ops.exe  →  EXIT=0
dune runtest                                         →  7/11 PASS
  lines_to_json:4                                    →  PASS  ← 본 PR
  lines_to_json:3                                    →  FAIL  (lib fix #18156)
  process_status_to_json:0,2,3                       →  FAIL  (stack #18161)
\`\`\`

PR #18152 + #18156 + #18161 + this 모두 머지 후 → 11/11 PASS.

## Stack

base = \`fix/keeper-shell-ops-test-yojson-option-bind\` (PR #18152). PR #18152 머지 후 자동 rebase.

## Diff

+8 / -3 LoC.

WORKAROUND-FREE: assertion 정합 + docstring 명료화.

RFC-WAIVED: PR #18073 family 마지막 카테고리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)