### PR TITLE
refactor(voice_bridge): drop fake `~sw` param from `call_voice_mcp_endpoint`

### DIFF
--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -323,7 +323,7 @@ let extract_mcp_result json =
   | e -> Error (Printf.sprintf "Parse error: %s" (Printexc.to_string e))
 ;;
 
-let call_voice_mcp_endpoint ~sw ~clock ~net ~endpoint ~tool_name ~arguments =
+let call_voice_mcp_endpoint ~clock ~net ~endpoint ~tool_name ~arguments =
   let uri =
     match Voice_runtime_overlay.session_mcp_url_of_endpoint endpoint with
     | Ok url -> Uri.of_string url
@@ -341,7 +341,6 @@ let call_voice_mcp_endpoint ~sw ~clock ~net ~endpoint ~tool_name ~arguments =
   let headers_list =
     [ "Content-Type", "application/json"; "Accept", "application/json" ]
   in
-  let _ = sw in
   let operation () =
     let timeout =
       Option.value endpoint.timeout_seconds ~default:(request_timeout_seconds ())
@@ -450,7 +449,6 @@ let attempt_tts_endpoint
     with_voice_output_turn ~agent_id (fun () ->
       match
         call_voice_mcp_endpoint
-          ~sw
           ~clock
           ~net
           ~endpoint
@@ -545,7 +543,7 @@ let call_session_tool ~sw ~clock ~net ~tool_name ~arguments =
   match session_endpoint_result () with
   | Error message -> Error message
   | Ok endpoint ->
-    (match call_voice_mcp_endpoint ~sw ~clock ~net ~endpoint ~tool_name ~arguments with
+    (match call_voice_mcp_endpoint ~clock ~net ~endpoint ~tool_name ~arguments with
      | Ok json ->
        (match extract_mcp_result json with
         | Ok data -> Ok (append_provider_metadata data endpoint)


### PR DESCRIPTION
## 목표

`call_voice_mcp_endpoint ~sw ~clock ~net ~endpoint ~tool_name ~arguments` 의 `~sw : Eio.Switch.t` 가 body 내 `let _ = sw in` 으로 명시적으로 버려짐. HTTP retry-with-backoff 흐름 (clock + net + endpoint 기반) 이 sw 를 의존하지 않음.

내부 함수 (mli 비노출) + 2 callsites (line 452, 548 in 같은 파일).

## 자가 증거

pre-PR (`lib/voice/voice_bridge.ml:326-344`):
```ocaml
let call_voice_mcp_endpoint ~sw ~clock ~net ~endpoint ~tool_name ~arguments =
  let uri = ... in
  let request_body = ... in
  let body_str = ... in
  let headers_list = ... in
  let _ = sw in   (* <-- 받자마자 버림 *)
  let operation () = ... in
  ...
```

## 변경

`lib/voice/voice_bridge.ml`:
- `let call_voice_mcp_endpoint ~sw ~clock ~net ...` 시그니처에서 `~sw` 제거
- body 의 `let _ = sw in` 제거
- 2 callsites (line 452 `with_voice_output_turn` 분기, line 548 dispatcher 분기) 에서 `~sw` 인자 제거

## 변경 파일 (1 파일, +1 / −4, **net −3 LoC**)

## Behavior parity

- `call_voice_mcp_endpoint` 가 sw 를 *받자마자 버림* → 제거 후 byte-identical
- 2 callsites 의 caller (`with_voice_output_turn` 블록 + 다른 dispatcher) 의 `~sw` 는 그대로 유지 — 본 PR scope 외 (cascade cleanup 후보)

## 5-prong audit

- `call_voice_mcp_endpoint` 가 `lib/voice/voice_bridge.mli` 에 노출 안 됨 → 내부 only
- module facade `include Voice_bridge` 등 없음
- bare-name catch-all: def + 2 internal callsites + 1 docstring 멘션 외 0
- test 파일 (`test/test_keeper_mutex_coverage.ml`) 은 `Voice_bridge_core.*` 만 사용, `Voice_bridge.call_voice_mcp_endpoint` 안 씀
- defensive witness: 없음

## 로컬 검증

```
$ dune build --root . lib/  # clean
$ rg "call_voice_mcp_endpoint.*~sw" lib/
(empty — 완전 제거)
```

## 후속 (별도 PR)

이 PR 이 정리하는 callsite 의 *위쪽* caller (`with_voice_output_turn` 블록 주변) 도 `~sw` 를 받지만 본 PR 변경 후 그 caller 의 `~sw` 가 unused 가 될 가능성 있음 — 별도 cascade-cleanup PR 후보.

## 관련

- #18159 (`create_backend_eio ~sw discarded`, 같은 fake-param 패턴)
- #18160 (`parse_response ?now discarded`, optional 변형)
- 12 anti-pattern iter 누적 (axes):
  - #18122 — function-name-lying
  - #18125 — body `()` no-op
  - #18130 — placeholder type chain
  - #18135 — dead mli no-op
  - #18139 — always-false body
  - #18144 / #18164 — literal-wrapper `"runtime"` (2 sites)
  - #18155 — always-None + cascade
  - #18159 — fake positional param (`~sw`)
  - #18160 — fake optional param (`?now`)
  - #18168 — fake param pair (`~model_id ~model_label`) + dead binding cascade
  - 본 PR — fake positional param (`~sw`, 2nd site in voice subsystem)
- 작업 출처: `/loop 10m 가짜 구현이나 억지로 되게끔만 만든 구현 숙청, 및 레거시 개념 제거`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>