### PR TITLE
fix(auth_strict_mode): restore of_string mli export (Cluster C, false-dead from #17946)

### DIFF
--- a/lib/auth_strict_mode.mli
+++ b/lib/auth_strict_mode.mli
@@ -30,3 +30,12 @@ val to_label : t -> string
 (** [to_label Off = "off"], [Dry_run = "dry_run"], [Strict = "strict"].
     Used as the Prometheus [mode] label so operators can break down
     [masc_auth_strict_would_reject_total] by mode. *)
+
+val of_string : string -> t
+(** Parse the case-insensitive flag value the env reader uses internally.
+    Exposed for [test_auth_strict_mode], which pins the parser semantics
+    (case-folding, unknown→[Dry_run] default, exact-match of [off]/
+    [dry_run]/[strict]) ahead of Phase B PR-2 promoting [Strict] to a
+    typed reject; the test header documents this on purpose so a silent
+    rename or unknown-handling change fails at the test boundary rather
+    than in production telemetry. *)


### PR DESCRIPTION
PR #17946 'remove dead export of_string' removed Auth_strict_mode.of_string from the .mli.  The function is alive in the .ml (line 10) and is the sole subject of test/test_auth_strict_mode.ml, whose header docstring explicitly states the function is pinned here on purpose ('a silent rename or unknown-handling change must fail at the test boundary rather than in production telemetry' — ahead of Phase B PR-2 promoting Strict to a typed reject).  The dead-export sweep missed the paired-test-file prong of the 5-prong audit pattern.  Restore the .mli export with a docstring documenting the deliberate test-boundary pin.  Cluster C of the broader dead-export-sweep main breakage. One of ~20 unique OCaml compile errors. Per draft-auto-merge guard, stays Draft.