### PR TITLE
refactor(keeper): remove legacy shell ir command shim

### DIFF
--- a/lib/keeper/keeper_shell_ir.ml
+++ b/lib/keeper/keeper_shell_ir.ml
@@ -22,31 +22,3 @@ let gate_verdict_map verdict ~f_allow ~f_reject ~f_cannot_parse ~f_too_complex =
   | Shell_gate.Cannot_parse _ -> f_cannot_parse
   | Shell_gate.Too_complex _ -> f_too_complex
 ;;
-
-let of_cmd cmd =
-  match Masc_exec_bash_parser.Bash.parse_string cmd with
-  | Masc_exec.Parsed.Parsed ir -> ir
-  | _ ->
-    let trimmed = String.trim cmd in
-    let bin_str =
-      match String.index_opt trimmed ' ' with
-      | Some i -> String.sub trimmed 0 i
-      | None -> trimmed
-    in
-    let bin =
-      match Masc_exec.Bin.of_string bin_str with
-      | Ok b -> b
-      | Error _ -> (
-        match Masc_exec.Bin.of_string "sh" with
-        | Ok b -> b
-        | Error _ -> failwith "Keeper_shell_ir.of_cmd: impossible bin fallback")
-    in
-    Masc_exec.Shell_ir.Simple
-      { bin
-      ; args = [ Masc_exec.Shell_ir.Lit (cmd, Masc_exec.Shell_ir.default_meta) ]
-      ; env = []
-      ; cwd = None
-      ; redirects = []
-      ; sandbox = Masc_exec.Sandbox_target.host ()
-      }
-;;

--- a/lib/keeper/keeper_shell_ir.mli
+++ b/lib/keeper/keeper_shell_ir.mli
@@ -4,8 +4,6 @@ val classify :
 
 val with_cwd : raw:string -> cwd:string -> Masc_exec.Shell_ir.t -> Masc_exec.Shell_ir.t
 
-val of_cmd : string -> Masc_exec.Shell_ir.t
-
 (** Map over a [Shell_command_gate] verdict, handling each constructor
     with a dedicated callback. Eliminates the repeated 4-way match in
     typed-bash and gh dispatch paths. *)


### PR DESCRIPTION
## Summary
- remove unused `Keeper_shell_ir.of_cmd` API
- drop the raw `Bash.parse_string` fallback shim instead of adding a ratchet exception

## Verification
- `bash scripts/audit-shell-ir-consumption.sh --baseline scripts/shell-ir-consumption-baseline.json`
- `git diff --check`
- `scripts/dune-local.sh build --cache=disabled test/test_gh_exit_class_wiring.exe test/test_keeper_sandbox_boundary_policy.exe`