### PR TITLE
refactor(masc_http_client/pool): drop fake `\`Reused/\`Fresh` variant + `origin` destructure

### DIFF
--- a/lib/masc_http_client/pool.ml
+++ b/lib/masc_http_client/pool.ml
@@ -325,15 +325,12 @@ let do_request t ?headers ?body ~method_ uri : (response, string) result =
   let host_origin = Uri.with_uri ~path:(Some "") ~query:None uri in
   let acquired =
     match try_acquire_idle t key with
-    | Some c -> Ok (c, `Reused)
-    | None ->
-      (match create_fresh t host_origin with
-       | Ok c -> Ok (c, `Fresh)
-       | Error e -> Error e)
+    | Some c -> Ok c
+    | None -> create_fresh t host_origin
   in
   match acquired with
   | Error e -> Error e
-  | Ok (client, origin) ->
+  | Ok client ->
     let path = path_and_query uri in
     let body_piaf = Option.map Piaf.Body.of_string body in
     t.counters.inflight <- t.counters.inflight + 1;
@@ -348,7 +345,6 @@ let do_request t ?headers ?body ~method_ uri : (response, string) result =
     | Error err ->
       (* Connection is suspect; close, do not park. *)
       release t key client ~close_only:true;
-      let _ = origin in
       Error (Piaf.Error.to_string (err :> Piaf.Error.t))
     | Ok resp ->
       let status = Piaf.Status.to_code (Piaf.Response.status resp) in


### PR DESCRIPTION
## 목표

`do_request` 의 `acquired` binding 이 **3 layer fake 누적**:

1. **Fake polymorphic variant** — `Some c -> Ok (c, \`Reused)` / `Ok c -> Ok (c, \`Fresh)` 생성, 0 consumer
2. **Fake tuple-wrap** — `Ok (c, \`Reused/\`Fresh)` 가 `(client * variant)` tuple 로 반환, variant 부분 사용 안 됨
3. **Destructure-then-discard** — `Ok (client, origin) -> ... let _ = origin in ...` 가 origin 받자마자 버림

세 layer 모두 동일 design intent — *future telemetry* (reused vs fresh connection tagging) placeholder. CLAUDE.md `software-development.md` §"Don't design for hypothetical future requirements" 위반.

## 자가 증거

pre-PR (`lib/masc_http_client/pool.ml:326-351`):
```ocaml
let acquired =
    match try_acquire_idle t key with
    | Some c -> Ok (c, \`Reused)
    | None ->
      (match create_fresh t host_origin with
       | Ok c -> Ok (c, \`Fresh)
       | Error e -> Error e)
  in
  match acquired with
  | Error e -> Error e
  | Ok (client, origin) ->
    ...
    | Error err ->
      release t key client ~close_only:true;
      let _ = origin in           (* <-- discard *)
      Error (Piaf.Error.to_string ...)
```

`rg "\\\`Reused|\\\`Fresh" lib/` → def 사이트만, 0 consumer.

## 변경

`lib/masc_http_client/pool.ml`:
- `Some c -> Ok (c, \`Reused)` → `Some c -> Ok c`
- `match create_fresh ... with | Ok c -> Ok (c, \`Fresh) | Error e -> Error e` → `create_fresh t host_origin` (이미 Result 반환)
- `Ok (client, origin) ->` → `Ok client ->`
- `let _ = origin in` 라인 제거

## 변경 파일 (1 파일, +3 / −7, **net −4 LoC**)

## Behavior parity

- `try_acquire_idle Some c` 분기: `client` 반환 (variant tag 손실, 외부 consumer 0)
- `try_acquire_idle None + create_fresh Ok c` 분기: `client` 반환 (variant tag 손실)
- Error 분기 모두 unchanged
- `match result with` 의 Error/Ok 분기 동작 동일

## 5-prong audit

- `lib/masc_http_client/pool.mli` 에 `Reused`/`Fresh`/`origin` 노출 0
- catch-all `Reused|Fresh` in lib/: 본 PR 변경 후 0 hit
- defensive witness: 없음

## 로컬 검증

```
$ dune build --root . lib/  # clean
$ rg "\`Reused|\`Fresh|let _ = origin" lib/masc_http_client/pool.ml
(empty — 완전 제거)
```

## 관련

- `software-development.md` §"Don't design for hypothetical future requirements"
- 14 iter 누적 axes:
  - #18122 function-name-lying / #18125 body-noop / #18130 placeholder-chain
  - #18135 dead-mli / #18139 always-false / #18144/#18164 literal-wrapper×2
  - #18155 always-None+cascade / #18159/#18171 fake-positional×2 / #18160 fake-optional
  - #18168 fake-param-pair / #18175 destructure-discard
  - 본 PR — **3-layer-stacked-fakeness** (variant + tuple-wrap + destructure-discard 동시)
- 작업 출처: `/loop 10m 가짜 구현이나 억지로 되게끔만 만든 구현 숙청, 및 레거시 개념 제거`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>