### PR TITLE
refactor: remove claude/gemini/codex hardcoding from MASC core

### DIFF
--- a/bin/gen_shell_ir_walkers.ml
+++ b/bin/gen_shell_ir_walkers.ml
@@ -534,9 +534,6 @@ let emit_of_simple buf spec =
     \            | Bin.Ffplay\n\
     \            | Bin.Mpg123\n\
     \            | Bin.Open\n\
-    \            | Bin.Claude\n\
-    \            | Bin.Gemini\n\
-    \            | Bin.Codex\n\
     \            | Bin.Su\n\
     \            | Bin.Chmod\n\
     \            | Bin.Chown\n\

--- a/lib/exec/bin.ml
+++ b/lib/exec/bin.ml
@@ -76,9 +76,6 @@ type known =
   | Ffplay
   | Mpg123
   | Open
-  | Claude
-  | Gemini
-  | Codex
   (* Privileged *)
   | Sudo
   | Su
@@ -143,9 +140,6 @@ let name_of_known : known -> string = function
   | Ffplay -> "ffplay"
   | Mpg123 -> "mpg123"
   | Open -> "open"
-  | Claude -> "claude"
-  | Gemini -> "gemini"
-  | Codex -> "codex"
   | Sudo -> "sudo"
   | Su -> "su"
   | Chmod -> "chmod"
@@ -209,10 +203,7 @@ let risk_of_known : known -> risk_class = function
   | Rec
   | Ffplay
   | Mpg123
-  | Open
-  | Claude
-  | Gemini
-  | Codex -> `Audited
+  | Open -> `Audited
   | Sudo | Su | Chmod | Chown | Rm | Dd | Mkfs -> `Privileged
 ;;
 
@@ -270,10 +261,7 @@ let kind_of_known : known -> kind = function
   | Rec
   | Ffplay
   | Mpg123
-  | Open
-  | Claude
-  | Gemini
-  | Codex -> `Other_audited
+  | Open -> `Other_audited
   | Sudo | Su | Chmod | Chown | Rm | Dd | Mkfs -> `Privileged_bin
 ;;
 
@@ -346,9 +334,6 @@ let known_of_string : string -> known option = function
   | "ffplay" -> Some Ffplay
   | "mpg123" -> Some Mpg123
   | "open" -> Some Open
-  | "claude" -> Some Claude
-  | "gemini" -> Some Gemini
-  | "codex" -> Some Codex
   | "sudo" -> Some Sudo
   | "su" -> Some Su
   | "chmod" -> Some Chmod

--- a/lib/exec/bin.mli
+++ b/lib/exec/bin.mli
@@ -95,9 +95,6 @@ type known =
   | Ffplay
   | Mpg123
   | Open
-  | Claude
-  | Gemini
-  | Codex
   | Sudo
   | Su
   | Chmod


### PR DESCRIPTION
## Summary
Remove all agent-specific string literals and closed-variant constructors for claude, gemini, and codex from the MASC coordination layer. Provider identity decisions now flow through `Agent_sdk.Provider_runtime_binding`.

## Changes

| File | Change |
|------|--------|
| `lib/exec/bin.ml{,i}` | Drop `Claude\|Gemini\|Codex` from `Bin.known` variant |
| `bin/gen_shell_ir_walkers.ml` | Remove stale constructor refs from `emit_of_simple` |
| `lib/auth_login.ml{,i}` | Derive MCP token env var from binding ID via convention `MASC_<ID>_MCP_TOKEN`; local-client check uses `transport=Cli` |
| `lib/auth_doctor.ml` | Dynamic `mcp_client_specs` from `Runtime_binding.all()` filtered by `transport=Cli` |
| `lib/provider_runtime_projection.ml` | Generic `spawn_key_of_binding` via `transport=Cli`; remove llama-specific alias injection |
| `scripts/lint/no-provider-name-hardcoding.allowlist` | Update line numbers after deletions |

## Verification
- [x] `dune build @install` passes
- [x] `scripts/lint/no-provider-name-hardcoding.sh --fail` passes
- [x] `scripts/audit-shell-ir-consumption.sh` passes (no G1/G7 regression)
- [x] `test/test_auth_login.exe` builds

## Risks
- `auth_doctor` MCP client spec output now lists all `transport=Cli` bindings instead of a hardcoded `[claude; gemini]`. If OAS adds non-MCP CLI bindings, they will appear in doctor output.
- `spawn_key_of_binding` now accepts any `transport=Cli` binding. Review OAS catalog to ensure all CLI bindings are legitimate spawn candidates.