### PR TITLE
fix(test): qualify Keeper_shell_docker_exec_failure path (Cluster D)

### DIFF
--- a/test/test_keeper_shell_docker_route.ml
+++ b/test/test_keeper_shell_docker_route.ml
@@ -2053,7 +2053,7 @@ let test_docker_mount_failure_message_preserves_path () =
     ^ ": no such file or directory"
   in
   let message =
-    Keeper_shell_docker_exec_failure.docker_exec_failure_message
+    Masc_mcp.Keeper_shell_docker_exec_failure.docker_exec_failure_message
       ~image:"masc-keeper-sandbox:local"
       ~status:(Unix.WEXITED 125)
       ~output


### PR DESCRIPTION
PR #18100 qualified the production-side callers but missed one test site in test/test_keeper_shell_docker_route.ml:2056.  The test references the module without the Masc_mcp prefix that external (test-tree) callers must use, so the compiler flags Unbound module Keeper_shell_docker_exec_failure.  Surgical one-line fix: re-qualify to Masc_mcp.Keeper_shell_docker_exec_failure.docker_exec_failure_message — same convention as the file's existing 'module Coord = Masc_mcp.Coord' style aliases.  Cluster D of the dead-export-sweep main breakage. One of ~20 unique compile errors. Per draft-auto-merge guard, stays Draft.