### PR TITLE
refactor(coord_agent): drop ref-accumulator in get_agents_status

### DIFF
--- a/lib/coord/coord_agent.ml
+++ b/lib/coord/coord_agent.ml
@@ -13,38 +13,43 @@ let get_agents_status config =
   let agents_path = agents_dir config in
   if not (Sys.file_exists agents_path) then
     `Assoc [("agents", `List []); ("count", `Int 0)]
-  else begin
-    let agents = ref [] in
-    Sys.readdir agents_path |> Array.iter (fun name ->
-        Coord_query.safe_yield ();
-      if Filename.check_suffix name ".json" then begin
-        let path = Filename.concat agents_path name in
-        match read_agent_with_repair config path with
-        | Ok agent ->
-            let is_zombie =
-              is_zombie_agent
-                ~agent_type:agent.agent_type
-                ~agent_name:agent.name
-                agent.last_seen
-            in
-            let status = if is_zombie then "zombie" else agent_status_to_string agent.status in
-            agents := `Assoc [
-              ("name", `String agent.name);
-              ("status", `String status);
-              ("is_zombie", `Bool is_zombie);
-              ("current_task", Json_util.string_opt_to_json agent.current_task);
-              ("last_seen", `String agent.last_seen);
-              ("capabilities", `List (List.map (fun s -> `String s) agent.capabilities));
-            ] :: !agents
-        | Error msg ->
-            Log.Misc.error "agent state read failed: %s" msg
-      end
-    );
+  else
+    let agents =
+      Sys.readdir agents_path
+      |> Array.to_list
+      |> List.filter_map (fun name ->
+          Coord_query.safe_yield ();
+          if not (Filename.check_suffix name ".json") then None
+          else
+            let path = Filename.concat agents_path name in
+            match read_agent_with_repair config path with
+            | Ok agent ->
+                let is_zombie =
+                  is_zombie_agent
+                    ~agent_type:agent.agent_type
+                    ~agent_name:agent.name
+                    agent.last_seen
+                in
+                let status =
+                  if is_zombie then "zombie"
+                  else agent_status_to_string agent.status
+                in
+                Some (`Assoc [
+                  ("name", `String agent.name);
+                  ("status", `String status);
+                  ("is_zombie", `Bool is_zombie);
+                  ("current_task", Json_util.string_opt_to_json agent.current_task);
+                  ("last_seen", `String agent.last_seen);
+                  ("capabilities", `List (List.map (fun s -> `String s) agent.capabilities));
+                ])
+            | Error msg ->
+                Log.Misc.error "agent state read failed: %s" msg;
+                None)
+    in
     `Assoc [
-      ("agents", `List (List.rev !agents));
-      ("count", `Int (List.length !agents));
+      ("agents", `List agents);
+      ("count", `Int (List.length agents));
     ]
-  end
 
 (* ============================================ *)
 (* Agent Discovery - Capability Broadcasting   *)


### PR DESCRIPTION
## 목표

`lib/coord/coord_agent.ml`의 `get_agents_status`에서 `let agents = ref []` + `Array.iter` + prepend + final `List.rev` 패턴을 `Array.to_list |> List.filter_map`으로 변환. filter-map이 두 가지 분기 모두 흡수: `.json` suffix filter (None for non-matches) + `read_agent_with_repair` Ok/Error split (Some for Ok, None + logging for Error).

## 왜

- 9번째 same-pattern conversion. *Array.iter + side-effect-on-error + suffix-filter* variant — 이전 PR들은 `List.iter` + 직접 prepend가 주류였음.
- `Coord_query.safe_yield ()` cooperative yield는 fold body 안에서도 동일하게 호출됨 → fiber-yield 시점 byte-equal.

## Behavior parity

| 측면 | 원본 | 새 코드 |
|---|---|---|
| `safe_yield` 호출 timing | 매 name마다 entry start | 동일 |
| `.json` suffix filter | `if Filename.check_suffix ... then begin ... end` | `if not (check_suffix ...) then None else ...` |
| Ok branch | prepend to ref | `Some ...` |
| Error branch | `Log.Misc.error msg` | `Log.Misc.error msg; None` |
| 최종 list order | `List.rev !agents` (after prepend) | `List.filter_map` natural order (no reverse) |
| `\`Assoc` shape | name/status/is_zombie/current_task/last_seen/capabilities | 동일 byte-equal |

## 변경 파일

- `lib/coord/coord_agent.ml` (+35 / −30, net +5 due to filter_map pattern nesting)

## 로컬 검증

```
$ dune build --root . lib/                      # PASS
$ dune exec --root . test/test_room.exe
... 92 tests run.  90 PASS / 2 FAIL.
```

**두 failure는 우리 변경과 무관**한 main baseline issue:
- `state.multiple tasks independent`
- `board_admin.audit orphan awaiting verifica...`

main에서도 동일하게 실패. error: `Eio_context.set_env not called — RFC-0107 Phase D pool cannot be initialized` (test-environment bootstrap-order bug, unrelated to coord_agent). `git stash; dune exec test_room.exe` baseline test로 confirmed.

`get_agents_status`를 직접 cover하는 3개 test (`test_get_agents_status` × 2 + sub-test)는 모두 PASS.

## 누적 (9 iter)

| Iter | PR | 함수 | 변형 | 상태 |
|---|---|---|---|---|
| #1 | #18106 | server_state_product.check_invariants | prepend + List.rev | MERGED |
| #2 | #18109 | chronicle_validate.validate_epoch | prepend + List.rev | MERGED |
| #3 | #18119 | tool_control.keeper_pause_status_json | prepend × 3 + fold | Draft |
| #4 | #18131 | governance_anomaly.detect_deviations | prepend + List.rev | Draft |
| #5 | #18141 | cascade_declarative_parser.parse_toml | append `:= !x @ errs` | Draft |
| #6 | #18150 | cdal_judge.check_execution_mode | prepend + List.rev | Draft |
| #7 | #18157 | audit_log.parse_entries | counter + list + logging | Draft |
| #8 | #18166 | memory_jsonl.batch_persist | prepend + dead-arm cleanup | Draft |
| #9 | (this) | coord_agent.get_agents_status | **Array.iter + filter_map + safe_yield** | Draft |

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>