### PR TITLE
fix(ratchet): ocaml-structure baseline + shell IR legacy naming purge

### DIFF
--- a/lib/exec/command_gate/shell_command_gate.ml
+++ b/lib/exec/command_gate/shell_command_gate.ml
@@ -14,7 +14,7 @@ module BIN = Masc_exec.Bin
 type caller =
   | Worker_dev_tools
   | Tool_code_write
-  | Keeper_shell_bash
+  | Keeper_shell_ir
 
 type reject_reason =
   | Command_not_in_allowlist of { bin : string }
@@ -433,7 +433,7 @@ let lower_typed_pipeline ?caller:_ ~stages ~sandbox () : verdict =
 let caller_tag = function
   | Worker_dev_tools -> "worker_dev_tools"
   | Tool_code_write -> "tool_code_write"
-  | Keeper_shell_bash -> "keeper_shell_bash"
+  | Keeper_shell_ir -> "keeper_shell_ir"
 ;;
 
 let verdict_tag = function

--- a/lib/exec/command_gate/shell_command_gate.mli
+++ b/lib/exec/command_gate/shell_command_gate.mli
@@ -44,7 +44,7 @@
 type caller =
   | Worker_dev_tools
   | Tool_code_write
-  | Keeper_shell_bash
+  | Keeper_shell_ir
 
 (** Parsed-but-rejected reasons. *)
 type reject_reason =

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -1,6 +1,6 @@
 (* Facade: keeper_exec_shell — thin re-export layer.
    Types, constants, and helpers live in [Keeper_shell_shared].
-   [handle_keeper_bash] lives in [Keeper_shell_bash].
+   [handle_keeper_shell_ir] lives in [Keeper_shell_bash].
    [handle_keeper_shell] lives in [Keeper_shell_ops].
    Docker/GH-context sub-modules remain as before. *)
 

--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -1,6 +1,6 @@
 (** Keeper shell tool handlers — command execution and structured shell ops.
 
-    Handles [keeper_bash] (arbitrary commands with blocklist) and
+    Handles [keeper_shell_ir] (arbitrary commands with blocklist) and
     [keeper_shell] (structured ops: ls, cat, find, rg, head, tail, wc, tree,
     git-log, git-diff, git-status, git-clone, git-worktree, gh).
 
@@ -35,8 +35,8 @@ val gh_min_timeout_sec : float
     tests can lock the floor against drift back to sub-network-latency
     values. See #8688. *)
 
-val keeper_bash_native_min_timeout_sec : float
-(** Minimum timeout_sec floor applied to keeper_bash on the *native*
+val keeper_shell_ir_native_min_timeout_sec : float
+(** Minimum timeout_sec floor applied to keeper_shell_ir on the *native*
     executor path. Exposed so regression tests can lock the floor
     against drift back to sub-I/O-latency values.  Container-backed
     dispatch paths re-clamp independently inside their backend. *)
@@ -60,7 +60,7 @@ val rewrite_docker_host_paths_to_container :
     commands to the corresponding in-container playground root before
     execution. *)
 
-val handle_keeper_bash :
+val handle_keeper_shell_ir :
   turn_sandbox_factory:Keeper_sandbox_factory.t option ->
   turn_sandbox_factory_git:Keeper_sandbox_factory.t option ->
   exec_cache:Masc_exec.Exec_cache.t option ->

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -468,7 +468,7 @@ let execute_keeper_tool_call_with_outcome
               ~args)
        | "keeper_bash" ->
          make_executed_tool_result
-           (Keeper_exec_shell.handle_keeper_bash
+           (Keeper_exec_shell.handle_keeper_shell_ir
               ~turn_sandbox_factory
               ~turn_sandbox_factory_git
               ~exec_cache

--- a/lib/keeper/keeper_shell_bash.ml
+++ b/lib/keeper/keeper_shell_bash.ml
@@ -23,7 +23,7 @@ let typed_input_command_text = Keeper_shell_bash_typed_input.typed_input_command
 let typed_input_has_env = Keeper_shell_bash_typed_input.typed_input_has_env
 let typed_validation_error_text = Keeper_shell_bash_typed_input.typed_validation_error_text
 
-let normalize_path_for_keeper_bash_containment path =
+let normalize_path_for_keeper_shell_ir_containment path =
   Keeper_alerting_path.normalize_path_for_check path
   |> Keeper_alerting_path.strip_trailing_slashes
 
@@ -34,7 +34,7 @@ let docker_runtime_failure_fields =
 let docker_local_fallback_target =
   Keeper_sandbox_shell_ir_target.docker_local_fallback_target
 
-let handle_keeper_bash_typed
+let handle_keeper_shell_ir_typed
       ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
       ~(config : Coord.config)
       ~(meta : keeper_meta)
@@ -141,7 +141,7 @@ let handle_keeper_bash_typed
             in
             let gate_verdict =
               Shell_gate.gate_typed
-                ~caller:Shell_gate.Keeper_shell_bash
+                ~caller:Shell_gate.Keeper_shell_ir
                 ~ir:ir_risk
                 ~allowlist:{ allowed_commands; allow_pipes = true; redirect_allowed = true }
                 ~path_policy:Shell_gate.allow_all_paths
@@ -185,7 +185,7 @@ let handle_keeper_bash_typed
                       ~end_time:(Unix.gettimeofday ())
                   in
                   Log.Keeper.info
-                    "keeper_bash shell_ir_dispatch keeper=%s sandbox=%s status=%s elapsed_ms=%d"
+                    "keeper_shell_ir dispatch keeper=%s sandbox=%s status=%s elapsed_ms=%d"
                     meta.name
                     (Keeper_types.sandbox_profile_to_string sandbox_profile)
                     (Keeper_sandbox_exec_failure.status_label result.status)
@@ -217,7 +217,7 @@ let handle_keeper_bash_typed
                        ~env_snapshot:env_snap
                        ())))
 
-let handle_keeper_bash
+let handle_keeper_shell_ir
       ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
       ~turn_sandbox_factory_git:_
       ~exec_cache:_
@@ -239,7 +239,7 @@ let handle_keeper_bash
   in
   if has_typed_bash_input_key args
   then
-    handle_keeper_bash_typed
+    handle_keeper_shell_ir_typed
       ~turn_sandbox_factory
       ~config
       ~meta

--- a/lib/keeper/keeper_shell_gh_bridge.ml
+++ b/lib/keeper/keeper_shell_gh_bridge.ml
@@ -164,7 +164,7 @@ let handle_gh_op
       in
       let gh_gate_verdict =
         Masc_exec_command_gate.Shell_command_gate.gate_typed
-          ~caller:Masc_exec_command_gate.Shell_command_gate.Keeper_shell_bash
+          ~caller:Masc_exec_command_gate.Shell_command_gate.Keeper_shell_ir
           ~ir:gh_ir
           ~allowlist:
             { allowed_commands = [ "gh" ]

--- a/lib/keeper/keeper_shell_ops.ml
+++ b/lib/keeper/keeper_shell_ops.ml
@@ -345,7 +345,7 @@ let handle_keeper_shell
          let allowed_commands = Dev_exec_allowlist.dev in
          let gate_verdict =
            Shell_gate.gate_typed
-             ~caller:Shell_gate.Keeper_shell_bash
+             ~caller:Shell_gate.Keeper_shell_ir
              ~ir:envelope.Masc_exec.Shell_ir_risk.ir
              ~allowlist:{ allowed_commands; allow_pipes = true; redirect_allowed = true }
              ~path_policy:Shell_gate.allow_all_paths
@@ -446,7 +446,7 @@ let handle_keeper_shell
          let allowed_commands = Dev_exec_allowlist.readonly in
          let gate_verdict =
            Shell_gate.gate_typed
-             ~caller:Shell_gate.Keeper_shell_bash
+             ~caller:Shell_gate.Keeper_shell_ir
              ~ir:envelope.Masc_exec.Shell_ir_risk.ir
              ~allowlist:{ allowed_commands; allow_pipes = true; redirect_allowed = true }
              ~path_policy:Shell_gate.allow_all_paths
@@ -546,7 +546,7 @@ let handle_keeper_shell
          let allowed_commands = Dev_exec_allowlist.readonly in
          let gate_verdict =
            Shell_gate.gate_typed
-             ~caller:Shell_gate.Keeper_shell_bash
+             ~caller:Shell_gate.Keeper_shell_ir
              ~ir:envelope.Masc_exec.Shell_ir_risk.ir
              ~allowlist:{ allowed_commands; allow_pipes = true; redirect_allowed = true }
              ~path_policy:Shell_gate.allow_all_paths
@@ -692,7 +692,7 @@ let handle_keeper_shell
             let allowed_commands = Dev_exec_allowlist.readonly in
             let gate_verdict =
               Shell_gate.gate_typed
-                ~caller:Shell_gate.Keeper_shell_bash
+                ~caller:Shell_gate.Keeper_shell_ir
                 ~ir:envelope.Masc_exec.Shell_ir_risk.ir
                 ~allowlist:{ allowed_commands; allow_pipes = true; redirect_allowed = true }
                 ~path_policy:Shell_gate.allow_all_paths
@@ -871,7 +871,7 @@ let handle_keeper_shell
             let allowed_commands = Dev_exec_allowlist.dev in
             let gate_verdict =
               Shell_gate.gate_typed
-                ~caller:Shell_gate.Keeper_shell_bash
+                ~caller:Shell_gate.Keeper_shell_ir
                 ~ir:envelope.Masc_exec.Shell_ir_risk.ir
                 ~allowlist:{ allowed_commands; allow_pipes = true; redirect_allowed = true }
                 ~path_policy:Shell_gate.allow_all_paths


### PR DESCRIPTION
## Summary

1. **Ratchet baseline update** — `lib/dune` line count grew to 654 after commit `6bc64306e` (godfile admin-main tranche). Updates `scripts/ocaml-structure-baseline.json`.

2. **RFC-0160 G1+G7: Shell IR legacy naming purge** — Renames `bash` → `shell_ir` identifiers across 8 files:
   - `keeper_shell_bash.ml`: `normalize_path_for_keeper_bash_containment` → `normalize_path_for_keeper_shell_ir_containment`, `handle_keeper_bash*` → `handle_keeper_shell_ir*`
   - `keeper_exec_shell.ml/mli`: comment + val updates
   - `keeper_exec_tools.ml`: caller site
   - `shell_command_gate.ml/mli`: `Keeper_shell_bash` → `Keeper_shell_ir`
   - `keeper_shell_gh_bridge.ml`, `keeper_shell_ops.ml`: caller tag updates

## Test plan

- [x] `dune build --root . @install --profile=release` passes
- [x] `scripts/ocaml-structure-ratchet.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)