### PR TITLE
refactor(memory_jsonl): drop ref-accumulator in batch_persist

### DIFF
--- a/lib/memory_jsonl/memory_jsonl.ml
+++ b/lib/memory_jsonl/memory_jsonl.ml
@@ -316,16 +316,18 @@ let make_backend_with_query_observer ~on_query_result ~base_dir ~agent_name
   in
 
   let batch_persist pairs =
-    let errors = ref [] in
-    List.iter (fun (key, json) ->
-      match persist ~key json with
-      | Ok () -> ()
-      | Error msg -> errors := msg :: !errors
-    ) pairs;
-    match !errors with
+    let errs =
+      List.fold_left
+        (fun acc (key, json) ->
+          match persist ~key json with
+          | Ok () -> acc
+          | Error msg -> msg :: acc)
+        []
+        pairs
+    in
+    match errs with
     | [] -> Ok ()
-    | errs ->
-      let first_err = match errs with e :: _ -> e | [] -> "unknown" in
+    | first_err :: _ ->
       let msg = Printf.sprintf "memory_jsonl batch_persist: %d/%d failed: %s"
           (List.length errs) (List.length pairs)
           first_err in


### PR DESCRIPTION
## 목표

`lib/memory_jsonl/memory_jsonl.ml`의 local closure `batch_persist`에서 `let errors = ref []` + `List.iter` + dual match-on-bang pattern을 `List.fold_left`로 변환.

## 왜

- 8번째 same-pattern conversion.
- 부산물: 원본의 `match errs with e :: _ -> e | [] -> "unknown"`은 *partial match를 exhaustive로 만들기 위한 dead arm*. outer match가 이미 `[]` 케이스를 처리하므로 `| [] -> "unknown"`은 unreachable. 새 코드는 outer match에서 `first_err :: _` 패턴으로 직접 추출 → ghost branch 제거.

## Behavior parity

| 측면 | 원본 | 새 코드 |
|---|---|---|
| `persist ~key json` 호출 횟수/순서 | 1 per pair (List.iter) | 동일 (List.fold_left) |
| `errs` 순서 | prepend (last-emitted first) | 동일 |
| `first_err` 값 | `e :: _ -> e` of `match errs` | `first_err :: _` of outer match (같은 element) |
| Error message format | `"memory_jsonl batch_persist: %d/%d failed: %s"` | 동일 |
| Ok / Error 분기 | empty errs → Ok, else → Error | 동일 |

## 변경 파일

- `lib/memory_jsonl/memory_jsonl.ml` (+11 / −9)

## 로컬 검증

```
$ dune build --root . lib/                                              # PASS
$ dune exec --root . test/test_memory_jsonl_truncation.exe
...
Test Successful in 0.016s. 8 tests run.
```

`batch_persist`는 local closure (line 318), `make` 함수의 record field로 `Agent_sdk.Memory.batch_persist` callback hook으로 외부 노출. 직접 caller test는 없지만 lib 전체 compile + 8 indirect tests 통과.

## 누적 (8 iter)

| Iter | PR | 함수 | 변형 | 상태 |
|---|---|---|---|---|
| #1 | #18106 | server_state_product.check_invariants | prepend + List.rev | MERGED |
| #2 | #18109 | chronicle_validate.validate_epoch | prepend + List.rev | MERGED |
| #3 | #18119 | tool_control.keeper_pause_status_json | prepend × 3 + fold | Draft |
| #4 | #18131 | governance_anomaly.detect_deviations | prepend + List.rev | Draft |
| #5 | #18141 | cascade_declarative_parser.parse_toml | append `:= !x @ errs` | Draft |
| #6 | #18150 | cdal_judge.check_execution_mode | prepend + List.rev | Draft |
| #7 | #18157 | audit_log.parse_entries | counter + list + logging | Draft |
| #8 | (this) | memory_jsonl.batch_persist | **prepend + dead-arm cleanup** | Draft |

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>