### PR TITLE
refactor(keeper): route shell reads through sandbox read runner

### DIFF
--- a/docs/design/keeper-tool-runtime-boundary-plan.html
+++ b/docs/design/keeper-tool-runtime-boundary-plan.html
@@ -274,7 +274,7 @@
           <span>Combined LOC across main hot files and new sandbox helper modules</span>
         </div>
       </div>
-      <p class="note">Slice 1 removes source-level references to <code>Keeper_shell_docker</code>, <code>Keeper_shell_docker_exec_failure</code>, and <code>Keeper_shell_bash_docker</code>. Slice 2 removes the legacy <code>Keeper_shell_shared.run_docker*</code> boundary and routes PR/GitHub tool execution through <code>Keeper_sandbox_runner</code>. Slice 3 moves <code>keeper_shell op=gh</code> compatibility execution into <code>Keeper_shell_gh_bridge</code>. Slice 4 moves <code>keeper_shell op=git_clone</code> compatibility execution into <code>Keeper_shell_git_bridge</code>. Slice 5 makes <code>Keeper_sandbox_runner</code> own route labels for bridge result shaping. Bridge tests use injected mock runners.</p>
+      <p class="note">Slice 1 removes source-level references to <code>Keeper_shell_docker</code>, <code>Keeper_shell_docker_exec_failure</code>, and <code>Keeper_shell_bash_docker</code>. Slice 2 removes the legacy <code>Keeper_shell_shared.run_docker*</code> boundary and routes PR/GitHub tool execution through <code>Keeper_sandbox_runner</code>. Slice 3 moves <code>keeper_shell op=gh</code> compatibility execution into <code>Keeper_shell_gh_bridge</code>. Slice 4 moves <code>keeper_shell op=git_clone</code> compatibility execution into <code>Keeper_shell_git_bridge</code>. Slice 5 makes <code>Keeper_sandbox_runner</code> own route labels for bridge result shaping. Slice 6 moves read-side sandbox execution behind <code>Keeper_sandbox_read_runner</code>. Bridge and runner tests use injected mock runners.</p>
     </section>
 
     <section>
@@ -312,6 +312,12 @@
             <td data-label="Goal">Make Local and Docker command failures share one semantic result shape.</td>
             <td data-label="Quantitative Gate">Golden tests show identical semantic fields for matched Local/Docker failures, with backend details only in optional evidence fields.</td>
             <td data-label="Status"><span class="status next">Started in slice 5</span></td>
+          </tr>
+          <tr>
+            <td data-label="ID">G5</td>
+            <td data-label="Goal">Keep structured shell read ops out of concrete Docker backend selection.</td>
+            <td data-label="Quantitative Gate"><code>keeper_shell_ops.ml</code> has <code>0</code> direct <code>Keeper_docker_read</code> calls and <code>0</code> bridge-local <code>via=docker</code> literals.</td>
+            <td data-label="Status"><span class="status next">Started in slice 6</span></td>
           </tr>
         </tbody>
       </table>
@@ -361,9 +367,9 @@
           <tr>
             <td data-label="Task">T5</td>
             <td data-label="Goal">Guardrails</td>
-            <td data-label="Todo">Extend source-level boundary tests to prevent tool-surface names and hard-coded Docker route labels from returning to tool bridges.</td>
-            <td data-label="Verification Method"><code>./_build/default/test/test_keeper_sandbox_boundary_policy.exe</code></td>
-            <td data-label="Exit Criteria">Test fails on new <code>shell_docker</code>/<code>shell_bash</code> sandbox helpers or bridge-local <code>via=docker</code> shaping.</td>
+            <td data-label="Todo">Extend source-level boundary tests to prevent tool-surface names, direct Docker-read backend calls, and hard-coded Docker route labels from returning to tool bridges.</td>
+            <td data-label="Verification Method"><code>./_build/default/test/test_keeper_sandbox_boundary_policy.exe</code>, <code>./_build/default/test/test_keeper_sandbox_read_runner.exe</code></td>
+            <td data-label="Exit Criteria">Test fails on new <code>shell_docker</code>/<code>shell_bash</code> sandbox helpers, direct <code>Keeper_docker_read</code> use from <code>keeper_shell_ops.ml</code>, or bridge-local <code>via=docker</code> shaping.</td>
           </tr>
         </tbody>
       </table>
@@ -376,9 +382,11 @@
         <div class="command">scripts/dune-local.sh build test/test_keeper_sandbox_boundary_policy.exe test/test_keeper_sandbox_runner.exe test/test_keeper_sandbox_docker_route.exe</div>
         <div class="command">./_build/default/test/test_keeper_sandbox_boundary_policy.exe</div>
         <div class="command">./_build/default/test/test_keeper_sandbox_runner.exe</div>
+        <div class="command">./_build/default/test/test_keeper_sandbox_read_runner.exe</div>
         <div class="command">./_build/default/test/test_keeper_shell_gh_bridge.exe</div>
         <div class="command">./_build/default/test/test_keeper_shell_git_bridge.exe</div>
         <div class="command">rg -n "&quot;via&quot;, `String &quot;docker&quot;" lib/keeper/keeper_shell_gh_bridge.ml lib/keeper/keeper_shell_git_bridge.ml</div>
+        <div class="command">rg -n "Keeper_docker_read\\.|&quot;via&quot;, `String &quot;docker&quot;" lib/keeper/keeper_shell_ops.ml</div>
         <div class="command">./_build/default/test/test_keeper_sandbox_docker_route.exe test docker_route_fires 17-21 --show-errors --compact</div>
         <div class="command">rg -n "Keeper_shell_docker|Keeper_shell_docker_exec_failure|Keeper_shell_bash_docker|keeper_shell_docker|keeper_shell_docker_exec_failure|keeper_shell_bash_docker" lib/keeper</div>
         <div class="command">rg -n "Keeper_sandbox_docker\\.run_|Keeper_shell_shared\\.run_docker" lib/keeper</div>

--- a/docs/design/keeper-tool-runtime-boundary-plan.md
+++ b/docs/design/keeper-tool-runtime-boundary-plan.md
@@ -74,6 +74,16 @@ and public tool aliases.
 
 5. Tighten boundary tests so new modules cannot reintroduce
    `shell_docker` or `shell_bash` names for sandbox-runtime concerns.
+   Started in slice 6:
+   - `Keeper_sandbox_read_runner` now hides Docker-routed read execution
+     behind a backend-neutral facade.
+   - `keeper_shell_ops.ml` no longer calls `Keeper_docker_read`
+     directly and uses runner-owned backend route labels for read
+     responses.
+   - `test_keeper_sandbox_read_runner` uses an injected mock backend to
+     pin the read facade without invoking Docker.
+   - `test_keeper_sandbox_boundary_policy` now fails if structured shell
+     read ops reselect `Keeper_docker_read` or hard-code `via=docker`.
 
 ## Verification
 
@@ -95,3 +105,7 @@ and public tool aliases.
   scripts name retired `keeper_shell_docker` files.
 - The boundary test now fails if gh/git compatibility bridges hard-code
   Docker route labels instead of asking `Keeper_sandbox_runner`.
+- The boundary test now fails if structured shell read ops call
+  `Keeper_docker_read` directly instead of `Keeper_sandbox_read_runner`.
+- `test_keeper_sandbox_read_runner` verifies facade delegation with a
+  mock backend and route labels sourced from `Keeper_sandbox_runner`.

--- a/lib/dune
+++ b/lib/dune
@@ -296,6 +296,7 @@
   keeper_sandbox_containment
   keeper_sandbox_runtime
   keeper_docker_read
+  keeper_sandbox_read_runner
   ;; tool_local_runtime sub-modules
   tool_local_runtime_http
   tool_local_runtime_verify

--- a/lib/keeper/keeper_sandbox_read_runner.ml
+++ b/lib/keeper/keeper_sandbox_read_runner.ml
@@ -1,0 +1,108 @@
+module type Backend = sig
+  val should_route_read : meta:Keeper_types.keeper_meta -> bool
+
+  val container_path_of_host :
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    host_path:string ->
+    (string, string) result
+
+  val read_file_in_container :
+    ?turn_sandbox_factory:Keeper_sandbox_factory.t ->
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    host_path:string ->
+    max_bytes:int ->
+    timeout_sec:float ->
+    unit ->
+    (string, string) result
+
+  val run_command_in_container_with_status :
+    ?turn_sandbox_factory:Keeper_sandbox_factory.t ->
+    ?ok_exit_codes:int list ->
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    command_argv:string list ->
+    max_bytes:int ->
+    timeout_sec:float ->
+    unit ->
+    (Unix.process_status * string, string) result
+
+  val run_command_in_container :
+    ?turn_sandbox_factory:Keeper_sandbox_factory.t ->
+    ?ok_exit_codes:int list ->
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    command_argv:string list ->
+    max_bytes:int ->
+    timeout_sec:float ->
+    unit ->
+    (string, string) result
+end
+
+module type S = sig
+  val host_via : string
+  val backend_via : string
+  val should_route_read : meta:Keeper_types.keeper_meta -> bool
+
+  val container_path_of_host :
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    host_path:string ->
+    (string, string) result
+
+  val read_file :
+    ?turn_sandbox_factory:Keeper_sandbox_factory.t ->
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    host_path:string ->
+    max_bytes:int ->
+    timeout_sec:float ->
+    unit ->
+    (string, string) result
+
+  val run_command_with_status :
+    ?turn_sandbox_factory:Keeper_sandbox_factory.t ->
+    ?ok_exit_codes:int list ->
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    command_argv:string list ->
+    max_bytes:int ->
+    timeout_sec:float ->
+    unit ->
+    (Unix.process_status * string, string) result
+
+  val run_command :
+    ?turn_sandbox_factory:Keeper_sandbox_factory.t ->
+    ?ok_exit_codes:int list ->
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    command_argv:string list ->
+    max_bytes:int ->
+    timeout_sec:float ->
+    unit ->
+    (string, string) result
+end
+
+module Make (Backend : Backend) = struct
+  let host_via = Keeper_sandbox_runner.route_label Keeper_sandbox_runner.Host
+  let backend_via =
+    Keeper_sandbox_runner.route_label Keeper_sandbox_runner.Sandbox_backend
+
+  let should_route_read = Backend.should_route_read
+  let container_path_of_host = Backend.container_path_of_host
+  let read_file = Backend.read_file_in_container
+  let run_command_with_status = Backend.run_command_in_container_with_status
+  let run_command = Backend.run_command_in_container
+end
+
+module Docker_backend = struct
+  let should_route_read = Keeper_docker_read.should_route_read
+  let container_path_of_host = Keeper_docker_read.container_path_of_host
+  let read_file_in_container = Keeper_docker_read.read_file_in_container
+  let run_command_in_container_with_status =
+    Keeper_docker_read.run_command_in_container_with_status
+  let run_command_in_container = Keeper_docker_read.run_command_in_container
+end
+
+include Make (Docker_backend)

--- a/lib/keeper/keeper_sandbox_read_runner.mli
+++ b/lib/keeper/keeper_sandbox_read_runner.mli
@@ -1,0 +1,94 @@
+(** Backend-neutral runner for keeper read-side sandbox execution.
+
+    Structured keeper shell operations should depend on this facade instead of
+    directly selecting the concrete Docker read backend. *)
+
+module type Backend = sig
+  val should_route_read : meta:Keeper_types.keeper_meta -> bool
+
+  val container_path_of_host :
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    host_path:string ->
+    (string, string) result
+
+  val read_file_in_container :
+    ?turn_sandbox_factory:Keeper_sandbox_factory.t ->
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    host_path:string ->
+    max_bytes:int ->
+    timeout_sec:float ->
+    unit ->
+    (string, string) result
+
+  val run_command_in_container_with_status :
+    ?turn_sandbox_factory:Keeper_sandbox_factory.t ->
+    ?ok_exit_codes:int list ->
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    command_argv:string list ->
+    max_bytes:int ->
+    timeout_sec:float ->
+    unit ->
+    (Unix.process_status * string, string) result
+
+  val run_command_in_container :
+    ?turn_sandbox_factory:Keeper_sandbox_factory.t ->
+    ?ok_exit_codes:int list ->
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    command_argv:string list ->
+    max_bytes:int ->
+    timeout_sec:float ->
+    unit ->
+    (string, string) result
+end
+
+module type S = sig
+  val host_via : string
+  val backend_via : string
+  val should_route_read : meta:Keeper_types.keeper_meta -> bool
+
+  val container_path_of_host :
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    host_path:string ->
+    (string, string) result
+
+  val read_file :
+    ?turn_sandbox_factory:Keeper_sandbox_factory.t ->
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    host_path:string ->
+    max_bytes:int ->
+    timeout_sec:float ->
+    unit ->
+    (string, string) result
+
+  val run_command_with_status :
+    ?turn_sandbox_factory:Keeper_sandbox_factory.t ->
+    ?ok_exit_codes:int list ->
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    command_argv:string list ->
+    max_bytes:int ->
+    timeout_sec:float ->
+    unit ->
+    (Unix.process_status * string, string) result
+
+  val run_command :
+    ?turn_sandbox_factory:Keeper_sandbox_factory.t ->
+    ?ok_exit_codes:int list ->
+    config:Coord.config ->
+    meta:Keeper_types.keeper_meta ->
+    command_argv:string list ->
+    max_bytes:int ->
+    timeout_sec:float ->
+    unit ->
+    (string, string) result
+end
+
+module Make : functor (Backend : Backend) -> S
+
+include S

--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -71,8 +71,8 @@ let handle_keeper_shell
   in
   let root = Keeper_alerting_path.project_root_of_config config in
   let raw_path = Safe_ops.json_string ~default:"" "path" args |> String.trim in
-  (* RFC-0006 Phase B-1.5: pin host-FS read guard for Docker keeper
-     shell read ops. Local keepers remain on the host path. *)
+  (* RFC-0006 Phase B-1.5: pin host-FS read guard for sandbox-backed
+     keeper shell read ops. Host-backed keepers remain on the host path. *)
   let containment_check target =
     Keeper_sandbox_containment.check_read_target ~config ~meta ~target
   in
@@ -149,7 +149,7 @@ let handle_keeper_shell
                | None -> `Null );
              (* host execution path: route discriminator must be present so
                 the dashboard / LLM cannot mistake a host-side run for a
-                docker-sandboxed run (#11080 sibling sweep). *)
+                sandbox-backed run (#11080 sibling sweep). *)
              "via", `String "host";
            ] @ insight_extra)
          ~status:st
@@ -186,9 +186,9 @@ let handle_keeper_shell
           List.map Masc_exec.Bash_history.failure_pattern_to_json patterns)
       ]
     in
-    (* Caller-supplied [extra] may already declare ["via"] (e.g. wc docker
+    (* Caller-supplied [extra] may already declare ["via"] (e.g. wc backend
        branch); only inject the default ["via", "host"] when absent so the
-       docker route's explicit ["via", "docker"] still wins. *)
+       backend route's explicit route label still wins. *)
     let extra_with_via =
       if List.exists (fun (k, _) -> k = "via") extra then extra
       else ("via", `String "host") :: extra
@@ -211,23 +211,23 @@ let handle_keeper_shell
          ~output:out
          ())
   in
-  let docker_read_error ~target msg =
+  let sandbox_read_error ~target msg =
     error_json ~fields:[ "op", `String op; "path", `String target ] msg
   in
   let hostify_turn_runtime_output out =
     Keeper_shell_shared.rewrite_turn_runtime_paths_to_host ~config ~meta out
   in
-  let run_readonly_in_docker ?(ok_exit_codes = [ 0 ]) ~target ~command_argv
+  let run_readonly_in_sandbox ?(ok_exit_codes = [ 0 ]) ~target ~command_argv
       ~max_bytes ~timeout_sec () =
     let max_eintr_retries = 8 in
     let rec loop attempts_left =
       match
-        Keeper_docker_read.container_path_of_host ~config ~meta ~host_path:target
+        Keeper_sandbox_read_runner.container_path_of_host ~config ~meta ~host_path:target
       with
-      | Error e -> Error (docker_read_error ~target e)
+      | Error e -> Error (sandbox_read_error ~target e)
       | Ok cpath -> (
           match
-            Keeper_docker_read.run_command_in_container_with_status
+            Keeper_sandbox_read_runner.run_command_with_status
               ?turn_sandbox_factory
               ~ok_exit_codes ~config ~meta ~command_argv:(command_argv cpath)
               ~max_bytes ~timeout_sec ()
@@ -237,7 +237,7 @@ let handle_keeper_shell
                  && String_util.contains_substring_ci msg
                       "interrupted system call" ->
               loop (attempts_left - 1)
-          | Error msg -> Error (docker_read_error ~target msg)
+          | Error msg -> Error (sandbox_read_error ~target msg)
           | Ok payload -> Ok payload)
     in
     loop max_eintr_retries
@@ -258,15 +258,15 @@ let handle_keeper_shell
     | None ->
       render_process_result ~cwd ~cmd command_argv
   in
-  let render_docker_process_result ~cwd ~cmd ~docker_cmd ~timeout_sec =
+  let render_sandbox_process_result ~cwd ~cmd ~backend_cmd ~timeout_sec =
     match
       Keeper_sandbox_runner.run_shell_command_with_status ~config ~meta ~cwd ~timeout_sec
-        ~cmd:docker_cmd ~git_creds_enabled:false ~network_mode:Network_none
+        ~cmd:backend_cmd ~git_creds_enabled:false ~network_mode:Network_none
     with
     | Error msg -> error_json ~fields:[ "op", `String op; "cwd", `String cwd ] msg
     | Ok result ->
-      (* PR #11080 sibling sweep: this helper always routes through
-         docker exec, so the LLM-facing [cwd] field must hold the
+      (* PR #11080 sibling sweep: this helper always routes through the
+         sandbox backend, so the LLM-facing [cwd] field must hold the
          in-container path.  Operator-side log fields above keep the
          host path. *)
       let cwd_response =
@@ -286,25 +286,25 @@ let handle_keeper_shell
                "op", `String op;
                "cmd", `String cmd;
                "cwd", Keeper_cwd_response.to_yojson_response cwd_response;
-               "via", `String "docker";
+               "via", `String Keeper_sandbox_read_runner.backend_via;
              ]
            ~status:result.status
            ~output:result.output
            ())
   in
-  let docker_git_log_path host_path =
+  let sandbox_git_log_path host_path =
     if String.trim host_path = "" then Ok ""
     else if Filename.is_relative host_path then Ok host_path
     else
-      Keeper_docker_read.container_path_of_host ~config ~meta ~host_path
+      Keeper_sandbox_read_runner.container_path_of_host ~config ~meta ~host_path
   in
   match op with
   | "pwd" ->
     (match cwd_target () with
      | Error e -> path_error e
      | Ok cwd ->
-       if Keeper_docker_read.should_route_read ~meta then
-         render_docker_process_result ~cwd ~cmd:"pwd" ~docker_cmd:"pwd"
+       if Keeper_sandbox_read_runner.should_route_read ~meta then
+         render_sandbox_process_result ~cwd ~cmd:"pwd" ~backend_cmd:"pwd"
            ~timeout_sec:Keeper_shell_shared.io_timeout_sec
        else
          run_in_turn_runtime ~cwd ~cmd:"pwd" ~command_argv:[ coreutils.pwd ]
@@ -314,10 +314,10 @@ let handle_keeper_shell
     (match cwd_target () with
      | Error e -> path_error e
      | Ok cwd ->
-       if Keeper_docker_read.should_route_read ~meta then
-         render_docker_process_result ~cwd
+       if Keeper_sandbox_read_runner.should_route_read ~meta then
+         render_sandbox_process_result ~cwd
            ~cmd:"git -C <cwd> --no-optional-locks status --short --branch"
-           ~docker_cmd:"git --no-optional-locks status --short --branch"
+           ~backend_cmd:"git --no-optional-locks status --short --branch"
            ~timeout_sec:Keeper_shell_shared.read_timeout_sec
        else
          (* P11: Host git_status via Shell IR pipeline.
@@ -389,13 +389,13 @@ let handle_keeper_shell
      | Error e -> path_error e
      | Ok target ->
        let limit = shell_readonly_limit args in
-       (* RFC-0006 Phase B-3b: Docker keepers route ls through the same
-          docker prelude as keeper_fs_read so the container's mount is
-          the load-bearing isolation. The host-side containment guard
-          above remains as defense in depth. *)
-       if Keeper_docker_read.should_route_read ~meta then
+       (* RFC-0006 Phase B-3b: sandbox-backed keepers route ls through
+          the same backend read prelude as keeper_fs_read so the backend
+          mount is the load-bearing isolation. The host-side containment
+          guard above remains as defense in depth. *)
+       if Keeper_sandbox_read_runner.should_route_read ~meta then
          (match
-            Keeper_docker_read.container_path_of_host ~config ~meta
+            Keeper_sandbox_read_runner.container_path_of_host ~config ~meta
               ~host_path:target
           with
           | Error e ->
@@ -403,7 +403,7 @@ let handle_keeper_shell
               ~fields:[ "op", `String op; "path", `String target ] e
           | Ok cpath ->
             (match
-               Keeper_docker_read.run_command_in_container
+               Keeper_sandbox_read_runner.run_command
                  ?turn_sandbox_factory ~config ~meta
                  ~command_argv:[ "ls"; "-la"; cpath ]
                  ~max_bytes:1_000_000
@@ -419,14 +419,13 @@ let handle_keeper_shell
                      [ "ok", `Bool true
                      ; "op", `String op
                      ; "path", `String target
-                     ; "via", `String "docker"
+                     ; "via", `String Keeper_sandbox_read_runner.backend_via
                      ; "entries", lines_to_json ~limit out
                      ])))
        else
-         (* P10: Host ls via Shell IR pipeline. Docker path preserved
-            above because Sandbox_target.docker runner semantics
-            (fresh vs reuse, container_path_of_host) differ from
-            Keeper_docker_read. *)
+         (* P10: Host ls via Shell IR pipeline. Sandbox-backend read path
+            preserved above because backend runner semantics (fresh vs reuse,
+            container_path_of_host) differ from host dispatch. *)
          let dispatch_sandbox = Masc_exec.Sandbox_target.host () in
          let ir =
            Masc_exec.Shell_ir.Simple
@@ -499,13 +498,11 @@ let handle_keeper_shell
         | Error e -> path_error e
         | Ok target ->
           let max_bytes = shell_readonly_cat_max_bytes args in
-       (* RFC-0006 Phase B-3b: docker route via the existing
-          read_file_in_container helper (which is already a [cat]
-          wrapper around run_command_in_container). Symmetry with
-          keeper_fs_read's [via: "docker"] response field. *)
-       if Keeper_docker_read.should_route_read ~meta then
+       (* RFC-0006 Phase B-3b: sandbox-backend route via the read-file helper.
+          Symmetry with keeper_fs_read's backend response field. *)
+       if Keeper_sandbox_read_runner.should_route_read ~meta then
          (match
-            Keeper_docker_read.read_file_in_container
+            Keeper_sandbox_read_runner.read_file
               ?turn_sandbox_factory ~config ~meta
               ~host_path:target ~max_bytes
               ~timeout_sec:Keeper_shell_shared.read_timeout_sec
@@ -522,13 +519,13 @@ let handle_keeper_shell
                   [ "ok", `Bool true
                   ; "op", `String op
                   ; "path", `String target
-                  ; "via", `String "docker"
+                  ; "via", `String Keeper_sandbox_read_runner.backend_via
                   ; "bytes", `Int total
                   ; "truncated", `Bool truncated
                   ; "content", `String body
                   ]))
        else
-         (* P11: Host cat via Shell IR pipeline. Docker path preserved
+         (* P11: Host cat via Shell IR pipeline. Backend read path preserved
             above per RFC-0006 Phase B-3b. *)
          let dispatch_sandbox = Masc_exec.Sandbox_target.host () in
          let ir =
@@ -610,12 +607,12 @@ let handle_keeper_shell
         let file_type = Safe_ops.json_string ~default:"" "type" args |> String.trim in
         (* Optional glob filter (e.g. "*.ml", "lib/**/*.ml") *)
         let glob = Safe_ops.json_string ~default:"" "glob" args |> String.trim in
-        if Keeper_docker_read.should_route_read ~meta then
+        if Keeper_sandbox_read_runner.should_route_read ~meta then
           let base_argv = [ "rg"; "-n"; "-m"; string_of_int limit ] in
           let type_argv = if file_type <> "" then [ "--type"; file_type ] else [] in
           let glob_argv = if glob <> "" then [ "--glob"; glob ] else [] in
           (match
-             run_readonly_in_docker ~target
+             run_readonly_in_sandbox ~target
                ~command_argv:(fun cpath ->
                  base_argv @ type_argv @ glob_argv @ [ pattern; cpath ])
                ~ok_exit_codes:[ 0; 1 ]
@@ -631,7 +628,7 @@ let handle_keeper_shell
                    ; "op", `String op
                    ; "path", `String target
                    ; "pattern", `String pattern
-                   ; "via", `String "docker"
+                   ; "via", `String Keeper_sandbox_read_runner.backend_via
                    ; "status", Keeper_alerting_path.process_status_to_json st
                    ; "matches", lines_to_json ~limit out
                    ]))
@@ -754,28 +751,28 @@ let handle_keeper_shell
        let format = Safe_ops.json_string ~default:"%h %s" "format" args in
        let file_path = Safe_ops.json_string ~default:"" "path" args |> String.trim in
        let grep = Safe_ops.json_string ~default:"" "grep" args |> String.trim in
-       if Keeper_docker_read.should_route_read ~meta then
-         (match docker_git_log_path file_path with
+       if Keeper_sandbox_read_runner.should_route_read ~meta then
+         (match sandbox_git_log_path file_path with
           | Error err ->
             error_json
               ~fields:
                 [ "op", `String op; "cwd", `String cwd; "path", `String file_path ]
               err
-          | Ok docker_file_path ->
-            let docker_cmd =
+          | Ok backend_file_path ->
+            let backend_cmd =
               let base =
                 Printf.sprintf "git --no-optional-locks log --format=%s -%d%s"
                   (Filename.quote format) count
                   (if grep = "" then "" else " --grep=" ^ Filename.quote grep)
               in
-              if docker_file_path = "" then
+              if backend_file_path = "" then
                 base
               else
-                Printf.sprintf "%s -- %s" base (Filename.quote docker_file_path)
+                Printf.sprintf "%s -- %s" base (Filename.quote backend_file_path)
             in
-            render_docker_process_result ~cwd
+            render_sandbox_process_result ~cwd
               ~cmd:"git -C <cwd> --no-optional-locks log --format=<fmt> -<n>"
-              ~docker_cmd ~timeout_sec:Keeper_shell_shared.read_timeout_sec)
+              ~backend_cmd ~timeout_sec:Keeper_shell_shared.read_timeout_sec)
        else
          (match Keeper_sandbox_factory.resolve_opt turn_sandbox_factory ~cwd with
           | Some runtime ->
@@ -814,9 +811,9 @@ let handle_keeper_shell
                error_json
                  ~fields:[ "op", `String op; "cwd", `String cwd ] msg
              | Ok (st, out) ->
-               (* PR #11080 sibling sweep: docker-route response — use
-                  the in-container cwd to keep the LLM aligned with the
-                  actual exec environment. *)
+               (* PR #11080 sibling sweep: backend-route response uses the
+                  runtime cwd to keep the LLM aligned with the actual exec
+                  environment. *)
                let cwd_response =
                  Keeper_cwd_response.docker ~host_cwd:cwd
                    ~container_cwd:
@@ -830,7 +827,7 @@ let handle_keeper_shell
                      ; "cwd", Keeper_cwd_response.to_yojson_response cwd_response
                      ; "count", `Int count
                      ; "grep", `String grep
-                     ; "via", `String "docker"
+                     ; "via", `String Keeper_sandbox_read_runner.backend_via
                      ; "status", Keeper_alerting_path.process_status_to_json st
                      ; "entries", lines_to_json ~limit:50 out
                      ]))
@@ -930,9 +927,9 @@ let handle_keeper_shell
       | Error e -> path_error e
       | Ok target ->
         let limit = shell_readonly_limit args in
-        if Keeper_docker_read.should_route_read ~meta then
+        if Keeper_sandbox_read_runner.should_route_read ~meta then
           (match
-             run_readonly_in_docker ~target
+             run_readonly_in_sandbox ~target
                ~command_argv:(fun cpath ->
                  [ "find"; cpath; "-maxdepth"; "5"; "-name"; name_pattern;
                    "-not"; "-path"; "*/.git/*";
@@ -950,7 +947,7 @@ let handle_keeper_shell
                    ; "op", `String op
                    ; "path", `String target
                    ; "name", `String name_pattern
-                   ; "via", `String "docker"
+                   ; "via", `String Keeper_sandbox_read_runner.backend_via
                    ; "status", Keeper_alerting_path.process_status_to_json st
                    ; "files", lines_to_json ~limit out
                    ]))
@@ -977,9 +974,9 @@ let handle_keeper_shell
      | Error e -> path_error e
      | Ok target ->
        let n = Safe_ops.json_int ~default:20 "lines" args |> fun v -> max 1 (min 200 v) in
-       if Keeper_docker_read.should_route_read ~meta then
+       if Keeper_sandbox_read_runner.should_route_read ~meta then
          (match
-            run_readonly_in_docker ~target
+            run_readonly_in_sandbox ~target
               ~command_argv:(fun cpath ->
                 [ "head"; "-n"; string_of_int n; cpath ])
               ~max_bytes:1_000_000
@@ -994,7 +991,7 @@ let handle_keeper_shell
                   ; "op", `String op
                   ; "path", `String target
                   ; "lines", `Int n
-                  ; "via", `String "docker"
+                  ; "via", `String Keeper_sandbox_read_runner.backend_via
                   ; "status", Keeper_alerting_path.process_status_to_json st
                   ; "content", `String out
                   ]))
@@ -1018,9 +1015,9 @@ let handle_keeper_shell
      | Error e -> path_error e
      | Ok target ->
        let n = Safe_ops.json_int ~default:20 "lines" args |> fun v -> max 1 (min 200 v) in
-       if Keeper_docker_read.should_route_read ~meta then
+       if Keeper_sandbox_read_runner.should_route_read ~meta then
          (match
-            run_readonly_in_docker ~target
+            run_readonly_in_sandbox ~target
               ~command_argv:(fun cpath ->
                 [ "tail"; "-n"; string_of_int n; cpath ])
               ~max_bytes:1_000_000
@@ -1035,7 +1032,7 @@ let handle_keeper_shell
                   ; "op", `String op
                   ; "path", `String target
                   ; "lines", `Int n
-                  ; "via", `String "docker"
+                  ; "via", `String Keeper_sandbox_read_runner.backend_via
                   ; "status", Keeper_alerting_path.process_status_to_json st
                   ; "content", `String out
                   ]))
@@ -1058,9 +1055,9 @@ let handle_keeper_shell
     (match read_target () with
      | Error e -> path_error e
      | Ok target ->
-       if Keeper_docker_read.should_route_read ~meta then
+       if Keeper_sandbox_read_runner.should_route_read ~meta then
          (match
-            run_readonly_in_docker ~target
+            run_readonly_in_sandbox ~target
               ~command_argv:(fun cpath -> [ "wc"; "-l"; cpath ])
               ~max_bytes:4096
               ~timeout_sec:Keeper_shell_shared.read_timeout_sec
@@ -1080,7 +1077,7 @@ let handle_keeper_shell
                      "cmd", `String "wc";
                      "cwd", `Null;
                      "path", `String target;
-                     "via", `String "docker";
+                     "via", `String Keeper_sandbox_read_runner.backend_via;
                    ]
                  ~status:st
                  ~output:out
@@ -1092,9 +1089,9 @@ let handle_keeper_shell
      | Error e -> path_error e
      | Ok target ->
        let limit = shell_readonly_limit args in
-       if Keeper_docker_read.should_route_read ~meta then
+       if Keeper_sandbox_read_runner.should_route_read ~meta then
          (match
-            run_readonly_in_docker ~target
+            run_readonly_in_sandbox ~target
               ~command_argv:(fun cpath ->
                 [ "find"; cpath; "-maxdepth"; "3"; "-print";
                   "-not"; "-path"; "*/.git/*";
@@ -1110,7 +1107,7 @@ let handle_keeper_shell
                    [ "ok", `Bool true
                    ; "op", `String op
                    ; "path", `String target
-                   ; "via", `String "docker"
+                   ; "via", `String Keeper_sandbox_read_runner.backend_via
                    ; "status", Keeper_alerting_path.process_status_to_json st
                    ; "entries", lines_to_json ~limit out
                    ]))

--- a/test/dune
+++ b/test/dune
@@ -245,6 +245,7 @@
   test_keeper_tool_alias
   test_keeper_sandbox_containment
   test_keeper_sandbox_runner
+  test_keeper_sandbox_read_runner
   test_keeper_shell_gh_bridge
   test_keeper_shell_git_bridge
   test_keeper_transition_audit
@@ -571,6 +572,7 @@
   test_keeper_tool_alias
   test_keeper_sandbox_containment
   test_keeper_sandbox_runner
+  test_keeper_sandbox_read_runner
   test_keeper_shell_gh_bridge
   test_keeper_shell_git_bridge
   test_keeper_transition_audit

--- a/test/test_keeper_exec_shell_cwd_response.ml
+++ b/test/test_keeper_exec_shell_cwd_response.ml
@@ -1,10 +1,10 @@
 (** Integration pin for PR-3 of the [Keeper_cwd_response] series.
 
     PR-3 wires [Keeper_cwd_response.to_yojson_response] into the
-    Docker-route response builders inside [keeper_shell_ops.ml]:
+    sandbox-backend response builders inside [keeper_shell_ops.ml]:
 
-    - [render_docker_process_result] (op=pwd / git_status / git_diff / ...)
-    - [op="git_log"] runtime branch (1 cwd-echo site under [via=docker])
+    - [render_sandbox_process_result] (op=pwd / git_status / git_diff / ...)
+    - [op="git_log"] runtime branch (1 cwd-echo site under backend [via])
 
     All other [cwd] usages in the file are intentionally left
     unchanged:
@@ -60,13 +60,13 @@ let count_substring src needle =
    for the dispatcher helper. Generic op=bash has been removed from
    keeper_shell, so there should no longer be a separate bash cwd echo path. *)
 
-let test_render_docker_process_result_uses_cwd_response () =
+let test_render_sandbox_process_result_uses_cwd_response () =
   match find_source_path () with
   | None -> ()
   | Some path ->
     let src = read_source path in
     check bool
-      "render_docker_process_result references Keeper_cwd_response.docker"
+      "render_sandbox_process_result references Keeper_cwd_response.docker"
       true
       (Astring.String.is_infix
          ~affix:"Keeper_cwd_response.docker ~host_cwd:cwd"
@@ -96,7 +96,7 @@ let test_git_log_runtime_branch_uses_cwd_response () =
     let src = read_source path in
     (* The git_log runtime branch builds its own cwd_response.
        Verify at least 2 distinct [cwd_response = Keeper_cwd_response.docker]
-       constructions in the file (render_docker + git_log; the
+       constructions in the file (render_sandbox + git_log; the
        generic op=bash branch was removed and now falls through the
        unsupported-op response, so it no longer constructs cwd responses). *)
     let docker_ctor_uses =
@@ -109,14 +109,20 @@ let test_git_log_runtime_branch_uses_cwd_response () =
          docker_ctor_uses)
       true (docker_ctor_uses >= 2)
 
+let is_backend_via_line line =
+  Astring.String.is_infix
+    ~affix:"\"via\", `String Keeper_sandbox_read_runner.backend_via"
+    line
+  || Astring.String.is_infix ~affix:"\"via\", `String \"docker\"" line
+
 (* Negative pin: a raw [String cwd] literal must not appear
-   in the same Assoc as a [via=docker] tag. For each line
+   in the same Assoc as a sandbox backend [via] tag. For each line
    that contains the cwd-string-literal pattern, scan up to
-   12 lines forward for a sibling docker-via line; any match
+   12 lines forward for a sibling backend-via line; any match
    is a regression and fails the test with the offending
    line numbers. *)
 
-let test_no_raw_cwd_in_docker_route () =
+let test_no_raw_cwd_in_backend_route () =
   match find_source_path () with
   | None -> ()
   | Some path ->
@@ -130,25 +136,21 @@ let test_no_raw_cwd_in_docker_route () =
         Astring.String.is_infix ~affix:"\"cwd\", `String cwd"
           arr.(i)
       then begin
-        (* Look forward up to 12 lines for a sibling
-           [via, `String "docker"] in the same Assoc. *)
+        (* Look forward up to 12 lines for a sibling backend [via] in the
+           same Assoc. *)
         let upper = min (n - 1) (i + 12) in
-        let found_docker_via = ref false in
+        let found_backend_via = ref false in
         for j = i + 1 to upper do
-          if
-            Astring.String.is_infix
-              ~affix:"\"via\", `String \"docker\""
-              arr.(j)
-          then found_docker_via := true
+          if is_backend_via_line arr.(j) then found_backend_via := true
         done;
-        if !found_docker_via then leaks := (i + 1) :: !leaks
+        if !found_backend_via then leaks := (i + 1) :: !leaks
       end
     done;
     let leaks = List.rev !leaks in
     if leaks <> [] then
       Alcotest.failf
         "raw (\"cwd\", `String cwd) literal found near a \
-         (\"via\", `String \"docker\") site at line(s): %s"
+         backend-via site at line(s): %s"
         (String.concat ", " (List.map string_of_int leaks))
 
 let () =
@@ -157,19 +159,19 @@ let () =
       ( "wiring-pins"
       , [
           test_case
-            "render_docker_process_result wires Cwd_response"
+            "render_sandbox_process_result wires Cwd_response"
             `Quick
-            test_render_docker_process_result_uses_cwd_response
+            test_render_sandbox_process_result_uses_cwd_response
         ; test_case "op=bash has no special runtime branch" `Quick
             test_bash_op_has_no_special_runtime_branch
         ; test_case
             "git_log runtime branch wires Cwd_response"
             `Quick test_git_log_runtime_branch_uses_cwd_response
         ] )
-    ; ( "no-leak-near-docker-via"
+    ; ( "no-leak-near-backend-via"
       , [
           test_case
-            "no raw (\"cwd\", `String cwd) literal near via=docker"
-            `Quick test_no_raw_cwd_in_docker_route
+            "no raw (\"cwd\", `String cwd) literal near backend via"
+            `Quick test_no_raw_cwd_in_backend_route
         ] )
     ]

--- a/test/test_keeper_sandbox_boundary_policy.ml
+++ b/test/test_keeper_sandbox_boundary_policy.ml
@@ -50,6 +50,28 @@ let assert_source_absent rel =
     false
     (Sys.file_exists (Filename.concat (repo_root ()) rel))
 
+let has_suffix text suffix =
+  let text_len = String.length text in
+  let suffix_len = String.length suffix in
+  text_len >= suffix_len
+  && String.equal (String.sub text (text_len - suffix_len) suffix_len) suffix
+
+let rec source_files_under rel =
+  let root = repo_root () in
+  let rec loop rel =
+    let abs = Filename.concat root rel in
+    match Unix.lstat abs with
+    | { Unix.st_kind = Unix.S_DIR; _ } ->
+      Sys.readdir abs
+      |> Array.to_list
+      |> List.concat_map (fun name -> loop (Filename.concat rel name))
+    | { Unix.st_kind = Unix.S_REG; _ }
+      when has_suffix rel ".ml" || has_suffix rel ".mli" -> [ rel ]
+    | _ -> []
+    | exception Unix.Unix_error _ -> []
+  in
+  loop rel
+
 let test_config_contract_uses_structured_toml () =
   let rel = "lib/config/keeper_sandbox_config.ml" in
   assert_contains rel "Otoml.Parser.from_string_result";
@@ -138,6 +160,40 @@ let test_tool_layer_does_not_select_concrete_backend () =
     ; "lib/keeper/keeper_tool_pr_review.ml"
     ]
 
+let test_shell_read_ops_use_sandbox_read_runner () =
+  let rel = "lib/keeper/keeper_shell_ops.ml" in
+  assert_contains rel "Keeper_sandbox_read_runner.";
+  assert_contains rel "Keeper_sandbox_read_runner.backend_via";
+  assert_not_contains rel "Keeper_docker_read.";
+  assert_not_contains rel "\"via\", `String \"docker\""
+
+let test_sandbox_runtime_sources_do_not_depend_on_shell_surface_names () =
+  let sandbox_runtime_sources =
+    source_files_under "lib/keeper"
+    |> List.filter (fun rel ->
+      let base = Filename.basename rel in
+      String.starts_with ~prefix:"keeper_sandbox" base
+      || String.starts_with ~prefix:"keeper_docker" base
+      || String.equal base "sandbox_error.ml"
+      || String.equal base "sandbox_error.mli")
+  in
+  Alcotest.(check bool)
+    "sandbox runtime sources discovered"
+    true
+    (sandbox_runtime_sources <> []);
+  let forbidden =
+    [ "Keeper_shell_docker"
+    ; "keeper_shell_docker"
+    ; "Keeper_shell_bash_docker"
+    ; "keeper_shell_bash_docker"
+    ; "shell_docker"
+    ; "shell_bash"
+    ]
+  in
+  List.iter
+    (fun rel -> List.iter (assert_not_contains rel) forbidden)
+    sandbox_runtime_sources
+
 let test_shell_ops_delegates_gh_bridge () =
   let shell_ops = "lib/keeper/keeper_shell_ops.ml" in
   let gh_bridge = "lib/keeper/keeper_shell_gh_bridge.ml" in
@@ -210,6 +266,14 @@ let () =
             "tool layer does not select concrete backend"
             `Quick
             test_tool_layer_does_not_select_concrete_backend;
+          Alcotest.test_case
+            "shell read ops use sandbox read runner"
+            `Quick
+            test_shell_read_ops_use_sandbox_read_runner;
+          Alcotest.test_case
+            "sandbox runtime sources do not depend on shell surface names"
+            `Quick
+            test_sandbox_runtime_sources_do_not_depend_on_shell_surface_names;
           Alcotest.test_case
             "shell ops delegates gh compatibility bridge"
             `Quick

--- a/test/test_keeper_sandbox_read_runner.ml
+++ b/test/test_keeper_sandbox_read_runner.ml
@@ -1,0 +1,189 @@
+open Masc_mcp
+
+let make_meta () =
+  let json =
+    `Assoc
+      [ "name", `String "read-runner-keeper"
+      ; "agent_name", `String "agent-read-runner"
+      ; "trace_id", `String "trace-read-runner"
+      ; "goal", `String "sandbox read runner mock test"
+      ; "allowed_paths", `List [ `String "*" ]
+      ; "sandbox_profile", `String "docker"
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok meta -> meta
+  | Error e -> Alcotest.fail e
+
+let config = Coord.default_config "/tmp/masc-read-runner-test"
+let meta = make_meta ()
+
+module Calls = struct
+  let events = ref []
+  let ok_exit_codes = ref []
+  let reset () = events := []; ok_exit_codes := []
+  let push event = events := event :: !events
+  let events () = List.rev !events
+end
+
+module Mock_backend = struct
+  let should_route_read ~meta:_ =
+    Calls.push "should_route_read";
+    true
+
+  let container_path_of_host ~config:_ ~meta:_ ~host_path =
+    Calls.push ("container_path:" ^ host_path);
+    Ok ("/container" ^ host_path)
+
+  let read_file_in_container
+      ?turn_sandbox_factory:_
+      ~config:_
+      ~meta:_
+      ~host_path
+      ~max_bytes
+      ~timeout_sec
+      () =
+    Calls.push
+      (Printf.sprintf
+         "read_file:%s:%d:%.1f"
+         host_path
+         max_bytes
+         timeout_sec);
+    Ok "mock file body"
+
+  let run_command_in_container_with_status
+      ?turn_sandbox_factory:_
+      ?(ok_exit_codes = [ 0 ])
+      ~config:_
+      ~meta:_
+      ~command_argv
+      ~max_bytes
+      ~timeout_sec
+      () =
+    Calls.ok_exit_codes := ok_exit_codes;
+    Calls.push
+      (Printf.sprintf
+         "run_status:%s:%d:%.1f"
+         (String.concat "," command_argv)
+         max_bytes
+         timeout_sec);
+    Ok (Unix.WEXITED 0, "mock command output")
+
+  let run_command_in_container
+      ?turn_sandbox_factory:_
+      ?(ok_exit_codes = [ 0 ])
+      ~config:_
+      ~meta:_
+      ~command_argv
+      ~max_bytes
+      ~timeout_sec
+      () =
+    Calls.ok_exit_codes := ok_exit_codes;
+    Calls.push
+      (Printf.sprintf
+         "run:%s:%d:%.1f"
+         (String.concat "," command_argv)
+         max_bytes
+         timeout_sec);
+    Ok "mock stdout"
+end
+
+module Runner = Keeper_sandbox_read_runner.Make (Mock_backend)
+
+let test_route_labels_match_sandbox_runner () =
+  Alcotest.(check string)
+    "host via"
+    (Keeper_sandbox_runner.route_label Keeper_sandbox_runner.Host)
+    Runner.host_via;
+  Alcotest.(check string)
+    "backend via"
+    (Keeper_sandbox_runner.route_label Keeper_sandbox_runner.Sandbox_backend)
+    Runner.backend_via
+
+let test_mock_backend_forwards_read_contract () =
+  Calls.reset ();
+  Alcotest.(check bool)
+    "should route"
+    true
+    (Runner.should_route_read ~meta);
+  Alcotest.(check (result string string))
+    "container path"
+    (Ok "/container/host/file.txt")
+    (Runner.container_path_of_host
+       ~config
+       ~meta
+       ~host_path:"/host/file.txt");
+  Alcotest.(check (result string string))
+    "read file"
+    (Ok "mock file body")
+    (Runner.read_file
+       ~config
+       ~meta
+       ~host_path:"/host/file.txt"
+       ~max_bytes:128
+       ~timeout_sec:2.5
+       ());
+  Alcotest.(check (list string))
+    "events"
+    [ "should_route_read"
+    ; "container_path:/host/file.txt"
+    ; "read_file:/host/file.txt:128:2.5"
+    ]
+    (Calls.events ())
+
+let test_mock_backend_forwards_command_contract () =
+  Calls.reset ();
+  (match
+     Runner.run_command_with_status
+       ~ok_exit_codes:[ 0; 1 ]
+       ~config
+       ~meta
+       ~command_argv:[ "rg"; "needle"; "/container/repo" ]
+       ~max_bytes:512
+       ~timeout_sec:3.0
+       ()
+   with
+   | Ok (Unix.WEXITED 0, "mock command output") -> ()
+   | Ok (status, output) ->
+     Alcotest.failf
+       "unexpected status/output: %s %S"
+       (Keeper_alerting_path.process_status_to_json status |> Yojson.Safe.to_string)
+       output
+   | Error msg -> Alcotest.failf "unexpected error: %s" msg);
+  Alcotest.(check (list int)) "status ok exits" [ 0; 1 ] !(Calls.ok_exit_codes);
+  Alcotest.(check (result string string))
+    "run command"
+    (Ok "mock stdout")
+    (Runner.run_command
+       ~ok_exit_codes:[ 0 ]
+       ~config
+       ~meta
+       ~command_argv:[ "cat"; "/container/file" ]
+       ~max_bytes:64
+       ~timeout_sec:1.0
+       ());
+  Alcotest.(check (list string))
+    "events"
+    [ "run_status:rg,needle,/container/repo:512:3.0"
+    ; "run:cat,/container/file:64:1.0"
+    ]
+    (Calls.events ())
+
+let () =
+  Alcotest.run
+    "keeper_sandbox_read_runner"
+    [ ( "mock-backend"
+      , [ Alcotest.test_case
+            "route labels come from sandbox runner"
+            `Quick
+            test_route_labels_match_sandbox_runner
+        ; Alcotest.test_case
+            "read operations delegate to backend"
+            `Quick
+            test_mock_backend_forwards_read_contract
+        ; Alcotest.test_case
+            "command operations delegate to backend"
+            `Quick
+            test_mock_backend_forwards_command_contract
+        ] )
+    ]


### PR DESCRIPTION
## Summary
- add `Keeper_sandbox_read_runner` as a backend-neutral facade over read-side sandbox execution
- migrate structured `keeper_shell_ops` read paths away from direct `Keeper_docker_read` calls and hard-coded `via=docker`
- add mock-based facade tests and boundary policy checks for the Tool/Backend split
- update the Keeper tool/runtime boundary plan with slice 6 gates

## Verification
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_sandbox_read_runner.exe test/test_keeper_sandbox_boundary_policy.exe test/test_keeper_exec_shell_cwd_response.exe test/test_keeper_shell_ops.exe`
- `./_build/default/test/test_keeper_sandbox_read_runner.exe`
- `./_build/default/test/test_keeper_sandbox_boundary_policy.exe`
- `./_build/default/test/test_keeper_exec_shell_cwd_response.exe`
- `./_build/default/test/test_keeper_shell_ops.exe`
- `opam exec -- ocamlformat --check lib/keeper/keeper_sandbox_read_runner.ml lib/keeper/keeper_sandbox_read_runner.mli lib/keeper/keeper_shell_ops.ml test/test_keeper_sandbox_read_runner.ml test/test_keeper_sandbox_boundary_policy.ml test/test_keeper_exec_shell_cwd_response.ml`
- `git diff --check`
- `scripts/check-version-truth.sh` -> `Version truth OK: package=0.19.28 changelog_entry=0.19.28 published_release=0.19.27`
- `rg -n 'Keeper_docker_read\.|"via", `String "docker"' lib/keeper/keeper_shell_ops.ml` -> no matches