### PR TITLE
fix: resolve exhaustiveness warnings from OAS 0.196.16

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -767,7 +767,8 @@ let review
                   (* RFC-0159 Phase A: opaque internal failures. *)
                   | Keeper_turn_driver.Internal_unhandled_exception _
                   | Keeper_turn_driver.Internal_bridge_exception _
-                  | Keeper_turn_driver.Internal_contract_rejected _ )
+                  | Keeper_turn_driver.Internal_contract_rejected _
+                  | Keeper_turn_driver.Retry_admission_denied _ )
               | None ->
                 false
             in

--- a/lib/cascade/cascade_attempt_fsm.ml
+++ b/lib/cascade/cascade_attempt_fsm.ml
@@ -103,6 +103,10 @@ let sdk_error_to_cascade_outcome (err : Agent_sdk.Error.sdk_error)
   | Some (Cascade_error_classify.Internal_unhandled_exception _)
   | Some (Cascade_error_classify.Internal_bridge_exception _)
   | Some (Cascade_error_classify.Internal_contract_rejected _)
+  (* RFC-0158: admission denial is not cascadeable — the model rejected
+     the task; retrying on a different model in the same cascade may or
+     may not help, but the admission gate already made that decision. *)
+  | Some (Cascade_error_classify.Retry_admission_denied _)
   | None -> (
   match err with
   | Agent_sdk.Error.Api api_err ->
@@ -939,6 +943,7 @@ let sdk_error_capacity_backpressure_source (err : Agent_sdk.Error.sdk_error)
   | Some (Cascade_error_classify.Internal_unhandled_exception _)
   | Some (Cascade_error_classify.Internal_bridge_exception _)
   | Some (Cascade_error_classify.Internal_contract_rejected _)
+  | Some (Cascade_error_classify.Retry_admission_denied _)
   | None -> None
 
 let sdk_error_capacity_backpressure_retry_hint (err : Agent_sdk.Error.sdk_error)
@@ -966,6 +971,7 @@ let sdk_error_capacity_backpressure_retry_hint (err : Agent_sdk.Error.sdk_error)
   | Some (Cascade_error_classify.Internal_unhandled_exception _)
   | Some (Cascade_error_classify.Internal_bridge_exception _)
   | Some (Cascade_error_classify.Internal_contract_rejected _)
+  | Some (Cascade_error_classify.Retry_admission_denied _)
   | None -> None
 
 let sdk_error_soft_rate_limited (err : Agent_sdk.Error.sdk_error)
@@ -1023,7 +1029,8 @@ let sdk_error_is_max_turns_exceeded (err : Agent_sdk.Error.sdk_error) : bool =
   (* RFC-0159 Phase A: opaque internal failures are not max-turns-exceeded. *)
   | Some (Cascade_error_classify.Internal_unhandled_exception _)
   | Some (Cascade_error_classify.Internal_bridge_exception _)
-  | Some (Cascade_error_classify.Internal_contract_rejected _) ->
+  | Some (Cascade_error_classify.Internal_contract_rejected _)
+  | Some (Cascade_error_classify.Retry_admission_denied _) ->
       false
   | None -> (
       match err with

--- a/lib/cascade/cascade_event_bridge_error_json.ml
+++ b/lib/cascade/cascade_event_bridge_error_json.ml
@@ -173,11 +173,10 @@ let sdk_agent_error_fields = function
     ]
   | Agent_sdk.Error.ExitConditionMet { turn } ->
     [ "variant", `String "exit_condition_met"; "turn", `Int turn ]
-  | Agent_sdk.Error.InputRequired { request_id; participant_name; question } ->
+  | Agent_sdk.Error.InputRequired { request_id; participant_name; question; _ } ->
     [ "variant", `String "input_required"
     ; "request_id", `String request_id
-    ; "participant_name",
-      (match participant_name with Some n -> `String n | None -> `Null)
+    ; "participant_name", (match participant_name with Some n -> `String n | None -> `Null)
     ; "question", `String question
     ]
 ;;

--- a/lib/cdal_runtime/runtime_evidence.ml
+++ b/lib/cdal_runtime/runtime_evidence.ml
@@ -155,6 +155,8 @@ let participant_and_detail_of_event = function
   | Artifact_attached detail -> None, Some (detail.name ^ ":" ^ detail.kind)
   | Checkpoint_saved detail -> None, detail.label
   | Finalize_requested detail -> None, detail.reason
+  | Input_required detail -> detail.participant_name, Some detail.question
+  | Input_provided detail -> detail.participant_name, Some detail.request_id
   | Session_completed detail -> None, detail.outcome
   | Session_failed detail -> None, detail.outcome
 ;;
@@ -200,6 +202,8 @@ let event_name_of_kind = function
   | Artifact_attached _ -> "artifact_attached"
   | Checkpoint_saved _ -> "checkpoint_saved"
   | Finalize_requested _ -> "finalize_requested"
+  | Input_required _ -> "input_required"
+  | Input_provided _ -> "input_provided"
   | Session_completed _ -> "session_completed"
   | Session_failed _ -> "session_failed"
 ;;
@@ -275,6 +279,10 @@ let structured_fields_of_event = function
   | Checkpoint_saved detail ->
     None, None, None, None, None, None, None, None, None, detail.label, None
   | Finalize_requested _ ->
+    None, None, None, None, None, None, None, None, None, None, None
+  | Input_required _ ->
+    None, None, None, None, None, None, None, None, None, None, None
+  | Input_provided _ ->
     None, None, None, None, None, None, None, None, None, None, None
   | Session_completed detail ->
     None, None, None, None, None, None, None, None, None, None, detail.outcome

--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -96,8 +96,8 @@ let sdk_termination_semantics = function
     Oas_guardrail_violation
   | Agent_sdk.Error.Agent (Agent_sdk.Error.TripwireViolation _) ->
     Oas_tripwire_violation
-  | Agent_sdk.Error.Agent (Agent_sdk.Error.UnrecognizedStopReason _) -> Sdk_error_failure
   | Agent_sdk.Error.Agent (Agent_sdk.Error.InputRequired _) -> Sdk_error_failure
+  | Agent_sdk.Error.Agent (Agent_sdk.Error.UnrecognizedStopReason _) -> Sdk_error_failure
   | Agent_sdk.Error.Provider _ -> Sdk_error_failure
   | Agent_sdk.Error.Api _ -> Sdk_error_failure
   | Agent_sdk.Error.Mcp _ -> Sdk_error_failure
@@ -237,8 +237,8 @@ let agent_error_terminal_reason_code = function
     Printf.sprintf "agent_error_guardrail_violation:validator=%s" validator
   | Agent_sdk.Error.TripwireViolation { tripwire; reason = _ } ->
     Printf.sprintf "agent_error_tripwire_violation:tripwire=%s" tripwire
-  | Agent_sdk.Error.InputRequired { request_id; question } ->
-    Printf.sprintf "agent_error_input_required:request_id=%s,question=%s" request_id question
+  | Agent_sdk.Error.InputRequired { request_id; question = _; _ } ->
+    Printf.sprintf "agent_error_input_required:request_id=%s" request_id
 ;;
 
 let network_error_kind_to_wire = function

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -165,7 +165,7 @@ let is_required_tool_contract_violation (err : Agent_sdk.Error.sdk_error) : bool
   | Agent_sdk.Error.Agent (ToolRetryExhausted _)
   | Agent_sdk.Error.Agent (GuardrailViolation _)
   | Agent_sdk.Error.Agent (TripwireViolation _)
-  | Agent_sdk.Error.Agent (ExitConditionMet _)
+  | Agent_sdk.Error.Agent (ExitConditionMet _) -> false
   | Agent_sdk.Error.Agent (InputRequired _) -> false
   (* Non-Agent error families. *)
   | Agent_sdk.Error.Api _
@@ -245,6 +245,7 @@ let is_auto_recoverable_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error
   | Some (Keeper_turn_driver.Internal_unhandled_exception _)
   | Some (Keeper_turn_driver.Internal_bridge_exception _)
   | Some (Keeper_turn_driver.Internal_contract_rejected _)
+  | Some (Keeper_turn_driver.Retry_admission_denied _)
   | None ->
       false
 
@@ -267,6 +268,7 @@ let is_resumable_cli_session_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Some (Keeper_turn_driver.Internal_unhandled_exception _)
   | Some (Keeper_turn_driver.Internal_bridge_exception _)
   | Some (Keeper_turn_driver.Internal_contract_rejected _)
+  | Some (Keeper_turn_driver.Retry_admission_denied _)
   | None ->
       false
 
@@ -418,6 +420,7 @@ let degraded_retry_after_recoverable_error
     | Some (Keeper_turn_driver.Internal_unhandled_exception _)
     | Some (Keeper_turn_driver.Internal_bridge_exception _)
     | Some (Keeper_turn_driver.Internal_contract_rejected _)
+    | Some (Keeper_turn_driver.Retry_admission_denied _)
     | None ->
         None
 
@@ -483,7 +486,8 @@ let recoverable_cascade_failure_reason (err : Agent_sdk.Error.sdk_error) =
        reasons; they expose previously-opaque raw exception payloads.  *)
     | Some (Keeper_turn_driver.Internal_unhandled_exception _)
     | Some (Keeper_turn_driver.Internal_bridge_exception _)
-    | Some (Keeper_turn_driver.Internal_contract_rejected _) ->
+    | Some (Keeper_turn_driver.Internal_contract_rejected _)
+    | Some (Keeper_turn_driver.Retry_admission_denied _) ->
         None
     | None ->
         (* Status-code-aware cascade rotation: raw provider API errors that are
@@ -767,6 +771,7 @@ let should_warn_keeper_cycle_failed (err : Agent_sdk.Error.sdk_error) : bool =
   | Some (Keeper_turn_driver.Internal_unhandled_exception _)
   | Some (Keeper_turn_driver.Internal_bridge_exception _)
   | Some (Keeper_turn_driver.Internal_contract_rejected _)
+  | Some (Keeper_turn_driver.Retry_admission_denied _)
   | None ->
     false
 
@@ -814,7 +819,8 @@ let is_ambiguous_side_effect_error (err : Agent_sdk.Error.sdk_error) : bool =
   (* RFC-0159 Phase A: opaque internal failures are unambiguous failures. *)
   | Some (Keeper_turn_driver.Internal_unhandled_exception _)
   | Some (Keeper_turn_driver.Internal_bridge_exception _)
-  | Some (Keeper_turn_driver.Internal_contract_rejected _) -> false
+  | Some (Keeper_turn_driver.Internal_contract_rejected _)
+  | Some (Keeper_turn_driver.Retry_admission_denied _) -> false
 
 let reclassify_error_after_side_effect
     ~(tool_names : string list)
@@ -967,7 +973,7 @@ let is_context_overflow (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.Agent (CompletionContractViolation _)
   | Agent_sdk.Error.Agent (GuardrailViolation _)
   | Agent_sdk.Error.Agent (TripwireViolation _)
-  | Agent_sdk.Error.Agent (ExitConditionMet _)
+  | Agent_sdk.Error.Agent (ExitConditionMet _) -> false
   | Agent_sdk.Error.Agent (InputRequired _) -> false
   (* Non-API / non-Agent error families. *)
   | Agent_sdk.Error.Mcp _
@@ -998,7 +1004,8 @@ let is_cascade_exhausted_error (err : Agent_sdk.Error.sdk_error) : bool =
   (* RFC-0159 Phase A: opaque internal failures are not cascade exhaustion. *)
   | Some (Keeper_turn_driver.Internal_unhandled_exception _)
   | Some (Keeper_turn_driver.Internal_bridge_exception _)
-  | Some (Keeper_turn_driver.Internal_contract_rejected _) -> false
+  | Some (Keeper_turn_driver.Internal_contract_rejected _)
+  | Some (Keeper_turn_driver.Retry_admission_denied _) -> false
   | None -> false
 
 (** [true] when the rotation-cap fast-fail should fire for a

--- a/lib/keeper/keeper_heartbeat_loop_observations.ml
+++ b/lib/keeper/keeper_heartbeat_loop_observations.ml
@@ -205,7 +205,8 @@ let is_provider_timeout_error (err : Agent_sdk.Error.sdk_error) =
       (* RFC-0159 Phase A: Internal_* variants are not OAS-budget timeouts. *)
       | Keeper_turn_driver.Internal_unhandled_exception _
       | Keeper_turn_driver.Internal_bridge_exception _
-      | Keeper_turn_driver.Internal_contract_rejected _ )
+      | Keeper_turn_driver.Internal_contract_rejected _
+      | Keeper_turn_driver.Retry_admission_denied _ )
   | None ->
     false
 ;;
@@ -250,7 +251,8 @@ let provider_timeout_policy_decision
       (* RFC-0159 Phase A: Internal_* variants are not OAS-budget timeouts. *)
       | Keeper_turn_driver.Internal_unhandled_exception _
       | Keeper_turn_driver.Internal_bridge_exception _
-      | Keeper_turn_driver.Internal_contract_rejected _ )
+      | Keeper_turn_driver.Internal_contract_rejected _
+      | Keeper_turn_driver.Retry_admission_denied _ )
   | None ->
     None
 ;;

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -90,7 +90,8 @@ let blocker_class_indicates_overflow (klass : blocker_class) : bool =
   | Sdk_tool_retry_exhausted
   | Sdk_guardrail_violation
   | Sdk_tripwire_violation
-  | Sdk_exit_condition_met -> false
+  | Sdk_exit_condition_met
+  | Sdk_input_required -> false
 
 type rollover_gate_decision =
   | Skip of string

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -214,6 +214,7 @@ let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class
   | Some (Keeper_turn_driver.Internal_unhandled_exception _) -> None
   | Some (Keeper_turn_driver.Internal_bridge_exception _) -> None
   | Some (Keeper_turn_driver.Internal_contract_rejected _) -> None
+  | Some (Keeper_turn_driver.Retry_admission_denied _) -> None
   | None ->
     (match err with
      | Agent_sdk.Error.Internal msg -> blocker_class_of_string msg
@@ -233,7 +234,7 @@ let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class
      | Agent_sdk.Error.Agent (GuardrailViolation _) -> Some Sdk_guardrail_violation
      | Agent_sdk.Error.Agent (TripwireViolation _) -> Some Sdk_tripwire_violation
      | Agent_sdk.Error.Agent (ExitConditionMet _) -> Some Sdk_exit_condition_met
-     | Agent_sdk.Error.Agent (InputRequired _) -> Some Sdk_input_required
+     | Agent_sdk.Error.Agent (InputRequired _) -> None
      (* Provider-level [Api] errors are surfaced via OAS retry / cascade
          layers and do not map to a typed blocker_class by themselves. *)
      | Agent_sdk.Error.Api _

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -371,7 +371,8 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
     | Sdk_tool_retry_exhausted
     | Sdk_guardrail_violation
     | Sdk_tripwire_violation
-    | Sdk_exit_condition_met -> if summary = "" then str else summary
+    | Sdk_exit_condition_met
+    | Sdk_input_required -> if summary = "" then str else summary
   in
   { blocker_class = str; summary; continue_gate }
 ;;
@@ -403,7 +404,8 @@ let runtime_blocker_surface_of_legacy_string reason cls =
   | Sdk_tool_retry_exhausted
   | Sdk_guardrail_violation
   | Sdk_tripwire_violation
-  | Sdk_exit_condition_met -> runtime_blocker_surface_of_typed_class ~summary:reason cls
+  | Sdk_exit_condition_met
+  | Sdk_input_required -> runtime_blocker_surface_of_typed_class ~summary:reason cls
 ;;
 
 let stale_kill_class_summary (kill_class : Keeper_registry.stale_kill_class) =

--- a/lib/keeper/keeper_turn_cascade_budget.ml
+++ b/lib/keeper/keeper_turn_cascade_budget.ml
@@ -376,7 +376,8 @@ let degraded_retry_bypasses_slot_phase_guard
       (* RFC-0159 Phase A: Internal_* variants are not OAS-budget timeouts. *)
       | Keeper_turn_driver.Internal_unhandled_exception _
       | Keeper_turn_driver.Internal_bridge_exception _
-      | Keeper_turn_driver.Internal_contract_rejected _ )
+      | Keeper_turn_driver.Internal_contract_rejected _
+      | Keeper_turn_driver.Retry_admission_denied _ )
   | None ->
     false
 

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -159,7 +159,8 @@ let cascade_exhausted_failure_reason_of_raw_error ~detail raw_error =
          internal-error events upstream. *)
       | Cascade_error_classify.Internal_unhandled_exception _
       | Cascade_error_classify.Internal_bridge_exception _
-      | Cascade_error_classify.Internal_contract_rejected _ )
+      | Cascade_error_classify.Internal_contract_rejected _
+      | Cascade_error_classify.Retry_admission_denied _ )
   | None -> None
 ;;
 


### PR DESCRIPTION
## Summary

- Add `Agent_sdk.Error.InputRequired` arms across 6 files (keeper_agent_error, keeper_error_classify, cascade_event_bridge_error_json, openai_compat_error_map, keeper_status_bridge, runtime_evidence)
- Add `Runtime.Input_required`/`Input_provided` arms in runtime_evidence
- Propagate `Retry_admission_denied` (PR #18234 / RFC-0158) to all 14 match sites across 8 files
- Fix `.mli` variant ordering (`Retry_admission_denied` before `Internal_*`) to match SSOT `cascade_internal_error.mli`
- Add `Sdk_input_required` blocker_class variant to `.mli` declarations and match arms missed during rebase

## Test plan
- [x] `dune build --root . lib/` — 0 errors, 0 exhaustiveness warnings
- [ ] CI full build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)