### PR TITLE
fix(keeper): remove git bridge CI leftovers

### DIFF
--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -58,16 +58,6 @@ jobs:
       - name: Run lint
         run: bash scripts/lint/provider-adapter-removal-ratchet.sh
 
-  shell-legacy-purge-ratchet:
-    name: Shell legacy purge ratchet
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install ripgrep
-        run: sudo apt-get install -y -qq ripgrep
-      - name: Run lint
-        run: bash scripts/lint/shell-legacy-purge-ratchet.sh
-
   shell-ir-consumption-ratchet:
     name: Shell IR consumption ratchet (RFC-0160)
     runs-on: ubuntu-latest

--- a/lib/keeper/keeper_shell_git_bridge.ml
+++ b/lib/keeper/keeper_shell_git_bridge.ml
@@ -100,10 +100,9 @@ let handle_git_clone
             ])
     | Ok () ->
       let clone_url = Tool_code_write.normalize_github_clone_url url in
-      let _bundle_paths =
+      let (_ : string list) =
         Keeper_alerting_path.ensure_sandbox_bundle ~config ~meta
       in
-      ignore (_bundle_paths : string list);
       let playground = keeper_playground_root ~config ~meta in
       let repos_dir = Filename.concat playground "repos" in
       Fs_compat.mkdir_p repos_dir;

--- a/test/test_keeper_shell_git_bridge.ml
+++ b/test/test_keeper_shell_git_bridge.ml
@@ -6,7 +6,9 @@ module Json = Yojson.Safe.Util
 let project_root = Masc_test_deps.find_project_root ()
 
 let () =
-  ignore (Result.get_ok (Keeper_tool_policy.init_policy_config ~base_path:project_root))
+  match Keeper_tool_policy.init_policy_config ~base_path:project_root with
+  | Ok _ -> ()
+  | Error e -> Alcotest.fail e
 
 let temp_dir prefix =
   let dir = Filename.temp_file prefix "" in


### PR DESCRIPTION
## Summary
- Remove the two `ignore()` sites introduced by the git bridge slice.
- Keep the same behavior by binding the sandbox bundle result to a typed wildcard and handling test policy initialization explicitly.
- Remove the completed Shell legacy purge workflow job now that #18204 deleted its script.

## Verification
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_shell_git_bridge.exe`
- `./_build/default/test/test_keeper_shell_git_bridge.exe`
- `opam exec -- ocamlformat --check lib/keeper/keeper_shell_git_bridge.ml test/test_keeper_shell_git_bridge.ml`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `bash scripts/ci/check-ignore-without-comment-diff.sh --base origin/main --head HEAD` -> `No new ignore() sites in PR diff.`
- `rg -n "shell-legacy-purge-ratchet|Shell legacy purge" .github scripts` -> no matches
- `scripts/check-version-truth.sh` -> `Version truth OK: package=0.19.28 changelog_entry=0.19.28 published_release=0.19.27`

## Version
No version bump: CI cleanup only, no behavior or public surface change.