### PR TITLE
fix(ci): repair keeper fs read runner follow-up

### DIFF
--- a/lib/exec_policy.ml
+++ b/lib/exec_policy.ml
@@ -823,7 +823,17 @@ let validate_shell_ir_paths ?keeper_id ?base_path ?workdir shell_ir =
 let is_git_branch_switch = Mutation_classifier.is_git_branch_switch
 let is_destructive_bash_operation = Mutation_classifier.is_destructive_bash_operation
 let flat_stage_words = Mutation_classifier.flat_stage_words
-let sanitize_command_for_log = Log_sanitize.sanitize_command_for_log
+
+let sanitize_command_for_log cmd =
+  let trimmed = String.trim cmd in
+  if trimmed = ""
+  then Log_sanitize.sanitize_command_for_log cmd
+  else (
+    match parse_string_to_ir ~mode:Coding trimmed with
+    | Ok ir -> Log_sanitize.sanitize_command_for_log_of_ir ~fallback_cmd:cmd ir
+    | Error _ -> Log_sanitize.sanitize_command_for_log cmd)
+;;
+
 let sanitize_command_for_log_of_ir = Log_sanitize.sanitize_command_for_log_of_ir
 let truncate_for_log = Log_sanitize.truncate_for_log
 

--- a/lib/exec_policy_log_sanitize.ml
+++ b/lib/exec_policy_log_sanitize.ml
@@ -81,12 +81,9 @@ let sanitize_command_for_log cmd =
   let trimmed = String.trim cmd in
   if trimmed = ""
   then "[EMPTY]"
-  else (
-    match Masc_exec_bash_parser.Bash.parse_string trimmed with
-    | Masc_exec.Parsed.Parsed ir ->
-      sanitize_parts (Exec_policy_mutation_classifier.flat_stage_words ir)
-    | _ when command_has_sensitive_marker cmd -> "[REDACTED]"
-    | _ -> cmd |> redact_url_credentials |> redact_inline_secret_assignment)
+  else if command_has_sensitive_marker cmd
+  then "[REDACTED]"
+  else cmd |> redact_url_credentials |> redact_inline_secret_assignment
 ;;
 
 let sanitize_command_for_log_of_ir ~fallback_cmd ir =

--- a/test/test_keeper_fs_write_containment.ml
+++ b/test/test_keeper_fs_write_containment.ml
@@ -81,7 +81,9 @@ let setup f =
        let meta = make_meta "tester" in
        let playground = Keeper_sandbox.host_root_abs_of_meta ~config meta in
        ensure_dir playground;
-       ignore (Keeper_registry.register ~base_path:base meta.name meta);
+       let (_registered : Keeper_registry.registry_entry) =
+         Keeper_registry.register ~base_path:base meta.name meta
+       in
        f ~config ~meta ~playground)
 ;;
 


### PR DESCRIPTION
## Summary
- Fix post-merge CI fallout from #18242.
- Keep `Exec_policy_log_sanitize` cycle-free without adding a new `Bash.parse_string` callsite by moving parse-backed sanitization to `Exec_policy` and leaving the lower module as redaction-only fallback.
- Remove the new `ignore(...)` site from the fs write containment test by binding the registry entry.

## Verification
- `bash scripts/audit-shell-ir-consumption.sh --baseline scripts/shell-ir-consumption-baseline.json`
- `bash scripts/ci/check-ignore-without-comment-diff.sh --base origin/main --head HEAD`
- `scripts/dune-local.sh build test/test_keeper_sandbox_boundary_policy.exe test/test_keeper_sandbox_read_runner.exe test/test_keeper_fs_write_containment.exe test/test_keeper_shell_ops.exe test/test_openai_compat_error_map.exe`
- `_build/default/test/test_keeper_sandbox_boundary_policy.exe` (13 tests)
- `_build/default/test/test_keeper_sandbox_read_runner.exe` (3 tests)
- `_build/default/test/test_keeper_fs_write_containment.exe` (2 tests)
- `_build/default/test/test_keeper_shell_ops.exe` (11 tests)
- `_build/default/test/test_openai_compat_error_map.exe` (24 tests)
- `opam exec -- ocamlformat --check ...`
- `git diff --check`
- `scripts/check-version-truth.sh`
- `bash scripts/check-doc-truth.sh`
- `scripts/check-oas-pin.sh` (passes with OAS upstream main drift warning; pinned API surface matches)
- `scripts/oas-drift-check.sh`
- `rg -n 'Keeper_docker_read\.|"via", `String "docker"' lib/keeper/keeper_exec_fs.ml` (no matches)