### PR TITLE
refactor(shell-ir): remove gate, migrate callers to gate_typed

### DIFF
--- a/lib/exec/command_gate/shell_command_gate.ml
+++ b/lib/exec/command_gate/shell_command_gate.ml
@@ -421,17 +421,6 @@ let parse_only_to_stages (parsed : SI.t PD.t) :
      | Nested_pipeline -> Error (`Too_complex Unsupported_nested_pipeline))
 ;;
 
-let gate ?caller:_ ~raw ~allowlist ~path_policy ~sandbox () : verdict =
-  (* [caller] is captured for the upcoming telemetry partition
-     (RFC-0131 PR-3) and does not affect the verdict.  The
-     ignored-argument pattern is intentional: this iter establishes
-     the API surface; PR-3 wires the counters. *)
-  match parse_only_to_stages (Masc_exec_bash_parser.Bash.parse_string raw) with
-  | Error (`Cannot_parse reason) -> Cannot_parse { reason }
-  | Error (`Too_complex reason) -> Too_complex { reason }
-  | Ok stages -> apply_policy ~allowlist ~path_policy ~sandbox ~stages
-;;
-
 let gate_typed ?caller:_ ~ir ~allowlist ~path_policy ~sandbox () : verdict =
   (* Typed callers have already crossed their schema boundary, so this
      entrypoint intentionally skips raw-string parsing while preserving

--- a/lib/exec/command_gate/shell_command_gate.mli
+++ b/lib/exec/command_gate/shell_command_gate.mli
@@ -141,22 +141,6 @@ val host_sandbox : sandbox_context
 (** Convenience: the default {!Masc_exec.Sandbox_target.host}
     sandbox. *)
 
-val gate
-  :  ?caller:caller
-  -> raw:string
-  -> allowlist:allowlist_policy
-  -> path_policy:path_policy
-  -> sandbox:sandbox_context
-  -> unit
-  -> verdict
-(** Phase 1 SSOT entrypoint. Calls the bash subset parser once, lifts the result
-    into a {!parsed_context}, then applies allowlist and path policy
-    in that order. Sandbox context is recorded on every stage's
-    [Masc_exec.Shell_ir.simple.sandbox] field so downstream consumers
-    can route to [Exec_dispatch] in Phase 4 without re-parsing.
-    [?caller] is captured for the upcoming telemetry partition
-    (RFC-0131 PR-3) and does not affect the verdict. *)
-
 val gate_typed
   :  ?caller:caller
   -> ir:Masc_exec.Shell_ir.t
@@ -168,7 +152,7 @@ val gate_typed
 (** Policy-aware typed entrypoint for callers that already have a
     {!Masc_exec.Shell_ir.t}. This bypasses raw Bash parsing but shares
     the same allowlist, redirect, path-policy, sandbox, and nested
-    pipeline handling as {!gate}. *)
+    pipeline handling as the legacy [gate] entrypoint. *)
 
 val lower_typed_pipeline
   :  ?caller:caller

--- a/lib/exec_policy.ml
+++ b/lib/exec_policy.ml
@@ -305,34 +305,40 @@ let command_context_with_allowlist ?caller ~allowed_commands cmd =
   if trimmed = ""
   then Error Empty_command
   else (
-    let verdict =
-      Exec_shell_gate.gate
-        ?caller
-        ~raw:trimmed
-        ~allowlist:(strict_allowlist_policy ~allowed_commands)
-        ~path_policy:Exec_shell_gate.allow_all_paths
-        ~sandbox:Exec_shell_gate.host_sandbox
-        ()
-    in
-    match verdict with
-    | Allow context ->
-      if context.Exec_shell_gate.direct_dune_seen
-      then Error Direct_dune_invocation
-      else (
-        match validate_no_unquoted_glob context.Exec_shell_gate.ast with
-        | Error _ as err -> err
-        | Ok () ->
-          (match
-             validate_wrapped_stages ~allowed_commands context.Exec_shell_gate.ast
-           with
-           | Ok () -> Ok context
-           | Error _ as err -> err))
-    | Reject { context; reason; _ } ->
-      if context.Exec_shell_gate.direct_dune_seen
-      then Error Direct_dune_invocation
-      else Error (block_reason_of_exec_reject reason)
-    | Cannot_parse _ -> Error Chain_or_redirect
-    | Too_complex { reason } -> Error (block_reason_of_exec_too_complex reason))
+    match Masc_exec_bash_parser.Bash.parse_string trimmed with
+    | (Masc_exec.Parsed.Parse_error _ | Masc_exec.Parsed.Parse_aborted _) ->
+      Error Chain_or_redirect
+    | Masc_exec.Parsed.Too_complex reason ->
+      Error (block_reason_of_exec_too_complex (Unsupported_construct reason))
+    | Masc_exec.Parsed.Parsed ir ->
+      let verdict =
+        Exec_shell_gate.gate_typed
+          ?caller
+          ~ir
+          ~allowlist:(strict_allowlist_policy ~allowed_commands)
+          ~path_policy:Exec_shell_gate.allow_all_paths
+          ~sandbox:Exec_shell_gate.host_sandbox
+          ()
+      in
+      match verdict with
+      | Allow context ->
+        if context.Exec_shell_gate.direct_dune_seen
+        then Error Direct_dune_invocation
+        else (
+          match validate_no_unquoted_glob context.Exec_shell_gate.ast with
+          | Error _ as err -> err
+          | Ok () ->
+            (match
+               validate_wrapped_stages ~allowed_commands context.Exec_shell_gate.ast
+             with
+             | Ok () -> Ok context
+             | Error _ as err -> err))
+      | Reject { context; reason; _ } ->
+        if context.Exec_shell_gate.direct_dune_seen
+        then Error Direct_dune_invocation
+        else Error (block_reason_of_exec_reject reason)
+      | Cannot_parse _ -> Error Chain_or_redirect
+      | Too_complex { reason } -> Error (block_reason_of_exec_too_complex reason))
 ;;
 
 let validate_command_with_allowlist ?caller ~allowed_commands cmd =
@@ -354,36 +360,42 @@ let command_context_coding_with_allowlist
   if trimmed = ""
   then Error Empty_command
   else (
-    let verdict =
-      Exec_shell_gate.gate
-        ?caller
-        ~raw:trimmed
-        ~allowlist:(coding_allowlist_policy ~allow_pipes ~allowed_commands ())
-        ~path_policy:Exec_shell_gate.allow_all_paths
-        ~sandbox:Exec_shell_gate.host_sandbox
-        ()
-    in
-    match verdict with
-    | Allow context ->
-      if context.Exec_shell_gate.direct_dune_seen
-      then Error Direct_dune_invocation
-      else (
-        match validate_no_unquoted_glob context.Exec_shell_gate.ast with
-        | Error _ as err -> err
-        | Ok () ->
-          (match
-             validate_wrapped_stages ~allowed_commands context.Exec_shell_gate.ast
-           with
-           | Ok () -> Ok context
-           | Error _ as err -> err))
-    | Reject { context; reason; _ } ->
-      (match reason with
-       | Pipes_not_allowed _ -> Error Pipes_not_allowed
-       | _ when context.Exec_shell_gate.direct_dune_seen ->
-         Error Direct_dune_invocation
-       | _ -> Error (block_reason_of_exec_reject reason))
-    | Cannot_parse _ -> Error Injection
-    | Too_complex { reason } -> Error (block_reason_of_exec_too_complex reason))
+    match Masc_exec_bash_parser.Bash.parse_string trimmed with
+    | (Masc_exec.Parsed.Parse_error _ | Masc_exec.Parsed.Parse_aborted _) ->
+      Error Injection
+    | Masc_exec.Parsed.Too_complex reason ->
+      Error (block_reason_of_exec_too_complex (Unsupported_construct reason))
+    | Masc_exec.Parsed.Parsed ir ->
+      let verdict =
+        Exec_shell_gate.gate_typed
+          ?caller
+          ~ir
+          ~allowlist:(coding_allowlist_policy ~allow_pipes ~allowed_commands ())
+          ~path_policy:Exec_shell_gate.allow_all_paths
+          ~sandbox:Exec_shell_gate.host_sandbox
+          ()
+      in
+      match verdict with
+      | Allow context ->
+        if context.Exec_shell_gate.direct_dune_seen
+        then Error Direct_dune_invocation
+        else (
+          match validate_no_unquoted_glob context.Exec_shell_gate.ast with
+          | Error _ as err -> err
+          | Ok () ->
+            (match
+               validate_wrapped_stages ~allowed_commands context.Exec_shell_gate.ast
+             with
+             | Ok () -> Ok context
+             | Error _ as err -> err))
+      | Reject { context; reason; _ } ->
+        (match reason with
+         | Pipes_not_allowed _ -> Error Pipes_not_allowed
+         | _ when context.Exec_shell_gate.direct_dune_seen ->
+           Error Direct_dune_invocation
+         | _ -> Error (block_reason_of_exec_reject reason))
+      | Cannot_parse _ -> Error Injection
+      | Too_complex { reason } -> Error (block_reason_of_exec_too_complex reason))
 ;;
 
 let validate_command_coding_with_allowlist ?caller ?allow_pipes ~allowed_commands cmd =

--- a/scripts/shell-ir-consumption-baseline.json
+++ b/scripts/shell-ir-consumption-baseline.json
@@ -16,6 +16,6 @@
   "g7_parallel_parser_total": 0,
   "info_ir_constructors_nontest": 62,
   "allowed_exceptions": {
-    "g1_parse_string": ["lib/exec/command_gate/shell_command_gate.ml","lib/exec_policy_mutation_classifier.ml"]
+    "g1_parse_string": ["lib/exec_policy.ml","lib/exec_policy_mutation_classifier.ml"]
   }
 }


### PR DESCRIPTION
## Summary
- Remove `Shell_command_gate.gate` (raw-string entrypoint with internal parse)
- Migrate `exec_policy.ml` callers to `gate_typed` + explicit `Bash.parse_string`
- Update RFC-0160 G1 allowed_exceptions: `shell_command_gate.ml` -> `exec_policy.ml`
- Preserves identical verdict semantics; parsing responsibility moves to callers

## Verification
- `dune build --root .`: PASS (ld warning only)
- No consumer signature changes (same string-in, context-out API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)