### PR TITLE
fix(test): canonical reason field in cascade_exhausted fixture (PR #18140 stack)

### DIFF
--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -519,7 +519,13 @@ let test_runtime_surface_derives_cascade_exhausted_from_meta () =
   KR.clear ();
   let base = make_meta ~name:"runtime-cascade-exhausted-test" () in
   let reason =
-    "Internal error: [masc_oas_error] {\"kind\":\"cascade_exhausted\",\"cascade_name\":\"primary\",\"detail\":\"all providers failed: Connection refused\"}"
+    (* The canonical envelope written by [masc_internal_error_to_json] in
+       lib/cascade/cascade_internal_error.ml uses a typed [reason] field
+       (variant serialization), not a free-form ["detail"] string.  Use
+       the typed value here so the runtime_blocker_summary classifier
+       (keeper_status_bridge.ml:298) can recover the variant and
+       synthesize the canonical English summary. *)
+    "Internal error: [masc_oas_error] {\"kind\":\"cascade_exhausted\",\"cascade_name\":\"primary\",\"reason\":\"connection_refused\"}"
   in
   let meta =
     {

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -558,7 +558,7 @@ let test_runtime_surface_names_no_tool_provider_details () =
         required_tool_names = [ "keeper_bash"; "masc_worktree_create" ];
         provider_rejections =
           [
-            { OWN.reason = "codex_keeper_bound_actor_required" };
+            { OWN.provider_label = "codex"; OWN.reason = "codex_keeper_bound_actor_required" };
           ];
       }
   in


### PR DESCRIPTION
## Summary

\`test_runtime_surface_derives_cascade_exhausted_from_meta\` (test_keeper_exec_status.ml:518) 의 mock \`masc_oas_error\` JSON fixture 가 lib 실제 serialization 과 어긋남.

### Mismatch

| 위치 | Field |
|---|---|
| Test fixture (f0075c361, 2026-05-17) | \`{"kind":"cascade_exhausted","cascade_name":"primary","detail":"all providers failed: Connection refused"}\` |
| lib emit (\`masc_internal_error_to_json\`, cascade_internal_error.ml:174) | \`{"kind":"cascade_exhausted","cascade_name":"primary","reason":"connection_refused"}\` |

\`detail\` (free-form string) vs \`reason\` (typed variant serialization) — 다른 field.

## Effect

classifier 경로:

\`\`\`
classify_masc_internal_error_of_string
  → parse_masc_internal_error_json
  → cascade_exhaustion_reason_of_json ("reason" 키 lookup)
\`\`\`

fixture 가 \`"detail"\` 사용 → reason_opt = None → 전체 parse None → \`_ -> summary\` fallback (keeper_status_bridge.ml:312) 가 raw "Internal error: [masc_oas_error] {...}" string verbatim 반환.

테스트는 canonical English summary "Cascade exhausted after provider failures; local runtime connection refused." 어설션 → FAIL.

## Fix

fixture 를 canonical 형식으로 정정:

\`\`\`diff
- "Internal error: [masc_oas_error] {...,\"detail\":\"all providers failed: Connection refused\"}"
+ "Internal error: [masc_oas_error] {...,\"reason\":\"connection_refused\"}"
\`\`\`

classifier 가 \`Connection_refused\` variant 복구 → \`cascade_exhaustion_summary Connection_refused\` 호출 → 정확한 English text 반환.

## Verification (stacked on PR #18140)

\`\`\`
dune build --root . test/test_keeper_exec_status.exe  →  EXIT=0
dune runtest  surface_status:9                         →  PASS  (was FAIL)
              surface_status:17 (stale watchdog)       →  still FAIL (별개)
\`\`\`

iter 8 (PR #18140) 의 compile fix 가 unmask 한 2 pre-existing 회귀 중 1 closure. surface_status:17 (stale watchdog reason classifier drift) 는 별개 영역 후속 PR.

## Stack

base = \`fix/keeper-exec-status-provider-label-fixture\` (PR #18140). PR #18140 머지 후 자동 rebase.

## Diff

+7 / -1 LoC.

WORKAROUND-FREE: fixture 가 lib emit 와 정합.

RFC-WAIVED: PR #18140 unmask 후속, lib serialization 정합.

🤖 Generated with [Claude Code](https://claude.com/claude-code)