### PR TITLE
test(keeper_bash_safety): add missing Parsed module alias

### DIFF
--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -12,6 +12,7 @@ module Keeper_registry = Masc_mcp.Keeper_registry
 module Keeper_sandbox = Masc_mcp.Keeper_sandbox
 module Keeper_shell_docker = Masc_mcp.Keeper_shell_docker
 module Keeper_types = Masc_mcp.Keeper_types
+module Parsed = Masc_exec.Parsed
 module Json = Yojson.Safe.Util
 
 let validate = Masc_mcp.Worker_dev_tools.validate_command


### PR DESCRIPTION
## 목적

\`test/test_keeper_bash_safety.ml\` 가 \`Parsed.Parsed ir\` 를 3 사이트 (line 94/731/736) 에서 호출하지만 \`module Parsed = ...\` alias 누락 — \"Unbound module Parsed\" 컴파일 에러. 1줄 alias 추가.

## 진단

모듈 살아있음 (\`lib/exec/parsed.{ml,mli}\` — bash subset parser의 4-way result variant SSOT).

다른 곳의 일관된 패턴:
- Production: \`lib/spawn.ml:264-272\` → \`Masc_exec.Parsed.Parsed\`, \`Masc_exec.Parsed.Parse_error\`, \`Masc_exec.Parsed.Parse_aborted\`, \`Masc_exec.Parsed.Too_complex\`
- Tests: \`test/test_exec_core.ml:127\`, \`test/test_keeper_shell_docker_route.ml:32,1555\` → \`Masc_exec.Parsed.Parsed\`

이번 test 파일만 *bare \`Parsed.\`* 사용 (alias 누락).

## 변경

\`test/test_keeper_bash_safety.ml\` 모듈 alias 블록 (line 9-15) 에 한 줄 추가:

\`\`\`ocaml
module Keeper_types = Masc_mcp.Keeper_types
+ module Parsed = Masc_exec.Parsed
module Json = Yojson.Safe.Util
\`\`\`

3개 bare \`Parsed.Parsed\` 사이트는 alias 통해 자동 resolve, per-site 변경 불필요.

## 검증

\`\`\`
dune build test/test_keeper_bash_safety.exe → exit 0
\`\`\`

## 도구 v2 blind spot — 같은 패턴 (iter 10)

\`audit-dead-export.sh\` v2 가 \`defining_count = 0\` 보고 + exit 3 (zombie). 실제로는 모듈 존재. **iter 10 (\`Keeper_shell_docker_exec_failure\`) 와 동일한 filename-based module blind spot**.

도구는 *content-based* \`^(let|and|val|type|module|exception)\s+...\` 패턴만 검색. OCaml의 *filename-as-module* convention (no explicit \`module Foo = struct\`) 미검출.

→ V3 enhancement 후보 누적 발견 — 두번째 케이스. \`find lib -name '<lowercase_name>.ml'\` 보조 검색이 점점 더 정당화됨.

본 PR 은 v3 enhancement 와 독립적인 1줄 alias fix.