### PR TITLE
fix(task): guard auto-start against already-in-progress tasks

### DIFF
--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -533,15 +533,30 @@ let handle_keeper_task_tool
     (match result with
      | Coord.Claim_next_claimed { task_id; _ } ->
        sync_keeper_meta_current_task ~config ~meta ~task_id;
-       let start_result =
-         Tool_task.handle_transition
-           ~tool_name:"keeper_auto_start"
-           ~start_time:0.0
-           { Tool_task.config; agent_name = keeper_agent_sender ~meta;
-             sw = Eio_context.get_switch_opt () }
-           (`Assoc ["task_id", `String task_id; "action", `String "start"])
+       (* Guard: claim_next_r returns existing active tasks via Existing_claim
+          (coord_task_schedule.ml:302). When the task is already InProgress,
+          dispatching Start produces an InvalidState transition error every
+          cycle. Only auto-start when the task is in a pre-start state. *)
+       let needs_start =
+         let tasks = Coord.get_tasks_raw config in
+         match List.find_opt (fun (t : Masc_domain.task) -> String.equal t.id task_id) tasks with
+         | Some { task_status = Masc_domain.InProgress _; _ } -> false
+         | Some { task_status = Masc_domain.Done _ | Masc_domain.Cancelled _
+                 | Masc_domain.AwaitingVerification _; _ } -> false
+         | _ -> true
        in
-       auto_started_ok := start_result.Tool_result.success
+       if needs_start then begin
+         let start_result =
+           Tool_task.handle_transition
+             ~tool_name:"keeper_auto_start"
+             ~start_time:0.0
+             { Tool_task.config; agent_name = keeper_agent_sender ~meta;
+               sw = Eio_context.get_switch_opt () }
+             (`Assoc ["task_id", `String task_id; "action", `String "start"])
+         in
+         auto_started_ok := start_result.Tool_result.success
+       end else
+         auto_started_ok := true
      | Coord.Claim_next_no_unclaimed
      | Coord.Claim_next_no_eligible _
      | Coord.Claim_next_error _ -> ());


### PR DESCRIPTION
## Summary

- `Coord.claim_next_r`이 기존 active task를 `Claim_next_claimed`로 재반환할 때 (`Existing_claim` 경로, `coord_task_schedule.ml:302`), keeper가 무조건 `action=start`를 dispatch
- 이미 `InProgress`인 task에 `Start`를 보내면 FSM transition error (`Transition 'start' from status 'in_progress' is not allowed`)가 매 keeper cycle마다 발생
- `start` dispatch 전에 task 상태를 조회하여 `InProgress`/`Done`/`Cancelled`/`AwaitingVerification`면 auto-start를 skip

## Root Cause

```
claim_next_r → Existing_claim (task already InProgress) → Claim_next_claimed
  → keeper_exec_task.ml dispatches start → InvalidState error (every cycle)
```

FSM (`valid_next_actions_for_status`): `InProgress` allows `done, submit_for_verification, release, cancel` — **not** `start`.

## Fix

Pre-dispatch status check in `keeper_exec_task.ml:540-546`:
- `Todo` / `Claimed` → needs start (original behavior)
- `InProgress` / `Done` / `Cancelled` / `AwaitingVerification` → skip, set `auto_started_ok = true`

## Test plan

- [ ] keeper가 이미 `InProgress` task를 가진 상태에서 `masc_claim_next` 호출 시 WARN 로그가 더 이상 발생하지 않는지 확인
- [ ] 새로운 `Todo`/`Claimed` task claim 시에는 기존처럼 auto-start가 정상 동작하는지 확인
- [ ] `dune build lib/masc_mcp.cma` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)