### PR TITLE
fix(shell-ir): RFC-0160 S7 ratchet fix — G1 migration + baseline update

### DIFF
--- a/lib/exec_policy_log_sanitize.ml
+++ b/lib/exec_policy_log_sanitize.ml
@@ -82,11 +82,11 @@ let sanitize_command_for_log cmd =
   if trimmed = ""
   then "[EMPTY]"
   else (
-    match Masc_exec_bash_parser.Bash.parse_string trimmed with
-    | Masc_exec.Parsed.Parsed ir ->
+    match Exec_policy.parse_string_to_ir ~mode:Coding trimmed with
+    | Ok ir ->
       sanitize_parts (Exec_policy_mutation_classifier.flat_stage_words ir)
-    | _ when command_has_sensitive_marker cmd -> "[REDACTED]"
-    | _ -> cmd |> redact_url_credentials |> redact_inline_secret_assignment)
+    | Error _ when command_has_sensitive_marker cmd -> "[REDACTED]"
+    | Error _ -> cmd |> redact_url_credentials |> redact_inline_secret_assignment)
 ;;
 
 let sanitize_command_for_log_of_ir ~fallback_cmd ir =

--- a/scripts/audit-shell-ir-consumption.sh
+++ b/scripts/audit-shell-ir-consumption.sh
@@ -118,9 +118,13 @@ g1_total_refs=$(count_code_refs "$g1_pattern")
 # matches were docstring-only (`gh_command_validation.ml`,
 # `keeper_shell_command_semantics.mli`, the two `.mli` interfaces) have
 # been removed — re-add only if a future code-side call resurfaces.
+#
+# S7: exec_policy.ml is the canonical `parse_string_to_ir` entry point;
+#      it wraps Bash.parse_string and is the SSOT for all other callers.
+#      shell_command_gate.ml is the low-level gate that needs direct access.
 g1_allowed_files=(
   "lib/exec/command_gate/shell_command_gate.ml"
-  "lib/exec_policy_mutation_classifier.ml"
+  "lib/exec_policy.ml"
 )
 g1_current_files=$(list_code_files "$g1_pattern" \
   | rg -v '/dune$|\.dune$' \

--- a/scripts/shell-ir-consumption-baseline.json
+++ b/scripts/shell-ir-consumption-baseline.json
@@ -16,6 +16,6 @@
   "g7_parallel_parser_total": 0,
   "info_ir_constructors_nontest": 62,
   "allowed_exceptions": {
-    "g1_parse_string": ["lib/exec/command_gate/shell_command_gate.ml","lib/exec_policy_mutation_classifier.ml"]
+    "g1_parse_string": ["lib/exec/command_gate/shell_command_gate.ml","lib/exec_policy.ml"]
   }
 }


### PR DESCRIPTION
## Problem

PR #18239 (RFC-0160 S7) merged with ratchet regression: G1 metric
detected unclassified `Bash.parse_string` callers:
- `lib/exec_policy.ml` (canonical entry point, missing from exceptions)
- `lib/exec_policy_log_sanitize.ml` (direct call, should use typed pipeline)

## Changes

1. **lib/exec_policy_log_sanitize.ml**: Route `sanitize_command_for_log`
   through `Exec_policy.parse_string_to_ir ~mode:Coding` instead of
   `Masc_exec_bash_parser.Bash.parse_string` directly.

2. **scripts/audit-shell-ir-consumption.sh**: Update `g1_allowed_files`:
   - Remove stale: `exec_policy_mutation_classifier.ml` (S4 migration
     eliminated its direct parse_string call)
   - Add canonical: `exec_policy.ml` (SSOT `parse_string_to_ir` wrapper)

3. **scripts/shell-ir-consumption-baseline.json**: Sync exceptions list.

## Verification

```bash
bash scripts/audit-shell-ir-consumption.sh --baseline \
  scripts/shell-ir-consumption-baseline.json
# → OK (RFC-0160 ratchet: no G1/G7 regression, no unclassified sites)
```

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>