### PR TITLE
fix: re-export Agent_sdk_log_bridge.effective_level via .mli (PR #17956 follow-up)

### DIFF
--- a/lib/agent_sdk_log_bridge.mli
+++ b/lib/agent_sdk_log_bridge.mli
@@ -9,6 +9,15 @@
 
     Should be called exactly once during server bootstrap. *)
 
+val effective_level : Agent_sdk.Log.record -> Log.level
+(** Normalize the OAS record severity before forwarding it into masc-mcp.
+    Preserves upstream levels by default, but promotes specific
+    operator-actionable warn-level failures on the keeper main path to
+    [Error]. Exposed at the module boundary so unit tests can pin the
+    promotion table — a silent change to the operator-actionable warn
+    set would surface in test_masc_log rather than as a stealth severity
+    drift across the dashboard / log ring. *)
+
 val install : unit -> unit
 (** Register the OAS → masc-mcp log sink as a global OAS sink.  Call
     once before any keeper turn fires an LLM call.  Idempotent via an


### PR DESCRIPTION
## 목적

PR #17956 이 \`render_record_message\` + \`effective_level\` 둘을 \"0 callers\" audit으로 제거. \`render_record_message\` 는 진짜 dead (module 내부 helper만), \`effective_level\` 은 4 test 가 severity-promotion table pin — **8번째 누적 audit-miss**. 이 PR은 \`effective_level\` 만 복원.

## 진단

\`\`\`
$ bash scripts/audit-dead-export.sh Agent_sdk_log_bridge.effective_level
  defining sites:      1  (content: 1, filename: 0)
  test callers:        4
  RESULT: zero production callers, but test/facade exposures exist.
  exit: 1

$ bash scripts/audit-dead-export.sh Agent_sdk_log_bridge.render_record_message
  defining sites:      1  (content: 1, filename: 0)
  test callers:        0
  RESULT: zero callers anywhere — safe to remove from both .ml and .mli.
  exit: 0
\`\`\`

도구가 두 함수를 *정확히 다른 결정*으로 분류 — \`effective_level\` 만 복원 대상.

\`render_record_message\` 는 PR #17956 이 올바르게 dead로 잡음 (\`lib/agent_sdk_log_bridge.ml:190\` 의 module 내부 호출만 있고 external 없음). mli 에서 hide 정상.

## 결정 — Restore (iter 1/5/12/15 패턴)

mli docstring 명시 (PR #17956 이 제거): *\"Normalize the OAS record severity before forwarding it into masc-mcp. Preserves upstream levels by default, but promotes specific operator-actionable warn-level failures on the keeper main path to [Error].\"*

이 promotion table 의 *4 row* 가 ring test 2-5 에서 pin:
- \"oas bridge promotes MCP server failures\"
- \"oas bridge promotes context injector failures\"
- \"oas bridge promotes missing approval callback\"
- \"oas bridge demotes normal tool_choice relax warn\"

Silent change → severity drift across dashboard / log ring (operator-invisible 사고 패턴). Test boundary가 그걸 catch.

## 변경

\`lib/agent_sdk_log_bridge.mli\` (+9):
- \`val effective_level : Agent_sdk.Log.record -> Log.level\` 복원 + 원본 docstring + test-boundary 역할 명시

## 검증

\`\`\`
dune exec test/test_masc_log.exe — effective_level 4 test (ring 2-5) all pass
\`\`\`

1개 별개 실패 (\`test_file_sink_reopens_when_log_path_is_deleted\` line 164) 는 environment-dependent file-system test, 본 PR scope 외.

## Audit-miss tally (8번째)

| PR | Removed | Test callers missed |
|---|---|---|
| #17946 | Auth_strict_mode.of_string | 4 |
| #17947 | set_util.{of_list_with,count_distinct} | 4 |
| #17950 | Prompt_defaults.init | 7 |
| #17951 | Http_protocol_detect.* | 6 |
| #17956 | Agent_sdk_log_bridge.effective_level | **4 (이 PR)** |
| #17967 | Dashboard_yjs.frame_update | 3 |
| #17998 | Lockfree_atomic.update_with_result | 3 |
| #18009 | Exec_adaptive_timeout.* | 5 |

8건 누적 동일 \`rg test/\` 누락. \`audit-dead-export.sh\` v1/v2/v3 도구 제품군 정당화.

특이점 — 이번 #17956 PR 은 *2개 함수 모두* dead로 잡았는데 1개만 진짜 dead. 도구가 *함수별 개별 분류*로 mixed-state 감지 가능.