### PR TITLE
fix: re-export Dashboard_yjs.frame_update via .mli (PR #17967 follow-up)

### DIFF
--- a/lib/dashboard/dashboard_yjs.mli
+++ b/lib/dashboard/dashboard_yjs.mli
@@ -1,6 +1,19 @@
 (** Dashboard_yjs — Yjs WebSocket Projection Layer for Live Telemetry
     @since Project World Building (Big Bang) *)
 
+(** [frame_update payload] returns the Yjs update frame used by dashboard
+    telemetry broadcasts: sync step 0, update message type 2, varint
+    payload byte length, then the payload bytes. Pure; preserves caller
+    order only through the caller's own sequencing.
+
+    Exposed for unit tests so the binary protocol encoding stays pinned
+    at the test boundary — a silent change to the varint or message
+    type would surface in dashboard observer parsers as malformed
+    frames, which is harder to diagnose than a unit-test failure. The
+    live entry point [broadcast_keeper_telemetry] consumes this
+    internally. *)
+val frame_update : string -> string
+
 (** [broadcast_keeper_telemetry ~keeper_name ~trace_id ~turn_index ~model_id]
     publishes a keeper Yjs telemetry update to dashboard observer sessions.
     [model_id] is accepted for legacy call sites but redacted to the neutral


### PR DESCRIPTION
## 목적

PR #17967 이 \`Dashboard_yjs.frame_update\` 를 \"0 callers\" audit으로 제거. 3개 test가 Yjs binary protocol encoding 검증 — *6번째 누적 audit-miss 패턴*. 분류 매트릭스 따라 복원.

## 진단 (audit-dead-export.sh)

\`\`\`
$ bash scripts/audit-dead-export.sh Dashboard_yjs.frame_update
  defining sites:      1
  production callers:  0
  test callers:        1  (test_dashboard_yjs.ml — 3 test cases via DY.frame_update)
  RESULT: zero production callers, but test/facade exposures exist.
  exit: 1
\`\`\`

## 결정 — Restore

분류 매트릭스:

| 케이스 | mli docstring 의도 | 결정 |
|---|---|---|
| Prompt_defaults.init (iter 1) | thin fixture-level entry point | 복원 |
| Auth_strict_mode.of_string (iter 5) | exposed for unit tests | 복원 |
| **Dashboard_yjs.frame_update (이번)** | **binary protocol encoder, encoding contract** | **복원** |
| Lockfree_atomic.update_with_result (iter 3) | (record form SSOT 존재) | caller migration |
| set_util.count_distinct (iter 4) | generic helper, no role | delete + test 제거 |

\`frame_update\` 는:
- Yjs sync message frame (sync step 0, update msg type 2, varint length, payload)
- Production live entry point \`broadcast_keeper_telemetry\` 가 *내부에서 사용*
- 3 test가 encoding contract pin (empty / small / multi-byte varint threshold)
- Encoding 변경이 silent 하게 일어나면 dashboard observer parser 가 malformed frame 받음 — *unit test boundary*에서 catch하는 것이 정답

## 변경

\`lib/dashboard/dashboard_yjs.mli\` (+13 LoC):
- \`val frame_update : string -> t\` 복원
- docstring 으로 encoding contract 명시 + \"exposed for unit tests\" + live entry point 포인터

## 검증

\`\`\`
dune exec test/test_dashboard_yjs.exe → 3/3 pass
\`\`\`

## Audit-miss tally (6th)

| PR | Removed | Test callers missed | Iter follow-up |
|---|---|---|---|
| #17946 | Auth_strict_mode.of_string | 4 | #18136 (iter 5) |
| #17947 | set_util.{of_list_with,count_distinct} | 4 | #18133 (iter 4) |
| #17950 | Prompt_defaults.init | 7 | #18118 (iter 1) |
| #17967 | Dashboard_yjs.frame_update | 3 | **이 PR (iter 12)** |
| #17998 | Lockfree_atomic.update_with_result | 3 | #18128 (iter 3) |
| #18009 | Exec_adaptive_timeout.{stats,stats_to_json} | 5 | #18098 (iter 미지정) |

6/6 sweep PR이 동일 \`rg test/\` 누락. \`audit-dead-export.sh\` (#18142/18151) 가 미래 sweep에서 동일 누락 차단.