### PR TITLE
scripts(audit-dead-export): add filename-based module discovery (v3)

### DIFF
--- a/scripts/audit-dead-export.sh
+++ b/scripts/audit-dead-export.sh
@@ -108,7 +108,33 @@ defining_mli=$("${rg_base[@]}" "$define_pat" -g '*.mli' 2>/dev/null || true)
 defining_all=$(printf '%s\n%s\n' "$defining" "$defining_mli" | sort -u | grep -v '^$' || true)
 defining_count=$(printf '%s' "$defining_all" | grep -c '^.' || true)
 echo "$defining_all"
-echo "(count: $defining_count)"
+echo "(count: $defining_count — content-based: let/and/val/type/module/exception)"
+
+# v3: Filename-based module discovery. OCaml convention treats
+# `foo.ml` as `module Foo` without an explicit `module Foo = struct`
+# declaration. The content-based scan above misses these; iter 10
+# (Keeper_shell_docker_exec_failure) and iter 13 (Parsed) both hit
+# this blind spot. When the requested symbol is capitalized, look for
+# `lower(name).ml` files in lib/ + test/ as supplementary defining
+# evidence.
+module_files=""
+module_file_count=0
+if [[ "$name" =~ ^[A-Z] ]]; then
+  lower_name=$(echo "$name" | tr '[:upper:]' '[:lower:]')
+  raw_finds=$(find lib test -type f \( -name "${lower_name}.ml" -o -name "${lower_name}.mli" \) 2>/dev/null || true)
+  module_files=$(printf '%s\n' "$raw_finds" \
+    | grep -v '_build' \
+    | grep -v '.worktrees' \
+    | grep -v '^$' \
+    | sort -u || true)
+  module_file_count=$(printf '%s' "$module_files" | grep -c '^.' || true)
+  if (( module_file_count > 0 )); then
+    echo
+    echo "$module_files"
+    echo "(count: $module_file_count — filename-based: ${lower_name}.ml/.mli on disk)"
+  fi
+fi
+defining_count=$(( defining_count + module_file_count ))
 echo
 
 # ─── 1. Qualified production callers ──────────────────────────────
@@ -205,13 +231,31 @@ any_callers=$(( prod_count + test_count + facade_count + bare_count ))
 total_callers=$(( prod_count + test_count + facade_count ))
 
 echo "─── Summary ─────────────────────────────────────────────────"
-printf '  defining sites:      %d\n' "$defining_count"
+printf '  defining sites:      %d  (content: %d, filename: %d)\n' \
+  "$defining_count" "$(( defining_count - module_file_count ))" "$module_file_count"
 printf '  production callers:  %d\n' "$prod_count"
 printf '  test callers:        %d  <- most-missed bucket\n' "$test_count"
 printf '  facade exposures:    %d\n' "$facade_count"
 printf '  mli doc mentions:    %d\n' "$doc_count"
 printf '  bare-name callers:   %d  (heuristic; review when facade>0)\n' "$bare_count"
 echo
+
+# Filename-based module exists but caller is missing an alias.
+# Distinguishes the iter 10/13 case (Keeper_shell_docker_exec_failure,
+# Parsed) from a true zombie: the symbol IS reachable as a module on
+# disk, just unbound in the calling scope. The fix is a `module X =
+# Masc_*.X` alias at the call site, not a caller-side rename.
+if (( module_file_count > 0 )) \
+   && [[ "$name" =~ ^[A-Z] ]] \
+   && (( defining_count - module_file_count == 0 )) \
+   && (( any_callers > 0 )); then
+  echo "RESULT: module '$name' exists on disk; caller likely missing alias."
+  echo "  Filename-based OCaml module ($lower_name.ml) is reachable, but"
+  echo "  the calling scope has no \`module $name = Masc_*.\$module\`."
+  echo "  Fix shape: add the alias next to neighbouring \`module X = ...\`"
+  echo "  declarations in the caller. No surface change."
+  exit 3
+fi
 
 # Inverse case: zero defining sites + callers exist = zombie callers.
 # The fix lives on the caller side, not the defining side — there is


### PR DESCRIPTION
## 목적

V2 (#18151) 가 *filename-based OCaml modules* 를 detect 못해서 iter 10 (Keeper_shell_docker_exec_failure) + iter 13 (Parsed) 두번 false-zombie 분류. workflow-pr.md \"같은 영역 2회 발생 → 3회차 전 root-fix\" 규칙 적용해서 도구가 직접 잡도록 보강.

기반: PR #18151 (v2) 위에 stack.

## v2 의 한계

OCaml convention: \`foo.ml\` 파일 = \`module Foo\` (no explicit \`module Foo = struct\` declaration). V2 scan:

\`\`\`bash
rg '^(let|and|val|type|module|exception)\s+...' --type ml
\`\`\`

content-based 만 검색 → 파일 시스템에 존재하지만 본문에 \`module Foo\` 선언 없는 모듈을 못 잡음.

결과: iter 10 (\`Keeper_shell_docker_exec_failure\`) 와 iter 13 (\`Parsed\`) 모두 *exit 3 (zombie)* 로 *오분류*. 실제로는 모듈 존재 + caller에 alias 누락. Fix shape는 비슷했지만 (caller-side migration), 진단 메시지가 잘못된 mental model 유도.

## V3 변경

### 1. Filename-based discovery (bucket 0 확장)

요청 이름이 capitalized 이면 \`find lib test -name '<lowercase>.ml' -o -name '<lowercase>.mli'\` 추가 검색. \`defining_count\` 에 합산.

### 2. Summary 가 content / filename 분리

\`\`\`
defining sites:  2  (content: 0, filename: 2)
\`\`\`

읽는 사람이 정의 종류 즉시 파악.

### 3. 새 RESULT 메시지 — module-exists-alias-missing

zombie 분기 *앞에* 추가:

\`\`\`
RESULT: module 'Parsed' exists on disk; caller likely missing alias.
  Filename-based OCaml module (parsed.ml) is reachable, but
  the calling scope has no \`module Parsed = Masc_*.\$module\`.
  Fix shape: add the alias next to neighbouring \`module X = ...\`
  declarations in the caller. No surface change.
\`\`\`

Exit code 3 유지 (caller-side fix) — restore/migrate (1) 와 production gate (2) 와 구분.

### 4. \`set -euo pipefail\` robustness

빈 \`find\` 결과가 set -e 트리거 — \`|| true\` 추가 + 명시적 \`grep -v '^$'\` empty-line 필터.

## 5 case regression test

| 케이스 | exit | filename | RESULT |
|---|---|---|---|
| Parsed (iter 13) | 3 | 2 | module exists; alias missing |
| Keeper_shell_docker_exec_failure (iter 10) | 3 | 1 | module exists; alias missing |
| gate_from_raw_typed (iter 7) | 3 | 0 | true zombie |
| count_distinct (iter 4) | 1 | 0 | restore-or-migrate |
| Totally_made_up_module (control) | 0 | 0 | not present |

## 분류 매트릭스 — 9th row

| 케이스 | content def | filename def | callers | exit | message |
|---|---|---|---|---|---|
| (8 existing rows) | ... | ... | ... | ... | ... |
| **module exists, alias missing** (v3 신규) | 0 | > 0 | > 0 | 3 | \"add module alias in caller\" |

도구가 8 → 9 row 매트릭스로 발전.

## SSOT 효과

미래 sweeper는 *수치 + RESULT 메시지* 만으로 9가지 결정 shape 자동 분류. iter 10/13 같은 mis-classification 미래 발생 0건 목표.