### PR TITLE
fix: handle Agent_sdk.InputRequired variant across 7 files

### DIFF
--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -167,7 +167,8 @@ let sdk_error_to_cascade_outcome (err : Agent_sdk.Error.sdk_error)
   | Agent_sdk.Error.Agent (ToolRetryExhausted _)
   | Agent_sdk.Error.Agent (GuardrailViolation _)
   | Agent_sdk.Error.Agent (TripwireViolation _)
-  | Agent_sdk.Error.Agent (ExitConditionMet _) -> None
+  | Agent_sdk.Error.Agent (ExitConditionMet _)
+  | Agent_sdk.Error.Agent (InputRequired _) -> None
   (* Other Config errors (different InvalidConfig field, MissingEnvVar,
      UnsupportedProvider) and non-Api / non-Agent / non-Config families are
      not cascade-recoverable. *)

--- a/lib/cascade/cascade_event_bridge_error_json.ml
+++ b/lib/cascade/cascade_event_bridge_error_json.ml
@@ -173,6 +173,13 @@ let sdk_agent_error_fields = function
     ]
   | Agent_sdk.Error.ExitConditionMet { turn } ->
     [ "variant", `String "exit_condition_met"; "turn", `Int turn ]
+  | Agent_sdk.Error.InputRequired { request_id; participant_name; question } ->
+    [ "variant", `String "input_required"
+    ; "request_id", `String request_id
+    ; "participant_name",
+      (match participant_name with Some n -> `String n | None -> `Null)
+    ; "question", `String question
+    ]
 ;;
 
 let sdk_mcp_error_fields = function

--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -97,6 +97,7 @@ let sdk_termination_semantics = function
   | Agent_sdk.Error.Agent (Agent_sdk.Error.TripwireViolation _) ->
     Oas_tripwire_violation
   | Agent_sdk.Error.Agent (Agent_sdk.Error.UnrecognizedStopReason _) -> Sdk_error_failure
+  | Agent_sdk.Error.Agent (Agent_sdk.Error.InputRequired _) -> Sdk_error_failure
   | Agent_sdk.Error.Provider _ -> Sdk_error_failure
   | Agent_sdk.Error.Api _ -> Sdk_error_failure
   | Agent_sdk.Error.Mcp _ -> Sdk_error_failure
@@ -236,6 +237,8 @@ let agent_error_terminal_reason_code = function
     Printf.sprintf "agent_error_guardrail_violation:validator=%s" validator
   | Agent_sdk.Error.TripwireViolation { tripwire; reason = _ } ->
     Printf.sprintf "agent_error_tripwire_violation:tripwire=%s" tripwire
+  | Agent_sdk.Error.InputRequired { request_id; question } ->
+    Printf.sprintf "agent_error_input_required:request_id=%s,question=%s" request_id question
 ;;
 
 let network_error_kind_to_wire = function

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -165,7 +165,8 @@ let is_required_tool_contract_violation (err : Agent_sdk.Error.sdk_error) : bool
   | Agent_sdk.Error.Agent (ToolRetryExhausted _)
   | Agent_sdk.Error.Agent (GuardrailViolation _)
   | Agent_sdk.Error.Agent (TripwireViolation _)
-  | Agent_sdk.Error.Agent (ExitConditionMet _) -> false
+  | Agent_sdk.Error.Agent (ExitConditionMet _)
+  | Agent_sdk.Error.Agent (InputRequired _) -> false
   (* Non-Agent error families. *)
   | Agent_sdk.Error.Api _
   | Agent_sdk.Error.Provider _
@@ -951,7 +952,8 @@ let is_context_overflow (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.Agent (CompletionContractViolation _)
   | Agent_sdk.Error.Agent (GuardrailViolation _)
   | Agent_sdk.Error.Agent (TripwireViolation _)
-  | Agent_sdk.Error.Agent (ExitConditionMet _) -> false
+  | Agent_sdk.Error.Agent (ExitConditionMet _)
+  | Agent_sdk.Error.Agent (InputRequired _) -> false
   (* Non-API / non-Agent error families. *)
   | Agent_sdk.Error.Mcp _
   | Agent_sdk.Error.Config _

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -155,6 +155,7 @@ type blocker_class =
   | Sdk_guardrail_violation
   | Sdk_tripwire_violation
   | Sdk_exit_condition_met
+  | Sdk_input_required
 
 let blocker_class_to_string = function
   | Cascade_exhausted _ -> "cascade_exhausted"
@@ -181,6 +182,7 @@ let blocker_class_to_string = function
   | Sdk_guardrail_violation -> "sdk_guardrail_violation"
   | Sdk_tripwire_violation -> "sdk_tripwire_violation"
   | Sdk_exit_condition_met -> "sdk_exit_condition_met"
+  | Sdk_input_required -> "sdk_input_required"
 ;;
 
 let blocker_class_of_serialized_string = function
@@ -208,6 +210,7 @@ let blocker_class_of_serialized_string = function
   | "sdk_guardrail_violation" -> Some Sdk_guardrail_violation
   | "sdk_tripwire_violation" -> Some Sdk_tripwire_violation
   | "sdk_exit_condition_met" -> Some Sdk_exit_condition_met
+  | "sdk_input_required" -> Some Sdk_input_required
   | _ -> None
 ;;
 
@@ -253,7 +256,8 @@ let blocker_class_continue_gate = function
   | Sdk_tool_retry_exhausted
   | Sdk_guardrail_violation
   | Sdk_tripwire_violation
-  | Sdk_exit_condition_met -> false
+  | Sdk_exit_condition_met
+  | Sdk_input_required -> false
 ;;
 
 let cascade_exhaustion_reason_to_json = function

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -229,6 +229,7 @@ let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class
      | Agent_sdk.Error.Agent (GuardrailViolation _) -> Some Sdk_guardrail_violation
      | Agent_sdk.Error.Agent (TripwireViolation _) -> Some Sdk_tripwire_violation
      | Agent_sdk.Error.Agent (ExitConditionMet _) -> Some Sdk_exit_condition_met
+     | Agent_sdk.Error.Agent (InputRequired _) -> Some Sdk_input_required
      (* Provider-level [Api] errors are surfaced via OAS retry / cascade
          layers and do not map to a typed blocker_class by themselves. *)
      | Agent_sdk.Error.Api _

--- a/lib/server/openai_compat_error_map.ml
+++ b/lib/server/openai_compat_error_map.ml
@@ -234,6 +234,11 @@ let of_agent_error (e : Agent_sdk.Error.agent_error) : t =
     ; openai_kind = kind_server
     ; openai_code = Some "exit_condition_met"
     ; message }
+  | InputRequired _ ->
+    { http_status = `Bad_request
+    ; openai_kind = kind_invalid_request
+    ; openai_code = Some "input_required"
+    ; message }
 
 let of_mcp_error (e : Agent_sdk.Error.mcp_error) : t =
   let message = Agent_sdk.Error.to_string (Agent_sdk.Error.Mcp e) in


### PR DESCRIPTION
## Summary

Agent_sdk 0.196.15 (OAS) added `InputRequired` variant to `Agent_sdk.Error.agent_error`. This caused `dune build @install --profile=release` to fail with partial-match warning 8 (treated as error) across 7 files in masc-mcp.

This PR adds exhaustive handling for the new variant at every match site, following the existing pattern established by `ExitConditionMet` and adjacent variants.

## Files changed

| File | Mapping |
|------|---------|
| `lib/cascade/cascade_attempt_fsm.ml` | Not cascade-recoverable → `None` |
| `lib/cascade/cascade_event_bridge_error_json.ml` | JSON serialization (`input_required` variant) |
| `lib/keeper/keeper_agent_error.ml` | `Sdk_error_failure` + terminal reason code |
| `lib/keeper/keeper_error_classify.ml` | Not a required-tool contract violation |
| `lib/keeper/keeper_meta_contract.ml` | `Sdk_input_required` blocker class |
| `lib/keeper/keeper_status_bridge.ml` | `blocker_class` mapping |
| `lib/server/openai_compat_error_map.ml` | `Bad_request` / `invalid_request_error` |

## Verification

- [x] `dune build @install --profile=release` passes
- [ ] `dune build @runtest` — worktree env issues (pin_guard), unrelated to this change

## Behavioral impact

No behavioral change for prior variants. The new `InputRequired` error is surfaced consistently across all error translation layers.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>