### PR TITLE
[RFC-0160 S7] Shell IR consumption CI ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -973,6 +973,25 @@ jobs:
       - name: Run silent-failure ratchet
         run: scripts/silent-failure-ratchet.sh
 
+  shell-ir-ratchet:
+    name: Shell IR Consumption Ratchet
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [pr-live-gate, changes]
+    if: ${{ always() && !cancelled() && needs.pr-live-gate.outputs.run_heavy == 'true' && needs.changes.result == 'success' && (needs.changes.outputs.lib_deps == 'true' || needs.changes.outputs.build == 'true') }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install ripgrep and jq
+        run: |
+          sudo apt-get install -y -qq ripgrep
+          sudo apt-get install -y -qq jq
+
+      - name: Run Shell IR consumption ratchet
+        run: scripts/audit-shell-ir-consumption.sh --baseline scripts/shell-ir-consumption-baseline.json
+
   keeper-cwd-leak-gate:
     name: Keeper Cwd Leak Gate
     runs-on: ubuntu-latest
@@ -1031,7 +1050,7 @@ jobs:
   ci-gate:
     name: CI Gate
     runs-on: ubuntu-latest
-    needs: [pr-sync-check, pr-live-gate, changes, meta, build, lint, dashboard, health, structure-ratchet, tla-specs]
+    needs: [pr-sync-check, pr-live-gate, changes, meta, build, lint, dashboard, health, structure-ratchet, shell-ir-ratchet, tla-specs]
     if: ${{ always() && !cancelled() }}
     timeout-minutes: 10
 

--- a/scripts/audit-shell-ir-consumption.sh
+++ b/scripts/audit-shell-ir-consumption.sh
@@ -121,8 +121,7 @@ g1_total_refs=$(count_code_refs "$g1_pattern")
 g1_allowed_files=(
   "lib/exec/command_gate/shell_command_gate.ml"
   "lib/exec_policy_mutation_classifier.ml"
-  "lib/keeper/keeper_hooks_oas_pr_metrics.ml"
-  "lib/spawn.ml"
+  "lib/keeper/keeper_shell_ir.ml"
 )
 g1_current_files=$(list_code_files "$g1_pattern" \
   | rg -v '/dune$|\.dune$' \

--- a/scripts/shell-ir-consumption-baseline.json
+++ b/scripts/shell-ir-consumption-baseline.json
@@ -1,20 +1,20 @@
 {
   "schema": "shell-ir-consumption/v1",
-  "generated_at_unix": 1779556389,
-  "g1_parse_string_caller_files_nontest": 4,
-  "g1_parse_string_total_refs_nontest": 10,
+  "generated_at_unix": 1779596548,
+  "g1_parse_string_caller_files_nontest": 3,
+  "g1_parse_string_total_refs_nontest": 9,
   "g2_classifier_string_sig": 0,
-  "g2_classifier_ir_sig": 2,
+  "g2_classifier_ir_sig": 1,
   "g3_gate_typed_refs_in_keeper": 10,
   "g4_risk_in_simple": 0,
   "g4_phantom_envelope": 20,
   "g4_dispatch_decided_consumers": 7,
   "g5_validate_paths_callers_nontest": 9,
-  "g6_tla_spec_exists": 0,
+  "g6_tla_spec_exists": 1,
   "g7_shell_word_values_refs": 0,
   "g7_bash_words_stages_refs": 0,
   "g7_parallel_parser_total": 0,
-  "info_ir_constructors_nontest": 59,
+  "info_ir_constructors_nontest": 64,
   "allowed_exceptions": {
     "g1_parse_string": ["lib/exec/command_gate/shell_command_gate.ml","lib/exec_policy_mutation_classifier.ml","lib/keeper/keeper_hooks_oas_pr_metrics.ml","lib/spawn.ml"]
   }


### PR DESCRIPTION
## Summary

RFC-0160 §S7 CI ratchet: block G1/G7 regression and unclassified parse_string sites on every PR.

## Changes

- **New CI job** `shell-ir-ratchet` (after `structure-ratchet`, before `keeper-cwd-leak-gate`).
  - Runs when `lib_deps` or `build` paths change.
  - Installs `ripgrep` + `jq`, then executes:
    ```bash
    scripts/audit-shell-ir-consumption.sh --baseline scripts/shell-ir-consumption-baseline.json
    ```
  - Exits 1 on G1 increase, G7 increase, G4 phantom decrease, or new unclassified caller files.
- **CI gate dependency**: `shell-ir-ratchet` added to `ci-gate.needs`.
- **Baseline updated** to post-S3 values (generated from main @ 01661238f):
  | Metric | Before | After |
  |--------|--------|-------|
  | G1 callers | 4 files | 3 files |
  | G1 refs | 10 | 9 |
  | G2 IR sig | 2 | 1 |
  | G6 TLA spec | 0 | 1 |
  | IR constructors | 59 | 64 |
- **Allowed exceptions list** synchronized with actual callers:
  - Removed: `keeper_hooks_oas_pr_metrics.ml`, `spawn.ml` (no longer callers after S4 consolidation).
  - Added: `keeper_shell_ir.ml` (gate consolidation parse_string caller).

## Verification

- [x] `bash scripts/audit-shell-ir-consumption.sh --baseline scripts/shell-ir-consumption-baseline.json` → OK
- [x] `bash scripts/audit-shell-ir-consumption.sh` (text mode) → all metrics within target

## RFC Reference

- RFC-0160 §S7: CI ratchet for Shell IR consumption audit

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>