### PR TITLE
refactor(coord_agent): drop ref-accumulator in find_agents_by_capability

### DIFF
--- a/lib/coord/coord_agent.ml
+++ b/lib/coord/coord_agent.ml
@@ -13,38 +13,43 @@ let get_agents_status config =
   let agents_path = agents_dir config in
   if not (Sys.file_exists agents_path) then
     `Assoc [("agents", `List []); ("count", `Int 0)]
-  else begin
-    let agents = ref [] in
-    Sys.readdir agents_path |> Array.iter (fun name ->
-        Coord_query.safe_yield ();
-      if Filename.check_suffix name ".json" then begin
-        let path = Filename.concat agents_path name in
-        match read_agent_with_repair config path with
-        | Ok agent ->
-            let is_zombie =
-              is_zombie_agent
-                ~agent_type:agent.agent_type
-                ~agent_name:agent.name
-                agent.last_seen
-            in
-            let status = if is_zombie then "zombie" else agent_status_to_string agent.status in
-            agents := `Assoc [
-              ("name", `String agent.name);
-              ("status", `String status);
-              ("is_zombie", `Bool is_zombie);
-              ("current_task", Json_util.string_opt_to_json agent.current_task);
-              ("last_seen", `String agent.last_seen);
-              ("capabilities", `List (List.map (fun s -> `String s) agent.capabilities));
-            ] :: !agents
-        | Error msg ->
-            Log.Misc.error "agent state read failed: %s" msg
-      end
-    );
+  else
+    let agents =
+      Sys.readdir agents_path
+      |> Array.to_list
+      |> List.filter_map (fun name ->
+          Coord_query.safe_yield ();
+          if not (Filename.check_suffix name ".json") then None
+          else
+            let path = Filename.concat agents_path name in
+            match read_agent_with_repair config path with
+            | Ok agent ->
+                let is_zombie =
+                  is_zombie_agent
+                    ~agent_type:agent.agent_type
+                    ~agent_name:agent.name
+                    agent.last_seen
+                in
+                let status =
+                  if is_zombie then "zombie"
+                  else agent_status_to_string agent.status
+                in
+                Some (`Assoc [
+                  ("name", `String agent.name);
+                  ("status", `String status);
+                  ("is_zombie", `Bool is_zombie);
+                  ("current_task", Json_util.string_opt_to_json agent.current_task);
+                  ("last_seen", `String agent.last_seen);
+                  ("capabilities", `List (List.map (fun s -> `String s) agent.capabilities));
+                ])
+            | Error msg ->
+                Log.Misc.error "agent state read failed: %s" msg;
+                None)
+    in
     `Assoc [
-      ("agents", `List (List.rev !agents));
-      ("count", `Int (List.length !agents));
+      ("agents", `List agents);
+      ("count", `Int (List.length agents));
     ]
-  end
 
 (* ============================================ *)
 (* Agent Discovery - Capability Broadcasting   *)

--- a/lib/coord/coord_agent.ml
+++ b/lib/coord/coord_agent.ml
@@ -168,30 +168,31 @@ let find_agents_by_capability config ~capability =
   let agents_path = agents_dir config in
   if not (Sys.file_exists agents_path) then
     `Assoc [("agents", `List []); ("count", `Int 0)]
-  else begin
-    let matching = ref [] in
-    Sys.readdir agents_path |> Array.iter (fun name ->
-        Coord_query.safe_yield ();
-      if Filename.check_suffix name ".json" then begin
-        let path = Filename.concat agents_path name in
-        match read_agent_with_repair config path with
-        | Ok agent
-          when List.mem capability agent.capabilities
-               && not (is_zombie_agent
-                         ~agent_type:agent.agent_type
-                         ~agent_name:agent.name
-                         agent.last_seen) ->
-            matching := `Assoc [
-              ("name", `String agent.name);
-              ("status", `String (agent_status_to_string agent.status));
-              ("capabilities", `List (List.map (fun s -> `String s) agent.capabilities));
-            ] :: !matching
-        | Ok _ | Error _ -> ()
-      end
-    );
+  else
+    let matching =
+      Sys.readdir agents_path
+      |> Array.to_list
+      |> List.filter_map (fun name ->
+          Coord_query.safe_yield ();
+          if not (Filename.check_suffix name ".json") then None
+          else
+            let path = Filename.concat agents_path name in
+            match read_agent_with_repair config path with
+            | Ok agent
+              when List.mem capability agent.capabilities
+                   && not (is_zombie_agent
+                             ~agent_type:agent.agent_type
+                             ~agent_name:agent.name
+                             agent.last_seen) ->
+                Some (`Assoc [
+                  ("name", `String agent.name);
+                  ("status", `String (agent_status_to_string agent.status));
+                  ("capabilities", `List (List.map (fun s -> `String s) agent.capabilities));
+                ])
+            | Ok _ | Error _ -> None)
+    in
     `Assoc [
       ("capability", `String capability);
-      ("agents", `List (List.rev !matching));
-      ("count", `Int (List.length !matching));
+      ("agents", `List matching);
+      ("count", `Int (List.length matching));
     ]
-  end


### PR DESCRIPTION
## 목표

`lib/coord/coord_agent.ml`의 자매 함수 `find_agents_by_capability`에서 #18174와 동일한 `Array.iter` → `Array.to_list |> List.filter_map` 변환 적용. 두 번째 사이트는 `Ok agent when ...capability check + not zombie` when-guard가 추가된 점만 차이.

## Stack

**Base: #18174** (fix/coord-agent-immutable).  머지 순서: #18174 먼저 → 이 PR rebase to main → 머지.

같은 파일 `coord_agent.ml`의 두 함수 (`get_agents_status` line 10-47 + `find_agents_by_capability` line 160-192). 별도 PR로 분리한 이유:
- iter #9 #18174이 이미 push된 상태에서 동일 sweep을 추가 적용
- when-guard 패턴이 추가된 *variant*라 별도 review 단위로 명확

## 왜

- 10번째 same-pattern conversion. *Array.iter + filter_map + when-guard* variant.
- when-guard는 filter_map 안에서 자연스럽게 `Some` / `None` 분기로 변환 — when 조건 미충족 시 `| Ok _ | Error _ -> None`의 fall-through로 떨어짐. catch-all 추가 아님 (원본 `| Ok _ | Error _ -> ()` 유지, `()` → `None`만 교체).

## Behavior parity

| 측면 | 원본 | 새 코드 |
|---|---|---|
| `safe_yield` per name | left-to-right | 동일 |
| `.json` filter | nested if-then | filter_map 첫 None branch |
| when-guard | `Ok agent when ...` 매칭 시 prepend | 매칭 시 `Some` |
| Non-match | `Ok _ \| Error _ -> ()` skip | `\| Ok _ \| Error _ -> None` |
| Output order | `List.rev !matching` | filter_map natural order |
| `\`Assoc` shape | name/status/capabilities + outer "capability"/"agents"/"count" | byte-equal |

## 변경 파일

- `lib/coord/coord_agent.ml` (+25 / −24, second function only; first function in #18174)

## 로컬 검증

```
$ dune build --root . lib/                                  # PASS
```

test_room의 2 baseline failures (RFC-0107 Phase D `Eio_context.set_env not called`)는 #18174 PR body와 동일하게 우리 변경과 무관. `find_agents_by_capability`를 직접 cover하는 2 tests는 PASS.

## 누적 (10 iter)

| Iter | PR | 함수 | 상태 |
|---|---|---|---|
| #1 | #18106 | server_state_product.check_invariants | MERGED |
| #2 | #18109 | chronicle_validate.validate_epoch | MERGED |
| #3-#9 | #18119 / #18131 / #18141 / #18150 / #18157 / #18166 / #18174 | Draft 7 |
| #10 | (this) | coord_agent.find_agents_by_capability | Draft (stack on #18174) |

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>