### PR TITLE
fix(test): use write_meta_with_retry to resolve CAS flake (#17231)

### DIFF
--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -2892,9 +2892,10 @@ proactive_enabled = true
       Alcotest.(check bool) "unknown active goal rejected" false ok;
       Alcotest.(check bool) "unknown active goal names surfaced" true
         (contains_substring msg "goal-missing");
-      (* Stop keepalive before direct write_meta to prevent CAS conflict.
-         The keepalive fiber bumps meta_version on each tick, racing with
-         the test's read-then-write cycle.  Issue #17231. *)
+      (* Stop keepalive before write_meta_with_retry to reduce CAS retries.
+         The keepalive fiber bumps meta_version on each tick; using
+         write_meta_with_retry resolves the flake by automatically retrying
+         on version conflict.  Issue #17231. *)
       Keeper_keepalive.stop_keepalive keeper_name;
       let meta = read_keeper_meta_exn config keeper_name in
       let mutated =
@@ -2922,7 +2923,7 @@ proactive_enabled = true
           updated_at = Masc_domain.now_iso ();
         }
       in
-      (match Masc_mcp.Keeper_types.write_meta config mutated with
+      (match Masc_mcp.Keeper_types.write_meta_with_retry config mutated with
       | Ok () -> ()
       | Error err -> Alcotest.fail ("meta write failed: " ^ err));
       let status, json =


### PR DESCRIPTION
## Summary
- Replace `write_meta` with `write_meta_with_retry` in `test_operator_control_keeper.ml` to fix CAS (compare-and-swap) flake
- The retry wrapper handles concurrent meta writes that cause intermittent test failures

## Test plan
- [x] Existing test suite passes with retry wrapper

Closes #17231

🤖 Generated with [Claude Code](https://claude.com/claude-code)