### PR TITLE
refactor(dashboard): purge MCP-client attribution from common/* headers (RFC-0169)

### DIFF
--- a/dashboard/src/api/dev-token.ts
+++ b/dashboard/src/api/dev-token.ts
@@ -30,7 +30,7 @@ function shouldRefreshDevToken(): boolean {
   const actor = currentDashboardActor()
   if (isRemoteAccess() || actor !== 'dashboard') return false
   // Loopback dashboard sessions should self-heal if they are still holding
-  // a borrowed non-dashboard token (for example an old codex paste/URL token).
+  // a borrowed non-dashboard token (for example an old MCP-client paste/URL token).
   return meta == null || meta.actor == null || meta.actor !== actor
 }
 

--- a/dashboard/src/components/common/agent-capability.ts
+++ b/dashboard/src/components/common/agent-capability.ts
@@ -1,6 +1,6 @@
 // AgentCapability — AX molecule that renders an agent's tool set.
 //
-// Kimi design system sec05 reference: icon + tooltip badges for each tool
+// MASC dashboard sec05 reference: icon + tooltip badges for each tool
 // an agent can use. The compact badge row lets operators quickly scan
 // an agent's capability envelope without opening a detail panel.
 //

--- a/dashboard/src/components/common/agent-card.ts
+++ b/dashboard/src/components/common/agent-card.ts
@@ -1,7 +1,7 @@
 // AgentCard — composite AX card that assembles Presence + Capability + Trust +
 // Failure + Human-in-the-loop into a single scannable unit.
 //
-// Kimi design system sec05 5.4: "에이전트의 삶을 조망하는 도구"의 핵심 단위.
+// MASC dashboard sec05 5.4: "에이전트의 삶을 조망하는 도구"의 핵심 단위.
 // Each section is conditional so the card density adapts to the agent's state.
 
 import { html } from 'htm/preact'

--- a/dashboard/src/components/common/agent-failure.ts
+++ b/dashboard/src/components/common/agent-failure.ts
@@ -1,6 +1,6 @@
 // AgentFailure — AX atom that renders an error state with type-aware styling.
 //
-// Kimi design system sec05 reference: icons + color-coded borders for retryable,
+// MASC dashboard sec05 reference: icons + color-coded borders for retryable,
 // non-retryable, human-required and degraded failure types. The compact alert
 // card lets operators instantly grasp severity and required action.
 //

--- a/dashboard/src/components/common/agent-presence.ts
+++ b/dashboard/src/components/common/agent-presence.ts
@@ -1,6 +1,6 @@
 // AgentPresence — AX atom that renders an agent's presence state.
 //
-// Kimi design system sec05 reference: Slack status dot + Discord activity
+// MASC dashboard sec05 reference: Slack status dot + Discord activity
 // indicator. The dot + pulse animation communicates "this agent is a
 // digital colleague" rather than an abstract process.
 //

--- a/dashboard/src/components/common/agent-trust.ts
+++ b/dashboard/src/components/common/agent-trust.ts
@@ -1,7 +1,7 @@
 // AgentTrust — AX organism that visualizes an agent's trust score and approval history.
 //
-// Kimi design system sec05 reference: Anthropic Constitutional AI-inspired
-// confidence indicator. Score bar + approval/rejection/override counts.
+// MASC dashboard sec05 reference: Constitutional-AI-style confidence
+// indicator. Score bar + approval/rejection/override counts.
 
 import { html } from 'htm/preact'
 

--- a/dashboard/src/components/common/command-bar.ts
+++ b/dashboard/src/components/common/command-bar.ts
@@ -1,6 +1,6 @@
 // CommandBar — inline fuzzy-search command input molecule.
 //
-// Kimi design system sec09 Phase 1 reference: fuzzy search, windowing,
+// MASC dashboard sec09 Phase 1 reference: fuzzy search, windowing,
 // split pane. This is the inline command bar (not the modal CommandPalette
 // which uses ninja-keys).
 

--- a/dashboard/src/components/common/event-stream.ts
+++ b/dashboard/src/components/common/event-stream.ts
@@ -1,6 +1,6 @@
 // EventStream — AX molecule for real-time event log visualization.
 //
-// Kimi design system sec02 reference: 2.1.3 agent log stream with level-based
+// MASC dashboard sec02 reference: 2.1.3 agent log stream with level-based
 // color coding and live append semantics.
 
 import { html } from 'htm/preact'

--- a/dashboard/src/components/common/file-tree.ts
+++ b/dashboard/src/components/common/file-tree.ts
@@ -1,6 +1,6 @@
 // FileTree — AX molecule for visualizing agent file systems.
 //
-// Kimi design system sec02 reference: 2.1.2 virtualized + collapsible file tree
+// MASC dashboard sec02 reference: 2.1.2 virtualized + collapsible file tree
 // with git status badges.
 
 import { html } from 'htm/preact'

--- a/dashboard/src/components/common/focus-scope.ts
+++ b/dashboard/src/components/common/focus-scope.ts
@@ -1,6 +1,6 @@
 // focus-scope.ts — tabbable element collection + cyclic focus management
 //
-// Kimi design system sec01 1.3.1: createFocusScope for focus traps in dialogs,
+// MASC dashboard sec01 1.3.1: createFocusScope for focus traps in dialogs,
 // drawers, and modals. Returns first/last refs and a cycle() handler for Tab.
 
 const TABBABLE_SELECTOR =

--- a/dashboard/src/components/common/grid.ts
+++ b/dashboard/src/components/common/grid.ts
@@ -1,5 +1,5 @@
 // Grid — ARIA grid with row-level keyboard navigation
-// Kimi sec06 ARIA pattern: grid. ArrowUp/Down moves between rows;
+// MASC sec06 ARIA pattern: grid. ArrowUp/Down moves between rows;
 // Home/End jumps to first/last row; Enter selects.
 
 import { html } from 'htm/preact'

--- a/dashboard/src/components/common/human-in-the-loop.ts
+++ b/dashboard/src/components/common/human-in-the-loop.ts
@@ -1,6 +1,6 @@
 // HumanInTheLoop — AX molecule for agent approval requests.
 //
-// Kimi design system sec05 reference: Google AI Human-in-the-loop pattern.
+// MASC dashboard sec05 reference: Human-in-the-loop UX pattern.
 // Risk-level styling + countdown timer + approve/reject/modify actions.
 
 import { html } from 'htm/preact'

--- a/dashboard/src/components/common/inline-edit.ts
+++ b/dashboard/src/components/common/inline-edit.ts
@@ -1,6 +1,6 @@
 // InlineEdit — click-to-edit atom with save/cancel semantics.
 //
-// Kimi design system sec02 2.3.1 reference: Atlassian ADS inline-edit pattern.
+// MASC dashboard sec02 2.3.1 reference: Atlassian ADS inline-edit pattern.
 // Translated to Preact + htm/preact + Tailwind v4 dashboard conventions.
 
 import { html } from 'htm/preact'

--- a/dashboard/src/components/common/keyboard-shortcut.ts
+++ b/dashboard/src/components/common/keyboard-shortcut.ts
@@ -1,5 +1,5 @@
 // KeyboardShortcut — shortcut conflict detection and context binding sheet
-// Kimi design system sec02 2.4.2: shortcut conflict detection, context binding.
+// MASC dashboard sec02 2.4.2: shortcut conflict detection, context binding.
 // Zero-dependency fallback (no fuzzysort).
 
 import { html } from 'htm/preact'

--- a/dashboard/src/components/common/list.ts
+++ b/dashboard/src/components/common/list.ts
@@ -1,5 +1,5 @@
 // List — ARIA list primitive
-// Kimi sec06 ARIA pattern: list. role="list" container + role="listitem" items.
+// MASC sec06 ARIA pattern: list. role="list" container + role="listitem" items.
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'

--- a/dashboard/src/components/common/log.ts
+++ b/dashboard/src/components/common/log.ts
@@ -1,5 +1,5 @@
 // Log — ARIA live region for appended messages
-// Kimi sec06 ARIA pattern: log. role="log" with implicit aria-live="polite".
+// MASC sec06 ARIA pattern: log. role="log" with implicit aria-live="polite".
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'

--- a/dashboard/src/components/common/memory-graph.ts
+++ b/dashboard/src/components/common/memory-graph.ts
@@ -1,5 +1,5 @@
 // MemoryGraph — Obsidian-style node-edge graph for long-term memory
-// Kimi design system sec03 3.1.1: agent memory node-edge graph.
+// MASC dashboard sec03 3.1.1: agent memory node-edge graph.
 // Zero-dependency SVG fallback (no D3).
 
 import { html } from 'htm/preact'

--- a/dashboard/src/components/common/popover.ts
+++ b/dashboard/src/components/common/popover.ts
@@ -1,5 +1,5 @@
 // Popover — non-modal floating panel primitive
-// Kimi sec09 Phase 1: Headless Popover. Distinct from Dialog (modal) and
+// MASC sec09 Phase 1: Headless Popover. Distinct from Dialog (modal) and
 // Tooltip (hover-only). Popover is click-triggered, non-modal, and may
 // contain interactive content.
 //

--- a/dashboard/src/components/common/portal.ts
+++ b/dashboard/src/components/common/portal.ts
@@ -1,6 +1,6 @@
 // portal.ts — render children into a document.body-mounted container
 //
-// Kimi design system sec01 1.2.1: Portal for overlays, modals, and drawers.
+// MASC dashboard sec01 1.2.1: Portal for overlays, modals, and drawers.
 // Uses createPortal from preact/compat and cleans up on unmount.
 
 import { createPortal } from 'preact/compat'

--- a/dashboard/src/components/common/region.ts
+++ b/dashboard/src/components/common/region.ts
@@ -1,5 +1,5 @@
 // Region — ARIA landmark region
-// Kimi sec06 ARIA pattern: region. Generic section landmark with aria-label.
+// MASC sec06 ARIA pattern: region. Generic section landmark with aria-label.
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'

--- a/dashboard/src/components/common/roving-tabindex.ts
+++ b/dashboard/src/components/common/roving-tabindex.ts
@@ -1,6 +1,6 @@
 // roving-tabindex.ts — Roving Tabindex hook for tablist / radiogroup / toolbar
 //
-// Kimi design system sec01 1.3.2: one item is tabbable (tabindex=0), rest are
+// MASC dashboard sec01 1.3.2: one item is tabbable (tabindex=0), rest are
 // tabindex=-1. Arrow keys move focus; Home/End jump to extremes.
 
 import { useState } from 'preact/hooks'

--- a/dashboard/src/components/common/search.ts
+++ b/dashboard/src/components/common/search.ts
@@ -1,5 +1,5 @@
 // Search — ARIA search primitive
-// Kimi sec06 ARIA pattern: search. Enter submits query, Escape clears.
+// MASC sec06 ARIA pattern: search. Enter submits query, Escape clears.
 
 import { html } from 'htm/preact'
 import type { FunctionComponent } from 'preact'

--- a/dashboard/src/components/common/switch.ts
+++ b/dashboard/src/components/common/switch.ts
@@ -1,6 +1,6 @@
 // Switch — accessible toggle switch atom.
 //
-// Kimi design system sec06 reference: ARIA switch pattern with Space activation.
+// MASC dashboard sec06 reference: ARIA switch pattern with Space activation.
 // Uses role="switch" and aria-checked for screen-reader contract.
 
 import { html } from 'htm/preact'

--- a/dashboard/src/components/common/tabs.ts
+++ b/dashboard/src/components/common/tabs.ts
@@ -1,5 +1,5 @@
 // Tabs — tablist/tab/tabpanel primitive
-// Kimi sec06 ARIA pattern: tablist. Keyboard arrows cycle tabs;
+// MASC sec06 ARIA pattern: tablist. Keyboard arrows cycle tabs;
 // Home/End jump to first/last.
 
 import { html } from 'htm/preact'

--- a/dashboard/src/components/common/terminal.ts
+++ b/dashboard/src/components/common/terminal.ts
@@ -1,6 +1,6 @@
 // Terminal — AX molecule for agent console output.
 //
-// Kimi design system sec02 reference: 2.1.3 terminal with ANSI color.
+// MASC dashboard sec02 reference: 2.1.3 terminal with ANSI color.
 // Fallback div renderer (no xterm.js) for zero-dependency bundles.
 
 import { html } from 'htm/preact'

--- a/dashboard/src/components/common/toolbar.ts
+++ b/dashboard/src/components/common/toolbar.ts
@@ -1,5 +1,5 @@
 // Toolbar — toolbar primitive with roving tabindex
-// Kimi sec06 ARIA pattern: toolbar. Arrow keys move focus between items;
+// MASC sec06 ARIA pattern: toolbar. Arrow keys move focus between items;
 // Home/End jump to first/last. Only one item is tab-accessible at a time.
 
 import { html } from 'htm/preact'

--- a/dashboard/src/components/common/use-controllable-state.ts
+++ b/dashboard/src/components/common/use-controllable-state.ts
@@ -1,6 +1,6 @@
 // use-controllable-state.ts — controlled/uncontrolled state bridge
 //
-// Kimi design system sec01 1.2: Headless primitives must support
+// MASC dashboard sec01 1.2: Headless primitives must support
 // both controlled (props-driven) and uncontrolled (internal state)
 // modes. This hook is the standard bridge.
 

--- a/dashboard/src/components/common/use-focus-ring.ts
+++ b/dashboard/src/components/common/use-focus-ring.ts
@@ -1,6 +1,6 @@
 // use-focus-ring.ts — keyboard-focus-only visual ring
 //
-// Kimi design system sec01 1.5.2: useFocusRing distinguishes keyboard focus
+// MASC dashboard sec01 1.5.2: useFocusRing distinguishes keyboard focus
 // (focus-visible) from mouse focus. Exposes data-focused / data-focus-visible.
 
 import { useState } from 'preact/hooks'

--- a/dashboard/src/components/common/use-hover.ts
+++ b/dashboard/src/components/common/use-hover.ts
@@ -1,6 +1,6 @@
 // use-hover.ts — touch-aware hover detection
 //
-// Kimi design system sec01 1.5.3: useHover skips hover effects on touch devices
+// MASC dashboard sec01 1.5.3: useHover skips hover effects on touch devices
 // by checking pointerType. Exposes hovered state via data-hovered.
 
 import { useRef, useState } from 'preact/hooks'

--- a/dashboard/src/components/common/use-move.ts
+++ b/dashboard/src/components/common/use-move.ts
@@ -1,6 +1,6 @@
 // use-move.ts — drag delta tracking for ResizablePanel
 //
-// Kimi design system sec01 1.5: useMove tracks Δx, Δy across pointer
+// MASC dashboard sec01 1.5: useMove tracks Δx, Δy across pointer
 // devices. Emits move start / move / move end callbacks.
 
 import { useRef, useState, useCallback } from 'preact/hooks'

--- a/dashboard/src/components/common/use-press.ts
+++ b/dashboard/src/components/common/use-press.ts
@@ -1,6 +1,6 @@
 // use-press.ts — touch/mouse/keyboard unified press detection
 //
-// Kimi design system sec01 1.5.1: usePress abstracts mousedown/touchstart/keydown
+// MASC dashboard sec01 1.5.1: usePress abstracts mousedown/touchstart/keydown
 // into a single onPress callback. Exposes pressed state via data-pressed.
 
 import { useState } from 'preact/hooks'

--- a/dashboard/src/components/common/use-theme.ts
+++ b/dashboard/src/components/common/use-theme.ts
@@ -1,6 +1,6 @@
 // use-theme.ts — theme context provider and consumer hook
 //
-// Kimi design system sec08 8.2.1: ThemeProvider + useTheme manage data-theme
+// MASC dashboard sec08 8.2.1: ThemeProvider + useTheme manage data-theme
 // attribute, localStorage persistence, and system-preference detection.
 
 import { createContext } from 'preact'

--- a/dashboard/src/components/common/window.ts
+++ b/dashboard/src/components/common/window.ts
@@ -1,5 +1,5 @@
 // Window — modal window with Alt+F4 close contract
-// Kimi sec06 ARIA pattern: window. role="dialog" + Alt+F4 keyboard contract.
+// MASC sec06 ARIA pattern: window. role="dialog" + Alt+F4 keyboard contract.
 
 import { html } from 'htm/preact'
 import type { ComponentChildren } from 'preact'

--- a/docs/rfc/RFC-0169-dashboard-common-attribution-purge.md
+++ b/docs/rfc/RFC-0169-dashboard-common-attribution-purge.md
@@ -1,0 +1,68 @@
+# RFC-0169 Dashboard common/* MCP-client attribution header purge
+
+| | |
+|---|---|
+| Status | Draft |
+| Related | RFC-0165 (auth client-agnostic), RFC-0166 (server big-bang sweep), RFC-0167 (codex/llama purge), RFC-0168 (provider palette) |
+| Scope | `dashboard/src/components/common/*.ts` JSDoc header comments, `dashboard/src/api/dev-token.ts` inline comment |
+| Repos | masc-mcp |
+
+## 1. Problem
+
+RFC-0165 / 0166 / 0167 cleared client/provider name literals from `lib/` and `bin/`. RFC-0168 cleared the dashboard's closed-roster provider color palette. The remaining MCP-client name surface in `dashboard/src/` is JSDoc-style attribution comments that cite the original design-doc source ("Kimi design system secXX") and one inline comment in `dev-token.ts` mentioning a competing MCP-client paste flow.
+
+- 33 files under `dashboard/src/components/common/` open with `// Kimi design system secXX:` or `// Kimi secXX:` header comments. Two of them further cite `Anthropic Constitutional AI` (`agent-trust.ts`) and `Google AI Human-in-the-loop` (`human-in-the-loop.ts`) as UX pattern sources.
+- `dashboard/src/api/dev-token.ts:33` carries an inline comment referencing `"an old codex paste/URL token"` as an example of a borrowed non-dashboard token.
+
+None of these surfaces dispatch on the cited names — they are pure attribution / example references. The names persist only as comment-level reminders of the original design-doc source.
+
+## 2. Decision
+
+- Sweep `Kimi design system sec` → `MASC dashboard sec` and `Kimi sec` → `MASC sec` across all 33 `common/*.ts` headers.
+- Rewrite the two paired LLM-vendor citations to vendor-agnostic phrasing:
+  - `Anthropic Constitutional AI-inspired confidence indicator` → `Constitutional-AI-style confidence indicator`
+  - `Google AI Human-in-the-loop pattern` → `Human-in-the-loop UX pattern`
+- Rewrite the `dev-token.ts:33` example to `old MCP-client paste/URL token` (drop the vendor-specific tool name).
+
+## 3. Non-changes (intentionally kept)
+
+| Surface | Token | Reason |
+|---------|-------|--------|
+| `keeper-state-diagram.ts:76` | `CLAUDE.md` | Project instruction file name. Not a vendor. |
+| `keeper-identity.ts:15` | `'llama'` | Animal name inside the keeper nickname pool, sibling to `cobra`/`gecko`/`lemur`/`manta`. False positive on the substring scanner. |
+| `cascade-config-panel.ts:893` | `case 'ollama': return 'Ollama'` | `ollama` is an LLM serving framework (akin to nginx/postgres), not an MCP-client or upstream-LLM-provider name. Exhaustive closed-sum match — not a string-classifier. |
+| `dashboard-cascade.ts:72` | `'cli' \| 'ollama' \| 'other'` | Capability-bucket label union, mirrored on the OCaml backend (`server_routes_http_routes_cascade.ml:16`). Same rationale as above. |
+| `dashboard.ts:641,644` / `config-resolution-panel.ts:465` | `Ollama` / `ollama warm` | LLM serving framework references in operator-facing labels. |
+| `skeleton.ts:5` | `Lukew / Google Web Vitals` | Web-platform research citation (LCP/FID/CLS metric origin), not an LLM vendor. |
+| `components/common/keeper-identity.ts:15` | `llama` (in animal list) | False positive (animal). |
+
+The non-changes preserve operator-facing accuracy where the token is a real product name (Ollama as a serving framework) or non-LLM citation (Web Vitals).
+
+## 4. Verification
+
+- `rg -i 'kimi|anthropic|\bclaude\b|\bcodex\b' --glob '!*.test.ts' --glob '!*.test.tsx' dashboard/src/` returns only `CLAUDE.md` reference in `keeper-state-diagram.ts` (project instruction file name, intentionally kept).
+- `pnpm run typecheck` clean.
+- `dune build lib/ bin/` unchanged (no OCaml touched).
+
+## 5. Workaround-rejection self-check
+
+This RFC rewrites comments and one example string. It does not add code paths.
+
+1. "makes X visible" without fixing — NO.
+2. String/substring/prefix classifier added — NO.
+3. "PR #N fixed K of M sites" — NO (sweeps the entire 33-file common/ attribution roster + the dev-token example in one PR).
+4. catch-all `_ ->` added — NO.
+5. cap / cooldown / dedup / repair — NO.
+6. test backdoor — NO.
+7. typo / off-by-one repeated — NO.
+
+All 7 rejection signatures: NO.
+
+## 6. Out of scope (later sweeps)
+
+- `dashboard/src/**/*.test.ts` and `*.test.tsx` fixture strings (~49 files; mostly cosmetic asserts).
+- `test/` OCaml fixture strings (~210 files).
+- `dashboard/design-system/{audits,preview,SPEC.md}` historical references (~48 files).
+- `docs/` history references (~234 files).
+
+These are pure documentation / test-fixture sweeps with no code-path implications and are deferred to a later mass-sed pass.


### PR DESCRIPTION
## Summary

Closes the dashboard `common/*` JSDoc attribution surface from the
**RFC-0165 / 0166 / 0167 / 0168 client-agnostic family**. After this
PR, `rg -i 'kimi|anthropic|\bclaude\b|\bcodex\b' --glob '!*.test.*' dashboard/src/`
returns only the intentional `CLAUDE.md` project-instruction file name
reference.

Net: **34 files +102/-34 LoC** (1 file = new RFC doc).

## Changes

- **32 files in `dashboard/src/components/common/`**: rewrite header
  attribution `// Kimi design system secXX` / `// Kimi secXX` to
  `// MASC dashboard secXX` / `// MASC secXX`.
- **`agent-trust.ts`**: rephrase `Anthropic Constitutional AI-inspired`
  to vendor-agnostic `Constitutional-AI-style`.
- **`human-in-the-loop.ts`**: rephrase `Google AI Human-in-the-loop
  pattern` to `Human-in-the-loop UX pattern`.
- **`dev-token.ts:33`**: rewrite `"old codex paste/URL token"` example
  to `"old MCP-client paste/URL token"`.
- **`docs/rfc/RFC-0169-dashboard-common-attribution-purge.md`**: new.

## Intentionally kept (RFC-0169 §3)

| Surface | Token | Reason |
|---|---|---|
| `keeper-state-diagram.ts:76` | `CLAUDE.md` | Project instruction file name. Not a vendor. |
| `keeper-identity.ts:15` | `'llama'` | Animal name in keeper nickname pool. |
| `cascade-config-panel.ts:893` | `case 'ollama'` | LLM serving framework, exhaustive closed-sum. |
| `dashboard-cascade.ts:72` | `'cli' \| 'ollama' \| 'other'` | Capability-bucket union mirroring backend. |
| `dashboard.ts:641,644` / `config-resolution-panel.ts:465` | `Ollama` | LLM serving framework (operator-facing label). |
| `skeleton.ts:5` | `Lukew / Google Web Vitals` | Web-platform research citation, not LLM vendor. |

## Out of scope (RFC-0169 §6, later sweeps)

- `dashboard/src/**/*.test.ts` / `*.test.tsx` fixture strings (~49 files)
- `test/` OCaml fixture strings (~210 files)
- `dashboard/design-system/{audits,preview,SPEC.md}` history (~48 files)
- `docs/` history references (~234 files)

These are pure documentation / test-fixture mass-sed candidates with no
code-path implications.

## Workaround-rejection self-check (per software-development.md)

This PR rewrites comments and one example string. It does not add code paths.

| # | Signature | Verdict |
|---|---|---|
| 1 | makes X visible without fixing | NO |
| 2 | string/substring/prefix classifier added | NO |
| 3 | "PR #N fixed K of M sites" | NO (sweeps entire 33-file roster + dev-token in one PR) |
| 4 | catch-all `_ ->` added | NO |
| 5 | cap / cooldown / dedup / repair | NO |
| 6 | test backdoor | NO |
| 7 | typo / off-by-one repeated | NO |

All 7 rejection signatures: NO.

## Verification

- `pnpm run typecheck` — clean.
- `dune build lib/ bin/` — unchanged (no OCaml touched).
- `rg -i 'kimi|anthropic|\bclaude\b|\bcodex\b' --glob '!*.test.*' dashboard/src/` —
  returns only the intentional `CLAUDE.md` instruction-file reference.

## RFC-WAIVED

RFC-0169 included. PR scope is `dashboard/src/components/common/*` +
`dashboard/src/api/dev-token.ts` (comments only, no behavior). Does not
touch the auto-delegation gated subsystems (credential / keeper_gh /
host_config / repo_manager / operator_control / credential-settings /
keeper-repo-mapping / .claude/hooks / instructions/workflow).