### PR TITLE
fix: re-export Http_protocol_detect detect_from_fd + protocol_to_string

### DIFF
--- a/lib/http_protocol_detect.mli
+++ b/lib/http_protocol_detect.mli
@@ -10,12 +10,35 @@
 
     Internal helpers (the [h2_preface_prefix] string constant
     and the [h2_preface_len] derived integer) are hidden —
-    callers consume only the [protocol] variant and the
-    detector entry point. *)
+    callers consume only the [protocol] variant, the two
+    detector entry points, and the printable converter. *)
 
 type protocol =
   | Http1
   | Http2
+
+val detect_from_fd :
+  Unix.file_descr ->
+  (protocol, string) result
+(** [detect_from_fd fd] peeks the first bytes of [fd] using
+    [MSG_PEEK] and classifies the protocol. Exposed as the
+    lower-level entry point so unit tests can drive detection
+    against an [Unix.socketpair] without pulling in the Eio
+    runtime — the algorithm boundary is pinned at the raw-fd
+    layer, not the Eio adapter.
+
+    Returns [Ok Http2] when the peek matches the H2 preface
+    prefix, [Ok Http1] for any other observed bytes (including
+    a partial read shorter than the preface — any valid H2
+    client sends the full preface immediately).
+
+    [Ok Http1] is also returned for [EAGAIN] / [EWOULDBLOCK]
+    on a non-blocking socket — an in-flight HTTP/1.1 request
+    is the most likely cause.
+
+    Returns [Error msg] for [recv = 0] (peer closed before
+    sending) and for any other [Unix.Unix_error]
+    (formatted via [Unix.error_message]). *)
 
 val detect :
   _ Eio.Net.stream_socket ->
@@ -26,3 +49,7 @@ val detect :
 
     Returns [Error "no Unix FD available on this socket"] when
     the flow has no Unix FD (e.g. an in-memory transport). *)
+
+val protocol_to_string : protocol -> string
+(** ["HTTP/1.1"] / ["HTTP/2"] — printable form for log lines and
+    metric labels. *)


### PR DESCRIPTION
## 목적

PR #17951 이 \`detect_from_fd\` + \`protocol_to_string\` 을 \"0 callers\" audit으로 제거. 7개 unit test 가 \`Unix.socketpair\` 로 raw fd 만들어 protocol detection 검증 — **7번째 누적 audit-miss**. 분류 매트릭스 따라 복원.

## 진단 (audit-dead-export.sh v3)

\`\`\`
$ bash scripts/audit-dead-export.sh Http_protocol_detect.detect_from_fd
  defining sites:      1  (content: 1, filename: 0)
  test callers:        6
  RESULT: zero production callers, but test/facade exposures exist.
  exit: 1
\`\`\`

## 결정 — Restore (iter 1/5/12 패턴)

mli docstring 이 role differentiation 을 명시:
- \`detect_from_fd\` : **raw fd 진입점** — \"Exposed as the lower-level entry point so unit tests can drive detection against an [Unix.socketpair] without pulling in the Eio runtime\"
- \`detect\` : **Eio adapter** — \"Eio adapter around {!detect_from_fd}\" (mli 본문이 이미 명시)
- \`protocol_to_string\` : printable label for logs/metrics

7개 test 가 protocol detection algorithm 의 라인을 *raw fd boundary* 에서 pin. Eio runtime 없이 \`Unix.recv MSG_PEEK\` 동작 검증 — production 실패 시 Eio integration 이슈와 algorithm 이슈를 *test-level 에서 분리*.

## 변경

\`lib/http_protocol_detect.mli\` (+29/-2):
- \`val detect_from_fd : Unix.file_descr -> (protocol, string) result\` 복원 + 원본 docstring (PR #17951 이 제거) + test-boundary 역할 명시 추가
- \`val protocol_to_string : protocol -> string\` 복원 + 원본 docstring
- header docstring 의 \"two detector entry points, and the printable converter\" 문구도 복원 (PR #17951 이 \"the detector entry point\" 단수로 truncate)

## 검증

\`\`\`
dune exec test/test_http_protocol_detect.exe → 7/7 pass
\`\`\`

## Audit-miss tally (7번째)

| PR | Removed | Test callers missed | Iter follow-up |
|---|---|---|---|
| #17946 | Auth_strict_mode.of_string | 4 | #18136 (iter 5) |
| #17947 | set_util.{of_list_with,count_distinct} | 4 | #18133 (iter 4) |
| #17950 | Prompt_defaults.init | 7 | #18118 (iter 1) |
| #17951 | Http_protocol_detect.* | 6 | **이 PR (iter 15)** |
| #17967 | Dashboard_yjs.frame_update | 3 | #18167 (iter 12) |
| #17998 | Lockfree_atomic.update_with_result | 3 | #18128 (iter 3) |
| #18009 | Exec_adaptive_timeout.{stats,stats_to_json} | 5 | #18098 |

7/7 동일 \`rg test/\` 누락. \`audit-dead-export.sh\` v1+v2+v3 (#18142/#18151/#18173) 도구 제품군이 미래 sweep에서 동일 누락 차단.