### PR TITLE
refactor(keeper): route tools through sandbox runner

### DIFF
--- a/docs/KEEPER-SANDBOX-BOUNDARY-POLICY.md
+++ b/docs/KEEPER-SANDBOX-BOUNDARY-POLICY.md
@@ -20,6 +20,7 @@ failure just because a keeper uses the Docker backend.
 | `Tool_code` / write tools | Tool input validation and sandbox-visible path normalization via `Keeper_sandbox` | Docker prefix literals, profile detection, keeper TOML reads |
 | `Keeper_shell_command_semantics` | Pure command-shape and cwd policy for `git`/`gh` commands | Docker process execution |
 | `Keeper_sandbox_shell_ir_target` | Backend target construction for typed Shell IR dispatch | Tool-surface ownership, command parsing, `keeper_bash` policy |
+| `Keeper_sandbox_runner` | Backend-neutral command execution facade used by tools; route selection between host and sandbox backend; mockable backend contract | Git/GitHub workflow semantics, tool input validation, command parsing ownership |
 | `Keeper_sandbox_docker` | Docker runtime setup, mounts, network mode, command execution, Docker result envelope | Generic command classification or cwd policy ownership |
 | `Keeper_sandbox_exec_failure` | Sandbox backend failure messages and registry recording | Tool-surface naming, command classification, shell-specific policy |
 
@@ -32,6 +33,9 @@ failure just because a keeper uses the Docker backend.
   not literals in tool code.
 - Per-command `git`/`gh` behavior is command semantics, not a sandbox
   profile.
+- Tool modules must not branch on `meta.sandbox_profile = Docker` or call
+  `Keeper_sandbox_docker` directly. They pass host/backend command
+  projections to `Keeper_sandbox_runner`.
 - Command semantics may only interpret commands accepted by the typed
   bash subset parser. Unsupported shell constructs fail closed and must
   not be reinterpreted with space splitting or fallback token scans.
@@ -47,6 +51,7 @@ Focused behavioral tests verify path and command behavior:
 Source-level boundary tests prevent regressions in layer ownership:
 
 - `test_keeper_sandbox_boundary_policy`
+- `test_keeper_sandbox_runner`
 
 The boundary test intentionally fails if:
 
@@ -54,6 +59,8 @@ The boundary test intentionally fails if:
 - coord worktree helpers reintroduce Docker container-root construction
   or sandbox-profile parsing;
 - Docker shell code re-exports generic command classification;
+- PR/GitHub tool code calls `Keeper_sandbox_docker` or selects Docker via
+  `meta.sandbox_profile = Docker`;
 - typed Shell IR backend target helpers are coupled to a `shell_bash`
   module name;
 - sandbox backend failure recording is coupled to a `shell_docker`

--- a/docs/design/keeper-tool-runtime-boundary-plan.html
+++ b/docs/design/keeper-tool-runtime-boundary-plan.html
@@ -243,8 +243,8 @@
       <p>Goal-driven cleanup for the confusing <code>Keeper_shell</code>, <code>Keeper_bash</code>, GitHub, Docker, and Local execution split.</p>
       <div class="meta">
         <span class="pill">Updated 2026-05-24</span>
-        <span class="pill">Branch refactor/keeper-sandbox-exec-failure-boundary</span>
-        <span class="pill">Worktree .worktrees/keeper-sandbox-exec-failure-boundary</span>
+        <span class="pill">Branch refactor/keeper-sandbox-runner-facade</span>
+        <span class="pill">Worktree .worktrees/keeper-sandbox-runner-facade</span>
       </div>
     </div>
   </header>
@@ -266,15 +266,15 @@
           <span>Old bad helper names in <code>lib/keeper</code></span>
         </div>
         <div class="panel metric">
-          <strong>13</strong>
-          <span>Current direct Docker runner alias/call references in <code>lib/keeper</code></span>
+          <strong>0</strong>
+          <span>Direct Docker runner calls outside <code>Keeper_sandbox_runner</code></span>
         </div>
         <div class="panel metric">
           <strong>3,706</strong>
           <span>Combined LOC across main hot files and new sandbox helper modules</span>
         </div>
       </div>
-      <p class="note">The first slice removes source-level references to <code>Keeper_shell_docker</code>, <code>Keeper_shell_docker_exec_failure</code>, and <code>Keeper_shell_bash_docker</code>. Remaining old-name mentions are intentional guard strings in tests and this planning artifact.</p>
+      <p class="note">Slice 1 removes source-level references to <code>Keeper_shell_docker</code>, <code>Keeper_shell_docker_exec_failure</code>, and <code>Keeper_shell_bash_docker</code>. Slice 2 removes the legacy <code>Keeper_shell_shared.run_docker*</code> boundary and routes PR/GitHub tool execution through <code>Keeper_sandbox_runner</code>.</p>
     </section>
 
     <section>
@@ -299,7 +299,7 @@
             <td data-label="ID">G2</td>
             <td data-label="Goal">Introduce a backend-neutral command runner facade so tool modules stop calling Docker helpers directly.</td>
             <td data-label="Quantitative Gate">Direct <code>Keeper_sandbox_docker.run_*</code> and <code>Keeper_shell_shared.run_docker*</code> call count in non-test source reaches <code>0</code> outside the facade.</td>
-            <td data-label="Status"><span class="status next">Next</span></td>
+            <td data-label="Status"><span class="status done">Done in slice 2</span></td>
           </tr>
           <tr>
             <td data-label="ID">G3</td>
@@ -340,9 +340,9 @@
           <tr>
             <td data-label="Task">T2</td>
             <td data-label="Goal">Runner facade</td>
-            <td data-label="Todo">Create a backend-neutral sandbox command runner and move callers behind it.</td>
-            <td data-label="Verification Method"><code>rg -n "Keeper_sandbox_docker\\.run_|Keeper_shell_shared\\.run_docker" lib/keeper</code></td>
-            <td data-label="Exit Criteria">Only facade internals may reference Docker runner functions.</td>
+            <td data-label="Todo">Create a backend-neutral sandbox command runner and move PR/GitHub tool callers behind it.</td>
+            <td data-label="Verification Method"><code>rg -n "Keeper_sandbox_docker\\.run_|Keeper_shell_shared\\.run_docker|meta\\.sandbox_profile = Docker" lib/keeper/keeper_tool_github_pr.ml lib/keeper/keeper_tool_pr_review.ml</code></td>
+            <td data-label="Exit Criteria">Tool modules use <code>Keeper_sandbox_runner.run_command_with_status</code>; only facade internals reference Docker runner functions.</td>
           </tr>
           <tr>
             <td data-label="Task">T3</td>
@@ -373,8 +373,9 @@
       <h2>Verification Commands</h2>
       <div class="commands">
         <div class="command">git diff --check</div>
-        <div class="command">scripts/dune-local.sh build test/test_keeper_sandbox_boundary_policy.exe test/test_keeper_sandbox_docker_route.exe</div>
+        <div class="command">scripts/dune-local.sh build test/test_keeper_sandbox_boundary_policy.exe test/test_keeper_sandbox_runner.exe test/test_keeper_sandbox_docker_route.exe</div>
         <div class="command">./_build/default/test/test_keeper_sandbox_boundary_policy.exe</div>
+        <div class="command">./_build/default/test/test_keeper_sandbox_runner.exe</div>
         <div class="command">./_build/default/test/test_keeper_sandbox_docker_route.exe test docker_route_fires 17-21 --show-errors --compact</div>
         <div class="command">rg -n "Keeper_shell_docker|Keeper_shell_docker_exec_failure|Keeper_shell_bash_docker|keeper_shell_docker|keeper_shell_docker_exec_failure|keeper_shell_bash_docker" lib/keeper</div>
         <div class="command">rg -n "Keeper_sandbox_docker\\.run_|Keeper_shell_shared\\.run_docker" lib/keeper</div>

--- a/docs/design/keeper-tool-runtime-boundary-plan.md
+++ b/docs/design/keeper-tool-runtime-boundary-plan.md
@@ -33,8 +33,11 @@ and public tool aliases.
    - `Keeper_shell_bash_docker` -> `Keeper_sandbox_shell_ir_target`
 
 2. Replace direct `Keeper_sandbox_docker` calls from tool-specific modules
-   with a backend-neutral sandbox command runner facade. Keep temporary
-   aliases only at the old boundary while callers move.
+   with a backend-neutral sandbox command runner facade. No legacy
+   `run_docker*` compatibility aliases remain in `Keeper_shell_shared`.
+   Tool modules now pass host and backend command projections to
+   `Keeper_sandbox_runner.run_command_with_status`; the runner decides
+   whether the command executes on the host or through the sandbox backend.
 
 3. Move Git/GitHub command semantics out of `keeper_shell_ops.ml` into
    Git/GitHub domain modules or native PR tools. The structured
@@ -53,5 +56,7 @@ and public tool aliases.
 - `test_keeper_sandbox_boundary_policy` protects source-level ownership.
 - `test_keeper_sandbox_docker_route` protects existing Docker route
   behavior while names and ownership move.
-- Follow-up slices should add facade-level tests before deleting old
-  compatibility aliases.
+- `test_keeper_sandbox_runner` uses a mock backend to verify the facade
+  delegates user-shell and trusted-tool commands without invoking Docker.
+- The boundary test now fails if PR/GitHub tool modules select the
+  concrete Docker backend directly.

--- a/lib/keeper/keeper_egress_audit.ml
+++ b/lib/keeper/keeper_egress_audit.ml
@@ -55,7 +55,7 @@ let host_direct_egress_path ~(config : Coord.config)
     "egress.json"
 
 let audit_one ~(config : Coord.config) ~(meta : Keeper_types.keeper_meta) =
-  let expected = Keeper_sandbox_docker.egress_policy_path ~config ~meta in
+  let expected = Keeper_sandbox_runner.egress_policy_path ~config ~meta in
   let status =
     match meta.sandbox_profile with
     | Keeper_types.Local ->

--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -37,10 +37,9 @@ val gh_min_timeout_sec : float
 
 val keeper_bash_native_min_timeout_sec : float
 (** Minimum timeout_sec floor applied to keeper_bash on the *native*
-    (non-Docker) executor path. Exposed so regression tests can lock the
-    floor against drift back to sub-I/O-latency values.  The Docker
-    dispatch path re-clamps independently to
-    {!Keeper_sandbox_docker.docker_run_min_timeout_sec}. *)
+    executor path. Exposed so regression tests can lock the floor
+    against drift back to sub-I/O-latency values.  Container-backed
+    dispatch paths re-clamp independently inside their backend. *)
 
 val rewrite_turn_runtime_paths_to_host :
   config:Coord.config ->
@@ -82,13 +81,3 @@ val handle_keeper_shell :
   meta:Keeper_types.keeper_meta ->
   args:Yojson.Safe.t ->
   string
-
-(** [ensure_keeper_sandbox_runtime ~timeout_sec] preflights the host
-    Docker runtime against the configured hardening requirements
-    (seccomp profile present, optional rootless / userns checks).
-    Returns the [--security-opt seccomp=...] argv fragment when the
-    runtime passes; [Error _] when something is missing. Exposed for
-    [Keeper_docker_read] (RFC-0006 Phase B-2) which reuses the same
-    preflight before spawning a one-shot container for fs reads. *)
-val ensure_keeper_sandbox_runtime :
-  timeout_sec:float -> (string list, string) result

--- a/lib/keeper/keeper_sandbox_docker_semantic.mli
+++ b/lib/keeper/keeper_sandbox_docker_semantic.mli
@@ -1,0 +1,13 @@
+val gh_exit_class_field
+  :  stages:Keeper_shell_command_semantics.parsed_stage list
+  -> status:Unix.process_status
+  -> output:string
+  -> (string * Yojson.Safe.t) list
+
+val docker_command_semantic_status
+  :  cmd:string
+  -> status:Unix.process_status
+  -> output:string
+  -> Exec_core.semantic_status
+
+val semantic_ok_of_status : Exec_core.semantic_status -> bool

--- a/lib/keeper/keeper_sandbox_factory.ml
+++ b/lib/keeper/keeper_sandbox_factory.ml
@@ -46,7 +46,7 @@ let resolve (t : t) ~cwd =
   with_lock t (fun () ->
     let in_playground = in_playground_of_cwd t ~cwd in
     let (effective_profile, effective_network) =
-      Keeper_sandbox_docker.effective_sandbox_profile
+      Keeper_sandbox_runner.effective_sandbox_profile
         ~meta:t.meta ~in_playground
     in
     let actual_network =

--- a/lib/keeper/keeper_sandbox_factory.mli
+++ b/lib/keeper/keeper_sandbox_factory.mli
@@ -2,7 +2,7 @@
 
     A single keeper turn may dispatch tool calls from different cwds,
     each implying a different [in_playground] state.  The factory
-    centralizes the {!Keeper_sandbox_docker.effective_sandbox_profile}
+    centralizes the {!Keeper_sandbox_runner.effective_sandbox_profile}
     invariant, evaluates [in_playground] from the call-site [cwd] for
     compatibility, and memoizes one runtime per [(in_playground, network_mode)]
     so a Docker container is created at most once per compatible dispatch
@@ -37,7 +37,7 @@ val resolve :
   t ->
   cwd:string ->
   Keeper_turn_sandbox_runtime.t option
-(** Returns [Some runtime] when {!Keeper_sandbox_docker.effective_sandbox_profile}
+(** Returns [Some runtime] when {!Keeper_sandbox_runner.effective_sandbox_profile}
     yields [Docker] (with [in_playground] derived from [cwd] vs the
     keeper's playground root for compatibility); [None] when [Local].  Memoizes per
     [(in_playground, network_mode)] so subsequent calls reuse the same

--- a/lib/keeper/keeper_sandbox_runner.ml
+++ b/lib/keeper/keeper_sandbox_runner.ml
@@ -23,7 +23,8 @@ type host_command =
   }
 
 type backend_command =
-  { cwd : string
+  { route_cwd : string
+  ; cwd : unit -> string
   ; command_text : string
   ; git_creds_enabled : bool
   ; network_mode : Keeper_types.network_mode
@@ -34,6 +35,7 @@ type routed_result =
   { status : Unix.process_status
   ; output : string
   ; via : string
+  ; backend_error : string option
   }
 
 module type Backend = sig
@@ -190,9 +192,10 @@ let run_host_command ~timeout_sec (host : host_command) =
       ?cwd:host.cwd
       host.argv
   in
-  { status; output; via = "host" }
+  { status; output; via = "host"; backend_error = None }
 
 let run_backend_command ~config ~meta ~timeout_sec (backend : backend_command) =
+  let cwd = backend.cwd () in
   let runner =
     match backend.trust with
     | User_shell -> run_shell_command_with_status
@@ -201,19 +204,27 @@ let run_backend_command ~config ~meta ~timeout_sec (backend : backend_command) =
   match
     runner
       ~config ~meta
-      ~cwd:backend.cwd
+      ~cwd
       ~timeout_sec
       ~cmd:backend.command_text
       ~git_creds_enabled:backend.git_creds_enabled
       ~network_mode:backend.network_mode
   with
   | Ok result ->
-    { status = result.status; output = result.output; via = "docker" }
+    { status = result.status
+    ; output = result.output
+    ; via = "docker"
+    ; backend_error = None
+    }
   | Error msg ->
-    { status = Unix.WEXITED 127; output = msg; via = "docker" }
+    { status = Unix.WEXITED 127
+    ; output = msg
+    ; via = "docker"
+    ; backend_error = Some msg
+    }
 
 let run_command_with_status ~config ~meta ~timeout_sec ~host ~backend =
-  if uses_backend ~config ~meta ~cwd:backend.cwd then
+  if uses_backend ~config ~meta ~cwd:backend.route_cwd then
     run_backend_command ~config ~meta ~timeout_sec backend
   else
     run_host_command ~timeout_sec host

--- a/lib/keeper/keeper_sandbox_runner.ml
+++ b/lib/keeper/keeper_sandbox_runner.ml
@@ -1,0 +1,219 @@
+type command_result =
+  { status : Unix.process_status
+  ; output : string
+  ; image : string
+  ; network_label : string
+  ; cmd_stages : Keeper_shell_command_semantics.parsed_stage list
+  ; cwd : string
+  ; semantic_status : Exec_core.semantic_status option
+  ; semantic_ok : bool
+  }
+
+type command_trust =
+  | User_shell
+  | Trusted_tool
+
+type host_command =
+  { actor : Masc_exec.Agent_id.t
+  ; raw_source : string
+  ; summary : string
+  ; env : string array option
+  ; cwd : string option
+  ; argv : string list
+  }
+
+type backend_command =
+  { cwd : string
+  ; command_text : string
+  ; git_creds_enabled : bool
+  ; network_mode : Keeper_types.network_mode
+  ; trust : command_trust
+  }
+
+type routed_result =
+  { status : Unix.process_status
+  ; output : string
+  ; via : string
+  }
+
+module type Backend = sig
+  val egress_policy_path :
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    string
+
+  val effective_sandbox_profile :
+    meta:Keeper_types.keeper_meta ->
+    in_playground:bool ->
+    Keeper_types.sandbox_profile * Keeper_types.network_mode
+
+  val ensure_runtime :
+    timeout_sec:float -> (string list, string) result
+
+  val command_uses_nested_runtime : string -> bool
+
+  val private_workspace_cwd :
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    string ->
+    string
+
+  val run_shell_command_with_status :
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    cwd:string ->
+    timeout_sec:float ->
+    cmd:string ->
+    git_creds_enabled:bool ->
+    network_mode:Keeper_types.network_mode ->
+    (command_result, string) result
+
+  val run_trusted_shell_command_with_status :
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    cwd:string ->
+    timeout_sec:float ->
+    cmd:string ->
+    git_creds_enabled:bool ->
+    network_mode:Keeper_types.network_mode ->
+    (command_result, string) result
+
+  val run_credentialed_bash :
+    turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t option ->
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    cwd:string ->
+    timeout_sec:float ->
+    cmd:string ->
+    unit ->
+    string
+
+  val run_bash :
+    turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t option ->
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    cwd:string ->
+    timeout_sec:float ->
+    cmd:string ->
+    network_mode:Keeper_types.network_mode ->
+    string
+end
+
+module Make (Backend : Backend) = struct
+  let egress_policy_path = Backend.egress_policy_path
+  let effective_sandbox_profile = Backend.effective_sandbox_profile
+  let ensure_runtime = Backend.ensure_runtime
+  let command_uses_nested_runtime = Backend.command_uses_nested_runtime
+  let private_workspace_cwd = Backend.private_workspace_cwd
+  let run_shell_command_with_status = Backend.run_shell_command_with_status
+  let run_trusted_shell_command_with_status =
+    Backend.run_trusted_shell_command_with_status
+  let run_credentialed_bash = Backend.run_credentialed_bash
+  let run_bash = Backend.run_bash
+end
+
+let of_docker_result
+    (result : Keeper_sandbox_docker.docker_shell_result)
+  : command_result =
+  { status = result.status
+  ; output = result.output
+  ; image = result.image
+  ; network_label = result.network_label
+  ; cmd_stages = result.cmd_stages
+  ; cwd = result.cwd
+  ; semantic_status = result.semantic_status
+  ; semantic_ok = result.semantic_ok
+  }
+
+module Docker_backend = struct
+  let egress_policy_path = Keeper_sandbox_docker.egress_policy_path
+  let effective_sandbox_profile = Keeper_sandbox_docker.effective_sandbox_profile
+  let ensure_runtime = Keeper_sandbox_docker.ensure_keeper_sandbox_runtime
+  let command_uses_nested_runtime =
+    Keeper_sandbox_docker.command_uses_nested_container_runtime
+  let private_workspace_cwd = Keeper_sandbox_docker.docker_private_workspace_cwd
+
+  let run_shell_command_with_status ~config ~meta ~cwd ~timeout_sec ~cmd
+      ~git_creds_enabled ~network_mode =
+    Keeper_sandbox_docker.run_docker_shell_command_with_status
+      ~config ~meta ~cwd ~timeout_sec ~cmd ~git_creds_enabled ~network_mode
+    |> Result.map of_docker_result
+
+  let run_trusted_shell_command_with_status ~config ~meta ~cwd ~timeout_sec ~cmd
+      ~git_creds_enabled ~network_mode =
+    Keeper_sandbox_docker.run_trusted_docker_shell_command_with_status
+      ~config ~meta ~cwd ~timeout_sec ~cmd ~git_creds_enabled ~network_mode
+    |> Result.map of_docker_result
+
+  let run_credentialed_bash =
+    Keeper_sandbox_docker.run_docker_credentialed_bash
+
+  let run_bash = Keeper_sandbox_docker.run_docker_bash
+end
+
+include Make (Docker_backend)
+
+let strip_trailing_slashes path =
+  let rec loop i =
+    if i > 0 && path.[i - 1] = '/' then loop (i - 1) else i
+  in
+  let len = loop (String.length path) in
+  if len = String.length path then path else String.sub path 0 len
+
+let normalize p =
+  Keeper_alerting_path.normalize_path_for_check p
+  |> strip_trailing_slashes
+
+let in_playground ~config ~meta ~cwd =
+  let host_root =
+    Keeper_sandbox.host_root_abs_of_meta ~config meta
+    |> normalize
+  in
+  let cwd = normalize cwd in
+  String.equal cwd host_root
+  || String.starts_with ~prefix:(host_root ^ "/") cwd
+
+let uses_backend ~config ~meta ~cwd =
+  let in_playground = in_playground ~config ~meta ~cwd in
+  match effective_sandbox_profile ~meta ~in_playground with
+  | Keeper_types.Docker, _ -> true
+  | Keeper_types.Local, _ -> false
+
+let run_host_command ~timeout_sec (host : host_command) =
+  let status, output =
+    Masc_exec.Exec_gate.run_argv_with_status
+      ~actor:host.actor
+      ~raw_source:host.raw_source
+      ~summary:host.summary
+      ~timeout_sec
+      ?env:host.env
+      ?cwd:host.cwd
+      host.argv
+  in
+  { status; output; via = "host" }
+
+let run_backend_command ~config ~meta ~timeout_sec (backend : backend_command) =
+  let runner =
+    match backend.trust with
+    | User_shell -> run_shell_command_with_status
+    | Trusted_tool -> run_trusted_shell_command_with_status
+  in
+  match
+    runner
+      ~config ~meta
+      ~cwd:backend.cwd
+      ~timeout_sec
+      ~cmd:backend.command_text
+      ~git_creds_enabled:backend.git_creds_enabled
+      ~network_mode:backend.network_mode
+  with
+  | Ok result ->
+    { status = result.status; output = result.output; via = "docker" }
+  | Error msg ->
+    { status = Unix.WEXITED 127; output = msg; via = "docker" }
+
+let run_command_with_status ~config ~meta ~timeout_sec ~host ~backend =
+  if uses_backend ~config ~meta ~cwd:backend.cwd then
+    run_backend_command ~config ~meta ~timeout_sec backend
+  else
+    run_host_command ~timeout_sec host

--- a/lib/keeper/keeper_sandbox_runner.mli
+++ b/lib/keeper/keeper_sandbox_runner.mli
@@ -1,0 +1,244 @@
+(** Backend-neutral keeper sandbox command runner.
+
+    Tool modules should depend on this module instead of concrete
+    sandbox backends. The production backend is currently Docker, but
+    that choice is intentionally hidden behind this facade. *)
+
+type command_result =
+  { status : Unix.process_status
+  ; output : string
+  ; image : string
+  ; network_label : string
+  ; cmd_stages : Keeper_shell_command_semantics.parsed_stage list
+  ; cwd : string
+  ; semantic_status : Exec_core.semantic_status option
+  ; semantic_ok : bool
+  }
+
+type command_trust =
+  | User_shell
+  | Trusted_tool
+
+type host_command =
+  { actor : Masc_exec.Agent_id.t
+  ; raw_source : string
+  ; summary : string
+  ; env : string array option
+  ; cwd : string option
+  ; argv : string list
+  }
+
+type backend_command =
+  { cwd : string
+  ; command_text : string
+  ; git_creds_enabled : bool
+  ; network_mode : Keeper_types.network_mode
+  ; trust : command_trust
+  }
+
+type routed_result =
+  { status : Unix.process_status
+  ; output : string
+  ; via : string
+  }
+
+module type Backend = sig
+  val egress_policy_path :
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    string
+
+  val effective_sandbox_profile :
+    meta:Keeper_types.keeper_meta ->
+    in_playground:bool ->
+    Keeper_types.sandbox_profile * Keeper_types.network_mode
+
+  val ensure_runtime :
+    timeout_sec:float -> (string list, string) result
+
+  val command_uses_nested_runtime : string -> bool
+
+  val private_workspace_cwd :
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    string ->
+    string
+
+  val run_shell_command_with_status :
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    cwd:string ->
+    timeout_sec:float ->
+    cmd:string ->
+    git_creds_enabled:bool ->
+    network_mode:Keeper_types.network_mode ->
+    (command_result, string) result
+
+  val run_trusted_shell_command_with_status :
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    cwd:string ->
+    timeout_sec:float ->
+    cmd:string ->
+    git_creds_enabled:bool ->
+    network_mode:Keeper_types.network_mode ->
+    (command_result, string) result
+
+  val run_credentialed_bash :
+    turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t option ->
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    cwd:string ->
+    timeout_sec:float ->
+    cmd:string ->
+    unit ->
+    string
+
+  val run_bash :
+    turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t option ->
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    cwd:string ->
+    timeout_sec:float ->
+    cmd:string ->
+    network_mode:Keeper_types.network_mode ->
+    string
+end
+
+module Make (Backend : Backend) : sig
+  val egress_policy_path :
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    string
+
+  val effective_sandbox_profile :
+    meta:Keeper_types.keeper_meta ->
+    in_playground:bool ->
+    Keeper_types.sandbox_profile * Keeper_types.network_mode
+
+  val ensure_runtime :
+    timeout_sec:float -> (string list, string) result
+
+  val command_uses_nested_runtime : string -> bool
+
+  val private_workspace_cwd :
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    string ->
+    string
+
+  val run_shell_command_with_status :
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    cwd:string ->
+    timeout_sec:float ->
+    cmd:string ->
+    git_creds_enabled:bool ->
+    network_mode:Keeper_types.network_mode ->
+    (command_result, string) result
+
+  val run_trusted_shell_command_with_status :
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    cwd:string ->
+    timeout_sec:float ->
+    cmd:string ->
+    git_creds_enabled:bool ->
+    network_mode:Keeper_types.network_mode ->
+    (command_result, string) result
+
+  val run_credentialed_bash :
+    turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t option ->
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    cwd:string ->
+    timeout_sec:float ->
+    cmd:string ->
+    unit ->
+    string
+
+  val run_bash :
+    turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t option ->
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    cwd:string ->
+    timeout_sec:float ->
+    cmd:string ->
+    network_mode:Keeper_types.network_mode ->
+    string
+end
+
+val egress_policy_path :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  string
+
+val effective_sandbox_profile :
+  meta:Keeper_types.keeper_meta ->
+  in_playground:bool ->
+  Keeper_types.sandbox_profile * Keeper_types.network_mode
+
+val ensure_runtime :
+  timeout_sec:float -> (string list, string) result
+
+val command_uses_nested_runtime : string -> bool
+
+val private_workspace_cwd :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  string ->
+  string
+
+val run_shell_command_with_status :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  cwd:string ->
+  timeout_sec:float ->
+  cmd:string ->
+  git_creds_enabled:bool ->
+  network_mode:Keeper_types.network_mode ->
+  (command_result, string) result
+
+val run_trusted_shell_command_with_status :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  cwd:string ->
+  timeout_sec:float ->
+  cmd:string ->
+  git_creds_enabled:bool ->
+  network_mode:Keeper_types.network_mode ->
+  (command_result, string) result
+
+val run_credentialed_bash :
+  turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t option ->
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  cwd:string ->
+  timeout_sec:float ->
+  cmd:string ->
+  unit ->
+  string
+
+val run_bash :
+  turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t option ->
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  cwd:string ->
+  timeout_sec:float ->
+  cmd:string ->
+  network_mode:Keeper_types.network_mode ->
+  string
+
+val uses_backend :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  cwd:string ->
+  bool
+
+val run_command_with_status :
+  config:Coord.config ->
+  meta:Keeper_types.keeper_meta ->
+  timeout_sec:float ->
+  host:host_command ->
+  backend:backend_command ->
+  routed_result

--- a/lib/keeper/keeper_sandbox_runner.mli
+++ b/lib/keeper/keeper_sandbox_runner.mli
@@ -29,7 +29,8 @@ type host_command =
   }
 
 type backend_command =
-  { cwd : string
+  { route_cwd : string
+  ; cwd : unit -> string
   ; command_text : string
   ; git_creds_enabled : bool
   ; network_mode : Keeper_types.network_mode
@@ -40,6 +41,7 @@ type routed_result =
   { status : Unix.process_status
   ; output : string
   ; via : string
+  ; backend_error : string option
   }
 
 module type Backend = sig

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -62,7 +62,7 @@ let handle_keeper_bash_typed
         in
         let in_playground = Keeper_shell_path.in_playground ~root ~cwd ~meta in
         let sandbox_profile, _sandbox_network_mode =
-          Keeper_sandbox_docker.effective_sandbox_profile ~meta ~in_playground
+          Keeper_sandbox_runner.effective_sandbox_profile ~meta ~in_playground
         in
         let dispatch_sandbox =
           match sandbox_profile with

--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -308,7 +308,7 @@ let handle_keeper_shell
   in
   let render_docker_process_result ~cwd ~cmd ~docker_cmd ~timeout_sec =
     match
-      Keeper_shell_shared.run_docker_shell_command_with_status ~config ~meta ~cwd ~timeout_sec
+      Keeper_sandbox_runner.run_shell_command_with_status ~config ~meta ~cwd ~timeout_sec
         ~cmd:docker_cmd ~git_creds_enabled:false ~network_mode:Network_none
     with
     | Error msg -> error_json ~fields:[ "op", `String op; "cwd", `String cwd ] msg
@@ -320,7 +320,7 @@ let handle_keeper_shell
       let cwd_response =
         Keeper_cwd_response.docker ~host_cwd:cwd
           ~container_cwd:
-            (Keeper_sandbox_docker.docker_private_workspace_cwd ~config
+            (Keeper_sandbox_runner.private_workspace_cwd ~config
                ~meta cwd)
       in
       Yojson.Safe.to_string
@@ -1303,7 +1303,7 @@ let handle_keeper_shell
          in
          let clone_path = Filename.concat repos_dir repo_name in
          let route_fields =
-           if meta.sandbox_profile = Docker then
+           if Keeper_sandbox_runner.uses_backend ~config ~meta ~cwd:repos_dir then
              [ "via", `String "docker" ]
            else
              []
@@ -1361,24 +1361,31 @@ let handle_keeper_shell
                   normalize_existing_origin_to_https clone_path
                 in
                 (* Already cloned — pull latest instead *)
-                let st, out =
-                  if meta.sandbox_profile = Docker then
-                    match
-                      Keeper_shell_shared.run_docker_shell_command_with_status ~config ~meta
-                        ~cwd:repos_dir ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Shell ())
-                        ~cmd:(Printf.sprintf "git -C %s pull --ff-only"
-                                (Filename.quote repo_name))
-                        ~git_creds_enabled:true ~network_mode:Network_inherit
-                    with
-                    | Ok result -> (result.status, result.output)
-                    | Error msg -> (Unix.WEXITED 127, msg)
-                  else
-                    Masc_exec.Exec_gate.run_argv_with_status ~actor:`Coord_git
-                      ~raw_source:("git -C " ^ clone_path ^ " pull --ff-only")
-                      ~summary:"keeper git pull"
-                      ~timeout_sec:(Env_config_exec_timeout.timeout_sec ~caller:Shell ())
-                      [ "git"; "-C"; clone_path; "pull"; "--ff-only" ]
+                let pull_timeout =
+                  Env_config_exec_timeout.timeout_sec ~caller:Shell ()
                 in
+                let pull_result =
+                  Keeper_sandbox_runner.run_command_with_status
+                    ~config ~meta ~timeout_sec:pull_timeout
+                    ~host:
+                      { actor = `Coord_git
+                      ; raw_source = "git -C " ^ clone_path ^ " pull --ff-only"
+                      ; summary = "keeper git pull"
+                      ; env = None
+                      ; cwd = None
+                      ; argv = [ "git"; "-C"; clone_path; "pull"; "--ff-only" ]
+                      }
+                    ~backend:
+                      { cwd = repos_dir
+                      ; command_text =
+                          Printf.sprintf "git -C %s pull --ff-only"
+                            (Filename.quote repo_name)
+                      ; git_creds_enabled = true
+                      ; network_mode = Network_inherit
+                      ; trust = Keeper_sandbox_runner.Trusted_tool
+                      }
+                in
+                let st, out = pull_result.status, pull_result.output in
                 if st = Unix.WEXITED 0 then
                   Keeper_shell_shared.update_playground_repo_cache
                     ~playground_dir:playground ~repo_name ~repo_path:clone_path
@@ -1407,28 +1414,34 @@ let handle_keeper_shell
              if depth > 0 then ["--depth"; string_of_int depth] else []
            in
            let shallow = depth > 0 in
-           let st, out =
-             if meta.sandbox_profile = Docker then
-               let clone_cmd =
-                 String.concat " "
-                   (List.map Filename.quote
-                      ("git" :: "clone" :: depth_args @ [ clone_url; repo_name ]))
-               in
-               match
-                 Keeper_shell_shared.run_docker_shell_command_with_status ~config ~meta ~cwd:repos_dir
-                   ~timeout_sec:(Keeper_tool_policy.clone_timeout_sec ())
-                   ~cmd:clone_cmd
-                   ~git_creds_enabled:true ~network_mode:Network_inherit
-               with
-               | Ok result -> (result.status, result.output)
-               | Error msg -> (Unix.WEXITED 127, msg)
-             else
-               Masc_exec.Exec_gate.run_argv_with_status ~actor:`Coord_git
-                 ~raw_source:("git clone " ^ String.concat " " depth_args ^ " " ^ clone_url ^ " " ^ clone_path)
-                 ~summary:"keeper git clone"
-                 ~timeout_sec:(Keeper_tool_policy.clone_timeout_sec ())
-                 ("git" :: "clone" :: depth_args @ [ clone_url; clone_path ])
+           let clone_cmd =
+             String.concat " "
+               (List.map Filename.quote
+                  ("git" :: "clone" :: depth_args @ [ clone_url; repo_name ]))
            in
+           let clone_timeout = Keeper_tool_policy.clone_timeout_sec () in
+           let clone_result =
+             Keeper_sandbox_runner.run_command_with_status
+               ~config ~meta ~timeout_sec:clone_timeout
+               ~host:
+                 { actor = `Coord_git
+                 ; raw_source =
+                     "git clone " ^ String.concat " " depth_args ^ " "
+                     ^ clone_url ^ " " ^ clone_path
+                 ; summary = "keeper git clone"
+                 ; env = None
+                 ; cwd = None
+                 ; argv = "git" :: "clone" :: depth_args @ [ clone_url; clone_path ]
+                 }
+               ~backend:
+                 { cwd = repos_dir
+                 ; command_text = clone_cmd
+                 ; git_creds_enabled = true
+                 ; network_mode = Network_inherit
+                 ; trust = Keeper_sandbox_runner.Trusted_tool
+                 }
+           in
+           let st, out = clone_result.status, clone_result.output in
            if st = Unix.WEXITED 0 then
              Keeper_shell_shared.update_playground_repo_cache
                ~playground_dir:playground ~repo_name ~repo_path:clone_path
@@ -1492,7 +1505,7 @@ let handle_keeper_shell
         in
         let gh_base ~ok ~cwd ~command extras =
           let route_fields =
-            if meta.sandbox_profile = Docker then
+            if Keeper_sandbox_runner.uses_backend ~config ~meta ~cwd then
               [ "via", `String "docker" ]
             else
               []
@@ -1532,16 +1545,11 @@ let handle_keeper_shell
              [gate_typed] + [validate_shell_ir_paths] before the
              actual dispatch. The dispatch step itself still uses the
              existing argv path ([run_argv_with_status] /
-             [run_docker_shell_command_with_status]); routing the
+             sandbox runner); routing the
              execution through [Exec_dispatch.dispatch_decided] is deferred
              (gh requires env / timeout / docker-routing fields that
              [Exec_dispatch] does not yet thread). *)
-          let gh_sandbox_target =
-            if meta.sandbox_profile = Docker
-            then Masc_exec.Sandbox_target.host ()
-              (* docker routing handled below; gate runs on host-shape IR *)
-            else Masc_exec.Sandbox_target.host ()
-          in
+          let gh_sandbox_target = Masc_exec.Sandbox_target.host () in
           let gh_ir =
             Keeper_gh_shared.gh_simple_command_to_shell_ir
               ~sandbox:gh_sandbox_target
@@ -1580,26 +1588,32 @@ let handle_keeper_shell
             match gh_path_verdict with
             | Error msg -> Error (Printf.sprintf "gh_path_reject: %s" msg)
             | Ok () ->
-            if meta.sandbox_profile = Docker
-            then
-              match
-                Keeper_shell_shared.run_docker_shell_command_with_status ~config ~meta ~cwd
-                  ~timeout_sec ~cmd:display_command
-                  ~git_creds_enabled:true ~network_mode:Network_inherit
-              with
-              | Ok result -> Ok (result.status, result.output)
-              | Error msg -> Error msg
-            else
-              (match Keeper_gh_env.keeper_process_env config ~keeper_name:meta.name with
-               | Error err -> Error err
-               | Ok env ->
-                   let gh_argv =
-                     "gh" :: Keeper_gh_shared.gh_simple_command_argv parsed_command
-                   in
-                   Ok (Masc_exec.Exec_gate.run_argv_with_status ~actor:`Keeper_shell
-                         ~raw_source:(String.concat " " gh_argv)
-                         ~summary:"keeper gh command"
-                         ?env ~cwd ~timeout_sec gh_argv))
+            (match Keeper_gh_env.keeper_process_env config ~keeper_name:meta.name with
+             | Error err -> Error err
+             | Ok env ->
+               let gh_argv =
+                 "gh" :: Keeper_gh_shared.gh_simple_command_argv parsed_command
+               in
+               let result =
+                 Keeper_sandbox_runner.run_command_with_status
+                   ~config ~meta ~timeout_sec
+                   ~host:
+                     { actor = `Keeper_shell
+                     ; raw_source = String.concat " " gh_argv
+                     ; summary = "keeper gh command"
+                     ; env
+                     ; cwd = Some cwd
+                     ; argv = gh_argv
+                     }
+                   ~backend:
+                     { cwd
+                     ; command_text = display_command
+                     ; git_creds_enabled = true
+                     ; network_mode = Network_inherit
+                     ; trust = Keeper_sandbox_runner.User_shell
+                     }
+               in
+               Ok (result.status, result.output))
           in
           match gh_process with
           | Error msg ->

--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -1376,7 +1376,8 @@ let handle_keeper_shell
                       ; argv = [ "git"; "-C"; clone_path; "pull"; "--ff-only" ]
                       }
                     ~backend:
-                      { cwd = repos_dir
+                      { route_cwd = repos_dir
+                      ; cwd = (fun () -> repos_dir)
                       ; command_text =
                           Printf.sprintf "git -C %s pull --ff-only"
                             (Filename.quote repo_name)
@@ -1432,9 +1433,10 @@ let handle_keeper_shell
                  ; env = None
                  ; cwd = None
                  ; argv = "git" :: "clone" :: depth_args @ [ clone_url; clone_path ]
-                 }
+               }
                ~backend:
-                 { cwd = repos_dir
+                 { route_cwd = repos_dir
+                 ; cwd = (fun () -> repos_dir)
                  ; command_text = clone_cmd
                  ; git_creds_enabled = true
                  ; network_mode = Network_inherit
@@ -1588,12 +1590,20 @@ let handle_keeper_shell
             match gh_path_verdict with
             | Error msg -> Error (Printf.sprintf "gh_path_reject: %s" msg)
             | Ok () ->
-            (match Keeper_gh_env.keeper_process_env config ~keeper_name:meta.name with
+            let gh_argv =
+              "gh" :: Keeper_gh_shared.gh_simple_command_argv parsed_command
+            in
+            let use_backend =
+              Keeper_sandbox_runner.uses_backend ~config ~meta ~cwd
+            in
+            let host_env_result =
+              if use_backend
+              then Ok None
+              else Keeper_gh_env.keeper_process_env config ~keeper_name:meta.name
+            in
+            (match host_env_result with
              | Error err -> Error err
              | Ok env ->
-               let gh_argv =
-                 "gh" :: Keeper_gh_shared.gh_simple_command_argv parsed_command
-               in
                let result =
                  Keeper_sandbox_runner.run_command_with_status
                    ~config ~meta ~timeout_sec
@@ -1604,16 +1614,19 @@ let handle_keeper_shell
                      ; env
                      ; cwd = Some cwd
                      ; argv = gh_argv
-                     }
-                   ~backend:
-                     { cwd
+                   }
+                 ~backend:
+                     { route_cwd = cwd
+                     ; cwd = (fun () -> cwd)
                      ; command_text = display_command
                      ; git_creds_enabled = true
                      ; network_mode = Network_inherit
                      ; trust = Keeper_sandbox_runner.User_shell
                      }
                in
-               Ok (result.status, result.output))
+               match result.backend_error with
+               | Some msg -> Error msg
+               | None -> Ok (result.status, result.output))
           in
           match gh_process with
           | Error msg ->

--- a/lib/keeper/keeper_shell_shared.ml
+++ b/lib/keeper/keeper_shell_shared.ml
@@ -82,13 +82,11 @@ let gh_min_timeout_sec =
 let git_meta_timeout_sec = env_float "MASC_KEEPER_GIT_META_TIMEOUT_SEC" 5.0
 
 (* Floor applied to caller-supplied [timeout_sec] for keeper_bash when
-   the command runs through the *native* (non-Docker) executor.  The
-   Docker dispatch path re-clamps inside
-   [Keeper_sandbox_docker.run_docker_shell_command_with_status_internal]
-   to [docker_run_min_timeout_sec] because container cold start adds
-   10-60s on top of the actual command — see runtime log issue #5
+   the command runs through the native executor.  Container-backed
+   dispatch re-clamps inside its backend because cold start adds 10-60s
+   on top of the actual command — see runtime log issue #5
    (2026-05-20).  Keeping a separate native floor avoids penalising
-   the host-side fast path for the Docker path's overhead. *)
+   the host-side fast path for backend overhead. *)
 let keeper_bash_native_min_timeout_sec =
   Timeout_floor.default_sec Timeout_floor.Native_shell
 ;;
@@ -681,14 +679,3 @@ let resolve_keeper_shell_read_path
         resolved_raw_path
     in
     resolve_with_autocorrect resolver_path
-
-(* Sandbox infrastructure stays in Keeper_sandbox_docker; command-shape
-   interpretation stays in Keeper_shell_command_semantics. *)
-let effective_sandbox_profile = Keeper_sandbox_docker.effective_sandbox_profile
-
-
-let ensure_keeper_sandbox_runtime = Keeper_sandbox_docker.ensure_keeper_sandbox_runtime
-let command_uses_nested_container_runtime = Keeper_sandbox_docker.command_uses_nested_container_runtime
-let run_docker_shell_command_with_status = Keeper_sandbox_docker.run_docker_shell_command_with_status
-let run_docker_credentialed_bash = Keeper_sandbox_docker.run_docker_credentialed_bash
-let run_docker_bash = Keeper_sandbox_docker.run_docker_bash

--- a/lib/keeper/keeper_shell_shared.mli
+++ b/lib/keeper/keeper_shell_shared.mli
@@ -78,12 +78,10 @@ val keeper_bash_native_min_timeout_sec : float
     disk or git metadata; lower caller-supplied values produce noisy
     partial-output timeout failures rather than useful latency bounds.
 
-    The Docker dispatch path re-clamps to
-    {!Keeper_sandbox_docker.docker_run_min_timeout_sec} inside
-    [run_docker_shell_command_with_status_internal] because container
-    cold start adds 10-60s on top of the actual command (runtime log
-    issue #5, 2026-05-20).  Keeping a separate native floor avoids
-    penalising the host-side fast path for the Docker path's overhead. *)
+    The sandbox backend dispatch path re-clamps again where needed because
+    container cold start can add 10-60s on top of the actual command
+    (runtime log issue #5, 2026-05-20).  Keeping a separate native floor
+    avoids penalising the host-side fast path for backend overhead. *)
 
 val keeper_bash_min_timeout_sec_for_args : Yojson.Safe.t -> float
 (** Minimum timeout_sec floor for a typed keeper_bash invocation.
@@ -232,50 +230,4 @@ val resolve_keeper_shell_read_path :
     fails.  Guards against playground-prefix doubling when both
     [cwd] and [path] independently include the playground prefix. *)
 
-(** {1 Sandbox dispatch and command semantics} *)
-
-val effective_sandbox_profile :
-  meta:Keeper_types.keeper_meta ->
-  in_playground:bool ->
-  Keeper_types.sandbox_profile * Keeper_types.network_mode
-(** Alias of {!Keeper_sandbox_docker.effective_sandbox_profile}. *)
-
-val ensure_keeper_sandbox_runtime :
-  timeout_sec:float -> (string list, string) result
-(** Alias of {!Keeper_sandbox_docker.ensure_keeper_sandbox_runtime}. *)
-
-val command_uses_nested_container_runtime : string -> bool
-(** Alias of {!Keeper_sandbox_docker.command_uses_nested_container_runtime}. *)
-
-val run_docker_shell_command_with_status :
-  config:Coord.config ->
-  meta:Keeper_types.keeper_meta ->
-  cwd:string ->
-  timeout_sec:float ->
-  cmd:string ->
-  git_creds_enabled:bool ->
-  network_mode:Keeper_types.network_mode ->
-  (Keeper_sandbox_docker.docker_shell_result, string) result
-(** Alias of {!Keeper_sandbox_docker.run_docker_shell_command_with_status}. *)
-
-val run_docker_credentialed_bash :
-  turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t option ->
-  config:Coord.config ->
-  meta:Keeper_types.keeper_meta ->
-  cwd:string ->
-  timeout_sec:float ->
-  cmd:string ->
-  unit ->
-  string
-(** Alias of {!Keeper_sandbox_docker.run_docker_credentialed_bash}. *)
-
-val run_docker_bash :
-  turn_sandbox_runtime:Keeper_turn_sandbox_runtime.t option ->
-  config:Coord.config ->
-  meta:Keeper_types.keeper_meta ->
-  cwd:string ->
-  timeout_sec:float ->
-  cmd:string ->
-  network_mode:Keeper_types.network_mode ->
-  string
-(** Alias of {!Keeper_sandbox_docker.run_docker_bash}. *)
+(** {1 Command semantics} *)

--- a/lib/keeper/keeper_tool_github_pr.ml
+++ b/lib/keeper/keeper_tool_github_pr.ml
@@ -148,27 +148,27 @@ let quote_argv argv =
 
 let run_gh_argv ~(config : Coord.config) ~(meta : keeper_meta) ~env ~cwd
     ~timeout_sec argv =
-  if meta.sandbox_profile = Docker then
-    match
-      Keeper_sandbox_docker.run_trusted_docker_shell_command_with_status
-        ~config ~meta ~cwd ~timeout_sec ~cmd:(quote_argv argv)
-        ~git_creds_enabled:true ~network_mode:Network_inherit
-    with
-    | Ok result ->
-        { status = result.Keeper_sandbox_docker.status
-        ; output = result.output
-        ; via = "docker"
+  let command_text = quote_argv argv in
+  let result =
+    Keeper_sandbox_runner.run_command_with_status
+      ~config ~meta ~timeout_sec
+      ~host:
+        { actor = `Coord_git
+        ; raw_source = command_text
+        ; summary = "keeper tool gh host"
+        ; env = Some env
+        ; cwd = Some cwd
+        ; argv
         }
-    | Error msg ->
-        { status = Unix.WEXITED 1; output = msg; via = "docker" }
-  else
-    let status, output =
-      Masc_exec.Exec_gate.run_argv_with_status ~actor:`Coord_git
-        ~raw_source:(quote_argv argv)
-        ~summary:"keeper tool gh host"
-        ~env ~cwd ~timeout_sec argv
-    in
-    { status; output; via = "host" }
+      ~backend:
+        { cwd
+        ; command_text
+        ; git_creds_enabled = true
+        ; network_mode = Network_inherit
+        ; trust = Keeper_sandbox_runner.Trusted_tool
+        }
+  in
+  { status = result.status; output = result.output; via = result.via }
 
 let sandbox_profile_string (meta : keeper_meta) =
   match meta.sandbox_profile with

--- a/lib/keeper/keeper_tool_github_pr.ml
+++ b/lib/keeper/keeper_tool_github_pr.ml
@@ -141,6 +141,7 @@ type gh_exec_result =
   { status : Unix.process_status
   ; output : string
   ; via : string
+  ; error : string option
   }
 
 let quote_argv argv =
@@ -161,14 +162,19 @@ let run_gh_argv ~(config : Coord.config) ~(meta : keeper_meta) ~env ~cwd
         ; argv
         }
       ~backend:
-        { cwd
+        { route_cwd = cwd
+        ; cwd = (fun () -> cwd)
         ; command_text
         ; git_creds_enabled = true
         ; network_mode = Network_inherit
         ; trust = Keeper_sandbox_runner.Trusted_tool
         }
   in
-  { status = result.status; output = result.output; via = result.via }
+  { status = result.status
+  ; output = result.output
+  ; via = result.via
+  ; error = result.backend_error
+  }
 
 let sandbox_profile_string (meta : keeper_meta) =
   match meta.sandbox_profile with
@@ -224,8 +230,13 @@ let run_gh ~tool ~operation ~config ~meta ~args ~write argv =
             run_gh_argv ~config ~meta ~env ~cwd ~timeout_sec argv
           in
           let result_ok = status_ok result.status in
+          let extra_fields =
+            match result.error with
+            | None -> []
+            | Some error -> [ "error", `String error ]
+          in
           output_json ~ok:result_ok ~tool ~operation ~meta ~binding ~state
-            ~cwd ~via:result.via ~output:result.output ())
+            ~cwd ~via:result.via ~output:result.output ~extra_fields ())
 
 let handle_keeper_pr_list ~(config : Coord.config) ~(meta : keeper_meta)
     ~(args : Yojson.Safe.t) =

--- a/lib/keeper/keeper_tool_pr_review.ml
+++ b/lib/keeper/keeper_tool_pr_review.ml
@@ -141,6 +141,7 @@ type pr_review_exec_result =
   { status : Unix.process_status
   ; output : string
   ; via : string
+  ; error : string option
   }
 
 let status_ok = function
@@ -237,14 +238,19 @@ let run_pr_review_argv
         ; argv
         }
       ~backend:
-        { cwd = sandbox_pr_review_cwd ~config meta
+        { route_cwd = root
+        ; cwd = (fun () -> sandbox_pr_review_cwd ~config meta)
         ; command_text
         ; git_creds_enabled = true
         ; network_mode = Network_inherit
         ; trust = Keeper_sandbox_runner.User_shell
         }
   in
-  { status = result.status; output = result.output; via = result.via }
+  { status = result.status
+  ; output = result.output
+  ; via = result.via
+  ; error = result.backend_error
+  }
 
 let repo_unresolved_json ~(config : Coord.config) (meta : keeper_meta)
     ~repo_slug ~(result : pr_review_exec_result) ?pr_number ?event () =

--- a/lib/keeper/keeper_tool_pr_review.ml
+++ b/lib/keeper/keeper_tool_pr_review.ml
@@ -158,15 +158,17 @@ let effective_repo_slug ~(config : Coord.config) ~(repo : string)
     | Some slug -> Ok slug
     | None -> Error "Could not determine repository. Provide repo parameter."
 
-let docker_pr_review_cwd ~(config : Coord.config) meta =
+let sandbox_pr_review_cwd ~(config : Coord.config) meta =
   let root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   let cwd = Filename.concat root ".gh-pr-review" in
   ignore (Keeper_fs.ensure_dir cwd);
   cwd
 
 let pr_review_body_file_dir ~(config : Coord.config) (meta : keeper_meta) =
-  if meta.sandbox_profile = Docker
-  then docker_pr_review_cwd ~config meta
+  if
+    Keeper_sandbox_runner.uses_backend
+      ~config ~meta ~cwd:(Keeper_sandbox.host_root_abs_of_meta ~config meta)
+  then sandbox_pr_review_cwd ~config meta
   else (
     let root = Keeper_alerting_path.project_root_of_config config in
     let dir = Filename.concat (Filename.concat root Common.masc_dirname) "pr-review" in
@@ -202,7 +204,11 @@ let with_pr_review_body_file ~(config : Coord.config) ~(meta : keeper_meta) ~bod
   in
   let host_path = create_file 0 in
   let command_path =
-    if meta.sandbox_profile = Docker then Filename.basename host_path else host_path
+    if
+      Keeper_sandbox_runner.uses_backend
+        ~config ~meta ~cwd:(Keeper_sandbox.host_root_abs_of_meta ~config meta)
+    then Filename.basename host_path
+    else host_path
   in
   Fun.protect
     ~finally:(fun () ->
@@ -217,39 +223,28 @@ let run_pr_review_argv
       ~summary
       ~argv
   =
-  if meta.sandbox_profile = Docker then
-    let cmd = Keeper_gh_pr_review_cli.quote_argv argv in
-    match
-      Keeper_shell_shared.run_docker_shell_command_with_status
-        ~config ~meta
-        ~cwd:(docker_pr_review_cwd ~config meta)
-        ~timeout_sec ~cmd
-        ~git_creds_enabled:true
-        ~network_mode:Network_inherit
-    with
-    | Ok result ->
-        { status = result.Keeper_sandbox_docker.status
-        ; output = result.output
-        ; via = "docker"
+  let command_text = Keeper_gh_pr_review_cli.quote_argv argv in
+  let root = Keeper_alerting_path.project_root_of_config config in
+  let result =
+    Keeper_sandbox_runner.run_command_with_status
+      ~config ~meta ~timeout_sec
+      ~host:
+        { actor = `Keeper_shell
+        ; raw_source = command_text
+        ; summary
+        ; env = Keeper_gh_env.process_env config
+        ; cwd = Some root
+        ; argv
         }
-    | Error msg ->
-        { status = Unix.WEXITED 1
-        ; output = msg
-        ; via = "docker"
+      ~backend:
+        { cwd = sandbox_pr_review_cwd ~config meta
+        ; command_text
+        ; git_creds_enabled = true
+        ; network_mode = Network_inherit
+        ; trust = Keeper_sandbox_runner.User_shell
         }
-  else
-    let root = Keeper_alerting_path.project_root_of_config config in
-    let status, output =
-      Masc_exec.Exec_gate.run_argv_with_status
-        ~actor:`Keeper_shell
-        ~raw_source:(Keeper_gh_pr_review_cli.quote_argv argv)
-        ~summary
-        ?env:(Keeper_gh_env.process_env config)
-        ~cwd:root
-        ~timeout_sec
-        argv
-    in
-    { status; output; via = "host" }
+  in
+  { status = result.status; output = result.output; via = result.via }
 
 let repo_unresolved_json ~(config : Coord.config) (meta : keeper_meta)
     ~repo_slug ~(result : pr_review_exec_result) ?pr_number ?event () =

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -25,7 +25,7 @@ let make_tool_bundle
   (* PR-3b (#11611 part 1): replace eager [Keeper_turn_sandbox_runtime]
      instances with a factory.  in_playground/cwd are unknown at
      turn-start, so the factory defers
-     [Keeper_sandbox_docker.effective_sandbox_profile] resolution until
+     [Keeper_sandbox_runner.effective_sandbox_profile] resolution until
      each tool call site that already knows its [cwd].  The git variant
      carries a [default_network_override] so resolved runtimes always
      inherit the host network. *)

--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -4,7 +4,7 @@
   "keeper_mli_missing": 0,
   "coord_mli_missing": 0,
   "godsplit_count": 0,
-  "lib_dune_lines": 643,
+  "lib_dune_lines": 653,
   "inferred_dump_headers": 0,
   "lib_other_mli_missing": 0
 }

--- a/test/dune
+++ b/test/dune
@@ -245,6 +245,7 @@
   test_keeper_tool_affinity
   test_keeper_tool_alias
   test_keeper_sandbox_containment
+  test_keeper_sandbox_runner
   test_keeper_transition_audit
   test_keeper_shell_containment
   test_keeper_sandbox_docker_route
@@ -564,6 +565,7 @@
   test_keeper_tool_affinity
   test_keeper_tool_alias
   test_keeper_sandbox_containment
+  test_keeper_sandbox_runner
   test_keeper_transition_audit
   test_keeper_shell_containment
   test_keeper_sandbox_docker_route

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -127,6 +127,17 @@ let test_sandbox_failure_recording_not_shell_docker_coupled () =
   assert_contains failure_ml "Sandbox backend exec failure";
   assert_not_contains failure_ml "keeper_shell_docker.ml"
 
+let test_tool_layer_does_not_select_concrete_backend () =
+  List.iter
+    (fun rel ->
+       assert_contains rel "Keeper_sandbox_runner.run_command_with_status";
+       assert_not_contains rel "Keeper_sandbox_docker.";
+       assert_not_contains rel "meta.sandbox_profile = Docker";
+       assert_not_contains rel "run_docker_shell_command_with_status")
+    [ "lib/keeper/keeper_tool_github_pr.ml"
+    ; "lib/keeper/keeper_tool_pr_review.ml"
+    ]
+
 let () =
   Alcotest.run
     "keeper_sandbox_boundary_policy"
@@ -160,5 +171,9 @@ let () =
             "sandbox failure recording is not shell-docker coupled"
             `Quick
             test_sandbox_failure_recording_not_shell_docker_coupled;
+          Alcotest.test_case
+            "tool layer does not select concrete backend"
+            `Quick
+            test_tool_layer_does_not_select_concrete_backend;
         ] );
     ]

--- a/test/test_keeper_sandbox_runner.ml
+++ b/test/test_keeper_sandbox_runner.ml
@@ -1,0 +1,170 @@
+open Alcotest
+open Masc_mcp
+
+let temp_dir prefix =
+  let dir = Filename.temp_file prefix "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir path =
+  let rec rm p =
+    match Unix.lstat p with
+    | { Unix.st_kind = Unix.S_DIR; _ } ->
+      Array.iter
+        (fun name -> rm (Filename.concat p name))
+        (Sys.readdir p);
+      Unix.rmdir p
+    | _ -> Unix.unlink p
+    | exception Unix.Unix_error _ -> ()
+  in
+  rm path
+
+let make_meta ~sandbox : Keeper_types.keeper_meta =
+  let json =
+    `Assoc
+      [ "name", `String "runner-test"
+      ; "agent_name", `String "runner-test-agent"
+      ; "trace_id", `String "runner-test-trace"
+      ; "goal", `String "sandbox runner boundary"
+      ; "allowed_paths", `List [ `String "*" ]
+      ; ( "sandbox_profile",
+          `String (Keeper_types.sandbox_profile_to_string sandbox) )
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok meta -> meta
+  | Error e -> Alcotest.fail e
+
+module Fake_backend = struct
+  let calls = ref []
+
+  let record call =
+    calls := call :: !calls
+
+  let egress_policy_path ~config:_ ~meta:_ =
+    "/fake/egress.json"
+
+  let effective_sandbox_profile ~meta:_ ~in_playground:_ =
+    Keeper_types.Docker, Keeper_types.Network_none
+
+  let ensure_runtime ~timeout_sec:_ =
+    Ok [ "--fake-seccomp" ]
+
+  let command_uses_nested_runtime cmd =
+    String.equal cmd "nested"
+
+  let private_workspace_cwd ~config:_ ~meta:_ cwd =
+    "/fake/container" ^ cwd
+
+  let result ~status ~output ~network_mode ~cwd
+      : Keeper_sandbox_runner.command_result =
+    { status = Unix.WEXITED status
+    ; output
+    ; image = "fake-image"
+    ; network_label = Keeper_types.network_mode_to_string network_mode
+    ; cmd_stages = []
+    ; cwd
+    ; semantic_status = None
+    ; semantic_ok = status = 0
+    }
+
+  let run_shell_command_with_status ~config:_ ~meta:_ ~cwd ~timeout_sec:_ ~cmd
+      ~git_creds_enabled ~network_mode =
+    record (Printf.sprintf "shell:%s:%b" cmd git_creds_enabled);
+    Ok (result ~status:3 ~output:("shell:" ^ cmd) ~network_mode ~cwd)
+
+  let run_trusted_shell_command_with_status ~config:_ ~meta:_ ~cwd
+      ~timeout_sec:_ ~cmd ~git_creds_enabled ~network_mode =
+    record (Printf.sprintf "trusted:%s:%b" cmd git_creds_enabled);
+    Ok (result ~status:0 ~output:("trusted:" ^ cmd) ~network_mode ~cwd)
+
+  let run_credentialed_bash ~turn_sandbox_runtime:_ ~config:_ ~meta:_ ~cwd:_
+      ~timeout_sec:_ ~cmd () =
+    record ("credentialed:" ^ cmd);
+    "credentialed:" ^ cmd
+
+  let run_bash ~turn_sandbox_runtime:_ ~config:_ ~meta:_ ~cwd:_ ~timeout_sec:_
+      ~cmd ~network_mode:_ =
+    record ("bash:" ^ cmd);
+    "bash:" ^ cmd
+end
+
+module Runner = Keeper_sandbox_runner.Make (Fake_backend)
+
+let with_fixture f =
+  let base = temp_dir "keeper_sandbox_runner_" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base)
+    (fun () ->
+       let config = Coord.default_config base in
+       let meta = make_meta ~sandbox:Keeper_types.Docker in
+       f ~config ~meta)
+
+let test_functor_delegates_user_shell () =
+  Fake_backend.calls := [];
+  with_fixture (fun ~config ~meta ->
+      match
+        Runner.run_shell_command_with_status ~config ~meta ~cwd:"/work"
+          ~timeout_sec:5.0 ~cmd:"git status" ~git_creds_enabled:false
+          ~network_mode:Keeper_types.Network_none
+      with
+      | Error e -> Alcotest.fail e
+      | Ok result ->
+        check int "status" 3
+          (match result.status with Unix.WEXITED n -> n | _ -> -1);
+        check string "output" "shell:git status" result.output;
+        check (list string) "calls"
+          [ "shell:git status:false" ]
+          (List.rev !Fake_backend.calls))
+
+let test_functor_delegates_trusted_tool () =
+  Fake_backend.calls := [];
+  with_fixture (fun ~config ~meta ->
+      match
+        Runner.run_trusted_shell_command_with_status ~config ~meta ~cwd:"/work"
+          ~timeout_sec:5.0 ~cmd:"gh pr view" ~git_creds_enabled:true
+          ~network_mode:Keeper_types.Network_inherit
+      with
+      | Error e -> Alcotest.fail e
+      | Ok result ->
+        check int "status" 0
+          (match result.status with Unix.WEXITED n -> n | _ -> -1);
+        check string "output" "trusted:gh pr view" result.output;
+        check string "network label" "inherit" result.network_label;
+        check (list string) "calls"
+          [ "trusted:gh pr view:true" ]
+          (List.rev !Fake_backend.calls))
+
+let test_uses_backend_respects_profile () =
+  let base = temp_dir "keeper_sandbox_runner_route_" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base)
+    (fun () ->
+       let config = Coord.default_config base in
+       let docker_meta = make_meta ~sandbox:Keeper_types.Docker in
+       let local_meta = make_meta ~sandbox:Keeper_types.Local in
+       let docker_cwd =
+         Keeper_sandbox.host_root_abs_of_meta ~config docker_meta
+       in
+       let local_cwd =
+         Keeper_sandbox.host_root_abs_of_meta ~config local_meta
+       in
+       check bool "docker profile uses backend" true
+         (Keeper_sandbox_runner.uses_backend
+            ~config ~meta:docker_meta ~cwd:docker_cwd);
+       check bool "local profile uses host" false
+         (Keeper_sandbox_runner.uses_backend
+            ~config ~meta:local_meta ~cwd:local_cwd))
+
+let () =
+  Alcotest.run
+    "keeper_sandbox_runner"
+    [ ( "mock-backend",
+        [ test_case "delegates user shell" `Quick test_functor_delegates_user_shell
+        ; test_case "delegates trusted tool" `Quick test_functor_delegates_trusted_tool
+        ] )
+    ; ( "routing",
+        [ test_case "profile selects backend" `Quick test_uses_backend_respects_profile
+        ] )
+    ]

--- a/test/test_keeper_sandbox_runner.ml
+++ b/test/test_keeper_sandbox_runner.ml
@@ -157,6 +157,37 @@ let test_uses_backend_respects_profile () =
          (Keeper_sandbox_runner.uses_backend
             ~config ~meta:local_meta ~cwd:local_cwd))
 
+let test_local_route_does_not_force_backend_cwd () =
+  let base = temp_dir "keeper_sandbox_runner_lazy_cwd_" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base)
+    (fun () ->
+       let config = Coord.default_config base in
+       let meta = make_meta ~sandbox:Keeper_types.Local in
+       let cwd = Keeper_sandbox.host_root_abs_of_meta ~config meta in
+       let result =
+         Keeper_sandbox_runner.run_command_with_status
+           ~config ~meta ~timeout_sec:5.0
+           ~host:
+             { actor = `Keeper_shell
+             ; raw_source = "true"
+             ; summary = "runner lazy cwd host smoke"
+             ; env = None
+             ; cwd = Some cwd
+             ; argv = [ "true" ]
+             }
+           ~backend:
+             { route_cwd = cwd
+             ; cwd = (fun () -> failwith "backend cwd evaluated on host route")
+             ; command_text = "true"
+             ; git_creds_enabled = false
+             ; network_mode = Keeper_types.Network_none
+             ; trust = Keeper_sandbox_runner.User_shell
+             }
+       in
+       check string "via" "host" result.via;
+       check bool "no backend error" true (Option.is_none result.backend_error))
+
 let () =
   Alcotest.run
     "keeper_sandbox_runner"
@@ -166,5 +197,9 @@ let () =
         ] )
     ; ( "routing",
         [ test_case "profile selects backend" `Quick test_uses_backend_respects_profile
+        ; test_case
+            "local route does not force backend cwd"
+            `Quick
+            test_local_route_does_not_force_backend_cwd
         ] )
     ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -25,7 +25,16 @@ module OMR = Masc_mcp.Cascade_runtime
 module AQ = Masc_mcp.Keeper_approval_queue
 module Keeper_types = Masc_mcp.Keeper_types
 
-let oas_error_cascade_name = Masc_mcp.Keeper_turn_driver.cascade_name_of_string
+let oas_error_cascade_name raw =
+  let normalized = Masc_mcp.Keeper_cascade_profile.normalize_declared_name raw in
+  let canonical =
+    if Cascade_name.is_canonical_prefix normalized
+    then normalized
+    else "tier-group." ^ normalized
+  in
+  Cascade_name.of_string_exn canonical
+;;
+
 let phase_buffer_cascade_name () =
   Masc_mcp.Keeper_cascade_profile.cascade_name_for_use
     Masc_mcp.Keeper_cascade_profile.Phase_buffer
@@ -3645,8 +3654,7 @@ let test_metrics_surface_model_prefers_successful_cascade_label () =
       ~output_tok:50
       ~cascade_observation:
         { Masc_mcp.Cascade_legacy_runner.cascade_name =
-            Masc_mcp.Keeper_cascade_profile.Runtime_name
-              Masc_mcp.(Keeper_config.default_cascade_name ())
+            oas_error_cascade_name Masc_mcp.(Keeper_config.default_cascade_name ())
         ; strategy = Some "round_robin"
         ; configured_labels = [ "llama:auto" ]
         ; candidate_models = [ "llama:qwen3.5-35b-a3b-ud-q8-xl"; selected_label ]
@@ -4298,8 +4306,7 @@ let test_append_metrics_snapshot_includes_cascade_observation () =
          ; cascade_observation =
              Some
                { Masc_mcp.Cascade_legacy_runner.cascade_name =
-                   Masc_mcp.Keeper_cascade_profile.Runtime_name
-                     Masc_mcp.(Keeper_config.default_cascade_name ())
+                   oas_error_cascade_name Masc_mcp.(Keeper_config.default_cascade_name ())
                ; strategy = Some "round_robin"
                ; configured_labels = [ "llama:auto" ]
                ; candidate_models =
@@ -5818,8 +5825,7 @@ let test_streaming_cancel_records_supervisor_stop_when_fiber_stop_set () =
          ~run_meta:meta
          ~run_generation:meta.runtime.generation
          ~cascade_name:
-           (Masc_mcp.Keeper_execution_receipt.cascade_name_of_string
-              (Masc_mcp.Keeper_types.cascade_name_of_meta meta))
+           (oas_error_cascade_name (Masc_mcp.Keeper_types.cascade_name_of_meta meta))
          ~keeper_turn_id:meta.runtime.usage.total_turns
          ();
        let supervisor_request_after =


### PR DESCRIPTION
## Summary
- add `Keeper_sandbox_runner` as the backend-neutral Tool -> Backend execution facade
- remove legacy `Keeper_shell_shared.run_docker*` aliases and route PR/GitHub tool commands through `run_command_with_status`
- add mock-backed runner tests and boundary guards so tool modules cannot select `Keeper_sandbox_docker` directly
- update the boundary plan/docs with the Tool/Backend split and verification gates
- unblock stale CI ratchets by adding the missing sandbox docker semantic interface and refreshing the current `lib/dune` structure baseline
- align stale unified-turn test fixtures with typed `Cascade_name.t` values so CI `@check` compiles after #18184
- address Codex review: avoid host GH env precheck on backend-routed gh commands, preserve backend errors as structured gh failures, and defer sandbox PR-review cwd creation until backend routing is selected

## Tests
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_sandbox_runner.exe test/test_keeper_sandbox_boundary_policy.exe test/test_keeper_sandbox_docker_route.exe test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_sandbox_runner.exe`
- `./_build/default/test/test_keeper_sandbox_boundary_policy.exe`
- `./_build/default/test/test_keeper_sandbox_docker_route.exe test docker_route_fires 17-21 --show-errors --compact`
- `scripts/ocaml-structure-ratchet.sh`
- `bash scripts/audit-shell-ir-consumption.sh --baseline scripts/shell-ir-consumption-baseline.json`
- `opam exec -- ocamlformat --check lib/keeper/keeper_sandbox_runner.ml lib/keeper/keeper_sandbox_runner.mli lib/keeper/keeper_shell_ops.ml lib/keeper/keeper_tool_github_pr.ml lib/keeper/keeper_tool_pr_review.ml test/test_keeper_sandbox_runner.ml`
- `git diff --check`
- `scripts/check-version-truth.sh`

#18189 has been merged; this PR is now directly based on `main`.

Follow-up issue for the intentional structure-ratchet baseline refresh: #18194.