### PR TITLE
fix(shell-ir): keep raw parsing behind command gate

### DIFF
--- a/lib/exec/command_gate/shell_command_gate.ml
+++ b/lib/exec/command_gate/shell_command_gate.ml
@@ -403,15 +403,24 @@ let parse_only_to_stages (parsed : SI.t PD.t) :
 let gate_typed ?caller:_ ~ir ~allowlist ~path_policy ~sandbox () : verdict =
   (* Typed callers have already crossed their schema boundary, so this
      entrypoint intentionally skips raw-string parsing while preserving
-     the same policy and verdict surface as [gate]. *)
+     the same policy and verdict surface as [gate_raw]. *)
   match parse_only_to_stages (PD.Parsed ir) with
   | Error (`Cannot_parse reason) -> Cannot_parse { reason }
   | Error (`Too_complex reason) -> Too_complex { reason }
   | Ok stages -> apply_policy ~allowlist ~path_policy ~sandbox ~stages
 ;;
 
+let gate_raw ?caller ~text ~allowlist ~path_policy ~sandbox () : verdict =
+  match Masc_exec_bash_parser.Bash.parse_string text with
+  | PD.Parsed ir -> gate_typed ?caller ~ir ~allowlist ~path_policy ~sandbox ()
+  | PD.Parse_error _ -> Cannot_parse { reason = Parse_error }
+  | PD.Parse_aborted reason -> Cannot_parse { reason = Parse_aborted reason }
+  | PD.Too_complex reason ->
+    Too_complex { reason = Unsupported_construct reason }
+;;
+
 let lower_typed_pipeline ?caller:_ ~stages ~sandbox () : verdict =
-  (* See note on [gate] — [caller] is API-shape-only for now. *)
+  (* See note on [gate_typed] — [caller] is API-shape-only for now. *)
   match stages with
   | [] -> Cannot_parse { reason = Parse_error }
   | _ ->

--- a/lib/exec/command_gate/shell_command_gate.mli
+++ b/lib/exec/command_gate/shell_command_gate.mli
@@ -13,8 +13,9 @@
     validation, and exit classification all share.
 
     The lib-root [Masc_mcp.Shell_command_gate] transition facade has
-    been retired. Callers that need shell policy verdicts use
-    [gate_typed] or [lower_typed_pipeline] directly.
+    been retired. Raw-string boundaries use [gate_raw] to cross into
+    Shell IR once; typed callers use [gate_typed] or
+    [lower_typed_pipeline] directly.
 
     Output verdict separates the four operational classes the Plan's
     Goal Tree distinguishes:
@@ -153,6 +154,19 @@ val gate_typed
     {!Masc_exec.Shell_ir.t}. This bypasses raw Bash parsing but shares
     the same allowlist, redirect, path-policy, sandbox, and nested
     pipeline handling as the legacy [gate] entrypoint. *)
+
+val gate_raw
+  :  ?caller:caller
+  -> text:string
+  -> allowlist:allowlist_policy
+  -> path_policy:path_policy
+  -> sandbox:sandbox_context
+  -> unit
+  -> verdict
+(** Raw-string entrypoint for shell frontends that have not yet crossed
+    the Shell IR boundary. Centralizing this parser call keeps
+    [Bash.parse_string] ownership inside this command-gate library
+    while preserving the same {!verdict} surface as {!gate_typed}. *)
 
 val lower_typed_pipeline
   :  ?caller:caller

--- a/lib/exec_policy.ml
+++ b/lib/exec_policy.ml
@@ -305,40 +305,33 @@ let command_context_with_allowlist ?caller ~allowed_commands cmd =
   if trimmed = ""
   then Error Empty_command
   else (
-    match Masc_exec_bash_parser.Bash.parse_string trimmed with
-    | (Masc_exec.Parsed.Parse_error _ | Masc_exec.Parsed.Parse_aborted _) ->
-      Error Chain_or_redirect
-    | Masc_exec.Parsed.Too_complex reason ->
-      Error (block_reason_of_exec_too_complex (Unsupported_construct reason))
-    | Masc_exec.Parsed.Parsed ir ->
-      let verdict =
-        Exec_shell_gate.gate_typed
-          ?caller
-          ~ir
-          ~allowlist:(strict_allowlist_policy ~allowed_commands)
-          ~path_policy:Exec_shell_gate.allow_all_paths
-          ~sandbox:Exec_shell_gate.host_sandbox
-          ()
-      in
-      match verdict with
-      | Allow context ->
-        if context.Exec_shell_gate.direct_dune_seen
-        then Error Direct_dune_invocation
-        else (
-          match validate_no_unquoted_glob context.Exec_shell_gate.ast with
-          | Error _ as err -> err
-          | Ok () ->
-            (match
-               validate_wrapped_stages ~allowed_commands context.Exec_shell_gate.ast
-             with
-             | Ok () -> Ok context
-             | Error _ as err -> err))
-      | Reject { context; reason; _ } ->
-        if context.Exec_shell_gate.direct_dune_seen
-        then Error Direct_dune_invocation
-        else Error (block_reason_of_exec_reject reason)
-      | Cannot_parse _ -> Error Chain_or_redirect
-      | Too_complex { reason } -> Error (block_reason_of_exec_too_complex reason))
+    match
+      Exec_shell_gate.gate_raw
+        ?caller
+        ~text:trimmed
+        ~allowlist:(strict_allowlist_policy ~allowed_commands)
+        ~path_policy:Exec_shell_gate.allow_all_paths
+        ~sandbox:Exec_shell_gate.host_sandbox
+        ()
+    with
+    | Allow context ->
+      if context.Exec_shell_gate.direct_dune_seen
+      then Error Direct_dune_invocation
+      else (
+        match validate_no_unquoted_glob context.Exec_shell_gate.ast with
+        | Error _ as err -> err
+        | Ok () ->
+          (match
+             validate_wrapped_stages ~allowed_commands context.Exec_shell_gate.ast
+           with
+           | Ok () -> Ok context
+           | Error _ as err -> err))
+    | Reject { context; reason; _ } ->
+      if context.Exec_shell_gate.direct_dune_seen
+      then Error Direct_dune_invocation
+      else Error (block_reason_of_exec_reject reason)
+    | Cannot_parse _ -> Error Chain_or_redirect
+    | Too_complex { reason } -> Error (block_reason_of_exec_too_complex reason))
 ;;
 
 let validate_command_with_allowlist ?caller ~allowed_commands cmd =
@@ -360,42 +353,35 @@ let command_context_coding_with_allowlist
   if trimmed = ""
   then Error Empty_command
   else (
-    match Masc_exec_bash_parser.Bash.parse_string trimmed with
-    | (Masc_exec.Parsed.Parse_error _ | Masc_exec.Parsed.Parse_aborted _) ->
-      Error Injection
-    | Masc_exec.Parsed.Too_complex reason ->
-      Error (block_reason_of_exec_too_complex (Unsupported_construct reason))
-    | Masc_exec.Parsed.Parsed ir ->
-      let verdict =
-        Exec_shell_gate.gate_typed
-          ?caller
-          ~ir
-          ~allowlist:(coding_allowlist_policy ~allow_pipes ~allowed_commands ())
-          ~path_policy:Exec_shell_gate.allow_all_paths
-          ~sandbox:Exec_shell_gate.host_sandbox
-          ()
-      in
-      match verdict with
-      | Allow context ->
-        if context.Exec_shell_gate.direct_dune_seen
-        then Error Direct_dune_invocation
-        else (
-          match validate_no_unquoted_glob context.Exec_shell_gate.ast with
-          | Error _ as err -> err
-          | Ok () ->
-            (match
-               validate_wrapped_stages ~allowed_commands context.Exec_shell_gate.ast
-             with
-             | Ok () -> Ok context
-             | Error _ as err -> err))
-      | Reject { context; reason; _ } ->
-        (match reason with
-         | Pipes_not_allowed _ -> Error Pipes_not_allowed
-         | _ when context.Exec_shell_gate.direct_dune_seen ->
-           Error Direct_dune_invocation
-         | _ -> Error (block_reason_of_exec_reject reason))
-      | Cannot_parse _ -> Error Injection
-      | Too_complex { reason } -> Error (block_reason_of_exec_too_complex reason))
+    match
+      Exec_shell_gate.gate_raw
+        ?caller
+        ~text:trimmed
+        ~allowlist:(coding_allowlist_policy ~allow_pipes ~allowed_commands ())
+        ~path_policy:Exec_shell_gate.allow_all_paths
+        ~sandbox:Exec_shell_gate.host_sandbox
+        ()
+    with
+    | Allow context ->
+      if context.Exec_shell_gate.direct_dune_seen
+      then Error Direct_dune_invocation
+      else (
+        match validate_no_unquoted_glob context.Exec_shell_gate.ast with
+        | Error _ as err -> err
+        | Ok () ->
+          (match
+             validate_wrapped_stages ~allowed_commands context.Exec_shell_gate.ast
+           with
+           | Ok () -> Ok context
+           | Error _ as err -> err))
+    | Reject { context; reason; _ } ->
+      (match reason with
+       | Pipes_not_allowed _ -> Error Pipes_not_allowed
+       | _ when context.Exec_shell_gate.direct_dune_seen ->
+         Error Direct_dune_invocation
+       | _ -> Error (block_reason_of_exec_reject reason))
+    | Cannot_parse _ -> Error Injection
+    | Too_complex { reason } -> Error (block_reason_of_exec_too_complex reason))
 ;;
 
 let validate_command_coding_with_allowlist ?caller ?allow_pipes ~allowed_commands cmd =

--- a/scripts/audit-shell-ir-consumption.sh
+++ b/scripts/audit-shell-ir-consumption.sh
@@ -119,7 +119,7 @@ g1_total_refs=$(count_code_refs "$g1_pattern")
 # `keeper_shell_command_semantics.mli`, the two `.mli` interfaces) have
 # been removed — re-add only if a future code-side call resurfaces.
 g1_allowed_files=(
-  "lib/exec_policy.ml"
+  "lib/exec/command_gate/shell_command_gate.ml"
   "lib/exec_policy_mutation_classifier.ml"
 )
 g1_current_files=$(list_code_files "$g1_pattern" \

--- a/scripts/shell-ir-consumption-baseline.json
+++ b/scripts/shell-ir-consumption-baseline.json
@@ -1,21 +1,21 @@
 {
   "schema": "shell-ir-consumption/v1",
-  "generated_at_unix": 1779604317,
+  "generated_at_unix": 1779608745,
   "g1_parse_string_caller_files_nontest": 2,
-  "g1_parse_string_total_refs_nontest": 8,
+  "g1_parse_string_total_refs_nontest": 7,
   "g2_classifier_string_sig": 0,
   "g2_classifier_ir_sig": 1,
   "g3_gate_typed_refs_in_keeper": 10,
   "g4_risk_in_simple": 0,
   "g4_phantom_envelope": 18,
   "g4_dispatch_decided_consumers": 7,
-  "g5_validate_paths_callers_nontest": 9,
+  "g5_validate_paths_callers_nontest": 10,
   "g6_tla_spec_exists": 1,
   "g7_shell_word_values_refs": 0,
   "g7_bash_words_stages_refs": 0,
   "g7_parallel_parser_total": 0,
   "info_ir_constructors_nontest": 62,
   "allowed_exceptions": {
-    "g1_parse_string": ["lib/exec_policy.ml","lib/exec_policy_mutation_classifier.ml"]
+    "g1_parse_string": ["lib/exec/command_gate/shell_command_gate.ml","lib/exec_policy_mutation_classifier.ml"]
   }
 }

--- a/test/test_exec_shell_command_gate.ml
+++ b/test/test_exec_shell_command_gate.ml
@@ -5,7 +5,7 @@
 
     This file exercises three contracts:
 
-    1. [Masc_exec_command_gate.Shell_command_gate.gate_typed] verdict shape
+    1. [Masc_exec_command_gate.Shell_command_gate.gate_raw] verdict shape
        matches what {!test/fixtures/shell_gate/baseline.jsonl}
        records for each corpus row (Phase 0 - baseline pin).
     2. [Masc_mcp.Worker_dev_tools.validate_command_coding_with_allowlist]
@@ -19,20 +19,11 @@
 
 module Gate = Masc_exec_command_gate.Shell_command_gate
 module W = Masc_mcp.Worker_dev_tools
-module PD = Masc_exec.Parsed
 
 let allowed = [ "rg"; "sort"; "head"; "wc"; "cat"; "git"; "ls"; "grep" ]
 
 let gate_from_raw ?caller ~raw ~allowlist ~path_policy ~sandbox () =
-  match Masc_exec_bash_parser.Bash.parse_string raw with
-  | PD.Parsed ir ->
-    Gate.gate_typed ?caller ~ir ~allowlist ~path_policy ~sandbox ()
-  | PD.Parse_error _ ->
-    Gate.Cannot_parse { reason = Gate.Parse_error }
-  | PD.Parse_aborted reason ->
-    Gate.Cannot_parse { reason = Gate.Parse_aborted reason }
-  | PD.Too_complex reason ->
-    Gate.Too_complex { reason = Gate.Unsupported_construct reason }
+  Gate.gate_raw ?caller ~text:raw ~allowlist ~path_policy ~sandbox ()
 let allowlist : Gate.allowlist_policy =
   { redirect_allowed = false; allowed_commands = allowed; allow_pipes = true }
 ;;


### PR DESCRIPTION
## Summary
- add a command-gate raw-string entrypoint so raw shell parsing stays inside Shell_command_gate
- route Exec_policy raw command validation through that entrypoint instead of calling Bash.parse_string directly
- align the RFC-0160 G1 exception list and baseline with the new parser ownership boundary

## Verification
- bash scripts/audit-shell-ir-consumption.sh --baseline scripts/shell-ir-consumption-baseline.json
- opam exec -- ocamlformat --check lib/exec/command_gate/shell_command_gate.ml lib/exec/command_gate/shell_command_gate.mli lib/exec_policy.ml test/test_exec_shell_command_gate.ml
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_exec_shell_command_gate.exe test/test_worker_dev_tools.exe
- ./_build/default/test/test_exec_shell_command_gate.exe
- ./_build/default/test/test_worker_dev_tools.exe
- git diff --check
- scripts/check-version-truth.sh