### PR TITLE
refactor(operator_control): drop fake `ok` destructure + discard in `masc_keeper_msg`

### DIFF
--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -445,13 +445,12 @@ let execute_keeper_action (ctx : 'a context) (request : action_request) =
           net = ctx.net;
         }
       in
-      let* ok, body =
+      let* body =
         match Tool_keeper.dispatch keeper_ctx ~name:"masc_keeper_msg" ~args with
-        | Some (true, body) -> Ok (true, body)
+        | Some (true, body) -> Ok body
         | Some (false, err) -> Error err
         | None -> Error "masc_keeper_msg dispatch unavailable"
       in
-      let _ = ok in
       Ok
         (`Assoc
           [


### PR DESCRIPTION
## 목표

`let* ok, body = ... in let _ = ok in Ok (...)` 패턴이 *fake destructuring*:

- `match` 의 Ok branch 가 *항상* `(true, body)` 반환 (Some (true, body) 분기만)
- `let*` 가 destructure 후 `let _ = ok in` 으로 ok 를 명시적으로 버림
- body 만 의미 있음

## 자가 증거

pre-PR (`lib/operator/operator_control.ml:448-454`):
```ocaml
let* ok, body =
  match Tool_keeper.dispatch keeper_ctx ~name:"masc_keeper_msg" ~args with
  | Some (true, body) -> Ok (true, body)
  | Some (false, err) -> Error err
  | None -> Error "masc_keeper_msg dispatch unavailable"
in
let _ = ok in
Ok (`Assoc [ ("tool_name", `String "masc_keeper_msg") ; ("result", json_of_dispatch_output body) ])
```

`ok` 가 Ok-branch 에서 hardcoded `true` → destructure + discard = 의미 0.

## 변경

`lib/operator/operator_control.ml` (`masc_keeper_msg` dispatch 경로):
- `Ok (true, body)` → `Ok body`
- `let* ok, body =` → `let* body =`
- `let _ = ok in` 라인 제거

## 변경 파일 (1 파일, +2 / −3, **net −1 LoC**)

## Behavior parity

- Ok branch reach 조건 unchanged: `Some (true, body)` 분기만 success
- `Some (false, err)` → `Error err` (unchanged)
- `None` → `Error "masc_keeper_msg dispatch unavailable"` (unchanged)
- 반환 JSON 구조 (`[tool_name, result]`) byte-identical

## 5-prong audit

- 단일 사이트 변경 (이 match expression 내부만)
- callsites 없음 (match branch 자체가 변경 대상)
- mli surface 변화 없음 (function 전체 시그니처는 그대로)
- defensive witness: 없음

## 로컬 검증

```
$ dune build --root . lib/  # clean
```

## 관련

- `~/me/memory/audit-deep-dive-2026-05-22.html` 의 *function-name-lying* 와는 다른 axis — destructure-then-discard 패턴
- 13 iter 누적, 새 axis (#13) 추가:
  - axes: function-name-lying (#18122) / body-noop (#18125) / placeholder-chain (#18130) / dead-mli (#18135) / always-false (#18139) / literal-wrapper "runtime" ×2 (#18144, #18164) / always-None+cascade (#18155) / fake-positional ×2 (#18159, #18171) / fake-optional (#18160) / fake-param-pair (#18168) / **destructure-then-discard** (본 PR)
- 작업 출처: `/loop 10m 가짜 구현이나 억지로 되게끔만 만든 구현 숙청, 및 레거시 개념 제거`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>