### PR TITLE
refactor(auth): make MCP server client-agnostic (RFC-0165)

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -546,6 +546,27 @@ let login_shell =
   let doc = "Emit shell export commands only" in
   Arg.(value & flag & info ["shell"] ~doc)
 
+let login_client_env =
+  let doc =
+    "Env var name your MCP client reads to pick up the minted bearer \
+     token. Required; the server holds no list of \"known\" MCP \
+     clients. Examples: MASC_MCP_TOKEN (generic default convention), \
+     MASC_CLAUDE_MCP_TOKEN, MASC_GEMINI_MCP_TOKEN. The value is \
+     rendered verbatim into the shell exports and JSON output."
+  in
+  Arg.(
+    required
+    & opt (some string) None
+    & info ["client-env"] ~docv:"VAR" ~doc)
+
+let login_no_expiry =
+  let doc =
+    "Mint a long-lived token without an [expires_at] field. \
+     Appropriate for long-running local MCP daemons that cannot \
+     easily refresh on expiry. Omit for the default expiring policy."
+  in
+  Arg.(value & flag & info ["no-expiry"] ~doc)
+
 (** Graceful shutdown exception *)
 (* Shutdown exception removed: graceful shutdown returns normally from
    await_shutdown_signal, letting Eio.Fiber.first cancel run_server. *)
@@ -1564,9 +1585,14 @@ let doctor_cmd =
     ; doctor_all_cmd
     ]
 
-let login_cmd_exit base_path host port agent role as_json as_shell =
+let login_cmd_exit base_path host port agent role client_env no_expiry
+    as_json as_shell =
+  let token_lifetime : Auth_login.token_lifetime =
+    if no_expiry then Long_lived else With_expiry
+  in
   match
-    Auth_login.mint ~base_path ~host ~port ~agent_name:agent ~role ()
+    Auth_login.mint ~base_path ~host ~port ~agent_name:agent ~role
+      ~token_env_var:client_env ~token_lifetime ()
   with
   | Error err ->
       Printf.eprintf "login failed: %s\n" (Masc_domain.masc_error_to_string err);
@@ -1586,13 +1612,16 @@ let login_cmd_exit base_path host port agent role as_json as_shell =
 let login_cmd =
   let doc =
     "Mint a local bearer token, persist its raw token file, and print \
-     dashboard/Codex MCP auth exports"
+     dashboard / MCP auth exports. Requires --client-env <VAR> to \
+     name the env var your MCP client reads; the server itself is \
+     client-agnostic."
   in
   let info = Cmd.info "login" ~doc in
   Cmd.v info
     Term.(
       const login_cmd_exit $ base_path $ host $ port $ login_agent
-      $ login_role $ doctor_json $ login_shell)
+      $ login_role $ login_client_env $ login_no_expiry $ doctor_json
+      $ login_shell)
 
 let init_force =
   let doc = "Overwrite existing config files instead of skipping them" in

--- a/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
+++ b/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
@@ -177,8 +177,17 @@ sub-sections.
 
 ## 5. Claude / Gemini MCP Bearers
 
-Claude and Gemini must not reuse the Codex bearer. Mint each local MCP client
-as its own worker identity, then sync the shared client config:
+> **MASC is MCP-client-agnostic.** The server holds no list of "known" clients
+> and does not derive env-var names from `--agent`. The operator names the env
+> var with `--client-env <VAR>` and chooses the lifetime with `--no-expiry`.
+> The conventions below are recommendations for the local wrapper script
+> (`~/me/scripts/mcp-sync.sh`), not server policy.
+
+Each local MCP client must mint its own worker identity so its bearer is
+distinct from the Codex bearer. Pick a per-client env var name (e.g.
+`MASC_CLAUDE_MCP_TOKEN`, `MASC_GEMINI_MCP_TOKEN`) and pass it in via
+`--client-env`. Long-running local MCP daemons typically want `--no-expiry` so
+their bearer survives across daemon restarts.
 
 ```bash
 BASE_PATH="${MASC_BASE_PATH:-/path/to/base}"
@@ -187,30 +196,36 @@ BASE_PATH="${MASC_BASE_PATH:-/path/to/base}"
   --base-path "$BASE_PATH" \
   --agent claude \
   --role worker \
+  --client-env MASC_CLAUDE_MCP_TOKEN \
+  --no-expiry \
   --shell
 
 ./_build/default/bin/main_eio.exe login \
   --base-path "$BASE_PATH" \
   --agent gemini \
   --role worker \
+  --client-env MASC_GEMINI_MCP_TOKEN \
+  --no-expiry \
   --shell
 
 ~/me/scripts/mcp-sync.sh
 ```
 
-Local startup also self-heals private non-expiring token files for `claude` and
-`gemini`. Manual `login` is for first-time setup or explicit rotation; after
-that, `~/me/scripts/mcp-sync.sh` can project those token files into client
-config.
+Manual `login` is for first-time setup or explicit rotation; after that,
+`~/me/scripts/mcp-sync.sh` projects the token files into client config.
 
-**Gemini and Claude configs should also use `bearer_token_env_var` (not a
+**Gemini and Claude configs should use `bearer_token_env_var` (not a
 hardcoded `Authorization` header).** The `mcp-sync.sh` pattern should export
 `MASC_CLAUDE_MCP_TOKEN` and `MASC_GEMINI_MCP_TOKEN` from the respective token
 files rather than embedding literal tokens in the config.
 
-`doctor auth --json` exposes `.mcp_clients[]`; `claude` should use
-`MASC_CLAUDE_MCP_TOKEN` / `X-MASC-Agent: claude`, and `gemini` should use
-`MASC_GEMINI_MCP_TOKEN` / `X-MASC-Agent: gemini`.
+Recommended local convention (enforced by the operator's wrapper, not the
+server): `claude` should use `MASC_CLAUDE_MCP_TOKEN` / `X-MASC-Agent: claude`,
+and `gemini` should use `MASC_GEMINI_MCP_TOKEN` / `X-MASC-Agent: gemini`.
+
+`doctor auth --json` no longer exposes a `.mcp_clients[]` section; compose
+per-client readiness checks externally over the raw doctor output and your
+own client roster.
 
 ## 6. Supported Local Start
 

--- a/docs/rfc/RFC-0165-mcp-server-client-agnostic.md
+++ b/docs/rfc/RFC-0165-mcp-server-client-agnostic.md
@@ -1,0 +1,100 @@
+# RFC-0165 MCP server is client-agnostic
+
+| | |
+|---|---|
+| Status | Draft |
+| Related | RFC-0042 closed-sum noted, RFC-0058 Phase 5.7 (different shape — Generalize vs Remove), RFC-0088 Counter-as-Fix umbrella, RFC-0149 Telemetry-as-fix sunset |
+| Scope | `lib/auth_login.ml{,.mli}`, `lib/auth_doctor.ml{,.mli}`, `bin/main_eio.ml` (login CLI), tests, runbook |
+| Repos | masc-mcp |
+
+## 1. Problem
+
+`lib/auth_login.ml` and `lib/auth_doctor.ml` carried hardcoded knowledge of two MCP clients (Claude and Gemini) in two SSOTs:
+
+1. **`auth_login.ml:23-30`** — `mcp_token_env_var_for_agent` dispatched on agent_name string to pick a per-client env var name (`MASC_CLAUDE_MCP_TOKEN`, `MASC_GEMINI_MCP_TOKEN`); `is_local_mcp_client_agent` matched on the same names to switch to a no-expiry credential.
+2. **`auth_doctor.ml:78-90`** — `mcp_client_specs` list embedded the same two clients as a static spec, producing a per-client diagnostic in the JSON / text doctor output.
+
+MASC is an MCP **server**. A server has no reason to know which clients connect to it. The coupling matches workaround-rejection signature §2 ("string-classifier addition", `software-development.md`): a closed-sum domain (the set of MCP clients) was encoded as string-match arms, so adding a new client would require touching server code in two places.
+
+Live measurement (2026-05-24) of the env var reads showed the runtime cost is *zero* — `MASC_CLAUDE_MCP_TOKEN` and `MASC_GEMINI_MCP_TOKEN` are read **only by the external MCP clients** (Claude Code, Gemini CLI). The server itself emits these names but never looks them up. The "table" was pure surface convention disguised as policy.
+
+## 2. Decision
+
+The server holds no list of "known" MCP clients. The caller (CLI or API consumer) supplies:
+
+- The env var name (`--client-env <VAR>`, required, no default).
+- The token-lifetime policy (`--no-expiry` flag, default `With_expiry`).
+
+The per-client doctor diagnostic is removed. Operators who need per-client readiness checks compose them externally over the raw `doctor auth --json` output and their own client roster.
+
+## 3. Why "Remove" rather than "Generalize via TOML"
+
+RFC-0058 Phase 5.7 (Draft) proposed generalizing similar single-product knowledge in `auth_doctor.ml` by reading client specs from `[providers.<id>.mcp_client_config]` TOML stanzas. That is a valid alternative shape.
+
+We chose **Remove** instead of **Generalize** because:
+
+1. The server emits — but does not read — these env names. There is no protocol invariant or auth boundary that justifies the server enforcing the client roster.
+2. The diagnostic's value is observable from the raw doctor output (`watched_agents`, `admin_bearer_sources`); a downstream wrapper script can synthesize the per-client view without server cooperation.
+3. Adding a TOML loader to read client specs keeps the coupling: any new client still requires *something* in the masc-mcp codebase (a stanza, a default file). Removing the diagnostic moves the boundary cleanly to the operator's wrapper.
+
+## 4. Non-Goals
+
+- Generalizing dispatch in other doctor modules (`codex_mcp_config_doctor.ml`, `server_runtime_bootstrap.ml`). RFC-0058 Phase 5.7 still governs those.
+- Adding a new TOML-driven client roster.
+- Sunset of `Auth.create_token_without_expiry`: it remains the implementation of the `Long_lived` lifetime, called from `Auth_login.mint` when `--no-expiry` is set.
+
+## 5. Changes
+
+### `lib/auth_login.ml{,.mli}`
+- Delete `default_mcp_token_env_var`, `mcp_token_env_var_for_agent`, `is_local_mcp_client_agent`.
+- Add closed-sum type `token_lifetime = With_expiry | Long_lived`.
+- `mint` gains required named args `~token_env_var:string` and `~token_lifetime:token_lifetime`.
+- `mcp_token_env_var` record field now stores the caller-supplied string verbatim.
+
+### `bin/main_eio.ml` (login subcommand)
+- New `--client-env VAR` flag, **required, no default**. Omitting it fails with a Cmdliner usage error.
+- New `--no-expiry` flag, default false.
+- `Auth_login.mint` call threads both values through.
+
+### `lib/auth_doctor.ml{,.mli}`
+- Delete `mcp_client_spec`, `mcp_client_specs`, `mcp_client_report`, `mcp_client_warning`, `mcp_client_next_action`, `mcp_client_to_yojson`, the public `mcp_client` type, and the `t.mcp_clients` field.
+- Remove the `mcp_clients:` text section and the JSON `mcp_clients` key.
+
+### Tests
+- `test/test_auth_login.ml`: renamed both cases. Case 1 verifies caller-supplied env var passthrough for `With_expiry`. Case 2 verifies passthrough + `expires_at = None` for `Long_lived` using an arbitrary `CUSTOM_MCP_TOKEN` name and a non-claude/gemini agent.
+- `test/test_auth_doctor.ml`: removed `test_reports_claude_and_gemini_mcp_client_identities` and the `find_mcp_client` helper. Added a regression test that the JSON output omits `"mcp_clients"` and the text output omits `mcp_clients:`.
+
+### Docs
+- `docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md` §5 rewritten: examples include `--client-env` and `--no-expiry`; conventions are explicitly framed as operator-side recommendations, not server policy. The factually wrong "Local startup also self-heals private non-expiring token files for `claude` and `gemini`" sentence is removed (no such code path exists; the unrelated keeper credential self-heal in `auth.ml:881` does not seed MCP-client tokens).
+
+## 6. Breaking changes
+
+**CLI**: `masc-mcp login --agent claude --role worker --shell` (without `--client-env`) now exits non-zero with a usage error. Callers must add `--client-env <VAR>`. Long-running local MCP daemons should also add `--no-expiry` to preserve prior behavior.
+
+**JSON API**: `doctor auth --json` no longer emits a `mcp_clients` field. Dashboard does not consume this field (verified by `rg 'mcp_clients' dashboard/` — 0 hits); `keeper_oas_checkpoint.ml:60`'s `mcp_clients` is an unrelated `Agent_sdk.Agent.options` field.
+
+**Text output**: `doctor auth` text rendering loses the `mcp_clients:` section.
+
+## 7. Workaround-rejection self-check (`software-development.md` §워크어라운드 거부 기준)
+
+This PR *removes* a string-classifier; it does not add one. Self-check against the 7 rejection items:
+
+1. "makes X visible" without fixing — NO (deletes a diagnostic, no telemetry added).
+2. String/substring/prefix classifier added — NO (deletes two of them).
+3. "PR #N fixed K of M sites" — NO (single PR closes both SSOTs).
+4. catch-all `_ ->` added — NO (closed-sum `token_lifetime` replaces the implicit fall-through).
+5. cap / cooldown / dedup / repair without alternate RFC — NO.
+6. test backdoor — NO.
+7. typo / off-by-one repeated across N sites — NO.
+
+## 8. Migration
+
+`~/me/scripts/mcp-sync.sh` should be updated (separate PR) to pass `--client-env MASC_CLAUDE_MCP_TOKEN --no-expiry` for Claude and `--client-env MASC_GEMINI_MCP_TOKEN --no-expiry` for Gemini. Until that PR lands, operators run those flags manually.
+
+## 9. Verification
+
+- `rg -i 'claude|gemini' lib/auth_login.ml lib/auth_doctor.ml` returns 0 hits.
+- `dune build` clean.
+- `dune exec test/test_auth_login.exe` PASS for both cases.
+- `dune exec test/test_auth_doctor.exe` PASS for all three cases (including new "json omits mcp_clients" regression test).
+- CLI smoke: `login --agent X --role worker --client-env CUSTOM_VAR --shell` emits `export CUSTOM_VAR=...`; without `--client-env` the CLI fails fast with a usage error.

--- a/lib/auth_doctor.ml
+++ b/lib/auth_doctor.ml
@@ -14,22 +14,6 @@ type watched_agent = {
   raw_token_file_present : bool;
 }
 
-type mcp_client = {
-  client_name : string;
-  agent_name : string;
-  token_env_var : string;
-  token_file_path : string;
-  credential_present : bool;
-  credential_role : string option;
-  raw_token_file_present : bool;
-  token_source : string;
-  token_status : string;
-  token_agent : string option;
-  token_role : string option;
-  token_can_read_state : bool option;
-  identity_ready : bool;
-}
-
 type t = {
   status : status;
   base_path : string;
@@ -53,7 +37,6 @@ type t = {
   credential_count : int;
   role_counts : (string * int) list;
   watched_agents : watched_agent list;
-  mcp_clients : mcp_client list;
   warnings : string list;
   next_actions : string list;
 }
@@ -68,26 +51,6 @@ let status_to_string = function
   | Ok -> "ok"
   | Warn -> "warn"
   | Error -> "error"
-
-type mcp_client_spec = {
-  client_name : string;
-  agent_name : string;
-  token_env_var : string;
-}
-
-let mcp_client_specs =
-  [
-    {
-      client_name = "claude";
-      agent_name = "claude";
-      token_env_var = "MASC_CLAUDE_MCP_TOKEN";
-    };
-    {
-      client_name = "gemini";
-      agent_name = "gemini";
-      token_env_var = "MASC_GEMINI_MCP_TOKEN";
-    };
-  ]
 
 let canonicalize_path path =
   try Unix.realpath path with
@@ -229,81 +192,6 @@ let admin_bearer_sources ~base_path ~auth_dir ~dashboard_dev_token_available
   env_sources @ dashboard_sources @ token_file_sources
   |> dedupe_keep_order
 
-let mcp_client_report ~base_path ~auth_dir
-    ({ client_name; agent_name; token_env_var } : mcp_client_spec) =
-  let token_file_path = raw_token_file_path ~auth_dir agent_name in
-  let credential_opt = Auth.load_credential base_path agent_name in
-  let raw_token_file_present = file_exists token_file_path in
-  let token_source, raw_token =
-    match Sys.getenv_opt token_env_var |> Env_config_core.trim_opt with
-    | Some value -> ("env", Some value)
-    | None -> (
-        match read_nonempty_text_file token_file_path with
-        | Some value -> ("token_file", Some value)
-        | None -> ("missing", None))
-  in
-  let token_status, token_agent, token_role, token_can_read_state =
-    match raw_token with
-    | None -> ("missing", None, None, None)
-    | Some token -> (
-        match Auth.find_credential_by_token base_path ~token with
-        | Ok cred ->
-            let status =
-              if String.equal cred.agent_name agent_name then
-                "live"
-              else
-                "wrong_agent"
-            in
-            ( status,
-              Some cred.agent_name,
-              Some (agent_role_to_string cred.role),
-              Some (has_permission cred.role CanReadState) )
-        | Error _ -> ("invalid_or_expired", None, None, None))
-  in
-  let identity_ready =
-    Option.is_some credential_opt && String.equal token_status "live"
-  in
-  {
-    client_name;
-    agent_name;
-    token_env_var;
-    token_file_path;
-    credential_present = Option.is_some credential_opt;
-    credential_role = Option.map (fun (cred : agent_credential) -> agent_role_to_string cred.role) credential_opt;
-    raw_token_file_present;
-    token_source;
-    token_status;
-    token_agent;
-    token_role;
-    token_can_read_state;
-    identity_ready;
-  }
-
-let mcp_client_warning (client : mcp_client) =
-  match client.token_status with
-  | "wrong_agent" ->
-      Some
-        (Printf.sprintf
-           "%s MCP bearer resolves to %s instead of %s; rerun `masc-mcp login --agent %s --role worker --shell` and `sb mcp sync`."
-           client.client_name
-           (Option.value ~default:"(unknown)" client.token_agent)
-           client.agent_name client.agent_name)
-  | "invalid_or_expired" ->
-      Some
-        (Printf.sprintf
-           "%s MCP bearer from %s is invalid or expired; rerun `masc-mcp login --agent %s --role worker --shell` and `sb mcp sync`."
-           client.client_name client.token_source client.agent_name)
-  | _ -> None
-
-let mcp_client_next_action (client : mcp_client) =
-  if client.identity_ready then
-    None
-  else
-    Some
-      (Printf.sprintf
-         "For %s MCP, run `masc-mcp login --agent %s --role worker --shell`, then `sb mcp sync` so its bearer and X-MASC-Agent match."
-         client.client_name client.agent_name)
-
 let analyze ~base_path_input ~default_base_path () =
   let normalized_base_path =
     Env_config_core.normalize_masc_base_path_input base_path_input
@@ -337,9 +225,6 @@ let analyze ~base_path_input ~default_base_path () =
   let admin_bearer_sources =
     admin_bearer_sources ~base_path ~auth_dir
       ~dashboard_dev_token_available ~admin_token_env_state credentials
-  in
-  let mcp_clients =
-    List.map (mcp_client_report ~base_path ~auth_dir) mcp_client_specs
   in
   let token_bound_admin_http_ready =
     auth_cfg.enabled && auth_cfg.require_token && admin_bearer_sources <> []
@@ -391,8 +276,6 @@ let analyze ~base_path_input ~default_base_path () =
          None);
     ]
     |> List.filter_map Fun.id
-    |> (fun values ->
-         values @ List.filter_map mcp_client_warning mcp_clients)
     |> dedupe_keep_order
   in
   let next_actions =
@@ -426,8 +309,6 @@ let analyze ~base_path_input ~default_base_path () =
       Some "Rerun `masc-mcp doctor auth` after editing auth files or rotating tokens.";
     ]
     |> List.filter_map Fun.id
-    |> (fun values ->
-         values @ List.filter_map mcp_client_next_action mcp_clients)
     |> dedupe_keep_order
   in
   let status =
@@ -462,7 +343,6 @@ let analyze ~base_path_input ~default_base_path () =
     credential_count = List.length credentials;
     role_counts = role_counts_of_credentials credentials;
     watched_agents;
-    mcp_clients;
     warnings;
     next_actions;
   }
@@ -479,27 +359,6 @@ let watched_agent_to_yojson (agent : watched_agent) =
         | None -> `Null );
       (option_field "expires_at" agent.expires_at);
       ("raw_token_file_present", `Bool agent.raw_token_file_present);
-    ]
-
-let mcp_client_to_yojson (client : mcp_client) =
-  `Assoc
-    [
-      ("client_name", `String client.client_name);
-      ("agent_name", `String client.agent_name);
-      ("token_env_var", `String client.token_env_var);
-      ("token_file_path", `String client.token_file_path);
-      ("credential_present", `Bool client.credential_present);
-      (option_field "credential_role" client.credential_role);
-      ("raw_token_file_present", `Bool client.raw_token_file_present);
-      ("token_source", `String client.token_source);
-      ("token_status", `String client.token_status);
-      (option_field "token_agent" client.token_agent);
-      (option_field "token_role" client.token_role);
-      ( "token_can_read_state",
-        match client.token_can_read_state with
-        | Some value -> `Bool value
-        | None -> `Null );
-      ("identity_ready", `Bool client.identity_ready);
     ]
 
 let to_yojson (report : t) =
@@ -541,8 +400,6 @@ let to_yojson (report : t) =
              report.role_counts) );
       ( "watched_agents",
         `List (List.map watched_agent_to_yojson report.watched_agents) );
-      ( "mcp_clients",
-        `List (List.map mcp_client_to_yojson report.mcp_clients) );
       ("warnings", `List (List.map (fun value -> `String value) report.warnings));
       ("next_actions", `List (List.map (fun value -> `String value) report.next_actions));
     ]
@@ -619,20 +476,6 @@ let render_text (report : t) =
            (yes_no agent.raw_token_file_present)
            (option_value agent.expires_at)))
     report.watched_agents;
-  add_line "";
-  add_line "mcp_clients:";
-  List.iter
-    (fun (client : mcp_client) ->
-      add_line
-        (Printf.sprintf
-           "- %s: agent=%s env=%s token_file=%s credential=%s token_source=%s token_status=%s token_agent=%s identity_ready=%s"
-           client.client_name client.agent_name client.token_env_var
-           client.token_file_path
-           (yes_no client.credential_present)
-           client.token_source client.token_status
-           (option_value client.token_agent)
-           (yes_no client.identity_ready)))
-    report.mcp_clients;
   if report.warnings <> [] then begin
     add_line "";
     add_line "warnings:";

--- a/lib/auth_doctor.mli
+++ b/lib/auth_doctor.mli
@@ -43,25 +43,13 @@ type watched_agent = {
 (** Per-agent credential snapshot.  Aggregated under
     {!t.watched_agents}. *)
 
-type mcp_client = {
-  client_name : string;
-  agent_name : string;
-  token_env_var : string;
-  token_file_path : string;
-  credential_present : bool;
-  credential_role : string option;
-  raw_token_file_present : bool;
-  token_source : string;
-  token_status : string;
-  token_agent : string option;
-  token_role : string option;
-  token_can_read_state : bool option;
-  identity_ready : bool;
-}
-(** Per-client MCP identity readiness for local Codex/Claude/Gemini
-    bearer-token wiring.  [token_source] is ["env"], ["token_file"],
-    or ["missing"]; [token_status] is ["live"], ["wrong_agent"],
-    ["invalid_or_expired"], or ["missing"]. *)
+(** Per-client MCP identity readiness was previously exposed here as
+    [type mcp_client] alongside a hardcoded list of "known" MCP
+    clients (Claude, Gemini). That list lived inside server code and
+    made the server client-aware — the wrong direction for an MCP
+    server. The diagnostic is removed; operators who need per-client
+    readiness checks compose them externally over the raw
+    [doctor auth --json] output and their own client roster. *)
 
 (** {1 Aggregate report} *)
 
@@ -88,7 +76,6 @@ type t = {
   credential_count : int;
   role_counts : (string * int) list;
   watched_agents : watched_agent list;
-  mcp_clients : mcp_client list;
   warnings : string list;
   next_actions : string list;
 }
@@ -114,7 +101,6 @@ val analyze :
     + Admin-token env-var status + admin-bearer source
       enumeration ([admin_bearer_sources]).
     + Codex MCP config via {!Codex_mcp_config_doctor}.
-    + Local MCP client identities for Codex, Claude, and Gemini.
 
     Side-effecting (file reads); pure with respect to the
     process registry — does not mutate auth state. *)

--- a/lib/auth_login.ml
+++ b/lib/auth_login.ml
@@ -5,6 +5,10 @@ type auth_change =
   | Auth_enabled
   | Require_token_enabled
 
+type token_lifetime =
+  | With_expiry
+  | Long_lived
+
 type t = {
   base_path : string;
   auth_config_path : string;
@@ -17,17 +21,6 @@ type t = {
   mcp_url : string;
   mcp_token_env_var : string;
 }
-
-let default_mcp_token_env_var = "MASC_MCP_TOKEN"
-
-let mcp_token_env_var_for_agent = function
-  | "claude" -> "MASC_CLAUDE_MCP_TOKEN"
-  | "gemini" -> "MASC_GEMINI_MCP_TOKEN"
-  | _ -> default_mcp_token_env_var
-
-let is_local_mcp_client_agent = function
-  | "claude" | "gemini" -> true
-  | _ -> false
 
 let rng_initialized = Atomic.make false
 
@@ -81,18 +74,18 @@ let ensure_required_bearer_auth ~base_path ~agent_name =
     Auth.save_auth_config base_path { cfg with require_token = true };
     Ok Require_token_enabled)
 
-let mint ~base_path ~host ~port ~agent_name ~role () =
+let create_token_for_lifetime = function
+  | With_expiry -> Auth.create_token
+  | Long_lived -> Auth.create_token_without_expiry
+
+let mint ~base_path ~host ~port ~agent_name ~role ~token_env_var
+    ~token_lifetime () =
   ensure_rng_initialized ();
   let base_path = normalize_base_path base_path in
   match ensure_required_bearer_auth ~base_path ~agent_name with
   | Error err -> Error err
   | Ok auth_change -> (
-      let create_token =
-        if is_local_mcp_client_agent agent_name then
-          Auth.create_token_without_expiry
-        else
-          Auth.create_token
-      in
+      let create_token = create_token_for_lifetime token_lifetime in
       match create_token base_path ~agent_name ~role with
       | Error err -> Error err
       | Ok (bearer_token, cred) ->
@@ -117,7 +110,7 @@ let mint ~base_path ~host ~port ~agent_name ~role () =
               raw_token_file;
               dashboard_url;
               mcp_url;
-              mcp_token_env_var = mcp_token_env_var_for_agent cred.agent_name;
+              mcp_token_env_var = token_env_var;
             })
 
 let to_yojson report =

--- a/lib/auth_login.mli
+++ b/lib/auth_login.mli
@@ -5,7 +5,8 @@
     1. Initialises the Mirage RNG idempotently.
     2. Ensures the auth config has bearer auth required (creating
        it when absent, flipping [require_token] when not yet on).
-    3. Mints a bearer token via {!Auth.create_token}.
+    3. Mints a bearer token via {!Auth.create_token} (or the
+       no-expiry variant when [~token_lifetime] is [`Long_lived]).
     4. Persists the raw token to a per-agent file under
        [<base_path>/.masc/auth/<agent_name>.token].
     5. Renders dashboard / MCP URLs using URL-encoded query params.
@@ -16,7 +17,14 @@
     All internal helpers (URL encoding, shell quoting, RNG init,
     config-flip, token persistence) stay private — the four entry
     points cover every documented [masc-mcp login] consumer (CLI,
-    JSON API, shell-export). *)
+    JSON API, shell-export).
+
+    The server is client-agnostic: the caller (CLI / API consumer)
+    supplies the env var name ([~token_env_var]) and the
+    token-lifetime policy ([~token_lifetime]). This module holds
+    no list of "known" MCP clients (Claude, Gemini, etc.) — those
+    conventions live in the operator's wrapper scripts and the
+    runbook, not in server code. *)
 
 (** {1 Auth configuration change taxonomy} *)
 
@@ -28,6 +36,19 @@ type auth_change =
   | Require_token_enabled
         (** Bearer auth was enabled but [require_token] was off;
             this call flipped it on. *)
+
+(** {1 Token lifetime policy} *)
+
+type token_lifetime =
+  | With_expiry
+        (** Token uses the default expiry window from the auth
+            config (see {!Auth.create_token}). Appropriate for
+            short-lived operator sessions. *)
+  | Long_lived
+        (** Token has no [expires_at]; appropriate for long-running
+            local MCP daemons that cannot easily refresh on expiry.
+            The decision to use this lifetime is the caller's —
+            this module never infers it from [agent_name]. *)
 
 (** {1 Login report} *)
 
@@ -52,9 +73,10 @@ type t = {
       written to [raw_token_file] (operator-readable, mode 0600).
     - [dashboard_url] always carries [agent] + [token] query params,
       both URL-encoded.
-    - [mcp_token_env_var] is the client-specific bearer env var for
-      known MCP clients ([claude] -> [MASC_CLAUDE_MCP_TOKEN],
-      [gemini] -> [MASC_GEMINI_MCP_TOKEN]). *)
+    - [mcp_token_env_var] is exactly the value the caller passed to
+      {!mint} via [~token_env_var]. The server does not interpret
+      or validate this string — it is rendered verbatim into the
+      [export] statements and JSON output. *)
 
 (** {1 Mint entry point} *)
 
@@ -64,10 +86,21 @@ val mint :
   port:int ->
   agent_name:string ->
   role:Masc_domain.agent_role ->
+  token_env_var:string ->
+  token_lifetime:token_lifetime ->
   unit ->
   (t, Masc_error.t) result
-(** [mint ~base_path ~host ~port ~agent_name ~role ()] runs the full
-    login lifecycle.
+(** [mint ~base_path ~host ~port ~agent_name ~role ~token_env_var
+        ~token_lifetime ()] runs the full login lifecycle.
+
+    {2 Required arguments}
+    - [~token_env_var] is the operator's chosen env var name (e.g.
+      ["MASC_MCP_TOKEN"], ["MASC_CLAUDE_MCP_TOKEN"]). The server
+      does not pick a default — the caller decides. The string is
+      embedded verbatim in shell / JSON / text output.
+    - [~token_lifetime] selects between expiring and long-lived
+      credentials. The server does not infer this from
+      [agent_name] — the caller decides.
 
     {2 Side effects}
     - Initialises Mirage's default RNG on first call (idempotent
@@ -107,7 +140,7 @@ val render_shell : t -> string
 
     - [MASC_OPERATOR_AGENT]
     - [MASC_OPERATOR_TOKEN]
-    - [<mcp_token_env_var>] (client-specific for Claude/Gemini)
+    - [<mcp_token_env_var>] (caller-supplied env var name)
     - [MASC_DASHBOARD_URL]
 
     All values are POSIX-quoted (single-quoted with embedded

--- a/test/test_auth_doctor.ml
+++ b/test/test_auth_doctor.ml
@@ -28,12 +28,6 @@ let with_temp_dir prefix f =
   Unix.mkdir dir 0o755;
   Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
 
-let write_file path content =
-  let oc = open_out path in
-  Fun.protect
-    ~finally:(fun () -> close_out_noerr oc)
-    (fun () -> output_string oc content)
-
 let contains_substring ~needle s =
   let nl = String.length needle in
   let sl = String.length s in
@@ -61,16 +55,6 @@ let save_credential_or_fail base_path ~agent_name ~role ~raw_token =
 
 let raw_token_file base_path agent_name =
   Filename.concat (Auth.auth_dir base_path) (agent_name ^ ".token")
-
-let find_mcp_client report client_name =
-  match
-    List.find_opt
-      (fun (client : Auth_doctor.mcp_client) ->
-        String.equal client.client_name client_name)
-      (report : Auth_doctor.t).mcp_clients
-  with
-  | Some client -> client
-  | None -> failf "missing mcp client report for %s" client_name
 
 let test_errors_when_no_admin_bearer_source_exists () =
   with_temp_dir "auth-doctor-error" @@ fun base_path ->
@@ -143,8 +127,15 @@ let test_ignores_stale_admin_raw_token_file () =
        ~needle:"No usable admin bearer source was detected"
        report.warnings)
 
-let test_reports_claude_and_gemini_mcp_client_identities () =
-  with_temp_dir "auth-doctor-mcp-clients" @@ fun base_path ->
+(* The previous test "reports Claude and Gemini MCP client identities"
+   was removed: the per-client diagnostic that it locked is gone.
+   The server is now MCP-client-agnostic, so it holds no list of
+   "known" clients to diagnose. Operators who need per-client
+   readiness checks compose them externally over the raw
+   doctor-auth JSON. *)
+
+let test_json_no_longer_emits_mcp_clients_field () =
+  with_temp_dir "auth-doctor-no-mcp-clients" @@ fun base_path ->
   let auth_cfg =
     Masc_domain.
       {
@@ -155,44 +146,25 @@ let test_reports_claude_and_gemini_mcp_client_identities () =
       }
   in
   Auth.save_auth_config base_path auth_cfg;
-  save_credential_or_fail base_path ~agent_name:"admin" ~role:Masc_domain.Admin
-    ~raw_token:"admin-token";
+  save_credential_or_fail base_path ~agent_name:"admin"
+    ~role:Masc_domain.Admin ~raw_token:"admin-token";
   Auth.save_private_text_file (raw_token_file base_path "admin")
     "admin-token";
-  save_credential_or_fail base_path ~agent_name:"claude"
-    ~role:Masc_domain.Worker ~raw_token:"claude-token";
-  Auth.save_private_text_file (raw_token_file base_path "claude")
-    "claude-token";
-  save_credential_or_fail base_path ~agent_name:"gemini"
-    ~role:Masc_domain.Worker ~raw_token:"gemini-token";
-  Auth.save_private_text_file (raw_token_file base_path "gemini")
-    "gemini-token";
   with_env "MASC_HOST" "127.0.0.1" @@ fun () ->
   with_env "MASC_HTTP_AUTH_STRICT" "" @@ fun () ->
   with_env "MASC_ADMIN_TOKEN" "" @@ fun () ->
   with_env "MASC_MCP_TOKEN" "" @@ fun () ->
-  with_env "MASC_CLAUDE_MCP_TOKEN" "" @@ fun () ->
-  with_env "MASC_GEMINI_MCP_TOKEN" "" @@ fun () ->
   let report =
     Auth_doctor.analyze ~base_path_input:base_path
       ~default_base_path:base_path ()
   in
-  let claude = find_mcp_client report "claude" in
-  check string "claude agent" "claude" claude.agent_name;
-  check string "claude env" "MASC_CLAUDE_MCP_TOKEN"
-    claude.token_env_var;
-  check string "claude token source" "token_file" claude.token_source;
-  check string "claude token status" "live" claude.token_status;
-  check bool "claude identity ready" true claude.identity_ready;
-  let gemini = find_mcp_client report "gemini" in
-  check string "gemini env" "MASC_GEMINI_MCP_TOKEN"
-    gemini.token_env_var;
-  check bool "gemini identity ready" true gemini.identity_ready;
-  check bool "json exposes mcp clients" true
-    (contains_substring ~needle:"\"mcp_clients\""
-       (Auth_doctor.to_yojson report |> Yojson.Safe.to_string));
-  check bool "text names claude env" true
-    (contains_substring ~needle:"MASC_CLAUDE_MCP_TOKEN"
+  let json_string =
+    Auth_doctor.to_yojson report |> Yojson.Safe.to_string
+  in
+  check bool "json omits mcp_clients key" false
+    (contains_substring ~needle:"\"mcp_clients\"" json_string);
+  check bool "text omits mcp_clients section" false
+    (contains_substring ~needle:"mcp_clients:"
        (Auth_doctor.render_text report))
 
 let () =
@@ -204,7 +176,7 @@ let () =
             test_errors_when_no_admin_bearer_source_exists;
           test_case "ignores stale admin raw token file" `Quick
             test_ignores_stale_admin_raw_token_file;
-          test_case "reports Claude and Gemini MCP client identities" `Quick
-            test_reports_claude_and_gemini_mcp_client_identities;
+          test_case "json omits mcp_clients field" `Quick
+            test_json_no_longer_emits_mcp_clients_field;
         ] );
     ]

--- a/test/test_auth_login.ml
+++ b/test/test_auth_login.ml
@@ -33,11 +33,16 @@ let contains_substring ~needle s =
     in
     loop 0
 
-let test_login_enables_bearer_auth_and_prints_exports () =
+(* With_expiry path: caller passes the default env var name, mint
+   honors it verbatim. Agent_name is just a free string — the server
+   no longer derives env names from it. *)
+let test_login_with_expiry_uses_caller_env_var () =
   with_temp_dir "auth-login" @@ fun base_path ->
   match
     Auth_login.mint ~base_path ~host:"127.0.0.1" ~port:8935
-      ~agent_name:"test-agent" ~role:Masc_domain.Worker ()
+      ~agent_name:"test-agent" ~role:Masc_domain.Worker
+      ~token_env_var:"MASC_MCP_TOKEN"
+      ~token_lifetime:Auth_login.With_expiry ()
   with
   | Error err ->
       failf "login mint failed: %s" (Masc_domain.masc_error_to_string err)
@@ -48,7 +53,7 @@ let test_login_enables_bearer_auth_and_prints_exports () =
       check string "agent" "test-agent" report.agent_name;
       check string "role" "worker"
         (Masc_domain.agent_role_to_string report.role);
-      check string "client env" "MASC_MCP_TOKEN"
+      check string "client env passthrough" "MASC_MCP_TOKEN"
         report.mcp_token_env_var;
       check bool "raw token file exists" true
         (Sys.file_exists report.raw_token_file);
@@ -57,15 +62,12 @@ let test_login_enables_bearer_auth_and_prints_exports () =
            ~token:report.bearer_token
        with
        | Ok cred ->
-           check string "token owner" "test-agent"
-             cred.agent_name;
-           check (option string) "mcp token does not expire" None
-             cred.expires_at
+           check string "token owner" "test-agent" cred.agent_name
        | Error err ->
            failf "minted token did not verify: %s"
              (Masc_domain.masc_error_to_string err));
       let shell = Auth_login.render_shell report in
-      check bool "shell exports mcp token" true
+      check bool "shell exports caller-named env var" true
         (contains_substring ~needle:"export MASC_MCP_TOKEN="
            shell);
       let json = Auth_login.to_yojson report in
@@ -73,34 +75,41 @@ let test_login_enables_bearer_auth_and_prints_exports () =
         (Yojson.Safe.Util.member "status" json
         |> Yojson.Safe.Util.to_string)
 
-let test_login_prints_claude_client_env () =
-  with_temp_dir "auth-login-claude" @@ fun base_path ->
+(* Long_lived path: caller passes an arbitrary env var name and
+   asks for a no-expiry credential. The server passes the name
+   through verbatim and stores a credential with expires_at=None.
+   The choice is the caller's — there is no agent-name match. *)
+let test_login_long_lived_passes_env_var_through () =
+  with_temp_dir "auth-login-long-lived" @@ fun base_path ->
   match
     Auth_login.mint ~base_path ~host:"127.0.0.1" ~port:8935
-      ~agent_name:"claude" ~role:Masc_domain.Worker ()
+      ~agent_name:"long-lived-daemon" ~role:Masc_domain.Worker
+      ~token_env_var:"CUSTOM_MCP_TOKEN"
+      ~token_lifetime:Auth_login.Long_lived ()
   with
   | Error err ->
-      failf "login mint failed: %s" (Masc_domain.masc_error_to_string err)
+      failf "long-lived login mint failed: %s"
+        (Masc_domain.masc_error_to_string err)
   | Ok report ->
-      check string "agent" "claude" report.agent_name;
-      check string "client env" "MASC_CLAUDE_MCP_TOKEN"
+      check string "agent" "long-lived-daemon" report.agent_name;
+      check string "client env passthrough" "CUSTOM_MCP_TOKEN"
         report.mcp_token_env_var;
       (match
          Auth.find_credential_by_token base_path
            ~token:report.bearer_token
        with
        | Ok cred ->
-           check (option string) "claude mcp token does not expire" None
-             cred.expires_at
+           check (option string) "long-lived token has no expires_at"
+             None cred.expires_at
        | Error err ->
-           failf "minted claude token did not verify: %s"
+           failf "minted long-lived token did not verify: %s"
              (Masc_domain.masc_error_to_string err));
       let shell = Auth_login.render_shell report in
-      check bool "shell exports claude token" true
-        (contains_substring ~needle:"export MASC_CLAUDE_MCP_TOKEN="
+      check bool "shell exports caller-named env var" true
+        (contains_substring ~needle:"export CUSTOM_MCP_TOKEN="
            shell);
       let json = Auth_login.to_yojson report in
-      check string "json client env" "MASC_CLAUDE_MCP_TOKEN"
+      check string "json client env passthrough" "CUSTOM_MCP_TOKEN"
         (Yojson.Safe.Util.member "mcp_client" json
          |> Yojson.Safe.Util.member "token_env_var"
          |> Yojson.Safe.Util.to_string)
@@ -110,9 +119,9 @@ let () =
     [
       ( "login",
         [
-          test_case "enables bearer auth and prints exports" `Quick
-            test_login_enables_bearer_auth_and_prints_exports;
-          test_case "prints Claude client env" `Quick
-            test_login_prints_claude_client_env;
+          test_case "with-expiry honors caller env var" `Quick
+            test_login_with_expiry_uses_caller_env_var;
+          test_case "long-lived honors caller env var + no expires_at"
+            `Quick test_login_long_lived_passes_env_var_through;
         ] );
     ]


### PR DESCRIPTION
## Summary

Strip MCP-client knowledge (`claude`/`gemini` literals) from `lib/auth_login.ml` and `lib/auth_doctor.ml`. The CLI now requires `--client-env <VAR>` and `--no-expiry` flags so the operator names the env var and chooses the token-lifetime policy — the server no longer infers either from `--agent`. Per-client doctor diagnostic (`mcp_clients[]` in `doctor auth --json`) is removed.

Closes the §2 (string-classifier) workaround pattern documented in `software-development.md`. See `docs/rfc/RFC-0165-mcp-server-client-agnostic.md` for full rationale.

Related: RFC-0058 Phase 5.7 (different shape — Generalize vs Remove), RFC-0042 closed-sum, RFC-0088 Counter-as-Fix umbrella.

## Breaking changes

- **CLI**: `masc-mcp login` now requires `--client-env <VAR>`. Long-running local daemons should add `--no-expiry`. Migration: `~/me/scripts/mcp-sync.sh` will be updated in a follow-up PR.
- **JSON API**: `doctor auth --json` no longer emits `mcp_clients`. Dashboard does not consume this field (verified: `rg 'mcp_clients' dashboard/` = 0 hits).
- **Text output**: `doctor auth` text loses the `mcp_clients:` section.

## Test plan

- [x] `dune build lib/ bin/` clean
- [x] `dune build test/test_auth_login.exe test/test_auth_doctor.exe` clean
- [x] `dune exec test/test_auth_login.exe` — 2/2 PASS (with-expiry passthrough, long-lived passthrough + expires_at=None)
- [x] `dune exec test/test_auth_doctor.exe` — 3/3 PASS (errors-when-no-admin, ignores-stale-token-file, json-omits-mcp_clients regression)
- [x] CLI smoke: `login` without `--client-env` → Cmdliner usage error (`required option --client-env is missing`)
- [x] CLI smoke: `login --client-env CUSTOM_VAR --no-expiry --shell` → emits `export CUSTOM_VAR=…`; credential JSON has `"expires_at": null`
- [x] CLI smoke: `doctor auth --json | grep mcp_clients` → 0 hits
- [x] Invariant: `rg -i 'claude|gemini' lib/auth_login.ml lib/auth_doctor.ml` → 0 hits

## Workaround-rejection self-check (`software-development.md` §워크어라운드 거부 기준)

This PR *removes* a string-classifier; it does not add one.

1. "makes X visible" without fixing — NO
2. String/substring/prefix classifier added — NO (deletes two)
3. "PR #N fixed K of M sites" — NO (single PR closes both SSOTs)
4. catch-all `_ ->` added — NO (closed-sum `token_lifetime` replaces the implicit fall-through)
5. cap/cooldown/dedup/repair — NO
6. test backdoor — NO
7. typo/off-by-one repeated — NO

All 7 rejection signatures: NO.

## Files changed (net -120 LoC)

```
lib/auth_login.ml{,.mli}             — closed-sum token_lifetime, ~token_env_var/~token_lifetime required args
lib/auth_doctor.ml{,.mli}            — mcp_clients diagnostic removed
bin/main_eio.ml                      — --client-env (required), --no-expiry flags
test/test_auth_login.ml              — caller-supplied env passthrough tests
test/test_auth_doctor.ml             — mcp_clients regression test
docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md — §5 rewritten as operator convention, factually-wrong "self-heals" sentence removed
docs/rfc/RFC-0165-mcp-server-client-agnostic.md — new
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
