### PR TITLE
feat(shell-ir): S3 risk-stamped IR — replace write_intent with risk_class

### DIFF
--- a/lib/exec_core.ml
+++ b/lib/exec_core.ml
@@ -61,7 +61,7 @@ type classification =
   { family : command_family
   ; reversibility : reversibility
   ; risk : risk
-  ; write_intent : bool
+  ; risk_class : Masc_exec.Shell_ir_risk.risk_class
   }
 
 type artifact_storage = Filesystem
@@ -291,7 +291,7 @@ let looks_like_test_command ~base ~sub =
   | _ -> false
 ;;
 
-let family_of_base_command ~write_intent ~tokens ~base =
+let family_of_base_command ~risk_class ~tokens ~base =
   let sub = second_token tokens in
   match String.lowercase_ascii base with
   | "git" ->
@@ -302,7 +302,10 @@ let family_of_base_command ~write_intent ~tokens ~base =
           | [] -> [])
      with
      | Some "clone" -> Clone
-     | _ -> if write_intent then Git_write else Git_read)
+     | _ ->
+       if risk_class = Masc_exec.Shell_ir_risk.R0_Read
+       then Git_read
+       else Git_write)
   | "rg" | "grep" | "find" -> Search
   | "ls" | "tree" | "du" -> List
   | "cat"
@@ -321,11 +324,9 @@ let family_of_base_command ~write_intent ~tokens ~base =
   | "sed" -> Read
   | "curl" | "wget" -> Network_read
   | "npm" | "pnpm" | "yarn" | "pip" | "opam" ->
-    if write_intent
-    then Package_install
-    else if looks_like_test_command ~base ~sub
-    then Test
-    else Build
+    if risk_class = Masc_exec.Shell_ir_risk.R0_Read
+    then (if looks_like_test_command ~base ~sub then Test else Build)
+    else Package_install
   | "cargo"
   | "dune"
   | "make"
@@ -355,30 +356,33 @@ let reversibility_of_command ~is_destructive family =
     | Package_install | Clone | Git_write | Unknown -> Reversible)
 ;;
 
-let risk_of_command ~write_intent ~is_destructive family =
+let risk_of_command ~risk_class ~is_destructive family =
   if is_destructive
   then High
   else (
     match family with
     | Git_write | Package_install | Clone -> High
-    | Unknown when write_intent -> High
+    | Unknown when risk_class <> Masc_exec.Shell_ir_risk.R0_Read -> High
     | Build | Test | Network_read | Unknown -> Medium
     | Read | Search | List | Git_read -> Low)
 ;;
 
 let classify_command_of_ir ir =
   let tokens = Exec_policy_mutation_classifier.flat_stage_words ir in
-  let write_intent = Exec_policy.is_write_operation ir in
+  let envelope =
+    Masc_exec.Shell_ir_risk.classify (Masc_exec.Shell_ir_risk.undecided ir)
+  in
+  let risk_class = envelope.Masc_exec.Shell_ir_risk.risk in
   let is_destructive = Exec_policy.is_destructive_bash_operation ir in
   let family =
     match base_command_of_tokens tokens with
-    | Some base -> family_of_base_command ~write_intent ~tokens ~base
+    | Some base -> family_of_base_command ~risk_class ~tokens ~base
     | None -> Unknown
   in
   { family
   ; reversibility = reversibility_of_command ~is_destructive family
-  ; risk = risk_of_command ~write_intent ~is_destructive family
-  ; write_intent
+  ; risk = risk_of_command ~risk_class ~is_destructive family
+  ; risk_class
   }
 
 let string_of_command_family = function
@@ -412,7 +416,7 @@ let classification_to_json classification =
     [ "family", `String (string_of_command_family classification.family)
     ; "reversibility", `String (string_of_reversibility classification.reversibility)
     ; "risk", `String (string_of_risk classification.risk)
-    ; "write_intent", `Bool classification.write_intent
+    ; "risk_class", `String (Masc_exec.Shell_ir_risk.string_of_risk_class classification.risk_class)
     ]
 ;;
 
@@ -636,7 +640,7 @@ let artifact_refs_of_output ~artifact_policy ~base_path ~keeper_name ~cmd ~outpu
      | None -> [])
 ;;
 
-let default_classification = { family = Unknown; reversibility = Read_only; risk = Low; write_intent = false }
+let default_classification = { family = Unknown; reversibility = Read_only; risk = Low; risk_class = Masc_exec.Shell_ir_risk.R0_Read }
 
 let build_process_outcome ~classification ~artifact_policy ~base_path ~keeper_name ~cmd ~status ~output =
   let semantic_status = semantic_status_of_process ~cmd ~output status in

--- a/lib/exec_core.mli
+++ b/lib/exec_core.mli
@@ -42,7 +42,7 @@ type classification = {
   family : command_family;
   reversibility : reversibility;
   risk : risk;
-  write_intent : bool;
+  risk_class : Masc_exec.Shell_ir_risk.risk_class;
 }
 
 type artifact_storage =

--- a/lib/exec_policy.ml
+++ b/lib/exec_policy.ml
@@ -812,7 +812,7 @@ let validate_shell_ir_paths ?keeper_id ?base_path ?workdir shell_ir =
       validate_parsed_shell_ir shell_ir
 ;;
 
-let is_write_operation = Mutation_classifier.is_write_operation
+
 let is_git_branch_switch = Mutation_classifier.is_git_branch_switch
 let is_destructive_bash_operation = Mutation_classifier.is_destructive_bash_operation
 let flat_stage_words = Keeper_shell_command_semantics.flat_stage_words

--- a/lib/exec_policy.mli
+++ b/lib/exec_policy.mli
@@ -69,7 +69,7 @@ val validate_shell_ir_paths :
   (unit, string) result
 
 (** RFC-0160 S1: IR-typed structural mutation classifiers. *)
-val is_write_operation : Masc_exec.Shell_ir.t -> bool
+
 val is_git_branch_switch : Masc_exec.Shell_ir.t -> bool
 val is_destructive_bash_operation : Masc_exec.Shell_ir.t -> bool
 

--- a/lib/exec_policy_mutation_classifier.ml
+++ b/lib/exec_policy_mutation_classifier.ml
@@ -42,33 +42,6 @@ let flat_stage_words (ir : Shell_ir.t) : string list =
 
 (* ---- IR-typed classifiers ------------------------------------- *)
 
-let is_write_operation (ir : Shell_ir.t) : bool =
-  match flat_stage_words ir with
-  | "git" :: sub :: _ ->
-    List.mem
-      sub
-      [ "push"
-      ; "commit"
-      ; "merge"
-      ; "rebase"
-      ; "reset"
-      ; "checkout"
-      ; "branch"
-      ; "tag"
-      ; "stash"
-      ; "clone"
-      ; "init"
-      ]
-  | "dune" :: sub :: _ -> List.mem sub [ "clean"; "promote" ]
-  | "make" :: sub :: _ -> List.mem sub [ "clean"; "deploy"; "install"; "publish" ]
-  | ("npm" | "pnpm" | "yarn") :: sub :: _ ->
-    List.mem
-      sub
-      [ "add"; "install"; "link"; "prune"; "publish"; "remove"; "unlink"; "update"; "up" ]
-  | cmd_name :: _ -> List.mem cmd_name [ "mv"; "cp"; "mkdir"; "touch"; "chmod" ]
-  | [] -> false
-;;
-
 let rec skip_git_global_options = function
   | [] -> []
   | "--" :: rest -> rest

--- a/lib/exec_policy_mutation_classifier.mli
+++ b/lib/exec_policy_mutation_classifier.mli
@@ -23,10 +23,7 @@ val flat_stage_words : Masc_exec.Shell_ir.t -> string list
     Non-literal-only stages contribute their literal prefix only.
     Replaces the historical string-era extractors. *)
 
-val is_write_operation : Masc_exec.Shell_ir.t -> bool
-(** [true] for commands that write filesystem or VCS state in the
-    closed sub-command set (git push/commit/merge/..., npm install/...,
-    dune clean, mv/cp/mkdir/touch/chmod). *)
+
 
 val is_git_branch_switch : Masc_exec.Shell_ir.t -> bool
 (** [true] for [git checkout]/[git switch]/[git branch <name>] that

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -52,7 +52,7 @@ let validate_command_coding = Exec_policy.validate_command_coding
 let simple_literal_args = Exec_policy.simple_literal_args
 let existing_dir_path_values_of_shell_ir = Exec_policy.existing_dir_path_values_of_shell_ir
 let validate_shell_ir_paths = Exec_policy.validate_shell_ir_paths
-let is_write_operation = Exec_policy.is_write_operation
+
 let is_git_branch_switch = Exec_policy.is_git_branch_switch
 let is_destructive_bash_operation = Exec_policy.is_destructive_bash_operation
 let flat_stage_words = Exec_policy.flat_stage_words

--- a/lib/worker_dev_tools.mli
+++ b/lib/worker_dev_tools.mli
@@ -127,15 +127,6 @@ val existing_dir_path_values_of_shell_ir : Masc_exec.Shell_ir.t -> string list
 
 (** {1 Bash safety classifiers} *)
 
-(** [true] iff the command performs a write/mutating operation
-    (git push/commit, dune clean, npm publish, mv, cp, mkdir,
-    chmod, ...).  Read-only commands (git status, rg)
-    return [false].
-
-    RFC-0160 S1: IR-typed signature; caller provides parsed
-    [Shell_ir.t] instead of raw string. *)
-val is_write_operation : Masc_exec.Shell_ir.t -> bool
-
 (** [true] iff [ir] is a git branch-switch / branch-mutation command
     (checkout, switch, branch -c/-m/-D, ...). *)
 val is_git_branch_switch : Masc_exec.Shell_ir.t -> bool

--- a/test/test_exec_core.ml
+++ b/test/test_exec_core.ml
@@ -133,7 +133,8 @@ let test_unknown_write_is_not_git_write () =
   check string "family" "unknown"
     (Masc_mcp.Exec_core.classification_to_json classification
      |> member "family" |> to_string);
-  check bool "write_intent" true classification.write_intent
+  check bool "risk_class is write" true
+    (classification.risk_class <> Masc_exec.Shell_ir_risk.R0_Read)
 
 let temp_dir () =
   let path = Filename.temp_file "exec_core_" "" in

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -92,7 +92,9 @@ let test_empty_command () =
 
 let is_write cmd =
   match Masc_exec_bash_parser.Bash.parse_string cmd with
-  | Masc_exec.Parsed.Parsed ir -> Masc_mcp.Worker_dev_tools.is_write_operation ir
+  | Masc_exec.Parsed.Parsed ir ->
+    let envelope = Masc_exec.Shell_ir_risk.classify (Masc_exec.Shell_ir_risk.undecided ir) in
+    envelope.Masc_exec.Shell_ir_risk.risk <> Masc_exec.Shell_ir_risk.R0_Read
   | _ -> false
 let test_write_ops_detected () =
   let writes = [


### PR DESCRIPTION
## Summary

RFC-0160 S3: Risk-stamped IR 구현. `Exec_core.classification`이 이제 단순 `bool` 대신 명시적 `risk_class`를 들고 흐른다.

### 변경 내용

- **Phantom envelope 선택 (Option B)**: `Shell_ir_risk.classify : undecided t -> decided decided_ir`
- **`Exec_core.classification` 필드 교체**: `write_intent: bool` → `risk_class: Masc_exec.Shell_ir_risk.risk_class`
- **`classify_command_of_ir`**: `Shell_ir_risk.classify` envelope에서 `risk_class`를 추출하여 record에 기록. caller는 재계산 없이 사용.
- **`family_of_base_command` / `risk_of_command`**: `risk_class` 기반 분류. R0_Read이면 git_read/build/test, 아니면 git_write/package_install.
- **JSON serialization**: `"write_intent"` 필드를 `"risk_class"` 문자열로 교체.
- **Legacy `is_write_operation` 완전 제거** (6파일):
  - `lib/exec_policy_mutation_classifier.ml` — 함수 정의 삭제
  - `lib/exec_policy_mutation_classifier.mli` — val 선언 삭제
  - `lib/exec_policy.ml` — re-export 삭제
  - `lib/exec_policy.mli` — val 선언 삭제
  - `lib/worker_dev_tools.ml` — re-export 삭제
  - `lib/worker_dev_tools.mli` — val 선언 + docstring 삭제

### 영향 범위

| 파일 | 변경 |
|------|------|
| `lib/exec_core.ml/mli` | `classification` record 필드 교체 + 사용처 업데이트 |
| `lib/exec_policy*.ml/mli` | `is_write_operation` 제거 |
| `lib/worker_dev_tools*.ml/mli` | `is_write_operation` 제거 |
| `test/test_exec_core.ml` | `write_intent` → `risk_class <> R0_Read` |
| `test/test_keeper_bash_safety.ml` | `Worker_dev_tools.is_write_operation` → `Shell_ir_risk.classify` |

## Test plan

- [x] `dune build lib/` — 라이브러리 빌드 clean
- [x] `test_exec_core.ml` — `mkdir tmp/generated` 분류 테스트 통과 (risk_class <> R0_Read)
- [x] `test_keeper_bash_safety.ml` — write/read ops detect 테스트 통과 (Shell_ir_risk.classify 기반)

## 검증

```bash
dune build lib/ --root .
```

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>