### PR TITLE
feat(cascade): phonebook/switchboard separation Phase 1-3

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -129,3 +129,8 @@ let resolve_ollama_max_concurrent =
   Cascade_config_strategy_resolve.resolve_ollama_max_concurrent
 let resolve_cli_max_concurrent =
   Cascade_config_strategy_resolve.resolve_cli_max_concurrent
+
+(* Phonebook loading (RFC Cascade-Phonebook) *)
+let load_phonebook = Cascade_config_loader.load_phonebook
+let invalidate_phonebook_cache = Cascade_config_loader.invalidate_phonebook_cache
+let load_phonebook_from_config = Cascade_config_loader.load_phonebook_from_config

--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -538,3 +538,20 @@ val resolve_cli_max_concurrent :
     [None] means "use the env-var default
     ([MASC_CLI_MAX_CONCURRENT] or 1)".
     @since 0.9.8 *)
+
+(** {2 Phonebook loading (RFC Cascade-Phonebook)} *)
+
+val load_phonebook :
+  string -> (Cascade_phonebook_types.cascade_phonebook, string) result
+(** Load a TOML file as a typed phonebook with mtime-based caching.
+    @since RFC Cascade-Phonebook *)
+
+val invalidate_phonebook_cache : string -> unit
+(** Drop the cached phonebook entry for a path.
+    @since RFC Cascade-Phonebook *)
+
+val load_phonebook_from_config :
+  unit -> (Cascade_phonebook_types.cascade_phonebook, string) result option
+(** Resolve cascade TOML path and load phonebook. Returns [None] when
+    no config dir is configured.
+    @since RFC Cascade-Phonebook *)

--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -1,10 +1,14 @@
-(** JSON config loading with mtime-based hot-reload.
+(** Config loading with mtime-based hot-reload.
 
-    Loads and caches cascade profile JSON files.  The cache is keyed by
-    file path and invalidated when the file mtime changes.
+    Two loading pipelines coexist:
+    1. Legacy JSON pipeline: TOML → [Cascade_toml_materializer] → Yojson.Safe.t
+    2. Phonebook pipeline:  TOML → [Cascade_phonebook_parser] → typed cascade_phonebook
+
+    Both share the same mtime-based cache invalidation strategy.
 
     @since 0.59.0
-    @since 0.92.0 extracted from Cascade_config *)
+    @since 0.92.0 extracted from Cascade_config
+    @since RFC Cascade-Phonebook added phonebook loading *)
 
 let config_cache : (string, float * Yojson.Safe.t) Hashtbl.t = Hashtbl.create 4
 
@@ -546,4 +550,109 @@ let resolve_strategy_config ~config_path ~name =
 
 let resolve_strategy_config_for_diagnostics ~config_path ~name =
   resolve_strategy_config_impl ~emit_telemetry:false ~config_path ~name
+;;
+
+(* ── Phonebook loading (RFC Cascade-Phonebook) ────────── *)
+
+(** Separate cache for typed phonebook records.  Keyed by file path,
+    invalidated on mtime change — same strategy as the JSON cache above. *)
+let phonebook_cache : (string, float * Cascade_phonebook_types.cascade_phonebook) Hashtbl.t =
+  Hashtbl.create 4
+
+(** Stat a file, return its mtime or None. *)
+let stat_mtime path =
+  try Some ((Unix.stat path).Unix.st_mtime) with
+  | Unix.Unix_error _ | Sys_error _ -> None
+
+(** Load a TOML file as a typed phonebook with mtime-based caching.
+
+    Same race-aware design as [load_toml_in_memory]:
+    1. stat → mtime_pre
+    2. cache lookup — hit returns cached phonebook
+    3. miss → Otoml parse → phonebook parse → stat → mtime_post
+    4. cache only when mtime_pre = mtime_post *)
+let load_phonebook_impl ~emit_telemetry path =
+  match stat_mtime path with
+  | None ->
+    (* File vanished or unreadable. Let Otoml surface the real error. *)
+    (try
+       let toml = Otoml.Parser.from_file path in
+       match Cascade_phonebook_parser.parse_phonebook toml with
+       | Ok pb -> Ok pb
+       | Error errs ->
+         let msg =
+           List.map (fun (e : Cascade_phonebook_parser.parse_error) ->
+             Printf.sprintf "%s: %s" e.path e.message) errs
+           |> String.concat "; "
+         in
+         Error (Printf.sprintf "phonebook parse error (%s): %s" path msg)
+     with
+     | Sys_error msg ->
+       Error (Printf.sprintf "phonebook IO error (path=%s): %s" path msg)
+     | Unix.Unix_error (err, fn, arg) ->
+       Error (Printf.sprintf "phonebook Unix error (path=%s): %s(%s): %s"
+                path fn arg (Unix.error_message err)))
+  | Some mtime_pre ->
+    let cached =
+      with_cache_lock (fun () ->
+        match Hashtbl.find_opt phonebook_cache path with
+        | Some (cached_mtime, cached_pb) when Float.equal cached_mtime mtime_pre ->
+          Some cached_pb
+        | _ -> None)
+    in
+    (match cached with
+     | Some pb -> Ok pb
+     | None ->
+       (try
+          let toml = Otoml.Parser.from_file path in
+          (match Cascade_phonebook_parser.parse_phonebook toml with
+           | Error errs ->
+             let msg =
+               List.map (fun (e : Cascade_phonebook_parser.parse_error) ->
+                 Printf.sprintf "%s: %s" e.path e.message) errs
+               |> String.concat "; "
+             in
+             Error (Printf.sprintf "phonebook parse error (%s): %s" path msg)
+           | Ok pb ->
+             let mtime_post = stat_mtime path in
+             (match mtime_post with
+              | Some mp when Float.equal mp mtime_pre ->
+                with_cache_lock (fun () ->
+                  Hashtbl.replace phonebook_cache path (mp, pb));
+                if emit_telemetry then
+                  Eio.traceln "[CascadeConfig] loaded phonebook %s mtime=%.0f" path mp;
+                Ok pb
+              | Some _mp ->
+                (* Race: mtime moved mid-read. Serve fresh but skip cache. *)
+                if emit_telemetry then
+                  Cascade_metrics.on_toml_read_race ();
+                Ok pb
+              | None ->
+                Ok pb))
+        with
+        | Sys_error msg ->
+          Error (Printf.sprintf "phonebook IO error (path=%s): %s" path msg)
+        | Unix.Unix_error (err, fn, arg) ->
+          Error (Printf.sprintf "phonebook Unix error (path=%s): %s(%s): %s"
+                   path fn arg (Unix.error_message err))))
+;;
+
+let load_phonebook path =
+  load_phonebook_impl ~emit_telemetry:true path
+;;
+
+(** Drop the cached phonebook entry for a path. *)
+let invalidate_phonebook_cache path =
+  with_cache_lock (fun () -> Hashtbl.remove phonebook_cache path)
+;;
+
+(** Resolve the cascade TOML path via config_dir_resolver and load phonebook.
+
+    Returns [None] when no cascade.toml is configured (missing/invalid config dir).
+    Returns [Some (Error msg)] when the file exists but fails to parse.
+    Returns [Some (Ok pb)] on success. *)
+let load_phonebook_from_config () =
+  match Config_dir_resolver.cascade_path_opt () with
+  | None -> None
+  | Some path -> Some (load_phonebook path)
 ;;

--- a/lib/cascade/cascade_config_loader.mli
+++ b/lib/cascade/cascade_config_loader.mli
@@ -203,3 +203,29 @@ val resolve_strategy_config :
 
 val resolve_strategy_config_for_diagnostics :
   config_path:string -> name:string -> strategy_config
+
+(* ── Phonebook loading (RFC Cascade-Phonebook) ────────── *)
+
+(** Load a TOML file as a typed [cascade_phonebook] with mtime-based caching.
+
+    Uses [Cascade_phonebook_parser] to parse directly from Otoml into
+    typed records, bypassing the legacy JSON rendering pipeline.
+
+    @since RFC Cascade-Phonebook *)
+val load_phonebook :
+  string -> (Cascade_phonebook_types.cascade_phonebook, string) result
+
+(** Drop the cached phonebook entry for a path.
+
+    @since RFC Cascade-Phonebook *)
+val invalidate_phonebook_cache : string -> unit
+
+(** Resolve the cascade TOML path via config_dir_resolver and load phonebook.
+
+    Returns [None] when no cascade.toml is configured (missing/invalid config dir).
+    Returns [Some (Error msg)] when the file exists but fails to parse.
+    Returns [Some (Ok pb)] on success.
+
+    @since RFC Cascade-Phonebook *)
+val load_phonebook_from_config :
+  unit -> (Cascade_phonebook_types.cascade_phonebook, string) result option

--- a/lib/cascade/cascade_phonebook_parser.ml
+++ b/lib/cascade/cascade_phonebook_parser.ml
@@ -1,0 +1,277 @@
+(** Phonebook TOML parser — reads the simplified phonebook TOML schema.
+
+    Parses providers, models, and tier-groups ONLY. No routes, tiers,
+    bindings, or aliases. All routing logic is in {!Cascade_routing_policy}.
+
+    Uses [Otoml] (same as existing {!Cascade_declarative_parser}) for
+    TOML parsing. Hot-reload is handled by {!Cascade_config_loader}.
+
+    Convention: [Otoml.find_opt tbl Fun.id path] returns a raw [Otoml.t]
+    for sub-tables. Typed getters like [Otoml.find_opt tbl Otoml.get_string]
+    return the extracted value directly. *)
+
+open Cascade_phonebook_types
+
+type parse_error =
+  { path : string
+  ; message : string
+  }
+[@@deriving show]
+
+let error path message = [ { path; message } ]
+
+let ( let* ) x f = Result.bind x f
+
+let partition_results
+    (results : ('a, parse_error list) result list)
+    : ('a list, parse_error list) result =
+  let oks, errs =
+    List.partition_map
+      (function
+        | Ok x -> Either.Left x
+        | Error e -> Either.Right e)
+      results
+  in
+  if errs <> [] then Error (List.concat errs) else Ok oks
+
+(* ── Thinking Control Format ─────────────────────────────────── *)
+
+let thinking_format_of_string (s : string)
+    : (cascade_thinking_control_format, string) result =
+  match s with
+  | "no_thinking_control" | "none" -> Ok No_thinking_control
+  | "thinking_object" -> Ok Thinking_object
+  | "reasoning_effort" -> Ok Reasoning_effort
+  | "reasoning_param" -> Ok Reasoning_param
+  | "chat_template_kwargs" -> Ok Chat_template_kwargs
+  | "reasoning_content" -> Ok Reasoning_content
+  | _ ->
+    Error
+      (Printf.sprintf
+         "unknown thinking_control_format %S: expected one of \
+          none, thinking_object, reasoning_effort, reasoning_param, \
+          chat_template_kwargs, reasoning_content"
+         s)
+
+(* ── Defaults ────────────────────────────────────────────────── *)
+
+let parse_defaults (tbl : Otoml.t) : (cascade_phonebook_defaults, parse_error list) result =
+  let max_output =
+    Otoml.find_or ~default:4096 tbl Otoml.get_integer [ "max_output_tokens" ]
+  in
+  let thinking_budget =
+    Otoml.find_or ~default:8192 tbl Otoml.get_integer [ "default_thinking_budget" ]
+  in
+  Ok { max_output_tokens = max_output; default_thinking_budget = thinking_budget }
+
+(* ── Provider ────────────────────────────────────────────────── *)
+
+let parse_provider (id : string) (tbl : Otoml.t)
+    : (cascade_phonebook_provider, parse_error list) result =
+  let path = Printf.sprintf "providers.%s" id in
+  let* endpoint =
+    match Otoml.find_opt tbl Otoml.get_string [ "endpoint" ] with
+    | Some e -> Ok e
+    | None -> Error (error (path ^ ".endpoint") "required field missing")
+  in
+  let protocol_str =
+    Otoml.find_or ~default:"openai-http" tbl Otoml.get_string [ "protocol" ]
+  in
+  let flavor_str =
+    Otoml.find_or ~default:"openai" tbl Otoml.get_string [ "flavor" ]
+  in
+  let auth_env = Otoml.find_opt tbl Otoml.get_string [ "auth_env" ] in
+  let note = Otoml.find_opt tbl Otoml.get_string [ "note" ] in
+  (try
+     let protocol = protocol_of_string protocol_str in
+     let flavor = flavor_of_string flavor_str in
+     Ok { id; endpoint; protocol; flavor; auth_env; note }
+   with Failure msg ->
+     Error (error path msg))
+
+(* ── Model Capabilities ──────────────────────────────────────── *)
+
+let parse_model_capabilities (tbl : Otoml.t) (path : string)
+    : (phonebook_model_capabilities, parse_error list) result =
+  let int_opt key = Otoml.find_opt tbl Otoml.get_integer [ key ] in
+  let bool_field key = Otoml.find_or ~default:false tbl Otoml.get_boolean [ key ] in
+  let thinking_str =
+    Otoml.find_or ~default:"none" tbl Otoml.get_string [ "thinking_control_format" ]
+  in
+  let* thinking_format =
+    match thinking_format_of_string thinking_str with
+    | Ok f -> Ok f
+    | Error msg -> Error (error (path ^ ".thinking_control_format") msg)
+  in
+  Ok
+    { max_output_tokens = int_opt "max_output_tokens"
+    ; supports_tool_choice = bool_field "supports_tool_choice"
+    ; supports_extended_thinking = bool_field "supports_extended_thinking"
+    ; supports_reasoning_budget = bool_field "supports_reasoning_budget"
+    ; thinking_control_format = thinking_format
+    ; supports_image_input = bool_field "supports_image_input"
+    ; supports_structured_output = bool_field "supports_structured_output"
+    ; supports_native_streaming = bool_field "supports_native_streaming"
+    }
+
+(* ── Model ───────────────────────────────────────────────────── *)
+
+let parse_model (id : string) (tbl : Otoml.t)
+    : (cascade_phonebook_model, parse_error list) result =
+  let path = Printf.sprintf "models.%s" id in
+  let* provider =
+    match Otoml.find_opt tbl Otoml.get_string [ "provider" ] with
+    | Some p -> Ok p
+    | None -> Error (error (path ^ ".provider") "required field missing")
+  in
+  let* model_id =
+    match Otoml.find_opt tbl Otoml.get_string [ "model_id" ] with
+    | Some m -> Ok m
+    | None -> Error (error (path ^ ".model_id") "required field missing")
+  in
+  let note = Otoml.find_opt tbl Otoml.get_string [ "note" ] in
+  let capabilities =
+    match Otoml.find_opt tbl Fun.id [ "capabilities" ] with
+    | Some cap_tbl ->
+      (match parse_model_capabilities cap_tbl (path ^ ".capabilities") with
+       | Ok caps -> caps
+       | Error _ -> phonebook_model_capabilities_default)
+    | None -> phonebook_model_capabilities_default
+  in
+  Ok { id; provider; model_id; capabilities; note }
+
+(* ── Tier-Group ──────────────────────────────────────────────── *)
+
+let parse_diversity_constraint (s : string) : (diversity_constraint, string) result =
+  match s with
+  | "diverse_from_primary" -> Ok Diverse_from_primary
+  | "same_provider" -> Ok Same_provider
+  | "any_available" -> Ok Any_available
+  | _ ->
+    Error
+      (Printf.sprintf
+         "unknown diversity constraint %S: expected one of \
+          diverse_from_primary, same_provider, any_available"
+         s)
+
+let parse_tier_group (name : string) (tbl : Otoml.t)
+    : (cascade_phonebook_tier_group, parse_error list) result =
+  let path = Printf.sprintf "tier-groups.%s" name in
+  let* members =
+    match Otoml.find_opt tbl (Otoml.get_array Otoml.get_string) [ "members" ] with
+    | Some m -> Ok m
+    | None -> Error (error (path ^ ".members") "required field missing")
+  in
+  let weight = Otoml.find_or ~default:100 tbl Otoml.get_integer [ "weight" ] in
+  let constraint_opt =
+    match Otoml.find_opt tbl Otoml.get_string [ "constraint" ] with
+    | Some s ->
+      (match parse_diversity_constraint s with
+       | Ok c -> Some c
+       | Error _ -> None)
+    | None -> None
+  in
+  let note = Otoml.find_opt tbl Otoml.get_string [ "note" ] in
+  Ok { name; members; weight; constraint_ = constraint_opt; note }
+
+(* ── Table key extraction ────────────────────────────────────── *)
+
+let table_keys_of (tbl : Otoml.t) : string list =
+  match Otoml.get_table tbl with
+  | exception Otoml.Type_error _ -> []
+  | entries -> List.map fst entries
+
+(* ── Top-level parser ────────────────────────────────────────── *)
+
+(** Parse a phonebook TOML document into typed [cascade_phonebook].
+
+    Top-level TOML structure:
+    {v
+    [defaults]
+    max_output_tokens = 4096
+    default_thinking_budget = 8192
+
+    [providers.runpod-llama]
+    endpoint = "..."
+    protocol = "openai-http"
+    flavor = "llama-cpp"
+    auth_env = "RUNPOD_API_TOKEN"
+
+    [models.qwen3-235b]
+    provider = "runpod-llama"
+    model_id = "qwen3-235b-a22b"
+    capabilities = { ... }
+
+    [tier-groups.primary]
+    members = ["qwen3-235b"]
+    weight = 100
+    v} *)
+let parse_phonebook (toml : Otoml.t)
+    : (cascade_phonebook, parse_error list) result =
+  (* Defaults *)
+  let defaults_result =
+    match Otoml.find_opt toml Fun.id [ "defaults" ] with
+    | Some defaults_tbl -> parse_defaults defaults_tbl
+    | None ->
+      Ok { max_output_tokens = 4096; default_thinking_budget = 8192 }
+  in
+  (* Providers *)
+  let providers_result =
+    match Otoml.find_opt toml Fun.id [ "providers" ] with
+    | Some providers_tbl ->
+      let provider_ids = table_keys_of providers_tbl in
+      let results =
+        List.filter_map
+          (fun id ->
+             match Otoml.find_opt providers_tbl Fun.id [ id ] with
+             | Some tbl -> Some (parse_provider id tbl)
+             | None -> None)
+          provider_ids
+      in
+      partition_results results
+    | None -> Ok []
+  in
+  (* Models *)
+  let models_result =
+    match Otoml.find_opt toml Fun.id [ "models" ] with
+    | Some models_tbl ->
+      let model_ids = table_keys_of models_tbl in
+      let results =
+        List.filter_map
+          (fun id ->
+             match Otoml.find_opt models_tbl Fun.id [ id ] with
+             | Some tbl -> Some (parse_model id tbl)
+             | None -> None)
+          model_ids
+      in
+      partition_results results
+    | None -> Ok []
+  in
+  (* Tier-groups *)
+  let tier_groups_result =
+    match Otoml.find_opt toml Fun.id [ "tier-groups" ] with
+    | Some tg_tbl ->
+      let tg_names = table_keys_of tg_tbl in
+      let results =
+        List.filter_map
+          (fun name ->
+             match Otoml.find_opt tg_tbl Fun.id [ name ] with
+             | Some tbl -> Some (parse_tier_group name tbl)
+             | None -> None)
+          tg_names
+      in
+      partition_results results
+    | None -> Ok []
+  in
+  (* Combine *)
+  match defaults_result, providers_result, models_result, tier_groups_result with
+  | Ok defaults, Ok providers, Ok models, Ok tier_groups ->
+    Ok { defaults; providers; models; tier_groups }
+  | _ ->
+    let all_errors =
+      (match defaults_result with Error e -> e | _ -> [])
+      @ (match providers_result with Error e -> e | _ -> [])
+      @ (match models_result with Error e -> e | _ -> [])
+      @ (match tier_groups_result with Error e -> e | _ -> [])
+    in
+    Error all_errors

--- a/lib/cascade/cascade_phonebook_parser.mli
+++ b/lib/cascade/cascade_phonebook_parser.mli
@@ -1,0 +1,8 @@
+(** Phonebook TOML parser — public interface. *)
+
+type parse_error = { path : string; message : string }
+[@@deriving show]
+
+val parse_phonebook :
+  Otoml.t -> (Cascade_phonebook_types.cascade_phonebook, parse_error list) result
+(** Parse a phonebook TOML document into typed phonebook config. *)

--- a/lib/cascade/cascade_phonebook_types.ml
+++ b/lib/cascade/cascade_phonebook_types.ml
@@ -1,0 +1,199 @@
+(** Phonebook types for the Cascade Phonebook/Switchboard RFC.
+
+    TOML = Phonebook (what exists), OAS = Switchboard (who to use).
+    This module defines ONLY the Phonebook side: providers, models,
+    tier-groups. All routing logic lives in {!Cascade_routing_policy}.
+
+    Design: ~150 lines of TOML config, zero routing intelligence. *)
+
+(* ── Flavor ──────────────────────────────────────────────────── *)
+
+(** Server flavor — determines request/response wire format.
+
+    Stored in TOML as a string hint per provider. The OAS Switchboard
+    selects the correct adapter based on this value.
+
+    Not a TOML concern: OAS code decides how to use the flavor. *)
+type cascade_server_flavor =
+  | Llama_cpp    (** llama.cpp server: chat_template_kwargs, grammar, reasoning_budget *)
+  | Ollama       (** ollama: /api/chat native, think, done_reason, arguments=JSON object *)
+  | Vllm         (** vLLM: extra_body, guided_json, guided_grammar, prefix_cached *)
+  | Openai       (** canonical: SSE, reasoning_effort, web_search, parallel_tool_calls *)
+  | Deep_seek    (** DeepSeek: thinking param, reasoning_content, reasoning_effort high/max *)
+  | Zai_glm      (** Z.AI/GLM: reasoning_content, business errors 1301/1302/1303 *)
+  | Qwen         (** Qwen/DashScope: OpenAI compat, tools+stream incompatible *)
+[@@deriving show, eq]
+
+let flavor_of_string = function
+  | "llama-cpp" -> Llama_cpp
+  | "ollama" -> Ollama
+  | "vllm" -> Vllm
+  | "openai" -> Openai
+  | "deepseek" -> Deep_seek
+  | "zai-glm" -> Zai_glm
+  | "qwen" -> Qwen
+  | s -> failwith (Printf.sprintf "Unknown server flavor: %s" s)
+
+let flavor_to_string = function
+  | Llama_cpp -> "llama-cpp"
+  | Ollama -> "ollama"
+  | Vllm -> "vllm"
+  | Openai -> "openai"
+  | Deep_seek -> "deepseek"
+  | Zai_glm -> "zai-glm"
+  | Qwen -> "qwen"
+
+(* ── Protocol ────────────────────────────────────────────────── *)
+
+type cascade_protocol =
+  | Openai_http     (** OpenAI-compatible HTTP (/v1/chat/completions) *)
+  | Ollama_http     (** Ollama native HTTP (/api/chat) *)
+  | Anthropic_http  (** Anthropic Messages API (/v1/messages) *)
+  | Openai_cli      (** CLI wrapper speaking OpenAI protocol *)
+[@@deriving show, eq]
+
+let protocol_of_string = function
+  | "openai-http" -> Openai_http
+  | "ollama-http" -> Ollama_http
+  | "anthropic-http" -> Anthropic_http
+  | "openai-cli" -> Openai_cli
+  | s -> failwith (Printf.sprintf "Unknown protocol: %s" s)
+
+let protocol_to_string = function
+  | Openai_http -> "openai-http"
+  | Ollama_http -> "ollama-http"
+  | Anthropic_http -> "anthropic-http"
+  | Openai_cli -> "openai-cli"
+
+(* ── Provider ────────────────────────────────────────────────── *)
+
+type cascade_phonebook_provider =
+  { id : string
+  ; endpoint : string
+  ; protocol : cascade_protocol
+  ; flavor : cascade_server_flavor
+  ; auth_env : string option
+  ; note : string option
+  }
+[@@deriving show, eq]
+
+(* ── Thinking Control Format ─────────────────────────────────── *)
+
+(** Re-export from cascade_declarative_types for backward compat.
+    The phonebook reuses the same wire-format taxonomy. *)
+type cascade_thinking_control_format =
+  | No_thinking_control
+  | Thinking_object  (** DeepSeek: {"thinking":{"type":"enabled"}} *)
+  | Reasoning_effort (** OpenAI o-series: {"reasoning_effort":"high"} *)
+  | Reasoning_param  (** DeepSeek-style reasoning_effort param *)
+  | Chat_template_kwargs (** llama.cpp: {"chat_template_kwargs":{"enable_thinking":bool}} *)
+  | Reasoning_content  (** Z.AI/GLM: reasoning_content field in response *)
+[@@deriving show, eq]
+
+(* ── Model Capabilities (reused from cascade_declarative_types) ── *)
+
+(** Per-model capabilities carried in the phonebook.
+
+    Subset of the full cascade_model_capabilities that the Switchboard
+    needs for routing decisions. Extended capabilities (prompt caching,
+    multimodal, etc.) are still read from cascade_declarative_types
+    for backward compatibility during migration. *)
+type phonebook_model_capabilities =
+  { max_output_tokens : int option
+  ; supports_tool_choice : bool
+  ; supports_extended_thinking : bool
+  ; supports_reasoning_budget : bool
+  ; thinking_control_format : cascade_thinking_control_format
+  ; supports_image_input : bool
+  ; supports_structured_output : bool
+  ; supports_native_streaming : bool
+  }
+[@@deriving show, eq]
+
+let phonebook_model_capabilities_default =
+  { max_output_tokens = None
+  ; supports_tool_choice = false
+  ; supports_extended_thinking = false
+  ; supports_reasoning_budget = false
+  ; thinking_control_format = No_thinking_control
+  ; supports_image_input = false
+  ; supports_structured_output = false
+  ; supports_native_streaming = false
+  }
+[@@deriving show, eq]
+
+(* ── Model ───────────────────────────────────────────────────── *)
+
+type cascade_phonebook_model =
+  { id : string
+  ; provider : string
+  ; model_id : string
+  ; capabilities : phonebook_model_capabilities
+  ; note : string option
+  }
+[@@deriving show, eq]
+
+(* ── Diversity Constraint ────────────────────────────────────── *)
+
+(** Constraint for selecting models from non-primary tier-groups.
+    The Switchboard enforces these when resolving task routing. *)
+type diversity_constraint =
+  | Diverse_from_primary  (** Must use different provider than primary *)
+  | Same_provider         (** Must use same provider (internal fallback) *)
+  | Any_available         (** No constraint *)
+[@@deriving show, eq]
+
+(* ── Tier-Group ──────────────────────────────────────────────── *)
+
+(** Sole routing unit. OAS selects tier-groups per task_use.
+    No model-level or provider-level selection in the phonebook. *)
+type cascade_phonebook_tier_group =
+  { name : string
+  ; members : string list  (** Model IDs from [models.*] *)
+  ; weight : int
+  ; constraint_ : diversity_constraint option
+  ; note : string option
+  }
+[@@deriving show, eq]
+
+(* ── Phonebook Config (top-level) ────────────────────────────── *)
+
+type cascade_phonebook_defaults =
+  { max_output_tokens : int
+  ; default_thinking_budget : int
+  }
+[@@deriving show, eq]
+
+(** Phonebook — what providers/models exist. No routing logic. *)
+type cascade_phonebook =
+  { defaults : cascade_phonebook_defaults
+  ; providers : cascade_phonebook_provider list
+  ; models : cascade_phonebook_model list
+  ; tier_groups : cascade_phonebook_tier_group list
+  }
+[@@deriving show, eq]
+
+(* ── Lookup helpers ──────────────────────────────────────────── *)
+
+let provider_of_id (pb : cascade_phonebook) (id : string) :
+    cascade_phonebook_provider option =
+  List.find_opt (fun (p : cascade_phonebook_provider) -> p.id = id) pb.providers
+
+let model_of_id (pb : cascade_phonebook) (id : string) :
+    cascade_phonebook_model option =
+  List.find_opt (fun (m : cascade_phonebook_model) -> m.id = id) pb.models
+
+let tier_group_of_name (pb : cascade_phonebook) (name : string) :
+    cascade_phonebook_tier_group option =
+  List.find_opt (fun (tg : cascade_phonebook_tier_group) -> tg.name = name)
+    pb.tier_groups
+
+let models_of_tier_group (pb : cascade_phonebook) (tg : cascade_phonebook_tier_group) :
+    cascade_phonebook_model list =
+  List.filter_map
+    (fun mid -> model_of_id pb mid)
+    tg.members
+
+let provider_of_model (pb : cascade_phonebook) (m : cascade_phonebook_model) :
+    cascade_phonebook_provider option =
+  provider_of_id pb m.provider

--- a/lib/cascade/cascade_phonebook_types.mli
+++ b/lib/cascade/cascade_phonebook_types.mli
@@ -1,0 +1,92 @@
+(** Phonebook types — public interface. *)
+
+type cascade_server_flavor =
+  | Llama_cpp | Ollama | Vllm | Openai | Deep_seek | Zai_glm | Qwen
+[@@deriving show, eq]
+
+val flavor_of_string : string -> cascade_server_flavor
+val flavor_to_string : cascade_server_flavor -> string
+
+type cascade_protocol =
+  | Openai_http | Ollama_http | Anthropic_http | Openai_cli
+[@@deriving show, eq]
+
+val protocol_of_string : string -> cascade_protocol
+val protocol_to_string : cascade_protocol -> string
+
+type cascade_phonebook_provider = {
+  id : string;
+  endpoint : string;
+  protocol : cascade_protocol;
+  flavor : cascade_server_flavor;
+  auth_env : string option;
+  note : string option;
+}
+[@@deriving show, eq]
+
+type cascade_thinking_control_format =
+  | No_thinking_control
+  | Thinking_object
+  | Reasoning_effort
+  | Reasoning_param
+  | Chat_template_kwargs
+  | Reasoning_content
+[@@deriving show, eq]
+
+type phonebook_model_capabilities = {
+  max_output_tokens : int option;
+  supports_tool_choice : bool;
+  supports_extended_thinking : bool;
+  supports_reasoning_budget : bool;
+  thinking_control_format : cascade_thinking_control_format;
+  supports_image_input : bool;
+  supports_structured_output : bool;
+  supports_native_streaming : bool;
+}
+[@@deriving show, eq]
+
+val phonebook_model_capabilities_default : phonebook_model_capabilities
+
+type cascade_phonebook_model = {
+  id : string;
+  provider : string;
+  model_id : string;
+  capabilities : phonebook_model_capabilities;
+  note : string option;
+}
+[@@deriving show, eq]
+
+type diversity_constraint =
+  | Diverse_from_primary | Same_provider | Any_available
+[@@deriving show, eq]
+
+type cascade_phonebook_tier_group = {
+  name : string;
+  members : string list;
+  weight : int;
+  constraint_ : diversity_constraint option;
+  note : string option;
+}
+[@@deriving show, eq]
+
+type cascade_phonebook_defaults = {
+  max_output_tokens : int;
+  default_thinking_budget : int;
+}
+[@@deriving show, eq]
+
+type cascade_phonebook = {
+  defaults : cascade_phonebook_defaults;
+  providers : cascade_phonebook_provider list;
+  models : cascade_phonebook_model list;
+  tier_groups : cascade_phonebook_tier_group list;
+}
+[@@deriving show, eq]
+
+val provider_of_id : cascade_phonebook -> string -> cascade_phonebook_provider option
+val model_of_id : cascade_phonebook -> string -> cascade_phonebook_model option
+val tier_group_of_name : cascade_phonebook -> string -> cascade_phonebook_tier_group option
+val models_of_tier_group :
+  cascade_phonebook -> cascade_phonebook_tier_group -> cascade_phonebook_model list
+val provider_of_model :
+  cascade_phonebook -> cascade_phonebook_model -> cascade_phonebook_provider option

--- a/lib/cascade/cascade_routing_policy.ml
+++ b/lib/cascade/cascade_routing_policy.ml
@@ -1,0 +1,147 @@
+(** Routing Policy — the Switchboard side of Phonebook/Switchboard.
+
+    Maps 6 task_use categories to tier-groups with diversity constraints.
+    All routing intelligence lives here; the phonebook TOML is data-only.
+
+    Replaces the old 18-variant [logical_use] in {!Cascade_ref} with a
+    simplified 6-variant [task_use] that covers all keeper/supervisor
+    routing needs without over-specification. *)
+
+(* ── Task Use (6 categories) ─────────────────────────────────── *)
+
+(** The 6 routing categories for cascade task dispatch.
+
+    Every former [logical_use] variant maps into one of these.
+    Cross-verification and adversarial review are handled by diversity
+    constraints on the [Code_review] task_use, not by separate variants. *)
+type task_use =
+  | Code_generation  (* synthesis, refactoring, translation *)
+  | Code_review      (* analysis, audit, adversarial review, cross-verify *)
+  | Quick_decision   (* classification, triage, short answer *)
+  | Long_reasoning   (* planning, research synthesis, RFC drafting *)
+  | Tool_execution   (* function calling, MCP tool use, structured output *)
+  | Conversation     (* general chat, explanation, user interaction *)
+[@@deriving show, eq]
+
+let task_use_to_string = function
+  | Code_generation -> "code_generation"
+  | Code_review -> "code_review"
+  | Quick_decision -> "quick_decision"
+  | Long_reasoning -> "long_reasoning"
+  | Tool_execution -> "tool_execution"
+  | Conversation -> "conversation"
+
+let task_use_of_string = function
+  | "code_generation" -> Some Code_generation
+  | "code_review" -> Some Code_review
+  | "quick_decision" -> Some Quick_decision
+  | "long_reasoning" -> Some Long_reasoning
+  | "tool_execution" -> Some Tool_execution
+  | "conversation" -> Some Conversation
+  | _ -> None
+
+(* ── Legacy logical_use → task_use mapping ───────────────────── *)
+
+(** Map the old 18-variant [logical_use] to new 6-variant [task_use].
+
+    Used during migration to translate keeper/supervisor routing
+    requests without touching all callers at once. *)
+let task_use_of_legacy_logical_use = function
+  | "keeper_turn" | "phase_recovery" | "phase_buffer" -> Code_generation
+  | "tool_required" -> Tool_execution
+  | "governance_judge" | "operator_judge" -> Code_review
+  | "cross_verifier" | "verifier" | "adversarial_reviewer" -> Code_review
+  | "auto_responder" -> Quick_decision
+  | "routing" -> Quick_decision
+  | "openai_compat" -> Code_generation
+  | "persona_generation" -> Code_generation
+  | "provider_benchmark" -> Quick_decision
+  | "simple_task" | "moderate_task" -> Quick_decision
+  | "complex_task" -> Long_reasoning
+  | "tool_rerank_use" -> Tool_execution
+  | _ -> Conversation  (* unknown → safest default *)
+
+(* ── Routing Policy ──────────────────────────────────────────── *)
+
+(** Which tier-group to use for a given task, and any diversity constraint
+    when selecting from non-primary tier-groups. *)
+type task_routing_policy =
+  { task : task_use
+  ; primary_tier_group : string
+  ; diversity : Cascade_phonebook_types.diversity_constraint option
+  }
+[@@deriving show, eq]
+
+(** Default routing policies.
+
+    These encode the Switchboard's intelligence. The phonebook only
+    says which models exist; these policies say which tier-group to use.
+
+    - Code_generation → primary (largest model, best quality)
+    - Code_review → cross-verify (diverse from primary for independent review)
+    - Quick_decision → primary (fast, high quality)
+    - Long_reasoning → primary (needs deep thinking)
+    - Tool_execution → primary (needs tool support)
+    - Conversation → primary (general purpose) *)
+let default_routing_policies : task_routing_policy list =
+  [ { task = Code_generation; primary_tier_group = "primary"; diversity = None }
+  ; { task = Code_review
+    ; primary_tier_group = "cross-verify"
+    ; diversity = Some Cascade_phonebook_types.Diverse_from_primary
+    }
+  ; { task = Quick_decision; primary_tier_group = "primary"; diversity = None }
+  ; { task = Long_reasoning; primary_tier_group = "primary"; diversity = None }
+  ; { task = Tool_execution; primary_tier_group = "primary"; diversity = None }
+  ; { task = Conversation; primary_tier_group = "primary"; diversity = None }
+  ]
+
+(* ── Resolution ──────────────────────────────────────────────── *)
+
+(** Resolve a task_use to its routing policy. *)
+let policy_for_task (policies : task_routing_policy list) (task : task_use) :
+    task_routing_policy option =
+  List.find_opt (fun (p : task_routing_policy) -> p.task = task) policies
+
+(** Resolve a tier-group name to its member model IDs via the phonebook. *)
+let resolve_models_for_task
+    (pb : Cascade_phonebook_types.cascade_phonebook)
+    (policies : task_routing_policy list)
+    (task : task_use)
+  : Cascade_phonebook_types.cascade_phonebook_model list =
+  match policy_for_task policies task with
+  | None -> []
+  | Some policy ->
+    match Cascade_phonebook_types.tier_group_of_name pb policy.primary_tier_group with
+    | None -> []
+    | Some tg -> Cascade_phonebook_types.models_of_tier_group pb tg
+
+(** Check that a candidate model satisfies the diversity constraint
+    relative to the primary tier-group's provider(s). *)
+let satisfies_diversity
+    (pb : Cascade_phonebook_types.cascade_phonebook)
+    (primary_tg : Cascade_phonebook_types.cascade_phonebook_tier_group)
+    (constraint_ : Cascade_phonebook_types.diversity_constraint option)
+    (candidate : Cascade_phonebook_types.cascade_phonebook_model)
+  : bool =
+  match constraint_ with
+  | None | Some Cascade_phonebook_types.Any_available -> true
+  | Some Cascade_phonebook_types.Same_provider ->
+    let primary_providers =
+      List.filter_map
+        (fun mid ->
+           Option.map
+             (fun (m : Cascade_phonebook_types.cascade_phonebook_model) -> m.provider)
+             (Cascade_phonebook_types.model_of_id pb mid))
+        primary_tg.members
+    in
+    List.mem candidate.provider primary_providers
+  | Some Cascade_phonebook_types.Diverse_from_primary ->
+    let primary_providers =
+      List.filter_map
+        (fun mid ->
+           Option.map
+             (fun (m : Cascade_phonebook_types.cascade_phonebook_model) -> m.provider)
+             (Cascade_phonebook_types.model_of_id pb mid))
+        primary_tg.members
+    in
+    not (List.mem candidate.provider primary_providers)

--- a/lib/cascade/cascade_routing_policy.ml
+++ b/lib/cascade/cascade_routing_policy.ml
@@ -47,19 +47,19 @@ let task_use_of_string = function
     Used during migration to translate keeper/supervisor routing
     requests without touching all callers at once. *)
 let task_use_of_legacy_logical_use = function
-  | "keeper_turn" | "phase_recovery" | "phase_buffer" -> Code_generation
-  | "tool_required" -> Tool_execution
-  | "governance_judge" | "operator_judge" -> Code_review
-  | "cross_verifier" | "verifier" | "adversarial_reviewer" -> Code_review
-  | "auto_responder" -> Quick_decision
-  | "routing" -> Quick_decision
-  | "openai_compat" -> Code_generation
-  | "persona_generation" -> Code_generation
-  | "provider_benchmark" -> Quick_decision
-  | "simple_task" | "moderate_task" -> Quick_decision
-  | "complex_task" -> Long_reasoning
-  | "tool_rerank_use" -> Tool_execution
-  | _ -> Conversation  (* unknown → safest default *)
+  | "keeper_turn" | "phase_recovery" | "phase_buffer" -> Some Code_generation
+  | "tool_required" -> Some Tool_execution
+  | "governance_judge" | "operator_judge" -> Some Code_review
+  | "cross_verifier" | "verifier" | "adversarial_reviewer" -> Some Code_review
+  | "auto_responder" -> Some Quick_decision
+  | "routing" -> Some Quick_decision
+  | "openai_compat" -> Some Code_generation
+  | "persona_generation" -> Some Code_generation
+  | "provider_benchmark" -> Some Quick_decision
+  | "simple_task" | "moderate_task" -> Some Quick_decision
+  | "complex_task" -> Some Long_reasoning
+  | "tool_rerank_use" -> Some Tool_execution
+  | _ -> None
 
 (* ── Routing Policy ──────────────────────────────────────────── *)
 

--- a/lib/cascade/cascade_routing_policy.mli
+++ b/lib/cascade/cascade_routing_policy.mli
@@ -1,0 +1,31 @@
+(** Routing Policy — public interface. *)
+
+type task_use =
+  | Code_generation | Code_review | Quick_decision
+  | Long_reasoning | Tool_execution | Conversation
+[@@deriving show, eq]
+
+val task_use_to_string : task_use -> string
+val task_use_of_string : string -> task_use option
+val task_use_of_legacy_logical_use : string -> task_use
+
+type task_routing_policy = {
+  task : task_use;
+  primary_tier_group : string;
+  diversity : Cascade_phonebook_types.diversity_constraint option;
+}
+[@@deriving show, eq]
+
+val default_routing_policies : task_routing_policy list
+val policy_for_task : task_routing_policy list -> task_use -> task_routing_policy option
+val resolve_models_for_task :
+  Cascade_phonebook_types.cascade_phonebook ->
+  task_routing_policy list ->
+  task_use ->
+  Cascade_phonebook_types.cascade_phonebook_model list
+val satisfies_diversity :
+  Cascade_phonebook_types.cascade_phonebook ->
+  Cascade_phonebook_types.cascade_phonebook_tier_group ->
+  Cascade_phonebook_types.diversity_constraint option ->
+  Cascade_phonebook_types.cascade_phonebook_model ->
+  bool

--- a/lib/cascade/cascade_routing_policy.mli
+++ b/lib/cascade/cascade_routing_policy.mli
@@ -7,7 +7,7 @@ type task_use =
 
 val task_use_to_string : task_use -> string
 val task_use_of_string : string -> task_use option
-val task_use_of_legacy_logical_use : string -> task_use
+val task_use_of_legacy_logical_use : string -> task_use option
 
 type task_routing_policy = {
   task : task_use;

--- a/lib/cascade/cascade_server_flavor.ml
+++ b/lib/cascade/cascade_server_flavor.ml
@@ -1,0 +1,189 @@
+(** Server Flavor Adapter — per-provider request/response shaping.
+
+    Each provider has quirks in how it expects requests and formats
+    responses. The adapter system encapsulates these differences so
+    the transport layer only sees a uniform interface.
+
+    Flavors are determined by the [cascade_server_flavor] in
+    {!Cascade_phonebook_types} (from TOML [providers.<id>.flavor]).
+    The adapter is selected at OAS code level, not TOML level. *)
+
+(* ── Imports ─────────────────────────────────────────────────── *)
+
+type cascade_server_flavor = Cascade_phonebook_types.cascade_server_flavor =
+  | Llama_cpp
+  | Ollama
+  | Vllm
+  | Openai
+  | Deep_seek
+  | Zai_glm
+  | Qwen
+
+(* ── Error types ─────────────────────────────────────────────── *)
+
+(** Flavor-specific errors that the transport layer may encounter. *)
+type flavor_error =
+  | Business_error of { code : int; message : string }
+      (** Z.AI/GLM business errors: 1301 (system), 1302 (policy), 1303 (quota) *)
+  | Content_filter of string
+      (** DeepSeek content_filter finish_reason *)
+  | Tools_stream_incompatible
+      (** Qwen: tools + stream=True not supported *)
+  | Reasoning_budget_exceeded
+      (** Thinking budget exceeded model limits *)
+  | Unknown_finish_reason of string
+      (** Unrecognized finish_reason from provider *)
+[@@deriving show, eq]
+
+(* ── Thinking control ────────────────────────────────────────── *)
+
+(** How to encode thinking/reasoning parameters in the request.
+    Each flavor has a different wire format. *)
+type thinking_control =
+  | No_thinking
+  | Deep_seek_thinking of { enabled : bool }
+      (** {"thinking":{"type":"enabled"|"disabled"}} *)
+  | Llama_cpp_thinking of { enable : bool; budget : int option }
+      (** {"chat_template_kwargs":{"enable_thinking":bool}} + reasoning_budget *)
+  | Openai_reasoning_effort of { effort : string }
+      (** {"reasoning_effort":"low"|"medium"|"high"} *)
+  | Ollama_think of { think : bool }
+      (** {"think":true|false} *)
+[@@deriving show, eq]
+
+(** Map generic thinking parameters to flavor-specific wire format. *)
+let thinking_control_for_flavor
+    (flavor : cascade_server_flavor)
+    (thinking_requested : bool)
+    (budget : int option)
+  : thinking_control =
+  match flavor with
+  | Llama_cpp ->
+    Llama_cpp_thinking { enable = thinking_requested; budget }
+  | Ollama ->
+    Ollama_think { think = thinking_requested }
+  | Openai ->
+    (match budget with
+     | Some _ -> Openai_reasoning_effort { effort = "high" }
+     | None -> Openai_reasoning_effort { effort = "medium" })
+  | Deep_seek ->
+    Deep_seek_thinking { enabled = thinking_requested }
+  | Zai_glm ->
+    (* Z.AI/GLM has built-in thinking for GLM-5.x, no external control *)
+    No_thinking
+  | Vllm ->
+    No_thinking
+  | Qwen ->
+    No_thinking
+
+(* ── Finish reason mapping ───────────────────────────────────── *)
+
+(** Canonical finish reasons across all flavors. *)
+type finish_reason =
+  | Stop
+  | Length
+  | Tool_calls
+  | Content_filter
+  | Error
+[@@deriving show, eq]
+
+(** Map a flavor-specific finish_reason string to canonical form. *)
+let finish_reason_of_string
+    (flavor : cascade_server_flavor)
+    (raw : string option)
+  : finish_reason =
+  match raw with
+  | None | Some "" | Some "null" -> Stop  (* Qwen returns null during generation *)
+  | Some "stop" -> Stop
+  | Some "length" -> Length
+  | Some "tool_calls" -> Tool_calls
+  | Some "content_filter" -> Content_filter
+  | Some "insufficient_system_resource" -> Error  (* DeepSeek-specific *)
+  | Some other ->
+    (match flavor with
+     | Ollama ->
+       (match other with
+        | "load" | "unload" -> Stop  (* Ollama model loading events *)
+        | _ -> Error)
+     | _ -> Error)
+
+(* ── Stream chunk ────────────────────────────────────────────── *)
+
+(** Parsed chunk from a streaming response. *)
+type stream_chunk =
+  | Content_delta of string
+  | Thinking_delta of string
+  | Tool_call of { index : int; id : string; name : string; arguments : string }
+  | Finish of finish_reason
+  | Usage of { input_tokens : int; output_tokens : int }
+  | Done
+[@@deriving show, eq]
+
+(* ── Flavor-specific constraints ─────────────────────────────── *)
+
+(** Per-flavor constraints that the transport layer must respect. *)
+type flavor_constraints =
+  { supports_tools_with_streaming : bool
+  ; supports_response_format : bool
+  ; supports_parallel_tool_calls : bool
+  ; finish_reason_nullable : bool  (* Qwen returns null during generation *)
+  ; arguments_as_json_object : bool  (* Ollama returns JSON object, not string *)
+  }
+[@@deriving show, eq]
+
+(** Get the constraints for a flavor. *)
+let constraints_of_flavor = function
+  | Llama_cpp ->
+    { supports_tools_with_streaming = true
+    ; supports_response_format = true
+    ; supports_parallel_tool_calls = true
+    ; finish_reason_nullable = false
+    ; arguments_as_json_object = false
+    }
+  | Ollama ->
+    { supports_tools_with_streaming = true
+    ; supports_response_format = true
+    ; supports_parallel_tool_calls = true
+    ; finish_reason_nullable = false
+    ; arguments_as_json_object = true  (* native /api/chat returns JSON object *)
+    }
+  | Vllm ->
+    { supports_tools_with_streaming = true
+    ; supports_response_format = true
+    ; supports_parallel_tool_calls = true
+    ; finish_reason_nullable = false
+    ; arguments_as_json_object = false
+    }
+  | Openai ->
+    { supports_tools_with_streaming = true
+    ; supports_response_format = true
+    ; supports_parallel_tool_calls = true
+    ; finish_reason_nullable = false
+    ; arguments_as_json_object = false
+    }
+  | Deep_seek ->
+    { supports_tools_with_streaming = true
+    ; supports_response_format = true
+    ; supports_parallel_tool_calls = true
+    ; finish_reason_nullable = false
+    ; arguments_as_json_object = false
+    }
+  | Zai_glm ->
+    { supports_tools_with_streaming = true
+    ; supports_response_format = true
+    ; supports_parallel_tool_calls = true
+    ; finish_reason_nullable = false
+    ; arguments_as_json_object = false
+    }
+  | Qwen ->
+    { supports_tools_with_streaming = false  (* CRITICAL: tools + stream=True incompatible *)
+    ; supports_response_format = false       (* response_format not supported *)
+    ; supports_parallel_tool_calls = true
+    ; finish_reason_nullable = true          (* returns null during generation *)
+    ; arguments_as_json_object = false
+    }
+
+(** Whether this flavor can accept tools when streaming is requested.
+    When false, the transport must fall back to non-streaming mode. *)
+let can_stream_with_tools (flavor : cascade_server_flavor) : bool =
+  (constraints_of_flavor flavor).supports_tools_with_streaming

--- a/lib/cascade/cascade_server_flavor.mli
+++ b/lib/cascade/cascade_server_flavor.mli
@@ -1,0 +1,49 @@
+(** Server Flavor Adapter — public interface. *)
+
+type cascade_server_flavor = Cascade_phonebook_types.cascade_server_flavor =
+  | Llama_cpp | Ollama | Vllm | Openai | Deep_seek | Zai_glm | Qwen
+
+type flavor_error =
+  | Business_error of { code : int; message : string }
+  | Content_filter of string
+  | Tools_stream_incompatible
+  | Reasoning_budget_exceeded
+  | Unknown_finish_reason of string
+[@@deriving show, eq]
+
+type thinking_control =
+  | No_thinking
+  | Deep_seek_thinking of { enabled : bool }
+  | Llama_cpp_thinking of { enable : bool; budget : int option }
+  | Openai_reasoning_effort of { effort : string }
+  | Ollama_think of { think : bool }
+[@@deriving show, eq]
+
+val thinking_control_for_flavor :
+  cascade_server_flavor -> bool -> int option -> thinking_control
+
+type finish_reason = Stop | Length | Tool_calls | Content_filter | Error
+[@@deriving show, eq]
+
+val finish_reason_of_string : cascade_server_flavor -> string option -> finish_reason
+
+type stream_chunk =
+  | Content_delta of string
+  | Thinking_delta of string
+  | Tool_call of { index : int; id : string; name : string; arguments : string }
+  | Finish of finish_reason
+  | Usage of { input_tokens : int; output_tokens : int }
+  | Done
+[@@deriving show, eq]
+
+type flavor_constraints = {
+  supports_tools_with_streaming : bool;
+  supports_response_format : bool;
+  supports_parallel_tool_calls : bool;
+  finish_reason_nullable : bool;
+  arguments_as_json_object : bool;
+}
+[@@deriving show, eq]
+
+val constraints_of_flavor : cascade_server_flavor -> flavor_constraints
+val can_stream_with_tools : cascade_server_flavor -> bool

--- a/test/dune
+++ b/test/dune
@@ -301,6 +301,10 @@
   test_cascade_declarative_validator
   test_cascade_declarative_adapter
   test_cascade_declarative_hotpath
+  test_cascade_phonebook
+  test_cascade_routing_policy
+  test_cascade_server_flavor
+  test_cascade_phonebook_integration
   test_keeper_cascade_profile_partial
   test_doctor_dispatch
   test_disk_hygiene_script
@@ -623,6 +627,10 @@
   test_cascade_declarative_validator
   test_cascade_declarative_adapter
   test_cascade_declarative_hotpath
+  test_cascade_phonebook
+  test_cascade_routing_policy
+  test_cascade_server_flavor
+  test_cascade_phonebook_integration
   test_keeper_cascade_profile_partial
   test_doctor_dispatch
   test_disk_hygiene_script

--- a/test/fixtures/cascade-phonebook.toml
+++ b/test/fixtures/cascade-phonebook.toml
@@ -1,0 +1,148 @@
+# Cascade Phonebook — data-only (routing logic is in OAS code)
+# SSOT: lib/cascade/cascade_phonebook_types.ml
+# Routing: lib/cascade/cascade_routing_policy.ml (task_use → tier-group)
+# Flavor: lib/cascade/cascade_server_flavor.ml (provider-specific adapters)
+
+# ── Defaults ──────────────────────────────────────────────────────
+
+[defaults]
+max_output_tokens = 4096
+default_thinking_budget = 8192
+
+# ── Providers ─────────────────────────────────────────────────────
+# flavor: OAS adapter hint (string, not logic)
+# protocol: transport method (openai-http, ollama-http, openai-cli)
+
+[providers.runpod-llama]
+endpoint = "https://ma8xbr1kgbclkl-19123.proxy.runpod.net/v1"
+protocol = "openai-http"
+flavor = "llama-cpp"
+auth_env = "RUNPOD_API_TOKEN"
+
+[providers.ollama-local]
+endpoint = "http://127.0.0.1:11434"
+protocol = "ollama-http"
+flavor = "ollama"
+
+[providers.openai-cloud]
+endpoint = "https://api.openai.com/v1"
+protocol = "openai-http"
+flavor = "openai"
+auth_env = "OPENAI_API_KEY"
+
+[providers.deepseek-cloud]
+endpoint = "https://api.deepseek.com"
+protocol = "openai-http"
+flavor = "deepseek"
+auth_env = "DEEPSEEK_API_KEY"
+
+[providers.qwen-dashscope-intl]
+endpoint = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+protocol = "openai-http"
+flavor = "qwen"
+auth_env = "DASHSCOPE_API_KEY"
+note = "Singapore region (closest to Korea)"
+
+[providers.qwen-dashscope-cn]
+endpoint = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+protocol = "openai-http"
+flavor = "qwen"
+auth_env = "DASHSCOPE_API_KEY"
+note = "Beijing region (for China-internal needs)"
+
+[providers.zai-glm-api]
+endpoint = "https://open.bigmodel.cn/api/paas/v4"
+protocol = "openai-http"
+flavor = "zai-glm"
+auth_env = "ZAI_API_KEY"
+note = "glm-5.1, glm-5, glm-5-turbo general models"
+
+[providers.zai-glm-coding]
+endpoint = "https://open.bigmodel.cn/api/paas/v4"
+protocol = "openai-http"
+flavor = "zai-glm"
+auth_env = "ZAI_API_KEY"
+note = "CodeGeeX coding models — separate provider from general API"
+
+# ── Models ────────────────────────────────────────────────────────
+# capabilities subset (full 22-field schema in cascade_model_capabilities)
+
+[models.qwen3-235b]
+provider = "runpod-llama"
+model_id = "qwen3-235b-a22b"
+capabilities = { max_output_tokens = 32768, supports_tool_choice = true, supports_extended_thinking = true, thinking_control_format = "chat_template_kwargs", supports_image_input = true }
+
+[models.glm-5]
+provider = "zai-glm-api"
+model_id = "glm-5"
+capabilities = { max_output_tokens = 16384, supports_tool_choice = true, supports_extended_thinking = true, thinking_control_format = "reasoning_content", supports_image_input = false }
+
+[models.glm-5-turbo]
+provider = "zai-glm-api"
+model_id = "glm-5-turbo"
+capabilities = { max_output_tokens = 8192, supports_tool_choice = true, supports_extended_thinking = false, thinking_control_format = "reasoning_content", supports_image_input = false }
+note = "Fast variant, lower cost"
+
+[models.glm-4-7-flash]
+provider = "zai-glm-api"
+model_id = "glm-4.7-flash"
+capabilities = { max_output_tokens = 4096, supports_tool_choice = true, supports_extended_thinking = false, thinking_control_format = "reasoning_content", supports_image_input = false }
+note = "30B-A3B MoE, free tier"
+
+[models.o3-mini]
+provider = "openai-cloud"
+model_id = "o3-mini"
+capabilities = { max_output_tokens = 65536, supports_tool_choice = true, supports_reasoning_budget = true, thinking_control_format = "reasoning_effort", supports_image_input = false }
+
+[models.deepseek-v4-flash]
+provider = "deepseek-cloud"
+model_id = "deepseek-v4-flash"
+capabilities = { max_output_tokens = 65536, supports_tool_choice = true, supports_extended_thinking = true, thinking_control_format = "reasoning_param", supports_image_input = false }
+
+[models.deepseek-v4-pro]
+provider = "deepseek-cloud"
+model_id = "deepseek-v4-pro"
+capabilities = { max_output_tokens = 65536, supports_tool_choice = true, supports_extended_thinking = true, thinking_control_format = "reasoning_param", supports_image_input = false }
+
+[models.qwen3-5-plus]
+provider = "qwen-dashscope-intl"
+model_id = "qwen3.5-plus"
+capabilities = { max_output_tokens = 16384, supports_tool_choice = true, supports_extended_thinking = false, thinking_control_format = "no_thinking_control", supports_image_input = false }
+note = "tools + stream=True not supported"
+
+[models.qwen3-coder-plus]
+provider = "qwen-dashscope-intl"
+model_id = "qwen3-coder-plus"
+capabilities = { max_output_tokens = 32768, supports_tool_choice = true, supports_extended_thinking = false, thinking_control_format = "no_thinking_control", supports_image_input = false }
+
+[models.codegeex-4]
+provider = "zai-glm-coding"
+model_id = "codegeex-4"
+capabilities = { max_output_tokens = 16384, supports_tool_choice = true, supports_extended_thinking = false, thinking_control_format = "reasoning_content", supports_image_input = false }
+note = "CodeGeeX coding specialist"
+
+# ── Tier-Groups (sole routing unit) ───────────────────────────────
+# OAS selects tier-group per task_use. No model/provider-level selection.
+
+[tier-groups.primary]
+members = ["qwen3-235b"]
+weight = 100
+
+[tier-groups.cross-verify]
+members = ["glm-5", "o3-mini", "deepseek-v4-flash"]
+constraint = "diverse_from_primary"
+note = "Independent from primary provider for adversarial review"
+
+[tier-groups.coding-verify]
+members = ["deepseek-v4-pro", "qwen3-coder-plus"]
+constraint = "diverse_from_primary"
+note = "Coding-specialist cross-verification"
+
+[tier-groups.fast]
+members = ["glm-5-turbo", "glm-4-7-flash", "qwen3-5-plus"]
+weight = 80
+note = "Quick decisions and fast responses"
+
+[tier-groups.coding]
+members = ["codegeex-4", "qwen3-coder-plus"]
+note = "Coding-focused models"

--- a/test/test_cascade_phonebook.ml
+++ b/test/test_cascade_phonebook.ml
@@ -281,7 +281,7 @@ let test_thinking_format_thinking_param () =
 
 (* --- Real TOML file validation --- *)
 
-let phonebook_toml_path = ".masc/config/cascade-phonebook.toml"
+let phonebook_toml_path = "test/fixtures/cascade-phonebook.toml"
 
 let test_real_toml_parses () =
   let toml = Otoml.Parser.from_file phonebook_toml_path in

--- a/test/test_cascade_phonebook.ml
+++ b/test/test_cascade_phonebook.ml
@@ -1,0 +1,367 @@
+(** Phonebook parser + types unit tests.
+
+    Validates TOML parsing into typed phonebook,
+    including lookup helpers and error accumulation. *)
+
+open Alcotest
+open Masc_mcp.Cascade_phonebook_types
+open Masc_mcp.Cascade_phonebook_parser
+
+(* --- Helpers --- *)
+
+let ok_phonebook
+    (result : (cascade_phonebook, parse_error list) result)
+    : cascade_phonebook =
+  match result with
+  | Ok pb -> pb
+  | Error errs ->
+    let msg =
+      List.map (fun e -> Printf.sprintf "%s: %s" e.path e.message) errs
+      |> String.concat "; "
+    in
+    failwith ("expected Ok, got Error: " ^ msg)
+
+let is_error
+    (result : (cascade_phonebook, parse_error list) result)
+    : parse_error list =
+  match result with
+  | Ok _ -> failwith "expected Error, got Ok"
+  | Error errs -> errs
+
+let has_error_at (path : string) (errs : parse_error list) =
+  check bool ("error at " ^ path) true (List.exists (fun e -> e.path = path) errs)
+
+(* --- Test TOML fixtures --- *)
+
+let minimal_toml =
+  {|[defaults]
+max_output_tokens = 4096
+default_thinking_budget = 8192
+
+[providers.runpod-llama]
+endpoint = "https://example.com/v1"
+protocol = "openai-http"
+flavor = "llama-cpp"
+auth_env = "RUNPOD_API_TOKEN"
+
+[models.qwen3-235b]
+provider = "runpod-llama"
+model_id = "qwen3-235b-a22b"
+
+[tier-groups.primary]
+members = ["qwen3-235b"]
+weight = 100
+|}
+
+let full_toml =
+  {|[defaults]
+max_output_tokens = 8192
+default_thinking_budget = 16384
+
+[providers.runpod-llama]
+endpoint = "https://ma8xbr1kgbclkl-19123.proxy.runpod.net/v1"
+protocol = "openai-http"
+flavor = "llama-cpp"
+auth_env = "RUNPOD_API_TOKEN"
+
+[providers.zai-glm-api]
+endpoint = "https://open.bigmodel.cn/api/paas/v4"
+protocol = "openai-http"
+flavor = "zai-glm"
+auth_env = "ZAI_API_KEY"
+
+[providers.deepseek-cloud]
+endpoint = "https://api.deepseek.com"
+protocol = "openai-http"
+flavor = "deepseek"
+auth_env = "DEEPSEEK_API_KEY"
+
+[models.qwen3-235b]
+provider = "runpod-llama"
+model_id = "qwen3-235b-a22b"
+capabilities = { max_output_tokens = 32768, supports_tool_choice = true, supports_extended_thinking = true, thinking_control_format = "chat_template_kwargs", supports_image_input = true }
+
+[models.glm-5]
+provider = "zai-glm-api"
+model_id = "glm-5"
+capabilities = { max_output_tokens = 16384, supports_tool_choice = true, supports_extended_thinking = true, thinking_control_format = "reasoning_content" }
+
+[models.deepseek-v4-flash]
+provider = "deepseek-cloud"
+model_id = "deepseek-v4-flash"
+capabilities = { max_output_tokens = 65536, supports_tool_choice = true, supports_extended_thinking = true, thinking_control_format = "reasoning_param" }
+
+[tier-groups.primary]
+members = ["qwen3-235b"]
+weight = 100
+
+[tier-groups.cross-verify]
+members = ["glm-5", "deepseek-v4-flash"]
+constraint = "diverse_from_primary"
+|}
+
+let parse_toml (s : string) : (cascade_phonebook, parse_error list) result =
+  let toml = Otoml.Parser.from_string s in
+  parse_phonebook toml
+
+(* --- Defaults tests --- *)
+
+let test_defaults_minimal () =
+  let pb = ok_phonebook (parse_toml minimal_toml) in
+  check int "max_output_tokens" 4096 pb.defaults.max_output_tokens;
+  check int "default_thinking_budget" 8192 pb.defaults.default_thinking_budget
+
+let test_defaults_full () =
+  let pb = ok_phonebook (parse_toml full_toml) in
+  check int "max_output_tokens" 8192 pb.defaults.max_output_tokens;
+  check int "default_thinking_budget" 16384 pb.defaults.default_thinking_budget
+
+let test_defaults_missing () =
+  let toml = {|[providers.x]
+endpoint = "https://example.com"
+protocol = "openai-http"
+flavor = "openai"
+|}
+  in
+  let pb = ok_phonebook (parse_toml toml) in
+  check int "max_output_tokens default" 4096 pb.defaults.max_output_tokens;
+  check int "default_thinking_budget default" 8192 pb.defaults.default_thinking_budget
+
+(* --- Provider tests --- *)
+
+let test_provider_count () =
+  let pb = ok_phonebook (parse_toml full_toml) in
+  check int "provider count" 3 (List.length pb.providers)
+
+let test_provider_fields () =
+  let pb = ok_phonebook (parse_toml full_toml) in
+  match provider_of_id pb "runpod-llama" with
+  | None -> failwith "provider runpod-llama not found"
+  | Some p ->
+    check string "id" "runpod-llama" p.id;
+    check string "endpoint" "https://ma8xbr1kgbclkl-19123.proxy.runpod.net/v1" p.endpoint;
+    check string "protocol" "openai-http" (protocol_to_string p.protocol);
+    check string "flavor" "llama-cpp" (flavor_to_string p.flavor);
+    check (option string) "auth_env" (Some "RUNPOD_API_TOKEN") p.auth_env
+
+let test_provider_missing_endpoint () =
+  let toml = {|[providers.broken]
+protocol = "openai-http"
+flavor = "openai"
+|}
+  in
+  let errs = is_error (parse_toml toml) in
+  has_error_at "providers.broken.endpoint" errs
+
+(* --- Model tests --- *)
+
+let test_model_count () =
+  let pb = ok_phonebook (parse_toml full_toml) in
+  check int "model count" 3 (List.length pb.models)
+
+let test_model_fields () =
+  let pb = ok_phonebook (parse_toml full_toml) in
+  match model_of_id pb "qwen3-235b" with
+  | None -> failwith "model qwen3-235b not found"
+  | Some m ->
+    check string "id" "qwen3-235b" m.id;
+    check string "provider" "runpod-llama" m.provider;
+    check string "model_id" "qwen3-235b-a22b" m.model_id
+
+let test_model_capabilities () =
+  let pb = ok_phonebook (parse_toml full_toml) in
+  match model_of_id pb "qwen3-235b" with
+  | None -> failwith "model not found"
+  | Some m ->
+    check (option int) "max_output_tokens" (Some 32768) m.capabilities.max_output_tokens;
+    check bool "supports_tool_choice" true m.capabilities.supports_tool_choice;
+    check bool "supports_extended_thinking" true m.capabilities.supports_extended_thinking;
+    check bool "supports_image_input" true m.capabilities.supports_image_input
+
+let test_model_missing_provider () =
+  let toml = {|[models.broken]
+model_id = "test"
+|}
+  in
+  let errs = is_error (parse_toml toml) in
+  has_error_at "models.broken.provider" errs
+
+let test_model_missing_model_id () =
+  let toml = {|[models.broken]
+provider = "x"
+|}
+  in
+  let errs = is_error (parse_toml toml) in
+  has_error_at "models.broken.model_id" errs
+
+(* --- Tier-group tests --- *)
+
+let test_tier_group_count () =
+  let pb = ok_phonebook (parse_toml full_toml) in
+  check int "tier_group count" 2 (List.length pb.tier_groups)
+
+let test_tier_group_primary () =
+  let pb = ok_phonebook (parse_toml full_toml) in
+  match tier_group_of_name pb "primary" with
+  | None -> failwith "tier-group primary not found"
+  | Some tg ->
+    check string "name" "primary" tg.name;
+    check int "weight" 100 tg.weight;
+    check int "members length" 1 (List.length tg.members);
+    check bool "no constraint" true (tg.constraint_ = None)
+
+let test_tier_group_cross_verify () =
+  let pb = ok_phonebook (parse_toml full_toml) in
+  match tier_group_of_name pb "cross-verify" with
+  | None -> failwith "tier-group cross-verify not found"
+  | Some tg ->
+    check int "members length" 2 (List.length tg.members);
+    check bool "constraint is Diverse_from_primary"
+      true
+      (tg.constraint_ = Some Diverse_from_primary)
+
+let test_tier_group_missing_members () =
+  let toml = {|[tier-groups.broken]
+weight = 50
+|}
+  in
+  let errs = is_error (parse_toml toml) in
+  has_error_at "tier-groups.broken.members" errs
+
+(* --- Lookup helpers --- *)
+
+let test_models_of_tier_group () =
+  let pb = ok_phonebook (parse_toml full_toml) in
+  match tier_group_of_name pb "primary" with
+  | None -> failwith "tier-group not found"
+  | Some tg ->
+    let models = models_of_tier_group pb tg in
+    check int "models in primary" 1 (List.length models);
+    match models with
+    | [] -> failwith "no models"
+    | m :: _ -> check string "model id" "qwen3-235b" m.id
+
+let test_provider_of_model () =
+  let pb = ok_phonebook (parse_toml full_toml) in
+  match model_of_id pb "glm-5" with
+  | None -> failwith "model glm-5 not found"
+  | Some m ->
+    match provider_of_model pb m with
+    | None -> failwith "provider not found"
+    | Some p -> check string "provider id" "zai-glm-api" p.id
+
+(* --- Thinking control format --- *)
+
+let test_thinking_format_chat_template_kwargs () =
+  let pb = ok_phonebook (parse_toml full_toml) in
+  match model_of_id pb "qwen3-235b" with
+  | None -> failwith "model not found"
+  | Some m ->
+    check bool "is Chat_template_kwargs"
+      true
+      (m.capabilities.thinking_control_format = Chat_template_kwargs)
+
+let test_thinking_format_reasoning_content () =
+  let pb = ok_phonebook (parse_toml full_toml) in
+  match model_of_id pb "glm-5" with
+  | None -> failwith "model not found"
+  | Some m ->
+    check bool "is Reasoning_content"
+      true
+      (m.capabilities.thinking_control_format = Reasoning_content)
+
+let test_thinking_format_thinking_param () =
+  let pb = ok_phonebook (parse_toml full_toml) in
+  match model_of_id pb "deepseek-v4-flash" with
+  | None -> failwith "model not found"
+  | Some m ->
+    check bool "is Reasoning_param"
+      true
+      (m.capabilities.thinking_control_format = Reasoning_param)
+
+(* --- Real TOML file validation --- *)
+
+let phonebook_toml_path = ".masc/config/cascade-phonebook.toml"
+
+let test_real_toml_parses () =
+  let toml = Otoml.Parser.from_file phonebook_toml_path in
+  let pb = ok_phonebook (parse_phonebook toml) in
+  check int "8 providers" 8 (List.length pb.providers);
+  check int "10 models" 10 (List.length pb.models);
+  check int "5 tier-groups" 5 (List.length pb.tier_groups)
+
+let test_real_toml_tier_groups () =
+  let toml = Otoml.Parser.from_file phonebook_toml_path in
+  let pb = ok_phonebook (parse_phonebook toml) in
+  let names = List.map (fun (tg : cascade_phonebook_tier_group) -> tg.name) pb.tier_groups
+              |> List.sort String.compare in
+  check (list string) "tier-group names"
+    ["coding"; "coding-verify"; "cross-verify"; "fast"; "primary"] names
+
+let test_real_toml_cross_verify_diverse () =
+  let toml = Otoml.Parser.from_file phonebook_toml_path in
+  let pb = ok_phonebook (parse_phonebook toml) in
+  match tier_group_of_name pb "cross-verify" with
+  | None -> failwith "cross-verify not found"
+  | Some tg ->
+    check int "3 members" 3 (List.length tg.members);
+    check bool "has Diverse_from_primary constraint"
+      true (tg.constraint_ = Some Diverse_from_primary)
+
+let test_real_toml_model_capabilities () =
+  let toml = Otoml.Parser.from_file phonebook_toml_path in
+  let pb = ok_phonebook (parse_phonebook toml) in
+  (match model_of_id pb "qwen3-235b" with
+   | None -> failwith "qwen3-235b not found"
+   | Some m ->
+     check (option int) "max_output_tokens" (Some 32768) m.capabilities.max_output_tokens;
+     check bool "supports_extended_thinking" true m.capabilities.supports_extended_thinking;
+     check bool "supports_image_input" true m.capabilities.supports_image_input);
+  (match model_of_id pb "glm-4-7-flash" with
+   | None -> failwith "glm-4-7-flash not found"
+   | Some m ->
+     check bool "no extended thinking" false m.capabilities.supports_extended_thinking)
+
+(* --- Suite --- *)
+
+let () =
+  run "Cascade Phonebook"
+    [ ( "defaults"
+      , [ test_case "minimal" `Quick test_defaults_minimal
+        ; test_case "full" `Quick test_defaults_full
+        ; test_case "missing uses defaults" `Quick test_defaults_missing
+        ] )
+    ; ( "providers"
+      , [ test_case "count" `Quick test_provider_count
+        ; test_case "fields" `Quick test_provider_fields
+        ; test_case "missing endpoint errors" `Quick test_provider_missing_endpoint
+        ] )
+    ; ( "models"
+      , [ test_case "count" `Quick test_model_count
+        ; test_case "fields" `Quick test_model_fields
+        ; test_case "capabilities" `Quick test_model_capabilities
+        ; test_case "missing provider errors" `Quick test_model_missing_provider
+        ; test_case "missing model_id errors" `Quick test_model_missing_model_id
+        ] )
+    ; ( "tier-groups"
+      , [ test_case "count" `Quick test_tier_group_count
+        ; test_case "primary" `Quick test_tier_group_primary
+        ; test_case "cross-verify" `Quick test_tier_group_cross_verify
+        ; test_case "missing members errors" `Quick test_tier_group_missing_members
+        ] )
+    ; ( "lookups"
+      , [ test_case "models_of_tier_group" `Quick test_models_of_tier_group
+        ; test_case "provider_of_model" `Quick test_provider_of_model
+        ] )
+    ; ( "thinking_format"
+      , [ test_case "chat_template_kwargs" `Quick test_thinking_format_chat_template_kwargs
+        ; test_case "reasoning_content" `Quick test_thinking_format_reasoning_content
+        ; test_case "thinking_param" `Quick test_thinking_format_thinking_param
+        ] )
+    ; ( "real_toml"
+      , [ test_case "parses" `Quick test_real_toml_parses
+        ; test_case "tier_groups" `Quick test_real_toml_tier_groups
+        ; test_case "cross_verify_diverse" `Quick test_real_toml_cross_verify_diverse
+        ; test_case "model_capabilities" `Quick test_real_toml_model_capabilities
+        ] )
+    ]

--- a/test/test_cascade_phonebook_integration.ml
+++ b/test/test_cascade_phonebook_integration.ml
@@ -141,12 +141,16 @@ let test_fast_tier_group_no_thinking () =
 
 let test_legacy_logical_use_to_phonebook_route () =
   let pb = load_fixture () in
-  let keeper_turn = task_use_of_legacy_logical_use "keeper_turn" in
-  let models = resolve_models_for_task pb default_routing_policies keeper_turn in
-  check bool "keeper_turn → at least 1 model" true (List.length models >= 1);
-  let adversarial = task_use_of_legacy_logical_use "adversarial_reviewer" in
-  let adv_models = resolve_models_for_task pb default_routing_policies adversarial in
-  check bool "adversarial_reviewer → at least 1 model" true (List.length adv_models >= 1)
+  (match task_use_of_legacy_logical_use "keeper_turn" with
+   | Some keeper_turn ->
+     let models = resolve_models_for_task pb default_routing_policies keeper_turn in
+     check bool "keeper_turn → at least 1 model" true (List.length models >= 1)
+   | None -> failwith "keeper_turn not mapped");
+  (match task_use_of_legacy_logical_use "adversarial_reviewer" with
+   | Some adversarial ->
+     let adv_models = resolve_models_for_task pb default_routing_policies adversarial in
+     check bool "adversarial_reviewer → at least 1 model" true (List.length adv_models >= 1)
+   | None -> failwith "adversarial_reviewer not mapped")
 
 (* --- Tier-group completeness --- *)
 

--- a/test/test_cascade_phonebook_integration.ml
+++ b/test/test_cascade_phonebook_integration.ml
@@ -1,0 +1,205 @@
+(** Phonebook integration tests.
+
+    End-to-end: TOML file → phonebook parser → routing policy → model resolution.
+    Uses the real cascade-phonebook.toml fixture. *)
+
+open Alcotest
+open Masc_mcp.Cascade_phonebook_types
+open Masc_mcp.Cascade_phonebook_parser
+open Masc_mcp.Cascade_routing_policy
+open Masc_mcp.Cascade_server_flavor
+
+let phonebook_toml_path = ".masc/config/cascade-phonebook.toml"
+
+let ok_phonebook (result : (cascade_phonebook, parse_error list) result) =
+  match result with
+  | Ok pb -> pb
+  | Error errs ->
+    let msg =
+      List.map (fun e -> Printf.sprintf "%s: %s" e.path e.message) errs
+      |> String.concat "; "
+    in
+    failwith ("expected Ok, got Error: " ^ msg)
+
+let load_fixture () =
+  let toml = Otoml.Parser.from_file phonebook_toml_path in
+  ok_phonebook (parse_phonebook toml)
+
+(* --- Routing policy end-to-end --- *)
+
+let test_code_generation_routes_to_primary () =
+  let pb = load_fixture () in
+  let models = resolve_models_for_task pb default_routing_policies Code_generation in
+  check bool "at least 1 model" true (List.length models >= 1);
+  match models with
+  | [] -> failwith "no models"
+  | m :: _ ->
+    check string "primary model" "qwen3-235b" m.id;
+    check string "provider" "runpod-llama" m.provider
+
+let test_code_review_routes_cross_verify () =
+  let pb = load_fixture () in
+  let models = resolve_models_for_task pb default_routing_policies Code_review in
+  check bool "at least 2 models" true (List.length models >= 2);
+  let primary_tg =
+    match tier_group_of_name pb "primary" with
+    | Some tg -> tg
+    | None -> failwith "primary tier-group not found"
+  in
+  List.iter (fun m ->
+    check bool (Printf.sprintf "%s is diverse from primary" m.id)
+      true (satisfies_diversity pb primary_tg (Some Diverse_from_primary) m)
+  ) models
+
+let test_quick_decision_routes_fast () =
+  let pb = load_fixture () in
+  let models = resolve_models_for_task pb default_routing_policies Quick_decision in
+  check bool "at least 1 model" true (List.length models >= 1)
+
+let test_conversation_routes_primary () =
+  let pb = load_fixture () in
+  let models = resolve_models_for_task pb default_routing_policies Conversation in
+  check bool "at least 1 model" true (List.length models >= 1)
+
+(* --- Flavor integration --- *)
+
+(* cascade_server_flavor.ml shares the type via
+   "type t = Cascade_phonebook_types.t = ...", so no conversion needed. *)
+let flavor_of_phonebook (f : cascade_server_flavor) : cascade_server_flavor = f
+
+let test_model_flavor_lookup () =
+  let pb = load_fixture () in
+  (match model_of_id pb "qwen3-235b" with
+   | None -> failwith "qwen3-235b not found"
+   | Some m ->
+     match provider_of_model pb m with
+     | None -> failwith "provider not found"
+     | Some p ->
+       check string "flavor" "llama-cpp" (flavor_to_string p.flavor);
+       check bool "can stream with tools" true
+         (can_stream_with_tools (flavor_of_phonebook p.flavor)));
+  (match model_of_id pb "deepseek-v4-flash" with
+   | None -> failwith "deepseek-v4-flash not found"
+   | Some m ->
+     match provider_of_model pb m with
+     | None -> failwith "provider not found"
+     | Some p ->
+       check string "flavor" "deepseek" (flavor_to_string p.flavor));
+  (match model_of_id pb "qwen3-5-plus" with
+   | None -> failwith "qwen3-5-plus not found"
+   | Some m ->
+     match provider_of_model pb m with
+     | None -> failwith "provider not found"
+     | Some p ->
+       check string "flavor" "qwen" (flavor_to_string p.flavor);
+       check bool "Qwen cannot stream with tools" false
+         (can_stream_with_tools (flavor_of_phonebook p.flavor)))
+
+let test_thinking_control_per_model () =
+  let pb = load_fixture () in
+  (* llama-cpp: extended thinking with chat_template_kwargs *)
+  (match model_of_id pb "qwen3-235b" with
+   | Some m ->
+     check bool "supports_extended_thinking" true m.capabilities.supports_extended_thinking;
+     check bool "format is Chat_template_kwargs"
+       true (m.capabilities.thinking_control_format = Chat_template_kwargs)
+   | None -> failwith "qwen3-235b not found");
+  (* zai-glm: extended thinking with reasoning_content *)
+  (match model_of_id pb "glm-5" with
+   | Some m ->
+     check bool "supports_extended_thinking" true m.capabilities.supports_extended_thinking;
+     check bool "format is Reasoning_content"
+       true (m.capabilities.thinking_control_format = Reasoning_content)
+   | None -> failwith "glm-5 not found");
+  (* deepseek: extended thinking with reasoning_param *)
+  (match model_of_id pb "deepseek-v4-flash" with
+   | Some m ->
+     check bool "supports_extended_thinking" true m.capabilities.supports_extended_thinking;
+     check bool "format is Reasoning_param"
+       true (m.capabilities.thinking_control_format = Reasoning_param)
+   | None -> failwith "deepseek-v4-flash not found");
+  (* openai: reasoning budget *)
+  (match model_of_id pb "o3-mini" with
+   | Some m ->
+     check bool "supports_reasoning_budget" true m.capabilities.supports_reasoning_budget;
+     check bool "format is Reasoning_effort"
+       true (m.capabilities.thinking_control_format = Reasoning_effort)
+   | None -> failwith "o3-mini not found")
+
+let test_fast_tier_group_no_thinking () =
+  let pb = load_fixture () in
+  match tier_group_of_name pb "fast" with
+  | None -> failwith "fast tier-group not found"
+  | Some tg ->
+    let models = models_of_tier_group pb tg in
+    List.iter (fun m ->
+      check bool (Printf.sprintf "%s: no extended thinking" m.id)
+        false m.capabilities.supports_extended_thinking
+    ) models
+
+(* --- Legacy mapping integration --- *)
+
+let test_legacy_logical_use_to_phonebook_route () =
+  let pb = load_fixture () in
+  let keeper_turn = task_use_of_legacy_logical_use "keeper_turn" in
+  let models = resolve_models_for_task pb default_routing_policies keeper_turn in
+  check bool "keeper_turn → at least 1 model" true (List.length models >= 1);
+  let adversarial = task_use_of_legacy_logical_use "adversarial_reviewer" in
+  let adv_models = resolve_models_for_task pb default_routing_policies adversarial in
+  check bool "adversarial_reviewer → at least 1 model" true (List.length adv_models >= 1)
+
+(* --- Tier-group completeness --- *)
+
+let test_all_tier_groups_resolve () =
+  let pb = load_fixture () in
+  let all_tg_names = ["primary"; "cross-verify"; "coding-verify"; "fast"; "coding"] in
+  List.iter (fun name ->
+    match tier_group_of_name pb name with
+    | None -> failwith (Printf.sprintf "tier-group '%s' not found" name)
+    | Some tg ->
+      let models = models_of_tier_group pb tg in
+      check int (Printf.sprintf "%s has members" name)
+        (List.length tg.members) (List.length models)
+  ) all_tg_names
+
+let test_coding_verify_diverse () =
+  let pb = load_fixture () in
+  match tier_group_of_name pb "coding-verify" with
+  | None -> failwith "coding-verify not found"
+  | Some tg ->
+    check bool "has Diverse_from_primary constraint"
+      true (tg.constraint_ = Some Diverse_from_primary);
+    let models = models_of_tier_group pb tg in
+    let primary_tg =
+      match tier_group_of_name pb "primary" with
+      | Some t -> t
+      | None -> failwith "primary not found"
+    in
+    List.iter (fun m ->
+      check bool (Printf.sprintf "%s is diverse from primary" m.id)
+        true (satisfies_diversity pb primary_tg (Some Diverse_from_primary) m)
+    ) models
+
+(* --- Suite --- *)
+
+let () =
+  run "Cascade Phonebook Integration"
+    [ ( "routing_e2e"
+      , [ test_case "code_generation → primary" `Quick test_code_generation_routes_to_primary
+        ; test_case "code_review → cross-verify diverse" `Quick test_code_review_routes_cross_verify
+        ; test_case "quick_decision → fast" `Quick test_quick_decision_routes_fast
+        ; test_case "conversation → primary" `Quick test_conversation_routes_primary
+        ] )
+    ; ( "flavor_e2e"
+      , [ test_case "model → provider → flavor" `Quick test_model_flavor_lookup
+        ; test_case "thinking control per model" `Quick test_thinking_control_per_model
+        ; test_case "fast tier no extended thinking" `Quick test_fast_tier_group_no_thinking
+        ] )
+    ; ( "legacy_compat"
+      , [ test_case "legacy logical_use routes" `Quick test_legacy_logical_use_to_phonebook_route
+        ] )
+    ; ( "tier_group_completeness"
+      , [ test_case "all tier-groups resolve" `Quick test_all_tier_groups_resolve
+        ; test_case "coding-verify diverse from primary" `Quick test_coding_verify_diverse
+        ] )
+    ]

--- a/test/test_cascade_phonebook_integration.ml
+++ b/test/test_cascade_phonebook_integration.ml
@@ -9,7 +9,7 @@ open Masc_mcp.Cascade_phonebook_parser
 open Masc_mcp.Cascade_routing_policy
 open Masc_mcp.Cascade_server_flavor
 
-let phonebook_toml_path = ".masc/config/cascade-phonebook.toml"
+let phonebook_toml_path = "test/fixtures/cascade-phonebook.toml"
 
 let ok_phonebook (result : (cascade_phonebook, parse_error list) result) =
   match result with

--- a/test/test_cascade_routing_policy.ml
+++ b/test/test_cascade_routing_policy.ml
@@ -34,40 +34,42 @@ let test_unknown_is_none () =
 
 (* --- Legacy logical_use mapping --- *)
 
+let unwrap = function Some x -> x | None -> failwith "unexpected None"
+
 let test_legacy_keeper_turn () =
   check string "keeper_turn → Code_generation"
     "code_generation"
-    (task_use_to_string (task_use_of_legacy_logical_use "keeper_turn"))
+    (task_use_to_string (unwrap (task_use_of_legacy_logical_use "keeper_turn")))
 
 let test_legacy_tool_required () =
   check string "tool_required → Tool_execution"
     "tool_execution"
-    (task_use_to_string (task_use_of_legacy_logical_use "tool_required"))
+    (task_use_to_string (unwrap (task_use_of_legacy_logical_use "tool_required")))
 
 let test_legacy_adversarial_reviewer () =
   check string "adversarial_reviewer → Code_review"
     "code_review"
-    (task_use_to_string (task_use_of_legacy_logical_use "adversarial_reviewer"))
+    (task_use_to_string (unwrap (task_use_of_legacy_logical_use "adversarial_reviewer")))
 
 let test_legacy_cross_verifier () =
   check string "cross_verifier → Code_review"
     "code_review"
-    (task_use_to_string (task_use_of_legacy_logical_use "cross_verifier"))
+    (task_use_to_string (unwrap (task_use_of_legacy_logical_use "cross_verifier")))
 
 let test_legacy_auto_responder () =
   check string "auto_responder → Quick_decision"
     "quick_decision"
-    (task_use_to_string (task_use_of_legacy_logical_use "auto_responder"))
+    (task_use_to_string (unwrap (task_use_of_legacy_logical_use "auto_responder")))
 
 let test_legacy_complex_task () =
   check string "complex_task → Long_reasoning"
     "long_reasoning"
-    (task_use_to_string (task_use_of_legacy_logical_use "complex_task"))
+    (task_use_to_string (unwrap (task_use_of_legacy_logical_use "complex_task")))
 
 let test_legacy_unknown () =
-  check string "unknown → Conversation"
-    "conversation"
-    (task_use_to_string (task_use_of_legacy_logical_use "something_new"))
+  check (option string) "unknown → None"
+    None
+    (Option.map task_use_to_string (task_use_of_legacy_logical_use "something_new"))
 
 (* --- Default routing policies --- *)
 

--- a/test/test_cascade_routing_policy.ml
+++ b/test/test_cascade_routing_policy.ml
@@ -1,0 +1,263 @@
+(** Routing policy unit tests.
+
+    Validates task_use categories, legacy mapping,
+    default policies, model resolution, and diversity constraints. *)
+
+open Alcotest
+open Masc_mcp.Cascade_phonebook_types
+open Masc_mcp.Cascade_routing_policy
+
+let task_use_of_string_exn (s : string) : task_use =
+  match task_use_of_string s with
+  | Some t -> t
+  | None -> failwith ("unknown task_use: " ^ s)
+
+(* --- task_use roundtrip --- *)
+
+let test_roundtrip () =
+  let all =
+    [ Code_generation; Code_review; Quick_decision
+    ; Long_reasoning; Tool_execution; Conversation
+    ]
+  in
+  List.iter
+    (fun t ->
+       let s = task_use_to_string t in
+       check (option string) "roundtrip"
+         (Some s)
+         (Option.map task_use_to_string (task_use_of_string s)))
+    all
+
+let test_unknown_is_none () =
+  check (option string) "unknown" None
+    (Option.map task_use_to_string (task_use_of_string "nonexistent"))
+
+(* --- Legacy logical_use mapping --- *)
+
+let test_legacy_keeper_turn () =
+  check string "keeper_turn → Code_generation"
+    "code_generation"
+    (task_use_to_string (task_use_of_legacy_logical_use "keeper_turn"))
+
+let test_legacy_tool_required () =
+  check string "tool_required → Tool_execution"
+    "tool_execution"
+    (task_use_to_string (task_use_of_legacy_logical_use "tool_required"))
+
+let test_legacy_adversarial_reviewer () =
+  check string "adversarial_reviewer → Code_review"
+    "code_review"
+    (task_use_to_string (task_use_of_legacy_logical_use "adversarial_reviewer"))
+
+let test_legacy_cross_verifier () =
+  check string "cross_verifier → Code_review"
+    "code_review"
+    (task_use_to_string (task_use_of_legacy_logical_use "cross_verifier"))
+
+let test_legacy_auto_responder () =
+  check string "auto_responder → Quick_decision"
+    "quick_decision"
+    (task_use_to_string (task_use_of_legacy_logical_use "auto_responder"))
+
+let test_legacy_complex_task () =
+  check string "complex_task → Long_reasoning"
+    "long_reasoning"
+    (task_use_to_string (task_use_of_legacy_logical_use "complex_task"))
+
+let test_legacy_unknown () =
+  check string "unknown → Conversation"
+    "conversation"
+    (task_use_to_string (task_use_of_legacy_logical_use "something_new"))
+
+(* --- Default routing policies --- *)
+
+let test_policy_count () =
+  check int "6 policies" 6 (List.length default_routing_policies)
+
+let test_code_generation_policy () =
+  match policy_for_task default_routing_policies Code_generation with
+  | None -> failwith "no policy for Code_generation"
+  | Some p ->
+    check string "primary_tier_group" "primary" p.primary_tier_group;
+    check (option string) "no diversity" None
+      (Option.map (fun (_ : diversity_constraint) -> "has diversity") p.diversity)
+
+let test_code_review_policy () =
+  match policy_for_task default_routing_policies Code_review with
+  | None -> failwith "no policy for Code_review"
+  | Some p ->
+    check string "primary_tier_group" "cross-verify" p.primary_tier_group;
+    check bool "has diversity" true
+      (match p.diversity with Some Diverse_from_primary -> true | _ -> false)
+
+let test_all_tasks_have_policies () =
+  let all =
+    [ Code_generation; Code_review; Quick_decision
+    ; Long_reasoning; Tool_execution; Conversation
+    ]
+  in
+  List.iter
+    (fun t ->
+       check (option string) (task_use_to_string t ^ " has policy")
+         (Some "yes")
+         (Option.map (fun (_ : task_routing_policy) -> "yes")
+            (policy_for_task default_routing_policies t)))
+    all
+
+(* --- Test phonebook fixture --- *)
+
+let test_pb : cascade_phonebook =
+  let toml =
+    {|[defaults]
+max_output_tokens = 4096
+default_thinking_budget = 8192
+
+[providers.runpod-llama]
+endpoint = "https://example.com/v1"
+protocol = "openai-http"
+flavor = "llama-cpp"
+
+[providers.zai-glm-api]
+endpoint = "https://open.bigmodel.cn/api/paas/v4"
+protocol = "openai-http"
+flavor = "zai-glm"
+
+[providers.deepseek-cloud]
+endpoint = "https://api.deepseek.com"
+protocol = "openai-http"
+flavor = "deepseek"
+
+[models.qwen3-235b]
+provider = "runpod-llama"
+model_id = "qwen3-235b-a22b"
+
+[models.glm-5]
+provider = "zai-glm-api"
+model_id = "glm-5"
+
+[models.deepseek-v4-flash]
+provider = "deepseek-cloud"
+model_id = "deepseek-v4-flash"
+
+[tier-groups.primary]
+members = ["qwen3-235b"]
+weight = 100
+
+[tier-groups.cross-verify]
+members = ["glm-5", "deepseek-v4-flash"]
+constraint = "diverse_from_primary"
+|}
+  in
+  let parsed = Otoml.Parser.from_string toml in
+  match Masc_mcp.Cascade_phonebook_parser.parse_phonebook parsed with
+  | Ok pb -> pb
+  | Error errs ->
+    failwith
+      ("test fixture parse error: "
+       ^ String.concat "; " (List.map (fun (e : Masc_mcp.Cascade_phonebook_parser.parse_error) -> e.path ^ ": " ^ e.message) errs))
+
+(* --- Model resolution --- *)
+
+let test_resolve_code_generation () =
+  let models = resolve_models_for_task test_pb default_routing_policies Code_generation in
+  check int "1 model" 1 (List.length models);
+  match models with
+  | [] -> failwith "no models"
+  | m :: _ -> check string "qwen3-235b" "qwen3-235b" m.id
+
+let test_resolve_code_review () =
+  let models = resolve_models_for_task test_pb default_routing_policies Code_review in
+  check int "2 models in cross-verify" 2 (List.length models)
+
+let test_resolve_unknown_tier_group () =
+  let bad_policy =
+    [ { task = Code_generation; primary_tier_group = "nonexistent"; diversity = None } ]
+  in
+  let models = resolve_models_for_task test_pb bad_policy Code_generation in
+  check int "0 models for nonexistent tier-group" 0 (List.length models)
+
+(* --- Diversity constraints --- *)
+
+let test_satisfies_no_constraint () =
+  let primary_tg =
+    match tier_group_of_name test_pb "primary" with
+    | Some tg -> tg
+    | None -> failwith "primary not found"
+  in
+  match model_of_id test_pb "glm-5" with
+  | None -> failwith "model not found"
+  | Some candidate ->
+    check bool "any available" true (satisfies_diversity test_pb primary_tg None candidate)
+
+let test_satisfies_diverse_from_primary () =
+  let primary_tg =
+    match tier_group_of_name test_pb "primary" with
+    | Some tg -> tg
+    | None -> failwith "primary not found"
+  in
+  (match model_of_id test_pb "glm-5" with
+   | None -> failwith "glm-5 not found"
+   | Some candidate ->
+     check bool "glm-5 is diverse from primary runpod"
+       true
+       (satisfies_diversity test_pb primary_tg (Some Diverse_from_primary) candidate));
+  (match model_of_id test_pb "qwen3-235b" with
+   | None -> failwith "qwen3-235b not found"
+   | Some candidate ->
+     check bool "qwen3-235b is NOT diverse from primary"
+       false
+       (satisfies_diversity test_pb primary_tg (Some Diverse_from_primary) candidate))
+
+let test_satisfies_same_provider () =
+  let primary_tg =
+    match tier_group_of_name test_pb "primary" with
+    | Some tg -> tg
+    | None -> failwith "primary not found"
+  in
+  (match model_of_id test_pb "qwen3-235b" with
+   | None -> failwith "qwen3-235b not found"
+   | Some candidate ->
+     check bool "qwen3-235b same provider as primary"
+       true
+       (satisfies_diversity test_pb primary_tg (Some Same_provider) candidate));
+  (match model_of_id test_pb "glm-5" with
+   | None -> failwith "glm-5 not found"
+   | Some candidate ->
+     check bool "glm-5 NOT same provider as primary"
+       false
+       (satisfies_diversity test_pb primary_tg (Some Same_provider) candidate))
+
+(* --- Suite --- *)
+
+let () =
+  run "Cascade Routing Policy"
+    [ ( "task_use"
+      , [ test_case "roundtrip" `Quick test_roundtrip
+        ; test_case "unknown is None" `Quick test_unknown_is_none
+        ] )
+    ; ( "legacy_mapping"
+      , [ test_case "keeper_turn" `Quick test_legacy_keeper_turn
+        ; test_case "tool_required" `Quick test_legacy_tool_required
+        ; test_case "adversarial_reviewer" `Quick test_legacy_adversarial_reviewer
+        ; test_case "cross_verifier" `Quick test_legacy_cross_verifier
+        ; test_case "auto_responder" `Quick test_legacy_auto_responder
+        ; test_case "complex_task" `Quick test_legacy_complex_task
+        ; test_case "unknown → Conversation" `Quick test_legacy_unknown
+        ] )
+    ; ( "default_policies"
+      , [ test_case "count" `Quick test_policy_count
+        ; test_case "code_generation" `Quick test_code_generation_policy
+        ; test_case "code_review" `Quick test_code_review_policy
+        ; test_case "all covered" `Quick test_all_tasks_have_policies
+        ] )
+    ; ( "resolution"
+      , [ test_case "code_generation → primary" `Quick test_resolve_code_generation
+        ; test_case "code_review → cross-verify" `Quick test_resolve_code_review
+        ; test_case "nonexistent tier-group → empty" `Quick test_resolve_unknown_tier_group
+        ] )
+    ; ( "diversity"
+      , [ test_case "no constraint" `Quick test_satisfies_no_constraint
+        ; test_case "diverse_from_primary" `Quick test_satisfies_diverse_from_primary
+        ; test_case "same_provider" `Quick test_satisfies_same_provider
+        ] )
+    ]

--- a/test/test_cascade_server_flavor.ml
+++ b/test/test_cascade_server_flavor.ml
@@ -1,0 +1,177 @@
+(** Server flavor adapter unit tests.
+
+    Validates flavor constraints, thinking control,
+    finish reason mapping, and Qwen tools+stream restriction. *)
+
+open Alcotest
+open Masc_mcp.Cascade_server_flavor
+
+(* --- Flavor constraints --- *)
+
+let test_llama_cpp_constraints () =
+  let c = constraints_of_flavor Llama_cpp in
+  check bool "supports_tools_with_streaming" true c.supports_tools_with_streaming;
+  check bool "supports_response_format" true c.supports_response_format
+
+let test_ollama_constraints () =
+  let c = constraints_of_flavor Ollama in
+  check bool "supports_tools_with_streaming" true c.supports_tools_with_streaming;
+  check bool "supports_parallel_tool_calls" true c.supports_parallel_tool_calls
+
+let test_openai_constraints () =
+  let c = constraints_of_flavor Openai in
+  check bool "supports_tools_with_streaming" true c.supports_tools_with_streaming;
+  check bool "supports_response_format" true c.supports_response_format;
+  check bool "supports_parallel_tool_calls" true c.supports_parallel_tool_calls
+
+let test_deep_seek_constraints () =
+  let c = constraints_of_flavor Deep_seek in
+  check bool "supports_tools_with_streaming" true c.supports_tools_with_streaming;
+  check bool "supports_response_format" true c.supports_response_format
+
+let test_zai_glm_constraints () =
+  let c = constraints_of_flavor Zai_glm in
+  check bool "supports_tools_with_streaming" true c.supports_tools_with_streaming
+
+let test_qwen_tools_stream_incompatible () =
+  let c = constraints_of_flavor Qwen in
+  check bool "Qwen does NOT support tools with streaming"
+    false c.supports_tools_with_streaming;
+  check bool "Qwen does NOT support response_format"
+    false c.supports_response_format
+
+let test_vllm_constraints () =
+  let c = constraints_of_flavor Vllm in
+  check bool "supports_tools_with_streaming" true c.supports_tools_with_streaming
+
+(* --- can_stream_with_tools --- *)
+
+let test_can_stream_with_tools_qwen () =
+  check bool "Qwen cannot stream with tools" false (can_stream_with_tools Qwen)
+
+let test_can_stream_with_tools_openai () =
+  check bool "OpenAI can stream with tools" true (can_stream_with_tools Openai)
+
+let test_can_stream_with_tools_llama_cpp () =
+  check bool "llama.cpp can stream with tools" true (can_stream_with_tools Llama_cpp)
+
+let test_can_stream_with_tools_ollama () =
+  check bool "Ollama can stream with tools" true (can_stream_with_tools Ollama)
+
+(* --- Thinking control --- *)
+
+let test_thinking_llama_cpp () =
+  let tc = thinking_control_for_flavor Llama_cpp true (Some 4096) in
+  check bool "is Llama_cpp_thinking"
+    true
+    (match tc with Llama_cpp_thinking { enable = true; budget = Some 4096 } -> true | _ -> false)
+
+let test_thinking_llama_cpp_no_budget () =
+  let tc = thinking_control_for_flavor Llama_cpp true None in
+  check bool "is Llama_cpp_thinking no budget"
+    true
+    (match tc with Llama_cpp_thinking { enable = true; budget = None } -> true | _ -> false)
+
+let test_thinking_deep_seek_enabled () =
+  let tc = thinking_control_for_flavor Deep_seek true None in
+  check bool "is Deep_seek_thinking enabled"
+    true
+    (match tc with Deep_seek_thinking { enabled = true } -> true | _ -> false)
+
+let test_thinking_deep_seek_disabled () =
+  let tc = thinking_control_for_flavor Deep_seek false None in
+  check bool "is Deep_seek_thinking disabled"
+    true
+    (match tc with Deep_seek_thinking { enabled = false } -> true | _ -> false)
+
+let test_thinking_openai_reasoning_effort () =
+  let tc = thinking_control_for_flavor Openai true (Some 8192) in
+  check bool "is Openai_reasoning_effort"
+    true
+    (match tc with Openai_reasoning_effort _ -> true | _ -> false)
+
+let test_thinking_ollama () =
+  let tc = thinking_control_for_flavor Ollama true None in
+  check bool "is Ollama_think"
+    true
+    (match tc with Ollama_think { think = true } -> true | _ -> false)
+
+let test_thinking_qwen_no_thinking () =
+  let tc = thinking_control_for_flavor Qwen true None in
+  check bool "Qwen has No_thinking" true (tc = No_thinking)
+
+let test_thinking_zai_glm_no_thinking () =
+  let tc = thinking_control_for_flavor Zai_glm true None in
+  check bool "Zai_glm has No_thinking" true (tc = No_thinking)
+
+let test_thinking_disabled () =
+  let tc = thinking_control_for_flavor Llama_cpp false None in
+  check bool "disabled is Llama_cpp_thinking{enable=false}"
+    true
+    (match tc with Llama_cpp_thinking { enable = false; budget = None } -> true | _ -> false)
+
+(* --- Finish reason mapping --- *)
+
+let test_finish_stop () =
+  let fr = finish_reason_of_string Openai (Some "stop") in
+  check bool "stop → Stop" true (fr = Stop)
+
+let test_finish_length () =
+  let fr = finish_reason_of_string Openai (Some "length") in
+  check bool "length → Length" true (fr = Length)
+
+let test_finish_tool_calls () =
+  let fr = finish_reason_of_string Openai (Some "tool_calls") in
+  check bool "tool_calls → Tool_calls" true (fr = Tool_calls)
+
+let test_finish_content_filter () =
+  let fr = finish_reason_of_string Deep_seek (Some "content_filter") in
+  check bool "content_filter → Content_filter" true (fr = Content_filter)
+
+let test_finish_none_qwen () =
+  let fr = finish_reason_of_string Qwen None in
+  check bool "Qwen None → Stop" true (fr = Stop)
+
+let test_finish_unknown () =
+  let fr = finish_reason_of_string Openai (Some "weird_reason") in
+  check bool "unknown → Error" true (fr = Error)
+
+(* --- Suite --- *)
+
+let () =
+  run "Cascade Server Flavor"
+    [ ( "constraints"
+      , [ test_case "llama_cpp" `Quick test_llama_cpp_constraints
+        ; test_case "ollama" `Quick test_ollama_constraints
+        ; test_case "openai" `Quick test_openai_constraints
+        ; test_case "deep_seek" `Quick test_deep_seek_constraints
+        ; test_case "zai_glm" `Quick test_zai_glm_constraints
+        ; test_case "qwen tools+stream incompatible" `Quick test_qwen_tools_stream_incompatible
+        ; test_case "vllm" `Quick test_vllm_constraints
+        ] )
+    ; ( "can_stream_with_tools"
+      , [ test_case "qwen false" `Quick test_can_stream_with_tools_qwen
+        ; test_case "openai true" `Quick test_can_stream_with_tools_openai
+        ; test_case "llama_cpp true" `Quick test_can_stream_with_tools_llama_cpp
+        ; test_case "ollama true" `Quick test_can_stream_with_tools_ollama
+        ] )
+    ; ( "thinking_control"
+      , [ test_case "llama_cpp with budget" `Quick test_thinking_llama_cpp
+        ; test_case "llama_cpp no budget" `Quick test_thinking_llama_cpp_no_budget
+        ; test_case "deep_seek enabled" `Quick test_thinking_deep_seek_enabled
+        ; test_case "deep_seek disabled" `Quick test_thinking_deep_seek_disabled
+        ; test_case "openai reasoning_effort" `Quick test_thinking_openai_reasoning_effort
+        ; test_case "ollama think" `Quick test_thinking_ollama
+        ; test_case "qwen no thinking" `Quick test_thinking_qwen_no_thinking
+        ; test_case "zai_glm no thinking" `Quick test_thinking_zai_glm_no_thinking
+        ; test_case "disabled" `Quick test_thinking_disabled
+        ] )
+    ; ( "finish_reason"
+      , [ test_case "stop" `Quick test_finish_stop
+        ; test_case "length" `Quick test_finish_length
+        ; test_case "tool_calls" `Quick test_finish_tool_calls
+        ; test_case "content_filter" `Quick test_finish_content_filter
+        ; test_case "qwen None" `Quick test_finish_none_qwen
+        ; test_case "unknown" `Quick test_finish_unknown
+        ] )
+    ]


### PR DESCRIPTION
## Summary

RFC Cascade Phonebook/Switchboard separation — TOML = "Phonebook" (what exists), OAS = "Switchboard" (who to use).

**New modules (6 pairs .ml/.mli)**:
- `cascade_phonebook_types`: TOML-agnostic types (providers, models, tier-groups, diversity constraints, thinking control formats)
- `cascade_phonebook_parser`: Otoml-based parser with validation error collection
- `cascade_routing_policy`: `task_use` (6 categories) → tier-group resolution with diversity constraints + legacy `logical_use` mapping
- `cascade_server_flavor`: per-provider constraints (tools+stream compat, response_format, finish_reason), thinking control — shares type with phonebook_types via type equality

**Config loader integration**:
- `cascade_config_loader`: phonebook cache with mtime-based hot-reload, shared mutex with legacy JSON pipeline
- `cascade_config`: facade re-exports (`load_phonebook`, `load_phonebook_from_config`)

**79 tests across 4 suites**:
- Phonebook parser: 24 tests (unit + real TOML fixture)
- Routing policy: 19 tests (task_use roundtrip, legacy mapping, diversity)
- Server flavor: 26 tests (constraints, thinking control, finish_reason)
- Integration: 10 tests (end-to-end TOML→parse→route→model→flavor)

## Architecture

```
TOML (Phonebook) → cascade_phonebook_parser → cascade_routing_policy → [model list]
                  → cascade_phonebook_types → cascade_server_flavor → [constraints/thinking]
                  → cascade_config_loader (mtime cache, hot-reload)
```

## Test plan
- [x] `dune exec test/test_cascade_phonebook.exe` — 24/24 pass
- [x] `dune exec test/test_cascade_routing_policy.exe` — 19/19 pass
- [x] `dune exec test/test_cascade_server_flavor.exe` — 26/26 pass
- [x] `dune exec test/test_cascade_phonebook_integration.exe` — 10/10 pass
- [ ] Full `dune build @runtest` (requires CI sandbox)

## Out of scope (future PRs)
- Phase 4: Transport ↔ Flavor direct integration
- Phase 5: Dashboard TypeScript type changes
- Phase 7: Legacy `cascade_routes.ml` replacement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>